### PR TITLE
fix(cxo): unstall the nodeFeeds broadcast path (encode off the event loop + conn closeq guard)

### DIFF
--- a/pkg/cxo/node/feed.go
+++ b/pkg/cxo/node/feed.go
@@ -141,20 +141,44 @@ func (n *nodeFeed) broadcastRoot(cr connRoot) {
 	// observe individual sub-side completions. sendRoot is fire-and-
 	// forget by design — errors translate to a Close that the
 	// conn's run() loop reaps.
-	// Encode the root message body ONCE and share it across every subscriber.
-	// Pre-fix each conn re-ran r.Encode() + msg.Root.Encode() on the (large)
-	// all-transports root, then buffered its own copy — O(rootSize * subs) CPU
-	// and RSS that ballooned the transport-discovery CXO node to multi-GB. Now
-	// the body is a single immutable buffer; each conn adds only its 8-byte head.
-	body := encodeRootBody(cr.r)
-
+	//
+	// The root message body is encoded ONCE and shared across every
+	// subscriber. Before that, each conn re-ran r.Encode() +
+	// msg.Root.Encode() on the (large) all-transports root and buffered its
+	// own copy — O(rootSize * subs) CPU and RSS that ballooned the
+	// transport-discovery CXO node to multi-GB. Now the body is a single
+	// immutable buffer and each conn adds only its 8-byte head.
+	//
+	// CRITICAL: the encode must NOT run on this goroutine. We are on the
+	// single nodeFeeds event loop (handleBroadcastRoot), which is the sole
+	// drainer of the UNBUFFERED brorq channel — so while we encode, every
+	// producer calling nodeFeeds.broadcastRoot is blocked. A first cut did
+	// encode here and the result was visible in production: 87 goroutines
+	// parked on that send, the feeds<->head filler pipeline backing up
+	// behind a multi-MB encode. Snapshot the subscriber set here (n.cs is
+	// actor-owned, so it can only be read on this goroutine — that part is
+	// cheap) and hand the encode plus the fan-out to a goroutine.
+	if len(n.cs) == 0 {
+		return
+	}
+	conns := make([]*Conn, 0, len(n.cs))
 	for c := range n.cs {
-
 		if c == cr.c {
 			continue
 		}
-
-		go c.sendSharedBody(c.nextSeq(), 0, body) //nolint:errcheck
+		conns = append(conns, c)
 	}
+	if len(conns) == 0 {
+		return
+	}
+
+	r := cr.r
+	go func() {
+		body := encodeRootBody(r)
+		for _, c := range conns {
+			// nextSeq is atomic, so it is safe off the event loop.
+			go c.sendSharedBody(c.nextSeq(), 0, body) //nolint:errcheck
+		}
+	}()
 
 }

--- a/pkg/cxo/node/feeds.go
+++ b/pkg/cxo/node/feeds.go
@@ -381,8 +381,26 @@ func (n *nodeFeeds) handleDelConnFeed(cf connFeed) {
 // (bubbling api)
 func (n *nodeFeeds) broadcastRoot(cr connRoot) {
 
+	// Same hazard receivedRoot documents, on the broadcast side: n.brorq is
+	// drained by the single nodeFeeds event loop, so when that loop backs up
+	// (the feeds↔head filler pipeline congesting) this send parks. Guarding
+	// ONLY on n.closeq means a connection that closes while parked here never
+	// unblocks, stranding the goroutine — and with it the originating Conn —
+	// until node shutdown. Production dumps on transport-discovery showed 87
+	// goroutines parked on this exact send.
+	//
+	// cr.c is nil for locally-published roots (node.go publishes with no
+	// originating connection). A nil channel blocks forever in select, which is
+	// exactly the wanted behaviour there: it degrades to the original
+	// two-way select rather than firing spuriously.
+	var connClosed <-chan struct{}
+	if cr.c != nil {
+		connClosed = cr.c.closeq
+	}
+
 	select {
 	case n.brorq <- cr:
+	case <-connClosed:
 	case <-n.closeq:
 	}
 

--- a/pkg/cxo/node/feeds.go
+++ b/pkg/cxo/node/feeds.go
@@ -391,7 +391,7 @@ func (n *nodeFeeds) broadcastRoot(cr connRoot) {
 	//
 	// cr.c is nil for locally-published roots (node.go publishes with no
 	// originating connection). A nil channel blocks forever in select, which is
-	// exactly the wanted behaviour there: it degrades to the original
+	// exactly the wanted behavior there: it degrades to the original
 	// two-way select rather than firing spuriously.
 	var connClosed <-chan struct{}
 	if cr.c != nil {


### PR DESCRIPTION
Two fixes to the same broadcast path — the **cause** of a production stall and the **hardening** that stops it stranding goroutines.

## 1. Move the shared-body encode off the nodeFeeds event loop (regression fix — currently live)

**This is a regression from #3514**, which is already merged and deployed.

#3514 hoisted the root encode out of the per-conn goroutines so the body is built once and shared — the right call for total CPU/RSS. But it ran the encode **inline in `nodeFeed.broadcastRoot`**, which executes on the single `nodeFeeds` event loop (`handleBroadcastRoot`).

That loop is the **sole drainer of `brorq`, and `brorq` is unbuffered** (`feeds.go:101`). So while the loop encodes a multi-MB root, every producer blocked in `nodeFeeds.broadcastRoot` stays blocked. Net effect: **N parallel encodes off the critical path were replaced by ONE encode on it.**

A production goroutine dump on transport-discovery — taken from a build containing #3514 (`v1.3.85-0.20260718213237-a986de4f41df`) — showed **87 goroutines parked on that send**, with the feeds↔head filler pipeline backed up behind it:

```
87 @ ...
#	nodeFeeds.broadcastRoot+0x1fa   feeds.go:384
#	fillHead.createFiller+0x16c     head.go:405
#	fillHead.handleFillingResult    head.go:479
```

**Fix:** keep the encode-once win, drop the serialization. Snapshot the subscriber set on the event loop (`n.cs` is actor-owned so it can only be read there, and the copy is cheap), then do the encode **and** the fan-out in a goroutine. `nextSeq` is atomic, so it's safe off the loop.

## 2. Unblock `broadcastRoot` when the originating conn closes (leak hardening)

`nodeFeeds.receivedRoot` already selects on the **connection's** `closeq` alongside the node's, with a comment explaining why (a conn that closes while parked never unblocks, stranding `receiveMsg`, its `Conn.run` in `await.Wait()`, and the whole Conn). `broadcastRoot` parks under the same conditions but was guarded **only** on `n.closeq`.

**Fix:** select on `cr.c.closeq` too. `cr.c` is **nil** for locally-published roots (`node.go:263` broadcasts `connRoot{nil, r}`), so the channel is only wired up when there is a conn — a nil channel blocks forever in `select`, degrading to the previous two-way behaviour rather than firing spuriously.

Fix 1 removes the stall; fix 2 ensures that if the path ever congests again, it doesn't strand goroutines.

## Testing

`go build ./...` clean; `go test -race ./pkg/cxo/node/...` green.