### PR TITLE
feat(visor): persist runtime hypervisor add/remove + make config-loaded hvs removable

### DIFF
--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -238,10 +238,13 @@ var hvStatusCmd = &cobra.Command{
 
 var hvAddCmd = &cobra.Command{
 	Use:   "add <public-key>",
-	Short: "Connect to a remote hypervisor at runtime",
+	Short: "Connect to a remote hypervisor at runtime (persisted)",
 	Long: `Add a remote hypervisor connection at runtime without editing
-the config file. The visor connects to the hypervisor immediately
-via DMSG. Not persisted — use SKYENV HYPERVISORPKS for persistence.`,
+the config file by hand. The visor connects to the hypervisor
+immediately via DMSG AND persists the PK to the config's
+hypervisors list, so the connection survives a restart. (On a
+non-file-backed config — wasm tab / STDIN — the connection is made
+but cannot be persisted.)`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		var pk cipher.PubKey
@@ -261,15 +264,16 @@ via DMSG. Not persisted — use SKYENV HYPERVISORPKS for persistence.`,
 
 var hvRmCmd = &cobra.Command{
 	Use:   "rm [public-key]",
-	Short: "Disconnect from a remote hypervisor at runtime",
-	Long: `Tear down a runtime-added hypervisor connection. Mirrors hv add
-— only affects connections created via AddHypervisor (this RPC or
-the corresponding CLI). Config-loaded hypervisors aren't affected;
-edit SKYENV HYPERVISORPKS and restart the visor to remove those.
+	Short: "Disconnect from a remote hypervisor at runtime (persisted)",
+	Long: `Tear down a hypervisor connection at runtime AND remove its PK
+from the config's hypervisors list, so it stays removed across a
+restart. Works for both runtime-added (hv add) and config-loaded
+hypervisors. (On a non-file-backed config — wasm tab / STDIN — the
+disconnect happens but cannot be persisted.)
 
-Pass --all to disconnect every runtime-added hypervisor in one
-call. Without --all, exactly one <public-key> argument is
-required.`,
+Pass --all to disconnect every hypervisor and clear the configured
+list in one call. Without --all, exactly one <public-key> argument
+is required.`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if hvRmAll {
 			if len(args) > 0 {

--- a/pkg/visor/api_hypervisors.go
+++ b/pkg/visor/api_hypervisors.go
@@ -58,7 +58,56 @@ func (v *Visor) AddHypervisor(hvPK cipher.PubKey) error {
 		return nil
 	})
 
+	// Persist so the change survives a restart (the operator is configuring this
+	// hypervisor, not just connecting once). Best-effort — see persistHypervisors.
+	v.persistHypervisors(addPK(v.configuredHypervisors(), hvPK))
+
 	return nil
+}
+
+// configuredHypervisors returns a copy of the visor's configured hypervisor PKs.
+// Unlocked read of v.conf.Hypervisors, matching the codebase's config-update
+// convention (UpdateMinHops etc. mutate under v1.mu; readers don't lock — the
+// writes are rare operator actions).
+func (v *Visor) configuredHypervisors() []cipher.PubKey {
+	if v.conf == nil {
+		return nil
+	}
+	return append([]cipher.PubKey(nil), v.conf.Hypervisors...)
+}
+
+// addPK returns pks with pk appended if not already present.
+func addPK(pks []cipher.PubKey, pk cipher.PubKey) []cipher.PubKey {
+	for _, p := range pks {
+		if p == pk {
+			return pks
+		}
+	}
+	return append(pks, pk)
+}
+
+// removePK returns pks without pk.
+func removePK(pks []cipher.PubKey, pk cipher.PubKey) []cipher.PubKey {
+	out := pks[:0:0]
+	for _, p := range pks {
+		if p != pk {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// persistHypervisors writes want to the config so a runtime add/remove survives
+// a restart. Best-effort: a non-file-backed config (wasm tab / STDIN) can't write
+// — the runtime connection change already took effect, so a write error is only
+// logged, never fatal.
+func (v *Visor) persistHypervisors(want []cipher.PubKey) {
+	if v.conf == nil || v.conf.Path() == "" {
+		return // not file-backed; runtime change stands without persistence
+	}
+	if err := v.conf.UpdateHypervisors(want); err != nil {
+		v.log.WithError(err).Warn("failed to persist hypervisors to config")
+	}
 }
 
 // RemoveHypervisor tears down a runtime-added hypervisor connection by
@@ -75,12 +124,16 @@ func (v *Visor) RemoveHypervisor(hvPK cipher.PubKey) error {
 	v.initLock.Lock()
 	cancel, ok := v.hypervisorCancels[hvPK]
 	v.initLock.Unlock()
-	if !ok {
-		// Not a runtime-added hypervisor (or already removed). Don't
-		// error — operator's intent is satisfied either way.
-		return nil
+	if ok {
+		// Tear down the live connection; its goroutine's deferred cleanup removes
+		// hvPK from connectedHypervisors + hypervisorCancels. Config-loaded
+		// hypervisors are tracked here too (initHypervisors registers them), so
+		// this now works for them, not only AddHypervisor-added ones.
+		cancel()
 	}
-	cancel()
+	// Persist the removal regardless (even if the connection was already gone or
+	// never tracked) so the visor doesn't reconnect to it on the next restart.
+	v.persistHypervisors(removePK(v.configuredHypervisors(), hvPK))
 	return nil
 }
 
@@ -97,6 +150,9 @@ func (v *Visor) RemoveAllHypervisors() (int, error) {
 	for _, c := range cancels {
 		c()
 	}
+	// Persist an empty configured set so none reconnect on restart (now that
+	// config-loaded hypervisors are tracked + cancelled here too).
+	v.persistHypervisors(nil)
 	return len(cancels), nil
 }
 

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -890,20 +890,24 @@ func initHypervisors(_ context.Context, v *Visor, _ *logging.Logger) error {
 		wg := new(sync.WaitGroup)
 		wg.Add(1)
 
-		go func(hvErrs chan error) {
+		go func(hvPK cipher.PubKey, cancel context.CancelFunc, hvErrs chan error) {
 			defer wg.Done()
-			//			var autoPeerIP string
-			//			if v.autoPeer {
-			//				autoPeerIP = v.autoPeerIP
-			//			} else {
-			//				autoPeerIP = ""
-			//			}
-			defer delete(v.connectedHypervisors, hvPK)
+			// Register the cancel so RemoveHypervisor can tear down this
+			// config-loaded connection at runtime (previously only
+			// AddHypervisor-added connections were removable). Deferred cleanup
+			// clears both maps, mirroring AddHypervisor.
+			defer func() {
+				v.initLock.Lock()
+				delete(v.connectedHypervisors, hvPK)
+				delete(v.hypervisorCancels, hvPK)
+				v.initLock.Unlock()
+			}()
+			v.initLock.Lock()
 			v.connectedHypervisors[hvPK] = true
+			v.hypervisorCancels[hvPK] = cancel
+			v.initLock.Unlock()
 			ServeRPCClient(ctx, log, v.tpM, v.dmsgC, rpcS, addr, hvErrs)
-			//			ServeRPCClient(ctx, log, autoPeerIP, v.dmsgC, rpcS, addr, hvErrs)
-
-		}(hvErrs)
+		}(hvPK, cancel, hvErrs)
 
 		// Background goroutine: probe the hypervisor via dmsg, then
 		// attempt stcpr / sudph transport creation so subsequent RPC

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -577,6 +577,19 @@ func (v1 *V1) UpdatePersistentTransports(pTps []tspec.PersistentTransports) erro
 	return v1.flush(v1)
 }
 
+// UpdateHypervisors persists the visor's configured hypervisor PKs so a runtime
+// add/remove survives a restart. Same lock+flush shape as UpdateMinHops /
+// UpdatePersistentTransports. A no-op flush on a non-file-backed config (STDIN /
+// in-memory) returns its error to the caller, which may ignore it (the runtime
+// connection change still took effect).
+func (v1 *V1) UpdateHypervisors(pks []cipher.PubKey) error {
+	v1.mu.Lock()
+	v1.Hypervisors = pks
+	v1.mu.Unlock()
+
+	return v1.flush(v1)
+}
+
 // GetPersistentTransports gets persistent_transports from config
 func (v1 *V1) GetPersistentTransports() ([]tspec.PersistentTransports, error) {
 	v1.mu.Lock()


### PR DESCRIPTION
Runtime hypervisor changes (`AddHypervisor`/`RemoveHypervisor`, exposed as `cli visor hv add`/`rm`) connected/disconnected but were **not persisted** ("use SKYENV for persistence"), and `rm` only worked for runtime-added hypervisors — so changing a visor's configured hypervisors meant hand-editing the config + a restart.

- `V1.UpdateHypervisors(pks)` persists the hypervisors list (same lock+flush shape as `UpdateMinHops`/`UpdatePersistentTransports`).
- `AddHypervisor` appends the PK to the config + flushes; `RemoveHypervisor` removes it; `RemoveAllHypervisors` clears it. **Best-effort**: a non-file-backed config (wasm tab / STDIN) makes the runtime change but can't persist (logged, not fatal). The desired list is computed from `v.conf.Hypervisors` so it's deterministic (not racy with the async connect goroutine).
- `initHypervisors` now registers each **config-loaded** connection's cancel in `v.hypervisorCancels` (under `initLock`, with deferred cleanup mirroring `AddHypervisor`), so `RemoveHypervisor` tears those down too.
- CLI help updated.

## Verified live
```
hv add <pk>  → config hypervisors: ["03d1d78e…"]
hv rm  <pk>  → config hypervisors: []
```
A visor's hypervisors can now be changed at runtime **and survive a restart**, no hand-editing.

Follow-up (optional): an HTTP endpoint + UI control wrapping these (the RPC/CLI are the access path today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)