### PR TITLE
chore(make): normalize file modes in embed-wallet (stop spurious mode churn)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,6 +304,12 @@ embed-wallet: ## Sync the vendored skycoin-web wallet dist into the embedded PWA
 	rm -rf ./pkg/visor/static/wallet
 	mkdir -p ./pkg/visor/static/wallet
 	cp -a ./vendor/github.com/skycoin/skycoin/src/skycoin-web/src/gui/dist/. ./pkg/visor/static/wallet/
+	@# Normalize modes: cp -a preserves the vendored source's permission bits, and
+	@# some assets (e.g. skycoin-lite.wasm) carry a 755 exec bit that then shows as
+	@# a spurious mode-only change vs the committed 644 tree. Force 644/755 so a
+	@# re-embed only diffs on real content (the content-hashed chunk renames).
+	find ./pkg/visor/static/wallet -type f -exec chmod 0644 {} +
+	find ./pkg/visor/static/wallet -type d -exec chmod 0755 {} +
 	@echo "synced pkg/visor/static/wallet from the vendored skycoin-web dist — review with 'git status', commit intentionally (~11MB)."
 
 prune-wasm-embed-history: ## Drop OLD embedded wasm-visor blobs from git history, keeping only the current one (reclaims ~9MB per past update). REWRITES HISTORY — needs git-filter-repo; run on a fresh clone, then force-push. See scripts/prune-wasm-embed-history.sh for the full warning.


### PR DESCRIPTION
`make embed-wallet` uses `cp -a`, which **preserves the vendored skycoin-web dist's permission bits**. Some assets (e.g. `skycoin-lite.wasm`) carry a `755` exec bit in the vendored tree, so after a copy they show up as a **mode-only git change** (`755` vs the committed `644`) — noise that makes a re-embed look like it touched files it didn't (this bit me while reviewing a wallet re-embed: `skycoin-lite.wasm` appeared "modified" with byte-identical content).

Fix: `chmod 0644`/`0755` the embedded tree after the copy, so a re-embed only diffs on **real content** (the Angular `outputHashing: all` content-hashed chunk renames).

Verified: `make embed-wallet` on the in-sync tree is now a clean **no-op** (0 wallet-tree changes), where before it produced a spurious `skycoin-lite.wasm` mode change.