### PR TITLE
chore(vendor): bump skycoin to develop HEAD

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pterm/pterm v0.12.83
 	github.com/robert-nix/ansihtml v1.0.1
 	github.com/sirupsen/logrus v1.9.4
-	github.com/skycoin/skycoin v0.28.6-0.20260720010916-a8217688ad6b
+	github.com/skycoin/skycoin v0.28.6-0.20260720145225-2f8729e56cfb
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -806,8 +806,8 @@ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/skycoin/encodertest v0.0.0-20190217072920-14c2e31898b9 h1:DElGw1Fhj4amuW1KM5q8Xowosb3RiOQce0lDJw0Qv0Y=
 github.com/skycoin/encodertest v0.0.0-20190217072920-14c2e31898b9/go.mod h1:OQz8NXVJUWEw7PWYASZ/1BIw5GXgVMTGvrCGDlZa9+k=
-github.com/skycoin/skycoin v0.28.6-0.20260720010916-a8217688ad6b h1:NzB6W5l0PAH+OpGNas2dNGGYJGtx8ptsRXsmEWpitzs=
-github.com/skycoin/skycoin v0.28.6-0.20260720010916-a8217688ad6b/go.mod h1:JlSE9QCzUX0q9uoC4pCoGBHRs4ZfNH6aGocM7VMEkFI=
+github.com/skycoin/skycoin v0.28.6-0.20260720145225-2f8729e56cfb h1:YA4JkEtifTWcL8+uxL6Nk0s934OU/QC5xbZWUDONZXw=
+github.com/skycoin/skycoin v0.28.6-0.20260720145225-2f8729e56cfb/go.mod h1:JlSE9QCzUX0q9uoC4pCoGBHRs4ZfNH6aGocM7VMEkFI=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8 h1:TG/diQgUe0pntT/2D9tmUCz4VNwm9MfrtPr0SU2qSX8=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -938,7 +938,7 @@ github.com/shopspring/decimal
 ## explicit; go 1.17
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/skycoin v0.28.6-0.20260720010916-a8217688ad6b
+# github.com/skycoin/skycoin v0.28.6-0.20260720145225-2f8729e56cfb
 ## explicit; go 1.26.1
 github.com/skycoin/skycoin/cmd/explorer/commands
 github.com/skycoin/skycoin/cmd/newcoin/commands


### PR DESCRIPTION
Refresh vendored `github.com/skycoin/skycoin` from 26b081dd (Jul 18) to develop HEAD `2f8729e56cfb`. Routine dependency sync; `go build ./...` clean.