### PR TITLE
feat(dmsg-server): serve WebSocket on the main port by default (unified)

### DIFF
--- a/pkg/dmsg/dmsgserver/api.go
+++ b/pkg/dmsg/dmsgserver/api.go
@@ -83,8 +83,12 @@ func (a *ServerAPI) SetDmsgServer(srv *dmsg.Server) {
 	a.sMu.Unlock()
 }
 
-// ListenAndServe runs dmsg Serve function alongside health endpoint
-func (a *ServerAPI) ListenAndServe(lAddr, pAddr, httpAddr string) error {
+// ListenAndServe runs dmsg Serve function alongside health endpoint. When wsURL
+// is non-empty the main TCP port ALSO serves dmsg-over-WebSocket (demuxed by
+// first bytes — raw Noise vs HTTP/1 upgrade), so one advertised ip:port carries
+// both protocols (see dmsg.Server.ServeWithWS and
+// docs/design/dmsg-server-protocol-unification.md). Empty wsURL = raw-dmsg only.
+func (a *ServerAPI) ListenAndServe(lAddr, pAddr, httpAddr, wsURL string) error {
 	errCh := make(chan error, 3)
 
 	dmsgLn, err := net.Listen("tcp", lAddr)
@@ -92,14 +96,20 @@ func (a *ServerAPI) ListenAndServe(lAddr, pAddr, httpAddr string) error {
 		return err
 	}
 	dmsgLis := &proxyproto.Listener{Listener: dmsgLn}
-	go func(l net.Listener, address string) {
-		serr := a.dmsgServer.Serve(l, address)
+	go func(l net.Listener, address, ws string) {
+		var serr error
+		if ws != "" {
+			// raw-dmsg + WebSocket on the one port
+			serr = a.dmsgServer.ServeWithWS(l, address, ws)
+		} else {
+			serr = a.dmsgServer.Serve(l, address)
+		}
 		l.Close() //nolint:errcheck,gosec
 		// Label so a dead DATA PLANE is identifiable, and use %v so a clean
 		// (nil) stop still yields a non-nil signal — ANY stop of the dmsg
 		// protocol Serve must surface, not be silently absorbed.
 		errCh <- fmt.Errorf("dmsg data-plane server stopped: %v", serr)
-	}(dmsgLis, pAddr)
+	}(dmsgLis, pAddr, wsURL)
 
 	// dmsg-over-QUIC (#2607): also listen on UDP (same port number as TCP) so
 	// QUIC-capable clients get a session with native QUIC stream multiplexing +

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	chi "github.com/go-chi/chi/v5"
@@ -278,21 +279,31 @@ func (s *service) Run(ctx context.Context) error {
 		primaryAdvertised = cfg.PublicAddress
 	}
 
+	// dmsg-over-WebSocket on the MAIN port (unified, the default): unless a
+	// SEPARATE ws_address is explicitly configured (e.g. for CDN/wss fronting),
+	// serve WS on the same TCP port as raw-dmsg and advertise ws://<advertised>/dmsg.
+	// One ip:port carries both, so every server becomes reachable by a browser
+	// wasm-visor with no extra port and no discovery topology change. See
+	// docs/design/dmsg-server-protocol-unification.md.
+	mainWSURL := ""
+	if cfg.WSAddress == "" && primaryAdvertised != "" && !strings.HasPrefix(primaryAdvertised, ":") {
+		mainWSURL = "ws://" + primaryAdvertised + "/dmsg"
+		log.WithField("ws_url", mainWSURL).Info("Serving dmsg over WebSocket on the main port (unified).")
+	}
+
 	go srvAPI.RunBackgroundTasks(runCtx)
 	log.WithField("addr", cfg.HTTPAddress).Info("Serving server API...")
 	go func() {
-		if err := srvAPI.ListenAndServe(cfg.LocalAddress, primaryAdvertised, cfg.HTTPAddress); err != nil {
+		if err := srvAPI.ListenAndServe(cfg.LocalAddress, primaryAdvertised, cfg.HTTPAddress, mainWSURL); err != nil {
 			log.Errorf("Serve: %v", err)
 			cancel()
 		}
 	}()
 
-	// dmsg-over-WebSocket (optional, off by default): bind a plaintext WS
-	// listener and advertise its public URL so WS-only clients — chiefly the
-	// js/wasm build, which cannot open a raw TCP/UDP socket — can reach this
-	// server. Best-effort and additive: a bind failure leaves TCP/QUIC serving
-	// normally. Requires both ws_address (bind) and public_address_ws
-	// (advertised URL); without the URL clients learn nothing to dial.
+	// dmsg-over-WebSocket on a SEPARATE port (opt-in, for CDN/wss fronting):
+	// mutually exclusive with the main-port WS above (the entry carries one
+	// AddressWS) — only runs when ws_address is explicitly set. Requires both
+	// ws_address (bind) and public_address_ws (advertised URL).
 	if cfg.WSAddress != "" && cfg.PublicAddressWS != "" {
 		wsLis, werr := net.Listen("tcp", cfg.WSAddress)
 		if werr != nil {


### PR DESCRIPTION
Wires `ServeWithWS` (#3271) into the deployed dmsg-server so every server serves **raw-dmsg + WebSocket on its one advertised ip:port** — no separate WS port. After a fleet redeploy, every server is reachable by a browser wasm-visor at `ws://<advertised-address>/dmsg`, which dissolves the "only one server advertises WS" problem that strands the tab on a single seed session (and blocks its discovery registration → route setup).

## Changes
- **`dmsgserver/api.go`** — `ListenAndServe` gains a `wsURL` param; when set it runs `ServeWithWS` on the main TCP listener (raw + WS, cmux-demuxed) instead of `Serve`. QUIC (same UDP port number) and the health server (`httpAddr`) are unchanged.
- **`dmsgsrv.go`** — by **default** derive the main-port WS URL `ws://<advertised>/dmsg` and pass it through. The pre-existing **separate-port** WS path (`ws_address` + `public_address_ws`) still works and takes precedence when explicitly configured (CDN/wss fronting) — mutually exclusive with the main-port WS since a discovery entry carries one `AddressWS`. So servers that already advertise a separate WS port keep doing so; everyone else gains main-port WS on redeploy. **Backward-compatible.**

`proxyproto` stays outside `cmux` (the PROXY header is stripped before the demux peeks the real first bytes — raw Noise is binary, the WS upgrade is HTTP/1).

## Rollout
Needs a **dmsg-server fleet redeploy** to take effect. Then the final step is the wasm-visor seeding from all discovered servers via `ws://<address>/dmsg` (mirroring the local visor's multi-server config). Full plan: `docs/design/dmsg-server-protocol-unification.md`.