### PR TITLE
feat(wasm-visor): RPC gateway + bridge wiring — skywire cli drives a tab

### DIFF
--- a/cmd/dmsg-wasm/serve.go
+++ b/cmd/dmsg-wasm/serve.go
@@ -23,6 +23,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -32,13 +33,18 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/skycoin/skywire/pkg/wasmrpc"
 )
 
 type tab struct {
-	id     string
-	events chan string // SSE command frames queued for this tab
-	mu     sync.Mutex
-	logs   []string
+	id      string
+	events  chan string // SSE command frames queued for this tab
+	mu      sync.Mutex
+	logs    []string
+	rpcAddr string // local 127.0.0.1:<port> the wasmrpc bridge fronts (when connected)
 }
 
 type command struct {
@@ -198,15 +204,53 @@ func main() {
 		w.WriteHeader(204)
 	})
 
-	// List connected tabs.
+	// List connected tabs, each with its RPC bridge address (if connected) so a
+	// shell can do: skywire --rpc <rpc> visor info
 	mux.HandleFunc("/ctl/tabs", func(w http.ResponseWriter, r *http.Request) {
+		type tabInfo struct {
+			ID  string `json:"id"`
+			RPC string `json:"rpc,omitempty"`
+		}
 		mu.Lock()
-		ids := make([]string, 0, len(tabs))
-		for id := range tabs {
-			ids = append(ids, id)
+		out := make([]tabInfo, 0, len(tabs))
+		for id, t := range tabs {
+			t.mu.Lock()
+			out = append(out, tabInfo{ID: id, RPC: t.rpcAddr})
+			t.mu.Unlock()
 		}
 		mu.Unlock()
-		_ = json.NewEncoder(w).Encode(ids)
+		_ = json.NewEncoder(w).Encode(out)
+	})
+
+	// RPC bridge: a wasm-visor tab dials this WebSocket and serves its visor RPC
+	// over it; we front it with a local 127.0.0.1:<port> that `skywire cli --rpc`
+	// targets. One bridge per tab; closed when the tab disconnects. See
+	// pkg/wasmrpc.
+	mux.HandleFunc("/ctl/rpc", func(w http.ResponseWriter, r *http.Request) {
+		t := getTab(r.URL.Query().Get("tab"))
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			log.Printf("rpc bridge accept (%s): %v", t.id, err)
+			return
+		}
+		c.SetReadLimit(-1)
+		conn := websocket.NetConn(context.Background(), c, websocket.MessageBinary)
+		bridge, err := wasmrpc.NewBridge(conn, 0, func(m string) { log.Printf("[rpc %s] %s", t.id, m) })
+		if err != nil {
+			log.Printf("rpc bridge (%s): %v", t.id, err)
+			_ = c.Close(websocket.StatusInternalError, "bridge setup failed")
+			return
+		}
+		t.mu.Lock()
+		t.rpcAddr = bridge.Addr()
+		t.mu.Unlock()
+		log.Printf("tab %s RPC bridge UP at %s — drive it: skywire --rpc %s visor info", t.id, bridge.Addr(), bridge.Addr())
+		<-r.Context().Done()
+		_ = bridge.Close()
+		t.mu.Lock()
+		t.rpcAddr = ""
+		t.mu.Unlock()
+		log.Printf("tab %s RPC bridge closed", t.id)
 	})
 
 	// Operator drives a tab: queue a command, wait for its result.

--- a/cmd/wasm-visor/index.html
+++ b/cmd/wasm-visor/index.html
@@ -67,9 +67,22 @@
         document.getElementById("seedws").value.trim(),
         document.getElementById("disc").value.trim());
       log("booted pk=" + pk);
+      startRPC();
     } catch (e) { log("boot error: " + (e.message || e)); }
   }
   function doStatus() { log("status: " + JSON.stringify(skywireVisor.status())); }
+
+  // startRPC dials the host RPC bridge (cmd/dmsg-wasm/serve.go's /ctl/rpc) so the
+  // ordinary `skywire cli --rpc <addr>` can drive this tab. The host logs the addr
+  // (also shown in /ctl/tabs). Best-effort — fine if the page is opened directly.
+  function startRPC() {
+    if (!skywireVisor.serveRPC) return;
+    const tabId = sessionStorage.getItem("ctlTabId") || "tab";
+    const url = (location.protocol === "https:" ? "wss://" : "ws://") + location.host + "/ctl/rpc?tab=" + tabId;
+    skywireVisor.serveRPC(url)
+      .then(() => log("rpc bridge serving — see serve.go log / curl /ctl/tabs for the skywire --rpc addr"))
+      .catch(e => log("rpc bridge error: " + (e.message || e)));
+  }
 
   // The dmsg virtual-browser engine lives in browse.js (shared verbatim with the
   // standalone hypervisor overlay). Wire an instance to this harness's browse
@@ -111,8 +124,11 @@
     async function exec(c) {
       const a = c.args || [];
       switch (c.action) {
-        case "boot":
-          return await skywireVisor.boot(a[0] || "", a[1] || "", a[2] || "", a[3] || "");
+        case "boot": {
+          const pk = await skywireVisor.boot(a[0] || "", a[1] || "", a[2] || "", a[3] || "");
+          startRPC(); // expose this tab's visor RPC to `skywire cli` over the bridge
+          return pk;
+        }
         case "hvApi": {
           const r = await skywireVisor.hvApi(a[0] || "GET", a[1] || "/api/visors", a[2] || null);
           return { status: r.status, body: new TextDecoder().decode(r.body) };

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -108,6 +108,7 @@ func main() {
 		"dialTransport": js.FuncOf(jsDialTransport),
 		"fetchDmsg":     js.FuncOf(jsFetchDmsg),
 		"serveContent":  js.FuncOf(jsServeContent),
+		"serveRPC":      js.FuncOf(jsServeRPC),
 	}))
 	fmt.Println("wasm-visor: ready — call skywireVisor.boot(sk, seedPk, seedWs, discDmsgAddr)")
 	select {} // block forever

--- a/cmd/wasm-visor/rpcbridge_js.go
+++ b/cmd/wasm-visor/rpcbridge_js.go
@@ -1,0 +1,56 @@
+//go:build js && wasm
+
+// Package main — RPC bridge client: serve this tab's visor RPC to `skywire cli`.
+//
+// A browser tab can't open a TCP listener, so it dials the host bridge over a
+// WebSocket; the host (cmd/dmsg-wasm/serve.go) fronts it with a local
+// 127.0.0.1:<port> that `skywire --rpc <port> visor …` targets. See pkg/wasmrpc.
+package main
+
+import (
+	"context"
+	"io"
+	"syscall/js"
+
+	"github.com/coder/websocket"
+
+	"github.com/skycoin/skywire/pkg/wasmhv"
+	"github.com/skycoin/skywire/pkg/wasmrpc"
+)
+
+// jsServeRPC(wsURL) opens a WebSocket to the host RPC bridge and serves this
+// tab's visor RPC (the app-visor.* gateway) over it, so the ordinary skywire CLI
+// can drive this specific tab. Idempotent-ish: each call opens a fresh session.
+func jsServeRPC(_ js.Value, args []js.Value) interface{} {
+	if len(args) < 1 || args[0].String() == "" {
+		return js.Global().Get("Error").New("serveRPC: a ws:// bridge url is required")
+	}
+	wsURL := args[0].String()
+	return promise(func() (interface{}, error) {
+		c, _, err := websocket.Dial(ctx, wsURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		// No read limit: RPC frames (summaries, transport lists) can exceed the
+		// 32KiB default.
+		c.SetReadLimit(-1)
+		conn := websocket.NetConn(context.Background(), c, websocket.MessageBinary)
+		srv, err := wasmhv.NewRPCServer(visorSelf{})
+		if err != nil {
+			return nil, err
+		}
+		go func() {
+			err := wasmrpc.ServeTab(conn, func(s io.ReadWriteCloser) { srv.ServeConn(s) })
+			vlog("rpc bridge: session ended: " + errStr(err))
+		}()
+		vlog("rpc bridge: serving visor RPC over " + wsURL)
+		return "ok", nil
+	})
+}
+
+func errStr(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	return err.Error()
+}

--- a/pkg/wasmhv/rpc_gateway.go
+++ b/pkg/wasmhv/rpc_gateway.go
@@ -1,0 +1,72 @@
+package wasmhv
+
+import (
+	"errors"
+	"net/rpc"
+)
+
+// RPCGateway adapts the wasm-visor's self view to the visor's net/rpc surface
+// (the "app-visor.*" methods `skywire cli` calls). It is registered on an
+// rpc.Server whose connections arrive over the wasmrpc bridge (one yamux stream
+// per cli connection), so the ordinary CLI can drive a browser tab.
+//
+// The reply types are the wasmhv mirrors (Summary/Overview/HealthInfo/…). gob
+// matches fields by name, so the CLI decodes them straight into the real
+// pkg/visor types — the same trick the HV UI core uses (gob_mirror_test.go
+// round-trips both directions, so a field drift fails a test).
+//
+// Only the read-side "info" methods are implemented so far; transport/route
+// control methods are added incrementally. Unknown methods simply aren't
+// registered, so the CLI gets a clear "can't find method" rather than a wrong
+// answer.
+type RPCGateway struct {
+	self SelfProvider
+}
+
+// errNoSelf is returned when the tab has no local visor wired (not booted).
+var errNoSelf = errors.New("wasm-visor: not booted (no self provider)")
+
+// NewRPCServer builds an rpc.Server exposing the gateway under the "app-visor"
+// name (the prefix the CLI uses). Feed its connections via ServeConn — e.g. from
+// wasmrpc.ServeTab(conn, srv.ServeConn).
+func NewRPCServer(self SelfProvider) (*rpc.Server, error) {
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("app-visor", &RPCGateway{self: self}); err != nil {
+		return nil, err
+	}
+	return srv, nil
+}
+
+// IsStartupComplete reports whether the tab's visor is up.
+func (g *RPCGateway) IsStartupComplete(_ *struct{}, out *bool) error {
+	*out = g.self != nil
+	return nil
+}
+
+// Health reports the tab visor as healthy whenever it's booted (the browser tab
+// being alive is, by definition, the service being up).
+func (g *RPCGateway) Health(_ *struct{}, out *HealthInfo) error {
+	if g.self == nil {
+		return errNoSelf
+	}
+	*out = HealthInfo{ServicesHealth: "healthy"}
+	return nil
+}
+
+// Summary returns the tab visor's summary (PK, transports, …).
+func (g *RPCGateway) Summary(_ *struct{}, out *Summary) error {
+	if g.self == nil {
+		return errNoSelf
+	}
+	*out = g.self.SelfSummary()
+	return nil
+}
+
+// Overview returns the tab visor's overview (the dashboard's top-level view).
+func (g *RPCGateway) Overview(_ *struct{}, out *Overview) error {
+	if g.self == nil {
+		return errNoSelf
+	}
+	*out = g.self.SelfOverview()
+	return nil
+}

--- a/pkg/wasmhv/rpc_gateway_test.go
+++ b/pkg/wasmhv/rpc_gateway_test.go
@@ -1,0 +1,76 @@
+package wasmhv
+
+import (
+	"io"
+	"net"
+	"net/rpc"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/wasmrpc"
+)
+
+// (fakeSelf is defined in self_test.go.)
+
+// TestRPCGateway_OverBridge drives the gateway exactly as `skywire cli` would: a
+// real rpc.Client → wasmrpc.Bridge → yamux → ServeTab → the gateway's rpc.Server.
+// No browser; the only thing stubbed is the SelfProvider.
+func TestRPCGateway_OverBridge(t *testing.T) {
+	var pk cipher.PubKey
+	require.NoError(t, pk.Set("0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13"))
+
+	srv, err := NewRPCServer(fakeSelf{pk: pk})
+	require.NoError(t, err)
+
+	hostConn, tabConn := net.Pipe()
+	go func() {
+		_ = wasmrpc.ServeTab(tabConn, func(s io.ReadWriteCloser) { srv.ServeConn(s) }) //nolint:errcheck
+	}()
+	b, err := wasmrpc.NewBridge(hostConn, 0, nil)
+	require.NoError(t, err)
+	defer b.Close() //nolint:errcheck
+
+	cli, err := rpc.Dial("tcp", b.Addr())
+	require.NoError(t, err)
+	defer cli.Close() //nolint:errcheck
+
+	var complete bool
+	require.NoError(t, cli.Call("app-visor.IsStartupComplete", &struct{}{}, &complete))
+	require.True(t, complete)
+
+	var health HealthInfo
+	require.NoError(t, cli.Call("app-visor.Health", &struct{}{}, &health))
+	require.Equal(t, "healthy", health.ServicesHealth)
+
+	var overview Overview
+	require.NoError(t, cli.Call("app-visor.Overview", &struct{}{}, &overview))
+	require.Equal(t, pk, overview.PubKey)
+}
+
+// TestRPCGateway_NotBooted confirms the gateway errors cleanly when no visor is
+// wired (rather than panicking or returning a zero value as if booted).
+func TestRPCGateway_NotBooted(t *testing.T) {
+	srv, err := NewRPCServer(nil)
+	require.NoError(t, err)
+	hostConn, tabConn := net.Pipe()
+	go func() {
+		_ = wasmrpc.ServeTab(tabConn, func(s io.ReadWriteCloser) { srv.ServeConn(s) }) //nolint:errcheck
+	}()
+	b, err := wasmrpc.NewBridge(hostConn, 0, nil)
+	require.NoError(t, err)
+	defer b.Close() //nolint:errcheck
+
+	cli, err := rpc.Dial("tcp", b.Addr())
+	require.NoError(t, err)
+	defer cli.Close() //nolint:errcheck
+
+	var complete bool
+	require.NoError(t, cli.Call("app-visor.IsStartupComplete", &struct{}{}, &complete))
+	require.False(t, complete, "not booted → startup not complete")
+
+	var s Summary
+	err = cli.Call("app-visor.Summary", &struct{}{}, &s)
+	require.Error(t, err, "Summary on an unbooted tab must error")
+}


### PR DESCRIPTION
Builds on the wasmrpc bridge core (#3260): a real wasm-visor tab now serves its visor RPC to the ordinary `skywire cli` end-to-end.

- **`pkg/wasmhv` `RPCGateway`** — the `app-visor.*` methods the CLI calls (`Summary`, `Overview`, `Health`, `IsStartupComplete`), backed by the tab's `SelfProvider`. Reply types are the wasmhv gob mirrors, so the CLI decodes them straight into the real `pkg/visor` types (the same field-name-match trick as the HV UI core). `NewRPCServer` registers it under `"app-visor"`. **Full-stack tested through the bridge with a mock `SelfProvider`** (no browser): `rpc.Client → Bridge → yamux → ServeTab → gateway`.
- **`cmd/wasm-visor`** — `skywireVisor.serveRPC(wsURL)` dials the host bridge WebSocket (coder/websocket, native js support), wraps it as a `net.Conn`, and serves the gateway via `wasmrpc.ServeTab`. The harness calls it after boot (manual + headless paths).
- **`cmd/dmsg-wasm/serve.go`** — `/ctl/rpc` WebSocket endpoint fronts each tab with a local `127.0.0.1:<port>` `wasmrpc.Bridge`, logs `skywire --rpc <addr> visor info`, and surfaces the addr in `/ctl/tabs`. One bridge per tab, closed on disconnect.

## Try it
`make wasm-visor` → `go run cmd/dmsg-wasm/serve.go -dir build/wasm-visor-go`, open a tab, boot, then `skywire --rpc <addr-from-serve.go-log> visor info` reaches that specific browser visor. N tabs = N addrs.

Read-side methods first; transport/route control (`transport add/ls`) next — the point being to drive the skynet-transport work against a live tab with the real CLI.