### PR TITLE
fix(wasm-hv): reserve the desktop taskbar strip so it doesn't cover the PK line

### DIFF
--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -1269,6 +1269,19 @@
         menu.style.bottom = BARH + "px"; menu.style.top = "auto";
         barTop = 0; barBottom = BARH;
       }
+      // Reserve the bar's strip on the HV-UI underneath so page content isn't
+      // painted over by the always-on-top taskbar. Without this the fixed bar
+      // (z 2147483646) covers the top ~BARH px of the Angular page — e.g. the
+      // node-info page's first line, the visor public key. Padding the body pushes
+      // the normal-flow content clear; the WinBox windows are unaffected (they're
+      // fixed-positioned and bounded by barTop/barBottom above).
+      try {
+        var pg = doc.body;
+        if (pg) {
+          pg.style.paddingTop = (dock === "top") ? BARH + "px" : "";
+          pg.style.paddingBottom = (dock === "bottom") ? BARH + "px" : "";
+        }
+      } catch (e) { /* body not ready — applyDock re-runs on dock toggle */ }
     }
     function addApp(label, fn) {
       var b = doc.createElement("button");


### PR DESCRIPTION
The always-on-top wasm-visor desktop taskbar (`#skywire-skynet-taskbar`, `position:fixed`, `z-index 2147483646`) painted over the top ~36px of the underlying HV-UI — most visibly the node-info page's first line, the **visor public key**. `applyDock()` set the WinBox window bounds (`barTop`/`barBottom`) but never offset the normal-flow HV-UI content.

Fix: pad the body by the bar height on the docked edge, so the page clears the bar (WinBox windows are fixed-positioned and bounded by `barTop`/`barBottom`, so they're unaffected).

**Validated live** (CDP): the `/info` PK line moved from y=20 (top 16px under the bar) to y=56 — fully below the 0–36 bar; `PK_still_under_bar=false`. browse.js only (no build-ui/blob).