### PR TITLE
feat(cli): hv serve mounts the dmsg/skynet browse + host overlay

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -73,6 +73,7 @@ page never asks anyone to type a secret key.`,
 		serveBytes("/wasm-visor.wasm", "application/wasm", wasm)
 		serveBytes("/wasm_exec.js", "text/javascript", wasmhv.WasmExecJS)
 		serveBytes("/hv-boot.js", "text/javascript", wasmhv.HvBootJS)
+		serveBytes("/browse.js", "text/javascript", wasmhv.BrowseJS)
 
 		// Everything else is the built Angular UI (incl. lazy chunks, css, fonts,
 		// assets). Routing is hash-based (#/...), so the server only ever sees "/"
@@ -103,10 +104,14 @@ page never asks anyone to type a secret key.`,
 
 // injectBoot inserts the hv-boot.js bootstrap as a classic <script> right after
 // <head>, so it runs before Angular's deferred module scripts — CFG.visor is set
-// and boot() starts (CFG.ready) before SkywireHttpBackend's first /api call.
+// and boot() starts (CFG.ready) before SkywireHttpBackend's first /api call. It
+// also loads browse.js + the launcher, which mount the dmsg/skynet browse+host
+// overlay (a floating "skynet" button) once the wasm-visor is up.
 func injectBoot(index []byte) []byte {
 	s := string(index)
-	tag := "\n<script src=\"hv-boot.js\"></script>\n"
+	tag := "\n<script src=\"hv-boot.js\"></script>\n" +
+		"<script src=\"browse.js\"></script>\n" +
+		"<script>" + wasmhv.BrowseLauncherJS + "</script>\n"
 	lower := strings.ToLower(s)
 	if i := strings.Index(lower, "<head"); i >= 0 {
 		if j := strings.IndexByte(s[i:], '>'); j >= 0 {

--- a/pkg/wasmhv/generate.go
+++ b/pkg/wasmhv/generate.go
@@ -150,7 +150,7 @@ func GenerateStandalone(uiFS fs.FS, wasmExecJS, wasm, overrideJS []byte, cfg Sta
 	// dmsg sites and self-host content over dmsg — no devtools, no extra page.
 	if cfg.Visor {
 		head += "<script>" + jsSafe(BrowseJS) + "</script>\n" +
-			"<script>" + browseLauncherJS + "</script>\n"
+			"<script>" + BrowseLauncherJS + "</script>\n"
 	}
 
 	loc := reHeadOpen.FindStringIndex(html)
@@ -260,11 +260,13 @@ func wasmBootstrap(wasm []byte, tinygo bool) (string, error) {
 })();`, nil
 }
 
-// browseLauncherJS waits for the wasm-visor + browse.js to be ready, mounts the
+// BrowseLauncherJS waits for the wasm-visor + browse.js to be ready, mounts the
 // browse/host overlay panel (SkywireBrowse.mountPanel), and adds a floating
 // "skynet" button to toggle it. Visor-mode only (it uses skywireVisor.fetchDmsg /
-// serveContent, which exist only in the wasm-visor build).
-const browseLauncherJS = `(function(){
+// serveContent, which exist only in the wasm-visor build). Exported so the
+// file-serving `+"`hv serve`"+` path can inject the same overlay as the single-file
+// generator.
+const BrowseLauncherJS = `(function(){
   if(!(window.__SKYWIRE_HV__||{}).visor) return;
   function ready(){
     if(!self.skywireVisor||!self.skywireVisor.fetchDmsg||!self.SkywireBrowse||!document.body){ return setTimeout(ready,200); }


### PR DESCRIPTION
The reworked file-serving `hv serve` (#3288) dropped the browse/host overlay the single-file generator adds. Restore it: serve `/browse.js` + inject the launcher so the page gets the floating **skynet** button → SkywireBrowse panel (browse dmsg/skynet sites by PK; host a page served over dmsg from the tab). Works over the wasm-visor's dmsg client directly — no transports needed. Exports `wasmhv.BrowseLauncherJS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)