### PR TITLE
feat(wasm-visor): dial direct WS/WT transports from the browser tab

### DIFF
--- a/cmd/wasm-visor/index.html
+++ b/cmd/wasm-visor/index.html
@@ -80,6 +80,11 @@
           const arr = JSON.parse(j);
           return { count: Array.isArray(arr) ? arr.length : 0, sample: Array.isArray(arr) ? arr.slice(0, 1) : arr };
         }
+        case "dialTransport": {
+          // a = [peerPK, netType("ws"|"wt"), url, certHash?]
+          const id = await skywireVisor.dialTransport(a[0] || "", a[1] || "wt", a[2] || "", a[3] || "");
+          return { transport: id };
+        }
         case "status":
           return skywireVisor.status();
         case "reload":

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -16,6 +16,9 @@
 //
 //	const pk = await skywireVisor.boot(skHexOrEmpty, seedPkHex, seedWsURL, discDmsgAddr)
 //	skywireVisor.status()  // → { pk, booted, dmsg, tpManager, router, procManager, transports, routes }
+//	// dial a direct visor↔visor transport from this tab to a peer that listens:
+//	await skywireVisor.dialTransport(peerPkHex, "wt", "https://host:port/skywire", certHashHex)
+//	await skywireVisor.dialTransport(peerPkHex, "ws", "ws://host:port/")
 //
 // Build + run the dev harness (index.html drives boot/status/reload, and connects
 // back to the cmd/dmsg-wasm serve.go control bridge so a shell can drive the tab):
@@ -55,7 +58,9 @@ import (
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/transport/network"
+	"github.com/skycoin/skywire/pkg/transport/network/stcp"
 	"github.com/skycoin/skywire/pkg/transport/tpdclient"
+	types "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/wasmhv"
 )
 
@@ -69,6 +74,12 @@ var (
 	procM  appserver.ProcManager
 	hvCore *wasmhv.Core
 	tpd    transport.DiscoveryClient
+
+	// wsTable / wtTable hold the dial targets (peer PK → endpoint) for the
+	// browser-dialable direct transports. They are mutable so the dialTransport
+	// JS hook can add a target just before SaveTransport dials it.
+	wsTable stcp.PKTable
+	wtTable network.WTTable
 )
 
 // vlog emits a step message to the browser console AND, when present, the
@@ -84,10 +95,11 @@ func vlog(msg string) {
 func main() {
 	ctx = context.Background()
 	js.Global().Set("skywireVisor", js.ValueOf(map[string]interface{}{
-		"boot":    js.FuncOf(jsBoot),
-		"status":  js.FuncOf(jsStatus),
-		"hvApi":   js.FuncOf(jsHvAPI),
-		"tpdEdge": js.FuncOf(jsTPDEdge),
+		"boot":          js.FuncOf(jsBoot),
+		"status":        js.FuncOf(jsStatus),
+		"hvApi":         js.FuncOf(jsHvAPI),
+		"tpdEdge":       js.FuncOf(jsTPDEdge),
+		"dialTransport": js.FuncOf(jsDialTransport),
 	}))
 	fmt.Println("wasm-visor: ready — call skywireVisor.boot(sk, seedPk, seedWs, discDmsgAddr)")
 	select {} // block forever
@@ -173,7 +185,15 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	}
 	tpd = tpdclient.NewDmsg(dmsgC, tpdPK, pk, sk, mLog)
 	eb := appevent.NewBroadcaster(mLog.PackageLogger("eb"), time.Second)
-	factory := network.ClientFactory{PK: pk, SK: sk, DmsgC: dmsgC, MLogger: mLog, EB: eb}
+	// Browser-dialable direct transports (WS / WT). The tables start empty and are
+	// populated at dial time by the dialTransport JS hook; the tab can DIAL these
+	// (browser WebSocket / WebTransport) but never accept them.
+	wsTable = stcp.NewTable(nil)
+	wtTable = network.NewWTTable(nil)
+	factory := network.ClientFactory{
+		PK: pk, SK: sk, DmsgC: dmsgC, MLogger: mLog, EB: eb,
+		WSTable: wsTable, WTTable: wtTable,
+	}
 	tmConf := &transport.ManagerConfig{
 		PubKey:          pk,
 		SecKey:          sk,
@@ -190,6 +210,14 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	vlog("tp_manager: dmsg client inited; serving…")
 	go tm.Serve(ctx)
 	vlog("tp_manager: serving")
+	// Register the browser-dialable direct transport clients. Their Start() fails
+	// closed under TinyGo (a tab can't run a WS/WT listener) — logged, non-fatal —
+	// but Dial works, so SaveTransport(WS|WT) can create an outbound transport to a
+	// peer that runs the listener. This makes WS/WT "known" networks for the
+	// dialTransport hook.
+	tm.InitClient(ctx, types.WS, 0)
+	tm.InitClient(ctx, types.WT, 0)
+	vlog("tp_manager: WS/WT dial clients registered")
 
 	// 3. edge router (receives route rules + forwards/consumes packets). nil
 	// RouteFinder/RouteGroupDialer → the route-SOURCE path is the build-tagged
@@ -353,5 +381,57 @@ func jsTPDEdge(_ js.Value, args []js.Value) interface{} {
 		}
 		b, _ := json.Marshal(entries) //nolint:errcheck
 		return string(b), nil
+	})
+}
+
+// jsDialTransport(pkHex, netType, url, certHash) creates a direct visor↔visor
+// transport from this tab to a peer that runs the listener:
+//   - netType "ws": url is the peer's ws:// (or wss://) WebSocket endpoint.
+//   - netType "wt": url is the peer's https:// WebTransport endpoint and
+//     certHash is the lowercase SHA-256 hex of its self-signed cert (CA-free,
+//     the browser serverCertificateHashes model).
+//
+// It registers the dial target in the appropriate table, then SaveTransport dials
+// it (browser WebSocket / WebTransport) and registers the new edge in the TPD over
+// dmsg — so peers' route-finders can path to this tab over the new link. Returns
+// the transport ID on success.
+func jsDialTransport(_ js.Value, args []js.Value) interface{} {
+	pkHex := args[0].String()
+	netType := args[1].String()
+	url := args[2].String()
+	certHash := ""
+	if len(args) > 3 {
+		certHash = args[3].String()
+	}
+	return promise(func() (interface{}, error) {
+		if tpM == nil {
+			return nil, errors.New("not booted; call boot() first")
+		}
+		var pk cipher.PubKey
+		if err := pk.UnmarshalText([]byte(pkHex)); err != nil {
+			return nil, fmt.Errorf("bad pk: %w", err)
+		}
+		switch types.Type(netType) {
+		case types.WS:
+			if wsTable == nil {
+				return nil, errors.New("ws table not initialized")
+			}
+			wsTable.SetAddr(pk, url)
+		case types.WT:
+			if wtTable == nil {
+				return nil, errors.New("wt table not initialized")
+			}
+			if certHash == "" {
+				return nil, errors.New("wt requires a cert hash (4th arg)")
+			}
+			wtTable.SetEntry(pk, network.WTEntry{URL: url, CertHash: certHash})
+		default:
+			return nil, fmt.Errorf("unsupported transport type %q (use ws or wt)", netType)
+		}
+		tp, err := tpM.SaveTransport(ctx, pk, types.Type(netType), transport.LabelUser)
+		if err != nil {
+			return nil, fmt.Errorf("save transport: %w", err)
+		}
+		return tp.Entry.ID.String(), nil
 	})
 }

--- a/pkg/transport/network/wt.go
+++ b/pkg/transport/network/wt.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	types "github.com/skycoin/skywire/pkg/transport/types"
@@ -35,23 +36,39 @@ type WTEntry struct {
 
 // WTTable maps a peer PK to its WebTransport dial target (URL + pinned cert
 // hash). It is the WT analog of stcp.PKTable, which carries only a bare address.
+// SetEntry allows entries to be added at runtime (e.g. learned from a peer or a
+// JS hook), mirroring stcp.PKTable.SetAddr.
 type WTTable interface {
 	Entry(pk cipher.PubKey) (WTEntry, bool)
+	SetEntry(pk cipher.PubKey, e WTEntry)
 }
 
-// wtMemoryTable is an in-memory WTTable.
+// wtMemoryTable is an in-memory, concurrency-safe WTTable.
 type wtMemoryTable struct {
+	mu      sync.RWMutex
 	entries map[cipher.PubKey]WTEntry
 }
 
-// NewWTTable returns an in-memory WTTable from the given entries.
+// NewWTTable returns an in-memory WTTable seeded with the given entries (may be
+// nil for an empty, runtime-populated table).
 func NewWTTable(entries map[cipher.PubKey]WTEntry) WTTable {
+	if entries == nil {
+		entries = make(map[cipher.PubKey]WTEntry)
+	}
 	return &wtMemoryTable{entries: entries}
 }
 
 func (t *wtMemoryTable) Entry(pk cipher.PubKey) (WTEntry, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	e, ok := t.entries[pk]
 	return e, ok
+}
+
+func (t *wtMemoryTable) SetEntry(pk cipher.PubKey, e WTEntry) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.entries[pk] = e
 }
 
 // wtClient is the WT-transport implementation of Client. table maps a peer PK to


### PR DESCRIPTION
## What

Wires the **WS-direct** (#3225) and **WT-direct** (#3226) transports into the browser visor so a tab can **create** a direct visor↔visor link to a peer that runs the listener — making those carriers usable by the centerpiece, not just unit-tested.

## How

- **transport/network**: `WTTable` gains `SetEntry` (mutable, concurrency-safe), the WT analog of `stcp.PKTable.SetAddr` — so a dial target can be added at runtime.
- **cmd/wasm-visor**: register WS + WT dial clients (`tm.InitClient`) after the manager serves. Their `Start()` fails closed under TinyGo (a tab has no listening socket) — logged, non-fatal — but `Dial` works, so the networks become "known" and `SaveTransport(WS|WT)` can dial out. New `dialTransport(peerPK, type, url[, certHash])` JS hook seeds the table, then `SaveTransport` dials it and registers the new edge in the TPD over dmsg, so peers can route to the tab over the new link.
- **index.html** harness: a `dialTransport` control action for runtime exercise.

WT is the browser-practical p2p link: its self-signed cert is pinned by SHA-256 (`serverCertificateHashes`), so a tab reaches a peer by **bare IP, no CA**. The dialed `net.Conn` flows through the same Noise+yamux transport path as every carrier.

End-to-end round-trip needs a peer running a WS/WT listener (the native carrier, unit-tested in #3225/#3226); this lands the dial side for the browser.

## Verification

- Native `go build ./...`, `tinygo build -target wasm ./cmd/wasm-visor`, and lint all pass.