### PR TITLE
feat(transport): TCP demux component for the unified transport port

### DIFF
--- a/pkg/transport/network/tcpdemux.go
+++ b/pkg/transport/network/tcpdemux.go
@@ -1,0 +1,51 @@
+//go:build !tinygo
+
+// Package network pkg/transport/network/tcpdemux.go
+//
+// tcpDemux multiplexes ONE TCP listener across the TCP transport types — WS (an
+// HTTP/1.1 WebSocket upgrade) and stcpr (a raw skywire handshake) — so a visor
+// can listen for both on a single transport_port instead of binding a port each.
+// See docs/design/transport-port-unification.md.
+//
+// It is a thin wrapper around the vendored soheilhy/cmux: cmux peeks each
+// accepted connection's first bytes (replaying them to the matched protocol) and
+// routes HTTP/1 to the WS listener, everything else to the stcpr listener. cmux
+// is the established connection-mux library, so unlike the UDP side this needs no
+// custom classifier. The TCP analog of udpDemux.
+package network
+
+import (
+	"net"
+
+	"github.com/soheilhy/cmux"
+)
+
+// tcpDemux fans one TCP listener out to a WS (HTTP) and an stcpr (raw) virtual
+// net.Listener. The protocols' accept loops consume the virtual listeners
+// unchanged. Closing the demux closes the master listener, which stops cmux and
+// the virtual listeners.
+type tcpDemux struct {
+	master net.Listener
+	ws     net.Listener
+	stcpr  net.Listener
+}
+
+func newTCPDemux(master net.Listener) *tcpDemux {
+	m := cmux.New(master)
+	// Order matters: match the HTTP/1 (WebSocket-upgrade) connections first, then
+	// everything else is the raw skywire stcpr handshake.
+	ws := m.Match(cmux.HTTP1Fast())
+	stcpr := m.Match(cmux.Any())
+	d := &tcpDemux{master: master, ws: ws, stcpr: stcpr}
+	go m.Serve() //nolint:errcheck // returns when the master listener closes
+	return d
+}
+
+// WS returns the virtual listener carrying HTTP/1 (WebSocket-upgrade) connections.
+func (d *tcpDemux) WS() net.Listener { return d.ws }
+
+// STCPR returns the virtual listener carrying raw (non-HTTP) connections.
+func (d *tcpDemux) STCPR() net.Listener { return d.stcpr }
+
+// Close closes the master listener, stopping cmux and the virtual listeners.
+func (d *tcpDemux) Close() error { return d.master.Close() }

--- a/pkg/transport/network/tcpdemux_test.go
+++ b/pkg/transport/network/tcpdemux_test.go
@@ -1,0 +1,94 @@
+//go:build !tinygo
+
+package network
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestTCPDemux_RoutesByPrefix validates the TCP demux against real connections: a
+// connection beginning with an HTTP/1 request line (a WebSocket upgrade) is routed
+// to the WS listener, and a connection beginning with raw non-HTTP bytes (a
+// skywire stcpr handshake) is routed to the stcpr listener — and the peeked bytes
+// are replayed so each protocol reads from the start.
+func TestTCPDemux_RoutesByPrefix(t *testing.T) {
+	master, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen master: %v", err)
+	}
+	d := newTCPDemux(master)
+	defer d.Close() //nolint:errcheck
+	addr := master.Addr().String()
+
+	// HTTP (WS) connection → WS listener; the full request line is replayed.
+	httpReq := "GET /dmsg HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\n\r\n"
+	go func() {
+		c, err := net.Dial("tcp", addr)
+		if err != nil {
+			return
+		}
+		defer c.Close()                   //nolint:errcheck
+		_, _ = io.WriteString(c, httpReq) //nolint:errcheck
+		time.Sleep(200 * time.Millisecond)
+	}()
+	wsConn, err := acceptWithTimeout(t, d.WS())
+	if err != nil {
+		t.Fatalf("WS accept: %v", err)
+	}
+	defer wsConn.Close() //nolint:errcheck
+	line, err := bufio.NewReader(wsConn).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read WS request line: %v", err)
+	}
+	if line != "GET /dmsg HTTP/1.1\r\n" {
+		t.Fatalf("WS got %q, want the replayed GET line", line)
+	}
+
+	// Raw (stcpr) connection → stcpr listener; the raw bytes are replayed.
+	raw := []byte{0x9e, 0x01, 0x02, 0x03, 0x04, 0x05}
+	go func() {
+		c, err := net.Dial("tcp", addr)
+		if err != nil {
+			return
+		}
+		defer c.Close()     //nolint:errcheck
+		_, _ = c.Write(raw) //nolint:errcheck
+		time.Sleep(200 * time.Millisecond)
+	}()
+	stcprConn, err := acceptWithTimeout(t, d.STCPR())
+	if err != nil {
+		t.Fatalf("stcpr accept: %v", err)
+	}
+	defer stcprConn.Close() //nolint:errcheck
+	buf := make([]byte, len(raw))
+	_ = stcprConn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+	if _, err := io.ReadFull(stcprConn, buf); err != nil {
+		t.Fatalf("read stcpr bytes: %v", err)
+	}
+	if string(buf) != string(raw) {
+		t.Fatalf("stcpr got %x, want %x", buf, raw)
+	}
+}
+
+func acceptWithTimeout(t *testing.T, lis net.Listener) (net.Conn, error) {
+	t.Helper()
+	type res struct {
+		c   net.Conn
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		c, err := lis.Accept()
+		ch <- res{c, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.c, r.err
+	case <-time.After(5 * time.Second):
+		return nil, io.EOF
+	}
+}


### PR DESCRIPTION
## What

The TCP analog of `udpDemux` (#3242): one TCP listener shared by the TCP transport types — **WS** (an HTTP/1.1 WebSocket upgrade) and **stcpr** (a raw skywire handshake) — so a visor can listen for both on a single `transport_port` instead of binding a port each.

Unlike the UDP side, this needs **no custom classifier**: it's a thin wrapper around the vendored `soheilhy/cmux`, which peeks each connection's first bytes (replaying them to the matched protocol) and routes HTTP/1 → the WS listener, everything else → the stcpr listener. The protocols' accept loops consume the virtual `net.Listener`s unchanged.

## Validation

`TestTCPDemux_RoutesByPrefix` against real connections: an HTTP request line routes to WS with the `GET` line replayed; raw non-HTTP bytes route to stcpr replayed from the start.

Isolated; the stcpr/WS + factory wiring (mirroring the UDP #3243–#3245 sequence) follows.

## Verification

- `go build ./...`, `go test`, lint — pass.