### PR TITLE
fix(cxo): treat non-positive fill/response timeouts as default, not disabled

### DIFF
--- a/pkg/cxo/cxoutils/cxoutils.go
+++ b/pkg/cxo/cxoutils/cxoutils.go
@@ -110,6 +110,13 @@ func RemoveObjects(c *skyobject.Container) (err error) {
 			if rc != 0 {
 				return false, nil
 			}
+			// Skipping cached keys is BY DESIGN: an object the in-memory Cache
+			// still holds (a wanted item from an in-flight fill) must not be
+			// deleted from under the fill. The residual — a rc==0 object kept
+			// alive only by a hung fill's want entry — is bounded not here but
+			// by MaxFillingTime (see head.go / #3562): when the fill times out
+			// it Unwants, the object leaves the cache, and the next sweep
+			// reclaims it. Do not "fix" this by deleting cached keys.
 			_, isCached := cached[key]
 			return !isCached, nil
 		})

--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -735,6 +735,14 @@ func (c *Conn) responseTimeout() (rt time.Duration) {
 	} else {
 		rt = c.n.config.UDP.ResponseTimeout
 	}
+	if rt <= 0 {
+		// A non-positive response timeout leaves the per-request wait channel
+		// (tc) nil, so an object request to a peer that never delivers pins its
+		// wanted-cache entry + handler goroutine for the whole connection
+		// lifetime. Treat 0 as "use the default", not "disable" — a disabled
+		// per-request timeout is a footgun, not a feature.
+		rt = ResponseTimeout
+	}
 	return
 }
 

--- a/pkg/cxo/node/head.go
+++ b/pkg/cxo/node/head.go
@@ -406,10 +406,16 @@ func (f *fillHead) createFiller(cr connRoot) {
 
 	f.tp = time.Now() // time point
 
-	if ft := f.node().config.MaxFillingTime; ft > 0 {
-		f.ft = time.NewTimer(ft)
-		f.tc = f.ft.C
+	// A non-positive MaxFillingTime would leave f.tc nil and disable the fill
+	// timeout entirely, so a peer that flaps mid-fill pins all the fill's
+	// "wanted" objects in the cache until the connection closes (the leak class
+	// behind #3562). Treat <= 0 as "use the default", not "disable".
+	ft := f.node().config.MaxFillingTime
+	if ft <= 0 {
+		ft = MaxFillingTime
 	}
+	f.ft = time.NewTimer(ft)
+	f.tc = f.ft.C
 
 	f.r = cr
 	f.rq = make(chan cipher.SHA256, f.maxParallel())


### PR DESCRIPTION
Two CXO node timeouts silently **disable** themselves at `<= 0` instead of falling back to a default, each leaving a per-peer resource pinned until the connection closes:

- `responseTimeout() <= 0` → the object-request wait channel (`tc`) is nil, so a request to a peer that never delivers pins its wanted-cache entry + handler goroutine for the whole connection lifetime (audit finding #11).
- `MaxFillingTime <= 0` → `head.go` leaves the fill-timeout timer unset, so a flapping peer's hung fill pins all its wanted objects forever (the leak class behind #3562).

Guard both: a non-positive configured value now uses the package default (59s / 10m) rather than disabling the timeout. A disabled per-peer timeout is a footgun, not a feature.

Also documents `cxoutils.RemoveObjects`' `isCached` skip as **by-design** (audit finding #12) — it must not delete objects an in-flight fill still wants; that residual is bounded by `MaxFillingTime`, not by deleting cached keys.

Build/test/lint pass. (The separate question of *lowering* the 10m default per #3569 is deferred for on-deployment observation.)