### PR TITLE
feat(autoconfig): --no-restart flag for pty-safe updates

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -237,6 +237,7 @@ type resolvedConfig struct {
 	skywireUser string // owner for PKGENV paths; empty = no chown
 	configPath  string // resolved skywire.json path
 	useUserUnit bool   // true = `systemctl --user`, false = system unit
+	noRestart   bool   // --no-restart: apply config but skip the service restart (pty-safe)
 }
 
 // autoconfigCmd is constructed in init() via the autoconfigcmd factory
@@ -462,6 +463,7 @@ func defaultSkyenvPath() string {
 // the legacy PKGENV-on-root behavior when the file is silent.
 func resolveConfig() resolvedConfig {
 	r := resolvedConfig{}
+	r.noRestart = autoconfigVals.NoRestart
 	r.skyenvPath = os.Getenv("SKYENV")
 	if r.skyenvPath == "" {
 		candidate := defaultSkyenvPath()
@@ -653,6 +655,21 @@ func restartOrPrompt(r resolvedConfig) {
 	if runtime.GOOS == "windows" {
 		msg2(fmt.Sprintf("Start skywire on Windows with (admin PowerShell):\n\t%sskywire visor -c %q%s",
 			colorRed, r.configPath, colorReset))
+		return
+	}
+
+	// pty-safe path: the operator asked us NOT to restart. This is for
+	// updating over the visor's own dmsgpty, where a `systemctl restart
+	// skywire` would tear down the pty session (and this very process)
+	// mid-restart. Config is already written; the operator applies it
+	// out-of-band, decoupled from the session, as the LAST step.
+	if r.noRestart {
+		startCmd := "systemctl start --no-block skywire-autoconfig.service"
+		if r.useUserUnit {
+			startCmd = "systemctl --user start --no-block skywire-autoconfig.service"
+		}
+		msg2(fmt.Sprintf("Config applied WITHOUT restarting skywire (--no-restart).\n\tApply it as your LAST command (safe over dmsgpty):\n\t%s%s%s",
+			colorRed, startCmd, colorReset))
 		return
 	}
 

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -197,6 +197,18 @@ type Values struct {
 	LogLevel        string // LOGLVL
 	ShutdownTimeout string // SHUTDOWNTIMEOUT
 	RegTimeout      string // REGTIMEOUT
+
+	// --- Runtime behavior (NOT written to skywire.conf) ---
+	// NoRestart generates/writes the config but skips the
+	// systemctl restart of skywire.service at the end. This is the
+	// pty-safe update path: when the operator is connected over the
+	// visor's own dmsgpty, restarting skywire.service kills that pty
+	// session (and any in-flight apt/autoconfig process with it). With
+	// --no-restart the config is applied without the restart; the
+	// operator then triggers the restart out-of-band as the LAST step
+	// via `systemctl start --no-block skywire-autoconfig.service`,
+	// which runs decoupled from the session.
+	NoRestart bool
 }
 
 // New returns a freshly-constructed autoconfig cobra command with
@@ -322,12 +334,16 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().StringVar(&v.ShutdownTimeout, "timeout", "", "graceful shutdown timeout (e.g. 10s) — writes SHUTDOWNTIMEOUT in skywire.conf")
 	cmd.Flags().StringVar(&v.RegTimeout, "regtimeout", "", "public visor registration timeout (e.g. 10m) — writes REGTIMEOUT in skywire.conf")
 
+	// Runtime behavior — not written to skywire.conf.
+	cmd.Flags().BoolVar(&v.NoRestart, "no-restart", false, "apply config but do NOT restart skywire.service — pty-safe update path (then run: systemctl start --no-block skywire-autoconfig.service as the last step)")
+
 	return cmd
 }
 
 // EnvMap returns the flag → SKYENV-var mapping. Keys are CLI flag
 // long names (without leading "--"). Flags absent from the map
-// (currently only --verbose) have no .conf-file effect.
+// (--verbose and --no-restart) have no .conf-file effect — they only
+// affect this run's behavior, not the persisted configuration.
 //
 // A fresh map is returned each call so callers can mutate it
 // without affecting the package-level data.

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
@@ -39,6 +39,16 @@ var allFlags = []string{
 	"skycoinweb", "no-skycoinweb", "skycoinwebaddr", "skycoinwebnodes", "skycoinwebwallet", "skycoinwebuser",
 	// Visor runtime
 	"binpath", "loglvl", "timeout", "regtimeout",
+	// Runtime behavior (no .conf effect, like --verbose)
+	"no-restart",
+}
+
+// behaviorOnlyFlags have no skywire.conf effect — they change how a
+// single autoconfig invocation behaves, not the persisted config, so
+// they are exempt from the EnvMap coverage assertion below.
+var behaviorOnlyFlags = map[string]bool{
+	"verbose":    true,
+	"no-restart": true,
 }
 
 // negationPairs enumerates every positive/negation flag pair. The
@@ -134,16 +144,18 @@ func TestNew_BindingsTrackValues(t *testing.T) {
 func TestEnvMap_Coverage(t *testing.T) {
 	m := EnvMap()
 	for _, name := range allFlags {
-		if name == "verbose" {
+		if behaviorOnlyFlags[name] {
 			continue
 		}
 		if _, ok := m[name]; !ok {
 			t.Errorf("envMap missing entry for --%s", name)
 		}
 	}
-	// --verbose must NOT be in envMap (display-only flag).
-	if _, ok := m["verbose"]; ok {
-		t.Errorf("envMap should NOT have --verbose entry; that flag has no .conf effect")
+	// Behavior-only flags must NOT be in envMap (no .conf effect).
+	for name := range behaviorOnlyFlags {
+		if _, ok := m[name]; ok {
+			t.Errorf("envMap should NOT have --%s entry; that flag has no .conf effect", name)
+		}
 	}
 	// And every envMap key should be a registered flag.
 	cmd := New(&Values{})


### PR DESCRIPTION
## Problem

`skywire autoconfig` ends by restarting `skywire.service` (`restartOrPrompt`). When an operator updates **over the visor's own dmsgpty**, that restart tears down the pty session — and the in-flight `apt`/`autoconfig` process with it — leaving the reconfigure half-applied.

The install-command generator (deb.theskywirenetwork.net/generator) already has a "pty-safe" mode that dodges this for the **package install** (`systemctl start install-skywire.service`, decoupled from the session). But if the operator selects any config option, the generated command still runs `skywire autoconfig <flags>` directly afterward — which restarts the service and kills the pty mid-reconfigure.

## Fix

Add `--no-restart`: generate and write the config as usual, but **skip the service restart**. The config is fully applied; the operator triggers the restart out-of-band as the LAST step:

```
skywire autoconfig <flags> --no-restart
systemctl start --no-block skywire-autoconfig.service
```

`skywire-autoconfig.service` is a `Type=oneshot` running `skywire autoconfig`. Because it's a **separate unit owned by systemd**, restarting `skywire.service` from inside it doesn't kill it — it completes. `--no-block` makes the operator's `systemctl start` return immediately instead of blocking until the oneshot finishes (blocking is what got it SIGHUP'd when the pty died mid-restart before — the failure mode reported in practice).

## Details

- The flag lives in the **shared `autoconfigcmd` factory**, so it appears in both the CLI and the WASM install-command generator automatically.
- It is **behavior-only** — NOT written to `skywire.conf` (absent from `EnvMap`). Added to the test's `allFlags` canonical list and a new `behaviorOnlyFlags` exemption set (alongside `--verbose`) so the EnvMap-coverage invariant stays honest.
- `restartOrPrompt` prints the exact follow-up command when `--no-restart` is used.
- No change needed to `skywire-autoconfig.service` itself — it was already correct for out-of-band execution.

## Testing

`go build ./...` clean; `go test ./pkg/skywireconfig/autoconfigcmd/ ./cmd/skywire/commands/` green; golangci-lint 0 issues. Verified `--no-restart` appears in `skywire autoconfig --help`.

## Follow-up (not in this PR)

The generator (apt-repo `cmd/wasm`) needs its pty-safe path updated to emit the `--no-restart` + `systemctl start --no-block skywire-autoconfig.service` sequence. That regen is currently blocked by an unrelated system-tinygo stdlib build error (`net/http/roundtrip_js.go: t.roundTrip undefined`), tracked separately.