### PR TITLE
feat(vpnrouter): firewall backend seam (iptables | nftables) — completes Phase 0b

### DIFF
--- a/pkg/vpn/firewall_iptables_linux.go
+++ b/pkg/vpn/firewall_iptables_linux.go
@@ -1,0 +1,99 @@
+//go:build linux && !nftfw
+// +build linux,!nftfw
+
+// Package vpn pkg/vpn/firewall_iptables_linux.go c4-app-vpn
+//
+// The default firewall backend: iptables shell-outs, identical to what the
+// router has always done. Each installed rule's full argv is recorded so
+// teardown can remove it with the matching `-D`. This is the fleet path; the
+// pure-Go nftables backend (firewall_nftfw_linux.go) replaces it only under the
+// `nftfw` build tag.
+package vpn
+
+import (
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/util/osutil"
+)
+
+type iptablesFirewall struct {
+	log   logrus.FieldLogger
+	added [][]string // full iptables argv (incl. -t <table> -A <chain>) per rule
+}
+
+// newFirewall builds the iptables backend. It never fails (rules are added
+// lazily); errors surface per-operation.
+func newFirewall(log logrus.FieldLogger) (firewall, error) {
+	return &iptablesFirewall{log: log}, nil
+}
+
+// run installs one rule and records its argv for teardown.
+func (f *iptablesFirewall) run(argv []string) error {
+	if err := osutil.RunElevated("iptables", argv...); err != nil {
+		return err
+	}
+	f.added = append(f.added, argv)
+	return nil
+}
+
+func (f *iptablesFirewall) masquerade(oif string) error {
+	return f.run([]string{"-t", "nat", "-A", "POSTROUTING", "-o", oif, "-j", "MASQUERADE"})
+}
+
+func (f *iptablesFirewall) forwardAccept(iif, oif string, stateful bool) error {
+	argv := []string{"-A", "FORWARD", "-i", iif, "-o", oif}
+	if stateful {
+		argv = append(argv, "-m", "state", "--state", "RELATED,ESTABLISHED")
+	}
+	argv = append(argv, "-j", "ACCEPT")
+	return f.run(argv)
+}
+
+func (f *iptablesFirewall) clampMSS(oif string) error {
+	return f.run([]string{
+		"-t", "mangle", "-A", "FORWARD", "-o", oif,
+		"-p", "tcp", "-m", "tcp", "--tcp-flags", "SYN,RST", "SYN",
+		"-j", "TCPMSS", "--clamp-mss-to-pmtu",
+	})
+}
+
+func (f *iptablesFirewall) redirectTCP(hook fwHook, iif string, dst *net.IPNet, toPort uint16) error {
+	chain := "PREROUTING"
+	if hook == fwOutput {
+		chain = "OUTPUT"
+	}
+	argv := []string{"-t", "nat", "-A", chain}
+	if iif != "" {
+		argv = append(argv, "-i", iif)
+	}
+	argv = append(argv, "-d", dst.String(), "-p", "tcp",
+		"-j", "REDIRECT", "--to-ports", strconv.Itoa(int(toPort)))
+	return f.run(argv)
+}
+
+// teardown removes each rule (newest first) by flipping its `-A` to `-D`.
+func (f *iptablesFirewall) teardown() {
+	for i := len(f.added) - 1; i >= 0; i-- {
+		del := deleteArgv(f.added[i])
+		if err := osutil.RunElevated("iptables", del...); err != nil {
+			f.log.WithError(err).Warnf("firewall teardown: remove %s", strings.Join(f.added[i], " "))
+		}
+	}
+	f.added = nil
+}
+
+// deleteArgv returns argv with the first "-A"/"-I" token replaced by "-D".
+func deleteArgv(argv []string) []string {
+	out := append([]string(nil), argv...)
+	for i, tok := range out {
+		if tok == "-A" || tok == "-I" {
+			out[i] = "-D"
+			break
+		}
+	}
+	return out
+}

--- a/pkg/vpn/firewall_linux.go
+++ b/pkg/vpn/firewall_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+// +build linux
+
+// Package vpn pkg/vpn/firewall_linux.go c4-app-vpn
+//
+// firewall abstracts the vpn-router's packet-filter / NAT rules behind a small
+// interface with two build-tagged backends, so the SAME router code runs either
+// with iptables (default — the fleet's proven path) or with a pure-Go nftables
+// backend (build tag `nftfw`, for the gokrazy appliance, which ships no iptables
+// binary). Each backend tracks the rules it installs and removes them all in
+// teardown(). See firewall_iptables_linux.go and firewall_nftfw_linux.go.
+package vpn
+
+import "net"
+
+// fwHook selects which NAT chain a REDIRECT lands in.
+type fwHook int
+
+const (
+	// fwPrerouting redirects forwarded/inbound traffic (the router/LAN case).
+	fwPrerouting fwHook = iota
+	// fwOutput redirects locally-generated traffic (the single-host case).
+	fwOutput
+)
+
+// firewall is the router's view of its packet-filter/NAT rules.
+type firewall interface {
+	// masquerade SNATs traffic leaving oif.
+	masquerade(oif string) error
+	// forwardAccept accepts iif→oif forwarded traffic; stateful additionally
+	// requires ct state related,established (the return path).
+	forwardAccept(iif, oif string, stateful bool) error
+	// clampMSS clamps forwarded TCP SYNs' MSS to the path MTU on oif.
+	clampMSS(oif string) error
+	// redirectTCP redirects TCP for dst (a CIDR) to a local port; iif optional.
+	redirectTCP(hook fwHook, iif string, dst *net.IPNet, toPort uint16) error
+	// teardown removes every rule this firewall installed.
+	teardown()
+}

--- a/pkg/vpn/firewall_nftfw_linux.go
+++ b/pkg/vpn/firewall_nftfw_linux.go
@@ -1,0 +1,54 @@
+//go:build linux && nftfw
+// +build linux,nftfw
+
+// Package vpn pkg/vpn/firewall_nftfw_linux.go c4-app-vpn
+//
+// The `nftfw` firewall backend: delegates to netctl.NFTFirewall (pure-Go
+// nftables). Selected only under the `nftfw` build tag — the gokrazy appliance
+// image, which ships no iptables binary. All rules land in a single `skywire`
+// nftables table; teardown drops the table.
+package vpn
+
+import (
+	"net"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/vpn/netctl"
+)
+
+type nftFirewall struct {
+	log logrus.FieldLogger
+	fw  *netctl.NFTFirewall
+}
+
+// newFirewall builds the skywire nftables table + base chains.
+func newFirewall(log logrus.FieldLogger) (firewall, error) {
+	fw, err := netctl.NewNFTFirewall()
+	if err != nil {
+		return nil, err
+	}
+	return &nftFirewall{log: log, fw: fw}, nil
+}
+
+func (n *nftFirewall) masquerade(oif string) error { return n.fw.Masquerade(oif) }
+
+func (n *nftFirewall) forwardAccept(iif, oif string, stateful bool) error {
+	return n.fw.ForwardAccept(iif, oif, stateful)
+}
+
+func (n *nftFirewall) clampMSS(oif string) error { return n.fw.ClampMSS(oif) }
+
+func (n *nftFirewall) redirectTCP(hook fwHook, iif string, dst *net.IPNet, toPort uint16) error {
+	h := netctl.HookPrerouting
+	if hook == fwOutput {
+		h = netctl.HookOutput
+	}
+	return n.fw.RedirectTCP(h, iif, dst, toPort)
+}
+
+func (n *nftFirewall) teardown() {
+	if err := n.fw.Teardown(); err != nil {
+		n.log.WithError(err).Warn("firewall teardown: drop skywire nft table")
+	}
+}

--- a/pkg/vpn/router_linux.go
+++ b/pkg/vpn/router_linux.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -34,27 +33,17 @@ type Router struct {
 	daemons []*exec.Cmd
 	tunIfc  string
 
+	// fw installs/removes the packet-filter + NAT rules — iptables (default) or
+	// nftables (build tag nftfw). It owns its own teardown.
+	fw firewall
+
 	// mesh gateway (optional; nil cfg.MeshDial = off).
-	meshGW       *meshgw.Gateway
-	meshProxy    net.Listener
-	meshRedirect []string // the nat/PREROUTING REDIRECT argv we added (nil = none)
+	meshGW    *meshgw.Gateway
+	meshProxy net.Listener
 
 	// state captured for restoration on teardown.
 	prevForwarding string
-	masquerading   bool
-	forwardRules   [][]string // iptables argv sets we added to the FORWARD chain
-	policyRouting  bool       // true once the LAN→tun policy route+rule are installed
-	mssClamped     bool       // true once the TCPMSS clamp rule is installed
-}
-
-// mssClampRule is the mangle-table rule that clamps forwarded TCP SYNs' MSS to
-// the path MTU. Shared by setup + teardown ("-A" vs "-D") via mssClampArgs.
-func (r *Router) mssClampArgs(op string) []string {
-	return []string{
-		"-t", "mangle", op, "FORWARD", "-o", r.tunIfc,
-		"-p", "tcp", "-m", "tcp", "--tcp-flags", "SYN,RST", "SYN",
-		"-j", "TCPMSS", "--clamp-mss-to-pmtu",
-	}
+	policyRouting  bool // true once the LAN→tun policy route+rule are installed
 }
 
 // lanPolicyTable is the dedicated routing table the router uses to send
@@ -111,6 +100,14 @@ func (r *Router) setup(ctx context.Context) error {
 		return fmt.Errorf("temp dir: %w", err)
 	}
 	r.confDir = dir
+
+	// Firewall backend (iptables by default; nftables under -tags nftfw). Built
+	// before the mesh gateway + NAT, which install rules through it.
+	fw, err := newFirewall(r.log)
+	if err != nil {
+		return fmt.Errorf("firewall backend: %w", err)
+	}
+	r.fw = fw
 
 	// 1. Bring up the downstream interface with the gateway address.
 	if err := r.setupLANInterface(); err != nil {
@@ -261,21 +258,16 @@ func (r *Router) setupNAT() error {
 	if err := EnableIPv4Forwarding(); err != nil {
 		return fmt.Errorf("enable IPv4 forwarding: %w", err)
 	}
-	if err := EnableIPMasquerading(r.tunIfc); err != nil {
+	if err := r.fw.masquerade(r.tunIfc); err != nil {
 		return fmt.Errorf("masquerade out %s: %w", r.tunIfc, err)
 	}
-	r.masquerading = true
 
 	// downstream → tunnel (new+established) and tunnel → downstream (established)
-	rules := [][]string{
-		{"-A", "FORWARD", "-i", r.cfg.LANInterface, "-o", r.tunIfc, "-j", "ACCEPT"},
-		{"-A", "FORWARD", "-i", r.tunIfc, "-o", r.cfg.LANInterface, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
+	if err := r.fw.forwardAccept(r.cfg.LANInterface, r.tunIfc, false); err != nil {
+		return fmt.Errorf("forward %s→%s: %w", r.cfg.LANInterface, r.tunIfc, err)
 	}
-	for _, rule := range rules {
-		if err := osutil.RunElevated("iptables", rule...); err != nil {
-			return fmt.Errorf("iptables %s: %w", strings.Join(rule, " "), err)
-		}
-		r.forwardRules = append(r.forwardRules, rule)
+	if err := r.fw.forwardAccept(r.tunIfc, r.cfg.LANInterface, true); err != nil {
+		return fmt.Errorf("forward %s→%s: %w", r.tunIfc, r.cfg.LANInterface, err)
 	}
 	r.log.Infof("NAT: %s → %s (masquerade)", r.cfg.LANInterface, r.tunIfc)
 
@@ -284,11 +276,9 @@ func (r *Router) setupNAT() error {
 	// segments black-hole (PMTU discovery is unreliable across NAT) — TCP
 	// stalls while ping works. Clamping lets clients auto-negotiate a fitting
 	// MSS with no per-client MTU tweaks.
-	if err := osutil.RunElevated("iptables", r.mssClampArgs("-A")...); err != nil {
+	if err := r.fw.clampMSS(r.tunIfc); err != nil {
 		// Non-fatal: forwarding still works; large-segment flows may stall.
 		r.log.WithError(err).Warn("could not install TCPMSS clamp (large downstream TCP flows may stall)")
-	} else {
-		r.mssClamped = true
 	}
 
 	if err := r.setupPolicyRouting(); err != nil {
@@ -369,38 +359,21 @@ func (r *Router) setupMeshGateway(ctx context.Context) error {
 		}
 	}()
 
-	rule := []string{
-		"-t", "nat", "-A", "PREROUTING",
-		"-i", r.cfg.LANInterface,
-		"-d", gw.PoolCIDR().String(),
-		"-p", "tcp",
-		"-j", "REDIRECT", "--to-ports", strconv.Itoa(port),
-	}
-	if err := osutil.RunElevated("iptables", rule...); err != nil {
+	if err := r.fw.redirectTCP(fwPrerouting, r.cfg.LANInterface, gw.PoolCIDR(), uint16(port)); err != nil { //nolint:gosec // ephemeral port fits uint16
 		return fmt.Errorf("mesh gateway REDIRECT: %w", err)
 	}
-	r.meshRedirect = rule
 	r.log.Infof("mesh gateway: *.dmsg / *.skynet → synthetic %s → proxy :%d (dials over mesh)", gw.PoolCIDR().String(), port)
 	return nil
 }
 
 // teardown reverses setup, best-effort (logs but does not abort on errors).
 func (r *Router) teardown() {
-	// Remove the mesh-gateway REDIRECT and stop its proxy.
-	if r.meshRedirect != nil {
-		del := append([]string{"-t", "nat", "-D"}, r.meshRedirect[3:]...)
-		if err := osutil.RunElevated("iptables", del...); err != nil {
-			r.log.WithError(err).Warn("teardown: remove mesh gateway REDIRECT")
-		}
+	// Remove every firewall rule (masquerade, FORWARD, MSS clamp, mesh REDIRECT).
+	if r.fw != nil {
+		r.fw.teardown()
 	}
 	if r.meshProxy != nil {
 		_ = r.meshProxy.Close() //nolint:errcheck // best-effort close on shutdown
-	}
-	// Remove the TCPMSS clamp.
-	if r.mssClamped {
-		if err := osutil.RunElevated("iptables", r.mssClampArgs("-D")...); err != nil {
-			r.log.WithError(err).Warn("teardown: remove TCPMSS clamp")
-		}
 	}
 	// Remove the LAN→tun policy route+rule.
 	if r.policyRouting {
@@ -409,18 +382,6 @@ func (r *Router) teardown() {
 		}
 		if err := netctl.FlushTable(lanPolicyTable); err != nil {
 			r.log.WithError(err).Warn("teardown: flush policy table")
-		}
-	}
-	// Remove the FORWARD rules we added (-D mirrors each -A).
-	for _, rule := range r.forwardRules {
-		del := append([]string{"-D"}, rule[1:]...)
-		if err := osutil.RunElevated("iptables", del...); err != nil {
-			r.log.WithError(err).Warnf("teardown: remove FORWARD rule %s", strings.Join(rule, " "))
-		}
-	}
-	if r.masquerading {
-		if err := DisableIPMasquerading(r.tunIfc); err != nil {
-			r.log.WithError(err).Warn("teardown: disable masquerading")
 		}
 	}
 	if r.prevForwarding != "" && r.prevForwarding != "1" {


### PR DESCRIPTION
Completes **Phase 0b** of the gokrazy appliance effort (#3557): the vpn-router's firewall rules now dispatch through a backend seam, so the same router code runs with iptables (fleet) or pure-Go nftables (appliance).

## What
The router's masquerade / FORWARD-accept / TCPMSS-clamp / mesh-gateway-REDIRECT rules go through a small `firewall` interface (`pkg/vpn/firewall_linux.go`) with two build-tagged backends:
- **default (`!nftfw`)** — iptables, **byte-identical to before**: same rule specs, same reversed `-D` teardown. The fleet path is unchanged.
- **`nftfw`** — delegates to `netctl.NFTFirewall` (the pure-Go nftables backend from #3556; one `skywire` table, `Teardown` drops the table). This is what makes the arm64 gokrazy image's firewall actually functional (the appliance ships no `iptables`).

The `Router` now holds one `firewall` and calls it; the backend owns its teardown, replacing the scattered `forwardRules`/`mssClamped`/`meshRedirect`/`masquerading` state. The vpn-server keeps its own `EnableIPMasquerading` (unchanged).

## Validation
- Both tag paths build + `golangci-lint` **0 issues**; existing vpn tests pass.
- The nft backend this delegates to is already validated against a real kernel end-to-end, **including on an Orange Pi Prime (aarch64, kernel 5.15)** — see #3556.
- Fleet-safe by construction: the default build compiles the iptables path, so nothing changes for existing installs regardless of this seam.

## Not converted here (tracked follow-up, not on the eth-router appliance's path)
- The vpn-client's mesh-gateway OUTPUT rules (`mesh_client_linux.go`) — for the single-host vpn-client appliance.
- The vpn-server masquerade — no server runs on the eth-router appliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)