### PR TITLE
fix(win_installer): close running skywire on upgrade so postinstall runs the new binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,8 +428,10 @@ jobs:
           $productWxs = $productWxs -replace "skywireVersion", $VERSION
           Set-Content -Path Product.wxs -Value $productWxs
 
-          # Build MSI
-          ..\..\wix\candle.exe UI.wxs Product.wxs -arch ${{ matrix.wix_arch }}
+          # Build MSI. -ext WixUtilExtension on candle too (not just light) so the
+          # <util:CloseApplication> element in Product.wxs — which stops a running
+          # skywire so an upgrade isn't blocked by locked files — compiles.
+          ..\..\wix\candle.exe -ext WixUtilExtension UI.wxs Product.wxs -arch ${{ matrix.wix_arch }}
           ..\..\wix\light.exe -ext WixUIExtension -ext WixUtilExtension -sacl -spdb -out skywire.msi UI.wixobj Product.wixobj
           Move-Item skywire.msi ..\..\dist\$MSI_NAME.msi
 

--- a/scripts/win_installer/Product.wxs
+++ b/scripts/win_installer/Product.wxs
@@ -8,7 +8,8 @@
     <?error Unsupported value of sys.BUILDARCH=$(sys.BUILDARCH)?>
 <?endif?>
 
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
    <Product Id="*" UpgradeCode="cd7955bc-304e-470f-9c24-eb9f429a8085"
             Name="Skywire"
             Version="skywireVersion"
@@ -37,6 +38,34 @@
          Schedule="afterInstallValidate"
          AllowSameVersionUpgrades="yes"
          DowngradeErrorMessage="A newer version of Skywire is already installed. Setup will now exit." />
+
+      <!-- Close a RUNNING skywire before the file operations. Windows users
+           leave the systray visor running, which keeps skywire.exe (and the
+           open skywire-config.json) LOCKED in C:\Program Files\Skywire. Without
+           this, an upgrade can't replace the locked binary — RestartManager
+           defers the swap to reboot — yet the RunSkywireAutoconfig CustomAction
+           still runs mid-transaction against the OLD on-disk binary, so the
+           config is regenerated with old defaults: the reported "config not
+           updated as part of the postinstall" symptom on upgrade. (This is a
+           SEPARATE gap from the MajorUpgrade file-skip fixed above — that one
+           was about the old product never being detected/removed; this one is
+           about the new files being locked by the still-running app.)
+
+           WixCloseApplications (scheduled by this element after InstallInitialize,
+           before InstallFiles) sends WM_CLOSE to skywire's systray window for a
+           graceful shutdown; ElevatedCloseMessage reaches the elevated perMachine
+           process, and TerminateProcess force-closes it if it doesn't exit within
+           the timeout (covers a windowless/unresponsive visor). RebootPrompt="no"
+           so a stubborn process never turns the upgrade into a reboot prompt. With
+           the app closed, InstallFiles lays down the NEW skywire.exe before the
+           postinstall runs it. -->
+      <util:CloseApplication
+         Id="CloseSkywireOnUpgrade"
+         Target="skywire.exe"
+         CloseMessage="yes"
+         ElevatedCloseMessage="yes"
+         TerminateProcess="0"
+         RebootPrompt="no" />
 
       <WixVariable Id="WixUIBannerBmp" Value=".\images\Banner.png" />
       <WixVariable Id="WixUIDialogBmp" Value=".\images\Dialog.png" />

--- a/scripts/win_installer/skywire-autoconfig.bat
+++ b/scripts/win_installer/skywire-autoconfig.bat
@@ -33,12 +33,24 @@ if not exist "%ProgramData%\Skywire\" (
     mkdir "%ProgramData%\Skywire" >nul 2>&1
 )
 
+:: Log everything to %ProgramData%\Skywire\autoconfig-install.log. The MSI runs
+:: this as a deferred CustomAction with Return="ignore", so WITHOUT a log any
+:: failure (a config-gen error, or — the classic upgrade bug — the OLD binary
+:: running because the new one was locked by a still-running skywire) is silent
+:: and undiagnosable. Recording `skywire --version` up front pins down exactly
+:: which binary regenerated the config, which is the clincher when a user reports
+:: "config not updated on upgrade".
+set "SKYLOG=%ProgramData%\Skywire\autoconfig-install.log"
+echo(>> "%SKYLOG%"
+echo ===== skywire-autoconfig %DATE% %TIME% =====>> "%SKYLOG%"
+"%~dp0skywire.exe" --version >> "%SKYLOG%" 2>&1
+
 :: Generate the env-file template ONLY if missing. -p forces package-mode
 :: defaults (paths under C:\Program Files\Skywire), -q renders the template,
 :: -Q writes it to the file. Mirrors the deb/arch
 :: `[[ ! -f /etc/skywire.conf ]] && skywire cli config gen -pqQ ...` pattern.
 if not exist "%SKYENV%" (
-    "%~dp0skywire.exe" cli config gen -pqQ "%SKYENV%"
+    "%~dp0skywire.exe" cli config gen -pqQ "%SKYENV%" >> "%SKYLOG%" 2>&1
 )
 
 :: (Re)generate the visor config through the SINGLE entry point — `skywire
@@ -58,4 +70,5 @@ if not exist "%SKYENV%" (
 :: VPNSERVER=false (replaces the old `--disableapps vpn-server`). Deployment
 :: service URLs come from the embedded dmsg-only services config (the single
 :: source of truth), so no -S / -D files are needed.
-"%~dp0skywire.exe" autoconfig --ishv --no-vpnserver
+"%~dp0skywire.exe" autoconfig --ishv --no-vpnserver >> "%SKYLOG%" 2>&1
+echo ----- autoconfig exit %ERRORLEVEL% ----->> "%SKYLOG%"


### PR DESCRIPTION
## Problem

A Windows user reported that after upgrading to the version released last night (v1.3.82), **their config wasn't updated as part of the postinstall**.

The MSI major-upgrade file-skip that #3382 fixed **is** in v1.3.82 (v1.3.79 was the last release without it), and `afterInstallValidate` correctly reinstalls files — so that bug isn't the cause. This is a **separate gap** #3382 didn't cover.

## Root cause

The MSI has no automatic app-close (only the `FilesInUse`/`MsiRMFilesInUse` dialogs are referenced). Windows users leave the **systray visor running**, so `skywire.exe` and the open `skywire-config.json` are **locked** in `C:\Program Files\Skywire`:

1. The locked `skywire.exe` can't be replaced during the upgrade — RestartManager defers the swap to reboot.
2. The `RunSkywireAutoconfig` CustomAction still runs **mid-transaction, before that reboot**, so `%~dp0skywire.exe autoconfig` executes the **old** on-disk binary and regenerates config with old defaults.
3. `Return="ignore"` + a postinstall that logged nothing meant this was completely silent.

That precisely matches "config wasn't updated as part of the postinstall process."

## Fix

- **Product.wxs** — `<util:CloseApplication>` stops a running skywire before file operations: `CloseMessage` (WM_CLOSE to the systray window, graceful), `ElevatedCloseMessage` (reaches the elevated perMachine process), `TerminateProcess="0"` (force-close a windowless/unresponsive visor), `RebootPrompt="no"` (never turn the upgrade into a reboot prompt). Scheduled by the extension after InstallInitialize, before InstallFiles, so the **new** binary is on disk before the postinstall runs it. No-op on fresh install.
- **release.yml** — add `-ext WixUtilExtension` to the `candle.exe` line (`light.exe` already linked it) so the `util:` element compiles.
- **skywire-autoconfig.bat** — tee output to `%ProgramData%\Skywire\autoconfig-install.log` and record `skywire --version` first, so a future "config not updated" report shows exactly which binary ran (turns the silent `Return=ignore` CustomAction diagnosable).

## Validation caveat

The MSI is only built on a tag push (`release.yml`), not on PRs, and WiX can't be compiled on Linux — so the `candle.exe -ext WixUtilExtension` + `util:CloseApplication` compile is validated on the **next tagged release**, not by PR CI. Product.wxs is well-formed XML and release.yml is valid YAML; `util:CloseApplication` (incl. `TerminateProcess`) is supported in the pinned WiX 3.11.