### PR TITLE
fix(visor/stats): prune day-start bandwidth baselines (unbounded map)

### DIFF
--- a/pkg/visor/stats/tracker.go
+++ b/pkg/visor/stats/tracker.go
@@ -507,7 +507,19 @@ func (t *Tracker) runRetention(now time.Time) {
 	// bounded at the configured rolling-window size.
 	t.sinkPruneOutsidePublishWindow(now)
 
+	// Prune day-start bandwidth baselines for transports not sampled today.
+	// A live transport recreates its baseline (keyed to today) on its next
+	// sample, so any entry still tagged with an earlier day belongs to a
+	// transport that has gone away. Without this, baselines grows unbounded
+	// with transport churn — every other prune path reclaimed records/bitmaps
+	// but structurally never touched this map.
+	today := now.UTC().Format(dateFmt)
 	t.mu.Lock()
+	for id, base := range t.baselines {
+		if base.day != today {
+			delete(t.baselines, id)
+		}
+	}
 	t.lastPruned = now
 	t.mu.Unlock()
 }


### PR DESCRIPTION
The `baselines` map gained an entry per transport UUID (tracker.go:377) and was **never deleted**. Every retention/prune path reclaimed transport records, daily rows, and bitmaps but structurally never touched `baselines` — so under transport churn (each new transport = new UUID) it grew without bound for the process lifetime. Same cleanup-skips-a-whole-category shape as the CXO wanted-object leak.

Fix: prune it in `runRetention` — drop any baseline whose `day != today`. A live transport recreates its baseline (keyed to today) on its next sample, so a stale-day entry belongs to a transport that has gone away. Bounds the map to ~one day of churn. Build/test/lint pass.