### PR TITLE
feat(transport): default-on stcpr+WS cmux (phase 2 — WS reachable everywhere)

### DIFF
--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -100,6 +100,11 @@ type ClientFactory struct {
 	// WS case in MakeClient (untagged) can read wsSharedListener directly.
 	stcprSharedListener net.Listener
 	wsSharedListener    net.Listener
+	// tcpDefaultDemux is true when the TCP cmux is the DEFAULT one bound on the
+	// stcpr port (EnableDefaultTCPDemux) rather than an explicit transport_port
+	// master. In that case stcpr always rides the cmux (the demux IS its port), so
+	// stcprSharedListenerFor ignores the per-type break-out check.
+	tcpDefaultDemux bool
 }
 
 // MakeClient creates a new client of specified type

--- a/pkg/transport/network/client_unified_tcp.go
+++ b/pkg/transport/network/client_unified_tcp.go
@@ -23,9 +23,30 @@ func (f *ClientFactory) EnableUnifiedTCP(port int) error {
 	if port == 0 {
 		return nil
 	}
+	return f.bindTCPDemux(port)
+}
+
+// EnableDefaultTCPDemux binds the DEFAULT TCP cmux (stcpr + WS) on the stcpr port
+// — the phase-2 behavior so EVERY visor accepts WebSocket on its stcpr TCP socket
+// without any config, with no port change (the cmux peeks: HTTP/WS-upgrade → WS,
+// else the raw skywire handshake → stcpr; existing stcpr peers are unaffected).
+// stcprPort 0 binds a random port (exactly as a per-type stcpr listener would).
+// Unlike EnableUnifiedTCP this is NOT gated on transport_port, and stcpr always
+// rides it (the cmux IS the stcpr listener — no break-out).
+func (f *ClientFactory) EnableDefaultTCPDemux(stcprPort int) error {
+	if err := f.bindTCPDemux(stcprPort); err != nil {
+		return err
+	}
+	f.tcpDefaultDemux = true
+	return nil
+}
+
+// bindTCPDemux binds a TCP listener on :port (port 0 → random) and installs the
+// stcpr+WS cmux over it.
+func (f *ClientFactory) bindTCPDemux(port int) error {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
-		return fmt.Errorf("unified transport port %d (tcp): %w", port, err)
+		return fmt.Errorf("tcp cmux (stcpr+ws) port %d: %w", port, err)
 	}
 	d := newTCPDemux(lis)
 	f.tcpDemux = d
@@ -47,6 +68,13 @@ func (f *ClientFactory) CloseUnifiedTCP() error {
 // non-zero stcpr_port breaks stcpr out onto its own port even when transport_port
 // is set. Returns nil → per-type binding.
 func (f *ClientFactory) stcprSharedListenerFor(perTypePort int) net.Listener {
+	// Default demux (phase 2): the cmux IS bound on the stcpr port, so stcpr
+	// always rides it — there's no master port to break out of.
+	if f.tcpDefaultDemux {
+		return f.stcprSharedListener
+	}
+	// Explicit transport_port master: a non-zero stcpr_port breaks stcpr out onto
+	// its own dedicated socket.
 	if perTypePort != 0 {
 		return nil
 	}

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -499,9 +499,16 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 			}
 		},
 	}
-	// Unified transport port (opt-in): when transport_port is set, QUIC + sudph
-	// share one master UDP socket (demuxed) instead of binding a port each. 0 =
-	// per-type binding (default). See docs/design/transport-port-unification.md.
+	// Transport-port wiring (see docs/design/transport-port-unification.md +
+	// wasm-public-autoconnect.md):
+	//   - transport_port SET   → QUIC+sudph share one master UDP socket AND
+	//     stcpr+WS share that same TCP port (full unification, opt-in).
+	//   - transport_port UNSET → phase 2 default: stcpr+WS still share a TCP cmux,
+	//     bound on the stcpr port (random if unset), so EVERY visor accepts
+	//     WebSocket on its stcpr socket with NO config and NO port change (the
+	//     cmux peeks: WS-upgrade → WS, else raw handshake → stcpr; existing stcpr
+	//     peers unaffected). This is what lets a browser visor reach any visor
+	//     over WS. UDP-side unification stays opt-in (it would shift sudph's port).
 	if v.conf.Transport != nil && v.conf.Transport.TransportPort != 0 {
 		port := v.conf.Transport.TransportPort
 		if err := factory.EnableUnifiedUDP(port); err != nil {
@@ -513,6 +520,16 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		log.Infof("Unified transport port %d: QUIC+sudph share UDP, stcpr+WS share TCP", port)
 		v.pushCloseStack("transport.unified_udp", factory.CloseUnifiedUDP)
 		v.pushCloseStack("transport.unified_tcp", factory.CloseUnifiedTCP)
+	} else {
+		stcprPort := 0
+		if v.conf.Transport != nil {
+			stcprPort = v.conf.Transport.StcprPort
+		}
+		if err := factory.EnableDefaultTCPDemux(stcprPort); err != nil {
+			return fmt.Errorf("default tcp cmux (stcpr+ws): %w", err)
+		}
+		log.Info("stcpr + WS share the stcpr TCP port (cmux) — this visor is reachable over WebSocket")
+		v.pushCloseStack("transport.tcp_cmux", factory.CloseUnifiedTCP)
 	}
 	tpM, err := transport.NewManager(managerLogger, v.arClient, v.ebc, &tpMConf, factory)
 	if err != nil {


### PR DESCRIPTION
Phase 2 of wasm public autoconnect (docs/design/wasm-public-autoconnect.md): make **every visor accept WebSocket on its stcpr TCP socket by default**, so a browser (wasm) visor can reach any visor over WS.

**Before:** a WS listener existed only when `transport_port` was explicitly set. Default (unset) → stcpr bound a plain TCP listener, no WS.

**Now:** `transport_port` unset → the stcpr TCP listener is a **cmux (stcpr + WS)** bound on the stcpr port (random if unset). **No port change, no firewall impact** — the cmux peeks the first bytes (WS-upgrade → WS, else raw skywire handshake → stcpr), so existing stcpr peers are unaffected and stcpr still registers its bound port with the AR. UDP-side unification stays opt-in. A non-zero `transport_port` keeps full TCP+UDP unification as before.

Verified live: a visor with `transport_port:0` binds the cmux on its stcpr port (`ss` + the "stcpr + WS share the stcpr TCP port" log); cmux/tcpdemux unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)