### PR TITLE
fix(wasm-hv): retry the deep-link auto-open on transient dmsg EOF

### DIFF
--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -1555,7 +1555,32 @@
       if (dl) {
         var dlWin = openBrowse();
         if (dl.kiosk) { enterKiosk(dlWin); }
-        whenVisorConnected(function () { try { dlWin.browser.browseTo(dl.target, "/"); } catch (e) {} });
+        // Auto-open the deep-link target with a few retries. whenVisorConnected
+        // fires as soon as ANY dmsg session is live, but the target's dmsg
+        // server may not be reachable yet (a fresh WSS session to it is still
+        // being established), so the first fetch can transiently EOF. A
+        // user-typed navigation would show that error for the user to retry;
+        // the deep-link is automatic, so retry it here on TRANSIENT failure
+        // only (status 0 with an error — not a deliberate block/direct/cancel
+        // or a real HTTP response). Linear backoff, ~15s total.
+        whenVisorConnected(function () {
+          var attempts = 0, maxAttempts = 6;
+          function tryOpen() {
+            attempts++;
+            var retry = function () {
+              if (attempts < maxAttempts) { setTimeout(tryOpen, 1500 * attempts); }
+            };
+            try {
+              var p = dlWin.browser.browseTo(dl.target, "/");
+              if (p && p.then) {
+                p.then(function (res) {
+                  if (res && res.status === 0 && res.error && !res.blocked && !res.direct && !res.cancelled) { retry(); }
+                }).catch(retry);
+              }
+            } catch (e) { retry(); }
+          }
+          tryOpen();
+        });
       }
     } catch (e) {}
 


### PR DESCRIPTION
## Problem

The `?skynet=<target>&kiosk=1` deep-link opens the in-tab browser to the target as soon as `whenVisorConnected` fires — i.e. as soon as *any* dmsg session is live. But the target's own dmsg server may not be reachable yet (a fresh WSS session to it is still being established), so the **first fetch can transiently `EOF`** and the pane sits empty until the user reloads. A user-typed navigation surfaces that error for a manual retry; the deep-link is automatic, so nothing retried it.

## Fix

Retry the deep-link open on **transient** failure only. `navigate()` returns `{status: 0, error}` for a failed fetch, distinct from a deliberate `block`/`direct`/`cancel` or a real HTTP response — so we retry only that case, with linear backoff (`1500ms × n`, up to 6 attempts, ~15s total). Scoped to the deep-link auto-open; interactive navigations are unchanged.

Belt-and-suspenders alongside #3394 (which fixes the dmsg-server load imbalance that caused the EOF in the first place).

## Notes
- `browse.js` is served via `go:embed`; `go build` re-embeds it. No wasm-blob regen needed.
- `node --check` passes; `go build` OK.