### PR TITLE
fix(cli): hv serve renders the wasm-visor (boot + lazy chunks)

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -2,8 +2,10 @@
 package clihv
 
 import (
+	"io/fs"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -13,35 +15,29 @@ import (
 	"github.com/skycoin/skywire/pkg/wasmhv/wasmbin"
 )
 
-var (
-	serveAddr   string
-	serveSeedPK string
-	serveSeedWS string
-	serveDisc   string
-)
+var serveAddr string
 
 func init() {
 	serveCmd.Flags().StringVarP(&serveAddr, "addr", "a", ":7999", "HTTP listen address")
-	serveCmd.Flags().StringVar(&serveSeedPK, "seed-pk", "", "seed dmsg server PK the browser connects to first")
-	serveCmd.Flags().StringVar(&serveSeedWS, "seed-ws", "", "seed dmsg server ws:// URL")
-	serveCmd.Flags().StringVar(&serveDisc, "disc", "", "dmsg discovery (dmsg://<pk>:80)")
 	RootCmd.AddCommand(serveCmd)
 }
 
 var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Serve the standalone wasm-visor over HTTP (keyless; reverse-proxy with Caddy)",
-	Long: `Serve the keyless standalone wasm-VISOR as a single self-contained page over HTTP.
+	Long: `Serve the keyless standalone wasm-VISOR over HTTP.
 
-The page is built ONCE at startup from THIS binary's embedded wasm-visor + hypervisor
-UI, so it always reflects the running skywire version. Restart the process to serve a
-newer build — e.g. wire this to a systemd service that restarts on auto-update, and put
-Caddy (or any reverse proxy) in front of it on a subdomain.
+Serves the hypervisor UI + the embedded wasm-visor + hv-boot.js as separate files
+(NOT the single-file 'hv gen' output — that inlines override.js and can't serve
+Angular's lazy-loaded chunks). hv-boot.js boots the in-tab visor and the Angular
+SkywireHttpBackend routes /api to it. Everything is built from THIS binary's
+embedded wasm + UI, so the served build reflects the running skywire version —
+restart the process after an update (e.g. wire it to a systemd service that
+restarts on auto-update) and put a reverse proxy (Caddy) in front on a subdomain.
 
-Keyless: no key is baked in; each visitor's browser mints + persists its own ephemeral
-key (localStorage). That is what makes serving from a domain safe — the page never asks
-anyone to type a secret key. (For a key-bearing or viewer build, use 'hv gen' and open
-it from file://; never serve a key-bearing build from a domain.)`,
+Keyless: no key is baked in; each visitor's browser mints + persists its own
+ephemeral key (localStorage). That is what makes serving from a domain safe — the
+page never asks anyone to type a secret key.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		if !wasmbin.Embedded() {
 			cmd.PrintErrln("no embedded wasm-visor: rebuild skywire after `make embed-wasm-visor`")
@@ -57,32 +53,42 @@ it from file://; never serve a key-bearing build from a domain.)`,
 			cmd.PrintErrln("hypervisor UI assets:", err)
 			os.Exit(1)
 		}
-		// Keyless standalone wasm-VISOR: visors run in the tab; each visitor's
-		// browser mints its own ephemeral key. Uses the embedded std-Go wasm-visor
-		// (Go's wasm_exec.js, also embedded).
-		cfg := wasmhv.StandaloneConfig{
-			Visor:      true,
-			Standalone: true,
-			SeedPK:     serveSeedPK,
-			SeedWS:     serveSeedWS,
-			Disc:       serveDisc,
-		}
-		html, err := wasmhv.GenerateStandalone(uiFS, wasmhv.WasmExecJS, wasm, wasmhv.OverrideJS, cfg)
+		indexB, err := fs.ReadFile(uiFS, "index.html")
 		if err != nil {
-			cmd.PrintErrln("generate:", err)
+			cmd.PrintErrln("read index.html:", err)
 			os.Exit(1)
 		}
+		index := injectBoot(indexB)
 
-		// Single self-contained page: serve the same bytes for every path (the SPA
-		// router runs client-side; there are no separate asset requests).
 		mux := http.NewServeMux()
-		mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.Header().Set("Cache-Control", "public, max-age=300")
-			_, _ = w.Write(html) //nolint:errcheck // best-effort write to the client
+		serveBytes := func(path, ct string, body []byte) {
+			mux.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", ct)
+				w.Header().Set("Cache-Control", "public, max-age=300")
+				_, _ = w.Write(body) //nolint:errcheck // best-effort write to the client
+			})
+		}
+		// The wasm-visor bootstrap files hv-boot.js fetches by name (resolved against
+		// <base href="/">). These are NOT in the Angular FS, so serve them explicitly.
+		serveBytes("/wasm-visor.wasm", "application/wasm", wasm)
+		serveBytes("/wasm_exec.js", "text/javascript", wasmhv.WasmExecJS)
+		serveBytes("/hv-boot.js", "text/javascript", wasmhv.HvBootJS)
+
+		// Everything else is the built Angular UI (incl. lazy chunks, css, fonts,
+		// assets). Routing is hash-based (#/...), so the server only ever sees "/"
+		// plus real asset paths — no SPA rewrite needed.
+		fileServer := http.FileServer(http.FS(uiFS))
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/" || r.URL.Path == "/index.html" {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.Header().Set("Cache-Control", "no-cache")
+				_, _ = w.Write(index) //nolint:errcheck // best-effort write to the client
+				return
+			}
+			fileServer.ServeHTTP(w, r)
 		})
 
-		cmd.Printf("serving standalone wasm-visor (%d bytes) on %s — reverse-proxy this with Caddy\n", len(html), serveAddr)
+		cmd.Printf("serving standalone wasm-visor (ui + %d-byte wasm + hv-boot) on %s — reverse-proxy this with Caddy\n", len(wasm), serveAddr)
 		srv := &http.Server{
 			Addr:              serveAddr,
 			Handler:           mux,
@@ -93,4 +99,20 @@ it from file://; never serve a key-bearing build from a domain.)`,
 			os.Exit(1)
 		}
 	},
+}
+
+// injectBoot inserts the hv-boot.js bootstrap as a classic <script> right after
+// <head>, so it runs before Angular's deferred module scripts — CFG.visor is set
+// and boot() starts (CFG.ready) before SkywireHttpBackend's first /api call.
+func injectBoot(index []byte) []byte {
+	s := string(index)
+	tag := "\n<script src=\"hv-boot.js\"></script>\n"
+	lower := strings.ToLower(s)
+	if i := strings.Index(lower, "<head"); i >= 0 {
+		if j := strings.IndexByte(s[i:], '>'); j >= 0 {
+			pos := i + j + 1
+			return []byte(s[:pos] + tag + s[pos:])
+		}
+	}
+	return []byte(tag + s)
 }

--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -19,6 +19,17 @@ var OverrideJS []byte
 //go:embed browse.js
 var BrowseJS []byte
 
+// HvBootJS is pkg/wasmhv/hv-boot.js — the clean boot bootstrap for serving the
+// wasm-VISOR hypervisor UI as separate files (the `hv serve` / dev-harness model,
+// as opposed to the single-file generator's inlined override.js). It sets
+// CFG.visor, loads wasm_exec.js + wasm-visor.wasm, calls skywireVisor.boot(), and
+// exposes the boot promise as CFG.ready — which the UI's SkywireHttpBackend awaits
+// before its first /api call. Routing is owned by the Angular HttpBackend, so no
+// fetch/XHR monkey-patch (unlike override.js).
+//
+//go:embed hv-boot.js
+var HvBootJS []byte
+
 // WasmExecJS is Go's lib/wasm/wasm_exec.js, vendored here so a generated file is
 // self-contained. It MUST match the Go toolchain that built the embedded/passed
 // dmsg.wasm — refresh it with the wasm build (the Makefile bundle target copies


### PR DESCRIPTION
The first `hv serve` (#3287) reused the single-file generator output, which is broken against the post-#3285 UI:
- inlines the old `override.js` and never calls `skywireVisor.boot()` → UI errors **"Hypervisor not serving; boot() first"**
- can't serve Angular's lazy-loaded chunks (`473.js`, …) / fonts — fetched by URL at runtime; the catch-all returned `index.html` → MIME/OTS errors

Fix: `hv serve` now serves the embedded UI files + embedded wasm-visor + `wasm_exec.js` + `hv-boot.js` (the proven harness model). `hv-boot.js` boots the in-tab visor + sets `CFG.ready`; the Angular `SkywireHttpBackend` routes `/api` to it. `index.html` gets the bootstrap injected; lazy chunks/css/fonts served from the embedded FS. Hash routing → no SPA rewrite needed. Embeds `hv-boot.js` as `wasmhv.HvBootJS`.

Verified locally: boot files + entry scripts + lazy chunk + font all 200 with correct MIME. (`hv gen` single-file path unchanged; its lazy-chunk limitation tracked separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)