### PR TITLE
feat(transport): compile the transport Manager under TinyGo (wasm)

### DIFF
--- a/cmd/wasm-visor-probe/main.go
+++ b/cmd/wasm-visor-probe/main.go
@@ -17,10 +17,13 @@
 //	                            //go:build !tinygo; ClientFactory.ARClient is `any`
 //	                            and EB is a local interface so addrresolver/appevent
 //	                            stay out of the graph. TCP tuning is build-tagged.
+//	   pkg/transport          — the transport Manager + ManagedTransport. DiscoveryClient
+//	                            is an abstract interface (no net/http here); the AR
+//	                            client (addrresolver) and event broadcaster (appevent)
+//	                            are typed `any`, ARClient() and the disc-404 check are
+//	                            build-tagged so net/http + net/rpc stay native-only.
 //
 //	⛔ BLOCKED (blocker → fix):
-//	   pkg/transport          net/http (TPD client) + net/rpc — net/http-free TPD
-//	                          client (FetchOverDmsg) + tag/abstract the net/rpc bits
 //	   pkg/router             net/http (routefinder) + net/rpc (cascade_source RSN)
 //	   pkg/app/appnet         net/http + net/rpc
 //	   pkg/app/appevent       net/rpc — app↔visor event channel
@@ -33,6 +36,7 @@ import (
 	"fmt"
 
 	_ "github.com/skycoin/skywire/pkg/routing"
+	_ "github.com/skycoin/skywire/pkg/transport"
 	_ "github.com/skycoin/skywire/pkg/transport/network"
 	_ "github.com/skycoin/skywire/pkg/visor/visorconfig"
 )

--- a/pkg/transport/disc_notfound_native.go
+++ b/pkg/transport/disc_notfound_native.go
@@ -1,0 +1,18 @@
+//go:build !tinygo
+
+package transport
+
+import (
+	"net/http"
+
+	"github.com/skycoin/skywire/pkg/httputil"
+)
+
+// isDiscNotFound reports whether err is a transport-discovery "404 Not Found"
+// response — meaning the entry is already gone, so a status update targeting it
+// can be treated as a no-op success. Lives in a native-only file because
+// httputil/net/http are excluded from the TinyGo graph.
+func isDiscNotFound(err error) bool {
+	httpErr, ok := err.(*httputil.HTTPError)
+	return ok && httpErr.Status == http.StatusNotFound
+}

--- a/pkg/transport/disc_notfound_tinygo.go
+++ b/pkg/transport/disc_notfound_tinygo.go
@@ -1,0 +1,8 @@
+//go:build tinygo
+
+package transport
+
+// isDiscNotFound is the TinyGo stub. The native build matches a discovery 404 via
+// httputil.HTTPError (net/http), which is excluded here; under TinyGo a status
+// update never reaches an HTTP discovery, so there is no 404 to special-case.
+func isDiscNotFound(err error) bool { return false }

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -16,9 +15,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/cipher"
-	"github.com/skycoin/skywire/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/routing"
@@ -50,8 +47,10 @@ var (
 
 // ManagedTransportConfig is a configuration for managed transport.
 type ManagedTransportConfig struct {
-	client          network.Client
-	ebc             *appevent.Broadcaster
+	client network.Client
+	// ebc is the app-event broadcaster (*appevent.Broadcaster on native builds);
+	// typed `any` to keep appevent (net/rpc) out of the TinyGo graph.
+	ebc             any
 	DC              DiscoveryClient
 	LS              LogStore
 	RemotePK        cipher.PubKey
@@ -764,7 +763,7 @@ func (mt *ManagedTransport) deleteFromDiscovery() error {
 				Warn("Failed to update transport status.")
 			return err
 		}
-		if httpErr, ok := err.(*httputil.HTTPError); ok && httpErr.Status == http.StatusNotFound {
+		if isDiscNotFound(err) {
 			return nil
 		}
 		return err

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -12,14 +12,12 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport/network"
-	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
 	tspec "github.com/skycoin/skywire/pkg/transport/spec"
 	types "github.com/skycoin/skywire/pkg/transport/types"
 )
@@ -59,9 +57,15 @@ type RouteChecker func(tpID uuid.UUID) bool
 type Manager struct {
 	Logger   *logging.Logger
 	Conf     *ManagerConfig
-	tps      map[uuid.UUID]*ManagedTransport
-	arClient addrresolver.APIClient
-	ebc      *appevent.Broadcaster
+	tps map[uuid.UUID]*ManagedTransport
+	// arClient is the address-resolver client (addrresolver.APIClient on native
+	// builds). Typed `any` so addrresolver — which pulls net/http — stays out of
+	// the TinyGo graph; recover it via the build-tagged ARClient() getter.
+	arClient any
+	// ebc is the app-event broadcaster (*appevent.Broadcaster on native builds).
+	// Typed `any` so appevent (net/rpc) stays out of the TinyGo graph; it is only
+	// stored and forwarded, never method-called here.
+	ebc any
 
 	readCh chan routing.Packet
 	mx     sync.RWMutex
@@ -130,7 +134,11 @@ type Manager struct {
 
 // NewManager creates a Manager with the provided configuration and transport factories.
 // 'factories' should be ordered by preference.
-func NewManager(log *logging.Logger, arClient addrresolver.APIClient, ebc *appevent.Broadcaster, config *ManagerConfig, factory network.ClientFactory) (*Manager, error) {
+// arClient must be an addrresolver.APIClient (native builds); ebc an
+// *appevent.Broadcaster. Both are typed `any` to keep addrresolver (net/http)
+// and appevent (net/rpc) out of the TinyGo graph — concrete callers are
+// unaffected since a concrete value satisfies `any`.
+func NewManager(log *logging.Logger, arClient any, ebc any, config *ManagerConfig, factory network.ClientFactory) (*Manager, error) {
 	if log == nil {
 		log = logging.MustGetLogger("tp_manager")
 	}
@@ -602,10 +610,8 @@ func (tm *Manager) checkARLimit() {
 		tm.arDeregisteredMu.Unlock()
 		tm.Logger.WithField("count", count).WithField("limit", limit).
 			Info("AR transport limit reached — deregistering from address resolver")
-		if tm.arClient != nil {
-			if err := tm.arClient.Close(); err != nil {
-				tm.Logger.WithError(err).Warn("Failed to close AR client during deregistration")
-			}
+		if err := tm.closeARClient(); err != nil {
+			tm.Logger.WithError(err).Warn("Failed to close AR client during deregistration")
 		}
 	} else {
 		tm.arDeregisteredMu.Unlock()
@@ -1042,9 +1048,14 @@ func (tm *Manager) GetTransportsByLabels(labels ...Label) []*ManagedTransport {
 	return trs
 }
 
-// ARClient returns the address resolver client used by this transport manager.
-func (tm *Manager) ARClient() addrresolver.APIClient {
-	return tm.arClient
+// closeARClient closes the address-resolver client if one is set. arClient is
+// typed `any` (to keep addrresolver out of the TinyGo graph), so recover the
+// Close method via an interface assert; a nil or non-closer arClient is a no-op.
+func (tm *Manager) closeARClient() error {
+	if c, ok := tm.arClient.(interface{ Close() error }); ok {
+		return c.Close()
+	}
+	return nil
 }
 
 // SaveTransportOptions contains options for transport creation.
@@ -1360,8 +1371,7 @@ func (tm *Manager) Close() {
 			tm.Logger.WithError(err).Warnf("Failed to close %s client", client.Type())
 		}
 	}
-	err := tm.arClient.Close()
-	if err != nil {
+	if err := tm.closeARClient(); err != nil {
 		tm.Logger.WithError(err).Warnf("Failed to close arClient")
 	}
 	tm.wg.Wait()

--- a/pkg/transport/manager_ar_native.go
+++ b/pkg/transport/manager_ar_native.go
@@ -1,0 +1,14 @@
+//go:build !tinygo
+
+package transport
+
+import "github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+
+// ARClient returns the address resolver client used by this transport manager.
+// arClient is stored as `any` (see Manager.arClient) to keep addrresolver — and
+// its net/http dependency — out of the TinyGo graph; this native getter recovers
+// the concrete type so existing callers are unchanged.
+func (tm *Manager) ARClient() addrresolver.APIClient {
+	c, _ := tm.arClient.(addrresolver.APIClient)
+	return c
+}

--- a/pkg/transport/manager_ar_tinygo.go
+++ b/pkg/transport/manager_ar_tinygo.go
@@ -1,0 +1,11 @@
+//go:build tinygo
+
+package transport
+
+// ARClient returns the address resolver client as an untyped value. Under TinyGo
+// addrresolver is excluded from the build (it pulls net/http), so there is no
+// concrete return type to expose; callers that need the resolver are themselves
+// native-only.
+func (tm *Manager) ARClient() any {
+	return tm.arClient
+}


### PR DESCRIPTION
## What

Brings `pkg/transport` (the transport **Manager** + **ManagedTransport**) into the TinyGo/browser build graph, advancing the wasm visor port one layer past `pkg/transport/network` (#3207).

## How

The package had exactly two TinyGo-hostile dependencies; both are **decoupled**, not ported:

- **`arClient`** (`addrresolver.APIClient`, pulls `net/http`) and **`ebc`** (`*appevent.Broadcaster`, pulls `net/rpc`) become `any`-typed fields. A concrete value satisfies `any`, so `NewManager`'s signature change **ripples to zero callers**.
- **`ARClient()`** getter is build-tagged: native returns `addrresolver.APIClient` (the 4 visor callers in `autoconnect.go`/`api_ar.go` are unchanged), TinyGo returns `any`.
- `arClient.Close()` now goes through an interface assert (`closeARClient`).
- `managed_transport.go`'s only `net/http` use — matching a discovery 404 via `httputil.HTTPError` — moves behind a build-tagged `isDiscNotFound` helper (native: the real check; tinygo: `false`).

`DiscoveryClient` is already an **abstract interface** in this package, so the concrete TPD HTTP client never enters the graph.

## Verification

- `cmd/wasm-visor-probe` now imports `pkg/transport`; `tinygo build -target wasm ./cmd/wasm-visor-probe` passes.
- The `js/wasm`+`tinygo` dep graph is free of `net/http`, `net/rpc`, `addrresolver`, and `appevent` (verified with `GOOS=js GOARCH=wasm go list -tags tinygo -deps`).
- Native `go build ./...`, `go vet ./pkg/transport/...`, and `go test ./pkg/transport/...` all pass unchanged.

## Frontier after this PR

```
✅ pkg/routing, pkg/visor/visorconfig, pkg/transport/network, pkg/transport
⛔ pkg/router (net/http routefinder + net/rpc cascade_source), pkg/app/appnet, pkg/app/appevent, pkg/visor
```