### PR TITLE
chore(lint): de-deprecate httprate.LimitByIP + gofmt addrresolver (unblock CI)

### DIFF
--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -750,7 +750,6 @@ func (c *httpClient) delBindSTCPR(ctx context.Context) error {
 // Handshake type is used to decouple client from handshake and network packages
 type Handshake func(net.Conn) (net.Conn, error)
 
-
 // serveSUDPHConn runs the read / heartbeat / re-register loops on arConn
 // until any of them errors (connection dead) or the client is closed.
 // Returns once all three loops have exited.

--- a/pkg/uptime-tracker/api/api.go
+++ b/pkg/uptime-tracker/api/api.go
@@ -39,6 +39,17 @@ const (
 	rateLimiterWindow   = 1 * time.Minute
 )
 
+// keyByRemoteAddr keys the rate limiter off the TCP peer address (r.RemoteAddr),
+// canonicalizing IPv6 to its /64. It is the explicit, non-deprecated equivalent
+// of httprate.KeyByIP (which was deprecated to make the trust model explicit).
+func keyByRemoteAddr(r *http.Request) (string, error) {
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		ip = r.RemoteAddr
+	}
+	return httprate.CanonicalizeIP(ip), nil
+}
+
 // API register all the API endpoints.
 // It implements a net/http.Handler.
 type API struct {
@@ -127,8 +138,13 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore, 
 		})
 
 		r.Group(func(r chi.Router) {
-			// request rate limited group
-			r.Use(httprate.LimitByIP(rateLimiterRequests, rateLimiterWindow))
+			// request rate limited group, keyed per TCP peer (r.RemoteAddr).
+			// Explicit form of the now-deprecated httprate.LimitByIP wrapper
+			// (identical behavior): LimitByIP/KeyByIP were deprecated to force
+			// callers to state a trust model, since behind a reverse proxy
+			// RemoteAddr is the proxy's address. We keep the prior per-RemoteAddr
+			// keying — see keyByRemoteAddr.
+			r.Use(httprate.LimitBy(rateLimiterRequests, rateLimiterWindow, keyByRemoteAddr))
 
 			r.Get("/visors", api.handleVisors)
 			r.Get("/uptimes", api.handleUptimes)


### PR DESCRIPTION
golangci-lint on `./...` (v2.12.2, after the recent httprate dependency bump) surfaces two **pre-existing develop lint errors** that currently fail the `linux`/`darwin`/`windows` jobs on **every** open PR:

```
pkg/transport/network/addrresolver/client.go:753:1: File is not properly formatted (gofmt)
pkg/uptime-tracker/api/api.go:131:10: SA1019: httprate.LimitByIP is deprecated (staticcheck)
```

**Fixes:**
- **uptime-tracker/api**: replace the deprecated `httprate.LimitByIP(...)` with the explicit `httprate.LimitBy(..., keyByRemoteAddr)` + a local `keyByRemoteAddr` key func inlining the old `KeyByIP` behavior (per-`r.RemoteAddr`, IPv6 canonicalized to /64). **Identical runtime behavior** — the deprecation only asks callers to state the trust model explicitly.
- **addrresolver/client.go**: `gofmt -w` (a stray double blank line).

Doc/format + behavior-preserving only. `go build ./...`, gofmt, and golangci-lint clean. Unblocks #3507, #3508, and other open PRs.