### PR TITLE
fix(visor): CXO telemetry announce reads discovery when discovery_dmsg is empty (fleet-wide bandwidth reporting break)

### DIFF
--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -160,22 +160,32 @@ func announceOnce(ctx context.Context, pub *treestore.Publisher, tpdPK cipher.Pu
 	}
 }
 
-// tpdCXOPeer extracts the TPD's PK from the visor's Transport.DiscoveryDmsg
-// URL ("dmsg://<pk>:<port>"). Returns ok=false when the URL is empty
-// or unparseable; the caller treats that as "no announce target."
+// tpdCXOPeer extracts the TPD's PK from the visor's transport-discovery
+// URL ("dmsg://<pk>:<port>") — the announce target for the CXO telemetry
+// feed. Returns ok=false when no dmsg:// URL is configured.
+//
+// It reads discovery_dmsg first (the historical DMSG-HTTP fallback field,
+// paired with a clearnet discovery), then falls back to discovery itself.
+// The dmsg-only deployment migration (#3348) collapsed the deployment URLs
+// into a single source of truth, so an updated visor now carries the TPD
+// dmsg:// address directly in discovery with discovery_dmsg empty — reading
+// only discovery_dmsg left the announce loop silently disabled fleet-wide,
+// which starves TPD's /metrics of all bandwidth (it is CXO-sourced only).
 func tpdCXOPeer(v *Visor) (cipher.PubKey, bool) {
-	raw := v.conf.Transport.DiscoveryDmsg
-	if raw == "" {
-		return cipher.PubKey{}, false
+	for _, raw := range []string{v.conf.Transport.DiscoveryDmsg, v.conf.Transport.Discovery} {
+		if raw == "" {
+			continue
+		}
+		var u dmsgcurl.URL
+		if err := u.Fill(raw); err != nil {
+			continue
+		}
+		if u.Scheme != "dmsg" {
+			continue
+		}
+		return u.Addr.PK, true
 	}
-	var u dmsgcurl.URL
-	if err := u.Fill(raw); err != nil {
-		return cipher.PubKey{}, false
-	}
-	if u.Scheme != "dmsg" {
-		return cipher.PubKey{}, false
-	}
-	return u.Addr.PK, true
+	return cipher.PubKey{}, false
 }
 
 // buildStatsPublisher constructs the visor's CXO publisher feed for


### PR DESCRIPTION
## Symptom
Reward daily-bandwidth collapsed ~30× over 06-26→06-29 (199.7 → 6.7 MB) and effectively flatlined from 06-30. `rewards bw-collect` sources this **entirely** from TPD `/metrics?bandwidth=true`.

## Root cause
TPD `/metrics` bandwidth is CXO-sourced **only** — `store.UpdateBandwidth` has exactly one caller, the CXO aggregator (`pkg/transport-discovery/cxoaggregator/aggregator.go`). Visors feed it by running a CXO telemetry publisher and periodically **announcing** to TPD so TPD subscribes back to their feed (`pkg/visor/init_stats.go` `runAnnounceLoop`).

The announce target PK came from `tpdCXOPeer`, which read **only** `Transport.DiscoveryDmsg` (JSON `discovery_dmsg`). The dmsg-only deployment migration (#3348, "single source of truth") collapsed the deployment URLs so an updated visor carries the TPD `dmsg://` address directly in `discovery`, leaving `discovery_dmsg` empty. Empty → `tpdCXOPeer` returns `ok=false` → `initStats` logs `"skipping CXO announce loop"` and the visor **never announces, never publishes telemetry**.

As the fleet adopted the dmsg-only config over 06-29→06-30, telemetry went dark visor-by-visor — matching the gradual decline and the 06-30 cliff.

## Evidence (live, via deployment-host pty + TPD `/metrics`)
- TPD CXO aggregator saw only **~5 visors** (feeds stuck at the initial root) over a 3h window.
- Same hub, TPD-reported vs its own bbolt tracker: 06-29 agree (16.8 vs 17.5 MB); 06-30 **16 MB (1 transport) vs 2,563 MB**; 07-01 **16 MB (3 tp) vs 6,987 MB** — 188 live transports, only 1–3 reported.
- Reporting-transport count network-wide: 5019 (06-26) → 189 (06-30).

## Fix
`tpdCXOPeer` falls back to `Transport.Discovery` when it is itself a `dmsg://` URL, so the announce loop finds the TPD PK under either config layout. One-function change; no schema/config change required.

Once merged and rolled out, visors resume announcing and TPD `/metrics` (and reward bandwidth) recovers. Reward runs for 06-30+ are under-counted until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)