### PR TITLE
feat(wasm-visor): embed the wasm-visor in the binary (build-tagged, no git history)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ skysocks-client
 # stray local artifacts (accidentally committed once; see chore/rm-stray-committed-files)
 /visor.log
 /hist/
+
+# Embedded wasm-visor binary (built by `make wasm-visor`, embedded under -tags embedwasm; never committed)
+pkg/wasmhv/wasmbin/wasm-visor.wasm.gz

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY : check lint install-linters dep test lint-extra
 .PHONY : update-deps update-dmsg update-skycoin push-deps
-.PHONY : build clean install format  bin build-race deploy
+.PHONY : build clean install format  bin build-race deploy build-embedwasm wasm-visor
 .PHONY : host-apps bin
 .PHONY : docker-image docker-clean docker-network
 .PHONY : docker-apps docker-bin docker-volume
@@ -245,7 +245,13 @@ wasm-visor: ## Build the browser WASM visor edge with STANDARD Go js/wasm into b
 	cp "$$(go env GOROOT)/lib/wasm/wasm_exec.js" ./build/wasm-visor-go/wasm_exec.js
 	cp ./cmd/wasm-visor/index.html ./build/wasm-visor-go/
 	cp ./pkg/wasmhv/browse.js ./build/wasm-visor-go/
-	@echo "built ./build/wasm-visor-go (standard Go js/wasm) — serve it: 'go run cmd/dmsg-wasm/serve.go -dir build/wasm-visor-go' then open http://localhost:8085/"
+	gzip -9 -c ./build/wasm-visor-go/wasm-visor.wasm > ./pkg/wasmhv/wasmbin/wasm-visor.wasm.gz
+	@echo "built ./build/wasm-visor-go (standard Go js/wasm) + embed gz at pkg/wasmhv/wasmbin/ (gitignored)"
+	@echo "  serve dev: 'go run cmd/dmsg-wasm/serve.go -dir build/wasm-visor-go'; embed in skywire: 'make build-embedwasm'"
+
+build-embedwasm: wasm-visor ## Build skywire with the std-Go wasm-visor embedded (so `cli hv gen` needs no --wasm). Runs `make wasm-visor` first.
+	${OPTS} go build -tags embedwasm ${BUILD_OPTS} -o $(BUILD_PATH)skywire .
+	@echo "built $(BUILD_PATH)skywire WITH embedded wasm-visor (~8MB larger) — `cli hv gen` works without --wasm"
 
 dmsg-wasm-hv: ## Build the browser hypervisor-over-dmsg bundle (Service Worker proxy) into build/dmsg-wasm-hv
 	mkdir -p ./build/dmsg-wasm-hv

--- a/cmd/skywire-cli/commands/hv/gen.go
+++ b/cmd/skywire-cli/commands/hv/gen.go
@@ -10,6 +10,7 @@ import (
 	"github.com/skycoin/skywire/pkg/visor"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 	"github.com/skycoin/skywire/pkg/wasmhv"
+	"github.com/skycoin/skywire/pkg/wasmhv/wasmbin"
 )
 
 var (
@@ -63,11 +64,6 @@ the baked-in key (the plaintext never touches the file).
 SECURITY: never serve a generated (key-bearing) file from a domain — it would
 train users to type secret keys into pages from external hosts.`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		if genWasm == "" {
-			cmd.PrintErrln("--wasm is required (build it with `make dmsg-wasm`)")
-			os.Exit(1)
-		}
-
 		skHex, err := resolveKey(cmd)
 		if err != nil {
 			cmd.PrintErrln("identity:", err)
@@ -77,26 +73,45 @@ train users to type secret keys into pages from external hosts.`,
 			cmd.PrintErrln("warning: the secret key is baked in WITHOUT a password (plaintext on disk); pass --password to encrypt it")
 		}
 
-		wasm, err := os.ReadFile(genWasm) //nolint:gosec // operator-supplied path
-		if err != nil {
-			cmd.PrintErrln("read --wasm:", err)
+		// Source the wasm: an explicit --wasm path wins; otherwise fall back to the
+		// std-Go wasm-visor embedded in this binary (builds with `-tags embedwasm`
+		// after `make wasm-visor`). The embedded one is the standard-Go build, so it
+		// uses Go's wasm_exec.js (the embedded default) — no --wasm-exec needed.
+		var wasm []byte
+		embeddedVisor := false
+		if genWasm != "" {
+			if wasm, err = os.ReadFile(genWasm); err != nil { //nolint:gosec // operator-supplied path
+				cmd.PrintErrln("read --wasm:", err)
+				os.Exit(1)
+			}
+		} else if wasmbin.Embedded() {
+			if wasm, err = wasmbin.Get(); err != nil {
+				cmd.PrintErrln("embedded wasm-visor:", err)
+				os.Exit(1)
+			}
+			genVisor = true // the embedded binary IS the std-Go wasm-visor
+			embeddedVisor = true
+		} else {
+			cmd.PrintErrln("--wasm is required (or build skywire with `-tags embedwasm` after `make wasm-visor` to embed it)")
 			os.Exit(1)
 		}
+
 		uiFS, err := visor.HypervisorUIFS()
 		if err != nil {
 			cmd.PrintErrln("hypervisor UI assets:", err)
 			os.Exit(1)
 		}
 
-		// A wasm-visor is TinyGo: its wasm_exec.js differs from Go's embedded one,
-		// so it must be supplied. The standalone (Go) dmsg-client uses the embedded.
+		// wasm_exec.js: the embedded std-Go wasm-visor (and the Go dmsg-client) use
+		// Go's, which is embedded. A --wasm-supplied wasm-VISOR is TinyGo and needs
+		// its own wasm_exec.js passed via --wasm-exec.
 		wasmExec := wasmhv.WasmExecJS
 		if genWasmExec != "" {
 			if wasmExec, err = os.ReadFile(genWasmExec); err != nil { //nolint:gosec // operator-supplied path
 				cmd.PrintErrln("read --wasm-exec:", err)
 				os.Exit(1)
 			}
-		} else if genVisor {
+		} else if genVisor && !embeddedVisor {
 			cmd.PrintErrln("--visor requires --wasm-exec (TinyGo's wasm_exec.js; build/wasm-visor/wasm_exec_tinygo.js)")
 			os.Exit(1)
 		}

--- a/docs/design/wasm-visor-distribution.md
+++ b/docs/design/wasm-visor-distribution.md
@@ -1,50 +1,58 @@
-# wasm-visor binary: never commit it; distribute it like any other binary
+# wasm-visor binary: embed it with the visor, without git-history accumulation
 
 ## The problem
 
 The standard-Go `wasm-visor.wasm` (the browser visor, since TinyGo can't do TLS —
-see [tinygo issue #3259]) is **~38 MB**, and it changes on every build. Git keeps
-every version of a tracked file forever, so committing it — or `go:embed`-ing it
-into a tracked package — would add a fresh ~38 MB blob to history on every change,
-permanently bloating the repository. We only ever need the *current* build.
+see [tinygo issue #3259]) is **~37 MB** and changes on every build. We want it
+**shipped inside the skywire binary** (so `cli hv gen` — and, later, the visor
+serving the HV UI — produce a browser visor with no external file), but git keeps
+every version of a tracked file forever, so committing it or `go:embed`-ing a
+*tracked* copy would add a fresh multi-MB blob to history on every change.
 
-## The rule
+## The approach: build-tagged embed of a gitignored binary
 
-**The `wasm-visor.wasm` binary is never tracked in git.** Verified policy:
+The binary is embedded, but the embedded file is **never committed**:
 
-- It builds only into `build/` (`make wasm-visor` → `build/wasm-visor-go/`,
-  `make tinygo-wasm-visor` → `build/wasm-visor/`), and `build/` is `.gitignore`d.
-- It is **not** `go:embed`-ed anywhere. The single-file hypervisor generator
-  (`skywire cli hv gen`) reads the wasm from a `--wasm <path>` flag at generation
-  time; it does not bake the binary into the repo.
-- `git ls-files '*.wasm'` must never list a `wasm-visor` binary. (It does list a
-  few small, intentionally-tracked wasm artifacts — tpviz, doc examples, vendored
-  skycoin-lite — which are a separate, pre-existing decision.)
+- `make wasm-visor` builds the wasm and writes a gzip of it to
+  `pkg/wasmhv/wasmbin/wasm-visor.wasm.gz` (~8 MB). That path is `.gitignore`d.
+- `pkg/wasmhv/wasmbin` embeds it **only under the `embedwasm` build tag**
+  (`embed_on.go`: `//go:embed wasm-visor.wasm.gz`). Default builds compile
+  `embed_off.go` instead and carry nothing — so a plain `go build ./...` (CI,
+  lint, dev) neither needs the file nor pays the size.
+- `make build-embedwasm` runs `make wasm-visor` then
+  `go build -tags embedwasm` — this is the build that ships the wasm-visor inside
+  skywire (~8 MB larger).
 
-Do **not** add a `//go:embed wasm-visor.wasm` to make `cli hv gen` "just work"
-without a build. That is exactly the history-bloat trap.
+Because the `.wasm.gz` is gitignored and produced at build time, **git history
+never accumulates the binary** — only the tiny source files in `wasmbin/` are
+tracked. Each build simply overwrites the local gz.
 
-## How it gets to users instead
+Do **not** commit `pkg/wasmhv/wasmbin/wasm-visor.wasm.gz` (it's gitignored for
+this reason) or change the embed to a non-tag-gated `go:embed` of a tracked file.
 
-The wasm-visor is distributed the same way skywire's other binaries are — built
-by the release pipeline, never via git:
+## Consuming it
 
-- **Release asset** — the release build runs `make wasm-visor` and attaches
-  `wasm-visor.wasm` (+ `wasm_exec.js`) to the GitHub release / packages. `cli hv
-  gen --wasm <downloaded-path>` consumes it.
-- **Package** — the apt/AUR packages can ship the prebuilt wasm under the skywire
-  data dir, and `cli hv gen` defaults to that path.
-- **Build on demand** — a developer runs `make wasm-visor` and points `--wasm` at
-  `build/wasm-visor-go/wasm-visor.wasm`.
+`skywire cli hv gen` sources the wasm in this order:
 
-If we ever do want a "latest-only, no history" copy reachable by URL, mirror the
-apt-repo pattern (`updgithub.sh`): a dedicated artifacts location that is
-force-pushed to a single commit (history wiped each update), never the main repo.
+1. `--wasm <path>` if given (e.g. a TinyGo build, which also needs `--wasm-exec`);
+2. otherwise the **embedded** std-Go wasm-visor (`wasmbin.Embedded()`), which uses
+   Go's embedded `wasm_exec.js` — no `--wasm-exec` needed;
+3. otherwise an error telling you to pass `--wasm` or build `-tags embedwasm`.
+
+So a release-built skywire (`make build-embedwasm`) runs `cli hv gen` with no
+flags. A default-built skywire still works via `--wasm`.
+
+## Release / packaging
+
+Build the shipped skywire with `make build-embedwasm` so the wasm-visor travels
+with the binary. The `.wasm.gz` is a build artifact, not a committed file; the
+release pipeline produces it via `make wasm-visor` as part of `build-embedwasm`.
 
 ## TODO when TinyGo gains software TLS
 
 Once [tinygo issue #3259] is resolved, the small (~2.2 MB) TinyGo build can do
-HTTPS again and becomes the default, shrinking the artifact ~17×. Same rule
-applies regardless: build it, ship it as an artifact, don't commit it.
+HTTPS again and becomes the default embed, shrinking the addition ~4×. The
+mechanism is unchanged: build it, gzip it to the gitignored embed path, embed
+under the tag.
 
 [tinygo issue #3259]: https://github.com/skycoin/skywire/issues/3259

--- a/pkg/wasmhv/wasmbin/embed_off.go
+++ b/pkg/wasmhv/wasmbin/embed_off.go
@@ -1,0 +1,16 @@
+//go:build !embedwasm
+
+package wasmbin
+
+import "errors"
+
+// ErrNotEmbedded is returned by Get when the wasm-visor binary was not compiled
+// in (the default; build with `-tags embedwasm` after `make wasm-visor`).
+var ErrNotEmbedded = errors.New("wasm-visor binary not embedded in this build " +
+	"(build with `-tags embedwasm` after `make wasm-visor`, or pass --wasm)")
+
+// Embedded reports whether a wasm-visor binary is compiled into this build.
+func Embedded() bool { return false }
+
+// Get returns ErrNotEmbedded: this build did not embed the wasm-visor binary.
+func Get() ([]byte, error) { return nil, ErrNotEmbedded }

--- a/pkg/wasmhv/wasmbin/embed_on.go
+++ b/pkg/wasmhv/wasmbin/embed_on.go
@@ -1,0 +1,35 @@
+//go:build embedwasm
+
+// Package wasmbin optionally carries the compiled wasm-visor binary inside the
+// skywire binary, so `cli hv gen` (and, later, the visor serving the HV UI) can
+// produce a browser visor with NO external --wasm file.
+//
+// The binary is embedded ONLY under the `embedwasm` build tag, and the embedded
+// file (wasm-visor.wasm.gz, ~8.5MB) is .gitignore'd — it is produced by
+// `make wasm-visor` and never committed, so git history does not accumulate a
+// new ~38MB blob on every build. Default builds (no tag) use the stub in
+// embed_off.go and carry nothing. See docs/design/wasm-visor-distribution.md.
+package wasmbin
+
+import (
+	"bytes"
+	"compress/gzip"
+	_ "embed"
+	"io"
+)
+
+//go:embed wasm-visor.wasm.gz
+var gzWasm []byte
+
+// Embedded reports whether a wasm-visor binary is compiled into this build.
+func Embedded() bool { return len(gzWasm) > 0 }
+
+// Get returns the embedded wasm-visor binary, decompressed.
+func Get() ([]byte, error) {
+	zr, err := gzip.NewReader(bytes.NewReader(gzWasm))
+	if err != nil {
+		return nil, err
+	}
+	defer zr.Close() //nolint:errcheck
+	return io.ReadAll(zr)
+}

--- a/pkg/wasmhv/wasmbin/embed_test.go
+++ b/pkg/wasmhv/wasmbin/embed_test.go
@@ -1,0 +1,20 @@
+//go:build embedwasm
+
+package wasmbin
+
+import "testing"
+
+func TestEmbeddedGet(t *testing.T) {
+	if !Embedded() {
+		t.Fatal("Embedded() false under -tags embedwasm")
+	}
+	b, err := Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	// the wasm-visor binary starts with the wasm magic \0asm
+	if len(b) < 4 || string(b[:4]) != "\x00asm" {
+		t.Fatalf("not a wasm binary (len=%d, magic=%x)", len(b), b[:min(4, len(b))])
+	}
+	t.Logf("decompressed wasm-visor: %.1f MB", float64(len(b))/1024/1024)
+}


### PR DESCRIPTION
Ships the std-Go wasm-visor **inside** skywire so `cli hv gen` needs no external `--wasm` file — **without** accumulating the ~37 MB binary in git history.

## Mechanism
- `pkg/wasmhv/wasmbin` embeds `wasm-visor.wasm.gz` (~8 MB) **only under the `embedwasm` build tag** (`embed_on.go`). Default builds compile `embed_off.go` (a stub) and carry nothing — plain `go build ./...` / CI / lint neither need the file nor pay the size.
- The embedded file is **`.gitignore`d** and produced by `make wasm-visor` (now gzips into `pkg/wasmhv/wasmbin/`), so it is **never committed** — git history never gains a blob; each build overwrites the local gz.
- `make build-embedwasm` = `make wasm-visor` then `go build -tags embedwasm` — the release build that travels with the wasm-visor (~8 MB larger).
- `cli hv gen`: `--wasm` path wins; else the embedded std-Go wasm-visor (uses Go's embedded `wasm_exec.js`, no `--wasm-exec`); else a clear error. A release-built skywire runs `cli hv gen` with no flags.

## Why this shape
Supersedes the earlier "never embed" note (#3265) per the new requirement: embed it **with** the visor, but keep the binary out of git via the gitignored + build-tag mechanism. `docs/design/wasm-visor-distribution.md` rewritten.

Verified: default + `-tags embedwasm` builds of `gen` and full skywire; `Get()` round-trips to a valid 37 MB wasm (`\0asm` magic) under the tag.

First of the redirect items; next: collapse with the Angular HV UI (wasm-visor as a tab / HV-UI replacement / standalone), route origination over dmsg, and the in-tab skysocks-client.