### PR TITLE
feat(tpdclient): dmsg transport-discovery client — routable browser visor

### DIFF
--- a/cmd/wasm-visor/index.html
+++ b/cmd/wasm-visor/index.html
@@ -75,6 +75,11 @@
           const r = await skywireVisor.hvApi(a[0] || "GET", a[1] || "/api/visors", a[2] || null);
           return { status: r.status, body: new TextDecoder().decode(r.body) };
         }
+        case "tpdEdge": {
+          const j = await skywireVisor.tpdEdge(a[0]);
+          const arr = JSON.parse(j);
+          return { count: Array.isArray(arr) ? arr.length : 0, sample: Array.isArray(arr) ? arr.slice(0, 1) : arr };
+        }
         case "status":
           return skywireVisor.status();
         case "reload":

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -35,13 +35,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"syscall/js"
 	"time"
 
-	"github.com/google/uuid"
-
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appdisc"
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/app/appserver"
@@ -54,6 +55,7 @@ import (
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/transport/network"
+	"github.com/skycoin/skywire/pkg/transport/tpdclient"
 	"github.com/skycoin/skywire/pkg/wasmhv"
 )
 
@@ -66,6 +68,7 @@ var (
 	rtr    router.Router
 	procM  appserver.ProcManager
 	hvCore *wasmhv.Core
+	tpd    transport.DiscoveryClient
 )
 
 // vlog emits a step message to the browser console AND, when present, the
@@ -81,9 +84,10 @@ func vlog(msg string) {
 func main() {
 	ctx = context.Background()
 	js.Global().Set("skywireVisor", js.ValueOf(map[string]interface{}{
-		"boot":   js.FuncOf(jsBoot),
-		"status": js.FuncOf(jsStatus),
-		"hvApi":  js.FuncOf(jsHvAPI),
+		"boot":    js.FuncOf(jsBoot),
+		"status":  js.FuncOf(jsStatus),
+		"hvApi":   js.FuncOf(jsHvAPI),
+		"tpdEdge": js.FuncOf(jsTPDEdge),
 	}))
 	fmt.Println("wasm-visor: ready — call skywireVisor.boot(sk, seedPk, seedWs, discDmsgAddr)")
 	select {} // block forever
@@ -159,13 +163,21 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	dmsgC = c
 	vlog("dmsg: ok")
 
-	// 2. transport manager (dmsg-only; no AR, no TPD registration yet).
+	// 2. transport manager (dmsg-only). The transport-discovery client registers
+	// the tab's transport edges OVER DMSG (net/http-free), against the deployment's
+	// transport_discovery_dmsg endpoint — so peers' route-finders can find paths to
+	// the tab once it dials a visor↔visor transport.
+	tpdPK, perr := dmsgURLPK(deployment.Prod.TransportDiscoveryDmsg)
+	if perr != nil {
+		return pk, fmt.Errorf("tpd dmsg url: %w", perr)
+	}
+	tpd = tpdclient.NewDmsg(dmsgC, tpdPK, pk, sk, mLog)
 	eb := appevent.NewBroadcaster(mLog.PackageLogger("eb"), time.Second)
 	factory := network.ClientFactory{PK: pk, SK: sk, DmsgC: dmsgC, MLogger: mLog, EB: eb}
 	tmConf := &transport.ManagerConfig{
 		PubKey:          pk,
 		SecKey:          sk,
-		DiscoveryClient: noopTPD{},
+		DiscoveryClient: tpd,
 		LogStore:        transport.InMemoryTransportLogStore(),
 	}
 	tm, err := transport.NewManager(mLog.PackageLogger("tp_manager"), nil, eb, tmConf, factory)
@@ -308,33 +320,38 @@ func promise(fn func() (interface{}, error)) interface{} {
 	return js.Global().Get("Promise").New(handler)
 }
 
-// noopTPD is a no-op transport.DiscoveryClient: a browser edge does not (yet)
-// register its transports in the transport discovery (that path is HTTP/native;
-// a dmsg-based TPD client is a follow-up). Route setup TO this edge therefore
-// relies on the dialing peer already knowing the edge's transport.
-type noopTPD struct{}
+// dmsgURLPK extracts the public key from a "dmsg://<pk>:<port>" URL.
+func dmsgURLPK(raw string) (cipher.PubKey, error) {
+	s := strings.TrimPrefix(raw, "dmsg://")
+	if i := strings.IndexByte(s, ':'); i >= 0 {
+		s = s[:i]
+	}
+	var pk cipher.PubKey
+	if err := pk.UnmarshalText([]byte(s)); err != nil {
+		return cipher.PubKey{}, fmt.Errorf("parse pk from %q: %w", raw, err)
+	}
+	return pk, nil
+}
 
-func (noopTPD) RegisterTransports(context.Context, ...*transport.SignedEntry) error { return nil }
-func (noopTPD) RegisterTransportsV3(context.Context, string, ...*transport.Entry) error {
-	return nil
-}
-func (noopTPD) GetTransportByID(context.Context, uuid.UUID) (*transport.Entry, error) {
-	return nil, nil
-}
-func (noopTPD) GetTransportsByEdge(context.Context, cipher.PubKey) ([]*transport.Entry, error) {
-	return nil, nil
-}
-func (noopTPD) GetAllTransports(context.Context) ([]*transport.Entry, error) { return nil, nil }
-func (noopTPD) GetTransportStats(context.Context, cipher.PubKey) (*transport.TransportStats, error) {
-	return nil, nil
-}
-func (noopTPD) GetAllTransportsStats(context.Context) (*transport.NetworkTransportStats, error) {
-	return nil, nil
-}
-func (noopTPD) GetAllTransportsPerKeyStats(context.Context) (transport.PerKeyStats, error) {
-	return nil, nil
-}
-func (noopTPD) DeleteTransport(context.Context, uuid.UUID) error { return nil }
-func (noopTPD) DeleteTransports(context.Context, []uuid.UUID) (int, error) {
-	return 0, nil
+// jsTPDEdge(pkHex) → Promise<entriesJSON>. Queries the transport discovery (over
+// dmsg) for the transports registered by edge pkHex — used to validate the
+// dmsg-TPD client against the live TPD (e.g. this host's full visor and its many
+// registered transports).
+func jsTPDEdge(_ js.Value, args []js.Value) interface{} {
+	pkHex := args[0].String()
+	return promise(func() (interface{}, error) {
+		if tpd == nil {
+			return nil, errors.New("not booted; call boot() first")
+		}
+		var pk cipher.PubKey
+		if err := pk.UnmarshalText([]byte(pkHex)); err != nil {
+			return nil, fmt.Errorf("bad pk: %w", err)
+		}
+		entries, err := tpd.GetTransportsByEdge(ctx, pk)
+		if err != nil {
+			return nil, err
+		}
+		b, _ := json.Marshal(entries) //nolint:errcheck
+		return string(b), nil
+	})
 }

--- a/pkg/httpauthclient/client.go
+++ b/pkg/httpauthclient/client.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 // Package httpauthclient http authorizatioon
 package httpauthclient
 

--- a/pkg/transport/tpdclient/client.go
+++ b/pkg/transport/tpdclient/client.go
@@ -1,3 +1,5 @@
+//go:build !tinygo
+
 // Package tpdclient implements transport discovery client
 package tpdclient
 

--- a/pkg/transport/tpdclient/dmsg_client.go
+++ b/pkg/transport/tpdclient/dmsg_client.go
@@ -1,0 +1,319 @@
+// Package tpdclient pkg/transport/tpdclient/dmsg_client.go
+//
+// A transport-discovery client that speaks to the TPD over DMSG instead of
+// net/http, so it compiles and runs on the TinyGo js/wasm target (a browser
+// visor). It performs the SAME signed-auth flow as the HTTP client (client.go,
+// //go:build !tinygo): GET the per-key nonce, sign payload+nonce with the
+// visor's secret key, send SW-Public/SW-Nonce/SW-Sig headers, and retry once on
+// a nonce mismatch. The signing primitives are reused verbatim from
+// httpauthclient (nonce.go is net/http-free), so signatures are byte-identical
+// to the HTTP client and the same TPD validates both.
+package tpdclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
+	"github.com/skycoin/skywire/pkg/httpauthclient"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// invalidNonceMessage mirrors httpauthclient's server-side message (kept local
+// so this file does not pull httpauthclient's net/http-bearing client.go).
+const invalidNonceMessage = "SW-Nonce does not match"
+
+// dmsgClient is the DMSG-transport implementation of transport.DiscoveryClient.
+type dmsgClient struct {
+	dmsgC *dmsg.Client
+	host  string // TPD public key (hex) or "pk:port"; FetchOverDmsg defaults port 80
+	key   cipher.PubKey
+	sec   cipher.SecKey
+	log   *logging.Logger
+
+	mu    sync.Mutex
+	nonce httpauthclient.Nonce
+}
+
+// NewDmsg returns a transport.DiscoveryClient that talks to the TPD at tpdPK
+// over the given dmsg client, authenticating as key/sec.
+func NewDmsg(dmsgC *dmsg.Client, tpdPK cipher.PubKey, key cipher.PubKey, sec cipher.SecKey, mLogger *logging.MasterLogger) transport.DiscoveryClient {
+	log := logging.MustGetLogger("tpd_dmsg")
+	if mLogger != nil {
+		log = mLogger.PackageLogger("tpd_dmsg")
+	}
+	return &dmsgClient{dmsgC: dmsgC, host: tpdPK.Hex(), key: key, sec: sec, log: log}
+}
+
+// fetch performs a signed request to the TPD over dmsg, fetching/refreshing the
+// nonce as needed and retrying once on a nonce mismatch (mirrors
+// httpauthclient.Client.do). Returns the HTTP status and response body.
+func (c *dmsgClient) fetch(ctx context.Context, method, path string, payload interface{}, extraHeaders map[string]string) (int, []byte, error) {
+	var body []byte
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return 0, nil, err
+		}
+		body = b
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.nonce == 0 {
+		n, err := c.fetchNonce(ctx)
+		if err != nil {
+			return 0, nil, err
+		}
+		c.nonce = n
+	}
+
+	status, resp, err := c.signedSend(ctx, method, path, body, extraHeaders)
+	if err != nil {
+		return 0, nil, err
+	}
+	if isNonceMismatch(status, resp) {
+		n, err := c.fetchNonce(ctx)
+		if err != nil {
+			return 0, nil, err
+		}
+		c.nonce = n
+		if status, resp, err = c.signedSend(ctx, method, path, body, extraHeaders); err != nil {
+			return 0, nil, err
+		}
+	}
+	if status >= 200 && status < 300 {
+		c.nonce++
+	}
+	return status, resp, nil
+}
+
+// signedSend signs (body, current nonce) and sends one request over dmsg.
+func (c *dmsgClient) signedSend(ctx context.Context, method, path string, body []byte, extraHeaders map[string]string) (int, []byte, error) {
+	sig, err := httpauthclient.Sign(body, c.nonce, c.sec)
+	if err != nil {
+		return 0, nil, err
+	}
+	headers := map[string]string{
+		"SW-Public": c.key.Hex(),
+		"SW-Nonce":  strconv.FormatUint(uint64(c.nonce), 10),
+		"SW-Sig":    sig.Hex(),
+	}
+	if len(body) > 0 {
+		headers["Content-Type"] = "application/json"
+	}
+	for k, v := range extraHeaders {
+		headers[k] = v
+	}
+	status, _, respBody, err := dmsgclient.FetchOverDmsg(ctx, c.dmsgC, method, c.host, path, headers, body)
+	return status, respBody, err
+}
+
+// fetchNonce GETs the next nonce for this visor's key from the TPD.
+func (c *dmsgClient) fetchNonce(ctx context.Context) (httpauthclient.Nonce, error) {
+	status, _, body, err := dmsgclient.FetchOverDmsg(ctx, c.dmsgC, "GET", c.host, "/security/nonces/"+c.key.Hex(), nil, nil)
+	if err != nil {
+		return 0, err
+	}
+	if status != 200 {
+		return 0, fmt.Errorf("tpd_dmsg: nonce fetch status %d: %s", status, string(body))
+	}
+	var nr struct {
+		NextNonce uint64 `json:"next_nonce"`
+	}
+	if err := json.Unmarshal(body, &nr); err != nil {
+		return 0, fmt.Errorf("tpd_dmsg: decode nonce: %w", err)
+	}
+	return httpauthclient.Nonce(nr.NextNonce), nil
+}
+
+// isNonceMismatch reports whether a response is the TPD's "bad nonce" rejection
+// (HTTP 401 or the SW-Nonce-mismatch message), matching httpauthclient.isNonceValid.
+func isNonceMismatch(status int, body []byte) bool {
+	if status == 401 {
+		return true
+	}
+	var r struct {
+		Error *struct {
+			Message string `json:"message"`
+			Code    int    `json:"code"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &r) != nil || r.Error == nil {
+		return false
+	}
+	return r.Error.Code == 401 || r.Error.Message == invalidNonceMessage
+}
+
+// statusErr returns a non-nil error for a non-2xx status.
+func statusErr(status int, body []byte) error {
+	if status >= 200 && status < 300 {
+		return nil
+	}
+	return fmt.Errorf("tpd_dmsg: status %d: %s", status, string(body))
+}
+
+// --- transport.DiscoveryClient ---
+
+func (c *dmsgClient) RegisterTransports(ctx context.Context, entries ...*transport.SignedEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	status, body, err := c.fetch(ctx, "POST", "/transports/", entries, nil)
+	if err != nil {
+		return err
+	}
+	return statusErr(status, body)
+}
+
+func (c *dmsgClient) RegisterTransportsV3(ctx context.Context, version string, entries ...*transport.Entry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	var hdrs map[string]string
+	if version != "" {
+		hdrs = map[string]string{"SW-Visor-Version": version}
+	}
+	status, body, err := c.fetch(ctx, "POST", "/v3/transports/", entries, hdrs)
+	if err != nil {
+		return err
+	}
+	if status == 404 {
+		// TPD predates /v3/transports/ — fall back to the legacy signed-entry format.
+		signed := make([]*transport.SignedEntry, 0, len(entries))
+		for _, e := range entries {
+			signed = append(signed, &transport.SignedEntry{Entry: e, Version: version})
+		}
+		return c.RegisterTransports(ctx, signed...)
+	}
+	return statusErr(status, body)
+}
+
+func (c *dmsgClient) GetTransportByID(ctx context.Context, id uuid.UUID) (*transport.Entry, error) {
+	status, body, err := c.fetch(ctx, "GET", fmt.Sprintf("/transports/id:%s", id.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := statusErr(status, body); err != nil {
+		return nil, err
+	}
+	var entry transport.Entry
+	if err := json.Unmarshal(body, &entry); err != nil {
+		return nil, fmt.Errorf("json: %w", err)
+	}
+	return &entry, nil
+}
+
+func (c *dmsgClient) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
+	status, body, err := c.fetch(ctx, "GET", fmt.Sprintf("/transports/edge:%s", pk), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := statusErr(status, body); err != nil {
+		return nil, err
+	}
+	var entries []*transport.Entry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return nil, fmt.Errorf("json: %w", err)
+	}
+	return entries, nil
+}
+
+func (c *dmsgClient) GetAllTransports(ctx context.Context) ([]*transport.Entry, error) {
+	status, body, err := c.fetch(ctx, "GET", "/all-transports", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := statusErr(status, body); err != nil {
+		return nil, err
+	}
+	var entries []*transport.Entry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return nil, fmt.Errorf("json: %w", err)
+	}
+	return entries, nil
+}
+
+func (c *dmsgClient) GetTransportStats(ctx context.Context, pk cipher.PubKey) (*transport.TransportStats, error) {
+	status, body, err := c.fetch(ctx, "GET", fmt.Sprintf("/transports/stats/%s", pk), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := statusErr(status, body); err != nil {
+		return nil, err
+	}
+	var stats transport.TransportStats
+	if err := json.Unmarshal(body, &stats); err != nil {
+		return nil, fmt.Errorf("json: %w", err)
+	}
+	return &stats, nil
+}
+
+func (c *dmsgClient) GetAllTransportsStats(ctx context.Context) (*transport.NetworkTransportStats, error) {
+	status, body, err := c.fetch(ctx, "GET", "/all-transports/stats", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := statusErr(status, body); err != nil {
+		return nil, err
+	}
+	var stats transport.NetworkTransportStats
+	if err := json.Unmarshal(body, &stats); err != nil {
+		return nil, fmt.Errorf("json: %w", err)
+	}
+	return &stats, nil
+}
+
+func (c *dmsgClient) GetAllTransportsPerKeyStats(ctx context.Context) (transport.PerKeyStats, error) {
+	status, body, err := c.fetch(ctx, "GET", "/all-transports/per-key-stats", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := statusErr(status, body); err != nil {
+		return nil, err
+	}
+	var stats transport.PerKeyStats
+	if err := json.Unmarshal(body, &stats); err != nil {
+		return nil, fmt.Errorf("json: %w", err)
+	}
+	return stats, nil
+}
+
+func (c *dmsgClient) DeleteTransport(ctx context.Context, id uuid.UUID) error {
+	status, body, err := c.fetch(ctx, "DELETE", fmt.Sprintf("/transports/id:%s", id.String()), nil, nil)
+	if err != nil {
+		return err
+	}
+	return statusErr(status, body)
+}
+
+func (c *dmsgClient) DeleteTransports(ctx context.Context, ids []uuid.UUID) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	idStrings := make([]string, len(ids))
+	for i, id := range ids {
+		idStrings[i] = id.String()
+	}
+	status, body, err := c.fetch(ctx, "POST", "/transports/delete-batch", idStrings, nil)
+	if err != nil || status == 404 || statusErr(status, body) != nil {
+		// Batch unsupported/failed: delete sequentially, counting successes.
+		deleted := 0
+		for _, id := range ids {
+			if derr := c.DeleteTransport(ctx, id); derr == nil {
+				deleted++
+			}
+		}
+		return deleted, nil
+	}
+	return len(ids), nil
+}


### PR DESCRIPTION
## What

The wasm-visor used a no-op TPD client, so it registered nothing in transport discovery and peers' route-finders couldn't find paths to the tab. The real `tpdclient` (HTTP + `httpauthclient` signed auth) doesn't compile under TinyGo.

Add a **DMSG transport-discovery client** (`NewDmsg`) implementing all 11 `transport.DiscoveryClient` methods over `dmsgclient.FetchOverDmsg` — net/http-free, so it runs in a browser visor. It performs the **same signed-auth flow** as the HTTP client (GET per-key nonce → sign payload+nonce → `SW-Public`/`SW-Nonce`/`SW-Sig` headers → retry once on nonce mismatch), reusing `httpauthclient`'s signing primitives **verbatim** (`nonce.go` is net/http-free) so signatures are byte-identical and the same TPD validates both.

Split like `rfclient`: `tpdclient/client.go` and `httpauthclient/client.go` are now `//go:build !tinygo`; the new `dmsg_client.go` + the existing `nonce.go` stay untagged.

`cmd/wasm-visor` wires `NewDmsg` (against the deployment `transport_discovery_dmsg` endpoint) as the transport manager's `DiscoveryClient`, replacing `noopTPD`, and exposes `skywireVisor.tpdEdge(pk)`.

## Validated against the LIVE TPD from a browser tab

`tpdEdge(<this host's full visor PK>)` returned **974 real transports** over dmsg (matching the host visor's registrations) — sample `{type:"stcpr", latency_ms:226.8, edges:[…]}`.

## Verification

- Native `go build ./...`, `go vet`, lint: pass.
- `GOOS=js GOARCH=wasm go list -tags tinygo -deps ./pkg/transport/tpdclient` is net/http-free; `tinygo build -target wasm` of an importer passes.