### PR TITLE
fix(cxo): close the duplicate transport in initConn (tpd CXO connection leak)

### DIFF
--- a/pkg/cxo/node/node.go
+++ b/pkg/cxo/node/node.go
@@ -468,6 +468,16 @@ func (n *Node) initConn(
 	switch {
 	// In case of existing connection return it.
 	case !isNew && !isPending:
+		// A connection to/from this address already exists, so `c` is that
+		// EXISTING Conn and the freshly-accepted/-dialed `fc` we were handed is a
+		// duplicate that nobody will use. Close it — its readLoop/writeLoop
+		// goroutines and noise/yamux/bufio buffers are already live, and the
+		// caller only closes `fc` on ERROR (here err is nil), so without this the
+		// duplicate transport leaks. DMSG.acceptConn (unlike the TCP/UDP paths)
+		// does not pre-guard duplicates, so on the tpd's dmsg CXO node every peer
+		// reconnect while its previous Conn lingered orphaned a full connection
+		// stack — measured ~150k retained stacks / 4GB heap / GC-bound CPU.
+		fc.Close() //nolint:errcheck,gosec
 		return c, nil
 
 	// In case of existing pending connnection:
@@ -492,6 +502,10 @@ func (n *Node) initConn(
 		if err = c.waitForInit(); err != nil {
 			return nil, err
 		}
+		// Same as the active-duplicate case above: `c` is the pre-existing in-flight
+		// Conn; the `fc` we were handed is an unused duplicate the caller won't close
+		// (err is nil). Close it so the duplicate transport stack doesn't leak.
+		fc.Close() //nolint:errcheck,gosec
 		return c, nil
 
 	// In case of new connection perform/accept handshake.


### PR DESCRIPTION
## Incident
The transport-discovery CXO node was under **sustained excessive CPU** (a live pprof CPU profile was ~90% `runtime` GC scan/sweep). Its heap was **~4 GB**: ~1000 *live* connections but **~150k retained dead connection stacks** (`transport.Connection` + `noise` ReadWriter + `yamux` stream + `bufio`) — i.e. a connection-object leak driving GC thrash.

## Root cause
`DMSG.acceptConn` (transport_dmsg.go) — unlike `TCP`/`UDP` `acceptConn`, which pre-guard duplicates via `getConn` — calls `initConn` directly. When a peer reconnects while its previous `Conn` still lingers in the node maps, `initConn`'s `onNewConn` dedup returns the **existing** `Conn` with `err == nil`, and the freshly-accepted `fc` (whose `readLoop`/`writeLoop` are already running) is **orphaned**: the caller only closes `fc` on **error**, so the unused duplicate transport stack is never freed. Under constant fleet churn every duplicate dmsg accept leaked a full stack → ~150k over ~15h → 4 GB.

## Fix
In `initConn`'s two *existing-connection-returned* paths (`!isNew && !isPending`, and the outgoing `!isNew && isPending` after `waitForInit`), close the unused `fc`. `c` there is the pre-existing `Conn` with its own transport; `fc` is the duplicate we were handed. Fixing it at the `initConn` level covers all transports uniformly (not just a per-`acceptConn` guard).

`pkg/cxo/node/...` tests pass; lint clean.

## Deploy
Deploys fleet-wide via the update channel. The tpd (and other CXO publishers) should be **restarted once** to shed the already-accumulated ~4 GB — the fix stops new leakage but doesn't reclaim what's already retained.