### PR TITLE
refactor(dmsg): fold PreferWS/PreferWT into an ordered Carriers list

### DIFF
--- a/cmd/dmsg-wasm/main.go
+++ b/cmd/dmsg-wasm/main.go
@@ -4,9 +4,9 @@
 //
 // A standard-Go js/wasm build of the dmsg client (NOT TinyGo — the client
 // pulls logrus + encoding/gob via the RPC paths, which need full reflection).
-// The browser sandbox can't open raw TCP/UDP sockets, so this build forces
-// Config.PreferWS: every session is dialed over the dmsg server's WebSocket
-// endpoint (Server.AddressWS). Inbound reachability still works — once the
+// The browser sandbox can't open raw TCP/UDP sockets, so this build forces the
+// WS carrier (Config.Carriers = ["ws"]): every session is dialed over the dmsg
+// server's WebSocket endpoint (Server.AddressWS). Inbound reachability still works — once the
 // client has an outbound WSS session to a dmsg server, peers dial it BY PUBLIC
 // KEY and the server bridges those streams back down the same WSS connection.
 // So a browser tab is a first-class, inbound-reachable dmsg peer.
@@ -135,7 +135,7 @@ func promise(fn func() (interface{}, error)) interface{} {
 //
 // A browser can't reach a dmsg-only discovery until it has a server, so we seed
 // one server directly: its PK + WebSocket URL (e.g. "ws://host:port/dmsg"). The
-// client connects to it over WS (forced PreferWS), then upgrades discovery to
+// client connects to it over WS (forced WS carrier), then upgrades discovery to
 // run over dmsg (discDmsgAddr = "dmsg://<disc-pk>:80") so it can register itself
 // + resolve peers. Empty secret key → ephemeral identity. See
 // dmsgclient.StartDmsgSeeded.

--- a/pkg/dmsg/dmsg/carrier_test.go
+++ b/pkg/dmsg/dmsg/carrier_test.go
@@ -1,0 +1,49 @@
+package dmsg
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+// TestPickCarrier locks the dmsg carrier-selection semantics: the first listed
+// carrier the server advertises wins; empty/no-match falls back to QUIC (when
+// advertised) else TCP; an explicit "tcp" wins even when QUIC is advertised.
+func TestPickCarrier(t *testing.T) {
+	full := &disc.Entry{
+		Protocol: "quic",
+		Server: &disc.Server{
+			Address:    "1.2.3.4:8081",
+			AddressWS:  "ws://1.2.3.4:8083/dmsg",
+			AddressWT:  "https://1.2.3.4:8084/dmsg",
+			AddressUDP: "1.2.3.4:8085",
+		},
+	}
+	tcpOnly := &disc.Entry{Server: &disc.Server{Address: "1.2.3.4:8081"}}
+
+	cases := []struct {
+		name     string
+		carriers []string
+		entry    *disc.Entry
+		wantNet  string
+		wantAddr string
+	}{
+		{"empty defaults to quic when advertised", nil, full, "quic", "1.2.3.4:8085"},
+		{"empty falls to tcp without quic", nil, tcpOnly, "tcp", "1.2.3.4:8081"},
+		{"ws preferred", []string{"ws"}, full, "ws", "ws://1.2.3.4:8083/dmsg"},
+		{"wt preferred", []string{"wt"}, full, "wt", "https://1.2.3.4:8084/dmsg"},
+		{"explicit tcp beats advertised quic", []string{"tcp"}, full, "tcp", "1.2.3.4:8081"},
+		{"first advertised wins (wt before ws)", []string{"wt", "ws"}, full, "wt", "https://1.2.3.4:8084/dmsg"},
+		{"skip unavailable, take next", []string{"wt", "ws"}, tcpOnly, "tcp", "1.2.3.4:8081"},
+		{"unknown name ignored, default applies", []string{"bogus"}, full, "quic", "1.2.3.4:8085"},
+		{"ws requested but not advertised → default", []string{"ws"}, tcpOnly, "tcp", "1.2.3.4:8081"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotNet, gotAddr := pickCarrier(c.carriers, c.entry)
+			if gotNet != c.wantNet || gotAddr != c.wantAddr {
+				t.Fatalf("pickCarrier(%v) = (%q,%q), want (%q,%q)", c.carriers, gotNet, gotAddr, c.wantNet, c.wantAddr)
+			}
+		})
+	}
+}

--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -72,22 +72,26 @@ type Config struct {
 	ConnectedServersType string
 	Protocol             string
 
-	// PreferWS makes the client dial a server's WebSocket endpoint
-	// (Server.AddressWS) when one is advertised, in preference to TCP/QUIC,
-	// falling back to TCP on WS failure. Native clients leave this false
-	// (raw TCP/QUIC is strictly better for them); it exists for restrictive
-	// networks where only HTTP(S)/443 egress is allowed, and is forced true
-	// in the js/wasm build, which has no other transport available.
-	PreferWS bool
-
-	// PreferWT makes the client dial a server's WebTransport endpoint
-	// (Server.AddressWT) when one is advertised, in preference to TCP/QUIC/WS,
-	// falling back to TCP on WT failure. Like PreferWS this is for non-default
-	// clients: it exists chiefly for the native test/tooling path that exercises
-	// the WebTransport listener (the production WT consumer is a browser dialing
-	// directly in JS). Native mesh clients leave this false.
-	PreferWT bool
+	// Carriers is the ordered preference of dmsg CARRIERS — how this client
+	// reaches a dmsg server — by name: "tcp", "ws", "wt", "quic". The first
+	// listed carrier the server advertises is dialed (falling back to TCP on dial
+	// failure). The carrier is transparent above the session: every dmsg stream is
+	// the same Noise+yamux regardless, so this only affects how bytes reach the
+	// rendezvous server. Empty (the native default) = QUIC when the server
+	// advertises it, else TCP — raw sockets are strictly better for native
+	// clients. It exists for restrictive networks (e.g. only 443/HTTPS egress →
+	// ["wt"] or ["ws"]) and is set to ["ws"] in the js/wasm build, which has no
+	// raw socket. Unknown names are ignored.
+	Carriers []string
 }
+
+// Carrier names for Config.Carriers.
+const (
+	CarrierTCP  = "tcp"
+	CarrierWS   = "ws"
+	CarrierWT   = "wt"
+	CarrierQUIC = "quic"
+)
 
 // Ensure ensures all config values are set.
 func (c *Config) Ensure() {

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -102,26 +102,44 @@ func (ce *Client) EnsureSession(ctx context.Context, entry *disc.Entry) error {
 // It is expected that the session is created and served before the context cancels, otherwise an error will be returned.
 // NOTE: This should not be called directly as it may lead to session duplicates.
 // Only `ensureSession` or `EnsureAndObtainSession` should call this function.
+// pickCarrier chooses the dmsg carrier (network + dial address) for a server
+// entry from an ordered carrier preference. The first listed carrier the server
+// advertises wins. Empty list or no match falls back to the default: QUIC when
+// the server advertises a QUIC endpoint (Protocol "quic" + AddressUDP), else the
+// legacy TCP path. Unknown carrier names are skipped. Pure — unit-tested.
+func pickCarrier(carriers []string, entry *disc.Entry) (network, addr string) {
+	for _, c := range carriers {
+		switch c {
+		case CarrierWT:
+			if entry.Server.AddressWT != "" {
+				return CarrierWT, entry.Server.AddressWT
+			}
+		case CarrierWS:
+			if entry.Server.AddressWS != "" {
+				return CarrierWS, entry.Server.AddressWS
+			}
+		case CarrierQUIC:
+			if entry.Protocol == "quic" && entry.Server.AddressUDP != "" {
+				return CarrierQUIC, entry.Server.AddressUDP
+			}
+		case CarrierTCP:
+			return CarrierTCP, entry.Server.Address
+		}
+	}
+	if entry.Protocol == "quic" && entry.Server.AddressUDP != "" {
+		return CarrierQUIC, entry.Server.AddressUDP
+	}
+	return CarrierTCP, entry.Server.Address
+}
+
 func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs ClientSession, err error) {
 	ce.log.WithField("remote_pk", entry.Static).Debug("Dialing session...")
 
-	// Pick transport. WS when the client prefers it and the server advertises
-	// one (forced in the js/wasm build, which has no raw socket); else QUIC when
-	// the server advertises a QUIC endpoint + Protocol "quic" (#2607 dmsg-over-
-	// QUIC); else the legacy TCP path.
-	network := "tcp"
-	dialAddr := entry.Server.Address
-	switch {
-	case ce.conf.PreferWT && entry.Server.AddressWT != "":
-		network = "wt"
-		dialAddr = entry.Server.AddressWT
-	case ce.conf.PreferWS && entry.Server.AddressWS != "":
-		network = "ws"
-		dialAddr = entry.Server.AddressWS
-	case entry.Protocol == "quic" && entry.Server.AddressUDP != "":
-		network = "quic"
-		dialAddr = entry.Server.AddressUDP
-	}
+	// Pick the carrier from the client's ordered Carriers preference: the first
+	// listed carrier the server advertises wins; empty/no-match falls back to the
+	// default (QUIC when advertised, else TCP). The chosen carrier is dialed below
+	// with a TCP fallback on failure.
+	network, dialAddr := pickCarrier(ce.conf.Carriers, entry)
 	var dSes ClientSession
 
 	// Trigger dial callback.

--- a/pkg/dmsg/dmsg/ws_test.go
+++ b/pkg/dmsg/dmsg/ws_test.go
@@ -51,7 +51,7 @@ func TestWebSocketSession(t *testing.T) {
 	// Two WS-preferring clients.
 	wsConf := func() *Config {
 		c := DefaultConfig()
-		c.PreferWS = true
+		c.Carriers = []string{CarrierWS}
 		return c
 	}
 	pkA, skA := GenKeyPair(t, "client A")

--- a/pkg/dmsg/dmsg/wt_test.go
+++ b/pkg/dmsg/dmsg/wt_test.go
@@ -65,7 +65,7 @@ func TestWebTransportSession(t *testing.T) {
 	// Two WT-preferring clients.
 	wtConf := func() *Config {
 		c := DefaultConfig()
-		c.PreferWT = true
+		c.Carriers = []string{CarrierWT}
 		return c
 	}
 	pkA, skA := GenKeyPair(t, "client A")
@@ -152,7 +152,7 @@ func TestWebTransportCertHashMismatch(t *testing.T) {
 
 	pkA, skA := GenKeyPair(t, "client A")
 	conf := DefaultConfig()
-	conf.PreferWT = true
+	conf.Carriers = []string{CarrierWT}
 	clientA := NewClient(pkA, skA, dc, conf)
 	clientA.SetLogger(logging.MustGetLogger("wt_client_bad"))
 	go clientA.Serve(context.Background())

--- a/pkg/dmsg/dmsgclient/seeded.go
+++ b/pkg/dmsg/dmsgclient/seeded.go
@@ -68,7 +68,9 @@ func StartDmsgSeeded(ctx context.Context, log *logging.Logger, pk cipher.PubKey,
 	dClient := direct.NewClient(entries, log)
 
 	conf := dmsg.DefaultConfig()
-	conf.PreferWS = preferWS // browser (wasm) seeds over WebSocket; native uses TCP
+	if preferWS { // browser (wasm) seeds over WebSocket; native uses TCP (empty)
+		conf.Carriers = []string{dmsg.CarrierWS}
+	}
 	// MinSessions 2 (not 1): once bootstrapped via the seed and registered in
 	// discovery, the client learns the live server list from discovery
 	// (seededDiscClient.AvailableServers → real) and holds a SECOND session, so a


### PR DESCRIPTION
## What

Replace the two ad-hoc `dmsg.Config` bools (`PreferWS`, `PreferWT`) with one ordered **`Carriers []string`** preference (`"tcp"`/`"ws"`/`"wt"`/`"quic"`). The first listed carrier the server advertises is dialed; empty (the native default) keeps today's behavior — QUIC when advertised, else TCP.

This is the clean control surface for "how a dmsg client reaches a server": the **carrier is transparent above the session** (every stream is the same Noise+yamux), so an ordered allow-list is all the granularity that's meaningful — useful for restrictive networks (e.g. 443-only egress → `["wt"]`/`["ws"]`).

## How

- **dmsg.Config**: `PreferWS`/`PreferWT` → `Carriers []string` + `CarrierTCP/WS/WT/QUIC` consts.
- **client_sessions**: extract a pure, unit-tested `pickCarrier(carriers, entry) → (network, addr)`; `dialSession` calls it (the per-carrier TCP-fallback-on-failure logic is unchanged). `carrier_test.go` covers first-advertised-wins, explicit-tcp-beats-quic, skip-unavailable, unknown-ignored, empty-defaults.
- **seeded.go**: the `StartDmsgSeeded` `preferWS` param (public signature unchanged) now sets `Carriers=["ws"]` internally — so the browser still forces WS, native stays empty (TCP). ws_test/wt_test updated.

**No behavior change**: empty `Carriers` == the old both-false default; `["ws"]`==PreferWS; `["wt"]`==PreferWT.

## Verification

- `go build ./...`, `go test ./pkg/dmsg/dmsg` (pickCarrier + the WS/WT session round-trips still pass). *(Pre-existing gosec G709 in `util.go` is unrelated/untouched.)*