### PR TITLE
feat(wasmhv)+dmsg: TinyGo wasm hypervisor (net/http-free) + browser p2p transports + dmsg registration fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,14 @@ dmsg-wasm: ## Build the browser WASM dmsg client + dev harness into build/dmsg-w
 	GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o ./build/dmsg-wasm/dmsg.wasm ./cmd/dmsg-wasm
 	cp "$$(go env GOROOT)/lib/wasm/wasm_exec.js" ./build/dmsg-wasm/
 	cp ./cmd/dmsg-wasm/index.html ./build/dmsg-wasm/
-	@echo "built ./build/dmsg-wasm — serve it (e.g. 'cd build/dmsg-wasm && python -m http.server') and open index.html"
+	@echo "built ./build/dmsg-wasm — serve it: 'go run cmd/dmsg-wasm/serve.go' then open http://localhost:8085/"
+
+tinygo-dmsg-wasm: ## Build the browser WASM dmsg client with TinyGo (~6.5MB vs ~21MB) into build/dmsg-wasm
+	mkdir -p ./build/dmsg-wasm
+	tinygo build -target wasm -o ./build/dmsg-wasm/dmsg.wasm ./cmd/dmsg-wasm
+	cp "$$(tinygo env TINYGOROOT)/targets/wasm_exec.js" ./build/dmsg-wasm/
+	cp ./cmd/dmsg-wasm/index.html ./build/dmsg-wasm/
+	@echo "built ./build/dmsg-wasm (TinyGo) — serve it: 'go run cmd/dmsg-wasm/serve.go' then open http://localhost:8085/"
 
 dmsg-wasm-hv: ## Build the browser hypervisor-over-dmsg bundle (Service Worker proxy) into build/dmsg-wasm-hv
 	mkdir -p ./build/dmsg-wasm-hv

--- a/cmd/dmsg-wasm/fetch_native.go
+++ b/cmd/dmsg-wasm/fetch_native.go
@@ -1,0 +1,95 @@
+//go:build js && wasm && !tinygo
+
+package main
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"syscall/js"
+
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
+)
+
+// dmsgHTTP is the HTTP-over-dmsg client backing jsFetch, built after connect.
+var dmsgHTTP *http.Client
+
+// onConnected wires the jsFetch transport once the dmsg client is up. Native
+// build: a net/http client over a dmsghttp transport.
+func onConnected(c *dmsg.Client) {
+	dmsgHTTP = &http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, c)}
+}
+
+// jsFetch(pkHostHex, method, path, bodyOrNull, headersOrNull) -> Promise<{status, body, headers}>.
+//
+// Performs an HTTP request over dmsg to dmsg://<pkHost><path>, where pkHost is a
+// public key (defaulting to the dmsg-HTTP port :80) or an explicit "pk:port".
+// This is the transport the browser hypervisor UI uses to talk to a remote
+// visor/hypervisor BY PUBLIC KEY — no clearnet, no exposed HTTP port. The
+// request rides the client's existing dmsg session(s).
+func jsFetch(_ js.Value, args []js.Value) interface{} {
+	pkHost := args[0].String()
+	method := args[1].String()
+	path := args[2].String()
+	var body string
+	if len(args) > 3 && !args[3].IsNull() && !args[3].IsUndefined() {
+		body = args[3].String()
+	}
+	// Optional request headers object (args[4]) — e.g. Cookie / X-CSRF-Token, so
+	// the proxied request carries the page's auth.
+	var reqHeaders js.Value
+	hasHeaders := false
+	if len(args) > 4 && !args[4].IsNull() && !args[4].IsUndefined() {
+		reqHeaders = args[4]
+		hasHeaders = true
+	}
+	return promise(func() (interface{}, error) {
+		if dmsgHTTP == nil {
+			return nil, errors.New("not connected; call connect() first")
+		}
+		host := pkHost
+		if !strings.Contains(host, ":") {
+			host += ":80" // default dmsg-HTTP port
+		}
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+		var bodyR io.Reader
+		if body != "" {
+			bodyR = strings.NewReader(body)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, "dmsg://"+host+path, bodyR)
+		if err != nil {
+			return nil, err
+		}
+		if hasHeaders {
+			keys := js.Global().Get("Object").Call("keys", reqHeaders)
+			for i := 0; i < keys.Length(); i++ {
+				k := keys.Index(i).String()
+				req.Header.Set(k, reqHeaders.Get(k).String())
+			}
+		}
+		resp, err := dmsgHTTP.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close() //nolint:errcheck
+		b, _ := io.ReadAll(resp.Body)
+
+		// Binary-safe body (Uint8Array) + headers, so the Service Worker can
+		// build a correct Response for any content type (JS/CSS/HTML/fonts/etc).
+		res := js.Global().Get("Object").New()
+		res.Set("status", resp.StatusCode)
+		buf := js.Global().Get("Uint8Array").New(len(b))
+		js.CopyBytesToJS(buf, b)
+		res.Set("body", buf)
+		headers := js.Global().Get("Object").New()
+		for k := range resp.Header {
+			headers.Set(k, resp.Header.Get(k))
+		}
+		res.Set("headers", headers)
+		return res, nil
+	})
+}

--- a/cmd/dmsg-wasm/fetch_tinygo.go
+++ b/cmd/dmsg-wasm/fetch_tinygo.go
@@ -1,0 +1,62 @@
+//go:build js && wasm && tinygo
+
+package main
+
+import (
+	"errors"
+	"syscall/js"
+
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
+)
+
+// onConnected is a no-op under TinyGo: jsFetch dials the dmsg client directly
+// per request via dmsgclient.FetchOverDmsg (no persistent net/http client).
+func onConnected(_ *dmsg.Client) {}
+
+// jsFetch(pkHostHex, method, path, bodyOrNull, headersOrNull) -> Promise<{status, body, headers}>.
+//
+// TinyGo build: identical surface to the native jsFetch, but the HTTP-over-dmsg
+// round-trip is performed net/http-free by dmsgclient.FetchOverDmsg (net/http is
+// broken on the TinyGo js target). Talks to a REMOTE visor/hypervisor BY PUBLIC
+// KEY over the client's existing dmsg session(s).
+func jsFetch(_ js.Value, args []js.Value) interface{} {
+	pkHost := args[0].String()
+	method := args[1].String()
+	path := args[2].String()
+	var body []byte
+	if len(args) > 3 && !args[3].IsNull() && !args[3].IsUndefined() {
+		body = []byte(args[3].String())
+	}
+	reqHeaders := map[string]string{}
+	if len(args) > 4 && !args[4].IsNull() && !args[4].IsUndefined() {
+		hdr := args[4]
+		keys := js.Global().Get("Object").Call("keys", hdr)
+		for i := 0; i < keys.Length(); i++ {
+			k := keys.Index(i).String()
+			reqHeaders[k] = hdr.Get(k).String()
+		}
+	}
+	return promise(func() (interface{}, error) {
+		if client == nil {
+			return nil, errors.New("not connected; call connect() first")
+		}
+		status, respHeaders, b, err := dmsgclient.FetchOverDmsg(ctx, client, method, pkHost, path, reqHeaders, body)
+		if err != nil {
+			return nil, err
+		}
+		// Binary-safe body (Uint8Array) + headers, so the Service Worker can build
+		// a correct Response for any content type (JS/CSS/HTML/fonts/etc).
+		res := js.Global().Get("Object").New()
+		res.Set("status", status)
+		buf := js.Global().Get("Uint8Array").New(len(b))
+		js.CopyBytesToJS(buf, b)
+		res.Set("body", buf)
+		headers := js.Global().Get("Object").New()
+		for k, v := range respHeaders {
+			headers.Set(k, v)
+		}
+		res.Set("headers", headers)
+		return res, nil
+	})
+}

--- a/cmd/dmsg-wasm/index.html
+++ b/cmd/dmsg-wasm/index.html
@@ -211,6 +211,8 @@
     const clog = (...a) => { log(...a); post("/ctl/log?tab=" + tabId, a.join(" ")); };
     // WebRTC (Go/wasm) signaling+ICE progress is routed here via window.__wrtclog.
     window.__wrtclog = m => clog("[rtc] " + m);
+    // dmsg-disc-over-dmsg (Go/wasm) internals routed here via window.__skylog.
+    window.__skylog = m => clog("[disc] " + m);
 
     const H = {};      // named stream/conn handles
     let myPK = "";
@@ -277,6 +279,12 @@
         default: throw new Error("unknown action: " + c.action);
       }
     }
+
+    // Signal true readiness (wasm loaded + API present) so an operator driving
+    // reloads knows when commands will actually work, not just when SSE connected.
+    const readyPoll = setInterval(() => {
+      if (window.skywireDmsg && skywireDmsg.connect) { clearInterval(readyPoll); clog("skywireDmsg READY " + tabId); }
+    }, 100);
 
     const es = new EventSource("/ctl/events?tab=" + tabId);
     es.onopen = () => clog("control bridge connected as " + tabId);

--- a/cmd/dmsg-wasm/index.html
+++ b/cmd/dmsg-wasm/index.html
@@ -61,6 +61,22 @@
   <button id="fetch">GET over dmsg</button>
 </fieldset>
 
+<fieldset>
+  <legend>5. in-wasm hypervisor (serve the standalone HV core from this tab)</legend>
+  <button id="servehv">serveHypervisor</button>
+  <input id="hvpath" placeholder="hvApi path" value="/api/visors">
+  <button id="hvapi">hvApi GET</button>
+</fieldset>
+
+<fieldset>
+  <legend>6. WebRTC p2p (direct datachannel; signaling rides dmsg :47)</legend>
+  <button id="rtclisten">webrtcListen</button>
+  <input id="rtcpk" placeholder="remote PK to webrtcDial">
+  <button id="rtcdial">webrtcDial</button>
+  <input id="rtcmsg" placeholder="message over the datachannel">
+  <button id="rtcsend">rtc send</button>
+</fieldset>
+
 <div id="log"></div>
 
 <script src="wasm_exec.js"></script>
@@ -118,13 +134,47 @@
     log("» " + m);
   };
 
+  const td = new TextDecoder();
+
   document.getElementById("fetch").onclick = async () => {
     try {
       const r = await skywireDmsg.fetch(
         document.getElementById("fpk").value.trim(), "GET",
         document.getElementById("fpath").value.trim(), null);
-      log("HTTP " + r.status + " over dmsg:\n" + r.body);
+      // body is a Uint8Array (binary-safe); decode for display.
+      log("HTTP " + r.status + " over dmsg:\n" + td.decode(r.body));
     } catch (e) { log("fetch error: " + e); }
+  };
+
+  document.getElementById("servehv").onclick = () => {
+    const r = skywireDmsg.serveHypervisor();
+    log(r instanceof Error ? "serveHypervisor error: " + r : "hypervisor core serving");
+  };
+
+  document.getElementById("hvapi").onclick = async () => {
+    try {
+      const r = await skywireDmsg.hvApi("GET", document.getElementById("hvpath").value.trim(), null);
+      log("hvApi " + r.status + ":\n" + td.decode(r.body));
+    } catch (e) { log("hvApi error: " + e); }
+  };
+
+  let rtc = null;
+  const wireRTC = c => { rtc = c; c.onMessage(m => log("rtc « " + m)); log("webrtc datachannel open"); };
+
+  document.getElementById("rtclisten").onclick = () => {
+    const r = skywireDmsg.webrtcListen(wireRTC);
+    log(r instanceof Error ? "webrtcListen error: " + r : "webrtcListen armed (dmsg :47)");
+  };
+
+  document.getElementById("rtcdial").onclick = async () => {
+    try { wireRTC(await skywireDmsg.webrtcDial(document.getElementById("rtcpk").value.trim())); }
+    catch (e) { log("webrtcDial error: " + e); }
+  };
+
+  document.getElementById("rtcsend").onclick = () => {
+    if (!rtc) { log("no datachannel — webrtcDial/Listen first"); return; }
+    const m = document.getElementById("rtcmsg").value;
+    rtc.send(m); log("rtc » " + m);
   };
 </script>
 </body>

--- a/cmd/dmsg-wasm/index.html
+++ b/cmd/dmsg-wasm/index.html
@@ -197,7 +197,10 @@
   // so two tabs can be orchestrated headlessly. No-ops if the server has no
   // /ctl endpoints (plain static host) — the manual buttons above still work.
   (function () {
-    const tabId = "tab-" + Math.random().toString(36).slice(2, 8);
+    // Stable per-tab id across reloads (sessionStorage is per-tab + survives
+    // reload), so the operator keeps the same control id when driving reloads.
+    let tabId = sessionStorage.getItem("ctlTabId");
+    if (!tabId) { tabId = "tab-" + Math.random().toString(36).slice(2, 8); sessionStorage.setItem("ctlTabId", tabId); }
     const banner = document.createElement("div");
     banner.style.cssText = "margin:.3rem 0;color:#06c";
     banner.textContent = "control id: " + tabId;
@@ -206,9 +209,17 @@
     const post = (path, body) =>
       fetch(path, { method: "POST", body: typeof body === "string" ? body : JSON.stringify(body) }).catch(() => {});
     const clog = (...a) => { log(...a); post("/ctl/log?tab=" + tabId, a.join(" ")); };
+    // WebRTC (Go/wasm) signaling+ICE progress is routed here via window.__wrtclog.
+    window.__wrtclog = m => clog("[rtc] " + m);
 
     const H = {};      // named stream/conn handles
     let myPK = "";
+    // ICE servers for WebRTC: the deployment's OWN STUN servers (exposed by the
+    // wasm from deployment.Prod.StunServers — the same ones the visor uses for
+    // sudph NAT detection), so a server-reflexive candidate is gathered without a
+    // third-party STUN dependency. Needed because mDNS .local host candidates
+    // don't resolve reliably between localhost tabs.
+    const iceServers = () => (skywireDmsg.stunServers || []).map(u => ({ urls: u }));
 
     async function exec(c) {
       const a = c.args || [];
@@ -248,10 +259,10 @@
           skywireDmsg.webrtcListen(conn => {
             H.rtc = conn; clog("rtc datachannel accepted");
             conn.onMessage(m => clog("rtc recv: " + m));
-          });
+          }, iceServers());
           return "webrtc listening (dmsg :47)";
         case "webrtcDial": {
-          const conn = await skywireDmsg.webrtcDial(a[0]);
+          const conn = await skywireDmsg.webrtcDial(a[0], iceServers());
           H.rtc = conn; conn.onMessage(m => clog("rtc recv: " + m));
           return "webrtc datachannel open";
         }
@@ -259,6 +270,10 @@
           if (!H.rtc) throw new Error("no datachannel");
           H.rtc.send(a[0] || "ping"); return "rtc sent";
         }
+        case "reload":
+          // Defer so the result POST goes out before the page unloads.
+          setTimeout(() => location.reload(), 150);
+          return "reloading";
         default: throw new Error("unknown action: " + c.action);
       }
     }

--- a/cmd/dmsg-wasm/index.html
+++ b/cmd/dmsg-wasm/index.html
@@ -191,6 +191,87 @@
     const m = document.getElementById("rtcmsg").value;
     rtc.send(m); log("rtc » " + m);
   };
+
+  // ---- control bridge -------------------------------------------------------
+  // Lets an external operator (curl against the serving server) drive THIS tab,
+  // so two tabs can be orchestrated headlessly. No-ops if the server has no
+  // /ctl endpoints (plain static host) — the manual buttons above still work.
+  (function () {
+    const tabId = "tab-" + Math.random().toString(36).slice(2, 8);
+    const banner = document.createElement("div");
+    banner.style.cssText = "margin:.3rem 0;color:#06c";
+    banner.textContent = "control id: " + tabId;
+    document.body.insertBefore(banner, document.getElementById("log"));
+
+    const post = (path, body) =>
+      fetch(path, { method: "POST", body: typeof body === "string" ? body : JSON.stringify(body) }).catch(() => {});
+    const clog = (...a) => { log(...a); post("/ctl/log?tab=" + tabId, a.join(" ")); };
+
+    const H = {};      // named stream/conn handles
+    let myPK = "";
+
+    async function exec(c) {
+      const a = c.args || [];
+      switch (c.action) {
+        case "connect":
+          myPK = await skywireDmsg.connect(a[0] || "", a[1], a[2], a[3] || "");
+          document.getElementById("pk").textContent = myPK;
+          return myPK;
+        case "pk": return myPK;
+        case "fetch": {
+          const r = await skywireDmsg.fetch(a[0], a[1] || "GET", a[2] || "/", null);
+          return { status: r.status, body: td.decode(r.body) };
+        }
+        case "serveHypervisor":
+          return skywireDmsg.serveHypervisor() instanceof Error ? "error" : "serving";
+        case "hvApi": {
+          const r = await skywireDmsg.hvApi(a[1] || "GET", a[0] || "/api/visors", null);
+          return { status: r.status, body: td.decode(r.body) };
+        }
+        case "listen":
+          skywireDmsg.listen(a[0] || 80, s => {
+            H.inbound = s; clog("inbound stream on :" + (a[0] || 80));
+            s.onMessage(m => clog("inbound recv: " + m));
+          });
+          return "listening on :" + (a[0] || 80);
+        case "dial": {
+          const s = await skywireDmsg.dial(a[0], a[1] || 80);
+          H.dialed = s; s.onMessage(m => clog("dialed recv: " + m));
+          return "dialed";
+        }
+        case "send": {
+          const h = H[a[0] || "dialed"];
+          if (!h) throw new Error("no handle: " + (a[0] || "dialed"));
+          h.send(a[1] || "ping"); return "sent";
+        }
+        case "webrtcListen":
+          skywireDmsg.webrtcListen(conn => {
+            H.rtc = conn; clog("rtc datachannel accepted");
+            conn.onMessage(m => clog("rtc recv: " + m));
+          });
+          return "webrtc listening (dmsg :47)";
+        case "webrtcDial": {
+          const conn = await skywireDmsg.webrtcDial(a[0]);
+          H.rtc = conn; conn.onMessage(m => clog("rtc recv: " + m));
+          return "webrtc datachannel open";
+        }
+        case "rtcsend": {
+          if (!H.rtc) throw new Error("no datachannel");
+          H.rtc.send(a[0] || "ping"); return "rtc sent";
+        }
+        default: throw new Error("unknown action: " + c.action);
+      }
+    }
+
+    const es = new EventSource("/ctl/events?tab=" + tabId);
+    es.onopen = () => clog("control bridge connected as " + tabId);
+    es.onerror = () => { /* no control server present; stay a manual harness */ };
+    es.onmessage = async ev => {
+      let c; try { c = JSON.parse(ev.data); } catch { return; }
+      try { const v = await exec(c); post("/ctl/result", { id: c.id, ok: true, value: v }); }
+      catch (e) { post("/ctl/result", { id: c.id, ok: false, error: e.message || String(e) }); }
+    };
+  })();
 </script>
 </body>
 </html>

--- a/cmd/dmsg-wasm/index.html
+++ b/cmd/dmsg-wasm/index.html
@@ -89,10 +89,25 @@
   let stream = null;
 
   const go = new Go();
-  WebAssembly.instantiateStreaming(fetch("dmsg.wasm"), go.importObject).then(r => {
-    go.run(r.instance);
-    log("wasm loaded; skywireDmsg ready");
-  });
+  // TinyGo's wasm_exec.js omits the gojs `runtime.getRandomData` import the Go
+  // runtime needs to seed itself (the crypto path) — so a crypto-using TinyGo
+  // wasm fails to instantiate ("function import requires a callable"). Inject it
+  // ONLY when absent, leaving the standard-Go build untouched (its wasm_exec.js
+  // already provides getRandomData, via a different sp-based ABI). TinyGo passes
+  // a []byte as (ptr, len, cap) and exposes linear memory as `memory`.
+  if (go.importObject.gojs && !go.importObject.gojs["runtime.getRandomData"]) {
+    go.importObject.gojs["runtime.getRandomData"] = (ptr, len) =>
+      crypto.getRandomValues(new Uint8Array(go._inst.exports.memory.buffer, ptr >>> 0, len >>> 0));
+  }
+  // Use fetch+arrayBuffer (not instantiateStreaming) so it works regardless of
+  // the server's wasm MIME type.
+  fetch("dmsg.wasm").then(r => r.arrayBuffer())
+    .then(buf => WebAssembly.instantiate(buf, go.importObject))
+    .then(r => {
+      go.run(r.instance);
+      log("wasm loaded; skywireDmsg ready: " + Object.keys(globalThis.skywireDmsg || {}).join(", "));
+    })
+    .catch(e => log("WASM LOAD FAILED: " + e));
 
   const wire = s => {
     stream = s;

--- a/cmd/dmsg-wasm/main.go
+++ b/cmd/dmsg-wasm/main.go
@@ -24,26 +24,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
-	"strings"
 	"syscall/js"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/wasmhv"
 )
 
 var (
-	client   *dmsg.Client
-	dmsgHTTP *http.Client // HTTP-over-dmsg client, built after connect
-	hvCore   *wasmhv.Core // set in standalone-hypervisor mode
-	selfPK   cipher.PubKey
-	ctx      context.Context
+	client *dmsg.Client
+	hvCore *wasmhv.Core // set in standalone-hypervisor mode
+	selfPK cipher.PubKey
+	ctx    context.Context
 )
 
 func main() {
@@ -163,81 +158,11 @@ func jsConnect(_ js.Value, args []js.Value) interface{} {
 		}
 		client = c
 		selfPK = pk
-		// HTTP-over-dmsg client for jsFetch (the browser hypervisor UI's transport).
-		dmsgHTTP = &http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, c)}
+		// Wire up the jsFetch transport (the browser hypervisor UI's HTTP-over-dmsg
+		// path to a REMOTE hypervisor). Build-tagged: native uses net/http +
+		// dmsghttp; TinyGo uses the net/http-free dmsgclient.FetchOverDmsg.
+		onConnected(c)
 		return pk.Hex(), nil
-	})
-}
-
-// jsFetch(pkHostHex, method, path, bodyOrNull) -> Promise<{status, body}>.
-//
-// Performs an HTTP request over dmsg to dmsg://<pkHost><path>, where pkHost is a
-// public key (defaulting to the dmsg-HTTP port :80) or an explicit "pk:port".
-// This is the transport the browser hypervisor UI uses to talk to a remote
-// visor/hypervisor BY PUBLIC KEY — no clearnet, no exposed HTTP port. The
-// request rides the client's existing dmsg session(s).
-func jsFetch(_ js.Value, args []js.Value) interface{} {
-	pkHost := args[0].String()
-	method := args[1].String()
-	path := args[2].String()
-	var body string
-	if len(args) > 3 && !args[3].IsNull() && !args[3].IsUndefined() {
-		body = args[3].String()
-	}
-	// Optional request headers object (args[4]) — e.g. Cookie / X-CSRF-Token, so
-	// the proxied request carries the page's auth.
-	var reqHeaders js.Value
-	hasHeaders := false
-	if len(args) > 4 && !args[4].IsNull() && !args[4].IsUndefined() {
-		reqHeaders = args[4]
-		hasHeaders = true
-	}
-	return promise(func() (interface{}, error) {
-		if dmsgHTTP == nil {
-			return nil, errors.New("not connected; call connect() first")
-		}
-		host := pkHost
-		if !strings.Contains(host, ":") {
-			host += ":80" // default dmsg-HTTP port
-		}
-		if !strings.HasPrefix(path, "/") {
-			path = "/" + path
-		}
-		var bodyR io.Reader
-		if body != "" {
-			bodyR = strings.NewReader(body)
-		}
-		req, err := http.NewRequestWithContext(ctx, method, "dmsg://"+host+path, bodyR)
-		if err != nil {
-			return nil, err
-		}
-		if hasHeaders {
-			keys := js.Global().Get("Object").Call("keys", reqHeaders)
-			for i := 0; i < keys.Length(); i++ {
-				k := keys.Index(i).String()
-				req.Header.Set(k, reqHeaders.Get(k).String())
-			}
-		}
-		resp, err := dmsgHTTP.Do(req)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close() //nolint:errcheck
-		b, _ := io.ReadAll(resp.Body)
-
-		// Binary-safe body (Uint8Array) + headers, so the Service Worker can
-		// build a correct Response for any content type (JS/CSS/HTML/fonts/etc).
-		res := js.Global().Get("Object").New()
-		res.Set("status", resp.StatusCode)
-		buf := js.Global().Get("Uint8Array").New(len(b))
-		js.CopyBytesToJS(buf, b)
-		res.Set("body", buf)
-		headers := js.Global().Get("Object").New()
-		for k := range resp.Header {
-			headers.Set(k, resp.Header.Get(k))
-		}
-		res.Set("headers", headers)
-		return res, nil
 	})
 }
 

--- a/cmd/dmsg-wasm/main.go
+++ b/cmd/dmsg-wasm/main.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"syscall/js"
 
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
@@ -53,6 +54,21 @@ func main() {
 		"webrtcDial":      js.FuncOf(jsWebrtcDial),
 		"webrtcListen":    js.FuncOf(jsWebrtcListen),
 	}
+	// Expose the deployment's own STUN servers (the ones the visor uses for sudph
+	// NAT detection) as WebRTC ICE server URLs — so WebRTC uses skywire infra, not
+	// a third-party STUN.
+	//
+	// TODO(wasm-visor): this uses the EMBEDDED default deployment config
+	// (deployment.Prod). When this UI is generated/embedded BY a visor (the
+	// standalone-HV generator, `cli hv gen`), it must instead inject THAT visor's
+	// runtime config — its configured StunServers, dmsg servers, discovery, and
+	// service URLs — which may differ from the embedded defaults (custom/private
+	// deployments). The generator already inlines config; STUN should ride along.
+	var stun []interface{}
+	for _, s := range deployment.Prod.StunServers {
+		stun = append(stun, "stun:"+s)
+	}
+	api["stunServers"] = stun
 	js.Global().Set("skywireDmsg", js.ValueOf(api))
 	// Keep the Go runtime alive for the page lifetime.
 	select {}

--- a/cmd/dmsg-wasm/main.go
+++ b/cmd/dmsg-wasm/main.go
@@ -50,6 +50,8 @@ func main() {
 		"fetch":           js.FuncOf(jsFetch),
 		"serveHypervisor": js.FuncOf(jsServeHypervisor),
 		"hvApi":           js.FuncOf(jsHvAPI),
+		"webrtcDial":      js.FuncOf(jsWebrtcDial),
+		"webrtcListen":    js.FuncOf(jsWebrtcListen),
 	}
 	js.Global().Set("skywireDmsg", js.ValueOf(api))
 	// Keep the Go runtime alive for the page lifetime.

--- a/cmd/dmsg-wasm/serve.go
+++ b/cmd/dmsg-wasm/serve.go
@@ -138,6 +138,15 @@ func main() {
 		}
 	})
 
+	// Clear a tab's buffered logs (so each test reads fresh output).
+	mux.HandleFunc("/ctl/clear", func(w http.ResponseWriter, r *http.Request) {
+		t := getTab(r.URL.Query().Get("tab"))
+		t.mu.Lock()
+		t.logs = nil
+		t.mu.Unlock()
+		w.WriteHeader(204)
+	})
+
 	// List connected tabs.
 	mux.HandleFunc("/ctl/tabs", func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
@@ -187,7 +196,17 @@ func main() {
 		}
 	})
 
-	mux.Handle("/", http.FileServer(http.Dir(*dir)))
+	// Static files with no-cache headers, so a reload always fetches the freshly
+	// built wasm/page (lets the operator drive reloads without cache-busting).
+	fs := http.FileServer(http.Dir(*dir))
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/favicon.ico" {
+			w.WriteHeader(204)
+			return
+		}
+		w.Header().Set("Cache-Control", "no-store, must-revalidate")
+		fs.ServeHTTP(w, r)
+	})
 
 	log.Printf("serving %s at http://localhost%s/ (control bridge at /ctl/*)", *dir, *addr)
 	log.Fatal(http.ListenAndServe(*addr, mux)) //nolint:gosec

--- a/cmd/dmsg-wasm/serve.go
+++ b/cmd/dmsg-wasm/serve.go
@@ -1,0 +1,31 @@
+//go:build ignore
+
+// serve.go is a tiny static file server for the dmsg-wasm browser harness — no
+// Python, no npm. It serves the built harness dir (default ./build/dmsg-wasm)
+// with the correct application/wasm MIME so WebAssembly.instantiateStreaming
+// works.
+//
+//	make tinygo-dmsg-wasm                       # build dmsg.wasm + stage the page
+//	go run cmd/dmsg-wasm/testharness/serve.go   # serve it
+//	open http://localhost:8085/
+package main
+
+import (
+	"flag"
+	"log"
+	"mime"
+	"net/http"
+)
+
+func main() {
+	dir := flag.String("dir", "build/dmsg-wasm", "directory to serve")
+	addr := flag.String("addr", ":8085", "listen address")
+	flag.Parse()
+
+	// Some environments lack a .wasm MIME mapping; set it explicitly so the
+	// streaming compiler accepts the response.
+	_ = mime.AddExtensionType(".wasm", "application/wasm")
+
+	log.Printf("serving %s at http://localhost%s/", *dir, *addr)
+	log.Fatal(http.ListenAndServe(*addr, http.FileServer(http.Dir(*dir)))) //nolint:gosec
+}

--- a/cmd/dmsg-wasm/serve.go
+++ b/cmd/dmsg-wasm/serve.go
@@ -1,31 +1,194 @@
 //go:build ignore
 
-// serve.go is a tiny static file server for the dmsg-wasm browser harness — no
-// Python, no npm. It serves the built harness dir (default ./build/dmsg-wasm)
-// with the correct application/wasm MIME so WebAssembly.instantiateStreaming
-// works.
+// serve.go — static file server + control bridge for the dmsg-wasm harness.
 //
-//	make tinygo-dmsg-wasm                       # build dmsg.wasm + stage the page
-//	go run cmd/dmsg-wasm/testharness/serve.go   # serve it
-//	open http://localhost:8085/
+// Beyond serving the page, it lets an EXTERNAL operator (curl) drive the browser
+// tab(s): each tab connects back over SSE (GET /ctl/events) to receive commands
+// and POSTs results (/ctl/result) + log lines (/ctl/log). So two tabs can be
+// orchestrated headlessly — e.g. `listen` on one and `webrtcDial` from the other
+// — without anyone clicking. No Python, no npm.
+//
+//	make tinygo-dmsg-wasm && go run cmd/dmsg-wasm/serve.go
+//	# open two browser tabs at http://localhost:8085/ , then from a shell:
+//	curl -s localhost:8085/ctl/tabs
+//	curl -s -XPOST 'localhost:8085/ctl/cmd?tab=<id>' -d '{"action":"connect","args":["","<seedPK>","<seedWS>","<discAddr>"]}'
+//	curl -s 'localhost:8085/ctl/log?tab=<id>'
 package main
 
 import (
+	"encoding/json"
 	"flag"
+	"fmt"
+	"io"
 	"log"
 	"mime"
 	"net/http"
+	"sync"
+	"time"
 )
+
+type tab struct {
+	id     string
+	events chan string // SSE command frames queued for this tab
+	mu     sync.Mutex
+	logs   []string
+}
+
+type command struct {
+	ID     string        `json:"id"`
+	Action string        `json:"action"`
+	Args   []interface{} `json:"args"`
+}
+
+type result struct {
+	ID    string      `json:"id"`
+	OK    bool        `json:"ok"`
+	Value interface{} `json:"value"`
+	Error string      `json:"error"`
+}
+
+var (
+	mu      sync.Mutex
+	tabs    = map[string]*tab{}
+	pending = map[string]chan result{}
+	seq     int
+)
+
+func getTab(id string) *tab {
+	mu.Lock()
+	defer mu.Unlock()
+	t := tabs[id]
+	if t == nil {
+		t = &tab{id: id, events: make(chan string, 8)}
+		tabs[id] = t
+	}
+	return t
+}
 
 func main() {
 	dir := flag.String("dir", "build/dmsg-wasm", "directory to serve")
 	addr := flag.String("addr", ":8085", "listen address")
 	flag.Parse()
-
-	// Some environments lack a .wasm MIME mapping; set it explicitly so the
-	// streaming compiler accepts the response.
 	_ = mime.AddExtensionType(".wasm", "application/wasm")
 
-	log.Printf("serving %s at http://localhost%s/", *dir, *addr)
-	log.Fatal(http.ListenAndServe(*addr, http.FileServer(http.Dir(*dir)))) //nolint:gosec
+	mux := http.NewServeMux()
+
+	// SSE: a tab subscribes here to receive commands.
+	mux.HandleFunc("/ctl/events", func(w http.ResponseWriter, r *http.Request) {
+		t := getTab(r.URL.Query().Get("tab"))
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flush", 500)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		fmt.Fprint(w, ": connected\n\n")
+		fl.Flush()
+		log.Printf("tab connected: %s", t.id)
+		for {
+			select {
+			case msg := <-t.events:
+				fmt.Fprintf(w, "data: %s\n\n", msg)
+				fl.Flush()
+			case <-r.Context().Done():
+				return
+			case <-time.After(15 * time.Second):
+				fmt.Fprint(w, ": ping\n\n")
+				fl.Flush()
+			}
+		}
+	})
+
+	// A tab posts a command result back here.
+	mux.HandleFunc("/ctl/result", func(w http.ResponseWriter, r *http.Request) {
+		var res result
+		if err := json.NewDecoder(r.Body).Decode(&res); err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		mu.Lock()
+		ch := pending[res.ID]
+		mu.Unlock()
+		if ch != nil {
+			select {
+			case ch <- res:
+			default:
+			}
+		}
+		w.WriteHeader(204)
+	})
+
+	// A tab streams its log lines here (POST); GET reads them back.
+	mux.HandleFunc("/ctl/log", func(w http.ResponseWriter, r *http.Request) {
+		t := getTab(r.URL.Query().Get("tab"))
+		if r.Method == http.MethodPost {
+			b, _ := io.ReadAll(r.Body)
+			t.mu.Lock()
+			t.logs = append(t.logs, string(b))
+			t.mu.Unlock()
+			w.WriteHeader(204)
+			return
+		}
+		t.mu.Lock()
+		out := append([]string(nil), t.logs...)
+		t.mu.Unlock()
+		for _, l := range out {
+			fmt.Fprintln(w, l)
+		}
+	})
+
+	// List connected tabs.
+	mux.HandleFunc("/ctl/tabs", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		ids := make([]string, 0, len(tabs))
+		for id := range tabs {
+			ids = append(ids, id)
+		}
+		mu.Unlock()
+		_ = json.NewEncoder(w).Encode(ids)
+	})
+
+	// Operator drives a tab: queue a command, wait for its result.
+	mux.HandleFunc("/ctl/cmd", func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Query().Get("tab")
+		mu.Lock()
+		t := tabs[id]
+		mu.Unlock()
+		if t == nil {
+			http.Error(w, "no such tab (open it first)", 404)
+			return
+		}
+		var c command
+		if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		mu.Lock()
+		seq++
+		c.ID = fmt.Sprintf("c%d", seq)
+		ch := make(chan result, 1)
+		pending[c.ID] = ch
+		mu.Unlock()
+		defer func() { mu.Lock(); delete(pending, c.ID); mu.Unlock() }()
+
+		b, _ := json.Marshal(c)
+		select {
+		case t.events <- string(b):
+		case <-time.After(5 * time.Second):
+			http.Error(w, "tab not receiving", 504)
+			return
+		}
+		select {
+		case res := <-ch:
+			_ = json.NewEncoder(w).Encode(res)
+		case <-time.After(40 * time.Second):
+			http.Error(w, "command timeout", 504)
+		}
+	})
+
+	mux.Handle("/", http.FileServer(http.Dir(*dir)))
+
+	log.Printf("serving %s at http://localhost%s/ (control bridge at /ctl/*)", *dir, *addr)
+	log.Fatal(http.ListenAndServe(*addr, mux)) //nolint:gosec
 }

--- a/cmd/dmsg-wasm/serve.go
+++ b/cmd/dmsg-wasm/serve.go
@@ -73,7 +73,9 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	// SSE: a tab subscribes here to receive commands.
+	// SSE: a tab subscribes here to receive commands. On reconnect (page reload,
+	// same id), install a FRESH events channel as the tab's current one so
+	// commands go to the live connection — not a lingering old reader.
 	mux.HandleFunc("/ctl/events", func(w http.ResponseWriter, r *http.Request) {
 		t := getTab(r.URL.Query().Get("tab"))
 		fl, ok := w.(http.Flusher)
@@ -81,6 +83,11 @@ func main() {
 			http.Error(w, "no flush", 500)
 			return
 		}
+		ch := make(chan string, 8)
+		t.mu.Lock()
+		t.events = ch
+		t.mu.Unlock()
+
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
 		fmt.Fprint(w, ": connected\n\n")
@@ -88,7 +95,7 @@ func main() {
 		log.Printf("tab connected: %s", t.id)
 		for {
 			select {
-			case msg := <-t.events:
+			case msg := <-ch:
 				fmt.Fprintf(w, "data: %s\n\n", msg)
 				fl.Flush()
 			case <-r.Context().Done():
@@ -181,9 +188,12 @@ func main() {
 		mu.Unlock()
 		defer func() { mu.Lock(); delete(pending, c.ID); mu.Unlock() }()
 
+		t.mu.Lock()
+		evCh := t.events
+		t.mu.Unlock()
 		b, _ := json.Marshal(c)
 		select {
-		case t.events <- string(b):
+		case evCh <- string(b):
 		case <-time.After(5 * time.Second):
 			http.Error(w, "tab not receiving", 504)
 			return

--- a/cmd/dmsg-wasm/webrtc_js.go
+++ b/cmd/dmsg-wasm/webrtc_js.go
@@ -72,6 +72,14 @@ func awaitJS(p js.Value) (js.Value, error) {
 // webrtcSignalPort is the dmsg port the WebRTC signaling listener accepts on.
 const webrtcSignalPort uint16 = 47
 
+// wlog routes WebRTC signaling/ICE progress to a JS hook (window.__wrtclog) when
+// present, so the control bridge / page can surface it. No-op otherwise.
+func wlog(msg string) {
+	if h := js.Global().Get("__wrtclog"); h.Truthy() {
+		h.Invoke(msg)
+	}
+}
+
 // signalMsg is one signaling message exchanged over the dmsg SignalChannel.
 type signalMsg struct {
 	Type      string `json:"type"`                // "offer" | "answer" | "candidate"
@@ -125,7 +133,11 @@ func (c *dmsgSignalChannel) recv() (signalMsg, error) {
 		return signalMsg{}, err
 	}
 	var m signalMsg
-	return m, json.Unmarshal(b, &m)
+	// NOTE: `return m, json.Unmarshal(b, &m)` is WRONG — Go leaves the order of
+	// the result-value read vs the call unspecified, and TinyGo reads m (empty)
+	// BEFORE Unmarshal populates it. Decode first, then return.
+	err := json.Unmarshal(b, &m)
+	return m, err
 }
 
 func (c *dmsgSignalChannel) Close() error { return c.s.Close() }
@@ -134,6 +146,7 @@ func (c *dmsgSignalChannel) Close() error { return c.s.Close() }
 // the offer, applies the answer and remote candidates from sc, and returns once
 // the DataChannel is open.
 func dialWebRTC(ctx context.Context, sc SignalChannel, iceServers js.Value) (net.Conn, error) {
+	wlog("dial: start")
 	pc := newPeerConnection(iceServers)
 	dc := pc.Call("createDataChannel", "skywire", map[string]interface{}{"ordered": true})
 	conn := newWebRTCConn(dc)
@@ -151,18 +164,23 @@ func dialWebRTC(ctx context.Context, sc SignalChannel, iceServers js.Value) (net
 	if err := sc.send(signalMsg{Type: "offer", SDP: offer.Get("sdp").String()}); err != nil {
 		return nil, fmt.Errorf("send offer: %w", err)
 	}
+	wlog("dial: offer sent, waiting for datachannel")
 	if err := conn.waitOpen(ctx); err != nil {
+		wlog("dial: waitOpen failed: " + err.Error())
 		return nil, err
 	}
+	wlog("dial: datachannel OPEN")
 	return conn, nil
 }
 
 // acceptWebRTC is the ANSWERER: it waits for the offer on sc, answers it, and
 // returns the DataChannel (delivered via pc.ondatachannel) once it is open.
 func acceptWebRTC(ctx context.Context, sc SignalChannel, iceServers js.Value) (net.Conn, error) {
+	wlog("accept: start")
 	pc := newPeerConnection(iceServers)
 	dcCh := make(chan js.Value, 1)
 	onDC := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
+		wlog("accept: ondatachannel fired")
 		select {
 		case dcCh <- args[0].Get("channel"):
 		default:
@@ -175,15 +193,16 @@ func acceptWebRTC(ctx context.Context, sc SignalChannel, iceServers js.Value) (n
 	go pumpRemoteSignals(ctx, pc, sc, func(offerSDP string) error {
 		desc := map[string]interface{}{"type": "offer", "sdp": offerSDP}
 		if _, err := awaitJS(pc.Call("setRemoteDescription", desc)); err != nil {
-			return err
+			return fmt.Errorf("setRemoteDescription(offer): %w", err)
 		}
 		answer, err := awaitJS(pc.Call("createAnswer"))
 		if err != nil {
-			return err
+			return fmt.Errorf("createAnswer: %w", err)
 		}
 		if _, err := awaitJS(pc.Call("setLocalDescription", answer)); err != nil {
-			return err
+			return fmt.Errorf("setLocalDescription(answer): %w", err)
 		}
+		wlog("accept: answer sent")
 		return sc.send(signalMsg{Type: "answer", SDP: answer.Get("sdp").String()})
 	})
 
@@ -191,10 +210,13 @@ func acceptWebRTC(ctx context.Context, sc SignalChannel, iceServers js.Value) (n
 	case dc := <-dcCh:
 		conn := newWebRTCConn(dc)
 		if err := conn.waitOpen(ctx); err != nil {
+			wlog("accept: waitOpen failed: " + err.Error())
 			return nil, err
 		}
+		wlog("accept: datachannel OPEN")
 		return conn, nil
 	case <-ctx.Done():
+		wlog("accept: ctx done before datachannel")
 		return nil, ctx.Err()
 	}
 }
@@ -206,7 +228,16 @@ func newPeerConnection(iceServers js.Value) js.Value {
 	if iceServers.Truthy() {
 		cfg.Set("iceServers", iceServers)
 	}
-	return js.Global().Get("RTCPeerConnection").New(cfg)
+	pc := js.Global().Get("RTCPeerConnection").New(cfg)
+	pc.Set("oniceconnectionstatechange", js.FuncOf(func(js.Value, []js.Value) interface{} {
+		wlog("iceConnectionState=" + pc.Get("iceConnectionState").String())
+		return nil
+	}))
+	pc.Set("onconnectionstatechange", js.FuncOf(func(js.Value, []js.Value) interface{} {
+		wlog("connectionState=" + pc.Get("connectionState").String())
+		return nil
+	}))
+	return pc
 }
 
 // wireLocalCandidates forwards locally-gathered ICE candidates to the peer over
@@ -215,14 +246,25 @@ func wireLocalCandidates(pc js.Value, sc SignalChannel) {
 	onCand := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
 		cand := args[0].Get("candidate")
 		if !cand.Truthy() {
+			wlog("local ICE gathering complete")
 			return nil // null candidate = gathering complete
 		}
-		_ = sc.send(signalMsg{ //nolint:errcheck
+		mid := ""
+		if v := cand.Get("sdpMid"); v.Truthy() {
+			mid = v.String()
+		}
+		line := 0
+		if v := cand.Get("sdpMLineIndex"); v.Truthy() {
+			line = v.Int()
+		}
+		if err := sc.send(signalMsg{
 			Type:      "candidate",
 			Candidate: cand.Get("candidate").String(),
-			SDPMid:    cand.Get("sdpMid").String(),
-			SDPMLine:  cand.Get("sdpMLineIndex").Int(),
-		})
+			SDPMid:    mid,
+			SDPMLine:  line,
+		}); err != nil {
+			wlog("send candidate err: " + err.Error())
+		}
 		return nil
 	})
 	pc.Set("onicecandidate", onCand)
@@ -232,28 +274,58 @@ func wireLocalCandidates(pc js.Value, sc SignalChannel) {
 // onOffer (answerer only) handles an inbound offer; for the offerer it is nil
 // and an "answer" sets the remote description.
 func pumpRemoteSignals(ctx context.Context, pc js.Value, sc SignalChannel, onOffer func(sdp string) error) {
+	remoteSet := false
+	var queued []signalMsg // candidates that arrived before the remote description
+	addCand := func(m signalMsg) {
+		cand := js.Global().Get("Object").New()
+		cand.Set("candidate", m.Candidate)
+		cand.Set("sdpMid", m.SDPMid)
+		cand.Set("sdpMLineIndex", m.SDPMLine)
+		if _, err := awaitJS(pc.Call("addIceCandidate", cand)); err != nil {
+			wlog("addIceCandidate err: " + err.Error())
+		}
+	}
+	flush := func() {
+		remoteSet = true
+		for _, c := range queued {
+			addCand(c)
+		}
+		queued = nil
+	}
 	for {
 		if ctx.Err() != nil {
 			return
 		}
 		m, err := sc.recv()
 		if err != nil {
+			wlog("signal stream ended: " + err.Error())
 			return
 		}
+		wlog("signal recv: " + m.Type)
 		switch m.Type {
 		case "offer":
 			if onOffer != nil {
-				_ = onOffer(m.SDP) //nolint:errcheck
+				if err := onOffer(m.SDP); err != nil {
+					wlog("onOffer err: " + err.Error())
+				} else {
+					flush()
+				}
 			}
 		case "answer":
 			desc := map[string]interface{}{"type": "answer", "sdp": m.SDP}
-			_, _ = awaitJS(pc.Call("setRemoteDescription", desc)) //nolint:errcheck
+			if _, err := awaitJS(pc.Call("setRemoteDescription", desc)); err != nil {
+				wlog("setRemoteDescription(answer) err: " + err.Error())
+			} else {
+				flush()
+			}
 		case "candidate":
-			cand := js.Global().Get("Object").New()
-			cand.Set("candidate", m.Candidate)
-			cand.Set("sdpMid", m.SDPMid)
-			cand.Set("sdpMLineIndex", m.SDPMLine)
-			_, _ = awaitJS(pc.Call("addIceCandidate", cand)) //nolint:errcheck
+			// addIceCandidate fails if the remote description isn't set yet, so
+			// buffer until it is (the classic trickle-ICE ordering fix).
+			if remoteSet {
+				addCand(m)
+			} else {
+				queued = append(queued, m)
+			}
 		}
 	}
 }
@@ -288,6 +360,7 @@ func newWebRTCConn(dc js.Value) *webRTCConn {
 	c := &webRTCConn{dc: dc, notify: make(chan struct{}), openCh: make(chan struct{})}
 
 	onOpen := js.FuncOf(func(js.Value, []js.Value) interface{} {
+		wlog("datachannel onopen")
 		c.openOnce.Do(func() { close(c.openCh) })
 		return nil
 	})

--- a/cmd/dmsg-wasm/webrtc_js.go
+++ b/cmd/dmsg-wasm/webrtc_js.go
@@ -1,0 +1,537 @@
+//go:build js && wasm
+
+// Package main — WebRTC DataChannel p2p transport for the browser dmsg client.
+//
+// This is the genuinely peer-to-peer transport: WebRTC's DTLS+SCTP DataChannel
+// is a direct, encrypted pipe between two browsers (or a browser and a native
+// pion peer), with NAT traversal via ICE. Unlike WebSocket/WebTransport (which
+// reach a dmsg SERVER), a DataChannel connects two LEAVES directly — no relay
+// carries the payload.
+//
+// WebRTC needs a signaling side-channel to exchange the SDP offer/answer and ICE
+// candidates BEFORE the direct pipe exists. dmsg is that side-channel: the two
+// peers already share dmsg connectivity, so the offer/answer/candidates ride a
+// dmsg stream (SignalChannel). Once the DataChannel opens, it is adapted to a
+// net.Conn — ready to carry a Noise+yamux session exactly like every other
+// carrier, so the SAME upper stack runs over a browser-native p2p link.
+//
+// Status: compile-verified (std-Go wasm + TinyGo wasm). The signaling state
+// machine needs browser runtime validation; it is the foundation for a
+// WebRTC-based skywire mesh transport (see docs/design/wasm-visor-p2p.md).
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"syscall/js"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+// awaitJS blocks until the JS promise p settles, returning its resolved value or
+// an error built from the rejection reason.
+func awaitJS(p js.Value) (js.Value, error) {
+	ch := make(chan struct{})
+	var res js.Value
+	var rejErr error
+	onOK := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
+		if len(args) > 0 {
+			res = args[0]
+		}
+		close(ch)
+		return nil
+	})
+	onErr := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
+		msg := "promise rejected"
+		if len(args) > 0 {
+			if m := args[0].Get("message"); m.Type() == js.TypeString {
+				msg = m.String()
+			} else {
+				msg = args[0].Call("toString").String()
+			}
+		}
+		rejErr = errors.New(msg)
+		close(ch)
+		return nil
+	})
+	p.Call("then", onOK).Call("catch", onErr)
+	<-ch
+	onOK.Release()
+	onErr.Release()
+	return res, rejErr
+}
+
+// webrtcSignalPort is the dmsg port the WebRTC signaling listener accepts on.
+const webrtcSignalPort uint16 = 47
+
+// signalMsg is one signaling message exchanged over the dmsg SignalChannel.
+type signalMsg struct {
+	Type      string `json:"type"`                // "offer" | "answer" | "candidate"
+	SDP       string `json:"sdp,omitempty"`       // for offer/answer
+	Candidate string `json:"candidate,omitempty"` // for an ICE candidate
+	SDPMid    string `json:"sdpMid,omitempty"`
+	SDPMLine  int    `json:"sdpMLineIndex,omitempty"`
+}
+
+// SignalChannel carries signaling messages between the two WebRTC peers before
+// the direct DataChannel exists. In production it is a dmsg stream.
+type SignalChannel interface {
+	send(signalMsg) error
+	recv() (signalMsg, error)
+	Close() error
+}
+
+// dmsgSignalChannel frames signalMsgs as length-prefixed JSON over a dmsg stream.
+type dmsgSignalChannel struct {
+	s     *dmsg.Stream
+	wmu   sync.Mutex
+	hdr   [4]byte
+	rdHdr [4]byte
+}
+
+func (c *dmsgSignalChannel) send(m signalMsg) error {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+	binary.BigEndian.PutUint32(c.hdr[:], uint32(len(b)))
+	if _, err := c.s.Write(c.hdr[:]); err != nil {
+		return err
+	}
+	_, err = c.s.Write(b)
+	return err
+}
+
+func (c *dmsgSignalChannel) recv() (signalMsg, error) {
+	if _, err := io.ReadFull(c.s, c.rdHdr[:]); err != nil {
+		return signalMsg{}, err
+	}
+	n := binary.BigEndian.Uint32(c.rdHdr[:])
+	if n > 1<<20 {
+		return signalMsg{}, fmt.Errorf("signal frame too large: %d", n)
+	}
+	b := make([]byte, n)
+	if _, err := io.ReadFull(c.s, b); err != nil {
+		return signalMsg{}, err
+	}
+	var m signalMsg
+	return m, json.Unmarshal(b, &m)
+}
+
+func (c *dmsgSignalChannel) Close() error { return c.s.Close() }
+
+// dialWebRTC is the OFFERER: it creates the peer connection + DataChannel, sends
+// the offer, applies the answer and remote candidates from sc, and returns once
+// the DataChannel is open.
+func dialWebRTC(ctx context.Context, sc SignalChannel, iceServers js.Value) (net.Conn, error) {
+	pc := newPeerConnection(iceServers)
+	dc := pc.Call("createDataChannel", "skywire", map[string]interface{}{"ordered": true})
+	conn := newWebRTCConn(dc)
+
+	wireLocalCandidates(pc, sc)
+	go pumpRemoteSignals(ctx, pc, sc, nil)
+
+	offer, err := awaitJS(pc.Call("createOffer"))
+	if err != nil {
+		return nil, fmt.Errorf("createOffer: %w", err)
+	}
+	if _, err := awaitJS(pc.Call("setLocalDescription", offer)); err != nil {
+		return nil, fmt.Errorf("setLocalDescription: %w", err)
+	}
+	if err := sc.send(signalMsg{Type: "offer", SDP: offer.Get("sdp").String()}); err != nil {
+		return nil, fmt.Errorf("send offer: %w", err)
+	}
+	if err := conn.waitOpen(ctx); err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+// acceptWebRTC is the ANSWERER: it waits for the offer on sc, answers it, and
+// returns the DataChannel (delivered via pc.ondatachannel) once it is open.
+func acceptWebRTC(ctx context.Context, sc SignalChannel, iceServers js.Value) (net.Conn, error) {
+	pc := newPeerConnection(iceServers)
+	dcCh := make(chan js.Value, 1)
+	onDC := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
+		select {
+		case dcCh <- args[0].Get("channel"):
+		default:
+		}
+		return nil
+	})
+	pc.Set("ondatachannel", onDC)
+
+	wireLocalCandidates(pc, sc)
+	go pumpRemoteSignals(ctx, pc, sc, func(offerSDP string) error {
+		desc := map[string]interface{}{"type": "offer", "sdp": offerSDP}
+		if _, err := awaitJS(pc.Call("setRemoteDescription", desc)); err != nil {
+			return err
+		}
+		answer, err := awaitJS(pc.Call("createAnswer"))
+		if err != nil {
+			return err
+		}
+		if _, err := awaitJS(pc.Call("setLocalDescription", answer)); err != nil {
+			return err
+		}
+		return sc.send(signalMsg{Type: "answer", SDP: answer.Get("sdp").String()})
+	})
+
+	select {
+	case dc := <-dcCh:
+		conn := newWebRTCConn(dc)
+		if err := conn.waitOpen(ctx); err != nil {
+			return nil, err
+		}
+		return conn, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// newPeerConnection constructs an RTCPeerConnection with the given iceServers
+// (a JS array, possibly null/undefined for none).
+func newPeerConnection(iceServers js.Value) js.Value {
+	cfg := js.Global().Get("Object").New()
+	if iceServers.Truthy() {
+		cfg.Set("iceServers", iceServers)
+	}
+	return js.Global().Get("RTCPeerConnection").New(cfg)
+}
+
+// wireLocalCandidates forwards locally-gathered ICE candidates to the peer over
+// the signaling channel (trickle ICE).
+func wireLocalCandidates(pc js.Value, sc SignalChannel) {
+	onCand := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
+		cand := args[0].Get("candidate")
+		if !cand.Truthy() {
+			return nil // null candidate = gathering complete
+		}
+		_ = sc.send(signalMsg{ //nolint:errcheck
+			Type:      "candidate",
+			Candidate: cand.Get("candidate").String(),
+			SDPMid:    cand.Get("sdpMid").String(),
+			SDPMLine:  cand.Get("sdpMLineIndex").Int(),
+		})
+		return nil
+	})
+	pc.Set("onicecandidate", onCand)
+}
+
+// pumpRemoteSignals reads signaling messages from sc and applies them to pc.
+// onOffer (answerer only) handles an inbound offer; for the offerer it is nil
+// and an "answer" sets the remote description.
+func pumpRemoteSignals(ctx context.Context, pc js.Value, sc SignalChannel, onOffer func(sdp string) error) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		m, err := sc.recv()
+		if err != nil {
+			return
+		}
+		switch m.Type {
+		case "offer":
+			if onOffer != nil {
+				_ = onOffer(m.SDP) //nolint:errcheck
+			}
+		case "answer":
+			desc := map[string]interface{}{"type": "answer", "sdp": m.SDP}
+			_, _ = awaitJS(pc.Call("setRemoteDescription", desc)) //nolint:errcheck
+		case "candidate":
+			cand := js.Global().Get("Object").New()
+			cand.Set("candidate", m.Candidate)
+			cand.Set("sdpMid", m.SDPMid)
+			cand.Set("sdpMLineIndex", m.SDPMLine)
+			_, _ = awaitJS(pc.Call("addIceCandidate", cand)) //nolint:errcheck
+		}
+	}
+}
+
+// webRTCConn adapts an RTCDataChannel to net.Conn (binaryType=arraybuffer),
+// using the same buffer+notify+deadline pattern as the WebSocket/WebTransport
+// browser conns.
+type webRTCConn struct {
+	dc   js.Value
+	addr webrtcAddr
+
+	mu        sync.Mutex
+	buf       []byte
+	notify    chan struct{}
+	openCh    chan struct{}
+	openOnce  sync.Once
+	openErr   error
+	closed    bool
+	closeErr  error
+	rDeadline time.Time
+
+	handlers []js.Func
+}
+
+type webrtcAddr struct{}
+
+func (webrtcAddr) Network() string { return "webrtc" }
+func (webrtcAddr) String() string  { return "webrtc-datachannel" }
+
+func newWebRTCConn(dc js.Value) *webRTCConn {
+	dc.Set("binaryType", "arraybuffer")
+	c := &webRTCConn{dc: dc, notify: make(chan struct{}), openCh: make(chan struct{})}
+
+	onOpen := js.FuncOf(func(js.Value, []js.Value) interface{} {
+		c.openOnce.Do(func() { close(c.openCh) })
+		return nil
+	})
+	onMsg := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
+		u8 := js.Global().Get("Uint8Array").New(args[0].Get("data"))
+		b := make([]byte, u8.Length())
+		js.CopyBytesToGo(b, u8)
+		c.mu.Lock()
+		c.buf = append(c.buf, b...)
+		c.wake()
+		c.mu.Unlock()
+		return nil
+	})
+	onClose := js.FuncOf(func(js.Value, []js.Value) interface{} {
+		c.fail(io.EOF)
+		c.openOnce.Do(func() { c.openErr = errors.New("datachannel closed before open"); close(c.openCh) })
+		return nil
+	})
+	onErr := js.FuncOf(func(js.Value, []js.Value) interface{} {
+		c.fail(errors.New("datachannel error"))
+		c.openOnce.Do(func() { c.openErr = errors.New("datachannel error before open"); close(c.openCh) })
+		return nil
+	})
+	c.handlers = []js.Func{onOpen, onMsg, onClose, onErr}
+	dc.Set("onopen", onOpen)
+	dc.Set("onmessage", onMsg)
+	dc.Set("onclose", onClose)
+	dc.Set("onerror", onErr)
+
+	// A channel created already-open (rare, but createDataChannel can resolve
+	// before we attach onopen) still reports readyState.
+	if dc.Get("readyState").String() == "open" {
+		c.openOnce.Do(func() { close(c.openCh) })
+	}
+	return c
+}
+
+func (c *webRTCConn) waitOpen(ctx context.Context) error {
+	select {
+	case <-c.openCh:
+		return c.openErr
+	case <-ctx.Done():
+		c.Close() //nolint:errcheck
+		return ctx.Err()
+	}
+}
+
+func (c *webRTCConn) wake() { close(c.notify); c.notify = make(chan struct{}) }
+
+func (c *webRTCConn) fail(err error) {
+	c.mu.Lock()
+	if !c.closed {
+		c.closed = true
+		c.closeErr = err
+		c.wake()
+	}
+	c.mu.Unlock()
+}
+
+func (c *webRTCConn) Read(p []byte) (int, error) {
+	for {
+		c.mu.Lock()
+		if len(c.buf) > 0 {
+			n := copy(p, c.buf)
+			c.buf = c.buf[n:]
+			c.mu.Unlock()
+			return n, nil
+		}
+		if c.closed {
+			err := c.closeErr
+			c.mu.Unlock()
+			if err == nil {
+				err = io.EOF
+			}
+			return 0, err
+		}
+		notify := c.notify
+		deadline := c.rDeadline
+		c.mu.Unlock()
+
+		var timeout <-chan time.Time
+		if !deadline.IsZero() {
+			d := time.Until(deadline)
+			if d <= 0 {
+				return 0, wrtcTimeout{}
+			}
+			t := time.NewTimer(d)
+			defer t.Stop()
+			timeout = t.C
+		}
+		select {
+		case <-notify:
+		case <-timeout:
+			return 0, wrtcTimeout{}
+		}
+	}
+}
+
+func (c *webRTCConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	if c.closed {
+		err := c.closeErr
+		c.mu.Unlock()
+		if err == nil {
+			err = net.ErrClosed
+		}
+		return 0, err
+	}
+	c.mu.Unlock()
+	u8 := js.Global().Get("Uint8Array").New(len(p))
+	js.CopyBytesToJS(u8, p)
+	c.dc.Call("send", u8)
+	return len(p), nil
+}
+
+func (c *webRTCConn) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	if c.closeErr == nil {
+		c.closeErr = net.ErrClosed
+	}
+	c.wake()
+	c.mu.Unlock()
+	c.dc.Call("close")
+	return nil
+}
+
+func (c *webRTCConn) LocalAddr() net.Addr  { return c.addr }
+func (c *webRTCConn) RemoteAddr() net.Addr { return c.addr }
+
+func (c *webRTCConn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.rDeadline = t
+	c.wake()
+	c.mu.Unlock()
+	return nil
+}
+func (c *webRTCConn) SetWriteDeadline(time.Time) error { return nil }
+func (c *webRTCConn) SetDeadline(t time.Time) error    { return c.SetReadDeadline(t) }
+
+type wrtcTimeout struct{}
+
+func (wrtcTimeout) Error() string   { return "webrtc: i/o timeout" }
+func (wrtcTimeout) Timeout() bool   { return true }
+func (wrtcTimeout) Temporary() bool { return true }
+
+// jsWebrtcListen(onConn) -> nil. Accepts inbound WebRTC signaling on dmsg port
+// 47; for each, runs the answerer handshake and hands the resulting net.Conn to
+// onConn(connHandle). The peer reaches us BY PK over dmsg, then we upgrade to a
+// direct DataChannel — a browser p2p endpoint reachable through the mesh.
+func jsWebrtcListen(_ js.Value, args []js.Value) interface{} {
+	onConn := args[0]
+	var iceServers js.Value
+	if len(args) > 1 {
+		iceServers = args[1]
+	}
+	if client == nil {
+		return js.Global().Get("Error").New("not connected; call connect() first")
+	}
+	lis, err := client.Listen(webrtcSignalPort)
+	if err != nil {
+		return js.Global().Get("Error").New(err.Error())
+	}
+	go func() {
+		for {
+			str, err := lis.AcceptStream()
+			if err != nil {
+				return
+			}
+			go func(s *dmsg.Stream) {
+				conn, err := acceptWebRTC(ctx, &dmsgSignalChannel{s: s}, iceServers)
+				if err != nil {
+					s.Close() //nolint:errcheck
+					return
+				}
+				onConn.Invoke(netConnHandle(conn))
+			}(str)
+		}
+	}()
+	return nil
+}
+
+// jsWebrtcDial(remotePkHex) -> Promise<connHandle>. Opens a dmsg signaling
+// stream to the peer's port 47, runs the offerer handshake, and resolves to the
+// direct DataChannel net.Conn (wrapped as a JS handle).
+func jsWebrtcDial(_ js.Value, args []js.Value) interface{} {
+	remoteHex := args[0].String()
+	var iceServers js.Value
+	if len(args) > 1 {
+		iceServers = args[1]
+	}
+	return promise(func() (interface{}, error) {
+		if client == nil {
+			return nil, errors.New("not connected; call connect() first")
+		}
+		var rPK cipher.PubKey
+		if err := rPK.UnmarshalText([]byte(remoteHex)); err != nil {
+			return nil, fmt.Errorf("bad remote public key: %w", err)
+		}
+		str, err := client.DialStream(ctx, dmsg.Addr{PK: rPK, Port: webrtcSignalPort})
+		if err != nil {
+			return nil, err
+		}
+		conn, err := dialWebRTC(ctx, &dmsgSignalChannel{s: str}, iceServers)
+		if err != nil {
+			str.Close() //nolint:errcheck
+			return nil, err
+		}
+		return netConnHandle(conn), nil
+	})
+}
+
+// netConnHandle wraps any net.Conn as a JS { send, onMessage, close } object,
+// mirroring streamHandle but for the WebRTC DataChannel conn.
+func netConnHandle(conn net.Conn) js.Value {
+	obj := js.Global().Get("Object").New()
+	obj.Set("send", js.FuncOf(func(_ js.Value, a []js.Value) interface{} {
+		msg := a[0].String()
+		go conn.Write([]byte(msg)) //nolint:errcheck
+		return nil
+	}))
+	obj.Set("onMessage", js.FuncOf(func(_ js.Value, a []js.Value) interface{} {
+		cb := a[0]
+		go func() {
+			buf := make([]byte, 32*1024)
+			for {
+				n, err := conn.Read(buf)
+				if n > 0 {
+					cb.Invoke(string(buf[:n]))
+				}
+				if err != nil {
+					return
+				}
+			}
+		}()
+		return nil
+	}))
+	obj.Set("close", js.FuncOf(func(_ js.Value, _ []js.Value) interface{} {
+		conn.Close() //nolint:errcheck
+		return nil
+	}))
+	return obj
+}

--- a/cmd/wasm-visor-probe/main.go
+++ b/cmd/wasm-visor-probe/main.go
@@ -1,0 +1,35 @@
+//go:build js && wasm
+
+// Command wasm-visor-probe measures how much of the visor stack compiles under
+// TinyGo for the browser. It is a BUILD-ONLY frontier probe — not a runnable
+// visor. `tinygo build -target wasm ./cmd/wasm-visor-probe` succeeding means the
+// imported packages are TinyGo/browser-portable; add packages as they are ported
+// and the frontier moves.
+//
+// Frontier as of this commit (measured via `go list -deps -tags tinygo`):
+//
+//	✅ COMPILES TODAY (imported below):
+//	   pkg/routing            — routing rules/types, pure
+//	   pkg/visor/visorconfig  — config types + keyring
+//
+//	⛔ BLOCKED (blocker → fix):
+//	   pkg/router             quic-go  → split raw-socket networks (stcp/sudph/quic) behind tags
+//	                          net/http → net/http-free routefinder client (dmsgclient.FetchOverDmsg pattern)
+//	                          net/rpc  → cascade_source.go RSN oracle (gob-RPC like wasmhv, or tag out)
+//	   pkg/transport          quic-go + net/http (TPD client) + net/rpc
+//	   pkg/transport/network  quic-go (quic.go/sudph.go/stcpr.go) — keep dmsg.go only for browser
+//	   pkg/app/appnet         quic-go + net/http + net/rpc
+//	   pkg/app/appevent       net/rpc — app↔visor event channel
+//	   pkg/visor              + os/exec (the app-SUBPROCESS model — needs in-process apps)
+//
+// See docs/design/wasm-visor-p2p.md §7 for the phased plan.
+package main
+
+import (
+	"fmt"
+
+	_ "github.com/skycoin/skywire/pkg/routing"
+	_ "github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+func main() { fmt.Println("wasm-visor-probe: portable visor subset compiled") }

--- a/docs/design/wasm-visor-p2p.md
+++ b/docs/design/wasm-visor-p2p.md
@@ -171,7 +171,13 @@ port; what `tinygo build` accepts is what's portable.
    (dmsg-only) variant. Native is unaffected (the tagged files stay in native
    builds) so this is a COMPILE-time refactor, not a runtime change — iterate the
    tinygo build until it accepts the dmsg-only factory. This drops quic-go from
-   `pkg/transport` and `pkg/router`.
+   `pkg/transport` and `pkg/router`. NOTE (measured): the cascade reaches
+   `client.go`'s core `Config` struct (embeds `stcp.PKTable`) and the
+   `makeClient` type-switch, so a clean split likely wants the per-network
+   constructors behind a small interface/registry (register dmsg untagged,
+   stcp/stcpr/sudph/quic in `!tinygo` init) rather than a giant tagged switch —
+   an invasive but mechanical restructure of core transport code. Do it as its
+   own reviewed PR, validated with the autonomous browser harness.
 2. **net/http-free service clients.** RF, TPD, and AR each talk HTTP to a service;
    port them over dmsg with `dmsgclient.FetchOverDmsg` (the disc client pattern),
    behind native/tinygo tags. Drops net/http from transport + router.

--- a/docs/design/wasm-visor-p2p.md
+++ b/docs/design/wasm-visor-p2p.md
@@ -1,0 +1,138 @@
+# Browser p2p transports and the wasm visor
+
+Status: design + foundation landed (browser WebSocket/WebTransport dmsg carriers
+and a WebRTC DataChannel `net.Conn` over dmsg signaling — all compile under
+TinyGo wasm). The mesh-routing integration described in §4–6 is not built yet.
+
+## 0. The reframing: reachability ≠ listening
+
+A browser tab cannot `accept()` an inbound connection — there is no listen
+socket in the sandbox. The intuitive conclusion is "a tab can't be a server."
+That conclusion is **wrong for skywire**, because skywire already decouples
+*reachability* from *listening*:
+
+- A **dmsg client** never listens. It dials *out* to a dmsg server. Once that
+  session exists, other clients dial it **by public key** and the server bridges
+  the stream back down the existing session. The client is inbound-reachable
+  without ever accepting a socket.
+- The same is true one layer up, at the **skywire transport + routing** layer. A
+  transport is *bidirectional once established* — it does not matter which side
+  dialed. If a node forms one outbound transport to a well-connected peer and
+  that transport edge is **registered in the Transport Discovery (TPD)**, the
+  route finder can compute routes *through* that peer to the node, and route
+  setup installs forwarding rules over the already-open transport. The node then
+  serves skynet apps (skychat, skysocks, a website on port 80, …) reachable by
+  any visor that can find a route — even though it never listened.
+
+So: a wasm tab that (a) connects out over a browser transport and (b) publishes
+its transport edge is a **first-class routable skywire node**. This is the dmsg
+model, generalized to the routing layer. The novelty is real — a website or
+service hosted from a browser tab, addressed by public key, reachable across the
+mesh, with no port, no domain, no inbound socket.
+
+## 1. The one true constraint
+
+What a tab *cannot* have is an entry that others can find **without the tab first
+establishing the outbound link**. Reachability is contingent on the tab being
+online and holding at least one transport whose edge is in TPD. The moment it
+drops, its TPD edges go stale and routes through it fail — exactly like a dmsg
+client dropping its session. That is a liveness property, not an addressing
+impossibility. (Cf. the dead-edge route-setup work: stale TPD edges are already a
+known failure mode the finder must weather.)
+
+Note what is **not** the mechanism: the **Address Resolver (AR)** maps
+`PK → IP:port` for hole-punched direct transports (sudph/stcpr). A tab has no
+IP:port to advertise, so AR is irrelevant to it. A tab's reachability comes
+purely from **TPD edge + routing**, the same way a dmsg client's comes from the
+discovery entry + server bridging.
+
+## 2. The browser transport menu
+
+Gated by the sandbox, not the compiler (TinyGo vs Go only changes binary size):
+
+| transport | reaches | role | status |
+|---|---|---|---|
+| WebSocket | a dmsg **server** | dmsg session carrier | ✅ `ws_js_tinygo.go` |
+| WebTransport (HTTP/3) | a dmsg **server** | dmsg session carrier, CA-free (cert-hash pin) | ✅ `wt_js_tinygo.go` |
+| WebRTC DataChannel | a **peer** (tab/visor) | true p2p link | ⚙️ `cmd/dmsg-wasm/webrtc_js.go` (foundation) |
+| raw TCP (stcp/stcpr) | — | — | ❌ no raw sockets |
+| raw UDP (sudph/KCP) | — | — | ❌ no raw sockets |
+
+WebSocket/WebTransport make the tab a dmsg **leaf** (reachable via server
+bridging — §0 bullet 1). WebRTC is the one that makes the tab a true **mesh
+peer** with a direct link — the building block for §4.
+
+## 3. WebRTC needs a signaling plane — and dmsg is it
+
+WebRTC can't bootstrap itself: the two peers must exchange an SDP offer/answer
+and ICE candidates *before* the direct DataChannel exists. They already share
+dmsg connectivity, so **dmsg is the signaling channel**: the offer/answer/
+candidates ride a dmsg stream (`SignalChannel`, backed by `*dmsg.Stream` on a
+dedicated signaling port). Once the DataChannel opens it is adapted to a
+`net.Conn` and carries a Noise+yamux session like any other carrier — the same
+upper stack, over a browser-native p2p pipe.
+
+This is the clean separation: **dmsg = signaling + fallback relay; WebRTC =
+direct data path.** A tab that can't form a direct DataChannel (symmetric NAT,
+no TURN) still talks over dmsg; WebRTC is an *upgrade*, never a prerequisite.
+
+## 4. From carrier to mesh transport (not built)
+
+The foundation above gives browser `net.Conn`s. Turning WebRTC into a real
+skywire **mesh transport** (so routes can traverse a tab) means:
+
+1. A `network.Type` `"webrtc"` + a transport factory in `pkg/transport` that
+   dials via the signaling handshake and yields the `net.Conn`.
+2. Wiring it into the transport manager so a tab-visor `SaveTransport` registers
+   the edge `(tabPK, peerPK, "webrtc")` in **TPD**.
+3. A **route-setup responder** in the tab: accept setup packets over its
+   transport(s) and install forwarding rules (this is what lets routes *end* at
+   the tab and lets it be an intermediate hop).
+4. App hosting: a minimal app server so the tab can answer on app ports
+   (a website, skychat, an API) addressed by its PK.
+
+Items 3–4 are the bulk of a "wasm visor": today `cmd/dmsg-wasm` is a dmsg leaf +
+in-wasm hypervisor; a wasm *visor* additionally runs the router, transport
+manager, and route-setup responder.
+
+## 5. Why this is worth doing
+
+- **Serverless services addressed by key.** Host a site/app from a tab, reachable
+  mesh-wide by PK — no host, no domain, no inbound port. The standalone
+  hypervisor already proves the "serve a UI from a tab over dmsg" shape; this
+  generalizes it to arbitrary routed services.
+- **Direct p2p where it matters.** Browser↔browser and browser↔visor DataChannels
+  keep payload off the relays — bandwidth and latency win, and a privacy win
+  (the relay sees signaling, not data).
+- **A genuinely portable visor.** The same reflection-light core that compiles to
+  TinyGo wasm and (per the IoT port) to wasip1/microcontrollers becomes a visor
+  that runs anywhere a JS engine or a WASM runtime does.
+
+## 6. Open questions
+
+- **ICE servers.** Browser↔browser through NAT needs STUN, and symmetric NAT
+  needs TURN — both are clearnet dependencies that cut against the no-clearnet
+  goal. Options: rely on host candidates only (works when one peer is public,
+  e.g. a visor), run a skywire-hosted STUN/TURN, or treat WebRTC as a
+  same-network / public-peer optimization and keep dmsg as the universal path.
+  The signaling layer is dmsg-native regardless; only the media path needs ICE.
+- **TPD trust for ephemeral tabs.** A tab churns more than a visor; TPD edge TTL
+  and the finder's liveness weighting (see the dead-edge work) need to tolerate
+  high-churn leaf edges without polluting routes for everyone.
+- **Carrier vs mesh for WebTransport.** WT is wired as a dmsg *carrier* here. It
+  could also back a `webtransport` mesh transport (browser→public-visor direct),
+  parallel to WebRTC. Decide whether that earns its keep over WS+routing.
+- **Scope of the wasm visor.** How much of `pkg/router` / `pkg/transport` is
+  worth compiling into wasm vs. keeping the tab a signaling-and-DataChannel leaf
+  that delegates routing to a paired full visor.
+
+## 7. What landed with this design
+
+- `pkg/dmsg/dmsg/ws_js_tinygo.go` — browser WebSocket `net.Conn` dmsg carrier.
+- `pkg/dmsg/dmsg/wt_js_tinygo.go` — browser WebTransport `net.Conn` dmsg carrier
+  (cert-hash pinned, CA-free), `wt_stub_tinygo.go` for non-browser TinyGo.
+- `cmd/dmsg-wasm/webrtc_js.go` — WebRTC DataChannel `net.Conn` + offer/answer/ICE
+  state machine over a dmsg `SignalChannel`; JS API `webrtcDial` / `webrtcListen`.
+
+All compile-verified under both standard-Go wasm and TinyGo wasm. None is
+runtime-validated in a browser yet — that is the next gate before §4.

--- a/docs/design/wasm-visor-p2p.md
+++ b/docs/design/wasm-visor-p2p.md
@@ -126,7 +126,56 @@ manager, and route-setup responder.
   worth compiling into wasm vs. keeping the tab a signaling-and-DataChannel leaf
   that delegates routing to a paired full visor.
 
-## 7. What landed with this design
+## 7. How much of the visor ports? (measured frontier)
+
+Measured with `go list -deps -tags tinygo` (GOOS=js) and confirmed by
+`tinygo build ./cmd/wasm-visor-probe`. The recurring blockers are a small set:
+**quic-go** (the raw-socket networks), **net/http** (RF/TPD/AR discovery
+clients), **net/rpc** (app-event + RSN cascade), and **os/exec** (app
+subprocesses).
+
+| package | blockers | note |
+|---|---|---|
+| `pkg/routing` | ✅ none | routing rules/types — **compiles under TinyGo today** |
+| `pkg/visor/visorconfig` | ✅ none | config + keyring — **compiles today** |
+| `pkg/transport/network` | quic-go | per-network files; browser needs only `dmsg.go` |
+| `pkg/app/appevent` | net/rpc | app↔visor event channel |
+| `pkg/router` | quic-go, net/http, net/rpc | finder client + RSN cascade + the networks |
+| `pkg/transport` | quic-go, net/http, net/rpc | TPD client + the networks |
+| `pkg/app/appnet` | quic-go, net/http, net/rpc | |
+| `pkg/visor` | + os/exec | the app-**subprocess** model is the deepest gap |
+
+`cmd/wasm-visor-probe` is the living frontier check — add imports as packages
+port; what `tinygo build` accepts is what's portable.
+
+### Phased plan
+
+1. **Networks: dmsg-only browser build.** Split `pkg/transport/network` so the
+   browser build compiles `dmsg.go` (+ the future `webrtc`) and tags out
+   `quic.go`/`sudph.go`/`stcpr.go` + `pkg/skyquic` + the STUN/addr-resolver bits.
+   This drops quic-go from `pkg/transport` and `pkg/router`. (Mirrors the dmsg
+   QUIC extraction already done.)
+2. **net/http-free service clients.** RF, TPD, and AR each talk HTTP to a service;
+   port them over dmsg with `dmsgclient.FetchOverDmsg` (the disc client pattern),
+   behind native/tinygo tags. Drops net/http from transport + router.
+3. **net/rpc.** Tag out (or gob-RPC, à la wasmhv) `appevent`'s RPC channel and
+   `router/cascade_source.go`'s RSN oracle for the browser build. With 1–3,
+   `pkg/transport` and `pkg/router` should hit the probe.
+4. **In-process apps (the fork).** `pkg/app/appserver` launches apps as OS
+   processes — impossible in a tab. A browser visor needs apps as in-process
+   goroutines behind the same app contract (this is also the unified-app-framework
+   direction, issue #2775). Decision: how many apps (skychat? a web server?) get
+   an in-process mode, vs. keeping the tab a routing leaf paired with a full visor.
+5. **Persistence + glue.** Config/transport-log/route-store over a browser store
+   (localStorage/IndexedDB via syscall/js) instead of the filesystem; assemble a
+   `cmd/wasm-visor` that wires router + transport-manager(dmsg/webrtc) + route-setup
+   responder + in-process apps.
+
+Phases 1–3 are mechanical (tag splits + the proven HTTP-over-dmsg pattern) and get
+a **routing+transport core** into the browser. Phase 4 is the real architectural
+decision. Phase 5 makes it a visor.
+
+## 8. What landed with this design
 
 - `pkg/dmsg/dmsg/ws_js_tinygo.go` — browser WebSocket `net.Conn` dmsg carrier.
 - `pkg/dmsg/dmsg/wt_js_tinygo.go` — browser WebTransport `net.Conn` dmsg carrier

--- a/docs/design/wasm-visor-p2p.md
+++ b/docs/design/wasm-visor-p2p.md
@@ -200,6 +200,21 @@ Phases 1–3 are mechanical (tag splits + the proven HTTP-over-dmsg pattern) and
 a **routing+transport core** into the browser. Phase 4 reuses the existing internal
 launcher. Phase 5 makes it a visor.
 
+**Phase-1 status + the AR/appevent cascade (measured 2026-06-22, partly committed).**
+The raw-socket carrier *files* (quic/sudph/stun) are tagged `!tinygo` (committed) —
+native unaffected. But two fields on the PUBLIC `network.ClientFactory` keep the
+package non-portable: `ARClient addrresolver.APIClient` (→ net/http + packetfilter,
+which pulls quic-go) and `EB *appevent.Broadcaster` (→ net/rpc). `eb` is used only by
+stcp/stcpr (`SendTCPDial`); `ar` by resolvedClient + dialVisor + stcpr/sudph/quic.
+Interface-abstracting both in the network package is clean — BUT the blocker just
+moves UP: `pkg/transport.Manager` constructs `ClientFactory{ARClient:…, EB:…}` with
+the concrete types, and `pkg/visor` constructs the Manager. So a real port must
+thread AR + appevent (and the net/http-free RF/TPD/AR clients + net/rpc removal)
+through **network → transport → visor** consistently — a broad restructure of
+production-critical transport APIs, not a contained tag split. Do it as a focused
+per-layer effort (interfaces + a network registry), validated with the autonomous
+browser harness, rather than rushed.
+
 ## 8. Which apps fit a wasm visor?
 
 The governing rule: **an app works in a wasm visor iff everything it does is either

--- a/docs/design/wasm-visor-p2p.md
+++ b/docs/design/wasm-visor-p2p.md
@@ -112,10 +112,20 @@ manager, and route-setup responder.
 
 - **ICE servers.** Browser↔browser through NAT needs STUN, and symmetric NAT
   needs TURN — both are clearnet dependencies that cut against the no-clearnet
-  goal. Options: rely on host candidates only (works when one peer is public,
-  e.g. a visor), run a skywire-hosted STUN/TURN, or treat WebRTC as a
+  goal. Skywire already ships STUN servers (the deployment's `StunServers`, used
+  for sudph NAT detection); WebRTC reuses them as ICE servers, so no third-party
+  STUN. Options for the harder cases: rely on host candidates only (works when one
+  peer is public, e.g. a visor), run a skywire-hosted TURN, or treat WebRTC as a
   same-network / public-peer optimization and keep dmsg as the universal path.
   The signaling layer is dmsg-native regardless; only the media path needs ICE.
+- **Config source = the VISOR's config, not the embedded default.** The test
+  harness (cmd/dmsg-wasm) exposes `deployment.Prod.StunServers` — the embedded
+  defaults. But when the UI is generated/embedded BY a visor (the standalone-HV
+  generator, `cli hv gen`), it must inject THAT visor's runtime config — its
+  configured STUN servers, dmsg servers, discovery, and service URLs — which may
+  differ on custom/private deployments. The generator already inlines config; the
+  STUN/ICE config (and any other deployment-specific values) rides along.
+  See the `TODO(wasm-visor)` in cmd/dmsg-wasm/main.go.
 - **TPD trust for ephemeral tabs.** A tab churns more than a visor; TPD edge TTL
   and the finder's liveness weighting (see the dead-edge work) need to tolerate
   high-churn leaf edges without polluting routes for everyone.

--- a/docs/design/wasm-visor-p2p.md
+++ b/docs/design/wasm-visor-p2p.md
@@ -161,21 +161,68 @@ port; what `tinygo build` accepts is what's portable.
 3. **net/rpc.** Tag out (or gob-RPC, à la wasmhv) `appevent`'s RPC channel and
    `router/cascade_source.go`'s RSN oracle for the browser build. With 1–3,
    `pkg/transport` and `pkg/router` should hit the probe.
-4. **In-process apps (the fork).** `pkg/app/appserver` launches apps as OS
-   processes — impossible in a tab. A browser visor needs apps as in-process
-   goroutines behind the same app contract (this is also the unified-app-framework
-   direction, issue #2775). Decision: how many apps (skychat? a web server?) get
-   an in-process mode, vs. keeping the tab a routing leaf paired with a full visor.
+4. **In-process apps.** Not a fork — the launcher ALREADY has two modes:
+   `RunModeInternal` (`appserver.Proc.startInProcess`, app run-func in a goroutine,
+   no subprocess) and `RunModeExternal` (`startExternal`, the os/exec path). A
+   browser visor simply uses the internal launcher and tags out `startExternal`,
+   which is the only os/exec in `pkg/visor`. The real question is not *how* to run
+   apps in-process but *which* apps can do their job inside the browser sandbox —
+   see §8. (This dovetails with the unified-app-framework direction, #2775.)
 5. **Persistence + glue.** Config/transport-log/route-store over a browser store
    (localStorage/IndexedDB via syscall/js) instead of the filesystem; assemble a
    `cmd/wasm-visor` that wires router + transport-manager(dmsg/webrtc) + route-setup
    responder + in-process apps.
 
 Phases 1–3 are mechanical (tag splits + the proven HTTP-over-dmsg pattern) and get
-a **routing+transport core** into the browser. Phase 4 is the real architectural
-decision. Phase 5 makes it a visor.
+a **routing+transport core** into the browser. Phase 4 reuses the existing internal
+launcher. Phase 5 makes it a visor.
 
-## 8. What landed with this design
+## 8. Which apps fit a wasm visor?
+
+The governing rule: **an app works in a wasm visor iff everything it does is either
+pure skywire mesh I/O (dmsg/routes) or a capability the browser sandbox exposes**
+(fetch, IndexedDB, WebCrypto, File API, WebRTC, notifications, media). It fails the
+moment it needs a raw socket, a TUN device, a local listen port, the filesystem,
+or a subprocess.
+
+| app | in a tab? | why |
+|---|---|---|
+| skychat | ✅ | pure messaging over routes + UI — the canonical fit |
+| content / site hosting | ✅ | serve content the tab holds (embedded / IndexedDB / File API) on app port 80, addressed by PK |
+| file share | ✅ | serve user-picked files (File API) to peers — personal, ephemeral, key-addressed |
+| wallet / skycoin-over-dmsg | ✅ | WebCrypto keys + IndexedDB + dmsg |
+| pubsub / CXO data sharing | ✅ likely | gob/reflection, which TinyGo 0.41 handles — needs a compile check |
+| capability bridge | ✅ novel | expose a browser-only power over skywire by PK: WebRTC signaling relay, WebCrypto signing oracle, notifications |
+| skysocks (egress proxy) | ❌ | needs arbitrary outbound TCP; a CORS-crippled fetch()-relay isn't a real proxy |
+| skysocks-client | ❌ | needs a local SOCKS listen port for local apps — a tab has neither |
+| VPN server/client | ❌ | TUN device + raw packets — categorically impossible |
+| port forwarding | ❌ | "local port" doesn't exist in a tab (the serving direction collapses into content hosting) |
+
+The unifying frame: **a wasm visor is a personal, present-when-you-are node, not
+always-on infrastructure.** The apps that fit cluster into four personal verbs —
+**communicate** (chat, receive, file-share), **publish** (host your site/profile,
+addressed by your key, no host/domain), **transact** (wallet/skycoin over dmsg),
+and **expose** (make a browser-only capability reachable by PK).
+
+The clean corollary that makes the limitation principled rather than sad: **a wasm
+visor can be a *consumer* of infrastructure apps (proxy, exit, VPN) via routes — it
+just can't be a *provider* of them.** Providers need raw sockets/devices the
+sandbox forbids; consumers only need routes, which it has. Network *infrastructure*
+stays on real visors; the browser becomes a first-class *participant and publisher*.
+
+Two caveats that shape what's worth building first:
+
+1. **Liveness.** These are presence-based services (alive only while the tab is
+   open) — great for chat/personal/interactive; for a 24/7 site you'd pair the tab
+   with a persistent visor or pin the content elsewhere. Same TPD-edge-goes-stale
+   property as §1.
+2. **Adoption.** The prize is that a *user* becomes a full skywire participant just
+   by opening a page — no install, identity by key, chat + publish + wallet. That
+   argues for **skychat + content hosting first** as the proof (both ✅, both
+   immediately useful), and tells phase-4's internal-app set to start with those,
+   not the proxy/VPN family.
+
+## 9. What landed with this design
 
 - `pkg/dmsg/dmsg/ws_js_tinygo.go` — browser WebSocket `net.Conn` dmsg carrier.
 - `pkg/dmsg/dmsg/wt_js_tinygo.go` — browser WebTransport `net.Conn` dmsg carrier

--- a/docs/design/wasm-visor-p2p.md
+++ b/docs/design/wasm-visor-p2p.md
@@ -232,6 +232,24 @@ Two caveats that shape what's worth building first:
    immediately useful), and tells phase-4's internal-app set to start with those,
    not the proxy/VPN family.
 
+## 8a. Known issue: seeded wasm client doesn't register in discovery
+
+Browser validation found that the TinyGo wasm client **connects to a dmsg server
+(session established) but does NOT register its entry in dmsg-discovery** — a
+lookup of its own PK returns 404. Peers still reach it via the **connected-servers
+fallback** (dmsg-100: a peer sharing a dmsg server is bridged without a discovery
+entry), which is why dmsg dial/listen + WebRTC signaling all worked between two
+tabs. But arbitrary peers that don't share a server can't resolve it.
+
+The dmsg client's `updateClientEntryLoop` → `EntityCommon.updateClientEntry` →
+`PutEntry` runs once at connect (periodic retry only every 5 min,
+`DefaultUpdateInterval*5`), so the initial registration via the net/http-free
+`dmsgDiscClient.PutEntry` is failing silently. To investigate: instrument
+`updateClientEntry` + `dmsgDiscClient.PutEntry`/`PostEntry`; likely the POST over
+dmsg, the entry signing, or an `Entry()` precheck under TinyGo. Not blocking
+(fallback covers shared-server reachability) but required for register-and-be-
+found-by-anyone reachability.
+
 ## 9. What landed with this design
 
 - `pkg/dmsg/dmsg/ws_js_tinygo.go` — browser WebSocket `net.Conn` dmsg carrier.

--- a/docs/design/wasm-visor-p2p.md
+++ b/docs/design/wasm-visor-p2p.md
@@ -161,10 +161,17 @@ port; what `tinygo build` accepts is what's portable.
 ### Phased plan
 
 1. **Networks: dmsg-only browser build.** Split `pkg/transport/network` so the
-   browser build compiles `dmsg.go` (+ the future `webrtc`) and tags out
-   `quic.go`/`sudph.go`/`stcpr.go` + `pkg/skyquic` + the STUN/addr-resolver bits.
-   This drops quic-go from `pkg/transport` and `pkg/router`. (Mirrors the dmsg
-   QUIC extraction already done.)
+   browser build compiles `dmsg.go` (+ the future `webrtc`) and tags out the
+   raw-socket networks. Concretely (measured): quic-go enters this package only
+   via `quic.go` + `quic_identity.go`; the cascade is `network.go`'s factory,
+   which constructs the per-network clients (stcp/stcpr/sudph/quic via raw
+   net.Listen/Dial + skyquic). The split: tag `quic.go`/`quic_identity.go`/
+   `stcp.go`/`stcpr.go`/`sudph.go`/`stun_client.go`/`tcp_liveness.go` `!tinygo`,
+   and split `network.go`'s factory into a native (all networks) + tinygo
+   (dmsg-only) variant. Native is unaffected (the tagged files stay in native
+   builds) so this is a COMPILE-time refactor, not a runtime change — iterate the
+   tinygo build until it accepts the dmsg-only factory. This drops quic-go from
+   `pkg/transport` and `pkg/router`.
 2. **net/http-free service clients.** RF, TPD, and AR each talk HTTP to a service;
    port them over dmsg with `dmsgclient.FetchOverDmsg` (the disc client pattern),
    behind native/tinygo tags. Drops net/http from transport + router.

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -208,6 +208,17 @@ func (c *EntityCommon) setDiscoveryClients(clients []disc.APIClient) {
 	if len(c.discoveries) > 0 {
 		c.dc = c.discoveries[0].Client
 	}
+	// A new discovery client means the entry must be (re)published there, even if
+	// the delegated-server set is unchanged. Clear the last-pushed snapshot so the
+	// next updateClientEntry isn't short-circuited by the SamePubKeys guard, and
+	// nudge the update loop. Without this, a client that swaps a bootstrap disc
+	// client for the real one (the seeded browser path) connects but never
+	// registers — the initial publish ran against the bootstrap client and marked
+	// the (unchanged) server set as already-pushed.
+	c.pushedSrvPKsMx.Lock()
+	c.lastPushedSrvPKs = nil
+	c.pushedSrvPKsMx.Unlock()
+	c.nudgeEntryUpdate()
 }
 
 // snapshotDiscoveries returns a copy of the discovery list, safe for

--- a/pkg/dmsg/dmsg/quic_stub.go
+++ b/pkg/dmsg/dmsg/quic_stub.go
@@ -6,14 +6,17 @@
 //
 //   - dmsg-over-QUIC (quic-go needs crypto/tls.QUICEncryptionLevel, absent in
 //     TinyGo's crypto/tls), and
-//   - dmsg-over-WebTransport (pulls quic-go + webtransport-go).
+//   - dmsg-over-WebTransport (pulls quic-go + webtransport-go) — EXCEPT on the
+//     browser (js/wasm) target, where dialSessionWT is provided natively via the
+//     browser WebTransport API in wt_js_tinygo.go.
 //
-// A TinyGo dmsg client never dials either — dialSession's switch only reaches
-// these if a server advertises a QUIC / WebTransport endpoint, and the stubs'
-// errors make it fall back to the TCP/WS path. The server-side listeners
-// (ServeQUIC / ServeWebTransport) live only in their !tinygo files and are
-// simply absent under TinyGo (a TinyGo build is a client, not a server). See
-// docs/design/tinygo-dmsg-client.md.
+// A TinyGo dmsg client never dials QUIC — dialSession's switch only reaches it
+// if a server advertises a QUIC endpoint, and the stub's error makes it fall
+// back to the TCP/WS path. The WT stub here covers the non-browser TinyGo (IoT)
+// build via wt_stub_tinygo.go; the browser build dials WT for real. The
+// server-side listeners (ServeQUIC / ServeWebTransport) live only in their
+// !tinygo files and are simply absent under TinyGo (a TinyGo build is a client,
+// not a server). See docs/design/tinygo-dmsg-client.md.
 package dmsg
 
 import (
@@ -26,9 +29,5 @@ import (
 var errNativeTransportUnsupported = errors.New("dmsg: QUIC/WebTransport not supported in this build (TinyGo); falling back to TCP/WS")
 
 func (ce *Client) dialSessionQUIC(_ context.Context, _ *disc.Entry) (ClientSession, error) {
-	return ClientSession{}, errNativeTransportUnsupported
-}
-
-func (ce *Client) dialSessionWT(_ context.Context, _ *disc.Entry) (ClientSession, error) {
 	return ClientSession{}, errNativeTransportUnsupported
 }

--- a/pkg/dmsg/dmsg/ws.go
+++ b/pkg/dmsg/dmsg/ws.go
@@ -1,3 +1,5 @@
+//go:build !(tinygo && js && wasm)
+
 // Package dmsg pkg/dmsg/dmsg/ws.go: dmsg-over-WebSocket.
 //
 // A WebSocket connection is a bidirectional, ordered, reliable byte pipe over
@@ -21,82 +23,12 @@ package dmsg
 import (
 	"context"
 	"fmt"
-	"net"
-	"net/http"
-	"time"
 
 	"github.com/coder/websocket"
 	"github.com/hashicorp/yamux"
 
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 )
-
-// wsPath is the HTTP path the dmsg WebSocket endpoint is served on. The
-// advertised Server.AddressWS URL includes it (e.g. "wss://host/dmsg") so the
-// operator can front the endpoint with a reverse proxy / CDN that routes only
-// this path to the dmsg server.
-const wsPath = "/dmsg"
-
-// ServeWS serves dmsg over WebSocket on lis and advertises advertisedWSURL in
-// discovery (Server.AddressWS). It runs alongside the TCP Serve and the QUIC
-// ServeQUIC: WS-capable clients (chiefly the js/wasm build) dial the WS URL,
-// everyone else stays on TCP/QUIC. lis is a plaintext HTTP listener — TLS for
-// wss:// is expected to be terminated by a front proxy, with the dmsg Noise
-// layer providing the actual end-to-end PK authentication regardless. Blocks
-// until the listener errors or the server closes.
-func (s *Server) ServeWS(lis net.Listener, advertisedWSURL string) error {
-	s.advertisedWSAddr = advertisedWSURL
-
-	mux := http.NewServeMux()
-	mux.HandleFunc(wsPath, s.handleWS)
-	httpSrv := &http.Server{
-		Handler:           mux,
-		ReadHeaderTimeout: 10 * time.Second,
-	}
-	// Tear the HTTP server down when the dmsg server closes so ServeWS returns.
-	go func() {
-		<-s.done
-		_ = httpSrv.Close() //nolint:errcheck
-	}()
-
-	s.log.WithField("addr_ws", advertisedWSURL).Info("Serving dmsg over WebSocket.")
-	err := httpSrv.Serve(lis)
-	if isClosed(s.done) {
-		return nil
-	}
-	return err
-}
-
-// handleWS upgrades an inbound HTTP request to a WebSocket and serves it as a
-// normal dmsg server session. websocket.NetConn yields a net.Conn, so the
-// connection flows through the shared handleSession path (Noise handshake +
-// yamux) exactly like an accepted TCP conn. handleSession blocks until the
-// session closes, which keeps this handler — and thus the WS conn — alive for
-// the session's lifetime.
-func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
-	c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		// dmsg clients are not browsers making cross-origin fetches; the Noise
-		// handshake authenticates the peer, so origin is not a trust boundary
-		// here. Skipping the check lets a WASM client hosted on any origin
-		// connect.
-		InsecureSkipVerify: true,
-	})
-	if err != nil {
-		s.log.WithError(err).Debug("dmsg-ws: websocket upgrade failed")
-		return
-	}
-	// MessageBinary: dmsg frames are raw bytes, not UTF-8 text. context.Background
-	// bounds the conn to its own lifetime (not the HTTP request's), so a read/
-	// write does not get canceled when net/http thinks the handler is "done".
-	conn := websocket.NetConn(context.Background(), c, websocket.MessageBinary)
-	defer conn.Close() //nolint:errcheck,gosec
-
-	if s.SessionCount() >= s.maxSessions {
-		s.log.WithField("max_sessions", s.maxSessions).
-			Debug("dmsg-ws: max sessions reached, still accepting for delegated listeners.")
-	}
-	s.handleSession(conn)
-}
 
 // dialSessionWS dials a dmsg server's WebSocket endpoint (Server.AddressWS) and
 // builds a yamux+Noise client session over it — the WS analog of the TCP dial

--- a/pkg/dmsg/dmsg/ws_js_tinygo.go
+++ b/pkg/dmsg/dmsg/ws_js_tinygo.go
@@ -1,0 +1,263 @@
+//go:build tinygo && js && wasm
+
+// Package dmsg pkg/dmsg/dmsg/ws_js_tinygo.go: dmsg-over-WebSocket CLIENT dial for
+// the TinyGo browser target.
+//
+// coder/websocket (used by ws.go on every other target) pulls net/http through
+// its Dial signature (*http.Response), and net/http is broken on the TinyGo js
+// target. So here we dial the browser's native WebSocket directly via syscall/js
+// and adapt it to a net.Conn — which then flows through the SAME
+// makeClientSession + yamux path as coder/websocket's NetConn does elsewhere.
+// No new session semantics, no new crypto; just a different way to obtain the
+// byte pipe.
+package dmsg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"syscall/js"
+	"time"
+
+	"github.com/hashicorp/yamux"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+// dialSessionWS dials the dmsg server's WebSocket endpoint (Server.AddressWS)
+// using the browser WebSocket API and builds a yamux+Noise client session over
+// it — the TinyGo-browser analog of ws.go's coder/websocket dial path.
+func (ce *Client) dialSessionWS(ctx context.Context, entry *disc.Entry) (ClientSession, error) {
+	conn, err := dialWebSocketJS(ctx, entry.Server.AddressWS)
+	if err != nil {
+		return ClientSession{}, fmt.Errorf("ws(js): dial %q: %w", entry.Server.AddressWS, err)
+	}
+
+	dSes, err := makeClientSession(&ce.EntityCommon, ce.porter, conn, entry.Static)
+	if err != nil {
+		conn.Close() //nolint:errcheck,gosec
+		return ClientSession{}, err
+	}
+	dSes.sm.yamux, err = yamux.Client(conn, YamuxConfig())
+	if err != nil {
+		conn.Close() //nolint:errcheck,gosec
+		return ClientSession{}, err
+	}
+	ce.log.Infof("ws stream session initial for %s", dSes.RemotePK().String())
+	return dSes, nil
+}
+
+// wsAddr is the net.Addr for a browser WebSocket connection.
+type wsAddr string
+
+func (wsAddr) Network() string  { return "ws" }
+func (a wsAddr) String() string { return string(a) }
+
+// wsTimeoutError is the net.Error returned when a read deadline elapses.
+type wsTimeoutError struct{}
+
+func (wsTimeoutError) Error() string   { return "ws: i/o timeout" }
+func (wsTimeoutError) Timeout() bool   { return true }
+func (wsTimeoutError) Temporary() bool { return true }
+
+// wsConnJS adapts a browser WebSocket (binaryType=arraybuffer) to a net.Conn.
+// Inbound frames are buffered by the message event handler; Read drains the
+// buffer and blocks (respecting the read deadline) when it is empty. Write maps
+// straight onto WebSocket.send. The connection is dialed already-open, so a send
+// never races the CONNECTING state.
+type wsConnJS struct {
+	ws   js.Value
+	addr wsAddr
+
+	mu        sync.Mutex
+	buf       []byte        // unread inbound bytes
+	notify    chan struct{} // closed (and replaced) to wake blocked readers
+	closed    bool
+	closeErr  error
+	rDeadline time.Time
+
+	// handlers are retained for the conn's lifetime; releasing them while the
+	// browser may still deliver a trailing close/error event would panic, so we
+	// intentionally do not Release (bounded leak: a handful per session).
+	handlers []js.Func
+}
+
+// dialWebSocketJS opens a browser WebSocket to url and returns once it is OPEN
+// (or ctx is done / the socket errors first).
+func dialWebSocketJS(ctx context.Context, url string) (*wsConnJS, error) {
+	ctor := js.Global().Get("WebSocket")
+	if !ctor.Truthy() {
+		return nil, errors.New("no WebSocket constructor in this JS environment")
+	}
+	ws := ctor.New(url)
+	ws.Set("binaryType", "arraybuffer")
+
+	c := &wsConnJS{ws: ws, addr: wsAddr(url), notify: make(chan struct{})}
+
+	openCh := make(chan struct{})
+	var openOnce sync.Once
+	var openErr error
+	finishOpen := func(err error) {
+		openOnce.Do(func() { openErr = err; close(openCh) })
+	}
+
+	onOpen := js.FuncOf(func(js.Value, []js.Value) interface{} {
+		finishOpen(nil)
+		return nil
+	})
+	onMsg := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
+		// data is an ArrayBuffer (binaryType=arraybuffer); wrap as Uint8Array.
+		u8 := js.Global().Get("Uint8Array").New(args[0].Get("data"))
+		b := make([]byte, u8.Length())
+		js.CopyBytesToGo(b, u8)
+		c.mu.Lock()
+		c.buf = append(c.buf, b...)
+		c.wake()
+		c.mu.Unlock()
+		return nil
+	})
+	onClose := js.FuncOf(func(js.Value, []js.Value) interface{} {
+		c.fail(io.EOF)
+		finishOpen(errors.New("ws closed before open"))
+		return nil
+	})
+	onErr := js.FuncOf(func(js.Value, []js.Value) interface{} {
+		c.fail(errors.New("ws: connection error"))
+		finishOpen(errors.New("ws error before open"))
+		return nil
+	})
+	c.handlers = []js.Func{onOpen, onMsg, onClose, onErr}
+	ws.Call("addEventListener", "open", onOpen)
+	ws.Call("addEventListener", "message", onMsg)
+	ws.Call("addEventListener", "close", onClose)
+	ws.Call("addEventListener", "error", onErr)
+
+	select {
+	case <-openCh:
+		if openErr != nil {
+			c.Close() //nolint:errcheck
+			return nil, openErr
+		}
+		return c, nil
+	case <-ctx.Done():
+		c.Close() //nolint:errcheck
+		return nil, ctx.Err()
+	}
+}
+
+// wake broadcasts to blocked readers. Caller must hold c.mu.
+func (c *wsConnJS) wake() {
+	close(c.notify)
+	c.notify = make(chan struct{})
+}
+
+// fail marks the conn closed with err and wakes readers.
+func (c *wsConnJS) fail(err error) {
+	c.mu.Lock()
+	if !c.closed {
+		c.closed = true
+		c.closeErr = err
+		c.wake()
+	}
+	c.mu.Unlock()
+}
+
+// Read drains buffered inbound bytes, blocking until data arrives, the read
+// deadline elapses, or the conn closes.
+func (c *wsConnJS) Read(p []byte) (int, error) {
+	for {
+		c.mu.Lock()
+		if len(c.buf) > 0 {
+			n := copy(p, c.buf)
+			c.buf = c.buf[n:]
+			c.mu.Unlock()
+			return n, nil
+		}
+		if c.closed {
+			err := c.closeErr
+			c.mu.Unlock()
+			if err == nil {
+				err = io.EOF
+			}
+			return 0, err
+		}
+		notify := c.notify
+		deadline := c.rDeadline
+		c.mu.Unlock()
+
+		var timeout <-chan time.Time
+		if !deadline.IsZero() {
+			d := time.Until(deadline)
+			if d <= 0 {
+				return 0, wsTimeoutError{}
+			}
+			t := time.NewTimer(d)
+			defer t.Stop()
+			timeout = t.C
+		}
+		select {
+		case <-notify:
+		case <-timeout:
+			return 0, wsTimeoutError{}
+		}
+	}
+}
+
+// Write sends p as a single binary WebSocket frame.
+func (c *wsConnJS) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	if c.closed {
+		err := c.closeErr
+		c.mu.Unlock()
+		if err == nil {
+			err = net.ErrClosed
+		}
+		return 0, err
+	}
+	c.mu.Unlock()
+
+	u8 := js.Global().Get("Uint8Array").New(len(p))
+	js.CopyBytesToJS(u8, p)
+	c.ws.Call("send", u8)
+	return len(p), nil
+}
+
+// Close closes the WebSocket and unblocks any pending Read.
+func (c *wsConnJS) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	if c.closeErr == nil {
+		c.closeErr = net.ErrClosed
+	}
+	c.wake()
+	c.mu.Unlock()
+	c.ws.Call("close")
+	return nil
+}
+
+func (c *wsConnJS) LocalAddr() net.Addr  { return c.addr }
+func (c *wsConnJS) RemoteAddr() net.Addr { return c.addr }
+
+// SetReadDeadline sets the deadline honored by Read; a blocked Read re-evaluates
+// it immediately.
+func (c *wsConnJS) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.rDeadline = t
+	c.wake()
+	c.mu.Unlock()
+	return nil
+}
+
+// SetWriteDeadline is a no-op: WebSocket.send does not block, so there is no
+// write to time out.
+func (c *wsConnJS) SetWriteDeadline(time.Time) error { return nil }
+
+// SetDeadline sets the read deadline (write has none).
+func (c *wsConnJS) SetDeadline(t time.Time) error { return c.SetReadDeadline(t) }

--- a/pkg/dmsg/dmsg/ws_server.go
+++ b/pkg/dmsg/dmsg/ws_server.go
@@ -1,0 +1,85 @@
+//go:build !tinygo
+
+// Package dmsg pkg/dmsg/dmsg/ws_server.go: dmsg-over-WebSocket SERVER side.
+//
+// Split out of ws.go behind //go:build !tinygo: ServeWS runs an http.Server
+// (net/http), which is broken on the TinyGo js target. The CLIENT dial path
+// (dialSessionWS) stays in ws.go untagged — it uses only coder/websocket, which
+// compiles to js/wasm, so the WASM dmsg client can still dial WS servers.
+package dmsg
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// wsPath is the HTTP path the dmsg WebSocket endpoint is served on. The
+// advertised Server.AddressWS URL includes it (e.g. "wss://host/dmsg") so the
+// operator can front the endpoint with a reverse proxy / CDN that routes only
+// this path to the dmsg server.
+const wsPath = "/dmsg"
+
+// ServeWS serves dmsg over WebSocket on lis and advertises advertisedWSURL in
+// discovery (Server.AddressWS). It runs alongside the TCP Serve and the QUIC
+// ServeQUIC: WS-capable clients (chiefly the js/wasm build) dial the WS URL,
+// everyone else stays on TCP/QUIC. lis is a plaintext HTTP listener — TLS for
+// wss:// is expected to be terminated by a front proxy, with the dmsg Noise
+// layer providing the actual end-to-end PK authentication regardless. Blocks
+// until the listener errors or the server closes.
+func (s *Server) ServeWS(lis net.Listener, advertisedWSURL string) error {
+	s.advertisedWSAddr = advertisedWSURL
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(wsPath, s.handleWS)
+	httpSrv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	// Tear the HTTP server down when the dmsg server closes so ServeWS returns.
+	go func() {
+		<-s.done
+		_ = httpSrv.Close() //nolint:errcheck
+	}()
+
+	s.log.WithField("addr_ws", advertisedWSURL).Info("Serving dmsg over WebSocket.")
+	err := httpSrv.Serve(lis)
+	if isClosed(s.done) {
+		return nil
+	}
+	return err
+}
+
+// handleWS upgrades an inbound HTTP request to a WebSocket and serves it as a
+// normal dmsg server session. websocket.NetConn yields a net.Conn, so the
+// connection flows through the shared handleSession path (Noise handshake +
+// yamux) exactly like an accepted TCP conn. handleSession blocks until the
+// session closes, which keeps this handler — and thus the WS conn — alive for
+// the session's lifetime.
+func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
+	c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		// dmsg clients are not browsers making cross-origin fetches; the Noise
+		// handshake authenticates the peer, so origin is not a trust boundary
+		// here. Skipping the check lets a WASM client hosted on any origin
+		// connect.
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		s.log.WithError(err).Debug("dmsg-ws: websocket upgrade failed")
+		return
+	}
+	// MessageBinary: dmsg frames are raw bytes, not UTF-8 text. context.Background
+	// bounds the conn to its own lifetime (not the HTTP request's), so a read/
+	// write does not get canceled when net/http thinks the handler is "done".
+	conn := websocket.NetConn(context.Background(), c, websocket.MessageBinary)
+	defer conn.Close() //nolint:errcheck,gosec
+
+	if s.SessionCount() >= s.maxSessions {
+		s.log.WithField("max_sessions", s.maxSessions).
+			Debug("dmsg-ws: max sessions reached, still accepting for delegated listeners.")
+	}
+	s.handleSession(conn)
+}

--- a/pkg/dmsg/dmsg/wt_js_tinygo.go
+++ b/pkg/dmsg/dmsg/wt_js_tinygo.go
@@ -1,0 +1,301 @@
+//go:build tinygo && js && wasm
+
+// Package dmsg pkg/dmsg/dmsg/wt_js_tinygo.go: dmsg-over-WebTransport CLIENT dial
+// for the TinyGo browser target.
+//
+// wt.go (the native WebTransport carrier) pulls quic-go + webtransport-go, which
+// don't compile under TinyGo. Here we dial the browser's native WebTransport API
+// directly via syscall/js and adapt one bidirectional stream to a net.Conn —
+// flowing through the SAME makeClientSession + yamux path as the WS/TCP carriers.
+//
+// WebTransport is the one browser-reachable carrier that needs NO CA: the
+// WebTransport constructor accepts a self-signed server cert pinned by SHA-256
+// via serverCertificateHashes. We pin Server.CertHashWT exactly as the native
+// path pins it in VerifyPeerCertificate — so a browser reaches a dmsg server by
+// bare IP, no domain, no Let's Encrypt. The client→server skywire PK is still
+// authenticated in the dmsg Noise handshake, identical to TCP/WS.
+package dmsg
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"syscall/js"
+	"time"
+
+	"github.com/hashicorp/yamux"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+// dialSessionWT dials the dmsg server's WebTransport endpoint (Server.AddressWT)
+// via the browser WebTransport API and builds a yamux+Noise client session over
+// one bidirectional stream — the TinyGo-browser analog of wt.go's dialSessionWT.
+func (ce *Client) dialSessionWT(ctx context.Context, entry *disc.Entry) (ClientSession, error) {
+	conn, err := dialWebTransportJS(ctx, entry.Server.AddressWT, entry.Server.CertHashWT)
+	if err != nil {
+		return ClientSession{}, fmt.Errorf("wt(js): dial %q: %w", entry.Server.AddressWT, err)
+	}
+
+	dSes, err := makeClientSession(&ce.EntityCommon, ce.porter, conn, entry.Static)
+	if err != nil {
+		conn.Close() //nolint:errcheck,gosec
+		return ClientSession{}, err
+	}
+	dSes.sm.yamux, err = yamux.Client(conn, YamuxConfig())
+	if err != nil {
+		conn.Close() //nolint:errcheck,gosec
+		return ClientSession{}, err
+	}
+	ce.log.Infof("wt stream session initial for %s", dSes.RemotePK().String())
+	return dSes, nil
+}
+
+// awaitJS blocks until the JS promise p settles, returning its resolved value or
+// an error built from the rejection reason. It parks the goroutine (off the JS
+// event loop) until a then/catch callback fires.
+func awaitJS(p js.Value) (js.Value, error) {
+	ch := make(chan struct{})
+	var res js.Value
+	var rejErr error
+	onOK := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
+		if len(args) > 0 {
+			res = args[0]
+		}
+		close(ch)
+		return nil
+	})
+	onErr := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
+		msg := "promise rejected"
+		if len(args) > 0 {
+			if m := args[0].Get("message"); m.Type() == js.TypeString {
+				msg = m.String()
+			} else {
+				msg = args[0].Call("toString").String()
+			}
+		}
+		rejErr = errors.New(msg)
+		close(ch)
+		return nil
+	})
+	p.Call("then", onOK).Call("catch", onErr)
+	<-ch
+	onOK.Release()
+	onErr.Release()
+	return res, rejErr
+}
+
+// dialWebTransportJS opens a browser WebTransport to url (pinning certHashHex),
+// awaits ready, opens one bidirectional stream, and returns it as a net.Conn.
+func dialWebTransportJS(ctx context.Context, url, certHashHex string) (*wtConnJS, error) {
+	ctor := js.Global().Get("WebTransport")
+	if !ctor.Truthy() {
+		return nil, errors.New("no WebTransport constructor in this JS environment")
+	}
+	wantHash, err := hex.DecodeString(certHashHex)
+	if err != nil || len(wantHash) != 32 {
+		return nil, fmt.Errorf("invalid cert hash %q", certHashHex)
+	}
+
+	// serverCertificateHashes: [{ algorithm: "sha-256", value: Uint8Array }]
+	hashU8 := js.Global().Get("Uint8Array").New(len(wantHash))
+	js.CopyBytesToJS(hashU8, wantHash)
+	hashEntry := js.Global().Get("Object").New()
+	hashEntry.Set("algorithm", "sha-256")
+	hashEntry.Set("value", hashU8)
+	hashes := js.Global().Get("Array").New()
+	hashes.Call("push", hashEntry)
+	opts := js.Global().Get("Object").New()
+	opts.Set("serverCertificateHashes", hashes)
+
+	wt := ctor.New(url, opts)
+
+	// Honour ctx during the ready/open handshakes by racing a watcher that
+	// closes the transport on cancellation (which rejects the pending promises).
+	watchDone := make(chan struct{})
+	defer close(watchDone)
+	if ctx.Done() != nil {
+		go func() {
+			select {
+			case <-ctx.Done():
+				wt.Call("close")
+			case <-watchDone:
+			}
+		}()
+	}
+
+	if _, err := awaitJS(wt.Get("ready")); err != nil {
+		return nil, fmt.Errorf("ready: %w", err)
+	}
+	streamV, err := awaitJS(wt.Call("createBidirectionalStream"))
+	if err != nil {
+		return nil, fmt.Errorf("open stream: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		wt.Call("close")
+		return nil, err
+	}
+
+	c := &wtConnJS{
+		wt:     wt,
+		reader: streamV.Get("readable").Call("getReader"),
+		writer: streamV.Get("writable").Call("getWriter"),
+		addr:   wsAddr(url),
+		notify: make(chan struct{}),
+	}
+	go c.readPump()
+	return c, nil
+}
+
+// wtConnJS adapts a WebTransport bidirectional stream (WHATWG readable/writable)
+// to a net.Conn. A pump goroutine drains the ReadableStream into a buffer; Read
+// serves from the buffer (deadline-aware); Write awaits writer.write so yamux
+// sees real backpressure. It reuses wsAddr / wsTimeoutError from ws_js_tinygo.go.
+type wtConnJS struct {
+	wt     js.Value
+	reader js.Value
+	writer js.Value
+	addr   wsAddr
+
+	mu        sync.Mutex
+	buf       []byte
+	notify    chan struct{}
+	closed    bool
+	closeErr  error
+	rDeadline time.Time
+}
+
+// readPump loops reader.read() and appends inbound bytes until done/error/close.
+func (c *wtConnJS) readPump() {
+	for {
+		v, err := awaitJS(c.reader.Call("read"))
+		if err != nil {
+			c.fail(err)
+			return
+		}
+		if v.Get("done").Bool() {
+			c.fail(io.EOF)
+			return
+		}
+		val := v.Get("value") // Uint8Array
+		b := make([]byte, val.Get("length").Int())
+		js.CopyBytesToGo(b, val)
+		c.mu.Lock()
+		if c.closed {
+			c.mu.Unlock()
+			return
+		}
+		c.buf = append(c.buf, b...)
+		c.wake()
+		c.mu.Unlock()
+	}
+}
+
+// wake broadcasts to blocked readers. Caller must hold c.mu.
+func (c *wtConnJS) wake() {
+	close(c.notify)
+	c.notify = make(chan struct{})
+}
+
+func (c *wtConnJS) fail(err error) {
+	c.mu.Lock()
+	if !c.closed {
+		c.closed = true
+		c.closeErr = err
+		c.wake()
+	}
+	c.mu.Unlock()
+}
+
+func (c *wtConnJS) Read(p []byte) (int, error) {
+	for {
+		c.mu.Lock()
+		if len(c.buf) > 0 {
+			n := copy(p, c.buf)
+			c.buf = c.buf[n:]
+			c.mu.Unlock()
+			return n, nil
+		}
+		if c.closed {
+			err := c.closeErr
+			c.mu.Unlock()
+			if err == nil {
+				err = io.EOF
+			}
+			return 0, err
+		}
+		notify := c.notify
+		deadline := c.rDeadline
+		c.mu.Unlock()
+
+		var timeout <-chan time.Time
+		if !deadline.IsZero() {
+			d := time.Until(deadline)
+			if d <= 0 {
+				return 0, wsTimeoutError{}
+			}
+			t := time.NewTimer(d)
+			defer t.Stop()
+			timeout = t.C
+		}
+		select {
+		case <-notify:
+		case <-timeout:
+			return 0, wsTimeoutError{}
+		}
+	}
+}
+
+func (c *wtConnJS) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	if c.closed {
+		err := c.closeErr
+		c.mu.Unlock()
+		if err == nil {
+			err = net.ErrClosed
+		}
+		return 0, err
+	}
+	c.mu.Unlock()
+
+	u8 := js.Global().Get("Uint8Array").New(len(p))
+	js.CopyBytesToJS(u8, p)
+	if _, err := awaitJS(c.writer.Call("write", u8)); err != nil {
+		c.fail(err)
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *wtConnJS) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	if c.closeErr == nil {
+		c.closeErr = net.ErrClosed
+	}
+	c.wake()
+	c.mu.Unlock()
+	c.wt.Call("close")
+	return nil
+}
+
+func (c *wtConnJS) LocalAddr() net.Addr  { return c.addr }
+func (c *wtConnJS) RemoteAddr() net.Addr { return c.addr }
+
+func (c *wtConnJS) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.rDeadline = t
+	c.wake()
+	c.mu.Unlock()
+	return nil
+}
+func (c *wtConnJS) SetWriteDeadline(time.Time) error { return nil }
+func (c *wtConnJS) SetDeadline(t time.Time) error    { return c.SetReadDeadline(t) }

--- a/pkg/dmsg/dmsg/wt_stub_tinygo.go
+++ b/pkg/dmsg/dmsg/wt_stub_tinygo.go
@@ -1,0 +1,20 @@
+//go:build tinygo && !(js && wasm)
+
+// Package dmsg pkg/dmsg/dmsg/wt_stub_tinygo.go
+//
+// dmsg-over-WebTransport stub for the NON-browser TinyGo (IoT) target. quic-go +
+// webtransport-go don't compile under TinyGo, and an IoT client has no browser
+// WebTransport API either, so dialSessionWT errors here and dialSession falls
+// back to TCP/WS. The browser TinyGo build (js/wasm) instead gets a real
+// dialSessionWT in wt_js_tinygo.go.
+package dmsg
+
+import (
+	"context"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+func (ce *Client) dialSessionWT(_ context.Context, _ *disc.Entry) (ClientSession, error) {
+	return ClientSession{}, errNativeTransportUnsupported
+}

--- a/pkg/dmsg/dmsgclient/cli.go
+++ b/pkg/dmsg/dmsgclient/cli.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 // Package dmsgclient pkg/dmsgclient/cli.go
 package dmsgclient
 

--- a/pkg/dmsg/dmsgclient/cli_fallback.go
+++ b/pkg/dmsg/dmsgclient/cli_fallback.go
@@ -1,4 +1,11 @@
+//go:build !tinygo
+
 // Package dmsgclient pkg/dmsgclient/cli_fallback.go
+//
+// net/http-using dmsg bootstrap helpers — excluded from TinyGo builds (net/http
+// is broken on the js target). The net/http-free fallbackDiscClient that these
+// helpers (and the TinyGo discovery-upgrade path) compose lives in
+// fallback_disc.go.
 package dmsgclient
 
 import (
@@ -304,132 +311,6 @@ func (c *cachingDiscClient) AllClientsByServer(ctx context.Context) (map[string]
 // ClientsByServer delegates to base client
 func (c *cachingDiscClient) ClientsByServer(ctx context.Context, serverPK cipher.PubKey) ([]*disc.Entry, error) {
 	return c.base.ClientsByServer(ctx, serverPK)
-}
-
-// fallbackDiscClient tries direct client first, falls back to HTTP discovery for unknown entries
-type fallbackDiscClient struct {
-	direct disc.APIClient
-	http   disc.APIClient
-	log    *logging.Logger
-	// register routes the WRITE methods (Put/Post/DelEntry). When false
-	// (the service variant), writes go to the direct client, which no-ops —
-	// services run as direct clients and don't publish to dmsg-discovery.
-	// When true (the visor variant), writes go to the HTTP client so the
-	// caller's entry IS published to the real dmsg-discovery, while READS
-	// still resolve direct-first. This lets one client both register itself
-	// AND resolve seeded service/server PKs statically (no HTTP-over-dmsg
-	// round-trip — the round-trip to the entry-less, root-of-trust dmsg-disc
-	// is what hot-loops when the whole disc is dmsgfirst).
-	register bool
-}
-
-// NewFallbackDiscClient creates a discovery client that tries direct first, then HTTP.
-// Used by callers that need to dial arbitrary client PKs registered in the real
-// dmsg-discovery while keeping a pre-loaded direct.Client for the bootstrap server
-// list (and any synthetic/seeded entries the caller wants to short-circuit).
-// WRITES no-op (direct) — the non-registering "service" variant.
-func NewFallbackDiscClient(direct, http disc.APIClient, log *logging.Logger) disc.APIClient {
-	return &fallbackDiscClient{
-		direct: direct,
-		http:   http,
-		log:    log,
-	}
-}
-
-// NewRegisteringFallbackDiscClient is the visor variant: READS resolve
-// direct-first (seeded service/server PKs short-circuit, no HTTP-over-dmsg
-// round-trip), but WRITES (Put/Post/DelEntry) go to the HTTP client so the
-// visor's own entry IS published to the real dmsg-discovery. This lets a
-// SINGLE dmsg client both register itself and resolve bootstrap PKs
-// statically — replacing the two-client (dmsgC discovery + dmsgDC direct)
-// setup whose shared PK self-evicts on the dmsg servers.
-func NewRegisteringFallbackDiscClient(direct, http disc.APIClient, log *logging.Logger) disc.APIClient {
-	return &fallbackDiscClient{
-		direct:   direct,
-		http:     http,
-		log:      log,
-		register: true,
-	}
-}
-
-// Entry tries direct client first, falls back to HTTP for unknown entries
-func (f *fallbackDiscClient) Entry(ctx context.Context, pk cipher.PubKey) (*disc.Entry, error) {
-	// Try direct client first
-	entry, err := f.direct.Entry(ctx, pk)
-	if err == nil && entry.Static == pk {
-		return entry, nil
-	}
-
-	// Fall back to HTTP discovery for unknown entries
-	f.log.WithField("pk", pk.String()).Debug("Entry not in direct client, querying HTTP discovery")
-	return f.http.Entry(ctx, pk)
-}
-
-// PostEntry ALWAYS no-ops via the direct client — even in the registering
-// variant. The dmsg serve loop calls PostEntry PRE-session
-// (initilizeClientEntry, "Initial post entry") BEFORE any session exists;
-// routing that to HTTP-over-dmsg would dial dmsg-disc over the client's own
-// not-yet-established sessions, blocking the serve loop on a chicken-egg and
-// starving the rest of the server-dialing loop — the visor gets stuck on a
-// single server / wedges. Durable registration is done by the POST-session
-// updateClientEntry loop via PutEntry (runs only after sessions exist); the
-// dmsg-disc setEntry handler upserts, so PutEntry creates the entry. Mirrors
-// StartDmsgSelfHostedDisc, whose single client works precisely because its
-// PostEntry no-ops and returns instantly so sessions can establish.
-func (f *fallbackDiscClient) PostEntry(ctx context.Context, entry *disc.Entry) error {
-	return f.direct.PostEntry(ctx, entry)
-}
-
-// PutEntry delegates to the direct client (which no-ops). Services
-// using this fallback wrapper run as direct dmsg clients and are not
-// supposed to register themselves in dmsg-discovery — they are
-// reachable equally through any dmsg server via the consumer's
-// preloaded direct.Client. Routing PutEntry to HTTP caused TD/SD/
-// dmsg-disc to publish themselves on every dmsg.Client UpdateInterval
-// (5 min default for clients), producing entries with seq numbers
-// growing into the hundreds and pointless write traffic against
-// dmsg-discovery; consumers gain nothing from those entries because
-// the visor's direct.Client already knows the service PK → all-servers
-// mapping at startup.
-func (f *fallbackDiscClient) PutEntry(ctx context.Context, sk cipher.SecKey, entry *disc.Entry) error {
-	if f.register {
-		return f.http.PutEntry(ctx, sk, entry)
-	}
-	return f.direct.PutEntry(ctx, sk, entry)
-}
-
-// DelEntry: registering variant removes from HTTP discovery; service
-// variant no-ops via the direct client.
-func (f *fallbackDiscClient) DelEntry(ctx context.Context, entry *disc.Entry) error {
-	if f.register {
-		return f.http.DelEntry(ctx, entry)
-	}
-	return f.direct.DelEntry(ctx, entry)
-}
-
-// AvailableServers delegates to direct client
-func (f *fallbackDiscClient) AvailableServers(ctx context.Context) ([]*disc.Entry, error) {
-	return f.direct.AvailableServers(ctx)
-}
-
-// AllServers delegates to direct client
-func (f *fallbackDiscClient) AllServers(ctx context.Context) ([]*disc.Entry, error) {
-	return f.direct.AllServers(ctx)
-}
-
-// AllEntries delegates to direct client
-func (f *fallbackDiscClient) AllEntries(ctx context.Context) ([]string, error) {
-	return f.direct.AllEntries(ctx)
-}
-
-// AllClientsByServer delegates to HTTP client
-func (f *fallbackDiscClient) AllClientsByServer(ctx context.Context) (map[string][]*disc.Entry, error) {
-	return f.http.AllClientsByServer(ctx)
-}
-
-// ClientsByServer delegates to HTTP client
-func (f *fallbackDiscClient) ClientsByServer(ctx context.Context, serverPK cipher.PubKey) ([]*disc.Entry, error) {
-	return f.http.ClientsByServer(ctx, serverPK)
 }
 
 // FallbackRoundTripper tries multiple DMSG transports until one succeeds.

--- a/pkg/dmsg/dmsgclient/discdmsg.go
+++ b/pkg/dmsg/dmsgclient/discdmsg.go
@@ -91,6 +91,9 @@ func errFromBody(body []byte) error {
 	if m.Message == disc.ErrValidationWrongSequence.Error() {
 		return disc.ErrValidationWrongSequence
 	}
+	if m.Message == disc.ErrKeyNotFound.Error() {
+		return disc.ErrKeyNotFound // so isEntryNotFound / errors.Is recognize it
+	}
 	return errors.New(m.Message)
 }
 
@@ -123,8 +126,10 @@ func (c *dmsgDiscClient) PostEntry(ctx context.Context, entry *disc.Entry) error
 	}
 	res, err := c.do(ctx, "POST", "/dmsg-discovery/entry/", body)
 	if err != nil {
+		jslog("PostEntry: do err: " + err.Error())
 		return err
 	}
+	jslog(fmt.Sprintf("PostEntry: status=%d body=%s", res.status, strings.TrimSpace(string(res.body))))
 	if res.status != 200 {
 		return errFromBody(res.body)
 	}

--- a/pkg/dmsg/dmsgclient/discdmsg.go
+++ b/pkg/dmsg/dmsgclient/discdmsg.go
@@ -1,0 +1,211 @@
+// Package dmsgclient pkg/dmsg/dmsgclient/discdmsg.go
+package dmsgclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// dmsgDiscClient implements disc.APIClient by speaking the dmsg-discovery REST
+// API directly over dmsg streams (HTTP/1.1 on dmsg port 80) with NO net/http —
+// so it compiles under TinyGo, where net/http is broken on the js target. It is
+// the net/http-free equivalent of
+//
+//	disc.NewHTTP(addr, &http.Client{Transport: dmsghttp.MakeHTTPTransport(...)}, log)
+//
+// Each call dials a fresh dmsg stream to the discovery PK, runs one HTTP/1.1
+// round-trip, and closes it (Connection: close — no keep-alive pool, matching
+// the simplicity the wasm hypervisor needs).
+type dmsgDiscClient struct {
+	dmsgC  *dmsg.Client
+	discPK cipher.PubKey
+	log    *logging.Logger
+	mu     sync.Mutex // serializes the PutEntry sequence bump (mirrors httpClient.updateMux)
+}
+
+// NewDmsgDiscClient constructs a net/http-free disc.APIClient that reaches the
+// discovery over the given dmsg client's own sessions. discDmsgAddr is a
+// "dmsg://<disc-pk>:<port>" address (the same value disc.NewHTTP would receive);
+// only the PK is used — the round-trip always targets dmsg port 80.
+func NewDmsgDiscClient(dmsgC *dmsg.Client, discDmsgAddr string, log *logging.Logger) (disc.APIClient, error) {
+	pkHex := dmsg.ExtractPKFromDmsgAddr(discDmsgAddr)
+	if pkHex == "" {
+		return nil, fmt.Errorf("dmsgclient: cannot extract discovery PK from %q", discDmsgAddr)
+	}
+	var discPK cipher.PubKey
+	if err := discPK.UnmarshalText([]byte(pkHex)); err != nil {
+		return nil, fmt.Errorf("dmsgclient: bad discovery PK %q: %w", pkHex, err)
+	}
+	return &dmsgDiscClient{dmsgC: dmsgC, discPK: discPK, log: log}, nil
+}
+
+// do dials a fresh stream to the discovery and runs one HTTP/1.1 round-trip,
+// bounded by ctx (the stream is closed on cancellation so a blocked read/write
+// unblocks).
+func (c *dmsgDiscClient) do(ctx context.Context, method, path string, reqBody []byte) (httpResult, error) {
+	stream, err := c.dmsgC.DialStream(ctx, dmsg.Addr{PK: c.discPK, Port: dmsg.DefaultDmsgHTTPPort})
+	if err != nil {
+		return httpResult{}, err
+	}
+	defer stream.Close() //nolint:errcheck
+
+	done := make(chan struct{})
+	defer close(done)
+	if ctx.Done() != nil {
+		go func() {
+			select {
+			case <-ctx.Done():
+				stream.Close() //nolint:errcheck,gosec
+			case <-done:
+			}
+		}()
+	}
+
+	return httpRoundTrip(stream, method, c.discPK.Hex(), path, nil, reqBody)
+}
+
+// discMessage mirrors disc.HTTPMessage's `message` field (disc.HTTPMessage
+// itself is net/http-tagged, so it isn't visible under TinyGo).
+type discMessage struct {
+	Message string `json:"message"`
+}
+
+// errFromBody maps an error response body back to a sentinel error. Only
+// ErrValidationWrongSequence needs to round-trip as a typed value (PutEntry
+// branches on it); everything else becomes a plain error carrying the message.
+func errFromBody(body []byte) error {
+	var m discMessage
+	if err := json.Unmarshal(body, &m); err != nil || m.Message == "" {
+		return fmt.Errorf("dmsg-discovery error: %s", strings.TrimSpace(string(body)))
+	}
+	if m.Message == disc.ErrValidationWrongSequence.Error() {
+		return disc.ErrValidationWrongSequence
+	}
+	return errors.New(m.Message)
+}
+
+// getJSON runs a GET and decodes a 200 body into out.
+func (c *dmsgDiscClient) getJSON(ctx context.Context, path string, out interface{}) error {
+	res, err := c.do(ctx, "GET", path, nil)
+	if err != nil {
+		return err
+	}
+	if res.status != 200 {
+		return errFromBody(res.body)
+	}
+	return json.Unmarshal(res.body, out)
+}
+
+// Entry retrieves an entry associated with the given public key.
+func (c *dmsgDiscClient) Entry(ctx context.Context, publicKey cipher.PubKey) (*disc.Entry, error) {
+	var entry disc.Entry
+	if err := c.getJSON(ctx, "/dmsg-discovery/entry/"+publicKey.String(), &entry); err != nil {
+		return nil, err
+	}
+	return &entry, nil
+}
+
+// PostEntry creates or updates an Entry.
+func (c *dmsgDiscClient) PostEntry(ctx context.Context, entry *disc.Entry) error {
+	body, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	res, err := c.do(ctx, "POST", "/dmsg-discovery/entry/", body)
+	if err != nil {
+		return err
+	}
+	if res.status != 200 {
+		return errFromBody(res.body)
+	}
+	return nil
+}
+
+// DelEntry deletes an Entry.
+func (c *dmsgDiscClient) DelEntry(ctx context.Context, entry *disc.Entry) error {
+	body, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	res, err := c.do(ctx, "DELETE", "/dmsg-discovery/entry", body)
+	if err != nil {
+		return err
+	}
+	if res.status != 200 {
+		return errFromBody(res.body)
+	}
+	return nil
+}
+
+// PutEntry updates Entry in dmsg discovery, signing it and retrying once on a
+// wrong-sequence rejection (mirrors httpClient.PutEntry exactly).
+func (c *dmsgDiscClient) PutEntry(ctx context.Context, sk cipher.SecKey, entry *disc.Entry) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	sequence := entry.Sequence + 1
+	entry.Timestamp = time.Now().UnixNano()
+
+	for {
+		entry.Sequence = sequence
+		if err := entry.Sign(sk); err != nil {
+			return err
+		}
+		err := c.PostEntry(ctx, entry)
+		if err == nil {
+			return nil
+		}
+		if err != disc.ErrValidationWrongSequence {
+			return err
+		}
+		rE, entryErr := c.Entry(ctx, entry.Static)
+		if entryErr != nil {
+			return entryErr
+		}
+		if rE.Timestamp > entry.Timestamp { // a more up-to-date entry exists; drop our update
+			entry.Sequence = rE.Sequence
+			return nil
+		}
+		sequence = rE.Sequence + 1
+	}
+}
+
+// AvailableServers returns the list of available servers.
+func (c *dmsgDiscClient) AvailableServers(ctx context.Context) ([]*disc.Entry, error) {
+	var entries []*disc.Entry
+	return entries, c.getJSON(ctx, "/dmsg-discovery/available_servers", &entries)
+}
+
+// AllServers returns the list of all servers.
+func (c *dmsgDiscClient) AllServers(ctx context.Context) ([]*disc.Entry, error) {
+	var entries []*disc.Entry
+	return entries, c.getJSON(ctx, "/dmsg-discovery/all_servers", &entries)
+}
+
+// AllEntries returns the list of all entry public keys.
+func (c *dmsgDiscClient) AllEntries(ctx context.Context) ([]string, error) {
+	var entries []string
+	return entries, c.getJSON(ctx, "/dmsg-discovery/entries", &entries)
+}
+
+// AllClientsByServer returns all client entries grouped by server public key.
+func (c *dmsgDiscClient) AllClientsByServer(ctx context.Context) (map[string][]*disc.Entry, error) {
+	var result map[string][]*disc.Entry
+	return result, c.getJSON(ctx, "/dmsg-discovery/servers/clients", &result)
+}
+
+// ClientsByServer returns all client entries delegated to a specific server.
+func (c *dmsgDiscClient) ClientsByServer(ctx context.Context, serverPK cipher.PubKey) ([]*disc.Entry, error) {
+	var entries []*disc.Entry
+	return entries, c.getJSON(ctx, "/dmsg-discovery/server/"+serverPK.Hex()+"/clients", &entries)
+}

--- a/pkg/dmsg/dmsgclient/fallback_disc.go
+++ b/pkg/dmsg/dmsgclient/fallback_disc.go
@@ -1,0 +1,143 @@
+// Package dmsgclient pkg/dmsg/dmsgclient/fallback_disc.go
+//
+// The fallbackDiscClient is net/http-FREE (it only composes other
+// disc.APIClient values), so it lives here untagged — usable from both the
+// native (dmsghttp-backed) and TinyGo (dmsg-stream-backed) discovery-upgrade
+// paths. The net/http-using bootstrap helpers (StartDmsgWith*,
+// FallbackRoundTripper, cachingDiscClient) stay in cli_fallback.go behind
+// //go:build !tinygo.
+package dmsgclient
+
+import (
+	"context"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// fallbackDiscClient tries direct client first, falls back to HTTP discovery for unknown entries
+type fallbackDiscClient struct {
+	direct disc.APIClient
+	http   disc.APIClient
+	log    *logging.Logger
+	// register routes the WRITE methods (Put/Post/DelEntry). When false
+	// (the service variant), writes go to the direct client, which no-ops —
+	// services run as direct clients and don't publish to dmsg-discovery.
+	// When true (the visor variant), writes go to the HTTP client so the
+	// caller's entry IS published to the real dmsg-discovery, while READS
+	// still resolve direct-first. This lets one client both register itself
+	// AND resolve seeded service/server PKs statically (no HTTP-over-dmsg
+	// round-trip — the round-trip to the entry-less, root-of-trust dmsg-disc
+	// is what hot-loops when the whole disc is dmsgfirst).
+	register bool
+}
+
+// NewFallbackDiscClient creates a discovery client that tries direct first, then HTTP.
+// Used by callers that need to dial arbitrary client PKs registered in the real
+// dmsg-discovery while keeping a pre-loaded direct.Client for the bootstrap server
+// list (and any synthetic/seeded entries the caller wants to short-circuit).
+// WRITES no-op (direct) — the non-registering "service" variant.
+func NewFallbackDiscClient(direct, http disc.APIClient, log *logging.Logger) disc.APIClient {
+	return &fallbackDiscClient{
+		direct: direct,
+		http:   http,
+		log:    log,
+	}
+}
+
+// NewRegisteringFallbackDiscClient is the visor variant: READS resolve
+// direct-first (seeded service/server PKs short-circuit, no HTTP-over-dmsg
+// round-trip), but WRITES (Put/Post/DelEntry) go to the HTTP client so the
+// visor's own entry IS published to the real dmsg-discovery. This lets a
+// SINGLE dmsg client both register itself and resolve bootstrap PKs
+// statically — replacing the two-client (dmsgC discovery + dmsgDC direct)
+// setup whose shared PK self-evicts on the dmsg servers.
+func NewRegisteringFallbackDiscClient(direct, http disc.APIClient, log *logging.Logger) disc.APIClient {
+	return &fallbackDiscClient{
+		direct:   direct,
+		http:     http,
+		log:      log,
+		register: true,
+	}
+}
+
+// Entry tries direct client first, falls back to HTTP for unknown entries
+func (f *fallbackDiscClient) Entry(ctx context.Context, pk cipher.PubKey) (*disc.Entry, error) {
+	// Try direct client first
+	entry, err := f.direct.Entry(ctx, pk)
+	if err == nil && entry.Static == pk {
+		return entry, nil
+	}
+
+	// Fall back to HTTP discovery for unknown entries
+	f.log.WithField("pk", pk.String()).Debug("Entry not in direct client, querying HTTP discovery")
+	return f.http.Entry(ctx, pk)
+}
+
+// PostEntry ALWAYS no-ops via the direct client — even in the registering
+// variant. The dmsg serve loop calls PostEntry PRE-session
+// (initilizeClientEntry, "Initial post entry") BEFORE any session exists;
+// routing that to HTTP-over-dmsg would dial dmsg-disc over the client's own
+// not-yet-established sessions, blocking the serve loop on a chicken-egg and
+// starving the rest of the server-dialing loop — the visor gets stuck on a
+// single server / wedges. Durable registration is done by the POST-session
+// updateClientEntry loop via PutEntry (runs only after sessions exist); the
+// dmsg-disc setEntry handler upserts, so PutEntry creates the entry. Mirrors
+// StartDmsgSelfHostedDisc, whose single client works precisely because its
+// PostEntry no-ops and returns instantly so sessions can establish.
+func (f *fallbackDiscClient) PostEntry(ctx context.Context, entry *disc.Entry) error {
+	return f.direct.PostEntry(ctx, entry)
+}
+
+// PutEntry delegates to the direct client (which no-ops). Services
+// using this fallback wrapper run as direct dmsg clients and are not
+// supposed to register themselves in dmsg-discovery — they are
+// reachable equally through any dmsg server via the consumer's
+// preloaded direct.Client. Routing PutEntry to HTTP caused TD/SD/
+// dmsg-disc to publish themselves on every dmsg.Client UpdateInterval
+// (5 min default for clients), producing entries with seq numbers
+// growing into the hundreds and pointless write traffic against
+// dmsg-discovery; consumers gain nothing from those entries because
+// the visor's direct.Client already knows the service PK → all-servers
+// mapping at startup.
+func (f *fallbackDiscClient) PutEntry(ctx context.Context, sk cipher.SecKey, entry *disc.Entry) error {
+	if f.register {
+		return f.http.PutEntry(ctx, sk, entry)
+	}
+	return f.direct.PutEntry(ctx, sk, entry)
+}
+
+// DelEntry: registering variant removes from HTTP discovery; service
+// variant no-ops via the direct client.
+func (f *fallbackDiscClient) DelEntry(ctx context.Context, entry *disc.Entry) error {
+	if f.register {
+		return f.http.DelEntry(ctx, entry)
+	}
+	return f.direct.DelEntry(ctx, entry)
+}
+
+// AvailableServers delegates to direct client
+func (f *fallbackDiscClient) AvailableServers(ctx context.Context) ([]*disc.Entry, error) {
+	return f.direct.AvailableServers(ctx)
+}
+
+// AllServers delegates to direct client
+func (f *fallbackDiscClient) AllServers(ctx context.Context) ([]*disc.Entry, error) {
+	return f.direct.AllServers(ctx)
+}
+
+// AllEntries delegates to direct client
+func (f *fallbackDiscClient) AllEntries(ctx context.Context) ([]string, error) {
+	return f.direct.AllEntries(ctx)
+}
+
+// AllClientsByServer delegates to HTTP client
+func (f *fallbackDiscClient) AllClientsByServer(ctx context.Context) (map[string][]*disc.Entry, error) {
+	return f.http.AllClientsByServer(ctx)
+}
+
+// ClientsByServer delegates to HTTP client
+func (f *fallbackDiscClient) ClientsByServer(ctx context.Context, serverPK cipher.PubKey) ([]*disc.Entry, error) {
+	return f.http.ClientsByServer(ctx, serverPK)
+}

--- a/pkg/dmsg/dmsgclient/flags.go
+++ b/pkg/dmsg/dmsgclient/flags.go
@@ -1,4 +1,9 @@
+//go:build !tinygo
+
 // Package dmsgclient pkg/dmsgclient/flags.go
+//
+// CLI flag wiring (cobra) — excluded from TinyGo builds. The TinyGo wasm HV
+// drives dmsg programmatically (StartDmsgSeeded), not via cobra flags.
 package dmsgclient
 
 import (

--- a/pkg/dmsg/dmsgclient/httpdmsg.go
+++ b/pkg/dmsg/dmsgclient/httpdmsg.go
@@ -1,0 +1,223 @@
+// Package dmsgclient pkg/dmsg/dmsgclient/httpdmsg.go
+package dmsgclient
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+// httpResult is a parsed minimal HTTP/1.1 response: the status code, the
+// response headers (canonical-ish keys as sent on the wire), and the fully-read
+// body.
+type httpResult struct {
+	status  int
+	headers map[string]string
+	body    []byte
+}
+
+// httpRoundTrip writes a minimal HTTP/1.1 request to conn and reads back the
+// response. It is net/http-FREE — so it compiles under TinyGo, where net/http
+// is broken on the js target — but speaks the exact HTTP/1.1 wire protocol, so
+// it talks to the dmsg-served discovery (a standard net/http server reached over
+// a dmsg stream) unchanged. It is the net/http-free equivalent of one
+// dmsghttp.HTTPTransport round-trip.
+//
+// `Connection: close` is sent so the server closes the stream after the
+// response; the caller dials one fresh stream per request (no keep-alive reuse).
+//
+// reqHeaders (may be nil) are extra request headers; Host, Connection and
+// Content-Length are managed here and any same-named entries are ignored. A
+// JSON Content-Type is assumed for a body only when reqHeaders sets none.
+func httpRoundTrip(conn io.ReadWriter, method, host, path string, reqHeaders map[string]string, body []byte) (httpResult, error) {
+	var req strings.Builder
+	req.WriteString(method)
+	req.WriteByte(' ')
+	req.WriteString(path)
+	req.WriteString(" HTTP/1.1\r\nHost: ")
+	req.WriteString(host)
+	req.WriteString("\r\nConnection: close\r\n")
+	hasCType := false
+	for k, v := range reqHeaders {
+		switch strings.ToLower(k) {
+		case "host", "connection", "content-length":
+			continue // managed here
+		case "content-type":
+			hasCType = true
+		}
+		req.WriteString(k)
+		req.WriteString(": ")
+		req.WriteString(v)
+		req.WriteString("\r\n")
+	}
+	if body != nil {
+		if !hasCType {
+			req.WriteString("Content-Type: application/json\r\n")
+		}
+		req.WriteString("Content-Length: ")
+		req.WriteString(strconv.Itoa(len(body)))
+		req.WriteString("\r\n")
+	}
+	req.WriteString("\r\n")
+	if _, err := io.WriteString(conn, req.String()); err != nil {
+		return httpResult{}, err
+	}
+	if body != nil {
+		if _, err := conn.Write(body); err != nil {
+			return httpResult{}, err
+		}
+	}
+	return readHTTPResponse(conn)
+}
+
+// readHTTPResponse parses a minimal HTTP/1.1 response: status line, headers, and
+// the body framed by Content-Length, chunked Transfer-Encoding, or read-to-EOF
+// (the `Connection: close` case).
+func readHTTPResponse(r io.Reader) (httpResult, error) {
+	br := bufio.NewReader(r)
+
+	statusLine, err := br.ReadString('\n')
+	if err != nil {
+		return httpResult{}, err
+	}
+	// "HTTP/1.1 200 OK\r\n" → fields[1] is the status code.
+	fields := strings.SplitN(strings.TrimSpace(statusLine), " ", 3)
+	if len(fields) < 2 {
+		return httpResult{}, fmt.Errorf("malformed HTTP status line: %q", statusLine)
+	}
+	code, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return httpResult{}, fmt.Errorf("malformed HTTP status code: %q", fields[1])
+	}
+
+	contentLength := -1
+	chunked := false
+	headers := make(map[string]string)
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return httpResult{}, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break // end of headers
+		}
+		name, val, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		name = strings.TrimSpace(name)
+		val = strings.TrimSpace(val)
+		headers[name] = val
+		switch strings.ToLower(name) {
+		case "content-length":
+			if n, err := strconv.Atoi(val); err == nil {
+				contentLength = n
+			}
+		case "transfer-encoding":
+			if strings.Contains(strings.ToLower(val), "chunked") {
+				chunked = true
+			}
+		}
+	}
+
+	var bodyBytes []byte
+	switch {
+	case chunked:
+		bodyBytes, err = readChunkedBody(br)
+	case contentLength >= 0:
+		bodyBytes = make([]byte, contentLength)
+		_, err = io.ReadFull(br, bodyBytes)
+	default:
+		bodyBytes, err = io.ReadAll(br) // Connection: close → body ends at EOF
+	}
+	if err != nil {
+		return httpResult{}, err
+	}
+	return httpResult{status: code, headers: headers, body: bodyBytes}, nil
+}
+
+// FetchOverDmsg performs ONE HTTP/1.1 request over dmsg to pkHost (a public key,
+// or "pk:port"; port defaults to the dmsg-HTTP port 80) and returns the response
+// status, headers, and body — net/http-FREE, so it works under TinyGo. It is the
+// transport the browser hypervisor UI uses to talk to a REMOTE visor/hypervisor
+// by PK (the net/http-free analog of an http.Client over a dmsghttp transport).
+func FetchOverDmsg(ctx context.Context, dmsgC *dmsg.Client, method, pkHost, path string, reqHeaders map[string]string, body []byte) (status int, respHeaders map[string]string, respBody []byte, err error) {
+	var addr dmsg.Addr
+	if err = addr.Set(pkHost); err != nil {
+		return 0, nil, nil, fmt.Errorf("dmsgclient: bad fetch host %q: %w", pkHost, err)
+	}
+	if addr.Port == 0 {
+		addr.Port = dmsg.DefaultDmsgHTTPPort
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	stream, err := dmsgC.DialStream(ctx, addr)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	defer stream.Close() //nolint:errcheck
+
+	done := make(chan struct{})
+	defer close(done)
+	if ctx.Done() != nil {
+		go func() {
+			select {
+			case <-ctx.Done():
+				stream.Close() //nolint:errcheck,gosec
+			case <-done:
+			}
+		}()
+	}
+
+	res, err := httpRoundTrip(stream, method, addr.PK.Hex(), path, reqHeaders, body)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	return res.status, res.headers, res.body, nil
+}
+
+// readChunkedBody decodes an HTTP/1.1 chunked body: a sequence of
+// hex-size CRLF chunk-data CRLF, terminated by a zero-size chunk.
+func readChunkedBody(br *bufio.Reader) ([]byte, error) {
+	var out []byte
+	for {
+		sizeLine, err := br.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		sizeLine = strings.TrimRight(sizeLine, "\r\n")
+		if i := strings.IndexByte(sizeLine, ';'); i >= 0 {
+			sizeLine = sizeLine[:i] // strip chunk extensions
+		}
+		size, err := strconv.ParseInt(strings.TrimSpace(sizeLine), 16, 64)
+		if err != nil {
+			return nil, fmt.Errorf("malformed chunk size: %q", sizeLine)
+		}
+		if size == 0 {
+			// Consume the trailer section up to the final blank line.
+			for {
+				line, err := br.ReadString('\n')
+				if err != nil || strings.TrimRight(line, "\r\n") == "" {
+					break
+				}
+			}
+			return out, nil
+		}
+		chunk := make([]byte, size)
+		if _, err := io.ReadFull(br, chunk); err != nil {
+			return nil, err
+		}
+		out = append(out, chunk...)
+		if _, err := br.Discard(2); err != nil { // trailing CRLF after chunk data
+			return nil, err
+		}
+	}
+}

--- a/pkg/dmsg/dmsgclient/httpdmsg_test.go
+++ b/pkg/dmsg/dmsgclient/httpdmsg_test.go
@@ -1,0 +1,88 @@
+package dmsgclient
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+// TestHTTPRoundTripWireCompat proves the net/http-free httpRoundTrip speaks the
+// exact HTTP/1.1 wire protocol by driving a REAL net/http server: Content-Length
+// responses (GET + POST body echo), a chunked response, and an error-status body
+// (whose message must map back to disc.ErrValidationWrongSequence).
+func TestHTTPRoundTripWireCompat(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{
+			"method": r.Method,
+			"path":   r.URL.Path,
+			"body":   string(b),
+		}))
+	})
+	mux.HandleFunc("/chunked", func(w http.ResponseWriter, r *http.Request) {
+		fl, ok := w.(http.Flusher)
+		require.True(t, ok)
+		_, err := io.WriteString(w, `{"part":`)
+		require.NoError(t, err)
+		fl.Flush() // forces chunked (no Content-Length)
+		_, err = io.WriteString(w, `"ok"}`)
+		require.NoError(t, err)
+		fl.Flush()
+	})
+	mux.HandleFunc("/fail", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{
+			"message": disc.ErrValidationWrongSequence.Error(),
+		}))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	// roundTrip dials a fresh conn (Connection: close ⇒ one request per conn).
+	roundTrip := func(method, path string, body []byte) httpResult {
+		conn, err := net.Dial("tcp", host)
+		require.NoError(t, err)
+		defer conn.Close() //nolint:errcheck
+		res, err := httpRoundTrip(conn, method, host, path, nil, body)
+		require.NoError(t, err)
+		return res
+	}
+
+	// GET with Content-Length response.
+	res := roundTrip("GET", "/echo", nil)
+	require.Equal(t, 200, res.status)
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(res.body, &got))
+	require.Equal(t, "GET", got["method"])
+	require.Equal(t, "/echo", got["path"])
+
+	// POST with a request body echoed back.
+	res = roundTrip("POST", "/echo", []byte(`{"x":1}`))
+	require.Equal(t, 200, res.status)
+	require.NoError(t, json.Unmarshal(res.body, &got))
+	require.Equal(t, "POST", got["method"])
+	require.Equal(t, `{"x":1}`, got["body"])
+
+	// Chunked Transfer-Encoding response.
+	res = roundTrip("GET", "/chunked", nil)
+	require.Equal(t, 200, res.status)
+	require.JSONEq(t, `{"part":"ok"}`, string(res.body))
+
+	// Error status: body message maps back to the typed sentinel.
+	res = roundTrip("GET", "/fail", nil)
+	require.Equal(t, 500, res.status)
+	require.Equal(t, disc.ErrValidationWrongSequence, errFromBody(res.body))
+}

--- a/pkg/dmsg/dmsgclient/jslog_js.go
+++ b/pkg/dmsg/dmsgclient/jslog_js.go
@@ -1,0 +1,14 @@
+//go:build js && wasm
+
+package dmsgclient
+
+import "syscall/js"
+
+// jslog routes a debug line to a JS hook (window.__skylog) when present, so the
+// browser harness / control bridge can surface dmsg-disc-over-dmsg internals.
+// No-op when the hook is absent. Build-tagged to the browser; a no-op elsewhere.
+func jslog(s string) {
+	if h := js.Global().Get("__skylog"); h.Truthy() {
+		h.Invoke(s)
+	}
+}

--- a/pkg/dmsg/dmsgclient/jslog_other.go
+++ b/pkg/dmsg/dmsgclient/jslog_other.go
@@ -1,0 +1,6 @@
+//go:build !(js && wasm)
+
+package dmsgclient
+
+// jslog is a no-op off the browser target (see jslog_js.go).
+func jslog(string) {}

--- a/pkg/dmsg/dmsgclient/seeded.go
+++ b/pkg/dmsg/dmsgclient/seeded.go
@@ -69,7 +69,12 @@ func StartDmsgSeeded(ctx context.Context, log *logging.Logger, pk cipher.PubKey,
 
 	conf := dmsg.DefaultConfig()
 	conf.PreferWS = preferWS // browser (wasm) seeds over WebSocket; native uses TCP
-	conf.MinSessions = 1
+	// MinSessions 2 (not 1): once bootstrapped via the seed and registered in
+	// discovery, the client learns the live server list from discovery
+	// (seededDiscClient.AvailableServers → real) and holds a SECOND session, so a
+	// single seed going down doesn't sever the client (and orphan it from the
+	// discovery it would need to find another server). Capped at the known set.
+	conf.MinSessions = 2
 
 	dmsgC, stop, err := direct.StartDmsg(ctx, log, pk, sk, dClient, conf)
 	if err != nil {
@@ -90,7 +95,7 @@ func StartDmsgSeeded(ctx context.Context, log *logging.Logger, pk cipher.PubKey,
 		// backing disc client; TinyGo uses the net/http-free dmsgDiscClient
 		// (HTTP/1.1 straight over a dmsg stream). On failure we degrade to
 		// seed-only rather than failing the whole client.
-		if err := upgradeDiscovery(ctx, log, dmsgC, dClient, discDmsgAddr); err != nil {
+		if err := upgradeDiscovery(ctx, log, dmsgC, dClient, seedServers, discDmsgAddr); err != nil {
 			log.WithError(err).Warn("dmsg: discovery upgrade failed; continuing seed-only (dialable but can't resolve new peers)")
 		}
 	}

--- a/pkg/dmsg/dmsgclient/seeded.go
+++ b/pkg/dmsg/dmsgclient/seeded.go
@@ -4,14 +4,12 @@ package dmsgclient
 import (
 	"context"
 	"errors"
-	"net/http"
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/direct"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
@@ -83,13 +81,18 @@ func StartDmsgSeeded(ctx context.Context, log *logging.Logger, pk cipher.PubKey,
 		// preloaded direct client first (the seed servers + the discovery PK
 		// short-circuit, so resolving the discovery's own location never recurses
 		// into HTTP-over-dmsg), and only unknown peers + WRITES go to the
-		// dmsg-backed HTTP client — which publishes our entry to the real
+		// dmsg-backed discovery client — which publishes our entry to the real
 		// discovery and makes us inbound-reachable by PK. Replacing the disc
 		// outright (instead of falling back) makes teardown recurse resolving the
 		// discovery server's own entry.
-		dmsgHTTP := &http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC)}
-		httpDisc := disc.NewHTTP(discDmsgAddr, dmsgHTTP, log)
-		dmsgC.SetDiscoveryClients([]disc.APIClient{NewRegisteringFallbackDiscClient(dClient, httpDisc, log)})
+		//
+		// upgradeDiscovery is build-tagged: native uses dmsghttp (net/http) as the
+		// backing disc client; TinyGo uses the net/http-free dmsgDiscClient
+		// (HTTP/1.1 straight over a dmsg stream). On failure we degrade to
+		// seed-only rather than failing the whole client.
+		if err := upgradeDiscovery(ctx, log, dmsgC, dClient, discDmsgAddr); err != nil {
+			log.WithError(err).Warn("dmsg: discovery upgrade failed; continuing seed-only (dialable but can't resolve new peers)")
+		}
 	}
 
 	return dmsgC, stop, nil

--- a/pkg/dmsg/dmsgclient/seeded_disc.go
+++ b/pkg/dmsg/dmsgclient/seeded_disc.go
@@ -1,0 +1,92 @@
+// Package dmsgclient pkg/dmsg/dmsgclient/seeded_disc.go
+package dmsgclient
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// seededDiscClient is the discovery client for a seeded dmsg client (browser /
+// standalone). It speaks to the REAL discovery for everything — registering its
+// own entry, resolving arbitrary peers, and fetching the live server list — and
+// keeps a small `shortcut` map ONLY for the bootstrap/recursion-avoidance set:
+// the discovery's own PK (so reaching the discovery never recurses through the
+// discovery) and the seed server PKs (so the first session can be dialed).
+//
+// This replaces the direct-first RegisteringFallbackDiscClient on the seeded
+// path. That one resolved the client's OWN pk from a synthetic direct entry, so
+// the dmsg client's registration logic (initilizeClientEntry / updateClientEntry)
+// saw a fake "already registered" entry and skipped the real PostEntry — the
+// client connected to a server but never actually registered in discovery. Here
+// the own pk resolves against the real discovery (404 when absent), so the
+// register-fresh-entry path fires; and AvailableServers returns the live
+// discovery list (falling back to the seeds before a session exists).
+type seededDiscClient struct {
+	real     disc.APIClient
+	shortcut map[cipher.PubKey]*disc.Entry
+	seeds    []*disc.Entry
+	log      *logging.Logger
+}
+
+// NewSeededDiscClient builds the seeded discovery client. shortcut must contain
+// the discovery PK + seed server entries; seeds is the seed server list used as
+// the AvailableServers/AllServers bootstrap fallback before the real discovery
+// is reachable.
+func NewSeededDiscClient(real disc.APIClient, shortcut map[cipher.PubKey]*disc.Entry, seeds []*disc.Entry, log *logging.Logger) disc.APIClient {
+	return &seededDiscClient{real: real, shortcut: shortcut, seeds: seeds, log: log}
+}
+
+func (c *seededDiscClient) Entry(ctx context.Context, pk cipher.PubKey) (*disc.Entry, error) {
+	if e, ok := c.shortcut[pk]; ok {
+		return e, nil
+	}
+	return c.real.Entry(ctx, pk)
+}
+
+func (c *seededDiscClient) PostEntry(ctx context.Context, entry *disc.Entry) error {
+	return c.real.PostEntry(ctx, entry)
+}
+
+func (c *seededDiscClient) PutEntry(ctx context.Context, sk cipher.SecKey, entry *disc.Entry) error {
+	return c.real.PutEntry(ctx, sk, entry)
+}
+
+func (c *seededDiscClient) DelEntry(ctx context.Context, entry *disc.Entry) error {
+	return c.real.DelEntry(ctx, entry)
+}
+
+// AvailableServers returns the live discovery server list, falling back to the
+// seeds before a session exists (so the bootstrap dial always has a target).
+func (c *seededDiscClient) AvailableServers(ctx context.Context) ([]*disc.Entry, error) {
+	srv, err := c.real.AvailableServers(ctx)
+	if err != nil || len(srv) == 0 {
+		jslog(fmt.Sprintf("seeded.AvailableServers -> seeds(%d) (real err=%v n=%d)", len(c.seeds), err, len(srv)))
+		return c.seeds, nil
+	}
+	jslog(fmt.Sprintf("seeded.AvailableServers -> real(%d)", len(srv)))
+	return srv, nil
+}
+
+func (c *seededDiscClient) AllServers(ctx context.Context) ([]*disc.Entry, error) {
+	srv, err := c.real.AllServers(ctx)
+	if err != nil || len(srv) == 0 {
+		return c.seeds, nil
+	}
+	return srv, nil
+}
+
+func (c *seededDiscClient) AllEntries(ctx context.Context) ([]string, error) {
+	return c.real.AllEntries(ctx)
+}
+
+func (c *seededDiscClient) AllClientsByServer(ctx context.Context) (map[string][]*disc.Entry, error) {
+	return c.real.AllClientsByServer(ctx)
+}
+
+func (c *seededDiscClient) ClientsByServer(ctx context.Context, serverPK cipher.PubKey) ([]*disc.Entry, error) {
+	return c.real.ClientsByServer(ctx, serverPK)
+}

--- a/pkg/dmsg/dmsgclient/seeded_upgrade_native.go
+++ b/pkg/dmsg/dmsgclient/seeded_upgrade_native.go
@@ -16,8 +16,12 @@ import (
 // upgradeDiscovery (native) backs the registering-fallback discovery with an
 // HTTP-over-dmsg client (net/http + dmsghttp transport over the client's own
 // sessions). See seeded.go for the rationale; the TinyGo build supplies a
-// net/http-free equivalent in seeded_upgrade_tinygo.go.
-func upgradeDiscovery(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Client, dClient disc.APIClient, discDmsgAddr string) error {
+// net/http-free equivalent (and the seededDiscClient registration fix) in
+// seeded_upgrade_tinygo.go. seedServers is unused here — the native path keeps
+// the proven RegisteringFallbackDiscClient to avoid changing native standalone
+// tools; it can adopt the seededDiscClient later.
+func upgradeDiscovery(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Client, dClient disc.APIClient, seedServers []*disc.Entry, discDmsgAddr string) error {
+	_ = seedServers
 	dmsgHTTP := &http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC)}
 	httpDisc := disc.NewHTTP(discDmsgAddr, dmsgHTTP, log)
 	dmsgC.SetDiscoveryClients([]disc.APIClient{NewRegisteringFallbackDiscClient(dClient, httpDisc, log)})

--- a/pkg/dmsg/dmsgclient/seeded_upgrade_native.go
+++ b/pkg/dmsg/dmsgclient/seeded_upgrade_native.go
@@ -1,0 +1,25 @@
+//go:build !tinygo
+
+// Package dmsgclient pkg/dmsg/dmsgclient/seeded_upgrade_native.go
+package dmsgclient
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// upgradeDiscovery (native) backs the registering-fallback discovery with an
+// HTTP-over-dmsg client (net/http + dmsghttp transport over the client's own
+// sessions). See seeded.go for the rationale; the TinyGo build supplies a
+// net/http-free equivalent in seeded_upgrade_tinygo.go.
+func upgradeDiscovery(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Client, dClient disc.APIClient, discDmsgAddr string) error {
+	dmsgHTTP := &http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC)}
+	httpDisc := disc.NewHTTP(discDmsgAddr, dmsgHTTP, log)
+	dmsgC.SetDiscoveryClients([]disc.APIClient{NewRegisteringFallbackDiscClient(dClient, httpDisc, log)})
+	return nil
+}

--- a/pkg/dmsg/dmsgclient/seeded_upgrade_tinygo.go
+++ b/pkg/dmsg/dmsgclient/seeded_upgrade_tinygo.go
@@ -6,22 +6,41 @@ package dmsgclient
 import (
 	"context"
 
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
-// upgradeDiscovery (TinyGo) backs the registering-fallback discovery with the
-// net/http-free dmsgDiscClient, which speaks HTTP/1.1 straight over a dmsg
-// stream. This is what lets the wasm hypervisor register itself and resolve
-// peers under TinyGo, where net/http (hence dmsghttp) won't compile on the js
-// target. ctx is unused here (NewDmsgDiscClient dials lazily per call) but kept
-// for signature parity with the native build.
-func upgradeDiscovery(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Client, dClient disc.APIClient, discDmsgAddr string) error {
-	dmsgDisc, err := NewDmsgDiscClient(dmsgC, discDmsgAddr, log)
+// upgradeDiscovery (TinyGo) installs the net/http-free seededDiscClient: it talks
+// to the REAL discovery (the dmsgDiscClient, HTTP/1.1 over a dmsg stream) for
+// registering + resolving + the live server list, with a small shortcut for the
+// discovery PK + seed servers (recursion-avoidance + bootstrap). This is what
+// lets the wasm client actually REGISTER in discovery and learn servers from it,
+// instead of resolving everything from the seeded direct client. ctx is unused
+// (NewDmsgDiscClient dials lazily per call); dClient (the bootstrap direct
+// client) is intentionally NOT consulted for discovery queries.
+func upgradeDiscovery(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Client, dClient disc.APIClient, seedServers []*disc.Entry, discDmsgAddr string) error {
+	real, err := NewDmsgDiscClient(dmsgC, discDmsgAddr, log)
 	if err != nil {
 		return err
 	}
-	dmsgC.SetDiscoveryClients([]disc.APIClient{NewRegisteringFallbackDiscClient(dClient, dmsgDisc, log)})
+
+	shortcut := make(map[cipher.PubKey]*disc.Entry)
+	var seedPKs []cipher.PubKey
+	for _, s := range seedServers {
+		shortcut[s.Static] = s
+		seedPKs = append(seedPKs, s.Static)
+	}
+	// Synthetic discovery entry (delegated to the seed servers) so a DialStream to
+	// the discovery PK bridges via a seed session without recursing into discovery.
+	if hex := dmsg.ExtractPKFromDmsgAddr(discDmsgAddr); hex != "" {
+		var discPK cipher.PubKey
+		if err := discPK.UnmarshalText([]byte(hex)); err == nil {
+			shortcut[discPK] = &disc.Entry{Version: "0.0.1", Static: discPK, Client: &disc.Client{DelegatedServers: seedPKs}}
+		}
+	}
+
+	dmsgC.SetDiscoveryClients([]disc.APIClient{NewSeededDiscClient(real, shortcut, seedServers, log)})
 	return nil
 }

--- a/pkg/dmsg/dmsgclient/seeded_upgrade_tinygo.go
+++ b/pkg/dmsg/dmsgclient/seeded_upgrade_tinygo.go
@@ -1,0 +1,27 @@
+//go:build tinygo
+
+// Package dmsgclient pkg/dmsg/dmsgclient/seeded_upgrade_tinygo.go
+package dmsgclient
+
+import (
+	"context"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// upgradeDiscovery (TinyGo) backs the registering-fallback discovery with the
+// net/http-free dmsgDiscClient, which speaks HTTP/1.1 straight over a dmsg
+// stream. This is what lets the wasm hypervisor register itself and resolve
+// peers under TinyGo, where net/http (hence dmsghttp) won't compile on the js
+// target. ctx is unused here (NewDmsgDiscClient dials lazily per call) but kept
+// for signature parity with the native build.
+func upgradeDiscovery(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Client, dClient disc.APIClient, discDmsgAddr string) error {
+	dmsgDisc, err := NewDmsgDiscClient(dmsgC, discDmsgAddr, log)
+	if err != nil {
+		return err
+	}
+	dmsgC.SetDiscoveryClients([]disc.APIClient{NewRegisteringFallbackDiscClient(dClient, dmsgDisc, log)})
+	return nil
+}

--- a/pkg/dmsg/noise/net.go
+++ b/pkg/dmsg/noise/net.go
@@ -4,8 +4,6 @@ package noise
 import (
 	"errors"
 	"net"
-	"net/rpc"
-	"sync"
 	"time"
 
 	"github.com/flynn/noise"
@@ -39,110 +37,6 @@ var (
 	// AcceptHandshakeTimeout determines how long a noise hs should take.
 	AcceptHandshakeTimeout = time.Second * 10
 )
-
-// RPCClientDialer attempts to redial to a remotely served RPCClient.
-// It exposes an RPCServer to the remote server.
-// The connection is encrypted via noise.
-type RPCClientDialer struct {
-	config  Config
-	pattern noise.HandshakePattern
-	addr    string
-	conn    net.Conn
-	mu      sync.Mutex
-	done    chan struct{} // nil: loop is not running, non-nil: loop is running.
-}
-
-// NewRPCClientDialer creates a new RPCClientDialer.
-func NewRPCClientDialer(addr string, pattern noise.HandshakePattern, config Config) *RPCClientDialer {
-	return &RPCClientDialer{config: config, pattern: pattern, addr: addr}
-}
-
-// Run repeatedly dials to remote until a successful connection is established.
-// It exposes a RPC Server.
-// It will return if Close is called or crypto fails.
-func (d *RPCClientDialer) Run(srv *rpc.Server, retry time.Duration) error {
-	if ok := d.setDone(); !ok {
-		return ErrAlreadyServing
-	}
-	for {
-		if err := d.establishConn(); err != nil {
-			// Only return if not network error.
-			if _, ok := err.(net.Error); !ok {
-				return err
-			}
-		} else {
-			// Only serve when then dial succeeds.
-			srv.ServeConn(d.conn)
-			d.setConn(nil)
-		}
-		select {
-		case <-d.done:
-			d.clearDone()
-			return nil
-		case <-time.After(retry):
-		}
-	}
-}
-
-// Close closes the handler.
-func (d *RPCClientDialer) Close() (err error) {
-	if d == nil {
-		return nil
-	}
-	d.mu.Lock()
-	if d.done != nil {
-		close(d.done)
-	}
-	if d.conn != nil {
-		err = d.conn.Close()
-	}
-	d.mu.Unlock()
-	return
-}
-
-// This operation should be atomic, hence protected by mutex.
-func (d *RPCClientDialer) establishConn() error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	conn, err := net.Dial("tcp", d.addr)
-	if err != nil {
-		return err
-	}
-	ns, err := New(d.pattern, d.config)
-	if err != nil {
-		conn.Close() //nolint:errcheck,gosec
-		return err
-	}
-	wrappedConn, err := WrapConn(conn, ns, time.Second*5)
-	if err != nil {
-		conn.Close() //nolint:errcheck,gosec
-		return err
-	}
-	d.conn = wrappedConn
-	return nil
-}
-
-func (d *RPCClientDialer) setConn(conn net.Conn) {
-	d.mu.Lock()
-	d.conn = conn
-	d.mu.Unlock()
-}
-
-func (d *RPCClientDialer) setDone() (ok bool) {
-	d.mu.Lock()
-	if ok = d.done == nil; ok {
-		d.done = make(chan struct{})
-	}
-	d.mu.Unlock()
-	return
-}
-
-func (d *RPCClientDialer) clearDone() {
-	d.mu.Lock()
-	d.done = nil
-	d.mu.Unlock()
-}
 
 // Addr is the address of a either an AppNode or ManagerNode.
 type Addr struct {

--- a/pkg/dmsg/noise/rpcdialer.go
+++ b/pkg/dmsg/noise/rpcdialer.go
@@ -1,0 +1,123 @@
+//go:build !tinygo
+
+// Package noise pkg/noise/rpcdialer.go
+//
+// RPCClientDialer is split out of net.go behind //go:build !tinygo because it
+// imports net/rpc, which transitively pulls net/http — broken on the TinyGo js
+// target. It is a server-side redial helper (a visor exposing an RPC server to a
+// remote), never used by a dmsg client, so excluding it from TinyGo builds costs
+// nothing. See docs/design/tinygo-dmsg-client.md.
+package noise
+
+import (
+	"net"
+	"net/rpc"
+	"sync"
+	"time"
+
+	"github.com/flynn/noise"
+)
+
+// RPCClientDialer attempts to redial to a remotely served RPCClient.
+// It exposes an RPCServer to the remote server.
+// The connection is encrypted via noise.
+type RPCClientDialer struct {
+	config  Config
+	pattern noise.HandshakePattern
+	addr    string
+	conn    net.Conn
+	mu      sync.Mutex
+	done    chan struct{} // nil: loop is not running, non-nil: loop is running.
+}
+
+// NewRPCClientDialer creates a new RPCClientDialer.
+func NewRPCClientDialer(addr string, pattern noise.HandshakePattern, config Config) *RPCClientDialer {
+	return &RPCClientDialer{config: config, pattern: pattern, addr: addr}
+}
+
+// Run repeatedly dials to remote until a successful connection is established.
+// It exposes a RPC Server.
+// It will return if Close is called or crypto fails.
+func (d *RPCClientDialer) Run(srv *rpc.Server, retry time.Duration) error {
+	if ok := d.setDone(); !ok {
+		return ErrAlreadyServing
+	}
+	for {
+		if err := d.establishConn(); err != nil {
+			// Only return if not network error.
+			if _, ok := err.(net.Error); !ok {
+				return err
+			}
+		} else {
+			// Only serve when then dial succeeds.
+			srv.ServeConn(d.conn)
+			d.setConn(nil)
+		}
+		select {
+		case <-d.done:
+			d.clearDone()
+			return nil
+		case <-time.After(retry):
+		}
+	}
+}
+
+// Close closes the handler.
+func (d *RPCClientDialer) Close() (err error) {
+	if d == nil {
+		return nil
+	}
+	d.mu.Lock()
+	if d.done != nil {
+		close(d.done)
+	}
+	if d.conn != nil {
+		err = d.conn.Close()
+	}
+	d.mu.Unlock()
+	return
+}
+
+// This operation should be atomic, hence protected by mutex.
+func (d *RPCClientDialer) establishConn() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	conn, err := net.Dial("tcp", d.addr)
+	if err != nil {
+		return err
+	}
+	ns, err := New(d.pattern, d.config)
+	if err != nil {
+		conn.Close() //nolint:errcheck,gosec
+		return err
+	}
+	wrappedConn, err := WrapConn(conn, ns, time.Second*5)
+	if err != nil {
+		conn.Close() //nolint:errcheck,gosec
+		return err
+	}
+	d.conn = wrappedConn
+	return nil
+}
+
+func (d *RPCClientDialer) setConn(conn net.Conn) {
+	d.mu.Lock()
+	d.conn = conn
+	d.mu.Unlock()
+}
+
+func (d *RPCClientDialer) setDone() (ok bool) {
+	d.mu.Lock()
+	if ok = d.done == nil; ok {
+		d.done = make(chan struct{})
+	}
+	d.mu.Unlock()
+	return
+}
+
+func (d *RPCClientDialer) clearDone() {
+	d.mu.Lock()
+	d.done = nil
+	d.mu.Unlock()
+}

--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -96,9 +96,9 @@ func (f *ClientFactory) MakeClient(netType types.Type, port int) (Client, error)
 	case types.STCPR:
 		return newStcpr(resolved, port), nil
 	case types.SUDPH:
-		return newSudph(resolved, port), nil
+		return makeSudphClient(resolved, port)
 	case types.QUIC:
-		return newQuic(resolved, port), nil
+		return makeQuicClient(resolved, port)
 	case types.DMSG:
 		return newDmsgClient(f.DmsgC), nil
 	}

--- a/pkg/transport/network/quic.go
+++ b/pkg/transport/network/quic.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 // Package network pkg/transport/network/quic.go: a QUIC-based skywire
 // transport. Mirrors the sudph/stcpr structure (AR-resolved, UDP-based)
 // but rides quic-go instead of KCP: the connection is secured by the
@@ -45,6 +47,13 @@ type quicClient struct {
 	listener *quic.Listener
 	tlsCert  tls.Certificate
 	qconf    *quic.Config
+}
+
+// makeQuicClient is the build-tagged QUIC constructor used by MakeClient. On
+// non-TinyGo it builds a real quicClient; the TinyGo build (quic_tinygo.go)
+// returns an unsupported error so the browser graph never pulls quic-go.
+func makeQuicClient(resolved *resolvedClient, port int) (Client, error) {
+	return newQuic(resolved, port), nil
 }
 
 func newQuic(resolved *resolvedClient, port int) Client {

--- a/pkg/transport/network/quic_identity.go
+++ b/pkg/transport/network/quic_identity.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 // Package network pkg/transport/network/quic_identity.go: thin wrappers over
 // pkg/skyquic, which holds the skywire-PK-bound QUIC TLS identity (#2607,
 // option A). The implementation moved to its own package so dmsg-over-QUIC can

--- a/pkg/transport/network/quic_tinygo.go
+++ b/pkg/transport/network/quic_tinygo.go
@@ -1,0 +1,16 @@
+//go:build tinygo
+
+// Package network pkg/transport/network/quic_tinygo.go
+//
+// QUIC carrier stub for TinyGo. quic-go (and pkg/skyquic) don't compile under
+// TinyGo, and a browser has no raw UDP anyway, so the QUIC transport is
+// unavailable on this target. MakeClient routes the QUIC case here; the real
+// constructor lives in quic.go (//go:build !tinygo). This keeps quic-go out of
+// the TinyGo transport graph while leaving dmsg (and the future webrtc) intact.
+package network
+
+import "errors"
+
+func makeQuicClient(_ *resolvedClient, _ int) (Client, error) {
+	return nil, errors.New("network: QUIC transport not supported in this build (TinyGo)")
+}

--- a/pkg/transport/network/stun_client.go
+++ b/pkg/transport/network/stun_client.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 // Package network pkg/transport/network/stun_client.go
 package network
 

--- a/pkg/transport/network/sudph.go
+++ b/pkg/transport/network/sudph.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 // Package network pkg/transport/network/sudph.go
 package network
 
@@ -34,6 +36,13 @@ type sudphClient struct {
 	packetListener  net.PacketConn
 	sudphVisorsConn net.PacketConn
 	port            int
+}
+
+// makeSudphClient is the build-tagged SUDPH constructor used by MakeClient. The
+// TinyGo build (sudph_tinygo.go) returns an unsupported error so the browser
+// graph never pulls kcp-go/pfilter (which transitively import quic-go).
+func makeSudphClient(resolved *resolvedClient, port int) (Client, error) {
+	return newSudph(resolved, port), nil
 }
 
 func newSudph(resolved *resolvedClient, port int) Client {

--- a/pkg/transport/network/sudph_tinygo.go
+++ b/pkg/transport/network/sudph_tinygo.go
@@ -1,0 +1,16 @@
+//go:build tinygo
+
+// Package network pkg/transport/network/sudph_tinygo.go
+//
+// SUDPH carrier stub for TinyGo. sudph rides kcp-go + pfilter (which pull
+// quic-go) over raw UDP — none of which fits the browser/TinyGo target. The real
+// constructor lives in sudph.go (//go:build !tinygo); this stub keeps those deps
+// out of the TinyGo transport graph. STUN (stun_client.go) is tagged out
+// alongside it (it's only used by the sudph NAT-detection path).
+package network
+
+import "errors"
+
+func makeSudphClient(_ *resolvedClient, _ int) (Client, error) {
+	return nil, errors.New("network: SUDPH transport not supported in this build (TinyGo)")
+}

--- a/pkg/wasmhv/core.go
+++ b/pkg/wasmhv/core.go
@@ -11,7 +11,6 @@ package wasmhv
 import (
 	"context"
 	"encoding/json"
-	"net/rpc"
 	"sync"
 	"time"
 
@@ -98,22 +97,22 @@ type Summary struct {
 // --- the core ---
 
 // Core is a standalone wasm hypervisor: it accepts visor dials and tracks an
-// rpc.Client per connected visor.
+// gob RPC client per connected visor (net/rpc wire protocol, no net/rpc import).
 type Core struct {
 	pk    cipher.PubKey
 	dmsgC *dmsg.Client
 
 	mu     sync.RWMutex
-	visors map[cipher.PubKey]*rpc.Client
+	visors map[cipher.PubKey]*gobRPCClient
 }
 
 // NewCore returns a Core for the given dmsg client + this hypervisor's PK.
 func NewCore(pk cipher.PubKey, dmsgC *dmsg.Client) *Core {
-	return &Core{pk: pk, dmsgC: dmsgC, visors: make(map[cipher.PubKey]*rpc.Client)}
+	return &Core{pk: pk, dmsgC: dmsgC, visors: make(map[cipher.PubKey]*gobRPCClient)}
 }
 
 // Serve listens on the hypervisor dmsg port and accepts visor dials. Each
-// accepted stream is wrapped in an rpc.Client (the dialing visor serves its RPC
+// accepted stream is wrapped in a gob RPC client (the dialing visor serves its RPC
 // over it). Blocks until the listener errors or ctx is done.
 func (c *Core) Serve(ctx context.Context) error {
 	lis, err := c.dmsgC.Listen(DmsgHypervisorPort)
@@ -127,7 +126,7 @@ func (c *Core) Serve(ctx context.Context) error {
 			return err
 		}
 		remotePK := stream.RawRemoteAddr().PK
-		client := rpc.NewClient(stream)
+		client := newGobRPCClient(stream)
 		c.mu.Lock()
 		if old := c.visors[remotePK]; old != nil {
 			old.Close() //nolint:errcheck,gosec

--- a/pkg/wasmhv/gobrpc.go
+++ b/pkg/wasmhv/gobrpc.go
@@ -62,7 +62,13 @@ func (c *gobRPCClient) Call(serviceMethod string, args, reply interface{}) error
 		return err
 	}
 	if resp.Error != "" {
-		_ = c.dec.Decode(nil) //nolint:errcheck // discard the empty error body to stay aligned
+		// The server still writes an (empty) reply body after an error response;
+		// read + discard it so the gob stream stays aligned for the next call.
+		// net/rpc sends struct{}{} (invalidRequest) as that body — decode into a
+		// matching throwaway pointer. (gob's Decode(nil) would also discard, but
+		// `go vet` flags the literal nil as "call of Decode passes non-pointer".)
+		var discard struct{}
+		_ = c.dec.Decode(&discard) //nolint:errcheck
 		return errors.New(resp.Error)
 	}
 	return c.dec.Decode(reply)

--- a/pkg/wasmhv/gobrpc.go
+++ b/pkg/wasmhv/gobrpc.go
@@ -1,0 +1,72 @@
+package wasmhv
+
+import (
+	"encoding/gob"
+	"errors"
+	"io"
+	"sync"
+)
+
+// gobRPCClient is a minimal client that speaks the EXACT net/rpc gob wire
+// protocol (Request header + args, then Response header + reply) — so it talks
+// to the visors' net/rpc server unchanged — but WITHOUT importing net/rpc, which
+// transitively pulls net/http (broken on the TinyGo js target). This is what
+// lets the wasm hypervisor core compile under TinyGo.
+//
+// One call at a time, serialized by mu — which is exactly how the hypervisor
+// core uses it (one outstanding RPC per visor at a time).
+type gobRPCClient struct {
+	conn io.ReadWriteCloser
+	enc  *gob.Encoder
+	dec  *gob.Decoder
+	mu   sync.Mutex
+	seq  uint64
+}
+
+// rpcRequest / rpcResponse mirror net/rpc.Request / net/rpc.Response by field
+// name + type, so gob encodes/decodes them wire-identically (gob matches struct
+// fields by name and ignores the Go type name).
+type rpcRequest struct {
+	ServiceMethod string
+	Seq           uint64
+}
+
+type rpcResponse struct {
+	ServiceMethod string
+	Seq           uint64
+	Error         string
+}
+
+func newGobRPCClient(conn io.ReadWriteCloser) *gobRPCClient {
+	return &gobRPCClient{conn: conn, enc: gob.NewEncoder(conn), dec: gob.NewDecoder(conn)}
+}
+
+// Call performs a synchronous net/rpc-compatible call: gob-encode the request
+// header + args, then gob-decode the response header + reply. On a server-side
+// error the server still writes an (empty) reply body, which is read and
+// discarded so the gob stream stays aligned for the next call.
+func (c *gobRPCClient) Call(serviceMethod string, args, reply interface{}) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.seq++
+	if err := c.enc.Encode(&rpcRequest{ServiceMethod: serviceMethod, Seq: c.seq}); err != nil {
+		return err
+	}
+	if err := c.enc.Encode(args); err != nil {
+		return err
+	}
+
+	var resp rpcResponse
+	if err := c.dec.Decode(&resp); err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		_ = c.dec.Decode(nil) //nolint:errcheck // discard the empty error body to stay aligned
+		return errors.New(resp.Error)
+	}
+	return c.dec.Decode(reply)
+}
+
+// Close closes the underlying connection.
+func (c *gobRPCClient) Close() error { return c.conn.Close() }

--- a/pkg/wasmhv/gobrpc_test.go
+++ b/pkg/wasmhv/gobrpc_test.go
@@ -1,0 +1,56 @@
+package wasmhv
+
+import (
+	"errors"
+	"net"
+	"net/rpc" // test-only: the SERVER side, to prove gobRPCClient is wire-compatible
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type echoSvc struct{}
+
+func (echoSvc) Echo(in *string, out *string) error { *out = "echo:" + *in; return nil }
+func (echoSvc) Fail(in *string, out *string) error { return errors.New("boom") }
+
+// TestGobRPCClientWireCompat proves the net/rpc-free gobRPCClient speaks the
+// exact net/rpc wire protocol: it drives a real net/rpc server over a pipe,
+// including the error path (whose empty body must be discarded so the stream
+// stays aligned for the next call).
+func TestGobRPCClientWireCompat(t *testing.T) {
+	srv := rpc.NewServer()
+	require.NoError(t, srv.RegisterName("Svc", echoSvc{}))
+
+	a, b := net.Pipe()
+	go srv.ServeConn(a)
+	defer a.Close() //nolint:errcheck
+
+	client := newGobRPCClient(b)
+	defer client.Close() //nolint:errcheck
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var out string
+		in := "hi"
+
+		require.NoError(t, client.Call("Svc.Echo", &in, &out))
+		require.Equal(t, "echo:hi", out)
+
+		// Error path: the server's empty error body must be discarded.
+		require.EqualError(t, client.Call("Svc.Fail", &in, &out), "boom")
+
+		// The stream is still aligned — a follow-up call works.
+		out = ""
+		require.NoError(t, client.Call("Svc.Echo", &in, &out))
+		require.Equal(t, "echo:hi", out)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out — gob stream likely misaligned")
+	}
+}


### PR DESCRIPTION
Makes the wasm hypervisor (`cmd/dmsg-wasm`) compile **and run** under **TinyGo** (net/http-free), adds browser WebTransport + WebRTC transports, fixes the seeded dmsg client's discovery registration, and begins the visor→wasm port. Everything new is build-tag-gated to `wasm`/`tinygo`; **native builds are unaffected** (verified across `go build ./...`, std-Go js/wasm, and `tinygo build -target wasm`).

## TinyGo wasm hypervisor — net/http-free (6.5 MB vs 21.6 MB; 2.4 MB gzipped)
`net/http` is broken on the TinyGo js target and can't be forked, so it's removed from the graph. Three pulls, each split native/tinygo:
- **net/rpc** → `pkg/wasmhv/gobrpc.go` (wire-compatible gob client, tested vs a real net/rpc server) + noise `RPCClientDialer` split.
- **discovery over dmsg** → `dmsgclient.dmsgDiscClient` speaks HTTP/1.1 straight over a dmsg stream (`httpdmsg.go`, tested vs a real net/http server); seeded.go/cli split.
- **coder/websocket** (pulls net/http via `Dial`) → `ws_js_tinygo.go` dials the browser WebSocket via `syscall/js` as a deadline-aware `net.Conn`.

## Browser p2p transports
- **WebTransport** dmsg carrier (`wt_js_tinygo.go`), CA-free cert-hash pin.
- **WebRTC DataChannel** (`cmd/dmsg-wasm/webrtc_js.go`) — first true p2p; **dmsg is the signaling plane**.

## dmsg discovery registration fix
The seeded (browser/standalone) client connected but never **registered** in dmsg-discovery — it resolved its own PK from a synthetic direct-client entry, so both register paths thought it already existed. Fix: `seededDiscClient` talks to the real discovery for register/resolve/server-list (shortcut only for discovery PK + seed servers); `setDiscoveryClients` nudges a re-publish on the bootstrap→real swap. Validated in-browser.

## Browser-runtime validated
Via an autonomous control bridge (`cmd/dmsg-wasm/serve.go`) driving real tabs: connect, dmsg dial/listen + bidirectional data, HTTP-over-dmsg, in-wasm hypervisor, **discovery registration** (`PostEntry 200`), and WebRTC signaling + ICE negotiation all confirmed. (WebRTC connection *completion* is blocked only by same-machine/same-NAT mDNS+hairpin — topology, not code.) Fixes found this way: TinyGo `getRandomData` shim, a `return m, Unmarshal(&m)` eval-order bug, ICE candidate buffering.

## Visor→wasm port (design + phase 1)
`docs/design/wasm-visor-p2p.md` + `cmd/wasm-visor-probe` map the frontier; `pkg/routing` + `pkg/visor/visorconfig` already compile under TinyGo. Phase 1 (carrier split: quic/sudph/stun tagged `!tinygo`) is included. The rest (AR/appevent restructure network→transport→visor, net/http-free RF/TPD/AR, net/rpc removal, in-process apps) is scoped as a follow-on — not in this PR.