### PR TITLE
feat(transport): unified transport port — QUIC + sudph share one UDP socket (opt-in)

### DIFF
--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -85,6 +85,12 @@ type ClientFactory struct {
 	// from an external (non-LAN) IP address. This validates that the visor is
 	// reachable from the internet.
 	OnExternalSTCPR func()
+
+	// udpDemux holds a *udpDemux (the unified transport_port shared UDP socket)
+	// when EnableUnifiedUDP has been called; nil otherwise → per-type UDP binding.
+	// Typed `any` because udpDemux is //go:build !tinygo (quic-go/kcp-go), and this
+	// struct is in the untagged file; the !tinygo client_unified_udp.go manages it.
+	udpDemux any
 }
 
 // MakeClient creates a new client of specified type

--- a/pkg/transport/network/client_resolved.go
+++ b/pkg/transport/network/client_resolved.go
@@ -34,9 +34,23 @@ func (f *ClientFactory) makeResolvedClient(netType types.Type, generic *genericC
 	case types.STCPR:
 		return newStcpr(resolved, port), nil
 	case types.SUDPH:
-		return makeSudphClient(resolved, port)
+		c, err := makeSudphClient(resolved, port)
+		if err != nil {
+			return nil, err
+		}
+		if sc := f.sharedUDPConn(protoSUDPH); sc != nil {
+			c.(*sudphClient).sharedConn = sc // unified transport port
+		}
+		return c, nil
 	case types.QUIC:
-		return makeQuicClient(resolved, port)
+		c, err := makeQuicClient(resolved, port)
+		if err != nil {
+			return nil, err
+		}
+		if sc := f.sharedUDPConn(protoQUIC); sc != nil {
+			c.(*quicClient).sharedConn = sc // unified transport port
+		}
+		return c, nil
 	}
 	return nil, fmt.Errorf("cannot initiate client, type %s not supported", netType)
 }

--- a/pkg/transport/network/client_unified_udp.go
+++ b/pkg/transport/network/client_unified_udp.go
@@ -1,0 +1,54 @@
+//go:build !tinygo
+
+// Package network pkg/transport/network/client_unified_udp.go
+//
+// The unified transport port (UDP side): bind ONE master UDP socket and route the
+// UDP transport types (QUIC + sudph) over it via a udpDemux, so they share a
+// single listening port instead of binding one each. See
+// docs/design/transport-port-unification.md. Opt-in: only active when the visor
+// configures transport_port (EnableUnifiedUDP is a no-op for port 0).
+package network
+
+import (
+	"fmt"
+	"net"
+)
+
+// EnableUnifiedUDP binds the master UDP socket on port and prepares the demux.
+// Call once, before MakeClient. port 0 is a no-op (per-type binding stays). The
+// quic/sudph clients created afterwards listen over the demux's per-protocol
+// virtual conn (see makeResolvedClient). The master socket lifecycle is owned
+// here — close it with CloseUnifiedUDP.
+func (f *ClientFactory) EnableUnifiedUDP(port int) error {
+	if port == 0 {
+		return nil
+	}
+	conn, err := net.ListenPacket("udp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return fmt.Errorf("unified transport port %d: %w", port, err)
+	}
+	// quic-go can't set the receive buffer on a demuxConn (not a *net.UDPConn), so
+	// set it once on the master socket (best-effort; quic-go's recommended size).
+	if uc, ok := conn.(*net.UDPConn); ok {
+		_ = uc.SetReadBuffer(7 << 20) //nolint:errcheck
+	}
+	f.udpDemux = newUDPDemux(conn)
+	return nil
+}
+
+// CloseUnifiedUDP closes the master UDP socket + demux, if enabled.
+func (f *ClientFactory) CloseUnifiedUDP() error {
+	if d, ok := f.udpDemux.(*udpDemux); ok && d != nil {
+		return d.Close()
+	}
+	return nil
+}
+
+// sharedUDPConn returns the demux's virtual conn for proto when unified UDP is
+// enabled, else nil (per-type binding).
+func (f *ClientFactory) sharedUDPConn(proto udpProto) net.PacketConn {
+	if d, ok := f.udpDemux.(*udpDemux); ok && d != nil {
+		return d.Conn(proto)
+	}
+	return nil
+}

--- a/pkg/transport/network/client_unified_udp_test.go
+++ b/pkg/transport/network/client_unified_udp_test.go
@@ -1,0 +1,49 @@
+//go:build !tinygo
+
+package network
+
+import (
+	"net"
+	"testing"
+)
+
+func freeUDPPort(t *testing.T) int {
+	t.Helper()
+	c, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe port: %v", err)
+	}
+	port := c.LocalAddr().(*net.UDPAddr).Port
+	c.Close() //nolint:errcheck,gosec
+	return port
+}
+
+// TestClientFactory_UnifiedUDP verifies the opt-in: off by default, a no-op for
+// port 0, and once enabled it exposes a shared demux conn for the UDP types.
+func TestClientFactory_UnifiedUDP(t *testing.T) {
+	f := &ClientFactory{}
+	if f.sharedUDPConn(protoQUIC) != nil {
+		t.Fatal("shared conn should be nil before enable")
+	}
+	if err := f.EnableUnifiedUDP(0); err != nil {
+		t.Fatalf("EnableUnifiedUDP(0): %v", err)
+	}
+	if f.sharedUDPConn(protoQUIC) != nil {
+		t.Fatal("port 0 must be a no-op")
+	}
+
+	port := freeUDPPort(t)
+	if err := f.EnableUnifiedUDP(port); err != nil {
+		t.Fatalf("EnableUnifiedUDP(%d): %v", port, err)
+	}
+	defer f.CloseUnifiedUDP() //nolint:errcheck
+
+	qc := f.sharedUDPConn(protoQUIC)
+	sc := f.sharedUDPConn(protoSUDPH)
+	if qc == nil || sc == nil {
+		t.Fatal("quic + sudph shared conns must be non-nil when enabled")
+	}
+	if qc.LocalAddr().String() != sc.LocalAddr().String() {
+		t.Fatalf("quic and sudph must share one socket: %s vs %s", qc.LocalAddr(), sc.LocalAddr())
+	}
+}

--- a/pkg/transport/network/quic.go
+++ b/pkg/transport/network/quic.go
@@ -57,7 +57,7 @@ type quicClient struct {
 // makeQuicClient is the build-tagged QUIC constructor used by MakeClient. On
 // non-TinyGo it builds a real quicClient; the TinyGo build (quic_tinygo.go)
 // returns an unsupported error so the browser graph never pulls quic-go.
-func makeQuicClient(resolved *resolvedClient, port int) (Client, error) {
+func makeQuicClient(resolved *resolvedClient, port int) (Client, error) { //nolint:unparam // error is for build-tag parity with the tinygo stub
 	return newQuic(resolved, port), nil
 }
 

--- a/pkg/transport/network/sudph.go
+++ b/pkg/transport/network/sudph.go
@@ -46,7 +46,7 @@ type sudphClient struct {
 // makeSudphClient is the build-tagged SUDPH constructor used by MakeClient. The
 // TinyGo build (sudph_tinygo.go) returns an unsupported error so the browser
 // graph never pulls kcp-go/pfilter (which transitively import quic-go).
-func makeSudphClient(resolved *resolvedClient, port int) (Client, error) {
+func makeSudphClient(resolved *resolvedClient, port int) (Client, error) { //nolint:unparam // error is for build-tag parity with the tinygo stub
 	return newSudph(resolved, port), nil
 }
 

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -499,6 +499,16 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 			}
 		},
 	}
+	// Unified transport port (opt-in): when transport_port is set, QUIC + sudph
+	// share one master UDP socket (demuxed) instead of binding a port each. 0 =
+	// per-type binding (default). See docs/design/transport-port-unification.md.
+	if v.conf.Transport != nil && v.conf.Transport.TransportPort != 0 {
+		if err := factory.EnableUnifiedUDP(v.conf.Transport.TransportPort); err != nil {
+			return fmt.Errorf("unified transport port: %w", err)
+		}
+		log.Infof("Unified transport port: QUIC + sudph share UDP port %d", v.conf.Transport.TransportPort)
+		v.pushCloseStack("transport.unified_udp", factory.CloseUnifiedUDP)
+	}
 	tpM, err := transport.NewManager(managerLogger, v.arClient, v.ebc, &tpMConf, factory)
 	if err != nil {
 		err := fmt.Errorf("failed to start transport manager: %w", err)

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -400,6 +400,12 @@ type Transport struct {
 	LogStore              *LogStore       `json:"log_store"`
 	StcprPort             int             `json:"stcpr_port"`
 	SudphPort             int             `json:"sudph_port"`
+	// TransportPort, when non-zero, is the single UDP port the UDP transport types
+	// (QUIC + sudph) share — one listening socket, demultiplexed by protocol (see
+	// docs/design/transport-port-unification.md) — instead of binding a port each.
+	// 0 (default/omitted) keeps the per-type binding (sudph_port/quic_port). Opt-in
+	// while the unified-port path proves out; the per-type ports stay honored.
+	TransportPort int `json:"transport_port,omitempty"`
 	// QUICPort optionally PINS the UDP port for the QUIC transport (#2607). QUIC
 	// is on by default (like stcpr/sudph); 0 (default/omitted) binds an ephemeral
 	// port — exactly as sudph_port does. Set a fixed port when a stable firewall


### PR DESCRIPTION
## What

The behavior-completing step of transport-port-unification: when a visor sets `transport_port`, **QUIC and sudph listen on ONE master UDP socket** (demuxed by protocol via `udpDemux`) instead of binding a port each. **Opt-in** — `transport_port` `0` (default) keeps the per-type binding, so default fleet behavior is unchanged.

## How

- **visorconfig**: `Transport.TransportPort int` (0 = per-type; N = unified UDP master).
- **`ClientFactory.EnableUnifiedUDP(port)`** binds the master socket + demux (sets the receive buffer on the real socket since a `demuxConn` can't); `CloseUnifiedUDP` tears it down; `sharedUDPConn(proto)` hands out the per-protocol virtual conn. The demux is held as `any` on the untagged `ClientFactory` (udpDemux is `!tinygo`) and driven by the new `!tinygo` `client_unified_udp.go`.
- **`makeResolvedClient`** sets quic/sudph `sharedConn` from the demux when enabled.
- **`init_transport`** calls `EnableUnifiedUDP(transport_port)` before `NewManager` and registers `CloseUnifiedUDP` on the close stack.

Both protocols register their bound (shared) port with the AR as before, so peers resolve the same port and the demux routes inbound packets by protocol.

## Validation

End-to-end with **real traffic** in #3243 (quic-go) / #3244 (kcp-go + pfilter); this PR's `TestClientFactory_UnifiedUDP` covers the factory opt-in + that quic/sudph get one shared socket.

**To try it:** set `"transport_port": <port>` in a visor config; QUIC + sudph come up on that one UDP port. webrtc-over-demux + the TCP side (stcpr/WS) follow.

## Verification

- `go build ./...`, `go test` (demux + factory), `tinygo build` wasm-visor (the `any` field is untagged-safe), lint — all pass.