### PR TITLE
fix(transport): accept cross-origin WS dials (browser visors send an Origin header)

### DIFF
--- a/pkg/transport/network/ws_native.go
+++ b/pkg/transport/network/ws_native.go
@@ -90,7 +90,15 @@ func newWSListenerOver(tcpLis net.Listener) *wsListener {
 }
 
 func (l *wsListener) handle(w http.ResponseWriter, r *http.Request) {
-	ws, err := websocket.Accept(w, r, nil)
+	// InsecureSkipVerify disables coder/websocket's same-origin (CSRF) check.
+	// A browser (wasm) visor ALWAYS sends an Origin header (its page origin),
+	// which never matches this visor's Host, so the default check 403s every
+	// browser-originated WS dial — the whole point of the WS carrier. The check
+	// is meaningless here anyway: the WS connection carries a skywire transport
+	// authenticated end-to-end by the Noise handshake (remote-PK verification),
+	// and there is no cookie / ambient session to protect against CSRF. A forged
+	// Origin buys nothing without the peer's keys.
+	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## The bug

The WS transport server upgraded with `websocket.Accept(w, r, nil)` — whose default options enforce coder/websocket's **same-origin (CSRF) check**. A browser (wasm) visor **always** sends an `Origin` header (its page origin), which never matches the target visor's `Host`, so the server **403'd every browser-originated WS dial**.

This silently defeated the WS carrier for its primary purpose — a browser leaf joining the mesh. The dial reached the cmux, upgraded, and was rejected *before* the skywire handshake ran. Native peers were unaffected because coder/websocket's *client* `Dial` sends no `Origin`.

## Diagnosis (on a transport_port=7773 visor)

| client | Origin header | result |
|---|---|---|
| browser `WebSocket` | yes (mandatory) | immediate error — server **403** |
| `curl` with `-H Origin:` | yes | **403** |
| `curl` without Origin | no | **101** |
| native visor (coder/websocket Dial) | no | works |

After the fix, `curl`-with-Origin and a real browser `WebSocket` both get **101 / open** (verified live via the browser).

## Fix

`websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})` — disable the origin check.

Safe here: the WS connection carries a skywire transport authenticated end-to-end by the **Noise handshake** (remote-PK verification), and there is no cookie/ambient session to protect against CSRF. A forged `Origin` buys nothing without the peer's keys.

Completes the browser-reachable WS carrier: #3295 (inbound stcpr under the cmux) → #3296 (start the WS server on the cmux) → this (let browsers actually connect to it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)