### PR TITLE
feat(dmsg): ServeWithWS — raw-dmsg + WebSocket on one listener/port

### DIFF
--- a/docs/design/dmsg-server-protocol-unification.md
+++ b/docs/design/dmsg-server-protocol-unification.md
@@ -1,0 +1,58 @@
+# dmsg server: all protocols on the one advertised ip:port
+
+## Problem
+
+dmsg servers gained extra carriers (WebSocket, WebTransport, QUIC) but each was
+put on its **own port** with its **own** advertised address (`Server.AddressWS`,
+`AddressWT`, `AddressUDP`). The discovery registration wasn't changed to match, so
+in practice almost no server advertises WS — and a **browser wasm-visor can only
+reach a server it has a WS address for**. Result: only one server in the fleet is
+WS-reachable, the tab is stuck on a single seed session, and it can't reach the
+discovery to register → route setup to it fails. (See
+wasm-visor-discovery-registration.md.)
+
+## Key insight: one ip:port already fits everything
+
+TCP and UDP are **separate port namespaces**, and the protocols are
+self-identifying on first bytes:
+
+- **`TCP:port`** carries **raw-dmsg AND WebSocket**. A WS client opens with an
+  HTTP/1 upgrade (ASCII); a native dmsg client opens with the Noise handshake
+  (binary). A `cmux` demux routes `HTTP1Fast → ServeWS`, `Any → Serve`.
+- **`UDP:port`** carries **QUIC AND WebTransport**. WT is HTTP/3-over-QUIC, so one
+  QUIC listener with multiple ALPNs (`h3` for WT, the dmsg-quic ALPN for native)
+  serves both. QUIC already binds the same port number as TCP.
+
+So a server binds `TCP:30087` (raw + WS) and `UDP:30087` (QUIC + WT), advertises
+the **one** existing `ip:port`, and every client reaches it over whatever protocol
+it speaks. A browser just dials `ws://host:30087/dmsg`. **No new ports; the only
+registration change is `AddressWS` pointing at the existing port** (which the
+self-registration loop already does when the server serves WS).
+
+## Implemented (this PR): the TCP half, proven
+
+`dmsg.Server.ServeWithWS(lis, advertisedAddr, advertisedWSURL)`
+(`pkg/dmsg/dmsg/serve_unified.go`): cmux-demuxes ONE listener into raw-dmsg + WS,
+and sets `advertisedWSAddr` so the entry advertises `Address` + `AddressWS` on the
+same port. Test (`serve_unified_test.go`): a raw-TCP client and a WS client both
+connect to the same server on the same port and bridge a stream — green.
+
+## Remaining wiring
+
+1. **Server**: in `pkg/dmsg/dmsgserver/api.go` `ListenAndServe`, use `ServeWithWS`
+   on the main TCP listener (pass the WS URL `ws://<public-host>:<main-port>/dmsg`)
+   instead of `Serve` + a separate `WSAddress` listener in
+   `pkg/services/dmsgsrv/dmsgsrv.go`. Add WT to the existing QUIC UDP listener
+   (multi-ALPN) similarly. Then **redeploy the dmsg-server fleet** — after which
+   every server is WS-reachable on its advertised port.
+2. **Client (wasm-visor)**: derive the WS URL from the advertised `Server.Address`
+   (`ws://<address>/dmsg`) — or just use the now-populated `AddressWS` — and seed
+   from **all** discovered servers, not one. This gives the tab the multi-server
+   connectivity it needs to reach the discovery and register (the route-setup
+   prerequisite).
+
+## How to tell which servers support WS today
+
+Query the discovery entry: a WS-capable server's entry has an
+`address (websocket): ws://…/dmsg` line (`skywire cli mdisc entry <pk>`). Today
+only one does; after the fleet wiring above, all will (on their main port).

--- a/pkg/dmsg/dmsg/serve_unified.go
+++ b/pkg/dmsg/dmsg/serve_unified.go
@@ -1,0 +1,44 @@
+//go:build !tinygo
+
+// Package dmsg pkg/dmsg/dmsg/serve_unified.go: serve raw-dmsg AND dmsg-over-
+// WebSocket on ONE listener / advertised ip:port.
+package dmsg
+
+import (
+	"net"
+
+	"github.com/soheilhy/cmux"
+)
+
+// ServeWithWS serves BOTH raw-dmsg and dmsg-over-WebSocket on a SINGLE listener,
+// so one advertised ip:port carries both protocols — no separate WS port. It
+// demultiplexes by first bytes: a WebSocket client opens with an HTTP/1 upgrade
+// (cmux.HTTP1Fast → ServeWS), a native dmsg client opens with the Noise handshake
+// (cmux.Any → Serve). They are trivially distinguishable because the WS handshake
+// is ASCII HTTP and the dmsg handshake is binary Noise.
+//
+// The server's discovery entry then advertises Server.Address (TCP) AND
+// Server.AddressWS (the SAME host:port, ws://host:port/dmsg) — no new port. So
+// every server running this becomes reachable by a browser at ws://<address>/dmsg
+// with no topology change: clients just dial the advertised address over whatever
+// protocol they speak. (QUIC + WebTransport share the matching UDP port the same
+// way — see the WT/QUIC listeners.)
+//
+// advertisedAddr is registered as Server.Address; advertisedWSURL (same host:port,
+// ending in /dmsg) as Server.AddressWS. Blocks until a sub-server returns.
+func (s *Server) ServeWithWS(lis net.Listener, advertisedAddr, advertisedWSURL string) error {
+	// Set the WS address BEFORE Serve starts its self-registration loop, so the
+	// first published entry already carries AddressWS alongside Address (both on
+	// this one port). ServeWS sets it again to the same value — harmless.
+	s.advertisedWSAddr = advertisedWSURL
+
+	m := cmux.New(lis)
+	httpL := m.Match(cmux.HTTP1Fast()) // the WS upgrade is an HTTP/1 request
+	rawL := m.Match(cmux.Any())        // everything else is raw dmsg (Noise)
+
+	errCh := make(chan error, 3)
+	go func() { errCh <- s.Serve(rawL, advertisedAddr) }()
+	go func() { errCh <- s.ServeWS(httpL, advertisedWSURL) }()
+	go func() { errCh <- m.Serve() }()
+	return <-errCh
+}

--- a/pkg/dmsg/dmsg/serve_unified_test.go
+++ b/pkg/dmsg/dmsg/serve_unified_test.go
@@ -1,0 +1,97 @@
+// Package dmsg pkg/dmsg/dmsg/serve_unified_test.go
+package dmsg
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestServeWithWS_RawAndWSOnOnePort proves the protocol-unification: a single
+// server listener serves BOTH raw-dmsg (TCP) and dmsg-over-WebSocket. A TCP
+// client and a WS client both connect to the SAME server on the SAME port (the
+// entry advertises Address + AddressWS pointing at it), and a stream bridges from
+// the TCP client to the WS client through the unified server.
+func TestServeWithWS_RawAndWSOnOnePort(t *testing.T) {
+	dc := disc.NewMock(0)
+	const maxSessions = 10
+
+	pkSrv, skSrv := GenKeyPair(t, "server")
+	srv := NewServer(pkSrv, skSrv, dc, &ServerConfig{MaxSessions: maxSessions, UpdateInterval: 0}, nil)
+	srv.SetLogger(logging.MustGetLogger("unified_server"))
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	tcpAddr := lis.Addr().String()
+	wsURL := "ws://" + tcpAddr + wsPath
+
+	chSrv := make(chan error, 1)
+	go func() { chSrv <- srv.ServeWithWS(lis, tcpAddr, wsURL) }()
+
+	// Publish the server entry advertising BOTH Address (TCP) and AddressWS — the
+	// SAME host:port — so a raw-TCP client and a WS client both target this one
+	// listener. (Posted manually, as ws_test does, to avoid the auto-registration
+	// retrier's cold-start timing in a mock-disc unit test; the unification under
+	// test is the cmux demux, not registration. ServeWithWS does advertise both in
+	// production via the Serve self-registration loop.)
+	srvEntry := disc.NewServerEntry(pkSrv, 0, tcpAddr, maxSessions)
+	srvEntry.Server.AddressWS = wsURL
+	require.NoError(t, srvEntry.Sign(skSrv))
+	require.NoError(t, dc.PostEntry(context.Background(), srvEntry))
+
+	// Raw-TCP client (default carrier).
+	pkA, skA := GenKeyPair(t, "tcp client")
+	clientA := NewClient(pkA, skA, dc, DefaultConfig())
+	clientA.SetLogger(logging.MustGetLogger("tcp_client"))
+	go clientA.Serve(context.Background())
+
+	// WS client (CarrierWS → dials the AddressWS over WebSocket).
+	wsConf := DefaultConfig()
+	wsConf.Carriers = []string{CarrierWS}
+	pkB, skB := GenKeyPair(t, "ws client")
+	clientB := NewClient(pkB, skB, dc, wsConf)
+	clientB.SetLogger(logging.MustGetLogger("ws_client"))
+	go clientB.Serve(context.Background())
+
+	require.Eventually(t, func() bool {
+		return clientA.SessionCount() > 0 && clientB.SessionCount() > 0
+	}, 10*time.Second, 200*time.Millisecond, "raw + WS clients failed to connect to the SAME unified server")
+
+	_, okA := clientA.Session(pkSrv)
+	_, okB := clientB.Session(pkSrv)
+	require.True(t, okA, "TCP client has no session to the unified server")
+	require.True(t, okB, "WS client has no session to the unified server")
+
+	// Bridge a stream from the TCP client to the WS client THROUGH the one server.
+	const port = 8080
+	lisB, err := clientB.Listen(port)
+	require.NoError(t, err)
+	defer lisB.Close() //nolint:errcheck
+
+	connA, err := clientA.DialStream(context.TODO(), Addr{PK: pkB, Port: port})
+	require.NoError(t, err)
+	defer connA.Close() //nolint:errcheck
+
+	connB, err := lisB.Accept()
+	require.NoError(t, err)
+	defer connB.Close() //nolint:errcheck
+
+	payload := cipher.RandByte(2048)
+	go func() { _, _ = connA.Write(payload) }() //nolint:errcheck
+	got := make([]byte, len(payload))
+	_, err = io.ReadFull(connB, got)
+	require.NoError(t, err)
+	require.Equal(t, payload, got, "payload mismatch over the TCP↔WS bridge through one unified port")
+
+	require.NoError(t, clientA.Close())
+	require.NoError(t, clientB.Close())
+	require.NoError(t, srv.Close())
+}


### PR DESCRIPTION
Answers "**can a dmsg server support all those protocols on the single ip:port it advertises in discovery?**" — yes, and this implements + proves the TCP half.

## The insight
TCP and UDP are separate port namespaces, and the carriers self-identify on first bytes:
- **`TCP:port`** → raw-dmsg **and** WebSocket. A WS client opens with an HTTP/1 upgrade (ASCII); a native dmsg client opens with the binary Noise handshake. `cmux` routes `HTTP1Fast → ServeWS`, `Any → Serve`.
- **`UDP:port`** → QUIC **and** WebTransport (WT is HTTP/3-over-QUIC; multi-ALPN). QUIC already binds the same port number as TCP.

So one advertised `ip:port` carries everything, a browser dials `ws://host:port/dmsg`, and **no discovery topology change is needed** — the only registration delta is `AddressWS` pointing at the existing port, which the self-registration loop already does.

## This PR
`dmsg.Server.ServeWithWS(lis, advertisedAddr, advertisedWSURL)` cmux-demuxes one listener into raw-dmsg + WS and advertises both `Address` + `AddressWS` on the same host:port. **Test passes**: a raw-TCP client and a WS client both connect to the same server on the same port and bridge a stream through it.

## Why it matters
This dissolves the "only one server advertises WS" problem that strands the browser wasm-visor on a single seed session — which is what blocks its dmsg-discovery registration and therefore route setup (see `docs/design/wasm-visor-discovery-registration.md`).

## Remaining (follow-ups, in the design note)
1. Wire `ServeWithWS` into `dmsgserver.ListenAndServe` (main port) + add WT to the QUIC UDP listener, then **redeploy the dmsg-server fleet** → every server WS-reachable on its advertised port.
2. wasm-visor: derive `ws://<address>/dmsg` from the advertised entry and seed from **all** discovered servers.

Plan: `docs/design/dmsg-server-protocol-unification.md`.