### PR TITLE
feat(vpn-router): `--mesh-gateway-only` — transparent .dmsg/.skynet for a LAN behind an existing router

### DIFF
--- a/cmd/apps/vpn-router/commands/meshgw_linux.go
+++ b/cmd/apps/vpn-router/commands/meshgw_linux.go
@@ -1,0 +1,51 @@
+//go:build linux
+// +build linux
+
+// Package commands cmd/apps/vpn-router/commands/meshgw_linux.go c4-app-vpn
+package commands
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/vpn"
+	"github.com/skycoin/skywire/pkg/vpnrouter/meshgw"
+)
+
+// runMeshGatewayOnly builds a standalone mesh-gateway config from the parsed
+// flags and runs it until ctx is canceled. Linux-only: the transparent proxy +
+// REDIRECT need netfilter.
+func runMeshGatewayOnly(ctx context.Context, dial meshgw.MeshDial, logger logrus.FieldLogger) error {
+	if lanIfc == "" {
+		return fmt.Errorf("--mesh-gateway-only needs --lan-ifc (the interface LAN traffic arrives on)")
+	}
+	cfg := vpn.MeshGatewayConfig{
+		LANInterface: lanIfc,
+		DNSPort:      meshDNSPort,
+		CIDR:         meshGWCIDR,
+		MeshDial:     dial,
+	}
+	if meshBind != "" {
+		if cfg.BindIP = net.ParseIP(meshBind); cfg.BindIP == nil {
+			return fmt.Errorf("invalid --mesh-bind %q", meshBind)
+		}
+	}
+	if len(meshAliases) > 0 {
+		aliases, err := vpn.ParseMeshAliases(meshAliases)
+		if err != nil {
+			return err
+		}
+		cfg.Aliases = aliases
+	}
+	if meshTLS {
+		minter, err := vpn.LoadOrCreateMeshCA(meshCACert, meshCAKey, defaultMeshCADir)
+		if err != nil {
+			return err
+		}
+		cfg.TLSMinter = minter
+	}
+	return vpn.RunMeshGatewayOnly(ctx, cfg, logger)
+}

--- a/cmd/apps/vpn-router/commands/meshgw_other.go
+++ b/cmd/apps/vpn-router/commands/meshgw_other.go
@@ -1,0 +1,20 @@
+//go:build !linux
+// +build !linux
+
+// Package commands cmd/apps/vpn-router/commands/meshgw_other.go c4-app-vpn
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/vpnrouter/meshgw"
+)
+
+// runMeshGatewayOnly is Linux-only (needs netfilter). On other platforms it
+// returns a clear error so the app still builds everywhere.
+func runMeshGatewayOnly(_ context.Context, _ meshgw.MeshDial, _ logrus.FieldLogger) error {
+	return fmt.Errorf("--mesh-gateway-only is only supported on Linux")
+}

--- a/cmd/apps/vpn-router/commands/vpn-router.go
+++ b/cmd/apps/vpn-router/commands/vpn-router.go
@@ -28,27 +28,30 @@ import (
 )
 
 var (
-	lanIfc      string
-	tunIfc      string
-	subnetCIDR  string
-	dhcpStart   string
-	dhcpEnd     string
-	dnsAddr     string
-	leaseTime   string
-	wifi        bool
-	ssid        string
-	passphrase  string
-	band        string
-	channel     int
-	country     string
-	openWiFi    bool
-	meshGateway bool
-	meshGWCIDR  string
-	meshTLS     bool
-	meshCACert  string
-	meshCAKey   string
-	meshAliases []string
-	appPort     uint16
+	lanIfc          string
+	tunIfc          string
+	subnetCIDR      string
+	dhcpStart       string
+	dhcpEnd         string
+	dnsAddr         string
+	leaseTime       string
+	wifi            bool
+	ssid            string
+	passphrase      string
+	band            string
+	channel         int
+	country         string
+	openWiFi        bool
+	meshGateway     bool
+	meshGatewayOnly bool
+	meshGWCIDR      string
+	meshBind        string
+	meshDNSPort     int
+	meshTLS         bool
+	meshCACert      string
+	meshCAKey       string
+	meshAliases     []string
+	appPort         uint16
 )
 
 // defaultMeshCADir is where the mesh gateway persists its self-generated CA so
@@ -74,7 +77,10 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&country, "country", "US", "WiFi regulatory country code (with --wifi)")
 	fs.BoolVar(&openWiFi, "open", false, "allow an open (passphrase-less) WiFi network")
 	fs.BoolVar(&meshGateway, "mesh-gateway", false, "mesh gateway: resolve *.dmsg / *.skynet for downstream clients and proxy them over the mesh (visor-launched only)")
+	fs.BoolVar(&meshGatewayOnly, "mesh-gateway-only", false, "standalone mesh gateway: ONLY serve *.dmsg / *.skynet DNS + transparent proxy for the LAN (no DHCP / NAT / tunnel) — for a board behind an existing OpenWRT/DD-WRT router (visor-launched only)")
 	fs.StringVar(&meshGWCIDR, "mesh-gateway-cidr", "", "synthetic-IP pool the mesh gateway leases from (empty = 100.64.0.0/16)")
+	fs.StringVar(&meshBind, "mesh-bind", "", "standalone mesh gateway: address the DNS + transparent proxy bind (empty = 0.0.0.0)")
+	fs.IntVar(&meshDNSPort, "mesh-dns-port", 53, "standalone mesh gateway: DNS port the upstream router forwards .dmsg/.skynet to")
 	fs.BoolVar(&meshTLS, "mesh-gateway-tls", false, "mesh gateway: TLS-MITM HTTPS to *.dmsg/*.skynet with a self-generated CA (LAN clients must trust it)")
 	fs.StringVar(&meshCACert, "mesh-gateway-ca", "", "mesh-gateway CA cert path (empty = <local>/mesh-gateway-ca/ca.pem; generated if absent)")
 	fs.StringVar(&meshCAKey, "mesh-gateway-ca-key", "", "mesh-gateway CA key path (empty = <local>/mesh-gateway-ca/ca.key)")
@@ -146,6 +152,19 @@ func RunVPNRouter(ctx context.Context, args []string) error {
 	bi := buildinfo.Get()
 	logger.Infof("Version %q built on %q against commit %q", bi.Version, bi.Date, bi.Commit)
 
+	// Standalone mesh-gateway mode: serve .dmsg/.skynet DNS + transparent proxy
+	// for the LAN only, with no DHCP/NAT/tunnel. Runs behind an existing router.
+	if meshGatewayOnly {
+		setAppStatus(appCl, logger, appserver.AppDetailedStatusRunning)
+		defer setAppStatus(appCl, logger, appserver.AppDetailedStatusStopped)
+		if err := runMeshGatewayOnly(ctx, vpn.MeshDialer(appCl), logger); err != nil {
+			logger.WithError(err).Error("standalone mesh gateway exited with error")
+			setAppErr(appCl, logger, err)
+			return err
+		}
+		return nil
+	}
+
 	cfg, err := buildRouterConfig(vpn.MeshDialer(appCl))
 	if err != nil {
 		logger.WithError(err).Error("invalid vpn-router configuration")
@@ -178,6 +197,13 @@ func RunVPNRouter(ctx context.Context, args []string) error {
 func runStandalone(ctx context.Context) error {
 	logger := logrus.New()
 	logger.SetOutput(os.Stderr)
+
+	// The mesh gateway (full or standalone) dials the mesh through the visor's
+	// app-server, which a directly-invoked binary doesn't have. Fail clearly
+	// rather than silently degrading to a plain (no-mesh) router.
+	if meshGatewayOnly || meshGateway {
+		return fmt.Errorf("--mesh-gateway / --mesh-gateway-only need the visor app-server to dial the mesh; launch vpn-router from a visor, not directly")
+	}
 
 	// Standalone has no visor app-server, so no mesh dialer (nil). buildRouterConfig
 	// rejects --mesh-gateway here with a clear error.

--- a/pkg/vpn/mesh_gateway_standalone_linux.go
+++ b/pkg/vpn/mesh_gateway_standalone_linux.go
@@ -1,0 +1,188 @@
+//go:build linux
+// +build linux
+
+// Package vpn pkg/vpn/mesh_gateway_standalone_linux.go c4-app-vpn
+//
+// Standalone mesh gateway: the mesh-name resolver + transparent proxy of the
+// full vpn-router (setupMeshGateway), but WITHOUT taking over the LAN. It runs
+// no DHCP, assigns no address, brings up no tunnel — it only serves `.dmsg` /
+// `.skynet` DNS and REDIRECTs synthetic-pool TCP into the mesh.
+//
+// This is the "board behind your existing router" topology: a small appliance
+// on the LAN gives every other device transparent, zero-per-device access to
+// dmsg/skynet by name, while the household's own OpenWRT / DD-WRT router keeps
+// doing DHCP and the default route. Two router-side settings wire it up:
+//
+//   - DNS forward:  `.dmsg` / `.skynet` queries → this board's DNS (below).
+//   - static route: the synthetic pool (default 100.64.0.0/16) → this board.
+//
+// A LAN client then resolves `reward.dmsg` via the router → this board's DNS →
+// a synthetic IP; its packets to that IP are static-routed here; PREROUTING
+// REDIRECT lands them on the transparent proxy, which reads SO_ORIGINAL_DST and
+// dials the encoded PK over the mesh (bypassing any VPN tunnel). Same mechanism
+// as setupMeshGateway, minus the router role — see meshgw and router_linux.go.
+package vpn
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	miekgdns "github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skynetca"
+	"github.com/skycoin/skywire/pkg/vpn/netctl"
+	"github.com/skycoin/skywire/pkg/vpnrouter/meshgw"
+)
+
+// defaultMeshGatewayDNSPort is the port the standalone gateway's DNS listens on.
+// The upstream router forwards `.dmsg` / `.skynet` queries here; 53 is the
+// natural default (dnsmasq's `server=/dmsg/<board>` forwards to :53), but a
+// board already running a resolver on 53 can pick another and tell the router.
+const defaultMeshGatewayDNSPort = 53
+
+// MeshGatewayConfig configures a standalone mesh gateway (RunMeshGatewayOnly).
+type MeshGatewayConfig struct {
+	// LANInterface is the interface LAN traffic arrives on — the `iif` the
+	// PREROUTING REDIRECT matches. Required: the REDIRECT must be pinned to the
+	// downstream link so it never catches the board's own upstream traffic.
+	LANInterface string
+
+	// BindIP is the address the DNS server and transparent proxy listen on.
+	// Nil / unspecified = all interfaces (0.0.0.0). Set it to the board's LAN IP
+	// to avoid exposing DNS on other interfaces.
+	BindIP net.IP
+
+	// DNSPort is the mesh-name DNS port. 0 = defaultMeshGatewayDNSPort (53).
+	DNSPort int
+
+	// CIDR is the synthetic-IP pool leased to `.dmsg` / `.skynet` names. Empty =
+	// defaultMeshGatewayCIDR (100.64.0.0/16). This is the range the upstream
+	// router must static-route to this board.
+	CIDR string
+
+	// MeshDial dials the mesh for a resolved (scheme, pk, port). Required — from
+	// the vpn-router app it is vpn.MeshDialer(appClient).
+	MeshDial meshgw.MeshDial
+
+	// Aliases (optional) maps friendly names → PK for names that aren't a raw PK.
+	Aliases map[string]cipher.PubKey
+
+	// TLSMinter (optional) enables TLS-MITM for HTTPS to `.dmsg` / `.skynet`
+	// (port 443). LAN clients must trust the minter's CA.
+	TLSMinter skynetca.LeafMinter
+}
+
+func (c MeshGatewayConfig) dnsPort() int {
+	if c.DNSPort == 0 {
+		return defaultMeshGatewayDNSPort
+	}
+	return c.DNSPort
+}
+
+func (c MeshGatewayConfig) bindHost() string {
+	if c.BindIP == nil {
+		return "0.0.0.0"
+	}
+	return c.BindIP.String()
+}
+
+// RunMeshGatewayOnly runs a standalone mesh gateway until ctx is canceled, then
+// tears its state (firewall REDIRECT + IPv4 forwarding) back down. It reuses the
+// same firewall backend (iptables, or nftables under -tags nftfw) and meshgw
+// engine as the full router; it just skips the DHCP/DNS-server-owns-the-LAN,
+// interface, WiFi, and tunnel-NAT roles.
+func RunMeshGatewayOnly(ctx context.Context, cfg MeshGatewayConfig, log logrus.FieldLogger) error {
+	if log == nil {
+		log = logrus.New()
+	}
+	if cfg.LANInterface == "" {
+		return fmt.Errorf("mesh gateway: LAN interface is required (the REDIRECT iif)")
+	}
+	if cfg.MeshDial == nil {
+		return fmt.Errorf("mesh gateway: MeshDial is required")
+	}
+
+	gw, err := meshgw.New(cfg.MeshDial, cfg.CIDR, cfg.Aliases, log)
+	if err != nil {
+		return fmt.Errorf("mesh gateway: %w", err)
+	}
+	if cfg.TLSMinter != nil {
+		gw.EnableTLSMITM(cfg.TLSMinter, 443)
+		log.Info("mesh gateway: TLS-MITM on (HTTPS to *.dmsg/*.skynet; clients must trust the CA)")
+	}
+
+	// Forwarded LAN traffic transits this board, so IPv4 forwarding must be on.
+	// Save the prior value and restore it on teardown so we don't silently leave
+	// a box forwarding that wasn't before.
+	prevForwarding, ferr := netctl.GetIPv4Forwarding()
+	if ferr != nil {
+		log.WithError(ferr).Warn("mesh gateway: could not read net.ipv4.ip_forward (continuing)")
+	} else if err := netctl.SetIPv4Forwarding("1"); err != nil {
+		return fmt.Errorf("mesh gateway: enable IPv4 forwarding: %w", err)
+	}
+	defer func() {
+		if ferr == nil && prevForwarding != "1" {
+			if err := netctl.SetIPv4Forwarding(prevForwarding); err != nil {
+				log.WithError(err).Warn("mesh gateway: could not restore net.ipv4.ip_forward")
+			}
+		}
+	}()
+
+	fw, err := newFirewall(log)
+	if err != nil {
+		return fmt.Errorf("mesh gateway: firewall backend: %w", err)
+	}
+	defer fw.teardown()
+
+	// Transparent proxy: bind all interfaces on an ephemeral port; REDIRECT is
+	// pinned to whatever we get. SO_ORIGINAL_DST recovers the synthetic IP
+	// regardless of bind address.
+	lis, err := net.Listen("tcp", net.JoinHostPort("0.0.0.0", "0"))
+	if err != nil {
+		return fmt.Errorf("mesh gateway: transparent proxy listen: %w", err)
+	}
+	defer lis.Close() //nolint:errcheck // best-effort close on shutdown
+	port := lis.Addr().(*net.TCPAddr).Port
+	go func() {
+		if err := gw.ServeTransparent(ctx, lis); err != nil && ctx.Err() == nil {
+			log.WithError(err).Error("mesh gateway transparent proxy exited")
+		}
+	}()
+
+	if err := fw.redirectTCP(fwPrerouting, cfg.LANInterface, gw.PoolCIDR(), uint16(port)); err != nil { //nolint:gosec // ephemeral port fits uint16
+		return fmt.Errorf("mesh gateway: REDIRECT: %w", err)
+	}
+
+	// DNS: a bare mux with only the `.dmsg` / `.skynet` zones. Everything else is
+	// REFUSED — this resolver is meant to sit BEHIND the LAN's real resolver,
+	// which forwards just those two zones here.
+	mux := miekgdns.NewServeMux()
+	gw.InstallDNS(mux)
+	dnsAddr := net.JoinHostPort(cfg.bindHost(), strconv.Itoa(cfg.dnsPort()))
+	dnsErr := make(chan error, 2)
+	for _, network := range []string{"udp", "tcp"} {
+		s := &miekgdns.Server{Addr: dnsAddr, Net: network, Handler: mux}
+		go func() { dnsErr <- s.ListenAndServe() }()
+		go func() { <-ctx.Done(); _ = s.Shutdown() }() //nolint:errcheck // best-effort shutdown
+	}
+
+	log.Infof("mesh gateway (standalone): DNS %s serves *.dmsg/*.skynet → synthetic %s → proxy :%d (dials over mesh)",
+		dnsAddr, gw.PoolCIDR().String(), port)
+	log.Infof("mesh gateway: on the LAN router, forward .dmsg/.skynet DNS to %s:%d and static-route %s to this board",
+		cfg.bindHost(), cfg.dnsPort(), gw.PoolCIDR().String())
+
+	select {
+	case <-ctx.Done():
+		log.Info("mesh gateway shutting down")
+		return nil
+	case err := <-dnsErr:
+		if ctx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("mesh gateway: DNS server exited: %w", err)
+	}
+}

--- a/pkg/vpn/mesh_gateway_standalone_linux_test.go
+++ b/pkg/vpn/mesh_gateway_standalone_linux_test.go
@@ -1,0 +1,48 @@
+//go:build linux
+// +build linux
+
+// Package vpn pkg/vpn/mesh_gateway_standalone_linux_test.go c4-app-vpn
+package vpn
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestMeshGatewayConfigDefaults(t *testing.T) {
+	// Zero DNSPort → 53; zero BindIP → 0.0.0.0.
+	var c MeshGatewayConfig
+	if got := c.dnsPort(); got != defaultMeshGatewayDNSPort {
+		t.Errorf("dnsPort() = %d; want %d", got, defaultMeshGatewayDNSPort)
+	}
+	if got := c.bindHost(); got != "0.0.0.0" {
+		t.Errorf("bindHost() = %q; want 0.0.0.0", got)
+	}
+
+	// Explicit values are preserved.
+	c = MeshGatewayConfig{DNSPort: 5353, BindIP: net.ParseIP("192.168.1.50")}
+	if got := c.dnsPort(); got != 5353 {
+		t.Errorf("dnsPort() = %d; want 5353", got)
+	}
+	if got := c.bindHost(); got != "192.168.1.50" {
+		t.Errorf("bindHost() = %q; want 192.168.1.50", got)
+	}
+}
+
+// The two pre-flight checks fire before any privileged (netfilter / sysctl)
+// operation, so they are safe to assert without root.
+func TestRunMeshGatewayOnlyPreflight(t *testing.T) {
+	okDial := func(_ context.Context, _ string, _ cipher.PubKey, _ uint16) (net.Conn, error) {
+		return nil, nil //nolint:nilnil // never called in these error paths
+	}
+
+	if err := RunMeshGatewayOnly(context.Background(), MeshGatewayConfig{MeshDial: okDial}, nil); err == nil {
+		t.Error("expected error when LANInterface is empty")
+	}
+	if err := RunMeshGatewayOnly(context.Background(), MeshGatewayConfig{LANInterface: "eth0"}, nil); err == nil {
+		t.Error("expected error when MeshDial is nil")
+	}
+}


### PR DESCRIPTION
## What

A new `--mesh-gateway-only` mode for the `vpn-router` app: run **only** the mesh-name resolver + transparent proxy for the LAN, with **no DHCP, no address assignment, no WiFi, no tunnel NAT**.

```
# on a board that sits behind the household's existing OpenWRT/DD-WRT router:
vpn-router --mesh-gateway-only --lan-ifc eth0
```

## Why

The mesh gateway (DNS hands `*.dmsg`/`*.skynet` a synthetic IP → PREROUTING REDIRECT → transparent proxy reads `SO_ORIGINAL_DST` → dials the PK over the mesh) already gives LAN devices **zero-per-device, zero-per-app** access to dmsg/skynet by name. But it only existed inside the full `vpn-router`, which takes over the LAN (DHCP + NAT + tunnel). That fits a board that **is** the router/AP — not a small appliance behind a household's existing router.

This is the difference users hit with the SOCKS5 resolving-proxy path (`docs/guides/dmsg-lan-gateway.md`): SOCKS5 is inherently per-application (the client must speak SOCKS and pass the hostname in-band), so it can never be transparent. Transparent `.dmsg` for *any* LAN device requires this DNS-synthesis + REDIRECT mechanism.

## Topology it enables

The household router keeps DHCP and the default route; **two router-side settings** wire the board in — both supported on OpenWRT *and* DD-WRT:

1. **DNS forward:** `.dmsg` / `.skynet` queries → the board's DNS (`server=/dmsg/<board>` in dnsmasq).
2. **Static route:** the synthetic pool (`100.64.0.0/16`) → the board.

A LAN client then resolves `reward.dmsg` through its normal resolver → the board → a synthetic IP; packets to that IP are static-routed to the board; PREROUTING REDIRECT lands them on the transparent proxy, which dials the encoded PK over the mesh. No per-device configuration anywhere.

## Implementation

`vpn.RunMeshGatewayOnly` reuses the **exact** firewall backend (iptables, or nftables under `-tags nftfw`) and `meshgw` engine as the full router. The REDIRECT→`SO_ORIGINAL_DST`→dial core is already netns-validated (`meshgwint`). New here is only the standalone lifecycle:

- enable IPv4 forwarding (and restore the prior value on teardown),
- bind the mesh-name DNS zones on a configurable addr/port (default `0.0.0.0:53`),
- flag wiring on the app (Linux; a clear error on other platforms).

`--mesh-bind` / `--mesh-dns-port` tune the listener; `--mesh-gateway-cidr` / `--mesh-alias` / `--mesh-gateway-tls` carry over from the full gateway.

Unit tests cover config defaulting + pre-flight validation; the netfilter data path is covered by the existing `meshgwint` netns test for the shared core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)