### PR TITLE
fix(visor): add the CXOFeedString alias (unbreaks pkg/visor test build)

### DIFF
--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -64,6 +64,10 @@ const (
 // timeout is per-feed (the all-transports feed needs longer than the rest).
 var feedFirstSyncTimeout = cxosub.FeedFirstSyncTimeout
 
+// CXOFeedString maps a feed constant to its stable string label. Kept as a
+// visor-package alias for existing callers (helpers_test.go round-trips it).
+var CXOFeedString = cxosub.FeedString
+
 // CXOFeedFromString is the inverse of the feed string label. Kept as a
 // visor-package alias for existing callers.
 var CXOFeedFromString = cxosub.FeedFromString


### PR DESCRIPTION
`helpers_test.go`'s `TestCXOFeedStringRoundTrip` (added in #2935) calls `CXOFeedString`, but only its inverse `CXOFeedFromString` was aliased into the visor package — `CXOFeedString` was never added, so `go test`/golangci-lint on `pkg/visor` failed to typecheck (`undefined: CXOFeedString`) on **develop**, red-lining CI for every branch. Adds the missing alias to `cxosub.FeedString`, mirroring `CXOFeedFromString`. Test passes.