### PR TITLE
fix(wasm-visor): populate Summary.DmsgStats so skywire cli visor info works

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -467,8 +467,11 @@ func (visorSelf) SelfOverview() wasmhv.Overview {
 func (s visorSelf) SelfSummary() wasmhv.Summary {
 	ov := s.SelfOverview()
 	return wasmhv.Summary{
-		Overview:     &ov,
-		Health:       &wasmhv.HealthInfo{ServicesHealth: "healthy"},
+		Overview: &ov,
+		Health:   &wasmhv.HealthInfo{ServicesHealth: "healthy"},
+		// Non-nil: the CLI's `visor info` dereferences DmsgStats.RoundTrip
+		// unconditionally. The tab has no dmsg-tracker, so RoundTrip stays 0.
+		DmsgStats:    &wasmhv.DmsgClientSummary{PK: selfPK},
 		Online:       true,
 		IsHypervisor: true,
 	}

--- a/pkg/wasmhv/core.go
+++ b/pkg/wasmhv/core.go
@@ -79,19 +79,29 @@ func (o Overview) MarshalJSON() ([]byte, error) {
 	}{alias(o), []struct{}{}, []struct{}{}})
 }
 
+// DmsgClientSummary mirrors visor/dmsgtracker.DmsgClientSummary. The CLI's
+// `visor info` dereferences summary.DmsgStats.RoundTrip unconditionally, so this
+// must decode to a non-nil pointer (gob matches by field name).
+type DmsgClientSummary struct {
+	PK        cipher.PubKey `json:"public_key"`
+	ServerPK  cipher.PubKey `json:"server_public_key"`
+	RoundTrip time.Duration `json:"round_trip"`
+}
+
 // Summary mirrors the scalar fields of visor.Summary the node table reads.
 type Summary struct {
-	Overview          *Overview   `json:"overview"`
-	Health            *HealthInfo `json:"health"`
-	Uptime            float64     `json:"uptime"`
-	Online            bool        `json:"online"`
-	MinHops           uint16      `json:"min_hops"`
-	RewardAddress     string      `json:"reward_address"`
-	BuildTag          string      `json:"build_tag"`
-	ConfigVersion     string      `json:"config_version"`
-	PublicAutoconnect bool        `json:"public_autoconnect"`
-	IsPublic          bool        `json:"is_public"`
-	IsHypervisor      bool        `json:"is_hypervisor,omitempty"`
+	Overview          *Overview          `json:"overview"`
+	Health            *HealthInfo        `json:"health"`
+	DmsgStats         *DmsgClientSummary `json:"dmsg_stats"`
+	Uptime            float64            `json:"uptime"`
+	Online            bool               `json:"online"`
+	MinHops           uint16             `json:"min_hops"`
+	RewardAddress     string             `json:"reward_address"`
+	BuildTag          string             `json:"build_tag"`
+	ConfigVersion     string             `json:"config_version"`
+	PublicAutoconnect bool               `json:"public_autoconnect"`
+	IsPublic          bool               `json:"is_public"`
+	IsHypervisor      bool               `json:"is_hypervisor,omitempty"`
 }
 
 // --- the core ---


### PR DESCRIPTION
Proven live: `skywire --rpc <tab> visor pk/ready` drive a browser wasm-visor over the RPC bridge (#3260/#3261). `visor info` panicked because the CLI formatter dereferences `summary.DmsgStats.RoundTrip` unconditionally (the real visor always sets it) and the wasm Summary left it nil.

Adds a `DmsgClientSummary` mirror (PK/ServerPK/RoundTrip, gob-name-matched to `dmsgtracker.DmsgClientSummary`) + a `Summary.DmsgStats` field, populated non-nil in `visorSelf.SelfSummary` (the tab has no dmsg-tracker, so RoundTrip stays 0). `Overview.BuildInfo` and `Health` were already non-nil.