### PR TITLE
feat(win+autoconfig): Windows postinstall runs skywire autoconfig; autoconfig is PATH-independent

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -63,6 +63,19 @@ const (
 // would be clobbered by the next package upgrade.
 const systemdDropIn = "/etc/systemd/system/skywire.service.d/skywire-user.conf"
 
+// skywireBin returns the absolute path to the running skywire binary so the
+// sub-invocations below (config gen, reward, -v) target THIS binary rather than
+// a bare "skywire" looked up on PATH. That matters on Windows: the MSI runs
+// autoconfig as a deferred CustomAction at install time, when the install dir is
+// not yet on PATH, so a bare "skywire" would not resolve. Falls back to "skywire"
+// only if os.Executable() fails (e.g. an exotic platform), preserving old behavior.
+func skywireBin() string {
+	if exe, err := os.Executable(); err == nil && exe != "" {
+		return exe
+	}
+	return "skywire"
+}
+
 // autoconfigVals holds the runtime values of the autoconfig flags.
 // Lives at package level so the Run function can read them; the
 // pkg/skywireconfig/autoconfigcmd factory wires the bindings.
@@ -270,7 +283,7 @@ func autoconfigRun(cmd *cobra.Command, args []string) {
 		msg3(fmt.Sprintf("Updated %s%s%s: %s", colorPurple, target, colorReset, strings.Join(editedKeys, " ")))
 	}
 
-	versionOut, err := exec.Command("skywire", "-v").Output()
+	versionOut, err := exec.Command(skywireBin(), "-v").Output()
 	if err == nil {
 		version := strings.TrimSpace(string(versionOut))
 		if !strings.Contains(version, "unknown") {
@@ -417,7 +430,7 @@ func autoconfigRun(cmd *cobra.Command, args []string) {
 		msg2(fmt.Sprintf("Remote Hypervisor Public Key:\n%s%s%s", colorPurple, strings.TrimSpace(hvPKs), colorReset))
 	}
 
-	rewardOut, err := exec.Command("skywire", "cli", "reward", "-r").Output() //nolint:gosec
+	rewardOut, err := exec.Command(skywireBin(), "cli", "reward", "-r").Output() //nolint:gosec
 	if err == nil && len(rewardOut) > 0 {
 		msg2(fmt.Sprintf("skycoin reward address:\n%s%s%s", colorGreen, strings.TrimSpace(string(rewardOut)), colorReset))
 	}
@@ -564,7 +577,7 @@ func generateConfig(r resolvedConfig, hvArg string) error {
 	// printableArgs above show the same command without -w to paste
 	// into a terminal.
 	var stderrBuf bytes.Buffer
-	cmd := exec.Command("skywire", args...) //nolint:gosec
+	cmd := exec.Command(skywireBin(), args...) //nolint:gosec
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = &stderrBuf
 	cmd.Env = os.Environ()
@@ -664,7 +677,7 @@ func restartOrPrompt(r resolvedConfig) {
 }
 
 func printWelcome(pubkey string, isHypervisor bool) {
-	rewardOut, err := exec.Command("skywire", "cli", "reward", "-r").Output()
+	rewardOut, err := exec.Command(skywireBin(), "cli", "reward", "-r").Output()
 	if err == nil && len(rewardOut) > 0 {
 		msg2(fmt.Sprintf("skycoin reward address:\n%s%s%s", colorGreen, strings.TrimSpace(string(rewardOut)), colorReset))
 		msg2(fmt.Sprintf("reward metrics:\n%shttps://theskywirenetwork.net%s", colorBlue, colorReset))

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -283,7 +283,7 @@ func autoconfigRun(cmd *cobra.Command, args []string) {
 		msg3(fmt.Sprintf("Updated %s%s%s: %s", colorPurple, target, colorReset, strings.Join(editedKeys, " ")))
 	}
 
-	versionOut, err := exec.Command(skywireBin(), "-v").Output()
+	versionOut, err := exec.Command(skywireBin(), "-v").Output() //nolint:gosec
 	if err == nil {
 		version := strings.TrimSpace(string(versionOut))
 		if !strings.Contains(version, "unknown") {
@@ -677,7 +677,7 @@ func restartOrPrompt(r resolvedConfig) {
 }
 
 func printWelcome(pubkey string, isHypervisor bool) {
-	rewardOut, err := exec.Command(skywireBin(), "cli", "reward", "-r").Output()
+	rewardOut, err := exec.Command(skywireBin(), "cli", "reward", "-r").Output() //nolint:gosec
 	if err == nil && len(rewardOut) > 0 {
 		msg2(fmt.Sprintf("skycoin reward address:\n%s%s%s", colorGreen, strings.TrimSpace(string(rewardOut)), colorReset))
 		msg2(fmt.Sprintf("reward metrics:\n%shttps://theskywirenetwork.net%s", colorBlue, colorReset))

--- a/scripts/win_installer/Product.wxs
+++ b/scripts/win_installer/Product.wxs
@@ -29,7 +29,6 @@
                     <File Id="SKYWIREAUTOCONFIGBAT" Source=".\build\skywire-autoconfig.bat"/>
                     <File Id="ICON" Source=".\images\ico.ico"/>
                     <File Id="WINTUN" Source=".\build\wintun.dll"/>
-                    <File Id="NEWUPDATE" Source=".\build\new.update"/>
                </Component>
                <Directory Id="APPS" Name="apps">
                   <Component Id="AppsFiles" Guid="d6263d6c-acea-49a0-bd9b-610f8a8bce82">

--- a/scripts/win_installer/README.md
+++ b/scripts/win_installer/README.md
@@ -43,7 +43,7 @@ or open `skywire` shortcut on start menu or desktop.
 - Q: *What is included in the packaging besides skywire? (i.e. scripts, services, batch files, etc.)*
   
   A:  - a `.bat` file that use for running skywire
-      - a `new.update` file for checking update then regenerate config file for update version and etc
+      - a `skywire-autoconfig.bat` that runs `skywire autoconfig` at install/upgrade/launch to (re)generate the config (retaining keys)
 - Q: *Where are the sources for the build of the installer or package?*
   
   A:  `scripts\win_installer`

--- a/scripts/win_installer/script.ps1
+++ b/scripts/win_installer/script.ps1
@@ -69,8 +69,6 @@ function BuildInstaller()
     Move-Item ..\..\archive\skywire.exe .\build\skywire.exe
     Copy-Item skywire.bat .\build\skywire.bat
     Copy-Item skywire-autoconfig.bat .\build\skywire-autoconfig.bat
-    New-Item new.update  > $null
-    Move-Item new.update .\build\new.update
     Invoke-WebRequest "https://deb.skywire.dev/wintun-0.14.1.zip" -OutFile wintun.zip
     Expand-Archive wintun.zip
     Copy-Item .\wintun\wintun\bin\$wintun_arch\wintun.dll .\build\wintun.dll

--- a/scripts/win_installer/skywire-autoconfig.bat
+++ b/scripts/win_installer/skywire-autoconfig.bat
@@ -40,16 +40,26 @@ if not exist "%SKYENV%" (
     "%~dp0skywire.exe" cli config gen -pqQ "%SKYENV%"
 )
 
-:: First install (no skywire-config.json yet) — generate a fresh config. cli
-:: reads %SKYENV% for PKGENV / HYPERVISORPKS / DISABLEPUBLICAUTOCONN / etc.
+:: (Re)generate the visor config through the SINGLE entry point — `skywire
+:: autoconfig` — never `cli config gen` directly (matches the Arch/AUR
+:: post_install). autoconfig runs `config gen -r` (regenerate, retaining the
+:: existing secret key + hypervisor PK list) and reads %SKYENV% for PKGENV /
+:: HYPERVISORPKS / DISABLEPUBLICAUTOCONN / etc. PKGENV=true (written into the
+:: template above) resolves the config to C:\Program Files\Skywire\
+:: skywire-config.json — the exact path the shortcut launches with. It calls its
+:: own binary by absolute path internally, so it works here even though the
+:: install dir is not yet on PATH at MSI-install time. --no-vpnserver persists
+:: VPNSERVER=false (replaces the old `--disableapps vpn-server`). Deployment
+:: service URLs come from the embedded dmsg-only services config (the single
+:: source of truth), so no -S / -D files are needed.
+::
+:: Run on first install (no config yet) and on upgrade (the new.update marker the
+:: MSI ships). A plain launch with an existing config + consumed marker skips
+:: both, so starting the visor stays cheap.
 if not exist "skywire-config.json" (
-    "%~dp0skywire.exe" cli config gen -irpw --disableapps vpn-server -S services-config.json -D dmsghttp-config.json --loglvl info
+    "%~dp0skywire.exe" autoconfig --no-vpnserver
 )
-
-:: Upgrade marker (new.update shipped in the MSI) — regenerate with -r/-x so
-:: the existing secret key and hypervisor PK list are preserved across the
-:: update (mirrors the deb/arch post_install regen). Then consume the marker.
 if exist "new.update" (
-    "%~dp0skywire.exe" cli config gen -irpwx --disableapps vpn-server -S services-config.json -D dmsghttp-config.json --loglvl info
+    "%~dp0skywire.exe" autoconfig --no-vpnserver
     del new.update >nul 2>&1
 )

--- a/scripts/win_installer/skywire-autoconfig.bat
+++ b/scripts/win_installer/skywire-autoconfig.bat
@@ -52,7 +52,10 @@ if not exist "%SKYENV%" (
 :: C:\Program Files\Skywire\skywire-config.json — the exact path the shortcut
 :: launches with. autoconfig calls its own binary by absolute path internally, so
 :: it works even though the install dir is not yet on PATH at MSI-install time.
-:: --no-vpnserver persists VPNSERVER=false (replaces the old `--disableapps
-:: vpn-server`). Deployment service URLs come from the embedded dmsg-only services
-:: config (the single source of truth), so no -S / -D files are needed.
-"%~dp0skywire.exe" autoconfig --no-vpnserver
+:: --ishv persists ISHYPERVISOR=true (Windows runs the local hypervisor UI at
+:: http://127.0.0.1:8000 — replaces the old always-passed `-i`, and keeps the HV
+:: across upgrades, not just on first install). --no-vpnserver persists
+:: VPNSERVER=false (replaces the old `--disableapps vpn-server`). Deployment
+:: service URLs come from the embedded dmsg-only services config (the single
+:: source of truth), so no -S / -D files are needed.
+"%~dp0skywire.exe" autoconfig --ishv --no-vpnserver

--- a/scripts/win_installer/skywire-autoconfig.bat
+++ b/scripts/win_installer/skywire-autoconfig.bat
@@ -6,12 +6,13 @@
 ::      so a fresh install has skywire.conf + skywire-config.json immediately,
 ::      without the operator having to launch first. This is the Windows
 ::      analogue of the deb/arch postinstall.
-::   2. By skywire.bat at LAUNCH, as an idempotent fallback (generate-if-
-::      missing), so manual / direct launches still self-configure.
+::   2. By skywire.bat at LAUNCH, so manual / direct launches still self-configure.
 ::
-:: It is intentionally idempotent: every step is gated on "if not exist", so
-:: re-running it (install + launch, or repeated installs) never clobbers an
-:: existing env file, config, or the operator's edits.
+:: It is idempotent: the env-file template is written only if missing (never
+:: clobbering operator edits), and the visor config is (re)generated through
+:: `skywire autoconfig`, which runs `config gen -r` — retaining the existing
+:: secret key + hypervisor PKs — so re-running it (install, upgrade, or every
+:: launch) converges on a current config without losing identity.
 ::
 :: IMPORTANT: at MSI-install time INSTALLDIR is NOT yet on PATH (the PATH
 :: environment component is applied separately), so this script calls the
@@ -43,23 +44,15 @@ if not exist "%SKYENV%" (
 :: (Re)generate the visor config through the SINGLE entry point — `skywire
 :: autoconfig` — never `cli config gen` directly (matches the Arch/AUR
 :: post_install). autoconfig runs `config gen -r` (regenerate, retaining the
-:: existing secret key + hypervisor PK list) and reads %SKYENV% for PKGENV /
-:: HYPERVISORPKS / DISABLEPUBLICAUTOCONN / etc. PKGENV=true (written into the
-:: template above) resolves the config to C:\Program Files\Skywire\
-:: skywire-config.json — the exact path the shortcut launches with. It calls its
-:: own binary by absolute path internally, so it works here even though the
-:: install dir is not yet on PATH at MSI-install time. --no-vpnserver persists
-:: VPNSERVER=false (replaces the old `--disableapps vpn-server`). Deployment
-:: service URLs come from the embedded dmsg-only services config (the single
-:: source of truth), so no -S / -D files are needed.
-::
-:: Run on first install (no config yet) and on upgrade (the new.update marker the
-:: MSI ships). A plain launch with an existing config + consumed marker skips
-:: both, so starting the visor stays cheap.
-if not exist "skywire-config.json" (
-    "%~dp0skywire.exe" autoconfig --no-vpnserver
-)
-if exist "new.update" (
-    "%~dp0skywire.exe" autoconfig --no-vpnserver
-    del new.update >nul 2>&1
-)
+:: existing secret key + hypervisor PK list). `-r` is safe whether or not a
+:: config already exists, so this runs UNCONDITIONALLY — fresh install, upgrade,
+:: and launch alike — with no install/upgrade marker to track. It reads %SKYENV%
+:: for PKGENV / HYPERVISORPKS / DISABLEPUBLICAUTOCONN / etc.; PKGENV=true (written
+:: into the template above) resolves the config to
+:: C:\Program Files\Skywire\skywire-config.json — the exact path the shortcut
+:: launches with. autoconfig calls its own binary by absolute path internally, so
+:: it works even though the install dir is not yet on PATH at MSI-install time.
+:: --no-vpnserver persists VPNSERVER=false (replaces the old `--disableapps
+:: vpn-server`). Deployment service URLs come from the embedded dmsg-only services
+:: config (the single source of truth), so no -S / -D files are needed.
+"%~dp0skywire.exe" autoconfig --no-vpnserver


### PR DESCRIPTION
Follow-up to #3349 (which merged only the deb part before these commits landed). Brings the **Windows** installer and the `autoconfig` command into the same single-entry-point model, matching deb/Arch.

### `skywire autoconfig` is now PATH-independent
It shelled out to a bare `"skywire"` for its sub-invocations (`config gen`, reward, `-v`). On Windows the MSI runs autoconfig as a deferred CustomAction at install time, when the install dir is **not yet on PATH**, so that would fail. Added `skywireBin()` (`os.Executable()`) and routed all four `exec.Command` calls through it, so autoconfig always drives **this** binary regardless of PATH — more robust on every platform.

### Windows postinstall runs `skywire autoconfig`
`skywire-autoconfig.bat` now runs `skywire autoconfig --ishv --no-vpnserver` instead of calling `cli config gen` directly:
- **Unconditional** — `config gen -r` regenerates whether or not a config exists (retaining the SK + hypervisor PKs), so there's no install/upgrade conditional and the `new.update` marker is gone (removed from `Product.wxs`, `script.ps1`, README).
- **`--ishv`** preserves the Windows-always-hypervisor default (HV UI at :8000) across **upgrades**, not just fresh installs (autoconfig only auto-adds `-i` on first install).
- **`--no-vpnserver`** replaces the old `--disableapps vpn-server`.
- Config path verified: PKGENV mode → `skyenv.SkywirePath + ConfigJSON` = `C:\Program Files\Skywire\skywire-config.json`, exactly what the shortcut launches with.
- Deployment URLs come from the embedded dmsg-only services config (#3348), so the dangling `-S`/`-D` file refs are dropped. The env-file template stays generate-if-missing (never clobbers operator edits).

**There is no Windows service** (the visor runs as a foreground process via the shortcut), so no service restart is involved. **Untestable from a non-Windows host** — to be validated on a real Windows install after the next release.
