### PR TITLE
feat(transport): declarative CXO transport CRUD — publish the list, TPD reconciles

### DIFF
--- a/pkg/services/tpd/tpd.go
+++ b/pkg/services/tpd/tpd.go
@@ -331,6 +331,10 @@ func (s *aggregatorSink) RegisterTransportFromCXO(ctx context.Context, entry *tr
 	return s.api.RegisterTransportFromCXO(ctx, entry, reporter, version)
 }
 
+func (s *aggregatorSink) ReconcileTransportsFromCXO(ctx context.Context, entries []*transport.Entry, reporter cipher.PubKey, version string) error {
+	return s.api.ReconcileTransportsFromCXO(ctx, entries, reporter, version)
+}
+
 func (s *aggregatorSink) DeregisterTransportFromCXO(ctx context.Context, id uuid.UUID, reporter cipher.PubKey) error {
 	return s.api.DeregisterTransportFromCXO(ctx, id, reporter)
 }

--- a/pkg/transport-discovery/api/cxo_register.go
+++ b/pkg/transport-discovery/api/cxo_register.go
@@ -96,3 +96,64 @@ func (api *API) DeregisterTransportFromCXO(ctx context.Context, id uuid.UUID, re
 	api.mirrorEdges(ctx, touchedEdges)
 	return nil
 }
+
+// ReconcileTransportsFromCXO applies a visor's full transport list published as a
+// single snapshot leaf (transports/list). It is the declarative replacement for the
+// per-transport entry (register) + tombstone (deregister) leaves: register/refresh
+// every entry the reporter is an edge of, and deregister any of the reporter's
+// existing transports that are ABSENT from the list (absence = deletion). Idempotent
+// and self-healing — a dropped update is corrected by the next snapshot.
+func (api *API) ReconcileTransportsFromCXO(ctx context.Context, entries []*transport.Entry, reporter cipher.PubKey, version string) error {
+	// Accept only entries the reporter is actually an edge of (auth parity with the
+	// per-entry path); build the authoritative keep-set.
+	keep := make(map[uuid.UUID]struct{}, len(entries))
+	signed := make([]*transport.SignedEntry, 0, len(entries))
+	touchedEdges := map[cipher.PubKey]struct{}{}
+	for _, e := range entries {
+		if e == nil || e.EdgeIndex(reporter) < 0 {
+			continue
+		}
+		keep[e.ID] = struct{}{}
+		signed = append(signed, &transport.SignedEntry{Entry: e, Version: version})
+		touchedEdges[e.Edges[0]] = struct{}{}
+		touchedEdges[e.Edges[1]] = struct{}{}
+	}
+
+	// Register/refresh everything currently present.
+	if len(signed) > 0 {
+		if err := api.store.RegisterTransportsBatch(ctx, reporter, signed); err != nil {
+			return fmt.Errorf("register batch: %w", err)
+		}
+		for _, se := range signed {
+			if err := api.store.RecordTransportHeartbeat(ctx, se.Entry.ID, string(se.Entry.Type), time.Time{}); err != nil {
+				_ = err //nolint:errcheck // uptime is auxiliary; store logs
+			}
+		}
+	}
+
+	// Deregister any of the reporter's existing transports absent from the snapshot.
+	// A transport the reporter no longer lists is a deregister signal for that edge —
+	// exactly what a tombstone was in the delta model.
+	existing, err := api.store.GetTransportsByEdgeNoLatency(ctx, reporter)
+	if err != nil {
+		return fmt.Errorf("get existing: %w", err)
+	}
+	for _, e := range existing {
+		if _, ok := keep[e.ID]; ok {
+			continue
+		}
+		if err := api.store.DeregisterTransport(ctx, e.ID); err != nil {
+			// Best-effort — a failed absent-deregister self-corrects on the next
+			// snapshot; the aggregator logs if the whole reconcile returns an error.
+			continue
+		}
+		touchedEdges[e.Edges[0]] = struct{}{}
+		touchedEdges[e.Edges[1]] = struct{}{}
+	}
+
+	api.mirrorEdges(ctx, touchedEdges)
+	if err := api.store.RecordHeartbeat(ctx, reporter, version); err != nil {
+		_ = err //nolint:errcheck // visor-level heartbeat is auxiliary
+	}
+	return nil
+}

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -86,6 +86,14 @@ type Sink interface {
 	// entry; an unknown ID is treated as a no-op (idempotent) so a
 	// tombstone that arrives after a TPD-side eviction doesn't error.
 	DeregisterTransportFromCXO(ctx context.Context, id uuid.UUID, reporter cipher.PubKey) error
+	// ReconcileTransportsFromCXO applies the visor's full transport list
+	// published as a single snapshot leaf at transports/list: it
+	// registers every entry the reporter is an edge of AND deregisters
+	// any of the reporter's existing transports that are ABSENT from the
+	// list (absence = deletion). This is the declarative replacement for
+	// the per-transport entry/tombstone leaves — self-healing, since a
+	// missed update is corrected by the next snapshot.
+	ReconcileTransportsFromCXO(ctx context.Context, entries []*transport.Entry, reporter cipher.PubKey, version string) error
 }
 
 // BandwidthSink is retained as an alias for callers that only need the
@@ -118,6 +126,15 @@ type liveSnapshot struct {
 type transportEntryLeaf struct {
 	Version string           `json:"version,omitempty"`
 	Entry   *transport.Entry `json:"entry"`
+}
+
+// transportListLeaf is the wire shape for the transports/list snapshot
+// leaf: the visor's full current transport set plus its build version.
+// Re-declared here (one-way dependency); the visor publisher in
+// pkg/transport/manager.go (publishTPDList) publishes the same JSON.
+type transportListLeaf struct {
+	Version string             `json:"version,omitempty"`
+	Entries []*transport.Entry `json:"entries"`
 }
 
 // tombstoneLeaf is the wire shape for transports/<uuid>/tombstone
@@ -407,6 +424,21 @@ func (a *Aggregator) walkAndDispatch(pack registry.Pack, n *treestore.TreeNode, 
 // Tier and service bitmaps still flow through the CXO cache but
 // aren't yet projected into TPD's redis uptime tables.
 func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubKey) {
+	// transports/list — the full-set snapshot (declarative CRUD). Reconcile the
+	// reporter's transport set against it (register new + deregister absent).
+	if path == "transports/list" {
+		var list transportListLeaf
+		if err := json.Unmarshal(leaf, &list); err != nil {
+			a.log.WithError(err).WithField("path", path).Debug("CXO aggregator: transport list leaf decode failed")
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := a.sink.ReconcileTransportsFromCXO(ctx, list.Entries, reporter, list.Version); err != nil {
+			a.log.WithError(err).WithField("reporter", reporter).Debug("CXO aggregator: ReconcileTransportsFromCXO failed")
+		}
+		return
+	}
 	if tpID, date, ok := parseTransportTimelinePath(path); ok {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/pkg/transport-discovery/cxoaggregator/aggregator_test.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator_test.go
@@ -136,6 +136,7 @@ type recordingSink struct {
 	}
 	registers   []recordedRegister
 	deregisters []recordedDeregister
+	reconciles  []recordedReconcile
 }
 
 func (s *recordingSink) UpdateBandwidth(_ context.Context, _ string, _ cipher.PubKey, _, _ uint64) error {
@@ -185,6 +186,13 @@ func (s *recordingSink) DeregisterTransportFromCXO(_ context.Context, id uuid.UU
 	return nil
 }
 
+func (s *recordingSink) ReconcileTransportsFromCXO(_ context.Context, entries []*transport.Entry, reporter cipher.PubKey, version string) error {
+	s.mu.Lock()
+	s.reconciles = append(s.reconciles, recordedReconcile{entries: entries, reporter: reporter, version: version})
+	s.mu.Unlock()
+	return nil
+}
+
 type recordedRegister struct {
 	entry    *transport.Entry
 	reporter cipher.PubKey
@@ -194,6 +202,12 @@ type recordedRegister struct {
 type recordedDeregister struct {
 	id       uuid.UUID
 	reporter cipher.PubKey
+}
+
+type recordedReconcile struct {
+	entries  []*transport.Entry
+	reporter cipher.PubKey
+	version  string
 }
 
 func TestDispatchLeafLatencyGate(t *testing.T) {
@@ -432,4 +446,32 @@ func TestDispatchLeafEntryAndTombstone(t *testing.T) {
 			t.Errorf("expected drop on bad json, got %d registers", len(sink.registers))
 		}
 	})
+}
+
+func TestDispatchLeafTransportListSnapshot(t *testing.T) {
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+	id1, id2 := uuid.New(), uuid.New()
+
+	sink := &recordingSink{}
+	a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
+	entries := []*transport.Entry{
+		{ID: id1, Edges: [2]cipher.PubKey{pkA, pkB}, Type: "stcpr"},
+		{ID: id2, Edges: [2]cipher.PubKey{pkA, pkB}, Type: "sudph"},
+	}
+	body, err := json.Marshal(transportListLeaf{Version: "v1.2.3", Entries: entries})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	a.dispatchLeaf("transports/list", body, pkA)
+	if len(sink.reconciles) != 1 {
+		t.Fatalf("expected 1 reconcile call, got %d", len(sink.reconciles))
+	}
+	got := sink.reconciles[0]
+	if len(got.entries) != 2 {
+		t.Errorf("reconcile entries = %d, want 2", len(got.entries))
+	}
+	if got.reporter != pkA || got.version != "v1.2.3" {
+		t.Errorf("reconcile reporter/version mismatch: %v %q", got.reporter, got.version)
+	}
 }

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -421,8 +421,11 @@ func (tm *Manager) flushDeletionQueue() {
 	// for no benefit. HTTP delete stays as the fallback ONLY when there is no CXO
 	// publisher (a TPD/visor pairing without CXO).
 	if tm.tpdLeafPublisher() != nil {
-		tm.Logger.Debugf("Deregistering %d transports via CXO tombstones", len(ids))
-		tm.publishTPDTombstones(ids)
+		// Snapshot model: re-publish our full transport list; currentBareEntries
+		// already excludes the just-closed ids, so TPD reconciles them away
+		// (absence = deletion). No tombstone leaf, no HTTP delete.
+		tm.Logger.Debugf("Deregistering %d transports via CXO transport-list snapshot", len(ids))
+		tm.publishTPDList(tm.currentBareEntries())
 		return
 	}
 
@@ -472,8 +475,10 @@ func (tm *Manager) reRegisterTransports(ctx context.Context) {
 	// reconciles, absence = deletion) — that removes the separate register/deregister
 	// paths and is self-healing. Tracked as a follow-up.
 	if tm.tpdLeafPublisher() != nil {
-		tm.Logger.Debugf("Re-registering %d transports via CXO entry leaves", len(bareEntries))
-		tm.publishTPDEntries(bareEntries)
+		// Snapshot model: publish the full transport list as one leaf; TPD reconciles
+		// (register new + deregister absent). Replaces per-transport entry/tombstone.
+		tm.Logger.Debugf("Publishing %d transports to TPD via CXO transport-list snapshot", len(bareEntries))
+		tm.publishTPDList(bareEntries)
 		return
 	}
 
@@ -525,64 +530,53 @@ func (tm *Manager) tpdLeafPublisher() TPDLeafPublisher {
 	return tm.tpdLeafPub
 }
 
-// publishTPDEntries publishes one transports/<uuid>/entry leaf per
-// entry. Best-effort: failures are logged at debug and the next
-// reRegister tick retries.
-func (tm *Manager) publishTPDEntries(entries []*Entry) {
-	pub := tm.tpdLeafPublisher()
-	if pub == nil || len(entries) == 0 {
-		return
-	}
-	type entryLeaf struct {
-		Version string `json:"version,omitempty"`
-		Entry   *Entry `json:"entry"`
-	}
-	for _, e := range entries {
-		if e == nil {
+// currentBareEntries returns this visor's live, non-self-loop transport entries —
+// the authoritative set it publishes to TPD. Closed transports are excluded even if
+// the manager's GC ticker hasn't removed them from tm.tps yet, so a just-torn-down
+// transport is absent from the snapshot immediately.
+func (tm *Manager) currentBareEntries() []*Entry {
+	tm.mx.RLock()
+	defer tm.mx.RUnlock()
+	out := make([]*Entry, 0, len(tm.tps))
+	for _, tp := range tm.tps {
+		if tp.IsClosed() {
 			continue
 		}
-		body, err := json.Marshal(entryLeaf{Version: tm.Conf.Version, Entry: e})
-		if err != nil {
-			tm.Logger.WithError(err).WithField("transport", e.ID).
-				Debug("Failed to marshal transport entry leaf")
+		// Self-loop transports (both edges the same PK) are diagnostic-only and must
+		// never reach TPD/DHT — they'd mislead other visors' pathfinders.
+		if tp.Entry.Edges[0] == tp.Entry.Edges[1] {
 			continue
 		}
-		path := fmt.Sprintf("transports/%s/entry", e.ID.String())
-		if err := pub.Put(path, body); err != nil {
-			tm.Logger.WithError(err).WithField("path", path).
-				Debug("Failed to publish transport entry leaf to CXO")
-		}
+		out = append(out, &tp.Entry)
 	}
+	return out
 }
 
-// publishTPDTombstones publishes a transports/<uuid>/tombstone leaf
-// per id, and removes the corresponding /entry leaf. Best-effort.
-func (tm *Manager) publishTPDTombstones(ids []uuid.UUID) {
+// publishTPDList publishes this visor's full transport list as a single CXO snapshot
+// leaf (transports/list). TPD's cxoaggregator RECONCILES against it — registers every
+// entry and deregisters any of this visor's transports absent from the list — so a
+// removed transport needs no explicit tombstone (absence = deletion) and a missed
+// update self-heals on the next publish. This is the declarative unification of the
+// former per-transport entry (register) + tombstone (deregister) delta leaves; only
+// telemetry (transports/<id>/current, timeline) stays per-transport-addressed.
+func (tm *Manager) publishTPDList(entries []*Entry) {
 	pub := tm.tpdLeafPublisher()
-	if pub == nil || len(ids) == 0 {
+	if pub == nil {
 		return
+	}
+	if entries == nil {
+		entries = []*Entry{} // publish an explicit empty list (last transport gone)
 	}
 	body, err := json.Marshal(struct {
-		DeletedAt time.Time `json:"deleted_at"`
-	}{DeletedAt: time.Now().UTC()})
+		Version string   `json:"version,omitempty"`
+		Entries []*Entry `json:"entries"`
+	}{Version: tm.Conf.Version, Entries: entries})
 	if err != nil {
-		tm.Logger.WithError(err).Debug("Failed to marshal tombstone body")
+		tm.Logger.WithError(err).Debug("Failed to marshal transport list leaf")
 		return
 	}
-	for _, id := range ids {
-		// Delete the entry leaf so a future tree walk doesn't replay
-		// the now-stale registration; the tombstone leaf is the
-		// positive deletion signal that drives TPD's aggregator.
-		entryPath := fmt.Sprintf("transports/%s/entry", id.String())
-		if err := pub.Delete(entryPath); err != nil {
-			tm.Logger.WithError(err).WithField("path", entryPath).
-				Debug("Failed to delete transport entry leaf from CXO")
-		}
-		tombPath := fmt.Sprintf("transports/%s/tombstone", id.String())
-		if err := pub.Put(tombPath, body); err != nil {
-			tm.Logger.WithError(err).WithField("path", tombPath).
-				Debug("Failed to publish transport tombstone to CXO")
-		}
+	if err := pub.Put("transports/list", body); err != nil {
+		tm.Logger.WithError(err).Debug("Failed to publish transport list leaf to CXO")
 	}
 }
 


### PR DESCRIPTION
Replaces the per-transport **delta** model ( register +  deregister leaves, #3375/#3376) with a single **declarative snapshot**, per the operator's design: the visor publishes its full transport list and TPD reconciles — **absence = deletion**.

**Why it's better:** one path instead of two, and *self-healing* — a dropped update or an unqueued delete is corrected by the next snapshot, whereas the delta model relied on every removal reliably emitting a tombstone. It also matches how the HTTP path already worked ( publishes the full list and TPD reconciles).

**Visor** ():
- `publishTPDList(entries)` publishes one `transports/list` leaf (`{version, entries}`).
- `currentBareEntries()` = live non-self-loop entries (excludes just-closed ones, so deletions reflect immediately).
- `reRegisterTransports` + `flushDeletionQueue` publish the snapshot when the CXO publisher is wired (deletions = re-publish the shrunken list — no tombstone).
- Removed the now-dead `publishTPDEntries` / `publishTPDTombstones`.

**TPD** ():
- `cxoaggregator`: `transportListLeaf` + dispatch of `transports/list` → new `Sink.ReconcileTransportsFromCXO`.
- `api.ReconcileTransportsFromCXO`: register/refresh every entry the reporter edges + deregister any of the reporter's existing transports absent from the list + mirror edges/heartbeat.
- Adapter + test stub wired; dispatch test added.

The per-transport `Register/DeregisterTransportFromCXO` handlers stay for backward-compat with visors still publishing delta leaves. Build + lint + tests green.