### PR TITLE
feat(wasm-hv): skynet browser home button + limitations panel + docs

### DIFF
--- a/docs/skynet-browser.md
+++ b/docs/skynet-browser.md
@@ -1,0 +1,75 @@
+# The skynet browser (wasm-visor iframe browser)
+
+The wasm-visor ships an in-tab **skynet browser** — a WinBox window whose address
+bar accepts a visor **PK**, **`pk.dmsg`**, an **`alias.dmsg`** (e.g.
+**`home.dmsg`**), or an **`https://`** clearnet URL. Pages are fetched over dmsg
+(skynet) — no DNS, no certificate authorities, IP-anonymous — or, for clearnet,
+routed through a skysocks exit selected in the ⚙ panel.
+
+Nav bar: `◀ ▶ ⟳ ⌂` (back / forward / reload / **home** → `home.dmsg`), the
+address bar + `go`, `⚙` (skysocks proxy + per-window request log), and `ⓘ`
+(this page's summary, in-UI).
+
+## Limitations (by design)
+
+Every fetched page is rendered into an iframe declared
+`sandbox="allow-scripts allow-forms"` — deliberately **without
+`allow-same-origin`**. The browser then forces each document into a **unique
+opaque origin**, which is the source of the properties below.
+
+- **No persistent storage.** Opaque origins cannot use Web Storage, cookies,
+  IndexedDB, or the Cache API — access throws. So **cookies / localStorage /
+  logins do not persist**, not even across a reload; each visit is effectively a
+  fresh, incognito, storage-less context.
+- **Isolation.** Sites cannot read each other's data, and — critically — cannot
+  read the visor's own storage. The visor's secret key lives in the *parent*
+  page's `localStorage` (`skywire-visor-sk`); the opaque-origin sandbox walls
+  browsed sites off from it. This isolation is the whole reason for the sandbox.
+- **Restricted scripting.** `allow-scripts allow-forms` only: no plugins, no
+  popups, no top-level navigation, no `allow-same-origin`. Some clearnet sites
+  that depend on cookies or service workers will misbehave.
+- **Direct-load path is sandboxed too.** For "direct" clearnet sites the engine
+  sets `frame.src = url` but leaves the `sandbox` attribute on the element, so
+  even a directly-loaded real site runs opaque-origin and cannot use its cookies.
+
+These are a privacy tradeoff, not bugs: no cross-site or site→visor leakage, and
+no persistent tracking state.
+
+## Why the wasm visor can't give per-site persistence
+
+Browser storage is partitioned by **origin** (`scheme://host:port`). To give each
+site its own durable, isolated storage bucket, each site must *be* a distinct
+origin. A browser tab cannot mint new origins for content it fetches itself, and
+a Service Worker is scoped to its page's single origin (path separation does not
+isolate storage). So in the keyless in-tab wasm visor there is no way to give
+browsed sites real per-origin storage without either (a) wildcard-subdomain
+serving infrastructure with a per-subdomain dmsg fetch relay, or (b) an embedded
+dmsg client per site — both heavy, and (a) reintroduces domain/DNS dependence the
+keyless model avoids.
+
+## The native path (future): one local proxy origin per site
+
+On the **native desktop** browser (a real process, e.g. the WebKitGTK sibling)
+per-site persistence *is* achievable, two ways:
+
+1. **Wildcard-host loopback reverse proxy.** Serve
+   `http://<sitekey>.skynet.localhost:PORT/` where `<sitekey>` is a stable 1:1
+   encoding of the dmsg target (e.g. `PubKey.DNSLabel()` base32). Decode the host
+   → dmsg target, fetch over the existing resolving-proxy path, serve it back
+   under that host. `*.localhost` needs no DNS and is a secure context in
+   Chromium, so each site gets its own persistent, isolated cookies / localStorage
+   / IndexedDB / service worker — isolated from other sites *and* from the visor
+   UI origin. In-page links are rewritten to keep same-site navigations on the
+   same synthetic host (cross-site → another `<sitekey>.skynet.localhost`, clearnet
+   → a clearnet-proxy origin). With isolation coming from the origin, the sandbox
+   can be dropped.
+2. **Point the whole webview at the resolving SOCKS5 proxy.** With
+   `socks5h://127.0.0.1:<port>` resolving `<pk>.dmsg`, the browser engine treats
+   `<pk>.dmsg` as the origin and partitions storage per-pk for free — no reverse
+   proxy, no rewriting. Browsers just don't allow a per-iframe SOCKS proxy, which
+   is why the wildcard-localhost reverse proxy is the fallback for the embedded
+   case.
+
+Recommended pairing: an **ephemeral / incognito** toggle that clears a site's
+bucket on close, and keeping the visor UI origin strictly out of the proxy's host
+namespace so a proxied site can never navigate to it or read its storage.

--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -587,10 +587,12 @@
       '<button id="sb-back" title="back" disabled style="cursor:pointer">◀</button>' +
       '<button id="sb-fwd" title="forward" disabled style="cursor:pointer">▶</button>' +
       '<button id="sb-reload" title="reload" style="cursor:pointer">⟳</button>' +
+      '<button id="sb-home" title="home (home.dmsg)" style="cursor:pointer">⌂</button>' +
       '<input id="sb-addr" placeholder="pk · pk.dmsg · home.dmsg · alias.dmsg · https://site (clearnet via proxy)" autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false" style="flex:1;min-width:0;background:#0e0c14;color:#cdd2da;border:1px solid #2a2342;padding:.4em">' +
       '<button id="sb-go" style="cursor:pointer">go</button>' +
       // Content hosting moved to its own 'host' tool window (top-left ☰ menu).
       '<button id="sb-proxy-t" title="skysocks proxy + request log" style="cursor:pointer">⚙</button>' +
+      '<button id="sb-info-t" title="about this browser + its limitations" style="cursor:pointer">ⓘ</button>' +
       '</div>' +
       '<div id="sb-proxy" style="display:none;flex-direction:column;gap:.4em;padding:.5em;background:#1a1726;border-bottom:1px solid #2a2342">' +
       '<div style="display:flex;gap:.4em;align-items:center;flex-wrap:wrap">' +
@@ -607,6 +609,21 @@
       // Terminal-like per-window request log: every fetch this browser window makes
       // over the resolving proxy (dmsg) or skysocks-lite (clearnet), + config events.
       '<pre id="sb-proxy-log" title="requests through this window — resolving proxy (dmsg) + skysocks-lite (clearnet)" style="margin:0;height:160px;overflow:auto;background:#0e0c14;color:#a9b1d6;border:1px solid #2a2342;padding:.45em;font:11px/1.45 monospace;white-space:pre-wrap;word-break:break-all"></pre>' +
+      '</div>' +
+      // About/limitations panel (toggled by ⓘ). The skynet browser is deliberately
+      // sandboxed; surface WHY so "my login didn't stick" reads as by-design, not a
+      // bug. See docs/skynet-browser.md for the full rationale + the native
+      // per-site-origin design that would lift the storage limit.
+      '<div id="sb-info-panel" style="display:none;flex-direction:column;gap:.5em;padding:.7em .8em;background:#1a1726;border-bottom:1px solid #2a2342;font:12px/1.5 monospace;color:#cdd2da;max-height:40%;overflow:auto">' +
+      '<div style="display:flex;align-items:center;gap:.5em"><b style="color:#9d7cff;font-size:13px">about the skynet browser</b><span style="flex:1"></span><button id="sb-info-x" style="cursor:pointer">×</button></div>' +
+      '<div>Fetches sites over <b>dmsg</b> (skynet) — no DNS, no certificate authorities, IP-anonymous. Address bar accepts a visor <b>PK</b>, <b>pk.dmsg</b>, an <b>alias.dmsg</b> (e.g. <b>home.dmsg</b>), or an <b>https://</b> clearnet site (routed through a skysocks exit — set in ⚙).</div>' +
+      '<div style="border-top:1px solid #2a2342;padding-top:.5em"><b style="color:#e0af68">Limitations (by design):</b></div>' +
+      '<ul style="margin:.1em 0 0;padding-left:1.2em;display:flex;flex-direction:column;gap:.25em">' +
+      '<li><b>No persistent storage.</b> Every page runs in a sandboxed frame with an opaque origin — <b>cookies, localStorage and logins do not persist</b>, even across a reload. Each visit is effectively fresh/incognito.</li>' +
+      '<li><b>Isolated.</b> Sites cannot read each other\'s data, and cannot read this visor\'s keys/storage.</li>' +
+      '<li><b>Scripts limited</b> (sandbox: allow-scripts allow-forms); no plugins, popups, or top-level navigation. Some clearnet sites that require cookies/service-workers may misbehave.</li>' +
+      '<li>Per-site persistent storage like a normal browser would need the <b>native desktop</b> app (each site on its own local origin) — not possible in a keyless browser tab.</li>' +
+      '</ul>' +
       '</div>' +
       '<iframe id="sb-frame" sandbox="allow-scripts allow-forms" style="flex:1;width:100%;border:0;background:#fff"></iframe>';
 
@@ -690,6 +707,9 @@
     $("sb-fwd").onclick = function () { browser.forward(); };
     // ⟳ reloads the current page; while a load is in flight it becomes ✕ (cancel).
     $("sb-reload").onclick = function () { if (loading) browser.cancel(); else browser.reload(); };
+    $("sb-home").onclick = function () { browser.browseTo("home.dmsg", "/"); };
+    $("sb-info-t").onclick = function () { var h = $("sb-info-panel"); h.style.display = h.style.display === "none" ? "flex" : "none"; };
+    $("sb-info-x").onclick = function () { $("sb-info-panel").style.display = "none"; };
     $("sb-addr").addEventListener("keydown", function (e) { if (e.key === "Enter") go(); });
     // clearnet upstream-proxy settings (per window; persists as the global default).
     $("sb-proxy-pk").value = browser.upstream();


### PR DESCRIPTION
Adds to the wasm-visor skynet browser:
- a **home button** (`⌂` → `home.dmsg`) in the nav bar next to back/forward/reload (does not replace the default home page);
- an **ⓘ about/limitations panel** explaining why the browser behaves as it does — pages run in a sandboxed **opaque-origin** frame, so cookies/localStorage/logins do **not** persist and sites are isolated from each other and from the visor's keys. Turns "my login didn't stick" from an apparent bug into documented, by-design behaviour.

`docs/skynet-browser.md` captures the full rationale + the **native per-site-origin design** (wildcard `*.skynet.localhost` reverse proxy, or routing the webview through the resolving SOCKS5 proxy so `<pk>.dmsg` is the origin) that would lift the storage limitation on desktop — impossible in a keyless browser tab.

browse.js only (embedded via `go build`); no Angular bundle change.