### PR TITLE
chore(lint): use latest golangci-lint v2.12.2 in CI and install targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.4
+          version: v2.12.2
 
       - name: Install Dependencies
         shell: bash
@@ -66,7 +66,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.4
+          version: v2.12.2
 
       - name: Checking Format and Testing
         run: |
@@ -89,7 +89,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.11.4
+          version: v2.12.2
 
       - name: Install Requirements
         shell: pwsh

--- a/Makefile
+++ b/Makefile
@@ -327,12 +327,12 @@ test-windows: ## Run tests on windows
 	${OPTS} go test ${TEST_OPTS} ./internal/... ./pkg/... ./cmd/skywire-cli... ./cmd/skywire-visor... ./cmd/skywire... ./cmd/apps...
 
 install-linters: ## Install linters
-	- VERSION=1.64.5 ./ci_scripts/install-golangci-lint.sh
+	${OPTS} go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	GOPRIVATE=github.com/skycoin/* go get -u
 	${OPTS} go install golang.org/x/tools/cmd/goimports@latest github.com/incu6us/goimports-reviser/v2@latest github.com/FiloSottile/vendorcheck@latest
 
 install-linters-windows: ## Install linters
-	${OPTS} go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest golang.org/x/tools/cmd/goimports@latest
+	${OPTS} go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest golang.org/x/tools/cmd/goimports@latest
 
 tidy: ## Tidies and vendors dependencies.
 	${OPTS} go mod tidy -v


### PR DESCRIPTION
CI pinned `golangci-lint-action` to **v2.11.4**, one patch behind the current release (**v2.12.2**, which is what runs locally). Bump the pin to v2.12.2 in all three `test.yml` jobs so CI and local lint with the same, latest version.

Also modernizes the Makefile install helpers, which lagged on golangci-lint v1:
- `install-linters` ran `install-golangci-lint.sh` pinned to **v1.64.5**
- `install-linters-windows` used the old (v1) module path

Both now `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`, matching the primary `check` target — so `make install-linters` no longer downgrades a dev to v1.