### PR TITLE
feat(autoconfig): DMSGWEBADDR/SKYNETWEBADDR + rework LAN-gateway guide

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -218,6 +218,8 @@ const envfileLinux = `#
 
 #--	skynetweb upstream address the bridge listens on (host:port)
 #SKYNETWEBUPSTREAM=':8083'
+#DMSGWEBADDR='0.0.0.0'
+#SKYNETWEBADDR='0.0.0.0'
 
 #--	Autostart the skymail bridge (SMTP <-> skywire mail gateway). Off by default.
 #SKYMAILBRIDGE=false

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -207,6 +207,8 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	addBool("SKYNETWEB", "skynetweb", "no-skynetweb", autoconfigVals.Skynetweb, autoconfigVals.NoSkynetweb)
 	addString("DMSGWEBUPSTREAM", "dmsgweb-upstream", autoconfigVals.DmsgwebUpstream)
 	addString("SKYNETWEBUPSTREAM", "skynetweb-upstream", autoconfigVals.SkynetwebUpstream)
+	addString("DMSGWEBADDR", "dmsgweb-addr", autoconfigVals.DmsgwebAddr)
+	addString("SKYNETWEBADDR", "skynetweb-addr", autoconfigVals.SkynetwebAddr)
 
 	// Skychat
 	addBool("SKYCHAT", "skychat", "no-skychat", autoconfigVals.Skychat, autoconfigVals.NoSkychat)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -22,7 +22,7 @@ cobra subcommand tree.
 - [socks5.md](socks5.md) — Skywire SOCKS5 proxy client with `skywire cli proxy`
 - [skynet.md](skynet.md) — SkyNet P2P port forwarding with `skywire cli skynet`
 - [resolving-proxy.md](resolving-proxy.md) — the `.dmsg` / `.skynet` resolving SOCKS5 proxies (`skywire cli resolver`): reach visors and deployment services by public key over dmsg/skynet from a browser or `curl` — the supported way to view deployment-service data now that the CLI has no plain-HTTP fallback
-- [dmsg-home-router.md](dmsg-home-router.md) — turn one board with a visor into a `.dmsg` gateway for a whole home-router (OpenWRT / DD-WRT) LAN, so any device reaches dmsg-only deployment services with no per-device skywire install (`--dmsgweb-addr`)
+- [dmsg-lan-gateway.md](dmsg-lan-gateway.md) — turn one board with a visor into a `.dmsg` / `.skynet` gateway for your whole LAN (OpenWRT / DD-WRT), so any device reaches dmsg-only deployment services with no per-device skywire install (via `skywire autoconfig --dmsgweb-addr`)
 - [standalone-skychat.md](standalone-skychat.md) — `skywire app skychat --standalone --tcp-listen :PORT` for visor-independent chat-app with direct-TCP entry point; port-forwarding caveats
 - [standalone-dmsgpty-host.md](standalone-dmsgpty-host.md) — `skywire dmsg pty host --tcplisten :PORT` for visor-independent pty server with DMSG + TCP modes; port-forwarding caveats
 

--- a/docs/guides/dmsg-lan-gateway.md
+++ b/docs/guides/dmsg-lan-gateway.md
@@ -1,4 +1,4 @@
-# A `.dmsg` gateway for a home router (OpenWRT / DD-WRT)
+# A `.dmsg` / `.skynet` gateway for your LAN (OpenWRT / DD-WRT)
 
 Skywire's deployment services — the reward system, transport discovery, route
 finder, address resolver, uptime tracker — are reachable **only over dmsg**;
@@ -19,30 +19,34 @@ device**.
 
 ## 1. On the board — bind the resolver to the LAN
 
-Generate (or regenerate) the visor config with the resolver enabled and bound
-to all interfaces instead of loopback:
+Enable the resolver and bind it to all interfaces instead of loopback. On an
+installed Linux system, configure this through **`skywire autoconfig`** (which
+writes `skywire.conf`) — **not** a direct `config gen` or a hand-edit of
+`skywire.json`, because the next `skywire autoconfig` run regenerates
+`skywire.json` and would overwrite anything not backed by `skywire.conf`:
 
 ```
-skywire cli config gen --dmsgweb --dmsgweb-addr 0.0.0.0 \
-                       --skynetweb --skynetweb-addr 0.0.0.0 \
-                       -bo /opt/skywire/skywire.json
-sudo systemctl restart skywire
+sudo skywire autoconfig --dmsgweb   --dmsgweb-addr   0.0.0.0 \
+                        --skynetweb --skynetweb-addr 0.0.0.0
 ```
 
-`--dmsgweb-addr 0.0.0.0` binds the `.dmsg` SOCKS5 proxy on **port 4445** on every
-interface (`--skynetweb-addr` does the same for `.skynet` on 4446). You can bind
-a specific LAN IP instead of `0.0.0.0` if you prefer. On an installed system you
-can also set it via autoconfig:
+That writes `DMSGWEB=true`, `DMSGWEBADDR=0.0.0.0`, `SKYNETWEB=true`, and
+`SKYNETWEBADDR=0.0.0.0` into `skywire.conf`, regenerates `skywire.json` from it,
+and restarts the visor — so the setting **survives both a visor restart and
+future `autoconfig` runs**. `DMSGWEBADDR=0.0.0.0` binds the `.dmsg` SOCKS5 proxy
+on **port 4445** on every interface; `SKYNETWEBADDR` does the same for `.skynet`
+on 4446. Bind a specific LAN IP instead of `0.0.0.0` if you prefer.
+
+Equivalently, edit `skywire.conf` directly and re-run autoconfig:
 
 ```
-sudo skywire autoconfig --dmsgweb --skynetweb   # then edit proxy_addr, or use the flags above
+DMSGWEB=true
+DMSGWEBADDR='0.0.0.0'
+SKYNETWEB=true
+SKYNETWEBADDR='0.0.0.0'
 ```
-
-Or set it directly in `skywire.json`:
-
-```json
-"dmsgweb":   { "enable": true, "proxy_addr": "0.0.0.0" },
-"skynetweb": { "enable": true, "proxy_addr": "0.0.0.0" }
+```
+sudo skywire autoconfig
 ```
 
 Confirm it is listening on the LAN (replace `192.168.1.50` with the board's IP):

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -176,6 +176,8 @@ type Values struct {
 	NoSkynetweb       bool
 	DmsgwebUpstream   string // DMSGWEBUPSTREAM
 	SkynetwebUpstream string // SKYNETWEBUPSTREAM
+	DmsgwebAddr       string // DMSGWEBADDR
+	SkynetwebAddr     string // SKYNETWEBADDR
 
 	// --- Skychat ---
 	Skychat         bool
@@ -325,6 +327,8 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().BoolVar(&v.NoSkynetweb, "no-skynetweb", false, "disable embedded .skynet resolving SOCKS5 proxy — writes SKYNETWEB=false in skywire.conf")
 	cmd.Flags().StringVar(&v.DmsgwebUpstream, "dmsgweb-upstream", "", "upstream SOCKS5 for non-.dmsg traffic (empty chains to skynetweb) — writes DMSGWEBUPSTREAM in skywire.conf")
 	cmd.Flags().StringVar(&v.SkynetwebUpstream, "skynetweb-upstream", "", "upstream SOCKS5 for non-.skynet traffic — writes SKYNETWEBUPSTREAM in skywire.conf")
+	cmd.Flags().StringVar(&v.DmsgwebAddr, "dmsgweb-addr", "", "host the .dmsg SOCKS5 proxy binds to (empty=127.0.0.1; 0.0.0.0 or a LAN IP to serve the LAN) — writes DMSGWEBADDR in skywire.conf")
+	cmd.Flags().StringVar(&v.SkynetwebAddr, "skynetweb-addr", "", "host the .skynet SOCKS5 proxy binds to — writes SKYNETWEBADDR in skywire.conf")
 
 	// --- Skychat ---
 	cmd.Flags().BoolVar(&v.Skychat, "skychat", false, "autostart skychat — writes SKYCHAT=true in skywire.conf")
@@ -466,6 +470,8 @@ var envMap = map[string]EnvMapping{
 	"skynetweb":          {Key: "SKYNETWEB", Format: EnvFormatBool},
 	"no-skynetweb":       {Key: "SKYNETWEB", Format: EnvFormatBool, Negate: true},
 	"dmsgweb-upstream":   {Key: "DMSGWEBUPSTREAM", Format: EnvFormatString},
+	"dmsgweb-addr":       {Key: "DMSGWEBADDR", Format: EnvFormatString},
+	"skynetweb-addr":     {Key: "SKYNETWEBADDR", Format: EnvFormatString},
 	"skynetweb-upstream": {Key: "SKYNETWEBUPSTREAM", Format: EnvFormatString},
 
 	// Skychat


### PR DESCRIPTION
Adds `DMSGWEBADDR`/`SKYNETWEBADDR` to skywire.conf/autoconfig so the resolver's SOCKS5 LAN bind (#3572) is set the **autoconfig-safe** way:
```
sudo skywire autoconfig --dmsgweb --dmsgweb-addr 0.0.0.0 --skynetweb --skynetweb-addr 0.0.0.0
```
This survives a visor restart **and** future `skywire autoconfig` runs — unlike a direct `config gen`/`skywire.json` edit, which autoconfig overwrites on Linux. (`config gen` already reads `${DMSGWEBADDR}` from skywire.conf per #3572; this completes the chain.)

Reworks the LAN-gateway guide to instruct autoconfig/skywire.conf instead of `config gen`, renames `dmsg-home-router.md` → `dmsg-lan-gateway.md`, and retitles to '.dmsg / .skynet gateway for your LAN' (more accurate). Build/lint pass.