### PR TITLE
feat(hv-ui): native wallet BTC route-through-exit (skysocks) for IP privacy

### DIFF
--- a/pkg/visor/api_browse.go
+++ b/pkg/visor/api_browse.go
@@ -319,3 +319,60 @@ func readBrowseResp(resp *http.Response) (*SkynetHTTPResponse, error) {
 type yamuxStreamDialer struct{ sess *yamux.Session }
 
 func (d yamuxStreamDialer) Dial(_, _ string) (net.Conn, error) { return d.sess.Open() }
+
+// tunnelConn ties extra closers (the yamux session + the underlying route conn)
+// to the lifetime of a tunneled stream, so closing the carried connection tears
+// the whole skysocks tunnel down instead of leaking the route group.
+type tunnelConn struct {
+	net.Conn
+	closers []io.Closer
+}
+
+func (c *tunnelConn) Close() error {
+	err := c.Conn.Close()
+	for _, cl := range c.closers {
+		_ = cl.Close() //nolint:errcheck
+	}
+	return err
+}
+
+// skysocksDialFunc returns a raw dialer (electrum.DialFunc-shaped) that carries
+// each connection through the given exit visor's skysocks-server: a skywire
+// route to exitPK:skysocks, a yamux client over it, and a SOCKS5 CONNECT to the
+// target host. This is the native equivalent of the wasm visor's in-tab
+// skysocks-lite BTC egress — it lets the native BTC gateway reach a clearnet
+// electrum server through ANOTHER visor for IP privacy, instead of egressing
+// itself. The returned conn owns the yamux session + route conn (both closed on
+// Close), and the electrum backend keeps ONE conn per server, so this is a
+// single tunnel per (exit, electrum-server), reused across chain queries.
+func (v *Visor) skysocksDialFunc(exitPK cipher.PubKey) func(network, addr string) (net.Conn, error) {
+	return func(network, addr string) (net.Conn, error) {
+		if v.router == nil {
+			return nil, fmt.Errorf("router not available")
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), browseFetchTimeout)
+		defer cancel()
+		conn, err := v.router.DialRoutes(ctx, exitPK, 0, routing.Port(skyenv.SkysocksPort), nil)
+		if err != nil {
+			return nil, fmt.Errorf("dial skysocks route: %w", err)
+		}
+		sess, err := yamux.Client(conn, yamux.DefaultConfig())
+		if err != nil {
+			_ = conn.Close() //nolint:errcheck
+			return nil, fmt.Errorf("yamux client: %w", err)
+		}
+		sd, err := proxy.SOCKS5("tcp", "skysocks", nil, yamuxStreamDialer{sess})
+		if err != nil {
+			_ = sess.Close() //nolint:errcheck
+			_ = conn.Close() //nolint:errcheck
+			return nil, err
+		}
+		stream, err := sd.Dial(network, addr)
+		if err != nil {
+			_ = sess.Close() //nolint:errcheck
+			_ = conn.Close() //nolint:errcheck
+			return nil, fmt.Errorf("skysocks dial %s: %w", addr, err)
+		}
+		return &tunnelConn{Conn: stream, closers: []io.Closer{sess, conn}}, nil
+	}
+}

--- a/pkg/visor/hypervisor_handlers_wallet.go
+++ b/pkg/visor/hypervisor_handlers_wallet.go
@@ -24,23 +24,48 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/skycoin/skywire/pkg/cipher"
+
 	"github.com/skycoin/skywire/pkg/btcgateway"
 	"github.com/skycoin/skywire/pkg/wasmhv/browseui"
 )
 
 var (
-	nativeBtcGatewayOnce sync.Once
-	nativeBtcGatewayInst *btcgateway.Gateway
+	nativeBtcGatewaysMu sync.Mutex
+	nativeBtcGateways   = map[string]*btcgateway.Gateway{}
 )
 
-// nativeBtcGateway is the HV's shared BTC electrum gateway for the native
-// HV-served wallet. A nil dialer means clearnet egress — a host visor reaches
-// public electrum servers directly; the per-request electrum URL comes from the
-// X-Skywire-Btc-Backend header (set by the wallet shim from
-// localStorage['skywire-btc-backend']).
-func nativeBtcGateway() *btcgateway.Gateway {
-	nativeBtcGatewayOnce.Do(func() { nativeBtcGatewayInst = btcgateway.New(nil) })
-	return nativeBtcGatewayInst
+// nativeBtcGateway is the HV's BTC electrum gateway for the given skysocks exit.
+// exitPK == "" (or the local visor's own PK) means clearnet egress: a nil dialer
+// so the host visor reaches public electrum servers over its own default route
+// (the zero-config native default — self-egress). A non-empty REMOTE exit PK
+// routes the electrum connection through that visor's skysocks-server for IP
+// privacy (the native twin of the wasm wallet's required skysocks exit). The
+// per-request electrum URL comes from X-Skywire-Btc-Backend; the exit from
+// X-Skywire-Btc-Proxy — both set by the wallet shim from localStorage
+// (skywire-btc-backend / skywire-btc-proxy, written by the config page).
+//
+// Gateways are cached per exit so the electrum backends (and their long-lived
+// per-server connections) are reused across chain queries.
+func (hv *Hypervisor) nativeBtcGateway(exitPK string) *btcgateway.Gateway {
+	exitPK = strings.TrimSpace(exitPK)
+	nativeBtcGatewaysMu.Lock()
+	defer nativeBtcGatewaysMu.Unlock()
+	if g, ok := nativeBtcGateways[exitPK]; ok {
+		return g
+	}
+	var g *btcgateway.Gateway
+	if exitPK != "" && hv.visor != nil {
+		var pk cipher.PubKey
+		if err := pk.Set(exitPK); err == nil && pk != hv.visor.conf.PK {
+			g = btcgateway.New(hv.visor.skysocksDialFunc(pk))
+		}
+	}
+	if g == nil { // empty / self / unparseable exit → clearnet self-egress
+		g = btcgateway.New(nil)
+	}
+	nativeBtcGateways[exitPK] = g
+	return g
 }
 
 // walletNodeDmsg is the skycoin node the HV-served wallet talks to by DEFAULT:
@@ -81,7 +106,8 @@ const walletNodeShim = `<script>(function(){` +
 	`init=init||{};` +
 	`var h=new Headers((init&&init.headers)||(typeof input!=="string"&&input&&input.headers)||undefined);` +
 	`if(mn){var n=ls("skywire-coin-node");if(n){h.set("X-Skywire-Coin-Node",n);}}` +
-	`else{var b=ls("skywire-btc-backend");if(b){h.set("X-Skywire-Btc-Backend",b);}}` +
+	`else{var b=ls("skywire-btc-backend");if(b){h.set("X-Skywire-Btc-Backend",b);}` +
+	`var xp=ls("skywire-btc-proxy");if(xp){h.set("X-Skywire-Btc-Proxy",xp);}}` +
 	`init.headers=h;return rf(target,init);` +
 	`};})();</script>`
 
@@ -113,11 +139,13 @@ func (hv *Hypervisor) walletHandler() http.HandlerFunc {
 		}
 		// BTC API (/wallet/v1/btc/*) → the in-process electrum gateway. The
 		// browser derives + signs BTC itself; only chain queries come here. The
-		// electrum server (X-Skywire-Btc-Backend, set by the shim) is dialed on
-		// the clearnet by the native visor (nil dialer).
+		// electrum server (X-Skywire-Btc-Backend) is reached either directly on
+		// the clearnet (self-egress, the default) or — when the operator sets a
+		// skysocks exit (X-Skywire-Btc-Proxy) — routed through that visor for IP
+		// privacy. Both headers are set by the shim from localStorage.
 		if strings.HasPrefix(rest, "v1/btc/") {
 			r.URL.Path = "/" + rest
-			nativeBtcGateway().ServeHTTP(w, r)
+			hv.nativeBtcGateway(r.Header.Get("X-Skywire-Btc-Proxy")).ServeHTTP(w, r)
 			return
 		}
 		if fsErr != nil {


### PR DESCRIPTION
Completes the wallet BTC egress story. The native HV-served wallet's BTC gateway self-egressed to the electrum server directly (nil dialer). Wire the skysocks-exit config the wasm wallet already requires: when the operator sets a skysocks exit (`skywire-btc-proxy`, sent as `X-Skywire-Btc-Proxy` by the wallet shim), route the electrum connection through **that** visor's skysocks-server instead — the native twin of the wasm in-tab skysocks-lite BTC egress. Empty/self exit keeps the zero-config self-egress default.

- `Visor.skysocksDialFunc(exitPK)`: a raw dialer that lays a route to `exitPK:skysocks`, runs a yamux client + SOCKS5 CONNECT over it, and returns a `tunnelConn` that closes the yamux session + route conn together with the carried stream (no route leak). Electrum keeps one conn per server, so it's one tunnel per (exit, server), reused across queries.
- `Hypervisor.nativeBtcGateway(exitPK)`: gateways cached per exit; unparseable/self exit falls back to clearnet.

**Verified live:** self-egress unchanged (genesis 57.22 BTC); a real exit routes electrum TCP+TLS through the remote skysocks-server end-to-end (balance + TLS handshake); an unroutable exit blocks on route setup (no silent clearnet fallback). Idle electrum-conn reconnect is a pre-existing gateway follow-up (affects clearnet too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)