### PR TITLE
fix(tpd): log reward-heartbeat store failures instead of dropping them silently

### DIFF
--- a/pkg/transport-discovery/store/redis_store.go
+++ b/pkg/transport-discovery/store/redis_store.go
@@ -142,8 +142,16 @@ func (s *redisStore) RecordHeartbeat(ctx context.Context, pk cipher.PubKey, vers
 	pipe.SetBit(ctx, tlKey, currentTimelineSlot(now), 1)
 	pipe.Expire(ctx, tlKey, 8*24*time.Hour)
 
-	_, err := pipe.Exec(ctx)
-	return err
+	if _, err := pipe.Exec(ctx); err != nil {
+		// Reward-critical: a persistent failure here silently drops the fleet's
+		// uptime/presence data, which is exactly how a reward-uptime outage can
+		// hide for days. Callers treat the heartbeat as best-effort and rely on
+		// the store to surface failures, so log at Warn here rather than let it
+		// vanish into a Debug line or a discarded error.
+		s.log.WithError(err).Warn("RecordHeartbeat: failed to persist visor heartbeat (uptime/reward data lost for this tick)")
+		return err
+	}
+	return nil
 }
 
 const minP2PTransportsOnline = 2

--- a/pkg/transport-discovery/store/redis_uptime.go
+++ b/pkg/transport-discovery/store/redis_uptime.go
@@ -190,8 +190,13 @@ func (s *redisStore) RecordTransportHeartbeat(ctx context.Context, tpID uuid.UUI
 	pipe.SetBit(ctx, tlKey, currentTimelineSlot(at), 1)
 	pipe.Expire(ctx, tlKey, 8*24*time.Hour)
 
-	_, err := pipe.Exec(ctx)
-	return err
+	if _, err := pipe.Exec(ctx); err != nil {
+		// Reward-critical (see RecordHeartbeat): surface store failures at Warn
+		// rather than letting best-effort callers discard them silently.
+		s.log.WithError(err).Warn("RecordTransportHeartbeat: failed to persist transport heartbeat (uptime data lost for this tick)")
+		return err
+	}
+	return nil
 }
 
 // transportTimelineBitmapBytes is the expected wire size of a single


### PR DESCRIPTION
## Problem

`RecordHeartbeat` and `RecordTransportHeartbeat` are the store writes that persist the fleet's reward-uptime data. Both returned `pipe.Exec` errors **with no logging**, and every caller treats the heartbeat as best-effort — discarding the error (`_ = err //nolint`) or logging at Debug — on the explicit assumption, stated in the caller comments, that *'the store layer logs.'* It didn't.

So a persistent Redis failure would drop the **whole fleet's** uptime/presence data with no signal at any log level — exactly how a reward-uptime outage hides for days (this is one of the failure shapes behind the outage we just diagnosed).

## Fix

Log both at **Warn** on error (the store already holds a logger). Silent in normal operation; loud only on real store failure. Makes the callers' 'store layer logs' comments true and gives one central, visible signal covering all paths (HTTP registration, CXO reconcile, aggregator).

Build/test/lint pass.