### PR TITLE
feat(wallet): shim honors skycoin-web's Nodes-GUI node selection

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -112,7 +112,16 @@ func walletDmsgFetchShim() string {
 		// resolving proxy (fetchDmsg). A clearnet http(s):// node (not .dmsg) goes
 		// through skysocks-client-lite (fetchClearnet) via the SAME upstream-proxy
 		// exit the browser uses (skywire-upstream-proxy) — IP-anonymous.
-		`var node=ls("skywire-coin-node")||"` + coinNodeDefault() + `";` +
+		//
+		// The node is whatever skycoin-web ADDRESSED the request to: its Settings →
+		// Nodes page (customNodeUrls) makes the fetch URL absolute, so that page is
+		// the authoritative source for node selection and the shim HONORS it. A
+		// relative/same-origin /api path means the coin is on its default; then fall
+		// back to the legacy wallet-config-panel key (skywire-coin-node), else the
+		// deployment mesh node. (Enter a mesh node in Settings → Nodes as
+		// http://<host>.dmsg to route it over dmsg.)
+		`var _u;try{_u=new URL(url,location.href);}catch(e){_u=null;}` +
+		`var node=(_u&&_u.host&&_u.host!==location.host)?(_u.protocol+"//"+_u.host):(ls("skywire-coin-node")||"` + coinNodeDefault() + `");` +
 		`var ct=ctOf(input,init),hdrs=ct?{"Content-Type":ct}:null;` +
 		`if(/^https?:\/\//i.test(node)&&!/\.dmsg\b/i.test(node)){` +
 		`if(!v.fetchClearnet)return Promise.resolve(jr(503,{error:"skysocks clearnet gateway not available"}));` +

--- a/pkg/visor/hypervisor_handlers_wallet.go
+++ b/pkg/visor/hypervisor_handlers_wallet.go
@@ -103,14 +103,23 @@ const walletNodeShim = `<script>(function(){` +
 	`window.fetch=function(input,init){` +
 	`var url=(typeof input==="string")?input:(input&&input.url)||"";` +
 	`var p=pathOf(url);` +
+	`function searchOf(u){try{return new URL(u,location.href).search;}catch(e){return "";}}` +
+	`function hostOf(u){try{var x=new URL(u,location.href);return (x.host&&x.host!==location.host)?(x.protocol+"//"+x.host):"";}catch(e){return "";}}` +
 	`var mn=/^\/(wallet\/)?api\/v[12]\//.exec(p);` +
 	`var mb=/^\/(wallet\/)?v1\/btc\//.exec(p);` +
 	`if(!mn&&!mb){return rf(input,init);}` +
 	`var pre=(mn&&mn[1])||(mb&&mb[1]);` +
-	`var target=pre?url:url.replace(p,"/wallet"+p);` +
+	// Always route to this handler same-origin. skycoin-web addresses a custom
+	// node (Settings → Nodes / customNodeUrls) with an ABSOLUTE url — strip the
+	// host, keep the /api path + query, and re-point at /wallet/api here; the
+	// chosen node travels in X-Skywire-Coin-Node so walletNodeProxy dials it.
+	`var target=pre?url:(location.origin+"/wallet"+p+searchOf(url));` +
 	`init=init||{};` +
 	`var h=new Headers((init&&init.headers)||(typeof input!=="string"&&input&&input.headers)||undefined);` +
-	`if(mn){var n=ls("skywire-coin-node");if(n){h.set("X-Skywire-Coin-Node",n);}}` +
+	// Node = whatever skycoin-web addressed (its Nodes GUI is authoritative);
+	// a same-origin/relative /api path falls back to the legacy config-panel key,
+	// else walletNodeProxy uses the deployment mesh default.
+	`if(mn){var nn=hostOf(url)||ls("skywire-coin-node");if(nn){h.set("X-Skywire-Coin-Node",nn);}}` +
 	`else{var b=ls("skywire-btc-backend");if(b){h.set("X-Skywire-Btc-Backend",b);}` +
 	`var xp=ls("skywire-btc-proxy");if(xp){h.set("X-Skywire-Btc-Proxy",xp);}}` +
 	`init.headers=h;return rf(target,init);` +


### PR DESCRIPTION
Converges node selection onto skycoin-web's own **Settings → Nodes** page as the authoritative source, instead of the shim overriding every `/api` call with a parallel skywire-side key (`skywire-coin-node`) that silently made skycoin-web's Nodes page a no-op. Pairs with **skycoin/skycoin#2939** (health probe follows the same effective node + Nodes-page help).

## Change
Both wallet fetch shims (`hv serve` + native HV) now take the coin node from the URL **skycoin-web addressed the request to** — its Nodes page (`customNodeUrls`) makes the fetch URL absolute, so the shim reads that host and routes to it (dmsg for a `.dmsg` host, skysocks for clearnet). A relative/same-origin `/api` path (coin on its default) **falls back** to the legacy config-panel key, else the deployment mesh node — so the existing wallet-config panel keeps working as a fallback and nothing breaks.

The native shim also rewrites an absolute custom-node URL to same-origin `/wallet/api` (preserving path + query) so it still lands on `walletNodeProxy`, with the chosen node carried in `X-Skywire-Coin-Node`.

**Usage:** enter a mesh node in the wallet's **Settings → Nodes** as `http://<host>.dmsg` to route it over dmsg.

Built + `golangci-lint` (0 issues); rebuilt `hv serve` and verified the injected shim JS (`node --check` valid, node-derivation present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)