### PR TITLE
feat(hv): cli hv serve --harness — opt-in operator control bridge

### DIFF
--- a/cmd/dmsg-wasm/serve.go
+++ b/cmd/dmsg-wasm/serve.go
@@ -23,97 +23,15 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"mime"
 	"net/http"
-	"sync"
-	"time"
 
-	"github.com/coder/websocket"
-
-	"github.com/skycoin/skywire/pkg/wasmrpc"
+	"github.com/skycoin/skywire/pkg/wasmhv/ctlbridge"
 )
-
-type tab struct {
-	id      string
-	events  chan string // SSE command frames queued for this tab
-	mu      sync.Mutex
-	logs    []string
-	rpcAddr string // local 127.0.0.1:<port> the wasmrpc bridge fronts (when connected)
-}
-
-type command struct {
-	ID     string        `json:"id"`
-	Action string        `json:"action"`
-	Args   []interface{} `json:"args"`
-}
-
-type result struct {
-	ID    string      `json:"id"`
-	OK    bool        `json:"ok"`
-	Value interface{} `json:"value"`
-	Error string      `json:"error"`
-}
-
-var (
-	mu      sync.Mutex
-	tabs    = map[string]*tab{}
-	pending = map[string]chan result{}
-	seq     int
-)
-
-func getTab(id string) *tab {
-	mu.Lock()
-	defer mu.Unlock()
-	t := tabs[id]
-	if t == nil {
-		t = &tab{id: id, events: make(chan string, 8)}
-		tabs[id] = t
-	}
-	return t
-}
-
-// sendCmd queues one command for a tab over SSE and waits for its result. Shared
-// by /ctl/cmd (single command) and /ctl/meshtest (a scripted sequence).
-func sendCmd(tabID, action string, args ...interface{}) (result, error) {
-	mu.Lock()
-	t := tabs[tabID]
-	mu.Unlock()
-	if t == nil {
-		return result{}, fmt.Errorf("no such tab %q (open it first)", tabID)
-	}
-	if args == nil {
-		args = []interface{}{}
-	}
-	mu.Lock()
-	seq++
-	c := command{ID: fmt.Sprintf("c%d", seq), Action: action, Args: args}
-	ch := make(chan result, 1)
-	pending[c.ID] = ch
-	mu.Unlock()
-	defer func() { mu.Lock(); delete(pending, c.ID); mu.Unlock() }()
-
-	t.mu.Lock()
-	evCh := t.events
-	t.mu.Unlock()
-	b, _ := json.Marshal(c)
-	select {
-	case evCh <- string(b):
-	case <-time.After(5 * time.Second):
-		return result{}, fmt.Errorf("tab %q not receiving", tabID)
-	}
-	select {
-	case res := <-ch:
-		return res, nil
-	case <-time.After(40 * time.Second):
-		return result{}, fmt.Errorf("tab %q command %q timeout", tabID, action)
-	}
-}
 
 func main() {
 	dir := flag.String("dir", "build/dmsg-wasm", "directory to serve")
@@ -123,161 +41,14 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	// SSE: a tab subscribes here to receive commands. On reconnect (page reload,
-	// same id), install a FRESH events channel as the tab's current one so
-	// commands go to the live connection — not a lingering old reader.
-	mux.HandleFunc("/ctl/events", func(w http.ResponseWriter, r *http.Request) {
-		t := getTab(r.URL.Query().Get("tab"))
-		fl, ok := w.(http.Flusher)
-		if !ok {
-			http.Error(w, "no flush", 500)
-			return
-		}
-		ch := make(chan string, 8)
-		t.mu.Lock()
-		t.events = ch
-		t.mu.Unlock()
-
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.Header().Set("Cache-Control", "no-cache")
-		fmt.Fprint(w, ": connected\n\n")
-		fl.Flush()
-		log.Printf("tab connected: %s", t.id)
-		for {
-			select {
-			case msg := <-ch:
-				fmt.Fprintf(w, "data: %s\n\n", msg)
-				fl.Flush()
-			case <-r.Context().Done():
-				return
-			case <-time.After(15 * time.Second):
-				fmt.Fprint(w, ": ping\n\n")
-				fl.Flush()
-			}
-		}
-	})
-
-	// A tab posts a command result back here.
-	mux.HandleFunc("/ctl/result", func(w http.ResponseWriter, r *http.Request) {
-		var res result
-		if err := json.NewDecoder(r.Body).Decode(&res); err != nil {
-			http.Error(w, err.Error(), 400)
-			return
-		}
-		mu.Lock()
-		ch := pending[res.ID]
-		mu.Unlock()
-		if ch != nil {
-			select {
-			case ch <- res:
-			default:
-			}
-		}
-		w.WriteHeader(204)
-	})
-
-	// A tab streams its log lines here (POST); GET reads them back.
-	mux.HandleFunc("/ctl/log", func(w http.ResponseWriter, r *http.Request) {
-		t := getTab(r.URL.Query().Get("tab"))
-		if r.Method == http.MethodPost {
-			b, _ := io.ReadAll(r.Body)
-			t.mu.Lock()
-			t.logs = append(t.logs, string(b))
-			t.mu.Unlock()
-			w.WriteHeader(204)
-			return
-		}
-		t.mu.Lock()
-		out := append([]string(nil), t.logs...)
-		t.mu.Unlock()
-		for _, l := range out {
-			fmt.Fprintln(w, l)
-		}
-	})
-
-	// Clear a tab's buffered logs (so each test reads fresh output).
-	mux.HandleFunc("/ctl/clear", func(w http.ResponseWriter, r *http.Request) {
-		t := getTab(r.URL.Query().Get("tab"))
-		t.mu.Lock()
-		t.logs = nil
-		t.mu.Unlock()
-		w.WriteHeader(204)
-	})
-
-	// List connected tabs, each with its RPC bridge address (if connected) so a
-	// shell can do: skywire --rpc <rpc> visor info
-	mux.HandleFunc("/ctl/tabs", func(w http.ResponseWriter, r *http.Request) {
-		type tabInfo struct {
-			ID  string `json:"id"`
-			RPC string `json:"rpc,omitempty"`
-		}
-		mu.Lock()
-		out := make([]tabInfo, 0, len(tabs))
-		for id, t := range tabs {
-			t.mu.Lock()
-			out = append(out, tabInfo{ID: id, RPC: t.rpcAddr})
-			t.mu.Unlock()
-		}
-		mu.Unlock()
-		_ = json.NewEncoder(w).Encode(out)
-	})
-
-	// RPC bridge: a wasm-visor tab dials this WebSocket and serves its visor RPC
-	// over it; we front it with a local 127.0.0.1:<port> that `skywire cli --rpc`
-	// targets. One bridge per tab; closed when the tab disconnects. See
-	// pkg/wasmrpc.
-	mux.HandleFunc("/ctl/rpc", func(w http.ResponseWriter, r *http.Request) {
-		t := getTab(r.URL.Query().Get("tab"))
-		c, err := websocket.Accept(w, r, nil)
-		if err != nil {
-			log.Printf("rpc bridge accept (%s): %v", t.id, err)
-			return
-		}
-		c.SetReadLimit(-1)
-		conn := websocket.NetConn(context.Background(), c, websocket.MessageBinary)
-		bridge, err := wasmrpc.NewBridge(conn, 0, func(m string) { log.Printf("[rpc %s] %s", t.id, m) })
-		if err != nil {
-			log.Printf("rpc bridge (%s): %v", t.id, err)
-			_ = c.Close(websocket.StatusInternalError, "bridge setup failed")
-			return
-		}
-		t.mu.Lock()
-		t.rpcAddr = bridge.Addr()
-		t.mu.Unlock()
-		log.Printf("tab %s RPC bridge UP at %s — drive it: skywire --rpc %s visor info", t.id, bridge.Addr(), bridge.Addr())
-		<-r.Context().Done()
-		_ = bridge.Close()
-		t.mu.Lock()
-		t.rpcAddr = ""
-		t.mu.Unlock()
-		log.Printf("tab %s RPC bridge closed", t.id)
-	})
-
-	// Operator drives a tab: queue a command, wait for its result.
-	mux.HandleFunc("/ctl/cmd", func(w http.ResponseWriter, r *http.Request) {
-		id := r.URL.Query().Get("tab")
-		mu.Lock()
-		t := tabs[id]
-		mu.Unlock()
-		if t == nil {
-			http.Error(w, "no such tab (open it first)", 404)
-			return
-		}
-		var c command
-		if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
-			http.Error(w, err.Error(), 400)
-			return
-		}
-		res, err := sendCmd(id, c.Action, c.Args...)
-		if err != nil {
-			http.Error(w, err.Error(), 504)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(res)
-	})
+	// The /ctl/* control surface (SSE events, result, log, clear, tabs, rpc, cmd)
+	// is shared with `cli hv serve --harness` — see pkg/wasmhv/ctlbridge.
+	br := ctlbridge.New(log.Printf)
+	br.Register(mux)
 
 	// Mesh test: boot two wasm-visor tabs, form a WebRTC transport from a→b, and
 	// verify both ends see a transport. One curl proves two browser visors meshing.
+	// Harness-only (scripted sequence over the shared bridge).
 	//
 	//	curl -s 'localhost:8085/ctl/meshtest?a=<tabA>&b=<tabB>&seedpk=<pk>&seedws=<ws>&disc=<dmsg://pk:80>'
 	mux.HandleFunc("/ctl/meshtest", func(w http.ResponseWriter, r *http.Request) {
@@ -285,7 +56,7 @@ func main() {
 		a, b := q.Get("a"), q.Get("b")
 		seedpk, seedws, disc := q.Get("seedpk"), q.Get("seedws"), q.Get("disc")
 		var steps []map[string]interface{}
-		record := func(name string, res result, err error) bool {
+		record := func(name string, res ctlbridge.Result, err error) bool {
 			s := map[string]interface{}{"step": name}
 			if err != nil {
 				s["error"] = err.Error()
@@ -305,12 +76,12 @@ func main() {
 		}
 
 		// 1. boot both tabs (ephemeral identities).
-		bootA, err := sendCmd(a, "boot", "", seedpk, seedws, disc)
+		bootA, err := br.SendCmd(a, "boot", "", seedpk, seedws, disc)
 		if !record("boot:a", bootA, err) {
 			finish(false, "tab a failed to boot")
 			return
 		}
-		bootB, err := sendCmd(b, "boot", "", seedpk, seedws, disc)
+		bootB, err := br.SendCmd(b, "boot", "", seedpk, seedws, disc)
 		if !record("boot:b", bootB, err) {
 			finish(false, "tab b failed to boot")
 			return
@@ -322,16 +93,16 @@ func main() {
 		}
 
 		// 2. dial a WebRTC transport a → b (signaling rides dmsg).
-		dial, err := sendCmd(a, "dialTransport", pkB, "webrtc")
+		dial, err := br.SendCmd(a, "dialTransport", pkB, "webrtc")
 		if !record("dialTransport:a→b(webrtc)", dial, err) {
 			finish(false, "WebRTC transport a→b failed")
 			return
 		}
 
 		// 3. both ends should now report >=1 transport.
-		statA, errA := sendCmd(a, "status")
+		statA, errA := br.SendCmd(a, "status")
 		record("status:a", statA, errA)
-		statB, errB := sendCmd(b, "status")
+		statB, errB := br.SendCmd(b, "status")
 		record("status:b", statB, errB)
 		ta := transportCount(statA.Value)
 		tb := transportCount(statB.Value)

--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io/fs"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -15,13 +16,18 @@ import (
 
 	"github.com/skycoin/skywire/pkg/visor"
 	"github.com/skycoin/skywire/pkg/wasmhv"
+	"github.com/skycoin/skywire/pkg/wasmhv/ctlbridge"
 	"github.com/skycoin/skywire/pkg/wasmhv/wasmbin"
 )
 
-var serveAddr string
+var (
+	serveAddr    string
+	serveHarness bool
+)
 
 func init() {
 	serveCmd.Flags().StringVarP(&serveAddr, "addr", "a", ":7999", "HTTP listen address")
+	serveCmd.Flags().BoolVar(&serveHarness, "harness", false, "mount the /ctl/* operator control bridge (drive the in-tab visor from a shell); DEV ONLY — never expose publicly")
 	RootCmd.AddCommand(serveCmd)
 }
 
@@ -66,7 +72,7 @@ page never asks anyone to type a secret key.`,
 		// autoupdate.js. Short SHA-256 prefix is plenty to spot a content change.
 		sum := sha256.Sum256(wasm)
 		wasmVer := hex.EncodeToString(sum[:])[:16]
-		index := injectBoot(indexB, wasmVer)
+		index := injectBoot(indexB, wasmVer, serveHarness)
 
 		mux := http.NewServeMux()
 		serveBytes := func(path, ct string, body []byte) {
@@ -90,6 +96,18 @@ page never asks anyone to type a secret key.`,
 			w.Header().Set("Cache-Control", "no-store")
 			_, _ = w.Write([]byte(wasmVer)) //nolint:errcheck // best-effort
 		})
+
+		// --harness mounts the same /ctl/* operator control bridge the dev harness
+		// (cmd/dmsg-wasm/serve.go) exposes, plus the ctl-bridge.js the page loads to
+		// connect to it. This lets a shell drive the in-tab visor (status, hvApi,
+		// RPC bridge) against the embedded wasm + current UI. DEV ONLY: it opens an
+		// unauthenticated control + eval surface — never enable it behind a public
+		// reverse proxy.
+		if serveHarness {
+			ctlbridge.New(log.Printf).Register(mux)
+			serveBytes("/ctl-bridge.js", "text/javascript", wasmhv.CtlBridgeJS)
+			cmd.Println("harness: /ctl/* control bridge mounted (DEV ONLY — do not expose publicly)")
+		}
 
 		// Everything else is the built Angular UI (incl. lazy chunks, css, fonts,
 		// assets). Routing is hash-based (#/...), so the server only ever sees "/"
@@ -123,7 +141,7 @@ page never asks anyone to type a secret key.`,
 // and boot() starts (CFG.ready) before SkywireHttpBackend's first /api call. It
 // also loads browse.js + the launcher, which mount the dmsg/skynet browse+host
 // overlay (a floating "skynet" button) once the wasm-visor is up.
-func injectBoot(index []byte, wasmVer string) []byte {
+func injectBoot(index []byte, wasmVer string, harness bool) []byte {
 	s := string(index)
 	tag := "\n<script src=\"hv-boot.js\"></script>\n" +
 		"<script src=\"browse.js\"></script>\n" +
@@ -132,6 +150,11 @@ func injectBoot(index []byte, wasmVer string) []byte {
 		// newer one and self-reload (it only runs here, never in the native UI).
 		"<script>window.__SKYWIRE_WASM_VERSION__=" + strconv.Quote(wasmVer) + ";</script>\n" +
 		"<script src=\"autoupdate.js\"></script>\n"
+	// --harness only: connect the tab to the /ctl/* control bridge so a shell can
+	// drive it. Never injected on the public serving path.
+	if harness {
+		tag += "<script src=\"ctl-bridge.js\"></script>\n"
+	}
 	lower := strings.ToLower(s)
 	if i := strings.Index(lower, "<head"); i >= 0 {
 		if j := strings.IndexByte(s[i:], '>'); j >= 0 {

--- a/pkg/wasmhv/ctl-bridge.js
+++ b/pkg/wasmhv/ctl-bridge.js
@@ -1,0 +1,47 @@
+// ctl-bridge.js — connects this serverless-HV tab to the ctlbridge control
+// surface (SSE /ctl/events) so a shell can inspect/drive the in-tab visor
+// (status, checkRegistered, hvApi, …) and see boot progress in /ctl/log. Served
+// by the cmd/dmsg-wasm harness and by `cli hv serve --harness`. Debug aid for
+// the serverless-UI harness; NOT part of the shipped standalone.
+(function () {
+  var tabId = sessionStorage.getItem('ctlTabId');
+  if (!tabId) { tabId = 'hv-' + Math.random().toString(36).slice(2, 8); sessionStorage.setItem('ctlTabId', tabId); }
+  var post = function (path, body) {
+    return fetch(path, { method: 'POST', body: typeof body === 'string' ? body : JSON.stringify(body) }).catch(function () {});
+  };
+  // wasm-visor vlog() forwards boot progress here → /ctl/log.
+  window.__skylog = function (m) { post('/ctl/log?tab=' + tabId, '[hv] ' + m); };
+
+  async function exec(c) {
+    var a = c.args || [];
+    var v = window.skywireVisor || {};
+    switch (c.action) {
+      case 'status': return v.status ? v.status() : { error: 'no skywireVisor yet' };
+      case 'checkRegistered': return v.checkRegistered ? await v.checkRegistered() : { error: 'not ready' };
+      case 'hvApi': {
+        var r = await v.hvApi(a[0] || 'GET', a[1] || '/api/visors-summary', a[2] || null);
+        return { status: r.status, body: new TextDecoder().decode(r.body).slice(0, 1200) };
+      }
+      case 'bootResult': return window.__SKYWIRE_HV__ && window.__SKYWIRE_HV__.ready
+        ? await window.__SKYWIRE_HV__.ready.then(function (pk) { return { booted: pk }; }).catch(function (e) { return { bootError: String(e && e.message || e) }; })
+        : { error: 'no ready promise' };
+      // reload the page (re-fetches freshly served assets). The tab keeps its
+      // ctlTabId (sessionStorage), so the bridge reconnects under the same id.
+      case 'reload': setTimeout(function () { location.reload(); }, 50); return { reloading: true };
+      // generic driver: eval a[0] in the page and return the (awaited) result —
+      // lets the shell click the browse/host panel, fill inputs, query the DOM,
+      // etc. Harness-only debug aid; NEVER shipped in the standalone.
+      case 'js': { var out = await (0, eval)(a[0]); return { value: out === undefined ? null : out }; }
+      default: throw new Error('unknown action: ' + c.action);
+    }
+  }
+
+  var es = new EventSource('/ctl/events?tab=' + tabId);
+  es.onmessage = async function (ev) {
+    var c = JSON.parse(ev.data);
+    try { var v = await exec(c); post('/ctl/result', { id: c.id, ok: true, value: v }); }
+    catch (e) { post('/ctl/result', { id: c.id, ok: false, error: e.message || String(e) }); }
+  };
+  es.onerror = function () {};
+  post('/ctl/log?tab=' + tabId, 'ctl-bridge ready ' + tabId);
+})();

--- a/pkg/wasmhv/ctlbridge/ctlbridge.go
+++ b/pkg/wasmhv/ctlbridge/ctlbridge.go
@@ -1,0 +1,288 @@
+// Package ctlbridge is the operator control bridge for the wasm-visor harness.
+//
+// It lets an EXTERNAL operator (curl, or `skywire cli`) drive the in-browser
+// wasm-visor tab(s) without anyone clicking: each tab connects back over SSE
+// (GET /ctl/events) to receive commands and POSTs results (/ctl/result) + log
+// lines (/ctl/log). Two tabs can be orchestrated headlessly — e.g. `listen` on
+// one and dial from the other.
+//
+// The handler set is shared by two front-ends:
+//   - the dev harness  cmd/dmsg-wasm/serve.go  (serves a -dir build)
+//   - `skywire cli hv serve --harness`         (serves the embedded wasm + UI)
+//
+// so the production serving path can opt into the same debug surface behind a
+// flag instead of duplicating it. The browser side is ctl-bridge.js (embedded
+// in pkg/wasmhv as CtlBridgeJS); inject it onto the page to activate the tab.
+package ctlbridge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/skycoin/skywire/pkg/wasmrpc"
+)
+
+type tab struct {
+	id      string
+	events  chan string // SSE command frames queued for this tab
+	mu      sync.Mutex
+	logs    []string
+	rpcAddr string // local 127.0.0.1:<port> the wasmrpc bridge fronts (when connected)
+}
+
+// Command is one command queued for a tab over SSE.
+type Command struct {
+	ID     string        `json:"id"`
+	Action string        `json:"action"`
+	Args   []interface{} `json:"args"`
+}
+
+// Result is a tab's reply to a Command.
+type Result struct {
+	ID    string      `json:"id"`
+	OK    bool        `json:"ok"`
+	Value interface{} `json:"value"`
+	Error string      `json:"error"`
+}
+
+// Bridge holds the live tab registry + pending-command table. Safe for
+// concurrent use. Create with New, wire with Register.
+type Bridge struct {
+	logf    func(string, ...interface{})
+	mu      sync.Mutex
+	tabs    map[string]*tab
+	pending map[string]chan Result
+	seq     int
+}
+
+// New returns a ready Bridge. logf is used for connection/bridge diagnostics
+// (pass log.Printf, or nil to discard).
+func New(logf func(string, ...interface{})) *Bridge {
+	if logf == nil {
+		logf = func(string, ...interface{}) {}
+	}
+	return &Bridge{
+		logf:    logf,
+		tabs:    map[string]*tab{},
+		pending: map[string]chan Result{},
+	}
+}
+
+func (b *Bridge) getTab(id string) *tab {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	t := b.tabs[id]
+	if t == nil {
+		t = &tab{id: id, events: make(chan string, 8)}
+		b.tabs[id] = t
+	}
+	return t
+}
+
+// SendCmd queues one command for a tab over SSE and waits for its result.
+// Shared by the /ctl/cmd handler and scripted sequences (e.g. meshtest).
+func (b *Bridge) SendCmd(tabID, action string, args ...interface{}) (Result, error) {
+	b.mu.Lock()
+	t := b.tabs[tabID]
+	b.mu.Unlock()
+	if t == nil {
+		return Result{}, fmt.Errorf("no such tab %q (open it first)", tabID)
+	}
+	if args == nil {
+		args = []interface{}{}
+	}
+	b.mu.Lock()
+	b.seq++
+	c := Command{ID: fmt.Sprintf("c%d", b.seq), Action: action, Args: args}
+	ch := make(chan Result, 1)
+	b.pending[c.ID] = ch
+	b.mu.Unlock()
+	defer func() { b.mu.Lock(); delete(b.pending, c.ID); b.mu.Unlock() }()
+
+	t.mu.Lock()
+	evCh := t.events
+	t.mu.Unlock()
+	raw, _ := json.Marshal(c) //nolint:errcheck // marshaling a Command never fails
+	select {
+	case evCh <- string(raw):
+	case <-time.After(5 * time.Second):
+		return Result{}, fmt.Errorf("tab %q not receiving", tabID)
+	}
+	select {
+	case res := <-ch:
+		return res, nil
+	case <-time.After(40 * time.Second):
+		return Result{}, fmt.Errorf("tab %q command %q timeout", tabID, action)
+	}
+}
+
+// Register mounts the /ctl/* handlers on mux.
+func (b *Bridge) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/ctl/events", b.handleEvents)
+	mux.HandleFunc("/ctl/result", b.handleResult)
+	mux.HandleFunc("/ctl/log", b.handleLog)
+	mux.HandleFunc("/ctl/clear", b.handleClear)
+	mux.HandleFunc("/ctl/tabs", b.handleTabs)
+	mux.HandleFunc("/ctl/rpc", b.handleRPC)
+	mux.HandleFunc("/ctl/cmd", b.handleCmd)
+}
+
+// handleEvents — SSE: a tab subscribes here to receive commands. On reconnect
+// (page reload, same id), install a FRESH events channel as the tab's current
+// one so commands go to the live connection — not a lingering old reader.
+func (b *Bridge) handleEvents(w http.ResponseWriter, r *http.Request) {
+	t := b.getTab(r.URL.Query().Get("tab"))
+	fl, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "no flush", 500)
+		return
+	}
+	ch := make(chan string, 8)
+	t.mu.Lock()
+	t.events = ch
+	t.mu.Unlock()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	fmt.Fprint(w, ": connected\n\n") //nolint:errcheck // best-effort SSE write
+	fl.Flush()
+	b.logf("tab connected: %s", t.id)
+	for {
+		select {
+		case msg := <-ch:
+			fmt.Fprintf(w, "data: %s\n\n", msg) //nolint:errcheck // best-effort SSE write
+			fl.Flush()
+		case <-r.Context().Done():
+			return
+		case <-time.After(15 * time.Second):
+			fmt.Fprint(w, ": ping\n\n") //nolint:errcheck // best-effort SSE write
+			fl.Flush()
+		}
+	}
+}
+
+// handleResult — a tab posts a command result back here.
+func (b *Bridge) handleResult(w http.ResponseWriter, r *http.Request) {
+	var res Result
+	if err := json.NewDecoder(r.Body).Decode(&res); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	b.mu.Lock()
+	ch := b.pending[res.ID]
+	b.mu.Unlock()
+	if ch != nil {
+		select {
+		case ch <- res:
+		default:
+		}
+	}
+	w.WriteHeader(204)
+}
+
+// handleLog — a tab streams its log lines here (POST); GET reads them back.
+func (b *Bridge) handleLog(w http.ResponseWriter, r *http.Request) {
+	t := b.getTab(r.URL.Query().Get("tab"))
+	if r.Method == http.MethodPost {
+		raw, _ := io.ReadAll(r.Body) //nolint:errcheck // best-effort read of a log line
+		t.mu.Lock()
+		t.logs = append(t.logs, string(raw))
+		t.mu.Unlock()
+		w.WriteHeader(204)
+		return
+	}
+	t.mu.Lock()
+	out := append([]string(nil), t.logs...)
+	t.mu.Unlock()
+	for _, l := range out {
+		fmt.Fprintln(w, l) //nolint:errcheck // best-effort write to the client
+	}
+}
+
+// handleClear — clear a tab's buffered logs (so each test reads fresh output).
+func (b *Bridge) handleClear(w http.ResponseWriter, r *http.Request) {
+	t := b.getTab(r.URL.Query().Get("tab"))
+	t.mu.Lock()
+	t.logs = nil
+	t.mu.Unlock()
+	w.WriteHeader(204)
+}
+
+// handleTabs — list connected tabs, each with its RPC bridge address (if
+// connected) so a shell can do: skywire --rpc <rpc> visor info
+func (b *Bridge) handleTabs(w http.ResponseWriter, _ *http.Request) {
+	type tabInfo struct {
+		ID  string `json:"id"`
+		RPC string `json:"rpc,omitempty"`
+	}
+	b.mu.Lock()
+	out := make([]tabInfo, 0, len(b.tabs))
+	for id, t := range b.tabs {
+		t.mu.Lock()
+		out = append(out, tabInfo{ID: id, RPC: t.rpcAddr})
+		t.mu.Unlock()
+	}
+	b.mu.Unlock()
+	_ = json.NewEncoder(w).Encode(out) //nolint:errcheck // best-effort write to the client
+}
+
+// handleRPC — RPC bridge: a wasm-visor tab dials this WebSocket and serves its
+// visor RPC over it; we front it with a local 127.0.0.1:<port> that
+// `skywire cli --rpc` targets. One bridge per tab; closed when the tab
+// disconnects. See pkg/wasmrpc.
+func (b *Bridge) handleRPC(w http.ResponseWriter, r *http.Request) {
+	t := b.getTab(r.URL.Query().Get("tab"))
+	c, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		b.logf("rpc bridge accept (%s): %v", t.id, err)
+		return
+	}
+	c.SetReadLimit(-1)
+	conn := websocket.NetConn(context.Background(), c, websocket.MessageBinary)
+	bridge, err := wasmrpc.NewBridge(conn, 0, func(m string) { b.logf("[rpc %s] %s", t.id, m) })
+	if err != nil {
+		b.logf("rpc bridge (%s): %v", t.id, err)
+		_ = c.Close(websocket.StatusInternalError, "bridge setup failed") //nolint:errcheck // best-effort close
+		return
+	}
+	t.mu.Lock()
+	t.rpcAddr = bridge.Addr()
+	t.mu.Unlock()
+	b.logf("tab %s RPC bridge UP at %s — drive it: skywire --rpc %s visor info", t.id, bridge.Addr(), bridge.Addr())
+	<-r.Context().Done()
+	_ = bridge.Close() //nolint:errcheck // best-effort close on tab disconnect
+	t.mu.Lock()
+	t.rpcAddr = ""
+	t.mu.Unlock()
+	b.logf("tab %s RPC bridge closed", t.id)
+}
+
+// handleCmd — operator drives a tab: queue a command, wait for its result.
+func (b *Bridge) handleCmd(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("tab")
+	b.mu.Lock()
+	t := b.tabs[id]
+	b.mu.Unlock()
+	if t == nil {
+		http.Error(w, "no such tab (open it first)", 404)
+		return
+	}
+	var c Command
+	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	res, err := b.SendCmd(id, c.Action, c.Args...)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusGatewayTimeout)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(res) //nolint:errcheck // best-effort write to the client
+}

--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -38,6 +38,15 @@ var AutoUpdateJS []byte
 //go:embed hv-boot.js
 var HvBootJS []byte
 
+// CtlBridgeJS is pkg/wasmhv/ctl-bridge.js — the browser side of the ctlbridge
+// control surface (pkg/wasmhv/ctlbridge). It connects the tab to /ctl/events
+// over SSE so a shell can drive the in-tab wasm-visor. Injected ONLY when the
+// harness control surface is enabled (the dev harness, or `hv serve --harness`),
+// never on the public serving path.
+//
+//go:embed ctl-bridge.js
+var CtlBridgeJS []byte
+
 // WasmExecJS is Go's lib/wasm/wasm_exec.js, vendored here so a generated file is
 // self-contained. It MUST match the Go toolchain that built the embedded/passed
 // dmsg.wasm — refresh it with the wasm build (the Makefile bundle target copies


### PR DESCRIPTION
## What

`cli hv serve` now accepts a `--harness` flag that mounts the same `/ctl/*` operator control surface the dev harness (`cmd/dmsg-wasm/serve.go`) exposes, and injects `ctl-bridge.js` onto the page. This lets a shell drive the in-tab wasm-visor (`status`, `hvApi`, the RPC bridge for `skywire --rpc`) against the binary's **embedded** wasm + the **current** Angular UI — instead of the separate `make wasm-visor` + dir-serve dev loop with a stale UI.

## Why

The two serving paths had diverged: production `hv serve` ships the embedded wasm + latest UI (so the violet-hue / tab-hide changes show) but has no control bridge; the dev harness has the `/ctl/*` bridge but serves a hand-built `build/hv-wasm` dir. `--harness` lets the production path opt into the debug surface, so the shipped build is exactly what gets driven headlessly.

## Safety

Off by default. Without `--harness` the public serving path is **unchanged** — `/ctl/*` and `/ctl-bridge.js` both 404 and no script is injected (verified). The flag opens an unauthenticated control + `eval` surface, so it is **DEV ONLY** and must never sit behind a public reverse proxy; the command logs a warning when it's on.

## How

- Extracts the `/ctl/*` handlers (SSE `events`, `result`, `log`, `clear`, `tabs`, `rpc`, `cmd`) out of `cmd/dmsg-wasm/serve.go` into a shared `pkg/wasmhv/ctlbridge` package — one implementation for both front-ends. The dev harness keeps its two-tab `meshtest` sequence layered on top of the shared `Bridge.SendCmd`.
- Moves `ctl-bridge.js` into the source tree and embeds it as `wasmhv.CtlBridgeJS`.
- Adds the `--harness` bool flag to `hv serve`; when set, registers the bridge, serves `/ctl-bridge.js`, and injects the script tag.

## Test

```
./skywire cli hv serve --harness --addr :8087
# /ctl/tabs → []   /ctl-bridge.js → served   page injects ctl-bridge.js
./skywire cli hv serve --addr :8088
# /ctl/tabs → 404  /ctl-bridge.js → 404       page does NOT inject it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)