### PR TITLE
feat(skychat): portless-internal — no TCP port, served in-process by the visor

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -161,9 +161,10 @@ func tryNetworkFallback(ctx context.Context, pk cipher.PubKey, currentNet appnet
 }
 
 var (
-	addr   string
-	appCl  *app.Client
-	appLog func(format string, args ...interface{}) // App logger function
+	addr     string
+	portless bool
+	appCl    *app.Client
+	appLog   func(format string, args ...interface{}) // App logger function
 	// chatLog is the package-level logrus logger every code path can
 	// reach without going through appCl. In visor-launched mode it
 	// proxies through appCl.Log(); in --standalone mode appCl is nil
@@ -677,6 +678,7 @@ func parseEventChannels(csv string) map[string]bool {
 func init() {
 	launcher.RegisterApp("skychat", RunSkychat)
 	RootCmd.Flags().StringVar(&addr, "addr", ":8001", "address to bind (default: localhost-only); use \"*:PORT\" to bind on all interfaces")
+	RootCmd.Flags().BoolVar(&portless, "portless", false, "portless-internal: don't bind a TCP port; publish the HTTP surface in-process for the visor's control surface to serve (default for internal-app deployments)")
 	RootCmd.Flags().Uint16Var(&appPort, "port", 0, "routing port for communication between app and visor")
 	RootCmd.Flags().BoolVar(&useSkynet, "skynet", true, "listen on skynet network")
 	RootCmd.Flags().BoolVar(&useDmsg, "dmsg", true, "listen on dmsg network")
@@ -751,6 +753,7 @@ func RunSkychat(ctx context.Context, args []string) error {
 		// Create independent FlagSet for parsing without initialization cycle
 		fs := pflag.NewFlagSet("skychat", pflag.ContinueOnError)
 		fs.StringVar(&addr, "addr", ":8001", "address to bind")
+		fs.BoolVar(&portless, "portless", false, "portless-internal: no TCP port; publish HTTP surface in-process")
 		fs.Uint16Var(&appPort, "port", 0, "routing port")
 		fs.BoolVar(&useSkynet, "skynet", true, "listen on skynet")
 		fs.BoolVar(&useDmsg, "dmsg", true, "listen on dmsg")
@@ -923,6 +926,23 @@ func RunSkychat(ctx context.Context, args []string) error {
 	mux.HandleFunc("/send-file", requireAuthFunc(sendFileHandler(ctx)))
 	mux.HandleFunc("/files/", requireAuthFunc(downloadFileHandler))
 	registerPairHTTPHandlers(ctx, mux)
+
+	// Portless-internal mode: no TCP port. Publish the mux to the visor's
+	// in-process HTTP-handler registry so the hypervisor's control surface
+	// (Visor.SkychatProxy) serves it directly via ServeHTTP — no loopback dial,
+	// and no http.Server WriteTimeout to strangle the SSE stream. The dmsg:1 /
+	// skynet:1 mesh listeners (the actual chat transport, started above) run
+	// regardless. This is the native twin of the wasm visor's in-process
+	// skychat, and the default for an internal-app deployment.
+	if portless {
+		launcher.RegisterHTTPHandler(skyenv.SkychatName, mux)
+		defer launcher.RegisterHTTPHandler(skyenv.SkychatName, nil)
+		appLog("Serving skychat in-process (portless) via the visor control surface")
+		appCl.SetStatusOrLog(appserver.AppDetailedStatusRunning)
+		<-ctx.Done()
+		appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
+		return nil
+	}
 
 	url := ""
 	address := addr

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1623,11 +1623,15 @@ func skychatExternalArgs(addr string, pair bool) []string {
 	return args
 }
 
-// skychatInternalArgs mirrors skychatExternalArgs for internal-apps
-// mode (apps run inside the visor process). The external-mode "app"
-// "skychat" prefix is dropped — the launcher routes by app Name.
-func skychatInternalArgs(addr string, pair bool) []string {
-	args := []string{"--addr", addr}
+// skychatInternalArgs builds the launcher Args for skychat under the (default)
+// internal-apps mode: apps run inside the visor process. The external-mode
+// "app skychat" prefix is dropped (the launcher routes by app Name), and
+// --addr is replaced by --portless — the in-process skychat binds no TCP port
+// and instead publishes its HTTP surface to the visor's control surface (which
+// serves the hvui's /skychat/proxy/* routes directly). The dmsg/skynet mesh
+// listeners that carry actual chat traffic are unaffected.
+func skychatInternalArgs(pair bool) []string {
+	args := []string{"--portless"}
 	if pair {
 		args = append(args, "--pair-enable")
 	}
@@ -1779,8 +1783,9 @@ func configureApps(log *logging.Logger) {
 				// --pair-enable opens chat-app ↔ visor pair-RPC for
 				// group chat. See the external-apps branch above for
 				// the rationale; mirrored here so internal-apps
-				// generated configs behave the same.
-				Args: skychatInternalArgs(chatAddr, isSkychatPairEnable),
+				// generated configs behave the same. Portless: no TCP
+				// port — served in-process via the visor control surface.
+				Args: skychatInternalArgs(isSkychatPairEnable),
 			},
 			{
 				Name:      skyenv.SkysocksName,

--- a/pkg/app/launcher/registry.go
+++ b/pkg/app/launcher/registry.go
@@ -3,6 +3,8 @@ package launcher
 
 import (
 	"fmt"
+	"net/http"
+	"sync"
 
 	"github.com/skycoin/skywire/pkg/app/appcommon"
 )
@@ -24,4 +26,38 @@ func RegisterApp(name string, fn AppFunc) {
 func GetApp(name string) (AppFunc, bool) {
 	fn, ok := appRegistry[name]
 	return fn, ok
+}
+
+// httpHandlers holds in-process HTTP handlers published by internal
+// (in-process) apps, keyed by app name. A portless-internal app — one that
+// runs in the visor process with no TCP port of its own — registers its
+// http.Handler here so a same-process consumer (the visor's control surface,
+// which backs the hypervisor UI's /skychat/proxy/* routes) can serve it
+// directly via ServeHTTP with no loopback dial. When the app instead runs
+// externally on its own port, no handler is registered and the consumer falls
+// back to an HTTP proxy to that port.
+var (
+	httpHandlersMu sync.RWMutex
+	httpHandlers   = make(map[string]http.Handler)
+)
+
+// RegisterHTTPHandler publishes an internal app's in-process HTTP handler.
+// It overwrites any previous handler for the same name (an app restart
+// re-registers); passing nil clears the entry (call on shutdown).
+func RegisterHTTPHandler(name string, h http.Handler) {
+	httpHandlersMu.Lock()
+	defer httpHandlersMu.Unlock()
+	if h == nil {
+		delete(httpHandlers, name)
+		return
+	}
+	httpHandlers[name] = h
+}
+
+// GetHTTPHandler returns the in-process HTTP handler an internal app published,
+// or nil if none is registered (the app runs externally on its own port).
+func GetHTTPHandler(name string) http.Handler {
+	httpHandlersMu.RLock()
+	defer httpHandlersMu.RUnlock()
+	return httpHandlers[name]
 }

--- a/pkg/app/launcher/registry_test.go
+++ b/pkg/app/launcher/registry_test.go
@@ -1,0 +1,59 @@
+// Package launcher pkg/app/launcher/registry_test.go
+package launcher
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHTTPHandlerRegistry covers the in-process HTTP-handler registry that
+// backs portless-internal apps (skychat): register → get → serve in-process →
+// clear. This is the seam the visor's control surface uses instead of a
+// loopback dial when an app runs with no TCP port of its own.
+func TestHTTPHandlerRegistry(t *testing.T) {
+	const name = "test-portless-app"
+
+	if h := GetHTTPHandler(name); h != nil {
+		t.Fatalf("expected no handler before registration, got %v", h)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`)) //nolint:errcheck
+	})
+	RegisterHTTPHandler(name, mux)
+
+	h := GetHTTPHandler(name)
+	if h == nil {
+		t.Fatal("expected handler after registration, got nil")
+	}
+
+	// Serve in-process, the way Visor.SkychatProxy does.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	h.ServeHTTP(rec, req)
+	res := rec.Result()
+	body, _ := io.ReadAll(res.Body)
+	_ = res.Body.Close() //nolint:errcheck
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if got, want := string(body), `{"ok":true}`; got != want {
+		t.Fatalf("body = %q, want %q", got, want)
+	}
+
+	// Re-registration overwrites (an app restart re-publishes).
+	RegisterHTTPHandler(name, http.NewServeMux())
+	if GetHTTPHandler(name) == nil {
+		t.Fatal("expected handler after re-registration")
+	}
+
+	// nil clears (shutdown).
+	RegisterHTTPHandler(name, nil)
+	if h := GetHTTPHandler(name); h != nil {
+		t.Fatalf("expected handler cleared after nil registration, got %v", h)
+	}
+}

--- a/pkg/visor/api_skychat.go
+++ b/pkg/visor/api_skychat.go
@@ -18,12 +18,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
@@ -135,6 +137,12 @@ func (v *Visor) ClearSkychatPassword(oldPassword string) error {
 // "history/peers"). The proxy attaches the internal token so the
 // password gate is bypassed for in-process hvui calls.
 func (v *Visor) SkychatProxy(method, path string, query string, headers http.Header, body io.Reader) (int, http.Header, []byte, error) {
+	// Portless-internal skychat publishes its mux to the in-process handler
+	// registry — serve it directly, no loopback dial. Falls through to the TCP
+	// proxy when skychat runs externally on its own port.
+	if h := launcher.GetHTTPHandler(skyenv.SkychatName); h != nil {
+		return v.serveSkychatInProcess(h, method, path, query, headers, body)
+	}
 	addr := skychatLocalAddr(v)
 	if addr == "" {
 		return 0, nil, nil, errors.New("skychat addr not configured")
@@ -172,6 +180,39 @@ func (v *Visor) SkychatProxy(method, path string, query string, headers http.Hea
 		return resp.StatusCode, resp.Header, nil, err
 	}
 	return resp.StatusCode, resp.Header, respBody, nil
+}
+
+// serveSkychatInProcess runs the portless-internal skychat mux directly (no
+// TCP), returning the buffered response — the no-loopback twin of the HTTP
+// proxy above. The streaming (SSE) path uses streamSkychatInProcess so the
+// live message stream isn't buffered until an end that never comes.
+func (v *Visor) serveSkychatInProcess(h http.Handler, method, path, query string, headers http.Header, body io.Reader) (int, http.Header, []byte, error) {
+	target := "/" + strings.TrimPrefix(path, "/")
+	if query != "" {
+		target += "?" + query
+	}
+	req, err := http.NewRequest(method, target, body) //nolint:gosec // in-process, visor-controlled target
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	for k, vv := range headers {
+		if strings.EqualFold(k, "Host") || strings.EqualFold(k, "Connection") {
+			continue
+		}
+		for _, hval := range vv {
+			req.Header.Add(k, hval)
+		}
+	}
+	req.Header.Set("X-Skychat-Internal-Token", v.skychatInternalToken())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	res := rec.Result()
+	respBody, err := io.ReadAll(res.Body)
+	_ = res.Body.Close() //nolint:errcheck
+	if err != nil {
+		return res.StatusCode, res.Header, nil, err
+	}
+	return res.StatusCode, res.Header, respBody, nil
 }
 
 // SkychatLocalAddr returns the host:port the visor's skychat is

--- a/pkg/visor/hypervisor_handlers_skychat.go
+++ b/pkg/visor/hypervisor_handlers_skychat.go
@@ -11,8 +11,11 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
+	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/httputil"
+	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor/usermanager"
 )
 
@@ -134,6 +137,13 @@ func (hv *Hypervisor) skychatProxyHandler() http.HandlerFunc {
 // (r.Context()). Local visor only, same internal-token bypass as the buffered
 // path.
 func (hv *Hypervisor) streamSkychatProxy(w http.ResponseWriter, r *http.Request, skychatPath string) {
+	// Portless-internal skychat: serve the registered mux directly, streaming
+	// to the client with no loopback dial. Falls through to the TCP proxy when
+	// skychat runs externally on its own port.
+	if h := launcher.GetHTTPHandler(skyenv.SkychatName); h != nil {
+		hv.streamSkychatInProcess(h, w, r, skychatPath)
+		return
+	}
 	addr := skychatLocalAddr(hv.visor)
 	if addr == "" {
 		http.Error(w, "skychat proxy: addr not configured", http.StatusBadGateway)
@@ -194,4 +204,39 @@ func (hv *Hypervisor) streamSkychatProxy(w http.ResponseWriter, r *http.Request,
 			return
 		}
 	}
+}
+
+// streamSkychatInProcess serves a long-lived (SSE) request against the
+// portless-internal skychat mux directly. The mux's SSE handler writes and
+// flushes events to the client's ResponseWriter, so passing it straight
+// through streams live with no loopback hop — and, since there is no
+// intermediate http.Server, no WriteTimeout to strangle it (the very bug the
+// TCP path worked around with flushing). The HV server's own write deadline is
+// cleared for the same reason; r.Context() ends the stream on client
+// disconnect.
+func (hv *Hypervisor) streamSkychatInProcess(h http.Handler, w http.ResponseWriter, r *http.Request, skychatPath string) {
+	target := "/" + strings.TrimPrefix(skychatPath, "/")
+	if r.URL.RawQuery != "" {
+		target += "?" + r.URL.RawQuery
+	}
+	// target is a routing path (not a dialed URL): this request is served
+	// in-process by ServeHTTP below and never touches the network.
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, target, r.Body) //nolint:gosec // in-process ServeHTTP, no network dial
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	for k, vv := range r.Header {
+		if strings.EqualFold(k, "Host") || strings.EqualFold(k, "Connection") {
+			continue
+		}
+		for _, hval := range vv {
+			req.Header.Add(k, hval)
+		}
+	}
+	req.Header.Set("X-Skychat-Internal-Token", hv.visor.skychatInternalToken())
+	// Long-lived stream: clear the HV server write deadline (mirrors the SSE
+	// deadline handling added for /api/log) so it isn't torn down at 10s.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{}) //nolint:errcheck
+	h.ServeHTTP(w, req)
 }


### PR DESCRIPTION
skychat ran as an internal app but still bound a loopback TCP port (`:8001`) for its DM HTTP surface, which the hypervisor reverse-proxied over the loop. This removes the port.

## What
A **portless-internal** skychat publishes its `http.Handler` to a shared in-process registry (`launcher.RegisterHTTPHandler`); the visor's control surface (`SkychatProxy` + the SSE stream) serves it directly via `ServeHTTP` — no loopback dial, and no intermediate `http.Server` `WriteTimeout` to strangle the SSE stream. This is the native twin of the wasm visor's in-process skychat, and the same model skycoin-web moved to in #3447.

## Changes
- **pkg/app/launcher**: `RegisterHTTPHandler`/`GetHTTPHandler` — an internal (in-process) app publishes its `http.Handler` for same-process consumers. Unit-tested.
- **cmd/apps/skychat**: `--portless` flag (both the cobra `RootCmd` and the internal-launch `FlagSet`); when set, register the mux and skip `ListenAndServe`. The dmsg:1/skynet:1 mesh listeners (the actual chat transport) are unaffected.
- **pkg/visor**: `SkychatProxy` and `streamSkychatProxy` prefer the in-process handler (flushing for `/sse`, HV write deadline cleared), falling back to the loopback TCP proxy when skychat runs externally on its own port.
- **config-gen**: internal-apps mode (the default) emits skychat with `--portless` instead of `--addr`; external mode keeps its own port.

## Validation (live, native visor)
- skychat app **running**; **no `:8001` listener** (portless).
- `/status`, `/history/peers`, and the live `/sse` stream (seed history + heartbeat, held open) all served **in-process** through the control surface.
- `golangci-lint` + `go test ./pkg/app/launcher/` green; external mode still emits `--addr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)