### PR TITLE
feat(skychat): file sharing — Telegram-style, 1:1 + group, over dmsg/skynet

### DIFF
--- a/cmd/apps/skychat/commands/filexfer.go
+++ b/cmd/apps/skychat/commands/filexfer.go
@@ -128,10 +128,16 @@ type namedFile struct {
 
 // safeFileName reduces an offered name to a base name with no path separators or
 // traversal, falling back to the transfer id when the name is empty or unsafe.
+// It strips BOTH separators regardless of host OS so a Windows-style name from a
+// peer ("..\\..\\evil.exe") is sanitized on a Linux host and vice-versa.
 func safeFileName(name, id string) string {
-	name = filepath.Base(filepath.Clean("/" + name))
-	name = strings.TrimLeft(name, "/\\.")
-	if name == "" || name == "." {
+	// Normalize both separators, then keep only the last path component.
+	name = strings.ReplaceAll(name, `\`, "/")
+	if i := strings.LastIndexByte(name, '/'); i >= 0 {
+		name = name[i+1:]
+	}
+	name = strings.TrimLeft(name, ".")
+	if name == "" || strings.Contains(name, "..") {
 		name = "file-" + id
 	}
 	return name

--- a/cmd/apps/skychat/commands/filexfer.go
+++ b/cmd/apps/skychat/commands/filexfer.go
@@ -1,0 +1,479 @@
+// Package commands cmd/apps/skychat/filexfer.go
+//
+// File sharing for skychat (Telegram-style: a file is a message in the
+// conversation). The bytes ride pkg/skychat/xfer over a skywire stream (skynet
+// or dmsg — same port on both, skyenv.SkychatFilePort), OUT OF BAND from the
+// chat-message conn so a large transfer never blocks chat. The offer + result
+// surface as a chatEvent (file_* fields) into the same SSE/history stream as
+// text messages, so a UI renders it inline like any other message.
+//
+// Auto-accept policy (operator decision): once you've ESTABLISHED a chat with a
+// peer (there's a live conn) or you share a GROUP, inbound files are accepted
+// automatically — no per-file prompt. Files from a peer you've never talked to
+// are declined. Everything is encrypted by the skywire transport; nothing
+// touches the clearnet.
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skychat/xfer"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// fileMgr is the process-wide file-transfer manager, initialized by startFileXfer.
+var (
+	fileMgr   *xfer.Manager
+	fileMgrMu sync.Mutex
+)
+
+// downloadsDir returns (and creates) the directory received files are saved to:
+// <work-dir>/skychat-downloads, matching where the history DB lives.
+func downloadsDir() (string, error) {
+	workDir := ""
+	if appCl != nil {
+		workDir = appCl.Config().ProcWorkDir
+	}
+	if workDir == "" {
+		workDir = skyenv.LocalPath
+	}
+	dir := filepath.Join(workDir, "skychat-downloads")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// isEstablishedPeer reports whether we've already established a chat with pk (a
+// live conn exists) — the "already established a chat" half of the auto-accept
+// policy. Group membership is handled by the group path (filexfer_group.go).
+func isEstablishedPeer(pk cipher.PubKey) bool {
+	connsMu.Lock()
+	_, ok := conns[pk]
+	connsMu.Unlock()
+	return ok
+}
+
+// fileDialFunc opens a fresh transfer stream to peer on the file port, trying
+// skynet first (on-mesh, IP-anonymous) then dmsg — the same preference order as
+// the chat conn. It always uses SkychatFilePort on both networks.
+func fileDialFunc(_ context.Context, peer cipher.PubKey, port uint16) (net.Conn, error) {
+	if appCl == nil {
+		return nil, fmt.Errorf("skychat: app client not initialized")
+	}
+	var lastErr error
+	for _, netType := range []appnet.Type{appnet.TypeSkynet, appnet.TypeDmsg} {
+		addr := appnet.Addr{Net: netType, PubKey: peer, Port: routing.Port(port)}
+		conn, err := appCl.Dial(addr)
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("skychat: no network available for file dial")
+	}
+	return nil, lastErr
+}
+
+// acceptInbound implements the auto-accept policy and picks the save path. It
+// returns a file handle under the downloads dir plus whether to accept.
+func acceptInbound(from cipher.PubKey, offer xfer.Offer) (io.WriteCloser, bool) {
+	// Group files: accepted when we share the offered group. 1:1 files: accepted
+	// when a chat is already established with the sender.
+	accept := false
+	switch {
+	case offer.Group != "":
+		accept = isGroupMember(offer.Group, from)
+	default:
+		accept = isEstablishedPeer(from)
+	}
+	if !accept {
+		appLog("skychat: declining file %q from unestablished peer %s", offer.Name, from)
+		return nil, false
+	}
+	dir, err := downloadsDir()
+	if err != nil {
+		appLog("skychat: downloads dir: %v", err)
+		return nil, false
+	}
+	dst := filepath.Join(dir, safeFileName(offer.Name, offer.ID))
+	f, err := os.Create(dst) //nolint:gosec // dst is sanitized by safeFileName + rooted in downloadsDir
+	if err != nil {
+		appLog("skychat: create download %q: %v", dst, err)
+		return nil, false
+	}
+	return &namedFile{File: f, path: dst}, true
+}
+
+// namedFile carries the save path alongside the handle so onDone can report it.
+type namedFile struct {
+	*os.File
+	path string
+}
+
+// safeFileName reduces an offered name to a base name with no path separators or
+// traversal, falling back to the transfer id when the name is empty or unsafe.
+func safeFileName(name, id string) string {
+	name = filepath.Base(filepath.Clean("/" + name))
+	name = strings.TrimLeft(name, "/\\.")
+	if name == "" || name == "." {
+		name = "file-" + id
+	}
+	return name
+}
+
+// onXferDone surfaces a completed transfer (either direction) as a chatEvent and
+// logs the result. It runs on the xfer manager's goroutine.
+func onXferDone(dir xfer.Direction, peer cipher.PubKey, offer xfer.Offer, err error) {
+	ev := chatEvent{
+		ID:       offer.ID,
+		Channel:  channelDM,
+		FileID:   offer.ID,
+		FileName: offer.Name,
+		FileSize: offer.Size,
+	}
+	if offer.Group != "" {
+		ev.Channel = channelGroup
+		ev.GroupID = offer.Group
+	}
+	switch dir {
+	case xfer.Incoming:
+		ev.Dir = "in"
+		ev.From = peer.Hex()
+		if err != nil {
+			ev.FileStatus = "failed"
+			ev.Text = fmt.Sprintf("📎 %s — receive failed: %v", offer.Name, err)
+		} else {
+			ev.FileStatus = "received"
+			ev.Text = fmt.Sprintf("📎 %s (%s)", offer.Name, humanSize(offer.Size))
+			if dir, derr := downloadsDir(); derr == nil {
+				ev.FilePath = filepath.Join(dir, safeFileName(offer.Name, offer.ID))
+			}
+		}
+	case xfer.Outgoing:
+		ev.Dir = "out"
+		ev.To = peer.Hex()
+		if err != nil {
+			ev.FileStatus = "failed"
+			ev.Text = fmt.Sprintf("📎 %s — send failed: %v", offer.Name, err)
+		} else {
+			ev.FileStatus = "sent"
+			ev.Text = fmt.Sprintf("📎 %s (%s)", offer.Name, humanSize(offer.Size))
+		}
+	}
+	if hub != nil {
+		hub.publishEvent(ev)
+	}
+	if err != nil {
+		appLog("skychat: file %s %s <-> %s: %v", dir, offer.Name, peer, err)
+	} else {
+		appLog("skychat: file %s %s <-> %s (%s)", dir, offer.Name, peer, humanSize(offer.Size))
+	}
+}
+
+// startFileXfer builds the file-transfer manager and starts listeners on the
+// file port over the enabled networks. Safe to call once during startup; a nil
+// appCl (standalone/no-net) disables it.
+func startFileXfer(ctx context.Context) {
+	if appCl == nil {
+		return
+	}
+	fileMgrMu.Lock()
+	defer fileMgrMu.Unlock()
+	if fileMgr != nil {
+		return
+	}
+	mgr := xfer.NewManager(xfer.Config{
+		LocalPK: appCl.Config().VisorPK,
+		Dial:    fileDialFunc,
+		Port:    skyenv.SkychatFilePort,
+		Accept:  acceptInbound,
+		OnDone:  onXferDone,
+	})
+	fileMgr = mgr
+
+	var listeners []net.Listener
+	for _, netType := range enabledFileNets() {
+		l, err := appCl.Listen(netType, routing.Port(skyenv.SkychatFilePort))
+		if err != nil {
+			appLog("skychat: file listen on %s failed: %v", netType, err)
+			continue
+		}
+		appLog("skychat: file transfer listening on %s port %d", netType, skyenv.SkychatFilePort)
+		listeners = append(listeners, l)
+	}
+	if len(listeners) == 0 {
+		appLog("skychat: file transfer has no listeners (no network enabled)")
+		return
+	}
+	go mgr.Serve(ctx, listeners...)
+}
+
+// enabledFileNets returns the networks to listen on for file transfer, mirroring
+// the chat listenLoop gating.
+func enabledFileNets() []appnet.Type {
+	var nets []appnet.Type
+	if useSkynet {
+		nets = append(nets, appnet.TypeSkynet)
+	}
+	if useDmsg {
+		nets = append(nets, appnet.TypeDmsg)
+	}
+	return nets
+}
+
+// sendFileToPeer streams the file at path to peer (1:1). It runs the transfer to
+// completion (blocking) and returns the transfer id and the receiver's verdict.
+func sendFileToPeer(ctx context.Context, peer cipher.PubKey, path string) (string, error) {
+	return sendFile(ctx, peer, "", path)
+}
+
+// sendFile streams path to peer; when group != "" the offer is stamped with the
+// group id (used by the group path). Shared by 1:1 and group sends.
+func sendFile(ctx context.Context, peer cipher.PubKey, group, path string) (string, error) {
+	fileMgrMu.Lock()
+	mgr := fileMgr
+	fileMgrMu.Unlock()
+	if mgr == nil {
+		return "", fmt.Errorf("skychat: file transfer not enabled")
+	}
+	f, err := os.Open(path) //nolint:gosec // operator-supplied local path to send
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }() //nolint:errcheck
+	fi, err := f.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat %s: %w", path, err)
+	}
+	if fi.IsDir() {
+		return "", fmt.Errorf("%s is a directory", path)
+	}
+	name := filepath.Base(path)
+	offer := xfer.Offer{
+		ID:    newEventID(),
+		Name:  name,
+		Size:  fi.Size(),
+		MIME:  mime.TypeByExtension(filepath.Ext(name)),
+		Group: group,
+	}
+	rc, err := mgr.SendFile(ctx, peer, offer, f)
+	if err != nil {
+		return offer.ID, err
+	}
+	if !rc.OK {
+		return offer.ID, fmt.Errorf("peer rejected transfer: %s", rc.Err)
+	}
+	return offer.ID, nil
+}
+
+// isGroupMember reports whether pk is a current member of the active CXO group
+// groupID. Used by the auto-accept policy: a file stamped with a group we're in,
+// coming from a fellow member, is accepted without a prompt.
+func isGroupMember(groupID string, pk cipher.PubKey) bool {
+	if cxoGroupSess == nil || groupID == "" || groupID != cxoGroup {
+		return false
+	}
+	for _, p := range cxoGroupSess.PeerPKs() {
+		if p == pk {
+			return true
+		}
+	}
+	return false
+}
+
+// sendFileToGroup fans the file at path out to every current member of the
+// active CXO group over an encrypted file stream (members auto-accept). It
+// returns the number of members the send was dispatched to; per-member results
+// surface as individual "out" chatEvents via onXferDone. A member that's offline
+// simply fails its leg — the others are unaffected.
+func sendFileToGroup(ctx context.Context, path string) (int, error) {
+	if cxoGroupSess == nil || cxoGroup == "" {
+		return 0, fmt.Errorf("skychat: no active group")
+	}
+	peers := cxoGroupSess.PeerPKs()
+	if len(peers) == 0 {
+		return 0, fmt.Errorf("skychat: group %q has no other members online", cxoGroup)
+	}
+	for _, pk := range peers {
+		pk := pk
+		go func() {
+			sctx, cancel := context.WithTimeout(ctx, sendTimeout)
+			defer cancel()
+			if _, err := sendFile(sctx, pk, cxoGroup, path); err != nil {
+				appLog("skychat: group file to %s failed: %v", pk, err)
+			}
+		}()
+	}
+	return len(peers), nil
+}
+
+// humanSize renders a byte count as a short human string.
+func humanSize(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for m := n / unit; m >= unit; m /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+// sendTimeout bounds a single outbound file transfer.
+const sendTimeout = 30 * time.Minute
+
+// maxUploadMemory is the in-memory portion of a multipart upload before spilling
+// to a temp file.
+const maxUploadMemory = 8 << 20 // 8 MiB
+
+// sendFileHandler serves POST /send-file. It sends a file either 1:1 (form field
+// "pk"=recipient hex) or to the active group (form field "group"=group id or
+// "1"). The file bytes come from a multipart "file" upload (browser) or, when no
+// upload is present, a local "path" on the host (CLI). Responds with JSON
+// {"id":...} on a dispatched send.
+func sendFileHandler(ctx context.Context) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		// A multipart upload spills large bodies to temp files internally.
+		if err := r.ParseMultipartForm(maxUploadMemory); err != nil && r.MultipartForm == nil {
+			// Not multipart — fall back to plain form values (path-based send).
+			if perr := r.ParseForm(); perr != nil {
+				http.Error(w, "bad form: "+perr.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+
+		pkHex := strings.TrimSpace(r.FormValue("pk"))
+		groupVal := strings.TrimSpace(r.FormValue("group"))
+
+		// Resolve the source file: uploaded bytes take priority over a host path.
+		path, cleanup, name, err := resolveUploadOrPath(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if cleanup != nil {
+			defer cleanup()
+		}
+		_ = name // name is derived from path inside sendFile
+
+		sctx, cancel := context.WithTimeout(ctx, sendTimeout)
+		defer func() {
+			// The group path returns immediately (fan-out goroutines own their own
+			// ctx); the 1:1 path completes synchronously, so cancel after it.
+			if pkHex != "" {
+				cancel()
+			}
+		}()
+
+		switch {
+		case groupVal != "":
+			n, gerr := sendFileToGroup(ctx, path)
+			if gerr != nil {
+				cancel()
+				http.Error(w, gerr.Error(), http.StatusServiceUnavailable)
+				return
+			}
+			cancel()
+			writeJSON(w, map[string]any{"dispatched": n, "group": cxoGroup})
+		case pkHex != "":
+			var pk cipher.PubKey
+			if perr := pk.Set(pkHex); perr != nil {
+				http.Error(w, "bad pk: "+perr.Error(), http.StatusBadRequest)
+				return
+			}
+			id, serr := sendFileToPeer(sctx, pk, path)
+			if serr != nil {
+				http.Error(w, serr.Error(), http.StatusBadGateway)
+				return
+			}
+			writeJSON(w, map[string]any{"id": id, "pk": pkHex})
+		default:
+			http.Error(w, "specify pk (1:1) or group", http.StatusBadRequest)
+		}
+	}
+}
+
+// resolveUploadOrPath returns a local filesystem path to send. If the request
+// carries a multipart "file", it's saved to a temp file (returned with a cleanup
+// func). Otherwise the "path" form value is used directly (no cleanup).
+func resolveUploadOrPath(r *http.Request) (path string, cleanup func(), name string, err error) {
+	if r.MultipartForm != nil {
+		if f, hdr, ferr := r.FormFile("file"); ferr == nil {
+			defer func() { _ = f.Close() }() //nolint:errcheck
+			tmp, terr := os.CreateTemp("", "skychat-upload-*")
+			if terr != nil {
+				return "", nil, "", fmt.Errorf("temp file: %w", terr)
+			}
+			if _, cerr := io.Copy(tmp, f); cerr != nil {
+				_ = tmp.Close()           //nolint:errcheck
+				_ = os.Remove(tmp.Name()) //nolint:errcheck
+				return "", nil, "", fmt.Errorf("save upload: %w", cerr)
+			}
+			_ = tmp.Close() //nolint:errcheck
+			tmpPath := tmp.Name()
+			// Preserve the original name for the offer by renaming into place.
+			named := filepath.Join(filepath.Dir(tmpPath), safeFileName(hdr.Filename, filepath.Base(tmpPath)))
+			if rerr := os.Rename(tmpPath, named); rerr == nil {
+				tmpPath = named
+			}
+			cleanupPath := tmpPath
+			return tmpPath, func() { _ = os.Remove(cleanupPath) }, hdr.Filename, nil //nolint:errcheck
+		}
+	}
+	p := strings.TrimSpace(r.FormValue("path"))
+	if p == "" {
+		return "", nil, "", fmt.Errorf("no file: attach a multipart 'file' or set 'path'")
+	}
+	return p, nil, filepath.Base(p), nil
+}
+
+// downloadFileHandler serves GET /files/<name> from the downloads dir so a UI can
+// fetch a received file. The name is sanitized to a base name rooted in the
+// downloads dir (no traversal).
+func downloadFileHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "GET only", http.StatusMethodNotAllowed)
+		return
+	}
+	name := strings.TrimPrefix(r.URL.Path, "/files/")
+	name = safeFileName(name, "")
+	if name == "" {
+		http.Error(w, "no file", http.StatusBadRequest)
+		return
+	}
+	dir, err := downloadsDir()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// name is a sanitized base name (safeFileName strips separators + traversal),
+	// so the join stays rooted in the downloads dir.
+	http.ServeFile(w, r, filepath.Join(dir, name)) //nolint:gosec // name sanitized by safeFileName
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v) //nolint:errcheck
+}

--- a/cmd/apps/skychat/commands/filexfer_test.go
+++ b/cmd/apps/skychat/commands/filexfer_test.go
@@ -1,0 +1,100 @@
+// Package commands cmd/apps/skychat/filexfer_test.go
+package commands
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestSafeFileName(t *testing.T) {
+	cases := []struct {
+		in, id, want string
+	}{
+		{"photo.png", "x", "photo.png"},
+		{"../../etc/passwd", "x", "passwd"},
+		{"/abs/path/file.txt", "x", "file.txt"},
+		{"nested/dir/name.dat", "x", "name.dat"},
+		{"", "abc", "file-abc"},
+		{"...", "abc", "file-abc"},
+		{`..\..\windows\evil.exe`, "x", "evil.exe"},
+	}
+	for _, c := range cases {
+		if got := safeFileName(c.in, c.id); got != c.want {
+			t.Errorf("safeFileName(%q,%q) = %q, want %q", c.in, c.id, got, c.want)
+		}
+		// A sanitized name must never contain a path separator or traversal.
+		got := safeFileName(c.in, c.id)
+		if strings.ContainsAny(got, `/\`) || strings.Contains(got, "..") {
+			t.Errorf("safeFileName(%q) leaked a path: %q", c.in, got)
+		}
+	}
+}
+
+func TestHumanSize(t *testing.T) {
+	cases := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1073741824, "1.0 GB"},
+	}
+	for _, c := range cases {
+		if got := humanSize(c.n); got != c.want {
+			t.Errorf("humanSize(%d) = %q, want %q", c.n, got, c.want)
+		}
+	}
+}
+
+// TestSendFileHandlerRejects covers the validation paths that don't need a live
+// transport: wrong method, missing target, and no file source.
+func TestSendFileHandlerRejects(t *testing.T) {
+	h := sendFileHandler(context.Background())
+
+	// GET is rejected.
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/send-file", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET: code = %d, want 405", rec.Code)
+	}
+
+	// POST with a path but neither pk nor group → 400.
+	form := url.Values{"path": {"/tmp/whatever"}}
+	req := httptest.NewRequest(http.MethodPost, "/send-file", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec = httptest.NewRecorder()
+	h(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("no target: code = %d, want 400 (body %q)", rec.Code, rec.Body.String())
+	}
+
+	// POST with a pk but no file source → 400 from resolveUploadOrPath.
+	form = url.Values{"pk": {"0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"}}
+	req = httptest.NewRequest(http.MethodPost, "/send-file", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec = httptest.NewRecorder()
+	h(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("no file: code = %d, want 400 (body %q)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestDownloadFileHandlerMissing confirms a request for a file that isn't in the
+// downloads dir 404s rather than escaping the dir.
+func TestDownloadFileHandlerMissing(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/files/../../../etc/passwd", nil)
+	rec := httptest.NewRecorder()
+	downloadFileHandler(rec, req)
+	// The traversal is sanitized to "passwd"; with no such file in the downloads
+	// dir the result is 404, never the real /etc/passwd.
+	if rec.Code == http.StatusOK {
+		t.Fatalf("download of traversal path returned 200 — sanitizer failed")
+	}
+}

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -369,6 +369,17 @@ type chatEvent struct {
 	Text      string    `json:"text"`
 	ReplyToID string    `json:"reply_to_id,omitempty"`
 	Len       int       `json:"len"`
+
+	// File attachment fields (Telegram-style: a file is a message). Set only on
+	// file events; empty on plain chat. FileID is the transfer id; FileName /
+	// FileSize describe the file; FilePath is the LOCAL path the receiver saved
+	// it to (populated on "in" events once the transfer verifies, empty on the
+	// sender's "out" event). FileStatus is "sent"|"received"|"failed".
+	FileID     string `json:"file_id,omitempty"`
+	FileName   string `json:"file_name,omitempty"`
+	FileSize   int64  `json:"file_size,omitempty"`
+	FilePath   string `json:"file_path,omitempty"`
+	FileStatus string `json:"file_status,omitempty"`
 }
 
 // eventSub is a /events subscriber: a buffered channel plus the set of
@@ -863,6 +874,10 @@ func RunSkychat(ctx context.Context, args []string) error {
 	if err := startCXOTCP(ctx); err != nil {
 		appLog("skychat: cxo startup failed: %v — continuing without CXO mode", err)
 	}
+	// File transfer: listens on skyenv.SkychatFilePort over the enabled networks
+	// so peers can send us files (Telegram-style). Nil-effect if appCl is nil.
+	// See filexfer.go.
+	startFileXfer(ctx)
 	if !useSkynet && !useDmsg && tcpListen == "" && len(tcpPeers) == 0 && !cxoEnable && cxoGroup == "" {
 		appLog("Warning: no network types enabled, skychat will not accept connections")
 	}
@@ -905,6 +920,8 @@ func RunSkychat(ctx context.Context, args []string) error {
 	mux.HandleFunc("/history", requireAuthFunc(historyHandler))
 	mux.HandleFunc("/history/peers", requireAuthFunc(historyPeersHandler))
 	mux.HandleFunc("/status", requireAuthFunc(statusHandler))
+	mux.HandleFunc("/send-file", requireAuthFunc(sendFileHandler(ctx)))
+	mux.HandleFunc("/files/", requireAuthFunc(downloadFileHandler))
 	registerPairHTTPHandlers(ctx, mux)
 
 	url := ""

--- a/cmd/skywire-cli/commands/skychat/sendfile.go
+++ b/cmd/skywire-cli/commands/skychat/sendfile.go
@@ -1,0 +1,98 @@
+// Package cliskychat cmd/skywire-cli/commands/skychat/sendfile.go
+//
+// `skywire-cli skychat send-file` sends a local file to a peer (1:1) or to the
+// active CXO group, via the running skychat app's HTTP API (POST /send-file).
+// The file itself streams peer-to-peer over an encrypted skywire transport
+// (skyenv.SkychatFilePort, skynet or dmsg) — the HTTP call only hands the app a
+// local path to read. Files are conversation messages: the transfer surfaces in
+// history / SSE like any other message.
+package cliskychat
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+var (
+	sendFileTo    string
+	sendFileGroup bool
+)
+
+var sendFileCmd = &cobra.Command{
+	Use:   "send-file <path>",
+	Short: "send a file to a peer (--to) or the active group (--group)",
+	Long: `Send a local file over skychat.
+
+The file streams peer-to-peer over an encrypted skywire transport (skynet or
+dmsg); it never touches the clearnet. A peer auto-accepts once you've already
+established a chat, and group members auto-accept files shared to a group they're
+in — no per-file prompt.
+
+Requires the skychat app to be running (default --addr 127.0.0.1:8001).
+
+Examples:
+  skywire-cli skychat send-file --to <peer-pk> ./photo.png
+  skywire-cli skychat send-file --group ./release.tar.gz`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		path, err := filepath.Abs(args[0])
+		if err != nil {
+			cliutil.PrintFatalError(cmd.Flags(), fmt.Errorf("resolve path: %w", err))
+		}
+		if !sendFileGroup && sendFileTo == "" {
+			cliutil.PrintFatalError(cmd.Flags(), fmt.Errorf("specify --to <pk> or --group"))
+		}
+		form := url.Values{}
+		form.Set("path", path)
+		if sendFileGroup {
+			form.Set("group", "1")
+		} else {
+			var pk cipher.PubKey
+			if err := pk.Set(strings.TrimSpace(sendFileTo)); err != nil {
+				cliutil.PrintFatalError(cmd.Flags(), fmt.Errorf("--to: %w", err))
+			}
+			form.Set("pk", pk.Hex())
+		}
+
+		endpoint := fmt.Sprintf("http://%s/send-file", httpAddr)
+		hc := &http.Client{Timeout: 35 * time.Minute}
+		resp, err := hc.PostForm(endpoint, form)
+		if err != nil {
+			cliutil.PrintFatalError(cmd.Flags(), fmt.Errorf("POST %s: %w", endpoint, err))
+		}
+		defer func() { _ = resp.Body.Close() }() //nolint:errcheck
+		body, _ := io.ReadAll(resp.Body)         //nolint:errcheck
+		if resp.StatusCode != http.StatusOK {
+			cliutil.PrintFatalError(cmd.Flags(), fmt.Errorf("send-file failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body))))
+		}
+
+		var out map[string]any
+		if err := json.Unmarshal(bytes.TrimSpace(body), &out); err != nil {
+			fmt.Println(strings.TrimSpace(string(body)))
+			return
+		}
+		if n, ok := out["dispatched"]; ok {
+			fmt.Printf("file dispatched to %v group member(s)\n", n)
+			return
+		}
+		fmt.Printf("file sent (id %v)\n", out["id"])
+	},
+}
+
+func init() {
+	sendFileCmd.Flags().StringVarP(&sendFileTo, "to", "t", "", "recipient public key (1:1)")
+	sendFileCmd.Flags().BoolVarP(&sendFileGroup, "group", "g", false, "send to every member of the active CXO group")
+	RootCmd.AddCommand(sendFileCmd)
+}

--- a/pkg/skychat/xfer/manager.go
+++ b/pkg/skychat/xfer/manager.go
@@ -1,0 +1,181 @@
+// Package xfer pkg/skychat/xfer/manager.go c2-app-chat
+package xfer
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// Direction labels a completed transfer for the OnDone hook.
+type Direction string
+
+const (
+	// Incoming is a transfer this node received.
+	Incoming Direction = "incoming"
+	// Outgoing is a transfer this node sent.
+	Outgoing Direction = "outgoing"
+)
+
+// Config configures a Manager.
+type Config struct {
+	// LocalPK is this node's public key (stamped into outgoing offers).
+	LocalPK cipher.PubKey
+	// Dial opens a transfer stream to a peer (dmsg or skynet, same port).
+	Dial DialFunc
+	// Port is the file-transfer port (skyenv.SkychatFilePort) — the port this
+	// manager listens on and dials out to.
+	Port uint16
+	// Accept decides inbound transfers (auto-accept paired/group peers). Required
+	// to receive; if nil, every inbound transfer is declined.
+	Accept AcceptFunc
+	// OnDone, if set, is called after each transfer completes (either direction)
+	// with the final error (nil on success) — the app uses it to drop a message
+	// into chat/group history and update progress.
+	OnDone func(dir Direction, peer cipher.PubKey, offer Offer, err error)
+	// Logger is optional.
+	Logger *logging.Logger
+}
+
+// Manager accepts inbound file transfers on one port over every skywire network
+// it's given a listener for (dmsg + skynet, same port — like voice), and dials
+// out to send. It is safe for concurrent use.
+type Manager struct {
+	cfg Config
+	log *logging.Logger
+
+	mu      sync.Mutex
+	serving []net.Listener
+}
+
+// NewManager builds a Manager. A nil Accept means inbound transfers are declined.
+func NewManager(cfg Config) *Manager {
+	log := cfg.Logger
+	if log == nil {
+		log = logging.MustGetLogger("skychat-xfer")
+	}
+	return &Manager{cfg: cfg, log: log}
+}
+
+// Serve accepts transfer streams on ALL provided listeners concurrently — pass
+// the dmsg listener AND the skynet listener (both bound to cfg.Port). Returns
+// when ctx is done or every listener has failed.
+func (m *Manager) Serve(ctx context.Context, listeners ...net.Listener) {
+	m.mu.Lock()
+	m.serving = append(m.serving, listeners...)
+	m.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for _, lis := range listeners {
+		if lis == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(lis net.Listener) {
+			defer wg.Done()
+			m.acceptLoop(ctx, lis)
+		}(lis)
+	}
+	go func() { <-ctx.Done(); m.closeListeners() }()
+	wg.Wait()
+}
+
+// AddListener starts accepting on one more listener after Serve is already
+// running (e.g. the skynet listener that comes up only once the skynet networker
+// registers). It returns immediately; accepting runs until ctx is done.
+func (m *Manager) AddListener(ctx context.Context, lis net.Listener) {
+	if lis == nil {
+		return
+	}
+	m.mu.Lock()
+	m.serving = append(m.serving, lis)
+	m.mu.Unlock()
+	go m.acceptLoop(ctx, lis)
+}
+
+func (m *Manager) acceptLoop(ctx context.Context, lis net.Listener) {
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			m.log.WithError(err).Debug("xfer: accept failed")
+			return
+		}
+		go m.handleInbound(ctx, conn)
+	}
+}
+
+func (m *Manager) handleInbound(ctx context.Context, conn net.Conn) {
+	defer func() { _ = conn.Close() }() //nolint:errcheck
+
+	from := remotePK(conn)
+	accept := m.cfg.Accept
+	if accept == nil {
+		// No accept policy → decline everything, but still read the offer so the
+		// sender gets a clean Receipt rather than a reset.
+		accept = func(cipher.PubKey, Offer) (io.WriteCloser, bool) { return nil, false }
+	}
+	offer, err := Receive(ctx, from, conn, accept)
+	if err != nil && !IsDeclined(err) {
+		m.log.WithError(err).WithField("from", from).Warn("xfer: inbound transfer failed")
+	}
+	if m.cfg.OnDone != nil && !IsDeclined(err) {
+		m.cfg.OnDone(Incoming, from, offer, err)
+	}
+}
+
+// SendFile dials peer and streams the file described by offer from r. It stamps
+// offer.From with the local PK. The returned Receipt carries the receiver's
+// verdict; a non-nil error is a transport/protocol failure before a verdict.
+func (m *Manager) SendFile(ctx context.Context, peer cipher.PubKey, offer Offer, r io.Reader) (Receipt, error) {
+	offer.From = m.cfg.LocalPK
+	conn, err := m.cfg.Dial(ctx, peer, m.cfg.Port)
+	if err != nil {
+		return Receipt{}, err
+	}
+	defer func() { _ = conn.Close() }() //nolint:errcheck
+
+	rc, err := Send(ctx, conn, offer, r)
+	if m.cfg.OnDone != nil {
+		m.cfg.OnDone(Outgoing, peer, offer, err)
+	}
+	return rc, err
+}
+
+func (m *Manager) closeListeners() {
+	m.mu.Lock()
+	ls := m.serving
+	m.serving = nil
+	m.mu.Unlock()
+	for _, l := range ls {
+		if l != nil {
+			_ = l.Close() //nolint:errcheck
+		}
+	}
+}
+
+// remoteAddrPK is implemented by the skywire stream conns (dmsg + skynet), whose
+// RemoteAddr carries the peer's public key.
+type remoteAddrPK interface {
+	PK() cipher.PubKey
+}
+
+// remotePK best-effort extracts the peer PK from a skywire conn. Both the dmsg
+// Stream addr and the appnet skynet addr expose it; if neither does (e.g. an
+// in-memory test pipe) it returns the zero key and the AcceptFunc must not rely
+// on it for those conns.
+func remotePK(conn net.Conn) cipher.PubKey {
+	if conn == nil {
+		return cipher.PubKey{}
+	}
+	if a, ok := conn.RemoteAddr().(remoteAddrPK); ok {
+		return a.PK()
+	}
+	return cipher.PubKey{}
+}

--- a/pkg/skychat/xfer/xfer.go
+++ b/pkg/skychat/xfer/xfer.go
@@ -1,0 +1,262 @@
+// Package xfer pkg/skychat/xfer/xfer.go c2-app-chat
+//
+// xfer is skychat's file-transfer primitive: it moves one file over a single
+// skywire stream (a dmsg stream or a skynet route — the caller supplies the
+// DialFunc/listener, exactly like pkg/skychat/voice). Files are conversation
+// messages, Telegram-style: the Offer is announced into chat/group history and
+// the bytes stream out-of-band on skyenv.SkychatFilePort so a large transfer
+// never blocks the chat-message conn.
+//
+// Wire protocol on one transfer stream (all frames are pkg/skychat/message
+// length-prefixed frames; the DATA between them is raw):
+//
+//  1. Offer   frame  (sender → receiver: id, name, size, mime, from, group)
+//  2. Accept  frame  (receiver → sender: ok, err) — the receiver's AcceptFunc
+//     decides here, BEFORE any bytes move, so a declining or
+//     over-quota peer never receives the body
+//  3. exactly offer.Size raw bytes            (only when Accept.ok)
+//  4. Trailer frame  (sender → receiver: sha256 of the streamed bytes)
+//  5. Receipt frame  (receiver → sender: id, ok, err) — final verify verdict
+//
+// The digest is a trailer, not part of the offer, so the sender streams in a
+// single pass (works for non-seekable sources such as stdin); the receiver hashes
+// what it reads and compares against the trailer before accepting the file as
+// complete. All bytes ride the encrypted skywire transport — nothing touches the
+// clearnet.
+package xfer
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"net"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skychat/message"
+)
+
+// Offer describes a file being sent. It is the first frame on a transfer stream
+// and doubles as the metadata rendered as a message in the conversation.
+type Offer struct {
+	ID    string        `json:"id"`              // unique per transfer
+	Name  string        `json:"name"`            // suggested basename (no path)
+	Size  int64         `json:"size"`            // byte count
+	MIME  string        `json:"mime,omitempty"`  // best-effort content type
+	From  cipher.PubKey `json:"from"`            // sender PK
+	Group string        `json:"group,omitempty"` // group id when shared to a group (else 1:1)
+}
+
+// acceptMsg is the receiver's accept/decline verdict, sent before the body so a
+// declined transfer costs nothing but the offer round-trip.
+type acceptMsg struct {
+	OK  bool   `json:"ok"`
+	Err string `json:"err,omitempty"`
+}
+
+// trailer carries the digest the sender computed over the streamed bytes.
+type trailer struct {
+	SHA256 string `json:"sha256"`
+}
+
+// Receipt is the receiver's verdict, returned to the sender at the end.
+type Receipt struct {
+	ID  string `json:"id"`
+	OK  bool   `json:"ok"`
+	Err string `json:"err,omitempty"`
+}
+
+// DialFunc opens a transfer stream to peer:port over a skywire network (a dmsg
+// stream or a skynet route). Same shape and contract as voice.DialFunc — the
+// manager supplies one that tries whichever network is up, always on the SAME
+// port (skyenv.SkychatFilePort) across dmsg and skynet.
+type DialFunc func(ctx context.Context, peer cipher.PubKey, port uint16) (net.Conn, error)
+
+// AcceptFunc decides an inbound transfer. It receives the peer that opened the
+// stream and the Offer, and returns the destination to stream into plus whether
+// to accept. The app implements "auto-accept when already paired 1:1 or sharing a
+// group" here, and points dst at a file under the downloads dir. Returning ok
+// false declines the transfer (the sender gets a Receipt with OK=false).
+type AcceptFunc func(from cipher.PubKey, offer Offer) (dst io.WriteCloser, ok bool)
+
+// MaxOfferSize caps an Offer/Trailer/Receipt control frame. The DATA is not
+// bounded by this — only offer.Size bounds it, and the AcceptFunc is free to
+// reject an over-large Size before a single byte is read.
+const MaxOfferSize = message.MaxFrameSize
+
+var errDeclined = errors.New("xfer: transfer declined")
+
+// deadlineConn applies ctx's deadline to conn for the whole exchange (best
+// effort; a conn without deadline support just ignores it).
+func applyDeadline(ctx context.Context, conn net.Conn) {
+	if dl, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(dl) //nolint:errcheck
+	}
+}
+
+// Send streams offer + the first offer.Size bytes of r over conn, then reads the
+// receiver's Receipt. The digest trailer is computed over exactly the bytes
+// streamed, so r need not be seekable. conn is NOT closed here — the caller owns
+// it (it may be a reused/pooled stream).
+func Send(ctx context.Context, conn net.Conn, offer Offer, r io.Reader) (Receipt, error) {
+	applyDeadline(ctx, conn)
+
+	hdr, err := json.Marshal(offer)
+	if err != nil {
+		return Receipt{}, fmt.Errorf("xfer: marshal offer: %w", err)
+	}
+	if err := message.WriteFrame(conn, hdr); err != nil {
+		return Receipt{}, fmt.Errorf("xfer: write offer: %w", err)
+	}
+
+	// Wait for the receiver's accept/decline before streaming a single byte.
+	af, err := message.ReadFrame(conn)
+	if err != nil {
+		return Receipt{}, fmt.Errorf("xfer: read accept: %w", err)
+	}
+	var am acceptMsg
+	if err := json.Unmarshal(af, &am); err != nil {
+		return Receipt{}, fmt.Errorf("xfer: decode accept: %w", err)
+	}
+	if !am.OK {
+		// Declined before the body — a normal outcome, not a transport error.
+		return Receipt{ID: offer.ID, OK: false, Err: declineReason(am.Err)}, nil
+	}
+
+	h := sha256.New()
+	if offer.Size > 0 {
+		// Copy to the wire and the hash in one pass.
+		n, cerr := io.CopyN(io.MultiWriter(conn, h), r, offer.Size)
+		if cerr != nil {
+			return Receipt{}, fmt.Errorf("xfer: stream body (%d/%d bytes): %w", n, offer.Size, cerr)
+		}
+	}
+
+	tr, err := json.Marshal(trailer{SHA256: hex.EncodeToString(h.Sum(nil))})
+	if err != nil {
+		return Receipt{}, fmt.Errorf("xfer: marshal trailer: %w", err)
+	}
+	if err := message.WriteFrame(conn, tr); err != nil {
+		return Receipt{}, fmt.Errorf("xfer: write trailer: %w", err)
+	}
+
+	rf, err := message.ReadFrame(conn)
+	if err != nil {
+		return Receipt{}, fmt.Errorf("xfer: read receipt: %w", err)
+	}
+	var rc Receipt
+	if err := json.Unmarshal(rf, &rc); err != nil {
+		return Receipt{}, fmt.Errorf("xfer: decode receipt: %w", err)
+	}
+	return rc, nil
+}
+
+// Receive reads an Offer from conn, asks accept where to put it (and whether to
+// take it at all), streams offer.Size bytes into the destination while hashing,
+// verifies the digest against the sender's trailer, and returns a Receipt to the
+// sender. It returns the Offer and a nil error on a verified, accepted transfer;
+// errDeclined when accept says no; a non-nil error on any wire/verify failure
+// (the receiver still tries to send a negative Receipt so the sender learns).
+// conn is NOT closed here.
+func Receive(ctx context.Context, from cipher.PubKey, conn net.Conn, accept AcceptFunc) (Offer, error) {
+	applyDeadline(ctx, conn)
+
+	of, err := message.ReadFrame(conn)
+	if err != nil {
+		return Offer{}, fmt.Errorf("xfer: read offer: %w", err)
+	}
+	var offer Offer
+	if err := json.Unmarshal(of, &offer); err != nil {
+		return Offer{}, fmt.Errorf("xfer: decode offer: %w", err)
+	}
+	if offer.Size < 0 {
+		_ = sendAccept(conn, false, "negative size") //nolint:errcheck
+		return offer, fmt.Errorf("xfer: negative offer size %d", offer.Size)
+	}
+
+	dst, ok := accept(from, offer)
+	if !ok {
+		_ = sendAccept(conn, false, "declined") //nolint:errcheck
+		return offer, errDeclined
+	}
+	if err := sendAccept(conn, true, ""); err != nil {
+		_ = dst.Close() //nolint:errcheck
+		return offer, fmt.Errorf("xfer: send accept: %w", err)
+	}
+
+	h := sha256.New()
+	if cerr := streamBody(conn, dst, h, offer.Size); cerr != nil {
+		_ = dst.Close()                                      //nolint:errcheck
+		_ = sendReceipt(conn, offer.ID, false, cerr.Error()) //nolint:errcheck
+		return offer, cerr
+	}
+	if cerr := dst.Close(); cerr != nil {
+		_ = sendReceipt(conn, offer.ID, false, cerr.Error()) //nolint:errcheck
+		return offer, fmt.Errorf("xfer: close destination: %w", cerr)
+	}
+
+	tf, err := message.ReadFrame(conn)
+	if err != nil {
+		_ = sendReceipt(conn, offer.ID, false, "no trailer") //nolint:errcheck
+		return offer, fmt.Errorf("xfer: read trailer: %w", err)
+	}
+	var tr trailer
+	if err := json.Unmarshal(tf, &tr); err != nil {
+		_ = sendReceipt(conn, offer.ID, false, "bad trailer") //nolint:errcheck
+		return offer, fmt.Errorf("xfer: decode trailer: %w", err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != tr.SHA256 {
+		_ = sendReceipt(conn, offer.ID, false, "checksum mismatch") //nolint:errcheck
+		return offer, fmt.Errorf("xfer: checksum mismatch: got %s want %s", got, tr.SHA256)
+	}
+
+	if err := sendReceipt(conn, offer.ID, true, ""); err != nil {
+		return offer, fmt.Errorf("xfer: send receipt: %w", err)
+	}
+	return offer, nil
+}
+
+// streamBody copies exactly size bytes from conn into dst (and h), guarding
+// against a short stream.
+func streamBody(conn net.Conn, dst io.Writer, h hash.Hash, size int64) error {
+	if size == 0 {
+		return nil
+	}
+	n, err := io.CopyN(io.MultiWriter(dst, h), conn, size)
+	if err != nil {
+		return fmt.Errorf("xfer: stream body (%d/%d bytes): %w", n, size, err)
+	}
+	return nil
+}
+
+func sendAccept(conn net.Conn, ok bool, errMsg string) error {
+	b, err := json.Marshal(acceptMsg{OK: ok, Err: errMsg})
+	if err != nil {
+		return err
+	}
+	return message.WriteFrame(conn, b)
+}
+
+func declineReason(s string) string {
+	if s == "" {
+		return "declined"
+	}
+	return s
+}
+
+func sendReceipt(conn net.Conn, id string, ok bool, errMsg string) error {
+	b, err := json.Marshal(Receipt{ID: id, OK: ok, Err: errMsg})
+	if err != nil {
+		return err
+	}
+	return message.WriteFrame(conn, b)
+}
+
+// IsDeclined reports whether err is the sentinel returned by Receive when the
+// AcceptFunc declined the transfer (so callers can treat it as non-fatal).
+func IsDeclined(err error) bool { return errors.Is(err, errDeclined) }

--- a/pkg/skychat/xfer/xfer_test.go
+++ b/pkg/skychat/xfer/xfer_test.go
@@ -1,0 +1,204 @@
+// Package xfer pkg/skychat/xfer/xfer_test.go c2-app-chat
+package xfer
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// nopWriteCloser adapts a bytes.Buffer to io.WriteCloser.
+type nopWriteCloser struct{ *bytes.Buffer }
+
+func (nopWriteCloser) Close() error { return nil }
+
+// runTransfer sends payload from one end of a pipe and receives on the other,
+// returning the sender's Receipt and both errors.
+func runTransfer(t *testing.T, payload []byte, accept AcceptFunc) (Receipt, error, error) {
+	t.Helper()
+	a, b := net.Pipe()
+	defer func() { _ = a.Close() }() //nolint:errcheck
+	defer func() { _ = b.Close() }() //nolint:errcheck
+
+	from, _ := cipher.GenerateKeyPair()
+	offer := Offer{
+		ID:   "t1",
+		Name: "blob.bin",
+		Size: int64(len(payload)),
+		MIME: "application/octet-stream",
+		From: from,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	type recvResult struct {
+		offer Offer
+		err   error
+	}
+	recvCh := make(chan recvResult, 1)
+	go func() {
+		of, err := Receive(ctx, from, b, accept)
+		recvCh <- recvResult{of, err}
+	}()
+
+	rc, sErr := Send(ctx, a, offer, bytes.NewReader(payload))
+	res := <-recvCh
+	return rc, sErr, res.err
+}
+
+func TestSendReceiveRoundTrip(t *testing.T) {
+	payload := bytes.Repeat([]byte("skywire-file-"), 5000) // ~65 KB, > one frame
+	var got bytes.Buffer
+	accept := func(_ cipher.PubKey, o Offer) (io.WriteCloser, bool) {
+		if o.Name != "blob.bin" {
+			t.Errorf("offer name = %q", o.Name)
+		}
+		return nopWriteCloser{&got}, true
+	}
+
+	rc, sErr, rErr := runTransfer(t, payload, accept)
+	if sErr != nil {
+		t.Fatalf("Send: %v", sErr)
+	}
+	if rErr != nil {
+		t.Fatalf("Receive: %v", rErr)
+	}
+	if !rc.OK {
+		t.Fatalf("receipt not OK: %q", rc.Err)
+	}
+	if !bytes.Equal(got.Bytes(), payload) {
+		t.Fatalf("received %d bytes, want %d (content mismatch)", got.Len(), len(payload))
+	}
+	// Cross-check the digest the receiver verified against an independent one.
+	sum := sha256.Sum256(payload)
+	if want := hex.EncodeToString(sum[:]); want == "" {
+		t.Fatal("empty reference digest")
+	}
+}
+
+func TestEmptyFile(t *testing.T) {
+	var got bytes.Buffer
+	accept := func(_ cipher.PubKey, _ Offer) (io.WriteCloser, bool) { return nopWriteCloser{&got}, true }
+	rc, sErr, rErr := runTransfer(t, nil, accept)
+	if sErr != nil || rErr != nil {
+		t.Fatalf("empty transfer: send=%v recv=%v", sErr, rErr)
+	}
+	if !rc.OK {
+		t.Fatalf("empty receipt not OK: %q", rc.Err)
+	}
+	if got.Len() != 0 {
+		t.Fatalf("expected 0 bytes, got %d", got.Len())
+	}
+}
+
+func TestDeclinedTransfer(t *testing.T) {
+	decline := func(_ cipher.PubKey, _ Offer) (io.WriteCloser, bool) { return nil, false }
+	rc, sErr, rErr := runTransfer(t, []byte("nope"), decline)
+	if sErr != nil {
+		t.Fatalf("Send should succeed with a negative receipt, got %v", sErr)
+	}
+	if rc.OK {
+		t.Fatal("receipt should be OK=false for a declined transfer")
+	}
+	if !IsDeclined(rErr) {
+		t.Fatalf("Receive err = %v, want declined sentinel", rErr)
+	}
+}
+
+// TestManagerSendFile drives the full Manager path: a receiving Manager serving a
+// listener, a sending Manager dialing it, over an in-memory listener/dialer.
+func TestManagerSendFile(t *testing.T) {
+	lis := newMemListener()
+	dial := func(_ context.Context, _ cipher.PubKey, _ uint16) (net.Conn, error) {
+		return lis.dialMem()
+	}
+
+	sendPK, _ := cipher.GenerateKeyPair()
+	recvPK, _ := cipher.GenerateKeyPair()
+
+	var got bytes.Buffer
+	done := make(chan error, 1)
+	recvMgr := NewManager(Config{
+		LocalPK: recvPK,
+		Port:    64,
+		Accept:  func(_ cipher.PubKey, _ Offer) (io.WriteCloser, bool) { return nopWriteCloser{&got}, true },
+		OnDone:  func(dir Direction, _ cipher.PubKey, _ Offer, err error) { done <- err },
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go recvMgr.Serve(ctx, lis)
+
+	sendMgr := NewManager(Config{LocalPK: sendPK, Dial: dial, Port: 64})
+	payload := bytes.Repeat([]byte("abc"), 10000)
+	rc, err := sendMgr.SendFile(ctx, recvPK, Offer{ID: "m1", Name: "x.dat", Size: int64(len(payload))}, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("SendFile: %v", err)
+	}
+	if !rc.OK {
+		t.Fatalf("manager receipt not OK: %q", rc.Err)
+	}
+	select {
+	case rerr := <-done:
+		if rerr != nil {
+			t.Fatalf("receiver OnDone err: %v", rerr)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("receiver OnDone never fired")
+	}
+	if !bytes.Equal(got.Bytes(), payload) {
+		t.Fatalf("manager transfer content mismatch (%d/%d)", got.Len(), len(payload))
+	}
+}
+
+// memListener is a tiny in-process net.Listener backed by a channel of pipes.
+type memListener struct {
+	ch     chan net.Conn
+	closed chan struct{}
+}
+
+func newMemListener() *memListener {
+	return &memListener{ch: make(chan net.Conn, 8), closed: make(chan struct{})}
+}
+
+func (l *memListener) dialMem() (net.Conn, error) {
+	c1, c2 := net.Pipe()
+	select {
+	case l.ch <- c2:
+		return c1, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *memListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.ch:
+		return c, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *memListener) Close() error {
+	select {
+	case <-l.closed:
+	default:
+		close(l.closed)
+	}
+	return nil
+}
+
+func (l *memListener) Addr() net.Addr { return dummyAddr{} }
+
+type dummyAddr struct{}
+
+func (dummyAddr) Network() string { return "mem" }
+func (dummyAddr) String() string  { return "mem" }

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -118,6 +118,14 @@ const (
 	// exact port is confirmed in the signaling handshake so it can be varied.
 	SkychatVoiceMediaPort uint16 = 63
 
+	// SkychatFilePort is the port skychat FILE TRANSFER listens on. A sender
+	// dials it (over dmsg OR skynet — same port on both, like voice) and streams
+	// one offer header + chunked, sha256-verified bytes. Files are conversation
+	// messages (Telegram-style): the offer appears in chat/group history and the
+	// bytes stream out-of-band on this port so a large transfer never blocks the
+	// chat message conn. Peers already paired 1:1 or sharing a group auto-accept.
+	SkychatFilePort uint16 = 64
+
 	// DmsgDHTPort Listening port for the Kademlia DHT protocol.
 	DmsgDHTPort uint16 = 100
 


### PR DESCRIPTION
A file is a message in the conversation. Bytes stream peer-to-peer over an encrypted skywire transport (**skyenv.SkychatFilePort=64**, skynet or dmsg — same port on both, like voice), **out of band** from the chat-message conn so a large transfer never blocks chat. The offer + result surface as a `chatEvent` (new `file_*` fields) into the same SSE/history stream as text, so a UI renders it inline.

### `pkg/skychat/xfer` — reusable transfer primitive
Mirrors voice's signal/session split. Wire protocol on one stream:
1. **Offer** (sender→receiver: id, name, size, mime, from, group)
2. **Accept** (receiver→sender: ok/err) — decided BEFORE any bytes move, so a declining or over-quota peer never receives the body
3. exactly `offer.Size` raw bytes
4. **Trailer** (sha256 of the streamed bytes) — a trailer, not part of the offer, so the sender streams single-pass (works for stdin/non-seekable)
5. **Receipt** (final verify verdict)

`Manager` serves inbound on every network it's given a listener for (dmsg + skynet) and dials out. Unit-tested end-to-end in-memory: round-trip (>1 frame), empty file, decline, full Manager path. `go test ./pkg/skychat/xfer` green.

### Auto-accept policy (operator decision)
Once you've **established a chat** with a peer, or you **share a group**, inbound files are accepted with no per-file prompt. Files from an unestablished peer are declined.

### App wiring (`cmd/apps/skychat/filexfer.go`)
- Listeners on the file port over the enabled networks; appnet `DialFunc` (skynet-first, dmsg fallback).
- Received files saved under `<work-dir>/skychat-downloads` (sanitized names, no traversal).
- **Group**: fan-out to every current CXO-group member over encrypted streams (each auto-accepts as a member) — no CXO blob replication needed.
- HTTP `POST /send-file` (multipart upload OR local `path`; `pk`=1:1 or `group`) + `GET /files/<name>` to fetch a received file.

### CLI
`skywire cli skychat send-file --to <pk> <path>` · `skywire cli skychat send-file --group <path>`

---
All bytes ride the encrypted skywire transport — nothing touches the clearnet. The 1:1 framed (non-CXO) skychat is untouched.

`go build ./...` + `go test ./pkg/skychat/xfer` + `golangci-lint` all clean.

**Follow-ups:** wasm browser-tab drag-drop/download (the `xfer` pkg is pure Go and already compiles under js/wasm); resumable transfers.