### PR TITLE
fix(dmsg): bound entry-registration retry + coalesce session-churn re-registration (discovery/TPD load)

### DIFF
--- a/pkg/dmsg/disc/client.go
+++ b/pkg/dmsg/disc/client.go
@@ -240,7 +240,15 @@ func (c *httpClient) PutEntry(ctx context.Context, sk cipher.SecKey, entry *Entr
 	sequence := entry.Sequence + 1
 	entry.Timestamp = time.Now().UnixNano()
 
-	for {
+	// Bound the read-modify-write retry on sequence conflict. Each iteration is a
+	// POST plus (on conflict) a GET — and over dmsg each of those is a fresh
+	// stream with a full Noise handshake, expensive on the discovery. A tight,
+	// unbounded retry loop under contention (many peers racing the same entry, or
+	// a busy server re-registering on every session change) turns one update into
+	// a handshake storm that GC-thrashes the discovery. Cap the attempts and back
+	// off between them.
+	backoff := putEntryConflictBaseBackoff
+	for attempt := 0; ; attempt++ {
 		entry.Sequence = sequence
 		err := entry.Sign(sk)
 		if err != nil {
@@ -253,6 +261,9 @@ func (c *httpClient) PutEntry(ctx context.Context, sk cipher.SecKey, entry *Entr
 		if err != ErrValidationWrongSequence {
 			return err
 		}
+		if attempt >= putEntryMaxConflictRetries {
+			return fmt.Errorf("put entry: gave up after %d sequence-conflict retries: %w", attempt, err)
+		}
 		rE, entryErr := c.Entry(ctx, entry.Static)
 		if entryErr != nil {
 			return entryErr
@@ -262,8 +273,26 @@ func (c *httpClient) PutEntry(ctx context.Context, sk cipher.SecKey, entry *Entr
 			return nil
 		}
 		sequence = rE.Sequence + 1
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		if backoff < putEntryConflictMaxBackoff {
+			backoff *= 2
+		}
 	}
 }
+
+const (
+	// putEntryMaxConflictRetries bounds PutEntry's sequence-conflict retry loop
+	// so a persistently-contended entry can't spin out a handshake storm.
+	putEntryMaxConflictRetries = 5
+	// putEntryConflictBaseBackoff / putEntryConflictMaxBackoff bound the
+	// exponential backoff between sequence-conflict retries.
+	putEntryConflictBaseBackoff = 100 * time.Millisecond
+	putEntryConflictMaxBackoff  = 2 * time.Second
+)
 
 // AvailableServers returns list of available servers.
 func (c *httpClient) AvailableServers(ctx context.Context) ([]*Entry, error) {

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -638,6 +638,16 @@ func (c *EntityCommon) updateServerEntryLoop(ctx context.Context, addr, addrV6 s
 				}
 			}
 		serverUpdate:
+			// Coalesce rapid session-churn nudges. AvailableSessions is a soft
+			// capacity hint that doesn't need per-session freshness, and
+			// re-registering on every change is a POST (a full Noise handshake)
+			// per change on the discovery — under churn that snowballs into a
+			// handshake storm. If we registered within entryUpdateMinInterval,
+			// skip: the periodic timer (or a later nudge past the interval)
+			// publishes the change within at most updateInterval.
+			if c.updatedWithin(entryUpdateMinInterval) {
+				continue
+			}
 			err := c.updateServerEntry(ctx, addr, addrV6, maxSessions, authPassphrase)
 			if err != nil {
 				c.log.WithError(err).Warn("Failed to update discovery entry (nudge).")
@@ -856,6 +866,20 @@ func (c *EntityCommon) updateClientEntryOnEndpoint(ctx context.Context, ep *disc
 // while shrinking the stale-entry window by 80 %.
 const entryUpdateDebounce = 1 * time.Second
 
+// entryUpdateMinInterval is the minimum spacing between nudge-driven SERVER
+// entry re-registrations. A busy dmsg-server's AvailableSessions (= maxSessions
+// − live sessions) changes on every client connect/disconnect, and each change
+// nudges a re-registration — a POST to the discovery over a fresh dmsg stream
+// with a full Noise (secp256k1 + PQ) handshake. Under heavy session churn that
+// snowballs into a handshake storm that GC-thrashes the discovery. AvailableSessions
+// is only a soft capacity hint for weighted server selection, so coalescing
+// churn-driven updates to at most one per this interval (the periodic
+// updateInterval still refreshes it, and a change still publishes within
+// updateInterval) cuts the load by an order of magnitude with no meaningful loss
+// of freshness. The client entry loop needs no equivalent: it already skips
+// updates when its delegated-server set is unchanged (SamePubKeys guard).
+const entryUpdateMinInterval = 10 * time.Second
+
 // entryUpdateAttemptTimeout bounds a single updateClientEntry call so a
 // stuck PUT (e.g. dmsg-HTTP stream-dial that the underlying transport never
 // errors out of) doesn't hang the loop forever. Without this, a service
@@ -1035,6 +1059,12 @@ func (c *EntityCommon) updateIsDue() (lastUpdate time.Time, isDue bool) {
 	lastUpdate = time.Unix(0, atomic.LoadInt64(&c.lastUpdate))
 	isDue = time.Since(lastUpdate) >= c.updateInterval
 	return lastUpdate, isDue
+}
+
+// updatedWithin reports whether the last discovery-entry update happened within
+// the given duration — used to coalesce rapid nudge-driven re-registrations.
+func (c *EntityCommon) updatedWithin(d time.Duration) bool {
+	return time.Since(time.Unix(0, atomic.LoadInt64(&c.lastUpdate))) < d
 }
 
 // nudgeEntryUpdate signals the update loop that a session changed and


### PR DESCRIPTION
## Problem

Elevated CPU/load on the **dmsg-discovery** and **TPD** hosts (124% CPU, load ~7 on dmsg-disc; same pathology on TPD), correlated with the number of visors connected through busy dmsg-servers.

## Root cause — self-amplifying registration storm

A dmsg-**server** re-registers its discovery entry on **every session add/remove**, because `AvailableSessions` (= `maxSessions - len(sessions)`) is part of the entry. Each change nudges the update loop (1s debounce), so a server churning clients emits **~25 registrations/min**.

Registration is a read-modify-write under optimistic sequence locking. Under contention ~2/3 of them lose the race and return HTTP **422 "wrong sequence"**. `PutEntry` retried those in a **tight, unbounded loop with no backoff** — and over dmsg every POST/GET is a **fresh stream with a full Noise (secp256k1 + PQ ML-KEM) handshake**. That crypto allocates heavily, so the retry loop turned one contended update into a **handshake storm that GC-thrashed the discovery**.

## Fix

**1. `pkg/dmsg/disc/client.go` — bound the retry.**
`PutEntry`'s sequence-conflict loop now has a capped exponential backoff (5 attempts, 100ms → 2s) and is ctx-aware. A persistently-contended entry can no longer spin out a handshake storm.

**2. `pkg/dmsg/dmsg/entity_common.go` — coalesce server re-registration.**
Nudge-driven **server** entry updates are coalesced to at most one per 10s (`entryUpdateMinInterval`). `AvailableSessions` is a soft capacity hint for weighted server selection and doesn't need per-session freshness; the periodic `updateInterval` still refreshes it and any change still publishes within `updateInterval`. The **client** entry loop needs no equivalent — it already skips updates when its delegated-server set is unchanged (`SamePubKeys` guard).

Together these cut discovery/TPD registration load by roughly an order of magnitude with no meaningful loss of entry freshness.

## Testing

- `go build ./pkg/dmsg/...`, `go vet` clean
- `go test ./pkg/dmsg/disc/` — ok
- `go test ./pkg/dmsg/dmsg/` — ok