### PR TITLE
fix(httpauth): share the nonce per (addr, PK) to stop concurrent-request 401s

### DIFF
--- a/pkg/httpauthclient/client.go
+++ b/pkg/httpauthclient/client.go
@@ -48,12 +48,49 @@ type HTTPError struct {
 	Code    int    `json:"code"`
 }
 
+// nonceState is the nonce counter + request serialization SHARED by every
+// Client that targets the same (addr, PK). httpauth's server keeps a single
+// monotonic nonce per PK (redis INCR), but a process legitimately holds several
+// clients to the same server as the same identity — e.g. a visor's utclient
+// (uptime heartbeat) and tpdclient (transport registration) both hit the TPD.
+// Before this, each Client had its own counter + reqMu, so two of them could
+// issue concurrent same-PK requests: both passed verifyAuth at nonce N, the
+// server INCR'd twice to N+2 while each client advanced only to N+1, and every
+// subsequent request 401'd until a resync that kept losing under sustained
+// load. That silently suppressed reward-uptime heartbeats for high-transport
+// visors. Sharing one counter + one reqMu per (addr, PK) serializes a process's
+// requests to a server so it never races its own nonce.
+type nonceState struct {
+	nonce       uint64     // shared counter; 64-bit-aligned as the first field
+	reqMu       sync.Mutex // serializes all Do() calls sharing this (addr, PK)
+	initMu      sync.Mutex // guards one-time initial nonce fetch
+	initialized bool
+}
+
+var (
+	nonceStatesMu sync.Mutex
+	// nonceStates is keyed by sanitizedAddr+"\x00"+PK. Bounded by the number of
+	// distinct (server, identity) pairs a process uses (a handful), so it is
+	// intentionally never pruned.
+	nonceStates = map[string]*nonceState{}
+)
+
+func sharedNonceState(addr string, key cipher.PubKey) *nonceState {
+	k := addr + "\x00" + key.Hex()
+	nonceStatesMu.Lock()
+	defer nonceStatesMu.Unlock()
+	st, ok := nonceStates[k]
+	if !ok {
+		st = &nonceState{}
+		nonceStates[k] = st
+	}
+	return st
+}
+
 // Client implements Client for auth services.
 type Client struct {
-	// atomic requires 64-bit alignment for struct field access
-	nonce          uint64
-	mu             sync.Mutex
-	reqMu          sync.Mutex
+	state          *nonceState // shared per (addr, PK) — see nonceState
+	mu             sync.Mutex  // serializes THIS client's own http.Client use
 	client         *http.Client
 	key            cipher.PubKey
 	sec            cipher.SecKey
@@ -78,13 +115,21 @@ func NewClient(ctx context.Context, addr string, key cipher.PubKey, sec cipher.S
 		clientPublicIP: clientPublicIP,
 		log:            mLog.PackageLogger("httpauth"),
 	}
+	c.state = sharedNonceState(c.addr, key)
 
-	// request server for a nonce
-	nonce, err := c.Nonce(ctx, c.key)
-	if err != nil {
-		return nil, err
+	// Establish the shared nonce once per (addr, PK). Additional clients to the
+	// same server+identity reuse the shared counter — kept current by the
+	// resync-on-401 path in do() — rather than each fetching and racing it.
+	c.state.initMu.Lock()
+	defer c.state.initMu.Unlock()
+	if !c.state.initialized {
+		nonce, err := c.Nonce(ctx, c.key)
+		if err != nil {
+			return nil, err
+		}
+		atomic.StoreUint64(&c.state.nonce, uint64(nonce))
+		c.state.initialized = true
 	}
-	c.nonce = uint64(nonce)
 
 	return c, nil
 }
@@ -96,8 +141,8 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 }
 
 func (c *Client) do(client *http.Client, req *http.Request) (*http.Response, error) {
-	c.reqMu.Lock()
-	defer c.reqMu.Unlock()
+	c.state.reqMu.Lock()
+	defer c.state.reqMu.Unlock()
 
 	body := make([]byte, 0)
 	if req.ContentLength != 0 {
@@ -184,7 +229,7 @@ func (c *Client) Nonce(ctx context.Context, key cipher.PubKey) (Nonce, error) {
 
 // SetNonce sets client current nonce to given nonce
 func (c *Client) SetNonce(n Nonce) {
-	atomic.StoreUint64(&c.nonce, uint64(n))
+	atomic.StoreUint64(&c.state.nonce, uint64(n))
 }
 
 // Addr returns sanitized address of the client
@@ -214,12 +259,12 @@ func (c *Client) doRequest(client *http.Client, req *http.Request, body []byte) 
 }
 
 func (c *Client) getCurrentNonce() Nonce {
-	return Nonce(atomic.LoadUint64(&c.nonce))
+	return Nonce(atomic.LoadUint64(&c.state.nonce))
 }
 
 // IncrementNonce increments client's current nonce.
 func (c *Client) IncrementNonce() {
-	atomic.AddUint64(&c.nonce, 1)
+	atomic.AddUint64(&c.state.nonce, 1)
 }
 
 // isNonceValid checks if `res` contains an invalid nonce error.

--- a/pkg/httpauthclient/client_concurrency_test.go
+++ b/pkg/httpauthclient/client_concurrency_test.go
@@ -1,0 +1,103 @@
+//go:build !tinygo || (js && wasm)
+
+package httpauthclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// TestClient_SharedNonceNoRace is the reward-uptime regression guard. A visor
+// holds several httpauth clients to the same server as the same identity (the
+// utclient uptime heartbeat and the tpdclient transport registration both hit
+// the TPD). Before the shared-nonce fix, each client had its own counter, so
+// concurrent same-PK requests raced the server's single monotonic nonce: both
+// passed at nonce N, the server INCR'd twice while each client advanced once,
+// and everything 401'd until a resync that kept losing under load — silently
+// suppressing reward heartbeats for high-transport visors.
+//
+// With one shared counter + reqMu per (addr, PK), a process serializes its own
+// requests to a server, so firing many requests through two clients
+// concurrently produces zero nonce mismatches and advances the server nonce
+// exactly once per request.
+func TestClient_SharedNonceNoRace(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+
+	var mu sync.Mutex
+	expected := 1
+	mismatches := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/security/nonces/"+pk.Hex() {
+			mu.Lock()
+			n := expected
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(&NextNonceResponse{Edge: pk, NextNonce: Nonce(n)}) //nolint:errcheck,gosec
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)               //nolint:errcheck
+		_ = r.Body.Close()                               //nolint:errcheck
+		got, _ := strconv.Atoi(r.Header.Get("SW-Nonce")) //nolint:errcheck
+		mu.Lock()
+		if got == expected {
+			expected++
+			mu.Unlock()
+			_, _ = fmt.Fprint(w, "ok") //nolint:errcheck
+			return
+		}
+		mismatches++
+		mu.Unlock()
+		// Mirror the real server's invalid-nonce response so the client resyncs.
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, errorMessage) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	// Two clients for the SAME (addr, PK) — the visor heartbeat + registration case.
+	c1, err := NewClient(context.TODO(), ts.URL, pk, sk, &http.Client{}, "", masterLogger)
+	require.NoError(t, err)
+	c2, err := NewClient(context.TODO(), ts.URL, pk, sk, &http.Client{}, "", masterLogger)
+	require.NoError(t, err)
+	require.Same(t, c1.state, c2.state, "clients for the same (addr, PK) must share nonce state")
+
+	const perClient = 30
+	var wg sync.WaitGroup
+	fire := func(c *Client) {
+		defer wg.Done()
+		for i := 0; i < perClient; i++ {
+			req, err := http.NewRequest(http.MethodGet, ts.URL+"/foo", bytes.NewBufferString(payload))
+			if err != nil {
+				continue
+			}
+			res, err := c.Do(req)
+			if err != nil {
+				continue
+			}
+			_, _ = io.Copy(io.Discard, res.Body) //nolint:errcheck
+			_ = res.Body.Close()                 //nolint:errcheck
+		}
+	}
+	wg.Add(2)
+	go fire(c1)
+	go fire(c2)
+	wg.Wait()
+
+	mu.Lock()
+	gotMismatches, gotExpected := mismatches, expected
+	mu.Unlock()
+
+	require.Zero(t, gotMismatches, "shared nonce state must eliminate concurrent nonce races")
+	require.Equal(t, 1+2*perClient, gotExpected, "server nonce must advance exactly once per request")
+}

--- a/pkg/httpauthclient/client_test.go
+++ b/pkg/httpauthclient/client_test.go
@@ -63,7 +63,7 @@ func TestClient(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, res.Body.Close())
 	assert.Equal(t, []byte(payload), b)
-	assert.Equal(t, uint64(2), c.nonce)
+	assert.Equal(t, uint64(2), uint64(c.getCurrentNonce()))
 
 	headers := <-headerCh
 	checkResp(t, headers, b, pk, 1)
@@ -80,7 +80,7 @@ func TestClient_BadNonce(t *testing.T) {
 	c, err := NewClient(context.TODO(), ts.URL, pk, sk, &http.Client{}, ip, masterLogger)
 	require.NoError(t, err)
 
-	c.nonce = 999
+	c.SetNonce(999)
 
 	req, err := http.NewRequest(http.MethodGet, ts.URL+"/foo", bytes.NewBufferString(payload))
 	require.NoError(t, err)
@@ -90,7 +90,7 @@ func TestClient_BadNonce(t *testing.T) {
 	b, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.NoError(t, res.Body.Close())
-	assert.Equal(t, uint64(2), c.nonce)
+	assert.Equal(t, uint64(2), uint64(c.getCurrentNonce()))
 
 	headers := <-headerCh
 	checkResp(t, headers, b, pk, 1)


### PR DESCRIPTION
Closes #3568 — the root cause of the reward-uptime heartbeat suppression.

## Problem
httpauth's server keeps a **single monotonic nonce per PK** (redis `INCR`, advanced on each 200). A process legitimately holds several `httpauthclient` instances to the same server as the same identity — a visor's **utclient** (uptime heartbeat) and **tpdclient** (transport registration) both authenticate to the TPD. Each `Client` had its **own** nonce counter + `reqMu`, so two of them could issue concurrent same-PK requests:

> both pass `verifyAuth` at nonce N → server INCRs twice to N+2 → each client advanced only to N+1 → every subsequent request 401s until a resync that keeps losing under load.

That is the reward-uptime suppression: high-transport visors (registration traffic overlapping the heartbeat) thrashed worst, so their `/v4/update` heartbeats mostly 401'd and recorded uptime collapsed to near-zero **despite being online** (~290 of 517 online visors observed).

## Fix
Move the nonce counter + request serialization into a `nonceState` **shared by all Clients for the same (sanitized addr, PK)** via a small package registry. A process now serializes its own requests to a server and never races its own nonce. Shared counter is initialized once (kept current by the existing resync-on-401 path); the per-client `mu` (http.Client serialization) stays per-client.

Contained to `pkg/httpauthclient` — no server change, no interface change. Adds a `-race` concurrency regression test: two clients sharing (addr, PK), many concurrent requests → **zero nonce mismatches**, server nonce advances exactly once per request. Build/vet/lint/-race all pass.

Pairs with #3563/#3564 (which made the failure visible and restored the heartbeat).