### PR TITLE
refactor(transport): rename the QUIC transport type to "squic" (skywire-quic)

### DIFF
--- a/pkg/transport/types/preference.go
+++ b/pkg/transport/types/preference.go
@@ -55,14 +55,15 @@ func SetPreferenceOrder(order []Type) {
 // detect this by comparing input/output lengths.
 func ParsePreferenceOrder(s []string) []Type {
 	known := map[string]Type{
-		string(STCPR):  STCPR,
-		string(QUIC):   QUIC,
-		string(SUDPH):  SUDPH,
-		string(STCP):   STCP,
-		string(WEBRTC): WEBRTC,
-		string(WS):     WS,
-		string(WT):     WT,
-		string(DMSG):   DMSG,
+		string(STCPR):      STCPR,
+		string(QUIC):       QUIC, // "squic"
+		string(QUICLegacy): QUIC, // "quic" — back-compat alias
+		string(SUDPH):      SUDPH,
+		string(STCP):       STCP,
+		string(WEBRTC):     WEBRTC,
+		string(WS):         WS,
+		string(WT):         WT,
+		string(DMSG):       DMSG,
 	}
 	out := make([]Type, 0, len(s))
 	for _, name := range s {

--- a/pkg/transport/types/preference_test.go
+++ b/pkg/transport/types/preference_test.go
@@ -30,10 +30,10 @@ func TestDefaultPreferenceOrder(t *testing.T) {
 	}
 }
 
-// TestParsePreferenceOrder confirms every known type (including the ones added)
+// TestParsePreferenceOrder confirms every known type (canonical "squic" included)
 // parses, and unknown strings are dropped.
 func TestParsePreferenceOrder(t *testing.T) {
-	in := []string{"stcpr", "quic", "sudph", "stcp", "webrtc", "ws", "wt", "dmsg", "nope"}
+	in := []string{"stcpr", "squic", "sudph", "stcp", "webrtc", "ws", "wt", "dmsg", "nope"}
 	got := ParsePreferenceOrder(in)
 	want := []Type{STCPR, QUIC, SUDPH, STCP, WEBRTC, WS, WT, DMSG}
 	if len(got) != len(want) {
@@ -43,6 +43,24 @@ func TestParsePreferenceOrder(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("parsed[%d]=%s, want %s", i, got[i], want[i])
 		}
+	}
+}
+
+// TestQUICLegacyAlias confirms the canonical QUIC wire name is "squic" and the
+// pre-rename "quic" still parses + normalizes for back-compat.
+func TestQUICLegacyAlias(t *testing.T) {
+	if QUIC != "squic" {
+		t.Fatalf("QUIC canonical wire name = %q, want squic", QUIC)
+	}
+	if NormalizeType(QUICLegacy) != QUIC {
+		t.Fatalf(`NormalizeType("quic") = %q, want squic`, NormalizeType(QUICLegacy))
+	}
+	if NormalizeType(QUIC) != QUIC {
+		t.Fatalf("NormalizeType is not idempotent on the canonical name")
+	}
+	// Both names parse to QUIC in a preference list.
+	if got := ParsePreferenceOrder([]string{"quic"}); len(got) != 1 || got[0] != QUIC {
+		t.Fatalf(`ParsePreferenceOrder(["quic"]) = %v, want [squic]`, got)
 	}
 }
 

--- a/pkg/transport/types/types.go
+++ b/pkg/transport/types/types.go
@@ -15,11 +15,16 @@ const (
 	STCP Type = "stcp"
 	// DMSG is a type of a transport that works through an intermediary service
 	DMSG Type = "dmsg"
-	// QUIC is a type of a transport that works via QUIC over UDP, resolving
-	// addresses using the address-resolver service. Gives reliable streams
-	// plus RFC 9221 unreliable datagrams; the TLS session is bound to the
-	// skywire static key (#2607 QUIC follow-on).
-	QUIC Type = "quic"
+	// QUIC (wire name "squic" — skywire-quic, matching stcp/stcpr/sudph) is a
+	// type of a transport that works via QUIC over UDP, resolving addresses using
+	// the address-resolver service. Gives reliable streams plus RFC 9221
+	// unreliable datagrams; the TLS session is bound to the skywire static key
+	// (#2607 QUIC follow-on). The legacy wire name "quic" is still accepted on
+	// input (NormalizeType / the preference parser) for back-compat.
+	QUIC Type = "squic"
+	// QUICLegacy is the pre-rename wire name for QUIC, accepted on input so older
+	// configs / CLI invocations / discovery entries keep working. Not emitted.
+	QUICLegacy Type = "quic"
 	// WS is a type of a transport that works visor-to-visor over a direct
 	// WebSocket, resolving the peer's wss:// endpoint via a PK table. Unlike the
 	// dmsg WebSocket carrier (which reaches a dmsg server), this is a first-class
@@ -45,3 +50,14 @@ const (
 	// see pkg/transport/network/wt_native.go / wt_tinygo.go.
 	WT Type = "wt"
 )
+
+// NormalizeType maps a legacy transport-type wire name to its canonical Type, so
+// older configs / CLI invocations / discovery entries keep working after a
+// rename. Currently only "quic" → "squic" (QUIC). Canonical or unknown values
+// pass through unchanged.
+func NormalizeType(t Type) Type {
+	if t == QUICLegacy {
+		return QUIC
+	}
+	return t
+}

--- a/pkg/visor/api_transport.go
+++ b/pkg/visor/api_transport.go
@@ -222,13 +222,16 @@ func (v *Visor) AddTransport(remote cipher.PubKey, tpType string, timeout time.D
 		return nil, fmt.Errorf("--no-register flag is only valid for user-labeled transports")
 	}
 
-	v.log.Debugf("Saving transport to %v via %v with label %s", remote, tpType, tpLabel)
+	// Accept the legacy "quic" wire name as well as the canonical "squic".
+	netType := types.NormalizeType(types.Type(tpType))
+
+	v.log.Debugf("Saving transport to %v via %v with label %s", remote, netType, tpLabel)
 
 	opts := transport.SaveTransportOptions{
 		NoRegister: noRegister,
 	}
 
-	tp, err := v.tpM.SaveTransportWithOptions(ctx, remote, types.Type(tpType), tpLabel, opts)
+	tp, err := v.tpM.SaveTransportWithOptions(ctx, remote, netType, tpLabel, opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What

The QUIC visor↔visor transport type's wire name was `"quic"`, out of step with the skywire-prefixed convention of the other p2p types (`stcp` = skywire-tcp, `stcpr` = skywire-tcp-resolver, `sudph` = skywire-udp-holepunch). Rename it to **`squic`** (skywire-quic). Done now while ~0 quic transports are deployed (quic is not auto-created), so the migration cost is minimal.

The rename is **decoupled** from:
- the dmsg-over-QUIC **carrier** (the dmsg `Protocol="quic"` field in `pkg/dmsg`) — untouched;
- the **address-resolver wire protocol** (the fixed `/bind/quic` endpoint + its JSON fields) — untouched.

Only the skywire transport-type string changes; nearly everything already uses the `types.QUIC` const, so it propagates cleanly.

## Back-compat — nothing user-facing breaks

- `QUICLegacy = "quic"` + `NormalizeType` map the old name to QUIC on input.
- The preference parser accepts **both** `"squic"` and `"quic"` → QUIC, so existing config `transport_preference` lists keep working.
- `AddTransport` normalizes `"quic"` → `"squic"`, so `cli tp add quic` still works.
- Only stray pre-existing `"quic"` discovery entries deprioritize until they re-register as `"squic"` (self-healing; ~0 exist since quic isn't autoconnected).

`preference_test.go` adds alias coverage (canonical `squic`, legacy `quic`→QUIC, idempotent `NormalizeType`).

## Verification

- `go build ./...`, `go test ./pkg/transport/... ./pkg/visor` (no test hardcoded the literal `"quic"` type), lint — all pass.