### PR TITLE
feat(wasm-visor): browser runtime-test harness + step instrumentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,11 +231,12 @@ tinygo-dmsg-wasm: ## Build the browser WASM dmsg client with TinyGo (~6.5MB vs ~
 	cp ./cmd/dmsg-wasm/index.html ./build/dmsg-wasm/
 	@echo "built ./build/dmsg-wasm (TinyGo) — serve it: 'go run cmd/dmsg-wasm/serve.go' then open http://localhost:8085/"
 
-tinygo-wasm-visor: ## Build the browser WASM visor edge (dmsg+transport+router+appserver) with TinyGo into build/wasm-visor
+tinygo-wasm-visor: ## Build the browser WASM visor edge (dmsg+transport+router+appserver) + dev harness into build/wasm-visor
 	mkdir -p ./build/wasm-visor
 	tinygo build -target wasm -o ./build/wasm-visor/wasm-visor.wasm ./cmd/wasm-visor
-	cp "$$(tinygo env TINYGOROOT)/targets/wasm_exec.js" ./build/wasm-visor/
-	@echo "built ./build/wasm-visor (TinyGo) — the browser visor EDGE assembly (skywireVisor.boot/status)"
+	cp "$$(tinygo env TINYGOROOT)/targets/wasm_exec.js" ./build/wasm-visor/wasm_exec_tinygo.js
+	cp ./cmd/wasm-visor/index.html ./build/wasm-visor/
+	@echo "built ./build/wasm-visor (TinyGo) — serve it: 'go run cmd/dmsg-wasm/serve.go -dir build/wasm-visor' then open http://localhost:8085/"
 
 dmsg-wasm-hv: ## Build the browser hypervisor-over-dmsg bundle (Service Worker proxy) into build/dmsg-wasm-hv
 	mkdir -p ./build/dmsg-wasm-hv

--- a/cmd/wasm-visor/index.html
+++ b/cmd/wasm-visor/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<!--
+  cmd/wasm-visor dev harness — loads wasm_exec_tinygo.js + wasm-visor.wasm and
+  exercises globalThis.skywireVisor (boot/status). Connects back to the
+  cmd/dmsg-wasm serve.go control bridge (SSE /ctl/events) so a shell can drive
+  the tab:  curl -s localhost:8085/ctl/tabs
+            curl -s -XPOST 'localhost:8085/ctl/cmd?tab=<id>' \
+                 -d '{"action":"boot","args":["","<seedPK>","<seedWS>","<discDmsgAddr>"]}'
+            curl -s 'localhost:8085/ctl/log?tab=<id>'
+  Serve it from the same dir as serve.go's -dir (drop this + wasm-visor.wasm +
+  wasm_exec_tinygo.js into build/dmsg-wasm/, open http://localhost:8085/visor.html).
+-->
+<html>
+<head><meta charset="utf-8"><title>wasm-visor</title></head>
+<body style="font-family:monospace;background:#111;color:#ddd;padding:1em">
+<h3>skywire wasm-visor (edge)</h3>
+<div>
+  sk <input id="sk" size="10" placeholder="(empty = ephemeral)">
+  seedPK <input id="seedpk" size="20" value="0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13">
+  seedWS <input id="seedws" size="30" value="ws://45.79.213.251:30088/dmsg">
+  disc <input id="disc" size="20" value="dmsg://022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa:80">
+  <button onclick="doBoot()">boot</button>
+  <button onclick="doStatus()">status</button>
+</div>
+<pre id="out" style="white-space:pre-wrap;max-height:70vh;overflow:auto"></pre>
+
+<script src="wasm_exec_tinygo.js"></script>
+<script>
+  const out = document.getElementById("out");
+  const log = (...a) => { out.textContent += a.join(" ") + "\n"; out.scrollTop = out.scrollHeight; };
+
+  const go = new Go();
+  // TinyGo's wasm_exec.js omits the gojs runtime.getRandomData import that the
+  // crypto-using Go runtime needs to seed itself; inject it only when absent.
+  if (go.importObject.gojs && !go.importObject.gojs["runtime.getRandomData"]) {
+    go.importObject.gojs["runtime.getRandomData"] = (ptr, len) =>
+      crypto.getRandomValues(new Uint8Array(go._inst.exports.memory.buffer, ptr >>> 0, len >>> 0));
+  }
+  fetch("wasm-visor.wasm").then(r => r.arrayBuffer())
+    .then(buf => WebAssembly.instantiate(buf, go.importObject))
+    .then(res => {
+      go.run(res.instance);
+      log("wasm loaded; skywireVisor ready: " + Object.keys(globalThis.skywireVisor || {}).join(", "));
+    })
+    .catch(e => log("wasm load error: " + e));
+
+  async function doBoot() {
+    try {
+      const pk = await skywireVisor.boot(
+        document.getElementById("sk").value.trim(),
+        document.getElementById("seedpk").value.trim(),
+        document.getElementById("seedws").value.trim(),
+        document.getElementById("disc").value.trim());
+      log("booted pk=" + pk);
+    } catch (e) { log("boot error: " + (e.message || e)); }
+  }
+  function doStatus() { log("status: " + JSON.stringify(skywireVisor.status())); }
+
+  // ---- control bridge (drives this tab from a shell via serve.go) ----
+  (function () {
+    let tabId = sessionStorage.getItem("ctlTabId");
+    if (!tabId) { tabId = "visor-" + Math.random().toString(36).slice(2, 8); sessionStorage.setItem("ctlTabId", tabId); }
+    log("control tab id: " + tabId);
+    const post = (path, body) =>
+      fetch(path, { method: "POST", body: typeof body === "string" ? body : JSON.stringify(body) }).catch(() => {});
+    const clog = (...a) => { log(...a); post("/ctl/log?tab=" + tabId, a.join(" ")); };
+    window.__skylog = m => clog("[dmsg] " + m);
+
+    async function exec(c) {
+      const a = c.args || [];
+      switch (c.action) {
+        case "boot":
+          return await skywireVisor.boot(a[0] || "", a[1] || "", a[2] || "", a[3] || "");
+        case "status":
+          return skywireVisor.status();
+        case "reload":
+          post("/ctl/log?tab=" + tabId, "reloading");
+          setTimeout(() => location.reload(), 150);
+          return "reloading";
+        default: throw new Error("unknown action: " + c.action);
+      }
+    }
+
+    const readyPoll = setInterval(() => {
+      if (window.skywireVisor && skywireVisor.boot) { clearInterval(readyPoll); clog("skywireVisor READY " + tabId); }
+    }, 200);
+
+    const es = new EventSource("/ctl/events?tab=" + tabId);
+    es.onmessage = async (ev) => {
+      const c = JSON.parse(ev.data);
+      try { const v = await exec(c); post("/ctl/result", { id: c.id, ok: true, value: v }); }
+      catch (e) { post("/ctl/result", { id: c.id, ok: false, error: e.message || String(e) }); }
+    };
+    es.onerror = () => {};
+  })();
+</script>
+</body>
+</html>

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -15,9 +15,22 @@
 // JS API on globalThis.skywireVisor:
 //
 //	const pk = await skywireVisor.boot(skHexOrEmpty, seedPkHex, seedWsURL, discDmsgAddr)
-//	skywireVisor.status()  // → { pk, transports, routes }
+//	skywireVisor.status()  // → { pk, booted, dmsg, tpManager, router, procManager, transports, routes }
 //
-// Build: tinygo build -target wasm -o wasm-visor.wasm ./cmd/wasm-visor
+// Build + run the dev harness (index.html drives boot/status/reload, and connects
+// back to the cmd/dmsg-wasm serve.go control bridge so a shell can drive the tab):
+//
+//	make tinygo-wasm-visor                       # → build/wasm-visor/
+//	go run cmd/dmsg-wasm/serve.go -dir build/wasm-visor
+//	# open http://localhost:8085/ , then drive from a shell:
+//	curl -s localhost:8085/ctl/tabs
+//	curl -s -XPOST 'localhost:8085/ctl/cmd?tab=<id>' \
+//	     -d '{"action":"boot","args":["","<seedPK>","<seedWS>","<discDmsgAddr>"]}'
+//	curl -s 'localhost:8085/ctl/log?tab=<id>'
+//
+// bootEdge emits vlog() step markers through the __skylog bridge so each
+// subsystem's progress is visible in /ctl/log — that is what pinned the
+// router.New TinyGo-reflect hang documented below.
 package main
 
 import (
@@ -37,6 +50,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/router"
+	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/transport/network"
 )
@@ -50,6 +64,16 @@ var (
 	rtr    router.Router
 	procM  appserver.ProcManager
 )
+
+// vlog emits a step message to the browser console AND, when present, the
+// __skylog bridge the dev harness wires to /ctl/log — so boot progress is
+// visible from the shell.
+func vlog(msg string) {
+	fmt.Println("[visor] " + msg)
+	if h := js.Global().Get("__skylog"); h.Type() == js.TypeFunction {
+		h.Invoke("[visor] " + msg)
+	}
+}
 
 func main() {
 	ctx = context.Background()
@@ -76,12 +100,23 @@ func jsBoot(_ js.Value, args []js.Value) interface{} {
 	})
 }
 
-// jsStatus() → { pk, transports, routes }.
+// jsStatus() → { pk, booted, dmsg, tpManager, router, procManager, transports, routes }.
+// The boolean subsystem flags make a fully-initialized edge distinguishable from
+// a half-boot (where a Serve() tripped and left a subsystem nil).
 func jsStatus(js.Value, []js.Value) interface{} {
-	st := map[string]interface{}{"pk": "", "transports": 0, "routes": 0}
+	st := map[string]interface{}{
+		"pk": "", "booted": false,
+		"dmsg": false, "tpManager": false, "router": false, "procManager": false,
+		"transports": 0, "routes": 0,
+	}
 	if !selfPK.Null() {
 		st["pk"] = selfPK.Hex()
 	}
+	st["dmsg"] = dmsgC != nil
+	st["tpManager"] = tpM != nil
+	st["router"] = rtr != nil
+	st["procManager"] = procM != nil
+	st["booted"] = dmsgC != nil && tpM != nil && rtr != nil && procM != nil
 	if tpM != nil {
 		st["transports"] = tpM.TransportCount()
 	}
@@ -108,11 +143,13 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 		return pk, fmt.Errorf("bad seed server pk: %w", err)
 	}
 	seed := &disc.Entry{Version: "0.0.1", Static: seedPK, Server: &disc.Server{AddressWS: seedWSURL}}
+	vlog("dmsg: connecting…")
 	c, _, err := dmsgclient.StartDmsgSeeded(ctx, mLog.PackageLogger("dmsg"), pk, sk, []*disc.Entry{seed}, discDmsgAddr, true)
 	if err != nil {
 		return pk, fmt.Errorf("dmsg: %w", err)
 	}
 	dmsgC = c
+	vlog("dmsg: ok")
 
 	// 2. transport manager (dmsg-only; no AR, no TPD registration yet).
 	eb := appevent.NewBroadcaster(mLog.PackageLogger("eb"), time.Second)
@@ -128,29 +165,52 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 		return pk, fmt.Errorf("transport manager: %w", err)
 	}
 	tpM = tm
+	vlog("tp_manager: ok; init dmsg client…")
 	tm.InitDmsgClient(ctx, dmsgC)
+	vlog("tp_manager: dmsg client inited; serving…")
 	go tm.Serve(ctx)
+	vlog("tp_manager: serving")
 
 	// 3. edge router (receives route rules + forwards/consumes packets). nil
 	// RouteFinder/RouteGroupDialer → the route-SOURCE path is the build-tagged
-	// TinyGo stub (a browser leaf does not originate routes).
-	rConf := &router.Config{
-		Logger:           mLog.PackageLogger("router"),
-		MasterLogger:     mLog,
-		PubKey:           pk,
-		SecKey:           sk,
-		TransportManager: tm,
+	// TinyGo stub (a browser leaf does not originate routes). We open the dmsg
+	// setup listener here and pass it as AwaitSetupListener.
+	vlog("router: dmsg Listen(setup :136)…")
+	setupLis, lerr := dmsgC.Listen(skyenv.DmsgAwaitSetupPort)
+	if lerr != nil {
+		return pk, fmt.Errorf("setup listen: %w", lerr)
 	}
+	vlog("router: setup listener ok")
+	// KNOWN RUNTIME LIMITATION (validated 2026-06-22 via this harness):
+	// router.New() HANGS under TinyGo at rpcSrv.Register(NewRPCGateway). gobimpl's
+	// reflection-based server calls reflect.Type.Method(i), which TinyGo's runtime
+	// reflect does not support — NumMethod() works but Method(i) never returns, so
+	// boot stops at "router: New…". The dmsg + transport.Manager layers above are
+	// validated working in-browser. Fix = a reflection-free gobrpc server (explicit
+	// handler map instead of method enumeration + Value.Call). See
+	// docs/design/wasm-visor-p2p.md.
+	vlog("router: New… (NOTE: hangs under TinyGo until the gobrpc server is reflection-free)")
+	rConf := &router.Config{
+		Logger:             mLog.PackageLogger("router"),
+		MasterLogger:       mLog,
+		PubKey:             pk,
+		SecKey:             sk,
+		TransportManager:   tm,
+		AwaitSetupListener: setupLis,
+	}
+	vlog("router: New…")
 	r, err := router.New(dmsgC, rConf, nil)
 	if err != nil {
 		return pk, fmt.Errorf("router: %w", err)
 	}
 	rtr = r
+	vlog("router: New ok; serving…")
 	go func() {
 		if err := r.Serve(ctx); err != nil {
 			mLog.PackageLogger("router").WithError(err).Error("router.Serve returned")
 		}
 	}()
+	vlog("router: serving")
 
 	// 4. in-process app server (RunModeInternal). No app registered yet — the
 	// in-process skychat AppFunc is the next step.


### PR DESCRIPTION
## What

A reproducible in-browser test harness for `cmd/wasm-visor`, plus the step-instrumentation that runtime-validated the edge assembly (#3218) and pinned its one runtime blocker.

- **`cmd/wasm-visor/index.html`** — a dev page that loads the TinyGo visor wasm (with the `getRandomData` shim) and connects back to the `cmd/dmsg-wasm` `serve.go` control bridge (SSE `/ctl/events`), so a shell can drive `boot`/`status`/`reload` on the tab via `curl /ctl/cmd`. Pre-filled with a known WS dmsg server.
- **`vlog()`** — emits boot step markers through the `__skylog` bridge to `/ctl/log`, so each subsystem's progress is visible from the shell.
- **Enriched `skywireVisor.status()`** — adds `booted`/`dmsg`/`tpManager`/`router`/`procManager` booleans, distinguishing a full boot from a half-boot (which is what surfaced the hang).
- **Makefile `tinygo-wasm-visor`** — also stages `index.html` + `wasm_exec_tinygo.js`; serve with `go run cmd/dmsg-wasm/serve.go -dir build/wasm-visor`.

## Validated in-browser with this harness

The 8.4 MB TinyGo visor **loads**, `boot()` **runs**, the dmsg client **connects + registers in discovery**, and `transport.Manager` **serves**. It then **hangs at `router.New()`** → root-caused to gobimpl's reflection-based RPC server calling `reflect.Type.Method(i)`, which **TinyGo's runtime reflect does not support** (`NumMethod` works, `Method(i)` never returns). `bootEdge` documents this **known runtime limitation** inline; the fix is a reflection-free gobrpc server (next PR).

## Verification

- `tinygo build -target wasm` passes.
- Native `go build ./...` unaffected (`//go:build js && wasm`).