### PR TITLE
fix(tpd): subscribe to a visor feed on connect, not on the 30s poll

### DIFF
--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -175,6 +175,12 @@ type Aggregator struct {
 	mu     sync.Mutex
 	cancel context.CancelFunc
 	done   chan struct{}
+
+	// nudge triggers an immediate reconcile out of band from the
+	// ReconcileInterval ticker. Buffered(1) so bursts of connects
+	// coalesce into a single pending reconcile (which is idempotent
+	// and walks the full conn set anyway).
+	nudge chan struct{}
 }
 
 // New constructs an Aggregator. Sets up a CXO Node, enables DMSG so
@@ -229,6 +235,24 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 		conf:    conf,
 		log:     conf.Logger,
 		done:    make(chan struct{}),
+		nudge:   make(chan struct{}, 1),
+	}
+	// Subscribe to a visor's feed the moment it dials in, rather than
+	// waiting up to ReconcileInterval (30s) for the next poll. A fresh
+	// visor (notably a browser wasm-visor) that AnnounceTo's the TPD and
+	// then registers a transport is otherwise invisible to the shared
+	// redis edge-index — and thus to the route-finder — for up to a full
+	// reconcile period, so `route find <fresh-visor> <exit>` 404s
+	// ("transport not found") until the poll catches up. The conn's
+	// handshake completes (peerID set) before OnConnect fires, so the
+	// nudged reconcile can subscribe immediately; it stays idempotent via
+	// alreadySubscribed, and the periodic ticker remains the safety net.
+	cxoNode.Config().OnConnect = func(_ *node.Conn) error {
+		select {
+		case a.nudge <- struct{}{}:
+		default:
+		}
+		return nil
 	}
 	// Wire all three Root-lifecycle callbacks. Together they make the
 	// CXO replication chain observable from tpd's logs:
@@ -310,6 +334,10 @@ func (a *Aggregator) loop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
+			a.reconcile()
+		case <-a.nudge:
+			// A visor just connected (OnConnect). Subscribe now instead
+			// of waiting for the next tick. reconcile() is idempotent.
 			a.reconcile()
 		}
 	}


### PR DESCRIPTION
## The bug (wasm-routing blocker)

`skywire cli route find <fresh-visor> <exit>` returns **404 "transport not found"** for a just-booted visor (notably a browser wasm-visor) even though `cli tp disc --pk <visor>` shows the transport registered — until the visor "warms up," after which it works.

## Diagnosis

- The **route-finder shares the TPD's redis** (`pkg/route-finder` imports `pkg/transport-discovery/store`; the RF service doc says *"shares Redis with TPD"*). There is no second store and no cross-DB sync — so this is **not** an RF-vs-TPD replication lag.
- `NewGraphWithDepth` → `GetTransportsByEdge(src)` returns `ErrTransportNotFound` → **404** when the **source** PK's redis edge-set (`SMEMBERS edge:<pk>`) is empty. Negative results are **not** cached, so the RF self-heals the instant redis is populated.
- So the only lag is: **how long until a fresh visor's transport lands in the shared edge-index.**

That index is populated by the **cxoaggregator**: the visor `AnnounceTo`s the TPD (dials its CXO node), the aggregator's reconcile loop subscribes to the conn's feed, and `OnRootFilled` walks the published transport-list snapshot into redis (`SADD edge:<pk>`). But `reconcile()` only ran on a **30s `ReconcileInterval` ticker** — a freshly-connected visor's feed wasn't subscribed for up to 30s, so its transport (published ~5s after `SaveTransport`) wasn't ingested, and the RF 404'd for up to ~30–60s after boot.

## Fix

Wire the CXO node's `OnConnect` callback to nudge an **immediate** reconcile. The conn's handshake completes (`peerID` set, `node.go:513`) *before* `OnConnect` fires (`conn.go:138`), so the nudged reconcile can subscribe right away. It stays idempotent via `alreadySubscribed`, bursts of connects coalesce through a buffered(1) channel, and the periodic ticker remains the safety net. Subscribing at connect (before the visor publishes its root) also closes the window where the initial root push could be missed.

## Rollout

TPD deployment-service change — takes effect after the TPD redeploys. Build + `golangci-lint` (0 issues) + `go test ./pkg/transport-discovery/cxoaggregator/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)