### PR TITLE
feat(dmsg-server): self-derive wss WS URL from PK via wss_domain_suffix

### DIFF
--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -132,6 +132,16 @@ type Config struct {
 	// (Server.AddressWS), e.g. "wss://dmsg1.skywire.skycoin.com/dmsg". Required
 	// when WSAddress is set, otherwise clients learn no URL to dial.
 	PublicAddressWS string `json:"public_address_ws,omitempty"`
+	// WSSDomainSuffix, when set, makes the server SELF-DERIVE its advertised
+	// wss:// WS URL from its own PK: "wss://<base32(PK)>.<suffix>/dmsg" (the
+	// base32 PK is the 53-char cipher.PubKey.DNSLabel — a DNS-safe identity
+	// label). It overrides the bare ws://IP advertised on the unified main port,
+	// so an HTTPS-served browser wasm-visor can reach the server with no mixed
+	// content. The WS listener stays plain on the main port; a front proxy
+	// (Caddy) terminates TLS for <label>.<suffix> and reverse-proxies to it (the
+	// server logs the exact Caddy line on startup). One uniform suffix across all
+	// servers is enough — each self-labels — so no per-server URL to hand-match.
+	WSSDomainSuffix string `json:"wss_domain_suffix,omitempty"`
 	// WTAddress is the local "host:port" the server binds a UDP socket on for
 	// the WebTransport (HTTP/3-over-QUIC) listener (dmsg-over-WebTransport).
 	// Empty disables WT — the default, so no extra port opens unless the

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -288,7 +288,22 @@ func (s *service) Run(ctx context.Context) error {
 	mainWSURL := ""
 	if cfg.WSAddress == "" && primaryAdvertised != "" && !strings.HasPrefix(primaryAdvertised, ":") {
 		mainWSURL = "ws://" + primaryAdvertised + "/dmsg"
-		log.WithField("ws_url", mainWSURL).Info("Serving dmsg over WebSocket on the main port (unified).")
+		// wss_domain_suffix: advertise a TLS-fronted wss:// URL self-derived from
+		// this server's PK instead of the bare ws://IP, so an HTTPS-served browser
+		// wasm-visor can reach it without mixed content. The listener stays plain
+		// ws on the main port; a front proxy (Caddy) terminates TLS. We log the
+		// exact Caddy line so the operator just pastes it (no label to compute).
+		if suffix := strings.TrimPrefix(cfg.WSSDomainSuffix, "."); suffix != "" {
+			host := cfg.PubKey.DNSLabel() + "." + suffix
+			mainWSURL = "wss://" + host + "/dmsg"
+			proxyTarget := primaryAdvertised
+			if _, port, perr := net.SplitHostPort(primaryAdvertised); perr == nil {
+				proxyTarget = "127.0.0.1:" + port
+			}
+			log.WithField("ws_url", mainWSURL).Infof("dmsg-ws: advertising wss (front with TLS) — Caddy: %s { reverse_proxy %s }", host, proxyTarget)
+		} else {
+			log.WithField("ws_url", mainWSURL).Info("Serving dmsg over WebSocket on the main port (unified).")
+		}
 	}
 
 	go srvAPI.RunBackgroundTasks(runCtx)


### PR DESCRIPTION
## Why

Giving a dmsg server a TLS-fronted `wss://` WebSocket URL (so an HTTPS-served browser wasm-visor can reach it without mixed content — see #3315/#3316) previously meant hand-setting `public_address_ws` per server to a URL whose hostname had to match a hand-written Caddy block. Two hardcoded values kept in sync by hand, per server.

## Change

`wss_domain_suffix`: set **one** uniform suffix (e.g. `theskywirenetwork.net`) across all dmsg-server configs, and each server **self-derives** its advertised URL from its own PK:

```
wss://<base32(PK)>.<suffix>/dmsg
```

where `base32(PK)` is the 53-char `cipher.PubKey.DNSLabel` — a DNS-safe, decodable identity label (so the wss hostname literally *is* the PK). It overrides the bare `ws://IP` advertised on the unified main port; the WS listener stays plain on that port, and a front proxy (Caddy) terminates TLS.

The server also **logs the exact Caddy line** on startup:

```
dmsg-ws: advertising wss (front with TLS) — Caddy: <label>.<suffix> { reverse_proxy 127.0.0.1:<port> }
```

so the operator pastes it rather than computing the label. No per-server hand-matching.

## Test

`go build ./...` green. Behavior is opt-in (empty suffix → unchanged `ws://IP` main-port advertisement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)