### PR TITLE
fix(hv-serve): /wasm-version fingerprints the whole build, not just the wasm blob

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/visor"
 	"github.com/skycoin/skywire/pkg/wasmhv"
@@ -179,11 +180,17 @@ page never asks anyone to type a secret key.`,
 			cmd.PrintErrln("read index.html:", err)
 			os.Exit(1)
 		}
-		// wasmVer fingerprints the embedded wasm so the page can detect a newer
-		// build (after the skywire binary updates) and self-reload — see
-		// autoupdate.js. Short SHA-256 prefix is plenty to spot a content change.
-		sum := sha256.Sum256(wasm)
-		wasmVer := hex.EncodeToString(sum[:])[:16]
+		// wasmVer fingerprints the WHOLE served build so the page detects ANY newer
+		// deploy and self-reloads (see autoupdate.js): the wasm blob, the Angular
+		// index (it references the content-hashed UI bundle, so a UI-only change
+		// moves it), AND the binary build version (so a plain version bump moves it
+		// even when the wasm blob is byte-identical — the case that left connected
+		// tabs stuck on an old build: /wasm-version used to hash only the wasm).
+		vh := sha256.New()
+		vh.Write(wasm)
+		vh.Write(indexB)
+		vh.Write([]byte(buildinfo.Version()))
+		wasmVer := hex.EncodeToString(vh.Sum(nil))[:16]
 		index := injectBoot(indexB, wasmVer, serveHarness)
 
 		mux := http.NewServeMux()


### PR DESCRIPTION
`autoupdate.js` polls `/wasm-version` to detect a new build. It hashed **only the wasm blob**, so UI-only / serve-only / plain version-bump deploys (wasm blob byte-identical) never moved it — connected tabs stayed on the old build even though the server was already serving the new one (observed live: theskywirenetwork.net stuck builds behind while its `hv serve` unit was actually current). Now the fingerprint = sha256(wasm blob + Angular index + `buildinfo.Version()`), so **any** deploy moves it. Pairs with #3482 (reliable SharedWorker reload). Built + lint clean; verified the served `/wasm-version` changes across builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)