### PR TITLE
fix(log): route go-socks5's logger through logrus in the resolving proxies

### DIFF
--- a/cmd/apps/vpn-client/commands/vpn-client_test.go
+++ b/cmd/apps/vpn-client/commands/vpn-client_test.go
@@ -7,7 +7,9 @@
 // without refactoring, which is intentionally out of scope here.
 package commands
 
-import "testing"
+import (
+	"testing"
+)
 
 // TestEnvInt covers envInt's parsing rules: unset, valid, zero, negative and
 // non-numeric values.

--- a/go.sum
+++ b/go.sum
@@ -525,6 +525,7 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNU
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/cpuid/v2 v2.4.0 h1:S6Hrbc7+ywsr0r+RLapfGBHfyefhCTwEh3A0tV913Dw=
 github.com/klauspost/cpuid/v2 v2.4.0/go.mod h1:19jmZ9mjzoF//ddRSUsv0zfBTJWh3QJh9FNxZTMrGxU=
 github.com/klauspost/reedsolomon v1.14.1 h1:swE9kzyWXD/wVG+l5Pe8bWnQ0giIY7D1GjCBKk3kG2U=

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -259,6 +259,10 @@ func normalize(cfg Config) Config {
 // streams are wrapped in tcpAddrConn.
 func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Client, cfg Config) error {
 	conf := &socks5.Config{
+		// Route go-socks5's own [ERR] lines through logrus so they match the
+		// rest of the visor's log format instead of the library's raw stdout
+		// default.
+		Logger:   logging.NewStdLogger(log),
 		Resolver: &dmsgResolver{cfg: cfg},
 		Dial: func(dialCtx context.Context, network, addr string) (conn net.Conn, dialErr error) {
 			defer func() {

--- a/pkg/logging/stdlog.go
+++ b/pkg/logging/stdlog.go
@@ -1,0 +1,59 @@
+// Package logging pkg/logging/stdlog.go
+//
+// Adapter that lets third-party libraries which only accept a stdlib
+// *log.Logger (e.g. armon/go-socks5's Config.Logger) funnel their output
+// through logrus, so their lines get the same timestamp format, colors, and
+// hooks as the rest of skywire instead of being written raw to stdout.
+package logging
+
+import (
+	stdlog "log"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// logrusWriter adapts a logrus FieldLogger to io.Writer. Each Write is one
+// log record; a leading level tag (e.g. "[ERR]", as armon/go-socks5 emits)
+// is stripped and mapped to the corresponding logrus level.
+type logrusWriter struct {
+	log logrus.FieldLogger
+}
+
+func (w logrusWriter) Write(p []byte) (int, error) {
+	msg := strings.TrimRight(string(p), "\n")
+	level := logrus.InfoLevel
+	if strings.HasPrefix(msg, "[") {
+		if end := strings.IndexByte(msg, ']'); end > 0 {
+			switch strings.ToUpper(msg[1:end]) {
+			case "ERR", "ERROR":
+				level = logrus.ErrorLevel
+			case "WARN", "WARNING":
+				level = logrus.WarnLevel
+			case "DEBUG":
+				level = logrus.DebugLevel
+			}
+			msg = strings.TrimSpace(msg[end+1:])
+		}
+	}
+	switch level {
+	case logrus.ErrorLevel:
+		w.log.Error(msg)
+	case logrus.WarnLevel:
+		w.log.Warn(msg)
+	case logrus.DebugLevel:
+		w.log.Debug(msg)
+	default:
+		w.log.Info(msg)
+	}
+	return len(p), nil
+}
+
+// NewStdLogger returns a stdlib *log.Logger that routes every line it
+// receives through the given logrus logger (level auto-detected from a
+// leading "[ERR]"/"[WARN]"/"[DEBUG]" tag, defaulting to info). Hand it to
+// libraries that insist on *log.Logger so their output matches skywire's
+// log format instead of writing uncolored lines straight to stdout.
+func NewStdLogger(log logrus.FieldLogger) *stdlog.Logger {
+	return stdlog.New(logrusWriter{log: log}, "", 0)
+}

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -190,6 +190,10 @@ func (r *skynetResolver) Resolve(ctx context.Context, name string) (context.Cont
 
 func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, cfg Config) error {
 	conf := &socks5.Config{
+		// Route go-socks5's own [ERR] lines through logrus so they match the
+		// rest of the visor's log format (colored, module-tagged) instead of
+		// the library's raw stdout "2006/01/02 ... [ERR] socks:" default.
+		Logger:   logging.NewStdLogger(log),
 		Resolver: &skynetResolver{cfg: cfg},
 		Dial: func(dialCtx context.Context, network, addr string) (retConn net.Conn, retErr error) {
 			// Fail the single request instead of crashing the whole visor if


### PR DESCRIPTION
The embedded **skynetweb** and **dmsgweb** SOCKS5 resolving proxies left `socks5.Config.Logger` nil, so `armon/go-socks5` fell back to its stdlib default (`log.New(os.Stdout, "", LstdFlags)`). Its `[ERR] socks: ...` lines came out uncolored and in a different timestamp format, interleaved with the visor's colored logrus output:

```
[2026-07-06T09:26:24-05:00] DEBUG [embedded_skynetweb]: SOCKS5 → upstream addr="..."   <- logrus (colored)
2026/07/06 09:26:24 [ERR] socks: Failed to handle request: ...                          <- go-socks5 stdout (plain)
```

Adds `logging.NewStdLogger` — a stdlib `*log.Logger` that funnels each line through logrus, auto-detecting the level from a leading `[ERR]`/`[WARN]`/`[DEBUG]` tag — and wires it into both resolving-proxy SOCKS5 configs. Their lines now match the rest of the visor (colors, module tag, hooks, format).

The skysocks *exit* server (`pkg/skysocks/server.go`) has the same nil default but takes no logger and would need a constructor signature change; left out of this focused fix.