### PR TITLE
fix(transport): include QUIC (+ ws/wt/webrtc) in the transport preference order

### DIFF
--- a/pkg/route-finder/store/mark_and_sweep.go
+++ b/pkg/route-finder/store/mark_and_sweep.go
@@ -33,7 +33,8 @@ func newVertex(edgeID cipher.PubKey, transports []*transport.Entry) *vertex {
 			neighbourPk = tr.Edges[0]
 		}
 		// When multiple transports exist between the same edges, prefer the
-		// one with the lower TypePreference (STCPR > SUDPH > STCP > DMSG).
+		// one with the lower TypePreference (see tptypes.defaultPreference:
+		// STCPR > QUIC > SUDPH > STCP > WEBRTC > WS > WT > DMSG).
 		if existing, ok := connections[neighbourPk]; ok &&
 			tptypes.TypePreference(tr.Type) >= tptypes.TypePreference(existing.Type) {
 			continue

--- a/pkg/transport/types/preference.go
+++ b/pkg/transport/types/preference.go
@@ -4,10 +4,19 @@ import (
 	"sync/atomic"
 )
 
-// defaultPreference is the built-in priority order: STCPR > SUDPH > STCP > DMSG.
-// Direct types are preferred over DMSG because a dmsg server is an opaque
-// intermediary not visible to path planning. Unknown types sort last.
-var defaultPreference = []Type{STCPR, SUDPH, STCP, DMSG}
+// defaultPreference is the built-in priority order:
+//
+//	STCPR > QUIC > SUDPH > STCP > WEBRTC > WS > WT > DMSG
+//
+// STCPR (plain TCP via the address resolver) connects through the widest set of
+// networks, so it stays the reliable baseline. QUIC slots above SUDPH: both are
+// UDP, but QUIC is encrypted with modern congestion control and gives datagrams,
+// whereas SUDPH is raw KCP over hole-punching. The browser-oriented direct types
+// (WEBRTC/WS/WT) sit just above DMSG — they ARE direct (the "direct over DMSG"
+// rule), but are newer and chiefly serve browser/NAT-constrained peers. DMSG is
+// last: a dmsg server is an opaque intermediary not visible to path planning.
+// Unknown types sort after everything listed.
+var defaultPreference = []Type{STCPR, QUIC, SUDPH, STCP, WEBRTC, WS, WT, DMSG}
 
 // preferenceOrder is the active order, settable via SetPreferenceOrder.
 // Stored atomically so reads are lock-free in hot path code.
@@ -46,10 +55,14 @@ func SetPreferenceOrder(order []Type) {
 // detect this by comparing input/output lengths.
 func ParsePreferenceOrder(s []string) []Type {
 	known := map[string]Type{
-		string(STCPR): STCPR,
-		string(SUDPH): SUDPH,
-		string(STCP):  STCP,
-		string(DMSG):  DMSG,
+		string(STCPR):  STCPR,
+		string(QUIC):   QUIC,
+		string(SUDPH):  SUDPH,
+		string(STCP):   STCP,
+		string(WEBRTC): WEBRTC,
+		string(WS):     WS,
+		string(WT):     WT,
+		string(DMSG):   DMSG,
 	}
 	out := make([]Type, 0, len(s))
 	for _, name := range s {

--- a/pkg/transport/types/preference_test.go
+++ b/pkg/transport/types/preference_test.go
@@ -1,0 +1,60 @@
+package tptypes
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestDefaultPreferenceOrder pins the built-in priority order and confirms QUIC
+// (previously absent → sorted below DMSG) now ranks above SUDPH, and every direct
+// type outranks DMSG.
+func TestDefaultPreferenceOrder(t *testing.T) {
+	SetPreferenceOrder(nil) // ensure the built-in default is active
+
+	want := []Type{STCPR, QUIC, SUDPH, STCP, WEBRTC, WS, WT, DMSG}
+	for i := 1; i < len(want); i++ {
+		if TypePreference(want[i-1]) >= TypePreference(want[i]) {
+			t.Fatalf("order broken: %s (%d) should rank before %s (%d)",
+				want[i-1], TypePreference(want[i-1]), want[i], TypePreference(want[i]))
+		}
+	}
+
+	// QUIC must beat DMSG (the bug: it used to sort last, below DMSG).
+	if TypePreference(QUIC) >= TypePreference(DMSG) {
+		t.Fatalf("QUIC (%d) must outrank DMSG (%d)", TypePreference(QUIC), TypePreference(DMSG))
+	}
+
+	// An unknown type sorts after everything listed.
+	if TypePreference(Type("bogus")) != len(want) {
+		t.Fatalf("unknown type should sort last, got %d", TypePreference(Type("bogus")))
+	}
+}
+
+// TestParsePreferenceOrder confirms every known type (including the ones added)
+// parses, and unknown strings are dropped.
+func TestParsePreferenceOrder(t *testing.T) {
+	in := []string{"stcpr", "quic", "sudph", "stcp", "webrtc", "ws", "wt", "dmsg", "nope"}
+	got := ParsePreferenceOrder(in)
+	want := []Type{STCPR, QUIC, SUDPH, STCP, WEBRTC, WS, WT, DMSG}
+	if len(got) != len(want) {
+		t.Fatalf("parsed %d types, want %d (unknown 'nope' should be dropped): %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("parsed[%d]=%s, want %s", i, got[i], want[i])
+		}
+	}
+}
+
+// TestSetPreferenceOrderSortsTransports verifies a configured override actually
+// reorders a slice the way the router's dial logic relies on.
+func TestSetPreferenceOrderSortsTransports(t *testing.T) {
+	defer SetPreferenceOrder(nil)
+	SetPreferenceOrder([]Type{QUIC, STCPR, DMSG}) // QUIC first now
+
+	tps := []Type{DMSG, STCPR, QUIC}
+	sort.Slice(tps, func(i, j int) bool { return TypePreference(tps[i]) < TypePreference(tps[j]) })
+	if tps[0] != QUIC || tps[1] != STCPR || tps[2] != DMSG {
+		t.Fatalf("custom order not applied: %v", tps)
+	}
+}


### PR DESCRIPTION
## What

QUIC was a transport type but **absent from both** the default preference order and `ParsePreferenceOrder`'s known map. Consequences:
1. A `quic` transport sorted **last, below dmsg** — worse than an opaque relay, despite being a direct encrypted link.
2. An operator who put `"quic"` in config `transport_preference` had it **silently dropped** — it couldn't even be configured.

The newer direct types (`ws`/`wt`/`webrtc`) were missing too.

## New default order

`STCPR > QUIC > SUDPH > STCP > WEBRTC > WS > WT > DMSG`

STCPR stays the widest-reaching baseline; QUIC ranks above SUDPH (both UDP, but QUIC is encrypted with modern congestion control + datagrams vs raw KCP-over-holepunch); the browser-oriented direct types sit just above DMSG (direct, but newer / NAT-constrained-peer-focused); DMSG stays last (opaque intermediary). *(Order per maintainer decision.)*

## How

- **preference.go**: QUIC/WEBRTC/WS/WT added to `defaultPreference` + the parser map.
- **preference_test.go** (new — there was none): pins the order, asserts QUIC outranks DMSG, unknown types sort last, and a configured override reorders as the dial logic expects.
- **mark_and_sweep.go**: comment refreshed to the new order.

No behavior change unless a quic/ws/wt/webrtc transport actually exists; it fixes their ranking (and config-parsing) for when they do.

## Verification

- `go build ./...`, `go test ./pkg/transport/types ./pkg/route-finder/store`, lint — all pass.