### PR TITLE
feat(transport): QUIC listens over the shared UDP demux conn (+ real-traffic test)

### DIFF
--- a/pkg/transport/network/quic.go
+++ b/pkg/transport/network/quic.go
@@ -42,11 +42,16 @@ const quicErrNoStream quic.ApplicationErrorCode = 1
 
 type quicClient struct {
 	*resolvedClient
-	port     int
-	udpConn  net.PacketConn
-	listener *quic.Listener
-	tlsCert  tls.Certificate
-	qconf    *quic.Config
+	port int
+	// sharedConn, when set, is the UDP socket QUIC listens over instead of
+	// binding its own — the QUIC demux conn of a unified transport_port socket
+	// (see udpDemux). nil = bind a dedicated socket (the default / per-type-port
+	// behavior). The master socket's lifecycle is owned by the demux, not here.
+	sharedConn net.PacketConn
+	udpConn    net.PacketConn
+	listener   *quic.Listener
+	tlsCert    tls.Certificate
+	qconf      *quic.Config
 }
 
 // makeQuicClient is the build-tagged QUIC constructor used by MakeClient. On
@@ -238,20 +243,27 @@ func (c *quicClient) serve() {
 
 func (c *quicClient) listen() (net.Listener, error) {
 	var udpConn net.PacketConn
-	var err error
-	confPort := ""
-	if c.port != 0 {
-		confPort = fmt.Sprintf(":%d", c.port)
-	}
-	for {
-		udpConn, err = net.ListenPacket("udp", confPort)
-		if err != nil {
-			c.log.WithError(err).Warnf("Failed to listen on UDP port %d", c.port)
-			c.port++
+	if c.sharedConn != nil {
+		// Unified transport port: listen over the shared socket's QUIC demux conn.
+		// quic.Listen does not own the PacketConn, so the master socket lifecycle
+		// stays with the demux.
+		udpConn = c.sharedConn
+	} else {
+		var err error
+		confPort := ""
+		if c.port != 0 {
 			confPort = fmt.Sprintf(":%d", c.port)
-			continue
 		}
-		break
+		for {
+			udpConn, err = net.ListenPacket("udp", confPort)
+			if err != nil {
+				c.log.WithError(err).Warnf("Failed to listen on UDP port %d", c.port)
+				c.port++
+				confPort = fmt.Sprintf(":%d", c.port)
+				continue
+			}
+			break
+		}
 	}
 	c.udpConn = udpConn
 

--- a/pkg/transport/network/udpdemux_quic_test.go
+++ b/pkg/transport/network/udpdemux_quic_test.go
@@ -1,0 +1,106 @@
+//go:build !tinygo
+
+package network
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// TestUDPDemux_QUICRealTraffic validates the demux against REAL quic-go traffic
+// (not synthetic packets): a quic-go listener runs over the demux's QUIC virtual
+// conn on a shared socket, a quic-go dialer connects to the shared socket's
+// address, and the demux must classify+route the actual QUIC handshake so the
+// session establishes and a stream carries bytes both ways. This is the de-risk
+// for wiring the demux under the production QUIC transport.
+func TestUDPDemux_QUICRealTraffic(t *testing.T) {
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	cliPK, cliSK := cipher.GenerateKeyPair()
+	srvCert, err := newQUICCertificate(srvPK, srvSK)
+	if err != nil {
+		t.Fatalf("server cert: %v", err)
+	}
+	cliCert, err := newQUICCertificate(cliPK, cliSK)
+	if err != nil {
+		t.Fatalf("client cert: %v", err)
+	}
+
+	master, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("master socket: %v", err)
+	}
+	d := newUDPDemux(master)
+	defer d.Close() //nolint:errcheck
+
+	qconf := &quic.Config{EnableDatagrams: true}
+	lis, err := quic.Listen(d.Conn(protoQUIC), quicTLSConfig(srvCert, nil, nil), qconf)
+	if err != nil {
+		t.Fatalf("quic.Listen over demux: %v", err)
+	}
+	defer lis.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	srvErr := make(chan error, 1)
+	go func() {
+		conn, err := lis.Accept(ctx)
+		if err != nil {
+			srvErr <- err
+			return
+		}
+		stream, err := conn.AcceptStream(ctx)
+		if err != nil {
+			srvErr <- err
+			return
+		}
+		buf := make([]byte, 4)
+		if _, err := io.ReadFull(stream, buf); err != nil {
+			srvErr <- err
+			return
+		}
+		_, err = stream.Write(buf) // echo
+		srvErr <- err
+	}()
+
+	dialUDP, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	if err != nil {
+		t.Fatalf("dial socket: %v", err)
+	}
+	defer dialUDP.Close() //nolint:errcheck
+
+	qc, err := quic.Dial(ctx, dialUDP, master.LocalAddr(), quicTLSConfig(cliCert, &srvPK, nil), qconf)
+	if err != nil {
+		t.Fatalf("quic.Dial to the shared socket (demux must route the handshake to QUIC): %v", err)
+	}
+	stream, err := qc.OpenStreamSync(ctx)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	if _, err := stream.Write([]byte("ping")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, 4)
+	if err := readStreamFull(stream, buf); err != nil {
+		t.Fatalf("client read echo: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Fatalf("echo = %q, want ping", buf)
+	}
+	if err := <-srvErr; err != nil {
+		t.Fatalf("server side: %v", err)
+	}
+}
+
+func readStreamFull(s *quic.Stream, b []byte) error {
+	_ = s.SetReadDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
+	_, err := io.ReadFull(s, b)
+	return err
+}


### PR DESCRIPTION
## What

First wiring step of the unified transport port: the QUIC client can now listen over an externally-provided `net.PacketConn` — the QUIC virtual conn of a `udpDemux`'d master socket (#3242) — instead of binding its own. `quicClient.sharedConn` (nil by default → unchanged per-type binding); when set, `listen()` uses it for `quic.Listen` and the master socket lifecycle stays with the demux.

## The key de-risk

`TestUDPDemux_QUICRealTraffic` runs a **real quic-go listener over a demux conn** on a shared socket and a **real quic-go dialer** against that socket's address — the demux's `classifyUDP` must route the actual QUIC handshake packets for the session to establish. Full handshake + stream + echo round-trips, proving the classifier works against **genuine QUIC traffic** (not synthetic packets). This validates the approach before sudph/webrtc join the same socket and before the manager makes a shared master socket the default.

> Note for the manager-wiring step: quic-go wants to set the UDP receive buffer on its conn; a `demuxConn` isn't a `*net.UDPConn`, so the buffer will be set once on the master socket instead (a harmless warning in this test).

**No default behavior change:** `sharedConn` is nil everywhere until the manager opts in.

## Verification

- `go build ./...`, `go test` (real-quic-over-demux), lint — pass.