### PR TITLE
fix(cxo): encode broadcast root once, share body across subscribers

### DIFF
--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -63,7 +63,7 @@ type Conn struct {
 	// ConnectPK, fresh dial replaces the dead Conn.
 	lastActivityNs atomic.Int64
 
-	sendq chan<- []byte // channel from transport.Connection
+	sendq chan<- transport.Frame // channel from transport.Connection
 
 	// # stat
 	//
@@ -363,6 +363,20 @@ func (c *Conn) sendRoot(r *registry.Root) {
 	})
 }
 
+// encodeRootBody encodes the msg.Root wire body for r ONCE, so a broadcast can
+// hand the same immutable []byte to every subscriber via sendSharedBody instead
+// of re-running the (expensive) r.Encode() + msg.Root.Encode() per connection.
+// It is exactly the body sendRoot builds per-conn; only the 8-byte header differs.
+func encodeRootBody(r *registry.Root) []byte {
+	return (&msg.Root{
+		Feed:  r.Pub,
+		Nonce: r.Nonce,
+		Seq:   r.Seq,
+		Value: r.Encode(),
+		Sig:   r.Sig,
+	}).Encode()
+}
+
 // send last Root to peer
 func (c *Conn) sendLastRoot(pk cipher.PubKey) {
 
@@ -547,19 +561,20 @@ func (c *Conn) nextSeq() uint32 {
 	return atomic.AddUint32(&c.seq, 1)
 }
 
-func (c *Conn) encodeMsg(seq, rseq uint32, m msg.Msg) (raw []byte) {
+// msgHead builds the 8-byte per-message header (seq + rseq).
+func msgHead(seq, rseq uint32) []byte {
+	head := make([]byte, 8)
+	binary.LittleEndian.PutUint32(head, seq)
+	binary.LittleEndian.PutUint32(head[4:], rseq)
+	return head
+}
 
-	var em = m.Encode()
-
-	raw = make([]byte, 8, 8+len(em))
-
-	binary.LittleEndian.PutUint32(raw, seq)
-	binary.LittleEndian.PutUint32(raw[4:], rseq)
-
-	raw = append(raw, em...)
-
-	return
-
+// encodeMsg builds the outbound frame for m: the per-conn Head plus the encoded
+// Body. Kept as a split Frame (rather than one concatenated buffer) so a
+// broadcast can encode the Body once and share it across every subscriber — see
+// transport.Frame and sendSharedBody.
+func (c *Conn) encodeMsg(seq, rseq uint32, m msg.Msg) transport.Frame {
+	return transport.Frame{Head: msgHead(seq, rseq), Body: m.Encode()}
 }
 
 // sendMsgQueueTimeout is the max time sendMsg will wait to enqueue a
@@ -586,18 +601,31 @@ const sendMsgQueueTimeout = 5 * time.Second
 
 func (c *Conn) sendMsg(seq, rseq uint32, m msg.Msg) error {
 	c.n.Debugf(MsgSendPin, "[%s] send %d %T", c.String(), rseq, m)
+	return c.sendFrame(c.encodeMsg(seq, rseq, m))
+}
 
+// sendSharedBody queues a frame whose Body is a caller-owned, immutable []byte
+// that MAY be shared across connections — the broadcast fast path: encode the
+// (large) message body once, then hand every subscriber the same Body with only
+// its own per-conn Head. The transport writes Body without copying, so N
+// subscribers cost one Body allocation, not N.
+func (c *Conn) sendSharedBody(seq, rseq uint32, body []byte) error {
+	return c.sendFrame(transport.Frame{Head: msgHead(seq, rseq), Body: body})
+}
+
+// sendFrame enqueues an already-built frame onto the per-conn send queue,
+// bounding the wait so one stuck subscriber can't stall a broadcast (see
+// sendMsgQueueTimeout).
+func (c *Conn) sendFrame(f transport.Frame) error {
 	select {
 	case <-c.closeq:
 		return ErrClosed
 	default:
 	}
 
-	encoded := c.encodeMsg(seq, rseq, m)
-
 	// Fast path: buffer has room, enqueue immediately.
 	select {
-	case c.sendq <- encoded:
+	case c.sendq <- f:
 		return nil
 	default:
 	}
@@ -606,7 +634,7 @@ func (c *Conn) sendMsg(seq, rseq uint32, m msg.Msg) error {
 	// doesn't stall the publisher's broadcastRoot iteration. closeq
 	// is also selected so a concurrent Close unblocks us cleanly.
 	select {
-	case c.sendq <- encoded:
+	case c.sendq <- f:
 		return nil
 	case <-c.closeq:
 		return ErrClosed

--- a/pkg/cxo/node/feed.go
+++ b/pkg/cxo/node/feed.go
@@ -141,13 +141,20 @@ func (n *nodeFeed) broadcastRoot(cr connRoot) {
 	// observe individual sub-side completions. sendRoot is fire-and-
 	// forget by design — errors translate to a Close that the
 	// conn's run() loop reaps.
+	// Encode the root message body ONCE and share it across every subscriber.
+	// Pre-fix each conn re-ran r.Encode() + msg.Root.Encode() on the (large)
+	// all-transports root, then buffered its own copy — O(rootSize * subs) CPU
+	// and RSS that ballooned the transport-discovery CXO node to multi-GB. Now
+	// the body is a single immutable buffer; each conn adds only its 8-byte head.
+	body := encodeRootBody(cr.r)
+
 	for c := range n.cs {
 
 		if c == cr.c {
 			continue
 		}
 
-		go c.sendRoot(cr.r) //nolint:errcheck
+		go c.sendSharedBody(c.nextSeq(), 0, body) //nolint:errcheck
 	}
 
 }

--- a/pkg/cxo/node/transport/connection.go
+++ b/pkg/cxo/node/transport/connection.go
@@ -9,6 +9,21 @@ import (
 	"time"
 )
 
+// Frame is one outbound message split into a small per-message Head (the
+// 8-byte seq/rseq the CXO Conn prepends) and a Body (the encoded message).
+// Splitting them lets a broadcast encode the (potentially large) Body ONCE and
+// share that immutable []byte across every subscriber connection — each conn
+// supplies only its own tiny Head. On the wire the frame is identical to the
+// old single-buffer form: [4-byte length][Head][Body]. Sharing the Body is what
+// turns a fan-out of an N-MB feed to M subscribers from O(N*M) memory + encode
+// CPU (one encoded+buffered copy per conn) into O(N + M). See
+// docs — the transport-discovery CXO node ballooned to multi-GB RSS re-encoding
+// the all-transports feed once per subscriber.
+type Frame struct {
+	Head []byte
+	Body []byte
+}
+
 // Connection wraps a net.Conn with channel-based message I/O.
 // Messages are length-prefixed (4 bytes, big-endian).
 type Connection struct {
@@ -19,7 +34,7 @@ type Connection struct {
 	closed bool
 
 	in   chan []byte
-	out  chan []byte
+	out  chan Frame
 	done chan struct{}
 }
 
@@ -28,7 +43,7 @@ func newConnection(conn net.Conn, isTCP bool) *Connection {
 		conn:  conn,
 		isTCP: isTCP,
 		in:    make(chan []byte, 256),
-		out:   make(chan []byte, 256),
+		out:   make(chan Frame, 256),
 		done:  make(chan struct{}),
 	}
 	go c.readLoop()
@@ -80,7 +95,7 @@ func (c *Connection) Close() {
 }
 
 // GetChanOut returns the send channel.
-func (c *Connection) GetChanOut() chan<- []byte {
+func (c *Connection) GetChanOut() chan<- Frame {
 	return c.out
 }
 
@@ -128,19 +143,26 @@ func (c *Connection) writeLoop() {
 	// underlying conn.Close inside Close). Close is idempotent.
 	defer c.Close()
 
-	header := make([]byte, 4)
 	for {
 		select {
-		case data, ok := <-c.out:
+		case f, ok := <-c.out:
 			if !ok {
 				return
 			}
-			binary.BigEndian.PutUint32(header, uint32(len(data))) //nolint:gosec
-			if _, err := c.conn.Write(header); err != nil {
+			// One small prefix write (4-byte length + Head) then the Body.
+			// The Body is written from its own (possibly shared) backing
+			// array with no copy — the whole point of the Frame split. Wire
+			// bytes are identical to the old [length][Head||Body] form.
+			prefix := make([]byte, 4+len(f.Head))
+			binary.BigEndian.PutUint32(prefix, uint32(len(f.Head)+len(f.Body))) //nolint:gosec
+			copy(prefix[4:], f.Head)
+			if _, err := c.conn.Write(prefix); err != nil {
 				return
 			}
-			if _, err := c.conn.Write(data); err != nil {
-				return
+			if len(f.Body) > 0 {
+				if _, err := c.conn.Write(f.Body); err != nil {
+					return
+				}
 			}
 		case <-c.done:
 			return

--- a/pkg/cxo/node/transport/connection_more_test.go
+++ b/pkg/cxo/node/transport/connection_more_test.go
@@ -41,7 +41,7 @@ func TestConnectionWrite(t *testing.T) {
 	defer c.Close()
 	defer b.Close() //nolint:errcheck
 
-	c.GetChanOut() <- []byte("hello")
+	c.GetChanOut() <- Frame{Body: []byte("hello")}
 
 	done := make(chan []byte, 1)
 	go func() {

--- a/pkg/cxo/node/transport/factory_test.go
+++ b/pkg/cxo/node/transport/factory_test.go
@@ -58,7 +58,7 @@ func TestTCPFactoryRoundTrip(t *testing.T) {
 	srvConn := acceptWithin(t, accepted, 10*time.Second)
 	defer srvConn.Close()
 
-	conn.GetChanOut() <- []byte("over noise")
+	conn.GetChanOut() <- Frame{Body: []byte("over noise")}
 	assert.Equal(t, []byte("over noise"), recvWithin(t, srvConn, 10*time.Second))
 }
 
@@ -113,7 +113,7 @@ func TestUDPFactoryRoundTrip(t *testing.T) {
 	srvConn := acceptWithin(t, accepted, 5*time.Second)
 	defer srvConn.Close()
 
-	conn.GetChanOut() <- []byte("udp-msg")
+	conn.GetChanOut() <- Frame{Body: []byte("udp-msg")}
 	assert.Equal(t, []byte("udp-msg"), recvWithin(t, srvConn, 5*time.Second))
 }
 


### PR DESCRIPTION
## Problem

The transport-discovery CXO node ballooned to multi-GB RSS (~4.2GB observed) and ~56% CPU under fleet load. RSS was stable (not a leak) — it was steady-state fan-out cost.

**Root cause:** `nodeFeed.broadcastRoot` fans the (large, ~2.3MB) all-transports root out to every subscriber by calling `sendRoot` per connection. Each `sendRoot` re-ran `r.Encode()` + `msg.Root.Encode()` and buffered its own copy of the result. With ~440 subscribers that is **O(rootSize × subscribers)** encode CPU and buffered memory on every feed change.

## Fix

Encode the message body **once** per broadcast and share the resulting immutable `[]byte` across every subscriber connection; each conn supplies only its own 8-byte per-message head. Fan-out becomes **O(rootSize + subscribers)**.

- **transport**: split the outbound unit into `Frame{Head, Body}`; `writeLoop` writes `[4-byte len][Head][Body]`. Wire bytes are **identical** to the previous `[len][head‖body]` single-buffer form — the receiver's `readLoop` is unchanged.
- **node/conn**: `encodeRootBody()` builds the `msg.Root` body once; `sendSharedBody()` enqueues a `Frame` reusing that shared `Body` with a per-conn head. `sendMsg`/`encodeMsg` refactored onto the same `Frame` path; the bounded-enqueue (`sendMsgQueueTimeout`) dead-subscriber protection is preserved.
- **node/feed**: `broadcastRoot` encodes the body once before the fan-out loop and hands it to every subscriber via `sendSharedBody`.

## Testing

No protocol change. `go build ./...` clean; `go test -race ./pkg/cxo/node/...` green — the framed round-trip is byte-identical to before (transport tests assert the on-wire body).