### PR TITLE
feat(dmsg): surface the dmsg-server connection protocol (tcp/ws/wss/webtransport/quic)

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/sessions.go
+++ b/cmd/skywire-cli/commands/dmsg/sessions.go
@@ -60,8 +60,16 @@ func printDmsgSessions(result *visor.DmsgClientSessions) {
 		}
 		fmt.Printf("%s (%s)\n", info.Role, info.PK)
 		fmt.Printf("  Connected sessions: %d\n", info.Count)
-		for _, s := range info.Servers {
-			fmt.Printf("    %s\n", s)
+		// Prefer the enriched session list (server PK + the protocol it was
+		// reached over); fall back to bare PKs for older visors.
+		if len(info.Sessions) > 0 {
+			for _, s := range info.Sessions {
+				fmt.Printf("    %s  %s\n", s.PK, s.Protocol)
+			}
+		} else {
+			for _, s := range info.Servers {
+				fmt.Printf("    %s\n", s)
+			}
 		}
 		fmt.Println()
 	}

--- a/cmd/wasm-visor/selfprovider_js.go
+++ b/cmd/wasm-visor/selfprovider_js.go
@@ -89,15 +89,27 @@ func (s visorSelf) SelfDmsgSessions() []byte {
 		return nil
 	}
 	servers := []cipher.PubKey{}
+	sessions := []map[string]interface{}{}
 	for _, cs := range dmsgC.AllSessions() {
 		servers = append(servers, cs.RemotePK())
+		// Mirror the native DmsgServerSession shape so the shared Angular UI —
+		// and the wasm-visor onboarding tour — can show which protocol
+		// (tcp/ws/wss/webtransport/quic) this browser edge reached each dmsg
+		// server over. A browser edge dials ws/wss or WebTransport, never tcp.
+		sessions = append(sessions, map[string]interface{}{
+			"pk":       cs.RemotePK(),
+			"carrier":  cs.Carrier(),
+			"protocol": cs.Protocol(),
+			"address":  cs.CarrierAddr(),
+		})
 	}
 	out := map[string]interface{}{
 		"main": map[string]interface{}{
-			"pk":      selfPK,
-			"role":    "main",
-			"count":   len(servers),
-			"servers": servers,
+			"pk":       selfPK,
+			"role":     "main",
+			"count":    len(servers),
+			"servers":  servers,
+			"sessions": sessions,
 		},
 	}
 	b, err := json.Marshal(out)

--- a/metrics
+++ b/metrics
@@ -1,0 +1,1 @@
+404 page not found

--- a/pkg/dmsg/dmsg/carrier_test.go
+++ b/pkg/dmsg/dmsg/carrier_test.go
@@ -47,3 +47,28 @@ func TestPickCarrier(t *testing.T) {
 		})
 	}
 }
+
+// TestProtocolLabel locks the human-readable protocol labeling — notably that
+// the WebSocket carrier reports wss vs ws by the endpoint scheme, and that an
+// empty carrier (an accepted server-side session) reports "accepted".
+func TestProtocolLabel(t *testing.T) {
+	cases := []struct {
+		carrier string
+		addr    string
+		want    string
+	}{
+		{CarrierTCP, "1.2.3.4:8081", "tcp"},
+		{CarrierWS, "ws://1.2.3.4:8083/dmsg", "ws"},
+		{CarrierWS, "wss://dmsg.example.com/dmsg", "wss"},
+		{CarrierWS, "https://dmsg.example.com/dmsg", "wss"},
+		{CarrierWS, "WSS://UPPER.example.com/dmsg", "wss"},
+		{CarrierWT, "https://1.2.3.4:8084/dmsg", "webtransport"},
+		{CarrierQUIC, "1.2.3.4:8085", "quic"},
+		{"", "", "accepted"},
+	}
+	for _, c := range cases {
+		if got := ProtocolLabel(c.carrier, c.addr); got != c.want {
+			t.Fatalf("ProtocolLabel(%q,%q) = %q, want %q", c.carrier, c.addr, got, c.want)
+		}
+	}
+}

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/hashicorp/yamux"
 	"github.com/xtaci/smux"
@@ -209,6 +210,40 @@ func pickCarrier(carriers []string, entry *disc.Entry) (network, addr string) {
 	return CarrierTCP, entry.Server.Address
 }
 
+// ProtocolLabel renders a human-readable label for the protocol a client used
+// to reach a dmsg server, given the carrier it dialed and that carrier's
+// endpoint address. Every dmsg carrier is Noise-encrypted end to end above the
+// byte pipe; the label names the underlying transport, and for the WebSocket
+// carrier it distinguishes plain ws:// from TLS-secured wss:// by the endpoint
+// scheme. An empty carrier (an accepted, server-side session) renders as
+// "accepted".
+func ProtocolLabel(carrier, addr string) string {
+	switch carrier {
+	case CarrierTCP:
+		return "tcp"
+	case CarrierWS:
+		if isSecureURL(addr) {
+			return "wss"
+		}
+		return "ws"
+	case CarrierWT:
+		return "webtransport"
+	case CarrierQUIC:
+		return "quic"
+	case "":
+		return "accepted"
+	default:
+		return carrier
+	}
+}
+
+// isSecureURL reports whether addr is a TLS-secured websocket / https endpoint
+// (wss:// or https://), used to distinguish wss from plain ws.
+func isSecureURL(addr string) bool {
+	a := strings.ToLower(strings.TrimSpace(addr))
+	return strings.HasPrefix(a, "wss://") || strings.HasPrefix(a, "https://")
+}
+
 func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs ClientSession, err error) {
 	ce.log.WithField("remote_pk", entry.Static).Debug("Dialing session...")
 
@@ -355,7 +390,10 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 	// identity-checked so it cannot evict this live replacement.
 	// Record the carrier actually used (after any WT→WS / *→TCP fallback above)
 	// so Client.UpgradeBrowserSessions can later converge wss → WebTransport.
+	// carrierAddr is the endpoint that carrier dialed, so callers can tell the
+	// exact protocol used to reach this server (and ws:// from wss://).
 	dSes.carrier = network
+	dSes.carrierAddr = dialAddr
 
 	ce.sessionsMx.Lock()
 	if ce.closed {

--- a/pkg/dmsg/dmsg/session_common.go
+++ b/pkg/dmsg/dmsg/session_common.go
@@ -34,6 +34,13 @@ type SessionCommon struct {
 	// wss converge to WebTransport: see Client.UpgradeBrowserSessions.
 	carrier string
 
+	// carrierAddr is the endpoint the carrier actually dialed: host:port for
+	// tcp/quic, the ws(s):// URL for ws, the https:// URL for WebTransport.
+	// Empty for accepted (server-side) sessions. Together with carrier it
+	// tells you the exact protocol a client used to reach its dmsg server
+	// (and, for ws, whether it was plain ws:// or secured wss://).
+	carrierAddr string
+
 	netConn net.Conn // underlying net.Conn (TCP connection to the dmsg server)
 	// ys      *yamux.Session
 	// ss      *smux.Session
@@ -237,6 +244,20 @@ func (sc *SessionCommon) LocalPK() cipher.PubKey { return sc.entity.pk }
 
 // RemotePK returns the remote public key of the session.
 func (sc *SessionCommon) RemotePK() cipher.PubKey { return sc.rPK }
+
+// Carrier reports how this client session's byte pipe to the dmsg server was
+// dialed: one of CarrierTCP / CarrierWS / CarrierWT / CarrierQUIC. It is empty
+// for accepted (server-side) sessions. Use Protocol for a human-readable label
+// that also distinguishes ws from wss.
+func (sc *SessionCommon) Carrier() string { return sc.carrier }
+
+// CarrierAddr reports the endpoint this session's carrier dialed. Empty for
+// accepted (server-side) sessions.
+func (sc *SessionCommon) CarrierAddr() string { return sc.carrierAddr }
+
+// Protocol renders a human-readable label for the protocol this session used
+// to reach its dmsg server, distinguishing plain ws:// from secured wss://.
+func (sc *SessionCommon) Protocol() string { return ProtocolLabel(sc.carrier, sc.carrierAddr) }
 
 // LocalTCPAddr returns the local address of the underlying TCP connection.
 func (sc *SessionCommon) LocalTCPAddr() net.Addr { return sc.netConn.LocalAddr() }

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -788,6 +788,23 @@ type DmsgClientSessionInfo struct {
 	Role    string          `json:"role"` // "main" | "route_setup" | "transport_setup"
 	Count   int             `json:"count"`
 	Servers []cipher.PubKey `json:"servers"`
+	// Sessions carries the same servers plus the protocol each one was reached
+	// over (tcp / ws / wss / webtransport / quic). Parallel to Servers, sorted
+	// the same way, so existing Servers consumers keep working.
+	Sessions []DmsgServerSession `json:"sessions,omitempty"`
+}
+
+// DmsgServerSession is one active dmsg-server session and the protocol the
+// local client used to reach it.
+type DmsgServerSession struct {
+	PK cipher.PubKey `json:"pk"`
+	// Carrier is the raw dmsg carrier: tcp | ws | wt | quic.
+	Carrier string `json:"carrier"`
+	// Protocol is a human-readable label distinguishing ws from wss:
+	// tcp | ws | wss | webtransport | quic.
+	Protocol string `json:"protocol"`
+	// Address is the endpoint the carrier dialed (host:port or ws(s)://…).
+	Address string `json:"address,omitempty"`
 }
 
 // DmsgHTTPRequest represents an HTTP request to be made over dmsg

--- a/pkg/visor/api_dmsg.go
+++ b/pkg/visor/api_dmsg.go
@@ -639,12 +639,13 @@ func (v *Visor) DmsgSessions() (*DmsgClientSessions, error) {
 	out := &DmsgClientSessions{}
 
 	if v.dmsgC != nil {
-		servers := dmsgClientServerPKs(v.dmsgC)
+		servers, sessions := dmsgClientServerSessions(v.dmsgC)
 		out.Main = &DmsgClientSessionInfo{
-			PK:      v.conf.PK,
-			Role:    "main",
-			Count:   len(servers),
-			Servers: servers,
+			PK:       v.conf.PK,
+			Role:     "main",
+			Count:    len(servers),
+			Servers:  servers,
+			Sessions: sessions,
 		}
 	}
 
@@ -654,39 +655,49 @@ func (v *Visor) DmsgSessions() (*DmsgClientSessions, error) {
 	v.initLock.Unlock()
 
 	if rsn != nil && rsn.DmsgClient() != nil {
-		servers := dmsgClientServerPKs(rsn.DmsgClient())
+		servers, sessions := dmsgClientServerSessions(rsn.DmsgClient())
 		out.RouteSetup = &DmsgClientSessionInfo{
-			PK:      rsn.PK(),
-			Role:    "route_setup",
-			Count:   len(servers),
-			Servers: servers,
+			PK:       rsn.PK(),
+			Role:     "route_setup",
+			Count:    len(servers),
+			Servers:  servers,
+			Sessions: sessions,
 		}
 	}
 	if tps != nil && tps.DmsgClient() != nil {
-		servers := dmsgClientServerPKs(tps.DmsgClient())
+		servers, sessions := dmsgClientServerSessions(tps.DmsgClient())
 		out.TransportSetup = &DmsgClientSessionInfo{
-			PK:      tps.PK(),
-			Role:    "transport_setup",
-			Count:   len(servers),
-			Servers: servers,
+			PK:       tps.PK(),
+			Role:     "transport_setup",
+			Count:    len(servers),
+			Servers:  servers,
+			Sessions: sessions,
 		}
 	}
 	return out, nil
 }
 
-// dmsgClientServerPKs returns the PKs of the dmsg servers the given client
-// currently has an active session with. Sorted by PK for stable output.
-func dmsgClientServerPKs(c *dmsg.Client) []cipher.PubKey {
-	strs := c.ConnectedServersPK()
-	out := make([]cipher.PubKey, 0, len(strs))
-	for _, s := range strs {
-		var pk cipher.PubKey
-		if err := pk.Set(s); err == nil {
-			out = append(out, pk)
-		}
+// dmsgClientServerSessions returns the dmsg servers the given client currently
+// has an active session with, both as bare PKs (Servers, kept for existing
+// consumers) and enriched with the protocol each was reached over (Sessions).
+// Both slices are sorted by server PK for stable output.
+func dmsgClientServerSessions(c *dmsg.Client) ([]cipher.PubKey, []DmsgServerSession) {
+	all := c.AllSessions()
+	sessions := make([]DmsgServerSession, 0, len(all))
+	for _, s := range all {
+		sessions = append(sessions, DmsgServerSession{
+			PK:       s.RemotePK(),
+			Carrier:  s.Carrier(),
+			Protocol: s.Protocol(),
+			Address:  s.CarrierAddr(),
+		})
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
-	return out
+	sort.Slice(sessions, func(i, j int) bool { return sessions[i].PK.String() < sessions[j].PK.String() })
+	pks := make([]cipher.PubKey, len(sessions))
+	for i, s := range sessions {
+		pks[i] = s.PK
+	}
+	return pks, sessions
 }
 
 // DmsgProbe checks whether a remote PK is reachable on a given dmsg port


### PR DESCRIPTION
## What

Surface the underlying protocol a visor's dmsg client(s) use to reach each dmsg server — `tcp` / `ws` / `wss` / `webtransport` / `quic` — from the CLI, the visor RPC/HTTP API, and the wasm (browser) visor's self-summary.

Until now the carrier a session was dialed over was recorded internally (`SessionCommon.carrier`, used by the browser wss→WebTransport upgrade) but never exposed. You could see *which* dmsg servers a client was connected to, not *how*.

## Why

Groundwork for the wasm-visor onboarding tour, which will explain dmsg-servers-as-anonymous-relay and the connection protocol (which differs for a browser visor over http vs https, and again for a host-native visor). More generally it's a useful diagnostic: a native visor connects over `tcp`, a browser tab over `wss`/`webtransport`, and now you can tell at a glance — including from a shell.

## Changes

- **dmsg (`pkg/dmsg/dmsg`)**: `SessionCommon.Carrier()` / `CarrierAddr()` / `Protocol()` accessors; record the dialed endpoint in a new `carrierAddr` field; `ProtocolLabel(carrier, addr)` helper that distinguishes plain `ws://` from TLS `wss://` by endpoint scheme and renders `accepted` for inbound server-side sessions. Unit-tested.
- **visor (`pkg/visor`)**: new `DmsgServerSession{pk,carrier,protocol,address}`; `DmsgClientSessionInfo` gains a parallel `sessions` field (the existing `servers []PubKey` is kept untouched for back-compat). `DmsgSessions()` populates it from `AllSessions()`.
- **CLI**: `skywire cli dmsg sessions` prints the protocol next to each server (falls back to bare PKs against an older visor).
- **wasm (`cmd/wasm-visor`)**: `SelfDmsgSessions()` emits the same `sessions` shape so the shared Angular UI and the tour get the browser edge's ws/wss/webtransport per server.

## Validation

- `go test ./pkg/dmsg/dmsg` (new `TestProtocolLabel`), native + `GOOS=js GOARCH=wasm` builds, gofmt/vet clean.
- Live against a native visor: `dmsg sessions` shows `tcp` for every server across the `main` and `transport_setup` clients; `--json` → `{pk, carrier:"tcp", protocol:"tcp", address:"172.105.179.5:30085"}` with `servers[]` still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
