### PR TITLE
test(e2e): guard the port-44 vpn-server collision (#3544)

### DIFF
--- a/internal/nativee2e/testdata/visorB.json
+++ b/internal/nativee2e/testdata/visorB.json
@@ -92,5 +92,13 @@
   "is_public": false,
   "geoip": "",
   "persistent_transports": null,
-  "memory_limit": "auto"
+  "memory_limit": "auto",
+  "dmsgpty": {
+    "dmsg_port": 22,
+    "cli_network": "unix",
+    "cli_address": "/tmp/dmsgptyB.sock",
+    "whitelist": [
+      "030a4fff35f74dfeeff2ee9466cf597a1d9aecca665b118d4eb5f795d11f77ed1f"
+    ]
+  }
 }

--- a/internal/nativee2e/vpn_test.go
+++ b/internal/nativee2e/vpn_test.go
@@ -23,6 +23,16 @@ import (
 // Runs on Linux, macOS and Windows. Needs privileges: root on unix, and on
 // Windows an elevated (admin) process — the GitHub windows runner already is —
 // plus wintun.dll alongside the binary, which the e2e-windows CI job provisions.
+//
+// Regression guard for the port-44 collision (#3544): visor B (the vpn-server
+// host) carries a dmsgpty whitelist in its testdata config, which activates the
+// visor-RPC skynet mirror — the same condition every hypervisor-connected fleet
+// board has. That mirror reserves skynet port 44 at init, and vpn-server also
+// listens on skynet 44 (VPNServerPort). Before #3544 (which moved
+// DmsgVisorRPCPort off 44) that made vpn-server fail "port already bound" on its
+// first Listen, so this test — which requires vpn-server to actually serve —
+// would fail. Without the whitelist the mirror stays off, :44 is free, and the
+// collision is invisible: exactly why CI missed it originally.
 func TestVPNClient(t *testing.T) {
 	if !elevated() {
 		t.Skip("vpn-client + vpn-server need root/admin (TUN devices + NAT); skipping")


### PR DESCRIPTION
CI never caught the `DmsgVisorRPCPort`/`VPNServerPort` = 44 collision (fixed in #3544) because the native e2e **split its two triggering conditions across different visors**:
- **visor A** — visor-RPC skynet mirror *active* (it has a hypervisor) → reserves skynet :44 — but runs **vpn-client**
- **visor B** — runs **vpn-server** — but no hypervisor / dmsgpty whitelist → mirror *off* → skynet :44 free → vpn-server binds fine

So the two conditions never coincided on one visor and the collision was invisible. On real fleet boards they always coincide (the vpn-server visor is connected to a hypervisor).

## Fix
Give **visor B** (the vpn-server host) a `dmsgpty.whitelist` in its testdata config, activating its visor-RPC skynet mirror — matching every hypervisor-connected fleet board. Now the mirror reserves skynet :44 at init, so:
- on the buggy code, vpn-server fails `port already bound` → `TestVPNClient` (which requires vpn-server actually serving) **fails**
- with #3544 (`DmsgVisorRPCPort=57`) it binds fine → **passes**

A proper regression guard for the whole port-collision class.

Follow-up worth doing separately (per discussion): drive the e2e configs from `skywire.conf` + `skywire cli config gen` so the integration tests always exercise real generated configs instead of hand-maintained JSON that can drift from what ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)