### PR TITLE
feat(transport): static config tables (ws/wt/quic) + finish ws/wt→swsr/swtr taxonomy

### DIFF
--- a/cmd/skywire-cli/commands/tp/tp-id.go
+++ b/cmd/skywire-cli/commands/tp/tp-id.go
@@ -29,7 +29,7 @@ discovery query — and mirrors transport.MakeTransportID().
 
 The returned ID is independent of PK order: id(T, A, B) == id(T, B, A).
 
-Valid transport types: stcpr, squic, sudph, stcp, webrtc, ws, wt, dmsg (default: dmsg)`,
+Valid transport types: stcpr, squicr, sudph, stcp, webrtc, swsr, swtr, dmsg (default: dmsg)`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		if !tptypes.Valid(tptypes.Type(idTpType)) {

--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -68,6 +68,10 @@ type ClientFactory struct {
 	// WTTable maps a peer PK to its direct WebTransport endpoint + pinned cert
 	// hash for the WT transport type. A nil/absent table disables WT dialing.
 	WTTable WTTable
+	// QUICTable statically pins a peer PK → UDP address ("host:port") for the QUIC
+	// transport type (the QUIC analog of PKTable/stcp). Consulted before the
+	// address resolver; nil/absent = AR-only.
+	QUICTable stcp.PKTable
 	// ICEURLs are the STUN/TURN URLs used for ICE by the WEBRTC transport type
 	// (skywire's own STUN, reused from sudph). Empty = host candidates only.
 	ICEURLs []string

--- a/pkg/transport/network/client_resolved.go
+++ b/pkg/transport/network/client_resolved.go
@@ -54,6 +54,7 @@ func (f *ClientFactory) makeResolvedClient(netType types.Type, generic *genericC
 		if err != nil {
 			return nil, err
 		}
+		c.(*quicClient).table = f.QUICTable // static PK→addr pins (AR-free dial)
 		if sc := f.sharedUDPConnFor(protoQUIC, port); sc != nil {
 			c.(*quicClient).sharedConn = sc
 		}

--- a/pkg/transport/network/quic.go
+++ b/pkg/transport/network/quic.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport/network/stcp"
 	types "github.com/skycoin/skywire/pkg/transport/types"
 )
 
@@ -42,7 +43,12 @@ const quicErrNoStream quic.ApplicationErrorCode = 1
 
 type quicClient struct {
 	*resolvedClient
-	port int
+	// table statically pins peer PK → UDP address ("host:port"), the QUIC analog
+	// of stcp's pk_table (transport.quic_table). Dial consults it before the
+	// address resolver, so a configured peer dials with no AR lookup — exactly
+	// like the WS/WT clients. nil/empty = AR-only (the default).
+	table stcp.PKTable
+	port  int
 	// sharedConn, when set, is the UDP socket QUIC listens over instead of
 	// binding its own — the QUIC demux conn of a unified transport_port socket
 	// (see udpDemux). nil = bind a dedicated socket (the default / per-type-port
@@ -65,6 +71,16 @@ func newQuic(resolved *resolvedClient, port int) Client {
 	client := &quicClient{resolvedClient: resolved, port: port}
 	client.netType = types.QUIC
 	return client
+}
+
+// tableAddr looks up a statically-configured UDP address for rPK. The table is
+// a nil interface when unconfigured (AR-only), so guard it — calling a method on
+// a nil interface would panic the visor (same guard as the WS client).
+func (c *quicClient) tableAddr(rPK cipher.PubKey) (string, bool) {
+	if c.table == nil {
+		return "", false
+	}
+	return c.table.Addr(rPK)
 }
 
 // quicStreamConn adapts a single QUIC stream (+ its connection) to net.Conn.
@@ -171,9 +187,19 @@ func (c *quicClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16) 
 		return nil, io.ErrClosedPipe
 	}
 	c.log.Debugf("Dialing PK %v over QUIC", rPK)
-	conn, err := c.dialVisor(ctx, rPK, func(ctx context.Context, addr string) (net.Conn, error) {
-		return c.dial(ctx, addr, rPK)
-	})
+	// Endpoint resolution order: static PK table first (a manually-configured
+	// peer — the QUIC analog of stcp's pk_table), then the address resolver.
+	// Mirrors the WS/WT clients; a nil/empty table just falls through to the AR.
+	var conn net.Conn
+	var err error
+	if addr, ok := c.tableAddr(rPK); ok {
+		c.log.Debugf("Resolved PK %v to %s via static QUIC table", rPK, addr)
+		conn, err = c.dial(ctx, addr, rPK)
+	} else {
+		conn, err = c.dialVisor(ctx, rPK, func(ctx context.Context, addr string) (net.Conn, error) {
+			return c.dial(ctx, addr, rPK)
+		})
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/transport/types/preference.go
+++ b/pkg/transport/types/preference.go
@@ -62,8 +62,10 @@ func ParsePreferenceOrder(s []string) []Type {
 		string(SUDPH):       SUDPH,
 		string(STCP):        STCP,
 		string(WEBRTC):      WEBRTC,
-		string(WS):          WS,
-		string(WT):          WT,
+		string(WS):          WS, // "swsr"
+		string(WSLegacy):    WS, // "ws"    — back-compat alias
+		string(WT):          WT, // "swtr"
+		string(WTLegacy):    WT, // "wt"    — back-compat alias
 		string(DMSG):        DMSG,
 	}
 	out := make([]Type, 0, len(s))

--- a/pkg/transport/types/preference_test.go
+++ b/pkg/transport/types/preference_test.go
@@ -69,6 +69,34 @@ func TestQUICLegacyAlias(t *testing.T) {
 	}
 }
 
+// TestWSWTLegacyAlias confirms the canonical WS/WT wire names are "swsr"/"swtr"
+// and the pre-rename names "ws"/"wt" still parse + normalize for back-compat.
+func TestWSWTLegacyAlias(t *testing.T) {
+	if WS != "swsr" {
+		t.Fatalf("WS canonical wire name = %q, want swsr", WS)
+	}
+	if WT != "swtr" {
+		t.Fatalf("WT canonical wire name = %q, want swtr", WT)
+	}
+	if NormalizeType(WSLegacy) != WS {
+		t.Fatalf(`NormalizeType("ws") = %q, want swsr`, NormalizeType(WSLegacy))
+	}
+	if NormalizeType(WTLegacy) != WT {
+		t.Fatalf(`NormalizeType("wt") = %q, want swtr`, NormalizeType(WTLegacy))
+	}
+	if NormalizeType(WS) != WS || NormalizeType(WT) != WT {
+		t.Fatal("NormalizeType is not idempotent on the canonical WS/WT names")
+	}
+	for _, c := range []struct {
+		name string
+		want Type
+	}{{"ws", WS}, {"swsr", WS}, {"wt", WT}, {"swtr", WT}} {
+		if got := ParsePreferenceOrder([]string{c.name}); len(got) != 1 || got[0] != c.want {
+			t.Fatalf(`ParsePreferenceOrder([%q]) = %v, want [%s]`, c.name, got, c.want)
+		}
+	}
+}
+
 // TestSetPreferenceOrderSortsTransports verifies a configured override actually
 // reorders a slice the way the router's dial logic relies on.
 func TestSetPreferenceOrderSortsTransports(t *testing.T) {

--- a/pkg/transport/types/types.go
+++ b/pkg/transport/types/types.go
@@ -29,13 +29,22 @@ const (
 	// discovery entries keep working. Not emitted.
 	QUICLegacy  Type = "quic"
 	QUICLegacy2 Type = "squic"
-	// WS is a type of a transport that works visor-to-visor over a direct
-	// WebSocket, resolving the peer's wss:// endpoint via a PK table. Unlike the
-	// dmsg WebSocket carrier (which reaches a dmsg server), this is a first-class
-	// skywire transport between two visors. A browser visor can DIAL it (the
-	// browser's WebSocket API) but not accept it (no server) — server-visors run
-	// the WS listener; see pkg/transport/network/ws_native.go / ws_tinygo.go.
-	WS Type = "ws"
+	// WS (wire name "swsr") is a transport that works visor-to-visor over a direct
+	// WebSocket. The name follows the taxonomy s(kywire-Noise)+protocol+suffix: the
+	// Noise+yamux layer runs over the WebSocket exactly as for every other
+	// transport (the "s"), it is WebSocket (the "ws"), and "r" = it resolves the
+	// peer's wss:// endpoint via the address-resolver when not pinned in the static
+	// ws_table (matching stcp→stcpr). Unlike the dmsg WebSocket carrier (which
+	// reaches a dmsg server), this is a first-class skywire transport between two
+	// visors. A browser visor can DIAL it (the browser's WebSocket API) but not
+	// accept it (no server) — server-visors run the WS listener; see
+	// pkg/transport/network/ws_native.go / ws_tinygo.go. The pre-rename name "ws"
+	// is still accepted on input (NormalizeType / the preference parser); only
+	// "swsr" is emitted.
+	WS Type = "swsr"
+	// WSLegacy is the pre-rename wire name for WS ("ws" → "swsr"), accepted on
+	// input so older configs / discovery entries keep working. Not emitted.
+	WSLegacy Type = "ws"
 	// WEBRTC is a type of a transport that works visor-to-visor over a direct
 	// WebRTC DataChannel (DTLS+SCTP, NAT-traversed via ICE). It is the genuinely
 	// peer-to-peer transport: the payload rides a direct encrypted pipe between two
@@ -44,25 +53,37 @@ const (
 	// is adapted to a net.Conn carrying the usual Noise+yamux session. Both ends can
 	// be browsers (syscall/js) or native (pion); see pkg/transport/network/webrtc*.
 	WEBRTC Type = "webrtc"
-	// WT is a type of a transport that works visor-to-visor over a direct
-	// WebTransport (HTTP/3 over QUIC) link, resolving the peer's https:// endpoint
-	// and pinned cert hash via a table. Like the dmsg WebTransport carrier, the
-	// server presents a short-lived self-signed cert pinned by SHA-256 (no CA, no
-	// domain) and the client→server PK is authenticated in the Noise handshake. A
-	// browser visor can DIAL it (the browser WebTransport API, serverCertificate-
-	// Hashes) but not accept it (no server) — server-visors run the WT listener;
-	// see pkg/transport/network/wt_native.go / wt_tinygo.go.
-	WT Type = "wt"
+	// WT (wire name "swtr") is a transport that works visor-to-visor over a direct
+	// WebTransport (HTTP/3 over QUIC) link. The name follows the taxonomy
+	// s(kywire-Noise)+protocol+suffix: the Noise+yamux layer runs over the
+	// WebTransport stream (the "s"), it is WebTransport (the "wt"), and "r" = it
+	// resolves the peer's https:// endpoint + pinned cert hash via the
+	// address-resolver when not pinned in the static wt_table. Like the dmsg
+	// WebTransport carrier, the server presents a short-lived self-signed cert
+	// pinned by SHA-256 (no CA, no domain) and the client→server PK is
+	// authenticated in the Noise handshake. A browser visor can DIAL it (the
+	// browser WebTransport API, serverCertificateHashes) but not accept it (no
+	// server) — server-visors run the WT listener; see
+	// pkg/transport/network/wt_native.go / wt_tinygo.go. The pre-rename name "wt"
+	// is still accepted on input; only "swtr" is emitted.
+	WT Type = "swtr"
+	// WTLegacy is the pre-rename wire name for WT ("wt" → "swtr"), accepted on
+	// input so older configs / discovery entries keep working. Not emitted.
+	WTLegacy Type = "wt"
 )
 
 // NormalizeType maps a legacy transport-type wire name to its canonical Type, so
 // older configs / CLI invocations / discovery entries keep working after a
-// rename. Currently "quic" and "squic" → "squicr" (QUIC). Canonical or unknown
-// values pass through unchanged.
+// rename. Currently "quic"/"squic" → "squicr" (QUIC), "ws" → "swsr" (WS), and
+// "wt" → "swtr" (WT). Canonical or unknown values pass through unchanged.
 func NormalizeType(t Type) Type {
 	switch t {
 	case QUICLegacy, QUICLegacy2:
 		return QUIC
+	case WSLegacy:
+		return WS
+	case WTLegacy:
+		return WT
 	}
 	return t
 }

--- a/pkg/visor/api_hypervisors.go
+++ b/pkg/visor/api_hypervisors.go
@@ -151,7 +151,7 @@ func (v *Visor) RemoveAllHypervisors() (int, error) {
 		c()
 	}
 	// Persist an empty configured set so none reconnect on restart (now that
-	// config-loaded hypervisors are tracked + cancelled here too).
+	// config-loaded hypervisors are tracked + canceled here too).
 	v.persistHypervisors(nil)
 	return len(cancels), nil
 }

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -168,8 +168,8 @@ func registerModules(logger *logging.MasterLogger) {
 	stcprC = maker("stcpr", initStcprClient, &tr)
 	stcpC = maker("stcp", initStcpClient, &tr)
 	quicC = maker("quic", initQuicClient, &tr)
-	wsC = maker("ws", initWSClient, &tr)
-	wtC = maker("wt", initWTClient, &tr)
+	wsC = maker("swsr", initWSClient, &tr)
+	wtC = maker("swtr", initWTClient, &tr)
 	dmsgC = maker("dmsg", initDmsg, &ebc, &dmsgHTTP)
 	dmsgCtrl = maker("dmsg_ctrl", initDmsgCtrl, &dmsgC, &tr)
 	// dmsghttp_logserver mounts /pty on top of dmsgpty's CLI socket

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -527,6 +527,12 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		}
 		wtTable = network.NewWTTable(entries)
 	}
+	// Static QUIC peers (transport.quic_table): pin PK → UDP "host:port" so a QUIC
+	// transport dials with no AR lookup (the QUIC analog of skywire-tcp's pk_table).
+	var quicTable stcp.PKTable
+	if v.conf.Transport != nil && len(v.conf.Transport.QUICTable) > 0 {
+		quicTable = stcp.NewTable(v.conf.Transport.QUICTable)
+	}
 	// WebRTC ICE servers: the configured STUN servers, prefixed with the stun:
 	// scheme the WebRTC stack wants. Set on the factory now; the WEBRTC client is
 	// started after dmsg comes up (init_dmsg → InitClient), since its signaling
@@ -544,6 +550,7 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		PKTable:    table,
 		WSTable:    wsTable,
 		WTTable:    wtTable,
+		QUICTable:  quicTable,
 		ARClient:   v.arClient,
 		EB:         v.ebc,
 		MLogger:    v.MasterLogger(),

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -508,6 +508,25 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		listenAddr = v.conf.STCP.ListeningAddress
 	}
 	v.stcpTable = table
+	// Static WS peers (transport.ws_table): pin PK → wss:// URL so a WS transport
+	// can be dialed with no address-resolver lookup, the WS analog of skywire-tcp.
+	// nil when unconfigured (runtime/autoconnect entries still work — the WS
+	// client tolerates a nil table).
+	var wsTable stcp.PKTable
+	if v.conf.Transport != nil && len(v.conf.Transport.WSTable) > 0 {
+		wsTable = stcp.NewTable(v.conf.Transport.WSTable)
+	}
+	// Static WT peers (transport.wt_table): pin PK → {url, cert_hash} so a WT
+	// transport dials with no AR lookup. nil when unconfigured (the WT client
+	// tolerates it; runtime/autoconnect entries still work).
+	var wtTable network.WTTable
+	if v.conf.Transport != nil && len(v.conf.Transport.WTTable) > 0 {
+		entries := make(map[cipher.PubKey]network.WTEntry, len(v.conf.Transport.WTTable))
+		for pk, p := range v.conf.Transport.WTTable {
+			entries[pk] = network.WTEntry{URL: p.URL, CertHash: p.CertHash}
+		}
+		wtTable = network.NewWTTable(entries)
+	}
 	// WebRTC ICE servers: the configured STUN servers, prefixed with the stun:
 	// scheme the WebRTC stack wants. Set on the factory now; the WEBRTC client is
 	// started after dmsg comes up (init_dmsg → InitClient), since its signaling
@@ -523,6 +542,8 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		SK:         v.conf.SK,
 		ListenAddr: listenAddr,
 		PKTable:    table,
+		WSTable:    wsTable,
+		WTTable:    wtTable,
 		ARClient:   v.arClient,
 		EB:         v.ebc,
 		MLogger:    v.MasterLogger(),

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -448,6 +448,11 @@ type Transport struct {
 	// visor DIAL a WT transport to a configured peer with no address-resolver
 	// lookup. Runtime entries are added on top; empty/omitted = no static WT peers.
 	WTTable map[cipher.PubKey]WTPeer `json:"wt_table,omitempty"`
+	// QUICTable statically pins QUIC transport peers by PK → UDP address
+	// ("host:port") — the QUIC analog of skywire-tcp's pk_table (and of ws_table /
+	// wt_table). Lets a visor DIAL a QUIC transport to a configured peer with no
+	// address-resolver lookup. Consulted before the AR; empty/omitted = AR-only.
+	QUICTable map[cipher.PubKey]string `json:"quic_table,omitempty"`
 	// ARTransportLimit controls address resolver registration for privacy:
 	//   0 (default): stay registered indefinitely
 	//   N > 0: deregister from AR after N transports are established

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -435,6 +435,19 @@ type Transport struct {
 	// binds an ephemeral port; the bound port + cert hash are registered with the
 	// address resolver either way. Set a fixed port to forward it through a NAT.
 	WTPort int `json:"wt_port,omitempty"`
+	// WSTable statically pins WebSocket (WS) transport peers by PK → wss:// URL —
+	// the WS analog of skywire-tcp's pk_table (STCP). It lets a visor DIAL a WS
+	// transport to a configured peer with NO address-resolver lookup (e.g. a peer
+	// on a LAN, or any visor whose wss endpoint you know), exactly as STCP pins
+	// TCP peers. Entries learned at runtime (autoconnect / a browser hook) are
+	// added on top; empty/omitted = no static WS peers.
+	WSTable map[cipher.PubKey]string `json:"ws_table,omitempty"`
+	// WTTable statically pins WebTransport (WT) peers by PK → {url, cert_hash} —
+	// the WT analog of ws_table. WT has no CA, so the dialer pins the peer's
+	// self-signed cert SHA-256 (cert_hash); url is the https:// endpoint. Lets a
+	// visor DIAL a WT transport to a configured peer with no address-resolver
+	// lookup. Runtime entries are added on top; empty/omitted = no static WT peers.
+	WTTable map[cipher.PubKey]WTPeer `json:"wt_table,omitempty"`
 	// ARTransportLimit controls address resolver registration for privacy:
 	//   0 (default): stay registered indefinitely
 	//   N > 0: deregister from AR after N transports are established
@@ -442,6 +455,14 @@ type Transport struct {
 	// When deregistered, the visor cannot receive new inbound transports
 	// but can still initiate outbound connections.
 	ARTransportLimit int `json:"ar_transport_limit,omitempty"`
+}
+
+// WTPeer is a statically-configured WebTransport peer (transport.wt_table): the
+// peer's https:// WebTransport endpoint and the lowercase-hex SHA-256 of its
+// self-signed cert, which the dialer pins (WT has no CA).
+type WTPeer struct {
+	URL      string `json:"url"`
+	CertHash string `json:"cert_hash"`
 }
 
 // TPSDmsgConfig configures the embedded Transport Setup Node's dmsg client.

--- a/pkg/wasmhv/self.go
+++ b/pkg/wasmhv/self.go
@@ -64,8 +64,8 @@ func (c *Core) selfRoute(self SelfProvider, sub string) (int, []byte) {
 		return jsonResp([]struct{}{})
 	case "transport-types":
 		// The direct transport types the wasm-visor can create (WebRTC is a
-		// symmetric DataChannel; ws/wt are browser-dial-only).
-		return jsonResp([]string{"dmsg", "ws", "wt", "webrtc"})
+		// symmetric DataChannel; swsr/swtr are browser-dial-only).
+		return jsonResp([]string{"dmsg", "swsr", "swtr", "webrtc"})
 	case "host-stats":
 		// A browser tab has no host to measure (no CPU/RAM/disk/NIC of its own),
 		// so report the shape with zeros + js/wasm identity. This keeps the


### PR DESCRIPTION
Completes the transport-type config + taxonomy cleanup. Two related pieces:

## 1. Static config tables for WS, WT and QUIC

STCP can statically pin peers by PK→addr (`skywire-tcp.pk_table`) so a transport dials with **no address-resolver lookup**. The other carriers had no such static config. This adds the PK-table analog to each:

- `transport.ws_table` — `PK → wss:// URL`
- `transport.wt_table` — `PK → {url, cert_hash}` (WT pins a self-signed cert hash; no CA/domain)
- `transport.quic_table` — `PK → UDP "host:port"`

Wired into the `ClientFactory`. The WS/WT/QUIC `Dial` paths try the static table **first**, then fall back to the address resolver — configured peer dials statically, everything else still resolves via the AR. Unconfigured = nil table = unchanged behaviour (clients nil-guard the table). QUIC stays a single type (`squicr`) with table-first→AR-fallback, mirroring WS/WT, rather than a separate manual transport type.

## 2. Finish the taxonomy: ws→swsr, wt→swtr

Following `squic→squicr`, the WebSocket/WebTransport types adopt `s`(kywire-Noise)+protocol+`r`(esolver): **`swsr`** and **`swtr`**. Only the canonical wire strings change — the Go constants `types.WS`/`types.WT` are unchanged, so all references are untouched. The old `"ws"`/`"wt"` are kept as legacy aliases (`WSLegacy`/`WTLegacy`) via `NormalizeType` + the preference parser, so older configs/discovery entries keep working (same back-compat shape as quic/squic→squicr). The dmsg-server `CarrierWS`/`CarrierWT` names are a separate wire namespace and are intentionally left as `"ws"`/`"wt"`.

Also fixes the `tp id` help text (which still said `squic` and `ws, wt`) and adds `TestWSWTLegacyAlias`.

## Test

- `go build ./...` and `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor/ ./pkg/wasmhv/` — clean
- `go test ./pkg/transport/... ./pkg/wasmhv/` — green (incl. new alias test)
- gofmt + golangci-lint clean on touched files
- `config_compat.go` mirrors the whole `Transport` struct, so the new table fields round-trip