### PR TITLE
fix(wallet): route skycoin-web's /api/v1/btc/* to the BTC gateway, not the node

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -75,7 +75,13 @@ func walletDmsgFetchShim() string {
 		`function p(u){try{return new URL(u,location.href).pathname;}catch(e){return String(u);}}` +
 		`function q(u){try{return new URL(u,location.href).search;}catch(e){return "";}}` +
 		`function isCoin(u){return /^\/api\/v[12]\//.test(p(u));}` +
-		`function isBtc(u){return /^\/(wallet\/)?v1\/btc\//.test(p(u));}` +
+		// BTC is any path containing /v1/btc/ — this catches BOTH the raw
+		// /v1/btc/health (node-health probe) AND skycoin-web's apiService form
+		// /api/v1/btc/{balance,history,send} (which also matches isCoin, but the
+		// BTC branch is checked first). No skycoin node endpoint contains
+		// /v1/btc/, and the gateway normalizes on that substring, so passing the
+		// full path through to btcFetch works either way.
+		`function isBtc(u){return /\/v1\/btc\//.test(p(u));}` +
 		`function ls(k){try{return localStorage.getItem(k)||"";}catch(e){return "";}}` +
 		// The wallet POSTs balance/transactions as x-www-form-urlencoded; forward the
 		// request Content-Type so fetchDmsg/fetchClearnet don't mislabel the body as

--- a/pkg/visor/hypervisor_handlers_wallet.go
+++ b/pkg/visor/hypervisor_handlers_wallet.go
@@ -105,23 +105,33 @@ const walletNodeShim = `<script>(function(){` +
 	`var p=pathOf(url);` +
 	`function searchOf(u){try{return new URL(u,location.href).search;}catch(e){return "";}}` +
 	`function hostOf(u){try{var x=new URL(u,location.href);return (x.host&&x.host!==location.host)?(x.protocol+"//"+x.host):"";}catch(e){return "";}}` +
-	`var mn=/^\/(wallet\/)?api\/v[12]\//.exec(p);` +
-	`var mb=/^\/(wallet\/)?v1\/btc\//.exec(p);` +
+	// BTC = any path containing /v1/btc/ — the raw /v1/btc/health probe AND
+	// skycoin-web's apiService form /api/v1/btc/{balance,history,send} (which
+	// also matches the node regex, so BTC is classified FIRST and wins). No
+	// skycoin node endpoint contains /v1/btc/.
+	`var mb=/\/v1\/btc\//.test(p);` +
+	`var mn=!mb&&/^\/(wallet\/)?api\/v[12]\//.test(p);` +
 	`if(!mn&&!mb){return rf(input,init);}` +
-	`var pre=(mn&&mn[1])||(mb&&mb[1]);` +
-	// Always route to this handler same-origin. skycoin-web addresses a custom
-	// node (Settings → Nodes / customNodeUrls) with an ABSOLUTE url — strip the
-	// host, keep the /api path + query, and re-point at /wallet/api here; the
-	// chosen node travels in X-Skywire-Coin-Node so walletNodeProxy dials it.
-	`var target=pre?url:(location.origin+"/wallet"+p+searchOf(url));` +
 	`init=init||{};` +
 	`var h=new Headers((init&&init.headers)||(typeof input!=="string"&&input&&input.headers)||undefined);` +
-	// Node = whatever skycoin-web addressed (its Nodes GUI is authoritative);
-	// a same-origin/relative /api path falls back to the legacy config-panel key,
-	// else walletNodeProxy uses the deployment mesh default.
-	`if(mn){var nn=hostOf(url)||ls("skywire-coin-node");if(nn){h.set("X-Skywire-Coin-Node",nn);}}` +
-	`else{var b=ls("skywire-btc-backend");if(b){h.set("X-Skywire-Btc-Backend",b);}` +
-	`var xp=ls("skywire-btc-proxy");if(xp){h.set("X-Skywire-Btc-Proxy",xp);}}` +
+	`var target;` +
+	`if(mb){` +
+	// Normalize any /v1/btc/ path (bare or /api/v1/btc/) to /wallet/v1/btc/… so
+	// the server routes it to the in-process electrum gateway, not the node.
+	`var tail=p.slice(p.indexOf("/v1/btc/"));target=location.origin+"/wallet"+tail+searchOf(url);` +
+	`var b=ls("skywire-btc-backend");if(b){h.set("X-Skywire-Btc-Backend",b);}` +
+	`var xp=ls("skywire-btc-proxy");if(xp){h.set("X-Skywire-Btc-Proxy",xp);}` +
+	`}else{` +
+	// Node API: skycoin-web addresses a custom node (Settings → Nodes /
+	// customNodeUrls) with an ABSOLUTE url — strip the host, keep the /api path +
+	// query, and re-point at /wallet/api here; the chosen node travels in
+	// X-Skywire-Coin-Node so walletNodeProxy dials it (its Nodes GUI is
+	// authoritative; a same-origin/relative /api path falls back to the legacy
+	// config-panel key, else the deployment mesh default).
+	`var mnx=/^\/(wallet\/)?api\/v[12]\//.exec(p);var pre=mnx&&mnx[1];` +
+	`target=pre?url:(location.origin+"/wallet"+p+searchOf(url));` +
+	`var nn=hostOf(url)||ls("skywire-coin-node");if(nn){h.set("X-Skywire-Coin-Node",nn);}` +
+	`}` +
 	`init.headers=h;return rf(target,init);` +
 	`};})();</script>`
 


### PR DESCRIPTION
## Problem

BTC **balance / history / send** were broken in the browser wallet (both the wasm `hv serve` path and the native HV `/wallet/` mount). Only the node-health strip worked.

skycoin-web fetches the BTC chain API through its `ApiService`: `apiService.get('btc/balance')` builds `<node>/api/v1/btc/balance` (ApiService prefixes `/api/v1/`). But both wallet fetch shims classified BTC with an **anchored** regex `^/(wallet/)?v1/btc/`, which does **not** match `/api/v1/btc/*`. Those requests fell through to the coin-node branch (`isCoin` = `^/api/v[12]/`) and were dialed at the **skycoin node**, which has no `/api/v1/btc/*` endpoint → error. Health worked only because it uses the raw `/v1/btc/health` path (matched the old regex).

## Fix

Classify BTC as *"path contains `/v1/btc/`"*, checked **before** the node branch (which wins), so it covers both the raw `/v1/btc/*` and the apiService `/api/v1/btc/*` forms. No skycoin node endpoint contains `/v1/btc/`, and the gateway already normalizes on that substring (`strings.Index(path, "/v1/btc/")`), so passing the path through is safe.

- **wasm shim** (`cmd/skywire-cli/commands/hv/serve.go`): widen `isBtc`; the BTC branch already precedes the coin branch, so it just needed to match.
- **native shim** (`pkg/visor/hypervisor_handlers_wallet.go`): classify BTC first, and rewrite the target to `/wallet/v1/btc/…` so the server's existing `HasPrefix(rest,"v1/btc/")` route hands it to the in-process electrum gateway instead of `walletNodeProxy`.

## Validation

Live on the standalone wasm-visor, the exact skycoin-web path now reaches the gateway end-to-end:

```
/api/v1/btc/balance?addrs=1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa
→ 200 {"confirmed":{"coins":5722502938}}   (57.225 BTC, genesis)
```

Before the fix that path was dialed at the coin node. Confirmed both path forms hit the gateway (raw `/v1/btc/health` and apiService `/api/v1/btc/balance`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)