### PR TITLE
feat(wasm-visor): seed dmsg from all embedded servers via main-port WS

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -179,14 +179,39 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 
 	mLog := logging.NewMasterLogger()
 
-	// 1. dmsg client (browser WebSocket carrier — see cmd/dmsg-wasm).
-	var seedPK cipher.PubKey
-	if err := seedPK.UnmarshalText([]byte(seedPKHex)); err != nil {
-		return pk, fmt.Errorf("bad seed server pk: %w", err)
+	// 1. dmsg client (browser WebSocket carrier). Seed from ALL embedded dmsg
+	// servers via WebSocket on their advertised port — the unified dmsg-server
+	// serves WS at ws://<Address>/dmsg (#3272). Multi-server connectivity mirrors
+	// the non-wasm visor (its config carries the full servers[] list) and is what
+	// lets a browser tab reach the discovery to register its own entry — the
+	// prerequisite for inbound reachability and route setup. A boot-arg seed
+	// (seedPk/seedWs), when given, is added or overrides (e.g. a server whose WS
+	// is on a SEPARATE port). Servers not yet serving main-port WS just fail to
+	// dial and are skipped (best-effort); the client settles on the reachable set.
+	seedsByPK := map[cipher.PubKey]*disc.Entry{}
+	for _, ds := range deployment.Prod.DmsgServers {
+		var spk cipher.PubKey
+		if ds.Server.Address == "" || spk.UnmarshalText([]byte(ds.Static)) != nil {
+			continue
+		}
+		seedsByPK[spk] = &disc.Entry{Version: "0.0.1", Static: spk, Server: &disc.Server{AddressWS: "ws://" + ds.Server.Address + "/dmsg"}}
 	}
-	seed := &disc.Entry{Version: "0.0.1", Static: seedPK, Server: &disc.Server{AddressWS: seedWSURL}}
-	vlog("dmsg: connecting…")
-	c, _, err := dmsgclient.StartDmsgSeeded(ctx, mLog.PackageLogger("dmsg"), pk, sk, []*disc.Entry{seed}, discDmsgAddr, true)
+	if seedPKHex != "" && seedWSURL != "" {
+		var spk cipher.PubKey
+		if err := spk.UnmarshalText([]byte(seedPKHex)); err != nil {
+			return pk, fmt.Errorf("bad seed server pk: %w", err)
+		}
+		seedsByPK[spk] = &disc.Entry{Version: "0.0.1", Static: spk, Server: &disc.Server{AddressWS: seedWSURL}}
+	}
+	seeds := make([]*disc.Entry, 0, len(seedsByPK))
+	for _, e := range seedsByPK {
+		seeds = append(seeds, e)
+	}
+	if len(seeds) == 0 {
+		return pk, errors.New("no dmsg seed servers (embedded set empty and no seedPk/seedWs provided)")
+	}
+	vlog(fmt.Sprintf("dmsg: connecting (%d WS seed servers)…", len(seeds)))
+	c, _, err := dmsgclient.StartDmsgSeeded(ctx, mLog.PackageLogger("dmsg"), pk, sk, seeds, discDmsgAddr, true)
 	if err != nil {
 		return pk, fmt.Errorf("dmsg: %w", err)
 	}


### PR DESCRIPTION
Now that the dmsg-server fleet serves WebSocket on each server's main advertised port (#3271/#3272 — verified live: `0281a102`/`03717576`/`02a2d4c3` advertise `ws://<addr>/dmsg`), the tab seeds from **all** embedded dmsg servers via `ws://<Address>/dmsg` instead of a single boot-arg seed.

This gives the browser visor the **multi-server connectivity a normal visor has** (its config carries the full `servers[]` list) — the prerequisite for reaching the discovery to register its own entry, which the route-setup node needs in order to dial the tab.

- `bootEdge` builds the seed set from `deployment.Prod.DmsgServers` (deriving `ws://<Address>/dmsg` per server); a boot-arg `seedPk`/`seedWs`, when given, is added or overrides by PK (e.g. a server whose WS is on a separate port, like `0371ab:30088`).
- Servers not yet serving main-port WS just fail to dial and are skipped (best-effort); the client settles on the reachable set and learns the rest from discovery (which now carries WS addresses fleet-wide).

This is the **wasm-visor config-format fix** you asked for — mirror the non-wasm visor's multi-server dmsg config — closing the divergence that stranded the tab on one seed session and blocked its discovery registration / route setup. The chain: fleet redeploy (done) → multi-seed (this) → register → route setup → in-tab skysocks-client.