### PR TITLE
feat(wallet): default coin node = node.skycoin.com vhost, sourced from services-config.json

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/visor"
 	"github.com/skycoin/skywire/pkg/wasmhv"
 	"github.com/skycoin/skywire/pkg/wasmhv/ctlbridge"
@@ -50,62 +51,72 @@ var (
 // forward). Everything else falls through to native fetch. No Service Worker
 // needed, so this works under --harness and file:// too. Same-origin iframe, so
 // it reads the parent's visor + the shared localStorage directly.
-// defaultCoinNode is the deployment skycoin node the bundled wallet talks to
-// out of the box: node.skycoin.com, whose visor forwards the local skycoin
-// node's :6420 over dmsg (addressed as "<pk>:<port>" for skywireVisor.fetchDmsg).
-// Users override it via the wallet's Settings->Nodes (localStorage
-// 'skywire-coin-node'). Same PK:port as deployment/services-config.json
-// prod.skycoin_node_dmsg ("dmsg://<pk>:6420") — here without the scheme,
-// which is what skywireVisor.fetchDmsg expects.
-const defaultCoinNode = "039a6d1e3c237f5f05b78ec19e9f31a007f84835d7ef1e812876102281d1db74c1:6420"
+// coinNodeDefault is the deployment skycoin node the bundled wallet talks to out
+// of the box, sourced from the embedded services-config.json
+// (prod.skycoin_node_dmsg) instead of hardcoded. node.skycoin.com over the mesh
+// as the resolver VHOST form "https://<vhost>.<base32-pk>.dmsg" (base32 =
+// PubKey.DNSLabel of the node's visor 039a6d1e…): routed through that visor's
+// port-80 forward (Caddy, --preserve-host) exactly like clearnet. The wallet
+// shim strips the https:// scheme and hands the host to skywireVisor.fetchDmsg,
+// which resolves the vhost + pk and sends Host: node.skycoin.com so Caddy
+// vhost-routes /api to the local skycoin node. Users override it via the wallet
+// config panel (localStorage 'skywire-coin-node').
+func coinNodeDefault() string {
+	if n := strings.TrimSpace(dmsg.Prod.SkycoinNode); n != "" {
+		return n
+	}
+	return "https://node.skycoin.com.aong2hr4en7v6bnxr3az5hzruad7qsbv27xr5ajioyicfaor3n2mc.dmsg"
+}
 
-const walletDmsgFetchShim = `<script>(function(){` +
-	`var rf=window.fetch?window.fetch.bind(window):null;` +
-	`function p(u){try{return new URL(u,location.href).pathname;}catch(e){return String(u);}}` +
-	`function q(u){try{return new URL(u,location.href).search;}catch(e){return "";}}` +
-	`function isCoin(u){return /^\/api\/v[12]\//.test(p(u));}` +
-	`function isBtc(u){return /^\/(wallet\/)?v1\/btc\//.test(p(u));}` +
-	`function ls(k){try{return localStorage.getItem(k)||"";}catch(e){return "";}}` +
-	// The wallet POSTs balance/transactions as x-www-form-urlencoded; forward the
-	// request Content-Type so fetchDmsg/fetchClearnet don't mislabel the body as
-	// JSON (which makes the skycoin node ignore the form → "addrs is required").
-	`function ctOf(input,init){try{var h;if(init&&init.headers)h=new Headers(init.headers);else if(input&&input.headers&&input.headers.get)h=input.headers;if(h&&h.get){var c=h.get("content-type");if(c)return c;}}catch(e){}return "";}` +
-	`function jr(s,o){return new Response(JSON.stringify(o),{status:s,headers:{"Content-Type":"application/json"}});}` +
-	`function mkResp(r){var b=(r&&typeof r.body==="string")?r.body:(r&&r.body?new TextDecoder().decode(r.body):"");return new Response(b,{status:(r&&r.status)||502,headers:{"Content-Type":"application/json"}});}` +
-	`window.fetch=function(input,init){` +
-	`var url=(typeof input==="string")?input:(input&&input.url);` +
-	`var coin=isCoin(url),btc=isBtc(url);` +
-	`if(!coin&&!btc)return rf?rf(input,init):Promise.reject(new Error("no fetch"));` +
-	`init=init||{};` +
-	`var v=window.parent&&window.parent.skywireVisor;` +
-	`if(!v||!v.fetchDmsg)return Promise.resolve(jr(503,{error:"skywire visor not ready"}));` +
-	// BTC: the wallet does keys+signing itself; only chain queries go over the
-	// mesh, through the in-tab electrum gateway (skywireVisor.btcFetch), which
-	// dials the ssl:// electrum via skysocks-lite (upstream-proxy exit).
-	`if(btc){` +
-	`if(!v.btcFetch)return Promise.resolve(jr(503,{error:"BTC gateway not available"}));` +
-	`var back=ls("skywire-btc-backend");if(!back)return Promise.resolve(jr(502,{error:"no BTC electrum server configured"}));` +
-	`return Promise.resolve(v.btcFetch(back,init.method||"GET",p(url)+q(url),init.body||null,ls("skywire-btc-proxy")||ls("skywire-upstream-proxy"))).then(mkResp).catch(function(e){return jr(502,{error:String(e)});});` +
-	`}` +
-	// COIN node API: routed exactly like the iframe browser (browse.js). A dmsg
-	// host (pk:port / pk.dmsg / name.pk.dmsg / alias) goes through the dmsg
-	// resolving proxy (fetchDmsg). A clearnet http(s):// node (not .dmsg) goes
-	// through skysocks-client-lite (fetchClearnet) via the SAME upstream-proxy
-	// exit the browser uses (skywire-upstream-proxy) — IP-anonymous. Requests are
-	// logged to the shared skywireLog so they show in the browser's log panel.
-	`var node=ls("skywire-coin-node")||"` + defaultCoinNode + `";` +
-	`var m=init.method||"GET",pth=p(url)+q(url),ct=ctOf(input,init),hdrs=ct?{"Content-Type":ct}:null;` +
-	`function wlog(s){try{var L=window.parent&&window.parent.skywireLog;if(L&&L.emit)L.emit("info",["[wallet] "+s]);}catch(e){}}` +
-	`if(/^https?:\/\//i.test(node)&&!/\.dmsg\b/i.test(node)){` +
-	`if(!v.fetchClearnet)return Promise.resolve(jr(503,{error:"skysocks clearnet gateway not available"}));` +
-	`var up=ls("skywire-upstream-proxy");if(!up)return Promise.resolve(jr(502,{error:"clearnet coin node needs a skysocks exit — set an upstream proxy"}));` +
-	`var full=node.replace(/\/+$/,"")+pth;wlog(m+" "+full+" via skysocks "+up.slice(0,8));` +
-	`return Promise.resolve(v.fetchClearnet(up,m,full,init.body||null,"wallet",hdrs)).then(mkResp).catch(function(e){return jr(502,{error:String(e)});});` +
-	`}` +
-	`var host=node.replace(/^\w+:\/\//,"");wlog(m+" dmsg://"+host+pth);` +
-	`return Promise.resolve(v.fetchDmsg(host,m,pth,init.body||null,hdrs)).then(mkResp).catch(function(e){return jr(502,{error:String(e)});});` +
-	`};` +
-	`})();</script>`
+func walletDmsgFetchShim() string {
+	return `<script>(function(){` +
+		`var rf=window.fetch?window.fetch.bind(window):null;` +
+		`function p(u){try{return new URL(u,location.href).pathname;}catch(e){return String(u);}}` +
+		`function q(u){try{return new URL(u,location.href).search;}catch(e){return "";}}` +
+		`function isCoin(u){return /^\/api\/v[12]\//.test(p(u));}` +
+		`function isBtc(u){return /^\/(wallet\/)?v1\/btc\//.test(p(u));}` +
+		`function ls(k){try{return localStorage.getItem(k)||"";}catch(e){return "";}}` +
+		// The wallet POSTs balance/transactions as x-www-form-urlencoded; forward the
+		// request Content-Type so fetchDmsg/fetchClearnet don't mislabel the body as
+		// JSON (which makes the skycoin node ignore the form → "addrs is required").
+		`function ctOf(input,init){try{var h;if(init&&init.headers)h=new Headers(init.headers);else if(input&&input.headers&&input.headers.get)h=input.headers;if(h&&h.get){var c=h.get("content-type");if(c)return c;}}catch(e){}return "";}` +
+		`function jr(s,o){return new Response(JSON.stringify(o),{status:s,headers:{"Content-Type":"application/json"}});}` +
+		`function mkResp(r){var b=(r&&typeof r.body==="string")?r.body:(r&&r.body?new TextDecoder().decode(r.body):"");return new Response(b,{status:(r&&r.status)||502,headers:{"Content-Type":"application/json"}});}` +
+		`window.fetch=function(input,init){` +
+		`var url=(typeof input==="string")?input:(input&&input.url);` +
+		`var coin=isCoin(url),btc=isBtc(url);` +
+		`if(!coin&&!btc)return rf?rf(input,init):Promise.reject(new Error("no fetch"));` +
+		`init=init||{};` +
+		`var v=window.parent&&window.parent.skywireVisor;` +
+		`if(!v||!v.fetchDmsg)return Promise.resolve(jr(503,{error:"skywire visor not ready"}));` +
+		// BTC: the wallet does keys+signing itself; only chain queries go over the
+		// mesh, through the in-tab electrum gateway (skywireVisor.btcFetch), which
+		// dials the ssl:// electrum via skysocks-lite (upstream-proxy exit).
+		`if(btc){` +
+		`if(!v.btcFetch)return Promise.resolve(jr(503,{error:"BTC gateway not available"}));` +
+		`var back=ls("skywire-btc-backend");if(!back)return Promise.resolve(jr(502,{error:"no BTC electrum server configured"}));` +
+		`return Promise.resolve(v.btcFetch(back,init.method||"GET",p(url)+q(url),init.body||null,ls("skywire-btc-proxy")||ls("skywire-upstream-proxy"))).then(mkResp).catch(function(e){return jr(502,{error:String(e)});});` +
+		`}` +
+		// COIN node API: routed exactly like the iframe browser (browse.js). A dmsg
+		// host (pk:port / pk.dmsg / name.pk.dmsg / alias) goes through the dmsg
+		// resolving proxy (fetchDmsg). A clearnet http(s):// node (not .dmsg) goes
+		// through skysocks-client-lite (fetchClearnet) via the SAME upstream-proxy
+		// exit the browser uses (skywire-upstream-proxy) — IP-anonymous. Requests are
+		// logged to the shared skywireLog so they show in the browser's log panel.
+		`var node=ls("skywire-coin-node")||"` + coinNodeDefault() + `";` +
+		`var m=init.method||"GET",pth=p(url)+q(url),ct=ctOf(input,init),hdrs=ct?{"Content-Type":ct}:null;` +
+		`function wlog(s){try{var L=window.parent&&window.parent.skywireLog;if(L&&L.emit)L.emit("info",["[wallet] "+s]);}catch(e){}}` +
+		`if(/^https?:\/\//i.test(node)&&!/\.dmsg\b/i.test(node)){` +
+		`if(!v.fetchClearnet)return Promise.resolve(jr(503,{error:"skysocks clearnet gateway not available"}));` +
+		`var up=ls("skywire-upstream-proxy");if(!up)return Promise.resolve(jr(502,{error:"clearnet coin node needs a skysocks exit — set an upstream proxy"}));` +
+		`var full=node.replace(/\/+$/,"")+pth;wlog(m+" "+full+" via skysocks "+up.slice(0,8));` +
+		`return Promise.resolve(v.fetchClearnet(up,m,full,init.body||null,"wallet",hdrs)).then(mkResp).catch(function(e){return jr(502,{error:String(e)});});` +
+		`}` +
+		`var host=node.replace(/^\w+:\/\//,"");wlog(m+" dmsg://"+host+pth);` +
+		`return Promise.resolve(v.fetchDmsg(host,m,pth,init.body||null,hdrs)).then(mkResp).catch(function(e){return jr(502,{error:String(e)});});` +
+		`};` +
+		`})();</script>`
+}
 
 func init() {
 	serveCmd.Flags().StringVarP(&serveAddr, "addr", "a", ":7999", "HTTP listen address")
@@ -233,7 +244,7 @@ page never asks anyone to type a secret key.`,
 			// origin-wide SW interception.
 			walletIndex = bytes.Replace(walletIndex,
 				[]byte(`<base href="/">`),
-				[]byte(`<base href="/wallet/">`+walletDmsgFetchShim), 1)
+				[]byte(`<base href="/wallet/">`+walletDmsgFetchShim()), 1)
 			mux.HandleFunc("/wallet/", func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/wallet/" || r.URL.Path == "/wallet/index.html" {
 					w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/deployment/services-config.json
+++ b/deployment/services-config.json
@@ -119,7 +119,7 @@
     ],
     "dns_server": "1.1.1.1",
     "geoip": "http://ip.skycoin.com",
-    "skycoin_node_dmsg": "dmsg://039a6d1e3c237f5f05b78ec19e9f31a007f84835d7ef1e812876102281d1db74c1:6420",
+    "skycoin_node_dmsg": "https://node.skycoin.com.aong2hr4en7v6bnxr3az5hzruad7qsbv27xr5ajioyicfaor3n2mc.dmsg",
     "skycoin_explorer_dmsg": "dmsg://039a6d1e3c237f5f05b78ec19e9f31a007f84835d7ef1e812876102281d1db74c1:8081",
     "skycoin_blog_dmsg": "dmsg://039a6d1e3c237f5f05b78ec19e9f31a007f84835d7ef1e812876102281d1db74c1:8082",
     "survey_whitelist": [

--- a/pkg/dmsg/dmsg/const.go
+++ b/pkg/dmsg/dmsg/const.go
@@ -73,6 +73,12 @@ type DmsghttpConfig struct {
 	RouteFinder        string       `json:"route_finder_dmsg"`
 	UptimeTracker      string       `json:"uptime_tracker_dmsg"`
 	ServiceDiscovery   string       `json:"service_discovery_dmsg"`
+	// SkycoinNode is the deployment's skycoin node, reachable over the mesh — the
+	// default coin node for the HV-served wallet (native + wasm). The resolver
+	// VHOST form "https://<vhost>.<base32-pk>.dmsg" routes /api through the node's
+	// visor port-80 forward (Caddy, --preserve-host) like clearnet; a bare
+	// "dmsg://<pk>:6420" hits the node directly (deployments without a web front).
+	SkycoinNode string `json:"skycoin_node_dmsg"`
 }
 
 func init() {

--- a/pkg/visor/api_browse.go
+++ b/pkg/visor/api_browse.go
@@ -95,10 +95,14 @@ func (v *Visor) browseHomePage(host string) *SkynetHTTPResponse {
 // resolved via the same alias map the dmsgweb/skynetweb resolving proxy uses.
 // The reserved "home" label is handled earlier by browseHomePage (synthetic
 // directory), not here.
-func (v *Visor) resolveBrowseHost(host string, reqPort uint16) (cipher.PubKey, uint16, error) {
+// resolveBrowseHost resolves a browse/coin host to (pk, port, vhost). vhost is
+// the readable name in a "<name>.<pk>.dmsg" form (e.g. "node.skycoin.com"),
+// empty for a bare pk — callers that HTTP-over-dmsg to a vhost-routing backend
+// (Caddy/nginx) MUST send it as the Host header, or the backend can't route.
+func (v *Visor) resolveBrowseHost(host string, reqPort uint16) (cipher.PubKey, uint16, string, error) {
 	host = browseStripHost(host)
 	if host == "" {
-		return cipher.PubKey{}, 0, fmt.Errorf("empty host")
+		return cipher.PubKey{}, 0, "", fmt.Errorf("empty host")
 	}
 	port := uint16(80)
 	if reqPort != 0 {
@@ -124,23 +128,23 @@ func (v *Visor) resolveBrowseHost(host string, reqPort uint16) (cipher.PubKey, u
 	// bare hex PK, optionally with :port (handled above).
 	var pk cipher.PubKey
 	if err := pk.Set(hp); err == nil {
-		return pk, port, nil
+		return pk, port, "", nil
 	}
-	// alias.dmsg / <pk>.dmsg / alias.skynet
+	// alias.dmsg / <pk>.dmsg / <name>.<pk>.dmsg / alias.skynet
 	aliases := v.browseAliases()
 	for _, suffix := range []string{".dmsg", ".skynet"} {
 		if strings.HasSuffix(lower, suffix) {
-			_, _, dest, p, err := skynetweb.ParseResolverHost(host, suffix, aliases)
+			vhost, _, dest, p, err := skynetweb.ParseResolverHost(host, suffix, aliases)
 			if err != nil {
-				return cipher.PubKey{}, 0, err
+				return cipher.PubKey{}, 0, "", err
 			}
 			if reqPort == 0 && p != 0 {
 				port = p
 			}
-			return dest, port, nil
+			return dest, port, vhost, nil
 		}
 	}
-	return cipher.PubKey{}, 0, fmt.Errorf("cannot resolve %q (use a pk, <pk>.dmsg, or alias.dmsg)", host)
+	return cipher.PubKey{}, 0, "", fmt.Errorf("cannot resolve %q (use a pk, <pk>.dmsg, or alias.dmsg)", host)
 }
 
 // BrowseFetch performs the request over skynet and/or dmsg per Scheme, returning
@@ -151,7 +155,7 @@ func (v *Visor) BrowseFetch(req BrowseFetchRequest) (*SkynetHTTPResponse, error)
 	if resp := v.browseHomePage(req.Host); resp != nil {
 		return resp, nil
 	}
-	pk, port, err := v.resolveBrowseHost(req.Host, req.Port)
+	pk, port, _, err := v.resolveBrowseHost(req.Host, req.Port)
 	if err != nil {
 		return nil, fmt.Errorf("resolve %q: %w", req.Host, err)
 	}

--- a/pkg/visor/api_dmsg.go
+++ b/pkg/visor/api_dmsg.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/app/appnet"
@@ -760,9 +761,16 @@ func (v *Visor) DmsgHTTP(req DmsgHTTPRequest) (*DmsgHTTPResponse, error) {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// Set headers
-	for k, v := range req.Header {
-		httpReq.Header.Set(k, v)
+	// Set headers. A "Host" header is special: Go sends req.Host (not a header)
+	// as the on-wire Host, and the transport dials req.URL.Host (the dmsg pk:port),
+	// so put the caller's vhost on req.Host — it reaches the backend as the Host
+	// header (for Caddy/nginx vhost routing) without affecting which pk we dial.
+	for k, val := range req.Header {
+		if strings.EqualFold(k, "Host") {
+			httpReq.Host = val
+			continue
+		}
+		httpReq.Header.Set(k, val)
 	}
 
 	// Perform request
@@ -802,8 +810,10 @@ type dmsgHTTPTransport struct {
 }
 
 func (t *dmsgHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Dial from the URL host (the dmsg pk:port), NOT req.Host — a caller may set
+	// req.Host to a vhost name (Caddy/nginx routing) that isn't a dmsg address.
 	var hostAddr dmsg.Addr
-	if err := hostAddr.Set(req.Host); err != nil {
+	if err := hostAddr.Set(req.URL.Host); err != nil {
 		return nil, fmt.Errorf("invalid host address: %w", err)
 	}
 	if hostAddr.Port == 0 {

--- a/pkg/visor/hypervisor_handlers_wallet.go
+++ b/pkg/visor/hypervisor_handlers_wallet.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 
 	"github.com/skycoin/skywire/pkg/btcgateway"
 	"github.com/skycoin/skywire/pkg/wasmhv/browseui"
@@ -68,14 +69,18 @@ func (hv *Hypervisor) nativeBtcGateway(exitPK string) *btcgateway.Gateway {
 	return g
 }
 
-// walletNodeDmsg is the skycoin node the HV-served wallet talks to by DEFAULT:
-// the deployment node addressed over dmsg (same PK:port as
-// services-config.json prod.skycoin_node_dmsg and the wasm wallet's
-// defaultCoinNode). Overridden per-request by the X-Skywire-Coin-Node header
-// (set from localStorage['skywire-coin-node'] by the injected shim — the
-// wallet tab's Node config panel writes that key). TODO(config): also source
-// the default from config + support multiple nodes (multi-coin /coin/N).
-const walletNodeDmsg = "dmsg://039a6d1e3c237f5f05b78ec19e9f31a007f84835d7ef1e812876102281d1db74c1:6420"
+// walletNodeDefault is the skycoin node the HV-served wallet talks to by DEFAULT,
+// sourced from the embedded services-config.json (prod.skycoin_node_dmsg) — the
+// same value the wasm wallet's coinNodeDefault() uses. Overridden per-request by
+// the X-Skywire-Coin-Node header (from localStorage['skywire-coin-node'], set by
+// the wallet config panel). Falls back to the node.skycoin.com vhost form if the
+// deployment config field is empty. TODO(config): multi-coin /coin/N.
+func walletNodeDefault() string {
+	if n := strings.TrimSpace(dmsg.Prod.SkycoinNode); n != "" {
+		return n
+	}
+	return "https://node.skycoin.com.aong2hr4en7v6bnxr3az5hzruad7qsbv27xr5ajioyicfaor3n2mc.dmsg"
+}
 
 // walletNodeShim is injected into the HV-served wallet index (right after
 // <base>). The skycoin-web GUI fetches the node API at absolute /api/v1|v2
@@ -191,7 +196,7 @@ func (hv *Hypervisor) walletNodeProxy(w http.ResponseWriter, r *http.Request, re
 	}
 	backend := strings.TrimSpace(r.Header.Get("X-Skywire-Coin-Node"))
 	if backend == "" {
-		backend = walletNodeDmsg
+		backend = walletNodeDefault()
 	}
 	path := "/" + rest
 	if r.URL.RawQuery != "" {
@@ -238,10 +243,17 @@ func (hv *Hypervisor) walletNodeProxy(w http.ResponseWriter, r *http.Request, re
 	// fetch step: BrowseFetch dials over the secondary dmsg client (v.dmsgHTTP /
 	// dmsgDC), which has session conflicts on the coin node (see Visor.DmsgHTTP);
 	// v.dmsgC (DmsgHTTP) has stable sessions.
-	pk, port, rerr := hv.visor.resolveBrowseHost(walletBackendStrip(backend), 0)
+	pk, port, vhost, rerr := hv.visor.resolveBrowseHost(walletBackendStrip(backend), 0)
 	if rerr != nil {
 		http.Error(w, "coin node resolve failed: "+rerr.Error(), http.StatusBadGateway)
 		return
+	}
+	// A "<name>.<pk>.dmsg" backend (e.g. node.skycoin.com.<pk>.dmsg) resolves to a
+	// vhost; send it as Host so the destination visor's port-80 forward (Caddy,
+	// --preserve-host) vhost-routes /api to the skycoin node — the same Host the
+	// wasm wallet's fetchDmsg sets, and what clearnet uses.
+	if vhost != "" {
+		header["Host"] = vhost
 	}
 	resp, err := hv.visor.DmsgHTTP(DmsgHTTPRequest{
 		URL:    fmt.Sprintf("dmsg://%s:%d%s", pk.Hex(), port, path),


### PR DESCRIPTION
The HV-served wallet's default coin node was hardcoded. Source it from the embedded `services-config.json` (`prod.skycoin_node_dmsg`) instead, and make that value the resolver **vhost form** `https://node.skycoin.com.<base32-pk>.dmsg` so the wallet reaches the node over the mesh exactly like clearnet — through the node's visor port-80 forward (Caddy, `--preserve-host`) — instead of a bare `dmsg://<pk>:6420`.

- `pkg/dmsg/dmsg`: add `SkycoinNode` (`json:"skycoin_node_dmsg"`) to `DmsghttpConfig` → `dmsg.Prod.SkycoinNode` is populated from the embedded config (native `go:embed` + standard-Go wasm; tinygo bundle unaffected).
- `serve.go` / `hypervisor_handlers_wallet.go`: `coinNodeDefault()`/`walletNodeDefault()` read `dmsg.Prod.SkycoinNode` (const→func), fall back to the node.skycoin.com vhost.
- `DmsgHTTP`: a `Host` header now sets `req.Host` (Go's on-wire Host) while the transport dials `req.URL.Host` (the dmsg pk:port) — so a vhost name reaches the backend as Host without changing which pk we dial.
- `resolveBrowseHost` now also returns the vhost; `walletNodeProxy` sends it as `Host` so Caddy/nginx vhost-routes `/api` (parity with the wasm wallet's `fetchDmsg`).

Operational: the node.skycoin.com host's port-80 forward was set `--preserve-host` + `--proxy-addr 127.0.0.1:80` (matching the working magnetosphere host) so `<vhost>.<pk>.dmsg` reaches Caddy with the real Host.

**Verified live** on native + wasm: default resolves to the node (blockchain seq 195245), balance renders, no "Syncing blocks".

🤖 Generated with [Claude Code](https://claude.com/claude-code)