### PR TITLE
fix(vpn): move prefixLen to router_linux.go (unblocks darwin/windows CI)

### DIFF
--- a/pkg/vpn/router.go
+++ b/pkg/vpn/router.go
@@ -172,15 +172,6 @@ func (c RouterConfig) validate() error {
 	return nil
 }
 
-// prefixLen returns the subnet's CIDR prefix length (e.g. 24).
-func (c RouterConfig) prefixLen() int {
-	if c.Subnet == nil {
-		return 0
-	}
-	ones, _ := c.Subnet.Mask.Size()
-	return ones
-}
-
 // DnsmasqConf renders the dnsmasq configuration for the downstream subnet
 // (DHCP pool + the router as gateway/DNS). It is pure (no I/O) so it can be
 // unit-tested and reviewed.

--- a/pkg/vpn/router_linux.go
+++ b/pkg/vpn/router_linux.go
@@ -274,3 +274,17 @@ func (r *Router) teardown() {
 		_ = os.RemoveAll(r.confDir) //nolint:errcheck // temp conf dir, best-effort
 	}
 }
+
+// prefixLen returns the subnet's CIDR prefix length (e.g. 24).
+//
+// Lives here rather than in router.go because it is only referenced from
+// this linux-only file. In router.go (which builds on every platform) it
+// is dead code on darwin/windows, where the `unused` linter fails the
+// build — which it did, on every PR.
+func (c RouterConfig) prefixLen() int {
+	if c.Subnet == nil {
+		return 0
+	}
+	ones, _ := c.Subnet.Mask.Size()
+	return ones
+}


### PR DESCRIPTION
## Problem

`RouterConfig.prefixLen` is declared in `pkg/vpn/router.go` — which builds on **every** platform — but its only callers are in `pkg/vpn/router_linux.go` (linux-only):

```
pkg/vpn/router_linux.go:118:  cidr := fmt.Sprintf("%s/%d", r.cfg.Gateway, r.cfg.prefixLen())
pkg/vpn/router_linux.go:268:  cidr := fmt.Sprintf("%s/%d", r.cfg.Gateway, r.cfg.prefixLen())
```

So on darwin and windows it is genuinely dead code, and the `unused` linter fails the build:

```
pkg/vpn/router.go:176:23: func RouterConfig.prefixLen is unused (unused)
```

This has been failing the **darwin** and **windows** jobs on every PR against develop (it's on #3514, #3515, #3516 — all unrelated changes). Those two checks are permanently red, so they no longer signal anything, and every PR has to be merged past them.

## Fix

Move the method next to its only callers, in the linux-only file.

No behavior change — identical implementation, just relocated.

## Verification

Built **and** linted for all three platforms:

| GOOS | build | golangci-lint |
|---|---|---|
| linux | ✅ | 0 issues |
| darwin | ✅ | 0 issues |
| windows | ✅ | 0 issues |

`go test ./pkg/vpn/...` passes.