### PR TITLE
fix(cxo): reap leaked Conns + break the feeds↔head cyclic deadlock (TPD OOM/stall)

### DIFF
--- a/pkg/cxo/node/feed.go
+++ b/pkg/cxo/node/feed.go
@@ -72,7 +72,29 @@ func (n *nodeFeed) receivedRoot(cr connRoot) {
 
 			var tormh = n.hs[torm]
 
-			tormh.errq <- ErrMaxHeadsLimit
+			// Hand the evicted head its error while draining brorq — same
+			// feeds↔head deadlock avoidance as nodeHead.receivedRoot. This runs
+			// on the nodeFeeds event-loop goroutine (handleReceivedRoot →
+			// nodeFeed.receivedRoot → here), the sole drainer of brorq; a bare
+			// `tormh.errq <- ...` would deadlock if tormh's handle loop is parked
+			// sending to brorq (broadcastRoot). handleBroadcastRoot is
+			// non-blocking and same-goroutine-safe. Once the error is delivered
+			// (or the head/node is closing), close() waits for the head loop to
+			// drain it and exit.
+			fs := n.fs
+		evict:
+			for {
+				select {
+				case tormh.errq <- ErrMaxHeadsLimit:
+					break evict
+				case <-tormh.closeq:
+					break evict
+				case bcr := <-fs.brorq:
+					fs.handleBroadcastRoot(bcr)
+				case <-fs.closeq:
+					break evict
+				}
+			}
 			tormh.close() // wait
 
 			delete(n.hs, torm) // remove

--- a/pkg/cxo/node/feeds.go
+++ b/pkg/cxo/node/feeds.go
@@ -464,8 +464,19 @@ func (n *nodeFeeds) handleDelConn(c *Conn) {
 // (api)
 func (n *nodeFeeds) receivedRoot(c *Conn, r *registry.Root) {
 
+	// receivedRoot runs synchronously on the connection's receiveMsg
+	// goroutine. n.rrq is drained by the single nodeFeeds event loop; if that
+	// loop stalls (e.g. the feeds↔head pipeline backs up), this send blocks.
+	// Guarding ONLY on n.closeq (node shutdown) means a connection that closes
+	// while parked here never unblocks — receiveMsg never returns, its Conn's
+	// run() stays in await.Wait(), and the whole Conn (≈5 goroutines + buffers)
+	// leaks. On a busy transport-discovery that leak reached thousands of
+	// goroutines / multi-GB RSS → OOM. Also select on c.closeq so a closing
+	// connection's receiveMsg unblocks and the Conn is reaped even while the
+	// node-level pipeline is stalled.
 	select {
 	case n.rrq <- connRoot{c, r}:
+	case <-c.closeq:
 	case <-n.closeq:
 	}
 

--- a/pkg/cxo/node/feeds_leak_test.go
+++ b/pkg/cxo/node/feeds_leak_test.go
@@ -1,0 +1,50 @@
+package node
+
+import (
+	"testing"
+	"time"
+)
+
+// TestReceivedRootUnblocksOnConnClose is a regression test for the
+// transport-discovery CXO connection leak (OOM): nodeFeeds.receivedRoot runs on
+// a connection's receiveMsg goroutine and sends into n.rrq. When the single
+// nodeFeeds event loop stalls (feeds↔head pipeline backpressure), that send
+// blocks. Before the fix it was guarded only on n.closeq (node shutdown), so a
+// connection that closed while parked here never unblocked — receiveMsg never
+// returned, its Conn's run() stayed in await.Wait(), and the whole Conn leaked
+// (~5 goroutines each), reaching thousands of goroutines / multi-GB RSS.
+//
+// The fix adds a c.closeq case so a closing connection's receiveMsg unblocks
+// even while the node-level pipeline is stalled. This test simulates the stall
+// with an unbuffered, never-drained rrq and asserts receivedRoot returns once
+// the conn closes.
+func TestReceivedRootUnblocksOnConnClose(t *testing.T) {
+	n := &nodeFeeds{
+		rrq:    make(chan connRoot), // unbuffered + never drained → the send blocks
+		closeq: make(chan struct{}), // node stays UP (n.closeq must NOT be what saves us)
+	}
+	c := &Conn{closeq: make(chan struct{})}
+
+	done := make(chan struct{})
+	go func() {
+		n.receivedRoot(c, nil) // parks on the blocked rrq send
+		close(done)
+	}()
+
+	// Ensure it's actually parked on the send before we close the conn.
+	select {
+	case <-done:
+		t.Fatal("receivedRoot returned before the conn closed — the send did not block as the test intends")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Closing the connection (idle watchdog / peer drop) must unblock receiveMsg.
+	close(c.closeq)
+
+	select {
+	case <-done:
+		// good: the conn's receiveMsg unblocked and can now return → Conn reaped
+	case <-time.After(2 * time.Second):
+		t.Fatal("receivedRoot did not unblock when the conn closed — CXO conn leak regression")
+	}
+}

--- a/pkg/cxo/node/head.go
+++ b/pkg/cxo/node/head.go
@@ -72,9 +72,28 @@ func (n *nodeHead) delConn(c *Conn) {
 // (api)
 func (n *nodeHead) receivedRoot(cr connRoot) {
 
-	select {
-	case n.rrq <- cr:
-	case <-n.closeq:
+	// Breaks the feeds↔head cyclic deadlock. This runs on the single nodeFeeds
+	// event-loop goroutine (handleReceivedRoot → nodeFeed.receivedRoot → here),
+	// which is ALSO the sole drainer of nodeFeeds.brorq. n.rrq is unbuffered and
+	// drained by this head's handle() loop — but that loop can itself be parked
+	// sending to brorq (handle → createFiller → broadcastRoot), and broadcastRoot
+	// only unblocks when the feeds loop drains brorq. So a bare `n.rrq <- cr`
+	// here deadlocks: we wait for the head loop to read rrq while the head loop
+	// waits for us to read brorq. Keep draining brorq while we wait to hand off,
+	// so the head loop can make progress and drain rrq. handleBroadcastRoot is
+	// non-blocking (fire-and-forget per-subscriber fan-out — see
+	// nodeFeed.broadcastRoot), and we're on the loop goroutine so touching fs
+	// state is safe.
+	fs := n.n.fs
+	for {
+		select {
+		case n.rrq <- cr:
+			return
+		case <-n.closeq:
+			return
+		case bcr := <-fs.brorq:
+			fs.handleBroadcastRoot(bcr)
+		}
 	}
 
 }


### PR DESCRIPTION
Fixes the production transport-discovery (CXO node) incident: **connection leak → OOM** (~500 leaked Conns, ~3000 goroutines, 4.25 GB RSS, +570 MB/hr) and the **pipeline stall** behind it. Diagnosed live via pty + `/debug/pprof/goroutine`. Two commits — the deadlock is the trigger, the leak is the fatal consequence.

## Commit 2 — the trigger: feeds↔head cyclic deadlock

A cyclic channel deadlock between the single `nodeFeeds` event loop and the per-head `nodeHead` loops, over two **unbuffered** channels:

- feeds loop → `handleReceivedRoot` → `nodeFeed.receivedRoot` → `nodeHead.receivedRoot` → send to the head's unbuffered **`rrq`** (blocks the feeds loop)
- head loop → `handle` → `createFiller` → `broadcastRoot` → send to `nodeFeeds.`**`brorq`** (blocks the head loop)

The single `nodeFeeds` loop is **both** the producer to heads (`rrq`) **and** the sole drainer of the heads' return channel (`brorq`). Block producing ⇒ stop draining `brorq` ⇒ head blocks producing back ⇒ stops draining its `rrq` ⇒ neither proceeds; only `n.closeq` (node shutdown) would break it. The whole receive pipeline freezes.

**Fix:** both feeds→head blocking sends run *on the nodeFeeds loop goroutine* — the sole `brorq` drainer — so keep draining `brorq` while waiting to hand off. `nodeFeed.broadcastRoot` (the `brorq` consumer) is fire-and-forget per-subscriber fan-out, so `handleBroadcastRoot` is non-blocking and same-goroutine safe. Applied to both feeds→head sends: `nodeHead.receivedRoot` (the every-root path) and the `MaxHeads` eviction `errq` send (MaxHeads default 10 → reachable). No goroutine spawn (avoids re-introducing a leak).

## Commit 1 — the fatal consequence: bound memory during a stall

`nodeFeeds.receivedRoot` runs synchronously on each connection's `receiveMsg` and sends into `n.rrq`, guarded **only on `n.closeq`**. While the pipeline was deadlocked, a connection that closed (idle watchdog / peer drop) never unblocked here → `receiveMsg` never returned → its Conn's `run()` stayed in `await.Wait()` → the whole Conn (~5 goroutines) leaked. pprof: **203 parked in `receivedRoot`**, `run` (696) > `receiveMsg`/`idleWatchdog` (493).

**Fix:** add `case <-c.closeq` so a closing connection's `receiveMsg` unblocks and the Conn is reaped even if the pipeline stalls — a defense-in-depth guard that bounds memory to the live-connection set regardless of pipeline health. Regression test (`feeds_leak_test.go`) times out without it.

## Test / build
- `go build ./pkg/cxo/node/`, `go vet`, `gofmt`, `golangci-lint` clean
- `go test ./pkg/cxo/node/ -race` green (full suite exercises the root pipeline) incl. the new regression test

## Follow-up (not this PR)
Worth questioning whether transport-discovery should run a full CXO node holding hundreds of peer connections at all.