### PR TITLE
fix(transport): deregister-all via empty CXO snapshot on Close (no shutdown 429s)

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -1361,15 +1361,26 @@ func (tm *Manager) Close() {
 		}
 	}
 
-	// Batch deregister from TPD (with fallback to sequential)
+	// Deregister all transports from TPD on shutdown. CXO-authoritative: publish an
+	// empty transport-list snapshot so TPD reconciles every one of our transports
+	// away (absence = deletion) — no HTTP DeleteTransports, which an old TPD
+	// rate-limits (429) on shutdown. tpdLeafPublisher() uses its own mutex, so this
+	// is safe under tm.mx. The publish is best-effort at process exit; anything that
+	// doesn't propagate is aged out by TPD's heartbeat timeout (same as a crash).
+	// Falls back to the HTTP batch delete only when there is no CXO publisher.
 	if len(tpIDs) > 0 {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		deleted, err := tm.Conf.DiscoveryClient.DeleteTransports(ctx, tpIDs)
-		cancel()
-		if err != nil {
-			tm.Logger.WithError(err).Warnf("Batch deregister completed with error: %d/%d deleted", deleted, len(tpIDs))
+		if tm.tpdLeafPublisher() != nil {
+			tm.publishTPDList(nil)
+			tm.Logger.Debugf("Deregistered %d transports via empty CXO transport-list snapshot on close", len(tpIDs))
 		} else {
-			tm.Logger.Debugf("Batch deregistered %d/%d transports from TPD", deleted, len(tpIDs))
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			deleted, err := tm.Conf.DiscoveryClient.DeleteTransports(ctx, tpIDs)
+			cancel()
+			if err != nil {
+				tm.Logger.WithError(err).Warnf("Batch deregister completed with error: %d/%d deleted", deleted, len(tpIDs))
+			} else {
+				tm.Logger.Debugf("Batch deregistered %d/%d transports from TPD", deleted, len(tpIDs))
+			}
 		}
 	}
 


### PR DESCRIPTION
Manager.Close() batch-deregistered every transport from TPD over HTTP DeleteTransports on shutdown. Against a TPD without the batch-delete endpoint that degrades to sequential per-transport deletes and trips the 429 rate limiter — the shutdown 429 storm seen when rolling a visor with ~90 transports (the last unflipped HTTP-delete caller after #3374-#3377).

Flip it to the CXO-authoritative path used everywhere else: when a CXO transport-list publisher is wired, publish an empty snapshot so TPD reconciles all of our transports away (absence = deletion). Best-effort at process exit; stragglers age out on TPD heartbeat timeout, same as a crash. HTTP batch delete stays only as the no-CXO fallback.

Completes the CXO-only transport CRUD story: register, deregister, re-register, and now shutdown-deregister all go through the transport-list snapshot when CXO is wired — no HTTP transport writes to rate-limit.