### PR TITLE
fix(dmsgpty): auto-establish a direct transport before the skynet pty dial

### DIFF
--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -584,7 +584,7 @@ func (v *Visor) DmsgPtyExec(args DmsgPtyExecArgs) (*pty.CommandExecResult, error
 		}
 		return v.dmsgPty.ExecRemoteVia(ctx, pty.NewDmsgDialer(v.dmsgC), args.RemotePK, args.RemotePort, &req)
 	case "skynet":
-		return v.dmsgPty.ExecRemoteVia(ctx, skywireDialer{}, args.RemotePK, args.RemotePort, &req)
+		return v.dmsgPty.ExecRemoteVia(ctx, skywireDialer{ensureTransport: v.ensureFastTransport}, args.RemotePK, args.RemotePort, &req)
 	default:
 		return nil, fmt.Errorf("dmsgpty: unknown scheme %q (want \"\", \"dmsg\", or \"skynet\")", args.Scheme)
 	}

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -862,7 +862,7 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 	// the chain here rather than at NewHost preserves backward
 	// compat for every other NewHost caller (cmd/dmsg/pty-host,
 	// sshd CLI, tests).
-	host := pty.NewHostWithDialer(dmsgC, wl, buildDmsgptyDialer(dmsgC))
+	host := pty.NewHostWithDialer(dmsgC, wl, buildDmsgptyDialer(dmsgC, v.ensureFastTransport))
 	// Opt-in persistent pty sessions: an interactive shell survives a dropped
 	// stream and a reconnecting client (the web terminal / `cli pty`) reattaches
 	// by id. Default TTL (0 → host default). The GC sweeper is started in the

--- a/pkg/visor/init_dmsg_skywire.go
+++ b/pkg/visor/init_dmsg_skywire.go
@@ -42,13 +42,34 @@ import (
 // adapter just returns a "no skywire networker" error in the
 // pre-init window and the MultiDialer falls through to dmsg —
 // matching the behavior we'd want anyway.
-type skywireDialer struct{}
+//
+// ensureTransport, when set, is called before the skynet dial to
+// auto-establish a fast (stcpr→sudph) direct transport to the peer
+// if none exists — so skynet has a real route to dial over instead
+// of failing and dropping the caller to the raw-dmsg relay fallback.
+// This is the crux of pty/scp/fs stability: a co-located peer gets a
+// direct stcpr transport (zero dmsg-server relay), matching what an
+// operator would otherwise do by hand with `tp add --type stcpr`. It
+// is best-effort: a failure (peer not directly reachable, or a
+// standalone dmsgpty-host that isn't a visor and can't peer a
+// transport) is non-fatal — the skynet dial then fails on "no route"
+// and the MultiDialer falls through to dmsg as before.
+type skywireDialer struct {
+	ensureTransport func(cipher.PubKey) error
+}
 
 // DialStream resolves the skynet networker on every call and dials
 // pk:port over it. Failure surfaces a wrapped error so the
 // MultiDialer's joined-error output identifies skynet as the
 // strategy that failed.
-func (skywireDialer) DialStream(ctx context.Context, pk cipher.PubKey, port uint16) (net.Conn, error) {
+func (d skywireDialer) DialStream(ctx context.Context, pk cipher.PubKey, port uint16) (net.Conn, error) {
+	// Best-effort: ensure a direct transport exists so skynet can
+	// route over it. Errors are intentionally swallowed — see the
+	// type doc; the dial below (and the MultiDialer's dmsg fallback)
+	// still runs.
+	if d.ensureTransport != nil {
+		_ = d.ensureTransport(pk) //nolint:errcheck // best-effort; skynet dial + dmsg fallback handle the miss
+	}
 	n, err := appnet.ResolveNetworker(appnet.TypeSkynet)
 	if err != nil {
 		return nil, fmt.Errorf("skywire: networker unavailable: %w", err)
@@ -171,9 +192,14 @@ func startSkywirePtyListener(ctx context.Context, pty *pty.Host, localPK cipher.
 //
 // Future strategies (stcpr, sudpr, direct-TCP) prepend or splice in
 // here without revisiting any other call site.
-func buildDmsgptyDialer(dmsgC *dmsg.Client) pty.StreamDialer {
+//
+// ensureTransport is the visor's ensureFastTransport (or nil in
+// contexts without a transport manager, e.g. tests): threaded into
+// the skynet strategy so it auto-establishes a direct transport
+// before dialing.
+func buildDmsgptyDialer(dmsgC *dmsg.Client, ensureTransport func(cipher.PubKey) error) pty.StreamDialer {
 	return pty.MultiDialer{
-		skywireDialer{},
+		skywireDialer{ensureTransport: ensureTransport},
 		pty.NewDmsgDialer(dmsgC),
 	}
 }

--- a/pkg/visor/init_dmsg_skywire_test.go
+++ b/pkg/visor/init_dmsg_skywire_test.go
@@ -73,7 +73,7 @@ func TestBuildDmsgptyDialer_SkywireFirstDmsgFallback(t *testing.T) {
 	// fallback. Swapping the order would silently regress to
 	// dmsg-only behavior for every call where skywire would
 	// succeed.
-	chain, ok := buildDmsgptyDialer(nil).(pty.MultiDialer)
+	chain, ok := buildDmsgptyDialer(nil, nil).(pty.MultiDialer)
 	if !ok {
 		t.Fatalf("buildDmsgptyDialer: got %T, want pty.MultiDialer", chain)
 	}


### PR DESCRIPTION
The visor's dmsgpty `MultiDialer` tries skynet first, then falls back to a **raw dmsg client connection** (`NewDmsgDialer`) relayed through a dmsg server. The skynet strategy only *used* an existing route — it never created one — so with no transport to the peer it failed and dropped every `pty`/`scp` call onto the fragile, relay-bound dmsg path. Under dmsg-server load that path is exactly where `cli pty exec` hangs.

## Fix
Give `skywireDialer` an `ensureTransport` hook wired to the visor's existing `ensureFastTransport` (stcpr→sudph). Before the skynet dial it now auto-establishes a direct transport when none exists, so skynet has a real route — a direct **stcpr** to a co-located peer means **zero dmsg-server relay**, matching what an operator would otherwise do by hand with `tp add --type stcpr`.

Best-effort: a peer that isn't directly reachable (or a standalone `dmsgpty-host` that isn't a visor and can't peer a transport) just falls through to the dmsg strategy as before, so no path regresses. The chain order contract (skywire-first, dmsg-fallback) and its test are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)