### PR TITLE
feat(hv-ui): one shared wallet config page (/wallet/config) + skysocks-exit field

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -81,7 +81,7 @@ const walletDmsgFetchShim = `<script>(function(){` +
 	`if(btc){` +
 	`if(!v.btcFetch)return Promise.resolve(jr(503,{error:"BTC gateway not available"}));` +
 	`var back=ls("skywire-btc-backend");if(!back)return Promise.resolve(jr(502,{error:"no BTC electrum server configured"}));` +
-	`return Promise.resolve(v.btcFetch(back,init.method||"GET",p(url)+q(url),init.body||null,ls("skywire-upstream-proxy"))).then(mkResp).catch(function(e){return jr(502,{error:String(e)});});` +
+	`return Promise.resolve(v.btcFetch(back,init.method||"GET",p(url)+q(url),init.body||null,ls("skywire-btc-proxy")||ls("skywire-upstream-proxy"))).then(mkResp).catch(function(e){return jr(502,{error:String(e)});});` +
 	`}` +
 	`var node=ls("skywire-coin-node");` +
 	`if(!node)node="` + defaultCoinNode + `";` +
@@ -221,6 +221,14 @@ page never asks anyone to type a secret key.`,
 					w.Header().Set("Content-Type", "text/html; charset=utf-8")
 					w.Header().Set("Cache-Control", "no-cache")
 					_, _ = w.Write(walletIndex) //nolint:errcheck // best-effort
+					return
+				}
+				// The ONE wallet config page, embedded via iframe by the ☰ wallet
+				// window and the Angular wallet tab (same page as the native HV).
+				if r.URL.Path == "/wallet/config" {
+					w.Header().Set("Content-Type", "text/html; charset=utf-8")
+					w.Header().Set("Cache-Control", "no-cache")
+					_, _ = w.Write([]byte(wasmhv.WalletConfigHTML)) //nolint:errcheck
 					return
 				}
 				fileServer.ServeHTTP(w, r) // /wallet/<asset> → static/wallet/<asset>

--- a/pkg/visor/hypervisor_handlers_wallet.go
+++ b/pkg/visor/hypervisor_handlers_wallet.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/skycoin/skywire/pkg/btcgateway"
+	"github.com/skycoin/skywire/pkg/wasmhv/browseui"
 )
 
 var (
@@ -96,6 +97,14 @@ func (hv *Hypervisor) walletHandler() http.HandlerFunc {
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		rest := chi.URLParam(r, "*")
+		// The ONE wallet config page (mode / coin nodes / BTC / skysocks exit),
+		// embedded via iframe by the ☰ wallet window AND the Angular wallet tab.
+		if rest == "config" {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Header().Set("Cache-Control", "no-cache")
+			_, _ = w.Write([]byte(browseui.WalletConfigHTML)) //nolint:errcheck
+			return
+		}
 		// Node API (/wallet/api/v1|v2/*) → proxy to the node over dmsg. The
 		// wallet's crypto is client-side; only these calls cross the mesh.
 		if strings.HasPrefix(rest, "api/v1/") || strings.HasPrefix(rest, "api/v2/") {

--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -1816,28 +1816,15 @@
       if (!skipLanding) { win.landHome(); }
       return win;
     }
-    var walletWin = null;
+    var walletWin = null, walletCfgListener = null;
     function openWallet() {
       if (focusExisting(walletWin)) { return; }
-      // The ☰ wallet: the PWA-bundled skycoin-web wallet iframe with the FULL
-      // coin-backend config behind a ⚙ toggle (collapsed by default) — parity
-      // with the Angular wallet tab's panel. The wallet's crypto
-      // (skycoin-lite.wasm) + wallets (localStorage) are client-side; its node
-      // API (/api/v1|v2) is routed over dmsg by the injected shim. This panel
-      // writes the SAME localStorage keys the tab + shim read, so config is
-      // unified across the tab, the ☰ window and the shim. (The tab's native-
-      // only "run a local skycoin-web server" control stays tab-only — it needs
-      // the app-management RPC that browse.js doesn't carry.)
-      var K_MODE = "skywire-wallet-mode", K_NODES = "skywire-coin-nodes",
-        K_SERVICE = "skywire-wallet-service", K_BTC = "skywire-btc-backend",
-        K_PRIMARY = "skywire-coin-node";
-      function ls(k, d) { try { return localStorage.getItem(k) || d; } catch (e) { return d; } }
-      function lsSet(k, v) { try { localStorage.setItem(k, v); } catch (e) { } }
-      var mode = ls(K_MODE, "browser");
-      var nodes = null;
-      try { nodes = JSON.parse(ls(K_NODES, "") || "null"); } catch (e) { nodes = null; }
-      if (!nodes || !nodes.length) { var p0 = ls(K_PRIMARY, ""); nodes = p0 ? [p0] : [""]; }
-
+      // The ☰ wallet: the PWA-bundled skycoin-web wallet iframe, with a ⚙
+      // settings toggle that reveals the ONE shared config page (/wallet/config)
+      // — the SAME page the Angular wallet tab embeds. Same origin → shared
+      // localStorage; on Apply the config posts back and we reload the wallet.
+      var isWasm = !!(globalThis.skywireVisor);
+      var cfgSrc = "/wallet/config" + (isWasm ? "?wasm=1" : "");
       var wrap = doc.createElement("div");
       wrap.style.cssText = "position:absolute;inset:0;display:flex;flex-direction:column;background:#15131c;overflow:hidden;font:12px monospace;color:#cdd2da";
       wrap.innerHTML =
@@ -1846,131 +1833,40 @@
         '.sww-bar button{background:#2a2342;color:#e8e8f0;border:1px solid #3a3352;border-radius:3px;padding:.35em .65em;cursor:pointer;font:inherit;line-height:1}' +
         '.sww-bar button:hover{background:#3a3352;color:#fff}.sww-bar button.on{border-color:#6f4bd8;color:#cbb8ff;background:rgba(111,75,216,.2)}' +
         '.sww-served{font-size:.92em;padding:.15em .6em;border-radius:999px;background:rgba(74,222,128,.18);color:#4ade80}' +
-        '.sww-panel{display:none;flex-direction:column;gap:.5em;padding:.6em .7em;background:#181521;border-bottom:1px solid #2a2342;max-height:60%;overflow:auto}' +
-        '.sww-panel.open{display:flex}' +
-        '.sww-modes{display:flex;gap:.4em}.sww-modes button{flex:1;background:#0d0b13;color:#e8e8f0;border:1px solid #3a3352;border-radius:4px;padding:.45em;cursor:pointer;font:inherit}' +
-        '.sww-modes button.on{border-color:#6f4bd8;color:#cbb8ff;background:rgba(111,75,216,.18)}' +
-        '.sww-row{display:flex;gap:.4em;align-items:center}.sww-row label{opacity:.72;min-width:4em;text-align:right;white-space:nowrap}' +
-        '.sww-row input{flex:1;min-width:0;background:#0d0b13;color:#e8e8f0;border:1px solid #3a3352;border-radius:3px;padding:.4em .5em;font:inherit}' +
-        '.sww-row input:focus{outline:none;border-color:#6f4bd8}' +
-        '.sww-hint{opacity:.75;line-height:1.4}.sww-hint b{color:#e8e8f0}' +
-        '.sww-add{align-self:flex-start;background:#2a2342;color:#e8e8f0;border:1px solid #3a3352;border-radius:3px;cursor:pointer;font:inherit;padding:.35em .6em}' +
-        '.sww-rm{background:transparent;color:#9aa0a6;border:0;cursor:pointer;font:inherit;padding:.2em .5em}.sww-rm:hover{color:#f7768e}' +
-        '.sww-apply{align-self:flex-end;background:#6f4bd8;color:#fff;border:0;border-radius:3px;padding:.45em 1.1em;cursor:pointer;font:inherit}' +
+        '#sww-cfg{display:none;border:0;border-bottom:1px solid #2a2342;width:100%;height:48%;min-height:0;background:#15131c}' +
+        '#sww-cfg.open{display:block}' +
         '</style>' +
         '<div class="sww-bar">' +
         '<button id="sww-gear" title="wallet configuration">⚙ settings</button>' +
-        '<span class="sww-served" title="Served by this visor at /wallet/ — wallets are client-side; only the node API crosses the mesh.">served</span>' +
-        '<span style="flex:1"></span><span style="opacity:.5" id="sww-cur"></span>' +
+        '<span class="sww-served" title="Served by this visor at /wallet/ — wallets are client-side; only the node/BTC queries cross the mesh.">served</span>' +
+        '<span style="flex:1"></span>' +
         '</div>' +
-        '<div class="sww-panel" id="sww-panel">' +
-        '<div class="sww-modes">' +
-        '<button id="sww-mb" title="Wallets stored in this browser; pick the coin node it queries.">Browser wallets</button>' +
-        '<button id="sww-ms" title="Point at a remote skycoin-web server over dmsg; wallets live there.">Remote wallet service</button>' +
-        '</div>' +
-        '<div id="sww-browser">' +
-        '<div class="sww-hint">Wallets are created + stored in <b>this browser</b>. Configure the coin node(s) it queries over dmsg — the first is the default; add one per fibercoin. A &lt;pk&gt;:&lt;port&gt; dmsg node is dialed directly; an http(s):// / .dmsg URL goes via the resolving proxy.</div>' +
-        '<div id="sww-nodes"></div>' +
-        '<button class="sww-add" id="sww-addnode">+ Add coin node</button>' +
-        '<div class="sww-hint"><b>Bitcoin</b> (optional): an <span class="mono">ssl://host:port</span> electrum server. Reached over the mesh by the visor\'s BTC gateway — your keys + signing stay in this browser, only chain queries cross.</div>' +
-        '<div class="sww-row"><label>btc</label><input id="sww-btc" list="sww-btc-list" spellcheck="false" placeholder="pick or type an ssl:// electrum server  (optional)"></div>' +
-        // Curated public electrum servers (a starting list, like Electrum's own
-        // servers.json) — a datalist, so you pick from it OR type a custom one.
-        '<datalist id="sww-btc-list">' +
-        '<option value="ssl://electrum.blockstream.info:50002"></option>' +
-        '<option value="ssl://fortress.qtornado.com:50002"></option>' +
-        '<option value="ssl://electrum.emzy.de:50002"></option>' +
-        '<option value="ssl://electrum.bitaroo.net:50002"></option>' +
-        '<option value="ssl://bitcoin.lu.ke:50002"></option>' +
-        '<option value="ssl://electrum.jochen-hoenicke.de:50006"></option>' +
-        '</datalist>' +
-        '</div>' +
-        '<div id="sww-service" style="display:none">' +
-        '<div class="sww-hint">Point at a remote <b>skycoin-web server</b> over dmsg. Wallets live on that server; all wallet + node API routes to it.</div>' +
-        '<div class="sww-row"><label>service</label><input id="sww-svc" spellcheck="false" placeholder="03d1d78e…:8002"></div>' +
-        '</div>' +
-        '<div id="sww-err" style="color:#f7768e;display:none"></div>' +
-        '<button class="sww-apply" id="sww-apply">Apply</button>' +
-        '</div>' +
-        // WinBox styles window-body iframes position:absolute (to fill for its
-        // url: mode), which would cover the bar + panel. Give the iframe a
-        // position:relative flex container so it fills only the region below.
+        '<iframe id="sww-cfg" src="' + cfgSrc + '"></iframe>' +
+        // WinBox styles window-body iframes position:absolute; give the wallet
+        // iframe a relative flex container so it fills only the region below.
         '<div style="flex:1;position:relative;min-height:0">' +
         '<iframe id="sww-frame" src="/wallet/" allowfullscreen style="position:absolute;inset:0;width:100%;height:100%;border:0;background:#fff"></iframe>' +
         '</div>';
-
       walletWin = makeWin(doc, withRoot({
-        title: "skycoin wallet", width: "500px", height: "780px",
+        title: "skycoin wallet", width: "500px", height: "800px",
         top: barTop, bottom: barBottom, mount: wrap,
-        onclose: function () { untrack(walletWin); walletWin = null; }
-      }));
-      var $ = function (id) { return wrap.querySelector("#" + id); };
-      var frame = $("sww-frame");
-
-      function refreshCur() {
-        var eff = mode === "service" ? ls(K_SERVICE, "") : (nodes[0] || "");
-        // Blank field = the deployment default coin node (node.skycoin.com's
-        // skycoin node over dmsg); show that so it's clear what's in effect.
-        $("sww-cur").textContent = eff ? eff.replace(/^https?:\/\//, "") : "default · node.skycoin.com";
-      }
-      function renderNodes() {
-        var box = $("sww-nodes"); box.innerHTML = "";
-        nodes.forEach(function (n, i) {
-          var row = doc.createElement("div"); row.className = "sww-row";
-          var lab = doc.createElement("label"); lab.textContent = "coin " + i;
-          var inp = doc.createElement("input"); inp.spellcheck = false; inp.value = n || "";
-          inp.placeholder = "039a6d1e…:6420 or node.skycoin.com.<pk>.dmsg:6420" + (i === 0 ? "  (blank = node.skycoin.com)" : "");
-          inp.oninput = function () { nodes[i] = inp.value; };
-          row.appendChild(lab); row.appendChild(inp);
-          if (nodes.length > 1) {
-            var rm = doc.createElement("button"); rm.className = "sww-rm"; rm.textContent = "✕"; rm.title = "remove";
-            rm.onclick = function () { nodes.splice(i, 1); renderNodes(); };
-            row.appendChild(rm);
-          }
-          box.appendChild(row);
-        });
-      }
-      function setMode(m) {
-        mode = m;
-        $("sww-mb").classList.toggle("on", m === "browser");
-        $("sww-ms").classList.toggle("on", m === "service");
-        $("sww-browser").style.display = m === "browser" ? "" : "none";
-        $("sww-service").style.display = m === "service" ? "" : "none";
-        refreshCur();
-      }
-      function apply() {
-        var err = $("sww-err"); err.style.display = "none"; err.textContent = "";
-        if (mode === "service") {
-          var svc = ($("sww-svc").value || "").trim();
-          if (!svc) { err.textContent = "Enter the wallet service address (a dmsg <pk>:<port> or URL)."; err.style.display = ""; return; }
-          lsSet(K_MODE, "service"); lsSet(K_SERVICE, svc); lsSet(K_PRIMARY, svc);
-        } else {
-          var clean = nodes.map(function (n) { return (n || "").trim(); }).filter(function (n, i) { return n || i === 0; });
-          if (!clean.length) { clean = [""]; }
-          nodes = clean;
-          lsSet(K_MODE, "browser");
-          lsSet(K_NODES, JSON.stringify(clean));
-          lsSet(K_BTC, ($("sww-btc").value || "").trim());
-          lsSet(K_PRIMARY, clean[0] || "");
+        onclose: function () {
+          untrack(walletWin); walletWin = null;
+          if (walletCfgListener) { try { window.removeEventListener("message", walletCfgListener); } catch (e) {} walletCfgListener = null; }
         }
-        refreshCur();
-        try { frame.src = "/wallet/?_=" + Date.now(); } catch (e) { }
-        $("sww-panel").classList.remove("open");
-      }
-
-      $("sww-btc").value = ls(K_BTC, "");
-      $("sww-svc").value = ls(K_SERVICE, "");
-      renderNodes();
-      setMode(mode);
-      refreshCur();
-      $("sww-gear").onclick = function () {
-        var p = $("sww-panel"); p.classList.toggle("open");
-        $("sww-gear").classList.toggle("on", p.classList.contains("open"));
+      }));
+      var frame = wrap.querySelector("#sww-frame");
+      var cfg = wrap.querySelector("#sww-cfg");
+      wrap.querySelector("#sww-gear").onclick = function () {
+        this.classList.toggle("on", cfg.classList.toggle("open"));
       };
-      $("sww-mb").onclick = function () { setMode("browser"); };
-      $("sww-ms").onclick = function () { setMode("service"); };
-      $("sww-addnode").onclick = function () { nodes.push(""); renderNodes(); };
-      $("sww-apply").onclick = apply;
+      // Reload the wallet iframe when the config page applies (same-origin).
+      walletCfgListener = function (ev) {
+        if (ev && ev.data && ev.data.type === "skywire-wallet-config") {
+          try { frame.src = "/wallet/?_=" + Date.now(); } catch (e) {}
+        }
+      };
+      window.addEventListener("message", walletCfgListener);
       track(walletWin, "wallet");
     }
     var logWin = null;

--- a/pkg/wasmhv/browseui/walletconfig.go
+++ b/pkg/wasmhv/browseui/walletconfig.go
@@ -1,0 +1,112 @@
+// pkg/wasmhv/browseui/walletconfig.go — the ONE wallet config panel.
+//
+// The wallet's backend config (storage mode, coin nodes, BTC electrum server,
+// skysocks exit) is a set of localStorage keys read by the /wallet/ fetch shim
+// (native: hypervisor_handlers_wallet.go; wasm: serve.go) and the in-tab BTC
+// gateway. It used to be reimplemented twice — once in browse.js (the ☰ wallet
+// window) and once in the Angular wallet tab. This is the single implementation:
+// a self-contained page served at /wallet/config that BOTH surfaces embed in an
+// <iframe>. Same origin as /wallet/, so it reads+writes the same localStorage,
+// and on Apply it posts {type:"skywire-wallet-config"} to its parent so the
+// embedder can reload the wallet view.
+package browseui
+
+// WalletConfigHTML is the standalone wallet-config page (served at /wallet/config
+// by both the native HV and the wasm `hv serve`). Keys, all read by the shims +
+// the BTC gateway:
+//
+//	skywire-wallet-mode     browser | service
+//	skywire-coin-nodes      JSON array of coin-node addresses (first = default)
+//	skywire-coin-node       the effective node the shim reads (mirrors nodes[0]
+//	                        or the service address)
+//	skywire-wallet-service  remote skycoin-web server (service mode)
+//	skywire-btc-backend     ssl:// electrum server
+//	skywire-btc-proxy       skysocks exit PK for the BTC electrum egress
+//	                        (required on wasm; optional on native = self-egress)
+const WalletConfigHTML = `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+:root{color-scheme:dark}
+body{margin:0;background:#15131c;color:#e8e8f0;font:12px/1.45 -apple-system,system-ui,monospace}
+.wrap{padding:.7em .8em;display:flex;flex-direction:column;gap:.6em}
+h1{font-size:12px;font-weight:600;margin:0;opacity:.75;letter-spacing:.3px;text-transform:uppercase}
+.modes{display:flex;gap:.4em}
+.modes button{flex:1;background:#0d0b13;color:#e8e8f0;border:1px solid #3a3352;border-radius:4px;padding:.5em;cursor:pointer;font:inherit}
+.modes button.on{border-color:#6f4bd8;color:#cbb8ff;background:rgba(111,75,216,.18)}
+.row{display:flex;gap:.4em;align-items:center}
+.row label{opacity:.72;min-width:4.5em;text-align:right;white-space:nowrap}
+.row input{flex:1;min-width:0;background:#0d0b13;color:#e8e8f0;border:1px solid #3a3352;border-radius:3px;padding:.4em .5em;font:inherit}
+.row input:focus{outline:none;border-color:#6f4bd8}
+.hint{opacity:.72;line-height:1.4}.hint b{color:#e8e8f0}.mono{font-family:monospace;opacity:.85}
+button.add{align-self:flex-start;background:#2a2342;color:#e8e8f0;border:1px solid #3a3352;border-radius:3px;cursor:pointer;font:inherit;padding:.35em .6em}
+button.rm{background:transparent;color:#9aa0a6;border:0;cursor:pointer;font:inherit;padding:.2em .5em}button.rm:hover{color:#f7768e}
+.apply{align-self:flex-end;background:#6f4bd8;color:#fff;border:0;border-radius:4px;padding:.5em 1.2em;cursor:pointer;font:inherit}
+.err{color:#f7768e;display:none}
+.sec{border-top:1px solid #2a2342;padding-top:.6em;display:flex;flex-direction:column;gap:.5em}
+</style></head><body><div class="wrap">
+<div class="modes">
+<button id="mb" title="Wallets stored in this browser; pick the coin node it queries.">Browser wallets</button>
+<button id="ms" title="Point at a remote skycoin-web server over dmsg.">Remote wallet service</button>
+</div>
+<div id="browser">
+<div class="hint">Wallets are created + stored in <b>this browser</b>. Configure the coin node(s) it queries over dmsg — the first is the default; add one per fibercoin. A <span class="mono">&lt;pk&gt;:&lt;port&gt;</span> dmsg node is dialed directly; an <span class="mono">http(s)://</span>/<span class="mono">.dmsg</span> URL goes via the resolving proxy.</div>
+<div id="nodes"></div>
+<button class="add" id="addnode">+ Add coin node</button>
+<div class="sec">
+<div class="hint"><b>Bitcoin</b> (optional): an <span class="mono">ssl://host:port</span> electrum server, reached over the mesh by the visor's BTC gateway. Keys + signing stay in this browser; only chain queries cross.</div>
+<div class="row"><label>btc</label><input id="btc" list="btclist" spellcheck="false" placeholder="pick or type an ssl:// electrum server"></div>
+<datalist id="btclist">
+<option value="ssl://electrum.blockstream.info:50002"></option>
+<option value="ssl://fortress.qtornado.com:50002"></option>
+<option value="ssl://electrum.emzy.de:50002"></option>
+<option value="ssl://electrum.bitaroo.net:50002"></option>
+<option value="ssl://bitcoin.lu.ke:50002"></option>
+<option value="ssl://electrum.jochen-hoenicke.de:50006"></option>
+</datalist>
+<div class="hint"><b>Skysocks exit</b> <span id="proxyreq"></span>: the visor PK whose skysocks-server relays the BTC electrum connection to the clearnet. <span id="proxynote"></span></div>
+<div class="row"><label>proxy</label><input id="proxy" spellcheck="false" placeholder="skysocks exit PK (66 hex)"></div>
+</div>
+</div>
+<div id="service" style="display:none">
+<div class="hint">Point at a remote <b>skycoin-web server</b> over dmsg. Wallets live on that server; all wallet + node API route to it.</div>
+<div class="row"><label>service</label><input id="svc" spellcheck="false" placeholder="03d1d78e…:8002"></div>
+</div>
+<div id="err" class="err"></div>
+<button class="apply" id="apply">Apply</button>
+</div>
+<script>(function(){
+var K={mode:"skywire-wallet-mode",nodes:"skywire-coin-nodes",prim:"skywire-coin-node",svc:"skywire-wallet-service",btc:"skywire-btc-backend",proxy:"skywire-btc-proxy"};
+function ls(k,d){try{return localStorage.getItem(k)||d;}catch(e){return d;}}
+function set(k,v){try{localStorage.setItem(k,v);}catch(e){}}
+function $(id){return document.getElementById(id);}
+// isWasm is passed by the embedder via ?wasm=1 (BTC egress needs an exit there).
+var isWasm=/[?&]wasm=1/.test(location.search);
+$("proxyreq").textContent=isWasm?"(required)":"(optional)";
+$("proxynote").textContent=isWasm?"The browser can't reach the clearnet itself, so this is required for BTC.":"Empty = this visor does the egress itself (self). Set one to route BTC through another visor for IP privacy.";
+var mode=ls(K.mode,"browser");
+var nodes;try{nodes=JSON.parse(ls(K.nodes,"")||"null");}catch(e){nodes=null;}
+if(!nodes||!nodes.length){var p=ls(K.prim,"");nodes=p?[p]:[""];}
+function renderNodes(){var box=$("nodes");box.innerHTML="";nodes.forEach(function(n,i){
+var r=document.createElement("div");r.className="row";
+var l=document.createElement("label");l.textContent="coin "+i;
+var inp=document.createElement("input");inp.spellcheck=false;inp.value=n||"";
+inp.placeholder=(i===0?"039a6d1e…:6420 or node.skycoin.com.<pk>.dmsg:6420  (blank = node.skycoin.com)":"039a6d1e…:6420");
+inp.oninput=function(){nodes[i]=inp.value;};
+r.appendChild(l);r.appendChild(inp);
+if(nodes.length>1){var rm=document.createElement("button");rm.className="rm";rm.textContent="✕";rm.title="remove";rm.onclick=function(){nodes.splice(i,1);renderNodes();};r.appendChild(rm);}
+box.appendChild(r);});}
+function setMode(m){mode=m;$("mb").classList.toggle("on",m==="browser");$("ms").classList.toggle("on",m==="service");
+$("browser").style.display=m==="browser"?"":"none";$("service").style.display=m==="service"?"":"none";}
+$("btc").value=ls(K.btc,"");$("proxy").value=ls(K.proxy,"");$("svc").value=ls(K.svc,"");
+renderNodes();setMode(mode);
+$("mb").onclick=function(){setMode("browser");};$("ms").onclick=function(){setMode("service");};
+$("addnode").onclick=function(){nodes.push("");renderNodes();};
+$("apply").onclick=function(){var e=$("err");e.style.display="none";e.textContent="";
+if(mode==="service"){var s=($("svc").value||"").trim();if(!s){e.textContent="Enter the wallet service address.";e.style.display="";return;}
+set(K.mode,"service");set(K.svc,s);set(K.prim,s);}
+else{var clean=nodes.map(function(n){return(n||"").trim();}).filter(function(n,i){return n||i===0;});if(!clean.length)clean=[""];nodes=clean;
+set(K.mode,"browser");set(K.nodes,JSON.stringify(clean));set(K.prim,clean[0]||"");
+set(K.btc,($("btc").value||"").trim());set(K.proxy,($("proxy").value||"").trim());}
+try{parent.postMessage({type:"skywire-wallet-config"},"*");}catch(_){}
+};
+})();</script></body></html>`

--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -25,6 +25,11 @@ var OverrideJS []byte
 // (pkg/wasmhv's gob-mirror test imports pkg/visor).
 var BrowseJS = browseui.BrowseJS
 
+// WalletConfigHTML is the single wallet-config page (served at /wallet/config by
+// both the native HV and `hv serve`, embedded via iframe by the ☰ wallet window
+// and the Angular wallet tab). Re-exported from the browseui leaf like BrowseJS.
+var WalletConfigHTML = browseui.WalletConfigHTML
+
 // AutoUpdateJS is pkg/wasmhv/autoupdate.js — the wasm-visor self-update poller for
 // the `hv serve` page: it compares a /wasm-version fingerprint against the version
 // the page booted with and reloads to a newer build (toast + opt-out). Injected


### PR DESCRIPTION
The wallet backend config was reimplemented **twice** — in browse.js (the ☰ wallet window) and in the Angular wallet tab. Replace both with **one self-contained page served at `/wallet/config`**, embedded via `<iframe>` by each surface (same origin → shared `localStorage`; on Apply it postMessages the parent to reload the wallet).

The page carries: storage mode, multi-coin node list, the BTC electrum server (curated dropdown), and a **new skysocks-exit field** for the BTC egress — **required on wasm** (the browser can't reach clearnet itself), **optional on native** (empty = the host visor self-egresses; set = route through another visor for IP privacy). Served by both the native HV and `hv serve`, from the `browseui` leaf (re-exported like `BrowseJS`).

- browse.js `openWallet`: ~150-line inline panel → a compact ⚙-toggled config iframe.
- Verified: `/wallet/config` serves on both visors; the ☰ window embeds it.

Follow-ups: point the Angular wallet tab at the same page (finish the dedup); native route-through-exit (a native skysocks DialFunc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)