### PR TITLE
fix(transport): WT bound the STCP port (:7777), not its own UDP port

### DIFF
--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -4,6 +4,7 @@ package network
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -141,7 +142,13 @@ func (f *ClientFactory) MakeClient(netType types.Type, port int) (Client, error)
 		return wc, nil
 	case types.WT:
 		wc := newWT(generic, f.WTTable)
-		wc.(*wtClient).ar = f.ARClient // native: register/resolve WT endpoint+cert via AR
+		wtc := wc.(*wtClient)
+		wtc.ar = f.ARClient // native: register/resolve WT endpoint+cert via AR
+		// WT binds its OWN UDP socket (HTTP/3-over-QUIC) — NOT f.ListenAddr, which
+		// is the STCP TCP address (:7777). Using f.ListenAddr made WT register the
+		// STCP port in the AR (a wrong, often-unforwarded port). Bind the wt_port
+		// passed via InitClient (":0" = ephemeral, registered with the AR either way).
+		wtc.listenAddr = fmt.Sprintf(":%d", port)
 		return wc, nil
 	case types.WEBRTC:
 		return newWebRTC(generic, f.DmsgC, f.ICEURLs), nil

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -411,7 +411,13 @@ func initWSClient(ctx context.Context, v *Visor, _ *logging.Logger) error {
 // restarts via re-register); a fixed firewall port can be pinned later.
 // Depends on &tr so v.tpM and the AR client both exist.
 func initWTClient(ctx context.Context, v *Visor, _ *logging.Logger) error {
-	v.tpM.InitClient(ctx, types.WT, 0)
+	// WT binds its OWN UDP port (it's HTTP/3-over-QUIC and can't share squic's
+	// socket). wt_port PINS it for NAT-forwarding; 0 binds an ephemeral port.
+	port := 0
+	if v.conf.Transport != nil {
+		port = v.conf.Transport.WTPort
+	}
+	v.tpM.InitClient(ctx, types.WT, port)
 	return nil
 }
 

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -428,6 +428,13 @@ type Transport struct {
 	// rule is wanted; the bound port is registered with the address resolver
 	// either way, so a random port works and survives restarts.
 	QUICPort int `json:"quic_port,omitempty"`
+	// WTPort optionally PINS the UDP port for the WebTransport (WT) listener,
+	// mirroring quic_port. WT is HTTP/3-over-QUIC, so it needs its OWN UDP socket
+	// — it cannot share the unified transport_port with the raw-QUIC (squic)
+	// transport (two QUIC listeners can't bind one UDP port). 0 (default/omitted)
+	// binds an ephemeral port; the bound port + cert hash are registered with the
+	// address resolver either way. Set a fixed port to forward it through a NAT.
+	WTPort int `json:"wt_port,omitempty"`
 	// ARTransportLimit controls address resolver registration for privacy:
 	//   0 (default): stay registered indefinitely
 	//   N > 0: deregister from AR after N transports are established


### PR DESCRIPTION
## Symptom
A visor's WebTransport endpoint resolved (via the address resolver) to its **STCP default port** `:7777` — e.g. a browser autoconnect dialing `https://<ip>:7777/skywire` — even on visors with `stcpr_port=0`, `transport_port=7778`. `:7777` is never advertised and usually not the visor's forwarded port, so WT-to-that-visor targets the wrong port.

## Cause
`ClientFactory.MakeClient` set every client's `listenAddr = f.ListenAddr` (the STCP TCP address, `skyenv.STCPAddr = ":7777"`) and ignored the `port` arg for the table-based types. STCP wants that; WS rides the stcpr TCP cmux; but **WT is a separate HTTP/3-over-QUIC UDP listener** — it bound UDP `:7777` and `BindWT`'d `:7777`.

## Fix
WT now binds its **own** UDP port via the `InitClient` port arg, exposed as a new **`wt_port`** config (mirroring `quic_port`): `0` = ephemeral (registered with the AR either way), or a fixed port to forward through a NAT. WT can't share the unified `transport_port` with raw-QUIC/`squic` — two QUIC listeners can't bind one UDP socket — so it gets its own pin. STCP/WS behaviour unchanged.

Builds: native + `js/wasm`; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)