### PR TITLE
feat(transport): per-type-port override for the unified transport port

### DIFF
--- a/docs/design/transport-port-unification.md
+++ b/docs/design/transport-port-unification.md
@@ -101,6 +101,18 @@ mode is the by-PK `dialTransport` trigger, since signaling rides dmsg.
    AR record with a URL + WT cert-hash; may require an AR-service change — to be
    confirmed).
 5. **Config collapse**: `transport_port` master + per-type overrides; keep the old
-   keys as overrides for compatibility.
+   keys as overrides for compatibility. (done — a non-zero per-type port breaks
+   that type out onto its own socket; 0 rides the master.)
 
 Each step is independently shippable.
+
+## Status
+
+- **Done:** QUIC default-on; UDP demux (quic+sudph) over one socket; TCP demux
+  (stcpr+WS, cmux) over one socket; `transport_port` opt-in wiring; per-type-port
+  override (break-out). A visor with `transport_port: N` listens for every type on
+  `N/tcp` + `N/udp`. Each carrier validated over its demux with real traffic.
+- **Remaining:** AR-integrate WS/WT for discovery (needs an address-resolver
+  service change — new bind/resolve for ws/wt + WT cert-hash storage); webrtc over
+  the shared UDP socket (optional — pion `SetICEUDPMux`); a static `PK → endpoint`
+  table for quic/sudph (the STCP model generalized).

--- a/pkg/transport/network/client_resolved.go
+++ b/pkg/transport/network/client_resolved.go
@@ -30,11 +30,14 @@ import (
 func (f *ClientFactory) makeResolvedClient(netType types.Type, generic *genericClient, port int) (Client, error) {
 	ar, _ := f.ARClient.(addrresolver.APIClient)
 	resolved := &resolvedClient{genericClient: generic, ar: ar}
+	// Unified transport port: a type rides the master socket only when its
+	// per-type port (the `port` arg) is 0; a non-zero per-type port breaks it out
+	// onto its own socket (see sharedUDPConnFor / stcprSharedListenerFor).
 	switch netType {
 	case types.STCPR:
 		c := newStcpr(resolved, port)
-		if f.stcprSharedListener != nil { // unified transport port
-			c.(*stcprClient).sharedListener = f.stcprSharedListener
+		if lis := f.stcprSharedListenerFor(port); lis != nil {
+			c.(*stcprClient).sharedListener = lis
 		}
 		return c, nil
 	case types.SUDPH:
@@ -42,8 +45,8 @@ func (f *ClientFactory) makeResolvedClient(netType types.Type, generic *genericC
 		if err != nil {
 			return nil, err
 		}
-		if sc := f.sharedUDPConn(protoSUDPH); sc != nil {
-			c.(*sudphClient).sharedConn = sc // unified transport port
+		if sc := f.sharedUDPConnFor(protoSUDPH, port); sc != nil {
+			c.(*sudphClient).sharedConn = sc
 		}
 		return c, nil
 	case types.QUIC:
@@ -51,8 +54,8 @@ func (f *ClientFactory) makeResolvedClient(netType types.Type, generic *genericC
 		if err != nil {
 			return nil, err
 		}
-		if sc := f.sharedUDPConn(protoQUIC); sc != nil {
-			c.(*quicClient).sharedConn = sc // unified transport port
+		if sc := f.sharedUDPConnFor(protoQUIC, port); sc != nil {
+			c.(*quicClient).sharedConn = sc
 		}
 		return c, nil
 	}

--- a/pkg/transport/network/client_unified_override_test.go
+++ b/pkg/transport/network/client_unified_override_test.go
@@ -1,0 +1,44 @@
+//go:build !tinygo
+
+package network
+
+import (
+	"testing"
+)
+
+// TestUnifiedPort_PerTypeOverride verifies that a type rides the master socket
+// only when its per-type port is 0; a non-zero per-type port breaks it out (the
+// shared conn/listener is withheld) even with the unified port enabled.
+func TestUnifiedPort_PerTypeOverride(t *testing.T) {
+	f := &ClientFactory{}
+	if err := f.EnableUnifiedUDP(freeUDPPort(t)); err != nil {
+		t.Fatalf("EnableUnifiedUDP: %v", err)
+	}
+	defer f.CloseUnifiedUDP() //nolint:errcheck
+	if err := f.EnableUnifiedTCP(freeTCPPort(t)); err != nil {
+		t.Fatalf("EnableUnifiedTCP: %v", err)
+	}
+	defer f.CloseUnifiedTCP() //nolint:errcheck
+
+	// per-type port 0 → ride the master.
+	if f.sharedUDPConnFor(protoQUIC, 0) == nil {
+		t.Fatal("quic_port 0 should ride the master UDP socket")
+	}
+	if f.sharedUDPConnFor(protoSUDPH, 0) == nil {
+		t.Fatal("sudph_port 0 should ride the master UDP socket")
+	}
+	if f.stcprSharedListenerFor(0) == nil {
+		t.Fatal("stcpr_port 0 should ride the master TCP socket")
+	}
+
+	// explicit per-type port → break out (no shared socket).
+	if f.sharedUDPConnFor(protoQUIC, 5000) != nil {
+		t.Fatal("quic_port 5000 should break out of the master")
+	}
+	if f.sharedUDPConnFor(protoSUDPH, 5001) != nil {
+		t.Fatal("sudph_port 5001 should break out of the master")
+	}
+	if f.stcprSharedListenerFor(5002) != nil {
+		t.Fatal("stcpr_port 5002 should break out of the master")
+	}
+}

--- a/pkg/transport/network/client_unified_tcp.go
+++ b/pkg/transport/network/client_unified_tcp.go
@@ -41,3 +41,14 @@ func (f *ClientFactory) CloseUnifiedTCP() error {
 	}
 	return nil
 }
+
+// stcprSharedListenerFor returns the shared stcpr virtual listener only when
+// stcpr rides the master port — i.e. its per-type port (stcpr_port) is 0. A
+// non-zero stcpr_port breaks stcpr out onto its own port even when transport_port
+// is set. Returns nil → per-type binding.
+func (f *ClientFactory) stcprSharedListenerFor(perTypePort int) net.Listener {
+	if perTypePort != 0 {
+		return nil
+	}
+	return f.stcprSharedListener
+}

--- a/pkg/transport/network/client_unified_udp.go
+++ b/pkg/transport/network/client_unified_udp.go
@@ -52,3 +52,15 @@ func (f *ClientFactory) sharedUDPConn(proto udpProto) net.PacketConn {
 	}
 	return nil
 }
+
+// sharedUDPConnFor returns the shared demux conn for proto only when the type
+// rides the master port — i.e. its per-type port is 0. A non-zero per-type port
+// (e.g. quic_port / sudph_port) breaks that type out onto its own socket even
+// when transport_port is set, so an operator can pin one type to a dedicated port
+// while the rest share. Returns nil → per-type binding.
+func (f *ClientFactory) sharedUDPConnFor(proto udpProto, perTypePort int) net.PacketConn {
+	if perTypePort != 0 {
+		return nil
+	}
+	return f.sharedUDPConn(proto)
+}

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -400,11 +400,14 @@ type Transport struct {
 	LogStore              *LogStore       `json:"log_store"`
 	StcprPort             int             `json:"stcpr_port"`
 	SudphPort             int             `json:"sudph_port"`
-	// TransportPort, when non-zero, is the single UDP port the UDP transport types
-	// (QUIC + sudph) share — one listening socket, demultiplexed by protocol (see
-	// docs/design/transport-port-unification.md) — instead of binding a port each.
-	// 0 (default/omitted) keeps the per-type binding (sudph_port/quic_port). Opt-in
-	// while the unified-port path proves out; the per-type ports stay honored.
+	// TransportPort, when non-zero, is the single port number the transport types
+	// share: QUIC + sudph on <port>/udp and stcpr + WS on <port>/tcp, each socket
+	// demultiplexed by protocol (see docs/design/transport-port-unification.md),
+	// instead of binding a port each. 0 (default/omitted) keeps per-type binding.
+	// Per-type ports remain an override: a type whose own port (stcpr_port /
+	// sudph_port / quic_port) is non-zero breaks OUT onto that dedicated port even
+	// when transport_port is set; left 0 it rides the shared port. Opt-in while the
+	// unified-port path proves out.
 	TransportPort int `json:"transport_port,omitempty"`
 	// QUICPort optionally PINS the UDP port for the QUIC transport (#2607). QUIC
 	// is on by default (like stcpr/sudph); 0 (default/omitted) binds an ephemeral


### PR DESCRIPTION
## What

Completes the unified-port config story (design doc step 5): a transport type rides the shared `transport_port` only when its per-type port is `0`; a non-zero per-type port (`stcpr_port` / `sudph_port` / `quic_port`) **breaks that type out** onto its own dedicated socket even when `transport_port` is set. So an operator can pin one type to a fixed port (e.g. a firewall hole) while the rest share the master port.

## How

- `sharedUDPConnFor(proto, perTypePort)` / `stcprSharedListenerFor(perTypePort)` return the shared conn/listener only when `perTypePort == 0`.
- `makeResolvedClient` gates the shared conn on the per-type port it's given (the port `InitClient` was called with).

**No change to the common case** (per-type ports default `0` → ride the master, as before); this only adds the break-out when a per-type port is explicitly set.

## Verification

- `go build ./...`, `go test` (`TestUnifiedPort_PerTypeOverride`), lint — pass.