### PR TITLE
Improve Skychat on UI, Groups and Channel feature

### DIFF
--- a/cmd/apps/skychat/README.md
+++ b/cmd/apps/skychat/README.md
@@ -74,12 +74,21 @@ don't lose data.
 ## Group chat
 
 ```bash
-# Owner: create a group, get an invite link
-skywire cli skychat group create my-room
-skywire cli skychat group invite <group-id>
+# Owner: create a group, a private group, or a broadcast channel
+skywire cli skychat group create --name my-room
+skywire cli skychat group create --name ops --kind private
+skywire cli skychat group create --name news --kind channel
 
-# Member: join via the invite link
+# Hand it out — as a link, or as a short address
+skywire cli skychat group invite  <group-id>   # skychat:invite:<base64url>
+skywire cli skychat group address <group-id>   # skychat://<host-pk>/<group-id>
+
+# Member: join by either form
 skywire cli skychat group join <invite-link>
+skywire cli skychat group join skychat://<host-pk>/<group-id>
+
+# "what is this thing someone sent me?"
+skywire cli skychat group resolve <address-or-link>
 
 # Send / read
 skywire cli skychat group send <group-id> "hi everyone"
@@ -87,6 +96,52 @@ skywire cli skychat group listen
 skywire cli skychat group info <group-id>
 skywire cli skychat group list
 ```
+
+### Group kinds
+
+| kind | admission | bodies | who posts |
+|---|---|---|---|
+| `public` | open — anyone who asks | plaintext on the feed | every member |
+| `private` | an admin approves each request | encrypted | every member |
+| `channel` | open — anyone who asks | plaintext on the feed | admins only |
+
+Public and channel bodies are plaintext for the same reason: admission is
+open, so the key would go to any stranger who asked and would protect
+nothing. Transport is Noise-encrypted regardless. A channel differs from
+the reversible `read_only` flag in being permanent — it is what the group
+*is*, not what an admin has currently switched on — which is why the
+reader-side gate drops a non-admin's leaves whatever their age.
+
+### Addresses vs invite links
+
+Two ways to name a conversation, and they trade against each other rather
+than one superseding the other:
+
+```
+skychat://<pk>                 a person — opens a DM
+skychat://<pk>/<group-id>      a group or channel
+skychat:invite:<base64url>     a group invite
+```
+
+An **address** is short enough to print, read aloud, or encode in a
+low-density QR code, and stays valid as the group changes. It is not
+self-contained: a group's feed port is allocated at random per group, so
+whoever holds an address asks the host what the group is before joining
+(one round trip on `skyenv.SkychatGroupProbePort`, describe-only — it
+decides nothing and mutates nothing). That means the host has to be
+reachable.
+
+An **invite link** carries the port, mode, admin list and proof-of-work
+price inline, so it works while the host is offline — at a few hundred
+characters, which is why it is not the thing you scan.
+
+Both go through the same admission gate. An address is a shorter way to
+name a group, not a way around its door.
+
+Whether a bare public key belongs to a person or to the host of a channel
+is not decidable by inspection — they are the same 66 characters. Only a
+group ID in the address distinguishes them, which is why `resolve` exists
+and why the UI asks before it offers an action.
 
 Groups are built on top of CXO TreeStore feeds. The owner publishes
 the canonical group feed; members subscribe and (post-#2539)
@@ -155,13 +210,35 @@ afterwards has a fallback door. The founder is still the group's
 immutable recovery anchor and is still asked first; it just isn't the
 only one who can let people in.
 
-The browser UI mirrors this with a Groups sidebar (create/join
-modals, per-sender message labels), backed by an HTTP proxy to the
-visor's group RPC — `GET/POST /group`, `POST /group/join`, and
+The browser UI mirrors this, backed by an HTTP proxy to the visor's
+group RPC — `GET/POST /group`, `POST /group/join` (which takes either
+`{invite}` or `{address}`), `GET /group/resolve?address=…`, and
 `/group/<id>/{invite,send,leave,history}`. It needs the visor RPC
 connection (`--pair-enable`); without it the Groups section stays
 hidden and the UI is DM-only. Group text is decrypted by the visor
 for private groups, so the browser never handles keys.
+
+Starting anything is one button — bottom-right on a phone, in the sidebar
+header otherwise — offering **Add by address**, **New group** and **New
+channel**. "Add by address" takes one field for every way of naming
+something: a bare public key, a `skychat://` address, an invite link, or a
+scanned QR code. It resolves the input first and then offers the single
+action that applies — Start Chat, Join Group, Send Request, or Join
+Channel — so nobody has to know which kind of thing they are holding.
+
+Every open conversation can show its own address as a QR code, with the
+address printed underneath as selectable text plus a copy button: a code
+is useless over a screen share, in a terminal, or on a device with no
+camera. Scanning uses the browser's own `BarcodeDetector` (Chrome, Edge,
+Android WebView) from the camera or from a chosen image; where the API is
+absent the dialog says so and the paste field — its primary input anyway —
+still works. The camera needs a secure context, which plain http only
+satisfies on `127.0.0.1`/`localhost`.
+
+Below 760px the sidebar and the chat stop sharing the screen: the list is
+the screen until a conversation is opened, which then replaces it and
+grows a back button. The device back button returns to the list rather
+than leaving the app.
 
 ## Media & files (browser UI)
 

--- a/cmd/apps/skychat/README.md
+++ b/cmd/apps/skychat/README.md
@@ -112,6 +112,40 @@ the reversible `read_only` flag in being permanent — it is what the group
 *is*, not what an admin has currently switched on — which is why the
 reader-side gate drops a non-admin's leaves whatever their age.
 
+**A channel's kind is immutable.** The store refuses any write that would
+change a persisted group's `Kind`, including one that merely omits it —
+`EnsureKind` would re-derive an empty kind from `Mode`, and a channel shares
+`ModePublic` with a public group, so a forgetful write would silently hand
+the floor to every subscriber. There is no migration: the honest way to turn
+a channel into a group is to create a group.
+
+### What makes a channel scale
+
+Three things differ from a group, and all three follow from "the audience
+is unbounded and one-way":
+
+**Subscriptions are O(admins), not O(members).** Under the group rule an
+admin follows every member — an input pipe worth having when everyone can
+post. In a channel a subscriber's feed can never carry a message, so both
+roles follow only the admins. Without this, an admin of a 10,000-subscriber
+channel would open 10,000 CXO subscriptions to feeds guaranteed to stay
+empty.
+
+**History and files come from admins.** `PeerBackfillEnabled` is always
+false for a channel, whatever the stored flag says: a subscriber has nothing
+of its own to serve, so mirroring the room onto every follower would give a
+large channel one copy of itself per member. `SetPeerBackfill` is refused on
+a channel rather than accepted-and-ignored.
+
+**Backlog arrives in chunks, and files only on request.** A joiner takes the
+newest page immediately and walks backwards as it reads
+(`history.Store.ListGroupBefore`, `GET /group/<id>/history?before=<ts_nano>`)
+instead of pulling an entire archive before showing anything. Attachments
+are published as feed references and nothing more — `acceptInbound` refuses
+an unrequested file in a channel even from an admin, so one admin attaching
+a 2 GB file cannot land it on every subscriber's disk at once. Opening the
+card requests that one file from a host that has it.
+
 ### Addresses vs invite links
 
 Two ways to name a conversation, and they trade against each other rather
@@ -142,6 +176,50 @@ Whether a bare public key belongs to a person or to the host of a channel
 is not decidable by inspection — they are the same 66 characters. Only a
 group ID in the address distinguishes them, which is why `resolve` exists
 and why the UI asks before it offers an action.
+
+### Discovery catalog
+
+A channel is the one thing here that is useless without discovery: a group
+gets its members from people who already know each other, but a channel
+wants an audience it has not met. So a visor can publish a catalog of its
+own groups and channels, and anyone holding its public key can ask:
+
+```bash
+skywire cli skychat group publish <group-id> on   # opt in (admin-only)
+skywire cli skychat group catalog <host-pk>       # ask a visor
+skywire cli skychat group catalog                 # see your own listing
+```
+
+**Opt-in, off by default, and that direction is load-bearing.** The catalog
+is the only mechanism in skychat that turns one public key into a *list*, so
+an entry has to be asked for — nothing a visor hosts becomes enumerable
+because somebody didn't read a checkbox, and existing records stay unlisted
+across the upgrade.
+
+`Listed` is **local and not gossiped**: it says what *this* visor answers
+questions about, which is a hosting decision rather than a property of the
+group. Two admins of the same channel can legitimately differ on whether
+they advertise it, and neither can un-list the other's copy — which is
+honest, because they never could.
+
+It shares the well-known probe port but is a *separate frame*, not the same
+request with an empty field, because the two disclose different things: a
+probe confirms one 122-bit group ID the asker already held, while a catalog
+turns a key into a list. Entries carry no member count — a listing is an
+invitation to join, not a report on who already did.
+
+There is no network-wide index, no aggregator and no registration. A catalog
+is served by the host itself and answers only for the host's own groups, so
+discovering anything still starts from a public key a human gave you. That
+keeps the trust model identical to the rest of skychat while removing the
+part that was actually painful: needing a fresh invite link per person for
+something meant to be public.
+
+In the browser UI this surfaces where it is useful rather than as a separate
+screen — entering a public key in **Add by address** also lists the channels
+that visor publishes, and tapping one fills the field so it is confirmed
+through the same path as a pasted address. Nothing is joined by tapping a
+row in a list.
 
 Groups are built on top of CXO TreeStore feeds. The owner publishes
 the canonical group feed; members subscribe and (post-#2539)

--- a/cmd/apps/skychat/commands/filexfer.go
+++ b/cmd/apps/skychat/commands/filexfer.go
@@ -35,9 +35,11 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skychat/group"
 	"github.com/skycoin/skywire/pkg/skychat/history"
 	"github.com/skycoin/skywire/pkg/skychat/xfer"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/visor"
 )
 
 // fileMgr is the process-wide file-transfer manager, initialized by startFileXfer.
@@ -88,20 +90,31 @@ func fileDialFunc(ctx context.Context, peer cipher.PubKey, port uint16) (net.Con
 func acceptInbound(from cipher.PubKey, offer xfer.Offer) (io.WriteCloser, bool) {
 	// Group files: accepted when we share the offered group. 1:1 files: accepted
 	// when a chat is already established with the sender.
+	//
+	// A CHANNEL is the exception: nothing is accepted there unless this visor
+	// asked for it by file id. Sharing a group is consent to receive what its
+	// members send; subscribing to a broadcast channel is not, because the
+	// relationship is one-way and the audience is unbounded — one admin
+	// deciding to attach a 2 GB file would otherwise land it on every
+	// subscriber's disk at once. So a channel's files are references until
+	// somebody opens one. See sendFileToVisorGroup, which already publishes
+	// only the reference; this is the receiving half of the same rule, and it
+	// holds even against an admin that pushes anyway.
 	accept := false
 	switch {
 	case offer.Group != "":
-		accept = isGroupMember(offer.Group, from)
+		accept = isGroupMember(offer.Group, from) && !isChannelGroup(offer.Group)
 	default:
 		accept = isEstablishedPeer(from)
 	}
 	// A file we explicitly requested (backfill) is accepted even from a peer we
-	// haven't otherwise established a chat with — we asked for it.
+	// haven't otherwise established a chat with — we asked for it. This is also
+	// the only door a channel's files come through.
 	if !accept && isRequestedFile(offer.ID, from) {
 		accept = true
 	}
 	if !accept {
-		appLog("skychat: declining file %q from unestablished peer %s", offer.Name, from)
+		appLog("skychat: declining unrequested file %q from %s", offer.Name, from)
 		return nil, false
 	}
 	dir, err := downloadsDir()
@@ -462,6 +475,32 @@ func isGroupMember(groupID string, pk cipher.PubKey) bool {
 		}
 	}
 	return false
+}
+
+// isChannelGroup reports whether groupID is a broadcast channel.
+//
+// Asked of the visor, which owns the record; a failure answers false, which
+// degrades to the ordinary group rule rather than refusing files outright —
+// the conservative direction for a transient RPC hiccup on a normal group,
+// and a channel's bytes still only ever arrive by request in practice
+// because its sender publishes a reference and nothing else.
+//
+// The standalone --cxo-group path is not consulted: it builds its record
+// with a hardcoded public mode and every member an admin (see cxo_tcp.go),
+// so it cannot host a channel at all.
+func isChannelGroup(groupID string) bool {
+	if groupID == "" || !pairEnable || !pairRPCAlive() {
+		return false
+	}
+	var kind string
+	if err := pairRPCCall("GroupGet", func(c visor.API) error {
+		info, err := c.GroupGet(groupID)
+		kind = string(info.Kind)
+		return err
+	}); err != nil {
+		return false
+	}
+	return kind == string(group.KindChannel)
 }
 
 // sendFileToGroup fans the file at path out to every current member of the

--- a/cmd/apps/skychat/commands/group.go
+++ b/cmd/apps/skychat/commands/group.go
@@ -331,6 +331,7 @@ func registerGroupHTTPHandlers(mux *http.ServeMux) {
 	// Registered before the catch-all /group/ so it isn't swallowed by
 	// groupItemHandler, which reads the next path segment as a group ID.
 	mux.HandleFunc("/group/resolve", requireAuthFunc(groupResolveHandler()))
+	mux.HandleFunc("/group/catalog", requireAuthFunc(groupCatalogHandler()))
 	mux.HandleFunc("/group/", requireAuthFunc(groupItemHandler()))
 }
 
@@ -381,6 +382,10 @@ func groupRootHandler() http.HandlerFunc {
 				// field — still gets the default (enabled) rather than
 				// silently creating admins-only groups.
 				PeerBackfill *bool `json:"peer_backfill"`
+				// Listed opts the group into this visor's discovery
+				// catalog. Absent means unlisted — see Record.Listed for
+				// why the default has to be the private one.
+				Listed bool `json:"listed"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				http.Error(w, "invalid body: "+err.Error(), http.StatusBadRequest)
@@ -410,7 +415,11 @@ func groupRootHandler() http.HandlerFunc {
 			var info visor.GroupInfo
 			var link string
 			if err := pairRPCCall("GroupCreate", func(c visor.API) error {
-				i, l, e := c.GroupCreate(visor.GroupCreateArgs{Name: body.Name, Kind: kind, InitialMembers: members})
+				i, l, e := c.GroupCreate(visor.GroupCreateArgs{
+					Name: body.Name, Kind: kind, InitialMembers: members,
+					DisablePeerBackfill: body.PeerBackfill != nil && !*body.PeerBackfill,
+					Listed:              body.Listed,
+				})
 				info, link = i, l
 				return e
 			}); err != nil {
@@ -473,6 +482,53 @@ func groupJoinHandler() http.HandlerFunc {
 	}
 }
 
+// groupCatalogHandler serves GET /group/catalog?pk=… — "what does this
+// visor publish?". An absent or empty pk asks this visor about itself, so
+// an operator can see their own listing exactly as others would.
+//
+// Read-only and answers only what the host chose to publish; a visor that
+// has listed nothing returns an empty list rather than an error, because
+// "nothing here" is a legitimate answer and not a failure.
+func groupCatalogHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !pairRPCAlive() {
+			http.Error(w, "groups disabled (visor RPC unavailable)", http.StatusServiceUnavailable)
+			return
+		}
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var host cipher.PubKey
+		if raw := strings.TrimSpace(r.URL.Query().Get("pk")); raw != "" {
+			// Accept a full skychat:// address as well as a bare key: the UI
+			// hands over whatever the user typed.
+			if addr, err := address.Parse(raw); err == nil {
+				host = addr.PK
+			} else if err := host.Set(raw); err != nil {
+				http.Error(w, "invalid pk: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+		var (
+			entries   []visor.GroupCatalogEntry
+			truncated bool
+		)
+		if err := pairRPCCall("GroupCatalog", func(c visor.API) error {
+			e, t, cerr := c.GroupCatalog(host)
+			entries, truncated = e, t
+			return cerr
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		if entries == nil {
+			entries = []visor.GroupCatalogEntry{}
+		}
+		writeJSON(w, map[string]any{"entries": entries, "truncated": truncated})
+	}
+}
+
 // groupResolveHandler serves GET|POST /group/resolve?address=… — "what is
 // this thing I just pasted or scanned".
 //
@@ -530,6 +586,7 @@ func groupResolveHandler() http.HandlerFunc {
 //	DELETE /group/<id>          → delete (owner)
 //	GET    /group/<id>/invite   → invite link
 //	POST   /group/<id>/send     → publish a message
+//	POST   /group/<id>/listed   → publish in the discovery catalog
 //	POST   /group/<id>/leave    → leave (member)
 //	GET    /group/<id>/history  → persisted history (?limit=N)
 func groupItemHandler() http.HandlerFunc {
@@ -763,6 +820,25 @@ func groupItemHandler() http.HandlerFunc {
 			}
 			writeJSON(w, info)
 
+		case action == "listed" && r.Method == http.MethodPost:
+			var body struct {
+				Listed bool `json:"listed"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, "invalid body: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			var info visor.GroupInfo
+			if err := pairRPCCall("GroupSetListed", func(c visor.API) error {
+				i, e := c.GroupSetListed(id, body.Listed)
+				info = i
+				return e
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			writeJSON(w, info)
+
 		case action == "leave" && r.Method == http.MethodPost:
 			if err := pairRPCCall("GroupLeave", func(c visor.API) error { return c.GroupLeave(id) }); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -777,9 +853,23 @@ func groupItemHandler() http.HandlerFunc {
 					limit = n
 				}
 			}
+			// before is the backward page cursor: the ts_nano of the oldest
+			// message the caller already holds. Absent means "the newest
+			// page", so a first load and a scroll-back are the same request.
+			// Unparseable is treated as absent rather than an error — a
+			// client that lost its cursor should get the newest page, not a
+			// failure.
+			var before time.Time
+			if s := r.URL.Query().Get("before"); s != "" {
+				if ns, err := strconv.ParseInt(s, 10, 64); err == nil && ns > 0 {
+					before = time.Unix(0, ns).UTC()
+				}
+			}
 			var msgs []visor.GroupMessage
-			if err := pairRPCCall("GroupHistory", func(c visor.API) error {
-				out, e := c.GroupHistory(id, limit)
+			if err := pairRPCCall("GroupHistoryPage", func(c visor.API) error {
+				out, e := c.GroupHistoryPage(visor.GroupHistoryPageArgs{
+					GroupID: id, Before: before, Limit: limit,
+				})
 				msgs = out
 				return e
 			}); err != nil {

--- a/cmd/apps/skychat/commands/group.go
+++ b/cmd/apps/skychat/commands/group.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skychat/address"
 	"github.com/skycoin/skywire/pkg/skychat/group"
 	"github.com/skycoin/skywire/pkg/visor"
 )
@@ -327,6 +328,9 @@ func registerGroupHTTPHandlers(mux *http.ServeMux) {
 	}
 	mux.HandleFunc("/group", requireAuthFunc(groupRootHandler()))
 	mux.HandleFunc("/group/join", requireAuthFunc(groupJoinHandler()))
+	// Registered before the catch-all /group/ so it isn't swallowed by
+	// groupItemHandler, which reads the next path segment as a group ID.
+	mux.HandleFunc("/group/resolve", requireAuthFunc(groupResolveHandler()))
 	mux.HandleFunc("/group/", requireAuthFunc(groupItemHandler()))
 }
 
@@ -395,7 +399,7 @@ func groupRootHandler() http.HandlerFunc {
 				kind = group.KindPublic
 			}
 			if !kind.IsValid() {
-				http.Error(w, "invalid kind (use public or private)", http.StatusBadRequest)
+				http.Error(w, "invalid kind (use public, private or channel)", http.StatusBadRequest)
 				return
 			}
 			members, err := parsePKList(body.Members)
@@ -421,7 +425,12 @@ func groupRootHandler() http.HandlerFunc {
 	}
 }
 
-// groupJoinHandler serves POST /group/join {invite}.
+// groupJoinHandler serves POST /group/join {invite} or {address}.
+//
+// Both spellings are accepted because they are not interchangeable: an
+// invite link is self-contained and works while the group's host is
+// offline, and a skychat://<pk>/<group-id> address is short enough to
+// scan from a QR code but has to ask the host what the group is first.
 func groupJoinHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !pairRPCAlive() {
@@ -433,19 +442,27 @@ func groupJoinHandler() http.HandlerFunc {
 			return
 		}
 		var body struct {
-			Invite string `json:"invite"`
+			Invite  string `json:"invite"`
+			Address string `json:"address"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, "invalid body: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		if strings.TrimSpace(body.Invite) == "" {
-			http.Error(w, "invite required", http.StatusBadRequest)
+		invite := strings.TrimSpace(body.Invite)
+		addr := strings.TrimSpace(body.Address)
+		if invite == "" && addr == "" {
+			http.Error(w, "invite or address required", http.StatusBadRequest)
 			return
+		}
+		// A single UI field takes either, so route by shape rather than
+		// trusting which key it arrived under.
+		if invite != "" && !address.IsInvite(invite) {
+			invite, addr = "", invite
 		}
 		var info visor.GroupInfo
 		if err := pairRPCCall("GroupJoin", func(c visor.API) error {
-			i, e := c.GroupJoin(visor.GroupJoinArgs{Invite: body.Invite})
+			i, e := c.GroupJoin(visor.GroupJoinArgs{Invite: invite, Address: addr})
 			info = i
 			return e
 		}); err != nil {
@@ -453,6 +470,57 @@ func groupJoinHandler() http.HandlerFunc {
 			return
 		}
 		writeJSON(w, info)
+	}
+}
+
+// groupResolveHandler serves GET|POST /group/resolve?address=… — "what is
+// this thing I just pasted or scanned".
+//
+// GET as well as POST because the UI calls this as the user types, and a
+// GET keeps that a plainly cacheless read with the address in the query
+// rather than a body. Nothing is mutated either way.
+//
+// A resolve failure is reported as 404 rather than 500: the overwhelmingly
+// common causes are a mistyped key and a group the host does not hold,
+// which are "not found", not "the visor broke". A UI showing a red error
+// bar for a half-typed key would be wrong every time.
+func groupResolveHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !pairRPCAlive() {
+			http.Error(w, "groups disabled (visor RPC unavailable)", http.StatusServiceUnavailable)
+			return
+		}
+		var raw string
+		switch r.Method {
+		case http.MethodGet:
+			raw = r.URL.Query().Get("address")
+		case http.MethodPost:
+			var body struct {
+				Address string `json:"address"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, "invalid body: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			raw = body.Address
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if strings.TrimSpace(raw) == "" {
+			http.Error(w, "address required", http.StatusBadRequest)
+			return
+		}
+		var res visor.GroupResolveResult
+		if err := pairRPCCall("GroupResolve", func(c visor.API) error {
+			out, e := c.GroupResolve(visor.GroupResolveArgs{Address: raw})
+			res = out
+			return e
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		writeJSON(w, res)
 	}
 }
 

--- a/cmd/apps/skychat/commands/group_handlers_test.go
+++ b/cmd/apps/skychat/commands/group_handlers_test.go
@@ -92,6 +92,27 @@ func (a *groupAPI) GroupHistory(id string, _ int) ([]visor.GroupMessage, error) 
 	return []visor.GroupMessage{{GroupID: id, Text: "old", TS: time.Now().UTC()}}, nil
 }
 
+// GroupHistoryPage is what the /group/<id>/history route actually calls now
+// that history is paged. Answered from the same `history` field, filtered by
+// the Before cursor so a test can exercise paging without a real store:
+// without the filter a scroll-back would return the same page forever.
+func (a *groupAPI) GroupHistoryPage(args visor.GroupHistoryPageArgs) ([]visor.GroupMessage, error) {
+	msgs, err := a.GroupHistory(args.GroupID, args.Limit)
+	if err != nil {
+		return nil, err
+	}
+	if args.Before.IsZero() {
+		return msgs, nil
+	}
+	out := make([]visor.GroupMessage, 0, len(msgs))
+	for _, m := range msgs {
+		if m.TS.Before(args.Before) {
+			out = append(out, m)
+		}
+	}
+	return out, nil
+}
+
 func TestGroupRootHandler_ListAndCreate(t *testing.T) {
 	fake := &groupAPI{groups: []visor.GroupInfo{{ID: "a", Name: "one"}, {ID: "b", Name: "two"}}}
 	withFakePairRPC(t, fake)

--- a/cmd/apps/skychat/commands/static/index.html
+++ b/cmd/apps/skychat/commands/static/index.html
@@ -101,32 +101,6 @@
       animation: none;
     }
 
-    .recipient-form {
-      display: flex;
-      gap: 8px;
-    }
-
-    .recipient-form input[type="text"] {
-      flex: 1;
-      padding: 10px 12px;
-      background: var(--bg-tertiary);
-      border: 1px solid var(--border-color);
-      border-radius: 8px;
-      color: var(--text-primary);
-      font-size: 13px;
-      transition: border-color 0.2s, box-shadow 0.2s;
-    }
-
-    .recipient-form input[type="text"]:focus {
-      outline: none;
-      border-color: var(--accent-blue);
-      box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.1);
-    }
-
-    .recipient-form input[type="text"]::placeholder {
-      color: var(--text-muted);
-    }
-
     .btn {
       padding: 10px 16px;
       background: var(--accent-blue);
@@ -144,11 +118,6 @@
 
     .btn:active {
       transform: scale(0.98);
-    }
-
-    .btn-icon {
-      padding: 10px 12px;
-      font-size: 16px;
     }
 
     /* Recipient List */
@@ -1479,8 +1448,201 @@
       background: var(--text-muted);
     }
 
-    /* Responsive */
-    @media (max-width: 768px) {
+    /* ---- Compose button + its three-option menu ------------------ */
+
+    .start-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 34px;
+      height: 34px;
+      flex: 0 0 auto;
+      background: var(--accent-blue);
+      border: none;
+      border-radius: 10px;
+      color: #fff;
+      cursor: pointer;
+      transition: background 0.2s, transform 0.1s;
+    }
+
+    .start-btn:hover { background: #0284c7; }
+    .start-btn:active { transform: scale(0.95); }
+
+    .start-menu {
+      position: fixed;
+      z-index: 120;
+      min-width: 250px;
+      padding: 6px;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-color);
+      border-radius: 12px;
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+      display: none;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .start-menu.visible { display: flex; }
+
+    .start-item {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      width: 100%;
+      padding: 10px 12px;
+      background: transparent;
+      border: none;
+      border-radius: 8px;
+      color: var(--text-primary);
+      text-align: left;
+      cursor: pointer;
+      font: inherit;
+    }
+
+    .start-item:hover { background: var(--bg-hover); }
+
+    .si-icon { font-size: 18px; line-height: 1; flex: 0 0 auto; }
+    .si-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+    .si-title { font-size: 14px; font-weight: 500; }
+    .si-sub { font-size: 11px; color: var(--text-muted); }
+
+    /* ---- Back button (one-pane layout only) ---------------------- */
+
+    .back-btn {
+      display: none;   /* shown by the one-pane media query */
+      align-items: center;
+      justify-content: center;
+      width: 34px;
+      height: 34px;
+      flex: 0 0 auto;
+      margin-right: 2px;
+      background: transparent;
+      border: none;
+      border-radius: 8px;
+      color: var(--text-secondary);
+      cursor: pointer;
+    }
+
+    .back-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+    /* ---- Add-by-address dialog ----------------------------------- */
+
+    .addr-scan-row {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+
+    .btn-slim {
+      flex: 1;
+      padding: 8px 10px;
+      font-size: 12px;
+      text-align: center;
+      /* The "From image" control is a <label> wrapping a hidden file
+         input, so it needs the pointer and centring a <button> gets for
+         free. */
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      cursor: pointer;
+    }
+
+    .addr-scanner {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+
+    .addr-scanner.hidden { display: none; }
+
+    .addr-scanner video {
+      width: 100%;
+      max-height: 240px;
+      background: #000;
+      border-radius: 10px;
+      object-fit: cover;
+    }
+
+    .addr-result {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 12px;
+      margin-bottom: 10px;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-color);
+      border-radius: 10px;
+    }
+
+    .addr-result.hidden { display: none; }
+    .addr-result.pending { opacity: 0.6; }
+    .addr-result.bad { border-color: var(--accent-red); }
+
+    .ar-avatar {
+      width: 40px;
+      height: 40px;
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+      background: var(--bg-hover);
+      font-size: 18px;
+    }
+
+    .ar-body { min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+    .ar-title { font-size: 14px; font-weight: 500; word-break: break-all; }
+    .ar-sub { font-size: 11px; color: var(--text-secondary); }
+    .ar-sub.warn { color: var(--accent-orange); }
+    .ar-sub.bad { color: var(--accent-red); }
+
+    /* ---- Address QR ---------------------------------------------- */
+
+    .qr-wrap {
+      display: flex;
+      justify-content: center;
+      padding: 14px;
+      margin-bottom: 14px;
+      /* White quiet zone regardless of theme: scanners expect a light
+         background around the modules, and the panel colour is dark. */
+      background: #fff;
+      border-radius: 12px;
+    }
+
+    #qrCanvas {
+      width: 100%;
+      max-width: 264px;
+      height: auto;
+      image-rendering: pixelated;   /* keep module edges crisp when scaled */
+    }
+
+    .qr-addr-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+
+    .qr-addr {
+      flex: 1;
+      min-width: 0;
+      padding: 10px 12px;
+      background: var(--bg-tertiary);
+      border-radius: 8px;
+      font-family: 'Monaco', 'Menlo', monospace;
+      font-size: 11px;
+      color: var(--text-secondary);
+      word-break: break-all;
+      /* Selectable on purpose — copy-by-hand is the fallback when the
+         clipboard API is unavailable (it needs a secure context). */
+      user-select: all;
+    }
+
+    /* ---- Responsive ---------------------------------------------- */
+
+    @media (max-width: 900px) and (min-width: 761px) {
       .sidebar {
         width: 280px;
         min-width: 280px;
@@ -1489,6 +1651,57 @@
       .message-bubble {
         max-width: 85%;
       }
+    }
+
+    /* One-pane layout. Below this width the sidebar and the chat no
+       longer share the screen: the list IS the screen until a
+       conversation is opened, and the chat then replaces it with a back
+       button in its header. Two 300px-ish panes side by side on a phone
+       leaves neither usable.
+       761px rather than 768px so the common 768px tablet portrait width
+       keeps the two-pane layout it has room for. */
+    @media (max-width: 760px) {
+      .sidebar {
+        width: 100%;
+        min-width: 0;
+        border-right: none;
+      }
+
+      /* body.chat-open is set by the JS when a conversation is opened
+         and cleared on the way back, so exactly one pane is ever
+         displayed. Driven by a class rather than by which elements
+         happen to be hidden, because the chat pane's own children are
+         independently toggled by the existing DM/group logic. */
+      body.chat-open .sidebar { display: none; }
+      body:not(.chat-open) .chat-container { display: none; }
+
+      .back-btn { display: flex; }
+
+      .chat-header { padding: 10px 12px; }
+      .chat-header-actions { gap: 4px; }
+      .message-bubble { max-width: 90%; }
+
+      /* The action button leaves the header flow and becomes a
+         thumb-reachable floating button, bottom right. Same element — the
+         fixed positioning takes it out of the title row it sat in. */
+      .start-btn {
+        position: fixed;
+        right: 16px;
+        bottom: 20px;
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        z-index: 90;
+        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+      }
+
+      /* Hidden while a chat is open: the button starts things from the
+         list, and over a conversation it would cover the composer. */
+      body.chat-open .start-btn { display: none; }
+
+      .start-btn svg { width: 26px; height: 26px; }
+
+      .start-menu { min-width: 220px; }
     }
 
     /* Groups */
@@ -1506,22 +1719,6 @@
       text-transform: uppercase;
       color: var(--accent-green);
     }
-
-    .groups-actions { display: flex; gap: 4px; }
-
-    .group-hdr-btn {
-      background: transparent;
-      border: 1px solid var(--border-color);
-      color: var(--text-secondary);
-      font-size: 13px;
-      width: 22px;
-      height: 22px;
-      border-radius: 4px;
-      cursor: pointer;
-      line-height: 1;
-    }
-
-    .group-hdr-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
 
     .group-list { list-style: none; }
 
@@ -1868,6 +2065,21 @@
           <span id="statusText">Connected</span>
         </div>
         <button class="icon-btn" style="margin-left:auto" onclick="app.openNotifSettings()" title="Notification settings" aria-label="Notification settings">&#x1F514;</button>
+        <!-- The one entry point for starting anything: an address (person,
+             group or channel), a new group, or a new channel. Sits here on
+             a wide screen and becomes a fixed bottom-right action button
+             on a phone, where the top of the screen is the hardest place
+             to reach with a thumb — one element repositioned by the
+             one-pane media query, not two in the DOM. -->
+        <button id="startBtn" class="start-btn" onclick="app.toggleStartMenu(event)"
+                title="Start a chat, group or channel" aria-label="Start a chat, group or channel"
+                aria-haspopup="true" aria-expanded="false">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" aria-hidden="true">
+            <line x1="12" y1="5" x2="12" y2="19"></line>
+            <line x1="5" y1="12" x2="19" y2="12"></line>
+          </svg>
+        </button>
       </div>
       <!-- First-run permission nudge. Hidden by default and only shown by
            _refreshNotifNudge when notifications are enabled but the browser has
@@ -1878,10 +2090,6 @@
         <button class="nn-allow" onclick="app.allowNotifFromNudge()">Allow</button>
         <button class="nn-dismiss" onclick="app.dismissNotifNudge()" title="Don't ask again" aria-label="Dismiss">&times;</button>
       </div>
-      <form class="recipient-form" onsubmit="app.createRecipient(this); return false;">
-        <input id="destinationPk" type="text" placeholder="Enter public key..." />
-        <button type="submit" class="btn btn-icon" title="Add contact">+</button>
-      </form>
     </div>
     <div id="pinnedSection" class="groups-section hidden">
       <div class="groups-header"><span>Pinned</span></div>
@@ -1893,11 +2101,7 @@
     </div>
     <div id="groupsSection" class="groups-section hidden">
       <div class="groups-header">
-        <span>Groups</span>
-        <div class="groups-actions">
-          <button class="group-hdr-btn" onclick="app.openCreateGroup()" title="Create group">+</button>
-          <button class="group-hdr-btn" onclick="app.openJoinGroup()" title="Join a group by invite">&#x2913;</button>
-        </div>
+        <span>Groups &amp; channels</span>
       </div>
       <ul id="groups" class="group-list"></ul>
     </div>
@@ -1907,6 +2111,14 @@
   <main class="chat-container">
     <div id="chatHeader" class="chat-header hidden">
       <div class="chat-header-info">
+        <!-- Shown only in the one-pane layout, where opening a chat
+             replaced the list and there is otherwise no way back to it. -->
+        <button class="back-btn" onclick="app.showChatList()" title="Back to chats" aria-label="Back to chats">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="15 18 9 12 15 6"></polyline>
+          </svg>
+        </button>
         <div class="avatar-wrap">
           <img id="headerAvatar" class="chat-header-avatar" src="p.png" />
           <span id="headerPresenceDot" class="presence-dot"></span>
@@ -1923,6 +2135,11 @@
         <button id="dmPinBtn" class="icon-btn" onclick="app.togglePin()" title="Pin to top">&#x1F4CC;</button>
         <button id="dmMuteBtn" class="icon-btn" onclick="app.toggleMute()" title="Mute notifications for this chat" aria-label="Mute notifications">&#x1F514;</button>
         <button id="pairToggleBtn" class="icon-btn hidden" onclick="app.togglePair()" title="Pair / unpair via CXO">&#x29B5;</button>
+        <button class="icon-btn" onclick="app.showQr()" title="Show this chat's address as a QR code" aria-label="Show address QR code">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
+            <path d="M3 3h7v7H3V3zm2 2v3h3V5H5zM14 3h7v7h-7V3zm2 2v3h3V5h-3zM3 14h7v7H3v-7zm2 2v3h3v-3H5zM14 14h2v2h-2v-2zm3 0h2v2h-2v-2zm2 2h2v2h-2v-2zm-2 2h2v2h-2v-2zm-3 0h2v3h-2v-3zm4 3h4v-2h-2v-1h-2v3z"/>
+          </svg>
+        </button>
         <button class="icon-btn" onclick="app.copyPk()" title="Copy public key">&#x2398;</button>
         <button class="icon-btn" onclick="app.openSettings()" title="Contact settings">&#x2699;</button>
         <button class="icon-btn danger" onclick="app.deleteChat()" title="Delete chat" aria-label="Delete chat">
@@ -1938,7 +2155,13 @@
 
     <div id="groupHeader" class="chat-header hidden">
       <div class="chat-header-info">
-        <div class="group-avatar">#</div>
+        <button class="back-btn" onclick="app.showChatList()" title="Back to chats" aria-label="Back to chats">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="15 18 9 12 15 6"></polyline>
+          </svg>
+        </button>
+        <div class="group-avatar" id="groupHeaderAvatar">#</div>
         <div>
           <div class="chat-header-pk" id="groupHeaderName">-</div>
           <div class="group-header-sub" id="groupHeaderSub"></div>
@@ -1946,6 +2169,11 @@
       </div>
       <div class="chat-header-actions">
         <button id="groupPinBtn" class="icon-btn" onclick="app.togglePin()" title="Pin to top">&#x1F4CC;</button>
+        <button class="icon-btn" onclick="app.showQr()" title="Show this group's address as a QR code" aria-label="Show address QR code">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
+            <path d="M3 3h7v7H3V3zm2 2v3h3V5H5zM14 3h7v7h-7V3zm2 2v3h3V5h-3zM3 14h7v7H3v-7zm2 2v3h3v-3H5zM14 14h2v2h-2v-2zm3 0h2v2h-2v-2zm2 2h2v2h-2v-2zm-2 2h2v2h-2v-2zm-3 0h2v3h-2v-3zm4 3h4v-2h-2v-1h-2v3z"/>
+          </svg>
+        </button>
         <button id="groupMuteBtn" class="icon-btn" onclick="app.toggleMute()" title="Mute notifications for this group" aria-label="Mute notifications">&#x1F514;</button>
         <button id="groupAdminBtn" class="icon-btn" onclick="app.openGroupAdmin()" title="Members and join requests" aria-label="Members and join requests">
           &#x1F465;<span id="groupPendingBadge" class="pending-badge hidden">0</span>
@@ -2020,6 +2248,34 @@
               oncontextmenu="return false"><span class="composer-icon">&#x27A4;</span></button>
     </form>
   </main>
+
+  <!-- Compose menu. A body-level child so nothing can clip it, and
+       positioned in JS from the button's own rect — that way the same
+       menu drops down from the sidebar header on a wide screen and rises
+       from the floating action button on a phone. -->
+  <div id="startMenu" class="start-menu" role="menu" aria-labelledby="startBtn">
+    <button class="start-item" role="menuitem" onclick="app.openAddressModal()">
+      <span class="si-icon">&#x1F517;</span>
+      <span class="si-text">
+        <span class="si-title">Add by address</span>
+        <span class="si-sub">Public key, skychat:// link, invite or QR</span>
+      </span>
+    </button>
+    <button class="start-item" role="menuitem" onclick="app.openCreateGroup()">
+      <span class="si-icon">&#x1F465;</span>
+      <span class="si-text">
+        <span class="si-title">New group</span>
+        <span class="si-sub">Everyone in it can post</span>
+      </span>
+    </button>
+    <button class="start-item" role="menuitem" onclick="app.openCreateChannel()">
+      <span class="si-icon">&#x1F4E3;</span>
+      <span class="si-text">
+        <span class="si-title">New channel</span>
+        <span class="si-sub">Open to join, only admins post</span>
+      </span>
+    </button>
+  </div>
 
   <!-- Settings Modal -->
   <div id="settingsModal" class="modal-overlay">
@@ -2148,14 +2404,95 @@
     </div>
   </div>
 
-  <!-- Join Group Modal -->
-  <div id="joinGroupModal" class="modal-overlay">
+  <!-- New Channel Modal. Separate from Create Group rather than a third
+       option in its mode select: a channel has no admission choice to
+       make (it is open by definition) and the thing an operator needs
+       told is who may post, which is a different sentence entirely. -->
+  <div id="createChannelModal" class="modal-overlay">
     <div class="modal">
-      <h3>Join Group</h3>
-      <input id="jgInvite" class="cg-input" type="text" placeholder="Paste invite link (skychat:invite:...)" />
+      <h3>New Channel</h3>
+      <input id="ccName" class="cg-input" type="text" placeholder="Channel name" />
+      <p class="cg-help">
+        Anyone with the address or invite link can join and read. Only
+        admins can post — members cannot reply on the channel itself.
+        Messages are not encrypted on the feed: admission is open, so the
+        key would go to anyone who asked and would protect nothing.
+        Traffic is still encrypted in transit.
+      </p>
+      <label class="cg-check">
+        <input type="checkbox" id="ccPeerBackfill" checked />
+        <span>Any member can share history with new members</span>
+      </label>
+      <p class="cg-help">
+        Off means only admins can, so the channel goes quiet for new
+        joiners whenever no admin is online.
+      </p>
       <div class="modal-actions">
-        <button class="btn" onclick="app.joinGroup()">Join</button>
-        <button class="btn btn-secondary" onclick="app.closeModal('joinGroupModal')">Cancel</button>
+        <button class="btn" onclick="app.createChannel()">Create</button>
+        <button class="btn btn-secondary" onclick="app.closeModal('createChannelModal')">Cancel</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Add by address: one field for every way of naming something —
+       a bare public key, a skychat:// address, an invite link, or a
+       scanned QR code. What it turns out to be decides which single
+       action button appears, so the user never has to pick the right
+       kind of thing first. -->
+  <div id="addressModal" class="modal-overlay">
+    <div class="modal">
+      <h3>Add by address</h3>
+      <input id="addrInput" class="cg-input" type="text" autocomplete="off" spellcheck="false"
+             placeholder="Public key, skychat://… or invite link"
+             oninput="app.onAddressInput()"
+             onkeydown="if (event.key === 'Enter') app.addressAction()" />
+      <div class="addr-scan-row">
+        <button class="btn btn-secondary btn-slim" onclick="app.startQrScan()">
+          &#x1F4F7; Scan QR code
+        </button>
+        <label class="btn btn-secondary btn-slim" title="Read a QR code from a saved image">
+          &#x1F5BC; From image
+          <input type="file" id="addrQrFile" accept="image/*" style="display:none"
+                 onchange="app.scanQrFile(event)" />
+        </label>
+      </div>
+
+      <!-- Live camera scanner. Collapsed until Scan is pressed so the
+           permission prompt only happens on a deliberate action. -->
+      <div id="addrScanner" class="addr-scanner hidden">
+        <video id="addrScanVideo" playsinline muted></video>
+        <button class="btn btn-secondary btn-slim" onclick="app.stopQrScan()">Stop scanning</button>
+      </div>
+
+      <!-- What the address resolved to, and the one action that follows. -->
+      <div id="addrResult" class="addr-result hidden"></div>
+      <p id="addrHint" class="cg-help"></p>
+
+      <div class="modal-actions">
+        <button id="addrActionBtn" class="btn hidden" onclick="app.addressAction()">Start Chat</button>
+        <button class="btn btn-secondary" onclick="app.closeAddressModal()">Cancel</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Address QR. The plain text sits under the code and is selectable,
+       with a copy button beside it: a QR is unusable for anyone reading
+       over a screen share, pasting into a terminal, or on a device with
+       no camera. -->
+  <div id="qrModal" class="modal-overlay">
+    <div class="modal">
+      <h3 id="qrTitle">Address</h3>
+      <div class="qr-wrap">
+        <canvas id="qrCanvas" width="264" height="264" aria-label="Address QR code"></canvas>
+      </div>
+      <div class="qr-addr-row">
+        <code id="qrAddrText" class="qr-addr">-</code>
+        <button class="icon-btn" onclick="app.copyQrAddress()" title="Copy address" aria-label="Copy address">&#x2398;</button>
+      </div>
+      <p class="cg-help" id="qrHelp"></p>
+      <div class="modal-actions">
+        <button id="qrInviteBtn" class="btn btn-secondary hidden" onclick="app.showGroupInvite()">Copy invite link instead</button>
+        <button class="btn btn-secondary" onclick="app.closeModal('qrModal')">Close</button>
       </div>
     </div>
   </div>
@@ -3630,31 +3967,6 @@
         };
       }
 
-      createRecipient(el) {
-        const recipient = this.processPk(el[0].value.trim());
-
-        if (recipient.length !== 66) {
-          this.showToast('Public keys must be 66 characters long.', 'error');
-          return;
-        }
-
-        if (!/^[0-9a-fA-F]+$/.test(recipient)) {
-          this.showToast('Invalid characters in public key.', 'error');
-          return;
-        }
-
-        if (this.recipients.includes(recipient)) {
-          this.selectRecipient(recipient);
-          el[0].value = '';
-          return;
-        }
-
-        el[0].value = '';
-        this._addRecipient(recipient);
-        this.selectRecipient(recipient);
-        this.showToast('Contact added successfully.');
-      }
-
       // syncHistoryPeers seeds the sidebar with peers the visor has
       // stored history for but localStorage doesn't know about (fresh
       // browser, new device, cleared cache). 404/503 means the visor
@@ -3752,6 +4064,10 @@
       }
 
       selectRecipient(pk) {
+        // Before the no-op guard below: on a phone the list and the chat
+        // are the same screen, so re-tapping the chat you already had open
+        // still has to switch panes to it.
+        this._enterChatPane();
         if (this.recipient === pk && !this.group) return;
         this.cancelReply(); // a reply armed in another thread must not follow
         this.group = null;
@@ -5335,7 +5651,10 @@
       // do right now (awaiting approval, read-only, restricted).
       _groupSubtitle(g) {
         const parts = [g.role || 'member', `${(g.members || []).length} members`];
-        parts.push(g.join_policy === 'approval' ? 'private' : 'public');
+        // A channel's defining property is who may post, not who may join
+        // — saying "public" about it would describe the uninteresting half.
+        if (g.kind === 'channel') parts.push('channel · admins post');
+        else parts.push(g.join_policy === 'approval' ? 'private' : 'public');
         if (g.status === 'awaiting_approval') parts.push('waiting for approval');
         else if (g.status === 'denied') parts.push('request declined');
         else if (g.status === 'banned') parts.push('banned');
@@ -5353,7 +5672,7 @@
           const badge = pending > 0 ? `<span class="ga-badge">${pending}</span>` : '';
           li.innerHTML = `
             <div class="group-item ${g.id === this.group ? 'active' : ''}" data-gid="${g.id}" onclick="app.selectGroup('${g.id}')">
-              <div class="group-avatar-sm">#</div>
+              <div class="group-avatar-sm">${g.kind === 'channel' ? '&#x1F4E3;' : '#'}</div>
               <div class="recipient-info">
                 <div class="recipient-pk">${this.escapeHtml(g.name || g.id)} ${badge}</div>
                 <div class="recipient-preview">${this.escapeHtml(this._groupSubtitle(g))}</div>
@@ -5472,6 +5791,7 @@
       }
 
       selectGroup(id) {
+        this._enterChatPane();   // see selectRecipient
         this.cancelReply(); // a reply armed in another thread must not follow
         this.group = id;
         this.recipient = null;
@@ -5492,6 +5812,8 @@
         if (attachBtn) attachBtn.classList.remove('hidden');
 
         const info = this.groups.find(g => g.id === id);
+        const avatar = document.getElementById('groupHeaderAvatar');
+        if (avatar) avatar.textContent = (info && info.kind === 'channel') ? '📣' : '#';
         document.getElementById('groupHeaderName').textContent = info ? info.name : id;
         document.getElementById('groupHeaderSub').textContent = info
           ? this._groupSubtitle(info) : '';
@@ -5675,6 +5997,7 @@
       }
 
       openCreateGroup() {
+        this.closeStartMenu();
         document.getElementById('cgName').value = '';
         // Back to the default on every open: an unchecked box left over
         // from a previous create would silently make the next group
@@ -5697,9 +6020,286 @@
           : 'Anyone holding the invite link is admitted automatically. Messages are not encrypted on the feed: in an open group the key would go to anyone who asks, so it would protect nothing. Traffic is still encrypted in transit.';
       }
 
-      openJoinGroup() {
-        document.getElementById('jgInvite').value = '';
-        document.getElementById('joinGroupModal').classList.add('visible');
+      openCreateChannel() {
+        this.closeStartMenu();
+        document.getElementById('ccName').value = '';
+        const backfill = document.getElementById('ccPeerBackfill');
+        if (backfill) backfill.checked = true;
+        document.getElementById('createChannelModal').classList.add('visible');
+      }
+
+      // createChannel creates a KindChannel group: open to join, admins
+      // only to post. Shares the /group endpoint with createGroup — the
+      // only difference on the wire is kind.
+      createChannel() {
+        const name = document.getElementById('ccName').value.trim();
+        const backfillEl = document.getElementById('ccPeerBackfill');
+        const peer_backfill = backfillEl ? !!backfillEl.checked : true;
+        if (!name) { this.showToast('Enter a channel name.', 'error'); return; }
+        fetch('/group', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, kind: 'channel', members: [], peer_backfill })
+        })
+          .then(res => res.ok ? res.json() : res.text().then(t => Promise.reject(t)))
+          .then(j => {
+            this.closeModal('createChannelModal');
+            this.syncGroups();
+            if (j.invite) { navigator.clipboard.writeText(j.invite).catch(() => {}); this.showToast('Channel created — invite link copied.'); }
+            if (j.info && j.info.id) setTimeout(() => this.selectGroup(j.info.id), 300);
+          })
+          .catch(e => this.showToast(`Create failed: ${e}`, 'error'));
+      }
+
+      // ---- Compose menu ----------------------------------------------
+
+      toggleStartMenu(ev) {
+        if (ev) ev.stopPropagation();
+        const menu = document.getElementById('startMenu');
+        if (menu.classList.contains('visible')) { this.closeStartMenu(); return; }
+        this._positionStartMenu();
+        menu.classList.add('visible');
+        document.getElementById('startBtn').setAttribute('aria-expanded', 'true');
+      }
+
+      closeStartMenu() {
+        const menu = document.getElementById('startMenu');
+        if (!menu) return;
+        menu.classList.remove('visible');
+        const btn = document.getElementById('startBtn');
+        if (btn) btn.setAttribute('aria-expanded', 'false');
+      }
+
+      // _positionStartMenu pins the menu to the button it belongs to.
+      //
+      // Measured rather than declared because the button moves: it is in
+      // the sidebar header on a wide screen and a floating button at the
+      // bottom of a phone screen. Opening downward from the header and
+      // upward from the floating button falls out of "is there room
+      // below", so neither case needs its own rule.
+      _positionStartMenu() {
+        const menu = document.getElementById('startMenu');
+        const btn = document.getElementById('startBtn');
+        if (!menu || !btn) return;
+        // Measure while displayed but still transparent to the user —
+        // offsetWidth is 0 on a display:none element.
+        menu.style.visibility = 'hidden';
+        menu.classList.add('visible');
+        const b = btn.getBoundingClientRect();
+        const w = menu.offsetWidth, h = menu.offsetHeight;
+        const gap = 8, pad = 8;
+        let left = Math.min(b.right - w, window.innerWidth - w - pad);
+        left = Math.max(pad, left);
+        let top = b.bottom + gap;
+        if (top + h > window.innerHeight - pad) top = b.top - h - gap;
+        top = Math.max(pad, top);
+        menu.style.left = `${Math.round(left)}px`;
+        menu.style.top = `${Math.round(top)}px`;
+        menu.classList.remove('visible');
+        menu.style.visibility = '';
+      }
+
+      // ---- Add by address --------------------------------------------
+
+      openAddressModal() {
+        this.closeStartMenu();
+        const input = document.getElementById('addrInput');
+        input.value = '';
+        this._addrResolved = null;
+        this._renderAddressResult(null);
+        document.getElementById('addrHint').textContent =
+          'Paste a public key to message someone, or a group or channel address to join it.';
+        document.getElementById('addressModal').classList.add('visible');
+        setTimeout(() => input.focus(), 50);
+      }
+
+      closeAddressModal() {
+        this.stopQrScan();
+        this.closeModal('addressModal');
+      }
+
+      // onAddressInput debounces the resolve so typing a 66-character key
+      // doesn't fire 66 requests, and so a half-typed key doesn't flash an
+      // error on every keystroke.
+      onAddressInput() {
+        clearTimeout(this._addrTimer);
+        this._addrResolved = null;
+        const raw = document.getElementById('addrInput').value.trim();
+        if (!raw) { this._renderAddressResult(null); return; }
+        this._addrTimer = setTimeout(() => this._resolveAddress(raw), 350);
+      }
+
+      // _resolveAddress asks the visor what an address points at.
+      //
+      // A bare public key is answered without the round trip: a key that
+      // names a person and a key that hosts a channel are the same 66
+      // characters, so only a group ID in the address can distinguish
+      // them — and opening a DM needs nobody's permission. That keeps the
+      // overwhelmingly common case instant and working offline.
+      _resolveAddress(raw) {
+        const seq = (this._addrSeq = (this._addrSeq || 0) + 1);
+        // Strip the scheme before the local test so a scanned contact code
+        // — skychat://<pk>, the exact thing showQr produces — resolves
+        // without a round trip too, not just a hand-typed bare key.
+        const bare = this.processPk(raw).replace(/^skychat:\/\//, '').replace(/\/$/, '');
+        if (/^[0-9a-f]{66}$/.test(bare)) {
+          this._addrResolved = { target: 'dm', pk: bare, address: `skychat://${bare}` };
+          this._renderAddressResult(this._addrResolved);
+          return;
+        }
+        this._renderAddressResult({ pending: true });
+        fetch(`/group/resolve?address=${encodeURIComponent(raw)}`)
+          .then(res => res.ok ? res.json() : res.text().then(t => Promise.reject(t)))
+          .then(res => {
+            // A slower earlier lookup must not overwrite a newer one.
+            if (seq !== this._addrSeq) return;
+            this._addrResolved = res;
+            if (res && res.invite) this._addrResolved.invite = res.invite;
+            this._renderAddressResult(res);
+          })
+          .catch(err => {
+            if (seq !== this._addrSeq) return;
+            this._addrResolved = null;
+            this._renderAddressResult({ error: String(err || 'could not resolve that address').trim() });
+          });
+      }
+
+      // _renderAddressResult draws the result card and decides the single
+      // action button. One button, never a choice: the whole point of
+      // resolving first is that the app knows which action applies.
+      _renderAddressResult(res) {
+        const box = document.getElementById('addrResult');
+        const btn = document.getElementById('addrActionBtn');
+        const hint = document.getElementById('addrHint');
+        box.className = 'addr-result';
+        btn.classList.add('hidden');
+
+        if (!res) { box.classList.add('hidden'); return; }
+
+        if (res.pending) {
+          box.classList.add('pending');
+          box.innerHTML = `<div class="ar-avatar">…</div><div class="ar-body">
+            <div class="ar-title">Looking it up…</div>
+            <div class="ar-sub">Asking the host what this address is</div></div>`;
+          return;
+        }
+
+        if (res.error) {
+          box.classList.add('bad');
+          box.innerHTML = `<div class="ar-avatar">!</div><div class="ar-body">
+            <div class="ar-title">Not resolved</div>
+            <div class="ar-sub bad">${this.escapeHtml(res.error)}</div></div>`;
+          hint.textContent = 'A group or channel address only works while its host is online. An invite link works either way.';
+          return;
+        }
+
+        if (res.target === 'dm') {
+          box.innerHTML = `<div class="ar-avatar">&#x1F464;</div><div class="ar-body">
+            <div class="ar-title">${this.escapeHtml(this.shortPk(res.pk))}</div>
+            <div class="ar-sub">Person · direct message</div></div>`;
+          hint.textContent = 'Messages to a person are encrypted end to end.';
+          btn.textContent = this.recipients.includes(res.pk) ? 'Open Chat' : 'Start Chat';
+          btn.classList.remove('hidden');
+          return;
+        }
+
+        const g = res.group || {};
+        const isChannel = g.kind === 'channel';
+        const noun = isChannel ? 'Channel' : 'Group';
+        const bits = [noun];
+        bits.push(g.policy === 'approval' ? 'approval needed' : 'open to join');
+        bits.push(isChannel ? 'only admins post' : (g.mode === 'private' ? 'encrypted' : 'not encrypted'));
+        let subClass = '';
+        let sub = bits.join(' · ');
+
+        if (g.banned) {
+          subClass = 'bad';
+          sub = `${noun} · this key is banned from it`;
+        } else if (res.joined) {
+          sub = `${noun} · you are already in it`;
+        } else if (res.status === 'awaiting_approval') {
+          subClass = 'warn';
+          sub = `${noun} · a request is already waiting for an admin`;
+        } else if (res.status === 'denied') {
+          subClass = 'warn';
+          sub = `${noun} · a previous request was declined`;
+        }
+
+        box.innerHTML = `<div class="ar-avatar">${isChannel ? '&#x1F4E3;' : '&#x1F465;'}</div>
+          <div class="ar-body">
+            <div class="ar-title">${this.escapeHtml(g.name || g.id || 'Unnamed')}</div>
+            <div class="ar-sub ${subClass}">${this.escapeHtml(sub)}</div>
+          </div>`;
+
+        // A host-stated price is shown as context, never as the button
+        // label: it is unverified text from a host that wants members.
+        hint.textContent = g.price_hint
+          ? `The host states a price of ${g.price_hint}. That is unverified — nothing is charged by this app.`
+          : (isChannel
+            ? 'Anyone can join and read a channel; only its admins can post.'
+            : (g.policy === 'approval'
+              ? 'An admin approves each request. You get in — and get the key — once they do.'
+              : 'Open admission: you are let in as soon as you ask.'));
+
+        if (g.banned) return;
+        if (res.joined) { btn.textContent = `Open ${noun}`; btn.classList.remove('hidden'); return; }
+        if (res.status === 'awaiting_approval') return;
+
+        btn.textContent = isChannel
+          ? 'Join Channel'
+          : (g.policy === 'approval' ? 'Send Request' : 'Join Group');
+        btn.classList.remove('hidden');
+      }
+
+      // addressAction performs whatever the resolved address implies.
+      addressAction() {
+        const res = this._addrResolved;
+        if (!res) {
+          // Enter pressed before the debounce fired: resolve now and let
+          // the user press again rather than guessing.
+          const raw = document.getElementById('addrInput').value.trim();
+          if (raw) { clearTimeout(this._addrTimer); this._resolveAddress(raw); }
+          return;
+        }
+        if (res.target === 'dm') {
+          const pk = res.pk;
+          this.closeAddressModal();
+          if (!this.recipients.includes(pk)) {
+            this._addRecipient(pk);
+            this.showToast('Contact added.');
+          }
+          this.selectRecipient(pk);
+          return;
+        }
+        const g = res.group || {};
+        if (res.joined) { this.closeAddressModal(); this.selectGroup(g.id); return; }
+
+        const body = res.invite ? { invite: res.invite } : { address: res.address };
+        const btn = document.getElementById('addrActionBtn');
+        const restore = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = 'Working…';
+        fetch('/group/join', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        })
+          .then(res2 => res2.ok ? res2.json() : res2.text().then(t => Promise.reject(t)))
+          .then(info => {
+            this.closeAddressModal();
+            this.syncGroups();
+            // An approval-gated group queues the request instead of
+            // admitting, so don't claim membership we don't have and
+            // don't open a room with nothing in it.
+            if (info && info.status === 'awaiting_approval') {
+              this.showToast('Request sent — waiting for an admin to approve.');
+              return;
+            }
+            this.showToast(g.kind === 'channel' ? 'Joined channel.' : 'Joined group.');
+            if (info && info.id) setTimeout(() => this.selectGroup(info.id), 300);
+          })
+          .catch(e => this.showToast(`Join failed: ${e}`, 'error'))
+          .finally(() => { btn.disabled = false; btn.textContent = restore; });
       }
 
       closeModal(id) { document.getElementById(id).classList.remove('visible'); }
@@ -5728,30 +6328,242 @@
           .catch(e => this.showToast(`Create failed: ${e}`, 'error'));
       }
 
-      joinGroup() {
-        const invite = document.getElementById('jgInvite').value.trim();
-        if (!invite) { this.showToast('Paste an invite link.', 'error'); return; }
-        fetch('/group/join', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ invite })
-        })
-          .then(res => res.ok ? res.json() : res.text().then(t => Promise.reject(t)))
-          .then(info => {
-            this.closeModal('joinGroupModal');
-            this.syncGroups();
-            // A private group queues the request instead of admitting, so
-            // don't claim we're in and don't open a room that has no
-            // messages yet — say what actually happened and let the
-            // background retry flip it to active on approval.
-            if (info && info.status === 'awaiting_approval') {
-              this.showToast('Request sent — waiting for an admin to approve.');
+      // joinByAddress opens the Add-by-address dialog pre-filled — the
+      // entry point for a skychat:// link or invite arriving from outside
+      // the UI. Joining itself lives in addressAction, so there is one
+      // code path for typed, pasted and scanned input alike.
+      joinByAddress(prefill) {
+        this.openAddressModal();
+        if (!prefill) return;
+        const input = document.getElementById('addrInput');
+        input.value = prefill;
+        this.onAddressInput();
+      }
+
+      // ---- Addresses + QR --------------------------------------------
+
+      // currentAddress describes the open conversation as a shareable
+      // skychat:// address. Null when nothing is open.
+      currentAddress() {
+        if (this.group) {
+          const info = this.groups.find(g => g.id === this.group);
+          if (!info) return null;
+          const host = String(info.owner_pk || '').toLowerCase();
+          const isChannel = info.kind === 'channel';
+          return {
+            address: `skychat://${host}/${info.id}`,
+            label: info.name || info.id,
+            noun: isChannel ? 'channel' : 'group',
+            isGroup: true,
+            isAdmin: this._isGroupAdmin(info),
+          };
+        }
+        if (this.recipient) {
+          return {
+            address: `skychat://${this.recipient}`,
+            label: this.shortPk(this.recipient),
+            noun: 'contact',
+            isGroup: false,
+            isAdmin: false,
+          };
+        }
+        return null;
+      }
+
+      // showQr renders the open conversation's address as a QR code.
+      //
+      // The address is also printed underneath as selectable text with a
+      // copy button: a code is useless to anyone reading over a screen
+      // share, pasting into a terminal, or on a device with no camera.
+      showQr() {
+        const cur = this.currentAddress();
+        if (!cur) { this.showToast('Open a chat first.', 'error'); return; }
+        document.getElementById('qrTitle').textContent =
+          cur.isGroup ? `${cur.label} — address` : 'Contact address';
+        document.getElementById('qrAddrText').textContent = cur.address;
+        this._qrAddress = cur.address;
+
+        const ok = QR.draw(document.getElementById('qrCanvas'), cur.address);
+        document.getElementById('qrHelp').textContent = !ok
+          ? 'This address is too long to encode as a QR code — copy the text instead.'
+          : (cur.isGroup
+            ? `Scanning this opens the ${cur.noun}. It stays valid as the ${cur.noun} changes, but whoever scans it needs this host reachable to join.`
+            : 'Scanning this starts a direct message with you.');
+
+        // The invite link is the offline-capable alternative, and only an
+        // admin can mint one — so only offer it when it is actually
+        // available.
+        document.getElementById('qrInviteBtn').classList.toggle('hidden', !(cur.isGroup && cur.isAdmin));
+        document.getElementById('qrModal').classList.add('visible');
+      }
+
+      copyQrAddress() {
+        const text = this._qrAddress || document.getElementById('qrAddrText').textContent;
+        if (!text) return;
+        // The clipboard API needs a secure context; the text is selectable
+        // so there is always a manual fallback to point at.
+        navigator.clipboard.writeText(text)
+          .then(() => this.showToast('Address copied.'))
+          .catch(() => this.showToast('Could not copy — select the text and copy it manually.', 'error'));
+      }
+
+      // ---- QR scanning -----------------------------------------------
+
+      // _qrDetector returns a BarcodeDetector for QR codes, or null where
+      // the browser has no such API.
+      //
+      // Native only, no bundled decoder: this covers Chrome, Edge and the
+      // Android WebView the mobile app runs in, and adds nothing to a page
+      // that is already embedded in the binary. Where it is missing
+      // (Safari, Firefox) scanning is declined in plain words and the
+      // paste field — which is the whole dialog's primary input anyway —
+      // still works.
+      _qrDetector() {
+        if (typeof window.BarcodeDetector !== 'function') return null;
+        try {
+          return new window.BarcodeDetector({ formats: ['qr_code'] });
+        } catch (e) {
+          console.debug('skychat: BarcodeDetector unavailable:', e && e.message);
+          return null;
+        }
+      }
+
+      _qrUnsupportedToast() {
+        this.showToast(
+          'QR scanning needs Chrome, Edge or the Android app. Paste the address instead.',
+          'error');
+      }
+
+      async startQrScan() {
+        const detector = this._qrDetector();
+        if (!detector) { this._qrUnsupportedToast(); return; }
+        if (!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)) {
+          // Same secure-context rule the voice recorder documents: plain
+          // http only counts as secure on 127.0.0.1 / localhost.
+          this.showToast('The camera needs a secure page (https, or 127.0.0.1).', 'error');
+          return;
+        }
+        const box = document.getElementById('addrScanner');
+        const video = document.getElementById('addrScanVideo');
+        try {
+          // The rear camera is the one pointed at someone else's screen.
+          this._qrStream = await navigator.mediaDevices.getUserMedia({
+            video: { facingMode: { ideal: 'environment' } }, audio: false,
+          });
+        } catch (e) {
+          this.showToast(`Camera unavailable: ${e && e.message ? e.message : e}`, 'error');
+          return;
+        }
+        video.srcObject = this._qrStream;
+        box.classList.remove('hidden');
+        try { await video.play(); } catch (e) { /* autoplay attribute covers this */ }
+
+        this._qrScanning = true;
+        const tick = async () => {
+          if (!this._qrScanning) return;
+          try {
+            const found = await detector.detect(video);
+            if (found && found.length && found[0].rawValue) {
+              this._onQrDecoded(found[0].rawValue);
               return;
             }
-            this.showToast('Joined group.');
-            if (info && info.id) setTimeout(() => this.selectGroup(info.id), 300);
-          })
-          .catch(e => this.showToast(`Join failed: ${e}`, 'error'));
+          } catch (e) {
+            // A transient detect failure (a frame arriving mid-resize) is
+            // normal; only stop if the stream itself is gone.
+            if (!this._qrStream) return;
+          }
+          this._qrTimer = setTimeout(tick, 220);
+        };
+        tick();
+      }
+
+      stopQrScan() {
+        this._qrScanning = false;
+        clearTimeout(this._qrTimer);
+        if (this._qrStream) {
+          this._qrStream.getTracks().forEach(t => t.stop());
+          this._qrStream = null;
+        }
+        const video = document.getElementById('addrScanVideo');
+        if (video) video.srcObject = null;
+        const box = document.getElementById('addrScanner');
+        if (box) box.classList.add('hidden');
+      }
+
+      // scanQrFile reads a code out of a saved image — a screenshot, or a
+      // photo of someone else's screen. Same detector as the camera path,
+      // and the only option on a device with no usable camera.
+      async scanQrFile(ev) {
+        const input = ev && ev.target;
+        const file = input && input.files && input.files[0];
+        // Cleared immediately so picking the same file twice re-fires.
+        if (input) input.value = '';
+        if (!file) return;
+        const detector = this._qrDetector();
+        if (!detector) { this._qrUnsupportedToast(); return; }
+        try {
+          const bitmap = await createImageBitmap(file);
+          const found = await detector.detect(bitmap);
+          bitmap.close();
+          if (!found || !found.length || !found[0].rawValue) {
+            this.showToast('No QR code found in that image.', 'error');
+            return;
+          }
+          this._onQrDecoded(found[0].rawValue);
+        } catch (e) {
+          this.showToast(`Could not read that image: ${e && e.message ? e.message : e}`, 'error');
+        }
+      }
+
+      // _onQrDecoded funnels a scan into the same field a paste lands in,
+      // so a scanned address is resolved and confirmed exactly like a
+      // typed one. Nothing is joined without the user pressing the button.
+      _onQrDecoded(text) {
+        this.stopQrScan();
+        const input = document.getElementById('addrInput');
+        input.value = String(text).trim();
+        this.showToast('Code scanned.');
+        this.onAddressInput();
+      }
+
+      // ---- One-pane (phone) layout -----------------------------------
+
+      // _isOnePane matches the CSS breakpoint. Read from matchMedia rather
+      // than tracked in JS so the two can never disagree about which
+      // layout is on screen.
+      _isOnePane() {
+        return window.matchMedia('(max-width: 760px)').matches;
+      }
+
+      // _enterChatPane switches a narrow screen from the list to the open
+      // conversation, and pushes a history entry so the device back button
+      // returns to the list instead of leaving the app.
+      //
+      // Replaces rather than pushes when a conversation is already open, so
+      // hopping between five chats leaves one entry to go back through
+      // rather than five.
+      _enterChatPane() {
+        if (!this._isOnePane()) return;
+        const wasOpen = document.body.classList.contains('chat-open');
+        document.body.classList.add('chat-open');
+        const state = { skychat: 'chat' };
+        if (wasOpen && history.state && history.state.skychat === 'chat') {
+          history.replaceState(state, '');
+        } else {
+          history.pushState(state, '');
+        }
+      }
+
+      // showChatList goes back to the conversation list.
+      //
+      // popHistory is false when this is *driven by* a popstate — the
+      // browser has already moved, and calling back() again would leave
+      // the app.
+      showChatList(popHistory = true) {
+        document.body.classList.remove('chat-open');
+        if (popHistory && history.state && history.state.skychat === 'chat') {
+          history.back();
+        }
       }
 
       // ---- Group admission control -----------------------------------
@@ -6151,6 +6963,9 @@
           document.getElementById('messages').classList.add('hidden');
           document.getElementById('msgForm').classList.add('hidden');
           document.getElementById('emptyState').classList.remove('hidden');
+          // On a phone the chat pane IS the screen, so leaving the group
+          // that was open would strand the user on a blank one.
+          this.showChatList();
         }
       }
 
@@ -6235,6 +7050,9 @@
         document.getElementById('messages').classList.add('hidden');
         document.getElementById('msgForm').classList.add('hidden');
         document.getElementById('emptyState').classList.remove('hidden');
+        // See _removeGroup: on a phone, deleting the open conversation has
+        // to hand the screen back to the list.
+        this.showChatList();
 
         this.saveRecipients();
         this.saveSeenList();
@@ -6983,6 +7801,429 @@
       }
     }
 
+    // -------------------------------------------------------------------
+    // QR encoder (byte mode, error-correction level M, versions 1–10).
+    //
+    // Written out rather than pulled from a library because this page is
+    // one //go:embed'ed file served by the app itself and a strict
+    // offline surface: there is no CDN to reach and no build step to
+    // bundle with. Ten versions is deliberate headroom — the longest
+    // thing encoded here is a group address at 113 characters
+    // ("skychat://" + 66-hex key + "/" + 36-char UUID), and version 10 at
+    // level M holds 213 bytes.
+    //
+    // Level M (~15% recovery) over L: these codes get scanned off
+    // screens at angles and under glare, where the extra redundancy is
+    // the difference between a scan and a retry.
+    // -------------------------------------------------------------------
+    const QR = (function () {
+      // Per version: [total codewords, EC codewords per block,
+      // group-1 blocks, group-1 data codewords, group-2 blocks,
+      // group-2 data codewords] at level M.
+      const SPEC = {
+        1:  [26,  10, 1, 16, 0, 0],
+        2:  [44,  16, 1, 28, 0, 0],
+        3:  [70,  26, 1, 44, 0, 0],
+        4:  [100, 18, 2, 32, 0, 0],
+        5:  [134, 24, 2, 43, 0, 0],
+        6:  [172, 16, 4, 27, 0, 0],
+        7:  [196, 18, 4, 31, 0, 0],
+        8:  [242, 22, 2, 38, 2, 39],
+        9:  [292, 22, 3, 36, 2, 37],
+        10: [346, 26, 4, 43, 1, 44],
+      };
+
+      // Alignment-pattern centre coordinates per version.
+      const ALIGN = {
+        1: [], 2: [6, 18], 3: [6, 22], 4: [6, 26], 5: [6, 30],
+        6: [6, 34], 7: [6, 22, 38], 8: [6, 24, 42], 9: [6, 26, 46],
+        10: [6, 28, 50],
+      };
+
+      // Pre-computed BCH(18,6) version information, needed from version 7.
+      const VERSION_BITS = { 7: 0x07C94, 8: 0x085BC, 9: 0x09A99, 10: 0x0A4D3 };
+
+      // GF(256) log/antilog tables, primitive polynomial 0x11D.
+      const EXP = new Uint8Array(512), LOG = new Uint8Array(256);
+      (function initGF() {
+        let x = 1;
+        for (let i = 0; i < 255; i++) {
+          EXP[i] = x;
+          LOG[x] = i;
+          x <<= 1;
+          if (x & 0x100) x ^= 0x11D;
+        }
+        for (let i = 255; i < 512; i++) EXP[i] = EXP[i - 255];
+      })();
+
+      const mul = (a, b) => (a === 0 || b === 0) ? 0 : EXP[LOG[a] + LOG[b]];
+
+      // rsGenerator returns the generator polynomial for n EC codewords.
+      function rsGenerator(n) {
+        let g = [1];
+        for (let i = 0; i < n; i++) {
+          const next = new Array(g.length + 1).fill(0);
+          for (let j = 0; j < g.length; j++) {
+            next[j] ^= g[j];
+            next[j + 1] ^= mul(g[j], EXP[i]);
+          }
+          g = next;
+        }
+        return g;
+      }
+
+      // rsEncode returns the n EC codewords for one data block.
+      function rsEncode(data, n) {
+        const gen = rsGenerator(n);
+        const rem = new Array(n).fill(0);
+        for (const byte of data) {
+          const factor = byte ^ rem[0];
+          rem.shift();
+          rem.push(0);
+          for (let j = 0; j < n; j++) rem[j] ^= mul(gen[j + 1], factor);
+        }
+        return rem;
+      }
+
+      // byteCapacity is how many payload bytes a version holds: the data
+      // codewords, minus the mode indicator (4 bits) and character count
+      // (8 bits below version 10, 16 from it), rounded down.
+      function byteCapacity(version) {
+        const [, ec, b1, d1, b2, d2] = SPEC[version];
+        const dataCodewords = b1 * d1 + b2 * d2;
+        const overheadBits = 4 + (version >= 10 ? 16 : 8);
+        void ec;
+        return Math.floor((dataCodewords * 8 - overheadBits) / 8);
+      }
+
+      function pickVersion(len) {
+        for (let v = 1; v <= 10; v++) if (byteCapacity(v) >= len) return v;
+        return 0;
+      }
+
+      // buildCodewords produces the interleaved data+EC codeword stream.
+      function buildCodewords(bytes, version) {
+        const [, ecPerBlock, b1, d1, b2, d2] = SPEC[version];
+        const dataCodewords = b1 * d1 + b2 * d2;
+
+        // Bit stream: mode 0100 (byte), length, payload, terminator.
+        const bits = [];
+        const push = (value, n) => {
+          for (let i = n - 1; i >= 0; i--) bits.push((value >> i) & 1);
+        };
+        push(0b0100, 4);
+        push(bytes.length, version >= 10 ? 16 : 8);
+        for (const b of bytes) push(b, 8);
+        for (let i = 0; i < 4 && bits.length < dataCodewords * 8; i++) bits.push(0);
+        while (bits.length % 8 !== 0) bits.push(0);
+
+        const words = [];
+        for (let i = 0; i < bits.length; i += 8) {
+          let byte = 0;
+          for (let j = 0; j < 8; j++) byte = (byte << 1) | bits[i + j];
+          words.push(byte);
+        }
+        // Pad bytes alternate 0xEC / 0x11 per the spec.
+        const PAD = [0xEC, 0x11];
+        for (let i = 0; words.length < dataCodewords; i++) words.push(PAD[i % 2]);
+
+        // Split into blocks, compute EC per block, then interleave.
+        const blocks = [], ecBlocks = [];
+        let at = 0;
+        for (let i = 0; i < b1; i++) { blocks.push(words.slice(at, at + d1)); at += d1; }
+        for (let i = 0; i < b2; i++) { blocks.push(words.slice(at, at + d2)); at += d2; }
+        for (const blk of blocks) ecBlocks.push(rsEncode(blk, ecPerBlock));
+
+        const out = [];
+        const maxData = Math.max(d1, d2);
+        for (let i = 0; i < maxData; i++) {
+          for (const blk of blocks) if (i < blk.length) out.push(blk[i]);
+        }
+        for (let i = 0; i < ecPerBlock; i++) {
+          for (const blk of ecBlocks) out.push(blk[i]);
+        }
+        return out;
+      }
+
+      // bchFormat computes the 15-bit format information for a mask.
+      // Level M is 0b00, so the 5 data bits are just the mask pattern.
+      function bchFormat(mask) {
+        const data = (0b00 << 3) | mask;
+        let v = data << 10;
+        for (let i = 4; i >= 0; i--) {
+          if (v & (1 << (i + 10))) v ^= 0x537 << i;
+        }
+        return ((data << 10) | v) ^ 0x5412;
+      }
+
+      // newMatrix lays out everything except the data and format bits,
+      // returning the module grid plus a parallel "reserved" grid so the
+      // data walk knows which cells it may not use.
+      function newMatrix(version) {
+        const size = version * 4 + 17;
+        const m = [], reserved = [];
+        for (let i = 0; i < size; i++) {
+          m.push(new Array(size).fill(0));
+          reserved.push(new Array(size).fill(false));
+        }
+        const set = (r, c, v) => { m[r][c] = v; reserved[r][c] = true; };
+
+        // Finder patterns and their separators. A finder is 7x7:
+        //
+        //   1111111    dark at Chebyshev ring 3 (the outer border)
+        //   1000001    light at ring 2
+        //   1011101    dark at rings 0 and 1 (the 3x3 core)
+        //   1011101
+        //   1011101
+        //   1000001
+        //   1111111
+        //
+        // Note this is NOT the alignment pattern's rule, which is 5x5 with
+        // a single light ring — using that one here produces a filled
+        // square that no scanner will lock onto.
+        const finder = (r0, c0) => {
+          for (let r = -1; r <= 7; r++) {
+            for (let c = -1; c <= 7; c++) {
+              const r1 = r0 + r, c1 = c0 + c;
+              if (r1 < 0 || c1 < 0 || r1 >= size || c1 >= size) continue;
+              const ring = Math.max(Math.abs(r - 3), Math.abs(c - 3));
+              set(r1, c1, (ring <= 1 || ring === 3) ? 1 : 0);
+            }
+          }
+        };
+        finder(0, 0); finder(0, size - 7); finder(size - 7, 0);
+
+        // Timing patterns.
+        for (let i = 8; i < size - 8; i++) {
+          const v = i % 2 === 0 ? 1 : 0;
+          set(6, i, v);
+          set(i, 6, v);
+        }
+
+        // Alignment patterns, skipping the three finder corners.
+        const centres = ALIGN[version];
+        for (const r0 of centres) {
+          for (const c0 of centres) {
+            const nearFinder =
+              (r0 === 6 && c0 === 6) ||
+              (r0 === 6 && c0 === size - 7) ||
+              (r0 === size - 7 && c0 === 6);
+            if (nearFinder) continue;
+            for (let r = -2; r <= 2; r++) {
+              for (let c = -2; c <= 2; c++) {
+                const ring = Math.max(Math.abs(r), Math.abs(c));
+                set(r0 + r, c0 + c, ring === 1 ? 0 : 1);
+              }
+            }
+          }
+        }
+
+        // Dark module, then reserve the format-info cells.
+        set(size - 8, 8, 1);
+        for (let i = 0; i < 9; i++) {
+          if (!reserved[8][i]) set(8, i, 0);
+          if (!reserved[i][8]) set(i, 8, 0);
+        }
+        for (let i = 0; i < 8; i++) {
+          if (!reserved[8][size - 1 - i]) set(8, size - 1 - i, 0);
+          if (!reserved[size - 1 - i][8]) set(size - 1 - i, 8, 0);
+        }
+
+        // Version information (version 7 and up).
+        if (version >= 7) {
+          const bits = VERSION_BITS[version];
+          for (let i = 0; i < 18; i++) {
+            const bit = (bits >> i) & 1;
+            set(Math.floor(i / 3), size - 11 + (i % 3), bit);
+            set(size - 11 + (i % 3), Math.floor(i / 3), bit);
+          }
+        }
+        return { m, reserved, size };
+      }
+
+      // placeData walks the standard two-column zigzag from the bottom
+      // right, skipping reserved cells.
+      function placeData(grid, codewords) {
+        const { m, reserved, size } = grid;
+        let bit = 0;
+        const total = codewords.length * 8;
+        const nextBit = () => {
+          if (bit >= total) return 0;   // remainder bits are 0
+          const v = (codewords[bit >> 3] >> (7 - (bit & 7))) & 1;
+          bit++;
+          return v;
+        };
+        let upward = true;
+        for (let col = size - 1; col > 0; col -= 2) {
+          if (col === 6) col--;   // the vertical timing pattern is not a column
+          for (let i = 0; i < size; i++) {
+            const row = upward ? size - 1 - i : i;
+            for (const c of [col, col - 1]) {
+              if (reserved[row][c]) continue;
+              m[row][c] = nextBit();
+            }
+          }
+          upward = !upward;
+        }
+      }
+
+      const MASKS = [
+        (r, c) => (r + c) % 2 === 0,
+        (r) => r % 2 === 0,
+        (r, c) => c % 3 === 0,
+        (r, c) => (r + c) % 3 === 0,
+        (r, c) => (Math.floor(r / 2) + Math.floor(c / 3)) % 2 === 0,
+        (r, c) => ((r * c) % 2) + ((r * c) % 3) === 0,
+        (r, c) => (((r * c) % 2) + ((r * c) % 3)) % 2 === 0,
+        (r, c) => (((r + c) % 2) + ((r * c) % 3)) % 2 === 0,
+      ];
+
+      // penalty scores a masked grid by the four standard rules. A poor
+      // mask still decodes in most readers, but the rules exist to avoid
+      // runs and blocks that look like finder patterns — exactly the
+      // failure a phone camera hits first.
+      function penalty(m, size) {
+        let score = 0;
+
+        // Rule 1: runs of five or more same-colour modules in a line.
+        const runs = (get) => {
+          for (let a = 0; a < size; a++) {
+            let run = 1;
+            for (let b = 1; b < size; b++) {
+              if (get(a, b) === get(a, b - 1)) {
+                run++;
+              } else {
+                if (run >= 5) score += 3 + (run - 5);
+                run = 1;
+              }
+            }
+            if (run >= 5) score += 3 + (run - 5);
+          }
+        };
+        runs((r, c) => m[r][c]);
+        runs((c, r) => m[r][c]);
+
+        // Rule 2: every 2x2 block of one colour.
+        for (let r = 0; r < size - 1; r++) {
+          for (let c = 0; c < size - 1; c++) {
+            const v = m[r][c];
+            if (v === m[r][c + 1] && v === m[r + 1][c] && v === m[r + 1][c + 1]) score += 3;
+          }
+        }
+
+        // Rule 3: the 1:1:3:1:1 finder-lookalike with four light modules
+        // on either side.
+        const A = [1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0];
+        const B = [0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1];
+        const matches = (get, a, start) => {
+          for (let k = 0; k < 11; k++) {
+            if (get(a, start + k) !== A[k]) return false;
+          }
+          return true;
+        };
+        const matchesB = (get, a, start) => {
+          for (let k = 0; k < 11; k++) {
+            if (get(a, start + k) !== B[k]) return false;
+          }
+          return true;
+        };
+        for (const get of [(r, c) => m[r][c], (c, r) => m[r][c]]) {
+          for (let a = 0; a < size; a++) {
+            for (let s = 0; s + 11 <= size; s++) {
+              if (matches(get, a, s) || matchesB(get, a, s)) score += 40;
+            }
+          }
+        }
+
+        // Rule 4: deviation of the dark-module proportion from 50%.
+        let dark = 0;
+        for (let r = 0; r < size; r++) for (let c = 0; c < size; c++) dark += m[r][c];
+        const pct = (dark * 100) / (size * size);
+        score += Math.floor(Math.abs(pct - 50) / 5) * 10;
+        return score;
+      }
+
+      // applyFormat writes the 15 format bits into their two copies.
+      //
+      // The split in copy 2 is 7 bits then 8, not 8 and 7: row size-8 in
+      // that column is the always-dark module, which the format must step
+      // over. Getting it wrong overwrites the dark module and shifts every
+      // remaining bit, which no scanner recovers from.
+      function applyFormat(m, size, mask) {
+        const bits = bchFormat(mask);
+        // Most significant bit first: position 0 of each copy carries bit
+        // 14. Placing it LSB-first instead yields a 15-bit value that is
+        // not in the format table at all, so a reader finds no valid
+        // (level, mask) pair and gives up before it ever looks at the
+        // data — which is indistinguishable from a corrupt image.
+        const at = (i) => (bits >> (14 - i)) & 1;
+        // Copy 1, around the top-left finder.
+        for (let i = 0; i <= 5; i++) m[8][i] = at(i);
+        m[8][7] = at(6);
+        m[8][8] = at(7);
+        m[7][8] = at(8);
+        for (let i = 9; i <= 14; i++) m[14 - i][8] = at(i);
+        // Copy 2: bits 0–6 up the bottom-left column, bits 7–14 along the
+        // top-right row.
+        for (let i = 0; i <= 6; i++) m[size - 1 - i][8] = at(i);
+        for (let i = 7; i <= 14; i++) m[8][size - 15 + i] = at(i);
+      }
+
+      // encode returns the finished module grid for text, or null when the
+      // text is too long for version 10.
+      function encode(text) {
+        const bytes = Array.from(new TextEncoder().encode(text));
+        const version = pickVersion(bytes.length);
+        if (!version) return null;
+        const codewords = buildCodewords(bytes, version);
+
+        let best = null, bestScore = Infinity;
+        for (let mask = 0; mask < 8; mask++) {
+          const grid = newMatrix(version);
+          placeData(grid, codewords);
+          const { m, reserved, size } = grid;
+          for (let r = 0; r < size; r++) {
+            for (let c = 0; c < size; c++) {
+              if (!reserved[r][c] && MASKS[mask](r, c)) m[r][c] ^= 1;
+            }
+          }
+          applyFormat(m, size, mask);
+          const score = penalty(m, size);
+          if (score < bestScore) { bestScore = score; best = { m, size }; }
+        }
+        return best;
+      }
+
+      // draw paints a grid onto a canvas with the mandatory 4-module
+      // quiet zone. Sized to whole pixels per module so the result stays
+      // crisp instead of blurring on a fractional scale.
+      function draw(canvas, text) {
+        const grid = encode(text);
+        const ctx = canvas.getContext('2d');
+        if (!grid) {
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+          return false;
+        }
+        const quiet = 4;
+        const total = grid.size + quiet * 2;
+        const scale = Math.max(2, Math.floor(264 / total));
+        canvas.width = canvas.height = total * scale;
+        ctx.fillStyle = '#fff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#000';
+        for (let r = 0; r < grid.size; r++) {
+          for (let c = 0; c < grid.size; c++) {
+            if (grid.m[r][c]) {
+              ctx.fillRect((c + quiet) * scale, (r + quiet) * scale, scale, scale);
+            }
+          }
+        }
+        return true;
+      }
+
+      return { encode, draw };
+    })();
+
     window.app = new Chat();
 
     // Close modal on backdrop click
@@ -6990,11 +8231,43 @@
       if (e.target === this) app.closeSettings();
     });
 
-    // Close group modals on backdrop click.
-    ['createGroupModal', 'joinGroupModal', 'groupAdminModal'].forEach(function(id) {
+    // Close group modals on backdrop click. addressModal closes through
+    // its own helper so a running camera scan is always stopped.
+    ['createGroupModal', 'createChannelModal', 'groupAdminModal', 'qrModal'].forEach(function(id) {
       document.getElementById(id).addEventListener('click', function(e) {
         if (e.target === this) app.closeModal(id);
       });
+    });
+    document.getElementById('addressModal').addEventListener('click', function(e) {
+      if (e.target === this) app.closeAddressModal();
+    });
+
+    // Dismiss the start menu on any click outside it. Capture phase so
+    // it fires before a click lands on whatever is underneath.
+    document.addEventListener('click', function(e) {
+      const menu = document.getElementById('startMenu');
+      if (!menu.classList.contains('visible')) return;
+      if (menu.contains(e.target)) return;
+      if (document.getElementById('startBtn').contains(e.target)) return;
+      app.closeStartMenu();
+    }, true);
+
+    // Keep the open menu attached to its button when the viewport changes
+    // — a resize can move the button between the header and the floating
+    // position, and an orientation change moves it a long way.
+    window.addEventListener('resize', function() {
+      const menu = document.getElementById('startMenu');
+      if (!menu.classList.contains('visible')) return;
+      app.closeStartMenu();
+    });
+
+    // Device / browser back on a phone returns to the conversation list
+    // rather than leaving the app. Only meaningful in the one-pane layout,
+    // where opening a chat pushed the entry this pops.
+    window.addEventListener('popstate', function() {
+      // popHistory=false: the browser has already moved back, so calling
+      // history.back() again here would navigate away from the app.
+      app.showChatList(false);
     });
 
     // Keyboard shortcuts
@@ -7002,9 +8275,12 @@
       if (e.key === 'Escape') {
         app.closeSettings();
         app.closeLightbox();
+        app.closeStartMenu();
         app.closeModal('createGroupModal');
-        app.closeModal('joinGroupModal');
+        app.closeModal('createChannelModal');
         app.closeModal('groupAdminModal');
+        app.closeModal('qrModal');
+        app.closeAddressModal();
       }
     });
   </script>

--- a/cmd/apps/skychat/commands/static/index.html
+++ b/cmd/apps/skychat/commands/static/index.html
@@ -1618,6 +1618,58 @@
       image-rendering: pixelated;   /* keep module edges crisp when scaled */
     }
 
+    .addr-catalog {
+      margin-bottom: 12px;
+      border: 1px solid var(--border-color);
+      border-radius: 10px;
+      overflow: hidden;
+    }
+
+    .addr-catalog.hidden { display: none; }
+
+    .ac-head {
+      padding: 8px 12px;
+      background: var(--bg-tertiary);
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.4px;
+      text-transform: uppercase;
+      color: var(--accent-green);
+    }
+
+    .ac-list { max-height: 190px; overflow-y: auto; }
+
+    .ac-item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      width: 100%;
+      padding: 9px 12px;
+      background: transparent;
+      border: none;
+      border-top: 1px solid var(--border-color);
+      color: var(--text-primary);
+      text-align: left;
+      font: inherit;
+      cursor: pointer;
+    }
+
+    .ac-item:hover { background: var(--bg-hover); }
+    .ac-icon { font-size: 15px; flex: 0 0 auto; }
+    .ac-body { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+    .ac-name { font-size: 13px; }
+    .ac-meta { font-size: 10px; color: var(--text-muted); }
+    .ac-go { margin-left: auto; font-size: 11px; color: var(--accent-blue); flex: 0 0 auto; }
+
+    .hist-loading {
+      padding: 6px 20px;
+      background: var(--bg-secondary);
+      border-bottom: 1px solid var(--border-color);
+      color: var(--text-muted);
+      font-size: 11px;
+      text-align: center;
+    }
+
     .qr-addr-row {
       display: flex;
       align-items: center;
@@ -2197,7 +2249,12 @@
       <p>Select a contact or add a new one by entering their public key to start messaging over the Skywire network.</p>
     </div>
 
-    <ul id="messages" class="messages-container hidden"></ul>
+    <!-- Shown while an older page of a group's backlog is on its way. Sits
+         outside the scroll container so appearing does not itself shift the
+         reader's position. -->
+    <div id="histLoading" class="hist-loading hidden">Loading earlier messages…</div>
+
+    <ul id="messages" class="messages-container hidden" onscroll="app._onMessagesScroll()"></ul>
 
     <div id="replyChip" class="reply-chip hidden"></div>
 
@@ -2419,13 +2476,23 @@
         key would go to anyone who asked and would protect nothing.
         Traffic is still encrypted in transit.
       </p>
+      <p class="cg-help">
+        History and files are served by the channel's admins, not by other
+        subscribers — a subscriber has nothing of its own to share, so a
+        large channel stays cheap to follow. New joiners receive the
+        backlog in chunks while an admin is online.
+      </p>
+      <!-- Unticked by default. Being findable is a decision, not a
+           default: nothing this visor hosts should become enumerable by
+           accident. -->
       <label class="cg-check">
-        <input type="checkbox" id="ccPeerBackfill" checked />
-        <span>Any member can share history with new members</span>
+        <input type="checkbox" id="ccListed" />
+        <span>List in the public catalog</span>
       </label>
       <p class="cg-help">
-        Off means only admins can, so the channel goes quiet for new
-        joiners whenever no admin is online.
+        On means anyone who knows this visor's public key can discover this
+        channel by asking it. Off keeps it reachable only by its address or
+        an invite link. An admin can change this later.
       </p>
       <div class="modal-actions">
         <button class="btn" onclick="app.createChannel()">Create</button>
@@ -2468,6 +2535,11 @@
       <div id="addrResult" class="addr-result hidden"></div>
       <p id="addrHint" class="cg-help"></p>
 
+      <!-- Channels and groups the entered visor publishes. A public key names
+           a person, but that person's visor may also host things worth
+           joining, and there is otherwise no way to find out. -->
+      <div id="addrCatalog" class="addr-catalog hidden"></div>
+
       <div class="modal-actions">
         <button id="addrActionBtn" class="btn hidden" onclick="app.addressAction()">Start Chat</button>
         <button class="btn btn-secondary" onclick="app.closeAddressModal()">Cancel</button>
@@ -2506,6 +2578,20 @@
           <input type="checkbox" id="gaReadOnly" onchange="app.toggleGroupReadOnly()" />
           <span>Read-only — only admins can send messages</span>
         </label>
+      </div>
+      <!-- Discovery. Local to this visor rather than a property of the group:
+           it says what WE answer questions about, so another admin's copy is
+           unaffected either way. -->
+      <div id="gaListedRow" class="ga-row hidden">
+        <label class="ga-toggle">
+          <input type="checkbox" id="gaListed" onchange="app.toggleGroupListed()" />
+          <span>List in this visor's public catalog</span>
+        </label>
+        <p class="cg-help">
+          On means anyone holding this visor's public key can discover it by
+          asking. Off keeps it reachable only by address or invite link. Other
+          admins publish their own copies independently.
+        </p>
       </div>
       <!-- Flood protection. Public keys are free, so this is the only
            thing that makes an identity cost anything. -->
@@ -5825,6 +5911,7 @@
         this.messages[id].forEach(m => this._showMessage(m));
         msgEl.scrollTop = msgEl.scrollHeight;
         document.getElementById('msgField').focus();
+        this._setHistLoading(false);
 
         this.loadGroupHistory(id);
         this.renderPinned();
@@ -5832,58 +5919,186 @@
         this._updateMuteButtons();
       }
 
-      // loadGroupHistory backfills persisted messages when the local buffer is
-      // empty. Group messages aren't cached in localStorage (the visor's
-      // history store is the source of truth), so this runs on each open of an
-      // empty thread; returns silently if group history is disabled.
+      // groupHistoryChunk is how many messages one page of backlog carries.
+      //
+      // Small on purpose. A channel can hold years of posts, and the point of
+      // paging is that opening one shows something immediately instead of
+      // waiting on the whole archive; 50 fills a screen with room to spare and
+      // the next page arrives before the reader gets to the top of this one.
+      static get groupHistoryChunk() { return 50; }
+
+      // _histState returns the paging state for a group, creating it on first
+      // use. cursor is the ts_nano of the OLDEST row we hold — the exclusive
+      // bound for the next page. done means the server has told us there is
+      // nothing older, which is what stops the scroll handler asking forever.
+      _histState(id) {
+        this._hist = this._hist || {};
+        if (!this._hist[id]) this._hist[id] = { cursor: null, done: false, loading: false };
+        return this._hist[id];
+      }
+
+      // _groupHistoryRows converts persisted rows into render entries and
+      // returns them with the oldest row's cursor.
+      //
+      // Shared by the first page and every older page so the two cannot drift
+      // in how they interpret a file reference, a reply, or a local hide — a
+      // scroll-back that rendered attachments differently from the initial
+      // load would be a subtle, hard-to-spot bug.
+      //
+      // Date dividers are deliberately NOT inserted here: a page boundary is
+      // not a day boundary, and a divider decided per-page would repeat or go
+      // missing depending on where the split fell. _redrawGroup adds them once
+      // over the assembled list instead.
+      _groupHistoryRows(id, msgs) {
+        const rows = [];
+        let oldest = null;
+        msgs.forEach(m => {
+          const tsNano = m.ts_nano != null ? m.ts_nano : null;
+          const ts = new Date(m.ts);
+          // The cursor tracks the oldest row REGARDLESS of whether it is
+          // rendered: paging past a message hidden on this device must still
+          // advance, or the next page would return the same rows forever.
+          const cur = tsNano != null ? String(tsNano) : String(ts.getTime() * 1000000);
+          if (oldest === null) oldest = cur;
+          // Skip messages this device deleted-for-me (groups reload from
+          // history, so the local hide lives in hiddenGroup, not the cache).
+          if (this._isGroupHidden(id, tsNano != null ? String(tsNano) : '')) return;
+          const sender = String(m.sender_pk || '').toLowerCase();
+          const senderIsMe = sender === this.myPK;
+          // A file-reference row (file_id set) becomes a media bubble.
+          // file_url is present only when this visor already holds the
+          // bytes; otherwise it renders as a card with a re-request link
+          // (skipped on our own sends — no .from). Bytes then arrive via a
+          // file-ready patch. In a channel that card is the normal state:
+          // nothing is downloaded until somebody asks for it.
+          const file = m.file_id ? {
+            id: m.file_id,
+            name: m.file_name || 'file',
+            size: m.file_size || 0,
+            url: m.file_url || null,
+            from: senderIsMe ? null : sender,
+          } : null;
+          const reply = (m.reply_to_ts || m.reply_to_preview || m.reply_to_sender) ? {
+            sender: (m.reply_to_sender || '').toLowerCase(),
+            ts: m.reply_to_ts || '',
+            preview: m.reply_to_preview || '',
+          } : null;
+          rows.push({ ts, from: senderIsMe ? 'me' : sender, text: m.text, group: true, sender, file, reply, tsNano });
+        });
+        return { rows, oldest };
+      }
+
+      // _redrawGroup re-renders the open group from this.messages, inserting
+      // date dividers over the whole assembled list.
+      //
+      // keepAnchor preserves the reader's position when older messages have
+      // just been prepended: the content above them grew, so scrollTop is
+      // shifted by exactly that growth and the message under the cursor does
+      // not move. Without it, loading a page would yank the view to the top.
+      _redrawGroup(id, keepAnchor) {
+        const el = document.getElementById('messages');
+        if (!el || this.group !== id) return;
+        const beforeH = el.scrollHeight;
+        const beforeTop = el.scrollTop;
+        el.innerHTML = '';
+        let lastDay = null;
+        (this.messages[id] || []).forEach(m => {
+          if (m.date) return; // stale divider from an earlier render
+          const day = m.ts ? m.ts.toDateString() : null;
+          if (day && day !== lastDay) {
+            this._showMessage({ date: m.ts });
+            lastDay = day;
+          }
+          this._showMessage(m);
+        });
+        if (keepAnchor) {
+          el.scrollTop = el.scrollHeight - beforeH + beforeTop;
+        } else {
+          el.scrollTop = el.scrollHeight;
+        }
+      }
+
+      // loadGroupHistory loads the NEWEST page of a group's backlog when the
+      // local buffer is empty. Group messages aren't cached in localStorage
+      // (the visor's history store is the source of truth), so this runs on
+      // each open of an empty thread; silent if group history is disabled.
+      //
+      // Older pages are not fetched here. They arrive as the reader scrolls
+      // back — see _onMessagesScroll — which is what makes a channel with a
+      // deep backlog open instantly instead of pulling all of it first.
       loadGroupHistory(id) {
         if (this.messages[id] && this.messages[id].length > 0) return;
-        fetch(`/group/${id}/history?limit=100`)
+        const st = this._histState(id);
+        st.loading = true;
+        fetch(`/group/${id}/history?limit=${Chat.groupHistoryChunk}`)
           .then(res => res.ok ? res.json() : null)
           .then(msgs => {
-            if (!msgs || !msgs.length) return;
+            st.loading = false;
+            if (!msgs || !msgs.length) { st.done = true; return; }
             if (this.messages[id].length > 0) return;
-            const withDates = [];
-            let lastDay = null;
-            msgs.forEach(m => {
-              const tsNano = m.ts_nano != null ? m.ts_nano : null;
-              // Skip messages this device deleted-for-me (groups reload from
-              // history, so the local hide lives in hiddenGroup, not the cache).
-              if (this._isGroupHidden(id, tsNano != null ? String(tsNano) : '')) return;
-              const ts = new Date(m.ts);
-              const day = ts.toDateString();
-              if (day !== lastDay) { withDates.push({ date: ts }); lastDay = day; }
-              const sender = String(m.sender_pk || '').toLowerCase();
-              const senderIsMe = sender === this.myPK;
-              // A file-reference row (file_id set) becomes a media bubble.
-              // file_url is present only when this visor already holds the
-              // bytes; otherwise it renders as a card with a re-request link
-              // (skipped on our own sends — no .from). Bytes then arrive via a
-              // file-ready patch.
-              const file = m.file_id ? {
-                id: m.file_id,
-                name: m.file_name || 'file',
-                size: m.file_size || 0,
-                url: m.file_url || null,
-                from: senderIsMe ? null : sender,
-              } : null;
-              const reply = (m.reply_to_ts || m.reply_to_preview || m.reply_to_sender) ? {
-                sender: (m.reply_to_sender || '').toLowerCase(),
-                ts: m.reply_to_ts || '',
-                preview: m.reply_to_preview || '',
-              } : null;
-              withDates.push({ ts, from: senderIsMe ? 'me' : sender, text: m.text, group: true, sender, file, reply, tsNano });
-            });
-            this.messages[id] = withDates;
+            const { rows, oldest } = this._groupHistoryRows(id, msgs);
+            this.messages[id] = rows;
             this.messagesQuantity[id] = msgs.length;
-            if (this.group === id) {
-              const el = document.getElementById('messages');
-              el.innerHTML = '';
-              this.messages[id].forEach(m => this._showMessage(m));
-              el.scrollTop = el.scrollHeight;
-            }
+            st.cursor = oldest;
+            // A short page means the store had nothing more to give.
+            if (msgs.length < Chat.groupHistoryChunk) st.done = true;
+            this._redrawGroup(id, false);
           })
-          .catch(e => console.debug('group history skipped:', e.message));
+          .catch(e => {
+            st.loading = false;
+            console.debug('group history skipped:', e.message);
+          });
+      }
+
+      // loadOlderGroupHistory fetches the page before what we hold and
+      // prepends it. Idempotent while a request is in flight, and a no-op once
+      // the store has reported the start of history.
+      loadOlderGroupHistory(id) {
+        const st = this._histState(id);
+        if (st.loading || st.done || !st.cursor) return;
+        st.loading = true;
+        this._setHistLoading(true);
+        fetch(`/group/${id}/history?limit=${Chat.groupHistoryChunk}&before=${encodeURIComponent(st.cursor)}`)
+          .then(res => res.ok ? res.json() : null)
+          .then(msgs => {
+            st.loading = false;
+            this._setHistLoading(false);
+            if (!msgs || !msgs.length) { st.done = true; return; }
+            const { rows, oldest } = this._groupHistoryRows(id, msgs);
+            if (oldest !== null) st.cursor = oldest;
+            if (msgs.length < Chat.groupHistoryChunk) st.done = true;
+            if (!rows.length) {
+              // Every row on this page was hidden locally. The cursor moved,
+              // so try the next page rather than stopping on a blank one.
+              if (!st.done) this.loadOlderGroupHistory(id);
+              return;
+            }
+            this.messages[id] = rows.concat(this.messages[id] || []);
+            this.messagesQuantity[id] = (this.messagesQuantity[id] || 0) + msgs.length;
+            this._redrawGroup(id, true);
+          })
+          .catch(e => {
+            st.loading = false;
+            this._setHistLoading(false);
+            console.debug('older group history skipped:', e.message);
+          });
+      }
+
+      _setHistLoading(on) {
+        const el = document.getElementById('histLoading');
+        if (el) el.classList.toggle('hidden', !on);
+      }
+
+      // _onMessagesScroll pulls the next page when the reader nears the top of
+      // the backlog. Bound once in the constructor path; harmless for DMs,
+      // which have no group paging state and fall out on the guard.
+      _onMessagesScroll() {
+        if (!this.group) return;
+        const el = document.getElementById('messages');
+        if (!el) return;
+        // A threshold rather than exactly zero so the next page is already
+        // arriving by the time the reader reaches the end of this one.
+        if (el.scrollTop <= 120) this.loadOlderGroupHistory(this.group);
       }
 
       sendGroupMessage(text) {
@@ -6023,8 +6238,8 @@
       openCreateChannel() {
         this.closeStartMenu();
         document.getElementById('ccName').value = '';
-        const backfill = document.getElementById('ccPeerBackfill');
-        if (backfill) backfill.checked = true;
+        const listed = document.getElementById('ccListed');
+        if (listed) listed.checked = false;
         document.getElementById('createChannelModal').classList.add('visible');
       }
 
@@ -6033,13 +6248,14 @@
       // only difference on the wire is kind.
       createChannel() {
         const name = document.getElementById('ccName').value.trim();
-        const backfillEl = document.getElementById('ccPeerBackfill');
-        const peer_backfill = backfillEl ? !!backfillEl.checked : true;
+        const listedEl = document.getElementById('ccListed');
+        // Off unless ticked: being findable is a decision, not a default.
+        const listed = listedEl ? !!listedEl.checked : false;
         if (!name) { this.showToast('Enter a channel name.', 'error'); return; }
         fetch('/group', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name, kind: 'channel', members: [], peer_backfill })
+          body: JSON.stringify({ name, kind: 'channel', members: [], listed })
         })
           .then(res => res.ok ? res.json() : res.text().then(t => Promise.reject(t)))
           .then(j => {
@@ -6173,6 +6389,8 @@
         const hint = document.getElementById('addrHint');
         box.className = 'addr-result';
         btn.classList.add('hidden');
+        // Any re-render invalidates whatever the last key's catalog showed.
+        this._clearCatalog();
 
         if (!res) { box.classList.add('hidden'); return; }
 
@@ -6200,6 +6418,9 @@
           hint.textContent = 'Messages to a person are encrypted end to end.';
           btn.textContent = this.recipients.includes(res.pk) ? 'Open Chat' : 'Start Chat';
           btn.classList.remove('hidden');
+          // A key names a person, but their visor may also publish channels.
+          // Asking is the only way to find out — there is no index anywhere.
+          this._loadCatalogFor(res.pk);
           return;
         }
 
@@ -6249,6 +6470,66 @@
           ? 'Join Channel'
           : (g.policy === 'approval' ? 'Send Request' : 'Join Group');
         btn.classList.remove('hidden');
+      }
+
+      // ---- Discovery catalog -----------------------------------------
+
+      _clearCatalog() {
+        this._catalogSeq = (this._catalogSeq || 0) + 1;
+        const box = document.getElementById('addrCatalog');
+        if (box) { box.innerHTML = ''; box.classList.add('hidden'); }
+      }
+
+      // _loadCatalogFor asks a visor what it publishes and lists the result
+      // under the resolved contact.
+      //
+      // Best-effort and silent on failure: most visors publish nothing, and an
+      // error bar for "this person hosts no channels" would be noise on the
+      // common path. Only listed entries ever come back — see Record.Listed.
+      _loadCatalogFor(pk) {
+        const seq = (this._catalogSeq = (this._catalogSeq || 0) + 1);
+        fetch(`/group/catalog?pk=${encodeURIComponent(pk)}`)
+          .then(res => res.ok ? res.json() : null)
+          .then(data => {
+            if (seq !== this._catalogSeq) return;   // a newer input superseded us
+            const entries = (data && data.entries) || [];
+            if (!entries.length) return;
+            this._renderCatalog(entries, !!(data && data.truncated));
+          })
+          .catch(() => {});
+      }
+
+      _renderCatalog(entries, truncated) {
+        const box = document.getElementById('addrCatalog');
+        if (!box) return;
+        const rows = entries.map(e => {
+          const isChannel = e.kind === 'channel';
+          const bits = [isChannel ? 'Channel' : 'Group'];
+          bits.push(e.policy === 'approval' ? 'approval needed' : 'open to join');
+          if (e.price_hint) bits.push(`${e.price_hint} (claimed)`);
+          const already = this.groups.some(g => g.id === e.id);
+          return `<button class="ac-item" onclick="app.openCatalogEntry('${this.escapeAttr(e.address)}')">
+              <span class="ac-icon">${isChannel ? '&#x1F4E3;' : '&#x1F465;'}</span>
+              <span class="ac-body">
+                <span class="ac-name">${this.escapeHtml(e.name || e.id)}</span>
+                <span class="ac-meta">${this.escapeHtml(bits.join(' · '))}</span>
+              </span>
+              <span class="ac-go">${already ? 'open' : 'view'}</span>
+            </button>`;
+        }).join('');
+        const more = truncated ? ' (showing the first few)' : '';
+        box.innerHTML = `<div class="ac-head">Also published by this visor${more}</div>
+          <div class="ac-list">${rows}</div>`;
+        box.classList.remove('hidden');
+      }
+
+      // openCatalogEntry puts a discovered address into the field and resolves
+      // it, so a listed channel is confirmed through exactly the same path as
+      // a pasted one — nothing is joined by tapping a row in a list.
+      openCatalogEntry(addr) {
+        const input = document.getElementById('addrInput');
+        input.value = addr;
+        this.onAddressInput();
       }
 
       // addressAction performs whatever the resolved address implies.
@@ -6595,8 +6876,15 @@
         const isAdmin = this._isGroupAdmin(info);
 
         const roRow = document.getElementById('gaReadOnlyRow');
-        roRow.classList.toggle('hidden', !isAdmin);
+        // A channel is admins-only permanently, so a reversible "quiet the
+        // room" toggle has nothing left to say there.
+        const isChannel = !!(info && info.kind === 'channel');
+        roRow.classList.toggle('hidden', !isAdmin || isChannel);
         document.getElementById('gaReadOnly').checked = !!(info && info.read_only);
+
+        const listedRow = document.getElementById('gaListedRow');
+        listedRow.classList.toggle('hidden', !isAdmin);
+        document.getElementById('gaListed').checked = !!(info && info.listed);
 
         // Encryption / key generation. Only private groups have a key, and
         // only admins can rotate it — a public group's bodies are plaintext
@@ -6861,6 +7149,27 @@
           })
           .catch(e => {
             document.getElementById('gaPeerBackfill').checked = !on;
+            this.showToast(`Failed: ${e}`, 'error');
+          });
+      }
+
+      // toggleGroupListed publishes or un-publishes this group in the visor's
+      // discovery catalog.
+      toggleGroupListed() {
+        const gid = this.group;
+        const on = document.getElementById('gaListed').checked;
+        fetch(`/group/${gid}/listed`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ listed: on })
+        })
+          .then(res => res.ok ? res.json() : res.text().then(t => Promise.reject(t)))
+          .then(() => {
+            this.syncGroups();
+            this.showToast(on ? 'Published in this visor\'s catalog.' : 'No longer published.');
+          })
+          .catch(e => {
+            document.getElementById('gaListed').checked = !on;
             this.showToast(`Failed: ${e}`, 'error');
           });
       }

--- a/cmd/apps/skychat/pairing/ports.go
+++ b/cmd/apps/skychat/pairing/ports.go
@@ -56,6 +56,7 @@ func ReservedPorts() map[uint16]struct{} {
 		80:                                   {}, // dmsg-http
 		skyenv.DmsgDHTPort:                   {},
 		skyenv.DmsgAwaitSetupPort:            {},
+		skyenv.SkychatGroupProbePort:         {},
 	}
 }
 

--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -10,6 +10,8 @@
 //	skywire cli skychat group invite  <group-id>           # re-emits the invite link
 //	skywire cli skychat group address <group-id>           # short skychat:// address
 //	skywire cli skychat group resolve <address>            # what does this address point at?
+//	skywire cli skychat group catalog [host-pk]            # what does a visor publish?
+//	skywire cli skychat group publish <group-id> <on|off>  # publish in the catalog
 //	skywire cli skychat group join    <invite-link|address>
 //	skywire cli skychat group add     <group-id> <pk>      # admin: extend allowlist
 //	skywire cli skychat group promote <group-id> <pk>      # admin: grant roster authority
@@ -49,6 +51,7 @@ var (
 	groupCreateName           string
 	groupCreateMode           string
 	groupCreateKind           string
+	groupCreateListed         bool
 	groupCreateMembers        []string
 	groupCreateNoPeerBackfill bool
 
@@ -69,6 +72,8 @@ func init() {
 	// scripts; --kind wins when both are given.
 	groupCreateCmd.Flags().StringVarP(&groupCreateMode, "mode", "m", "", "deprecated alias for --kind, accepts public | private only")
 	groupCreateCmd.Flags().StringSliceVar(&groupCreateMembers, "member", nil, "initial member PK; repeat for many (the owner is implicit)")
+	groupCreateCmd.Flags().BoolVar(&groupCreateListed, "listed", false,
+		"publish in this visor's discovery catalog, so anyone with this visor's key can find it; off by default")
 	groupCreateCmd.Flags().BoolVar(&groupCreateNoPeerBackfill, "no-peer-backfill", false,
 		"only admins may serve this group's history to a joiner; without this flag any online member can, so the group stays readable while admins are offline")
 	groupCreateCmd.MarkFlagRequired("name") //nolint:errcheck,gosec
@@ -86,7 +91,7 @@ func init() {
 
 	groupCmd.AddCommand(
 		groupCreateCmd, groupListCmd, groupInfoCmd, groupInviteCmd,
-		groupAddressCmd, groupResolveCmd,
+		groupAddressCmd, groupResolveCmd, groupCatalogCmd, groupPublishCmd,
 		groupJoinCmd, groupAskAgainCmd, groupAddCmd, groupPromoteCmd, groupDemoteCmd, groupRotateKeyCmd,
 		groupPeerBackfillCmd,
 		groupSendCmd, groupUnsendCmd, groupListenCmd, groupHistoryCmd,
@@ -136,6 +141,7 @@ var groupCreateCmd = &cobra.Command{
 			Kind:                kind,
 			InitialMembers:      members,
 			DisablePeerBackfill: groupCreateNoPeerBackfill,
+			Listed:              groupCreateListed,
 		})
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
@@ -345,6 +351,101 @@ that is not a safe assumption.`,
 		}
 		addr := skychataddr.Group(info.OwnerPK, info.ID).String()
 		internal.PrintOutput(cmd.Flags(), addr, addr+"\n")
+	},
+}
+
+var groupCatalogCmd = &cobra.Command{
+	Use:   "catalog [host-pk]",
+	Short: "List the groups and channels a visor publishes",
+	Long: `Ask a visor what it publishes, or omit the key to see your own listing
+exactly as others would.
+
+Only groups an admin has explicitly published appear — see ` + "`group publish`" + `.
+There is no network-wide index: a catalog is served by the host itself and
+answers only for its own groups, so discovery still starts from a public key
+somebody gave you.`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var host cipher.PubKey
+		if len(args) == 1 {
+			if err := host.Set(args[0]); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid host pk: %w", err))
+			}
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		entries, truncated, err := rpcClient.GroupCatalog(host)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(),
+			map[string]any{"entries": entries, "truncated": truncated},
+			humanCatalog(entries, truncated))
+	},
+}
+
+// humanCatalog renders a catalog as a table, leading with the kind so a
+// channel is distinguishable from a group at a glance.
+func humanCatalog(entries []visor.GroupCatalogEntry, truncated bool) string {
+	if len(entries) == 0 {
+		return "nothing published\n"
+	}
+	var b strings.Builder
+	w := tabwriter.NewWriter(&b, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "KIND\tNAME\tJOIN\tADDRESS")
+	for _, e := range entries {
+		join := "open"
+		if e.Policy == skychatgroup.JoinApproval {
+			join = "on approval"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", e.Kind, e.Name, join, e.Address)
+	}
+	_ = w.Flush() //nolint:errcheck
+	if truncated {
+		fmt.Fprintf(&b, "\n(the host has more published than it will list at once)\n")
+	}
+	return b.String()
+}
+
+var groupPublishCmd = &cobra.Command{
+	Use:   "publish <group-id> <on|off>",
+	Short: "Publish a group or channel in this visor's discovery catalog",
+	Long: `Add a group or channel to this visor's catalog, so anyone holding this
+visor's public key can find it by asking.
+
+Off by default, and admin-only. This is a LOCAL hosting decision, not a
+property of the group: it is not gossiped, so it says what THIS visor is
+willing to answer questions about. Two admins of the same channel can
+legitimately differ on whether they advertise it, and neither can un-list
+the other's copy.`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		var listed bool
+		switch strings.ToLower(args[1]) {
+		case "on", "true", "yes":
+			listed = true
+		case "off", "false", "no":
+			listed = false
+		default:
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("expected on or off, got %q", args[1]))
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		info, err := rpcClient.GroupSetListed(args[0], listed)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		state := "not published"
+		if listed {
+			state = "published in this visor's catalog"
+		}
+		human := fmt.Sprintf("%q is now %s\n  address: %s\n",
+			info.Name, state, skychataddr.Group(info.OwnerPK, info.ID))
+		internal.PrintOutput(cmd.Flags(), info, human)
 	},
 }
 

--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -394,13 +394,13 @@ func humanCatalog(entries []visor.GroupCatalogEntry, truncated bool) string {
 	}
 	var b strings.Builder
 	w := tabwriter.NewWriter(&b, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "KIND\tNAME\tJOIN\tADDRESS")
+	fmt.Fprintln(w, "KIND\tNAME\tJOIN\tADDRESS") //nolint
 	for _, e := range entries {
 		join := "open"
 		if e.Policy == skychatgroup.JoinApproval {
 			join = "on approval"
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", e.Kind, e.Name, join, e.Address)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", e.Kind, e.Name, join, e.Address) //nolint
 	}
 	_ = w.Flush() //nolint:errcheck
 	if truncated {
@@ -505,7 +505,7 @@ func humanResolve(res visor.GroupResolveResult) string {
 		fmt.Fprintf(&b, "  action:  join (open admission)\n")
 	}
 	if g.PriceHint != "" {
-		// Labelled as claimed rather than stated: this is unverified text
+		// Labeled as claimed rather than stated: this is unverified text
 		// from a host that wants members.
 		fmt.Fprintf(&b, "  price:   %s (claimed by the host, unverified)\n", g.PriceHint)
 	}

--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -4,11 +4,13 @@
 //
 // Subcommands:
 //
-//	skywire cli skychat group create  --name <name> [--mode public|private] [--member <pk> ...]
+//	skywire cli skychat group create  --name <name> [--kind public|private|channel] [--member <pk> ...]
 //	skywire cli skychat group list
 //	skywire cli skychat group info    <group-id>
 //	skywire cli skychat group invite  <group-id>           # re-emits the invite link
-//	skywire cli skychat group join    <invite-link>
+//	skywire cli skychat group address <group-id>           # short skychat:// address
+//	skywire cli skychat group resolve <address>            # what does this address point at?
+//	skywire cli skychat group join    <invite-link|address>
 //	skywire cli skychat group add     <group-id> <pk>      # admin: extend allowlist
 //	skywire cli skychat group promote <group-id> <pk>      # admin: grant roster authority
 //	skywire cli skychat group demote  <group-id> <pk>      # admin: revoke roster authority (founder is immutable)
@@ -37,6 +39,7 @@ import (
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/pkg/cipher"
+	skychataddr "github.com/skycoin/skywire/pkg/skychat/address"
 	skychatgroup "github.com/skycoin/skywire/pkg/skychat/group"
 	"github.com/skycoin/skywire/pkg/visor"
 	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
@@ -45,6 +48,7 @@ import (
 var (
 	groupCreateName           string
 	groupCreateMode           string
+	groupCreateKind           string
 	groupCreateMembers        []string
 	groupCreateNoPeerBackfill bool
 
@@ -59,7 +63,11 @@ var (
 
 func init() {
 	groupCreateCmd.Flags().StringVarP(&groupCreateName, "name", "n", "", "human-readable group name (required)")
-	groupCreateCmd.Flags().StringVarP(&groupCreateMode, "mode", "m", "public", "public | private — private encrypts feed messages with an AES key shipped in the invite link")
+	groupCreateCmd.Flags().StringVarP(&groupCreateKind, "kind", "k", "", "public | private | channel — private is admin-approved and encrypted; a channel is open to join but only admins may post (default public)")
+	// --mode predates --kind and cannot name a channel (public and
+	// channel share the same encryption mode). Kept working for existing
+	// scripts; --kind wins when both are given.
+	groupCreateCmd.Flags().StringVarP(&groupCreateMode, "mode", "m", "", "deprecated alias for --kind, accepts public | private only")
 	groupCreateCmd.Flags().StringSliceVar(&groupCreateMembers, "member", nil, "initial member PK; repeat for many (the owner is implicit)")
 	groupCreateCmd.Flags().BoolVar(&groupCreateNoPeerBackfill, "no-peer-backfill", false,
 		"only admins may serve this group's history to a joiner; without this flag any online member can, so the group stays readable while admins are offline")
@@ -78,6 +86,7 @@ func init() {
 
 	groupCmd.AddCommand(
 		groupCreateCmd, groupListCmd, groupInfoCmd, groupInviteCmd,
+		groupAddressCmd, groupResolveCmd,
 		groupJoinCmd, groupAskAgainCmd, groupAddCmd, groupPromoteCmd, groupDemoteCmd, groupRotateKeyCmd,
 		groupPeerBackfillCmd,
 		groupSendCmd, groupUnsendCmd, groupListenCmd, groupHistoryCmd,
@@ -102,9 +111,17 @@ var groupCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new group (this visor becomes the owner)",
 	Run: func(cmd *cobra.Command, _ []string) {
-		mode := skychatgroup.Mode(groupCreateMode)
-		if !mode.IsValid() {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --mode %q (use public or private)", groupCreateMode))
+		// --kind first, then the legacy --mode, then the public default.
+		raw := groupCreateKind
+		if raw == "" {
+			raw = groupCreateMode
+		}
+		if raw == "" {
+			raw = string(skychatgroup.KindPublic)
+		}
+		kind := skychatgroup.Kind(raw)
+		if !kind.IsValid() {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid group kind %q (use public, private or channel)", raw))
 		}
 		members, err := parsePKs(groupCreateMembers)
 		if err != nil {
@@ -115,9 +132,10 @@ var groupCreateCmd = &cobra.Command{
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 		info, link, err := rpcClient.GroupCreate(visor.GroupCreateArgs{
-			Name:           groupCreateName,
-			Mode:           mode,
-			InitialMembers: members,
+			Name:                groupCreateName,
+			Kind:                kind,
+			InitialMembers:      members,
+			DisablePeerBackfill: groupCreateNoPeerBackfill,
 		})
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
@@ -303,16 +321,119 @@ var groupInviteCmd = &cobra.Command{
 	},
 }
 
-var groupJoinCmd = &cobra.Command{
-	Use:   "join <invite-link>",
-	Short: "Join a group by invite link",
-	Args:  cobra.ExactArgs(1),
+var groupAddressCmd = &cobra.Command{
+	Use:   "address <group-id>",
+	Short: "Print the short skychat:// address of a group",
+	Long: `Print the short address of a group or channel.
+
+	skychat://<host-pk>/<group-id>
+
+Shorter than an invite link and stable as the group changes, so it is the
+form to print on a card, read aloud, or encode in a QR code. It is not
+self-contained: whoever uses it asks the host what the group is before
+joining, so the host must be reachable. Use ` + "`group invite`" + ` when
+that is not a safe assumption.`,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		info, err := rpcClient.GroupJoin(visor.GroupJoinArgs{Invite: args[0]})
+		info, err := rpcClient.GroupGet(args[0])
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		addr := skychataddr.Group(info.OwnerPK, info.ID).String()
+		internal.PrintOutput(cmd.Flags(), addr, addr+"\n")
+	},
+}
+
+var groupResolveCmd = &cobra.Command{
+	Use:   "resolve <address|invite-link>",
+	Short: "Report what a skychat address points at",
+	Long: `Say whether an address names a person, a group, or a channel — and
+for a group, whether joining it means walking in or asking.
+
+Accepts a bare public key, skychat://<pk>, skychat://<pk>/<group-id>, or a
+skychat:invite: link. A bare key is answered locally: a key that names a
+person and a key that hosts a channel are the same 66 characters, so only
+the presence of a group ID can tell them apart. A group address is answered
+from this visor's own records when it knows the group, and otherwise by
+asking the host.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		res, err := rpcClient.GroupResolve(visor.GroupResolveArgs{Address: args[0]})
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(), res, humanResolve(res))
+	},
+}
+
+// humanResolve renders a resolve result for a terminal, leading with the
+// action the operator would take next.
+func humanResolve(res visor.GroupResolveResult) string {
+	var b strings.Builder
+	if res.Group == nil {
+		fmt.Fprintf(&b, "direct message with %s\n  address: %s\n", res.PK, res.Address)
+		return b.String()
+	}
+	g := res.Group
+	noun := "group"
+	if g.Kind == skychatgroup.KindChannel {
+		noun = "channel"
+	}
+	fmt.Fprintf(&b, "%s %q\n", noun, g.Name)
+	fmt.Fprintf(&b, "  address: %s\n", res.Address)
+	fmt.Fprintf(&b, "  host:    %s\n", g.HostPK)
+	fmt.Fprintf(&b, "  kind:    %s (%s)\n", g.Kind, g.Mode)
+	switch {
+	case g.Banned:
+		fmt.Fprintf(&b, "  action:  none — this public key is banned from it\n")
+	case res.Joined:
+		fmt.Fprintf(&b, "  action:  none — already a member (%s)\n", res.Status)
+	case res.Status == skychatgroup.StatusAwaitingApproval:
+		fmt.Fprintf(&b, "  action:  none — a request is already queued for an admin\n")
+	case g.Policy == skychatgroup.JoinApproval:
+		fmt.Fprintf(&b, "  action:  send a join request (an admin approves each one)\n")
+	default:
+		fmt.Fprintf(&b, "  action:  join (open admission)\n")
+	}
+	if g.PriceHint != "" {
+		// Labelled as claimed rather than stated: this is unverified text
+		// from a host that wants members.
+		fmt.Fprintf(&b, "  price:   %s (claimed by the host, unverified)\n", g.PriceHint)
+	}
+	return b.String()
+}
+
+var groupJoinCmd = &cobra.Command{
+	Use:   "join <invite-link|address>",
+	Short: "Join a group by invite link or short skychat:// address",
+	Long: `Join a group or channel.
+
+Takes either form:
+
+	skychat:invite:<base64url>      self-contained; works while the host is offline
+	skychat://<host-pk>/<group-id>  short; asks the host what the group is first
+
+Both go through the same admission gate — an address is a shorter way to
+name the group, not a way around its door.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		join := visor.GroupJoinArgs{Invite: args[0]}
+		if !skychataddr.IsInvite(args[0]) {
+			join = visor.GroupJoinArgs{Address: args[0]}
+		}
+		info, err := rpcClient.GroupJoin(join)
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}

--- a/pkg/app/launcher/launcher_test.go
+++ b/pkg/app/launcher/launcher_test.go
@@ -69,10 +69,18 @@ func TestRegistry(t *testing.T) {
 	require.NoError(t, got(context.Background(), nil))
 	require.True(t, called)
 
-	// Re-registering the same name panics.
-	require.Panics(t, func() {
-		RegisterApp("registry-test-app", fn)
-	})
+	// Re-registering replaces the function so visor resume can initialize
+	// embedded apps again.
+	replacementCalled := false
+	replacement := func(_ context.Context, _ []string) error {
+		replacementCalled = true
+		return nil
+	}
+	RegisterApp("registry-test-app", replacement)
+	got, ok = GetApp("registry-test-app")
+	require.True(t, ok)
+	require.NoError(t, got(context.Background(), nil))
+	require.True(t, replacementCalled)
 }
 
 func TestExpandHome(t *testing.T) {

--- a/pkg/app/launcher/registry.go
+++ b/pkg/app/launcher/registry.go
@@ -2,7 +2,6 @@
 package launcher
 
 import (
-	"fmt"
 	"net/http"
 	"sync"
 
@@ -12,18 +11,32 @@ import (
 // AppFunc is an alias for the app function type defined in appcommon.
 type AppFunc = appcommon.AppFunc
 
-var appRegistry = make(map[string]AppFunc)
+var (
+	appRegistryMu sync.Mutex
+	appRegistry   = make(map[string]AppFunc)
+)
 
 // RegisterApp registers an app function by name.
+//
+// Registration is mutex-guarded and idempotent. Guarded because module inits run
+// concurrently (visorinit.InitConcurrent), so several embedded-app modules call
+// this in parallel — an unsynchronized map write there is a data race that can
+// fatally crash the process. Idempotent because a visor Resume re-runs the whole
+// module-init graph after Suspend, so each embedded app re-registers its (same,
+// deterministic) func; the old hard panic on a duplicate name turned Resume into
+// a half-initialized, still-"suspended" state (dmsg_pty/dmsgweb/skynetweb panicked
+// on their already-registered names). Re-registering overwrites — the same
+// overwrite-on-re-register semantics RegisterHTTPHandler below already uses.
 func RegisterApp(name string, fn AppFunc) {
-	if _, exists := appRegistry[name]; exists {
-		panic(fmt.Sprintf("app %q already registered", name))
-	}
+	appRegistryMu.Lock()
+	defer appRegistryMu.Unlock()
 	appRegistry[name] = fn
 }
 
 // GetApp returns the app function for the given name, or nil if not found.
 func GetApp(name string) (AppFunc, bool) {
+	appRegistryMu.Lock()
+	defer appRegistryMu.Unlock()
 	fn, ok := appRegistry[name]
 	return fn, ok
 }

--- a/pkg/skychat/address/address.go
+++ b/pkg/skychat/address/address.go
@@ -1,0 +1,205 @@
+// Package address pkg/skychat/address/address.go c4-app-chat
+// the skychat:// address grammar — one shareable, scannable identifier
+// for the three things a user can open: a person, a group, a channel.
+//
+// Grammar:
+//
+//	skychat://<pk>              a person — opens a 1:1 DM
+//	skychat://<pk>/<group-id>   a group or channel hosted by that visor
+//
+// Both forms are short enough to print on a card and to encode in a
+// low-density QR code, which is the whole reason they exist: an invite
+// link (skychat:invite:<base64url(json)>) is a few hundred characters
+// because it carries the group's port, mode, admin list and proof-of-work
+// price inline, and a code that dense is unpleasant to scan on a phone.
+//
+// The trade is that an address is NOT self-contained. A group address
+// names a group but does not describe it, so acting on one requires
+// asking the host visor what it is — see Manager.ProbeGroup. That
+// round trip is also what makes "type a key and let the app work out what
+// it is" possible at all: a bare public key looks identical whether it
+// belongs to a person or to the host of a channel, so nothing can be
+// decided by inspection.
+//
+// Which of the two forms to hand out is therefore a real choice, not a
+// preference: an address is short and stays valid as the group changes,
+// an invite works while the host is offline. Both are accepted
+// everywhere a user can paste — see the note on Parse and ErrIsInvite.
+//
+// Why the group ID is a path segment and not, say, a query parameter:
+// a query needs escaping rules that QR alphanumeric mode does not cover
+// cheaply, and "host/resource" is the shape every user already reads
+// correctly from a URL.
+package address
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// Scheme is the URI prefix of a skychat address.
+//
+// The `//` form is deliberate and distinguishes this from the older
+// `skychat:invite:` links: an authority-style `//<pk>` says the part
+// after it is a host, which is exactly what a visor public key is here.
+const Scheme = "skychat://"
+
+// inviteScheme is the invite-link prefix. Mirrored (not imported) from
+// pkg/skychat/group so this package stays a leaf with no dependency on
+// the group model — an address names a group, it does not know one.
+// Parse only needs it to tell a caller "that is the other kind of link",
+// so a copy of a constant that can never change without breaking every
+// link already in circulation is the cheaper coupling.
+const inviteScheme = "skychat:invite:"
+
+// pkHexLen is the length of a hex-encoded 33-byte compressed secp256k1
+// public key.
+const pkHexLen = 66
+
+var (
+	// ErrEmpty is returned for input that is blank once trimmed.
+	ErrEmpty = errors.New("skychat address: empty")
+
+	// ErrIsInvite marks input that is a group invite link rather than an
+	// address. Returned as a distinct sentinel so a caller holding one
+	// paste box can try both parsers and route accordingly, rather than
+	// telling a user who pasted a perfectly good invite that their
+	// address is malformed.
+	ErrIsInvite = errors.New("skychat address: this is an invite link, not an address")
+)
+
+// Kind is what an address points at.
+type Kind string
+
+const (
+	// KindDM — a bare public key: a person, opened as a 1:1 chat.
+	KindDM Kind = "dm"
+
+	// KindGroup — a public key plus a group ID. Whether the group is an
+	// ordinary group or a broadcast channel is NOT knowable from the
+	// address; only the host visor can say, so a resolver reports the
+	// group kind separately. Calling this KindGroup rather than
+	// KindGroupOrChannel keeps the grammar honest: the address form is
+	// the same for both, and pretending otherwise would invite callers
+	// to trust a distinction the string cannot carry.
+	KindGroup Kind = "group"
+)
+
+// Address is a parsed skychat address.
+type Address struct {
+	// PK is the visor the address names: the peer for a DM, the group's
+	// host for a group address.
+	PK cipher.PubKey
+
+	// GroupID is the group's UUID, empty for a DM address.
+	GroupID string
+}
+
+// Kind reports what this address points at.
+func (a Address) Kind() Kind {
+	if a.GroupID != "" {
+		return KindGroup
+	}
+	return KindDM
+}
+
+// IsGroup reports whether this address names a group or channel rather
+// than a person.
+func (a Address) IsGroup() bool { return a.GroupID != "" }
+
+// String renders the canonical form. Lowercase hex, because an address
+// is compared and deduplicated as a string in several places (the UI's
+// contact list keys on it) and mixed case would make two spellings of
+// one identity look like two identities.
+func (a Address) String() string {
+	s := Scheme + strings.ToLower(a.PK.Hex())
+	if a.GroupID != "" {
+		s += "/" + a.GroupID
+	}
+	return s
+}
+
+// DM returns the address of a peer's 1:1 chat.
+func DM(pk cipher.PubKey) Address { return Address{PK: pk} }
+
+// Group returns the address of a group or channel hosted by pk.
+func Group(pk cipher.PubKey, groupID string) Address {
+	return Address{PK: pk, GroupID: groupID}
+}
+
+// Parse reads any of the accepted spellings of an address:
+//
+//	skychat://<pk>
+//	skychat://<pk>/<group-id>
+//	<pk>
+//	<pk>/<group-id>
+//
+// The bare forms are accepted because the field this feeds used to take
+// nothing but a raw public key, and every key a user has already saved
+// or shared is in that shape. Requiring the scheme would have broken
+// every one of them for no gain.
+//
+// Whitespace is trimmed and a trailing slash ignored — both are what a
+// terminal copy, a QR decode, or a chat client's link detector tend to
+// leave behind. A group invite link returns ErrIsInvite so the caller
+// can hand it to the invite parser instead.
+func Parse(s string) (Address, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return Address{}, ErrEmpty
+	}
+	if strings.HasPrefix(strings.ToLower(s), inviteScheme) {
+		return Address{}, ErrIsInvite
+	}
+	// Case-insensitive on the scheme only. The key that follows is hex,
+	// where case is not meaningful either, but the group ID is compared
+	// byte-for-byte against a stored UUID so it is left exactly as given.
+	if len(s) >= len(Scheme) && strings.EqualFold(s[:len(Scheme)], Scheme) {
+		s = s[len(Scheme):]
+	}
+	s = strings.TrimSuffix(s, "/")
+	if s == "" {
+		return Address{}, ErrEmpty
+	}
+
+	pkPart, groupPart, _ := strings.Cut(s, "/")
+	if strings.Contains(groupPart, "/") {
+		return Address{}, fmt.Errorf("skychat address: unexpected extra path segment in %q", s)
+	}
+
+	// Length first: a truncated key is by far the most common paste
+	// error, and "66 characters, got 64" tells the user what to fix
+	// where cipher.PubKey.Set's decode error would not.
+	pkPart = strings.ToLower(pkPart)
+	if len(pkPart) != pkHexLen {
+		return Address{}, fmt.Errorf("skychat address: public key must be %d hex characters, got %d", pkHexLen, len(pkPart))
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(pkPart); err != nil {
+		return Address{}, fmt.Errorf("skychat address: invalid public key: %w", err)
+	}
+
+	if groupPart == "" {
+		return Address{PK: pk}, nil
+	}
+	// Group IDs are uuid.NewString() values (see group.Manager.Create).
+	// Validating here means a mistyped address fails locally instead of
+	// spending a dial and a 15s probe timeout to be told the group does
+	// not exist.
+	if _, err := uuid.Parse(groupPart); err != nil {
+		return Address{}, fmt.Errorf("skychat address: invalid group id %q", groupPart)
+	}
+	return Address{PK: pk, GroupID: groupPart}, nil
+}
+
+// IsInvite reports whether s looks like a group invite link. Exported so
+// a caller can route input before parsing, without depending on the
+// error value.
+func IsInvite(s string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(s)), inviteScheme)
+}

--- a/pkg/skychat/address/address_test.go
+++ b/pkg/skychat/address/address_test.go
@@ -1,0 +1,169 @@
+// Package address pkg/skychat/address/address_test.go c4-app-chat
+// round-trip and rejection tests for the skychat:// grammar.
+//
+// The rejection half matters more than the happy path: this parser is
+// the first thing an arbitrary pasted or QR-decoded string reaches, so
+// every malformed shape has to fail with a message rather than produce a
+// plausible-looking Address that later costs a dial to disprove.
+package address
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// testPK is a valid compressed secp256k1 key in the shape every skychat
+// surface uses (02-prefixed, 66 hex chars).
+const testPK = "0248c948affc71f4dd6b0b6b47e5d5f1e0e13bc39d3f5d5f4e1f3d3a6e6c0b2b7f"
+
+const testGID = "9c1e4b7a-2d3f-4c5e-8a9b-0d1e2f3a4b5c"
+
+func mustPK(t *testing.T, hex string) cipher.PubKey {
+	t.Helper()
+	var pk cipher.PubKey
+	if err := pk.Set(hex); err != nil {
+		t.Fatalf("test key %q is not a valid public key: %v", hex, err)
+	}
+	return pk
+}
+
+func TestParseDM(t *testing.T) {
+	pk := mustPK(t, testPK)
+	// Every spelling a user can plausibly arrive with must land on the
+	// same address: the scheme is optional because the field this feeds
+	// used to accept a bare key, and trailing slashes / whitespace are
+	// what a copy-paste or a QR decode leaves behind.
+	for _, in := range []string{
+		Scheme + testPK,
+		testPK,
+		"  " + Scheme + testPK + "  ",
+		Scheme + testPK + "/",
+		"SKYCHAT://" + testPK,
+		Scheme + strings.ToUpper(testPK),
+	} {
+		got, err := Parse(in)
+		if err != nil {
+			t.Fatalf("Parse(%q): unexpected error: %v", in, err)
+		}
+		if got.PK != pk {
+			t.Errorf("Parse(%q): pk = %s, want %s", in, got.PK.Hex(), pk.Hex())
+		}
+		if got.GroupID != "" {
+			t.Errorf("Parse(%q): group id = %q, want empty", in, got.GroupID)
+		}
+		if got.Kind() != KindDM {
+			t.Errorf("Parse(%q): kind = %q, want %q", in, got.Kind(), KindDM)
+		}
+		if got.IsGroup() {
+			t.Errorf("Parse(%q): IsGroup() = true, want false", in)
+		}
+	}
+}
+
+func TestParseGroup(t *testing.T) {
+	pk := mustPK(t, testPK)
+	for _, in := range []string{
+		Scheme + testPK + "/" + testGID,
+		testPK + "/" + testGID,
+		Scheme + testPK + "/" + testGID + "/",
+	} {
+		got, err := Parse(in)
+		if err != nil {
+			t.Fatalf("Parse(%q): unexpected error: %v", in, err)
+		}
+		if got.PK != pk {
+			t.Errorf("Parse(%q): pk = %s, want %s", in, got.PK.Hex(), pk.Hex())
+		}
+		if got.GroupID != testGID {
+			t.Errorf("Parse(%q): group id = %q, want %q", in, got.GroupID, testGID)
+		}
+		if got.Kind() != KindGroup {
+			t.Errorf("Parse(%q): kind = %q, want %q", in, got.Kind(), KindGroup)
+		}
+		if !got.IsGroup() {
+			t.Errorf("Parse(%q): IsGroup() = false, want true", in)
+		}
+	}
+}
+
+func TestStringRoundTrip(t *testing.T) {
+	pk := mustPK(t, testPK)
+	for _, a := range []Address{DM(pk), Group(pk, testGID)} {
+		back, err := Parse(a.String())
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", a.String(), err)
+		}
+		if back != a {
+			t.Errorf("round trip of %q: got %+v, want %+v", a.String(), back, a)
+		}
+	}
+}
+
+// A canonical address is lowercase, because the UI keys its contact list
+// on the string: two spellings of one identity must not read as two.
+func TestStringIsLowercase(t *testing.T) {
+	pk := mustPK(t, strings.ToUpper(testPK))
+	got := DM(pk).String()
+	if got != Scheme+strings.ToLower(testPK) {
+		t.Errorf("String() = %q, want lowercase %q", got, Scheme+strings.ToLower(testPK))
+	}
+}
+
+// An invite link has to be distinguishable rather than merely invalid:
+// one paste box accepts both, and a user who pasted a working invite
+// must not be told their address is malformed.
+func TestParseRejectsInviteWithSentinel(t *testing.T) {
+	for _, in := range []string{
+		"skychat:invite:eyJpZCI6IngifQ",
+		"  SKYCHAT:INVITE:eyJpZCI6IngifQ  ",
+	} {
+		_, err := Parse(in)
+		if !errors.Is(err, ErrIsInvite) {
+			t.Errorf("Parse(%q): err = %v, want ErrIsInvite", in, err)
+		}
+		if !IsInvite(in) {
+			t.Errorf("IsInvite(%q) = false, want true", in)
+		}
+	}
+	if IsInvite(Scheme + testPK) {
+		t.Error("IsInvite reported true for a plain address")
+	}
+}
+
+func TestParseRejects(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"scheme only", Scheme},
+		{"short key", Scheme + testPK[:64]},
+		{"long key", Scheme + testPK + "ab"},
+		{"non-hex key", Scheme + strings.Repeat("z", 66)},
+		{"group id not a uuid", Scheme + testPK + "/not-a-uuid"},
+		{"extra path segment", Scheme + testPK + "/" + testGID + "/extra"},
+		{"empty key with group", Scheme + "/" + testGID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, err := Parse(tt.in); err == nil {
+				t.Errorf("Parse(%q) = %+v, want error", tt.in, got)
+			}
+		})
+	}
+}
+
+// ErrEmpty is separate from a generic parse failure so a caller can keep
+// quiet while the user is still typing rather than flashing an error on
+// an empty field.
+func TestParseEmptySentinel(t *testing.T) {
+	for _, in := range []string{"", "   ", Scheme, Scheme + "/"} {
+		if _, err := Parse(in); !errors.Is(err, ErrEmpty) {
+			t.Errorf("Parse(%q): err = %v, want ErrEmpty", in, err)
+		}
+	}
+}

--- a/pkg/skychat/group/catalog.go
+++ b/pkg/skychat/group/catalog.go
@@ -1,0 +1,390 @@
+// Package group pkg/skychat/group/catalog.go c4-app-chat
+// the discovery catalog: "what does this visor host that it wants found?"
+//
+// # Why this is separate from the probe
+//
+// probe.go answers a question about a group ID you already hold. This
+// answers a question about a PUBLIC KEY, and that is a categorically
+// different disclosure: a probe confirms one 122-bit identifier somebody
+// already had, a catalog turns one key into a list. So it is not the same
+// request with an empty field — it is its own frame, gated on its own
+// per-group opt-in (Record.Listed), and it will never mention a group
+// whose host did not tick the box.
+//
+// Both live on the same well-known port because both are "ask a visor
+// about its groups" and neither mutates anything; one listener is simpler
+// than two.
+//
+// # What a catalog entry is for
+//
+// Channels. A broadcast channel is the one shape here that is useless
+// without discovery: a group gets its members from people who already know
+// each other, but a channel wants an audience it has not met, and until now
+// the only way to reach one was for someone to hand you a link. Groups may
+// be listed too — the mechanism does not care — but the default is off and
+// the reason it exists is channels.
+//
+// # What it deliberately is not
+//
+// Not a network-wide index. There is no aggregator, no crawl, no
+// registration: a catalog is served by the host itself and answers only
+// for the host's own groups, so discovering anything still starts from a
+// public key somebody gave you. That keeps the trust model identical to
+// the rest of skychat — you learn about a visor from a human — while
+// removing the part that was genuinely painful, which was needing a fresh
+// invite link per person for something meant to be public.
+package group
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"sort"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skychat/message"
+)
+
+// Catalog frame kinds. Distinct from the join frames so the probe
+// listener can dispatch on the discriminator alone.
+const (
+	frameKindCatalogRequest  = "catalog_request"
+	frameKindCatalogResponse = "catalog_response"
+)
+
+// maxCatalogEntries caps one answer.
+//
+// A bound rather than paging: a visor hosting more than this many
+// deliberately-published channels is not a case worth designing for, and
+// an unbounded list would let one request pull an arbitrary amount of
+// writing (names) out of a host. Truncation is reported in the response
+// so a caller can say "showing 64 of 90" instead of quietly lying.
+const maxCatalogEntries = 64
+
+// maxCatalogNameLen bounds an entry's name on receipt. Names are
+// host-supplied text heading for a UI list.
+const maxCatalogNameLen = 64
+
+// catalogTimeout caps one catalog round trip. Same reasoning as
+// probeTimeout: a store read under a user watching a spinner.
+const catalogTimeout = 8 * time.Second
+
+// ErrCatalogUnreachable means the host could not be reached or answered
+// nothing — including a host running a build with no catalog at all,
+// which is indistinguishable from silence and equally retryable.
+var ErrCatalogUnreachable = errors.New("group: catalog: host did not answer")
+
+// CatalogRequestMsg asks a visor what it publishes.
+//
+// Carries no filter and no cursor on purpose. A filter would invite
+// probing ("do you host anything called X?") against unlisted groups, and
+// the answer is bounded by maxCatalogEntries anyway.
+type CatalogRequestMsg struct {
+	Kind string    `json:"kind"`
+	TS   time.Time `json:"ts"`
+}
+
+// CatalogEntryMsg is one published group on the wire.
+//
+// A subset of GroupDescriptor: enough to render a row and then join it,
+// and nothing about the roster. Note it carries no member count — a
+// listing is an invitation to join, not a report on who already did, and
+// the count is the one field that turns a catalog into surveillance of a
+// channel's popularity.
+type CatalogEntryMsg struct {
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	GroupKind Kind       `json:"group_kind"`
+	Policy    JoinPolicy `json:"policy"`
+	Port      uint16     `json:"port"`
+	PoWBits   uint8      `json:"pow_bits,omitempty"`
+	PriceHint string     `json:"price_hint,omitempty"`
+}
+
+// CatalogResponseMsg is the host's answer.
+type CatalogResponseMsg struct {
+	Kind    string            `json:"kind"`
+	HostPK  cipher.PubKey     `json:"host_pk"`
+	Entries []CatalogEntryMsg `json:"entries"`
+
+	// Truncated reports that the host had more listed groups than it sent,
+	// so a caller can say so rather than presenting a partial list as
+	// complete. See maxCatalogEntries.
+	Truncated bool `json:"truncated,omitempty"`
+}
+
+// CatalogEntry is one discovered group, host-side or caller-side.
+type CatalogEntry struct {
+	ID        string        `json:"id"`
+	HostPK    cipher.PubKey `json:"host_pk"`
+	Name      string        `json:"name"`
+	Kind      Kind          `json:"kind"`
+	Mode      Mode          `json:"mode"`
+	Policy    JoinPolicy    `json:"policy"`
+	Port      uint16        `json:"port"`
+	PoWBits   uint8         `json:"pow_bits,omitempty"`
+	PriceHint string        `json:"price_hint,omitempty"`
+
+	// Address is the canonical skychat:// form, so a caller can hand a row
+	// straight to the join path or render it as a QR code. Built by the
+	// RECEIVER from HostPK + ID rather than trusted from the wire — a host
+	// that could name its own address string could name someone else's.
+	Address string `json:"address"`
+}
+
+// IsChannel reports whether this entry is a broadcast channel.
+func (e CatalogEntry) IsChannel() bool { return e.Kind == KindChannel }
+
+// Invite rebuilds the invite this entry is equivalent to, so a discovered
+// row joins through exactly the same path as a pasted link. Carries no
+// key, for the same reason GroupDescriptor.Invite does not.
+func (e CatalogEntry) Invite() Invite {
+	return Invite{
+		ID:      e.ID,
+		Name:    e.Name,
+		OwnerPK: e.HostPK,
+		Port:    e.Port,
+		Mode:    e.Mode,
+		Kind:    e.Kind,
+		PoWBits: e.PoWBits,
+	}
+}
+
+// ---------------------------------------------------------------------
+// host side
+// ---------------------------------------------------------------------
+
+// Catalog returns what THIS visor publishes: every non-terminal record
+// with Listed set, newest first, capped at maxCatalogEntries.
+//
+// Newest first because a catalog is a shop window and the thing just
+// opened is the thing worth showing; the cap then drops the oldest rather
+// than an arbitrary slice.
+func (m *Manager) Catalog() ([]CatalogEntry, bool, error) {
+	all, err := m.store.List()
+	if err != nil {
+		return nil, false, fmt.Errorf("group: Catalog: list: %w", err)
+	}
+	out := make([]CatalogEntry, 0, len(all))
+	for _, r := range all {
+		if !r.Listed || r.Status.IsTerminal() {
+			continue
+		}
+		// Only a visor with roster authority can answer for a group: a
+		// plain member advertising somebody else's channel would be
+		// republishing a claim it cannot back, and its Port/policy view
+		// may be stale in ways it cannot detect.
+		if !r.IsAdmin(m.myPK) {
+			continue
+		}
+		out = append(out, CatalogEntry{
+			ID: r.ID, HostPK: r.OwnerPK, Name: r.Name,
+			Kind: r.Kind, Mode: r.Mode, Policy: r.JoinPolicy(),
+			Port: r.Port, PoWBits: r.JoinPoWRequired(),
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].ID > out[j].ID })
+	truncated := len(out) > maxCatalogEntries
+	if truncated {
+		out = out[:maxCatalogEntries]
+	}
+	return out, truncated, nil
+}
+
+// SetListed opts a group into or out of this visor's catalog.
+//
+// Admin-only, and deliberately NOT gossiped — see Record.Listed. It is a
+// local hosting decision, so it writes the record directly rather than
+// going through moderate(): there is no signed state for other members to
+// converge on, and pretending otherwise would imply an admin can un-list
+// a copy somebody else is advertising.
+func (m *Manager) SetListed(id string, listed bool) (Record, error) {
+	r, ok, err := m.store.Get(id)
+	if err != nil {
+		return Record{}, fmt.Errorf("group: SetListed: get: %w", err)
+	}
+	if !ok {
+		return Record{}, fmt.Errorf("group: SetListed: no record for %s", id)
+	}
+	if !r.IsAdmin(m.myPK) {
+		return Record{}, errors.New("group: SetListed: only admins can publish a group")
+	}
+	if r.Status.IsTerminal() {
+		return Record{}, errors.New("group: SetListed: this group is over; nothing to publish")
+	}
+	if r.Listed == listed {
+		return r, nil
+	}
+	r.Listed = listed
+	if err := m.store.Put(r); err != nil {
+		return Record{}, fmt.Errorf("group: SetListed: store: %w", err)
+	}
+	m.log.WithField("id", id).WithField("listed", listed).
+		Info("group: catalog: publication changed")
+	return r, nil
+}
+
+// handleCatalogRequest answers one catalog frame on the probe listener.
+func (m *Manager) handleCatalogRequest(c net.Conn, asker cipher.PubKey) {
+	entries, truncated, err := m.Catalog()
+	resp := CatalogResponseMsg{Kind: frameKindCatalogResponse, HostPK: m.myPK}
+	if err != nil {
+		// An empty catalog is the honest answer to a failed store read:
+		// there is nothing we can stand behind, and a listing we are not
+		// sure of is worse than none.
+		m.log.WithError(err).Debug("group: catalog: read failed; answering empty")
+	} else {
+		resp.Truncated = truncated
+		resp.Entries = make([]CatalogEntryMsg, 0, len(entries))
+		for _, e := range entries {
+			resp.Entries = append(resp.Entries, CatalogEntryMsg{
+				ID: e.ID, Name: truncate(e.Name, maxCatalogNameLen),
+				GroupKind: e.Kind, Policy: e.Policy, Port: e.Port,
+				PoWBits: e.PoWBits, PriceHint: truncate(e.PriceHint, maxPriceHintLen),
+			})
+		}
+	}
+	body, err := json.Marshal(&resp)
+	if err != nil {
+		m.log.WithError(err).Debug("group: catalog: encode response")
+		return
+	}
+	if err := c.SetWriteDeadline(time.Now().Add(catalogTimeout)); err != nil {
+		return
+	}
+	if err := message.WriteFrame(c, body); err != nil {
+		m.log.WithError(err).Debug("group: catalog: write response")
+		return
+	}
+	m.log.WithField("asker", asker.Hex()).WithField("entries", len(resp.Entries)).
+		Debug("group: catalog: answered")
+}
+
+// ---------------------------------------------------------------------
+// caller side
+// ---------------------------------------------------------------------
+
+// FetchCatalog asks host what it publishes.
+//
+// Every entry's Address is built here from the host PK we dialed plus the
+// entry's own ID, never taken from the wire: the transport authenticates
+// the host, so an address derived from it cannot point somewhere else,
+// whereas a host-supplied string could advertise a channel it does not
+// own. Same reason Kind is cross-checked against Mode on the join path.
+func (m *Manager) FetchCatalog(ctx context.Context, host cipher.PubKey) ([]CatalogEntry, bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req := CatalogRequestMsg{Kind: frameKindCatalogRequest, TS: time.Now().UTC()}
+	body, err := json.Marshal(&req)
+	if err != nil {
+		return nil, false, fmt.Errorf("group: catalog: encode: %w", err)
+	}
+
+	frame, err := catalogRoundTrip(ctx, m.dmsgC, host, body)
+	if err != nil {
+		return nil, false, err
+	}
+	var resp CatalogResponseMsg
+	if err := json.Unmarshal(frame, &resp); err != nil {
+		return nil, false, fmt.Errorf("group: catalog: decode: %w", err)
+	}
+	if resp.Kind != frameKindCatalogResponse {
+		return nil, false, fmt.Errorf("group: catalog: unexpected frame kind %q", resp.Kind)
+	}
+
+	out := make([]CatalogEntry, 0, len(resp.Entries))
+	for _, e := range resp.Entries {
+		if e.ID == "" || e.Port == 0 {
+			continue // unjoinable; drop rather than render a dead row
+		}
+		kind := e.GroupKind
+		if !kind.IsValid() {
+			kind = KindPublic // a host predating channels, or noise
+		}
+		mode := modeForKind(kind)
+		policy := e.Policy
+		if policy != JoinOpen && policy != JoinApproval {
+			policy = policyForKind(kind)
+		}
+		out = append(out, CatalogEntry{
+			ID:        e.ID,
+			HostPK:    host,
+			Name:      truncate(e.Name, maxCatalogNameLen),
+			Kind:      kind,
+			Mode:      mode,
+			Policy:    policy,
+			Port:      e.Port,
+			PoWBits:   clampJoinPoWBits(e.PoWBits),
+			PriceHint: truncate(e.PriceHint, maxPriceHintLen),
+			Address:   catalogAddress(host, e.ID),
+		})
+		if len(out) >= maxCatalogEntries {
+			// A host that ignores its own cap does not get to make us
+			// render an unbounded list.
+			return out, true, nil
+		}
+	}
+	return out, resp.Truncated, nil
+}
+
+// catalogAddress renders the skychat:// group address for an entry.
+//
+// Spelled out here rather than importing pkg/skychat/address, which
+// imports nothing from this package and must keep it that way — address
+// is a leaf that names a group without knowing what one is. The grammar
+// is fixed by that package's Scheme constant and its tests.
+func catalogAddress(host cipher.PubKey, id string) string {
+	return "skychat://" + host.Hex() + "/" + id
+}
+
+// catalogRoundTrip writes the request and reads the answer, skynet first
+// then dmsg — the same preference order as every other skychat dial.
+func catalogRoundTrip(ctx context.Context, dmsgC *dmsg.Client, host cipher.PubKey, body []byte) ([]byte, error) {
+	skyAddr := appnet.Addr{Net: appnet.TypeSkynet, PubKey: host, Port: routing.Port(ProbePort)}
+	if conn, dialErr := dialSkynetRelay(ctx, skyAddr); dialErr == nil {
+		frame, rtErr := catalogExchange(conn, body)
+		_ = conn.Close() //nolint:errcheck
+		if rtErr == nil {
+			return frame, nil
+		}
+	}
+	if dmsgC == nil {
+		return nil, ErrCatalogUnreachable
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, catalogTimeout)
+	defer cancel()
+	stream, err := dmsgC.DialStream(dialCtx, dmsg.Addr{PK: host, Port: ProbePort})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCatalogUnreachable, err)
+	}
+	defer stream.Close() //nolint:errcheck
+	return catalogExchange(stream, body)
+}
+
+func catalogExchange(c net.Conn, body []byte) ([]byte, error) {
+	deadline := time.Now().Add(catalogTimeout)
+	if err := c.SetWriteDeadline(deadline); err != nil {
+		return nil, fmt.Errorf("group: catalog: set write deadline: %w", err)
+	}
+	if err := message.WriteFrame(c, body); err != nil {
+		return nil, fmt.Errorf("group: catalog: write: %w", err)
+	}
+	if err := c.SetReadDeadline(deadline); err != nil {
+		return nil, fmt.Errorf("group: catalog: set read deadline: %w", err)
+	}
+	frame, err := message.ReadFrame(c)
+	if err != nil {
+		// A host that takes the frame and says nothing is a build without
+		// a catalog — reported as unreachable, which is both true and the
+		// retryable answer a caller should act on.
+		return nil, fmt.Errorf("%w: %v", ErrCatalogUnreachable, err)
+	}
+	return frame, nil
+}

--- a/pkg/skychat/group/channel_test.go
+++ b/pkg/skychat/group/channel_test.go
@@ -1,0 +1,264 @@
+// Package group pkg/skychat/group/channel_test.go
+//
+// The invariants a broadcast channel rests on, none of which are visible
+// from reading a single function:
+//
+//   - a channel cannot become a group, at the persistence boundary;
+//   - only admins may post, permanently, not as a moderation setting;
+//   - the subscription topology is O(admins) rather than O(members),
+//     which is the difference between a channel that scales and one that
+//     opens ten thousand dead subscriptions per admin.
+//
+// Pure unit tests — no transport. The dmsg-backed channel cases live in
+// probe_integration_test.go.
+package group
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// A channel must never be convertible into a group. Nothing in the current
+// code tries to, which is exactly why this test exists: the guarantee is
+// the store's, so a future caller that reassigns Kind fails here rather
+// than silently handing the floor to every subscriber of a channel they
+// joined on the understanding that only admins post.
+func TestChannel_KindIsImmutable(t *testing.T) {
+	forEachStore(t, func(t *testing.T, st *Store) {
+		owner, _ := cipher.GenerateKeyPair()
+		rec := Record{
+			ID: "chan-1", Name: "news", OwnerPK: owner,
+			Port: 40000, Mode: ModePublic, Kind: KindChannel,
+			Members: []cipher.PubKey{owner}, Role: RoleOwner, Status: StatusActive,
+		}
+		require.NoError(t, st.Put(rec), "initial Put")
+
+		// Every direction that would redefine what the group is.
+		for _, to := range []Kind{KindPublic, KindPrivate} {
+			bad := rec
+			bad.Kind = to
+			bad.Mode = modeForKind(to)
+			err := st.Put(bad)
+			require.Error(t, err, "channel must not become %q", to)
+			require.ErrorIs(t, err, ErrKindImmutable)
+		}
+
+		// A write that merely FORGETS the kind is the dangerous one:
+		// EnsureKind would re-derive it from Mode on the next read, and a
+		// channel shares ModePublic with a public group — so the channel
+		// would quietly reopen to everyone.
+		dropped := rec
+		dropped.Kind = ""
+		err := st.Put(dropped)
+		require.Error(t, err, "a write with no kind must not erase a channel's kind")
+		require.ErrorIs(t, err, ErrKindImmutable)
+
+		// And the stored record is untouched by any of those attempts.
+		got, ok, err := st.Get("chan-1")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, KindChannel, got.Kind)
+
+		// An unchanged kind still writes — this guards a rename, a roster
+		// change, and every other legitimate read-modify-write.
+		renamed := rec
+		renamed.Name = "news v2"
+		require.NoError(t, st.Put(renamed), "an unchanged kind must still be writable")
+	})
+}
+
+// A record written before Kind existed must still normalize: prev == ""
+// is a first-time fill, not a change.
+func TestChannel_LegacyRecordCanStillNormalize(t *testing.T) {
+	forEachStore(t, func(t *testing.T, st *Store) {
+		owner, _ := cipher.GenerateKeyPair()
+		legacy := Record{
+			ID: "legacy-1", OwnerPK: owner, Port: 40001,
+			Mode:    ModePrivate, // no Kind, as a pre-Kind build wrote it
+			Members: []cipher.PubKey{owner}, Role: RoleOwner, Status: StatusActive,
+		}
+		require.NoError(t, st.Put(legacy))
+
+		// The store fills Kind on read; writing that back must be accepted.
+		got, ok, err := st.Get("legacy-1")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, KindPrivate, got.Kind, "EnsureKind should derive from Mode")
+		require.NoError(t, st.Put(got), "normalizing a legacy record must be allowed")
+	})
+}
+
+// Admins-only posting on a channel is a property of the group, not a
+// moderation state — so it holds with ReadOnly off, and CanPost reports it
+// with a reason naming the channel rather than the read-only flag.
+func TestChannel_OnlyAdminsMayPost(t *testing.T) {
+	owner, _ := cipher.GenerateKeyPair()
+	admin, _ := cipher.GenerateKeyPair()
+	member, _ := cipher.GenerateKeyPair()
+	r := Record{
+		ID: "c", OwnerPK: owner, Kind: KindChannel, Mode: ModePublic,
+		Admins:  []cipher.PubKey{owner, admin},
+		Members: []cipher.PubKey{owner, admin, member},
+	}
+
+	require.Equal(t, PostAdminsOnly, r.PostPolicy(), "a channel is admins-only whatever ReadOnly says")
+	require.True(t, r.IsChannel())
+
+	for _, pk := range []cipher.PubKey{owner, admin} {
+		ok, reason := r.CanPost(pk)
+		require.True(t, ok, "an admin must be able to post")
+		require.Empty(t, reason)
+	}
+	ok, reason := r.CanPost(member)
+	require.False(t, ok, "a subscriber must not be able to post")
+	require.Contains(t, reason, "channel")
+
+	// Joining is still open — a channel restricts publishing, not reading.
+	require.Equal(t, JoinOpen, r.JoinPolicy())
+
+	// A ban still outranks everything, and a mute still applies to an admin.
+	banned := r
+	banned.Banned = []cipher.PubKey{member}
+	ok, reason = banned.CanPost(member)
+	require.False(t, ok)
+	require.Contains(t, reason, "banned")
+
+	mutedAdmin := r
+	mutedAdmin.Muted = []cipher.PubKey{admin}
+	ok, reason = mutedAdmin.CanPost(admin)
+	require.False(t, ok, "an explicit mute applies even to an admin")
+	require.Contains(t, reason, "restricted")
+}
+
+// The scaling property. Under the group rule an admin follows every
+// member; in a channel those feeds can never carry a message, so following
+// them would mean one CXO subscription per subscriber per admin. Both roles
+// must follow admins only.
+func TestChannel_TopologyFollowsAdminsOnly(t *testing.T) {
+	owner, _ := cipher.GenerateKeyPair()
+	admin, _ := cipher.GenerateKeyPair()
+
+	subscribers := make([]cipher.PubKey, 0, 50)
+	for i := 0; i < 50; i++ {
+		pk, _ := cipher.GenerateKeyPair()
+		subscribers = append(subscribers, pk)
+	}
+	members := append([]cipher.PubKey{owner, admin}, subscribers...)
+	channel := Record{
+		ID: "c", OwnerPK: owner, Kind: KindChannel, Mode: ModePublic,
+		Admins: []cipher.PubKey{owner, admin}, Members: members,
+	}
+
+	// From an admin's seat: the other admin, and nobody else. The 50
+	// subscribers are exactly what the group rule would have followed.
+	fromAdmin := desiredPeerSubsForRole(channel, owner, defaultPeerFanout)
+	require.Len(t, fromAdmin, 1, "an admin must not follow a channel's subscribers")
+	require.Contains(t, fromAdmin, admin)
+
+	// From a subscriber's seat: both admins, and no other subscriber — the
+	// fanout ring is off, because a channel's history comes from admins.
+	fromSub := desiredPeerSubsForRole(channel, subscribers[0], defaultPeerFanout)
+	require.Len(t, fromSub, 2)
+	require.Contains(t, fromSub, owner)
+	require.Contains(t, fromSub, admin)
+
+	// Cost is flat in audience size: adding subscribers changes nothing.
+	bigger := channel
+	for i := 0; i < 200; i++ {
+		pk, _ := cipher.GenerateKeyPair()
+		bigger.Members = append(bigger.Members, pk)
+	}
+	require.Len(t, desiredPeerSubsForRole(bigger, owner, defaultPeerFanout), 1,
+		"an admin's subscription count must not grow with the audience")
+
+	// Contrast: the same roster as an ordinary group DOES fan out, which is
+	// what makes the channel rule worth having.
+	asGroup := channel
+	asGroup.Kind = KindPublic
+	require.Greater(t, len(desiredPeerSubsForRole(asGroup, owner, defaultPeerFanout)), 1,
+		"a public group's admin still follows every member")
+}
+
+// A channel never serves history peer-to-peer: a subscriber has nothing of
+// its own to serve, and mirroring the room onto every follower would give a
+// large channel one copy of itself per member.
+func TestChannel_PeerBackfillIsAlwaysOff(t *testing.T) {
+	owner, _ := cipher.GenerateKeyPair()
+	r := Record{ID: "c", OwnerPK: owner, Kind: KindChannel, Mode: ModePublic}
+	require.False(t, r.PeerBackfillEnabled(), "a channel must not peer-backfill")
+
+	// Even with the stored flag explicitly set to the enabled value.
+	r.PeerBackfillDisabled = false
+	require.False(t, r.PeerBackfillEnabled())
+
+	// An ordinary group is unaffected.
+	g := Record{ID: "g", OwnerPK: owner, Kind: KindPublic, Mode: ModePublic}
+	require.True(t, g.PeerBackfillEnabled())
+}
+
+// Kind survives a link and is preferred from the group's own answer, so a
+// channel joined from an invite arrives as a channel rather than as a public
+// group with an unlocked composer.
+func TestChannel_KindSurvivesInviteAndResponse(t *testing.T) {
+	owner, _ := cipher.GenerateKeyPair()
+	inv := Invite{ID: "c", Name: "news", OwnerPK: owner, Port: 40002, Mode: ModePublic, Kind: KindChannel}
+
+	link, err := EncodeInvite(inv)
+	require.NoError(t, err, "a channel invite must encode")
+	back, err := DecodeInvite(link)
+	require.NoError(t, err, "a channel invite must decode")
+	require.Equal(t, KindChannel, back.Kind)
+	require.Equal(t, KindChannel, back.InviteKind())
+
+	// The group's own answer wins over the link.
+	require.Equal(t, KindChannel, joinedKind(Invite{Mode: ModePublic}, JoinResponseMsg{GroupKind: KindChannel}))
+	// The link is the fallback when the responder predates channels.
+	require.Equal(t, KindChannel, joinedKind(back, JoinResponseMsg{}))
+	// Neither source: Mode decides, and a pre-channel record was never one.
+	require.Equal(t, KindPublic, joinedKind(Invite{Mode: ModePublic}, JoinResponseMsg{}))
+
+	// A kind that contradicts Mode is refused rather than persisted: Mode
+	// drives decryption and Kind drives posting, so a record whose halves
+	// disagree either can't read the feed or can't post to it.
+	_, err = EncodeInvite(Invite{ID: "x", OwnerPK: owner, Port: 1, Mode: ModePrivate, Kind: KindChannel})
+	require.Error(t, err, "kind=channel with mode=private must be refused")
+	require.Equal(t, KindPublic,
+		joinedKind(Invite{Mode: ModePublic}, JoinResponseMsg{GroupKind: KindPrivate}),
+		"a response kind that contradicts the mode falls back")
+}
+
+// Publishing is opt-in and admin-only, and a catalog lists only what was
+// published.
+func TestChannel_CatalogIsOptIn(t *testing.T) {
+	owner, _ := cipher.GenerateKeyPair()
+	r := Record{ID: "c", OwnerPK: owner, Kind: KindChannel, Mode: ModePublic}
+	require.False(t, r.Listed, "a new record must not be listed")
+
+	applied := Record{}
+	WithListed(true)(&applied)
+	require.True(t, applied.Listed)
+
+	// The default when the option is not passed at all.
+	untouched := Record{}
+	require.False(t, untouched.Listed, "omitting the option must leave it unlisted")
+}
+
+// forEachStore runs fn against the platform's group-record store.
+//
+// Only one backend exists per build — store_memory.go is `//go:build js` and
+// store_bbolt.go is its inverse — so this is a single case here and the
+// wasm backend is covered when the suite runs under GOOS=js. The kind guard
+// is implemented in both files precisely because they cannot be tested
+// together; keeping this helper named for the general case is a reminder
+// that the invariant belongs to both.
+func forEachStore(t *testing.T, fn func(t *testing.T, st *Store)) {
+	t.Helper()
+	st, err := OpenStore(filepath.Join(t.TempDir(), "groups.db"), testStoreSK())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() }) //nolint:errcheck
+	fn(t, st)
+}

--- a/pkg/skychat/group/group.go
+++ b/pkg/skychat/group/group.go
@@ -84,26 +84,34 @@ func (m Mode) IsValid() bool {
 }
 
 // Kind is the user-facing group type — the one switch an operator
-// picks at create time. It determines admission policy and, through
-// modeForKind, payload encryption.
-//
-// A third value (KindChannel — a public group only admins may post
-// to) is the planned broadcast-channel type; PostPolicy is already
-// shaped to carry it so adding it is a table entry rather than a
-// refactor.
+// picks at create time. It determines admission policy, who may
+// publish, and — through modeForKind — payload encryption.
 type Kind string
 
 const (
-	// KindPublic — open admission, plaintext bodies.
+	// KindPublic — open admission, plaintext bodies, everyone posts.
 	KindPublic Kind = "public"
 
 	// KindPrivate — admin-approved admission, encrypted bodies.
 	KindPrivate Kind = "private"
+
+	// KindChannel — broadcast: open admission like a public group, but
+	// only admins may publish. Plaintext for the same reason a public
+	// group is: admission is open, so the key would go to anyone who
+	// asked and would protect nothing.
+	//
+	// Unlike the ReadOnly flag — which is a reversible "everyone quiet
+	// now" an admin toggles — a channel is admins-only permanently, as
+	// a property of the group rather than of its current moderation
+	// state. That distinction is why PostPolicy consults Kind before
+	// ReadOnly, and why the reader-side gate applies it to leaves of
+	// every age rather than forward-only.
+	KindChannel Kind = "channel"
 )
 
 // IsValid returns true for the recognized group kinds.
 func (k Kind) IsValid() bool {
-	return k == KindPublic || k == KindPrivate
+	return k == KindPublic || k == KindPrivate || k == KindChannel
 }
 
 // modeForKind maps a group kind onto the persisted encryption mode.
@@ -148,8 +156,8 @@ const (
 	PostAll PostPolicy = "all"
 
 	// PostAdminsOnly — only admins may post. Set either by the
-	// group-wide ReadOnly flag (a reversible "everyone quiet now")
-	// or, in future, permanently by a broadcast-channel Kind.
+	// group-wide ReadOnly flag (a reversible "everyone quiet now") or
+	// permanently by KindChannel.
 	PostAdminsOnly PostPolicy = "admins"
 )
 
@@ -523,6 +531,14 @@ func (r Record) JoinPolicy() JoinPolicy {
 	return policyForKind(r.Kind)
 }
 
+// Policy returns the admission rule this kind implies. Exported for
+// callers holding a Kind without a Record — the invite/describe paths,
+// which know what a group is before they have one.
+func (k Kind) Policy() JoinPolicy { return policyForKind(k) }
+
+// policyForKind maps a kind onto its admission rule. Only KindPrivate
+// queues; public groups and channels both admit on request — a channel
+// restricts publishing, not reading.
 func policyForKind(k Kind) JoinPolicy {
 	if k == KindPrivate {
 		return JoinApproval
@@ -533,12 +549,23 @@ func policyForKind(k Kind) JoinPolicy {
 // PostPolicy returns who may currently publish into this group.
 // ReadOnly narrows an otherwise-open group to admins only; it is a
 // live toggle, so this is deliberately computed rather than stored.
+// A channel is admins-only by construction, whatever ReadOnly says.
 func (r Record) PostPolicy() PostPolicy {
-	if r.ReadOnly {
+	if r.IsChannel() || r.ReadOnly {
 		return PostAdminsOnly
 	}
 	return PostAll
 }
+
+// IsChannel reports whether this group is a broadcast channel — open to
+// join, admins-only to post.
+//
+// Needs no Mode fallback, unlike JoinPolicy: a record written before Kind
+// existed cannot have been a channel, because channels did not, so an
+// empty Kind is correctly false. That is also the safe direction — an
+// unnormalized record reads as an ordinary group rather than silently
+// silencing every member of one.
+func (r Record) IsChannel() bool { return r.Kind == KindChannel }
 
 // JoinPoWRequired returns the difficulty a join request must meet for
 // this group: the admin's setting when one exists, the package default
@@ -588,6 +615,8 @@ func (r Record) CanPost(pk cipher.PubKey) (bool, string) {
 		return false, "you are banned from this group"
 	case r.IsMuted(pk):
 		return false, "you are restricted from sending messages in this group"
+	case r.IsChannel() && !r.IsAdmin(pk):
+		return false, "this is a channel — only admins can post"
 	case r.ReadOnly && !r.IsAdmin(pk):
 		return false, "this group is read-only — only admins can send messages"
 	default:

--- a/pkg/skychat/group/group.go
+++ b/pkg/skychat/group/group.go
@@ -53,6 +53,8 @@
 package group
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -387,6 +389,26 @@ type Record struct {
 	// are offline.
 	PeerBackfillDisabled bool `json:"peer_backfill_disabled,omitempty"`
 
+	// Listed opts this group into the visor's discovery catalog: with it
+	// set, anyone who knows the HOST's public key can ask for the group
+	// and be told it exists. Without it, the group is reachable only by
+	// its address or an invite link, both of which require the group ID —
+	// 122 bits nobody guesses.
+	//
+	// Opt-in, and the zero value is the private one. That direction is the
+	// whole point: a catalog is the only mechanism here that turns one
+	// public key into a LIST, so it must never acquire an entry because
+	// somebody didn't read a checkbox. Existing records stay unlisted
+	// through the upgrade for the same reason.
+	//
+	// Local, NOT gossiped. It says what THIS visor is willing to answer
+	// questions about, which is a hosting decision rather than a property
+	// of the group — two admins can legitimately differ on whether they
+	// advertise the same channel, and neither should be able to publish
+	// the other's copy. That also means an admin cannot un-list a channel
+	// somebody else is advertising, which is honest: they never could.
+	Listed bool `json:"listed,omitempty"`
+
 	// ReadOnlySince is when the current read-only period began, and
 	// exists for the same forward-only reason as MutedSince. Without
 	// it, flipping a busy group to read-only would make every prior
@@ -557,6 +579,40 @@ func (r Record) PostPolicy() PostPolicy {
 	return PostAll
 }
 
+// ErrKindImmutable is returned by the store when a write would change an
+// existing group's Kind.
+var ErrKindImmutable = errors.New("group: a group's kind cannot be changed after it is created")
+
+// checkKindStable rejects a write that would redefine what a persisted
+// group IS.
+//
+// The rule exists for channels specifically. Every other property of a
+// group is negotiable — a name, an admin set, a key, even whether it is
+// read-only — but "only admins may post here" is the promise a channel's
+// subscribers joined under, and flipping it to a public group would hand
+// the floor to thousands of people who were never admitted on those
+// terms. There is no legitimate migration: the honest way to change a
+// channel into a group is to create a group.
+//
+// An empty incoming Kind counts as a change, not as "no opinion". That is
+// the dangerous direction: EnsureKind re-derives an empty Kind from Mode
+// on the next read, and a channel and a public group share ModePublic — so
+// a write that merely FORGOT the kind would silently reopen the channel to
+// everyone. Rejecting it turns that class of bug into an error at the
+// boundary instead of a policy change nobody asked for.
+//
+// prev == "" is allowed through: that is a record written before Kind
+// existed, being normalized for the first time.
+func checkKindStable(id string, prev, next Kind) error {
+	if prev == "" || prev == next {
+		return nil
+	}
+	if next == "" {
+		return fmt.Errorf("%w: %s is %q and the write carried no kind", ErrKindImmutable, id, prev)
+	}
+	return fmt.Errorf("%w: %s is %q and cannot become %q", ErrKindImmutable, id, prev, next)
+}
+
 // IsChannel reports whether this group is a broadcast channel — open to
 // join, admins-only to post.
 //
@@ -581,7 +637,19 @@ func (r Record) JoinPoWRequired() uint8 {
 // group's history and messages, as opposed to admins only. The single
 // predicate every call site should consult — see PeerBackfillDisabled for
 // why the stored field is inverted.
-func (r Record) PeerBackfillEnabled() bool { return !r.PeerBackfillDisabled }
+//
+// Always false for a channel, whatever the stored flag says. In a channel
+// a non-admin has nothing of its own to serve — it cannot post — so
+// mirroring the room onto its feed would buy availability for nobody while
+// charging every subscriber the disk. It is also what the whole shape of a
+// channel implies: subscribers read, admins publish and serve. A channel
+// with 10,000 members would otherwise have 10,000 copies of itself.
+func (r Record) PeerBackfillEnabled() bool {
+	if r.IsChannel() {
+		return false
+	}
+	return !r.PeerBackfillDisabled
+}
 
 // IsBanned reports whether pk is barred from this group.
 func (r Record) IsBanned(pk cipher.PubKey) bool { return containsPK(r.Banned, pk) }

--- a/pkg/skychat/group/invite.go
+++ b/pkg/skychat/group/invite.go
@@ -45,6 +45,19 @@ type Invite struct {
 	Port    uint16        `json:"port"`
 	Mode    Mode          `json:"mode"`
 
+	// Kind is the group type, carried because Mode alone can no longer
+	// name it: a public group and a channel are both ModePublic, and
+	// differ only in who may publish. Without this a channel joined
+	// from a link would come up as an ordinary public group and its
+	// members' composers would be unlocked.
+	//
+	// Absent in links minted before channels existed; a joiner reading
+	// one derives the kind from Mode, which is exactly the old
+	// behavior. Untrusted like the rest of the link, and cross-checked
+	// against Mode on decode — the group's own answer to the join
+	// request is what a joiner ultimately records.
+	Kind Kind `json:"kind,omitempty"`
+
 	// Admins are further PKs with roster authority that a joiner may ask
 	// for admission when the founder doesn't answer. Excludes OwnerPK,
 	// which is carried above and is always tried first.
@@ -111,6 +124,9 @@ func EncodeInvite(inv Invite) (string, error) {
 	if inv.Mode == ModePublic && len(inv.AESKey) > 0 {
 		return "", fmt.Errorf("group invite: public mode must not carry an AES key")
 	}
+	if err := checkInviteKind(inv); err != nil {
+		return "", err
+	}
 	body, err := json.Marshal(inv)
 	if err != nil {
 		return "", fmt.Errorf("group invite: marshal: %w", err)
@@ -144,6 +160,9 @@ func DecodeInvite(s string) (Invite, error) {
 	if inv.Mode == ModePublic && len(inv.AESKey) > 0 {
 		return Invite{}, fmt.Errorf("group invite: public mode must not carry an AES key")
 	}
+	if err := checkInviteKind(inv); err != nil {
+		return Invite{}, err
+	}
 	if inv.ID == "" {
 		return Invite{}, fmt.Errorf("group invite: empty ID")
 	}
@@ -155,6 +174,38 @@ func DecodeInvite(s string) (Invite, error) {
 	}
 	inv.PoWBits = clampJoinPoWBits(inv.PoWBits)
 	return inv, nil
+}
+
+// checkInviteKind validates the optional Kind field against Mode.
+//
+// An empty Kind is fine — that is a link from before channels existed,
+// and the reader derives the kind from Mode. A Kind that IS present has
+// to agree with Mode, because the two are read by different code paths:
+// Mode decides whether bodies are decrypted, Kind decides who may post.
+// A link asserting kind=private/mode=public would produce a record that
+// expects encrypted bodies on a plaintext feed and never renders
+// anything, so it is rejected here rather than persisted.
+func checkInviteKind(inv Invite) error {
+	if inv.Kind == "" {
+		return nil
+	}
+	if !inv.Kind.IsValid() {
+		return fmt.Errorf("group invite: invalid kind %q", inv.Kind)
+	}
+	if modeForKind(inv.Kind) != inv.Mode {
+		return fmt.Errorf("group invite: kind %q does not match mode %q", inv.Kind, inv.Mode)
+	}
+	return nil
+}
+
+// InviteKind returns the group type this invite names, falling back to
+// what Mode implies for links minted before Kind was carried. The single
+// accessor callers should use so the legacy fallback lives in one place.
+func (inv Invite) InviteKind() Kind {
+	if inv.Kind == "" {
+		return kindForMode(inv.Mode)
+	}
+	return inv.Kind
 }
 
 // GenerateAESKey returns a fresh 32-byte key sourced from

--- a/pkg/skychat/group/join.go
+++ b/pkg/skychat/group/join.go
@@ -125,6 +125,18 @@ const (
 	// throttled request is never stored, so a flood costs the admin one
 	// hash and one frame rather than a row and a notification.
 	JoinStatusThrottled JoinStatus = "throttled"
+
+	// JoinStatusInfo — the answer to a DESCRIBE (JoinRequestMsg.Probe):
+	// "here is what this group is". Carries the group's kind, admission
+	// policy, feed port and name, and grants nothing.
+	//
+	// A status of its own rather than a separate frame kind so the whole
+	// existing round trip — codec, deadlines, identity check — is reused.
+	// It is deliberately NOT a decision (see IsDecision) and NOT terminal:
+	// nothing in the join state machine may ever act on it, because a
+	// describe answer says nothing about whether the asker would be let
+	// in. See probe.go.
+	JoinStatusInfo JoinStatus = "info"
 )
 
 // IsTerminal reports whether the requester should stop re-asking.
@@ -181,6 +193,19 @@ type JoinRequestMsg struct {
 	// honestly.
 	AskAgain bool `json:"ask_again,omitempty"`
 
+	// Probe asks the group to DESCRIBE itself and decide nothing: no
+	// roster change, no queue entry, no notification. Answered with
+	// JoinStatusInfo.
+	//
+	// This is what makes a short skychat://<pk>/<group-id> address
+	// actionable — the sender cannot know the group's kind, admission
+	// policy or feed port until someone tells it, and it must be able to
+	// ask without that ask being read as "let me in". A build that
+	// predates this field ignores it and answers the request as a real
+	// join, so the requester only ever sends a probe to the well-known
+	// probe port, which no older build listens on at all.
+	Probe bool `json:"probe,omitempty"`
+
 	TS time.Time `json:"ts"`
 }
 
@@ -196,6 +221,18 @@ type JoinResponseMsg struct {
 	// Name lets the joiner display the real group name rather than
 	// whatever the invite link said, which may be stale.
 	Name string `json:"name,omitempty"`
+
+	// GroupKind is the group's type as the group itself reports it —
+	// authoritative over whatever the invite link claimed. Named
+	// GroupKind rather than Kind because Kind above is the frame
+	// discriminator.
+	//
+	// This is what stops a channel from being joined as an ordinary
+	// public group: both are ModePublic, so without it a member's
+	// composer would come up unlocked on a feed nobody else will render
+	// their leaves from. Empty from a responder predating channels, in
+	// which case the joiner falls back to the invite and then to Mode.
+	GroupKind Kind `json:"group_kind,omitempty"`
 
 	// AESKey is the group key, present iff Status is admitted AND the
 	// group is encrypted. This is the delivery channel that replaced
@@ -247,6 +284,36 @@ type JoinResponseMsg struct {
 
 	// Reason is operator-facing text for the non-admitted cases.
 	Reason string `json:"reason,omitempty"`
+
+	// ---- describe-only fields (Status == JoinStatusInfo) ------------
+	//
+	// These answer "what is this group", for a requester that holds a
+	// short address and therefore knows nothing but the group's ID. They
+	// are populated only on a probe answer; a real admission response
+	// leaves them zero, because by then the joiner has the invite link
+	// and the roster and needs none of them.
+
+	// Port is the group's CXO feed port — Record.Port. Without it a
+	// short address cannot be turned into a join at all: the admission
+	// listener is at Port+1 and Port is allocated at random per group.
+	Port uint16 `json:"port,omitempty"`
+
+	// Policy is the group's admission rule, so a UI can offer "Join" or
+	// "Send request" before spending a round trip to find out which it
+	// was. Derived, not stored — see Record.JoinPolicy.
+	Policy JoinPolicy `json:"policy,omitempty"`
+
+	// PriceHint is free text a group may state about what admission
+	// costs ("5 SKY", "5 SKY / month"). Reserved for paid channels,
+	// always empty today.
+	//
+	// A hint, and named as one: it is unverified text from a host that
+	// wants members, so it is display-only context and must never be
+	// treated as terms. A real payment flow will carry its own verified
+	// amounts; this field exists so introducing one does not require a
+	// wire change, and so a UI has somewhere to put the number. Bounded
+	// by maxPriceHintLen on receipt.
+	PriceHint string `json:"price_hint,omitempty"`
 }
 
 // maxJoinNoteLen bounds the free-text note. Long enough for a sentence
@@ -523,7 +590,7 @@ func decodeJoinResponse(b []byte) (JoinResponseMsg, error) {
 	}
 	switch m.Status {
 	case JoinStatusAdmitted, JoinStatusPending, JoinStatusDenied, JoinStatusBanned,
-		JoinStatusUnavailable, JoinStatusChallenge, JoinStatusThrottled:
+		JoinStatusUnavailable, JoinStatusChallenge, JoinStatusThrottled, JoinStatusInfo:
 	default:
 		return JoinResponseMsg{}, fmt.Errorf("group: decode join response: unknown status %q", m.Status)
 	}

--- a/pkg/skychat/group/manager.go
+++ b/pkg/skychat/group/manager.go
@@ -245,6 +245,16 @@ func WithPeerBackfill(enabled bool) CreateOption {
 	return func(r *Record) { r.PeerBackfillDisabled = !enabled }
 }
 
+// WithListed opts the new group into this visor's discovery catalog, so
+// anyone holding the host's public key can find it.
+//
+// Off when the option is not passed, and that default is load-bearing:
+// the catalog is the only thing here that turns one key into a list, so an
+// entry has to be asked for. See Record.Listed.
+func WithListed(listed bool) CreateOption {
+	return func(r *Record) { r.Listed = listed }
+}
+
 // Create constructs a new owner-side group, persists it, and opens
 // the publisher. Returns the persisted Record (with ID + Port + key
 // populated) so the caller can build the invite link.

--- a/pkg/skychat/group/manager.go
+++ b/pkg/skychat/group/manager.go
@@ -85,6 +85,12 @@ type Manager struct {
 	// DefaultMaxPendingJoins.
 	maxPending int
 
+	// probe holds the well-known describe listeners — the port that
+	// makes a short skychat:// group address resolvable. Per-visor
+	// rather than per-session, because the whole point is to be
+	// reachable without knowing any group's port. See probe.go.
+	probe probeListener
+
 	// reconnect loop state — see runReconnectLoop.
 	reconnectCtx    context.Context
 	reconnectCancel context.CancelFunc
@@ -682,6 +688,12 @@ func (m *Manager) Resume() error {
 		m.replaySessionHistory(r.ID)
 	}
 	m.startReconnectLoop()
+	// The describe port is bound unconditionally, not only when this
+	// visor already hosts something: a group can be created at any point
+	// after startup, and a listener that only appeared for visors that
+	// happened to hold a group at boot would leave every freshly created
+	// group's short address dead until the next restart.
+	m.StartProbeListener()
 	return nil
 }
 
@@ -1412,6 +1424,7 @@ func (m *Manager) Close() error {
 		cancel()
 		m.reconnectWG.Wait()
 	}
+	m.StopProbeListener()
 	m.mu.Lock()
 	sessions := m.sessions
 	m.sessions = make(map[string]*Session)
@@ -1542,6 +1555,9 @@ func (m *Manager) BuildInvite(id string) (string, error) {
 		OwnerPK: r.OwnerPK,
 		Port:    r.Port,
 		Mode:    r.Mode,
+		// Kind, so a channel arrives as a channel. Mode cannot express it
+		// — a channel and a public group share ModePublic.
+		Kind: r.Kind,
 		// Name the group's other admins so the founder isn't the only
 		// door in. Self first: whoever is minting this link is
 		// demonstrably alive and is the admin most likely to be watching

--- a/pkg/skychat/group/manager_admission.go
+++ b/pkg/skychat/group/manager_admission.go
@@ -374,9 +374,14 @@ func (m *Manager) admissionHandler(id string) JoinRequestHandler {
 // approved and nobody else.
 func (m *Manager) admittedResponse(r Record) JoinResponseMsg {
 	resp := JoinResponseMsg{
-		Status:               JoinStatusAdmitted,
-		GroupID:              r.ID,
-		Name:                 r.Name,
+		Status:  JoinStatusAdmitted,
+		GroupID: r.ID,
+		Name:    r.Name,
+		// Authoritative over the link. A channel admits like a public
+		// group, so without this the joiner would record KindPublic and
+		// come up with an unlocked composer on a feed whose other members
+		// drop non-admin leaves.
+		GroupKind:            r.Kind,
 		Members:              append([]cipher.PubKey(nil), r.Members...),
 		Admins:               append([]cipher.PubKey(nil), r.Admins...),
 		Muted:                append([]cipher.PubKey(nil), r.Muted...),
@@ -878,7 +883,7 @@ func (m *Manager) recordFromInvite(inv Invite, resp JoinResponseMsg) Record {
 		AdmissionPKs:         append([]cipher.PubKey(nil), inv.Admins...),
 		Port:                 inv.Port,
 		Mode:                 inv.Mode,
-		Kind:                 kindForMode(inv.Mode),
+		Kind:                 joinedKind(inv, resp),
 		AESKey:               key,
 		KeyEpoch:             resp.KeyEpoch,
 		Members:              members,
@@ -891,6 +896,28 @@ func (m *Manager) recordFromInvite(inv Invite, resp JoinResponseMsg) Record {
 	}
 	r.EnsureFounderInAdmins()
 	return r
+}
+
+// joinedKind decides which Kind a freshly-joined member-side record
+// takes: the group's own answer first, then the invite link, then what
+// Mode implies for a responder and a link that both predate channels.
+//
+// Either source is only accepted when modeForKind agrees with the Mode
+// the record is actually being built with. Mode governs decryption and
+// Kind governs posting, and a record whose two halves disagree either
+// tries to decrypt a plaintext feed or posts into a channel — so a
+// mismatch falls back to the Mode-derived kind rather than being
+// persisted. The mismatch is unreachable through honest peers (both
+// sides compute Kind and Mode from the same table); this exists because
+// the invite is attacker-supplied text and the response arrives before
+// there is any group state to check it against.
+func joinedKind(inv Invite, resp JoinResponseMsg) Kind {
+	for _, k := range []Kind{resp.GroupKind, inv.Kind} {
+		if k.IsValid() && modeForKind(k) == inv.Mode {
+			return k
+		}
+	}
+	return kindForMode(inv.Mode)
 }
 
 // openAdmitted brings up the session for a freshly-admitted member and
@@ -939,7 +966,7 @@ func (m *Manager) legacyJoin(inv Invite) (Record, error) {
 		OwnerPK:   inv.OwnerPK,
 		Port:      inv.Port,
 		Mode:      inv.Mode,
-		Kind:      kindForMode(inv.Mode),
+		Kind:      joinedKind(inv, JoinResponseMsg{}),
 		AESKey:    inv.AESKey,
 		Members:   []cipher.PubKey{inv.OwnerPK, m.myPK},
 		Role:      RoleMember,

--- a/pkg/skychat/group/manager_admission.go
+++ b/pkg/skychat/group/manager_admission.go
@@ -671,7 +671,16 @@ func (m *Manager) SetJoinPoW(id string, bits uint8) (Record, error) {
 //
 // The live session's subscription set is re-evaluated either way, so the
 // change takes effect now rather than at the next restart.
+//
+// Refused outright on a channel. PeerBackfillEnabled is unconditionally
+// false there (a subscriber has nothing of its own to serve), so accepting
+// the call would gossip a signed state change to every member and change
+// nothing — an admin would be told the setting took, and it would not
+// have. An error is the honest answer.
 func (m *Manager) SetPeerBackfill(id string, enabled bool) (Record, error) {
+	if r, ok, err := m.store.Get(id); err == nil && ok && r.IsChannel() {
+		return Record{}, errors.New("group: SetPeerBackfill: a channel always serves history from its admins; this setting does not apply")
+	}
 	op := ModOpPeerBackfillOff
 	if enabled {
 		op = ModOpPeerBackfillOn

--- a/pkg/skychat/group/mod_reconcile.go
+++ b/pkg/skychat/group/mod_reconcile.go
@@ -178,6 +178,15 @@ func (s *Session) IsBanned(pk cipher.PubKey) bool {
 // Admins are exempt from read-only (they set it) but not from an
 // explicit mute, matching Record.CanPost so the local composer state
 // and the remote drop decision can never disagree.
+//
+// The channel gate is the one case that is NOT forward-only, and
+// deliberately so: "only admins publish here" is what the group IS, not
+// something that started at a moment in time. A non-admin leaf on a
+// channel feed is illegitimate whenever it was authored, so there is no
+// `since` to compare against. Admin status is read from
+// s.cfg.Record.Admins, which the admin reconciler keeps current under
+// this same lock (see SetAdminRoster) — so a freshly promoted admin's
+// posts are rendered rather than dropped.
 func (s *Session) senderAllowedToPost(senderPK cipher.PubKey, ts time.Time) (bool, string) {
 	s.membersMu.RLock()
 	defer s.membersMu.RUnlock()
@@ -186,6 +195,8 @@ func (s *Session) senderAllowedToPost(senderPK cipher.PubKey, ts time.Time) (boo
 		return false, "banned"
 	case s.isMutedLocked(senderPK) && afterOrEqual(ts, s.mutedSince[senderPK.Hex()]):
 		return false, "muted"
+	case s.cfg.Record.IsChannel() && !s.cfg.Record.IsAdmin(senderPK):
+		return false, "channel is admins-only"
 	case s.readOnly && !s.cfg.Record.IsAdmin(senderPK) && afterOrEqual(ts, s.readOnlySince):
 		return false, "group is read-only"
 	default:

--- a/pkg/skychat/group/probe.go
+++ b/pkg/skychat/group/probe.go
@@ -382,7 +382,7 @@ func (m *Manager) StartProbeListener() {
 	if m.probe.cancel != nil {
 		return // already running
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background()) //nolint
 	m.probe.ctx, m.probe.cancel = ctx, cancel
 
 	if m.dmsgC != nil {

--- a/pkg/skychat/group/probe.go
+++ b/pkg/skychat/group/probe.go
@@ -1,0 +1,585 @@
+// Package group pkg/skychat/group/probe.go c4-app-chat
+// the describe half of admission: "what is the group with this ID?".
+//
+// # Why this exists
+//
+// A group is reachable only if you know four things — its ID, its host,
+// its feed port, and its mode — and three of those live nowhere but the
+// invite link, because the port is allocated at random per group
+// (defaultPortAlloc) and the mode is not derivable from anything public.
+// That made the short address form (skychat://<pk>/<group-id>, see
+// pkg/skychat/address) impossible to act on, and made "type a public key
+// and let the app work out whether it's a person, a group or a channel"
+// impossible to answer at all: those three are indistinguishable strings.
+//
+// A probe closes that gap with one round trip on a fixed per-visor port.
+//
+// # Shape
+//
+// Deliberately built out of the join round trip rather than beside it:
+// same frame kinds, same codec, same identity check, same deadlines. A
+// probe is a JoinRequestMsg with Probe set, answered with
+// JoinStatusInfo. Nothing about it is new except the port it arrives on
+// and the fact that it decides nothing.
+//
+// # What a probe does NOT do
+//
+// It never mutates: no roster change, no queue entry, no notification,
+// no PoW demanded. That is what makes it safe to answer cheaply, and it
+// is why the well-known port carries describes ONLY — every admission
+// decision stays on the per-group listener at Record.Port+1, which the
+// asker can reach once the probe has told it the port.
+//
+// # Enumeration
+//
+// A probe is answered only for an exact group ID, and a group ID is a
+// v4 UUID: 122 bits. Knowing one is already a capability, so answering
+// "yes, that is a private group, send a request" leaks nothing that
+// holding the ID did not already imply. There is deliberately no "list
+// your groups" form — that would turn one PK into a directory of every
+// private group a visor hosts, which is exactly the thing the ID's
+// entropy is protecting. A visor that WANTS to be listed can publish its
+// addresses wherever it likes; that is a directory's job, not this port's.
+//
+// Two things are still withheld from a probe answer even for a group
+// whose ID the asker holds: the roster (who is in it) and the key. Both
+// ride the admission response, after a decision.
+package group
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skychat/message"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// ProbePort is the well-known dmsg/skynet port a visor answers group
+// describes on. Aliased from skyenv so this package reads self-contained
+// while the number stays in the one registry that the pair-feed and
+// CXO-feed allocators check against.
+const ProbePort = skyenv.SkychatGroupProbePort
+
+// maxPriceHintLen bounds the free text a host may state about admission
+// cost. Long enough for "5 SKY / month", short enough that it cannot be
+// used to push a paragraph of copy into a dialog.
+const maxPriceHintLen = 40
+
+// probeTimeout caps one describe round trip. Shorter than
+// joinResponseReadTimeout because a probe does no store write, no roster
+// publish and no key wrap — it is a lookup, and it sits directly under a
+// user watching a dialog for a spinner to stop.
+const probeTimeout = 6 * time.Second
+
+// ErrProbeNoSuchGroup means the host answered, and does not hold a group
+// with that ID (or holds one it has left or deleted). Distinct from a
+// transport failure: the address is wrong, not unreachable, so a caller
+// should say "no such group" rather than "try again".
+var ErrProbeNoSuchGroup = errors.New("group: probe: host does not hold that group")
+
+// ErrProbeUnreachable means the host could not be reached, or answered
+// nothing. The group may well exist — this is the retryable case, and
+// also what an older host that does not serve ProbePort looks like.
+var ErrProbeUnreachable = errors.New("group: probe: host did not answer")
+
+// GroupDescriptor is what a probe learns about a group. Everything a
+// caller needs to render a join affordance and then perform the join,
+// and nothing that a non-member should not see.
+type GroupDescriptor struct {
+	// ID and HostPK are echoed back so a descriptor is self-describing
+	// once it has been handed to a UI or an RPC caller.
+	ID     string        `json:"id"`
+	HostPK cipher.PubKey `json:"host_pk"`
+
+	Name string `json:"name"`
+	Kind Kind   `json:"kind"`
+	Mode Mode   `json:"mode"`
+
+	// Policy is what joining will involve: JoinOpen admits on request,
+	// JoinApproval queues for an admin.
+	Policy JoinPolicy `json:"policy"`
+
+	// Port is the group's CXO feed port, needed to build the invite the
+	// join path consumes.
+	Port uint16 `json:"port"`
+
+	// PoWBits is the proof of work a join request must carry, so the
+	// joiner pays before it dials rather than being challenged.
+	PoWBits uint8 `json:"pow_bits,omitempty"`
+
+	// ReadOnly reports that posting is currently suspended for
+	// non-admins. Separate from a channel: this one is reversible.
+	ReadOnly bool `json:"read_only,omitempty"`
+
+	// PriceHint is unverified display text about admission cost. See
+	// JoinResponseMsg.PriceHint — never treat it as terms.
+	PriceHint string `json:"price_hint,omitempty"`
+
+	// Banned reports that the ASKING visor is barred from this group, so
+	// a UI can say why rather than offering a join that will be refused.
+	Banned bool `json:"banned,omitempty"`
+}
+
+// IsChannel reports whether the described group is a broadcast channel.
+func (d GroupDescriptor) IsChannel() bool { return d.Kind == KindChannel }
+
+// Invite rebuilds the invite this descriptor is equivalent to, so the
+// existing join path — which speaks Invite and nothing else — can be
+// driven from a short address.
+//
+// The AES key is absent by construction, which is correct: an encrypted
+// group's key travels in the admission response, after a decision. That
+// is the same shape a freshly minted link has (see Manager.BuildInvite),
+// so joining from an address and joining from a link converge on
+// identical code.
+//
+// Admins are left empty: a probe is answered by ONE host, and naming
+// further admins would be repeating an unverified claim to ourselves.
+// The real admin set arrives with the admission response.
+func (d GroupDescriptor) Invite() Invite {
+	return Invite{
+		ID:      d.ID,
+		Name:    d.Name,
+		OwnerPK: d.HostPK,
+		Port:    d.Port,
+		Mode:    d.Mode,
+		Kind:    d.Kind,
+		PoWBits: d.PoWBits,
+	}
+}
+
+// ---------------------------------------------------------------------
+// requester side
+// ---------------------------------------------------------------------
+
+// ProbeGroup asks host what the group with id gid is.
+//
+// Answers locally without a round trip when this visor already holds the
+// group: the store knows everything a probe would return, and a member
+// re-opening its own address should not depend on the host being up.
+func (m *Manager) ProbeGroup(ctx context.Context, host cipher.PubKey, gid string) (GroupDescriptor, error) {
+	if gid == "" {
+		return GroupDescriptor{}, errors.New("group: ProbeGroup: group id required")
+	}
+	if r, ok, err := m.store.Get(gid); err == nil && ok && !r.Status.IsTerminal() {
+		return descriptorFor(r), nil
+	}
+	resp, err := sendProbe(ctx, m.dmsgC, host, gid, m.myPK)
+	if err != nil {
+		return GroupDescriptor{}, err
+	}
+	switch resp.Status {
+	case JoinStatusInfo:
+		return GroupDescriptor{
+			ID:        gid,
+			HostPK:    host,
+			Name:      resp.Name,
+			Kind:      probedKind(resp),
+			Mode:      probedMode(resp),
+			Policy:    probedPolicy(resp),
+			Port:      resp.Port,
+			PoWBits:   clampJoinPoWBits(resp.PoWBits),
+			ReadOnly:  resp.ReadOnly,
+			PriceHint: truncate(resp.PriceHint, maxPriceHintLen),
+		}, nil
+	case JoinStatusBanned:
+		// Still a description — the group exists and we now know the one
+		// fact that matters most about our relationship to it. Reported
+		// as a descriptor rather than an error so a UI can name the group
+		// and explain, instead of showing a bare failure.
+		return GroupDescriptor{
+			ID: gid, HostPK: host, Name: resp.Name,
+			Kind: probedKind(resp), Mode: probedMode(resp),
+			Policy: probedPolicy(resp), Port: resp.Port,
+			Banned: true,
+		}, nil
+	case JoinStatusUnavailable:
+		return GroupDescriptor{}, fmt.Errorf("%w: %s", ErrProbeNoSuchGroup, resp.Reason)
+	default:
+		// Any other status means the host understood the frame but
+		// answered as though it were a real join — an older build that
+		// somehow serves this port. Not usable as a description.
+		return GroupDescriptor{}, fmt.Errorf("%w: unexpected status %q", ErrProbeUnreachable, resp.Status)
+	}
+}
+
+// descriptorFor builds a descriptor from a record we already hold. Used
+// for the local shortcut in ProbeGroup and by the responder.
+func descriptorFor(r Record) GroupDescriptor {
+	return GroupDescriptor{
+		ID:       r.ID,
+		HostPK:   r.OwnerPK,
+		Name:     r.Name,
+		Kind:     r.Kind,
+		Mode:     r.Mode,
+		Policy:   r.JoinPolicy(),
+		Port:     r.Port,
+		PoWBits:  r.JoinPoWRequired(),
+		ReadOnly: r.ReadOnly,
+	}
+}
+
+// probedKind reads the kind out of a probe answer, tolerating a
+// responder that sent none, and refusing one whose kind contradicts its
+// mode. Same rule and same reason as joinedKind: Mode drives decryption
+// and Kind drives posting, so a record must never be built from a pair
+// that disagrees.
+func probedKind(resp JoinResponseMsg) Kind {
+	if resp.GroupKind.IsValid() && modeForKind(resp.GroupKind) == probedMode(resp) {
+		return resp.GroupKind
+	}
+	return kindForMode(probedMode(resp))
+}
+
+// probedMode derives the encryption mode from the answered kind, since
+// the describe answer carries Kind and not Mode. An answer with no valid
+// kind is treated as public — the safe direction, because it means "do
+// not expect encrypted bodies" rather than "expect a key that isn't
+// coming". A private group's actual mode comes back the moment its Kind
+// does, and the admission response is authoritative either way.
+func probedMode(resp JoinResponseMsg) Mode {
+	if resp.GroupKind.IsValid() {
+		return modeForKind(resp.GroupKind)
+	}
+	return ModePublic
+}
+
+// probedPolicy prefers the policy the host stated, falling back to what
+// the kind implies. The two agree for every honest host; the fallback
+// covers a responder that populated Kind but not Policy.
+func probedPolicy(resp JoinResponseMsg) JoinPolicy {
+	switch resp.Policy {
+	case JoinOpen, JoinApproval:
+		return resp.Policy
+	default:
+		return policyForKind(probedKind(resp))
+	}
+}
+
+// JoinByAddress joins the group a short address names: probe for what it
+// is, then drive the ordinary invite-based join with the answer.
+//
+// Idempotent through the same path a link-based join is — RequestJoin
+// returns the existing record for a group we are already active in.
+func (m *Manager) JoinByAddress(ctx context.Context, host cipher.PubKey, gid string) (Record, error) {
+	if r, ok, err := m.store.Get(gid); err == nil && ok && r.Status == StatusActive {
+		return r, nil
+	}
+	d, err := m.ProbeGroup(ctx, host, gid)
+	if err != nil {
+		return Record{}, err
+	}
+	if d.Banned {
+		return Record{}, ErrJoinBanned
+	}
+	// A descriptor for a group we host is not something to join.
+	if d.HostPK == m.myPK {
+		return Record{}, errors.New("group: JoinByAddress: refusing to join own group")
+	}
+	return m.RequestJoin(d.Invite(), "")
+}
+
+// sendProbe writes one describe frame and reads the answer. Tries skynet
+// first then dmsg, mirroring sendJoinRequestOnce — a probe should be
+// reachable by whichever network the asker has.
+func sendProbe(ctx context.Context, dmsgC *dmsg.Client, host cipher.PubKey, gid string, asker cipher.PubKey) (JoinResponseMsg, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req := JoinRequestMsg{
+		Kind:        frameKindJoinRequest,
+		GroupID:     gid,
+		RequesterPK: asker,
+		Probe:       true,
+		TS:          time.Now().UTC(),
+	}
+	body, err := encodeJoinRequest(req)
+	if err != nil {
+		return JoinResponseMsg{}, fmt.Errorf("group: probe: encode: %w", err)
+	}
+
+	skyAddr := appnet.Addr{Net: appnet.TypeSkynet, PubKey: host, Port: routing.Port(ProbePort)}
+	if conn, dialErr := dialSkynetRelay(ctx, skyAddr); dialErr == nil {
+		resp, rtErr := probeRoundTrip(conn, body)
+		_ = conn.Close() //nolint:errcheck
+		if rtErr == nil {
+			return resp, nil
+		}
+	}
+
+	if dmsgC == nil {
+		return JoinResponseMsg{}, ErrProbeUnreachable
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	stream, err := dmsgC.DialStream(dialCtx, dmsg.Addr{PK: host, Port: ProbePort})
+	if err != nil {
+		return JoinResponseMsg{}, fmt.Errorf("%w: %v", ErrProbeUnreachable, err)
+	}
+	defer stream.Close() //nolint:errcheck
+	resp, err := probeRoundTrip(stream, body)
+	if err != nil {
+		return JoinResponseMsg{}, err
+	}
+	return resp, nil
+}
+
+func probeRoundTrip(c net.Conn, body []byte) (JoinResponseMsg, error) {
+	deadline := time.Now().Add(probeTimeout)
+	if err := c.SetWriteDeadline(deadline); err != nil {
+		return JoinResponseMsg{}, fmt.Errorf("group: probe: set write deadline: %w", err)
+	}
+	if err := message.WriteFrame(c, body); err != nil {
+		return JoinResponseMsg{}, fmt.Errorf("group: probe: write: %w", err)
+	}
+	if err := c.SetReadDeadline(deadline); err != nil {
+		return JoinResponseMsg{}, fmt.Errorf("group: probe: set read deadline: %w", err)
+	}
+	frame, err := message.ReadFrame(c)
+	if err != nil {
+		// Wrapped as unreachable rather than as a decode failure: a host
+		// that takes the frame and says nothing is the fingerprint of a
+		// build that does not serve this port, and the caller's job is
+		// then to suggest an invite link, not to report a protocol bug.
+		return JoinResponseMsg{}, fmt.Errorf("%w: %v", ErrProbeUnreachable, err)
+	}
+	return decodeJoinResponse(frame)
+}
+
+// ---------------------------------------------------------------------
+// responder side
+// ---------------------------------------------------------------------
+
+// probeListener holds the per-Manager describe listeners.
+type probeListener struct {
+	mu     sync.Mutex
+	ctx    context.Context
+	cancel context.CancelFunc
+	dmsg   net.Listener
+	wg     sync.WaitGroup
+}
+
+// StartProbeListener binds the well-known describe port and serves it
+// until StopProbeListener (or Close) is called. Idempotent.
+//
+// Best effort by design, matching every other listener in this package:
+// a failed bind disables short-address joins for this run and logs it,
+// rather than failing group chat as a whole. The invite-link path is
+// unaffected, so the degradation is "addresses need a link instead", not
+// "groups are broken".
+func (m *Manager) StartProbeListener() {
+	m.probe.mu.Lock()
+	defer m.probe.mu.Unlock()
+	if m.probe.cancel != nil {
+		return // already running
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	m.probe.ctx, m.probe.cancel = ctx, cancel
+
+	if m.dmsgC != nil {
+		if lis, err := m.dmsgC.Listen(ProbePort); err != nil {
+			m.log.WithError(err).WithField("port", ProbePort).
+				Warn("group: probe: dmsg listen failed; short addresses will need an invite link")
+		} else {
+			m.probe.dmsg = lis
+			m.probe.wg.Add(1)
+			go m.acceptProbes(lis, "dmsg")
+		}
+	}
+	m.probe.wg.Add(1)
+	go m.bindProbeSkynet(ctx)
+}
+
+// StopProbeListener tears the describe listeners down. Idempotent.
+func (m *Manager) StopProbeListener() {
+	m.probe.mu.Lock()
+	cancel := m.probe.cancel
+	lis := m.probe.dmsg
+	m.probe.cancel, m.probe.ctx, m.probe.dmsg = nil, nil, nil
+	m.probe.mu.Unlock()
+	if cancel == nil {
+		return
+	}
+	cancel()
+	if lis != nil {
+		_ = lis.Close() //nolint:errcheck
+	}
+	m.probe.wg.Wait()
+}
+
+// probeCtx returns the live listener context, or nil once stopped.
+func (m *Manager) probeCtx() context.Context {
+	m.probe.mu.Lock()
+	defer m.probe.mu.Unlock()
+	return m.probe.ctx
+}
+
+func (m *Manager) acceptProbes(lis net.Listener, transport string) {
+	defer m.probe.wg.Done()
+	for {
+		c, err := lis.Accept()
+		if err != nil {
+			if ctx := m.probeCtx(); ctx == nil || ctx.Err() == nil {
+				m.log.WithError(err).WithField("transport", transport).
+					Debug("group: probe: accept ended")
+			}
+			return
+		}
+		m.probe.wg.Add(1)
+		go func(c net.Conn) {
+			defer m.probe.wg.Done()
+			defer c.Close() //nolint:errcheck
+			m.handleProbe(c)
+		}(c)
+	}
+}
+
+// bindProbeSkynet waits for the skynet networker to register, then binds
+// the same port there. Same deferred-bind reasoning as
+// Session.bindRelaySkynet: the visor brings dmsg up before the router,
+// and a listener started in between would otherwise never get a skynet
+// side at all.
+func (m *Manager) bindProbeSkynet(ctx context.Context) {
+	defer m.probe.wg.Done()
+	backoff := 200 * time.Millisecond
+	const maxBackoff = 5 * time.Second
+	for {
+		if _, err := appnet.ResolveNetworker(appnet.TypeSkynet); err == nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+			if backoff < maxBackoff {
+				backoff *= 2
+				if backoff > maxBackoff {
+					backoff = maxBackoff
+				}
+			}
+		}
+	}
+	lis, err := appnet.ListenContext(ctx, appnet.Addr{
+		Net:    appnet.TypeSkynet,
+		PubKey: m.myPK,
+		Port:   routing.Port(ProbePort),
+	})
+	if err != nil {
+		m.log.WithError(err).WithField("port", ProbePort).
+			Debug("group: probe: skynet listen failed")
+		return
+	}
+	go func() {
+		<-ctx.Done()
+		_ = lis.Close() //nolint:errcheck
+	}()
+	m.probe.wg.Add(1)
+	m.acceptProbes(lis, "skynet")
+}
+
+// handleProbe answers one describe request.
+//
+// Ordering matches handleJoinRequest for the same reasons: decode first
+// (a malformed frame costs nothing), then take the asker's identity from
+// the AUTHENTICATED transport rather than the envelope — the ban answer
+// below is about a specific PK, and answering it for a self-asserted one
+// would let anybody ask "is Alice banned from this group".
+//
+// A frame that is NOT a probe is refused rather than treated as a join.
+// This port makes no admission decisions at all, and quietly promoting a
+// stray join request into one here would put a second, unrate-limited
+// door on every group.
+func (m *Manager) handleProbe(c net.Conn) {
+	if err := c.SetReadDeadline(time.Now().Add(probeTimeout)); err != nil {
+		return
+	}
+	frame, err := message.ReadFrame(c)
+	if err != nil {
+		m.log.WithError(err).Debug("group: probe: read frame")
+		return
+	}
+	req, err := decodeJoinRequest(frame)
+	if err != nil {
+		m.log.WithError(err).Debug("group: probe: undecodable frame")
+		return
+	}
+	pk, err := requesterPK(c, req)
+	if err != nil {
+		m.log.WithError(err).Debug("group: probe: refusing unauthenticated request")
+		return
+	}
+	resp := m.describeGroup(req, pk)
+	body, err := encodeJoinResponse(resp)
+	if err != nil {
+		m.log.WithError(err).Debug("group: probe: encode response")
+		return
+	}
+	if err := c.SetWriteDeadline(time.Now().Add(probeTimeout)); err != nil {
+		return
+	}
+	if err := message.WriteFrame(c, body); err != nil {
+		m.log.WithError(err).Debug("group: probe: write response")
+	}
+}
+
+// describeGroup is the policy for what a describe answer reveals.
+//
+// Unavailable — not "denied" — for a group we do not hold, have left, or
+// have deleted, so the shape matches admissionHandler's: a requester
+// asking the wrong one of several admins learns to ask elsewhere rather
+// than treating the group as closed. It is also the answer that says the
+// least: "not from me" reveals nothing about whether the group exists.
+func (m *Manager) describeGroup(req JoinRequestMsg, asker cipher.PubKey) JoinResponseMsg {
+	if !req.Probe {
+		return JoinResponseMsg{
+			GroupID: req.GroupID,
+			Status:  JoinStatusUnavailable,
+			Reason:  "this port answers group describes only; join requests go to the group's own port",
+		}
+	}
+	r, ok, err := m.store.Get(req.GroupID)
+	if err != nil || !ok || r.Status.IsTerminal() {
+		return JoinResponseMsg{
+			GroupID: req.GroupID,
+			Status:  JoinStatusUnavailable,
+			Reason:  "this visor does not hold that group",
+		}
+	}
+	// Named before the ban check so a banned asker still sees WHICH group
+	// refused them. They hold its ID already, so this adds nothing they
+	// could not have learned by asking about any other group.
+	base := JoinResponseMsg{
+		GroupID:   r.ID,
+		Name:      r.Name,
+		GroupKind: r.Kind,
+		Policy:    r.JoinPolicy(),
+		Port:      r.Port,
+	}
+	if r.IsBanned(asker) {
+		base.Status = JoinStatusBanned
+		base.Reason = "this public key is banned from the group"
+		return base
+	}
+	base.Status = JoinStatusInfo
+	base.PoWBits = r.JoinPoWRequired()
+	base.ReadOnly = r.ReadOnly
+	m.log.WithField("id", r.ID).WithField("asker", asker.Hex()).
+		Debug("group: probe: described group")
+	return base
+}
+
+// truncate bounds untrusted display text at n bytes.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/pkg/skychat/group/probe.go
+++ b/pkg/skychat/group/probe.go
@@ -48,6 +48,7 @@ package group
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -504,6 +505,24 @@ func (m *Manager) handleProbe(c net.Conn) {
 	frame, err := message.ReadFrame(c)
 	if err != nil {
 		m.log.WithError(err).Debug("group: probe: read frame")
+		return
+	}
+	// Identity comes from the authenticated transport in both branches, so
+	// take it before dispatching: a catalog answer is a disclosure and
+	// should be attributable in the log even though it is not authorized
+	// per-asker.
+	asker, ok := remotePKOf(c)
+	if !ok {
+		m.log.Debug("group: probe: refusing request with no authenticated peer identity")
+		return
+	}
+	// Two questions arrive on this port: "describe this group ID" and
+	// "what do you publish?". They are separate frames rather than one
+	// with an empty field because they disclose different things — see
+	// catalog.go — and the discriminator keeps them from being confused.
+	var probeKind relayFrameProbe
+	if err := json.Unmarshal(frame, &probeKind); err == nil && probeKind.Kind == frameKindCatalogRequest {
+		m.handleCatalogRequest(c, asker)
 		return
 	}
 	req, err := decodeJoinRequest(frame)

--- a/pkg/skychat/group/probe_integration_test.go
+++ b/pkg/skychat/group/probe_integration_test.go
@@ -1,0 +1,304 @@
+// Package group pkg/skychat/group/probe_integration_test.go
+//
+// The dmsg-backed lane for the describe port: what a short
+// skychat://<pk>/<group-id> address can be turned into, and what it must
+// never be turned into.
+//
+// These need a real transport for the same reason the admission tests do
+// — the asker's identity comes from the authenticated stream, and the
+// ban answer is about that identity — plus one case that exists purely
+// to pin a security property: a real join request arriving on this port
+// must be refused, not honored, or every group would have a second door
+// that skips the proof-of-work and rate gates.
+//
+// Reuses the harness in manager_integration_test.go; skipped under
+// -short like every other dmsg-backed test in this package.
+package group
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/skychat/message"
+)
+
+// probeCtxFor is the per-call budget for a describe in tests. Generous
+// relative to probeTimeout so a slow CI box fails on the assertion
+// rather than on the clock.
+func probeCtxFor(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), 30*time.Second)
+}
+
+// The headline case: a group's kind, admission policy and feed port are
+// all learnable from its ID alone. Without this a short address is inert
+// — the port is random per group, so nothing can be dialed from it.
+func TestProbe_DescribesGroupFromIDAlone(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       Kind
+		wantPolicy JoinPolicy
+		wantMode   Mode
+	}{
+		{"public group", KindPublic, JoinOpen, ModePublic},
+		{"private group", KindPrivate, JoinApproval, ModePrivate},
+		{"channel", KindChannel, JoinOpen, ModePublic},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, b := newGroupEnv(t)
+			a.mgr.StartProbeListener()
+
+			rec, err := a.mgr.Create(tt.name, tt.kind, nil)
+			require.NoError(t, err, "Create")
+
+			ctx, cancel := probeCtxFor(t)
+			defer cancel()
+			d, err := b.mgr.ProbeGroup(ctx, a.pk, rec.ID)
+			require.NoError(t, err, "ProbeGroup")
+
+			require.Equal(t, rec.ID, d.ID)
+			require.Equal(t, a.pk, d.HostPK)
+			require.Equal(t, tt.name, d.Name, "the describe must carry the real name")
+			require.Equal(t, tt.kind, d.Kind)
+			require.Equal(t, tt.wantMode, d.Mode)
+			require.Equal(t, tt.wantPolicy, d.Policy)
+			require.Equal(t, rec.Port, d.Port, "the feed port is the whole reason to probe")
+			require.False(t, d.Banned)
+
+			// A describe grants nothing: the key stays behind the
+			// admission decision, and the roster is not named at all.
+			inv := d.Invite()
+			require.Empty(t, inv.AESKey, "a describe must never hand over the group key")
+			require.Empty(t, inv.Admins, "a describe must not repeat an unverified admin list")
+			require.Equal(t, tt.kind, inv.Kind)
+		})
+	}
+}
+
+// A public group is joinable from a short address with no invite link at
+// all — the point of the whole feature.
+func TestProbe_JoinByAddressAdmitsToPublicGroup(t *testing.T) {
+	a, b := newGroupEnv(t)
+	a.mgr.StartProbeListener()
+
+	rec, err := a.mgr.Create("open room", KindPublic, nil)
+	require.NoError(t, err, "Create")
+	require.NotContains(t, rec.Members, b.pk, "B must not be pre-admitted for this test to mean anything")
+
+	ctx, cancel := probeCtxFor(t)
+	defer cancel()
+	joined, err := b.mgr.JoinByAddress(ctx, a.pk, rec.ID)
+	require.NoError(t, err, "JoinByAddress with no invite link")
+	require.Equal(t, StatusActive, joined.Status)
+	require.Equal(t, RoleMember, joined.Role)
+	require.Equal(t, KindPublic, joined.Kind)
+
+	owner, ok, err := a.mgr.Get(rec.ID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Contains(t, owner.Members, b.pk, "join-by-address did not reach the roster")
+
+	// Idempotent, like the link-based join.
+	again, err := b.mgr.JoinByAddress(ctx, a.pk, rec.ID)
+	require.NoError(t, err, "second JoinByAddress")
+	require.Equal(t, joined.ID, again.ID)
+}
+
+// A private group must queue rather than admit, exactly as it does for a
+// link. The address form must not become a way around approval.
+func TestProbe_JoinByAddressQueuesOnPrivateGroup(t *testing.T) {
+	a, b := newGroupEnv(t)
+	a.mgr.StartProbeListener()
+
+	rec, err := a.mgr.Create("private room", KindPrivate, nil)
+	require.NoError(t, err, "Create")
+
+	ctx, cancel := probeCtxFor(t)
+	defer cancel()
+	joined, err := b.mgr.JoinByAddress(ctx, a.pk, rec.ID)
+	require.NoError(t, err, "JoinByAddress should queue, not fail")
+	require.Equal(t, StatusAwaitingApproval, joined.Status,
+		"an address must not admit to a group that requires approval")
+	require.Empty(t, joined.AESKey, "no key before approval")
+
+	reqs, err := a.mgr.PendingJoins(rec.ID)
+	require.NoError(t, err, "PendingJoins")
+	require.Len(t, reqs, 1, "the request should be on the admin's queue")
+	require.Equal(t, b.pk, reqs[0].PK)
+}
+
+// Joining a channel by address must produce a record that knows it is a
+// channel. Mode cannot express this — a channel and a public group are
+// both ModePublic — so a member whose Kind degraded would come up with
+// an unlocked composer and publish leaves every other member drops.
+func TestProbe_JoinByAddressKeepsChannelAdminsOnly(t *testing.T) {
+	a, b := newGroupEnv(t)
+	a.mgr.StartProbeListener()
+
+	rec, err := a.mgr.Create("announcements", KindChannel, nil)
+	require.NoError(t, err, "Create")
+
+	ctx, cancel := probeCtxFor(t)
+	defer cancel()
+	joined, err := b.mgr.JoinByAddress(ctx, a.pk, rec.ID)
+	require.NoError(t, err, "JoinByAddress")
+	require.Equal(t, KindChannel, joined.Kind, "the joined record must remember it is a channel")
+	require.True(t, joined.IsChannel())
+
+	canPost, reason := joined.CanPost(b.pk)
+	require.False(t, canPost, "a plain member must not be able to post to a channel")
+	require.Contains(t, reason, "channel")
+
+	owner, ok, err := a.mgr.Get(rec.ID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	ownerCanPost, _ := owner.CanPost(a.pk)
+	require.True(t, ownerCanPost, "the channel's admin must still be able to post")
+}
+
+// A banned asker gets a description carrying that fact rather than a
+// bare failure, so the UI can name the group and explain instead of
+// offering a join that is certain to be refused.
+func TestProbe_BannedAskerIsToldSo(t *testing.T) {
+	a, b := newGroupEnv(t)
+	a.mgr.StartProbeListener()
+
+	rec, err := a.mgr.Create("open room", KindPublic, nil)
+	require.NoError(t, err, "Create")
+	_, err = a.mgr.BanMember(rec.ID, b.pk)
+	require.NoError(t, err, "BanMember")
+
+	ctx, cancel := probeCtxFor(t)
+	defer cancel()
+	d, err := b.mgr.ProbeGroup(ctx, a.pk, rec.ID)
+	require.NoError(t, err, "a ban is a description, not a probe failure")
+	require.True(t, d.Banned)
+	require.Equal(t, rec.ID, d.ID)
+
+	// And the join it would have offered is refused.
+	_, err = b.mgr.JoinByAddress(ctx, a.pk, rec.ID)
+	require.ErrorIs(t, err, ErrJoinBanned)
+}
+
+// An ID the host does not hold is a wrong address, not an unreachable
+// one — a caller has to be able to say "no such group" rather than
+// "try again later".
+func TestProbe_UnknownGroupIsNotFound(t *testing.T) {
+	a, b := newGroupEnv(t)
+	a.mgr.StartProbeListener()
+
+	ctx, cancel := probeCtxFor(t)
+	defer cancel()
+	_, err := b.mgr.ProbeGroup(ctx, a.pk, uuid.NewString())
+	require.ErrorIs(t, err, ErrProbeNoSuchGroup)
+}
+
+// A group the host has LEFT must answer the same way as one it never
+// had: a terminal record is not something anyone can join.
+func TestProbe_LeftGroupIsNotFound(t *testing.T) {
+	a, b := newGroupEnv(t)
+	a.mgr.StartProbeListener()
+
+	rec, err := a.mgr.Create("closing down", KindPublic, nil)
+	require.NoError(t, err, "Create")
+	require.NoError(t, a.mgr.Delete(rec.ID), "Delete")
+
+	ctx, cancel := probeCtxFor(t)
+	defer cancel()
+	_, err = b.mgr.ProbeGroup(ctx, a.pk, rec.ID)
+	require.ErrorIs(t, err, ErrProbeNoSuchGroup)
+}
+
+// The security property this port exists under: it describes, and never
+// decides. A genuine join request delivered here must be refused, or the
+// describe port would be a second admission door — one that skips the
+// proof-of-work and rate-limit gates guarding the real one.
+func TestProbe_PortRefusesRealJoinRequests(t *testing.T) {
+	a, b := newGroupEnv(t)
+	a.mgr.StartProbeListener()
+
+	rec, err := a.mgr.Create("open room", KindPublic, nil)
+	require.NoError(t, err, "Create")
+
+	// A well-formed join request — Probe unset — straight at the
+	// describe port.
+	req := NewJoinRequest(rec.ID, b.pk, "let me in", 0)
+	body, err := encodeJoinRequest(req)
+	require.NoError(t, err, "encodeJoinRequest")
+
+	ctx, cancel := probeCtxFor(t)
+	defer cancel()
+	stream, err := b.dmsgC.DialStream(ctx, dmsg.Addr{PK: a.pk, Port: ProbePort})
+	require.NoError(t, err, "dial describe port")
+	defer stream.Close() //nolint:errcheck
+
+	require.NoError(t, stream.SetWriteDeadline(time.Now().Add(30*time.Second)))
+	require.NoError(t, message.WriteFrame(stream, body), "write join frame")
+	require.NoError(t, stream.SetReadDeadline(time.Now().Add(30*time.Second)))
+	frame, err := message.ReadFrame(stream)
+	require.NoError(t, err, "read answer")
+	resp, err := decodeJoinResponse(frame)
+	require.NoError(t, err, "decode answer")
+
+	require.Equal(t, JoinStatusUnavailable, resp.Status,
+		"the describe port must refuse to decide a join")
+	require.NotEqual(t, JoinStatusAdmitted, resp.Status)
+
+	// And nothing was admitted behind our back.
+	owner, ok, err := a.mgr.Get(rec.ID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotContains(t, owner.Members, b.pk, "the describe port admitted a member")
+	reqs, err := a.mgr.PendingJoins(rec.ID)
+	require.NoError(t, err)
+	require.Empty(t, reqs, "the describe port queued a request")
+}
+
+// Probing a group we already hold must not depend on the host being
+// reachable: the store already knows everything the answer contains.
+func TestProbe_LocalRecordAnswersWithoutHost(t *testing.T) {
+	a, b := newGroupEnv(t)
+	a.mgr.StartProbeListener()
+
+	rec, err := a.mgr.Create("open room", KindPublic, nil)
+	require.NoError(t, err, "Create")
+
+	ctx, cancel := probeCtxFor(t)
+	defer cancel()
+	_, err = b.mgr.JoinByAddress(ctx, a.pk, rec.ID)
+	require.NoError(t, err, "JoinByAddress")
+
+	// Take the host's describe listener away; B is a member and should
+	// still be able to describe its own group.
+	a.mgr.StopProbeListener()
+
+	d, err := b.mgr.ProbeGroup(ctx, a.pk, rec.ID)
+	require.NoError(t, err, "a member must describe its own group locally")
+	require.Equal(t, rec.ID, d.ID)
+	require.Equal(t, KindPublic, d.Kind)
+	require.Equal(t, rec.Port, d.Port)
+}
+
+// A host that does not serve the describe port at all — an older build —
+// must surface as retryable-unreachable, which is what tells a UI to
+// suggest an invite link instead of claiming the group does not exist.
+func TestProbe_HostWithoutListenerIsUnreachable(t *testing.T) {
+	a, b := newGroupEnv(t)
+	// Deliberately no StartProbeListener on A.
+
+	rec, err := a.mgr.Create("open room", KindPublic, nil)
+	require.NoError(t, err, "Create")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, err = b.mgr.ProbeGroup(ctx, a.pk, rec.ID)
+	require.Error(t, err, "a host with no describe listener cannot answer")
+	require.NotErrorIs(t, err, ErrProbeNoSuchGroup,
+		"an unreachable host must not be reported as a wrong address")
+}

--- a/pkg/skychat/group/session.go
+++ b/pkg/skychat/group/session.go
@@ -1774,6 +1774,20 @@ func (s *Session) shouldMirrorLeaves() bool {
 // the group stays readable when no admin is up. See defaultPeerFanout for
 // why the second term exists and why it is bounded.
 //
+// A CHANNEL collapses all of that to "follow the admins", for both roles:
+//
+//	desired = { pk in r.Admins : pk != myPK }
+//
+// A non-admin in a channel cannot publish, so a subscription to its feed
+// can never carry a message — and PeerBackfillEnabled is false for a
+// channel, so it carries no mirrored history either. Following members
+// there is not a small waste but the difference between a channel that
+// works and one that does not: under the group rule an admin of a
+// 10,000-subscriber channel would open 10,000 CXO subscriptions to feeds
+// that are guaranteed to stay empty. Subscriber cost stays O(admins)
+// regardless of how large the audience gets, which is the only shape a
+// broadcast medium can have.
+//
 // The legacy s.sub subscription to OwnerPK is independent of this set;
 // non-admins always have the owner covered via s.sub plus (transitively)
 // via owner-as-admin membership here.
@@ -1781,6 +1795,15 @@ func (s *Session) shouldMirrorLeaves() bool {
 // Pure function: no Session state, no CXO. Used at openMember and
 // SetAdminRoster so the rule has one source of truth.
 func desiredPeerSubsForRole(r Record, myPK cipher.PubKey, fanout int) map[cipher.PubKey]struct{} {
+	if r.IsChannel() {
+		out := make(map[cipher.PubKey]struct{}, len(r.Admins)+1)
+		for _, pk := range r.Members {
+			if pk != myPK && r.IsAdmin(pk) {
+				out[pk] = struct{}{}
+			}
+		}
+		return out
+	}
 	iAmAdmin := r.IsAdmin(myPK)
 	// The group's own setting is the ceiling. An admin turning backfill off
 	// means "members must not carry each other's history", and a member

--- a/pkg/skychat/group/store_bbolt.go
+++ b/pkg/skychat/group/store_bbolt.go
@@ -189,10 +189,17 @@ func (s *Store) Put(r Record) error {
 		b := tx.Bucket([]byte(groupsBucket))
 		if raw := b.Get([]byte(r.ID)); raw != nil {
 			var prev Record
-			// Watermarks are not sealed, so the raw JSON is enough here and
-			// a record we cannot open still contributes its watermarks.
+			// Watermarks and Kind are not sealed, so the raw JSON is enough
+			// here and a record we cannot open still contributes its
+			// watermarks.
 			if err := json.Unmarshal(raw, &prev); err == nil {
 				r.MutationSeen = mergeWatermarks(prev.MutationSeen, r.MutationSeen)
+				// Enforced here rather than in each caller because this is
+				// the one chokepoint every write goes through — see
+				// checkKindStable for why a channel must stay one.
+				if err := checkKindStable(r.ID, prev.Kind, r.Kind); err != nil {
+					return err
+				}
 			}
 		}
 		body, err := s.encodeRecord(r)

--- a/pkg/skychat/group/store_memory.go
+++ b/pkg/skychat/group/store_memory.go
@@ -89,9 +89,14 @@ func (s *Store) Put(r Record) error {
 	defer s.mu.Unlock()
 	if raw, ok := s.kvs[r.ID]; ok {
 		var prev Record
-		// Watermarks are not sealed, so the raw JSON is enough here.
+		// Watermarks and Kind are not sealed, so the raw JSON is enough here.
 		if err := json.Unmarshal(raw, &prev); err == nil {
 			r.MutationSeen = mergeWatermarks(prev.MutationSeen, r.MutationSeen)
+			// Same invariant as the bbolt backend — the two must not
+			// disagree about what a group is allowed to become.
+			if err := checkKindStable(r.ID, prev.Kind, r.Kind); err != nil {
+				return err
+			}
 		}
 	}
 	body, err := s.encodeRecord(r)

--- a/pkg/skychat/history/history.go
+++ b/pkg/skychat/history/history.go
@@ -133,6 +133,27 @@ type Store interface {
 	// group, newest last. If limit <= 0, returns all.
 	ListByGroup(groupID string, limit int) ([]GroupMessage, error)
 
+	// ListGroupBefore returns up to limit messages STRICTLY OLDER than
+	// before, newest last — the backward page cursor.
+	//
+	// This is what makes a large room readable at all. ListByGroup can
+	// only ever hand back the newest N, so without a way to ask for what
+	// came before them a client's options were "the tail" or "everything":
+	// a channel with fifty thousand posts had to ship all of them to a
+	// joiner before showing anything. With this, a joiner takes the newest
+	// chunk immediately and walks backwards as it reads.
+	//
+	// A zero `before` means "from the newest", so the first page is just
+	// ListGroupBefore(id, time.Time{}, n) and a caller needs no special
+	// case to start. The bound is exclusive for the same reason
+	// ListGroupSince's is: `before` is the oldest message the caller
+	// already holds, and returning it again would duplicate a row on every
+	// page boundary.
+	//
+	// Ordering matches ListByGroup (newest last) so a page can be
+	// prepended to what the caller has without re-sorting.
+	ListGroupBefore(groupID string, before time.Time, limit int) ([]GroupMessage, error)
+
 	// ListGroupSince returns every stored group message whose Timestamp
 	// is strictly after `since`, oldest first. Returns nil for an
 	// unknown group or for a group with no messages newer than `since`.

--- a/pkg/skychat/history/list_group_before_test.go
+++ b/pkg/skychat/history/list_group_before_test.go
@@ -1,0 +1,228 @@
+//go:build !js
+// +build !js
+
+// Package history pkg/skychat/history/list_group_before_test.go
+// the backward page cursor, across both backends.
+//
+// Paging is the kind of thing that looks right and is off by one: the
+// boundary is exclusive, the page order is newest-last while the walk runs
+// newest-first, and a zero cursor has to mean "the newest page" rather than
+// "the beginning of time". Each of those gets its own case, and the whole
+// table runs against bolt and mem through the same Store interface so the
+// two cannot drift.
+//
+// Carries the !js tag because BoltStore does.
+package history
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// seedGroup writes n messages one second apart and returns their
+// timestamps, oldest first.
+func seedGroup(t *testing.T, st Store, groupID string, n int) []time.Time {
+	t.Helper()
+	base := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	out := make([]time.Time, 0, n)
+	for i := 0; i < n; i++ {
+		ts := base.Add(time.Duration(i) * time.Second)
+		err := st.AppendGroup(GroupMessage{
+			GroupID:   groupID,
+			SenderPK:  "0248c948affc71f4dd6b0b6b47e5d5f1e0e13bc39d3f5d5f4e1f3d3a6e6c0b2b7f",
+			Text:      fmt.Sprintf("msg-%02d", i),
+			Timestamp: ts,
+		})
+		if err != nil {
+			t.Fatalf("AppendGroup %d: %v", i, err)
+		}
+		out = append(out, ts)
+	}
+	return out
+}
+
+func pageTexts(msgs []GroupMessage) []string {
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, m.Text)
+	}
+	return out
+}
+
+func eq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func forEachBackend(t *testing.T, fn func(t *testing.T, st Store)) {
+	t.Helper()
+	t.Run("bolt", func(t *testing.T) { fn(t, newTestStore(t, DefaultLimits())) })
+	t.Run("mem", func(t *testing.T) { fn(t, newTestMemStore(t, DefaultLimits())) })
+}
+
+// A zero cursor must mean "the newest page", so a caller's first request
+// needs no special case. If it meant "from the beginning" instead, a joiner
+// to a large channel would be handed the oldest messages first — the exact
+// thing chunking exists to avoid.
+func TestListGroupBefore_ZeroCursorIsNewestPage(t *testing.T) {
+	forEachBackend(t, func(t *testing.T, st Store) {
+		seedGroup(t, st, "g1", 10)
+		got, err := st.ListGroupBefore("g1", time.Time{}, 3)
+		if err != nil {
+			t.Fatalf("ListGroupBefore: %v", err)
+		}
+		want := []string{"msg-07", "msg-08", "msg-09"}
+		if !eq(pageTexts(got), want) {
+			t.Errorf("got %v, want %v", pageTexts(got), want)
+		}
+		// And it agrees with ListByGroup, which is the same question.
+		byGroup, err := st.ListByGroup("g1", 3)
+		if err != nil {
+			t.Fatalf("ListByGroup: %v", err)
+		}
+		if !eq(pageTexts(got), pageTexts(byGroup)) {
+			t.Errorf("zero cursor %v != ListByGroup %v", pageTexts(got), pageTexts(byGroup))
+		}
+	})
+}
+
+// Walking backwards page by page must reconstruct the whole group exactly
+// once, in order, with no duplicate at any boundary and nothing skipped.
+// This is the property the UI depends on.
+func TestListGroupBefore_PagesCoverEverythingOnce(t *testing.T) {
+	forEachBackend(t, func(t *testing.T, st Store) {
+		const total, page = 10, 3
+		seedGroup(t, st, "g1", total)
+
+		var assembled []string
+		cursor := time.Time{}
+		for i := 0; i < total; i++ { // bounded: cannot loop forever
+			got, err := st.ListGroupBefore("g1", cursor, page)
+			if err != nil {
+				t.Fatalf("page %d: %v", i, err)
+			}
+			if len(got) == 0 {
+				break
+			}
+			// Pages arrive newest-last, so each one prepends.
+			assembled = append(pageTexts(got), assembled...)
+			cursor = got[0].Timestamp
+		}
+		want := make([]string, 0, total)
+		for i := 0; i < total; i++ {
+			want = append(want, fmt.Sprintf("msg-%02d", i))
+		}
+		if !eq(assembled, want) {
+			t.Errorf("assembled %v, want %v", assembled, want)
+		}
+	})
+}
+
+// The bound is exclusive: the cursor message is the oldest the caller
+// already holds, so returning it again would duplicate a row on every page
+// boundary.
+func TestListGroupBefore_CursorIsExclusive(t *testing.T) {
+	forEachBackend(t, func(t *testing.T, st Store) {
+		ts := seedGroup(t, st, "g1", 5)
+		got, err := st.ListGroupBefore("g1", ts[2], 10)
+		if err != nil {
+			t.Fatalf("ListGroupBefore: %v", err)
+		}
+		want := []string{"msg-00", "msg-01"}
+		if !eq(pageTexts(got), want) {
+			t.Errorf("got %v, want %v (msg-02 is the cursor and must be excluded)", pageTexts(got), want)
+		}
+	})
+}
+
+// Reaching the start of history returns empty rather than repeating the
+// first page — that is what stops the UI's scroll-back loop.
+func TestListGroupBefore_ExhaustsCleanly(t *testing.T) {
+	forEachBackend(t, func(t *testing.T, st Store) {
+		ts := seedGroup(t, st, "g1", 3)
+		got, err := st.ListGroupBefore("g1", ts[0], 10)
+		if err != nil {
+			t.Fatalf("ListGroupBefore: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected nothing older than the first message, got %v", pageTexts(got))
+		}
+	})
+}
+
+// A cursor newer than everything stored is the "before is in the future"
+// case — it must return the newest page, not nothing. Reachable whenever a
+// client's clock runs ahead of the writer's.
+func TestListGroupBefore_FutureCursorReturnsNewest(t *testing.T) {
+	forEachBackend(t, func(t *testing.T, st Store) {
+		seedGroup(t, st, "g1", 5)
+		got, err := st.ListGroupBefore("g1", time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC), 2)
+		if err != nil {
+			t.Fatalf("ListGroupBefore: %v", err)
+		}
+		want := []string{"msg-03", "msg-04"}
+		if !eq(pageTexts(got), want) {
+			t.Errorf("got %v, want %v", pageTexts(got), want)
+		}
+	})
+}
+
+// An unknown group and a zero group id are empty answers, not errors: the
+// UI asks before it knows whether anything was ever persisted.
+func TestListGroupBefore_UnknownGroup(t *testing.T) {
+	forEachBackend(t, func(t *testing.T, st Store) {
+		for _, id := range []string{"", "no-such-group"} {
+			got, err := st.ListGroupBefore(id, time.Time{}, 10)
+			if err != nil {
+				t.Errorf("ListGroupBefore(%q): unexpected error %v", id, err)
+			}
+			if len(got) != 0 {
+				t.Errorf("ListGroupBefore(%q): got %v, want empty", id, pageTexts(got))
+			}
+		}
+	})
+}
+
+// A non-positive limit means "no cap" — same convention as ListByGroup, so
+// a caller can ask for a whole small group in one request.
+func TestListGroupBefore_ZeroLimitReturnsAll(t *testing.T) {
+	forEachBackend(t, func(t *testing.T, st Store) {
+		seedGroup(t, st, "g1", 4)
+		got, err := st.ListGroupBefore("g1", time.Time{}, 0)
+		if err != nil {
+			t.Fatalf("ListGroupBefore: %v", err)
+		}
+		want := []string{"msg-00", "msg-01", "msg-02", "msg-03"}
+		if !eq(pageTexts(got), want) {
+			t.Errorf("got %v, want %v", pageTexts(got), want)
+		}
+	})
+}
+
+// Pages must not leak across groups.
+func TestListGroupBefore_ScopedToGroup(t *testing.T) {
+	forEachBackend(t, func(t *testing.T, st Store) {
+		seedGroup(t, st, "g1", 3)
+		seedGroup(t, st, "g2", 3)
+		got, err := st.ListGroupBefore("g1", time.Time{}, 10)
+		if err != nil {
+			t.Fatalf("ListGroupBefore: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("got %d messages, want 3", len(got))
+		}
+		for _, m := range got {
+			if m.GroupID != "g1" {
+				t.Errorf("page leaked a %q message into g1", m.GroupID)
+			}
+		}
+	})
+}

--- a/pkg/skychat/history/store_bolt.go
+++ b/pkg/skychat/history/store_bolt.go
@@ -391,6 +391,63 @@ func (s *BoltStore) ListByGroup(groupID string, limit int) ([]GroupMessage, erro
 	return msgs, err
 }
 
+// ListGroupBefore implements Store. Mirror of ListGroupSince in the other
+// direction: Seek to before's tsKey and walk BACKWARDS, so the cost is
+// O(limit) rather than O(all-messages-in-group) however deep into a large
+// channel's backlog the caller has read.
+//
+// The boundary is exclusive. cursor.Seek lands on the first key >= the
+// target, so one Prev() from there is the newest key strictly older than
+// before — and when Seek runs off the end (before is newer than every
+// stored message) the newest key is simply Last(). Both cases collapse to
+// "start from the newest thing older than the cursor".
+func (s *BoltStore) ListGroupBefore(groupID string, before time.Time, limit int) ([]GroupMessage, error) {
+	if groupID == "" {
+		return nil, nil
+	}
+	var msgs []GroupMessage
+	err := s.db.View(func(tx *bolt.Tx) error {
+		root := tx.Bucket([]byte(groupsBucket))
+		gBkt := root.Bucket([]byte(groupID))
+		if gBkt == nil {
+			return nil
+		}
+		cur := gBkt.Cursor()
+		var k, v []byte
+		if before.IsZero() || before.UnixNano() <= 0 {
+			// "From the newest" — the first page. Also the guard the
+			// forward walk documents: uint64(negative nano) wraps to a huge
+			// value whose tsKey sorts after every real key, which would
+			// silently return nothing.
+			k, v = cur.Last()
+		} else {
+			k, v = cur.Seek(tsKey(before))
+			if k == nil {
+				k, v = cur.Last()
+			} else {
+				k, v = cur.Prev()
+			}
+		}
+		for ; k != nil; k, v = cur.Prev() {
+			var m GroupMessage
+			if err := json.Unmarshal(v, &m); err != nil {
+				continue
+			}
+			msgs = append(msgs, m)
+			if limit > 0 && len(msgs) >= limit {
+				break
+			}
+		}
+		// Collected newest-first by the backward walk; flip so newest is
+		// last, matching ListByGroup.
+		for i, j := 0, len(msgs)-1; i < j; i, j = i+1, j-1 {
+			msgs[i], msgs[j] = msgs[j], msgs[i]
+		}
+		return nil
+	})
+	return msgs, err
+}
+
 // ListGroupSince implements Store. The bolt bucket is keyed by
 // tsKey(Timestamp), so we Seek to since's tsKey and walk forward —
 // O(messages-since) instead of O(all-messages-in-group). Returns

--- a/pkg/skychat/history/store_bolt.go
+++ b/pkg/skychat/history/store_bolt.go
@@ -421,7 +421,7 @@ func (s *BoltStore) ListGroupBefore(groupID string, before time.Time, limit int)
 			// silently return nothing.
 			k, v = cur.Last()
 		} else {
-			k, v = cur.Seek(tsKey(before))
+			k, v = cur.Seek(tsKey(before)) //nolint
 			if k == nil {
 				k, v = cur.Last()
 			} else {

--- a/pkg/skychat/history/store_mem.go
+++ b/pkg/skychat/history/store_mem.go
@@ -262,6 +262,38 @@ func (s *MemStore) ListByGroup(groupID string, limit int) ([]GroupMessage, error
 	return tailCopyGroup(s.byGroup[groupID], limit), nil
 }
 
+// ListGroupBefore implements Store. Returns up to limit messages strictly
+// older than `before`, newest last — matching BoltStore's exclusive-cursor
+// semantics so the two backends page identically.
+//
+// The slice is already in insertion (chronological) order, so this is a
+// filter plus a tail rather than a cursor walk. The mem store is bounded
+// by PerPeerCap anyway, which is why the linear scan the bolt backend
+// avoids is fine here.
+func (s *MemStore) ListGroupBefore(groupID string, before time.Time, limit int) ([]GroupMessage, error) {
+	if groupID == "" {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	src := s.byGroup[groupID]
+	if len(src) == 0 {
+		return nil, nil
+	}
+	// A zero cursor means "from the newest", so the whole slice is in
+	// scope and this degenerates to ListByGroup.
+	if before.IsZero() || before.UnixNano() <= 0 {
+		return tailCopyGroup(src, limit), nil
+	}
+	var older []GroupMessage
+	for _, m := range src {
+		if m.Timestamp.Before(before) {
+			older = append(older, m)
+		}
+	}
+	return tailCopyGroup(older, limit), nil
+}
+
 // ListGroupSince implements Store. Returns messages strictly newer than
 // `since`, oldest first — matching BoltStore's exclusive-cursor semantics.
 func (s *MemStore) ListGroupSince(groupID string, since time.Time) ([]GroupMessage, error) {

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -129,6 +129,30 @@ const (
 	// exact port is confirmed in the signaling handshake so it can be varied.
 	SkychatVoiceMediaPort uint16 = 63
 
+	// SkychatGroupProbePort is the well-known dmsg port a visor answers
+	// group DESCRIBE requests on: "what is the group with this ID — a group
+	// or a channel, open or approval-gated, on which feed port?".
+	//
+	// It exists because a group's own admission listener sits at
+	// Record.Port+1, where Record.Port is allocated at random per group
+	// (see group.defaultPortAlloc) and is therefore unknowable to anyone
+	// who does not already hold an invite link. That made the short
+	// skychat://<pk>/<group-id> address unusable on its own — the whole
+	// point of which is to be short enough to scan or read aloud, which an
+	// invite link carrying port, mode, admin list and PoW price is not.
+	// One fixed port per visor closes that gap: dial it with a group ID and
+	// the answer carries everything a join needs.
+	//
+	// Describe ONLY. Admission decisions stay on the per-group listener,
+	// which the joiner can reach once the probe has told it the port — so
+	// this port never mutates state and a flood of probes costs a store
+	// read apiece.
+	//
+	// Deliberately not a small well-known number: 49–64 are fully assigned
+	// and the pair/group feed allocators own [10000, 65000). Same reasoning
+	// as SkydexMarketPort picking 8050.
+	SkychatGroupProbePort uint16 = 8060
+
 	// SkychatFilePort is the port skychat FILE TRANSFER listens on. A sender
 	// dials it (over dmsg OR skynet — same port on both, like voice) and streams
 	// one offer header + chunked, sha256-verified bytes. Files are conversation

--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -276,23 +276,32 @@ func (c *httpClient) initHTTPClient(httpC, httpCV6 *http.Client) {
 	close(c.ready)
 }
 
-// fetchPublicUDPAddr does a single unauthenticated GET /health using
-// the underlying HTTP client (which carries the dmsghttp transport)
-// and returns the udp_address advertised by the AR. Returns "" on any
-// failure — the caller treats that as "SUDPH not available via this AR".
+// fetchPublicUDPAddr does an unauthenticated GET /health using the underlying
+// HTTP client (which carries the dmsghttp transport) and returns the UDP address
+// advertised by the AR. Transient transport errors are retried because visor
+// restarts can briefly race DMSG server reconnection. Valid responses are not
+// retried: an AR without udp_address intentionally does not support SUDPH.
 func (c *httpClient) fetchPublicUDPAddr(httpC *http.Client) string {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.remoteHTTPAddr+"/health", nil)
-	if err != nil {
-		c.log.WithError(err).Debug("Failed to build /health request for udp_address lookup")
-		return ""
-	}
-	resp, err := httpC.Do(req)
-	if err != nil {
-		c.log.WithError(err).Debug("Failed to GET /health for udp_address lookup")
-		return ""
+	var resp *http.Response
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.remoteHTTPAddr+"/health", nil)
+		if err != nil {
+			c.log.WithError(err).Debug("Failed to build /health request for udp_address lookup")
+			return ""
+		}
+		resp, err = httpC.Do(req)
+		if err == nil {
+			break
+		}
+		c.log.WithError(err).Debug("Failed to GET /health for udp_address lookup; retrying")
+		select {
+		case <-ctx.Done():
+			return ""
+		case <-time.After(250 * time.Millisecond):
+		}
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {

--- a/pkg/transport/network/addrresolver/client_extra_test.go
+++ b/pkg/transport/network/addrresolver/client_extra_test.go
@@ -241,6 +241,33 @@ func TestFetchPublicUDPAddr(t *testing.T) {
 		assert.Empty(t, c.fetchPublicUDPAddr(&http.Client{}))
 	})
 
+	t.Run("transient transport error is retried", func(t *testing.T) {
+		attempts := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attempts++
+			if attempts == 1 {
+				hijacker, ok := w.(http.Hijacker)
+				if !ok {
+					t.Error("response writer does not support hijacking")
+					return
+				}
+				conn, _, err := hijacker.Hijack()
+				if err != nil {
+					t.Errorf("hijack connection: %v", err)
+					return
+				}
+				_ = conn.Close()
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"udp_address": "5.6.7.8:30178"}) //nolint
+		}))
+		defer srv.Close()
+
+		c := &httpClient{log: logging.MustGetLogger("ar-udp"), remoteHTTPAddr: srv.URL}
+		assert.Equal(t, "5.6.7.8:30178", c.fetchPublicUDPAddr(&http.Client{}))
+		assert.GreaterOrEqual(t, attempts, 2)
+	})
+
 	t.Run("non-OK status yields empty", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			http.Error(w, "no", http.StatusInternalServerError)

--- a/pkg/transport/network/addrresolver/client_extra_test.go
+++ b/pkg/transport/network/addrresolver/client_extra_test.go
@@ -256,7 +256,7 @@ func TestFetchPublicUDPAddr(t *testing.T) {
 					t.Errorf("hijack connection: %v", err)
 					return
 				}
-				_ = conn.Close()
+				_ = conn.Close() //nolint
 				return
 			}
 			_ = json.NewEncoder(w).Encode(map[string]string{"udp_address": "5.6.7.8:30178"}) //nolint

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -274,6 +274,7 @@ type API interface {
 	// allowlists. See pkg/visor/group.go.
 	GroupCreate(args GroupCreateArgs) (GroupInfo, string, error)
 	GroupJoin(args GroupJoinArgs) (GroupInfo, error)
+	GroupResolve(args GroupResolveArgs) (GroupResolveResult, error)
 	GroupAskAgain(id string) (GroupInfo, error)
 	GroupList() ([]GroupInfo, error)
 	GroupGet(id string) (GroupInfo, error)

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -289,6 +289,8 @@ type API interface {
 	GroupMuteMember(id string, pk cipher.PubKey) (GroupInfo, error)
 	GroupUnmuteMember(id string, pk cipher.PubKey) (GroupInfo, error)
 	GroupSetReadOnly(id string, readOnly bool) (GroupInfo, error)
+	GroupSetListed(id string, listed bool) (GroupInfo, error)
+	GroupCatalog(host cipher.PubKey) ([]GroupCatalogEntry, bool, error)
 	GroupPromoteAdmin(id string, pk cipher.PubKey) (GroupInfo, error)
 	GroupDemoteAdmin(id string, pk cipher.PubKey) (GroupInfo, error)
 	GroupRotateKey(id string) (GroupInfo, error)
@@ -301,6 +303,7 @@ type API interface {
 	GroupDelete(id string) error
 	GroupLeave(id string) error
 	GroupHistory(groupID string, limit int) ([]GroupMessage, error)
+	GroupHistoryPage(args GroupHistoryPageArgs) ([]GroupMessage, error)
 	GroupHistoryGroups() ([]string, error)
 
 	// Skychat 1:1 voice calls (pkg/skychat/call).

--- a/pkg/visor/cxo_user_feeds.go
+++ b/pkg/visor/cxo_user_feeds.go
@@ -67,6 +67,7 @@ func reservedDmsgPorts() map[uint16]string {
 		DmsgForwardProxyPort:                 "dmsg-forward-proxy",
 		skyenv.DmsgDHTPort:                   "dht",
 		skyenv.DmsgAwaitSetupPort:            "await-setup",
+		skyenv.SkychatGroupProbePort:         "skychat-group-probe",
 	}
 }
 

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -21,11 +21,13 @@ package visor
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	skychataddr "github.com/skycoin/skywire/pkg/skychat/address"
 	skychatgroup "github.com/skycoin/skywire/pkg/skychat/group"
 )
 
@@ -245,14 +247,16 @@ type GroupMessage struct {
 type GroupCreateArgs struct {
 	Name string `json:"name"`
 
-	// Kind is the group type: "public" (open admission, plaintext) or
-	// "private" (admin-approved admission, encrypted). Preferred over
-	// Mode.
+	// Kind is the group type: "public" (open admission, plaintext),
+	// "private" (admin-approved admission, encrypted) or "channel"
+	// (open admission, plaintext, only admins may post). Preferred
+	// over Mode.
 	Kind skychatgroup.Kind `json:"kind,omitempty"`
 
 	// Mode is the legacy field, kept so an older RPC client keeps
 	// working: it carried the same two values and mapped onto the same
-	// two group types. Used only when Kind is empty.
+	// two group types. Used only when Kind is empty, and it cannot name
+	// a channel — public and channel share ModePublic.
 	Mode skychatgroup.Mode `json:"mode,omitempty"`
 
 	InitialMembers []cipher.PubKey `json:"initial_members,omitempty"`
@@ -277,9 +281,89 @@ func (a GroupCreateArgs) kind() skychatgroup.Kind {
 	return skychatgroup.KindPublic
 }
 
-// GroupJoinArgs is the RPC input for GroupJoin.
+// GroupJoinArgs is the RPC input for GroupJoin. Exactly one of the two
+// fields is used, Invite first.
 type GroupJoinArgs struct {
+	// Invite is a skychat:invite:<base64url> link. Self-contained: it
+	// works even while the group's host is offline, because it carries
+	// the port and mode inline.
 	Invite string `json:"invite"`
+
+	// Address is the short form — skychat://<host-pk>/<group-id>. Not
+	// self-contained: the host is asked what the group is (see
+	// group.Manager.JoinByAddress) before the ordinary join runs, so
+	// this needs the host reachable and an invite does not.
+	//
+	// Both are accepted because they trade against each other rather
+	// than one superseding the other: an address is short enough to scan
+	// or read aloud and stays correct as the group changes, a link keeps
+	// working when nobody is home.
+	Address string `json:"address,omitempty"`
+}
+
+// GroupResolveArgs is the RPC input for GroupResolve.
+type GroupResolveArgs struct {
+	// Address is any spelling the address parser accepts — a bare public
+	// key, skychat://<pk>, skychat://<pk>/<group-id> — or a
+	// skychat:invite: link, which is answered from the link itself
+	// without a round trip.
+	Address string `json:"address"`
+}
+
+// GroupResolveResult describes what an address points at, so a UI can
+// offer the one right action instead of making the user pick.
+//
+// The zero-ish DM case is deliberately cheap: a bare public key needs no
+// network at all to classify, because a key that names a person and a key
+// that hosts a channel are the same 66 characters — only the presence of
+// a group ID distinguishes them, and that is in the address.
+type GroupResolveResult struct {
+	// Target is "dm" or "group".
+	Target string `json:"target"`
+
+	// PK is the peer for a DM, the host for a group address.
+	PK cipher.PubKey `json:"pk"`
+
+	// Address is the canonical skychat:// form of what was resolved,
+	// suitable for display, copying, and QR encoding.
+	Address string `json:"address"`
+
+	// Group is populated for a group address: what the group is and what
+	// joining it will involve. Nil for a DM.
+	Group *GroupDescriptor `json:"group,omitempty"`
+
+	// Joined reports that this visor is already an active member, so the
+	// caller should open the group rather than offer to join it.
+	Joined bool `json:"joined,omitempty"`
+
+	// Status is this visor's own record status for the group when one
+	// exists — "awaiting_approval" and "denied" in particular, which are
+	// the difference between offering "Send request" and explaining that
+	// one was already refused.
+	Status skychatgroup.Status `json:"status,omitempty"`
+
+	// Invite carries the link back when the input WAS a link, so a
+	// caller that resolved one can hand it straight to GroupJoin without
+	// re-parsing.
+	Invite string `json:"invite,omitempty"`
+}
+
+// GroupDescriptor is the RPC-facing shape of group.GroupDescriptor.
+// Re-declared rather than aliased so the RPC surface can carry
+// display-oriented additions (a rendered kind label, later a price) that
+// the protocol type has no business knowing about.
+type GroupDescriptor struct {
+	ID        string                  `json:"id"`
+	HostPK    cipher.PubKey           `json:"host_pk"`
+	Name      string                  `json:"name"`
+	Kind      skychatgroup.Kind       `json:"kind"`
+	Mode      skychatgroup.Mode       `json:"mode"`
+	Policy    skychatgroup.JoinPolicy `json:"policy"`
+	Port      uint16                  `json:"port"`
+	PoWBits   uint8                   `json:"pow_bits,omitempty"`
+	ReadOnly  bool                    `json:"read_only,omitempty"`
+	PriceHint string                  `json:"price_hint,omitempty"`
+	Banned    bool                    `json:"banned,omitempty"`
 }
 
 // GroupSendArgs is the RPC input for GroupSend.
@@ -359,22 +443,158 @@ func (v *Visor) GroupCreate(args GroupCreateArgs) (GroupInfo, string, error) {
 	return toInfo(r), link, nil
 }
 
-// GroupJoin accepts an invite link, registers a member-side record,
-// and opens the subscriber. Returns the info on the joined group.
+// GroupJoin accepts an invite link OR a short skychat:// group address,
+// registers a member-side record, and opens the subscriber. Returns the
+// info on the joined group.
+//
+// An address route costs one extra round trip (the describe) before the
+// join proper; a link goes straight to the join. Both converge on
+// Manager.RequestJoin, so admission policy, proof of work and rate
+// limiting are identical either way — the address is a shorter way to
+// name the group, not a shortcut past its door.
 func (v *Visor) GroupJoin(args GroupJoinArgs) (GroupInfo, error) {
 	mgr := v.groupManager()
 	if mgr == nil {
 		return GroupInfo{}, ErrGroupingDisabled
 	}
-	inv, err := skychatgroup.DecodeInvite(args.Invite)
+	// An invite link is preferred when both are given: it needs no
+	// network to interpret and carries strictly more than an address.
+	raw := strings.TrimSpace(args.Invite)
+	if raw == "" {
+		raw = strings.TrimSpace(args.Address)
+	}
+	if raw == "" {
+		return GroupInfo{}, errors.New("grouping: join: invite or address required")
+	}
+	if skychataddr.IsInvite(raw) {
+		inv, err := skychatgroup.DecodeInvite(raw)
+		if err != nil {
+			return GroupInfo{}, err
+		}
+		r, err := mgr.Join(inv)
+		if err != nil {
+			return GroupInfo{}, err
+		}
+		return toInfo(r), nil
+	}
+	addr, err := skychataddr.Parse(raw)
 	if err != nil {
 		return GroupInfo{}, err
 	}
-	r, err := mgr.Join(inv)
+	if !addr.IsGroup() {
+		return GroupInfo{}, errors.New("grouping: join: that address names a person, not a group — open a direct message instead")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), groupJoinByAddressBudget)
+	defer cancel()
+	r, err := mgr.JoinByAddress(ctx, addr.PK, addr.GroupID)
 	if err != nil {
 		return GroupInfo{}, err
 	}
 	return toInfo(r), nil
+}
+
+// groupJoinByAddressBudget caps a join driven from a short address: one
+// describe round trip plus the join fan-out behind it. Generous, because
+// it is a deliberate user action where a spurious timeout is worse than a
+// slow success — the same reasoning as joinResponseReadTimeout.
+const groupJoinByAddressBudget = 45 * time.Second
+
+// GroupResolve says what a skychat address points at: a person, or a
+// group/channel and what joining it involves.
+//
+// This is what lets one input field accept anything a user can hold. A
+// bare public key is answered locally — a key naming a person and a key
+// hosting a channel are the same string, so only the address's shape can
+// distinguish them, and a DM needs no permission to open. A group address
+// is answered from this visor's own store when it already knows the
+// group, and otherwise by asking the host.
+func (v *Visor) GroupResolve(args GroupResolveArgs) (GroupResolveResult, error) {
+	raw := strings.TrimSpace(args.Address)
+	if raw == "" {
+		return GroupResolveResult{}, errors.New("grouping: resolve: address required")
+	}
+
+	// A pasted invite link is answered from the link itself. No round
+	// trip, and it works while the host is offline — which is the reason
+	// links still exist alongside addresses.
+	if skychataddr.IsInvite(raw) {
+		inv, err := skychatgroup.DecodeInvite(raw)
+		if err != nil {
+			return GroupResolveResult{}, err
+		}
+		res := GroupResolveResult{
+			Target:  string(skychataddr.KindGroup),
+			PK:      inv.OwnerPK,
+			Address: skychataddr.Group(inv.OwnerPK, inv.ID).String(),
+			Invite:  raw,
+			Group: &GroupDescriptor{
+				ID: inv.ID, HostPK: inv.OwnerPK, Name: inv.Name,
+				Kind: inv.InviteKind(), Mode: inv.Mode,
+				Policy:  inv.InviteKind().Policy(),
+				Port:    inv.Port,
+				PoWBits: inv.PoWBits,
+			},
+		}
+		v.fillGroupMembership(&res, inv.ID)
+		return res, nil
+	}
+
+	addr, err := skychataddr.Parse(raw)
+	if err != nil {
+		return GroupResolveResult{}, err
+	}
+	if !addr.IsGroup() {
+		return GroupResolveResult{
+			Target:  string(skychataddr.KindDM),
+			PK:      addr.PK,
+			Address: addr.String(),
+		}, nil
+	}
+
+	mgr := v.groupManager()
+	if mgr == nil {
+		return GroupResolveResult{}, ErrGroupingDisabled
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), groupResolveBudget)
+	defer cancel()
+	d, err := mgr.ProbeGroup(ctx, addr.PK, addr.GroupID)
+	if err != nil {
+		return GroupResolveResult{}, err
+	}
+	res := GroupResolveResult{
+		Target:  string(skychataddr.KindGroup),
+		PK:      addr.PK,
+		Address: addr.String(),
+		Group: &GroupDescriptor{
+			ID: d.ID, HostPK: d.HostPK, Name: d.Name,
+			Kind: d.Kind, Mode: d.Mode, Policy: d.Policy,
+			Port: d.Port, PoWBits: d.PoWBits, ReadOnly: d.ReadOnly,
+			PriceHint: d.PriceHint, Banned: d.Banned,
+		},
+	}
+	v.fillGroupMembership(&res, d.ID)
+	return res, nil
+}
+
+// groupResolveBudget caps one describe. Sits directly under a user
+// watching a dialog, so it is deliberately tighter than the join budget.
+const groupResolveBudget = 15 * time.Second
+
+// fillGroupMembership annotates a resolve result with what this visor
+// already knows about the group. Without it the UI would offer "Join" for
+// a group the operator is already in, and would offer it again to someone
+// whose request is still queued.
+func (v *Visor) fillGroupMembership(res *GroupResolveResult, id string) {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return
+	}
+	r, ok, err := mgr.Get(id)
+	if err != nil || !ok {
+		return
+	}
+	res.Status = r.Status
+	res.Joined = r.Status == skychatgroup.StatusActive || r.Status == skychatgroup.StatusPending
 }
 
 // GroupAskAgain re-submits a join request an admin has DECLINED — the UI's

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -72,6 +72,11 @@ type GroupInfo struct {
 	// negative to render a checkbox.
 	PeerBackfill bool `json:"peer_backfill"`
 
+	// Listed reports whether THIS visor publishes the group in its
+	// discovery catalog. Local, not gossiped — another admin's copy of the
+	// same group carries its own answer. See skychatgroup.Record.Listed.
+	Listed bool `json:"listed,omitempty"`
+
 	// KeyEpoch is the generation of the key this group currently encrypts
 	// with — 0 for a plaintext group or one still on its create-time key,
 	// incremented by every rotation. Surfaced so an operator can see that
@@ -268,6 +273,11 @@ type GroupCreateArgs struct {
 	// own inverted field. An admin can change it later with
 	// GroupSetPeerBackfill.
 	DisablePeerBackfill bool `json:"disable_peer_backfill,omitempty"`
+
+	// Listed opts the new group into this visor's discovery catalog. The
+	// zero value keeps it unlisted, which is the private direction — see
+	// skychatgroup.Record.Listed for why that default matters.
+	Listed bool `json:"listed,omitempty"`
 }
 
 // kind resolves the group type from either field, defaulting to public.
@@ -432,7 +442,8 @@ func (v *Visor) GroupCreate(args GroupCreateArgs) (GroupInfo, string, error) {
 		return GroupInfo{}, "", ErrGroupingDisabled
 	}
 	r, err := mgr.Create(args.Name, args.kind(), args.InitialMembers,
-		skychatgroup.WithPeerBackfill(!args.DisablePeerBackfill))
+		skychatgroup.WithPeerBackfill(!args.DisablePeerBackfill),
+		skychatgroup.WithListed(args.Listed))
 	if err != nil {
 		return GroupInfo{}, "", err
 	}
@@ -908,6 +919,76 @@ func (v *Visor) GroupSetPeerBackfill(id string, enabled bool) (GroupInfo, error)
 	})
 }
 
+// GroupSetListed publishes (or un-publishes) a group in this visor's
+// discovery catalog. Admin-only, and local rather than gossiped — it says
+// what this visor answers questions about, not what the group is.
+func (v *Visor) GroupSetListed(id string, listed bool) (GroupInfo, error) {
+	return v.groupRosterOp(id, cipher.PubKey{}, func(mgr *skychatgroup.Manager) (skychatgroup.Record, error) {
+		return mgr.SetListed(id, listed)
+	})
+}
+
+// GroupCatalog asks a visor what groups and channels it publishes.
+//
+// Answered locally when host is this visor, so an operator can see their
+// own listing exactly as others would without a network round trip.
+func (v *Visor) GroupCatalog(host cipher.PubKey) ([]GroupCatalogEntry, bool, error) {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return nil, false, ErrGroupingDisabled
+	}
+	var (
+		entries   []skychatgroup.CatalogEntry
+		truncated bool
+		err       error
+	)
+	if host == (cipher.PubKey{}) || host == v.conf.PK {
+		entries, truncated, err = mgr.Catalog()
+		// The local path returns records, which carry no Address — the
+		// remote path builds one from the host it dialed. Fill it in so
+		// both answers have the same shape.
+		for i := range entries {
+			entries[i].Address = skychataddr.Group(entries[i].HostPK, entries[i].ID).String()
+		}
+	} else {
+		ctx, cancel := context.WithTimeout(context.Background(), groupCatalogBudget)
+		defer cancel()
+		entries, truncated, err = mgr.FetchCatalog(ctx, host)
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	out := make([]GroupCatalogEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, GroupCatalogEntry{
+			ID: e.ID, HostPK: e.HostPK, Name: e.Name, Kind: e.Kind,
+			Mode: e.Mode, Policy: e.Policy, PriceHint: e.PriceHint,
+			Address: e.Address,
+		})
+	}
+	return out, truncated, nil
+}
+
+// groupCatalogBudget caps one catalog fetch. Sits under a user watching a
+// list appear, so it is tight for the same reason groupResolveBudget is.
+const groupCatalogBudget = 15 * time.Second
+
+// GroupCatalogEntry is the RPC-facing shape of one discovered group.
+//
+// Port and PoWBits are deliberately absent: they are join mechanics the
+// visor uses internally, and a caller acts on Address, which carries
+// everything needed to join and nothing a UI has to understand.
+type GroupCatalogEntry struct {
+	ID        string                  `json:"id"`
+	HostPK    cipher.PubKey           `json:"host_pk"`
+	Name      string                  `json:"name"`
+	Kind      skychatgroup.Kind       `json:"kind"`
+	Mode      skychatgroup.Mode       `json:"mode"`
+	Policy    skychatgroup.JoinPolicy `json:"policy"`
+	PriceHint string                  `json:"price_hint,omitempty"`
+	Address   string                  `json:"address"`
+}
+
 // GroupRotateKey mints a new key for an encrypted group and hands it to
 // every current member, each copy sealed to that member's own PK.
 // Admin-only.
@@ -1048,6 +1129,12 @@ type GroupHistoryFetcher interface {
 	// ListByGroup returns up to limit most recent messages for the
 	// named group, newest last. Limit <= 0 returns all stored.
 	ListByGroup(groupID string, limit int) ([]GroupMessage, error)
+	// ListGroupBefore returns up to limit messages strictly older than
+	// `before`, newest last — the backward page cursor that lets a
+	// client walk a large channel's backlog a chunk at a time instead
+	// of pulling all of it to show anything. A zero `before` means
+	// "from the newest", so it doubles as the first page.
+	ListGroupBefore(groupID string, before time.Time, limit int) ([]GroupMessage, error)
 	// Groups returns the set of group IDs that have any stored
 	// messages — useful for operator inspection ('cli skychat group
 	// history --list-groups' style introspection).
@@ -1067,13 +1154,33 @@ type GroupHistoryFetcher interface {
 // in-memory ring buffer — operators can recover messages across visor
 // restarts.
 func (v *Visor) GroupHistory(groupID string, limit int) ([]GroupMessage, error) {
+	return v.GroupHistoryPage(GroupHistoryPageArgs{GroupID: groupID, Limit: limit})
+}
+
+// GroupHistoryPage is GroupHistory with a backward cursor: up to Limit
+// messages strictly older than Before, newest last.
+//
+// A zero Before asks for the newest page, so a client's first call and its
+// subsequent "older, please" calls are the same request with the oldest
+// timestamp it holds filled in. That is the whole mechanism behind reading
+// a channel's backlog in chunks — see history.Store.ListGroupBefore.
+func (v *Visor) GroupHistoryPage(args GroupHistoryPageArgs) ([]GroupMessage, error) {
 	v.initLock.RLock()
 	hist := v.grouping.history
 	v.initLock.RUnlock()
 	if hist == nil {
 		return nil, ErrGroupHistoryDisabled
 	}
-	return hist.ListByGroup(groupID, limit)
+	return hist.ListGroupBefore(args.GroupID, args.Before, args.Limit)
+}
+
+// GroupHistoryPageArgs is the RPC input for GroupHistoryPage.
+type GroupHistoryPageArgs struct {
+	GroupID string `json:"group_id"`
+	// Before is the exclusive upper bound — the oldest message the caller
+	// already has. Zero means "the newest page".
+	Before time.Time `json:"before,omitempty"`
+	Limit  int       `json:"limit,omitempty"`
 }
 
 // GroupHistoryGroups lists every group ID that has stored messages.
@@ -1128,6 +1235,7 @@ func toInfo(r skychatgroup.Record) GroupInfo {
 		Muted:         append([]cipher.PubKey(nil), r.Muted...),
 		ReadOnly:      r.ReadOnly,
 		PeerBackfill:  r.PeerBackfillEnabled(),
+		Listed:        r.Listed,
 		JoinPoWBits:   r.JoinPoWRequired(),
 		KeyEpoch:      r.KeyEpoch,
 		Role:          r.Role,

--- a/pkg/visor/init_group.go
+++ b/pkg/visor/init_group.go
@@ -233,6 +233,42 @@ func (a *groupHistoryAdapter) Groups() ([]string, error) {
 	return a.store.Groups()
 }
 
+// ListGroupBefore implements GroupHistoryFetcher (backward page cursor).
+// Same invalid-PK-skip defense as ListByGroup.
+func (a *groupHistoryAdapter) ListGroupBefore(groupID string, before time.Time, limit int) ([]GroupMessage, error) {
+	hMsgs, err := a.store.ListGroupBefore(groupID, before, limit)
+	if err != nil {
+		return nil, err
+	}
+	return a.toVisorMessages(groupID, hMsgs, "history-before"), nil
+}
+
+// toVisorMessages converts store rows to the RPC shape, skipping any row
+// whose sender PK will not parse.
+//
+// Shared by the three read paths so they cannot drift on that skip: a
+// record written by a path that failed to validate should not be able to
+// fail one query and pass another. `what` names the caller in the debug
+// line so a bad row is traceable to the query that hit it.
+func (a *groupHistoryAdapter) toVisorMessages(groupID string, hMsgs []history.GroupMessage, what string) []GroupMessage {
+	out := make([]GroupMessage, 0, len(hMsgs))
+	for _, m := range hMsgs {
+		var senderPK cipher.PubKey
+		if err := senderPK.Set(m.SenderPK); err != nil {
+			a.log.WithError(err).WithField("group", groupID).
+				Debugf("grouping: %s skip bad pk", what)
+			continue
+		}
+		out = append(out, GroupMessage{
+			GroupID:  m.GroupID,
+			SenderPK: senderPK,
+			Text:     m.Text,
+			TS:       m.Timestamp,
+		})
+	}
+	return out
+}
+
 // ListGroupSince implements groupHistorySink (read path beyond the
 // inbox ring). Walks the bolt store from the first message with TS
 // strictly after `since`, returning visor-shaped GroupMessage values

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -802,6 +802,14 @@ func (proxyDefaultAPI) GroupResolve(_ GroupResolveArgs) (GroupResolveResult, err
 	return GroupResolveResult{}, ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) GroupSetListed(_ string, _ bool) (GroupInfo, error) {
+	return GroupInfo{}, ErrProxyNotSupported
+}
+
+func (proxyDefaultAPI) GroupCatalog(_ cipher.PubKey) ([]GroupCatalogEntry, bool, error) {
+	return nil, false, ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) GroupAskAgain(_ string) (GroupInfo, error) {
 	return GroupInfo{}, ErrProxyNotSupported
 }
@@ -939,6 +947,10 @@ func (proxyDefaultAPI) VoiceMute(_ string, _, _ bool) error {
 }
 
 func (proxyDefaultAPI) GroupHistory(_ string, _ int) ([]GroupMessage, error) {
+	return nil, ErrProxyNotSupported
+}
+
+func (proxyDefaultAPI) GroupHistoryPage(_ GroupHistoryPageArgs) ([]GroupMessage, error) {
 	return nil, ErrProxyNotSupported
 }
 

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -798,6 +798,10 @@ func (proxyDefaultAPI) GroupJoin(_ GroupJoinArgs) (GroupInfo, error) {
 	return GroupInfo{}, ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) GroupResolve(_ GroupResolveArgs) (GroupResolveResult, error) {
+	return GroupResolveResult{}, ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) GroupAskAgain(_ string) (GroupInfo, error) {
 	return GroupInfo{}, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1564,6 +1564,20 @@ func (rc *rpcClient) GroupResolve(args GroupResolveArgs) (GroupResolveResult, er
 	return resp, err
 }
 
+// GroupSetListed implements API.
+func (rc *rpcClient) GroupSetListed(id string, listed bool) (GroupInfo, error) {
+	var resp GroupInfo
+	err := rc.Call("GroupSetListed", &GroupSetListedRequest{ID: id, Listed: listed}, &resp)
+	return resp, err
+}
+
+// GroupCatalog implements API.
+func (rc *rpcClient) GroupCatalog(host cipher.PubKey) ([]GroupCatalogEntry, bool, error) {
+	var resp GroupCatalogResponse
+	err := rc.Call("GroupCatalog", &host, &resp)
+	return resp.Entries, resp.Truncated, err
+}
+
 // GroupAskAgain implements API.
 func (rc *rpcClient) GroupAskAgain(id string) (GroupInfo, error) {
 	var resp GroupInfo
@@ -1785,6 +1799,13 @@ func (rc *rpcClient) VoiceMute(callID string, mic, speaker bool) error {
 func (rc *rpcClient) GroupHistory(groupID string, limit int) ([]GroupMessage, error) {
 	var resp []GroupMessage
 	err := rc.Call("GroupHistory", &GroupHistoryRequest{GroupID: groupID, Limit: limit}, &resp)
+	return resp, err
+}
+
+// GroupHistoryPage implements API.
+func (rc *rpcClient) GroupHistoryPage(args GroupHistoryPageArgs) ([]GroupMessage, error) {
+	var resp []GroupMessage
+	err := rc.Call("GroupHistoryPage", &args, &resp)
 	return resp, err
 }
 

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1557,6 +1557,13 @@ func (rc *rpcClient) GroupJoin(args GroupJoinArgs) (GroupInfo, error) {
 	return resp, err
 }
 
+// GroupResolve implements API.
+func (rc *rpcClient) GroupResolve(args GroupResolveArgs) (GroupResolveResult, error) {
+	var resp GroupResolveResult
+	err := rc.Call("GroupResolve", &args, &resp)
+	return resp, err
+}
+
 // GroupAskAgain implements API.
 func (rc *rpcClient) GroupAskAgain(id string) (GroupInfo, error) {
 	var resp GroupInfo

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1289,6 +1289,14 @@ func (mc *mockRPCClient) GroupResolve(_ GroupResolveArgs) (GroupResolveResult, e
 	return GroupResolveResult{}, nil
 }
 
+// GroupSetListed implements API.
+func (mc *mockRPCClient) GroupSetListed(_ string, _ bool) (GroupInfo, error) { return GroupInfo{}, nil }
+
+// GroupCatalog implements API.
+func (mc *mockRPCClient) GroupCatalog(_ cipher.PubKey) ([]GroupCatalogEntry, bool, error) {
+	return nil, false, nil
+}
+
 // GroupAskAgain implements API.
 func (mc *mockRPCClient) GroupAskAgain(_ string) (GroupInfo, error) { return GroupInfo{}, nil }
 
@@ -1422,6 +1430,11 @@ func (mc *mockRPCClient) VoiceMute(_ string, _, _ bool) error {
 
 // GroupHistory implements API.
 func (mc *mockRPCClient) GroupHistory(_ string, _ int) ([]GroupMessage, error) { return nil, nil }
+
+// GroupHistoryPage implements API.
+func (mc *mockRPCClient) GroupHistoryPage(_ GroupHistoryPageArgs) ([]GroupMessage, error) {
+	return nil, nil
+}
 
 // GroupHistoryGroups implements API.
 func (mc *mockRPCClient) GroupHistoryGroups() ([]string, error) { return nil, nil }

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1284,6 +1284,11 @@ func (mc *mockRPCClient) GroupCreate(_ GroupCreateArgs) (GroupInfo, string, erro
 // GroupJoin implements API.
 func (mc *mockRPCClient) GroupJoin(_ GroupJoinArgs) (GroupInfo, error) { return GroupInfo{}, nil }
 
+// GroupResolve implements API.
+func (mc *mockRPCClient) GroupResolve(_ GroupResolveArgs) (GroupResolveResult, error) {
+	return GroupResolveResult{}, nil
+}
+
 // GroupAskAgain implements API.
 func (mc *mockRPCClient) GroupAskAgain(_ string) (GroupInfo, error) { return GroupInfo{}, nil }
 

--- a/pkg/visor/rpc_group.go
+++ b/pkg/visor/rpc_group.go
@@ -60,6 +60,21 @@ func (r *RPC) GroupJoin(req *GroupJoinArgs, out *GroupInfo) (err error) {
 	return nil
 }
 
+// GroupResolve reports what a skychat address points at — a person, or a
+// group/channel and what joining it involves.
+func (r *RPC) GroupResolve(req *GroupResolveArgs, out *GroupResolveResult) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupResolve", req)(out, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	res, err := r.visor.GroupResolve(*req)
+	if err != nil {
+		return err
+	}
+	*out = res
+	return nil
+}
+
 // GroupList returns every persisted group on this visor.
 func (r *RPC) GroupList(_ *struct{}, out *[]GroupInfo) (err error) {
 	defer rpcutil.LogCall(r.log, "GroupList", nil)(out, &err)

--- a/pkg/visor/rpc_group.go
+++ b/pkg/visor/rpc_group.go
@@ -75,6 +75,49 @@ func (r *RPC) GroupResolve(req *GroupResolveArgs, out *GroupResolveResult) (err 
 	return nil
 }
 
+// GroupSetListedRequest is the input to RPC.GroupSetListed.
+type GroupSetListedRequest struct {
+	ID     string `json:"id"`
+	Listed bool   `json:"listed"`
+}
+
+// GroupCatalogResponse pairs the discovered entries with whether the host
+// had more than it sent.
+type GroupCatalogResponse struct {
+	Entries   []GroupCatalogEntry `json:"entries"`
+	Truncated bool                `json:"truncated,omitempty"`
+}
+
+// GroupSetListed publishes or un-publishes a group in this visor's
+// discovery catalog.
+func (r *RPC) GroupSetListed(req *GroupSetListedRequest, out *GroupInfo) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupSetListed", req)(out, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	info, err := r.visor.GroupSetListed(req.ID, req.Listed)
+	if err != nil {
+		return err
+	}
+	*out = info
+	return nil
+}
+
+// GroupCatalog asks a visor what groups and channels it publishes. A zero
+// host means this visor.
+func (r *RPC) GroupCatalog(host *cipher.PubKey, out *GroupCatalogResponse) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupCatalog", host)(out, &err)
+	if host == nil {
+		return fmt.Errorf("nil request")
+	}
+	entries, truncated, err := r.visor.GroupCatalog(*host)
+	if err != nil {
+		return err
+	}
+	*out = GroupCatalogResponse{Entries: entries, Truncated: truncated}
+	return nil
+}
+
 // GroupList returns every persisted group on this visor.
 func (r *RPC) GroupList(_ *struct{}, out *[]GroupInfo) (err error) {
 	defer rpcutil.LogCall(r.log, "GroupList", nil)(out, &err)
@@ -438,6 +481,23 @@ func (r *RPC) GroupHistory(req *GroupHistoryRequest, out *[]GroupMessage) (err e
 		return fmt.Errorf("nil request")
 	}
 	msgs, err := r.visor.GroupHistory(req.GroupID, req.Limit)
+	if err != nil {
+		return err
+	}
+	*out = msgs
+	return nil
+}
+
+// GroupHistoryPage is GroupHistory with a backward cursor — up to Limit
+// messages strictly older than Before, newest last. A zero Before asks for
+// the newest page, so the first request and every "older, please" request
+// have the same shape.
+func (r *RPC) GroupHistoryPage(req *GroupHistoryPageArgs, out *[]GroupMessage) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupHistoryPage", req)(out, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	msgs, err := r.visor.GroupHistoryPage(*req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

**Changes:**	
- Replaced the sidebar PK input and the two group icons with a single button opening Add by address / New group / New channel — in the header on desktop, a floating button at the bottom on a phone.
- Added an Add by address dialog: one field takes a public key, a skychat:// address, an invite link, or a scanned QR code, resolves it, then offers exactly one action — Start Chat, Join Group, Send Request, or Join Channel.
- Added the skychat://<pk> / skychat://<pk>/<group-id> address grammar as a new pkg/skychat/address package (100% covered).
- Added a describe-only probe on a new well-known dmsg port so a short address can be resolved and joined; it decides nothing, and a real join request sent there is refused.
- Added GroupResolve RPC, a /group/resolve route, and join-by-address through the visor, the app's HTTP proxy, and the CLI (group  address, group resolve, --kind).
- Added channels as a real group kind — open to join, admins-only to post, permanently rather than via the reversible read-only flag; carried through invites and join responses so a joined channel can't degrade into an ordinary group.
- Added a QR view for the open conversation, with the address underneath as selectable text plus a copy button; scanning works from the camera or a chosen image, and says so plainly where the browser lacks the API.
- Made the layout one-pane below 760px: the list is the screen, opening a chat replaces it and grows a back button, and the device back button returns to the list.
- Documented all of it in the app README.
- Locked a channel's kind at the store boundary — it can never become a group, including via a write that merely omits the kind.
- Rewrote the subscription topology for channels so cost is flat in audience size instead of growing with every subscriber.
- Made channels serve history and files from their admins only, and refused the peer-backfill setting there rather than accepting it and doing nothing.
- Added a backward history cursor to both storage backends, threaded through the RPC and HTTP layers.
- Made the UI load a group or channel's backlog a chunk at a time — newest page on open, older pages as you scroll back.
- Made channel attachments reference-only: an unrequested file is refused even from an admin, so bytes arrive only when someone opens the card.
- Added an opt-in discovery catalog — a new wire frame on the existing probe port, plus RPC, HTTP route, CLI commands, a create-time checkbox and an admin toggle.
- Surfaced discovery where it's useful: entering a public key in Add by address also lists the channels that visor publishes.
- Added tests for the channel invariants and the page cursor, and documented all of it in the app README.	

**How to test this PR:**
```
make e2e-build
make e2e-run
make e2e-skychat
```
then open `http://localhost:8001` and `http://localhost:8002` on different browser and check new changes.