### PR TITLE
feat(wasmrpc): yamux RPC bridge core — drive a browser wasm-visor with skywire cli

### DIFF
--- a/pkg/wasmrpc/bridge.go
+++ b/pkg/wasmrpc/bridge.go
@@ -1,0 +1,99 @@
+// Package wasmrpc bridges a browser wasm-visor's net/rpc server to local
+// `skywire cli` clients.
+//
+// A wasm-visor runs in a browser tab and cannot open a TCP listener, so the
+// connection is inverted: the tab dials the host over a single WebSocket, both
+// ends wrap that one connection as a yamux session, and the HOST opens a fresh
+// yamux stream per local `skywire cli` connection. The tab accepts each stream
+// into its rpc.Server.ServeConn. So:
+//
+//	skywire --rpc 127.0.0.1:<port> visor info   # drives one specific tab
+//
+// and N tabs => N bridges on N ephemeral ports — driving multiple wasm-visors
+// with the ordinary CLI. The host end is Bridge (this file); the tab end is
+// ServeTab (tab.go), which the wasm-visor calls.
+package wasmrpc
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/hashicorp/yamux"
+)
+
+// Bridge fronts ONE tab: a yamux session over the tab's WebSocket connection,
+// plus a local TCP listener whose every accepted connection is piped to a fresh
+// yamux stream (the tab serves net/rpc over it).
+type Bridge struct {
+	session *yamux.Session
+	lis     net.Listener
+	log     func(string)
+	once    sync.Once
+}
+
+// NewBridge wraps tabConn (the host side of the tab's WebSocket, as a net.Conn)
+// in a yamux SERVER and opens a local TCP listener on 127.0.0.1:<port> (port 0 =
+// an OS-assigned ephemeral port). Accepted cli connections are each piped to a
+// new yamux stream. Close tears it all down.
+func NewBridge(tabConn net.Conn, port int, log func(string)) (*Bridge, error) {
+	sess, err := yamux.Server(tabConn, yamux.DefaultConfig())
+	if err != nil {
+		return nil, fmt.Errorf("wasmrpc: yamux server: %w", err)
+	}
+	lis, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		_ = sess.Close() //nolint:errcheck
+		return nil, fmt.Errorf("wasmrpc: rpc listen: %w", err)
+	}
+	b := &Bridge{session: sess, lis: lis, log: log}
+	go b.acceptLoop()
+	return b, nil
+}
+
+// Addr is the local address `skywire cli --rpc` should target for this tab.
+func (b *Bridge) Addr() string { return b.lis.Addr().String() }
+
+func (b *Bridge) logf(format string, args ...interface{}) {
+	if b.log != nil {
+		b.log(fmt.Sprintf(format, args...))
+	}
+}
+
+func (b *Bridge) acceptLoop() {
+	for {
+		cliConn, err := b.lis.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		go b.pipe(cliConn)
+	}
+}
+
+// pipe shuttles one cli connection to a new yamux stream and back. A yamux
+// stream is a clean per-RPC-connection channel to the tab, so the tab's
+// rpc.Server.ServeConn sees exactly one client per stream.
+func (b *Bridge) pipe(cliConn net.Conn) {
+	defer cliConn.Close() //nolint:errcheck
+	stream, err := b.session.Open()
+	if err != nil {
+		b.logf("open stream: %v", err)
+		return
+	}
+	defer stream.Close() //nolint:errcheck
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(stream, cliConn); done <- struct{}{} }() //nolint:errcheck
+	go func() { _, _ = io.Copy(cliConn, stream); done <- struct{}{} }() //nolint:errcheck
+	<-done                                                              // one side closed → tear down the other via the defers
+}
+
+// Close shuts the listener and the yamux session (idempotent).
+func (b *Bridge) Close() error {
+	var err error
+	b.once.Do(func() {
+		err = b.lis.Close()
+		_ = b.session.Close() //nolint:errcheck
+	})
+	return err
+}

--- a/pkg/wasmrpc/bridge_test.go
+++ b/pkg/wasmrpc/bridge_test.go
@@ -1,0 +1,86 @@
+package wasmrpc
+
+import (
+	"io"
+	"net"
+	"net/rpc"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockVisor is a stand-in for the wasm-visor's RPC gateway.
+type mockVisor struct{}
+
+func (mockVisor) Info(arg string, reply *string) error {
+	*reply = "wasm-visor: " + arg
+	return nil
+}
+
+// startMockTab runs the tab end over tabConn: a net/rpc server with mockVisor,
+// served per yamux stream. Returns when the session ends.
+func startMockTab(t *testing.T, tabConn net.Conn) {
+	t.Helper()
+	srv := rpc.NewServer()
+	require.NoError(t, srv.RegisterName("app-visor", mockVisor{}))
+	go func() {
+		_ = ServeTab(tabConn, func(stream io.ReadWriteCloser) { srv.ServeConn(stream) }) //nolint:errcheck
+	}()
+}
+
+// TestBridge_EndToEnd proves the whole host bridge: a real rpc.Client dialing the
+// bridge's local TCP addr reaches the mock tab's RPC over the yamux-muxed link —
+// exactly the path `skywire cli --rpc <addr>` takes, with no browser involved.
+func TestBridge_EndToEnd(t *testing.T) {
+	hostConn, tabConn := net.Pipe() // stands in for the tab's WebSocket
+	startMockTab(t, tabConn)
+
+	b, err := NewBridge(hostConn, 0, nil) // 0 = ephemeral local port
+	require.NoError(t, err)
+	defer b.Close() //nolint:errcheck
+
+	require.Contains(t, b.Addr(), "127.0.0.1:")
+
+	cli, err := rpc.Dial("tcp", b.Addr())
+	require.NoError(t, err)
+	defer cli.Close() //nolint:errcheck
+
+	var reply string
+	require.NoError(t, cli.Call("app-visor.Info", "hello", &reply))
+	require.Equal(t, "wasm-visor: hello", reply)
+}
+
+// TestBridge_MultipleClients confirms several concurrent cli connections each get
+// their own yamux stream to the same tab (the basis for many CLI calls / tabs).
+func TestBridge_MultipleClients(t *testing.T) {
+	hostConn, tabConn := net.Pipe()
+	startMockTab(t, tabConn)
+	b, err := NewBridge(hostConn, 0, nil)
+	require.NoError(t, err)
+	defer b.Close() //nolint:errcheck
+
+	for i := 0; i < 5; i++ {
+		cli, err := rpc.Dial("tcp", b.Addr())
+		require.NoError(t, err)
+		var reply string
+		require.NoError(t, cli.Call("app-visor.Info", "n", &reply))
+		require.Equal(t, "wasm-visor: n", reply)
+		_ = cli.Close() //nolint:errcheck
+	}
+}
+
+// TestBridge_CloseStopsListener confirms Close releases the local port.
+func TestBridge_CloseStopsListener(t *testing.T) {
+	hostConn, tabConn := net.Pipe()
+	startMockTab(t, tabConn)
+	b, err := NewBridge(hostConn, 0, nil)
+	require.NoError(t, err)
+	addr := b.Addr()
+	require.NoError(t, b.Close())
+
+	// A dial after Close must fail (listener gone). Give the OS a moment.
+	time.Sleep(20 * time.Millisecond)
+	_, err = net.DialTimeout("tcp", addr, 100*time.Millisecond)
+	require.Error(t, err)
+}

--- a/pkg/wasmrpc/tab.go
+++ b/pkg/wasmrpc/tab.go
@@ -1,0 +1,31 @@
+package wasmrpc
+
+import (
+	"io"
+	"net"
+
+	"github.com/hashicorp/yamux"
+)
+
+// ServeTab runs the TAB end of the bridge: it wraps tabConn (the tab's WebSocket
+// to the host) in a yamux CLIENT, accepts the streams the host opens (one per
+// `skywire cli` connection), and hands each to serve — typically a closure that
+// calls rpc.Server.ServeConn(stream). It blocks until the session ends (the WS
+// drops or Close is called on the underlying conn), then returns the error.
+//
+// Pure Go (yamux + net), so it compiles for js/wasm as well as native — the
+// wasm-visor calls it with a net.Conn wrapping a browser WebSocket.
+func ServeTab(tabConn net.Conn, serve func(stream io.ReadWriteCloser)) error {
+	sess, err := yamux.Client(tabConn, yamux.DefaultConfig())
+	if err != nil {
+		return err
+	}
+	defer sess.Close() //nolint:errcheck
+	for {
+		stream, err := sess.Accept()
+		if err != nil {
+			return err
+		}
+		go serve(stream)
+	}
+}


### PR DESCRIPTION
First piece of exposing a wasm-visor's `net/rpc` to local `skywire cli` clients, so the ordinary CLI can drive a browser tab (and tests can use real commands instead of a bespoke harness).

## Approach
A browser tab can't open a TCP listener, so the connection is **inverted**: the tab dials the host over one WebSocket, both ends wrap it as a **yamux** session, and the **host** opens a fresh yamux stream per `skywire cli` connection — the tab accepts each into its `rpc.Server.ServeConn`.

```
skywire --rpc 127.0.0.1:<port> visor info    # drives one specific tab
```

N tabs => N bridges on N ephemeral ports → control multiple wasm-visors with the normal CLI.

- **`Bridge`** (host): wraps the tab conn in `yamux.Server`, opens `127.0.0.1:<port|0>`, pipes each accepted cli conn to a new yamux stream; `Close` tears it down.
- **`ServeTab`** (tab): wraps the tab conn in `yamux.Client`, accepts streams, hands each to a `serve` callback (`rpc.Server.ServeConn`). Pure Go → compiles for `js/wasm` too.

## Tested (no browser)
A real `rpc.Client` dialing the bridge's local addr reaches a mock tab's `net/rpc` gateway over the muxed link — single client, 5 concurrent clients, and `Close` releasing the port. Builds native **and** `GOOS=js`; lint clean.

## Next
- `cmd/dmsg-wasm/serve.go` opens a `Bridge` per connected tab (prints the addr alongside `/ctl/tabs`).
- The wasm-visor opens the WS + calls `ServeTab` with a gateway adapting the CLI-relevant `app-visor.*` methods to its `tpM`/`router`/`dmsgC` (reusing the gob-name-match trick from `hvCore` for the reply types).

Builds toward the skysocks-client-over-skynet clearnet browsing feature; the bridge makes that testable end-to-end with `skywire cli transport add/ls`.