### PR TITLE
fix(visorconfig): IsRoot nil-deref panics static (musl) builds in init() — v1.3.86 regression

### DIFF
--- a/pkg/visor/visorconfig/values_darwin.go
+++ b/pkg/visor/visorconfig/values_darwin.go
@@ -67,10 +67,17 @@ func SystemSurvey() (Survey, error) {
 	return s, nil
 }
 
-// IsRoot checks for root permissions
+// IsRoot checks for root permissions. Resolves euid first (0 == root, no passwd
+// lookup) so a nil user.Current() on a build without a resolvable passwd entry
+// can't nil-deref (see the values_linux.go note).
 func IsRoot() bool {
-	userLvl, _ := user.Current() //nolint:errcheck
-	return userLvl.Username == "root"
+	if os.Geteuid() == 0 {
+		return true
+	}
+	if u, err := user.Current(); err == nil && u != nil {
+		return u.Username == "root"
+	}
+	return false
 }
 
 type customSysinfo struct {

--- a/pkg/visor/visorconfig/values_linux.go
+++ b/pkg/visor/visorconfig/values_linux.go
@@ -5,6 +5,7 @@
 package visorconfig
 
 import (
+	"os"
 	"os/user"
 	"runtime"
 	"strings"
@@ -80,8 +81,22 @@ func SystemSurvey() (Survey, error) {
 	return s, nil
 }
 
-// IsRoot checks for root permissions
+// IsRoot checks for root permissions.
+//
+// It resolves the effective UID FIRST (0 == root), which never needs a passwd
+// lookup. On a static (musl) build running under a UID with no /etc/passwd
+// entry, user.Current() returns (nil, err); the previous code ignored the error
+// and dereferenced the nil user, panicking in this package's init() — which
+// crashed EVERY skywire command on such hosts (seen on the prod hv-serve unit,
+// crash-looping v1.3.86). Geteuid is both safer and the canonical root test.
 func IsRoot() bool {
-	userLvl, _ := user.Current() //nolint:errcheck
-	return userLvl.Username == "root"
+	if os.Geteuid() == 0 {
+		return true
+	}
+	// Non-zero euid: still honor a username match for the rare setup where
+	// "root" is a non-zero uid, but guard the nil user.
+	if u, err := user.Current(); err == nil && u != nil {
+		return u.Username == "root"
+	}
+	return false
 }


### PR DESCRIPTION
## Critical — crashes every command on affected hosts

`IsRoot()` ignored `user.Current()`'s error and dereferenced the result:

```go
userLvl, _ := user.Current() //nolint:errcheck
return userLvl.Username == "root"
```

On a **static (musl) build** — the release binary format — `user.Current()` returns `(nil, err)` whenever the running UID has no resolvable `/etc/passwd` entry (musl NSS + no passwd row). The nil user is then dereferenced → **SIGSEGV**. And because `IsRoot()` runs from `pkg/visor`'s `init()`, this panics **every `skywire` command** on such a host, before it even runs.

**Observed in production:** the prod02 `hv serve` systemd unit crash-looped on v1.3.86 (restart counter **1016**), taking down **https://theskywirenetwork.net** (Caddy → 502).

## Fix

Resolve the effective UID first (`os.Geteuid() == 0`) — never needs a passwd lookup, and is the canonical root test — then fall back to a nil-guarded username check for the rare non-zero-uid `root`. Applied to both the **linux** and **darwin** variants.

## Testing

`CGO_ENABLED=0` build of `IsRoot()` runs clean (returns without panic) even with `USER`/`LOGNAME`/`HOME` scrambled. `go build ./pkg/visor/...` + `GOOS=darwin` clean.

**Warrants an immediate v1.3.87** — any static-musl install running under a non-resolvable user is currently crash-looping.