### PR TITLE
refactor(cli): validate transport types against types.Known(), not a hardcoded list

### DIFF
--- a/cmd/skywire-cli/commands/tp/tp-add.go
+++ b/cmd/skywire-cli/commands/tp/tp-add.go
@@ -74,8 +74,12 @@ var addTpCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		if transportType != "dmsg" && transportType != "stcpr" && transportType != "sudph" && transportType != "stcp" && transportType != "" {
-			logger.Fatal("Invalid transport type specified:", transportType)
+		// Validate against the canonical type set (types.Known()) rather than a
+		// hard-coded subset, so newly-added types (squic, webrtc, ws, wt) are
+		// accepted without editing the CLI. The visor still validates and may
+		// refuse a type it can't dial (e.g. ws/wt without an endpoint).
+		if transportType != "" && !types.Valid(types.Type(transportType)) {
+			logger.Fatalf("Invalid transport type %q; valid types: %v", transportType, types.Known())
 		}
 		if stcpAddr != "" && transportType != "stcp" {
 			logger.Fatal("--addr flag requires -t stcp")

--- a/cmd/skywire-cli/commands/tp/tp-id.go
+++ b/cmd/skywire-cli/commands/tp/tp-id.go
@@ -29,13 +29,11 @@ discovery query — and mirrors transport.MakeTransportID().
 
 The returned ID is independent of PK order: id(T, A, B) == id(T, B, A).
 
-Valid transport types: dmsg, stcp, stcpr, sudph (default: dmsg)`,
+Valid transport types: stcpr, squic, sudph, stcp, webrtc, ws, wt, dmsg (default: dmsg)`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		switch idTpType {
-		case "dmsg", "stcp", "stcpr", "sudph":
-		default:
-			internal.Catch(cmd.Flags(), fmt.Errorf("invalid transport type %q (valid: dmsg, stcp, stcpr, sudph)", idTpType))
+		if !tptypes.Valid(tptypes.Type(idTpType)) {
+			internal.Catch(cmd.Flags(), fmt.Errorf("invalid transport type %q (valid: %v)", idTpType, tptypes.Known()))
 		}
 
 		var pk1, pk2 cipher.PubKey

--- a/cmd/skywire-cli/commands/tp/tp-route-addr.go
+++ b/cmd/skywire-cli/commands/tp/tp-route-addr.go
@@ -46,10 +46,8 @@ Valid transport types: dmsg, stcp, stcpr, sudph (default: sudph — dmsg transpo
 are not used for multi-hop routes).`,
 	Args: cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		switch routeAddrType {
-		case "dmsg", "stcp", "stcpr", "sudph":
-		default:
-			internal.Catch(cmd.Flags(), fmt.Errorf("invalid transport type %q (valid: dmsg, stcp, stcpr, sudph)", routeAddrType))
+		if !tptypes.Valid(tptypes.Type(routeAddrType)) {
+			internal.Catch(cmd.Flags(), fmt.Errorf("invalid transport type %q (valid: %v)", routeAddrType, tptypes.Known()))
 		}
 
 		path := make([]cipher.PubKey, len(args))

--- a/pkg/transport/types/types.go
+++ b/pkg/transport/types/types.go
@@ -61,3 +61,21 @@ func NormalizeType(t Type) Type {
 	}
 	return t
 }
+
+// Known returns every recognized transport type, in canonical form. This is the
+// single source of truth callers (e.g. the CLI's `tp add` validation) should use
+// instead of hard-coding a subset that drifts as new types are added.
+func Known() []Type {
+	return []Type{STCPR, QUIC, SUDPH, STCP, WEBRTC, WS, WT, DMSG}
+}
+
+// Valid reports whether t names a recognized transport type. Alias-aware (the
+// legacy "quic" name normalizes to "squic"), so older invocations keep working.
+func Valid(t Type) bool {
+	switch NormalizeType(t) {
+	case STCPR, QUIC, SUDPH, STCP, WEBRTC, WS, WT, DMSG:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/transport/types/types_valid_test.go
+++ b/pkg/transport/types/types_valid_test.go
@@ -1,0 +1,23 @@
+package tptypes
+
+import "testing"
+
+func TestValidAndKnown(t *testing.T) {
+	for _, ty := range Known() {
+		if !Valid(ty) {
+			t.Errorf("Known() type %q not Valid()", ty)
+		}
+	}
+	if !Valid(QUICLegacy) {
+		t.Error("legacy \"quic\" should be Valid (alias of squic)")
+	}
+	if !Valid("webrtc") || !Valid("ws") || !Valid("wt") || !Valid("squic") {
+		t.Error("newer types must be Valid")
+	}
+	if Valid("bogus") || Valid("") {
+		t.Error("unknown/empty must be invalid")
+	}
+	if len(Known()) != 8 {
+		t.Errorf("expected 8 known types, got %d", len(Known()))
+	}
+}


### PR DESCRIPTION
`tp add` / `tp id` / `tp route-addr` hard-coded `dmsg/stcpr/sudph/stcp` and rejected the newer types (`squic`, `webrtc`, `ws`, `wt`) **client-side** — so `tp add <pk> -t webrtc` failed with "Invalid transport type" before ever reaching the visor.

- Adds `types.Known()` (the canonical type set) + `types.Valid()` (alias-aware, so legacy `quic` still normalizes to `squic`), and validates against them in the `tp` commands.
- New types now flow through to the visor, which remains the authority on whether it can actually dial a given type (e.g. `ws`/`wt` without an endpoint).
- **Proven live**: `skywire cli tp add <pk> -t webrtc --rpc <wasm-visor>` is now accepted and attempts the dial (vs. a hard client-side rejection before).

Left as deliberate domain rules: `tp-add-pv` (public visors advertise stcpr/sudph only) and the transport-setup service. Unit test covers `Known()`/`Valid()` incl. the `quic→squic` alias and the newer types.

Follow-up to the wasm-visor transport-control work (#3263), where this hardcode first surfaced.