### PR TITLE
feat(transport): unified transport port — stcpr + WS share one TCP socket (opt-in)

### DIFF
--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -91,6 +91,15 @@ type ClientFactory struct {
 	// Typed `any` because udpDemux is //go:build !tinygo (quic-go/kcp-go), and this
 	// struct is in the untagged file; the !tinygo client_unified_udp.go manages it.
 	udpDemux any
+	// tcpDemux holds a *tcpDemux (the unified transport_port shared TCP listener,
+	// cmux) when EnableUnifiedTCP has been called. `any` for the same reason as
+	// udpDemux; managed by the !tinygo client_unified_tcp.go.
+	tcpDemux any
+	// stcprSharedListener / wsSharedListener are the tcpDemux's per-protocol
+	// virtual listeners, set by EnableUnifiedTCP. net.Listener (stdlib), so the
+	// WS case in MakeClient (untagged) can read wsSharedListener directly.
+	stcprSharedListener net.Listener
+	wsSharedListener    net.Listener
 }
 
 // MakeClient creates a new client of specified type
@@ -119,7 +128,11 @@ func (f *ClientFactory) MakeClient(netType types.Type, port int) (Client, error)
 	case types.STCP:
 		return newStcp(generic, f.PKTable), nil
 	case types.WS:
-		return newWS(generic, f.WSTable), nil
+		wc := newWS(generic, f.WSTable)
+		if f.wsSharedListener != nil { // unified transport port
+			wc.(*wsClient).sharedListener = f.wsSharedListener
+		}
+		return wc, nil
 	case types.WT:
 		return newWT(generic, f.WTTable), nil
 	case types.WEBRTC:

--- a/pkg/transport/network/client_resolved.go
+++ b/pkg/transport/network/client_resolved.go
@@ -32,7 +32,11 @@ func (f *ClientFactory) makeResolvedClient(netType types.Type, generic *genericC
 	resolved := &resolvedClient{genericClient: generic, ar: ar}
 	switch netType {
 	case types.STCPR:
-		return newStcpr(resolved, port), nil
+		c := newStcpr(resolved, port)
+		if f.stcprSharedListener != nil { // unified transport port
+			c.(*stcprClient).sharedListener = f.stcprSharedListener
+		}
+		return c, nil
 	case types.SUDPH:
 		c, err := makeSudphClient(resolved, port)
 		if err != nil {

--- a/pkg/transport/network/client_unified_tcp.go
+++ b/pkg/transport/network/client_unified_tcp.go
@@ -1,0 +1,43 @@
+//go:build !tinygo
+
+// Package network pkg/transport/network/client_unified_tcp.go
+//
+// The unified transport port (TCP side): bind ONE master TCP listener and route
+// the TCP transport types (stcpr raw + WS HTTP-upgrade) over it via a tcpDemux
+// (cmux), so they share a single listening port instead of binding one each. See
+// docs/design/transport-port-unification.md. Opt-in: only active when the visor
+// configures transport_port (EnableUnifiedTCP is a no-op for port 0).
+package network
+
+import (
+	"fmt"
+	"net"
+)
+
+// EnableUnifiedTCP binds the master TCP listener on port and prepares the cmux
+// demux. Call once, before MakeClient. port 0 is a no-op (per-type binding
+// stays). stcpr accepts over the raw virtual listener and the WS HTTP server runs
+// over the HTTP virtual listener (see makeResolvedClient / MakeClient). The master
+// listener lifecycle is owned here — close it with CloseUnifiedTCP.
+func (f *ClientFactory) EnableUnifiedTCP(port int) error {
+	if port == 0 {
+		return nil
+	}
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return fmt.Errorf("unified transport port %d (tcp): %w", port, err)
+	}
+	d := newTCPDemux(lis)
+	f.tcpDemux = d
+	f.stcprSharedListener = d.STCPR()
+	f.wsSharedListener = d.WS()
+	return nil
+}
+
+// CloseUnifiedTCP closes the master TCP listener + cmux demux, if enabled.
+func (f *ClientFactory) CloseUnifiedTCP() error {
+	if d, ok := f.tcpDemux.(*tcpDemux); ok && d != nil {
+		return d.Close()
+	}
+	return nil
+}

--- a/pkg/transport/network/client_unified_tcp_test.go
+++ b/pkg/transport/network/client_unified_tcp_test.go
@@ -1,0 +1,49 @@
+//go:build !tinygo
+
+package network
+
+import (
+	"net"
+	"testing"
+)
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close() //nolint:errcheck,gosec
+	return port
+}
+
+// TestClientFactory_UnifiedTCP verifies the opt-in: off by default, a no-op for
+// port 0, and once enabled it exposes the stcpr + WS virtual listeners over one
+// TCP socket.
+func TestClientFactory_UnifiedTCP(t *testing.T) {
+	f := &ClientFactory{}
+	if f.stcprSharedListener != nil || f.wsSharedListener != nil {
+		t.Fatal("shared listeners should be nil before enable")
+	}
+	if err := f.EnableUnifiedTCP(0); err != nil {
+		t.Fatalf("EnableUnifiedTCP(0): %v", err)
+	}
+	if f.stcprSharedListener != nil {
+		t.Fatal("port 0 must be a no-op")
+	}
+
+	port := freeTCPPort(t)
+	if err := f.EnableUnifiedTCP(port); err != nil {
+		t.Fatalf("EnableUnifiedTCP(%d): %v", port, err)
+	}
+	defer f.CloseUnifiedTCP() //nolint:errcheck
+
+	if f.stcprSharedListener == nil || f.wsSharedListener == nil {
+		t.Fatal("stcpr + WS virtual listeners must be non-nil when enabled")
+	}
+	if f.stcprSharedListener.Addr().String() != f.wsSharedListener.Addr().String() {
+		t.Fatalf("stcpr and WS must share one socket: %s vs %s",
+			f.stcprSharedListener.Addr(), f.wsSharedListener.Addr())
+	}
+}

--- a/pkg/transport/network/stcpr.go
+++ b/pkg/transport/network/stcpr.go
@@ -26,6 +26,10 @@ const (
 type stcprClient struct {
 	*resolvedClient
 	port int
+	// sharedListener, when set, is the TCP listener stcpr accepts over instead of
+	// binding its own — the raw (non-HTTP) virtual listener of a unified
+	// transport_port socket (see tcpDemux). nil = bind a dedicated listener.
+	sharedListener net.Listener
 }
 
 func newStcpr(resolved *resolvedClient, port int) Client {
@@ -87,21 +91,28 @@ func (c *stcprClient) Start() error {
 
 func (c *stcprClient) serve() {
 	var lis net.Listener
-	var err error
-	var confPort string
-	if c.port != 0 {
-		confPort = fmt.Sprintf(":%d", c.port)
-	}
-	for {
-		lis, err = net.Listen("tcp", confPort)
-		if err != nil {
-			c.log.WithError(err).Warnf("Failed to listen on port: %d", c.port)
-			c.port++
+	if c.sharedListener != nil {
+		// Unified transport port: accept over the shared TCP listener's raw
+		// (non-HTTP) virtual listener. The master listener lifecycle stays with the
+		// demux. The AR is still bound to the actual (shared) port below.
+		lis = c.sharedListener
+	} else {
+		var err error
+		var confPort string
+		if c.port != 0 {
 			confPort = fmt.Sprintf(":%d", c.port)
-			c.log.Warnf("Trying port %d", c.port)
-			continue
 		}
-		break
+		for {
+			lis, err = net.Listen("tcp", confPort)
+			if err != nil {
+				c.log.WithError(err).Warnf("Failed to listen on port: %d", c.port)
+				c.port++
+				confPort = fmt.Sprintf(":%d", c.port)
+				c.log.Warnf("Trying port %d", c.port)
+				continue
+			}
+			break
+		}
 	}
 
 	localAddr := lis.Addr().String()

--- a/pkg/transport/network/ws.go
+++ b/pkg/transport/network/ws.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/transport/network/stcp"
@@ -28,6 +29,11 @@ import (
 type wsClient struct {
 	*genericClient
 	table stcp.PKTable
+	// sharedListener, when set, is the TCP listener the WS HTTP server serves over
+	// instead of binding its own — the HTTP virtual listener of a unified
+	// transport_port socket (see tcpDemux, !tinygo). net.Listener so this stays in
+	// the untagged file; only ws_native.go (the server) consumes it.
+	sharedListener net.Listener
 }
 
 func newWS(generic *genericClient, table stcp.PKTable) Client {

--- a/pkg/transport/network/ws_native.go
+++ b/pkg/transport/network/ws_native.go
@@ -39,10 +39,18 @@ func (c *wsClient) Start() error {
 }
 
 func (c *wsClient) serve() {
-	lis, err := newWSListener(c.listenAddr)
-	if err != nil {
-		c.log.Errorf("Failed to start WS listener on %q: %v", c.listenAddr, err)
-		return
+	var lis *wsListener
+	if c.sharedListener != nil {
+		// Unified transport port: run the WS HTTP server over the shared listener's
+		// HTTP virtual listener instead of binding our own.
+		lis = newWSListenerOver(c.sharedListener)
+	} else {
+		var err error
+		lis, err = newWSListener(c.listenAddr)
+		if err != nil {
+			c.log.Errorf("Failed to start WS listener on %q: %v", c.listenAddr, err)
+			return
+		}
 	}
 	c.acceptTransports(lis)
 }
@@ -62,6 +70,13 @@ func newWSListener(addr string) (*wsListener, error) {
 	if err != nil {
 		return nil, err
 	}
+	return newWSListenerOver(tcpLis), nil
+}
+
+// newWSListenerOver runs the WebSocket HTTP server over an already-bound TCP
+// listener (e.g. the HTTP virtual listener of a unified transport_port demux),
+// rather than binding its own.
+func newWSListenerOver(tcpLis net.Listener) *wsListener {
 	l := &wsListener{
 		addr:  tcpLis.Addr(),
 		conns: make(chan net.Conn),
@@ -71,7 +86,7 @@ func newWSListener(addr string) (*wsListener, error) {
 	mux.HandleFunc("/", l.handle)
 	l.srv = &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	go l.srv.Serve(tcpLis) //nolint:errcheck
-	return l, nil
+	return l
 }
 
 func (l *wsListener) handle(w http.ResponseWriter, r *http.Request) {

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -503,11 +503,16 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 	// share one master UDP socket (demuxed) instead of binding a port each. 0 =
 	// per-type binding (default). See docs/design/transport-port-unification.md.
 	if v.conf.Transport != nil && v.conf.Transport.TransportPort != 0 {
-		if err := factory.EnableUnifiedUDP(v.conf.Transport.TransportPort); err != nil {
-			return fmt.Errorf("unified transport port: %w", err)
+		port := v.conf.Transport.TransportPort
+		if err := factory.EnableUnifiedUDP(port); err != nil {
+			return fmt.Errorf("unified transport port (udp): %w", err)
 		}
-		log.Infof("Unified transport port: QUIC + sudph share UDP port %d", v.conf.Transport.TransportPort)
+		if err := factory.EnableUnifiedTCP(port); err != nil {
+			return fmt.Errorf("unified transport port (tcp): %w", err)
+		}
+		log.Infof("Unified transport port %d: QUIC+sudph share UDP, stcpr+WS share TCP", port)
 		v.pushCloseStack("transport.unified_udp", factory.CloseUnifiedUDP)
+		v.pushCloseStack("transport.unified_tcp", factory.CloseUnifiedTCP)
 	}
 	tpM, err := transport.NewManager(managerLogger, v.arClient, v.ebc, &tpMConf, factory)
 	if err != nil {


### PR DESCRIPTION
## What

Completes the listening-port unification: with `transport_port` set, **stcpr and WS share one master TCP socket** (cmux-demuxed) — together with QUIC + sudph on the one UDP socket (#3245) — so a visor listens for **all** transport types on a single port number (tcp + udp). Still opt-in: `transport_port` `0` (default) keeps per-type binding, so default fleet behavior is unchanged.

## How

- **stcpr**: optional `sharedListener` (the raw/non-HTTP cmux virtual listener); `serve()` accepts over it. AR is bound to the actual (shared) port.
- **WS**: optional `sharedListener` (the HTTP cmux virtual listener); `newWSListenerOver` runs the WS HTTP server over it. `wsClient.sharedListener` is `net.Listener` (stdlib) so it stays in the untagged `ws.go`; only `ws_native.go` (the server) consumes it.
- **`ClientFactory.EnableUnifiedTCP(port)`** binds the master TCP listener + `tcpDemux` (cmux) and exposes the stcpr/WS virtual listeners; `CloseUnifiedTCP` tears it down. Held as `any` (tcpDemux is `!tinygo`) + driven by the new `!tinygo` `client_unified_tcp.go`; the two `net.Listener` fields are untagged-safe so the WS case in `MakeClient` reads `wsSharedListener` directly.
- `makeResolvedClient` sets stcpr `sharedListener`; `MakeClient` sets WS `sharedListener`.
- `init_transport` calls `EnableUnifiedTCP(transport_port)` alongside `EnableUnifiedUDP` + registers `CloseUnifiedTCP`.

So `transport_port = N` → **QUIC+sudph on N/udp, stcpr+WS on N/tcp**: one firewall rule, one AR-registered port number, every type demuxed.

## Validation

Component validated in #3246 (cmux routes HTTP→WS, raw→stcpr); this PR's `TestClientFactory_UnifiedTCP` covers the factory opt-in.

## Verification

- `go build ./...`, `go test`, `tinygo build` wasm-visor (untagged-safe), lint — pass.