### PR TITLE
feat(wallet): skycoin-web multicoin via the /coin/<index> server-proxy model (native + wasm)

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -30,6 +30,7 @@ import (
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/visor"
+	"github.com/skycoin/skywire/pkg/wallet/coins"
 	"github.com/skycoin/skywire/pkg/wasmhv"
 	"github.com/skycoin/skywire/pkg/wasmhv/ctlbridge"
 	"github.com/skycoin/skywire/pkg/wasmhv/wasmbin"
@@ -72,16 +73,20 @@ func coinNodeDefault() string {
 func walletDmsgFetchShim() string {
 	return `<script>(function(){` +
 		`var rf=window.fetch?window.fetch.bind(window):null;` +
+		// The coin registry (same source of truth as the native visor's
+		// pkg/wallet/coins). skycoin-web's coin.service fetches /api/v1/coins;
+		// each coin's nodeUrl is a "/coin/<index>" prefix this shim routes.
+		`var COINS=` + string(coins.JSON()) + `;` +
 		`function p(u){try{return new URL(u,location.href).pathname;}catch(e){return String(u);}}` +
 		`function q(u){try{return new URL(u,location.href).search;}catch(e){return "";}}` +
-		`function isCoin(u){return /^\/api\/v[12]\//.test(p(u));}` +
-		// BTC is any path containing /v1/btc/ — this catches BOTH the raw
-		// /v1/btc/health (node-health probe) AND skycoin-web's apiService form
-		// /api/v1/btc/{balance,history,send} (which also matches isCoin, but the
-		// BTC branch is checked first). No skycoin node endpoint contains
-		// /v1/btc/, and the gateway normalizes on that substring, so passing the
-		// full path through to btcFetch works either way.
-		`function isBtc(u){return /\/v1\/btc\//.test(p(u));}` +
+		// A wallet request is either a "/coin/<index>/…" per-coin call or a bare
+		// "/api/v[12]/…" (pre-registry / fallback → the default coin 0). mc[2] is
+		// the node-relative path after the /coin/<index> prefix.
+		`function coinMatch(pth){return /^\/coin\/(\d+)(\/[^?]*)?/.exec(pth);}` +
+		// BTC is any path containing /v1/btc/ (the wallet addresses bitcoin as
+		// /coin/1/api/v1/btc/…). The in-tab electrum gateway normalizes on that
+		// substring, so routing by it is robust to custom node overrides too.
+		`function isBtc(pth){return /\/v1\/btc\//.test(pth);}` +
 		`function ls(k){try{return localStorage.getItem(k)||"";}catch(e){return "";}}` +
 		// The wallet POSTs balance/transactions as x-www-form-urlencoded; forward the
 		// request Content-Type so fetchDmsg/fetchClearnet don't mislabel the body as
@@ -91,8 +96,14 @@ func walletDmsgFetchShim() string {
 		`function mkResp(r){var b=(r&&typeof r.body==="string")?r.body:(r&&r.body?new TextDecoder().decode(r.body):"");return new Response(b,{status:(r&&r.status)||502,headers:{"Content-Type":"application/json"}});}` +
 		`window.fetch=function(input,init){` +
 		`var url=(typeof input==="string")?input:(input&&input.url);` +
-		`var coin=isCoin(url),btc=isBtc(url);` +
-		`if(!coin&&!btc)return rf?rf(input,init):Promise.reject(new Error("no fetch"));` +
+		`var pn=p(url);` +
+		// Coin list → served in-tab from the registry (no node round-trip).
+		`if(/\/api\/v1\/coins$/.test(pn)){return Promise.resolve(new Response(JSON.stringify(COINS),{status:200,headers:{"Content-Type":"application/json"}}));}` +
+		`var mc=coinMatch(pn);` +
+		`var coin=!!mc||/^\/api\/v[12]\//.test(pn);` +
+		`if(!coin)return rf?rf(input,init):Promise.reject(new Error("no fetch"));` +
+		// Node-relative path: strip the /coin/<index> prefix if present.
+		`var rel=mc?(mc[2]||"/"):pn;var btc=isBtc(pn);` +
 		`init=init||{};` +
 		`var v=window.parent&&window.parent.skywireVisor;` +
 		`if(!v||!v.fetchDmsg)return Promise.resolve(jr(503,{error:"skywire visor not ready"}));` +
@@ -101,7 +112,7 @@ func walletDmsgFetchShim() string {
 		// #plog panel — and the browser console — show what's crossing the mesh,
 		// mirroring the resolving-proxy browser (browse.js). Visible even at the
 		// seed-entry screen, where there's no wallet to query yet.
-		`var m=init.method||"GET",pth=p(url)+q(url),t0=Date.now();` +
+		`var m=init.method||"GET",pth=rel+q(url),t0=Date.now();` +
 		`function wlog(s){try{var L=window.parent&&window.parent.skywireLog;if(L&&L.emit)L.emit("info",["[wallet] "+s]);}catch(e){}}` +
 		`function done(tag){return function(r){wlog(tag+" → "+((r&&r.status)||"?")+" ("+(Date.now()-t0)+"ms)");return mkResp(r);};}` +
 		`function fail(tag){return function(e){wlog(tag+" ✗ "+String((e&&e.message)||e));return jr(502,{error:String(e)});};}` +

--- a/docs/design/skycoin-web-multicoin-wallets.md
+++ b/docs/design/skycoin-web-multicoin-wallets.md
@@ -1,0 +1,86 @@
+# skycoin-web multicoin over the visor — the `/coin/<index>` server-proxy model
+
+## The correct model (as skycoin-web already implements it)
+
+skycoin-web is **already multicoin**. It does NOT need per-coin URLs baked into the
+wallet. The mechanism (in the vendored source):
+
+- `coin.service.ts` fetches the coin list from **`/api/v1/coins`** and builds
+  `BaseCoin[]` via `BaseCoin.fromServerData` — each coin has an `id`, a
+  `nodeUrl`, a `coinType` (`skycoin` | `bitcoin` | `bitcoin-segwit`), symbol,
+  hours name, price-ticker id, explorer, etc.
+- `api.service.ts` sends every request for the current coin to
+  `customNodeUrls[coin.id] || coin.nodeUrl` — i.e. the coin's **own `nodeUrl`
+  prefix**.
+- The wallet already understands bitcoin coins (`isBitcoin()` → 8 decimals, no
+  Coin Hours, skycoin-lite signing). BTC is just a coin with
+  `coinType: 'bitcoin'`.
+
+So the **server** (normally the skycoin daemon; here **the visor**) is the coin
+router: it serves `/api/v1/coins` and proxies `/coin/<index>/…` to each coin's
+backend. The wallet source needs **no change**.
+
+### Why the earlier attempt was wrong (and is being reworked)
+
+#2940 / #3493 put the backend into the coin's `nodeUrl` directly (e.g. an
+`ssl://` electrum server in the URL) and bolted BTC on with a special
+`/v1/btc/` fetch-intercept in the visor's `/wallet/` shim. That diverges from
+skycoin-web's model, doesn't generalise past one extra coin, and left a
+`TODO(config): multi-coin /coin/N` in `hypervisor_handlers_wallet.go`. This
+rework replaces it with the native `/coin/<index>` model.
+
+## Coin registry (visor-side)
+
+A small ordered registry, each entry a `BaseCoin` record returned by
+`/api/v1/coins` with `nodeUrl = "/coin/<index>"`:
+
+| index | coinType | backend the visor proxies `/coin/<index>/…` to |
+|---|---|---|
+| 0 | `skycoin` | the skycoin node, over dmsg (the deployment `skycoin_node_dmsg`, or the operator's Settings→Nodes URL) |
+| 1 | `bitcoin` | the in-visor **electrum gateway** (`pkg/btcgateway`), dialed ssl:// over the mesh via skysocks-lite |
+
+Extensible: adding a coin = one registry entry + its backend route. `serverWallets:false` for all (the browser holds keys/does signing).
+
+## Visor implementation
+
+**Native visor** (`pkg/visor/hypervisor_handlers_wallet.go`):
+- `GET /api/v1/coins` → serialize the registry (JSON array of `BaseCoin`).
+- `/coin/<index>/*` → strip the prefix, route the remainder to the registry
+  entry's backend:
+  - index 0 → the existing dmsg node proxy (`walletNodeProxy`).
+  - index 1 → the existing BTC electrum gateway (`nativeBtcGateway`).
+- **Remove** the `/v1/btc/` special-case intercept (now just `/coin/1/api/v1/btc/…`).
+- Keep the operator's Settings→Nodes override working: `customNodeUrls[0]` (a
+  full dmsg/clearnet URL) overrides the default skycoin node for `/coin/0`.
+
+**wasm visor** (`cmd/skywire-cli/commands/hv/serve.go` shim + the in-tab
+`skywireVisor`):
+- `/api/v1/coins` → served by the tab (same registry, static JSON).
+- `/coin/<index>/…` → the shim routes to `skywireVisor.fetchDmsg` (index 0) or
+  `skywireVisor.btcFetch` (index 1); drop the `/v1/btc/` substring special-case.
+
+Both paths converge on the same registry definition (one Go source of truth,
+mirrored to the tab as JSON) so native + wasm serve identical coins.
+
+## What stays unchanged
+
+- **The wallet source** — skycoin-web already does `/api/v1/coins` + per-coin
+  `nodeUrl`. (The unrelated onboarding-disclaimer reword + the embedded
+  wizard-skip are separate.)
+- `pkg/btcgateway` (the electrum→HTTP gateway) — reused as the `/coin/1` backend.
+- Key handling / signing — always browser-side (skycoin-lite WASM).
+
+## Migration / compatibility
+
+- Bare `/api/v1/*` (no `/coin/` prefix) → treat as `/coin/0` (default coin) so an
+  un-migrated wallet build still reaches skycoin.
+- The `/v1/btc/*` intercept is deleted once the registry lists BTC at `/coin/1`.
+
+## Open decisions
+
+1. **Registry location**: a new `pkg/skyenv` (or `pkg/wallet/coins`) Go slice, so
+   native + wasm + config-gen share it.
+2. Whether the **coin list is operator-configurable** (add coins via config) or
+   fixed to {skycoin, bitcoin} for now — start fixed, make it config later.
+3. Per-coin node override UX lives in skycoin-web's **Settings→Nodes**
+   (`customNodeUrls`) — the outer visor wallet-config panel slims to transport-only.

--- a/pkg/visor/hypervisor_handlers_wallet.go
+++ b/pkg/visor/hypervisor_handlers_wallet.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 
 	"github.com/skycoin/skywire/pkg/btcgateway"
+	"github.com/skycoin/skywire/pkg/wallet/coins"
 	"github.com/skycoin/skywire/pkg/wasmhv/browseui"
 )
 
@@ -105,31 +107,32 @@ const walletNodeShim = `<script>(function(){` +
 	`var p=pathOf(url);` +
 	`function searchOf(u){try{return new URL(u,location.href).search;}catch(e){return "";}}` +
 	`function hostOf(u){try{var x=new URL(u,location.href);return (x.host&&x.host!==location.host)?(x.protocol+"//"+x.host):"";}catch(e){return "";}}` +
-	// BTC = any path containing /v1/btc/ — the raw /v1/btc/health probe AND
-	// skycoin-web's apiService form /api/v1/btc/{balance,history,send} (which
-	// also matches the node regex, so BTC is classified FIRST and wins). No
-	// skycoin node endpoint contains /v1/btc/.
-	`var mb=/\/v1\/btc\//.test(p);` +
-	`var mn=!mb&&/^\/(wallet\/)?api\/v[12]\//.test(p);` +
-	`if(!mn&&!mb){return rf(input,init);}` +
+	// Coin list: coin.service fetches /api/v1/coins raw (no coin prefix). Serve it
+	// from the visor registry (/wallet/coins), not a node.
+	`if(/\/api\/v1\/coins$/.test(p)){return rf(location.origin+"/wallet/coins",init);}` +
+	// Per-coin API: api.service prefixes every request with the coin's nodeUrl =
+	// "/coin/<index>". Re-point at the mounted proxy (/wallet/coin/<index>/…).
+	`var mc=/\/coin\/(\d+)\//.exec(p);` +
+	// Legacy: a bare /api/v[12]/ with no /coin/ prefix (pre-registry build /
+	// fallback coin) → the default coin 0.
+	`var ml=!mc&&/^\/(wallet\/)?api\/v[12]\//.test(p);` +
+	`if(!mc&&!ml){return rf(input,init);}` +
 	`init=init||{};` +
 	`var h=new Headers((init&&init.headers)||(typeof input!=="string"&&input&&input.headers)||undefined);` +
 	`var target;` +
-	`if(mb){` +
-	// Normalize any /v1/btc/ path (bare or /api/v1/btc/) to /wallet/v1/btc/… so
-	// the server routes it to the in-process electrum gateway, not the node.
-	`var tail=p.slice(p.indexOf("/v1/btc/"));target=location.origin+"/wallet"+tail+searchOf(url);` +
+	`if(mc){` +
+	`var tail=p.slice(p.indexOf("/coin/"));target=location.origin+"/wallet"+tail+searchOf(url);` +
+	`}else{` +
+	`var bare=p.replace(/^\/(wallet\/)?/,"");target=location.origin+"/wallet/coin/0/"+bare+searchOf(url);` +
+	`}` +
+	// Tag the backend selection by path. BTC (any /v1/btc/) carries the operator's
+	// electrum backend + optional skysocks exit; a skycoin-style node carries the
+	// chosen node (absolute host from Settings → Nodes, else the config-panel key,
+	// else the deployment default) — walletCoinProxy / walletNodeProxy use these.
+	`if(/\/v1\/btc\//.test(p)){` +
 	`var b=ls("skywire-btc-backend");if(b){h.set("X-Skywire-Btc-Backend",b);}` +
 	`var xp=ls("skywire-btc-proxy");if(xp){h.set("X-Skywire-Btc-Proxy",xp);}` +
 	`}else{` +
-	// Node API: skycoin-web addresses a custom node (Settings → Nodes /
-	// customNodeUrls) with an ABSOLUTE url — strip the host, keep the /api path +
-	// query, and re-point at /wallet/api here; the chosen node travels in
-	// X-Skywire-Coin-Node so walletNodeProxy dials it (its Nodes GUI is
-	// authoritative; a same-origin/relative /api path falls back to the legacy
-	// config-panel key, else the deployment mesh default).
-	`var mnx=/^\/(wallet\/)?api\/v[12]\//.exec(p);var pre=mnx&&mnx[1];` +
-	`target=pre?url:(location.origin+"/wallet"+p+searchOf(url));` +
 	`var nn=hostOf(url)||ls("skywire-coin-node");if(nn){h.set("X-Skywire-Coin-Node",nn);}` +
 	`}` +
 	`init.headers=h;return rf(target,init);` +
@@ -155,21 +158,27 @@ func (hv *Hypervisor) walletHandler() http.HandlerFunc {
 			_, _ = w.Write([]byte(browseui.WalletConfigHTML)) //nolint:errcheck
 			return
 		}
-		// Node API (/wallet/api/v1|v2/*) → proxy to the node over dmsg. The
-		// wallet's crypto is client-side; only these calls cross the mesh.
-		if strings.HasPrefix(rest, "api/v1/") || strings.HasPrefix(rest, "api/v2/") {
-			hv.walletNodeProxy(w, r, rest)
+		// Coin registry (/wallet/coins) → the list skycoin-web's coin.service
+		// fetches from /api/v1/coins. Each coin's nodeUrl is a /coin/<index>
+		// prefix this handler proxies below.
+		if rest == "coins" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Cache-Control", "no-cache")
+			_, _ = w.Write(coins.JSON()) //nolint:errcheck
 			return
 		}
-		// BTC API (/wallet/v1/btc/*) → the in-process electrum gateway. The
-		// browser derives + signs BTC itself; only chain queries come here. The
-		// electrum server (X-Skywire-Btc-Backend) is reached either directly on
-		// the clearnet (self-egress, the default) or — when the operator sets a
-		// skysocks exit (X-Skywire-Btc-Proxy) — routed through that visor for IP
-		// privacy. Both headers are set by the shim from localStorage.
-		if strings.HasPrefix(rest, "v1/btc/") {
-			r.URL.Path = "/" + rest
-			hv.nativeBtcGateway(r.Header.Get("X-Skywire-Btc-Proxy")).ServeHTTP(w, r)
+		// Per-coin API (/wallet/coin/<index>/*) → route to that coin's backend:
+		// a skycoin-style node over dmsg, or the in-visor BTC electrum gateway.
+		if strings.HasPrefix(rest, "coin/") {
+			hv.walletCoinProxy(w, r, strings.TrimPrefix(rest, "coin/"))
+			return
+		}
+		// Legacy: a bare node-API call (/wallet/api/v1|v2/*) with no /coin/ prefix
+		// → the default coin (skycoin, index 0), so an un-migrated wallet build
+		// still reaches the node. The wallet's crypto is client-side; only these
+		// calls cross the mesh.
+		if strings.HasPrefix(rest, "api/v1/") || strings.HasPrefix(rest, "api/v2/") {
+			hv.walletNodeProxy(w, r, rest)
 			return
 		}
 		if fsErr != nil {
@@ -186,6 +195,46 @@ func (hv *Hypervisor) walletHandler() http.HandlerFunc {
 		r.URL.Path = "/wallet/" + rest
 		fileServer.ServeHTTP(w, r)
 	}
+}
+
+// walletCoinProxy routes a per-coin API call (/wallet/coin/<index>/<path>) to
+// the coin's backend. rest is "<index>/<path…>". Skycoin-style coins go to the
+// dmsg node proxy; bitcoin coins go to the in-visor electrum gateway. This is
+// the server-proxy half of skycoin-web's /coin/<index> multicoin model — see
+// docs/design/skycoin-web-multicoin-wallets.md.
+func (hv *Hypervisor) walletCoinProxy(w http.ResponseWriter, r *http.Request, rest string) {
+	idxStr, path := rest, ""
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		idxStr, path = rest[:i], rest[i+1:]
+	}
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil {
+		http.Error(w, "invalid coin index", http.StatusBadRequest)
+		return
+	}
+	coin, ok := coins.ByIndex(idx)
+	if !ok {
+		http.Error(w, "unknown coin", http.StatusNotFound)
+		return
+	}
+	if coin.IsBitcoin() {
+		// The browser derives + signs BTC itself; only chain queries come here,
+		// to the in-process electrum gateway. Normalize the path to /v1/btc/… (the
+		// wallet addresses it as coin/<index>/api/v1/btc/…). The backend electrum
+		// server (X-Skywire-Btc-Backend) is reached on the clearnet by default, or
+		// via a skysocks exit (X-Skywire-Btc-Proxy) for IP privacy — headers set
+		// by the shim from localStorage.
+		if i := strings.Index(path, "v1/btc/"); i >= 0 {
+			r.URL.Path = "/" + path[i:]
+		} else {
+			r.URL.Path = "/" + path
+		}
+		hv.nativeBtcGateway(r.Header.Get("X-Skywire-Btc-Proxy")).ServeHTTP(w, r)
+		return
+	}
+	// Skycoin-style node: proxy the remaining api/v1|v2 path to the coin's node
+	// over dmsg (X-Skywire-Coin-Node selects it; empty = deployment default).
+	hv.walletNodeProxy(w, r, path)
 }
 
 // serveWalletIndex serves the embedded wallet index.html with its <base href>

--- a/pkg/visor/hypervisor_handlers_wallet_test.go
+++ b/pkg/visor/hypervisor_handlers_wallet_test.go
@@ -1,0 +1,74 @@
+package visor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/skycoin/skywire/pkg/wallet/coins"
+)
+
+// walletReq builds a request whose chi "*" URL param is set to rest, as the
+// /wallet/* route delivers it to walletHandler.
+func walletReq(rest string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/wallet/"+rest, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("*", rest)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// TestWalletHandlerRouting covers the multicoin routing decisions added to the
+// native wallet handler (the /coin/<index> server-proxy model). The paths that
+// need a live visor/gateway (coin 0 node proxy, coin 1 electrum) aren't
+// exercised here — only the classification is.
+func TestWalletHandlerRouting(t *testing.T) {
+	hv := &Hypervisor{}
+	h := hv.walletHandler()
+
+	t.Run("coins returns the registry", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h(w, walletReq("coins"))
+		if w.Code != http.StatusOK {
+			t.Fatalf("status=%d, want 200", w.Code)
+		}
+		if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "json") {
+			t.Errorf("Content-Type=%q, want json", ct)
+		}
+		var got []coins.Coin
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatalf("body not the coin registry JSON: %v", err)
+		}
+		if len(got) != len(coins.Registry) || got[1].CoinSymbol != "BTC" {
+			t.Fatalf("unexpected registry: %s", w.Body.String())
+		}
+	})
+
+	t.Run("unknown coin index → 404", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h(w, walletReq("coin/9/api/v1/health"))
+		if w.Code != http.StatusNotFound {
+			t.Errorf("status=%d, want 404 for unknown coin", w.Code)
+		}
+	})
+
+	t.Run("non-numeric coin index → 400", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h(w, walletReq("coin/x/api/v1/health"))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status=%d, want 400 for invalid index", w.Code)
+		}
+	})
+
+	t.Run("config page served", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h(w, walletReq("config"))
+		if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "<") {
+			t.Errorf("config page not served: status=%d", w.Code)
+		}
+	})
+}

--- a/pkg/wallet/coins/coins.go
+++ b/pkg/wallet/coins/coins.go
@@ -1,0 +1,81 @@
+// Package coins is the visor-side coin registry for the embedded skycoin-web
+// wallet. skycoin-web is already multicoin: its coin.service fetches the coin
+// list from GET /api/v1/coins and its api.service routes each coin's requests to
+// that coin's NodeURL. The visor serves this registry at /api/v1/coins with each
+// coin's NodeURL set to a "/coin/<index>" prefix, then proxies /coin/<index>/…
+// to the matching backend (the skycoin node over dmsg, or the in-visor BTC
+// electrum gateway). The wallet source needs no changes.
+//
+// See docs/design/skycoin-web-multicoin-wallets.md.
+package coins
+
+import "encoding/json"
+
+// Coin mirrors the server-data shape skycoin-web's BaseCoin.fromServerData reads
+// (coins/basecoin.ts). Only the fields the wallet consumes are set; the rest
+// fall back to skycoin-web's own defaults.
+type Coin struct {
+	ID                int    `json:"id"`
+	NodeURL           string `json:"nodeUrl"`
+	CoinName          string `json:"coinName"`
+	CoinSymbol        string `json:"coinSymbol"`
+	HoursName         string `json:"hoursName,omitempty"`
+	PriceTickerID     string `json:"priceTickerId,omitempty"`
+	PriceTickerSource string `json:"priceTickerSource,omitempty"`
+	CoinExplorer      string `json:"coinExplorer,omitempty"`
+	CoinType          string `json:"coinType"`
+	ServerWallets     bool   `json:"serverWallets"`
+}
+
+// IsBitcoin reports whether the coin is routed to the BTC electrum gateway
+// rather than a skycoin-style node. Mirrors BaseCoin.isBitcoin().
+func (c Coin) IsBitcoin() bool {
+	return c.CoinType == "bitcoin" || c.CoinType == "bitcoin-segwit"
+}
+
+// Registry is the fixed set of coins the visor serves at /api/v1/coins. The
+// slice index equals Coin.ID equals the "/coin/<index>" proxy prefix. Making
+// this operator-configurable is a later pass (see the design doc); for now the
+// browser holds all keys and does all signing, so ServerWallets is always false.
+var Registry = []Coin{
+	{
+		ID:                0,
+		NodeURL:           "/coin/0",
+		CoinName:          "Skycoin",
+		CoinSymbol:        "SKY",
+		HoursName:         "Coin Hours",
+		PriceTickerID:     "sky-skycoin",
+		PriceTickerSource: "coinpaprika",
+		CoinExplorer:      "https://explorer.skycoin.com",
+		CoinType:          "skycoin",
+		ServerWallets:     false,
+	},
+	{
+		ID:                1,
+		NodeURL:           "/coin/1",
+		CoinName:          "Bitcoin",
+		CoinSymbol:        "BTC",
+		PriceTickerID:     "btc-bitcoin",
+		PriceTickerSource: "coinpaprika",
+		CoinExplorer:      "https://blockstream.info",
+		CoinType:          "bitcoin",
+		ServerWallets:     false,
+	},
+}
+
+// ByIndex returns the coin at the given /coin/<index> position.
+func ByIndex(index int) (Coin, bool) {
+	if index >= 0 && index < len(Registry) {
+		return Registry[index], true
+	}
+	return Coin{}, false
+}
+
+// JSON is the marshaled registry served at GET /api/v1/coins.
+func JSON() []byte {
+	b, err := json.Marshal(Registry)
+	if err != nil { // Registry is a static literal; marshal cannot fail.
+		return []byte("[]")
+	}
+	return b
+}

--- a/pkg/wallet/coins/coins_test.go
+++ b/pkg/wallet/coins/coins_test.go
@@ -1,0 +1,52 @@
+package coins
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRegistryShape(t *testing.T) {
+	if len(Registry) != 2 {
+		t.Fatalf("expected 2 coins, got %d", len(Registry))
+	}
+	// index == ID == /coin/<index> prefix
+	for i, c := range Registry {
+		if c.ID != i {
+			t.Errorf("coin %d: ID=%d, want %d", i, c.ID, i)
+		}
+		if want := "/coin/" + string(rune('0'+i)); c.NodeURL != want {
+			t.Errorf("coin %d: NodeURL=%q, want %q", i, c.NodeURL, want)
+		}
+		if c.ServerWallets {
+			t.Errorf("coin %d: ServerWallets must be false (browser-held keys)", i)
+		}
+	}
+	if Registry[0].CoinType != "skycoin" || Registry[0].IsBitcoin() {
+		t.Errorf("coin 0 should be skycoin")
+	}
+	if !Registry[1].IsBitcoin() {
+		t.Errorf("coin 1 should be bitcoin")
+	}
+}
+
+func TestJSONRoundTrip(t *testing.T) {
+	var got []Coin
+	if err := json.Unmarshal(JSON(), &got); err != nil {
+		t.Fatalf("JSON() not valid: %v", err)
+	}
+	if len(got) != 2 || got[1].CoinSymbol != "BTC" || got[0].CoinSymbol != "SKY" {
+		t.Fatalf("unexpected marshaled registry: %s", JSON())
+	}
+}
+
+func TestByIndex(t *testing.T) {
+	if c, ok := ByIndex(1); !ok || !c.IsBitcoin() {
+		t.Errorf("ByIndex(1) should be bitcoin, ok=%v", ok)
+	}
+	if _, ok := ByIndex(5); ok {
+		t.Errorf("ByIndex(5) should be not-ok")
+	}
+	if _, ok := ByIndex(-1); ok {
+		t.Errorf("ByIndex(-1) should be not-ok")
+	}
+}


### PR DESCRIPTION
Reworks the visor-embedded skycoin-web wallet onto skycoin-web's **native** multicoin model, replacing the earlier diverged approach (electrum-URL-in-`nodeUrl` + a `/v1/btc/` fetch-intercept; there was a literal `TODO(config): multi-coin /coin/N` in the code).

## The model (design doc included)

skycoin-web is already multicoin: `coin.service` fetches **`/api/v1/coins`** and `api.service` routes each coin's requests to that coin's `nodeUrl`. So the **visor becomes the coin router** and the **wallet source needs no change** (no rebuild/re-embed):

- **`/api/v1/coins`** → the coin registry (Skycoin `/coin/0`, Bitcoin `/coin/1`)
- **`/coin/<index>/…`** → proxied to that coin's backend: skycoin node over dmsg, or the in-visor `pkg/btcgateway` electrum gateway

BTC stops being a special case — it's just `/coin/1`.

## Changes
- **`pkg/wallet/coins`** — the registry (`BaseCoin`-shaped), one Go source of truth for native + wasm. Unit-tested.
- **Native HV** (`hypervisor_handlers_wallet.go`) — `GET /wallet/coins` → registry; `/wallet/coin/<index>/*` → `walletCoinProxy` (skycoin → dmsg node proxy, bitcoin → electrum gateway); removed the `/v1/btc/` intercept; shim rewrites `/api/v1/coins` → `/wallet/coins` and `/coin/<index>/…` → the mounted proxy.
- **wasm-visor** (`serve.go` shim) — injects the same registry, serves `/api/v1/coins` in-tab, strips the `/coin/<index>` prefix and routes to `skywireVisor.fetchDmsg` / `btcFetch`.
- **docs/design/skycoin-web-multicoin-wallets.md** — the corrected model.

## Validation
- Registry unit-tested; `go build ./...`, `go vet`, `gofmt`, tests green.
- **wasm side validated live** (`hv serve` + browser, visor booted, wallet loaded in-context): `/api/v1/coins` → both coins; **`/coin/0/api/v1/health` → the real skycoin node over dmsg, HTTP 200 with live blockchain head**; `/coin/1/api/v1/btc/health` → the BTC gateway branch (needs a configured electrum backend).
- Native side mirrors the same model in Go (compiles, registry-tested); benefits from a running-hypervisor smoke test (the routing logic is validated on the wasm twin).

## Follow-ups (not this PR)
- Operator-configurable coin list (currently fixed {skycoin, bitcoin}).
- The onboarding wizard-skip + reworded disclaimer for the embedded wallet (separate; reword already PR'd — skywire #3501 / skycoin #2941).