### PR TITLE
feat(wasm-visor): shared browse engine + browse/host overlay in the standalone HV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,7 @@ tinygo-wasm-visor: ## Build the browser WASM visor edge (dmsg+transport+router+a
 	tinygo build -target wasm -o ./build/wasm-visor/wasm-visor.wasm ./cmd/wasm-visor
 	cp "$$(tinygo env TINYGOROOT)/targets/wasm_exec.js" ./build/wasm-visor/wasm_exec_tinygo.js
 	cp ./cmd/wasm-visor/index.html ./build/wasm-visor/
+	cp ./pkg/wasmhv/browse.js ./build/wasm-visor/
 	@echo "built ./build/wasm-visor (TinyGo) — serve it: 'go run cmd/dmsg-wasm/serve.go -dir build/wasm-visor' then open http://localhost:8085/"
 
 dmsg-wasm-hv: ## Build the browser hypervisor-over-dmsg bundle (Service Worker proxy) into build/dmsg-wasm-hv

--- a/cmd/wasm-visor/index.html
+++ b/cmd/wasm-visor/index.html
@@ -39,6 +39,7 @@
 <iframe id="browseframe" sandbox="allow-scripts allow-forms" style="width:100%;height:45vh;background:#fff;border:1px solid #444" title="dmsg site"></iframe>
 
 <script src="wasm_exec_tinygo.js"></script>
+<script src="browse.js"></script>
 <script>
   const out = document.getElementById("out");
   const log = (...a) => { out.textContent += a.join(" ") + "\n"; out.scrollTop = out.scrollHeight; };
@@ -70,155 +71,21 @@
   }
   function doStatus() { log("status: " + JSON.stringify(skywireVisor.status())); }
 
-  // currentSitePK is the PK of the site shown in the iframe, so in-page links
-  // and the site's own fetch/XHR (relayed via postMessage) route to the same
-  // site over dmsg.
-  let currentSitePK = "";
-
-  // same-site = relative or root-relative (no scheme, not //host, not #anchor).
-  // External http(s)/scheme links are left to the browser.
-  function sameSite(u) {
-    return !!u && u.charAt(0) !== "#" && !/^https?:\/\//i.test(u) && !/^\/\//.test(u) && !/^[a-z][a-z0-9+.-]*:/i.test(u);
-  }
-  function resolvePath(href, base) {
-    try { const u = new URL(href, "http://dmsg" + base); return u.pathname + u.search; } catch (e) { return href; }
-  }
-  // Guess a MIME from a path extension (fallback when dmsg omits Content-Type).
-  function mimeOf(path) {
-    const m = (path.split("?")[0].match(/\.([a-z0-9]+)$/i) || [, ""])[1].toLowerCase();
-    return { css: "text/css", js: "text/javascript", mjs: "text/javascript", json: "application/json",
-      png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", gif: "image/gif", svg: "image/svg+xml",
-      webp: "image/webp", ico: "image/x-icon", woff: "font/woff", woff2: "font/woff2", ttf: "font/ttf",
-      html: "text/html" }[m] || "application/octet-stream";
-  }
-  function bytesToB64(bytes) {
-    let s = ""; const C = 0x8000;
-    for (let i = 0; i < bytes.length; i += C) s += String.fromCharCode.apply(null, bytes.subarray(i, i + C));
-    return btoa(s);
-  }
-  function ctOf(headers, path) {
-    const ct = headers && (headers["Content-Type"] || headers["content-type"]);
-    return (ct || mimeOf(path)).split(";")[0].trim();
-  }
-
-  // navShimSrc is JS injected (as a <script> built via DOM, so no </script> in a
-  // string) at the top of the browsed iframe's <head>. It (1) intercepts same-site
-  // link clicks → postMessage a nav request to this parent, and (2) overrides
-  // window.fetch so the site's OWN same-site requests are relayed to the parent and
-  // fetched over dmsg — the app-level equivalent of a SOCKS5 proxy for the page.
-  function navShimSrc(path) {
-    return (
-      'var cur=' + JSON.stringify(path) + ';' +
-      'function pathOf(h){try{var u=new URL(h,"http://dmsg"+cur);return u.pathname+u.search;}catch(e){return h;}}' +
-      'function same(u){return !!u&&u.charAt(0)!=="#"&&!/^https?:\\/\\//i.test(u)&&!/^\\/\\//.test(u)&&!/^[a-z][a-z0-9+.-]*:/i.test(u);}' +
-      'document.addEventListener("click",function(e){' +
-      'var a=e.target.closest?e.target.closest("a[href]"):null;if(!a)return;' +
-      'var h=a.getAttribute("href")||"";if(!same(h))return;' +
-      'e.preventDefault();parent.postMessage({type:"dmsgnav",path:pathOf(h)},"*");' +
-      '},true);' +
-      'var _rq=0,_pend={};' +
-      'window.addEventListener("message",function(e){var d=e.data||{};if(d.type!=="dmsgreply")return;var p=_pend[d.id];if(!p)return;delete _pend[d.id];p(d);});' +
-      'function relay(p,m,b){return new Promise(function(res){var id=++_rq;_pend[id]=res;parent.postMessage({type:"dmsgreq",id:id,path:p,method:m||"GET",body:b||null},"*");});}' +
-      'var _f=window.fetch;window.fetch=function(input,init){var u=typeof input==="string"?input:(input&&input.url);' +
-      'if(!same(u))return _f.apply(this,arguments);' +
-      'return relay(pathOf(u),(init&&init.method)||"GET",(init&&init.body)||null).then(function(r){' +
-      'var body=r.body?Uint8Array.from(atob(r.body),function(c){return c.charCodeAt(0);}):new Uint8Array();' +
-      'return new Response(body,{status:r.status||200,headers:{"Content-Type":r.ct||"application/octet-stream"}});});};'
-    );
-  }
-
-  // inlineCss rewrites same-site url(...) references in a stylesheet to base64
-  // data: URIs fetched over dmsg, so background-images/fonts/@import assets load
-  // (they'd otherwise resolve against the dead iframe origin). base is the path
-  // the stylesheet itself was loaded from, for relative url() resolution.
-  const CSS_URL = /url\(\s*(['"]?)([^'")]+)\1\s*\)/gi;
-  async function inlineCss(pk, base, css) {
-    const uniq = [...new Set([...css.matchAll(CSS_URL)].map(m => m[2]).filter(sameSite))];
-    if (!uniq.length) return css;
-    const map = {};
-    await Promise.all(uniq.map(u => skywireVisor.fetchDmsg(pk, "GET", resolvePath(u, base), null)
-      .then(r => { map[u] = "data:" + ctOf(r.headers, u) + ";base64," + bytesToB64(r.body); })
-      .catch(() => {})));
-    return css.replace(CSS_URL, (m, q, u) => map[u] ? 'url("' + map[u] + '")' : m);
-  }
-
-  // renderSite shows a fetched dmsg page in the sandboxed iframe: it inlines the
-  // page's same-site subresources (stylesheets/images/scripts, and url() assets
-  // referenced from CSS) by fetching each over dmsg, and injects navShimSrc so
-  // links + the site's fetch route over dmsg too. So a whole site renders and
-  // navigates with no DNS, no IP, no CA.
-  async function renderSite(pk, path, html) {
-    currentSitePK = pk;
-    document.getElementById("browsepk").value = pk;
-    document.getElementById("browsepath").value = path;
-    let docHtml;
-    try {
-      const doc = new DOMParser().parseFromString(html, "text/html");
-      const head = doc.head || doc.documentElement;
-      const base = doc.createElement("base"); base.setAttribute("target", "_self");
-      const sc = doc.createElement("script"); sc.textContent = navShimSrc(path);
-      head.insertBefore(sc, head.firstChild);
-      head.insertBefore(base, head.firstChild);
-
-      const jobs = [];
-      doc.querySelectorAll("link[rel~='stylesheet'][href]").forEach(el => {
-        const href = el.getAttribute("href");
-        if (!sameSite(href)) return;
-        const cssPath = resolvePath(href, path);
-        jobs.push(skywireVisor.fetchDmsg(pk, "GET", cssPath, null)
-          .then(r => inlineCss(pk, cssPath, new TextDecoder().decode(r.body)))
-          .then(css => { const style = doc.createElement("style"); style.textContent = css; el.replaceWith(style); })
-          .catch(() => {}));
-      });
-      // url() assets in the page's own inline <style> blocks (resolve vs the page).
-      doc.querySelectorAll("style").forEach(el => {
-        if (!/url\(/i.test(el.textContent || "")) return;
-        jobs.push(inlineCss(pk, path, el.textContent).then(css => { el.textContent = css; }).catch(() => {}));
-      });
-      doc.querySelectorAll("img[src],script[src],source[src]").forEach(el => {
-        const src = el.getAttribute("src");
-        if (!sameSite(src)) return;
-        jobs.push(skywireVisor.fetchDmsg(pk, "GET", resolvePath(src, path), null).then(r => {
-          el.setAttribute("src", "data:" + ctOf(r.headers, src) + ";base64," + bytesToB64(r.body));
-        }).catch(() => {}));
-      });
-      await Promise.all(jobs);
-      docHtml = "<!doctype html>" + doc.documentElement.outerHTML;
-    } catch (e) {
-      docHtml = html; // parse failed → render the raw HTML
-    }
-    document.getElementById("browseframe").srcdoc = docHtml;
-  }
-
-  async function browseTo(pk, path) {
-    pk = (pk || "").trim();
-    path = path || "/";
-    if (!pk) { log("browse: enter a site PK"); return; }
-    try {
-      const r = await skywireVisor.fetchDmsg(pk, "GET", path, null);
-      await renderSite(pk, path, new TextDecoder().decode(r.body));
-      log("browsed dmsg://" + pk + path + " → " + r.status + " (" + r.body.length + " bytes)");
-    } catch (e) { log("browse error: " + (e.message || e)); }
-  }
+  // The dmsg virtual-browser engine lives in browse.js (shared verbatim with the
+  // standalone hypervisor overlay). Wire an instance to this harness's browse
+  // controls; createBrowser installs its own postMessage handler for in-iframe
+  // navigation and the page's own fetch.
+  const browser = SkywireBrowse.createBrowser({
+    frame: document.getElementById("browseframe"),
+    fetchDmsg: (...a) => skywireVisor.fetchDmsg(...a),
+    log: log,
+    setPK: (pk) => { document.getElementById("browsepk").value = pk; },
+    setPath: (p) => { document.getElementById("browsepath").value = p; },
+  });
 
   function doBrowse() {
-    browseTo(document.getElementById("browsepk").value, document.getElementById("browsepath").value.trim() || "/");
+    browser.browseTo(document.getElementById("browsepk").value, document.getElementById("browsepath").value.trim() || "/");
   }
-
-  // Relayed from inside the browsed iframe: link clicks (dmsgnav) re-fetch a page;
-  // the site's own fetch (dmsgreq) is served over dmsg and the bytes posted back.
-  window.addEventListener("message", async function (e) {
-    const d = e.data || {};
-    if (d.type === "dmsgnav" && currentSitePK) { browseTo(currentSitePK, d.path); return; }
-    if (d.type === "dmsgreq" && currentSitePK) {
-      try {
-        const r = await skywireVisor.fetchDmsg(currentSitePK, d.method || "GET", d.path, d.body || null);
-        e.source.postMessage({ type: "dmsgreply", id: d.id, status: r.status, ct: ctOf(r.headers, d.path), body: bytesToB64(r.body) }, "*");
-      } catch (err) {
-        e.source.postMessage({ type: "dmsgreply", id: d.id, status: 502, ct: "text/plain", body: btoa("dmsg fetch error") }, "*");
-      }
-    }
-  });
 
   function doHost() {
     const path = document.getElementById("hostpath").value.trim() || "/";
@@ -264,11 +131,8 @@
           return skywireVisor.status();
         case "browse": {
           // a = [sitePK, path] — fetch a dmsg site, render it (nav-enabled).
-          const pk = a[0] || "", path = a[1] || "/";
-          const r = await skywireVisor.fetchDmsg(pk, "GET", path, null);
-          const html = new TextDecoder().decode(r.body);
-          await renderSite(pk, path, html);
-          return { status: r.status, bytes: r.body.length, preview: html.slice(0, 2000) };
+          const res = await browser.browseTo(a[0] || "", a[1] || "/");
+          return { status: res.status, bytes: res.bytes, preview: (res.html || "").slice(0, 2000) };
         }
         case "host": {
           // a = [path, contentType, body] — self-host a page over dmsg.

--- a/pkg/wasmhv/browse.js
+++ b/pkg/wasmhv/browse.js
@@ -1,0 +1,224 @@
+// browse.js — the dmsg virtual-browser engine, shared by the wasm-visor dev
+// harness (cmd/wasm-visor/index.html loads a copy of this) and the standalone
+// hypervisor overlay (embedded + injected by the generator in visor mode).
+//
+// It renders a page fetched over dmsg into a SANDBOXED iframe and routes the
+// whole site over dmsg with no DNS, no IP, no CA:
+//   - same-site subresources (stylesheets/images/scripts) are fetched over dmsg
+//     and inlined (stylesheets as <style>, the rest as base64 data: URIs);
+//   - url() assets inside CSS (background-images/fonts/@import) are rewritten to
+//     data: URIs fetched over dmsg;
+//   - same-site link clicks navigate over dmsg (a shim relays them to the parent);
+//   - the page's OWN window.fetch is overridden so its same-site requests are
+//     relayed to the parent and fetched over dmsg (the app-level equivalent of a
+//     SOCKS5 proxy for the iframe).
+// External http(s)/scheme URLs are left to the browser untouched.
+//
+// All fetching goes through an injected fetchDmsg(pkHost, method, path, body) that
+// returns {status, body:Uint8Array, headers} — i.e. globalThis.skywireVisor.fetchDmsg.
+(function () {
+  function sameSite(u) {
+    return !!u && u.charAt(0) !== "#" && !/^https?:\/\//i.test(u) && !/^\/\//.test(u) && !/^[a-z][a-z0-9+.-]*:/i.test(u);
+  }
+  function resolvePath(href, base) {
+    try { var u = new URL(href, "http://dmsg" + base); return u.pathname + u.search; } catch (e) { return href; }
+  }
+  // Guess a MIME from a path extension (fallback when dmsg omits Content-Type).
+  function mimeOf(path) {
+    var m = (path.split("?")[0].match(/\.([a-z0-9]+)$/i) || [, ""])[1].toLowerCase();
+    return { css: "text/css", js: "text/javascript", mjs: "text/javascript", json: "application/json",
+      png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", gif: "image/gif", svg: "image/svg+xml",
+      webp: "image/webp", ico: "image/x-icon", woff: "font/woff", woff2: "font/woff2", ttf: "font/ttf",
+      html: "text/html" }[m] || "application/octet-stream";
+  }
+  function bytesToB64(bytes) {
+    var s = "", C = 0x8000;
+    for (var i = 0; i < bytes.length; i += C) s += String.fromCharCode.apply(null, bytes.subarray(i, i + C));
+    return btoa(s);
+  }
+  function ctOf(headers, path) {
+    var ct = headers && (headers["Content-Type"] || headers["content-type"]);
+    return (ct || mimeOf(path)).split(";")[0].trim();
+  }
+
+  // navShimSrc is JS injected (as a <script> built via DOM, so no </script> in a
+  // string) at the top of the browsed iframe's <head>: (1) same-site link clicks
+  // → postMessage a nav request to the parent; (2) window.fetch override → relay
+  // the page's own same-site requests to the parent, fetched over dmsg.
+  function navShimSrc(path) {
+    return (
+      'var cur=' + JSON.stringify(path) + ';' +
+      'function pathOf(h){try{var u=new URL(h,"http://dmsg"+cur);return u.pathname+u.search;}catch(e){return h;}}' +
+      'function same(u){return !!u&&u.charAt(0)!=="#"&&!/^https?:\\/\\//i.test(u)&&!/^\\/\\//.test(u)&&!/^[a-z][a-z0-9+.-]*:/i.test(u);}' +
+      'document.addEventListener("click",function(e){' +
+      'var a=e.target.closest?e.target.closest("a[href]"):null;if(!a)return;' +
+      'var h=a.getAttribute("href")||"";if(!same(h))return;' +
+      'e.preventDefault();parent.postMessage({type:"dmsgnav",path:pathOf(h)},"*");' +
+      '},true);' +
+      'var _rq=0,_pend={};' +
+      'window.addEventListener("message",function(e){var d=e.data||{};if(d.type!=="dmsgreply")return;var p=_pend[d.id];if(!p)return;delete _pend[d.id];p(d);});' +
+      'function relay(p,m,b){return new Promise(function(res){var id=++_rq;_pend[id]=res;parent.postMessage({type:"dmsgreq",id:id,path:p,method:m||"GET",body:b||null},"*");});}' +
+      'var _f=window.fetch;window.fetch=function(input,init){var u=typeof input==="string"?input:(input&&input.url);' +
+      'if(!same(u))return _f.apply(this,arguments);' +
+      'return relay(pathOf(u),(init&&init.method)||"GET",(init&&init.body)||null).then(function(r){' +
+      'var body=r.body?Uint8Array.from(atob(r.body),function(c){return c.charCodeAt(0);}):new Uint8Array();' +
+      'return new Response(body,{status:r.status||200,headers:{"Content-Type":r.ct||"application/octet-stream"}});});};'
+    );
+  }
+
+  // createBrowser drives one iframe against one "current site". opts:
+  //   frame      — the <iframe> element to render into (sandbox allow-scripts).
+  //   fetchDmsg  — (pkHost, method, path, body) => Promise<{status,body,headers}>.
+  //   log        — optional (msg) => void.
+  //   setPK/setPath — optional callbacks to reflect the current pk/path into a UI.
+  // Returns { renderSite, browseTo, currentPK() }.
+  function createBrowser(opts) {
+    var frame = opts.frame;
+    var fetchDmsg = opts.fetchDmsg || function () { return globalThis.skywireVisor.fetchDmsg.apply(null, arguments); };
+    var log = opts.log || function () {};
+    var currentSitePK = "";
+
+    var CSS_URL = /url\(\s*(['"]?)([^'")]+)\1\s*\)/gi;
+    function inlineCss(pk, base, css) {
+      var uniq = [...new Set([...css.matchAll(CSS_URL)].map(function (m) { return m[2]; }).filter(sameSite))];
+      if (!uniq.length) return Promise.resolve(css);
+      var map = {};
+      return Promise.all(uniq.map(function (u) {
+        return fetchDmsg(pk, "GET", resolvePath(u, base), null)
+          .then(function (r) { map[u] = "data:" + ctOf(r.headers, u) + ";base64," + bytesToB64(r.body); })
+          .catch(function () {});
+      })).then(function () {
+        return css.replace(CSS_URL, function (m, q, u) { return map[u] ? 'url("' + map[u] + '")' : m; });
+      });
+    }
+
+    async function renderSite(pk, path, html) {
+      currentSitePK = pk;
+      if (opts.setPK) opts.setPK(pk);
+      if (opts.setPath) opts.setPath(path);
+      var docHtml;
+      try {
+        var doc = new DOMParser().parseFromString(html, "text/html");
+        var head = doc.head || doc.documentElement;
+        var base = doc.createElement("base"); base.setAttribute("target", "_self");
+        var sc = doc.createElement("script"); sc.textContent = navShimSrc(path);
+        head.insertBefore(sc, head.firstChild);
+        head.insertBefore(base, head.firstChild);
+
+        var jobs = [];
+        doc.querySelectorAll("link[rel~='stylesheet'][href]").forEach(function (el) {
+          var href = el.getAttribute("href");
+          if (!sameSite(href)) return;
+          var cssPath = resolvePath(href, path);
+          jobs.push(fetchDmsg(pk, "GET", cssPath, null)
+            .then(function (r) { return inlineCss(pk, cssPath, new TextDecoder().decode(r.body)); })
+            .then(function (css) { var style = doc.createElement("style"); style.textContent = css; el.replaceWith(style); })
+            .catch(function () {}));
+        });
+        doc.querySelectorAll("style").forEach(function (el) {
+          if (!/url\(/i.test(el.textContent || "")) return;
+          jobs.push(inlineCss(pk, path, el.textContent).then(function (css) { el.textContent = css; }).catch(function () {}));
+        });
+        doc.querySelectorAll("img[src],script[src],source[src]").forEach(function (el) {
+          var src = el.getAttribute("src");
+          if (!sameSite(src)) return;
+          jobs.push(fetchDmsg(pk, "GET", resolvePath(src, path), null)
+            .then(function (r) { el.setAttribute("src", "data:" + ctOf(r.headers, src) + ";base64," + bytesToB64(r.body)); })
+            .catch(function () {}));
+        });
+        await Promise.all(jobs);
+        docHtml = "<!doctype html>" + doc.documentElement.outerHTML;
+      } catch (e) {
+        docHtml = html; // parse failed → render the raw HTML
+      }
+      frame.srcdoc = docHtml;
+    }
+
+    async function browseTo(pk, path) {
+      pk = (pk || "").trim();
+      path = path || "/";
+      if (!pk) { log("browse: enter a site PK"); return { status: 0 }; }
+      try {
+        var r = await fetchDmsg(pk, "GET", path, null);
+        var html = new TextDecoder().decode(r.body);
+        await renderSite(pk, path, html);
+        log("browsed dmsg://" + pk + path + " → " + r.status + " (" + r.body.length + " bytes)");
+        return { status: r.status, bytes: r.body.length, html: html };
+      } catch (e) { log("browse error: " + (e.message || e)); return { status: 0, error: String(e.message || e) }; }
+    }
+
+    // Relayed from inside the browsed iframe: link clicks (dmsgnav) re-fetch a
+    // page; the site's own fetch (dmsgreq) is served over dmsg, bytes posted back.
+    window.addEventListener("message", async function (e) {
+      var d = e.data || {};
+      if (d.type === "dmsgnav" && currentSitePK) { browseTo(currentSitePK, d.path); return; }
+      if (d.type === "dmsgreq" && currentSitePK) {
+        try {
+          var r = await fetchDmsg(currentSitePK, d.method || "GET", d.path, d.body || null);
+          e.source.postMessage({ type: "dmsgreply", id: d.id, status: r.status, ct: ctOf(r.headers, d.path), body: bytesToB64(r.body) }, "*");
+        } catch (err) {
+          e.source.postMessage({ type: "dmsgreply", id: d.id, status: 502, ct: "text/plain", body: btoa("dmsg fetch error") }, "*");
+        }
+      }
+    });
+
+    return { renderSite: renderSite, browseTo: browseTo, currentPK: function () { return currentSitePK; } };
+  }
+
+  // mountPanel builds a floating, toggleable browse/host panel into `doc` (the
+  // standalone-HV overlay surface) and wires it to a browser instance. opts:
+  //   fetchDmsg, serveContent — the skywireVisor primitives; selfPK() — optional.
+  // Returns { panel, browser, toggle }.
+  function mountPanel(doc, opts) {
+    var fetchDmsg = opts.fetchDmsg, serveContent = opts.serveContent;
+    var wrap = doc.createElement("div");
+    wrap.id = "skywire-browse-panel";
+    wrap.style.cssText = "position:fixed;right:12px;bottom:12px;width:520px;max-width:92vw;height:62vh;" +
+      "background:#15171c;color:#cdd2da;font:12px/1.4 monospace;border:1px solid #333;border-radius:8px;" +
+      "box-shadow:0 8px 30px rgba(0,0,0,.5);z-index:2147483000;display:none;flex-direction:column;overflow:hidden";
+    wrap.innerHTML =
+      '<div style="display:flex;gap:.4em;align-items:center;padding:.5em;background:#1d2026;border-bottom:1px solid #333">' +
+      '<b style="color:#7aa2f7">skynet</b>' +
+      '<input id="sb-pk" placeholder="site pk or pk:port" style="flex:1;min-width:0;background:#0e0f12;color:#cdd2da;border:1px solid #333;padding:.25em">' +
+      '<input id="sb-path" value="/" size="6" style="background:#0e0f12;color:#cdd2da;border:1px solid #333;padding:.25em">' +
+      '<button id="sb-go" style="cursor:pointer">go</button>' +
+      '<button id="sb-host-t" title="host a page" style="cursor:pointer">host</button>' +
+      '<button id="sb-x" title="close" style="cursor:pointer">×</button>' +
+      '</div>' +
+      '<div id="sb-host" style="display:none;gap:.3em;padding:.5em;background:#1a1d22;border-bottom:1px solid #333;flex-direction:column">' +
+      '<div style="display:flex;gap:.4em;align-items:center">path <input id="sb-hpath" value="/" size="8" style="background:#0e0f12;color:#cdd2da;border:1px solid #333;padding:.2em">' +
+      'type <input id="sb-hct" value="text/html" size="10" style="background:#0e0f12;color:#cdd2da;border:1px solid #333;padding:.2em">' +
+      '<button id="sb-host-go" style="cursor:pointer">serve over dmsg</button>' +
+      '<span id="sb-host-msg" style="color:#888;flex:1;overflow:hidden;white-space:nowrap;text-overflow:ellipsis"></span></div>' +
+      '<textarea id="sb-hbody" rows="3" placeholder="&lt;h1&gt;hosted from my browser, over dmsg&lt;/h1&gt;" style="background:#0e0f12;color:#cdd2da;border:1px solid #333;font:12px monospace"></textarea>' +
+      '</div>' +
+      '<iframe id="sb-frame" sandbox="allow-scripts allow-forms" style="flex:1;width:100%;border:0;background:#fff"></iframe>';
+    (doc.body || doc.documentElement).appendChild(wrap);
+
+    function $(id) { return wrap.querySelector("#" + id); }
+    var browser = createBrowser({
+      frame: $("sb-frame"), fetchDmsg: fetchDmsg,
+      log: function (m) { try { console.log("[skynet] " + m); } catch (e) {} },
+      setPK: function (pk) { $("sb-pk").value = pk; }, setPath: function (p) { $("sb-path").value = p; }
+    });
+    function go() { browser.browseTo($("sb-pk").value, ($("sb-path").value || "/").trim() || "/"); }
+    $("sb-go").onclick = go;
+    $("sb-pk").addEventListener("keydown", function (e) { if (e.key === "Enter") go(); });
+    $("sb-path").addEventListener("keydown", function (e) { if (e.key === "Enter") go(); });
+    $("sb-x").onclick = function () { wrap.style.display = "none"; };
+    $("sb-host-t").onclick = function () { var h = $("sb-host"); h.style.display = h.style.display === "none" ? "flex" : "none"; };
+    $("sb-host-go").onclick = function () {
+      if (!serveContent) { $("sb-host-msg").textContent = "serveContent unavailable"; return; }
+      var p = ($("sb-hpath").value || "/").trim() || "/";
+      var m = {}; m[p] = { ct: ($("sb-hct").value || "text/html").trim(), body: $("sb-hbody").value };
+      serveContent(m);
+      var pk = ""; try { pk = (opts.selfPK && opts.selfPK()) || ""; } catch (e) {}
+      $("sb-host-msg").textContent = "hosting " + p + (pk ? " — browse pk " + pk : "");
+    };
+
+    function toggle() { wrap.style.display = wrap.style.display === "none" ? "flex" : "none"; }
+    return { panel: wrap, browser: browser, toggle: toggle };
+  }
+
+  globalThis.SkywireBrowse = { createBrowser: createBrowser, mountPanel: mountPanel };
+})();

--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -10,6 +10,15 @@ import _ "embed"
 //go:embed override.js
 var OverrideJS []byte
 
+// BrowseJS is pkg/wasmhv/browse.js — the dmsg virtual-browser engine (the same
+// file the wasm-visor dev harness loads). Injected into a generated standalone
+// file in VISOR mode so the page gets a browse/host overlay (skynet sites
+// rendered + self-hosting over dmsg, via globalThis.skywireVisor). Unused in
+// viewer/standalone-hypervisor modes (no skywireVisor).
+//
+//go:embed browse.js
+var BrowseJS []byte
+
 // WasmExecJS is Go's lib/wasm/wasm_exec.js, vendored here so a generated file is
 // self-contained. It MUST match the Go toolchain that built the embedded/passed
 // dmsg.wasm — refresh it with the wasm build (the Makefile bundle target copies

--- a/pkg/wasmhv/generate.go
+++ b/pkg/wasmhv/generate.go
@@ -144,6 +144,15 @@ func GenerateStandalone(uiFS fs.FS, wasmExecJS, wasm, overrideJS []byte, cfg Sta
 		"<script>" + wasmJS + "</script>\n" +
 		"<script>" + jsSafe(overrideJS) + "</script>\n"
 
+	// VISOR mode only: ship the dmsg virtual-browser overlay (browse.js engine +
+	// a launcher that mounts a toggleable browse/host panel once skywireVisor is
+	// up). This gives the standalone wasm-visor a real surface to browse skynet/
+	// dmsg sites and self-host content over dmsg — no devtools, no extra page.
+	if cfg.Visor {
+		head += "<script>" + jsSafe(BrowseJS) + "</script>\n" +
+			"<script>" + browseLauncherJS + "</script>\n"
+	}
+
 	loc := reHeadOpen.FindStringIndex(html)
 	if loc == nil {
 		return nil, fmt.Errorf("no <head> in index.html")
@@ -250,6 +259,28 @@ func wasmBootstrap(wasm []byte, tinygo bool) (string, error) {
   go.run(res.instance);
 })();`, nil
 }
+
+// browseLauncherJS waits for the wasm-visor + browse.js to be ready, mounts the
+// browse/host overlay panel (SkywireBrowse.mountPanel), and adds a floating
+// "skynet" button to toggle it. Visor-mode only (it uses skywireVisor.fetchDmsg /
+// serveContent, which exist only in the wasm-visor build).
+const browseLauncherJS = `(function(){
+  if(!(window.__SKYWIRE_HV__||{}).visor) return;
+  function ready(){
+    if(!self.skywireVisor||!self.skywireVisor.fetchDmsg||!self.SkywireBrowse||!document.body){ return setTimeout(ready,200); }
+    var p=self.SkywireBrowse.mountPanel(document,{
+      fetchDmsg:function(){ return self.skywireVisor.fetchDmsg.apply(null,arguments); },
+      serveContent:function(m){ return self.skywireVisor.serveContent(m); },
+      selfPK:function(){ try{ return self.skywireVisor.status().pk; }catch(e){ return ""; } }
+    });
+    var btn=document.createElement("button");
+    btn.textContent="skynet"; btn.title="browse / host dmsg sites";
+    btn.style.cssText="position:fixed;left:12px;bottom:12px;z-index:2147483001;cursor:pointer;background:#7aa2f7;color:#0e0f12;border:0;border-radius:6px;padding:.5em .8em;font:bold 12px monospace;box-shadow:0 4px 14px rgba(0,0,0,.4)";
+    btn.onclick=function(){ p.toggle(); };
+    document.body.appendChild(btn);
+  }
+  ready();
+})();`
 
 // assetMapJS inlines the UI's runtime assets (everything under assets/ — i18n
 // JSON, images, fonts) into a JS object the standalone file serves locally:

--- a/pkg/wasmhv/generate_test.go
+++ b/pkg/wasmhv/generate_test.go
@@ -101,6 +101,10 @@ func TestGenerateStandalone_VisorMode(t *testing.T) {
 	// The TinyGo getRandomData shim must be present so the wasm instantiates.
 	require.Contains(t, s, `runtime.getRandomData`)
 	require.Contains(t, s, "DecompressionStream")
+	// Visor mode ships the browse/host overlay: the browse.js engine + the
+	// launcher that mounts the panel.
+	require.Contains(t, s, "globalThis.SkywireBrowse", "browse.js engine must be injected in visor mode")
+	require.Contains(t, s, "SkywireBrowse.mountPanel", "the overlay launcher must be injected in visor mode")
 }
 
 // TestGenerateStandalone_NoShimForGoTarget confirms the non-visor (Go wasm) path


### PR DESCRIPTION
Promotes the dmsg virtual browser from the dev harness to a real, shipped surface in the standalone hypervisor — and de-duplicates the engine so the two can't drift.

## What
- **Shared engine** — the browse engine moves into `pkg/wasmhv/browse.js` (`globalThis.SkywireBrowse`):
  - `createBrowser(opts)` drives one sandboxed iframe: same-site subresource inlining, CSS `url()` rewriting, link-click navigation, and the page's own `fetch` — all routed over dmsg via an injected `fetchDmsg`.
  - `mountPanel(doc, opts)` builds a toggleable browse/host panel (address bar + a host textarea).
  This is the exact logic the harness ran inline, now in one place.
- **Harness uses it** — `cmd/wasm-visor/index.html` loads `browse.js` and wires its controls to `SkywireBrowse.createBrowser` (its ~130 inline engine lines are gone). The `tinygo-wasm-visor` Makefile target copies `browse.js` into `build/wasm-visor`.
- **Standalone HV ships it** — the generator embeds `browse.js` (`embed.go: BrowseJS`) and, in **visor mode only**, injects it plus a launcher that mounts the panel once `skywireVisor` is up and adds a floating **skynet** button to toggle it. A generated wasm-visor HV can now browse skynet/dmsg sites and self-host over dmsg with no devtools and no separate page. Viewer / standalone-hypervisor modes (no `skywireVisor`) are untouched.

## Verified
`go build` + `go test ./pkg/wasmhv` (new assertions: visor-mode output contains the engine + launcher), `node --check` on `browse.js` and the harness inline JS, and the concatenated injected-shim string via `new Function()`.

This is the first of the two UI surfaces ("both for the moment") — the `override.js`-side overlay. The Angular `Skynet` page follows.