### PR TITLE
fix(dmsgclient): keep-alive stream pool for the net/http-free HTTP path

### DIFF
--- a/pkg/dmsg/dmsgclient/discdmsg.go
+++ b/pkg/dmsg/dmsgclient/discdmsg.go
@@ -49,29 +49,17 @@ func NewDmsgDiscClient(dmsgC *dmsg.Client, discDmsgAddr string, log *logging.Log
 	return &dmsgDiscClient{dmsgC: dmsgC, discPK: discPK, log: log}, nil
 }
 
-// do dials a fresh stream to the discovery and runs one HTTP/1.1 round-trip,
-// bounded by ctx (the stream is closed on cancellation so a blocked read/write
-// unblocks).
+// do runs one HTTP/1.1 round-trip against the discovery over a pooled
+// keep-alive stream, bounded by ctx (the stream is closed on cancellation so a
+// blocked read/write unblocks).
+//
+// Pooling matters most here: the discovery is polled on a fixed cadence by
+// every client (entry re-POST plus dial-path lookups), and dialing a fresh
+// stream each time made the discovery pay a full noise + PQ handshake per call
+// — the handshake storm that dominated its CPU. See fetchPooled.
 func (c *dmsgDiscClient) do(ctx context.Context, method, path string, reqBody []byte) (httpResult, error) {
-	stream, err := c.dmsgC.DialStream(ctx, dmsg.Addr{PK: c.discPK, Port: dmsg.DefaultDmsgHTTPPort})
-	if err != nil {
-		return httpResult{}, err
-	}
-	defer stream.Close() //nolint:errcheck
-
-	done := make(chan struct{})
-	defer close(done)
-	if ctx.Done() != nil {
-		go func() {
-			select {
-			case <-ctx.Done():
-				stream.Close() //nolint:errcheck,gosec
-			case <-done:
-			}
-		}()
-	}
-
-	return httpRoundTrip(stream, method, c.discPK.Hex(), path, nil, reqBody)
+	addr := dmsg.Addr{PK: c.discPK, Port: dmsg.DefaultDmsgHTTPPort}
+	return fetchPooled(ctx, c.dmsgC, addr, method, c.discPK.Hex(), path, nil, reqBody)
 }
 
 // discMessage mirrors disc.HTTPMessage's `message` field (disc.HTTPMessage

--- a/pkg/dmsg/dmsgclient/httpdmsg.go
+++ b/pkg/dmsg/dmsgclient/httpdmsg.go
@@ -19,6 +19,12 @@ type httpResult struct {
 	status  int
 	headers map[string]string
 	body    []byte
+
+	// reusable reports whether the stream may go back into the keep-alive
+	// pool: the body was framed (Content-Length or chunked) so we stopped on
+	// a clean message boundary, and the peer did not ask to close. A
+	// read-to-EOF body is never reusable — the stream is spent by definition.
+	reusable bool
 }
 
 // httpRoundTrip writes a minimal HTTP/1.1 request to conn and reads back the
@@ -28,20 +34,30 @@ type httpResult struct {
 // a dmsg stream) unchanged. It is the net/http-free equivalent of one
 // dmsghttp.HTTPTransport round-trip.
 //
-// `Connection: close` is sent so the server closes the stream after the
-// response; the caller dials one fresh stream per request (no keep-alive reuse).
+// `Connection: keep-alive` is sent so the stream survives the response and can
+// be reused for the next request. Pre-keep-alive this sent `Connection: close`,
+// which made the server tear the stream down after EVERY request — so each
+// periodic call (TPD registration, discovery poll) paid a full noise + PQ
+// handshake on the server. That per-request handshake storm is what pinned
+// dmsg-discovery's CPU: a production profile showed ~73% of ALL allocation in
+// ClientSession.handshakeResponder (secp256k1 ECDH + ML-KEM), with GC burning
+// ~2.6 cores while the actual request rate was modest. The net/http side was
+// fixed the same way in dmsghttp.HTTPTransport; this is its net/http-free twin.
+//
+// br must be the reader that owns conn's buffered bytes — on a reused stream it
+// carries whatever was already pulled off the wire.
 //
 // reqHeaders (may be nil) are extra request headers; Host, Connection and
 // Content-Length are managed here and any same-named entries are ignored. A
 // JSON Content-Type is assumed for a body only when reqHeaders sets none.
-func httpRoundTrip(conn io.ReadWriter, method, host, path string, reqHeaders map[string]string, body []byte) (httpResult, error) {
+func httpRoundTrip(conn io.ReadWriter, br *bufio.Reader, method, host, path string, reqHeaders map[string]string, body []byte) (httpResult, error) {
 	var req strings.Builder
 	req.WriteString(method)
 	req.WriteByte(' ')
 	req.WriteString(path)
 	req.WriteString(" HTTP/1.1\r\nHost: ")
 	req.WriteString(host)
-	req.WriteString("\r\nConnection: close\r\n")
+	req.WriteString("\r\nConnection: keep-alive\r\n")
 	hasCType := false
 	for k, v := range reqHeaders {
 		switch strings.ToLower(k) {
@@ -72,15 +88,15 @@ func httpRoundTrip(conn io.ReadWriter, method, host, path string, reqHeaders map
 			return httpResult{}, err
 		}
 	}
-	return readHTTPResponse(conn)
+	return readHTTPResponse(br)
 }
 
 // readHTTPResponse parses a minimal HTTP/1.1 response: status line, headers, and
 // the body framed by Content-Length, chunked Transfer-Encoding, or read-to-EOF
-// (the `Connection: close` case).
-func readHTTPResponse(r io.Reader) (httpResult, error) {
-	br := bufio.NewReader(r)
-
+// (the `Connection: close` case). br carries any bytes already buffered for this
+// stream, so it is supplied by the caller rather than created here — a reused
+// keep-alive stream may have the next response's opening bytes already read.
+func readHTTPResponse(br *bufio.Reader) (httpResult, error) {
 	statusLine, err := br.ReadString('\n')
 	if err != nil {
 		return httpResult{}, err
@@ -97,6 +113,7 @@ func readHTTPResponse(r io.Reader) (httpResult, error) {
 
 	contentLength := -1
 	chunked := false
+	peerWantsClose := false
 	headers := make(map[string]string)
 	for {
 		line, err := br.ReadString('\n')
@@ -123,6 +140,10 @@ func readHTTPResponse(r io.Reader) (httpResult, error) {
 			if strings.Contains(strings.ToLower(val), "chunked") {
 				chunked = true
 			}
+		case "connection":
+			if strings.Contains(strings.ToLower(val), "close") {
+				peerWantsClose = true
+			}
 		}
 	}
 
@@ -139,7 +160,12 @@ func readHTTPResponse(r io.Reader) (httpResult, error) {
 	if err != nil {
 		return httpResult{}, err
 	}
-	return httpResult{status: code, headers: headers, body: bodyBytes}, nil
+	// Reusable only when the body was explicitly framed — then we stopped on a
+	// clean message boundary and the next response starts where this one ended.
+	// The read-to-EOF branch consumed the stream to its end, so it can never be
+	// reused regardless of what the peer advertised.
+	reusable := (chunked || contentLength >= 0) && !peerWantsClose
+	return httpResult{status: code, headers: headers, body: bodyBytes, reusable: reusable}, nil
 }
 
 // FetchOverDmsg performs ONE HTTP/1.1 request over dmsg to pkHost (a public key,
@@ -159,24 +185,6 @@ func FetchOverDmsg(ctx context.Context, dmsgC *dmsg.Client, method, pkHost, path
 		path = "/" + path
 	}
 
-	stream, err := dmsgC.DialStream(ctx, addr)
-	if err != nil {
-		return 0, nil, nil, err
-	}
-	defer stream.Close() //nolint:errcheck
-
-	done := make(chan struct{})
-	defer close(done)
-	if ctx.Done() != nil {
-		go func() {
-			select {
-			case <-ctx.Done():
-				stream.Close() //nolint:errcheck,gosec
-			case <-done:
-			}
-		}()
-	}
-
 	// Host header defaults to the destination PK, but a caller can override it
 	// via reqHeaders["Host"] to carry a vhost — e.g. the resolving proxy reaching
 	// a name-based virtual host (bunkerofdoom.com.<pk>.dmsg) served by a
@@ -186,11 +194,79 @@ func FetchOverDmsg(ctx context.Context, dmsgC *dmsg.Client, method, pkHost, path
 	if h := reqHeaders["Host"]; h != "" {
 		hostHeader = h
 	}
-	res, err := httpRoundTrip(stream, method, hostHeader, path, reqHeaders, body)
+
+	res, err := fetchPooled(ctx, dmsgC, addr, method, hostHeader, path, reqHeaders, body)
 	if err != nil {
 		return 0, nil, nil, err
 	}
 	return res.status, res.headers, res.body, nil
+}
+
+// fetchPooled runs one HTTP/1.1 round-trip to addr over a keep-alive stream
+// taken from dmsgC's pool, falling back to a fresh dial when none is idle.
+//
+// A pooled stream may be retired by the peer (or by its idle timeout) between
+// our last use and this one, and we only discover that when the write or read
+// fails. So a failure on a REUSED stream is retried once on a freshly-dialed
+// one; a failure on a fresh stream is a real error and propagates. This is what
+// makes keep-alive safe against servers that close early — including
+// pre-v1.3.80 peers whose idle timeout is shorter than our pool's.
+func fetchPooled(ctx context.Context, dmsgC *dmsg.Client, addr dmsg.Addr, method, hostHeader, path string, reqHeaders map[string]string, body []byte) (httpResult, error) {
+	pool := poolFor(dmsgC)
+
+	for attempt := 0; attempt < 2; attempt++ {
+		// Only the first attempt may draw from the pool; the retry always dials
+		// fresh. Otherwise a burst of streams that all went stale together (the
+		// usual case — the peer restarted) would just hand us a second dead one.
+		var ps *pooledStream
+		reused := false
+		if attempt == 0 {
+			if ps = pool.get(addr); ps != nil {
+				reused = true
+			}
+		}
+		if ps == nil {
+			stream, derr := dmsgC.DialStream(ctx, addr)
+			if derr != nil {
+				return httpResult{}, derr
+			}
+			ps = &pooledStream{s: stream, br: bufio.NewReader(stream)}
+		}
+
+		res, rerr := fetchOnce(ctx, ps, method, hostHeader, path, reqHeaders, body)
+		if rerr != nil {
+			ps.s.Close() //nolint:errcheck,gosec
+			if reused {
+				continue // stale pooled stream — retry on a fresh dial
+			}
+			return httpResult{}, rerr
+		}
+
+		if res.reusable {
+			pool.put(addr, ps)
+		} else {
+			ps.s.Close() //nolint:errcheck,gosec
+		}
+		return res, nil
+	}
+	return httpResult{}, fmt.Errorf("dmsgclient: fetch %s failed after keep-alive retry", path)
+}
+
+// fetchOnce runs one request/response over ps, aborting the stream if ctx is
+// canceled mid-flight.
+func fetchOnce(ctx context.Context, ps *pooledStream, method, hostHeader, path string, reqHeaders map[string]string, body []byte) (httpResult, error) {
+	done := make(chan struct{})
+	defer close(done)
+	if ctx.Done() != nil {
+		go func() {
+			select {
+			case <-ctx.Done():
+				ps.s.Close() //nolint:errcheck,gosec
+			case <-done:
+			}
+		}()
+	}
+	return httpRoundTrip(ps.s, ps.br, method, hostHeader, path, reqHeaders, body)
 }
 
 // readChunkedBody decodes an HTTP/1.1 chunked body: a sequence of

--- a/pkg/dmsg/dmsgclient/httpdmsg_test.go
+++ b/pkg/dmsg/dmsgclient/httpdmsg_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -95,10 +96,12 @@ func TestHTTPRoundTripWireCompat(t *testing.T) {
 // over dmsg, a full noise + PQ handshake).
 func TestHTTPRoundTripKeepAliveReuse(t *testing.T) {
 	var served int
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		served++
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"n":`+r.URL.Path[1:]+`}`)
+		// Echo the server-side counter (never request input) so the assertions
+		// below prove both requests reached the server in order over one conn.
+		_, _ = io.WriteString(w, `{"n":`+strconv.Itoa(served)+`}`) //nolint:errcheck
 	}))
 	defer srv.Close()
 	host := strings.TrimPrefix(srv.URL, "http://")
@@ -129,7 +132,7 @@ func TestHTTPRoundTripKeepAliveReuse(t *testing.T) {
 func TestHTTPRoundTripNotReusableOnClose(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Connection", "close")
-		_, _ = io.WriteString(w, "bye")
+		_, _ = io.WriteString(w, "bye") //nolint:errcheck
 	}))
 	defer srv.Close()
 	host := strings.TrimPrefix(srv.URL, "http://")

--- a/pkg/dmsg/dmsgclient/httpdmsg_test.go
+++ b/pkg/dmsg/dmsgclient/httpdmsg_test.go
@@ -1,6 +1,7 @@
 package dmsgclient
 
 import (
+	"bufio"
 	"encoding/json"
 	"io"
 	"net"
@@ -51,12 +52,12 @@ func TestHTTPRoundTripWireCompat(t *testing.T) {
 	defer srv.Close()
 	host := strings.TrimPrefix(srv.URL, "http://")
 
-	// roundTrip dials a fresh conn (Connection: close ⇒ one request per conn).
+	// roundTrip dials a fresh conn and runs one request over it.
 	roundTrip := func(method, path string, body []byte) httpResult {
 		conn, err := net.Dial("tcp", host)
 		require.NoError(t, err)
 		defer conn.Close() //nolint:errcheck
-		res, err := httpRoundTrip(conn, method, host, path, nil, body)
+		res, err := httpRoundTrip(conn, bufio.NewReader(conn), method, host, path, nil, body)
 		require.NoError(t, err)
 		return res
 	}
@@ -85,4 +86,59 @@ func TestHTTPRoundTripWireCompat(t *testing.T) {
 	res = roundTrip("GET", "/fail", nil)
 	require.Equal(t, 500, res.status)
 	require.Equal(t, disc.ErrValidationWrongSequence, errFromBody(res.body))
+}
+
+// TestHTTPRoundTripKeepAliveReuse verifies that two sequential requests can run
+// over ONE connection — the property the stream pool depends on. Pre-keep-alive
+// the client sent `Connection: close`, so the server tore the connection down
+// after the first response and every subsequent request paid a fresh dial (and,
+// over dmsg, a full noise + PQ handshake).
+func TestHTTPRoundTripKeepAliveReuse(t *testing.T) {
+	var served int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		served++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"n":`+r.URL.Path[1:]+`}`)
+	}))
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	conn, err := net.Dial("tcp", host)
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+	br := bufio.NewReader(conn)
+
+	// Both round-trips share one conn and one reader.
+	res1, err := httpRoundTrip(conn, br, "GET", host, "/1", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, res1.status)
+	require.JSONEq(t, `{"n":1}`, string(res1.body))
+	require.True(t, res1.reusable, "framed response must be poolable")
+
+	res2, err := httpRoundTrip(conn, br, "GET", host, "/2", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, res2.status)
+	require.JSONEq(t, `{"n":2}`, string(res2.body))
+	require.True(t, res2.reusable)
+
+	require.Equal(t, 2, served, "both requests should have been served")
+}
+
+// TestHTTPRoundTripNotReusableOnClose verifies we do NOT pool a stream the peer
+// asked to close — pooling it would hand the next request a dead stream.
+func TestHTTPRoundTripNotReusableOnClose(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Connection", "close")
+		_, _ = io.WriteString(w, "bye")
+	}))
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	conn, err := net.Dial("tcp", host)
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	res, err := httpRoundTrip(conn, bufio.NewReader(conn), "GET", host, "/", nil, nil)
+	require.NoError(t, err)
+	require.False(t, res.reusable, "Connection: close must not be pooled")
 }

--- a/pkg/dmsg/dmsgclient/streampool.go
+++ b/pkg/dmsg/dmsgclient/streampool.go
@@ -1,0 +1,126 @@
+// Package dmsgclient pkg/dmsg/dmsgclient/streampool.go c1-net-dmsg
+package dmsgclient
+
+import (
+	"bufio"
+	"sync"
+	"time"
+
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+// poolIdleTimeout is how long an idle stream may sit in the pool before we
+// drop it. It MUST stay below the dmsg-HTTP server's IdleTimeout
+// (dmsg.StreamIdleTimeout-5s, i.e. 115s — see dmsghttp/http.go) so we retire
+// a stream before the server does; otherwise every reuse races the server's
+// teardown and we pay the reconnect anyway. 90s matches the net/http-side
+// pool in dmsghttp.HTTPTransport.
+const poolIdleTimeout = 90 * time.Second
+
+// maxIdlePerHost caps idle streams held per destination. Sustained traffic to
+// one host collapses onto a couple of long-lived streams; a burst of parallel
+// requests may briefly exceed this, and the surplus is closed on return
+// rather than pooled.
+const maxIdlePerHost = 4
+
+// pooledStream is an idle dmsg stream plus the bufio.Reader that owns its
+// buffered bytes. The reader MUST travel with the stream: after a keep-alive
+// response the reader may hold bytes already pulled off the wire, so pairing a
+// pooled stream with a fresh reader would silently drop them.
+type pooledStream struct {
+	s      *dmsg.Stream
+	br     *bufio.Reader
+	idleAt time.Time
+}
+
+// streamPool holds idle keep-alive streams per destination for one dmsg.Client.
+type streamPool struct {
+	mu   sync.Mutex
+	idle map[dmsg.Addr][]*pooledStream
+}
+
+// clientPools maps each dmsg.Client to its own pool. Keyed by client because
+// streams are only interchangeable within the client that dialed them.
+//
+// Entries are dropped by releasePools when a client is closed. A visor holds
+// one long-lived dmsg.Client, so this map stays tiny in practice.
+var (
+	clientPoolsMu sync.Mutex
+	clientPools   = make(map[*dmsg.Client]*streamPool)
+)
+
+// poolFor returns (creating if needed) the pool for dmsgC.
+func poolFor(dmsgC *dmsg.Client) *streamPool {
+	clientPoolsMu.Lock()
+	defer clientPoolsMu.Unlock()
+	p, ok := clientPools[dmsgC]
+	if !ok {
+		p = &streamPool{idle: make(map[dmsg.Addr][]*pooledStream)}
+		clientPools[dmsgC] = p
+	}
+	return p
+}
+
+// ReleasePools closes and forgets every pooled stream belonging to dmsgC. Call
+// it when a dmsg.Client is torn down so the pool doesn't pin dead streams (and
+// the client itself) alive. Safe to call more than once.
+func ReleasePools(dmsgC *dmsg.Client) {
+	clientPoolsMu.Lock()
+	p, ok := clientPools[dmsgC]
+	delete(clientPools, dmsgC)
+	clientPoolsMu.Unlock()
+	if !ok {
+		return
+	}
+	p.mu.Lock()
+	streams := p.idle
+	p.idle = make(map[dmsg.Addr][]*pooledStream)
+	p.mu.Unlock()
+	for _, list := range streams {
+		for _, ps := range list {
+			ps.s.Close() //nolint:errcheck,gosec
+		}
+	}
+}
+
+// get pops a live idle stream for addr, or returns nil if none is usable.
+// Streams idle past poolIdleTimeout are closed rather than returned — the
+// server may already have retired them.
+func (p *streamPool) get(addr dmsg.Addr) *pooledStream {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	list := p.idle[addr]
+	for len(list) > 0 {
+		// Take the most recently returned stream: it has the longest
+		// remaining time before the server's idle timeout fires.
+		ps := list[len(list)-1]
+		list = list[:len(list)-1]
+		if time.Since(ps.idleAt) < poolIdleTimeout {
+			p.idle[addr] = list
+			return ps
+		}
+		ps.s.Close() //nolint:errcheck,gosec
+	}
+	if len(list) == 0 {
+		delete(p.idle, addr)
+	} else {
+		p.idle[addr] = list
+	}
+	return nil
+}
+
+// put returns a stream to the idle pool. The stream must have had its response
+// body fully consumed, so the next request starts at a clean message boundary.
+func (p *streamPool) put(addr dmsg.Addr, ps *pooledStream) {
+	ps.idleAt = time.Now()
+
+	p.mu.Lock()
+	if len(p.idle[addr]) >= maxIdlePerHost {
+		p.mu.Unlock()
+		ps.s.Close() //nolint:errcheck,gosec
+		return
+	}
+	p.idle[addr] = append(p.idle[addr], ps)
+	p.mu.Unlock()
+}


### PR DESCRIPTION
## Problem

dmsg-discovery is sitting at **~84% CPU** with GC burning **~2.6 cores**. Production profiles (taken over dmsgpty against the live deployment):

**CPU profile** — the work is almost entirely garbage collection, not application logic:

| function | flat | cum |
|---|---|---|
| `runtime.scanObject` | 3.49% | **57.41%** |
| `runtime.spanClass.sizeclass` | **24.05%** | 24.05% |
| `runtime.findObject` | 15.00% | 15.60% |
| `runtime.sweepone` | — | 14.04% |
| secp256k1 `Field.Sqr`/`Mul` (real work) | — | ~7% |

**Allocation profile** — ~1 TB allocated over 21h uptime (~13 MB/s), and **73% of ALL allocation is under `ClientSession.handshakeResponder`**:

```
dmsg.(*Client).dialSession.func2                 745 GB  73.3%
└─ dmsg.(*ClientSession).handshakeResponder      743 GB  73.1%
   ├─ noise.MakeHandshakeMessage                 168 GB  16.5%
   ├─ noise.ProcessHandshakeMessage              159 GB  15.7%
   ├─ noise.Secp256k1.DH → cipher.ECDH           144 GB  14.2%  → big.nat.make 163 GB
   ├─ dmsg.decodeGob → gob.Decode                 98 GB   9.7%
   └─ mlkem.NewEncapsulationKey768 (PQ)           55 GB   5.4%
```

Only **100 goroutines** — no leak. It is pure per-handshake churn.

**Cause:** the net/http-free HTTP client sent `Connection: close` on every request and dialed a brand-new dmsg stream per call. Every periodic call — TPD registration (2× per 90s per visor), discovery entry re-POST, dial-path lookups — forced the server through a full noise + PQ handshake. The PQ hybrid handshake (ML-KEM768) made each one substantially more expensive, amplifying a pre-existing per-request-handshake design.

The `net/http` side was fixed exactly this way in `dmsghttp.HTTPTransport` (#3097, which also raised the server's `IdleTimeout` to 115s so a client-side pool can span refreshes). The **net/http-free twin never got the same treatment** — so it kept forcing teardowns even against the fixed server.

## Fix

Send `Connection: keep-alive` and pool idle streams per destination.

- **`streampool.go`** — per-`dmsg.Client`, per-destination idle pool. The `bufio.Reader` travels **with** the stream (a kept-alive stream may hold bytes already pulled off the wire, so pairing it with a fresh reader would silently drop them). 90s idle cap, safely below the server's 115s. `ReleasePools()` for client teardown.
- **Reuse only when safe** — the response must be explicitly framed (`Content-Length` or chunked, so we stop on a clean message boundary) and the peer must not have asked to close. A read-to-EOF body spends the stream by definition and is never pooled.
- **Retry-once semantics** — a failure on a *reused* stream retries once on a freshly-dialed one, and the retry never draws from the pool. This is what makes keep-alive safe against peers that close early.
- **`discdmsg.do`** (the dmsg-discovery client itself) routes through the same pool — it's the most frequently polled endpoint.

## Reverse compatibility

Deliberately safe in both directions:
- `Connection: keep-alive` is plain HTTP/1.1; **no wire-format change**.
- A server that closes anyway (including **pre-v1.3.80 peers** whose idle timeout is shorter than our pool's) just costs one retry — correctness is unaffected.
- Stays **net/http-free**, so the TinyGo / js-wasm build is intact.

## Testing

- `go build ./...` clean; `GOOS=js GOARCH=wasm go build` clean (TinyGo path preserved).
- `go test -race ./pkg/dmsg/dmsgclient/... ./pkg/dmsg/dmsghttp/...` green; `./pkg/transport/tpdclient/...` green.
- New tests: `TestHTTPRoundTripKeepAliveReuse` (two sequential requests over **one** connection — the property the pool depends on) and `TestHTTPRoundTripNotReusableOnClose` (a `Connection: close` response is never pooled).