### PR TITLE
feat(wasm-hv): deep-link gateway — open a dmsg site full-page from a URL

### DIFF
--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -1402,6 +1402,65 @@
     // the app menu so any old caller still surfaces the launcher.
     function toggle() { menu.style.display = (menu.style.display === "block") ? "none" : "block"; }
 
+    // Deep-link: ?skynet=<target>[&kiosk=1] (or a #skynet=<target> hash fragment)
+    // opens the skynet browser straight to <target> over dmsg, optionally full-page
+    // (kiosk — hides the taskbar + maximizes so the site obscures the HV UI). Lets a
+    // clearnet redirect drop a visitor into a dmsg site: e.g. Caddy sends
+    // theskywirenetwork.net → skywire.theskywirenetwork.net/?skynet=rewards.dmsg&kiosk=1.
+    function readDeepLink() {
+      // hv-boot.js captured the query param before Angular could drop it — prefer
+      // that. Fall back to the live location (query / hash fragment) for callers
+      // (e.g. the native HV) that don't preload it.
+      try {
+        var pre = self.__SKYWIRE_DEEPLINK__ || (doc.defaultView || window).__SKYWIRE_DEEPLINK__;
+        if (pre && pre.target) { return { target: pre.target, kiosk: !!pre.kiosk }; }
+      } catch (e) {}
+      var loc = (doc.defaultView || window).location, qs = {};
+      try {
+        (loc.search || "").replace(/^\?/, "").split("&").forEach(function (kv) {
+          if (!kv) return;
+          var i = kv.indexOf("="), k = i < 0 ? kv : kv.slice(0, i), v = i < 0 ? "" : kv.slice(i + 1);
+          qs[decodeURIComponent(k)] = decodeURIComponent(v);
+        });
+        var h = loc.hash || "", m = h.match(/[#&]skynet=([^&]+)/);
+        if (m && !qs.skynet) { qs.skynet = decodeURIComponent(m[1]); }
+        if (/[#&]kiosk=1\b/.test(h)) { qs.kiosk = "1"; }
+      } catch (e) {}
+      if (!qs.skynet) { return null; }
+      return { target: qs.skynet, kiosk: qs.kiosk === "1" || qs.kiosk === "true" };
+    }
+    // whenVisorConnected fires cb once the wasm visor has a live dmsg session (so a
+    // fetch over dmsg won't just error), bounded to ~20s so a stuck visor still lands
+    // on the browser's own error page instead of hanging forever.
+    function whenVisorConnected(cb) {
+      var tries = 0;
+      (function poll() {
+        Promise.resolve().then(function () { return self.skywireVisor && self.skywireVisor.status(); })
+          .then(function (st) {
+            if ((st && (st.dmsg_connected || (st.dmsg_sessions | 0) > 0)) || tries > 40) { cb(); }
+            else { tries++; setTimeout(poll, 500); }
+          }).catch(function () { if (tries > 40) { cb(); } else { tries++; setTimeout(poll, 500); } });
+      })();
+    }
+    // enterKiosk hides the taskbar and maximizes the window to the full viewport so
+    // the browsed site fills the page, obscuring the HV UI. Exit by un-maximizing.
+    function enterKiosk(win) {
+      try {
+        doc.body.classList.add("skywire-kiosk");
+        bar.style.display = "none";
+        barTop = 0; barBottom = 0;
+        if (win && win.wb && win.wb.maximize) { win.wb.maximize(true); }
+      } catch (e) {}
+    }
+    try {
+      var dl = readDeepLink();
+      if (dl) {
+        var dlWin = openBrowse();
+        if (dl.kiosk) { enterKiosk(dlWin); }
+        whenVisorConnected(function () { try { dlWin.browser.browseTo(dl.target, "/"); } catch (e) {} });
+      }
+    } catch (e) {}
+
     return {
       panel: bar,
       toggle: toggle,

--- a/pkg/wasmhv/hv-boot.js
+++ b/pkg/wasmhv/hv-boot.js
@@ -16,6 +16,21 @@
 // the bare served HTML is a working serverless visor with zero configuration.
 (function () {
   var CFG = (window.__SKYWIRE_HV__ = window.__SKYWIRE_HV__ || {});
+  // Capture any deep-link params (?skynet=<target>[&kiosk=1]) NOW — this is the
+  // first script, so it runs before Angular's hash router boots and drops
+  // location.search. The skynet browser (browse.js mountPanel → readDeepLink)
+  // reads window.__SKYWIRE_DEEPLINK__ to open <target> over dmsg full-page on
+  // load. Lets a clearnet Caddy redirect land a visitor straight in a dmsg site.
+  try {
+    var dlp = new URLSearchParams(window.location.search || '');
+    var dlTarget = dlp.get('skynet');
+    if (dlTarget) {
+      window.__SKYWIRE_DEEPLINK__ = {
+        target: dlTarget,
+        kiosk: dlp.get('kiosk') === '1' || dlp.get('kiosk') === 'true',
+      };
+    }
+  } catch (e) {}
   // This tab is a full wasm-VISOR (edge + router + its own hypervisor); /api
   // resolves against the in-wasm core (globalThis.skywireVisor.hvApi).
   CFG.visor = true;


### PR DESCRIPTION
Adds a deep-link handler so the wasm visor (and native HV — same `browse.js`) can be pointed straight at a dmsg site **full-page** from a shareable URL: `?skynet=<target>[&kiosk=1]` (e.g. a `<pk>.dmsg`).

- `hv-boot.js` (the first script) captures the query param into `window.__SKYWIRE_DEEPLINK__` **before Angular's hash router boots and drops `location.search`**.
- `browse.js` `mountPanel` opens the skynet browser to `<target>` once the visor has a live dmsg session, and in **kiosk** mode hides the taskbar + maximizes so the site obscures the HV UI.

Lets a clearnet Caddy redirect land a visitor straight in a dmsg site (`theskywirenetwork.net` → `skywire.theskywirenetwork.net/?skynet=<reward-pk>.dmsg&kiosk=1`), deprecating clearnet serving while keeping the site reachable via the in-browser visor.

**Validated live**: reward UI fetched over dmsg (200, 341 KB) and rendered full-page in kiosk. JS-only (embedded via `go build`).

Follow-ups: wire the `rewards` resolver alias into the wasm visor fetch path (raw PK works today); Caddy splash-redirect + `htmpl.go` dead-link triage are the deployment layer.