### PR TITLE
fix(visor): bound the remaining unbounded stun.ready waits

### DIFF
--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -79,11 +79,28 @@ func getRouteSetupHooks(ctx context.Context, v *Visor, log *logging.Logger) []ro
 					continue
 				}
 
-				// Wait until stun client is ready
-				<-v.stun.ready
+				// Wait until the stun client is ready — but bounded. An
+				// unbounded <-v.stun.ready blocks direct-transport setup for this
+				// peer forever when STUN never becomes ready (no reachable STUN
+				// server), wedging automatic transport establishment. Same wedge
+				// class as the AR/service-discovery paths.
+				stunReady := false
+				select {
+				case <-v.stun.ready:
+					stunReady = true
+				case <-time.After(20 * time.Second):
+					log.Warn("STUN not ready within 20s; skipping SUDPH for this peer")
+				case <-ctx.Done():
+					return ctx.Err()
+				}
 
 				// skip SUDPH if NAT type prevents it (symmetric NAT, firewall, or STUN failure)
 				if nType == types.SUDPH {
+					// Without a ready STUN client we can't determine NAT type;
+					// skip SUDPH rather than nil-deref v.stun.client.
+					if !stunReady || v.stun.client == nil {
+						continue
+					}
 					switch v.stun.client.NATType {
 					case stun.NATSymmetric, stun.NATSymmetricUDPFirewall,
 						stun.NATError, stun.NATUnknown, stun.NATBlocked:

--- a/pkg/visor/init_services.go
+++ b/pkg/visor/init_services.go
@@ -181,8 +181,16 @@ func getPublicIP(v *Visor, service string) (string, error) {
 		return pIP, fmt.Errorf("provided URL is invalid: %w", err)
 	}
 
-	<-v.stun.ready
-	if v.stun.client.PublicIP != nil {
+	// Bound the STUN wait — an unbounded <-v.stun.ready blocks every caller of
+	// getPublicIP (transport setup, the reward heartbeat client) forever when
+	// STUN never becomes ready. The public IP is only a registration hint, so
+	// proceed without it on timeout.
+	select {
+	case <-v.stun.ready:
+	case <-time.After(20 * time.Second):
+		v.log.Warn("getPublicIP: STUN not ready within 20s; proceeding without a STUN-derived public IP")
+	}
+	if v.stun.client != nil && v.stun.client.PublicIP != nil {
 		pIP = v.stun.client.PublicIP.IP()
 		return pIP, nil
 	}


### PR DESCRIPTION
Two `<-v.stun.ready` receives had no timeout/cancel sibling, unlike the AR and service-discovery paths that were already bounded (`init_transport.go:240`):

- **init_router.go** — direct-transport (SUDPH) setup per remote peer: an unreachable STUN server blocks automatic transport establishment for that peer **forever**.
- **getPublicIP (init_services.go)** — now on the reward-heartbeat client's init path: a stuck STUN would wedge heartbeat-client construction.

Bound both at 20s (matching the existing pattern) and guard `v.stun.client` against nil on the timeout path — skip SUDPH / proceed without a public IP rather than nil-deref. Build/vet/lint pass.