### PR TITLE
feat(skycoin-web): add `skywire app skycoin web` command + document internal-app User= no-op

### DIFF
--- a/cmd/apps/skycoin-web/commands/skycoin-web.go
+++ b/cmd/apps/skycoin-web/commands/skycoin-web.go
@@ -12,13 +12,28 @@ import (
 	"strings"
 
 	skycoinweb "github.com/skycoin/skycoin/cmd/skycoin-web/commands"
+	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
+// RootCmd is the `skywire app skycoin` command group. skycoin-web mounts under
+// it as `skywire app skycoin web`, matching the other visor apps under
+// `skywire app <name>` (skychat, skysocks, vpn, …). The name is left
+// unhyphenated ("skycoin web", not "skycoin-web") so future skycoin apps —
+// `skywire app skycoin daemon`, `skywire app skycoin explorer` — can hang off
+// the same group without a rename.
+var RootCmd = &cobra.Command{
+	Use:   "skycoin",
+	Short: "skycoin apps",
+}
+
 func init() {
 	launcher.RegisterApp(skyenv.SkycoinWebName, RunSkycoinWeb)
+	// Mount the vendored skycoin-web command as the `web` subcommand.
+	skycoinweb.RootCmd.Use = "web"
+	RootCmd.AddCommand(skycoinweb.RootCmd)
 }
 
 // RunSkycoinWeb runs the vendored skycoin-web thin-client wallet server

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1746,10 +1746,11 @@ func configureApps(log *logging.Logger) {
 		// (default skycoin + fibercoins). The User= field lets
 		// the wallet drop to the operator's UID so the wallet dir
 		// is writable even when the visor itself runs as _skywire.
-		// External-launch form: `skywire skycoin web <flags>` (Binary=skywire).
+		// External-launch form: `skywire app skycoin web <flags>` (Binary=skywire),
+		// under the same `skywire app <name>` namespace as the other apps.
 		// Opt-in — the default is the internal launcher app in the else branch.
 		webFlags, webEnv := skycoinWebFlagsEnv()
-		webArgs := append([]string{"skycoin", "web"}, webFlags...)
+		webArgs := append([]string{"app", "skycoin", "web"}, webFlags...)
 		apps = append(apps, appserver.AppConfig{
 			Name:      skyenv.SkycoinWebName,
 			Binary:    "skywire",
@@ -1804,6 +1805,19 @@ func configureApps(log *logging.Logger) {
 				// empty → RunSkycoinWeb (cmd/apps/skycoin-web/commands). This
 				// is the default; the same internal path serves it on the wasm
 				// visor. External (`skywire skycoin web`) is the opt-in above.
+				//
+				// IMPORTANT — User= is a NO-OP for an internal app. Internal
+				// apps run IN the visor process (RunModeInternal AppFunc), so
+				// there is no child process to setuid: on a root visor (common,
+				// for VPN + root pty) an internal skycoin-web IS root, and any
+				// wallet dir it writes lands under root's HOME
+				// (/root/.skycoin/wallets). To actually drop to SKYCOINWEBUSER
+				// and write wallets under that user's HOME, run skycoin-web
+				// EXTERNAL (the --external-apps branch above), which the
+				// launcher spawns as a separate process and can setuid. The
+				// default (no --wallet-dir) sidesteps this entirely: skycoin-web
+				// runs web-only, wallets live in browser storage — same as the
+				// wasm visor.
 				Name:      skyenv.SkycoinWebName,
 				AutoStart: isSkycoinWebEnable,
 				Port:      routing.Port(skyenv.SkycoinWebPort),

--- a/cmd/skywire/commands/root.go
+++ b/cmd/skywire/commands/root.go
@@ -9,7 +9,7 @@ import (
 
 	pty "github.com/skycoin/skywire/cmd/apps/pty/commands"
 	sc "github.com/skycoin/skywire/cmd/apps/skychat/commands"
-	_ "github.com/skycoin/skywire/cmd/apps/skycoin-web/commands" // registers skycoin-web as an internal launcher app
+	scw "github.com/skycoin/skywire/cmd/apps/skycoin-web/commands" // registers skycoin-web as an internal launcher app + `skywire app skycoin web`
 	snc "github.com/skycoin/skywire/cmd/apps/skynet-client/commands"
 	sn "github.com/skycoin/skywire/cmd/apps/skynet/commands"
 	ssc "github.com/skycoin/skywire/cmd/apps/skysocks-client/commands"
@@ -44,6 +44,7 @@ func init() {
 		sn.RootCmd,
 		snc.RootCmd,
 		pty.RootCmd,
+		scw.RootCmd,
 		skysocksPairCmd,
 		vpnPairCmd,
 		skynetPairCmd,


### PR DESCRIPTION
skycoin-web was registered as an internal launcher app (#3447) but never mounted under the `skywire app <name>` namespace like every other app (skychat, skysocks, vpn, …). This adds it for consistency.

- New `skycoin` command group with `web` as its subcommand → **`skywire app skycoin web`**. Left unhyphenated ("skycoin web") so `skywire app skycoin daemon`/`explorer` can hang off the same group later.
- External-apps config now points at `app skycoin web` (was the bare `skycoin web`, which had no registered parent command).
- Documents a real gotcha at the internal skycoin-web app config: **`User=` is a no-op for internal apps** — they run *in* the visor process (RunModeInternal), so there's no child to `setuid`. On a root visor an internal skycoin-web *is* root; to actually drop to `SKYCOINWEBUSER`, run it external. The default (no `--wallet-dir` → web-only, browser storage) sidesteps this and matches the wasm visor.

Verified: `skywire app skycoin web --help` resolves; `skywire app --help` lists `skycoin` alongside skychat/skysocks.