### PR TITLE
fix(wasm/dmsg): robust on-demand rendezvous — browser never falls back to TCP (+ live server discovery)

### DIFF
--- a/cmd/wasm-visor/selfprovider_js.go
+++ b/cmd/wasm-visor/selfprovider_js.go
@@ -8,7 +8,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -116,6 +118,45 @@ func (s visorSelf) SelfDmsgSessions() []byte {
 	if err != nil {
 		return nil
 	}
+	return b
+}
+
+// SelfDmsgConnectAll serves POST /visors/<pk>/dmsg/connect-all. A browser edge
+// boots with a session to only a couple of dmsg servers (sessions_count), so it
+// can't reach peers delegated to OTHER servers → "dmsg error 202 - cannot
+// connect to delegated server" (the skychat-reply + resolving-proxy failures).
+// This opens a session to every wss-reachable server the deployment config
+// advertises — concurrently, mirroring the boot seed loop (main.go) — so the
+// edge can rendezvous with any peer. Result mirrors native Visor.DmsgConnectAll.
+func (s visorSelf) SelfDmsgConnectAll() []byte {
+	res := map[string]interface{}{"total": 0, "already_connected": 0, "newly_connected": 0}
+	if dmsgC == nil {
+		b, _ := json.Marshal(res)
+		return b
+	}
+	// ConnectToAllServers enumerates every server in dmsg DISCOVERY (not just the
+	// 2 embedded seed servers) and EnsureSessions each over the browser's wss
+	// carrier — the same routine the native visor uses. Bounded so a slow/dead
+	// server can't hang the /api call forever.
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	r, err := dmsgC.ConnectToAllServers(ctx)
+	res["total"] = r.Total
+	res["already_connected"] = r.AlreadyConnected
+	res["newly_connected"] = r.NewlyConnected
+	if len(r.Failed) > 0 {
+		failed := make(map[string]string, len(r.Failed))
+		for pk, e := range r.Failed {
+			failed[pk.String()] = e
+		}
+		res["failed"] = failed
+	}
+	if err != nil {
+		res["error"] = err.Error()
+	}
+	vlog(fmt.Sprintf("dmsg connect-all: total=%d already=%d newly=%d failed=%d err=%v",
+		r.Total, r.AlreadyConnected, r.NewlyConnected, len(r.Failed), err))
+	b, _ := json.Marshal(res)
 	return b
 }
 

--- a/pkg/dmsg/dmsgclient/fallback_disc.go
+++ b/pkg/dmsg/dmsgclient/fallback_disc.go
@@ -133,13 +133,27 @@ func (f *fallbackDiscClient) DelEntry(ctx context.Context, entry *disc.Entry) er
 	return f.direct.DelEntry(ctx, entry)
 }
 
-// AvailableServers delegates to direct client
+// AvailableServers delegates to the direct client. This is the BOOT / normal
+// session-maintenance path — it must stay fast and never block on the live
+// discovery (which isn't reachable until dmsg is up), so it returns the seed set
+// the client already holds.
 func (f *fallbackDiscClient) AvailableServers(ctx context.Context) ([]*disc.Entry, error) {
 	return f.direct.AvailableServers(ctx)
 }
 
-// AllServers delegates to direct client
+// AllServers prefers the LIVE discovery (every registered server), falling back
+// to the direct client's seed set only on failure/empty. This is the "maximize
+// connectivity now" path (ConnectToAllServers) — not boot — so a live fetch is
+// safe and desired. Delegating solely to `direct` pinned a seeded client (the
+// wasm/browser edge, which boots from just 2 seed servers) to those seeds, so it
+// never learned the rest of the deployment and couldn't rendezvous with peers
+// delegated to other servers ("dmsg error 202 - cannot connect to delegated
+// server") — "connect to all servers" was a no-op. The discovery's own entry is
+// seed-cached, so this dial doesn't recurse.
 func (f *fallbackDiscClient) AllServers(ctx context.Context) ([]*disc.Entry, error) {
+	if srv, err := f.http.AllServers(ctx); err == nil && len(srv) > 0 {
+		return srv, nil
+	}
 	return f.direct.AllServers(ctx)
 }
 

--- a/pkg/dmsg/dmsgclient/seeded_disc.go
+++ b/pkg/dmsg/dmsgclient/seeded_disc.go
@@ -74,6 +74,17 @@ func (c *seededDiscClient) AvailableServers(ctx context.Context) ([]*disc.Entry,
 func (c *seededDiscClient) AllServers(ctx context.Context) ([]*disc.Entry, error) {
 	srv, err := c.real.AllServers(ctx)
 	if err != nil || len(srv) == 0 {
+		// /dmsg-discovery/all_servers can fail over the browser's dmsghttp path
+		// (the edge only ever exercises /available_servers for normal session
+		// establishment). Fall back to AvailableServers — the reachable set — so
+		// callers like ConnectToAllServers see the whole deployment instead of the
+		// 2 seed servers, which is what made "Connect to all servers" a no-op on
+		// the wasm visor and left it unable to rendezvous with peers on other servers.
+		if avail, aerr := c.real.AvailableServers(ctx); aerr == nil && len(avail) > 0 {
+			jslog(fmt.Sprintf("seeded.AllServers -> AvailableServers(%d) (all_servers err=%v n=%d)", len(avail), err, len(srv)))
+			return avail, nil
+		}
+		jslog(fmt.Sprintf("seeded.AllServers -> seeds(%d) (all_servers err=%v; available also empty)", len(c.seeds), err))
 		return c.seeds, nil
 	}
 	return srv, nil

--- a/pkg/wasmhv/self.go
+++ b/pkg/wasmhv/self.go
@@ -47,6 +47,13 @@ type SelfProvider interface {
 	// edge runs only the main client. nil when dmsg isn't up. Without it the node
 	// page's dmsg-sessions expander errors "Failed to fetch dmsg sessions".
 	SelfDmsgSessions() []byte
+	// SelfDmsgConnectAll opens a dmsg session to every wss-reachable server the
+	// tab knows (mirrors the native Visor.DmsgConnectAll), so a browser edge can
+	// rendezvous with peers delegated to servers it wasn't already on — the fix
+	// for "dmsg error 202 - cannot connect to delegated server" that breaks
+	// skychat replies + the resolving proxy. Returns the native
+	// DmsgConnectAllResult JSON ({total,already_connected,newly_connected,failed?}).
+	SelfDmsgConnectAll() []byte
 	// SelfRouterSettings returns the router knobs as pre-marshaled JSON in the
 	// native /visors/{pk}/router-settings shape
 	// ({force_local_routes,existing_tp_only,mux_routes,min_hops}). nil when the
@@ -140,6 +147,17 @@ func (c *Core) selfRoute(self SelfProvider, method, sub string, body []byte, que
 			return 200, body
 		}
 		return jsonResp(map[string]interface{}{})
+	case "dmsg/connect-all":
+		// POST "Connect to all servers": reach every known wss dmsg server so the
+		// edge can rendezvous with any peer. Native implements this; the wasm core
+		// used to 404, so the button errored in the browser.
+		if method != "POST" {
+			return 405, []byte(`{"error":"method not allowed"}`)
+		}
+		if body := self.SelfDmsgConnectAll(); body != nil {
+			return 200, body
+		}
+		return jsonResp(map[string]interface{}{"total": 0, "already_connected": 0, "newly_connected": 0})
 	case "router-settings":
 		// The Router Settings expander (force-local-routes / existing-tp-only /
 		// mux-routes / min-hops).

--- a/pkg/wasmhv/self_test.go
+++ b/pkg/wasmhv/self_test.go
@@ -31,6 +31,9 @@ func (f fakeSelf) SelfNetworkTransports(int) []byte    { return nil }
 func (f fakeSelf) SelfDmsgSessions() []byte {
 	return []byte(`{"main":{"pk":"","role":"main","count":1,"servers":[]}}`)
 }
+func (f fakeSelf) SelfDmsgConnectAll() []byte {
+	return []byte(`{"total":0,"already_connected":0,"newly_connected":0}`)
+}
 func (f fakeSelf) SelfRouterSettings() []byte {
 	return []byte(`{"force_local_routes":false,"existing_tp_only":false,"mux_routes":0,"min_hops":0}`)
 }


### PR DESCRIPTION
## The real bug (on-demand rendezvous)
dmsg is a rendezvous network: a visor holds a few sessions and, to reach a peer, opens an on-demand session to one of **that peer's** delegated servers — `DialStream` already iterates a peer's servers and tries the next on failure. A **browser/wss-only** client (`Carriers=[WT,WS]`) should never need to connect to every server. But the carrier logic fell back to **raw TCP** in places a tab can never satisfy:

- The per-carrier dial-failure fallbacks (WT/WS/QUIC) fell back to TCP whenever the entry had a TCP `Address`, gated on `Address==""` under the false assumption that js/wasm entries carry no TCP address. **Discovery-resolved entries DO**, so a failed wss dial became a futile `dial tcp …:30082: connection refused` that dead-ended the attempt → `dmsg error 202`.
- `pickCarrier`'s final fallback returned TCP/QUIC even for a client listing neither.

**Fix:** every TCP/QUIC fallback is gated on `hasCarrier()`. A wss-only client that can't reach a given server now fails **cleanly**, so `DialStream` moves on to the peer's **next** server over wss. Native clients (empty `Carriers`) keep the historic QUIC→TCP default. (`pkg/dmsg/dmsg/client_sessions.go`, `carrier_test.go`.)

## Supporting fix (live server discovery + connect-all)
The seeded discovery clients answered `AllServers` from the **direct (seed-only)** client, never the live discovery — so a browser edge never learned the deployment's other servers. `fallback_disc.go` (go-js/native) and `seeded_disc.go` (tinygo) now prefer the live discovery for `AllServers`; `AvailableServers` stays direct (boot path). Also implemented the previously-404'ing `POST /dmsg/connect-all` in the wasm core — a manual "maximize connectivity" action (e.g. for setup nodes), **not** the normal path. (`pkg/wasmhv`, `cmd/wasm-visor`.)

## Validation (live, wasm go variant, over CDP)
- On-demand, **NO connect-all**: futile `dial tcp` attempts and WS→TCP fallbacks dropped from several to **0**; skychat flows on just the **2 seed sessions** (198ms).
- As a harness, connect-all's 3 unreachable servers now surface honest `ws: dial "wss://…"` errors (their wss endpoints are genuinely down — a **deployment** issue to check) instead of masking them as TCP refusals.
- `go test ./pkg/dmsg/...` green.

Note: embedded wasm blobs re-embed at release. The scaling model is preserved — a visor holds a few sessions and reaches peers on demand, never "connect to everything."

🤖 Generated with [Claude Code](https://claude.com/claude-code)