### PR TITLE
fix(tpviz): restore shortPK helper — unbreak the install-page wasm build

### DIFF
--- a/pkg/tpviz/wasm/ui/graph.go
+++ b/pkg/tpviz/wasm/ui/graph.go
@@ -463,6 +463,17 @@ func (o *RenderOptions) ShowNodeStatus(s NodeStatus) bool {
 
 // Helper functions
 
+// shortPK returns the first 8 hex chars of a public key for compact on-canvas
+// graph-node and HTML sidebar labels (callers typically append "…"). This is
+// display-only truncation in the visualizer UI — it is NOT for logs, where
+// public keys must always be rendered in full.
+func shortPK(pk string) string {
+	if len(pk) <= 8 {
+		return pk
+	}
+	return pk[:8]
+}
+
 // itoa converts int to string without fmt
 func itoa(i int) string {
 	if i == 0 {


### PR DESCRIPTION
## Problem

`GOOS=js GOARCH=wasm go build ./pkg/tpviz/wasm` (the `make tpviz-wasm` target) currently **fails on develop**:

```
pkg/tpviz/wasm/ui/app.go:1441:98: undefined: shortPK
pkg/tpviz/wasm/ui/data.go:242:26: undefined: shortPK
... (13 call sites across app/data/fetch/render/sidebar)
```

`shortPK` was removed in the public-key-truncation cleanup (#2393), but its call sites in the visualizer UI remained. CI builds/lints the **native** target, so this js-only break went unnoticed.

## Fix

`shortPK` is **display-only** truncation for compact on-canvas graph-node and HTML sidebar labels (callers append `"…"`) — not logging, where keys must stay full. Restore it (first 8 hex chars) where it used to live in `graph.go`, next to `itoa`.

## Verification

- `GOOS=js GOARCH=wasm go build ./pkg/tpviz/wasm` now succeeds.

## Notes

- The optional `make tpviz-wasm-tinygo` target still fails on the **known** TinyGo js `net/http` `roundtrip_js.go` bug — separate and pre-existing.
- Restoring the build unmasks ~21 pre-existing lint findings in this js-only package (previously hidden behind the typecheck failure); left untouched to keep this fix focused.