### PR TITLE
fix(cxo): lower MaxFillingTime default 10m → 2m

### DIFF
--- a/pkg/cxo/node/config.go
+++ b/pkg/cxo/node/config.go
@@ -17,7 +17,7 @@ const (
 	Prefix                string        = "[node] "
 	MaxConnections        int           = 1000 * 1000
 	MaxPendingConnections int           = 1000
-	MaxFillingTime        time.Duration = 10 * time.Minute
+	MaxFillingTime        time.Duration = 2 * time.Minute
 	MaxHeads              int           = 10
 	ListenTCP             string        = ":8870"
 	ListenUDP             string        = "" // don't listen
@@ -137,7 +137,15 @@ type Config struct {
 	// MaxHeads is limit of heads per feed.
 	MaxHeads int
 
-	// MaxFillingTime is time limit for filling of a Root object.
+	// MaxFillingTime is the time limit for filling of a Root object. A fill
+	// still running after this long is treated as a broken peer and aborted
+	// with ErrTimeout (the Root refills when the publisher republishes). The
+	// default was 10m, which is pathologically generous — a healthy tree fill
+	// completes in seconds, and a fill hung that long pins all its "wanted"
+	// objects in the cache (which cleanDown skips) for the whole window. That
+	// was the residual TPD aggregator leak (#3562/#3569); 2m keeps ~20-40x
+	// margin over a healthy fill while capping hung fills. The TPD aggregator
+	// pins its own tighter 90s override on top of this.
 	MaxFillingTime time.Duration
 
 	// RPC is RPC listening address. Empty string disables RPC.


### PR DESCRIPTION
## What

Lower the CXO node's default `MaxFillingTime` from **10 minutes** to **2 minutes** (`pkg/cxo/node/config.go`).

## Why

A healthy Root (transport-tree) fill completes in seconds. A fill still running after minutes is a broken/flapping peer, not a slow one — and for the whole timeout window it pins every "wanted" object of that fill in the in-memory cache (`cleanDown` skips filling objects, so the LRU can't evict them). With many unstable peers, that standing pool of hung-fill memory was the residual TPD-aggregator leak behind #3562.

#3562 worked around it by pinning the **aggregator's** own `MaxFillingTime` to 90s locally, but the **shared** node default stayed 10m for every other CXO node (the deployment publishers, any visor). This is the deferred follow-up (#3569): now that the 90s aggregator override has been observed healthy in production, bring the shared default down too.

## Why 2m (not 90s)

2m is still ~20–40× a healthy fill, leaving ample margin for a legitimately slow fill over a congested mesh path (which simply refills on the next publish), while eliminating the minutes-of-pinned-memory-per-hung-peer pathology. The TPD aggregator keeps its tighter 90s override on top of this — its behavior is unchanged.

Follow-up to #3561 / #3562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)