### PR TITLE
feat(wasm-visor): learn own country from a dmsg server (LookupIPGeo)

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -110,6 +110,11 @@ var (
 	// does for AR bind payloads. Refreshed by refreshSelfPublicIP; read by
 	// SelfOverview. Holds a string ("" until first learned).
 	selfPublicIP atomic.Value
+	// selfGeoCountry caches this visor's ISO country as resolved by a dmsg server
+	// (ClientSession.LookupIPGeo). A wasm visor ships no embedded GeoIP DB, so —
+	// like its public IP — this is the only way it can show its own country in
+	// the hypervisor node list.
+	selfGeoCountry atomic.Value
 )
 
 // vlog emits a step message to the browser console AND, when present, the
@@ -777,6 +782,9 @@ func (s visorSelf) SelfOverview() wasmhv.Overview {
 	if ip, ok := selfPublicIP.Load().(string); ok {
 		ov.PublicIP = ip
 	}
+	if c, ok := selfGeoCountry.Load().(string); ok {
+		ov.CountryCode = c
+	}
 	return ov
 }
 
@@ -814,6 +822,15 @@ func refreshSelfPublicIP(ctx context.Context) {
 		if prev, _ := selfPublicIP.Load().(string); prev != ip {
 			selfPublicIP.Store(ip)
 			vlog("self public IP (via dmsg server): " + ip)
+		}
+		// Country (once): the dmsg server folds geoip into LookupIPGeo, so a wasm
+		// visor — which ships no embedded GeoIP DB — can still show its own
+		// country in the hypervisor node list.
+		if _, ok := selfGeoCountry.Load().(string); !ok {
+			if resp, gerr := dmsgC.LookupIPGeo(ctx, nil); gerr == nil && resp.GeoCountry != "" {
+				selfGeoCountry.Store(resp.GeoCountry)
+				vlog("self country (via dmsg server): " + resp.GeoCountry)
+			}
 		}
 	}
 }

--- a/pkg/wasmhv/core.go
+++ b/pkg/wasmhv/core.go
@@ -66,6 +66,11 @@ type Overview struct {
 	Hypervisors         []cipher.PubKey `json:"hypervisors"`
 	ConnectedHypervisor []cipher.PubKey `json:"connected_hypervisor"`
 	Hostname            string          `json:"hostname,omitempty"`
+	// CountryCode is the visor's ISO country, shown in the hypervisor node list.
+	// A wasm visor has no embedded GeoIP DB, so (like its public IP) it learns
+	// this from a dmsg server via LookupIPGeo. Same json tag as the native
+	// visor's Overview so the HV UI renders it identically.
+	CountryCode string `json:"country_code,omitempty"`
 
 	// transports holds THIS (self) visor's live transports so MarshalJSON can
 	// emit them in the overview's "transports" array (the node-table count). It


### PR DESCRIPTION
## What

Let the wasm visor show its **own country** in the hypervisor node list.

## Why

The HV node list shows each visor's country, including the local visor. A wasm visor ships **no embedded GeoIP DB**, so it couldn't resolve its own country and showed blank. But the dmsg servers already fold geoip into `LookupIPGeo` (`GeoCountry`/`GeoRegion`/`GeoLat`) — the same call the native visor uses — and the wasm visor already learns its **public IP** from a dmsg server the same way (`refreshSelfPublicIP` → `LookupIPsByFamily`). It just never asked for the geo.

## How

- Extend `refreshSelfPublicIP` to also call `dmsgC.LookupIPGeo` once and cache the country (`selfGeoCountry`).
- Add `CountryCode` to the wasm `Overview` (same `country_code` json tag as the native visor's Overview) and populate it in `SelfOverview`, so the HV UI renders it identically.

Applies to any visor that lacks the embedded GeoIP DB (or can't resolve itself in it) — today just the wasm visor, but also future minimal / small‑hardware ports.

## Note

The embedded wasm blob must be rebuilt (`embed-wasm-visor`) for the deployed HV to pick this up; this PR is the source change. Builds native (`pkg/wasmhv`) and `GOOS=js GOARCH=wasm` (`cmd/wasm-visor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)