### PR TITLE
feat(wasm-visor): fold a reworded disclaimer into the tour + refine opening copy

### DIFF
--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -1072,7 +1072,9 @@
     if (doc.getElementById("skywire-tour")) { return; }
     var steps = [
       { title: "This is not a normal web page",
-        body: "You're running a full <b>Skywire visor</b> — a routing peer on an encrypted peer-to-peer mesh — entirely inside this browser tab. No install, no account, and no central server. A 60-second tour of what that means." },
+        body: "You're running a full <b>Skywire visor</b> — a live routing peer on an encrypted, peer-to-peer mesh — right here in this browser tab. No install, no account, no central server, no one in the middle. Here's a 60-second tour of what that means.",
+        disc: { summary: "Open-source, no warranty — your keys are yours",
+          details: "Skywire and the Skycoin wallet are experimental, open-source software, provided as-is and without warranty. You run this visor yourself and hold your own keys and coins; no one else can access or recover them. Understand the risks before relying on it or storing value." } },
       { sel: "#tb-menu", title: "Your apps",
         body: "Everything opens from here: a browser for the mesh, encrypted 1:1 chat, a live log, a command console, and your visor's cryptographic identity." },
       { sel: "app-top-bar", title: "The network, live",
@@ -1119,6 +1121,11 @@
         '<b style="color:#9d7cff;font-size:14px">' + s.title + '</b><span style="flex:1"></span>' +
         '<span style="opacity:.55;font-size:11px">' + (i + 1) + " / " + steps.length + '</span></div>' +
         '<div style="margin-bottom:.9em">' + s.body + '</div>' +
+        (s.disc ?
+          '<details style="margin:-.35em 0 .85em;border-top:1px solid #2a2342;padding-top:.6em">' +
+          '<summary style="cursor:pointer;color:#8b93a7;font-size:11.5px;outline:none">' + s.disc.summary + '</summary>' +
+          '<div style="margin-top:.5em;color:#9aa0ad;font-size:11.5px">' + s.disc.details + '</div>' +
+          '</details>' : '') +
         '<div style="display:flex;gap:.5em;align-items:center">' +
         '<button id="tour-skip" style="cursor:pointer;background:transparent;color:#8b93a7;border:0">skip</button>' +
         '<span style="flex:1"></span>' +


### PR DESCRIPTION
The wasm-visor tour's opening screen now carries a concise, honest **disclaimer behind a collapsible expander** (above the skip/next buttons), covering **both Skywire and the Skycoin wallet** — both open-source, as-is, self-custody. This is the replacement for the blocking disclaimer modal that skycoin-web shows before the wallet: the visor-embedded wallet will skip that modal (follow-up), while the **standalone** skycoin-web keeps its own — reworded — disclaimer.

**Wording** deliberately fixes the original modal's two weak points:
- *"cryptographic tokens"* → dropped. Skycoin is its own coin (own chain + Coin Hours), not a token; the software has no token support.
- *"agree to the Terms and Conditions"* → dropped. There are no published T&C, so it referenced nothing.

It keeps the honest **as-is / no-warranty** and adds the point that actually matters for a local wallet: **you alone hold your keys and coins, and no one can recover them.**

Tour expander:
> **Open-source, no warranty — your keys are yours** ▸
> *Skywire and the Skycoin wallet are experimental, open-source software, provided as-is and without warranty. You run this visor yourself and hold your own keys and coins; no one else can access or recover them. Understand the risks before relying on it or storing value.*

Also lightly refines the opening body copy.

**Validated live:** built, served via `hv serve`, triggered the tour over CDP, confirmed the expander renders and reads correctly in the dark theme.

### Related (separate)
- skycoin-web standalone disclaimer reword (same fixes) → a PR to the skycoin fork.
- Skipping the disclaimer + language modals for the *visor-embedded* wallet (via the `/wallet/` shim pre-setting skycoin-web's onboarding localStorage flags) → follow-up.