### PR TITLE
fix(rewards): JSON endpoints read the SKY amount, not bandwidth bytes

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -1624,15 +1624,24 @@ func buildRouter() *gin.Engine {
 				Share  float64 `json:"share"`
 				Amount float64 `json:"amount"`
 			}
+			// Bandwidth-mode shares.csv has 11 columns where col4 is
+			// "Bandwidth (bytes)" and col5 is "Total Reward SKY"; legacy-mode has
+			// 10 columns with the SKY amount in col4. Detect from the header so
+			// this doesn't return the byte count as the SKY amount (which showed
+			// comically-high rewards in the hypervisor UI). Mirrors the HTML page.
+			skyCol := 4
+			if len(lines) > 0 && strings.Contains(lines[0], "Bandwidth (bytes)") {
+				skyCol = 5
+			}
 			var results []visorReward
 			for i, line := range lines {
 				if i == 0 {
 					continue // skip header
 				}
-				pkStr, _ := script.Echo(line).Column(2).String()    //nolint:errcheck,gosec
-				shareStr, _ := script.Echo(line).Column(3).String() //nolint:errcheck,gosec
-				skyStr, _ := script.Echo(line).Column(4).String()   //nolint:errcheck,gosec
-				pkStr = strings.TrimSpace(pkStr)
+				pkStr, _ := script.Echo(line).Column(2).String()       //nolint:errcheck,gosec
+				shareStr, _ := script.Echo(line).Column(3).String()    //nolint:errcheck,gosec
+				skyStr, _ := script.Echo(line).Column(skyCol).String() //nolint:errcheck,gosec
+				pkStr = strings.TrimRight(strings.TrimSpace(pkStr), ",")
 				share, _ := strconv.ParseFloat(strings.TrimRight(strings.TrimSpace(shareStr), ","), 64) //nolint:errcheck
 				sky, _ := strconv.ParseFloat(strings.TrimRight(strings.TrimSpace(skyStr), ","), 64)     //nolint:errcheck
 				if pkStr != "" {
@@ -1680,6 +1689,12 @@ func buildRouter() *gin.Engine {
 					txid = strings.TrimSpace(txidBytes)
 					sent = txid != ""
 				}
+				// Bandwidth-mode shares.csv: col4 is bandwidth bytes, col5 the SKY
+				// amount. Detect from the header (see the /hist/:date/json endpoint).
+				skyCol := 4
+				if len(lines) > 0 && strings.Contains(lines[0], "Bandwidth (bytes)") {
+					skyCol = 5
+				}
 				found := false
 				for j, line := range lines {
 					if j == 0 {
@@ -1689,7 +1704,7 @@ func buildRouter() *gin.Engine {
 					pkStr = strings.TrimRight(strings.TrimSpace(pkStr), ",")
 					if pkStr == pk {
 						shareStr, _ := script.Echo(line).Column(3).String()                                     //nolint:errcheck,gosec
-						skyStr, _ := script.Echo(line).Column(4).String()                                       //nolint:errcheck,gosec
+						skyStr, _ := script.Echo(line).Column(skyCol).String()                                  //nolint:errcheck,gosec
 						share, _ := strconv.ParseFloat(strings.TrimRight(strings.TrimSpace(shareStr), ","), 64) //nolint:errcheck
 						sky, _ := strconv.ParseFloat(strings.TrimRight(strings.TrimSpace(skyStr), ","), 64)     //nolint:errcheck
 						history = append(history, dayReward{Date: date, Amount: sky, Share: share, Sent: sent, Txid: txid})


### PR DESCRIPTION
## Symptom

The hypervisor UI reward pages (`/#/nodes/rewards/1`, `/#/nodes/<pk>/rewards`) showed **comically-high rewards** — e.g. **1,084,504 "SKY"** for a visor whose actual reward was **13.347602 SKY**. Cross-referenced against `haltingstate.net` (the HTML page), which showed the correct 13.347602.

## Root cause

The reward system's two JSON endpoints — `/skycoin-rewards/hist/:date/json` and `/skycoin-rewards/visor/:pk` (the latter is what the HV UI reads via the reward proxy) — **hardcoded `Column(4)`** as the SKY amount.

But a **bandwidth-mode** `shares.csv` has 11 columns where **col4 = "Bandwidth (bytes)"** and **col5 = "Total Reward SKY"** (legacy mode has 10 cols with SKY in col4). The HTML hist page already detects this from the header row and reads the right column — the JSON endpoints did **not**. So in bandwidth mode they returned each visor's **bandwidth byte count** as the reward "amount" (1084504 ≈ 1 MB). The ratio to the true SKY varied per visor (78K–9.4M×) precisely because it was per-visor bandwidth, not a fixed units error.

## Fix

Detect bandwidth mode from the header (`"Bandwidth (bytes)"`) and read `col5` in that case, exactly mirroring the HTML page — so the hypervisor UI now matches `haltingstate.net`. Also trims a stray trailing comma on the PK in the `hist/:date/json` result.

`go build` + `go vet` clean. (The HV UI code itself is correct — it faithfully displays what the reward API returns; the bug was the API returning the wrong column.)

## Deploy note

Reaches the live HV UI once v1.3.87 deploys and the reward server (`fiberreward`) on prod02 is restarted.