### PR TITLE
chore(format): normalize import grouping via goimports-reviser

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root_test.go
+++ b/cmd/skywire-cli/commands/rpc/root_test.go
@@ -1,7 +1,9 @@
 // Package clirpc root_test.go
 package clirpc
 
-import "testing"
+import (
+	"testing"
+)
 
 // TestIsUnderBase locks in the boundary behavior that distinguishes
 // base+suffix from sub-paths beneath it. The pre-fix prefix match

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -58,10 +58,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/skycoin/skywire/deployment"
-	"github.com/skycoin/skywire/pkg/app/appdisc"
 
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appcommon"
+	"github.com/skycoin/skywire/pkg/app/appdisc"
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/app/appserver"

--- a/pkg/app/appserver/proc_external_native.go
+++ b/pkg/app/appserver/proc_external_native.go
@@ -20,13 +20,12 @@ import (
 	"os/exec"
 	"runtime"
 
+	ipc "github.com/james-barrow/golang-ipc"
 	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skywire/pkg/app/appcommon"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
-
-	ipc "github.com/james-barrow/golang-ipc"
 )
 
 // newExternalCmd builds the *exec.Cmd for an external-mode app (nil for

--- a/pkg/app/appserver/proc_ingress_listen_native.go
+++ b/pkg/app/appserver/proc_ingress_listen_native.go
@@ -3,7 +3,9 @@
 // Package appserver pkg/app/appserver/proc_ingress_listen_native.go
 package appserver
 
-import "net"
+import (
+	"net"
+)
 
 // listenIngress opens the proc manager's app-ingress TCP listener. External
 // (os/exec) apps dial it to reach the visor; in-process apps use net.Pipe

--- a/pkg/app/appserver/proc_ingress_listen_tinygo.go
+++ b/pkg/app/appserver/proc_ingress_listen_tinygo.go
@@ -3,7 +3,9 @@
 // Package appserver pkg/app/appserver/proc_ingress_listen_tinygo.go
 package appserver
 
-import "net"
+import (
+	"net"
+)
 
 // listenIngress returns no listener on the TinyGo js/wasm target: a browser
 // cannot net.Listen("tcp"), and in-process apps (RunModeInternal — the only

--- a/pkg/cxo/skyobject/config_test.go
+++ b/pkg/cxo/skyobject/config_test.go
@@ -1,6 +1,8 @@
 package skyobject
 
-import "testing"
+import (
+	"testing"
+)
 
 // TestNewConfigPopulatesMaxFillingParallel guards against the
 // regression where NewConfig() left MaxFillingParallel at its int

--- a/pkg/cxo/treestore/leak_subscriber_repro_test.go
+++ b/pkg/cxo/treestore/leak_subscriber_repro_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	skycipher "github.com/skycoin/skycoin/src/cipher"
+	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 )

--- a/pkg/dmsg/disc/interface_tinygo.go
+++ b/pkg/dmsg/disc/interface_tinygo.go
@@ -12,7 +12,9 @@
 // See docs/design/tinygo-dmsg-client.md.
 package disc
 
-import stdjson "encoding/json"
+import (
+	stdjson "encoding/json"
+)
 
 var json = jsonCodec{}
 

--- a/pkg/dmsg/dmsg/quic_iface.go
+++ b/pkg/dmsg/dmsg/quic_iface.go
@@ -1,7 +1,9 @@
 // Package dmsg pkg/dmsg/quic_iface.go
 package dmsg
 
-import "context"
+import (
+	"context"
+)
 
 // quicConn / quicStream abstract the quic-go connection + stream that the
 // session core uses, so the concrete *quic.Conn / *quic.Stream — and all of

--- a/pkg/dmsg/dmsg/tcpnodelay_native.go
+++ b/pkg/dmsg/dmsg/tcpnodelay_native.go
@@ -3,7 +3,9 @@
 // Package dmsg pkg/dmsg/tcpnodelay_native.go
 package dmsg
 
-import "net"
+import (
+	"net"
+)
 
 // setTCPNoDelay disables Nagle's algorithm on a TCP conn (TCP_NODELAY). dmsg
 // multiplexes many small logical streams (pty keystrokes, dmsg-HTTP, RPC) over

--- a/pkg/dmsg/dmsg/tcpnodelay_tinygo.go
+++ b/pkg/dmsg/dmsg/tcpnodelay_tinygo.go
@@ -3,7 +3,9 @@
 // Package dmsg pkg/dmsg/tcpnodelay_tinygo.go
 package dmsg
 
-import "net"
+import (
+	"net"
+)
 
 // setTCPNoDelay is a no-op under TinyGo: net.TCPConn has no SetNoDelay method.
 // See tcpnodelay_native.go.

--- a/pkg/dmsg/dmsg/upgrade_test.go
+++ b/pkg/dmsg/dmsg/upgrade_test.go
@@ -1,6 +1,8 @@
 package dmsg
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestPrefersWTOverWS(t *testing.T) {
 	cases := []struct {

--- a/pkg/dmsg/dmsgclient/jslog_js.go
+++ b/pkg/dmsg/dmsgclient/jslog_js.go
@@ -2,7 +2,9 @@
 
 package dmsgclient
 
-import "syscall/js"
+import (
+	"syscall/js"
+)
 
 // jslog routes a debug line to a JS hook (window.__skylog) when present, so the
 // browser harness / control bridge can surface dmsg-disc-over-dmsg internals.

--- a/pkg/dmsg/noise/pqhybrid.go
+++ b/pkg/dmsg/noise/pqhybrid.go
@@ -14,10 +14,11 @@
 package noise
 
 import (
-	"crypto/hkdf"
-	"crypto/mlkem"
 	"crypto/sha256"
 	"fmt"
+
+	"crypto/hkdf"
+	"crypto/mlkem"
 )
 
 const (

--- a/pkg/gobrpc/gobrpc_native.go
+++ b/pkg/gobrpc/gobrpc_native.go
@@ -19,7 +19,9 @@
 // ServeConn, the Call value, and ErrShutdown.
 package gobrpc
 
-import "net/rpc"
+import (
+	"net/rpc"
+)
 
 // Client is net/rpc.Client.
 type Client = rpc.Client

--- a/pkg/router/datagram_route_group_test.go
+++ b/pkg/router/datagram_route_group_test.go
@@ -14,11 +14,11 @@ import (
 	"net"
 	"sync/atomic"
 	"testing"
-	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"testing/synctest"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/routing"

--- a/pkg/transport/network/tcp_tune_native.go
+++ b/pkg/transport/network/tcp_tune_native.go
@@ -2,7 +2,9 @@
 
 package network
 
-import "net"
+import (
+	"net"
+)
 
 // tuneTCPConn applies TCP_NODELAY + keepalive tuning to a raw TCP transport
 // connection (no-op for non-TCP conns). Split behind a build tag: TinyGo's

--- a/pkg/transport/network/tcp_tune_tinygo.go
+++ b/pkg/transport/network/tcp_tune_tinygo.go
@@ -2,7 +2,9 @@
 
 package network
 
-import "net"
+import (
+	"net"
+)
 
 // tuneTCPConn is a no-op under TinyGo (no raw TCP carriers; net.TCPConn lacks the
 // tuning methods). See tcp_tune_native.go.

--- a/pkg/transport/types/types_valid_test.go
+++ b/pkg/transport/types/types_valid_test.go
@@ -1,6 +1,8 @@
 package tptypes
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestValidAndKnown(t *testing.T) {
 	for _, ty := range Known() {

--- a/pkg/visor/visorconfig/values_darwin.go
+++ b/pkg/visor/visorconfig/values_darwin.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jaypipes/ghw"
-	"github.com/skycoin/skywire/third_party/zcalusic/sysinfo"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/third_party/zcalusic/sysinfo"
 )
 
 // UserConfig contains installation paths for running skywire as the user

--- a/pkg/visor/visorconfig/values_linux.go
+++ b/pkg/visor/visorconfig/values_linux.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jaypipes/ghw"
-	"github.com/skycoin/skywire/third_party/zcalusic/sysinfo"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/third_party/zcalusic/sysinfo"
 )
 
 // UserConfig contains installation paths for running skywire as the user

--- a/pkg/wasmhv/browseui/embed.go
+++ b/pkg/wasmhv/browseui/embed.go
@@ -5,7 +5,9 @@
 // (pkg/wasmhv's gob-mirror test imports pkg/visor).
 package browseui
 
-import _ "embed"
+import (
+	_ "embed"
+)
 
 // winBoxJS is WinBox.js (vendored, Apache-2.0, dependency-free, CSS inlined):
 // the window manager that provides draggable / resizable / minimizable /

--- a/pkg/wasmhv/wasmbin/embed_test.go
+++ b/pkg/wasmhv/wasmbin/embed_test.go
@@ -1,6 +1,8 @@
 package wasmbin
 
-import "testing"
+import (
+	"testing"
+)
 
 // TestEmbeddedGet confirms the committed wasm-visor.wasm.gz decompresses to a
 // valid wasm binary (so a default build — incl. `go install` — really carries a

--- a/third_party/zcalusic/sysinfo/chassis.go
+++ b/third_party/zcalusic/sysinfo/chassis.go
@@ -4,7 +4,9 @@
 
 package sysinfo
 
-import "strconv"
+import (
+	"strconv"
+)
 
 // Chassis information.
 type Chassis struct {

--- a/third_party/zcalusic/sysinfo/cpu_other.go
+++ b/third_party/zcalusic/sysinfo/cpu_other.go
@@ -7,7 +7,9 @@
 
 package sysinfo
 
-import "runtime"
+import (
+	"runtime"
+)
 
 // getCPUInfo is a no-op on non-Linux targets that import this package
 // (only for the SysInfo / CPU type shape used in survey marshaling).

--- a/third_party/zcalusic/sysinfo/meta.go
+++ b/third_party/zcalusic/sysinfo/meta.go
@@ -4,7 +4,9 @@
 
 package sysinfo
 
-import "time"
+import (
+	"time"
+)
 
 // Meta information.
 type Meta struct {

--- a/third_party/zcalusic/sysinfo/product.go
+++ b/third_party/zcalusic/sysinfo/product.go
@@ -4,7 +4,9 @@
 
 package sysinfo
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+)
 
 // Product information.
 type Product struct {


### PR DESCRIPTION
Ran `make format` (goimports + goimports-reviser) across the tree. These 27 files had drifted from the repo's canonical import grouping — local project imports (`github.com/skycoin/skywire/...`) belong in their own block after third-party.

Import reordering only; no logic changes, `go.mod`/`go.sum`/`vendor` untouched. Builds clean on the default and `js/wasm` targets.