### PR TITLE
fix(hv-ui): resolve .dmsg:port coin-node addresses (shared resolver bug) + reuse the resolver

### DIFF
--- a/pkg/visor/api_browse.go
+++ b/pkg/visor/api_browse.go
@@ -104,8 +104,11 @@ func (v *Visor) resolveBrowseHost(host string, reqPort uint16) (cipher.PubKey, u
 	if reqPort != 0 {
 		port = reqPort
 	}
-	lower := strings.ToLower(host)
-	// bare hex PK, optionally with :port (a hex PK never contains a colon).
+	// Split off an optional :port up front (a hex PK never contains a colon; a
+	// .dmsg/.skynet host may carry a non-80 port like :6420). The suffix match
+	// below MUST be on the port-stripped host — otherwise "<host>.dmsg:6420"
+	// never matches ".dmsg" and falls through to "cannot resolve" (which broke
+	// the coin node's readable "node.skycoin.com.<pk>.dmsg:6420" form).
 	hp := host
 	if i := strings.LastIndexByte(host, ':'); i > 0 {
 		// ParseUint with bitSize 16 bounds the value to a valid port, so the
@@ -117,6 +120,8 @@ func (v *Visor) resolveBrowseHost(host string, reqPort uint16) (cipher.PubKey, u
 			}
 		}
 	}
+	lower := strings.ToLower(hp)
+	// bare hex PK, optionally with :port (handled above).
 	var pk cipher.PubKey
 	if err := pk.Set(hp); err == nil {
 		return pk, port, nil

--- a/pkg/visor/hypervisor_handlers_wallet.go
+++ b/pkg/visor/hypervisor_handlers_wallet.go
@@ -15,6 +15,7 @@
 package visor
 
 import (
+	"fmt"
 	"io"
 	"io/fs"
 	"net/http"
@@ -157,12 +158,20 @@ func (hv *Hypervisor) walletNodeProxy(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 
-	// Mesh coin node (dmsg-served API) → dmsg-HTTP over the AUTHORITATIVE dmsg
-	// client (DmsgHTTP uses v.dmsgC). Not BrowseFetch — that's for browsing
-	// (skynet-first + the secondary dmsg client), which is the wrong tool for a
-	// pure dmsg node API.
+	// Mesh coin node: resolve the host with the SAME resolver the iframe browser
+	// uses (bare "<pk>[:port]", the readable "<name>.<pk>.dmsg[:port]" alias,
+	// "alias.dmsg", …) via resolveBrowseHost, then dmsg-HTTP over the
+	// AUTHORITATIVE dmsg client. We reuse the resolver but NOT BrowseFetch's
+	// fetch step: BrowseFetch dials over the secondary dmsg client (v.dmsgHTTP /
+	// dmsgDC), which has session conflicts on the coin node (see Visor.DmsgHTTP);
+	// v.dmsgC (DmsgHTTP) has stable sessions.
+	pk, port, rerr := hv.visor.resolveBrowseHost(walletBackendStrip(backend), 0)
+	if rerr != nil {
+		http.Error(w, "coin node resolve failed: "+rerr.Error(), http.StatusBadGateway)
+		return
+	}
 	resp, err := hv.visor.DmsgHTTP(DmsgHTTPRequest{
-		URL:    "dmsg://" + walletBackendStrip(backend) + path,
+		URL:    fmt.Sprintf("dmsg://%s:%d%s", pk.Hex(), port, path),
 		Method: r.Method,
 		Header: header,
 		Body:   body,

--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -1899,7 +1899,9 @@
 
       function refreshCur() {
         var eff = mode === "service" ? ls(K_SERVICE, "") : (nodes[0] || "");
-        $("sww-cur").textContent = eff ? eff.replace(/^https?:\/\//, "") : "default node";
+        // Blank field = the deployment default coin node (node.skycoin.com's
+        // skycoin node over dmsg); show that so it's clear what's in effect.
+        $("sww-cur").textContent = eff ? eff.replace(/^https?:\/\//, "") : "default · node.skycoin.com";
       }
       function renderNodes() {
         var box = $("sww-nodes"); box.innerHTML = "";
@@ -1907,7 +1909,7 @@
           var row = doc.createElement("div"); row.className = "sww-row";
           var lab = doc.createElement("label"); lab.textContent = "coin " + i;
           var inp = doc.createElement("input"); inp.spellcheck = false; inp.value = n || "";
-          inp.placeholder = "039a6d1e…:6420 or http://node…" + (i === 0 ? "  (blank = default)" : "");
+          inp.placeholder = "039a6d1e…:6420 or node.skycoin.com.<pk>.dmsg:6420" + (i === 0 ? "  (blank = node.skycoin.com)" : "");
           inp.oninput = function () { nodes[i] = inp.value; };
           row.appendChild(lab); row.appendChild(inp);
           if (nodes.length > 1) {


### PR DESCRIPTION
The wallet's coin-node config only accepted a bare `<pk>:port`; the readable `node.skycoin.com.<pk>.dmsg:6420` form failed with "cannot resolve."

## Root cause (shared resolver bug)
`resolveBrowseHost` checked the `.dmsg`/`.skynet` suffix on the host **with the port still attached**, so `<host>.dmsg:6420` never matched the `.dmsg` branch and fell through. This also broke the **iframe browser** for any `.dmsg:<non-80-port>` site — not just the wallet.

## Fix
- **pkg/visor/api_browse.go** — strip the `:port` before the suffix match (fixes the resolver for the wallet *and* the iframe browser).
- **pkg/visor/hypervisor_handlers_wallet.go** — the wallet mesh path now **reuses `resolveBrowseHost`** (bare `<pk>`, `dmsg://<pk>:port`, `<name>.<pk>.dmsg[:port]` all in one place) then dmsg-HTTP over the **authoritative** client — no hand-rolled PK parsing, and not `BrowseFetch`'s secondary/session-conflicting client.
- **browse.js** — the ☰ wallet config shows the effective default (`node.skycoin.com`) when the field is blank.

## Validated live
`<pk>:6420`, `dmsg://<pk>:6420`, `<pk>.dmsg:6420`, and `node.skycoin.com.<pk>.dmsg:6420` all return the chain (head seq 195245). `go test ./pkg/skynetweb/... ./pkg/visor/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)