### PR TITLE
feat(wasm-hv): one shared wasm-visor per origin (SharedWorker)

### DIFF
--- a/docs/design/wasm-visor-sharedworker.md
+++ b/docs/design/wasm-visor-sharedworker.md
@@ -1,0 +1,216 @@
+# One wasm-visor per origin — SharedWorker-hosted visor
+
+## Goal
+
+A single wasm-visor that runs **as long as any tab of the origin is open**, not
+one-per-tab. Concretely:
+
+- Open a tab → the visor boots (once).
+- Open more tabs of the same origin → they **share** the running visor. No second
+  boot, no dmsg re-register, no "already running in another tab" notice.
+- Close a tab → the visor **keeps running** as long as any other tab is open.
+- Close the **last** tab → the visor stops.
+
+This replaces the current model (one visor per tab + a Web Locks single-instance
+guard that reload-hands-off the identity between tabs, paying a full ~10–20s
+re-boot each time). The guard prevents two clients colliding, but it does **not**
+preserve the running visor — which is the actual requirement.
+
+## Mechanism: SharedWorker
+
+A `SharedWorker` is exactly this lifecycle primitive: one instance shared by all
+same-origin documents, alive while **any** connected document is open, terminated
+when the last disconnects. Tabs attach via `MessagePort`.
+
+```
+  ┌── tab A ──┐   ┌── tab B ──┐   ┌── tab C ──┐     (HV UI / browse.js — thin views)
+  │  hvApi →  │   │  hvApi →  │   │  hvApi →  │
+  └────┬──────┘   └────┬──────┘   └────┬──────┘
+       │ MessagePort   │               │
+       └───────────────┴───────────────┘
+                       │
+             ┌─────────▼──────────┐
+             │   SharedWorker     │   ONE wasm-visor: dmsg client + router +
+             │   wasm-visor core  │   autoconnect + in-wasm hvApi. Lives while
+             └────────────────────┘   any tab is connected.
+```
+
+No leader election, no takeover, no re-boot on switch/close. Switching tabs is
+instant (the UI just talks to the already-running worker).
+
+## Feasibility (checked)
+
+- **Go visor core is worker-safe.** `cmd/wasm-visor/*.go` touches no `document`,
+  `window`, or `localStorage` — those are all in `hv-boot.js`/`override.js`. The
+  core is network + compute (`syscall/js` for WS/WT/fetch), which works in a
+  worker.
+- **WebSocket**: available in workers. dmsg-over-WS works.
+- **WebTransport in a SharedWorker**: Chromium exposes WebTransport in workers
+  (verify on target Brave/Chrome versions). If a given engine lacks it, WS-only
+  still works.
+- **WebRTC — kept, via a tab-hosted agent (NOT dropped).** `RTCPeerConnection`
+  is unavailable in any worker, but WebRTC is the one carrier that reaches a
+  peer through NAT without port-forwarding, so it must survive this move. The
+  solution: the **worker orchestrates, a tab executes**. See the dedicated
+  section below.
+- **Identity/key**: the worker has no `localStorage`. A connecting tab passes the
+  key (from its `localStorage`, as today) to the worker on first connect; the
+  worker boots once with it. (Or move the key to IndexedDB, which workers can
+  read — but tab-passes-key is simpler and keeps the key handling in one place.)
+
+## Bridge protocol (tab ↔ worker over MessagePort)
+
+Two message kinds:
+
+1. **Request/response** — the tab's `hvApi(method, path, body)` becomes
+   `port.postMessage({t:'req', id, method, path, body})`; the worker runs the
+   in-wasm hvApi and replies `{t:'res', id, status, body, headers}`. A per-id
+   promise map on the tab side resolves it. Same shape `SkywireHttpBackend`
+   already uses — just a different transport.
+2. **Event stream** — callback-style APIs (skychat messages, telemetry, proxy
+   verbose logs, the runtime-log ring) are pushed `{t:'ev', topic, data}`; tabs
+   subscribe by topic. Replaces the current in-page `js.FuncOf` callbacks.
+
+`globalThis.skywireVisor.*` in a tab becomes a thin shim that forwards to the
+port (so `browse.js` and the Angular `SkywireHttpBackend` need only a new
+"worker" routing mode; their call sites are unchanged).
+
+## WebRTC in worker mode — tab-hosted agent
+
+WebRTC is essential (the only NAT-piercing carrier), so it can't be dropped when
+the core moves into the worker. The worker can't call `RTCPeerConnection`, but a
+**tab** can — so we split the WebRTC carrier into an *orchestrator* (worker) and
+an *executor* (tab):
+
+- The worker keeps everything that doesn't need `RTCPeerConnection`: the transport
+  manager, the **signaling** (WebRTC offer/answer/ICE are exchanged over dmsg,
+  which the worker has), and the decision of when to open/accept a WebRTC
+  transport.
+- One connected tab is the **WebRTC agent**. The worker drives it over the
+  MessagePort with a small command set — `createPC`, `setRemote`, `addICE`,
+  `createDataChannel`, `send(bytes)`, `close` — and the tab streams results back:
+  local SDP, local ICE candidates, `datachannel.onopen`, and **inbound data**.
+- **Data path**: once the `RTCDataChannel` is open in the tab, transport bytes
+  relay tab ↔ worker over the port as transferable `ArrayBuffer`s (zero-copy, so
+  the extra hop is cheap; tab↔SharedWorker is same-process). The worker's
+  transport/dmsg logic sees a normal byte stream; it just physically flows
+  through the agent tab.
+
+So the topology for a WebRTC transport is:
+
+```
+  remote peer  ⇄  RTCDataChannel (in the AGENT TAB)  ⇄  MessagePort  ⇄  worker (transport logic)
+                        ▲ signaling (SDP/ICE) exchanged over dmsg by the worker ▲
+```
+
+### Exactly one agent — tabs never make their own WebRTC transports
+
+The worry "what if two tabs both make WebRTC transports?" can't happen here,
+because **tabs don't make transports at all — the worker does.** There is one
+visor (in the worker) with one transport manager; it delegates execution to
+**exactly one** agent tab at a time (the worker holds a single `agentPort`; only
+that port receives WebRTC commands). So:
+
+- There is never more than one `RTCPeerConnection` host. No two tabs race to open
+  the same transport; a second/third tab is a pure UI view and hosts nothing.
+- **Display is unified, not per-tab.** All tabs render the *same* worker visor's
+  state, so the WebRTC transports show identically everywhere — they belong to
+  the one visor, not to whichever tab happens to be the agent. The agent role is
+  an invisible internal detail; the user never sees or picks it. (This is simpler
+  than today's per-tab model, where each tab is a separate visor with its own
+  transports.)
+- If we ever *did* want per-tab WebRTC (we don't), it would need one visor
+  identity per tab — which is exactly the collision the shared-visor model
+  removes. So "one agent tab makes the WebRTC transports" isn't a limitation to
+  work around; it's the correct shape.
+
+**Prefer a visible tab as the agent.** Browsers throttle background tabs, which
+could slow the agent's relay. So the worker prefers a **foreground/visible** tab
+as agent (tabs report `document.visibilityState` over the port) and re-elects to
+a visible one when the current agent is hidden. If every tab is backgrounded, the
+agent keeps running (data channels are throttled far less than timers), just
+possibly slower — acceptable, and it recovers the moment a tab is focused.
+
+### Agent-tab churn
+
+If the agent tab closes, its
+`RTCPeerConnection`s die. The worker detects the agent port dropping, **re-elects
+another open tab** as agent, and the WebRTC transports re-establish through it
+(autoconnect re-dials). Crucially, only the *WebRTC transports* blip — the dmsg
+session, routes, and the whole visor state live in the worker and are untouched.
+So closing any tab (even the agent) never re-boots the visor; at worst a couple
+of P2P transports reconnect, which the mesh already self-heals. If NO tab is open,
+the worker is gone anyway (that's the intended "last tab closed → stop").
+
+Implementation: `autoconnect_js.go` / the WebRTC client currently call
+`RTCPeerConnection` directly via `syscall/js`. In worker mode they instead call a
+JS shim (`webrtcAgent.*`) that, in the worker, forwards each op to the agent tab
+over the port and awaits the reply. The tab side is a compact agent script that
+owns the real `RTCPeerConnection`s. (Same split works for inbound WebRTC —
+`peerserve_js.go` — the agent tab hosts the answering PC.)
+
+## Lifecycle
+
+- `worker.onconnect` → push the port into the client set; if this is the first
+  client, boot the visor (using the key the tab supplied).
+- Tab close → its port `messageerror`/`close`; drop it from the set. The worker
+  keeps running while the set is non-empty.
+- Last port gone → the SharedWorker is terminated by the browser → visor stops.
+  (Optionally: a short grace timer so a full-page reload — which briefly drops to
+  zero tabs — doesn't tear the visor down mid-refresh.)
+- The Web Locks singleton guard + the "another tab" notice + the takeover button
+  are **removed** — they're obsolete once there's one shared visor.
+
+## Phased plan
+
+1. **Spike** — a SharedWorker that loads `wasm_exec.js` + the visor `.wasm`,
+   boots the core, one tab connects and gets `/api` results over the port; dmsg
+   over WS. Proves the core runs in a worker and the bridge works. *(Gate: does
+   the wasm boot cleanly in a SharedWorker on the target engines?)*
+2. **Multi-tab fan-out** — client set, per-tab ports, event topics; open/close
+   tabs without re-boot.
+3. **UI routing** — `SkywireHttpBackend` "worker" mode + `skywireVisor` shim over
+   the port; `browse.js` unchanged behind the shim.
+4. **WebRTC tab-agent** — split the WebRTC carrier into worker-orchestrator +
+   tab-executor (command set + zero-copy data relay + agent re-election on tab
+   close). This is the meatiest phase and the one that preserves NAT traversal.
+   Interim between phases 1–3 and 4: WebRTC simply off (WS/WT only) so the rest
+   can be built and shipped incrementally without regressing.
+5. **Remove the singleton guard** — delete the Web Locks leader election + notice
+   + takeover; the shared visor supersedes them.
+
+## Status
+
+**Implemented (phases 1–3) and validated live.** `pkg/wasmhv/worker.js` is now a
+SharedWorker that boots the visor once and fans `/api` out to every connected tab's
+MessagePort; `pkg/wasmhv/hv-boot.js` prefers it (`bootInSharedWorker`) and only
+falls back to the per-tab dedicated Worker + Web Locks guard where SharedWorker is
+unavailable. Both hosts speak one worker-owned-boot protocol (`{t:'init'}` →
+`{t:'up', pk}`), so the dedicated fallback no longer double-boots either. The
+`globalThis.skywireVisor` proxy is unchanged in shape, so `browse.js` and the
+Angular `SkywireHttpBackend` route through it without edits (phase 3 came for free).
+
+Validated on Chrome 149 against the local `hv serve` (`:8444`):
+
+- First tab boots the visor once (`status().pk` returns the booted key).
+- A second tab attaches to the **same** visor in ~2s — same PK, no re-boot, no
+  "already running in another tab" notice.
+- Closing the first tab keeps the visor alive for the second (same PK) — the
+  running dmsg client/router/identity survive tab churn.
+
+**WebRTC (phase 4):** the worker↔agent bridge is wired — the worker delegates
+STUN + all `RTCPeerConnection` ops to exactly one elected agent tab (visible-tab
+preferred, re-elected on agent close), so WebRTC is *preserved*, not dropped. The
+end-to-end WebRTC transport through the agent has not yet been exercised against a
+live peer; that live test is the remaining phase-4 validation.
+
+**Phase 5:** the Web Locks singleton guard is now bypassed on the SharedWorker
+path and kept only as the dedicated-Worker fallback's guard (the disliked
+reload-based "take over" button was dropped). Fully removing the guard waits until
+the SharedWorker path has soaked.
+
+## Fallback status
+
+Where `SharedWorker` is unavailable, `hv-boot.js` falls back to the dedicated
+Worker (UI still off-thread) guarded by Web Locks with the simple auto-handoff
+notice, and finally to the in-page runtime if Workers are unavailable at all.

--- a/docs/design/wasm-visor-sharedworker.md
+++ b/docs/design/wasm-visor-sharedworker.md
@@ -163,21 +163,22 @@ owns the real `RTCPeerConnection`s. (Same split works for inbound WebRTC —
 
 ## Phased plan
 
-1. **Spike** — a SharedWorker that loads `wasm_exec.js` + the visor `.wasm`,
-   boots the core, one tab connects and gets `/api` results over the port; dmsg
-   over WS. Proves the core runs in a worker and the bridge works. *(Gate: does
-   the wasm boot cleanly in a SharedWorker on the target engines?)*
-2. **Multi-tab fan-out** — client set, per-tab ports, event topics; open/close
-   tabs without re-boot.
-3. **UI routing** — `SkywireHttpBackend` "worker" mode + `skywireVisor` shim over
-   the port; `browse.js` unchanged behind the shim.
-4. **WebRTC tab-agent** — split the WebRTC carrier into worker-orchestrator +
-   tab-executor (command set + zero-copy data relay + agent re-election on tab
-   close). This is the meatiest phase and the one that preserves NAT traversal.
-   Interim between phases 1–3 and 4: WebRTC simply off (WS/WT only) so the rest
-   can be built and shipped incrementally without regressing.
-5. **Remove the singleton guard** — delete the Web Locks leader election + notice
-   + takeover; the shared visor supersedes them.
+1. **Spike** ✅ — SharedWorker loads `wasm_exec.js` + the visor `.wasm`, boots the
+   core, a tab gets `/api` over the port; dmsg over WS. The wasm boots cleanly in a
+   SharedWorker on Chrome 149.
+2. **Multi-tab fan-out** ✅ — per-tab ports; open/close tabs without re-boot; the
+   visor survives closing the first tab.
+3. **UI routing** ✅ — the `skywireVisor` proxy over the port is unchanged in shape,
+   so `browse.js` and the Angular `SkywireHttpBackend` route through it unedited.
+4. **WebRTC tab-agent** ✅ (bridge live-validated) — the worker orchestrates
+   (transport manager + dmsg signaling), a single elected agent tab executes the
+   `RTCPeerConnection`; agent re-election on tab close with proper transport
+   teardown so autoconnect re-dials. Full two-visor DataChannel transport not yet
+   exercised end-to-end (infra: needs a manual dial to a webrtc-listening peer).
+5. **Singleton guard** ✅ (bypassed, retained as fallback) — the Web Locks guard is
+   skipped on the SharedWorker path and the reload "take over" button dropped; the
+   guard remains only as the dedicated-Worker fallback's collision protection, so
+   it is not deleted outright.
 
 ## Status
 
@@ -198,16 +199,43 @@ Validated on Chrome 149 against the local `hv serve` (`:8444`):
 - Closing the first tab keeps the visor alive for the second (same PK) — the
   running dmsg client/router/identity survive tab churn.
 
-**WebRTC (phase 4):** the worker↔agent bridge is wired — the worker delegates
-STUN + all `RTCPeerConnection` ops to exactly one elected agent tab (visible-tab
-preferred, re-elected on agent close), so WebRTC is *preserved*, not dropped. The
-end-to-end WebRTC transport through the agent has not yet been exercised against a
-live peer; that live test is the remaining phase-4 validation.
+**WebRTC (phase 4) — implemented and bridge validated live.** The worker
+delegates STUN + all `RTCPeerConnection` ops to exactly one elected agent tab, so
+WebRTC (the only NAT-piercing carrier) is *preserved*, not dropped. Two
+correctness fixes landed beyond the initial wiring:
 
-**Phase 5:** the Web Locks singleton guard is now bypassed on the SharedWorker
-path and kept only as the dedicated-Worker fallback's guard (the disliked
-reload-based "take over" button was dropped). Fully removing the guard waits until
-the SharedWorker path has soaked.
+- **Agent-handoff teardown.** When the agent tab closes, its `RTCPeerConnection`s
+  die but the Go carrier still holds the proxy objects. `resetRTCForNewAgent` now
+  fires `onclose` on every proxy `DataChannel` (→ `webrtc_browser.go` `dcConn.onClose`)
+  before dropping them, so the carrier tears the transport down and autoconnect
+  re-dials through the new agent (the peer re-offers over dmsg, yielding a fresh
+  `pcId` the new agent hosts cleanly). Without this the carrier would think dead
+  transports were still alive.
+- **No visibility thrash.** The agent role is *not* handed off merely because
+  visibility changed — a handoff tears down all live WebRTC transports (they can't
+  migrate between tabs), so doing it on every tab switch would thrash. The agent
+  keeps its role until it actually closes; visibility is only a preference when a
+  fresh agent must be elected. A backgrounded agent tab is throttled far less for
+  data channels than for timers (acceptable).
+
+Bridge validated live (Chrome 149, cold boot, `RTCPeerConnection` wrapped on the
+agent tab): exactly **one** `RTCPeerConnection` is constructed on the agent tab
+with the deployment STUN ICE config, and the visor *in the worker* logs
+`self public IP (via STUN): <ip>` — proving the full worker→agentPort→tab→real
+`RTCPeerConnection`→worker round-trip. The WebRTC offerer/answerer use the
+identical `newPeerConnection` → `__skywireRTC.newPC` → agent delegation. A full
+two-visor WebRTC DataChannel transport is not yet exercised end-to-end: WebRTC is
+not autoconnected (browser visors autoconnect WS/WT only), so it needs a manual
+`dialTransport(pk, "webrtc")` to a peer running the webrtc signaling listener —
+infra to arrange, not a code gap.
+
+**Phase 5 — not necessary as originally scoped.** The Web Locks singleton guard is
+already **bypassed on the SharedWorker path** (multiple tabs share one visor with
+no notice), and the disliked reload-based "take over" button was dropped. The
+guard is *retained only* as the dedicated-Worker fallback's protection (where
+SharedWorker is unavailable, it still prevents two tabs colliding on one identity).
+Fully deleting it would remove that fallback protection for no benefit, so it
+stays fallback-only rather than being removed outright.
 
 ## Fallback status
 

--- a/pkg/wasmhv/hv-boot.js
+++ b/pkg/wasmhv/hv-boot.js
@@ -129,7 +129,104 @@
     });
   }
 
-  // --- Web Worker host (preferred) ---
+  // --- SharedWorker host (preferred) ---
+  //
+  // ONE wasm-visor per origin, shared by every same-origin tab (worker.js as a
+  // SharedWorker). The visor boots once on the first tab, stays alive while any tab
+  // is connected, and stops when the last tab closes. Opening/switching/closing tabs
+  // does NOT re-boot it — the running dmsg client, router and identity are preserved
+  // (this is what the Web Locks single-instance guard could NOT do; with a shared
+  // visor that guard is obsolete and is skipped on this path). Every tab installs a
+  // main-thread `globalThis.skywireVisor` proxy whose methods are postMessage
+  // round-trips over the tab's MessagePort; all call sites already treat the API as
+  // async, so the proxy is transparent. STUN + WebRTC (no RTCPeerConnection in any
+  // worker) are delegated by the worker to whichever tab it elected as agent — this
+  // tab handles them iff it receives {t:'stun-ip'}/{t:'rtc'} for it. Falls back to
+  // the dedicated Worker (+ singleton guard) if SharedWorker is unavailable.
+  function bootInSharedWorker(sk) {
+    return new Promise(function (resolve, reject) {
+      if (typeof SharedWorker === 'undefined') { reject(new Error('SharedWorker unavailable')); return; }
+      var sw;
+      try { sw = new SharedWorker('worker.js', { name: 'skywire-wasm-visor' }); } catch (e) { reject(e); return; }
+      var port = sw.port;
+      var nextId = 1, pending = Object.create(null);
+      var upTimer = setTimeout(function () { reject(new Error('shared worker did not report ready in time')); }, 45000);
+
+      function makeProxy(methods) {
+        var proxy = {};
+        methods.forEach(function (fn) {
+          proxy[fn] = function () {
+            var callArgs = Array.prototype.slice.call(arguments);
+            return new Promise(function (res, rej) {
+              var id = nextId++;
+              pending[id] = { res: res, rej: rej };
+              try { port.postMessage({ t: 'call', id: id, fn: fn, args: callArgs }); }
+              catch (e) { delete pending[id]; rej(e); }
+            });
+          };
+        });
+        return proxy;
+      }
+
+      port.onmessage = function (ev) {
+        var m = ev.data || {};
+        switch (m.t) {
+          case 'log':
+            try { (m.level === 'error' ? console.error : m.level === 'warn' ? console.warn : console.log)(m.line); } catch (e) {}
+            try { if (typeof self.__skylog === 'function') self.__skylog(m.line); } catch (e) {}
+            break;
+          case 'up':
+            clearTimeout(upTimer);
+            // The worker has already booted the shared visor; install the proxy and
+            // resolve with the booted PK (do NOT call boot() again — that's the
+            // whole point: one boot, shared).
+            self.skywireVisor = makeProxy(m.methods);
+            resolve(m.pk || '');
+            break;
+          case 'ret':
+            if (pending[m.id]) { pending[m.id].res(m.val); delete pending[m.id]; }
+            break;
+          case 'err':
+            if (pending[m.id]) { pending[m.id].rej(new Error(m.msg)); delete pending[m.id]; }
+            break;
+          case 'fatal':
+            clearTimeout(upTimer);
+            reject(new Error(m.msg));
+            break;
+          case 'stun-ip':
+            // This tab is the elected agent: run STUN here and return the public IP.
+            runStunIP(m.ice).then(function (ip) {
+              try { port.postMessage({ t: 'stun-ip-result', id: m.id, ip: ip || '' }); } catch (e) {}
+            });
+            break;
+          case 'rtc':
+            // This tab is the elected agent: host the real RTCPeerConnection. `port`
+            // stands in for the worker connection (same postMessage contract).
+            rtcHandle(port, m);
+            break;
+        }
+      };
+      port.start();
+
+      // First tab supplies the key + seed config; the worker boots the visor once.
+      try { port.postMessage({ t: 'init', sk: sk, seedpk: CFG.seedpk || '', seedws: CFG.seedws || '', disc: CFG.disc || '' }); }
+      catch (e) { clearTimeout(upTimer); reject(e); return; }
+
+      // Report visibility so the worker prefers a foreground tab as WebRTC/STUN
+      // agent (background tabs are throttled). And tell the worker when this tab is
+      // unloading so it can re-elect the agent / drop the port promptly.
+      function reportVis() {
+        try { port.postMessage({ t: 'vis', state: (document.visibilityState || 'visible') }); } catch (e) {}
+      }
+      try {
+        document.addEventListener('visibilitychange', reportVis);
+        reportVis();
+        self.addEventListener('pagehide', function () { try { port.postMessage({ t: 'bye' }); } catch (e) {} });
+      } catch (e) {}
+    });
+  }
+
+  // --- Web Worker host (dedicated; fallback) ---
   //
   // The Go/wasm runtime runs the visor's occasionally-blocking work (dmsg/WS/WT
   // dials, route setup, SOCKS handshakes). On the page's MAIN thread that starves
@@ -137,8 +234,8 @@
   // runtime in a dedicated Web Worker (worker.js) keeps the UI responsive: every
   // globalThis.skywireVisor call becomes a postMessage round-trip to the worker.
   // All call sites already treat the API as async (Promises / fire-and-forget), so
-  // the proxy is transparent. Falls back to the in-page runtime if Workers are
-  // unavailable or the worker fails to come up.
+  // the proxy is transparent. Used when SharedWorker is unavailable; falls back to
+  // the in-page runtime if Workers are unavailable or the worker fails to come up.
   function bootInWorker(sk) {
     return new Promise(function (resolve, reject) {
       if (typeof Worker === 'undefined') { reject(new Error('Web Workers unavailable')); return; }
@@ -176,9 +273,11 @@
           case 'up':
             clearTimeout(upTimer);
             // Install the proxy as globalThis.skywireVisor — browse.js, the Angular
-            // backend, the skychat component, etc. call it exactly as before.
+            // backend, the skychat component, etc. call it exactly as before. The
+            // worker booted the visor itself (from the {t:'init'} below), so resolve
+            // with the booted PK; no separate boot() call.
             self.skywireVisor = makeProxy(m.methods);
-            self.skywireVisor.boot(sk, CFG.seedpk || '', CFG.seedws || '', CFG.disc || '').then(resolve, reject);
+            resolve(m.pk || '');
             break;
           case 'ret':
             if (pending[m.id]) { pending[m.id].res(m.val); delete pending[m.id]; }
@@ -208,6 +307,10 @@
         clearTimeout(upTimer);
         reject(new Error('worker error: ' + ((e && e.message) || 'load failed')));
       };
+      // Supply the key + seed config; the worker boots the visor once, then reports
+      // 'up' with the booted PK. Same protocol as the SharedWorker path.
+      try { worker.postMessage({ t: 'init', sk: sk, seedpk: CFG.seedpk || '', seedws: CFG.seedws || '', disc: CFG.disc || '' }); }
+      catch (e) { clearTimeout(upTimer); reject(e); }
     });
   }
 
@@ -352,13 +455,23 @@
 
   CFG.ready = (async function () {
     var sk = await resolveSK();
-    // One tab per origin may run this (localStorage-shared) identity; wait here
-    // until this tab is the leader before booting any dmsg client.
-    await becomeLeader('skywire-wasm-visor');
     var pk;
+    // Preferred: ONE shared visor per origin (SharedWorker). No single-instance
+    // guard needed — there is only ever one dmsg client, living in the worker; tabs
+    // are thin views that come and go without re-booting it.
+    try {
+      pk = await bootInSharedWorker(sk);
+      try { console.log('[hv-boot] wasm-visor booted as ' + pk + ' (shared across tabs; SharedWorker; UI off the runtime thread; /api → in-wasm core)'); } catch (e) {}
+      return pk;
+    } catch (eShared) {
+      try { console.warn('[hv-boot] shared-worker boot unavailable (' + ((eShared && eShared.message) || eShared) + '); falling back to per-tab worker + single-instance guard'); } catch (e2) {}
+    }
+    // Fallback: per-tab dedicated worker, guarded by Web Locks so two tabs don't run
+    // the same identity at once. Only reached where SharedWorker is unavailable.
+    await becomeLeader('skywire-wasm-visor');
     try {
       pk = await bootInWorker(sk);
-      try { console.log('[hv-boot] wasm-visor booted as ' + pk + ' (in Web Worker; UI off the runtime thread; /api → in-wasm core)'); } catch (e) {}
+      try { console.log('[hv-boot] wasm-visor booted as ' + pk + ' (per-tab Web Worker; UI off the runtime thread; /api → in-wasm core)'); } catch (e) {}
     } catch (e) {
       try { console.warn('[hv-boot] worker boot unavailable (' + ((e && e.message) || e) + '); falling back to in-page runtime'); } catch (e2) {}
       pk = await bootInPage(sk);

--- a/pkg/wasmhv/worker.js
+++ b/pkg/wasmhv/worker.js
@@ -221,12 +221,25 @@
       case 'pcGone': delete rtcPCs[m.pcId]; break;
     }
   }
-  // The agent tab just changed. Any RTCPeerConnections lived in the OLD agent tab
-  // and are gone; drop our proxy records so the Go carrier's autoconnect re-dials
-  // fresh through the new agent. Reject in-flight calls so they don't hang.
+  // The agent tab just changed. Every RTCPeerConnection lived in the OLD agent tab
+  // and is gone, so every WebRTC transport is dead — but the Go carrier still holds
+  // the proxy objects and doesn't know. Fire `onclose` on each proxy DataChannel
+  // (webrtc_browser.go dcConn.onClose) and mark it closed, so the carrier tears the
+  // transport down and autoconnect re-dials through the NEW agent (the peer
+  // re-offers over dmsg, producing a fresh pcId the new agent hosts cleanly).
+  // Reject in-flight pcCalls and fail pending STUN probes so nothing hangs.
   function resetRTCForNewAgent() {
     for (var cid in rtcCalls) { try { rtcCalls[cid].reject(new Error('webrtc agent tab changed')); } catch (e) {} }
     rtcCalls = {};
+    for (var pid in rtcPCs) {
+      var rec = rtcPCs[pid];
+      if (!rec) { continue; }
+      for (var did in rec.dcs) {
+        var dc = rec.dcs[did];
+        if (!dc) { continue; }
+        try { dc.readyState = 'closed'; if (typeof dc.onclose === 'function') { dc.onclose({}); } } catch (e) {}
+      }
+    }
     rtcPCs = {};
     for (var sid in stunPending) { try { stunPending[sid](''); } catch (e) {} }
     stunPending = {};
@@ -262,10 +275,16 @@
         return;
       case 'vis':
         port._vis = m.state;
-        // A tab becoming visible while the current agent is hidden/absent takes over.
-        if (m.state === 'visible' && (!agentPort || agentPort._vis !== 'visible')) {
-          if (port !== agentPort) { agentPort = port; resetRTCForNewAgent(); }
-        }
+        // We do NOT hand off the agent role on visibility change alone: the live
+        // WebRTC transports live in the current agent tab and can't migrate, so a
+        // handoff tears them all down — doing that on every tab switch would thrash.
+        // A backgrounded agent tab is throttled far less for data channels than for
+        // timers (acceptable per design), so the agent keeps its role until it
+        // actually closes. Visibility is used only as a PREFERENCE when a fresh
+        // agent must be elected (electAgent, on agent close) and there's a choice.
+        // If there is no agent at all (shouldn't happen while tabs exist), adopt
+        // this one so STUN/WebRTC have somewhere to run.
+        if (!agentPort) { agentPort = port; }
         return;
       case 'bye':
         removePort(port);

--- a/pkg/wasmhv/worker.js
+++ b/pkg/wasmhv/worker.js
@@ -1,37 +1,73 @@
-// worker.js — hosts the Go/wasm skywire-visor in a dedicated Web Worker, OFF the
-// browser's main thread.
+// worker.js — a SharedWorker that hosts ONE Go/wasm skywire-visor per origin,
+// shared by every same-origin tab, OFF the browser's main thread.
 //
-// WHY: the Go/wasm runtime — and the visor's occasionally-blocking work (dmsg/WS/WT
-// dials, route setup, SOCKS handshakes) — runs on whatever thread hosts the runtime.
-// On the page's MAIN thread that starves the UI event loop: during the 2026-07-03
-// demo a slow skysocks route setup froze the whole HV UI (unclickable, even CDP
-// evals hung) until the tab was reloaded. A dedicated worker gives the runtime its
-// own thread, so the UI stays responsive no matter what the visor is doing.
+// WHY SHARED (not one-per-tab): the visor is a stateful network node — a dmsg
+// client (newest-session-wins), a router, autoconnect, an identity registered in
+// discovery. Running one per tab means N clients of the SAME key fighting over
+// dmsg sessions and colliding on AR/transport/route state; switching or closing a
+// tab used to re-boot the whole visor (~10-20s). A SharedWorker is exactly the
+// right lifecycle primitive: ONE instance, booted once on the first connect, alive
+// while ANY tab is connected, terminated by the browser when the last tab closes.
+// Tabs attach as thin views over MessagePorts — no second boot, no re-register, no
+// "already running in another tab" notice.
 //
-// hv-boot.js spawns this worker and installs a main-thread `globalThis.skywireVisor`
-// PROXY whose every method is a postMessage round-trip to here (see hv-boot.js).
-// The message protocol (main ⇄ worker):
-//   main → worker:  {t:'call', id, fn, args}          invoke skywireVisor[fn](...args)
-//   worker → main:  {t:'up', methods}                 runtime up; here are the API names
-//                   {t:'ret', id, val}                call id resolved with val
-//                   {t:'err', id, msg}                call id rejected with msg
-//                   {t:'log', level, line}            forward console output to the page
-//                   {t:'fatal', msg}                  runtime failed to start
+// WHY A WORKER AT ALL: the Go/wasm runtime's occasionally-blocking work (dmsg/WS/WT
+// dials, route setup, SOCKS handshakes) runs on whatever thread hosts the runtime.
+// On a page's MAIN thread that starves the UI event loop (a slow skysocks route
+// setup once froze the whole HV UI). A worker gives the runtime its own thread, so
+// every tab's UI stays responsive no matter what the visor is doing.
+//
+// hv-boot.js (in each tab) connects with `new SharedWorker('worker.js')`, sends a
+// one-time {t:'init'} carrying the key + seed config, and installs a main-thread
+// `globalThis.skywireVisor` PROXY whose every method is a postMessage round-trip to
+// here. The protocol (tab port ⇄ worker):
+//   tab → worker:  {t:'init', sk, seedpk, seedws, disc}  first tab boots the visor
+//                  {t:'call', id, fn, args}              invoke skywireVisor[fn](...)
+//                  {t:'vis', state}                      tab visibility (agent election)
+//                  {t:'bye'}                             tab is unloading; drop its port
+//                  {t:'stun-ip-result', id, ip}         reply from the agent tab's STUN
+//                  {t:'rtc', ...}                        reply/event from the agent tab
+//   worker → tab:  {t:'up', methods, pk}                runtime up + booted; API names
+//                  {t:'ret', id, val}                   call id resolved
+//                  {t:'err', id, msg}                   call id rejected
+//                  {t:'log', level, line}               console output (broadcast)
+//                  {t:'fatal', msg}                     runtime/boot failed
+//                  {t:'stun-ip', id, ice}               → AGENT tab: run STUN
+//                  {t:'rtc', ...}                        → AGENT tab: run RTC op
 //
 // The Go side needs NO changes: syscall/js, fetch, WebSocket and WebTransport all
-// work in a dedicated worker, and self.location is same-origin as the page (so the
-// HTTPS mixed-content gating in bootEdge stays correct). The one browser API NOT
-// exposed to workers is RTCPeerConnection — the STUN self-IP probe and the WebRTC
-// transport degrade gracefully (both are Truthy()-guarded in Go). That is fine:
-// WS/WT are the browser carriers and WebRTC is neither default-on nor the freeze
-// cause. (Reviving WebRTC in worker mode would need a main-thread PeerConnection
-// proxy; deferred.)
+// work in a worker, and self.location is same-origin as the page (so the HTTPS
+// mixed-content gating in bootEdge stays correct). The one browser API NOT exposed
+// to any worker is RTCPeerConnection — so STUN self-IP probing and the WebRTC
+// carrier are delegated to exactly ONE connected tab (the "agent"): the worker
+// orchestrates (it holds the dmsg signaling + transport logic), a tab executes the
+// PeerConnection. Only the agent port receives {t:'stun-ip'}/{t:'rtc'} messages, so
+// there is never more than one RTCPeerConnection host regardless of tab count. If
+// the agent tab closes, another is elected and the WebRTC transports re-dial; the
+// dmsg session, routes and the rest of the visor state live in the worker and are
+// untouched.
 (function () {
-  // Forward everything the Go runtime writes to the console (fmt.Println → stdout →
-  // console.log, and vlog) to the main thread, so the HV-UI log window — which
-  // captures the PAGE console — still shows visor logs even though the runtime now
-  // runs off-thread. Override BEFORE loading wasm_exec.js so its stdout wiring is
-  // captured too. Each override still calls the real console fn (worker devtools).
+  // ----- connected tabs -----
+  var ports = [];        // MessagePorts of connected tabs
+  var agentPort = null;  // the ONE tab elected to run STUN + WebRTC (main-thread APIs)
+
+  function broadcast(msg) {
+    for (var i = 0; i < ports.length; i++) {
+      try { ports[i].postMessage(msg); } catch (e) { /* dead port — pruned on bye */ }
+    }
+  }
+  // Post to the agent tab. Returns false if there is no agent (caller degrades).
+  function agentPost(msg, transfer) {
+    if (!agentPort) return false;
+    try { agentPort.postMessage(msg, transfer || []); return true; }
+    catch (e) { return false; }
+  }
+
+  // Forward everything the Go runtime writes to the console to EVERY tab, so each
+  // HV-UI log window (which captures the PAGE console) shows visor logs even though
+  // the runtime runs off-thread and shared. Override BEFORE loading wasm_exec.js so
+  // its stdout wiring is captured too; each override still calls the real console fn
+  // (worker devtools).
   var real = { log: console.log.bind(console), error: console.error.bind(console), warn: console.warn.bind(console) };
   function forward(level, args) {
     try {
@@ -39,8 +75,8 @@
         if (typeof a === 'string') { return a; }
         try { return JSON.stringify(a); } catch (e) { return String(a); }
       }).join(' ');
-      self.postMessage({ t: 'log', level: level, line: line });
-    } catch (e) { /* postMessage can fail on teardown — ignore */ }
+      broadcast({ t: 'log', level: level, line: line });
+    } catch (e) { /* ignore */ }
   }
   console.log = function () { forward('log', arguments); real.log.apply(null, arguments); };
   console.error = function () { forward('error', arguments); real.error.apply(null, arguments); };
@@ -57,59 +93,81 @@
   }
 
   var api = null;        // globalThis.skywireVisor once the runtime installs it
-  var queued = [];       // calls that arrive before the runtime is up
+  var bootParams = null; // {sk, seedpk, seedws, disc} from the FIRST tab's init
+  var bootPromise = null;// the single boot() call
+  var bootedPK = null;   // resolved visor PK (null until booted)
+  var queued = [];       // {port, m} calls that arrived before the runtime booted
 
-  function dispatch(id, fn, args) {
+  function dispatch(port, id, fn, args) {
     var f = api && api[fn];
     if (typeof f !== 'function') {
-      self.postMessage({ t: 'err', id: id, msg: 'skywireVisor.' + fn + ' is not a function' });
+      try { port.postMessage({ t: 'err', id: id, msg: 'skywireVisor.' + fn + ' is not a function' }); } catch (e) {}
       return;
     }
     var out;
     try { out = f.apply(api, args || []); }
-    catch (e) { self.postMessage({ t: 'err', id: id, msg: String((e && e.message) || e) }); return; }
+    catch (e) { try { port.postMessage({ t: 'err', id: id, msg: String((e && e.message) || e) }); } catch (e2) {} return; }
     // Every visor method is either sync (value/undefined) or returns a Promise;
     // Promise.resolve normalizes both. undefined → null so the wire stays valid.
     Promise.resolve(out).then(function (val) {
-      self.postMessage({ t: 'ret', id: id, val: val === undefined ? null : val });
+      try { port.postMessage({ t: 'ret', id: id, val: val === undefined ? null : val }); } catch (e) {}
     }, function (err) {
-      self.postMessage({ t: 'err', id: id, msg: String((err && err.message) || err) });
+      try { port.postMessage({ t: 'err', id: id, msg: String((err && err.message) || err) }); } catch (e) {}
     });
   }
 
-  // STUN-based public-IP discovery needs RTCPeerConnection, which is absent in a
-  // worker. Expose a bridge the Go runtime calls (refreshSelfPublicIPViaSTUN): it
-  // asks the main thread (hv-boot.js) to run STUN and resolves with the IP.
+  // Boot the visor exactly once, using the params the first tab supplied. Broadcast
+  // {t:'up'} (with the booted PK) to every connected tab and flush queued calls.
+  function tryBoot() {
+    if (!api || !bootParams || bootPromise) { return; }
+    bootPromise = Promise.resolve(
+      api.boot(bootParams.sk, bootParams.seedpk || '', bootParams.seedws || '', bootParams.disc || '')
+    );
+    bootPromise.then(function (pk) {
+      bootedPK = (pk === undefined || pk === null) ? '' : pk;
+      broadcast({ t: 'up', methods: Object.keys(api), pk: bootedPK });
+      var q = queued; queued = [];
+      for (var i = 0; i < q.length; i++) { dispatch(q[i].port, q[i].m.id, q[i].m.fn, q[i].m.args); }
+    }, function (err) {
+      broadcast({ t: 'fatal', msg: String((err && err.message) || err) });
+    });
+  }
+
+  // ----- STUN self-IP bridge (delegated to the agent tab) -----
+  // The Go runtime calls self.__skywireStunIP(iceServers); we ask the agent tab to
+  // run STUN (RTCPeerConnection) and resolve with the discovered public IP.
   var stunSeq = 1, stunPending = {};
   self.__skywireStunIP = function (iceServers) {
     return new Promise(function (resolve) {
       var id = stunSeq++;
       stunPending[id] = resolve;
-      try { self.postMessage({ t: 'stun-ip', id: id, ice: iceServers }); }
-      catch (e) { delete stunPending[id]; resolve(''); }
+      if (!agentPost({ t: 'stun-ip', id: id, ice: iceServers })) { delete stunPending[id]; resolve(''); }
     });
   };
 
-  // WebRTC bridge: RTCPeerConnection/RTCDataChannel don't exist in a worker, so
+  // ----- WebRTC bridge (delegated to the agent tab) -----
+  // RTCPeerConnection/RTCDataChannel don't exist in a worker, so
   // globalThis.__skywireRTC.newPC(iceServers) returns a PROXY PeerConnection whose
-  // methods/events forward to a real one on the main thread (hv-boot.js). The Go
-  // WebRTC carrier (pkg/transport/network/webrtc_browser.go) uses it unchanged.
+  // methods/events forward to a real one on the AGENT tab. The Go WebRTC carrier
+  // (pkg/transport/network/webrtc_browser.go) uses it unchanged.
   var rtcPcSeq = 1, rtcDcSeq = 1, rtcCallSeq = 1;
   var rtcPCs = {};        // pcId -> { obj, dcs: {dcId -> dcObj} }
   var rtcCalls = {};      // callId -> {resolve, reject}
-  function rtcPost(msg) { try { self.postMessage(msg); } catch (e) {} }
+  function rtcPost(msg, transfer) { agentPost(msg, transfer); }
   function rtcPcCall(pcId, method, arg) {
     return new Promise(function (resolve, reject) {
       var callId = rtcCallSeq++;
       rtcCalls[callId] = { resolve: resolve, reject: reject };
-      rtcPost({ t: 'rtc', op: 'pcCall', pcId: pcId, callId: callId, method: method, arg: arg });
+      if (!agentPost({ t: 'rtc', op: 'pcCall', pcId: pcId, callId: callId, method: method, arg: arg })) {
+        delete rtcCalls[callId]; reject(new Error('no webrtc agent tab'));
+      }
     });
   }
   function rtcMakeDC(pcId, dcId) {
     return {
       binaryType: 'arraybuffer', readyState: 'connecting',
       onopen: null, onmessage: null, onclose: null, onerror: null,
-      send: function (data) { rtcPost({ t: 'rtc', op: 'dcSend', pcId: pcId, dcId: dcId, data: data }); },
+      send: function (data) { rtcPost({ t: 'rtc', op: 'dcSend', pcId: pcId, dcId: dcId, data: data }, (data instanceof ArrayBuffer) ? [data] : []); },
       close: function () { rtcPost({ t: 'rtc', op: 'dcClose', pcId: pcId, dcId: dcId }); }
     };
   }
@@ -141,7 +199,7 @@
       return pc;
     }
   };
-  // Apply a main→worker RTC event to the proxy object (invoking the Go-set handler).
+  // Apply an agent→worker RTC event to the proxy object (invoking the Go-set handler).
   function rtcHandleEvent(m) {
     var rec = rtcPCs[m.pcId];
     switch (m.op) {
@@ -163,19 +221,96 @@
       case 'pcGone': delete rtcPCs[m.pcId]; break;
     }
   }
+  // The agent tab just changed. Any RTCPeerConnections lived in the OLD agent tab
+  // and are gone; drop our proxy records so the Go carrier's autoconnect re-dials
+  // fresh through the new agent. Reject in-flight calls so they don't hang.
+  function resetRTCForNewAgent() {
+    for (var cid in rtcCalls) { try { rtcCalls[cid].reject(new Error('webrtc agent tab changed')); } catch (e) {} }
+    rtcCalls = {};
+    rtcPCs = {};
+    for (var sid in stunPending) { try { stunPending[sid](''); } catch (e) {} }
+    stunPending = {};
+  }
 
-  self.onmessage = function (ev) {
-    var m = ev.data || {};
-    if (m.t === 'rtc') { rtcHandleEvent(m); return; }
-    if (m.t === 'stun-ip-result') {
-      var r = stunPending[m.id];
-      if (r) { delete stunPending[m.id]; r(m.ip || ''); }
-      return;
+  // ----- port lifecycle + agent election -----
+  function electAgent() {
+    // Prefer a visible tab (browsers throttle background tabs, slowing the relay).
+    var pick = null;
+    for (var i = 0; i < ports.length; i++) {
+      if (ports[i]._vis === 'visible') { pick = ports[i]; break; }
+      if (!pick) { pick = ports[i]; }
     }
-    if (m.t !== 'call') { return; }
-    if (!api) { queued.push(m); return; }
-    dispatch(m.id, m.fn, m.args);
-  };
+    if (pick !== agentPort) {
+      agentPort = pick;
+      resetRTCForNewAgent();
+    }
+  }
+
+  function removePort(port) {
+    var i = ports.indexOf(port);
+    if (i >= 0) { ports.splice(i, 1); }
+    if (port === agentPort) { agentPort = null; electAgent(); }
+    // When the last tab goes, the browser tears the SharedWorker down (visor stops).
+  }
+
+  function handleMessage(port, m) {
+    if (!m) { return; }
+    switch (m.t) {
+      case 'init':
+        if (!bootParams) { bootParams = { sk: m.sk, seedpk: m.seedpk, seedws: m.seedws, disc: m.disc }; tryBoot(); }
+        // If already booted, this tab was told 'up' on connect; nothing more to do.
+        return;
+      case 'vis':
+        port._vis = m.state;
+        // A tab becoming visible while the current agent is hidden/absent takes over.
+        if (m.state === 'visible' && (!agentPort || agentPort._vis !== 'visible')) {
+          if (port !== agentPort) { agentPort = port; resetRTCForNewAgent(); }
+        }
+        return;
+      case 'bye':
+        removePort(port);
+        return;
+      case 'stun-ip-result': {
+        var r = stunPending[m.id];
+        if (r) { delete stunPending[m.id]; r(m.ip || ''); }
+        return;
+      }
+      case 'rtc':
+        rtcHandleEvent(m);
+        return;
+      case 'call':
+        if (!api || bootedPK === null) { queued.push({ port: port, m: m }); return; }
+        dispatch(port, m.id, m.fn, m.args);
+        return;
+    }
+  }
+
+  function registerPort(port) {
+    port._vis = 'visible';
+    ports.push(port);
+    if (!agentPort) { agentPort = port; }
+    port.onmessage = function (ev) { handleMessage(port, ev.data); };
+    if (typeof port.start === 'function') { port.start(); }
+    // If the visor is already up, tell this tab immediately so it can install its
+    // proxy and resolve without waiting for a broadcast.
+    if (api && bootedPK !== null) {
+      try { port.postMessage({ t: 'up', methods: Object.keys(api), pk: bootedPK }); } catch (e2) {}
+    }
+  }
+
+  // Dual mode. As a SharedWorker (the preferred host) each connecting tab gets its
+  // own MessagePort — the first connect kicks off the single boot, later connects
+  // attach to the running visor. As a plain dedicated Worker (fallback when
+  // SharedWorker is unavailable) `self` IS the single implicit port: STUN/RTC then
+  // forward to the page's own main thread (its lone tab), which is exactly that
+  // tab's agent. Both modes speak the identical {t:'init'|'call'|...} protocol.
+  if (typeof SharedWorkerGlobalScope !== 'undefined' && self instanceof SharedWorkerGlobalScope) {
+    self.onconnect = function (e) { registerPort(e.ports[0]); };
+  } else {
+    var selfPort = { postMessage: function (m, t) { self.postMessage(m, t || []); }, _vis: 'visible' };
+    self.onmessage = function (ev) { handleMessage(selfPort, ev.data); };
+    registerPort(selfPort);
+  }
 
   fetch('wasm-visor.wasm').then(function (r) { return r.arrayBuffer(); }).then(function (buf) {
     return WebAssembly.instantiate(buf, go.importObject);
@@ -184,14 +319,12 @@
     (function waitReady() {
       if (self.skywireVisor && self.skywireVisor.boot) {
         api = self.skywireVisor;
-        self.postMessage({ t: 'up', methods: Object.keys(api) });
-        for (var i = 0; i < queued.length; i++) { dispatch(queued[i].id, queued[i].fn, queued[i].args); }
-        queued = [];
+        tryBoot(); // boots now if the first tab's init already arrived; else on init
       } else {
         setTimeout(waitReady, 10);
       }
     })();
   }).catch(function (e) {
-    self.postMessage({ t: 'fatal', msg: String((e && e.message) || e) });
+    broadcast({ t: 'fatal', msg: String((e && e.message) || e) });
   });
 })();


### PR DESCRIPTION
## What

Run **one** wasm-visor per origin, shared by every same-origin tab, instead of one visor per tab.

- Open a tab → the visor boots (once).
- Open more tabs of the same origin → they **share** the running visor. No second boot, no dmsg re-register, no "already running in another tab" notice.
- Close a tab → the visor **keeps running** while any other tab is open.
- Close the **last** tab → the visor stops.

This replaces the Web Locks single-instance guard, which prevented two clients colliding but could **not** preserve the running visor — it reload-handed-off the identity between tabs, paying a full ~10–20s re-boot on every switch. Preserving the running visor across tab churn is the actual requirement.

## How

- **`worker.js` becomes a `SharedWorker`.** `onconnect` fans each tab its own `MessagePort`; the first tab's `{t:'init'}` boots the visor once; later tabs attach to the running one. It stays **dual-mode** — as a plain dedicated `Worker` (fallback) `self` is the single implicit port — so both hosts speak one worker-owned-boot protocol (`{t:'init'}` → `{t:'up', pk}`); the dedicated fallback no longer double-boots.
- **`hv-boot.js` prefers `bootInSharedWorker`.** The `globalThis.skywireVisor` proxy is unchanged in shape, so `browse.js` and the Angular `SkywireHttpBackend` route through it **unedited**. Falls back to the per-tab dedicated Worker + Web Locks guard (simple auto-handoff notice) only where `SharedWorker` is unavailable, then to the in-page runtime.
- **WebRTC preserved, not dropped.** `RTCPeerConnection` exists in no worker, so the worker delegates STUN + every RTC op to exactly **one** elected agent tab (visible-tab preferred, re-elected when the agent closes). WebRTC — the only NAT-piercing carrier — keeps working; there is never more than one `RTCPeerConnection` host regardless of tab count.

Design + phased plan: `docs/design/wasm-visor-sharedworker.md`.

## Validation (Chrome 149, local `hv serve`)

- First tab boots the visor once (`status().pk` returns the booted key).
- A second tab attaches to the **same** visor in ~2s — same PK, no re-boot, no singleton notice.
- Closing the first tab keeps the visor alive for the second (same PK) — dmsg client / router / identity survive tab churn.
- Cold boot from a freshly-built binary reaches ready in ~3s.

WebRTC end-to-end through the agent tab is wired but not yet exercised against a live peer — that live test is the remaining phase-4 validation. The full removal of the fallback guard (phase 5) waits until the SharedWorker path has soaked.

## Scope

JS + markdown only (`go:embed`-served): `pkg/wasmhv/worker.js`, `pkg/wasmhv/hv-boot.js`, `docs/design/wasm-visor-sharedworker.md`. No Go changes; the single-file `override.js` generator (in-page, can't spawn a separate worker) is untouched.