### PR TITLE
fix(address-resolver): handle the QUIC type in the redis store (quic dead fleet-wide)

### DIFF
--- a/pkg/address-resolver/store/address_test.go
+++ b/pkg/address-resolver/store/address_test.go
@@ -43,4 +43,18 @@ func (s *AddressSuite) TestRegister() {
 		require.NoError(t, err)
 		require.Equal(t, visorData, got)
 	})
+
+	// QUIC must bind + resolve like STCPR. The redis store originally switched
+	// only on STCPR/SUDPH and returned ErrUnknownTransportType for QUIC, so the
+	// AR 500'd every /resolve/quic and visors could never register QUIC (0 QUIC
+	// transports fleet-wide). Guard the round-trip for both store backends.
+	t.Run(".BindQUIC", func(t *testing.T) {
+		require.NoError(t, s.Bind(ctx, types.QUIC, pk, visorData))
+	})
+
+	t.Run(".ResolveQUIC", func(t *testing.T) {
+		got, err := s.Resolve(ctx, types.QUIC, pk)
+		require.NoError(t, err)
+		require.Equal(t, visorData, got)
+	})
 }

--- a/pkg/address-resolver/store/redis_store.go
+++ b/pkg/address-resolver/store/redis_store.go
@@ -66,7 +66,7 @@ func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl
 
 func (s *redisStore) Bind(ctx context.Context, netType types.Type, pk cipher.PubKey, visorData addrresolver.VisorData) error {
 	switch netType {
-	case types.STCPR, types.SUDPH:
+	case types.STCPR, types.SUDPH, types.QUIC:
 		return s.bindWithIndex(ctx, netType, pk, visorData)
 	default:
 		return ErrUnknownTransportType
@@ -75,7 +75,7 @@ func (s *redisStore) Bind(ctx context.Context, netType types.Type, pk cipher.Pub
 
 func (s *redisStore) DelBind(ctx context.Context, netType types.Type, pk cipher.PubKey) error {
 	switch netType {
-	case types.STCPR, types.SUDPH:
+	case types.STCPR, types.SUDPH, types.QUIC:
 		return s.delBindWithIndex(ctx, netType, pk)
 	default:
 		return ErrUnknownTransportType
@@ -84,7 +84,7 @@ func (s *redisStore) DelBind(ctx context.Context, netType types.Type, pk cipher.
 
 func (s *redisStore) Resolve(ctx context.Context, netType types.Type, pk cipher.PubKey) (addrresolver.VisorData, error) {
 	switch netType {
-	case types.STCPR, types.SUDPH:
+	case types.STCPR, types.SUDPH, types.QUIC:
 		key := getKey(string(netType), pk)
 		return s.resolve(ctx, key)
 	default:
@@ -94,7 +94,7 @@ func (s *redisStore) Resolve(ctx context.Context, netType types.Type, pk cipher.
 
 func (s *redisStore) GetAll(ctx context.Context, netType types.Type) ([]string, error) {
 	switch netType {
-	case types.STCPR, types.SUDPH:
+	case types.STCPR, types.SUDPH, types.QUIC:
 		if pks, ok := s.getAllCache.Get(netType); ok {
 			return pks, nil
 		}


### PR DESCRIPTION
## QUIC has been dead network-wide

0 QUIC transports across the fleet; visors retry `BindQUIC` forever; every `tp add -t quic` fails with `resolve PK: status: 500`.

## Root cause

The AR exposes `POST /bind/quic` and `GET /resolve/quic/{pk}` (#2607 QUIC follow-on), but the **redis store** (production backend) switched only on `STCPR`/`SUDPH` in `Bind`/`DelBind`/`Resolve`/`GetAll` and returned `ErrUnknownTransportType` for QUIC:

```go
func (s *redisStore) Resolve(...) {
    switch netType {
    case types.STCPR, types.SUDPH:   // QUIC missing
        ...
    default:
        return ..., ErrUnknownTransportType
    }
}
```

The resolve handler maps any non-`ErrNoEntry` error to **500**, so every `/resolve/quic` 500'd and `BindQUIC` failed — no visor could register QUIC.

## Fix

The underlying store handlers are **type-generic** (they key on the `netType` string), so the fix is just adding `types.QUIC` to the four switches — exactly how the **memory store already worked** (fully generic, which is why only redis/production was affected). Extends the shared `AddressSuite` with a QUIC bind/resolve round-trip (runs against both backends; redis case runs in CI).

Deploys with the AR service; visors then register QUIC and quic transports form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)