### PR TITLE
test(appdisc): fix PauseResume race against the async initial register

### DIFF
--- a/pkg/app/appdisc/appdisc_test.go
+++ b/pkg/app/appdisc/appdisc_test.go
@@ -224,8 +224,19 @@ func TestServiceUpdater_Heartbeat(t *testing.T) {
 func TestServiceUpdater_PauseResume(t *testing.T) {
 	ml := testLog()
 	u := newServiceUpdater(&ml, liveClient(), 15*time.Millisecond)
+	beforeStart := sdPostN.Load()
 	u.Start()
 	defer u.Stop()
+
+	// Start() fires the initial client.Register in a goroutine (it must not block
+	// the visor init path), so its POST lands at an arbitrary point. Wait for it
+	// before sampling the counter below — otherwise it can arrive during the
+	// paused window and be miscounted as a heartbeat, failing the test spuriously.
+	// This asserts nothing about pause; it only pins down the starting count.
+	regDeadline := time.Now().Add(2 * time.Second)
+	for sdPostN.Load() == beforeStart && time.Now().Before(regDeadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
 
 	u.Pause()
 	if !u.paused.Load() {


### PR DESCRIPTION
## Problem

`TestServiceUpdater_PauseResume` is failing on **develop** (hit on the darwin job of #3516, but it is not caused by that PR — it reproduces on unmodified `upstream/develop`):

```
--- FAIL: TestServiceUpdater_PauseResume (0.06s)
    appdisc_test.go:240: paused updater sent 1 heartbeats, want 0
FAIL	github.com/skycoin/skywire/pkg/app/appdisc
```

`Start()` fires the initial `client.Register` **in a goroutine** — introduced in #3511, and correctly so: `Start()` runs on the visor init path (`initPublicVisor`), and a synchronous `Register` (which retries with backoff) blocked init for minutes and stalled the hypervisor.

That makes the initial POST land at an arbitrary point. The test samples `sdPostN` immediately after `Pause()`, so when the initial POST hasn't landed yet it arrives during the 60 ms paused window and is miscounted as a heartbeat.

## Fix

The heartbeat loop **does** honour pause — that part works, and it's what the test means to verify. The test simply assumed `Start()` registered synchronously.

Wait for the initial registration to land before sampling the counter. This pins down the starting count, asserts nothing about pause, and changes no production behaviour.

## Verification

- Fails **reproducibly on unmodified develop** (confirmed by checking out `upstream/develop` and running it).
- After the fix: **40/40** runs of the test pass, and **15/15** runs of the whole package pass under `-race`.
- `golangci-lint ./pkg/app/appdisc/...`: 0 issues.