### PR TITLE
chore: fix pre-existing CI lint failures (Go errcheck + UI member-ordering)

### DIFF
--- a/pkg/app/launcher/registry_test.go
+++ b/pkg/app/launcher/registry_test.go
@@ -36,8 +36,8 @@ func TestHTTPHandlerRegistry(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/status", nil)
 	h.ServeHTTP(rec, req)
 	res := rec.Result()
-	body, _ := io.ReadAll(res.Body)
-	_ = res.Body.Close() //nolint:errcheck
+	body, _ := io.ReadAll(res.Body) //nolint:errcheck // test read; error not material
+	_ = res.Body.Close()            //nolint:errcheck
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", res.StatusCode)
 	}

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -985,7 +985,8 @@ export class NodeListComponent extends PageBaseComponent implements OnInit, OnDe
         }
       });
     }
-    return {incoming, outgoing};
+
+    return {incoming: incoming, outgoing: outgoing};
   }
 
   /**

--- a/static/skywire-manager-src/src/app/components/pages/node/wallet/wallet.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/wallet/wallet.component.ts
@@ -53,11 +53,6 @@ export class WalletComponent extends PageBaseComponent implements OnInit, OnDest
   // wallet window uses, so there is one config implementation. On Apply it
   // postMessages {type:'skywire-wallet-config'} and we reload the wallet iframe.
   configUrl: SafeResourceUrl | null = null;
-  private onConfigMessage = (ev: MessageEvent) => {
-    if (ev?.data && ev.data.type === 'skywire-wallet-config') {
-      this.reloadWallet();
-    }
-  };
   // Last node PK we built the iframe URL for. NodeComponent.currentNode
   // emits on every polling refresh; rebuilding the SafeResourceUrl on
   // every tick reloads the iframe and tears down whatever the wallet
@@ -89,8 +84,16 @@ export class WalletComponent extends PageBaseComponent implements OnInit, OnDest
     private appsService: AppsService,
     private snackbar: SnackbarService,
   ) {
- super(); 
+ super();
 }
+
+  // Reload the wallet iframe when its config page posts a change. Declared here
+  // (a method-like arrow field) after the data fields to satisfy member-ordering.
+  private onConfigMessage = (ev: MessageEvent) => {
+    if (ev?.data && ev.data.type === 'skywire-wallet-config') {
+      this.reloadWallet();
+    }
+  };
 
   ngOnInit() {
     // The config UI lives in the embedded /wallet/config page (same origin, so


### PR DESCRIPTION
Develop's CI has been red on the **lint** checks (`linux`/`darwin`/`windows` golangci-lint + `ui` tslint) for a while — unrelated to any one feature branch — which has been forcing `--admin` merges. This greens them.

- **`pkg/app/launcher/registry_test.go`** — `//nolint:errcheck` on the test body read (golangci-lint's errcheck flags the blank-assigned error).
- **`.../node/wallet/wallet.component.ts`** — move the `onConfigMessage` arrow-function field below the data fields; as a method-like member it tripped `member-ordering` ("field should be declared before all instance method definitions").
- **`.../node-list/node-list.component.ts`** — blank line before a `return` + longform object properties (`padding-line-between-statements`, `object-shorthand`).

Verified locally: `golangci-lint run ./pkg/app/launcher/` → **0 issues**; `ng lint` → **All files pass linting**.

No behavior change — pure lint hygiene so feature PRs get a green baseline.