### PR TITLE
feat(transport): native WT dial resolves the peer endpoint + cert hash via the AR

### DIFF
--- a/pkg/transport/network/wt.go
+++ b/pkg/transport/network/wt.go
@@ -114,16 +114,25 @@ func (c *wtClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16) (T
 		return nil, io.ErrClosedPipe
 	}
 
-	if c.table == nil {
-		return nil, ErrWTEntryNotFound
+	// Endpoint resolution order: explicit table entry (browser autoconnect sets
+	// the URL+cert hash), then address-resolver fallback (native) — resolve the
+	// peer's WT record (https://host:port/skywire + pinned cert hash).
+	var url, certHash string
+	var ok bool
+	if c.table != nil {
+		if e, found := c.table.Entry(rPK); found {
+			url, certHash, ok = e.URL, e.CertHash, true
+		}
 	}
-	e, ok := c.table.Entry(rPK)
+	if !ok {
+		url, certHash, ok = c.resolveWTViaAR(ctx, rPK)
+	}
 	if !ok {
 		return nil, ErrWTEntryNotFound
 	}
-	c.log.Debugf("Dialing WT %v @ %s", rPK, e.URL)
+	c.log.Debugf("Dialing WT %v @ %s", rPK, url)
 
-	conn, err := wtDial(ctx, e.URL, e.CertHash)
+	conn, err := wtDial(ctx, url, certHash)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/transport/network/wt_native.go
+++ b/pkg/transport/network/wt_native.go
@@ -27,9 +27,32 @@ import (
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/webtransport-go"
 
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skyquic"
 	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+	types "github.com/skycoin/skywire/pkg/transport/types"
 )
+
+// resolveWTViaAR resolves a peer's WebTransport endpoint + pinned cert hash from
+// the address resolver when there is no explicit table entry (a native
+// `tp add -t wt`). The WT bind stored both (BindWT), so /resolve/wt returns the
+// UDP endpoint and the SHA-256 cert hash; the URL is https://host:port/skywire.
+// ok=false when there is no AR, no WT record, or no cert hash.
+func (c *wtClient) resolveWTViaAR(ctx context.Context, rPK cipher.PubKey) (url, certHash string, ok bool) {
+	ar, _ := c.ar.(addrresolver.APIClient)
+	if ar == nil {
+		return "", "", false
+	}
+	vd, err := ar.Resolve(ctx, string(types.WT), rPK)
+	if err != nil || vd.CertHash == "" {
+		return "", "", false
+	}
+	addr := canonicalAddr(vd.RemoteAddr, vd.Port)
+	if addr == "" {
+		return "", "", false
+	}
+	return "https://" + addr + wtPath, vd.CertHash, true
+}
 
 // wtPath is the HTTP/3 path the WebTransport endpoint is served on; the
 // advertised URL includes it (e.g. "https://host:port/skywire").

--- a/pkg/transport/network/wt_tinygo.go
+++ b/pkg/transport/network/wt_tinygo.go
@@ -9,7 +9,18 @@
 // wt_tinygo_nows.go (other TinyGo targets) stubs it.
 package network
 
-import "errors"
+import (
+	"context"
+	"errors"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// resolveWTViaAR has no address resolver on a TinyGo target (addrresolver is
+// !tinygo), so WT dials come only from the explicit table. Always ok=false.
+func (c *wtClient) resolveWTViaAR(_ context.Context, _ cipher.PubKey) (string, string, bool) {
+	return "", "", false
+}
 
 // errWTServe is returned by Start on TinyGo (no listening socket / no HTTP/3).
 var errWTServe = errors.New("wt: serving not supported on this build (TinyGo) — a browser/embedded target has no HTTP/3 listener")


### PR DESCRIPTION
Third PR of the WebTransport carrier build (after #3302 AR foundation, #3303 accept-side).

A native `tp add -t wt <pk>` had only the `WTTable` to find a peer's WebTransport endpoint, so a native visor returned `ErrWTEntryNotFound`. Now, on a table miss, `wtClient.Dial` resolves the peer's WT record from the address resolver — the endpoint (`https://host:port/skywire`) **and** the pinned self-signed cert hash that `BindWT` stored — and dials with the pin. Mirrors the native WS resolution (#3301).

Build-tagged like the WS resolver (real on `!tinygo` via `addrresolver`, no-op stub on `tinygo`); browser build unaffected (table hit first, nil AR).

End-to-end native↔native WT needs #3302 (AR) + #3303 (accept) **deployed** so peers have WT records — this is the dial half. Next: WS/WT multi-type autoconnect (wasm dials both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)