### PR TITLE
feat(wasm-hv): skydm deep-link — open a 1:1 skychat from a shared link

### DIFF
--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -1554,11 +1554,14 @@
     var timer = setInterval(render, 1500);
     render();
     if (!send) setStatus("skychat is only available in the browser-tab (wasm) visor", "#e0af68");
+    // Deep-link (?skydm=<pk>): open a conversation pre-addressed to this peer so a
+    // shared theskywirenetwork.net link drops the visitor straight into a 1:1 chat.
+    if (opts.initialPeer) { try { setPeer(opts.initialPeer); } catch (e) {} }
     var wb = makeWin(doc, {
       title: "skychat", root: opts.root, top: opts.top, bottom: opts.bottom, width: "42%", height: "62%",
       mount: wrap, onclose: function () { clearInterval(timer); logUnsub(); if (opts.onClose) opts.onClose(); }
     });
-    return { wb: wb, close: function () { wb.close(); } };
+    return { wb: wb, close: function () { wb.close(); }, setPeer: setPeer };
   }
 
   // createTerminalWindow opens a real dmsgpty terminal as a WinBox iframe to
@@ -1768,10 +1771,15 @@
       track(termWin, "terminal");
     }
     var chatWin = null;
-    function openChat() {
-      if (focusExisting(chatWin)) { return; }
-      chatWin = createChatWindow(doc, withRoot({ onClose: function () { untrack(chatWin); chatWin = null; } }));
+    function openChat(initialPeer) {
+      if (focusExisting(chatWin)) {
+        // Already open — retarget it to the deep-linked peer if one was given.
+        if (initialPeer && chatWin && chatWin.setPeer) { try { chatWin.setPeer(initialPeer); } catch (e) {} }
+        return chatWin;
+      }
+      chatWin = createChatWindow(doc, withRoot({ onClose: function () { untrack(chatWin); chatWin = null; }, initialPeer: initialPeer || "" }));
       track(chatWin, "skychat");
+      return chatWin;
     }
     var hostWin = null;
     function openHost() {
@@ -1802,7 +1810,9 @@
       // (e.g. the native HV) that don't preload it.
       try {
         var pre = self.__SKYWIRE_DEEPLINK__ || (doc.defaultView || window).__SKYWIRE_DEEPLINK__;
-        if (pre && pre.target) { return { target: pre.target, kiosk: !!pre.kiosk }; }
+        if (pre && (pre.target || pre.skydm || pre.skygroup)) {
+          return { target: pre.target || "", skydm: pre.skydm || "", skygroup: pre.skygroup || "", kiosk: !!pre.kiosk };
+        }
       } catch (e) {}
       var loc = (doc.defaultView || window).location, qs = {};
       try {
@@ -1813,10 +1823,14 @@
         });
         var h = loc.hash || "", m = h.match(/[#&]skynet=([^&]+)/);
         if (m && !qs.skynet) { qs.skynet = decodeURIComponent(m[1]); }
+        var md = h.match(/[#&]skydm=([^&]+)/);
+        if (md && !qs.skydm) { qs.skydm = decodeURIComponent(md[1]); }
+        var mg = h.match(/[#&]skygroup=([^&]+)/);
+        if (mg && !qs.skygroup) { qs.skygroup = decodeURIComponent(mg[1]); }
         if (/[#&]kiosk=1\b/.test(h)) { qs.kiosk = "1"; }
       } catch (e) {}
-      if (!qs.skynet) { return null; }
-      return { target: qs.skynet, kiosk: qs.kiosk === "1" || qs.kiosk === "true" };
+      if (!qs.skynet && !qs.skydm && !qs.skygroup) { return null; }
+      return { target: qs.skynet || "", skydm: qs.skydm || "", skygroup: qs.skygroup || "", kiosk: qs.kiosk === "1" || qs.kiosk === "true" };
     }
     // whenVisorConnected fires cb once the wasm visor has a live dmsg session (so a
     // fetch over dmsg won't just error), bounded to ~20s so a stuck visor still lands
@@ -1843,7 +1857,18 @@
     }
     try {
       var dl = readDeepLink();
-      if (dl) {
+      // ?skydm=<pk> — open a 1:1 skychat pre-addressed to the peer ("message me"
+      // links). wasm-visor only (needs the in-tab skychatSend hook); a native HV
+      // has its own Angular skychat tab. Handled before the skynet-browse path so
+      // a chat deep-link never falls through to openBrowse.
+      if (dl && dl.skydm && globalThis.skywireVisor && globalThis.skywireVisor.skychatSend) {
+        var cwin = openChat(dl.skydm);
+        if (cwin && dl.kiosk) { enterKiosk(cwin); }
+        dl = null; // handled — skip the skynet-browse path below
+      }
+      // NOTE: ?skygroup=<invite> (join+open a federated group) is handled by the
+      // Angular skychat tab, which owns the group UI; browse.js has no group view.
+      if (dl && dl.target) {
         var dlWin = openBrowse(true); // skip home.dmsg auto-land; go to the deep-link target
         if (dl.kiosk) { enterKiosk(dlWin); }
         // Navigate straight to the target — do NOT wait for dmsg first. render()'s

--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -1866,8 +1866,19 @@
         if (cwin && dl.kiosk) { enterKiosk(cwin); }
         dl = null; // handled — skip the skynet-browse path below
       }
-      // NOTE: ?skygroup=<invite> (join+open a federated group) is handled by the
-      // Angular skychat tab, which owns the group UI; browse.js has no group view.
+      // ?skygroup=<invite> — join the federated group from the invite blob so a
+      // shared link drops the visitor straight into membership. browse.js has no
+      // group message view (that lives in the Angular skychat tab, which owns the
+      // group UI); this wiring performs the JOIN, then the operator opens the
+      // skychat tab to read/post. Best-effort: a failed join is logged, not fatal.
+      if (dl && dl.skygroup && globalThis.skywireVisor && globalThis.skywireVisor.skychatGroupJoin) {
+        Promise.resolve(skywireVisor.skychatGroupJoin(dl.skygroup)).then(function (g) {
+          try { log("skygroup: joined " + ((g && g.name) ? g.name : "group") + " — open the skychat tab to view it"); } catch (e) {}
+        }).catch(function (e) {
+          try { log("skygroup: join failed: " + ((e && e.message) || e)); } catch (e2) {}
+        });
+        dl = null; // handled — skip the skynet-browse path below
+      }
       if (dl && dl.target) {
         var dlWin = openBrowse(true); // skip home.dmsg auto-land; go to the deep-link target
         if (dl.kiosk) { enterKiosk(dlWin); }

--- a/pkg/wasmhv/hv-boot.js
+++ b/pkg/wasmhv/hv-boot.js
@@ -16,17 +16,24 @@
 // the bare served HTML is a working serverless visor with zero configuration.
 (function () {
   var CFG = (window.__SKYWIRE_HV__ = window.__SKYWIRE_HV__ || {});
-  // Capture any deep-link params (?skynet=<target>[&kiosk=1]) NOW — this is the
-  // first script, so it runs before Angular's hash router boots and drops
-  // location.search. The skynet browser (browse.js mountPanel → readDeepLink)
-  // reads window.__SKYWIRE_DEEPLINK__ to open <target> over dmsg full-page on
-  // load. Lets a clearnet Caddy redirect land a visitor straight in a dmsg site.
+  // Capture any deep-link params NOW — this is the first script, so it runs
+  // before Angular's hash router boots and drops location.search. browse.js
+  // (mountPanel → readDeepLink) reads window.__SKYWIRE_DEEPLINK__ on load:
+  //   ?skynet=<target>   open a dmsg site full-page (clearnet→dmsg gateway)
+  //   ?skydm=<pk>        open a 1:1 skychat pre-addressed to <pk> ("message me")
+  //   ?skygroup=<invite> join + open a federated group chat from an invite blob
+  //   &kiosk=1           full-page (hide the HV taskbar, maximize)
+  // so a clearnet Caddy redirect can land a visitor straight in a site OR a chat.
   try {
     var dlp = new URLSearchParams(window.location.search || '');
     var dlTarget = dlp.get('skynet');
-    if (dlTarget) {
+    var dlDm = dlp.get('skydm');
+    var dlGroup = dlp.get('skygroup');
+    if (dlTarget || dlDm || dlGroup) {
       window.__SKYWIRE_DEEPLINK__ = {
-        target: dlTarget,
+        target: dlTarget || '',
+        skydm: dlDm || '',
+        skygroup: dlGroup || '',
         kiosk: dlp.get('kiosk') === '1' || dlp.get('kiosk') === 'true',
       };
     }


### PR DESCRIPTION
First slice of the skychat deep-link + moderation work (tracked in #3423).

## What

Extends the existing `?skynet=<target>&kiosk=1` deep-link gateway with a chat verb:

```
theskywirenetwork.net/?skydm=<pk>[&kiosk=1]
```

opens the browser wasm-visor straight into a **1:1 skychat pre-addressed to `<pk>`** — so someone can share a "message me" link and a visitor lands in a chat with them. `kiosk=1` reuses the full-page takeover.

## How

- **hv-boot.js**: capture `?skydm` and `?skygroup` alongside `?skynet` (first script, before Angular strips `location.search`).
- **browse.js**: `readDeepLink()` now returns `{target, skydm, skygroup, kiosk}`; dispatch opens `createChatWindow` pre-addressed via a new `opts.initialPeer` (the window calls `setPeer()` on mount and exposes `setPeer` so an already-open chat retargets). The skynet-browse path is guarded on `dl.target` so a chat deep-link never falls through to the site browser.

## Scope / follow-ups (this is slice 1)

- `?skygroup=<invite>` (join + open a federated group) is **captured** here but handled by the **Angular skychat tab**, which owns the group UI — that wiring is the next slice.
- Admin actions (kick/ban/promote/demote GUI) and private-group polish are separate PRs.

## Testing

- `node --check` clean on both JS files; `go build ./pkg/wasmhv/...` green (go:embed resolves).
- Both files are served via go:embed, so the change takes effect on a serving-binary rebuild — no wasm blob regen needed (browse.js/hv-boot.js are static assets, not compiled into the wasm).