### PR TITLE
feat(transport): native WS dial resolves the peer endpoint via the address resolver

### DIFF
--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -134,6 +134,7 @@ func (f *ClientFactory) MakeClient(netType types.Type, port int) (Client, error)
 		return newStcp(generic, f.PKTable), nil
 	case types.WS:
 		wc := newWS(generic, f.WSTable)
+		wc.(*wsClient).ar = f.ARClient // native: resolve ws:// from the stcpr AR record
 		if f.wsSharedListener != nil { // unified transport port
 			wc.(*wsClient).sharedListener = f.wsSharedListener
 		}

--- a/pkg/transport/network/ws.go
+++ b/pkg/transport/network/ws.go
@@ -34,6 +34,12 @@ type wsClient struct {
 	// transport_port socket (see tcpDemux, !tinygo). net.Listener so this stays in
 	// the untagged file; only ws_native.go (the server) consumes it.
 	sharedListener net.Listener
+	// ar is the address-resolver client (addrresolver.APIClient), typed `any` to
+	// keep addrresolver out of the TinyGo graph (mirrors ClientFactory.ARClient).
+	// On native it lets WS dial a peer with no explicit table entry: WS rides the
+	// stcpr cmux port, so resolveWSURLViaAR resolves the peer's stcpr address and
+	// forms ws://host:port/. nil on the browser (which dials from the table only).
+	ar any
 }
 
 func newWS(generic *genericClient, table stcp.PKTable) Client {
@@ -53,15 +59,20 @@ func (c *wsClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16) (T
 		return nil, io.ErrClosedPipe
 	}
 
-	// A native visor starts the WS client to ACCEPT (the cmux WS branch) but
-	// never populates a WSTable, so c.table is a nil interface here. Calling a
-	// method on it panics and crashes the visor on any `tp add -t ws`. Guard it,
-	// exactly as wtClient.Dial does. WS dials are endpoint-driven (the browser
-	// autoconnect sets the table); a native visor with no table has no WS target.
-	if c.table == nil {
-		return nil, ErrWSEntryNotFound
+	// Endpoint resolution order:
+	//  1. explicit table entry (the browser autoconnect sets the ws:// URL here),
+	//  2. address-resolver fallback (native): WS rides the stcpr cmux port, so we
+	//     resolve the peer's stcpr address and form ws://host:port/.
+	// c.table is a nil interface on a native visor (it starts the WS client only
+	// to ACCEPT), so guard it — calling a method on it would panic the visor.
+	var url string
+	var ok bool
+	if c.table != nil {
+		url, ok = c.table.Addr(rPK)
 	}
-	url, ok := c.table.Addr(rPK)
+	if !ok {
+		url, ok = c.resolveWSURLViaAR(ctx, rPK)
+	}
 	if !ok {
 		return nil, ErrWSEntryNotFound
 	}

--- a/pkg/transport/network/ws_native.go
+++ b/pkg/transport/network/ws_native.go
@@ -16,7 +16,35 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+	types "github.com/skycoin/skywire/pkg/transport/types"
 )
+
+// resolveWSURLViaAR resolves a peer's WS endpoint from the address resolver when
+// there is no explicit table entry (a native `tp add -t ws`). WS shares the
+// stcpr cmux TCP port, so the peer's stcpr AR record (host:port) IS its WS
+// endpoint — wrap it as ws://host:port/. ok=false when there is no AR client or
+// no stcpr record for the peer.
+func (c *wsClient) resolveWSURLViaAR(ctx context.Context, rPK cipher.PubKey) (string, bool) {
+	ar, _ := c.ar.(addrresolver.APIClient)
+	if ar == nil {
+		return "", false
+	}
+	vd, err := ar.Resolve(ctx, string(types.STCPR), rPK)
+	if err != nil {
+		return "", false
+	}
+	// RemoteAddr may be a bare host with the port carried separately in
+	// VisorData.Port (same shape the stcpr dialer handles via canonicalAddr) —
+	// "ws://"+RemoteAddr would otherwise drop the port and dial 80/443.
+	addr := canonicalAddr(vd.RemoteAddr, vd.Port)
+	if addr == "" {
+		return "", false
+	}
+	return "ws://" + addr + "/", true
+}
 
 // wsDial opens a direct WebSocket to url and adapts it to a net.Conn.
 func wsDial(ctx context.Context, url string) (net.Conn, error) {

--- a/pkg/transport/network/ws_tinygo.go
+++ b/pkg/transport/network/ws_tinygo.go
@@ -9,7 +9,18 @@
 // (other TinyGo targets) stubs it.
 package network
 
-import "errors"
+import (
+	"context"
+	"errors"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// resolveWSURLViaAR has no address resolver on a TinyGo target (addrresolver is
+// !tinygo), so WS dials come only from the explicit table. Always ok=false.
+func (c *wsClient) resolveWSURLViaAR(_ context.Context, _ cipher.PubKey) (string, bool) {
+	return "", false
+}
 
 // errWSServe is returned by Start on TinyGo (no listening socket).
 var errWSServe = errors.New("ws: serving not supported on this build (TinyGo) — a browser/embedded target has no listening socket")


### PR DESCRIPTION
A native `tp add -t ws <pk>` had no way to find the peer's WS endpoint — the WS client only consulted its `WSTable` (populated by the browser autoconnect), so a native visor returned `ErrWSEntryNotFound` and could never make a WS transport.

## Fix

WS rides the **stcpr+WS cmux TCP port**, so a peer's **stcpr AR record IS its WS endpoint**. On a table miss the native WS client now resolves the peer's stcpr record and forms `ws://host:port/` — reusing `canonicalAddr`, since `RemoteAddr` can be a bare host with the port carried separately in `VisorData.Port` (missing that gave `https://<ip>/` with no port → TLS error in testing).

The AR client is held as `any` and the resolver is build-tagged (real on `!tinygo`, no-op stub on `tinygo`) so `addrresolver` stays out of the TinyGo graph. The browser build is unaffected — table hit first, nil AR.

## Verified live

Native→native WS transports **established** to two public visors (`03a590ea`, prod02 `03d1d78e`). Visor stayed alive throughout (pairs with #3299, the nil-table crash guard).

Completes the WS carrier matrix: browser→native (autoconnect) and native→native both work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)