### PR TITLE
feat(wasm-visor): transport-control RPC — skywire cli tp ls/add/rm drive a tab

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -50,8 +50,10 @@ import (
 	"syscall/js"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appdisc"
+
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/buildinfo"
@@ -475,6 +477,46 @@ func (s visorSelf) SelfSummary() wasmhv.Summary {
 		Online:       true,
 		IsHypervisor: true,
 	}
+}
+
+// tpController is the wasmhv.TransportController backing the RPC gateway's
+// transport-control methods (the CLI's `tp add`/`tp rm`), over this tab's
+// transport.Manager. webrtc/dmsg dial by PK alone; ws/wt need an endpoint and
+// must go through skywireVisor.dialTransport (which carries the url/cert).
+type tpController struct{}
+
+func (tpController) AddTransport(remote cipher.PubKey, tpType string, _ time.Duration) (*wasmhv.TransportSummary, error) {
+	if tpM == nil {
+		return nil, errors.New("not booted; call boot() first")
+	}
+	t := types.Type(tpType)
+	switch t {
+	case types.WEBRTC, types.DMSG:
+		// no endpoint needed (webrtc signals over dmsg; dmsg dials by PK)
+	case types.WS, types.WT:
+		return nil, fmt.Errorf("%s needs a peer endpoint over the CLI path; use skywireVisor.dialTransport(pk, %q, url[, certHash])", tpType, tpType)
+	default:
+		return nil, fmt.Errorf("unsupported transport type %q (cli: webrtc or dmsg)", tpType)
+	}
+	tp, err := tpM.SaveTransport(ctx, remote, t, transport.LabelUser)
+	if err != nil {
+		return nil, fmt.Errorf("save transport: %w", err)
+	}
+	return &wasmhv.TransportSummary{
+		ID:     tp.Entry.ID,
+		Local:  selfPK,
+		Remote: remote,
+		Type:   tpType,
+		Label:  string(transport.LabelUser),
+	}, nil
+}
+
+func (tpController) RemoveTransport(id uuid.UUID) error {
+	if tpM == nil {
+		return errors.New("not booted; call boot() first")
+	}
+	tpM.DeleteTransport(id)
+	return nil
 }
 
 func (visorSelf) SelfTransports() []*wasmhv.TransportSummary {

--- a/cmd/wasm-visor/rpcbridge_js.go
+++ b/cmd/wasm-visor/rpcbridge_js.go
@@ -35,7 +35,7 @@ func jsServeRPC(_ js.Value, args []js.Value) interface{} {
 		// 32KiB default.
 		c.SetReadLimit(-1)
 		conn := websocket.NetConn(context.Background(), c, websocket.MessageBinary)
-		srv, err := wasmhv.NewRPCServer(visorSelf{})
+		srv, err := wasmhv.NewRPCServer(visorSelf{}, tpController{})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/wasmhv/control.go
+++ b/pkg/wasmhv/control.go
@@ -64,6 +64,23 @@ type TransportLogEntry struct {
 	SentBytes uint64
 }
 
+// GobEncode mirrors transport.LogEntry.GobEncode: two separately-encoded uint64s.
+// Needed because over the RPC bridge the wasm-visor is the ENCODER; without it
+// gob describes TransportSummary.Log as a plain struct rather than a GobEncoder
+// type, mismatching the CLI's *transport.LogEntry and failing the whole `tp ls`
+// decode ("wrong type for received field .Log").
+func (le *TransportLogEntry) GobEncode() ([]byte, error) {
+	var b bytes.Buffer
+	enc := gob.NewEncoder(&b)
+	if err := enc.Encode(atomic.LoadUint64(&le.RecvBytes)); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(atomic.LoadUint64(&le.SentBytes)); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
 // GobDecode mirrors transport.LogEntry.GobEncode: two separately-encoded uint64s.
 func (le *TransportLogEntry) GobDecode(b []byte) error {
 	dec := gob.NewDecoder(bytes.NewReader(b))

--- a/pkg/wasmhv/gob_mirror_test.go
+++ b/pkg/wasmhv/gob_mirror_test.go
@@ -91,6 +91,44 @@ func TestMirrorTransportSummaryDecodes(t *testing.T) {
 	require.Equal(t, uint64(222), got.Log.SentBytes)
 }
 
+// TestMirrorTransportSummaryEncodes confirms the REVERSE direction the RPC bridge
+// uses: a wasm-visor encodes its TransportSummary reply and the CLI decodes it
+// into visor.TransportSummary. Without TransportLogEntry.GobEncode, gob describes
+// .Log as a plain struct and the decode fails ("wrong type for received field
+// .Log") — which broke `skywire cli tp ls` over the bridge.
+func TestMirrorTransportSummaryEncodes(t *testing.T) {
+	pkL, _ := cipher.GenerateKeyPair()
+	pkR, _ := cipher.GenerateKeyPair()
+	mirror := &TransportSummary{
+		ID:        uuid.New(),
+		Local:     pkL,
+		Remote:    pkR,
+		Type:      "dmsg",
+		Log:       &TransportLogEntry{RecvBytes: 7, SentBytes: 9},
+		Label:     "user",
+		LatencyMS: 12.5,
+	}
+	var got visor.TransportSummary
+	gobRoundTrip(t, mirror, &got)
+	require.Equal(t, mirror.ID, got.ID)
+	require.Equal(t, "dmsg", string(got.Type))
+	require.Equal(t, "user", string(got.Label))
+	require.NotNil(t, got.Log)
+	require.NotNil(t, got.Log.RecvBytes)
+	require.Equal(t, uint64(7), *got.Log.RecvBytes)
+	require.Equal(t, uint64(9), *got.Log.SentBytes)
+}
+
+// TestMirrorTransportListEmptyEncodes reproduces the exact failure that bit
+// `tp ls`: an EMPTY []*TransportSummary reply must still decode into the CLI's
+// []*visor.TransportSummary (gob transmits the element type description, which
+// must match) — it panicked before TransportLogEntry.GobEncode existed.
+func TestMirrorTransportListEmptyEncodes(t *testing.T) {
+	var got []*visor.TransportSummary
+	gobRoundTrip(t, []*TransportSummary{}, &got)
+	require.Empty(t, got)
+}
+
 // TestMirrorArgsEncode confirms the mirror RPC ARGUMENT types gob-encode into
 // the real visor.* argument types (the direction a control call travels).
 func TestMirrorArgsEncode(t *testing.T) {

--- a/pkg/wasmhv/rpc_gateway.go
+++ b/pkg/wasmhv/rpc_gateway.go
@@ -3,7 +3,38 @@ package wasmhv
 import (
 	"errors"
 	"net/rpc"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
 )
+
+// TransportController is the control surface the gateway needs beyond the
+// read-only SelfProvider: creating and removing the tab's own transports. The
+// wasm-visor implements it over its transport.Manager. May be nil (then the
+// transport-control methods return an error rather than panic).
+type TransportController interface {
+	AddTransport(remote cipher.PubKey, tpType string, timeout time.Duration) (*TransportSummary, error)
+	RemoveTransport(id uuid.UUID) error
+}
+
+// TransportsIn mirrors visor.TransportsIn (the Transports RPC arg).
+type TransportsIn struct {
+	FilterTypes   []string
+	FilterPubKeys []cipher.PubKey
+	ShowLogs      bool
+}
+
+// AddTransportIn mirrors visor.AddTransportIn (the AddTransport RPC arg).
+type AddTransportIn struct {
+	RemotePK         cipher.PubKey
+	TpType           string
+	Timeout          time.Duration
+	Label            string
+	NoRegister       bool
+	SkipLatencyProbe bool
+}
 
 // RPCGateway adapts the wasm-visor's self view to the visor's net/rpc surface
 // (the "app-visor.*" methods `skywire cli` calls). It is registered on an
@@ -21,20 +52,101 @@ import (
 // answer.
 type RPCGateway struct {
 	self SelfProvider
+	ctl  TransportController
 }
 
 // errNoSelf is returned when the tab has no local visor wired (not booted).
 var errNoSelf = errors.New("wasm-visor: not booted (no self provider)")
 
+// errNoControl is returned when a control method is called but no controller is
+// wired (read-only mode).
+var errNoControl = errors.New("wasm-visor: transport control not available")
+
 // NewRPCServer builds an rpc.Server exposing the gateway under the "app-visor"
-// name (the prefix the CLI uses). Feed its connections via ServeConn — e.g. from
-// wasmrpc.ServeTab(conn, srv.ServeConn).
-func NewRPCServer(self SelfProvider) (*rpc.Server, error) {
+// name (the prefix the CLI uses). self provides the read views; ctl (optional,
+// may be nil) provides transport control. Feed its connections via ServeConn —
+// e.g. from wasmrpc.ServeTab(conn, srv.ServeConn).
+func NewRPCServer(self SelfProvider, ctl TransportController) (*rpc.Server, error) {
 	srv := rpc.NewServer()
-	if err := srv.RegisterName("app-visor", &RPCGateway{self: self}); err != nil {
+	if err := srv.RegisterName("app-visor", &RPCGateway{self: self, ctl: ctl}); err != nil {
 		return nil, err
 	}
 	return srv, nil
+}
+
+// Transports returns the tab's transports (the CLI's `tp ls`). Filters are
+// applied if given; an empty filter returns all.
+func (g *RPCGateway) Transports(in *TransportsIn, out *[]*TransportSummary) error {
+	if g.self == nil {
+		return errNoSelf
+	}
+	all := g.self.SelfTransports()
+	res := make([]*TransportSummary, 0, len(all))
+	for _, t := range all {
+		if t == nil || !matchTransport(t, in) {
+			continue
+		}
+		res = append(res, t)
+	}
+	*out = res
+	return nil
+}
+
+// matchTransport applies a TransportsIn filter (empty filter = match all).
+func matchTransport(t *TransportSummary, in *TransportsIn) bool {
+	if in == nil {
+		return true
+	}
+	if len(in.FilterTypes) > 0 {
+		ok := false
+		for _, ty := range in.FilterTypes {
+			if ty == t.Type {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	if len(in.FilterPubKeys) > 0 {
+		ok := false
+		for _, pk := range in.FilterPubKeys {
+			if pk == t.Remote {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// AddTransport creates a transport from this tab to a remote visor (the CLI's
+// `tp add`). webrtc/dmsg work over the CLI (no endpoint needed); ws/wt need an
+// endpoint and must use skywireVisor.dialTransport instead.
+func (g *RPCGateway) AddTransport(in *AddTransportIn, out *TransportSummary) error {
+	if g.ctl == nil {
+		return errNoControl
+	}
+	ts, err := g.ctl.AddTransport(in.RemotePK, in.TpType, in.Timeout)
+	if err != nil {
+		return err
+	}
+	if ts != nil {
+		*out = *ts
+	}
+	return nil
+}
+
+// RemoveTransport tears down a transport by ID (the CLI's `tp rm`).
+func (g *RPCGateway) RemoveTransport(tid *uuid.UUID, _ *struct{}) error {
+	if g.ctl == nil {
+		return errNoControl
+	}
+	return g.ctl.RemoveTransport(*tid)
 }
 
 // IsStartupComplete reports whether the tab's visor is up.

--- a/pkg/wasmhv/rpc_gateway_test.go
+++ b/pkg/wasmhv/rpc_gateway_test.go
@@ -21,7 +21,7 @@ func TestRPCGateway_OverBridge(t *testing.T) {
 	var pk cipher.PubKey
 	require.NoError(t, pk.Set("0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13"))
 
-	srv, err := NewRPCServer(fakeSelf{pk: pk})
+	srv, err := NewRPCServer(fakeSelf{pk: pk}, nil)
 	require.NoError(t, err)
 
 	hostConn, tabConn := net.Pipe()
@@ -52,7 +52,7 @@ func TestRPCGateway_OverBridge(t *testing.T) {
 // TestRPCGateway_NotBooted confirms the gateway errors cleanly when no visor is
 // wired (rather than panicking or returning a zero value as if booted).
 func TestRPCGateway_NotBooted(t *testing.T) {
-	srv, err := NewRPCServer(nil)
+	srv, err := NewRPCServer(nil, nil)
 	require.NoError(t, err)
 	hostConn, tabConn := net.Pipe()
 	go func() {


### PR DESCRIPTION
Extends the RPC gateway (#3260/#3261) with transport control, **proven live**: `skywire cli tp add <pk> -t dmsg --rpc <tab>` established a **dmsg transport between two browser-tab visors**, and `tp ls` listed it on both ends (each showing the other's PK).

```
$ skywire cli tp ls --rpc 127.0.0.1:37941
type   id            remote_pk          mode      label
dmsg   61204ee0-...  020da5af...1002be  regular   user
$ skywire cli tp ls --rpc 127.0.0.1:46229   # the inbound side
dmsg   61204ee0-...  034b5aa9...e47fce  regular   user
```

## What
- `RPCGateway` gains `Transports` (read, with type/pk filters) backed by `SelfProvider`, and `AddTransport`/`RemoveTransport` backed by a new `TransportController` interface (nil → read-only). `TransportsIn`/`AddTransportIn` mirror the visor RPC args. `NewRPCServer(self, ctl)`.
- `cmd/wasm-visor` `tpController` implements control over the tab's `transport.Manager`: `AddTransport` `SaveTransport`s a webrtc/dmsg link by PK (ws/wt need an endpoint → still via `skywireVisor.dialTransport`); `RemoveTransport` `DeleteTransport`s by id.
- **gob fix**: `TransportLogEntry` gains `GobEncode` (it had only `GobDecode`, for the HV UI *receiving*). Over the bridge the wasm-visor is the *encoder*, and without it gob described `TransportSummary.Log` as a plain struct instead of a GobEncoder type, mismatching the CLI's `*transport.LogEntry` and failing the whole `tp ls` decode ("wrong type for received field .Log") — even for an empty list. Regression tests cover the encode direction and the empty-list case.

## Note
The CLI's `tp add` still hard-codes its accepted type list (`dmsg/stcpr/sudph/stcp`), so `-t webrtc` is rejected client-side — de-hardcoding that is a follow-up. `dmsg` works today and proves the path.