### PR TITLE
refactor(visor): shared visorcore.BuildRouter — converge router construction

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -327,34 +327,29 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	rgDialer := router.NewSetupNodeDialerFull(nil, router.NewRSNRelayCache(mLog.PackageLogger("router")), tm, true)
 	vlog(fmt.Sprintf("router: route origination wired (rf=%s, %d setup nodes)", svc.RouteFinderDmsg, len(svc.RouteSetupNodes)))
 
-	rConf := &router.Config{
-		Logger:             mLog.PackageLogger("router"),
-		MasterLogger:       mLog,
+	// Assemble + serve the router through the shared visorcore.BuildRouter so the
+	// edge and the native visor can't drift on the router.Config field mapping
+	// (e.g. the MinHops==0 ⇒ "routing disabled" gotcha) or the Serve pattern.
+	// svc.MinHops is 1 (origination enabled; a direct transport still downgrades to
+	// a 0-intermediate-hop path).
+	vlog("router: New + serve…")
+	r, err := visorcore.BuildRouter(ctx, visorcore.RouterDeps{
+		DmsgC:              dmsgC,
 		PubKey:             pk,
 		SecKey:             sk,
 		TransportManager:   tm,
-		AwaitSetupListener: setupLis,
 		RouteFinder:        rfClient,
 		RouteGroupDialer:   rgDialer,
 		SetupNodes:         svc.RouteSetupNodes,
-		// MinHops must be >0 or the router treats routing as DISABLED
-		// (router_dial.go: "routing disabled. (minhop=0)"). 1 enables
-		// origination; a direct transport, when one exists, still downgrades to a
-		// 0-intermediate-hop path.
-		MinHops: 1,
-	}
-	vlog("router: New…")
-	r, err := router.New(dmsgC, rConf, nil)
+		MinHops:            svc.MinHops,
+		AwaitSetupListener: setupLis,
+		Logger:             mLog.PackageLogger("router"),
+		MasterLogger:       mLog,
+	})
 	if err != nil {
 		return pk, fmt.Errorf("router: %w", err)
 	}
 	rtr = r
-	vlog("router: New ok; serving…")
-	go func() {
-		if err := r.Serve(ctx); err != nil {
-			mLog.PackageLogger("router").WithError(err).Error("router.Serve returned")
-		}
-	}()
 	vlog("router: serving")
 
 	vlog("router: serving — EDGE up (dmsg + transport + router)")

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -21,6 +21,7 @@ import (
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/transport"
 	types "github.com/skycoin/skywire/pkg/transport/types"
+	"github.com/skycoin/skywire/pkg/visor/visorcore"
 )
 
 // getRouteSetupHooks aka autotransport
@@ -158,29 +159,18 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 		log.WithField("order", v.conf.Routing.TransportPreference).Info("Applied configured transport preference order")
 	}
 
-	rConf := router.Config{
-		Logger:             logger,
-		MasterLogger:       v.MasterLogger(),
-		PubKey:             v.conf.PK,
-		SecKey:             v.conf.SK,
-		TransportManager:   v.tpM,
-		RouteFinder:        rfClient,
-		RouteGroupDialer:   rgDialer,
-		SetupNodes:         v.conf.EffectiveRouteSetupNodes(),
-		RulesGCInterval:    0, // 0 = DefaultRulesGCInterval (10s)
-		MinHops:            v.conf.Routing.MinHops,
-		AwaitSetupListener: v.awaitSetupListener,
-		// Tag rg-scoped log entries with the originating app's name so
-		// 'cli proxy start --verbose' can scope to a session. Resolved
-		// lazily via the proc manager — the manager owns the port↔app
-		// mapping and is the only authoritative source.
-		AppLookup: func(p routing.Port) (string, bool) {
-			if v.procM == nil {
-				return "", false
-			}
-			return v.procM.AppByPort(p)
-		},
+	// Tag rg-scoped log entries with the originating app's name so
+	// 'cli proxy start --verbose' can scope to a session. Resolved lazily via
+	// the proc manager — the manager owns the port↔app mapping.
+	appLookup := func(p routing.Port) (string, bool) {
+		if v.procM == nil {
+			return "", false
+		}
+		return v.procM.AppByPort(p)
 	}
+	// dialHook is set by the routing-policy block below (nil = no policy = a
+	// zero-cost dial path). Threaded into visorcore.BuildRouter as Config.DialHook.
+	var dialHook router.DialHook
 
 	// Operator-programmable routing policy (RFC #2882).
 	// When conf.Routing.PolicyPerDial is set, build a Loader,
@@ -251,21 +241,36 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 			}
 		}
 
-		rConf.DialHook = hook
+		dialHook = hook
 	}
 
 	routeSetupHooks := getRouteSetupHooks(ctx, v, log)
 
-	r, err := router.New(v.dmsgC, &rConf, routeSetupHooks)
-	if err != nil {
-		err := fmt.Errorf("failed to create router: %w", err)
-		return err
-	}
-
+	// Assemble + serve the router through the shared visorcore.BuildRouter so the
+	// native visor and the wasm edge can't drift on the router.Config field mapping
+	// or the Serve pattern. Native-only inputs (DialHook, AppLookup, SetupHooks) are
+	// threaded through; the edge passes their zero values.
 	serveCtx, cancel := context.WithCancel(context.Background())
-	if err := r.Serve(serveCtx); err != nil {
+	r, err := visorcore.BuildRouter(serveCtx, visorcore.RouterDeps{
+		DmsgC:              v.dmsgC,
+		PubKey:             v.conf.PK,
+		SecKey:             v.conf.SK,
+		TransportManager:   v.tpM,
+		RouteFinder:        rfClient,
+		RouteGroupDialer:   rgDialer,
+		SetupNodes:         v.conf.EffectiveRouteSetupNodes(),
+		MinHops:            v.conf.Routing.MinHops,
+		AwaitSetupListener: v.awaitSetupListener,
+		Logger:             logger,
+		MasterLogger:       v.MasterLogger(),
+		AppLookup:          appLookup,
+		DialHook:           dialHook,
+		RulesGCInterval:    0, // 0 = DefaultRulesGCInterval (10s)
+		SetupHooks:         routeSetupHooks,
+	})
+	if err != nil {
 		cancel()
-		return err
+		return fmt.Errorf("failed to create router: %w", err)
 	}
 
 	v.pushCloseStack("router.serve", func() error {

--- a/pkg/visor/visorcore/router.go
+++ b/pkg/visor/visorcore/router.go
@@ -1,0 +1,75 @@
+package visorcore
+
+import (
+	"context"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/rfclient"
+	"github.com/skycoin/skywire/pkg/router"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// RouterDeps is the platform-neutral input to BuildRouter: the router.Config
+// fields plus the dmsg client and setup hooks. The caller builds the platform-
+// specific pieces (the route-finder client over its own HTTP/dmsg transport, the
+// setup-node dialer with or without an embedded RSN, and — native only — the
+// routing-policy DialHook / AppLookup / setup hooks); BuildRouter owns the
+// Config field mapping + New + Serve so the two visors can't drift on it.
+//
+// Zero values for the optional native-only fields (AppLookup, DialHook,
+// RulesGCInterval, SetupHooks) are correct for a browser edge.
+type RouterDeps struct {
+	DmsgC              *dmsg.Client
+	PubKey             cipher.PubKey
+	SecKey             cipher.SecKey
+	TransportManager   *transport.Manager
+	RouteFinder        rfclient.Client
+	RouteGroupDialer   router.RouteGroupDialer
+	SetupNodes         []cipher.PubKey
+	MinHops            uint16
+	AwaitSetupListener *dmsg.Listener
+	Logger             *logging.Logger
+	MasterLogger       *logging.MasterLogger
+
+	AppLookup       func(routing.Port) (string, bool)
+	DialHook        router.DialHook
+	RulesGCInterval time.Duration
+	SetupHooks      []router.RouteSetupHook
+}
+
+// BuildRouter assembles router.Config from deps, creates the router, and starts
+// it serving under serveCtx. router.Serve starts its goroutines and returns
+// immediately, so its error is checked synchronously here — the browser edge
+// previously fired it in a `go r.Serve(ctx)` goroutine that discarded the error.
+// One place owns the Config field mapping + New + Serve, so the native visor and
+// the wasm edge cannot drift on it (e.g. the MinHops==0 ⇒ "routing disabled"
+// gotcha, or a newly-added Config field reaching only one of the two).
+func BuildRouter(serveCtx context.Context, deps RouterDeps) (router.Router, error) {
+	rConf := &router.Config{
+		Logger:             deps.Logger,
+		MasterLogger:       deps.MasterLogger,
+		PubKey:             deps.PubKey,
+		SecKey:             deps.SecKey,
+		TransportManager:   deps.TransportManager,
+		RouteFinder:        deps.RouteFinder,
+		RouteGroupDialer:   deps.RouteGroupDialer,
+		SetupNodes:         deps.SetupNodes,
+		MinHops:            deps.MinHops,
+		AwaitSetupListener: deps.AwaitSetupListener,
+		AppLookup:          deps.AppLookup,
+		DialHook:           deps.DialHook,
+		RulesGCInterval:    deps.RulesGCInterval,
+	}
+	r, err := router.New(deps.DmsgC, rConf, deps.SetupHooks)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.Serve(serveCtx); err != nil {
+		return nil, err
+	}
+	return r, nil
+}


### PR DESCRIPTION
Construction convergence: both the native visor (`init_router`) and the browser wasm-visor (`bootEdge`) now assemble + serve the router through one **`visorcore.BuildRouter`**. It owns the `router.Config` field mapping + `router.New` + `Serve`, so the two can't drift on it — e.g. the `MinHops==0 ⇒ "routing disabled"` gotcha, or a newly-added `Config` field reaching only one of the two.

Also unifies the **Serve pattern**: `router.Serve` starts its goroutines and returns immediately, so it's error-checked synchronously. The edge previously fired it in a `go r.Serve(ctx)` goroutine that **discarded the error** — now fixed.

Platform-specific inputs (route-finder client, setup-node dialer, and native-only `DialHook` / `AppLookup` / `RouteSetupHooks`) are built by each caller and passed via `RouterDeps`; the edge passes their zero values. `visorcore` stays lean — `router` + `rfclient` are wasm-safe, the `GOOS=js` build gate holds.

## Validated live on the running visor
Rebuilt from this branch → healthy, transports forming, and **route origination works**: `cli visor ping <public-exit>` → `Route setup: 11025 ms | Ping 1: 1668 ms`. The router serves *and* sets up routes through the shared helper. Native + js/wasm + full repo builds green.