### PR TITLE
fix(visor): public-visor SD registration must not block init (stalls the hypervisor)

### DIFF
--- a/pkg/app/appdisc/discovery_manager_native.go
+++ b/pkg/app/appdisc/discovery_manager_native.go
@@ -55,17 +55,23 @@ func (u *serviceUpdater) Start() {
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel is stored in u.cancel and called in Stop()
 	u.cancel = cancel
 
-	// Best-effort initial registration. A failure here used to return
-	// early without starting the heartbeat loop, permanently disabling
-	// re-registration for the rest of the visor's lifetime — which
-	// turned a single transient SD failure (probe timeout, SD restart,
-	// dmsg flake) into "this visor never appears in service-discovery
-	// until it is restarted." Always start the heartbeat: it retries
-	// every ServiceDiscUpdateInterval (90s), which is exactly the
-	// recovery mechanism callers expect.
-	if err := u.client.Register(ctx); err != nil {
-		u.log.WithError(err).Warn("Initial service discovery registration failed; will retry via heartbeat")
-	}
+	// Best-effort initial registration — MUST run in the background. client.Register
+	// retries internally (netutil.Retrier with backoff), so when the SD is slow or
+	// unreachable (dmsg flake, SD restart, a dmsg-server rejecting connections) a
+	// synchronous call here blocks Start() for minutes. Start() runs on the visor
+	// INIT path (initPublicVisor), so that block stalls every init module ordered
+	// after public_visor — including the hypervisor, which then never comes up
+	// ("hypervisor configured but not initialized yet"). Firing it in a goroutine
+	// keeps init non-blocking; the heartbeat loop below is the real recovery
+	// mechanism anyway (retries every ServiceDiscUpdateInterval, 90s), and a
+	// failure here no longer disables re-registration.
+	u.wg.Add(1)
+	go func() {
+		defer u.wg.Done()
+		if err := u.client.Register(ctx); err != nil {
+			u.log.WithError(err).Warn("Initial service discovery registration failed; will retry via heartbeat")
+		}
+	}()
 
 	u.wg.Add(1)
 	go u.heartbeatLoop(ctx)


### PR DESCRIPTION
## Symptom
On a public visor, the **hypervisor never initializes** — the HV HTTP UI (`:8000`) never binds, and `skywire cli visor hv enable` returns *"hypervisor configured but not initialized yet — init stalled"*.

## Root cause
`serviceUpdater.Start()` (pkg/app/appdisc) runs the *best-effort initial* `client.Register(ctx)` **synchronously**. `Register` retries **internally** (`netutil.Retrier`, backoff), so when the service-discovery is slow/unreachable the call blocks for minutes.

`Start()` runs on the **visor init path** via `initPublicVisor`, and the `hypervisor` module is ordered after `public_visor` — so a blocked registration **stalls the whole init tail**, and the hypervisor never comes up.

This surfaced right now because the go-proxyproto v0.15 `REQUIRE` change (#3510) made some dmsg servers reject connections → SD registration over dmsg kept retrying → init stalled. But the fragility is independent: **a slow SD should never be able to take down the hypervisor.**

Goroutine dump (smoking gun):
```
netutil.Retrier.Do  (retrier.go:87)                 [8 minutes]
servicedisc.HTTPClient.Register  (client.go:358)
appdisc.serviceUpdater.Start  (discovery_manager_native.go:66)
visor.initPublicVisor  (init_transport.go:923)
```

## Fix
Fire the initial registration in a goroutine (tracked by the updater's WaitGroup). Init stays non-blocking; the heartbeat loop right below is already the real recovery mechanism (retries every 90s), so nothing is lost.

## Verified live
Rebuilt + restarted a stuck public hypervisor visor with this fix → `Hypervisor HTTP serving on :8000` → `Initialized`; HV UI returns 200 and `hv ls` shows the tree. Was permanently stalled before.