### PR TITLE
feat(wasm-visor): wire route origination (RouteFinder + setup-node dialer)

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -46,6 +46,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"syscall/js"
 	"time"
@@ -61,7 +62,9 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/rfclient"
 	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport"
@@ -255,6 +258,16 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	// never returns). Fixed by the reflection-free gobrpc server — the router now
 	// registers explicit handlers under TinyGo (router_setup_rpc_tinygo.go) instead
 	// of reflection. Validated in-browser via this harness.
+	// Route ORIGINATION: query the route-finder over dmsg and dial route groups
+	// via the deployment's setup nodes, so this tab can SET UP multihop (and mux)
+	// routes — not just receive rules and forward. Legacy setup path
+	// (forceLegacy=true); no embedded route-setup node in a browser leaf. The
+	// std-Go build compiles the full route-source (the TinyGo stub does not apply).
+	rfHTTP := &http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC)}
+	rfClient := rfclient.NewHTTP(deployment.Prod.RouteFinderDmsg, 10*time.Second, rfHTTP, mLog)
+	rgDialer := router.NewSetupNodeDialerFull(nil, router.NewRSNRelayCache(mLog.PackageLogger("router")), tm, true)
+	vlog(fmt.Sprintf("router: route origination wired (rf=%s, %d setup nodes)", deployment.Prod.RouteFinderDmsg, len(deployment.Prod.RouteSetupNodes)))
+
 	rConf := &router.Config{
 		Logger:             mLog.PackageLogger("router"),
 		MasterLogger:       mLog,
@@ -262,6 +275,9 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 		SecKey:             sk,
 		TransportManager:   tm,
 		AwaitSetupListener: setupLis,
+		RouteFinder:        rfClient,
+		RouteGroupDialer:   rgDialer,
+		SetupNodes:         deployment.Prod.RouteSetupNodes,
 	}
 	vlog("router: New…")
 	r, err := router.New(dmsgC, rConf, nil)


### PR DESCRIPTION
The wasm-visor was a pure leaf — `router.Config` had `RouteFinder`/`RouteGroupDialer` nil, so it could only *receive* route rules and forward, not *set up* routes. The std-Go build compiles the full route-source (the TinyGo stub doesn't apply), so it can originate now.

`bootEdge` wires:
- **RouteFinder** — `rfclient.NewHTTP` over a `dmsghttp.MakeHTTPTransport(dmsgC)` `http.Client` to `deployment.Prod.RouteFinderDmsg` (the dmsg-served route finder).
- **RouteGroupDialer** — `router.NewSetupNodeDialerFull(nil, NewRSNRelayCache, tpM, true)` (legacy setup path; no embedded RSN in a browser leaf).
- **SetupNodes** — `deployment.Prod.RouteSetupNodes`.

So a tab can query the route-finder over dmsg and dial route groups via the deployment's setup nodes — multihop (and mux) routes between visors, including two wasm-visors via an intermediary (your "webRTC isn't a blocker — a route between them can exist" point).

**Verified live**: both browser tabs boot with route origination wired (log: `route origination wired (rf=dmsg://039d89c5…:80, 2 setup nodes)`), the router serves, and `cli visor info` stays healthy. The actual route *setup* is exercised in-process by the next piece — the in-tab skysocks-client, which originates a route to the skysocks-server's visor.