### PR TITLE
feat(appserver): browser-adapt the ProcManager — no TCP ingress under TinyGo

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/skycoin/skywire/pkg/app/appdisc"
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -115,11 +116,10 @@ func jsStatus(js.Value, []js.Value) interface{} {
 	st["tpManager"] = tpM != nil
 	st["router"] = rtr != nil
 	st["procManager"] = procM != nil
-	// The EDGE is dmsg + transport + router (rule reception + packet forwarding).
-	// procManager (in-process app hosting) is a separate, later concern — it
-	// net.Listen("tcp")s, which a browser can't do, so it is not on the edge
-	// boot path yet.
-	st["booted"] = dmsgC != nil && tpM != nil && rtr != nil
+	// booted = the edge (dmsg + transport + router: rule reception + packet
+	// forwarding) plus the in-process app host (procManager). No app is running
+	// yet — that's the in-process-skychat step.
+	st["booted"] = dmsgC != nil && tpM != nil && rtr != nil && procM != nil
 	if tpM != nil {
 		st["transports"] = tpM.TransportCount()
 	}
@@ -212,18 +212,23 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	}()
 	vlog("router: serving")
 
-	// EDGE booted: dmsg + transport + router are up. The tab now receives route
-	// rules and forwards/consumes packets — a routable skynet edge.
-	vlog("EDGE booted: dmsg + transport + router up")
-	fmt.Printf("wasm-visor: edge booted pk=%s\n", pk.Hex())
+	vlog("router: serving — EDGE up (dmsg + transport + router)")
 
-	// 4. in-process app server (RunModeInternal) — DEFERRED (procM stays nil).
-	// appserver.NewProcManager net.Listen("tcp")s for the external-app IPC
-	// ingress, which a browser cannot do (it blocks under TinyGo/js). In-process
-	// skychat needs a browser-adapted ProcManager (no TCP ingress; net.Pipe
-	// in-process conns only) — the next step toward "edge + in-process skychat".
-	// Wiring NewProcManager here would hang the boot.
+	// 4. in-process app server (RunModeInternal). The browser-adapted
+	// appserver.NewProcManager no longer net.Listen("tcp")s under TinyGo (a
+	// browser can't); in-process apps connect over net.Pipe. addr "" → no TCP
+	// ingress. No app registered yet — in-process skychat (an appcommon.AppFunc)
+	// is the next step.
+	vlog("proc_manager: New…")
+	pm, err := appserver.NewProcManager(mLog, &appdisc.Factory{}, eb, "", "")
+	if err != nil {
+		return pk, fmt.Errorf("proc manager: %w", err)
+	}
+	procM = pm
+	vlog("proc_manager: ok")
 
+	vlog("EDGE + app-host booted")
+	fmt.Printf("wasm-visor: booted pk=%s\n", pk.Hex())
 	return pk, nil
 }
 

--- a/pkg/app/appserver/proc_ingress_listen_native.go
+++ b/pkg/app/appserver/proc_ingress_listen_native.go
@@ -1,0 +1,14 @@
+//go:build !tinygo
+
+// Package appserver pkg/app/appserver/proc_ingress_listen_native.go
+package appserver
+
+import "net"
+
+// listenIngress opens the proc manager's app-ingress TCP listener. External
+// (os/exec) apps dial it to reach the visor; in-process apps use net.Pipe
+// instead (appcommon.RegisterInProcessConn), so the TinyGo build returns no
+// listener — a browser can't net.Listen anyway. See proc_ingress_listen_tinygo.go.
+func listenIngress(addr string) (net.Listener, error) {
+	return net.Listen("tcp", addr)
+}

--- a/pkg/app/appserver/proc_ingress_listen_tinygo.go
+++ b/pkg/app/appserver/proc_ingress_listen_tinygo.go
@@ -1,0 +1,15 @@
+//go:build tinygo
+
+// Package appserver pkg/app/appserver/proc_ingress_listen_tinygo.go
+package appserver
+
+import "net"
+
+// listenIngress returns no listener on the TinyGo js/wasm target: a browser
+// cannot net.Listen("tcp"), and in-process apps (RunModeInternal — the only
+// mode in a browser visor) reach the visor over net.Pipe via
+// appcommon.RegisterInProcessConn, not the TCP ingress. The proc manager's
+// accept loop, Addr, and Close all guard a nil listener.
+func listenIngress(_ string) (net.Listener, error) {
+	return nil, nil
+}

--- a/pkg/app/appserver/proc_manager.go
+++ b/pkg/app/appserver/proc_manager.go
@@ -100,7 +100,10 @@ func NewProcManager(mLog *logging.MasterLogger, discF *appdisc.Factory, eb *appe
 		eb = appevent.NewBroadcaster(mLog.PackageLogger("event_broadcaster"), time.Second)
 	}
 
-	lis, err := net.Listen("tcp", addr)
+	// listenIngress is the TCP app-ingress listener on native builds, and nil on
+	// TinyGo (a browser can't net.Listen; in-process apps use net.Pipe). serve(),
+	// Addr() and Close() guard a nil listener.
+	lis, err := listenIngress(addr)
 	if err != nil {
 		return nil, err
 	}
@@ -129,6 +132,12 @@ func NewProcManager(mLog *logging.MasterLogger, discF *appdisc.Factory, eb *appe
 }
 
 func (m *procManager) serve() {
+	// No TCP ingress listener (TinyGo/browser): in-process apps connect over
+	// net.Pipe via InjectConn, not this accept loop.
+	if m.lis == nil {
+		return
+	}
+
 	defer func() {
 		m.connsMx.Lock()
 		for _, conn := range m.conns {
@@ -496,8 +505,12 @@ func (m *procManager) stopAll() {
 	m.procs = make(map[string]*Proc)
 }
 
-// Addr returns the underlying listener's listening address.
+// Addr returns the underlying listener's listening address (nil on TinyGo,
+// where there is no TCP ingress listener — in-process apps use net.Pipe).
 func (m *procManager) Addr() net.Addr {
+	if m.lis == nil {
+		return nil
+	}
 	return m.lis.Addr()
 }
 
@@ -512,7 +525,10 @@ func (m *procManager) Close() error {
 	close(m.done)
 
 	m.stopAll()
-	err := m.lis.Close()
+	var err error
+	if m.lis != nil {
+		err = m.lis.Close()
+	}
 	m.connsWG.Wait()
 	return err
 }


### PR DESCRIPTION
## What

Runtime-validating `cmd/wasm-visor` surfaced the next blocker after the reflection-free gobrpc fix (#3220): boot hung at `appserver.NewProcManager`, which `net.Listen("tcp", addr)`s for the external-app IPC ingress. **A browser can't listen on TCP** (it blocks under TinyGo/js), and in-process apps (`RunModeInternal` — the only mode in a browser visor) don't use that ingress anyway: they connect over `net.Pipe` via `appcommon.RegisterInProcessConn`.

Make the TCP ingress listener build-tagged and optional:
- `listenIngress(addr)` → `net.Listen("tcp", addr)` on native (`proc_ingress_listen_native.go`); → `nil` on TinyGo (`proc_ingress_listen_tinygo.go`).
- `procManager.serve()` returns immediately when there's no listener (no accept loop); `Addr()` returns nil; `Close()` skips the nil listener. In-process apps are still served via `InjectConn` over `net.Pipe`, unchanged.

`cmd/wasm-visor` now wires the ProcManager into the edge boot.

## Validated in-browser

The full stack boots **`booted:true` with `procManager:true`** — dmsg + transport + router + in-process app host all up in a tab. No app runs yet; in-process skychat (an `appcommon.AppFunc`) is next, which also needs the same reflection-free `HandleFunc` treatment for `AwaitConn`'s `RegisterName` (the app↔visor ingress RPC — same TinyGo `reflect.Type.Method` hang).

## Verification

- Native `go build ./...`, the `pkg/app/appserver` test suite, and lint: pass unchanged (the nil-listener guards are no-ops on native).
- `tinygo build -target wasm ./cmd/wasm-visor` boots `booted:true` in a browser.