### PR TITLE
feat(dmsg): wss_domain_suffix in services-config.json — one source for the fleet wss domain

### DIFF
--- a/deployment/cmd/gen/main.go
+++ b/deployment/cmd/gen/main.go
@@ -57,6 +57,7 @@ type services struct {
 	DNSServer          string   `json:"dns_server,omitempty"`
 	GeoIP              string   `json:"geoip,omitempty"`
 	SurveyWhitelist    []string `json:"survey_whitelist,omitempty"`
+	WSSDomainSuffix    string   `json:"wss_domain_suffix,omitempty"`
 	DmsgServers        []struct {
 		Static string `json:"static"`
 		Server struct {
@@ -176,6 +177,7 @@ func emitServices(buf *bytes.Buffer, s services) {
 	emitStringField(buf, "GeoIP", s.GeoIP)
 	emitPubKeyList(buf, "SurveyWhitelist", s.SurveyWhitelist)
 	emitStringField(buf, "ConfDmsg", s.ConfDmsg)
+	emitStringField(buf, "WSSDomainSuffix", s.WSSDomainSuffix)
 	emitDmsgServers(buf, s.DmsgServers)
 	emitStringField(buf, "DmsgDiscoveryDmsg", s.DmsgDiscoveryDmsg)
 	emitStringField(buf, "TransportDiscoveryDmsg", s.TransportDiscoveryDmsg)

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -84,6 +84,21 @@ func (s *Services) HasDmsgServers() bool {
 	return len(s.DmsgServers) > 0
 }
 
+// IsKnownDmsgServer reports whether pk is one of the deployment's known
+// (official) dmsg servers. Used to gate fleet-wide defaults — e.g. the
+// WSSDomainSuffix — to servers this deployment actually runs DNS/TLS for, so a
+// third party running the same binary doesn't self-advertise the deployment's
+// wss domain for a PK that has no DNS record.
+func (s *Services) IsKnownDmsgServer(pk cipher.PubKey) bool {
+	for i := range s.DmsgServers {
+		var spk cipher.PubKey
+		if spk.Set(s.DmsgServers[i].Static) == nil && spk == pk {
+			return true
+		}
+	}
+	return false
+}
+
 // DmsgServerEntriesToDisc converts a list of DmsgServerEntry to
 // []*disc.Entry suitable for direct.NewClient / direct.GetAllEntries.
 // Entries whose Static field is not a valid public key are skipped
@@ -178,14 +193,23 @@ type Services struct {
 	GeoIP              string          `json:"geoip,omitempty"` // HTTP only (dmsg doesn't preserve client IP)
 	SurveyWhitelist    []cipher.PubKey `json:"survey_whitelist,omitempty"`
 	// DMSG endpoints (dmsg:// URLs for the same services)
-	ConfDmsg               string            `json:"conf_dmsg,omitempty"`
-	DmsgServers            []DmsgServerEntry `json:"dmsg_servers,omitempty"`
-	DmsgDiscoveryDmsg      string            `json:"dmsg_discovery_dmsg,omitempty"`
-	TransportDiscoveryDmsg string            `json:"transport_discovery_dmsg,omitempty"`
-	AddressResolverDmsg    string            `json:"address_resolver_dmsg,omitempty"`
-	RouteFinderDmsg        string            `json:"route_finder_dmsg,omitempty"`
-	UptimeTrackerDmsg      string            `json:"uptime_tracker_dmsg,omitempty"`
-	ServiceDiscoveryDmsg   string            `json:"service_discovery_dmsg,omitempty"`
+	ConfDmsg    string            `json:"conf_dmsg,omitempty"`
+	DmsgServers []DmsgServerEntry `json:"dmsg_servers,omitempty"`
+	// WSSDomainSuffix is the deployment-wide DNS suffix the official dmsg servers
+	// self-derive their wss:// AddressWS from — "wss://<DNSLabel(PK)>.<suffix>/dmsg"
+	// — so an HTTPS-served browser wasm-visor reaches them without mixed content.
+	// One string for the whole fleet (each server self-labels from its own PK), so
+	// the domain lives in exactly one place (this file) instead of every dmsg
+	// server's local config. A dmsg server applies it only when its own PK is a
+	// known fleet server (IsKnownDmsgServer) — a third party running this binary
+	// never mis-advertises this domain for a PK with no DNS record.
+	WSSDomainSuffix        string `json:"wss_domain_suffix,omitempty"`
+	DmsgDiscoveryDmsg      string `json:"dmsg_discovery_dmsg,omitempty"`
+	TransportDiscoveryDmsg string `json:"transport_discovery_dmsg,omitempty"`
+	AddressResolverDmsg    string `json:"address_resolver_dmsg,omitempty"`
+	RouteFinderDmsg        string `json:"route_finder_dmsg,omitempty"`
+	UptimeTrackerDmsg      string `json:"uptime_tracker_dmsg,omitempty"`
+	ServiceDiscoveryDmsg   string `json:"service_discovery_dmsg,omitempty"`
 	// Reward system
 	RewardSystem     string `json:"reward_system,omitempty"`
 	RewardSystemDmsg string `json:"reward_system_dmsg,omitempty"`

--- a/deployment/data_static_js.go
+++ b/deployment/data_static_js.go
@@ -52,7 +52,8 @@ var prodData = Services{
 		mustPubKey("0327e2cf1d2e516ecbfdbd616a87489cc92a73af97335d5c8c29eafb5d8882264a"),
 		mustPubKey("03abbb3eff140cf3dce468b3fa5a28c80fa02c6703d7b952be6faaf2050990ebf4"),
 	},
-	ConfDmsg: "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
+	ConfDmsg:        "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
+	WSSDomainSuffix: "theskywirenetwork.net",
 	DmsgServers: []DmsgServerEntry{
 		{Static: "0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb", Server: struct {
 			Address   string `json:"address"`
@@ -128,7 +129,8 @@ var testData = Services{
 		mustPubKey("0327e2cf1d2e516ecbfdbd616a87489cc92a73af97335d5c8c29eafb5d8882264a"),
 		mustPubKey("03abbb3eff140cf3dce468b3fa5a28c80fa02c6703d7b952be6faaf2050990ebf4"),
 	},
-	ConfDmsg: "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
+	ConfDmsg:        "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
+	WSSDomainSuffix: "theskywirenetwork.net",
 	DmsgServers: []DmsgServerEntry{
 		{Static: "0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb", Server: struct {
 			Address   string `json:"address"`

--- a/deployment/services-config-clearnet.json
+++ b/deployment/services-config-clearnet.json
@@ -2,6 +2,7 @@
   "test": {
     "conf": "http://conf.skywire.dev",
     "conf_dmsg": "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
+    "wss_domain_suffix": "theskywirenetwork.net",
     "dmsg_discovery": "http://dmsgd.skywire.dev",
     "transport_discovery": "http://tpd.skywire.dev",
     "address_resolver": "http://ar.skywire.dev",
@@ -101,6 +102,7 @@
   "prod": {
     "conf": "http://conf.skywire.skycoin.com",
     "conf_dmsg": "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
+    "wss_domain_suffix": "theskywirenetwork.net",
     "dmsg_discovery": "http://dmsgd.skywire.skycoin.com",
     "transport_discovery": "http://tpd.skywire.skycoin.com",
     "address_resolver": "http://ar.skywire.skycoin.com",

--- a/deployment/services-config.json
+++ b/deployment/services-config.json
@@ -1,6 +1,7 @@
 {
   "test": {
     "conf_dmsg": "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
+    "wss_domain_suffix": "theskywirenetwork.net",
     "route_setup_nodes": [
       "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557",
       "024fbd3997d4260f731b01abcfce60b8967a6d4c6a11d1008812810ea1437ce438"
@@ -92,6 +93,7 @@
   },
   "prod": {
     "conf_dmsg": "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
+    "wss_domain_suffix": "theskywirenetwork.net",
     "route_setup_nodes": [
       "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557",
       "024fbd3997d4260f731b01abcfce60b8967a6d4c6a11d1008812810ea1437ce438"

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -293,7 +293,16 @@ func (s *service) Run(ctx context.Context) error {
 		// wasm-visor can reach it without mixed content. The listener stays plain
 		// ws on the main port; a front proxy (Caddy) terminates TLS. We log the
 		// exact Caddy line so the operator just pastes it (no label to compute).
-		if suffix := strings.TrimPrefix(cfg.WSSDomainSuffix, "."); suffix != "" {
+		// Suffix precedence: an explicit per-server wss_domain_suffix wins; else
+		// fall back to the deployment-wide suffix from the embedded services-config
+		// (deployment.Prod.WSSDomainSuffix) — but ONLY for a known fleet server, so a
+		// third party running this binary never advertises the deployment's domain
+		// for a PK that has no DNS record.
+		suffix := strings.TrimPrefix(cfg.WSSDomainSuffix, ".")
+		if suffix == "" && deployment.Prod.IsKnownDmsgServer(cfg.PubKey) {
+			suffix = strings.TrimPrefix(deployment.Prod.WSSDomainSuffix, ".")
+		}
+		if suffix != "" {
 			host := cfg.PubKey.DNSLabel() + "." + suffix
 			mainWSURL = "wss://" + host + "/dmsg"
 			proxyTarget := primaryAdvertised


### PR DESCRIPTION
## What

The dmsg servers' `wss://` `AddressWS` — the TLS-fronted subdomain an HTTPS-served browser wasm-visor seeds dmsg from — was set per-server in each host's local dmsg-server config (`wss_domain_suffix`). That scatters the deployment's domain across host configs.

This moves it into **services-config.json** (the deployment master) as a single `wss_domain_suffix` string. A dmsg server defaults its suffix from the embedded deployment config (`deployment.Prod.WSSDomainSuffix`) when its own config doesn't set one; each server still self-derives `wss://<DNSLabel(PK)>.<suffix>/dmsg` from its own PK, so one string covers the whole fleet — no per-server URL, no domain in any host config.

## Safety

- **Gated on `IsKnownDmsgServer`**: the embedded suffix applies only to a PK that's in the deployment's own `dmsg_servers` list, so a third party running this binary never advertises this domain for a PK with no DNS record.
- An explicit per-server `wss_domain_suffix` still overrides the embedded default.
- Native visors dial `Address` (TCP) and never look at `AddressWS`, so this is browser-only and adds no DNS/TLS dependency for the mesh.

## Single source of truth

The domain now lives in exactly one place — `services-config.json` — plus its generated TinyGo mirror `data_static_js.go` (the `go generate` tool was updated to emit the new field, so the mirror doesn't drift).

## Rollout note

Once deployed, each known fleet dmsg server self-advertises wss on restart, so its `<DNSLabel>.<suffix>` subdomain needs DNS + a TLS front proxy (Caddy) in place — the server logs the exact Caddy line on startup. Until a server's proxy is up, HTTPS browsers simply skip it (http pages and native visors are unaffected, since they use `Address`). Refresh the embedded server snapshot afterward with `make dmsg-servers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)