### PR TITLE
feat(transport): visor accepts WebTransport + registers its cert hash with the AR

### DIFF
--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -140,7 +140,9 @@ func (f *ClientFactory) MakeClient(netType types.Type, port int) (Client, error)
 		}
 		return wc, nil
 	case types.WT:
-		return newWT(generic, f.WTTable), nil
+		wc := newWT(generic, f.WTTable)
+		wc.(*wtClient).ar = f.ARClient // native: register/resolve WT endpoint+cert via AR
+		return wc, nil
 	case types.WEBRTC:
 		return newWebRTC(generic, f.DmsgC, f.ICEURLs), nil
 	case types.DMSG:

--- a/pkg/transport/network/wt.go
+++ b/pkg/transport/network/wt.go
@@ -77,6 +77,13 @@ type wtClient struct {
 	*genericClient
 	table WTTable
 
+	// ar is the address-resolver client (addrresolver.APIClient), typed `any` to
+	// keep addrresolver out of the TinyGo graph (mirrors wsClient.ar). On native
+	// the WT server registers its UDP port + self-signed cert hash with the AR
+	// (BindWT) so dialing peers can discover the endpoint AND pin the cert; the
+	// dial side resolves the same record. nil on the browser (table-only).
+	ar any
+
 	// advertised holds the WT listener's public dial info once Start has run
 	// (native only); a browser/TinyGo client never serves, so these stay empty.
 	advertisedURL      string

--- a/pkg/transport/network/wt_native.go
+++ b/pkg/transport/network/wt_native.go
@@ -28,11 +28,20 @@ import (
 	"github.com/quic-go/webtransport-go"
 
 	"github.com/skycoin/skywire/pkg/skyquic"
+	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
 )
 
 // wtPath is the HTTP/3 path the WebTransport endpoint is served on; the
 // advertised URL includes it (e.g. "https://host:port/skywire").
 const wtPath = "/skywire"
+
+const (
+	// wtReRegisterInterval keeps the WT AR entry alive (< the AR's 2-min TTL),
+	// mirroring stcpr/quic.
+	wtReRegisterInterval = 90 * time.Second
+	wtBindRetryDelay     = 5 * time.Second
+	wtBindMaxRetryDelay  = 60 * time.Second
+)
 
 // wtAcceptTimeout bounds how long a freshly-upgraded WebTransport session may
 // take to open its first (yamux-carrying) bidirectional stream.
@@ -114,7 +123,52 @@ func (c *wtClient) serve() {
 	c.advertisedURL = fmt.Sprintf("https://%s%s", lis.Addr().String(), wtPath)
 	c.advertisedCertHash = hex.EncodeToString(lis.certHash[:])
 	c.log.Infof("Serving WT transport at %s (cert %s)", c.advertisedURL, c.advertisedCertHash)
+
+	// Register the WT endpoint + cert hash with the address resolver so peers can
+	// discover it and pin the self-signed cert (WT has no CA). Like stcpr/quic,
+	// keep the entry alive with a periodic re-register.
+	if ar, _ := c.ar.(addrresolver.APIClient); ar != nil {
+		if _, port, err := net.SplitHostPort(lis.Addr().String()); err == nil {
+			go c.registerWT(ar, port, c.advertisedCertHash)
+		} else {
+			c.log.WithError(err).Warn("WT: cannot extract port for AR registration")
+		}
+	}
+
 	c.acceptTransports(lis)
+}
+
+// registerWT binds the WT UDP port + cert hash to the address resolver, retrying
+// with backoff, then re-registers periodically to keep the entry alive.
+func (c *wtClient) registerWT(ar addrresolver.APIClient, port, certHash string) {
+	delay := wtBindRetryDelay
+	for {
+		if err := ar.BindWT(context.Background(), port, certHash); err == nil {
+			c.log.Debugf("Successfully bound WT to AR (port %s)", port)
+			break
+		} else {
+			c.log.WithError(err).Warnf("Failed to bind WT, retrying in %v", delay)
+		}
+		if c.isClosed() {
+			return
+		}
+		time.Sleep(delay)
+		if delay *= 2; delay > wtBindMaxRetryDelay {
+			delay = wtBindMaxRetryDelay
+		}
+	}
+	ticker := time.NewTicker(wtReRegisterInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-ticker.C:
+			if err := ar.BindWT(context.Background(), port, certHash); err != nil {
+				c.log.WithError(err).Warn("Failed to re-register WT")
+			}
+		}
+	}
 }
 
 // wtListener fronts a WebTransport (HTTP/3) server as a net.Listener: the first

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -61,6 +61,9 @@ var (
 	// WS module: serves the WebSocket transport over the stcpr+WS cmux so
 	// browser (wasm) visors can reach this visor over WebSocket
 	wsC vinit.Module
+	// WT module: serves the WebTransport (QUIC/HTTP3) transport + registers its
+	// cert hash with the AR so browser (wasm) visors can dial it
+	wtC vinit.Module
 	// dmsg pty: a remote terminal to the visor working over dmsg protocol
 	ptyModule vinit.Module
 	// Dmsg module
@@ -166,6 +169,7 @@ func registerModules(logger *logging.MasterLogger) {
 	stcpC = maker("stcp", initStcpClient, &tr)
 	quicC = maker("quic", initQuicClient, &tr)
 	wsC = maker("ws", initWSClient, &tr)
+	wtC = maker("wt", initWTClient, &tr)
 	dmsgC = maker("dmsg", initDmsg, &ebc, &dmsgHTTP)
 	dmsgCtrl = maker("dmsg_ctrl", initDmsgCtrl, &dmsgC, &tr)
 	// dmsghttp_logserver mounts /pty on top of dmsgpty's CLI socket
@@ -235,7 +239,7 @@ func registerModules(logger *logging.MasterLogger) {
 	// store. See init_group.go.
 	groupingMod = maker("grouping", initGrouping, &dmsgC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &ptyModule,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -402,6 +402,19 @@ func initWSClient(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	return nil
 }
 
+// initWTClient starts the WebTransport server. WT is a QUIC/HTTP3 carrier with a
+// self-signed cert (no CA): the server binds its own UDP port, generates a cert,
+// and registers BOTH the endpoint and the cert's SHA-256 hash with the address
+// resolver (BindWT) so a dialing peer — especially a browser, which can only
+// reach a visor over WS/WT/WebRTC — can discover the endpoint and pin the cert.
+// Like quic it binds an ephemeral UDP port (registered with the AR, survives
+// restarts via re-register); a fixed firewall port can be pinned later.
+// Depends on &tr so v.tpM and the AR client both exist.
+func initWTClient(ctx context.Context, v *Visor, _ *logging.Logger) error {
+	v.tpM.InitClient(ctx, types.WT, 0)
+	return nil
+}
+
 // initQuicClient starts the experimental QUIC transport when a quic_port is
 // configured (#2607 QUIC follow-on). Opt-in: a zero port leaves it disabled.
 func initQuicClient(ctx context.Context, v *Visor, log *logging.Logger) error {


### PR DESCRIPTION
Second PR of the WebTransport carrier build (after #3302, the AR cert-hash foundation).

Every native visor now starts a **WebTransport server** and advertises it so browser (wasm) visors — which can only reach a visor over WS/WT/WebRTC — can dial it:

- `initWTClient` (module `wt`, depends on the transport module like ws/quic) calls `InitClient(types.WT)`. The WT server binds its own ephemeral UDP port, generates a self-signed cert, and serves HTTP/3 WebTransport.
- The WT client gets the AR (held as `any`, mirroring `wsClient.ar`). On serve it registers the endpoint + the cert's **SHA-256 hash** via `BindWT` (#3302) and keeps the entry alive with a 90s re-register (retry-with-backoff like stcpr/quic).

`wtClient.Dial` already guards a nil table, so no `tp add -t wt` crash before the dial-resolution PR lands.

## Verified live

The WT server starts, binds UDP (port 7777), mints a cert (`74d836a3…`), and `BindWT` retries — **404 until the AR redeploys #3302** — visor stays alive throughout.

Next PRs: dial-side resolution (resolve the peer's WT endpoint+hash from the AR, pin the cert) → WS/WT multi-type autoconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)