### PR TITLE
feat(wallet): BTC over the mesh — electrum→HTTP gateway (native)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pterm/pterm v0.12.83
 	github.com/robert-nix/ansihtml v1.0.1
 	github.com/sirupsen/logrus v1.9.4
-	github.com/skycoin/skycoin v0.28.6-0.20260713130140-898c5dd8203d
+	github.com/skycoin/skycoin v0.28.6-0.20260713131448-bf9a0e032c1a
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pterm/pterm v0.12.83
 	github.com/robert-nix/ansihtml v1.0.1
 	github.com/sirupsen/logrus v1.9.4
-	github.com/skycoin/skycoin v0.28.6-0.20260711221955-70f2b057fb42
+	github.com/skycoin/skycoin v0.28.6-0.20260713130140-898c5dd8203d
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -790,8 +790,8 @@ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/skycoin/encodertest v0.0.0-20190217072920-14c2e31898b9 h1:DElGw1Fhj4amuW1KM5q8Xowosb3RiOQce0lDJw0Qv0Y=
 github.com/skycoin/encodertest v0.0.0-20190217072920-14c2e31898b9/go.mod h1:OQz8NXVJUWEw7PWYASZ/1BIw5GXgVMTGvrCGDlZa9+k=
-github.com/skycoin/skycoin v0.28.6-0.20260711221955-70f2b057fb42 h1:693hG0V2jAPsAW/ICR3v6GCbLhYN3K8VJ+GTmjN8N+8=
-github.com/skycoin/skycoin v0.28.6-0.20260711221955-70f2b057fb42/go.mod h1:qsofJ2GAX8MmP4PFeO1pFmKbxB0TibBynIz43r1WYfw=
+github.com/skycoin/skycoin v0.28.6-0.20260713130140-898c5dd8203d h1:w3fV7QVd/DTIXPzMGpde20lC+09hxaAFXvgYQAznk5k=
+github.com/skycoin/skycoin v0.28.6-0.20260713130140-898c5dd8203d/go.mod h1:qsofJ2GAX8MmP4PFeO1pFmKbxB0TibBynIz43r1WYfw=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8 h1:TG/diQgUe0pntT/2D9tmUCz4VNwm9MfrtPr0SU2qSX8=

--- a/go.sum
+++ b/go.sum
@@ -790,8 +790,8 @@ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/skycoin/encodertest v0.0.0-20190217072920-14c2e31898b9 h1:DElGw1Fhj4amuW1KM5q8Xowosb3RiOQce0lDJw0Qv0Y=
 github.com/skycoin/encodertest v0.0.0-20190217072920-14c2e31898b9/go.mod h1:OQz8NXVJUWEw7PWYASZ/1BIw5GXgVMTGvrCGDlZa9+k=
-github.com/skycoin/skycoin v0.28.6-0.20260713130140-898c5dd8203d h1:w3fV7QVd/DTIXPzMGpde20lC+09hxaAFXvgYQAznk5k=
-github.com/skycoin/skycoin v0.28.6-0.20260713130140-898c5dd8203d/go.mod h1:qsofJ2GAX8MmP4PFeO1pFmKbxB0TibBynIz43r1WYfw=
+github.com/skycoin/skycoin v0.28.6-0.20260713131448-bf9a0e032c1a h1:htMa6JbmU+mOO99E2DyQvS5V7RhdzRow0Y5dh+M7r4g=
+github.com/skycoin/skycoin v0.28.6-0.20260713131448-bf9a0e032c1a/go.mod h1:qsofJ2GAX8MmP4PFeO1pFmKbxB0TibBynIz43r1WYfw=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8 h1:TG/diQgUe0pntT/2D9tmUCz4VNwm9MfrtPr0SU2qSX8=

--- a/pkg/btcgateway/gateway.go
+++ b/pkg/btcgateway/gateway.go
@@ -1,0 +1,206 @@
+// Package btcgateway serves the skycoin-web wallet's /v1/btc/* endpoints by
+// translating them to an Electrum backend, so a Skywire visor can provide the
+// in-browser BTC wallet its chain data (balance / utxos / history / fee /
+// broadcast). The wallet keeps keys, address derivation and signing entirely
+// client-side (skycoin-lite WASM) — only these chain queries cross the mesh.
+//
+// The Electrum connection is dialed via an optional DialFunc, so the visor can
+// reach an ssl:// Electrum server through skysocks/dmsg over the mesh (nil dial
+// = clearnet, for a native visor that already has egress). This is what lets
+// BTC "just work" in the browser wallet without per-port dmsg forwarding —
+// a raw ssl://host:port electrum URL is enough.
+package btcgateway
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/skycoin/skycoin/src/btc"
+	"github.com/skycoin/skycoin/src/electrum"
+)
+
+// DialFunc routes the Electrum TCP connection over a custom transport (e.g.
+// skysocks-client-lite for clearnet, or a dmsg stream). nil = stdlib clearnet.
+type DialFunc = electrum.DialFunc
+
+// Gateway is an /v1/btc/* HTTP handler backed by Electrum. Backends are cached
+// per Electrum server URL because Electrum connections are long-lived.
+type Gateway struct {
+	dial     DialFunc
+	mu       sync.Mutex
+	backends map[string]btc.Backend
+}
+
+// New returns a Gateway that dials Electrum via dial (nil = clearnet).
+func New(dial DialFunc) *Gateway {
+	return &Gateway{dial: dial, backends: make(map[string]btc.Backend)}
+}
+
+// Close shuts down all cached Electrum backends.
+func (g *Gateway) Close() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for url, b := range g.backends {
+		_ = b.Close() //nolint:errcheck
+		delete(g.backends, url)
+	}
+}
+
+// backendFor returns a cached (or newly-connected) Electrum backend for url.
+func (g *Gateway) backendFor(url string) (btc.Backend, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if b, ok := g.backends[url]; ok {
+		return b, nil
+	}
+	b, err := btc.NewElectrumBackendWithDialer(url, g.dial)
+	if err != nil {
+		return nil, err
+	}
+	g.backends[url] = b
+	return b, nil
+}
+
+// ServeHTTP dispatches /v1/btc/{balance,utxos,history,fee,send}. The Electrum
+// server URL comes from the X-Skywire-Btc-Backend header (the wallet shim sets
+// it from localStorage['skywire-btc-backend']); addresses come from ?addrs=.
+func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	url := strings.TrimSpace(r.Header.Get("X-Skywire-Btc-Backend"))
+	if url == "" {
+		writeErr(w, http.StatusBadGateway, "no BTC backend configured (set a BTC electrum server in wallet settings)")
+		return
+	}
+	b, err := g.backendFor(url)
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "connect electrum: "+err.Error())
+		return
+	}
+
+	path := strings.TrimSuffix(r.URL.Path, "/")
+	if i := strings.Index(path, "/v1/btc/"); i >= 0 {
+		path = path[i:]
+	}
+	switch {
+	case path == "/v1/btc/balance" && r.Method == http.MethodGet:
+		g.balance(w, r, b)
+	case path == "/v1/btc/utxos" && r.Method == http.MethodGet:
+		g.utxos(w, r, b)
+	case path == "/v1/btc/history" && r.Method == http.MethodGet:
+		g.history(w, r, b)
+	case path == "/v1/btc/fee" && r.Method == http.MethodGet:
+		g.fee(w, r, b)
+	case path == "/v1/btc/send" && r.Method == http.MethodPost:
+		g.send(w, r, b)
+	default:
+		writeErr(w, http.StatusNotFound, "unknown BTC endpoint "+path)
+	}
+}
+
+func (g *Gateway) balance(w http.ResponseWriter, r *http.Request, b btc.Backend) {
+	addrs := addrsParam(r)
+	if len(addrs) == 0 {
+		writeErr(w, http.StatusBadRequest, "addrs parameter required")
+		return
+	}
+	bals, err := b.GetBalance(addrs)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	var total int64
+	addrBalances := make(map[string]map[string]map[string]int64, len(bals))
+	for addr, bal := range bals {
+		total += bal.Confirmed
+		addrBalances[addr] = map[string]map[string]int64{"confirmed": {"coins": bal.Confirmed}}
+	}
+	writeJSON(w, map[string]interface{}{
+		"confirmed": map[string]int64{"coins": total},
+		"predicted": map[string]int64{"coins": total},
+		"addresses": addrBalances,
+	})
+}
+
+func (g *Gateway) utxos(w http.ResponseWriter, r *http.Request, b btc.Backend) {
+	addrs := addrsParam(r)
+	if len(addrs) == 0 {
+		writeErr(w, http.StatusBadRequest, "addrs parameter required")
+		return
+	}
+	u, err := b.ListUnspent(addrs)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, u)
+}
+
+func (g *Gateway) history(w http.ResponseWriter, r *http.Request, b btc.Backend) {
+	addrs := addrsParam(r)
+	if len(addrs) == 0 {
+		writeErr(w, http.StatusBadRequest, "addrs parameter required")
+		return
+	}
+	h, err := b.GetHistory(addrs)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, h)
+}
+
+func (g *Gateway) fee(w http.ResponseWriter, r *http.Request, b btc.Backend) {
+	blocks := 6
+	if v := r.URL.Query().Get("blocks"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			blocks = n
+		}
+	}
+	spb, err := b.EstimateFee(blocks)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, map[string]interface{}{"sat_per_byte": spb, "blocks": blocks})
+}
+
+// send broadcasts a client-signed raw transaction — the in-browser wallet signs
+// with skycoin-lite WASM (keys never leave the browser), then broadcasts here.
+// Body: {"rawtx":"<hex>"}.
+func (g *Gateway) send(w http.ResponseWriter, r *http.Request, b btc.Backend) {
+	var body struct {
+		RawTx string `json:"rawtx"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&body); err != nil || body.RawTx == "" {
+		writeErr(w, http.StatusBadRequest, "rawtx required")
+		return
+	}
+	txid, err := b.BroadcastTransaction(body.RawTx)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, map[string]string{"txid": txid})
+}
+
+func addrsParam(r *http.Request) []string {
+	p := strings.TrimSpace(r.URL.Query().Get("addrs"))
+	if p == "" {
+		return nil
+	}
+	return strings.Split(p, ",")
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v) //nolint:errcheck
+}
+
+func writeErr(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg}) //nolint:errcheck
+}

--- a/pkg/btcgateway/gateway_test.go
+++ b/pkg/btcgateway/gateway_test.go
@@ -1,0 +1,94 @@
+package btcgateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/skycoin/skycoin/src/btc"
+)
+
+// mockBackend is a btc.Backend that returns canned data — lets us test the
+// gateway's routing + JSON shapes without a live Electrum server.
+type mockBackend struct{}
+
+func (mockBackend) GetBalance(addrs []string) (map[string]btc.AddressBalance, error) {
+	out := make(map[string]btc.AddressBalance, len(addrs))
+	for _, a := range addrs {
+		out[a] = btc.AddressBalance{Confirmed: 1000, Unconfirmed: 0}
+	}
+	return out, nil
+}
+func (mockBackend) ListUnspent([]string) ([]btc.UTXO, error)       { return []btc.UTXO{}, nil }
+func (mockBackend) GetHistory([]string) ([]btc.Transaction, error) { return []btc.Transaction{}, nil }
+func (mockBackend) BroadcastTransaction(string) (string, error)    { return "deadbeef", nil }
+func (mockBackend) EstimateFee(int) (int64, error)                 { return 12, nil }
+func (mockBackend) Close() error                                   { return nil }
+
+func newTestGateway() *Gateway {
+	g := New(nil)
+	g.backends["mock"] = mockBackend{} // pre-seed so no dial happens
+	return g
+}
+
+func do(g *Gateway, method, target string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(method, target, nil)
+	r.Header.Set("X-Skywire-Btc-Backend", "mock")
+	w := httptest.NewRecorder()
+	g.ServeHTTP(w, r)
+	return w
+}
+
+func TestBalanceShape(t *testing.T) {
+	w := do(newTestGateway(), http.MethodGet, "/v1/btc/balance?addrs=addrA,addrB")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Confirmed struct {
+			Coins int64 `json:"coins"`
+		} `json:"confirmed"`
+		Addresses map[string]map[string]map[string]int64 `json:"addresses"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v — %s", err, w.Body.String())
+	}
+	if resp.Confirmed.Coins != 2000 {
+		t.Fatalf("total confirmed = %d, want 2000", resp.Confirmed.Coins)
+	}
+	if got := resp.Addresses["addrA"]["confirmed"]["coins"]; got != 1000 {
+		t.Fatalf("addrA confirmed = %d, want 1000", got)
+	}
+}
+
+func TestFeeShape(t *testing.T) {
+	w := do(newTestGateway(), http.MethodGet, "/v1/btc/fee?blocks=3")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		SatPerByte int64 `json:"sat_per_byte"`
+		Blocks     int   `json:"blocks"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.SatPerByte != 12 || resp.Blocks != 3 {
+		t.Fatalf("fee resp = %+v, want {12, 3}", resp)
+	}
+}
+
+func TestMissingBackendHeader(t *testing.T) {
+	g := newTestGateway()
+	r := httptest.NewRequest(http.MethodGet, "/v1/btc/balance?addrs=a", nil) // no header
+	w := httptest.NewRecorder()
+	g.ServeHTTP(w, r)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 (no backend configured)", w.Code)
+	}
+}
+
+func TestUnknownEndpoint(t *testing.T) {
+	if w := do(newTestGateway(), http.MethodGet, "/v1/btc/nope"); w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}

--- a/pkg/visor/hypervisor_handlers_wallet.go
+++ b/pkg/visor/hypervisor_handlers_wallet.go
@@ -20,9 +20,27 @@ import (
 	"io/fs"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/skycoin/skywire/pkg/btcgateway"
 )
+
+var (
+	nativeBtcGatewayOnce sync.Once
+	nativeBtcGatewayInst *btcgateway.Gateway
+)
+
+// nativeBtcGateway is the HV's shared BTC electrum gateway for the native
+// HV-served wallet. A nil dialer means clearnet egress — a host visor reaches
+// public electrum servers directly; the per-request electrum URL comes from the
+// X-Skywire-Btc-Backend header (set by the wallet shim from
+// localStorage['skywire-btc-backend']).
+func nativeBtcGateway() *btcgateway.Gateway {
+	nativeBtcGatewayOnce.Do(func() { nativeBtcGatewayInst = btcgateway.New(nil) })
+	return nativeBtcGatewayInst
+}
 
 // walletNodeDmsg is the skycoin node the HV-served wallet talks to by DEFAULT:
 // the deployment node addressed over dmsg (same PK:port as
@@ -42,18 +60,27 @@ const walletNodeDmsg = "dmsg://039a6d1e3c237f5f05b78ec19e9f31a007f84835d7ef1e812
 // X-Skywire-Coin-Node so walletNodeProxy dials it over dmsg. Empty selection →
 // the deployment default. This is the native twin of the wasm fetchDmsg shim;
 // same localStorage key, so node config is unified across both visors.
+// It ALSO intercepts the wallet's BTC API (/v1/btc/*) and tags the operator-
+// selected electrum backend (localStorage['skywire-btc-backend'], "ssl://host:
+// port") as X-Skywire-Btc-Backend, so the HV's in-process BTC gateway
+// (pkg/btcgateway) reaches it — keys + signing stay in the browser, only chain
+// queries cross. Same localStorage keys as the wasm shim + the config panel.
 const walletNodeShim = `<script>(function(){` +
 	`var rf=window.fetch?window.fetch.bind(window):null;if(!rf){return;}` +
-	`function node(){try{return localStorage.getItem("skywire-coin-node")||"";}catch(e){return "";}}` +
+	`function ls(k){try{return localStorage.getItem(k)||"";}catch(e){return "";}}` +
 	`function pathOf(u){try{return new URL(u,location.href).pathname;}catch(e){return String(u);}}` +
 	`window.fetch=function(input,init){` +
 	`var url=(typeof input==="string")?input:(input&&input.url)||"";` +
-	`var m=/^\/(wallet\/)?api\/v[12]\//.exec(pathOf(url));` +
-	`if(!m){return rf(input,init);}` +
-	`var target=m[1]?url:url.replace(pathOf(url),"/wallet"+pathOf(url));` +
+	`var p=pathOf(url);` +
+	`var mn=/^\/(wallet\/)?api\/v[12]\//.exec(p);` +
+	`var mb=/^\/(wallet\/)?v1\/btc\//.exec(p);` +
+	`if(!mn&&!mb){return rf(input,init);}` +
+	`var pre=(mn&&mn[1])||(mb&&mb[1]);` +
+	`var target=pre?url:url.replace(p,"/wallet"+p);` +
 	`init=init||{};` +
 	`var h=new Headers((init&&init.headers)||(typeof input!=="string"&&input&&input.headers)||undefined);` +
-	`var n=node();if(n){h.set("X-Skywire-Coin-Node",n);}` +
+	`if(mn){var n=ls("skywire-coin-node");if(n){h.set("X-Skywire-Coin-Node",n);}}` +
+	`else{var b=ls("skywire-btc-backend");if(b){h.set("X-Skywire-Btc-Backend",b);}}` +
 	`init.headers=h;return rf(target,init);` +
 	`};})();</script>`
 
@@ -73,6 +100,15 @@ func (hv *Hypervisor) walletHandler() http.HandlerFunc {
 		// wallet's crypto is client-side; only these calls cross the mesh.
 		if strings.HasPrefix(rest, "api/v1/") || strings.HasPrefix(rest, "api/v2/") {
 			hv.walletNodeProxy(w, r, rest)
+			return
+		}
+		// BTC API (/wallet/v1/btc/*) → the in-process electrum gateway. The
+		// browser derives + signs BTC itself; only chain queries come here. The
+		// electrum server (X-Skywire-Btc-Backend, set by the shim) is dialed on
+		// the clearnet by the native visor (nil dialer).
+		if strings.HasPrefix(rest, "v1/btc/") {
+			r.URL.Path = "/" + rest
+			nativeBtcGateway().ServeHTTP(w, r)
 			return
 		}
 		if fsErr != nil {

--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -1872,8 +1872,8 @@
         '<div class="sww-hint">Wallets are created + stored in <b>this browser</b>. Configure the coin node(s) it queries over dmsg — the first is the default; add one per fibercoin. A &lt;pk&gt;:&lt;port&gt; dmsg node is dialed directly; an http(s):// / .dmsg URL goes via the resolving proxy.</div>' +
         '<div id="sww-nodes"></div>' +
         '<button class="sww-add" id="sww-addnode">+ Add coin node</button>' +
-        '<div class="sww-hint"><b>Bitcoin</b> (optional): a node RPC / electrum backend. Full BTC support needs a wallet service.</div>' +
-        '<div class="sww-row"><label>btc</label><input id="sww-btc" spellcheck="false" placeholder="electrum host / http://…  (optional)"></div>' +
+        '<div class="sww-hint"><b>Bitcoin</b> (optional): an <span class="mono">ssl://host:port</span> electrum server. Reached over the mesh by the visor\'s BTC gateway — your keys + signing stay in this browser, only chain queries cross.</div>' +
+        '<div class="sww-row"><label>btc</label><input id="sww-btc" spellcheck="false" placeholder="ssl://electrum.blockstream.info:50002  (optional)"></div>' +
         '</div>' +
         '<div id="sww-service" style="display:none">' +
         '<div class="sww-hint">Point at a remote <b>skycoin-web server</b> over dmsg. Wallets live on that server; all wallet + node API routes to it.</div>' +

--- a/vendor/github.com/skycoin/skycoin/src/btc/electrum_backend.go
+++ b/vendor/github.com/skycoin/skycoin/src/btc/electrum_backend.go
@@ -15,7 +15,15 @@ type ElectrumBackend struct {
 
 // NewElectrumBackend creates a new Electrum backend connected to the given server URL
 func NewElectrumBackend(serverURL string) (*ElectrumBackend, error) {
-	client, err := electrum.NewClient(serverURL, 30*time.Second)
+	return NewElectrumBackendWithDialer(serverURL, nil)
+}
+
+// NewElectrumBackendWithDialer is NewElectrumBackend with a caller-supplied
+// dialer, so the Electrum connection can be carried over an arbitrary transport
+// (e.g. a Skywire mesh tunnel) rather than the stdlib clearnet dialer. dial==nil
+// behaves exactly like NewElectrumBackend.
+func NewElectrumBackendWithDialer(serverURL string, dial electrum.DialFunc) (*ElectrumBackend, error) {
+	client, err := electrum.NewClientWithDialer(serverURL, 30*time.Second, dial)
 	if err != nil {
 		return nil, fmt.Errorf("connect to electrum server: %w", err)
 	}

--- a/vendor/github.com/skycoin/skycoin/src/electrum/client.go
+++ b/vendor/github.com/skycoin/skycoin/src/electrum/client.go
@@ -52,11 +52,33 @@ type rpcError struct {
 	Message string `json:"message"`
 }
 
-// NewClient creates a new Electrum client connected to the given server URL.
+// DialFunc dials a raw stream to a "host:port" address. Supplied to
+// NewClientWithDialer to route the Electrum connection through a tunnel/proxy
+// (e.g. skywire's skysocks-client over the mesh, or a dmsg stream) instead of
+// the stdlib clearnet dialer. For ssl:// URLs the TLS handshake still runs
+// client-side on top of the returned conn, so the tunnel can't read the stream.
+type DialFunc func(network, addr string) (net.Conn, error)
+
+// NewClient creates a new Electrum client connected to the given server URL,
+// dialing over the clearnet with the standard library.
 // URL format: "ssl://host:port" for TLS or "tcp://host:port" for plain TCP.
 func NewClient(serverURL string, timeout time.Duration) (*Client, error) {
+	return NewClientWithDialer(serverURL, timeout, nil)
+}
+
+// NewClientWithDialer is NewClient with a caller-supplied raw dialer. When
+// dial is nil it behaves exactly like NewClient (net.DialTimeout). This lets a
+// caller carry the Electrum connection over an arbitrary transport — the whole
+// point being that a skywire visor can reach an ssl:// Electrum server through
+// skysocks/dmsg while the TLS handshake is still performed end-to-end here.
+func NewClientWithDialer(serverURL string, timeout time.Duration, dial DialFunc) (*Client, error) {
 	if timeout == 0 {
 		timeout = DefaultTimeout
+	}
+	if dial == nil {
+		dial = func(network, addr string) (net.Conn, error) {
+			return net.DialTimeout(network, addr, timeout)
+		}
 	}
 
 	var conn net.Conn
@@ -68,18 +90,22 @@ func NewClient(serverURL string, timeout time.Duration) (*Client, error) {
 		if herr != nil {
 			return nil, fmt.Errorf("invalid server address %q: %w", addr, herr)
 		}
-		conn, err = tls.DialWithDialer(
-			&net.Dialer{Timeout: timeout},
-			"tcp",
-			addr,
-			&tls.Config{
-				ServerName: host,
-				MinVersion: tls.VersionTLS12,
-			},
-		)
+		raw, derr := dial("tcp", addr)
+		if derr != nil {
+			return nil, fmt.Errorf("failed to connect to %s: %w", serverURL, derr)
+		}
+		tlsConn := tls.Client(raw, &tls.Config{
+			ServerName: host,
+			MinVersion: tls.VersionTLS12,
+		})
+		if herr := tlsConn.Handshake(); herr != nil {
+			raw.Close() //nolint:errcheck,gosec
+			return nil, fmt.Errorf("tls handshake with %s: %w", serverURL, herr)
+		}
+		conn = tlsConn
 	} else if strings.HasPrefix(serverURL, "tcp://") {
 		addr := strings.TrimPrefix(serverURL, "tcp://")
-		conn, err = net.DialTimeout("tcp", addr, timeout)
+		conn, err = dial("tcp", addr)
 	} else {
 		return nil, fmt.Errorf("unsupported protocol in URL %q (use ssl:// or tcp://)", serverURL)
 	}

--- a/vendor/github.com/skycoin/skycoin/src/electrum/client.go
+++ b/vendor/github.com/skycoin/skycoin/src/electrum/client.go
@@ -44,12 +44,38 @@ type jsonRPCResponse struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      int64           `json:"id"`
 	Result  json.RawMessage `json:"result"`
-	Error   *rpcError       `json:"error"`
+	// Error is parsed leniently: Electrum servers encode the JSON-RPC error
+	// field inconsistently — null/absent/empty on success, a {code,message}
+	// object, or (e.g. blockstream's electrs on listunspent/history) a bare
+	// string. A fixed *struct type made the whole response fail to unmarshal.
+	Error json.RawMessage `json:"error"`
 }
 
 type rpcError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
+}
+
+// rpcErrorString returns a human error from the JSON-RPC error field, or "" when
+// there is no error (null/absent/empty string). Accepts both the {code,message}
+// object form and the bare-string form servers use interchangeably.
+func rpcErrorString(raw json.RawMessage) string {
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "null" || s == `""` {
+		return ""
+	}
+	var obj rpcError
+	if err := json.Unmarshal(raw, &obj); err == nil && (obj.Code != 0 || obj.Message != "") {
+		return fmt.Sprintf("RPC error %d: %s", obj.Code, obj.Message)
+	}
+	var str string
+	if err := json.Unmarshal(raw, &str); err == nil {
+		if strings.TrimSpace(str) == "" {
+			return ""
+		}
+		return "RPC error: " + str
+	}
+	return "RPC error: " + s
 }
 
 // DialFunc dials a raw stream to a "host:port" address. Supplied to
@@ -175,8 +201,8 @@ func (c *Client) call(method string, params []any, result any) error {
 		return fmt.Errorf("unmarshal response: %w", err)
 	}
 
-	if resp.Error != nil {
-		return fmt.Errorf("RPC error %d: %s", resp.Error.Code, resp.Error.Message)
+	if es := rpcErrorString(resp.Error); es != "" {
+		return fmt.Errorf("%s", es)
 	}
 
 	if result != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -918,7 +918,7 @@ github.com/shopspring/decimal
 ## explicit; go 1.17
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/skycoin v0.28.6-0.20260711221955-70f2b057fb42
+# github.com/skycoin/skycoin v0.28.6-0.20260713130140-898c5dd8203d
 ## explicit; go 1.26.1
 github.com/skycoin/skycoin/cmd/explorer/commands
 github.com/skycoin/skycoin/cmd/newcoin/commands

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -918,7 +918,7 @@ github.com/shopspring/decimal
 ## explicit; go 1.17
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/skycoin v0.28.6-0.20260713130140-898c5dd8203d
+# github.com/skycoin/skycoin v0.28.6-0.20260713131448-bf9a0e032c1a
 ## explicit; go 1.26.1
 github.com/skycoin/skycoin/cmd/explorer/commands
 github.com/skycoin/skycoin/cmd/newcoin/commands


### PR DESCRIPTION
Makes **Bitcoin work in the skycoin-web wallet over the mesh**. The browser already does BTC key derivation, tx building and signing itself (skycoin-lite WASM); it only lacked chain data. This adds a gateway that serves the wallet's `/v1/btc/{balance,utxos,history,fee,send}` by translating them to an Electrum backend — **keys + signing never leave the browser, only chain queries cross.**

## How
- **pkg/btcgateway** — serves `/v1/btc/*` via vendored `btc.Backend`, dialing Electrum through an injectable `DialFunc` so an `ssl://` server is reachable over the mesh with **no per-port forwarding**. Builds native *and* js/wasm; unit-tested.
- **Native wiring** — `/wallet/v1/btc/*` routes to the in-process gateway (clearnet dial); the wallet fetch shim tags `X-Skywire-Btc-Backend` from `localStorage['skywire-btc-backend']`.
- Vendors skycoin **#2931** (`electrum.NewClientWithDialer`), **#2932** (`btc.NewElectrumBackendWithDialer`), **#2933** (lenient JSON-RPC error parse).
- BTC config field reframed for `ssl://host:port`.

## Validated live
Against `ssl://electrum.blockstream.info:50002`: the Bitcoin genesis address returns its real **57.2 BTC** balance; `/fee` works; utxos/history parse.

Follow-up: the **wasm** path (run the gateway in-tab with a skysocks-lite dialer) so the browser visor gets BTC the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)