### PR TITLE
refactor(cxo): extract cxosub; wire standalone reward server to CXO feeds

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -252,7 +252,12 @@ func buildRouter() *gin.Engine {
 					return
 				}
 				tpvizServer.SetDmsgHTTPClient(&http.Client{Transport: dmsghttp.MakeHTTPTransport(context.Background(), dmsgC)})
-				dlog.Info("tp-viz: deployment discovery now sourced over dmsg")
+				// Prefer the intermittent CXO subscriber over the same dmsg client:
+				// tp-viz sources TPD/SD/DMSG-D data (transports, uptime, services,
+				// dmsg-clients) from the deployment CXO feeds and only falls back to
+				// the HTTP-over-dmsg client above on a cache miss.
+				tpvizServer.SetCXOSubMgrFromDmsg(dmsgC)
+				dlog.Info("tp-viz: deployment discovery now sourced over dmsg (CXO-first)")
 			}()
 		}
 

--- a/docs/tpviz-cxo-subscriber.md
+++ b/docs/tpviz-cxo-subscriber.md
@@ -1,0 +1,94 @@
+# Reward server (tpviz) → CXO subscriber for all deployment feeds
+
+## Problem
+
+The standalone reward server (`skywire cli rewards server`, serving
+theskywirenetwork.net over dmsg) fetches TPD/SD/DMSGD data via **HTTP-over-dmsg
+polling** (`tpviz.SetDmsgHTTPClient`). The deployment services are dmsg-only and
+already publish their data on **CXO feeds**, so the right mechanism is an
+**intermittent CXO subscriber** (subscribe → wait-for-Root → snapshot →
+unsubscribe), which also handles resubscribe and doesn't require the publisher
+(TPD) to persistently track subscribers across restarts.
+
+The concrete trigger: `/api/uptimes` was empty (standalone UT decommissioned) →
+all visors "unknown" → hidden → transport-graph showed ~9 of ~1011 visors.
+PR #3388 patched it via HTTP-over-dmsg; this doc is the proper CXO version.
+
+## What already exists
+
+- TPD/SD/DMSGD CXO publishers, consumed today by the **visor**'s HV visualizer:
+  | Feed | Publisher | dmsg port (skyenv) | prefix | payload |
+  |---|---|---|---|---|
+  | `FeedTPDMetrics` | TPD | `DmsgTPDMetricsCXOPort` (51) | `metrics/days/` | `[]TransportMetric` |
+  | `FeedTPDUptime` | TPD | `DmsgTPDUptimeCXOPort` (52) | `uptimes/days/` | `[]VisorSummary` |
+  | `FeedSDServices` | SD | `DmsgSDServicesCXOPort` (53) | `services/` | services entries |
+  | `FeedDMSGDClientsByServer` | DMSG-D | `DmsgDMSGDClientsByServerCXOPort` | `clients-by-server/` | client entries |
+  | `FeedTPDAllTransports` | TPD | `DmsgTPDAllTransportsCXOPort` | `transports/all/` | all-transports snapshot |
+- `pkg/visor/cxo_subscription_manager.go` (800 lines) implements the intermittent
+  subscriber: `syncOnce` (subscribe/snapshot/unsubscribe), `AcquireForTab` /
+  `ReleaseForTab` grace batching, `Get`/`Walk`, `feedSpec` (feed → pk/port/prefix
+  from `v.conf`). It imports only `cipher`, `cxo/treestore`, `dmsg/dmsgcurl`,
+  `logging`, `skyenv` — **no visor-specific packages**.
+- `pkg/tpviz/cxo_subscriber.go` defines the `CXOSubMgr` interface
+  (`AcquireForTab`/`ReleaseForTab`/`Walk`) tpviz consumes, plus `tryCXOServices`
+  and `tryCXOClientsByServer` (services + dmsg already CXO-capable when a mgr is
+  wired). Only the **hypervisor** wires one (`hypervisor.go:145`,
+  `cxoSubMgrAdapter{v: visor}`); the standalone reward server wires none.
+
+## Recommendation: extract the manager to a lightweight package
+
+**Approach A**, but as a clean *move* into a new package rather than importing the
+heavy `pkg/visor`:
+
+1. **Move** `cxo_subscription_manager.go` → new package **`pkg/cxo/cxosub`**
+   (`manager.go`). Because it already imports nothing visor-specific, this is a
+   near-verbatim move.
+2. **Replace the `*Visor` coupling** with an injected dependency set:
+   ```go
+   package cxosub
+   type Feed int // the CXOFeed constants move here
+   type Deps struct {
+       Dmsg     *dmsgcurl.Client                  // was v.dmsgC
+       FeedSpec func(Feed) (pk cipher.PubKey, port uint16, prefix string, err error) // was m.feedSpec
+       Log      *logging.Logger                   // was v.MasterLogger
+   }
+   func NewManager(deps Deps, interval time.Duration) *Manager
+   // Manager keeps AcquireForTab/ReleaseForTab/Get/Walk unchanged.
+   ```
+   `initLock` / `cxoSubMgr` self-ref become manager-internal.
+3. **`pkg/visor`**: a thin shim builds `cxosub.Deps` from `v.conf`
+   (`tpdCXOPeer/sdCXOPeer/dmsgdCXOPeer` → `FeedSpec`) + `v.dmsgC`. The existing
+   `cxoSubMgrAdapter` continues bridging to tpviz's `CXOSubMgr`. Behavior
+   unchanged; the visor keeps its tab→feed map.
+4. **Reward server** (`cmd/skywire-cli/commands/rewards/server`): build
+   `cxosub.Deps` from **deployment config dmsg PKs**
+   (`deployment.Prod.TransportDiscoveryDmsg` → TPD PK, `…ServiceDiscoveryDmsg`,
+   `…DmsgDiscoveryDmsg`) + the reward server's existing embedded dmsg client
+   (`StartDmsgEmbedded`), construct `cxosub.NewManager`, wrap in a small adapter
+   implementing tpviz's `CXOSubMgr`, and call `tpvizServer.SetCXOSubMgr(...)`.
+   This replaces `SetDmsgHTTPClient` as the primary path.
+5. **`pkg/tpviz`**: add the missing feed constants (`CXOFeedTPDMetrics=0`,
+   `CXOFeedTPDUptime=1`, `CXOFeedTPDAllTransports=4`; services=2, cbs=3 exist) and
+   `tryCXOUptimes` (Walk `uptimes/days/`), `tryCXOTransports` (Walk
+   `transports/all/`), `tryCXOMetrics` (Walk `metrics/days/`). Wire each handler
+   CXO-first with the HTTP-over-dmsg path as fallback; once validated, retire the
+   HTTP polling in the reward server.
+
+**Feed coverage:** all five (metrics, uptime, services, clients-by-server,
+all-transports) — the complete dmsg-only-via-CXO end state.
+
+Why not Approach B (lean tpviz-local subscriber): it would duplicate the
+non-trivial intermittent-subscribe / grace / resubscribe / snapshot logic that
+already exists and is battle-tested in the visor, inviting drift. One shared impl
+is better.
+
+## Open items / risks
+
+- Confirm `treestore.NewSubscriber` param type matches the reward server's dmsg
+  client (visor uses `dmsgcurl` import; reward server uses `dmsgclient` /
+  `StartDmsgEmbedded`) — likely the same underlying `*dmsg.Client`.
+- The move must preserve the visor's existing netviz behavior + tests.
+- Deployment: prod TPD must actually **publish** the uptime feed
+  (`StartUptimeCXOPublisher` running) and populate it — verify after redeploy.
+- `#3388` (HTTP-over-dmsg uptime fetch) stays as the fallback until CXO is
+  validated live, then the HTTP polling path can be removed.

--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -1,0 +1,790 @@
+// Package cxosub pkg/cxo/cxosub/manager.go
+//
+// Cycle-based on-demand CXO sync manager.
+//
+// The hypervisor's network visualizer / metrics tabs, the visor's
+// own autoconnect / CLI listing commands, and standalone services
+// (e.g. the reward server) all want a recent snapshot of network-wide
+// state from one of the deployment-side CXO publishers (TPD's metrics
+// + uptime aggregates, SD's services tree, DMSG-D's clients-by-server
+// tree). Keeping a long-lived subscription alive is wasteful — most
+// of those updates are noise to a UI that might be open for a few
+// seconds at a time, and a subscription that was open across a
+// publisher restart goes silently stale because
+// `treestore.Subscriber.Connect` is one-shot with no built-in
+// reconnect.
+//
+// This manager runs each feed as a periodic *cycle*:
+//
+//	subscribe → wait for first Root → walk into local snapshot
+//	→ unsubscribe → sleep `interval` → repeat
+//
+// Cycles only run while at least one consumer holds the feed via
+// AcquireFor. When the last release happens the cycle stops on the
+// next interval boundary (with a small grace), so a fast acquire-
+// release-acquire reuses the running cycle without re-dialing.
+//
+// Get / Walk read the *snapshot*, not a live subscriber — so the
+// data they see is always at most `interval`-old, never tied to a
+// dmsg session that may have died. A publisher restart self-heals
+// on the next sync because each cycle dials fresh.
+//
+// The manager is decoupled from any host type via Deps: the caller
+// injects a live-dmsg-client accessor and a feed→(peer, port, prefix)
+// resolver, so both the visor and a standalone service can drive it.
+package cxosub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// Feed identifies one upstream CXO publisher feed the manager can
+// sync from. Adding a new feed means: add a const here, a case in the
+// injected FeedSpec resolver, and a tab → feeds dependency entry
+// below.
+type Feed int
+
+const (
+	// FeedTPDMetrics is TPD's metrics-aggregate publisher
+	// (metrics/days/<n>).
+	FeedTPDMetrics Feed = iota
+	// FeedTPDUptime is TPD's uptime-aggregate publisher
+	// (uptimes/days/<n>).
+	FeedTPDUptime
+	// FeedSDServices is SD's services publisher
+	// (services/<type>/<pk>/{entry,tombstone}).
+	FeedSDServices
+	// FeedDMSGDClientsByServer is DMSG-D's clients-by-server publisher
+	// (clients-by-server/<server>/<client>/{entry,tombstone}).
+	FeedDMSGDClientsByServer
+	// FeedTPDAllTransports is TPD's all-transports snapshot publisher
+	// (transports/all/{with-self,without-self}). Used by the CLI's
+	// `pv -t`, `tp tree`, `tp viz` commands as a CXO alternative to
+	// HTTP-polling /all-transports.
+	FeedTPDAllTransports
+)
+
+// FeedRoute returns the fixed dmsg CXO port and TreeStore path prefix a feed's
+// publisher uses. The publisher PK is service-specific and supplied separately
+// by the caller's FeedSpec — centralizing this (port, prefix) mapping keeps every
+// FeedSpec (visor config-derived, reward-server deployment-derived) consistent.
+// ok is false for an unknown feed.
+func FeedRoute(f Feed) (port uint16, prefix string, ok bool) {
+	switch f {
+	case FeedTPDMetrics:
+		return skyenv.DmsgTPDMetricsCXOPort, "metrics/days/", true
+	case FeedTPDUptime:
+		return skyenv.DmsgTPDUptimeCXOPort, "uptimes/days/", true
+	case FeedSDServices:
+		return skyenv.DmsgSDServicesCXOPort, "services/", true
+	case FeedDMSGDClientsByServer:
+		return skyenv.DmsgDMSGDClientsByServerCXOPort, "clients-by-server/", true
+	case FeedTPDAllTransports:
+		return skyenv.DmsgTPDAllTransportsCXOPort, "transports/all/", true
+	}
+	return 0, "", false
+}
+
+// Tab identifies a consumer of one or more CXO feeds. Tabs in the
+// hypervisor UI map onto tabs here directly; non-UI consumers
+// (autoconnect, CLI commands) get their own tab kinds.
+type Tab int
+
+const (
+	// TabNetworkVisualizer is the network visualizer tab — needs SD
+	// services + DMSG-D clients-by-server + TPD metrics.
+	TabNetworkVisualizer Tab = iota
+	// TabMetrics is the metrics tab — TPD metrics + TPD uptime.
+	TabMetrics
+	// TabUptime is the network uptime tab — TPD uptime only.
+	TabUptime
+	// TabAutoconnect is the visor's public-visor autoconnect cycle —
+	// SD services only (filters down to the visor type at walk time).
+	TabAutoconnect
+	// TabCLIServices is the operator-facing service-listing CLI
+	// commands (`skywire cli proxy list`, `vpn list`, `pv`). Same
+	// SD services feed; refcount summed with TabAutoconnect when
+	// both are active so they share the running cycle.
+	TabCLIServices
+	// TabCLITransports is the operator-facing transport-listing CLI
+	// commands (`pv -t`, `tp tree`, `tp viz`). Maps to the TPD
+	// all-transports feed.
+	TabCLITransports
+	// TabRoutingPolicy is the operator-programmable routing-policy
+	// provider's SD-services consumer. Needed so the policy script's
+	// geo.country(pk) can resolve multihop intermediates that
+	// advertise themselves as proxy/vpn/visor services.
+	TabRoutingPolicy
+)
+
+// tabFeedDeps maps each tab to the set of feeds it depends on.
+// Acquire / Release walks this list; a feed shared between tabs has
+// its refcount summed across them.
+var tabFeedDeps = map[Tab][]Feed{
+	TabNetworkVisualizer: {FeedSDServices, FeedDMSGDClientsByServer, FeedTPDMetrics},
+	TabMetrics:           {FeedTPDMetrics, FeedTPDUptime},
+	TabUptime:            {FeedTPDUptime},
+	TabAutoconnect:       {FeedSDServices},
+	TabCLIServices:       {FeedSDServices},
+	TabCLITransports:     {FeedTPDAllTransports},
+	TabRoutingPolicy:     {FeedSDServices},
+}
+
+// Deps are the host-injected dependencies the manager needs. They
+// decouple it from any concrete host type (*visor.Visor, a standalone
+// reward server, …).
+type Deps struct {
+	// Dmsg returns the live dmsg client (may be nil during early
+	// startup or when DMSG is disabled). Called fresh on each sync so
+	// the manager always uses the current client.
+	Dmsg func() *dmsg.Client
+	// FeedSpec resolves a feed to its (publisher PK, CXO dmsg port,
+	// TreeStore path prefix). Returns an error when the publisher
+	// isn't configured — meaning the feed can never sync until the
+	// host's config is fixed.
+	FeedSpec func(Feed) (peerPK cipher.PubKey, port uint16, prefix string, err error)
+	// Log is the logger; nil falls back to a default package logger.
+	Log *logging.Logger
+}
+
+// Manager owns the per-feed cycle goroutines + the in-memory
+// snapshots they populate. Construct with NewManager.
+type Manager struct {
+	deps     Deps
+	log      *logging.Logger
+	interval time.Duration // cycle period (cxo_subscribe_interval)
+	grace    time.Duration // delay after last release before stopping the cycle
+
+	mu    sync.Mutex
+	feeds map[Feed]*managedFeed
+}
+
+// managedFeed holds a single feed's runtime state.
+type managedFeed struct {
+	// Snapshot data — populated by syncOnce, read by Get / Walk.
+	snapMu     sync.RWMutex
+	snapshot   map[string][]byte
+	lastSyncAt time.Time
+	lastErr    error // sticky last error from syncOnce; cleared on success
+	// lastSyncCachePaths / lastSyncCacheKeys: discriminator for empty
+	// snapshots (publisher sent empty Root vs manager-side filter
+	// dropped everything). Captured in syncOnce right before
+	// sub.Close. Surfaced via FeedStatus for `cxo status`.
+	lastSyncCachePaths int
+	lastSyncCacheKeys  []string
+
+	// Lifecycle (mutated only under manager.mu).
+	refcount  int
+	cancel    context.CancelFunc // stops the cycle goroutine
+	done      chan struct{}      // closed when the cycle goroutine exits
+	stopTimer *time.Timer        // pending grace-expiry stop
+}
+
+// DefaultSubscribeInterval is the cycle period when the operator
+// hasn't set hypervisor.cxo_subscribe_interval. 5min matches the
+// "no more than once every 5 min" intent.
+const DefaultSubscribeInterval = 5 * time.Minute
+
+// TabCloseGrace is how long after the refcount falls to zero we
+// keep running the cycle. 10s smooths over UI tab navigation flicker
+// without leaking a long idle subscription.
+const TabCloseGrace = 10 * time.Second
+
+// FirstSyncTimeout bounds how long syncOnce waits for the first Root
+// after Connect. After this the subscriber is closed and the cycle
+// records an error; the next cycle (or an explicit AcquireFor that
+// triggers a sync) retries from scratch. Long enough to ride out a
+// dmsg-session reconnect, short enough that a UI Acquire on a dead
+// publisher returns its cache-miss within ~10s.
+const FirstSyncTimeout = 10 * time.Second
+
+// allTransportsFirstSyncTimeout is the first-Root wait for the TPD
+// all-transports feed. It's the largest, deepest tree (~8MB network-wide
+// snapshot) and routinely needs well over FirstSyncTimeout to deliver its
+// first Root over dmsg — a 10s bound left it never syncing over CXO. The
+// all-transports topology is the most important feed for the transport
+// graph, so it gets the room it needs; other feeds keep the tighter default.
+const allTransportsFirstSyncTimeout = 45 * time.Second
+
+// FeedFirstSyncTimeout returns the first-Root wait for a feed. Per-feed so the
+// large all-transports snapshot syncs reliably without slowing a UI Acquire on
+// the small, fast feeds.
+func FeedFirstSyncTimeout(f Feed) time.Duration {
+	if f == FeedTPDAllTransports {
+		return allTransportsFirstSyncTimeout
+	}
+	return FirstSyncTimeout
+}
+
+// NewManager constructs an idle, ready manager. interval comes from
+// hypervisor.cxo_subscribe_interval; <= 0 falls back to
+// DefaultSubscribeInterval. deps.Log nil falls back to a default
+// package logger.
+func NewManager(deps Deps, interval time.Duration) *Manager {
+	if interval <= 0 {
+		interval = DefaultSubscribeInterval
+	}
+	log := deps.Log
+	if log == nil {
+		log = logging.MustGetLogger("cxosub")
+	}
+	return &Manager{
+		deps:     deps,
+		log:      log,
+		interval: interval,
+		grace:    TabCloseGrace,
+		feeds:    make(map[Feed]*managedFeed),
+	}
+}
+
+// dmsgClient returns the live dmsg client via the injected accessor,
+// or nil if none was injected.
+func (m *Manager) dmsgClient() *dmsg.Client {
+	if m.deps.Dmsg == nil {
+		return nil
+	}
+	return m.deps.Dmsg()
+}
+
+// feedSpec resolves a feed via the injected resolver.
+func (m *Manager) feedSpec(fk Feed) (cipher.PubKey, uint16, string, error) {
+	if m.deps.FeedSpec == nil {
+		return cipher.PubKey{}, 0, "", errors.New("no feed resolver configured")
+	}
+	return m.deps.FeedSpec(fk)
+}
+
+// AcquireFor signals that a consumer is about to read from the
+// feeds a tab depends on. Idempotent across multiple holders;
+// refcount sums. On the first acquire of a feed, the cycle goroutine
+// starts and a sync is kicked off immediately so the snapshot has a
+// chance to populate before the caller's first Get / Walk. (Whether
+// it actually does depends on dmsg session readiness; callers handle
+// the cache-miss case by falling through to HTTP.)
+func (m *Manager) AcquireFor(tab Tab) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, fk := range tabFeedDeps[tab] {
+		m.acquireFeedLocked(fk)
+	}
+}
+
+// ReleaseFor signals that a consumer is done. Drops the refcount on
+// each feed the tab depends on. Feeds whose refcount falls to zero
+// schedule their cycle goroutine to stop after the grace period —
+// during which a fresh AcquireFor cancels the stop and reuses the
+// running cycle.
+func (m *Manager) ReleaseFor(tab Tab) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, fk := range tabFeedDeps[tab] {
+		m.releaseFeedLocked(fk)
+	}
+}
+
+// Get returns the cached body for (feed, path) plus the timestamp of
+// the most recent successful sync, or ok=false if the feed has no
+// snapshot yet (no acquire ever happened, the first cycle hasn't
+// completed, or every cycle failed). Callers handle ok=false by
+// falling through to HTTP.
+func (m *Manager) Get(feed Feed, path string) ([]byte, time.Time, bool) {
+	if m == nil {
+		return nil, time.Time{}, false
+	}
+	m.mu.Lock()
+	f, ok := m.feeds[feed]
+	m.mu.Unlock()
+	if !ok || f == nil {
+		return nil, time.Time{}, false
+	}
+	f.snapMu.RLock()
+	defer f.snapMu.RUnlock()
+	if f.snapshot == nil {
+		return nil, time.Time{}, false
+	}
+	body, ok := f.snapshot[path]
+	if !ok || len(body) == 0 {
+		return nil, time.Time{}, false
+	}
+	out := make([]byte, len(body))
+	copy(out, body)
+	return out, f.lastSyncAt, true
+}
+
+// Walk invokes fn for every (path, body) in the feed's cached
+// snapshot whose path begins with prefix. Returns ok=false (with fn
+// never called) if the feed has no snapshot. Bodies passed to fn
+// are owned by the snapshot — callers must copy if they need to
+// retain bytes after fn returns.
+func (m *Manager) Walk(feed Feed, prefix string, fn func(path string, body []byte) bool) bool {
+	if m == nil {
+		return false
+	}
+	m.mu.Lock()
+	f, ok := m.feeds[feed]
+	m.mu.Unlock()
+	if !ok || f == nil {
+		return false
+	}
+	f.snapMu.RLock()
+	defer f.snapMu.RUnlock()
+	if len(f.snapshot) == 0 {
+		return false
+	}
+	for path, body := range f.snapshot {
+		if prefix != "" && !hasPathPrefix(path, prefix) {
+			continue
+		}
+		if !fn(path, body) {
+			return true
+		}
+	}
+	return true
+}
+
+// Close stops every active cycle and drops every snapshot. Called
+// from the host's shutdown sequence.
+func (m *Manager) Close() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	feeds := make([]*managedFeed, 0, len(m.feeds))
+	for _, f := range m.feeds {
+		if f.stopTimer != nil {
+			f.stopTimer.Stop()
+			f.stopTimer = nil
+		}
+		feeds = append(feeds, f)
+	}
+	m.feeds = make(map[Feed]*managedFeed)
+	m.mu.Unlock()
+	for _, f := range feeds {
+		if f.cancel != nil {
+			f.cancel()
+		}
+		if f.done != nil {
+			<-f.done
+		}
+	}
+}
+
+// FeedStatus is one row of Manager.Status. Tells the operator
+// everything needed to decide whether a CXO miss is "the snapshot is
+// genuinely empty", "the cycle has never run", or "the cycle keeps
+// failing for reason X". Exposed via the visor RPC so `skywire cli
+// visor cxo status` can render it.
+type FeedStatus struct {
+	// Feed is the FeedXxx constant's stable string name (matches the
+	// label FeedString returns).
+	Feed string
+	// PeerPK is the publisher's PK (or empty if not configured).
+	PeerPK string
+	// DmsgPort is the publisher's CXO port.
+	DmsgPort uint16
+	// Prefix is the TreeStore path prefix this feed walks under.
+	Prefix string
+	// SnapshotPaths is the number of (path, body) entries currently
+	// cached. 0 + LastSyncAt zero means "no cycle has ever completed".
+	SnapshotPaths int
+	// SnapshotBytes is the sum of body lengths in the snapshot. Quick
+	// "how much memory is this feed using" check.
+	SnapshotBytes int
+	// LastSyncAt is the wall-clock time of the most recent successful
+	// sync. Zero when no cycle has ever finished cleanly.
+	LastSyncAt time.Time
+	// LastErr is the sticky last error from syncOnce, cleared on
+	// success. Empty when the most recent cycle worked.
+	LastErr string
+	// Refcount is the number of holders that have currently AcquireFor'd
+	// this feed without releasing it. >0 means a cycle is running.
+	Refcount int
+	// CycleRunning is true while the per-feed goroutine is alive (i.e.
+	// inside its tick loop). Goes false during the grace-period close.
+	CycleRunning bool
+	// SpecErr is non-empty if the feed resolver couldn't resolve the
+	// publisher (e.g. SD CXO peer not configured) — meaning the feed
+	// can never sync until the host config is fixed.
+	SpecErr string
+	// LastSyncCachePaths is len(sub.cache) snapshotted right before the
+	// most recent syncOnce closed its subscriber. Discriminator for
+	// "SnapshotPaths=0 with no error": when this is also 0 the
+	// publisher's Root was structurally empty; when this is >0 but
+	// SnapshotPaths=0 the manager's snapshot copy / prefix filter is
+	// the culprit.
+	LastSyncCachePaths int
+	// LastSyncCacheSampleKeys is up to 5 keys from sub.cache at the
+	// moment LastSyncCachePaths was captured. Lets the operator
+	// eyeball whether the publisher is writing the paths the
+	// subscriber's prefix expects.
+	LastSyncCacheSampleKeys []string
+}
+
+// Status returns a snapshot of every feed the manager knows about
+// (i.e. every feed someone has ever acquired). Feeds that were never
+// touched don't appear; callers should treat absence as "no cycle
+// ever started". Safe to call on a nil receiver — returns nil.
+func (m *Manager) Status() []FeedStatus {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	out := make([]FeedStatus, 0, len(m.feeds))
+	for fk, f := range m.feeds {
+		st := FeedStatus{Feed: FeedString(fk)}
+		if pk, port, prefix, err := m.feedSpec(fk); err != nil {
+			st.SpecErr = err.Error()
+		} else {
+			st.PeerPK = pk.Hex()
+			st.DmsgPort = port
+			st.Prefix = prefix
+		}
+		st.Refcount = f.refcount
+		st.CycleRunning = f.cancel != nil
+		f.snapMu.RLock()
+		st.SnapshotPaths = len(f.snapshot)
+		for _, body := range f.snapshot {
+			st.SnapshotBytes += len(body)
+		}
+		st.LastSyncAt = f.lastSyncAt
+		if f.lastErr != nil {
+			st.LastErr = f.lastErr.Error()
+		}
+		st.LastSyncCachePaths = f.lastSyncCachePaths
+		if len(f.lastSyncCacheKeys) > 0 {
+			st.LastSyncCacheSampleKeys = append([]string(nil), f.lastSyncCacheKeys...)
+		}
+		f.snapMu.RUnlock()
+		out = append(out, st)
+	}
+	m.mu.Unlock()
+	return out
+}
+
+// RefreshNow forces a fresh subscribe → first-Root → walk cycle for
+// `feed` and blocks until either the cycle reports success/failure or
+// the caller's ctx expires. Unlike AcquireFor — which starts a cycle
+// goroutine and returns immediately, leaving the caller racing the
+// first sync — this is synchronous: the returned FeedStatus reflects
+// the snapshot AFTER the sync attempt. Used by `skywire cli visor cxo
+// refresh` so an operator can deterministically test "can this visor
+// actually reach the publisher right now".
+//
+// The cycle goroutine started by AcquireFor (if any) is left alone;
+// this opens its own short-lived subscriber.
+func (m *Manager) RefreshNow(ctx context.Context, feed Feed) (FeedStatus, error) {
+	if m == nil {
+		return FeedStatus{}, errors.New("cxo manager not initialized (no DMSG client?)")
+	}
+	m.mu.Lock()
+	f, ok := m.feeds[feed]
+	if !ok {
+		f = &managedFeed{}
+		m.feeds[feed] = f
+	}
+	m.mu.Unlock()
+	m.syncOnce(ctx, feed, f)
+	st := m.statusFor(feed, f)
+	if f.lastErr != nil {
+		return st, f.lastErr
+	}
+	return st, nil
+}
+
+// statusFor builds a FeedStatus for one feed under the manager's lock
+// discipline. Pulled out so Status() and RefreshNow() share one
+// implementation.
+func (m *Manager) statusFor(fk Feed, f *managedFeed) FeedStatus {
+	st := FeedStatus{Feed: FeedString(fk)}
+	if pk, port, prefix, err := m.feedSpec(fk); err != nil {
+		st.SpecErr = err.Error()
+	} else {
+		st.PeerPK = pk.Hex()
+		st.DmsgPort = port
+		st.Prefix = prefix
+	}
+	m.mu.Lock()
+	st.Refcount = f.refcount
+	st.CycleRunning = f.cancel != nil
+	m.mu.Unlock()
+	f.snapMu.RLock()
+	st.SnapshotPaths = len(f.snapshot)
+	for _, body := range f.snapshot {
+		st.SnapshotBytes += len(body)
+	}
+	st.LastSyncAt = f.lastSyncAt
+	if f.lastErr != nil {
+		st.LastErr = f.lastErr.Error()
+	}
+	st.LastSyncCachePaths = f.lastSyncCachePaths
+	if len(f.lastSyncCacheKeys) > 0 {
+		st.LastSyncCacheSampleKeys = append([]string(nil), f.lastSyncCacheKeys...)
+	}
+	f.snapMu.RUnlock()
+	return st
+}
+
+// FeedString returns the stable string label for a feed constant.
+// Used by Status / RefreshNow so RPC clients don't need to import the
+// Feed integer enum.
+func FeedString(feed Feed) string {
+	switch feed {
+	case FeedTPDMetrics:
+		return "tpd-metrics"
+	case FeedTPDUptime:
+		return "tpd-uptime"
+	case FeedSDServices:
+		return "sd-services"
+	case FeedDMSGDClientsByServer:
+		return "dmsgd-clients-by-server"
+	case FeedTPDAllTransports:
+		return "tpd-all-transports"
+	}
+	return fmt.Sprintf("feed#%d", feed)
+}
+
+// FeedFromString is the inverse of FeedString. Returns ok=false
+// for any unrecognized name.
+func FeedFromString(name string) (Feed, bool) {
+	switch name {
+	case "tpd-metrics":
+		return FeedTPDMetrics, true
+	case "tpd-uptime":
+		return FeedTPDUptime, true
+	case "sd-services":
+		return FeedSDServices, true
+	case "dmsgd-clients-by-server":
+		return FeedDMSGDClientsByServer, true
+	case "tpd-all-transports":
+		return FeedTPDAllTransports, true
+	}
+	return 0, false
+}
+
+// LastError returns the sticky last error seen by syncOnce on a
+// feed, or nil if the most recent cycle succeeded (or no cycle has
+// ever run). Exposed for /health-style introspection.
+func (m *Manager) LastError(feed Feed) error {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	f, ok := m.feeds[feed]
+	m.mu.Unlock()
+	if !ok || f == nil {
+		return nil
+	}
+	f.snapMu.RLock()
+	defer f.snapMu.RUnlock()
+	return f.lastErr
+}
+
+// acquireFeedLocked must be called under m.mu.
+func (m *Manager) acquireFeedLocked(fk Feed) {
+	f, ok := m.feeds[fk]
+	if !ok {
+		f = &managedFeed{}
+		m.feeds[fk] = f
+	}
+	f.refcount++
+	if f.stopTimer != nil {
+		f.stopTimer.Stop()
+		f.stopTimer = nil
+	}
+	if f.cancel == nil {
+		// First reference: start the cycle goroutine. cancel is
+		// stashed on the feed and called from releaseFeedLocked
+		// (via the grace timer) or Close — gosec's "context cancel
+		// not called" check can't see across the timer hop.
+		ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec
+		f.cancel = cancel
+		f.done = make(chan struct{})
+		go m.cycleLoop(ctx, fk, f)
+	}
+}
+
+// releaseFeedLocked must be called under m.mu.
+func (m *Manager) releaseFeedLocked(fk Feed) {
+	f, ok := m.feeds[fk]
+	if !ok {
+		return
+	}
+	if f.refcount > 0 {
+		f.refcount--
+	}
+	if f.refcount > 0 {
+		return
+	}
+	// refcount hit zero — schedule cycle stop after grace. A fresh
+	// acquire before the timer fires cancels it.
+	if f.stopTimer != nil {
+		return
+	}
+	feed := fk
+	f.stopTimer = time.AfterFunc(m.grace, func() {
+		m.mu.Lock()
+		ff, ok := m.feeds[feed]
+		if !ok || ff.refcount > 0 {
+			if ff != nil {
+				ff.stopTimer = nil
+			}
+			m.mu.Unlock()
+			return
+		}
+		cancel := ff.cancel
+		done := ff.done
+		ff.cancel = nil
+		ff.done = nil
+		ff.stopTimer = nil
+		m.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
+		if done != nil {
+			<-done
+		}
+	})
+}
+
+// cycleLoop is the per-feed goroutine. Runs syncOnce immediately,
+// then on every `interval` tick, until ctx is canceled.
+func (m *Manager) cycleLoop(ctx context.Context, fk Feed, f *managedFeed) {
+	defer close(f.done)
+	m.syncOnce(ctx, fk, f)
+	t := time.NewTicker(m.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			m.syncOnce(ctx, fk, f)
+		}
+	}
+}
+
+// syncOnce performs a single subscribe → wait-for-first-Root →
+// snapshot → unsubscribe cycle. On any error the previous snapshot
+// is left in place; callers continue serving stale data until the
+// next cycle succeeds.
+func (m *Manager) syncOnce(ctx context.Context, fk Feed, f *managedFeed) {
+	dmsgC := m.dmsgClient()
+	if dmsgC == nil {
+		f.recordErr(errors.New("dmsg client not ready"))
+		return
+	}
+	peerPK, port, prefix, err := m.feedSpec(fk)
+	if err != nil {
+		f.recordErr(err)
+		return
+	}
+
+	sub, err := treestore.NewSubscriber(dmsgC, peerPK, treestore.SubConfig{
+		InMemoryDB: true,
+		DmsgPort:   port,
+	})
+	if err != nil {
+		f.recordErr(fmt.Errorf("create subscriber: %w", err))
+		return
+	}
+	sub.SetPrefixes([]string{prefix})
+
+	rootCh := make(chan struct{}, 1)
+	sub.OnUpdate(func(_ []treestore.UpdateEvent) {
+		select {
+		case rootCh <- struct{}{}:
+		default:
+		}
+	})
+
+	if err := sub.Connect(ctx, peerPK); err != nil {
+		_ = sub.Close() //nolint:errcheck
+		f.recordErr(fmt.Errorf("dial publisher: %w", err))
+		return
+	}
+
+	syncTimeout := FeedFirstSyncTimeout(fk)
+	select {
+	case <-rootCh:
+		// First Root arrived — proceed to snapshot.
+	case <-time.After(syncTimeout):
+		_ = sub.Close() //nolint:errcheck
+		f.recordErr(fmt.Errorf("timeout waiting for Root after %s", syncTimeout))
+		return
+	case <-ctx.Done():
+		_ = sub.Close() //nolint:errcheck
+		return
+	}
+
+	snapshot := make(map[string][]byte)
+	sub.Walk(prefix, func(path string, body []byte) bool {
+		// Walk passes a copy of body, so storing it is safe.
+		snapshot[path] = body
+		return true
+	})
+	// Capture the raw cache stats BEFORE Close so the FeedStatus
+	// discriminator (LastSyncCachePaths vs SnapshotPaths) is honest:
+	// cache>0 + snapshot=0 means the manager's prefix filter or
+	// snapshot copy dropped everything; both 0 means the publisher's
+	// Root was structurally empty.
+	cacheSize, cacheKeys := sub.CacheSizeAndSampleKeys(5)
+	_ = sub.Close() //nolint:errcheck
+
+	f.snapMu.Lock()
+	f.snapshot = snapshot
+	f.lastSyncAt = time.Now()
+	f.lastSyncCachePaths = cacheSize
+	f.lastSyncCacheKeys = cacheKeys
+	f.lastErr = nil
+	f.snapMu.Unlock()
+}
+
+// recordErr stores the error on the feed for LastError to surface.
+// Does not touch the snapshot — the previous one stays in place.
+func (f *managedFeed) recordErr(err error) {
+	f.snapMu.Lock()
+	f.lastErr = err
+	f.snapMu.Unlock()
+}
+
+// hasPathPrefix matches the semantics of the upstream
+// treestore.HasPrefix without the package import: empty prefix
+// matches everything, and the prefix must end at a path-segment
+// boundary (or the path must equal the prefix).
+func hasPathPrefix(path, prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	if path == prefix {
+		return true
+	}
+	if len(path) <= len(prefix) {
+		return false
+	}
+	if path[:len(prefix)] != prefix {
+		return false
+	}
+	// Allow either the prefix already includes a trailing '/', or the
+	// next char in path is '/'.
+	last := prefix[len(prefix)-1]
+	if last == '/' {
+		return true
+	}
+	return path[len(prefix)] == '/'
+}

--- a/pkg/tpviz/cxo_standalone.go
+++ b/pkg/tpviz/cxo_standalone.go
@@ -1,0 +1,141 @@
+// Package tpviz pkg/tpviz/cxo_standalone.go
+//
+// Standalone CXO wiring. When tp-viz runs OUTSIDE a visor (the reward
+// server serving theskywirenetwork.net over dmsg), it has no visor to
+// hand it a CXOSubMgr. SetCXOSubMgrFromDmsg builds an intermittent CXO
+// subscriber (pkg/cxo/cxosub) over the server's own dmsg client and
+// wires it in — so the standalone server sources TPD/SD/DMSG-D data from
+// the same CXO feeds the hypervisor uses, instead of HTTP-over-dmsg
+// polling. Feed publisher PKs are resolved from the config's dmsg://
+// service URLs (TPDURLDmsg / SDURLDmsg / DMSGURLDmsg).
+package tpviz
+
+import (
+	"fmt"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxosub"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// SetCXOSubMgrFromDmsg wires an intermittent CXO subscriber over dmsgC so a
+// STANDALONE tp-viz sources deployment data from the TPD/SD/DMSG-D CXO feeds.
+// No-op when dmsgC is nil. Keep any HTTP-over-dmsg client set via
+// SetDmsgHTTPClient as the fallback: tp-viz tries CXO first and falls through
+// on a cache miss (feed not yet synced), so the two compose safely.
+func (s *Server) SetCXOSubMgrFromDmsg(dmsgC *dmsg.Client) {
+	if dmsgC == nil {
+		return
+	}
+	tpd := parseCXOPeer(s.config.TPDURLDmsg)
+	sd := parseCXOPeer(s.config.SDURLDmsg)
+	dmsgd := parseCXOPeer(s.config.DMSGURLDmsg)
+
+	feedSpec := func(f cxosub.Feed) (cipher.PubKey, uint16, string, error) {
+		port, prefix, ok := cxosub.FeedRoute(f)
+		if !ok {
+			return cipher.PubKey{}, 0, "", fmt.Errorf("unknown feed %d", f)
+		}
+		var pk cipher.PubKey
+		switch f {
+		case cxosub.FeedTPDMetrics, cxosub.FeedTPDUptime, cxosub.FeedTPDAllTransports:
+			pk = tpd
+		case cxosub.FeedSDServices:
+			pk = sd
+		case cxosub.FeedDMSGDClientsByServer:
+			pk = dmsgd
+		}
+		if (pk == cipher.PubKey{}) {
+			return cipher.PubKey{}, 0, "", fmt.Errorf("no publisher PK for feed %d (dmsg service URL unset)", f)
+		}
+		return pk, port, prefix, nil
+	}
+
+	mgr := cxosub.NewManager(cxosub.Deps{
+		Dmsg:     func() *dmsg.Client { return dmsgC },
+		FeedSpec: feedSpec,
+		Log:      logging.MustGetLogger("tpviz-cxosub"),
+	}, 0) // 0 → default cycle interval
+	s.SetCXOSubMgr(&standaloneCXOAdapter{m: mgr})
+}
+
+// standaloneCXOAdapter bridges cxosub.Manager (typed Feed/Tab) to tp-viz's
+// int-based CXOSubMgr interface. Values match by construction.
+type standaloneCXOAdapter struct{ m *cxosub.Manager }
+
+func (a *standaloneCXOAdapter) AcquireForTab(tab int) { a.m.AcquireFor(cxosub.Tab(tab)) }
+func (a *standaloneCXOAdapter) ReleaseForTab(tab int) { a.m.ReleaseFor(cxosub.Tab(tab)) }
+func (a *standaloneCXOAdapter) Walk(feed int, prefix string, fn func(path string, body []byte) bool) bool {
+	return a.m.Walk(cxosub.Feed(feed), prefix, fn)
+}
+
+// parseCXOPeer extracts the publisher PK from a dmsg://<pk>:<port> service URL,
+// or the zero PubKey when raw is empty / not a dmsg URL (callers treat the zero
+// value as "unset" and skip that feed).
+func parseCXOPeer(raw string) cipher.PubKey {
+	if raw == "" {
+		return cipher.PubKey{}
+	}
+	var u dmsgcurl.URL
+	if err := u.Fill(raw); err != nil || u.Scheme != "dmsg" {
+		return cipher.PubKey{}
+	}
+	return u.Addr.PK
+}
+
+// tryCXOUptimes returns the []VisorSummary JSON from the TPD uptime feed's
+// local snapshot (any day-window leaf carries the current online status), or
+// ok=false when the manager isn't wired / the feed hasn't synced yet — in which
+// case the caller falls through to its HTTP fetch. The body is byte-identical to
+// what GET /uptimes?v=v2 serves, so it's forwarded to the UI unchanged.
+func (s *Server) tryCXOUptimes() ([]byte, bool) {
+	mgr := s.cxoMgr()
+	if mgr == nil {
+		return nil, false
+	}
+	mgr.AcquireForTab(CXOTabUptime)
+	defer mgr.ReleaseForTab(CXOTabUptime)
+
+	var out []byte
+	mgr.Walk(CXOFeedTPDUptime, "uptimes/days/", func(_ string, body []byte) bool {
+		if len(body) > 0 && string(body) != "null" {
+			out = append([]byte(nil), body...)
+			return false // first non-empty leaf is enough
+		}
+		return true
+	})
+	if out == nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// tryCXOTransports returns the all-transports JSON snapshot from the TPD
+// all-transports feed's local snapshot (the network-wide "without-self" leaf),
+// or ok=false on cache miss. The leaf body is the same JSON GET /all-transports
+// serves, so it forwards unchanged.
+func (s *Server) tryCXOTransports() ([]byte, bool) {
+	mgr := s.cxoMgr()
+	if mgr == nil {
+		return nil, false
+	}
+	mgr.AcquireForTab(CXOTabCLITransports)
+	defer mgr.ReleaseForTab(CXOTabCLITransports)
+
+	leaves := make(map[string][]byte, 2)
+	mgr.Walk(CXOFeedTPDAllTransports, "transports/all/", func(path string, body []byte) bool {
+		if len(body) > 0 {
+			leaves[path] = append([]byte(nil), body...)
+		}
+		return true
+	})
+	if b, ok := leaves["transports/all/without-self"]; ok {
+		return b, true
+	}
+	for _, b := range leaves { // any leaf beats a fallback HTTP round-trip
+		return b, true
+	}
+	return nil, false
+}

--- a/pkg/tpviz/cxo_subscriber.go
+++ b/pkg/tpviz/cxo_subscriber.go
@@ -23,17 +23,22 @@ import (
 )
 
 // Tab identifiers used in calls to CXOSubMgr.AcquireForTab /
-// ReleaseForTab. Values match pkg/visor.CXOTab; the hypervisor
-// adapter passes them through unchanged.
+// ReleaseForTab. Values match pkg/visor.CXOTab / cxosub.Tab; the
+// hypervisor adapter and the standalone adapter pass them through.
 const (
 	CXOTabNetworkVisualizer = 0
+	CXOTabUptime            = 2 // TPD uptime feed
+	CXOTabCLITransports     = 5 // TPD all-transports feed
 )
 
 // Feed identifiers used in calls to CXOSubMgr.Walk. Values match
-// pkg/visor.CXOFeed; the hypervisor adapter passes them through.
+// pkg/visor.CXOFeed / cxosub.Feed; the adapters pass them through.
 const (
+	CXOFeedTPDMetrics           = 0 // metrics/days/<n>
+	CXOFeedTPDUptime            = 1 // uptimes/days/<n> — []VisorSummary
 	CXOFeedSDServices           = 2 // services/<type>/<pk>/{entry,tombstone}
 	CXOFeedDMSGDClientsByServer = 3 // clients-by-server/<server>/<client>/{entry,tombstone}
+	CXOFeedTPDAllTransports     = 4 // transports/all/{with-self,without-self}
 )
 
 // CXOSubMgr is the minimal slice of pkg/visor.CXOSubscriptionManager

--- a/pkg/tpviz/tpviz.go
+++ b/pkg/tpviz/tpviz.go
@@ -748,6 +748,17 @@ func (s *Server) handleTransports(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// CXO-first (standalone): the TPD publishes the all-transports snapshot on
+	// its CXO feed. Serve from the subscriber's local snapshot when wired; fall
+	// through to the HTTP fetch below on a cache miss.
+	if body, ok := s.tryCXOTransports(); ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("X-Skywire-Source", "cxo")
+		w.Write(body) //nolint:errcheck,gosec
+		return
+	}
+
 	// Standalone mode (no visor): fetch from the operator-supplied TPDURL.
 	tpdURL := s.config.TPDURL + "/all-transports"
 	cacheFile := CacheFilePath(s.config.CacheDirTPD, tpdURL)
@@ -765,6 +776,16 @@ func (s *Server) handleTransports(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleUptimes(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	// CXO-first: the TPD publishes []VisorSummary on its uptime feed. When a CXO
+	// subscriber is wired (standalone reward server via SetCXOSubMgrFromDmsg, or
+	// the hypervisor), serve from its local snapshot; fall through to the HTTP
+	// fetch below on a cache miss (feed not yet synced).
+	if body, ok := s.tryCXOUptimes(); ok {
+		w.Header().Set("X-Skywire-Source", "cxo")
+		w.Write(body) //nolint:errcheck,gosec
+		return
+	}
 
 	// Uptime now comes from the TPD-integrated uptime tracker; the standalone
 	// uptime tracker was decommissioned. Prefer an operator-supplied UTURL for

--- a/pkg/visor/api_fetch_cxo.go
+++ b/pkg/visor/api_fetch_cxo.go
@@ -147,7 +147,7 @@ func (v *Visor) CXORefreshFeed(args CXORefreshArgs) (*FeedStatus, error) {
 	}
 	timeout := args.Timeout
 	if timeout <= 0 {
-		timeout = firstSyncTimeout + 5*time.Second
+		timeout = feedFirstSyncTimeout(feed) + 5*time.Second
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -1,187 +1,83 @@
 // Package visor pkg/visor/cxo_subscription_manager.go
 //
-// Cycle-based on-demand CXO sync manager.
+// Thin visor-side shim over the reusable pkg/cxo/cxosub cycle-based
+// CXO sync manager. The implementation lives in cxosub, decoupled
+// from *Visor via cxosub.Deps; this file only:
 //
-// The hypervisor's network visualizer / metrics tabs and the visor's
-// own autoconnect / CLI listing commands all want a recent snapshot
-// of network-wide state from one of the deployment-side CXO
-// publishers (TPD's metrics + uptime aggregates, SD's services tree,
-// DMSG-D's clients-by-server tree). Keeping a long-lived subscription
-// alive is wasteful — most of those updates are noise to a UI that
-// might be open for a few seconds at a time, and a subscription that
-// was open across a publisher restart goes silently stale because
-// `treestore.Subscriber.Connect` is one-shot with no built-in
-// reconnect.
+//   - re-exports the cxosub types/consts under their historical
+//     visor names (CXOFeed, CXOTab, CXOSubscriptionManager, the
+//     FeedXxx/TabXxx consts, FeedStatus) so existing callers compile
+//     unchanged, and
+//   - supplies the visor's dependency wiring: the live dmsg client
+//     accessor and the feed → (peerPK, port, prefix) resolver that
+//     reads service publisher PKs out of the visor config.
 //
-// This manager runs each feed as a periodic *cycle*:
-//
-//	subscribe → wait for first Root → walk into local snapshot
-//	→ unsubscribe → sleep `interval` → repeat
-//
-// Cycles only run while at least one consumer holds the feed via
-// AcquireFor. When the last release happens the cycle stops on the
-// next interval boundary (with a small grace), so a fast acquire-
-// release-acquire reuses the running cycle without re-dialing.
-//
-// Get / Walk read the *snapshot*, not a live subscriber — so the
-// data they see is always at most `interval`-old, never tied to a
-// dmsg session that may have died. A publisher restart self-heals
-// on the next sync because each cycle dials fresh.
+// The manager's cycle semantics are documented in the cxosub package.
 package visor
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
-	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/cxo/cxosub"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
-// CXOFeed identifies one upstream CXO publisher feed the manager can
-// sync from. Adding a new feed means: add a const here, a case in
-// feedSpec, and a tab → feeds dependency entry below.
-type CXOFeed int
-
-const (
-	// FeedTPDMetrics is TPD's metrics-aggregate publisher
-	// (metrics/days/<n>).
-	FeedTPDMetrics CXOFeed = iota
-	// FeedTPDUptime is TPD's uptime-aggregate publisher
-	// (uptimes/days/<n>).
-	FeedTPDUptime
-	// FeedSDServices is SD's services publisher
-	// (services/<type>/<pk>/{entry,tombstone}).
-	FeedSDServices
-	// FeedDMSGDClientsByServer is DMSG-D's clients-by-server publisher
-	// (clients-by-server/<server>/<client>/{entry,tombstone}).
-	FeedDMSGDClientsByServer
-	// FeedTPDAllTransports is TPD's all-transports snapshot publisher
-	// (transports/all/{with-self,without-self}). Used by the CLI's
-	// `pv -t`, `tp tree`, `tp viz` commands as a CXO alternative to
-	// HTTP-polling /all-transports.
-	FeedTPDAllTransports
+// Re-exported types so existing pkg/visor callers keep working.
+type (
+	// CXOFeed identifies one upstream CXO publisher feed.
+	CXOFeed = cxosub.Feed
+	// CXOTab identifies a consumer of one or more CXO feeds.
+	CXOTab = cxosub.Tab
+	// CXOSubscriptionManager is the visor's alias for cxosub.Manager.
+	CXOSubscriptionManager = cxosub.Manager
+	// FeedStatus is one row of CXOSubscriptionManager.Status.
+	FeedStatus = cxosub.FeedStatus
 )
 
-// CXOTab identifies a consumer of one or more CXO feeds. Tabs in the
-// hypervisor UI map onto tabs here directly; non-UI consumers
-// (autoconnect, CLI commands) get their own tab kinds.
-type CXOTab int
-
+// Re-exported feed constants.
 const (
-	// TabNetworkVisualizer is the network visualizer tab — needs SD
-	// services + DMSG-D clients-by-server + TPD metrics.
-	TabNetworkVisualizer CXOTab = iota
-	// TabMetrics is the metrics tab — TPD metrics + TPD uptime.
-	TabMetrics
-	// TabUptime is the network uptime tab — TPD uptime only.
-	TabUptime
-	// TabAutoconnect is the visor's public-visor autoconnect cycle —
-	// SD services only (filters down to the visor type at walk time).
-	TabAutoconnect
-	// TabCLIServices is the operator-facing service-listing CLI
-	// commands (`skywire cli proxy list`, `vpn list`, `pv`). Same
-	// SD services feed; refcount summed with TabAutoconnect when
-	// both are active so they share the running cycle.
-	TabCLIServices
-	// TabCLITransports is the operator-facing transport-listing CLI
-	// commands (`pv -t`, `tp tree`, `tp viz`). Maps to the TPD
-	// all-transports feed.
-	TabCLITransports
-	// TabRoutingPolicy is the operator-programmable routing-policy
-	// provider's SD-services consumer. Needed so the policy script's
-	// geo.country(pk) can resolve multihop intermediates that
-	// advertise themselves as proxy/vpn/visor services.
-	TabRoutingPolicy
+	FeedTPDMetrics           = cxosub.FeedTPDMetrics
+	FeedTPDUptime            = cxosub.FeedTPDUptime
+	FeedSDServices           = cxosub.FeedSDServices
+	FeedDMSGDClientsByServer = cxosub.FeedDMSGDClientsByServer
+	FeedTPDAllTransports     = cxosub.FeedTPDAllTransports
 )
 
-// tabFeedDeps maps each tab to the set of feeds it depends on.
-// Acquire / Release walks this list; a feed shared between tabs has
-// its refcount summed across them.
-var tabFeedDeps = map[CXOTab][]CXOFeed{
-	TabNetworkVisualizer: {FeedSDServices, FeedDMSGDClientsByServer, FeedTPDMetrics},
-	TabMetrics:           {FeedTPDMetrics, FeedTPDUptime},
-	TabUptime:            {FeedTPDUptime},
-	TabAutoconnect:       {FeedSDServices},
-	TabCLIServices:       {FeedSDServices},
-	TabCLITransports:     {FeedTPDAllTransports},
-	TabRoutingPolicy:     {FeedSDServices},
-}
+// Re-exported tab constants.
+const (
+	TabNetworkVisualizer = cxosub.TabNetworkVisualizer
+	TabMetrics           = cxosub.TabMetrics
+	TabUptime            = cxosub.TabUptime
+	TabAutoconnect       = cxosub.TabAutoconnect
+	TabCLIServices       = cxosub.TabCLIServices
+	TabCLITransports     = cxosub.TabCLITransports
+	TabRoutingPolicy     = cxosub.TabRoutingPolicy
+)
 
-// CXOSubscriptionManager owns the per-feed cycle goroutines + the
-// in-memory snapshots they populate. Constructed lazily by
-// Visor.CXOSubMgr() on first use.
-type CXOSubscriptionManager struct {
-	v        *Visor
-	log      *logging.Logger
-	interval time.Duration // cycle period (cxo_subscribe_interval)
-	grace    time.Duration // delay after last release before stopping the cycle
+// feedFirstSyncTimeout forwards to cxosub so the RPC fetch/refresh default
+// timeout is per-feed (the all-transports feed needs longer than the rest).
+var feedFirstSyncTimeout = cxosub.FeedFirstSyncTimeout
 
-	mu    sync.Mutex
-	feeds map[CXOFeed]*managedFeed
-}
+// CXOFeedFromString is the inverse of the feed string label. Kept as a
+// visor-package alias for existing callers.
+var CXOFeedFromString = cxosub.FeedFromString
 
-// managedFeed holds a single feed's runtime state.
-type managedFeed struct {
-	// Snapshot data — populated by syncOnce, read by Get / Walk.
-	snapMu     sync.RWMutex
-	snapshot   map[string][]byte
-	lastSyncAt time.Time
-	lastErr    error // sticky last error from syncOnce; cleared on success
-	// lastSyncCachePaths / lastSyncCacheKeys: discriminator for empty
-	// snapshots (publisher sent empty Root vs manager-side filter
-	// dropped everything). Captured in syncOnce right before
-	// sub.Close. Surfaced via FeedStatus for `cxo status`.
-	lastSyncCachePaths int
-	lastSyncCacheKeys  []string
-
-	// Lifecycle (mutated only under manager.mu).
-	refcount  int
-	cancel    context.CancelFunc // stops the cycle goroutine
-	done      chan struct{}      // closed when the cycle goroutine exits
-	stopTimer *time.Timer        // pending grace-expiry stop
-}
-
-// defaultCXOSubscribeInterval is the cycle period when the operator
-// hasn't set hypervisor.cxo_subscribe_interval. 5min matches the
-// "no more than once every 5 min" intent.
-const defaultCXOSubscribeInterval = 5 * time.Minute
-
-// cxoTabCloseGrace is how long after the refcount falls to zero we
-// keep running the cycle. 10s smooths over UI tab navigation flicker
-// without leaking a long idle subscription.
-const cxoTabCloseGrace = 10 * time.Second
-
-// firstSyncTimeout bounds how long syncOnce waits for the first Root
-// after Connect. After this the subscriber is closed and the cycle
-// records an error; the next cycle (or an explicit AcquireFor that
-// triggers a sync) retries from scratch. Long enough to ride out a
-// dmsg-session reconnect, short enough that a UI Acquire on a dead
-// publisher returns its cache-miss within ~10s.
-const firstSyncTimeout = 10 * time.Second
-
-// NewCXOSubscriptionManager constructs an idle manager. interval
-// comes from hypervisor.cxo_subscribe_interval; <= 0 falls back to
-// defaultCXOSubscribeInterval.
+// NewCXOSubscriptionManager constructs a manager wired to the visor:
+// the live dmsg client accessor and the visor's feed resolver. interval
+// comes from hypervisor.cxo_subscribe_interval; <= 0 falls back to the
+// cxosub default. log nil falls back to a default package logger.
 func NewCXOSubscriptionManager(v *Visor, interval time.Duration, log *logging.Logger) *CXOSubscriptionManager {
-	if interval <= 0 {
-		interval = defaultCXOSubscribeInterval
-	}
-	if log == nil {
-		log = logging.MustGetLogger("cxo_subscription_manager")
-	}
-	return &CXOSubscriptionManager{
-		v:        v,
-		log:      log,
-		interval: interval,
-		grace:    cxoTabCloseGrace,
-		feeds:    make(map[CXOFeed]*managedFeed),
-	}
+	return cxosub.NewManager(cxosub.Deps{
+		Dmsg:     func() *dmsg.Client { return v.dmsgC },
+		FeedSpec: v.cxoFeedSpec,
+		Log:      log,
+	}, interval)
 }
 
 // CXOSubMgr returns the visor's manager, constructing it lazily on
@@ -198,7 +94,7 @@ func (v *Visor) CXOSubMgr() *CXOSubscriptionManager {
 	if v.dmsgC == nil {
 		return nil
 	}
-	interval := defaultCXOSubscribeInterval
+	var interval time.Duration // 0 => cxosub default
 	if v.conf != nil && v.conf.Hypervisor != nil {
 		if d := time.Duration(v.conf.Hypervisor.CXOSubscribeInterval); d > 0 {
 			interval = d
@@ -208,534 +104,37 @@ func (v *Visor) CXOSubMgr() *CXOSubscriptionManager {
 	return v.cxoSubMgr
 }
 
-// AcquireFor signals that a consumer is about to read from the
-// feeds a tab depends on. Idempotent across multiple holders;
-// refcount sums. On the first acquire of a feed, the cycle goroutine
-// starts and a sync is kicked off immediately so the snapshot has a
-// chance to populate before the caller's first Get / Walk. (Whether
-// it actually does depends on dmsg session readiness; callers handle
-// the cache-miss case by falling through to HTTP.)
-func (m *CXOSubscriptionManager) AcquireFor(tab CXOTab) {
-	if m == nil {
-		return
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for _, fk := range tabFeedDeps[tab] {
-		m.acquireFeedLocked(fk)
-	}
-}
-
-// ReleaseFor signals that a consumer is done. Drops the refcount on
-// each feed the tab depends on. Feeds whose refcount falls to zero
-// schedule their cycle goroutine to stop after the grace period —
-// during which a fresh AcquireFor cancels the stop and reuses the
-// running cycle.
-func (m *CXOSubscriptionManager) ReleaseFor(tab CXOTab) {
-	if m == nil {
-		return
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for _, fk := range tabFeedDeps[tab] {
-		m.releaseFeedLocked(fk)
-	}
-}
-
-// Get returns the cached body for (feed, path) plus the timestamp of
-// the most recent successful sync, or ok=false if the feed has no
-// snapshot yet (no acquire ever happened, the first cycle hasn't
-// completed, or every cycle failed). Callers handle ok=false by
-// falling through to HTTP.
-func (m *CXOSubscriptionManager) Get(feed CXOFeed, path string) ([]byte, time.Time, bool) {
-	if m == nil {
-		return nil, time.Time{}, false
-	}
-	m.mu.Lock()
-	f, ok := m.feeds[feed]
-	m.mu.Unlock()
-	if !ok || f == nil {
-		return nil, time.Time{}, false
-	}
-	f.snapMu.RLock()
-	defer f.snapMu.RUnlock()
-	if f.snapshot == nil {
-		return nil, time.Time{}, false
-	}
-	body, ok := f.snapshot[path]
-	if !ok || len(body) == 0 {
-		return nil, time.Time{}, false
-	}
-	out := make([]byte, len(body))
-	copy(out, body)
-	return out, f.lastSyncAt, true
-}
-
-// Walk invokes fn for every (path, body) in the feed's cached
-// snapshot whose path begins with prefix. Returns ok=false (with fn
-// never called) if the feed has no snapshot. Bodies passed to fn
-// are owned by the snapshot — callers must copy if they need to
-// retain bytes after fn returns.
-func (m *CXOSubscriptionManager) Walk(feed CXOFeed, prefix string, fn func(path string, body []byte) bool) bool {
-	if m == nil {
-		return false
-	}
-	m.mu.Lock()
-	f, ok := m.feeds[feed]
-	m.mu.Unlock()
-	if !ok || f == nil {
-		return false
-	}
-	f.snapMu.RLock()
-	defer f.snapMu.RUnlock()
-	if len(f.snapshot) == 0 {
-		return false
-	}
-	for path, body := range f.snapshot {
-		if prefix != "" && !hasPathPrefix(path, prefix) {
-			continue
-		}
-		if !fn(path, body) {
-			return true
-		}
-	}
-	return true
-}
-
-// Close stops every active cycle and drops every snapshot. Called
-// from the visor's shutdown sequence.
-func (m *CXOSubscriptionManager) Close() {
-	if m == nil {
-		return
-	}
-	m.mu.Lock()
-	feeds := make([]*managedFeed, 0, len(m.feeds))
-	for _, f := range m.feeds {
-		if f.stopTimer != nil {
-			f.stopTimer.Stop()
-			f.stopTimer = nil
-		}
-		feeds = append(feeds, f)
-	}
-	m.feeds = make(map[CXOFeed]*managedFeed)
-	m.mu.Unlock()
-	for _, f := range feeds {
-		if f.cancel != nil {
-			f.cancel()
-		}
-		if f.done != nil {
-			<-f.done
-		}
-	}
-}
-
-// FeedStatus is one row of CXOSubscriptionManager.Status. Tells the
-// operator everything needed to decide whether a CXO miss is "the
-// snapshot is genuinely empty", "the cycle has never run", or "the
-// cycle keeps failing for reason X". Exposed via the visor RPC so
-// `skywire cli visor cxo status` can render it.
-type FeedStatus struct {
-	// Feed is the FeedXxx constant's stable string name (matches the
-	// label CXOFeedString returns).
-	Feed string
-	// PeerPK is the publisher's PK (or empty if not configured).
-	PeerPK string
-	// DmsgPort is the publisher's CXO port.
-	DmsgPort uint16
-	// Prefix is the TreeStore path prefix this feed walks under.
-	Prefix string
-	// SnapshotPaths is the number of (path, body) entries currently
-	// cached. 0 + LastSyncAt zero means "no cycle has ever completed".
-	SnapshotPaths int
-	// SnapshotBytes is the sum of body lengths in the snapshot. Quick
-	// "how much memory is this feed using" check.
-	SnapshotBytes int
-	// LastSyncAt is the wall-clock time of the most recent successful
-	// sync. Zero when no cycle has ever finished cleanly.
-	LastSyncAt time.Time
-	// LastErr is the sticky last error from syncOnce, cleared on
-	// success. Empty when the most recent cycle worked.
-	LastErr string
-	// Refcount is the number of holders that have currently AcquireFor'd
-	// this feed without releasing it. >0 means a cycle is running.
-	Refcount int
-	// CycleRunning is true while the per-feed goroutine is alive (i.e.
-	// inside its tick loop). Goes false during the grace-period close.
-	CycleRunning bool
-	// SpecErr is non-empty if feedSpec couldn't resolve the publisher
-	// (e.g. SD CXO peer not configured) — meaning the feed can never
-	// sync until the visor config is fixed.
-	SpecErr string
-	// LastSyncCachePaths is len(sub.cache) snapshotted right before the
-	// most recent syncOnce closed its subscriber. Discriminator for
-	// "SnapshotPaths=0 with no error": when this is also 0 the
-	// publisher's Root was structurally empty; when this is >0 but
-	// SnapshotPaths=0 the manager's snapshot copy / prefix filter is
-	// the culprit.
-	LastSyncCachePaths int
-	// LastSyncCacheSampleKeys is up to 5 keys from sub.cache at the
-	// moment LastSyncCachePaths was captured. Lets the operator
-	// eyeball whether the publisher is writing the paths the
-	// subscriber's prefix expects.
-	LastSyncCacheSampleKeys []string
-}
-
-// Status returns a snapshot of every feed the manager knows about
-// (i.e. every feed someone has ever acquired). Feeds that were never
-// touched don't appear; callers should treat absence as "no cycle
-// ever started". Safe to call on a nil receiver — returns nil.
-func (m *CXOSubscriptionManager) Status() []FeedStatus {
-	if m == nil {
-		return nil
-	}
-	m.mu.Lock()
-	out := make([]FeedStatus, 0, len(m.feeds))
-	for fk, f := range m.feeds {
-		st := FeedStatus{Feed: CXOFeedString(fk)}
-		if pk, port, prefix, err := m.feedSpec(fk); err != nil {
-			st.SpecErr = err.Error()
-		} else {
-			st.PeerPK = pk.Hex()
-			st.DmsgPort = port
-			st.Prefix = prefix
-		}
-		st.Refcount = f.refcount
-		st.CycleRunning = f.cancel != nil
-		f.snapMu.RLock()
-		st.SnapshotPaths = len(f.snapshot)
-		for _, body := range f.snapshot {
-			st.SnapshotBytes += len(body)
-		}
-		st.LastSyncAt = f.lastSyncAt
-		if f.lastErr != nil {
-			st.LastErr = f.lastErr.Error()
-		}
-		st.LastSyncCachePaths = f.lastSyncCachePaths
-		if len(f.lastSyncCacheKeys) > 0 {
-			st.LastSyncCacheSampleKeys = append([]string(nil), f.lastSyncCacheKeys...)
-		}
-		f.snapMu.RUnlock()
-		out = append(out, st)
-	}
-	m.mu.Unlock()
-	return out
-}
-
-// RefreshNow forces a fresh subscribe → first-Root → walk cycle for
-// `feed` and blocks until either the cycle reports success/failure or
-// the caller's ctx expires. Unlike AcquireFor — which starts a cycle
-// goroutine and returns immediately, leaving the caller racing the
-// first sync — this is synchronous: the returned FeedStatus reflects
-// the snapshot AFTER the sync attempt. Used by `skywire cli visor cxo
-// refresh` so an operator can deterministically test "can this visor
-// actually reach the publisher right now".
-//
-// The cycle goroutine started by AcquireFor (if any) is left alone;
-// this opens its own short-lived subscriber.
-func (m *CXOSubscriptionManager) RefreshNow(ctx context.Context, feed CXOFeed) (FeedStatus, error) {
-	if m == nil {
-		return FeedStatus{}, errors.New("cxo manager not initialized (no DMSG client?)")
-	}
-	m.mu.Lock()
-	f, ok := m.feeds[feed]
-	if !ok {
-		f = &managedFeed{}
-		m.feeds[feed] = f
-	}
-	m.mu.Unlock()
-	m.syncOnce(ctx, feed, f)
-	st := m.statusFor(feed, f)
-	if f.lastErr != nil {
-		return st, f.lastErr
-	}
-	return st, nil
-}
-
-// statusFor builds a FeedStatus for one feed under the manager's lock
-// discipline. Pulled out so Status() and RefreshNow() share one
-// implementation.
-func (m *CXOSubscriptionManager) statusFor(fk CXOFeed, f *managedFeed) FeedStatus {
-	st := FeedStatus{Feed: CXOFeedString(fk)}
-	if pk, port, prefix, err := m.feedSpec(fk); err != nil {
-		st.SpecErr = err.Error()
-	} else {
-		st.PeerPK = pk.Hex()
-		st.DmsgPort = port
-		st.Prefix = prefix
-	}
-	m.mu.Lock()
-	st.Refcount = f.refcount
-	st.CycleRunning = f.cancel != nil
-	m.mu.Unlock()
-	f.snapMu.RLock()
-	st.SnapshotPaths = len(f.snapshot)
-	for _, body := range f.snapshot {
-		st.SnapshotBytes += len(body)
-	}
-	st.LastSyncAt = f.lastSyncAt
-	if f.lastErr != nil {
-		st.LastErr = f.lastErr.Error()
-	}
-	st.LastSyncCachePaths = f.lastSyncCachePaths
-	if len(f.lastSyncCacheKeys) > 0 {
-		st.LastSyncCacheSampleKeys = append([]string(nil), f.lastSyncCacheKeys...)
-	}
-	f.snapMu.RUnlock()
-	return st
-}
-
-// CXOFeedString returns the stable string label for a feed constant.
-// Used by Status / RefreshNow so RPC clients don't need to import the
-// CXOFeed integer enum.
-func CXOFeedString(feed CXOFeed) string {
-	switch feed {
-	case FeedTPDMetrics:
-		return "tpd-metrics"
-	case FeedTPDUptime:
-		return "tpd-uptime"
-	case FeedSDServices:
-		return "sd-services"
-	case FeedDMSGDClientsByServer:
-		return "dmsgd-clients-by-server"
-	case FeedTPDAllTransports:
-		return "tpd-all-transports"
-	}
-	return fmt.Sprintf("feed#%d", feed)
-}
-
-// CXOFeedFromString is the inverse of CXOFeedString. Returns ok=false
-// for any unrecognized name.
-func CXOFeedFromString(name string) (CXOFeed, bool) {
-	switch name {
-	case "tpd-metrics":
-		return FeedTPDMetrics, true
-	case "tpd-uptime":
-		return FeedTPDUptime, true
-	case "sd-services":
-		return FeedSDServices, true
-	case "dmsgd-clients-by-server":
-		return FeedDMSGDClientsByServer, true
-	case "tpd-all-transports":
-		return FeedTPDAllTransports, true
-	}
-	return 0, false
-}
-
-// LastError returns the sticky last error seen by syncOnce on a
-// feed, or nil if the most recent cycle succeeded (or no cycle has
-// ever run). Exposed for /health-style introspection.
-func (m *CXOSubscriptionManager) LastError(feed CXOFeed) error {
-	if m == nil {
-		return nil
-	}
-	m.mu.Lock()
-	f, ok := m.feeds[feed]
-	m.mu.Unlock()
-	if !ok || f == nil {
-		return nil
-	}
-	f.snapMu.RLock()
-	defer f.snapMu.RUnlock()
-	return f.lastErr
-}
-
-// acquireFeedLocked must be called under m.mu.
-func (m *CXOSubscriptionManager) acquireFeedLocked(fk CXOFeed) {
-	f, ok := m.feeds[fk]
-	if !ok {
-		f = &managedFeed{}
-		m.feeds[fk] = f
-	}
-	f.refcount++
-	if f.stopTimer != nil {
-		f.stopTimer.Stop()
-		f.stopTimer = nil
-	}
-	if f.cancel == nil {
-		// First reference: start the cycle goroutine. cancel is
-		// stashed on the feed and called from releaseFeedLocked
-		// (via the grace timer) or Close — gosec's "context cancel
-		// not called" check can't see across the timer hop.
-		ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec
-		f.cancel = cancel
-		f.done = make(chan struct{})
-		go m.cycleLoop(ctx, fk, f)
-	}
-}
-
-// releaseFeedLocked must be called under m.mu.
-func (m *CXOSubscriptionManager) releaseFeedLocked(fk CXOFeed) {
-	f, ok := m.feeds[fk]
-	if !ok {
-		return
-	}
-	if f.refcount > 0 {
-		f.refcount--
-	}
-	if f.refcount > 0 {
-		return
-	}
-	// refcount hit zero — schedule cycle stop after grace. A fresh
-	// acquire before the timer fires cancels it.
-	if f.stopTimer != nil {
-		return
-	}
-	feed := fk
-	f.stopTimer = time.AfterFunc(m.grace, func() {
-		m.mu.Lock()
-		ff, ok := m.feeds[feed]
-		if !ok || ff.refcount > 0 {
-			if ff != nil {
-				ff.stopTimer = nil
-			}
-			m.mu.Unlock()
-			return
-		}
-		cancel := ff.cancel
-		done := ff.done
-		ff.cancel = nil
-		ff.done = nil
-		ff.stopTimer = nil
-		m.mu.Unlock()
-		if cancel != nil {
-			cancel()
-		}
-		if done != nil {
-			<-done
-		}
-	})
-}
-
-// cycleLoop is the per-feed goroutine. Runs syncOnce immediately,
-// then on every `interval` tick, until ctx is canceled.
-func (m *CXOSubscriptionManager) cycleLoop(ctx context.Context, fk CXOFeed, f *managedFeed) {
-	defer close(f.done)
-	m.syncOnce(ctx, fk, f)
-	t := time.NewTicker(m.interval)
-	defer t.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.C:
-			m.syncOnce(ctx, fk, f)
-		}
-	}
-}
-
-// syncOnce performs a single subscribe → wait-for-first-Root →
-// snapshot → unsubscribe cycle. On any error the previous snapshot
-// is left in place; callers continue serving stale data until the
-// next cycle succeeds.
-func (m *CXOSubscriptionManager) syncOnce(ctx context.Context, fk CXOFeed, f *managedFeed) {
-	if m.v.dmsgC == nil {
-		f.recordErr(errors.New("dmsg client not ready"))
-		return
-	}
-	peerPK, port, prefix, err := m.feedSpec(fk)
-	if err != nil {
-		f.recordErr(err)
-		return
-	}
-
-	sub, err := treestore.NewSubscriber(m.v.dmsgC, peerPK, treestore.SubConfig{
-		InMemoryDB: true,
-		DmsgPort:   port,
-	})
-	if err != nil {
-		f.recordErr(fmt.Errorf("create subscriber: %w", err))
-		return
-	}
-	sub.SetPrefixes([]string{prefix})
-
-	rootCh := make(chan struct{}, 1)
-	sub.OnUpdate(func(_ []treestore.UpdateEvent) {
-		select {
-		case rootCh <- struct{}{}:
-		default:
-		}
-	})
-
-	if err := sub.Connect(ctx, peerPK); err != nil {
-		_ = sub.Close() //nolint:errcheck
-		f.recordErr(fmt.Errorf("dial publisher: %w", err))
-		return
-	}
-
-	select {
-	case <-rootCh:
-		// First Root arrived — proceed to snapshot.
-	case <-time.After(firstSyncTimeout):
-		_ = sub.Close() //nolint:errcheck
-		f.recordErr(fmt.Errorf("timeout waiting for Root after %s", firstSyncTimeout))
-		return
-	case <-ctx.Done():
-		_ = sub.Close() //nolint:errcheck
-		return
-	}
-
-	snapshot := make(map[string][]byte)
-	sub.Walk(prefix, func(path string, body []byte) bool {
-		// Walk passes a copy of body, so storing it is safe.
-		snapshot[path] = body
-		return true
-	})
-	// Capture the raw cache stats BEFORE Close so the FeedStatus
-	// discriminator (LastSyncCachePaths vs SnapshotPaths) is honest:
-	// cache>0 + snapshot=0 means the manager's prefix filter or
-	// snapshot copy dropped everything; both 0 means the publisher's
-	// Root was structurally empty.
-	cacheSize, cacheKeys := sub.CacheSizeAndSampleKeys(5)
-	_ = sub.Close() //nolint:errcheck
-
-	f.snapMu.Lock()
-	f.snapshot = snapshot
-	f.lastSyncAt = time.Now()
-	f.lastSyncCachePaths = cacheSize
-	f.lastSyncCacheKeys = cacheKeys
-	f.lastErr = nil
-	f.snapMu.Unlock()
-}
-
-// recordErr stores the error on the feed for LastError to surface.
-// Does not touch the snapshot — the previous one stays in place.
-func (f *managedFeed) recordErr(err error) {
-	f.snapMu.Lock()
-	f.lastErr = err
-	f.snapMu.Unlock()
-}
-
-// feedSpec returns the (peerPK, dmsgPort, pathPrefix) tuple for a
+// cxoFeedSpec returns the (peerPK, dmsgPort, pathPrefix) tuple for a
 // feed. Returns an error if the visor doesn't have the peer's PK
-// configured.
-func (m *CXOSubscriptionManager) feedSpec(fk CXOFeed) (cipher.PubKey, uint16, string, error) {
+// configured. This is the FeedSpec resolver injected into cxosub.
+func (v *Visor) cxoFeedSpec(fk cxosub.Feed) (cipher.PubKey, uint16, string, error) {
 	switch fk {
 	case FeedTPDMetrics:
-		pk, ok := tpdCXOPeer(m.v)
+		pk, ok := tpdCXOPeer(v)
 		if !ok {
 			return cipher.PubKey{}, 0, "", errors.New("no TPD CXO peer (transport.discovery_dmsg unset)")
 		}
 		return pk, skyenv.DmsgTPDMetricsCXOPort, "metrics/days/", nil
 	case FeedTPDUptime:
-		pk, ok := tpdCXOPeer(m.v)
+		pk, ok := tpdCXOPeer(v)
 		if !ok {
 			return cipher.PubKey{}, 0, "", errors.New("no TPD CXO peer (transport.discovery_dmsg unset)")
 		}
 		return pk, skyenv.DmsgTPDUptimeCXOPort, "uptimes/days/", nil
 	case FeedSDServices:
-		pk, ok := sdCXOPeer(m.v)
+		pk, ok := sdCXOPeer(v)
 		if !ok {
 			return cipher.PubKey{}, 0, "", errors.New("no SD CXO peer (launcher.service_discovery_dmsg unset)")
 		}
 		return pk, skyenv.DmsgSDServicesCXOPort, "services/", nil
 	case FeedDMSGDClientsByServer:
-		pk, ok := dmsgdCXOPeer(m.v)
+		pk, ok := dmsgdCXOPeer(v)
 		if !ok {
 			return cipher.PubKey{}, 0, "", errors.New("no DMSG-D CXO peer (dmsg.discovery_dmsg unset)")
 		}
 		return pk, skyenv.DmsgDMSGDClientsByServerCXOPort, "clients-by-server/", nil
 	case FeedTPDAllTransports:
-		pk, ok := tpdCXOPeer(m.v)
+		pk, ok := tpdCXOPeer(v)
 		if !ok {
 			return cipher.PubKey{}, 0, "", errors.New("no TPD CXO peer (transport.discovery_dmsg unset)")
 		}
@@ -771,30 +170,4 @@ func parseDmsgPeer(raw string) (cipher.PubKey, bool) {
 		return cipher.PubKey{}, false
 	}
 	return u.Addr.PK, true
-}
-
-// hasPathPrefix matches the semantics of the upstream
-// treestore.HasPrefix without the package import: empty prefix
-// matches everything, and the prefix must end at a path-segment
-// boundary (or the path must equal the prefix).
-func hasPathPrefix(path, prefix string) bool {
-	if prefix == "" {
-		return true
-	}
-	if path == prefix {
-		return true
-	}
-	if len(path) <= len(prefix) {
-		return false
-	}
-	if path[:len(prefix)] != prefix {
-		return false
-	}
-	// Allow either the prefix already includes a trailing '/', or the
-	// next char in path is '/'.
-	last := prefix[len(prefix)-1]
-	if last == '/' {
-		return true
-	}
-	return path[len(prefix)] == '/'
 }


### PR DESCRIPTION
Extracts the visor's intermittent CXO subscription manager (`pkg/visor/cxo_subscription_manager.go`, ~800 lines) into a new lightweight reusable package **`pkg/cxo/cxosub`**, decoupled from `*Visor` via injected `Deps{Dmsg, FeedSpec, Log}`. `pkg/visor` keeps working unchanged via type aliases + a thin `cxoFeedSpec` shim — netviz behavior + tests preserved.

Wires the **standalone reward server** (tp-viz serving theskywirenetwork.net over dmsg) to the same intermittent subscriber instead of HTTP-over-dmsg polling: `tpviz.SetCXOSubMgrFromDmsg` builds a `cxosub.Manager` over the server's dmsg client, resolving TPD/SD/DMSG-D publishers from the config's `dmsg://` service URLs. `handleUptimes` + `handleTransports` now try CXO first and fall back to HTTP-over-dmsg on a cache miss; services + dmsg-clients already had CXO walks that now activate.

**Fixes** the transport-graph showing ~9 of ~1011 visors (empty `/api/uptimes` → all "unknown" → hidden) via the *correct* mechanism — the TPD-integrated uptime feed over CXO, intermittent subscribe→snapshot→unsubscribe (self-heals across TPD restarts, no persistent subscriber state). Supersedes #3388 (kept as fallback). Design: `docs/tpviz-cxo-subscriber.md`.

Verified: `go build ./...`, `go vet`, `go test ./pkg/visor/...` (green), gofmt + goimports-reviser clean.