### PR TITLE
feat(config): dmsg-only deployment services — strip clearnet URLs, single source of truth

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -159,10 +159,10 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "url")
 	genConfigCmd.Flags().BoolVarP(&isTestEnv, "testenv", "t", scriptExecBool("${TESTENV:-false}"), "use test deployment (ports offset +10000 from prod)")
 	gHiddenFlags = append(gHiddenFlags, "testenv")
+	// Deployment services are dmsg-only. --dmsghttp is the (default) behavior and
+	// kept as a hidden no-op for back-compat; the former --http / --dual modes are
+	// gone — plain HTTP to deployment services is no longer supported.
 	genConfigCmd.Flags().BoolVarP(&isDmsgHTTP, "dmsghttp", "d", scriptExecBool("${DMSGHTTP:-false}"), "use only dmsg for skywire services, no http (this is the default)")
-	genConfigCmd.Flags().BoolVar(&isHTTPOnly, "http", false, "use only http for skywire services (no dmsg)")
-	genConfigCmd.Flags().BoolVar(&isDual, "dual", false, "use http for skywire services with dmsg as fallback (dual)")
-	genConfigCmd.MarkFlagsMutuallyExclusive("dmsghttp", "http")
 	gHiddenFlags = append(gHiddenFlags, "dmsghttp")
 	genConfigCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "D", scriptExecString("${DMSGCONF}"), "dmsghttp config path")
 	gHiddenFlags = append(gHiddenFlags, "dmsgconf")
@@ -935,13 +935,12 @@ func readExistingConfig(log *logging.Logger) {
 var oldConfCache *visorconfig.V1
 
 // configureDMSGHTTP loads dmsghttp server list when dmsg URLs are needed.
-// This runs for both --dmsghttp (DMSG-only) and default (dual) modes.
-// With the unified services-config.json, DMSG fields are already in the services struct.
-// The separate dmsghttp-config.json path is retained for backward compatibility
-// and custom deployment overrides.
+// Deployment services are dmsg-only; the DMSG fields are already in the services
+// struct from services-config.json. The separate dmsghttp-config.json path is
+// retained for backward compatibility and custom deployment overrides.
 func configureDMSGHTTP(log *logging.Logger, outerErr error) {
 	_ = outerErr
-	if isDmsgHTTP || !isHTTPOnly {
+	{
 		if dmsgHTTPPath != "" {
 			// Override: load from user-supplied dmsghttp-config.json
 			dmsghttpConfigData, err := os.ReadFile(dmsgHTTPPath)
@@ -1240,51 +1239,29 @@ func configureLauncher(log *logging.Logger) {
 	// fields, no http). --dual keeps the http URLs with dmsg in the _dmsg
 	// fallback fields. --http (isHTTPOnly) skips the dmsg fields entirely.
 	// --dmsghttp forces dmsg-only (== the default) for backward compatibility.
-	dmsgOnly := isDmsgHTTP || !isDual
-	if !isHTTPOnly {
-		// Prefer unified services config; fall back to legacy dmsgHTTPServersList
-		if services.HasDmsgEndpoints() {
-			// Unified config: DMSG fields from services-config.json
-			conf.Dmsg.Servers = deployment.DmsgServerEntriesToDisc(services.DmsgServers)
-
-			if dmsgOnly {
-				conf.Dmsg.Discovery = services.DmsgDiscoveryDmsg
-				conf.Transport.AddressResolver = services.AddressResolverDmsg
-				conf.Transport.Discovery = services.TransportDiscoveryDmsg
-				conf.Routing.RouteFinder = services.RouteFinderDmsg
-				conf.Launcher.ServiceDisc = services.ServiceDiscoveryDmsg
-			} else {
-				conf.Dmsg.DiscoveryDmsg = services.DmsgDiscoveryDmsg
-				conf.Transport.AddressResolverDmsg = services.AddressResolverDmsg
-				conf.Transport.DiscoveryDmsg = services.TransportDiscoveryDmsg
-				conf.Routing.RouteFinderDmsg = services.RouteFinderDmsg
-				conf.Launcher.ServiceDiscDmsg = services.ServiceDiscoveryDmsg
-			}
-		} else if dmsgHTTPServersList != nil {
-			// Legacy fallback: separate dmsghttp-config.json
-			var dmsgConf *visorconfig.DmsgHTTPServersData
-			if isTestEnv {
-				dmsgConf = &dmsgHTTPServersList.Test
-			} else {
-				dmsgConf = &dmsgHTTPServersList.Prod
-			}
-			if dmsgConf != nil {
-				conf.Dmsg.Servers = dmsgConf.DMSGServers
-				if dmsgOnly {
-					conf.Dmsg.Discovery = dmsgConf.DMSGDiscovery
-					conf.Transport.AddressResolver = dmsgConf.AddressResolver
-					conf.Transport.Discovery = dmsgConf.TransportDiscovery
-					conf.Routing.RouteFinder = dmsgConf.RouteFinder
-					conf.Launcher.ServiceDisc = dmsgConf.ServiceDiscovery
-				} else {
-					conf.Dmsg.DiscoveryDmsg = dmsgConf.DMSGDiscovery
-					conf.Transport.AddressResolverDmsg = dmsgConf.AddressResolver
-					conf.Transport.DiscoveryDmsg = dmsgConf.TransportDiscovery
-					conf.Routing.RouteFinderDmsg = dmsgConf.RouteFinder
-					conf.Launcher.ServiceDiscDmsg = dmsgConf.ServiceDiscovery
-				}
-			}
+	// Deployment services are dmsg-only: the dmsg:// service URLs go straight into
+	// the primary config fields. (Plain-HTTP to deployment services is no longer
+	// supported — the former --http / --dual modes are gone.) The dmsg URLs come
+	// from services-config.json's *_dmsg fields, the single source of truth.
+	if services.HasDmsgEndpoints() {
+		conf.Dmsg.Servers = deployment.DmsgServerEntriesToDisc(services.DmsgServers)
+		conf.Dmsg.Discovery = services.DmsgDiscoveryDmsg
+		conf.Transport.AddressResolver = services.AddressResolverDmsg
+		conf.Transport.Discovery = services.TransportDiscoveryDmsg
+		conf.Routing.RouteFinder = services.RouteFinderDmsg
+		conf.Launcher.ServiceDisc = services.ServiceDiscoveryDmsg
+	} else if dmsgHTTPServersList != nil {
+		// Legacy fallback: separate dmsghttp-config.json (custom deployments).
+		dmsgConf := &dmsgHTTPServersList.Prod
+		if isTestEnv {
+			dmsgConf = &dmsgHTTPServersList.Test
 		}
+		conf.Dmsg.Servers = dmsgConf.DMSGServers
+		conf.Dmsg.Discovery = dmsgConf.DMSGDiscovery
+		conf.Transport.AddressResolver = dmsgConf.AddressResolver
+		conf.Transport.Discovery = dmsgConf.TransportDiscovery
+		conf.Routing.RouteFinder = dmsgConf.RouteFinder
+		conf.Launcher.ServiceDisc = dmsgConf.ServiceDiscovery
 	}
 
 	// Configure public visor

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -45,8 +45,6 @@ var (
 	routeSetupNodes            string
 	transportSetupPKs          string
 	isDmsgHTTP                 bool
-	isHTTPOnly                 bool
-	isDual                     bool
 	minDmsgSess                int
 	isVpnServerEnable          bool
 	isDisableAuth              bool

--- a/cmd/svc/config-bootstrapper/commands/root.go
+++ b/cmd/svc/config-bootstrapper/commands/root.go
@@ -65,14 +65,17 @@ func generateExamples() string {
 		"dmsg_address": exPK1 + ":80",
 	}
 
-	// GET / - visorconfig.Services (partial, key fields shown)
+	// GET / - visorconfig.Services (partial, key fields shown). Deployment
+	// services are dmsg-only; the example pulls the real dmsg:// URLs from the
+	// embedded services-config.json (deployment.Prod) — the single source of
+	// truth — rather than hardcoding any URL.
 	servicesExample := map[string]interface{}{
-		"dmsg_discovery":      "http://dmsgd.skywire.skycoin.com",
-		"transport_discovery": "http://tpd.skywire.skycoin.com",
-		"address_resolver":    "http://ar.skywire.skycoin.com",
-		"route_finder":        "http://rf.skywire.skycoin.com",
-		"uptime_tracker":      "http://ut.skywire.skycoin.com",
-		"service_discovery":   "http://sd.skycoin.com",
+		"dmsg_discovery":      deployment.Prod.DmsgDiscoveryDmsg,
+		"transport_discovery": deployment.Prod.TransportDiscoveryDmsg,
+		"address_resolver":    deployment.Prod.AddressResolverDmsg,
+		"route_finder":        deployment.Prod.RouteFinderDmsg,
+		"uptime_tracker":      deployment.Prod.UptimeTrackerDmsg,
+		"service_discovery":   deployment.Prod.ServiceDiscoveryDmsg,
 		"route_setup_nodes":   []string{exPK1, exPK2},
 		"stun_servers":        []string{"stun.l.google.com:19302"},
 		"transport_setup":     []string{exPK1},

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -191,6 +191,39 @@ type Services struct {
 	RewardSystemDmsg string `json:"reward_system_dmsg,omitempty"`
 }
 
+// BackfillClearnetFromDmsg copies each *_dmsg deployment-service URL into its
+// historically-clearnet sibling field when that field is empty. services-config.json
+// no longer carries plain-HTTP deployment URLs (only geoip — the one allowed clearnet
+// deployment endpoint, since dmsg can't preserve the client IP a geoip lookup needs),
+// so the HTTP-named fields would otherwise be empty. In a dmsg-only deployment the
+// correct value for them IS the dmsg:// URL, so every existing consumer of the
+// HTTP-named fields keeps working unchanged — getHTTPClient builds a dmsghttp client
+// for the dmsg:// scheme. The single source of truth stays services-config.json; this
+// derives, it does not hardcode. GeoIP is deliberately left untouched.
+func (s *Services) BackfillClearnetFromDmsg() {
+	if s.DmsgDiscovery == "" {
+		s.DmsgDiscovery = s.DmsgDiscoveryDmsg
+	}
+	if s.TransportDiscovery == "" {
+		s.TransportDiscovery = s.TransportDiscoveryDmsg
+	}
+	if s.AddressResolver == "" {
+		s.AddressResolver = s.AddressResolverDmsg
+	}
+	if s.RouteFinder == "" {
+		s.RouteFinder = s.RouteFinderDmsg
+	}
+	if s.UptimeTracker == "" {
+		s.UptimeTracker = s.UptimeTrackerDmsg
+	}
+	if s.ServiceDiscovery == "" {
+		s.ServiceDiscovery = s.ServiceDiscoveryDmsg
+	}
+	if s.RewardSystem == "" {
+		s.RewardSystem = s.RewardSystemDmsg
+	}
+}
+
 // Conf is the configuration URL for the deployment which may be fetched on `skywire cli config gen`
 type Conf struct {
 	Conf string `json:"conf,omitempty"`

--- a/deployment/config_js.go
+++ b/deployment/config_js.go
@@ -40,4 +40,15 @@ func init() {
 	Test = testData
 	ProdConf = prodConfData
 	TestConf = testConfData
+	// services-config.json is dmsg-only (no plain-HTTP deployment URLs except
+	// geoip); backfill the HTTP-named fields from their dmsg:// siblings. Mirrors
+	// config_native.go. See Services.BackfillClearnetFromDmsg.
+	Prod.BackfillClearnetFromDmsg()
+	Test.BackfillClearnetFromDmsg()
+	if ProdConf.Conf == "" {
+		ProdConf.Conf = Prod.ConfDmsg
+	}
+	if TestConf.Conf == "" {
+		TestConf.Conf = Test.ConfDmsg
+	}
 }

--- a/deployment/config_native.go
+++ b/deployment/config_native.go
@@ -51,4 +51,15 @@ func init() {
 			log.Panic(err)
 		}
 	}
+	// services-config.json is dmsg-only (no plain-HTTP deployment URLs except
+	// geoip); backfill the HTTP-named fields from their dmsg:// siblings so every
+	// consumer keeps a working URL. See Services.BackfillClearnetFromDmsg.
+	Prod.BackfillClearnetFromDmsg()
+	Test.BackfillClearnetFromDmsg()
+	if ProdConf.Conf == "" {
+		ProdConf.Conf = Prod.ConfDmsg
+	}
+	if TestConf.Conf == "" {
+		TestConf.Conf = Test.ConfDmsg
+	}
 }

--- a/deployment/data_static_js.go
+++ b/deployment/data_static_js.go
@@ -21,10 +21,6 @@ import (
 )
 
 var prodData = Services{
-	DmsgDiscovery:      "http://dmsgd.skywire.skycoin.com",
-	TransportDiscovery: "http://tpd.skywire.skycoin.com",
-	AddressResolver:    "http://ar.skywire.skycoin.com",
-	RouteFinder:        "http://rf.skywire.skycoin.com",
 	RouteSetupNodes: []cipher.PubKey{
 		mustPubKey("0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"),
 		mustPubKey("024fbd3997d4260f731b01abcfce60b8967a6d4c6a11d1008812810ea1437ce438"),
@@ -41,8 +37,6 @@ var prodData = Services{
 		mustPubKey("03aa0b1c4e23616872058c11c6efba777c130a85eaf909945d697399a1eb08426d"),
 		mustPubKey("03adb2c924987d8deef04d02bd95236c5ae172fe5dfe7273e0461d96bf4bc220be"),
 	},
-	UptimeTracker:    "http://ut.skywire.skycoin.com",
-	ServiceDiscovery: "http://sd.skycoin.com",
 	StunServers: []string{
 		"139.162.160.227:3478",
 		"172.104.247.120:3478",
@@ -99,15 +93,10 @@ var prodData = Services{
 	RouteFinderDmsg:        "dmsg://039d89c5eedfda4a28b0c58b0b643eff949f08e4f68c8357278081d26f5a592d74:80",
 	UptimeTrackerDmsg:      "dmsg://022c424caa6239ba7d1d9d8f7dab56cd5ec6ae2ea9ad97bb94ad4b48f62a540d3f:80",
 	ServiceDiscoveryDmsg:   "dmsg://0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7:80",
-	RewardSystem:           "https://theskywirenetwork.net",
 	RewardSystemDmsg:       "dmsg://036a70e6956061778e1883e928c1236189db14dfd446df23d83e45c321b330c91f:80",
 }
 
 var testData = Services{
-	DmsgDiscovery:      "http://dmsgd.skywire.dev",
-	TransportDiscovery: "http://tpd.skywire.dev",
-	AddressResolver:    "http://ar.skywire.dev",
-	RouteFinder:        "http://rf.skywire.dev",
 	RouteSetupNodes: []cipher.PubKey{
 		mustPubKey("0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"),
 		mustPubKey("024fbd3997d4260f731b01abcfce60b8967a6d4c6a11d1008812810ea1437ce438"),
@@ -124,8 +113,6 @@ var testData = Services{
 		mustPubKey("03aa0b1c4e23616872058c11c6efba777c130a85eaf909945d697399a1eb08426d"),
 		mustPubKey("03adb2c924987d8deef04d02bd95236c5ae172fe5dfe7273e0461d96bf4bc220be"),
 	},
-	UptimeTracker:    "http://ut.skywire.dev",
-	ServiceDiscovery: "http://sd.skywire.dev",
 	StunServers: []string{
 		"139.162.160.227:3478",
 		"172.104.247.120:3478",
@@ -182,9 +169,8 @@ var testData = Services{
 	RouteFinderDmsg:        "dmsg://039d89c5eedfda4a28b0c58b0b643eff949f08e4f68c8357278081d26f5a592d74:80",
 	UptimeTrackerDmsg:      "dmsg://022c424caa6239ba7d1d9d8f7dab56cd5ec6ae2ea9ad97bb94ad4b48f62a540d3f:80",
 	ServiceDiscoveryDmsg:   "dmsg://0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7:80",
-	RewardSystem:           "https://theskywirenetwork.net",
 	RewardSystemDmsg:       "dmsg://036a70e6956061778e1883e928c1236189db14dfd446df23d83e45c321b330c91f:80",
 }
 
-var prodConfData = Conf{Conf: "http://conf.skywire.skycoin.com"}
-var testConfData = Conf{Conf: "http://conf.skywire.dev"}
+var prodConfData = Conf{Conf: ""}
+var testConfData = Conf{Conf: ""}

--- a/deployment/services-config-clearnet.json
+++ b/deployment/services-config-clearnet.json
@@ -1,6 +1,11 @@
 {
   "test": {
+    "conf": "http://conf.skywire.dev",
     "conf_dmsg": "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
+    "dmsg_discovery": "http://dmsgd.skywire.dev",
+    "transport_discovery": "http://tpd.skywire.dev",
+    "address_resolver": "http://ar.skywire.dev",
+    "route_finder": "http://rf.skywire.dev",
     "route_setup_nodes": [
       "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557",
       "024fbd3997d4260f731b01abcfce60b8967a6d4c6a11d1008812810ea1437ce438"
@@ -17,6 +22,8 @@
       "03aa0b1c4e23616872058c11c6efba777c130a85eaf909945d697399a1eb08426d",
       "03adb2c924987d8deef04d02bd95236c5ae172fe5dfe7273e0461d96bf4bc220be"
     ],
+    "uptime_tracker": "http://ut.skywire.dev",
+    "service_discovery": "http://sd.skywire.dev",
     "stun_servers": [
       "139.162.160.227:3478",
       "172.104.247.120:3478"
@@ -88,10 +95,16 @@
     "route_finder_dmsg": "dmsg://039d89c5eedfda4a28b0c58b0b643eff949f08e4f68c8357278081d26f5a592d74:80",
     "uptime_tracker_dmsg": "dmsg://022c424caa6239ba7d1d9d8f7dab56cd5ec6ae2ea9ad97bb94ad4b48f62a540d3f:80",
     "service_discovery_dmsg": "dmsg://0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7:80",
+    "reward_system": "https://theskywirenetwork.net",
     "reward_system_dmsg": "dmsg://036a70e6956061778e1883e928c1236189db14dfd446df23d83e45c321b330c91f:80"
   },
   "prod": {
+    "conf": "http://conf.skywire.skycoin.com",
     "conf_dmsg": "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
+    "dmsg_discovery": "http://dmsgd.skywire.skycoin.com",
+    "transport_discovery": "http://tpd.skywire.skycoin.com",
+    "address_resolver": "http://ar.skywire.skycoin.com",
+    "route_finder": "http://rf.skywire.skycoin.com",
     "route_setup_nodes": [
       "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557",
       "024fbd3997d4260f731b01abcfce60b8967a6d4c6a11d1008812810ea1437ce438"
@@ -108,6 +121,8 @@
       "03aa0b1c4e23616872058c11c6efba777c130a85eaf909945d697399a1eb08426d",
       "03adb2c924987d8deef04d02bd95236c5ae172fe5dfe7273e0461d96bf4bc220be"
     ],
+    "uptime_tracker": "http://ut.skywire.skycoin.com",
+    "service_discovery": "http://sd.skycoin.com",
     "stun_servers": [
       "139.162.160.227:3478",
       "172.104.247.120:3478"
@@ -181,6 +196,7 @@
     "route_finder_dmsg": "dmsg://039d89c5eedfda4a28b0c58b0b643eff949f08e4f68c8357278081d26f5a592d74:80",
     "uptime_tracker_dmsg": "dmsg://022c424caa6239ba7d1d9d8f7dab56cd5ec6ae2ea9ad97bb94ad4b48f62a540d3f:80",
     "service_discovery_dmsg": "dmsg://0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7:80",
+    "reward_system": "https://theskywirenetwork.net",
     "reward_system_dmsg": "dmsg://036a70e6956061778e1883e928c1236189db14dfd446df23d83e45c321b330c91f:80"
   }
 }

--- a/pkg/config-bootstrapper/api/api.go
+++ b/pkg/config-bootstrapper/api/api.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -74,18 +73,13 @@ type Config struct {
 // (deployment.Prod). The domain parameter applies HTTP URL replacements for
 // custom deployments; DMSG addresses are PK-based and don't change.
 func New(log *logging.Logger, conf Config, domain, dmsgAddr string) *API {
-	// Start from the full embedded deployment config (includes DMSG fields)
+	// Start from the full embedded deployment config (includes DMSG fields).
+	// Deployment services are dmsg-only and addressed by public key (dmsg://<pk>),
+	// which is domain-independent, so the legacy per-domain HTTP-URL rewrite is
+	// gone; a custom deployment supplies its own services-config.json (SKYDEPLOY).
+	_ = domain
 	svcs := deployment.Prod
 
-	// Apply domain replacement to HTTP URLs for custom deployments
-	if domain != "" && domain != "skywire.skycoin.com" {
-		svcs.DmsgDiscovery = strings.Replace(svcs.DmsgDiscovery, "skywire.skycoin.com", domain, -1)
-		svcs.TransportDiscovery = strings.Replace(svcs.TransportDiscovery, "skywire.skycoin.com", domain, -1)
-		svcs.AddressResolver = strings.Replace(svcs.AddressResolver, "skywire.skycoin.com", domain, -1)
-		svcs.RouteFinder = strings.Replace(svcs.RouteFinder, "skywire.skycoin.com", domain, -1)
-		svcs.UptimeTracker = strings.Replace(svcs.UptimeTracker, "skywire.skycoin.com", domain, -1)
-		svcs.ServiceDiscovery = strings.Replace(svcs.ServiceDiscovery, "skycoin.com", domain, -1)
-	}
 	// Override from config file if provided
 	if conf.SetupNodes != nil {
 		svcs.RouteSetupNodes = conf.SetupNodes
@@ -231,33 +225,27 @@ func (a *API) dmsghttp(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) dmsghttpConfGen() httputil.DMSGHTTPConf {
+	a.servicesMu.RLock()
+	defer a.servicesMu.RUnlock()
+	// Deployment services are dmsg-only: serve the dmsg:// service addresses
+	// straight from the embedded config (services-config.json's *_dmsg fields —
+	// the single source of truth), with no runtime clearnet health-probe. The
+	// bootstrap server list is the in-memory DmsgServers (embedded, kept current
+	// by refreshDmsgServers).
 	var dmsghttpConf httputil.DMSGHTTPConf
-	dmsghttpConf.DMSGServers = fetchDMSGServers(a.services.DmsgDiscovery)
-	dmsghttpConf.AddressResolver = fetchDMSGAddress(a.services.AddressResolver)
-	dmsghttpConf.DMSGDiscovery = fetchDMSGAddress(a.services.DmsgDiscovery)
-	dmsghttpConf.RouteFinder = fetchDMSGAddress(a.services.RouteFinder)
-	dmsghttpConf.ServiceDiscovery = fetchDMSGAddress(a.services.ServiceDiscovery)
-	dmsghttpConf.TranspordDiscovery = fetchDMSGAddress(a.services.TransportDiscovery)
-	dmsghttpConf.UptimeTracker = fetchDMSGAddress(a.services.UptimeTracker)
-
+	for _, s := range a.services.DmsgServers {
+		var e httputil.DMSGServersConf
+		e.Static = s.Static
+		e.Server.Address = s.Server.Address
+		dmsghttpConf.DMSGServers = append(dmsghttpConf.DMSGServers, e)
+	}
+	dmsghttpConf.AddressResolver = a.services.AddressResolverDmsg
+	dmsghttpConf.DMSGDiscovery = a.services.DmsgDiscoveryDmsg
+	dmsghttpConf.RouteFinder = a.services.RouteFinderDmsg
+	dmsghttpConf.ServiceDiscovery = a.services.ServiceDiscoveryDmsg
+	dmsghttpConf.TranspordDiscovery = a.services.TransportDiscoveryDmsg
+	dmsghttpConf.UptimeTracker = a.services.UptimeTrackerDmsg
 	return dmsghttpConf
-}
-
-func fetchDMSGAddress(url string) string {
-	resp, err := http.Get(fmt.Sprintf("%s/health", url))
-	if err != nil {
-		return ""
-	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return ""
-	}
-	var healthResponse httputil.HealthCheckResponse
-	err = json.Unmarshal(body, &healthResponse)
-	if err != nil {
-		return ""
-	}
-	return healthResponse.DmsgAddr
 }
 
 func fetchDMSGServers(url string) []httputil.DMSGServersConf {

--- a/pkg/tpviz/tpviz.go
+++ b/pkg/tpviz/tpviz.go
@@ -89,7 +89,7 @@ type Config struct {
 }
 
 // CacheDirFromURL returns a cache directory path based on the service URL host.
-// For example, "http://tpd.skywire.skycoin.com" -> "/tmp/tpd.skywire.skycoin.com"
+// For example, "dmsg://02b307…095ae:80" -> "/tmp/02b307…095ae".
 func CacheDirFromURL(serviceURL string) string {
 	u, err := url.Parse(serviceURL)
 	if err != nil || u.Host == "" {


### PR DESCRIPTION
Deployment services are dmsg-only — plain HTTP to them is no longer supported (#3191). This removes the ways a clearnet deployment URL could ever enter a config, and consolidates **every deployment URL — clearnet *and* dmsg — into one file: `services-config.json`**.

Motivated by a Windows report where a pre-v1.3.78 config still carried `http://sd.skycoin.com` etc. and the v1.3.78 binary fatally rejected it.

### Changes
- **`services-config.json`:** removed the clearnet deployment URLs (`conf`, `dmsg_discovery`, `transport_discovery`, `address_resolver`, `route_finder`, `uptime_tracker`, `service_discovery`, `reward_system`). Kept the `*_dmsg` URLs, the `dmsg_servers` list (incl. the `address_ws` wss bootstrap subdomains — browser-only, separate from the IP `address`), and **`geoip`** — the one allowed clearnet endpoint (dmsg can't preserve the client IP a geoip lookup needs). The full clearnet set is preserved for reference in the new committed-but-not-embedded **`services-config-clearnet.json`**.
- **`deployment` package:** `BackfillClearnetFromDmsg` copies each `*_dmsg` URL into its historically-clearnet sibling field at parse time (native + tinygo/js inits), so every existing consumer of the HTTP-named fields transparently gets the `dmsg://` URL — `getHTTPClient` builds a dmsghttp client for it. It derives from the one file; it hardcodes nothing. Regenerated `data_static_js.go`.
- **`config gen`:** removed the unsupported `--http` / `--dual` modes (and `isHTTPOnly`/`isDual`); the mapping is dmsg-only.
- **config-bootstrapper service:** serves the `dmsg://` service addresses straight from the static `*_dmsg` fields — dropped the runtime `fetchDMSGAddress(clearnet)` health-probe and the per-domain HTTP rewrite (dmsg addresses are PK-based, domain-independent).
- Removed the last hardcoded clearnet deployment URLs from Go (the config-bootstrapper command's help example now pulls from `deployment.Prod`; a `tpviz` doc comment).

### Validation
`config gen` for **prod / test / hypervisor** (with `--nofetch`) emits **zero clearnet deployment URLs — only `geoip`** — and 9 `dmsg://` service URLs. Builds native **and** under the tinygo tag; `pkg/dmsg/dmsg`, `visorconfig`, `visorcore` tests pass.

Pairs with #3347 (config-version logging). Next: native postinstall parity (all platforms call `skywire autoconfig` + restart).
