### PR TITLE
fix(vpnrouter): policy-route by input interface, not source subnet

### DIFF
--- a/pkg/vpn/router_linux.go
+++ b/pkg/vpn/router_linux.go
@@ -288,25 +288,32 @@ func (r *Router) setupNAT() error {
 // its own uplink — the mesh transport carrying the tunnel to the vpn-server
 // rides that uplink, so redirecting the host default through the tun would cut
 // the tunnel's own carrier. Instead we install a dedicated table with a
-// default route out the tun and an `ip rule` matching only the LAN subnet as
-// source, so forwarded client packets egress via the VPN while everything the
-// router originates (dmsg/skywire included) keeps the main table.
+// default route out the tun and an `ip rule` matching traffic FORWARDED IN from
+// the downstream interface, so client packets egress via the VPN while
+// everything the router originates (dmsg/skywire included) keeps the main table.
+//
+// The rule matches by input interface (`iif <lan>`), NOT by source subnet: the
+// gateway's own IP is IN the LAN subnet, so a `from <subnet>` rule also caught
+// the router's replies to clients (DNS answers, ICMP replies, source =
+// gateway IP) and shoved them out the tun, black-holing every local service and
+// gateway response. `iif <lan>` only matches packets forwarded in from the
+// downstream — locally-generated router traffic has no iif and stays on main.
 func (r *Router) setupPolicyRouting() error {
 	table := strconv.Itoa(lanPolicyTable)
-	subnet := r.cfg.Subnet.String()
+	lan := r.cfg.LANInterface
 
 	// default route via the tun device in our private table.
 	if err := osutil.RunElevated("ip", "route", "replace", "default", "dev", r.tunIfc, "table", table); err != nil {
 		return fmt.Errorf("policy route (default dev %s table %s): %w", r.tunIfc, table, err)
 	}
-	// match LAN-sourced traffic into that table. Delete any stale copy first so
-	// a restart doesn't stack duplicate rules.
-	_ = osutil.RunElevated("ip", "rule", "del", "from", subnet, "lookup", table) //nolint:errcheck // best-effort cleanup of a stale rule
-	if err := osutil.RunElevated("ip", "rule", "add", "from", subnet, "lookup", table); err != nil {
-		return fmt.Errorf("policy rule (from %s lookup %s): %w", subnet, table, err)
+	// route traffic forwarded in from the LAN interface into that table. Delete
+	// any stale copy first so a restart doesn't stack duplicate rules.
+	_ = osutil.RunElevated("ip", "rule", "del", "iif", lan, "lookup", table) //nolint:errcheck // best-effort cleanup of a stale rule
+	if err := osutil.RunElevated("ip", "rule", "add", "iif", lan, "lookup", table); err != nil {
+		return fmt.Errorf("policy rule (iif %s lookup %s): %w", lan, table, err)
 	}
 	r.policyRouting = true
-	r.log.Infof("policy routing: %s → %s (table %s); router uplink unchanged", subnet, r.tunIfc, table)
+	r.log.Infof("policy routing: iif %s → %s (table %s); router uplink + local services unchanged", lan, r.tunIfc, table)
 	return nil
 }
 
@@ -321,8 +328,7 @@ func (r *Router) teardown() {
 	// Remove the LAN→tun policy route+rule.
 	if r.policyRouting {
 		table := strconv.Itoa(lanPolicyTable)
-		subnet := r.cfg.Subnet.String()
-		if err := osutil.RunElevated("ip", "rule", "del", "from", subnet, "lookup", table); err != nil {
+		if err := osutil.RunElevated("ip", "rule", "del", "iif", r.cfg.LANInterface, "lookup", table); err != nil {
 			r.log.WithError(err).Warn("teardown: remove policy rule")
 		}
 		if err := osutil.RunElevated("ip", "route", "flush", "table", table); err != nil {


### PR DESCRIPTION
The LAN→tun policy rule (added in #3542) matched `from <lan-subnet>` — but the **gateway's own address is in that subnet**, so the router's replies to clients (embedded-DNS answers, ICMP echo replies, anything the gateway sourced) *also* matched and were routed **out the tun**, black-holing them. Downstream clients could associate, get a DHCP lease, and ARP the gateway, yet every packet to a router-local service (DNS on the gateway, ping to the gateway) timed out.

## Fix
Match by **input interface** instead: `ip rule add iif <lan-ifc> lookup <table>`. That catches only traffic **forwarded in** from the downstream interface (the client egress we want tunneled); locally-generated router traffic has no `iif` and stays on the main table, so gateway responses and local services work. Forwarded client egress is unaffected (still `iif = lan`).

## Found on hardware
A WiFi client on the vpn-router (Orange Pi Prime rtl8723bs AP) associated + leased + ARP'd fine but **could not ping the gateway or use its DNS** — it looked like an rtl8723bs data-path fault. Switching the rule to `iif` fixed it immediately: gateway ping 0% loss, router DNS resolves. The radio was fine; the policy rule was the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)