### PR TITLE
refactor(visor): shared visorcore.ResolveServices — converge wasm + native visor assembly

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -74,6 +74,7 @@ import (
 	"github.com/skycoin/skywire/pkg/transport/network/stcp"
 	"github.com/skycoin/skywire/pkg/transport/tpdclient"
 	types "github.com/skycoin/skywire/pkg/transport/types"
+	"github.com/skycoin/skywire/pkg/visor/visorcore"
 	"github.com/skycoin/skywire/pkg/wasmhv"
 )
 
@@ -178,6 +179,12 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	}
 	selfPK = pk
 
+	// Resolve the deployment service endpoints through the SHARED resolver
+	// (pkg/visor/visorcore) — the same one the native visor will use — so the two
+	// visors can't drift on config sourcing. nil V1 → pure deployment defaults
+	// (a browser edge has no operator config file).
+	svc := visorcore.ResolveServices(nil)
+
 	// Default the discovery to the deployment's dmsg-discovery when the caller
 	// didn't pass one. Without a discDmsgAddr, StartDmsgSeeded skips the discovery
 	// upgrade, so the client never installs the registering fallback and never
@@ -185,7 +192,7 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	// which dials the source's own @136 over dmsg). A browser edge always wants the
 	// deployment discovery; an explicit arg still overrides (e.g. a test discovery).
 	if discDmsgAddr == "" {
-		discDmsgAddr = deployment.Prod.DmsgDiscoveryDmsg
+		discDmsgAddr = svc.DmsgDiscoveryDmsg
 	}
 
 	mLog := logging.NewMasterLogger()
@@ -200,7 +207,7 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	// is on a SEPARATE port). Servers not yet serving main-port WS just fail to
 	// dial and are skipped (best-effort); the client settles on the reachable set.
 	seedsByPK := map[cipher.PubKey]*disc.Entry{}
-	for _, ds := range deployment.Prod.DmsgServers {
+	for _, ds := range svc.DmsgServers {
 		var spk cipher.PubKey
 		if ds.Server.Address == "" || spk.UnmarshalText([]byte(ds.Static)) != nil {
 			continue
@@ -227,13 +234,13 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	// to the dmsg-discovery, so without this a multihop DialRoutes (route-finder POST)
 	// 404s. dmsgURLPK errors are non-fatal here (a null PK is skipped downstream).
 	var servicePKs []cipher.PubKey
-	if rfPK, e := dmsgURLPK(deployment.Prod.RouteFinderDmsg); e == nil {
+	if rfPK, e := dmsgURLPK(svc.RouteFinderDmsg); e == nil {
 		servicePKs = append(servicePKs, rfPK)
 	}
-	if tpdSvcPK, e := dmsgURLPK(deployment.Prod.TransportDiscoveryDmsg); e == nil {
+	if tpdSvcPK, e := dmsgURLPK(svc.TransportDiscoveryDmsg); e == nil {
 		servicePKs = append(servicePKs, tpdSvcPK)
 	}
-	servicePKs = append(servicePKs, deployment.Prod.RouteSetupNodes...)
+	servicePKs = append(servicePKs, svc.RouteSetupNodes...)
 	c, _, err := dmsgclient.StartDmsgSeeded(ctx, mLog.PackageLogger("dmsg"), pk, sk, seeds, discDmsgAddr, true, servicePKs...)
 	if err != nil {
 		return pk, fmt.Errorf("dmsg: %w", err)
@@ -245,7 +252,7 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	// the tab's transport edges OVER DMSG (net/http-free), against the deployment's
 	// transport_discovery_dmsg endpoint — so peers' route-finders can find paths to
 	// the tab once it dials a visor↔visor transport.
-	tpdPK, perr := dmsgURLPK(deployment.Prod.TransportDiscoveryDmsg)
+	tpdPK, perr := dmsgURLPK(svc.TransportDiscoveryDmsg)
 	if perr != nil {
 		return pk, fmt.Errorf("tpd dmsg url: %w", perr)
 	}
@@ -259,7 +266,7 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	// WebRTC ICE servers: the deployment's own STUN (reused from sudph). The
 	// bare host:port entries need the stun: URL scheme the WebRTC stack expects.
 	var iceURLs []string
-	for _, s := range deployment.Prod.StunServers {
+	for _, s := range svc.StunServers {
 		iceURLs = append(iceURLs, "stun:"+s)
 	}
 	factory := network.ClientFactory{
@@ -316,9 +323,9 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	// (forceLegacy=true); no embedded route-setup node in a browser leaf. The
 	// std-Go build compiles the full route-source (the TinyGo stub does not apply).
 	rfHTTP := &http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC)}
-	rfClient := rfclient.NewHTTP(deployment.Prod.RouteFinderDmsg, 10*time.Second, rfHTTP, mLog)
+	rfClient := rfclient.NewHTTP(svc.RouteFinderDmsg, 10*time.Second, rfHTTP, mLog)
 	rgDialer := router.NewSetupNodeDialerFull(nil, router.NewRSNRelayCache(mLog.PackageLogger("router")), tm, true)
-	vlog(fmt.Sprintf("router: route origination wired (rf=%s, %d setup nodes)", deployment.Prod.RouteFinderDmsg, len(deployment.Prod.RouteSetupNodes)))
+	vlog(fmt.Sprintf("router: route origination wired (rf=%s, %d setup nodes)", svc.RouteFinderDmsg, len(svc.RouteSetupNodes)))
 
 	rConf := &router.Config{
 		Logger:             mLog.PackageLogger("router"),
@@ -329,7 +336,7 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 		AwaitSetupListener: setupLis,
 		RouteFinder:        rfClient,
 		RouteGroupDialer:   rgDialer,
-		SetupNodes:         deployment.Prod.RouteSetupNodes,
+		SetupNodes:         svc.RouteSetupNodes,
 		// MinHops must be >0 or the router treats routing as DISABLED
 		// (router_dial.go: "routing disabled. (minhop=0)"). 1 enables
 		// origination; a direct transport, when one exists, still downgrades to a

--- a/docs/visor-core-convergence.md
+++ b/docs/visor-core-convergence.md
@@ -1,0 +1,80 @@
+# Visor-core convergence: one assembly, two shells
+
+## Problem
+
+There are two implementations of "assemble a skywire visor from its subsystems":
+
+- **Native** — `pkg/visor`, a concurrent module DAG (`init.go` → `init_dmsg.go`,
+  `init_transport.go`, `init_router.go`, `init_apps.go`, …). Assumes a filesystem,
+  OS processes (app launcher, dmsgpty), an HTTP API server, system networking.
+- **Browser** — `cmd/wasm-visor` (`bootEdge`), a linear hand-assembly that bypasses
+  `pkg/visor` because `pkg/visor` cannot compile/run under js/wasm.
+
+Both build the **same subsystems** with the **same constructors and types**
+(`dmsgc.New`/`direct.StartDmsg`, `transport.NewManager`, `router.New`,
+`appserver.NewProcManager`), but via **divergent wiring code** and **divergent
+config sourcing**. That drift is not hypothetical: PR #3277 (a multi-session
+debugging effort) was caused by exactly this — the wasm dmsg setup served before
+installing the registering-fallback discovery, while the native path installs it
+before serving. Two assemblies of one subsystem drifted on an ordering invariant.
+
+## Goal
+
+A single, platform-neutral **`pkg/visor/visorcore`** package that holds the
+assembly logic. `pkg/visor` becomes "core + OS/server shell"; `cmd/wasm-visor`
+becomes "core + browser shell." Neither re-implements the core. Config flows
+through one resolver so it cannot diverge either.
+
+Feasibility confirmed: `visorconfig`, `pkg/transport`, `pkg/router`,
+`pkg/app/appserver`, and `deployment` **all compile under `GOOS=js GOARCH=wasm`**,
+so the core can use the real `visorconfig.V1` types.
+
+## What's shared vs platform-specific
+
+| Subsystem | Shared (→ visorcore) | Platform-specific (injected via deps) |
+|---|---|---|
+| dmsg client | NewClient → set transport → Serve → Ready → **register** (the #3277 invariant) | how the disc client is built: native = clearnet/dmsg HTTP over the full server list; browser = seeded WS + dmsg-HTTP upgrade |
+| transport mgr | `NewManager` + `ManagerConfig` + `Serve` | which `InitClient` network types run (native: STCP/STCPR/SUDPH/QUIC/DMSG; browser: WS/WT/WEBRTC dial-only) |
+| router | `router.New` + `router.Config` (RouteFinder, RouteGroupDialer, SetupNodes, MinHops, AwaitSetupListener) | route-source build tags; embedded RSN (native only) |
+| proc manager | `NewProcManager` | ServerAddr (native: TCP; browser: "" = net.Pipe), app launcher (native only) |
+| config | **`ResolveServices(v1) Services`** — the one place `pick(config, deployment-default)` lives | where the V1 comes from: native = file; browser = built from `deployment.Prod` |
+
+Native's config = `visorconfig.V1` (operator overrides) merged with
+`deployment.Prod.*` (embedded defaults) via scattered `pick()` calls across
+`init_*.go`. Browser reads `deployment.Prod.*` directly. Convergence = both go
+through `visorcore.ResolveServices`.
+
+## Incremental plan (each step a separate, independently-validated PR)
+
+1. **`visorcore.ResolveServices`** — a `Services` struct (resolved dmsg servers,
+   dmsg/clearnet disc URLs, TPD, route-finder, setup nodes, STUN, AR) + a resolver
+   that merges a (nullable) `*visorconfig.V1` with `deployment.Prod`. Adopt in
+   `cmd/wasm-visor` first (replace direct `deployment.Prod.*` reads). Low risk:
+   new package + one wasm consumer; validate the tab still boots/registers/fetches.
+2. **`visorcore.StartDmsg`** — the register-before-serve starter (NewClient →
+   `setTransport` hook → Serve → Ready). `StartDmsgSeeded` and `pkg/dmsgc` + 
+   `init_dmsg` both call it, so the #3277 ordering invariant lives in one place.
+3. **`visorcore.BuildTransportManager` / `BuildRouter` / `BuildProcManager`** —
+   extract the construction (not the platform-specific InitClient set). wasm-visor
+   adopts; then a native `visor_core` module delegates to them.
+4. **Native adoption** — migrate `pkg/visor` `init_*.go` `pick()` calls to
+   `ResolveServices`, and the construction to the `Build*` helpers, one module at a
+   time. `pkg/visor` is production-critical → smallest possible diffs, each tested.
+5. **Config alignment** — `cmd/wasm-visor` consumes a real (minimal) `visorconfig.V1`
+   instead of `deployment.Prod` directly, so both sides share the config shape.
+
+## Sequencing note
+
+This must land **before** the Angular HV UI → SPA work. The SPA needs a
+backend-abstraction layer (REST for native, in-tab JS for wasm); building it on a
+still-divergent visor would bake the divergence into the UI layer too. Converge
+the core first, align config, then unify the UI.
+
+## Risk / non-goals
+
+- NOT making all of `pkg/visor` compile under wasm (multi-month fight with OS
+  assumptions, little gain). Only the platform-neutral core is shared.
+- `visorcore` must stay lean: it may import `pkg/dmsg`, `pkg/transport`,
+  `pkg/router`, `pkg/app/appserver`, `deployment`, `visorconfig` — but NOT
+  `pkg/visor` (which pulls in launcher/dmsgpty/OS code), or the wasm build breaks.
+  A `GOOS=js GOARCH=wasm go build ./pkg/visor/visorcore/` gate enforces this.

--- a/pkg/visor/visorcore/services.go
+++ b/pkg/visor/visorcore/services.go
@@ -1,0 +1,103 @@
+// Package visorcore holds the platform-neutral visor assembly shared by the
+// native visor (pkg/visor) and the browser wasm-visor (cmd/wasm-visor), so the
+// two stop diverging on how a visor is wired from its subsystems. It must stay
+// LEAN — it may import pkg/dmsg, pkg/transport, pkg/router, pkg/app/appserver,
+// deployment and visorconfig, but NOT pkg/visor itself (which pulls in the OS
+// launcher / dmsgpty / HTTP-API code that does not compile under js/wasm). A
+// `GOOS=js GOARCH=wasm go build ./pkg/visor/visorcore/` gate enforces that.
+//
+// See docs/visor-core-convergence.md for the full design + incremental plan.
+package visorcore
+
+import (
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// Services is the resolved set of deployment service endpoints the subsystems
+// need, with both the dmsg-HTTP ("…Dmsg") and clearnet-HTTP variants. It is the
+// single shape both shells build their subsystems from — produced by exactly one
+// merge function (ResolveServices), so config sourcing cannot drift.
+type Services struct {
+	// dmsg
+	DmsgServers       []deployment.DmsgServerEntry // seed/embedded server set
+	DmsgDiscovery     string                       // clearnet dmsg-discovery (native)
+	DmsgDiscoveryDmsg string                       // dmsg://… dmsg-discovery (browser / dmsg-only)
+	// transport discovery
+	TransportDiscovery     string
+	TransportDiscoveryDmsg string
+	// address resolver
+	AddressResolver     string
+	AddressResolverDmsg string
+	// routing
+	RouteFinder     string
+	RouteFinderDmsg string
+	RouteSetupNodes []cipher.PubKey
+	MinHops         uint16
+	// misc
+	StunServers []string
+}
+
+func pick(override, fallback string) string {
+	if override != "" {
+		return override
+	}
+	return fallback
+}
+
+// ResolveServices merges an operator config (v1, nullable) over the embedded
+// deployment defaults (deployment.Prod) — the single place the
+// "operator-override-else-deployment-default" rule lives. The native visor's
+// scattered pick() calls across init_*.go collapse onto this; the browser visor
+// passes v1 == nil to get pure deployment defaults.
+//
+// MinHops defaults to 1 (origination enabled; a direct transport still downgrades
+// to a 0-intermediate-hop path) so an edge can SET UP routes; the router treats
+// MinHops==0 as "routing disabled".
+func ResolveServices(v1 *visorconfig.V1) Services {
+	d := deployment.Prod
+	s := Services{
+		DmsgServers:            d.DmsgServers,
+		DmsgDiscovery:          d.DmsgDiscovery,
+		DmsgDiscoveryDmsg:      d.DmsgDiscoveryDmsg,
+		TransportDiscovery:     d.TransportDiscovery,
+		TransportDiscoveryDmsg: d.TransportDiscoveryDmsg,
+		AddressResolver:        d.AddressResolver,
+		AddressResolverDmsg:    d.AddressResolverDmsg,
+		RouteFinder:            d.RouteFinder,
+		RouteFinderDmsg:        d.RouteFinderDmsg,
+		RouteSetupNodes:        d.RouteSetupNodes,
+		MinHops:                1,
+		StunServers:            d.StunServers,
+	}
+	if v1 == nil {
+		return s
+	}
+	if v1.Dmsg != nil {
+		s.DmsgDiscovery = pick(v1.Dmsg.Discovery, s.DmsgDiscovery)
+		s.DmsgDiscoveryDmsg = pick(v1.Dmsg.DiscoveryDmsg, s.DmsgDiscoveryDmsg)
+		// NOTE: a v1.Dmsg.Servers override (type-mapped to DmsgServerEntry) is a
+		// follow-up; the browser seeds from the deployment set today.
+	}
+	if v1.Transport != nil {
+		s.TransportDiscovery = pick(v1.Transport.Discovery, s.TransportDiscovery)
+		s.TransportDiscoveryDmsg = pick(v1.Transport.DiscoveryDmsg, s.TransportDiscoveryDmsg)
+		s.AddressResolver = pick(v1.Transport.AddressResolver, s.AddressResolver)
+		s.AddressResolverDmsg = pick(v1.Transport.AddressResolverDmsg, s.AddressResolverDmsg)
+	}
+	if v1.Routing != nil {
+		s.RouteFinder = pick(v1.Routing.RouteFinder, s.RouteFinder)
+		s.RouteFinderDmsg = pick(v1.Routing.RouteFinderDmsg, s.RouteFinderDmsg)
+		if len(v1.Routing.RouteSetupNodes) > 0 || len(v1.Routing.UserRouteSetupNodes) > 0 {
+			s.RouteSetupNodes = v1.EffectiveRouteSetupNodes()
+		}
+		if v1.Routing.MinHops > 0 {
+			s.MinHops = v1.Routing.MinHops
+		}
+	}
+	if len(v1.StunServers) > 0 {
+		s.StunServers = v1.StunServers
+	}
+	return s
+}

--- a/pkg/visor/visorcore/services_test.go
+++ b/pkg/visor/visorcore/services_test.go
@@ -1,0 +1,36 @@
+package visorcore
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/deployment"
+)
+
+// TestResolveServicesNilMatchesDeployment locks in that ResolveServices(nil)
+// returns exactly the deployment defaults — so the wasm-visor's switch from
+// reading deployment.Prod.* directly to svc.* is a behavior-preserving refactor.
+func TestResolveServicesNilMatchesDeployment(t *testing.T) {
+	s := ResolveServices(nil)
+	d := deployment.Prod
+	if s.DmsgDiscoveryDmsg != d.DmsgDiscoveryDmsg {
+		t.Errorf("DmsgDiscoveryDmsg = %q, want %q", s.DmsgDiscoveryDmsg, d.DmsgDiscoveryDmsg)
+	}
+	if s.TransportDiscoveryDmsg != d.TransportDiscoveryDmsg {
+		t.Errorf("TransportDiscoveryDmsg = %q, want %q", s.TransportDiscoveryDmsg, d.TransportDiscoveryDmsg)
+	}
+	if s.RouteFinderDmsg != d.RouteFinderDmsg {
+		t.Errorf("RouteFinderDmsg = %q, want %q", s.RouteFinderDmsg, d.RouteFinderDmsg)
+	}
+	if len(s.DmsgServers) != len(d.DmsgServers) {
+		t.Errorf("DmsgServers len = %d, want %d", len(s.DmsgServers), len(d.DmsgServers))
+	}
+	if len(s.RouteSetupNodes) != len(d.RouteSetupNodes) {
+		t.Errorf("RouteSetupNodes len = %d, want %d", len(s.RouteSetupNodes), len(d.RouteSetupNodes))
+	}
+	if len(s.StunServers) != len(d.StunServers) {
+		t.Errorf("StunServers len = %d, want %d", len(s.StunServers), len(d.StunServers))
+	}
+	if s.MinHops != 1 {
+		t.Errorf("MinHops = %d, want 1 (origination enabled)", s.MinHops)
+	}
+}


### PR DESCRIPTION
First step of converging the two divergent visor assemblies — native `pkg/visor` (a module DAG) and browser `cmd/wasm-visor` (`bootEdge`, which bypasses `pkg/visor` because it can't compile under js/wasm) — onto a shared, platform-neutral core. Full design + incremental plan in **`docs/visor-core-convergence.md`**.

That divergence is not hypothetical: **#3277** (a multi-session debugging effort) was caused by exactly it — the wasm dmsg setup served *before* installing the registering-fallback discovery, while the native path installs it *before* serving. Two assemblies of one subsystem drifted on an ordering invariant.

## This PR
Adds **`pkg/visor/visorcore`** — a lean package (compiles under `GOOS=js GOARCH=wasm`; must **not** import `pkg/visor`, enforced as a build gate) that will hold the assembly logic both shells share. The first piece is **config resolution**:

`ResolveServices(*visorconfig.V1) Services` merges an operator config over the embedded `deployment.Prod` defaults — the single place the *operator-override-else-deployment-default* rule lives. It replaces the native visor's scattered `pick()` calls (migrated in a later PR). The browser passes `nil` → pure deployment defaults.

`cmd/wasm-visor` adopts it: `bootEdge` resolves once and reads `svc.*` instead of `deployment.Prod.*` directly. A unit test pins `ResolveServices(nil) == deployment defaults`, so this is a **behavior-preserving** refactor. Native + js/wasm builds green; `visorcore` test green.

## Next (separate PRs)
- `visorcore.StartDmsg` — the register-before-serve invariant in one place (kills the #3277 bug class).
- `Build{TransportManager,Router,ProcManager}` extraction.
- Native `pkg/visor` adoption (migrate `pick()` → `ResolveServices`, construction → `Build*`), one module at a time.
- Then the Angular HV UI → SPA against a backend abstraction (must come after core convergence).