### PR TITLE
feat(wasm-hv): run the wasm-visor in a dedicated Web Worker (unfreeze the UI)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,8 @@ wasm-visor: ## Build the browser WASM visor edge with STANDARD Go js/wasm into b
 	cp ./cmd/wasm-visor/index.html ./build/wasm-visor-go/
 	cp ./pkg/wasmhv/browseui/winbox.min.js ./build/wasm-visor-go/
 	cp ./pkg/wasmhv/browseui/browse.js ./build/wasm-visor-go/
+	cp ./pkg/wasmhv/hv-boot.js ./build/wasm-visor-go/
+	cp ./pkg/wasmhv/worker.js ./build/wasm-visor-go/
 	@echo "built ./build/wasm-visor-go (standard Go js/wasm) — serve dev: 'go run cmd/dmsg-wasm/serve.go -dir build/wasm-visor-go'"
 
 embed-wasm-visor: wasm-visor ## Update the COMMITTED embedded wasm-visor blob (pkg/wasmhv/wasmbin/wasm-visor.wasm.gz) — run intentionally, then `git add` + commit it. Deterministic gzip (-n) so re-running on the same wasm yields no diff.

--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -104,6 +104,9 @@ page never asks anyone to type a secret key.`,
 		serveBytes("/wasm-visor.wasm", "application/wasm", wasm)
 		serveBytes("/wasm_exec.js", "text/javascript", wasmhv.WasmExecJS)
 		serveBytes("/hv-boot.js", "text/javascript", wasmhv.HvBootJS)
+		// worker.js hosts the wasm runtime off the main thread; hv-boot.js loads it
+		// by name (new Worker('worker.js')) and proxies skywireVisor over postMessage.
+		serveBytes("/worker.js", "text/javascript", wasmhv.WorkerJS)
 		serveBytes("/browse.js", "text/javascript", wasmhv.BrowseJS)
 		serveBytes("/autoupdate.js", "text/javascript", wasmhv.AutoUpdateJS)
 		// PWA: manifest + icons make the served page installable; sw.js gives it

--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -44,6 +44,16 @@ var AutoUpdateJS []byte
 //go:embed hv-boot.js
 var HvBootJS []byte
 
+// WorkerJS is pkg/wasmhv/worker.js — the dedicated Web Worker that hosts the Go/wasm
+// visor runtime OFF the page's main thread. hv-boot.js spawns it and proxies every
+// globalThis.skywireVisor call to it over postMessage, so the visor's blocking work
+// (dmsg/WS/WT dials, route setup) can't freeze the UI event loop. Served alongside
+// hv-boot.js by `hv serve` (the served model); the single-file generator keeps the
+// in-page path since it can't load a separate worker script.
+//
+//go:embed worker.js
+var WorkerJS []byte
+
 // CtlBridgeJS is pkg/wasmhv/ctl-bridge.js — the browser side of the ctlbridge
 // control surface (pkg/wasmhv/ctlbridge). It connects the tab to /ctl/events
 // over SSE so a shell can drive the in-tab wasm-visor. Injected ONLY when the

--- a/pkg/wasmhv/hv-boot.js
+++ b/pkg/wasmhv/hv-boot.js
@@ -114,11 +114,84 @@
     });
   }
 
-  CFG.ready = (async function () {
+  // --- Web Worker host (preferred) ---
+  //
+  // The Go/wasm runtime runs the visor's occasionally-blocking work (dmsg/WS/WT
+  // dials, route setup, SOCKS handshakes). On the page's MAIN thread that starves
+  // the UI event loop — a slow route setup once froze the whole HV UI. Running the
+  // runtime in a dedicated Web Worker (worker.js) keeps the UI responsive: every
+  // globalThis.skywireVisor call becomes a postMessage round-trip to the worker.
+  // All call sites already treat the API as async (Promises / fire-and-forget), so
+  // the proxy is transparent. Falls back to the in-page runtime if Workers are
+  // unavailable or the worker fails to come up.
+  function bootInWorker(sk) {
+    return new Promise(function (resolve, reject) {
+      if (typeof Worker === 'undefined') { reject(new Error('Web Workers unavailable')); return; }
+      var worker;
+      try { worker = new Worker('worker.js'); } catch (e) { reject(e); return; }
+      var nextId = 1, pending = Object.create(null);
+      var upTimer = setTimeout(function () { reject(new Error('worker did not report ready in time')); }, 30000);
+
+      // Build the main-thread proxy: one forwarding function per worker API method.
+      function makeProxy(methods) {
+        var proxy = {};
+        methods.forEach(function (fn) {
+          proxy[fn] = function () {
+            var callArgs = Array.prototype.slice.call(arguments);
+            return new Promise(function (res, rej) {
+              var id = nextId++;
+              pending[id] = { res: res, rej: rej };
+              try { worker.postMessage({ t: 'call', id: id, fn: fn, args: callArgs }); }
+              catch (e) { delete pending[id]; rej(e); }
+            });
+          };
+        });
+        return proxy;
+      }
+
+      worker.onmessage = function (ev) {
+        var m = ev.data || {};
+        switch (m.t) {
+          case 'log':
+            // Re-emit worker/visor output on the PAGE console so the HV-UI log
+            // window (which captures console.*) shows it, and feed __skylog.
+            try { (m.level === 'error' ? console.error : m.level === 'warn' ? console.warn : console.log)(m.line); } catch (e) {}
+            try { if (typeof self.__skylog === 'function') self.__skylog(m.line); } catch (e) {}
+            break;
+          case 'up':
+            clearTimeout(upTimer);
+            // Install the proxy as globalThis.skywireVisor — browse.js, the Angular
+            // backend, the skychat component, etc. call it exactly as before.
+            self.skywireVisor = makeProxy(m.methods);
+            self.skywireVisor.boot(sk, CFG.seedpk || '', CFG.seedws || '', CFG.disc || '').then(resolve, reject);
+            break;
+          case 'ret':
+            if (pending[m.id]) { pending[m.id].res(m.val); delete pending[m.id]; }
+            break;
+          case 'err':
+            if (pending[m.id]) { pending[m.id].rej(new Error(m.msg)); delete pending[m.id]; }
+            break;
+          case 'fatal':
+            clearTimeout(upTimer);
+            reject(new Error(m.msg));
+            break;
+        }
+      };
+      worker.onerror = function (e) {
+        clearTimeout(upTimer);
+        reject(new Error('worker error: ' + ((e && e.message) || 'load failed')));
+      };
+    });
+  }
+
+  // --- In-page host (fallback) ---
+  //
+  // The original path: load + run the runtime on the main thread. Used when Workers
+  // are unavailable or worker.js can't be loaded (e.g. exotic embeddings). Keeps the
+  // page working, at the cost of the main-thread-freeze risk the worker path avoids.
+  async function bootInPage(sk) {
     await loadScript('wasm_exec.js');
     var go = new Go();
-    // TinyGo's wasm_exec.js omits the gojs getRandomData import the crypto-using
-    // Go runtime needs to seed itself; inject it only when absent.
     if (go.importObject.gojs && !go.importObject.gojs['runtime.getRandomData']) {
       go.importObject.gojs['runtime.getRandomData'] = function (ptr, len) {
         crypto.getRandomValues(new Uint8Array(go._inst.exports.memory.buffer, ptr >>> 0, len >>> 0));
@@ -130,12 +203,23 @@
     while (!self.skywireVisor || !self.skywireVisor.boot) {
       await new Promise(function (r) { setTimeout(r, 10); });
     }
+    return await self.skywireVisor.boot(sk, CFG.seedpk || '', CFG.seedws || '', CFG.disc || '');
+  }
+
+  CFG.ready = (async function () {
     var sk = await resolveSK();
     // One tab per origin may run this (localStorage-shared) identity; wait here
     // until this tab is the leader before booting any dmsg client.
     await becomeLeader('skywire-wasm-visor');
-    var pk = await self.skywireVisor.boot(sk, CFG.seedpk || '', CFG.seedws || '', CFG.disc || '');
-    try { console.log('[hv-boot] wasm-visor booted as ' + pk + ' (edge + hypervisor; /api → in-wasm core)'); } catch (e) {}
+    var pk;
+    try {
+      pk = await bootInWorker(sk);
+      try { console.log('[hv-boot] wasm-visor booted as ' + pk + ' (in Web Worker; UI off the runtime thread; /api → in-wasm core)'); } catch (e) {}
+    } catch (e) {
+      try { console.warn('[hv-boot] worker boot unavailable (' + ((e && e.message) || e) + '); falling back to in-page runtime'); } catch (e2) {}
+      pk = await bootInPage(sk);
+      try { console.log('[hv-boot] wasm-visor booted as ' + pk + ' (in-page runtime; edge + hypervisor; /api → in-wasm core)'); } catch (e2) {}
+    }
     return pk;
   })();
 })();

--- a/pkg/wasmhv/sw.js
+++ b/pkg/wasmhv/sw.js
@@ -26,6 +26,7 @@ const PRECACHE = [
   'icon-512.png',
   'wasm_exec.js',
   'hv-boot.js',
+  'worker.js',
   'browse.js',
 ];
 

--- a/pkg/wasmhv/worker.js
+++ b/pkg/wasmhv/worker.js
@@ -1,0 +1,104 @@
+// worker.js — hosts the Go/wasm skywire-visor in a dedicated Web Worker, OFF the
+// browser's main thread.
+//
+// WHY: the Go/wasm runtime — and the visor's occasionally-blocking work (dmsg/WS/WT
+// dials, route setup, SOCKS handshakes) — runs on whatever thread hosts the runtime.
+// On the page's MAIN thread that starves the UI event loop: during the 2026-07-03
+// demo a slow skysocks route setup froze the whole HV UI (unclickable, even CDP
+// evals hung) until the tab was reloaded. A dedicated worker gives the runtime its
+// own thread, so the UI stays responsive no matter what the visor is doing.
+//
+// hv-boot.js spawns this worker and installs a main-thread `globalThis.skywireVisor`
+// PROXY whose every method is a postMessage round-trip to here (see hv-boot.js).
+// The message protocol (main ⇄ worker):
+//   main → worker:  {t:'call', id, fn, args}          invoke skywireVisor[fn](...args)
+//   worker → main:  {t:'up', methods}                 runtime up; here are the API names
+//                   {t:'ret', id, val}                call id resolved with val
+//                   {t:'err', id, msg}                call id rejected with msg
+//                   {t:'log', level, line}            forward console output to the page
+//                   {t:'fatal', msg}                  runtime failed to start
+//
+// The Go side needs NO changes: syscall/js, fetch, WebSocket and WebTransport all
+// work in a dedicated worker, and self.location is same-origin as the page (so the
+// HTTPS mixed-content gating in bootEdge stays correct). The one browser API NOT
+// exposed to workers is RTCPeerConnection — the STUN self-IP probe and the WebRTC
+// transport degrade gracefully (both are Truthy()-guarded in Go). That is fine:
+// WS/WT are the browser carriers and WebRTC is neither default-on nor the freeze
+// cause. (Reviving WebRTC in worker mode would need a main-thread PeerConnection
+// proxy; deferred.)
+(function () {
+  // Forward everything the Go runtime writes to the console (fmt.Println → stdout →
+  // console.log, and vlog) to the main thread, so the HV-UI log window — which
+  // captures the PAGE console — still shows visor logs even though the runtime now
+  // runs off-thread. Override BEFORE loading wasm_exec.js so its stdout wiring is
+  // captured too. Each override still calls the real console fn (worker devtools).
+  var real = { log: console.log.bind(console), error: console.error.bind(console), warn: console.warn.bind(console) };
+  function forward(level, args) {
+    try {
+      var line = Array.prototype.map.call(args, function (a) {
+        if (typeof a === 'string') { return a; }
+        try { return JSON.stringify(a); } catch (e) { return String(a); }
+      }).join(' ');
+      self.postMessage({ t: 'log', level: level, line: line });
+    } catch (e) { /* postMessage can fail on teardown — ignore */ }
+  }
+  console.log = function () { forward('log', arguments); real.log.apply(null, arguments); };
+  console.error = function () { forward('error', arguments); real.error.apply(null, arguments); };
+  console.warn = function () { forward('warn', arguments); real.warn.apply(null, arguments); };
+
+  importScripts('wasm_exec.js');
+  var go = new Go();
+  // TinyGo's wasm_exec.js omits the gojs getRandomData import the crypto-using Go
+  // runtime needs to seed itself; inject it only when absent (mirrors hv-boot.js).
+  if (go.importObject.gojs && !go.importObject.gojs['runtime.getRandomData']) {
+    go.importObject.gojs['runtime.getRandomData'] = function (ptr, len) {
+      crypto.getRandomValues(new Uint8Array(go._inst.exports.memory.buffer, ptr >>> 0, len >>> 0));
+    };
+  }
+
+  var api = null;        // globalThis.skywireVisor once the runtime installs it
+  var queued = [];       // calls that arrive before the runtime is up
+
+  function dispatch(id, fn, args) {
+    var f = api && api[fn];
+    if (typeof f !== 'function') {
+      self.postMessage({ t: 'err', id: id, msg: 'skywireVisor.' + fn + ' is not a function' });
+      return;
+    }
+    var out;
+    try { out = f.apply(api, args || []); }
+    catch (e) { self.postMessage({ t: 'err', id: id, msg: String((e && e.message) || e) }); return; }
+    // Every visor method is either sync (value/undefined) or returns a Promise;
+    // Promise.resolve normalizes both. undefined → null so the wire stays valid.
+    Promise.resolve(out).then(function (val) {
+      self.postMessage({ t: 'ret', id: id, val: val === undefined ? null : val });
+    }, function (err) {
+      self.postMessage({ t: 'err', id: id, msg: String((err && err.message) || err) });
+    });
+  }
+
+  self.onmessage = function (ev) {
+    var m = ev.data || {};
+    if (m.t !== 'call') { return; }
+    if (!api) { queued.push(m); return; }
+    dispatch(m.id, m.fn, m.args);
+  };
+
+  fetch('wasm-visor.wasm').then(function (r) { return r.arrayBuffer(); }).then(function (buf) {
+    return WebAssembly.instantiate(buf, go.importObject);
+  }).then(function (res) {
+    go.run(res.instance); // installs self.skywireVisor, then parks on select{}
+    (function waitReady() {
+      if (self.skywireVisor && self.skywireVisor.boot) {
+        api = self.skywireVisor;
+        self.postMessage({ t: 'up', methods: Object.keys(api) });
+        for (var i = 0; i < queued.length; i++) { dispatch(queued[i].id, queued[i].fn, queued[i].args); }
+        queued = [];
+      } else {
+        setTimeout(waitReady, 10);
+      }
+    })();
+  }).catch(function (e) {
+    self.postMessage({ t: 'fatal', msg: String((e && e.message) || e) });
+  });
+})();


### PR DESCRIPTION
## What

Move the in-tab **wasm-visor** runtime off the browser **main thread** into a dedicated **Web Worker**.

The Go/wasm runtime — and the visor's occasionally-blocking work (dmsg/WS/WT dials, route setup, SOCKS handshakes) — ran on the page's main thread, so a slow path starved the UI event loop. During the 2026-07-03 demo a slow skysocks route setup **froze the whole HV UI** (unclickable, even CDP evals hung) until the tab was reloaded. This is the root-cause fix flagged as a follow-up in #3362.

## How

- **`worker.js` (new)** hosts the runtime: `importScripts('wasm_exec.js')`, instantiate `wasm-visor.wasm`, `go.run` → installs `self.skywireVisor`.
- **`hv-boot.js`** spawns the worker and installs a main-thread `globalThis.skywireVisor` **proxy** whose every method is a `postMessage` round-trip to the worker (correlated by id). All call sites (Angular `SkywireHttpBackend`, `browse.js`, the skychat component) already treat the API as async (Promises / fire-and-forget), so the proxy is transparent.
- Worker console output (all Go stdout + `vlog`) is **forwarded to the page console** so the HV-UI log window still shows visor logs.
- **Graceful fallback** to the in-page runtime if Web Workers are unavailable or `worker.js` can't load (keeps the single-file `hv gen` output and exotic embeddings working).
- Web Locks leader election + `localStorage` SK persistence stay on the main thread (workers have neither); the resolved key is passed into the worker via the `boot()` call.

## Go side is unchanged

`syscall/js`, `fetch`, `WebSocket` and `WebTransport` all work in a dedicated worker, and `self.location` is same-origin as the page (so the HTTPS mixed-content gating in `bootEdge` stays correct). The one worker-absent API — `RTCPeerConnection` — is already `Truthy()`-guarded in Go (STUN self-IP + the WebRTC transport degrade gracefully). That's fine: WS/WT are the browser carriers and WebRTC is neither default-on nor the freeze cause. (Reviving WebRTC in worker mode would need a main-thread PeerConnection proxy; deferred.)

## Scope

The **served model** (`hv serve` / standalone-live / dev harness, all via `hv-boot.js`). The single-file `hv gen` output keeps the in-page path (it can't load a separate worker script). **JS-only change — the committed wasm blob is unchanged.**

## Validation

Headless via `hvinspect` over a local `hv serve`:
- Boots **"in Web Worker; UI off the runtime thread"** (not the in-page fallback).
- dmsg connects + WS transports dial **from the worker** (`swsr Dialing WS … ws://…`) → `fetch`/`WebSocket` confirmed in-worker.
- The dashboard **renders its own PK** via the `hvApi` proxy → worker → in-wasm core → back.
- Visor logs reach the **page console** (log forwarding works).
- No `DataCloneError` / "not a function" / uncaught errors.