### PR TITLE
feat(transport,dmsg): browser-native WT dial for the std-Go wasm visor (build-tag fix)

### DIFF
--- a/pkg/dmsg/dmsg/jsaddr_js.go
+++ b/pkg/dmsg/dmsg/jsaddr_js.go
@@ -1,0 +1,21 @@
+//go:build js && wasm
+
+// Package dmsg pkg/dmsg/dmsg/jsaddr_js.go: tiny net.Addr / net.Error helpers
+// shared by the browser WebSocket (ws_js_tinygo.go, tinygo only) and WebTransport
+// (wt_js_tinygo.go, all js/wasm) carrier adapters. Lives in a js&&wasm file so
+// std-Go js/wasm — which uses coder/websocket for the dmsg WS session but still
+// needs the browser-native WT dial — gets them too.
+package dmsg
+
+// wsAddr is the net.Addr for a browser WebSocket / WebTransport connection.
+type wsAddr string
+
+func (wsAddr) Network() string  { return "ws" }
+func (a wsAddr) String() string { return string(a) }
+
+// wsTimeoutError is the net.Error returned when a read deadline elapses.
+type wsTimeoutError struct{}
+
+func (wsTimeoutError) Error() string   { return "ws: i/o timeout" }
+func (wsTimeoutError) Timeout() bool   { return true }
+func (wsTimeoutError) Temporary() bool { return true }

--- a/pkg/dmsg/dmsg/ws_js_tinygo.go
+++ b/pkg/dmsg/dmsg/ws_js_tinygo.go
@@ -50,18 +50,8 @@ func (ce *Client) dialSessionWS(ctx context.Context, entry *disc.Entry) (ClientS
 	return dSes, nil
 }
 
-// wsAddr is the net.Addr for a browser WebSocket connection.
-type wsAddr string
-
-func (wsAddr) Network() string  { return "ws" }
-func (a wsAddr) String() string { return string(a) }
-
-// wsTimeoutError is the net.Error returned when a read deadline elapses.
-type wsTimeoutError struct{}
-
-func (wsTimeoutError) Error() string   { return "ws: i/o timeout" }
-func (wsTimeoutError) Timeout() bool   { return true }
-func (wsTimeoutError) Temporary() bool { return true }
+// wsAddr / wsTimeoutError moved to jsaddr_js.go (js && wasm) so the WT browser
+// dial (wt_js_tinygo.go, all js/wasm) can share them on std-Go wasm too.
 
 // wsConnJS adapts a browser WebSocket (binaryType=arraybuffer) to a net.Conn.
 // Inbound frames are buffered by the message event handler; Read drains the

--- a/pkg/dmsg/dmsg/wt.go
+++ b/pkg/dmsg/dmsg/wt.go
@@ -1,4 +1,4 @@
-//go:build !tinygo
+//go:build !tinygo && !(js && wasm)
 
 // Package dmsg pkg/dmsg/dmsg/wt.go: dmsg-over-WebTransport.
 //

--- a/pkg/dmsg/dmsg/wt_js_tinygo.go
+++ b/pkg/dmsg/dmsg/wt_js_tinygo.go
@@ -1,4 +1,4 @@
-//go:build tinygo && js && wasm
+//go:build js && wasm
 
 // Package dmsg pkg/dmsg/dmsg/wt_js_tinygo.go: dmsg-over-WebTransport CLIENT dial
 // for the TinyGo browser target.

--- a/pkg/transport/network/wt_browser.go
+++ b/pkg/transport/network/wt_browser.go
@@ -1,25 +1,42 @@
-//go:build tinygo && js && wasm
+//go:build js && wasm
 
 // Package network pkg/transport/network/wt_browser.go
 //
 // Browser WT-transport DIAL: a browser visor dials a peer visor's WebTransport
 // endpoint via the browser-native WebTransport API, pinning the peer's
 // self-signed cert by SHA-256 (serverCertificateHashes). webtransport-go (the
-// native carrier, wt_native.go) pulls quic-go, which doesn't compile on the
-// TinyGo js target, so we reuse the dmsg carrier's tested syscall/js
-// WebTransport→net.Conn adapter (dmsg.DialWebTransportJS), the same one a browser
-// visor uses to reach a dmsg server. The returned net.Conn flows through the same
-// Noise+yamux initTransport path as every other carrier — so a tab can be the
-// dialing edge of a direct WT transport (it still can't accept; see wt_tinygo.go).
+// native carrier, wt_native.go) pulls quic-go, which can't open UDP in a browser
+// on EITHER wasm toolchain (TinyGo or std-Go js/wasm), so any js/wasm build
+// reuses the dmsg carrier's tested syscall/js WebTransport→net.Conn adapter
+// (dmsg.DialWebTransportJS), the same one a browser visor uses to reach a dmsg
+// server. The returned net.Conn flows through the same Noise+yamux initTransport
+// path as every other carrier — so a tab can be the dialing edge of a direct WT
+// transport. A browser can't serve (no HTTP/3 listener), so Start fails closed
+// and there is no address resolver to register/resolve against (table only).
 package network
 
 import (
 	"context"
+	"errors"
 	"net"
 
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 )
 
 func wtDial(ctx context.Context, url, certHashHex string) (net.Conn, error) {
 	return dmsg.DialWebTransportJS(ctx, url, certHashHex)
+}
+
+// Start implements Client: a browser tab cannot run the HTTP/3 WebTransport
+// server a WT listener needs, so it fails closed (dial-only, like ws_browser).
+func (c *wtClient) Start() error {
+	return errors.New("wt: serving not supported in a browser (no HTTP/3 listener) — dial only")
+}
+
+// resolveWTViaAR is a no-op in the browser: there is no address-resolver client
+// (addrresolver is !tinygo and pulls quic-go); WT dials come from the table the
+// autoconnect populates with the AR-resolved endpoint + cert hash.
+func (c *wtClient) resolveWTViaAR(_ context.Context, _ cipher.PubKey) (string, string, bool) {
+	return "", "", false
 }

--- a/pkg/transport/network/wt_native.go
+++ b/pkg/transport/network/wt_native.go
@@ -1,4 +1,4 @@
-//go:build !tinygo
+//go:build !tinygo && !(js && wasm)
 
 // Package network pkg/transport/network/wt_native.go
 //

--- a/pkg/transport/network/wt_tinygo.go
+++ b/pkg/transport/network/wt_tinygo.go
@@ -1,12 +1,12 @@
-//go:build tinygo
+//go:build tinygo && !(js && wasm)
 
 // Package network pkg/transport/network/wt_tinygo.go
 //
-// TinyGo WT-transport: the SERVE side. A browser (or any TinyGo target) cannot
-// run the HTTP/3 WebTransport server a WT transport listener needs, so Start
-// fails closed on all TinyGo builds. The DIAL side is target-specific:
-// wt_browser.go (tinygo && js && wasm) dials the browser-native WebTransport;
-// wt_tinygo_nows.go (other TinyGo targets) stubs it.
+// TinyGo (non-browser/embedded) WT-transport stubs. A browser is handled by
+// wt_browser.go (js && wasm, either toolchain), which provides its own Start +
+// dial + resolve; this file covers embedded TinyGo targets (no HTTP/3 server, no
+// dial — wt_tinygo_nows.go stubs the dial). Kept disjoint from wt_browser.go so
+// tinygo+js+wasm doesn't get two definitions of Start/resolveWTViaAR.
 package network
 
 import (


### PR DESCRIPTION
Part of the WebTransport carrier build — the wasm dial side.

`DialWebTransportJS` (the syscall/js WebTransport adapter) and the transport-layer `wt_browser.go` that calls it were gated `tinygo && js && wasm`, so the **std-Go js/wasm** visor compiled `wt_native.go` instead — webtransport-go/quic-go, which **can't open UDP in a browser**. So a std-Go wasm visor could never dial WT. (WS avoided this because coder/websocket has a real js implementation; quic-go does not.)

## Retag by browser-vs-native (the real distinction)

**transport/network:**
- `wt_native.go` `!tinygo` → `!tinygo && !(js && wasm)` (native only)
- `wt_browser.go` `tinygo && js && wasm` → `js && wasm` (any browser) + now provides the `Start` + `resolveWTViaAR` stubs a browser needs (can't serve, no AR)
- `wt_tinygo.go` `tinygo` → `tinygo && !(js && wasm)` (embedded only) so it doesn't collide with `wt_browser` on tinygo-wasm

**dmsg:**
- `wt.go` `!tinygo` → `!tinygo && !(js && wasm)`; `wt_js_tinygo.go` `tinygo && js && wasm` → `js && wasm`
- shared `wsAddr`/`wsTimeoutError` move to a new `jsaddr_js.go` (`js && wasm`) so both the WS (tinygo-only) and WT (all-js) browser adapters get them
- the dmsg **WS** session dial is untouched (coder/websocket, `ws.go`) — the wasm visor's lifeline is unaffected

## Verified
Native + std-Go js/wasm (`cmd/wasm-visor`) build clean. Symbol-consistent for tinygo-wasm + tinygo-embedded (helpers moved to a file both include; no new redeclarations; the tinygo `net/http roundtrip_js` error is pre-existing, unrelated).

Enabling change — the wasm autoconnect dialing WT (multi-type) is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)