### PR TITLE
fix(cxo): close the superseded conn on peer reconnect (accept-side connection leak)

### DIFF
--- a/pkg/cxo/node/transport_dmsg.go
+++ b/pkg/cxo/node/transport_dmsg.go
@@ -44,8 +44,25 @@ func newDMSG(n *Node, factory *transport.DMSGFactory) *DMSG {
 
 func (d *DMSG) addConn(pk cipher.PubKey, c *Conn) {
 	d.mx.Lock()
-	defer d.mx.Unlock()
+	old := d.cs[pk]
 	d.cs[pk] = c
+	d.mx.Unlock()
+	// A peer reconnected: a fresh Conn (accepted or dialed) supersedes an
+	// existing one for the same PK. Close the OLD conn so its transport
+	// read/write loops exit — dmsg does not reliably surface the old
+	// stream's close to us, so without this the superseded Conn's goroutine
+	// blocks forever in ReadRawFrame and the *Conn (+ its bufio readers +
+	// noise streams) never GC. That is one leak PER RECONNECT; under
+	// reconnect churn (e.g. subscribers to TPD's large all-transports feed)
+	// it accumulated into a multi-GB accept-side connection heap that turned
+	// TPD GC-bound. closeConn (added for the teardown path) never fired for
+	// these because nothing closed the old Conn, so its run loop never
+	// reached cleanup. Close OUTSIDE d.mx: Conn.Close → run-cleanup →
+	// closeConn re-takes d.mx, and closeConn is identity-checked so it only
+	// evicts `old` (already overwritten here), never the new `c`.
+	if old != nil && old != c {
+		old.Close() //nolint:errcheck,gosec
+	}
 }
 
 func (d *DMSG) getConn(pk cipher.PubKey) *Conn {


### PR DESCRIPTION
## Root cause of the TPD accept-side leak (companion to #3408)

`DMSG.addConn` overwrote `d.cs[pk] = c` **without closing the Conn it replaced**. When a peer reconnected (a fresh accepted/dialed Conn for a PK that already had one), the old Conn was dropped from the map but never closed — dmsg doesn't reliably surface the old stream's close, so its transport read/write loops blocked forever in `ReadRawFrame` and the `*Conn` (+ bufio readers + noise streams) never GC'd. **One leak per reconnect.**

`closeConn` (added for the teardown path, whose own comment documents this exact class — *"36,609 writeLoop goroutines, one per peer ever connected"*) never fired for these, because nothing closed the old Conn so its run loop never reached cleanup.

### Evidence (TPD pprof over the dmsg SOCKS5 proxy)
- 1.9 GB in `pkg/cxo/node/transport.newConnection`, **allocation traces show all of it from `DMSGFactory.acceptLoop`** (accept side)
- + ~1.3 GB dmsg noise streams → 4.18 GB heap, GC-bound ~90% CPU

## Fix
`addConn` closes the superseded Conn — **outside `d.mx`** (Conn.Close → run-cleanup → `closeConn` re-takes the lock; `closeConn` is identity-checked so it evicts only the old Conn, never the new one).

## Relationship to #3408
- **#3408** bounds the reconnect *rate* (backs off the fill-break kick so it can't storm) — defense in depth.
- **This** stops the per-reconnect *leak* at the source — the real root cause, independent of the kick (the normal 60s watchdog leaked it slowly too; the #3407 kick just made it fast).

Local: build (native+wasm) + `go test ./pkg/cxo/node` + lint clean.