### PR TITLE
feat(wasmhv): serve the Angular hypervisor UI from a wasm-visor

### DIFF
--- a/cmd/skywire-cli/commands/hv/gen.go
+++ b/cmd/skywire-cli/commands/hv/gen.go
@@ -23,10 +23,14 @@ var (
 	genSeedPK   string
 	genSeedWS   string
 	genDisc     string
+	genVisor    bool
+	genWasmExec string
 )
 
 func init() {
-	genCmd.Flags().StringVar(&genWasm, "wasm", "", "path to the js/wasm dmsg-client binary (build: make dmsg-wasm) [required]")
+	genCmd.Flags().StringVar(&genWasm, "wasm", "", "path to the wasm binary: the js/wasm dmsg-client (make dmsg-wasm), or the TinyGo wasm-visor with --visor [required]")
+	genCmd.Flags().BoolVar(&genVisor, "visor", false, "target a full wasm-VISOR (cmd/wasm-visor, TinyGo) — edge + router + its own hypervisor — instead of the standalone dmsg-client hypervisor")
+	genCmd.Flags().StringVar(&genWasmExec, "wasm-exec", "", "path to wasm_exec.js (REQUIRED with --visor: TinyGo's differs from Go's; build/wasm-visor/wasm_exec_tinygo.js)")
 	genCmd.Flags().StringVarP(&genOut, "out", "o", "hypervisor.html", "output file")
 	genCmd.Flags().StringVarP(&genConf, "conf", "c", "", "visor config to derive the standalone key from (uses its sk)")
 	genCmd.Flags().Uint32Var(&genIndex, "index", 0, "with -c: re-derive keyring entry at this index (read-only); omit to mint+record the next one")
@@ -46,7 +50,10 @@ var genCmd = &cobra.Command{
 The output is a single file (Angular UI + WASM dmsg client + override.js + your
 config, all inlined) you can open from file:// — no server. By default it is a
 STANDALONE hypervisor (visors dial in); --viewer-pk makes it dial a remote
-hypervisor instead.
+hypervisor instead. --visor targets a full wasm-VISOR (edge + router + its own
+hypervisor, TinyGo) — pass the wasm-visor binary as --wasm plus its TinyGo
+--wasm-exec; the page then runs a complete visor in the tab and serves its own
+hypervisor UI.
 
 Identity: --sk sets an explicit key; otherwise -c <config> derives a standalone
 key from the visor's secret key (one-way + deterministic — regenerable, and a
@@ -81,8 +88,22 @@ train users to type secret keys into pages from external hosts.`,
 			os.Exit(1)
 		}
 
+		// A wasm-visor is TinyGo: its wasm_exec.js differs from Go's embedded one,
+		// so it must be supplied. The standalone (Go) dmsg-client uses the embedded.
+		wasmExec := wasmhv.WasmExecJS
+		if genWasmExec != "" {
+			if wasmExec, err = os.ReadFile(genWasmExec); err != nil { //nolint:gosec // operator-supplied path
+				cmd.PrintErrln("read --wasm-exec:", err)
+				os.Exit(1)
+			}
+		} else if genVisor {
+			cmd.PrintErrln("--visor requires --wasm-exec (TinyGo's wasm_exec.js; build/wasm-visor/wasm_exec_tinygo.js)")
+			os.Exit(1)
+		}
+
 		cfg := wasmhv.StandaloneConfig{
-			Standalone:   genViewerPK == "",
+			Visor:        genVisor,
+			Standalone:   !genVisor && genViewerPK == "",
 			HypervisorPK: genViewerPK,
 			SeedPK:       genSeedPK,
 			SeedWS:       genSeedWS,
@@ -90,7 +111,7 @@ train users to type secret keys into pages from external hosts.`,
 			SecretKey:    skHex,
 			Password:     genPassword,
 		}
-		html, err := wasmhv.GenerateStandalone(uiFS, wasmhv.WasmExecJS, wasm, wasmhv.OverrideJS, cfg)
+		html, err := wasmhv.GenerateStandalone(uiFS, wasmExec, wasm, wasmhv.OverrideJS, cfg)
 		if err != nil {
 			cmd.PrintErrln("generate:", err)
 			os.Exit(1)

--- a/pkg/wasmhv/generate.go
+++ b/pkg/wasmhv/generate.go
@@ -41,6 +41,15 @@ type StandaloneConfig struct {
 	Standalone   bool
 	HypervisorPK string // CFG.pk for viewer mode
 
+	// Visor, when true, targets a full wasm-VISOR (cmd/wasm-visor, TinyGo) rather
+	// than the standalone wasm dmsg-client hypervisor: it emits CFG.visor (so
+	// override.js boots via globalThis.skywireVisor and routes /api to the visor's
+	// in-wasm hvApi) and injects the TinyGo getRandomData shim into the WASM
+	// bootstrap (TinyGo's wasm_exec.js omits that gojs import, which a key-
+	// generating build needs). The caller must pass the TinyGo wasm-visor binary
+	// and TinyGo's wasm_exec.js.
+	Visor bool
+
 	// dmsg bootstrap: a seed server (PK + ws:// URL) the browser connects to
 	// first, then upgrades discovery to run over dmsg.
 	SeedPK string
@@ -121,7 +130,7 @@ func GenerateStandalone(uiFS fs.FS, wasmExecJS, wasm, overrideJS []byte, cfg Sta
 	if err != nil {
 		return nil, err
 	}
-	wasmJS, err := wasmBootstrap(wasm)
+	wasmJS, err := wasmBootstrap(wasm, cfg.Visor)
 	if err != nil {
 		return nil, err
 	}
@@ -153,9 +162,12 @@ func configJS(cfg StandaloneConfig) (string, error) {
 			fields = append(fields, fmt.Sprintf("%s:%s", k, jsString(v)))
 		}
 	}
-	if cfg.Standalone {
+	switch {
+	case cfg.Visor:
+		fields = append(fields, "visor:true")
+	case cfg.Standalone:
 		fields = append(fields, "standalone:true")
-	} else {
+	default:
 		add("pk", cfg.HypervisorPK)
 	}
 	add("seedpk", cfg.SeedPK)
@@ -202,9 +214,12 @@ func encryptKey(secretKeyHex, password string) (string, error) {
 }
 
 // wasmBootstrap gzips the wasm, base64s it, and emits the JS that decompresses
-// it in-browser (DecompressionStream) and instantiates + runs it. Go's wasm sets
-// globalThis.skywireDmsg and then blocks, so go.run is fired (not awaited).
-func wasmBootstrap(wasm []byte) (string, error) {
+// it in-browser (DecompressionStream) and instantiates + runs it. The wasm sets
+// its global (skywireDmsg / skywireVisor) and then blocks, so go.run is fired
+// (not awaited). When tinygo is true (the wasm-visor target), the gojs
+// runtime.getRandomData import that TinyGo's wasm_exec.js omits is injected — a
+// key-generating TinyGo build fails to instantiate without it.
+func wasmBootstrap(wasm []byte, tinygo bool) (string, error) {
 	var gz bytes.Buffer
 	w, err := gzip.NewWriterLevel(&gz, gzip.BestCompression)
 	if err != nil {
@@ -217,11 +232,20 @@ func wasmBootstrap(wasm []byte) (string, error) {
 		return "", err
 	}
 	b64 := base64.StdEncoding.EncodeToString(gz.Bytes())
+	shim := ""
+	if tinygo {
+		shim = `
+  if (go.importObject.gojs && !go.importObject.gojs["runtime.getRandomData"]) {
+    go.importObject.gojs["runtime.getRandomData"] = function(ptr, len){
+      crypto.getRandomValues(new Uint8Array(go._inst.exports.memory.buffer, ptr >>> 0, len >>> 0));
+    };
+  }`
+	}
 	return `(async function(){
   var b64 = "` + b64 + `";
   var bin = Uint8Array.from(atob(b64), function(c){ return c.charCodeAt(0); });
   var buf = await new Response(new Blob([bin]).stream().pipeThrough(new DecompressionStream("gzip"))).arrayBuffer();
-  var go = new Go();
+  var go = new Go();` + shim + `
   var res = await WebAssembly.instantiate(buf, go.importObject);
   go.run(res.instance);
 })();`, nil

--- a/pkg/wasmhv/generate_test.go
+++ b/pkg/wasmhv/generate_test.go
@@ -85,6 +85,34 @@ func TestGenerateStandalone_ViewerMode(t *testing.T) {
 	require.NotContains(t, string(out), "standalone:true")
 }
 
+// TestGenerateStandalone_VisorMode verifies the wasm-VISOR target emits CFG.visor
+// (so override.js boots via skywireVisor + routes /api to the visor's hvApi) and
+// injects the TinyGo getRandomData shim the key-generating visor build needs.
+func TestGenerateStandalone_VisorMode(t *testing.T) {
+	out, err := GenerateStandalone(fakeUI(),
+		[]byte("globalThis.Go=function(){};"), // stand-in TinyGo wasm_exec.js
+		[]byte("\x00asm-visor"), []byte("/*override*/"),
+		StandaloneConfig{Visor: true, SeedPK: "0371ab", Disc: "dmsg://022e:80"})
+	require.NoError(t, err)
+	s := string(out)
+	require.Contains(t, s, "visor:true")
+	require.NotContains(t, s, "standalone:true")
+	require.NotContains(t, s, `{pk:`, "visor mode has no remote hypervisor pk field")
+	// The TinyGo getRandomData shim must be present so the wasm instantiates.
+	require.Contains(t, s, `runtime.getRandomData`)
+	require.Contains(t, s, "DecompressionStream")
+}
+
+// TestGenerateStandalone_NoShimForGoTarget confirms the non-visor (Go wasm) path
+// does NOT inject the TinyGo getRandomData shim (Go's wasm_exec.js provides it).
+func TestGenerateStandalone_NoShimForGoTarget(t *testing.T) {
+	out, err := GenerateStandalone(fakeUI(),
+		[]byte("globalThis.Go=function(){};"), []byte("w"), []byte("o"),
+		StandaloneConfig{Standalone: true})
+	require.NoError(t, err)
+	require.NotContains(t, string(out), `runtime.getRandomData`)
+}
+
 // TestGenerateStandalone_EncryptedKey verifies the baked-in encsk decrypts with
 // the exact PBKDF2-SHA256(200000) + AES-GCM scheme override.js resolveSK uses:
 // base64([16-salt | 12-iv | ciphertext]).

--- a/pkg/wasmhv/override.js
+++ b/pkg/wasmhv/override.js
@@ -26,7 +26,7 @@
 
   // active = "do I have a mode to take over for?" When false, stay dormant and
   // let the serving backend's /api answer natively (served mode).
-  var active = !CFG.served && (Boolean(CFG.pk) || Boolean(CFG.standalone));
+  var active = !CFG.served && (Boolean(CFG.pk) || Boolean(CFG.standalone) || Boolean(CFG.visor));
   if (!active) {
     log('dormant: no hypervisor mode configured; native fetch/XHR pass through to the serving backend');
     return;
@@ -54,16 +54,26 @@
   // ensure boots the wasm client + connects (once). The first shimmed request
   // awaits this, so the app's initial /api call blocks until dmsg is up.
   //
-  // Two modes:
+  // Three modes:
   //  - viewer (default): route /api over dmsg to a REMOTE hypervisor CFG.pk.
-  //  - standalone (CFG.standalone): THIS tab IS the hypervisor — start
-  //    serveHypervisor() so visors listing this PK dial in, and route /api to
-  //    the in-wasm core (hvApi) instead of a remote fetch.
+  //  - standalone (CFG.standalone): THIS tab IS the hypervisor (wasm dmsg client) —
+  //    start serveHypervisor() so visors listing this PK dial in, and route /api
+  //    to the in-wasm core (hvApi) instead of a remote fetch.
+  //  - visor (CFG.visor): THIS tab is a full wasm-VISOR (TinyGo: edge + router +
+  //    its own hypervisor). boot() brings the whole stack up (and the HV core);
+  //    /api routes to the visor's in-wasm hvApi, which surfaces THIS visor plus
+  //    any visors that dial in. globalThis.skywireVisor, not skywireDmsg.
   function ensure() {
     if (readyP) return readyP;
     readyP = (async function () {
-      while (!self.skywireDmsg) { await new Promise(function (r) { setTimeout(r, 10); }); }
       var sk = await resolveSK();
+      if (CFG.visor) {
+        while (!self.skywireVisor) { await new Promise(function (r) { setTimeout(r, 10); }); }
+        var vpk = await self.skywireVisor.boot(sk, CFG.seedpk, CFG.seedws, CFG.disc);
+        log('wasm-visor booted as ' + vpk + ' (edge + hypervisor; /api → in-wasm core)');
+        return;
+      }
+      while (!self.skywireDmsg) { await new Promise(function (r) { setTimeout(r, 10); }); }
       var pk = await self.skywireDmsg.connect(sk, CFG.seedpk, CFG.seedws, CFG.disc);
       if (CFG.standalone) {
         await self.skywireDmsg.serveHypervisor();
@@ -75,11 +85,15 @@
     return readyP;
   }
 
-  // dispatch routes one same-origin request: in standalone mode to the in-wasm
-  // hypervisor core (hvApi), else over dmsg to the remote hypervisor (fetch).
-  // Both resolve to {status, body:Uint8Array, headers}; hvApi has no response
-  // headers of its own, so we synthesize a JSON content-type for the UI.
+  // dispatch routes one same-origin request: a wasm-visor / standalone hypervisor
+  // tab answers /api from its in-wasm core (hvApi); a viewer routes over dmsg to a
+  // remote hypervisor (fetch). Both resolve to {status, body:Uint8Array, headers};
+  // hvApi has no response headers of its own, so we synthesize a JSON content-type.
   function dispatch(method, path, body, headers) {
+    if (CFG.visor) {
+      return self.skywireVisor.hvApi(method, path, body == null ? null : String(body))
+        .then(function (r) { return { status: r.status, body: r.body, headers: { 'Content-Type': 'application/json' } }; });
+    }
     if (CFG.standalone) {
       return self.skywireDmsg.hvApi(method, path, body == null ? null : String(body))
         .then(function (r) { return { status: r.status, body: r.body, headers: { 'Content-Type': 'application/json' } }; });


### PR DESCRIPTION
## What

The standalone generator (`cli hv gen`) produced an Angular HV UI for the wasm dmsg-client hypervisor (`globalThis.skywireDmsg`). This teaches the same single-file machinery to target a full wasm-**VISOR** (`cmd/wasm-visor`, TinyGo) — so the browser tab runs a complete visor (edge + router + its own hypervisor) **and** serves its own Angular hypervisor UI, `/api` answered in-wasm. The UI then shows **this** visor (via the #3228 self-provider) alongside any visors that dial in.

## How

- **override.js**: a third mode, `CFG.visor`. `ensure()` boots via `skywireVisor.boot` (the whole stack + HV core) instead of `skywireDmsg.connect`; `dispatch()` routes `/api` to `skywireVisor.hvApi`. Viewer/standalone modes unchanged.
- **generate.go**: `StandaloneConfig.Visor` emits `CFG.visor` and injects the TinyGo `getRandomData` shim into the WASM bootstrap (TinyGo's wasm_exec.js omits that gojs import, which a key-generating build needs to instantiate); the Go target is unchanged (no shim).
- **`cli hv gen --visor`** (+ `--wasm-exec` for TinyGo's wasm_exec.js, which differs from Go's embedded one): pass the wasm-visor binary as `--wasm` to produce a single-file, serverless wasm-visor + hypervisor UI.

## Verification

- `go build ./...`, `go test ./pkg/wasmhv` (visor mode emits `CFG.visor` + the shim; Go target omits the shim), and lint all pass.