### PR TITLE
Notification Hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -671,20 +671,30 @@ e2e-config: ## E2E. Regenerate visor configs from template and deployment config
 	@# reach http://visor-x:8001 and a browser can reach the published
 	@# host ports. Regenerating drops that: re-apply the skychat args in
 	@# all three configs afterwards (see the note printed below).
+	@#
+	@# --pty-rpc-exec is required by TestEnv_DmsgPtyExec: #3658 gated the
+	@# RPC-initiated `cli pty exec` path behind pty.allow_rpc_exec, OFF by
+	@# default. Every visor needs it, not just the hypervisor — the test's
+	@# negative case drives visor-a as the CALLER to prove the remote's
+	@# whitelist rejects it, and without the flag that call dies on the
+	@# gate instead, which is a different (and untested) rejection.
 	@echo "Regenerating E2E visor configs..."
 	@# visor-A: skychat node with hypervisor set to visor-B
 	SKYDEPLOY=docker/integration/services-config.json SKYENV=docker/integration/e2e.conf \
 		go run . cli config gen -f --nofetch --sk 42bca4df2f3189b28872d40e6c61aacd5e85b8e91f8fea65780af27c142419e5 \
 		-j 0348c941c5015a05c455ff238af2e57fb8f914c399aab604e9abb5b32b91a4c1fe \
+		--pty-rpc-exec \
 		-o docker/integration/visorA.json
 	@# visor-B: hypervisor
 	SKYDEPLOY=docker/integration/services-config.json SKYENV=docker/integration/e2e.conf \
 		go run . cli config gen -f --nofetch --sk da4f48916e99aa3de794bffe1b5ecd465335e38b55457a9f78b411eb8585e36f \
+		--pty-rpc-exec \
 		-i -o docker/integration/visorB.json
 	@# visor-C: skychat node with hypervisor set to visor-B
 	SKYDEPLOY=docker/integration/services-config.json SKYENV=docker/integration/e2e.conf \
 		go run . cli config gen -f --nofetch --sk 0e17cd505d81f998950e22864ae4692249124441bd9148b801f76f1595ac688f \
 		-j 0348c941c5015a05c455ff238af2e57fb8f914c399aab604e9abb5b32b91a4c1fe \
+		--pty-rpc-exec \
 		-o docker/integration/visorC.json
 	@echo "E2E visor configs regenerated."
 	@echo ""

--- a/cmd/apps/skychat/commands/osnotify.go
+++ b/cmd/apps/skychat/commands/osnotify.go
@@ -122,9 +122,29 @@ func logOSNotifyStartup() {
 // the suite from posting real notifications on a developer's desktop.
 func notifyOSInbound(title, body string) {
 	if !shouldNotifyOS(osNotify, uiCanNotify()) {
+		// The gate is the first place a "why did I get no notification?"
+		// investigation stops, and until now it left no trace at all — an
+		// attached-but-capable UI and a disabled flag look identical from
+		// outside. Debug only: this fires once per inbound message.
+		if chatLog != nil {
+			chatLog.WithField("os_notify", osNotify).
+				WithField("ui_capable", uiCanNotify()).
+				WithField("ui_clients", uiClientCount()).
+				Debug("skychat: host-OS notification suppressed")
+		}
 		return
 	}
 	go deliverNotification(title, body)
+}
+
+// uiClientCount reports how many browser UIs are attached, for the trace above:
+// "a UI is connected but says it cannot notify" and "no UI at all" are
+// different problems and the lease alone doesn't tell them apart.
+func uiClientCount() int {
+	if hub == nil {
+		return 0
+	}
+	return hub.clientCount()
 }
 
 // shouldNotifyOS is the no-double-fire rule, split out so it can be pinned

--- a/cmd/apps/skychat/commands/osnotify.go
+++ b/cmd/apps/skychat/commands/osnotify.go
@@ -15,11 +15,20 @@
 //     (permission denied / notifications turned off) it stops (or posts
 //     capable:false) and the lease goes stale, so the Go side resumes.
 //
-// Delivery is best-effort: on a headless visor (server / router / daemon) there
-// is no desktop session, osnotify.Available() is false, and this all no-ops.
+// Once past that gate skychat is done deciding: it publishes to the VISOR's
+// notification hub (pkg/visor/notifyhub.go) and the hub picks the sink that can
+// actually reach the user — a subscribed host app (the Android service), the
+// host OS notification center, or nothing at all on a headless visor. The split
+// is deliberate: the app knows *whether* an event deserves attention (focus,
+// mutes), the visor knows *where* the user can be reached.
 //
-// This is intentionally a thin, reusable seam — the same pkg/osnotify backend
-// is meant to serve vpn-client / skydex notifications later.
+// Note the gate no longer consults osnotify.Available(). It cannot: on Android
+// there is no desktop session, yet the host-app sink is exactly the one that
+// must fire. Dropping it is behavior-neutral on the desktop because
+// osnotify.Notify re-checks availability itself.
+//
+// --standalone is the one exception: with no visor there is no hub to publish
+// to, so that mode keeps posting to the host OS directly.
 package commands
 
 import (
@@ -105,19 +114,42 @@ func logOSNotifyStartup() {
 	}
 }
 
-// notifyOSInbound posts a desktop notification for an inbound message when no
-// capable UI is attached (see the file header). Best-effort + async: the exec
-// runs in a goroutine so a slow notifier never delays message handling.
+// notifyOSInbound surfaces an inbound message when no capable UI is attached
+// (see the file header). Best-effort + async: delivery runs in a goroutine so
+// neither an RPC round-trip nor a slow notifier delays message handling.
+//
+// `!osNotify` stays the first clause — TestMain flips that single flag to keep
+// the suite from posting real notifications on a developer's desktop.
 func notifyOSInbound(title, body string) {
-	if !osNotify || uiCanNotify() || !osnotify.Available() {
+	if !shouldNotifyOS(osNotify, uiCanNotify()) {
 		return
 	}
-	go func() {
-		err := osnotify.Notify(osnotify.Notification{Title: title, Body: body, AppName: "Skychat"})
-		if err != nil && !errors.Is(err, osnotify.ErrUnavailable) && appLog != nil {
-			appLog("skychat: os notification failed: %v", err)
-		}
-	}()
+	go deliverNotification(title, body)
+}
+
+// shouldNotifyOS is the no-double-fire rule, split out so it can be pinned
+// exhaustively by a test: the Go side delivers only when notifications are
+// enabled AND no UI that can show them itself is attached. A capable UI owns
+// the notification because it alone knows the focused thread and the mutes.
+func shouldNotifyOS(enabled, uiCapable bool) bool {
+	return enabled && !uiCapable
+}
+
+// deliverNotification hands the notification to the visor, which routes it to
+// whichever sink can reach the user. In --standalone mode there is no visor
+// (appCl is nil), so it posts to the host OS itself — today's path, unchanged.
+func deliverNotification(title, body string) {
+	if appCl != nil {
+		appCl.NotifyOrLog(title, body, "")
+		return
+	}
+	if !osnotify.Available() {
+		return
+	}
+	err := osnotify.Notify(osnotify.Notification{Title: title, Body: body, AppName: "Skychat"})
+	if err != nil && !errors.Is(err, osnotify.ErrUnavailable) && appLog != nil {
+		appLog("skychat: os notification failed: %v", err)
+	}
 }
 
 // notifPreviewLen bounds the message snippet shown in an OS notification.

--- a/cmd/apps/skychat/commands/osnotify_test.go
+++ b/cmd/apps/skychat/commands/osnotify_test.go
@@ -154,6 +154,41 @@ func TestUICanNotify(t *testing.T) {
 	}
 }
 
+// TestShouldNotifyOS pins the no-double-fire rule that survives the move to the
+// visor-global hub. skychat keeps deciding WHETHER (it alone knows the focused
+// thread and the per-thread mutes); the visor decides WHERE. If this gate ever
+// let both tiers through, one inbound message would surface twice — once from
+// the browser's Web Notification and once from whichever sink the hub picks.
+func TestShouldNotifyOS(t *testing.T) {
+	cases := []struct {
+		name             string
+		enabled, capable bool
+		want             bool
+	}{
+		{"capable UI attached → browser tier owns it", true, true, false},
+		{"no capable UI → Go side delivers", true, false, true},
+		{"notifications disabled", false, false, false},
+		{"disabled and a capable UI", false, true, false},
+	}
+	for _, c := range cases {
+		if got := shouldNotifyOS(c.enabled, c.capable); got != c.want {
+			t.Errorf("%s: shouldNotifyOS(%v, %v) = %v, want %v", c.name, c.enabled, c.capable, got, c.want)
+		}
+	}
+}
+
+// TestNotifyOSInboundRespectsDisableFlag guards the TestMain contract: the
+// suite flips the single osNotify flag to keep handleConn-driven tests from
+// posting real desktop notifications, so that flag must remain the first and
+// sufficient short-circuit.
+func TestNotifyOSInboundRespectsDisableFlag(t *testing.T) {
+	if osNotify {
+		t.Fatal("TestMain must leave osNotify=false, or the suite pops real notifications")
+	}
+	// Must be inert regardless of lease state.
+	notifyOSInbound("alice", "hi")
+}
+
 func TestShortHexPK(t *testing.T) {
 	pk, _ := cipher.GenerateKeyPair()
 	hex := pk.Hex()

--- a/cmd/apps/skychat/commands/static/index.html
+++ b/cmd/apps/skychat/commands/static/index.html
@@ -1751,6 +1751,31 @@
     .notif-perm { font-size: 13px; color: var(--text-secondary); padding: 10px 0; }
     .notif-perm.granted { color: var(--accent-green); }
     .notif-perm.denied { color: var(--accent-orange); }
+    .notif-allow-btn { display: inline-block; margin-top: 8px; padding: 6px 14px; font-size: 13px; }
+
+    /* First-run notification-permission nudge (sidebar header). */
+    .notif-nudge {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 10px;
+      padding: 8px 10px;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+    }
+    .notif-nudge .nn-text { flex: 1; min-width: 0; font-size: 12px; color: var(--text-secondary); line-height: 1.35; }
+    .notif-nudge .nn-allow {
+      flex-shrink: 0; padding: 5px 12px; font-size: 12px; font-weight: 600;
+      color: #fff; background: var(--accent-blue);
+      border: none; border-radius: 6px; cursor: pointer;
+    }
+    .notif-nudge .nn-allow:hover { filter: brightness(1.1); }
+    .notif-nudge .nn-dismiss {
+      flex-shrink: 0; padding: 0 4px; font-size: 16px; line-height: 1;
+      color: var(--text-muted); background: none; border: none; cursor: pointer;
+    }
+    .notif-nudge .nn-dismiss:hover { color: var(--text-primary); }
     .notif-muted-title { font-size: 12px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .04em; margin: 14px 0 4px; }
     .notif-muted-list { max-height: 160px; overflow-y: auto; }
     .notif-muted-empty { font-size: 13px; color: var(--text-muted); padding: 6px 0; }
@@ -1843,6 +1868,15 @@
           <span id="statusText">Connected</span>
         </div>
         <button class="icon-btn" style="margin-left:auto" onclick="app.openNotifSettings()" title="Notification settings" aria-label="Notification settings">&#x1F514;</button>
+      </div>
+      <!-- First-run permission nudge. Hidden by default and only shown by
+           _refreshNotifNudge when notifications are enabled but the browser has
+           never been asked — otherwise that state is completely invisible and
+           every notification is silently dropped. -->
+      <div id="notifNudge" class="notif-nudge" style="display:none">
+        <span class="nn-text">🔔 Allow notifications to be alerted about new messages.</span>
+        <button class="nn-allow" onclick="app.allowNotifFromNudge()">Allow</button>
+        <button class="nn-dismiss" onclick="app.dismissNotifNudge()" title="Don't ask again" aria-label="Dismiss">&times;</button>
       </div>
       <form class="recipient-form" onsubmit="app.createRecipient(this); return false;">
         <input id="destinationPk" type="text" placeholder="Enter public key..." />
@@ -2365,6 +2399,8 @@
         // disabled) the lease expires (~45s) and the Go side takes over.
         this._reportNotifCapability();
         setInterval(() => { if (this._notifCapable()) this._reportNotifCapability(); }, 20000);
+        // Surface the permission banner if this browser was never asked.
+        this._refreshNotifNudge();
         // Voice calls: the visor owns the call manager + host audio; this UI is a
         // control surface that polls /voice/{incoming,active} and drives
         // /voice/{call,answer,decline,hangup,mute,levels}. Auto-hides when voice
@@ -6254,9 +6290,10 @@
             enabled: raw.enabled !== false, // default ON
             preview: raw.preview !== false, // default ON (show text snippet)
             muted: (raw.muted && typeof raw.muted === 'object') ? raw.muted : {},
+            nudged: raw.nudged === true, // user dismissed the permission prompt banner
           };
         } catch (e) {
-          return { enabled: true, preview: true, muted: {} };
+          return { enabled: true, preview: true, muted: {}, nudged: false };
         }
       }
 
@@ -6265,6 +6302,7 @@
           enabled: this.notif.enabled,
           preview: this.notif.preview,
           muted: this.notif.muted,
+          nudged: this.notif.nudged,
         }));
       }
 
@@ -6318,6 +6356,58 @@
       openNotifSettings() {
         this._renderNotifModal();
         document.getElementById('notifModal').classList.add('visible');
+        // Opening the bell is a user gesture, so the browser lets us ask here.
+        // Without this the default-ON preference is a dead end: the permission
+        // request only ever fired on an off->on flip of a switch that is
+        // already on, so a fresh profile was never prompted and every
+        // notification was silently dropped by _shouldNotify.
+        this._ensureNotifPermission();
+      }
+
+      // _ensureNotifPermission asks the browser for permission when the user
+      // wants notifications but has never been asked. MUST be called from a
+      // user gesture (a click) — browsers ignore or quiet-UI an unsolicited
+      // prompt. Safe to call repeatedly: it is a no-op once the browser has
+      // made a decision either way.
+      _ensureNotifPermission() {
+        if (!this._notifSupported() || !this.notif.enabled) return;
+        if (Notification.permission !== 'default') return;
+        Notification.requestPermission().then(() => {
+          this._renderNotifModal();
+          this._refreshNotifNudge();
+          // Tell the server immediately rather than waiting out the lease, so
+          // the visor stops posting host-OS notifications the moment this UI
+          // becomes capable.
+          this._reportNotifCapability();
+        }).catch(() => {});
+      }
+
+      // _refreshNotifNudge shows or hides the first-run banner. It appears only
+      // when notifications are wanted but unasked-for — the exact state that
+      // used to be invisible — and a user who never opens the bell would
+      // otherwise never discover it.
+      _refreshNotifNudge() {
+        const el = document.getElementById('notifNudge');
+        if (!el) return;
+        const show = this._notifSupported() &&
+                     this.notif.enabled &&
+                     !this.notif.nudged &&
+                     Notification.permission === 'default';
+        el.style.display = show ? 'flex' : 'none';
+      }
+
+      // allowNotifFromNudge is the banner's Allow button: a direct click, which
+      // is the cleanest possible gesture for the browser prompt.
+      allowNotifFromNudge() {
+        this._ensureNotifPermission();
+      }
+
+      // dismissNotifNudge hides the banner for good on this browser. The bell
+      // still offers the prompt, so nothing becomes unreachable.
+      dismissNotifNudge() {
+        this.notif.nudged = true;
+        this._saveNotifPrefs();
+        this._refreshNotifNudge();
       }
 
       _renderNotifModal() {
@@ -6338,8 +6428,17 @@
             perm.className = 'notif-perm denied';
             perm.textContent = 'Blocked by the browser. Allow notifications for this site in your browser settings to receive alerts.';
           } else {
+            // permission === 'default'. The old copy read "Turn on 'Enable
+            // notifications' to grant browser permission" while that switch was
+            // already on — an instruction the user could not follow. Give them
+            // a button instead; openNotifSettings also prompts on its own.
             perm.className = 'notif-perm';
-            perm.textContent = 'Turn on “Enable notifications” to grant browser permission.';
+            perm.textContent = 'This browser hasn’t been asked yet — notifications won’t appear until you allow them. ';
+            const btn = document.createElement('button');
+            btn.className = 'btn btn-secondary notif-allow-btn';
+            btn.textContent = 'Allow notifications';
+            btn.onclick = () => this._ensureNotifPermission();
+            perm.appendChild(btn);
           }
           enabledBox.disabled = false;
           enabledBox.checked = this.notif.enabled;
@@ -6376,12 +6475,11 @@
         this._saveNotifPrefs();
         // Enabling with no decision yet → ask the browser (this runs inside the
         // checkbox's user gesture, so the prompt is allowed).
-        if (on && this._notifSupported() && Notification.permission === 'default') {
-          Notification.requestPermission().then(() => { this._renderNotifModal(); this._reportNotifCapability(); });
-        }
+        this._ensureNotifPermission();
         // Reflect the new capability to the server immediately (esp. disabling,
         // so the Go side can take over without waiting for the lease to lapse).
         this._reportNotifCapability();
+        this._refreshNotifNudge();
       }
 
       toggleNotifPreview(on) {

--- a/cmd/apps/skychat/pairing/pair.go
+++ b/cmd/apps/skychat/pairing/pair.go
@@ -256,13 +256,13 @@ func Open(cfg Config) (*Pair, error) {
 //
 // # Why this hangs off Send instead of a timer
 //
-// The announcement is a CXO write, and pkg/cxo/skyobject has a
+// The announcement is a CXO write, and pkg/cxo/skyobject HAD a
 // lock-order inversion between a write and a fill on the SAME node:
-// Cache.Get holds Cache.mx and blocks on bbolt's writer lock, while
-// Cache.WithBatch (reached only from the publisher's tree walk) holds
-// bbolt's writer lock and blocks on Cache.mx. A pair puts its publisher
+// Cache.Get held Cache.mx and blocked on bbolt's writer lock, while
+// Cache.WithBatch (reached only from the publisher's tree walk) held
+// bbolt's writer lock and blocked on Cache.mx. A pair puts its publisher
 // and its subscriber on one node by design, so an announcement
-// published while the peer's tree is filling can wedge the node
+// published while the peer's tree was filling could wedge the node
 // permanently — the publish loop stops clearing its dirty flag and
 // every later send is silently lost.
 //
@@ -270,17 +270,16 @@ func Open(cfg Config) (*Pair, error) {
 // pairing suite ran 6/6 green, and with it a background announce timer
 // hung the suite roughly one run in four.
 //
-// Riding Send is what makes this safe by construction rather than by
-// timing. The Put lands in the same publisher batch as the message, so
+// That inversion is fixed — WithBatch now takes Cache.mx before the
+// writer, pinned by TestWithBatch_DoesNotInvertCacheAndWriterLocks — so
+// a timer is no longer unsafe. Riding Send is kept anyway, on its own
+// merits: the Put lands in the same publisher batch as the message, so
 // the pair performs exactly as many publishes as it did before this
-// feature existed — no new window is opened. The cost is that forward
-// secrecy engages once each side has sent at least once (the first
-// message from each side goes out under the legacy static key), which
-// for a conversation is the normal case.
-//
-// Removing this workaround is a one-line change once the CXO lock order
-// is fixed; the announcement can then go on a timer and cover pairs
-// where one side never speaks.
+// feature existed, and no timing assumption is involved at all. The
+// cost is that forward secrecy engages once each side has sent at least
+// once (the first message from each side goes out under the legacy
+// static key), which for a conversation is the normal case. A timer
+// would only add value for pairs where one side never speaks.
 func (p *Pair) maybeAnnounce(now time.Time) {
 	if p.pub == nil {
 		return

--- a/cmd/apps/skydex-client/commands/skydex-client.go
+++ b/cmd/apps/skydex-client/commands/skydex-client.go
@@ -32,6 +32,23 @@ import (
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
+// Notification coalescing tags. Events sharing a tag replace one another in a
+// sink that supports it (an Android notification tag) instead of stacking.
+//
+// Only two events in this wrapper are worth notifying, because only these
+// reach the skywire side at all: the market dial (which the wrapper performs,
+// and which can outlive the user's attention because dmsg is slow) and an
+// abnormal engine exit. Everything a trader would actually want —
+// order filled, trade executed — is invisible here: the market protocol is
+// strictly request/response with no unsolicited frames, the engine exposes no
+// event stream, and order status is discovered only by the UI polling in the
+// browser. A disconnect is equally invisible: the engine closes the conn
+// internally and never tells the wrapper.
+const (
+	notifyTagMarket    = "skydex-market"
+	notifyTagLifecycle = "skydex-lifecycle"
+)
+
 var (
 	// uiAddr is the localhost address the trading UI is served on.
 	uiAddr string
@@ -88,6 +105,9 @@ type appnetDialer struct {
 func (d appnetDialer) Dial(ref string) (*skymarket.Conn, error) {
 	var pk cipher.PubKey
 	if err := pk.UnmarshalText([]byte(ref)); err != nil {
+		// Deliberately NOT notified: parsing is instantaneous, so the user is
+		// still looking at the connect form they just submitted, and the engine
+		// already renders this error inline there.
 		return nil, errors.New("invalid market public key")
 	}
 	raw, err := d.appCl.Dial(appnet.Addr{
@@ -96,9 +116,25 @@ func (d appnetDialer) Dial(ref string) (*skymarket.Conn, error) {
 		Port:   d.marketPort,
 	})
 	if err != nil {
+		// The transport failed — worth surfacing because a connect can be
+		// started from the UI and then left (backgrounded on a phone), so
+		// nobody may be looking at the screen when it fails.
+		d.appCl.NotifyOrLog("SkyDEX", "Could not reach market "+shortPK(ref), notifyTagMarket)
 		return nil, fmt.Errorf("dial market: %w", err)
 	}
+	// Same tag as the failure above so a sink that coalesces (Android) replaces
+	// a stale "could not reach" rather than stacking a second entry.
+	d.appCl.NotifyOrLog("SkyDEX", "Connected to market "+shortPK(ref), notifyTagMarket)
 	return skymarket.NewConn(raw), nil
+}
+
+// shortPK renders a market public key as a compact 8…4 label for a
+// notification body — a full 66-char hex key is unreadable in a toast.
+func shortPK(pk string) string {
+	if len(pk) >= 14 {
+		return pk[:8] + "…" + pk[len(pk)-4:]
+	}
+	return pk
 }
 
 // RunSkydexClient runs the skydex-client app: it serves the trading UI (from the
@@ -161,6 +197,19 @@ func RunSkydexClient(ctx context.Context, args []string) error {
 	case err := <-errCh:
 		if err != nil {
 			appCl.LogError("skydex-client engine stopped: %v", err)
+		}
+		// The trigger is the engine returning while we still wanted it running
+		// — NOT err != nil. The engine swallows its own fatal errors (a UI-port
+		// bind failure is logged and Run still returns nil), so gating on err
+		// would make this dead code and the app would vanish seconds after
+		// start looking like a clean exit. ctx.Err() is the honest test: nil
+		// means nobody asked it to stop. It also settles the shutdown race —
+		// when ctx is canceled both this arm and ctx.Done() are ready, and if
+		// select happens to pick this one we must stay quiet.
+		//
+		// Body stays generic: engine errors can carry local paths.
+		if ctx.Err() == nil {
+			appCl.NotifyOrLog("SkyDEX", "Trading client stopped unexpectedly", notifyTagLifecycle)
 		}
 	case <-ctx.Done():
 		appCl.LogInfo("Context canceled, shutting down...")

--- a/cmd/apps/skydex-client/commands/skydex-client.go
+++ b/cmd/apps/skydex-client/commands/skydex-client.go
@@ -37,8 +37,9 @@ import (
 //
 // Only two events in this wrapper are worth notifying, because only these
 // reach the skywire side at all: the market dial (which the wrapper performs,
-// and which can outlive the user's attention because dmsg is slow) and an
-// abnormal engine exit. Everything a trader would actually want —
+// and only once it has outrun the user's attention — see
+// notifyAttentionWindow) and an abnormal engine exit. Everything a trader
+// would actually want —
 // order filled, trade executed — is invisible here: the market protocol is
 // strictly request/response with no unsolicited frames, the engine exposes no
 // event stream, and order status is discovered only by the UI polling in the
@@ -110,22 +111,46 @@ func (d appnetDialer) Dial(ref string) (*skymarket.Conn, error) {
 		// already renders this error inline there.
 		return nil, errors.New("invalid market public key")
 	}
+	started := time.Now()
 	raw, err := d.appCl.Dial(appnet.Addr{
 		Net:    appnet.TypeDmsg,
 		PubKey: pk,
 		Port:   d.marketPort,
 	})
+	waited := time.Since(started)
+
 	if err != nil {
-		// The transport failed — worth surfacing because a connect can be
-		// started from the UI and then left (backgrounded on a phone), so
-		// nobody may be looking at the screen when it fails.
-		d.appCl.NotifyOrLog("SkyDEX", "Could not reach market "+shortPK(ref), notifyTagMarket)
+		d.notifyIfUnwatched(waited, "Could not reach market "+shortPK(ref))
 		return nil, fmt.Errorf("dial market: %w", err)
 	}
-	// Same tag as the failure above so a sink that coalesces (Android) replaces
-	// a stale "could not reach" rather than stacking a second entry.
-	d.appCl.NotifyOrLog("SkyDEX", "Connected to market "+shortPK(ref), notifyTagMarket)
+	d.notifyIfUnwatched(waited, "Connected to market "+shortPK(ref))
 	return skymarket.NewConn(raw), nil
+}
+
+// notifyAttentionWindow is how long a user-initiated operation must run before
+// its outcome is worth a notification.
+//
+// It stands in for the focus signal this app cannot have. skychat suppresses
+// notifications for the thread you are looking at by asking its own UI; the
+// SkyDEX UI belongs to the vendored engine, so this wrapper cannot ask it
+// anything. What it does know is that a market dial is ALWAYS user-initiated —
+// the engine never connects on its own — so for the first few seconds after the
+// click the user is still watching the connect form, where the engine already
+// renders the outcome inline. A notification then is pure duplication.
+//
+// Past this window the dial has taken long enough (dmsg can be slow) that the
+// user may well have switched away, and the outcome becomes worth raising.
+const notifyAttentionWindow = 3 * time.Second
+
+// notifyIfUnwatched publishes body only when the operation ran long enough that
+// the user has plausibly stopped watching. All market events share one tag so a
+// sink that coalesces (an Android notification tag) replaces a stale entry
+// rather than stacking a second one.
+func (d appnetDialer) notifyIfUnwatched(waited time.Duration, body string) {
+	if waited < notifyAttentionWindow {
+		return
+	}
+	d.appCl.NotifyOrLog("SkyDEX", body, notifyTagMarket)
 }
 
 // shortPK renders a market public key as a compact 8…4 label for a

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1200,7 +1200,7 @@ func minHopsValue() uint16 {
 	if genMinHops < 0 {
 		return 0
 	}
-	return uint16(genMinHops)
+	return uint16(genMinHops) //nolint:gosec
 }
 
 // configureRouting sets up routing configuration on conf, preserving MinHops

--- a/cmd/skywire-cli/commands/hv/notify.go
+++ b/cmd/skywire-cli/commands/hv/notify.go
@@ -1,0 +1,235 @@
+// Package clihv cmd/skywire-cli/commands/hv/notify.go c4-vis-cli
+//
+// The desktop host-app sink for the visor-global notification hub: subscribes
+// to a visor's notification stream and posts each event to THIS machine's
+// notification center.
+//
+// It exists because "the visor" and "the user" are often not the same machine:
+//
+//   - The visor runs in a container (the docker e2e env) or on a headless box.
+//     pkg/osnotify finds no desktop session there and the hub's host-OS tier is
+//     dead, so notifications silently drop no matter what the apps publish.
+//   - You browse a visor's app UI over the LAN. Plain http on a non-loopback
+//     address is not a secure context, so the browser's Notification API is
+//     unavailable and the UI can't alert you either — and the visor's own
+//     host-OS notification would pop on the visor's machine, where nobody is
+//     sitting.
+//
+// Run this where the user actually is and both gaps close. It is the desktop
+// counterpart of the Android foreground service, speaking the same SSE contract
+// (see pkg/visor/hypervisor_handlers_notify.go), which is exactly what the
+// hub's host-app tier was designed for.
+//
+// While it is connected the visor stops posting its own host-OS notifications
+// (subscriber presence outranks the OS sink), so events are never doubled.
+package clihv
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/osnotify"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+var (
+	notifyAddr      string
+	notifyUser      string
+	notifyPass      string
+	notifyPrintOnly bool
+)
+
+func init() {
+	notifyCmd.Flags().StringVarP(&notifyAddr, "addr", "a", "http://127.0.0.1:8000", "hypervisor API address")
+	notifyCmd.Flags().StringVarP(&notifyUser, "user", "u", "", "username, when the hypervisor has auth enabled")
+	notifyCmd.Flags().StringVarP(&notifyPass, "pass", "p", "", "password, when the hypervisor has auth enabled")
+	notifyCmd.Flags().BoolVar(&notifyPrintOnly, "print", false, "print events instead of posting them to the OS (for testing/headless use)")
+	RootCmd.AddCommand(notifyCmd)
+}
+
+var notifyCmd = &cobra.Command{
+	Use:   "notify",
+	Short: "Show a visor's app notifications on this machine",
+	Long: `Subscribe to a visor's notification stream and post each event to this
+machine's notification center.
+
+Use it when the visor is somewhere the user is not — a container, a headless
+box, or a machine you only reach over the network. While it is connected the
+visor stops posting its own host-OS notifications, so nothing is doubled.
+
+Examples:
+  skywire-cli hv notify
+  skywire-cli hv notify --addr http://127.0.0.1:8000
+  skywire-cli hv notify --addr https://hv.example.com -u admin -p secret
+  skywire-cli hv notify --print          # just print, don't touch the OS`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		// Ctrl-C must unsubscribe promptly: a lingering subscriber keeps the
+		// visor's own host-OS sink suppressed.
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
+		base := strings.TrimSuffix(notifyAddr, "/")
+
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			return fmt.Errorf("cookie jar: %w", err)
+		}
+		// No client Timeout: this is an endless stream, and a timeout here
+		// would sever it exactly like the server-side one the endpoint had to
+		// opt out of.
+		client := &http.Client{Jar: jar}
+
+		if notifyUser != "" {
+			if err := notifyLogin(ctx, client, base); err != nil {
+				return err
+			}
+		}
+
+		if !notifyPrintOnly && !osnotify.Available() {
+			cmd.PrintErrln("warning: no desktop notification backend on THIS machine either — " +
+				"notifications will be printed only. Run this where you have a desktop session.")
+			notifyPrintOnly = true
+		}
+
+		cmd.Printf("Listening for notifications from %s (Ctrl-C to stop)\n", base)
+
+		// Reconnect forever: a visor restart, a laptop sleeping, or a dropped
+		// link should not end the session. Backoff keeps a down visor from
+		// becoming a busy loop.
+		backoff := time.Second
+		for ctx.Err() == nil {
+			err := notifyStream(ctx, client, base, cmd)
+			if ctx.Err() != nil {
+				break
+			}
+			if err != nil {
+				cmd.PrintErrf("stream ended (%v); retrying in %s\n", err, backoff)
+			}
+			select {
+			case <-ctx.Done():
+			case <-time.After(backoff):
+			}
+			if backoff < 30*time.Second {
+				backoff *= 2
+			}
+		}
+		cmd.Println("Stopped.")
+		return nil
+	},
+}
+
+// notifyLogin exchanges credentials for the session cookie the stream endpoint
+// requires when the hypervisor runs with auth enabled. The cookie lands in the
+// client's jar, so the subsequent GET carries it automatically.
+func notifyLogin(ctx context.Context, client *http.Client, base string) error {
+	body, err := json.Marshal(map[string]string{"username": notifyUser, "password": notifyPass})
+	if err != nil {
+		return fmt.Errorf("encode login: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+"/api/login", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("login request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("login: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // response body close on a short request
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("login failed: %s", resp.Status)
+	}
+	return nil
+}
+
+// notifyEvent mirrors the SSE wire shape the hub emits.
+type notifyEvent struct {
+	App   string `json:"app"`
+	Title string `json:"title"`
+	Body  string `json:"body"`
+	Tag   string `json:"tag"`
+}
+
+// notifyStream holds one connection open, posting every event it receives. It
+// returns when the stream ends, the context is canceled, or the connection
+// fails — the caller reconnects.
+func notifyStream(ctx context.Context, client *http.Client, base string, cmd *cobra.Command) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/api/notifications/stream", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck // stream teardown
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusUnauthorized {
+			return fmt.Errorf("unauthorized — the hypervisor has auth enabled; pass --user/--pass")
+		}
+		return fmt.Errorf("unexpected status %s", resp.Status)
+	}
+
+	// Long lines are possible (a title plus a 200-char body), so give the
+	// scanner room rather than letting it error out mid-stream.
+	sc := bufio.NewScanner(resp.Body)
+	sc.Buffer(make([]byte, 0, 4096), 64*1024)
+
+	for sc.Scan() {
+		line := sc.Text()
+		// Comments (": ping") and the blank line between events carry no data.
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var ev notifyEvent
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &ev); err != nil {
+			continue // a frame we don't understand is not worth dying over
+		}
+		deliverNotifyEvent(ev, cmd)
+	}
+	if err := sc.Err(); err != nil {
+		return err
+	}
+	return fmt.Errorf("closed by server")
+}
+
+// deliverNotifyEvent posts one event to this machine, or prints it in --print
+// mode. The title carries the app name so a user can tell at a glance which app
+// spoke — the OS sink's own app label is not always visible.
+func deliverNotifyEvent(ev notifyEvent, cmd *cobra.Command) {
+	title := ev.Title
+	if title == "" {
+		title = "Skywire"
+	}
+	if notifyPrintOnly {
+		cmd.Printf("%s  [%s] %s — %s\n", time.Now().Format("15:04:05"), ev.App, title, ev.Body)
+		return
+	}
+	err := osnotify.Notify(osnotify.Notification{
+		Title: title,
+		Body:  ev.Body,
+		// Same mapping the visor's own host-OS sink uses, so an event looks
+		// identical whether it was posted locally or bridged from elsewhere.
+		AppName: skyenv.AppDisplayName(ev.App),
+	})
+	if err != nil {
+		cmd.PrintErrf("could not post notification: %v\n", err)
+	}
+}

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -531,7 +531,9 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr string) (cipher.PubKey, 
 	// browser can't); in-process apps connect over net.Pipe. addr "" → no TCP
 	// ingress.
 	vlog("proc_manager: New…")
-	pm, err := appserver.NewProcManager(mLog, &appdisc.Factory{}, eb, "", "")
+	// nil notification hub: a browser tab has no desktop notification centre
+	// and no host app subscribed over SSE, so app notifications simply drop.
+	pm, err := appserver.NewProcManager(mLog, &appdisc.Factory{}, eb, nil, "", "")
 	if err != nil {
 		return pk, fmt.Errorf("proc manager: %w", err)
 	}

--- a/docker/integration/visorA.json
+++ b/docker/integration/visorA.json
@@ -24,7 +24,8 @@
     "dmsg_port": 22,
     "cli_network": "unix",
     "cli_address": "/tmp/dmsgpty.sock",
-    "whitelist": []
+    "whitelist": [],
+    "allow_rpc_exec": true
   },
   "ui_server": {
     "enable": false,

--- a/docker/integration/visorB.json
+++ b/docker/integration/visorB.json
@@ -24,7 +24,8 @@
     "dmsg_port": 22,
     "cli_network": "unix",
     "cli_address": "/tmp/dmsgpty.sock",
-    "whitelist": []
+    "whitelist": [],
+    "allow_rpc_exec": true
   },
   "ui_server": {
     "enable": false,

--- a/docker/integration/visorC.json
+++ b/docker/integration/visorC.json
@@ -24,7 +24,8 @@
 		"dmsg_port": 22,
 		"cli_network": "unix",
 		"cli_address": "/tmp/dmsgpty.sock",
-		"whitelist": []
+		"whitelist": [],
+		"allow_rpc_exec": true
 	},
 	"ui_server": {
 		"enable": false,

--- a/docs/app_implement_guidance.md
+++ b/docs/app_implement_guidance.md
@@ -197,21 +197,91 @@ if err != nil {
 ```
 
 ### 5.3 User Notifications
-When something happens that deserves the user's attention while they are *not* looking at your app, publish a notification. Your app decides **whether** to notify; the visor decides **where** it lands — a subscribed host application (the Android service), the host OS notification centre, or nowhere at all on a headless visor. You write no OS-specific code and no platform checks.
+
+When something happens that deserves the user's attention while they are *not* looking at your app, publish a notification:
 
 ```go
-// Best-effort and nil-safe: works in standalone mode, no-ops on a headless visor.
+// Best-effort and nil-safe: no-ops in standalone mode and on a headless visor.
 appCl.NotifyOrLog("MyApp", "Transfer finished", "myapp-transfers")
 ```
 
-The third argument is an optional coalescing tag: events sharing a tag replace one another in sinks that support it (an Android notification tag) instead of stacking. Pass `""` for no coalescing.
+That is the entire API. No OS-specific code, no platform checks, no `runtime.GOOS`.
 
-Two rules worth internalising:
+#### The split: you decide *whether*, the visor decides *where*
 
-- **Only your app knows whether to notify.** If your app has its own UI and it is open and focused, it should surface the event itself and *not* publish — otherwise the user sees it twice. `cmd/apps/skychat/commands/osnotify.go` shows the pattern (a capability lease the UI heartbeats).
-- **Notify sparingly.** Something the user just triggered in a visible UI is noise; a failure, or a result arriving long after they walked away, is not.
+This division is the whole design, and getting it wrong is the main way apps misbehave.
 
-You never set the app name: the visor stamps it from your proc's identity, so an app cannot publish under another app's name.
+**Your app decides whether.** Only you know what the user has muted, which screen they have open, and whether this event matters. Nobody else can make that call for you.
+
+**The visor decides where.** It routes to the first delivery path that can actually reach the user:
+
+| | Sink | Wins when |
+|---|---|---|
+| a | An attached UI holding a capability lease | that UI will surface it itself |
+| b | A subscribed host app (Android service, `skywire-cli hv notify`) | one is connected |
+| c | The host OS notification centre (`pkg/osnotify`) | there is a desktop session |
+| d | Dropped | headless — the normal case for most of the fleet |
+
+First match wins, so an event surfaces **exactly once**. You never think about this — but knowing it exists explains why you must not double up at your end.
+
+#### The rules
+
+**1. Never notify about something the user is already looking at.** If your app has a UI and it is open and focused, that UI should show the event and your app should stay quiet. Otherwise the user gets it twice.
+
+**2. Notify sparingly.** A result the user is waiting for, on screen, is noise. A failure, or a result arriving long after they walked away, is not. When unsure, don't — a notification the user didn't want costs far more trust than one they didn't get.
+
+**3. Never set the app name.** The visor stamps it from your proc's identity and overwrites whatever you send. This is deliberate: an app must not be able to publish under another app's name.
+
+**4. Bodies may be untrusted, and are never logged.** If the body contains peer-supplied text, that is fine — it is passed to every sink as data, never as anything executable. Do not log it yourself either.
+
+**5. Use a tag for anything that supersedes.** Events sharing a tag *replace* one another in sinks that support it (an Android notification tag) instead of stacking. Status transitions for one connection should share a tag; independent events should not. `""` means no coalescing.
+
+#### Two worked patterns for rule 1
+
+Your app knows *something* about whether the user is watching. Use whatever signal you actually have:
+
+**If you own your UI — ask it.** skychat serves its own UI, so the UI heartbeats "I can show notifications myself" and the Go side stays silent while that lease is fresh:
+
+```go
+// cmd/apps/skychat/commands/osnotify.go
+func shouldNotifyOS(enabled, uiCapable bool) bool { return enabled && !uiCapable }
+```
+
+The lease must expire (skychat: 45s) so a UI that dies without saying goodbye can't silence notifications forever, and it must mean *"a UI that will really surface this"* — not merely "a UI is connected". A browser tab with notifications blocked, or a backgrounded mobile WebView, can show nothing and must stop claiming capability.
+
+**If you don't own your UI — use time.** skydex-client's UI belongs to a vendored engine it cannot query. But a market dial is always user-initiated, so for the first few seconds the user is still watching the form where the engine already renders the result:
+
+```go
+// cmd/apps/skydex-client/commands/skydex-client.go
+const notifyAttentionWindow = 3 * time.Second
+
+func (d appnetDialer) notifyIfUnwatched(waited time.Duration, body string) {
+    if waited < notifyAttentionWindow {
+        return
+    }
+    d.appCl.NotifyOrLog("SkyDEX", body, notifyTagMarket)
+}
+```
+
+#### Don't promise what you can't observe
+
+Before adding a notification, confirm the event actually reaches your Go code. skydex-client would love to announce "order filled", but the market protocol is strictly request/response with no unsolicited frames and order status is discovered only by the browser polling — so no Go layer ever learns it. A notification for an event you cannot observe is dead code that reads like a feature.
+
+Equally, check the *trigger* is real. An `if err != nil` guard is worthless if the function it wraps can only ever return `nil`.
+
+#### Testing
+
+Notifications are invisible on a headless box and in CI, so don't test through the OS. Two options:
+
+- **Unit-test the decision, not the delivery.** The interesting logic is your "should I notify?" gate — a pure function is trivial to pin exhaustively.
+- **Watch the stream.** `skywire-cli hv notify --print` subscribes to the visor and prints every event, which works headlessly and in containers:
+
+```
+$ skywire-cli hv notify --print
+20:17:49  [skychat] 024ec474…58c7 — hello there
+```
+
+Keep a global disable flag (skychat's `--os-notify`) that your `TestMain` can switch off, so a test suite never posts real notifications on a developer's desktop.
 
 ### 5.4 Advanced Dialing Options
 For high-bandwidth or high-latency scenarios, you can use `DialWithOptions` to request multi-path routing (`muxRoutes`) or enforce a minimum number of hops for privacy (`minHops`).

--- a/docs/app_implement_guidance.md
+++ b/docs/app_implement_guidance.md
@@ -196,7 +196,24 @@ if err != nil {
 }
 ```
 
-### 5.3 Advanced Dialing Options
+### 5.3 User Notifications
+When something happens that deserves the user's attention while they are *not* looking at your app, publish a notification. Your app decides **whether** to notify; the visor decides **where** it lands — a subscribed host application (the Android service), the host OS notification centre, or nowhere at all on a headless visor. You write no OS-specific code and no platform checks.
+
+```go
+// Best-effort and nil-safe: works in standalone mode, no-ops on a headless visor.
+appCl.NotifyOrLog("MyApp", "Transfer finished", "myapp-transfers")
+```
+
+The third argument is an optional coalescing tag: events sharing a tag replace one another in sinks that support it (an Android notification tag) instead of stacking. Pass `""` for no coalescing.
+
+Two rules worth internalising:
+
+- **Only your app knows whether to notify.** If your app has its own UI and it is open and focused, it should surface the event itself and *not* publish — otherwise the user sees it twice. `cmd/apps/skychat/commands/osnotify.go` shows the pattern (a capability lease the UI heartbeats).
+- **Notify sparingly.** Something the user just triggered in a visible UI is noise; a failure, or a result arriving long after they walked away, is not.
+
+You never set the app name: the visor stamps it from your proc's identity, so an app cannot publish under another app's name.
+
+### 5.4 Advanced Dialing Options
 For high-bandwidth or high-latency scenarios, you can use `DialWithOptions` to request multi-path routing (`muxRoutes`) or enforce a minimum number of hops for privacy (`minHops`).
 
 ```go
@@ -233,6 +250,7 @@ func init() {
 3. [ ] **Logging:** Replace `log.Println` with `appCl.Log().Info()`.
 4. [ ] **Networking:** Use `appCl.Listen()` to accept secure connections and `appCl.Dial()` to initiate them.
 5. [ ] **Status:** Call `SetStatusOrLog(Running)` on startup and `Stopped` on shutdown.
+6. [ ] **Notifications:** Use `NotifyOrLog` for events the user should see when they aren't watching your app (see 5.3).
 6. [ ] **Graceful Exit:** Listen for `os.Interrupt` to cancel your context and close listeners cleanly.
 7. [ ] **Registration:** Call `launcher.RegisterApp()` in `init()`.
 

--- a/internal/integration/dmsgpty_test.go
+++ b/internal/integration/dmsgpty_test.go
@@ -20,6 +20,13 @@
 //
 // dmsgpty rides dmsg directly (no skywire transport), so no `tp add` is required —
 // only live dmsg sessions.
+//
+// CONFIG DEPENDENCY: #3658 gated the RPC-initiated exec path behind
+// pty.allow_rpc_exec (OFF by default), so all three e2e visor configs set it —
+// including visor-a, which is only ever the CALLER here (the negative case must
+// reach the remote's whitelist to be rejected BY IT, not die locally on the
+// gate). Without the flag every exec below fails with "RPC-initiated exec is
+// disabled" and this test times out.
 package integration_test
 
 import (
@@ -40,6 +47,36 @@ func (env *TestEnv) VisorPtyExec(callerVisor, remotePK string, cmdAndArgs ...str
 	full := fmt.Sprintf("/release/skywire cli --rpc %s:3435 pty exec %s -- %s",
 		callerVisor, remotePK, strings.Join(cmdAndArgs, " "))
 	return env.execResult(full)
+}
+
+// retryPtyExec polls exec until want accepts its result, returning the last
+// result and whether it ever passed.
+//
+// Why not require.Eventually: its message args are evaluated at CALL time, so a
+// failure printed the ZERO ExecResult — the previous CI failure here reported
+// `exit=0 stdout="<nil>"` for a run whose every attempt had actually failed with
+// "dmsgpty: RPC-initiated exec is disabled", and the real cause had to be dug
+// out of the source. Logging each attempt as it happens keeps the reason in the
+// CI log where the next person will look.
+func retryPtyExec(t *testing.T, timeout, interval time.Duration,
+	exec func() (ExecResult, error), want func(ExecResult, error) bool) (ExecResult, bool) {
+	t.Helper()
+
+	var res ExecResult
+	var err error
+	deadline := time.Now().Add(timeout)
+	for attempt := 1; ; attempt++ {
+		res, err = exec()
+		if want(res, err) {
+			return res, true
+		}
+		t.Logf("pty exec attempt %d: err=%v exit=%d stdout=%q stderr=%q",
+			attempt, err, res.ExitCode, strings.TrimSpace(res.Stdout()), strings.TrimSpace(res.Stderr()))
+		if time.Now().After(deadline) {
+			return res, false
+		}
+		time.Sleep(interval)
+	}
 }
 
 // TestEnv_DmsgPtyExec runs /bin/hostname on visor-a and visor-c over dmsgpty from
@@ -71,14 +108,12 @@ func TestEnv_DmsgPtyExec(t *testing.T) {
 	// first DialStream to a peer can return the transient dmsg-202).
 	for _, remote := range []string{visorA, visorC} {
 		pk := env.visorPKs[remote]
-		var res ExecResult
-		var err error
-		require.Eventually(t, func() bool {
-			res, err = env.VisorPtyExec(visorB, pk, "/bin/hostname")
+		res, ok := retryPtyExec(t, 60*time.Second, 3*time.Second, func() (ExecResult, error) {
+			return env.VisorPtyExec(visorB, pk, "/bin/hostname")
+		}, func(res ExecResult, err error) bool {
 			return err == nil && res.ExitCode == 0 && strings.TrimSpace(res.Stdout()) == remote
-		}, 60*time.Second, 3*time.Second,
-			"dmsgpty exec visor-b->%s did not return the remote hostname (last err=%v exit=%d stdout=%q stderr=%q)",
-			remote, err, res.ExitCode, strings.TrimSpace(res.Stdout()), strings.TrimSpace(res.Stderr()))
+		})
+		require.True(t, ok, "dmsgpty exec visor-b->%s did not return the remote hostname", remote)
 		t.Logf("dmsgpty exec visor-b->%s: hostname=%q exit=%d", remote, strings.TrimSpace(res.Stdout()), res.ExitCode)
 	}
 
@@ -86,14 +121,12 @@ func TestEnv_DmsgPtyExec(t *testing.T) {
 	// whitelist, so a pty exec visor-a->visor-c must be rejected by the remote
 	// dmsgpty host (non-zero exit + a "rejected" message). Retry past any cold-
 	// session transient until the deterministic rejection surfaces.
-	var neg ExecResult
-	var negErr error
-	require.Eventually(t, func() bool {
-		neg, negErr = env.VisorPtyExec(visorA, pkC, "/bin/hostname")
-		return negErr == nil && neg.ExitCode != 0 && strings.Contains(neg.Combined(), "reject")
-	}, 60*time.Second, 3*time.Second,
-		"expected non-whitelisted pty exec visor-a->visor-c to be rejected (last err=%v exit=%d out=%q)",
-		negErr, neg.ExitCode, strings.TrimSpace(neg.Combined()))
+	neg, ok := retryPtyExec(t, 60*time.Second, 3*time.Second, func() (ExecResult, error) {
+		return env.VisorPtyExec(visorA, pkC, "/bin/hostname")
+	}, func(res ExecResult, err error) bool {
+		return err == nil && res.ExitCode != 0 && strings.Contains(res.Combined(), "reject")
+	})
+	require.True(t, ok, "expected non-whitelisted pty exec visor-a->visor-c to be rejected")
 	t.Logf("dmsgpty whitelist gate held: visor-a->visor-c rejected (exit=%d)", neg.ExitCode)
 
 	t.Logf("TestEnv_DmsgPtyExec completed in %v", time.Since(start).Round(time.Second))

--- a/pkg/app/appserver/appserver_more_test.go
+++ b/pkg/app/appserver/appserver_more_test.go
@@ -168,7 +168,7 @@ func TestNewProc_ExternalWithLogDB(t *testing.T) {
 
 func newManager(t *testing.T) *procManager {
 	t.Helper()
-	mI, err := NewProcManager(nil, nil, nil, ":0", "")
+	mI, err := NewProcManager(nil, nil, nil, nil, ":0", "")
 	require.NoError(t, err)
 	m, ok := mI.(*procManager)
 	require.True(t, ok)

--- a/pkg/app/appserver/mock_rpc_ingress_client.go
+++ b/pkg/app/appserver/mock_rpc_ingress_client.go
@@ -188,6 +188,24 @@ func (_m *MockRPCIngressClient) Listen(local appnet.Addr) (uint16, error) {
 	return r0, r1
 }
 
+// Notify provides a mock function with given fields: n
+func (_m *MockRPCIngressClient) Notify(n NotifyReq) error {
+	ret := _m.Called(n)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Notify")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(NotifyReq) error); ok {
+		r0 = rf(n)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Read provides a mock function with given fields: connID, b
 func (_m *MockRPCIngressClient) Read(connID uint16, b []byte) (int, error) {
 	ret := _m.Called(connID, b)

--- a/pkg/app/appserver/notify.go
+++ b/pkg/app/appserver/notify.go
@@ -1,0 +1,48 @@
+// Package appserver pkg/app/appserver/notify.go c2-vis-appsvc
+//
+// The app→visor half of the visor-global notification system.
+//
+// An app decides *whether* an event deserves the user's attention — only
+// skychat knows which thread is focused and which are muted, only vpn-client
+// knows a reconnect matters. It then publishes a NotifyReq and is done. The
+// visor decides *where* that lands (an attached UI, a subscribed host app such
+// as the Android service, the host-OS notification center, or nowhere at all on
+// a headless box). Apps therefore carry no OS-specific notification code.
+//
+// This file deliberately holds only the wire type and a one-method interface:
+// pkg/app/appserver must keep compiling for GOOS=js/wasm and TinyGo (the
+// browser wasm-visor imports it), so every transport concern — net/http, SSE,
+// os/exec — lives on the pkg/visor side, which never builds for those targets.
+package appserver
+
+// NotifyReq is a single user-facing notification published by an app.
+//
+// All fields are plain strings so the value gob-encodes on both the reflection
+// and the TinyGo codec paths without a gob.Register.
+type NotifyReq struct {
+	// App is the publishing app's name (e.g. "skychat"). Apps may leave it
+	// empty: the visor stamps it from the proc's own identity and overwrites
+	// whatever arrived on the wire, so an app cannot publish under another
+	// app's name (see RPCIngressGateway.Notify).
+	App string
+	// Title is the bold heading.
+	Title string
+	// Body is the message text. Frequently UNTRUSTED — a peer's chat message —
+	// so it is never logged and never interpolated into anything executable.
+	Body string
+	// Tag optionally groups related notifications so a sink that supports
+	// coalescing (an Android notification tag, say) can replace rather than
+	// stack them. Empty means "no coalescing". Sinks without the concept —
+	// pkg/osnotify — ignore it.
+	Tag string
+}
+
+// NotificationHub receives notifications published by apps and routes them to
+// whatever sink can actually reach the user. It is implemented on the visor
+// side (*visor.NotifyHub); appserver only needs the seam.
+//
+// Publish MUST NOT block: it is called on the publishing app's single RPC serve
+// goroutine, so a slow sink would stall that app's Dial/Write/Read too.
+type NotificationHub interface {
+	Publish(n NotifyReq)
+}

--- a/pkg/app/appserver/notify_test.go
+++ b/pkg/app/appserver/notify_test.go
@@ -1,0 +1,101 @@
+// Package appserver pkg/app/appserver/notify_test.go
+//
+// Coverage for the app→visor notification seam. The security-relevant property
+// is app attribution: the App field is taken from the calling proc's own
+// identity and OVERWRITES whatever arrived on the wire. Without that, any app
+// could publish under another's name — which downstream maps to a per-app
+// notification channel the user may have deliberately muted.
+package appserver
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/app/appcommon"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// hubRecorder captures what the visor-side hub would receive.
+type hubRecorder struct {
+	mu  sync.Mutex
+	got []NotifyReq
+}
+
+func (h *hubRecorder) Publish(n NotifyReq) {
+	h.mu.Lock()
+	h.got = append(h.got, n)
+	h.mu.Unlock()
+}
+
+func (h *hubRecorder) calls() []NotifyReq {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]NotifyReq(nil), h.got...)
+}
+
+func TestRPCIngressGateway_Notify_OverridesAppName(t *testing.T) {
+	hub := &hubRecorder{}
+	proc := &Proc{conf: appcommon.ProcConfig{AppName: "skychat"}, notifyHub: hub}
+	gw := NewRPCGateway(logging.MustGetLogger("rpc_gateway"), proc)
+
+	// The app claims to be something else; the gateway must not believe it.
+	var reply struct{}
+	if err := gw.Notify(&NotifyReq{App: "vpn-client", Title: "alice", Body: "hi", Tag: "dm"}, &reply); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+
+	got := hub.calls()
+	if len(got) != 1 {
+		t.Fatalf("hub received %d notifications, want 1", len(got))
+	}
+	if got[0].App != "skychat" {
+		t.Errorf("App = %q, want skychat (the proc's own identity, not the claim)", got[0].App)
+	}
+	if got[0].Title != "alice" || got[0].Body != "hi" || got[0].Tag != "dm" {
+		t.Errorf("payload = %+v, want title/body/tag passed through untouched", got[0])
+	}
+}
+
+func TestRPCIngressGateway_Notify_StampsEmptyAppName(t *testing.T) {
+	// The normal case: apps leave App empty and the visor fills it in.
+	hub := &hubRecorder{}
+	proc := &Proc{conf: appcommon.ProcConfig{AppName: "skydex-client"}, notifyHub: hub}
+	gw := NewRPCGateway(logging.MustGetLogger("rpc_gateway"), proc)
+
+	var reply struct{}
+	if err := gw.Notify(&NotifyReq{Title: "SkyDEX", Body: "Connected"}, &reply); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+
+	got := hub.calls()
+	if len(got) != 1 || got[0].App != "skydex-client" {
+		t.Fatalf("hub got %+v, want App=skydex-client", got)
+	}
+}
+
+func TestRPCIngressGateway_Notify_NilRequestErrors(t *testing.T) {
+	gw := NewRPCGateway(logging.MustGetLogger("rpc_gateway"), &Proc{})
+
+	var reply struct{}
+	if err := gw.Notify(nil, &reply); err == nil {
+		t.Error("Notify(nil) should error rather than panic")
+	}
+}
+
+func TestRPCIngressGateway_Notify_NilProcIsNoOp(t *testing.T) {
+	// Many tests in this package build a gateway with a nil proc; the
+	// notification path must tolerate it.
+	gw := NewRPCGateway(logging.MustGetLogger("rpc_gateway"), nil)
+
+	var reply struct{}
+	if err := gw.Notify(&NotifyReq{Title: "x"}, &reply); err != nil {
+		t.Errorf("Notify with a nil proc should be a silent no-op, got %v", err)
+	}
+}
+
+func TestProc_Notify_NilHubIsNoOp(t *testing.T) {
+	// A bare &Proc{} (and the browser wasm-visor, which passes no hub) must
+	// drop notifications rather than panic.
+	p := &Proc{conf: appcommon.ProcConfig{AppName: "skychat"}}
+	p.Notify(NotifyReq{Title: "x"}) // must not panic
+}

--- a/pkg/app/appserver/proc.go
+++ b/pkg/app/appserver/proc.go
@@ -64,6 +64,11 @@ type Proc struct {
 	m       ProcManager
 	appName string
 
+	// notifyHub routes notifications this app publishes (see Notify). Set by
+	// procManager at construction; nil on a bare &Proc{} and wherever the
+	// visor was built without a hub, in which case notifications drop.
+	notifyHub NotificationHub
+
 	startTimeMx sync.RWMutex
 	startTime   time.Time
 
@@ -477,6 +482,21 @@ func (p *Proc) DetailedStatus() string {
 	defer p.statusMx.RUnlock()
 
 	return p.status
+}
+
+// Notify forwards a notification the app published to the visor's notification
+// hub, which decides which sink (if any) can actually reach the user.
+//
+// Best-effort and total-no-op safe: the hub is nil on a bare &Proc{} (unit
+// tests) and on the browser wasm-visor, and a nil hub simply drops. The App
+// field is re-stamped from this proc's own config so the hub always attributes
+// the event correctly even if the caller left it empty or lied.
+func (p *Proc) Notify(n NotifyReq) {
+	if p.notifyHub == nil {
+		return
+	}
+	n.App = p.conf.AppName
+	p.notifyHub.Publish(n)
 }
 
 // SetOTP sets the proc's current one-time code. Apps that gate their own UI

--- a/pkg/app/appserver/proc_ingress_rpc_tinygo.go
+++ b/pkg/app/appserver/proc_ingress_rpc_tinygo.go
@@ -38,6 +38,14 @@ func registerIngressRPC(s *rpc.Server, name string, gw *RPCIngressGateway) error
 		var r struct{}
 		return &r, gw.SetOTP(&a, &r)
 	})
+	h("Notify", func(dec *gob.Decoder) (interface{}, error) {
+		var a NotifyReq
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r struct{}
+		return &r, gw.Notify(&a, &r)
+	})
 	h("SetConnectionDuration", func(dec *gob.Decoder) (interface{}, error) {
 		var a int64
 		if err := dec.Decode(&a); err != nil {

--- a/pkg/app/appserver/proc_manager.go
+++ b/pkg/app/appserver/proc_manager.go
@@ -82,6 +82,11 @@ type procManager struct {
 	// event broadcaster: broadcasts events to apps
 	eb *appevent.Broadcaster
 
+	// notifyHub receives user-facing notifications published by apps and
+	// routes them to whatever sink can reach the user. Nil is valid and
+	// means "drop them" — the browser wasm-visor and unit tests run that way.
+	notifyHub NotificationHub
+
 	mx   sync.RWMutex
 	done chan struct{}
 
@@ -89,7 +94,8 @@ type procManager struct {
 }
 
 // NewProcManager constructs `ProcManager`.
-func NewProcManager(mLog *logging.MasterLogger, discF *appdisc.Factory, eb *appevent.Broadcaster, addr, logStorePath string) (ProcManager, error) {
+func NewProcManager(mLog *logging.MasterLogger, discF *appdisc.Factory, eb *appevent.Broadcaster,
+	hub NotificationHub, addr, logStorePath string) (ProcManager, error) {
 	if mLog == nil {
 		mLog = logging.NewMasterLogger()
 	}
@@ -118,6 +124,7 @@ func NewProcManager(mLog *logging.MasterLogger, discF *appdisc.Factory, eb *appe
 		procsByKey:   make(map[appcommon.ProcKey]*Proc),
 		errors:       make(map[string]string),
 		eb:           eb,
+		notifyHub:    hub,
 		done:         make(chan struct{}),
 		logStorePath: logStorePath,
 	}
@@ -244,6 +251,7 @@ func (m *procManager) Start(conf appcommon.ProcConfig) (appcommon.ProcID, error)
 	}
 
 	proc := NewProc(nil, conf, disc, m, conf.AppName, m.logStorePath)
+	proc.notifyHub = m.notifyHub
 	m.procs[conf.AppName] = proc
 	m.procsByKey[conf.ProcKey] = proc
 
@@ -308,6 +316,7 @@ func (m *procManager) Register(conf appcommon.ProcConfig) (appcommon.ProcKey, er
 	}
 
 	proc := NewProc(nil, conf, disc, m, conf.AppName, m.logStorePath)
+	proc.notifyHub = m.notifyHub
 	m.procs[conf.AppName] = proc
 	m.procsByKey[conf.ProcKey] = proc
 

--- a/pkg/app/appserver/proc_manager_test.go
+++ b/pkg/app/appserver/proc_manager_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestProcManager_ProcByName(t *testing.T) {
-	mI, err := NewProcManager(nil, nil, nil, ":0", "")
+	mI, err := NewProcManager(nil, nil, nil, nil, ":0", "")
 	require.NoError(t, err)
 
 	m, ok := mI.(*procManager)
@@ -32,7 +32,7 @@ func TestProcManager_ProcByName(t *testing.T) {
 }
 
 func TestProcManager_Range(t *testing.T) {
-	mI, err := NewProcManager(nil, nil, nil, ":0", "")
+	mI, err := NewProcManager(nil, nil, nil, nil, ":0", "")
 	require.NoError(t, err)
 
 	m, ok := mI.(*procManager)
@@ -61,7 +61,7 @@ func TestProcManager_Range(t *testing.T) {
 }
 
 func TestProcManager_Pop(t *testing.T) {
-	mI, err := NewProcManager(nil, nil, nil, ":0", "")
+	mI, err := NewProcManager(nil, nil, nil, nil, ":0", "")
 	require.NoError(t, err)
 
 	m, ok := mI.(*procManager)
@@ -84,7 +84,7 @@ func TestProcManager_Pop(t *testing.T) {
 }
 
 func TestProcManager_SetDetailedStatus(t *testing.T) {
-	mI, err := NewProcManager(nil, nil, nil, ":0", "")
+	mI, err := NewProcManager(nil, nil, nil, nil, ":0", "")
 	require.NoError(t, err)
 
 	m, ok := mI.(*procManager)
@@ -109,7 +109,7 @@ func TestProcManager_SetDetailedStatus(t *testing.T) {
 }
 
 func TestProcManager_DetailedStatus(t *testing.T) {
-	mI, err := NewProcManager(nil, nil, nil, ":0", "")
+	mI, err := NewProcManager(nil, nil, nil, nil, ":0", "")
 	require.NoError(t, err)
 
 	m, ok := mI.(*procManager)
@@ -132,7 +132,7 @@ func TestProcManager_DetailedStatus(t *testing.T) {
 }
 
 func TestProcManager_RegisterAndDeregister(t *testing.T) {
-	mI, err := NewProcManager(nil, nil, nil, ":0", "")
+	mI, err := NewProcManager(nil, nil, nil, nil, ":0", "")
 	require.NoError(t, err)
 
 	m, ok := mI.(*procManager)

--- a/pkg/app/appserver/rpc_ingress_client.go
+++ b/pkg/app/appserver/rpc_ingress_client.go
@@ -17,6 +17,10 @@ import (
 type RPCIngressClient interface {
 	SetDetailedStatus(status string) error
 	SetOTP(otp string) error
+	// Notify publishes a user-facing notification to the visor's
+	// notification hub. The visor overwrites the App field from the calling
+	// proc's identity, so it may be left empty.
+	Notify(n NotifyReq) error
 	SetConnectionDuration(dur int64) error
 	SetError(appErr string) error
 	SetAppPort(appPort routing.Port) error
@@ -63,6 +67,11 @@ func (c *rpcIngressClient) SetDetailedStatus(status string) error {
 // SetOTP sets the current one-time code of an app that gates its own UI.
 func (c *rpcIngressClient) SetOTP(otp string) error {
 	return c.rpc.Call(c.formatMethod("SetOTP"), &otp, nil)
+}
+
+// Notify publishes a user-facing notification to the visor's notification hub.
+func (c *rpcIngressClient) Notify(n NotifyReq) error {
+	return c.rpc.Call(c.formatMethod("Notify"), &n, nil)
 }
 
 // SetConnectionDuration sets the connection duration for an app

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -100,6 +100,34 @@ func (r *RPCIngressGateway) SetOTP(otp *string, _ *struct{}) (err error) {
 	return nil
 }
 
+// Notify publishes a user-facing notification to the visor's notification hub,
+// which routes it to whatever sink can actually reach the user.
+//
+// Like SetOTP the payload is withheld from rpcutil.LogCall (nil input): a body
+// is routinely UNTRUSTED peer text (a chat message), and app logs are
+// retrievable over the hypervisor API.
+//
+// The App field is overwritten from this proc's own identity rather than
+// trusted: the RPC service is registered per-proc and served on that proc's
+// private conn, so the visor already knows the caller for certain. Without the
+// override any app could publish under skychat's name — which on Android maps
+// to a per-app notification channel the user may have deliberately muted.
+func (r *RPCIngressGateway) Notify(req *NotifyReq, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "Notify", nil)(nil, &err)
+
+	if req == nil {
+		return errors.New("nil notification request")
+	}
+	// r.proc is nil in unit tests that construct a bare gateway; dropping is
+	// the correct best-effort behavior there.
+	if r.proc == nil {
+		return nil
+	}
+	r.proc.Notify(*req)
+
+	return nil
+}
+
 // SetConnectionDuration sets the connection duration of an app (vpn-client in this instance)
 func (r *RPCIngressGateway) SetConnectionDuration(dur int64, _ *struct{}) (err error) {
 	defer rpcutil.LogCall(r.log, "SetConnectionDuration", dur)(nil, &err)

--- a/pkg/app/client.go
+++ b/pkg/app/client.go
@@ -140,6 +140,31 @@ func (c *Client) SetOTPOrLog(otp string) {
 	}
 }
 
+// Notify publishes a user-facing notification to the visor's notification hub,
+// which decides which sink can actually reach the user (an attached UI, a
+// subscribed host app such as the Android service, the host-OS notification
+// center, or nowhere at all on a headless visor).
+//
+// The app decides *whether* to notify — it alone knows what is muted or already
+// on screen; the visor decides *where*. The visor stamps the App field from the
+// calling proc's identity, so callers leave it empty.
+func (c *Client) Notify(n appserver.NotifyReq) error {
+	return c.rpcC.Notify(n)
+}
+
+// NotifyOrLog publishes a notification, logging (without the body — it is
+// routinely untrusted peer text) if the visor can't be reached. Best-effort and
+// nil-safe like SetStatusOrLog, so apps that can run standalone don't have to
+// guard each call site.
+func (c *Client) NotifyOrLog(title, body, tag string) {
+	if c == nil {
+		return
+	}
+	if err := c.Notify(appserver.NotifyReq{Title: title, Body: body, Tag: tag}); err != nil {
+		c.Log().Errorf("Failed to publish notification: %v", err)
+	}
+}
+
 // SetErrorOrLog records an app error in the visor and logs the
 // failure to record (not the original error — that's already in
 // appErr). Best-effort and nil-safe like SetStatusOrLog. Replaces

--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -129,9 +129,13 @@ type Cache struct {
 	// Reads happen under c.mx (every Cache write/read path holds it),
 	// so concurrent Set/Get/Inc callers serialize their tx use through
 	// the mutex; the bbolt tx is never touched by two goroutines at
-	// once. WithBatch tears the pin down only after taking c.mx again
-	// to drain any in-flight CXDS user — see WithBatch for the full
-	// invariant.
+	// once.
+	//
+	// The pin is established and torn down so that EVERY goroutine
+	// holding c.mx during the tx's lifetime sees it. That is not a
+	// nicety: a c.mx holder that misses the pin falls through to the
+	// unpinned store and blocks on bbolt's writer lock, which the tx
+	// owns — while the tx owner blocks on c.mx. See WithBatch.
 	batchTx atomic.Pointer[data.CXDS]
 }
 
@@ -196,34 +200,78 @@ func (c *Cache) db() data.CXDS {
 // that one tx — replacing N per-leaf commits with a single one. fn
 // returning nil commits the tx; a non-nil return rolls it back.
 //
-// The pin lives in c.batchTx (atomic). Reads happen under c.mx, so
-// concurrent Cache writers/readers from outside fn naturally serialize
-// against fn's tx use through the mutex — the bbolt tx is never
-// touched by two goroutines at once. The tear-down sequence on the
-// way out:
+// LOCK ORDER — the reason this function is shaped the way it is.
 //
-//  1. Store nil into c.batchTx so any newly-arriving Cache.Set sees
-//     the untwisted CXDS (and will block in bbolt's writer mutex
-//     until our tx commits, as it would have pre-batch).
-//  2. Lock/unlock c.mx once to drain any in-flight Cache.Set that
-//     captured the now-stale tx pointer before step 1 — they finish
-//     their work under our serialization while we wait.
-//  3. Return; the bbolt tx commits at this point.
+// Two locks are in play: c.mx and bbolt's writer lock (held for the
+// whole of DB.Update / DB.Batch). Everywhere else in the Cache the
+// order is c.mx → writer: Cache.Get(key, inc != 0) and Cache.Set on a
+// miss take c.mx and then reach bbolt, which needs the writer for the
+// refcount bump. This function is the one place that would take them
+// the other way round — RunBatch opens the tx (writer) and fn then
+// calls back into Cache.Set (c.mx) — and that inversion deadlocked:
+//
+//	G1 fill:    holds c.mx        → waits for the writer (DB.Batch)
+//	G2 publish: holds the writer  → waits for c.mx (Cache.Set in fn)
+//
+// It wedged the node permanently: the publisher never cleared dirty,
+// every later send was silently lost, and teardown hung because the
+// cleanup sweep also wants c.mx. Windows CI hit it as a 25-minute
+// package timeout in cmd/apps/skychat/pairing, which publishes and
+// subscribes on one node by design.
+//
+// The fix is to make c.mx → writer hold here too, WITHOUT holding c.mx
+// across fn (fn's own Cache.Set needs it, and the mutex isn't
+// reentrant). Three windows, in order:
+//
+//  1. Take c.mx BEFORE opening the tx. Anyone already inside the Cache
+//     — possibly blocked in bbolt — finishes first, so we never open
+//     the writer underneath a c.mx holder that still needs it.
+//  2. Store the pin, then release c.mx. From here every arriving Cache
+//     op sees the pin and joins our tx, so none of them touches the
+//     writer while we own it. fn runs in this window.
+//  3. Re-take c.mx BEFORE clearing the pin. Taking it is safe (by (2)
+//     no c.mx holder is waiting on the writer) and it drains anyone
+//     mid-call on the scoped handle; clearing the pin only afterwards
+//     means no goroutine can pick the unpinned store up while the tx
+//     is still open. c.mx is released after RunBatch returns, i.e.
+//     after the commit.
+//
+// The cost of step (1) is that Cache operations now also queue behind
+// however long the writer takes to become free — including a long
+// RemoveObjects sweep. Before, an inc==0 read (bbolt View, no writer)
+// could slip past. That is latency, not a cycle: nothing that holds the
+// writer ever asks for c.mx (RemoveObjects deliberately snapshots
+// CachedKeys up front for this reason), so the wait always ends.
 //
 // fn must not retain the pinned handle past its return — the tx is
-// gone afterward.
+// gone afterward. WithBatch is not reentrant (step 1 would deadlock
+// against itself); it has a single caller, treestore.publishRoot.
 func (c *Cache) WithBatch(fn func() error) error {
+	// (1) Claim the Cache before the writer. RunBatch invokes fn
+	// synchronously on this goroutine, so this plain bool needs no
+	// synchronization of its own.
+	c.mx.Lock()
+	held := true
+	unlock := func() {
+		if held {
+			held = false
+			c.mx.Unlock()
+		}
+	}
+	// Covers step (3)'s re-lock, and the case where RunBatch fails
+	// before ever calling us back.
+	defer unlock()
+
 	return c.c.db.CXDS().RunBatch(func(scoped data.CXDS) (err error) {
 		c.batchTx.Store(&scoped)
+		// (2) The pin is visible to everyone who takes c.mx from here
+		// on; hand the Cache back to them.
+		unlock()
 		defer func() {
-			c.batchTx.Store(nil)
-			// Wait for any in-flight Cache operation that may still be
-			// using the scoped CXDS to finish before letting bbolt
-			// commit. Holding the mutex briefly is sufficient: every
-			// Cache CXDS call holds c.mx for its duration, so once we
-			// acquire it nobody else is mid-tx.
+			// (3) Drain in-flight scoped users, then retire the pin.
 			c.mx.Lock()
-			c.mx.Unlock() //nolint:staticcheck // intentional drain
+			held = true
+			c.batchTx.Store(nil)
 		}()
 		return fn()
 	})

--- a/pkg/cxo/skyobject/cache_batch_lockorder_test.go
+++ b/pkg/cxo/skyobject/cache_batch_lockorder_test.go
@@ -1,0 +1,162 @@
+// Package skyobject pkg/cxo/skyobject/cache_batch_lockorder_test.go
+//
+// Pins the lock order between Cache.mx and bbolt's writer lock, which
+// WithBatch is the only place able to invert (it opens the writer, then
+// calls back into Cache.Set). The inversion deadlocked a node
+// permanently — the publisher stopped clearing dirty, every later send
+// was silently dropped, and teardown hung because the cleanup sweep
+// wants Cache.mx too. Windows CI hit it as a 25-minute package timeout
+// in cmd/apps/skychat/pairing, which publishes and subscribes on one
+// CXO node by design.
+//
+// This test drives the interleaving directly rather than waiting for a
+// pairing suite to get unlucky: hold the writer, park a cache reader
+// that needs it (a refcount bump goes through a write tx), then start
+// the batch on top of both.
+package skyobject
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cxo/data"
+)
+
+// lockOrderRounds — one round is enough against the pre-fix code (the
+// staging in lockOrderRound is deliberate, not a race to lose), but the
+// staging leans on two short sleeps, so a few rounds keep it honest on a
+// loaded runner where one of them might land wrong.
+const lockOrderRounds = 5
+
+// lockOrderWatchdog bounds the whole run. Far above the ~1s the rounds
+// take when nothing is wedged — it only has to tell "slow CI" from
+// "blocked forever".
+const lockOrderWatchdog = 30 * time.Second
+
+// TestWithBatch_DoesNotInvertCacheAndWriterLocks fails (by watchdog) if
+// WithBatch ever again takes bbolt's writer lock before Cache.mx.
+func TestWithBatch_DoesNotInvertCacheAndWriterLocks(t *testing.T) {
+	// An on-disk container: the in-memory CXDS has no writer lock, so
+	// the inversion this guards against cannot exist there.
+	conf := NewConfig()
+	conf.InMemoryDB = false
+	conf.DBPath = filepath.Join(t.TempDir(), "db")
+
+	c, err := NewContainer(conf)
+	if err != nil {
+		t.Fatalf("NewContainer: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < lockOrderRounds; i++ {
+			lockOrderRound(t, c, i)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(lockOrderWatchdog):
+		// Deliberately no Close() on this path: the wedged goroutines
+		// hold the bbolt writer, and bolt's Close waits for it — the
+		// cleanup would hang exactly like the bug under test.
+		t.Fatalf("deadlock: WithBatch and a concurrent Cache.Get are waiting on each other "+
+			"(Cache.mx vs the bbolt writer) — %s elapsed with rounds unfinished", lockOrderWatchdog)
+	}
+
+	if err := c.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+// lockOrderRound stages the three-goroutine interleaving that produced
+// the CI hang, then lets it resolve:
+//
+//	(a) holds bbolt's writer lock,
+//	(b) WithBatch — wants the writer, and once inside wants Cache.mx,
+//	(c) a Cache.Get with inc != 0 — takes Cache.mx, then needs the
+//	    writer for the refcount bump, so it parks holding the mutex.
+//
+// Order matters, and it is why (b) is started before (c): bbolt hands a
+// contended writer lock to the goroutine that queued first, so whoever
+// waits first wins it when (a) lets go. With (b) first, the pre-fix code
+// took the writer, pinned, and only then asked for Cache.mx — which (c)
+// was holding while waiting for the writer (b) had just taken. Cycle.
+//
+// Start them the other way round and the pre-fix code survives by luck:
+// (c)'s refcount bump commits before (b) ever enters the tx. That
+// accident is why this bug reached CI as an occasional 25-minute hang
+// instead of a reproducible failure.
+//
+// Post-fix (b) takes Cache.mx before the writer, so it simply queues
+// behind (c) — no interleaving of the three can cycle.
+func lockOrderRound(t *testing.T, c *Container, round int) {
+	t.Helper()
+
+	// A key that is on disk but NOT in the cache, so Get has to reach
+	// bbolt. Fresh per round: once round N's Get lands the object in
+	// the cache, a repeat would short-circuit before the DB.
+	key := cipher.SumSHA256([]byte(fmt.Sprintf("lock-order-probe-%d", round)))
+	if _, err := c.DB().CXDS().Set(key, []byte("probe"), 1); err != nil {
+		t.Errorf("seed CXDS: %v", err)
+		return
+	}
+
+	var wg sync.WaitGroup
+	holding, release := make(chan struct{}), make(chan struct{})
+
+	// (a) Occupy the writer lock so (b) and (c) both have to wait.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := c.DB().CXDS().RunBatch(func(_ data.CXDS) error {
+			close(holding)
+			<-release
+			return nil
+		})
+		if err != nil {
+			t.Errorf("holder RunBatch: %v", err)
+		}
+	}()
+	<-holding
+
+	// (b) The publisher's batch. Queues on the writer first, so it is
+	// the one that gets it.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := c.WithBatch(func() error {
+			k := cipher.SumSHA256([]byte(fmt.Sprintf("lock-order-batch-%d", round)))
+			_, err := c.Set(k, []byte("batched"), 1)
+			return err
+		})
+		if err != nil {
+			t.Errorf("WithBatch: %v", err)
+		}
+	}()
+	// No signal exists for "now blocked on the writer", so give it a
+	// moment. A too-short wait only weakens the round; it cannot cause a
+	// false failure, since a correct WithBatch never deadlocks either
+	// way.
+	time.Sleep(100 * time.Millisecond)
+
+	// (c) The cache reader. inc != 0 makes it a read-modify-write, which
+	// bbolt serves from a write tx — so it parks with Cache.mx held.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// The returned value and error don't matter — the locks this
+		// call takes on its way to bbolt are the whole point.
+		_, _, _ = c.Get(key, 1) //nolint:errcheck,gosec // see above
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	close(release)
+	wg.Wait()
+}

--- a/pkg/skychat/group/roster_authority_test.go
+++ b/pkg/skychat/group/roster_authority_test.go
@@ -26,6 +26,7 @@
 package group
 
 import (
+	"errors"
 	"sort"
 	"sync/atomic"
 	"testing"
@@ -494,4 +495,59 @@ func TestSetAdminRoster_PrefersLiveMembersSnapshot(t *testing.T) {
 	}
 	assertPKSet(t, "peerSubs after the admin recompute", peerSubPKs(s), []cipher.PubKey{fresh})
 	assertBookkeepingMatchesSubs(t, s)
+}
+
+// --- teardown races ---------------------------------------------------------
+
+// TestPeerSubReconcile_AfterCloseIsRefused pins the guard both reconcilers
+// need: Close() nils s.peerSubs under peerSubsMu, so a reconcile that arrives
+// afterwards used to reach `s.peerSubs[pk] = ps` and panic with "assignment to
+// entry in nil map" — which is exactly how Windows CI died, from a CXO fill
+// callback (applySnapshot → onUpdate → applyModLeaf → SetAdminRoster) landing
+// on a session that was being torn down.
+//
+// Both entry points are covered because both write the map, and a fix applied
+// to only one leaves the other panicking on the same race.
+func TestPeerSubReconcile_AfterCloseIsRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(s *Session, peer cipher.PubKey) ([]cipher.PubKey, error)
+	}{
+		{"SetAllowlist", func(s *Session, peer cipher.PubKey) ([]cipher.PubKey, error) {
+			return s.SetAllowlist([]cipher.PubKey{s.cfg.MyPK, peer})
+		}},
+		{"SetAdminRoster", func(s *Session, peer cipher.PubKey) ([]cipher.PubKey, error) {
+			return s.SetAdminRoster([]cipher.PubKey{peer})
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			me, sk := cipher.GenerateKeyPair()
+			peer, _ := cipher.GenerateKeyPair()
+			s := newRosterSession(t, me, sk, Record{
+				OwnerPK: me,
+				Role:    RoleOwner,
+				Members: []cipher.PubKey{me, peer},
+			})
+
+			if err := s.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+
+			evicted, err := tc.call(s, peer)
+			if !errors.Is(err, errSessionClosed) {
+				t.Fatalf("%s after Close = %v, want errSessionClosed", tc.name, err)
+			}
+			if evicted != nil {
+				t.Errorf("evicted = %v, want nil — a closed session has nothing to evict", hexes(evicted))
+			}
+			// And nothing was resurrected: the map stays nil, so a later
+			// reconcile can't find a subscriber attached to a dead node.
+			s.peerSubsMu.RLock()
+			resurrected := len(s.peerSubs)
+			s.peerSubsMu.RUnlock()
+			if resurrected != 0 {
+				t.Errorf("peerSubs has %d entries after Close, want none", resurrected)
+			}
+		})
+	}
 }

--- a/pkg/skychat/group/session.go
+++ b/pkg/skychat/group/session.go
@@ -63,6 +63,13 @@ import (
 // each call site.
 var cryptoRandRead = cryptoRand.Read
 
+// errSessionClosed reports that a peer-sub reconciliation
+// (SetAllowlist / SetAdminRoster) arrived after teardown nil'd
+// s.peerSubs. Callers treat both functions as best-effort and log at
+// Debug, which is the right level for a closed session: there is
+// nothing left to reconcile.
+var errSessionClosed = errors.New("group: session closed")
+
 // MessagePathPrefix is the prefix used for message leaves within a
 // group feed. Matches the pairing analog so an operator who
 // understands one understands both.
@@ -1623,6 +1630,15 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) ([]cipher.PubKey, error)
 	// attempts to a fresh peerSub.
 	var evicted []cipher.PubKey
 	s.peerSubsMu.Lock()
+	if s.peerSubs == nil {
+		// Close() nils the map under this same lock, so a nil map IS the
+		// teardown signal (see teardown's peer-sub block). Bail before the
+		// add loop below: assigning there panics with "assignment to entry
+		// in nil map", and any subscriber created would attach to an
+		// already-closed node and never be closed.
+		s.peerSubsMu.Unlock()
+		return nil, errSessionClosed
+	}
 	// Drop removed peers — close their subs while still holding the
 	// lock so a racing Connect doesn't pick up a half-torn sub.
 	for pk, ps := range s.peerSubs {
@@ -1865,6 +1881,15 @@ func (s *Session) SetAdminRoster(admins []cipher.PubKey) ([]cipher.PubKey, error
 
 	var evicted []cipher.PubKey
 	s.peerSubsMu.Lock()
+	if s.peerSubs == nil {
+		// Session closed concurrently — see the identical guard in
+		// SetAllowlist. This is the one CI actually caught: a CXO fill
+		// callback (Subscriber.applySnapshot → onUpdate → applyModLeaf)
+		// landed on a session whose teardown had already nil'd the map,
+		// and the add loop below panicked on the nil-map assignment.
+		s.peerSubsMu.Unlock()
+		return nil, errSessionClosed
+	}
 	// Drop peers no longer desired — close their subs while still
 	// holding the lock so a racing Connect doesn't pick up a
 	// half-torn sub (same pattern as SetAllowlist).

--- a/pkg/skyenv/appname_test.go
+++ b/pkg/skyenv/appname_test.go
@@ -1,0 +1,31 @@
+// Package skyenv — pkg/skyenv/appname_test.go: pins the app id → display label
+// mapping used on user-facing surfaces.
+//
+// Worth a test because the label is a silent regression risk: apps stopped
+// passing it themselves when notifications moved to the visor-global hub, and
+// skychat's notifications had read "Skychat" long before that. A missing case
+// here doesn't fail anything — the id just leaks through lowercase into what
+// the user sees.
+package skyenv
+
+import "testing"
+
+func TestAppDisplayName(t *testing.T) {
+	cases := []struct {
+		app  string
+		want string
+	}{
+		{SkychatName, "Skychat"},
+		{SkysocksClientName, "Skysocks"},
+		{VPNClientName, "SkyVPN"},
+		{SkydexClientName, "SkyDEX"},
+		{"", "Skywire"},
+		// An app not yet listed must still read sensibly rather than vanish.
+		{"some-future-app", "some-future-app"},
+	}
+	for _, c := range cases {
+		if got := AppDisplayName(c.app); got != c.want {
+			t.Errorf("AppDisplayName(%q) = %q, want %q", c.app, got, c.want)
+		}
+	}
+}

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -417,6 +417,29 @@ func SkywireConfig() string {
 	return SkywirePath + "/" + ConfigJSON
 }
 
+// AppDisplayName maps an app's id to the human label a user-facing surface
+// shows for it — today the app name on a desktop notification.
+//
+// It lives here, beside the ids themselves, because more than one place needs
+// the same answer: the visor's notification hub posting locally, and the
+// `hv notify` bridge posting on a different machine. An unknown id passes
+// through unchanged, so a new app reads sensibly before it is listed.
+func AppDisplayName(app string) string {
+	switch app {
+	case SkychatName:
+		return "Skychat"
+	case SkysocksClientName:
+		return "Skysocks"
+	case VPNClientName:
+		return "SkyVPN"
+	case SkydexClientName:
+		return "SkyDEX"
+	case "":
+		return "Skywire"
+	}
+	return app
+}
+
 // PkgConfig struct contains paths specific to the installation
 type PkgConfig struct {
 	LauncherBinPath string `json:"launcher"`

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -979,6 +979,20 @@ func (hv *Hypervisor) makeMux() chi.Router {
 			})
 		}
 
+		// Notification stream for a host application (the Android foreground
+		// service; later the manager UI's bell). Registered here rather than
+		// inside the /api group on purpose: that group applies
+		// middleware.Timeout(httpTimeout), a 30s deadline on the whole
+		// request, which severs a long-lived SSE response — the same reason
+		// /pty sits out here. Auth is opted into explicitly instead.
+		r.Route("/api/notifications", func(r chi.Router) {
+			if hv.c.EnableAuth {
+				r.Use(hv.users.Authorize)
+			}
+
+			r.Get("/stream", hv.getNotifyStream())
+		})
+
 		// we don't enable `dmsgpty` endpoints for Windows
 		r.Route("/pty", func(r chi.Router) {
 			if hv.c.EnableAuth {

--- a/pkg/visor/hypervisor_handlers_notify.go
+++ b/pkg/visor/hypervisor_handlers_notify.go
@@ -1,0 +1,138 @@
+// Package visor pkg/visor/hypervisor_handlers_notify.go c3-vis-core
+//
+// The host-app sink of the notification hub (tier (b), see notifyhub.go): an
+// SSE stream of the notifications apps publish, for a host application that can
+// surface them natively — the Android foreground service posting through
+// per-app notification channels, and later the manager UI's notification bell.
+//
+// Live-only, no replay: a subscriber sees what arrives while it is connected
+// and nothing else. A reconnecting phone getting a burst of stale "you had a
+// message" toasts is worse than missing them, and the hub's whole contract is
+// best-effort delivery to whoever is listening now.
+//
+// While at least one subscriber is connected the hub stops posting to the
+// host OS, so a desktop running the Android-style host app doesn't double up.
+// That is derived per publish from the live subscriber set — never cached — so
+// a dropped connection restores the desktop path immediately.
+package visor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// notifyStreamCapacity is the per-subscriber buffer for the SSE stream.
+// Notifications are sparse; a consumer this far behind has stopped reading.
+const notifyStreamCapacity = 64
+
+// notifyPingInterval keeps an idle stream alive and — more importantly — makes
+// a vanished client observable. Once the write deadline is cleared a failed
+// write is the only disconnect signal, and a notification feed can legitimately
+// be silent for hours (the log stream never needed this because it is chatty).
+const notifyPingInterval = 20 * time.Second
+
+// notifyWriteTimeout bounds a single write to a subscriber. Generous — it is
+// not a liveness heartbeat (that's notifyPingInterval) but a backstop that
+// unwedges a handler blocked on a peer that stopped reading without closing.
+const notifyWriteTimeout = 45 * time.Second
+
+// notifyEvent is the wire shape of one SSE event. Declared explicitly rather
+// than marshaling appserver.NotifyReq so the JSON contract the Android client
+// codes against is visible here and can't drift with a Go field rename.
+type notifyEvent struct {
+	App   string `json:"app"`
+	Title string `json:"title"`
+	Body  string `json:"body"`
+	Tag   string `json:"tag,omitempty"`
+}
+
+// getNotifyStream streams notifications published by this visor's apps as SSE.
+func (hv *Hypervisor) getNotifyStream() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+		if hv.visor == nil {
+			http.Error(w, "notification hub unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		// Long-lived stream: the hypervisor http.Server's WriteTimeout (10s) is
+		// a single deadline for the WHOLE response, so left alone it tears the
+		// stream down ~10s in.
+		//
+		// Re-armed per write rather than cleared outright (which is what getLog
+		// does). Clearing it leaves the handler with NO liveness bound: a peer
+		// that keeps the socket open but stops reading — a dozing phone, a
+		// zero-window TCP receiver — produces neither FIN nor RST, so the
+		// request context never cancels and the goroutine parks forever inside
+		// a write. It would then hold its subscription indefinitely, and since
+		// subscriber presence suppresses the host-OS sink, the desktop would go
+		// permanently silent. A rolling deadline turns that wedge into a write
+		// error, which unwinds to the deferred cancel and restores tier (c).
+		rc := http.NewResponseController(w)
+		armDeadline := func() {
+			if err := rc.SetWriteDeadline(time.Now().Add(notifyWriteTimeout)); err != nil {
+				// Non-fatal: on a transport without deadline control the stream
+				// still works, it just re-inherits the server WriteTimeout.
+				hv.log(r).WithError(err).Debug("notify SSE: could not extend write deadline")
+			}
+		}
+		armDeadline()
+
+		ch, cancel := hv.visor.SubscribeNotifications(notifyStreamCapacity)
+		if ch == nil {
+			http.Error(w, "notification hub unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		// Unconditional: leaking a subscriber would suppress the host-OS sink
+		// forever, silently muting the desktop.
+		defer cancel()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Connection", "keep-alive")
+		// Defeat proxy buffering, which would hold events until the buffer
+		// fills — indistinguishable from "nothing happened" on a sparse feed.
+		w.Header().Set("X-Accel-Buffering", "no")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+
+		ping := time.NewTicker(notifyPingInterval)
+		defer ping.Stop()
+
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-ping.C:
+				armDeadline()
+				if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+					return // client gone
+				}
+				flusher.Flush()
+			case n, open := <-ch:
+				if !open {
+					return
+				}
+				b, err := json.Marshal(notifyEvent{
+					App:   n.App,
+					Title: n.Title,
+					Body:  n.Body,
+					Tag:   n.Tag,
+				})
+				if err != nil {
+					continue
+				}
+				armDeadline()
+				if _, err := fmt.Fprintf(w, "data: %s\n\n", b); err != nil {
+					return // client gone
+				}
+				flusher.Flush()
+			}
+		}
+	}
+}

--- a/pkg/visor/hypervisor_handlers_notify_test.go
+++ b/pkg/visor/hypervisor_handlers_notify_test.go
@@ -1,0 +1,249 @@
+// Package visor — pkg/visor/hypervisor_handlers_notify_test.go: pins the
+// notification SSE endpoint's contract with the host app (the Android
+// foreground service).
+//
+// Two of these are structural rather than behavioral, and both guard traps
+// that are invisible at compile time: the route must resolve OUTSIDE the /api
+// group (whose 30s middleware.Timeout would sever a long-lived stream) while
+// leaving the group's own routes intact, and the handler must 503 rather than
+// panic when there is no hub — bare-visor Hypervisors are a normal fixture here.
+package visor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// nonFlusher is a ResponseWriter that cannot stream, which is the one condition
+// the handler must reject up front.
+type nonFlusher struct {
+	hdr    http.Header
+	status int
+	body   strings.Builder
+}
+
+func (n *nonFlusher) Header() http.Header {
+	if n.hdr == nil {
+		n.hdr = make(http.Header)
+	}
+	return n.hdr
+}
+func (n *nonFlusher) Write(b []byte) (int, error) { return n.body.Write(b) }
+func (n *nonFlusher) WriteHeader(status int)      { n.status = status }
+
+func TestGetNotifyStream_NonFlusherIs500(t *testing.T) {
+	hv := &Hypervisor{visor: &Visor{notifyHub: NewNotifyHub()}}
+	w := &nonFlusher{}
+	r := httptest.NewRequest(http.MethodGet, "/api/notifications/stream", nil)
+
+	hv.getNotifyStream()(w, r)
+
+	if w.status != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.status, http.StatusInternalServerError)
+	}
+}
+
+func TestGetNotifyStream_NoHubIs503(t *testing.T) {
+	// getLog's sibling omits this guard and would panic; a Hypervisor with a
+	// nil visor is constructed in this package's own tests.
+	for name, hv := range map[string]*Hypervisor{
+		"nil visor": {},
+		"no hub":    {visor: &Visor{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/api/notifications/stream", nil)
+
+			hv.getNotifyStream()(w, r)
+
+			if w.Code != http.StatusServiceUnavailable {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+			}
+		})
+	}
+}
+
+func TestGetNotifyStream_StreamsEventAndEndsOnContextCancel(t *testing.T) {
+	hub := NewNotifyHub()
+	hv := &Hypervisor{visor: &Visor{notifyHub: hub}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/notifications/stream", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		hv.getNotifyStream()(w, r)
+	}()
+
+	// Wait for the handler to register before publishing, otherwise the event
+	// races ahead of the subscription.
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.SubscriberCount() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("handler never subscribed to the hub")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	hub.Publish(appserver.NotifyReq{App: "skychat", Title: "alice", Body: "hi", Tag: "dm"})
+
+	// Canceling the request context is how a disconnected client is noticed.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return after the request context was canceled")
+	}
+
+	if ct := w.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	if b := w.Header().Get("X-Accel-Buffering"); b != "no" {
+		t.Errorf("X-Accel-Buffering = %q, want no", b)
+	}
+	body := w.Body.String()
+	want := `data: {"app":"skychat","title":"alice","body":"hi","tag":"dm"}` + "\n\n"
+	if !strings.Contains(body, want) {
+		t.Errorf("body = %q, want it to contain %q", body, want)
+	}
+
+	// The subscription must be released, or the host-OS sink stays suppressed
+	// forever and the desktop goes permanently silent.
+	if got := hub.SubscriberCount(); got != 0 {
+		t.Errorf("SubscriberCount = %d after handler returned, want 0", got)
+	}
+}
+
+// TestNotifyStreamRouting pins the structural decision that the route lives
+// OUTSIDE the /api group. Inside it, middleware.Timeout(httpTimeout) puts a 30s
+// deadline on the whole request and would sever the stream every 30s — invisible
+// in a unit test of the handler alone, and on a live-only feed every event in
+// the reconnect gap is simply lost. It also checks the sibling routes still
+// resolve, since a static /api/notifications edge at the "/" level sits beside
+// the /api subrouter.
+func TestNotifyStreamRouting(t *testing.T) {
+	config := visorconfig.HypervisorConfig{
+		DBPath:     filepath.Join(t.TempDir(), "users.db"),
+		EnableAuth: false,
+	}
+	hv, err := NewHypervisor(config, nil, nil)
+	if err != nil {
+		t.Fatalf("NewHypervisor: %v", err)
+	}
+	defer hv.users.Close() //nolint:errcheck // test teardown
+
+	mux := hv.HTTPHandler()
+
+	t.Run("stream route resolves to the handler", func(t *testing.T) {
+		// hv.visor is nil here, so reaching the handler means 503 — the point
+		// is that it is NOT 404, i.e. the route exists and dispatches.
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/notifications/stream", nil))
+
+		if w.Code == http.StatusNotFound {
+			t.Fatal("route did not resolve: got 404")
+		}
+		if w.Code != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want %d (handler reached, no hub)", w.Code, http.StatusServiceUnavailable)
+		}
+	})
+
+	t.Run("sibling /api routes still resolve", func(t *testing.T) {
+		// A static /api/notifications edge is registered at the "/" level,
+		// beside the /api subrouter. Confirm that doesn't shadow the group.
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/ping", nil))
+
+		if w.Code == http.StatusNotFound {
+			t.Error("/api/ping stopped resolving after adding the /api/notifications edge")
+		}
+	})
+}
+
+// TestNotifyStreamPlacementRationale pins the chi behavior that dictates where
+// the route is registered: a handler inside a group carrying
+// middleware.Timeout(httpTimeout) sees a request-context deadline, and one
+// registered at the "/" level does not — even when its pattern starts /api.
+//
+// That deadline is fatal to SSE (the response is torn down at httpTimeout, and
+// on a live-only feed every event in the reconnect gap is lost), and it is
+// invisible in a handler-level test. Should someone "tidy" the route into the
+// /api group, this fails and says why.
+func TestNotifyStreamPlacementRationale(t *testing.T) {
+	var insideDeadline, outsideDeadline bool
+
+	r := chi.NewRouter()
+	r.Route("/", func(r chi.Router) {
+		r.Route("/api", func(r chi.Router) {
+			r.Use(middleware.Timeout(httpTimeout))
+			r.Get("/inside", func(_ http.ResponseWriter, req *http.Request) {
+				_, insideDeadline = req.Context().Deadline()
+			})
+		})
+		r.Route("/api/outside", func(r chi.Router) {
+			r.Get("/stream", func(_ http.ResponseWriter, req *http.Request) {
+				_, outsideDeadline = req.Context().Deadline()
+			})
+		})
+	})
+
+	for _, path := range []string{"/api/inside", "/api/outside/stream"} {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: status = %d, want 200 (route must resolve)", path, w.Code)
+		}
+	}
+
+	if !insideDeadline {
+		t.Error("a route inside the /api group should carry a request deadline; the premise of the placement is gone")
+	}
+	if outsideDeadline {
+		t.Error("a route registered outside the /api group must NOT carry a request deadline")
+	}
+}
+
+func TestGetNotifyStream_OmitsEmptyTag(t *testing.T) {
+	// Tag is optional on the wire; skychat publishes without one.
+	hub := NewNotifyHub()
+	hv := &Hypervisor{visor: &Visor{notifyHub: hub}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/notifications/stream", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		hv.getNotifyStream()(w, r)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.SubscriberCount() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("handler never subscribed to the hub")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	hub.Publish(appserver.NotifyReq{App: "skychat", Title: "alice", Body: "hi"})
+	cancel()
+	<-done
+
+	if strings.Contains(w.Body.String(), `"tag"`) {
+		t.Errorf("body = %q, want no tag field when Tag is empty", w.Body.String())
+	}
+}

--- a/pkg/visor/hypervisor_handlers_notify_test.go
+++ b/pkg/visor/hypervisor_handlers_notify_test.go
@@ -43,7 +43,7 @@ func (n *nonFlusher) Write(b []byte) (int, error) { return n.body.Write(b) }
 func (n *nonFlusher) WriteHeader(status int)      { n.status = status }
 
 func TestGetNotifyStream_NonFlusherIs500(t *testing.T) {
-	hv := &Hypervisor{visor: &Visor{notifyHub: NewNotifyHub()}}
+	hv := &Hypervisor{visor: &Visor{notifyHub: NewNotifyHub(nil)}}
 	w := &nonFlusher{}
 	r := httptest.NewRequest(http.MethodGet, "/api/notifications/stream", nil)
 
@@ -75,7 +75,7 @@ func TestGetNotifyStream_NoHubIs503(t *testing.T) {
 }
 
 func TestGetNotifyStream_StreamsEventAndEndsOnContextCancel(t *testing.T) {
-	hub := NewNotifyHub()
+	hub := NewNotifyHub(nil)
 	hv := &Hypervisor{visor: &Visor{notifyHub: hub}}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -219,7 +219,7 @@ func TestNotifyStreamPlacementRationale(t *testing.T) {
 
 func TestGetNotifyStream_OmitsEmptyTag(t *testing.T) {
 	// Tag is optional on the wire; skychat publishes without one.
-	hub := NewNotifyHub()
+	hub := NewNotifyHub(nil)
 	hv := &Hypervisor{visor: &Visor{notifyHub: hub}}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -38,7 +38,7 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 	conf := v.conf.Launcher
 
 	// Prepare proc manager.
-	procM, err := appserver.NewProcManager(v.MasterLogger(), &v.serviceDisc, v.ebc, conf.ServerAddr, v.conf.LocalPath)
+	procM, err := appserver.NewProcManager(v.MasterLogger(), &v.serviceDisc, v.ebc, v.notifyHub, conf.ServerAddr, v.conf.LocalPath)
 	if err != nil {
 		err := fmt.Errorf("failed to start proc_manager: %w", err)
 		return err

--- a/pkg/visor/notifyhub.go
+++ b/pkg/visor/notifyhub.go
@@ -29,10 +29,13 @@
 package visor
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/osnotify"
@@ -69,6 +72,13 @@ type NotifyHub struct {
 	// spawned. Both are injected so tests never post a real notification.
 	osAvailable func() bool
 	osSend      func(n appserver.NotifyReq)
+
+	// log traces which tier took each notification. Every outcome here is
+	// silent by design — a dropped event on a headless visor is normal, and
+	// the OS sink's errors are not actionable — which leaves an operator
+	// asking "why did nothing appear?" with nothing to read. One Debug line
+	// per publish answers it. Nil is valid (tests, a bare hub).
+	log logrus.FieldLogger
 }
 
 type notifySub struct {
@@ -89,13 +99,27 @@ type notifySub struct {
 // surfaces (lint and the amd64 test suite both stay silent).
 const _ = uint(0 - unsafe.Offsetof(notifySub{}.dropped)%8)
 
-// NewNotifyHub constructs an empty hub with the host-OS sink wired up.
-func NewNotifyHub() *NotifyHub {
-	return &NotifyHub{
+// NewNotifyHub constructs an empty hub with the host-OS sink wired up. log may
+// be nil; it only carries the per-publish trace.
+func NewNotifyHub(log logrus.FieldLogger) *NotifyHub {
+	h := &NotifyHub{
 		subs:        make(map[*notifySub]struct{}),
 		osAvailable: osnotify.Available,
-		osSend:      osNotifySend,
+		log:         log,
 	}
+	h.osSend = h.sendToOS
+	return h
+}
+
+// trace records the routing decision for one notification. Never the body —
+// that is routinely untrusted peer text — and not the title either, which is
+// app-controlled and can carry the same. The app name and the tier are what
+// answer "why didn't I get a notification?".
+func (h *NotifyHub) trace(app, outcome string) {
+	if h == nil || h.log == nil {
+		return
+	}
+	h.log.WithField("app", app).WithField("sink", outcome).Debug("notification routed")
 }
 
 // Publish routes n to the first tier that can deliver it (see the file header).
@@ -105,6 +129,7 @@ func (h *NotifyHub) Publish(n appserver.NotifyReq) {
 	// (a) A UI that can surface this itself owns the notification — staying
 	// quiet here is what stops an event appearing twice.
 	if h.uiCapable() {
+		h.trace(n.App, "attached-ui")
 		return
 	}
 
@@ -112,6 +137,7 @@ func (h *NotifyHub) Publish(n appserver.NotifyReq) {
 	// subscriber: a consumer that has stopped reading loses events rather than
 	// back-pressuring the publisher.
 	if h.fanout(n) {
+		h.trace(n.App, "subscriber")
 		return
 	}
 
@@ -119,12 +145,15 @@ func (h *NotifyHub) Publish(n appserver.NotifyReq) {
 	// and cheap, so it runs inline; the delivery shells out to a subprocess
 	// and so gets its own goroutine.
 	if h.osAvailable != nil && h.osSend != nil && h.osAvailable() {
+		h.trace(n.App, "host-os")
 		go h.osSend(n)
 		return
 	}
 
 	// (d) Headless: nowhere to put it. Dropping is the expected outcome on
-	// most of the fleet, so this is deliberately silent.
+	// most of the fleet, so this is not an error — but it IS the answer when
+	// someone asks why no notification appeared, so it gets a line too.
+	h.trace(n.App, "dropped-headless")
 }
 
 // fanout delivers n to every current subscriber, reporting whether there was at
@@ -211,14 +240,16 @@ func (h *NotifyHub) uiCapable() bool {
 	return !h.leaseAt.IsZero() && time.Since(h.leaseAt) < notifyCapableTTL
 }
 
-// osNotifySend posts n to the host OS notification center. Best-effort: the
-// error is deliberately discarded (osnotify itself distinguishes "no desktop
-// session" from a real failure and neither is actionable here).
+// sendToOS posts n to the host OS notification center. Best-effort: a failure
+// is not actionable and must not propagate, but it IS logged at Debug — this is
+// the last step before the user's screen, so "the notifier itself refused" and
+// "we never got here" have to be distinguishable when someone reports a missing
+// notification. ErrUnavailable is expected on a headless box and stays quiet.
 //
 // Tag is dropped: osnotify.Notification has no equivalent — coalescing is a
 // concept only the host-app sinks (Android notification tags) support.
-func osNotifySend(n appserver.NotifyReq) {
-	_ = osnotify.Notify(osnotify.Notification{ //nolint:errcheck // best-effort sink
+func (h *NotifyHub) sendToOS(n appserver.NotifyReq) {
+	err := osnotify.Notify(osnotify.Notification{
 		Title: n.Title,
 		Body:  n.Body,
 		// Keeps the visible label stable now that apps no longer pass it
@@ -227,6 +258,10 @@ func osNotifySend(n appserver.NotifyReq) {
 		// the `hv notify` bridge, which posts the same events elsewhere.
 		AppName: skyenv.AppDisplayName(n.App),
 	})
+	if err != nil && !errors.Is(err, osnotify.ErrUnavailable) && h != nil && h.log != nil {
+		// No body/title: the notifier's error text is ours, the payload is not.
+		h.log.WithError(err).WithField("app", n.App).Debug("host-OS notification failed")
+	}
 }
 
 // NotifyHub exposes the visor's notification hub. Nil-safe: a bare &Visor{}

--- a/pkg/visor/notifyhub.go
+++ b/pkg/visor/notifyhub.go
@@ -219,30 +219,14 @@ func (h *NotifyHub) uiCapable() bool {
 // concept only the host-app sinks (Android notification tags) support.
 func osNotifySend(n appserver.NotifyReq) {
 	_ = osnotify.Notify(osnotify.Notification{ //nolint:errcheck // best-effort sink
-		Title:   n.Title,
-		Body:    n.Body,
-		AppName: appDisplayName(n.App),
+		Title: n.Title,
+		Body:  n.Body,
+		// Keeps the visible label stable now that apps no longer pass it
+		// themselves — skychat used to send "Skychat", and without this its
+		// notifications would silently start reading "skychat". Shared with
+		// the `hv notify` bridge, which posts the same events elsewhere.
+		AppName: skyenv.AppDisplayName(n.App),
 	})
-}
-
-// appDisplayName maps an app's id to the label a notification center shows
-// (the Linux --app-name). Keeps the visible label stable now that apps no
-// longer pass it themselves — skychat used to send "Skychat", and without this
-// its notifications would silently start reading "skychat".
-func appDisplayName(app string) string {
-	switch app {
-	case skyenv.SkychatName:
-		return "Skychat"
-	case skyenv.SkysocksClientName:
-		return "Skysocks"
-	case skyenv.VPNClientName:
-		return "SkyVPN"
-	case skyenv.SkydexClientName:
-		return "SkyDEX"
-	case "":
-		return "Skywire"
-	}
-	return app
 }
 
 // NotifyHub exposes the visor's notification hub. Nil-safe: a bare &Visor{}

--- a/pkg/visor/notifyhub.go
+++ b/pkg/visor/notifyhub.go
@@ -1,0 +1,265 @@
+// Package visor pkg/visor/notifyhub.go c3-vis-core
+//
+// The visor-global notification hub — the "where" half of the notification
+// system whose "whether" half lives in each app (see pkg/app/appserver/notify.go).
+//
+// An app publishes a NotifyReq and stops caring. The hub owns the one decision
+// an app cannot make for itself: which delivery path can actually reach the
+// user right now. It walks a fixed priority chain and stops at the first tier
+// that can deliver, so a single event surfaces exactly once:
+//
+//	(a) an attached UI holding a fresh capability lease — a UI that will really
+//	    put this in front of the user (it also knows what is focused and muted),
+//	    so the hub must not double up. No consumer ships today: the lease is the
+//	    designed-in slot for the hypervisor manager UI's notification bell, and
+//	    it stays false until something calls MarkUICapable.
+//	(b) subscribed host apps — the Android foreground service (and later the
+//	    manager UI) reading the SSE stream, which post native notifications
+//	    through per-app channels.
+//	(c) the host OS notification center via pkg/osnotify — the desktop default.
+//	(d) nothing: on a headless visor (server, router, daemon) there is no UI, no
+//	    subscriber and no desktop session, so the event drops. That is the
+//	    normal case for most of the fleet, not an error.
+//
+// Why the tiers are ordered this way: each one is strictly "closer" to a user
+// who is actually looking. A capable UI beats a background service beats a
+// desktop toast. Suppression is always DERIVED at publish time (is anyone
+// subscribed right now?), never stored — a cached "phone is attached" flag plus
+// a dropped connection would mute the desktop permanently.
+package visor
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/osnotify"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// notifyCapableTTL is how long a UI's "I can notify" heartbeat keeps the
+// capability lease fresh. A consumer refreshes well within this window; once it
+// stops (window closed, notifications blocked, app backgrounded) the lease goes
+// stale and the hub resumes delivering through the lower tiers.
+//
+// Matches skychat's app-local lease (cmd/apps/skychat/commands/osnotify.go) —
+// this is that mechanism generalised from one app to the whole visor.
+const notifyCapableTTL = 45 * time.Second
+
+// notifySubCapacity is the default per-subscriber buffer. Notifications are
+// sparse compared with log lines, so a small buffer is plenty; anything beyond
+// it means the consumer has stopped reading and dropping is correct.
+const notifySubCapacity = 64
+
+// NotifyHub fans user-facing notifications out to whichever sink can reach the
+// user. Safe for concurrent use; every method is non-blocking.
+type NotifyHub struct {
+	mu   sync.RWMutex
+	subs map[*notifySub]struct{}
+
+	// leaseMu guards the attached-UI capability lease. Separate from mu so a
+	// heartbeat can never contend with a fan-out.
+	leaseMu sync.Mutex
+	leaseAt time.Time
+
+	// Tier-(c) host-OS sink, split so the cheap availability probe can run
+	// inline while the delivery (which shells out to a subprocess) is
+	// spawned. Both are injected so tests never post a real notification.
+	osAvailable func() bool
+	osSend      func(n appserver.NotifyReq)
+}
+
+type notifySub struct {
+	ch chan appserver.NotifyReq
+	// atomic.Uint64 rather than a bare uint64: on 32-bit targets (the 386 /
+	// arm / armhf builds this repo ships) a bare uint64 following the channel
+	// pointer lands at offset 4 and every atomic.AddUint64 on it panics with
+	// "unaligned 64-bit atomic operation". atomic.Uint64 carries its own
+	// alignment guarantee, so the field order stops mattering.
+	dropped atomic.Uint64
+	closed  atomic.Bool
+}
+
+// Compile-time guard for the alignment note above: if `dropped` ever reverts to
+// a bare uint64 its offset stops being a multiple of 8 on 32-bit targets and
+// this expression underflows, failing the build for that GOARCH. Far better
+// than a panic on a router in the field, which is the only other way this
+// surfaces (lint and the amd64 test suite both stay silent).
+const _ = uint(0 - unsafe.Offsetof(notifySub{}.dropped)%8)
+
+// NewNotifyHub constructs an empty hub with the host-OS sink wired up.
+func NewNotifyHub() *NotifyHub {
+	return &NotifyHub{
+		subs:        make(map[*notifySub]struct{}),
+		osAvailable: osnotify.Available,
+		osSend:      osNotifySend,
+	}
+}
+
+// Publish routes n to the first tier that can deliver it (see the file header).
+// Never blocks: it runs on the publishing app's single RPC serve goroutine, so
+// stalling here would stall that app's Dial/Write/Read too.
+func (h *NotifyHub) Publish(n appserver.NotifyReq) {
+	// (a) A UI that can surface this itself owns the notification — staying
+	// quiet here is what stops an event appearing twice.
+	if h.uiCapable() {
+		return
+	}
+
+	// (b) Host-app subscribers (the Android service). Non-blocking per
+	// subscriber: a consumer that has stopped reading loses events rather than
+	// back-pressuring the publisher.
+	if h.fanout(n) {
+		return
+	}
+
+	// (c) The host OS notification center. The availability probe is cached
+	// and cheap, so it runs inline; the delivery shells out to a subprocess
+	// and so gets its own goroutine.
+	if h.osAvailable != nil && h.osSend != nil && h.osAvailable() {
+		go h.osSend(n)
+		return
+	}
+
+	// (d) Headless: nowhere to put it. Dropping is the expected outcome on
+	// most of the fleet, so this is deliberately silent.
+}
+
+// fanout delivers n to every current subscriber, reporting whether there was at
+// least one. Zero subscribers is a fall-through to the next tier, NOT a drop —
+// a divergence from skychat's SSE hub, which counts a no-subscriber broadcast
+// as a drop because it is the only delivery path it has.
+func (h *NotifyHub) fanout(n appserver.NotifyReq) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	for sub := range h.subs {
+		select {
+		case sub.ch <- n:
+		default:
+			sub.dropped.Add(1)
+		}
+	}
+	return len(h.subs) > 0
+}
+
+// Subscribe returns a receive-only channel of notifications plus a cancel func
+// that closes it and reports how many events were dropped for this subscriber.
+// Cancel is idempotent and MUST be called (the SSE handler defers it) or the
+// subscriber leaks and keeps suppressing the host-OS sink forever.
+func (h *NotifyHub) Subscribe(capacity int) (<-chan appserver.NotifyReq, func() uint64) {
+	if capacity <= 0 {
+		capacity = notifySubCapacity
+	}
+	sub := &notifySub{ch: make(chan appserver.NotifyReq, capacity)}
+
+	h.mu.Lock()
+	h.subs[sub] = struct{}{}
+	h.mu.Unlock()
+
+	cancel := func() uint64 {
+		if !sub.closed.CompareAndSwap(false, true) {
+			return sub.dropped.Load()
+		}
+		// Take the write lock so any in-flight fanout holding RLock has
+		// finished iterating before we delete and close — otherwise this
+		// races into a send on a closed channel.
+		h.mu.Lock()
+		delete(h.subs, sub)
+		h.mu.Unlock()
+		close(sub.ch)
+		return sub.dropped.Load()
+	}
+	return sub.ch, cancel
+}
+
+// SubscriberCount reports how many host apps are currently subscribed.
+func (h *NotifyHub) SubscriberCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return len(h.subs)
+}
+
+// MarkUICapable refreshes (capable) or clears (!capable) the attached-UI
+// capability lease. Nothing calls it yet — it is the seam the hypervisor
+// manager UI's notification bell will heartbeat on, mirroring skychat's
+// POST /notify-capable.
+//
+// The lease means "a UI that will ACTUALLY surface this to the user is
+// attached", not merely "a UI is connected": a backgrounded mobile WebView can
+// show nothing, so it must stop heartbeating or it would silence the native
+// path (01_playbook.md Step 4a).
+func (h *NotifyHub) MarkUICapable(capable bool) {
+	h.leaseMu.Lock()
+	defer h.leaseMu.Unlock()
+
+	if capable {
+		h.leaseAt = time.Now()
+		return
+	}
+	h.leaseAt = time.Time{}
+}
+
+// uiCapable reports whether the capability lease is currently fresh.
+func (h *NotifyHub) uiCapable() bool {
+	h.leaseMu.Lock()
+	defer h.leaseMu.Unlock()
+
+	return !h.leaseAt.IsZero() && time.Since(h.leaseAt) < notifyCapableTTL
+}
+
+// osNotifySend posts n to the host OS notification center. Best-effort: the
+// error is deliberately discarded (osnotify itself distinguishes "no desktop
+// session" from a real failure and neither is actionable here).
+//
+// Tag is dropped: osnotify.Notification has no equivalent — coalescing is a
+// concept only the host-app sinks (Android notification tags) support.
+func osNotifySend(n appserver.NotifyReq) {
+	_ = osnotify.Notify(osnotify.Notification{ //nolint:errcheck // best-effort sink
+		Title:   n.Title,
+		Body:    n.Body,
+		AppName: appDisplayName(n.App),
+	})
+}
+
+// appDisplayName maps an app's id to the label a notification center shows
+// (the Linux --app-name). Keeps the visible label stable now that apps no
+// longer pass it themselves — skychat used to send "Skychat", and without this
+// its notifications would silently start reading "skychat".
+func appDisplayName(app string) string {
+	switch app {
+	case skyenv.SkychatName:
+		return "Skychat"
+	case skyenv.SkysocksClientName:
+		return "Skysocks"
+	case skyenv.VPNClientName:
+		return "SkyVPN"
+	case skyenv.SkydexClientName:
+		return "SkyDEX"
+	case "":
+		return "Skywire"
+	}
+	return app
+}
+
+// NotifyHub exposes the visor's notification hub. Nil-safe: a bare &Visor{}
+// (test fixtures) has no hub.
+func (v *Visor) NotifyHub() *NotifyHub {
+	if v == nil {
+		return nil
+	}
+	return v.notifyHub
+}
+
+// SubscribeNotifications registers a host-app subscriber on the visor's hub,
+// mirroring SubscribeLogs. Returns a nil channel when there is no hub so
+// callers can answer "unavailable" rather than panic.
+func (v *Visor) SubscribeNotifications(capacity int) (<-chan appserver.NotifyReq, func() uint64) {
+	if v == nil || v.notifyHub == nil {
+		return nil, func() uint64 { return 0 }
+	}
+	return v.notifyHub.Subscribe(capacity)
+}

--- a/pkg/visor/notifyhub_test.go
+++ b/pkg/visor/notifyhub_test.go
@@ -70,7 +70,7 @@ func (o *osRecorder) refuteOS(t *testing.T) {
 // newTestHub builds a hub whose host-OS tier is a recorder.
 func newTestHub(available bool) (*NotifyHub, *osRecorder) {
 	rec := newOSRecorder(available)
-	h := NewNotifyHub()
+	h := NewNotifyHub(nil)
 	h.osAvailable = rec.isAvailable
 	h.osSend = rec.send
 	return h, rec

--- a/pkg/visor/notifyhub_test.go
+++ b/pkg/visor/notifyhub_test.go
@@ -1,0 +1,344 @@
+// Package visor — pkg/visor/notifyhub_test.go: pins the notification hub's
+// priority chain, which is the whole point of the type. The chain (capable UI >
+// host-app subscribers > host OS > drop) is what guarantees an event surfaces
+// exactly ONCE, so every tier boundary gets a test: silence when a UI holds the
+// lease, no host-OS post while a subscriber is attached, and — the regression
+// that would silently mute a desktop — the host-OS path returning the moment
+// the last subscriber goes away.
+//
+// The real host-OS sink is never invoked: both osnotify seams are replaced with
+// recorders, so the suite posts no desktop notification on a developer machine.
+package visor
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appserver"
+)
+
+// osRecorder stands in for the host-OS sink (tier c).
+type osRecorder struct {
+	mu        sync.Mutex
+	got       []appserver.NotifyReq
+	available bool
+	fired     chan struct{}
+}
+
+func newOSRecorder(available bool) *osRecorder {
+	return &osRecorder{available: available, fired: make(chan struct{}, 16)}
+}
+
+func (o *osRecorder) isAvailable() bool { return o.available }
+
+func (o *osRecorder) send(n appserver.NotifyReq) {
+	o.mu.Lock()
+	o.got = append(o.got, n)
+	o.mu.Unlock()
+	o.fired <- struct{}{}
+}
+
+func (o *osRecorder) calls() []appserver.NotifyReq {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]appserver.NotifyReq(nil), o.got...)
+}
+
+// awaitOS waits for the host-OS sink to fire, which happens on its own
+// goroutine. Fails the test rather than hanging if it never does.
+func (o *osRecorder) awaitOS(t *testing.T) {
+	t.Helper()
+	select {
+	case <-o.fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("host-OS sink never fired")
+	}
+}
+
+// refuteOS asserts the host-OS sink stays silent. The wait has to be long
+// enough that a wrongly-spawned goroutine would have run.
+func (o *osRecorder) refuteOS(t *testing.T) {
+	t.Helper()
+	select {
+	case <-o.fired:
+		t.Fatal("host-OS sink fired but a higher-priority tier should have claimed the event")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// newTestHub builds a hub whose host-OS tier is a recorder.
+func newTestHub(available bool) (*NotifyHub, *osRecorder) {
+	rec := newOSRecorder(available)
+	h := NewNotifyHub()
+	h.osAvailable = rec.isAvailable
+	h.osSend = rec.send
+	return h, rec
+}
+
+func TestNotifyHub_OSSinkWhenNothingElseAttached(t *testing.T) {
+	// The plain-desktop case: no UI lease, no subscriber → the host OS gets it.
+	h, rec := newTestHub(true)
+
+	h.Publish(appserver.NotifyReq{App: "skychat", Title: "alice", Body: "hi"})
+
+	rec.awaitOS(t)
+	got := rec.calls()
+	if len(got) != 1 {
+		t.Fatalf("host-OS sink calls = %d, want 1", len(got))
+	}
+	if got[0].Title != "alice" || got[0].Body != "hi" {
+		t.Errorf("host-OS sink got %+v, want title=alice body=hi", got[0])
+	}
+}
+
+func TestNotifyHub_CapableUISuppressesEverythingBelow(t *testing.T) {
+	// Tier (a): a UI that will surface this itself owns the notification.
+	// Publishing anyway is what would make an event appear twice.
+	h, rec := newTestHub(true)
+	ch, cancel := h.Subscribe(4)
+	defer cancel()
+
+	h.MarkUICapable(true)
+	h.Publish(appserver.NotifyReq{App: "skychat", Title: "alice", Body: "hi"})
+
+	rec.refuteOS(t)
+	select {
+	case n := <-ch:
+		t.Fatalf("subscriber received %+v, but a capable UI outranks it", n)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestNotifyHub_SubscriberSuppressesOSSink(t *testing.T) {
+	// Tier (b) outranks tier (c): a host app posts natively, so the visor must
+	// not also raise a desktop toast for the same event.
+	h, rec := newTestHub(true)
+	ch, cancel := h.Subscribe(4)
+	defer cancel()
+
+	h.Publish(appserver.NotifyReq{App: "skychat", Title: "alice", Body: "hi"})
+
+	select {
+	case n := <-ch:
+		if n.Title != "alice" {
+			t.Errorf("subscriber got title %q, want alice", n.Title)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("subscriber never received the notification")
+	}
+	rec.refuteOS(t)
+}
+
+func TestNotifyHub_OSSinkReturnsAfterLastSubscriberLeaves(t *testing.T) {
+	// The regression this guards: suppression is DERIVED per publish, never
+	// cached. A stored "a host app is attached" flag plus a dropped phone
+	// connection would mute the desktop permanently.
+	h, rec := newTestHub(true)
+	_, cancel := h.Subscribe(4)
+
+	h.Publish(appserver.NotifyReq{App: "skychat", Title: "first"})
+	rec.refuteOS(t)
+
+	cancel()
+	if got := h.SubscriberCount(); got != 0 {
+		t.Fatalf("SubscriberCount after cancel = %d, want 0", got)
+	}
+
+	h.Publish(appserver.NotifyReq{App: "skychat", Title: "second"})
+	rec.awaitOS(t)
+	got := rec.calls()
+	if len(got) != 1 || got[0].Title != "second" {
+		t.Fatalf("host-OS sink calls = %+v, want exactly the post-cancel one", got)
+	}
+}
+
+func TestNotifyHub_LeaseExpiryRestoresLowerTiers(t *testing.T) {
+	// The lease is time-bounded so a UI that dies without clearing it can't
+	// silence notifications forever.
+	h, rec := newTestHub(true)
+
+	h.MarkUICapable(true)
+	if !h.uiCapable() {
+		t.Fatal("lease should be fresh immediately after MarkUICapable(true)")
+	}
+
+	// Backdate past the TTL rather than sleeping for it.
+	h.leaseMu.Lock()
+	h.leaseAt = time.Now().Add(-notifyCapableTTL - time.Second)
+	h.leaseMu.Unlock()
+
+	if h.uiCapable() {
+		t.Fatal("lease should be stale once older than notifyCapableTTL")
+	}
+	h.Publish(appserver.NotifyReq{App: "skychat", Title: "after expiry"})
+	rec.awaitOS(t)
+}
+
+func TestNotifyHub_MarkUICapableFalseClearsLease(t *testing.T) {
+	h, rec := newTestHub(true)
+
+	h.MarkUICapable(true)
+	h.MarkUICapable(false)
+
+	if h.uiCapable() {
+		t.Fatal("lease should be cleared by MarkUICapable(false)")
+	}
+	h.Publish(appserver.NotifyReq{App: "skychat", Title: "x"})
+	rec.awaitOS(t)
+}
+
+func TestNotifyHub_HeadlessDropsSilently(t *testing.T) {
+	// The common fleet case: server/router visor, no UI, no subscriber, no
+	// desktop session. Dropping is the expected outcome, not an error.
+	h, rec := newTestHub(false)
+
+	h.Publish(appserver.NotifyReq{App: "skychat", Title: "nobody home"})
+
+	rec.refuteOS(t)
+	if got := len(rec.calls()); got != 0 {
+		t.Errorf("host-OS sink calls = %d, want 0 when unavailable", got)
+	}
+}
+
+func TestNotifyHub_SlowSubscriberDropsRatherThanBlocks(t *testing.T) {
+	// A consumer that stops reading must lose events, never back-pressure the
+	// publisher — Publish runs on the app's RPC serve goroutine.
+	h, _ := newTestHub(true)
+	_, cancel := h.Subscribe(1)
+
+	for i := 0; i < 5; i++ {
+		h.Publish(appserver.NotifyReq{App: "skychat", Title: "x"})
+	}
+
+	// One fits the buf=1 channel; the other four drop.
+	if dropped := cancel(); dropped != 4 {
+		t.Errorf("dropped = %d, want 4", dropped)
+	}
+}
+
+func TestNotifyHub_CancelIsIdempotent(t *testing.T) {
+	// The SSE handler defers cancel; a double call must not close twice.
+	h, _ := newTestHub(true)
+	_, cancel := h.Subscribe(2)
+
+	h.Publish(appserver.NotifyReq{App: "skychat", Title: "x"})
+	first := cancel()
+	second := cancel()
+
+	if first != second {
+		t.Errorf("second cancel returned %d, want the same %d", second, first)
+	}
+	if got := h.SubscriberCount(); got != 0 {
+		t.Errorf("SubscriberCount = %d after double cancel, want 0", got)
+	}
+}
+
+func TestNotifyHub_FanoutReachesEverySubscriber(t *testing.T) {
+	h, _ := newTestHub(true)
+	const subs = 3
+
+	chans := make([]<-chan appserver.NotifyReq, subs)
+	for i := 0; i < subs; i++ {
+		ch, cancel := h.Subscribe(4)
+		defer cancel()
+		chans[i] = ch
+	}
+	if got := h.SubscriberCount(); got != subs {
+		t.Fatalf("SubscriberCount = %d, want %d", got, subs)
+	}
+
+	h.Publish(appserver.NotifyReq{App: "skychat", Title: "broadcast"})
+
+	for i, ch := range chans {
+		select {
+		case n := <-ch:
+			if n.Title != "broadcast" {
+				t.Errorf("subscriber %d got title %q, want broadcast", i, n.Title)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("subscriber %d never received the notification", i)
+		}
+	}
+}
+
+func TestNotifyHub_ConcurrentPublishSubscribeCancel(t *testing.T) {
+	// Race detector coverage for the one genuinely dangerous interaction:
+	// cancel deletes+closes a subscriber channel while a fan-out may be
+	// mid-iteration. Without the write-lock-before-close discipline this is a
+	// send-on-closed-channel panic.
+	h, _ := newTestHub(false) // no OS sink goroutines to leak
+	const workers = 16
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				h.Publish(appserver.NotifyReq{App: "skychat", Title: "x"})
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				ch, cancel := h.Subscribe(1)
+				select {
+				case <-ch:
+				default:
+				}
+				cancel()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := h.SubscriberCount(); got != 0 {
+		t.Errorf("SubscriberCount = %d after all cancels, want 0", got)
+	}
+}
+
+func TestAppDisplayName(t *testing.T) {
+	// The label a notification center shows. skychat used to pass "Skychat"
+	// itself; now that the hub owns it, the visible name must not drift to the
+	// lowercase app id.
+	cases := []struct {
+		app  string
+		want string
+	}{
+		{"skychat", "Skychat"},
+		{"vpn-client", "SkyVPN"},
+		{"skysocks-client", "Skysocks"},
+		{"skydex-client", "SkyDEX"},
+		{"", "Skywire"},
+		{"some-future-app", "some-future-app"},
+	}
+	for _, c := range cases {
+		if got := appDisplayName(c.app); got != c.want {
+			t.Errorf("appDisplayName(%q) = %q, want %q", c.app, got, c.want)
+		}
+	}
+}
+
+func TestVisor_SubscribeNotifications_NilSafe(t *testing.T) {
+	// Bare &Visor{} fixtures are common in this package; the accessor must
+	// answer "unavailable" rather than panic so the SSE handler can 503.
+	var v *Visor
+	ch, cancel := v.SubscribeNotifications(1)
+	if ch != nil {
+		t.Error("nil visor should yield a nil channel")
+	}
+	if got := cancel(); got != 0 {
+		t.Errorf("nil-visor cancel returned %d, want 0", got)
+	}
+
+	empty := &Visor{}
+	if ch, _ := empty.SubscribeNotifications(1); ch != nil {
+		t.Error("visor without a hub should yield a nil channel")
+	}
+	if empty.NotifyHub() != nil {
+		t.Error("visor without a hub should report a nil hub")
+	}
+}

--- a/pkg/visor/notifyhub_test.go
+++ b/pkg/visor/notifyhub_test.go
@@ -300,28 +300,6 @@ func TestNotifyHub_ConcurrentPublishSubscribeCancel(t *testing.T) {
 	}
 }
 
-func TestAppDisplayName(t *testing.T) {
-	// The label a notification center shows. skychat used to pass "Skychat"
-	// itself; now that the hub owns it, the visible name must not drift to the
-	// lowercase app id.
-	cases := []struct {
-		app  string
-		want string
-	}{
-		{"skychat", "Skychat"},
-		{"vpn-client", "SkyVPN"},
-		{"skysocks-client", "Skysocks"},
-		{"skydex-client", "SkyDEX"},
-		{"", "Skywire"},
-		{"some-future-app", "some-future-app"},
-	}
-	for _, c := range cases {
-		if got := appDisplayName(c.app); got != c.want {
-			t.Errorf("appDisplayName(%q) = %q, want %q", c.app, got, c.want)
-		}
-	}
-}
-
 func TestVisor_SubscribeNotifications_NilSafe(t *testing.T) {
 	// Bare &Visor{} fixtures are common in this package; the accessor must
 	// answer "unavailable" rather than panic so the SSE handler can 503.

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -660,7 +660,7 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1, logBcast *logging.Broad
 	// Constructed eagerly rather than as an init module: the hub has no
 	// dependencies and locks internally, and building it here removes any
 	// window where an app publishing early finds a nil hub.
-	v.notifyHub = NewNotifyHub()
+	v.notifyHub = NewNotifyHub(v.conf.MasterLogger().PackageLogger("visor:notify"))
 	v.startedAt = time.Now()
 	v.startupComplete = make(chan struct{})
 

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -193,6 +193,10 @@ type Visor struct {
 	// so the sky-forwarding server can dispatch without localhost TCP.
 	services *ServiceRegistry
 
+	// Visor-global notification hub — apps publish user-facing
+	// notifications here and it picks the sink that can reach the user.
+	notifyHub *NotifyHub
+
 	// Skywire ping state
 	ping pingState
 
@@ -653,6 +657,10 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1, logBcast *logging.Broad
 	v.logBcast = logBcast
 	v.logstore = logStore
 	v.services = NewServiceRegistry()
+	// Constructed eagerly rather than as an init module: the hub has no
+	// dependencies and locks internally, and building it here removes any
+	// window where an app publishing early finds a nil hub.
+	v.notifyHub = NewNotifyHub()
 	v.startedAt = time.Now()
 	v.startupComplete = make(chan struct{})
 


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes Part of #3559

**Changes**
Apps had no way to reach a user who isn't looking at them. skychat was the only app with notifications, and it posted straight to the host OS itself — which meant every other app would have had to duplicate that code, and it only ever worked when the visor and the user were the same desktop machine. This splits the problem: the app decides whether an event deserves attention, the visor decides where it can land.

New: visor-global notification hub
  - pkg/visor/notifyhub.go — routes each notification down a fixed priority chain and stops at the first tier that can deliver, so one event surfaces exactly once: (a) an attached UI holding a fresh capability lease → (b) subscribed host apps on the SSE stream → (c) the host OS via pkg/osnotify → (d) dropped (headless — the normal case for most of the fleet, not an error).
  - Suppression is derived per publish, never cached: a cached "a subscriber is attached" flag plus a dropped connection would mute the desktop permanently.
  - Publish never blocks — it runs on the publishing app's single RPC serve goroutine, so a slow sink would stall that app's Dial/Write/Read too. Slow subscribers lose events rather than back-pressure the publisher.
  - Hub is constructed eagerly in NewVisor (no init module) so there's no window where an app publishing early finds a nil hub.
  - notifySub.dropped is an atomic.Uint64 with a compile-time offset guard — a bare uint64 at offset 4 panics on the 32-bit (386/arm/armhf) builds this repo ships, and neither lint nor the amd64 suite would catch it.

New: app-facing API (one call, no OS-specific code)
  - pkg/app/appserver/notify.go — NotifyReq{App,Title,Body,Tag} + a one-method NotificationHub seam. Deliberately transport-free: appserver must keep compiling for GOOS=js/wasm and TinyGo, so all net/http/os/exec concerns live on the pkg/visor side.
  - pkg/app/client.go — Notify / NotifyOrLog(title, body, tag), best-effort and nil-safe like SetStatusOrLog, so apps that can run standalone don't guard every call site. The body is never logged (it's routinely untrusted peer text).
  - RPCIngressGateway.Notify overwrites the App field from the calling proc's own identity instead of trusting it — otherwise any app could publish under skychat's name. Payload is withheld from rpcutil.LogCall for the same untrusted-body reason.
  - Proc/procManager carry the hub; nil hub is valid and means "drop" — used by unit tests and by cmd/wasm-visor (a browser tab has no OS notification centre and no subscriber).
  - pkg/skyenv.AppDisplayName — app id → user-visible label, shared by the local OS sink and the hv notify bridge so an event looks identical either way. Needed because apps stopped passing their own label, and without it skychat's notifications would have silently started reading "skychat".

New: SSE stream for host apps
  - GET /api/notifications/stream (pkg/visor/hypervisor_handlers_notify.go) — live-only, no replay: a reconnecting client getting a burst of stale "you had a message" toasts is worse than missing them.
  - Registered outside the /api group on purpose — that group's middleware.Timeout(httpTimeout) is a 30s deadline on the whole request and would sever a long-lived stream (same reason /pty sits out). Auth is opted into explicitly instead.
  - Write deadline is re-armed per write rather than cleared (which is what getLog does): clearing it leaves no liveness bound at all, so a peer that holds the socket open but stops reading parks the handler forever inside a write — and since subscriber presence suppresses the OS sink, the desktop would go permanently silent. A 20s ping makes a vanished client observable on a feed that can legitimately be quiet for hours.

New: skywire-cli hv notify
  - Subscribes to a visor's stream and posts each event to this machine's notification centre — because the visor and the user are often not the same box: a containerised/headless visor has no desktop session, and a UI browsed over the LAN isn't a secure context so the browser's Notification API is unavailable there too.
  - While it's connected the visor stops posting its own OS notifications, so nothing doubles.
  - --print prints instead of posting (headless/CI-friendly), --user/--pass for auth-enabled hypervisors, auto-reconnect with capped backoff, and Ctrl-C unsubscribes promptly so the OS sink is restored.

Existing apps moved onto it

  - skychat now publishes to the hub instead of posting to the OS itself; the "should I notify?" gate is factored out as shouldNotifyOS(enabled, uiCapable). The gate no longer consults osnotify.Available() — it can't, since sinks other than the local desktop must still fire; this is behaviour-neutral on desktop because osnotify.Notify re-checks availability itself. --standalone (no visor, no hub) keeps posting directly.
  - skychat UI — fixes a real bug: the notification pref defaults to ON, and permission was only ever requested on an off→on flip of a switch that was already on, so a fresh browser profile was never prompted and every notification was silently dropped. Adds a first-run "Allow notifications" nudge in the sidebar (dismissable, persisted), an Allow button in the bell modal, and a prompt on opening the bell (all inside real user gestures, which browsers require). Capability is reported to the server immediately after a decision instead of waiting out the 45s lease.
  - skydex-client — notifies on market dial outcome only once the dial has outrun a 3s attention window (a dial is always user-initiated and the engine already renders the result inline on the form the user is still watching), plus an abnormal-exit notification. That one is gated on ctx.Err() == nil, not err != nil: the vendored engine swallows its own fatal errors and returns nil, so an err != nil guard would have been dead code.

Docs
  - docs/app_implement_guidance.md §5.3 "User Notifications" for app authors: the whether/where split, the five rules (don't notify appserver must keep compiling for GOOS=js/wasm and TinyGo, so all net/http/os/exec concerns live on the pkg/visor side.
  - pkg/app/client.go — Notify / NotifyOrLog(title, body, tag), best-effort and nil-safe like SetStatusOrLog, so apps that can run standalone don't guard every call site. The body is never logged (it's routinely untrusted peer text).
  - RPCIngressGateway.Notify overwrites the App field from the calling proc's own identity instead of trusting it — otherwise any app could publish under skychat's name. Payload is withheld from rpcutil.LogCall for the same untrusted-body reason.
  - Proc/procManager carry the hub; nil hub is valid and means "drop" — used by unit tests and by cmd/wasm-visor (a browser tab has no OS notification centre and no subscriber).
  - pkg/skyenv.AppDisplayName — app id → user-visible label, shared by the local OS sink and the hv notify bridge so an event looks identical either way. Needed because apps stopped passing their own label, and without it skychat's notifications would have silently started reading "skychat".


**How to test**

Unit tests (all pass locally):
  ```
  go test ./pkg/visor/ -run 'TestNotifyHub|TestGetNotifyStream|TestNotifyStream|TestVisor_SubscribeNotifications' -count=1
  go test ./pkg/app/appserver/ ./pkg/skyenv/ -run 'Notify|AppDisplayName' -count=1
  go test ./cmd/apps/skychat/commands/ -run 'ShouldNotifyOS|NotifyOSInbound' -count=1
  make format && make check
  ```

End-to-end, headless (no desktop needed) — this is the fastest full-path check:
  1. make e2e-build && make e2e-run && make e2e-skychat (three visors; visor-b is the hypervisor on 127.0.0.1:8000, skychat UIs on 8001/8002/8003).
  2. In one terminal: skywire-cli hv notify --print --addr http://127.0.0.1:8000 → prints Listening for notifications….
  3. Open visor-a's UI (127.0.0.1:8001) and send a message to visor-b's PK. Close visor-b's tab (:8002) first — an open, permission-granted tab holds the capability lease and correctly suppresses everything below it.
  4. Expect one line like 20:17:49  [skychat] 024ec474…58c7 — hello there.
  5. Re-open visor-b's tab and send again → nothing prints (tier (a) wins). Close it, wait out the ~45s lease, send again → it prints.
  6. Kill the hv notify process and send again → the visor falls back to its OS sink (dropped in the container; verify by restarting the bridge and seeing events resume, proving the subscriber set isn't cached).
  7. Leave the bridge idle >20s and confirm the stream stays up (ping keepalive) rather than dying at the 10s server write timeout.

Desktop toast path: run a visor locally with skychat, close all skychat tabs, message it from another visor → a real OS notification titled from AppDisplayName ("Skychat"). Open a tab with notifications allowed → the Web Notification fires instead, and only once.

Browser permission fix (needs a fresh profile or "Reset permission" for the origin — the bug only shows in the default permission state):
  - Load the skychat UI → the sidebar nudge appears; click Allow → browser prompt appears, nudge disappears, notifications work.
  - Reset again → click ✕ → nudge stays gone across reloads; the bell modal still offers "Allow notifications" and opening the bell also prompts.
  - With permission already granted or denied, the nudge must never appear.

skydex-client: dial a market PK that resolves fast → no notification (the user is still on the form). Dial an unreachable PK so it hangs past 3s → one "Could not reach market …" notification. Kill the engine process while the app is running → "Trading client stopped unexpectedly"; stop the app normally → silence.

Auth + build coverage:
  - skywire-cli hv notify --addr … -u <user> -p <pass> against an auth-enabled hypervisor; without credentials it should report unauthorized.
  - skywire-cli hv notify --print against a stopped visor → retries with backoff instead of exiting or busy-looping.
  - Confirm cmd/wasm-visor still builds (it passes a nil hub) and cross-compile one 32-bit target (e.g. GOARCH=386 go build ./pkg/visor/) to exercise the atomic-alignment guard.