### PR TITLE
fix(concurrency): Add-after-Wait races in skynet.Server + cxo Filler (+ CI test hardening)

### DIFF
--- a/pkg/cxo/skyobject/fill.go
+++ b/pkg/cxo/skyobject/fill.go
@@ -183,7 +183,15 @@ func (f *Filler) requset(key cipher.SHA256) (ok bool) {
 // goroutines the split creates
 func (f *Filler) Close() {
 	f.closeo.Do(func() {
+		// Close closeq under f.mx so it is serialized against the
+		// await.Add in Go. Once closeq is closed, Go no longer adds
+		// new goroutines, so the Wait below observes the final count
+		// and cannot return while a still-to-be-spawned Split escapes
+		// it (the Add-after-Wait leak that let a Split goroutine touch
+		// the filler after Close returned).
+		f.mx.Lock()
 		close(f.closeq)
+		f.mx.Unlock()
 		f.await.Wait()
 	})
 }
@@ -261,7 +269,24 @@ func (f *Filler) Go(fn func()) {
 
 		// parallel
 
+		// Register the goroutine under f.mx so the Add is serialized
+		// against close(f.closeq) in Close. If the filler is already
+		// closing, don't spawn: release the acquired limit slot and
+		// bail, so no goroutine can escape Close's await.Wait and read
+		// the filler after it has been torn down and its memory reused.
+		f.mx.Lock()
+		select {
+		case <-f.closeq:
+			f.mx.Unlock()
+			if f.limit != nil {
+				<-f.limit // release the slot acquire took
+			}
+			return
+		default:
+		}
 		f.await.Add(1)
+		f.mx.Unlock()
+
 		go func() {
 			defer f.await.Done()
 			<-f.limit // release

--- a/pkg/skynet/server.go
+++ b/pkg/skynet/server.go
@@ -24,7 +24,7 @@ type Server struct {
 	mu         sync.RWMutex
 	listener   net.Listener
 	closeCh    chan struct{}
-	closeOnce  sync.Once
+	closed     bool // guarded by mu; gates activeConn.Add against Close's Wait
 	activeConn sync.WaitGroup
 }
 
@@ -41,6 +41,10 @@ func NewServer(log logrus.FieldLogger) *Server {
 // Serve starts the server on the given listener
 func (s *Server) Serve(lis net.Listener) error {
 	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
 	s.listener = lis
 	s.mu.Unlock()
 
@@ -60,7 +64,19 @@ func (s *Server) Serve(lis net.Listener) error {
 			}
 		}
 
+		// Register the connection under mu, gated on !closed, so the Add is
+		// ordered against Close's close(closeCh)+Wait. Without this, an Accept
+		// that returns concurrently with Close could Add to activeConn after
+		// Wait already observed zero — an Add-after-Wait data race.
+		s.mu.Lock()
+		if s.closed {
+			s.mu.Unlock()
+			_ = conn.Close() //nolint:errcheck,gosec
+			return nil
+		}
 		s.activeConn.Add(1)
+		s.mu.Unlock()
+
 		go func(c net.Conn) {
 			defer s.activeConn.Done()
 			s.handleConn(c)
@@ -249,21 +265,26 @@ func (s *Server) Whitelist() []cipher.PubKey {
 	return pks
 }
 
-// Close stops the server
+// Close stops the server. It is idempotent and safe to call concurrently with
+// Serve: setting closed + closing closeCh + closing the listener all happen
+// under mu, so Serve stops registering new connections before Wait runs.
 func (s *Server) Close() error {
-	var err error
-	s.closeOnce.Do(func() {
-		close(s.closeCh)
-
-		s.mu.Lock()
-		if s.listener != nil {
-			if cErr := s.listener.Close(); cErr != nil {
-				err = cErr
-			}
-		}
+	s.mu.Lock()
+	if s.closed {
 		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	close(s.closeCh)
+	var err error
+	if s.listener != nil {
+		if cErr := s.listener.Close(); cErr != nil {
+			err = cErr
+		}
+	}
+	s.mu.Unlock()
 
-		s.activeConn.Wait()
-	})
+	// Wait outside the lock: handleConn takes mu (RLock) while serving.
+	s.activeConn.Wait()
 	return err
 }

--- a/pkg/skynet/server_overlap_test.go
+++ b/pkg/skynet/server_overlap_test.go
@@ -1,0 +1,40 @@
+package skynet
+
+import (
+	"net"
+	"sync"
+	"testing"
+)
+
+// TestServeCloseOverlapRace closes the server with no settling delay so Close's
+// activeConn.Wait races Serve's Accept + activeConn.Add — the interleaving a
+// Windows CI runner hit. Guards against a regression of the Add-after-Wait race
+// (run under -race). The plain settle-then-close path is TestServerServeAndClose.
+func TestServeCloseOverlapRace(t *testing.T) {
+	const iters = 300
+	for i := 0; i < iters; i++ {
+		s := NewServer(testLog())
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		serveErr := make(chan error, 1)
+		go func() { serveErr <- s.Serve(lis) }()
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if c, derr := net.Dial("tcp", lis.Addr().String()); derr == nil {
+				_ = c.Close() //nolint:errcheck
+			}
+		}()
+
+		// No settling delay: Close overlaps Accept + activeConn.Add.
+		if cerr := s.Close(); cerr != nil {
+			t.Fatalf("Close: %v", cerr)
+		}
+		wg.Wait()
+		<-serveErr
+	}
+}

--- a/pkg/skyudpbridge/skyudpbridge_test.go
+++ b/pkg/skyudpbridge/skyudpbridge_test.go
@@ -115,7 +115,7 @@ func TestClientFramesDatagramsOntoStream(t *testing.T) {
 	go func() { done <- RunClient(ctx, cfg, pd, logger) }()
 
 	// Wait briefly for the UDP listen to land.
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	var sender *net.UDPConn
 	for time.Now().Before(deadline) {
 		sender, err = net.DialUDP("udp", nil, bound)
@@ -152,7 +152,7 @@ func TestClientFramesDatagramsOntoStream(t *testing.T) {
 	}
 	defer peerConn.Close() //nolint:errcheck,gosec
 
-	_ = peerConn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck,gosec
+	_ = peerConn.SetReadDeadline(time.Now().Add(10 * time.Second)) //nolint:errcheck,gosec
 	got := make([]byte, MaxFrameSize)
 	n, err := ReadFrame(peerConn, got)
 	if err != nil {
@@ -165,7 +165,9 @@ func TestClientFramesDatagramsOntoStream(t *testing.T) {
 	cancel()
 	select {
 	case <-done:
-	case <-time.After(2 * time.Second):
+	// Shutdown is prompt (closing the UDP socket + flow conns unblocks serveUDP);
+	// the generous wait only guards against a slow/loaded CI runner.
+	case <-time.After(10 * time.Second):
 		t.Fatal("RunClient did not exit after cancel")
 	}
 }

--- a/pkg/transport/network/ws_native_test.go
+++ b/pkg/transport/network/ws_native_test.go
@@ -75,7 +75,9 @@ func TestWSCarrier_RoundTrip(t *testing.T) {
 }
 
 func readFull(c net.Conn, b []byte) error {
-	if err := c.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+	// Generous deadline (matches the sibling WS/dmsg round-trip tests) so a
+	// slow/loaded CI runner doesn't flake mid-handshake.
+	if err := c.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
 		return err
 	}
 	_, err := io.ReadFull(c, b)


### PR DESCRIPTION
Extracts the **general, non-exchange** fixes from #3434 so they can land + be reviewed on their own (the exchange engine itself is a separate discussion — see my comment on #3434).

## Concurrency fixes (two Add-after-Wait races, same shape)

- **`pkg/skynet/server.go`** — `Serve()`'s `activeConn.Add(1)` for a freshly `Accept`ed connection could run concurrently with `Close()`'s `close(closeCh)` + `activeConn.Wait()`. That's an Add-after-Wait on the `WaitGroup` (a data race / potential panic, and a connection that escapes graceful shutdown). Fix: register the connection under `mu`, gated on a `closed` flag that `Close` sets — together with `close(closeCh)` + `listener.Close()` — under the same `mu`, so `Serve` stops registering before `Wait` runs. `Wait` moves outside the lock (handleConn `RLock`s while serving). New `server_overlap_test.go` exercises the Serve/Close overlap.
- **`pkg/cxo/skyobject/fill.go`** — `Filler.Go()`'s `await.Add(1)` could likewise escape `Close()`'s `close(closeq)` + `await.Wait()`, letting a `Split` goroutine touch the filler after `Close` returned (use-after-teardown). Fix: serialize the `Add` under `f.mx` against the `closeq` close; if already closing, release the acquired limit slot and bail.

Both packages pass `go test -race`.

## Test hardening
`pkg/skyudpbridge` + `pkg/transport/network/ws_native` — bump too-tight (2–3s) read/shutdown deadlines to 10s so slow CI runners don't flake. No production change.

## Attribution
These originate in @mrpalide's exchange PR (#3434); pulling them out so the reliability fixes aren't gated on that larger review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)