### PR TITLE
feat(dmsg): preload non-registering service entries in StartDmsgSeeded

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -212,7 +212,19 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 		return pk, errors.New("no dmsg seed servers (embedded set empty and no seedPk/seedWs provided)")
 	}
 	vlog(fmt.Sprintf("dmsg: connecting (%d WS seed servers)…", len(seeds)))
-	c, _, err := dmsgclient.StartDmsgSeeded(ctx, mLog.PackageLogger("dmsg"), pk, sk, seeds, discDmsgAddr, true)
+	// Preload the deployment's non-registering SERVICE clients (route-finder, setup
+	// nodes, transport-discovery) delegated to the seed servers — they never publish
+	// to the dmsg-discovery, so without this a multihop DialRoutes (route-finder POST)
+	// 404s. dmsgURLPK errors are non-fatal here (a null PK is skipped downstream).
+	var servicePKs []cipher.PubKey
+	if rfPK, e := dmsgURLPK(deployment.Prod.RouteFinderDmsg); e == nil {
+		servicePKs = append(servicePKs, rfPK)
+	}
+	if tpdSvcPK, e := dmsgURLPK(deployment.Prod.TransportDiscoveryDmsg); e == nil {
+		servicePKs = append(servicePKs, tpdSvcPK)
+	}
+	servicePKs = append(servicePKs, deployment.Prod.RouteSetupNodes...)
+	c, _, err := dmsgclient.StartDmsgSeeded(ctx, mLog.PackageLogger("dmsg"), pk, sk, seeds, discDmsgAddr, true, servicePKs...)
 	if err != nil {
 		return pk, fmt.Errorf("dmsg: %w", err)
 	}

--- a/pkg/dmsg/dmsgclient/seeded.go
+++ b/pkg/dmsg/dmsgclient/seeded.go
@@ -34,7 +34,7 @@ import (
 //
 // seedServers must carry Server.AddressWS for the WebSocket dial to be chosen;
 // a browser build has no working TCP/QUIC fallback.
-func StartDmsgSeeded(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey, seedServers []*disc.Entry, discDmsgAddr string, preferWS bool) (*dmsg.Client, func(), error) {
+func StartDmsgSeeded(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey, seedServers []*disc.Entry, discDmsgAddr string, preferWS bool, servicePKs ...cipher.PubKey) (*dmsg.Client, func(), error) {
 	if len(seedServers) == 0 {
 		return nil, nil, errors.New("dmsg: no seed servers provided")
 	}
@@ -64,6 +64,23 @@ func StartDmsgSeeded(ctx context.Context, log *logging.Logger, pk cipher.PubKey,
 				})
 			}
 		}
+	}
+	// Preload non-registering SERVICE clients (route-finder, setup nodes, transport-
+	// discovery) as direct entries delegated to the seed servers. Services run as
+	// direct clients and never PUBLISH to the dmsg-discovery, so without this a tab's
+	// attempt to resolve e.g. the route-finder 404s ("entry is not found in
+	// discovery") and multihop DialRoutes fails at the route-finder POST. A 1-hop
+	// route to a directly-transported peer skips the route-finder and so works
+	// without this; a multihop route to a distant skysocks exit does not.
+	for _, spk := range servicePKs {
+		if spk.Null() {
+			continue
+		}
+		entries = append(entries, &disc.Entry{
+			Version: "0.0.1",
+			Static:  spk,
+			Client:  &disc.Client{DelegatedServers: seedServerPKs},
+		})
 	}
 	dClient := direct.NewClient(entries, log)
 


### PR DESCRIPTION
A seeded dmsg client (browser tab / embedded edge) could reach the dmsg-discovery — its entry is preloaded, delegated to the seed servers — but **not** the non-registering **service** clients (route-finder, setup nodes, transport-discovery). Those run as direct clients and never *publish* to the discovery, so resolving them 404s ("entry is not found in discovery"), and a **multihop** `DialRoutes` fails at the route-finder POST. A 1-hop route to a directly-transported peer skips the route-finder, which masked this.

## Change
`StartDmsgSeeded` gains a variadic `servicePKs ...cipher.PubKey`; each is preloaded as a direct entry delegated to the seed servers — exactly as the discovery PK already is. The wasm-visor passes the deployment's route-finder, transport-discovery and route-setup-node PKs.

## Proven live
A browser wasm-visor's multihop fetch went from `route finder: ... entry is not found in discovery` (route-finder unreachable) to **reaching the route-finder and entering route setup**. The preload is the unblock.

Variadic → existing callers (`StartDmsgEmbedded`, `cmd/dmsg-wasm`) compile unchanged.