### PR TITLE
refactor(visor): route remaining service-URL reads through visorcore.ResolveServices

### DIFF
--- a/pkg/visor/api_ping.go
+++ b/pkg/visor/api_ping.go
@@ -14,13 +14,13 @@ import (
 
 	"golang.org/x/net/proxy"
 
-	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/visor/visorcore"
 )
 
 // DialPing implements API.
@@ -658,7 +658,7 @@ func (v *Visor) TestProxy(conf ProxyTestConfig) ([]ProxyTestResult, error) {
 
 	// Set defaults
 	if conf.TestURL == "" {
-		conf.TestURL = deployment.Prod.GeoIP
+		conf.TestURL = visorcore.ResolveServices(v.conf).GeoIP
 	}
 	if conf.Timeout == 0 {
 		conf.Timeout = 30 * time.Second

--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -24,6 +24,7 @@ import (
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+	"github.com/skycoin/skywire/pkg/visor/visorcore"
 )
 
 // ServiceHealth checks the health of all configured deployment services.
@@ -171,10 +172,7 @@ func (v *Visor) confServiceHTTP() string {
 }
 
 func (v *Visor) confServiceDmsg() string {
-	if v.conf.ConfServiceDmsg != "" {
-		return v.conf.ConfServiceDmsg
-	}
-	return deployment.Prod.ConfDmsg
+	return visorcore.ResolveServices(v.conf).ConfDmsg
 }
 
 // dmsgServerHealth returns one ServiceHealthEntry per DMSG server the

--- a/pkg/visor/config_refresh.go
+++ b/pkg/visor/config_refresh.go
@@ -13,6 +13,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+	"github.com/skycoin/skywire/pkg/visor/visorcore"
 )
 
 const configRefreshInterval = 1 * time.Hour
@@ -91,10 +92,10 @@ func (v *Visor) refreshKeySets(ctx context.Context, log *logging.Logger) {
 
 func (v *Visor) fetchServicesConfig(ctx context.Context, log *logging.Logger) *visorconfig.Services {
 	// Prefer URLs from visor config; fall back to embedded deployment defaults.
-	confDmsg := v.conf.ConfServiceDmsg
-	if confDmsg == "" {
-		confDmsg = deployment.Prod.ConfDmsg
-	}
+	// confDmsg goes through the shared resolver (same pick); confHTTP keeps its
+	// own deployment.ProdConf.Conf fallback (a separate clearnet-config var not in
+	// the resolver).
+	confDmsg := visorcore.ResolveServices(v.conf).ConfDmsg
 	confHTTP := v.conf.ConfService
 	if confHTTP == "" {
 		confHTTP = deployment.ProdConf.Conf

--- a/pkg/visor/visorcore/services.go
+++ b/pkg/visor/visorcore/services.go
@@ -46,6 +46,7 @@ type Services struct {
 	UptimeTrackerDmsg string
 	// misc
 	StunServers []string
+	GeoIP       string // HTTP-only (dmsg doesn't preserve client IP); no config override
 }
 
 func pick(override, fallback string) string {
@@ -86,6 +87,7 @@ func ResolveServices(v1 *visorconfig.V1) Services {
 		UptimeTracker:     d.UptimeTracker,
 		UptimeTrackerDmsg: d.UptimeTrackerDmsg,
 		StunServers:       d.StunServers,
+		GeoIP:             d.GeoIP,
 	}
 	if v1 == nil {
 		return s


### PR DESCRIPTION
Finishes centralizing the native visor's deployment service-URL sourcing onto the shared `visorcore.ResolveServices` resolver. Migrates three sites that already did the exact `pick(config, deployment-default)` inline:
- `confServiceDmsg()` (api_services.go) → `svc.ConfDmsg`
- `fetchServicesConfig()` confDmsg (config_refresh.go) → `svc.ConfDmsg`
- `TestProxy` default test URL (api_ping.go) → `svc.GeoIP` (adds `GeoIP` to `Services`)

Each is a behavior-preserving substitution of the same merge. `confServiceHTTP`/`confHTTP` keep their `deployment.ProdConf.Conf` fallback (a separate clearnet-config var not in the resolver); the reward-system 3-way pick is left as-is.

**Validated live:** rebuilt the running visor from this branch → healthy, uptime tracker healthy, 58 transports, registered. Full repo + js/wasm builds green; `visorcore` test pins `GeoIP`/`ConfDmsg` == deployment default for a nil config.