### PR TITLE
build(deps-dev): bump websocket-driver from 0.7.4 to 0.7.5 in /static/skywire-manager-src

### DIFF
--- a/static/skywire-manager-src/package-lock.json
+++ b/static/skywire-manager-src/package-lock.json
@@ -18365,9 +18365,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
Bumps the transitive dev-dependency `websocket-driver` from 0.7.4 to 0.7.5 (lockfile-only; the `^0.7.4` spec is unchanged and satisfied by 0.7.5).

Reproduces the change from the Dependabot PR #3495 as a clean authored commit on the 0pcom fork (no cherry-pick), so it can be reviewed/merged through the normal fork-PR flow.

0.7.5 upstream changes (defensive hardening for the WS framing layer):
- Close a draft-75/76 connection if a length header grows to exceed the configured max length.
- Fail the connection if a message is larger than the configured max length after extension processing.

Closes #3495.