### PR TITLE
feat(visor): clearnet HTTP forward-proxy over dmsg (opt-in, whitelist-gated)

### DIFF
--- a/docs/design/dmsg-forward-proxy.md
+++ b/docs/design/dmsg-forward-proxy.md
@@ -1,0 +1,88 @@
+# Clearnet HTTP forward-proxy over dmsg
+
+## Problem
+
+The browser **wasm-visor** can already browse skynet/dmsg sites: it fetches HTTP
+over a dmsg stream (`skywireVisor.fetchDmsg`) and renders the result, routing a
+page's subresources and its own `fetch` over dmsg (see the wasm-visor browse
+overlay). What it cannot do is reach the **clearnet** (ordinary `https://`
+websites):
+
+- It runs under **TinyGo**, which has no `crypto/tls`, so the tab cannot
+  terminate TLS to an origin itself.
+- A browser cannot be pointed at a SOCKS5 proxy from JavaScript, and a sandboxed
+  iframe cannot run a Service Worker, so there is no transparent proxy hook.
+
+## Model
+
+A full visor (normal Go, with TLS) acts as a **forward proxy reached over dmsg**.
+The wasm-visor sends an absolute-URL HTTP request over dmsg; the proxy visor
+fetches it from the clearnet and returns the response. This is the same shape as
+the existing resolving proxy's *upstream fallback*, but the ingress is HTTP over
+dmsg instead of local SOCKS5.
+
+```
+wasm-visor --dmsg(HTTP)--> proxy visor --[upstream SOCKS5]--> skysocks exit --> clearnet
+                                       \--[no upstream set]--> direct ---------> clearnet
+```
+
+TLS terminates at the proxy visor (or the skysocks exit), never in the tab.
+
+### Wire format
+
+The wasm-visor passes the **full URL as the request path** to `fetchDmsg`. The
+dmsg HTTP client (`dmsgclient.httpRoundTrip`) writes the path verbatim as the
+request target, producing the standard *absolute-form* proxy request:
+
+```
+GET http://example.com/page HTTP/1.1
+Host: <proxy-pk-hex>
+Connection: close
+```
+
+Go's `http.Server` parses this with `r.URL.IsAbs()` true (scheme + host set), so
+the handler needs no custom framing — it is an ordinary `http.Handler`.
+
+## Security
+
+A clearnet forward proxy is an open-relay risk, so it is deliberately
+constrained:
+
+1. **Opt-in.** Off unless `dmsg_web.forward_proxy` is `true`. Default visors do
+   not serve it.
+2. **Whitelist-gated.** `pkGatedListener` drops any inbound dmsg stream whose
+   remote public key is not in the visor's authoritative whitelist (own PK +
+   survey whitelist + hypervisors + pty whitelist) — the same set that gates the
+   visor's other privileged dmsg surfaces. An unauthorized peer never reaches the
+   HTTP handler. It is **not** an open relay.
+3. **Egress prefers upstream.** When `upstream_socks` is set, every fetch is
+   dialed through that SOCKS5 proxy (a skysocks exit), so the exit IP is the
+   skysocks node, not the proxy visor. Only when `upstream_socks` is empty does
+   the proxy connect directly — and then its own IP is the exit.
+4. **SSRF guard on direct egress.** When egressing directly, targets that resolve
+   to loopback / private (RFC1918/ULA) / link-local / unspecified addresses are
+   refused (`403`), so a whitelisted-but-curious caller cannot probe the proxy
+   operator's LAN or cloud-metadata endpoint. With an upstream SOCKS5 the upstream
+   is the boundary and the check is skipped.
+5. **No tunneling.** `CONNECT` is refused (`405`); only fetched http(s) requests
+   are served. Redirects are returned to the caller, not followed server-side, so
+   the browsing tab's address bar stays honest.
+
+## Config
+
+Fields on `DmsgWebConfig` (`dmsg_web` in the visor config), reusing the
+resolver's existing `upstream_socks`:
+
+| field            | default | meaning                                              |
+|------------------|---------|------------------------------------------------------|
+| `forward_proxy`  | `false` | serve the clearnet forward-proxy over dmsg           |
+| `forward_port`   | `84`    | dmsg port to listen on                               |
+| `upstream_socks` | `""`    | egress via this SOCKS5 (skysocks exit); empty=direct |
+
+## Status
+
+- [x] Server: gated dmsg-served `http.Handler`, upstream/direct egress, SSRF
+      guard, unit-tested (`pkg/visor/forward_proxy.go`).
+- [ ] Client: wasm-visor resolver that routes a browsed page's external `http(s)`
+      requests to a configured proxy PK over dmsg, and a browse-overlay setting
+      for the proxy PK. (Follow-up.)

--- a/pkg/visor/cxo_user_feeds.go
+++ b/pkg/visor/cxo_user_feeds.go
@@ -64,6 +64,7 @@ func reservedDmsgPorts() map[uint16]string {
 		skyenv.DmsgGRPCPort:                  "grpc",
 		skyenv.DmsgCXOPort:                   "stats", // system CXO feed
 		80:                                   "dmsg-http",
+		DmsgForwardProxyPort:                 "dmsg-forward-proxy",
 		skyenv.DmsgDHTPort:                   "dht",
 		skyenv.DmsgAwaitSetupPort:            "await-setup",
 	}

--- a/pkg/visor/forward_proxy.go
+++ b/pkg/visor/forward_proxy.go
@@ -1,0 +1,260 @@
+package visor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/net/proxy"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// DmsgForwardProxyPort is the default dmsg port the clearnet forward-proxy
+// listens on when DmsgWeb.ForwardPort is unset.
+const DmsgForwardProxyPort uint16 = 84
+
+// forwardProxyTimeout bounds a single clearnet fetch end-to-end.
+const forwardProxyTimeout = 60 * time.Second
+
+// hopByHopHeaders are stripped from both the forwarded request and the returned
+// response — they describe a single transport hop, not the end-to-end message.
+var hopByHopHeaders = map[string]struct{}{
+	"connection": {}, "keep-alive": {}, "proxy-authenticate": {}, "proxy-authorization": {},
+	"te": {}, "trailer": {}, "transfer-encoding": {}, "upgrade": {},
+}
+
+// initDmsgForwardProxy serves a CLEARNET HTTP forward-proxy over dmsg when
+// DmsgWeb.ForwardProxy is set. A whitelisted peer (e.g. a browser wasm-visor,
+// which can't itself do TLS) sends an absolute-URL HTTP request over dmsg; this
+// visor fetches it from the clearnet and returns the response. Default off, and
+// gated by the same whitelist as the visor's other privileged dmsg surfaces —
+// it is NOT an open relay. Egress prefers UpstreamSOCKS (so the exit IP is the
+// skysocks node, not this visor); only when UpstreamSOCKS is empty does this
+// visor connect directly (its own IP becomes the exit).
+func initDmsgForwardProxy(ctx context.Context, v *Visor, log *logging.Logger) error {
+	if v.conf.DmsgWeb == nil || !v.conf.DmsgWeb.ForwardProxy {
+		return nil
+	}
+	dmsgC := v.dmsgC
+	if dmsgC == nil {
+		return fmt.Errorf("cannot start dmsg forward-proxy: dmsg not configured")
+	}
+	port := v.conf.DmsgWeb.ForwardPort
+	if port == 0 {
+		port = DmsgForwardProxyPort
+	}
+
+	// The same authoritative whitelist initDmsgHTTPLogServer builds for the
+	// visor's privileged surfaces: own PK + survey whitelist + hypervisors + pty.
+	allowed := map[cipher.PubKey]struct{}{v.conf.PK: {}}
+	for _, pk := range v.conf.EffectiveSurveyWhitelist() {
+		allowed[pk] = struct{}{}
+	}
+	for _, pk := range v.conf.Hypervisors {
+		allowed[pk] = struct{}{}
+	}
+	if v.conf.Pty != nil {
+		for _, pk := range v.conf.Pty.Whitelist {
+			allowed[pk] = struct{}{}
+		}
+	}
+
+	client, err := newForwardProxyClient(v.conf.DmsgWeb.UpstreamSOCKS)
+	if err != nil {
+		return fmt.Errorf("dmsg forward-proxy: build egress client: %w", err)
+	}
+	direct := v.conf.DmsgWeb.UpstreamSOCKS == ""
+
+	lis, err := dmsgC.Listen(port)
+	if err != nil {
+		return fmt.Errorf("dmsg forward-proxy: listen dmsg:%d: %w", port, err)
+	}
+	go func() {
+		<-ctx.Done()
+		_ = lis.Close() //nolint:errcheck
+	}()
+
+	srv := &http.Server{
+		ReadHeaderTimeout: 10 * time.Second,
+		Handler:           &forwardProxyHandler{client: client, direct: direct, log: log},
+	}
+	go func() {
+		// pkGatedListener drops non-whitelisted peers before they reach the
+		// HTTP server, so an unauthorized stream never gets to issue a fetch.
+		_ = srv.Serve(&pkGatedListener{Listener: lis, allowed: allowed, log: log}) //nolint:errcheck
+	}()
+
+	mode := "egress via upstream " + v.conf.DmsgWeb.UpstreamSOCKS
+	if direct {
+		mode = "egress DIRECT (this visor's IP is the exit)"
+	}
+	log.WithField("dmsg_port", port).WithField("whitelisted", len(allowed)).
+		Infof("Serving clearnet HTTP forward-proxy over dmsg — %s", mode)
+	return nil
+}
+
+// pkGatedListener wraps a dmsg listener and drops any inbound stream whose
+// remote public key is not in the allowed set, before it is handed to Serve.
+type pkGatedListener struct {
+	net.Listener
+	allowed map[cipher.PubKey]struct{}
+	log     *logging.Logger
+}
+
+func (l *pkGatedListener) Accept() (net.Conn, error) {
+	for {
+		conn, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		if l.allows(conn) {
+			return conn, nil
+		}
+		if l.log != nil {
+			l.log.WithField("remote", conn.RemoteAddr().String()).
+				Warn("dmsg forward-proxy: rejected non-whitelisted peer")
+		}
+		_ = conn.Close() //nolint:errcheck
+	}
+}
+
+func (l *pkGatedListener) allows(conn net.Conn) bool {
+	da, ok := conn.RemoteAddr().(dmsg.Addr)
+	if !ok {
+		return false // not a dmsg stream → cannot authenticate the caller
+	}
+	_, ok = l.allowed[da.PK]
+	return ok
+}
+
+// forwardProxyHandler serves one forward-proxy request: an absolute-URL HTTP
+// request (the standard proxy request form, which FetchOverDmsg produces when
+// the caller passes the full URL as the path) is fetched from the clearnet and
+// the response copied back.
+type forwardProxyHandler struct {
+	client *http.Client
+	direct bool
+	log    *logging.Logger
+}
+
+func (h *forwardProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodConnect {
+		http.Error(w, "CONNECT tunneling not supported", http.StatusMethodNotAllowed)
+		return
+	}
+	if !r.URL.IsAbs() || (r.URL.Scheme != "http" && r.URL.Scheme != "https") {
+		http.Error(w, "forward-proxy expects an absolute http(s) URL", http.StatusBadRequest)
+		return
+	}
+	// On DIRECT egress this visor's IP is the exit, so refuse targets that
+	// resolve to loopback/private/link-local addresses — a whitelisted-but-
+	// curious caller must not be able to probe the proxy operator's LAN or
+	// cloud metadata endpoint. With an upstream SOCKS5 the upstream is the
+	// boundary, so the check is skipped.
+	if h.direct && !hostIsPublic(r.URL.Hostname()) {
+		http.Error(w, "target host is not a public address", http.StatusForbidden)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), forwardProxyTimeout)
+	defer cancel()
+	out, err := http.NewRequestWithContext(ctx, r.Method, r.URL.String(), r.Body)
+	if err != nil {
+		http.Error(w, "bad request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	copyHeaders(out.Header, r.Header)
+	out.Header.Del("Host")
+
+	resp, err := h.client.Do(out)
+	if err != nil {
+		if h.log != nil {
+			h.log.WithError(err).WithField("url", r.URL.String()).Debug("forward-proxy fetch failed")
+		}
+		http.Error(w, "upstream fetch error: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	copyHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body) //nolint:errcheck
+}
+
+// copyHeaders copies non-hop-by-hop headers from src to dst.
+func copyHeaders(dst, src http.Header) {
+	for k, vs := range src {
+		if _, hop := hopByHopHeaders[strings.ToLower(k)]; hop {
+			continue
+		}
+		for _, v := range vs {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// newForwardProxyClient builds the egress http.Client. With a non-empty
+// upstream it dials every connection through that SOCKS5 proxy (the skysocks
+// exit); empty means direct connect.
+func newForwardProxyClient(upstreamSOCKS string) (*http.Client, error) {
+	transport := &http.Transport{
+		Proxy:                 nil,
+		MaxIdleConns:          16,
+		IdleConnTimeout:       30 * time.Second,
+		TLSHandshakeTimeout:   15 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	if upstreamSOCKS != "" {
+		d, err := proxy.SOCKS5("tcp", upstreamSOCKS, nil, proxy.Direct)
+		if err != nil {
+			return nil, err
+		}
+		if cd, ok := d.(proxy.ContextDialer); ok {
+			transport.DialContext = cd.DialContext
+		} else {
+			transport.DialContext = func(_ context.Context, network, addr string) (net.Conn, error) {
+				return d.Dial(network, addr)
+			}
+		}
+	}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   forwardProxyTimeout,
+		// Don't follow redirects server-side: return them so the caller (the
+		// browsing tab) decides, keeping its address bar honest.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}, nil
+}
+
+// hostIsPublic reports whether host (a hostname or IP literal) resolves only to
+// routable public addresses. Loopback, private (RFC1918/ULA), link-local, and
+// unspecified addresses make it return false.
+func hostIsPublic(host string) bool {
+	if host == "" {
+		return false
+	}
+	var ips []net.IP
+	if ip := net.ParseIP(host); ip != nil {
+		ips = []net.IP{ip}
+	} else {
+		resolved, err := net.LookupIP(host)
+		if err != nil || len(resolved) == 0 {
+			return false
+		}
+		ips = resolved
+	}
+	for _, ip := range ips {
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+			ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/visor/forward_proxy_test.go
+++ b/pkg/visor/forward_proxy_test.go
@@ -1,0 +1,112 @@
+package visor
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newProxyHandler builds a forwardProxyHandler with a default (direct) egress
+// client for tests.
+func newProxyHandler(t *testing.T, direct bool) *forwardProxyHandler {
+	t.Helper()
+	client, err := newForwardProxyClient("")
+	require.NoError(t, err)
+	return &forwardProxyHandler{client: client, direct: direct}
+}
+
+// proxyRequest issues a proxy-style request (absolute-URL target) at the handler
+// and returns the recorded response.
+func proxyRequest(h *forwardProxyHandler, method, absURL string, body io.Reader) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, absURL, body) // absolute URL → r.URL.IsAbs()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestForwardProxy_FetchesAndCopies verifies an absolute-URL request is fetched
+// from the (test) origin and its status/body/headers are copied back, while
+// hop-by-hop headers are stripped.
+func TestForwardProxy_FetchesAndCopies(t *testing.T) {
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/page?q=1", r.URL.RequestURI())
+		w.Header().Set("X-Origin", "yes")
+		w.Header().Set("Connection", "keep-alive") // hop-by-hop, must be stripped
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = io.WriteString(w, "hello from origin")
+	}))
+	defer origin.Close()
+
+	// origin is 127.0.0.1 → only reachable with the direct-egress LAN guard off.
+	h := newProxyHandler(t, false)
+	rec := proxyRequest(h, http.MethodGet, origin.URL+"/page?q=1", nil)
+
+	require.Equal(t, http.StatusTeapot, rec.Code)
+	require.Equal(t, "hello from origin", rec.Body.String())
+	require.Equal(t, "yes", rec.Header().Get("X-Origin"))
+	require.Empty(t, rec.Header().Get("Connection"), "hop-by-hop header must be stripped")
+}
+
+// TestForwardProxy_RejectsNonAbsolute confirms a normal (origin-form) path is
+// rejected — the proxy only serves absolute-URL requests.
+func TestForwardProxy_RejectsNonAbsolute(t *testing.T) {
+	h := newProxyHandler(t, false)
+	req := httptest.NewRequest(http.MethodGet, "/just/a/path", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestForwardProxy_RejectsConnect confirms CONNECT tunneling is refused.
+func TestForwardProxy_RejectsConnect(t *testing.T) {
+	h := newProxyHandler(t, false)
+	req := httptest.NewRequest(http.MethodConnect, "https://example.com:443", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// TestForwardProxy_DirectGuardsLAN confirms that with direct egress (no upstream)
+// a target resolving to loopback/private is refused (SSRF guard), but is allowed
+// once an upstream is configured (the upstream becomes the boundary).
+func TestForwardProxy_DirectGuardsLAN(t *testing.T) {
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer origin.Close()
+
+	// direct=true → the loopback origin must be blocked before any fetch.
+	h := newProxyHandler(t, true)
+	rec := proxyRequest(h, http.MethodGet, origin.URL+"/", nil)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Contains(t, strings.ToLower(rec.Body.String()), "not a public address")
+}
+
+// TestHostIsPublic spot-checks the SSRF guard's address classification.
+func TestHostIsPublic(t *testing.T) {
+	require.False(t, hostIsPublic(""))
+	require.False(t, hostIsPublic("127.0.0.1"))
+	require.False(t, hostIsPublic("10.1.2.3"))
+	require.False(t, hostIsPublic("192.168.1.1"))
+	require.False(t, hostIsPublic("169.254.169.254")) // cloud metadata
+	require.False(t, hostIsPublic("::1"))
+	require.True(t, hostIsPublic("1.1.1.1"))
+	require.True(t, hostIsPublic("8.8.8.8"))
+}
+
+// TestNewForwardProxyClient_UpstreamWiring confirms that configuring an upstream
+// SOCKS5 installs a custom DialContext (egress routes through it), while the
+// direct client leaves DialContext nil (default net dialer).
+func TestNewForwardProxyClient_UpstreamWiring(t *testing.T) {
+	direct, err := newForwardProxyClient("")
+	require.NoError(t, err)
+	require.Nil(t, direct.Transport.(*http.Transport).DialContext, "direct egress uses the default dialer")
+
+	upstream, err := newForwardProxyClient("127.0.0.1:1080")
+	require.NoError(t, err)
+	require.NotNil(t, upstream.Transport.(*http.Transport).DialContext, "upstream egress must dial through SOCKS5")
+}

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -112,6 +112,8 @@ var (
 	embRouteSetup vinit.Module
 	// Embedded dmsgweb resolver (localhost SOCKS5 for .dmsg browsing)
 	embDmsgWeb vinit.Module
+	// Clearnet HTTP forward-proxy over dmsg (opt-in, whitelist-gated)
+	embFwdProxy vinit.Module
 	// Embedded skynetweb resolver (localhost SOCKS5 for .skynet browsing)
 	embSkynetWeb vinit.Module
 	// Embedded SMTP→skywire bridge (localhost SMTP listener for *.skynet recipients)
@@ -172,6 +174,7 @@ func registerModules(logger *logging.MasterLogger) {
 	ptyModule = maker("dmsg_pty", initDmsgpty, &dmsgC)
 	embRouteSetup = maker("embedded_route_setup", initEmbeddedRouteSetup, &dmsgC)
 	embDmsgWeb = maker("embedded_dmsgweb", initEmbeddedDmsgWeb, &dmsgC)
+	embFwdProxy = maker("dmsg_forward_proxy", initDmsgForwardProxy, &dmsgC)
 	embSkymailBridge = maker("embedded_skymail_bridge", initEmbeddedSkymailBridge, &dmsgC)
 	// routerListener pre-opens DmsgAwaitSetupPort the moment dmsgC is
 	// ready so peers dialing it during the rt-init window (held up by
@@ -228,7 +231,7 @@ func registerModules(logger *logging.MasterLogger) {
 	// store. See init_group.go.
 	groupingMod = maker("grouping", initGrouping, &dmsgC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &ptyModule,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -276,6 +276,19 @@ type DmsgWebConfig struct {
 	// through one's own proxy is inherently authorized. Set false to render the
 	// self-loopback landing page as an anonymous (unauthenticated) caller.
 	SelfLoopbackAuthenticated *bool `json:"self_loopback_authenticated,omitempty"`
+	// ForwardProxy, when true, makes the visor serve a CLEARNET HTTP forward-
+	// proxy over dmsg on ForwardPort: a whitelisted peer (e.g. a browser
+	// wasm-visor that cannot itself do TLS) sends an absolute-URL HTTP request
+	// over dmsg and this visor fetches it from the clearnet and returns the
+	// response. Default off. Access is restricted to the same whitelist that
+	// gates the visor's other privileged dmsg surfaces (own PK + hypervisors +
+	// survey/pty whitelist) — it is NOT an open relay. Egress prefers
+	// UpstreamSOCKS when set (so the exit IP is the skysocks node, not this
+	// visor); only if UpstreamSOCKS is empty does this visor connect directly
+	// (its own IP becomes the exit). See docs/design/dmsg-forward-proxy.md.
+	ForwardProxy bool `json:"forward_proxy,omitempty"`
+	// ForwardPort is the dmsg port the forward-proxy listens on. Default 84.
+	ForwardPort uint16 `json:"forward_port,omitempty"`
 }
 
 // SkynetWebConfig enables the embedded `.skynet` resolving proxy — the


### PR DESCRIPTION
The server half of "browse clearnet sites from the wasm-visor." A browser wasm-visor has no `crypto/tls` under TinyGo, so it can't terminate HTTPS to an origin itself. Instead it sends an absolute-URL HTTP request **over dmsg** to a full visor, which fetches it from the clearnet and returns the response — the resolving-proxy-with-upstream model, with the ingress being HTTP over dmsg.

## Wire format
No custom framing: the wasm-visor passes the full URL as the `fetchDmsg` path, which `dmsgclient.httpRoundTrip` writes verbatim as the request target — a standard absolute-form proxy request (`GET http://host/p HTTP/1.1`). Go's `http.Server` parses it with `r.URL.IsAbs()`, so the handler is an ordinary `http.Handler` over a `dmsgC.Listen` accept loop.

## Security — it is NOT an open relay
- **Opt-in** — off unless `dmsg_web.forward_proxy` is true. Default visors don't serve it.
- **Whitelist-gated** — `pkGatedListener` drops any inbound dmsg stream whose remote PK isn't in the visor's authoritative whitelist (own PK + survey whitelist + hypervisors + pty) *before* it reaches the handler.
- **Egress prefers upstream** — when `upstream_socks` is set, fetches dial through that SOCKS5 (a skysocks exit), so the exit IP is the skysocks node, not this visor. Direct only when no upstream is configured.
- **SSRF guard** — on direct egress, targets resolving to loopback/private/link-local are refused (`403`) so a curious whitelisted caller can't probe the operator's LAN or cloud-metadata endpoint; skipped when an upstream is the boundary.
- **No tunneling** — `CONNECT` refused (`405`); redirects returned, not followed.

## Config
New `DmsgWebConfig` fields `forward_proxy` (bool) and `forward_port` (uint16, default 84), reusing the resolver's existing `upstream_socks`. Wired as the `dmsg_forward_proxy` init module (no-op when disabled); dmsg port 84 reserved. The whole `DmsgWeb` struct is already mirrored in `config_compat.go`. Design note: `docs/design/dmsg-forward-proxy.md`.

## Tests
fetch+copy with hop-by-hop stripping, non-absolute / CONNECT rejection, the direct-egress LAN guard, address classification, and upstream dial wiring. `go build` + `go vet` + `gofmt` clean.

Follow-up: the wasm-visor client resolver that routes a browsed page's external `http(s)` requests through a configured proxy PK (the **"both, prefer upstream"** egress chosen for the exit model).