### PR TITLE
feat(vpnrouter): standalone run mode + LAN-through-tunnel policy routing

### DIFF
--- a/cmd/apps/vpn-router/commands/vpn-router.go
+++ b/cmd/apps/vpn-router/commands/vpn-router.go
@@ -6,12 +6,16 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/skycoin/skywire/pkg/app"
+	"github.com/skycoin/skywire/pkg/app/appcommon"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/buildinfo"
@@ -99,6 +103,18 @@ func RunVPNRouter(ctx context.Context, args []string) error {
 		}
 	}
 
+	// Standalone mode: when the app is not launched by a visor (no
+	// PROC_CONFIG in the environment), run the router as a plain daemon
+	// rather than fatally requiring the visor's app-server. The router's
+	// job — serve DHCP/DNS on the downstream interface and NAT into a tun
+	// the vpn-client (or any tunnel) provides — needs no visor coupling,
+	// so this is a first-class way to run it: on a host OS, for testing,
+	// or wherever the mesh tunnel is managed separately. app-server status
+	// reporting is simply skipped (there's nothing to report to).
+	if _, launched := os.LookupEnv(appcommon.EnvProcConfig); !launched {
+		return runStandalone(ctx)
+	}
+
 	appCl := app.NewClient(nil)
 	defer appCl.Close()
 	logger := appCl.Log()
@@ -135,6 +151,29 @@ func RunVPNRouter(ctx context.Context, args []string) error {
 		return err
 	}
 	return nil
+}
+
+// runStandalone runs the router without any visor app-server coupling: build
+// config from flags, construct the Router, and Run until a signal (or ctx)
+// cancels. Used when the binary is invoked directly (no PROC_CONFIG), e.g. for
+// on-host operation or hardware testing.
+func runStandalone(ctx context.Context) error {
+	logger := logrus.New()
+	logger.SetOutput(os.Stderr)
+
+	cfg, err := buildRouterConfig()
+	if err != nil {
+		return fmt.Errorf("invalid vpn-router configuration: %w", err)
+	}
+	router, err := vpn.NewRouter(cfg, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create vpn-router: %w", err)
+	}
+
+	sigCtx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	logger.Info("vpn-router running standalone (no visor app-server; status reporting disabled)")
+	return router.Run(sigCtx)
 }
 
 // buildRouterConfig turns the parsed flags into a vpn.RouterConfig.

--- a/pkg/vpn/router_linux.go
+++ b/pkg/vpn/router_linux.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,7 +36,14 @@ type Router struct {
 	prevForwarding string
 	masquerading   bool
 	forwardRules   [][]string // iptables argv sets we added to the FORWARD chain
+	policyRouting  bool       // true once the LAN→tun policy route+rule are installed
 }
+
+// lanPolicyTable is the dedicated routing table the router uses to send
+// downstream-LAN traffic through the tunnel. A high, fixed id keeps it clear of
+// the main/local/default tables and of typical per-link tables; the router owns
+// it exclusively and flushes it on teardown.
+const lanPolicyTable = 142
 
 // NewRouter validates cfg and returns a Router ready to Run. It does not touch
 // any system state.
@@ -230,11 +238,56 @@ func (r *Router) setupNAT() error {
 		r.forwardRules = append(r.forwardRules, rule)
 	}
 	r.log.Infof("NAT: %s → %s (masquerade)", r.cfg.LANInterface, r.tunIfc)
+
+	if err := r.setupPolicyRouting(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// setupPolicyRouting sends downstream-LAN traffic through the tunnel without
+// touching the router's own default route.
+//
+// This is the difference between a VPN *client* and a VPN *router*: a client
+// can point the whole host's default route at the tun, but a router MUST keep
+// its own uplink — the mesh transport carrying the tunnel to the vpn-server
+// rides that uplink, so redirecting the host default through the tun would cut
+// the tunnel's own carrier. Instead we install a dedicated table with a
+// default route out the tun and an `ip rule` matching only the LAN subnet as
+// source, so forwarded client packets egress via the VPN while everything the
+// router originates (dmsg/skywire included) keeps the main table.
+func (r *Router) setupPolicyRouting() error {
+	table := strconv.Itoa(lanPolicyTable)
+	subnet := r.cfg.Subnet.String()
+
+	// default route via the tun device in our private table.
+	if err := osutil.RunElevated("ip", "route", "replace", "default", "dev", r.tunIfc, "table", table); err != nil {
+		return fmt.Errorf("policy route (default dev %s table %s): %w", r.tunIfc, table, err)
+	}
+	// match LAN-sourced traffic into that table. Delete any stale copy first so
+	// a restart doesn't stack duplicate rules.
+	_ = osutil.RunElevated("ip", "rule", "del", "from", subnet, "lookup", table) //nolint:errcheck // best-effort cleanup of a stale rule
+	if err := osutil.RunElevated("ip", "rule", "add", "from", subnet, "lookup", table); err != nil {
+		return fmt.Errorf("policy rule (from %s lookup %s): %w", subnet, table, err)
+	}
+	r.policyRouting = true
+	r.log.Infof("policy routing: %s → %s (table %s); router uplink unchanged", subnet, r.tunIfc, table)
 	return nil
 }
 
 // teardown reverses setup, best-effort (logs but does not abort on errors).
 func (r *Router) teardown() {
+	// Remove the LAN→tun policy route+rule.
+	if r.policyRouting {
+		table := strconv.Itoa(lanPolicyTable)
+		subnet := r.cfg.Subnet.String()
+		if err := osutil.RunElevated("ip", "rule", "del", "from", subnet, "lookup", table); err != nil {
+			r.log.WithError(err).Warn("teardown: remove policy rule")
+		}
+		if err := osutil.RunElevated("ip", "route", "flush", "table", table); err != nil {
+			r.log.WithError(err).Warn("teardown: flush policy table")
+		}
+	}
 	// Remove the FORWARD rules we added (-D mirrors each -A).
 	for _, rule := range r.forwardRules {
 		del := append([]string{"-D"}, rule[1:]...)

--- a/pkg/vpn/router_linux.go
+++ b/pkg/vpn/router_linux.go
@@ -108,7 +108,7 @@ func (r *Router) setup(ctx context.Context) error {
 
 	// 3. DHCP + DNS for the downstream subnet — an embedded, pure-Go engine
 	// (vendored router7 dhcp4d + dns), replacing the external dnsmasq the app
-	// used to shell out to. StartLAN blocks until ctx is cancelled, so run it
+	// used to shell out to. StartLAN blocks until ctx is canceled, so run it
 	// in the background; a startup error surfaces via the log.
 	go func() {
 		if err := vpnrouter.StartLAN(ctx, r.cfg.LANInterface, r.confDir); err != nil && ctx.Err() == nil {


### PR DESCRIPTION
Two gaps surfaced while validating the vpn-router on real hardware (Orange Pi Prime).

## 1. Standalone run mode
`RunVPNRouter` called `app.NewClient`, which `log.Fatal`s when `PROC_CONFIG` is absent — so `skywire app vpn-router` could only run when launched by a visor, never as a plain daemon. When `PROC_CONFIG` is not set we now run the `Router` directly (logrus + signal-cancelled ctx) and skip app-server status reporting. The router needs no visor coupling to serve DHCP/DNS and NAT into a tun, so this is a first-class way to run it — on a host OS, for testing, or with the tunnel managed separately.

## 2. LAN-through-tunnel policy routing
`setupNAT` masqueraded onto the tun but never *routed* LAN traffic there — it relied on the host default route being the tun. That is wrong for a **router**: the board’s own uplink must stay put, because the mesh transport carrying the tunnel to the vpn-server rides it — redirecting the host default through the tun would cut the tunnel’s own carrier (a circular dependency).

Instead we install a dedicated routing table (142) with a default route via the tun and an `ip rule` matching only the LAN subnet as source. Forwarded client packets egress via the VPN while everything the router itself originates (dmsg/skywire included) keeps the main table. Reversed on teardown.

Validated on hardware: DHCP lease obtained by a downstream client, and `ip route get <dst> from <lan-ip> iif <lan>` resolves via the tun table while the board default stays on its uplink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)