### PR TITLE
fix(address-resolver): normalize transport type so /resolve/wt + /resolve/quic stop 500ing

### DIFF
--- a/pkg/address-resolver/store/memory_store.go
+++ b/pkg/address-resolver/store/memory_store.go
@@ -23,6 +23,7 @@ func newMemoryStore() *memStore {
 func (s *memStore) Bind(_ context.Context, netType types.Type, pk cipher.PubKey, visorData addrresolver.VisorData) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	netType = types.NormalizeType(netType)
 
 	if _, ok := s.visorData[netType]; !ok {
 		s.visorData[netType] = make(map[string]addrresolver.VisorData)
@@ -52,6 +53,7 @@ func (s *memStore) Bind(_ context.Context, netType types.Type, pk cipher.PubKey,
 func (s *memStore) DelBind(_ context.Context, netType types.Type, pk cipher.PubKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	netType = types.NormalizeType(netType)
 	delete(s.visorData[netType], pk.String())
 	return nil
 }
@@ -59,6 +61,7 @@ func (s *memStore) DelBind(_ context.Context, netType types.Type, pk cipher.PubK
 func (s *memStore) Resolve(_ context.Context, netType types.Type, pk cipher.PubKey) (addrresolver.VisorData, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	netType = types.NormalizeType(netType)
 
 	tpTypeData, ok := s.visorData[netType]
 	if !ok {
@@ -76,6 +79,7 @@ func (s *memStore) Resolve(_ context.Context, netType types.Type, pk cipher.PubK
 func (s *memStore) GetAll(_ context.Context, netType types.Type) (pks []string, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	netType = types.NormalizeType(netType)
 
 	for pk := range s.visorData[netType] {
 		pks = append(pks, pk)

--- a/pkg/address-resolver/store/normalize_test.go
+++ b/pkg/address-resolver/store/normalize_test.go
@@ -1,0 +1,47 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// TestResolveLegacyTypeAlias guards the AR /resolve 500 regression: the WT/QUIC
+// renames made types.WT/types.QUIC "swtr"/"squicr", but clients (and the
+// resolve URL) still send the legacy "wt"/"quic". Without normalization the
+// store's type switch missed every case → ErrUnknownTransportType → HTTP 500.
+// A bind under the canonical type must be resolvable by the legacy name (and
+// vice-versa), and an unknown type must still be ErrUnknownTransportType.
+func TestResolveLegacyTypeAlias(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStore()
+	pk, _ := cipher.GenerateKeyPair()
+	data := addrresolver.VisorData{RemoteAddr: "1.2.3.4:5678"}
+
+	// Bind via the canonical constants (what the bind handlers pass).
+	require.NoError(t, s.Bind(ctx, types.WT, pk, data))
+	require.NoError(t, s.Bind(ctx, types.QUIC, pk, data))
+
+	for _, name := range []types.Type{"wt", "swtr", "quic", "squic", "squicr"} {
+		got, err := s.Resolve(ctx, name, pk)
+		require.NoErrorf(t, err, "resolve %q must not error (was the AR 500)", name)
+		require.Equal(t, data.RemoteAddr, got.RemoteAddr, "resolve %q", name)
+	}
+
+	// A genuinely unknown type cleanly misses (the mem store reports ErrNoEntry →
+	// HTTP 404), never a hit and never the 500-causing path.
+	_, err := s.Resolve(ctx, "bogus", pk)
+	require.ErrorIs(t, err, ErrNoEntry)
+
+	// Bind via a legacy name resolves under the canonical name too.
+	pk2, _ := cipher.GenerateKeyPair()
+	require.NoError(t, s.Bind(ctx, "wt", pk2, data))
+	got, err := s.Resolve(ctx, types.WT, pk2)
+	require.NoError(t, err)
+	require.Equal(t, data.RemoteAddr, got.RemoteAddr)
+}

--- a/pkg/address-resolver/store/redis_store.go
+++ b/pkg/address-resolver/store/redis_store.go
@@ -65,6 +65,7 @@ func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl
 }
 
 func (s *redisStore) Bind(ctx context.Context, netType types.Type, pk cipher.PubKey, visorData addrresolver.VisorData) error {
+	netType = types.NormalizeType(netType)
 	switch netType {
 	case types.STCPR, types.SUDPH, types.QUIC, types.WT:
 		return s.bindWithIndex(ctx, netType, pk, visorData)
@@ -74,6 +75,7 @@ func (s *redisStore) Bind(ctx context.Context, netType types.Type, pk cipher.Pub
 }
 
 func (s *redisStore) DelBind(ctx context.Context, netType types.Type, pk cipher.PubKey) error {
+	netType = types.NormalizeType(netType)
 	switch netType {
 	case types.STCPR, types.SUDPH, types.QUIC, types.WT:
 		return s.delBindWithIndex(ctx, netType, pk)
@@ -83,6 +85,7 @@ func (s *redisStore) DelBind(ctx context.Context, netType types.Type, pk cipher.
 }
 
 func (s *redisStore) Resolve(ctx context.Context, netType types.Type, pk cipher.PubKey) (addrresolver.VisorData, error) {
+	netType = types.NormalizeType(netType)
 	switch netType {
 	case types.STCPR, types.SUDPH, types.QUIC, types.WT:
 		key := getKey(string(netType), pk)
@@ -93,6 +96,7 @@ func (s *redisStore) Resolve(ctx context.Context, netType types.Type, pk cipher.
 }
 
 func (s *redisStore) GetAll(ctx context.Context, netType types.Type) ([]string, error) {
+	netType = types.NormalizeType(netType)
 	switch netType {
 	case types.STCPR, types.SUDPH, types.QUIC, types.WT:
 		if pks, ok := s.getAllCache.Get(netType); ok {


### PR DESCRIPTION
## Root cause

The WT/QUIC type renames made `types.WT`/`types.QUIC` the canonical `"swtr"`/`"squicr"`, but clients and the `/resolve/{type}/{pk}` URL still send the legacy `"wt"`/`"quic"`. The store's type switch (`case types.STCPR, types.SUDPH, types.QUIC, types.WT`) only matched the canonical constants, so `"wt"`/`"quic"` fell to `default` → `ErrUnknownTransportType` → the resolve handler returned **HTTP 500** instead of a clean 404.

**Impact:** every `/resolve/wt` and `/resolve/quic` 500'd fleet-wide, so no visor could resolve a peer's WT/QUIC endpoint and those transports never formed. This is:
- the cause of the wasm-visor autoconnect making **no transports** (its `resolveWT` got AR 500 for every peer), and
- the same root cause as the long-standing **QUIC `/bind`+`/resolve` 500** (task #34).

## Fix

Normalize the transport type at the store boundary (`Bind`/`DelBind`/`Resolve`/`GetAll`, both redis and memory stores) via `types.NormalizeType`, so a bind under the canonical type is resolvable by the legacy name and vice-versa. Bind handlers already pass the canonical constant; this makes resolve (which carries the raw URL string) agree.

## Test

`TestResolveLegacyTypeAlias`: `wt`/`swtr`/`quic`/`squic`/`squicr` all resolve a canonical bind; an unknown type still cleanly misses (`ErrNoEntry` → 404, never the 500 path). Builds clean.

## Deploy note

This is a deployment-service fix — the live address-resolver must redeploy for fleet visors (incl. the wasm visor) to resolve WT/QUIC again.