### PR TITLE
refactor(routing): un-exclude core routing types from the js/wasm build

### DIFF
--- a/pkg/routing/cascade.go
+++ b/pkg/routing/cascade.go
@@ -1,12 +1,4 @@
-//go:build !js
-
 // Package routing pkg/routing/cascade.go
-//
-// Build-tag-gated off the WASM path because it imports
-// github.com/google/uuid (which transitively pulls encoding/json
-// and the reflect runtime helpers TinyGo's stdlib lacks).
-// CascadeSetup is data-plane runtime; the WASM install-page graph
-// only needs the primitive routing.Port type from addr.go.
 //
 // CascadeSetup and CascadeAck define the wire format for the cascade
 // route setup protocol. Messages are nested (Russian-doll style) so

--- a/pkg/routing/route.go
+++ b/pkg/routing/route.go
@@ -1,13 +1,5 @@
-//go:build !js
-
 // Package routing defines routing related entities and management
 // operations.
-//
-// route.go is build-tag-gated off the WASM path because it imports
-// encoding/json (Route.String / EdgeRules.String render via
-// json.MarshalIndent) and github.com/google/uuid (transitively
-// from rule.go). The install-page WASM only needs routing.Port
-// from addr.go.
 package routing
 
 import (

--- a/pkg/routing/rule.go
+++ b/pkg/routing/rule.go
@@ -1,11 +1,4 @@
-//go:build !js
-
 // Package routing pkg/routing/rule.go
-//
-// Build-tag-gated off the WASM path because it imports
-// github.com/google/uuid (which transitively pulls encoding/json
-// and reflect helpers TinyGo's stdlib lacks). Rules are router
-// data-plane state; the WASM install-page graph doesn't need them.
 package routing
 
 import (

--- a/pkg/routing/table.go
+++ b/pkg/routing/table.go
@@ -1,13 +1,4 @@
-//go:build !js
-
 // Package routing pkg/routing/table.go
-//
-// Build-tag-gated off the WASM path because it imports
-// github.com/google/uuid (transitive encoding/json + reflect
-// helpers TinyGo's stdlib lacks) and pkg/logging (logrus
-// transitively pulls encoding/json too). Routing tables are
-// router data-plane state; the WASM install-page graph
-// doesn't reach this code.
 package routing
 
 import (


### PR DESCRIPTION
## Why

`route.go`, `rule.go`, `table.go`, and `cascade.go` were `//go:build !js`, gating `Route`/`Hop`/`PathEdges`/`Rule`/`Table`/`CascadeSetup` off **every** js/wasm build. This blocks the wasm-visor port (continuing #3207/#3208/#3209/#3210) — the browser router needs these core types.

The stated reason in those file headers — TinyGo's stdlib "lacks" `encoding/json` + reflect helpers and `google/uuid` won't compile — is **obsolete**: TinyGo 0.41 compiles `encoding/json`, `reflect`, `logrus`, and `google/uuid`. That's already what the dmsg client (`make tinygo-dmsg`) and `pkg/gobrpc` rely on.

The exclusion was historically there because the tpviz install-page wasm only needed `routing.Port` from `addr.go`. But **the install page doesn't import `pkg/routing` at all** — `GOOS=js GOARCH=wasm go list -deps ./pkg/tpviz/wasm` shows zero `pkg/routing` — so the gate protects no shipped bundle.

## What

Drop the `!js` build tags from the four files (and correct the now-false header comments).

## Verification

- Native `go build ./...`, `go vet ./pkg/routing`, `go test ./pkg/routing`, and lint: unchanged.
- `GOOS=js GOARCH=wasm go build ./pkg/routing`: succeeds.
- A probe referencing `routing.Hop`/`Route`/`Rule`/`Table` + `google/uuid` compiles under `tinygo build -target wasm`.
- No `//go:build js` counterpart files exist in `pkg/routing`, so no duplicate-symbol conflicts.

## Unrelated note

While verifying, I found the **tpviz install-page wasm build is already broken on develop** (`undefined: shortPK` in `pkg/tpviz/wasm/ui`) — pre-existing and independent of this change. Flagging separately.