### PR TITLE
fix(vpn): only exempt transport peers with a routable IP (regression from #3546)

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"sync"
 	"time"
 
@@ -1239,14 +1240,32 @@ func (tm *Manager) TransportRemoteAddrs() []string {
 		// tp.transport directly: close() can nil it between the nil-check and
 		// the deref — a data race and a nil-deref crash.
 		netTp := tp.getTransport()
-		if netTp != nil {
-			if remoteRaw := netTp.RemoteRawAddr().String(); remoteRaw != "" {
-				addrs = append(addrs, remoteRaw)
-			}
+		if netTp == nil {
+			continue
+		}
+		remoteRaw := netTp.RemoteRawAddr().String()
+		// Only emit addresses whose host is a routable IP. The vpn-client
+		// resolves each of these (vpn.ParseIP → net.LookupIP for non-IPs), so a
+		// non-IP raw address — e.g. webrtc's "webrtc-datachannel(<pk>)" — makes
+		// the client's whole startup fail "no such host". Those transports have
+		// no IP the tunnel could route anyway, so skipping them is correct as
+		// well as safe.
+		if remoteRaw != "" && hostIsIP(remoteRaw) {
+			addrs = append(addrs, remoteRaw)
 		}
 	}
 
 	return addrs
+}
+
+// hostIsIP reports whether raw's host component is a literal IP (accepting an
+// optional :port), i.e. something vpn.ParseIP can resolve without a DNS lookup.
+func hostIsIP(raw string) bool {
+	host := raw
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return net.ParseIP(host) != nil
 }
 
 // DeleteTransport deregisters the Transport of Transport ID in transport discovery and deletes it locally.


### PR DESCRIPTION
Follow-up to #3546. Broadening the vpn direct-route exemptions from stcpr-only to **all non-dmsg transports** was too broad: some transport types have a **non-IP remote address** — notably **webrtc**, whose `RemoteRawAddr` is `webrtc-datachannel(<pk>)`.

The vpn-client resolves every exemption entry (`vpn.ParseIP` → `net.LookupIP` for non-literals), so a webrtc entry makes the **whole client fail to start**:

```
error getting TP remote IPs: ... lookup webrtc-datachannel(...): no such host
```

i.e. a visor with *any* webrtc transport couldn’t run vpn-client at all — the tunnel came up **NO-CARRIER** because the client never started. (Found live: Board A had a webrtc transport, so `vpn start` aborted on the merged binary.)

## Fix
Filter `TransportRemoteAddrs()` to transports whose host is a **literal IP** (`hostIsIP`: `SplitHostPort` + `net.ParseIP`). Non-IP transports have no IP the tunnel could route anyway, so skipping them is both correct and safe. stcpr / sudph / stcp / quic keep their IPs; webrtc (and any hostname-only address) is dropped, avoiding the DNS lookup entirely.

Verified `hostIsIP`: `IP:port`→keep, bare IP→keep, IPv6→keep, `webrtc-datachannel(pk)`→drop, hostname→drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)