### PR TITLE
fix(deb): postinstall runs skywire autoconfig (not the invalid skywire-cli visor gen-config)

### DIFF
--- a/scripts/deb_installer/deb.postinst
+++ b/scripts/deb_installer/deb.postinst
@@ -5,7 +5,13 @@ if [ -f "/opt/skywire/removing" ]
 then
 	rm -rf /opt/skywire/removing
 else
-	/opt/skywire/skywire-cli visor gen-config -o /opt/skywire/skywire-config.json
+	# (Re)generate the config through the single entry point, the same one the
+	# Arch/AUR post_install uses. `skywire autoconfig` runs `config gen -r`
+	# (regenerate, retaining the secret key + hypervisor PKs) so an UPGRADE
+	# refreshes service URLs / new fields instead of leaving a stale config —
+	# it never runs `config gen` directly. Run as root → PKGENV mode
+	# (/opt/skywire paths, system unit). The dh_systemd section below restarts.
+	/opt/skywire/skywire autoconfig
 fi
 
 setcap 'cap_net_admin+p' /opt/skywire/apps/vpn-client


### PR DESCRIPTION
The deb postinstall ran `/opt/skywire/skywire-cli visor gen-config` — not a valid command (`visor` is the RPC-query command; no `gen-config` subcommand) — so a deb install/upgrade never regenerated the config. Replaced with the single entry point every platform should use, **`skywire autoconfig`**, matching the Arch/AUR post_install: it runs `config gen -r` (regenerate, retaining the SK + hypervisor PKs), so upgrades refresh service URLs / new fields instead of leaving a stale config. As root → PKGENV mode (/opt/skywire), matching the deb layout; the existing dh_systemd section restarts.

Part of the dmsg-only config hygiene series (#3347 config-version logging, #3348 dmsg-only services). Note: Linux packaging is canonically the **AUR** (separate repo); this fixes the in-repo deb. mac/Windows postinstall are analyzed separately — see the PR discussion.