### PR TITLE
fix(servicedisc): register visor geo LIVE so it isn't lost to the async-lookup race

### DIFF
--- a/pkg/app/appdisc/factory.go
+++ b/pkg/app/appdisc/factory.go
@@ -32,6 +32,12 @@ type Factory struct {
 	ClientPublicIP    string
 	HeartbeatInterval time.Duration // Interval for service discovery heartbeats
 	Geo               any           // *geo.LocationData on native builds; visor geolocation in service entries
+	// GeoFunc, when set, is a `func() *geo.LocationData` that returns the visor's
+	// CURRENT geolocation. It is preferred over Geo so a heartbeat picks up the
+	// geo once the async public-IP/geo lookup finishes — Geo alone was a nil
+	// snapshot captured at init (before that lookup), which dropped country from
+	// every registration that lost the race.
+	GeoFunc any
 }
 
 func (f *Factory) setDefaults() {

--- a/pkg/app/appdisc/factory_native.go
+++ b/pkg/app/appdisc/factory_native.go
@@ -31,6 +31,14 @@ func (f *Factory) geoData() *geo.LocationData {
 	return g
 }
 
+// geoFunc recovers the live geolocation getter stored in the `any`-typed
+// Factory.GeoFunc (nil if unset). Preferred over geoData so heartbeats pick up
+// the visor's country once its async geoip lookup completes.
+func (f *Factory) geoFunc() func() *geo.LocationData {
+	fn, _ := f.GeoFunc.(func() *geo.LocationData)
+	return fn
+}
+
 // VisorUpdater obtains a visor updater.
 func (f *Factory) VisorUpdater(port uint16) Updater {
 	// Always return empty updater if keys are not set.
@@ -46,6 +54,7 @@ func (f *Factory) VisorUpdater(port uint16) Updater {
 		DiscAddr:      f.ServiceDisc,
 		DisplayNodeIP: f.DisplayNodeIP,
 		Geo:           f.geoData(),
+		GeoFunc:       f.geoFunc(),
 	}
 
 	return newServiceUpdater(
@@ -77,6 +86,7 @@ func (f *Factory) PublicVisorUpdater(
 		DiscAddr:      f.ServiceDisc,
 		DisplayNodeIP: f.DisplayNodeIP,
 		Geo:           f.geoData(),
+		GeoFunc:       f.geoFunc(),
 	}
 
 	inner := newServiceUpdater(
@@ -119,6 +129,7 @@ func (f *Factory) AppUpdater(conf appcommon.ProcConfig) (Updater, bool) {
 			Port:     uint16(conf.RoutingPort),
 			DiscAddr: f.ServiceDisc,
 			Geo:      f.geoData(),
+			GeoFunc:  f.geoFunc(),
 		}
 	}
 

--- a/pkg/servicedisc/client.go
+++ b/pkg/servicedisc/client.go
@@ -49,6 +49,13 @@ type Config struct {
 	// its own geoip lookup (via dmsg-server LookupIPGeo or the visor's
 	// embedded MaxMind DB) eliminates the SD→geoip-service round-trip.
 	Geo *geo.LocationData
+	// GeoFunc, when non-nil, returns the visor's CURRENT geolocation and is
+	// re-read on every RegisterEntry (heartbeat). This is what makes geo
+	// RELIABLE: the visor's geoip lookup is async and usually finishes AFTER
+	// the first registration, so a fixed Geo snapshot (captured at NewClient)
+	// permanently registered with no country whenever it lost that race. With
+	// GeoFunc, the next heartbeat after the lookup completes carries the country.
+	GeoFunc func() *geo.LocationData
 }
 
 // HTTPClient is responsible for interacting with the service-discovery
@@ -227,6 +234,14 @@ func (c *HTTPClient) RegisterEntry(ctx context.Context) error {
 		}
 	}
 	c.entry.Addr = NewSWAddr(c.conf.PK, c.conf.Port) // Just in case.
+
+	// Refresh geo from the live getter so a heartbeat picks up the country once
+	// the visor's async geoip lookup has completed (see Config.GeoFunc).
+	if c.conf.GeoFunc != nil {
+		if g := c.conf.GeoFunc(); g != nil {
+			c.entry.Geo = g
+		}
+	}
 
 	entry, err := c.postEntry(ctx)
 	if err != nil {

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -227,6 +227,10 @@ func initDiscovery(ctx context.Context, v *Visor, _ *logging.Logger) error {
 		factory.HeartbeatInterval = time.Duration(conf.HeartbeatInterval)
 		factory.Client = httpC
 		factory.Geo = v.serviceGeo()
+		// Live getter: the geoip lookup (resolvePublicIPForAR) runs async and
+		// usually finishes AFTER this point, so the snapshot above is nil for the
+		// race-losers. GeoFunc lets each heartbeat re-read the current geo.
+		factory.GeoFunc = v.serviceGeo
 
 		// Get public IP for service discovery (needed for NAT setups).
 		// Try dmsg first; fall back to STUN. No HTTP geoip query.
@@ -792,6 +796,7 @@ func (v *Visor) startPublicAutoconnectInternal(ctx context.Context, log *logging
 		DiscAddr:      serviceDisc,
 		DisplayNodeIP: v.conf.Launcher.DisplayNodeIP,
 		Geo:           v.serviceGeo(),
+		GeoFunc:       v.serviceGeo, // live: heartbeats re-read geo once the async lookup completes
 	}
 	// only needed for dmsghttp
 	pIP, err := getPublicIP(v, serviceDisc)


### PR DESCRIPTION
## What

Make visors register their **own geolocation** with the service discovery reliably, instead of dropping it whenever the geoip lookup finished after the first registration.

## The bug

Visors send their geo to the SD so the network view / reward UI can group by country. That geo was captured as a **nil snapshot**:

- the visor's public-IP + geoip lookup (`resolvePublicIPForAR`) runs in a **background goroutine** (up to a 10s dmsg `LookupIPGeo`, then up to a 20s STUN fallback);
- but the appdisc factory set `factory.Geo = v.serviceGeo()` **synchronously** at discovery init — almost always *before* that goroutine populated `v.geo.data`;
- `servicedisc` then froze that value into the entry at `NewClient` and **never re-read it**.

So any visor that lost the race registered with **no country for its entire run**. Only the handful that won it (fast dmsg geo response) carried geo — which is why the SD only has geo for ~30 of ~800 visors, and big populations (e.g. Indonesia) never form a country cluster in the reward UI.

## Fix

Make the geo **live**:
- `servicedisc.Config` gains `GeoFunc func() *geo.LocationData`, re-read on every `RegisterEntry` (heartbeat);
- `appdisc.Factory` carries `GeoFunc` (`any` → func, same TinyGo-compat pattern as `Geo`) and threads it into every updater's `Config`;
- the visor sets `factory.GeoFunc = v.serviceGeo` (and the public-autoconnect connector likewise).

The first heartbeat after the geoip lookup completes (≤ the 90s interval) registers the country, and it stays correct across restarts. The old `Geo` snapshot is kept as the initial value / fallback.

## Context

Companion to **#3521** ("geoip: OpenEmbedded must trigger the lazy decompress", the v1.3.85 gzip regression, fixed in v1.3.86): that restored the embedded DB; **this** stops the value from being dropped before it's sent. Both are needed for country to reliably reach the SD. Also complements the tpviz survey-GeoIP full-fleet fallback (#3586), which makes the reward UI correct even for visors that register no service at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)