### PR TITLE
feat(visor): QUIC default-on + transport-port-unification design note

### DIFF
--- a/docs/design/transport-port-unification.md
+++ b/docs/design/transport-port-unification.md
@@ -1,0 +1,106 @@
+# Transport port unification + AR-integrated discovery
+
+Status: design (incremental implementation in progress)
+
+## Problem
+
+A visor today binds a **separate listening port per transport type** — `stcpr_port`
+(TCP), `sudph_port` (UDP), `quic_port` (UDP) — plus the newer WS/WT/WebRTC types,
+each with their own socket. Each type also discovers peers differently:
+
+- **stcpr / sudph / quic** register their bound address in the **address resolver
+  (AR)** and resolve peers from it.
+- **stcp** is the *static* variant of stcpr: a manual `PK → addr` table in config,
+  no AR.
+- **WS / WT** were added with their own manual `PK → URL[+cert-hash]` tables
+  (`WSTable` / `WTTable`), and are **not** AR-integrated.
+- **WebRTC** signals by PK over dmsg (no endpoint to register or resolve).
+
+Two consequences:
+
+1. **N firewall rules / N AR registrations / N config knobs** for one visor.
+2. **WS/WT aren't autoconnect-able** — a peer can't *discover* another's WS/WT
+   endpoint (manual table only), whereas the AR-resolved types can.
+
+## Goals
+
+- **One listening port** by default — `transport_port` (one `tcp` + one `udp`
+  socket on the same number), with every type demultiplexed onto it.
+- **AR-integrated discovery for WS/WT**, like the other resolved types, so they
+  become autoconnect-able (a browser tab resolves a peer's WS endpoint from the AR
+  and dials it — it can't register one, having no listener, but it can resolve).
+- **A static `PK → endpoint` table for every type that makes sense** (the STCP
+  model generalized), for manual / no-AR links.
+- **Reverse-compatible** with the existing per-type port config.
+
+## Model
+
+### Listening
+
+- `transport_port` (master, default `0` = random): one TCP + one UDP listener,
+  demuxed by protocol signature. Carries every type that does not have its own
+  port.
+- Per-type ports (`stcpr_port` / `sudph_port` / `quic_port` / …, default `0` =
+  *ride the master port*; explicit = *break out onto a dedicated port for that
+  type only*).
+
+So `0` no longer means "own random port" — it means "use the master port" (itself
+random if `0`). Setting a specific port pulls that one type out onto its own
+socket. This is a standard global-default + per-item-override pattern.
+
+**Disambiguation** is bookkeeping in the transport manager: it knows which
+listener (master vs a dedicated one) serves which type; each listener registers
+*whatever port it actually bound* with the AR; peers resolve from the AR. A demux
+only ever classifies the types assigned to its socket.
+
+### Demultiplexing
+
+- **TCP (`transport_port`/tcp)** → **stcpr + WS**: peek the first bytes on accept.
+  `GET … HTTP/1.1\r\n … Upgrade: websocket` → WS; otherwise the raw skywire
+  handshake → stcpr. (The `cmux` technique.)
+- **UDP (`transport_port`/udp)** → **quic + WT + sudph + webrtc**: classify each
+  datagram on one socket —
+  - QUIC long-header (high bit + fixed bit set) → quic-go; **quic vs WT split by
+    ALPN** inside the handshake (skywire-quic vs `h3`).
+  - STUN magic cookie `0x2112A442` / DTLS content-type → WebRTC (pion
+    `SettingEngine.SetICEUDPMux` shares one socket).
+  - otherwise → sudph (KCP).
+
+  ICE already demultiplexes STUN/DTLS/data on a single socket, and quic-go/pion
+  both accept an externally-provided `net.PacketConn`, so this is proven ground.
+  The implementation is a `udpDemux` wrapping one `net.PacketConn` that routes
+  inbound packets by signature to per-protocol virtual `PacketConn`s.
+
+### Discovery
+
+Each AR-resolved type registers its bound endpoint with the AR and resolves peers
+from it. WS/WT extend the AR record with a URL (+ WT cert-hash) rather than a bare
+`IP:port`. In addition, each type optionally carries a **static `PK → endpoint`
+table** in config (the STCP model) for manual / no-AR links — stcpr/stcp (addr),
+quic/sudph (`IP:port`, direct dial, no hole-punch), WS/WT (URL). WebRTC's "manual"
+mode is the by-PK `dialTransport` trigger, since signaling rides dmsg.
+
+## Reverse compatibility
+
+- **Behaviorally compatible:** an existing `stcpr_port: 0` binds stcpr on its own
+  random TCP port today; under this model it binds on the master random TCP port
+  (shared with WS). stcpr still works and registers its bound port in the AR — the
+  *outcome* is identical, just the socket is shared.
+- **Explicit per-type ports** are still honored as dedicated breakouts, so
+  hand-tuned firewall configs keep working.
+
+## Incremental plan
+
+1. **QUIC default-on** — drop the `quic_port == 0` opt-in gate; bind ephemeral
+   when unset, like sudph. (done)
+2. **Static `PK → endpoint` tables** for the AR-resolved types that lack one
+   (quic/sudph), mirroring STCP. (additive, low-risk)
+3. **One master port — UDP first**: `udpDemux` shared socket for quic + sudph +
+   webrtc (+ WT). Then **TCP**: peek-router for stcpr + WS.
+4. **AR-integrate WS/WT**: register/resolve WS/WT endpoints in the AR (extends the
+   AR record with a URL + WT cert-hash; may require an AR-service change — to be
+   confirmed).
+5. **Config collapse**: `transport_port` master + per-type overrides; keep the old
+   keys as overrides for compatibility.
+
+Each step is independently shippable.

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -385,11 +385,23 @@ func initStcprClient(ctx context.Context, v *Visor, _ *logging.Logger) error {
 // initQuicClient starts the experimental QUIC transport when a quic_port is
 // configured (#2607 QUIC follow-on). Opt-in: a zero port leaves it disabled.
 func initQuicClient(ctx context.Context, v *Visor, log *logging.Logger) error {
-	if v.conf.Transport == nil || v.conf.Transport.QUICPort == 0 {
-		return nil
+	// QUIC is on by default, like stcpr/sudph — a visor accepts every transport
+	// type it can. quic_port (if set) PINS the UDP port for a stable firewall
+	// rule / AR registration; left 0 it binds an ephemeral port, exactly as
+	// sudph_port does. The QUIC client registers whatever port it actually bound
+	// with the address resolver (BindQUIC), so a random port works and survives
+	// restarts via re-registration. QUIC doesn't hole-punch (it dials AR-resolved
+	// addresses), so unlike sudph it needs no STUN gate and starts immediately.
+	port := 0
+	if v.conf.Transport != nil {
+		port = v.conf.Transport.QUICPort
 	}
-	log.Infof("Initializing QUIC transport on UDP port %d", v.conf.Transport.QUICPort)
-	v.tpM.InitClient(ctx, types.QUIC, v.conf.Transport.QUICPort)
+	if port == 0 {
+		log.Info("Initializing QUIC transport on an ephemeral UDP port")
+	} else {
+		log.Infof("Initializing QUIC transport on UDP port %d", port)
+	}
+	v.tpM.InitClient(ctx, types.QUIC, port)
 	return nil
 }
 

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -400,10 +400,11 @@ type Transport struct {
 	LogStore              *LogStore       `json:"log_store"`
 	StcprPort             int             `json:"stcpr_port"`
 	SudphPort             int             `json:"sudph_port"`
-	// QUICPort enables the experimental QUIC transport on the given UDP port
-	// (#2607 QUIC follow-on). 0 (default/omitted) disables it — QUIC is opt-in
-	// until proven on the fleet. A fixed port is preferable to ephemeral so the
-	// address-resolver registration + any firewall rule are stable.
+	// QUICPort optionally PINS the UDP port for the QUIC transport (#2607). QUIC
+	// is on by default (like stcpr/sudph); 0 (default/omitted) binds an ephemeral
+	// port — exactly as sudph_port does. Set a fixed port when a stable firewall
+	// rule is wanted; the bound port is registered with the address resolver
+	// either way, so a random port works and survives restarts.
 	QUICPort int `json:"quic_port,omitempty"`
 	// ARTransportLimit controls address resolver registration for privacy:
 	//   0 (default): stay registered indefinitely


### PR DESCRIPTION
## What

**QUIC default-on:** drop the `quic_port == 0` opt-in gate so QUIC starts like stcpr/sudph. `quic_port` (if set) *pins* the UDP port for a stable firewall rule / AR registration; left `0` it binds an **ephemeral** port. The QUIC client already registers whatever port it bound with the AR (`BindQUIC`), so a random port works and survives restarts via re-registration; QUIC doesn't hole-punch, so it needs no STUN gate. A visor now accepts every transport type it can.

**Plus `docs/design/transport-port-unification.md`** — the model for collapsing the per-type listening ports into **one master `transport_port`** (one tcp + one udp socket, demuxed by protocol: cmux-style peek for TCP stcpr/WS; signature-classify + ALPN + pion UDP-mux for UDP quic/WT/sudph/webrtc), AR-integrating WS/WT for discovery, and a static `PK → endpoint` table per type (the STCP model generalized) — reverse-compatibly (per-type ports become dedicated breakouts; `0` = ride the master port). Guides the incremental build.

## Verification

- `go build ./...`, lint — pass.