### PR TITLE
comprehensive unit + integration coverage; fix 4 latent bugs

### DIFF
--- a/cmd/apps/skychat/commands/cxo_tcp_loops_test.go
+++ b/cmd/apps/skychat/commands/cxo_tcp_loops_test.go
@@ -1,0 +1,417 @@
+// Package commands cmd/apps/skychat/commands/cxo_tcp_loops_test.go
+//
+// Coverage for the CXO-over-native-TCP loops: startCXOTCP, startCXOGroup,
+// cxoDialUntilConnected, publishCXO and surfaceCXOInbound.
+//
+// Like tcp-direct, none of this needs dmsg — treestore has a native TCP
+// transport and an in-memory DB, so a test can stand up a real peer publisher
+// on 127.0.0.1, point --cxo-peer at it, and watch a genuine leaf propagate
+// through the production subscriber into the SSE hub.
+//
+// Two behaviors are pinned beyond mere reachability:
+//
+//   - startCXOTCP must SKIP a malformed --cxo-peer and keep going. Aborting
+//     the whole transport over one bad operator flag would take the working
+//     peers down with it.
+//   - cxoDialUntilConnected exists because Subscriber.ConnectTCP only arms its
+//     reconnect watchdog after a FIRST success — a peer that isn't listening
+//     yet at startup would otherwise never be retried. The test asserts it
+//     keeps retrying and that the retry sleep is cancel-interruptible.
+package commands
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/skychat/dm"
+)
+
+// --- harness ----------------------------------------------------------------
+
+// withCXOEnv resets every cxo global, gives the test a private hub, and tears
+// down whatever the run brought up before restoring.
+func withCXOEnv(t *testing.T) {
+	t.Helper()
+	if appLog == nil {
+		appLog = func(string, ...any) {}
+	}
+	withChatLog(t)
+
+	origHub, origCtrl := hub, chatCtrl
+	origEnable, origListen, origPeers := cxoEnable, cxoListen, cxoPeers
+	origGroup, origOwner := cxoGroup, cxoGroupOwner
+	origSK, origCfg := tcpSKFlag, tcpConfigPath
+
+	hub = newSSEHub()
+	chatCtrl = dm.New(dm.Config{})
+	cxoEnable, cxoListen, cxoPeers = false, "", nil
+	cxoGroup, cxoGroupOwner = "", ""
+	tcpSKFlag, tcpConfigPath = "", ""
+	t.Setenv("DMSGCURL_SK", "") // resolveTCPIdentity reads it
+
+	cxoMu.Lock()
+	cxoPub, cxoSubs, cxoGroupSess, cxoSeq = nil, nil, nil, 0
+	cxoMu.Unlock()
+
+	t.Cleanup(func() {
+		cxoMu.Lock()
+		pub, subs, sess := cxoPub, cxoSubs, cxoGroupSess
+		cxoPub, cxoSubs, cxoGroupSess, cxoSeq = nil, nil, nil, 0
+		cxoMu.Unlock()
+		for _, s := range subs {
+			_ = s.Close() //nolint:errcheck
+		}
+		if pub != nil {
+			_ = pub.Close() //nolint:errcheck
+		}
+		if sess != nil {
+			_ = sess.Close() //nolint:errcheck
+		}
+		hub, chatCtrl = origHub, origCtrl
+		cxoEnable, cxoListen, cxoPeers = origEnable, origListen, origPeers
+		cxoGroup, cxoGroupOwner = origGroup, origOwner
+		tcpSKFlag, tcpConfigPath = origSK, origCfg
+	})
+}
+
+// peerPublisher stands up a real CXO publisher on loopback — the "other visor"
+// our subscriber follows.
+func peerPublisher(t *testing.T) (feedPK cipher.PubKey, addr string, pub *treestore.Publisher) {
+	t.Helper()
+	pk, sk := cipher.GenerateKeyPair()
+	addr = freeTCPAddr(t) // from tcp_direct_loops_test.go
+	p, err := treestore.NewWithTCP(addr, sk, treestore.PubConfig{
+		InMemoryDB:  true,
+		BatchWindow: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("peer publisher on %s: %v", addr, err)
+	}
+	t.Cleanup(func() { _ = p.Close() }) //nolint:errcheck
+	return pk, addr, p
+}
+
+// --- surfaceCXOInbound ------------------------------------------------------
+
+func TestSurfaceCXOInbound(t *testing.T) {
+	withCXOEnv(t)
+	cxoGroup = "grp-42"
+
+	sub, unsub := hub.subscribeEvents(nil, 0)
+	defer unsub()
+
+	sender, _ := cipher.GenerateKeyPair()
+	surfaceCXOInbound(sender.Hex(), "from the feed")
+
+	select {
+	case ev := <-sub:
+		if ev.Channel != channelGroup || ev.Transport != "cxo" || ev.Dir != "in" {
+			t.Errorf("event = channel %q transport %q dir %q; want group/cxo/in",
+				ev.Channel, ev.Transport, ev.Dir)
+		}
+		if ev.From != sender.Hex() || ev.Text != "from the feed" || ev.GroupID != "grp-42" {
+			t.Errorf("event = %+v", ev)
+		}
+		if ev.ID == "" {
+			t.Error("a surfaced CXO message needs an id so the UI can address it")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("surfaceCXOInbound published nothing on the hub")
+	}
+}
+
+// --- publishCXO -------------------------------------------------------------
+
+func TestPublishCXO_NoPublisherIsAnError(t *testing.T) {
+	withCXOEnv(t)
+	if _, err := publishCXO("nowhere to go"); err == nil {
+		t.Error("publishing with no CXO publisher should error, not silently drop")
+	}
+}
+
+func TestPublishCXO_WritesUniqueOrderedPaths(t *testing.T) {
+	withCXOEnv(t)
+	_, sk := cipher.GenerateKeyPair()
+	pub, err := treestore.NewWithTCP(freeTCPAddr(t), sk, treestore.PubConfig{
+		InMemoryDB: true, BatchWindow: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("publisher: %v", err)
+	}
+	t.Cleanup(func() { _ = pub.Close() }) //nolint:errcheck
+
+	cxoMu.Lock()
+	cxoPub = pub
+	cxoMu.Unlock()
+
+	shape := regexp.MustCompile(`^msgs/\d{19}-\d{6}$`)
+	var paths []string
+	for i := 0; i < 3; i++ {
+		p, perr := publishCXO("body " + string(rune('a'+i)))
+		if perr != nil {
+			t.Fatalf("publishCXO: %v", perr)
+		}
+		if !shape.MatchString(p) {
+			t.Errorf("path %q does not match msgs/<ts-nano>-<seq>", p)
+		}
+		paths = append(paths, p)
+	}
+
+	// Unique and lexically ordered — two sends in the same nanosecond must
+	// still sort deterministically, which is what the seq suffix is for.
+	for i := 1; i < len(paths); i++ {
+		if paths[i] <= paths[i-1] {
+			t.Errorf("paths not strictly increasing: %q then %q", paths[i-1], paths[i])
+		}
+	}
+	if body, ok := pub.Get(paths[0]); !ok || string(body) != "body a" {
+		t.Errorf("leaf at %q = %q ok=%v, want the published body", paths[0], body, ok)
+	}
+}
+
+// --- cxoDialUntilConnected --------------------------------------------------
+
+func TestCXODialUntilConnected_ReturnsOnFirstSuccess(t *testing.T) {
+	withCXOEnv(t)
+	feedPK, addr, _ := peerPublisher(t)
+
+	sub, err := treestore.NewSubscriberTCP("", feedPK, treestore.SubConfig{InMemoryDB: true})
+	if err != nil {
+		t.Fatalf("subscriber: %v", err)
+	}
+	t.Cleanup(func() { _ = sub.Close() }) //nolint:errcheck
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		cxoDialUntilConnected(context.Background(), sub, addr, feedPK.Hex())
+	}()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("cxoDialUntilConnected never returned against a live peer")
+	}
+}
+
+// TestCXODialUntilConnected_RetriesAndIsCancelable — the retry loop is the
+// whole reason this helper exists (ConnectTCP arms its watchdog only after a
+// first success), so it must keep trying against a dead peer AND unwind
+// promptly on cancel rather than sleeping out the backoff.
+func TestCXODialUntilConnected_RetriesAndIsCancelable(t *testing.T) {
+	withCXOEnv(t)
+	feedPK, _ := cipher.GenerateKeyPair()
+	dead := freeTCPAddr(t) // reserved then released — nothing is listening
+
+	sub, err := treestore.NewSubscriberTCP("", feedPK, treestore.SubConfig{InMemoryDB: true})
+	if err != nil {
+		t.Fatalf("subscriber: %v", err)
+	}
+	t.Cleanup(func() { _ = sub.Close() }) //nolint:errcheck
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		cxoDialUntilConnected(ctx, sub, dead, feedPK.Hex())
+	}()
+
+	// Still retrying, not returned.
+	select {
+	case <-done:
+		t.Fatal("cxoDialUntilConnected returned against a dead peer; it must keep retrying")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	cancel()
+	start := time.Now()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("cxoDialUntilConnected did not unwind after cancel")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("unwind took %v — cancel should interrupt the backoff sleep", elapsed)
+	}
+}
+
+// --- startCXOTCP ------------------------------------------------------------
+
+func TestStartCXOTCP_DisabledIsNoOp(t *testing.T) {
+	withCXOEnv(t)
+	cxoEnable, cxoGroup = false, ""
+
+	if err := startCXOTCP(context.Background()); err != nil {
+		t.Errorf("with --cxo unset startCXOTCP should be a no-op, got %v", err)
+	}
+	cxoMu.Lock()
+	defer cxoMu.Unlock()
+	if cxoPub != nil {
+		t.Error("a disabled CXO transport must not open a publisher")
+	}
+}
+
+func TestStartCXOTCP_RequiresIdentity(t *testing.T) {
+	withCXOEnv(t)
+	cxoEnable = true
+	cxoListen = freeTCPAddr(t)
+
+	if err := startCXOTCP(context.Background()); err == nil {
+		t.Error("enabling --cxo with no configured identity should error")
+	}
+}
+
+// TestStartCXOTCP_SubscribesAndSurfacesPeerMessages is the end-to-end case: a
+// real peer publisher, the production subscriber wiring, and a genuine leaf
+// arriving on the SSE hub.
+func TestStartCXOTCP_SubscribesAndSurfacesPeerMessages(t *testing.T) {
+	withCXOEnv(t)
+	_, mySK := cipher.GenerateKeyPair()
+	feedPK, peerAddr, peerPub := peerPublisher(t)
+
+	cxoEnable = true
+	cxoListen = freeTCPAddr(t)
+	tcpSKFlag = mySK.Hex()
+	cxoPeers = []string{
+		"tcp://not-a-pk@127.0.0.1:1",             // malformed: must be skipped
+		"tcp://" + feedPK.Hex() + "@" + peerAddr, // the real one
+	}
+
+	events := make(chan chatEvent, 8)
+	sub, unsub := hub.subscribeEvents(nil, 0)
+	defer unsub()
+	go func() {
+		for ev := range sub {
+			select {
+			case events <- ev:
+			default:
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := startCXOTCP(ctx); err != nil {
+		t.Fatalf("startCXOTCP: %v", err)
+	}
+
+	// One bad spec must not take the transport down with it.
+	cxoMu.Lock()
+	pubUp, nSubs := cxoPub != nil, len(cxoSubs)
+	cxoMu.Unlock()
+	if !pubUp {
+		t.Fatal("our own feed publisher should be up")
+	}
+	if nSubs != 1 {
+		t.Fatalf("subscribers = %d, want 1 (the malformed --cxo-peer is skipped)", nSubs)
+	}
+
+	// Give the subscriber time to attach, then publish from the peer.
+	deadline := time.Now().Add(30 * time.Second)
+	var got chatEvent
+	for time.Now().Before(deadline) {
+		if err := peerPub.Put("msgs/0000000000000000001-000001", []byte("hello from the peer")); err != nil {
+			t.Fatalf("peer Put: %v", err)
+		}
+		select {
+		case ev := <-events:
+			got = ev
+		case <-time.After(500 * time.Millisecond):
+			continue
+		}
+		break
+	}
+	if got.Text != "hello from the peer" {
+		t.Fatalf("surfaced event = %+v, want the peer's message", got)
+	}
+	if got.From != feedPK.Hex() {
+		t.Errorf("event from = %s, want the peer feed %s", got.From, feedPK.Hex()[:8])
+	}
+	if got.Transport != "cxo" {
+		t.Errorf("event transport = %q, want cxo", got.Transport)
+	}
+}
+
+// --- startCXOGroup ----------------------------------------------------------
+
+func TestStartCXOGroup_RejectsBadOwner(t *testing.T) {
+	withCXOEnv(t)
+	_, sk := cipher.GenerateKeyPair()
+	cxoGroup = uuid.NewString()
+	cxoGroupOwner = "not-a-pk"
+	tcpSKFlag = sk.Hex()
+	cxoListen = freeTCPAddr(t)
+
+	err := startCXOTCP(context.Background()) // routes to startCXOGroup when cxoGroup is set
+	if err == nil {
+		t.Fatal("an invalid --cxo-group-owner should error")
+	}
+	if !strings.Contains(err.Error(), "cxo-group") {
+		t.Errorf("err = %v, want it attributed to cxo-group", err)
+	}
+}
+
+func TestStartCXOGroup_RequiresIdentity(t *testing.T) {
+	withCXOEnv(t)
+	owner, _ := cipher.GenerateKeyPair()
+	cxoGroup = uuid.NewString()
+	cxoGroupOwner = owner.Hex()
+	cxoListen = freeTCPAddr(t)
+	tcpSKFlag, tcpConfigPath = "", ""
+
+	if err := startCXOTCP(context.Background()); err == nil {
+		t.Error("cxo-group with no configured identity should error")
+	}
+}
+
+// TestStartCXOGroup_OpensSessionAndRoutesSends — with --cxo-group set,
+// startCXOTCP hands off to the group subsystem, and publishCXO must route
+// through the session rather than the flat per-feed publisher.
+func TestStartCXOGroup_OpensSessionAndRoutesSends(t *testing.T) {
+	withCXOEnv(t)
+	myPK, mySK := cipher.GenerateKeyPair()
+	peerPK, _ := cipher.GenerateKeyPair()
+
+	cxoGroup = uuid.NewString()
+	cxoGroupOwner = myPK.Hex() // we are the owner → RoleOwner
+	tcpSKFlag = mySK.Hex()
+	cxoListen = freeTCPAddr(t)
+	cxoPeers = []string{
+		"tcp://malformed", // skipped
+		"tcp://" + peerPK.Hex() + "@127.0.0.1:" + "65001", // never dialed successfully; that's fine
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := startCXOTCP(ctx); err != nil {
+		t.Fatalf("startCXOTCP → startCXOGroup: %v", err)
+	}
+
+	cxoMu.Lock()
+	sess, myPKSet := cxoGroupSess, cxoMyPK
+	cxoMu.Unlock()
+	if sess == nil {
+		t.Fatal("a group session should be open")
+	}
+	if myPKSet != myPK {
+		t.Errorf("cxoMyPK = %s, want %s", myPKSet.Hex()[:8], myPK.Hex()[:8])
+	}
+	if sess.ID() != cxoGroup {
+		t.Errorf("session id = %q, want %q", sess.ID(), cxoGroup)
+	}
+
+	// publishCXO takes the group branch and reports "group" as the path.
+	path, err := publishCXO("a group send")
+	if err != nil {
+		t.Fatalf("publishCXO in group mode: %v", err)
+	}
+	if path != "group" {
+		t.Errorf("path = %q, want \"group\" — group mode routes through Session.Send", path)
+	}
+}

--- a/cmd/apps/skychat/commands/filexfer_transfer_test.go
+++ b/cmd/apps/skychat/commands/filexfer_transfer_test.go
@@ -1,0 +1,981 @@
+// Package commands cmd/apps/skychat/commands/filexfer_transfer_test.go
+//
+// Unit coverage for the file-transfer core that the existing filexfer tests
+// left at 0%: the auto-accept policy (acceptInbound / isEstablishedPeer /
+// isGroupMember), the completion hook (onXferDone), and the send path
+// (sendFileID / sendFileToGroup).
+//
+// The centerpiece is TestSendFileID_EndToEnd, which runs a REAL transfer
+// between two xfer.Managers over an in-process listener — the receiving side
+// wired to the production acceptInbound + onXferDone hooks rather than to
+// stubs. That exercises the policy decision, the on-disk save path, the SSE
+// surfacing and the history persist in one pass, which is how the pieces
+// actually fail: individually they all look fine.
+//
+// Downloads-dir note: downloadsDir() resolves to <skyenv.LocalPath>/
+// skychat-downloads when appCl is nil (LocalPath is a const, so it can't be
+// redirected at a temp dir). withCleanDownloads therefore snapshots the
+// directory and removes whatever the test added, rather than isolating it.
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/cmd/apps/skychat/group"
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skychat/dm"
+	"github.com/skycoin/skywire/pkg/skychat/history"
+	"github.com/skycoin/skywire/pkg/skychat/xfer"
+)
+
+// --- harness ----------------------------------------------------------------
+
+// withCleanDownloads returns the downloads dir and removes every entry the test
+// creates in it on cleanup, leaving anything that was already there.
+func withCleanDownloads(t *testing.T) string {
+	t.Helper()
+	dir, err := downloadsDir()
+	if err != nil {
+		t.Fatalf("downloadsDir: %v", err)
+	}
+	before := map[string]bool{}
+	if entries, rerr := os.ReadDir(dir); rerr == nil {
+		for _, e := range entries {
+			before[e.Name()] = true
+		}
+	}
+	t.Cleanup(func() {
+		entries, rerr := os.ReadDir(dir)
+		if rerr != nil {
+			return
+		}
+		for _, e := range entries {
+			if !before[e.Name()] {
+				_ = os.Remove(filepath.Join(dir, e.Name())) //nolint:errcheck
+			}
+		}
+	})
+	return dir
+}
+
+// withXferEnv gives the test a private SSE hub, a discard chatLog, pairing and
+// OS notifications off, and a clean file-request registry — restoring every
+// global it touches.
+func withXferEnv(t *testing.T) {
+	t.Helper()
+	if appLog == nil {
+		appLog = func(string, ...any) {}
+	}
+	withChatLog(t)
+
+	origHub, origPair, origNotify := hub, pairEnable, osNotify
+	origMgr, origCtrl := fileMgr, chatCtrl
+	origSess, origGroup := cxoGroupSess, cxoGroup
+
+	hub = newSSEHub()
+	pairEnable = false
+	osNotify = false
+	fileMgr = nil
+	cxoGroupSess = nil
+	cxoGroup = ""
+
+	clearRequestedFiles()
+	t.Cleanup(func() {
+		hub, pairEnable, osNotify = origHub, origPair, origNotify
+		fileMgrMu.Lock()
+		fileMgr = origMgr
+		fileMgrMu.Unlock()
+		chatCtrl = origCtrl
+		cxoGroupSess, cxoGroup = origSess, origGroup
+		clearRequestedFiles()
+	})
+}
+
+func clearRequestedFiles() {
+	requestedFilesMu.Lock()
+	requestedFiles = map[string]cipher.PubKey{}
+	requestedFilesMu.Unlock()
+}
+
+// establishPeer wires chatCtrl to an in-memory transport and forces a cached
+// conn to pk, so isEstablishedPeer(pk) reports true — the real precondition
+// the auto-accept policy checks, not a stub of it.
+func establishPeer(t *testing.T, pk cipher.PubKey) {
+	t.Helper()
+	cc := newCapturingClient() // from pairing_handlers_test.go
+	ctrl := dm.New(dm.Config{Client: cc, Networks: []appnet.Type{appnet.TypeSkynet}})
+	chatCtrl = ctrl
+	if err := ctrl.SendRaw(context.Background(), pk, []byte("warm the conn")); err != nil {
+		t.Fatalf("seeding a cached conn to %s: %v", pk.Hex(), err)
+	}
+	if !ctrl.HasConn(pk) {
+		t.Fatal("expected a cached conn after SendRaw")
+	}
+	t.Cleanup(func() {
+		_ = ctrl.Close() //nolint:errcheck
+		cc.closeAll()
+	})
+}
+
+// pkAddrConn overrides RemoteAddr so xfer's remotePK sees a real peer key —
+// a bare net.Pipe reports no PK, which would make every accept decision run
+// against the zero key.
+type pkAddrConn struct {
+	net.Conn
+	addr appnet.Addr
+}
+
+func (c pkAddrConn) RemoteAddr() net.Addr { return c.addr }
+
+// memXferListener is an in-process net.Listener: dialMem hands the caller one
+// end of a pipe and queues the other for Accept, stamped with the sender's PK.
+type memXferListener struct {
+	ch        chan net.Conn
+	closed    chan struct{}
+	closeOnce sync.Once
+	senderPK  cipher.PubKey
+}
+
+func newMemXferListener(senderPK cipher.PubKey) *memXferListener {
+	return &memXferListener{
+		ch:       make(chan net.Conn, 8),
+		closed:   make(chan struct{}),
+		senderPK: senderPK,
+	}
+}
+
+func (l *memXferListener) dialMem() (net.Conn, error) {
+	dialer, callee := net.Pipe()
+	accepted := pkAddrConn{
+		Conn: callee,
+		addr: appnet.Addr{Net: appnet.TypeSkynet, PubKey: l.senderPK, Port: routing.Port(1)},
+	}
+	select {
+	case l.ch <- accepted:
+		return dialer, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *memXferListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.ch:
+		return c, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *memXferListener) Close() error {
+	l.closeOnce.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *memXferListener) Addr() net.Addr { return appnet.Addr{Net: appnet.TypeSkynet} }
+
+// newEmptyGroupSession returns a zero-value group.Session: PeerPKs() reads an
+// empty peer set under its (zero-usable) mutex, which is all isGroupMember and
+// sendFileToGroup need. A session with actual peers can't be built from here —
+// peerSubs is unexported and only a real CXO attach populates it, so
+// isGroupMember's member-found branch stays uncovered by design.
+func newEmptyGroupSession() *group.Session { return &group.Session{} }
+
+// waitForFile blocks until path exists with at least size bytes. The receiver
+// writes on the xfer manager's goroutine, so the sender returning does not
+// guarantee the file is flushed yet.
+func waitForFile(t *testing.T, path string, size int64) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if fi, err := os.Stat(path); err == nil && fi.Size() >= size {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	fi, err := os.Stat(path)
+	t.Fatalf("timed out waiting for %s to reach %d bytes (stat: %v, %v)", path, size, fi, err)
+}
+
+// writeTempFile writes content to a fresh temp file and returns its path.
+func writeTempFile(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+// collectEvents subscribes to the structured /events stream and returns a
+// drain func that gathers whatever arrived within a short settle window.
+func collectEvents(t *testing.T) func() []chatEvent {
+	t.Helper()
+	ch, unsub := hub.subscribeEvents(nil, 0)
+	t.Cleanup(unsub)
+	return func() []chatEvent {
+		var out []chatEvent
+		deadline := time.After(2 * time.Second)
+		for {
+			select {
+			case ev := <-ch:
+				out = append(out, ev)
+			case <-time.After(200 * time.Millisecond):
+				return out
+			case <-deadline:
+				return out
+			}
+		}
+	}
+}
+
+// --- isEstablishedPeer / isGroupMember --------------------------------------
+
+func TestIsEstablishedPeer(t *testing.T) {
+	withXferEnv(t)
+	pk, _ := cipher.GenerateKeyPair()
+
+	chatCtrl = nil
+	if isEstablishedPeer(pk) {
+		t.Error("a nil controller must not report an established peer")
+	}
+
+	other, _ := cipher.GenerateKeyPair()
+	establishPeer(t, pk)
+	if !isEstablishedPeer(pk) {
+		t.Error("a peer with a cached conn should be established")
+	}
+	if isEstablishedPeer(other) {
+		t.Error("a peer with no cached conn must not be established")
+	}
+}
+
+func TestIsGroupMember_FalseCases(t *testing.T) {
+	withXferEnv(t)
+	pk, _ := cipher.GenerateKeyPair()
+
+	// No active group session at all.
+	cxoGroupSess, cxoGroup = nil, "g1"
+	if isGroupMember("g1", pk) {
+		t.Error("no session → not a member")
+	}
+
+	// A session exists, but the offered group id doesn't match ours (or is
+	// empty) — a file stamped with someone else's group must not be accepted.
+	cxoGroupSess = newEmptyGroupSession()
+	cxoGroup = "g1"
+	if isGroupMember("", pk) {
+		t.Error("an empty group id → not a member")
+	}
+	if isGroupMember("other-group", pk) {
+		t.Error("a different group id → not a member")
+	}
+	// Right group, but the sender isn't in the peer set.
+	if isGroupMember("g1", pk) {
+		t.Error("a non-member peer → not a member")
+	}
+}
+
+// --- acceptInbound ----------------------------------------------------------
+
+func TestAcceptInbound_DeclinesUnestablishedPeer(t *testing.T) {
+	withXferEnv(t)
+	withCleanDownloads(t)
+	from, _ := cipher.GenerateKeyPair()
+
+	w, ok := acceptInbound(from, xfer.Offer{ID: "ai-decline-1", Name: "x.txt", Size: 3})
+	if ok || w != nil {
+		t.Errorf("acceptInbound from a peer we've never talked to = (%v, %v), want (nil, false)", w, ok)
+	}
+}
+
+func TestAcceptInbound_AcceptsEstablishedPeer(t *testing.T) {
+	withXferEnv(t)
+	dir := withCleanDownloads(t)
+	from, _ := cipher.GenerateKeyPair()
+	establishPeer(t, from)
+
+	offer := xfer.Offer{ID: "ai-est-1", Name: "notes.txt", Size: 5}
+	w, ok := acceptInbound(from, offer)
+	if !ok || w == nil {
+		t.Fatalf("acceptInbound from an established peer = (%v, %v), want a handle and true", w, ok)
+	}
+	defer func() { _ = w.Close() }() //nolint:errcheck
+
+	nf, isNamed := w.(*namedFile)
+	if !isNamed {
+		t.Fatalf("handle is %T, want *namedFile (onDone reads the path off it)", w)
+	}
+	want := filepath.Join(dir, safeFileName(offer.Name, offer.ID))
+	if nf.path != want {
+		t.Errorf("save path = %q, want %q", nf.path, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("accepting should have created the destination file: %v", err)
+	}
+}
+
+func TestAcceptInbound_AcceptsRequestedFileFromStranger(t *testing.T) {
+	// A backfill re-send arrives from a peer we may have no live conn with —
+	// we asked for it, so the policy lets it through.
+	withXferEnv(t)
+	withCleanDownloads(t)
+	from, _ := cipher.GenerateKeyPair()
+
+	offer := xfer.Offer{ID: "ai-req-1", Name: "backfilled.png", Size: 9}
+	if w, ok := acceptInbound(from, offer); ok || w != nil {
+		t.Fatal("precondition: an unrequested file from a stranger must be declined")
+	}
+
+	markFileRequested(offer.ID, from)
+	w, ok := acceptInbound(from, offer)
+	if !ok || w == nil {
+		t.Fatalf("a requested file should be accepted, got (%v, %v)", w, ok)
+	}
+	_ = w.Close() //nolint:errcheck
+
+	// The request is keyed to the peer we asked — a different peer answering
+	// with the same id is still a stranger.
+	impostor, _ := cipher.GenerateKeyPair()
+	if _, ok := acceptInbound(impostor, offer); ok {
+		t.Error("a requested id must not accept bytes from a different peer")
+	}
+}
+
+func TestAcceptInbound_GroupOfferFromNonMember(t *testing.T) {
+	withXferEnv(t)
+	withCleanDownloads(t)
+	from, _ := cipher.GenerateKeyPair()
+	// Established as a DM peer, but the offer is stamped with a group — the
+	// group branch decides, and we're not in it.
+	establishPeer(t, from)
+	cxoGroupSess = newEmptyGroupSession()
+	cxoGroup = "g1"
+
+	offer := xfer.Offer{ID: "ai-grp-1", Name: "shared.txt", Size: 4, Group: "g1"}
+	if w, ok := acceptInbound(from, offer); ok || w != nil {
+		t.Error("a group file from a non-member must be declined even if we DM that peer")
+	}
+}
+
+// TestAcceptInbound_SanitizesHostileName is the path-traversal guard at the
+// point where a peer-supplied name first reaches the filesystem.
+func TestAcceptInbound_SanitizesHostileName(t *testing.T) {
+	withXferEnv(t)
+	dir := withCleanDownloads(t)
+	from, _ := cipher.GenerateKeyPair()
+	establishPeer(t, from)
+
+	hostile := []string{
+		"../../evil.sh",
+		`..\..\evil.exe`,
+		"/etc/passwd",
+		"....//....//evil",
+	}
+	for _, name := range hostile {
+		t.Run(name, func(t *testing.T) {
+			offer := xfer.Offer{ID: "ai-evil-" + safeFileName(name, "x"), Name: name, Size: 1}
+			w, ok := acceptInbound(from, offer)
+			if !ok {
+				t.Fatalf("expected the transfer to be accepted (then sanitized), got declined")
+			}
+			defer func() { _ = w.Close() }() //nolint:errcheck
+
+			nf := w.(*namedFile) //nolint:errcheck,forcetypeassert
+			if filepath.Dir(nf.path) != filepath.Clean(dir) {
+				t.Errorf("save path %q escaped the downloads dir %q", nf.path, dir)
+			}
+			if strings.Contains(nf.path, "..") {
+				t.Errorf("save path %q still contains a traversal segment", nf.path)
+			}
+		})
+	}
+}
+
+// TestAcceptInbound_DeclinesWhenDestinationUnwritable covers the save-path
+// failure arm: the policy said yes but the file can't be created (here: a
+// directory already occupies the name; in the field, a full or read-only
+// disk). The transfer must be declined rather than accepted with a nil writer,
+// which the xfer receiver would deref.
+func TestAcceptInbound_DeclinesWhenDestinationUnwritable(t *testing.T) {
+	withXferEnv(t)
+	dir := withCleanDownloads(t)
+	from, _ := cipher.GenerateKeyPair()
+	establishPeer(t, from)
+
+	offer := xfer.Offer{ID: "ai-nowrite-1", Name: "blocked.txt", Size: 4}
+	blocker := filepath.Join(dir, safeFileName(offer.Name, offer.ID))
+	if err := os.Mkdir(blocker, 0o750); err != nil {
+		t.Fatalf("staging a directory at the destination: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(blocker) }) //nolint:errcheck
+
+	w, ok := acceptInbound(from, offer)
+	if ok || w != nil {
+		t.Errorf("acceptInbound with an uncreatable destination = (%v, %v), want (nil, false)", w, ok)
+	}
+}
+
+// --- onXferDone -------------------------------------------------------------
+
+func TestOnXferDone_IncomingSuccess(t *testing.T) {
+	withXferEnv(t)
+	restoreHistoryStore(t)
+	historyStore = newTempStore(t, history.Limits{})
+	dir := withCleanDownloads(t)
+	drain := collectEvents(t)
+
+	peer, _ := cipher.GenerateKeyPair()
+	offer := xfer.Offer{ID: "oxd-in-1", Name: "photo.png", Size: 2048}
+	onXferDone(xfer.Incoming, peer, offer, nil)
+
+	evs := drain()
+	if len(evs) != 1 {
+		t.Fatalf("got %d events, want 1: %+v", len(evs), evs)
+	}
+	ev := evs[0]
+	if ev.Dir != "in" || ev.From != peer.Hex() {
+		t.Errorf("dir/from = %q/%q, want in/%s", ev.Dir, ev.From, peer.Hex())
+	}
+	if ev.Channel != channelDM || ev.FileStatus != "received" {
+		t.Errorf("channel/status = %q/%q, want %s/received", ev.Channel, ev.FileStatus, channelDM)
+	}
+	if ev.FileID != offer.ID || ev.FileName != offer.Name || ev.FileSize != offer.Size {
+		t.Errorf("file fields = %s/%s/%d, want %s/%s/%d",
+			ev.FileID, ev.FileName, ev.FileSize, offer.ID, offer.Name, offer.Size)
+	}
+	if want := filepath.Join(dir, safeFileName(offer.Name, offer.ID)); ev.FilePath != want {
+		t.Errorf("file path = %q, want %q", ev.FilePath, want)
+	}
+	if !strings.Contains(ev.Text, "2.0 KB") {
+		t.Errorf("text %q should carry the human size", ev.Text)
+	}
+
+	// Persisted so the file re-renders from /history on a fresh browser.
+	msgs, err := historyStore.ListByPeer(peer.Hex(), 10)
+	if err != nil {
+		t.Fatalf("history list: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("history rows = %d, want 1", len(msgs))
+	}
+	if msgs[0].FileID != offer.ID || msgs[0].FileStatus != "received" || msgs[0].Outgoing {
+		t.Errorf("persisted row = %+v, want an incoming received row for %s", msgs[0], offer.ID)
+	}
+	if want := "/files/" + safeFileName(offer.Name, offer.ID); msgs[0].FileURL != want {
+		t.Errorf("persisted FileURL = %q, want %q", msgs[0].FileURL, want)
+	}
+}
+
+func TestOnXferDone_IncomingFailure(t *testing.T) {
+	withXferEnv(t)
+	restoreHistoryStore(t)
+	historyStore = newTempStore(t, history.Limits{})
+	withCleanDownloads(t)
+	drain := collectEvents(t)
+
+	peer, _ := cipher.GenerateKeyPair()
+	offer := xfer.Offer{ID: "oxd-inerr-1", Name: "broken.bin", Size: 10}
+	onXferDone(xfer.Incoming, peer, offer, context.DeadlineExceeded)
+
+	evs := drain()
+	if len(evs) != 1 {
+		t.Fatalf("got %d events, want 1", len(evs))
+	}
+	if evs[0].FileStatus != "failed" {
+		t.Errorf("status = %q, want failed", evs[0].FileStatus)
+	}
+	if !strings.Contains(evs[0].Text, "receive failed") {
+		t.Errorf("text %q should say the receive failed", evs[0].Text)
+	}
+	// A failed receive has no saved file, so no path is advertised.
+	if evs[0].FilePath != "" {
+		t.Errorf("failed receive advertised a path %q", evs[0].FilePath)
+	}
+}
+
+func TestOnXferDone_OutgoingSuccessPointsAtSenderCopy(t *testing.T) {
+	withXferEnv(t)
+	restoreHistoryStore(t)
+	historyStore = newTempStore(t, history.Limits{})
+	dir := withCleanDownloads(t)
+	drain := collectEvents(t)
+
+	peer, _ := cipher.GenerateKeyPair()
+	offer := xfer.Offer{ID: "oxd-out-1", Name: "clip.mp4", Size: 1024}
+	onXferDone(xfer.Outgoing, peer, offer, nil)
+
+	evs := drain()
+	if len(evs) != 1 {
+		t.Fatalf("got %d events, want 1", len(evs))
+	}
+	ev := evs[0]
+	if ev.Dir != "out" || ev.To != peer.Hex() || ev.From != "" {
+		t.Errorf("dir/to/from = %q/%q/%q, want out/%s/empty", ev.Dir, ev.To, ev.From, peer.Hex())
+	}
+	if ev.FileStatus != "sent" {
+		t.Errorf("status = %q, want sent", ev.FileStatus)
+	}
+	// The sender's own bubble renders from the kept copy, which is id-named.
+	if want := filepath.Join(dir, sentCopyName(offer)); ev.FilePath != want {
+		t.Errorf("file path = %q, want the sender copy %q", ev.FilePath, want)
+	}
+
+	msgs, err := historyStore.ListByPeer(peer.Hex(), 10)
+	if err != nil {
+		t.Fatalf("history list: %v", err)
+	}
+	if len(msgs) != 1 || !msgs[0].Outgoing {
+		t.Fatalf("history rows = %+v, want one outgoing row", msgs)
+	}
+}
+
+func TestOnXferDone_OutgoingFailure(t *testing.T) {
+	withXferEnv(t)
+	withCleanDownloads(t)
+	drain := collectEvents(t)
+
+	peer, _ := cipher.GenerateKeyPair()
+	onXferDone(xfer.Outgoing, peer, xfer.Offer{ID: "oxd-outerr-1", Name: "big.iso", Size: 1}, context.Canceled)
+
+	evs := drain()
+	if len(evs) != 1 {
+		t.Fatalf("got %d events, want 1", len(evs))
+	}
+	if evs[0].FileStatus != "failed" || !strings.Contains(evs[0].Text, "send failed") {
+		t.Errorf("event = %q/%q, want a failed send", evs[0].FileStatus, evs[0].Text)
+	}
+	if evs[0].FilePath != "" {
+		t.Errorf("failed send advertised a path %q", evs[0].FilePath)
+	}
+}
+
+// TestOnXferDone_GroupFileRoutesToGroupChannel — a group file must land on the
+// group channel with its id, and must NOT be persisted into the DM history
+// bucket (group messages live in the group bucket).
+func TestOnXferDone_GroupFileRoutesToGroupChannel(t *testing.T) {
+	withXferEnv(t)
+	restoreHistoryStore(t)
+	historyStore = newTempStore(t, history.Limits{})
+	withCleanDownloads(t)
+	drain := collectEvents(t)
+
+	peer, _ := cipher.GenerateKeyPair()
+	offer := xfer.Offer{ID: "oxd-grp-1", Name: "deck.pdf", Size: 512, Group: "group-abc"}
+	onXferDone(xfer.Incoming, peer, offer, nil)
+
+	evs := drain()
+	if len(evs) != 1 {
+		t.Fatalf("got %d events, want 1", len(evs))
+	}
+	if evs[0].Channel != channelGroup || evs[0].GroupID != "group-abc" {
+		t.Errorf("channel/group = %q/%q, want %s/group-abc", evs[0].Channel, evs[0].GroupID, channelGroup)
+	}
+
+	msgs, err := historyStore.ListByPeer(peer.Hex(), 10)
+	if err != nil {
+		t.Fatalf("history list: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("group file persisted %d DM history rows, want 0", len(msgs))
+	}
+}
+
+// TestOnXferDone_RequestedFileEmitsFileReady — a backfill response patches the
+// message that already references the file instead of creating a new one, so
+// it broadcasts a file-ready control event and skips both the normal event and
+// the history write.
+func TestOnXferDone_RequestedFileEmitsFileReady(t *testing.T) {
+	withXferEnv(t)
+	restoreHistoryStore(t)
+	historyStore = newTempStore(t, history.Limits{})
+	dir := withCleanDownloads(t)
+
+	raw, unsub := hub.subscribe()
+	defer unsub()
+	drain := collectEvents(t)
+
+	peer, _ := cipher.GenerateKeyPair()
+	offer := xfer.Offer{ID: "oxd-ready-1", Name: "late.png", Size: 32}
+	markFileRequested(offer.ID, peer)
+
+	onXferDone(xfer.Incoming, peer, offer, nil)
+
+	got := waitForString(t, raw, 2*time.Second)
+	var m map[string]any
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("decode file-ready: %v (raw %q)", err, got)
+	}
+	if m["channel"] != "file-ready" || m["file_id"] != offer.ID {
+		t.Errorf("broadcast = %v, want a file-ready for %s", m, offer.ID)
+	}
+	if want := "/files/" + safeFileName(offer.Name, offer.ID); m["file_url"] != want {
+		t.Errorf("file_url = %v, want %q", m["file_url"], want)
+	}
+	_ = dir
+
+	// The fulfilled request is dropped so a later unsolicited send is declined.
+	if isRequestedFile(offer.ID, peer) {
+		t.Error("a completed backfill should clear its pending request")
+	}
+	// No normal file event, and nothing persisted.
+	if evs := drain(); len(evs) != 0 {
+		t.Errorf("backfill emitted %d normal events, want 0: %+v", len(evs), evs)
+	}
+	msgs, err := historyStore.ListByPeer(peer.Hex(), 10)
+	if err != nil {
+		t.Fatalf("history list: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("backfill persisted %d rows, want 0 (it patches an existing message)", len(msgs))
+	}
+}
+
+// --- sendFileID -------------------------------------------------------------
+
+func TestSendFileID_Errors(t *testing.T) {
+	withXferEnv(t)
+	withCleanDownloads(t)
+	peer, _ := cipher.GenerateKeyPair()
+	ctx := context.Background()
+
+	// No manager (file transfer disabled / standalone).
+	fileMgr = nil
+	if _, err := sendFileID(ctx, peer, "", writeTempFile(t, "a.txt", "x"), "id1", "a.txt", false); err == nil ||
+		!strings.Contains(err.Error(), "not enabled") {
+		t.Errorf("nil manager err = %v, want a 'not enabled' error", err)
+	}
+
+	// With a manager installed, the source checks run before any dial.
+	fileMgr = xfer.NewManager(xfer.Config{Dial: func(context.Context, cipher.PubKey, uint16) (net.Conn, error) {
+		t.Error("dial must not be attempted for an unreadable source")
+		return nil, net.ErrClosed
+	}})
+
+	missing := filepath.Join(t.TempDir(), "nope.txt")
+	if _, err := sendFileID(ctx, peer, "", missing, "id2", "nope.txt", false); err == nil ||
+		!strings.Contains(err.Error(), "open") {
+		t.Errorf("missing source err = %v, want an open error", err)
+	}
+
+	if _, err := sendFileID(ctx, peer, "", t.TempDir(), "id3", "", false); err == nil ||
+		!strings.Contains(err.Error(), "is a directory") {
+		t.Errorf("directory source err = %v, want a directory error", err)
+	}
+}
+
+// TestSendFileID_EndToEnd runs a real transfer between two managers over an
+// in-process listener, with the receiving side wired to the production
+// acceptInbound + onXferDone. It covers the send path, the accept policy, the
+// on-disk save, the SSE surfacing and the history write together.
+func TestSendFileID_EndToEnd(t *testing.T) {
+	withXferEnv(t)
+	restoreHistoryStore(t)
+	historyStore = newTempStore(t, history.Limits{})
+	dir := withCleanDownloads(t)
+	drain := collectEvents(t)
+
+	senderPK, _ := cipher.GenerateKeyPair()
+	recvPK, _ := cipher.GenerateKeyPair()
+
+	// The receiver auto-accepts because a chat with the sender is established —
+	// the real policy, not a stubbed Accept.
+	establishPeer(t, senderPK)
+
+	lis := newMemXferListener(senderPK)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
+	// The receiver runs on its own goroutines and touches the package globals
+	// (hub, historyStore) that withXferEnv restores on cleanup. Join both
+	// before returning, or the restore races the in-flight receive. Deferred
+	// here so it runs ahead of every t.Cleanup.
+	serveDone := make(chan struct{})
+	recvDone := make(chan struct{})
+	var recvOnce sync.Once
+	defer func() {
+		cancel()
+		_ = lis.Close() //nolint:errcheck
+		<-serveDone
+	}()
+
+	recvMgr := xfer.NewManager(xfer.Config{
+		LocalPK: recvPK,
+		Port:    1,
+		Accept:  acceptInbound,
+		OnDone: func(d xfer.Direction, p cipher.PubKey, o xfer.Offer, e error) {
+			onXferDone(d, p, o, e)
+			recvOnce.Do(func() { close(recvDone) })
+		},
+	})
+	go func() {
+		defer close(serveDone)
+		recvMgr.Serve(ctx, lis)
+	}()
+
+	fileMgrMu.Lock()
+	fileMgr = xfer.NewManager(xfer.Config{
+		LocalPK: senderPK,
+		Port:    1,
+		Dial:    func(context.Context, cipher.PubKey, uint16) (net.Conn, error) { return lis.dialMem() },
+		OnDone:  onXferDone,
+	})
+	fileMgrMu.Unlock()
+
+	payload := strings.Repeat("skychat-payload-", 512) // 8 KiB
+	src := writeTempFile(t, "report.txt", payload)
+
+	const id = "e2e-xfer-1"
+	gotID, err := sendFileID(ctx, recvPK, "", src, id, "report.txt", true)
+	if err != nil {
+		t.Fatalf("sendFileID: %v", err)
+	}
+	if gotID != id {
+		t.Errorf("returned id = %q, want %q", gotID, id)
+	}
+
+	// SendFile returns once the receipt is read; the receiver's own OnDone
+	// (history persist included) can still be running.
+	select {
+	case <-recvDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the receiver's OnDone never fired")
+	}
+
+	// The receiver saved the bytes under the sanitized name.
+	saved := filepath.Join(dir, safeFileName("report.txt", id))
+	waitForFile(t, saved, int64(len(payload)))
+	b, rerr := os.ReadFile(saved) //nolint:gosec
+	if rerr != nil {
+		t.Fatalf("read saved file: %v", rerr)
+	}
+	if !bytes.Equal(b, []byte(payload)) {
+		t.Errorf("saved content differs (%d bytes vs %d sent)", len(b), len(payload))
+	}
+
+	// The sender kept its own served copy so its bubble survives a reload.
+	sentCopy := filepath.Join(dir, sentCopyName(xfer.Offer{ID: id, Name: "report.txt"}))
+	if _, serr := os.Stat(sentCopy); serr != nil {
+		t.Errorf("sender copy %q missing: %v", sentCopy, serr)
+	}
+
+	// Both legs surfaced: an "out" event from the sender manager and an "in"
+	// event from the receiver's.
+	evs := drain()
+	var sawIn, sawOut bool
+	for _, ev := range evs {
+		if ev.FileID != id {
+			continue
+		}
+		switch ev.Dir {
+		case "in":
+			sawIn = true
+			if ev.FileStatus != "received" {
+				t.Errorf("inbound status = %q, want received", ev.FileStatus)
+			}
+		case "out":
+			sawOut = true
+			if ev.FileStatus != "sent" {
+				t.Errorf("outbound status = %q, want sent", ev.FileStatus)
+			}
+		}
+	}
+	if !sawIn || !sawOut {
+		t.Errorf("events in=%v out=%v, want both (%d total: %+v)", sawIn, sawOut, len(evs), evs)
+	}
+}
+
+// TestSendFileID_DeclinedByPeer covers the receiver-verdict branch: an
+// unestablished peer declines, and the sender must report that rather than
+// claiming success.
+func TestSendFileID_DeclinedByPeer(t *testing.T) {
+	withXferEnv(t)
+	withCleanDownloads(t)
+
+	senderPK, _ := cipher.GenerateKeyPair()
+	recvPK, _ := cipher.GenerateKeyPair()
+	// NOTE: no establishPeer → acceptInbound declines.
+	chatCtrl = nil
+
+	lis := newMemXferListener(senderPK)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
+	// acceptInbound reads chatCtrl, which withXferEnv restores on cleanup —
+	// join the receiver before returning. A DECLINED transfer never calls
+	// OnDone, so the Accept hook itself is what signals.
+	serveDone := make(chan struct{})
+	consulted := make(chan struct{})
+	var acceptOnce sync.Once
+	defer func() {
+		cancel()
+		_ = lis.Close() //nolint:errcheck
+		<-serveDone
+	}()
+
+	recvMgr := xfer.NewManager(xfer.Config{
+		LocalPK: recvPK,
+		Port:    1,
+		Accept: func(pk cipher.PubKey, o xfer.Offer) (io.WriteCloser, bool) {
+			defer acceptOnce.Do(func() { close(consulted) })
+			return acceptInbound(pk, o)
+		},
+	})
+	go func() {
+		defer close(serveDone)
+		recvMgr.Serve(ctx, lis)
+	}()
+
+	fileMgrMu.Lock()
+	fileMgr = xfer.NewManager(xfer.Config{
+		LocalPK: senderPK,
+		Port:    1,
+		Dial:    func(context.Context, cipher.PubKey, uint16) (net.Conn, error) { return lis.dialMem() },
+	})
+	fileMgrMu.Unlock()
+
+	src := writeTempFile(t, "rejected.txt", "nope")
+	_, err := sendFileID(ctx, recvPK, "", src, "e2e-decline-1", "rejected.txt", false)
+	if err == nil {
+		t.Fatal("sendFileID to a declining peer should return an error")
+	}
+	if !strings.Contains(err.Error(), "rejected") {
+		t.Errorf("err = %v, want it to mention the peer rejected the transfer", err)
+	}
+	select {
+	case <-consulted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the accept policy was never consulted")
+	}
+}
+
+func TestSendFileID_SenderCopyRules(t *testing.T) {
+	withXferEnv(t)
+	dir := withCleanDownloads(t)
+	peer, _ := cipher.GenerateKeyPair()
+	ctx := context.Background()
+
+	// A dial that always fails: the copy decision happens BEFORE SendFile, so
+	// the send failing doesn't affect what this asserts.
+	fileMgrMu.Lock()
+	fileMgr = xfer.NewManager(xfer.Config{
+		Dial: func(context.Context, cipher.PubKey, uint16) (net.Conn, error) { return nil, net.ErrClosed },
+	})
+	fileMgrMu.Unlock()
+
+	cases := []struct {
+		name     string
+		id       string
+		group    string
+		keepCopy bool
+		want     bool
+	}{
+		{"dm send keeps a copy", "copy-dm-1", "", true, true},
+		{"backfill re-send keeps none", "copy-bf-1", "", false, false},
+		{"group send keeps none", "copy-grp-1", "g1", true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			src := writeTempFile(t, "doc.txt", "content")
+			_, _ = sendFileID(ctx, peer, c.group, src, c.id, "doc.txt", c.keepCopy) //nolint:errcheck
+
+			copyPath := filepath.Join(dir, sentCopyName(xfer.Offer{ID: c.id, Name: "doc.txt"}))
+			_, err := os.Stat(copyPath)
+			if got := err == nil; got != c.want {
+				t.Errorf("sender copy at %q exists = %v, want %v", copyPath, got, c.want)
+			}
+		})
+	}
+}
+
+// TestSendFileID_EmptyNameFallsBackToBase pins the display-name default: an
+// empty name must not produce a nameless offer.
+func TestSendFileID_EmptyNameFallsBackToBase(t *testing.T) {
+	withXferEnv(t)
+	dir := withCleanDownloads(t)
+	peer, _ := cipher.GenerateKeyPair()
+
+	fileMgrMu.Lock()
+	fileMgr = xfer.NewManager(xfer.Config{
+		Dial: func(context.Context, cipher.PubKey, uint16) (net.Conn, error) { return nil, net.ErrClosed },
+	})
+	fileMgrMu.Unlock()
+
+	src := writeTempFile(t, "fallback.dat", "x")
+	_, _ = sendFileID(context.Background(), peer, "", src, "name-fb-1", "", true) //nolint:errcheck
+
+	// The kept copy's extension comes from the offer name, which defaulted to
+	// the source's base name.
+	want := filepath.Join(dir, "name-fb-1.dat")
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("expected the sender copy at %q (name defaulted to the base name): %v", want, err)
+	}
+}
+
+// TestSendFileID_SenderCopyFailureIsNonFatal pins the best-effort contract on
+// the kept copy: if it can't be written the send still goes ahead (the copy
+// only backs the sender's own thumbnail). Here a directory occupies the copy's
+// name; in the field it would be a full disk.
+func TestSendFileID_SenderCopyFailureIsNonFatal(t *testing.T) {
+	withXferEnv(t)
+	dir := withCleanDownloads(t)
+	peer, _ := cipher.GenerateKeyPair()
+
+	const id = "copy-fail-1"
+	blocker := filepath.Join(dir, sentCopyName(xfer.Offer{ID: id, Name: "doc.txt"}))
+	if err := os.Mkdir(blocker, 0o750); err != nil {
+		t.Fatalf("staging a directory at the copy path: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(blocker) }) //nolint:errcheck
+
+	dialed := false
+	fileMgrMu.Lock()
+	fileMgr = xfer.NewManager(xfer.Config{
+		Dial: func(context.Context, cipher.PubKey, uint16) (net.Conn, error) {
+			dialed = true
+			return nil, net.ErrClosed
+		},
+	})
+	fileMgrMu.Unlock()
+
+	src := writeTempFile(t, "doc.txt", "content")
+	if _, err := sendFileID(context.Background(), peer, "", src, id, "doc.txt", true); err == nil {
+		t.Fatal("expected the (failing) dial to surface an error")
+	}
+	if !dialed {
+		t.Error("a failed sender copy must not abort the send before it dials")
+	}
+}
+
+// --- sendFileToGroup --------------------------------------------------------
+
+func TestSendFileToGroup_Errors(t *testing.T) {
+	withXferEnv(t)
+	src := writeTempFile(t, "g.txt", "x")
+
+	cxoGroupSess, cxoGroup = nil, ""
+	if n, err := sendFileToGroup(context.Background(), src); err == nil || n != 0 {
+		t.Errorf("no session: (%d, %v), want (0, error)", n, err)
+	}
+
+	// A session with an id but no online members has nobody to send to.
+	cxoGroupSess = newEmptyGroupSession()
+	cxoGroup = "g1"
+	n, err := sendFileToGroup(context.Background(), src)
+	if err == nil || n != 0 {
+		t.Errorf("no members: (%d, %v), want (0, error)", n, err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "no other members online") {
+		t.Errorf("err = %v, want it to name the empty-group case", err)
+	}
+}

--- a/cmd/apps/skychat/commands/filexfer_transfer_test.go
+++ b/cmd/apps/skychat/commands/filexfer_transfer_test.go
@@ -87,7 +87,12 @@ func withXferEnv(t *testing.T) {
 	hub = newSSEHub()
 	pairEnable = false
 	osNotify = false
+	// fileMgr is read under fileMgrMu by sendFileID, which handleFileRequestFrame
+	// calls from a goroutine that can outlive the test that spawned it — so this
+	// write needs the lock too, not just the one in Cleanup below.
+	fileMgrMu.Lock()
 	fileMgr = nil
+	fileMgrMu.Unlock()
 	cxoGroupSess = nil
 	cxoGroup = ""
 

--- a/cmd/apps/skychat/commands/ipcsignal_test.go
+++ b/cmd/apps/skychat/commands/ipcsignal_test.go
@@ -1,0 +1,210 @@
+// Package commands cmd/apps/skychat/commands/ipcsignal_test.go
+//
+// Unit coverage for the IPC shutdown-signal handler.
+//
+// The load-bearing test here is TestIPCSignalLoop_ReadErrorStopsAfterOneRead.
+// This loop once lacked its `break` on a read error, and golang-ipc's Read
+// closes the receive channel on the first error — so every later Read returned
+// instantly and the loop spun at full tilt, logging hundreds of lines per
+// millisecond. On the 2-core Windows CI runner that starved the HTTP server
+// and dmsg, and skychat's port stopped answering (the visor-B "connection
+// refused" failures in the native e2e suite).
+//
+// A test that only checks "the loop exits" would pass on a build that spins a
+// million times first, so the assertion is on the READ COUNT: exactly one.
+// The fake keeps returning the error forever — as the real client does once
+// its channel is closed — so a build without the break never leaves the loop
+// on its own. Verified by mutation: deleting the break makes the fake log
+// ~2.6e8 reads in ten seconds.
+package commands
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	ipc "github.com/james-barrow/golang-ipc"
+
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// fakeIPC is a scripted ipcConn. Each Read pops the next step; once the script
+// is exhausted it repeats the last one forever, which is what golang-ipc does
+// after it closes the receive channel — and what turns a missing `break` into
+// a spin instead of a clean exit.
+type fakeIPC struct {
+	mu     sync.Mutex
+	script []ipcStep
+	reads  int
+	closed int
+	// maxReads bounds a runaway loop. Past it Read hands back a SHUTDOWN
+	// message rather than another error: a build that ignores read errors
+	// would ignore one more error too and keep spinning, whereas the shutdown
+	// type breaks the loop on a path that build still honors. That converts a
+	// regression from a ten-second watchdog timeout into an immediate,
+	// precise read-count failure.
+	maxReads int
+}
+
+type ipcStep struct {
+	msg *ipc.Message
+	err error
+}
+
+func newFakeIPC(script ...ipcStep) *fakeIPC {
+	return &fakeIPC{script: script, maxReads: 100}
+}
+
+func (f *fakeIPC) Read() (*ipc.Message, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reads++
+	if f.reads > f.maxReads {
+		return msg(skyenv.IPCShutdownMessageType), nil // see maxReads
+	}
+	idx := f.reads - 1
+	if idx >= len(f.script) {
+		idx = len(f.script) - 1 // repeat the terminal step, like the real client
+	}
+	s := f.script[idx]
+	return s.msg, s.err
+}
+
+func (f *fakeIPC) Close() {
+	f.mu.Lock()
+	f.closed++
+	f.mu.Unlock()
+}
+
+func (f *fakeIPC) counts() (reads, closed int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reads, f.closed
+}
+
+// runLoop runs ipcSignalLoop with a watchdog so a spinning regression fails
+// loudly instead of blocking the package for the whole test timeout.
+func runLoop(t *testing.T, f *fakeIPC) {
+	t.Helper()
+	if appLog == nil {
+		appLog = func(string, ...any) {}
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ipcSignalLoop(f)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		reads, _ := f.counts()
+		t.Fatalf("ipcSignalLoop did not return (%d reads) — the read loop is spinning", reads)
+	}
+}
+
+func msg(msgType int) *ipc.Message { return &ipc.Message{MsgType: msgType} }
+
+// TestIPCSignalLoop_ReadErrorStopsAfterOneRead is the regression guard for the
+// Windows CI outage: a read error must terminate the loop immediately.
+func TestIPCSignalLoop_ReadErrorStopsAfterOneRead(t *testing.T) {
+	// The real failure mode: Read errors and keeps erroring, because
+	// golang-ipc closed the receive channel underneath it.
+	f := newFakeIPC(ipcStep{err: errors.New("the received channel has been closed")})
+	runLoop(t, f)
+
+	reads, closed := f.counts()
+	if reads != 1 {
+		t.Errorf("Read called %d times after an error; want exactly 1 "+
+			"(more than one means the loop is spinning on a dead channel)", reads)
+	}
+	if closed != 1 {
+		t.Errorf("Close called %d times, want 1 — the client must be released on the error path", closed)
+	}
+}
+
+// TestIPCSignalLoop_ErrorAfterTrafficStillStops covers the realistic sequence:
+// normal messages flow, then the connection dies mid-stream.
+func TestIPCSignalLoop_ErrorAfterTrafficStillStops(t *testing.T) {
+	f := newFakeIPC(
+		ipcStep{msg: msg(1)},
+		ipcStep{msg: msg(2)},
+		ipcStep{err: errors.New("connection lost")},
+	)
+	runLoop(t, f)
+
+	reads, closed := f.counts()
+	if reads != 3 {
+		t.Errorf("Read called %d times, want 3 (two messages then the error)", reads)
+	}
+	if closed != 1 {
+		t.Errorf("Close called %d times, want 1", closed)
+	}
+}
+
+func TestIPCSignalLoop_ShutdownMessageStopsLoop(t *testing.T) {
+	f := newFakeIPC(ipcStep{msg: msg(skyenv.IPCShutdownMessageType)})
+	runLoop(t, f)
+
+	reads, closed := f.counts()
+	if reads != 1 {
+		t.Errorf("Read called %d times, want 1 — the shutdown message ends the loop", reads)
+	}
+	if closed != 1 {
+		t.Errorf("Close called %d times, want 1", closed)
+	}
+}
+
+// TestIPCSignalLoop_IgnoresOtherMessageTypes — only the shutdown type ends the
+// handler; anything else (including golang-ipc's negative internal types, such
+// as the connect/reconnect status messages it injects) is skipped.
+func TestIPCSignalLoop_IgnoresOtherMessageTypes(t *testing.T) {
+	f := newFakeIPC(
+		ipcStep{msg: msg(-1)}, // internal status message
+		ipcStep{msg: msg(1)},
+		ipcStep{msg: msg(skyenv.IPCShutdownMessageType + 1)}, // adjacent, must not match
+		ipcStep{msg: msg(skyenv.IPCShutdownMessageType)},
+	)
+	runLoop(t, f)
+
+	if reads, _ := f.counts(); reads != 4 {
+		t.Errorf("Read called %d times, want 4 — only the shutdown type should end the loop", reads)
+	}
+}
+
+// TestIPCSignalLoop_NilMessageIsSkipped — Read may hand back (nil, nil); the
+// loop must not deref it. Without the `if m != nil` guard this panics.
+func TestIPCSignalLoop_NilMessageIsSkipped(t *testing.T) {
+	f := newFakeIPC(
+		ipcStep{}, // nil message, nil error
+		ipcStep{msg: msg(skyenv.IPCShutdownMessageType)},
+	)
+	runLoop(t, f)
+
+	if reads, _ := f.counts(); reads != 2 {
+		t.Errorf("Read called %d times, want 2 — a nil message is skipped, not fatal", reads)
+	}
+}
+
+// TestHandleIPCSignal_NilClient — the guard that keeps a failed StartClient
+// from panicking the handler goroutine. ipcStartupDelay is zeroed so the test
+// doesn't sit out the real startup grace period.
+func TestHandleIPCSignal_NilClient(t *testing.T) {
+	if appLog == nil {
+		appLog = func(string, ...any) {}
+	}
+	prev := ipcStartupDelay
+	ipcStartupDelay = 0
+	t.Cleanup(func() { ipcStartupDelay = prev })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleIPCSignal(nil) // must return, not deref
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleIPCSignal(nil) did not return")
+	}
+}

--- a/cmd/apps/skychat/commands/lifecycle_test.go
+++ b/cmd/apps/skychat/commands/lifecycle_test.go
@@ -1,0 +1,918 @@
+// Package commands cmd/apps/skychat/commands/lifecycle_test.go
+//
+// Coverage for the long-running / lifecycle surface that was still at 0%: the
+// two SSE stream handlers (/sse and /events), the DM send handler, the
+// controller's surfacing callback, the feature-gated mux registrations, the
+// two visor-RPC pollers, and the RPC dial + watchdog lifecycle.
+//
+// These are all loops or wiring, which is why they were skipped: none of them
+// return on their own. The pattern used throughout is to run the thing under a
+// cancellable context in a goroutine, drive one observable cycle, cancel, and
+// only then read what it produced — reading a recorder while its handler is
+// still writing is a data race, not a test.
+//
+// Two properties here are worth more than the coverage:
+//
+//   - the /sse seed lines are tagged history:"true". The browser relies on that
+//     tag to skip them; without it every reconnect re-renders the last 50
+//     messages as if they were new (the "old messages show as new on reload"
+//     bug).
+//   - registerGroupHTTPHandlers / registerPresenceHTTPHandlers /
+//     registerVoiceHTTPHandlers must register NOTHING when --pair-enable is
+//     off, so a standalone skychat doesn't advertise endpoints that can only
+//     ever 503.
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skychat/dm"
+	"github.com/skycoin/skywire/pkg/skychat/history"
+	"github.com/skycoin/skywire/pkg/skychat/message"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+// --- harness ----------------------------------------------------------------
+
+// withLifecycleEnv gives the test a private hub, a discard chatLog, pairing
+// off, no CXO, and restores every global it touches.
+func withLifecycleEnv(t *testing.T) {
+	t.Helper()
+	if appLog == nil {
+		appLog = func(string, ...any) {}
+	}
+	withChatLog(t)
+
+	orig := struct {
+		hub          *sseHub
+		pairEnable   bool
+		osNotify     bool
+		cxoEnable    bool
+		cxoGroup     string
+		chatCtrl     *dm.Controller
+		seed         int
+		pollInterval time.Duration
+		rpcAddr      string
+	}{hub, pairEnable, osNotify, cxoEnable, cxoGroup, chatCtrl, persistSeedCount, pairPollInterval, pairRPCAddr}
+
+	hub = newSSEHub()
+	pairEnable = false
+	osNotify = false
+	cxoEnable = false
+	cxoGroup = ""
+	persistSeedCount = 0
+
+	t.Cleanup(func() {
+		hub, pairEnable, osNotify = orig.hub, orig.pairEnable, orig.osNotify
+		cxoEnable, cxoGroup, chatCtrl = orig.cxoEnable, orig.cxoGroup, orig.chatCtrl
+		persistSeedCount, pairPollInterval, pairRPCAddr = orig.seed, orig.pollInterval, orig.rpcAddr
+	})
+}
+
+// serveStream runs an SSE-style handler against a recorder under a cancellable
+// request context, gives it `settle` to produce output, then cancels and waits
+// for the handler to return before handing back the body. Reading the recorder
+// any earlier races the handler's writes.
+func serveStream(t *testing.T, h http.HandlerFunc, target string, settle time.Duration,
+	during func()) *httptest.ResponseRecorder {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, target, nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h(rr, req)
+	}()
+
+	if during != nil {
+		during()
+	}
+	time.Sleep(settle)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream handler did not return after its request context was canceled")
+	}
+	return rr
+}
+
+// nonFlusher is an http.ResponseWriter without Flush, so the streaming
+// handlers' capability check fires.
+type nonFlusher struct {
+	hdr  http.Header
+	code int
+	body strings.Builder
+}
+
+func (n *nonFlusher) Header() http.Header {
+	if n.hdr == nil {
+		n.hdr = http.Header{}
+	}
+	return n.hdr
+}
+func (n *nonFlusher) Write(b []byte) (int, error) { return n.body.Write(b) }
+func (n *nonFlusher) WriteHeader(c int)           { n.code = c }
+
+// --- sseHandler -------------------------------------------------------------
+
+func TestSSEHandler_RejectsNonStreamingWriter(t *testing.T) {
+	withLifecycleEnv(t)
+	nf := &nonFlusher{}
+	sseHandler(nf, httptest.NewRequest(http.MethodGet, "/sse", nil))
+	if nf.code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 when the writer cannot stream", nf.code)
+	}
+}
+
+func TestSSEHandler_StreamsBroadcasts(t *testing.T) {
+	withLifecycleEnv(t)
+
+	rr := serveStream(t, sseHandler, "/sse", 300*time.Millisecond, func() {
+		// Give the handler a moment to subscribe before broadcasting, or the
+		// message is published to nobody.
+		time.Sleep(150 * time.Millisecond)
+		hub.broadcast(`{"sender":"peer","message":"live one"}`)
+	})
+
+	body := rr.Body.String()
+	if ct := rr.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	if rr.Header().Get("X-Accel-Buffering") != "no" {
+		t.Error("X-Accel-Buffering: no is required or a reverse proxy buffers the stream")
+	}
+	if !strings.Contains(body, ": connected") {
+		t.Errorf("stream should open with a ': connected' keepalive; got %q", body)
+	}
+	if !strings.Contains(body, `data: {"sender":"peer","message":"live one"}`) {
+		t.Errorf("broadcast not delivered; body = %q", body)
+	}
+}
+
+// TestSSEHandler_SeedsHistoryTagged is the guard for the "old messages show as
+// new on reload" bug: every seeded line must carry history:"true" so the
+// browser skips it. An untagged seed renders as fresh traffic on every
+// EventSource reconnect.
+func TestSSEHandler_SeedsHistoryTagged(t *testing.T) {
+	withLifecycleEnv(t)
+	restoreHistoryStore(t)
+	historyStore = newTempStore(t, history.Limits{})
+	persistSeedCount = 10
+
+	peer, _ := cipher.GenerateKeyPair()
+	if err := historyStore.Append(history.Message{
+		Peer: peer.Hex(), From: peer.Hex(), Text: "seeded inbound", Timestamp: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed append: %v", err)
+	}
+	if err := historyStore.Append(history.Message{
+		Peer: peer.Hex(), Outgoing: true, Text: "seeded outbound", Timestamp: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed append: %v", err)
+	}
+
+	rr := serveStream(t, sseHandler, "/sse", 200*time.Millisecond, nil)
+	body := rr.Body.String()
+
+	if !strings.Contains(body, "seeded inbound") || !strings.Contains(body, "seeded outbound") {
+		t.Fatalf("history was not seeded into the stream; body = %q", body)
+	}
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var m map[string]string
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &m); err != nil {
+			continue
+		}
+		if m["history"] != "true" {
+			t.Errorf("seeded line %q lacks history:\"true\" — the browser would render it as new", line)
+		}
+	}
+	// An outgoing seed is attributed to "self" so the UI can side it correctly.
+	if !strings.Contains(body, `"sender":"self"`) {
+		t.Error("an outgoing seeded message should be attributed to self")
+	}
+}
+
+// --- eventsHandler ----------------------------------------------------------
+
+func TestEventsHandler_RejectsNonStreamingWriter(t *testing.T) {
+	withLifecycleEnv(t)
+	nf := &nonFlusher{}
+	eventsHandler(nf, httptest.NewRequest(http.MethodGet, "/events", nil))
+	if nf.code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", nf.code)
+	}
+}
+
+func TestEventsHandler_RejectsBadSince(t *testing.T) {
+	withLifecycleEnv(t)
+	rr := httptest.NewRecorder()
+	eventsHandler(rr, httptest.NewRequest(http.MethodGet, "/events?since=not-a-number", nil))
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for a non-numeric since", rr.Code)
+	}
+}
+
+func TestEventsHandler_StreamsStructuredEvents(t *testing.T) {
+	withLifecycleEnv(t)
+
+	peer, _ := cipher.GenerateKeyPair()
+	rr := serveStream(t, eventsHandler, "/events", 300*time.Millisecond, func() {
+		time.Sleep(150 * time.Millisecond)
+		hub.publishEvent(chatEvent{
+			ID: "ev-1", Channel: channelDM, Dir: "in", From: peer.Hex(), Text: "structured",
+		})
+	})
+
+	body := rr.Body.String()
+	if !strings.Contains(body, ": connected") {
+		t.Errorf("stream should open with ': connected'; got %q", body)
+	}
+	var found bool
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var ev chatEvent
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &ev); err != nil {
+			t.Errorf("event line is not a chatEvent: %v (%q)", err, line)
+			continue
+		}
+		if ev.ID == "ev-1" && ev.Text == "structured" && ev.Channel == channelDM {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("published event not delivered on /events; body = %q", body)
+	}
+}
+
+// TestEventsHandler_ChannelFilterExcludes — ?channel=group must not deliver dm
+// traffic, or `cli skychat events --channel group` is noise.
+func TestEventsHandler_ChannelFilterExcludes(t *testing.T) {
+	withLifecycleEnv(t)
+
+	rr := serveStream(t, eventsHandler, "/events?channel=group", 300*time.Millisecond, func() {
+		time.Sleep(150 * time.Millisecond)
+		hub.publishEvent(chatEvent{ID: "dm-1", Channel: channelDM, Dir: "in", Text: "a dm"})
+		hub.publishEvent(chatEvent{ID: "grp-1", Channel: channelGroup, Dir: "in", Text: "a group msg"})
+	})
+
+	body := rr.Body.String()
+	if strings.Contains(body, "dm-1") {
+		t.Error("channel=group delivered a dm event")
+	}
+	if !strings.Contains(body, "grp-1") {
+		t.Errorf("channel=group did not deliver the group event; body = %q", body)
+	}
+}
+
+// --- messageHandler ---------------------------------------------------------
+
+func TestMessageHandler_Validation(t *testing.T) {
+	withLifecycleEnv(t)
+	h := messageHandler(context.Background())
+	pk, _ := cipher.GenerateKeyPair()
+
+	cases := []struct{ name, body string }{
+		{"malformed json", `{"recipient":`},
+		{"bad recipient", `{"recipient":"not-a-pk","message":"x"}`},
+		{"unknown network", `{"recipient":"` + pk.Hex() + `","message":"x","network":"carrier-pigeon"}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			h(rr, httptest.NewRequest(http.MethodPost, "/message", strings.NewReader(c.body)))
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400; body=%q", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestMessageHandler_SendsPlainAndReceipts(t *testing.T) {
+	withLifecycleEnv(t)
+	cc := newCapturingClient()
+	chatCtrl = dm.New(dm.Config{Client: cc, Networks: []appnet.Type{appnet.TypeSkynet}})
+	t.Cleanup(func() {
+		_ = chatCtrl.Close() //nolint:errcheck
+		cc.closeAll()
+	})
+
+	h := messageHandler(context.Background())
+	pk, _ := cipher.GenerateKeyPair()
+
+	// Plain send: byte-identical wire (no envelope), empty 200 body.
+	rr := httptest.NewRecorder()
+	h(rr, httptest.NewRequest(http.MethodPost, "/message",
+		strings.NewReader(`{"recipient":"`+pk.Hex()+`","message":"plain hello"}`)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("plain send status = %d, want 200; body=%q", rr.Code, rr.Body.String())
+	}
+	select {
+	case raw := <-cc.frames:
+		if string(raw) != "plain hello" {
+			t.Errorf("wire payload = %q, want the bare text (a default send must stay envelope-free)", raw)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("nothing reached the wire on a plain send")
+	}
+
+	// Receipts send: id'd envelope, non-blocking, returns the wire id.
+	rr = httptest.NewRecorder()
+	h(rr, httptest.NewRequest(http.MethodPost, "/message",
+		strings.NewReader(`{"recipient":"`+pk.Hex()+`","message":"tracked","receipts":true}`)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("receipts send status = %d, want 200; body=%q", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		OK bool   `json:"ok"`
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode receipts response: %v (%q)", err, rr.Body.String())
+	}
+	if !resp.OK || resp.ID == "" {
+		t.Errorf("receipts response = %+v, want ok plus a wire id the UI can track", resp)
+	}
+	select {
+	case raw := <-cc.frames:
+		if !strings.Contains(string(raw), resp.ID) {
+			t.Errorf("wire frame %q should carry the returned id %q", raw, resp.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("nothing reached the wire on a receipts send")
+	}
+}
+
+// TestMessageHandler_WaitTimesOut — a --wait send against a peer that never
+// acks must report 504 with acked:false rather than claiming delivery.
+func TestMessageHandler_WaitTimesOut(t *testing.T) {
+	withLifecycleEnv(t)
+	cc := newCapturingClient()
+	chatCtrl = dm.New(dm.Config{Client: cc, Networks: []appnet.Type{appnet.TypeSkynet}})
+	t.Cleanup(func() {
+		_ = chatCtrl.Close() //nolint:errcheck
+		cc.closeAll()
+	})
+
+	h := messageHandler(context.Background())
+	pk, _ := cipher.GenerateKeyPair()
+
+	rr := httptest.NewRecorder()
+	// wait_ms=1 clamps up to chatAckTimeoutFloor (100ms), so this is quick.
+	h(rr, httptest.NewRequest(http.MethodPost, "/message",
+		strings.NewReader(`{"recipient":"`+pk.Hex()+`","message":"anyone there","wait_ms":1}`)))
+
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504; body=%q", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Acked  bool   `json:"acked"`
+		Reason string `json:"reason"`
+		ID     string `json:"id"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (%q)", err, rr.Body.String())
+	}
+	if resp.Acked || resp.Reason != "timeout" {
+		t.Errorf("response = %+v, want acked:false reason:timeout", resp)
+	}
+	if resp.ID == "" {
+		t.Error("a timed-out wait send should still report the id it used")
+	}
+}
+
+// --- onChatEvent ------------------------------------------------------------
+
+func TestOnChatEvent_SurfacesBothDirections(t *testing.T) {
+	withLifecycleEnv(t)
+	peer, _ := cipher.GenerateKeyPair()
+
+	sub, unsub := hub.subscribeEvents(nil, 0)
+	defer unsub()
+
+	onChatEvent(dm.Event{ID: "in-1", Dir: "in", Peer: peer.Hex(), Network: "skynet", Text: "hi"})
+	onChatEvent(dm.Event{Dir: "out", Peer: peer.Hex(), Network: "dmsg", Text: "yo", ReplyTo: "in-1"})
+
+	var got []chatEvent
+	for len(got) < 2 {
+		select {
+		case ev := <-sub:
+			got = append(got, ev)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d events surfaced, want 2", len(got))
+		}
+	}
+
+	in, out := got[0], got[1]
+	if in.Dir != "in" || in.From != peer.Hex() || in.To != "" {
+		t.Errorf("inbound = dir %q from %q to %q; want in/<peer>/empty", in.Dir, in.From, in.To)
+	}
+	if in.ID != "in-1" || in.Transport != "skynet" || in.Len != len("hi") {
+		t.Errorf("inbound event = %+v", in)
+	}
+	if out.Dir != "out" || out.To != peer.Hex() {
+		t.Errorf("outbound = dir %q to %q; want out/<peer>", out.Dir, out.To)
+	}
+	if out.ReplyToID != "in-1" {
+		t.Errorf("outbound ReplyToID = %q, want the quoted id", out.ReplyToID)
+	}
+	// An event with no id gets one minted, or the UI cannot address the bubble.
+	if out.ID == "" {
+		t.Error("an id-less controller event should be assigned a fresh event id")
+	}
+}
+
+// --- feature-gated mux registration -----------------------------------------
+
+func TestRegisterHandlers_DisabledRegistersNothing(t *testing.T) {
+	withLifecycleEnv(t)
+	pairEnable = false
+
+	mux := http.NewServeMux()
+	registerGroupHTTPHandlers(mux)
+	registerPresenceHTTPHandlers(mux)
+	registerVoiceHTTPHandlers(mux)
+
+	paths := []string{"/group", "/group/join", "/presence", "/voice/call", "/voice/active", "/voice/levels"}
+	for _, p := range paths {
+		t.Run(p, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, p, nil))
+			if rr.Code != http.StatusNotFound {
+				t.Errorf("%s: status = %d, want 404 — a standalone skychat must not advertise it", p, rr.Code)
+			}
+		})
+	}
+}
+
+func TestRegisterHandlers_EnabledRegistersRoutes(t *testing.T) {
+	withLifecycleEnv(t)
+	resetAuth(t)
+	if err := loadSkychatPassword(""); err != nil {
+		t.Fatal(err)
+	}
+	pairEnable = true
+	withPairRPCDown(t) // registered but RPC down → 503, which proves the route exists
+
+	mux := http.NewServeMux()
+	registerGroupHTTPHandlers(mux)
+	registerPresenceHTTPHandlers(mux)
+	registerVoiceHTTPHandlers(mux)
+
+	// Every route must resolve to its handler (503 from the RPC guard), never
+	// to the mux's 404.
+	for _, p := range []string{"/group", "/group/join", "/voice/active", "/voice/incoming", "/voice/levels"} {
+		t.Run(p, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, p, nil))
+			if rr.Code == http.StatusNotFound {
+				t.Errorf("%s was not registered", p)
+			}
+		})
+	}
+	// /presence is registered too (it answers without the RPC).
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/presence", nil))
+	if rr.Code == http.StatusNotFound {
+		t.Error("/presence was not registered")
+	}
+}
+
+// --- pollers ----------------------------------------------------------------
+
+// pollAPI is a fake visor.API for the two SSE-bridge pollers.
+type pollAPI struct {
+	visorAPIShim
+	mu     sync.Mutex
+	pair   []visor.PairMessage
+	group  []visor.GroupMessage
+	pairN  int
+	groupN int
+	// polled fires once per poll. stopPairPoller/stopGroupPoller only CANCEL
+	// the loop — they do not join it — so a test that restored the globals the
+	// goroutine reads (hub, pairPollInterval) right after canceling would race
+	// it. Receiving from this channel is a real happens-before edge with
+	// everything the goroutine did before that poll, which is what awaitQuiet
+	// below relies on.
+	polled chan struct{}
+}
+
+func newPollAPI() *pollAPI { return &pollAPI{polled: make(chan struct{}, 64)} }
+
+func (p *pollAPI) signal() {
+	select {
+	case p.polled <- struct{}{}:
+	default:
+	}
+}
+
+// awaitQuiet waits for `n` further polls, then cancels. Each poll after the
+// first returns no messages, so the goroutine touches no globals in those
+// iterations; receiving their signals therefore orders every hub access the
+// goroutine ever makes before the caller's cleanup.
+func (p *pollAPI) awaitQuiet(t *testing.T, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		select {
+		case <-p.polled:
+		case <-time.After(3 * time.Second):
+			t.Fatal("poller stopped ticking before it went quiet")
+		}
+	}
+}
+
+func (p *pollAPI) PairPoll(time.Time) ([]visor.PairMessage, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.pairN++
+	out := p.pair
+	p.pair = nil // deliver once, like a drained inbox
+	p.signal()
+	return out, nil
+}
+
+func (p *pollAPI) GroupPoll(time.Time) ([]visor.GroupMessage, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.groupN++
+	out := p.group
+	p.group = nil
+	p.signal()
+	return out, nil
+}
+
+func (p *pollAPI) counts() (pair, group int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.pairN, p.groupN
+}
+
+func TestPollers_DisabledDoNotRun(t *testing.T) {
+	withLifecycleEnv(t)
+	pairEnable = false
+	pairPollInterval = 10 * time.Millisecond
+	fake := newPollAPI()
+	withFakePairRPC(t, fake)
+
+	startPairPoller(context.Background())
+	startGroupPoller(context.Background())
+	t.Cleanup(func() { stopPairPoller(); stopGroupPoller() })
+
+	time.Sleep(120 * time.Millisecond)
+	if pairN, groupN := fake.counts(); pairN != 0 || groupN != 0 {
+		t.Errorf("polls with pairing disabled: pair=%d group=%d, want 0/0", pairN, groupN)
+	}
+}
+
+func TestPairPoller_BridgesInboundToSSE(t *testing.T) {
+	withLifecycleEnv(t)
+	pairEnable = true
+	pairPollInterval = 10 * time.Millisecond
+
+	peer, _ := cipher.GenerateKeyPair()
+	fake := newPollAPI()
+	fake.pair = []visor.PairMessage{{PeerPK: peer, Text: "from the pair feed", TS: time.Now().UTC()}}
+	withFakePairRPC(t, fake)
+
+	raw, unsub := hub.subscribe()
+	defer unsub()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startPairPoller(ctx)
+	// Order every hub access the goroutine makes before this test's cleanup.
+	t.Cleanup(func() { fake.awaitQuiet(t, 2); cancel(); stopPairPoller() })
+
+	got := waitForString(t, raw, 3*time.Second)
+	var m map[string]string
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("poller broadcast is not JSON: %v (%q)", err, got)
+	}
+	if m["channel"] != "pair" || m["message"] != "from the pair feed" || m["sender"] != peer.Hex() {
+		t.Errorf("bridged envelope = %v, want a pair-channel message from %s", m, peer.Hex()[:8])
+	}
+}
+
+func TestGroupPoller_BridgesInboundToSSE(t *testing.T) {
+	withLifecycleEnv(t)
+	pairEnable = true
+	pairPollInterval = 10 * time.Millisecond
+
+	peer, _ := cipher.GenerateKeyPair()
+	fake := newPollAPI()
+	fake.group = []visor.GroupMessage{{GroupID: "g-1", SenderPK: peer, Text: "from the group feed", TS: time.Now().UTC()}}
+	withFakePairRPC(t, fake)
+
+	raw, unsub := hub.subscribe()
+	defer unsub()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startGroupPoller(ctx)
+	t.Cleanup(func() { fake.awaitQuiet(t, 2); cancel(); stopGroupPoller() })
+
+	got := waitForString(t, raw, 3*time.Second)
+	var m map[string]any
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("poller broadcast is not JSON: %v (%q)", err, got)
+	}
+	if m["channel"] != "group" || m["group_id"] != "g-1" {
+		t.Errorf("bridged envelope = %v, want a group-channel message for g-1", m)
+	}
+}
+
+func TestStopPollers_Idempotent(t *testing.T) {
+	withLifecycleEnv(t)
+	// Never started — stopping must be a no-op, not a nil-deref.
+	stopPairPoller()
+	stopGroupPoller()
+	stopPairRPCWatchdog()
+
+	pairEnable = true
+	pairPollInterval = 10 * time.Millisecond
+	fake := newPollAPI()
+	withFakePairRPC(t, fake)
+	startPairPoller(context.Background())
+	startGroupPoller(context.Background())
+	// Both tickers must be built (they read pairPollInterval) before the
+	// harness restores it.
+	fake.awaitQuiet(t, 2)
+
+	stopPairPoller()
+	stopPairPoller() // second stop must not panic
+	stopGroupPoller()
+	stopGroupPoller()
+}
+
+// --- visor RPC dial + watchdog ----------------------------------------------
+
+func TestConnectPairRPCLocked_DisabledAndDialFailure(t *testing.T) {
+	withLifecycleEnv(t)
+
+	// Pairing off → no dial attempted, nil client.
+	pairEnable = false
+	pairRPCAddr = "127.0.0.1:1"
+	if got := connectPairRPCLocked("test-disabled"); got != nil {
+		t.Error("a disabled pairing subsystem must not dial")
+	}
+
+	// Enabled but nothing listening → nil, logged, no panic.
+	pairEnable = true
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve a port: %v", err)
+	}
+	dead := lis.Addr().String()
+	_ = lis.Close() //nolint:errcheck // now guaranteed closed
+	pairRPCAddr = dead
+
+	pairRPCMu.Lock()
+	prev := pairRPC
+	pairRPCMu.Unlock()
+	t.Cleanup(func() {
+		pairRPCMu.Lock()
+		pairRPC = prev
+		pairRPCMu.Unlock()
+	})
+
+	if got := connectPairRPCLocked("test-dial-fail"); got != nil {
+		t.Errorf("dialing a closed port should yield a nil client, got %v", got)
+	}
+	if pairRPCAlive() {
+		t.Error("a failed dial must leave no client installed")
+	}
+}
+
+func TestConnectPairRPCLocked_DialSuccessSwapsClient(t *testing.T) {
+	withLifecycleEnv(t)
+	pairEnable = true
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = lis.Close() }() //nolint:errcheck
+	go func() {
+		for {
+			c, aerr := lis.Accept()
+			if aerr != nil {
+				return
+			}
+			go func() { <-time.After(2 * time.Second); _ = c.Close() }() //nolint:errcheck
+		}
+	}()
+	pairRPCAddr = lis.Addr().String()
+
+	pairRPCMu.Lock()
+	prev := pairRPC
+	pairRPCMu.Unlock()
+	t.Cleanup(func() {
+		pairRPCMu.Lock()
+		pairRPC = prev
+		pairRPCMu.Unlock()
+	})
+
+	first := connectPairRPCLocked("test-dial-ok")
+	if first == nil {
+		t.Fatal("dialing a live listener should install a client")
+	}
+	if !pairRPCAlive() {
+		t.Error("a successful dial should leave the client installed")
+	}
+
+	// Redial swaps a fresh client in (and closes the old conn).
+	second := connectPairRPCLocked("test-redial")
+	if second == nil {
+		t.Fatal("redial should install a client")
+	}
+	if first == second {
+		t.Error("redial should install a NEW client, not reuse the shut-down one")
+	}
+
+	// connectPairRPC is the startup wrapper over the same path.
+	connectPairRPC()
+	if !pairRPCAlive() {
+		t.Error("connectPairRPC should leave a live client after a successful dial")
+	}
+}
+
+func TestPairRPCWatchdog_DisabledIsNoOpAndStopIsIdempotent(t *testing.T) {
+	withLifecycleEnv(t)
+	pairEnable = false
+
+	startPairRPCWatchdog(context.Background())
+	if pairRPCWatchdogCancel != nil {
+		t.Error("a disabled watchdog must not install a cancel func")
+	}
+	stopPairRPCWatchdog()
+
+	pairEnable = true
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startPairRPCWatchdog(ctx)
+	if pairRPCWatchdogCancel == nil {
+		t.Fatal("an enabled watchdog should install a cancel func")
+	}
+	stopPairRPCWatchdog()
+	if pairRPCWatchdogCancel != nil {
+		t.Error("stop should clear the cancel func so a later stop is a no-op")
+	}
+	stopPairRPCWatchdog() // must not panic
+}
+
+// --- presence probe ---------------------------------------------------------
+
+// pingAPI is a fake visor.API for the dmsg-ping presence probe.
+type pingAPI struct {
+	visorAPIShim
+	dialErr error
+	pingErr error
+	rtt     time.Duration
+	stopped int
+}
+
+func (p *pingAPI) DialDmsgPing(cipher.PubKey) error { return p.dialErr }
+func (p *pingAPI) StopDmsgPing(cipher.PubKey) error { p.stopped++; return nil }
+func (p *pingAPI) DmsgPingOnce(visor.PingConfig) (time.Duration, error) {
+	return p.rtt, p.pingErr
+}
+
+func TestProbePeerViaVisor(t *testing.T) {
+	withLifecycleEnv(t)
+	pk, _ := cipher.GenerateKeyPair()
+
+	// RPC down → offline, and no ping is attempted.
+	withPairRPCDown(t)
+	if got := probePeerViaVisor(pk); got.Online {
+		t.Error("with the visor RPC down the peer cannot be reported online")
+	}
+
+	// Dial fails (peer unreachable) → offline.
+	dialFail := &pingAPI{dialErr: errors.New("no route")}
+	withFakePairRPC(t, dialFail)
+	if got := probePeerViaVisor(pk); got.Online {
+		t.Error("a failed dmsg dial means offline")
+	}
+	if dialFail.stopped != 0 {
+		t.Error("no StopDmsgPing should be issued for a dial that never succeeded")
+	}
+
+	// Dial succeeds but the ping does not → online with no RTT. Reaching the
+	// peer at all is the liveness signal; the RTT is a nice-to-have.
+	pingFail := &pingAPI{pingErr: errors.New("timeout")}
+	withFakePairRPC(t, pingFail)
+	got := probePeerViaVisor(pk)
+	if !got.Online {
+		t.Error("a successful dial means online even when the ping itself fails")
+	}
+	if got.RTTMs != 0 {
+		t.Errorf("RTTMs = %d, want 0 when the ping failed", got.RTTMs)
+	}
+	if pingFail.stopped != 1 {
+		t.Errorf("StopDmsgPing called %d times, want 1 — a successful dial must be torn down", pingFail.stopped)
+	}
+
+	// Full success → online with the reported RTT.
+	ok := &pingAPI{rtt: 42 * time.Millisecond}
+	withFakePairRPC(t, ok)
+	got = probePeerViaVisor(pk)
+	if !got.Online || got.RTTMs != 42 {
+		t.Errorf("probe = %+v, want online with RTTMs 42", got)
+	}
+	if got.At == 0 {
+		t.Error("the probe should stamp when it ran")
+	}
+
+	// A nonsense RTT from the visor is replaced by our own measurement rather
+	// than surfaced as a negative or absurd number.
+	weird := &pingAPI{rtt: -5 * time.Second}
+	withFakePairRPC(t, weird)
+	got = probePeerViaVisor(pk)
+	if got.RTTMs < 0 {
+		t.Errorf("RTTMs = %d, want a self-timed non-negative value", got.RTTMs)
+	}
+}
+
+func TestStartPresenceLoop_DisabledIsNoOp(t *testing.T) {
+	withLifecycleEnv(t)
+	pairEnable = false
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startPresenceLoop(ctx) // must return immediately without spawning a sweeper
+
+	pairEnable = true
+	startPresenceLoop(ctx) // spawns; canceling the ctx unwinds it
+}
+
+// --- misc lifecycle ---------------------------------------------------------
+
+func TestLogOSNotifyStartup(t *testing.T) {
+	withLifecycleEnv(t)
+	var lines []string
+	origLog := appLog
+	appLog = func(f string, a ...any) { lines = append(lines, fmt.Sprintf(f, a...)) }
+	t.Cleanup(func() { appLog = origLog })
+
+	osNotify = false
+	logOSNotifyStartup()
+	if len(lines) != 0 {
+		t.Errorf("nothing should be logged when notifications are off, got %v", lines)
+	}
+
+	osNotify = true
+	logOSNotifyStartup()
+	if len(lines) != 1 || !strings.Contains(lines[0], "Host-OS desktop notifications") {
+		t.Errorf("startup log = %v, want one line about host-OS notifications", lines)
+	}
+}
+
+func TestSendReadReceipt(t *testing.T) {
+	withLifecycleEnv(t)
+	peer, _ := cipher.GenerateKeyPair()
+
+	chatCtrl = nil
+	if err := sendReadReceipt(context.Background(), peer, "m-1"); err == nil {
+		t.Error("sending a receipt with no controller should error, not nil-deref")
+	}
+
+	cc := newCapturingClient()
+	chatCtrl = dm.New(dm.Config{Client: cc, Networks: []appnet.Type{appnet.TypeSkynet}})
+	t.Cleanup(func() {
+		_ = chatCtrl.Close() //nolint:errcheck
+		cc.closeAll()
+	})
+
+	if err := sendReadReceipt(context.Background(), peer, "m-1"); err != nil {
+		t.Fatalf("sendReadReceipt: %v", err)
+	}
+	select {
+	case raw := <-cc.frames:
+		var env message.Envelope
+		if err := json.Unmarshal(raw, &env); err != nil {
+			t.Fatalf("receipt is not an envelope: %v (%q)", err, raw)
+		}
+		if env.Type != message.TypeRead || env.ID != "m-1" {
+			t.Errorf("receipt = %+v, want a chat-read for m-1", env)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no read receipt reached the wire")
+	}
+}

--- a/cmd/apps/skychat/commands/lifecycle_test.go
+++ b/cmd/apps/skychat/commands/lifecycle_test.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -866,21 +865,29 @@ func TestStartPresenceLoop_DisabledIsNoOp(t *testing.T) {
 
 func TestLogOSNotifyStartup(t *testing.T) {
 	withLifecycleEnv(t)
-	var lines []string
-	origLog := appLog
-	appLog = func(f string, a ...any) { lines = append(lines, fmt.Sprintf(f, a...)) }
-	t.Cleanup(func() { appLog = origLog })
+	// Read the package-wide recorder rather than swapping appLog: background
+	// loops from earlier tests can still be calling it, and assigning the global
+	// here would race them (see appLogRecorder in osnotify_test.go).
+	mark := testAppLog.count()
 
 	osNotify = false
 	logOSNotifyStartup()
-	if len(lines) != 0 {
-		t.Errorf("nothing should be logged when notifications are off, got %v", lines)
+	if got := testAppLog.since(mark); len(got) != 0 {
+		t.Errorf("nothing should be logged when notifications are off, got %v", got)
 	}
 
+	mark = testAppLog.count()
 	osNotify = true
 	logOSNotifyStartup()
-	if len(lines) != 1 || !strings.Contains(lines[0], "Host-OS desktop notifications") {
-		t.Errorf("startup log = %v, want one line about host-OS notifications", lines)
+
+	var found bool
+	for _, l := range testAppLog.since(mark) {
+		if strings.Contains(l, "Host-OS desktop notifications") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("startup should log a line about host-OS notifications; got %v", testAppLog.since(mark))
 	}
 }
 

--- a/cmd/apps/skychat/commands/osnotify_test.go
+++ b/cmd/apps/skychat/commands/osnotify_test.go
@@ -7,21 +7,62 @@
 package commands
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 )
 
+// appLogRecorder is the package-wide appLog sink, installed ONCE by TestMain.
+//
+// appLog is a plain global func var that background loops (the pollers, the
+// cxo-group Connect/reconnect goroutines, the tcp-direct dialers) call from
+// goroutines which routinely outlive the test that started them. Any test that
+// assigned appLog itself would therefore race those readers. Installing one
+// mutex-guarded recorder up front means nothing ever writes the variable again,
+// and a test that wants to assert on log output reads the recorder instead.
+type appLogRecorder struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (r *appLogRecorder) record(format string, args ...interface{}) {
+	r.mu.Lock()
+	r.lines = append(r.lines, fmt.Sprintf(format, args...))
+	r.mu.Unlock()
+}
+
+// count returns how many lines have been recorded so far.
+func (r *appLogRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.lines)
+}
+
+// since returns the lines recorded after index n.
+func (r *appLogRecorder) since(n int) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if n > len(r.lines) {
+		return nil
+	}
+	return append([]string(nil), r.lines[n:]...)
+}
+
+var testAppLog = &appLogRecorder{}
+
 func TestMain(m *testing.M) {
 	// Never fire a real host-OS notification during the suite: handleConn-driven
 	// tests reach notifyOSInbound, and on a developer desktop
 	// osnotify.Available() is true, which would otherwise pop real notifications.
 	osNotify = false
+	appLog = testAppLog.record
 	os.Exit(m.Run())
 }
 

--- a/cmd/apps/skychat/commands/pairing.go
+++ b/cmd/apps/skychat/commands/pairing.go
@@ -583,7 +583,17 @@ func sendPairControl(ctx context.Context, peerPK cipher.PubKey, msgType string) 
 }
 
 // parsePK parses a hex-encoded public key and returns a cipher.PubKey.
+//
+// The empty string is rejected explicitly: cipher.PubKey.UnmarshalText treats
+// "" as a no-op and returns a nil error, so without this guard an absent
+// peer_pk in a request body would parse as the all-zero key and be handed to
+// PairAdd/PairSend/SendRaw as if it were a real peer. The path-based callers
+// pre-check for an empty segment; the body-based ones (POST /pair, /delete,
+// /read-receipt, /request-file, /voice/call) rely on this.
 func parsePK(s string) (cipher.PubKey, error) {
+	if strings.TrimSpace(s) == "" {
+		return cipher.PubKey{}, errors.New("empty public key")
+	}
 	var pk cipher.PubKey
 	if err := pk.UnmarshalText([]byte(s)); err != nil {
 		return cipher.PubKey{}, err

--- a/cmd/apps/skychat/commands/pairing_handlers_test.go
+++ b/cmd/apps/skychat/commands/pairing_handlers_test.go
@@ -1,0 +1,934 @@
+// Package commands cmd/apps/skychat/commands/pairing_handlers_test.go
+//
+// Unit coverage for the /pair HTTP surface that pair_inbox_handler_test.go
+// left untested: pairRootHandler (add/list), pairItemHandler (remove/send),
+// pairInvitesListHandler + pairInvitesItemHandler (the accept/decline
+// consent flow), sendPairControl, and registerPairHTTPHandlers' route
+// precedence.
+//
+// Two seams make this hermetic:
+//
+//   - the visor RPC is a fake visor.API installed via withFakePairRPC
+//     (from pair_inbox_handler_test.go), recording every pair mutation;
+//   - the wire is a fake dm.Client whose Dial hands back one end of a
+//     net.Pipe, so the control frames sendPairControl emits can be read
+//     back and asserted rather than inferred.
+//
+// The best-effort contracts get explicit tests, because they are the ones a
+// refactor is most likely to "tidy" into strictness: a POST /pair still
+// succeeds when the invite can't be delivered (the pair record is kept so
+// both sides converge later), and an accept still succeeds when
+// PairMarkActive fails. Conversely, a FAILED PairAdd on accept must leave
+// the invite pending so the user can retry.
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skychat/dm"
+	"github.com/skycoin/skywire/pkg/skychat/message"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+// --- fakes ------------------------------------------------------------------
+
+// pairHandlersAPI is a fake visor.API recording the pair mutations the /pair
+// handlers drive through the RPC, with per-method error injection. Only the
+// methods these handlers call are implemented; anything else panics via the
+// nil-embedded interface, which is the point — an unexpected RPC call should
+// fail loudly rather than silently no-op.
+type pairHandlersAPI struct {
+	visorAPIShim
+
+	mu           sync.Mutex
+	added        []cipher.PubKey
+	removed      []cipher.PubKey
+	markedActive []cipher.PubKey
+	sent         []pairSentMsg
+	list         []visor.PairInfo
+
+	addErr        error
+	removeErr     error
+	markActiveErr error
+	sendErr       error
+	listErr       error
+}
+
+type pairSentMsg struct {
+	peer cipher.PubKey
+	text string
+}
+
+func (a *pairHandlersAPI) PairAdd(pk cipher.PubKey) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.addErr != nil {
+		return a.addErr
+	}
+	a.added = append(a.added, pk)
+	return nil
+}
+
+func (a *pairHandlersAPI) PairRemove(pk cipher.PubKey) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.removeErr != nil {
+		return a.removeErr
+	}
+	a.removed = append(a.removed, pk)
+	return nil
+}
+
+func (a *pairHandlersAPI) PairMarkActive(pk cipher.PubKey) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.markActiveErr != nil {
+		return a.markActiveErr
+	}
+	a.markedActive = append(a.markedActive, pk)
+	return nil
+}
+
+func (a *pairHandlersAPI) PairSend(pk cipher.PubKey, text string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.sendErr != nil {
+		return a.sendErr
+	}
+	a.sent = append(a.sent, pairSentMsg{peer: pk, text: text})
+	return nil
+}
+
+func (a *pairHandlersAPI) PairList() ([]visor.PairInfo, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.list, a.listErr
+}
+
+func (a *pairHandlersAPI) PairPoll(time.Time) ([]visor.PairMessage, error) { return nil, nil }
+
+func (a *pairHandlersAPI) snapshot() ([]cipher.PubKey, []cipher.PubKey, []cipher.PubKey, []pairSentMsg) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.added, a.removed, a.markedActive, a.sent
+}
+
+// capturingClient is a dm.Client whose Dial returns the local end of a
+// net.Pipe; a goroutine drains the peer end and publishes each decoded frame
+// on `frames`. That makes an outbound pair-control frame observable without a
+// mesh. Listen is never reached — the tests drive handlers directly and never
+// Start the controller.
+type capturingClient struct {
+	mu      sync.Mutex
+	closers []io.Closer
+	dialed  []appnet.Addr
+	dialErr error
+
+	frames chan []byte
+}
+
+func newCapturingClient() *capturingClient {
+	return &capturingClient{frames: make(chan []byte, 16)}
+}
+
+func (c *capturingClient) Listen(appnet.Type, routing.Port) (net.Listener, error) {
+	return nil, errors.New("capturingClient: Listen not supported")
+}
+
+func (c *capturingClient) Dial(addr appnet.Addr) (net.Conn, error) {
+	c.mu.Lock()
+	c.dialed = append(c.dialed, addr)
+	derr := c.dialErr
+	c.mu.Unlock()
+	if derr != nil {
+		return nil, derr
+	}
+
+	local, remote := net.Pipe()
+	c.mu.Lock()
+	c.closers = append(c.closers, local, remote)
+	c.mu.Unlock()
+
+	// net.Pipe is unbuffered: without an active reader the app's write would
+	// block until its deadline and the send would look like a failure.
+	go func() {
+		for {
+			f, err := message.ReadFrame(remote)
+			if err != nil {
+				return
+			}
+			select {
+			case c.frames <- f:
+			default: // never wedge the reader on a test that stopped listening
+			}
+		}
+	}()
+	return local, nil
+}
+
+// setDialErr makes every subsequent Dial fail, simulating an offline peer.
+func (c *capturingClient) setDialErr(err error) {
+	c.mu.Lock()
+	c.dialErr = err
+	c.mu.Unlock()
+}
+
+func (c *capturingClient) dialCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.dialed)
+}
+
+func (c *capturingClient) closeAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, cl := range c.closers {
+		_ = cl.Close() //nolint:errcheck
+	}
+	c.closers = nil
+}
+
+// --- harness ----------------------------------------------------------------
+
+// withPairHandlerEnv turns pairing on, gives the test a private SSE hub, a
+// fake visor RPC, and a chatCtrl wired to a capturing transport. Every global
+// it touches is restored on cleanup.
+func withPairHandlerEnv(t *testing.T, fake visor.API) *capturingClient {
+	t.Helper()
+	clearPending()
+
+	origHub, origEnable, origCtrl := hub, pairEnable, chatCtrl
+	hub = newSSEHub()
+	pairEnable = true
+
+	cc := newCapturingClient()
+	chatCtrl = dm.New(dm.Config{
+		Client:   cc,
+		Networks: []appnet.Type{appnet.TypeSkynet},
+	})
+
+	withFakePairRPC(t, fake) // sets appLog, swaps pairRPC, restores on cleanup
+
+	t.Cleanup(func() {
+		_ = chatCtrl.Close() //nolint:errcheck
+		cc.closeAll()
+		hub, pairEnable, chatCtrl = origHub, origEnable, origCtrl
+		clearPending()
+	})
+	return cc
+}
+
+// withPairRPCDown drops the RPC client so the handlers' 503 guard fires.
+func withPairRPCDown(t *testing.T) {
+	t.Helper()
+	if appLog == nil {
+		appLog = func(string, ...any) {}
+	}
+	pairRPCMu.Lock()
+	prev := pairRPC
+	pairRPC = nil
+	pairRPCMu.Unlock()
+	t.Cleanup(func() {
+		pairRPCMu.Lock()
+		pairRPC = prev
+		pairRPCMu.Unlock()
+	})
+}
+
+// wantFrame reads one control frame off the wire and returns its decoded type.
+func wantFrame(t *testing.T, cc *capturingClient) string {
+	t.Helper()
+	select {
+	case raw := <-cc.frames:
+		var env pairMsg
+		if err := json.Unmarshal(raw, &env); err != nil {
+			t.Fatalf("control frame is not a pair envelope: %v (raw %q)", err, raw)
+		}
+		return env.Type
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for a pair-control frame on the wire")
+		return ""
+	}
+}
+
+// wantNoFrame asserts nothing was put on the wire.
+func wantNoFrame(t *testing.T, cc *capturingClient) {
+	t.Helper()
+	select {
+	case raw := <-cc.frames:
+		t.Errorf("unexpected control frame on the wire: %q", raw)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func mustPK(t *testing.T) cipher.PubKey {
+	t.Helper()
+	pk, _ := cipher.GenerateKeyPair()
+	return pk
+}
+
+// --- pairRootHandler --------------------------------------------------------
+
+func TestPairRootHandler_GetListsPairs(t *testing.T) {
+	peer := mustPK(t)
+	fake := &pairHandlersAPI{list: []visor.PairInfo{
+		{PeerPK: peer, Port: 4242, EstablishedAt: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)},
+	}}
+	withPairHandlerEnv(t, fake)
+
+	rr := httptest.NewRecorder()
+	pairRootHandler(context.Background())(rr, httptest.NewRequest(http.MethodGet, "/pair", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var got []visor.PairInfo
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode body: %v (raw %q)", err, rr.Body.String())
+	}
+	if len(got) != 1 || got[0].PeerPK != peer || got[0].Port != 4242 {
+		t.Errorf("got = %+v, want one entry for %s:4242", got, peer.Hex())
+	}
+}
+
+func TestPairRootHandler_GetListErrorReturns500(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{listErr: errors.New("list boom")})
+
+	rr := httptest.NewRecorder()
+	pairRootHandler(context.Background())(rr, httptest.NewRequest(http.MethodGet, "/pair", nil))
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500; body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestPairRootHandler_PostAddsPairAndSendsInvite(t *testing.T) {
+	fake := &pairHandlersAPI{}
+	cc := withPairHandlerEnv(t, fake)
+	peer := mustPK(t)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/pair",
+		strings.NewReader(`{"peer_pk":"`+peer.Hex()+`"}`))
+	pairRootHandler(context.Background())(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%q", rr.Code, rr.Body.String())
+	}
+	added, _, _, _ := fake.snapshot()
+	if len(added) != 1 || added[0] != peer {
+		t.Errorf("PairAdd calls = %v, want one for %s", added, peer.Hex())
+	}
+	if got := wantFrame(t, cc); got != pairTypeInvite {
+		t.Errorf("wire frame type = %q, want %q", got, pairTypeInvite)
+	}
+}
+
+func TestPairRootHandler_PostSucceedsWhenInviteUndeliverable(t *testing.T) {
+	// Documented contract: the pair record is kept even when the peer is
+	// unreachable, so both sides converge on next contact. A refactor that
+	// made the invite send fatal would strand the operator.
+	fake := &pairHandlersAPI{}
+	cc := withPairHandlerEnv(t, fake)
+	cc.setDialErr(errors.New("peer offline"))
+	peer := mustPK(t)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/pair",
+		strings.NewReader(`{"peer_pk":"`+peer.Hex()+`"}`))
+	pairRootHandler(context.Background())(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204 despite the undeliverable invite; body=%q", rr.Code, rr.Body.String())
+	}
+	added, _, _, _ := fake.snapshot()
+	if len(added) != 1 || added[0] != peer {
+		t.Errorf("PairAdd calls = %v, want the record kept for %s", added, peer.Hex())
+	}
+	if cc.dialCount() == 0 {
+		t.Error("expected at least one dial attempt for the invite")
+	}
+}
+
+func TestPairRootHandler_PostPairAddErrorReturns500(t *testing.T) {
+	fake := &pairHandlersAPI{addErr: errors.New("add boom")}
+	cc := withPairHandlerEnv(t, fake)
+	peer := mustPK(t)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/pair",
+		strings.NewReader(`{"peer_pk":"`+peer.Hex()+`"}`))
+	pairRootHandler(context.Background())(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%q", rr.Code, rr.Body.String())
+	}
+	// No local record → no invite should go out, or the peer would see an
+	// invite for a pair this side doesn't have.
+	wantNoFrame(t, cc)
+}
+
+func TestPairRootHandler_PostRejectsBadInput(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{})
+
+	cases := []struct{ name, body string }{
+		{"malformed json", `{"peer_pk":`},
+		{"empty body", ``},
+		{"non-hex pk", `{"peer_pk":"not-a-pk"}`},
+		{"missing pk", `{}`},
+		{"truncated pk", `{"peer_pk":"0281a1"}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/pair", strings.NewReader(c.body))
+			pairRootHandler(context.Background())(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400; body=%q", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestPairRootHandler_RejectsOtherMethods(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{})
+	for _, m := range []string{http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		t.Run(m, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			pairRootHandler(context.Background())(rr, httptest.NewRequest(m, "/pair", nil))
+			if rr.Code != http.StatusMethodNotAllowed {
+				t.Errorf("status = %d, want 405", rr.Code)
+			}
+		})
+	}
+}
+
+func TestPairRootHandler_RPCUnavailableReturns503(t *testing.T) {
+	withPairRPCDown(t)
+	rr := httptest.NewRecorder()
+	pairRootHandler(context.Background())(rr, httptest.NewRequest(http.MethodGet, "/pair", nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rr.Code)
+	}
+}
+
+// --- pairItemHandler --------------------------------------------------------
+
+func TestPairItemHandler_DeleteRemovesPair(t *testing.T) {
+	fake := &pairHandlersAPI{}
+	withPairHandlerEnv(t, fake)
+	peer := mustPK(t)
+
+	rr := httptest.NewRecorder()
+	pairItemHandler(context.Background())(rr,
+		httptest.NewRequest(http.MethodDelete, "/pair/"+peer.Hex(), nil))
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%q", rr.Code, rr.Body.String())
+	}
+	_, removed, _, _ := fake.snapshot()
+	if len(removed) != 1 || removed[0] != peer {
+		t.Errorf("PairRemove calls = %v, want one for %s", removed, peer.Hex())
+	}
+}
+
+func TestPairItemHandler_DeleteErrorReturns500(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{removeErr: errors.New("remove boom")})
+	peer := mustPK(t)
+
+	rr := httptest.NewRecorder()
+	pairItemHandler(context.Background())(rr,
+		httptest.NewRequest(http.MethodDelete, "/pair/"+peer.Hex(), nil))
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500; body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestPairItemHandler_PostMessageSendsViaCXO(t *testing.T) {
+	fake := &pairHandlersAPI{}
+	withPairHandlerEnv(t, fake)
+	peer := mustPK(t)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/pair/"+peer.Hex()+"/message",
+		strings.NewReader(`{"text":"hello over the feed"}`))
+	pairItemHandler(context.Background())(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%q", rr.Code, rr.Body.String())
+	}
+	_, _, _, sent := fake.snapshot()
+	if len(sent) != 1 || sent[0].peer != peer || sent[0].text != "hello over the feed" {
+		t.Errorf("PairSend calls = %+v, want one {%s, %q}", sent, peer.Hex(), "hello over the feed")
+	}
+}
+
+func TestPairItemHandler_PostMessageErrorReturns500(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{sendErr: errors.New("send boom")})
+	peer := mustPK(t)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/pair/"+peer.Hex()+"/message",
+		strings.NewReader(`{"text":"hi"}`))
+	pairItemHandler(context.Background())(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500; body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestPairItemHandler_PostMessageBadBodyReturns400(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{})
+	peer := mustPK(t)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/pair/"+peer.Hex()+"/message",
+		strings.NewReader(`{"text":`))
+	pairItemHandler(context.Background())(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestPairItemHandler_RejectsBadPaths(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{})
+	peer := mustPK(t)
+
+	cases := []struct {
+		name, method, path string
+		want               int
+	}{
+		{"missing pk", http.MethodDelete, "/pair/", http.StatusBadRequest},
+		{"non-hex pk", http.MethodDelete, "/pair/not-a-pk", http.StatusBadRequest},
+		{"truncated pk", http.MethodDelete, "/pair/0281a1", http.StatusBadRequest},
+		{"get on item", http.MethodGet, "/pair/" + peer.Hex(), http.StatusMethodNotAllowed},
+		{"post without /message", http.MethodPost, "/pair/" + peer.Hex(), http.StatusMethodNotAllowed},
+		{"delete on /message", http.MethodDelete, "/pair/" + peer.Hex() + "/message", http.StatusMethodNotAllowed},
+		{"unknown subresource", http.MethodPost, "/pair/" + peer.Hex() + "/bogus", http.StatusMethodNotAllowed},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			pairItemHandler(context.Background())(rr, httptest.NewRequest(c.method, c.path, nil))
+			if rr.Code != c.want {
+				t.Errorf("%s %s: status = %d, want %d; body=%q", c.method, c.path, rr.Code, c.want, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestPairItemHandler_RPCUnavailableReturns503(t *testing.T) {
+	withPairRPCDown(t)
+	peer := mustPK(t)
+	rr := httptest.NewRecorder()
+	pairItemHandler(context.Background())(rr,
+		httptest.NewRequest(http.MethodDelete, "/pair/"+peer.Hex(), nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rr.Code)
+	}
+}
+
+// --- pairInvitesListHandler -------------------------------------------------
+
+func TestPairInvitesListHandler_ReturnsPendingInvites(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{})
+	peer := mustPK(t)
+	pendingPut(peer)
+
+	rr := httptest.NewRecorder()
+	pairInvitesListHandler()(rr, httptest.NewRequest(http.MethodGet, "/pair/invites", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var got []pendingInvite
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode body: %v (raw %q)", err, rr.Body.String())
+	}
+	if len(got) != 1 || got[0].PeerPK != peer {
+		t.Fatalf("got = %+v, want one pending invite from %s", got, peer.Hex())
+	}
+	if got[0].ReceivedAt.IsZero() {
+		t.Error("pending invite should carry a received_at timestamp")
+	}
+}
+
+func TestPairInvitesListHandler_EmptyReturnsJSONArray(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{})
+
+	rr := httptest.NewRecorder()
+	pairInvitesListHandler()(rr, httptest.NewRequest(http.MethodGet, "/pair/invites", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	// pendingList pre-allocates, so an empty set must marshal as [] — a UI
+	// doing `.forEach` on the response would break on null.
+	if got := strings.TrimSpace(rr.Body.String()); got != "[]" {
+		t.Errorf("body = %q, want []", got)
+	}
+}
+
+func TestPairInvitesListHandler_RejectsNonGet(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{})
+	for _, m := range []string{http.MethodPost, http.MethodDelete} {
+		t.Run(m, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			pairInvitesListHandler()(rr, httptest.NewRequest(m, "/pair/invites", nil))
+			if rr.Code != http.StatusMethodNotAllowed {
+				t.Errorf("status = %d, want 405", rr.Code)
+			}
+		})
+	}
+}
+
+func TestPairInvitesListHandler_RPCUnavailableReturns503(t *testing.T) {
+	withPairRPCDown(t)
+	rr := httptest.NewRecorder()
+	pairInvitesListHandler()(rr, httptest.NewRequest(http.MethodGet, "/pair/invites", nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rr.Code)
+	}
+}
+
+// --- pairInvitesItemHandler -------------------------------------------------
+
+func TestPairInvitesItemHandler_AcceptPairsAndAcks(t *testing.T) {
+	fake := &pairHandlersAPI{}
+	cc := withPairHandlerEnv(t, fake)
+	peer := mustPK(t)
+	pendingPut(peer)
+
+	rr := httptest.NewRecorder()
+	pairInvitesItemHandler(context.Background())(rr,
+		httptest.NewRequest(http.MethodPost, "/pair/invites/"+peer.Hex()+"/accept", nil))
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%q", rr.Code, rr.Body.String())
+	}
+	added, _, active, _ := fake.snapshot()
+	if len(added) != 1 || added[0] != peer {
+		t.Errorf("PairAdd calls = %v, want one for %s", added, peer.Hex())
+	}
+	if len(active) != 1 || active[0] != peer {
+		t.Errorf("PairMarkActive calls = %v, want one for %s — the user consented, "+
+			"so this side is active immediately", active, peer.Hex())
+	}
+	if pendingHas(peer) {
+		t.Error("accepted invite should be dropped from the pending set")
+	}
+	if got := wantFrame(t, cc); got != pairTypeAck {
+		t.Errorf("wire frame type = %q, want %q", got, pairTypeAck)
+	}
+}
+
+func TestPairInvitesItemHandler_AcceptSucceedsWhenMarkActiveFails(t *testing.T) {
+	// PairMarkActive is best-effort: the pair record already exists, so a
+	// failure here must not undo the accept or 500 the operator.
+	fake := &pairHandlersAPI{markActiveErr: errors.New("mark boom")}
+	cc := withPairHandlerEnv(t, fake)
+	peer := mustPK(t)
+	pendingPut(peer)
+
+	rr := httptest.NewRecorder()
+	pairInvitesItemHandler(context.Background())(rr,
+		httptest.NewRequest(http.MethodPost, "/pair/invites/"+peer.Hex()+"/accept", nil))
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%q", rr.Code, rr.Body.String())
+	}
+	if pendingHas(peer) {
+		t.Error("invite should still be cleared when PairMarkActive fails")
+	}
+	if got := wantFrame(t, cc); got != pairTypeAck {
+		t.Errorf("wire frame type = %q, want %q", got, pairTypeAck)
+	}
+}
+
+func TestPairInvitesItemHandler_AcceptPairAddErrorKeepsInvitePending(t *testing.T) {
+	// PairAdd is the one call that must be fatal: with no local pair record
+	// there is nothing to ack, and dropping the invite would leave the user
+	// with no way to retry from the UI.
+	fake := &pairHandlersAPI{addErr: errors.New("add boom")}
+	cc := withPairHandlerEnv(t, fake)
+	peer := mustPK(t)
+	pendingPut(peer)
+
+	rr := httptest.NewRecorder()
+	pairInvitesItemHandler(context.Background())(rr,
+		httptest.NewRequest(http.MethodPost, "/pair/invites/"+peer.Hex()+"/accept", nil))
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%q", rr.Code, rr.Body.String())
+	}
+	if !pendingHas(peer) {
+		t.Error("a failed accept must leave the invite pending so the user can retry")
+	}
+	wantNoFrame(t, cc)
+}
+
+func TestPairInvitesItemHandler_DeclineDropsInviteAndNotifiesPeer(t *testing.T) {
+	fake := &pairHandlersAPI{}
+	cc := withPairHandlerEnv(t, fake)
+	peer := mustPK(t)
+	pendingPut(peer)
+
+	rr := httptest.NewRecorder()
+	pairInvitesItemHandler(context.Background())(rr,
+		httptest.NewRequest(http.MethodPost, "/pair/invites/"+peer.Hex()+"/decline", nil))
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%q", rr.Code, rr.Body.String())
+	}
+	if pendingHas(peer) {
+		t.Error("declined invite should be dropped from the pending set")
+	}
+	added, _, active, _ := fake.snapshot()
+	if len(added) != 0 || len(active) != 0 {
+		t.Errorf("decline must not create a pair: added=%v active=%v", added, active)
+	}
+	if got := wantFrame(t, cc); got != pairTypeDecline {
+		t.Errorf("wire frame type = %q, want %q", got, pairTypeDecline)
+	}
+}
+
+func TestPairInvitesItemHandler_DeclineSucceedsWhenPeerUnreachable(t *testing.T) {
+	fake := &pairHandlersAPI{}
+	cc := withPairHandlerEnv(t, fake)
+	cc.setDialErr(errors.New("peer offline"))
+	peer := mustPK(t)
+	pendingPut(peer)
+
+	rr := httptest.NewRecorder()
+	pairInvitesItemHandler(context.Background())(rr,
+		httptest.NewRequest(http.MethodPost, "/pair/invites/"+peer.Hex()+"/decline", nil))
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204 despite the undeliverable decline; body=%q", rr.Code, rr.Body.String())
+	}
+	if pendingHas(peer) {
+		t.Error("invite should be dropped locally even when the peer can't be told")
+	}
+}
+
+func TestPairInvitesItemHandler_UnknownPeerReturns404(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{})
+	peer := mustPK(t) // never pendingPut
+
+	for _, action := range []string{"accept", "decline"} {
+		t.Run(action, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			pairInvitesItemHandler(context.Background())(rr,
+				httptest.NewRequest(http.MethodPost, "/pair/invites/"+peer.Hex()+"/"+action, nil))
+			if rr.Code != http.StatusNotFound {
+				t.Errorf("status = %d, want 404; body=%q", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestPairInvitesItemHandler_UnknownActionReturns400(t *testing.T) {
+	// The pending check runs before the action switch, so the invite must
+	// exist for the request to reach the 400.
+	withPairHandlerEnv(t, &pairHandlersAPI{})
+	peer := mustPK(t)
+	pendingPut(peer)
+
+	rr := httptest.NewRecorder()
+	pairInvitesItemHandler(context.Background())(rr,
+		httptest.NewRequest(http.MethodPost, "/pair/invites/"+peer.Hex()+"/maybe", nil))
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body=%q", rr.Code, rr.Body.String())
+	}
+	if !pendingHas(peer) {
+		t.Error("an unknown action must not consume the pending invite")
+	}
+}
+
+func TestPairInvitesItemHandler_RejectsBadPaths(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{})
+	peer := mustPK(t)
+	pendingPut(peer)
+
+	cases := []struct {
+		name, path string
+	}{
+		{"no action", "/pair/invites/" + peer.Hex()},
+		{"empty action", "/pair/invites/" + peer.Hex() + "/"},
+		{"empty pk", "/pair/invites//accept"},
+		{"nothing at all", "/pair/invites/"},
+		{"non-hex pk", "/pair/invites/not-a-pk/accept"},
+		{"truncated pk", "/pair/invites/0281a1/accept"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			pairInvitesItemHandler(context.Background())(rr,
+				httptest.NewRequest(http.MethodPost, c.path, nil))
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("%s: status = %d, want 400; body=%q", c.path, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestPairInvitesItemHandler_RejectsNonPost(t *testing.T) {
+	withPairHandlerEnv(t, &pairHandlersAPI{})
+	peer := mustPK(t)
+	pendingPut(peer)
+
+	for _, m := range []string{http.MethodGet, http.MethodDelete, http.MethodPut} {
+		t.Run(m, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			pairInvitesItemHandler(context.Background())(rr,
+				httptest.NewRequest(m, "/pair/invites/"+peer.Hex()+"/accept", nil))
+			if rr.Code != http.StatusMethodNotAllowed {
+				t.Errorf("status = %d, want 405", rr.Code)
+			}
+		})
+	}
+	if !pendingHas(peer) {
+		t.Error("a rejected method must not consume the pending invite")
+	}
+}
+
+func TestPairInvitesItemHandler_RPCUnavailableReturns503(t *testing.T) {
+	withPairRPCDown(t)
+	peer := mustPK(t)
+	rr := httptest.NewRecorder()
+	pairInvitesItemHandler(context.Background())(rr,
+		httptest.NewRequest(http.MethodPost, "/pair/invites/"+peer.Hex()+"/accept", nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rr.Code)
+	}
+}
+
+// --- sendPairControl --------------------------------------------------------
+
+func TestSendPairControl_WritesEnvelopeForEachType(t *testing.T) {
+	cc := withPairHandlerEnv(t, &pairHandlersAPI{})
+	peer := mustPK(t)
+
+	for _, want := range []string{pairTypeInvite, pairTypeAck, pairTypeDecline} {
+		t.Run(want, func(t *testing.T) {
+			if err := sendPairControl(context.Background(), peer, want); err != nil {
+				t.Fatalf("sendPairControl(%s) = %v, want nil", want, err)
+			}
+			raw := <-cc.frames
+			var env pairMsg
+			if err := json.Unmarshal(raw, &env); err != nil {
+				t.Fatalf("frame is not a pair envelope: %v (raw %q)", err, raw)
+			}
+			if env.Type != want {
+				t.Errorf("frame type = %q, want %q", env.Type, want)
+			}
+			// from_pk is informational and omitted on the wire — the receiver
+			// authenticates via the connection's remote PK instead.
+			if env.FromPK != "" {
+				t.Errorf("from_pk = %q, want empty (identity comes from the conn)", env.FromPK)
+			}
+		})
+	}
+}
+
+func TestSendPairControl_ReturnsErrorWhenUndeliverable(t *testing.T) {
+	cc := withPairHandlerEnv(t, &pairHandlersAPI{})
+	cc.setDialErr(errors.New("peer offline"))
+	peer := mustPK(t)
+
+	if err := sendPairControl(context.Background(), peer, pairTypeInvite); err == nil {
+		t.Error("sendPairControl should surface the dial failure so callers can log it")
+	}
+}
+
+// --- parsePK empty guard ----------------------------------------------------
+
+func TestParsePK_RejectsEmpty(t *testing.T) {
+	// cipher.PubKey.UnmarshalText("") is a no-op returning a nil error, so an
+	// absent peer_pk would otherwise parse as the all-zero key and reach
+	// PairAdd/PairSend/SendRaw as a real peer. Guarded in parsePK so every
+	// body-based caller inherits it.
+	for _, s := range []string{"", " ", "\t\n"} {
+		if pk, err := parsePK(s); err == nil {
+			t.Errorf("parsePK(%q) = %s, nil; want an error", s, pk.Hex())
+		}
+	}
+}
+
+// --- registerPairHTTPHandlers ----------------------------------------------
+
+func TestRegisterPairHTTPHandlers_RoutePrecedence(t *testing.T) {
+	// /pair/inbox and /pair/invites must beat the /pair/ catchall. Regression
+	// pin for #2699: the inbox path once fell through to pairItemHandler,
+	// which parsed "inbox" as a peer-PK and answered 400.
+	fake := &pairHandlersAPI{}
+	withPairHandlerEnv(t, fake)
+	resetAuth(t)
+	if err := loadSkychatPassword(""); err != nil { // no password → passthrough
+		t.Fatal(err)
+	}
+	peer := mustPK(t)
+
+	mux := http.NewServeMux()
+	registerPairHTTPHandlers(context.Background(), mux)
+
+	cases := []struct {
+		name, method, path string
+		want               int
+	}{
+		{"inbox not swallowed by catchall", http.MethodGet, "/pair/inbox", http.StatusOK},
+		{"invites list", http.MethodGet, "/pair/invites", http.StatusOK},
+		{"root list", http.MethodGet, "/pair", http.StatusOK},
+		{"item delete", http.MethodDelete, "/pair/" + peer.Hex(), http.StatusNoContent},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, httptest.NewRequest(c.method, c.path, nil))
+			if rr.Code != c.want {
+				t.Errorf("%s %s: status = %d, want %d; body=%q", c.method, c.path, rr.Code, c.want, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestRegisterPairHTTPHandlers_DisabledRegistersNothing(t *testing.T) {
+	origEnable := pairEnable
+	pairEnable = false
+	t.Cleanup(func() { pairEnable = origEnable })
+
+	mux := http.NewServeMux()
+	registerPairHTTPHandlers(context.Background(), mux)
+
+	for _, path := range []string{"/pair", "/pair/invites", "/pair/inbox"} {
+		t.Run(path, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+			if rr.Code != http.StatusNotFound {
+				t.Errorf("%s: status = %d, want 404 (pairing off registers no routes)", path, rr.Code)
+			}
+		})
+	}
+}

--- a/cmd/apps/skychat/commands/presence_handler_test.go
+++ b/cmd/apps/skychat/commands/presence_handler_test.go
@@ -1,0 +1,140 @@
+// Package commands cmd/apps/skychat/commands/presence_handler_test.go
+//
+// Drives the REAL presenceHandler past its visor-RPC gate, and covers the
+// eviction arm of presenceStore.record.
+//
+// presence_test.go's shape tests predate the fake-RPC harness, so they inline
+// the handler's post-gate logic rather than calling it — which exercises a copy
+// of the code instead of the code. With withFakePairRPC available the handler
+// itself is reachable, so these call it directly.
+package commands
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// withTestPresence swaps the package presence store for one with an injected
+// prober, and installs a fake visor RPC so the handler's gate opens.
+func withTestPresence(t *testing.T, probe func(cipher.PubKey) peerPresence) {
+	t.Helper()
+	withFakePairRPC(t, &pairHandlersAPI{}) // any non-nil client opens the gate
+	orig := presence
+	presence = newTestPresence(probe)
+	t.Cleanup(func() { presence = orig })
+}
+
+func callPresence(t *testing.T, method, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	presenceHandler()(rr, httptest.NewRequest(method, "/presence", strings.NewReader(body)))
+	return rr
+}
+
+func TestPresenceHandler_PostReturnsSnapshot(t *testing.T) {
+	pks := testPKs(t, 2)
+	withTestPresence(t, func(pk cipher.PubKey) peerPresence {
+		return peerPresence{Online: pk == pks[0], RTTMs: 7, At: time.Now().Unix()}
+	})
+
+	rr := callPresence(t, http.MethodPost,
+		`{"pks":["`+pks[0].Hex()+`","`+pks[1].Hex()+`"]}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rr.Code, rr.Body.String())
+	}
+
+	var res struct {
+		Peers     map[string]peerPresence `json:"peers"`
+		RefreshMS int64                   `json:"refresh_ms"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode: %v (%q)", err, rr.Body.String())
+	}
+	if res.RefreshMS != presenceRefresh.Milliseconds() {
+		t.Errorf("refresh_ms = %d, want %d — the UI reads its poll cadence from here",
+			res.RefreshMS, presenceRefresh.Milliseconds())
+	}
+
+	// POSTing a list also installs it as the watch set, and a NEW contact
+	// triggers an immediate sweep rather than waiting out the refresh tick.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && len(presence.watchSet()) != 2 {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := presence.watchSet(); len(got) != 2 {
+		t.Errorf("watch set = %d entries, want 2", len(got))
+	}
+}
+
+func TestPresenceHandler_GetUsesExistingWatchSet(t *testing.T) {
+	pks := testPKs(t, 2)
+	withTestPresence(t, func(pk cipher.PubKey) peerPresence {
+		return peerPresence{Online: true, RTTMs: 3, At: time.Now().Unix()}
+	})
+	presence.setWatch(pks)
+	presence.sweep(t.Context())
+
+	rr := callPresence(t, http.MethodGet, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rr.Code, rr.Body.String())
+	}
+	var res struct {
+		Peers map[string]peerPresence `json:"peers"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(res.Peers) != 2 {
+		t.Errorf("GET returned %d peers, want the 2 in the watch set", len(res.Peers))
+	}
+}
+
+func TestPresenceHandler_RejectsBadInput(t *testing.T) {
+	withTestPresence(t, func(cipher.PubKey) peerPresence { return peerPresence{} })
+
+	if rr := callPresence(t, http.MethodPost, "{not json"); rr.Code != http.StatusBadRequest {
+		t.Errorf("malformed body: status = %d, want 400", rr.Code)
+	}
+	for _, m := range []string{http.MethodPut, http.MethodDelete} {
+		if rr := callPresence(t, m, ""); rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s: status = %d, want 405", m, rr.Code)
+		}
+	}
+}
+
+// TestPresenceStore_RecordEvictsUnwatched covers record's pruning arm: the seen
+// map tracks the CONTACT LIST, not every peer ever probed, so a long-running
+// visor doesn't accumulate entries for peers the operator removed.
+func TestPresenceStore_RecordEvictsUnwatched(t *testing.T) {
+	p := newTestPresence(func(cipher.PubKey) peerPresence { return peerPresence{} })
+
+	watched := testPKs(t, 3)
+	p.setWatch(watched)
+
+	// Record far more than the eviction threshold (presenceMaxWatch*2).
+	for _, pk := range testPKs(t, presenceMaxWatch*2+5) {
+		p.record(pk, peerPresence{Online: true, At: time.Now().Unix()})
+	}
+	// Then record the watched ones so they survive the prune.
+	for _, pk := range watched {
+		p.record(pk, peerPresence{Online: true, At: time.Now().Unix()})
+	}
+
+	p.mu.Lock()
+	n := len(p.seen)
+	_, keptFirst := p.seen[watched[0]]
+	p.mu.Unlock()
+
+	if n > presenceMaxWatch*2 {
+		t.Errorf("seen holds %d entries, want it pruned to at most %d", n, presenceMaxWatch*2)
+	}
+	if !keptFirst {
+		t.Error("pruning must keep the peers still on the watch set")
+	}
+}

--- a/cmd/apps/skychat/commands/remaining_test.go
+++ b/cmd/apps/skychat/commands/remaining_test.go
@@ -1,0 +1,308 @@
+// Package commands cmd/apps/skychat/commands/remaining_test.go
+//
+// The tail of the 0% list: deleteHandler, voiceErrStatus, fileDialFunc,
+// startFileXfer's disabled guard, and RunSkychat's flag-parse failure.
+//
+// Two functions are deliberately NOT covered here and are expected to stay at
+// 0%:
+//
+//   - Execute — on error it calls log.Fatal, which os.Exit(1)s the test binary;
+//     on success it runs the whole app. There is no way to drive either arm
+//     from a unit test without forking a subprocess, and the body is two lines
+//     of cobra plumbing.
+//   - RunSkychat past its flag parsing — it opens listeners, dials the visor,
+//     starts the HTTP server and blocks. That is the job of the native e2e
+//     lane (internal/nativee2e), not of a unit test.
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skychat/dm"
+	"github.com/skycoin/skywire/pkg/skychat/message"
+)
+
+// Sentinel errors for the table-driven cases below.
+var (
+	errNoRoute         = errors.New("no route to peer")
+	errVoiceDisabled   = errors.New("voice: disabled")
+	errWrappedDisabled = fmt.Errorf("rpc call VoiceActive: %w", errVoiceDisabled)
+)
+
+// --- deleteHandler ----------------------------------------------------------
+
+func TestDeleteHandler_Validation(t *testing.T) {
+	withLifecycleEnv(t)
+	h := deleteHandler(context.Background())
+	pk, _ := cipher.GenerateKeyPair()
+
+	cases := []struct {
+		name, method, body string
+		want               int
+	}{
+		{"non-POST", http.MethodGet, "", http.StatusMethodNotAllowed},
+		{"malformed json", http.MethodPost, `{"pk":`, http.StatusBadRequest},
+		{"bad pk", http.MethodPost, `{"pk":"not-a-pk","id":"m-1"}`, http.StatusBadRequest},
+		{"empty pk", http.MethodPost, `{"pk":"","id":"m-1"}`, http.StatusBadRequest},
+		{"missing id", http.MethodPost, `{"pk":"` + pk.Hex() + `"}`, http.StatusBadRequest},
+		{"blank id", http.MethodPost, `{"pk":"` + pk.Hex() + `","id":"   "}`, http.StatusBadRequest},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			h(rr, httptest.NewRequest(c.method, "/delete", strings.NewReader(c.body)))
+			if rr.Code != c.want {
+				t.Errorf("status = %d, want %d; body=%q", rr.Code, c.want, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestDeleteHandler_NoControllerReturns503(t *testing.T) {
+	withLifecycleEnv(t)
+	chatCtrl = nil
+	pk, _ := cipher.GenerateKeyPair()
+
+	rr := httptest.NewRecorder()
+	deleteHandler(context.Background())(rr, httptest.NewRequest(http.MethodPost, "/delete",
+		strings.NewReader(`{"pk":"`+pk.Hex()+`","id":"m-1"}`)))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503 with no DM controller", rr.Code)
+	}
+}
+
+func TestDeleteHandler_SendsTombstoneAndTombstonesLocally(t *testing.T) {
+	withLifecycleEnv(t)
+	cc := newCapturingClient()
+	chatCtrl = dm.New(dm.Config{Client: cc, Networks: []appnet.Type{appnet.TypeSkynet}})
+	t.Cleanup(func() {
+		_ = chatCtrl.Close() //nolint:errcheck
+		cc.closeAll()
+	})
+
+	raw, unsub := hub.subscribe()
+	defer unsub()
+
+	peer, _ := cipher.GenerateKeyPair()
+	rr := httptest.NewRecorder()
+	deleteHandler(context.Background())(rr, httptest.NewRequest(http.MethodPost, "/delete",
+		strings.NewReader(`{"pk":"`+peer.Hex()+`","id":"m-42"}`)))
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%q", rr.Code, rr.Body.String())
+	}
+
+	// The peer gets a chat-delete so their UI tombstones it too.
+	select {
+	case frame := <-cc.frames:
+		var env message.Envelope
+		if err := json.Unmarshal(frame, &env); err != nil {
+			t.Fatalf("wire frame is not an envelope: %v (%q)", err, frame)
+		}
+		if env.Type != message.TypeDelete || env.ID != "m-42" {
+			t.Errorf("wire envelope = %+v, want a chat-delete for m-42", env)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no chat-delete reached the wire")
+	}
+
+	// And our own bubble tombstones immediately via a dm-status event.
+	got := waitForString(t, raw, 2*time.Second)
+	var m map[string]string
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("dm-status is not JSON: %v (%q)", err, got)
+	}
+	if m["channel"] != "dm-status" || m["id"] != "m-42" ||
+		m["status"] != dmStatusDeleted || m["peer"] != peer.Hex() {
+		t.Errorf("dm-status = %v, want a deleted status for m-42/%s", m, peer.Hex()[:8])
+	}
+}
+
+// TestDeleteHandler_UnreachablePeerStillTombstonesLocally — the operator's
+// intent is recorded even when the peer cannot be told. Failing the request
+// here would leave the deleter staring at a message they just deleted.
+func TestDeleteHandler_UnreachablePeerStillTombstonesLocally(t *testing.T) {
+	withLifecycleEnv(t)
+	cc := newCapturingClient()
+	cc.setDialErr(errNoRoute)
+	chatCtrl = dm.New(dm.Config{Client: cc, Networks: []appnet.Type{appnet.TypeSkynet}})
+	t.Cleanup(func() {
+		_ = chatCtrl.Close() //nolint:errcheck
+		cc.closeAll()
+	})
+
+	raw, unsub := hub.subscribe()
+	defer unsub()
+
+	peer, _ := cipher.GenerateKeyPair()
+	rr := httptest.NewRecorder()
+	deleteHandler(context.Background())(rr, httptest.NewRequest(http.MethodPost, "/delete",
+		strings.NewReader(`{"pk":"`+peer.Hex()+`","id":"m-offline"}`)))
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204 even when the peer is unreachable", rr.Code)
+	}
+	got := waitForString(t, raw, 2*time.Second)
+	if !strings.Contains(got, "m-offline") || !strings.Contains(got, dmStatusDeleted) {
+		t.Errorf("local tombstone missing; broadcast = %q", got)
+	}
+}
+
+// --- voiceErrStatus ---------------------------------------------------------
+
+// TestVoiceErrStatus — a DISABLED voice manager (no dmsg, no audio device) must
+// map to 503 so the browser hides the call controls entirely; every other
+// proxy failure is a 502 the UI can surface as a transient error.
+func TestVoiceErrStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil error", nil, http.StatusBadGateway},
+		{"voice disabled", errVoiceDisabled, http.StatusServiceUnavailable},
+		{"disabled inside a wrapped message", errWrappedDisabled, http.StatusServiceUnavailable},
+		{"unrelated failure", errNoRoute, http.StatusBadGateway},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := voiceErrStatus(c.err); got != c.want {
+				t.Errorf("voiceErrStatus(%v) = %d, want %d", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+// --- file transport guards --------------------------------------------------
+
+// TestFileDialFunc_NoAppClient — in --standalone mode there is no app client,
+// so a file dial must report that rather than nil-deref.
+func TestFileDialFunc_NoAppClient(t *testing.T) {
+	withLifecycleEnv(t)
+	origApp := appCl
+	appCl = nil
+	t.Cleanup(func() { appCl = origApp })
+
+	peer, _ := cipher.GenerateKeyPair()
+	conn, err := fileDialFunc(context.Background(), peer, 1)
+	if err == nil || conn != nil {
+		t.Errorf("fileDialFunc with no app client = (%v, %v), want (nil, error)", conn, err)
+	}
+	if !strings.Contains(err.Error(), "not initialized") {
+		t.Errorf("err = %v, want it to name the missing app client", err)
+	}
+}
+
+// TestStartFileXfer_NoAppClientIsNoOp — same standalone guard on the listener
+// side: no app client means no file transport, silently.
+func TestStartFileXfer_NoAppClientIsNoOp(t *testing.T) {
+	withLifecycleEnv(t)
+	origApp, origMgr := appCl, fileMgr
+	appCl = nil
+	fileMgrMu.Lock()
+	fileMgr = nil
+	fileMgrMu.Unlock()
+	t.Cleanup(func() {
+		appCl = origApp
+		fileMgrMu.Lock()
+		fileMgr = origMgr
+		fileMgrMu.Unlock()
+	})
+
+	startFileXfer(context.Background())
+
+	fileMgrMu.Lock()
+	defer fileMgrMu.Unlock()
+	if fileMgr != nil {
+		t.Error("startFileXfer should not build a manager without an app client")
+	}
+}
+
+// --- RunSkychat flag parsing ------------------------------------------------
+
+// snapshotFlagGlobals saves and restores every package global RunSkychat's
+// FlagSet binds. pflag writes each default into its target as soon as the flag
+// is registered — before Parse can fail — so even the error path rewrites all
+// of them.
+func snapshotFlagGlobals(t *testing.T) {
+	t.Helper()
+	type snap struct {
+		addr                                   string
+		portless                               bool
+		appPort                                uint16
+		useSkynet, useDmsg, osNotify           bool
+		passwordFile, internalToken            string
+		persistEnabled                         bool
+		persistDBPath                          string
+		persistMaxMsgSize, persistPerPeerRate  int
+		persistPerPeerCap, persistTotalCapMB   int
+		persistTTLDays                         int
+		persistWhitelistFile                   string
+		persistSeedCount                       int
+		pairEnable                             bool
+		pairRPCAddr                            string
+		pairPollInterval                       time.Duration
+		tcpListen                              string
+		tcpPeers                               []string
+		tcpWhitelist, tcpSKFlag, tcpConfigPath string
+	}
+	s := snap{
+		addr, portless, appPort, useSkynet, useDmsg, osNotify,
+		passwordFile, internalToken, persistEnabled, persistDBPath,
+		persistMaxMsgSize, persistPerPeerRate, persistPerPeerCap,
+		persistTotalCapMB, persistTTLDays, persistWhitelistFile,
+		persistSeedCount, pairEnable, pairRPCAddr, pairPollInterval,
+		tcpListen, tcpPeers, tcpWhitelist, tcpSKFlag, tcpConfigPath,
+	}
+	t.Cleanup(func() {
+		addr, portless, appPort = s.addr, s.portless, s.appPort
+		useSkynet, useDmsg, osNotify = s.useSkynet, s.useDmsg, s.osNotify
+		passwordFile, internalToken = s.passwordFile, s.internalToken
+		persistEnabled, persistDBPath = s.persistEnabled, s.persistDBPath
+		persistMaxMsgSize, persistPerPeerRate = s.persistMaxMsgSize, s.persistPerPeerRate
+		persistPerPeerCap, persistTotalCapMB = s.persistPerPeerCap, s.persistTotalCapMB
+		persistTTLDays, persistWhitelistFile = s.persistTTLDays, s.persistWhitelistFile
+		persistSeedCount, pairEnable = s.persistSeedCount, s.pairEnable
+		pairRPCAddr, pairPollInterval = s.pairRPCAddr, s.pairPollInterval
+		tcpListen, tcpPeers = s.tcpListen, s.tcpPeers
+		tcpWhitelist, tcpSKFlag, tcpConfigPath = s.tcpWhitelist, s.tcpSKFlag, s.tcpConfigPath
+	})
+}
+
+// TestRunSkychat_RejectsUnknownFlag — the visor passes skychat's args verbatim
+// from skywire.json, so a typo there must fail loudly at startup instead of
+// silently running with defaults on the wrong port/transport.
+func TestRunSkychat_RejectsUnknownFlag(t *testing.T) {
+	snapshotFlagGlobals(t)
+
+	err := RunSkychat(context.Background(), []string{"--definitely-not-a-flag"})
+	if err == nil {
+		t.Fatal("an unknown flag should abort startup")
+	}
+	if !strings.Contains(err.Error(), "parse flags") {
+		t.Errorf("err = %v, want it attributed to flag parsing", err)
+	}
+}
+
+func TestRunSkychat_RejectsMalformedFlagValue(t *testing.T) {
+	snapshotFlagGlobals(t)
+
+	// --port is a uint16; a non-numeric value must not silently become 0.
+	err := RunSkychat(context.Background(), []string{"--port=not-a-number"})
+	if err == nil {
+		t.Fatal("a malformed flag value should abort startup")
+	}
+	if !strings.Contains(err.Error(), "parse flags") {
+		t.Errorf("err = %v, want it attributed to flag parsing", err)
+	}
+}

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -1725,12 +1725,32 @@ func getFileSystem() http.FileSystem {
 	return http.FS(fsys)
 }
 
+// ipcStartupDelay is the grace period before the IPC handler starts reading,
+// giving the visor's IPC server time to come up. A package var so tests can
+// drive the handler without waiting it out.
+var ipcStartupDelay = 5 * time.Second
+
+// ipcConn is the subset of *ipc.Client the signal handler uses. It exists so
+// ipcSignalLoop can be driven from a test: the spin-loop regression the loop
+// guards against is only observable by controlling what Read returns, which a
+// live IPC server can't do on demand.
+type ipcConn interface {
+	Read() (*ipc.Message, error)
+	Close()
+}
+
 func handleIPCSignal(client *ipc.Client) {
-	time.Sleep(5 * time.Second)
+	time.Sleep(ipcStartupDelay)
 	if client == nil {
 		appLog("Unable to create IPC Client: server is non-existent")
 		return
 	}
+	ipcSignalLoop(client)
+}
+
+// ipcSignalLoop drains IPC messages until a shutdown signal or a read error,
+// then closes the client.
+func ipcSignalLoop(client ipcConn) {
 	for {
 		m, err := client.Read()
 		if err != nil {

--- a/cmd/apps/skychat/commands/tcp_direct_loops_test.go
+++ b/cmd/apps/skychat/commands/tcp_direct_loops_test.go
@@ -1,0 +1,521 @@
+// Package commands cmd/apps/skychat/commands/tcp_direct_loops_test.go
+//
+// Coverage for the TCP-direct transport loops, which were the last of the
+// lifecycle set still at 0%: runTCPListen, acceptTCPConn, runTCPPeerDialers,
+// peerDialLoop and startTCPDirect.
+//
+// Unlike the dmsg/skynet paths these need no mesh at all — they are real TCP
+// plus a noise-XK handshake, so the tests run both ends on 127.0.0.1 and drive
+// actual encrypted frames through the production accept path into the shared
+// DM controller.
+//
+// The load-bearing assertion is the WHITELIST GATE in acceptTCPConn. Its
+// semantics are deliberately inverted from what "whitelist" suggests — an
+// EMPTY list means OPEN (accept any authenticated peer), matching the skywire
+// convention, while a NON-EMPTY list restricts. Getting that backwards either
+// locks every operator out or silently serves the world, and neither shows up
+// until someone is already exposed, so both directions are pinned here.
+//
+// Goroutine/cleanup note: these loops read the package-level chatCtrl. Every
+// test that reaches chatCtrl.Serve waits until the conn is actually cached
+// (HasConn takes the controller's mutex, which orders that read before the
+// harness restores the global) or joins the goroutine it owns. Canceling and
+// hoping is not enough for the race detector — see lifecycle_test.go.
+package commands
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skychat/dm"
+	"github.com/skycoin/skywire/pkg/skychat/message"
+	"github.com/skycoin/skywire/pkg/skywire/tcpnoise"
+)
+
+// --- harness ----------------------------------------------------------------
+
+// withTCPEnv installs a controller whose surfaced events the test can read,
+// and restores every tcp-direct flag var.
+func withTCPEnv(t *testing.T) <-chan dm.Event {
+	t.Helper()
+	if appLog == nil {
+		appLog = func(string, ...any) {}
+	}
+	withChatLog(t)
+
+	origCtrl := chatCtrl
+	origListen, origPeers := tcpListen, tcpPeers
+	origWL, origSK, origCfg := tcpWhitelist, tcpSKFlag, tcpConfigPath
+
+	events := make(chan dm.Event, 16)
+	ctrl := dm.New(dm.Config{
+		OnEvent: func(ev dm.Event) {
+			select {
+			case events <- ev:
+			default:
+			}
+		},
+	})
+	chatCtrl = ctrl
+
+	// DMSGCURL_SK would otherwise leak an operator's real identity into
+	// resolveTCPIdentity; t.Setenv restores it after the test.
+	t.Setenv("DMSGCURL_SK", "")
+	tcpListen, tcpPeers, tcpWhitelist, tcpSKFlag, tcpConfigPath = "", nil, "", "", ""
+
+	t.Cleanup(func() {
+		_ = ctrl.Close() //nolint:errcheck // unblocks any Serve still reading
+		chatCtrl = origCtrl
+		tcpListen, tcpPeers = origListen, origPeers
+		tcpWhitelist, tcpSKFlag, tcpConfigPath = origWL, origSK, origCfg
+	})
+	return events
+}
+
+// freeTCPAddr reserves a loopback port and releases it, so the caller can hand
+// the address to code that opens its own listener.
+func freeTCPAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve a port: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close() //nolint:errcheck
+	return addr
+}
+
+// waitListening blocks until addr accepts TCP connections.
+func waitListening(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			_ = c.Close() //nolint:errcheck
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("nothing listening on %s after 5s", addr)
+}
+
+// waitConnCached polls until the controller has cached a conn for pk. The
+// HasConn read takes the controller's mutex, which is what orders the
+// goroutine's chatCtrl access before this test's cleanup.
+func waitConnCached(t *testing.T, pk cipher.PubKey) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if chatCtrl.HasConn(pk) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("the controller never cached a conn for %s", pk.Hex()[:8])
+}
+
+func waitEvent(t *testing.T, ch <-chan dm.Event, d time.Duration) dm.Event {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		return ev
+	case <-time.After(d):
+		t.Fatal("no chat event surfaced from the tcp-direct conn")
+		return dm.Event{}
+	}
+}
+
+// startListener runs runTCPListen in the background and returns its address
+// plus a stop func that cancels it and joins.
+func startListener(t *testing.T, pk cipher.PubKey, sk cipher.SecKey,
+	wl map[cipher.PubKey]struct{}) (addr string, stop func()) {
+	t.Helper()
+	addr = freeTCPAddr(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runTCPListen(ctx, addr, pk, sk, wl) }()
+	waitListening(t, addr)
+
+	return addr, func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("runTCPListen returned %v, want nil on context cancel", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("runTCPListen did not return after its context was canceled")
+		}
+	}
+}
+
+// --- runTCPListen / acceptTCPConn -------------------------------------------
+
+// TestRunTCPListen_ServesWhitelistedPeer drives a full noise handshake and a
+// real chat frame through the production accept path.
+func TestRunTCPListen_ServesWhitelistedPeer(t *testing.T) {
+	events := withTCPEnv(t)
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	cliPK, cliSK := cipher.GenerateKeyPair()
+
+	addr, stop := startListener(t, srvPK, srvSK, map[cipher.PubKey]struct{}{cliPK: {}})
+	defer stop()
+
+	conn, err := tcpnoise.Dial(context.Background(), addr, cliPK, cliSK, srvPK)
+	if err != nil {
+		t.Fatalf("noise dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }() //nolint:errcheck
+
+	// The accepted conn is cached under the noise-learned PK, so the existing
+	// DM machinery (send, receipts, stale-conn eviction) works over TCP too.
+	waitConnCached(t, cliPK)
+
+	if err := message.WriteFrame(conn, []byte("over tcp-direct")); err != nil {
+		t.Fatalf("write frame: %v", err)
+	}
+	ev := waitEvent(t, events, 5*time.Second)
+	if ev.Text != "over tcp-direct" {
+		t.Errorf("surfaced text = %q, want %q", ev.Text, "over tcp-direct")
+	}
+	if ev.Peer != cliPK.Hex() {
+		t.Errorf("event peer = %s, want the noise-authenticated %s", ev.Peer, cliPK.Hex()[:8])
+	}
+	if ev.Dir != "in" {
+		t.Errorf("event dir = %q, want in", ev.Dir)
+	}
+	// The transport is tagged so operators can tell which path carried it.
+	if ev.Network != string(appnet.TypeTCPDirect) {
+		t.Errorf("event network = %q, want the tcp-direct tag %q", ev.Network, appnet.TypeTCPDirect)
+	}
+}
+
+// TestRunTCPListen_RejectsNonWhitelistedPeer — a NON-EMPTY whitelist restricts.
+// The peer still completes the noise handshake (it is authenticated), then the
+// gate drops it: no cached conn, and the socket is closed under it.
+func TestRunTCPListen_RejectsNonWhitelistedPeer(t *testing.T) {
+	withTCPEnv(t)
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	cliPK, cliSK := cipher.GenerateKeyPair()
+	allowed, _ := cipher.GenerateKeyPair() // someone else
+
+	addr, stop := startListener(t, srvPK, srvSK, map[cipher.PubKey]struct{}{allowed: {}})
+	defer stop()
+
+	conn, err := tcpnoise.Dial(context.Background(), addr, cliPK, cliSK, srvPK)
+	if err != nil {
+		t.Fatalf("noise dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }() //nolint:errcheck
+
+	// The server hangs up rather than serving. A read TIMEOUT would mean the
+	// conn was left open (i.e. we were served after all), so the error has to
+	// be a real close, not a deadline.
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
+	_, rerr := message.ReadFrame(conn)
+	if rerr == nil {
+		t.Fatal("a non-whitelisted peer should have its conn closed, not served")
+	}
+	var nerr net.Error
+	if errors.As(rerr, &nerr) && nerr.Timeout() {
+		t.Errorf("read timed out (%v) instead of failing on a closed conn — the peer was served", rerr)
+	}
+	if chatCtrl.HasConn(cliPK) {
+		t.Error("a non-whitelisted peer must not be cached in the controller")
+	}
+}
+
+// TestRunTCPListen_EmptyWhitelistIsOpen pins the inverted semantics: an empty
+// list is OPEN (any authenticated peer), matching skynet's Server.useWL and the
+// CXO treestore's nil-allowlist. Reading it as "deny all" would lock out every
+// operator who set --tcp-listen without --tcp-whitelist.
+func TestRunTCPListen_EmptyWhitelistIsOpen(t *testing.T) {
+	withTCPEnv(t)
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	cliPK, cliSK := cipher.GenerateKeyPair()
+
+	addr, stop := startListener(t, srvPK, srvSK, map[cipher.PubKey]struct{}{})
+	defer stop()
+
+	conn, err := tcpnoise.Dial(context.Background(), addr, cliPK, cliSK, srvPK)
+	if err != nil {
+		t.Fatalf("noise dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }() //nolint:errcheck
+
+	waitConnCached(t, cliPK)
+}
+
+func TestRunTCPListen_BindFailureReturnsError(t *testing.T) {
+	withTCPEnv(t)
+	pk, sk := cipher.GenerateKeyPair()
+
+	err := runTCPListen(context.Background(), "127.0.0.1:not-a-port", pk, sk, nil)
+	if err == nil {
+		t.Error("binding an invalid address should return an error, not block")
+	}
+}
+
+// TestRunTCPListen_ContextCancelIsCleanShutdown — cancel must close the
+// listener and return nil, not surface the resulting "use of closed network
+// connection" as a failure.
+func TestRunTCPListen_ContextCancelIsCleanShutdown(t *testing.T) {
+	withTCPEnv(t)
+	pk, sk := cipher.GenerateKeyPair()
+
+	addr, stop := startListener(t, pk, sk, nil)
+	stop() // asserts a nil return internally
+
+	// The port is released, so it can be bound again.
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("port %s still held after shutdown: %v", addr, err)
+	}
+	_ = l.Close() //nolint:errcheck
+}
+
+// TestAcceptTCPConn_HandshakeFailureDropsConn — a peer that hangs up mid
+// handshake (or speaks something other than noise) must not be served.
+func TestAcceptTCPConn_HandshakeFailureDropsConn(t *testing.T) {
+	withTCPEnv(t)
+	srvPK, srvSK := cipher.GenerateKeyPair()
+
+	server, client := net.Pipe()
+	_ = client.Close() //nolint:errcheck // hang up before the handshake starts
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		acceptTCPConn(server, srvPK, srvSK, nil)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("acceptTCPConn should return promptly when the handshake fails")
+	}
+	if n := chatCtrl.Conns(); n != 0 {
+		t.Errorf("a failed handshake cached %d conns, want 0", n)
+	}
+}
+
+// --- peerDialLoop / runTCPPeerDialers ---------------------------------------
+
+// noiseEchoServer accepts noise conns and hands each accepted conn to the
+// returned channel, so a test can observe reconnects and close conns at will.
+func noiseEchoServer(t *testing.T, pk cipher.PubKey, sk cipher.SecKey) (addr string, accepted <-chan net.Conn) {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() }) //nolint:errcheck
+
+	ch := make(chan net.Conn, 8)
+	go func() {
+		for {
+			raw, aerr := lis.Accept()
+			if aerr != nil {
+				return
+			}
+			go func(raw net.Conn) {
+				c, _, herr := tcpnoise.Accept(raw, pk, sk)
+				if herr != nil {
+					return
+				}
+				select {
+				case ch <- c:
+				default:
+					_ = c.Close() //nolint:errcheck
+				}
+			}(raw)
+		}
+	}()
+	return lis.Addr().String(), ch
+}
+
+// TestPeerDialLoop_ConnectsAndRedialsAfterDisconnect — a dropped peer must be
+// picked back up. Backoff resets on a successful dial, so the redial after a
+// disconnect is immediate rather than waiting out the previous window.
+func TestPeerDialLoop_ConnectsAndRedialsAfterDisconnect(t *testing.T) {
+	withTCPEnv(t)
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	cliPK, cliSK := cipher.GenerateKeyPair()
+
+	addr, accepted := noiseEchoServer(t, srvPK, srvSK)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		peerDialLoop(ctx, srvPK, addr, cliPK, cliSK)
+	}()
+
+	first := <-acceptedWithin(t, accepted)
+	waitConnCached(t, srvPK)
+
+	// Drop the peer; the loop should come straight back.
+	_ = first.Close() //nolint:errcheck
+	second := <-acceptedWithin(t, accepted)
+
+	cancel()
+	_ = second.Close() //nolint:errcheck // unblocks the Serve the loop is inside
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("peerDialLoop did not exit after its context was canceled")
+	}
+}
+
+// acceptedWithin adapts a receive-with-timeout into a channel expression.
+func acceptedWithin(t *testing.T, ch <-chan net.Conn) <-chan net.Conn {
+	t.Helper()
+	out := make(chan net.Conn, 1)
+	select {
+	case c := <-ch:
+		out <- c
+	case <-time.After(10 * time.Second):
+		t.Fatal("peer never connected")
+	}
+	return out
+}
+
+// TestPeerDialLoop_UnreachablePeerBacksOffAndExits — the backoff sleep must be
+// interruptible, or shutdown stalls for up to tcpReconnectMax.
+func TestPeerDialLoop_UnreachablePeerBacksOffAndExits(t *testing.T) {
+	withTCPEnv(t)
+	srvPK, _ := cipher.GenerateKeyPair()
+	cliPK, cliSK := cipher.GenerateKeyPair()
+
+	dead := freeTCPAddr(t) // reserved then released: nothing is listening
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		peerDialLoop(ctx, srvPK, dead, cliPK, cliSK)
+	}()
+
+	// Let the first dial fail and the loop enter its backoff sleep.
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+
+	start := time.Now()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("peerDialLoop did not exit during its backoff window")
+	}
+	if elapsed := time.Since(start); elapsed > tcpReconnectMin {
+		t.Errorf("exit took %v — cancel should interrupt the backoff, not wait it out", elapsed)
+	}
+}
+
+func TestRunTCPPeerDialers_SkipsBadSpecsAndDialsGoodOnes(t *testing.T) {
+	withTCPEnv(t)
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	cliPK, cliSK := cipher.GenerateKeyPair()
+
+	addr, accepted := noiseEchoServer(t, srvPK, srvSK)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runTCPPeerDialers(ctx, []string{
+		"not-a-url",                         // no tcp:// prefix
+		"tcp://missing-at-separator",        // no @
+		"tcp://deadbeef@127.0.0.1:1",        // bad pk
+		"tcp://" + srvPK.Hex() + "@" + addr, // the good one
+	}, cliPK, cliSK)
+
+	conn := <-acceptedWithin(t, accepted)
+	waitConnCached(t, srvPK)
+	cancel()
+	_ = conn.Close() //nolint:errcheck
+}
+
+// --- startTCPDirect ---------------------------------------------------------
+
+func TestStartTCPDirect_DisabledIsNoOp(t *testing.T) {
+	withTCPEnv(t)
+	tcpListen, tcpPeers = "", nil
+
+	if err := startTCPDirect(context.Background()); err != nil {
+		t.Errorf("with neither flag set startTCPDirect should be a no-op, got %v", err)
+	}
+}
+
+// TestStartTCPDirect_RequiresIdentity — TCP-direct pins peers by PK, so an
+// ephemeral key would defeat the trust model. Enabling it without an identity
+// must fail loudly at startup rather than silently generating one.
+func TestStartTCPDirect_RequiresIdentity(t *testing.T) {
+	withTCPEnv(t)
+	tcpListen = freeTCPAddr(t)
+	tcpSKFlag, tcpConfigPath = "", ""
+
+	err := startTCPDirect(context.Background())
+	if err == nil {
+		t.Fatal("enabling tcp-direct with no configured identity should error")
+	}
+	if !strings.Contains(err.Error(), "identity") {
+		t.Errorf("err = %v, want it to name the missing identity", err)
+	}
+}
+
+func TestStartTCPDirect_ListensWithFlagIdentity(t *testing.T) {
+	events := withTCPEnv(t)
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	cliPK, cliSK := cipher.GenerateKeyPair()
+
+	addr := freeTCPAddr(t)
+	tcpListen = addr
+	tcpSKFlag = srvSK.Hex()
+	tcpWhitelist = cliPK.Hex()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := startTCPDirect(ctx); err != nil {
+		t.Fatalf("startTCPDirect: %v", err)
+	}
+	waitListening(t, addr)
+
+	conn, err := tcpnoise.Dial(context.Background(), addr, cliPK, cliSK, srvPK)
+	if err != nil {
+		t.Fatalf("noise dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }() //nolint:errcheck
+
+	waitConnCached(t, cliPK)
+	if err := message.WriteFrame(conn, []byte("via startTCPDirect")); err != nil {
+		t.Fatalf("write frame: %v", err)
+	}
+	if ev := waitEvent(t, events, 5*time.Second); ev.Text != "via startTCPDirect" {
+		t.Errorf("surfaced text = %q", ev.Text)
+	}
+}
+
+func TestStartTCPDirect_DialsConfiguredPeers(t *testing.T) {
+	withTCPEnv(t)
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	_, cliSK := cipher.GenerateKeyPair()
+
+	addr, accepted := noiseEchoServer(t, srvPK, srvSK)
+	tcpPeers = []string{"tcp://" + srvPK.Hex() + "@" + addr}
+	tcpSKFlag = cliSK.Hex()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := startTCPDirect(ctx); err != nil {
+		t.Fatalf("startTCPDirect: %v", err)
+	}
+
+	conn := <-acceptedWithin(t, accepted)
+	waitConnCached(t, srvPK)
+	cancel()
+	_ = conn.Close() //nolint:errcheck
+}

--- a/cmd/apps/skychat/group/manager_integration_test.go
+++ b/cmd/apps/skychat/group/manager_integration_test.go
@@ -1,0 +1,350 @@
+// Package group cmd/apps/skychat/group/manager_integration_test.go
+//
+// The dmsg-backed integration lane for group.Manager — the half of manager.go
+// that cannot be reached without a real transport: Create, Join, AddMember,
+// PromoteAdmin, DemoteAdmin, SendToGroup, Resume, ReplayHistory and openLocked.
+//
+// Manager takes a *dmsg.Client and openLocked hands it straight to group.Open,
+// so unlike Session (which also has a native-TCP mode) there is no transport
+// seam to substitute. This spins up a 1-server / 2-client dmsgtest env and
+// drives two managers against it, mirroring pairing/integration_test.go.
+//
+// Skipped under -short, matching this repo's convention for dmsg-backed tests
+// (pairing/baseline_test.go, pairing/integration_test.go).
+//
+// Timing note: CXO subscription bring-up over dmsg is eventually consistent —
+// see the scope note in session_lifecycle_test.go for the wait-for-root
+// behavior that makes it so. Everything here therefore polls with a generous
+// budget rather than asserting immediately after an operation returns.
+package group
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgtest"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// --- harness ----------------------------------------------------------------
+
+// groupNode is one visor in the integration group.
+type groupNode struct {
+	pk    cipher.PubKey
+	sk    cipher.SecKey
+	dmsgC *dmsg.Client
+	store *Store
+	dir   string
+	mgr   *Manager
+	inbox *msgInbox // from session_lifecycle_test.go
+}
+
+// newGroupEnv brings up a dmsg env with two managers wired to it.
+func newGroupEnv(t *testing.T) (a, b *groupNode) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("dmsg integration test; skipped under -short")
+	}
+
+	pkA, skA := cipher.GenerateKeyPair()
+	pkB, skB := cipher.GenerateKeyPair()
+
+	env := dmsgtest.NewEnv(t, dmsgtest.DefaultTimeout)
+	env.Discovery()
+	require.NoError(t, env.Startup(dmsgtest.DefaultTimeout, 1, 0, &dmsg.Config{MinSessions: 1}))
+	t.Cleanup(env.Shutdown)
+
+	dmsgA, err := env.NewClientWithKeys(pkA, skA, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err)
+	dmsgB, err := env.NewClientWithKeys(pkB, skB, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err)
+	waitDmsgClientReady(t, dmsgA)
+	waitDmsgClientReady(t, dmsgB)
+
+	mk := func(pk cipher.PubKey, sk cipher.SecKey, c *dmsg.Client, tag string) *groupNode {
+		dir := t.TempDir()
+		st, serr := OpenStore(filepath.Join(dir, "groups.db"))
+		require.NoError(t, serr)
+		t.Cleanup(func() { _ = st.Close() }) //nolint:errcheck
+
+		mgr, merr := NewManager(ManagerConfig{
+			Store: st, DmsgC: c, MyPK: pk, MySK: sk,
+			DataDir: filepath.Join(dir, "cxo"),
+			Logger:  logging.MustGetLogger("group-mgr-" + tag),
+		})
+		require.NoError(t, merr)
+		t.Cleanup(func() { _ = mgr.Close() }) //nolint:errcheck
+
+		box := &msgInbox{}
+		mgr.SetMessageHandler(box.deliver)
+		return &groupNode{pk: pk, sk: sk, dmsgC: c, store: st, dir: dir, mgr: mgr, inbox: box}
+	}
+
+	return mk(pkA, skA, dmsgA, "A"), mk(pkB, skB, dmsgB, "B")
+}
+
+func waitDmsgClientReady(t *testing.T, c *dmsg.Client) {
+	t.Helper()
+	select {
+	case <-c.Ready():
+	case <-time.After(20 * time.Second):
+		t.Fatalf("dmsg client %s never became ready", c.LocalPK().Hex()[:8])
+	}
+}
+
+// waitInbox polls an inbox until pred holds, or fails.
+func waitInbox(t *testing.T, box *msgInbox, what string, pred func([]Message) bool) {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if pred(box.snapshot()) {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s; inbox = %+v", what, box.snapshot())
+}
+
+func hasText(text string) func([]Message) bool {
+	return func(msgs []Message) bool {
+		for _, m := range msgs {
+			if m.Text == text {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// createAndJoin runs the real onboarding flow: A creates, admits B, issues an
+// invite, B joins. Returns the group id.
+func createAndJoin(t *testing.T, a, b *groupNode, mode Mode) string {
+	t.Helper()
+
+	rec, err := a.mgr.Create("integration room", mode, nil)
+	require.NoError(t, err, "Create")
+	require.Equal(t, RoleOwner, rec.Role)
+	require.Equal(t, StatusActive, rec.Status)
+	require.Contains(t, rec.Members, a.pk, "the creator is always in its own allowlist")
+
+	// Admit B BEFORE it subscribes, or the publisher's allowlist rejects it.
+	updated, err := a.mgr.AddMember(rec.ID, b.pk)
+	require.NoError(t, err, "AddMember")
+	require.Contains(t, updated.Members, b.pk)
+
+	link, err := a.mgr.BuildInvite(rec.ID)
+	require.NoError(t, err, "BuildInvite")
+	inv, err := DecodeInvite(link)
+	require.NoError(t, err, "DecodeInvite")
+
+	joined, err := b.mgr.Join(inv)
+	require.NoError(t, err, "Join")
+	require.Equal(t, rec.ID, joined.ID)
+	require.Equal(t, RoleMember, joined.Role)
+	require.Equal(t, StatusActive, joined.Status, "Join marks the record active even on an optimistic connect")
+
+	return rec.ID
+}
+
+// --- onboarding + send ------------------------------------------------------
+
+// TestManagerIntegration_CreateJoinAndSend walks the whole operator flow and
+// asserts the owner's message actually reaches the joiner's handler.
+func TestManagerIntegration_CreateJoinAndSend(t *testing.T) {
+	a, b := newGroupEnv(t)
+	id := createAndJoin(t, a, b, ModePublic)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Re-send periodically: a joiner's subscription attaches asynchronously, so
+	// the first publish can precede it.
+	const fromOwner = "hello from the owner"
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second):
+				_ = a.mgr.SendToGroup(ctx, id, fromOwner) //nolint:errcheck
+			}
+		}
+	}()
+	require.NoError(t, a.mgr.SendToGroup(ctx, id, fromOwner), "SendToGroup")
+
+	waitInbox(t, b.inbox, "the owner's message", hasText(fromOwner))
+
+	// The owner self-echoes its own sends, so its inbox matches the members'.
+	waitInbox(t, a.inbox, "the owner's self-echo", hasText(fromOwner))
+
+	// last_message_at is refreshed by the send path.
+	rec, ok, err := a.mgr.Get(id)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, rec.LastMessageAt.IsZero(), "SendToGroup should refresh LastMessageAt")
+}
+
+// TestManagerIntegration_SendToGroupUnknownID — sending to a group with no live
+// session must report it rather than silently dropping the message.
+func TestManagerIntegration_SendToGroupUnknownID(t *testing.T) {
+	a, _ := newGroupEnv(t)
+	err := a.mgr.SendToGroup(context.Background(), "no-such-group", "into the void")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no live session")
+}
+
+// TestManagerIntegration_PrivateGroupRoundTrip — a ModePrivate group generates
+// an AES key at Create, ships it in the invite, and the joiner decrypts with it.
+func TestManagerIntegration_PrivateGroupRoundTrip(t *testing.T) {
+	a, b := newGroupEnv(t)
+
+	rec, err := a.mgr.Create("private room", ModePrivate, nil)
+	require.NoError(t, err)
+	require.Len(t, rec.AESKey, 32, "a private group gets a 32-byte AES key at create time")
+
+	_, err = a.mgr.AddMember(rec.ID, b.pk)
+	require.NoError(t, err)
+	link, err := a.mgr.BuildInvite(rec.ID)
+	require.NoError(t, err)
+	inv, err := DecodeInvite(link)
+	require.NoError(t, err)
+	require.Equal(t, rec.AESKey, inv.AESKey, "the invite carries the group key")
+
+	_, err = b.mgr.Join(inv)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	const secret = "sealed group traffic"
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second):
+				_ = a.mgr.SendToGroup(ctx, rec.ID, secret) //nolint:errcheck
+			}
+		}
+	}()
+	require.NoError(t, a.mgr.SendToGroup(ctx, rec.ID, secret))
+
+	waitInbox(t, b.inbox, "the decrypted private message", hasText(secret))
+}
+
+// --- roster operations ------------------------------------------------------
+
+// TestManagerIntegration_RosterOps covers AddMember / PromoteAdmin /
+// DemoteAdmin including their authority gates, which is the part a
+// non-integration test cannot reach (they all mutate a live session).
+func TestManagerIntegration_RosterOps(t *testing.T) {
+	a, b := newGroupEnv(t)
+	id := createAndJoin(t, a, b, ModePublic)
+
+	// AddMember is idempotent.
+	before, _, _ := a.mgr.Get(id) //nolint:errcheck
+	again, err := a.mgr.AddMember(id, b.pk)
+	require.NoError(t, err)
+	require.Len(t, again.Members, len(before.Members), "re-adding an existing member is a no-op")
+
+	// A non-admin cannot edit the roster.
+	stranger, _ := cipher.GenerateKeyPair()
+	_, err = b.mgr.AddMember(id, stranger)
+	require.Error(t, err, "a plain member must not be able to add members")
+	require.Contains(t, err.Error(), "admin")
+
+	// Promote B, then it CAN.
+	promoted, err := a.mgr.PromoteAdmin(id, b.pk)
+	require.NoError(t, err, "PromoteAdmin")
+	require.True(t, promoted.IsAdmin(b.pk), "B should be an admin after promotion")
+
+	// Demote B again.
+	demoted, err := a.mgr.DemoteAdmin(id, b.pk)
+	require.NoError(t, err, "DemoteAdmin")
+	require.False(t, demoted.IsAdmin(b.pk), "B should not be an admin after demotion")
+
+	// The founder cannot be demoted — it is the recovery anchor.
+	_, err = a.mgr.DemoteAdmin(id, a.pk)
+	require.Error(t, err, "demoting the founder must be refused")
+
+	// Roster ops on an unknown group report it.
+	_, err = a.mgr.AddMember("no-such-group", stranger)
+	require.Error(t, err)
+	_, err = a.mgr.PromoteAdmin("no-such-group", stranger)
+	require.Error(t, err)
+}
+
+// TestManagerIntegration_JoinRejectsOwnGroup — Join is the joiner side; using
+// it on your own invite would subscribe a visor to itself.
+func TestManagerIntegration_JoinRejectsOwnGroup(t *testing.T) {
+	a, _ := newGroupEnv(t)
+	rec, err := a.mgr.Create("mine", ModePublic, nil)
+	require.NoError(t, err)
+
+	link, err := a.mgr.BuildInvite(rec.ID)
+	require.NoError(t, err)
+	inv, err := DecodeInvite(link)
+	require.NoError(t, err)
+
+	_, err = a.mgr.Join(inv)
+	require.Error(t, err, "joining your own group must be refused")
+	require.Contains(t, err.Error(), "own group")
+}
+
+// --- Resume -----------------------------------------------------------------
+
+// TestManagerIntegration_ResumeReopensStoredGroups is the restart path: a fresh
+// Manager on the same store must bring every non-revoked group back up, and the
+// reopened session must still send.
+func TestManagerIntegration_ResumeReopensStoredGroups(t *testing.T) {
+	a, b := newGroupEnv(t)
+	id := createAndJoin(t, a, b, ModePublic)
+
+	// A revoked group must NOT come back.
+	revoked, err := a.mgr.Create("deleted room", ModePublic, nil)
+	require.NoError(t, err)
+	require.NoError(t, a.mgr.Delete(revoked.ID))
+
+	// Restart A's manager against the same store + data dir.
+	require.NoError(t, a.mgr.Close())
+	time.Sleep(500 * time.Millisecond)
+
+	mgr2, err := NewManager(ManagerConfig{
+		Store: a.store, DmsgC: a.dmsgC, MyPK: a.pk, MySK: a.sk,
+		DataDir: filepath.Join(a.dir, "cxo"),
+		Logger:  logging.MustGetLogger("group-mgr-A2"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr2.Close() }) //nolint:errcheck
+	inbox2 := &msgInbox{}
+	mgr2.SetMessageHandler(inbox2.deliver)
+
+	require.NoError(t, mgr2.Resume(), "Resume")
+
+	if _, ok := mgr2.sessions[id]; !ok {
+		t.Fatal("Resume should have reopened the active group")
+	}
+	if _, ok := mgr2.sessions[revoked.ID]; ok {
+		t.Error("Resume must not reopen a revoked group")
+	}
+
+	// The resumed session still publishes, and ReplayHistory re-pumps what it
+	// already holds through the handler.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, mgr2.SendToGroup(ctx, id, "after the restart"))
+	waitInbox(t, inbox2, "the post-restart self-echo", hasText("after the restart"))
+
+	replay := &msgInbox{}
+	mgr2.SetMessageHandler(replay.deliver)
+	mgr2.ReplayHistory(id)
+	waitInbox(t, replay, "the replayed history", hasText("after the restart"))
+
+	// ReplayHistory for an unknown group is a no-op, not a panic.
+	mgr2.ReplayHistory("no-such-group")
+}

--- a/cmd/apps/skychat/group/manager_integration_test.go
+++ b/cmd/apps/skychat/group/manager_integration_test.go
@@ -20,6 +20,7 @@ package group
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -124,10 +125,10 @@ func hasText(text string) func([]Message) bool {
 
 // createAndJoin runs the real onboarding flow: A creates, admits B, issues an
 // invite, B joins. Returns the group id.
-func createAndJoin(t *testing.T, a, b *groupNode, mode Mode) string {
+func createAndJoin(t *testing.T, a, b *groupNode) string {
 	t.Helper()
 
-	rec, err := a.mgr.Create("integration room", mode, nil)
+	rec, err := a.mgr.Create("integration room", ModePublic, nil)
 	require.NoError(t, err, "Create")
 	require.Equal(t, RoleOwner, rec.Role)
 	require.Equal(t, StatusActive, rec.Status)
@@ -158,7 +159,7 @@ func createAndJoin(t *testing.T, a, b *groupNode, mode Mode) string {
 // asserts the owner's message actually reaches the joiner's handler.
 func TestManagerIntegration_CreateJoinAndSend(t *testing.T) {
 	a, b := newGroupEnv(t)
-	id := createAndJoin(t, a, b, ModePublic)
+	id := createAndJoin(t, a, b)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -244,7 +245,7 @@ func TestManagerIntegration_PrivateGroupRoundTrip(t *testing.T) {
 // non-integration test cannot reach (they all mutate a live session).
 func TestManagerIntegration_RosterOps(t *testing.T) {
 	a, b := newGroupEnv(t)
-	id := createAndJoin(t, a, b, ModePublic)
+	id := createAndJoin(t, a, b)
 
 	// AddMember is idempotent.
 	before, _, _ := a.mgr.Get(id) //nolint:errcheck
@@ -303,7 +304,7 @@ func TestManagerIntegration_JoinRejectsOwnGroup(t *testing.T) {
 // reopened session must still send.
 func TestManagerIntegration_ResumeReopensStoredGroups(t *testing.T) {
 	a, b := newGroupEnv(t)
-	id := createAndJoin(t, a, b, ModePublic)
+	id := createAndJoin(t, a, b)
 
 	// A revoked group must NOT come back.
 	revoked, err := a.mgr.Create("deleted room", ModePublic, nil)
@@ -347,4 +348,50 @@ func TestManagerIntegration_ResumeReopensStoredGroups(t *testing.T) {
 
 	// ReplayHistory for an unknown group is a no-op, not a panic.
 	mgr2.ReplayHistory("no-such-group")
+}
+
+// TestManagerIntegration_SubmitToOwnerRelay drives the member's relay fallback
+// over dmsg: B submits to A's relay listener, A's handleRelay verifies the
+// sender against the allowlist, republishes, and acks.
+//
+// The relay is vestigial for steady-state groups (every member publishes to its
+// own feed now), but SendToGroup still falls back to it when the local
+// publisher is unhealthy — so it has to keep working.
+func TestManagerIntegration_SubmitToOwnerRelay(t *testing.T) {
+	a, b := newGroupEnv(t)
+	id := createAndJoin(t, a, b)
+
+	b.mgr.mu.RLock()
+	sess := b.mgr.sessions[id]
+	b.mgr.mu.RUnlock()
+	require.NotNil(t, sess, "the joiner should hold a live session")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// The owner's relay listener binds during openOwner; give dmsg a moment.
+	const viaRelay = "submitted through the owner relay"
+	var lastErr error
+	for attempt := 0; attempt < 10; attempt++ {
+		lastErr = sess.SubmitToOwner(ctx, viaRelay)
+		// ErrRelayNoAck means the bytes landed but the ack didn't come back —
+		// still a successful submit as far as the owner's feed is concerned.
+		if lastErr == nil || errors.Is(lastErr, ErrRelayNoAck) {
+			break
+		}
+		time.Sleep(time.Duration(500+attempt*500) * time.Millisecond)
+	}
+	require.True(t, lastErr == nil || errors.Is(lastErr, ErrRelayNoAck),
+		"SubmitToOwner over dmsg: %v", lastErr)
+
+	// The owner republished it under the MEMBER's PK — sender attribution
+	// survives the relay hop, which is the whole point of the path.
+	waitInbox(t, a.inbox, "the relayed message", func(msgs []Message) bool {
+		for _, m := range msgs {
+			if m.Text == viaRelay && m.SenderPK == b.pk {
+				return true
+			}
+		}
+		return false
+	})
 }

--- a/cmd/apps/skychat/group/manager_state_test.go
+++ b/cmd/apps/skychat/group/manager_state_test.go
@@ -1,0 +1,748 @@
+// Package group cmd/apps/skychat/group/manager_state_test.go
+//
+// Unit coverage for the parts of manager.go that do NOT need a dmsg mesh: the
+// session-level reconnect backoff, the warm-up cadence decision, the
+// constructor's validation, and the store-backed accessors.
+//
+// manager.go is the largest untested body in skychat (~1600 lines, almost all
+// at 0%) because most of it — Create/Join/Resume/SendToGroup/AddMember/
+// Promote/Demote and the tryReconnect* family — opens real CXO sessions over
+// dmsg. Those stay on the manual E2E plan, the same convention
+// per_peer_backoff_test.go already follows. What IS reachable is the decision
+// logic those paths consult, and that is what this file pins:
+//
+//   - reconnectShouldAttempt / reconnectRecordFailure — the SESSION-level
+//     backoff schedule. per_peer_backoff_test.go covers the per-peer
+//     counterparts; these are the ones tryReconnect and tryReconnectLegacySub
+//     gate on, and the two schedules must stay independent of each other.
+//   - hasWarmingPeer — decides whether the reconnect loop holds its fast
+//     warmup cadence or eases back to the steady 30s tick. Its documented
+//     guarantee is that ONE DEAD PEER CANNOT KEEP THE LOOP FAST FOREVER, which
+//     is a property no integration test would notice going wrong.
+//
+// Sessions are the in-process fixture from roster_authority_test.go
+// (newRosterSession + SetAllowlist): real peerSubs on an in-memory CXO node,
+// no network.
+package group
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// mustPK returns a fresh public key. Real keys throughout — cipher.PubKey
+// validates the curve point, so synthetic bytes would not round-trip.
+func mustPK(t *testing.T) cipher.PubKey {
+	t.Helper()
+	pk, _ := cipher.GenerateKeyPair()
+	return pk
+}
+
+// dmsgStub satisfies NewManager's non-nil DmsgC requirement. Nothing here
+// dials, so it is never dereferenced.
+var dmsgStub = new(dmsg.Client)
+
+// newStateTestManager builds a Manager on a real bbolt store with the
+// reconnect maps initialized. No dmsg client: every path exercised here either
+// stops at the store or reads sessions the test installs directly.
+func newStateTestManager(t *testing.T, myPK cipher.PubKey) *Manager {
+	t.Helper()
+	st, err := OpenStore(filepath.Join(t.TempDir(), "groups.db"))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() }) //nolint:errcheck
+	return &Manager{
+		store:              st,
+		myPK:               myPK,
+		log:                logging.MustGetLogger("group.manager-state-test"),
+		portAlloc:          defaultPortAlloc,
+		sessions:           make(map[string]*Session),
+		reconnectState:     make(map[string]*reconnectState),
+		peerReconnectState: make(map[string]map[cipher.PubKey]*reconnectState),
+	}
+}
+
+// installSession registers sess under id so the Manager's session-keyed
+// accessors can see it.
+func installSession(m *Manager, id string, sess *Session) {
+	m.mu.Lock()
+	m.sessions[id] = sess
+	m.mu.Unlock()
+}
+
+// seedRecord persists an active record for id with the given members.
+func seedRecord(t *testing.T, m *Manager, id string, owner cipher.PubKey, members []cipher.PubKey, status Status) {
+	t.Helper()
+	r := Record{
+		ID:      id,
+		Name:    "state-test",
+		OwnerPK: owner,
+		Port:    60001,
+		Mode:    ModePublic,
+		Members: members,
+		Role:    RoleMember,
+		Status:  status,
+	}
+	if err := m.store.Put(r); err != nil {
+		t.Fatalf("store.Put: %v", err)
+	}
+}
+
+// --- session-level reconnect backoff ----------------------------------------
+
+func TestReconnectShouldAttempt_DefaultsTrue(t *testing.T) {
+	m := newStateTestManager(t, mustPK(t))
+	if !m.reconnectShouldAttempt("group-1", time.Now().UTC()) {
+		t.Error("no recorded failures → the loop should attempt a reconnect")
+	}
+}
+
+func TestReconnectRecordFailure_BackoffSchedule(t *testing.T) {
+	m := newStateTestManager(t, mustPK(t))
+	const id = "group-1"
+	now := time.Now().UTC()
+	boom := errors.New("synthetic session reconnect failure")
+
+	// Below the first threshold the loop keeps trying every tick.
+	for i := uint32(1); i < reconnectBackoffFailures1; i++ {
+		m.reconnectRecordFailure(id, boom)
+		if !m.reconnectShouldAttempt(id, now) {
+			t.Fatalf("at failure=%d (below threshold %d), want shouldAttempt=true", i, reconnectBackoffFailures1)
+		}
+	}
+
+	// Crossing threshold 1 pushes the next attempt out by interval 1.
+	m.reconnectRecordFailure(id, boom)
+	if m.reconnectShouldAttempt(id, now) {
+		t.Errorf("at failure=%d, want shouldAttempt=false inside the backoff window", reconnectBackoffFailures1)
+	}
+	if !m.reconnectShouldAttempt(id, now.Add(reconnectBackoffInterval1+time.Second)) {
+		t.Error("once interval 1 elapses, the loop should attempt again")
+	}
+
+	// Crossing threshold 2 extends further — past interval 1 is no longer enough.
+	for i := reconnectBackoffFailures1; i < reconnectBackoffFailures2; i++ {
+		m.reconnectRecordFailure(id, boom)
+	}
+	if m.reconnectShouldAttempt(id, now.Add(reconnectBackoffInterval1+time.Second)) {
+		t.Errorf("at failure=%d the longer interval should still be engaged", reconnectBackoffFailures2)
+	}
+	if !m.reconnectShouldAttempt(id, now.Add(reconnectBackoffInterval2+time.Second)) {
+		t.Error("once interval 2 elapses, the loop should attempt again")
+	}
+}
+
+func TestReconnectState_IndependentBetweenGroups(t *testing.T) {
+	m := newStateTestManager(t, mustPK(t))
+	for i := uint32(0); i < reconnectBackoffFailures1; i++ {
+		m.reconnectRecordFailure("group-a", errors.New("force-state"))
+	}
+	now := time.Now().UTC()
+	if m.reconnectShouldAttempt("group-a", now) {
+		t.Error("group-a should be in backoff")
+	}
+	if !m.reconnectShouldAttempt("group-b", now) {
+		t.Error("group-b state must be independent of group-a's")
+	}
+}
+
+// TestReconnectState_SessionAndPeerSchedulesAreIndependent is the T2b property
+// read from the session side: engaging the session-level backoff must not gate
+// per-peer attempts, and vice versa. They share applyBackoffTransition but must
+// not share state.
+func TestReconnectState_SessionAndPeerSchedulesAreIndependent(t *testing.T) {
+	m := newStateTestManager(t, mustPK(t))
+	const id = "group-1"
+	pk := mustPK(t)
+	now := time.Now().UTC()
+
+	for i := uint32(0); i < reconnectBackoffFailures1; i++ {
+		m.reconnectRecordFailure(id, errors.New("session-level"))
+	}
+	if m.reconnectShouldAttempt(id, now) {
+		t.Fatal("precondition: session-level backoff should be engaged")
+	}
+	if !m.peerReconnectShouldAttempt(id, pk, now) {
+		t.Error("a session-level backoff must not gate per-peer reconnect attempts")
+	}
+	if got := m.peerReconnectFailures(id, pk); got != 0 {
+		t.Errorf("peerReconnectFailures = %d, want 0 — session failures are not peer failures", got)
+	}
+
+	// And the reverse.
+	m2 := newStateTestManager(t, mustPK(t))
+	for i := uint32(0); i < reconnectBackoffFailures1; i++ {
+		m2.peerReconnectRecordFailure(id, pk, errors.New("peer-level"))
+	}
+	if m2.peerReconnectShouldAttempt(id, pk, now) {
+		t.Fatal("precondition: per-peer backoff should be engaged")
+	}
+	if !m2.reconnectShouldAttempt(id, now) {
+		t.Error("a per-peer backoff must not gate the session-level attempt")
+	}
+}
+
+// --- peerReconnectFailures --------------------------------------------------
+
+func TestPeerReconnectFailures_Counts(t *testing.T) {
+	m := newStateTestManager(t, mustPK(t))
+	const id = "group-1"
+	a, b := mustPK(t), mustPK(t)
+
+	if got := m.peerReconnectFailures(id, a); got != 0 {
+		t.Errorf("untracked peer = %d, want 0", got)
+	}
+	for i := 0; i < 3; i++ {
+		m.peerReconnectRecordFailure(id, a, errors.New("x"))
+	}
+	if got := m.peerReconnectFailures(id, a); got != 3 {
+		t.Errorf("after 3 failures = %d, want 3", got)
+	}
+	if got := m.peerReconnectFailures(id, b); got != 0 {
+		t.Errorf("a different peer = %d, want 0", got)
+	}
+	if got := m.peerReconnectFailures("other-group", a); got != 0 {
+		t.Errorf("the same peer in another group = %d, want 0", got)
+	}
+	m.peerReconnectClear(id, a)
+	if got := m.peerReconnectFailures(id, a); got != 0 {
+		t.Errorf("after clear = %d, want 0", got)
+	}
+}
+
+// --- hasWarmingPeer ---------------------------------------------------------
+
+// warmingFixture builds a manager with one active record whose live session
+// follows `peer`, freshly added and therefore never attached.
+func warmingFixture(t *testing.T) (m *Manager, id string, sess *Session, peer cipher.PubKey) {
+	t.Helper()
+	me, sk := cipher.GenerateKeyPair()
+	peer = mustPK(t)
+	id = uuid.NewString()
+
+	m = newStateTestManager(t, me)
+	seedRecord(t, m, id, me, []cipher.PubKey{me, peer}, StatusActive)
+
+	sess = newRosterSession(t, me, sk, Record{ID: id, OwnerPK: me, Role: RoleOwner})
+	if _, err := sess.SetAllowlist([]cipher.PubKey{me, peer}); err != nil {
+		t.Fatalf("SetAllowlist: %v", err)
+	}
+	installSession(m, id, sess)
+	return m, id, sess, peer
+}
+
+func TestHasWarmingPeer_NoRecords(t *testing.T) {
+	m := newStateTestManager(t, mustPK(t))
+	if m.hasWarmingPeer() {
+		t.Error("an empty store has nothing warming")
+	}
+}
+
+func TestHasWarmingPeer_NoLiveSession(t *testing.T) {
+	me := mustPK(t)
+	m := newStateTestManager(t, me)
+	seedRecord(t, m, uuid.NewString(), me, []cipher.PubKey{me, mustPK(t)}, StatusActive)
+	// Record exists but nothing was opened for it.
+	if m.hasWarmingPeer() {
+		t.Error("a record with no live session has no warming peer")
+	}
+}
+
+// TestHasWarmingPeer_UnattachedPeerHoldsFastCadence — a freshly added peer has
+// a zero PeerLastInbound and no failures, so the loop stays fast while it
+// converges.
+func TestHasWarmingPeer_UnattachedPeerHoldsFastCadence(t *testing.T) {
+	m, _, sess, peer := warmingFixture(t)
+	if !sess.PeerLastInbound(peer).IsZero() {
+		t.Fatal("precondition: a peer that never connected should have a zero last-inbound")
+	}
+	if !m.hasWarmingPeer() {
+		t.Error("an unattached peer within its retry budget should hold the fast cadence")
+	}
+}
+
+// TestHasWarmingPeer_AttachedPeerReleasesFastCadence — once the peer reports an
+// inbound it is converged, so the loop can ease back to the steady tick.
+func TestHasWarmingPeer_AttachedPeerReleasesFastCadence(t *testing.T) {
+	m, _, sess, peer := warmingFixture(t)
+
+	sess.peerSubsMu.RLock()
+	a := sess.peerLastInboundNs[peer]
+	sess.peerSubsMu.RUnlock()
+	if a == nil {
+		t.Fatal("precondition: expected a liveness counter for the peer")
+	}
+	a.Store(time.Now().UnixNano())
+
+	if m.hasWarmingPeer() {
+		t.Error("an attached peer should not hold the fast cadence")
+	}
+}
+
+// TestHasWarmingPeer_DeadPeerStopsHoldingFastCadence is the documented
+// guarantee: a peer that never attaches stops qualifying once it burns its
+// fast-retry budget, so one dead peer cannot pin the loop at the fast cadence
+// forever. Without it the reconnect loop would spin fast indefinitely whenever
+// any group has one permanently-offline member.
+func TestHasWarmingPeer_DeadPeerStopsHoldingFastCadence(t *testing.T) {
+	m, id, _, peer := warmingFixture(t)
+	if !m.hasWarmingPeer() {
+		t.Fatal("precondition: the peer should start out warming")
+	}
+
+	for i := uint32(0); i < reconnectBackoffFailures1-1; i++ {
+		m.peerReconnectRecordFailure(id, peer, errors.New("unreachable"))
+	}
+	if !m.hasWarmingPeer() {
+		t.Errorf("with %d failures (budget %d) the peer should still be warming",
+			reconnectBackoffFailures1-1, reconnectBackoffFailures1)
+	}
+
+	m.peerReconnectRecordFailure(id, peer, errors.New("unreachable"))
+	if m.hasWarmingPeer() {
+		t.Errorf("after %d failures the peer has exhausted its fast-retry budget "+
+			"and must fall to the backoff schedule, not hold the loop fast", reconnectBackoffFailures1)
+	}
+}
+
+// TestHasWarmingPeer_SkipsInactiveRecords — left/revoked groups are not
+// converging toward anything.
+func TestHasWarmingPeer_SkipsInactiveRecords(t *testing.T) {
+	for _, status := range []Status{StatusLeft, StatusRevoked} {
+		t.Run(string(status), func(t *testing.T) {
+			me, sk := cipher.GenerateKeyPair()
+			peer := mustPK(t)
+			id := uuid.NewString()
+
+			m := newStateTestManager(t, me)
+			seedRecord(t, m, id, me, []cipher.PubKey{me, peer}, status)
+			sess := newRosterSession(t, me, sk, Record{ID: id, OwnerPK: me, Role: RoleOwner})
+			if _, err := sess.SetAllowlist([]cipher.PubKey{me, peer}); err != nil {
+				t.Fatalf("SetAllowlist: %v", err)
+			}
+			installSession(m, id, sess)
+
+			if m.hasWarmingPeer() {
+				t.Errorf("a %s record must not hold the fast cadence", status)
+			}
+		})
+	}
+}
+
+// --- NewManager -------------------------------------------------------------
+
+func TestNewManager_Validation(t *testing.T) {
+	st, err := OpenStore(filepath.Join(t.TempDir(), "groups.db"))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() }) //nolint:errcheck
+
+	if _, err := NewManager(ManagerConfig{DmsgC: dmsgStub, DataDir: "/tmp"}); err == nil {
+		t.Error("a nil Store must be rejected")
+	}
+	if _, err := NewManager(ManagerConfig{Store: st, DataDir: "/tmp"}); err == nil {
+		t.Error("a nil DmsgC must be rejected")
+	}
+	if _, err := NewManager(ManagerConfig{Store: st, DmsgC: dmsgStub}); err == nil {
+		t.Error("an empty DataDir must be rejected unless InMemoryDB is set")
+	}
+	// InMemoryDB waives the DataDir requirement (the js/wasm visor has no disk).
+	if _, err := NewManager(ManagerConfig{Store: st, DmsgC: dmsgStub, InMemoryDB: true}); err != nil {
+		t.Errorf("InMemoryDB should waive DataDir, got %v", err)
+	}
+}
+
+func TestNewManager_Defaults(t *testing.T) {
+	st, err := OpenStore(filepath.Join(t.TempDir(), "groups.db"))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() }) //nolint:errcheck
+
+	m, err := NewManager(ManagerConfig{
+		Store: st, DmsgC: dmsgStub, DataDir: t.TempDir(),
+		HeartbeatInterval: DefaultHeartbeatInterval,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if m.log == nil {
+		t.Error("a nil Logger should be defaulted, not left nil")
+	}
+	if m.portAlloc == nil {
+		t.Error("portAlloc should default to defaultPortAlloc")
+	}
+	// The maps must be non-nil or the first reconnect bookkeeping write panics.
+	if m.sessions == nil || m.reconnectState == nil || m.peerReconnectState == nil {
+		t.Error("NewManager must initialize sessions/reconnectState/peerReconnectState")
+	}
+	if m.heartbeatInterval != DefaultHeartbeatInterval {
+		t.Errorf("heartbeatInterval = %v, want %v", m.heartbeatInterval, DefaultHeartbeatInterval)
+	}
+	// No sessions are opened until Resume.
+	if len(m.sessions) != 0 {
+		t.Errorf("NewManager opened %d sessions, want 0", len(m.sessions))
+	}
+}
+
+// --- store-backed accessors -------------------------------------------------
+
+func TestManagerGetAndList(t *testing.T) {
+	me := mustPK(t)
+	m := newStateTestManager(t, me)
+
+	if _, ok, err := m.Get("nope"); err != nil || ok {
+		t.Errorf("Get(unknown) = ok %v err %v, want false/nil", ok, err)
+	}
+	id := uuid.NewString()
+	seedRecord(t, m, id, me, []cipher.PubKey{me}, StatusActive)
+
+	r, ok, err := m.Get(id)
+	if err != nil || !ok || r.ID != id {
+		t.Fatalf("Get = %+v ok %v err %v", r, ok, err)
+	}
+	all, err := m.List()
+	if err != nil || len(all) != 1 || all[0].ID != id {
+		t.Errorf("List = %+v err %v, want the one seeded record", all, err)
+	}
+}
+
+func TestBuildInvite(t *testing.T) {
+	me := mustPK(t)
+	m := newStateTestManager(t, me)
+
+	if _, err := m.BuildInvite("missing"); err == nil {
+		t.Error("BuildInvite for an unknown group should error")
+	}
+
+	// A non-admin member may not issue invites.
+	otherOwner := mustPK(t)
+	memberID := uuid.NewString()
+	seedRecord(t, m, memberID, otherOwner, []cipher.PubKey{otherOwner, me}, StatusActive)
+	if _, err := m.BuildInvite(memberID); err == nil {
+		t.Error("a non-admin member must not be able to issue invites")
+	}
+
+	// The founder can, and the link round-trips.
+	ownID := uuid.NewString()
+	seedRecord(t, m, ownID, me, []cipher.PubKey{me}, StatusActive)
+	link, err := m.BuildInvite(ownID)
+	if err != nil {
+		t.Fatalf("BuildInvite as founder: %v", err)
+	}
+	inv, err := DecodeInvite(link)
+	if err != nil {
+		t.Fatalf("DecodeInvite(%q): %v", link, err)
+	}
+	if inv.ID != ownID || inv.OwnerPK != me {
+		t.Errorf("decoded invite = %+v, want id %s owner %s", inv, ownID, me.Hex()[:8])
+	}
+}
+
+func TestMarkMessageDelivered(t *testing.T) {
+	me := mustPK(t)
+	m := newStateTestManager(t, me)
+	id := uuid.NewString()
+	seedRecord(t, m, id, me, []cipher.PubKey{me}, StatusActive)
+
+	ts := time.Now().UTC().Truncate(time.Millisecond)
+	m.MarkMessageDelivered(id, ts)
+
+	r, ok, err := m.Get(id)
+	if err != nil || !ok {
+		t.Fatalf("Get: ok %v err %v", ok, err)
+	}
+	if r.LastMessageAt.IsZero() {
+		t.Error("MarkMessageDelivered should refresh LastMessageAt")
+	}
+	// Best-effort for an unknown group: logged, never panics or errors out.
+	m.MarkMessageDelivered("unknown", ts)
+}
+
+func TestIsSubscriberAlive_NoSession(t *testing.T) {
+	m := newStateTestManager(t, mustPK(t))
+	if m.IsSubscriberAlive("nope") {
+		t.Error("no live session → not alive")
+	}
+}
+
+func TestPeerLivenessAndUpdateCount(t *testing.T) {
+	m := newStateTestManager(t, mustPK(t))
+
+	// Graceful degradation: empty (non-nil) maps when there is no session, so
+	// callers can range over the result without a nil check.
+	if got := m.PeerLiveness("nope"); got == nil || len(got) != 0 {
+		t.Errorf("PeerLiveness(unknown) = %v, want an empty non-nil map", got)
+	}
+	if got := m.PeerUpdateCount("nope"); got == nil || len(got) != 0 {
+		t.Errorf("PeerUpdateCount(unknown) = %v, want an empty non-nil map", got)
+	}
+
+	m2, id, sess, peer := warmingFixture(t)
+	live := m2.PeerLiveness(id)
+	if len(live) != 1 {
+		t.Fatalf("PeerLiveness = %v, want one entry", live)
+	}
+	if ts, ok := live[peer]; !ok || !ts.IsZero() {
+		t.Errorf("PeerLiveness[peer] = %v ok=%v, want a zero time for a never-attached peer", ts, ok)
+	}
+	counts := m2.PeerUpdateCount(id)
+	if got, ok := counts[peer]; !ok || got != 0 {
+		t.Errorf("PeerUpdateCount[peer] = %d ok=%v, want 0", got, ok)
+	}
+	_ = sess
+}
+
+// --- handler wiring ---------------------------------------------------------
+
+func TestSetMessageHandler_PropagatesToLiveSessions(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	m := newStateTestManager(t, me)
+	id := uuid.NewString()
+	sess := newRosterSession(t, me, sk, Record{ID: id, OwnerPK: me, Role: RoleOwner})
+	installSession(m, id, sess)
+
+	called := false
+	m.SetMessageHandler(func(string, cipher.PubKey, Message) { called = true })
+
+	m.onMessageMu.RLock()
+	stored := m.onMessage
+	m.onMessageMu.RUnlock()
+	if stored == nil {
+		t.Fatal("SetMessageHandler should record the handler on the manager")
+	}
+	// And it must reach the already-open session, not just future ones.
+	h := sess.handler
+	if h == nil {
+		t.Fatal("SetMessageHandler should propagate to live sessions")
+	}
+	h(id, me, Message{Text: "x"})
+	if !called {
+		t.Error("the propagated handler should be the one that was installed")
+	}
+}
+
+// TestWrapHandler_MarksMessageAndCallsThrough — the decorator is what keeps
+// last_message_at fresh for INBOUND traffic; before it, the field only moved on
+// outbound sends and member-side records read "0001-01-01" forever.
+func TestWrapHandler_MarksMessageAndCallsThrough(t *testing.T) {
+	me := mustPK(t)
+	m := newStateTestManager(t, me)
+	id := uuid.NewString()
+	seedRecord(t, m, id, me, []cipher.PubKey{me}, StatusActive)
+
+	var gotGroup string
+	var gotText string
+	wrapped := m.wrapHandler(id, func(g string, _ cipher.PubKey, msg Message) {
+		gotGroup, gotText = g, msg.Text
+	})
+
+	ts := time.Now().UTC()
+	wrapped(id, me, Message{Text: "inbound", TS: ts})
+
+	if gotGroup != id || gotText != "inbound" {
+		t.Errorf("inner handler saw (%q, %q), want (%q, inbound)", gotGroup, gotText, id)
+	}
+	r, ok, err := m.Get(id)
+	if err != nil || !ok {
+		t.Fatalf("Get: ok %v err %v", ok, err)
+	}
+	if r.LastMessageAt.IsZero() {
+		t.Error("wrapHandler should refresh LastMessageAt on inbound traffic")
+	}
+}
+
+// --- persistRoster ----------------------------------------------------------
+
+// TestPersistRoster_WritesConvergedRoster covers the #3426 follow-up: the
+// reconciler's converged member+admin set has to reach the store, or group
+// info/list keep showing the pre-convergence roster and it is lost on restart.
+func TestPersistRoster_WritesConvergedRoster(t *testing.T) {
+	founder := mustPK(t)
+	m := newStateTestManager(t, founder)
+	id := uuid.NewString()
+	seedRecord(t, m, id, founder, []cipher.PubKey{founder}, StatusActive)
+
+	a, b := mustPK(t), mustPK(t)
+	m.persistRoster(id)([]cipher.PubKey{founder, a, b}, []cipher.PubKey{a})
+
+	r, ok, err := m.Get(id)
+	if err != nil || !ok {
+		t.Fatalf("Get: ok %v err %v", ok, err)
+	}
+	assertPKSet(t, "persisted members", r.Members, []cipher.PubKey{founder, a, b})
+	// EnsureFounderInAdmins runs on the way in, so the founder is always
+	// explicitly present even though the reconciler didn't list them.
+	assertPKSet(t, "persisted admins", r.Admins, []cipher.PubKey{founder, a})
+	if !r.IsAdmin(founder) {
+		t.Error("the founder must remain an admin after a roster persist")
+	}
+}
+
+func TestPersistRoster_UnknownGroupIsNoOp(t *testing.T) {
+	m := newStateTestManager(t, mustPK(t))
+	// Must not panic or create a record out of thin air.
+	m.persistRoster("missing")([]cipher.PubKey{mustPK(t)}, nil)
+	all, err := m.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 0 {
+		t.Errorf("persistRoster for an unknown group created %d records, want 0", len(all))
+	}
+}
+
+// --- terminate / Leave / Delete ---------------------------------------------
+
+func TestLeave_MarksLeftAndDropsSessionState(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	m := newStateTestManager(t, me)
+	id := uuid.NewString()
+	peer := mustPK(t)
+	seedRecord(t, m, id, me, []cipher.PubKey{me, peer}, StatusActive)
+
+	sess := newRosterSession(t, me, sk, Record{ID: id, OwnerPK: me, Role: RoleOwner})
+	installSession(m, id, sess)
+	m.reconnectRecordFailure(id, errors.New("x"))
+	m.peerReconnectRecordFailure(id, peer, errors.New("x"))
+
+	if err := m.Leave(id); err != nil {
+		t.Fatalf("Leave: %v", err)
+	}
+
+	r, ok, err := m.Get(id)
+	if err != nil || !ok {
+		t.Fatalf("Get: ok %v err %v", ok, err)
+	}
+	if r.Status != StatusLeft {
+		t.Errorf("status = %q, want %q", r.Status, StatusLeft)
+	}
+	m.mu.RLock()
+	_, stillLive := m.sessions[id]
+	m.mu.RUnlock()
+	if stillLive {
+		t.Error("Leave should drop the live session")
+	}
+	// Reconnect bookkeeping for a departed group would otherwise be
+	// unreachable memory until process restart.
+	m.reconnectMu.Lock()
+	_, sessState := m.reconnectState[id]
+	_, peerState := m.peerReconnectState[id]
+	m.reconnectMu.Unlock()
+	if sessState || peerState {
+		t.Error("Leave should drop the group's reconnect state")
+	}
+}
+
+func TestLeave_UnknownGroupIsIdempotent(t *testing.T) {
+	m := newStateTestManager(t, mustPK(t))
+	if err := m.Leave("missing"); err != nil {
+		t.Errorf("Leave(unknown) = %v, want nil (idempotent)", err)
+	}
+}
+
+func TestDelete_RequiresAdmin(t *testing.T) {
+	me := mustPK(t)
+	m := newStateTestManager(t, me)
+
+	// Someone else's group, we're a plain member → must refuse and leave the
+	// record untouched, so a typo can't revoke a group another admin owns.
+	otherOwner := mustPK(t)
+	id := uuid.NewString()
+	seedRecord(t, m, id, otherOwner, []cipher.PubKey{otherOwner, me}, StatusActive)
+	if err := m.Delete(id); err == nil {
+		t.Error("a non-admin must not be able to revoke a group")
+	}
+	r, _, _ := m.Get(id) //nolint:errcheck
+	if r.Status != StatusActive {
+		t.Errorf("status = %q after a refused Delete, want it untouched at %q", r.Status, StatusActive)
+	}
+
+	// Our own group → revoked.
+	ownID := uuid.NewString()
+	seedRecord(t, m, ownID, me, []cipher.PubKey{me}, StatusActive)
+	if err := m.Delete(ownID); err != nil {
+		t.Fatalf("Delete as founder: %v", err)
+	}
+	own, _, _ := m.Get(ownID) //nolint:errcheck
+	if own.Status != StatusRevoked {
+		t.Errorf("status = %q, want %q", own.Status, StatusRevoked)
+	}
+
+	// Unknown id is idempotent, not an error.
+	if err := m.Delete("missing"); err != nil {
+		t.Errorf("Delete(unknown) = %v, want nil", err)
+	}
+}
+
+// --- Close ------------------------------------------------------------------
+
+func TestManagerClose_ClearsSessions(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	m := newStateTestManager(t, me)
+	id := uuid.NewString()
+	installSession(m, id, newRosterSession(t, me, sk, Record{ID: id, OwnerPK: me, Role: RoleOwner}))
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	m.mu.RLock()
+	n := len(m.sessions)
+	m.mu.RUnlock()
+	if n != 0 {
+		t.Errorf("Close left %d sessions, want 0", n)
+	}
+	// Idempotent — a second Close with no reconnect loop running must not hang
+	// on the waitgroup or double-cancel.
+	if err := m.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+
+// --- kickReconnect ----------------------------------------------------------
+
+// TestKickReconnect_NoOpCases — SendToGroup calls this on every send, so the
+// cheap guards matter: an unknown group, a session with no legacy subscriber,
+// and a healthy subscriber must all return without spawning a reconnect.
+func TestKickReconnect_NoOpCases(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	m := newStateTestManager(t, me)
+
+	m.kickReconnect(t.Context(), "unknown") // no session
+
+	id := uuid.NewString()
+	sess := newRosterSession(t, me, sk, Record{ID: id, OwnerPK: me, Role: RoleOwner})
+	installSession(m, id, sess) // sess.sub is nil (owner role)
+	m.kickReconnect(t.Context(), id)
+}
+
+// --- defaultPortAlloc -------------------------------------------------------
+
+func TestDefaultPortAlloc_InRange(t *testing.T) {
+	// Must stay clear of the pairing range; a collision there would have two
+	// subsystems fighting over the same dmsg port.
+	seen := map[uint16]bool{}
+	for i := 0; i < 200; i++ {
+		p, err := defaultPortAlloc()
+		if err != nil {
+			t.Fatalf("defaultPortAlloc: %v", err)
+		}
+		if p < 60000 || p >= 65000 {
+			t.Fatalf("port %d outside [60000, 65000)", p)
+		}
+		seen[p] = true
+	}
+	if len(seen) < 2 {
+		t.Errorf("200 allocations produced %d distinct ports — the allocator looks stuck", len(seen))
+	}
+}

--- a/cmd/apps/skychat/group/relay_test.go
+++ b/cmd/apps/skychat/group/relay_test.go
@@ -574,6 +574,20 @@ func TestSessionIsSubscriberAlive(t *testing.T) {
 	if closed.IsSubscriberAlive() {
 		t.Error("a closed session must never report alive")
 	}
+
+	// Same through the REAL Close path. This used to report ALIVE: doClose set
+	// s.sub = nil, which hits the `s.sub == nil -> owner role -> true`
+	// short-circuit above, so a torn-down member session advertised
+	// subscriber_alive=true on /status. doClose no longer nils the field —
+	// that write also raced every concurrent reader of it.
+	reallyClosed := newMember(t)
+	reallyClosed.lastInboundNs.Store(time.Now().UnixNano())
+	if err := reallyClosed.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if reallyClosed.IsSubscriberAlive() {
+		t.Error("a member session closed via Close() must not report subscriber_alive")
+	}
 }
 
 // --- dialSkynetRelay --------------------------------------------------------

--- a/cmd/apps/skychat/group/relay_test.go
+++ b/cmd/apps/skychat/group/relay_test.go
@@ -1,0 +1,593 @@
+// Package group cmd/apps/skychat/group/relay_test.go
+//
+// Unit coverage for the owner-side relay path and its member-side ack reader —
+// handleRelay, writeAndReadAck, acceptRelayOn — plus the small Session
+// accessors that were still at 0%.
+//
+// The relay is the pre-D1 fallback send path: a member opens a stream to the
+// owner's relay listener, writes a RelayMessage, and the owner re-publishes it
+// into the CXO feed and acks. Both halves are plain framed JSON over a
+// net.Conn, so a net.Pipe drives them end to end with no mesh.
+//
+// The assertion that carries the most weight is the ALLOWLIST GATE: handleRelay
+// re-publishes under a sender PK the *caller* supplies, so a missing membership
+// check would let any visor that can reach the relay port inject messages
+// attributed to any PK. The rejection tests assert the leaf is absent from the
+// feed, not merely that no ack came back.
+//
+// Ack pairing is the other one: writeAndReadAck must reject an ack whose MsgID
+// doesn't match the message it sent, or a member could read a stale ack from a
+// previous message as confirmation for the current one.
+package group
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skychat/message"
+)
+
+// memRelayListener is an in-process net.Listener: dial() hands back one end of
+// a pipe and queues the other for Accept.
+type memRelayListener struct {
+	ch     chan net.Conn
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newMemRelayListener() *memRelayListener {
+	return &memRelayListener{ch: make(chan net.Conn, 4), closed: make(chan struct{})}
+}
+
+func (l *memRelayListener) dial() (net.Conn, error) {
+	a, b := net.Pipe()
+	select {
+	case l.ch <- b:
+		return a, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *memRelayListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.ch:
+		return c, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *memRelayListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *memRelayListener) Addr() net.Addr { return appnet.Addr{Net: appnet.TypeSkynet} }
+
+// waitWG fails the test if wg does not drain within d.
+func waitWG(t *testing.T, wg *sync.WaitGroup, d time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatal("waitgroup did not drain — the accept loop is still running")
+	}
+}
+
+// skynetRelayAddr is the address shape bindRelaySkynet/SubmitToOwner use.
+func skynetRelayAddr(pk cipher.PubKey) appnet.Addr {
+	return appnet.Addr{Net: appnet.TypeSkynet, PubKey: pk, Port: routing.Port(60001)}
+}
+
+// newRelaySession builds an owner-role session on an in-memory publisher whose
+// member allowlist is `members`. ModePublic so relayed text lands as plaintext
+// on the leaf (an unset Mode falls through publishAs's switch and would publish
+// an empty body).
+func newRelaySession(t *testing.T, members []cipher.PubKey) *Session {
+	t.Helper()
+	me, sk := cipher.GenerateKeyPair()
+	s := newRosterSession(t, me, sk, Record{
+		ID:      uuid.NewString(),
+		OwnerPK: me,
+		Role:    RoleOwner,
+		Mode:    ModePublic,
+	})
+	// SetAllowlist is what seeds s.members, which isMember reads.
+	if _, err := s.SetAllowlist(append([]cipher.PubKey{me}, members...)); err != nil {
+		t.Fatalf("SetAllowlist: %v", err)
+	}
+	return s
+}
+
+// relayLeafPath is the feed path publishAs writes to for the FIRST publish on
+// a fresh publisher (seq starts at 1), which is all these tests make.
+func relayLeafPath(sender cipher.PubKey, ts time.Time) string {
+	return MessagePathPrefix + "/" + sender.Hex() + "/" +
+		strconv.FormatInt(ts.UnixNano(), 10) + "/1"
+}
+
+// driveRelay runs handleRelay against one end of a pipe, writes rawBody from
+// the member end, and returns the ack the owner wrote (if any).
+//
+// handleRelay writes its ack onto the same unbuffered pipe, so the read must
+// happen before waiting for the handler to return — otherwise the ack write
+// blocks forever and the test deadlocks.
+func driveRelay(t *testing.T, s *Session, rawBody []byte) (ack RelayAck, gotAck bool) {
+	t.Helper()
+	memberEnd, ownerEnd := net.Pipe()
+	defer func() { _ = memberEnd.Close() }() //nolint:errcheck
+	defer func() { _ = ownerEnd.Close() }()  //nolint:errcheck
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.handleRelay(ownerEnd)
+	}()
+
+	if err := message.WriteFrame(memberEnd, rawBody); err != nil {
+		t.Fatalf("write relay frame: %v", err)
+	}
+
+	_ = memberEnd.SetReadDeadline(time.Now().Add(250 * time.Millisecond)) //nolint:errcheck
+	payload, err := message.ReadFrame(memberEnd)
+	if err == nil {
+		if uerr := json.Unmarshal(payload, &ack); uerr != nil {
+			t.Fatalf("ack is not a RelayAck: %v (raw %q)", uerr, payload)
+		}
+		gotAck = true
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleRelay did not return")
+	}
+	return ack, gotAck
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// --- handleRelay ------------------------------------------------------------
+
+func TestHandleRelay_PublishesAndAcksForMember(t *testing.T) {
+	member := mustPK(t)
+	s := newRelaySession(t, []cipher.PubKey{member})
+
+	ts := time.Now().UTC().Truncate(time.Nanosecond)
+	ack, gotAck := driveRelay(t, s, mustJSON(t, RelayMessage{
+		SenderPK: member, Text: "relayed hello", TS: ts, MsgID: "m-1",
+	}))
+
+	if !gotAck {
+		t.Fatal("a relayed message from a member should be acked")
+	}
+	if !ack.Ack || ack.MsgID != "m-1" {
+		t.Errorf("ack = %+v, want {Ack:true MsgID:m-1}", ack)
+	}
+
+	// The ack's contract is "the leaf is committed to the feed" — verify it is.
+	body := pubReadable(t, s.pub, relayLeafPath(member, ts))
+	var msg Message
+	if err := json.Unmarshal(body, &msg); err != nil {
+		t.Fatalf("published leaf is not a Message: %v", err)
+	}
+	if msg.SenderPK != member {
+		t.Errorf("leaf SenderPK = %s, want the relayed sender %s", msg.SenderPK.Hex()[:8], member.Hex()[:8])
+	}
+	if msg.Text != "relayed hello" {
+		t.Errorf("leaf Text = %q, want %q", msg.Text, "relayed hello")
+	}
+}
+
+// TestHandleRelay_RejectsNonMember is the authorization gate. handleRelay
+// republishes under a caller-supplied sender PK, so without the allowlist check
+// anyone able to reach the relay port could inject messages attributed to any
+// PK. Asserts the leaf never lands, not just that no ack came back.
+func TestHandleRelay_RejectsNonMember(t *testing.T) {
+	member := mustPK(t)
+	stranger := mustPK(t)
+	s := newRelaySession(t, []cipher.PubKey{member})
+
+	ts := time.Now().UTC()
+	_, gotAck := driveRelay(t, s, mustJSON(t, RelayMessage{
+		SenderPK: stranger, Text: "injected", TS: ts, MsgID: "m-evil",
+	}))
+
+	if gotAck {
+		t.Error("a non-member's relay message must not be acked")
+	}
+	if _, ok := s.pub.Get(relayLeafPath(stranger, ts)); ok {
+		t.Error("a non-member's relay message must not reach the feed")
+	}
+}
+
+// TestHandleRelay_RejectsEmptySenderPK — the zero PK is not a member, and an
+// unauthenticated stream must not be able to publish under it.
+func TestHandleRelay_RejectsEmptySenderPK(t *testing.T) {
+	member := mustPK(t)
+	s := newRelaySession(t, []cipher.PubKey{member})
+
+	ts := time.Now().UTC()
+	_, gotAck := driveRelay(t, s, mustJSON(t, RelayMessage{
+		SenderPK: cipher.PubKey{}, Text: "anon", TS: ts, MsgID: "m-anon",
+	}))
+
+	if gotAck {
+		t.Error("a relay message with an empty sender PK must not be acked")
+	}
+	if _, ok := s.pub.Get(relayLeafPath(cipher.PubKey{}, ts)); ok {
+		t.Error("a relay message with an empty sender PK must not reach the feed")
+	}
+}
+
+func TestHandleRelay_RejectsMalformedPayload(t *testing.T) {
+	member := mustPK(t)
+	s := newRelaySession(t, []cipher.PubKey{member})
+
+	if _, gotAck := driveRelay(t, s, []byte("{not json")); gotAck {
+		t.Error("a malformed relay payload must not be acked")
+	}
+}
+
+// TestHandleRelay_FillsZeroTimestamp — a member that sends no TS still gets
+// published, stamped with the owner's clock. The ack is the authoritative
+// signal: handleRelay only writes it after publishAs has returned, so an ack
+// here proves the zero TS did not fail the publish.
+func TestHandleRelay_FillsZeroTimestamp(t *testing.T) {
+	member := mustPK(t)
+	s := newRelaySession(t, []cipher.PubKey{member})
+
+	ack, gotAck := driveRelay(t, s, mustJSON(t, RelayMessage{
+		SenderPK: member, Text: "no timestamp", MsgID: "m-nots",
+	}))
+	if !gotAck || !ack.Ack {
+		t.Fatal("a zero-TS message from a member should still publish and ack")
+	}
+	if ack.MsgID != "m-nots" {
+		t.Errorf("ack MsgID = %q, want m-nots", ack.MsgID)
+	}
+	// A zero TS would have produced the path .../-6795364578871345152/1
+	// (time.Time{}.UnixNano()); the fill-in means that path must NOT exist.
+	if _, ok := s.pub.Get(relayLeafPath(member, time.Time{})); ok {
+		t.Error("the zero timestamp was published verbatim instead of being filled in")
+	}
+}
+
+// TestHandleRelay_NoAckForEmptyMsgID — a pre-ack member sends no MsgID and
+// cannot parse a response, so writing one would be wasted bytes on a stream it
+// is about to close.
+func TestHandleRelay_NoAckForEmptyMsgID(t *testing.T) {
+	member := mustPK(t)
+	s := newRelaySession(t, []cipher.PubKey{member})
+
+	ts := time.Now().UTC()
+	_, gotAck := driveRelay(t, s, mustJSON(t, RelayMessage{
+		SenderPK: member, Text: "legacy member", TS: ts,
+	}))
+	if gotAck {
+		t.Error("no ack should be written when the member sent no MsgID")
+	}
+	// But the message must still be published — the member just can't confirm it.
+	if _, ok := s.pub.Get(relayLeafPath(member, ts)); !ok {
+		t.Error("a pre-ack member's message must still reach the feed")
+	}
+}
+
+func TestHandleRelay_ReadErrorReturns(t *testing.T) {
+	member := mustPK(t)
+	s := newRelaySession(t, []cipher.PubKey{member})
+
+	memberEnd, ownerEnd := net.Pipe()
+	_ = memberEnd.Close() //nolint:errcheck // hang up before writing anything
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.handleRelay(ownerEnd)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleRelay should return promptly when the stream is closed")
+	}
+	_ = ownerEnd.Close() //nolint:errcheck
+}
+
+// --- writeAndReadAck --------------------------------------------------------
+
+// ackResponder replies to one framed message on c with the given RelayAck.
+// Returns the payload it read so the caller can assert what went out.
+func ackResponder(t *testing.T, c net.Conn, reply *RelayAck, garbage []byte) <-chan []byte {
+	t.Helper()
+	out := make(chan []byte, 1)
+	go func() {
+		payload, err := message.ReadFrame(c)
+		if err != nil {
+			close(out)
+			return
+		}
+		out <- payload
+		switch {
+		case garbage != nil:
+			_ = message.WriteFrame(c, garbage) //nolint:errcheck
+		case reply != nil:
+			b, _ := json.Marshal(reply)  //nolint:errcheck
+			_ = message.WriteFrame(c, b) //nolint:errcheck
+		default:
+			_ = c.Close() //nolint:errcheck // hang up without acking
+		}
+	}()
+	return out
+}
+
+func TestWriteAndReadAck_HappyPath(t *testing.T) {
+	sender, peer := net.Pipe()
+	defer func() { _ = sender.Close() }() //nolint:errcheck
+	defer func() { _ = peer.Close() }()   //nolint:errcheck
+
+	sent := ackResponder(t, peer, &RelayAck{Ack: true, MsgID: "m-1"}, nil)
+	body := []byte(`{"hello":"relay"}`)
+
+	if err := writeAndReadAck(sender, body, "m-1"); err != nil {
+		t.Fatalf("writeAndReadAck: %v", err)
+	}
+	if got := <-sent; string(got) != string(body) {
+		t.Errorf("peer received %q, want %q", got, body)
+	}
+}
+
+// TestWriteAndReadAck_EmptyMsgIDSkipsRead — with no MsgID there is nothing to
+// pair an ack to, so the function must return as soon as the write lands rather
+// than blocking for a response that will never come.
+func TestWriteAndReadAck_EmptyMsgIDSkipsRead(t *testing.T) {
+	sender, peer := net.Pipe()
+	defer func() { _ = sender.Close() }() //nolint:errcheck
+	defer func() { _ = peer.Close() }()   //nolint:errcheck
+
+	// The peer reads the body but never replies.
+	sent := ackResponder(t, peer, nil, nil)
+
+	done := make(chan error, 1)
+	go func() { done <- writeAndReadAck(sender, []byte("body"), "") }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("writeAndReadAck with no MsgID = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("writeAndReadAck blocked waiting for an ack it should not expect")
+	}
+	<-sent
+}
+
+func TestWriteAndReadAck_NoAckCases(t *testing.T) {
+	cases := []struct {
+		name    string
+		reply   *RelayAck
+		garbage []byte
+	}{
+		{"peer hangs up without acking", nil, nil},
+		{"ack is not JSON", nil, []byte("not-an-ack")},
+		{"ack refuses", &RelayAck{Ack: false, MsgID: "m-1"}, nil},
+		{"ack is for a different message", &RelayAck{Ack: true, MsgID: "m-OTHER"}, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sender, peer := net.Pipe()
+			defer func() { _ = sender.Close() }() //nolint:errcheck
+			defer func() { _ = peer.Close() }()   //nolint:errcheck
+
+			ackResponder(t, peer, c.reply, c.garbage)
+
+			err := writeAndReadAck(sender, []byte("body"), "m-1")
+			if err != ErrRelayNoAck { //nolint:errorlint // sentinel is returned verbatim
+				t.Errorf("err = %v, want ErrRelayNoAck", err)
+			}
+		})
+	}
+}
+
+func TestWriteAndReadAck_WriteFailureIsReported(t *testing.T) {
+	sender, peer := net.Pipe()
+	_ = peer.Close()   //nolint:errcheck
+	_ = sender.Close() //nolint:errcheck
+
+	err := writeAndReadAck(sender, []byte("body"), "m-1")
+	if err == nil {
+		t.Fatal("writing to a closed conn should error")
+	}
+	if err == ErrRelayNoAck { //nolint:errorlint // sentinel comparison is intentional
+		t.Error("a write failure must be distinguishable from a missing ack")
+	}
+}
+
+// TestRelayRoundTrip drives the real member half against the real owner half
+// over one pipe — the exchange as it happens on the wire.
+func TestRelayRoundTrip(t *testing.T) {
+	member := mustPK(t)
+	s := newRelaySession(t, []cipher.PubKey{member})
+
+	memberEnd, ownerEnd := net.Pipe()
+	defer func() { _ = memberEnd.Close() }() //nolint:errcheck
+	defer func() { _ = ownerEnd.Close() }()  //nolint:errcheck
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.handleRelay(ownerEnd)
+	}()
+
+	ts := time.Now().UTC()
+	msgID := newRelayMsgID()
+	body := mustJSON(t, RelayMessage{SenderPK: member, Text: "round trip", TS: ts, MsgID: msgID})
+
+	if err := writeAndReadAck(memberEnd, body, msgID); err != nil {
+		t.Fatalf("member side: %v", err)
+	}
+	<-done
+
+	if _, ok := s.pub.Get(relayLeafPath(member, ts)); !ok {
+		t.Error("an acked round trip must leave the message on the feed")
+	}
+}
+
+func TestNewRelayMsgID_Unique(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		id := newRelayMsgID()
+		if len(id) != 16 {
+			t.Fatalf("msg id %q is %d chars, want 16 hex", id, len(id))
+		}
+		if seen[id] {
+			t.Fatalf("duplicate relay msg id %q — ack pairing would be ambiguous", id)
+		}
+		seen[id] = true
+	}
+}
+
+// --- acceptRelayOn ----------------------------------------------------------
+
+// TestAcceptRelayOn_ServesThenExitsOnClose covers the accept loop: it must
+// dispatch an inbound stream to handleRelay and unwind cleanly when the
+// listener closes.
+func TestAcceptRelayOn_ServesThenExitsOnClose(t *testing.T) {
+	member := mustPK(t)
+	s := newRelaySession(t, []cipher.PubKey{member})
+	s.relayCtx, s.relayCancel = context.WithCancel(context.Background())
+	defer s.relayCancel()
+
+	lis := newMemRelayListener()
+	s.relayWG.Add(1)
+	go s.acceptRelayOn(lis, "test")
+
+	conn, err := lis.dial()
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	ts := time.Now().UTC()
+	msgID := "m-accept"
+	body := mustJSON(t, RelayMessage{SenderPK: member, Text: "via accept loop", TS: ts, MsgID: msgID})
+	if err := writeAndReadAck(conn, body, msgID); err != nil {
+		t.Fatalf("relay through the accept loop: %v", err)
+	}
+	_ = conn.Close() //nolint:errcheck
+
+	if _, ok := s.pub.Get(relayLeafPath(member, ts)); !ok {
+		t.Error("the accept loop should have dispatched the stream to handleRelay")
+	}
+
+	// Closing the listener ends the loop.
+	_ = lis.Close() //nolint:errcheck
+	waitWG(t, &s.relayWG, 5*time.Second)
+}
+
+// --- Session accessors ------------------------------------------------------
+
+func TestSessionIDAndPort(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	id := uuid.NewString()
+	s := newRosterSession(t, me, sk, Record{ID: id, OwnerPK: me, Role: RoleOwner})
+	s.port = 60123
+
+	if s.ID() != id {
+		t.Errorf("ID() = %q, want %q", s.ID(), id)
+	}
+	if s.Port() != 60123 {
+		t.Errorf("Port() = %d, want 60123", s.Port())
+	}
+}
+
+func TestSessionIsSubscriberAlive(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+
+	// Owner role has no legacy subscriber — reported alive so a
+	// subscriber-health field never reads "down" for a publisher-only visor.
+	owner := newRosterSession(t, me, sk, Record{ID: uuid.NewString(), OwnerPK: me, Role: RoleOwner})
+	if !owner.IsSubscriberAlive() {
+		t.Error("an owner-role session (no legacy subscriber) should report alive")
+	}
+	owner.closed.Store(true)
+	if !owner.IsSubscriberAlive() {
+		t.Error("the nil-sub owner short-circuit runs before the closed check")
+	}
+
+	// Member role: health is a pure function of the legacy subscriber's
+	// last-inbound, which is what /status surfaces as subscriber_alive.
+	newMember := func(t *testing.T) *Session {
+		t.Helper()
+		mPK, mSK := cipher.GenerateKeyPair()
+		s := newRosterSession(t, mPK, mSK, Record{ID: uuid.NewString(), OwnerPK: me, Role: RoleMember})
+		sub, err := treestore.NewSubscriberOnNode(s.pub.Node(), me, treestore.SubConfig{Logger: s.log})
+		if err != nil {
+			t.Fatalf("NewSubscriberOnNode: %v", err)
+		}
+		t.Cleanup(func() { _ = sub.Close() }) //nolint:errcheck
+		s.sub = sub
+		return s
+	}
+
+	// Never observed an inbound → not alive (still converging or wedged).
+	fresh := newMember(t)
+	if fresh.IsSubscriberAlive() {
+		t.Error("a member session that never saw an inbound should not report alive")
+	}
+
+	// Recent inbound → alive.
+	live := newMember(t)
+	live.lastInboundNs.Store(time.Now().UnixNano())
+	if !live.IsSubscriberAlive() {
+		t.Error("a member session with a recent inbound should report alive")
+	}
+
+	// Inbound older than the stale threshold → not alive.
+	stale := newMember(t)
+	stale.lastInboundNs.Store(time.Now().Add(-subscriberStaleThreshold - time.Minute).UnixNano())
+	if stale.IsSubscriberAlive() {
+		t.Errorf("an inbound older than %v should report not alive", subscriberStaleThreshold)
+	}
+
+	// A closed session is never alive, however fresh its last inbound.
+	closed := newMember(t)
+	closed.lastInboundNs.Store(time.Now().UnixNano())
+	closed.closed.Store(true)
+	if closed.IsSubscriberAlive() {
+		t.Error("a closed session must never report alive")
+	}
+}
+
+// --- dialSkynetRelay --------------------------------------------------------
+
+// TestDialSkynetRelay_NoNetworkerErrors — the skynet networker is registered by
+// the visor's router init; with none registered the dial must fail fast so the
+// caller falls back to dmsg instead of hanging on a 15s dial.
+func TestDialSkynetRelay_NoNetworkerErrors(t *testing.T) {
+	start := time.Now()
+	_, err := dialSkynetRelay(t.Context(), skynetRelayAddr(mustPK(t)))
+	if err == nil {
+		t.Fatal("dialSkynetRelay should error when no skynet networker is registered")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("failed in %v — the no-networker check should short-circuit before the dial timeout", elapsed)
+	}
+}

--- a/cmd/apps/skychat/group/roster_authority_test.go
+++ b/cmd/apps/skychat/group/roster_authority_test.go
@@ -1,0 +1,476 @@
+// Package group cmd/apps/skychat/group/roster_authority_test.go
+//
+// Unit coverage for the two Session methods that reshape who this visor
+// subscribes to: SetAllowlist (owner-role membership changes) and
+// SetAdminRoster (admin promotions/demotions under the admin-aggregator
+// topology, #2685). Both were at ~5% — only their guard clauses were reached.
+//
+// These are authority gates, so the assertions are about what happens to the
+// per-peer CXO subscriptions, not just the return value:
+//
+//   - a removed member's subscriber is CLOSED and dropped, and reported in the
+//     returned evicted slice (the Manager keys per-peer reconnect backoff on
+//     that, so a missed eviction leaves stale backoff suppressing a later
+//     re-add);
+//   - a DEMOTED admin's subscription is torn down — a non-admin must not keep
+//     reading a feed it is no longer entitled to follow;
+//   - the two bookkeeping maps (peerLastInboundNs, peerUpdateCount) are
+//     cleaned alongside peerSubs, since a leak there feeds the staleness
+//     detector bad data.
+//
+// Fixture: an in-memory CXO publisher (newInProcessPublisher, no network) with
+// DmsgC nil and PeerAddrs empty, so connectSub takes the native-TCP branch and
+// fails instantly on "no TCP address configured" rather than burning the 15s
+// reconnectAttemptTimeout per peer. The add path still installs the
+// subscriber, which is what these tests check.
+package group
+
+import (
+	"sort"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// newRosterSession builds a Session on an in-memory publisher with the
+// per-peer maps initialized, ready for SetAllowlist / SetAdminRoster.
+func newRosterSession(t *testing.T, myPK cipher.PubKey, mySK cipher.SecKey, rec Record) *Session {
+	t.Helper()
+	if rec.ID == "" {
+		rec.ID = uuid.NewString()
+	}
+	return &Session{
+		cfg: Config{MyPK: myPK, MySK: mySK, Record: rec},
+		pub: newInProcessPublisher(t, mySK),
+		log: logging.MustGetLogger("group.roster-authority-test"),
+
+		peerSubs:          map[cipher.PubKey]*treestore.Subscriber{},
+		peerLastInboundNs: map[cipher.PubKey]*atomic.Int64{},
+		peerUpdateCount:   map[cipher.PubKey]*atomic.Uint64{},
+	}
+}
+
+// peerSubPKs returns the session's current per-peer subscription keys, sorted
+// for comparison.
+func peerSubPKs(s *Session) []cipher.PubKey {
+	s.peerSubsMu.RLock()
+	defer s.peerSubsMu.RUnlock()
+	out := make([]cipher.PubKey, 0, len(s.peerSubs))
+	for pk := range s.peerSubs {
+		out = append(out, pk)
+	}
+	sortPKs(out)
+	return out
+}
+
+func sortPKs(pks []cipher.PubKey) {
+	sort.Slice(pks, func(i, j int) bool { return pks[i].Hex() < pks[j].Hex() })
+}
+
+// assertPKSet compares two PK sets order-insensitively.
+func assertPKSet(t *testing.T, what string, got, want []cipher.PubKey) {
+	t.Helper()
+	g := append([]cipher.PubKey(nil), got...)
+	w := append([]cipher.PubKey(nil), want...)
+	sortPKs(g)
+	sortPKs(w)
+	if len(g) != len(w) {
+		t.Errorf("%s = %v (%d), want %v (%d)", what, hexes(g), len(g), hexes(w), len(w))
+		return
+	}
+	for i := range g {
+		if g[i] != w[i] {
+			t.Errorf("%s = %v, want %v", what, hexes(g), hexes(w))
+			return
+		}
+	}
+}
+
+func hexes(pks []cipher.PubKey) []string {
+	out := make([]string, len(pks))
+	for i, pk := range pks {
+		out[i] = pk.Hex()[:8]
+	}
+	return out
+}
+
+// assertBookkeepingMatchesSubs pins the invariant that the two per-peer
+// counters track peerSubs exactly — a leak on either side feeds the staleness
+// detector entries for peers that no longer exist.
+func assertBookkeepingMatchesSubs(t *testing.T, s *Session) {
+	t.Helper()
+	s.peerSubsMu.RLock()
+	defer s.peerSubsMu.RUnlock()
+	for pk := range s.peerSubs {
+		if s.peerLastInboundNs[pk] == nil {
+			t.Errorf("peer %s has a sub but no peerLastInboundNs entry", pk.Hex()[:8])
+		}
+		if s.peerUpdateCount[pk] == nil {
+			t.Errorf("peer %s has a sub but no peerUpdateCount entry", pk.Hex()[:8])
+		}
+	}
+	if len(s.peerLastInboundNs) != len(s.peerSubs) {
+		t.Errorf("peerLastInboundNs has %d entries, want %d (one per sub) — evictions leaked",
+			len(s.peerLastInboundNs), len(s.peerSubs))
+	}
+	if len(s.peerUpdateCount) != len(s.peerSubs) {
+		t.Errorf("peerUpdateCount has %d entries, want %d (one per sub) — evictions leaked",
+			len(s.peerUpdateCount), len(s.peerSubs))
+	}
+}
+
+// --- SetAllowlist -----------------------------------------------------------
+
+func TestSetAllowlist_RejectsNonOwnerRole(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	other, _ := cipher.GenerateKeyPair()
+	s := newRosterSession(t, me, sk, Record{OwnerPK: other, Role: RoleMember})
+
+	evicted, err := s.SetAllowlist([]cipher.PubKey{me, other})
+	if err == nil {
+		t.Fatal("a member-role session has no allowlist to set; want an error")
+	}
+	if evicted != nil {
+		t.Errorf("evicted = %v, want nil on the rejected path", hexes(evicted))
+	}
+}
+
+func TestSetAllowlist_RejectsNilPublisher(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	s := &Session{cfg: Config{MyPK: me, MySK: sk, Record: Record{OwnerPK: me, Role: RoleOwner}}}
+
+	if _, err := s.SetAllowlist([]cipher.PubKey{me}); err == nil {
+		t.Fatal("a session with no publisher cannot set an allowlist; want an error")
+	}
+}
+
+func TestSetAllowlist_AddsPeerSubsExcludingSelf(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	s := newRosterSession(t, me, sk, Record{OwnerPK: me, Role: RoleOwner})
+
+	evicted, err := s.SetAllowlist([]cipher.PubKey{me, a, b})
+	if err != nil {
+		t.Fatalf("SetAllowlist: %v", err)
+	}
+	if len(evicted) != 0 {
+		t.Errorf("evicted = %v, want none on a first allowlist", hexes(evicted))
+	}
+	// Self is excluded — a visor does not subscribe to its own feed.
+	assertPKSet(t, "peerSubs", peerSubPKs(s), []cipher.PubKey{a, b})
+	assertBookkeepingMatchesSubs(t, s)
+
+	// The members snapshot keeps the full list, self included.
+	s.membersMu.RLock()
+	got := append([]cipher.PubKey(nil), s.members...)
+	s.membersMu.RUnlock()
+	assertPKSet(t, "members snapshot", got, []cipher.PubKey{me, a, b})
+}
+
+func TestSetAllowlist_EvictsRemovedMembers(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	s := newRosterSession(t, me, sk, Record{OwnerPK: me, Role: RoleOwner})
+
+	if _, err := s.SetAllowlist([]cipher.PubKey{me, a, b}); err != nil {
+		t.Fatalf("seed SetAllowlist: %v", err)
+	}
+
+	// Remove b.
+	evicted, err := s.SetAllowlist([]cipher.PubKey{me, a})
+	if err != nil {
+		t.Fatalf("SetAllowlist: %v", err)
+	}
+	assertPKSet(t, "evicted", evicted, []cipher.PubKey{b})
+	assertPKSet(t, "peerSubs", peerSubPKs(s), []cipher.PubKey{a})
+	assertBookkeepingMatchesSubs(t, s)
+}
+
+func TestSetAllowlist_EmptyListEvictsEveryone(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	s := newRosterSession(t, me, sk, Record{OwnerPK: me, Role: RoleOwner})
+
+	if _, err := s.SetAllowlist([]cipher.PubKey{me, a, b}); err != nil {
+		t.Fatalf("seed SetAllowlist: %v", err)
+	}
+	evicted, err := s.SetAllowlist(nil)
+	if err != nil {
+		t.Fatalf("SetAllowlist(nil): %v", err)
+	}
+	assertPKSet(t, "evicted", evicted, []cipher.PubKey{a, b})
+	if got := peerSubPKs(s); len(got) != 0 {
+		t.Errorf("peerSubs = %v, want empty", hexes(got))
+	}
+	assertBookkeepingMatchesSubs(t, s)
+}
+
+// TestSetAllowlist_ReusesExistingSubs pins the `if _, exists := ...; continue`
+// arm: re-applying the same roster must not tear down and rebuild live
+// subscriptions, which would drop their connections for no reason.
+func TestSetAllowlist_ReusesExistingSubs(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	a, _ := cipher.GenerateKeyPair()
+	s := newRosterSession(t, me, sk, Record{OwnerPK: me, Role: RoleOwner})
+
+	if _, err := s.SetAllowlist([]cipher.PubKey{me, a}); err != nil {
+		t.Fatalf("seed SetAllowlist: %v", err)
+	}
+	s.peerSubsMu.RLock()
+	first := s.peerSubs[a]
+	s.peerSubsMu.RUnlock()
+	if first == nil {
+		t.Fatal("precondition: expected a sub for a")
+	}
+
+	evicted, err := s.SetAllowlist([]cipher.PubKey{me, a})
+	if err != nil {
+		t.Fatalf("SetAllowlist: %v", err)
+	}
+	if len(evicted) != 0 {
+		t.Errorf("evicted = %v, want none — the roster did not change", hexes(evicted))
+	}
+	s.peerSubsMu.RLock()
+	second := s.peerSubs[a]
+	s.peerSubsMu.RUnlock()
+	if first != second {
+		t.Error("re-applying an unchanged roster replaced a live subscriber")
+	}
+}
+
+// TestSetAllowlist_SnapshotsCallerSlice — the caller's slice must not alias
+// session state, or a later mutation on their side would silently reshape the
+// roster (and the publisher's allowlist) without going through this gate.
+func TestSetAllowlist_SnapshotsCallerSlice(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	s := newRosterSession(t, me, sk, Record{OwnerPK: me, Role: RoleOwner})
+
+	members := []cipher.PubKey{me, a}
+	if _, err := s.SetAllowlist(members); err != nil {
+		t.Fatalf("SetAllowlist: %v", err)
+	}
+	members[1] = b // caller mutates their slice afterwards
+
+	s.membersMu.RLock()
+	got := append([]cipher.PubKey(nil), s.members...)
+	s.membersMu.RUnlock()
+	assertPKSet(t, "members after the caller mutated its slice", got, []cipher.PubKey{me, a})
+}
+
+// TestSetAllowlist_EvictionKeepsTheSharedNodeAlive — the per-peer subscribers
+// run on the publisher's CXO node. Closing one on eviction must not take the
+// node (and therefore the whole session) down with it.
+func TestSetAllowlist_EvictionKeepsTheSharedNodeAlive(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	a, _ := cipher.GenerateKeyPair()
+	s := newRosterSession(t, me, sk, Record{OwnerPK: me, Role: RoleOwner})
+
+	if _, err := s.SetAllowlist([]cipher.PubKey{me, a}); err != nil {
+		t.Fatalf("seed SetAllowlist: %v", err)
+	}
+	if _, err := s.SetAllowlist([]cipher.PubKey{me}); err != nil {
+		t.Fatalf("evicting SetAllowlist: %v", err)
+	}
+
+	// The node still serves: a fresh subscriber can be created on it.
+	other, _ := cipher.GenerateKeyPair()
+	sub, err := treestore.NewSubscriberOnNode(s.pub.Node(), other, treestore.SubConfig{Logger: s.log})
+	if err != nil {
+		t.Fatalf("the shared CXO node did not survive an eviction: %v", err)
+	}
+	_ = sub.Close() //nolint:errcheck
+}
+
+// --- SetAdminRoster ---------------------------------------------------------
+
+func TestSetAdminRoster_RejectsNilSessionOrPublisher(t *testing.T) {
+	var nilSession *Session
+	if _, err := nilSession.SetAdminRoster(nil); err == nil {
+		t.Error("a nil session must return an error, not panic")
+	}
+
+	me, sk := cipher.GenerateKeyPair()
+	s := &Session{cfg: Config{MyPK: me, MySK: sk, Record: Record{OwnerPK: me}}}
+	if _, err := s.SetAdminRoster(nil); err == nil {
+		t.Error("a session with no publisher must return an error")
+	}
+}
+
+// TestSetAdminRoster_AdminFollowsEveryMember — an admin is an aggregator: it
+// subscribes to every other member's feed so it can republish.
+func TestSetAdminRoster_AdminFollowsEveryMember(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair() // me == an admin, not the founder
+	owner, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	m, _ := cipher.GenerateKeyPair()
+
+	s := newRosterSession(t, me, sk, Record{
+		OwnerPK: owner,
+		Role:    RoleMember,
+		Members: []cipher.PubKey{owner, me, b, m},
+	})
+
+	evicted, err := s.SetAdminRoster([]cipher.PubKey{me})
+	if err != nil {
+		t.Fatalf("SetAdminRoster: %v", err)
+	}
+	if len(evicted) != 0 {
+		t.Errorf("evicted = %v, want none", hexes(evicted))
+	}
+	assertPKSet(t, "peerSubs for an admin", peerSubPKs(s), []cipher.PubKey{owner, b, m})
+	assertBookkeepingMatchesSubs(t, s)
+}
+
+// TestSetAdminRoster_NonAdminFollowsOnlyAdmins — a plain member follows only
+// admin feeds (the founder counts as an admin implicitly). Subscribing to a
+// non-admin peer would be redundant work at best.
+func TestSetAdminRoster_NonAdminFollowsOnlyAdmins(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair() // plain member
+	owner, _ := cipher.GenerateKeyPair()
+	adminA, _ := cipher.GenerateKeyPair()
+	plainB, _ := cipher.GenerateKeyPair()
+
+	s := newRosterSession(t, me, sk, Record{
+		OwnerPK: owner,
+		Role:    RoleMember,
+		Members: []cipher.PubKey{owner, adminA, plainB, me},
+	})
+
+	if _, err := s.SetAdminRoster([]cipher.PubKey{adminA}); err != nil {
+		t.Fatalf("SetAdminRoster: %v", err)
+	}
+	// owner is implicitly an admin (founder); plainB is not.
+	assertPKSet(t, "peerSubs for a non-admin", peerSubPKs(s), []cipher.PubKey{owner, adminA})
+	assertBookkeepingMatchesSubs(t, s)
+}
+
+// TestSetAdminRoster_DemotionEvictsTheDemotedAdminsSub is the authority gate
+// that matters: once a peer loses admin status, this visor must stop following
+// its feed.
+func TestSetAdminRoster_DemotionEvictsTheDemotedAdminsSub(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair() // plain member
+	owner, _ := cipher.GenerateKeyPair()
+	adminA, _ := cipher.GenerateKeyPair()
+	plainB, _ := cipher.GenerateKeyPair()
+
+	s := newRosterSession(t, me, sk, Record{
+		OwnerPK: owner,
+		Role:    RoleMember,
+		Members: []cipher.PubKey{owner, adminA, plainB, me},
+	})
+
+	if _, err := s.SetAdminRoster([]cipher.PubKey{adminA}); err != nil {
+		t.Fatalf("seed SetAdminRoster: %v", err)
+	}
+	assertPKSet(t, "peerSubs before demotion", peerSubPKs(s), []cipher.PubKey{owner, adminA})
+
+	// Demote adminA. The founder stays an admin via IsAdmin's union.
+	evicted, err := s.SetAdminRoster(nil)
+	if err != nil {
+		t.Fatalf("demoting SetAdminRoster: %v", err)
+	}
+	assertPKSet(t, "evicted on demotion", evicted, []cipher.PubKey{adminA})
+	assertPKSet(t, "peerSubs after demotion", peerSubPKs(s), []cipher.PubKey{owner})
+	assertBookkeepingMatchesSubs(t, s)
+}
+
+// TestSetAdminRoster_PromotionOfSelfWidensTheSubSet — being promoted turns
+// this visor into an aggregator, so it must pick up the members it previously
+// had no reason to follow.
+func TestSetAdminRoster_PromotionOfSelfWidensTheSubSet(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	owner, _ := cipher.GenerateKeyPair()
+	adminA, _ := cipher.GenerateKeyPair()
+	plainB, _ := cipher.GenerateKeyPair()
+
+	s := newRosterSession(t, me, sk, Record{
+		OwnerPK: owner,
+		Role:    RoleMember,
+		Members: []cipher.PubKey{owner, adminA, plainB, me},
+	})
+
+	if _, err := s.SetAdminRoster([]cipher.PubKey{adminA}); err != nil {
+		t.Fatalf("seed SetAdminRoster: %v", err)
+	}
+	assertPKSet(t, "peerSubs as a plain member", peerSubPKs(s), []cipher.PubKey{owner, adminA})
+
+	// Promote self.
+	evicted, err := s.SetAdminRoster([]cipher.PubKey{adminA, me})
+	if err != nil {
+		t.Fatalf("promoting SetAdminRoster: %v", err)
+	}
+	if len(evicted) != 0 {
+		t.Errorf("evicted = %v, want none — a promotion only widens the set", hexes(evicted))
+	}
+	assertPKSet(t, "peerSubs as an admin", peerSubPKs(s), []cipher.PubKey{owner, adminA, plainB})
+	assertBookkeepingMatchesSubs(t, s)
+}
+
+// TestSetAdminRoster_CachesSnapshotOnRecord — the new admin set is written
+// back to cfg.Record.Admins so IsAdmin checks elsewhere (publish path, roster
+// reconcile) read the same view, and it must be a defensive copy.
+func TestSetAdminRoster_CachesSnapshotOnRecord(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair()
+	owner, _ := cipher.GenerateKeyPair()
+	adminA, _ := cipher.GenerateKeyPair()
+	other, _ := cipher.GenerateKeyPair()
+
+	s := newRosterSession(t, me, sk, Record{
+		OwnerPK: owner,
+		Role:    RoleMember,
+		Members: []cipher.PubKey{owner, adminA, me},
+	})
+
+	admins := []cipher.PubKey{adminA}
+	if _, err := s.SetAdminRoster(admins); err != nil {
+		t.Fatalf("SetAdminRoster: %v", err)
+	}
+	assertPKSet(t, "cached Record.Admins", s.cfg.Record.Admins, []cipher.PubKey{adminA})
+	if !s.cfg.Record.IsAdmin(adminA) {
+		t.Error("IsAdmin should see the newly cached admin")
+	}
+
+	admins[0] = other // caller mutates afterwards
+	assertPKSet(t, "cached Record.Admins after the caller mutated its slice",
+		s.cfg.Record.Admins, []cipher.PubKey{adminA})
+}
+
+// TestSetAdminRoster_PrefersLiveMembersSnapshot — an owner session keeps the
+// authoritative roster in s.members (updated by SetAllowlist), which can be
+// ahead of the cfg.Record.Members it was opened with. The admin-roster
+// recompute must read the live one.
+func TestSetAdminRoster_PrefersLiveMembersSnapshot(t *testing.T) {
+	me, sk := cipher.GenerateKeyPair() // founder → implicitly an admin
+	stale, _ := cipher.GenerateKeyPair()
+	fresh, _ := cipher.GenerateKeyPair()
+
+	s := newRosterSession(t, me, sk, Record{
+		OwnerPK: me,
+		Role:    RoleOwner,
+		Members: []cipher.PubKey{me, stale}, // the record it was opened with
+	})
+
+	// SetAllowlist installs the live snapshot, replacing `stale` with `fresh`.
+	if _, err := s.SetAllowlist([]cipher.PubKey{me, fresh}); err != nil {
+		t.Fatalf("SetAllowlist: %v", err)
+	}
+	assertPKSet(t, "peerSubs after the allowlist change", peerSubPKs(s), []cipher.PubKey{fresh})
+
+	// As founder I am an admin, so desired == every member but me. If this
+	// read cfg.Record.Members it would resurrect `stale` and drop `fresh`.
+	if _, err := s.SetAdminRoster(nil); err != nil {
+		t.Fatalf("SetAdminRoster: %v", err)
+	}
+	assertPKSet(t, "peerSubs after the admin recompute", peerSubPKs(s), []cipher.PubKey{fresh})
+	assertBookkeepingMatchesSubs(t, s)
+}

--- a/cmd/apps/skychat/group/roster_reconcile.go
+++ b/cmd/apps/skychat/group/roster_reconcile.go
@@ -197,7 +197,11 @@ func (s *Session) applyAdminLeaf(body []byte) {
 // so it's safe to call on every owner-session open. Best-effort: publish errors
 // are debug-logged and retried on the next open.
 func (s *Session) BroadcastRoster() {
-	if s.pub == nil {
+	// openLocked calls this from a goroutine after rosterBroadcastDelay, so the
+	// session can already be torn down by the time it fires (create-then-delete,
+	// or app shutdown right after a join). Bail rather than publishing N leaves
+	// into a closed publisher.
+	if s == nil || s.pub == nil || s.closed.Load() {
 		return
 	}
 	s.membersMu.RLock()

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -379,6 +379,9 @@ type Session struct {
 	// lastInbound timing. Owner-role sessions ignore this — they're
 	// always alive while the publisher is running.
 	closed atomic.Bool
+	// closeOnce / closeErr make Close concurrency-safe and idempotent.
+	closeOnce sync.Once
+	closeErr  error
 
 	// heartbeatCancel stops the owner-side heartbeat emission loop.
 	// nil for member-role sessions or when HeartbeatInterval=0.
@@ -1692,9 +1695,20 @@ func (s *Session) PublishAdminMutation(op AdminOp, peerPK cipher.PubKey, parentS
 	return seq, nil
 }
 
-// Close tears down the subscriber + publisher (and the underlying
-// CXO node, owned by the publisher). Idempotent.
+// Close tears down the subscriber + publisher (and the underlying CXO node,
+// owned by the publisher).
+//
+// Safe to call concurrently and repeatedly: the body runs exactly once and
+// later callers get the same error. Without the Once, two closers race on the
+// s.pub / s.sub / relay fields (read-then-write with no lock) — reachable
+// whenever a ctx-done teardown goroutine and an explicit Close both fire, e.g.
+// the native-TCP group path in commands.startCXOGroup.
 func (s *Session) Close() error {
+	s.closeOnce.Do(func() { s.closeErr = s.doClose() })
+	return s.closeErr
+}
+
+func (s *Session) doClose() error {
 	var firstErr error
 	// Mark closed first so any concurrent /status read sees the
 	// session as dead even if Close races with a long Subscriber.Close.

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -1725,11 +1725,23 @@ func (s *Session) doClose() error {
 	if s.relayCancel != nil {
 		s.relayCancel()
 	}
+	// NOTE on the fields below: teardown deliberately does NOT nil s.relayDmsg,
+	// s.sub or s.pub. Those writes were the old idempotency mechanism, which
+	// closeOnce now provides — and they are unguarded, so each one raced every
+	// concurrent reader of the field. The one CI caught: openLocked spawns a
+	// delayed BroadcastRoster goroutine that reads s.pub, so creating or
+	// joining a group and tearing it down inside rosterBroadcastDelay raced
+	// `s.pub = nil` here. Closing the handles is what matters; leaving the
+	// pointers in place lets readers keep their nil-checks and get an error
+	// from the closed handle instead of racing a write.
+	//
+	// Dropping the s.sub nil also fixes IsSubscriberAlive: it short-circuits
+	// `s.sub == nil` to true (owner role), so a CLOSED member session used to
+	// report subscriber_alive=true. It now falls through to the closed flag.
 	if s.relayDmsg != nil {
 		if err := s.relayDmsg.Close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
-		s.relayDmsg = nil
 	}
 	s.relayMu.Lock()
 	skyLis := s.relaySkynet
@@ -1745,7 +1757,6 @@ func (s *Session) doClose() error {
 		if err := s.sub.Close(); err != nil {
 			firstErr = err
 		}
-		s.sub = nil
 	}
 	// D1 per-PK peer subscribers — close before the local publisher so
 	// the subscribers' Disconnect frames flush through pub.Node() while
@@ -1766,7 +1777,6 @@ func (s *Session) doClose() error {
 		if err := s.pub.Close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
-		s.pub = nil
 	}
 	return firstErr
 }

--- a/cmd/apps/skychat/group/session_lifecycle_test.go
+++ b/cmd/apps/skychat/group/session_lifecycle_test.go
@@ -1,0 +1,340 @@
+// Package group cmd/apps/skychat/group/session_lifecycle_test.go
+//
+// Coverage for the Session bring-up path that the rest of this package's tests
+// skipped as "needs a mesh": Open's validation arms, openOwner / openMember /
+// newPublisher, the owner heartbeat loop, ReplayHistoryThrough, and
+// BroadcastRoster.
+//
+// None of this needs dmsg. group.Config has a native-TCP mode (TCPListenAddr +
+// PeerAddrs) — the same one commands.startCXOGroup uses for --cxo-group — and
+// in that mode newPublisher goes through treestore's TCP transport with an
+// in-memory CXDS, so a real session comes up on 127.0.0.1 with a real
+// publisher, real signing and a real feed.
+//
+// SCOPE: every test here is SINGLE-NODE. Session.Connect / ReconnectPeer and
+// cross-node delivery are deliberately NOT covered, because the native-TCP CXO
+// link is not reliably establishable in-process: it connects in isolation but
+// blocks out its deadline under load, since a subscriber whose publisher has no
+// fresh root to announce waits rather than syncing what is already on the feed.
+// Production lives with exactly that — commands.startCXOGroup treats its first
+// Connect as best-effort and drives per-peer reconnects on a ticker, and
+// manager.detectStaleAndReconnect does the same — but a unit test built on it
+// is just flaky, which is worse than no test. Cross-node group delivery belongs
+// in the e2e lane alongside the dmsg-backed pairing integration tests.
+package group
+
+import (
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// --- fixture ----------------------------------------------------------------
+
+// freeAddr reserves a loopback port and releases it for the session to bind.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve a port: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close() //nolint:errcheck
+	return addr
+}
+
+// tcpNode is one participant in a native-TCP group.
+type tcpNode struct {
+	pk    cipher.PubKey
+	sk    cipher.SecKey
+	addr  string
+	sess  *Session
+	inbox *msgInbox
+}
+
+// msgInbox collects messages delivered to a session's handler.
+type msgInbox struct {
+	mu   sync.Mutex
+	msgs []Message
+}
+
+func (i *msgInbox) deliver(_ string, _ cipher.PubKey, m Message) {
+	i.mu.Lock()
+	i.msgs = append(i.msgs, m)
+	i.mu.Unlock()
+}
+
+func (i *msgInbox) snapshot() []Message {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return append([]Message(nil), i.msgs...)
+}
+
+// openTCPGroup opens BOTH roles of a native-TCP group. Nothing here connects
+// them (see the scope note at the top of the file) — opening both is how
+// openOwner AND openMember get exercised, and it lets a test assert the
+// structural difference between the two.
+func openTCPGroup(t *testing.T, mode Mode, aesKey []byte, heartbeat time.Duration) (owner, member *tcpNode) {
+	t.Helper()
+	id := uuid.NewString()
+
+	ownerPK, ownerSK := cipher.GenerateKeyPair()
+	memberPK, memberSK := cipher.GenerateKeyPair()
+	ownerAddr, memberAddr := freeAddr(t), freeAddr(t)
+	members := []cipher.PubKey{ownerPK, memberPK}
+
+	rec := func(role Role) Record {
+		return Record{
+			ID:      id,
+			Name:    "tcp-group",
+			OwnerPK: ownerPK,
+			Port:    8870,
+			Mode:    mode,
+			AESKey:  aesKey,
+			Members: members,
+			Admins:  members, // full mesh: everyone follows everyone
+			Role:    role,
+		}
+	}
+
+	open := func(pk cipher.PubKey, sk cipher.SecKey, addr string, peers map[cipher.PubKey]string, role Role, hb time.Duration) *tcpNode {
+		box := &msgInbox{}
+		s, err := Open(Config{
+			MyPK: pk, MySK: sk,
+			Record:            rec(role),
+			TCPListenAddr:     addr,
+			PeerAddrs:         peers,
+			InMemoryDB:        true,
+			BatchWindow:       20 * time.Millisecond,
+			HeartbeatInterval: hb,
+			Logger:            logging.MustGetLogger("group-tcp-" + string(role)),
+		})
+		if err != nil {
+			t.Fatalf("Open(%s): %v", role, err)
+		}
+		t.Cleanup(func() { _ = s.Close() }) //nolint:errcheck
+		s.SetMessageHandler(box.deliver)
+		return &tcpNode{pk: pk, sk: sk, addr: addr, sess: s, inbox: box}
+	}
+
+	owner = open(ownerPK, ownerSK, ownerAddr, map[cipher.PubKey]string{memberPK: memberAddr}, RoleOwner, heartbeat)
+	member = open(memberPK, memberSK, memberAddr, map[cipher.PubKey]string{ownerPK: ownerAddr}, RoleMember, 0)
+	return owner, member
+}
+
+// --- Open validation --------------------------------------------------------
+
+func TestOpen_Validation(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+	base := func() Config {
+		return Config{
+			MyPK: pk, MySK: sk,
+			TCPListenAddr: "127.0.0.1:0",
+			InMemoryDB:    true,
+			Record: Record{
+				ID: uuid.NewString(), OwnerPK: pk, Port: 8870,
+				Mode: ModePublic, Role: RoleOwner,
+			},
+		}
+	}
+
+	cases := []struct {
+		name string
+		mut  func(*Config)
+		want string
+	}{
+		{"no transport", func(c *Config) { c.TCPListenAddr = "" }, "TCPListenAddr"},
+		{"no record id", func(c *Config) { c.Record.ID = "" }, "Record.ID"},
+		{"no owner pk", func(c *Config) { c.Record.OwnerPK = cipher.PubKey{} }, "OwnerPK"},
+		{"no port", func(c *Config) { c.Record.Port = 0 }, "Port"},
+		{"invalid mode", func(c *Config) { c.Record.Mode = "sideways" }, "Mode"},
+		{"private without key", func(c *Config) { c.Record.Mode = ModePrivate }, "AESKey"},
+		{"short aes key", func(c *Config) {
+			c.Record.Mode = ModePrivate
+			c.Record.AESKey = make([]byte, 16)
+		}, "AESKey"},
+		{"no data dir", func(c *Config) { c.InMemoryDB = false }, "DataDir"},
+		{"invalid role", func(c *Config) { c.Record.Role = "bystander" }, "Role"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := base()
+			c.mut(&cfg)
+			s, err := Open(cfg)
+			if err == nil {
+				_ = s.Close() //nolint:errcheck
+				t.Fatalf("expected an error mentioning %q", c.want)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("err = %v, want it to name %q", err, c.want)
+			}
+		})
+	}
+}
+
+// --- ReplayHistoryThrough ---------------------------------------------------
+
+// TestSessionTCP_ReplayHistoryThrough — the wasm visor calls this after a Join
+// to backfill history that arrived before its handler existed.
+func TestSessionTCP_ReplayHistoryThrough(t *testing.T) {
+	owner, _ := openTCPGroup(t, ModePublic, nil, 0)
+
+	sent := []string{"first", "second", "third"}
+	for _, txt := range sent {
+		if err := owner.sess.Send(txt); err != nil {
+			t.Fatalf("Send(%q): %v", txt, err)
+		}
+	}
+	// Self-echo is synchronous inside publishAs, but the batch window still has
+	// to flush before the leaves are walkable.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) && len(owner.inbox.snapshot()) < len(sent) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	if n := len(owner.inbox.snapshot()); n < len(sent) {
+		t.Fatalf("owner self-echoed %d of %d sends", n, len(sent))
+	}
+
+	replay := &msgInbox{}
+	owner.sess.ReplayHistoryThrough(replay.deliver, 50)
+
+	got := replay.snapshot()
+	if len(got) < len(sent) {
+		t.Fatalf("replayed %d messages, want at least %d: %+v", len(got), len(sent), got)
+	}
+	// Replay is ordered by message timestamp, not by feed path.
+	for i := 1; i < len(got); i++ {
+		if got[i].TS.Before(got[i-1].TS) {
+			t.Errorf("replay out of order at %d: %v before %v", i, got[i].TS, got[i-1].TS)
+		}
+	}
+	texts := map[string]bool{}
+	for _, m := range got {
+		texts[m.Text] = true
+	}
+	for _, want := range sent {
+		if !texts[want] {
+			t.Errorf("replay is missing %q", want)
+		}
+	}
+
+	// Guards: a nil handler or a non-positive cap is a no-op, not a panic.
+	owner.sess.ReplayHistoryThrough(nil, 10)
+	owner.sess.ReplayHistoryThrough(replay.deliver, 0)
+}
+
+// --- heartbeat --------------------------------------------------------------
+
+// TestSessionTCP_HeartbeatPublishes — the owner-side heartbeat is what lets
+// members detect a silently-stalled subscriber. It rides the normal publish
+// path but must NOT surface as chat content.
+func TestSessionTCP_HeartbeatPublishes(t *testing.T) {
+	owner, _ := openTCPGroup(t, ModePublic, nil, 50*time.Millisecond)
+
+	deadline := time.Now().Add(20 * time.Second)
+	var seen bool
+	for time.Now().Before(deadline) && !seen {
+		owner.sess.pub.Walk(MessagePathPrefix, func(_ string, value []byte) bool {
+			if strings.Contains(string(value), HeartbeatMarker) {
+				seen = true
+				return false
+			}
+			return true
+		})
+		if !seen {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	if !seen {
+		t.Fatal("the owner heartbeat never reached the feed")
+	}
+
+	// ...but is filtered out of the chat handler, so it never renders as a message.
+	for _, m := range owner.inbox.snapshot() {
+		if strings.Contains(m.Text, HeartbeatMarker) {
+			t.Errorf("a heartbeat leaked into the chat handler: %+v", m)
+		}
+	}
+}
+
+// --- BroadcastRoster --------------------------------------------------------
+
+// TestBroadcastRoster_AdminOnly — the roster re-broadcast is how late joiners
+// hydrate the member set. Only admins may issue it; a non-admin publishing
+// roster mutations would let any member rewrite the group.
+func TestBroadcastRoster_AdminOnly(t *testing.T) {
+	founder, fsk := cipher.GenerateKeyPair()
+	a, _ := cipher.GenerateKeyPair()
+	outsider, osk := cipher.GenerateKeyPair()
+
+	// Founder is implicitly an admin → publishes roster mutations.
+	own := newRosterSession(t, founder, fsk, Record{
+		ID: uuid.NewString(), OwnerPK: founder, Role: RoleOwner, Mode: ModePublic,
+		Members: []cipher.PubKey{founder, a}, Admins: []cipher.PubKey{founder, a},
+	})
+	own.BroadcastRoster()
+
+	var rosterLeaves int
+	own.pub.Walk(RosterPathPrefix, func(string, []byte) bool { rosterLeaves++; return true })
+	if rosterLeaves == 0 {
+		t.Error("an admin's BroadcastRoster should publish roster mutations")
+	}
+
+	// A non-admin publishes nothing.
+	notAdmin := newRosterSession(t, outsider, osk, Record{
+		ID: uuid.NewString(), OwnerPK: founder, Role: RoleMember, Mode: ModePublic,
+		Members: []cipher.PubKey{founder, outsider}, Admins: []cipher.PubKey{founder},
+	})
+	notAdmin.BroadcastRoster()
+
+	var outsiderLeaves int
+	notAdmin.pub.Walk(RosterPathPrefix, func(string, []byte) bool { outsiderLeaves++; return true })
+	if outsiderLeaves != 0 {
+		t.Errorf("a non-admin published %d roster leaves, want 0", outsiderLeaves)
+	}
+
+	// A publisher-less session is a no-op rather than a nil-deref.
+	(&Session{}).BroadcastRoster()
+}
+
+// TestOpen_RoleShapes pins the structural difference openOwner / openMember
+// produce, which is what the rest of the session logic branches on: only a
+// member carries the legacy owner-feed subscriber, and both roles follow every
+// other member under the full-mesh admin roster.
+func TestOpen_RoleShapes(t *testing.T) {
+	owner, member := openTCPGroup(t, ModePublic, nil, 0)
+
+	if owner.sess.sub != nil {
+		t.Error("an owner session must not have a legacy owner-feed subscriber")
+	}
+	if member.sess.sub == nil {
+		t.Error("a member session must have the legacy owner-feed subscriber")
+	}
+	if owner.sess.pub == nil || member.sess.pub == nil {
+		t.Error("both roles publish their own feed post-federation")
+	}
+	if got := owner.sess.PeerPKs(); len(got) != 1 || got[0] != member.pk {
+		t.Errorf("owner peerSubs = %v, want just the member", hexes(got))
+	}
+	if got := member.sess.PeerPKs(); len(got) != 1 || got[0] != owner.pk {
+		t.Errorf("member peerSubs = %v, want just the owner", hexes(got))
+	}
+	// Ports and ids come straight off the record.
+	if owner.sess.ID() != member.sess.ID() {
+		t.Error("both roles share the group id")
+	}
+	if owner.sess.Port() != 8870 {
+		t.Errorf("Port() = %d, want the record's 8870", owner.sess.Port())
+	}
+	// A fresh session has seen nothing from its peer yet.
+	if !owner.sess.PeerLastInbound(member.pk).IsZero() {
+		t.Error("a freshly opened session should have no per-peer inbound yet")
+	}
+}

--- a/cmd/apps/skychat/group/session_lifecycle_test.go
+++ b/cmd/apps/skychat/group/session_lifecycle_test.go
@@ -81,7 +81,7 @@ func (i *msgInbox) snapshot() []Message {
 // them (see the scope note at the top of the file) — opening both is how
 // openOwner AND openMember get exercised, and it lets a test assert the
 // structural difference between the two.
-func openTCPGroup(t *testing.T, mode Mode, aesKey []byte, heartbeat time.Duration) (owner, member *tcpNode) {
+func openTCPGroup(t *testing.T, heartbeat time.Duration) (owner, member *tcpNode) {
 	t.Helper()
 	id := uuid.NewString()
 
@@ -96,8 +96,7 @@ func openTCPGroup(t *testing.T, mode Mode, aesKey []byte, heartbeat time.Duratio
 			Name:    "tcp-group",
 			OwnerPK: ownerPK,
 			Port:    8870,
-			Mode:    mode,
-			AESKey:  aesKey,
+			Mode:    ModePublic,
 			Members: members,
 			Admins:  members, // full mesh: everyone follows everyone
 			Role:    role,
@@ -184,7 +183,7 @@ func TestOpen_Validation(t *testing.T) {
 // TestSessionTCP_ReplayHistoryThrough — the wasm visor calls this after a Join
 // to backfill history that arrived before its handler existed.
 func TestSessionTCP_ReplayHistoryThrough(t *testing.T) {
-	owner, _ := openTCPGroup(t, ModePublic, nil, 0)
+	owner, _ := openTCPGroup(t, 0)
 
 	sent := []string{"first", "second", "third"}
 	for _, txt := range sent {
@@ -236,7 +235,7 @@ func TestSessionTCP_ReplayHistoryThrough(t *testing.T) {
 // members detect a silently-stalled subscriber. It rides the normal publish
 // path but must NOT surface as chat content.
 func TestSessionTCP_HeartbeatPublishes(t *testing.T) {
-	owner, _ := openTCPGroup(t, ModePublic, nil, 50*time.Millisecond)
+	owner, _ := openTCPGroup(t, 50*time.Millisecond)
 
 	deadline := time.Now().Add(20 * time.Second)
 	var seen bool
@@ -309,7 +308,7 @@ func TestBroadcastRoster_AdminOnly(t *testing.T) {
 // member carries the legacy owner-feed subscriber, and both roles follow every
 // other member under the full-mesh admin roster.
 func TestOpen_RoleShapes(t *testing.T) {
-	owner, member := openTCPGroup(t, ModePublic, nil, 0)
+	owner, member := openTCPGroup(t, 0)
 
 	if owner.sess.sub != nil {
 		t.Error("an owner session must not have a legacy owner-feed subscriber")
@@ -336,5 +335,21 @@ func TestOpen_RoleShapes(t *testing.T) {
 	// A fresh session has seen nothing from its peer yet.
 	if !owner.sess.PeerLastInbound(member.pk).IsZero() {
 		t.Error("a freshly opened session should have no per-peer inbound yet")
+	}
+}
+
+// TestSubmitToOwner_MemberRoleOnly — the relay is the member's fallback send
+// path. An owner has nowhere to relay TO (it is the relay), so calling it on an
+// owner session is a programming error and must be reported rather than
+// silently dialing itself.
+func TestSubmitToOwner_MemberRoleOnly(t *testing.T) {
+	owner, _ := openTCPGroup(t, 0)
+
+	err := owner.sess.SubmitToOwner(t.Context(), "owner relaying to itself")
+	if err == nil {
+		t.Fatal("SubmitToOwner on an owner-role session should error")
+	}
+	if !strings.Contains(err.Error(), "member-role") {
+		t.Errorf("err = %v, want it to name the member-role requirement", err)
 	}
 }

--- a/cmd/apps/skychat/pairing/manager_resume_test.go
+++ b/cmd/apps/skychat/pairing/manager_resume_test.go
@@ -1,0 +1,355 @@
+// Package pairing cmd/apps/skychat/pairing/manager_resume_test.go
+//
+// Covers the Manager/Pair surface integration_test.go left untouched: the
+// constructor + Open validation arms, the small accessors, and — the one that
+// matters — Manager.Resume.
+//
+// Resume is where a real, live-verified bug lived: it used to Open each stored
+// pair (publisher + subscriber + onUpdate) but never Connect it. The symptom
+// after any visor restart was silent and one-directional — outbound Sends kept
+// working (the publisher's local Put succeeds with no peer attached) while
+// inbound onUpdate never fired again, so `skychat pair poll` stayed empty
+// forever. Nothing short of an actual restart-then-receive exercise catches
+// that: a test that only checks Resume's return count, or that the Pair is in
+// the map, passes on the broken version.
+//
+// So TestResumeReconnectsSubscriberAfterRestart tears the manager down and
+// rebuilds it on the same store, then has the PEER send. The message can only
+// arrive if Resume reconnected the subscriber.
+//
+// The dmsg-backed tests skip under -short, matching this package's existing
+// convention (baseline_test.go, integration_test.go).
+package pairing
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgtest"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// --- no-dmsg: validation + accessors ----------------------------------------
+
+func TestNewManager_Validation(t *testing.T) {
+	dir := t.TempDir()
+	st, err := OpenStore(filepath.Join(dir, "pairs.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() }) //nolint:errcheck
+
+	dmsgC := new(dmsg.Client) // never dialed; only the non-nil check reads it
+
+	if _, err := NewManager(ManagerConfig{DmsgC: dmsgC, DataDir: dir}); err == nil {
+		t.Error("a nil Store must be rejected")
+	}
+	if _, err := NewManager(ManagerConfig{Store: st, DataDir: dir}); err == nil {
+		t.Error("a nil DmsgC must be rejected")
+	}
+	if _, err := NewManager(ManagerConfig{Store: st, DmsgC: dmsgC}); err == nil {
+		t.Error("an empty DataDir must be rejected")
+	}
+
+	m, err := NewManager(ManagerConfig{Store: st, DmsgC: dmsgC, DataDir: dir})
+	require.NoError(t, err)
+	if m.log == nil {
+		t.Error("a nil Logger should be defaulted, not left nil")
+	}
+	if m.pairs == nil {
+		t.Error("the pairs map must be initialized or the first Add panics")
+	}
+	if len(m.pairs) != 0 {
+		t.Errorf("NewManager opened %d pairs, want 0 — that is Resume's job", len(m.pairs))
+	}
+}
+
+func TestManagerGet(t *testing.T) {
+	m := &Manager{pairs: map[cipher.PubKey]*Pair{}}
+	pk, _ := cipher.GenerateKeyPair()
+
+	if p, ok := m.Get(pk); ok || p != nil {
+		t.Errorf("Get on an empty manager = (%v, %v), want (nil, false)", p, ok)
+	}
+
+	want := &Pair{}
+	m.pairs[pk] = want
+	got, ok := m.Get(pk)
+	if !ok || got != want {
+		t.Errorf("Get = (%v, %v), want the stored pair and true", got, ok)
+	}
+
+	other, _ := cipher.GenerateKeyPair()
+	if _, ok := m.Get(other); ok {
+		t.Error("Get for an unpaired peer should report false")
+	}
+}
+
+func TestManagerMarkActive(t *testing.T) {
+	dir := t.TempDir()
+	st, err := OpenStore(filepath.Join(dir, "pairs.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() }) //nolint:errcheck
+
+	m := &Manager{store: st, log: logging.MustGetLogger("pair-marktest")}
+	pk, _ := cipher.GenerateKeyPair()
+
+	// No record yet — the store surfaces that rather than silently creating one.
+	if err := m.MarkActive(pk); err == nil {
+		t.Error("MarkActive for an unknown peer should error")
+	}
+
+	require.NoError(t, st.Put(Record{PeerPK: pk, Status: StatusPending}))
+	require.NoError(t, m.MarkActive(pk))
+
+	recs, err := st.List()
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	if recs[0].Status != StatusActive {
+		t.Errorf("status = %q, want %q", recs[0].Status, StatusActive)
+	}
+}
+
+func TestPairPortAndPeerPK(t *testing.T) {
+	peer, _ := cipher.GenerateKeyPair()
+	p := &Pair{port: 12345, cfg: Config{PeerPK: peer}}
+
+	if p.Port() != 12345 {
+		t.Errorf("Port() = %d, want 12345", p.Port())
+	}
+	if p.PeerPK() != peer {
+		t.Errorf("PeerPK() = %s, want %s", p.PeerPK().Hex()[:8], peer.Hex()[:8])
+	}
+}
+
+func TestPairOpen_Validation(t *testing.T) {
+	peer, _ := cipher.GenerateKeyPair()
+	dir := t.TempDir()
+
+	// Every arm below must fail BEFORE any CXO node is built, so these run
+	// without a dmsg env.
+	if _, err := Open(Config{PeerPK: peer, DataDir: dir}); err == nil {
+		t.Error("a nil DmsgC must be rejected")
+	}
+	if _, err := Open(Config{DmsgC: new(dmsg.Client), DataDir: dir}); err == nil {
+		t.Error("a zero PeerPK must be rejected")
+	}
+	if _, err := Open(Config{DmsgC: new(dmsg.Client), PeerPK: peer}); err == nil {
+		t.Error("an empty DataDir must be rejected")
+	}
+}
+
+// TestPairConnect_AfterCloseReturnsSentinel — Close nils the subscriber, and
+// Connect used to nil-deref on it. A closed pair must report ErrPairClosed so
+// the reconnect machinery can tell "torn down" from "peer unreachable".
+func TestPairConnect_AfterCloseReturnsSentinel(t *testing.T) {
+	p := &Pair{} // sub == nil, the post-Close shape
+	err := p.Connect(context.Background())
+	if err != ErrPairClosed { //nolint:errorlint // sentinel is returned verbatim
+		t.Errorf("Connect on a closed pair = %v, want ErrPairClosed", err)
+	}
+}
+
+// --- dmsg-backed: Resume ----------------------------------------------------
+
+// resumeEnv brings up a 1-server dmsg env with two clients, ready to use.
+func resumeEnv(t *testing.T) (dmsgA, dmsgB *dmsg.Client, pkA cipher.PubKey, skA cipher.SecKey, pkB cipher.PubKey, skB cipher.SecKey) {
+	t.Helper()
+	pkA, skA = cipher.GenerateKeyPair()
+	pkB, skB = cipher.GenerateKeyPair()
+
+	env := dmsgtest.NewEnv(t, dmsgtest.DefaultTimeout)
+	env.Discovery()
+	require.NoError(t, env.Startup(dmsgtest.DefaultTimeout, 1, 0, &dmsg.Config{MinSessions: 1}))
+	t.Cleanup(env.Shutdown)
+
+	var err error
+	dmsgA, err = env.NewClientWithKeys(pkA, skA, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err)
+	dmsgB, err = env.NewClientWithKeys(pkB, skB, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err)
+
+	waitDmsgReady(t, dmsgA, 10*time.Second)
+	waitDmsgReady(t, dmsgB, 10*time.Second)
+	return dmsgA, dmsgB, pkA, skA, pkB, skB
+}
+
+// connectRetry mirrors integration_test.go: concurrent dmsg handshakes on a
+// loaded runner can transiently fail with "cannot connect to delegated server".
+func connectRetry(p *Pair) error {
+	var lastErr error
+	for attempt := 0; attempt < 10; attempt++ {
+		if err := p.Connect(context.Background()); err == nil {
+			return nil
+		} else { //nolint:revive
+			lastErr = err
+		}
+		time.Sleep(time.Duration(200+attempt*100) * time.Millisecond)
+	}
+	return lastErr
+}
+
+// TestResumeReconnectsSubscriberAfterRestart is the regression guard for the
+// Open-without-Connect bug. The assertion is INBOUND delivery after a restart:
+// a Resume that only opened the pair would leave the publisher live (so
+// outbound still works) and the subscriber dead, exactly the reported symptom.
+func TestResumeReconnectsSubscriberAfterRestart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("dmsg integration test; skipped under -short")
+	}
+	dmsgA, dmsgB, pkA, skA, pkB, skB := resumeEnv(t)
+
+	dirA, dirB := t.TempDir(), t.TempDir()
+	storeA, err := OpenStore(filepath.Join(dirA, "pairs.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storeA.Close() }) //nolint:errcheck
+	storeB, err := OpenStore(filepath.Join(dirB, "pairs.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storeB.Close() }) //nolint:errcheck
+
+	newMgrA := func(tag string) *Manager {
+		m, mErr := NewManager(ManagerConfig{
+			Store: storeA, DmsgC: dmsgA, MyPK: pkA, MySK: skA,
+			DataDir: filepath.Join(dirA, "cxo"),
+			Logger:  logging.MustGetLogger("pair-A-" + tag),
+		})
+		require.NoError(t, mErr)
+		return m
+	}
+
+	mgrB, err := NewManager(ManagerConfig{
+		Store: storeB, DmsgC: dmsgB, MyPK: pkB, MySK: skB,
+		DataDir: filepath.Join(dirB, "cxo"),
+		Logger:  logging.MustGetLogger("pair-B"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgrB.Close() }) //nolint:errcheck
+
+	inboxB := newTestInbox()
+	mgrB.SetMessageHandler(inboxB.deliver)
+
+	// --- first run: pair up and confirm both directions work -----------------
+	mgrA1 := newMgrA("run1")
+	inboxA1 := newTestInbox()
+	mgrA1.SetMessageHandler(inboxA1.deliver)
+
+	pairA, err := mgrA1.Add(pkB)
+	require.NoError(t, err)
+	pairB, err := mgrB.Add(pkA)
+	require.NoError(t, err)
+	require.NoError(t, connectRetry(pairA))
+	require.NoError(t, connectRetry(pairB))
+
+	require.NoError(t, pairB.Send("before restart"))
+	require.NoError(t, inboxA1.waitFor(20*time.Second, func(msgs []testReceived) bool {
+		for _, m := range msgs {
+			if m.peer == pkB && m.text == "before restart" {
+				return true
+			}
+		}
+		return false
+	}), "baseline inbound delivery failed — the restart assertion below would be meaningless")
+
+	// --- restart A: same store + data dir, brand-new Manager -----------------
+	require.NoError(t, mgrA1.Close())
+	time.Sleep(500 * time.Millisecond) // let the CXO node release its dmsg port
+
+	mgrA2 := newMgrA("run2")
+	t.Cleanup(func() { _ = mgrA2.Close() }) //nolint:errcheck
+	inboxA2 := newTestInbox()
+	mgrA2.SetMessageHandler(inboxA2.deliver)
+
+	resumed, err := mgrA2.Resume()
+	require.NoError(t, err)
+	if resumed != 1 {
+		t.Fatalf("Resume restored %d pairs, want 1", resumed)
+	}
+	if _, ok := mgrA2.Get(pkB); !ok {
+		t.Fatal("the resumed pair should be live in the manager's map")
+	}
+
+	// THE assertion: inbound still works after the restart. Only true if Resume
+	// reconnected the subscriber rather than merely opening the pair.
+	require.NoError(t, pairB.Send("after restart"))
+	require.NoError(t, inboxA2.waitFor(30*time.Second, func(msgs []testReceived) bool {
+		for _, m := range msgs {
+			if m.peer == pkB && m.text == "after restart" {
+				return true
+			}
+		}
+		return false
+	}), "no inbound after Resume — the subscriber was opened but never reconnected")
+
+	// Outbound from the resumed pair also still works — but only once the PEER
+	// re-subscribes. A's restart replaced its CXO node, so B's subscriber is
+	// still attached to the old one; in production B's reconnect watchdog
+	// closes that gap. Reconnecting explicitly keeps this assertion about A's
+	// republished publisher rather than about B's watchdog timing.
+	require.NoError(t, connectRetry(pairB))
+
+	resumedPair, ok := mgrA2.Get(pkB)
+	require.True(t, ok)
+	require.NoError(t, resumedPair.Send("outbound after restart"))
+	require.NoError(t, inboxB.waitFor(30*time.Second, func(msgs []testReceived) bool {
+		for _, m := range msgs {
+			if m.peer == pkA && m.text == "outbound after restart" {
+				return true
+			}
+		}
+		return false
+	}), "the resumed publisher never reached the re-subscribed peer")
+}
+
+// TestResumeSkipsRevokedAndAlreadyLive covers Resume's two skip arms without
+// needing a live peer: a revoked record must not be reopened (Remove is
+// supposed to be final), and a second Resume must not double-open pairs that
+// the first one already brought up.
+func TestResumeSkipsRevokedAndAlreadyLive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("dmsg integration test; skipped under -short")
+	}
+	dmsgA, _, pkA, skA, pkB, _ := resumeEnv(t)
+
+	dir := t.TempDir()
+	store, err := OpenStore(filepath.Join(dir, "pairs.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() }) //nolint:errcheck
+
+	revoked, _ := cipher.GenerateKeyPair()
+	require.NoError(t, store.Put(Record{PeerPK: pkB, Status: StatusPending}))
+	require.NoError(t, store.Put(Record{PeerPK: revoked, Status: StatusPending}))
+	require.NoError(t, store.SetStatus(revoked, StatusRevoked))
+
+	mgr, err := NewManager(ManagerConfig{
+		Store: store, DmsgC: dmsgA, MyPK: pkA, MySK: skA,
+		DataDir: filepath.Join(dir, "cxo"),
+		Logger:  logging.MustGetLogger("pair-resume-skips"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Close() }) //nolint:errcheck
+
+	// A pending record IS resumed (a crash between invite and ack must not lose
+	// state); the revoked one is not.
+	resumed, err := mgr.Resume()
+	require.NoError(t, err)
+	if resumed != 1 {
+		t.Errorf("Resume restored %d pairs, want 1 (pending yes, revoked no)", resumed)
+	}
+	if _, ok := mgr.Get(revoked); ok {
+		t.Error("a revoked record must not be brought back up")
+	}
+	if _, ok := mgr.Get(pkB); !ok {
+		t.Error("a pending record should be resumed")
+	}
+
+	// Idempotent: a second Resume adds nothing.
+	again, err := mgr.Resume()
+	require.NoError(t, err)
+	if again != 0 {
+		t.Errorf("second Resume restored %d pairs, want 0 — already-live pairs must be skipped", again)
+	}
+}

--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -139,6 +139,14 @@ type Subscriber struct {
 	// succeeds.
 	publisherAddr atomic.Pointer[string]
 
+	// reconnectMu guards reconnectStop / reconnectKick. Both are assigned
+	// lazily on the first successful Connect and read by Close and by
+	// handleFillingBreaks, which run on unrelated goroutines — the two
+	// sync.Once values below order nothing between those parties (they are
+	// DIFFERENT Onces, and Close's closeMu is not held by Connect). Held only
+	// around the field access itself, never across a call, so it cannot
+	// participate in a lock cycle.
+	reconnectMu sync.Mutex
 	// reconnectStop, when closed, terminates the watchdog. Created
 	// when Connect is first called; closed by Close. Idempotent
 	// close via reconnectOnce.
@@ -385,8 +393,12 @@ func (s *Subscriber) Connect(ctx context.Context, publisherPK cipher.PubKey) err
 	s.lastUpdateNs.Store(time.Now().UnixNano())
 	// Start the watchdog on the FIRST successful Connect only.
 	s.reconnectStartOnce.Do(func() {
+		s.reconnectMu.Lock()
 		s.reconnectStop = make(chan struct{})
 		s.reconnectKick = make(chan struct{}, 1)
+		s.reconnectMu.Unlock()
+		// The watchdog's reads of both channels are ordered by this
+		// goroutine start, so it needs no lock of its own.
 		go s.runReconnectWatchdog()
 	})
 	return nil
@@ -424,8 +436,12 @@ func (s *Subscriber) ConnectTCP(ctx context.Context, address string) error {
 	s.lastUpdateNs.Store(time.Now().UnixNano())
 	// Start the watchdog on the FIRST successful connect only.
 	s.reconnectStartOnce.Do(func() {
+		s.reconnectMu.Lock()
 		s.reconnectStop = make(chan struct{})
 		s.reconnectKick = make(chan struct{}, 1)
+		s.reconnectMu.Unlock()
+		// The watchdog's reads of both channels are ordered by this
+		// goroutine start, so it needs no lock of its own.
 		go s.runReconnectWatchdog()
 	})
 	return nil
@@ -713,8 +729,11 @@ func (s *Subscriber) Close() error {
 	// node mid-Connect. Idempotent — channel may already be nil if
 	// Connect was never called.
 	s.reconnectOnce.Do(func() {
-		if s.reconnectStop != nil {
-			close(s.reconnectStop)
+		s.reconnectMu.Lock()
+		stop := s.reconnectStop
+		s.reconnectMu.Unlock()
+		if stop != nil {
+			close(stop)
 		}
 	})
 	if s.ownsNode {
@@ -891,8 +910,11 @@ func (s *Subscriber) handleFillingBreaks(r *registry.Root, err error) {
 		Warn("treestore-sub: Root filling aborted; kicking a re-Connect to re-fetch")
 	// Non-blocking — the cap-1 channel coalesces repeated breaks, and a nil
 	// channel (watchdog never started, e.g. native-TCP pre-Connect) no-ops.
+	s.reconnectMu.Lock()
+	kick := s.reconnectKick
+	s.reconnectMu.Unlock()
 	select {
-	case s.reconnectKick <- struct{}{}:
+	case kick <- struct{}{}:
 	default:
 	}
 }

--- a/pkg/skychat/call/accessors_test.go
+++ b/pkg/skychat/call/accessors_test.go
@@ -1,0 +1,132 @@
+// Package call pkg/skychat/call/accessors_test.go
+//
+// The small state accessors voice_test.go's end-to-end flows never touch:
+// the per-session mute flags, Manager.SetMute that drives them, the
+// late-listener hooks, and the signal-type label used in decline/busy errors.
+//
+// The mute pair is the only one here that guards user-facing behavior, and it
+// guards a privacy-relevant one: SetMicMuted(false) means this visor's
+// microphone is streaming to the peer. The rest are cheap correctness pins.
+package call
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestSessionMuteFlags(t *testing.T) {
+	s := &Session{}
+
+	// Default is UNMUTED both ways — a fresh call streams audio, which is why
+	// the manual-answer gate exists upstream.
+	if s.MicMuted() || s.SpeakerMuted() {
+		t.Errorf("fresh session = mic %v speaker %v, want both unmuted", s.MicMuted(), s.SpeakerMuted())
+	}
+
+	s.SetMicMuted(true)
+	if !s.MicMuted() {
+		t.Error("SetMicMuted(true) should mute the mic")
+	}
+	if s.SpeakerMuted() {
+		t.Error("muting the mic must not mute the speaker — they are independent")
+	}
+
+	s.SetSpeakerMuted(true)
+	if !s.SpeakerMuted() {
+		t.Error("SetSpeakerMuted(true) should mute the speaker")
+	}
+
+	s.SetMicMuted(false)
+	if s.MicMuted() {
+		t.Error("SetMicMuted(false) should unmute the mic")
+	}
+	if !s.SpeakerMuted() {
+		t.Error("unmuting the mic must not unmute the speaker")
+	}
+}
+
+// TestManagerSetMute — the /voice/mute endpoint proxies to this, so an unknown
+// call id has to report rather than silently succeed (the UI would show the
+// wrong mute state).
+func TestManagerSetMute(t *testing.T) {
+	m := NewManager(Config{})
+
+	if err := m.SetMute("no-such-call", true, true); err == nil {
+		t.Error("SetMute on an unknown call should error")
+	}
+
+	sess := &Session{}
+	m.mu.Lock()
+	m.calls["c-1"] = sess
+	m.mu.Unlock()
+
+	if err := m.SetMute("c-1", true, false); err != nil {
+		t.Fatalf("SetMute: %v", err)
+	}
+	if !sess.MicMuted() || sess.SpeakerMuted() {
+		t.Errorf("after SetMute(mic=true, speaker=false): mic %v speaker %v",
+			sess.MicMuted(), sess.SpeakerMuted())
+	}
+
+	if err := m.SetMute("c-1", false, true); err != nil {
+		t.Fatalf("SetMute: %v", err)
+	}
+	if sess.MicMuted() || !sess.SpeakerMuted() {
+		t.Errorf("after SetMute(mic=false, speaker=true): mic %v speaker %v",
+			sess.MicMuted(), sess.SpeakerMuted())
+	}
+}
+
+func TestSigTypeName(t *testing.T) {
+	cases := []struct {
+		in   SigType
+		want string
+	}{
+		{SigDecline, "declined"},
+		{SigBusy, "busy"},
+		{SigInvite, "sig(1)"}, // anything else falls through to the numeric form
+		{SigType(99), "sig(99)"},
+	}
+	for _, c := range cases {
+		if got := sigTypeName(c.in); got != c.want {
+			t.Errorf("sigTypeName(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestAddListener_LateBinding — the skynet listener comes up after the dmsg one,
+// so both the Signaler and the voice Manager must be able to take an extra
+// listener once Serve is already running. A nil listener is a no-op.
+func TestAddListener_LateBinding(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pk, _ := cipher.GenerateKeyPair()
+	sig := NewSignaler(pk, 1, nil, nil)
+	sig.AddListener(ctx, nil) // must not panic or register anything
+	lis := newMemListener()
+	sig.AddListener(ctx, lis)
+
+	sig.mu.Lock()
+	n := len(sig.serving)
+	sig.mu.Unlock()
+	if n != 1 {
+		t.Errorf("Signaler.serving = %d, want 1 (the nil listener is skipped)", n)
+	}
+
+	m := NewManager(Config{})
+	m.AddListener(ctx, newMemListener())
+	m.sig.mu.Lock()
+	n = len(m.sig.serving)
+	m.sig.mu.Unlock()
+	if n != 1 {
+		t.Errorf("Manager.AddListener did not reach the Signaler; serving = %d", n)
+	}
+
+	// Closing the listener unwinds the accept loop.
+	_ = lis.Close() //nolint:errcheck
+	time.Sleep(50 * time.Millisecond)
+}

--- a/pkg/skychat/call/spectrogram/pixels_test.go
+++ b/pkg/skychat/call/spectrogram/pixels_test.go
@@ -1,0 +1,451 @@
+// Package spectrogram pkg/skychat/call/spectrogram/pixels_test.go c4-app-chat
+//
+// Unit coverage for the rendering half of the DSP core: Normalize, the three
+// colormaps, the magnitude→pixel pipeline, and the package-global wrappers
+// (MagnitudeToPixel / ComputeFFT) that read the shared Settings.
+//
+// The colormaps are piecewise-linear, so the interesting assertions are at the
+// segment boundaries — a fencepost slip there shows up as a visible seam in
+// the rendered column. Each boundary is checked for continuity rather than for
+// an exact triple, which keeps the test robust to the uint8 truncation without
+// letting a real discontinuity through.
+package spectrogram
+
+import (
+	"image/color"
+	"math"
+	"testing"
+)
+
+// rgba unwraps a color.Color the package produced. Everything here returns
+// color.RGBA by construction.
+func rgba(t *testing.T, c color.Color) color.RGBA {
+	t.Helper()
+	v, ok := c.(color.RGBA)
+	if !ok {
+		t.Fatalf("color is %T, want color.RGBA", c)
+	}
+	return v
+}
+
+// withS swaps the package-level Settings for the duration of a test.
+func withS(t *testing.T, s *Settings) {
+	t.Helper()
+	prev := S
+	S = s
+	t.Cleanup(func() { S = prev })
+}
+
+func TestSetSingleThreaded(t *testing.T) {
+	// Retained for upstream API compatibility; must stay a callable no-op.
+	SetSingleThreaded()
+}
+
+func TestNormalize(t *testing.T) {
+	cases := []struct {
+		name            string
+		value, min, max float64
+		want            float64
+	}{
+		{"midpoint", 5, 0, 10, 0.5},
+		{"at min", 0, 0, 10, 0},
+		{"at max", 10, 0, 10, 1},
+		{"below min clamps", -100, 0, 10, 0},
+		{"above max clamps", 100, 0, 10, 1},
+		{"negative window", -30, -60, 0, 0.5},
+		{"quarter", 2.5, 0, 10, 0.25},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Normalize(c.value, c.min, c.max); math.Abs(got-c.want) > 1e-9 {
+				t.Errorf("Normalize(%v, %v, %v) = %v, want %v", c.value, c.min, c.max, got, c.want)
+			}
+		})
+	}
+}
+
+// TestNormalize_DegenerateWindows pins the two out-of-contract cases, both
+// reachable from the UI via AdjustMin/AdjustMax (which clamp independently).
+func TestNormalize_DegenerateWindows(t *testing.T) {
+	// min == max divides by zero → NaN. Documented, not defended against here;
+	// the colormaps absorb it without panicking (see the test below).
+	if got := Normalize(10, 45, 45); !math.IsNaN(got) {
+		t.Errorf("Normalize with min==max = %v, want NaN", got)
+	}
+	// min > max collapses to zero rather than producing a negative or NaN.
+	if got := Normalize(10, 50, 45); got != 0 {
+		t.Errorf("Normalize with min>max = %v, want 0", got)
+	}
+}
+
+func TestValueToPixelHeat_Endpoints(t *testing.T) {
+	if got := rgba(t, ValueToPixelHeat(0)); got != (color.RGBA{0, 0, 0, 255}) {
+		t.Errorf("heat(0) = %v, want opaque black", got)
+	}
+	if got := rgba(t, ValueToPixelHeat(1)); got != (color.RGBA{255, 255, 255, 255}) {
+		t.Errorf("heat(1) = %v, want opaque white", got)
+	}
+	// The ramp runs black → blue → green → yellow → red → white.
+	if got := rgba(t, ValueToPixelHeat(0.2)); got.B != 255 || got.R != 0 || got.G != 0 {
+		t.Errorf("heat(0.2) = %v, want pure blue", got)
+	}
+	if got := rgba(t, ValueToPixelHeat(0.4)); got.G != 255 || got.R != 0 || got.B != 0 {
+		t.Errorf("heat(0.4) = %v, want pure green", got)
+	}
+	if got := rgba(t, ValueToPixelHeat(0.6)); got.R != 255 || got.G != 255 || got.B != 0 {
+		t.Errorf("heat(0.6) = %v, want yellow", got)
+	}
+	if got := rgba(t, ValueToPixelHeat(0.8)); got.R != 255 || got.G != 0 || got.B != 0 {
+		t.Errorf("heat(0.8) = %v, want pure red", got)
+	}
+}
+
+// TestValueToPixelHeat_ContinuousAtBoundaries is the fencepost guard: the five
+// segments must join without a visible jump. A mis-set Normalize window in any
+// arm would show up here as a ~255 delta.
+func TestValueToPixelHeat_ContinuousAtBoundaries(t *testing.T) {
+	const eps = 1e-6
+	for _, b := range []float64{1.0 / 5, 2.0 / 5, 3.0 / 5, 4.0 / 5} {
+		lo := rgba(t, ValueToPixelHeat(b-eps))
+		hi := rgba(t, ValueToPixelHeat(b))
+		d := func(a, c uint8) int {
+			if a > c {
+				return int(a - c)
+			}
+			return int(c - a)
+		}
+		if d(lo.R, hi.R) > 2 || d(lo.G, hi.G) > 2 || d(lo.B, hi.B) > 2 {
+			t.Errorf("discontinuity at %v: %v → %v", b, lo, hi)
+		}
+	}
+}
+
+func TestValueToPixelBlue(t *testing.T) {
+	if got := rgba(t, ValueToPixelBlue(0)); got != (color.RGBA{0, 0, 0, 255}) {
+		t.Errorf("blue(0) = %v, want opaque black", got)
+	}
+	if got := rgba(t, ValueToPixelBlue(0.5)); got.B != 255 || got.R != 0 || got.G != 0 {
+		t.Errorf("blue(0.5) = %v, want pure blue", got)
+	}
+	if got := rgba(t, ValueToPixelBlue(1)); got != (color.RGBA{255, 255, 255, 255}) {
+		t.Errorf("blue(1) = %v, want opaque white", got)
+	}
+	// Below the midpoint the red and green channels stay dark.
+	for _, v := range []float64{0.1, 0.25, 0.49} {
+		if got := rgba(t, ValueToPixelBlue(v)); got.R != 0 || got.G != 0 {
+			t.Errorf("blue(%v) = %v, want R=G=0 in the lower half", v, got)
+		}
+	}
+	// Continuity across the single 0.5 seam.
+	lo, hi := rgba(t, ValueToPixelBlue(0.5-1e-6)), rgba(t, ValueToPixelBlue(0.5))
+	if int(hi.B)-int(lo.B) > 2 || hi.R > 2 || hi.G > 2 {
+		t.Errorf("discontinuity at 0.5: %v → %v", lo, hi)
+	}
+}
+
+func TestValueToPixelGrayscale(t *testing.T) {
+	cases := []struct {
+		value float64
+		want  uint8
+	}{{0, 0}, {0.5, 127}, {1, 255}}
+	for _, c := range cases {
+		got := rgba(t, ValueToPixelGrayscale(c.value))
+		if got.R != c.want || got.G != c.want || got.B != c.want {
+			t.Errorf("grayscale(%v) = %v, want all channels %d", c.value, got, c.want)
+		}
+		if got.A != 255 {
+			t.Errorf("grayscale(%v) alpha = %d, want 255", c.value, got.A)
+		}
+	}
+	// Monotonic across the ramp.
+	prev := rgba(t, ValueToPixelGrayscale(0)).R
+	for v := 0.05; v <= 1.0; v += 0.05 {
+		cur := rgba(t, ValueToPixelGrayscale(v)).R
+		if cur < prev {
+			t.Fatalf("grayscale not monotonic at %v: %d after %d", v, cur, prev)
+		}
+		prev = cur
+	}
+}
+
+// TestColormaps_AlwaysOpaque — a transparent pixel would render as a hole in
+// the spectrogram column.
+func TestColormaps_AlwaysOpaque(t *testing.T) {
+	maps := map[string]func(float64) color.Color{
+		"heat":      ValueToPixelHeat,
+		"blue":      ValueToPixelBlue,
+		"grayscale": ValueToPixelGrayscale,
+	}
+	for name, fn := range maps {
+		for v := 0.0; v <= 1.0; v += 0.01 {
+			if got := rgba(t, fn(v)); got.A != 255 {
+				t.Fatalf("%s(%v) alpha = %d, want 255", name, v, got.A)
+			}
+		}
+	}
+}
+
+func TestMagnitudeToPixelWith_LogScale(t *testing.T) {
+	s := DefaultSettings() // log, [0,45] dB, heat
+
+	// Silence: 20*log10(1e-10) = -200 dB, clamped to the 0 dB floor → black.
+	if got := rgba(t, MagnitudeToPixelWith(0, s)); got != (color.RGBA{0, 0, 0, 255}) {
+		t.Errorf("log magnitude 0 = %v, want black", got)
+	}
+	// 45 dB is the top of the window: 10^(45/20) ≈ 177.8 → white.
+	if got := rgba(t, MagnitudeToPixelWith(1000, s)); got != (color.RGBA{255, 255, 255, 255}) {
+		t.Errorf("log magnitude 1000 = %v, want saturated white", got)
+	}
+	// A mid magnitude must land on the heat ramp, matching a direct call.
+	const mid = 10.0 // 20 dB → (20-0)/45 ≈ 0.444
+	want := rgba(t, ValueToPixelHeat(Normalize(20*math.Log10(mid+1e-10), 0, 45)))
+	if got := rgba(t, MagnitudeToPixelWith(mid, s)); got != want {
+		t.Errorf("log magnitude %v = %v, want %v", mid, got, want)
+	}
+}
+
+func TestMagnitudeToPixelWith_LinearScale(t *testing.T) {
+	s := DefaultSettings()
+	s.ToggleScale() // linear, [0,1000]
+
+	if got := rgba(t, MagnitudeToPixelWith(0, s)); got != (color.RGBA{0, 0, 0, 255}) {
+		t.Errorf("linear magnitude 0 = %v, want black", got)
+	}
+	if got := rgba(t, MagnitudeToPixelWith(1000, s)); got != (color.RGBA{255, 255, 255, 255}) {
+		t.Errorf("linear magnitude 1000 = %v, want white", got)
+	}
+	// Linear must NOT take the log: 500 sits at the exact midpoint.
+	want := rgba(t, ValueToPixelHeat(0.5))
+	if got := rgba(t, MagnitudeToPixelWith(500, s)); got != want {
+		t.Errorf("linear magnitude 500 = %v, want the 0.5 heat value %v", got, want)
+	}
+}
+
+func TestMagnitudeToPixelWith_ColorSchemeDispatch(t *testing.T) {
+	const mag = 10.0
+	norm := Normalize(20*math.Log10(mag+1e-10), 0, 45)
+
+	cases := []struct {
+		scheme ColorScheme
+		want   color.RGBA
+	}{
+		{ColorHeat, rgba(t, ValueToPixelHeat(norm))},
+		{ColorBlue, rgba(t, ValueToPixelBlue(norm))},
+		{ColorGrayscale, rgba(t, ValueToPixelGrayscale(norm))},
+	}
+	for _, c := range cases {
+		s := DefaultSettings()
+		s.Color = c.scheme
+		if got := rgba(t, MagnitudeToPixelWith(mag, s)); got != c.want {
+			t.Errorf("scheme %v = %v, want %v", c.scheme, got, c.want)
+		}
+	}
+	// An out-of-range scheme falls back to heat rather than rendering nothing.
+	s := DefaultSettings()
+	s.Color = ColorScheme(99)
+	if got := rgba(t, MagnitudeToPixelWith(mag, s)); got != rgba(t, ValueToPixelHeat(norm)) {
+		t.Errorf("out-of-range scheme = %v, want the heat fallback", got)
+	}
+}
+
+// TestMagnitudeToPixel_DegenerateRangeDoesNotPanic covers the MagMin == MagMax
+// case, which the UI can reach by pushing AdjustMin up into MagMax (the two
+// clamp independently). Normalize then yields NaN and the colormaps convert it
+// with uint8(NaN) — implementation-defined in Go, so only the invariants that
+// hold on every platform are asserted: no panic, and an opaque pixel.
+func TestMagnitudeToPixel_DegenerateRangeDoesNotPanic(t *testing.T) {
+	for _, scheme := range []ColorScheme{ColorHeat, ColorBlue, ColorGrayscale} {
+		s := DefaultSettings()
+		s.Color = scheme
+		s.SetMagMin(45)
+		s.SetMagMax(45)
+		got := rgba(t, MagnitudeToPixelWith(5, s))
+		if got.A != 255 {
+			t.Errorf("scheme %v with a zero-width window: alpha = %d, want 255", scheme, got.A)
+		}
+	}
+	// Inverted window (min > max) is well-defined: Normalize → 0 → black.
+	s := DefaultSettings()
+	s.SetMagMin(50)
+	s.SetMagMax(45)
+	if got := rgba(t, MagnitudeToPixelWith(5, s)); got != (color.RGBA{0, 0, 0, 255}) {
+		t.Errorf("inverted window = %v, want black", got)
+	}
+}
+
+// TestMagnitudeToPixel_UsesPackageSettings pins the global wrapper to the
+// shared S rather than to a private default.
+func TestMagnitudeToPixel_UsesPackageSettings(t *testing.T) {
+	s := DefaultSettings()
+	s.Color = ColorGrayscale
+	withS(t, s)
+
+	const mag = 10.0
+	if got, want := rgba(t, MagnitudeToPixel(mag)), rgba(t, MagnitudeToPixelWith(mag, s)); got != want {
+		t.Errorf("MagnitudeToPixel = %v, want the S-configured %v", got, want)
+	}
+	// Changing S must change what the wrapper produces.
+	grayscale := rgba(t, MagnitudeToPixel(mag))
+	s.Color = ColorBlue
+	if blue := rgba(t, MagnitudeToPixel(mag)); blue == grayscale {
+		t.Error("MagnitudeToPixel ignored a color-scheme change on S")
+	}
+}
+
+func TestComputeFFT_UsesPackageSettings(t *testing.T) {
+	s := DefaultSettings()
+	s.SetWindowByName("rectangular")
+	withS(t, s)
+
+	const n = 256
+	in := make([]float32, n)
+	for i := range in {
+		in[i] = float32(math.Sin(2 * math.Pi * 8 * float64(i) / n))
+	}
+
+	got := ComputeFFT(in)
+	want := ComputeFFTWith(in, s)
+	if len(got) != len(want) {
+		t.Fatalf("ComputeFFT len = %d, want %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("ComputeFFT[%d] = %v, want %v (the global wrapper must read S)", i, got[i], want[i])
+		}
+	}
+
+	// The window from S must actually be applied: hann tapers the edges, so it
+	// produces a different spectrum than rectangular for the same input.
+	s.SetWindowByName("hann")
+	hann := ComputeFFT(in)
+	same := true
+	for i := range hann {
+		if hann[i] != got[i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Error("switching the window on S did not change the spectrum")
+	}
+}
+
+// TestComputeFFTWith_ZeroPadsToPowerOfTwo documents the length contract: the
+// input is padded up to the next power of two, so the magnitude count is
+// half the PADDED size, not half the input.
+func TestComputeFFTWith_ZeroPadsToPowerOfTwo(t *testing.T) {
+	s := DefaultSettings()
+	cases := []struct{ in, want int }{
+		{256, 128},
+		{100, 64},   // padded to 128
+		{1000, 512}, // padded to 1024
+	}
+	for _, c := range cases {
+		got := ComputeFFTWith(make([]float32, c.in), s)
+		if len(got) != c.want {
+			t.Errorf("ComputeFFTWith(len %d) → %d magnitudes, want %d", c.in, len(got), c.want)
+		}
+	}
+}
+
+// TestComputeFFTWith_DegenerateInput — the audio tap can hand over a short or
+// empty buffer at call setup/teardown; that must not panic.
+func TestComputeFFTWith_DegenerateInput(t *testing.T) {
+	s := DefaultSettings()
+	for _, n := range []int{0, 1, 2, 3} {
+		got := ComputeFFTWith(make([]float32, n), s)
+		if n < 2 && len(got) != 0 {
+			t.Errorf("ComputeFFTWith(len %d) = %d magnitudes, want 0", n, len(got))
+		}
+	}
+	if got := ComputeFFTWith(nil, s); len(got) != 0 {
+		t.Errorf("ComputeFFTWith(nil) = %d magnitudes, want 0", len(got))
+	}
+}
+
+// TestComputeFFTWith_AllWindows walks every window arm of the switch and
+// checks the result is finite — a NaN here would poison the whole column.
+func TestComputeFFTWith_AllWindows(t *testing.T) {
+	const n = 128
+	in := make([]float32, n)
+	for i := range in {
+		in[i] = float32(math.Sin(2 * math.Pi * 4 * float64(i) / n))
+	}
+	for _, name := range []string{"hann", "hamming", "bartlett", "rectangular"} {
+		t.Run(name, func(t *testing.T) {
+			s := DefaultSettings()
+			s.SetWindowByName(name)
+			mags := ComputeFFTWith(in, s)
+			if len(mags) != n/2 {
+				t.Fatalf("magnitudes len = %d, want %d", len(mags), n/2)
+			}
+			peak := 0
+			for i, m := range mags {
+				if math.IsNaN(m) || math.IsInf(m, 0) {
+					t.Fatalf("magnitude[%d] = %v, want a finite value", i, m)
+				}
+				if m < 0 {
+					t.Fatalf("magnitude[%d] = %v, want a non-negative value", i, m)
+				}
+				if m > mags[peak] {
+					peak = i
+				}
+			}
+			// Every window must preserve the bin-4 tone; tapering only spreads
+			// energy into the neighbors.
+			if peak != 4 {
+				t.Errorf("%s window moved the peak to bin %d, want 4", name, peak)
+			}
+		})
+	}
+}
+
+// TestWindows_SingleSampleGuard covers the n == 1 arm of each tapering window.
+// Without the guard the coefficient formula divides by n-1 == 0 and yields
+// NaN, which would propagate through the FFT and poison the whole column. A
+// one-sample buffer is reachable from the audio tap at call setup.
+func TestWindows_SingleSampleGuard(t *testing.T) {
+	windows := map[string]func(int) []float64{
+		"hann":        hann,
+		"hamming":     hamming,
+		"bartlett":    bartlett,
+		"rectangular": rectangular,
+	}
+	for name, fn := range windows {
+		t.Run(name, func(t *testing.T) {
+			w := fn(1)
+			if len(w) != 1 {
+				t.Fatalf("%s(1) len = %d, want 1", name, len(w))
+			}
+			if math.IsNaN(w[0]) {
+				t.Fatalf("%s(1) = NaN — the single-sample guard is missing", name)
+			}
+			if w[0] != 1 {
+				t.Errorf("%s(1) = %v, want the unit coefficient 1", name, w[0])
+			}
+			// A zero-length buffer must also be handled without panicking.
+			if got := fn(0); len(got) != 0 {
+				t.Errorf("%s(0) len = %d, want 0", name, len(got))
+			}
+		})
+	}
+}
+
+// TestConstantsMatchDefaults keeps the legacy package constants in step with
+// DefaultSettings — the browser spectrogram in the skychat UI hardcodes a
+// 1024-point window to match, so a drift here desyncs the two renderers.
+func TestConstantsMatchDefaults(t *testing.T) {
+	d := DefaultSettings()
+	if FFTSize != d.DFTSize {
+		t.Errorf("FFTSize = %d but DefaultSettings.DFTSize = %d", FFTSize, d.DFTSize)
+	}
+	if Overlap != d.Overlap {
+		t.Errorf("Overlap = %v but DefaultSettings.Overlap = %v", Overlap, d.Overlap)
+	}
+	if StepSize != d.StepSize() {
+		t.Errorf("StepSize = %d but DefaultSettings.StepSize() = %d", StepSize, d.StepSize())
+	}
+	if SampleRate != 24000 {
+		t.Errorf("SampleRate = %d, want 24000 (the call codec rate)", SampleRate)
+	}
+}

--- a/pkg/skychat/call/spectrogram/pixels_test.go
+++ b/pkg/skychat/call/spectrogram/pixels_test.go
@@ -65,16 +65,60 @@ func TestNormalize(t *testing.T) {
 }
 
 // TestNormalize_DegenerateWindows pins the two out-of-contract cases, both
-// reachable from the UI via AdjustMin/AdjustMax (which clamp independently).
+// reachable from the UI via AdjustMin/AdjustMax (which clamp independently)
+// and via the unclamped SetMagMin/SetMagMax.
 func TestNormalize_DegenerateWindows(t *testing.T) {
-	// min == max divides by zero → NaN. Documented, not defended against here;
-	// the colormaps absorb it without panicking (see the test below).
-	if got := Normalize(10, 45, 45); !math.IsNaN(got) {
-		t.Errorf("Normalize with min==max = %v, want NaN", got)
+	// A zero-width window must behave as a step at the threshold, never NaN —
+	// NaN would reach uint8(NaN) in the colormaps, which Go leaves
+	// implementation-defined.
+	cases := []struct {
+		value, min, max float64
+		want            float64
+	}{
+		{10, 45, 45, 0},     // below the threshold
+		{45, 45, 45, 0},     // exactly at it — floors, matching the ramp's v==min
+		{100, 45, 45, 1},    // above it saturates
+		{0, 0, 0, 0},        // zero window at the origin
+		{-1, 0, 0, 0},       //
+		{1, 0, 0, 1},        //
+		{-100, -80, -80, 0}, // negative dB window, below the threshold
+		{-80, -80, -80, 0},  // exactly at it
+		{-50, -80, -80, 1},  // above it
+	}
+	for _, c := range cases {
+		got := Normalize(c.value, c.min, c.max)
+		if math.IsNaN(got) {
+			t.Errorf("Normalize(%v, %v, %v) = NaN; the zero-width guard is missing", c.value, c.min, c.max)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("Normalize(%v, %v, %v) = %v, want %v", c.value, c.min, c.max, got, c.want)
+		}
 	}
 	// min > max collapses to zero rather than producing a negative or NaN.
 	if got := Normalize(10, 50, 45); got != 0 {
 		t.Errorf("Normalize with min>max = %v, want 0", got)
+	}
+}
+
+// TestNormalize_NeverNaN sweeps the window combinations the settings API can
+// produce and asserts the result is always a usable [0,1] fraction — the
+// property the colormaps rely on to avoid an undefined uint8 conversion.
+func TestNormalize_NeverNaN(t *testing.T) {
+	bounds := []float64{-80, -45, -1, 0, 1, 45, 80, 1000}
+	values := []float64{-200, -80, -0.5, 0, 0.5, 45, 200, 1e6}
+	for _, lo := range bounds {
+		for _, hi := range bounds {
+			for _, v := range values {
+				got := Normalize(v, lo, hi)
+				if math.IsNaN(got) || math.IsInf(got, 0) {
+					t.Fatalf("Normalize(%v, %v, %v) = %v, want a finite value", v, lo, hi, got)
+				}
+				if got < 0 || got > 1 {
+					t.Fatalf("Normalize(%v, %v, %v) = %v, want it within [0,1]", v, lo, hi, got)
+				}
+			}
+		}
 	}
 }
 
@@ -248,20 +292,29 @@ func TestMagnitudeToPixelWith_ColorSchemeDispatch(t *testing.T) {
 	}
 }
 
-// TestMagnitudeToPixel_DegenerateRangeDoesNotPanic covers the MagMin == MagMax
-// case, which the UI can reach by pushing AdjustMin up into MagMax (the two
-// clamp independently). Normalize then yields NaN and the colormaps convert it
-// with uint8(NaN) — implementation-defined in Go, so only the invariants that
-// hold on every platform are asserted: no panic, and an opaque pixel.
-func TestMagnitudeToPixel_DegenerateRangeDoesNotPanic(t *testing.T) {
+// TestMagnitudeToPixel_DegenerateRange covers the MagMin == MagMax case, which
+// the UI can reach by pushing AdjustMin up into MagMax (the two clamp
+// independently). With the zero-width guard in Normalize the window acts as a
+// threshold, so the result is fully determined on every platform rather than
+// depending on an implementation-defined uint8(NaN).
+func TestMagnitudeToPixel_DegenerateRange(t *testing.T) {
+	const (
+		black = 5.0    // 20*log10(5) ≈ 14 dB — below the 45 dB threshold
+		white = 1000.0 // 60 dB — above it
+	)
 	for _, scheme := range []ColorScheme{ColorHeat, ColorBlue, ColorGrayscale} {
 		s := DefaultSettings()
 		s.Color = scheme
 		s.SetMagMin(45)
 		s.SetMagMax(45)
-		got := rgba(t, MagnitudeToPixelWith(5, s))
-		if got.A != 255 {
-			t.Errorf("scheme %v with a zero-width window: alpha = %d, want 255", scheme, got.A)
+
+		lo := rgba(t, MagnitudeToPixelWith(black, s))
+		if lo != (color.RGBA{0, 0, 0, 255}) {
+			t.Errorf("scheme %v below the threshold = %v, want black", scheme, lo)
+		}
+		hi := rgba(t, MagnitudeToPixelWith(white, s))
+		if hi != (color.RGBA{255, 255, 255, 255}) {
+			t.Errorf("scheme %v above the threshold = %v, want white", scheme, hi)
 		}
 	}
 	// Inverted window (min > max) is well-defined: Normalize → 0 → black.

--- a/pkg/skychat/call/spectrogram/settings_test.go
+++ b/pkg/skychat/call/spectrogram/settings_test.go
@@ -1,0 +1,614 @@
+// Package spectrogram pkg/skychat/call/spectrogram/settings_test.go c4-app-chat
+//
+// Unit coverage for the Settings state machine — the clamping, cycling and
+// name<->enum mapping behind the spectrogram's interactive controls (the CLI
+// `skychat voice spectrogram` keybinds drive these directly).
+//
+// Everything here is pure and lock-guarded, so the tests assert exact values
+// rather than ranges. Two behaviors are pinned deliberately because they read
+// as surprising and a "cleanup" could silently change them:
+//
+//   - SetDFTSize rounds UP to the next power of two, not to the nearest one
+//     (its doc comment says "nearest");
+//   - Double/HalveFFTSize reset Overlap to 0.50 unconditionally, including
+//     when the size is already pinned at the 8192 cap or the 64 floor.
+package spectrogram
+
+import (
+	"math"
+	"sync"
+	"testing"
+)
+
+func TestDefaultSettings(t *testing.T) {
+	s := DefaultSettings()
+	if s.Color != ColorHeat || s.Window != WindowHann || s.Mag != ScaleLog {
+		t.Errorf("defaults = color %v / window %v / scale %v; want heat/hann/log", s.Color, s.Window, s.Mag)
+	}
+	if s.MagMin != 0.0 || s.MagMax != 45.0 {
+		t.Errorf("default magnitude range = [%v,%v], want [0,45]", s.MagMin, s.MagMax)
+	}
+	if s.DFTSize != 1024 || s.Overlap != 0.50 {
+		t.Errorf("default DFTSize/Overlap = %d/%v, want 1024/0.5", s.DFTSize, s.Overlap)
+	}
+	// The package-level S the UIs share must start from the same defaults.
+	if got := S.GetDFTSize(); got != 1024 {
+		t.Errorf("package S DFTSize = %d, want 1024", got)
+	}
+}
+
+func TestStepSize(t *testing.T) {
+	cases := []struct {
+		dft     int
+		overlap float64
+		want    int
+	}{
+		{1024, 0.50, 512},
+		{1024, 0.75, 256},
+		{512, 0.00, 512}, // no overlap → advance a whole frame
+		{64, 0.95, 3},    // the tightest setter-reachable combination
+		{2048, 0.25, 1536},
+	}
+	for _, c := range cases {
+		s := DefaultSettings()
+		s.DFTSize = c.dft
+		s.Overlap = c.overlap
+		if got := s.StepSize(); got != c.want {
+			t.Errorf("StepSize(dft=%d, overlap=%v) = %d, want %d", c.dft, c.overlap, got, c.want)
+		}
+	}
+}
+
+// TestStepSize_NeverZeroViaSetters pins the invariant a caller depends on: a
+// frame loop advancing by StepSize() must make progress. The setters clamp
+// DFTSize to >=64 and Overlap to <=0.95, so the product can never floor to 0.
+func TestStepSize_NeverZeroViaSetters(t *testing.T) {
+	for _, dft := range []int{1, 64, 100, 1024, 8192, 99999} {
+		for _, ov := range []float64{-5, 0, 0.5, 0.95, 1.0, 42} {
+			s := DefaultSettings()
+			s.SetDFTSize(dft)
+			s.SetOverlap(ov)
+			if got := s.StepSize(); got < 1 {
+				t.Errorf("StepSize() = %d after SetDFTSize(%d)+SetOverlap(%v); must stay >= 1", got, dft, ov)
+			}
+		}
+	}
+}
+
+func TestGetters(t *testing.T) {
+	s := DefaultSettings()
+	s.SetDFTSize(256)
+	s.SetOverlap(0.30)
+	if got := s.GetDFTSize(); got != 256 {
+		t.Errorf("GetDFTSize() = %d, want 256", got)
+	}
+	if got := s.GetOverlap(); got != 0.30 {
+		t.Errorf("GetOverlap() = %v, want 0.30", got)
+	}
+}
+
+func TestSetColorByName(t *testing.T) {
+	cases := []struct {
+		name string
+		want ColorScheme
+	}{
+		{"heat", ColorHeat},
+		{"blue", ColorBlue},
+		{"grayscale", ColorGrayscale},
+		{"gray", ColorGrayscale}, // alias
+	}
+	for _, c := range cases {
+		s := DefaultSettings()
+		s.Color = ColorBlue // start off-target so "heat" is a real change
+		s.SetColorByName(c.name)
+		if s.Color != c.want {
+			t.Errorf("SetColorByName(%q) = %v, want %v", c.name, s.Color, c.want)
+		}
+	}
+	// An unrecognized name is a no-op, not a reset to the default.
+	s := DefaultSettings()
+	s.SetColorByName("grayscale")
+	s.SetColorByName("chartreuse")
+	if s.Color != ColorGrayscale {
+		t.Errorf("unknown color name changed the scheme to %v, want it left at grayscale", s.Color)
+	}
+}
+
+func TestSetWindowByName(t *testing.T) {
+	cases := []struct {
+		name string
+		want WindowFunc
+	}{
+		{"hann", WindowHann},
+		{"hamming", WindowHamming},
+		{"bartlett", WindowBartlett},
+		{"rectangular", WindowRectangular},
+		{"rect", WindowRectangular}, // alias
+	}
+	for _, c := range cases {
+		s := DefaultSettings()
+		s.Window = WindowBartlett
+		s.SetWindowByName(c.name)
+		if s.Window != c.want {
+			t.Errorf("SetWindowByName(%q) = %v, want %v", c.name, s.Window, c.want)
+		}
+	}
+	s := DefaultSettings()
+	s.SetWindowByName("blackman") // not implemented locally
+	if s.Window != WindowHann {
+		t.Errorf("unknown window name changed the function to %v, want it left at hann", s.Window)
+	}
+}
+
+func TestSetScaleByName(t *testing.T) {
+	cases := []struct {
+		name string
+		want Scale
+	}{
+		{"log", ScaleLog},
+		{"logarithmic", ScaleLog}, // alias
+		{"linear", ScaleLinear},
+	}
+	for _, c := range cases {
+		s := DefaultSettings()
+		s.Mag = ScaleLinear
+		s.SetScaleByName(c.name)
+		if s.Mag != c.want {
+			t.Errorf("SetScaleByName(%q) = %v, want %v", c.name, s.Mag, c.want)
+		}
+	}
+	s := DefaultSettings()
+	s.SetScaleByName("mel")
+	if s.Mag != ScaleLog {
+		t.Errorf("unknown scale name changed the scale to %v, want it left at log", s.Mag)
+	}
+}
+
+// TestSetScaleByName_DoesNotResetRange separates SetScaleByName from
+// ToggleScale: only the latter re-baselines MagMin/MagMax for the new scale.
+// Switching to linear by name leaves the log-appropriate 0..45 window in
+// place, which is the caller's problem to fix.
+func TestSetScaleByName_DoesNotResetRange(t *testing.T) {
+	s := DefaultSettings()
+	s.SetScaleByName("linear")
+	if s.MagMin != 0.0 || s.MagMax != 45.0 {
+		t.Errorf("SetScaleByName left range [%v,%v], want the untouched [0,45]", s.MagMin, s.MagMax)
+	}
+}
+
+func TestSetMagMinMax(t *testing.T) {
+	// Unlike the Adjust* helpers these are raw setters — no clamping, and no
+	// cross-check that min <= max.
+	s := DefaultSettings()
+	s.SetMagMin(-999)
+	s.SetMagMax(12345)
+	if s.MagMin != -999 || s.MagMax != 12345 {
+		t.Errorf("range = [%v,%v], want the values set verbatim", s.MagMin, s.MagMax)
+	}
+}
+
+func TestSetDFTSize(t *testing.T) {
+	// Rounds UP to the next power of two and clamps to [64, 8192]. NOTE: the
+	// doc comment says "nearest power of 2" but 65 and 70 both go to 128, not
+	// 64 — round-up is the actual (and more useful) contract.
+	cases := []struct{ in, want int }{
+		{-1, 64},
+		{0, 64},
+		{63, 64},
+		{64, 64},
+		{65, 128},
+		{70, 128},
+		{100, 128},
+		{128, 128},
+		{1000, 1024},
+		{1024, 1024},
+		{8192, 8192},
+		{8193, 8192},
+		{99999, 8192},
+	}
+	for _, c := range cases {
+		s := DefaultSettings()
+		s.SetDFTSize(c.in)
+		if got := s.GetDFTSize(); got != c.want {
+			t.Errorf("SetDFTSize(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSetDFTSize_AlwaysPowerOfTwo(t *testing.T) {
+	// fftInPlace requires a power-of-two length; anything else corrupts the
+	// butterfly stages silently.
+	for n := -10; n <= 300; n++ {
+		s := DefaultSettings()
+		s.SetDFTSize(n)
+		got := s.GetDFTSize()
+		if got&(got-1) != 0 {
+			t.Fatalf("SetDFTSize(%d) = %d, which is not a power of two", n, got)
+		}
+	}
+}
+
+func TestSetOverlap(t *testing.T) {
+	cases := []struct{ in, want float64 }{
+		{-1.0, 0.05},
+		{0.0, 0.05},
+		{0.05, 0.05},
+		{0.50, 0.50},
+		{0.95, 0.95},
+		{1.0, 0.95},
+		{42.0, 0.95},
+	}
+	for _, c := range cases {
+		s := DefaultSettings()
+		s.SetOverlap(c.in)
+		if got := s.GetOverlap(); got != c.want {
+			t.Errorf("SetOverlap(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestCycleColor(t *testing.T) {
+	s := DefaultSettings()
+	want := []ColorScheme{ColorBlue, ColorGrayscale, ColorHeat}
+	for i, w := range want {
+		s.CycleColor()
+		if s.Color != w {
+			t.Fatalf("CycleColor #%d = %v, want %v", i+1, s.Color, w)
+		}
+	}
+	// Three schemes → three cycles return to the start.
+	if s.Color != ColorHeat {
+		t.Errorf("after a full cycle Color = %v, want the starting heat", s.Color)
+	}
+}
+
+func TestCycleWindow(t *testing.T) {
+	s := DefaultSettings()
+	want := []WindowFunc{WindowHamming, WindowBartlett, WindowRectangular, WindowHann}
+	for i, w := range want {
+		s.CycleWindow()
+		if s.Window != w {
+			t.Fatalf("CycleWindow #%d = %v, want %v", i+1, s.Window, w)
+		}
+	}
+}
+
+func TestToggleScale(t *testing.T) {
+	s := DefaultSettings() // log, [0,45]
+
+	s.ToggleScale()
+	if s.Mag != ScaleLinear {
+		t.Fatalf("first toggle → %v, want linear", s.Mag)
+	}
+	if s.MagMin != 0.0 || s.MagMax != 1000.0 {
+		t.Errorf("linear range = [%v,%v], want [0,1000]", s.MagMin, s.MagMax)
+	}
+
+	s.ToggleScale()
+	if s.Mag != ScaleLog {
+		t.Fatalf("second toggle → %v, want log", s.Mag)
+	}
+	if s.MagMin != 0.0 || s.MagMax != 45.0 {
+		t.Errorf("log range = [%v,%v], want [0,45]", s.MagMin, s.MagMax)
+	}
+}
+
+// TestToggleScale_DiscardsCustomRange documents that toggling re-baselines the
+// magnitude window: a hand-tuned range does not survive a scale flip.
+func TestToggleScale_DiscardsCustomRange(t *testing.T) {
+	s := DefaultSettings()
+	s.SetMagMin(-30)
+	s.SetMagMax(20)
+	s.ToggleScale()
+	if s.MagMin != 0.0 || s.MagMax != 1000.0 {
+		t.Errorf("range after toggle = [%v,%v], want the linear baseline [0,1000]", s.MagMin, s.MagMax)
+	}
+}
+
+func TestAdjustMin(t *testing.T) {
+	// Log scale: 5 dB per unit delta, clamped to [-80, 80].
+	s := DefaultSettings()
+	s.AdjustMin(1)
+	if s.MagMin != 5 {
+		t.Errorf("log AdjustMin(1) = %v, want 5 (5 dB per unit)", s.MagMin)
+	}
+	s.AdjustMin(-2)
+	if s.MagMin != -5 {
+		t.Errorf("log AdjustMin(-2) = %v, want -5", s.MagMin)
+	}
+	s.AdjustMin(1000)
+	if s.MagMin != 80 {
+		t.Errorf("log AdjustMin clamp high = %v, want 80", s.MagMin)
+	}
+	s.AdjustMin(-1000)
+	if s.MagMin != -80 {
+		t.Errorf("log AdjustMin clamp low = %v, want -80", s.MagMin)
+	}
+
+	// Linear scale: 25 units per delta, clamped to [0, 1000].
+	l := DefaultSettings()
+	l.ToggleScale()
+	l.AdjustMin(2)
+	if l.MagMin != 50 {
+		t.Errorf("linear AdjustMin(2) = %v, want 50 (25 per unit)", l.MagMin)
+	}
+	l.AdjustMin(-1000)
+	if l.MagMin != 0 {
+		t.Errorf("linear AdjustMin clamp low = %v, want 0", l.MagMin)
+	}
+	l.AdjustMin(1000)
+	if l.MagMin != 1000 {
+		t.Errorf("linear AdjustMin clamp high = %v, want 1000", l.MagMin)
+	}
+}
+
+func TestAdjustMax(t *testing.T) {
+	s := DefaultSettings()
+	s.AdjustMax(1)
+	if s.MagMax != 50 {
+		t.Errorf("log AdjustMax(1) = %v, want 50", s.MagMax)
+	}
+	s.AdjustMax(1000)
+	if s.MagMax != 80 {
+		t.Errorf("log AdjustMax clamp high = %v, want 80", s.MagMax)
+	}
+	s.AdjustMax(-1000)
+	if s.MagMax != -80 {
+		t.Errorf("log AdjustMax clamp low = %v, want -80", s.MagMax)
+	}
+
+	l := DefaultSettings()
+	l.ToggleScale()
+	l.AdjustMax(-1)
+	if l.MagMax != 975 {
+		t.Errorf("linear AdjustMax(-1) = %v, want 975", l.MagMax)
+	}
+	l.AdjustMax(-1000)
+	if l.MagMax != 0 {
+		t.Errorf("linear AdjustMax clamp low = %v, want 0", l.MagMax)
+	}
+	l.AdjustMax(1000)
+	if l.MagMax != 1000 {
+		t.Errorf("linear AdjustMax clamp high = %v, want 1000", l.MagMax)
+	}
+}
+
+// TestAdjustMinMax_CanCross documents that the two are clamped independently:
+// nothing stops MagMin from being pushed past MagMax. Normalize copes (it
+// yields 0 for an inverted window) but MagMin == MagMax is a NaN — see
+// TestMagnitudeToPixel_DegenerateRangeDoesNotPanic.
+func TestAdjustMinMax_CanCross(t *testing.T) {
+	s := DefaultSettings() // [0,45]
+	s.AdjustMin(20)        // → 100, clamped to 80
+	if s.MagMin <= s.MagMax {
+		t.Fatalf("expected MagMin(%v) to be pushed past MagMax(%v)", s.MagMin, s.MagMax)
+	}
+	if got := Normalize(10, s.MagMin, s.MagMax); got != 0 {
+		t.Errorf("Normalize over an inverted window = %v, want 0", got)
+	}
+}
+
+func TestDoubleFFTSize(t *testing.T) {
+	s := DefaultSettings()
+	s.DFTSize = 1024
+	s.Overlap = 0.90
+	s.DoubleFFTSize()
+	if s.DFTSize != 2048 {
+		t.Errorf("DoubleFFTSize = %d, want 2048", s.DFTSize)
+	}
+	if s.Overlap != 0.50 {
+		t.Errorf("Overlap = %v, want it reset to 0.50", s.Overlap)
+	}
+
+	// At the cap the size holds, but the overlap reset still fires.
+	s.DFTSize = 8192
+	s.Overlap = 0.90
+	s.DoubleFFTSize()
+	if s.DFTSize != 8192 {
+		t.Errorf("DoubleFFTSize at the cap = %d, want it held at 8192", s.DFTSize)
+	}
+	if s.Overlap != 0.50 {
+		t.Errorf("Overlap at the cap = %v, want 0.50 (the reset is unconditional)", s.Overlap)
+	}
+}
+
+func TestHalveFFTSize(t *testing.T) {
+	s := DefaultSettings()
+	s.DFTSize = 1024
+	s.Overlap = 0.90
+	s.HalveFFTSize()
+	if s.DFTSize != 512 {
+		t.Errorf("HalveFFTSize = %d, want 512", s.DFTSize)
+	}
+	if s.Overlap != 0.50 {
+		t.Errorf("Overlap = %v, want it reset to 0.50", s.Overlap)
+	}
+
+	s.DFTSize = 64
+	s.Overlap = 0.90
+	s.HalveFFTSize()
+	if s.DFTSize != 64 {
+		t.Errorf("HalveFFTSize at the floor = %d, want it held at 64", s.DFTSize)
+	}
+	if s.Overlap != 0.50 {
+		t.Errorf("Overlap at the floor = %v, want 0.50 (the reset is unconditional)", s.Overlap)
+	}
+}
+
+// TestFFTSizeRoundTrip walks the whole ladder up and back down, checking every
+// step stays a power of two within the documented bounds.
+func TestFFTSizeRoundTrip(t *testing.T) {
+	s := DefaultSettings()
+	s.SetDFTSize(64)
+	for i := 0; i < 10; i++ {
+		s.DoubleFFTSize()
+		n := s.GetDFTSize()
+		if n&(n-1) != 0 || n < 64 || n > 8192 {
+			t.Fatalf("after %d doublings DFTSize = %d, want a power of two in [64,8192]", i+1, n)
+		}
+	}
+	if got := s.GetDFTSize(); got != 8192 {
+		t.Errorf("10 doublings from 64 = %d, want the 8192 cap", got)
+	}
+	for i := 0; i < 10; i++ {
+		s.HalveFFTSize()
+	}
+	if got := s.GetDFTSize(); got != 64 {
+		t.Errorf("10 halvings from 8192 = %d, want the 64 floor", got)
+	}
+}
+
+func TestAdjustOverlap(t *testing.T) {
+	s := DefaultSettings() // 0.50
+	s.AdjustOverlap(0.25)
+	if math.Abs(s.Overlap-0.75) > 1e-9 {
+		t.Errorf("AdjustOverlap(0.25) = %v, want 0.75", s.Overlap)
+	}
+	s.AdjustOverlap(10)
+	if s.Overlap != 0.95 {
+		t.Errorf("AdjustOverlap clamp high = %v, want 0.95", s.Overlap)
+	}
+	s.AdjustOverlap(-10)
+	if s.Overlap != 0.05 {
+		t.Errorf("AdjustOverlap clamp low = %v, want 0.05", s.Overlap)
+	}
+}
+
+func TestNames(t *testing.T) {
+	colors := map[ColorScheme]string{ColorHeat: "heat", ColorBlue: "blue", ColorGrayscale: "grayscale"}
+	for c, want := range colors {
+		s := DefaultSettings()
+		s.Color = c
+		if got := s.ColorName(); got != want {
+			t.Errorf("ColorName(%v) = %q, want %q", c, got, want)
+		}
+	}
+	windows := map[WindowFunc]string{
+		WindowHann: "hann", WindowHamming: "hamming",
+		WindowBartlett: "bartlett", WindowRectangular: "rectangular",
+	}
+	for w, want := range windows {
+		s := DefaultSettings()
+		s.Window = w
+		if got := s.WindowName(); got != want {
+			t.Errorf("WindowName(%v) = %q, want %q", w, got, want)
+		}
+	}
+	scales := map[Scale]string{ScaleLog: "logarithmic", ScaleLinear: "linear"}
+	for m, want := range scales {
+		s := DefaultSettings()
+		s.Mag = m
+		if got := s.ScaleName(); got != want {
+			t.Errorf("ScaleName(%v) = %q, want %q", m, got, want)
+		}
+	}
+}
+
+// TestNames_OutOfRangeFallsBackToDefault covers the default arms: an enum from
+// a corrupt config shouldn't produce an empty label in the UI.
+func TestNames_OutOfRangeFallsBackToDefault(t *testing.T) {
+	s := DefaultSettings()
+	s.Color = ColorScheme(99)
+	if got := s.ColorName(); got != "heat" {
+		t.Errorf("ColorName(99) = %q, want the heat fallback", got)
+	}
+	s.Window = WindowFunc(99)
+	if got := s.WindowName(); got != "hann" {
+		t.Errorf("WindowName(99) = %q, want the hann fallback", got)
+	}
+	s.Mag = Scale(99)
+	if got := s.ScaleName(); got != "logarithmic" {
+		t.Errorf("ScaleName(99) = %q, want the logarithmic fallback", got)
+	}
+}
+
+// TestNameRoundTrip is the property that keeps a saved/restored UI state
+// stable: every *Name() output must be accepted by its Set*ByName counterpart
+// and land back on the same enum.
+func TestNameRoundTrip(t *testing.T) {
+	for _, c := range []ColorScheme{ColorHeat, ColorBlue, ColorGrayscale} {
+		s := DefaultSettings()
+		s.Color = c
+		name := s.ColorName()
+		r := DefaultSettings()
+		r.SetColorByName(name)
+		if r.Color != c {
+			t.Errorf("color round-trip %v → %q → %v", c, name, r.Color)
+		}
+	}
+	for _, w := range []WindowFunc{WindowHann, WindowHamming, WindowBartlett, WindowRectangular} {
+		s := DefaultSettings()
+		s.Window = w
+		name := s.WindowName()
+		r := DefaultSettings()
+		r.SetWindowByName(name)
+		if r.Window != w {
+			t.Errorf("window round-trip %v → %q → %v", w, name, r.Window)
+		}
+	}
+	for _, m := range []Scale{ScaleLog, ScaleLinear} {
+		s := DefaultSettings()
+		s.Mag = m
+		name := s.ScaleName()
+		r := DefaultSettings()
+		r.SetScaleByName(name)
+		if r.Mag != m {
+			t.Errorf("scale round-trip %v → %q → %v", m, name, r.Mag)
+		}
+	}
+}
+
+// TestSettings_ConcurrentAccess is the reason Settings carries a mutex: the
+// render loop reads while the key handler writes. Meaningful under -race.
+func TestSettings_ConcurrentAccess(t *testing.T) {
+	s := DefaultSettings()
+	var wg sync.WaitGroup
+	const iters = 200
+
+	writers := []func(){
+		func() { s.CycleColor() },
+		func() { s.CycleWindow() },
+		func() { s.ToggleScale() },
+		func() { s.AdjustMin(1) },
+		func() { s.AdjustMax(-1) },
+		func() { s.AdjustOverlap(0.01) },
+		func() { s.DoubleFFTSize() },
+		func() { s.HalveFFTSize() },
+		func() { s.SetColorByName("blue") },
+		func() { s.SetWindowByName("hamming") },
+		func() { s.SetScaleByName("linear") },
+		func() { s.SetMagMin(-10) },
+		func() { s.SetMagMax(40) },
+		func() { s.SetDFTSize(512) },
+		func() { s.SetOverlap(0.6) },
+	}
+	for _, w := range writers {
+		wg.Add(1)
+		go func(fn func()) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				fn()
+			}
+		}(w)
+	}
+
+	readers := []func(){
+		func() { _ = s.StepSize() },
+		func() { _ = s.GetDFTSize() },
+		func() { _ = s.GetOverlap() },
+		func() { _ = s.ColorName() },
+		func() { _ = s.WindowName() },
+		func() { _ = s.ScaleName() },
+		func() { _ = MagnitudeToPixelWith(1.5, s) },
+	}
+	for _, r := range readers {
+		wg.Add(1)
+		go func(fn func()) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				fn()
+			}
+		}(r)
+	}
+	wg.Wait()
+}

--- a/pkg/skychat/call/spectrogram/spectrogram.go
+++ b/pkg/skychat/call/spectrogram/spectrogram.go
@@ -31,8 +31,27 @@ const StepSize = int(FFTSize * (1.0 - Overlap))
 // synchronous. Kept for API compatibility with upstream audioprism-go.
 func SetSingleThreaded() {}
 
-// Normalize normalizes the value between the given range.
+// Normalize maps value onto [0,1] across the [minVal,maxVal] window, clamping
+// anything outside it.
+//
+// A zero-width window (maxVal == minVal) is handled explicitly: the ramp's
+// limit as the window narrows is a step at the threshold, so values above it
+// saturate and everything else floors. Without this guard the division below
+// is 0/0 = NaN, and the colormaps then evaluate uint8(NaN) — a conversion Go
+// leaves implementation-defined, so the rendered column would differ by
+// platform. The degenerate window is reachable from the UI because AdjustMin
+// and AdjustMax clamp independently (nothing stops MagMin being pushed onto
+// MagMax), and because SetMagMin/SetMagMax apply no clamping at all.
+//
+// An inverted window (minVal > maxVal) is left as it was: the clamps collapse
+// the numerator to zero, so the result is 0.
 func Normalize(value, minVal, maxVal float64) float64 {
+	if maxVal == minVal {
+		if value > minVal {
+			return 1
+		}
+		return 0
+	}
 	return (math.Max(math.Min(value, maxVal), minVal) - minVal) / (maxVal - minVal)
 }
 

--- a/pkg/skychat/dm/accessors_test.go
+++ b/pkg/skychat/dm/accessors_test.go
@@ -1,0 +1,143 @@
+// Package dm pkg/skychat/dm/accessors_test.go
+//
+// The /status-facing accessors and the network predicate that the controller's
+// send/receive tests never reach directly.
+//
+// Conns and Peers back the chat-app's /status output, so they are what an
+// operator reads when diagnosing "is anyone actually connected"; NoteInbound is
+// how transports that bypass the framed read loop (the CXO feed path) keep
+// those counters honest.
+package dm
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skychat/message"
+)
+
+// dialOnlyClient is a Client whose Dial always succeeds, handing back one end
+// of a net.Pipe with the peer end drained. Enough to populate the conn cache
+// the accessors report on, without standing up the full memHub fixture.
+type dialOnlyClient struct {
+	mu      sync.Mutex
+	closers []net.Conn
+}
+
+func (d *dialOnlyClient) Listen(appnet.Type, routing.Port) (net.Listener, error) {
+	return nil, errors.New("dialOnlyClient: Listen unsupported")
+}
+
+func (d *dialOnlyClient) Dial(appnet.Addr) (net.Conn, error) {
+	local, remote := net.Pipe()
+	d.mu.Lock()
+	d.closers = append(d.closers, local, remote)
+	d.mu.Unlock()
+	// net.Pipe is unbuffered: drain the peer end or the first write blocks.
+	go func() {
+		for {
+			if _, err := message.ReadFrame(remote); err != nil {
+				return
+			}
+		}
+	}()
+	return local, nil
+}
+
+func (d *dialOnlyClient) closeAll() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, c := range d.closers {
+		_ = c.Close() //nolint:errcheck
+	}
+}
+
+func TestHasNetwork(t *testing.T) {
+	c := New(Config{Networks: []appnet.Type{appnet.TypeSkynet}})
+	if !c.hasNetwork(appnet.TypeSkynet) {
+		t.Error("a configured network should be reported")
+	}
+	if c.hasNetwork(appnet.TypeDmsg) {
+		t.Error("an unconfigured network must not be reported")
+	}
+
+	both := New(Config{Networks: []appnet.Type{appnet.TypeSkynet, appnet.TypeDmsg}})
+	if !both.hasNetwork(appnet.TypeSkynet) || !both.hasNetwork(appnet.TypeDmsg) {
+		t.Error("both configured networks should be reported")
+	}
+
+	// A controller with no networks reports none — this is what makes the
+	// standalone/TCP-direct path fall through the send loop cleanly.
+	if New(Config{}).hasNetwork(appnet.TypeSkynet) {
+		t.Error("a controller with no networks must report none")
+	}
+}
+
+// TestConnsAndPeers drives the accessors through the real conn cache: Serve
+// registers a conn keyed by its appnet.Addr, so the counters move without any
+// reaching into unexported state.
+func TestConnsAndPeers(t *testing.T) {
+	cc := &dialOnlyClient{}
+	c := New(Config{Client: cc, Networks: []appnet.Type{appnet.TypeSkynet}})
+	t.Cleanup(func() {
+		_ = c.Close() //nolint:errcheck
+		cc.closeAll()
+	})
+
+	if n := c.Conns(); n != 0 {
+		t.Errorf("fresh controller Conns() = %d, want 0", n)
+	}
+	if p := c.Peers(); len(p) != 0 {
+		t.Errorf("fresh controller Peers() = %v, want empty", p)
+	}
+
+	peer, _ := cipher.GenerateKeyPair()
+	if err := c.SendRaw(context.Background(), peer, []byte("warm the conn")); err != nil {
+		t.Fatalf("SendRaw: %v", err)
+	}
+
+	if n := c.Conns(); n != 1 {
+		t.Errorf("Conns() = %d, want 1 after a dial", n)
+	}
+	peers := c.Peers()
+	if len(peers) != 1 || peers[0] != peer.Hex() {
+		t.Errorf("Peers() = %v, want [%s]", peers, peer.Hex())
+	}
+	if !c.HasConn(peer) {
+		t.Error("HasConn should agree with Peers")
+	}
+
+	// Close drops the cache, so /status stops advertising dead peers.
+	_ = c.Close() //nolint:errcheck
+	if n := c.Conns(); n != 0 {
+		t.Errorf("after Close, Conns() = %d, want 0", n)
+	}
+}
+
+// TestNoteInbound — transports that don't ride the framed read loop (the CXO
+// feed) call this so /status counters stay accurate for them too.
+func TestNoteInbound(t *testing.T) {
+	c := New(Config{})
+
+	before := c.Stats()
+	if before.InboundMsgs != 0 {
+		t.Fatalf("fresh controller already reports %d inbound", before.InboundMsgs)
+	}
+
+	c.NoteInbound()
+	c.NoteInbound()
+
+	got := c.Stats()
+	if got.InboundMsgs != 2 {
+		t.Errorf("InboundMsgs = %d after two NoteInbound calls, want 2", got.InboundMsgs)
+	}
+	if got.LastRxAt.IsZero() {
+		t.Error("NoteInbound should stamp LastRxAt so /status shows recent activity")
+	}
+}

--- a/pkg/skychat/xfer/accessors_test.go
+++ b/pkg/skychat/xfer/accessors_test.go
@@ -1,0 +1,42 @@
+// Package xfer pkg/skychat/xfer/accessors_test.go
+//
+// AddListener — the late-binding hook. Serve takes the listeners available at
+// startup; the skynet one only exists once the visor's networker registers, so
+// it joins afterwards through here. A nil listener is a no-op so the caller
+// doesn't have to branch on whether skynet came up.
+package xfer
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestAddListener_LateBinding(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := NewManager(Config{})
+
+	m.AddListener(ctx, nil) // must not panic or register anything
+	m.mu.Lock()
+	n := len(m.serving)
+	m.mu.Unlock()
+	if n != 0 {
+		t.Errorf("a nil listener registered %d entries, want 0", n)
+	}
+
+	lis := newMemListener()
+	m.AddListener(ctx, lis)
+	m.mu.Lock()
+	n = len(m.serving)
+	m.mu.Unlock()
+	if n != 1 {
+		t.Errorf("serving = %d after AddListener, want 1", n)
+	}
+
+	// Canceling unwinds the accept loop it spawned.
+	cancel()
+	_ = lis.Close() //nolint:errcheck
+	time.Sleep(50 * time.Millisecond)
+}


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes Part of #3559 

Fills the test gaps across skychat, working down a ranked list of untested code. 258 new tests in 20 files; 92 lines of production change.

  ## Coverage

  | Package | Before | After |
  |---|---|---|
  | `cmd/apps/skychat/commands` | 48.3% | **79.6%** |
  | `cmd/apps/skychat/group` | 30.4% | **74.7%** |
  | `cmd/apps/skychat/pairing` | 71.4% | **82.8%** |
  | `pkg/skychat/call/spectrogram` | 27.0% | **100%** |
  | `pkg/skychat/call` | 75.6% | **82.3%** |
  | `pkg/skychat/dm` | 75.7% | **80.9%** |
  | `pkg/skychat/xfer` | 71.6% | **74.7%** |

  ## Bugs found and fixed

  1. **`parsePK` accepted the empty string** — `cipher.PubKey.UnmarshalText("")` returns a nil error and the all-zero key, so an absent `peer_pk` reached `PairAdd`/`PairSend`/`SendRaw` as a real peer across 5 endpoints.
  2. **`spectrogram.Normalize` produced NaN** on a zero-width magnitude window, which the colormaps then fed to `uint8(NaN)` — implementation-defined in Go. Reachable from the UI (`AdjustMin`/`AdjustMax` clamp independently).
  3. **Data race in `pkg/cxo/treestore` Subscriber** (shared package): `Connect` writes `reconnectStop`/`reconnectKick` under one `sync.Once` while `Close` reads them under a *different* one. Hit on shutdown-during-connect.
  4. **`group.Session.Close` was not concurrency-safe** — read-then-write of `s.pub` with no lock, so two closers race.

  ## Testing

  New harnesses, all in-process: fake visor RPC, `net.Pipe`-backed DM/xfer transports, loopback TCP + noise for tcp-direct, loopback CXO for the cxo-over-tcp path, and a `dmsgtest` integration lane for `group.Manager` (gated on `-short`, so the unit lane stays fast).

  Security-relevant gates are **mutation-verified** — the tcp-direct whitelist (both directions), the group relay's allowlist, the pairing `Resume` reconnect, and the IPC read-loop `break` that once took down Windows CI.

  Verified: full suite green · `-race` clean · `-shuffle=on` repeated runs · `go vet` + `golangci-lint` clean · Windows and js/wasm cross-builds.