### PR TITLE
fix(tpd): stop double-counting network/visor bandwidth aggregates

### DIFF
--- a/pkg/transport-discovery/store/redis_bandwidth.go
+++ b/pkg/transport-discovery/store/redis_bandwidth.go
@@ -122,6 +122,11 @@ func (s *redisStore) UpdateBandwidth(ctx context.Context, transportID string,
 		pipe.Expire(ctx, s.visorAllKey(), 400*24*time.Hour)
 
 		vDaily := s.visorBandwidthDailyKey(reporterHex, now)
+		// Keep sent/recv separate so the per-visor directional split is real
+		// rather than a fabricated bw/2 (this reporter's transports; not
+		// double-counted since only the reporter writes its own visor key).
+		pipe.HIncrBy(ctx, vDaily, "sent", int64(deltaSent))  //nolint:gosec
+		pipe.HIncrBy(ctx, vDaily, "recv", int64(deltaRecv))  //nolint:gosec
 		pipe.HIncrBy(ctx, vDaily, "bandwidth", int64(delta)) //nolint:gosec
 		pipe.HSet(ctx, vDaily, "updated_at", now.Unix())
 		pipe.Expire(ctx, vDaily, 35*24*time.Hour)
@@ -263,10 +268,7 @@ func (s *redisStore) GetVisorBandwidth(ctx context.Context, pk cipher.PubKey,
 		if err != nil || len(result) == 0 {
 			continue
 		}
-		var bw uint64
-		if val, ok := result["bandwidth"]; ok {
-			fmt.Sscanf(val, "%d", &bw) //nolint:errcheck,gosec
-		}
+		bw := transportDailyBandwidth(result)
 		if bw == 0 {
 			continue
 		}

--- a/pkg/transport-discovery/store/redis_metrics.go
+++ b/pkg/transport-discovery/store/redis_metrics.go
@@ -16,6 +16,52 @@ import (
 	"github.com/skycoin/skywire/pkg/transport"
 )
 
+// transportDailyBandwidth returns a transport's true daily throughput in
+// bytes (both directions) from its daily bandwidth hash.
+//
+// Each edge of a transport reports the FULL transport throughput
+// independently — a managed transport counts both the bytes it sends and
+// the bytes it receives (pkg/transport/managed_transport.go logSent/logRecv).
+// So edge A's (sent+recv) ≈ edge B's (sent+recv) ≈ the real bytes that
+// crossed the wire. Summing both reporters (as the legacy combined
+// "bandwidth" field does) double-counts. We instead take the MAX across
+// reporters of (sent+recv): exact for a single-reporter transport, and the
+// most-complete single observation when both edges report. Falls back to the
+// legacy combined field only for old redis data lacking per-reporter fields.
+func transportDailyBandwidth(result map[string]string) uint64 {
+	perReporter := make(map[string]uint64)
+	for k, v := range result {
+		var suffix string
+		switch {
+		case strings.HasSuffix(k, ":sent"):
+			suffix = ":sent"
+		case strings.HasSuffix(k, ":recv"):
+			suffix = ":recv"
+		default:
+			continue
+		}
+		var n uint64
+		fmt.Sscanf(v, "%d", &n) //nolint:errcheck,gosec
+		perReporter[strings.TrimSuffix(k, suffix)] += n
+	}
+	if len(perReporter) > 0 {
+		var best uint64
+		for _, total := range perReporter {
+			if total > best {
+				best = total
+			}
+		}
+		return best
+	}
+	// Legacy fallback: the combined field may double-count two-edge
+	// transports written before per-reporter accounting existed.
+	var bw uint64
+	if val, ok := result["bandwidth"]; ok {
+		fmt.Sscanf(val, "%d", &bw) //nolint:errcheck,gosec
+	}
+	return bw
+}
+
 // getP2PTransportCounts returns a map of visor PK hex → count of p2p transports
 // (stcpr, sudph). A visor is considered online when it has 2+ p2p transports,
 // indicating genuine peer-to-peer network participation (not just dmsg
@@ -75,11 +121,9 @@ func (s *redisStore) getBandwidthFromHash(ctx context.Context, key, transportID,
 		PeriodKey:   periodKey,
 	}
 
-	if val, ok := result["bandwidth"]; ok {
-		if _, err := fmt.Sscanf(val, "%d", &agg.Bandwidth); err != nil {
-			return BandwidthAggregation{}, fmt.Errorf("failed to parse bandwidth value %q: %w", val, err)
-		}
-	}
+	// De-double-counted total: both edges report the full throughput, so
+	// take the max across reporters rather than the summed combined field.
+	agg.Bandwidth = transportDailyBandwidth(result)
 	if val, ok := result["updated_at"]; ok {
 		if _, err := fmt.Sscanf(val, "%d", &agg.UpdatedAt); err != nil {
 			return BandwidthAggregation{}, fmt.Errorf("failed to parse updated_at value %q: %w", val, err)
@@ -159,10 +203,7 @@ func (s *redisStore) GetNetworkMetrics(ctx context.Context, query MetricsQuery) 
 			continue
 		}
 
-		var bw uint64
-		if val, ok := result["bandwidth"]; ok {
-			fmt.Sscanf(val, "%d", &bw) //nolint:errcheck,gosec
-		}
+		bw := transportDailyBandwidth(result)
 		if bw == 0 {
 			continue
 		}
@@ -298,18 +339,28 @@ func (s *redisStore) GetVisorAggregateMetrics(ctx context.Context, pks []cipher.
 				dailyAgg.Date = bwCmds[d].dateStr
 				bwResult, err := bwCmds[d].cmd.Result()
 				if err == nil && len(bwResult) > 0 {
-					var bw uint64
+					var bw, sent, recv uint64
 					if val, ok := bwResult["bandwidth"]; ok {
 						fmt.Sscanf(val, "%d", &bw) //nolint:errcheck,gosec
 					}
-					if bw > 0 {
+					if val, ok := bwResult["sent"]; ok {
+						fmt.Sscanf(val, "%d", &sent) //nolint:errcheck,gosec
+					}
+					if val, ok := bwResult["recv"]; ok {
+						fmt.Sscanf(val, "%d", &recv) //nolint:errcheck,gosec
+					}
+					// Legacy rows have only the combined field; split evenly.
+					if sent == 0 && recv == 0 && bw > 0 {
+						sent, recv = bw/2, bw/2
+					}
+					if total := sent + recv; total > 0 {
 						dailyAgg.Bandwidth = &VisorBandwidthAggregate{
-							Sent:  bw / 2,
-							Recv:  bw / 2,
-							Total: bw,
+							Sent:  sent,
+							Recv:  recv,
+							Total: total,
 						}
-						totalSent += bw / 2
-						totalRecv += bw / 2
+						totalSent += sent
+						totalRecv += recv
 					}
 				}
 			} else {

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -63,10 +63,12 @@ func (le *LogEntry) AddSent(n uint64) {
 	atomic.AddUint64(le.SentBytes, n)
 }
 
-// Reset resets LogEntry.
+// Reset resets LogEntry. Uses atomic stores rather than subtracting a
+// non-atomically-read current value, which could race with a concurrent
+// AddSent/AddRecv and under/over-shoot (or wrap uint64).
 func (le *LogEntry) Reset() {
-	atomic.AddUint64(le.SentBytes, -*le.SentBytes)
-	atomic.AddUint64(le.RecvBytes, -*le.RecvBytes)
+	atomic.StoreUint64(le.SentBytes, 0)
+	atomic.StoreUint64(le.RecvBytes, 0)
 }
 
 // MarshalJSON implements json.Marshaller


### PR DESCRIPTION
## Audit result

While auditing the transport bandwidth/metrics pipeline for correctness, the rolled-up aggregates were found to **inflate throughput ~2×**.

Each edge of a transport reports the **full** transport throughput independently — a managed transport counts both the bytes it sends *and* the bytes it receives (`pkg/transport/managed_transport.go` `logSent`/`logRecv`). So edge A's `(sent+recv)` ≈ edge B's `(sent+recv)` ≈ the real bytes that crossed the wire. The per-transport daily redis hash keeps correct **per-reporter** fields (`<pk>:sent` / `<pk>:recv`) **and** a legacy combined `"bandwidth"` field that `HIncrBy`'s *both* reporters' deltas — so the combined field is ~2× for any transport whose two edges both report.

The per-transport `/metrics` view was already correct (it reads the per-edge fields). But every **rolled-up total** read the combined field:

| Reader | Surface | Was |
|---|---|---|
| `GetNetworkMetrics` | dashboard network total + per-type | 2× |
| `GetVisorBandwidth` | sum of combined field over a visor's transports | 2× |
| `getBandwidthFromHash` (`GetTransportBandwidth`) | single-transport daily total | 2× |

## Fix

- Add `transportDailyBandwidth(result)`: a transport's true daily throughput = **max across reporters of `(sent+recv)`** from the per-edge fields — exact for a single-reporter transport, ~correct when both edges report — falling back to the combined field only for legacy rows without per-reporter fields. Route all three rolled-up readers through it.
- **Per-visor sent/recv split**: `GetVisorAggregateMetrics` reported `Sent = Recv = bandwidth/2` (fabricated 50/50, wrong for any asymmetric egress/ingress workload like a skysocks exit). The per-visor total was never double-counted (only the reporter writes its own visor key), so now store `deltaSent`/`deltaRecv` as real `sent`/`recv` fields on the visor daily key and read them back; keep the `bw/2` fallback only for legacy rows.
- `LogEntry.Reset()` now uses `atomic.StoreUint64(_, 0)` instead of `atomic.AddUint64(_, -*p)` (racy non-atomic read of the current value). Dead code today, but correct.

## Rollout

Read-side fixes correct **existing** redis data immediately (per-edge fields already exist). The per-visor `sent`/`recv` split takes effect for data written after the TPD redeploys.

Build + `golangci-lint` (0 issues) + `go test ./pkg/transport-discovery/store/ ./pkg/transport/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)