### PR TITLE
fix(visor): bound autoconnect transport dials so a stuck WebRTC dial can't wedge the loop

### DIFF
--- a/pkg/visor/visorcore/autoconnect.go
+++ b/pkg/visor/visorcore/autoconnect.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"math/big"
 	"net"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -148,8 +149,24 @@ func ShufflePubKeys(keys []cipher.PubKey) []cipher.PubKey {
 	return keys
 }
 
+// perAttemptTransportTimeout bounds a SINGLE autoconnect transport-establishment
+// attempt. The autoconnect loop hands its visor-lifetime context straight down to
+// SaveTransport, and a dial that neither completes nor errors blocks that call
+// forever: SaveTransport waits on an unbuffered errCh fed by an async dial, and
+// the WebRTC dialer's awaitConn only unblocks on connCh/errCh/ctx.Done() — so a
+// last-resort Phase-4 WebRTC ICE negotiation to an unreachable peer (no answer,
+// no error) with a never-canceled ctx wedges the whole loop: no further ticks
+// fire and no transports are ever made (observed live, a v1.3.79 visor stuck here
+// for 5+ days with 0 transports). Every dial path (stcpr DialContext, sudph, quic,
+// webrtc awaitConn) honors ctx, so a bounded per-attempt deadline lets a stuck
+// dial return DeadlineExceeded and the loop advances to the next target/tick.
+const perAttemptTransportTimeout = 30 * time.Second
+
 // tryEstablishTransport attempts to establish a transport of the specified type to the given public key, and return error.
 func (c *Connector) tryEstablishTransport(ctx context.Context, pk cipher.PubKey, netType tptypes.Type, logger *logrus.Entry) error {
+	ctx, cancel := context.WithTimeout(ctx, perAttemptTransportTimeout)
+	defer cancel()
+
 	if _, err := c.Tm.SaveTransport(ctx, pk, netType, transport.LabelAutomatic); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

A user reported visors with `public_autoconnect: true` making **0 transports**. Investigating one such visor live (v1.3.79, up since boot) via its goroutine dump over the dmsg log server showed the autoconnect goroutine **parked for 7479 minutes (~5.2 days, since boot)**:

```
autoconnector.Run (autoconnect.go:358 — Phase 4 WebRTC)
 -> visorcore.Connector.ConnectToVisors
 -> tryEstablishTransport (visorcore/autoconnect.go)
 -> transport.Manager.SaveTransport -> saveTransportInternal  [chan receive, 7479 min]
```

## Root cause

The autoconnect loop hands its **visor-lifetime context** straight down to `SaveTransport`. `SaveTransport` blocks on an unbuffered `errCh` fed by an async dial (`go mTp.DialAsync(ctx, errCh); err = <-errCh`), and the WebRTC dialer's `awaitConn` only returns on `connCh` / `errCh` / `ctx.Done()`.

A last-resort **Phase-4 WebRTC** ICE negotiation to an unreachable peer never completes *and* never errors, so with a never-canceled context that `select` waits forever. This wedges the **entire** autoconnect loop — no further ticks fire, no transports of any type are ever created. Once a visor hits one un-answerable WebRTC target it silently stops autoconnecting for good (fresh restarts work until they hit the same wall, which is why newly-started visors in the same fleet had transports while long-running ones sat at 0).

## Fix

Bound each attempt with a 30s per-attempt deadline in the shared `visorcore` `tryEstablishTransport`. Every dial path (stcpr `DialContext`, sudph, quic, webrtc `awaitConn`) already honors `ctx`, so a stuck dial now returns `DeadlineExceeded` and the loop advances to the next target/tick instead of parking forever. Placing it in `visorcore` covers both the native and wasm visors.

## Testing

- `go build`, `gofmt`, `golangci-lint` clean; `go test ./pkg/visor/visorcore/... ./pkg/transport/` green.
- Diagnosis is backed by the live goroutine dump above (exact park site + 5-day duration).
- No unit test added: `Connector.Tm` is a concrete `*transport.Manager`, so simulating a blocking dial would require an interface seam larger than this fix warrants.