### PR TITLE
feat(visor): opt-in WebRTC transport for non-wasm visors

### DIFF
--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -37,6 +37,7 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/pty"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/util/osutil"
 	"github.com/skycoin/skywire/pkg/visor/dmsgtracker"
 	"github.com/skycoin/skywire/pkg/visor/logserver"
@@ -527,6 +528,14 @@ func initDmsgCtrl(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	logger := dmsgC.Logger()
 	logger.Debug("Initializing DMSG transport client...")
 	v.tpM.InitDmsgClient(ctx, dmsgC)
+
+	// WebRTC (opt-in) signals over dmsg, so its client is started only now that
+	// the manager has the dmsg client. InitClient also starts the dmsg signaling
+	// listener, so the visor ACCEPTS WebRTC dials (e.g. from browser visors).
+	if v.conf.Transport != nil && v.conf.Transport.WebRTC {
+		logger.Info("Initializing WebRTC transport client (opt-in)...")
+		v.tpM.InitClient(ctx, tptypes.WEBRTC, 0)
+	}
 
 	// dmsgctrl setup — listen for incoming control streams (ping/pong).
 	// Each accepted Control is self-serving (handles ping/pong in its own goroutine).

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -457,6 +457,16 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		listenAddr = v.conf.STCP.ListeningAddress
 	}
 	v.stcpTable = table
+	// WebRTC ICE servers (only when the opt-in WebRTC transport is enabled): the
+	// configured STUN servers, prefixed with the stun: scheme the WebRTC stack
+	// wants. Set on the factory now; the WEBRTC client is started after dmsg comes
+	// up (init_dmsg → InitClient), since its signaling rides the dmsg client.
+	var iceURLs []string
+	if v.conf.Transport != nil && v.conf.Transport.WebRTC {
+		for _, s := range v.conf.StunServers {
+			iceURLs = append(iceURLs, "stun:"+s)
+		}
+	}
 	factory := network.ClientFactory{
 		PK:         v.conf.PK,
 		SK:         v.conf.SK,
@@ -465,6 +475,7 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		ARClient:   v.arClient,
 		EB:         v.ebc,
 		MLogger:    v.MasterLogger(),
+		ICEURLs:    iceURLs,
 		// OnExternalSTCPR notifies the public visor updater when an external
 		// connection is received, validating that the visor is internet-reachable
 		OnExternalSTCPR: func() {

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -405,6 +405,13 @@ type Transport struct {
 	// until proven on the fleet. A fixed port is preferable to ephemeral so the
 	// address-resolver registration + any firewall rule are stable.
 	QUICPort int `json:"quic_port,omitempty"`
+	// WebRTC enables the WebRTC DataChannel transport (ICE NAT-traversal;
+	// signaling rides dmsg). false (default/omitted) disables it — opt-in until
+	// proven on the fleet. When enabled the visor ACCEPTS WebRTC dials (so browser
+	// visors, which can't do stcpr/sudph/quic, can reach it) and can create them
+	// via `tp add webrtc`. ICE uses the configured StunServers. No fixed port:
+	// pion gathers ephemeral UDP host candidates and traverses NAT via ICE.
+	WebRTC bool `json:"webrtc,omitempty"`
 	// ARTransportLimit controls address resolver registration for privacy:
 	//   0 (default): stay registered indefinitely
 	//   N > 0: deregister from AR after N transports are established


### PR DESCRIPTION
## What

Lets a production (non-wasm) visor enable the **WebRTC DataChannel transport**, the same way `QUICPort` gates QUIC ("opt-in until proven on the fleet"). Its main value is the **accept side**: a browser visor can't do stcpr/sudph/quic (no raw sockets), so WebRTC (ICE NAT-traversal, signaling over dmsg) is how it reaches a native visor — and now native visors can answer.

## How

- **visorconfig**: `Transport.WebRTC bool` (json `"webrtc"`, default off). Carried by the whole-struct config mirror, so no `config_compat` change.
- **init_transport**: when enabled, set `ClientFactory.ICEURLs` from the configured `StunServers` (`stun:` scheme). No fixed port — pion gathers ephemeral UDP host candidates and traverses NAT via ICE.
- **init_dmsg**: after `InitDmsgClient` (which gives the manager the dmsg client WebRTC signals over), `InitClient(WEBRTC)` — this also starts the dmsg signaling listener, so the visor **accepts** WebRTC dials. Can also create them via `tp add webrtc`.

**Default-off**: no behavior change unless an operator sets `transport.webrtc=true`.

> Note: WebRTC is not yet *auto*-established — the hardcoded `EnsureDirectTransport` / autoconnect order is `STCPR/SUDPH/DMSG` and omits QUIC + the new types. Making the establishment order preference-aware is a tracked follow-up. This lands **accept + on-demand creation**.

## Verification

- `go build ./...`, lint — pass.