### PR TITLE
refactor(dmsg): share the register-before-serve invariant (direct.StartDmsgWithSetup)

### DIFF
--- a/pkg/dmsg/direct/direct.go
+++ b/pkg/dmsg/direct/direct.go
@@ -11,12 +11,36 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
-// StartDmsg starts dmsg directly without the discovery
+// StartDmsg starts dmsg directly without the discovery.
 func StartDmsg(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey,
 	dClient disc.APIClient, config *dmsg.Config) (dmsgDC *dmsg.Client, stop func(), err error) {
+	return StartDmsgWithSetup(ctx, log, pk, sk, dClient, config, nil)
+}
+
+// StartDmsgWithSetup builds the dmsg client, runs beforeServe (if non-nil) to
+// FINISH configuring it — installing the final discovery client and/or the
+// HTTP-over-dmsg transport — and only THEN serves and waits for Ready.
+//
+// Running setup BEFORE Serve is load-bearing, not cosmetic: the client's entry-
+// update (registration) loop starts during Serve, so a discovery client or
+// transport installed AFTER Serve misses the first registration tick and the
+// client can sit unregistered for minutes / forever. This is the shared
+// register-before-serve invariant — the native visor wires dmsg exactly this way
+// (pkg/visor/init_dmsg.go: NewClient(disc) → set transport → Serve), and the
+// seeded/edge path (dmsgclient.StartDmsgSeeded) regressed precisely by violating
+// it (serve-with-bare-client, upgrade-after) until #3277. Both now funnel through
+// here so they cannot drift on it again.
+func StartDmsgWithSetup(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey,
+	dClient disc.APIClient, config *dmsg.Config, beforeServe func(*dmsg.Client) error) (dmsgDC *dmsg.Client, stop func(), err error) {
 
 	dmsgDC = dmsg.NewClient(pk, sk, dClient, config)
 	dmsgDC.SetLogger(log)
+
+	if beforeServe != nil {
+		if err := beforeServe(dmsgDC); err != nil {
+			return nil, nil, err
+		}
+	}
 
 	wg := new(sync.WaitGroup)
 	wg.Add(1)

--- a/pkg/dmsg/dmsgclient/seeded.go
+++ b/pkg/dmsg/dmsgclient/seeded.go
@@ -4,7 +4,6 @@ package dmsgclient
 import (
 	"context"
 	"errors"
-	"sync"
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -96,56 +95,33 @@ func StartDmsgSeeded(ctx context.Context, log *logging.Logger, pk cipher.PubKey,
 	// discovery it would need to find another server). Capped at the known set.
 	conf.MinSessions = 2
 
-	// Build the dmsg client and install the registering-fallback discovery BEFORE
-	// serving — matching the native visor exactly (dmsgc.New → dmsg.NewClient(disc)
-	// → set transport → Serve, see pkg/visor/init_dmsg.go).
-	//
-	// This used to call direct.StartDmsg (NewClient(dClient) + Serve + wait Ready)
-	// and only THEN upgradeDiscovery. That two-phase ordering was the bug behind
-	// "a browser tab never registers in discovery": the entry-update loop starts
-	// during Serve, so its FIRST iteration ran against the bare direct client — a
-	// PutEntry that no-ops AND records a successful update, resetting the ~5-min
-	// update timer. By the time upgradeDiscovery swapped in the fallback, the loop
-	// was asleep, so the real (HTTP-over-dmsg) registration didn't fire for minutes
-	// and the tab stayed 404 in discovery — which also blocks route setup (it dials
-	// the source's own @136 over dmsg, needing the entry registered). The native
-	// visor never hit this because its fallback is live from the first serve tick.
-	dmsgC := dmsg.NewClient(pk, sk, dClient, conf)
-	dmsgC.SetLogger(log)
-
-	if discDmsgAddr != "" {
+	// Install the registering-fallback discovery BEFORE serving — the shared
+	// register-before-serve invariant (direct.StartDmsgWithSetup). The native visor
+	// wires dmsg the same way (dmsg.NewClient(disc) → set transport → Serve, see
+	// pkg/visor/init_dmsg.go). This path regressed by serving the bare direct client
+	// first and upgrading AFTER (#3277): the entry-update loop's first tick ran
+	// against the no-op direct client, recorded a "successful" update, and reset the
+	// ~5-min timer, so real registration didn't fire for minutes and the tab stayed
+	// 404 — which also blocks route setup (it dials the source's own @136 over dmsg,
+	// needing the entry registered). Funnelling through the shared helper keeps the
+	// two visors from drifting on the ordering again.
+	beforeServe := func(c *dmsg.Client) error {
+		if discDmsgAddr == "" {
+			return nil
+		}
 		// upgradeDiscovery is build-tagged: native backs the registering fallback
 		// with dmsghttp (net/http over the client's own sessions); TinyGo uses the
-		// net/http-free dmsgDiscClient (HTTP/1.1 straight over a dmsg stream). READS
-		// resolve direct-first (seed servers + discovery PK short-circuit, no
-		// HTTP-over-dmsg recursion); unknown peers + WRITES go to the real discovery,
-		// publishing our entry so we become inbound-reachable by PK. It only sets the
-		// disc client + builds the transport over dmsgC (no IO), so calling it before
-		// Serve is safe. On failure we degrade to seed-only rather than failing.
-		if err := upgradeDiscovery(ctx, log, dmsgC, dClient, seedServers, discDmsgAddr); err != nil {
+		// net/http-free dmsgDiscClient (HTTP/1.1 over a dmsg stream). READS resolve
+		// direct-first (seed servers + discovery PK short-circuit, no HTTP-over-dmsg
+		// recursion); unknown peers + WRITES go to the real discovery, publishing our
+		// entry so we become inbound-reachable by PK. On failure we degrade to
+		// seed-only (dialable but can't resolve new peers) — never fatal.
+		if err := upgradeDiscovery(ctx, log, c, dClient, seedServers, discDmsgAddr); err != nil {
 			log.WithError(err).Warn("dmsg: discovery upgrade failed; continuing seed-only (dialable but can't resolve new peers)")
 		}
+		return nil
 	}
-
-	wg := new(sync.WaitGroup)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		dmsgC.Serve(ctx)
-	}()
-	stop := func() {
-		err := dmsgC.Close()
-		log.WithError(err).Debug("Disconnected from dmsg network.")
-		wg.Wait()
-	}
-
-	select {
-	case <-ctx.Done():
-		stop()
-		return nil, nil, ctx.Err()
-	case <-dmsgC.Ready():
-		return dmsgC, stop, nil
-	}
+	return direct.StartDmsgWithSetup(ctx, log, pk, sk, dClient, conf, beforeServe)
 }
 
 // StartDmsgEmbedded starts a dmsg client seeded from the embedded production


### PR DESCRIPTION
Step 2 of the visor-core convergence (`docs/visor-core-convergence.md`): put the **register-before-serve** dmsg-startup invariant in **one place** so the seeded/edge path and the native path can't drift on it again — the exact bug class behind #3277.

## Change
`direct.StartDmsgWithSetup(…, beforeServe func(*dmsg.Client) error)` does `NewClient(disc)` → **`beforeServe`** (install the *final* discovery client / HTTP-over-dmsg transport) → `Serve` → `Ready`. Running setup **before** `Serve` is load-bearing: the entry-update (registration) loop starts during `Serve`, so a disc client/transport installed *after* `Serve` misses the first registration tick and the client can sit unregistered for minutes.

`direct.StartDmsg` is now a thin wrapper (`beforeServe=nil`), so its ~11 existing callers are untouched.

`StartDmsgSeeded` funnels through the helper (`beforeServe = upgradeDiscovery`), replacing the inline `NewClient`+serve+ready it has carried since #3277. The native visor already wires dmsg this way (`init_dmsg.go`: `NewClient(fallback)` → set transport → `Serve`) and can adopt the helper next.

## Verified
- `StartDmsgEmbedded` (the seeded path, native TCP) self-registers at **t+4s**.
- Full repo + `js/wasm` builds green; `direct` + `dmsgclient` tests pass.