### PR TITLE
docs+feat(wasm-visor): diagnose route-setup blocker — tab not in dmsg discovery

### DIFF
--- a/cmd/wasm-visor/index.html
+++ b/cmd/wasm-visor/index.html
@@ -147,6 +147,8 @@
           // a = [remotePK, port] — originate a route group via the router.
           return await skywireVisor.dialRoute(a[0] || "", a[1] || 80);
         }
+        case "checkRegistered":
+          return await skywireVisor.checkRegistered();
         case "status":
           return skywireVisor.status();
         case "browse": {

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -46,6 +46,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"syscall/js"
@@ -107,15 +108,16 @@ func vlog(msg string) {
 func main() {
 	ctx = context.Background()
 	js.Global().Set("skywireVisor", js.ValueOf(map[string]interface{}{
-		"boot":          js.FuncOf(jsBoot),
-		"status":        js.FuncOf(jsStatus),
-		"hvApi":         js.FuncOf(jsHvAPI),
-		"tpdEdge":       js.FuncOf(jsTPDEdge),
-		"dialTransport": js.FuncOf(jsDialTransport),
-		"fetchDmsg":     js.FuncOf(jsFetchDmsg),
-		"serveContent":  js.FuncOf(jsServeContent),
-		"serveRPC":      js.FuncOf(jsServeRPC),
-		"dialRoute":     js.FuncOf(jsDialRoute),
+		"boot":            js.FuncOf(jsBoot),
+		"status":          js.FuncOf(jsStatus),
+		"hvApi":           js.FuncOf(jsHvAPI),
+		"tpdEdge":         js.FuncOf(jsTPDEdge),
+		"dialTransport":   js.FuncOf(jsDialTransport),
+		"fetchDmsg":       js.FuncOf(jsFetchDmsg),
+		"serveContent":    js.FuncOf(jsServeContent),
+		"serveRPC":        js.FuncOf(jsServeRPC),
+		"dialRoute":       js.FuncOf(jsDialRoute),
+		"checkRegistered": js.FuncOf(jsCheckRegistered),
 	}))
 	fmt.Println("wasm-visor: ready — call skywireVisor.boot(sk, seedPk, seedWs, discDmsgAddr)")
 	select {} // block forever
@@ -649,6 +651,42 @@ func jsDialRoute(_ js.Value, args []js.Value) interface{} {
 		res.Set("ok", true)
 		res.Set("remote", conn.RemoteAddr().String())
 		res.Set("local", conn.LocalAddr().String())
+		return res, nil
+	})
+}
+
+// jsCheckRegistered() → Promise<{registered, status, detail}>. Diagnoses dmsg
+// discovery registration: GETs this tab's OWN entry from the dmsg-discovery over
+// the tab's dmsg-HTTP. 200 = registered (RSN can reach us for route setup); 404 =
+// reachable but NOT published (the registration write isn't landing); a transport
+// error = the tab can't even reach the discovery over its one seed session
+// (bootstrap reachability). See docs/design/wasm-visor-discovery-registration.md.
+func jsCheckRegistered(_ js.Value, _ []js.Value) interface{} {
+	return promise(func() (interface{}, error) {
+		if dmsgC == nil {
+			return nil, errors.New("not booted; call boot() first")
+		}
+		httpC := &http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC), Timeout: 25 * time.Second}
+		reqURL := deployment.Prod.DmsgDiscoveryDmsg + "/dmsg-discovery/entry/" + selfPK.Hex()
+		dctx, cancel := context.WithTimeout(ctx, 25*time.Second)
+		defer cancel()
+		req, _ := http.NewRequestWithContext(dctx, http.MethodGet, reqURL, nil)
+		res := js.Global().Get("Object").New()
+		resp, err := httpC.Do(req)
+		if err != nil {
+			res.Set("registered", false)
+			res.Set("status", 0)
+			res.Set("detail", "reach discovery: "+err.Error())
+			return res, nil
+		}
+		defer resp.Body.Close() //nolint:errcheck
+		body, _ := io.ReadAll(resp.Body)
+		if len(body) > 200 {
+			body = body[:200]
+		}
+		res.Set("registered", resp.StatusCode == http.StatusOK)
+		res.Set("status", resp.StatusCode)
+		res.Set("detail", string(body))
 		return res, nil
 	})
 }

--- a/docs/design/wasm-visor-discovery-registration.md
+++ b/docs/design/wasm-visor-discovery-registration.md
@@ -1,0 +1,78 @@
+# wasm-visor route setup blocker: the tab isn't registered in dmsg discovery
+
+## Symptom
+
+A browser wasm-visor can now ORIGINATE routes (route-finder + setup-node dialer
+wired, `MinHops=1`; see #3268/#3269). `rtr.DialRoutes(...)` gets past the
+routing-disabled gate into route-id reservation, then fails:
+
+```
+route setup: failed to instantiate route id reserver: a dial attempt failed with:
+dial <tab-pk>@136: dmsg error 100 - entry is not found in discovery
+```
+
+The setup node (RSN) tries to dial the **tab itself** at `<pk>@136` (to install
+the route's source rule, the legacy setup path) and can't find the tab in dmsg
+discovery — so route setup can't complete.
+
+## Root cause (traced)
+
+A browser tab uses a **seeded/direct** dmsg client (`StartDmsgSeeded`): it can
+only WebSocket to one seed server, and bootstraps discovery from a preloaded
+direct entry. The registration mechanism IS present and correct:
+
+- `upgradeDiscovery` installs a `RegisteringFallbackDiscClient`
+  (`fallback_disc.go`): READS resolve direct-first; WRITES (`PutEntry`) route to
+  the real HTTP-over-dmsg discovery (`register: true`).
+- The dmsg client's post-session `updateClientEntry` loop calls `PutEntry`
+  (`entity_common.go:798`). On the first cycle `isDue` is true (`lastUpdate=0`),
+  so it *does* attempt the write.
+
+But the tab's entry never appears in discovery (`mdisc entry <pk>` → 404). So the
+**`PutEntry` write to the dmsg-discovery is not succeeding** — and it's the
+classic dmsg-bootstrap reachability problem: a client connected to a *single*
+seed server can only reach peers/services that server can bridge to. The
+route-finder query worked (so the tab reaches *some* dmsg services), but the
+discovery write specifically isn't landing — likely the discovery isn't reachable
+through the one seed server the tab holds, or the write errors and the update loop
+swallows it.
+
+This is exactly where the wasm-visor diverges from the non-wasm visor: a normal
+visor dials **many** dmsg servers and registers cleanly; the browser tab holds one
+WS session and hits the chicken-egg (needs discovery to learn more servers, needs
+more servers to reach discovery). `MinSessions=2` is meant to help but only after
+the first discovery contact.
+
+## Why it matters
+
+Route setup (legacy path) requires the RSN to dial **every hop including the
+source** at `@136`. The source is the tab. If the tab isn't discovery-registered,
+the RSN can't reach it. This blocks multihop routes from the tab — and therefore
+the in-tab skysocks-client / clearnet browsing, which ride `DialRoutes`.
+
+## Fix options (next focused work)
+
+1. **Make the tab actually register** — ensure the seed server(s) the tab uses can
+   bridge to the dmsg-discovery, and/or have the tab open multiple WS sessions
+   (browsers can) so it reaches the discovery's server. The registration code is
+   already correct; this is about reachability/topology. **Needs a diagnostic**
+   that surfaces the `PutEntry` error (today it's a swallowed Debug log in the
+   browser console) — e.g. a `skywireVisor.checkRegistered()` hook that GETs the
+   tab's own entry from discovery over its dmsg-HTTP and reports found / the exact
+   error.
+
+2. **Source-inject cascade setup** — set `forceLegacy=false` so the route uses the
+   cascade path where the SOURCE injects its own rule down its own transports and
+   the RSN never dials the source (it's a signing oracle). A browser tab that's
+   hard to reach inbound is the ideal case for this. Caveat: the cascade had a
+   multihop data-plane bug (opt-in until fixed); may work for 1-hop.
+
+3. **Both** — register for inbound reachability *and* prefer source-inject so route
+   setup doesn't depend on the RSN reaching the tab.
+
+## Status
+
+Route origination is wired and initiates setup (#3268/#3269). The remaining
+blocker is this discovery-registration / dmsg-bootstrap reachability for browser
+tabs — the real prerequisite for the in-tab skysocks-client. A `checkRegistered`
+diagnostic is the next step to see *why* the `PutEntry` write isn't landing.


### PR DESCRIPTION
Route origination is wired (#3268/#3269) and **initiates** setup, but fails because the setup node can't dial the tab at `<pk>@136` ("entry not found in discovery").

Traced: a browser tab's seeded/direct dmsg client *attempts* registration (the `RegisteringFallbackDiscClient` routes `PutEntry` to the real discovery, and the update loop fires it on the first cycle), but the write isn't landing — the classic dmsg-bootstrap reachability problem (a client on a single seed server can't necessarily reach the discovery to publish its entry). This is exactly where the wasm-visor diverges from the non-wasm visor, which dials many servers and registers cleanly.

- `docs/design/wasm-visor-discovery-registration.md` — full root-cause analysis + fix options (register via reachable/multiple seed servers; or source-inject cascade setup so the RSN never dials the source).
- `skywireVisor.checkRegistered()` — a diagnostic that GETs the tab's own entry from the dmsg-discovery over its dmsg-HTTP and reports 200 (registered) / 404 (reachable but unpublished) / transport error (can't reach discovery). The tool to see *why* the registration write isn't landing (today a swallowed Debug log in the browser console).

No fix yet — captures the precisely-characterized blocker + the instrument to crack it, the prerequisite for the in-tab skysocks-client / clearnet browsing.