### PR TITLE
feat(transport): UDP demux component for the unified transport port

### DIFF
--- a/pkg/transport/network/udpdemux.go
+++ b/pkg/transport/network/udpdemux.go
@@ -1,0 +1,290 @@
+//go:build !tinygo
+
+// Package network pkg/transport/network/udpdemux.go
+//
+// udpDemux multiplexes ONE UDP socket across the UDP-based transport protocols
+// (QUIC, sudph/KCP, WebRTC/ICE), so a visor can listen for all of them on a
+// single `transport_port` instead of one port per type. See
+// docs/design/transport-port-unification.md.
+//
+// Each inbound datagram is classified by its wire signature (classifyUDP) and
+// routed to a per-protocol virtual net.PacketConn (demuxConn). The protocols'
+// own stacks — quic-go's Transport, xtaci/kcp-go, pion's ICE UDP-mux — each take
+// a net.PacketConn, so they consume a demuxConn unchanged. Classification is
+// applied to the FIRST datagram from a remote address; the result is then PINNED
+// per source (srcProto) so short-header QUIC and subsequent KCP packets — which
+// carry no distinguishing prefix — follow the same route.
+//
+// This component is intentionally standalone + unit-tested before being wired
+// into the transport managers; getting the classifier wrong would misroute live
+// traffic, so it is validated in isolation first.
+package network
+
+import (
+	"encoding/binary"
+	"net"
+	"sync"
+	"time"
+)
+
+// udpProto identifies a UDP-based transport protocol on the shared socket.
+type udpProto uint8
+
+const (
+	protoUnknown udpProto = iota
+	protoQUIC
+	protoWebRTC
+	protoSUDPH
+)
+
+func (p udpProto) String() string {
+	switch p {
+	case protoQUIC:
+		return "quic"
+	case protoWebRTC:
+		return "webrtc"
+	case protoSUDPH:
+		return "sudph"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	// stunMagicCookie is the fixed value at bytes 4..8 of every STUN message
+	// (RFC 5389) — WebRTC's ICE connectivity checks. Unambiguous.
+	stunMagicCookie = 0x2112A442
+	// KCP command byte (offset 4) values (xtaci/kcp-go: IKCP_CMD_PUSH..WINS).
+	kcpCmdMin = 81
+	kcpCmdMax = 84
+)
+
+// classifyUDP returns the protocol of a datagram from its leading bytes:
+//
+//   - WebRTC: a STUN message (two high bits of byte 0 clear + magic cookie at
+//     4..8) or a DTLS record (content-type 20..63 in byte 0, DTLS version 0xfe**
+//     in byte 1). Both are unambiguous.
+//   - QUIC: a long-header packet (header-form + fixed bit set → 0xC0 mask) whose
+//     KCP-command slot (byte 4) is NOT a KCP command. New QUIC connections always
+//     start with a long header (Initial), whose byte 4 is the low version byte
+//     (0x01 for v1), never 81..84.
+//   - sudph (KCP): a packet whose command byte (offset 4) is 81..84. KCP carries
+//     no magic, so this is the most specific signal it has.
+//
+// Returns protoUnknown when nothing matches — the caller pins a source's protocol
+// from its first classifiable packet, so short-header QUIC / bare KCP follow-ups
+// don't need to re-classify.
+func classifyUDP(p []byte) udpProto {
+	if len(p) == 0 {
+		return protoUnknown
+	}
+	// STUN: message type's two high bits are 0; magic cookie at 4..8.
+	if len(p) >= 8 && p[0]&0xC0 == 0 && binary.BigEndian.Uint32(p[4:8]) == stunMagicCookie {
+		return protoWebRTC
+	}
+	// DTLS record: content-type 20..63, version high byte 0xfe.
+	if len(p) >= 3 && p[0] >= 20 && p[0] <= 63 && p[1] == 0xfe {
+		return protoWebRTC
+	}
+	isKCPCmd := len(p) >= 5 && p[4] >= kcpCmdMin && p[4] <= kcpCmdMax
+	// QUIC long header: header-form + fixed bit (0xC0), and not a KCP command in
+	// the byte-4 slot (a long-header QUIC Initial has a version byte there, not
+	// 81..84).
+	if p[0]&0xC0 == 0xC0 && !isKCPCmd {
+		return protoQUIC
+	}
+	if isKCPCmd {
+		return protoSUDPH
+	}
+	return protoUnknown
+}
+
+// udpDemux wraps one underlying net.PacketConn and fans inbound datagrams out to
+// a per-protocol virtual net.PacketConn. Writes from any virtual conn go to the
+// shared socket. Close on the demux closes the socket and all virtual conns.
+type udpDemux struct {
+	conn net.PacketConn
+
+	mu    sync.RWMutex
+	srcs  map[string]udpProto // remote addr → pinned protocol
+	conns map[udpProto]*demuxConn
+	done  chan struct{}
+	once  sync.Once
+}
+
+// newUDPDemux starts demultiplexing conn. Call Conn(proto) to obtain the virtual
+// net.PacketConn for each protocol, then hand those to the protocol stacks.
+func newUDPDemux(conn net.PacketConn) *udpDemux {
+	d := &udpDemux{
+		conn:  conn,
+		srcs:  make(map[string]udpProto),
+		conns: make(map[udpProto]*demuxConn),
+		done:  make(chan struct{}),
+	}
+	for _, p := range []udpProto{protoQUIC, protoWebRTC, protoSUDPH} {
+		d.conns[p] = newDemuxConn(d, p)
+	}
+	go d.readLoop()
+	return d
+}
+
+// Conn returns the virtual net.PacketConn carrying proto's traffic.
+func (d *udpDemux) Conn(proto udpProto) net.PacketConn { return d.conns[proto] }
+
+// route returns the protocol a datagram from src belongs to, pinning the source's
+// protocol on its first classifiable packet so later (unclassifiable) packets
+// from the same source follow the same route.
+func (d *udpDemux) route(src net.Addr, p []byte) (udpProto, bool) {
+	key := src.String()
+	d.mu.RLock()
+	proto, pinned := d.srcs[key]
+	d.mu.RUnlock()
+	if pinned {
+		return proto, true
+	}
+	proto = classifyUDP(p)
+	if proto == protoUnknown {
+		return protoUnknown, false
+	}
+	d.mu.Lock()
+	d.srcs[key] = proto
+	d.mu.Unlock()
+	return proto, true
+}
+
+func (d *udpDemux) readLoop() {
+	buf := make([]byte, 64*1024)
+	for {
+		n, src, err := d.conn.ReadFrom(buf)
+		if err != nil {
+			d.Close() //nolint:errcheck,gosec
+			return
+		}
+		proto, ok := d.route(src, buf[:n])
+		if !ok {
+			continue // unclassifiable, no pinned source — drop
+		}
+		pkt := make([]byte, n)
+		copy(pkt, buf[:n])
+		c := d.conns[proto]
+		select {
+		case c.in <- packet{addr: src, data: pkt}:
+		case <-d.done:
+			return
+		default:
+			// virtual conn backlogged — drop (UDP is lossy; the protocol recovers).
+		}
+	}
+}
+
+// Close closes the underlying socket and every virtual conn.
+func (d *udpDemux) Close() error {
+	d.once.Do(func() {
+		close(d.done)
+		for _, c := range d.conns {
+			c.close()
+		}
+	})
+	return d.conn.Close()
+}
+
+// packet is one inbound datagram queued for a virtual conn.
+type packet struct {
+	addr net.Addr
+	data []byte
+}
+
+// demuxConn is a virtual net.PacketConn over the shared socket: ReadFrom drains
+// this protocol's inbound queue (deadline-aware, and a deadline change interrupts
+// a blocked read — quic-go/kcp-go rely on that); WriteTo writes straight to the
+// shared socket. Write deadlines delegate to the shared socket (UDP writes don't
+// block in practice).
+type demuxConn struct {
+	d     *udpDemux
+	proto udpProto
+	in    chan packet
+	done  chan struct{}
+	once  sync.Once
+
+	mu        sync.Mutex
+	rDeadline time.Time
+	notify    chan struct{} // closed + replaced when the read deadline changes
+}
+
+func newDemuxConn(d *udpDemux, proto udpProto) *demuxConn {
+	return &demuxConn{
+		d: d, proto: proto,
+		in:     make(chan packet, 256),
+		done:   make(chan struct{}),
+		notify: make(chan struct{}),
+	}
+}
+
+func (c *demuxConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	for {
+		c.mu.Lock()
+		deadline := c.rDeadline
+		notify := c.notify
+		c.mu.Unlock()
+
+		var timeout <-chan time.Time
+		if !deadline.IsZero() {
+			d := time.Until(deadline)
+			if d <= 0 {
+				return 0, nil, errDeadline{}
+			}
+			t := time.NewTimer(d)
+			defer t.Stop()
+			timeout = t.C
+		}
+		select {
+		case pkt := <-c.in:
+			return copy(p, pkt.data), pkt.addr, nil
+		case <-timeout:
+			return 0, nil, errDeadline{}
+		case <-notify:
+			// read deadline changed — re-evaluate (this is also how a blocked
+			// read is woken when a deadline is set).
+		case <-c.done:
+			return 0, nil, net.ErrClosed
+		}
+	}
+}
+
+func (c *demuxConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	select {
+	case <-c.done:
+		return 0, net.ErrClosed
+	default:
+	}
+	return c.d.conn.WriteTo(p, addr)
+}
+
+func (c *demuxConn) close() { c.once.Do(func() { close(c.done) }) }
+
+func (c *demuxConn) Close() error { c.close(); return nil }
+
+func (c *demuxConn) LocalAddr() net.Addr { return c.d.conn.LocalAddr() }
+
+func (c *demuxConn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.rDeadline = t
+	close(c.notify) // wake any blocked ReadFrom so it picks up the new deadline
+	c.notify = make(chan struct{})
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *demuxConn) SetWriteDeadline(t time.Time) error { return c.d.conn.SetWriteDeadline(t) }
+
+func (c *demuxConn) SetDeadline(t time.Time) error {
+	_ = c.SetReadDeadline(t) //nolint:errcheck
+	return c.SetWriteDeadline(t)
+}
+
+// errDeadline is the net.Error returned when a demuxConn read deadline elapses.
+type errDeadline struct{}
+
+func (errDeadline) Error() string   { return "udpdemux: i/o timeout" }
+func (errDeadline) Timeout() bool   { return true }
+func (errDeadline) Temporary() bool { return true }

--- a/pkg/transport/network/udpdemux_test.go
+++ b/pkg/transport/network/udpdemux_test.go
@@ -1,0 +1,181 @@
+//go:build !tinygo
+
+package network
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// --- classifier ---
+
+func stunPacket() []byte {
+	p := make([]byte, 20)   // STUN header
+	p[0], p[1] = 0x00, 0x01 // Binding Request (two high bits clear)
+	binary.BigEndian.PutUint16(p[2:4], 0)
+	binary.BigEndian.PutUint32(p[4:8], stunMagicCookie)
+	return p
+}
+
+func dtlsPacket() []byte {
+	// content-type=22 (handshake), version=0xfefd (DTLS 1.2)
+	return []byte{22, 0xfe, 0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+}
+
+func quicLongHeader() []byte {
+	// header-form + fixed bit (0xC0) + type bits; version v1 (0x00000001) in 1..5.
+	return []byte{0xc3, 0x00, 0x00, 0x00, 0x01, 0xaa, 0xbb}
+}
+
+func kcpPacket(cmd byte) []byte {
+	// conv(4) | cmd(1) | frg(1) | wnd(2) | ts(4) | sn(4) | una(4) | len(4)
+	p := make([]byte, 24)
+	binary.LittleEndian.PutUint32(p[0:4], 0xC0FFEE42) // conv: low byte 0x42, high byte 0xC0
+	p[4] = cmd
+	return p
+}
+
+func TestClassifyUDP(t *testing.T) {
+	cases := []struct {
+		name string
+		pkt  []byte
+		want udpProto
+	}{
+		{"stun", stunPacket(), protoWebRTC},
+		{"dtls", dtlsPacket(), protoWebRTC},
+		{"quic long header", quicLongHeader(), protoQUIC},
+		{"kcp push", kcpPacket(81), protoSUDPH},
+		{"kcp wins", kcpPacket(84), protoSUDPH},
+		{"empty", nil, protoUnknown},
+		// A KCP packet whose conv high byte sets the QUIC fixed-bit mask must still
+		// classify as sudph because byte 4 is a KCP command (the disambiguator).
+		{"kcp with quic-looking byte0", func() []byte { p := kcpPacket(82); p[0] = 0xc5; return p }(), protoSUDPH},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := classifyUDP(c.pkt); got != c.want {
+				t.Fatalf("classifyUDP(%s) = %v, want %v", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+// --- demux routing over a real loopback UDP pair ---
+
+func TestUDPDemux_RoutesBySignature(t *testing.T) {
+	// Shared "server" socket the demux wraps, and a "client" socket that sends
+	// packets of different protocols to it.
+	srv, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen srv: %v", err)
+	}
+	d := newUDPDemux(srv)
+	defer d.Close() //nolint:errcheck
+
+	srvAddr := srv.LocalAddr()
+
+	// Send one packet of each protocol from distinct source ports (so the
+	// per-source pinning keys don't collide). UDP writes are non-blocking and the
+	// demux's per-conn queue is buffered, so a synchronous send-then-read works:
+	// the demux read loop drains the wire and routes into the protocol's queue.
+	send := func(pkt []byte) {
+		c, err := net.ListenPacket("udp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen sender: %v", err)
+		}
+		defer c.Close() //nolint:errcheck
+		if _, err := c.WriteTo(pkt, srvAddr); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+	}
+
+	read := func(proto udpProto, wantFirst byte) {
+		c := d.Conn(proto)
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+		buf := make([]byte, 1500)
+		n, _, err := c.ReadFrom(buf)
+		if err != nil {
+			t.Fatalf("%v ReadFrom: %v", proto, err)
+		}
+		if n == 0 || buf[0] != wantFirst {
+			t.Fatalf("%v got first byte %#x, want %#x", proto, buf[0], wantFirst)
+		}
+	}
+
+	send(quicLongHeader())
+	read(protoQUIC, 0xc3)
+
+	send(stunPacket())
+	read(protoWebRTC, 0x00)
+
+	send(kcpPacket(81))
+	read(protoSUDPH, 0x42) // conv low byte (LittleEndian 0xC0FFEE42)
+}
+
+// TestUDPDemux_ReadDeadline confirms a read deadline elapses (and that setting a
+// deadline interrupts a blocked read).
+func TestUDPDemux_ReadDeadline(t *testing.T) {
+	srv, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	d := newUDPDemux(srv)
+	defer d.Close() //nolint:errcheck
+
+	c := d.Conn(protoQUIC)
+	_ = c.SetReadDeadline(time.Now().Add(100 * time.Millisecond)) //nolint:errcheck
+	buf := make([]byte, 1500)
+	start := time.Now()
+	_, _, err = c.ReadFrom(buf)
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	ne, ok := err.(net.Error)
+	if !ok || !ne.Timeout() {
+		t.Fatalf("expected a net.Error timeout, got %T %v", err, err)
+	}
+	if time.Since(start) < 50*time.Millisecond {
+		t.Fatalf("read returned too early (%v) — deadline not honored", time.Since(start))
+	}
+}
+
+// TestUDPDemux_PinnedSource confirms a source's protocol is pinned from its first
+// classifiable packet, so an unclassifiable follow-up still routes correctly.
+func TestUDPDemux_PinnedSource(t *testing.T) {
+	srv, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	d := newUDPDemux(srv)
+	defer d.Close() //nolint:errcheck
+
+	sender, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen sender: %v", err)
+	}
+	defer sender.Close() //nolint:errcheck
+
+	// First packet classifies as QUIC and pins the source.
+	if _, err := sender.WriteTo(quicLongHeader(), srv.LocalAddr()); err != nil {
+		t.Fatalf("send 1: %v", err)
+	}
+	c := d.Conn(protoQUIC)
+	buf := make([]byte, 1500)
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+	if _, _, err := c.ReadFrom(buf); err != nil {
+		t.Fatalf("read 1: %v", err)
+	}
+
+	// A short-header-looking follow-up (would classify as unknown on its own) must
+	// still route to QUIC because the source is pinned.
+	shortHeader := []byte{0x40, 0x11, 0x22, 0x33} // fixed bit only, no clear signature
+	if _, err := sender.WriteTo(shortHeader, srv.LocalAddr()); err != nil {
+		t.Fatalf("send 2: %v", err)
+	}
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+	if _, _, err := c.ReadFrom(buf); err != nil {
+		t.Fatalf("pinned follow-up did not route to QUIC: %v", err)
+	}
+}


### PR DESCRIPTION
## What

The foundational piece of [transport-port-unification](../blob/develop/docs/design/transport-port-unification.md): one UDP socket shared by the UDP-based transport protocols (**QUIC, sudph/KCP, WebRTC/ICE**), so a visor can listen for all of them on one `transport_port` instead of a port per type.

`udpDemux` wraps a `net.PacketConn` and routes each inbound datagram to a per-protocol virtual `net.PacketConn` (`demuxConn`) — and quic-go's `Transport`, kcp-go, and pion's ICE UDP-mux all take a `net.PacketConn`, so they consume a `demuxConn` unchanged.

## Classification (`classifyUDP`)

- **WebRTC:** STUN (magic cookie `0x2112A442`) or DTLS record (content-type 20..63 + `0xfe**` version) — both unambiguous.
- **QUIC:** long-header form (`0xC0` mask) whose byte-4 slot is **not** a KCP command (a QUIC Initial has a version byte there, never 81..84).
- **sudph:** KCP command byte (offset 4) in 81..84 — KCP's only distinguishing mark.

The first classifiable packet from a source **pins** that source→protocol, so short-header QUIC and bare KCP follow-ups (no prefix) route correctly. `demuxConn` is a proper `net.PacketConn`: deadline-aware reads where a deadline change interrupts a blocked read (quic-go/kcp-go rely on that).

## Why isolated

**Deliberately standalone + unit-tested before wiring into the transport managers** — misrouting live traffic would be a fleet-wide break, so the classifier + routing + deadline + source-pinning are validated in isolation first (race-clean). The wiring (shared socket → quic/sudph/webrtc clients) is the next, separately-reviewed step.

## Verification

- `go build ./...`, `go test -race` (classifier cases incl. the KCP-vs-QUIC disambiguation, real-loopback routing, read-deadline, pinned-source), lint — all pass.