### PR TITLE
fix(hv-ui): node-list hang, empty tree-summary, and /api/log SSE errors

### DIFF
--- a/pkg/visor/hypervisor_handlers_log.go
+++ b/pkg/visor/hypervisor_handlers_log.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -26,6 +27,18 @@ func (hv *Hypervisor) getLog() http.HandlerFunc {
 		if !ok {
 			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
 			return
+		}
+		// This is a long-lived stream. The hypervisor http.Server sets
+		// WriteTimeout (10s), which is a single deadline for the WHOLE
+		// response — for an endless SSE stream it fires ~10s in and forcibly
+		// closes the connection, which the browser surfaces as a recurring
+		// ERR_INCOMPLETE_CHUNKED_ENCODING and a 10s-cyclic gap in the log
+		// window. Clear the write deadline for THIS response only (via
+		// ResponseController); every other endpoint keeps WriteTimeout.
+		if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil {
+			// Non-fatal: on a transport without deadline control the stream
+			// still works, it just re-inherits the server WriteTimeout.
+			hv.log(r).WithError(err).Debug("log SSE: could not clear write deadline")
 		}
 		// Empty filter = firehose (every module, Debug+). See Broadcaster.matches.
 		ch, cancel := hv.visor.SubscribeLogs(logging.Filter{MinLevel: logrus.DebugLevel}, 512)

--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -112,6 +112,19 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		localPK := hv.visor.conf.PK
 
+		// This handler does a parallel sub-hypervisor RPC walk with a 10s
+		// per-remote timeout, then a 5s fallback Summary pass, then writes a
+		// large (often >1MB) body — all BEFORE the first byte goes out. That
+		// can exceed the http.Server WriteTimeout (10s), which then closes the
+		// connection with no body written: the browser sees ERR_EMPTY_RESPONSE
+		// and the node list fails to load, precisely when a sub-hypervisor is
+		// slow/unreachable (the same condition that produces the error
+		// sections). Give this response a generous write deadline so a slow
+		// remote can't blow the whole tree; other endpoints keep WriteTimeout.
+		if err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(45 * time.Second)); err != nil {
+			hv.log(r).WithError(err).Debug("tree-summary: could not extend write deadline")
+		}
+
 		// Build the local section by reusing the same Summary
 		// machinery as /visors-summary — same fields, same cache,
 		// same offline-row semantics.
@@ -320,6 +333,18 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 		// across sections, which matches the doc comment at the top
 		// of this function ("Visor entries replicate across sections
 		// when a visor is connected to multiple hypervisors").
+
+		// A nil Visors slice marshals to JSON `null`, not `[]`. The hvui's
+		// node-list concatenates every section's `visors` and maps over the
+		// result; a `null` there throws "(...).map is not a function", which
+		// crashes buildSwitcherTabs and hangs the whole UI with a spinner. The
+		// SubError branch (an errored/timed-out sub-hypervisor) leaves Visors
+		// nil, so coerce every section to an empty array before writing.
+		for i := range sections {
+			if sections[i].Visors == nil {
+				sections[i].Visors = []Summary{}
+			}
+		}
 
 		httputil.WriteJSON(w, r, http.StatusOK, VisorTreeResponse{Sections: sections})
 	}

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -542,7 +542,11 @@ export class NodeListComponent extends PageBaseComponent implements OnInit, OnDe
             this.localHypervisorPk = '';
           }
 
-          this.allNodes = result.data as Node[];
+          // Never store a non-array in allNodes: a malformed/error summary body
+          // would otherwise break the data filterer + the switcher (see
+          // visorSwitcherChips). Fall back to empty so the UI renders instead of
+          // hanging when the fleet is mid-churn (visors restarting/reconfiguring).
+          this.allNodes = Array.isArray(result.data) ? (result.data as Node[]) : [];
           this.dataFilterer.setData(this.allNodes);
           this.buildSwitcherTabs();
 

--- a/static/skywire-manager-src/src/app/utils/visor-switcher.ts
+++ b/static/skywire-manager-src/src/app/utils/visor-switcher.ts
@@ -23,10 +23,15 @@ export function abbreviatePk(pk: string): string {
  * Shared by the node-list and node (detail) pages so the row is identical on both.
  */
 export function visorSwitcherChips(nodes: Node[]): TabButtonData[] {
-  return (nodes || []).map(n => ({
-      icon: (n as any).isHypervisor ? 'router' : ((n as any).arch === 'wasm' ? 'public' : 'devices'),
-      label: n.label || abbreviatePk(n.localPk),
-      sublabel: n.localPk || '',
-      linkParts: ['/nodes', n.localPk, 'info'],
-    } as TabButtonData));
+  // Guard with Array.isArray, not `nodes || []`: a truthy-but-non-array value
+  // (e.g. an error/object body assigned to allNodes when the fleet is churning)
+  // would otherwise pass through `|| []` and throw "(...).map is not a function",
+  // which crashes buildSwitcherTabs and hangs the whole hypervisor UI. One bad
+  // summary response must not take down the switcher.
+  return (Array.isArray(nodes) ? nodes : []).map(n => ({
+    icon: (n as any).isHypervisor ? 'router' : ((n as any).arch === 'wasm' ? 'public' : 'devices'),
+    label: n.label || abbreviatePk(n.localPk),
+    sublabel: n.localPk || '',
+    linkParts: ['/nodes', n.localPk, 'info'],
+  } as TabButtonData));
 }


### PR DESCRIPTION
Four related hypervisor-UI reliability fixes, found while debugging a host-native HV whose node list hung on the loading spinner.

### 1. Server — tree-summary sections return `[]`, not `null`
`getVisorsTreeSummary`'s **SubError branch** (an errored/timed-out sub-hypervisor) left `Visors` nil, which marshals to JSON `visors: null`. The hvui concatenates + maps each section's visors; a `null` throws `(...).map is not a function`, crashing `buildSwitcherTabs` and hanging the whole UI on the spinner. Now every section's `Visors` is coerced to an empty slice before writing.

*Reproduced live:* the HV had two timed-out sub-hypervisor sections returning `visors: null`; after the fix, `null`-visors section count = 0 and the switcher renders.

### 2. Client — guard the switcher + `allNodes` against a non-array
Defense-in-depth for the same bug class. `visorSwitcherChips` uses `Array.isArray(nodes) ? nodes : []` instead of `nodes || []` (a truthy-but-non-array value slips through `|| []`), and node-list stores `[]` rather than a raw non-array `result.data`. One bad summary response can no longer take down the switcher — even against an old server that still emits `null`.

### 3. Server — tree-summary needs a longer write deadline
The handler does a parallel sub-hypervisor RPC walk (**10s** per-remote timeout) + a 5s fallback pass, then writes a **>1MB** body — all before the first byte. That can exceed the server `WriteTimeout` (10s), which closes the connection with no body written: the browser sees `ERR_EMPTY_RESPONSE` and the list fails to load, exactly when a sub-hypervisor is slow (the same condition that produces the error sections). The write deadline is extended to 45s for this response only.

### 4. Server — `/api/log` SSE clears the write deadline
Same `WriteTimeout`, different endpoint: on the endless `/api/log` SSE stream the 10s deadline fires ~10s in and forcibly closes the connection — surfacing as a recurring `ERR_INCOMPLETE_CHUNKED_ENCODING` and a 10s-cyclic gap in the log window. The stream now clears its write deadline via `http.ResponseController`.

*Confirmed live:* the stream closed at exactly **10.26s** before the fix.

---
**Root cause shared by 3 & 4:** the hypervisor `http.Server`'s single `WriteTimeout` is wrong for long-running / streaming responses. Both use `http.ResponseController` to override it per-response, leaving every other endpoint protected.

Verified on a live host-native HV: spinner clears, all sections render (local 26 visors + 3 sub-hypervisor sections with 2/5/8), 37 switcher chips, no `.map` exception. `golangci-lint run ./pkg/visor/` → 0 issues; `go build` clean.