### PR TITLE
feat(vpn-router): enableable via config-gen + autoconfig + skywire.conf

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -139,6 +139,14 @@ const envfileLinux = `#
 #--	Autostart vpn server for this visor
 #VPNSERVER=false
 
+#--	Autostart the vpn-router: a LAN/WiFi gateway that NATs downstream
+#	clients into the vpn-client tunnel. Needs VPNROUTERLANIFC (the
+#	downstream interface). Requires root + the vpn-client running.
+#VPNROUTER=false
+
+#--	Downstream LAN/WiFi interface the vpn-router serves (e.g. eth1 or wlan0)
+#VPNROUTERLANIFC='eth1'
+
 #--	Set server public key for proxy client to connect to
 #PROXYCLIENTPK=''
 

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -275,6 +275,8 @@ func init() {
 	genConfigCmd.Flags().StringVar(&binPath, "binpath", scriptExecString("${BINPATH}"), "set bin_path for visor native apps")
 	gHiddenFlags = append(gHiddenFlags, "binpath")
 	genConfigCmd.Flags().BoolVarP(&isVpnServerEnable, "servevpn", "v", scriptExecBool("${VPNSERVER:-true}"), "autostart vpn server")
+	genConfigCmd.Flags().BoolVar(&isVpnRouterEnable, "servevpnrouter", scriptExecBool("${VPNROUTER:-false}"), "autostart the vpn router (LAN/WiFi gateway that NATs into the vpn-client tunnel; needs --vpnrouter-lan-ifc)")
+	genConfigCmd.Flags().StringVar(&vpnRouterLanIfc, "vpnrouter-lan-ifc", scriptExecString("${VPNROUTERLANIFC}"), "downstream LAN/WiFi interface the vpn router serves (e.g. eth1 or wlan0)")
 	gHiddenFlags = append(gHiddenFlags, "servevpn")
 
 	// VPN flags
@@ -1758,6 +1760,16 @@ func configureApps(log *logging.Logger) {
 				Args:      []string{"app", "vpn-server"},
 			},
 			{
+				// Local LAN/WiFi gateway that NATs downstream clients into the
+				// vpn-client tunnel. Off by default; enabled via --servevpnrouter
+				// (VPNROUTER) and needs a downstream interface (--vpnrouter-lan-ifc).
+				Name:      skyenv.VPNRouterName,
+				Binary:    "skywire",
+				AutoStart: isVpnRouterEnable,
+				Port:      routing.Port(skyenv.VPNRouterPort),
+				Args:      []string{"app", "vpn-router", "--lan-ifc", vpnRouterLanIfc},
+			},
+			{
 				Name:      skyenv.SkydexMarketName,
 				Binary:    "skywire",
 				AutoStart: false,
@@ -1846,6 +1858,15 @@ func configureApps(log *logging.Logger) {
 				AutoStart: isVpnServerEnable,
 				Args:      []string{},
 				Port:      routing.Port(skyenv.VPNServerPort),
+			},
+			{
+				// Local LAN/WiFi gateway that NATs downstream clients into the
+				// vpn-client tunnel. Off by default; enabled via --servevpnrouter
+				// (VPNROUTER) with a downstream interface (--vpnrouter-lan-ifc).
+				Name:      skyenv.VPNRouterName,
+				AutoStart: isVpnRouterEnable,
+				Args:      []string{"--lan-ifc", vpnRouterLanIfc},
+				Port:      routing.Port(skyenv.VPNRouterPort),
 			},
 			{
 				Name:      skyenv.SkydexMarketName,

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -47,6 +47,8 @@ var (
 	isDmsgHTTP                 bool
 	minDmsgSess                int
 	isVpnServerEnable          bool
+	isVpnRouterEnable          bool
+	vpnRouterLanIfc            string
 	isDisableAuth              bool
 	isEnableAuth               bool
 	isEnablePKEndpoint         bool

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -177,6 +177,8 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 
 	// VPN server
 	addBool("VPNSERVER", "vpnserver", "no-vpnserver", autoconfigVals.VpnServer, autoconfigVals.NoVpnServer)
+	addSoloBool("VPNROUTER", "vpnrouter", autoconfigVals.VpnRouter)
+	addString("VPNROUTERLANIFC", "vpnrouter-lan-ifc", autoconfigVals.VpnRouterLanIfc)
 	addString("VPNKS", "killsw", autoconfigVals.VpnKillSw)
 	addString("ADDVPNPK", "addvpn", autoconfigVals.AddVpn)
 	addArray("VPNSERVERWL", "vpnwl", autoconfigVals.VpnWl)

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -210,6 +210,11 @@ const (
 	// downstream LAN/WiFi clients and NATs them into the tunnel vpn-client owns.
 	VPNRouterName = "vpn-router"
 
+	// VPNRouterPort is a nominal launcher port for the vpn-router app. The app
+	// serves no dmsg endpoint (it's a local gateway), but every launcher
+	// AppConfig carries a port; this keeps it unique from the others.
+	VPNRouterPort uint16 = 62
+
 	// ExampleServerName is the name of the example server app
 	ExampleServerName = "example-server-app"
 

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -141,13 +141,15 @@ type Values struct {
 	CalculateRoutes bool // CALCULATEROUTES
 
 	// --- VPN server feature ---
-	VpnServer   bool
-	NoVpnServer bool
-	VpnKillSw   string // VPNKS
-	AddVpn      string // ADDVPNPK
-	VpnWl       string // VPNSERVERWL (comma-separated)
-	VpnSecure   string // VPNSEVERSECURE (sic — typo retained for compat with config gen's env-var name)
-	VpnNetIfc   string // VPNSEVERNETIFC (sic — same)
+	VpnServer       bool
+	NoVpnServer     bool
+	VpnRouter       bool   // VPNROUTER
+	VpnRouterLanIfc string // VPNROUTERLANIFC
+	VpnKillSw       string // VPNKS
+	AddVpn          string // ADDVPNPK
+	VpnWl           string // VPNSERVERWL (comma-separated)
+	VpnSecure       string // VPNSEVERSECURE (sic — typo retained for compat with config gen's env-var name)
+	VpnNetIfc       string // VPNSEVERNETIFC (sic — same)
 
 	// --- Proxy feature ---
 	ProxyServer   bool
@@ -279,6 +281,8 @@ func New(v *Values) *cobra.Command {
 	// --- VPN server ---
 	cmd.Flags().BoolVar(&v.VpnServer, "vpnserver", false, "autostart vpn-server — writes VPNSERVER=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoVpnServer, "no-vpnserver", false, "do not autostart vpn-server — writes VPNSERVER=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.VpnRouter, "vpnrouter", false, "autostart the vpn-router LAN/WiFi gateway — writes VPNROUTER=true in skywire.conf")
+	cmd.Flags().StringVar(&v.VpnRouterLanIfc, "vpnrouter-lan-ifc", "", "downstream LAN/WiFi interface the vpn-router serves — writes VPNROUTERLANIFC in skywire.conf")
 	cmd.Flags().StringVar(&v.VpnKillSw, "killsw", "", "vpn client killswitch — writes VPNKS in skywire.conf")
 	cmd.Flags().StringVar(&v.AddVpn, "addvpn", "", "vpn server public key for vpn client — writes ADDVPNPK in skywire.conf")
 	cmd.Flags().StringVar(&v.VpnWl, "vpnwl", "", "vpn server whitelist PKs, comma-separated (empty = allow all) — writes VPNSERVERWL in skywire.conf")
@@ -406,13 +410,15 @@ var envMap = map[string]EnvMapping{
 	"calculate-routes": {Key: "CALCULATEROUTES", Format: EnvFormatBool},
 
 	// VPN server
-	"vpnserver":    {Key: "VPNSERVER", Format: EnvFormatBool},
-	"no-vpnserver": {Key: "VPNSERVER", Format: EnvFormatBool, Negate: true},
-	"killsw":       {Key: "VPNKS", Format: EnvFormatString},
-	"addvpn":       {Key: "ADDVPNPK", Format: EnvFormatString},
-	"vpnwl":        {Key: "VPNSERVERWL", Format: EnvFormatBashArray},
-	"secure":       {Key: "VPNSEVERSECURE", Format: EnvFormatString},
-	"netifc":       {Key: "VPNSEVERNETIFC", Format: EnvFormatString},
+	"vpnserver":         {Key: "VPNSERVER", Format: EnvFormatBool},
+	"no-vpnserver":      {Key: "VPNSERVER", Format: EnvFormatBool, Negate: true},
+	"vpnrouter":         {Key: "VPNROUTER", Format: EnvFormatBool},
+	"vpnrouter-lan-ifc": {Key: "VPNROUTERLANIFC", Format: EnvFormatString},
+	"killsw":            {Key: "VPNKS", Format: EnvFormatString},
+	"addvpn":            {Key: "ADDVPNPK", Format: EnvFormatString},
+	"vpnwl":             {Key: "VPNSERVERWL", Format: EnvFormatBashArray},
+	"secure":            {Key: "VPNSEVERSECURE", Format: EnvFormatString},
+	"netifc":            {Key: "VPNSEVERNETIFC", Format: EnvFormatString},
 
 	// Proxy
 	"proxyserver":      {Key: "PROXYSERVER", Format: EnvFormatBool},

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
@@ -24,7 +24,7 @@ var allFlags = []string{
 	// Route calculation
 	"calculate-routes",
 	// VPN server
-	"vpnserver", "no-vpnserver", "killsw", "addvpn", "vpnwl", "secure", "netifc",
+	"vpnserver", "no-vpnserver", "vpnrouter", "vpnrouter-lan-ifc", "killsw", "addvpn", "vpnwl", "secure", "netifc",
 	// Proxy
 	"proxyserver", "no-proxyserver", "proxyclientpk", "startproxyclient", "proxywl",
 	// SOCKS5 web bridges


### PR DESCRIPTION
## Problem

The `vpn-router` app is built into the binary and registered as a launcher AppFunc, but had **no config surface**: it wasn't in the generated app list (so it never showed in the hypervisor Apps tab), and there was no `config-gen`/`autoconfig`/`.conf` knob to enable it — you could only run `skywire vpn-router …` by hand. Same class of gap as the recent config-template audit.

## Fix

Wire it up mirroring **vpn-server** (its structural twin — both `RegisterApp` + `RootCmd` + `RunX`):

- **`config gen`**: `--servevpnrouter` (`${VPNROUTER:-false}`) + `--vpnrouter-lan-ifc` (`${VPNROUTERLANIFC}`). `vpn-router` now appears in **both** app-list templates — present but `AutoStart=false` by default (so it's visible in the Apps tab), and autostarts with `--lan-ifc` when enabled.
- **autoconfig factory**: `--vpnrouter` / `--vpnrouter-lan-ifc` flags + EnvMap (`VPNROUTER` bool, `VPNROUTERLANIFC` string) + the `collectSkyenvEdits` mapping — so the install-command generator and `skywire autoconfig` can set them.
- **`skywire.conf` template**: documented `VPNROUTER` + `VPNROUTERLANIFC` in the Apps section.
- **`skyenv.VPNRouterPort`**: a nominal launcher port (the app serves no dmsg endpoint, but every `AppConfig` carries a unique port).

## Verified

- `config gen -n --servevpnrouter --vpnrouter-lan-ifc eth1` → vpn-router app entry with `args: --lan-ifc eth1`, `auto_start: true`.
- default `config gen` → vpn-router present, `auto_start: false`.
- `config gen -q` → shows `VPNROUTER` + `VPNROUTERLANIFC`.
- `go build`/`go vet` clean; `autoconfigcmd` tests pass.

End-to-end launch (does the app bring up hostapd/dnsmasq/NAT correctly when started from config) is best verified on an SBC with a spare interface — the config plumbing is what this PR delivers.