### PR TITLE
chore(rewards): reward UI → reward.theskywirenetwork.net

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -143,7 +143,7 @@ func buildRouter() *gin.Engine {
 			c.Writer.WriteHeader(http.StatusOK)
 			base := strings.TrimRight(canonicalDomain, "/")
 			if base == "" {
-				base = "https://theskywirenetwork.net"
+				base = "https://reward.theskywirenetwork.net"
 			}
 			urls := []struct{ loc, priority string }{
 				{"/", "1.0"},

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -680,7 +680,7 @@ func printWelcome(pubkey string, isHypervisor bool) {
 	rewardOut, err := exec.Command(skywireBin(), "cli", "reward", "-r").Output() //nolint:gosec
 	if err == nil && len(rewardOut) > 0 {
 		msg2(fmt.Sprintf("skycoin reward address:\n%s%s%s", colorGreen, strings.TrimSpace(string(rewardOut)), colorReset))
-		msg2(fmt.Sprintf("reward metrics:\n%shttps://theskywirenetwork.net%s", colorBlue, colorReset))
+		msg2(fmt.Sprintf("reward metrics:\n%shttps://reward.theskywirenetwork.net%s", colorBlue, colorReset))
 		msg2(fmt.Sprintf("distribution notifications:\n%shttps://t.me/skywire_reward%s", colorBlue, colorReset))
 	} else {
 		msg2(fmt.Sprintf("reward eligibility rules:\n%shttps://github.com/skycoin/skywire/blob/develop/mainnet_rules.md%s", colorYellow, colorReset))


### PR DESCRIPTION
The reward UI moved to reward.theskywirenetwork.net (apex now = the wasm visor). Updates the canonical-domain default + the autoconfig reward-metrics link.