### PR TITLE
feat(visor): enable WebRTC by default (a visor accepts every type it can)

### DIFF
--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -529,13 +529,12 @@ func initDmsgCtrl(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	logger.Debug("Initializing DMSG transport client...")
 	v.tpM.InitDmsgClient(ctx, dmsgC)
 
-	// WebRTC (opt-in) signals over dmsg, so its client is started only now that
-	// the manager has the dmsg client. InitClient also starts the dmsg signaling
-	// listener, so the visor ACCEPTS WebRTC dials (e.g. from browser visors).
-	if v.conf.Transport != nil && v.conf.Transport.WebRTC {
-		logger.Info("Initializing WebRTC transport client (opt-in)...")
-		v.tpM.InitClient(ctx, tptypes.WEBRTC, 0)
-	}
+	// WebRTC signals over dmsg, so its client is started only now that the manager
+	// has the dmsg client. InitClient also starts the dmsg signaling listener, so
+	// the visor ACCEPTS WebRTC dials (e.g. from browser visors). On by default,
+	// like stcpr/sudph — a visor accepts every transport type it can.
+	logger.Info("Initializing WebRTC transport client...")
+	v.tpM.InitClient(ctx, tptypes.WEBRTC, 0)
 
 	// dmsgctrl setup — listen for incoming control streams (ping/pong).
 	// Each accepted Control is self-serving (handles ping/pong in its own goroutine).

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -457,15 +457,15 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		listenAddr = v.conf.STCP.ListeningAddress
 	}
 	v.stcpTable = table
-	// WebRTC ICE servers (only when the opt-in WebRTC transport is enabled): the
-	// configured STUN servers, prefixed with the stun: scheme the WebRTC stack
-	// wants. Set on the factory now; the WEBRTC client is started after dmsg comes
-	// up (init_dmsg → InitClient), since its signaling rides the dmsg client.
+	// WebRTC ICE servers: the configured STUN servers, prefixed with the stun:
+	// scheme the WebRTC stack wants. Set on the factory now; the WEBRTC client is
+	// started after dmsg comes up (init_dmsg → InitClient), since its signaling
+	// rides the dmsg client. WebRTC is on by default, like stcpr/sudph — a visor
+	// accepts every transport type it can, so browser visors (which can't do
+	// stcpr/sudph/quic) can always reach it.
 	var iceURLs []string
-	if v.conf.Transport != nil && v.conf.Transport.WebRTC {
-		for _, s := range v.conf.StunServers {
-			iceURLs = append(iceURLs, "stun:"+s)
-		}
+	for _, s := range v.conf.StunServers {
+		iceURLs = append(iceURLs, "stun:"+s)
 	}
 	factory := network.ClientFactory{
 		PK:         v.conf.PK,

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -405,13 +405,6 @@ type Transport struct {
 	// until proven on the fleet. A fixed port is preferable to ephemeral so the
 	// address-resolver registration + any firewall rule are stable.
 	QUICPort int `json:"quic_port,omitempty"`
-	// WebRTC enables the WebRTC DataChannel transport (ICE NAT-traversal;
-	// signaling rides dmsg). false (default/omitted) disables it — opt-in until
-	// proven on the fleet. When enabled the visor ACCEPTS WebRTC dials (so browser
-	// visors, which can't do stcpr/sudph/quic, can reach it) and can create them
-	// via `tp add webrtc`. ICE uses the configured StunServers. No fixed port:
-	// pion gathers ephemeral UDP host candidates and traverses NAT via ICE.
-	WebRTC bool `json:"webrtc,omitempty"`
 	// ARTransportLimit controls address resolver registration for privacy:
 	//   0 (default): stay registered indefinitely
 	//   N > 0: deregister from AR after N transports are established


### PR DESCRIPTION
## What

#3237 gated the WebRTC transport behind an opt-in `transport.webrtc` flag (the `QUICPort` "until proven" pattern). But the original transport types (stcpr/sudph) were never opt-in, and **a visor should accept/make every transport type it can** — so a browser visor (which can't do stcpr/sudph/quic) can always reach it via WebRTC. Make WebRTC on by default, like stcpr/sudph.

## How

- Drop the `Transport.WebRTC` config field (configs that still set it are ignored — the whole-struct mirror tolerates the unknown key).
- `init_transport` always sets `ICEURLs` from `StunServers`; `init_dmsg` always `InitClient(WEBRTC)` after the dmsg client is up (starts the dmsg:47 signaling listener → accepts WebRTC dials). pion gathers ephemeral UDP candidates lazily, so this is cheap until a peer actually dials.

This is the **accept** side; WebRTC is still not *auto*-established (the autoconnect order is a separate, tracked change).

## Verification

- `go build ./...`, lint — pass. Running on a live visor (rebuilt from this tree).