### PR TITLE
fix(skychat/group): receive-side roster reconciler + stop self-echo (#3426)

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -164,6 +164,26 @@ func (m *Manager) SetMessageHandler(h MessageHandler) {
 	m.mu.RUnlock()
 }
 
+// persistRoster returns a roster-change callback (installed on every session)
+// that writes the reconciler's converged member+admin set back to the store,
+// so group info/list reflect convergence and it survives restart. Best-effort:
+// a store failure is debug-logged, not propagated — the live session state has
+// already converged regardless. See #3426.
+func (m *Manager) persistRoster(id string) func(members, admins []cipher.PubKey) {
+	return func(members, admins []cipher.PubKey) {
+		r, ok, err := m.store.Get(id)
+		if err != nil || !ok {
+			return
+		}
+		r.Members = members
+		r.Admins = admins
+		r.EnsureFounderInAdmins()
+		if err := m.store.Put(r); err != nil {
+			m.log.WithError(err).WithField("id", id).Debug("group: persistRoster: store put failed")
+		}
+	}
+}
+
 // Create constructs a new owner-side group, persists it, and opens
 // the publisher. Returns the persisted Record (with ID + Port + key
 // populated) so the caller can build the invite link.
@@ -1477,6 +1497,9 @@ func (m *Manager) openLocked(r Record) (*Session, error) {
 	if h != nil {
 		sess.SetMessageHandler(m.wrapHandler(r.ID, h))
 	}
+	// Persist reconciled roster changes back to the store so group info/list
+	// reflect convergence and it survives restart (#3426).
+	sess.SetRosterChangeHandler(m.persistRoster(r.ID))
 	m.mu.Lock()
 	m.sessions[r.ID] = sess
 	m.mu.Unlock()

--- a/cmd/apps/skychat/group/roster_reconcile.go
+++ b/cmd/apps/skychat/group/roster_reconcile.go
@@ -1,0 +1,179 @@
+// Package group — receive-side roster/admin reconciler.
+//
+// PublishRosterMutation/PublishAdminMutation write signed roster/<seq> and
+// admin/<seq> leaves onto the issuer's feed, but before this file NOTHING read
+// them: every subscriber subscribed to msgs/ only, and onUpdate had no branch
+// for roster/admin leaves. So a late joiner (which bootstraps its Record as
+// [owner, self] from the invite) never converged to the owner's real member
+// list — the "reconciler (step 3 of the gossip impl)" the comments referenced
+// was never implemented. See skycoin/skywire#3426.
+//
+// This wires the receive side: subscribers now include the roster/+admin/
+// prefixes (see subscribedPrefixes), and onUpdate hands each such leaf to
+// applyRosterLeaf / applyAdminLeaf here. The security-critical rule is that a
+// mutation is applied ONLY if it is (a) signature-valid and (b) issued by a
+// CURRENT admin of the group — otherwise any member could forge the roster.
+package group
+
+import (
+	"encoding/json"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// subscribedPrefixes is the set of CXO path prefixes every group subscriber
+// watches: msgs/ (chat) plus roster/ and admin/ (signed membership + admin
+// gossip). Centralized so all SetPrefixes call sites stay in lockstep.
+func subscribedPrefixes() []string {
+	return []string{MessagePathPrefix, RosterPathPrefix, AdminPathPrefix}
+}
+
+// SetRosterChangeHandler installs a callback invoked (with a snapshot of the
+// reconciled members + admins) whenever the reconciler mutates this session's
+// roster. The manager uses it to persist the updated Record to its store so
+// group info/list reflect the converged roster and it survives restart. nil is
+// fine — the in-memory session state + peer-subscriptions still converge; only
+// on-disk persistence is skipped.
+func (s *Session) SetRosterChangeHandler(f func(members, admins []cipher.PubKey)) {
+	s.onRosterChange = f
+}
+
+func containsPK(list []cipher.PubKey, pk cipher.PubKey) bool {
+	for _, x := range list {
+		if x == pk {
+			return true
+		}
+	}
+	return false
+}
+
+func removePK(list []cipher.PubKey, pk cipher.PubKey) []cipher.PubKey {
+	out := make([]cipher.PubKey, 0, len(list))
+	for _, x := range list {
+		if x != pk {
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+// applyRosterLeaf decodes, authenticates, and applies one roster/<seq> leaf.
+// Rejected silently (debug-logged) if it doesn't decode, the signature is
+// invalid, it targets another group, or — the security gate — the issuer is not
+// a current admin. Idempotent: an Add of an existing member (or Remove of an
+// absent one) is a no-op.
+func (s *Session) applyRosterLeaf(body []byte) {
+	var m RosterMutation
+	if err := json.Unmarshal(body, &m); err != nil {
+		return
+	}
+	if m.GroupID.String() != s.cfg.Record.ID {
+		return
+	}
+	if err := VerifyRoster(m); err != nil {
+		s.log.WithError(err).Debug("group: reconcile: rejecting roster mutation with bad signature")
+		return
+	}
+
+	s.membersMu.Lock()
+	// AUTHORITY GATE: only a current admin may mutate the roster. Without this
+	// any member could forge roster/<seq> leaves and add/remove arbitrary PKs.
+	if !s.cfg.Record.IsAdmin(m.IssuerPK) {
+		s.membersMu.Unlock()
+		s.log.WithField("issuer", m.IssuerPK.String()).
+			Debug("group: reconcile: rejecting roster mutation from non-admin issuer")
+		return
+	}
+	changed := false
+	switch m.Op {
+	case RosterOpAdd:
+		if m.PeerPK != (cipher.PubKey{}) && !containsPK(s.cfg.Record.Members, m.PeerPK) {
+			s.cfg.Record.Members = append(s.cfg.Record.Members, m.PeerPK)
+			changed = true
+		}
+	case RosterOpRemove:
+		// Never let a remove strip the founder — matches DemoteAdmin's
+		// founder-immutability and keeps the group recoverable.
+		if m.PeerPK != s.cfg.Record.OwnerPK && containsPK(s.cfg.Record.Members, m.PeerPK) {
+			s.cfg.Record.Members = removePK(s.cfg.Record.Members, m.PeerPK)
+			changed = true
+		}
+	}
+	members := append([]cipher.PubKey(nil), s.cfg.Record.Members...)
+	admins := append([]cipher.PubKey(nil), s.cfg.Record.Admins...)
+	s.membersMu.Unlock()
+
+	if !changed {
+		return
+	}
+	s.log.WithField("op", int(m.Op)).WithField("peer", m.PeerPK.String()).
+		Debug("group: reconcile: applied roster mutation")
+	// Reconcile peer-subscriptions so this visor actually subscribes to the
+	// new member's feed where its role calls for it (SetAllowlist is the
+	// owner-side reconciler; it recomputes the desired peer-sub set).
+	if _, err := s.SetAllowlist(members); err != nil {
+		s.log.WithError(err).Debug("group: reconcile: SetAllowlist after roster change failed")
+	}
+	if s.onRosterChange != nil {
+		s.onRosterChange(members, admins)
+	}
+}
+
+// applyAdminLeaf decodes, authenticates, and applies one admin/<seq> leaf
+// (promote/demote). Same authority gate as applyRosterLeaf; the founder can
+// never be demoted.
+func (s *Session) applyAdminLeaf(body []byte) {
+	var m AdminMutation
+	if err := json.Unmarshal(body, &m); err != nil {
+		return
+	}
+	if m.GroupID.String() != s.cfg.Record.ID {
+		return
+	}
+	if err := VerifyAdmin(m); err != nil {
+		s.log.WithError(err).Debug("group: reconcile: rejecting admin mutation with bad signature")
+		return
+	}
+
+	s.membersMu.Lock()
+	if !s.cfg.Record.IsAdmin(m.IssuerPK) {
+		s.membersMu.Unlock()
+		s.log.WithField("issuer", m.IssuerPK.String()).
+			Debug("group: reconcile: rejecting admin mutation from non-admin issuer")
+		return
+	}
+	changed := false
+	switch m.Op {
+	case AdminOpPromote:
+		if m.PeerPK != (cipher.PubKey{}) && !s.cfg.Record.IsAdmin(m.PeerPK) {
+			s.cfg.Record.Admins = append(s.cfg.Record.Admins, m.PeerPK)
+			changed = true
+		}
+	case AdminOpDemote:
+		if m.PeerPK != s.cfg.Record.OwnerPK && containsPK(s.cfg.Record.Admins, m.PeerPK) {
+			s.cfg.Record.Admins = removePK(s.cfg.Record.Admins, m.PeerPK)
+			changed = true
+		}
+	}
+	s.cfg.Record.EnsureFounderInAdmins()
+	members := append([]cipher.PubKey(nil), s.cfg.Record.Members...)
+	admins := append([]cipher.PubKey(nil), s.cfg.Record.Admins...)
+	s.membersMu.Unlock()
+
+	if !changed {
+		return
+	}
+	s.log.WithField("op", int(m.Op)).WithField("peer", m.PeerPK.String()).
+		Debug("group: reconcile: applied admin mutation")
+	// Admin-set changes shift who non-admins subscribe to (admins) and who
+	// admins aggregate — reconcile both sides.
+	if _, err := s.SetAdminRoster(admins); err != nil {
+		s.log.WithError(err).Debug("group: reconcile: SetAdminRoster after admin change failed")
+	}
+	if _, err := s.SetAllowlist(members); err != nil {
+		s.log.WithError(err).Debug("group: reconcile: SetAllowlist after admin change failed")
+	}
+	if s.onRosterChange != nil {
+		s.onRosterChange(members, admins)
+	}
+}

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -342,7 +342,11 @@ type Session struct {
 	members   []cipher.PubKey
 
 	handler MessageHandler
-	log     *logging.Logger
+	// onRosterChange is invoked with a snapshot of the reconciled members +
+	// admins after applyRosterLeaf/applyAdminLeaf mutate the roster, so the
+	// manager can persist the converged Record. See SetRosterChangeHandler.
+	onRosterChange func(members, admins []cipher.PubKey)
+	log            *logging.Logger
 
 	// lastInboundNs is the unified liveness signal for this session,
 	// in unix-nanoseconds. Set on every observable inbound event —
@@ -678,7 +682,7 @@ func openOwner(cfg Config, log *logging.Logger) (*Session, error) {
 				Warn("group: owner peer-sub create failed; group still usable via legacy relay path")
 			continue
 		}
-		ps.SetPrefixes([]string{MessagePathPrefix})
+		ps.SetPrefixes(subscribedPrefixes())
 		s.peerLastInboundNs[peerPK] = new(atomic.Int64)
 		s.peerUpdateCount[peerPK] = new(atomic.Uint64)
 		ps.OnUpdate(s.makePeerOnUpdate(peerPK))
@@ -792,7 +796,7 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 		_ = pub.Close() //nolint:errcheck
 		return nil, fmt.Errorf("group: Open member: attach subscriber: %w", err)
 	}
-	sub.SetPrefixes([]string{MessagePathPrefix})
+	sub.SetPrefixes(subscribedPrefixes())
 	s := &Session{
 		cfg: cfg, port: cfg.Record.Port, pub: pub, sub: sub, log: log,
 		peerSubs:          make(map[cipher.PubKey]*treestore.Subscriber),
@@ -838,7 +842,7 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 		// Subscribe to both primary (peer's own sends) AND mirror
 		// (admin-relayed copies of other members' sends) — see the
 		// openOwner equivalent for the full rationale.
-		ps.SetPrefixes([]string{MessagePathPrefix})
+		ps.SetPrefixes(subscribedPrefixes())
 		s.peerUpdateCount[peerPK] = new(atomic.Uint64)
 		s.peerLastInboundNs[peerPK] = new(atomic.Int64)
 		ps.OnUpdate(s.makePeerOnUpdate(peerPK))
@@ -1427,7 +1431,7 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) ([]cipher.PubKey, error)
 				Warn("group: SetAllowlist: peer-sub create failed; will retry on next allowlist change")
 			continue
 		}
-		ps.SetPrefixes([]string{MessagePathPrefix})
+		ps.SetPrefixes(subscribedPrefixes())
 		s.peerLastInboundNs[pk] = new(atomic.Int64)
 		s.peerUpdateCount[pk] = new(atomic.Uint64)
 		ps.OnUpdate(s.makePeerOnUpdate(pk))
@@ -1565,7 +1569,7 @@ func (s *Session) SetAdminRoster(admins []cipher.PubKey) ([]cipher.PubKey, error
 				Warn("group: SetAdminRoster: peer-sub create failed; will retry on next admin-roster change")
 			continue
 		}
-		ps.SetPrefixes([]string{MessagePathPrefix})
+		ps.SetPrefixes(subscribedPrefixes())
 		s.peerLastInboundNs[pk] = new(atomic.Int64)
 		s.peerUpdateCount[pk] = new(atomic.Uint64)
 		ps.OnUpdate(s.makePeerOnUpdate(pk))
@@ -2286,12 +2290,30 @@ func (s *Session) onUpdate(events []treestore.UpdateEvent) {
 	// per-peer subscriber walks the publisher's CXO tree from
 	// SinceTimestampNs and gets every leaf the publisher still has,
 	// without needing a separate admin-driven mirror.
+	// Receive-side roster/admin reconciler (#3426): apply signed membership +
+	// admin mutations issued by current admins so late joiners converge to the
+	// real roster. Runs before the handler gate so it works even on sessions
+	// with no message handler installed.
+	for _, ev := range events {
+		if ev.Value == nil {
+			continue
+		}
+		if strings.HasPrefix(ev.Path, RosterPathPrefix+"/") {
+			s.applyRosterLeaf(ev.Value)
+		} else if strings.HasPrefix(ev.Path, AdminPathPrefix+"/") {
+			s.applyAdminLeaf(ev.Value)
+		}
+	}
 	h := s.handler
 	if h == nil {
 		return
 	}
 	for _, ev := range events {
 		if ev.Value == nil {
+			continue
+		}
+		// roster/admin leaves were handled by the reconciler pre-pass above.
+		if strings.HasPrefix(ev.Path, RosterPathPrefix+"/") || strings.HasPrefix(ev.Path, AdminPathPrefix+"/") {
 			continue
 		}
 		// Cross-source dedup: collapse the (primary + N mirror copies)
@@ -2393,6 +2415,15 @@ func (s *Session) onUpdate(events []treestore.UpdateEvent) {
 		// up to the user handler — they're wire-level liveness
 		// probes, not chat content.
 		if IsHeartbeat(msg) {
+			continue
+		}
+		// Don't deliver our OWN messages back to us. A non-admin member reads an
+		// admin's canonical feed, and the admin republishes every verified leaf
+		// verbatim — INCLUDING this member's own sends — so without this guard a
+		// member sees its own message echoed back after sending. The UI shows
+		// local sends optimistically, so the round-tripped copy is a duplicate.
+		// (Owner-role self-echo is delivered separately from publishAs, not here.)
+		if msg.SenderPK == s.cfg.MyPK {
 			continue
 		}
 		h(s.cfg.Record.ID, msg.SenderPK, msg)


### PR DESCRIPTION
Fixes #3426. Roster gossip was **write-only** — `PublishRosterMutation` wrote `roster/<seq>` leaves but every subscriber watched `msgs/` only and `onUpdate` had no branch to apply them, so a late joiner never converged past its `[owner, self]` bootstrap (observed live: a wasm member showed 2 members while the owner showed 4).

## Changes
- **Subscribe to `roster/` + `admin/`** alongside `msgs/` (`subscribedPrefixes()`, 5 sites).
- **Receive-side reconciler** (`roster_reconcile.go`): `onUpdate` hands each `roster/`/`admin/` leaf to `applyRosterLeaf`/`applyAdminLeaf` → json-decode → `VerifyRoster`/`VerifyAdmin` (signature) → **AUTHORITY GATE: issuer must be a current admin (`Record.IsAdmin`)** or it's rejected (prevents roster forgery) → apply Add/Remove/Promote/Demote (founder-immutable, idempotent) → reconcile peer-subs → **persist** via a new session→manager callback (`Manager.persistRoster`) so `group info/list` reflect convergence and it survives restart.
- **Self-echo fix**: a non-admin reads an admin's feed, and the admin republishes every verified leaf verbatim **including the member's own sends**, so a member saw its own message echoed after sending (reported live by a group member). `onUpdate` now skips handler delivery when `msg.SenderPK == MyPK` (the UI shows local sends optimistically).

## Security
The authority gate is the crux — without it any member could forge `roster/` leaves. Applied mutations require a valid signature **and** a current-admin issuer.

## Follow-ups (noted, not in this PR)
- Gossip **create-time (`--member`) members** so they hydrate on late joins (today the reconciler applies post-join AddMember gossip; create-time members aren't re-broadcast).
- **Subscription-liveness**: stale owner↔member peer-subs cause fresh messages to stop propagating (a wasm member's new messages weren't reaching others) — a reconnect/staleness fix, separate from convergence.
- Forge-rejection unit test.

## Testing
`go build` (group + visor + binary), `gofmt`, `golangci-lint` (0 issues), `go test ./cmd/apps/skychat/group/` all green.