### PR TITLE
feat(transport): start the WS server on the stcpr+WS cmux (browser visors can reach any visor)

### DIFF
--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -58,6 +58,9 @@ var (
 	stcpC vinit.Module
 	// QUIC module (#2607 QUIC follow-on)
 	quicC vinit.Module
+	// WS module: serves the WebSocket transport over the stcpr+WS cmux so
+	// browser (wasm) visors can reach this visor over WebSocket
+	wsC vinit.Module
 	// dmsg pty: a remote terminal to the visor working over dmsg protocol
 	ptyModule vinit.Module
 	// Dmsg module
@@ -162,6 +165,7 @@ func registerModules(logger *logging.MasterLogger) {
 	stcprC = maker("stcpr", initStcprClient, &tr)
 	stcpC = maker("stcp", initStcpClient, &tr)
 	quicC = maker("quic", initQuicClient, &tr)
+	wsC = maker("ws", initWSClient, &tr)
 	dmsgC = maker("dmsg", initDmsg, &ebc, &dmsgHTTP)
 	dmsgCtrl = maker("dmsg_ctrl", initDmsgCtrl, &dmsgC, &tr)
 	// dmsghttp_logserver mounts /pty on top of dmsgpty's CLI socket
@@ -231,7 +235,7 @@ func registerModules(logger *logging.MasterLogger) {
 	// store. See init_group.go.
 	groupingMod = maker("grouping", initGrouping, &dmsgC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &ptyModule,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -382,6 +382,26 @@ func initStcprClient(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	return nil
 }
 
+// initWSClient starts the WebSocket transport server. WS has no dedicated
+// listener of its own: it serves over the stcpr+WS TCP cmux — the shared WS
+// virtual listener wired by EnableDefaultTCPDemux / EnableUnifiedTCP in
+// initTransport — so every visor accepts WebSocket transports on its stcpr TCP
+// port with no extra port and no config. This is what lets a browser (wasm)
+// visor — which can only dial WS/WT/WebRTC — reach any public visor over WS.
+//
+// Because WS rides the stcpr socket, the visor's existing stcpr
+// address-resolver registration already advertises the right IP:port for WS
+// dials; no separate WS registration is needed. The wasm autoconnect resolves a
+// peer's IP via the AR's stcpr entry and dials ws://host:<stcpr-port>/, which
+// the cmux peeks and routes to this WS server.
+//
+// Depends on &tr (initTransport), which always enables the TCP demux, so
+// v.tpM and the cmux's WS listener both exist by the time this runs.
+func initWSClient(ctx context.Context, v *Visor, _ *logging.Logger) error {
+	v.tpM.InitClient(ctx, types.WS, 0)
+	return nil
+}
+
 // initQuicClient starts the experimental QUIC transport when a quic_port is
 // configured (#2607 QUIC follow-on). Opt-in: a zero port leaves it disabled.
 func initQuicClient(ctx context.Context, v *Visor, log *logging.Logger) error {


### PR DESCRIPTION
## The gap

Phase 2 (#3292) binds a **stcpr+WS cmux** on every visor's stcpr TCP port, and the `ClientFactory` wires the WS virtual listener (`wsSharedListener`) — but **nothing ever called `InitClient(types.WS)`**. The visor inits DMSG/SUDPH/STCPR/QUIC/STCP/WEBRTC clients, never WS. So the WS branch of the cmux had **no server accepting on it**.

A browser (wasm) visor dialing `ws://host:<stcpr-port>/` reached the cmux, got routed to the WS virtual listener, and **hung** — TCP connected, 0 bytes back — because no WS HTTP server was `Accept()`-ing. This is the missing half of wasm public autoconnect over WS: the dial chain (SD → authed AR resolve → `ws://` dial) was correct, but had nowhere to land.

## Fix

Add `initWSClient` (module `ws`, depends on the transport module like stcpr/quic) which calls `InitClient(types.WS)`. The WS client's `serve()` runs its WebSocket HTTP server over the shared cmux listener, so **every visor accepts WS transports on its stcpr socket** — no extra port, no config.

No separate address-resolver registration is needed: WS rides the stcpr socket, so the existing stcpr AR entry already advertises the right `IP:port`. The wasm autoconnect resolves a peer's IP via the AR stcpr entry and dials `ws://host:<stcpr-port>/`, which the cmux peeks and routes to this server.

## Verification

On a `transport_port=7773` visor:
- **Before:** an HTTP/WS-upgrade to `:7773` hung with 0 bytes received.
- **After:** returns `101 Switching Protocols` with a valid `Sec-WebSocket-Accept`, while raw stcpr handshakes on the **same** port keep working (cmux routes raw → stcpr, HTTP/WS-upgrade → WS).

Pairs with #3295 (which fixed inbound stcpr on the same cmux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)