### PR TITLE
fix(rewards): pool 2 weight is per-IP, not per-visor — closes the splitting bonus

### DIFF
--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -249,6 +249,50 @@ func calcPresenceShare(ni nodeinfo, ipCounts, macCounts map[string]int) float64 
 	return share
 }
 
+// bytesPerIP returns the total bandwidth bytes per IP, considering
+// only visors whose Bandwidth meets the minBW threshold. Used by the
+// per-IP saturation step in pool 2: a visor's effective weight is
+// visor.Bandwidth × ipTotal[ip]^(exp-1), which makes the total weight
+// contributed by any IP scale as ipTotal^exp regardless of how the
+// bandwidth is distributed across visors at that IP. This prevents
+// an operator from multiplying their pool 2 share by splitting traffic
+// across many PKs at the same IP — and is address-agnostic, so the
+// same trick using multiple skycoin addresses fails identically.
+func bytesPerIP(nodes []nodeinfo, minBW uint64) map[string]uint64 {
+	out := make(map[string]uint64)
+	for _, ni := range nodes {
+		if ni.Bandwidth > 0 && ni.Bandwidth >= minBW {
+			out[ni.IPAddr] += ni.Bandwidth
+		}
+	}
+	return out
+}
+
+// pool2Weight returns the effective pool-2 weight of a visor under
+// per-IP saturation:
+//
+//	weight = bytes × ip.total ^ (exp - 1)
+//
+// Equivalent forms by exponent:
+//
+//	exp = 1.0 → bytes (strict bytes-proportional; per-IP form
+//	            collapses since ip.total^0 = 1)
+//	exp = 0.5 → bytes / sqrt(ip.total)   (default; per-IP sqrt)
+//	exp = 0.0 → bytes / ip.total         (each IP contributes equal
+//	            total weight, divided proportionally by byte share)
+//
+// The per-IP form means an IP sending N bytes always contributes N^exp
+// to the network total weight, regardless of how N is partitioned
+// across visors at that IP. Splitting a single big-bandwidth visor
+// into many small ones at the same IP no longer multiplies the
+// operator's pool 2 share. See bytesPerIP for the rationale.
+func pool2Weight(bytes, ipTotal uint64, exp float64) float64 {
+	if bytes == 0 || ipTotal == 0 {
+		return 0
+	}
+	return float64(bytes) * math.Pow(float64(ipTotal), exp-1.0)
+}
+
 // applyRegionalSaturation scales each visor's share by a per-country
 // density factor unique_ips_country^(exponent - 1). This is a per-visor
 // multiplier, not a country-pot allocation: a country's total reward
@@ -365,8 +409,9 @@ func aggregateBy(nodes []nodeinfo, field func(nodeinfo) float64) []rewardData {
 //	{wdate}_pool1_shares.csv     — every qualifying visor with its
 //	                               presence share + Pool 1 SKY.
 //	{wdate}_pool2_shares.csv     — only visors whose bandwidth cleared
-//	                               minBW, with bytes, weight (bytes^exp),
-//	                               and Pool 2 SKY.
+//	                               minBW, with bytes, effective weight
+//	                               (bytes × ip.total^(exp-1)), and
+//	                               Pool 2 SKY.
 //	{wdate}_pool1_rewardtxn0.csv — Pool 1 amounts aggregated by skycoin
 //	                               address (sorted descending).
 //	{wdate}_pool2_rewardtxn0.csv — Pool 2 amounts aggregated by skycoin
@@ -411,6 +456,13 @@ func writePerPoolFiles(histDir, wdate string, nodes []nodeinfo, bwExp float64, m
 	// set this file will be header-only; intentional so consumers
 	// can rely on the file's presence rather than condition on the
 	// mode flag.
+	//
+	// The Pool 2 Weight column is the visor's *effective* weight
+	// under per-IP saturation: bytes × ip.total^(exp-1). It collapses
+	// to the historical bytes^exp at exp=1.0, and at exp=0.5 becomes
+	// bytes / sqrt(ip.total). Auditors can verify Pool 2 SKY = Weight
+	// × rate, where rate is reported in stats.txt.
+	ipBytesFile := bytesPerIP(nodes, minBW)
 	if err := write("pool2_shares.csv", func(w io.Writer) error {
 		if _, err := fmt.Fprintln(w, "Skycoin Address, Skywire Public Key, Bandwidth (bytes), Pool 2 Weight, Pool 2 SKY, IP, Architecture, UUID, Interfaces, Country, XPub"); err != nil {
 			return err
@@ -424,7 +476,7 @@ func writePerPoolFiles(histDir, wdate string, nodes []nodeinfo, bwExp float64, m
 			if strings.HasPrefix(ni.SkyAddr, "xpub") {
 				xpub = ni.SkyAddr
 			}
-			weight := math.Pow(float64(ni.Bandwidth), bwExp)
+			weight := pool2Weight(ni.Bandwidth, ipBytesFile[ni.IPAddr], bwExp)
 			if _, err := fmt.Fprintf(w, "%s, %s, %d, %.6f, %.6f, %s, %s, %s, %s, %s, %s \n",
 				resolved, ni.PK, ni.Bandwidth, weight, ni.BandwidthReward,
 				ni.IPAddr, ni.Arch, ni.UUID, ni.Interfaces, ni.Country, xpub); err != nil {
@@ -1081,28 +1133,38 @@ Architectures:
 			}
 
 			// Bandwidth pool: add proportional bandwidth reward on top,
-			// dampened by --bw-sat-exp. At exponent 1.0 each visor's
-			// share is strictly bytes/total — the most concentrated
-			// outcome, where a single heavy sender can take a dominant
-			// fraction of the pool. At 0.5 (default) the weight is
-			// sqrt(bytes), flattening the distribution so a 100×
-			// bandwidth lead produces only a 10× share advantage.
-			// At 0 every sender that clears the threshold is weighted
-			// equally — effectively turning pool 2 into a presence
-			// pool for senders.
+			// dampened by --bw-sat-exp under per-IP saturation. A
+			// visor's effective weight is bytes × ip.total^(exp-1):
+			//
+			//   exp = 1.0 → bytes (strict bytes-proportional)
+			//   exp = 0.5 → bytes / sqrt(ip.total) (default; per-IP sqrt)
+			//   exp = 0.0 → bytes / ip.total (each IP contributes equal
+			//               total weight, divided proportionally by
+			//               byte share)
+			//
+			// The per-IP grouping closes the splitting bonus that the
+			// previous sum-of-sqrt-per-visor formula opened: under the
+			// old form an operator could 5× their pool 2 share by
+			// re-pointing one fat visor's traffic onto 37 PKs at the
+			// same IP, since sqrt is concave. With per-IP saturation
+			// the IP contributes ip.total^exp regardless of partition,
+			// so PK multiplication at one IP no longer pays. The same
+			// invariant holds across skycoin addresses — the per-IP
+			// total is address-agnostic.
+			ipBytes := bytesPerIP(nodesInfos1, minBWThreshold)
 			var totalBWShares float64
 			var bwPoolCount int
 			if !noBWPool {
 				for _, ni := range nodesInfos1 {
 					if ni.Bandwidth >= minBWThreshold {
-						totalBWShares += math.Pow(float64(ni.Bandwidth), bwSaturationExponent)
+						totalBWShares += pool2Weight(ni.Bandwidth, ipBytes[ni.IPAddr], bwSaturationExponent)
 						bwPoolCount++
 					}
 				}
 				if totalBWShares > 0 {
 					for i := range nodesInfos1 {
 						if nodesInfos1[i].Bandwidth >= minBWThreshold {
-							weight := math.Pow(float64(nodesInfos1[i].Bandwidth), bwSaturationExponent)
+							weight := pool2Weight(nodesInfos1[i].Bandwidth, ipBytes[nodesInfos1[i].IPAddr], bwSaturationExponent)
 							bw := weight * dayReward / totalBWShares
 							nodesInfos1[i].BandwidthReward = bw
 							nodesInfos1[i].Reward += bw
@@ -1144,7 +1206,7 @@ Architectures:
 				if noBWPool {
 					fmt.Printf("\n--- Bandwidth Pool: DISABLED (budget folded into presence) ---\n")
 				} else {
-					fmt.Printf("\n--- Bandwidth Pool (sender-pays, weighted bytes^%.2f) ---\n", bwSaturationExponent)
+					fmt.Printf("\n--- Bandwidth Pool (sender-pays, per-IP weighted bytes^%.2f) ---\n", bwSaturationExponent)
 					fmt.Printf("bandwidth pool budget: %.6f\n", dayReward)
 					fmt.Printf("Pool 2 Total: %.6f\n", pool2Sum)
 					fmt.Printf("minimum bandwidth threshold: %d bytes\n", minBWThreshold)
@@ -1156,17 +1218,20 @@ Architectures:
 						}
 					}
 					fmt.Printf("total network bandwidth: %s\n", formatBytes(totalBW))
+					fmt.Printf("contributing IPs: %d\n", len(ipBytes))
 					fmt.Printf("bandwidth saturation exponent: %.2f\n", bwSaturationExponent)
 					if totalBWShares > 0 {
-						// "Per √byte" is the actual linear coefficient
-						// in sqrt-share space: reward = bytes^exp * rate
-						// where rate = dayReward / Σ(bytes^exp). At
-						// exponent 1.0 this collapses to the per-byte
-						// rate; at 0.5 it's the per-√byte rate. Print
-						// it unconditionally so operators can derive
-						// any specific-bandwidth example without
-						// reaching into the shares CSV math.
-						fmt.Printf("Skycoin Per (bytes^%.2f) (Pool 2): %.12f\n", bwSaturationExponent, dayReward/totalBWShares)
+						// Pool 2 rate is SKY per unit of effective
+						// pool-2 weight, where weight = bytes ×
+						// ip.total^(exp-1). At exp=1.0 this collapses
+						// to the per-byte rate (and Skycoin Per GB is
+						// emitted explicitly below). At exp=0.5 each
+						// visor's weight is bytes/sqrt(ip.total) — a
+						// visor's reward is its share of its IP's
+						// sqrt-weighted slice of the pool. Print the
+						// rate unconditionally so operators can
+						// reproduce any visor's reward as Weight×rate.
+						fmt.Printf("Skycoin Per Pool 2 Weight Unit: %.12f\n", dayReward/totalBWShares)
 						if bwSaturationExponent == 1.0 {
 							fmt.Printf("Skycoin Per GB (Pool 2): %.6f\n", dayReward/totalBWShares*1024*1024*1024)
 						}

--- a/rewards/mainnet_rules.md
+++ b/rewards/mainnet_rules.md
@@ -43,15 +43,19 @@ Regional saturation scaling is applied to the presence pool to promote geographi
 
 The bandwidth pool reward for a day is distributed based on the amount of transport bandwidth each visor **sent** during the previous day — sender-pays. A visor accrues bandwidth credit for the bytes it transmitted on each transport, with its per-edge sent counter capped by the counterparty's reported recv so a one-sided inflation cannot pump credit. Only visors whose sender-side total exceeds a minimum threshold are eligible for the bandwidth pool.
 
-The pool is divided using a square-root scaling of sent bytes — analogous to how regional saturation scales the presence pool, but applied to bandwidth amount instead of country IP count:
+The pool is divided using a **per-IP** scaling of sent bytes. Each IP's total sent bandwidth is first aggregated across all visors at that IP; the IP then contributes `ip_total ^ exponent` to the network weight; each visor at the IP receives a slice of that contribution proportional to its share of the IP's bytes:
 
 ```
-visor_weight    = sent_bytes ^ bandwidth_exponent     (default 0.5)
+ip_total        = sum(sent_bytes_of_each_visor_at_ip)
+visor_weight    = (visor.sent_bytes / ip_total) * (ip_total ^ bandwidth_exponent)
+                = visor.sent_bytes * (ip_total ^ (bandwidth_exponent - 1))
 visor_share     = visor_weight / sum(all visor_weights)
 visor_reward    = visor_share * pool_2_budget
 ```
 
-With the default exponent of `0.5`, a 100× bandwidth lead over another sender produces only a ~10× share advantage. This prevents any single high-throughput visor from dominating the pool while still rewarding heavier senders more than lighter ones. Setting the exponent to `1.0` reverts to strict bytes-proportional distribution; `0` weights every qualifying sender equally.
+With the default exponent of `0.5`, a 100× bandwidth lead by one IP over another produces only a ~10× share advantage — preventing any single high-throughput IP from dominating the pool while still rewarding heavier senders more than lighter ones. Setting the exponent to `1.0` reverts to strict bytes-proportional distribution; `0` gives every contributing IP equal total weight (divided proportionally among its senders).
+
+**Why per-IP?** Splitting one visor's traffic across many PKs at the same IP — or pointing those PKs at different skycoin addresses — does not change the IP's `ip_total`, so it does not change the IP's contribution to the pool. PK / address multiplication at a single IP is therefore neutral; the only way to earn more pool 2 is to actually send more bandwidth, or to send from more distinct IPs.
 
 Each transport edge is evaluated independently: a visor earns bandwidth credit for what it sent regardless of whether the counterparty is also reward-eligible. Credit only flows to the sender, so an ineligible peer was never going to receive a share — its eligibility is not checked.
 


### PR DESCRIPTION
## Problem

The previous pool 2 formula computed each visor's weight as `sqrt(visor.bytes)` and summed across all visors at a skycoin address. Because `sqrt` is concave, splitting one visor's bandwidth across N visors at the same IP always grew the address's total weight — the bonus is `(Σsqrt(b_i)) / sqrt(Σb_i)`, maximised when bytes are even.

On 2026-06-26 this let an operator with 37 visors at one operator-pool sweep **16% of pool 2 with 18 MB** while an honest 2-visor operator with **74 MB took only 7%**:

| Operator | Visors | IPs | Bytes | Old Pool 2 | Share |
|---|---:|---:|---:|---:|---:|
| 5CmPZ26V | 37 | 15 | 17.96 MB | 179.55 SKY | 16.06% |
| fqbvfpRU | 2 | 2 | 74.14 MB | 79.14 SKY | 7.08% |

`mainnet_rules.md` said the sqrt prevented \"any single high-throughput visor from dominating the pool\" — true for one visor, but it didn't prevent an operator with many smaller PKs at the same IP from sweeping it.

## Why not per-address?

Per-address aggregation can't fix this because the skycoin address is operator-controllable — they'd just split the same trick across multiple addresses and it would be invisible. The dedup has to happen at something the operator **can't** multiply: **IP**.

## Fix

```
visor.weight = bytes × ip.total ^ (exp - 1)
             = (bytes / ip.total) × ip.total ^ exp
```

Every IP contributes `ip.total^exp` to the network weight regardless of how that bandwidth is partitioned across visors or addresses at that IP. PK/address multiplication at one IP is now neutral. The only way to earn more pool 2 is to send more bandwidth or to send from more distinct IPs.

## Exponent semantics preserved

| value | weight at exp | meaning |
|---|---|---|
| 1.0 | `bytes` | strict bytes-proportional (the `ip.total^0 = 1` collapse makes this case byte-identical to the prior formula) |
| 0.5 | `bytes / sqrt(ip.total)` | default; per-IP sqrt |
| 0.0 | `bytes / ip.total` | each IP gets equal total weight, divided proportionally by byte share |

## Modeled deltas on 2026-06-26

199.6 MB across 142 IPs / 386 BW visors, default exp 0.5:

| Operator | Visors | IPs | Bytes | Old | New | Δ |
|---|---:|---:|---:|---:|---:|---:|
| 4ve73p4j | 51 | 51 | 5.19 MB | 105.04 | **169.20** | **+61.1%** |
| fqbvfpRU | 2 | 2 | 74.14 MB | 79.14 | **127.22** | **+60.7%** |
| N8VrqKkU | 2 | 1 | 43.44 MB | 53.66 | **82.82** | **+54.3%** |
| 5CmPZ26V | 37 | 15 | 17.96 MB | 179.55 | 162.17 | −9.7% |
| b6Ku3Svj | 28 | 22 | 2.07 MB | 49.74 | 73.75 | +48.3% |
| 2MhSYV43 | 10 | 1 | 12.46 MB | 74.64 | 45.21 | −39.4% |
| K9TzLrgq | 8 | 1 | 2.23 MB | 29.91 | 19.13 | −36.0% |
| pXt1fqLV | 12 | 2 | 0.88 MB | 24.65 | 14.42 | −41.5% |
| 2676X47q | 7 | 1 | 1.31 MB | 20.26 | 14.64 | −27.8% |
| 2MwHUXbC | 31 | 4 | 0.21 MB | 17.69 | 10.72 | −39.4% |
| w1qbzKxX | 8 | 1 | 2.50 MB | 26.06 | 20.26 | −22.2% |

Operators who actually push bandwidth gain. Operators who multiply PKs at the same IP lose. Total pool 2 = 1117.81 SKY unchanged.

## Implementation notes

- Two small helpers (`bytesPerIP`, `pool2Weight`), wired into the runtime calc and `writePerPoolFiles`.
- **Pool 1 (presence)** and the bandwidth budget are unchanged.
- The bandwidth eligibility gate, `minBW` threshold, `--no-bw-pool`, and `--bw-sat-exp` flag all behave as before.
- **CSV column meanings**: `Pool 2 Weight` in `pool2_shares.csv` now holds the effective weight (`bytes × ip.total^(exp-1)`) — same column position, more accurate value. Auditors can still verify `Pool 2 SKY = Weight × rate`.
- **Stats label** changed from `Skycoin Per (bytes^X)` to `Skycoin Per Pool 2 Weight Unit` since the rate now multiplies the effective weight, not `bytes^X`. Added a `contributing IPs:` line for visibility.
- The UI reads `Skycoin Per GB (Pool 2):` (still emitted at exp=1.0) — no UI-side change needed.

## Test plan

- [x] Built with the new formula and ran against the on-disk 2026-06-26 calc (with pool files backed up + restored) — totals match: pool 1 = 1117.81 SKY unchanged, pool 2 = 1117.81 SKY redistributed per the table above.
- [x] `make format check` clean on the modified file (`cmd/skywire-cli/commands/rewards/` lints to 0 issues).
- [x] Doc: `rewards/mainnet_rules.md` Pool 2 section rewritten to describe the per-IP form and call out the no-multiplication invariant.