### PR TITLE
feat(visor): log config version + warn when it trails the binary

### DIFF
--- a/pkg/visor/visorconfig/parse.go
+++ b/pkg/visor/visorconfig/parse.go
@@ -47,6 +47,23 @@ func Parse(log *logging.Logger, r io.Reader, confPath string, visorBuildInfo *bu
 			log.Debug(`error on semver.Make(strings.TrimPrefix(visorBuildInfo.Version, "v"))`)
 			return conf, compat, err
 		}
+		// Surface the config version alongside the visor version (logged
+		// separately at startup) so a mismatch — the usual cause of a
+		// stale-config failure — is visible at a glance. A correctly upgraded
+		// install regenerates the config (skywire autoconfig) on every update,
+		// so config and visor versions should match; any gap means the config
+		// was not regenerated and may be missing settings this release expects.
+		log.WithField("config_version", conf.Version).
+			WithField("visor_version", visorBuildInfo.Version).
+			Info("Loaded config.")
+		switch {
+		case cVer.Major != vVer.Major:
+			log.Warnf("config major version %d differs from the visor's %d — the config is incompatible; regenerate it with `skywire autoconfig`", cVer.Major, vVer.Major)
+		case cVer.LT(vVer):
+			log.Warnf("config version %s trails the visor %s — it may be missing settings from this release; regenerate it with `skywire autoconfig`", conf.Version, visorBuildInfo.Version)
+		case cVer.GT(vVer):
+			log.Warnf("config version %s is newer than the visor %s (downgrade?) — regenerate it with `skywire autoconfig` if the visor misbehaves", conf.Version, visorBuildInfo.Version)
+		}
 		if cVer.Major == vVer.Major {
 			compat = true
 		}


### PR DESCRIPTION
Motivated by a real Windows report: a visor upgraded to v1.3.78 fatally failed at startup (`deployment service "http://sd.skycoin.com" is not a dmsg:// URL`) because its **v1.3.77 config still had clearnet deployment URLs** — and the log showed the *binary* version but never the *config* version, so the mismatch wasn't visible.

The visor logged its own version at startup but never the loaded config's version. `Parse` already parses both with semver, so this:
- logs the config version alongside the visor version (`Info`: `config_version=… visor_version=…`), right after the startup buildinfo line;
- **warns** when they diverge — a major-version gap (incompatible; the visor fatals on it upstream anyway), or the config trailing/leading the binary.

A correctly upgraded install regenerates the config via `skywire autoconfig` on every update, so config and visor versions should match; any gap means that didn't happen, and the warning names the remedy.

First of a short series tightening dmsg-only config hygiene (next: remove the unsupported `--http`/`--dual` gen modes, make `services-config.json` the single source of service URLs with no clearnet except geoip + the wss bootstrap subdomains, and align native postinstall to call `skywire autoconfig`).