### PR TITLE
fix(cxo): back off the fill-break reconnect kick (TPD accept-side connection leak)

### DIFF
--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -55,6 +55,17 @@ const reconnectWatchdogTick = 30 * time.Second
 // watchdog goroutine.
 const reconnectConnectTimeout = 15 * time.Second
 
+// fill-break kick backoff (see fillBreakStreak): the Nth consecutive
+// fill-break kicks a reconnect only once fillBreakKickBase<<(N-1) has
+// elapsed since the last kick, capped at fillBreakKickMax. So the first
+// break kicks ~immediately, then 2s, 4s, 8s … up to the cap — a feed
+// that never fills converges to the quiet-threshold watchdog cadence
+// instead of tight-looping reconnects into the publisher's accept path.
+const (
+	fillBreakKickBase = 2 * time.Second
+	fillBreakKickMax  = reconnectQuietThreshold
+)
+
 // UpdateEvent describes a single leaf change observed by the
 // subscriber. Value is nil when the leaf was deleted (path missing
 // in the new Root that was present in the previous one).
@@ -142,6 +153,17 @@ type Subscriber struct {
 	// quiet threshold. Buffered (cap 1) so repeated breaks coalesce into
 	// at most one pending kick. Created alongside reconnectStop.
 	reconnectKick chan struct{}
+	// fillBreakStreak counts consecutive fill-breaks since the last
+	// successful fill; lastFillBreakKickNs is the last time a break kicked
+	// a reconnect. Together they exponentially back the kick off so a feed
+	// that PERSISTENTLY fails to fill (e.g. one too large to ever fetch
+	// over a flaky link, like TPD's all-transports feed) can't tight-loop
+	// reconnects and flood the publisher's accept path — a persistent break
+	// converges to the plain quiet-threshold watchdog cadence, while a
+	// transient break (fills after one reconnect) still recovers fast.
+	// handleRootFilled resets the streak on success.
+	fillBreakStreak     atomic.Int64
+	lastFillBreakKickNs atomic.Int64
 	// reconnectAttempts counts watchdog-triggered Connect attempts
 	// (incremented BEFORE the Connect call regardless of outcome).
 	// Surfaced only for tests; treat as opaque metric otherwise.
@@ -782,6 +804,10 @@ func (s *Subscriber) handleRootFilled(r *registry.Root) {
 	// matching Roots or walk-failures don't count as live activity
 	// for THIS subscriber's purposes.
 	s.lastUpdateNs.Store(time.Now().UnixNano())
+	// A successful fill clears the fill-break backoff so the next transient
+	// break gets a fast kick again.
+	s.fillBreakStreak.Store(0)
+	s.lastFillBreakKickNs.Store(0)
 	// Signal any ConnectAndWaitForRoot caller blocked on this
 	// subscriber that a Root was received and the fill walk
 	// completed — the subscription is verifiably live now.
@@ -830,16 +856,41 @@ func (s *Subscriber) handleFillingBreaks(r *registry.Root, err error) {
 	if r.Pub != skycipher.PubKey(s.feedPK) {
 		return
 	}
+	// Proactive recovery (the follow-up this hook's comment anticipated):
+	// ask the watchdog to re-Connect so the publisher re-pushes the Root and
+	// the fill retries, instead of waiting out the quiet threshold (~90s).
+	// BUT exponentially back off (fillBreakStreak) so a feed that never fills
+	// — e.g. one too large to fetch over a flaky link, like TPD's
+	// all-transports feed — can't tight-loop reconnects and flood the
+	// publisher's accept path (that regressed TPD into a multi-GB accept-side
+	// connection leak). A transient break fills after one reconnect and the
+	// streak resets in handleRootFilled; a persistent break converges to the
+	// quiet-threshold watchdog cadence.
+	streak := s.fillBreakStreak.Add(1)
+	shift := streak - 1
+	if shift > 6 { // 2s<<6 = 128s already exceeds the cap; avoid shift overflow
+		shift = 6
+	}
+	backoff := fillBreakKickBase << uint(shift)
+	if backoff > fillBreakKickMax {
+		backoff = fillBreakKickMax
+	}
+	now := time.Now().UnixNano()
+	if last := s.lastFillBreakKickNs.Load(); last != 0 && time.Duration(now-last) < backoff {
+		s.log.WithError(err).
+			WithField("feed", s.feedPK.Hex()).WithField("seq", r.Seq).
+			WithField("break_streak", streak).
+			Debug("treestore-sub: Root filling aborted; kick backed off (persistent break)")
+		return
+	}
+	s.lastFillBreakKickNs.Store(now)
 	s.log.WithError(err).
 		WithField("feed", s.feedPK.Hex()).
 		WithField("seq", r.Seq).
-		Warn("treestore-sub: Root filling aborted; kicking an immediate re-Connect to re-fetch")
-	// Proactive recovery (the follow-up this hook's comment anticipated):
-	// ask the watchdog to re-Connect immediately so the publisher re-pushes
-	// the Root and the fill retries now, instead of waiting out the quiet
-	// threshold (~90s). Non-blocking — the cap-1 channel coalesces repeated
-	// breaks, and a nil channel (watchdog never started, e.g. native-TCP
-	// pre-Connect) just no-ops.
+		WithField("break_streak", streak).
+		Warn("treestore-sub: Root filling aborted; kicking a re-Connect to re-fetch")
+	// Non-blocking — the cap-1 channel coalesces repeated breaks, and a nil
+	// channel (watchdog never started, e.g. native-TCP pre-Connect) no-ops.
 	select {
 	case s.reconnectKick <- struct{}{}:
 	default:


### PR DESCRIPTION
## Urgent — fleet regression from #3407

The fill-break kick added in #3407 re-Connected a treestore subscriber the instant a Root failed to fill, **with no backoff**. For a feed that never fills — too large to fetch over a flaky link, e.g. **TPD's ~8 MB all-transports feed** that times out `firstSyncTimeout` — this tight-looped reconnects (break → kick → reconnect → Root push → break → …).

Each reconnect made **TPD's `DMSGFactory.acceptLoop` accept a fresh CXO connection**, and they accumulated on the accept side.

### Live diagnosis (TPD pprof over the dmsg SOCKS5 proxy)
- heap **4.18 GB inuse**: `pkg/cxo/node/transport.newConnection` **1.9 GB (45%)** + `bufio.NewReaderSize` 1.1 GB + dmsg noise streams ~1.3 GB
- allocation traces: **every leaked connection is from `DMSGFactory.acceptLoop`** (accept side)
- CPU profile: >70% in GC (`scanSpan`/`scanObject`) — GC-bound, same signature as the pre-#3403 leak
- grew to 4 GB within ~8h of the #3407 deploy (TPD restarted `07:12Z` on `73592b2a`)

## Fix
Exponential backoff keyed on a per-subscriber consecutive-break streak:
- first break still kicks ~immediately (**fast recovery for a transient break** — the wasm group-feed case #3407 targeted)
- each subsequent break without a successful fill doubles the min inter-kick interval (2s, 4s, 8s …) capped at the quiet threshold (60s)
- `handleRootFilled` resets the streak on any successful fill

So a persistently-unfillable feed converges to the plain ~60s watchdog cadence (its pre-#3407 behavior) and **cannot storm the publisher's accept path**, while the transient-break fast-recovery that makes wasm group chat work is preserved.

Local: build (native+wasm) + `go test ./pkg/cxo/treestore` + lint all clean.