### PR TITLE
chore(deployment): add dmsg server 02a49bc0 @ 143.42.59.213:30088 to services-config.json

### DIFF
--- a/deployment/data_static_js.go
+++ b/deployment/data_static_js.go
@@ -87,6 +87,10 @@ var prodData = Services{
 			Address   string `json:"address"`
 			AddressWS string `json:"address_ws,omitempty"`
 		}{Address: "139.162.173.101:30083"}},
+		{Static: "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0", Server: struct {
+			Address   string `json:"address"`
+			AddressWS string `json:"address_ws,omitempty"`
+		}{Address: "143.42.59.213:30088"}},
 	},
 	DmsgDiscoveryDmsg:      "dmsg://022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa:80",
 	TransportDiscoveryDmsg: "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80",

--- a/deployment/services-config-clearnet.json
+++ b/deployment/services-config-clearnet.json
@@ -190,6 +190,12 @@
         "server": {
           "address": "139.162.173.101:30083"
         }
+      },
+      {
+        "static": "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0",
+        "server": {
+          "address": "143.42.59.213:30088"
+        }
       }
     ],
     "dmsg_discovery_dmsg": "dmsg://022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa:80",

--- a/deployment/services-config.json
+++ b/deployment/services-config.json
@@ -175,6 +175,12 @@
         "server": {
           "address": "139.162.173.101:30083"
         }
+      },
+      {
+        "static": "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0",
+        "server": {
+          "address": "143.42.59.213:30088"
+        }
       }
     ],
     "dmsg_discovery_dmsg": "dmsg://022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa:80",


### PR DESCRIPTION
The dmsg server `02a49bc0` (running on `143.42.59.213`, type=official) was registered in discovery but **missing from services-config.json** — the only one of the 9 live servers not in the master config. This adds it to `.prod.dmsg_servers` (+ the clearnet mirror + regenerated `data_static_js.go`), so the deployed set matches the config.

Its port was also moved **30081 → 30088** on the host, so it no longer shares port `30081` with `03f57e7c @ 172.235.168.146` (the two servers were both on `:30081` at different IPs, which was confusing). Verified on the host: listening on `:30088`, externally reachable (TCP), and re-registered in discovery at the new address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)