### PR TITLE
fix(skyenv): move DmsgVisorRPCPort off 44 (collided with vpn-server)

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -51,7 +51,7 @@ var (
 	CliSK string
 	// Via, when non-empty, requests proxy to a remote visor through
 	// the local visor named by --rpc. Supported schemes:
-	//   - "dmsg://<pk>" — local visor opens a dmsg stream to <pk>:44
+	//   - "dmsg://<pk>" — local visor opens a dmsg stream to <pk>:57
 	//     and bridges bytes back to this CLI (multiplexed onto the
 	//     existing --rpc port via cmux + magic-byte prefix).
 	//   - "skynet://<pk>" — local visor proxies via TransportRPCCall
@@ -333,7 +333,7 @@ func DmsgClient(cmdFlags *pflag.FlagSet) (visor.API, error) {
 	// Dial visor over dmsg at the visor-RPC port. Previously this
 	// dialed DmsgHypervisorPort 46 which is wrong-direction (visors
 	// DIAL hypervisors there; the hypervisor side runs rpc.Client,
-	// not rpc.Server). DmsgVisorRPCPort 44 is the correct port —
+	// not rpc.Server). DmsgVisorRPCPort 57 is the correct port —
 	// visor runs rpc.Server.ServeConn on accepted streams there,
 	// gated by the same hypervisor + dmsgpty whitelist as
 	// TransportRPCServer.

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -36,7 +36,13 @@ const (
 	// visor-dials-hypervisor (visor side serves rpc.Server, hypervisor
 	// side runs rpc.Client). Here the visor itself serves rpc.Server
 	// to whoever's authorized to dial in.
-	DmsgVisorRPCPort uint16 = 44
+	//
+	// MUST NOT be 44: that is VPNServerPort, and the skynet mirror
+	// reserves this port in the appnet porter at visor init (whenever
+	// the visor has hypervisor/dmsgpty-whitelist PKs — i.e. almost
+	// always). Sharing 44 made vpn-server's `Listen(skynet, 44)` fail
+	// with "port already bound" on every hypervisor-connected board.
+	DmsgVisorRPCPort uint16 = 57
 
 	// DmsgHypervisorPort Listening port of a hypervisor for incoming RPC visor connections over dmsg.
 	DmsgHypervisorPort uint16 = 46
@@ -212,8 +218,9 @@ const (
 
 	// VPNRouterPort is a nominal launcher port for the vpn-router app. The app
 	// serves no dmsg endpoint (it's a local gateway), but every launcher
-	// AppConfig carries a port; this keeps it unique from the others.
-	VPNRouterPort uint16 = 62
+	// AppConfig carries a port; this keeps it unique from the others. 62 was
+	// already taken by SkychatVoiceSignalPort, so this uses 58.
+	VPNRouterPort uint16 = 58
 
 	// ExampleServerName is the name of the example server app
 	ExampleServerName = "example-server-app"

--- a/pkg/visor/rpc_bridge.go
+++ b/pkg/visor/rpc_bridge.go
@@ -13,7 +13,7 @@
 //	1 byte  — scheme: 0 = dmsg, 1 = skynet
 //	33 bytes — target visor PK
 //	2 bytes — little-endian uint16. Dmsg port for scheme=0
-//	          (typically DmsgVisorRPCPort = 44). Ignored for
+//	          (typically DmsgVisorRPCPort = 57). Ignored for
 //	          scheme=1.
 //
 // Total: 42 bytes.


### PR DESCRIPTION
On every hypervisor-connected board, **vpn-server cannot start** — it errors `port already bound` on its very first `Listen`:

```
ERROR [vpn-server]: Error listening network error="port already bound" port=44
```

## Root cause
`skyenv.go` hardcodes **two services to port 44**: `DmsgVisorRPCPort = 44` and `VPNServerPort = 44`.

The dmsg visor-RPC server is **dual-listened** — `v.dmsgC.Listen(DmsgVisorRPCPort)` on dmsg **and** `goServeSkynetMirror(..., DmsgVisorRPCPort, ...)` which reserves the port on the **appnet skynet porter** (`init_apps.go:717`). That mirror comes up at visor init whenever the visor has hypervisor / dmsgpty-whitelist PKs — i.e. essentially every fleet board. So skynet port 44 is already reserved by the time vpn-server calls `appCl.Listen(TypeSkynet, 44)` → `ErrPortAlreadyBound`.

The proc-manager then restarts vpn-server on the failure, and it cycles — which on a non-root host also floods polkit with `pkexec` prompts from the NAT setup/teardown.

## Fix
`VPNServerPort = 44` is long-standing and baked into deployments + service discovery, so **`DmsgVisorRPCPort` moves to 57** (free, adjacent to its `Dmsg*` siblings). It is only ever referenced via the constant — server `Listen` and `--rpc dmsg://<pk>` client dial both read `skyenv.DmsgVisorRPCPort` — so server and client move together.

Also fixes **`VPNRouterPort`**, whose comment claimed "unique from the others" but was 62 = `SkychatVoiceSignalPort`. vpn-router serves no endpoint (nominal launcher port), so nothing broke at runtime, but restore the intended uniqueness with 58.

## Compat
`--rpc dmsg://<pk>` / `--via` dial the visor-RPC on `DmsgVisorRPCPort`; during rollout a new CLI targets 57 while an un-updated visor still serves 44, so both ends should be on the same release for that feature — an acceptable window for an internal RPC port, versus vpn-server being unstartable fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)