### PR TITLE
fix(transport): WebRTC signaling port (47) collided with DmsgTransportSetupPort — webrtc dead fleet-wide

### DIFF
--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -97,6 +97,15 @@ const (
 	// subscribe to one TPD feed without dragging in the others.
 	DmsgTPDAllTransportsCXOPort uint16 = 55
 
+	// DmsgWebRTCSignalPort is the dmsg port the WebRTC carrier exchanges its SDP
+	// offer/answer + ICE candidates on (a visor dials a peer here to open a
+	// signaling stream; the answerer listens). It MUST live in this registry: it
+	// previously hardcoded 47 in pkg/transport/network, colliding with
+	// DmsgTransportSetupPort (47) — so the webrtc listener lost the bind and
+	// offers reached the transport-setup listener instead, leaving webrtc dead
+	// fleet-wide.
+	DmsgWebRTCSignalPort uint16 = 56
+
 	// DmsgDHTPort Listening port for the Kademlia DHT protocol.
 	DmsgDHTPort uint16 = 100
 

--- a/pkg/transport/network/webrtc.go
+++ b/pkg/transport/network/webrtc.go
@@ -32,12 +32,16 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/skyenv"
 	types "github.com/skycoin/skywire/pkg/transport/types"
 )
 
-// webrtcSignalPort is the dmsg port the WebRTC signaling listener accepts on
-// (mirror of the browser carrier's port 47, so native and browser interoperate).
-const webrtcSignalPort uint16 = 47
+// webrtcSignalPort is the dmsg port the WebRTC signaling listener accepts on.
+// Sourced from the central skyenv registry — it used to hardcode 47 here, which
+// collided with DmsgTransportSetupPort (47) and left webrtc dead fleet-wide
+// (the listener couldn't bind; offers hit the transport-setup listener). Native
+// and browser carriers share this constant so they interoperate.
+const webrtcSignalPort = skyenv.DmsgWebRTCSignalPort
 
 // signalMsg is one signaling message exchanged over the dmsg signaling stream.
 // The JSON field set + names match the browser carrier exactly (interop).
@@ -130,6 +134,7 @@ func (c *webrtcClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16
 	if err != nil {
 		return nil, fmt.Errorf("webrtc: dial signaling: %w", err)
 	}
+	c.log.Debugf("WebRTC signaling stream to %v established; starting offerer", rPK)
 	conn, err := webrtcDial(ctx, str, c.iceURLs)
 	if err != nil {
 		str.Close() //nolint:errcheck,gosec

--- a/pkg/transport/network/webrtc_native.go
+++ b/pkg/transport/network/webrtc_native.go
@@ -19,7 +19,16 @@ import (
 
 	"github.com/pion/datachannel"
 	"github.com/pion/webrtc/v4"
+
+	"github.com/skycoin/skywire/pkg/logging"
 )
+
+// wrtcLog carries WebRTC signaling diagnostics. WebRTC negotiation is opaque
+// otherwise — a failed dial just times out — so log the signaling milestones +
+// the gathered/received ICE candidates. (Pion's On*StateChange callbacks have
+// different signatures on native vs the js/wasm build, so deeper ICE-state
+// logging can't live in this shared file.)
+var wrtcLog = logging.MustGetLogger("webrtc")
 
 // dcLabel is the DataChannel label both peers agree on (matches the browser).
 const dcLabel = "skywire"
@@ -61,6 +70,7 @@ func wireLocalCandidates(pc *webrtc.PeerConnection, sc *signalConn) {
 		if init.SDPMLineIndex != nil {
 			line = int(*init.SDPMLineIndex)
 		}
+		wrtcLog.Debugf("webrtc: gathered local candidate: %s", init.Candidate)
 		_ = sc.send(signalMsg{Type: "candidate", Candidate: init.Candidate, SDPMid: mid, SDPMLine: line}) //nolint:errcheck
 	})
 }
@@ -94,16 +104,23 @@ func pumpRemoteSignals(ctx context.Context, pc *webrtc.PeerConnection, sc *signa
 		}
 		switch m.Type {
 		case "offer":
+			wrtcLog.Info("webrtc[answerer]: received offer")
 			if onOffer != nil {
-				if err := onOffer(m.SDP); err == nil {
+				if err := onOffer(m.SDP); err != nil {
+					wrtcLog.WithError(err).Warn("webrtc[answerer]: onOffer failed")
+				} else {
 					flush()
 				}
 			}
 		case "answer":
-			if err := pc.SetRemoteDescription(webrtc.SessionDescription{Type: webrtc.SDPTypeAnswer, SDP: m.SDP}); err == nil {
+			wrtcLog.Info("webrtc[offerer]: received answer")
+			if err := pc.SetRemoteDescription(webrtc.SessionDescription{Type: webrtc.SDPTypeAnswer, SDP: m.SDP}); err != nil {
+				wrtcLog.WithError(err).Warn("webrtc[offerer]: set remote (answer) failed")
+			} else {
 				flush()
 			}
 		case "candidate":
+			wrtcLog.Debugf("webrtc: received remote candidate (remoteSet=%t): %s", remoteSet, m.Candidate)
 			if remoteSet {
 				addCand(m)
 			} else {


### PR DESCRIPTION
WebRTC has **0 transports network-wide** — it never worked native↔native. Root cause: its dmsg signaling port was hardcoded `webrtcSignalPort = 47` in `pkg/transport/network`, **outside the skyenv port registry**, and **47 is already `DmsgTransportSetupPort`** (the Transport Setup Node's listen port).

So:
- the WebRTC signaling listener lost the bind to the transport-setup listener (`dmsg error 400 - port already occupied`) → visors had **no webrtc answerer**;
- an offerer dialing `peer:47` connected to the peer's **transport-setup** listener (which a probe reports "reachable"), which doesn't speak webrtc signaling → the offer was never answered → ICE never started → **dial timed out**.

### Diagnosis
Instrumented the offerer + streamed the `webrtc` module log during a dial: the signaling stream "established" but **zero ICE progress**, and the listener logged `port already occupied` at boot. A dmsg probe of `prod02:47` returned "reachable" — but that's the *transport-setup* listener, not webrtc.

### Fix
Move the port into the **skyenv registry** as `DmsgWebRTCSignalPort = 56` (a free dmsg port) and source `webrtcSignalPort` from it. Verified: the webrtc listener now **binds** (`dmsg:56` reachable on the local visor, no "occupied").

Native↔native + browser webrtc establish once **both ends** run this. Since webrtc was 0 fleet-wide, nothing working breaks during rollout. Also adds signaling/candidate diagnostic logging so a future hung negotiation is traceable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)