### PR TITLE
feat(transport): sudph listens over the shared UDP demux conn (+ real-traffic test)

### DIFF
--- a/pkg/transport/network/sudph.go
+++ b/pkg/transport/network/sudph.go
@@ -36,6 +36,11 @@ type sudphClient struct {
 	packetListener  net.PacketConn
 	sudphVisorsConn net.PacketConn
 	port            int
+	// sharedConn, when set, is the UDP socket sudph listens over instead of
+	// binding its own — the sudph virtual conn of a unified transport_port socket
+	// (see udpDemux). nil = bind a dedicated socket (default / per-type-port).
+	// sudph's internal pfilter still wraps it exactly as it wraps a real socket.
+	sharedConn net.PacketConn
 }
 
 // makeSudphClient is the build-tagged SUDPH constructor used by MakeClient. The
@@ -72,21 +77,28 @@ func (c *sudphClient) serve() {
 // listen
 func (c *sudphClient) listen() (net.Listener, error) {
 	var packetListener net.PacketConn
-	var err error
-	var confPort string
-	if c.port != 0 {
-		confPort = fmt.Sprintf(":%d", c.port)
-	}
-	for {
-		packetListener, err = net.ListenPacket("udp", confPort)
-		if err != nil {
-			c.log.WithError(err).Warnf("Failed to listen on port: %d", c.port)
-			c.port++
+	if c.sharedConn != nil {
+		// Unified transport port: filter over the shared socket's sudph demux conn
+		// instead of binding our own. The master socket lifecycle stays with the
+		// demux; pfilter wraps the virtual conn exactly as it would a real socket.
+		packetListener = c.sharedConn
+	} else {
+		var err error
+		var confPort string
+		if c.port != 0 {
 			confPort = fmt.Sprintf(":%d", c.port)
-			c.log.Warnf("Trying port %d", c.port)
-			continue
 		}
-		break
+		for {
+			packetListener, err = net.ListenPacket("udp", confPort)
+			if err != nil {
+				c.log.WithError(err).Warnf("Failed to listen on port: %d", c.port)
+				c.port++
+				confPort = fmt.Sprintf(":%d", c.port)
+				c.log.Warnf("Trying port %d", c.port)
+				continue
+			}
+			break
+		}
 	}
 	c.packetListener = packetListener
 	c.filter = pfilter.NewPacketFilter(packetListener)

--- a/pkg/transport/network/udpdemux_sudph_test.go
+++ b/pkg/transport/network/udpdemux_sudph_test.go
@@ -1,0 +1,79 @@
+//go:build !tinygo
+
+package network
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/AudriusButkevicius/pfilter"
+	kcp "github.com/xtaci/kcp-go"
+)
+
+// TestUDPDemux_KCPRealTraffic validates the demux against REAL sudph traffic: a
+// kcp-go listener runs over a pfilter wrapping the demux's sudph virtual conn (the
+// exact stack sudph.listen() builds), a kcp-go dialer connects to the shared
+// socket's address, and the demux must classify+route the actual KCP packets. The
+// risk this de-risks is pfilter operating over a demuxConn rather than a real UDP
+// socket. Full session + echo round-trips.
+func TestUDPDemux_KCPRealTraffic(t *testing.T) {
+	master, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("master socket: %v", err)
+	}
+	d := newUDPDemux(master)
+	defer d.Close() //nolint:errcheck
+
+	// Server stack, mirroring sudph.listen(): pfilter over the sudph demux conn,
+	// a catch-all conn, kcp.ServeConn over it.
+	filter := pfilter.NewPacketFilter(d.Conn(protoSUDPH))
+	srvConn := filter.NewConn(100, nil)
+	filter.Start()
+	lis, err := kcp.ServeConn(nil, 0, 0, srvConn)
+	if err != nil {
+		t.Fatalf("kcp.ServeConn over demux+pfilter: %v", err)
+	}
+	defer lis.Close() //nolint:errcheck
+
+	srvErr := make(chan error, 1)
+	go func() {
+		sess, err := lis.AcceptKCP()
+		if err != nil {
+			srvErr <- err
+			return
+		}
+		_ = sess.SetReadDeadline(time.Now().Add(10 * time.Second)) //nolint:errcheck
+		buf := make([]byte, 4)
+		if _, err := io.ReadFull(sess, buf); err != nil {
+			srvErr <- err
+			return
+		}
+		_, err = sess.Write(buf) // echo
+		srvErr <- err
+	}()
+
+	// Dialer: a plain kcp.Dial (binds its own socket) to the shared socket's addr.
+	sess, err := kcp.Dial(master.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("kcp.Dial to the shared socket (demux must route KCP to sudph): %v", err)
+	}
+	defer sess.Close() //nolint:errcheck
+
+	_ = sess.SetWriteDeadline(time.Now().Add(10 * time.Second)) //nolint:errcheck
+	if _, err := sess.Write([]byte("ping")); err != nil {
+		t.Fatalf("dialer write: %v", err)
+	}
+	_ = sess.SetReadDeadline(time.Now().Add(10 * time.Second)) //nolint:errcheck
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(sess, buf); err != nil {
+		t.Fatalf("dialer read echo: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Fatalf("echo = %q, want ping", buf)
+	}
+	if err := <-srvErr; err != nil {
+		t.Fatalf("server side: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Second wiring step of the unified transport port, same shape as the QUIC one (#3243): the sudph client can listen over an externally-provided `net.PacketConn` — the sudph virtual conn of a `udpDemux`'d master socket — instead of binding its own. `sudphClient.sharedConn` (nil by default → unchanged per-type binding); when set, `listen()` wraps it in pfilter exactly as it wraps a real socket. Master socket lifecycle stays with the demux.

## De-risk

`TestUDPDemux_KCPRealTraffic` runs the **real sudph receive stack** (pfilter over the demux conn → `kcp.ServeConn`) and a **real kcp-go dialer** against the shared socket's address — the demux's `classifyUDP` must route the actual KCP packets. This validates the trickier integration: **pfilter operating over a `demuxConn`** rather than a raw UDP socket. Full session + echo round-trips.

So both QUIC and sudph are now proven over the shared socket with genuine traffic. **No default behavior change:** `sharedConn` is nil until the manager opts in (webrtc + the master-socket wiring follow).

## Verification

- `go build ./...`, `go test` (real kcp-go over pfilter over demux), lint — pass.