### PR TITLE
fix(dmsg): stop the session accept loop on any error (kill the WARN spam)

### DIFF
--- a/pkg/dmsg/dmsg/client_session.go
+++ b/pkg/dmsg/dmsg/client_session.go
@@ -4,12 +4,9 @@ package dmsg
 import (
 	"context"
 	"errors"
-	"io"
 	"net"
 	"sync"
 	"time"
-
-	"github.com/hashicorp/yamux"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/netutil"
@@ -280,44 +277,22 @@ func (cs *ClientSession) serve() error {
 	for {
 		dStr, err := cs.acceptYamuxStream()
 		if err != nil {
-			// Stream-mux-level failure. Shutdown / closed / EOF are
-			// terminal — the underlying session is dead. Everything
-			// else is treated as potentially-transient and retried
-			// with a short backoff, mirroring the server-side loop
-			// in ServerSession.Serve (streamErrorBackoff = 50ms).
+			// Stream-mux-level failure on Accept. yamux, smux, AND quic
+			// AcceptStream all have NO transient errors: each blocks until a
+			// stream arrives or the session is done, then returns the session's
+			// terminal error. So ANY error here is terminal — stop the accept
+			// loop and let the session be torn down / re-dialed.
 			//
-			// `cs.sm` carries either a yamux session or an smux
-			// session — never both. Pre-fix this branch dereferenced
-			// `cs.sm.yamux.IsClosed()` unconditionally, which nil-
-			// deref'd whenever the session was negotiated as smux
-			// (`entry.Protocol == "smux"` in client_sessions.go and
-			// the matching server-side path) and any non-EOF /
-			// non-yamux-shutdown error reached this branch.
-			// Recovered by the goroutine's defer/recover but logged
-			// only as "recovered panic in session serve goroutine: …"
-			// with no clue about the cause.
-			sessionClosed := errors.Is(err, io.EOF)
-			switch {
-			case cs.sm.yamux != nil:
-				sessionClosed = sessionClosed || errors.Is(err, yamux.ErrSessionShutdown) || cs.sm.yamux.IsClosed()
-			case cs.sm.smux != nil:
-				sessionClosed = sessionClosed || cs.sm.smux.IsClosed()
-			case cs.sm.quic != nil:
-				// quic-go's AcceptStream blocks until a stream arrives or the
-				// connection is done; it never returns a transient error. So any
-				// error here is terminal — treat the session as closed and exit
-				// the accept loop. Without this the loop spun forever on a closed
-				// QUIC session ("session closed"), hanging ClientSession.Close()
-				// on the never-exiting goroutine. (#2607 dmsg-over-QUIC.)
-				sessionClosed = true
-			}
-			if sessionClosed {
-				cs.log.WithError(err).Debug("Session shut down, stopping accept loop.")
-				return err
-			}
-			cs.log.WithError(err).Warn("Failed to accept yamux stream, continuing...")
-			time.Sleep(streamErrorBackoff)
-			continue
+			// In particular, for a carrier that rides QUIC (WebTransport: yamux
+			// over a WT bidi stream), the error is the underlying quic-go
+			// "Application error 0x0 (remote): session closed" — which is NOT
+			// yamux.ErrSessionShutdown / io.EOF and can arrive BEFORE
+			// yamux.IsClosed() flips. The previous narrow shutdown check let such
+			// errors fall through to a Warn+continue that spun forever (a wall of
+			// "Failed to accept yamux stream, continuing"). The quic-native case
+			// was already handled this way (#2607); yamux/smux share the property.
+			cs.log.WithError(err).Debug("Session shut down, stopping accept loop.")
+			return err
 		}
 
 		if err := cs.handshakeResponder(dStr); err != nil {

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -132,13 +132,15 @@ func (ss *ServerSession) Serve() {
 		for {
 			yStr, err := ss.sm.yamux.AcceptStream()
 			if err != nil {
-				if err == yamux.ErrSessionShutdown || err == io.EOF || ss.sm.yamux.IsClosed() {
-					ss.log.WithError(err).Info("Stopping session...")
-					return
-				}
-				ss.log.WithError(err).Warn("Failed to accept yamux stream, continuing...")
-				time.Sleep(streamErrorBackoff)
-				continue
+				// yamux.AcceptStream has no transient errors — any error is the
+				// session's terminal shutdown error. For a QUIC-backed carrier
+				// (WebTransport) that is the underlying quic-go "Application error
+				// 0x0 (remote): session closed", NOT yamux.ErrSessionShutdown, and
+				// it can arrive before yamux.IsClosed() flips — so the old narrow
+				// check spun this loop forever ("Failed to accept yamux stream,
+				// continuing"). Stop the session on any accept error.
+				ss.log.WithError(err).Info("Stopping session...")
+				return
 			}
 
 			log := ss.log.WithField("yamux_id", yStr.StreamID())


### PR DESCRIPTION
## Symptom

A visor flooding logs with:
```
WARN [dmsgC]: Failed to accept yamux stream, continuing... error="Application error 0x0 (remote): session closed"
```

## Root cause

That `"Application error 0x0 (remote): session closed"` is a **quic-go** error. It surfaces on a **yamux** `AcceptStream` because the **WebTransport carrier runs yamux over a WT bidi stream that rides QUIC**. When the underlying QUIC connection closes, `yamux.AcceptStream` returns that quic-go error — which is **not** `yamux.ErrSessionShutdown` / `io.EOF` and can arrive **before** `yamux.IsClosed()` flips. So the narrow shutdown check fell through to `Warn` + sleep + `continue` and **spun forever** on a dead session.

## Fix

`yamux`, `smux`, and `quic` `AcceptStream` all share one property: **no transient errors** — each blocks until a stream arrives or the session is done, then returns the session's terminal error. The quic-native case was already handled this way (#2607); this generalizes it. Now **any** accept error stops the loop (the session is torn down / re-dialed), in both the client (`client_session.go`) and server (`server_session.go`) serve loops.

Per-stream handshake failures are unaffected — those are handled separately and still keep the session alive.

## Verification

- `go build ./...`, `go test ./pkg/dmsg/dmsg` (full suite, incl. WS/WT/QUIC session round-trips).