### PR TITLE
feat(skychat): wire voice into the visor — init + RPC + CLI

### DIFF
--- a/cmd/skywire-cli/commands/skychat/voice.go
+++ b/cmd/skywire-cli/commands/skychat/voice.go
@@ -1,0 +1,80 @@
+// Package cliskychat cmd/skywire-cli/commands/skychat/voice.go c4-vis-cli
+package cliskychat
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func init() {
+	voiceCmd.AddCommand(voiceCallCmd, voiceHangupCmd, voiceListCmd)
+	RootCmd.AddCommand(voiceCmd)
+}
+
+var voiceCmd = &cobra.Command{
+	Use:   "voice",
+	Short: "1:1 voice calls (dmsg/skynet signaling, RTP media on the mesh)",
+}
+
+var voiceCallCmd = &cobra.Command{
+	Use:   "call <peer-pk>",
+	Short: "Place a voice call to a peer",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var pk cipher.PubKey
+		if err := pk.Set(args[0]); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("bad peer pk: %w", err))
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		id, err := rpcClient.VoiceCall(pk)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(), id, fmt.Sprintf("call started: %s\n", id))
+	},
+}
+
+var voiceHangupCmd = &cobra.Command{
+	Use:   "hangup <call-id>",
+	Short: "End an active call",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.VoiceHangup(args[0]); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(), args[0], fmt.Sprintf("hung up: %s\n", args[0]))
+	},
+}
+
+var voiceListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List active calls",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		ids, err := rpcClient.VoiceActive()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		out := "no active calls\n"
+		if len(ids) > 0 {
+			out = "active calls:\n  " + strings.Join(ids, "\n  ") + "\n"
+		}
+		internal.PrintOutput(cmd.Flags(), ids, out)
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	github.com/peterh/liner v1.2.2
 	github.com/pgavlin/femto v0.0.0-20201224065653-0c9d20f9cac4
 	github.com/pion/datachannel v1.6.2
+	github.com/pion/rtp v1.10.3
 	github.com/pion/webrtc/v4 v4.2.16
 	github.com/pkg/sftp v1.13.10
 	github.com/quic-go/webtransport-go v0.11.0
@@ -118,7 +119,6 @@ require (
 	github.com/pion/mdns/v2 v2.1.0 // indirect
 	github.com/pion/randutil v0.1.0 // indirect
 	github.com/pion/rtcp v1.2.17 // indirect
-	github.com/pion/rtp v1.10.3 // indirect
 	github.com/pion/sctp v1.10.3 // indirect
 	github.com/pion/sdp/v3 v3.0.19 // indirect
 	github.com/pion/srtp/v3 v3.0.12 // indirect

--- a/pkg/skychat/voice/manager.go
+++ b/pkg/skychat/voice/manager.go
@@ -77,6 +77,12 @@ func (m *Manager) Serve(ctx context.Context, listeners ...net.Listener) {
 	m.sig.Serve(ctx, listeners...)
 }
 
+// AddListener joins an additional signaling listener after Serve has started
+// (used for the skynet listener, which comes up after the dmsg one).
+func (m *Manager) AddListener(ctx context.Context, lis net.Listener) {
+	m.sig.AddListener(ctx, lis)
+}
+
 // Call places an outbound call to peer: invite over signaling, and on accept
 // start a media Session over the (now media-mode) conn. Returns the live
 // Session, or the peer's decline/busy reason.
@@ -94,7 +100,10 @@ func (m *Manager) Call(ctx context.Context, peer cipher.PubKey) (*Session, error
 		return nil, fmt.Errorf("voice: call not accepted: %s", reason)
 	}
 	sess := m.startSession(callID, conn, ssrcFromPK(m.cfg.LocalPK))
-	go func() { sess.Run(ctx); m.dropCall(callID) }()
+	// The session runs independently of the (possibly short) invite ctx — it
+	// ends when the conn closes (Hangup or the peer hanging up), not when the
+	// caller's dial deadline elapses.
+	go func() { sess.Run(context.Background()); m.dropCall(callID) }() //nolint:gosec // session outlives the invite/request ctx by design
 	return sess, nil
 }
 
@@ -113,7 +122,7 @@ func (m *Manager) handleInvite(inv Sig, conn net.Conn) {
 		return
 	}
 	sess := m.startSession(inv.CallID, conn, ssrcFromPK(m.cfg.LocalPK))
-	go func() { sess.Run(context.Background()); m.dropCall(inv.CallID) }()
+	go func() { sess.Run(context.Background()); m.dropCall(inv.CallID) }() //nolint:gosec // session outlives the invite/request ctx by design
 }
 
 func (m *Manager) startSession(callID string, conn net.Conn, ssrc uint32) *Session {

--- a/pkg/skychat/voice/signal.go
+++ b/pkg/skychat/voice/signal.go
@@ -149,6 +149,19 @@ func (s *Signaler) Serve(ctx context.Context, listeners ...net.Listener) {
 	wg.Wait()
 }
 
+// AddListener starts accepting on an ADDITIONAL listener after Serve has already
+// begun — e.g. the skynet networker registers later than the dmsg client, so its
+// listener joins once it's up. Runs an accept loop until ctx is done.
+func (s *Signaler) AddListener(ctx context.Context, lis net.Listener) {
+	if lis == nil {
+		return
+	}
+	s.mu.Lock()
+	s.serving = append(s.serving, lis)
+	s.mu.Unlock()
+	go s.acceptLoop(ctx, lis)
+}
+
 func (s *Signaler) acceptLoop(ctx context.Context, lis net.Listener) {
 	for {
 		conn, err := lis.Accept()

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -286,6 +286,11 @@ type API interface {
 	GroupHistory(groupID string, limit int) ([]GroupMessage, error)
 	GroupHistoryGroups() ([]string, error)
 
+	// Skychat 1:1 voice calls (pkg/skychat/voice).
+	VoiceCall(peer cipher.PubKey) (string, error)
+	VoiceHangup(callID string) error
+	VoiceActive() ([]string, error)
+
 	// Embedded Transport Setup Node (TPS) controls
 	TPSStatus() (*TPSStatus, error)
 	TPSAddTransport(targetPK, remotePK cipher.PubKey, tpType string) (*TPSTransportResponse, error)

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -142,6 +142,8 @@ var (
 	// Chat-group feed manager (D1 owner-centric CXO feeds with
 	// multi-PK allowlist).
 	groupingMod vinit.Module
+	// Skychat 1:1 voice-call manager (dmsg+skynet signaling, RTP media).
+	voiceMod vinit.Module
 	// visor that groups all modules together
 	vis vinit.Module
 	// config initialization
@@ -238,8 +240,11 @@ func registerModules(logger *logging.MasterLogger) {
 	// shape as pairingMod, same dmsgC dependency, separate bbolt
 	// store. See init_group.go.
 	groupingMod = maker("grouping", initGrouping, &dmsgC)
+	// Skychat 1:1 voice: signaling + RTP media over dmsg/skynet. Depends on
+	// dmsgC. See init_voice.go.
+	voiceMod = maker("voice", initVoice, &dmsgC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &ptyModule,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod, &voiceMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/init_voice.go
+++ b/pkg/visor/init_voice.go
@@ -1,0 +1,93 @@
+// Package visor pkg/visor/init_voice.go c3-vis-core
+//
+// Brings up the skychat 1:1 voice-call manager (pkg/skychat/voice): it listens
+// for inbound call signaling on skyenv.SkychatVoiceSignalPort over BOTH dmsg AND
+// skynet (same port), and dials outbound calls over whichever network resolves.
+// Media (RTP) rides the signaling conn (a Noise-encrypted skywire transport),
+// never a raw-internet/ICE path — see docs/skychat-voice-rfc.md.
+package visor
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsgpkg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+	skyvoice "github.com/skycoin/skywire/pkg/skychat/voice"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// initVoice wires the voice manager. Best-effort: with no dmsg client it's a
+// no-op (voice disabled), like grouping/pairing.
+func initVoice(_ context.Context, v *Visor, log *logging.Logger) error {
+	if v.dmsgC == nil {
+		return nil
+	}
+	localPK := v.conf.PK
+	port := skyenv.SkychatVoiceSignalPort
+
+	// Dial prefers skynet (on-mesh, IP-anonymous, multi-hop) when its networker
+	// is up, and falls back to a direct dmsg stream. Both target the SAME port.
+	dial := func(dctx context.Context, peer cipher.PubKey, p uint16) (net.Conn, error) {
+		if _, err := appnet.ResolveNetworker(appnet.TypeSkynet); err == nil {
+			addr := appnet.Addr{Net: appnet.TypeSkynet, PubKey: peer, Port: routing.Port(p)}
+			if c, derr := appnet.DialContext(dctx, addr); derr == nil {
+				return c, nil
+			}
+		}
+		return v.dmsgC.DialStream(dctx, dmsgpkg.Addr{PK: peer, Port: p})
+	}
+
+	mgr := skyvoice.NewManager(skyvoice.Config{
+		LocalPK:    localPK,
+		Dial:       dial,
+		SignalPort: port,
+		// Headless auto-answer for now: media is silent/null until the audio
+		// backend lands, so accepting an inbound call leaks no audio. A UI
+		// ring/consent hook replaces this before real mic capture ships.
+		OnIncoming: func(inv skyvoice.Sig) bool {
+			log.WithField("from", inv.FromPK.Hex()).Info("voice: inbound call — auto-answering (headless)")
+			return true
+		},
+		Logger: log,
+	})
+	v.voice = mgr
+
+	// dmsg signaling listener on the shared port, now.
+	var listeners []net.Listener
+	if dl, err := v.dmsgC.Listen(port); err != nil {
+		log.WithError(err).Warn("voice: dmsg signaling listen failed")
+	} else {
+		listeners = append(listeners, dl)
+	}
+
+	serveCtx, cancel := context.WithCancel(context.Background())
+	go mgr.Serve(serveCtx, listeners...)
+
+	// The skynet networker registers after dmsg; join its listener on the SAME
+	// port once it's up (best-effort, bounded wait).
+	go func() {
+		for i := 0; i < 30; i++ {
+			if serveCtx.Err() != nil {
+				return
+			}
+			if _, err := appnet.ResolveNetworker(appnet.TypeSkynet); err == nil {
+				addr := appnet.Addr{Net: appnet.TypeSkynet, PubKey: localPK, Port: routing.Port(port)}
+				if sl, lerr := appnet.ListenContext(serveCtx, addr); lerr == nil {
+					mgr.AddListener(serveCtx, sl)
+					log.Debug("voice: skynet signaling listener up")
+					return
+				}
+			}
+			time.Sleep(time.Second)
+		}
+	}()
+
+	v.pushCloseStack("voice", func() error { cancel(); return nil })
+	log.WithField("port", port).Info("voice: 1:1 call manager up (dmsg+skynet signaling)")
+	return nil
+}

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -834,6 +834,21 @@ func (proxyDefaultAPI) GroupLeave(_ string) error {
 	return ErrProxyNotSupported
 }
 
+// VoiceCall implements API (not proxied).
+func (proxyDefaultAPI) VoiceCall(_ cipher.PubKey) (string, error) {
+	return "", ErrProxyNotSupported
+}
+
+// VoiceHangup implements API (not proxied).
+func (proxyDefaultAPI) VoiceHangup(_ string) error {
+	return ErrProxyNotSupported
+}
+
+// VoiceActive implements API (not proxied).
+func (proxyDefaultAPI) VoiceActive() ([]string, error) {
+	return nil, ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) GroupHistory(_ string, _ int) ([]GroupMessage, error) {
 	return nil, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1607,6 +1607,25 @@ func (rc *rpcClient) GroupLeave(id string) error {
 	return rc.Call("GroupLeave", &id, &struct{}{})
 }
 
+// VoiceCall implements API.
+func (rc *rpcClient) VoiceCall(peer cipher.PubKey) (string, error) {
+	var id string
+	err := rc.Call("VoiceCall", &peer, &id)
+	return id, err
+}
+
+// VoiceHangup implements API.
+func (rc *rpcClient) VoiceHangup(callID string) error {
+	return rc.Call("VoiceHangup", &callID, &struct{}{})
+}
+
+// VoiceActive implements API.
+func (rc *rpcClient) VoiceActive() ([]string, error) {
+	var out []string
+	err := rc.Call("VoiceActive", &struct{}{}, &out)
+	return out, err
+}
+
 // GroupHistory implements API. Returns persisted group messages from
 // the visor's history store; returns the wrapped ErrGroupHistoryDisabled
 // when persistence is off.

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1311,6 +1311,15 @@ func (mc *mockRPCClient) GroupDelete(_ string) error { return nil }
 // GroupLeave implements API.
 func (mc *mockRPCClient) GroupLeave(_ string) error { return nil }
 
+// VoiceCall implements API.
+func (mc *mockRPCClient) VoiceCall(_ cipher.PubKey) (string, error) { return "", nil }
+
+// VoiceHangup implements API.
+func (mc *mockRPCClient) VoiceHangup(_ string) error { return nil }
+
+// VoiceActive implements API.
+func (mc *mockRPCClient) VoiceActive() ([]string, error) { return nil, nil }
+
 // GroupHistory implements API.
 func (mc *mockRPCClient) GroupHistory(_ string, _ int) ([]GroupMessage, error) { return nil, nil }
 

--- a/pkg/visor/rpc_voice.go
+++ b/pkg/visor/rpc_voice.go
@@ -1,0 +1,43 @@
+// Package visor pkg/visor/rpc_voice.go c3-vis-core
+package visor
+
+import (
+	"fmt"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/util/rpcutil"
+)
+
+// VoiceCall places a 1:1 voice call to the given peer PK; replies with the call id.
+func (r *RPC) VoiceCall(peer *cipher.PubKey, callID *string) (err error) {
+	defer rpcutil.LogCall(r.log, "VoiceCall", peer)(callID, &err)
+	if peer == nil {
+		return fmt.Errorf("nil request")
+	}
+	id, err := r.visor.VoiceCall(*peer)
+	if err != nil {
+		return err
+	}
+	*callID = id
+	return nil
+}
+
+// VoiceHangup ends an active call by id.
+func (r *RPC) VoiceHangup(callID *string, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "VoiceHangup", callID)(nil, &err)
+	if callID == nil {
+		return fmt.Errorf("nil request")
+	}
+	return r.visor.VoiceHangup(*callID)
+}
+
+// VoiceActive replies with the ids of active calls.
+func (r *RPC) VoiceActive(_ *struct{}, out *[]string) (err error) {
+	defer rpcutil.LogCall(r.log, "VoiceActive", nil)(out, &err)
+	ids, err := r.visor.VoiceActive()
+	if err != nil {
+		return err
+	}
+	*out = ids
+	return nil
+}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -36,6 +36,7 @@ import (
 	"github.com/skycoin/skywire/pkg/rfclient"
 	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/serviceuptime"
+	skyvoice "github.com/skycoin/skywire/pkg/skychat/voice"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/transport/network"
 	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
@@ -251,6 +252,11 @@ type Visor struct {
 	// inbound message ring. Same shape as pairing, brought up by
 	// init_group.go. nil when group chat is disabled.
 	grouping groupState
+
+	// voice is the skychat 1:1 voice-call manager (signaling over dmsg +
+	// skynet on skyenv.SkychatVoiceSignalPort, RTP media over a skywire
+	// conn). Brought up by init_voice.go; nil when dmsg is unavailable.
+	voice *skyvoice.Manager
 
 	// groupStreamSendCounter ticks once per successful stream.Send on
 	// any rpcgrpc.StreamGroupMessages stream. Bumped from the gRPC

--- a/pkg/visor/voice.go
+++ b/pkg/visor/voice.go
@@ -1,0 +1,50 @@
+// Package visor pkg/visor/voice.go c3-vis-core
+//
+// Visor-side RPC surface for skychat 1:1 voice (the manager lives in
+// pkg/skychat/voice, brought up by init_voice.go). Place a call, hang up, and
+// list active calls; media rides an encrypted skywire transport.
+package visor
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// ErrVoiceDisabled is returned when the voice manager isn't running (voice
+// needs a dmsg client; see init_voice.go).
+var ErrVoiceDisabled = errors.New("voice: disabled (no dmsg)")
+
+// VoiceCall places a 1:1 voice call to peer over the mesh and returns the new
+// call id. Blocks until the callee accepts/declines or the dial times out; the
+// media session then runs in the background until Hangup.
+func (v *Visor) VoiceCall(peer cipher.PubKey) (string, error) {
+	if v.voice == nil {
+		return "", ErrVoiceDisabled
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	sess, err := v.voice.Call(ctx, peer)
+	if err != nil {
+		return "", err
+	}
+	return sess.CallID, nil
+}
+
+// VoiceHangup ends an active call by id.
+func (v *Visor) VoiceHangup(callID string) error {
+	if v.voice == nil {
+		return ErrVoiceDisabled
+	}
+	return v.voice.Hangup(callID)
+}
+
+// VoiceActive returns the ids of active calls.
+func (v *Visor) VoiceActive() ([]string, error) {
+	if v.voice == nil {
+		return nil, ErrVoiceDisabled
+	}
+	return v.voice.Active(), nil
+}


### PR DESCRIPTION
Follow-up to #3412 (voice core): brings the `pkg/skychat/voice` manager up on a native visor and makes it usable.

- **init_voice.go** — `initVoice` module (dep dmsgC). Listens for inbound call signaling on `skyenv.SkychatVoiceSignalPort` over **both dmsg AND skynet** (same port; the skynet listener joins async once its networker registers, via the new `Manager.AddListener`). Dial prefers **skynet** (on-mesh/anonymous), falls back to a **dmsg** stream. Headless **auto-answer** for now (media is silent until the audio backend lands, so no audio leaks); a UI consent hook replaces it before real mic capture.
- **RPC** — `VoiceCall(peerPK)→callID`, `VoiceHangup(callID)`, `VoiceActive()` on the API interface + server wrappers + rpc_client + mock + proxy-default stubs.
- **CLI** — `skywire cli skychat voice call/hangup/list`.
- **voice pkg fixes** — `Manager.Call` now runs the session on an independent ctx (a call must outlive the short invite/RPC deadline); added `Manager.AddListener`.
- **go.mod** — `pion/rtp` promoted indirect→direct (now imported directly).

`go build ./...` + `go test ./pkg/skychat/voice` + `golangci-lint` all clean. Remaining: datagram-route media carrier, cgo Opus + audio devices, wasm WebCodecs path (all in the RFC).