### PR TITLE
feat(skychat/group): sender-side unsend — genuinely delete a group message

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -374,6 +374,21 @@ func (m *Manager) SendToGroup(ctx context.Context, id, text string) error {
 	return nil
 }
 
+// Unsend removes a message the local visor published to group id,
+// identified by its UnixNano timestamp. Only the sender can unsend their
+// own message (a publisher controls only its own feed); the deletion
+// propagates to subscribers via CXO snapshot-diff replication. Returns an
+// error if there is no live session for the group.
+func (m *Manager) Unsend(id string, tsNano int64) error {
+	m.mu.RLock()
+	sess, ok := m.sessions[id]
+	m.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("group: Unsend: no live session for %s", id)
+	}
+	return sess.Unsend(tsNano)
+}
+
 // AddMember (owner) extends the allowlist + persisted member list.
 // Returns the updated record so the caller can re-issue the invite.
 func (m *Manager) AddMember(id string, pk cipher.PubKey) (Record, error) {

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -1352,6 +1352,28 @@ func (s *Session) Send(text string) error {
 	return s.publishAs(s.cfg.MyPK, text, time.Now().UTC())
 }
 
+// Unsend deletes a message this session previously published, identified
+// by its timestamp (UnixNano — the value carried in the delivered
+// Message.TS, so the UI already has it). Only leaves on THIS session's
+// own feed can be removed — a publisher controls only its own feed — so
+// unsend is inherently sender-scoped and needs no extra authority check.
+//
+// PrunePrefix wipes the msgs/<myPK>/<ts> subtree, i.e. the single leaf at
+// that timestamp (seq lives one level below ts). CXO's snapshot-diff
+// replication then reports the removal to every subscriber (see
+// treestore TestSubscriberApplySnapshotReportsDeletes), so the message is
+// genuinely deleted from members' replicas — not merely hidden locally.
+// The unavoidable caveat is inherent to any federated store: a member
+// that is offline forever, or a modified client that archived the bytes,
+// cannot be forced to forget.
+func (s *Session) Unsend(tsNano int64) error {
+	if s.pub == nil {
+		return errors.New("group: Unsend: session has no publisher")
+	}
+	prefix := MessagePathPrefix + "/" + s.cfg.MyPK.Hex() + "/" + strconv.FormatInt(tsNano, 10)
+	return s.pub.PrunePrefix(prefix)
+}
+
 // SetAllowlist updates the publisher's subscriber allowlist AND the
 // owner-side relay-gate's view of the member set, both live. Owner-
 // side only. Used when an invite is issued or a member is removed.

--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -75,7 +76,7 @@ func init() {
 	groupCmd.AddCommand(
 		groupCreateCmd, groupListCmd, groupInfoCmd, groupInviteCmd,
 		groupJoinCmd, groupAddCmd, groupPromoteCmd, groupDemoteCmd,
-		groupSendCmd, groupListenCmd, groupHistoryCmd,
+		groupSendCmd, groupUnsendCmd, groupListenCmd, groupHistoryCmd,
 		groupLeaveCmd, groupDeleteCmd,
 	)
 	RootCmd.AddCommand(groupCmd)
@@ -391,6 +392,34 @@ var groupSendCmd = &cobra.Command{
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 		internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintf("sent to %s\n", id))
+	},
+}
+
+var groupUnsendCmd = &cobra.Command{
+	Use:   "unsend <group-id> <ts-unixnano>",
+	Short: "Delete a message you published, by its UnixNano timestamp",
+	Long: `Delete a message the local visor published to a group, identified
+by its UnixNano timestamp (the ts field in ` + "`group history --json`" + `).
+
+Only your own messages can be unsent — a visor owns only its own feed.
+The deletion is replicated to other members via CXO (a genuine delete,
+not just a local hide), though an offline member or a client that already
+archived the message cannot be forced to forget it.`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		id := args[0]
+		ts, err := strconv.ParseInt(args[1], 10, 64)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid ts (want UnixNano int): %w", err))
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.GroupUnsend(visor.GroupUnsendArgs{ID: id, TS: ts}); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintf("unsent %d from %s\n", ts, id))
 	},
 }
 

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -280,6 +280,7 @@ type API interface {
 	GroupPromoteAdmin(id string, pk cipher.PubKey) (GroupInfo, error)
 	GroupDemoteAdmin(id string, pk cipher.PubKey) (GroupInfo, error)
 	GroupSend(args GroupSendArgs) error
+	GroupUnsend(args GroupUnsendArgs) error
 	GroupPoll(since time.Time) ([]GroupMessage, error)
 	GroupDelete(id string) error
 	GroupLeave(id string) error

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -460,6 +460,24 @@ func (v *Visor) GroupSend(args GroupSendArgs) error {
 	return mgr.SendToGroup(ctx, args.ID, args.Text)
 }
 
+// GroupUnsendArgs is the RPC input for GroupUnsend. TS is the message's
+// UnixNano timestamp (the value carried in the delivered message).
+type GroupUnsendArgs struct {
+	ID string `json:"id"`
+	TS int64  `json:"ts"`
+}
+
+// GroupUnsend deletes a message the local visor published to the group,
+// by its UnixNano timestamp. Only the sender can remove their own
+// message; the deletion propagates to subscribers via CXO snapshot-diff.
+func (v *Visor) GroupUnsend(args GroupUnsendArgs) error {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return ErrGroupingDisabled
+	}
+	return mgr.Unsend(args.ID, args.TS)
+}
+
 // GroupPoll drains messages with TS > since. Mirrors PairPoll.
 func (v *Visor) GroupPoll(since time.Time) ([]GroupMessage, error) {
 	v.initLock.RLock()

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -822,6 +822,10 @@ func (proxyDefaultAPI) GroupSend(_ GroupSendArgs) error {
 	return ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) GroupUnsend(_ GroupUnsendArgs) error {
+	return ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) GroupPoll(_ time.Time) ([]GroupMessage, error) {
 	return nil, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1590,6 +1590,11 @@ func (rc *rpcClient) GroupSend(args GroupSendArgs) error {
 	return rc.Call("GroupSend", &args, &struct{}{})
 }
 
+// GroupUnsend implements API.
+func (rc *rpcClient) GroupUnsend(args GroupUnsendArgs) error {
+	return rc.Call("GroupUnsend", &args, &struct{}{})
+}
+
 // GroupPoll implements API.
 func (rc *rpcClient) GroupPoll(since time.Time) ([]GroupMessage, error) {
 	var resp []GroupMessage

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1302,6 +1302,9 @@ func (mc *mockRPCClient) GroupDemoteAdmin(_ string, _ cipher.PubKey) (GroupInfo,
 // GroupSend implements API.
 func (mc *mockRPCClient) GroupSend(_ GroupSendArgs) error { return nil }
 
+// GroupUnsend implements API.
+func (mc *mockRPCClient) GroupUnsend(_ GroupUnsendArgs) error { return nil }
+
 // GroupPoll implements API.
 func (mc *mockRPCClient) GroupPoll(_ time.Time) ([]GroupMessage, error) { return nil, nil }
 

--- a/pkg/visor/rpc_group.go
+++ b/pkg/visor/rpc_group.go
@@ -161,6 +161,15 @@ func (r *RPC) GroupSend(req *GroupSendArgs, _ *struct{}) (err error) {
 	return r.visor.GroupSend(*req)
 }
 
+// GroupUnsend deletes a message the local visor published, by UnixNano TS.
+func (r *RPC) GroupUnsend(req *GroupUnsendArgs, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupUnsend", req)(nil, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	return r.visor.GroupUnsend(*req)
+}
+
 // GroupPoll drains inbound group messages with TS strictly after Since.
 func (r *RPC) GroupPoll(req *GroupPollRequest, out *[]GroupMessage) (err error) {
 	defer rpcutil.LogCall(r.log, "GroupPoll", req)(out, &err)


### PR DESCRIPTION
Implements sender-side **unsend** for group chat — a real delete, not a hide (per the design discussion). Tracked alongside #3423.

## What
`skywire cli skychat group unsend <group-id> <ts-unixnano>` (and `Visor.GroupUnsend` API/RPC) removes a message the local visor published, by its UnixNano timestamp.

## Why it actually deletes
A message is a leaf at `msgs/<senderPK>/<ts>/<seq>` on the sender's own CXO feed. `Unsend` calls the publisher's `PrunePrefix("msgs/<myPK>/<ts>")`:
- A publisher owns **only its own feed**, so unsend is inherently sender-scoped (no extra authority check needed — you can't delete someone else's leaf).
- CXO's **snapshot-diff replication reports the removal to every subscriber** (proven by `treestore.TestSubscriberApplySnapshotReportsDeletes`), so the leaf is dropped from members' replicas — a genuine delete, not a local hide.
- **Inherent caveat** (true of any federated store): an offline member, or a modified/archiving client, can't be forced to forget.

The message is identified by its **timestamp** (already carried in the delivered `Message.TS`), so no send-path signature changes were needed.

## Layers
- `group` pkg: `Session.Unsend(tsNano)` / `Manager.Unsend(id, tsNano)`.
- `pkg/visor`: `GroupUnsendArgs`, `Visor.GroupUnsend`, `RPC.GroupUnsend`, client/mock/proxy.
- CLI: `group unsend`.

## Follow-ups (not in this PR)
- **Receiver live-UI removal**: the leaf/replica delete happens now; making an *already-rendered* line vanish live needs the group inbox to handle the `UpdateEvent{Value:nil}` delete events (infra exists) + surface msg IDs to the UI.
- **Edit**: re-`Put` at the same path is suppressed by the receiver's (sender,ts,seq) dedup, so edit needs a supersede-reference + "edited" marker — next slice, reusing this plumbing.
- **wasm JS hook + Angular button**.

## Testing
`go build` (visor + CLI + binary), `gofmt`, `golangci-lint` (0 issues), `go test ./cmd/apps/skychat/group/` all green. Delete-propagation is backed by the existing treestore subscriber test.