### PR TITLE
fix(dmsg): restore proxyproto USE policy (v0.15 REQUIRE default broke dmsg data-plane fleet-wide)

### DIFF
--- a/pkg/dmsg/dmsgserver/api.go
+++ b/pkg/dmsg/dmsgserver/api.go
@@ -95,7 +95,7 @@ func (a *ServerAPI) ListenAndServe(lAddr, pAddr, httpAddr, wsURL string) error {
 	if err != nil {
 		return err
 	}
-	dmsgLis := &proxyproto.Listener{Listener: dmsgLn}
+	dmsgLis := &proxyproto.Listener{Listener: dmsgLn, ConnPolicy: optionalProxyHeader}
 	go func(l net.Listener, address, ws string) {
 		var serr error
 		if ws != "" {
@@ -133,7 +133,7 @@ func (a *ServerAPI) ListenAndServe(lAddr, pAddr, httpAddr, wsURL string) error {
 		dmsgLis.Close() //nolint:errcheck,gosec
 		return err
 	}
-	lis := &proxyproto.Listener{Listener: ln}
+	lis := &proxyproto.Listener{Listener: ln, ConnPolicy: optionalProxyHeader}
 	srv := &http.Server{
 		ReadTimeout:       3 * time.Second,
 		WriteTimeout:      3 * time.Second,
@@ -301,4 +301,14 @@ func calculateThroughput(
 		}
 	}
 	return newDecValues, newEncValues, average
+}
+
+// optionalProxyHeader restores go-proxyproto's pre-v0.15 lenient default (USE):
+// honor a PROXY header when an upstream proxy sends one, but ALSO accept
+// connections that arrive without one (direct dmsg clients doing a Noise
+// handshake, health checks). v0.15 changed the zero-value default to REQUIRE,
+// which rejects every header-less connection with ErrNoProxyProtocol — that
+// silently broke the client-facing dmsg listener fleet-wide.
+func optionalProxyHeader(proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+	return proxyproto.USE, nil
 }

--- a/pkg/services/dmsgdisc/dmsgdisc.go
+++ b/pkg/services/dmsgdisc/dmsgdisc.go
@@ -462,7 +462,16 @@ func listenAndServe(addr string, handler http.Handler) error {
 	if err != nil {
 		return err
 	}
-	proxyListener := &proxyproto.Listener{Listener: ln}
+	proxyListener := &proxyproto.Listener{Listener: ln, ConnPolicy: optionalProxyHeader}
 	defer proxyListener.Close() //nolint:errcheck
 	return srv.Serve(proxyListener)
+}
+
+// optionalProxyHeader restores go-proxyproto's pre-v0.15 lenient default (USE):
+// honor a PROXY header when an upstream proxy sends one, but ALSO accept
+// connections that arrive without one (direct clients, health checks, dmsg
+// Noise handshakes). v0.15 changed the zero-value default to REQUIRE, which
+// rejects every header-less connection with ErrNoProxyProtocol.
+func optionalProxyHeader(proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+	return proxyproto.USE, nil
 }

--- a/pkg/tcpproxy/http.go
+++ b/pkg/tcpproxy/http.go
@@ -26,7 +26,17 @@ func ListenAndServe(addr string, handler http.Handler) error {
 	if err != nil {
 		return err
 	}
-	proxyListener := &proxyproto.Listener{Listener: ln}
+	proxyListener := &proxyproto.Listener{Listener: ln, ConnPolicy: optionalProxyHeader}
 	defer proxyListener.Close() // nolint:errcheck
 	return srv.Serve(proxyListener)
+}
+
+// optionalProxyHeader restores go-proxyproto's pre-v0.15 lenient default (USE):
+// honor a PROXY header when an upstream proxy sends one, but ALSO accept
+// connections that arrive without one (direct dmsg clients doing a Noise
+// handshake, health checks). v0.15 changed the zero-value default to REQUIRE,
+// which rejects every header-less connection with ErrNoProxyProtocol — that
+// silently broke the client-facing dmsg listener fleet-wide.
+func optionalProxyHeader(proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+	return proxyproto.USE, nil
 }


### PR DESCRIPTION
## Urgent — fleet-wide dmsg outage

`go-proxyproto` **v0.15.0** (pulled in by the #3505 `make update-dep` bump) flipped the zero-value `DefaultPolicy` from lenient **USE** to **REQUIRE**. A bare `proxyproto.Listener{Listener: ln}` now fails the first Read/Write of any connection that doesn't open with a PROXY header (`ErrNoProxyProtocol`).

The **client-facing dmsg data-plane listener** (`pkg/dmsg/dmsgserver/api.go`) is exactly that: dmsg clients open with a raw Noise handshake, never a PROXY header. So as dmsg servers auto-updated onto develop, they began **rejecting every visor connection** — dmsg sessions can't establish, and anything needing dmsg (hypervisor init, route/transport setup) goes dark. The dmsg-discovery + tcpproxy HTTP listeners hit the same wall (health checks + their package tests get EOF — this is the develop `linux`-job red I flagged earlier).

## Fix
Give all four `proxyproto.Listener` sites an explicit `ConnPolicy` returning `USE` — restoring pre-v0.15 behavior (honor a PROXY header if an upstream proxy sends one; also accept header-less direct connections). Explicit policy survives future dep bumps.

Sites: dmsgserver (data-plane + health), dmsg-discovery, tcpproxy.

## Verified
- `pkg/services/dmsgdisc` **TestListenAndServe_Serves** now passes (was failing on develop).
- `pkg/tcpproxy` **TestListenAndServe_ServesRequests** now passes.
- `go build ./...` clean.

Fixes the develop test breakage; unblocks the fleet.