### PR TITLE
fix(cli): source ut + conf URLs in help from deployment (no hardcoded clearnet)

### DIFF
--- a/cmd/skywire-cli/commands/log/log.go
+++ b/cmd/skywire-cli/commands/log/log.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/pflag"
 
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
@@ -60,7 +61,7 @@ func init() {
 var logCmd = &cobra.Command{
 	Use:   "log",
 	Short: "survey & transport log collection",
-	Long:  "Fetch health, survey, and transport logging from visors which are online in the uptime tracker\nhttp://ut.skywire.skycoin.com/uptimes?v=v2\nhttp://ut.skywire.skycoin.com/uptimes?v=v2&visors=<pk1>;<pk2>;<pk3>",
+	Long:  fmt.Sprintf("Fetch health, survey, and transport logging from visors which are online in the uptime tracker\n%[1]s/uptimes?v=v2\n%[1]s/uptimes?v=v2&visors=<pk1>;<pk2>;<pk3>", deployment.Prod.UptimeTracker),
 	Run: func(cmd *cobra.Command, _ []string) {
 		log := logging.MustGetLogger("log-collecting")
 		fver, err := version.NewVersion("v1.3.17")

--- a/cmd/svc/config-bootstrapper/commands/root.go
+++ b/cmd/svc/config-bootstrapper/commands/root.go
@@ -118,8 +118,8 @@ var RootCmd = &cobra.Command{
 	Long: calvin.AsciiFont("config-bootstrapper") + `
 Config Bootstrap Server - provides initial configuration for visors.
 
-Production: http://conf.skywire.skycoin.com
-Test:       http://conf.skywire.dev
+Production: ` + deployment.ProdConf.Conf + `
+Test:       ` + deployment.TestConf.Conf + `
 
 HTTP Endpoints:
   GET  /health     Health check


### PR DESCRIPTION
`skywire help -r` still printed hardcoded clearnet deployment URLs in two help strings the #3348 sweep missed:
- `cmd/skywire-cli/commands/log`: `http://ut.skywire.skycoin.com/uptimes?v=v2` (×2) — the other `svc/*` commands already use `deployment.Prod.UptimeTracker`.
- `cmd/svc/config-bootstrapper`: `Production: http://conf.skywire.skycoin.com` / `Test: http://conf.skywire.dev`.

Both now source from the `deployment` struct (dmsg:// after the backfill), so the single source of truth drives help text too. **Verified:** `skywire help -r | grep http://` shows only `ip.skycoin.com` (geoip — the one allowed clearnet deployment endpoint).

Found via `./skywire help -r | grep http://`. Follows #3348.