### PR TITLE
refactor(transport): rename QUIC type wire name squic → squicr

### DIFF
--- a/pkg/transport/types/preference.go
+++ b/pkg/transport/types/preference.go
@@ -55,15 +55,16 @@ func SetPreferenceOrder(order []Type) {
 // detect this by comparing input/output lengths.
 func ParsePreferenceOrder(s []string) []Type {
 	known := map[string]Type{
-		string(STCPR):      STCPR,
-		string(QUIC):       QUIC, // "squic"
-		string(QUICLegacy): QUIC, // "quic" — back-compat alias
-		string(SUDPH):      SUDPH,
-		string(STCP):       STCP,
-		string(WEBRTC):     WEBRTC,
-		string(WS):         WS,
-		string(WT):         WT,
-		string(DMSG):       DMSG,
+		string(STCPR):       STCPR,
+		string(QUIC):        QUIC, // "squicr"
+		string(QUICLegacy):  QUIC, // "quic"  — back-compat alias
+		string(QUICLegacy2): QUIC, // "squic" — back-compat alias
+		string(SUDPH):       SUDPH,
+		string(STCP):        STCP,
+		string(WEBRTC):      WEBRTC,
+		string(WS):          WS,
+		string(WT):          WT,
+		string(DMSG):        DMSG,
 	}
 	out := make([]Type, 0, len(s))
 	for _, name := range s {

--- a/pkg/transport/types/preference_test.go
+++ b/pkg/transport/types/preference_test.go
@@ -30,7 +30,7 @@ func TestDefaultPreferenceOrder(t *testing.T) {
 	}
 }
 
-// TestParsePreferenceOrder confirms every known type (canonical "squic" included)
+// TestParsePreferenceOrder confirms every known type (canonical "squicr" included (alias "squic"))
 // parses, and unknown strings are dropped.
 func TestParsePreferenceOrder(t *testing.T) {
 	in := []string{"stcpr", "squic", "sudph", "stcp", "webrtc", "ws", "wt", "dmsg", "nope"}
@@ -46,21 +46,26 @@ func TestParsePreferenceOrder(t *testing.T) {
 	}
 }
 
-// TestQUICLegacyAlias confirms the canonical QUIC wire name is "squic" and the
-// pre-rename "quic" still parses + normalizes for back-compat.
+// TestQUICLegacyAlias confirms the canonical QUIC wire name is "squicr" and the
+// pre-rename names "quic"/"squic" still parse + normalize for back-compat.
 func TestQUICLegacyAlias(t *testing.T) {
-	if QUIC != "squic" {
-		t.Fatalf("QUIC canonical wire name = %q, want squic", QUIC)
+	if QUIC != "squicr" {
+		t.Fatalf("QUIC canonical wire name = %q, want squicr", QUIC)
 	}
 	if NormalizeType(QUICLegacy) != QUIC {
-		t.Fatalf(`NormalizeType("quic") = %q, want squic`, NormalizeType(QUICLegacy))
+		t.Fatalf(`NormalizeType("quic") = %q, want squicr`, NormalizeType(QUICLegacy))
+	}
+	if NormalizeType(QUICLegacy2) != QUIC {
+		t.Fatalf(`NormalizeType("squic") = %q, want squicr`, NormalizeType(QUICLegacy2))
 	}
 	if NormalizeType(QUIC) != QUIC {
 		t.Fatalf("NormalizeType is not idempotent on the canonical name")
 	}
-	// Both names parse to QUIC in a preference list.
-	if got := ParsePreferenceOrder([]string{"quic"}); len(got) != 1 || got[0] != QUIC {
-		t.Fatalf(`ParsePreferenceOrder(["quic"]) = %v, want [squic]`, got)
+	// All three names parse to QUIC in a preference list.
+	for _, n := range []string{"quic", "squic", "squicr"} {
+		if got := ParsePreferenceOrder([]string{n}); len(got) != 1 || got[0] != QUIC {
+			t.Fatalf(`ParsePreferenceOrder([%q]) = %v, want [squicr]`, n, got)
+		}
 	}
 }
 

--- a/pkg/transport/types/types.go
+++ b/pkg/transport/types/types.go
@@ -15,16 +15,20 @@ const (
 	STCP Type = "stcp"
 	// DMSG is a type of a transport that works through an intermediary service
 	DMSG Type = "dmsg"
-	// QUIC (wire name "squic" — skywire-quic, matching stcp/stcpr/sudph) is a
-	// type of a transport that works via QUIC over UDP, resolving addresses using
-	// the address-resolver service. Gives reliable streams plus RFC 9221
-	// unreliable datagrams; the TLS session is bound to the skywire static key
-	// (#2607 QUIC follow-on). The legacy wire name "quic" is still accepted on
-	// input (NormalizeType / the preference parser) for back-compat.
-	QUIC Type = "squic"
-	// QUICLegacy is the pre-rename wire name for QUIC, accepted on input so older
-	// configs / CLI invocations / discovery entries keep working. Not emitted.
-	QUICLegacy Type = "quic"
+	// QUIC (wire name "squicr") is a transport over QUIC/UDP that resolves the
+	// peer address via the address-resolver. The name follows the taxonomy
+	// s(kywire-Noise)+protocol+suffix: the Noise+yamux layer runs over the QUIC
+	// stream exactly as for every other transport (the "s"), it is QUIC (the
+	// "quic"), and "r" = address-resolver (matching stcp→stcpr). QUIC's own TLS
+	// is additionally bound to the skywire static key (#2607). The pre-rename
+	// names "squic" and "quic" are still accepted on input (NormalizeType / the
+	// preference parser) for back-compat; only "squicr" is emitted.
+	QUIC Type = "squicr"
+	// QUICLegacy / QUICLegacy2 are the pre-rename wire names for QUIC ("quic" →
+	// "squic" → "squicr"), accepted on input so older configs / CLI invocations /
+	// discovery entries keep working. Not emitted.
+	QUICLegacy  Type = "quic"
+	QUICLegacy2 Type = "squic"
 	// WS is a type of a transport that works visor-to-visor over a direct
 	// WebSocket, resolving the peer's wss:// endpoint via a PK table. Unlike the
 	// dmsg WebSocket carrier (which reaches a dmsg server), this is a first-class
@@ -53,10 +57,11 @@ const (
 
 // NormalizeType maps a legacy transport-type wire name to its canonical Type, so
 // older configs / CLI invocations / discovery entries keep working after a
-// rename. Currently only "quic" → "squic" (QUIC). Canonical or unknown values
-// pass through unchanged.
+// rename. Currently "quic" and "squic" → "squicr" (QUIC). Canonical or unknown
+// values pass through unchanged.
 func NormalizeType(t Type) Type {
-	if t == QUICLegacy {
+	switch t {
+	case QUICLegacy, QUICLegacy2:
 		return QUIC
 	}
 	return t

--- a/pkg/visor/api_transport.go
+++ b/pkg/visor/api_transport.go
@@ -222,7 +222,7 @@ func (v *Visor) AddTransport(remote cipher.PubKey, tpType string, timeout time.D
 		return nil, fmt.Errorf("--no-register flag is only valid for user-labeled transports")
 	}
 
-	// Accept the legacy "quic" wire name as well as the canonical "squic".
+	// Accept the legacy "quic"/"squic" wire names as well as the canonical "squicr".
 	netType := types.NormalizeType(types.Type(tpType))
 
 	v.log.Debugf("Saving transport to %v via %v with label %s", remote, netType, tpLabel)


### PR DESCRIPTION
Finishes the transport-type taxonomy: **`s`** = the skywire-Noise layer, then protocol, then suffix **`r`** = address-resolver / **`h`** = holepunch / none = manual PK-table.

The AR-resolved QUIC transport runs **Noise+yamux over its QUIC/TLS stream** exactly like every other transport (so the `s` is real — verified in `quic.go`), and it resolves via the address-resolver, so it gets the `r` to match `stcp`→`stcpr`: **`squic` → `squicr`**. (QUIC's own TLS is *additionally* bound to the skywire static key.)

**Back-compat:** `NormalizeType` + the preference parser accept both pre-rename names (`quic`, `squic`) → `squicr`; only `squicr` is emitted. The AR `/bind|/resolve` paths are unaffected (fixed strings, not the type name). Tests updated.

**Reserves `quic`/`quicr`** for a future *single*-encrypted QUIC transport (the PK-bound QUIC-TLS only, no redundant Noise) — the performance variant — so the two can coexist: `squicr` (Noise-over-QUIC, post-quantum-handshake-capable per #27) and `quicr` (fast). That's additive future work, not part of this rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)