### PR TITLE
feat(resolver): `resolver up --bind <host>` to serve the LAN (persisted)

### DIFF
--- a/cmd/skywire-cli/commands/resolver/resolver.go
+++ b/cmd/skywire-cli/commands/resolver/resolver.go
@@ -42,12 +42,14 @@ var (
 	resolverSkynetOnly bool
 	resolverUpstream   string
 	resolverNoChain    bool
+	resolverBind       string
 )
 
 func init() {
 	upCmd.Flags().BoolVar(&resolverDmsgOnly, "dmsg-only", false, "only enable the .dmsg resolver")
 	upCmd.Flags().BoolVar(&resolverSkynetOnly, "skynet-only", false, "only enable the .skynet resolver")
 	upCmd.Flags().StringVar(&resolverUpstream, "upstream", "", "upstream SOCKS5 for non-matching traffic (e.g. 127.0.0.1:1080)")
+	upCmd.Flags().StringVar(&resolverBind, "bind", "", "SOCKS5 bind host, persisted (e.g. 0.0.0.0 or a LAN IP to serve the LAN; empty = loopback)")
 	upCmd.Flags().BoolVar(&resolverNoChain, "no-chain", false, "skip the dmsgweb→skynetweb auto-chain even when both resolvers are up")
 	upCmd.MarkFlagsMutuallyExclusive("dmsg-only", "skynet-only")
 
@@ -125,6 +127,22 @@ different flags update the upstream.`,
 			}
 		}
 
+		// Bind host (persisted). Empty leaves the resolver on loopback.
+		// A LAN IP or 0.0.0.0 makes the resolver reachable from the LAN and
+		// survives a restart (the visor re-reads the persisted proxy_addr).
+		if resolverBind != "" {
+			if wantDmsg {
+				if err := rpcClient.SetEmbeddedProxyBind("dmsg", resolverBind); err != nil {
+					internal.PrintFatalError(cmd.Flags(), fmt.Errorf("bind dmsg resolver: %w", err))
+				}
+			}
+			if wantSkynet {
+				if err := rpcClient.SetEmbeddedProxyBind("skynet", resolverBind); err != nil {
+					internal.PrintFatalError(cmd.Flags(), fmt.Errorf("bind skynet resolver: %w", err))
+				}
+			}
+		}
+
 		// Wire upstream and the auto-chain. If both resolvers are up
 		// and the user didn't explicitly opt out, chain dmsgweb to
 		// skynetweb (so .skynet still resolves through the same
@@ -151,6 +169,9 @@ different flags update the upstream.`,
 
 		var msg strings.Builder
 		msg.WriteString("Resolver up.\n")
+		if resolverBind != "" {
+			fmt.Fprintf(&msg, "  bind:     %s (persisted; reachable from the LAN)\n", resolverBind)
+		}
 		if resolverUpstream != "" {
 			fmt.Fprintf(&msg, "  upstream: %s\n", resolverUpstream)
 		}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -326,6 +326,7 @@ type API interface {
 	// reverts to the config's Enable flag.
 	SetEmbeddedProxyEnabled(kind string, enable bool) error
 	SetEmbeddedProxyUpstream(kind, addr string) error
+	SetEmbeddedProxyBind(kind, addr string) error
 	ResetRouteSetupStats() error
 
 	TPSExternalHealthCheck(tpsPK cipher.PubKey) error

--- a/pkg/visor/api_proxies.go
+++ b/pkg/visor/api_proxies.go
@@ -189,6 +189,53 @@ func (v *Visor) SetEmbeddedProxyUpstream(kind, addr string) error {
 	}
 }
 
+// SetEmbeddedProxyBind changes the SOCKS5 bind host for a resolving proxy at
+// runtime AND persists it (proxy_addr + enable) to the visor config, so it
+// survives a restart — the way to make a board a `.dmsg`/`.skynet` LAN gateway
+// without a config-file edit. Pass "" for loopback (the default) or
+// "0.0.0.0"/a LAN IP to serve the LAN. Note: a subsequent `skywire autoconfig`
+// regenerates the config from skywire.conf and would reset this; on
+// autoconfig-managed hosts, set DMSGWEBADDR in skywire.conf instead.
+func (v *Visor) SetEmbeddedProxyBind(kind, addr string) error {
+	if v == nil {
+		return fmt.Errorf("visor not initialized")
+	}
+	switch kind {
+	case "dmsg", "dmsgweb", "dmsg_web":
+		v.initLock.Lock()
+		runtime := v.embeddedDmsgWeb
+		if v.conf.DmsgWeb == nil {
+			v.conf.DmsgWeb = &visorconfig.DmsgWebConfig{}
+		}
+		v.conf.DmsgWeb.Enable = true
+		v.conf.DmsgWeb.ProxyAddr = addr
+		v.initLock.Unlock()
+		if runtime != nil {
+			if err := runtime.SetBind(addr); err != nil {
+				return err
+			}
+		}
+		return v.conf.Flush()
+	case "skynet", "skynetweb", "skynet_web":
+		v.initLock.Lock()
+		runtime := v.embeddedSkynetWeb
+		if v.conf.SkynetWeb == nil {
+			v.conf.SkynetWeb = &visorconfig.SkynetWebConfig{}
+		}
+		v.conf.SkynetWeb.Enable = true
+		v.conf.SkynetWeb.ProxyAddr = addr
+		v.initLock.Unlock()
+		if runtime != nil {
+			if err := runtime.SetBind(addr); err != nil {
+				return err
+			}
+		}
+		return v.conf.Flush()
+	default:
+		return fmt.Errorf("unknown proxy kind %q (want \"dmsg\" or \"skynet\")", kind)
+	}
+}
+
 func dmsgProxyInfo(cfg *visorconfig.DmsgWebConfig, runtime *EmbeddedDmsgWeb) *EmbeddedProxyInfo {
 	info := &EmbeddedProxyInfo{
 		Enabled:       cfg.Enable,

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -181,6 +181,23 @@ func (e *EmbeddedDmsgWeb) SetUpstream(addr string) error {
 	return nil
 }
 
+// SetBind changes the SOCKS5 bind host and restarts the resolver so it takes
+// effect immediately. "" = loopback (default); "0.0.0.0"/a LAN IP serves the LAN.
+func (e *EmbeddedDmsgWeb) SetBind(addr string) error {
+	e.mu.Lock()
+	e.cfg.ProxyAddr = addr
+	wasRunning := e.running
+	e.mu.Unlock()
+
+	if wasRunning {
+		if err := e.Stop(); err != nil {
+			return fmt.Errorf("stop before bind change: %w", err)
+		}
+		return e.Start()
+	}
+	return nil
+}
+
 // Upstream returns the current upstream SOCKS5 address.
 func (e *EmbeddedDmsgWeb) Upstream() string {
 	e.mu.Lock()

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -151,6 +151,23 @@ func (e *EmbeddedSkynetWeb) SetUpstream(addr string) error {
 	return nil
 }
 
+// SetBind changes the SOCKS5 bind host and restarts the resolver so it takes
+// effect immediately. "" = loopback (default); "0.0.0.0"/a LAN IP serves the LAN.
+func (e *EmbeddedSkynetWeb) SetBind(addr string) error {
+	e.mu.Lock()
+	e.cfg.ProxyAddr = addr
+	wasRunning := e.running
+	e.mu.Unlock()
+
+	if wasRunning {
+		if err := e.Stop(); err != nil {
+			return fmt.Errorf("stop before bind change: %w", err)
+		}
+		return e.Start()
+	}
+	return nil
+}
+
 // Upstream returns the current upstream SOCKS5 address.
 func (e *EmbeddedSkynetWeb) Upstream() string {
 	e.mu.Lock()

--- a/pkg/visor/proxied_visor_api.go
+++ b/pkg/visor/proxied_visor_api.go
@@ -263,6 +263,10 @@ func (p *proxiedVisorAPI) SetEmbeddedProxyUpstream(kind, addr string) error {
 	return p.hvAPI.HVSetEmbeddedProxyUpstream(p.targetPK, kind, addr)
 }
 
+func (p *proxiedVisorAPI) SetEmbeddedProxyBind(_, _ string) error {
+	return ErrProxyNotSupported
+}
+
 func (p *proxiedVisorAPI) ListTCPPorts() ([]int, error) {
 	return p.hvAPI.HVListTCPPorts(p.targetPK)
 }

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -934,6 +934,10 @@ func (proxyDefaultAPI) SetEmbeddedProxyUpstream(_ string, _ string) error {
 	return ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) SetEmbeddedProxyBind(_ string, _ string) error {
+	return ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) ResetRouteSetupStats() error {
 	return ErrProxyNotSupported
 }

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -334,6 +334,11 @@ type SetEmbeddedProxyUpstreamRequest struct {
 	Kind string
 	Addr string // upstream SOCKS5 address, "" to clear
 }
+
+type SetEmbeddedProxyBindRequest struct {
+	Kind string
+	Addr string // SOCKS5 bind host, "" = loopback
+}
 type DmsgProbeRequest struct {
 	PK   cipher.PubKey
 	Port uint16

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1387,6 +1387,13 @@ func (rc *rpcClient) SetEmbeddedProxyUpstream(kind, addr string) error {
 		&struct{}{})
 }
 
+// SetEmbeddedProxyBind sets a resolver's SOCKS5 bind host at runtime (persisted).
+func (rc *rpcClient) SetEmbeddedProxyBind(kind, addr string) error {
+	return rc.Call("SetEmbeddedProxyBind",
+		&SetEmbeddedProxyBindRequest{Kind: kind, Addr: addr},
+		&struct{}{})
+}
+
 // DmsgHTTP performs an HTTP request over dmsg using the visor's dmsg client.
 func (rc *rpcClient) DmsgHTTP(req DmsgHTTPRequest) (*DmsgHTTPResponse, error) {
 	var resp DmsgHTTPResponse

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1191,6 +1191,11 @@ func (mc *mockRPCClient) SetEmbeddedProxyUpstream(_, _ string) error {
 	return nil
 }
 
+// SetEmbeddedProxyBind implements API.
+func (mc *mockRPCClient) SetEmbeddedProxyBind(_, _ string) error {
+	return nil
+}
+
 // SkynetHTTP implements API.
 func (mc *mockRPCClient) SkynetHTTP(_ SkynetHTTPRequest) (*SkynetHTTPResponse, error) {
 	return &SkynetHTTPResponse{StatusCode: 200, Status: "OK"}, nil

--- a/pkg/visor/rpc_proxies.go
+++ b/pkg/visor/rpc_proxies.go
@@ -65,3 +65,12 @@ func (r *RPC) SetEmbeddedProxyUpstream(req *SetEmbeddedProxyUpstreamRequest, _ *
 	}
 	return r.visor.SetEmbeddedProxyUpstream(req.Kind, req.Addr)
 }
+
+// SetEmbeddedProxyBind sets a resolver's SOCKS5 bind host (and persists it).
+func (r *RPC) SetEmbeddedProxyBind(req *SetEmbeddedProxyBindRequest, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "SetEmbeddedProxyBind", req)(nil, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	return r.visor.SetEmbeddedProxyBind(req.Kind, req.Addr)
+}


### PR DESCRIPTION
## What

Adds a `--bind` flag to `skywire cli resolver up` that sets the SOCKS5 bind host of the embedded `.dmsg` / `.skynet` resolving proxies **at runtime** and **persists it**, so a LAN-reachable bind survives a visor restart.

```
skywire cli resolver up --bind 0.0.0.0        # serve every interface
skywire cli resolver up --bind 192.168.1.50   # serve one LAN IP
```

## Why

The embedded resolvers bind `127.0.0.1` by default, so only the board they run on can use them. To use one board as a `.dmsg` gateway for a LAN (see `docs/guides/dmsg-lan-gateway.md`), the SOCKS5 listener has to bind a LAN address — and that has to *persist*, or a restart silently drops the LAN back to loopback-only.

`resolver up` previously did **not** persist anything (no `Flush()`); the resolver only autostarts when `DmsgWeb.Enable == true` in the config. `--bind` now sets `Enable = true` + `proxy_addr = <host>` and flushes `skywire.json`, and re-applies the bind to the already-running resolver via `Embedded{Dmsg,Skynet}Web.SetBind`.

## Surface

`SetEmbeddedProxyBind(kind, addr string) error` wired through api / rpc / rpc_proxies / rpc_client / mock / proxied / default. The proxied (HV-remote) and default stubs return `ErrProxyNotSupported` — bind is a local, on-board operation.

## Relation to #3576

Complements the `DMSGWEBADDR` / `SKYNETWEBADDR` autoconfig knobs: use `--bind` on a running visor you configure by hand; use `skywire.conf` on autoconfig-managed hosts (where `autoconfig` would otherwise regenerate `skywire.json` and reset a hand-set bind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)