### PR TITLE
feat(transport): WS-direct as a first-class network.Type (visor↔visor WebSocket)

### DIFF
--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -61,6 +61,9 @@ type ClientFactory struct {
 	SK         cipher.SecKey
 	ListenAddr string
 	PKTable    stcp.PKTable
+	// WSTable maps a peer PK to its direct WebSocket (wss://) URL for the WS
+	// transport type. Reuses stcp.PKTable (PK→URL); empty/absent disables WS.
+	WSTable stcp.PKTable
 	// ARClient is the address-resolver client (addrresolver.APIClient). Typed as
 	// `any` so this file doesn't import addrresolver — which pulls net/http +
 	// packetfilter (→ quic-go), none of which compile on the TinyGo target. Only
@@ -103,6 +106,8 @@ func (f *ClientFactory) MakeClient(netType types.Type, port int) (Client, error)
 	switch netType {
 	case types.STCP:
 		return newStcp(generic, f.PKTable), nil
+	case types.WS:
+		return newWS(generic, f.WSTable), nil
 	case types.DMSG:
 		return newDmsgClient(f.DmsgC), nil
 	}

--- a/pkg/transport/network/ws.go
+++ b/pkg/transport/network/ws.go
@@ -1,0 +1,67 @@
+// Package network pkg/transport/network/ws.go
+//
+// WS is a first-class skywire transport type: a direct visor-to-visor link over
+// a WebSocket, with the peer's wss:// endpoint resolved from a PK table (like
+// stcp, but over WebSocket instead of raw TCP). It is distinct from the dmsg
+// WebSocket carrier, which reaches a dmsg server rather than a peer visor.
+//
+// A browser visor can DIAL this transport (the browser's WebSocket API) but
+// cannot accept it (no listening socket) — so server-visors run the WS listener
+// (ws_native.go) while the dial side is build-tagged: coder/websocket on native,
+// the browser-native WebSocket under TinyGo/js (ws_tinygo.go). The accepted /
+// dialed WebSocket is adapted to a net.Conn and flows through the SAME
+// genericClient initTransport (Noise + yamux) path as every other carrier.
+package network
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport/network/stcp"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// wsClient is the WS-transport implementation of Client. table maps a peer PK to
+// its wss:// (or ws://) URL.
+type wsClient struct {
+	*genericClient
+	table stcp.PKTable
+}
+
+func newWS(generic *genericClient, table stcp.PKTable) Client {
+	client := &wsClient{genericClient: generic, table: table}
+	client.netType = types.WS
+	return client
+}
+
+// ErrWSEntryNotFound is returned when the requested PK has no WS URL in the table.
+var ErrWSEntryNotFound = errors.New("ws: entry not found in PK table")
+
+// Dial implements Client: resolve the peer's WS URL, dial it (build-tagged
+// carrier: coder/websocket on native, browser WebSocket on TinyGo/js), and wrap
+// the resulting net.Conn in a skywire transport.
+func (c *wsClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16) (Transport, error) {
+	if c.isClosed() {
+		return nil, io.ErrClosedPipe
+	}
+
+	url, ok := c.table.Addr(rPK)
+	if !ok {
+		return nil, ErrWSEntryNotFound
+	}
+	c.log.Debugf("Dialing WS %v @ %s", rPK, url)
+
+	conn, err := wsDial(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	tp, err := c.initTransport(ctx, conn, rPK, rPort)
+	if err != nil {
+		conn.Close() //nolint:errcheck,gosec
+		return nil, err
+	}
+	return tp, nil
+}

--- a/pkg/transport/network/ws_native.go
+++ b/pkg/transport/network/ws_native.go
@@ -1,0 +1,110 @@
+//go:build !tinygo
+
+// Package network pkg/transport/network/ws_native.go
+//
+// Native WS-transport carrier: dial via coder/websocket, and accept by running
+// a WebSocket HTTP server fronted as a net.Listener so the shared
+// acceptTransports loop can drain it. A browser visor has neither (it can't run
+// a server, and coder/websocket pulls net/http) — see ws_tinygo.go.
+package network
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// wsDial opens a direct WebSocket to url and adapts it to a net.Conn.
+func wsDial(ctx context.Context, url string) (net.Conn, error) {
+	c, _, err := websocket.Dial(ctx, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	// Background context: the per-read/write deadlines are managed by the
+	// transport layer over the returned net.Conn, not this lifetime ctx.
+	return websocket.NetConn(context.Background(), c, websocket.MessageBinary), nil
+}
+
+// Start implements Client: serve incoming WS transports.
+func (c *wsClient) Start() error {
+	if c.connListener != nil {
+		return ErrAlreadyListening
+	}
+	go c.serve()
+	return nil
+}
+
+func (c *wsClient) serve() {
+	lis, err := newWSListener(c.listenAddr)
+	if err != nil {
+		c.log.Errorf("Failed to start WS listener on %q: %v", c.listenAddr, err)
+		return
+	}
+	c.acceptTransports(lis)
+}
+
+// wsListener fronts a WebSocket HTTP server as a net.Listener: each upgraded
+// WebSocket connection is delivered as a net.Conn from Accept().
+type wsListener struct {
+	addr  net.Addr
+	conns chan net.Conn
+	done  chan struct{}
+	srv   *http.Server
+	once  sync.Once
+}
+
+func newWSListener(addr string) (*wsListener, error) {
+	tcpLis, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	l := &wsListener{
+		addr:  tcpLis.Addr(),
+		conns: make(chan net.Conn),
+		done:  make(chan struct{}),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", l.handle)
+	l.srv = &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	go l.srv.Serve(tcpLis) //nolint:errcheck
+	return l, nil
+}
+
+func (l *wsListener) handle(w http.ResponseWriter, r *http.Request) {
+	ws, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		return
+	}
+	conn := websocket.NetConn(context.Background(), ws, websocket.MessageBinary)
+	select {
+	case l.conns <- conn:
+	case <-l.done:
+		_ = conn.Close() //nolint:errcheck
+	}
+}
+
+// Accept implements net.Listener.
+func (l *wsListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.conns:
+		return c, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+
+// Close implements net.Listener.
+func (l *wsListener) Close() error {
+	l.once.Do(func() {
+		close(l.done)
+		_ = l.srv.Close() //nolint:errcheck
+	})
+	return nil
+}
+
+// Addr implements net.Listener.
+func (l *wsListener) Addr() net.Addr { return l.addr }

--- a/pkg/transport/network/ws_native_test.go
+++ b/pkg/transport/network/ws_native_test.go
@@ -1,0 +1,79 @@
+//go:build !tinygo
+
+package network
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestWSCarrier_RoundTrip exercises the native WS carrier: the WS-server-as-
+// net.Listener bridge (wsListener) accepts a coder/websocket dial (wsDial) and
+// the resulting net.Conn carries bytes both ways. This is the carrier the WS
+// transport type wraps in Noise+yamux via initTransport.
+func TestWSCarrier_RoundTrip(t *testing.T) {
+	lis, err := newWSListener("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("newWSListener: %v", err)
+	}
+	defer lis.Close() //nolint:errcheck
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, aerr := lis.Accept()
+		if aerr != nil {
+			accepted <- nil
+			return
+		}
+		accepted <- c
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cli, err := wsDial(ctx, "ws://"+lis.Addr().String()+"/")
+	if err != nil {
+		t.Fatalf("wsDial: %v", err)
+	}
+	defer cli.Close() //nolint:errcheck
+
+	srv := <-accepted
+	if srv == nil {
+		t.Fatal("listener Accept returned no conn")
+	}
+	defer srv.Close() //nolint:errcheck
+
+	// client -> server
+	if _, err := cli.Write([]byte("ping")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, 4)
+	if err := readFull(srv, buf); err != nil {
+		t.Fatalf("server read: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Fatalf("server got %q, want ping", buf)
+	}
+
+	// server -> client
+	if _, err := srv.Write([]byte("pong")); err != nil {
+		t.Fatalf("server write: %v", err)
+	}
+	buf2 := make([]byte, 4)
+	if err := readFull(cli, buf2); err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if string(buf2) != "pong" {
+		t.Fatalf("client got %q, want pong", buf2)
+	}
+}
+
+func readFull(c net.Conn, b []byte) error {
+	if err := c.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		return err
+	}
+	_, err := io.ReadFull(c, b)
+	return err
+}

--- a/pkg/transport/network/ws_tinygo.go
+++ b/pkg/transport/network/ws_tinygo.go
@@ -1,0 +1,30 @@
+//go:build tinygo
+
+// Package network pkg/transport/network/ws_tinygo.go
+//
+// TinyGo WS-transport carrier. Serving is impossible in a browser (no listening
+// socket), so Start fails closed. Dialing IS possible via the browser's native
+// WebSocket API, but coder/websocket (used natively) pulls net/http, which does
+// not compile here — so the browser dial is wired in a follow-up that adapts the
+// syscall/js WebSocket to a net.Conn (the same pattern as the dmsg WS carrier's
+// ws_js_tinygo.go). Until then it fails closed so the package builds and a
+// browser visor can still use its other transports (dmsg).
+package network
+
+import (
+	"context"
+	"errors"
+	"net"
+)
+
+// errWSUnsupported is returned by the TinyGo WS carrier stubs.
+var errWSUnsupported = errors.New("ws: not supported on this build yet (TinyGo) — browser WebSocket dial is a follow-up; serving needs a listening socket a browser lacks")
+
+func wsDial(_ context.Context, _ string) (net.Conn, error) {
+	return nil, errWSUnsupported
+}
+
+// Start implements Client: a browser cannot accept WS transports.
+func (c *wsClient) Start() error {
+	return errWSUnsupported
+}

--- a/pkg/transport/types/types.go
+++ b/pkg/transport/types/types.go
@@ -20,4 +20,11 @@ const (
 	// plus RFC 9221 unreliable datagrams; the TLS session is bound to the
 	// skywire static key (#2607 QUIC follow-on).
 	QUIC Type = "quic"
+	// WS is a type of a transport that works visor-to-visor over a direct
+	// WebSocket, resolving the peer's wss:// endpoint via a PK table. Unlike the
+	// dmsg WebSocket carrier (which reaches a dmsg server), this is a first-class
+	// skywire transport between two visors. A browser visor can DIAL it (the
+	// browser's WebSocket API) but not accept it (no server) — server-visors run
+	// the WS listener; see pkg/transport/network/ws_native.go / ws_tinygo.go.
+	WS Type = "ws"
 )


### PR DESCRIPTION
## What

Promotes WebSocket from a **dmsg carrier** (reaches a dmsg server) to a **first-class skywire transport type**: a *direct* visor-to-visor link over a WebSocket, with the peer's `wss://` endpoint resolved from a PK table (like `stcp`, but over WebSocket). Usable by both wasm and non-wasm visors, and the **carrier→network.Type pattern** the WebTransport/WebRTC types will follow.

- `types.WS` (`"ws"`) added to the transport type set.
- `wsClient` (`ws.go`): `Dial` resolves the peer's WS URL from a PK table and wraps the resulting `net.Conn` in the shared Noise+yamux `initTransport` path. The dial carrier is build-tagged.
- `ws_native.go` (`!tinygo`): `wsDial` via coder/websocket; `Start` runs a WebSocket HTTP server fronted as a `net.Listener` (`wsListener`) so the existing `acceptTransports` loop drains it.
- `ws_tinygo.go` (tinygo): fail-closed stubs — a browser can't serve, and the browser-native WebSocket dial (coder/websocket pulls net/http) is the **next PR**; until then the package builds and a browser visor uses its other transports.
- `ClientFactory.WSTable` (PK→wss URL) + `MakeClient` dispatch for `types.WS`.

## Verification

- New `ws_native_test.go` validates the carrier end-to-end: `wsListener` accepts a `wsDial` and the `net.Conn` carries bytes **both ways**.
- Native `go build ./...`, the `pkg/transport/network` suite, and lint pass; the wasm-visor tinygo build is unaffected.

## Next

Browser-native WebSocket **dial** under TinyGo (adapting the syscall/js WebSocket to a `net.Conn`, like the dmsg WS carrier's `ws_js_tinygo.go`) — so a browser tab can dial a server-visor's WS transport. Then WebTransport-direct and WebRTC follow the same pattern.