### PR TITLE
feat(wasm-visor): standard-Go js/wasm build (unlocks crypto/tls + net/http in the tab)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,13 +231,21 @@ tinygo-dmsg-wasm: ## Build the browser WASM dmsg client with TinyGo (~6.5MB vs ~
 	cp ./cmd/dmsg-wasm/index.html ./build/dmsg-wasm/
 	@echo "built ./build/dmsg-wasm (TinyGo) — serve it: 'go run cmd/dmsg-wasm/serve.go' then open http://localhost:8085/"
 
-tinygo-wasm-visor: ## Build the browser WASM visor edge (dmsg+transport+router+appserver) + dev harness into build/wasm-visor
+tinygo-wasm-visor: ## Build the browser WASM visor edge (dmsg+transport+router+appserver) + dev harness into build/wasm-visor — TinyGo (~2.2MB, NO crypto/tls → no https clearnet)
 	mkdir -p ./build/wasm-visor
 	tinygo build -target wasm -o ./build/wasm-visor/wasm-visor.wasm ./cmd/wasm-visor
-	cp "$$(tinygo env TINYGOROOT)/targets/wasm_exec.js" ./build/wasm-visor/wasm_exec_tinygo.js
+	cp "$$(tinygo env TINYGOROOT)/targets/wasm_exec.js" ./build/wasm-visor/wasm_exec.js
 	cp ./cmd/wasm-visor/index.html ./build/wasm-visor/
 	cp ./pkg/wasmhv/browse.js ./build/wasm-visor/
 	@echo "built ./build/wasm-visor (TinyGo) — serve it: 'go run cmd/dmsg-wasm/serve.go -dir build/wasm-visor' then open http://localhost:8085/"
+
+wasm-visor: ## Build the browser WASM visor edge with STANDARD Go js/wasm into build/wasm-visor-go — larger (~38MB) but full crypto/tls + net/http (https clearnet via skysocks)
+	mkdir -p ./build/wasm-visor-go
+	GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o ./build/wasm-visor-go/wasm-visor.wasm ./cmd/wasm-visor
+	cp "$$(go env GOROOT)/lib/wasm/wasm_exec.js" ./build/wasm-visor-go/wasm_exec.js
+	cp ./cmd/wasm-visor/index.html ./build/wasm-visor-go/
+	cp ./pkg/wasmhv/browse.js ./build/wasm-visor-go/
+	@echo "built ./build/wasm-visor-go (standard Go js/wasm) — serve it: 'go run cmd/dmsg-wasm/serve.go -dir build/wasm-visor-go' then open http://localhost:8085/"
 
 dmsg-wasm-hv: ## Build the browser hypervisor-over-dmsg bundle (Service Worker proxy) into build/dmsg-wasm-hv
 	mkdir -p ./build/dmsg-wasm-hv

--- a/cmd/wasm-visor/index.html
+++ b/cmd/wasm-visor/index.html
@@ -38,7 +38,7 @@
 <pre id="out" style="white-space:pre-wrap;max-height:22vh;overflow:auto"></pre>
 <iframe id="browseframe" sandbox="allow-scripts allow-forms" style="width:100%;height:45vh;background:#fff;border:1px solid #444" title="dmsg site"></iframe>
 
-<script src="wasm_exec_tinygo.js"></script>
+<script src="wasm_exec.js"></script>
 <script src="browse.js"></script>
 <script>
   const out = document.getElementById("out");

--- a/pkg/app/appcommon/log_store_native.go
+++ b/pkg/app/appcommon/log_store_native.go
@@ -1,4 +1,4 @@
-//go:build !tinygo
+//go:build !tinygo && !js
 
 // Package appcommon pkg/app/appcommon/log_store_native.go
 //

--- a/pkg/app/appcommon/log_store_tinygo.go
+++ b/pkg/app/appcommon/log_store_tinygo.go
@@ -1,4 +1,4 @@
-//go:build tinygo
+//go:build tinygo || js
 
 // Package appcommon pkg/app/appcommon/log_store_tinygo.go
 //

--- a/pkg/app/appserver/proc_credential_unix.go
+++ b/pkg/app/appserver/proc_credential_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows && !tinygo
+//go:build !windows && !tinygo && !js
 // +build !windows,!tinygo
 
 // Package appserver pkg/app/appserver/proc_credential_unix.go

--- a/pkg/app/appserver/proc_external_native.go
+++ b/pkg/app/appserver/proc_external_native.go
@@ -1,4 +1,4 @@
-//go:build !tinygo
+//go:build !tinygo && !js
 
 // Package appserver pkg/app/appserver/proc_external_native.go
 //

--- a/pkg/app/appserver/proc_external_tinygo.go
+++ b/pkg/app/appserver/proc_external_tinygo.go
@@ -1,4 +1,4 @@
-//go:build tinygo
+//go:build tinygo || js
 
 // Package appserver pkg/app/appserver/proc_external_tinygo.go
 //

--- a/pkg/app/appserver/proc_ingress_listen_native.go
+++ b/pkg/app/appserver/proc_ingress_listen_native.go
@@ -1,4 +1,4 @@
-//go:build !tinygo
+//go:build !tinygo && !js
 
 // Package appserver pkg/app/appserver/proc_ingress_listen_native.go
 package appserver

--- a/pkg/app/appserver/proc_ingress_listen_tinygo.go
+++ b/pkg/app/appserver/proc_ingress_listen_tinygo.go
@@ -1,4 +1,4 @@
-//go:build tinygo
+//go:build tinygo || js
 
 // Package appserver pkg/app/appserver/proc_ingress_listen_tinygo.go
 package appserver


### PR DESCRIPTION
The TinyGo wasm-visor has **no `crypto/tls`** (verified: `tls.Conn` is undefined under tinygo 0.41), so a browser tab can't terminate TLS — which blocks `https://` clearnet browsing over a skysocks tunnel. Standard Go's js/wasm has full `crypto/tls` + `net/http`; this makes `cmd/wasm-visor` compile under it.

## What blocked it
Only two deps: `bbolt` (no js `MaxAllocSize`) and `golang-ipc` (no js impl) — both already stubbed for TinyGo. The fix lets the `js` target take the same lightweight stub side as `tinygo` for the three appserver/appcommon split pairs that gate them:

```
!tinygo   ->  !tinygo && !js     (native, dep-heavy side: now also skips js)
tinygo    ->  tinygo || js       (stub side: now also covers js)
```

plus `proc_credential_unix.go` gets `&& !js` (its only caller is the now-js-excluded `proc_external_native.go`; `syscall.Credential` doesn't exist on js). Same pattern as the existing `dmsgc/spec/spec_native.go` `//go:build !js`. **Native and TinyGo builds are unaffected** — the added terms only change behavior under `GOOS=js` (both verified building green).

## New build target
`make wasm-visor` builds the standard-Go variant into `build/wasm-visor-go` (~38MB / ~8.5MB gz vs TinyGo's 2.2MB — the size cost of full TLS). TinyGo stays the default for IoT/size via `make tinygo-wasm-visor`. The harness loads a build-agnostic `wasm_exec.js` so either toolchain's loader drops in.

## Why
Prerequisite for the in-tab **skysocks-client** clearnet feature: browse `https://` sites from the serverless tab via a remote skysocks-server over dmsg, no local visor. A future TinyGo with real `crypto/tls` would let the small build do this too — I'll file that upstream-tracking issue.