### PR TITLE
feat(vpn-router): VPN gateway / WiFi-AP app (downstream LAN/WiFi → mesh VPN)

### DIFF
--- a/cmd/apps/vpn-router/commands/vpn-router.go
+++ b/cmd/apps/vpn-router/commands/vpn-router.go
@@ -1,0 +1,191 @@
+// Package commands cmd/apps/vpn-router/commands/vpn-router.go
+package commands
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/skycoin/skywire/pkg/app"
+	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/app/launcher"
+	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/calvin"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/vpn"
+)
+
+var (
+	lanIfc     string
+	tunIfc     string
+	subnetCIDR string
+	dhcpStart  string
+	dhcpEnd    string
+	dnsAddr    string
+	leaseTime  string
+	wifi       bool
+	ssid       string
+	passphrase string
+	band       string
+	channel    int
+	country    string
+	openWiFi   bool
+	appPort    uint16
+)
+
+// registerFlags declares the router flags on a pflag.FlagSet. Both the cobra
+// RootCmd and the internal-launcher parse path use it, so a flag is never
+// present in one and missing in the other.
+func registerFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&lanIfc, "lan-ifc", "", "downstream interface serving clients (e.g. eth1 or wlan0) — REQUIRED")
+	fs.StringVar(&tunIfc, "tun-ifc", "", "upstream mesh-VPN tunnel to NAT into (empty = auto-detect the first tun* the vpn-client brings up)")
+	fs.StringVar(&subnetCIDR, "subnet", "192.168.42.1/24", "router gateway address + downstream subnet, as <gateway-ip>/<prefix>")
+	fs.StringVar(&dhcpStart, "dhcp-start", "", "DHCP pool start (empty = .10 of the subnet)")
+	fs.StringVar(&dhcpEnd, "dhcp-end", "", "DHCP pool end (empty = .254 of the subnet)")
+	fs.StringVar(&dnsAddr, "dns", "", "DNS advertised to clients over DHCP (empty = the router itself)")
+	fs.StringVar(&leaseTime, "lease", "12h", "DHCP lease time")
+	fs.BoolVar(&wifi, "wifi", false, "WiFi-out: also run hostapd to beacon an AP on the downstream interface")
+	fs.StringVar(&ssid, "ssid", "", "WiFi SSID (with --wifi)")
+	fs.StringVar(&passphrase, "passphrase", "", "WiFi WPA2 passphrase, 8–63 chars (with --wifi)")
+	fs.StringVar(&band, "band", "2.4", "WiFi band: 2.4 or 5 (with --wifi)")
+	fs.IntVar(&channel, "channel", 0, "WiFi channel (0 = default for the band)")
+	fs.StringVar(&country, "country", "US", "WiFi regulatory country code (with --wifi)")
+	fs.BoolVar(&openWiFi, "open", false, "allow an open (passphrase-less) WiFi network")
+	fs.Uint16Var(&appPort, "port", 0, "routing port for communication between app and visor")
+}
+
+func init() {
+	launcher.RegisterApp(skyenv.VPNRouterName, RunVPNRouter)
+	registerFlags(RootCmd.Flags())
+}
+
+// RootCmd is the vpn-router app command.
+var RootCmd = &cobra.Command{
+	Use:                   "vpn-router",
+	Short:                 "skywire vpn router (gateway / WiFi-AP) application",
+	Long:                  calvin.AsciiFont("vpn-router"),
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+	Version:               buildinfo.Version(),
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return RunVPNRouter(context.Background(), nil)
+	},
+}
+
+// Execute executes the root CLI command.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		log.Fatal("Failed to execute command: ", err)
+	}
+}
+
+// RunVPNRouter is the launcher AppFunc: it brings up the downstream interface,
+// DHCP/DNS (and optionally a WiFi AP), and NATs client traffic into the mesh-VPN
+// tunnel maintained by the companion vpn-client app.
+func RunVPNRouter(ctx context.Context, args []string) error {
+	if len(args) > 0 {
+		fs := pflag.NewFlagSet("vpn-router", pflag.ContinueOnError)
+		registerFlags(fs)
+		if err := fs.Parse(args); err != nil {
+			return fmt.Errorf("failed to parse flags: %w", err)
+		}
+	}
+
+	appCl := app.NewClient(nil)
+	defer appCl.Close()
+	logger := appCl.Log()
+
+	if appPort != 0 {
+		if err := appCl.SetAppPort(routing.Port(appPort)); err != nil {
+			logger.WithError(err).WithField("port", appPort).Warn("Failed to set app port")
+		}
+	}
+
+	bi := buildinfo.Get()
+	logger.Infof("Version %q built on %q against commit %q", bi.Version, bi.Date, bi.Commit)
+
+	cfg, err := buildRouterConfig()
+	if err != nil {
+		logger.WithError(err).Error("invalid vpn-router configuration")
+		setAppErr(appCl, logger, err)
+		return err
+	}
+
+	router, err := vpn.NewRouter(cfg, logger)
+	if err != nil {
+		logger.WithError(err).Error("failed to create vpn-router")
+		setAppErr(appCl, logger, err)
+		return err
+	}
+
+	setAppStatus(appCl, logger, appserver.AppDetailedStatusRunning)
+	defer setAppStatus(appCl, logger, appserver.AppDetailedStatusStopped)
+
+	if err := router.Run(ctx); err != nil {
+		logger.WithError(err).Error("vpn-router exited with error")
+		setAppErr(appCl, logger, err)
+		return err
+	}
+	return nil
+}
+
+// buildRouterConfig turns the parsed flags into a vpn.RouterConfig.
+func buildRouterConfig() (vpn.RouterConfig, error) {
+	gw, subnet, err := net.ParseCIDR(subnetCIDR)
+	if err != nil {
+		return vpn.RouterConfig{}, fmt.Errorf("invalid --subnet %q (want <gateway-ip>/<prefix>, e.g. 192.168.42.1/24): %w", subnetCIDR, err)
+	}
+	cfg := vpn.RouterConfig{
+		LANInterface: lanIfc,
+		TUNInterface: tunIfc,
+		Gateway:      gw,
+		Subnet:       subnet,
+		LeaseTime:    leaseTime,
+	}
+	if dhcpStart != "" {
+		if cfg.DHCPStart = net.ParseIP(dhcpStart); cfg.DHCPStart == nil {
+			return cfg, fmt.Errorf("invalid --dhcp-start %q", dhcpStart)
+		}
+	}
+	if dhcpEnd != "" {
+		if cfg.DHCPEnd = net.ParseIP(dhcpEnd); cfg.DHCPEnd == nil {
+			return cfg, fmt.Errorf("invalid --dhcp-end %q", dhcpEnd)
+		}
+	}
+	if dnsAddr != "" {
+		if cfg.DNS = net.ParseIP(dnsAddr); cfg.DNS == nil {
+			return cfg, fmt.Errorf("invalid --dns %q", dnsAddr)
+		}
+	}
+	if wifi {
+		cfg.WiFi = &vpn.WiFiConfig{
+			SSID:        ssid,
+			Passphrase:  passphrase,
+			Band:        band,
+			Channel:     channel,
+			CountryCode: country,
+			AllowOpen:   openWiFi,
+		}
+	}
+	return cfg, nil
+}
+
+func setAppErr(appCl *app.Client, logg logrus.FieldLogger, err error) {
+	if appErr := appCl.SetError(err.Error()); appErr != nil {
+		logg.WithError(appErr).WithField("original_error", err).Warn("Failed to set error")
+	}
+}
+
+func setAppStatus(appCl *app.Client, logg logrus.FieldLogger, status appserver.AppDetailedStatus) {
+	if err := appCl.SetDetailedStatus(string(status)); err != nil {
+		logg.WithError(err).WithField("status", status).Warn("Failed to set status")
+	}
+}

--- a/cmd/apps/vpn-router/vpn-router.go
+++ b/cmd/apps/vpn-router/vpn-router.go
@@ -1,0 +1,43 @@
+// Package main cmd/apps/vpn-router/vpn-router.go
+package main
+
+import (
+	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/cmd/apps/vpn-router/commands"
+)
+
+func init() {
+	var helpflag bool
+	commands.RootCmd.SetUsageTemplate(help)
+	commands.RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help menu")
+	commands.RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	commands.RootCmd.PersistentFlags().MarkHidden("help") //nolint:errcheck,gosec
+}
+
+func main() {
+	cc.Init(&cc.Config{
+		RootCmd:         commands.RootCmd,
+		Headings:        cc.HiBlue + cc.Bold,
+		Commands:        cc.HiBlue + cc.Bold,
+		CmdShortDescr:   cc.HiBlue,
+		Example:         cc.HiBlue + cc.Italic,
+		ExecName:        cc.HiBlue + cc.Bold,
+		Flags:           cc.HiBlue + cc.Bold,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
+	commands.Execute()
+}
+
+const help = "Usage:\r\n" +
+	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/skywire/commands/root.go
+++ b/cmd/skywire/commands/root.go
@@ -15,6 +15,7 @@ import (
 	ssc "github.com/skycoin/skywire/cmd/apps/skysocks-client/commands"
 	ss "github.com/skycoin/skywire/cmd/apps/skysocks/commands"
 	vpnc "github.com/skycoin/skywire/cmd/apps/vpn-client/commands"
+	vpnr "github.com/skycoin/skywire/cmd/apps/vpn-router/commands"
 	vpns "github.com/skycoin/skywire/cmd/apps/vpn-server/commands"
 	cxo "github.com/skycoin/skywire/cmd/cxo/commands"
 	dmsg "github.com/skycoin/skywire/cmd/dmsg/dmsg/commands"
@@ -38,6 +39,7 @@ func init() {
 	appsCmd.AddCommand(
 		vpns.RootCmd,
 		vpnc.RootCmd,
+		vpnr.RootCmd,
 		ssc.RootCmd,
 		ss.RootCmd,
 		sc.RootCmd,
@@ -103,6 +105,8 @@ func init() {
 	vpns.RootCmd.Hidden = true
 	vpnc.RootCmd.Use = "vpn-client"
 	vpnc.RootCmd.Hidden = true
+	vpnr.RootCmd.Use = "vpn-router"
+	vpnr.RootCmd.Hidden = true
 	// skysocks pair (server + client) is collapsed under
 	// `skywire app skysocks {serve,client}`. The legacy direct
 	// invocations stay mounted but Hidden so operator scripts

--- a/docs/design/vpn-router-app.md
+++ b/docs/design/vpn-router-app.md
@@ -1,0 +1,125 @@
+# vpn-router — Skywire VPN gateway / WiFi-AP role
+
+`vpn-router` turns a visor into a **router**: downstream LAN/WiFi clients reach
+the internet through the Skywire mesh VPN without running any Skywire software
+themselves. A laptop or phone joins the router's WiFi (or plugs into its LAN
+port) and its traffic is NATed into the mesh tunnel.
+
+## Architecture
+
+`vpn-router` is a **companion** to the existing `vpn-client` app, not a
+replacement:
+
+```
+   downstream clients            this visor                    mesh
+  ┌──────────────┐        ┌───────────────────────┐
+  │ laptop/phone │  DHCP  │  vpn-router (this app) │
+  │              │◀──────▶│   • hostapd (WiFi)     │
+  │ 192.168.42.x │        │   • dnsmasq (DHCP/DNS) │        ┌────────────┐
+  └──────────────┘        │   • NAT downstream→tun │        │ vpn-server │
+        wlan0/eth1        │                        │        │ (exit)     │
+                          │  vpn-client (companion)│──tun0──▶│            │──▶ internet
+                          │   • owns tun0 tunnel   │  mesh   └────────────┘
+                          └───────────────────────┘
+```
+
+- **`vpn-client`** owns the tunnel interface (`tun0`) to a chosen VPN server —
+  unchanged.
+- **`vpn-router`** owns the *downstream* side: it brings up the LAN/WiFi
+  interface, runs DHCP+DNS, optionally beacons a WiFi AP, and NATs the client
+  subnet into `tun0`.
+
+Enable **both** apps (AutoStart) on the gateway visor. `vpn-router` waits for the
+tunnel interface to appear (up to 90 s), so start order doesn't matter.
+
+### Two variants, one code path
+
+| Variant | `LANInterface` | Extra daemon | Hardware |
+|---|---|---|---|
+| **Ethernet-out** | a 2nd wired NIC (`eth1`) | dnsmasq only | any Linux SBC incl. the existing Skyminer boards |
+| **WiFi-out** | AP-capable wireless NIC (`wlan0`) | dnsmasq + **hostapd** | Pi onboard radio, or a MT7612U USB dongle |
+
+The WiFi variant is the ethernet variant **plus** hostapd beaconing an SSID on
+the same interface. See `reference_vpn_router_hardware` for chipset notes — many
+cheap onboard radios (AIC8800 fullMAC) can't do AP mode; a MT7612U dongle is the
+reliable fallback.
+
+## Code map
+
+| Piece | File |
+|---|---|
+| Config + pure config-file generators (`DnsmasqConf`, `HostapdConf`) | `pkg/vpn/router.go` |
+| Linux orchestration (interface, daemons, NAT, teardown) | `pkg/vpn/router_linux.go` |
+| Non-Linux stub | `pkg/vpn/router_other.go` |
+| Launcher app (`RunVPNRouter`, flags) | `cmd/apps/vpn-router/commands/vpn-router.go` |
+| NAT/forwarding helpers (reused from vpn-server) | `pkg/vpn/os_server_linux.go` |
+
+The NAT is exactly the vpn-server primitives applied to the tunnel:
+`EnableIPv4Forwarding()`, `EnableIPMasquerading(tun0)`, plus targeted
+`FORWARD` rules `LAN↔tun0`. On shutdown everything is reversed (rules removed,
+masquerade dropped, forwarding restored, downstream address flushed, daemons
+reaped via context).
+
+## Enabling it on a visor
+
+`vpn-router` is registered as a launcher app but is **not** in the default
+generated config yet (config-gen default inclusion is a follow-up). Add it to
+`skywire.json` under `launcher.apps`, alongside an auto-started `vpn-client`:
+
+```json
+{
+  "name": "vpn-client",
+  "auto_start": true,
+  "port": 43,
+  "args": ["-srv", "<VPN_SERVER_PK>"]
+},
+{
+  "name": "vpn-router",
+  "auto_start": true,
+  "port": 0,
+  "args": ["--lan-ifc", "wlan0", "--subnet", "192.168.42.1/24",
+           "--wifi", "--ssid", "Skywire", "--passphrase", "changeme8+"]
+}
+```
+
+Ethernet-out is the same without the WiFi flags:
+`["--lan-ifc", "eth1", "--subnet", "192.168.42.1/24"]`.
+
+### Flags
+
+`--lan-ifc` (required), `--tun-ifc` (auto-detect if empty), `--subnet
+<gateway-ip>/<prefix>`, `--dhcp-start/-end`, `--dns`, `--lease`; WiFi:
+`--wifi --ssid --passphrase [--band 2.4|5] [--channel N] [--country XX] [--open]`.
+
+## Privileges
+
+Like the other VPN apps, `vpn-router` needs `CAP_NET_ADMIN` / root: it runs
+`ip`, `iptables`, `sysctl`, `hostapd`, `dnsmasq`. It shells these out via the
+same `osutil.RunElevated` path vpn-server uses. Requires `hostapd` and `dnsmasq`
+installed on the host.
+
+## Test status
+
+- **Unit-tested (CI):** config validation, DHCP-pool defaults, and the generated
+  `dnsmasq.conf` / `hostapd.conf` content (`pkg/vpn/router_test.go`).
+- **Build-verified:** compiles on Linux and (as a stub) non-Linux; the app
+  registers and its CLI flags parse.
+- **Needs hardware:** the live interface/daemon/NAT path is only exercisable on a
+  real router box. Validation procedure:
+  1. Board with two interfaces (e.g. Pi 4: `eth0` uplink + `wlan0` AP, or an SBC
+     with `eth0`+`eth1`), `hostapd`+`dnsmasq` installed, running as root.
+  2. Configure `vpn-client` to a working `vpn-server`; confirm `tun0` is up and
+     the visor itself has mesh internet.
+  3. Enable `vpn-router` as above; join the SSID / plug into the LAN port from a
+     second device.
+  4. Expect: DHCP lease in `192.168.42.0/24`, DNS resolves, and the client's
+     public IP is the **vpn-server's** exit IP (not the uplink's).
+
+## Follow-ups
+
+- Add `vpn-router` to config-gen behind a flag (and the internal/external app
+  templates), updating the golden config fixtures.
+- HV UI settings page (mirror the vpn-client component).
+- Optional self-contained mode (embed the tunnel so it's one app/lifecycle
+  instead of a vpn-client companion).
+- Client-isolation / per-PK ACL (reuse vpn-server's `--secure` / whitelist idea).

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -205,6 +205,11 @@ const (
 	// VPNClientPort over dmsg
 	VPNClientPort uint16 = 43
 
+	// VPNRouterName is the name of the vpn router (gateway / WiFi-AP) app. It is a
+	// LOCAL companion to vpn-client with no dmsg port of its own: it aggregates
+	// downstream LAN/WiFi clients and NATs them into the tunnel vpn-client owns.
+	VPNRouterName = "vpn-router"
+
 	// ExampleServerName is the name of the example server app
 	ExampleServerName = "example-server-app"
 

--- a/pkg/vpn/router.go
+++ b/pkg/vpn/router.go
@@ -1,0 +1,246 @@
+package vpn
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// A Router turns a visor into a VPN gateway: it aggregates downstream LAN/WiFi
+// clients on a local interface and forwards their traffic into the mesh-VPN
+// tunnel that the vpn-client app maintains (with NAT), so an ordinary laptop or
+// phone reaches the internet through Skywire without running any Skywire
+// software itself.
+//
+// The router is a COMPANION to vpn-client: vpn-client owns the tunnel interface
+// (tun*) to the chosen VPN server; the router owns the downstream interface plus
+// the forwarding/NAT between them. Both are ordinary launcher apps; enable both
+// (AutoStart) on the visor that should act as the gateway.
+//
+// Two variants share one code path — the only difference is whether an
+// 802.11 AP is brought up on the downstream interface:
+//   - Ethernet-out: LANInterface is a second wired NIC (e.g. eth1); clients plug
+//     in (or sit behind a switch). Works on the existing Skyminer SBCs.
+//   - WiFi-out: LANInterface is an AP-capable wireless NIC (e.g. wlan0) and WiFi
+//     is set, so hostapd additionally beacons an SSID. Needs a chipset whose
+//     driver does hostapd AP mode (Pi onboard, or a MT7612U USB dongle).
+//
+// Either way dnsmasq serves DHCP + DNS on the downstream subnet, and the
+// downstream→tunnel path is masqueraded. The heavy lifting (IPv4 forwarding, NAT
+// masquerade) reuses the same helpers the vpn-server app uses — see
+// os_server_linux.go.
+
+// RouterConfig is the platform-neutral configuration for a VPN router.
+type RouterConfig struct {
+	// LANInterface is the downstream interface that serves clients — a wired NIC
+	// (e.g. "eth1") for the ethernet-out variant, or an AP-capable wireless NIC
+	// (e.g. "wlan0") for the WiFi-out variant.
+	LANInterface string
+
+	// TUNInterface is the upstream mesh-VPN tunnel to masquerade into (e.g.
+	// "tun0"), owned by the vpn-client app. Empty = auto-detect the first tun*
+	// interface once vpn-client has brought it up.
+	TUNInterface string
+
+	// Gateway is the router's own address on the downstream subnet (the default
+	// gateway handed to clients), e.g. 192.168.42.1.
+	Gateway net.IP
+
+	// Subnet is the downstream network in CIDR form, e.g. 192.168.42.0/24.
+	Subnet *net.IPNet
+
+	// DHCPStart and DHCPEnd bound the DHCP address pool. Both must lie inside
+	// Subnet. Zero values default to .10 … .254 of the subnet.
+	DHCPStart net.IP
+	DHCPEnd   net.IP
+
+	// DNS is the resolver advertised to clients over DHCP (e.g. 1.1.1.1). Zero
+	// value defaults to the Gateway (dnsmasq then resolves for clients).
+	DNS net.IP
+
+	// LeaseTime is the DHCP lease duration in dnsmasq form (e.g. "12h"). Empty
+	// defaults to "12h".
+	LeaseTime string
+
+	// WiFi, when non-nil, additionally runs hostapd to create a WiFi AP on
+	// LANInterface. Nil = ethernet-out (no AP).
+	WiFi *WiFiConfig
+}
+
+// WiFiConfig configures the hostapd access point for the WiFi-out variant.
+type WiFiConfig struct {
+	SSID string
+	// Passphrase is the WPA2 pre-shared key (8–63 chars). Empty = open network
+	// (allowed but strongly discouraged; validate() warns via error unless
+	// explicitly opened with AllowOpen).
+	Passphrase string
+	// Band is "2.4" or "5". Selects hostapd hw_mode (g / a).
+	Band string
+	// Channel is the 802.11 channel. 0 = a sensible default for the band
+	// (channel 6 on 2.4 GHz, 36 on 5 GHz).
+	Channel int
+	// CountryCode is the regulatory domain (e.g. "US"). Empty = "US".
+	CountryCode string
+	// AllowOpen permits an empty Passphrase (open network) without erroring.
+	AllowOpen bool
+}
+
+// defaultLeaseTime is the DHCP lease used when RouterConfig.LeaseTime is empty.
+const defaultLeaseTime = "12h"
+
+// hwMode maps a band to a hostapd hw_mode letter.
+func (w WiFiConfig) hwMode() string {
+	if strings.HasPrefix(w.Band, "5") {
+		return "a"
+	}
+	return "g"
+}
+
+// channel returns the configured channel or a per-band default.
+func (w WiFiConfig) channel() int {
+	if w.Channel != 0 {
+		return w.Channel
+	}
+	if w.hwMode() == "a" {
+		return 36
+	}
+	return 6
+}
+
+func (w WiFiConfig) countryCode() string {
+	if w.CountryCode == "" {
+		return "US"
+	}
+	return w.CountryCode
+}
+
+// withDefaults returns a copy of c with zero-value fields filled in from Subnet.
+func (c RouterConfig) withDefaults() RouterConfig {
+	if c.LeaseTime == "" {
+		c.LeaseTime = defaultLeaseTime
+	}
+	if c.DNS == nil {
+		c.DNS = c.Gateway
+	}
+	if c.Subnet != nil {
+		if c.DHCPStart == nil {
+			c.DHCPStart = nthHost(c.Subnet, 10)
+		}
+		if c.DHCPEnd == nil {
+			c.DHCPEnd = nthHost(c.Subnet, 254)
+		}
+	}
+	return c
+}
+
+// validate checks the config is internally consistent before any system state
+// is touched.
+func (c RouterConfig) validate() error {
+	if c.LANInterface == "" {
+		return fmt.Errorf("vpn-router: LAN interface is required")
+	}
+	if c.Gateway == nil {
+		return fmt.Errorf("vpn-router: gateway IP is required")
+	}
+	if c.Subnet == nil {
+		return fmt.Errorf("vpn-router: subnet is required")
+	}
+	if !c.Subnet.Contains(c.Gateway) {
+		return fmt.Errorf("vpn-router: gateway %s is not inside subnet %s", c.Gateway, c.Subnet)
+	}
+	if c.DHCPStart != nil && !c.Subnet.Contains(c.DHCPStart) {
+		return fmt.Errorf("vpn-router: DHCP start %s is not inside subnet %s", c.DHCPStart, c.Subnet)
+	}
+	if c.DHCPEnd != nil && !c.Subnet.Contains(c.DHCPEnd) {
+		return fmt.Errorf("vpn-router: DHCP end %s is not inside subnet %s", c.DHCPEnd, c.Subnet)
+	}
+	if c.WiFi != nil {
+		if c.WiFi.SSID == "" {
+			return fmt.Errorf("vpn-router: WiFi SSID is required for the WiFi-out variant")
+		}
+		if c.WiFi.Passphrase == "" && !c.WiFi.AllowOpen {
+			return fmt.Errorf("vpn-router: WiFi passphrase is empty; set one (8–63 chars) or explicitly allow an open network")
+		}
+		if l := len(c.WiFi.Passphrase); c.WiFi.Passphrase != "" && (l < 8 || l > 63) {
+			return fmt.Errorf("vpn-router: WiFi passphrase must be 8–63 chars (got %d)", l)
+		}
+		if b := c.WiFi.Band; b != "" && !strings.HasPrefix(b, "2") && !strings.HasPrefix(b, "5") {
+			return fmt.Errorf("vpn-router: WiFi band must be \"2.4\" or \"5\" (got %q)", b)
+		}
+	}
+	return nil
+}
+
+// prefixLen returns the subnet's CIDR prefix length (e.g. 24).
+func (c RouterConfig) prefixLen() int {
+	if c.Subnet == nil {
+		return 0
+	}
+	ones, _ := c.Subnet.Mask.Size()
+	return ones
+}
+
+// DnsmasqConf renders the dnsmasq configuration for the downstream subnet
+// (DHCP pool + the router as gateway/DNS). It is pure (no I/O) so it can be
+// unit-tested and reviewed.
+func (c RouterConfig) DnsmasqConf() string {
+	c = c.withDefaults()
+	var b strings.Builder
+	fmt.Fprintf(&b, "# generated by skywire vpn-router — dnsmasq for %s\n", c.LANInterface)
+	fmt.Fprintf(&b, "interface=%s\n", c.LANInterface)
+	fmt.Fprintf(&b, "bind-interfaces\n")
+	fmt.Fprintf(&b, "except-interface=lo\n")
+	// DHCP: hand out addresses in the pool, with the router as gateway + DNS.
+	fmt.Fprintf(&b, "dhcp-range=%s,%s,%s\n", c.DHCPStart, c.DHCPEnd, c.LeaseTime)
+	fmt.Fprintf(&b, "dhcp-option=option:router,%s\n", c.Gateway)
+	fmt.Fprintf(&b, "dhcp-option=option:dns-server,%s\n", c.DNS)
+	// Upstream resolver dnsmasq forwards client DNS queries to.
+	fmt.Fprintf(&b, "server=%s\n", c.DNS)
+	fmt.Fprintf(&b, "domain-needed\n")
+	fmt.Fprintf(&b, "bogus-priv\n")
+	return b.String()
+}
+
+// HostapdConf renders the hostapd configuration for the WiFi-out variant. It is
+// pure (no I/O). iface is the wireless interface the AP runs on.
+func (w WiFiConfig) HostapdConf(iface string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# generated by skywire vpn-router — hostapd AP on %s\n", iface)
+	fmt.Fprintf(&b, "interface=%s\n", iface)
+	fmt.Fprintf(&b, "driver=nl80211\n")
+	fmt.Fprintf(&b, "ssid=%s\n", w.SSID)
+	fmt.Fprintf(&b, "country_code=%s\n", w.countryCode())
+	fmt.Fprintf(&b, "hw_mode=%s\n", w.hwMode())
+	fmt.Fprintf(&b, "channel=%d\n", w.channel())
+	fmt.Fprintf(&b, "ieee80211n=1\n")
+	fmt.Fprintf(&b, "wmm_enabled=1\n")
+	fmt.Fprintf(&b, "auth_algs=1\n")
+	fmt.Fprintf(&b, "macaddr_acl=0\n")
+	if w.Passphrase == "" {
+		// Open network (AllowOpen was set): no WPA block.
+		fmt.Fprintf(&b, "# open network — no passphrase\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "wpa=2\n")
+	fmt.Fprintf(&b, "wpa_key_mgmt=WPA-PSK\n")
+	fmt.Fprintf(&b, "rsn_pairwise=CCMP\n")
+	fmt.Fprintf(&b, "wpa_passphrase=%s\n", w.Passphrase)
+	return b.String()
+}
+
+// nthHost returns the n-th host address of subnet (1-based over the host part),
+// e.g. nthHost(192.168.42.0/24, 10) == 192.168.42.10. Returns nil if it would
+// overflow the subnet.
+func nthHost(subnet *net.IPNet, n int) net.IP {
+	base := subnet.IP.To4()
+	if base == nil {
+		return nil
+	}
+	v := uint32(base[0])<<24 | uint32(base[1])<<16 | uint32(base[2])<<8 | uint32(base[3])
+	v += uint32(n) //nolint:gosec // n is a small positive constant
+	ip := net.IPv4(byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	if !subnet.Contains(ip) {
+		return nil
+	}
+	return ip
+}

--- a/pkg/vpn/router_linux.go
+++ b/pkg/vpn/router_linux.go
@@ -1,0 +1,275 @@
+//go:build linux
+// +build linux
+
+package vpn
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/util/osutil"
+)
+
+// Router orchestrates the downstream interface, the DHCP/DNS + optional WiFi AP
+// daemons, and the forwarding/NAT into the mesh-VPN tunnel. Construct with
+// NewRouter, then Run.
+type Router struct {
+	cfg RouterConfig
+	log logrus.FieldLogger
+
+	confDir string
+	daemons []*exec.Cmd
+	tunIfc  string
+
+	// state captured for restoration on teardown.
+	prevForwarding string
+	masquerading   bool
+	forwardRules   [][]string // iptables argv sets we added to the FORWARD chain
+}
+
+// NewRouter validates cfg and returns a Router ready to Run. It does not touch
+// any system state.
+func NewRouter(cfg RouterConfig, log logrus.FieldLogger) (*Router, error) {
+	cfg = cfg.withDefaults()
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	if log == nil {
+		log = logrus.New()
+	}
+	return &Router{cfg: cfg, log: log}, nil
+}
+
+// Run sets the router up and blocks until ctx is canceled, then tears
+// everything back down. It returns the setup error (after best-effort teardown)
+// or nil on clean shutdown.
+func (r *Router) Run(ctx context.Context) error {
+	if err := r.setup(ctx); err != nil {
+		r.teardown()
+		return err
+	}
+	r.log.Infof("vpn-router up: %s (%s) → %s; clients get %s via DHCP",
+		r.cfg.LANInterface, r.variant(), r.tunIfc, r.cfg.Subnet)
+	<-ctx.Done()
+	r.log.Info("vpn-router shutting down")
+	r.teardown()
+	return nil
+}
+
+func (r *Router) variant() string {
+	if r.cfg.WiFi != nil {
+		return "WiFi AP " + r.cfg.WiFi.SSID
+	}
+	return "ethernet"
+}
+
+func (r *Router) setup(ctx context.Context) error {
+	if os.Geteuid() != 0 {
+		// hostapd/dnsmasq + ip/iptables need privilege; the vpn apps run
+		// elevated. Fail early with a clear message rather than partway through.
+		r.log.Warn("vpn-router is not running as root — interface/daemon setup will likely fail")
+	}
+
+	dir, err := os.MkdirTemp("", "skywire-vpn-router-")
+	if err != nil {
+		return fmt.Errorf("temp dir: %w", err)
+	}
+	r.confDir = dir
+
+	// 1. Bring up the downstream interface with the gateway address.
+	if err := r.setupLANInterface(); err != nil {
+		return err
+	}
+
+	// 2. WiFi-out: start hostapd so the interface actually beacons an AP.
+	if r.cfg.WiFi != nil {
+		if err := r.startHostapd(ctx); err != nil {
+			return err
+		}
+	}
+
+	// 3. DHCP + DNS for the downstream subnet.
+	if err := r.startDnsmasq(ctx); err != nil {
+		return err
+	}
+
+	// 4. Wait for the vpn-client tunnel, then forward + NAT into it.
+	tun, err := r.awaitTUN(ctx)
+	if err != nil {
+		return err
+	}
+	r.tunIfc = tun
+	return r.setupNAT()
+}
+
+// setupLANInterface flushes and assigns the gateway address to the downstream
+// interface and brings it up.
+func (r *Router) setupLANInterface() error {
+	lan := r.cfg.LANInterface
+	cidr := fmt.Sprintf("%s/%d", r.cfg.Gateway, r.cfg.prefixLen())
+	// Flush any stale addressing, set ours, bring the link up.
+	_ = osutil.RunElevated("ip", "addr", "flush", "dev", lan) //nolint:errcheck // best-effort clean slate
+	if err := osutil.RunElevated("ip", "addr", "add", cidr, "dev", lan); err != nil {
+		return fmt.Errorf("assign %s to %s: %w", cidr, lan, err)
+	}
+	if err := osutil.RunElevated("ip", "link", "set", lan, "up"); err != nil {
+		return fmt.Errorf("bring up %s: %w", lan, err)
+	}
+	r.log.Infof("downstream %s = %s", lan, cidr)
+	return nil
+}
+
+func (r *Router) startHostapd(ctx context.Context) error {
+	if _, err := exec.LookPath("hostapd"); err != nil {
+		return fmt.Errorf("hostapd not found — install it for the WiFi-out variant: %w", err)
+	}
+	confPath := filepath.Join(r.confDir, "hostapd.conf")
+	if err := os.WriteFile(confPath, []byte(r.cfg.WiFi.HostapdConf(r.cfg.LANInterface)), 0o600); err != nil {
+		return fmt.Errorf("write hostapd.conf: %w", err)
+	}
+	return r.startDaemon(ctx, "hostapd", confPath)
+}
+
+func (r *Router) startDnsmasq(ctx context.Context) error {
+	if _, err := exec.LookPath("dnsmasq"); err != nil {
+		return fmt.Errorf("dnsmasq not found — install it (DHCP/DNS for clients): %w", err)
+	}
+	confPath := filepath.Join(r.confDir, "dnsmasq.conf")
+	if err := os.WriteFile(confPath, []byte(r.cfg.DnsmasqConf()), 0o600); err != nil {
+		return fmt.Errorf("write dnsmasq.conf: %w", err)
+	}
+	// --keep-in-foreground: dnsmasq daemonizes by default; keep it a child so
+	// ctx cancellation reaps it. --conf-file=<ours> ignores system config.
+	return r.startDaemon(ctx, "dnsmasq", "--keep-in-foreground", "--conf-file="+confPath)
+}
+
+// startDaemon launches a long-running child bound to ctx (killed on cancel) and
+// records it for teardown.
+func (r *Router) startDaemon(ctx context.Context, bin string, args ...string) error {
+	cmd := exec.CommandContext(ctx, bin, args...) //nolint:gosec // bin is a fixed daemon name, args are our generated conf paths
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s: %w", bin, err)
+	}
+	r.daemons = append(r.daemons, cmd)
+	r.log.Infof("started %s (pid %d)", bin, cmd.Process.Pid)
+	return nil
+}
+
+// awaitTUN resolves the configured tunnel interface, or polls for the first
+// tun* interface to appear (vpn-client may start after the router).
+func (r *Router) awaitTUN(ctx context.Context) (string, error) {
+	deadline := time.NewTimer(90 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(time.Second)
+	defer tick.Stop()
+	for {
+		if name := r.findTUN(); name != "" {
+			return name, nil
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-deadline.C:
+			return "", fmt.Errorf("no VPN tunnel interface appeared within 90s — is the vpn-client app running and connected?")
+		case <-tick.C:
+		}
+	}
+}
+
+// findTUN returns the configured tunnel interface if it exists, else the first
+// tun* interface, else "".
+func (r *Router) findTUN() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	if want := r.cfg.TUNInterface; want != "" {
+		for _, ifc := range ifaces {
+			if ifc.Name == want {
+				return want
+			}
+		}
+		return ""
+	}
+	for _, ifc := range ifaces {
+		if strings.HasPrefix(ifc.Name, "tun") {
+			return ifc.Name
+		}
+	}
+	return ""
+}
+
+// setupNAT enables IPv4 forwarding and masquerades the downstream subnet out the
+// tunnel, with targeted FORWARD rules downstream↔tunnel.
+func (r *Router) setupNAT() error {
+	prev, err := GetIPv4ForwardingValue()
+	if err == nil {
+		r.prevForwarding = prev
+	}
+	if err := EnableIPv4Forwarding(); err != nil {
+		return fmt.Errorf("enable IPv4 forwarding: %w", err)
+	}
+	if err := EnableIPMasquerading(r.tunIfc); err != nil {
+		return fmt.Errorf("masquerade out %s: %w", r.tunIfc, err)
+	}
+	r.masquerading = true
+
+	// downstream → tunnel (new+established) and tunnel → downstream (established)
+	rules := [][]string{
+		{"-A", "FORWARD", "-i", r.cfg.LANInterface, "-o", r.tunIfc, "-j", "ACCEPT"},
+		{"-A", "FORWARD", "-i", r.tunIfc, "-o", r.cfg.LANInterface, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
+	}
+	for _, rule := range rules {
+		if err := osutil.RunElevated("iptables", rule...); err != nil {
+			return fmt.Errorf("iptables %s: %w", strings.Join(rule, " "), err)
+		}
+		r.forwardRules = append(r.forwardRules, rule)
+	}
+	r.log.Infof("NAT: %s → %s (masquerade)", r.cfg.LANInterface, r.tunIfc)
+	return nil
+}
+
+// teardown reverses setup, best-effort (logs but does not abort on errors).
+func (r *Router) teardown() {
+	// Remove the FORWARD rules we added (-D mirrors each -A).
+	for _, rule := range r.forwardRules {
+		del := append([]string{"-D"}, rule[1:]...)
+		if err := osutil.RunElevated("iptables", del...); err != nil {
+			r.log.WithError(err).Warnf("teardown: remove FORWARD rule %s", strings.Join(rule, " "))
+		}
+	}
+	if r.masquerading {
+		if err := DisableIPMasquerading(r.tunIfc); err != nil {
+			r.log.WithError(err).Warn("teardown: disable masquerading")
+		}
+	}
+	if r.prevForwarding != "" && r.prevForwarding != "1" {
+		if err := SetIPv4ForwardingValue(r.prevForwarding); err != nil {
+			r.log.WithError(err).Warn("teardown: restore IPv4 forwarding")
+		}
+	}
+	// ctx cancellation already signals the daemons; wait so they're reaped.
+	for _, cmd := range r.daemons {
+		_ = cmd.Wait() //nolint:errcheck // killed by ctx; Wait just reaps
+	}
+	// Drop the gateway address we assigned.
+	if r.cfg.LANInterface != "" && r.cfg.Gateway != nil {
+		cidr := fmt.Sprintf("%s/%d", r.cfg.Gateway, r.cfg.prefixLen())
+		if err := osutil.RunElevated("ip", "addr", "del", cidr, "dev", r.cfg.LANInterface); err != nil {
+			r.log.WithError(err).Warn("teardown: remove downstream address")
+		}
+	}
+	if r.confDir != "" {
+		_ = os.RemoveAll(r.confDir) //nolint:errcheck // temp conf dir, best-effort
+	}
+}

--- a/pkg/vpn/router_other.go
+++ b/pkg/vpn/router_other.go
@@ -1,0 +1,30 @@
+//go:build !linux
+// +build !linux
+
+package vpn
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Router is a stub on non-Linux platforms — the VPN gateway/AP role relies on
+// hostapd, dnsmasq, iptables and Linux IP forwarding.
+type Router struct{}
+
+// NewRouter reports that the VPN router is unsupported on this platform. The
+// config is still validated so misconfiguration surfaces the same way.
+func NewRouter(cfg RouterConfig, _ logrus.FieldLogger) (*Router, error) {
+	if err := cfg.withDefaults().validate(); err != nil {
+		return nil, err
+	}
+	return nil, fmt.Errorf("vpn-router: the VPN gateway/AP role is only supported on Linux (this is %s)", runtime.GOOS)
+}
+
+// Run never runs — NewRouter already errored on non-Linux.
+func (r *Router) Run(_ context.Context) error {
+	return fmt.Errorf("vpn-router: unsupported on %s", runtime.GOOS)
+}

--- a/pkg/vpn/router_test.go
+++ b/pkg/vpn/router_test.go
@@ -1,0 +1,129 @@
+package vpn
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func mustCIDR(t *testing.T, s string) (net.IP, *net.IPNet) {
+	t.Helper()
+	ip, n, err := net.ParseCIDR(s)
+	if err != nil {
+		t.Fatalf("ParseCIDR(%q): %v", s, err)
+	}
+	return ip, n
+}
+
+func TestRouterConfigValidate(t *testing.T) {
+	gw, subnet := mustCIDR(t, "192.168.42.1/24")
+	base := func() RouterConfig {
+		return RouterConfig{LANInterface: "eth1", Gateway: gw, Subnet: subnet}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(c *RouterConfig)
+		wantErr bool
+	}{
+		{"valid ethernet", func(_ *RouterConfig) {}, false},
+		{"no LAN interface", func(c *RouterConfig) { c.LANInterface = "" }, true},
+		{"no gateway", func(c *RouterConfig) { c.Gateway = nil }, true},
+		{"no subnet", func(c *RouterConfig) { c.Subnet = nil }, true},
+		{"gateway outside subnet", func(c *RouterConfig) { c.Gateway = net.ParseIP("10.0.0.1") }, true},
+		{"dhcp start outside subnet", func(c *RouterConfig) { c.DHCPStart = net.ParseIP("10.0.0.5") }, true},
+		{"valid wifi wpa2", func(c *RouterConfig) {
+			c.WiFi = &WiFiConfig{SSID: "sky", Passphrase: "supersecret", Band: "2.4"}
+		}, false},
+		{"wifi no ssid", func(c *RouterConfig) { c.WiFi = &WiFiConfig{Passphrase: "supersecret"} }, true},
+		{"wifi empty passphrase not allowed", func(c *RouterConfig) { c.WiFi = &WiFiConfig{SSID: "sky"} }, true},
+		{"wifi open allowed", func(c *RouterConfig) { c.WiFi = &WiFiConfig{SSID: "sky", AllowOpen: true} }, false},
+		{"wifi passphrase too short", func(c *RouterConfig) { c.WiFi = &WiFiConfig{SSID: "sky", Passphrase: "short"} }, true},
+		{"wifi bad band", func(c *RouterConfig) {
+			c.WiFi = &WiFiConfig{SSID: "sky", Passphrase: "supersecret", Band: "6"}
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := base()
+			tt.mutate(&c)
+			err := c.withDefaults().validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validate() err=%v, wantErr=%v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDefaultsFromSubnet(t *testing.T) {
+	gw, subnet := mustCIDR(t, "192.168.42.1/24")
+	c := RouterConfig{LANInterface: "eth1", Gateway: gw, Subnet: subnet}.withDefaults()
+	if got := c.DHCPStart.String(); got != "192.168.42.10" {
+		t.Errorf("DHCPStart = %s, want 192.168.42.10", got)
+	}
+	if got := c.DHCPEnd.String(); got != "192.168.42.254" {
+		t.Errorf("DHCPEnd = %s, want 192.168.42.254", got)
+	}
+	if got := c.DNS.String(); got != "192.168.42.1" {
+		t.Errorf("DNS defaulted to %s, want the gateway 192.168.42.1", got)
+	}
+	if c.LeaseTime != defaultLeaseTime {
+		t.Errorf("LeaseTime = %q, want %q", c.LeaseTime, defaultLeaseTime)
+	}
+}
+
+func TestDnsmasqConf(t *testing.T) {
+	gw, subnet := mustCIDR(t, "192.168.42.1/24")
+	c := RouterConfig{LANInterface: "wlan0", Gateway: gw, Subnet: subnet}
+	conf := c.DnsmasqConf()
+	for _, want := range []string{
+		"interface=wlan0",
+		"dhcp-range=192.168.42.10,192.168.42.254,12h",
+		"dhcp-option=option:router,192.168.42.1",
+		"dhcp-option=option:dns-server,192.168.42.1",
+	} {
+		if !strings.Contains(conf, want) {
+			t.Errorf("dnsmasq.conf missing %q\n---\n%s", want, conf)
+		}
+	}
+}
+
+func TestHostapdConf(t *testing.T) {
+	w := WiFiConfig{SSID: "SkywireVPN", Passphrase: "supersecret", Band: "5", Channel: 0, CountryCode: "DE"}
+	conf := w.HostapdConf("wlan0")
+	for _, want := range []string{
+		"interface=wlan0",
+		"driver=nl80211",
+		"ssid=SkywireVPN",
+		"country_code=DE",
+		"hw_mode=a",  // 5 GHz
+		"channel=36", // default for 5 GHz
+		"wpa=2",
+		"wpa_passphrase=supersecret",
+	} {
+		if !strings.Contains(conf, want) {
+			t.Errorf("hostapd.conf missing %q\n---\n%s", want, conf)
+		}
+	}
+
+	// 2.4 GHz open network: hw_mode g, default channel 6, no WPA block.
+	open := WiFiConfig{SSID: "Open", Band: "2.4", AllowOpen: true}
+	oc := open.HostapdConf("wlan0")
+	if !strings.Contains(oc, "hw_mode=g") || !strings.Contains(oc, "channel=6") {
+		t.Errorf("open 2.4GHz conf wrong hw_mode/channel\n%s", oc)
+	}
+	if strings.Contains(oc, "wpa=") {
+		t.Errorf("open network should have no wpa block\n%s", oc)
+	}
+}
+
+func TestNthHost(t *testing.T) {
+	_, subnet := mustCIDR(t, "192.168.42.0/24")
+	if got := nthHost(subnet, 10); got == nil || got.String() != "192.168.42.10" {
+		t.Errorf("nthHost(.../24, 10) = %v, want 192.168.42.10", got)
+	}
+	// overflow past the /24 returns nil
+	if got := nthHost(subnet, 300); got != nil {
+		t.Errorf("nthHost(.../24, 300) = %v, want nil (overflow)", got)
+	}
+}


### PR DESCRIPTION
## What

A new `vpn-router` launcher app that turns a visor into a **router**: downstream LAN/WiFi clients reach the internet through the Skywire mesh VPN **without running any Skywire software themselves**. A laptop or phone joins the router's WiFi (or plugs into its LAN port) and its traffic is NATed into the mesh tunnel.

## Design — companion to vpn-client, not a replacement

```
 clients            this visor                 mesh
┌────────┐   DHCP  ┌────────────────────┐
│ laptop │◀───────▶│ vpn-router (new)   │
│ phone  │         │  hostapd (WiFi)    │
│192.168 │         │  dnsmasq (DHCP/DNS)│      ┌────────────┐
│  .42.x │         │  NAT downstream→tun│      │ vpn-server │
└────────┘         │                    │      │  (exit)    │
  wlan0/eth1       │ vpn-client (exists)│─tun0─▶│           │──▶ internet
                   │  owns tun0 tunnel  │ mesh └────────────┘
                   └────────────────────┘
```

`vpn-client` owns the tunnel (`tun0`) — unchanged. `vpn-router` owns the downstream side: brings up the LAN/WiFi interface, runs `dnsmasq` (DHCP+DNS), optionally runs `hostapd` (WiFi AP), and NATs the client subnet into `tun0`. Enable both apps (AutoStart); the router waits up to 90 s for the tunnel, so start order is irrelevant.

**Two variants, one code path:**
- **ethernet-out** — `--lan-ifc eth1`; works on the existing Skyminer SBCs, dnsmasq only.
- **WiFi-out** — `--lan-ifc wlan0 --wifi --ssid … --passphrase …`; hostapd also beacons the SSID (needs a chipset whose driver does AP mode — Pi onboard or a MT7612U dongle).

The NAT reuses the **vpn-server** primitives applied to the tunnel (`EnableIPv4Forwarding`, `EnableIPMasquerading(tun0)`, targeted `LAN↔tun0` FORWARD rules); teardown reverses everything and reaps the daemons via context.

## Files
- `pkg/vpn/router.go` — config + pure `DnsmasqConf`/`HostapdConf` generators
- `pkg/vpn/router_linux.go` — interface/daemon/NAT orchestration + teardown
- `pkg/vpn/router_other.go` — non-Linux stub
- `pkg/vpn/router_test.go` — validation + config-generation unit tests
- `cmd/apps/vpn-router/…` — launcher app + flags; `pkg/skyenv` name; root wiring
- `docs/design/vpn-router-app.md` — architecture, enabling in config, hardware test procedure

## Test status (honest)
- **Unit-tested (CI):** config validation, DHCP-pool defaults, generated `dnsmasq.conf`/`hostapd.conf`.
- **Build-verified:** Linux + non-Linux stub; app registers, flags parse; `go build ./...`, vet + golangci-lint clean.
- **Needs hardware:** the live interface/daemon/NAT path needs a real two-interface router box (Pi 4 `eth0`+`wlan0`, or an SBC with `eth0`+`eth1`) — validation procedure in the doc.

## Follow-ups (not in this PR)
- Add to config-gen behind a flag (updating golden config fixtures).
- HV UI settings page (mirror the vpn-client component).
- Optional self-contained mode (embed the tunnel) + per-client ACL.