### PR TITLE
feat(wallet): capability-gated wallet config block (Stage 1)

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -143,6 +143,10 @@ func init() {
 	}
 	genConfigCmd.Flags().StringVarP(&output, "out", "o", scriptExecString("${OUTPUT}"), msg+"")
 	genConfigCmd.Flags().BoolVarP(&isHide, "hide", "w", false, "suppress config output to terminal")
+	genConfigCmd.Flags().StringVar(&walletCustody, "wallet-custody", "", "where the skycoin-web wallet keeps keys: browser|disk|remote")
+	genConfigCmd.Flags().StringVar(&walletDir, "wallet-dir", "", "wallet dir for --wallet-custody=disk (a seed-wallet store, not per-coin)")
+	genConfigCmd.Flags().StringVar(&walletRemotePK, "wallet-remote", "", "visor PK holding the wallets, for --wallet-custody=remote")
+	genConfigCmd.Flags().BoolVar(&noWallet, "no-wallet", false, "do not serve the skycoin-web wallet frontend")
 	gHiddenFlags = append(gHiddenFlags, "hide")
 	genConfigCmd.Flags().BoolVarP(&isEnvs, "envs", "q", false, "show the conf template (reflects flags passed)")
 	genConfigCmd.Flags().StringVarP(&envfileOut, "envout", "Q", "", "write conf template to file (reflects flags passed)")
@@ -1264,6 +1268,27 @@ func configureLauncher(log *logging.Logger) {
 		conf.Transport.Discovery = dmsgConf.TransportDiscovery
 		conf.Routing.RouteFinder = dmsgConf.RouteFinder
 		conf.Launcher.ServiceDisc = dmsgConf.ServiceDiscovery
+	}
+
+	// Configure the skycoin-web wallet. Only emit a block when the operator
+	// asked for something — an unconditional block would add noise to every
+	// generated config AND freeze today's defaults into the file, so a later
+	// change to those defaults would not reach existing configs.
+	if noWallet || walletCustody != "" {
+		switch walletCustody {
+		case "", visorconfig.WalletCustodyBrowser, visorconfig.WalletCustodyDisk, visorconfig.WalletCustodyRemote:
+		default:
+			log.Fatalf("invalid --wallet-custody %q: want browser, disk or remote", walletCustody)
+		}
+		if walletCustody == visorconfig.WalletCustodyRemote && walletRemotePK == "" {
+			log.Fatal("--wallet-custody=remote requires --wallet-remote <visor-pk>")
+		}
+		conf.Wallet = &visorconfig.WalletConfig{
+			Serve:    !noWallet,
+			Custody:  walletCustody,
+			Dir:      walletDir,
+			RemotePK: walletRemotePK,
+		}
 	}
 
 	// Configure public visor

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -59,6 +59,10 @@ var (
 	servicesConfig             servicesConf
 	isForce                    bool
 	isHide                     bool
+	walletCustody              string
+	walletDir                  string
+	walletRemotePK             string
+	noWallet                   bool
 	isAll                      bool
 	isOutUnset                 bool
 	ver                        string

--- a/docs/design/skycoin-web-wallet-architecture.md
+++ b/docs/design/skycoin-web-wallet-architecture.md
@@ -1,0 +1,133 @@
+# skycoin-web wallet architecture — serving, custody, multicoin
+
+Extends `gui-app-serving-modes.md` (the wallet-is-a-feature vs backend-is-an-app
+distinction) with the **custody model** and the **seed-centric multicoin** model.
+One mental model that reads identically on a native HV, a served standalone PWA
+(`hv serve`), and a browser-tab wasm visor.
+
+## 1. Layers — what varies vs what the operator chooses
+
+The wallet **frontend is always a browser SPA** (Angular + `skycoin-lite.wasm`).
+Two things vary by platform and the operator should never think about them:
+
+- **How the frontend is served** — native Go handler (`walletHandler`) / static
+  embedded assets (`hv serve`, wasm) / inlined single-file (`hv gen`).
+- **How the node API is reached** — server-side dmsg proxy (native) / in-tab
+  fetch-over-dmsg (wasm/standalone). This is the `/coin/<index>` seam.
+
+The **one axis the operator actually chooses is custody** (where keys + wallet
+files live).
+
+## 2. Custody — `browser | disk | remote`, capability-gated
+
+| Custody | Storage | Available where | Trust |
+|---|---|---|---|
+| **browser** (default) | localStorage (native/served) / OPFS virtual-dir (wasm) | **everywhere** — the SPA is always a browser | host never sees keys (zero-trust) |
+| **disk** | real filesystem `wallet.dir` via the `skycoin-web` **server** (`RunSkycoinWeb`) | only where a backend Go process + FS exists: native visor, `hv serve` | host holds keys |
+| **remote** | on another visor's `skycoin-web` server, over dmsg | **everywhere** (a dmsg target) | trust the remote |
+
+**Capability gating is the crux of making sense across contexts:** a single-file
+HV or a statically-hosted wasm PWA has no backend filesystem → offers only
+`browser` + `remote`. A native visor or `hv serve` additionally offers `disk`.
+The config is uniform; the *offered* options degrade to what the context realizes.
+
+## 3. One config block, three realizations
+
+```jsonc
+wallet: {
+  serve:     true,                 // serve the /wallet/ frontend at all (feature on/off)
+  custody:   "browser",            // browser | disk | remote
+  dir:       "~/.skycoin/wallets", // disk only: real path (seed-wallet STORE, not per-coin)
+  user:      "operator",           // disk only: UID drop (SKYCOINWEBUSER) when visor runs as _skywire
+  remote_pk: "",                   // remote only
+}
+```
+
+- **Native visor / `hv serve`:** all three custody modes; `disk` runs
+  `RunSkycoinWeb` with `wallet.dir`.
+- **wasm / single-file:** `custody` clamped to `browser|remote`; browser = OPFS.
+- **`RunSkycoinWeb` app:** it *is* the `disk`-custody implementation. It gets no
+  *separate* enable — choosing `disk` (with a dir) is what turns it on. The Apps
+  tab shows it running/stoppable; `wallet.custody` is the source of truth.
+
+The existing `skycoinweb*` config-gen flags (`--skycoinweb`, `--skycoinwebwallet`,
+`--skycoinwebaddr`, `--skycoinwebnodes`, `--skycoinwebuser`) become aliases into
+this block.
+
+## 4. Surfaces are views of the one block
+- **GUI** (`/wallet/config` panel, any context): Storage selector Browser / This
+  host (disk) / Remote; `dir` field revealed only for disk-and-capable; a security
+  note that disk flips the trust model to host-holds-keys. Writes back via
+  config-update. Subsumes today's browser-vs-remote toggle.
+- **CLI** (`config gen` + `hv serve`): `--wallet[=false]` (serve), `--wallet-custody`,
+  `--wallet-dir`, `--wallet-remote`.
+- **Apps tab / internal-app:** the `skycoin-web` server = the disk-custody backend;
+  enable == `custody==disk`; its settings show the same `dir`. No parallel knob to drift.
+
+## 5. Multicoin — seed-centric, NO wallet file-format change
+
+### The crypto (verified in vendored `cipher`)
+- Skycoin address = `RIPEMD160(SHA256(SHA256(pubkey)))`; Bitcoin P2PKH =
+  `RIPEMD160(SHA256(pubkey))`. **Addresses are NOT convertible between chains;
+  the only shared thing is the KEY.**
+- **Fibercoins (skycoin + every fork) share the address format AND keys** (same
+  `cipher`, `coinType:"skycoin"`) — no fork changes the address version byte
+  (it's a compile-time `cipher` constant, not a fiber-config param; verified
+  against the reward **login chain**, which only sets `bip44_coin = 8001` +
+  genesis/ticker, never the version byte).
+
+### The format already supports multi-chain in one file
+The bip44 wallet serializes `"accounts": [ … ]` where **each account carries its
+own `"coin_type"`** ("determines the way to generate addresses"). Only `Meta.coin`
+/ `Meta.bip44Coin` are single — a default, not a constraint. So one seed → one file
+→ `accounts:[{coin_type:8000},{coin_type:0/BTC},{coin_type:8001/login}]` natively.
+
+**Therefore: no new format, and NOT one-file-per-chain.** A wallet is a **seed**;
+"a coin" is an **account (coin_type) inside it**.
+
+- **Deterministic wallets** (coin-agnostic): one address set, **shared across ALL
+  fibercoins** — query different nodes for per-coin balances. Cannot do BTC/foreign
+  (no coin_type level).
+- **BIP44 wallets:** each `coin_type` is its own branch off the one seed
+  (skycoin 8000, login 8001, BTC 0…) — SLIP-44-correct, no cross-coin address
+  linkage. The reward login flow already demonstrates both (deterministic address
+  funded directly; xpub derived at `m/44'/coin'/0'/1/0`).
+
+### What changes (logic/UI, shared by browser AND disk custody)
+1. Lift the single-coin assumption in wallet-create/API + `MetaCoin` gating so a
+   wallet holds accounts of different `coin_type`s (`newBip44Account(coinType)`
+   already supports it).
+2. Reshape skycoin-web's coin selector: "which coin" = which coin_type account in
+   the *current* wallet, not a separate wallet/dir. "Activate a chain" = add its
+   coin_type account.
+3. Deterministic stays fibercoin-shared; bip44 is the foreign-chain vehicle.
+4. Per-coin-dir demoted to a legacy import path.
+
+Both custody paths (client-side skycoin-lite WASM, server-side `RunSkycoinWeb`)
+use the same wallet lib, so this one change fixes both.
+
+## 6. Settled decisions
+- Custody axis browser|disk|remote, capability-gated; **default browser**.
+- Wallet-dir lives in the GUI Storage section, revealed only in disk mode; it is a
+  **seed-wallet store** (one dir, N seed files), never per-coin.
+- Frontend serve is a CLI/config knob (`--wallet`), not a GUI self-toggle.
+- `disk` selection requires an explicit "start the wallet server" confirmation
+  (it flips the trust model).
+- `hv serve` MAY offer disk (it has a FS) but defaults to browser to keep the
+  standalone/serverless story clean.
+
+## 7. Implementation staging
+1. **skywire, self-contained:** `wallet.*` config block (+ `skycoinweb*` aliases),
+   `hv serve --wallet`, GUI Storage section (browser/disk/remote + gated dir),
+   config-update writeback. No wallet-model change yet — disk still single-coin.
+2. **skycoin-web (skycoin repo):** lift the single-coin assumption; coin selector =
+   coin_type-account-in-wallet; seed-centric create. Re-vendor + re-embed.
+3. **skywire backend align:** `RunSkycoinWeb` seed-wallet dir (drop per-coin-dir);
+   `/coin/<index>` routing keyed by coin_type. Legacy per-coin-dir import.
+
+## 8. Future — adopt the Android wallet UX
+The operator prefers the **skycoin-android** wallet GUI to skycoin-web's. It's
+native Java over the Go lib (not portable code), so "adopt" = re-implement its
+UX/layout in the Angular skycoin-web app. Keep the seed-centric model above
+UI-agnostic so a reskin is a view change, not a model change. Separate effort;
+does not block the model work.

--- a/pkg/skywireconfig/genvisor/genvisor.go
+++ b/pkg/skywireconfig/genvisor/genvisor.go
@@ -74,6 +74,29 @@ type Options struct {
 	// transport-discovery, route-finder, etc.). Mirrors the
 	// `--testenv` flag in cli config gen.
 	TestEnv bool
+
+	// WalletCustody, when non-empty, sets V1.Wallet.Custody — where the
+	// skycoin-web wallet keeps keys (browser | disk | remote; see the
+	// visorconfig.WalletCustody* constants). Empty leaves the wallet block
+	// unset, which means "serve the wallet, browser custody" — today's
+	// behavior. The value is NOT clamped here: a config generated for a
+	// native visor may legitimately say "disk", and V1.WalletCustody()
+	// does the per-build clamping at read time.
+	WalletCustody string
+
+	// WalletDir sets V1.Wallet.Dir — the disk-custody wallet directory. It
+	// is a seed-wallet store (one dir, N seed files), not one dir per coin.
+	// Ignored unless WalletCustody is "disk".
+	WalletDir string
+
+	// WalletRemotePK sets V1.Wallet.RemotePK — the visor whose skycoin-web
+	// server holds the wallets. Ignored unless WalletCustody is "remote".
+	WalletRemotePK string
+
+	// NoWallet disables serving the wallet frontend entirely
+	// (V1.Wallet.Serve=false). Distinct from custody: this is the feature
+	// on/off switch.
+	NoWallet bool
 }
 
 // Generate composes a fresh visorconfig.V1 from opts + the
@@ -116,6 +139,19 @@ func Generate(opts Options) (*visorconfig.V1, error) {
 
 	if opts.RewardAddress != "" {
 		conf.RewardAddress = opts.RewardAddress
+	}
+
+	// Emit a wallet block only when the operator actually asked for
+	// something. Writing one unconditionally would add noise to every
+	// generated config and, worse, pin today's defaults into the file so a
+	// later change to those defaults wouldn't reach existing configs.
+	if opts.NoWallet || opts.WalletCustody != "" {
+		conf.Wallet = &visorconfig.WalletConfig{
+			Serve:    !opts.NoWallet,
+			Custody:  opts.WalletCustody,
+			Dir:      opts.WalletDir,
+			RemotePK: opts.WalletRemotePK,
+		}
 	}
 
 	conf.IsPublic = opts.IsPublic

--- a/pkg/visor/visorconfig/config_compat.go
+++ b/pkg/visor/visorconfig/config_compat.go
@@ -48,8 +48,9 @@ type v1JSON struct {
 	UptimeTracker *UptimeTracker       `json:"uptime_tracker,omitempty"`
 	Launcher      *Launcher            `json:"launcher"`
 
-	Stats   *Stats   `json:"stats,omitempty"`
-	Skychat *Skychat `json:"skychat,omitempty"`
+	Stats   *Stats        `json:"stats,omitempty"`
+	Skychat *Skychat      `json:"skychat,omitempty"`
+	Wallet  *WalletConfig `json:"wallet,omitempty"`
 
 	CoinNodes []CoinNodeConfig `json:"coin_nodes,omitempty"`
 
@@ -111,6 +112,7 @@ func (v *V1) UnmarshalJSON(data []byte) error {
 	v.Launcher = mirror.Launcher
 	v.Stats = mirror.Stats
 	v.Skychat = mirror.Skychat
+	v.Wallet = mirror.Wallet
 	v.CoinNodes = mirror.CoinNodes
 	v.SurveyWhitelist = mirror.SurveyWhitelist
 	v.UserSurveyWhitelist = mirror.UserSurveyWhitelist

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -39,6 +39,16 @@ type V1 struct {
 	// persistence; expected to grow as the chat surface evolves.
 	Skychat *Skychat `json:"skychat,omitempty"`
 
+	// Wallet configures the skycoin-web wallet: whether to serve the
+	// frontend, and — the one axis the operator actually chooses — where
+	// keys live (browser | disk | remote). One block covers the native
+	// visor, `hv serve` and the wasm visor; what varies is which custody
+	// modes a given build can realize, which V1.WalletCustody() clamps.
+	// Nil (a config predating this block) serves the wallet with browser
+	// custody, i.e. existing behavior. See
+	// docs/design/skycoin-web-wallet-architecture.md.
+	Wallet *WalletConfig `json:"wallet,omitempty"`
+
 	// CoinNodes lists fibercoin nodes (see servicedisc.ServiceTypeCoin)
 	// this visor forwards over dmsg and advertises in service discovery,
 	// so a browser/thin-client wallet can discover and reach a node for

--- a/pkg/visor/visorconfig/walletconfig.go
+++ b/pkg/visor/visorconfig/walletconfig.go
@@ -1,0 +1,147 @@
+// Package visorconfig pkg/visor/visorconfig/walletconfig.go c3-app-wallet
+package visorconfig
+
+// Wallet custody modes — WHERE the keys and wallet files live. This is the one
+// axis the operator actually chooses; how the frontend is served and how the
+// node API is reached vary by platform and are not the operator's concern.
+//
+// See docs/design/skycoin-web-wallet-architecture.md.
+const (
+	// WalletCustodyBrowser keeps keys in the browser (localStorage on a native
+	// visor or `hv serve`, an OPFS virtual directory under wasm). The host
+	// never sees them. Available EVERYWHERE, because the wallet frontend is
+	// always a browser SPA — hence the default.
+	WalletCustodyBrowser = "browser"
+
+	// WalletCustodyDisk keeps wallet files on a real filesystem, served by the
+	// skycoin-web server (RunSkycoinWeb) at Wallet.Dir. Requires a backend Go
+	// process AND a filesystem, so it is offered only on a native visor or
+	// `hv serve` — never in a statically-hosted wasm PWA or a single-file
+	// hypervisor. Flips the trust model: the host holds the keys.
+	WalletCustodyDisk = "disk"
+
+	// WalletCustodyRemote delegates to another visor's skycoin-web server over
+	// dmsg (Wallet.RemotePK). Available anywhere a dmsg target is reachable;
+	// you are trusting that remote.
+	WalletCustodyRemote = "remote"
+)
+
+// WalletConfig is the single config block behind the wallet feature, in all
+// three realizations (native visor, `hv serve`, wasm/single-file). The block is
+// uniform; what DEGRADES per context is which custody modes can actually be
+// realized — a context with no backend filesystem offers only browser|remote.
+// Keeping one block rather than per-context knobs is what stops the surfaces
+// drifting apart.
+//
+// The existing skycoinweb* config-gen flags (--skycoinweb, --skycoinwebwallet,
+// --skycoinwebaddr, --skycoinwebnodes, --skycoinwebuser) become aliases into
+// this block rather than a parallel source of truth.
+type WalletConfig struct {
+	// Serve controls whether the /wallet/ frontend is served at all — the
+	// feature on/off switch. Deliberately a CLI/config knob rather than a GUI
+	// self-toggle: a GUI that can turn off the surface hosting it is a trap.
+	Serve bool `json:"serve"`
+
+	// Custody is browser | disk | remote (the WalletCustody* constants).
+	// Empty means browser. A value the current context cannot realize is
+	// clamped by WalletCustody() rather than failing the config load, so a
+	// config written on a native visor still loads under wasm.
+	Custody string `json:"custody,omitempty"`
+
+	// Dir is the disk-custody wallet directory. It is a SEED-wallet store —
+	// one directory holding N seed files — NOT one directory per coin. The
+	// per-coin-directory layout is legacy: since bip44 carries coin_type per
+	// account, one seed file already spans several chains.
+	Dir string `json:"dir,omitempty"`
+
+	// User is the account to drop to when running the wallet server, for
+	// visors running as a system user (_skywire) that should not own the
+	// operator's wallet files. Mirrors SKYCOINWEBUSER. Disk custody only.
+	User string `json:"user,omitempty"`
+
+	// RemotePK is the visor whose skycoin-web server holds the wallets, for
+	// remote custody.
+	RemotePK string `json:"remote_pk,omitempty"`
+}
+
+// WalletServe reports whether the wallet frontend should be served. Nil-safe:
+// a config predating this block (or with the block omitted) serves the wallet,
+// preserving existing behavior — the block is opt-OUT, not opt-in.
+func (v *V1) WalletServe() bool {
+	if v == nil {
+		return false
+	}
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	if v.Wallet == nil {
+		return true
+	}
+	return v.Wallet.Serve
+}
+
+// WalletCustody returns the effective custody mode, defaulting to browser and
+// clamping to what this build can actually realize.
+//
+// The clamp is the point of the capability gating: disk needs a backend process
+// with a filesystem. Under wasm there is none, so a config carrying
+// custody:"disk" — perfectly valid on the native visor that wrote it — silently
+// degrades to browser instead of leaving the UI offering a mode that cannot
+// work. See walletCustodyDiskCapable (per-build).
+func (v *V1) WalletCustody() string {
+	if v == nil {
+		return WalletCustodyBrowser
+	}
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	if v.Wallet == nil || v.Wallet.Custody == "" {
+		return WalletCustodyBrowser
+	}
+	switch v.Wallet.Custody {
+	case WalletCustodyDisk:
+		if !walletCustodyDiskCapable {
+			return WalletCustodyBrowser
+		}
+		return WalletCustodyDisk
+	case WalletCustodyRemote:
+		return WalletCustodyRemote
+	default:
+		return WalletCustodyBrowser
+	}
+}
+
+// WalletDir returns the disk-custody wallet directory (empty unless disk
+// custody is both selected and realizable).
+func (v *V1) WalletDir() string {
+	if v.WalletCustody() != WalletCustodyDisk {
+		return ""
+	}
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	if v.Wallet == nil {
+		return ""
+	}
+	return v.Wallet.Dir
+}
+
+// WalletRemotePK returns the remote-custody target (empty unless remote).
+func (v *V1) WalletRemotePK() string {
+	if v.WalletCustody() != WalletCustodyRemote {
+		return ""
+	}
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	if v.Wallet == nil {
+		return ""
+	}
+	return v.Wallet.RemotePK
+}
+
+// WalletCustodyOptions lists the custody modes this build can realize — what a
+// GUI should offer. browser and remote are always available; disk appears only
+// where there is a backend process with a filesystem.
+func WalletCustodyOptions() []string {
+	if walletCustodyDiskCapable {
+		return []string{WalletCustodyBrowser, WalletCustodyDisk, WalletCustodyRemote}
+	}
+	return []string{WalletCustodyBrowser, WalletCustodyRemote}
+}

--- a/pkg/visor/visorconfig/walletconfig_native.go
+++ b/pkg/visor/visorconfig/walletconfig_native.go
@@ -1,0 +1,9 @@
+//go:build !wasm && !(js && wasm)
+
+// Package visorconfig pkg/visor/visorconfig/walletconfig_native.go c3-app-wallet
+package visorconfig
+
+// walletCustodyDiskCapable: this build has a real filesystem and can run the
+// skycoin-web server, so disk custody is realizable. Covers the native visor
+// and `hv serve` (which is the same binary).
+const walletCustodyDiskCapable = true

--- a/pkg/visor/visorconfig/walletconfig_test.go
+++ b/pkg/visor/visorconfig/walletconfig_test.go
@@ -1,0 +1,106 @@
+// Package visorconfig pkg/visor/visorconfig/walletconfig_test.go c3-app-wallet
+package visorconfig
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWalletDefaultsPreserveExistingBehavior pins the opt-OUT contract: a
+// config written before the wallet block existed (Wallet == nil) must still
+// serve the wallet, with browser custody. If this flips, every deployed config
+// silently loses its wallet on upgrade.
+func TestWalletDefaultsPreserveExistingBehavior(t *testing.T) {
+	v := &V1{}
+	require.True(t, v.WalletServe(), "nil Wallet block must still serve the wallet")
+	require.Equal(t, WalletCustodyBrowser, v.WalletCustody())
+	require.Empty(t, v.WalletDir())
+	require.Empty(t, v.WalletRemotePK())
+}
+
+func TestWalletServeOptOut(t *testing.T) {
+	v := &V1{Wallet: &WalletConfig{Serve: false}}
+	require.False(t, v.WalletServe())
+
+	v = &V1{Wallet: &WalletConfig{Serve: true}}
+	require.True(t, v.WalletServe())
+}
+
+// TestWalletCustodyClamp covers the capability gate. On a build with a
+// filesystem, disk is honored; on a browser build it must clamp to browser
+// rather than offering a mode that cannot work. Asserting against the same
+// constant the production code uses keeps this meaningful under both builds
+// instead of only the one CI happens to run.
+func TestWalletCustodyClamp(t *testing.T) {
+	v := &V1{Wallet: &WalletConfig{Serve: true, Custody: WalletCustodyDisk, Dir: "/tmp/w"}}
+
+	if walletCustodyDiskCapable {
+		require.Equal(t, WalletCustodyDisk, v.WalletCustody())
+		require.Equal(t, "/tmp/w", v.WalletDir())
+	} else {
+		require.Equal(t, WalletCustodyBrowser, v.WalletCustody(),
+			"disk custody must clamp to browser where there is no filesystem")
+		require.Empty(t, v.WalletDir(), "no wallet dir once clamped away from disk")
+	}
+}
+
+func TestWalletCustodyRemote(t *testing.T) {
+	pk := "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c"
+	v := &V1{Wallet: &WalletConfig{Serve: true, Custody: WalletCustodyRemote, RemotePK: pk}}
+	require.Equal(t, WalletCustodyRemote, v.WalletCustody())
+	require.Equal(t, pk, v.WalletRemotePK())
+	require.Empty(t, v.WalletDir(), "remote custody has no local dir")
+}
+
+// An unrecognized custody value must not brick the wallet — fall back to the
+// safe default rather than erroring the config load.
+func TestWalletCustodyUnknownFallsBackToBrowser(t *testing.T) {
+	v := &V1{Wallet: &WalletConfig{Serve: true, Custody: "nonsense"}}
+	require.Equal(t, WalletCustodyBrowser, v.WalletCustody())
+}
+
+func TestWalletCustodyOptionsMatchCapability(t *testing.T) {
+	opts := WalletCustodyOptions()
+	require.Contains(t, opts, WalletCustodyBrowser)
+	require.Contains(t, opts, WalletCustodyRemote)
+	if walletCustodyDiskCapable {
+		require.Contains(t, opts, WalletCustodyDisk)
+	} else {
+		require.NotContains(t, opts, WalletCustodyDisk,
+			"must not offer disk custody where it cannot be realized")
+	}
+}
+
+// The block must survive the v1JSON compat mirror — that mirror is hand-kept in
+// sync with V1, so a field added to one and not the other is silently dropped
+// on every config read/write cycle.
+func TestWalletSurvivesCompatRoundTrip(t *testing.T) {
+	in := &V1{Wallet: &WalletConfig{
+		Serve:   true,
+		Custody: WalletCustodyDisk,
+		Dir:     "/home/operator/.skycoin/wallets",
+		User:    "operator",
+	}}
+
+	b, err := json.Marshal(in)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"wallet"`)
+
+	var out V1
+	require.NoError(t, json.Unmarshal(b, &out))
+	require.NotNil(t, out.Wallet, "wallet block dropped by the compat mirror")
+	require.Equal(t, WalletCustodyDisk, out.Wallet.Custody)
+	require.Equal(t, "/home/operator/.skycoin/wallets", out.Wallet.Dir)
+	require.Equal(t, "operator", out.Wallet.User)
+	require.True(t, out.Wallet.Serve)
+}
+
+// A config with no wallet block must not grow one on marshal — otherwise every
+// existing config file gains noise on the next write.
+func TestWalletOmittedWhenUnset(t *testing.T) {
+	b, err := json.Marshal(&V1{})
+	require.NoError(t, err)
+	require.NotContains(t, string(b), `"wallet"`)
+}

--- a/pkg/visor/visorconfig/walletconfig_wasm.go
+++ b/pkg/visor/visorconfig/walletconfig_wasm.go
@@ -1,0 +1,10 @@
+//go:build wasm || (js && wasm)
+
+// Package visorconfig pkg/visor/visorconfig/walletconfig_wasm.go c3-app-wallet
+package visorconfig
+
+// walletCustodyDiskCapable: a browser build has no backend process and no
+// filesystem to hold wallet files, so disk custody cannot be realized here.
+// A config carrying custody:"disk" (written by a native visor) clamps to
+// browser rather than offering a mode that would fail at use time.
+const walletCustodyDiskCapable = false


### PR DESCRIPTION
Stage 1 of `docs/design/skycoin-web-wallet-architecture.md` (added here — it was the only record of that design session and was sitting untracked).

## One block, three realizations

The wallet frontend is **always a browser SPA**. How it's served and how the node API is reached vary by platform, and the operator should never have to think about either. The one axis they actually choose is **custody — where keys live**:

| custody | storage | available where | trust |
|---|---|---|---|
| **browser** (default) | localStorage (native / `hv serve`) or OPFS (wasm) | **everywhere** | host never sees keys |
| **disk** | real files at `wallet.dir` via `RunSkycoinWeb` | native visor, `hv serve` | host holds keys |
| **remote** | another visor's skycoin-web over dmsg | anywhere dmsg reaches | trust the remote |

## Capability gating is what makes one block work everywhere

`walletCustodyDiskCapable` is a build-tagged constant — true where there's a filesystem, false under wasm — and `WalletCustody()` clamps against it.

So a config written on a native visor with `custody:"disk"` still **loads** under wasm and degrades to browser, instead of failing the load or leaving the UI offering a mode that cannot work. `WalletCustodyOptions()` reports what to actually offer.

## Backwards compatibility

Accessors are nil-safe and **opt-OUT**: a config predating this block (`Wallet == nil`) serves the wallet with browser custody — exactly today's behavior. An unrecognized custody string falls back to browser rather than erroring; a typo shouldn't brick the wallet. A config with no wallet block doesn't grow one on marshal.

## `wallet.dir` is a seed store, not a per-coin dir

bip44 already serializes `coin_type` **per account**, so one seed file spans several chains. A wallet **is a seed**; "a coin" is an account inside it. Per-coin directories become a legacy import path. (This is why no wallet file-format change is needed for multicoin — see §5 of the design doc.)

## CLI

```
--wallet-custody browser|disk|remote
--wallet-dir     <path>
--wallet-remote  <visor-pk>
--no-wallet
```

A block is emitted only when something was asked for — an unconditional block would add noise to every generated config and freeze today's defaults into the file. Invalid input fails at gen time, not visor start. Same options added to `genvisor.Options` so the WASM generate flow uses this block rather than a second way to express it.

## Testing

- 8 new tests covering the nil-default contract, the opt-out switch, the **capability clamp** (asserted against the same constant production uses, so it stays meaningful under both builds), unknown-value fallback, and the `v1JSON` compat round-trip — that mirror is hand-kept in sync with `V1`, so a field added to one and not the other is silently dropped on every read/write cycle.
- Verified end-to-end against a built binary: disk → `{"serve":true,"custody":"disk","dir":...}`, `--no-wallet` → `{"serve":false}`, no flags → no wallet key, and both validation paths fail with the intended message.
- `go build ./...` + `GOOS=js GOARCH=wasm` clean; golangci-lint 0 issues.

## Not in this PR

`hv serve --wallet` and the GUI Storage section (still Stage 1), then Stages 2–3 (lifting skycoin-web's single-coin assumption; aligning `RunSkycoinWeb` on the seed-wallet dir).