### PR TITLE
feat(visor): fibercoin node discovery over dmsg (ServiceTypeCoin phase 1b)

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -229,6 +229,20 @@ const envfileLinux = `#
 #	the default skycoin-web entry already has).
 #SKYCOINWEBUSER='youruser'
 
+#--	Advertise already-running fibercoin nodes over dmsg + service
+#	discovery (type=coin), so a thin-client wallet — including the
+#	browser wasm visor — can discover and reach a node for the right
+#	coin over the mesh, with no local full node and no launch flags.
+#	Bash array. Each entry is "<local_addr>[@<dmsg_port>]" where
+#	local_addr is the node's HTTP API on this host; dmsg_port defaults
+#	to local_addr's port. The node runs INDEPENDENTLY of the visor
+#	(it need not be a skywire SKYCOIND app) and is health-gated: the
+#	visor advertises it only while its /api/v1/health answers.
+#		COIN_NODES=('127.0.0.1:6420')
+#	Multi-coin (skycoin + a fibercoin on 6430):
+#		COIN_NODES=('127.0.0.1:6420' '127.0.0.1:6430@6430')
+#COIN_NODES=('')
+
 ### Advanced Tuning #####################################################
 
 #--	CLI RPC address (default localhost:3435)

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -335,6 +335,8 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "skycoindinstances")
 	genConfigCmd.Flags().StringVar(&skycoinDaemonFlags, "skycoindflags", scriptExecString("${SKYCOIND_FLAGS}"), "extra flags appended to every skycoin daemon (port and data dir auto allocated)")
 	gHiddenFlags = append(gHiddenFlags, "skycoindflags")
+	genConfigCmd.Flags().StringVar(&coinNodes, "coin-nodes", scriptExecArray("${COIN_NODES[@]}"), "fibercoin nodes to forward over dmsg + advertise (type=coin); CSV of local_addr[@dmsg_port]")
+	gHiddenFlags = append(gHiddenFlags, "coin-nodes")
 	genConfigCmd.Flags().BoolVar(&isSkycoinWebEnable, "skycoinweb", scriptExecBool("${SKYCOINWEB:-false}"), "autostart skycoin web wallet (thin client)")
 	// 8002 to avoid colliding with skychat's default at 127.0.0.1:8001.
 	// Both apps' upstream defaults happen to be 8001; skychat got there
@@ -1394,6 +1396,46 @@ func configureHypervisor(log *logging.Logger) {
 	}
 }
 
+// buildCoinNodes parses the --coin-nodes CSV (${COIN_NODES[@]}) into
+// visorconfig.CoinNodeConfig entries. Each spec is "<local_addr>" or
+// "<local_addr>@<dmsg_port>", where local_addr is the node's HTTP API on this
+// host (host:port). When the dmsg port is omitted it defaults to local_addr's
+// TCP port — so "127.0.0.1:6420" is advertised on dmsg port 6420. Whitelist is
+// not expressible via the flag (public read-mostly coin APIs are the common
+// case); edit the config directly to restrict peers. Returns nil for empty.
+func buildCoinNodes() ([]visorconfig.CoinNodeConfig, error) {
+	specs := splitCSV(coinNodes)
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	out := make([]visorconfig.CoinNodeConfig, 0, len(specs))
+	for _, s := range specs {
+		addr := s
+		var dport uint64
+		if at := strings.LastIndex(s, "@"); at >= 0 {
+			addr = s[:at]
+			p, err := strconv.ParseUint(s[at+1:], 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("coin-nodes: invalid dmsg port in %q: %w", s, err)
+			}
+			dport = p
+		}
+		_, portStr, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("coin-nodes: invalid local_addr %q (want host:port): %w", addr, err)
+		}
+		if dport == 0 {
+			p, err := strconv.ParseUint(portStr, 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("coin-nodes: invalid port in %q: %w", addr, err)
+			}
+			dport = p
+		}
+		out = append(out, visorconfig.CoinNodeConfig{LocalAddr: addr, DmsgPort: uint16(dport)})
+	}
+	return out, nil
+}
+
 // buildSkycoinDaemonApps emits the AppConfig slice for skycoin-daemon
 // instances based on the SKYCOIND_* knobs.
 //
@@ -1728,6 +1770,15 @@ func configureApps(log *logging.Logger) {
 			},
 		}
 	}
+
+	// Fibercoin node discovery (servicedisc.ServiceTypeCoin). Independent
+	// of the apps mode above — the node runs on its own; the visor only
+	// forwards + advertises it. See pkg/visor/init_coinnode.go.
+	coinNodeCfgs, cnErr := buildCoinNodes()
+	if cnErr != nil {
+		log.WithError(cnErr).Fatal("invalid coin-nodes configuration")
+	}
+	conf.CoinNodes = coinNodeCfgs
 
 	// Disable apps --disable-apps flag
 	if disableApps != "" {

--- a/cmd/skywire-cli/commands/config/gen_coinnode_test.go
+++ b/cmd/skywire-cli/commands/config/gen_coinnode_test.go
@@ -1,0 +1,67 @@
+package cliconfig
+
+import (
+	"testing"
+)
+
+func TestBuildCoinNodes(t *testing.T) {
+	defer func() { coinNodes = "" }()
+
+	t.Run("empty", func(t *testing.T) {
+		coinNodes = ""
+		got, err := buildCoinNodes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != nil {
+			t.Fatalf("want nil, got %v", got)
+		}
+	})
+
+	t.Run("addr only -> dmsg port defaults to local port", func(t *testing.T) {
+		coinNodes = "127.0.0.1:6420"
+		got, err := buildCoinNodes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 || got[0].LocalAddr != "127.0.0.1:6420" || got[0].DmsgPort != 6420 {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("explicit dmsg port", func(t *testing.T) {
+		coinNodes = "127.0.0.1:6420@7000"
+		got, err := buildCoinNodes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 || got[0].LocalAddr != "127.0.0.1:6420" || got[0].DmsgPort != 7000 {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("multiple CSV", func(t *testing.T) {
+		coinNodes = "127.0.0.1:6420,127.0.0.1:6430@6430"
+		got, err := buildCoinNodes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 2 || got[1].LocalAddr != "127.0.0.1:6430" || got[1].DmsgPort != 6430 {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("invalid addr errors", func(t *testing.T) {
+		coinNodes = "not-an-addr"
+		if _, err := buildCoinNodes(); err == nil {
+			t.Fatal("expected error for missing host:port")
+		}
+	})
+
+	t.Run("invalid dmsg port errors", func(t *testing.T) {
+		coinNodes = "127.0.0.1:6420@notaport"
+		if _, err := buildCoinNodes(); err == nil {
+			t.Fatal("expected error for bad dmsg port")
+		}
+	})
+}

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -140,12 +140,19 @@ var (
 	// instance's args (e.g. "--enable-gui-api-sets READ,STATUS").
 	// --port and --data-dir are auto-allocated per instance and
 	// must not appear here — gen errors out if they do.
-	skycoinDaemonFlags       string
-	isSkycoinWebEnable       bool
-	skycoinWebAddr           string
-	skycoinWebNodeURLs       string // comma-separated; rendered as repeated --node-url flags
-	skycoinWebWalletDir      string
-	skycoinWebUser           string
+	skycoinDaemonFlags  string
+	isSkycoinWebEnable  bool
+	skycoinWebAddr      string
+	skycoinWebNodeURLs  string // comma-separated; rendered as repeated --node-url flags
+	skycoinWebWalletDir string
+	skycoinWebUser      string
+	// coinNodes advertises already-running fibercoin nodes over dmsg +
+	// service-discovery (servicedisc.ServiceTypeCoin). CSV of
+	// "<local_addr>[@<dmsg_port>]" specs; each becomes a
+	// visorconfig.CoinNodeConfig the visor forwards + health-gates. The
+	// node runs INDEPENDENTLY (it need not be a skywire-managed daemon
+	// app), so this is orthogonal to SKYCOIND. Driven by ${COIN_NODES[@]}.
+	coinNodes                string
 	rewardSkyAddr            string
 	hvHTTPAddr               string
 	stunServers              string

--- a/pkg/servicedisc/client.go
+++ b/pkg/servicedisc/client.go
@@ -183,6 +183,16 @@ func (c *HTTPClient) Services(ctx context.Context, quantity int, version, countr
 	return out, err
 }
 
+// SetCoinInfo attaches fibercoin identity/metadata (CoinInfo) to the entry
+// this client registers. Call before Register/RegisterEntry, and again between
+// heartbeats to refresh volatile fields (e.g. HeadSeq). Only meaningful for a
+// ServiceTypeCoin client; ignored by other service types on the SD server side.
+func (c *HTTPClient) SetCoinInfo(info *CoinInfo) {
+	c.entryMx.Lock()
+	c.entry.Coin = info
+	c.entryMx.Unlock()
+}
+
 // RegisterEntry calls 'POST /api/services', retrieves the entry
 // and updates local field with the result
 // if there are no ip addresses in the entry it also tries to fetch those

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -144,6 +144,8 @@ var (
 	groupingMod vinit.Module
 	// Skychat 1:1 voice-call manager (dmsg+skynet signaling, RTP media).
 	voiceMod vinit.Module
+	// coinNodesMod forwards + advertises configured fibercoin nodes
+	coinNodesMod vinit.Module
 	// visor that groups all modules together
 	vis vinit.Module
 	// config initialization
@@ -243,8 +245,12 @@ func registerModules(logger *logging.MasterLogger) {
 	// Skychat 1:1 voice: signaling + RTP media over dmsg/skynet. Depends on
 	// dmsgC. See init_voice.go.
 	voiceMod = maker("voice", initVoice, &dmsgC)
+	// Fibercoin node discovery: forward configured coin-node HTTP APIs over
+	// dmsg + health-gated type=coin SD registration. Depends on dmsgC (forward
+	// + SD dmsg client) and skyFwd (dmsg forwarder). See init_coinnode.go.
+	coinNodesMod = maker("coin_nodes", initCoinNodes, &dmsgC, &skyFwd)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &ptyModule,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod, &voiceMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod, &voiceMod, &coinNodesMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/init_coinnode.go
+++ b/pkg/visor/init_coinnode.go
@@ -1,0 +1,234 @@
+// Package visor pkg/visor/init_coinnode.go
+//
+// Brings up fibercoin node discovery (servicedisc.ServiceTypeCoin). For each
+// v.conf.CoinNodes entry the visor:
+//
+//  1. reverse-proxies the node's local HTTP API over dmsg on the configured
+//     DmsgPort (reusing the forwarded-ports infra), so a remote thin-client
+//     wallet — including the browser wasm visor over its HTTP-over-dmsg shim —
+//     can reach the node's API through the mesh; and
+//  2. on the SD heartbeat interval, probes the node's /api/v1/health, builds a
+//     DETECTED CoinInfo (never operator-claimed), and registers a type=coin SD
+//     entry ONLY while the node answers — deregistering when it goes away, so
+//     the advertisement is always truthful (no dead entries).
+//
+// The node itself runs INDEPENDENTLY of the visor (systemd/terminal); the visor
+// never starts or stops it. See docs and project_skycoin_wallet_over_dmsg.
+package visor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/servicedisc"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// coinHealthProbeTimeout bounds a single /health probe. Kept short so a hung
+// node can't stall the heartbeat loop.
+const coinHealthProbeTimeout = 10 * time.Second
+
+// coinHealth is the subset of the skycoin /api/v1/health response we read to
+// build a CoinInfo. Every field is generic across fibercoins (skycoin, mdl,
+// aviate, …) — they share the daemon codebase and this response shape.
+type coinHealth struct {
+	Coin             string `json:"coin"`
+	BlockchainPubkey string `json:"blockchain_pubkey"`
+	Version          struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+	} `json:"version"`
+	Fiber struct {
+		Name string `json:"name"`
+	} `json:"fiber"`
+	Blockchain struct {
+		Head struct {
+			Seq uint64 `json:"seq"`
+		} `json:"head"`
+	} `json:"blockchain"`
+}
+
+// parseCoinHealth maps a raw /api/v1/health JSON body to a CoinInfo. The coin
+// name prefers fiber.name (canonical) and falls back to the top-level "coin"
+// field. Returns an error on malformed JSON so a bad response never registers a
+// bogus entry.
+func parseCoinHealth(body []byte) (*servicedisc.CoinInfo, error) {
+	var h coinHealth
+	if err := json.Unmarshal(body, &h); err != nil {
+		return nil, fmt.Errorf("parse coin health: %w", err)
+	}
+	fiber := h.Fiber.Name
+	if fiber == "" {
+		fiber = h.Coin
+	}
+	return &servicedisc.CoinInfo{
+		BlockchainPubKey: h.BlockchainPubkey,
+		Fiber:            fiber,
+		Version:          h.Version.Version,
+		Commit:           h.Version.Commit,
+		HeadSeq:          h.Blockchain.Head.Seq,
+	}, nil
+}
+
+// probeCoinNode GETs <localAddr>/api/v1/health and parses it into a CoinInfo.
+// localAddr is the node's HTTP API address on this host (e.g. 127.0.0.1:6420).
+func probeCoinNode(ctx context.Context, client *http.Client, localAddr string) (*servicedisc.CoinInfo, error) {
+	url := "http://" + localAddr + "/api/v1/health"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("coin node health: status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	return parseCoinHealth(body)
+}
+
+// initCoinNodes wires fibercoin node discovery. Best-effort: no configured
+// nodes, or no dmsg client, is a no-op. Each node gets a dmsg forward and a
+// health-gated SD registrar loop.
+func initCoinNodes(_ context.Context, v *Visor, log *logging.Logger) error {
+	if v.conf == nil || len(v.conf.CoinNodes) == 0 {
+		return nil
+	}
+	if v.dmsgC == nil {
+		log.Warn("coin_nodes configured but dmsg client is nil; skipping")
+		return nil
+	}
+
+	// The SD address must be a dmsg:// URL — the entry we register is reachable
+	// over the mesh, so it's registered through the dmsg-served SD.
+	sdURL := v.conf.Launcher.ServiceDiscDmsg
+	if sdURL == "" {
+		sdURL = v.conf.Launcher.ServiceDisc
+	}
+	httpC, err := getHTTPClient(context.Background(), v, sdURL)
+	if err != nil {
+		log.WithError(err).Warn("coin_nodes: cannot build SD dmsg client; skipping")
+		return nil
+	}
+
+	// Local health probes are plain localhost HTTP (the node's own API); no
+	// dmsg involved. Short per-probe timeout via the request context.
+	localHTTP := &http.Client{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	for i := range v.conf.CoinNodes {
+		node := v.conf.CoinNodes[i]
+		if node.LocalAddr == "" || node.DmsgPort == 0 {
+			log.WithField("index", i).Warn("coin_nodes: entry missing local_addr or dmsg_port; skipping")
+			continue
+		}
+
+		// (1) Expose the node's local API over dmsg on DmsgPort. ProxyAddr fronts
+		// the external local endpoint; LocalPort 0 means "use ProxyAddr".
+		fp := ForwardedPort{
+			Port:      int(node.DmsgPort),
+			ProxyAddr: node.LocalAddr,
+			Label:     "coin",
+			DMSG:      true,
+			Whitelist: node.Whitelist,
+		}
+		if rerr := v.forwardedPorts.Register(fp); rerr != nil {
+			log.WithError(rerr).WithField("dmsg_port", node.DmsgPort).
+				Warn("coin_nodes: failed to register forwarded port; skipping")
+			continue
+		}
+		v.startDmsgForwarder(int(node.DmsgPort), 0)
+
+		// (2) Health-gated SD registrar for this node.
+		sdClient := servicedisc.NewClient(
+			logging.MustGetLogger("servicedisc.coin"),
+			newInfoMasterLogger(),
+			servicedisc.Config{
+				Type:     servicedisc.ServiceTypeCoin,
+				PK:       v.conf.PK,
+				SK:       v.conf.SK,
+				Port:     node.DmsgPort,
+				DiscAddr: sdURL,
+			}, httpC, "")
+
+		go runCoinRegistrar(ctx, log.WithField("dmsg_port", node.DmsgPort), sdClient, localHTTP, node)
+	}
+
+	v.pushCloseStack("coin_nodes", func() error { cancel(); return nil })
+	log.WithField("count", len(v.conf.CoinNodes)).Info("coin_nodes: fibercoin node discovery up")
+	return nil
+}
+
+// newInfoMasterLogger builds an info-level master logger for a coin SD client,
+// matching the convention used by the on-demand services lookup path.
+func newInfoMasterLogger() *logging.MasterLogger {
+	ml := logging.NewMasterLogger()
+	ml.SetLevel(logrus.InfoLevel)
+	return ml
+}
+
+// runCoinRegistrar probes the node's /health on the SD heartbeat interval and
+// keeps the type=coin entry registered only while the node answers. It probes
+// once immediately, then on each tick. On a failed probe it deregisters (the
+// node is down / the advertisement would be dead). CoinInfo is refreshed every
+// successful probe so volatile fields (HeadSeq) stay current.
+func runCoinRegistrar(ctx context.Context, log logrus.FieldLogger, sd *servicedisc.HTTPClient, localHTTP *http.Client, node visorconfig.CoinNodeConfig) {
+	ticker := time.NewTicker(skyenv.ServiceDiscUpdateInterval)
+	defer ticker.Stop()
+
+	registered := false
+	tick := func() {
+		pctx, cancel := context.WithTimeout(ctx, coinHealthProbeTimeout)
+		defer cancel()
+		info, err := probeCoinNode(pctx, localHTTP, node.LocalAddr)
+		if err != nil {
+			if registered {
+				log.WithError(err).Info("coin node unhealthy; deregistering")
+				if derr := sd.DeleteEntry(ctx); derr != nil {
+					log.WithError(derr).Debug("coin node deregister failed")
+				}
+				registered = false
+			}
+			return
+		}
+		sd.SetCoinInfo(info)
+		if rerr := sd.RegisterEntry(ctx); rerr != nil {
+			log.WithError(rerr).Debug("coin node register failed")
+			return
+		}
+		if !registered {
+			log.WithField("fiber", info.Fiber).WithField("head_seq", info.HeadSeq).
+				Info("coin node healthy; registered type=coin")
+			registered = true
+		}
+	}
+
+	tick()
+	for {
+		select {
+		case <-ctx.Done():
+			if registered {
+				dctx, cancel := context.WithTimeout(context.Background(), coinHealthProbeTimeout)
+				_ = sd.DeleteEntry(dctx) //nolint:errcheck
+				cancel()
+			}
+			return
+		case <-ticker.C:
+			tick()
+		}
+	}
+}

--- a/pkg/visor/init_coinnode.go
+++ b/pkg/visor/init_coinnode.go
@@ -222,7 +222,10 @@ func runCoinRegistrar(ctx context.Context, log logrus.FieldLogger, sd *servicedi
 		select {
 		case <-ctx.Done():
 			if registered {
-				dctx, cancel := context.WithTimeout(context.Background(), coinHealthProbeTimeout)
+				// ctx is already canceled here (shutdown), so derive a live,
+				// non-cancelable context from it for the final deregister —
+				// keeps values, drops the cancellation, no bare Background.
+				dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), coinHealthProbeTimeout)
 				_ = sd.DeleteEntry(dctx) //nolint:errcheck
 				cancel()
 			}

--- a/pkg/visor/init_coinnode_test.go
+++ b/pkg/visor/init_coinnode_test.go
@@ -1,0 +1,66 @@
+package visor
+
+import (
+	"testing"
+)
+
+// TestParseCoinHealth verifies the /api/v1/health -> CoinInfo mapping, using a
+// representative skycoin mainnet health response (trimmed to the fields we read
+// plus a few extras that must be ignored).
+func TestParseCoinHealth(t *testing.T) {
+	body := []byte(`{
+		"blockchain": {
+			"head": {"seq": 123456, "block_hash": "abc", "previous_block_hash": "def"},
+			"unspents": 100,
+			"unconfirmed": 0
+		},
+		"version": {"version": "0.28.0", "commit": "1e07e977", "branch": "develop"},
+		"coin": "skycoin",
+		"user_agent": "skycoin:0.28.0",
+		"open_connections": 8,
+		"csrf_enabled": true,
+		"block_publisher": false,
+		"blockchain_pubkey": "0328c576d3f420e7682058a981173a4b374c7cc5ff55bf394d3cf57059bbe6456a",
+		"fiber": {"name": "skycoin", "display_name": "Skycoin", "ticker": "SKY", "bip44_coin": 8000}
+	}`)
+
+	info, err := parseCoinHealth(body)
+	if err != nil {
+		t.Fatalf("parseCoinHealth: %v", err)
+	}
+	if info.BlockchainPubKey != "0328c576d3f420e7682058a981173a4b374c7cc5ff55bf394d3cf57059bbe6456a" {
+		t.Errorf("BlockchainPubKey = %q", info.BlockchainPubKey)
+	}
+	if info.Fiber != "skycoin" {
+		t.Errorf("Fiber = %q, want skycoin", info.Fiber)
+	}
+	if info.Version != "0.28.0" {
+		t.Errorf("Version = %q, want 0.28.0", info.Version)
+	}
+	if info.Commit != "1e07e977" {
+		t.Errorf("Commit = %q, want 1e07e977", info.Commit)
+	}
+	if info.HeadSeq != 123456 {
+		t.Errorf("HeadSeq = %d, want 123456", info.HeadSeq)
+	}
+}
+
+// TestParseCoinHealthFiberFallback verifies the coin name falls back to the
+// top-level "coin" field when fiber.name is absent.
+func TestParseCoinHealthFiberFallback(t *testing.T) {
+	info, err := parseCoinHealth([]byte(`{"coin": "mdl", "blockchain_pubkey": "02deadbeef"}`))
+	if err != nil {
+		t.Fatalf("parseCoinHealth: %v", err)
+	}
+	if info.Fiber != "mdl" {
+		t.Errorf("Fiber = %q, want mdl (fallback to coin)", info.Fiber)
+	}
+}
+
+// TestParseCoinHealthMalformed ensures a bad body errors rather than
+// registering a bogus entry.
+func TestParseCoinHealthMalformed(t *testing.T) {
+	if _, err := parseCoinHealth([]byte(`not json`)); err == nil {
+		t.Fatal("expected error for malformed health body")
+	}
+}

--- a/pkg/visor/visorconfig/config_compat.go
+++ b/pkg/visor/visorconfig/config_compat.go
@@ -51,6 +51,8 @@ type v1JSON struct {
 	Stats   *Stats   `json:"stats,omitempty"`
 	Skychat *Skychat `json:"skychat,omitempty"`
 
+	CoinNodes []CoinNodeConfig `json:"coin_nodes,omitempty"`
+
 	SurveyWhitelist     []cipher.PubKey `json:"survey_whitelist"`
 	UserSurveyWhitelist []cipher.PubKey `json:"user_survey_whitelist,omitempty"`
 	Hypervisors         []cipher.PubKey `json:"hypervisors"`
@@ -109,6 +111,7 @@ func (v *V1) UnmarshalJSON(data []byte) error {
 	v.Launcher = mirror.Launcher
 	v.Stats = mirror.Stats
 	v.Skychat = mirror.Skychat
+	v.CoinNodes = mirror.CoinNodes
 	v.SurveyWhitelist = mirror.SurveyWhitelist
 	v.UserSurveyWhitelist = mirror.UserSurveyWhitelist
 	v.Hypervisors = mirror.Hypervisors

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -39,6 +39,15 @@ type V1 struct {
 	// persistence; expected to grow as the chat surface evolves.
 	Skychat *Skychat `json:"skychat,omitempty"`
 
+	// CoinNodes lists fibercoin nodes (see servicedisc.ServiceTypeCoin)
+	// this visor forwards over dmsg and advertises in service discovery,
+	// so a browser/thin-client wallet can discover and reach a node for
+	// the right coin over the mesh with no local full node and no launch
+	// flags. Each entry is health-gated (see pkg/visor/init_coinnode.go):
+	// the visor probes the node's HTTP /health on the SD heartbeat
+	// interval and only advertises it while it answers — no dead entries.
+	CoinNodes []CoinNodeConfig `json:"coin_nodes,omitempty"`
+
 	SurveyWhitelist     []cipher.PubKey `json:"survey_whitelist"`
 	UserSurveyWhitelist []cipher.PubKey `json:"user_survey_whitelist,omitempty"` // user-added keys, preserved across config refresh
 	Hypervisors         []cipher.PubKey `json:"hypervisors"`
@@ -94,6 +103,27 @@ type Skychat struct {
 	// aware overrides (rate-limit disabled, larger per-group cap).
 	// A future config knob may expose the limits directly.
 	GroupHistoryDB string `json:"group_history_db,omitempty"`
+}
+
+// CoinNodeConfig describes one fibercoin node this visor exposes over dmsg
+// and advertises in service discovery (servicedisc.ServiceTypeCoin). The node
+// (e.g. `skywire skycoin daemon`) runs INDEPENDENTLY of the visor and serves a
+// plain HTTP API on localhost; the visor merely reverse-proxies it over the
+// mesh and, on the SD heartbeat interval, reads its /api/v1/health to build a
+// truthful, DETECTED CoinInfo advertisement (never operator-claimed identity).
+type CoinNodeConfig struct {
+	// LocalAddr is the node's HTTP API address on this host
+	// (e.g. "127.0.0.1:6420" — the skycoin daemon default). The visor
+	// reverse-proxies this over dmsg and probes <LocalAddr>/api/v1/health.
+	LocalAddr string `json:"local_addr"`
+	// DmsgPort is the dmsg port the node is exposed on. The advertised SD
+	// entry address is <this-visor-PK>:<DmsgPort>, which a wallet dials
+	// through the mesh (or the wasm visor's HTTP-over-dmsg shim).
+	DmsgPort uint16 `json:"dmsg_port"`
+	// Whitelist, when non-empty, restricts which peer PKs may reach the
+	// forwarded node. Empty (default) = any authenticated peer — the usual
+	// choice for a public read-mostly coin API.
+	Whitelist []cipher.PubKey `json:"whitelist,omitempty"`
 }
 
 // Pty configures the pseudoterminal subsystem (formerly Dmsgpty).


### PR DESCRIPTION
Visor-side wiring for coin-node service discovery (follows #3436 which added the generic `coin` service type + `CoinInfo`).

For each configured `CoinNode`, the visor:
1. reverse-proxies the node's local HTTP API over dmsg on `DmsgPort` (reusing the forwarded-ports infra), so a remote thin-client wallet — including the browser wasm visor over its HTTP-over-dmsg shim — can reach the node's API through the mesh; and
2. on the SD heartbeat interval, probes `<LocalAddr>/api/v1/health`, builds a **detected** `CoinInfo` (`blockchain_pubkey`/`fiber`/`version`/`commit`/`head_seq` — never operator-claimed identity), and registers a `type=coin` SD entry **only while the node answers** — deregistering when it goes away, so the advertisement is always truthful (no dead entries).

The coin node runs **independently** of the visor (systemd/terminal); the visor never starts or stops it. Desktop hosts are unaffected unless `coin_nodes` is configured — this exists to make `skycoin web` (and any fibercoin thin client) work over dmsg, chiefly from the wasm visor as a substitute for the discontinued mobile wallets.

**Changes**
- `visorconfig`: `CoinNodeConfig{LocalAddr,DmsgPort,Whitelist}` + `V1.CoinNodes`, mirrored in `config_compat.go` (v1JSON + copyback).
- `servicedisc`: `HTTPClient.SetCoinInfo` to attach the detected `CoinInfo` to the registered entry.
- `pkg/visor/init_coinnode.go`: the forward + health-gated registrar loop.
- Health-JSON → `CoinInfo` parser unit-tested (skycoin mainnet sample, fiber fallback, malformed).

Depends on the `blockchain_pubkey` field in skycoin `/health` (skycoin #2912, merged); the registrar reads it from the node's live JSON at runtime so it works regardless of the visor's vendored skycoin version.

Phase 2 (wasm serves skycoin-web + routes its API over dmsg via the shim) follows.