### PR TITLE
feat(wasm-visor): browse-dmsg demo — render a dmsg site in a sandboxed iframe

### DIFF
--- a/cmd/wasm-visor/index.html
+++ b/cmd/wasm-visor/index.html
@@ -22,7 +22,14 @@
   <button onclick="doBoot()">boot</button>
   <button onclick="doStatus()">status</button>
 </div>
-<pre id="out" style="white-space:pre-wrap;max-height:70vh;overflow:auto"></pre>
+<div style="margin-top:.6em">
+  browse dmsg site — pk <input id="browsepk" size="40" placeholder="&lt;site-pk&gt; or pk:port">
+  path <input id="browsepath" size="10" value="/">
+  <button onclick="doBrowse()">browse</button>
+  <span style="color:#888">(renders fetched dmsg content in a sandboxed iframe — no DNS, no IP)</span>
+</div>
+<pre id="out" style="white-space:pre-wrap;max-height:35vh;overflow:auto"></pre>
+<iframe id="browseframe" sandbox style="width:100%;height:40vh;background:#fff;border:1px solid #444" title="dmsg site"></iframe>
 
 <script src="wasm_exec_tinygo.js"></script>
 <script>
@@ -56,6 +63,17 @@
   }
   function doStatus() { log("status: " + JSON.stringify(skywireVisor.status())); }
 
+  async function doBrowse() {
+    const pk = document.getElementById("browsepk").value.trim();
+    const path = document.getElementById("browsepath").value.trim() || "/";
+    try {
+      const r = await skywireVisor.fetchDmsg(pk, "GET", path, null);
+      const html = new TextDecoder().decode(r.body);
+      document.getElementById("browseframe").srcdoc = html;
+      log("browsed dmsg://" + pk + path + " → " + r.status + " (" + r.body.length + " bytes)");
+    } catch (e) { log("browse error: " + (e.message || e)); }
+  }
+
   // ---- control bridge (drives this tab from a shell via serve.go) ----
   (function () {
     let tabId = sessionStorage.getItem("ctlTabId");
@@ -87,6 +105,14 @@
         }
         case "status":
           return skywireVisor.status();
+        case "browse": {
+          // a = [sitePK, method, path, bodyOrNull] — fetch a dmsg site, render it.
+          const r = await skywireVisor.fetchDmsg(a[0] || "", a[1] || "GET", a[2] || "/", a[3] || null);
+          const html = new TextDecoder().decode(r.body);
+          const frame = document.getElementById("browseframe");
+          if (frame) frame.srcdoc = html;
+          return { status: r.status, bytes: r.body.length, preview: html.slice(0, 2000) };
+        }
         case "reload":
           post("/ctl/log?tab=" + tabId, "reloading");
           setTimeout(() => location.reload(), 150);


### PR DESCRIPTION
## What

Demonstrates the **"virtual browser"** end to end on the harness page: a `pk` + `path` input and a **browse** button call `skywireVisor.fetchDmsg` (#3250) and render the fetched content in a **sandboxed iframe** (`sandbox` = no scripts/same-origin, so untrusted dmsg HTML/CSS renders safely). No DNS, no IP — a skynet/dmsg site reached by public key over the dmsg overlay, displayed in the tab.

Also a `browse` control-bridge action (`a=[sitePK, method, path, body]`) so the test harness can drive a fetch+render headlessly and assert on the result.

Self-contained pages (inlined CSS) render fully; pages with external resources show the markup — per-resource dmsg routing (the iframe itself running override.js) is the next step toward a full browsing experience.

Static harness page (copied into `build/wasm-visor`); no build change.