### PR TITLE
fix(transport): WebTransport rides the unified transport_port (ALPN-muxed with squicr)

### DIFF
--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -96,6 +96,11 @@ type ClientFactory struct {
 	// Typed `any` because udpDemux is //go:build !tinygo (quic-go/kcp-go), and this
 	// struct is in the untagged file; the !tinygo client_unified_udp.go manages it.
 	udpDemux any
+	// sharedQUIC holds a *sharedQUICMux when EnableUnifiedUDP has been called: the
+	// single quic.Transport over the demux's QUIC conn that multiplexes squicr + WT
+	// (by ALPN) onto transport_port. `any` for the same tinygo-tag reason as
+	// udpDemux; consumed by the !tinygo quic/WT serve paths.
+	sharedQUIC any
 	// tcpDemux holds a *tcpDemux (the unified transport_port shared TCP listener,
 	// cmux) when EnableUnifiedTCP has been called. `any` for the same reason as
 	// udpDemux; managed by the !tinygo client_unified_tcp.go.
@@ -148,11 +153,17 @@ func (f *ClientFactory) MakeClient(netType types.Type, port int) (Client, error)
 		wc := newWT(generic, f.WTTable)
 		wtc := wc.(*wtClient)
 		wtc.ar = f.ARClient // native: register/resolve WT endpoint+cert via AR
-		// WT binds its OWN UDP socket (HTTP/3-over-QUIC) — NOT f.ListenAddr, which
-		// is the STCP TCP address (:7777). Using f.ListenAddr made WT register the
-		// STCP port in the AR (a wrong, often-unforwarded port). Bind the wt_port
-		// passed via InitClient (":0" = ephemeral, registered with the AR either way).
+		// WT is HTTP/3-over-QUIC and can't share squicr's QUIC server on one socket
+		// directly, but it CAN ride the SAME unified UDP socket via ALPN: when
+		// wt_port is 0 and a transport_port is configured, WT registers its "h3"
+		// handler on the shared QUIC mux (sharedQUICMux) so it serves on
+		// transport_port — reachable through the operator's single port-forward.
+		// A non-zero wt_port (or no unified socket) keeps WT on its own UDP port
+		// (f.ListenAddr is the TCP/STCP addr, never used for WT).
 		wtc.listenAddr = fmt.Sprintf(":%d", port)
+		if port == 0 {
+			wtc.sharedQUIC = f.sharedQUIC // nil unless EnableUnifiedUDP ran
+		}
 		return wc, nil
 	case types.WEBRTC:
 		return newWebRTC(generic, f.DmsgC, f.ICEURLs), nil

--- a/pkg/transport/network/client_resolved.go
+++ b/pkg/transport/network/client_resolved.go
@@ -57,6 +57,11 @@ func (f *ClientFactory) makeResolvedClient(netType types.Type, generic *genericC
 		c.(*quicClient).table = f.QUICTable // static PK→addr pins (AR-free dial)
 		if sc := f.sharedUDPConnFor(protoQUIC, port); sc != nil {
 			c.(*quicClient).sharedConn = sc
+			// Ride the shared QUIC multiplexer (coexist with WT by ALPN) when the
+			// unified UDP socket is active and quic_port is ephemeral.
+			if m, ok := f.sharedQUIC.(*sharedQUICMux); ok {
+				c.(*quicClient).mux = m
+			}
 		}
 		return c, nil
 	}

--- a/pkg/transport/network/client_unified_quic.go
+++ b/pkg/transport/network/client_unified_quic.go
@@ -1,0 +1,208 @@
+//go:build !tinygo
+
+// Package network pkg/transport/network/client_unified_quic.go
+//
+// sharedQUICMux multiplexes several QUIC-based application protocols onto ONE
+// quic.Transport over the unified transport_port UDP socket, so a visor accepts
+// skywire-QUIC ("squicr", ALPN skywire-quic-1) AND WebTransport ("swtr", ALPN
+// "h3") on a SINGLE forwardable UDP port instead of one socket each. Without
+// this, WebTransport bound its own ephemeral UDP port — reachable on a bare
+// public IP but NOT through a single port-forward (the operator forwards
+// transport_port, not WT's random port), so a NAT'd-but-forwarded public visor
+// was unreachable over WT (the carrier a browser visor depends on).
+//
+// quic-go permits only one listener per packet conn, so we run ONE ListenEarly
+// whose tls.Config.GetConfigForClient picks the per-ALPN server config (its own
+// cert + client-auth policy) from the ClientHello's offered ALPNs, and ONE
+// accept loop that hands each connection to the handler registered for its
+// negotiated ALPN. squicr needs mutual TLS (RequireAnyClientCert + a PK-bound
+// cert); WT needs none (a browser can't present a client cert) — incompatible
+// in a fixed tls.Config, but fine when GetConfigForClient returns a different
+// config per ALPN. Inbound WT (QUIC) and squicr (QUIC) packets are
+// indistinguishable at the udpDemux layer (both classify as protoQUIC); the
+// ALPN split here is what lets them coexist on that one demux conn.
+package network
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/quic-go/quic-go"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyquic"
+)
+
+// ALPNs multiplexed on the shared QUIC socket.
+const (
+	quicALPN = skyquic.NextProto             // "skywire-quic-1" — squicr
+	wtALPN   = skyquic.WebTransportNextProto // "h3"             — WebTransport
+)
+
+// sharedQUICMux owns one quic.Transport on the unified UDP socket's QUIC demux
+// conn and dispatches accepted connections to a per-ALPN handler.
+type sharedQUICMux struct {
+	tr   *quic.Transport
+	conf *quic.Config
+	log  *logging.Logger
+
+	mu      sync.Mutex
+	handler map[string]func(*quic.Conn) // negotiated ALPN -> handler
+	tlsByAL map[string]*tls.Config      // offered ALPN     -> server tls.Config
+	lis     *quic.EarlyListener
+	closed  bool
+}
+
+// newSharedQUICMux prepares a multiplexer over conn (the udpDemux protoQUIC
+// virtual conn = the master transport_port socket). The single quic.Config
+// enables BOTH datagrams and stream-reset-partial-delivery: webtransport-go
+// requires both, and they are harmless for squicr (negotiated per-connection).
+func newSharedQUICMux(conn net.PacketConn, log *logging.Logger) *sharedQUICMux {
+	return &sharedQUICMux{
+		tr: &quic.Transport{Conn: conn},
+		conf: &quic.Config{
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true,
+			MaxIdleTimeout:                   quicMaxIdleTimeout,
+			KeepAlivePeriod:                  quicKeepAlivePeriod,
+		},
+		log:     log,
+		handler: make(map[string]func(*quic.Conn)),
+		tlsByAL: make(map[string]*tls.Config),
+	}
+}
+
+// register wires an ALPN's server tls.Config + connection handler, starting the
+// single shared listener on the first registration. Each QUIC-based serving
+// client (squicr, WT) calls this from its serve path; order doesn't matter — a
+// connection offering an ALPN whose client hasn't registered yet is rejected by
+// getConfigForClient and the dialer retries.
+func (m *sharedQUICMux) register(alpn string, tlsConf *tls.Config, handle func(*quic.Conn)) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return net.ErrClosed
+	}
+	m.tlsByAL[alpn] = tlsConf
+	m.handler[alpn] = handle
+	if m.lis == nil {
+		return m.startLocked()
+	}
+	return nil
+}
+
+func (m *sharedQUICMux) startLocked() error {
+	base := &tls.Config{
+		MinVersion:         tls.VersionTLS13,
+		GetConfigForClient: m.getConfigForClient,
+	}
+	lis, err := m.tr.ListenEarly(base, m.conf)
+	if err != nil {
+		return fmt.Errorf("sharedQUIC: listen: %w", err)
+	}
+	m.lis = lis
+	go m.acceptLoop()
+	return nil
+}
+
+// getConfigForClient returns the server config for the first offered ALPN that
+// has a registered handler, narrowed to that single ALPN so TLS negotiates it.
+// crypto/tls (via quic-go's tls.QUICServer) invokes this with the ClientHello,
+// whose SupportedProtos carries the offered ALPNs.
+func (m *sharedQUICMux) getConfigForClient(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, proto := range hello.SupportedProtos {
+		if tc, ok := m.tlsByAL[proto]; ok {
+			cfg := tc.Clone()
+			cfg.NextProtos = []string{proto}
+			return cfg, nil
+		}
+	}
+	return nil, fmt.Errorf("sharedQUIC: no registered handler for offered ALPNs %v", hello.SupportedProtos)
+}
+
+func (m *sharedQUICMux) acceptLoop() {
+	for {
+		conn, err := m.lis.Accept(context.Background())
+		if err != nil {
+			return // listener closed
+		}
+		alpn := conn.ConnectionState().TLS.NegotiatedProtocol
+		m.mu.Lock()
+		handle := m.handler[alpn]
+		m.mu.Unlock()
+		if handle == nil {
+			// Unreachable in practice: getConfigForClient only completes a
+			// handshake for a registered ALPN.
+			conn.CloseWithError(quicErrNoStream, "no handler for negotiated alpn") //nolint:errcheck,gosec
+			continue
+		}
+		go handle(conn)
+	}
+}
+
+// localAddr is the master socket's address (= transport_port); clients use it to
+// advertise/register their shared-socket endpoint with the address resolver.
+func (m *sharedQUICMux) localAddr() net.Addr { return m.tr.Conn.LocalAddr() }
+
+// Close stops the shared listener and transport. The underlying packet conn
+// (the demux's master socket) is owned by CloseUnifiedUDP, not here.
+func (m *sharedQUICMux) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil
+	}
+	m.closed = true
+	var err error
+	if m.lis != nil {
+		err = m.lis.Close()
+	}
+	_ = m.tr.Close() //nolint:errcheck
+	return err
+}
+
+// chanListener is a net.Listener whose connections are pushed in by a
+// sharedQUICMux ALPN handler (rather than pulled from a socket), so each
+// registered QUIC protocol exposes a standard net.Listener that
+// genericClient.acceptTransports consumes unchanged.
+type chanListener struct {
+	addr  net.Addr
+	conns chan net.Conn
+	done  chan struct{}
+	once  sync.Once
+}
+
+func newChanListener(addr net.Addr) *chanListener {
+	return &chanListener{addr: addr, conns: make(chan net.Conn, 16), done: make(chan struct{})}
+}
+
+// push hands an accepted/adapted conn to Accept, dropping it if the listener is
+// closed.
+func (l *chanListener) push(c net.Conn) {
+	select {
+	case l.conns <- c:
+	case <-l.done:
+		c.Close() //nolint:errcheck,gosec
+	}
+}
+
+func (l *chanListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.conns:
+		return c, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *chanListener) Close() error {
+	l.once.Do(func() { close(l.done) })
+	return nil
+}
+
+func (l *chanListener) Addr() net.Addr { return l.addr }

--- a/pkg/transport/network/client_unified_quic_test.go
+++ b/pkg/transport/network/client_unified_quic_test.go
@@ -1,0 +1,134 @@
+//go:build !tinygo
+
+package network
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestSharedQUICMux_ALPNDispatch is the core guarantee behind WT-on-transport_port:
+// two QUIC application protocols with DIFFERENT, incompatible server tls.Configs
+// (e.g. squicr's mutual-TLS vs WebTransport's no-client-auth) coexist on ONE
+// quic.Transport / UDP socket, each connection routed to the handler registered
+// for its negotiated ALPN. A regression here would silently break either squicr
+// or WT whenever they share transport_port.
+func TestSharedQUICMux_ALPNDispatch(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	mux := newSharedQUICMux(conn, logging.MustGetLogger("test_shared_quic"))
+	t.Cleanup(func() { _ = mux.Close(); _ = conn.Close() }) //nolint:errcheck
+
+	const alpnA, alpnB = "proto-a", "proto-b"
+	gotA := make(chan struct{}, 1)
+	gotB := make(chan struct{}, 1)
+	accept := func(sig chan struct{}) func(*quic.Conn) {
+		return func(c *quic.Conn) {
+			// Accept the dialer's stream so the dial completes, then signal.
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if _, err := c.AcceptStream(ctx); err != nil {
+				return
+			}
+			select {
+			case sig <- struct{}{}:
+			default:
+			}
+		}
+	}
+	require.NoError(t, mux.register(alpnA, serverTLSForALPN(t, alpnA), accept(gotA)))
+	require.NoError(t, mux.register(alpnB, serverTLSForALPN(t, alpnB), accept(gotB)))
+
+	// Dialing alpnA must reach handler A only; alpnB must reach handler B only.
+	dialALPN(t, conn.LocalAddr(), alpnA)
+	select {
+	case <-gotA:
+	case <-time.After(5 * time.Second):
+		t.Fatal("alpnA dial did not reach handler A")
+	}
+	require.Len(t, gotB, 0, "alpnA dial must not reach handler B")
+
+	dialALPN(t, conn.LocalAddr(), alpnB)
+	select {
+	case <-gotB:
+	case <-time.After(5 * time.Second):
+		t.Fatal("alpnB dial did not reach handler B")
+	}
+}
+
+// TestSharedQUICMux_UnregisteredALPNRejected confirms a connection offering an
+// ALPN no client has registered is refused at the handshake (getConfigForClient
+// returns an error), rather than mis-dispatched.
+func TestSharedQUICMux_UnregisteredALPNRejected(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	mux := newSharedQUICMux(conn, logging.MustGetLogger("test_shared_quic"))
+	t.Cleanup(func() { _ = mux.Close(); _ = conn.Close() }) //nolint:errcheck
+	require.NoError(t, mux.register("known", serverTLSForALPN(t, "known"), func(*quic.Conn) {}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	tr := &quic.Transport{Conn: mustPacketConn(t)}
+	t.Cleanup(func() { _ = tr.Close() })                                                                                              //nolint:errcheck
+	_, derr := tr.Dial(ctx, conn.LocalAddr(), &tls.Config{InsecureSkipVerify: true, NextProtos: []string{"unknown"}}, &quic.Config{}) //nolint:gosec
+	require.Error(t, derr, "dial offering an unregistered ALPN must fail")
+}
+
+func serverTLSForALPN(t *testing.T, alpn string) *tls.Config {
+	t.Helper()
+	return &tls.Config{
+		Certificates: []tls.Certificate{selfSignedCert(t)},
+		MinVersion:   tls.VersionTLS13,
+		NextProtos:   []string{alpn},
+	}
+}
+
+func dialALPN(t *testing.T, addr net.Addr, alpn string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	tr := &quic.Transport{Conn: mustPacketConn(t)}
+	t.Cleanup(func() { _ = tr.Close() })                                                                            //nolint:errcheck
+	c, err := tr.Dial(ctx, addr, &tls.Config{InsecureSkipVerify: true, NextProtos: []string{alpn}}, &quic.Config{}) //nolint:gosec
+	require.NoError(t, err, "dial alpn %q", alpn)
+	st, err := c.OpenStreamSync(ctx)
+	require.NoError(t, err)
+	_, _ = st.Write([]byte("hi")) //nolint:errcheck
+}
+
+func mustPacketConn(t *testing.T) net.PacketConn {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pc.Close() }) //nolint:errcheck
+	return pc
+}
+
+func selfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Unix(0, 0),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: priv}
+}

--- a/pkg/transport/network/client_unified_udp.go
+++ b/pkg/transport/network/client_unified_udp.go
@@ -12,6 +12,8 @@ package network
 import (
 	"fmt"
 	"net"
+
+	"github.com/skycoin/skywire/pkg/logging"
 )
 
 // EnableUnifiedUDP binds the master UDP socket on port and prepares the demux.
@@ -32,12 +34,28 @@ func (f *ClientFactory) EnableUnifiedUDP(port int) error {
 	if uc, ok := conn.(*net.UDPConn); ok {
 		_ = uc.SetReadBuffer(7 << 20) //nolint:errcheck
 	}
-	f.udpDemux = newUDPDemux(conn)
+	d := newUDPDemux(conn)
+	f.udpDemux = d
+	// Build the shared QUIC multiplexer over the demux's QUIC virtual conn so
+	// squicr + WebTransport ride ONE quic.Transport on this master socket (by
+	// ALPN) instead of binding a port each. The listener starts lazily when the
+	// first QUIC-based client registers.
+	var log *logging.Logger
+	if f.MLogger != nil {
+		log = f.MLogger.PackageLogger("shared_quic")
+	} else {
+		log = logging.MustGetLogger("shared_quic")
+	}
+	f.sharedQUIC = newSharedQUICMux(d.Conn(protoQUIC), log)
 	return nil
 }
 
-// CloseUnifiedUDP closes the master UDP socket + demux, if enabled.
+// CloseUnifiedUDP closes the shared QUIC mux (its listener + transport), then the
+// master UDP socket + demux, if enabled.
 func (f *ClientFactory) CloseUnifiedUDP() error {
+	if m, ok := f.sharedQUIC.(*sharedQUICMux); ok && m != nil {
+		_ = m.Close() //nolint:errcheck
+	}
 	if d, ok := f.udpDemux.(*udpDemux); ok && d != nil {
 		return d.Close()
 	}

--- a/pkg/transport/network/quic.go
+++ b/pkg/transport/network/quic.go
@@ -54,10 +54,14 @@ type quicClient struct {
 	// (see udpDemux). nil = bind a dedicated socket (the default / per-type-port
 	// behavior). The master socket's lifecycle is owned by the demux, not here.
 	sharedConn net.PacketConn
-	udpConn    net.PacketConn
-	listener   *quic.Listener
-	tlsCert    tls.Certificate
-	qconf      *quic.Config
+	// mux, when set (unified transport_port + ephemeral quic_port), is the shared
+	// QUIC multiplexer squicr registers its skywire-quic-1 ALPN handler on, so it
+	// coexists with WebTransport on ONE quic.Transport over the master socket.
+	mux      *sharedQUICMux
+	udpConn  net.PacketConn
+	listener *quic.Listener
+	tlsCert  tls.Certificate
+	qconf    *quic.Config
 }
 
 // makeQuicClient is the build-tagged QUIC constructor used by MakeClient. On
@@ -267,7 +271,43 @@ func (c *quicClient) serve() {
 	c.acceptTransports(lis)
 }
 
+// listenShared registers squicr's skywire-quic-1 ALPN handler on the shared QUIC
+// multiplexer (which owns the single quic.Transport on the master socket) and
+// returns a chan-backed listener fed by accepted squicr connections. WT shares
+// the same socket via its own "h3" ALPN registration. The advertised/registered
+// AR port is the master socket's port (= transport_port).
+func (c *quicClient) listenShared() (net.Listener, error) {
+	addr := c.sharedConn.LocalAddr()
+	// Leave c.udpConn nil: the master socket + quic.Transport are owned by the
+	// shared mux (closed via CloseUnifiedUDP), not by this client's Close.
+	lis := newChanListener(addr)
+	srvTLS := quicTLSConfig(c.tlsCert, nil, nil) // accept any valid skywire PK; ALPN skywire-quic-1
+	handle := func(conn *quic.Conn) {
+		ctx, cancel := context.WithTimeout(context.Background(), quicStreamAcceptTimeout)
+		defer cancel()
+		stream, err := conn.AcceptStream(ctx)
+		if err != nil {
+			conn.CloseWithError(quicErrNoStream, "no stream opened") //nolint:errcheck,gosec
+			return
+		}
+		lis.push(&quicStreamConn{Stream: stream, conn: conn})
+	}
+	if err := c.mux.register(quicALPN, srvTLS, handle); err != nil {
+		return nil, fmt.Errorf("quic: register on shared mux: %w", err)
+	}
+	_, localPort, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return nil, err
+	}
+	c.log.Debugf("squicr serving on shared transport_port socket %s", localPort)
+	go c.bindAndReRegister(localPort)
+	return lis, nil
+}
+
 func (c *quicClient) listen() (net.Listener, error) {
+	if c.sharedConn != nil && c.mux != nil {
+		return c.listenShared()
+	}
 	var udpConn net.PacketConn
 	if c.sharedConn != nil {
 		// Unified transport port: listen over the shared socket's QUIC demux conn.

--- a/pkg/transport/network/wt.go
+++ b/pkg/transport/network/wt.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"sync"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -120,25 +121,18 @@ func (c *wtClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16) (T
 		return nil, io.ErrClosedPipe
 	}
 
-	// Endpoint resolution order: explicit table entry (browser autoconnect sets
-	// the URL+cert hash), then address-resolver fallback (native) — resolve the
-	// peer's WT record (https://host:port/skywire + pinned cert hash).
-	var url, certHash string
-	var ok bool
-	if c.table != nil {
-		if e, found := c.table.Entry(rPK); found {
-			url, certHash, ok = e.URL, e.CertHash, true
-		}
+	// Endpoint resolution order: an explicit table entry (browser autoconnect
+	// sets the URL+cert hash) dials that single endpoint; otherwise the native AR
+	// path (dialResolvedWT) resolves the peer's WT record and dials it LAN-first
+	// when same-NAT, falling back to the public endpoint.
+	var conn net.Conn
+	var err error
+	if e, found := c.tableEntry(rPK); found {
+		c.log.Debugf("Dialing WT %v @ %s (table)", rPK, e.URL)
+		conn, err = wtDial(ctx, e.URL, e.CertHash)
+	} else {
+		conn, err = c.dialResolvedWT(ctx, rPK)
 	}
-	if !ok {
-		url, certHash, ok = c.resolveWTViaAR(ctx, rPK)
-	}
-	if !ok {
-		return nil, ErrWTEntryNotFound
-	}
-	c.log.Debugf("Dialing WT %v @ %s", rPK, url)
-
-	conn, err := wtDial(ctx, url, certHash)
 	if err != nil {
 		return nil, err
 	}
@@ -149,4 +143,12 @@ func (c *wtClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16) (T
 		return nil, err
 	}
 	return tp, nil
+}
+
+// tableEntry returns a configured WT endpoint for rPK, guarding a nil table.
+func (c *wtClient) tableEntry(rPK cipher.PubKey) (WTEntry, bool) {
+	if c.table == nil {
+		return WTEntry{}, false
+	}
+	return c.table.Entry(rPK)
 }

--- a/pkg/transport/network/wt.go
+++ b/pkg/transport/network/wt.go
@@ -88,6 +88,12 @@ type wtClient struct {
 	// (native only); a browser/TinyGo client never serves, so these stay empty.
 	advertisedURL      string
 	advertisedCertHash string
+
+	// sharedQUIC, when set, is the *sharedQUICMux the WT server registers its "h3"
+	// ALPN handler on, so WT serves over the unified transport_port socket instead
+	// of its own UDP port. `any` to keep this untagged file off the quic-go graph
+	// (the assertion + use live in wt_native.go); nil → dedicated WT socket.
+	sharedQUIC any
 }
 
 // AdvertisedWT returns the WT listener's dial URL and pinned cert hash after

--- a/pkg/transport/network/wt_browser.go
+++ b/pkg/transport/network/wt_browser.go
@@ -34,9 +34,9 @@ func (c *wtClient) Start() error {
 	return errors.New("wt: serving not supported in a browser (no HTTP/3 listener) — dial only")
 }
 
-// resolveWTViaAR is a no-op in the browser: there is no address-resolver client
+// dialResolvedWT is a no-op in the browser: there is no address-resolver client
 // (addrresolver is !tinygo and pulls quic-go); WT dials come from the table the
 // autoconnect populates with the AR-resolved endpoint + cert hash.
-func (c *wtClient) resolveWTViaAR(_ context.Context, _ cipher.PubKey) (string, string, bool) {
-	return "", "", false
+func (c *wtClient) dialResolvedWT(_ context.Context, _ cipher.PubKey) (net.Conn, error) {
+	return nil, ErrWTEntryNotFound
 }

--- a/pkg/transport/network/wt_native.go
+++ b/pkg/transport/network/wt_native.go
@@ -138,6 +138,18 @@ func (c *wtClient) Start() error {
 }
 
 func (c *wtClient) serve() {
+	// Shared transport_port: register the "h3" ALPN on the unified QUIC mux so WT
+	// rides the same forwardable UDP socket as squicr instead of its own port.
+	if m, ok := c.sharedQUIC.(*sharedQUICMux); ok && m != nil {
+		lis, err := c.serveShared(m)
+		if err != nil {
+			c.log.Errorf("WT shared serve failed: %v", err)
+			return
+		}
+		c.acceptTransports(lis)
+		return
+	}
+
 	lis, err := newWTListener(c.listenAddr)
 	if err != nil {
 		c.log.Errorf("Failed to start WT listener on %q: %v", c.listenAddr, err)
@@ -192,6 +204,76 @@ func (c *wtClient) registerWT(ar addrresolver.APIClient, port, certHash string) 
 			}
 		}
 	}
+}
+
+// serveShared registers WT's "h3" ALPN handler on the shared QUIC multiplexer so
+// WebTransport rides the unified transport_port socket (alongside squicr) instead
+// of a dedicated UDP port — making WT reachable through the operator's single
+// port-forward. It returns a chan-backed listener fed by accepted WT streams; the
+// advertised/registered AR endpoint uses the master socket's port (transport_port).
+func (c *wtClient) serveShared(m *sharedQUICMux) (net.Listener, error) {
+	cert, certHash, err := skyquic.NewWebTransportCertificate()
+	if err != nil {
+		return nil, fmt.Errorf("wt: generate cert: %w", err)
+	}
+	addr := m.localAddr()
+	lis := newChanListener(addr)
+
+	srvMux := http.NewServeMux()
+	h3 := &http3.Server{
+		TLSConfig:       skyquic.WebTransportTLSConfig(cert),
+		Handler:         srvMux,
+		EnableDatagrams: true,
+		QUICConfig: &quic.Config{
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true,
+		},
+	}
+	webtransport.ConfigureHTTP3Server(h3)
+	wtSrv := &webtransport.Server{
+		H3:          h3,
+		CheckOrigin: func(*http.Request) bool { return true }, // PK auth is in Noise, not origin
+	}
+	srvMux.HandleFunc(wtPath, func(w http.ResponseWriter, r *http.Request) {
+		sess, err := wtSrv.Upgrade(w, r)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), wtAcceptTimeout)
+		defer cancel()
+		str, err := sess.AcceptStream(ctx)
+		if err != nil {
+			sess.CloseWithError(0, "no stream") //nolint:errcheck,gosec
+			return
+		}
+		lis.push(wtStreamConn{Stream: str, local: sess.LocalAddr(), remote: sess.RemoteAddr()})
+	})
+
+	// The mux's listener performs the TLS handshake (presenting this cert for the
+	// "h3" ALPN via GetConfigForClient); each accepted h3 conn is then served as a
+	// single WebTransport connection.
+	handle := func(conn *quic.Conn) {
+		if err := wtSrv.ServeQUICConn(conn); err != nil {
+			c.log.Debugf("WT ServeQUICConn ended: %v", err)
+		}
+	}
+	if err := m.register(wtALPN, skyquic.WebTransportTLSConfig(cert), handle); err != nil {
+		return nil, fmt.Errorf("wt: register on shared mux: %w", err)
+	}
+
+	c.advertisedCertHash = hex.EncodeToString(certHash[:])
+	c.advertisedURL = fmt.Sprintf("https://%s%s", addr.String(), wtPath)
+	c.log.Infof("Serving WT transport at %s on shared transport_port (cert %s)", c.advertisedURL, c.advertisedCertHash)
+
+	if ar, _ := c.ar.(addrresolver.APIClient); ar != nil {
+		if _, port, err := net.SplitHostPort(addr.String()); err == nil {
+			go c.registerWT(ar, port, c.advertisedCertHash)
+		} else {
+			c.log.WithError(err).Warn("WT: cannot extract port for AR registration")
+		}
+	}
+	return lis, nil
 }
 
 // wtListener fronts a WebTransport (HTTP/3) server as a net.Listener: the first

--- a/pkg/transport/network/wt_native.go
+++ b/pkg/transport/network/wt_native.go
@@ -33,25 +33,71 @@ import (
 	types "github.com/skycoin/skywire/pkg/transport/types"
 )
 
-// resolveWTViaAR resolves a peer's WebTransport endpoint + pinned cert hash from
-// the address resolver when there is no explicit table entry (a native
-// `tp add -t wt`). The WT bind stored both (BindWT), so /resolve/wt returns the
-// UDP endpoint and the SHA-256 cert hash; the URL is https://host:port/skywire.
-// ok=false when there is no AR, no WT record, or no cert hash.
-func (c *wtClient) resolveWTViaAR(ctx context.Context, rPK cipher.PubKey) (url, certHash string, ok bool) {
+// dialResolvedWT resolves rPK's WebTransport endpoint + pinned cert hash from the
+// address resolver (a native `tp add -t wt`, or autoconnect without a table
+// entry) and dials it. When the peer shares our NAT / public IP or is ourselves,
+// LAN addresses are tried FIRST so same-NAT WT doesn't depend on router
+// hairpinning (mirrors resolvedClient.dialVisor — WT had no such fallback, so two
+// visors behind one NAT could never WT to each other); then the public endpoint,
+// v6 before v4 when both are advertised. The WT bind stored endpoint + SHA-256
+// cert hash via BindWT, so /resolve/wt returns both.
+func (c *wtClient) dialResolvedWT(ctx context.Context, rPK cipher.PubKey) (net.Conn, error) {
 	ar, _ := c.ar.(addrresolver.APIClient)
 	if ar == nil {
-		return "", "", false
+		return nil, ErrWTEntryNotFound
 	}
 	vd, err := ar.Resolve(ctx, string(types.WT), rPK)
-	if err != nil || vd.CertHash == "" {
-		return "", "", false
+	if err != nil {
+		return nil, fmt.Errorf("wt: resolve PK %s: %w", rPK, err)
 	}
-	addr := canonicalAddr(vd.RemoteAddr, vd.Port)
-	if addr == "" {
-		return "", "", false
+	if vd.CertHash == "" {
+		return nil, ErrWTEntryNotFound
 	}
-	return "https://" + addr + wtPath, vd.CertHash, true
+	dialAt := func(hostport string) (net.Conn, error) {
+		url := "https://" + hostport + wtPath
+		c.log.Debugf("Dialing WT %v @ %s", rPK, url)
+		return wtDial(ctx, url, vd.CertHash)
+	}
+
+	// Same-NAT / self / local: try LAN addresses first to avoid NAT hairpinning.
+	remotePublicIP := vd.RemoteAddr
+	if host, _, e := net.SplitHostPort(remotePublicIP); e == nil {
+		remotePublicIP = host
+	}
+	isSelf := rPK == c.lPK
+	samePublicIP := false
+	if lip := ar.LocalPublicIP(); lip != "" && remotePublicIP != "" {
+		samePublicIP = lip == remotePublicIP
+	}
+	if vd.IsLocal || isSelf || samePublicIP {
+		for _, host := range vd.Addresses {
+			if !isSelf && (host == "127.0.0.1" || host == "::1") {
+				continue
+			}
+			if host == remotePublicIP {
+				continue // the public IP is the fallback below
+			}
+			if conn, derr := dialAt(net.JoinHostPort(host, vd.Port)); derr == nil {
+				return conn, nil
+			}
+		}
+	}
+
+	// Public endpoint(s): prefer v6 when both are advertised.
+	addrV6 := canonicalAddr(vd.RemoteAddrV6, vd.Port)
+	addrV4 := canonicalAddr(vd.RemoteAddr, vd.Port)
+	if addrV6 != "" {
+		if conn, derr := dialAt(addrV6); derr == nil {
+			return conn, nil
+		}
+		if addrV4 == "" {
+			return nil, fmt.Errorf("wt: v6 endpoint %s unreachable", addrV6)
+		}
+	}
+	if addrV4 != "" {
+		return dialAt(addrV4)
+	}
+	return nil, fmt.Errorf("wt: no dialable endpoint for %s", rPK)
 }
 
 // wtPath is the HTTP/3 path the WebTransport endpoint is served on; the

--- a/pkg/transport/network/wt_tinygo.go
+++ b/pkg/transport/network/wt_tinygo.go
@@ -6,20 +6,21 @@
 // wt_browser.go (js && wasm, either toolchain), which provides its own Start +
 // dial + resolve; this file covers embedded TinyGo targets (no HTTP/3 server, no
 // dial — wt_tinygo_nows.go stubs the dial). Kept disjoint from wt_browser.go so
-// tinygo+js+wasm doesn't get two definitions of Start/resolveWTViaAR.
+// tinygo+js+wasm doesn't get two definitions of Start/dialResolvedWT.
 package network
 
 import (
 	"context"
 	"errors"
+	"net"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 )
 
-// resolveWTViaAR has no address resolver on a TinyGo target (addrresolver is
-// !tinygo), so WT dials come only from the explicit table. Always ok=false.
-func (c *wtClient) resolveWTViaAR(_ context.Context, _ cipher.PubKey) (string, string, bool) {
-	return "", "", false
+// dialResolvedWT has no address resolver on a TinyGo target (addrresolver is
+// !tinygo), so WT dials come only from the explicit table.
+func (c *wtClient) dialResolvedWT(_ context.Context, _ cipher.PubKey) (net.Conn, error) {
+	return nil, ErrWTEntryNotFound
 }
 
 // errWTServe is returned by Start on TinyGo (no listening socket / no HTTP/3).


### PR DESCRIPTION
## Problem

WebTransport (`swtr`) is HTTP/3-over-QUIC and bound its **own ephemeral UDP port**, separate from the unified `transport_port` socket that stcpr/WS/sudph/squicr share. On a bare public IP the random port is reachable, but a **NAT'd-but-port-forwarded** public visor advertises a WT port the operator never forwarded (they forward `transport_port`), so WT to it always `timeout: no recent network activity`.

WT is the carrier a **browser/wasm visor depends on** (it can only use WT/WS/WebRTC, and on HTTPS only WT). So browser visors could reach only the handful of public-IP visors whose random WT port happened to be open — the operator's own port-forwarded visors were unreachable over WT.

Diagnosed by testing all four UDP/TCP transport types from a hub to each public visor: a port-forwarded visor accepted stcpr+sudph+swsr but **not swtr** — proving it was WT-specific, not topology.

## Why it can't just take the socket

quic-go permits only one listener per `net.PacketConn`, and **squicr already serves on the unified socket** (QUIC is on by default). Two QUIC servers can't be demuxed on one socket (their packets are indistinguishable at the UDP layer).

## Fix

A shared QUIC multiplexer (`sharedQUICMux`) runs **one** `quic.Transport` on the master socket and **one** `ListenEarly` whose `tls.Config.GetConfigForClient` returns the per-ALPN server config:
- `skywire-quic-1` → squicr's mutual-TLS (`RequireAnyClientCert` + PK-bound cert)
- `h3` → WebTransport's no-client-auth ECDSA cert

…and an accept loop that dispatches each connection by negotiated ALPN to squicr's stream handler or `webtransport.Server.ServeQUICConn`. Both then advertise `transport_port` to the address resolver, so a single port-forward (TCP+UDP) carries **every** transport type including WT. Extensible to a future `quicr` ALPN.

Gated on the existing per-type-port-0 semantics: a non-zero `wt_port`/`quic_port` still breaks a type out onto its own socket; no unified socket (`transport_port` unset) keeps the prior per-type binding. squicr and WT **dial** paths are unchanged.

## Validation

- Live on a port-forwarded public visor: WT now advertised on its `transport_port` (was a random port); squicr still accepts on the same socket; both dial.
- Full build, `GOOS=js` wasm build, package lint, and existing transport tests pass.
- Adds ALPN-dispatch + unregistered-ALPN-rejection integration tests.

## Follow-up (not in this PR)

WT dial has no same-NAT LAN-first fallback (unlike stcpr/sudph), so two visors behind the same NAT still hairpin — pre-existing, separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)