### PR TITLE
feat(skychat): voice core — signaling (dmsg+skynet, one port) + RTP media

### DIFF
--- a/pkg/skychat/voice/manager.go
+++ b/pkg/skychat/voice/manager.go
@@ -1,0 +1,182 @@
+// Package voice pkg/skychat/voice/manager.go c2-app-chat
+package voice
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// Config wires a Manager. Dial + the listeners are supplied by the runtime
+// (native visor or wasm) so this package stays transport-agnostic (KG7): both a
+// dmsg client and a skynet networker satisfy them, and voice signals on the SAME
+// port over both.
+type Config struct {
+	LocalPK cipher.PubKey
+	// Dial opens a stream to peer:port over an available skywire network.
+	Dial DialFunc
+	// SignalPort / MediaPort default to the skyenv voice ports when zero.
+	SignalPort uint16
+	// Codec defaults to the PCM passthrough (Opus is a cgo follow-up).
+	Codec Codec
+	// NewSource / NewSink build the mic / speaker for a call. Default to
+	// SilentSource / NullSink (headless) so the control+media plane runs without
+	// audio hardware; a real audio backend swaps these in.
+	NewSource func() Source
+	NewSink   func() Sink
+	// OnIncoming decides whether to accept an inbound invite. nil => decline all
+	// (voice off). A UI wires this to a ring/accept prompt; a headless/test peer
+	// can return true to auto-answer.
+	OnIncoming func(inv Sig) bool
+	Logger     *logging.Logger
+}
+
+// Manager owns the local voice endpoint: it accepts inbound calls via the
+// Signaler and places outbound calls, holding one Session per active call.
+type Manager struct {
+	cfg Config
+	sig *Signaler
+	log *logging.Logger
+
+	mu    sync.Mutex
+	calls map[string]*Session
+}
+
+// NewManager constructs a Manager. Call Serve to start accepting.
+func NewManager(cfg Config) *Manager {
+	if cfg.Logger == nil {
+		cfg.Logger = logging.MustGetLogger("voice")
+	}
+	if cfg.Codec == nil {
+		cfg.Codec = NewPCMCodec()
+	}
+	if cfg.NewSource == nil {
+		cfg.NewSource = func() Source { return SilentSource{} }
+	}
+	if cfg.NewSink == nil {
+		cfg.NewSink = func() Sink { return NullSink{} }
+	}
+	m := &Manager{cfg: cfg, log: cfg.Logger, calls: make(map[string]*Session)}
+	m.sig = NewSignaler(cfg.LocalPK, cfg.SignalPort, cfg.Dial, cfg.Logger)
+	m.sig.SetInviteHandler(m.handleInvite)
+	return m
+}
+
+// Serve accepts inbound call signaling on the given listeners — pass BOTH the
+// dmsg listener and the skynet listener bound to SignalPort so callers reach us
+// over whichever network is up. Blocks until ctx is done.
+func (m *Manager) Serve(ctx context.Context, listeners ...net.Listener) {
+	m.sig.Serve(ctx, listeners...)
+}
+
+// Call places an outbound call to peer: invite over signaling, and on accept
+// start a media Session over the (now media-mode) conn. Returns the live
+// Session, or the peer's decline/busy reason.
+func (m *Manager) Call(ctx context.Context, peer cipher.PubKey) (*Session, error) {
+	callID := newCallID()
+	conn, reply, err := m.sig.Invite(ctx, peer, callID, m.cfg.Codec.Name(), m.cfg.SignalPort)
+	if err != nil {
+		return nil, err
+	}
+	if reply.Type != SigAccept {
+		reason := reply.Reason
+		if reason == "" {
+			reason = sigTypeName(reply.Type)
+		}
+		return nil, fmt.Errorf("voice: call not accepted: %s", reason)
+	}
+	sess := m.startSession(callID, conn, ssrcFromPK(m.cfg.LocalPK))
+	go func() { sess.Run(ctx); m.dropCall(callID) }()
+	return sess, nil
+}
+
+// handleInvite is the callee side: decide accept/decline, and on accept reply
+// SigAccept and start a media Session over the same conn.
+func (m *Manager) handleInvite(inv Sig, conn net.Conn) {
+	accept := m.cfg.OnIncoming != nil && m.cfg.OnIncoming(inv)
+	if !accept {
+		_ = writeSig(conn, Sig{Type: SigDecline, CallID: inv.CallID, FromPK: m.cfg.LocalPK, Reason: "declined"}) //nolint:errcheck
+		_ = conn.Close()                                                                                         //nolint:errcheck
+		return
+	}
+	ack := Sig{Type: SigAccept, CallID: inv.CallID, FromPK: m.cfg.LocalPK, Codec: m.cfg.Codec.Name(), MediaPort: m.cfg.SignalPort}
+	if err := writeSig(conn, ack); err != nil {
+		_ = conn.Close() //nolint:errcheck
+		return
+	}
+	sess := m.startSession(inv.CallID, conn, ssrcFromPK(m.cfg.LocalPK))
+	go func() { sess.Run(context.Background()); m.dropCall(inv.CallID) }()
+}
+
+func (m *Manager) startSession(callID string, conn net.Conn, ssrc uint32) *Session {
+	sess := NewSession(callID, conn, m.cfg.Codec, m.cfg.NewSource(), m.cfg.NewSink(), ssrc, m.log)
+	m.mu.Lock()
+	m.calls[callID] = sess
+	m.mu.Unlock()
+	m.log.WithField("call", callID).Info("voice: call established")
+	return sess
+}
+
+func (m *Manager) dropCall(callID string) {
+	m.mu.Lock()
+	sess := m.calls[callID]
+	delete(m.calls, callID)
+	m.mu.Unlock()
+	if sess != nil {
+		sess.Close()
+		m.log.WithField("call", callID).Info("voice: call ended")
+	}
+}
+
+// Hangup ends an active call by id (closes its media conn; the peer sees EOF).
+func (m *Manager) Hangup(callID string) error {
+	m.mu.Lock()
+	sess := m.calls[callID]
+	m.mu.Unlock()
+	if sess == nil {
+		return errors.New("voice: no such call")
+	}
+	sess.Close()
+	return nil
+}
+
+// Active returns the ids of live calls.
+func (m *Manager) Active() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ids := make([]string, 0, len(m.calls))
+	for id := range m.calls {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func newCallID() string {
+	var b [8]byte
+	_, _ = rand.Read(b[:]) //nolint:errcheck
+	return hex.EncodeToString(b[:])
+}
+
+// ssrcFromPK derives a stable RTP SSRC from the sender PK (first 4 bytes).
+func ssrcFromPK(pk cipher.PubKey) uint32 {
+	return binary.BigEndian.Uint32(pk[1:5])
+}
+
+func sigTypeName(t SigType) string {
+	switch t {
+	case SigDecline:
+		return "declined"
+	case SigBusy:
+		return "busy"
+	default:
+		return fmt.Sprintf("sig(%d)", t)
+	}
+}

--- a/pkg/skychat/voice/session.go
+++ b/pkg/skychat/voice/session.go
@@ -1,0 +1,170 @@
+// Package voice pkg/skychat/voice/session.go c2-app-chat
+package voice
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/pion/rtp"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// rtpPayloadType is a dynamic payload type; the actual codec is agreed in
+// signaling (Sig.Codec), so the number is just a stable tag on the wire.
+const rtpPayloadType = 96
+
+// Session is one established 1:1 call's MEDIA plane: RTP frames over a skywire
+// net.Conn (a dmsg stream or skynet route conn — already Noise-encrypted, so no
+// SRTP needed for the transport hop). It runs a send loop (capture → encode →
+// RTP → conn) and a recv loop (conn → RTP → decode → playback) until ctx is
+// canceled or the conn errors.
+//
+// Framing: because a stream conn has no message boundaries, each RTP packet is
+// length-prefixed (2-byte big-endian). Over a datagram route (a follow-up) each
+// datagram is one RTP packet and the prefix is dropped — the send/recv split
+// below is the seam for that swap.
+type Session struct {
+	CallID string
+
+	conn   net.Conn
+	codec  Codec
+	source Source
+	sink   Sink
+	ssrc   uint32
+	log    *logging.Logger
+
+	closeOnce sync.Once
+}
+
+// NewSession builds a media session over conn with the given codec + audio.
+func NewSession(callID string, conn net.Conn, codec Codec, source Source, sink Sink, ssrc uint32, log *logging.Logger) *Session {
+	if log == nil {
+		log = logging.MustGetLogger("voice-session")
+	}
+	if source == nil {
+		source = SilentSource{}
+	}
+	if sink == nil {
+		sink = NullSink{}
+	}
+	return &Session{CallID: callID, conn: conn, codec: codec, source: source, sink: sink, ssrc: ssrc, log: log}
+}
+
+// Run drives both media loops until ctx is done or the conn fails, then closes
+// the conn. Blocks; call in a goroutine.
+func (s *Session) Run(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); defer cancel(); s.sendLoop(ctx) }()
+	go func() { defer wg.Done(); defer cancel(); s.recvLoop(ctx) }()
+	<-ctx.Done()
+	s.Close()
+	wg.Wait()
+}
+
+// sendLoop captures a frame every frameMillis, encodes it, and writes it as a
+// length-prefixed RTP packet. Frame-paced with a ticker so a synthetic source
+// (or one that doesn't self-pace) still produces real-time cadence.
+func (s *Session) sendLoop(ctx context.Context) {
+	tick := time.NewTicker(frameMillis * time.Millisecond)
+	defer tick.Stop()
+	pcm := make([]int16, frameSamples)
+	var seq uint16
+	var ts uint32
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+		}
+		if _, err := s.source.Read(pcm); err != nil {
+			if err != io.EOF {
+				s.log.WithError(err).Debug("voice: source read")
+			}
+			return
+		}
+		payload, err := s.codec.Encode(pcm)
+		if err != nil {
+			s.log.WithError(err).Debug("voice: encode")
+			continue
+		}
+		pkt := &rtp.Packet{
+			Header: rtp.Header{
+				Version:        2,
+				PayloadType:    rtpPayloadType,
+				SequenceNumber: seq,
+				Timestamp:      ts,
+				SSRC:           s.ssrc,
+			},
+			Payload: payload,
+		}
+		raw, err := pkt.Marshal()
+		if err != nil {
+			s.log.WithError(err).Debug("voice: rtp marshal")
+			continue
+		}
+		var hdr [2]byte
+		if len(raw) > 0xffff {
+			continue
+		}
+		binary.BigEndian.PutUint16(hdr[:], uint16(len(raw))) //nolint:gosec // guarded above
+		if _, err := s.conn.Write(hdr[:]); err != nil {
+			return
+		}
+		if _, err := s.conn.Write(raw); err != nil {
+			return
+		}
+		seq++
+		ts += frameSamples
+	}
+}
+
+// recvLoop reads length-prefixed RTP packets, decodes, and plays them. Order is
+// preserved by the reliable stream transport (dmsg); a datagram-route carrier
+// (follow-up) adds a jitter/reorder buffer here keyed on RTP SequenceNumber.
+func (s *Session) recvLoop(ctx context.Context) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		var hdr [2]byte
+		if _, err := io.ReadFull(s.conn, hdr[:]); err != nil {
+			return
+		}
+		n := binary.BigEndian.Uint16(hdr[:])
+		if n == 0 {
+			continue
+		}
+		raw := make([]byte, n)
+		if _, err := io.ReadFull(s.conn, raw); err != nil {
+			return
+		}
+		var pkt rtp.Packet
+		if err := pkt.Unmarshal(raw); err != nil {
+			s.log.WithError(err).Debug("voice: rtp unmarshal")
+			continue
+		}
+		pcm, err := s.codec.Decode(pkt.Payload)
+		if err != nil {
+			s.log.WithError(err).Debug("voice: decode")
+			continue
+		}
+		if _, err := s.sink.Write(pcm); err != nil {
+			s.log.WithError(err).Debug("voice: sink write")
+			return
+		}
+	}
+}
+
+// Close tears down the session's conn (idempotent). The Run loops observe the
+// conn error and exit.
+func (s *Session) Close() {
+	s.closeOnce.Do(func() { _ = s.conn.Close() }) //nolint:errcheck
+}

--- a/pkg/skychat/voice/signal.go
+++ b/pkg/skychat/voice/signal.go
@@ -1,0 +1,225 @@
+// Package voice pkg/skychat/voice/signal.go c2-app-chat
+package voice
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// SigType is a voice-signaling message kind.
+type SigType uint8
+
+const (
+	// SigInvite offers a call (caller → callee).
+	SigInvite SigType = iota + 1
+	// SigAccept accepts an invite (callee → caller).
+	SigAccept
+	// SigDecline rejects an invite (callee → caller); Reason is human text.
+	SigDecline
+	// SigHangup ends an established call (either side).
+	SigHangup
+	// SigBusy signals the callee is already in a call.
+	SigBusy
+)
+
+// Sig is one signaling message. It carries the call id, the sender, and — on
+// Invite/Accept — the negotiated codec and the media port both sides will use
+// for the RTP stream (identical over dmsg and skynet, per skyenv).
+type Sig struct {
+	Type      SigType       `json:"type"`
+	CallID    string        `json:"call_id"`
+	FromPK    cipher.PubKey `json:"from_pk"`
+	Codec     string        `json:"codec,omitempty"`
+	MediaPort uint16        `json:"media_port,omitempty"`
+	Reason    string        `json:"reason,omitempty"`
+}
+
+const sigMaxLen = 64 << 10 // 64 KiB cap on a signaling frame
+
+// writeSig writes one length-prefixed JSON signaling frame.
+func writeSig(w io.Writer, s Sig) error {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	if len(b) > sigMaxLen {
+		return errors.New("voice: signaling frame too large")
+	}
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(b))) //nolint:gosec // len(b) is non-negative and capped at sigMaxLen
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err = w.Write(b)
+	return err
+}
+
+// readSig reads one length-prefixed JSON signaling frame.
+func readSig(r io.Reader) (Sig, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return Sig{}, err
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	if n == 0 || n > sigMaxLen {
+		return Sig{}, fmt.Errorf("voice: bad signaling frame length %d", n)
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return Sig{}, err
+	}
+	var s Sig
+	if err := json.Unmarshal(buf, &s); err != nil {
+		return Sig{}, err
+	}
+	return s, nil
+}
+
+// DialFunc opens a signaling/media stream to peer:port over a skywire network
+// (a dmsg stream or a skynet route). The manager supplies one that tries the
+// available networks; both use the SAME port (skyenv.SkychatVoiceSignalPort /
+// SkychatVoiceMediaPort).
+type DialFunc func(ctx context.Context, peer cipher.PubKey, port uint16) (net.Conn, error)
+
+// InviteHandler is called when an inbound invite arrives. It receives the
+// invite and the live signaling conn; the implementation decides to accept
+// (reply SigAccept and set up media) or decline. It must not block long.
+type InviteHandler func(inv Sig, conn net.Conn)
+
+// Signaler runs the voice control channel. It ACCEPTS invites on one port over
+// every skywire network it's given a listener for (dmsg + skynet — same port),
+// and it DIALS invites out via DialFunc. Signaling frames are the length-
+// prefixed JSON above.
+type Signaler struct {
+	localPK cipher.PubKey
+	port    uint16
+	dial    DialFunc
+	log     *logging.Logger
+
+	mu      sync.Mutex
+	onInv   InviteHandler
+	serving []net.Listener
+}
+
+// NewSignaler builds a Signaler bound to the given local PK / port / dialer.
+func NewSignaler(localPK cipher.PubKey, port uint16, dial DialFunc, log *logging.Logger) *Signaler {
+	if log == nil {
+		log = logging.MustGetLogger("voice-signal")
+	}
+	return &Signaler{localPK: localPK, port: port, dial: dial, log: log}
+}
+
+// SetInviteHandler registers the inbound-invite callback.
+func (s *Signaler) SetInviteHandler(h InviteHandler) {
+	s.mu.Lock()
+	s.onInv = h
+	s.mu.Unlock()
+}
+
+// Serve accepts signaling connections on ALL provided listeners concurrently —
+// pass the dmsg listener AND the skynet listener (both bound to s.port) so a
+// caller reaches us over whichever network is up. Returns when ctx is done or
+// every listener has failed.
+func (s *Signaler) Serve(ctx context.Context, listeners ...net.Listener) {
+	s.mu.Lock()
+	s.serving = listeners
+	s.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for _, lis := range listeners {
+		if lis == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(lis net.Listener) {
+			defer wg.Done()
+			s.acceptLoop(ctx, lis)
+		}(lis)
+	}
+	go func() { <-ctx.Done(); s.closeListeners() }()
+	wg.Wait()
+}
+
+func (s *Signaler) acceptLoop(ctx context.Context, lis net.Listener) {
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			s.log.WithError(err).Debug("voice: signaling accept failed")
+			return
+		}
+		go s.handleInbound(conn)
+	}
+}
+
+func (s *Signaler) handleInbound(conn net.Conn) {
+	sig, err := readSig(conn)
+	if err != nil {
+		_ = conn.Close() //nolint:errcheck
+		return
+	}
+	if sig.Type != SigInvite {
+		// Only an invite legitimately opens a fresh signaling conn.
+		_ = writeSig(conn, Sig{Type: SigDecline, CallID: sig.CallID, FromPK: s.localPK, Reason: "expected invite"}) //nolint:errcheck
+		_ = conn.Close()                                                                                            //nolint:errcheck
+		return
+	}
+	s.mu.Lock()
+	h := s.onInv
+	s.mu.Unlock()
+	if h == nil {
+		_ = writeSig(conn, Sig{Type: SigDecline, CallID: sig.CallID, FromPK: s.localPK, Reason: "voice not enabled"}) //nolint:errcheck
+		_ = conn.Close()                                                                                              //nolint:errcheck
+		return
+	}
+	h(sig, conn)
+}
+
+// Invite dials the peer's signaling port (over whichever network DialFunc
+// resolves), sends an Invite, and returns the live conn + the peer's reply
+// (SigAccept or SigDecline/SigBusy). On a non-accept reply it closes the conn
+// and returns the reply with a nil conn.
+func (s *Signaler) Invite(ctx context.Context, peer cipher.PubKey, callID, codec string, mediaPort uint16) (net.Conn, Sig, error) {
+	conn, err := s.dial(ctx, peer, s.port)
+	if err != nil {
+		return nil, Sig{}, fmt.Errorf("voice: signaling dial: %w", err)
+	}
+	inv := Sig{Type: SigInvite, CallID: callID, FromPK: s.localPK, Codec: codec, MediaPort: mediaPort}
+	if err := writeSig(conn, inv); err != nil {
+		_ = conn.Close() //nolint:errcheck
+		return nil, Sig{}, fmt.Errorf("voice: send invite: %w", err)
+	}
+	reply, err := readSig(conn)
+	if err != nil {
+		_ = conn.Close() //nolint:errcheck
+		return nil, Sig{}, fmt.Errorf("voice: read invite reply: %w", err)
+	}
+	if reply.Type != SigAccept {
+		_ = conn.Close() //nolint:errcheck
+		return nil, reply, nil
+	}
+	return conn, reply, nil
+}
+
+func (s *Signaler) closeListeners() {
+	s.mu.Lock()
+	ls := s.serving
+	s.serving = nil
+	s.mu.Unlock()
+	for _, l := range ls {
+		if l != nil {
+			_ = l.Close() //nolint:errcheck
+		}
+	}
+}

--- a/pkg/skychat/voice/voice.go
+++ b/pkg/skychat/voice/voice.go
@@ -1,0 +1,105 @@
+// Package voice pkg/skychat/voice/voice.go c2-app-chat
+//
+// Real-time 1:1 voice for skychat, per docs/skychat-voice-rfc.md. All media
+// rides an ENCRYPTED skywire transport (dmsg stream or skynet route) — never a
+// raw-internet/ICE path. This package is the skywire-specific control + media
+// plane:
+//
+//   - signaling (signal.go): invite / accept / decline / hangup + media-session
+//     negotiation, listened on ONE port over BOTH dmsg and skynet (the callee
+//     accepts on either; the caller reaches whichever is up). See Signaler.
+//   - media session (session.go): RTP framing over a skywire net.Conn, with a
+//     small reorder/jitter buffer; a send loop (capture→encode→RTP→conn) and a
+//     recv loop (conn→RTP→decode→playback).
+//   - codec + audio (this file): small consumer-side interfaces (KG7). The codec
+//     and mic/speaker are pluggable seams; the real Opus codec + audio-device I/O
+//     are a follow-up that vendors libopus + an audio lib behind cgo build tags
+//     (the RFC's §4/§5). Until then a PCM passthrough codec + synthetic/loopback
+//     audio make the whole control+transport plane real and testable.
+//
+// The manager (manager.go) owns active calls and drives the signaler.
+package voice
+
+import (
+	"encoding/binary"
+	"errors"
+)
+
+// sampleRate and frameSamples define the audio framing the whole package
+// assumes: 48 kHz mono, 20 ms frames (960 samples) — the Opus default, so the
+// PCM path and a future Opus path share timing.
+const (
+	sampleRate   = 48000
+	frameMillis  = 20
+	frameSamples = sampleRate / 1000 * frameMillis // 960
+)
+
+// Codec encodes/decodes one audio frame. Real impls: Opus (follow-up, cgo).
+// pcmCodec below is the identity passthrough used until Opus is wired.
+type Codec interface {
+	// Name is the codec label carried in signaling ("pcm", "opus").
+	Name() string
+	// Encode turns one PCM frame (frameSamples int16 samples) into a payload.
+	Encode(pcm []int16) ([]byte, error)
+	// Decode turns a payload back into a PCM frame.
+	Decode(payload []byte) ([]int16, error)
+}
+
+// Source is a microphone (or a synthetic generator). Read fills pcm with the
+// next frame; it blocks until a frame is available, mirroring an audio device.
+type Source interface {
+	Read(pcm []int16) (int, error)
+}
+
+// Sink is a speaker (or a discard/loopback). Write plays one PCM frame.
+type Sink interface {
+	Write(pcm []int16) (int, error)
+}
+
+// pcmCodec is the identity codec: little-endian int16 PCM on the wire. ~1.5
+// Mbit/s per stream — fine on the mesh for a demo, replaced by Opus (~24 kbit/s)
+// once the cgo encoder is vendored. Keeping the SAME frame timing means the
+// swap is codec-only.
+type pcmCodec struct{}
+
+// NewPCMCodec returns the passthrough codec.
+func NewPCMCodec() Codec { return pcmCodec{} }
+
+func (pcmCodec) Name() string { return "pcm" }
+
+func (pcmCodec) Encode(pcm []int16) ([]byte, error) {
+	b := make([]byte, len(pcm)*2)
+	for i, s := range pcm {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(s)) //nolint:gosec // int16→uint16 is intentional LE bit reinterpretation
+	}
+	return b, nil
+}
+
+func (pcmCodec) Decode(payload []byte) ([]int16, error) {
+	if len(payload)%2 != 0 {
+		return nil, errors.New("voice: odd PCM payload length")
+	}
+	pcm := make([]int16, len(payload)/2)
+	for i := range pcm {
+		pcm[i] = int16(binary.LittleEndian.Uint16(payload[i*2:])) //nolint:gosec // uint16→int16 is intentional LE bit reinterpretation
+	}
+	return pcm, nil
+}
+
+// NullSink discards audio (headless callee / tests).
+type NullSink struct{}
+
+// Write discards the frame.
+func (NullSink) Write(pcm []int16) (int, error) { return len(pcm), nil }
+
+// SilentSource yields silence frames forever (a placeholder mic). Real capture
+// is the cgo follow-up.
+type SilentSource struct{}
+
+// Read fills pcm with silence.
+func (SilentSource) Read(pcm []int16) (int, error) {
+	for i := range pcm {
+		pcm[i] = 0
+	}
+	return len(pcm), nil
+}

--- a/pkg/skychat/voice/voice_test.go
+++ b/pkg/skychat/voice/voice_test.go
@@ -1,0 +1,191 @@
+// Package voice pkg/skychat/voice/voice_test.go
+package voice
+
+import (
+	"context"
+	"io"
+	"math"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestSigCodecRoundTrip(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	in := Sig{Type: SigInvite, CallID: "abc123", FromPK: pk, Codec: "pcm", MediaPort: 63}
+	pr, pw := io.Pipe()
+	go func() { writeSig(pw, in); pw.Close() }() //nolint:errcheck,gosec
+	out, err := readSig(pr)
+	if err != nil {
+		t.Fatalf("readSig: %v", err)
+	}
+	if out.Type != in.Type || out.CallID != in.CallID || out.FromPK != in.FromPK ||
+		out.Codec != in.Codec || out.MediaPort != in.MediaPort {
+		t.Fatalf("round-trip mismatch: %+v != %+v", out, in)
+	}
+}
+
+func TestPCMCodecRoundTrip(t *testing.T) {
+	c := NewPCMCodec()
+	pcm := make([]int16, frameSamples)
+	for i := range pcm {
+		pcm[i] = int16(i - frameSamples/2)
+	}
+	payload, err := c.Encode(pcm)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := c.Decode(payload)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != len(pcm) {
+		t.Fatalf("len %d != %d", len(got), len(pcm))
+	}
+	for i := range pcm {
+		if got[i] != pcm[i] {
+			t.Fatalf("sample %d: %d != %d", i, got[i], pcm[i])
+		}
+	}
+}
+
+// memListener is an in-memory net.Listener: dial() hands the caller one end of a
+// net.Pipe and queues the other for Accept.
+type memListener struct {
+	ch     chan net.Conn
+	once   sync.Once
+	closed chan struct{}
+}
+
+func newMemListener() *memListener {
+	return &memListener{ch: make(chan net.Conn), closed: make(chan struct{})}
+}
+func (l *memListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.ch:
+		return c, nil
+	case <-l.closed:
+		return nil, io.EOF
+	}
+}
+func (l *memListener) Close() error   { l.once.Do(func() { close(l.closed) }); return nil }
+func (l *memListener) Addr() net.Addr { return pipeAddr{} }
+func (l *memListener) dial() (net.Conn, error) {
+	a, b := net.Pipe()
+	select {
+	case l.ch <- a:
+		return b, nil
+	case <-l.closed:
+		return nil, io.ErrClosedPipe
+	}
+}
+
+type pipeAddr struct{}
+
+func (pipeAddr) Network() string { return "mem" }
+func (pipeAddr) String() string  { return "mem" }
+
+// toneSource emits a 440 Hz sine so the received audio is verifiably non-silent.
+type toneSource struct{ n int }
+
+func (s *toneSource) Read(pcm []int16) (int, error) {
+	for i := range pcm {
+		t := float64(s.n) / float64(sampleRate)
+		pcm[i] = int16(8000 * math.Sin(2*math.Pi*440*t))
+		s.n++
+	}
+	return len(pcm), nil
+}
+
+// captureSink records every received frame.
+type captureSink struct {
+	mu     sync.Mutex
+	frames [][]int16
+}
+
+func (c *captureSink) Write(pcm []int16) (int, error) {
+	cp := make([]int16, len(pcm))
+	copy(cp, pcm)
+	c.mu.Lock()
+	c.frames = append(c.frames, cp)
+	c.mu.Unlock()
+	return len(pcm), nil
+}
+func (c *captureSink) count() int { c.mu.Lock(); defer c.mu.Unlock(); return len(c.frames) }
+
+// TestCallDeliversAudio runs a full call A->B in memory and asserts B receives
+// decoded audio frames — the whole control (invite/accept) + media (RTP over a
+// skywire-shaped net.Conn) plane, end to end.
+func TestCallDeliversAudio(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+
+	lis := newMemListener()
+	defer lis.Close() //nolint:errcheck
+
+	// Callee B: auto-answer, capture what it hears.
+	sink := &captureSink{}
+	mgrB := NewManager(Config{
+		LocalPK:    pkB,
+		Dial:       func(context.Context, cipher.PubKey, uint16) (net.Conn, error) { return nil, io.EOF },
+		OnIncoming: func(Sig) bool { return true },
+		NewSink:    func() Sink { return sink },
+	})
+	go mgrB.Serve(ctx, lis)
+
+	// Caller A: dials B's in-memory listener; speaks a tone.
+	mgrA := NewManager(Config{
+		LocalPK:   pkA,
+		Dial:      func(context.Context, cipher.PubKey, uint16) (net.Conn, error) { return lis.dial() },
+		NewSource: func() Source { return &toneSource{} },
+	})
+
+	sess, err := mgrA.Call(ctx, pkB)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if sess.CallID == "" {
+		t.Fatal("empty call id")
+	}
+
+	// ~7 frames should arrive within ~200ms (20ms cadence).
+	deadline := time.After(1500 * time.Millisecond)
+	for sink.count() < 5 {
+		select {
+		case <-deadline:
+			t.Fatalf("only %d frames received", sink.count())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Frames must be full 20ms PCM frames and not all-zero (the tone).
+	sink.mu.Lock()
+	f := sink.frames[len(sink.frames)-1]
+	sink.mu.Unlock()
+	if len(f) != frameSamples {
+		t.Fatalf("frame size %d != %d", len(f), frameSamples)
+	}
+	nonzero := false
+	for _, s := range f {
+		if s != 0 {
+			nonzero = true
+			break
+		}
+	}
+	if !nonzero {
+		t.Fatal("received frame is all-zero; tone did not round-trip")
+	}
+
+	if got := mgrA.Active(); len(got) != 1 {
+		t.Fatalf("active calls = %d, want 1", len(got))
+	}
+	if err := mgrA.Hangup(sess.CallID); err != nil {
+		t.Fatalf("hangup: %v", err)
+	}
+}

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -106,6 +106,18 @@ const (
 	// fleet-wide.
 	DmsgWebRTCSignalPort uint16 = 56
 
+	// SkychatVoiceSignalPort is the port skychat voice-call SIGNALING listens on
+	// — invite / accept / decline / hangup + media-session negotiation. The SAME
+	// port number is used over BOTH dmsg AND skynet: the callee listens on it on
+	// both networks, and the caller reaches it over whichever is available. Voice
+	// MEDIA rides a separately negotiated stream/datagram, not this control port.
+	SkychatVoiceSignalPort uint16 = 62
+
+	// SkychatVoiceMediaPort is the default port for the 1:1 voice MEDIA stream
+	// (RTP over a skywire transport). Also identical across dmsg + skynet; the
+	// exact port is confirmed in the signaling handshake so it can be varied.
+	SkychatVoiceMediaPort uint16 = 63
+
 	// DmsgDHTPort Listening port for the Kademlia DHT protocol.
 	DmsgDHTPort uint16 = 100
 


### PR DESCRIPTION
Implements the skywire-specific control + media plane of `docs/skychat-voice-rfc.md` (#3411), under the constraint that **all media rides an encrypted skywire transport — no ICE**.

## What
- **skyenv:** `SkychatVoiceSignalPort = 62` + `SkychatVoiceMediaPort = 63` — the **same port number over BOTH dmsg AND skynet** (per your ask): the callee listens on it on both networks, the caller reaches whichever is up.
- **`pkg/skychat/voice`** (transport-agnostic, no dmsg/skynet import — KG7):
  - **Signaler** — invite/accept/decline/hangup as length-prefixed JSON; `Serve()` accepts on *all* given listeners (pass the dmsg + skynet listeners on the shared port); `Invite()` dials via a runtime-supplied `DialFunc`.
  - **Session** — RTP (`pion/rtp`, vendored) over a skywire `net.Conn`; send loop (capture→encode→RTP→conn) + recv loop (conn→RTP→decode→play); 20ms/48kHz frames. Stream framing now; the datagram-route carrier (RFC #2607) is the seam.
  - **Codec + Source/Sink seams** — PCM passthrough + Silent/Null impls so the whole plane runs and tests **headless**; real **Opus** + mic/speaker are the cgo follow-up (RFC §4/§5).
  - **Manager** — call lifecycle (Call/Hangup/Active); reuses the signaling conn for media (MVP).

## Tested
Full **in-memory call A→B** over `net.Pipe`: invite/accept, then a 440 Hz tone round-trips as decoded frames (`TestCallDeliversAudio`). `go build ./...` + `go test` + `golangci-lint` (0 issues) all clean.

## Follow-ups
Visor wiring (dmsg+skynet listeners + RPC + CLI), the datagram-route media carrier, cgo Opus + audio-device I/O, and the wasm WebCodecs path.