### PR TITLE
refactor(visor): native dmsgServicePKs uses visorcore.ResolveServices

### DIFF
--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -42,6 +42,7 @@ import (
 	"github.com/skycoin/skywire/pkg/visor/dmsgtracker"
 	"github.com/skycoin/skywire/pkg/visor/logserver"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+	"github.com/skycoin/skywire/pkg/visor/visorcore"
 )
 
 func initDmsgHTTP(ctx context.Context, v *Visor, _ *logging.Logger) error {
@@ -436,28 +437,21 @@ func (v *Visor) refreshDmsgServersCacheLoop(ctx context.Context, discURL string,
 // so DialStream for e.g. TPD hit the HTTP discovery, found no entry (TPD
 // is direct-client by design), and bailed with "entry not found".
 func (v *Visor) dmsgServicePKs() cipher.PubKeys {
-	pick := func(a, b string) string {
-		if a != "" {
-			return a
-		}
-		return b
-	}
+	// Resolve the deployment service endpoints through the SHARED resolver
+	// (pkg/visor/visorcore) — the same one the browser wasm-visor uses — so the two
+	// visors can't drift on the operator-override-else-deployment-default rule. This
+	// replaced six inline pick() calls; ResolveServices applies identical semantics
+	// (and handles the nullable UptimeTracker/Launcher blocks).
+	svc := visorcore.ResolveServices(v.conf)
 	dmsgURLs := []string{
-		pick(v.conf.Dmsg.DiscoveryDmsg, deployment.Prod.DmsgDiscoveryDmsg),
-		pick(v.conf.Transport.DiscoveryDmsg, deployment.Prod.TransportDiscoveryDmsg),
-		pick(v.conf.Transport.AddressResolverDmsg, deployment.Prod.AddressResolverDmsg),
-		pick(v.conf.Routing.RouteFinderDmsg, deployment.Prod.RouteFinderDmsg),
-		pick(v.conf.Launcher.ServiceDiscDmsg, deployment.Prod.ServiceDiscoveryDmsg),
-		pick(v.conf.ConfServiceDmsg, deployment.Prod.ConfDmsg),
+		svc.DmsgDiscoveryDmsg,
+		svc.TransportDiscoveryDmsg,
+		svc.AddressResolverDmsg,
+		svc.RouteFinderDmsg,
+		svc.ServiceDiscoveryDmsg,
+		svc.ConfDmsg,
+		svc.UptimeTrackerDmsg,
 	}
-	// UptimeTracker is the only nullable sub-config; treat a nil block
-	// the same as an empty AddrDmsg field and fall through to the embedded
-	// default so we still seed UT's PK on minimal configs.
-	utDmsg := deployment.Prod.UptimeTrackerDmsg
-	if v.conf.UptimeTracker != nil {
-		utDmsg = pick(v.conf.UptimeTracker.AddrDmsg, utDmsg)
-	}
-	dmsgURLs = append(dmsgURLs, utDmsg)
 	var pks cipher.PubKeys
 	for _, rawURL := range dmsgURLs {
 		if rawURL == "" {

--- a/pkg/visor/visorcore/services.go
+++ b/pkg/visor/visorcore/services.go
@@ -35,6 +35,15 @@ type Services struct {
 	RouteFinderDmsg string
 	RouteSetupNodes []cipher.PubKey
 	MinHops         uint16
+	// service discovery
+	ServiceDiscovery     string
+	ServiceDiscoveryDmsg string
+	// config-bootstrap service
+	Conf     string
+	ConfDmsg string
+	// uptime tracker
+	UptimeTracker     string
+	UptimeTrackerDmsg string
 	// misc
 	StunServers []string
 }
@@ -69,7 +78,14 @@ func ResolveServices(v1 *visorconfig.V1) Services {
 		RouteFinderDmsg:        d.RouteFinderDmsg,
 		RouteSetupNodes:        d.RouteSetupNodes,
 		MinHops:                1,
-		StunServers:            d.StunServers,
+		ServiceDiscovery:       d.ServiceDiscovery,
+		ServiceDiscoveryDmsg:   d.ServiceDiscoveryDmsg,
+		// Conf has no clearnet deployment default (deployment is dmsg-only for the
+		// config-bootstrap service); a v1.ConfService override below still applies.
+		ConfDmsg:          d.ConfDmsg,
+		UptimeTracker:     d.UptimeTracker,
+		UptimeTrackerDmsg: d.UptimeTrackerDmsg,
+		StunServers:       d.StunServers,
 	}
 	if v1 == nil {
 		return s
@@ -95,6 +111,16 @@ func ResolveServices(v1 *visorconfig.V1) Services {
 		if v1.Routing.MinHops > 0 {
 			s.MinHops = v1.Routing.MinHops
 		}
+	}
+	if v1.Launcher != nil {
+		s.ServiceDiscovery = pick(v1.Launcher.ServiceDisc, s.ServiceDiscovery)
+		s.ServiceDiscoveryDmsg = pick(v1.Launcher.ServiceDiscDmsg, s.ServiceDiscoveryDmsg)
+	}
+	s.Conf = pick(v1.ConfService, s.Conf)
+	s.ConfDmsg = pick(v1.ConfServiceDmsg, s.ConfDmsg)
+	if v1.UptimeTracker != nil {
+		s.UptimeTracker = pick(v1.UptimeTracker.Addr, s.UptimeTracker)
+		s.UptimeTrackerDmsg = pick(v1.UptimeTracker.AddrDmsg, s.UptimeTrackerDmsg)
 	}
 	if len(v1.StunServers) > 0 {
 		s.StunServers = v1.StunServers

--- a/pkg/visor/visorcore/services_test.go
+++ b/pkg/visor/visorcore/services_test.go
@@ -33,4 +33,19 @@ func TestResolveServicesNilMatchesDeployment(t *testing.T) {
 	if s.MinHops != 1 {
 		t.Errorf("MinHops = %d, want 1 (origination enabled)", s.MinHops)
 	}
+	// The dmsg service URLs the native visor preloads (dmsgServicePKs) must each
+	// match the deployment default for a nil config.
+	for _, c := range []struct {
+		name, got, want string
+	}{
+		{"TransportDiscoveryDmsg", s.TransportDiscoveryDmsg, d.TransportDiscoveryDmsg},
+		{"AddressResolverDmsg", s.AddressResolverDmsg, d.AddressResolverDmsg},
+		{"ServiceDiscoveryDmsg", s.ServiceDiscoveryDmsg, d.ServiceDiscoveryDmsg},
+		{"ConfDmsg", s.ConfDmsg, d.ConfDmsg},
+		{"UptimeTrackerDmsg", s.UptimeTrackerDmsg, d.UptimeTrackerDmsg},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
+		}
+	}
 }


### PR DESCRIPTION
Step 4 of the visor-core convergence (`docs/visor-core-convergence.md`): the **native** visor now sources its deployment service endpoints through the **same resolver** as the browser wasm-visor (#3278), so the two can't drift on the *operator-override-else-deployment-default* rule.

## Change
- Expands `visorcore.Services`/`ResolveServices` to cover the remaining deployment services the native visor preloads: service-discovery, config-bootstrap, uptime-tracker (clearnet + dmsg variants), handling the nullable `Launcher`/`UptimeTracker` blocks.
- `init_dmsg.go`'s `dmsgServicePKs()` drops its six inline `pick()` calls for `svc.*`. `ResolveServices` applies identical semantics, so this is **behavior-preserving**.
- Unit test pins each dmsg service URL == deployment default for a nil config.

## Validated live on the running visor
Rebuilt the local visor from this branch: boots clean, **registered in discovery**, uptime tracker healthy, **7 transports** (TPD reachable via the preloaded PK), 5 apps listed, no service-reach errors. The preloaded service PKs resolve exactly as before.