### PR TITLE
feat(hv serve): wasm-visor self-update — reload to a newer served build

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -2,9 +2,12 @@
 package clihv
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"io/fs"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -58,7 +61,12 @@ page never asks anyone to type a secret key.`,
 			cmd.PrintErrln("read index.html:", err)
 			os.Exit(1)
 		}
-		index := injectBoot(indexB)
+		// wasmVer fingerprints the embedded wasm so the page can detect a newer
+		// build (after the skywire binary updates) and self-reload — see
+		// autoupdate.js. Short SHA-256 prefix is plenty to spot a content change.
+		sum := sha256.Sum256(wasm)
+		wasmVer := hex.EncodeToString(sum[:])[:16]
+		index := injectBoot(indexB, wasmVer)
 
 		mux := http.NewServeMux()
 		serveBytes := func(path, ct string, body []byte) {
@@ -74,6 +82,14 @@ page never asks anyone to type a secret key.`,
 		serveBytes("/wasm_exec.js", "text/javascript", wasmhv.WasmExecJS)
 		serveBytes("/hv-boot.js", "text/javascript", wasmhv.HvBootJS)
 		serveBytes("/browse.js", "text/javascript", wasmhv.BrowseJS)
+		serveBytes("/autoupdate.js", "text/javascript", wasmhv.AutoUpdateJS)
+		// /wasm-version is the build fingerprint autoupdate.js polls; no-cache so a
+		// new binary is seen promptly (the wasm itself stays cacheable).
+		mux.HandleFunc("/wasm-version", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			w.Header().Set("Cache-Control", "no-store")
+			_, _ = w.Write([]byte(wasmVer)) //nolint:errcheck // best-effort
+		})
 
 		// Everything else is the built Angular UI (incl. lazy chunks, css, fonts,
 		// assets). Routing is hash-based (#/...), so the server only ever sees "/"
@@ -107,11 +123,15 @@ page never asks anyone to type a secret key.`,
 // and boot() starts (CFG.ready) before SkywireHttpBackend's first /api call. It
 // also loads browse.js + the launcher, which mount the dmsg/skynet browse+host
 // overlay (a floating "skynet" button) once the wasm-visor is up.
-func injectBoot(index []byte) []byte {
+func injectBoot(index []byte, wasmVer string) []byte {
 	s := string(index)
 	tag := "\n<script src=\"hv-boot.js\"></script>\n" +
 		"<script src=\"browse.js\"></script>\n" +
-		"<script>" + wasmhv.BrowseLauncherJS + "</script>\n"
+		"<script>" + wasmhv.BrowseLauncherJS + "</script>\n" +
+		// Record the build this page loaded, then let autoupdate.js poll for a
+		// newer one and self-reload (it only runs here, never in the native UI).
+		"<script>window.__SKYWIRE_WASM_VERSION__=" + strconv.Quote(wasmVer) + ";</script>\n" +
+		"<script src=\"autoupdate.js\"></script>\n"
 	lower := strings.ToLower(s)
 	if i := strings.Index(lower, "<head"); i >= 0 {
 		if j := strings.IndexByte(s[i:], '>'); j >= 0 {

--- a/pkg/wasmhv/autoupdate.js
+++ b/pkg/wasmhv/autoupdate.js
@@ -1,0 +1,71 @@
+// autoupdate.js — wasm-visor self-update for the `skywire cli hv serve` page.
+//
+// The standalone wasm-visor's ONLY update step is a page reload: the server
+// (hv serve) embeds the wasm in the running skywire binary, so when that binary
+// updates the served /wasm-visor.wasm changes and a reload picks it up. This
+// script polls a tiny /wasm-version fingerprint and, when it differs from the
+// version this page booted with, reloads to the new build — by default, with a
+// user-visible toast that lets them keep the current version (disabling
+// auto-update). It is injected ONLY by hv serve, so it never runs for a
+// native-hosted hypervisor UI.
+(function () {
+  'use strict';
+  var POLL_MS = 60000;          // how often to check for a new build
+  var GRACE_MS = 8000;          // countdown before auto-reloading
+  var KEY = 'skywire.autoupdate'; // localStorage: 'off' disables auto-reload
+  var booted = window.__SKYWIRE_WASM_VERSION__ || '';
+  if (!booted) { return; }      // server didn't inject a version → nothing to do
+
+  function enabled() { try { return localStorage.getItem(KEY) !== 'off'; } catch (e) { return true; } }
+  function setEnabled(on) { try { localStorage.setItem(KEY, on ? 'on' : 'off'); } catch (e) {} }
+
+  // Public API (a settings-menu control can call these; also handy from the console).
+  window.skywireAutoUpdate = {
+    bootVersion: booted,
+    isEnabled: enabled,
+    enable: function () { setEnabled(true); },
+    disable: function () { setEnabled(false); },
+    checkNow: function () { check(true); },
+  };
+
+  var notifying = false;
+
+  function toast(latest) {
+    if (notifying) { return; }
+    notifying = true;
+    var box = document.createElement('div');
+    box.style.cssText = 'position:fixed;z-index:2147483647;right:16px;bottom:16px;max-width:320px;' +
+      'background:#2b2540;color:#eee;font:13px/1.4 system-ui,sans-serif;padding:12px 14px;' +
+      'border:1px solid #6c5ce7;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,.4)';
+    var secs = Math.round(GRACE_MS / 1000);
+    box.innerHTML = '<b>New wasm-visor available</b><br>Updating in <span id="su-c">' + secs +
+      '</span>s… <div style="margin-top:8px"><button id="su-now" style="margin-right:8px">Update now</button>' +
+      '<button id="su-keep">Keep this version</button></div>';
+    document.body.appendChild(box);
+    var t = setInterval(function () {
+      secs -= 1;
+      var c = document.getElementById('su-c');
+      if (c) { c.textContent = String(secs); }
+      if (secs <= 0) { clearInterval(t); location.reload(); }
+    }, 1000);
+    document.getElementById('su-now').onclick = function () { clearInterval(t); location.reload(); };
+    document.getElementById('su-keep').onclick = function () {
+      clearInterval(t); setEnabled(false); box.remove(); notifying = false;
+      console.log('[autoupdate] disabled — staying on ' + booted + ' (re-enable: skywireAutoUpdate.enable())');
+    };
+  }
+
+  function check(force) {
+    fetch('wasm-version', { cache: 'no-store' }).then(function (r) {
+      return r.ok ? r.text() : null;
+    }).then(function (latest) {
+      if (!latest) { return; }
+      latest = latest.trim();
+      if (latest === booted) { return; }
+      console.log('[autoupdate] new build ' + latest + ' (running ' + booted + ')');
+      if (force || enabled()) { toast(latest); }
+    }).catch(function () { /* server unreachable — ignore, try next tick */ });
+  }
+
+  setInterval(check, POLL_MS);
+})();

--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -19,6 +19,14 @@ var OverrideJS []byte
 //go:embed browse.js
 var BrowseJS []byte
 
+// AutoUpdateJS is pkg/wasmhv/autoupdate.js — the wasm-visor self-update poller for
+// the `hv serve` page: it compares a /wasm-version fingerprint against the version
+// the page booted with and reloads to a newer build (toast + opt-out). Injected
+// ONLY by hv serve, so it never runs for a native-hosted hypervisor UI.
+//
+//go:embed autoupdate.js
+var AutoUpdateJS []byte
+
 // HvBootJS is pkg/wasmhv/hv-boot.js — the clean boot bootstrap for serving the
 // wasm-VISOR hypervisor UI as separate files (the `hv serve` / dev-harness model,
 // as opposed to the single-file generator's inlined override.js). It sets


### PR DESCRIPTION
The standalone wasm-visor (`skywire cli hv serve`, e.g. skywire.theskywirenetwork.net) embeds the wasm in the running skywire binary, so its **only update step is a page reload** — when the binary updates, the served `/wasm-visor.wasm` changes and a reload picks it up. This makes that automatic.

- `hv serve` fingerprints the embedded wasm (short SHA-256) and serves it at `/wasm-version` (no-store); it injects the booted version + `autoupdate.js` into the page. **Only `hv serve` injects it**, so it never runs for a native-hosted HV UI.
- `autoupdate.js` polls `/wasm-version` every 60s; when it differs from the version the page booted with, it shows a toast (*"Updating in 8s… [Update now] [Keep this version]"*) and reloads. **"Keep this version"** disables auto-update (localStorage). `window.skywireAutoUpdate.{enable,disable,isEnabled,checkNow}` backs a future settings-menu toggle.

Default-on, user-overridable, wasm-only.

## Verified live
Ran `hv serve`: `/wasm-version` → `96b5e41e883d66dd`, `/autoupdate.js` serves, and the page injects `__SKYWIRE_WASM_VERSION__` + the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)