### PR TITLE
fix(vpn): exempt ALL transport peer IPs from the tunnel, not just stcpr

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -1211,21 +1211,36 @@ func (tm *Manager) saveTransportInternal(ctx context.Context, remote cipher.PubK
 	return mTp, nil
 }
 
-// STCPRRemoteAddrs gets remote IPs for all known STCPR transports.
-func (tm *Manager) STCPRRemoteAddrs() []string {
+// TransportRemoteAddrs gets remote IPs for all non-DMSG transports (stcpr,
+// sudph, stcp, quic, …).
+//
+// Used only to seed the vpn-client's direct-route exemptions. Every one of
+// these peer IPs MUST bypass the tunnel: routing an established transport's
+// remote IP into the TUN severs that transport — and if the transport carries
+// the vpn's own path to the vpn-server, it severs the tunnel itself (the
+// client stops receiving the ServerHello → NO-CARRIER). Previously this
+// returned STCPR only, so a visor whose path to the server ran over sudph (or
+// any non-stcpr type) had that peer tunneled and the VPN silently failed.
+//
+// DMSG is deliberately excluded: it relays through dmsg servers and has no
+// single routable peer IP, and its servers are exempted separately via
+// DirectRoutesEnvConfig.DmsgServers.
+func (tm *Manager) TransportRemoteAddrs() []string {
 	var addrs []string
 
 	tm.mx.RLock()
 	defer tm.mx.RUnlock()
 
 	for _, tp := range tm.tps {
+		if tp.Entry.Type == types.DMSG {
+			continue
+		}
 		// Use getTransport() (locks transportMx) rather than reading
 		// tp.transport directly: close() can nil it between the nil-check and
 		// the deref — a data race and a nil-deref crash.
 		netTp := tp.getTransport()
 		if netTp != nil {
-			remoteRaw := netTp.RemoteRawAddr().String()
-			if tp.Entry.Type == types.STCPR && remoteRaw != "" {
+			if remoteRaw := netTp.RemoteRawAddr().String(); remoteRaw != "" {
 				addrs = append(addrs, remoteRaw)
 			}
 		}

--- a/pkg/visor/api_apps.go
+++ b/pkg/visor/api_apps.go
@@ -91,7 +91,7 @@ func (v *Visor) StartAppWithMode(appName, launcherMode string) error {
 		if v.tpM == nil {
 			return ErrTrpMangerNotAvailable
 		}
-		maker := vpnEnvMaker(v.conf, v.dmsgC, v.dmsgDC, v.tpM.STCPRRemoteAddrs())
+		maker := vpnEnvMaker(v.conf, v.dmsgC, v.dmsgDC, v.tpM.TransportRemoteAddrs())
 		envs, err = maker()
 		if err != nil {
 			return err
@@ -468,7 +468,7 @@ func (v *Visor) StartVPNClientWithMode(pk cipher.PubKey, launcherMode string) er
 			// unlike the api method `StartApp` where `nil` is passed in `v.appL.StartApp` as args
 			// but the args are set in the config
 			v.conf.Launcher.Apps[index].Args = []string{"app", "vpn-client", "--srv", pk.Hex()}
-			maker := vpnEnvMaker(v.conf, v.dmsgC, v.dmsgDC, v.tpM.STCPRRemoteAddrs())
+			maker := vpnEnvMaker(v.conf, v.dmsgC, v.dmsgDC, v.tpM.TransportRemoteAddrs())
 			envs, err = maker()
 			if err != nil {
 				return err

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -119,7 +119,7 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 	}
 
 	err = launch.AutoStart(launcher.EnvMap{
-		skyenv.VPNClientName: vpnEnvMaker(v.conf, v.dmsgC, v.dmsgDC, v.tpM.STCPRRemoteAddrs()),
+		skyenv.VPNClientName: vpnEnvMaker(v.conf, v.dmsgC, v.dmsgDC, v.tpM.TransportRemoteAddrs()),
 		skyenv.VPNServerName: vpnEnvMaker(v.conf, v.dmsgC, v.dmsgDC, nil),
 	})
 


### PR DESCRIPTION
The vpn-client installs **direct routes** so traffic to skywire infrastructure (dmsg servers, discovery / AR / route-finder / uptime-tracker) and to the visor’s **existing transport peers** bypasses the tunnel — otherwise the tunnel would route the very connections it rides on into the TUN and sever them.

But the transport-peer half of that list came from `Manager.STCPRRemoteAddrs()`, which filtered `Entry.Type == STCPR`. So a visor whose path to the vpn-server ran over **sudph** (or quic/stcp/…) had that peer’s IP tunneled: the client’s own connection to the server broke, it never received the `ServerHello`, and the tunnel came up **NO-CARRIER** — the VPN silently failed. This is easy to hit — sudph is a normal transport type, and it’s what you get whenever stcpr can’t be established.

## Fix
Rename to `TransportRemoteAddrs()` and return remote IPs for **every non-DMSG transport**. DMSG stays excluded on purpose: it relays through servers (no single routable peer IP) and its servers are already exempted via `DirectRoutesEnvConfig.DmsgServers`.

Only used to seed the vpn direct-route exemptions (3 call sites, all updated).

## Known follow-up (separate gap)
The exemption list is still seeded once at vpn-start, so a transport established *after* the client starts is not yet dynamically exempted. Closing that means pushing new transport peer IPs to the running client over the existing `directIPs` channel — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)