### PR TITLE
fix(transport): WS Dial panics the visor on a nil WSTable (tp add -t ws crash)

### DIFF
--- a/pkg/transport/network/ws.go
+++ b/pkg/transport/network/ws.go
@@ -53,6 +53,14 @@ func (c *wsClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16) (T
 		return nil, io.ErrClosedPipe
 	}
 
+	// A native visor starts the WS client to ACCEPT (the cmux WS branch) but
+	// never populates a WSTable, so c.table is a nil interface here. Calling a
+	// method on it panics and crashes the visor on any `tp add -t ws`. Guard it,
+	// exactly as wtClient.Dial does. WS dials are endpoint-driven (the browser
+	// autoconnect sets the table); a native visor with no table has no WS target.
+	if c.table == nil {
+		return nil, ErrWSEntryNotFound
+	}
 	url, ok := c.table.Addr(rPK)
 	if !ok {
 		return nil, ErrWSEntryNotFound

--- a/pkg/transport/network/ws_native_test.go
+++ b/pkg/transport/network/ws_native_test.go
@@ -4,10 +4,14 @@ package network
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	types "github.com/skycoin/skywire/pkg/transport/types"
 )
 
 // TestWSCarrier_RoundTrip exercises the native WS carrier: the WS-server-as-
@@ -76,4 +80,16 @@ func readFull(c net.Conn, b []byte) error {
 	}
 	_, err := io.ReadFull(c, b)
 	return err
+}
+
+// TestWSDialNilTableNoPanic guards the fleet-wide crash where a native visor —
+// which starts the WS client to ACCEPT but never populates a WSTable — panicked
+// on any `tp add -t ws` because wsClient.Dial called a method on the nil table
+// interface. Dial must return ErrWSEntryNotFound, not panic.
+func TestWSDialNilTableNoPanic(t *testing.T) {
+	c := newWS(&genericClient{netType: types.WS}, nil)
+	_, err := c.Dial(context.Background(), cipher.PubKey{}, 0)
+	if !errors.Is(err, ErrWSEntryNotFound) {
+		t.Fatalf("nil-table WS Dial: want ErrWSEntryNotFound, got %v", err)
+	}
 }


### PR DESCRIPTION
## Critical: latent fleet-wide crash

#3296 starts the WS client on every native visor so it **accepts** WebSocket on the cmux WS branch. But native visors never populate a `WSTable`, so `wsClient.Dial`'s `c.table.Addr(rPK)` calls a method on a **nil `PKTable` interface → panic → visor crash** on ANY `tp add -t ws`.

Caught while verifying the host-native visor can make every transport type to public visors: `tp add -t ws <pk>` returned "unexpected EOF" (the RPC died) and the visor restarted.

The accept path is unaffected (it uses the shared listener, not the table) — only **dialing** WS hit it. `wtClient.Dial` already guards `c.table == nil`; `wsClient.Dial` didn't.

## Fix

Guard the nil table, returning `ErrWSEntryNotFound` — WS dials are endpoint-driven (the browser autoconnect populates the table; a native visor with no table simply has no WS dial target). Adds `TestWSDialNilTableNoPanic`.

Follow-up to #3296 / #3297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)