### PR TITLE
fix(geoip): OpenEmbedded must trigger the lazy decompress (v1.3.85 location regression)

### DIFF
--- a/pkg/geoip/geoip.go
+++ b/pkg/geoip/geoip.go
@@ -106,6 +106,13 @@ func Lookup(db *geoip2.Reader, ipStr string) (*Result, error) {
 
 // OpenEmbedded returns a *geoip2.Reader backed by the embedded database.
 // Reuse the reader — it's safe for concurrent use.
+//
+// It calls EmbeddedDB() (not the bare `embedded` var) so the lazy gzip
+// decompress is guaranteed to have run: since #3500 the DB is decompressed
+// only inside EmbeddedDB()'s sync.Once, and a caller that reached
+// OpenEmbedded() first would otherwise get OpenBytes(nil) → no database →
+// empty geoip results (the regression that dropped every visor's country
+// code from the node list on v1.3.85).
 func OpenEmbedded() (*geoip2.Reader, error) {
-	return geoip2.OpenBytes(embedded)
+	return geoip2.OpenBytes(EmbeddedDB())
 }

--- a/pkg/geoip/geoip_test.go
+++ b/pkg/geoip/geoip_test.go
@@ -2,10 +2,38 @@ package geoip
 
 import (
 	_ "embed"
+	"sync"
 	"testing"
 
 	"github.com/oschwald/geoip2-golang/v2"
 )
+
+// TestOpenEmbedded_FirstCall reproduces the #3500 regression: OpenEmbedded()
+// must work even when it is the FIRST geoip call, i.e. before anything has
+// called EmbeddedDB() to trigger the lazy gzip decompress. The pre-existing
+// TestOpenEmbedded passed only because TestEmbeddedDB ran earlier in the same
+// process and primed the sync.Once. Reset the package state so this test
+// exercises the cold path a fresh visor hits — where the bug dropped every
+// visor's country code from the node list.
+func TestOpenEmbedded_FirstCall(t *testing.T) {
+	// Reset the lazy-decompress state so OpenEmbedded is genuinely first.
+	embeddedOnce = sync.Once{}
+	embedded = nil
+
+	db, err := OpenEmbedded()
+	if err != nil {
+		t.Fatalf("OpenEmbedded as first call: %v", err)
+	}
+	defer db.Close() //nolint:errcheck,gosec
+
+	res, err := Lookup(db, "8.8.8.8")
+	if err != nil {
+		t.Fatalf("Lookup after cold OpenEmbedded: %v", err)
+	}
+	if res.CountryCode == "" {
+		t.Fatal("empty CountryCode — embedded DB was not decompressed before OpenEmbedded (the v1.3.85 node-list regression)")
+	}
+}
 
 // nonCityDB is a minimal GeoLite2-ASN database (a valid MaxMind DB that is
 // not a City database). Opening it succeeds, but Lookup's db.City() call


### PR DESCRIPTION
## Problem — a v1.3.85 regression

Every v1.3.85 visor lost its **country code** in the hypervisor node list (v1.3.84 visors still show it). Reported in the field.

#3500 gzipped the embedded GeoLite2-City DB and made it decompress **lazily** inside `EmbeddedDB()`'s `sync.Once`. But `OpenEmbedded()` kept reading the bare `embedded` package var — which, post-#3500, is populated **only as a side effect of `EmbeddedDB()`**:

```go
func OpenEmbedded() (*geoip2.Reader, error) {
	return geoip2.OpenBytes(embedded)   // nil unless EmbeddedDB() ran first
}
```

The visor's self-geoip lookup (`geoip.OpenEmbedded()` in `init_services.go`) is the first geoip call, so `embedded` is still `nil` → `OpenBytes(nil)` → no database → empty results → empty `CountryCode`. Pre-#3500 the DB was embedded raw (`//go:embed …mmdb` straight into `embedded`), always populated, so this worked.

## Fix

One line — route through `EmbeddedDB()` so the `sync.Once` decompress is guaranteed to have run:

```go
func OpenEmbedded() (*geoip2.Reader, error) {
	return geoip2.OpenBytes(EmbeddedDB())
}
```

## Why the existing test didn't catch it

`TestOpenEmbedded` passed only because `TestEmbeddedDB` runs earlier in the same process and primes the `Once`. Added **`TestOpenEmbedded_FirstCall`**, which resets `embeddedOnce`/`embedded` so `OpenEmbedded()` is genuinely the first call — the cold path a fresh visor hits. **Verified it fails on the old code and passes on the fix** (reverted `geoip.go` and re-ran).

## Testing

`go build ./...` clean; `go test ./pkg/geoip/` green; golangci-lint 0 issues.

Worth a v1.3.86 point release since it's a visible fleet-wide regression.