### PR TITLE
feat(wasmhv): real transport counts + per-hypervisor node sections + flap resistance

### DIFF
--- a/pkg/wasmhv/core.go
+++ b/pkg/wasmhv/core.go
@@ -163,7 +163,33 @@ type Core struct {
 	mu     sync.RWMutex
 	visors map[cipher.PubKey]*gobRPCClient
 	self   SelfProvider // the tab's OWN visor (nil for a plain standalone HV)
+
+	// Per-visor caches that make the node list resilient to the wasm visor's
+	// often-marginal dmsg link: a transient RPC timeout no longer blinks a
+	// visor to offline (red-X / blank) or its transport count to 0.
+	cacheMu  sync.Mutex
+	tpCache  map[cipher.PubKey]tpCacheEntry
+	sumCache map[cipher.PubKey]sumCacheEntry
 }
+
+type tpCacheEntry struct {
+	tps []*TransportSummary
+	at  time.Time
+}
+
+type sumCacheEntry struct {
+	s  Summary
+	at time.Time
+}
+
+// tpCacheTTL is how long a fetched transport list is reused before re-fetching
+// (transports change rarely, and re-RPCing every node-list poll adds load to a
+// marginal link). sumGrace is how long a last-known Summary is shown after an
+// RPC failure before the visor is reported offline for real.
+const (
+	tpCacheTTL = 20 * time.Second
+	sumGrace   = 45 * time.Second
+)
 
 // NewCore returns a Core for the given dmsg client + this hypervisor's PK.
 func NewCore(pk cipher.PubKey, dmsgC *dmsg.Client) *Core {
@@ -230,15 +256,62 @@ func (c *Core) overviewOf(pk cipher.PubKey) Overview {
 	if err := c.call(pk, "Overview", &struct{}{}, &ov); err != nil {
 		return Overview{PubKey: pk}
 	}
+	ov.SetSelfTransports(c.transportsForCount(pk))
 	return ov
 }
 
-// summaryOf fetches a visor's Summary, or an offline stub on error.
+// summaryOf fetches a visor's Summary. On a transient RPC failure it returns the
+// last-known Summary within sumGrace (so the node list doesn't blink the visor
+// to offline on a marginal link), else an offline stub.
 func (c *Core) summaryOf(pk cipher.PubKey) Summary {
 	var s Summary
 	if err := c.call(pk, "Summary", &struct{}{}, &s); err != nil {
+		c.cacheMu.Lock()
+		e, ok := c.sumCache[pk]
+		c.cacheMu.Unlock()
+		if ok && time.Since(e.at) < sumGrace {
+			return e.s
+		}
 		return Summary{Overview: &Overview{PubKey: pk}, Online: false}
 	}
 	s.Online = true
+	if s.Overview != nil {
+		s.Overview.SetSelfTransports(c.transportsForCount(pk))
+	}
+	c.cacheMu.Lock()
+	if c.sumCache == nil {
+		c.sumCache = make(map[cipher.PubKey]sumCacheEntry)
+	}
+	c.sumCache[pk] = sumCacheEntry{s: s, at: time.Now()}
+	c.cacheMu.Unlock()
 	return s
+}
+
+// transportsForCount fetches a remote visor's transports (no logs) so the node
+// table's "Total" count is real — remote mirrored overviews arrive with nil
+// transports (the field is unexported + gob-skipped). Cached for tpCacheTTL to
+// avoid re-RPCing every poll; on failure it reuses the last-known list so the
+// count doesn't blink to 0.
+func (c *Core) transportsForCount(pk cipher.PubKey) []*TransportSummary {
+	c.cacheMu.Lock()
+	if e, ok := c.tpCache[pk]; ok && time.Since(e.at) < tpCacheTTL {
+		c.cacheMu.Unlock()
+		return e.tps
+	}
+	c.cacheMu.Unlock()
+
+	var reply []*TransportSummary
+	if err := c.call(pk, "Transports", &transportsIn{ShowLogs: false}, &reply); err != nil {
+		c.cacheMu.Lock()
+		e := c.tpCache[pk]
+		c.cacheMu.Unlock()
+		return e.tps // last-known (nil if never fetched)
+	}
+	c.cacheMu.Lock()
+	if c.tpCache == nil {
+		c.tpCache = make(map[cipher.PubKey]tpCacheEntry)
+	}
+	c.tpCache[pk] = tpCacheEntry{tps: reply, at: time.Now()}
+	c.cacheMu.Unlock()
+	return reply
 }

--- a/pkg/wasmhv/router.go
+++ b/pkg/wasmhv/router.go
@@ -60,16 +60,12 @@ func (c *Core) ServeHTTP(method, path string, body []byte) (int, []byte) {
 		return jsonResp(c.allSummaries())
 
 	// The node-list UI uses /visors-tree-summary (getNodesTree) and expects a
-	// {sections:[{hypervisor_pk, visors:[...]}]} TREE, not a flat array — a flat
-	// array leaves result.sections undefined and the list renders EMPTY. The tab
-	// is a single local hypervisor, so emit one section keyed by its own PK whose
-	// visors are the flat summaries (this tab's visor + any that dialed in).
+	// {sections:[{hypervisor_pk, visors:[...]}]} TREE. Section 0 is this
+	// hypervisor; each connected visor that is ITSELF a hypervisor gets its own
+	// section, so the UI renders separate per-hypervisor clusters like the native
+	// HV (was a single flat section here).
 	case p == "/visors-tree-summary":
-		return jsonResp(map[string]interface{}{
-			"sections": []map[string]interface{}{
-				{"hypervisor_pk": c.pk.String(), "via_chain": []string{}, "visors": c.allSummaries()},
-			},
-		})
+		return jsonResp(map[string]interface{}{"sections": c.treeSections()})
 
 	case strings.HasPrefix(p, "/visors/"):
 		rawQuery := ""
@@ -294,6 +290,47 @@ func (c *Core) allSummaries() []Summary {
 		out = append([]Summary{self.SelfSummary()}, out...)
 	}
 	return out
+}
+
+// treeSections groups the connected visors into the per-hypervisor sections the
+// node-list UI renders as separate clusters (result.sections). Section 0 is this
+// wasm hypervisor (self + everything connected to it); then one section per
+// connected visor that is ITSELF a hypervisor, whose members are the visors that
+// report it in their connected_hypervisor list. A visor managed by several
+// hypervisors appears under each, mirroring the native HV's tree. Previously the
+// wasm HV emitted a single flat section, so no per-hypervisor clusters showed.
+func (c *Core) treeSections() []map[string]interface{} {
+	sums := c.allSummaries()
+	sections := []map[string]interface{}{
+		{"hypervisor_pk": c.pk.String(), "via_chain": []string{}, "visors": sums},
+	}
+	seen := map[string]bool{c.pk.String(): true}
+	for _, s := range sums {
+		if !s.IsHypervisor || s.Overview == nil {
+			continue
+		}
+		hvpk := s.Overview.PubKey.String()
+		if seen[hvpk] {
+			continue
+		}
+		seen[hvpk] = true
+		members := []Summary{}
+		for _, m := range sums {
+			if m.Overview == nil {
+				continue
+			}
+			for _, ch := range m.Overview.ConnectedHypervisor {
+				if ch.String() == hvpk {
+					members = append(members, m)
+					break
+				}
+			}
+		}
+		sections = append(sections, map[string]interface{}{
+			"hypervisor_pk": hvpk, "via_chain": []string{}, "visors": members,
+		})
+	}
+	return sections
 }
 
 func jsonResp(v interface{}) (int, []byte) {


### PR DESCRIPTION
Three wasm‑hypervisor node‑list fixes, matching the native HV (reported by the AU miner owner — screenshots showed `Total: 0` transports and a single flat list that flickered).

## 1. Transports "Total: 0" for managed visors
Remote mirrored `Overview`s arrive with **nil** transports — `Overview.transports` is unexported + gob‑skipped, and `SetSelfTransports` was only ever called for the *self* visor. `overviewOf`/`summaryOf` now fetch each remote visor's transports (Transports RPC, no logs) and attach them, so the node table's Total is the real count (the native HV builds transports into the overview locally).

## 2. No per‑hypervisor clusters
`/visors-tree-summary` hardcoded a **single** section keyed by this HV's PK, so the UI's `subSections` were always empty. `treeSections()` now emits section 0 (this HV) plus **one section per connected visor that is itself a hypervisor**, its members being the visors that report it in `connected_hypervisor` — so the UI renders separate per‑hypervisor clusters like the native HV. No Angular change (the tree template already renders whatever sections the endpoint returns).

## 3. Flap resistance (the flickering node list)
The wasm visor's dmsg link is often marginal, so a transient RPC timeout blinked a visor to offline (red‑X / blank version) or its count to 0 — and the added transport RPCs would have made it worse. Short per‑visor caches fix both: transports are reused for `tpCacheTTL` (20s), and a failed `Summary` falls back to the **last‑known** within `sumGrace` (45s) before reporting offline. Cuts RPC load *and* stops the flicker.

Builds native (`pkg/wasmhv`) and `GOOS=js GOARCH=wasm` (`cmd/wasm-visor`). The embedded wasm blob must be rebuilt (`embed-wasm-visor`) to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)