### PR TITLE
feat(resolver): configurable SOCKS5 bind host so a board can serve the LAN

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -321,6 +321,10 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "dmsgweb-upstream")
 	genConfigCmd.Flags().StringVar(&skynetWebUpstreamSOCKS, "skynetweb-upstream", scriptExecString("${SKYNETWEBUPSTREAM}"), "upstream SOCKS5 for non .skynet traffic")
 	gHiddenFlags = append(gHiddenFlags, "skynetweb-upstream")
+	genConfigCmd.Flags().StringVar(&dmsgWebProxyAddr, "dmsgweb-addr", scriptExecString("${DMSGWEBADDR}"), "host the .dmsg SOCKS5 proxy binds to (empty=127.0.0.1; 0.0.0.0 or a LAN IP to serve the LAN)")
+	gHiddenFlags = append(gHiddenFlags, "dmsgweb-addr")
+	genConfigCmd.Flags().StringVar(&skynetWebProxyAddr, "skynetweb-addr", scriptExecString("${SKYNETWEBADDR}"), "host the .skynet SOCKS5 proxy binds to (empty=127.0.0.1; 0.0.0.0 or a LAN IP to serve the LAN)")
+	gHiddenFlags = append(gHiddenFlags, "skynetweb-addr")
 
 	// Skychat flags
 	genConfigCmd.Flags().BoolVar(&isSkychatEnable, "servechat", scriptExecBool("${SKYCHAT:-true}"), "autostart skychat")
@@ -2044,12 +2048,14 @@ func configureResolvingProxies() {
 		conf.DmsgWeb = &visorconfig.DmsgWebConfig{
 			Enable:        true,
 			UpstreamSOCKS: dmsgWebUpstreamSOCKS,
+			ProxyAddr:     dmsgWebProxyAddr,
 		}
 	}
 	if enableSkynetWeb {
 		conf.SkynetWeb = &visorconfig.SkynetWebConfig{
 			Enable:        true,
 			UpstreamSOCKS: skynetWebUpstreamSOCKS,
+			ProxyAddr:     skynetWebProxyAddr,
 		}
 	}
 	if enableSkymailBridge {

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -119,6 +119,8 @@ var (
 	enableSkymailBridge        bool
 	dmsgWebUpstreamSOCKS       string
 	skynetWebUpstreamSOCKS     string
+	dmsgWebProxyAddr           string
+	skynetWebProxyAddr         string
 	configServicePath          string
 	dmsgHTTPPath               string
 	snConfig                   bool

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -46,6 +46,15 @@ import (
 // default so the visor app gets the same behavior.
 const DefaultDomainSuffix = ".dmsg"
 
+// proxyHost returns the SOCKS5 bind host, defaulting to loopback when unset so
+// the proxy is never accidentally exposed to the network.
+func proxyHost(addr string) string {
+	if addr == "" {
+		return "127.0.0.1"
+	}
+	return addr
+}
+
 // Config configures a dmsgweb runtime. Two operating modes:
 //
 //  1. ResolveAddr empty → SOCKS5 resolver mode. Any hostname ending
@@ -68,6 +77,13 @@ type Config struct {
 	// (fixed-mapping); ignored in SOCKS5 mode. One entry per ResolveAddr.
 	WebPorts []uint
 
+	// ProxyAddr is the host the SOCKS5 proxy listens on. Empty means
+	// loopback ("127.0.0.1") — the safe default. Set to "0.0.0.0" or a
+	// specific LAN IP to serve OTHER devices on the network, e.g. a board
+	// acting as a `.dmsg` gateway for a home router's LAN. Binding a
+	// non-loopback address exposes the proxy to the LAN; only do so on a
+	// trusted network.
+	ProxyAddr string
 	// ProxyPort is the SOCKS5 proxy listener port. Zero disables the
 	// SOCKS5 proxy (useful when the runtime is embedded inside an
 	// app that already provides its own SOCKS5 front-end).
@@ -416,7 +432,7 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 	if err != nil {
 		return fmt.Errorf("create SOCKS5 server: %w", err)
 	}
-	lisAddr := fmt.Sprintf("127.0.0.1:%d", cfg.ProxyPort)
+	lisAddr := fmt.Sprintf("%s:%d", proxyHost(cfg.ProxyAddr), cfg.ProxyPort)
 	log.WithField("addr", lisAddr).Debug("Serving SOCKS5 direct proxy")
 	// Open the listener ourselves so we can close it on ctx cancel —
 	// armon/go-socks5's Serve returns when the listener is closed.

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -95,6 +95,11 @@ func PerformHandshake(conn net.Conn, port uint16) error {
 type Config struct {
 	// DomainSuffix is the TLD matched by the resolver (default ".skynet").
 	DomainSuffix string
+	// ProxyAddr is the host the SOCKS5 proxy listens on. Empty means loopback
+	// ("127.0.0.1"). Set to "0.0.0.0" or a LAN IP to serve other devices on
+	// the network (a `.skynet` gateway for a home router's LAN). Only bind a
+	// non-loopback address on a trusted network.
+	ProxyAddr string
 	// ProxyPort is the SOCKS5 listener port.
 	ProxyPort uint
 	// UpstreamSOCKS forwards non-matching SOCKS5 CONNECTs to this
@@ -335,7 +340,11 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 	if err != nil {
 		return fmt.Errorf("create SOCKS5 server: %w", err)
 	}
-	lisAddr := fmt.Sprintf("127.0.0.1:%d", cfg.ProxyPort)
+	host := cfg.ProxyAddr
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	lisAddr := fmt.Sprintf("%s:%d", host, cfg.ProxyPort)
 	log.WithField("addr", lisAddr).Info("Serving skynetweb SOCKS5 proxy")
 
 	// Open the listener ourselves so we can close it on ctx cancel —

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -192,6 +192,7 @@ func (e *EmbeddedDmsgWeb) serve(ctx context.Context) {
 	cfg := dmsgweb.Config{
 		DomainSuffix:  stringOrDefault(e.cfg.DomainSuffix, dmsgweb.DefaultDomainSuffix),
 		ProxyPort:     uintOrDefault(e.cfg.ProxyPort, defaultDmsgWebProxyPort),
+		ProxyAddr:     e.cfg.ProxyAddr,
 		UpstreamSOCKS: e.cfg.UpstreamSOCKS,
 		Stats:         e.stats,
 	}

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -162,6 +162,7 @@ func (e *EmbeddedSkynetWeb) serve(ctx context.Context) {
 	cfg := skynetweb.Config{
 		DomainSuffix:  stringOrDefault(e.cfg.DomainSuffix, skynetweb.DefaultDomainSuffix),
 		ProxyPort:     uintOrDefault(e.cfg.ProxyPort, defaultSkynetWebProxyPort),
+		ProxyAddr:     e.cfg.ProxyAddr,
 		UpstreamSOCKS: e.cfg.UpstreamSOCKS,
 		Stats:         e.stats,
 	}

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -274,6 +274,11 @@ type DmsgWebConfig struct {
 	Enable bool `json:"enable"`
 	// ProxyPort is the local SOCKS5 listener. Default 4445.
 	ProxyPort uint `json:"proxy_port,omitempty"`
+	// ProxyAddr is the host the SOCKS5 proxy binds to. Empty = loopback
+	// ("127.0.0.1"). Set to "0.0.0.0" or a LAN IP to serve OTHER devices on
+	// the network — e.g. a board acting as a `.dmsg` gateway for a home
+	// router's LAN. Only bind a non-loopback address on a trusted network.
+	ProxyAddr string `json:"proxy_addr,omitempty"`
 	// WebPort is the local HTTP bridge the SOCKS5 proxy rewrites
 	// matched hosts to. Default 8080.
 	WebPort uint `json:"web_port,omitempty"`
@@ -345,6 +350,11 @@ type SkynetWebConfig struct {
 	Enable bool `json:"enable"`
 	// ProxyPort is the local SOCKS5 listener. Default 4446.
 	ProxyPort uint `json:"proxy_port,omitempty"`
+	// ProxyAddr is the host the SOCKS5 proxy binds to. Empty = loopback
+	// ("127.0.0.1"). Set to "0.0.0.0" or a LAN IP to serve other devices on
+	// the network (a `.skynet` gateway for a home router's LAN). Only bind a
+	// non-loopback address on a trusted network.
+	ProxyAddr string `json:"proxy_addr,omitempty"`
 	// WebPort is the local HTTP bridge port. Default 8081.
 	WebPort uint `json:"web_port,omitempty"`
 	// DomainSuffix is the TLD treated as skynet addresses. Default ".skynet".


### PR DESCRIPTION
## Why
The embedded `.dmsg`/`.skynet` resolving proxies (`skywire cli resolver`) always bound `127.0.0.1`, so only the board itself could use them. To let a **board with a visor act as a `.dmsg` gateway for a home‑router LAN** (so any device reaches dmsg‑only deployment services — reward system, TPD, … — with no per‑device skywire install), the SOCKS5 listener needs to bind a LAN address.

## What
- `ProxyAddr` on the `dmsgweb`/`skynetweb` runtime configs → used at the listener (empty = loopback, unchanged default).
- `proxy_addr` on `DmsgWebConfig`/`SkynetWebConfig`, plumbed through the embedded proxies.
- Config‑gen flags:
  ```
  skywire cli config gen --dmsgweb --dmsgweb-addr 0.0.0.0 --skynetweb --skynetweb-addr 0.0.0.0
  ```

Verified end‑to‑end: the flag emits `"proxy_addr": "0.0.0.0"` and the proxy binds it. Loopback stays the default; a non‑loopback bind is opt‑in and documented as trusted‑network‑only.

Follow‑ups (separate): a runtime `resolver up --bind` toggle (RPC), the `DMSGWEBADDR` autoconfig `.conf` env, and a home‑router setup guide. Build/vet/lint pass.