### PR TITLE
fix(transport): stcpr handshake breaks under the stcpr+WS cmux (readFrame0 single-Read)

### DIFF
--- a/pkg/transport/network/handshake/handshake.go
+++ b/pkg/transport/network/handshake/handshake.go
@@ -225,17 +225,19 @@ func writeFrame0(w io.Writer) error {
 func readFrame0(r io.Reader) error {
 	buf := make([]byte, len(Message))
 
-	n, err := r.Read(buf)
-	if err != nil {
+	// io.ReadFull, not a single r.Read: Message can arrive split across reads.
+	// A bare Read only ever returned all len(Message) bytes by luck of TCP
+	// delivering the initiator's single write in one segment. Once stcpr rides the
+	// stcpr+WS cmux (transport-port unification), the demux sniffs the first bytes
+	// to classify the protocol and replays them as a *separate* Read — so the first
+	// Read here yields 8 of 9 bytes and the old single-Read check spuriously failed
+	// ("not enough bytes read"), breaking every inbound stcpr handshake.
+	if _, err := io.ReadFull(r, buf); err != nil {
 		return err
 	}
 
-	if n != len(Message) {
-		return fmt.Errorf("not enough bytes read")
-	}
-
-	if string(buf[:n]) != Message {
-		return fmt.Errorf("bad handshake message: %v", string(buf[:n]))
+	if string(buf) != Message {
+		return fmt.Errorf("bad handshake message: %v", string(buf))
 	}
 
 	return nil

--- a/pkg/transport/network/handshake/handshake_test.go
+++ b/pkg/transport/network/handshake/handshake_test.go
@@ -3,6 +3,7 @@ package handshake
 
 import (
 	"errors"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -76,5 +77,43 @@ func TestHandshake(t *testing.T) {
 
 		assert.NoError(t, initC.Close())
 		assert.NoError(t, respC.Close())
+	}
+}
+
+// chunkedReader returns its payload in fixed-size chunks, one per Read, to
+// emulate cmux's sniff-replay: the demux peeks the first bytes to classify the
+// protocol, then replays them as a separate Read from the live remainder. This
+// is also just legal io.Reader behavior — a Read may return fewer bytes than
+// asked even when more are available.
+type chunkedReader struct {
+	data  []byte
+	chunk int
+}
+
+func (c *chunkedReader) Read(p []byte) (int, error) {
+	if len(c.data) == 0 {
+		return 0, io.EOF
+	}
+	n := c.chunk
+	if n > len(c.data) {
+		n = len(c.data)
+	}
+	if n > len(p) {
+		n = len(p)
+	}
+	copy(p, c.data[:n])
+	c.data = c.data[n:]
+	return n, nil
+}
+
+// TestReadFrame0Chunked guards the stcpr+WS cmux regression: frame0 (Message)
+// arriving split across reads — e.g. cmux replays the first 8 sniffed bytes,
+// then the 9th comes live — must still parse. The old single-Read check failed
+// with "not enough bytes read", breaking every inbound stcpr handshake on a
+// cmux-equipped (transport-port-unified) visor.
+func TestReadFrame0Chunked(t *testing.T) {
+	for _, chunk := range []int{1, 8, len(Message), len(Message) + 5} {
+		r := &chunkedReader{data: []byte(Message), chunk: chunk}
+		require.NoError(t, readFrame0(r), "chunk size %d", chunk)
 	}
 }


### PR DESCRIPTION
## The regression

stcpr transports collapsed fleet-wide after the default-on **stcpr+WS cmux** (#3292) deployed — visors that previously held *hundreds* of stcpr transports dropped to ~2 reachable. Only the handful of visors **not** running the cmux stayed stcpr-reachable.

## Root cause

`readFrame0` read the 9-byte handshake `Message` (`"get_nonce"`) with a **single `r.Read`** and required `n == len(Message)` — assuming the whole frame arrives in one read. That only ever held by luck of TCP delivering the initiator's single write in one segment.

The cmux breaks that assumption deterministically. The demux sniffs the first bytes of every accepted connection to classify the protocol (`cmux.HTTP1Fast` reads up to **8 bytes** via `io.ReadFull`). On the stcpr fall-through (`cmux.Any()`), cmux **replays those 8 sniffed bytes as a separate `Read`** — its `bufferedReader` returns the buffered chunk and *"immediately returns ... otherwise we may block forever"*. So the responder's first `Read(buf[9])` yields **8 of 9 bytes** → `readFrame0` returns `"not enough bytes read"` → **every inbound stcpr handshake to a cmux-equipped visor fails**.

## Fix

Read frame0 with `io.ReadFull`. Correct independent of cmux — a single `Read` returning all requested bytes was never guaranteed by `io.Reader`; cmux just made the split deterministic and exposed the latent bug. No protocol or wire change; non-cmux peers are unaffected.

Adds `TestReadFrame0Chunked`, which feeds frame0 split at 1 / 8 / len / len+5 byte boundaries (reproducing the cmux sniff-replay) and asserts the handshake still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)