### PR TITLE
fix(gobrpc): reflection-free server so the wasm-visor edge boots in-browser

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -41,7 +41,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/skycoin/skywire/pkg/app/appdisc"
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -116,7 +115,11 @@ func jsStatus(js.Value, []js.Value) interface{} {
 	st["tpManager"] = tpM != nil
 	st["router"] = rtr != nil
 	st["procManager"] = procM != nil
-	st["booted"] = dmsgC != nil && tpM != nil && rtr != nil && procM != nil
+	// The EDGE is dmsg + transport + router (rule reception + packet forwarding).
+	// procManager (in-process app hosting) is a separate, later concern — it
+	// net.Listen("tcp")s, which a browser can't do, so it is not on the edge
+	// boot path yet.
+	st["booted"] = dmsgC != nil && tpM != nil && rtr != nil
 	if tpM != nil {
 		st["transports"] = tpM.TransportCount()
 	}
@@ -181,15 +184,12 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 		return pk, fmt.Errorf("setup listen: %w", lerr)
 	}
 	vlog("router: setup listener ok")
-	// KNOWN RUNTIME LIMITATION (validated 2026-06-22 via this harness):
-	// router.New() HANGS under TinyGo at rpcSrv.Register(NewRPCGateway). gobimpl's
-	// reflection-based server calls reflect.Type.Method(i), which TinyGo's runtime
-	// reflect does not support — NumMethod() works but Method(i) never returns, so
-	// boot stops at "router: New…". The dmsg + transport.Manager layers above are
-	// validated working in-browser. Fix = a reflection-free gobrpc server (explicit
-	// handler map instead of method enumeration + Value.Call). See
-	// docs/design/wasm-visor-p2p.md.
-	vlog("router: New… (NOTE: hangs under TinyGo until the gobrpc server is reflection-free)")
+	// router.New() used to HANG here under TinyGo: it registers the setup RPC
+	// gateway, and gobimpl's reflection-based server called reflect.Type.Method(i),
+	// which TinyGo's runtime reflect doesn't support (NumMethod works, Method(i)
+	// never returns). Fixed by the reflection-free gobrpc server — the router now
+	// registers explicit handlers under TinyGo (router_setup_rpc_tinygo.go) instead
+	// of reflection. Validated in-browser via this harness.
 	rConf := &router.Config{
 		Logger:             mLog.PackageLogger("router"),
 		MasterLogger:       mLog,
@@ -212,15 +212,18 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	}()
 	vlog("router: serving")
 
-	// 4. in-process app server (RunModeInternal). No app registered yet — the
-	// in-process skychat AppFunc is the next step.
-	pm, err := appserver.NewProcManager(mLog, &appdisc.Factory{}, eb, ":0", "")
-	if err != nil {
-		return pk, fmt.Errorf("proc manager: %w", err)
-	}
-	procM = pm
-
+	// EDGE booted: dmsg + transport + router are up. The tab now receives route
+	// rules and forwards/consumes packets — a routable skynet edge.
+	vlog("EDGE booted: dmsg + transport + router up")
 	fmt.Printf("wasm-visor: edge booted pk=%s\n", pk.Hex())
+
+	// 4. in-process app server (RunModeInternal) — DEFERRED (procM stays nil).
+	// appserver.NewProcManager net.Listen("tcp")s for the external-app IPC
+	// ingress, which a browser cannot do (it blocks under TinyGo/js). In-process
+	// skychat needs a browser-adapted ProcManager (no TCP ingress; net.Pipe
+	// in-process conns only) — the next step toward "edge + in-process skychat".
+	// Wiring NewProcManager here would hang the boot.
+
 	return pk, nil
 }
 

--- a/pkg/gobrpc/gobimpl/gobimpl.go
+++ b/pkg/gobrpc/gobimpl/gobimpl.go
@@ -246,10 +246,39 @@ type service struct {
 type Server struct {
 	mu         sync.Mutex
 	serviceMap map[string]*service
+	handlers   map[string]HandlerFunc
 }
 
 // NewServer returns a new Server, mirroring net/rpc.NewServer.
 func NewServer() *Server { return &Server{serviceMap: make(map[string]*service)} }
+
+// HandlerFunc handles one RPC method WITHOUT reflection: it decodes its argument
+// from dec (exactly one gob value, to keep the stream aligned) and returns the
+// reply value to send back. This is the TinyGo-safe alternative to Register —
+// TinyGo's runtime reflect can't enumerate methods (reflect.Type.Method hangs)
+// or invoke them (reflect.Value.Call), so reflection-based Register/ServeConn
+// dispatch deadlocks there. Registered via (*Server).HandleFunc and dispatched
+// by ServeConn ahead of the reflection path. The wire format is identical, so a
+// HandleFunc-based server still interoperates with a stdlib net/rpc client.
+type HandlerFunc func(dec *gob.Decoder) (reply interface{}, err error)
+
+// HandleFunc registers a reflection-free handler for serviceMethod
+// (e.g. "RPCGateway.AddEdgeRules"). See HandlerFunc.
+func (server *Server) HandleFunc(serviceMethod string, h HandlerFunc) {
+	server.mu.Lock()
+	if server.handlers == nil {
+		server.handlers = make(map[string]HandlerFunc)
+	}
+	server.handlers[serviceMethod] = h
+	server.mu.Unlock()
+}
+
+func (server *Server) handler(serviceMethod string) HandlerFunc {
+	server.mu.Lock()
+	h := server.handlers[serviceMethod]
+	server.mu.Unlock()
+	return h
+}
 
 // Dial connects to a gobrpc server at the given network address, mirroring
 // net/rpc.Dial.
@@ -356,6 +385,19 @@ func (server *Server) ServeConn(conn io.ReadWriteCloser) {
 		var req Request
 		if err := dec.Decode(&req); err != nil {
 			break
+		}
+
+		// Reflection-free path (TinyGo-safe): if a HandleFunc is registered for
+		// this method, it decodes its own arg from dec (synchronously, so the
+		// gob stream stays ordered) and returns the reply. No reflect involved.
+		if h := server.handler(req.ServiceMethod); h != nil {
+			reply, herr := h(dec)
+			errmsg := ""
+			if herr != nil {
+				errmsg = herr.Error()
+			}
+			server.sendResponse(sending, enc, &req, reply, errmsg)
+			continue
 		}
 
 		svc, mtype, lookupErr := server.lookup(req.ServiceMethod)

--- a/pkg/gobrpc/gobimpl/gobimpl_test.go
+++ b/pkg/gobrpc/gobimpl/gobimpl_test.go
@@ -1,6 +1,7 @@
 package gobimpl_test
 
 import (
+	"encoding/gob"
 	"errors"
 	"io"
 	"net"
@@ -130,6 +131,52 @@ func TestStdlibClient_ToGobimplServer(t *testing.T) {
 	}
 	if reply.C != 4 {
 		t.Fatalf("post-unknown Multiply = %d, want 4", reply.C)
+	}
+}
+
+// TestHandleFunc_ReflectionFree drives a stdlib net/rpc client against a gobimpl
+// server registered via the reflection-free HandleFunc path (no Register, no
+// reflect) — the path the TinyGo wasm-visor needs because TinyGo's runtime
+// reflect can't enumerate/invoke methods. Proves wire-compat + stream alignment.
+func TestHandleFunc_ReflectionFree(t *testing.T) {
+	srvConn, cliConn := pipePair()
+
+	srv := gobimpl.NewServer()
+	srv.HandleFunc("Arith.Multiply", func(dec *gob.Decoder) (interface{}, error) {
+		var args Args
+		if err := dec.Decode(&args); err != nil {
+			return nil, err
+		}
+		return Reply{C: args.A * args.B}, nil
+	})
+	srv.HandleFunc("Arith.Boom", func(dec *gob.Decoder) (interface{}, error) {
+		var args Args
+		_ = dec.Decode(&args) //nolint:errcheck // must still consume the arg body
+		return nil, errors.New("boom")
+	})
+	go srv.ServeConn(srvConn)
+
+	c := rpc.NewClient(cliConn)
+	defer c.Close() //nolint:errcheck
+
+	var reply Reply
+	if err := c.Call("Arith.Multiply", Args{A: 6, B: 7}, &reply); err != nil {
+		t.Fatalf("Multiply: %v", err)
+	}
+	if reply.C != 42 {
+		t.Fatalf("Multiply = %d, want 42", reply.C)
+	}
+
+	// Error path: surfaced AND the stream stays aligned for the next call.
+	if err := c.Call("Arith.Boom", Args{}, &Reply{}); err == nil || err.Error() != "boom" {
+		t.Fatalf("Boom err = %v, want \"boom\"", err)
+	}
+	reply = Reply{}
+	if err := c.Call("Arith.Multiply", Args{A: 3, B: 4}, &reply); err != nil {
+		t.Fatalf("post-error Multiply: %v", err)
+	}
+	if reply.C != 12 {
+		t.Fatalf("post-error Multiply = %d, want 12", reply.C)
 	}
 }
 

--- a/pkg/gobrpc/gobrpc_tinygo.go
+++ b/pkg/gobrpc/gobrpc_tinygo.go
@@ -17,6 +17,12 @@ type Server = gobimpl.Server
 // Call is gobimpl.Call (net/rpc-compatible).
 type Call = gobimpl.Call
 
+// HandlerFunc is gobimpl.HandlerFunc — a reflection-free RPC method handler.
+// TinyGo can't run net/rpc's reflection dispatch, so servers register handlers
+// via (*Server).HandleFunc instead of Register. Native builds use net/rpc and
+// have no equivalent (this alias is TinyGo-only).
+type HandlerFunc = gobimpl.HandlerFunc
+
 // NewClient mirrors net/rpc.NewClient.
 var NewClient = gobimpl.NewClient
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -536,8 +536,12 @@ func New(dmsgC *dmsg.Client, config *Config, routeSetupHooks []RouteSetupHook) (
 
 	go r.rulesGCLoop()
 
-	if err := r.rpcSrv.Register(NewRPCGateway(r, config.MasterLogger)); err != nil {
-		return nil, fmt.Errorf("failed to register RPC server")
+	// Register the setup RPC gateway on r.rpcSrv. Build-tagged: native uses
+	// reflection (net/rpc-style Register); TinyGo uses explicit HandleFunc
+	// handlers, because TinyGo's runtime reflect can't enumerate/invoke methods
+	// (reflect.Type.Method hangs) — see router_setup_rpc_{native,tinygo}.go.
+	if err := r.registerSetupRPC(config.MasterLogger); err != nil {
+		return nil, fmt.Errorf("failed to register RPC server: %w", err)
 	}
 
 	return r, nil

--- a/pkg/router/router_setup_rpc_native.go
+++ b/pkg/router/router_setup_rpc_native.go
@@ -1,0 +1,13 @@
+//go:build !tinygo
+
+// Package router pkg/router/router_setup_rpc_native.go
+package router
+
+import "github.com/skycoin/skywire/pkg/logging"
+
+// registerSetupRPC registers the setup RPC gateway via net/rpc-style reflection
+// (gobrpc.Server is net/rpc.Server on native builds). The TinyGo build registers
+// explicit handlers instead — see router_setup_rpc_tinygo.go.
+func (r *router) registerSetupRPC(mLog *logging.MasterLogger) error {
+	return r.rpcSrv.Register(NewRPCGateway(r, mLog))
+}

--- a/pkg/router/router_setup_rpc_tinygo.go
+++ b/pkg/router/router_setup_rpc_tinygo.go
@@ -1,0 +1,63 @@
+//go:build tinygo
+
+// Package router pkg/router/router_setup_rpc_tinygo.go
+package router
+
+import (
+	"encoding/gob"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// registerSetupRPC registers the setup RPC gateway using gobrpc's reflection-free
+// HandleFunc path. TinyGo's runtime reflect can't enumerate or invoke methods
+// (reflect.Type.Method hangs; reflect.Value.Call is unsupported), so net/rpc-style
+// Register deadlocks — see pkg/gobrpc/gobimpl. Each handler decodes its argument
+// (matching the gateway method's arg type) and returns the reply value; the wire
+// format is identical to net/rpc, so a native router peer interoperates.
+func (r *router) registerSetupRPC(mLog *logging.MasterLogger) error {
+	gw := NewRPCGateway(r, mLog)
+
+	r.rpcSrv.HandleFunc(RPCName+".AddEdgeRules", func(dec *gob.Decoder) (interface{}, error) {
+		var rules routing.EdgeRules
+		if err := dec.Decode(&rules); err != nil {
+			return nil, err
+		}
+		var ok bool
+		err := gw.AddEdgeRules(rules, &ok)
+		return ok, err
+	})
+
+	r.rpcSrv.HandleFunc(RPCName+".AddIntermediaryRules", func(dec *gob.Decoder) (interface{}, error) {
+		var rules []routing.Rule
+		if err := dec.Decode(&rules); err != nil {
+			return nil, err
+		}
+		var ok bool
+		err := gw.AddIntermediaryRules(rules, &ok)
+		return ok, err
+	})
+
+	r.rpcSrv.HandleFunc(RPCName+".ReserveIDs", func(dec *gob.Decoder) (interface{}, error) {
+		var n uint8
+		if err := dec.Decode(&n); err != nil {
+			return nil, err
+		}
+		var ids []routing.RouteID
+		err := gw.ReserveIDs(n, &ids)
+		return ids, err
+	})
+
+	r.rpcSrv.HandleFunc(RPCName+".DelRules", func(dec *gob.Decoder) (interface{}, error) {
+		var ids []routing.RouteID
+		if err := dec.Decode(&ids); err != nil {
+			return nil, err
+		}
+		var ok bool
+		err := gw.DelRules(ids, &ok)
+		return ok, err
+	})
+
+	return nil
+}

--- a/pkg/router/routerclient.go
+++ b/pkg/router/routerclient.go
@@ -20,9 +20,6 @@ import (
 	"github.com/skycoin/skywire/pkg/transport/network"
 )
 
-// RPCName is the RPC gateway object name.
-const RPCName = "RPCGateway"
-
 // Client is used to interact with the router's API remotely. The setup node uses this.
 type Client struct {
 	rpc  *rpc.Client

--- a/pkg/router/rpc_gateway.go
+++ b/pkg/router/rpc_gateway.go
@@ -6,6 +6,12 @@ import (
 	"github.com/skycoin/skywire/pkg/routing"
 )
 
+// RPCName is the RPC gateway object name (the net/rpc / gobrpc service name the
+// route-setup client dials as "RPCGateway.<Method>"). It lives in this untagged
+// file so both the native client (routerclient.go, !tinygo) and the TinyGo
+// HandleFunc registration (router_setup_rpc_tinygo.go) can reference it.
+const RPCName = "RPCGateway"
+
 // RPCGateway is a RPC interface for router.
 type RPCGateway struct {
 	logger *logging.Logger


### PR DESCRIPTION
## The bug (caught by runtime validation, not compilation)

Runtime-validating `cmd/wasm-visor` (the browser edge assembly, #3218/#3219) via the dev harness surfaced a hang compilation + native tests couldn't: `boot()` **hung at `router.New()`**. The harness step-log pinned it to `rpcSrv.Register(NewRPCGateway)` → `reflect.Type.Method(i)`, which **TinyGo's runtime reflect does not support** (`NumMethod` works; `Method(i)` never returns, deadlocking the wasm thread).

So gobimpl's reflection-based RPC **server** (`Register` + `ServeConn`-via-`Value.Call`) only ever worked **natively** — where #3209/#3215's tests run. Under TinyGo it hangs.

## Fix — reflection-free dispatch

- **`(*Server).HandleFunc(serviceMethod, HandlerFunc)`** registers an explicit handler; `HandlerFunc` decodes its own gob arg and returns the reply. `ServeConn` checks the handler map **before** the reflection path — no `reflect.Type.Method`, no `reflect.Value.Call`. Wire format unchanged, so a HandleFunc server still interoperates with a stdlib `net/rpc` client (new test **`TestHandleFunc_ReflectionFree`** drives `net/rpc` → gobimpl-HandleFunc over `net.Pipe`).
- `gobrpc` re-exports `HandlerFunc` (TinyGo alias).
- The router's setup-gateway registration is **build-tagged**: native uses reflection `Register` (`router_setup_rpc_native.go`); TinyGo registers the 4 `RPCGateway` methods as explicit handlers (`router_setup_rpc_tinygo.go`). `RPCName` moved to the untagged `rpc_gateway.go`.

## Validated end-to-end in a browser tab

With `router.New` fixed, `cmd/wasm-visor` **boots the full edge in-browser**: dmsg connects + registers in discovery, `transport.Manager` serves, `router.New` completes and `Serve`s — `status` returns **`booted: true`**. The in-process `ProcManager` step is **deferred** — `appserver.NewProcManager` `net.Listen("tcp")`s for external-app IPC, which a browser can't do; in-process app hosting needs a browser-adapted ProcManager (the next step toward edge + skychat).

## Verification

- Native `go build ./...`, the **gobrpc + router** test suites, and lint: pass unchanged.
- `tinygo build -target wasm ./cmd/wasm-visor` builds (8.79 MB) and **boots to `booted:true` in a browser**.