### PR TITLE
feat(transport): browser WebSocket dial for the WS transport (wasm visor)

### DIFF
--- a/pkg/dmsg/dmsg/ws_js_tinygo.go
+++ b/pkg/dmsg/dmsg/ws_js_tinygo.go
@@ -261,3 +261,12 @@ func (c *wsConnJS) SetWriteDeadline(time.Time) error { return nil }
 
 // SetDeadline sets the read deadline (write has none).
 func (c *wsConnJS) SetDeadline(t time.Time) error { return c.SetReadDeadline(t) }
+
+// DialWebSocketJS dials a browser-native WebSocket to url and returns it as a
+// net.Conn. It is the TinyGo/js WebSocket dialer, exported so the WS transport
+// carrier (pkg/transport/network) can reuse the same tested net.Conn adapter a
+// browser visor uses to reach a dmsg server — here to reach a peer visor's WS
+// transport endpoint.
+func DialWebSocketJS(ctx context.Context, url string) (net.Conn, error) {
+	return dialWebSocketJS(ctx, url)
+}

--- a/pkg/transport/network/ws_browser.go
+++ b/pkg/transport/network/ws_browser.go
@@ -1,0 +1,24 @@
+//go:build tinygo && js && wasm
+
+// Package network pkg/transport/network/ws_browser.go
+//
+// Browser WS-transport DIAL: a browser visor dials a peer visor's WebSocket
+// transport endpoint via the browser-native WebSocket API. coder/websocket
+// (the native carrier, ws_native.go) pulls net/http, which is broken on the
+// TinyGo js target, so we reuse the dmsg carrier's tested syscall/js WebSocket→
+// net.Conn adapter (dmsg.DialWebSocketJS). The returned net.Conn flows through
+// the same Noise+yamux initTransport path as every other carrier — so a tab can
+// be the dialing edge of a direct WS transport (it still can't accept; see
+// ws_tinygo.go).
+package network
+
+import (
+	"context"
+	"net"
+
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+func wsDial(ctx context.Context, url string) (net.Conn, error) {
+	return dmsg.DialWebSocketJS(ctx, url)
+}

--- a/pkg/transport/network/ws_tinygo.go
+++ b/pkg/transport/network/ws_tinygo.go
@@ -2,29 +2,22 @@
 
 // Package network pkg/transport/network/ws_tinygo.go
 //
-// TinyGo WS-transport carrier. Serving is impossible in a browser (no listening
-// socket), so Start fails closed. Dialing IS possible via the browser's native
-// WebSocket API, but coder/websocket (used natively) pulls net/http, which does
-// not compile here — so the browser dial is wired in a follow-up that adapts the
-// syscall/js WebSocket to a net.Conn (the same pattern as the dmsg WS carrier's
-// ws_js_tinygo.go). Until then it fails closed so the package builds and a
-// browser visor can still use its other transports (dmsg).
+// TinyGo WS-transport: the SERVE side. A browser (or any TinyGo target) cannot
+// run the WebSocket HTTP server a WS transport listener needs, so Start fails
+// closed on all TinyGo builds. The DIAL side is target-specific: ws_browser.go
+// (tinygo && js && wasm) dials the browser-native WebSocket; ws_tinygo_nows.go
+// (other TinyGo targets) stubs it.
 package network
 
-import (
-	"context"
-	"errors"
-	"net"
-)
+import "errors"
 
-// errWSUnsupported is returned by the TinyGo WS carrier stubs.
-var errWSUnsupported = errors.New("ws: not supported on this build yet (TinyGo) — browser WebSocket dial is a follow-up; serving needs a listening socket a browser lacks")
+// errWSServe is returned by Start on TinyGo (no listening socket).
+var errWSServe = errors.New("ws: serving not supported on this build (TinyGo) — a browser/embedded target has no listening socket")
 
-func wsDial(_ context.Context, _ string) (net.Conn, error) {
-	return nil, errWSUnsupported
-}
+// errWSDial is returned by the WS dial stub on non-browser TinyGo targets.
+var errWSDial = errors.New("ws: WebSocket dial not supported on this TinyGo target")
 
-// Start implements Client: a browser cannot accept WS transports.
+// Start implements Client: a browser/embedded TinyGo target cannot accept WS.
 func (c *wsClient) Start() error {
-	return errWSUnsupported
+	return errWSServe
 }

--- a/pkg/transport/network/ws_tinygo_nows.go
+++ b/pkg/transport/network/ws_tinygo_nows.go
@@ -1,0 +1,17 @@
+//go:build tinygo && !(js && wasm)
+
+// Package network pkg/transport/network/ws_tinygo_nows.go
+//
+// WS dial stub for non-browser TinyGo targets (e.g. wasip1, bare-metal). There
+// is no browser WebSocket API here and coder/websocket (net/http) is excluded,
+// so WS dialing is unavailable. The browser dial lives in ws_browser.go.
+package network
+
+import (
+	"context"
+	"net"
+)
+
+func wsDial(_ context.Context, _ string) (net.Conn, error) {
+	return nil, errWSDial
+}


### PR DESCRIPTION
## What

Completes WS-direct (#3224) for the browser: a wasm visor can now **dial** a peer visor's WebSocket transport endpoint. `coder/websocket` (the native carrier) pulls net/http — broken on TinyGo js — so reuse the dmsg carrier's tested `syscall/js` WebSocket→`net.Conn` adapter, **the same one a browser visor already uses to reach dmsg servers** (here pointed at a peer visor's WS endpoint instead).

- **dmsg**: export `DialWebSocketJS(ctx, url) (net.Conn, error)` wrapping the existing browser WebSocket dialer (`tinygo && js && wasm`).
- **network WS carrier split by target**:
  - `ws_native.go` (`!tinygo`): coder/websocket dial + WS server (unchanged).
  - `ws_browser.go` (`tinygo && js && wasm`): `wsDial` → `dmsg.DialWebSocketJS`.
  - `ws_tinygo_nows.go` (`tinygo && !(js && wasm)`): `wsDial` stub (wasip1/embedded).
  - `ws_tinygo.go` (`tinygo`): `Start` fails closed on all TinyGo (no listening socket).

So a browser tab is the **dial-only edge** of a direct WS transport; server-visors run the listener. The `net.Conn` flows through the same Noise+yamux `initTransport` path as every carrier.

## Verification

- Native `go build ./...`, `tinygo build -target wasm ./cmd/wasm-visor` (browser dial wired), and `tinygo build -target wasip1` (stub path) all pass.
- The browser `net.Conn` adapter is the same one already proven in production reaching dmsg servers over WS.