### PR TITLE
feat(wasm-visor): surface the tab's own visor in its hypervisor UI

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appdisc"
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
@@ -280,6 +281,10 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	// porting the app.
 	vlog("hypervisor: serving…")
 	hvCore = wasmhv.NewCore(pk, dmsgC)
+	// The tab is a visor AND its own hypervisor: surface THIS visor in the HV UI
+	// (identity / routes / transports), read from its own transport.Manager +
+	// router, alongside any remote visors that dial in.
+	hvCore.SetSelf(visorSelf{})
 	go func() {
 		if err := hvCore.Serve(ctx); err != nil {
 			mLog.PackageLogger("hypervisor").WithError(err).Error("hvCore.Serve returned")
@@ -382,6 +387,50 @@ func jsTPDEdge(_ js.Value, args []js.Value) interface{} {
 		b, _ := json.Marshal(entries) //nolint:errcheck
 		return string(b), nil
 	})
+}
+
+// visorSelf is the wasmhv.SelfProvider for the tab's own visor: it reads the
+// local identity, route count, and transports straight from this process's
+// router + transport.Manager, so the HV UI shows THIS visor (not just remote
+// visors that dial in).
+type visorSelf struct{}
+
+func (visorSelf) SelfPK() cipher.PubKey { return selfPK }
+
+func (visorSelf) SelfOverview() wasmhv.Overview {
+	ov := wasmhv.Overview{PubKey: selfPK, BuildInfo: buildinfo.Get()}
+	if rtr != nil {
+		ov.RoutesCount = rtr.RoutesCount()
+	}
+	return ov
+}
+
+func (s visorSelf) SelfSummary() wasmhv.Summary {
+	ov := s.SelfOverview()
+	return wasmhv.Summary{
+		Overview:     &ov,
+		Health:       &wasmhv.HealthInfo{ServicesHealth: "healthy"},
+		Online:       true,
+		IsHypervisor: true,
+	}
+}
+
+func (visorSelf) SelfTransports() []*wasmhv.TransportSummary {
+	out := []*wasmhv.TransportSummary{}
+	if tpM == nil {
+		return out
+	}
+	tpM.WalkTransports(func(mt *transport.ManagedTransport) bool {
+		out = append(out, &wasmhv.TransportSummary{
+			ID:     mt.Entry.ID,
+			Local:  selfPK,
+			Remote: mt.Remote(),
+			Type:   string(mt.Type()),
+			Label:  string(mt.Entry.Label),
+		})
+		return true
+	})
+	return out
 }
 
 // jsDialTransport(pkHex, netType, url, certHash) creates a direct visor↔visor

--- a/pkg/wasmhv/core.go
+++ b/pkg/wasmhv/core.go
@@ -104,6 +104,7 @@ type Core struct {
 
 	mu     sync.RWMutex
 	visors map[cipher.PubKey]*gobRPCClient
+	self   SelfProvider // the tab's OWN visor (nil for a plain standalone HV)
 }
 
 // NewCore returns a Core for the given dmsg client + this hypervisor's PK.

--- a/pkg/wasmhv/router.go
+++ b/pkg/wasmhv/router.go
@@ -74,6 +74,11 @@ func (c *Core) visorRoute(method, rest string, body []byte) (int, []byte) {
 	if len(parts) == 2 {
 		sub = parts[1]
 	}
+	// The tab's OWN visor is served locally (its transport.Manager + router),
+	// not over a gob RPC dial.
+	if self := c.selfProvider(); self != nil && self.SelfPK() == pk {
+		return c.selfRoute(self, sub)
+	}
 	switch {
 	case sub == "":
 		return jsonResp(c.overviewOf(pk))
@@ -198,7 +203,8 @@ func (c *Core) transportRoute(method string, pk cipher.PubKey, tid string) (int,
 	return 404, []byte(`{"error":"transport subroute not implemented in wasm core"}`)
 }
 
-// allOverviews concurrently fetches every connected visor's Overview.
+// allOverviews concurrently fetches every connected visor's Overview, with the
+// tab's OWN visor (if any) listed first.
 func (c *Core) allOverviews() []Overview {
 	pks := c.connectedPKs()
 	out := make([]Overview, len(pks))
@@ -208,10 +214,14 @@ func (c *Core) allOverviews() []Overview {
 		go func(i int, pk cipher.PubKey) { defer wg.Done(); out[i] = c.overviewOf(pk) }(i, pk)
 	}
 	wg.Wait()
+	if self := c.selfProvider(); self != nil {
+		out = append([]Overview{self.SelfOverview()}, out...)
+	}
 	return out
 }
 
-// allSummaries concurrently fetches every connected visor's Summary.
+// allSummaries concurrently fetches every connected visor's Summary, with the
+// tab's OWN visor (if any) listed first.
 func (c *Core) allSummaries() []Summary {
 	pks := c.connectedPKs()
 	out := make([]Summary, len(pks))
@@ -221,6 +231,9 @@ func (c *Core) allSummaries() []Summary {
 		go func(i int, pk cipher.PubKey) { defer wg.Done(); out[i] = c.summaryOf(pk) }(i, pk)
 	}
 	wg.Wait()
+	if self := c.selfProvider(); self != nil {
+		out = append([]Summary{self.SelfSummary()}, out...)
+	}
 	return out
 }
 

--- a/pkg/wasmhv/self.go
+++ b/pkg/wasmhv/self.go
@@ -1,0 +1,54 @@
+package wasmhv
+
+import "github.com/skycoin/skywire/pkg/cipher"
+
+// SelfProvider supplies the LOCAL (tab's own) visor's hypervisor view, so a
+// wasm-visor presents ITSELF in its hypervisor UI alongside the remote visors
+// that dial in. Unlike a remote visor (reached over a gob RPC dial), the self
+// visor is THIS process — its Overview/Summary/Transports are read straight from
+// the tab's own transport.Manager + router, no dmsg round-trip.
+//
+// A wasm-visor wires this via Core.SetSelf; a plain standalone wasm hypervisor
+// (no local visor) leaves it nil and only shows dialed-in visors.
+type SelfProvider interface {
+	SelfPK() cipher.PubKey
+	SelfOverview() Overview
+	SelfSummary() Summary
+	SelfTransports() []*TransportSummary
+}
+
+// SetSelf attaches the local visor's hypervisor view. Pass nil to detach.
+func (c *Core) SetSelf(self SelfProvider) {
+	c.mu.Lock()
+	c.self = self
+	c.mu.Unlock()
+}
+
+// selfProvider returns the attached SelfProvider (nil if none).
+func (c *Core) selfProvider() SelfProvider {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.self
+}
+
+// selfRoute handles /visors/<selfPK>[/sub] for the local visor, reading the
+// tab's own transport.Manager + router instead of dialing over dmsg. Only the
+// read views the dashboard needs are served; control sub-routes (app/transport
+// mutation) are not yet wired for the self visor and 404.
+func (c *Core) selfRoute(self SelfProvider, sub string) (int, []byte) {
+	switch sub {
+	case "":
+		return jsonResp(self.SelfOverview())
+	case "summary":
+		return jsonResp(self.SelfSummary())
+	case "health":
+		// The local visor is, by definition, up if the tab is running.
+		return jsonResp(HealthInfo{ServicesHealth: "healthy"})
+	case "transports":
+		return jsonResp(self.SelfTransports())
+	case "transport-types":
+		// The browser-dialable direct transport types the wasm-visor supports.
+		return jsonResp([]string{"dmsg", "ws", "wt"})
+	}
+	return 404, []byte(`{"error":"self visor subroute not implemented in wasm core"}`)
+}

--- a/pkg/wasmhv/self_test.go
+++ b/pkg/wasmhv/self_test.go
@@ -1,0 +1,104 @@
+package wasmhv
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// fakeSelf is a SelfProvider stub for a known local visor.
+type fakeSelf struct {
+	pk  cipher.PubKey
+	tps []*TransportSummary
+}
+
+func (f fakeSelf) SelfPK() cipher.PubKey { return f.pk }
+func (f fakeSelf) SelfOverview() Overview {
+	return Overview{PubKey: f.pk, RoutesCount: 3}
+}
+func (f fakeSelf) SelfSummary() Summary {
+	ov := f.SelfOverview()
+	return Summary{Overview: &ov, Online: true, IsHypervisor: true}
+}
+func (f fakeSelf) SelfTransports() []*TransportSummary { return f.tps }
+
+func newSelfPK(t *testing.T) cipher.PubKey {
+	t.Helper()
+	pk, _ := cipher.GenerateKeyPair()
+	return pk
+}
+
+// TestSelf_ListedAndRoutedLocally verifies that once a SelfProvider is attached,
+// the local visor appears in the summary list and its /visors/<pk> routes are
+// served from the provider (not a gob RPC dial), with no remote visors connected.
+func TestSelf_ListedAndRoutedLocally(t *testing.T) {
+	pk := newSelfPK(t)
+	tid := uuid.New()
+	core := NewCore(pk, nil)
+	core.SetSelf(fakeSelf{
+		pk:  pk,
+		tps: []*TransportSummary{{ID: tid, Local: pk, Remote: newSelfPK(t), Type: "wt", Label: "user"}},
+	})
+
+	// /visors-summary includes the self visor (the only one).
+	status, body := core.ServeHTTP("GET", "/api/visors-summary", nil)
+	if status != 200 {
+		t.Fatalf("visors-summary status = %d", status)
+	}
+	var sums []Summary
+	if err := json.Unmarshal(body, &sums); err != nil {
+		t.Fatalf("unmarshal summaries: %v", err)
+	}
+	if len(sums) != 1 || sums[0].Overview == nil || sums[0].Overview.PubKey != pk {
+		t.Fatalf("self visor not first in summaries: %+v", sums)
+	}
+	if !sums[0].IsHypervisor || !sums[0].Online {
+		t.Fatalf("self summary flags wrong: %+v", sums[0])
+	}
+
+	// /visors/<selfPK> is served locally (overview with the route count).
+	status, body = core.ServeHTTP("GET", "/api/visors/"+pk.Hex(), nil)
+	if status != 200 {
+		t.Fatalf("self overview status = %d", status)
+	}
+	var ov Overview
+	if err := json.Unmarshal(body, &ov); err != nil {
+		t.Fatalf("unmarshal overview: %v", err)
+	}
+	if ov.PubKey != pk || ov.RoutesCount != 3 {
+		t.Fatalf("self overview wrong: %+v", ov)
+	}
+
+	// /visors/<selfPK>/transports returns the local transports.
+	status, body = core.ServeHTTP("GET", "/api/visors/"+pk.Hex()+"/transports", nil)
+	if status != 200 {
+		t.Fatalf("self transports status = %d", status)
+	}
+	var tps []*TransportSummary
+	if err := json.Unmarshal(body, &tps); err != nil {
+		t.Fatalf("unmarshal transports: %v", err)
+	}
+	if len(tps) != 1 || tps[0].ID != tid || tps[0].Type != "wt" {
+		t.Fatalf("self transports wrong: %+v", tps)
+	}
+}
+
+// TestSelf_AbsentWhenNotSet verifies a plain standalone HV (no SelfProvider)
+// lists no visors when none have dialed in.
+func TestSelf_AbsentWhenNotSet(t *testing.T) {
+	core := NewCore(newSelfPK(t), nil)
+	status, body := core.ServeHTTP("GET", "/api/visors-summary", nil)
+	if status != 200 {
+		t.Fatalf("status = %d", status)
+	}
+	var sums []Summary
+	if err := json.Unmarshal(body, &sums); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(sums) != 0 {
+		t.Fatalf("expected no visors without a self provider, got %d", len(sums))
+	}
+}


### PR DESCRIPTION
## What

The wasm-visor is a visor **and** its own hypervisor, but `wasmhv.Core` only listed **remote** visors that dial in over dmsg (gob RPC). So the HV UI never showed the tab's own identity, routes, or transports. This adds a `SelfProvider` so the local visor appears in the dashboard — read straight from this process's router + `transport.Manager`, no dmsg round-trip to itself.

## How

- **wasmhv**: `SelfProvider` interface (`SelfPK`/`SelfOverview`/`SelfSummary`/`SelfTransports`) + `Core.SetSelf`. `/api/visors` and `/api/visors-summary` list the self visor **first**; `/api/visors/<selfPK>[/summary|health|transports|transport-types]` are served locally via `selfRoute` instead of a gob RPC dial. A plain standalone HV (no `SelfProvider`) is unchanged — still shows only dialed-in visors.
- **cmd/wasm-visor**: `visorSelf` implements `SelfProvider` from `selfPK` + `rtr.RoutesCount()` + `tpM.WalkTransports`; wired via `hvCore.SetSelf(visorSelf{})`.

So the browser tab's hypervisor UI now shows **the tab itself** as a controllable visor (identity, route count, its WS/WT/dmsg transports) — the HV-UI half of the wasm-visor product.

## Verification

- Native `go build ./...`, `go test ./pkg/wasmhv` (self listed + routed locally; absent without a provider), `tinygo build -target wasm ./cmd/wasm-visor`, and lint all pass.