### PR TITLE
feat(transport): WT-direct as a first-class network.Type (visor↔visor WebTransport)

### DIFF
--- a/pkg/dmsg/dmsg/wt_js_tinygo.go
+++ b/pkg/dmsg/dmsg/wt_js_tinygo.go
@@ -299,3 +299,13 @@ func (c *wtConnJS) SetReadDeadline(t time.Time) error {
 }
 func (c *wtConnJS) SetWriteDeadline(time.Time) error { return nil }
 func (c *wtConnJS) SetDeadline(t time.Time) error    { return c.SetReadDeadline(t) }
+
+// DialWebTransportJS dials a browser-native WebTransport to url, pinning the
+// server cert by certHashHex (lowercase SHA-256 hex), and returns one
+// bidirectional stream as a net.Conn. It is the TinyGo/js WebTransport dialer,
+// exported so the WT transport carrier (pkg/transport/network) can reuse the same
+// tested cert-pinned net.Conn adapter a browser visor uses to reach a dmsg
+// server — here to reach a peer visor's WT transport endpoint.
+func DialWebTransportJS(ctx context.Context, url, certHashHex string) (net.Conn, error) {
+	return dialWebTransportJS(ctx, url, certHashHex)
+}

--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -64,6 +64,9 @@ type ClientFactory struct {
 	// WSTable maps a peer PK to its direct WebSocket (wss://) URL for the WS
 	// transport type. Reuses stcp.PKTable (PK→URL); empty/absent disables WS.
 	WSTable stcp.PKTable
+	// WTTable maps a peer PK to its direct WebTransport endpoint + pinned cert
+	// hash for the WT transport type. A nil/absent table disables WT dialing.
+	WTTable WTTable
 	// ARClient is the address-resolver client (addrresolver.APIClient). Typed as
 	// `any` so this file doesn't import addrresolver — which pulls net/http +
 	// packetfilter (→ quic-go), none of which compile on the TinyGo target. Only
@@ -108,6 +111,8 @@ func (f *ClientFactory) MakeClient(netType types.Type, port int) (Client, error)
 		return newStcp(generic, f.PKTable), nil
 	case types.WS:
 		return newWS(generic, f.WSTable), nil
+	case types.WT:
+		return newWT(generic, f.WTTable), nil
 	case types.DMSG:
 		return newDmsgClient(f.DmsgC), nil
 	}

--- a/pkg/transport/network/wt.go
+++ b/pkg/transport/network/wt.go
@@ -1,0 +1,113 @@
+// Package network pkg/transport/network/wt.go
+//
+// WT is a first-class skywire transport type: a direct visor-to-visor link over
+// WebTransport (HTTP/3 over QUIC), with the peer's https:// endpoint and pinned
+// cert hash resolved from a table (like WS, but over WebTransport instead of a
+// WebSocket). It is distinct from the dmsg WebTransport carrier, which reaches a
+// dmsg server rather than a peer visor.
+//
+// The server presents a short-lived self-signed cert pinned by SHA-256 — no CA,
+// no domain (the dmsg WT cert-hash model). A browser visor can DIAL this
+// transport (the browser's WebTransport API + serverCertificateHashes) but
+// cannot accept it (no listening socket) — so server-visors run the WT listener
+// (wt_native.go) while the dial side is build-tagged: webtransport-go on native,
+// the browser-native WebTransport under TinyGo/js (wt_browser.go). The dialed /
+// accepted bidirectional stream is adapted to a net.Conn and flows through the
+// SAME genericClient initTransport (Noise + yamux) path as every other carrier.
+package network
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// WTEntry is a peer's WebTransport dial target: the https:// endpoint URL and
+// the lowercase SHA-256 hex of the server's self-signed cert (pinned exactly as
+// a browser pins it via serverCertificateHashes).
+type WTEntry struct {
+	URL      string
+	CertHash string
+}
+
+// WTTable maps a peer PK to its WebTransport dial target (URL + pinned cert
+// hash). It is the WT analog of stcp.PKTable, which carries only a bare address.
+type WTTable interface {
+	Entry(pk cipher.PubKey) (WTEntry, bool)
+}
+
+// wtMemoryTable is an in-memory WTTable.
+type wtMemoryTable struct {
+	entries map[cipher.PubKey]WTEntry
+}
+
+// NewWTTable returns an in-memory WTTable from the given entries.
+func NewWTTable(entries map[cipher.PubKey]WTEntry) WTTable {
+	return &wtMemoryTable{entries: entries}
+}
+
+func (t *wtMemoryTable) Entry(pk cipher.PubKey) (WTEntry, bool) {
+	e, ok := t.entries[pk]
+	return e, ok
+}
+
+// wtClient is the WT-transport implementation of Client. table maps a peer PK to
+// its WebTransport endpoint + pinned cert hash.
+type wtClient struct {
+	*genericClient
+	table WTTable
+
+	// advertised holds the WT listener's public dial info once Start has run
+	// (native only); a browser/TinyGo client never serves, so these stay empty.
+	advertisedURL      string
+	advertisedCertHash string
+}
+
+// AdvertisedWT returns the WT listener's dial URL and pinned cert hash after
+// Start has run, for advertising to peers (table/discovery). Both are empty
+// before Start or on non-serving (browser/TinyGo) builds.
+func (c *wtClient) AdvertisedWT() (url, certHash string) {
+	return c.advertisedURL, c.advertisedCertHash
+}
+
+func newWT(generic *genericClient, table WTTable) Client {
+	client := &wtClient{genericClient: generic, table: table}
+	client.netType = types.WT
+	return client
+}
+
+// ErrWTEntryNotFound is returned when the requested PK has no WT entry in the table.
+var ErrWTEntryNotFound = errors.New("wt: entry not found in table")
+
+// Dial implements Client: resolve the peer's WT endpoint + cert hash, dial it
+// (build-tagged carrier: webtransport-go on native, the browser WebTransport API
+// on TinyGo/js), and wrap the resulting net.Conn in a skywire transport.
+func (c *wtClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16) (Transport, error) {
+	if c.isClosed() {
+		return nil, io.ErrClosedPipe
+	}
+
+	if c.table == nil {
+		return nil, ErrWTEntryNotFound
+	}
+	e, ok := c.table.Entry(rPK)
+	if !ok {
+		return nil, ErrWTEntryNotFound
+	}
+	c.log.Debugf("Dialing WT %v @ %s", rPK, e.URL)
+
+	conn, err := wtDial(ctx, e.URL, e.CertHash)
+	if err != nil {
+		return nil, err
+	}
+
+	tp, err := c.initTransport(ctx, conn, rPK, rPort)
+	if err != nil {
+		conn.Close() //nolint:errcheck,gosec
+		return nil, err
+	}
+	return tp, nil
+}

--- a/pkg/transport/network/wt_browser.go
+++ b/pkg/transport/network/wt_browser.go
@@ -1,0 +1,25 @@
+//go:build tinygo && js && wasm
+
+// Package network pkg/transport/network/wt_browser.go
+//
+// Browser WT-transport DIAL: a browser visor dials a peer visor's WebTransport
+// endpoint via the browser-native WebTransport API, pinning the peer's
+// self-signed cert by SHA-256 (serverCertificateHashes). webtransport-go (the
+// native carrier, wt_native.go) pulls quic-go, which doesn't compile on the
+// TinyGo js target, so we reuse the dmsg carrier's tested syscall/js
+// WebTransport→net.Conn adapter (dmsg.DialWebTransportJS), the same one a browser
+// visor uses to reach a dmsg server. The returned net.Conn flows through the same
+// Noise+yamux initTransport path as every other carrier — so a tab can be the
+// dialing edge of a direct WT transport (it still can't accept; see wt_tinygo.go).
+package network
+
+import (
+	"context"
+	"net"
+
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+func wtDial(ctx context.Context, url, certHashHex string) (net.Conn, error) {
+	return dmsg.DialWebTransportJS(ctx, url, certHashHex)
+}

--- a/pkg/transport/network/wt_native.go
+++ b/pkg/transport/network/wt_native.go
@@ -1,0 +1,214 @@
+//go:build !tinygo
+
+// Package network pkg/transport/network/wt_native.go
+//
+// Native WT-transport carrier: dial via webtransport-go (pinning the server's
+// self-signed cert by SHA-256, the browser serverCertificateHashes model), and
+// accept by running a WebTransport (HTTP/3 over QUIC) server fronted as a
+// net.Listener so the shared acceptTransports loop can drain it. A browser visor
+// has neither (it can't run a server, and webtransport-go pulls quic-go) — see
+// wt_tinygo.go.
+package network
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/webtransport-go"
+
+	"github.com/skycoin/skywire/pkg/skyquic"
+)
+
+// wtPath is the HTTP/3 path the WebTransport endpoint is served on; the
+// advertised URL includes it (e.g. "https://host:port/skywire").
+const wtPath = "/skywire"
+
+// wtAcceptTimeout bounds how long a freshly-upgraded WebTransport session may
+// take to open its first (yamux-carrying) bidirectional stream.
+const wtAcceptTimeout = 30 * time.Second
+
+// wtStreamConn adapts a WebTransport bidirectional stream + its session
+// addresses into a net.Conn, so the stream flows through the shared transport
+// path (Noise + yamux) like any accepted/dialed conn.
+type wtStreamConn struct {
+	*webtransport.Stream
+	local, remote net.Addr
+}
+
+func (c wtStreamConn) LocalAddr() net.Addr  { return c.local }
+func (c wtStreamConn) RemoteAddr() net.Addr { return c.remote }
+
+// wtDial dials a peer visor's WebTransport endpoint at url, pinning its
+// self-signed server cert by certHashHex (lowercase SHA-256 hex), opens one
+// bidirectional stream, and adapts it to a net.Conn. Standard CA verification is
+// disabled; the cert-hash pin is authoritative, exactly as the dmsg WT carrier
+// (and a browser's serverCertificateHashes) does it.
+func wtDial(ctx context.Context, url, certHashHex string) (net.Conn, error) {
+	wantHash, err := hex.DecodeString(certHashHex)
+	if err != nil || len(wantHash) != sha256.Size {
+		return nil, fmt.Errorf("wt: invalid cert hash %q", certHashHex)
+	}
+	tlsConf := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // pinned by cert-hash below, browser serverCertificateHashes model
+		NextProtos:         []string{skyquic.WebTransportNextProto},
+		// Disable session resumption: a resumed session would skip
+		// VerifyPeerCertificate and thus the cert-hash pin (gosec G123).
+		ClientSessionCache:     nil,
+		SessionTicketsDisabled: true,
+		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			if len(rawCerts) == 0 {
+				return fmt.Errorf("wt: server presented no certificate")
+			}
+			got := sha256.Sum256(rawCerts[0])
+			if !hmac.Equal(got[:], wantHash) {
+				return fmt.Errorf("wt: server cert hash mismatch")
+			}
+			return nil
+		},
+	}
+	d := &webtransport.Dialer{
+		TLSClientConfig: tlsConf,
+		QUICConfig: &quic.Config{
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true, // required by webtransport-go
+		},
+	}
+	_, sess, err := d.Dial(ctx, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("wt: dial %q: %w", url, err)
+	}
+	str, err := sess.OpenStreamSync(ctx)
+	if err != nil {
+		sess.CloseWithError(0, "open stream") //nolint:errcheck,gosec
+		return nil, fmt.Errorf("wt: open stream: %w", err)
+	}
+	return wtStreamConn{Stream: str, local: sess.LocalAddr(), remote: sess.RemoteAddr()}, nil
+}
+
+// Start implements Client: serve incoming WT transports.
+func (c *wtClient) Start() error {
+	if c.connListener != nil {
+		return ErrAlreadyListening
+	}
+	go c.serve()
+	return nil
+}
+
+func (c *wtClient) serve() {
+	lis, err := newWTListener(c.listenAddr)
+	if err != nil {
+		c.log.Errorf("Failed to start WT listener on %q: %v", c.listenAddr, err)
+		return
+	}
+	c.advertisedURL = fmt.Sprintf("https://%s%s", lis.Addr().String(), wtPath)
+	c.advertisedCertHash = hex.EncodeToString(lis.certHash[:])
+	c.log.Infof("Serving WT transport at %s (cert %s)", c.advertisedURL, c.advertisedCertHash)
+	c.acceptTransports(lis)
+}
+
+// wtListener fronts a WebTransport (HTTP/3) server as a net.Listener: the first
+// bidirectional stream of each accepted WebTransport session is delivered as a
+// net.Conn from Accept(). The server presents a fresh self-signed cert; its
+// SHA-256 (certHash) is what dialing peers pin. Cert rotation (WebTransport certs
+// are browser-capped at <=14 days) is a wiring concern for a longer-lived
+// listener; this listener holds one cert for its lifetime.
+type wtListener struct {
+	addr     net.Addr
+	certHash [32]byte
+	conns    chan net.Conn
+	done     chan struct{}
+	wtSrv    *webtransport.Server
+	once     sync.Once
+}
+
+func newWTListener(addr string) (*wtListener, error) {
+	udpConn, err := net.ListenPacket("udp", addr)
+	if err != nil {
+		return nil, err
+	}
+	cert, certHash, err := skyquic.NewWebTransportCertificate()
+	if err != nil {
+		udpConn.Close() //nolint:errcheck,gosec
+		return nil, fmt.Errorf("wt: generate cert: %w", err)
+	}
+
+	l := &wtListener{
+		addr:     udpConn.LocalAddr(),
+		certHash: certHash,
+		conns:    make(chan net.Conn),
+		done:     make(chan struct{}),
+	}
+
+	mux := http.NewServeMux()
+	h3 := &http3.Server{
+		TLSConfig:       skyquic.WebTransportTLSConfig(cert),
+		Handler:         mux,
+		EnableDatagrams: true,
+		QUICConfig: &quic.Config{
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true,
+		},
+	}
+	webtransport.ConfigureHTTP3Server(h3)
+	l.wtSrv = &webtransport.Server{
+		H3:          h3,
+		CheckOrigin: func(*http.Request) bool { return true }, // PK auth is in Noise, not origin
+	}
+	mux.HandleFunc(wtPath, l.handle)
+	go l.wtSrv.Serve(udpConn) //nolint:errcheck
+	return l, nil
+}
+
+func (l *wtListener) handle(w http.ResponseWriter, r *http.Request) {
+	sess, err := l.wtSrv.Upgrade(w, r)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), wtAcceptTimeout)
+	defer cancel()
+	str, err := sess.AcceptStream(ctx)
+	if err != nil {
+		sess.CloseWithError(0, "no stream") //nolint:errcheck,gosec
+		return
+	}
+	conn := wtStreamConn{Stream: str, local: sess.LocalAddr(), remote: sess.RemoteAddr()}
+	select {
+	case l.conns <- conn:
+	case <-l.done:
+		sess.CloseWithError(0, "closed") //nolint:errcheck,gosec
+	}
+}
+
+// Accept implements net.Listener.
+func (l *wtListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.conns:
+		return c, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+
+// Close implements net.Listener.
+func (l *wtListener) Close() error {
+	l.once.Do(func() {
+		close(l.done)
+		_ = l.wtSrv.Close() //nolint:errcheck
+	})
+	return nil
+}
+
+// Addr implements net.Listener.
+func (l *wtListener) Addr() net.Addr { return l.addr }

--- a/pkg/transport/network/wt_native_test.go
+++ b/pkg/transport/network/wt_native_test.go
@@ -1,0 +1,97 @@
+//go:build !tinygo
+
+package network
+
+import (
+	"context"
+	"encoding/hex"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestWTCarrier_RoundTrip exercises the native WT carrier: the WebTransport-
+// server-as-net.Listener bridge (wtListener) accepts a cert-pinned webtransport-go
+// dial (wtDial) and the resulting net.Conn carries bytes both ways. This is the
+// carrier the WT transport type wraps in Noise+yamux via initTransport. The dial
+// pins the listener's self-signed cert by SHA-256 exactly as a browser would.
+func TestWTCarrier_RoundTrip(t *testing.T) {
+	lis, err := newWTListener("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("newWTListener: %v", err)
+	}
+	defer lis.Close() //nolint:errcheck
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, aerr := lis.Accept()
+		if aerr != nil {
+			accepted <- nil
+			return
+		}
+		accepted <- c
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	url := "https://" + lis.Addr().String() + wtPath
+	cli, err := wtDial(ctx, url, hex.EncodeToString(lis.certHash[:]))
+	if err != nil {
+		t.Fatalf("wtDial: %v", err)
+	}
+	defer cli.Close() //nolint:errcheck
+
+	// A WebTransport (QUIC) stream is not created on the wire until the client
+	// first writes, so the server's AcceptStream — and thus the listener's
+	// Accept — only completes after this write. (In real use, initTransport
+	// writes the Noise handshake immediately, which is what triggers it.)
+	if _, err := cli.Write([]byte("ping")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+
+	srv := <-accepted
+	if srv == nil {
+		t.Fatal("listener Accept returned no conn")
+	}
+	defer srv.Close() //nolint:errcheck
+
+	// client -> server
+	buf := make([]byte, 4)
+	if err := readFull(srv, buf); err != nil {
+		t.Fatalf("server read: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Fatalf("server got %q, want ping", buf)
+	}
+
+	// server -> client
+	if _, err := srv.Write([]byte("pong")); err != nil {
+		t.Fatalf("server write: %v", err)
+	}
+	buf2 := make([]byte, 4)
+	if err := readFull(cli, buf2); err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if string(buf2) != "pong" {
+		t.Fatalf("client got %q, want pong", buf2)
+	}
+}
+
+// TestWTCarrier_CertHashMismatch confirms the cert-hash pin rejects a wrong hash.
+func TestWTCarrier_CertHashMismatch(t *testing.T) {
+	lis, err := newWTListener("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("newWTListener: %v", err)
+	}
+	defer lis.Close() //nolint:errcheck
+
+	go func() { _, _ = lis.Accept() }() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	url := "https://" + lis.Addr().String() + wtPath
+	var wrong [32]byte // all-zero hash, never matches a real cert
+	if _, err := wtDial(ctx, url, hex.EncodeToString(wrong[:])); err == nil {
+		t.Fatal("wtDial succeeded with wrong cert hash, want failure")
+	}
+}

--- a/pkg/transport/network/wt_tinygo.go
+++ b/pkg/transport/network/wt_tinygo.go
@@ -1,0 +1,23 @@
+//go:build tinygo
+
+// Package network pkg/transport/network/wt_tinygo.go
+//
+// TinyGo WT-transport: the SERVE side. A browser (or any TinyGo target) cannot
+// run the HTTP/3 WebTransport server a WT transport listener needs, so Start
+// fails closed on all TinyGo builds. The DIAL side is target-specific:
+// wt_browser.go (tinygo && js && wasm) dials the browser-native WebTransport;
+// wt_tinygo_nows.go (other TinyGo targets) stubs it.
+package network
+
+import "errors"
+
+// errWTServe is returned by Start on TinyGo (no listening socket / no HTTP/3).
+var errWTServe = errors.New("wt: serving not supported on this build (TinyGo) — a browser/embedded target has no HTTP/3 listener")
+
+// errWTDial is returned by the WT dial stub on non-browser TinyGo targets.
+var errWTDial = errors.New("wt: WebTransport dial not supported on this TinyGo target")
+
+// Start implements Client: a browser/embedded TinyGo target cannot accept WT.
+func (c *wtClient) Start() error {
+	return errWTServe
+}

--- a/pkg/transport/network/wt_tinygo_nows.go
+++ b/pkg/transport/network/wt_tinygo_nows.go
@@ -1,0 +1,17 @@
+//go:build tinygo && !(js && wasm)
+
+// Package network pkg/transport/network/wt_tinygo_nows.go
+//
+// WT dial stub for non-browser TinyGo targets (e.g. wasip1, bare-metal). There
+// is no browser WebTransport API here and webtransport-go (quic-go) is excluded,
+// so WT dialing is unavailable. The browser dial lives in wt_browser.go.
+package network
+
+import (
+	"context"
+	"net"
+)
+
+func wtDial(_ context.Context, _, _ string) (net.Conn, error) {
+	return nil, errWTDial
+}

--- a/pkg/transport/types/types.go
+++ b/pkg/transport/types/types.go
@@ -27,4 +27,13 @@ const (
 	// browser's WebSocket API) but not accept it (no server) — server-visors run
 	// the WS listener; see pkg/transport/network/ws_native.go / ws_tinygo.go.
 	WS Type = "ws"
+	// WT is a type of a transport that works visor-to-visor over a direct
+	// WebTransport (HTTP/3 over QUIC) link, resolving the peer's https:// endpoint
+	// and pinned cert hash via a table. Like the dmsg WebTransport carrier, the
+	// server presents a short-lived self-signed cert pinned by SHA-256 (no CA, no
+	// domain) and the client→server PK is authenticated in the Noise handshake. A
+	// browser visor can DIAL it (the browser WebTransport API, serverCertificate-
+	// Hashes) but not accept it (no server) — server-visors run the WT listener;
+	// see pkg/transport/network/wt_native.go / wt_tinygo.go.
+	WT Type = "wt"
 )


### PR DESCRIPTION
## What

Promotes WebTransport from a **dmsg carrier** to a **first-class skywire transport type** — the WT analog of WS-direct (#3224). A direct visor-to-visor link over WebTransport (HTTP/3 over QUIC).

Like the dmsg WT carrier, the server presents a short-lived **self-signed cert pinned by SHA-256** — no CA, no domain — and the client→server PK is authenticated in the Noise handshake. A **browser visor can DIAL** it (the browser WebTransport API + `serverCertificateHashes`) but not accept it (no HTTP/3 listener); server-visors run the listener.

## How

- **types**: add `WT Type = "wt"`.
- **network WT client** (`wt.go`, untagged): `wtClient` + `Dial`; `WTTable` maps PK → `{URL, CertHash}` (richer than `stcp.PKTable`, which carries only an address); `AdvertisedWT()` exposes the listener's dial URL + cert hash for advertising to peers.
- **carrier split by target**:
  - `wt_native.go` (`!tinygo`): cert-pinned webtransport-go dial + a WebTransport (HTTP/3) server fronted as a `net.Listener` (`wtListener`) delivering each session's first bidirectional stream as a `net.Conn`; self-signed cert via `skyquic.NewWebTransportCertificate`.
  - `wt_browser.go` (`tinygo && js && wasm`): `wtDial` → `dmsg.DialWebTransportJS` (reuses the tested `syscall/js` WebTransport→`net.Conn` cert-pinned adapter).
  - `wt_tinygo_nows.go` (`tinygo && !(js && wasm)`): `wtDial` stub (wasip1/embedded).
  - `wt_tinygo.go` (`tinygo`): `Start` fails closed on all TinyGo.
- **dmsg**: export `DialWebTransportJS(ctx, url, certHashHex)` for the browser carrier.
- `ClientFactory.WTTable` wires PK→target into `MakeClient(types.WT)`.

The dialed/accepted stream flows through the same Noise+yamux `initTransport` path as every carrier.

> A WebTransport stream is created on the wire only on the client's first write, so the listener's `Accept` completes once `initTransport` sends the Noise handshake — the round-trip test writes before awaiting `Accept` for this reason.

## Verification

- Native `go build ./...`, `go test` (WT carrier **round-trip** + **cert-hash mismatch rejection**), `tinygo build -target wasm ./cmd/wasm-visor` (browser dial), and the wasip1 stub-path typecheck all pass.