### PR TITLE
Skychat fixing: header ⋮ menus + avatar, port and forward fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -662,15 +662,14 @@ e2e-test-local:  ## E2E. Run e2e-tests suite in Docker. Prepare e2e environment 
 		sh -c "go clean -testcache && go test -v -timeout=45m ./internal/integration"
 
 e2e-config: ## E2E. Regenerate visor configs from template and deployment config
-	@# HEADS UP: `config gen` emits skychat as an INTERNAL app with
-	@# `--portless` (no TCP port, served through the visor's control
-	@# surface). The committed e2e configs deliberately run it as
-	@# `--addr *:8001 --pair-enable` instead — still the in-process app
-	@# (no "binary" key; bin_path is "./", so an external launch could
-	@# not resolve one anyway), but bound to a port so the e2e suite can
-	@# reach http://visor-x:8001 and a browser can reach the published
-	@# host ports. Regenerating drops that: re-apply the skychat args in
-	@# all three configs afterwards (see the note printed below).
+	@# skychat comes out as `--addr *:8001 --pair-enable` on its own:
+	@# SKYCHATADDR in docker/integration/e2e.conf supplies the
+	@# all-interfaces bind (the suite reaches http://visor-x:8001 across
+	@# containers, and docker-compose publishes those ports to the host)
+	@# and SKYCHATPAIR defaults on. It is still the in-process app — no
+	@# "binary" key, bin_path is "./", so an external launch could not
+	@# resolve one anyway — just one that also listens. This used to need
+	@# a manual re-apply after every regeneration; it does not any more.
 	@#
 	@# --pty-rpc-exec is required by TestEnv_DmsgPtyExec: #3658 gated the
 	@# RPC-initiated `cli pty exec` path behind pty.allow_rpc_exec, OFF by
@@ -698,9 +697,10 @@ e2e-config: ## E2E. Regenerate visor configs from template and deployment config
 		-o docker/integration/visorC.json
 	@echo "E2E visor configs regenerated."
 	@echo ""
-	@echo "NOTE: skychat was regenerated as \"--portless\". For the e2e env + browser"
-	@echo "      testing, set its args back to \"--addr *:8001 --pair-enable\" in"
-	@echo "      docker/integration/visor{A,B,C}.json (see make e2e-skychat)."
+	@echo "NOTE: skychat should read \"--addr *:8001 --pair-enable\" in"
+	@echo "      docker/integration/visor{A,B,C}.json (from SKYCHATADDR in"
+	@echo "      docker/integration/e2e.conf). If it does not, the e2e suite"
+	@echo "      and the browser UIs cannot reach it — see make e2e-skychat."
 
 e2e-skychat: ## E2E. Wire transports between all three visors and print the skychat UIs + PKs
 	@# Manual/browser testing of the chat app against three real visors.

--- a/VISOR_CONFIG_GEN.md
+++ b/VISOR_CONFIG_GEN.md
@@ -69,7 +69,8 @@ Flags:
       --serveproxy             autostart proxy server (default true)
       --proxywl string         proxy server whitelist
       --servechat              autostart skychat (default true)
-      --chataddr string        skychat local address (default ":8001")
+      --chataddr string        skychat local address (default "127.0.0.1:8001")
+      --chatportless           run skychat with no TCP port; reach its UI only through the hypervisor
       --rewardaddr string      skycoin reward address or xpub key
   -k, --os string              (linux / mac / win) paths (default "linux")
   -p, --pkg                    use path for package: /opt/skywire
@@ -232,7 +233,10 @@ SKYENV=/etc/skywire.conf skywire cli config gen
 #SKYCHAT=false
 
 #--	Skychat local address
-#SKYCHATADDR=':8001'
+#SKYCHATADDR='127.0.0.1:8001'
+
+#--	Run skychat with no TCP port (hypervisor-only access)
+#SKYCHATPORTLESS=false
 
 #--	Whitelist public keys for the proxy server (empty = allow all)
 #PROXYSERVERWL=('')
@@ -377,7 +381,8 @@ SKYENV=/etc/skywire.conf skywire cli config gen
 | `PROXYSERVER` | bool | true | Autostart proxy server (skysocks) |
 | `PROXYSERVERWL` | string | (empty) | Proxy server whitelist (comma-separated PKs) |
 | `SKYCHAT` | bool | true | Autostart skychat |
-| `SKYCHATADDR` | string | :8001 | Skychat local address |
+| `SKYCHATADDR` | string | 127.0.0.1:8001 | Skychat local address |
+| `SKYCHATPORTLESS` | bool | false | Run skychat with no TCP port (hypervisor-only access) |
 | `PROXYCLIENTPK` | string | | Proxy client server public key |
 | `STARTPROXYCLIENT` | bool | false | Autostart proxy client |
 | `ADDVPNPK` | string | | VPN client server public key |

--- a/cmd/apps/skychat/README.md
+++ b/cmd/apps/skychat/README.md
@@ -402,12 +402,17 @@ the address other people need in order to ask.
   relationship exists, which is exactly what a per-group port cannot
   do. Stored in `<local>/skychat/profile.json`; a visor that has set
   nothing answers empty rather than refusing.
-- **The avatar is at most 32×32 pixels** and 8 KB. It travels inline in
-  one response frame on a port any stranger may dial, so an uncapped
+- **The avatar is at most 256×256 pixels and 32 KB.** It travels inline
+  in one response frame on a port any stranger may dial, so an uncapped
   picture would turn "ask who this is" into a way to make a visor serve
-  arbitrary bytes. The browser centre-crops and scales before upload;
-  the visor enforces the result by *decoding* the image (PNG or JPEG),
-  never by trusting a declared size or MIME type.
+  arbitrary bytes. 256 is what covers the largest box the UI renders it
+  in (the 120px profile dialog) on a retina screen; the byte cap is the
+  one that holds the wire promise, and it leaves ~21 KB of slack under
+  the 64 KB frame limit after base64. The browser centre-crops, scales,
+  and encodes down — PNG if it fits, otherwise JPEG at descending
+  quality — so the cap is never something the user has to hit. The visor
+  enforces the result by *decoding* the image (PNG or JPEG), never by
+  trusting a declared size or MIME type.
 - **Your address** — `skychat://<your-pk>` — is shown as a QR code and
   as selectable text with a copy button, the same treatment a group
   gets. This half works with no visor RPC at all, so it is still

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -575,7 +575,7 @@ func parseEventChannels(csv string) map[string]bool {
 func init() {
 	launcher.RegisterApp("skychat", RunSkychat)
 	RootCmd.Flags().StringVar(&addr, "addr", ":8001", "address to bind (default: localhost-only); use \"*:PORT\" to bind on all interfaces")
-	RootCmd.Flags().BoolVar(&portless, "portless", false, "portless-internal: don't bind a TCP port; publish the HTTP surface in-process for the visor's control surface to serve (default for internal-app deployments)")
+	RootCmd.Flags().BoolVar(&portless, "portless", false, "don't bind a TCP port; reach the UI only through the visor's control surface (the in-process surface is published either way)")
 	RootCmd.Flags().Uint16Var(&appPort, "port", 0, "routing port for communication between app and visor")
 	RootCmd.Flags().BoolVar(&useSkynet, "skynet", true, "listen on skynet network")
 	RootCmd.Flags().BoolVar(&useDmsg, "dmsg", true, "listen on dmsg network")
@@ -651,7 +651,7 @@ func RunSkychat(ctx context.Context, args []string) error {
 		// Create independent FlagSet for parsing without initialization cycle
 		fs := pflag.NewFlagSet("skychat", pflag.ContinueOnError)
 		fs.StringVar(&addr, "addr", ":8001", "address to bind")
-		fs.BoolVar(&portless, "portless", false, "portless-internal: no TCP port; publish HTTP surface in-process")
+		fs.BoolVar(&portless, "portless", false, "no TCP port; reach the UI only through the visor's control surface")
 		fs.Uint16Var(&appPort, "port", 0, "routing port")
 		fs.BoolVar(&useSkynet, "skynet", true, "listen on skynet")
 		fs.BoolVar(&useDmsg, "dmsg", true, "listen on dmsg")
@@ -894,16 +894,31 @@ func RunSkychat(ctx context.Context, args []string) error {
 	registerPresenceHTTPHandlers(mux)
 	startPresenceLoop(ctx)
 
-	// Portless-internal mode: no TCP port. Publish the mux to the visor's
-	// in-process HTTP-handler registry so the hypervisor's control surface
-	// (Visor.SkychatProxy) serves it directly via ServeHTTP — no loopback dial,
-	// and no http.Server WriteTimeout to strangle the SSE stream. The dmsg:1 /
-	// skynet:1 mesh listeners (the actual chat transport, started above) run
-	// regardless. This is the native twin of the wasm visor's in-process
-	// skychat, and the default for an internal-app deployment.
+	// Publish the mux to the visor's in-process HTTP-handler registry so the
+	// hypervisor's control surface (Visor.SkychatProxy) serves it directly via
+	// ServeHTTP — no loopback dial, and no http.Server WriteTimeout to strangle
+	// the SSE stream.
+	//
+	// This happens whether or not a TCP port is also bound. The two are not
+	// alternatives: it is the same mux either way, and registering it costs a
+	// map entry while NOT registering it would push the hypervisor onto the
+	// loopback path with the 10s write deadline the in-process path exists to
+	// avoid. When skychat runs as a separate process (external-apps mode) this
+	// registers into that process's own registry, where nothing reads it — an
+	// inert write, not a wrong one.
+	//
+	// The clear on the way out is identity-checked: an app restart re-registers
+	// before the old instance's defer runs, and an unconditional delete-by-name
+	// would take the new instance's handler down with it.
+	launcher.RegisterHTTPHandler(skyenv.SkychatName, mux)
+	defer launcher.ClearHTTPHandler(skyenv.SkychatName, mux)
+
+	// Portless-internal mode: no TCP port at all, so the registration above is
+	// the only way in. The dmsg:1 / skynet:1 mesh listeners (the actual chat
+	// transport, started above) run regardless. This is the native twin of the
+	// wasm visor's in-process skychat; opt-in, since a visor whose chat UI has
+	// no address of its own is a deployment choice.
 	if portless {
-		launcher.RegisterHTTPHandler(skyenv.SkychatName, mux)
-		defer launcher.RegisterHTTPHandler(skyenv.SkychatName, nil)
 		appLog("Serving skychat in-process (portless) via the visor control surface")
 		appCl.SetStatusOrLog(appserver.AppDetailedStatusRunning)
 		<-ctx.Done()
@@ -966,9 +981,19 @@ func RunSkychat(ctx context.Context, args []string) error {
 	select {
 	case err := <-errCh:
 		if err != nil {
-			appLog("HTTP server error: %v", err)
-			appCl.SetErrorOrLog(err)
-			return err
+			// A port that will not bind — almost always a second visor, a
+			// stale skychat, or a docker publish already holding it — costs
+			// the local UI and nothing else. The mesh listeners carrying
+			// actual chat traffic are already running, and the mux is already
+			// published to the visor's control surface, so the hypervisor's
+			// chat tab still works. Killing the app over the loss of one of
+			// its two front doors would take the conversation down with it.
+			appLog("HTTP server error on %s: %v — continuing without the local "+
+				"UI port; reach skychat through the hypervisor, or set a free "+
+				"address with --addr", url, err)
+			<-ctx.Done()
+			appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
+			return nil
 		}
 	case <-ctx.Done():
 		appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)

--- a/cmd/apps/skychat/commands/static/index.html
+++ b/cmd/apps/skychat/commands/static/index.html
@@ -2384,6 +2384,18 @@
       line-height: 1.5;
     }
 
+    /* Heading inside the forward list. Same treatment as the sidebar's
+       section headers so the dialog reads as the same kind of list. */
+    .fwd-section {
+      padding: 12px 16px 4px;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      color: var(--accent-green);
+      pointer-events: none;
+    }
+
     .contact-actions {
       display: flex;
       gap: 4px;
@@ -2894,7 +2906,7 @@
       </div>
       <div id="fwdOrigin" class="cg-help"></div>
       <input id="fwdSearch" class="cg-input" type="search" autocomplete="off"
-             placeholder="Search chats, groups and channels" oninput="app.renderForwardTargets()" />
+             placeholder="Search chats, contacts, groups and channels" oninput="app.renderForwardTargets()" />
       <div class="contacts-body">
         <ul id="fwdTargets" class="recipient-list"></ul>
         <div id="fwdEmpty" class="contacts-empty hidden">Nothing matches that.</div>
@@ -7355,21 +7367,46 @@
 
       // _forwardTargets is everywhere a message can go, in the order a user
       // is most likely to want: notes first (the "keep this" case), then
-      // conversations, then groups and channels.
+      // open conversations, then the rest of the address book, then groups
+      // and channels.
+      //
+      // Chats and the address book are two lists, not one, because they
+      // answer different questions. Somebody who messaged you once and was
+      // never saved has no address-book row at all — they exist only as a
+      // conversation — and a flat list rendered them as a bare hex string
+      // among named contacts, which is indistinguishable from noise. The
+      // person you want to forward to is, more often than not, exactly the
+      // one you were just talking to.
+      //
+      // A peer in both appears once, under Chats: it is the more specific
+      // fact about them.
       _forwardTargets() {
-        const out = [{ kind: 'saved', id: this.savedKey(), label: 'Saved Messages', sub: 'Notes on this device', icon: '\u{1F516}' }];
+        const out = [{
+          kind: 'saved', id: this.savedKey(), section: '',
+          label: 'Saved Messages', sub: 'Notes on this device', icon: '\u{1F516}',
+        }];
         const seen = new Set();
-        [...this.recipients, ...this.contacts].forEach(pk => {
+        const peer = (pk, section) => {
           if (seen.has(pk)) return;
           seen.add(pk);
-          out.push({ kind: 'dm', id: pk, label: this.shortPk(pk), sub: this.abbrevPk(pk), icon: '\u{1F464}' });
-        });
+          const name = this.peerName(pk);
+          out.push({
+            kind: 'dm', id: pk, section,
+            label: name || this.abbrevPk(pk),
+            // The key, but only when the label is a name — otherwise the
+            // label already IS the key and repeating it says nothing.
+            sub: name ? this.abbrevPk(pk) : '',
+            icon: '\u{1F464}',
+          });
+        };
+        this.recipients.filter(pk => pk !== this.savedKey()).forEach(pk => peer(pk, 'Chats'));
+        this.contacts.forEach(pk => peer(pk, 'Address book'));
         this.groups.forEach(g => {
           // A channel we cannot post in is not a destination.
           if (g.can_post === false || g.read_only) return;
           if (g.status && g.status !== 'active') return;
           out.push({
-            kind: 'group', id: g.id,
+            kind: 'group', id: g.id, section: 'Groups and channels',
             label: g.name || g.id,
             sub: g.kind === 'channel' ? 'Channel' : 'Group',
             icon: g.kind === 'channel' ? '\u{1F4E3}' : '#',
@@ -7387,17 +7424,30 @@
         const rows = this._forwardTargets().filter(t =>
           !q || t.label.toLowerCase().includes(q) || String(t.id).toLowerCase().includes(q));
         list.innerHTML = '';
+        // Headings are emitted from the rows that survived the search, so a
+        // section whose every row was filtered out does not leave its title
+        // standing over nothing.
+        let section = null;
         rows.forEach(t => {
+          if (t.section && t.section !== section) {
+            section = t.section;
+            const head = document.createElement('li');
+            head.className = 'fwd-section';
+            head.textContent = section;
+            list.appendChild(head);
+          }
           const li = document.createElement('li');
           const avatar = t.kind === 'dm'
             ? `<img class="recipient-avatar" src="${this.escapeAttr(localStorage.getItem(`i_${t.id}`) || 'p.png')}" alt="" />`
             : `<div class="saved-avatar">${t.icon}</div>`;
+          const sub = t.sub
+            ? `<div class="recipient-preview">${this.escapeHtml(t.sub)}</div>` : '';
           li.innerHTML = `
             <div class="recipient-item" onclick="app.doForward('${this.escapeAttr(t.kind)}', '${this.escapeAttr(t.id)}')">
               <div class="avatar-wrap">${avatar}</div>
               <div class="recipient-info">
                 <div class="recipient-pk">${this.escapeHtml(t.label)}</div>
-                <div class="recipient-preview">${this.escapeHtml(t.sub)}</div>
+                ${sub}
               </div>
             </div>`;
           list.appendChild(li);

--- a/cmd/apps/skychat/commands/static/index.html
+++ b/cmd/apps/skychat/commands/static/index.html
@@ -1506,6 +1506,94 @@
     .si-title { font-size: 14px; font-weight: 500; }
     .si-sub { font-size: 11px; color: var(--text-muted); }
 
+    /* ---- Chat-header overflow menu (the ⋮) ----------------------- */
+
+    /* Same shape as the compose menu — a body-level fixed panel placed
+       from its trigger's rect — but narrower and single-line, because
+       every row here is a verb on the open conversation rather than a
+       thing to start. Shares .start-menu's positioning code. */
+    .hdr-menu {
+      position: fixed;
+      /* Above the toast container (1000): a toast is transient and lands in
+         the same top-right corner the menu drops into, and it must not sit
+         over rows the user opened the menu to read. */
+      z-index: 1100;
+      min-width: 184px;
+      padding: 6px;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-color);
+      border-radius: 12px;
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+      display: none;
+      flex-direction: column;
+      gap: 2px;
+      /* A phone in landscape is shorter than the DM menu is tall. Scroll the
+         rows rather than letting the last ones fall off the screen —
+         _positionMenu can only choose a side, not make room. */
+      max-height: calc(100vh - 24px);
+      overflow-y: auto;
+    }
+
+    .hdr-menu.visible { display: flex; }
+
+    .hdr-item {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      width: 100%;
+      padding: 9px 12px;
+      background: transparent;
+      border: none;
+      border-radius: 8px;
+      color: var(--text-primary);
+      text-align: left;
+      cursor: pointer;
+      font: inherit;
+      font-size: 13px;
+      white-space: nowrap;
+    }
+
+    .hdr-item:hover { background: var(--bg-hover); }
+
+    .hi-icon {
+      width: 18px;
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 15px;
+      line-height: 1;
+    }
+
+    .hi-label { flex: 1; min-width: 0; }
+
+    /* Row-level state, mirroring what the old icon buttons said with a
+       border colour: the row for an action already in effect is tinted
+       rather than relabelled twice. */
+    .hdr-item.on { color: var(--msg-sent); }
+    .hdr-item.warn { color: var(--accent-orange); }
+    .hdr-item.danger { color: var(--accent-red); }
+    .hdr-item.danger:hover { background: rgba(239, 68, 68, 0.1); }
+
+    /* Count of waiting join requests, shown inline on the Members row.
+       The same number rides the ⋮ trigger itself (see .pending-badge) —
+       a request the admin cannot see without opening a menu is a
+       request they will not answer. */
+    .hi-count {
+      flex: 0 0 auto;
+      min-width: 16px;
+      height: 16px;
+      padding: 0 5px;
+      border-radius: 8px;
+      background: #ef4444;
+      color: #fff;
+      font-size: 10px;
+      line-height: 16px;
+      text-align: center;
+    }
+
+    .hdr-sep { height: 1px; margin: 4px 6px; background: var(--border-color); }
+
     /* ---- Back button (one-pane layout only) ---------------------- */
 
     .back-btn {
@@ -1777,7 +1865,6 @@
     /* A pinned conversation is rendered in #pinnedList; its copy in the normal
        list is hidden so it isn't shown twice. */
     li.pin-dup { display: none; }
-    .icon-btn.pinned-active { color: var(--msg-sent); border-color: var(--msg-sent); }
 
     .group-item {
       display: flex;
@@ -1951,8 +2038,10 @@
       text-align: center;
     }
 
-    /* Count of join requests waiting on the group header's members
-       button. Absolutely positioned so it rides the icon corner. */
+    /* Count of join requests waiting on the group header's ⋮ trigger.
+       Absolutely positioned so it rides the icon corner — the actions
+       themselves are a menu now, and an admin must be able to see that
+       something is waiting without opening it. */
     .pending-badge {
       position: absolute;
       top: -4px;
@@ -1968,7 +2057,7 @@
       text-align: center;
       pointer-events: none;
     }
-    #groupAdminBtn { position: relative; }
+    #groupMenuBtn { position: relative; }
 
     /* Composer lock: shown in place of the input when this visor may not
        post (muted, read-only group, or still awaiting approval). The
@@ -2052,7 +2141,10 @@
     .switch input:checked + .slider { background: var(--accent-blue); border-color: var(--accent-blue); }
     .switch input:checked + .slider::before { transform: translateX(18px); }
     .switch input:disabled + .slider { opacity: .5; cursor: not-allowed; }
-    /* Header mute-bell active (muted) state */
+    /* Muted state on the header ⋮ trigger. The bell itself lives in the
+       menu now, so without this the one piece of state a closed menu
+       still has to report — "this thread will not ring" — would be
+       invisible until you opened it. */
     .icon-btn.muted { color: var(--accent-orange); border-color: var(--accent-orange); }
 
     /* Voice call — incoming banner */
@@ -2127,9 +2219,9 @@
 
     .me-row:hover { background: var(--bg-hover); }
 
-    /* 32px on screen for a 32x32 source: the published avatar is exactly
-       this size, so it renders 1:1 and never gets the soft look an
-       upscaled thumbnail would have. */
+    /* The smallest place an avatar appears. The published picture is much
+       larger than this, so it is downscaled here — which is the direction
+       that stays sharp. */
     .me-avatar {
       width: 32px;
       height: 32px;
@@ -2310,12 +2402,13 @@
     .recipient-item:focus-within .contact-actions .icon-btn { opacity: 1; }
 
     /* ---- Avatar cropper --------------------------------------------
-       Preview of what will actually be stored, at 3x so the pixels are
-       inspectable. Deliberately not an interactive crop box: the source
-       is centre-cropped square and scaled, which is right for the
-       overwhelming majority of pictures people pick, and a pan/zoom
-       surface would be a large amount of machinery to place a face in a
-       32-pixel circle. */
+       Preview of what will actually be stored, shown at the two sizes
+       the app renders it: the profile dialog and a list row. Deliberately
+       not an interactive crop box — the source is centre-cropped square
+       and scaled, which is right for the overwhelming majority of
+       pictures people pick, and a pan/zoom surface would be a large
+       amount of machinery for a decision the centre of the frame already
+       makes correctly. */
     .av-preview {
       display: flex;
       align-items: center;
@@ -2331,8 +2424,8 @@
       border: 1px solid var(--border-color);
     }
 
-    .av-preview .av-lg { width: 96px; height: 96px; }
-    .av-preview .av-sm { width: 32px; height: 32px; }
+    .av-preview .av-lg { width: 120px; height: 120px; }
+    .av-preview .av-sm { width: 44px; height: 44px; }
 
     .av-caption {
       font-size: 11px;
@@ -2577,26 +2670,15 @@
              which have no epoch to report. -->
         <span id="headerEpoch" class="epoch-tag hidden"></span>
       </div>
+      <!-- Every per-conversation action lives behind this one control.
+           Eight 36px icons across the top of a phone left no room for the
+           name they act on, and a row of unlabelled glyphs makes the user
+           hover each one to find out what it is — a menu says it once, in
+           words. See app._dmMenuItems. -->
       <div class="chat-header-actions">
-        <button id="dmCallBtn" class="icon-btn hidden" onclick="app.placeCall()" title="Start a voice call" aria-label="Voice call">&#x1F4DE;</button>
-        <button id="dmPinBtn" class="icon-btn" onclick="app.togglePin()" title="Pin to top">&#x1F4CC;</button>
-        <button id="dmMuteBtn" class="icon-btn" onclick="app.toggleMute()" title="Mute notifications for this chat" aria-label="Mute notifications">&#x1F514;</button>
-        <button id="pairToggleBtn" class="icon-btn hidden" onclick="app.togglePair()" title="Pair / unpair via CXO">&#x29B5;</button>
-        <button class="icon-btn" onclick="app.showQr()" title="Show this chat's address as a QR code" aria-label="Show address QR code">
-          <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
-            <path d="M3 3h7v7H3V3zm2 2v3h3V5H5zM14 3h7v7h-7V3zm2 2v3h3V5h-3zM3 14h7v7H3v-7zm2 2v3h3v-3H5zM14 14h2v2h-2v-2zm3 0h2v2h-2v-2zm2 2h2v2h-2v-2zm-2 2h2v2h-2v-2zm-3 0h2v3h-2v-3zm4 3h4v-2h-2v-1h-2v3z"/>
-          </svg>
-        </button>
-        <button class="icon-btn" onclick="app.copyPk()" title="Copy public key">&#x2398;</button>
-        <button class="icon-btn" onclick="app.openSettings()" title="Contact settings">&#x2699;</button>
-        <button class="icon-btn danger" onclick="app.deleteChat()" title="Delete chat" aria-label="Delete chat">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <polyline points="3 6 5 6 21 6"></polyline>
-            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-            <line x1="10" y1="11" x2="10" y2="17"></line>
-            <line x1="14" y1="11" x2="14" y2="17"></line>
-          </svg>
-        </button>
+        <button id="dmMenuBtn" class="icon-btn" onclick="app.toggleHeaderMenu(event)"
+                title="Chat actions" aria-label="Chat actions"
+                aria-haspopup="true" aria-expanded="false">&#x22EE;</button>
       </div>
     </div>
 
@@ -2614,27 +2696,16 @@
           <div class="group-header-sub" id="groupHeaderSub"></div>
         </div>
       </div>
+      <!-- Same one control as the DM header; the rows differ by what is
+           open (see app._groupMenuItems), and their wording follows the
+           kind — a channel is not a group to the person reading it. The
+           join-request count rides the trigger so it is visible with the
+           menu shut. -->
       <div class="chat-header-actions">
-        <button id="groupPinBtn" class="icon-btn" onclick="app.togglePin()" title="Pin to top">&#x1F4CC;</button>
-        <button class="icon-btn" onclick="app.showQr()" title="Show this group's address as a QR code" aria-label="Show address QR code">
-          <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
-            <path d="M3 3h7v7H3V3zm2 2v3h3V5H5zM14 3h7v7h-7V3zm2 2v3h3V5h-3zM3 14h7v7H3v-7zm2 2v3h3v-3H5zM14 14h2v2h-2v-2zm3 0h2v2h-2v-2zm2 2h2v2h-2v-2zm-2 2h2v2h-2v-2zm-3 0h2v3h-2v-3zm4 3h4v-2h-2v-1h-2v3z"/>
-          </svg>
-        </button>
-        <button id="groupMuteBtn" class="icon-btn" onclick="app.toggleMute()" title="Mute notifications for this group" aria-label="Mute notifications">&#x1F514;</button>
-        <button id="groupAdminBtn" class="icon-btn" onclick="app.openGroupAdmin()" title="Members and join requests" aria-label="Members and join requests">
-          &#x1F465;<span id="groupPendingBadge" class="pending-badge hidden">0</span>
-        </button>
-        <button class="icon-btn" onclick="app.showGroupInvite()" title="Copy invite link">&#x1F517;</button>
-        <button class="icon-btn" onclick="app.leaveGroup()" title="Leave group">&#x21AA;</button>
-        <button class="icon-btn danger" onclick="app.deleteGroup()" title="Delete group (owner only)" aria-label="Delete group">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <polyline points="3 6 5 6 21 6"></polyline>
-            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-            <line x1="10" y1="11" x2="10" y2="17"></line>
-            <line x1="14" y1="11" x2="14" y2="17"></line>
-          </svg>
-        </button>
+        <button id="groupMenuBtn" class="icon-btn" onclick="app.toggleHeaderMenu(event)"
+                title="Group actions" aria-label="Group actions"
+                aria-haspopup="true" aria-expanded="false">&#x22EE;<span
+                id="groupPendingBadge" class="pending-badge hidden">0</span></button>
       </div>
     </div>
 
@@ -2739,6 +2810,13 @@
       </span>
     </button>
   </div>
+
+  <!-- Chat-header overflow menu. One element for both headers: only one
+       conversation is ever open, so a second panel could only ever be the
+       stale copy. Rebuilt from app state on every open rather than kept in
+       sync — a row's label IS its state here ("Unpin", "Unmute"), and
+       deriving label and state together is what stops them disagreeing. -->
+  <div id="hdrMenu" class="hdr-menu" role="menu" aria-label="Conversation actions"></div>
 
   <!-- Settings Modal -->
   <div id="settingsModal" class="modal-overlay">
@@ -2912,8 +2990,8 @@
     <div class="modal">
       <h3 id="avatarTitle">Use this picture?</h3>
       <div class="av-preview">
-        <img id="avPreviewLg" class="av-lg" src="p.png" alt="Avatar preview, enlarged" />
-        <img id="avPreviewSm" class="av-sm" src="p.png" alt="Avatar preview, actual size" />
+        <img id="avPreviewLg" class="av-lg" src="p.png" alt="Avatar preview at profile-dialog size" />
+        <img id="avPreviewSm" class="av-sm" src="p.png" alt="Avatar preview at list size" />
       </div>
       <p class="av-caption" id="avCaption"></p>
       <div class="modal-actions">
@@ -3370,6 +3448,10 @@
         this.profileAvailable = null;
         // A pending avatar crop awaiting confirmation: {dataUrl, target}.
         this._pendingAvatar = null;
+
+        // Which ⋮ the header menu is currently hanging from — 'dmMenuBtn'
+        // or 'groupMenuBtn'. Only meaningful while the menu is open.
+        this._hdrMenuBtn = 'dmMenuBtn';
         // Peer presence, refreshed from /presence: {pk: {online, rtt_ms, at}}.
         // presenceAvailable stays null until the first answer; false means the
         // endpoint isn't there (no --pair-enable) so the dots stay hidden.
@@ -4790,11 +4872,9 @@
         if (attachBtn) attachBtn.classList.remove('hidden');
         document.querySelectorAll('.group-item').forEach(el => el.classList.remove('active'));
         // selectSaved parks itself in `recipient` too, so leaving it has to
-        // clear its row and restore the call button it hid.
+        // clear its row.
         const savedRow = document.getElementById('savedItem');
         if (savedRow) savedRow.classList.remove('active');
-        const callBtn = document.getElementById('dmCallBtn');
-        if (callBtn && this.voice && this.voice.available) callBtn.classList.remove('hidden');
 
         this.recipient = pk;
         this.loadHistoryFor(pk);
@@ -4832,33 +4912,27 @@
         this._updateMuteButtons();
       }
 
-      // refreshPairControls toggles the pair button + the CXO option
-      // in the network select based on whether pairing is available
-      // and whether the current recipient is paired.
+      // refreshPairControls toggles the CXO option in the network select
+      // based on whether pairing is available and whether the current
+      // recipient is paired. The Pair/Unpair row itself is built by the
+      // header ⋮ menu from the same two facts.
       refreshPairControls() {
-        const pairBtn = document.getElementById('pairToggleBtn');
         const cxoOpt = document.getElementById('cxoNetworkOption');
         const select = document.getElementById('networkSelect');
+        this._refreshHeaderMenu();
         // Nothing to pair with in the notes thread.
-        if (this.isSaved()) {
-          pairBtn.classList.add('hidden');
-          return;
-        }
+        if (this.isSaved()) return;
         if (!this.pairAvailable) {
-          pairBtn.classList.add('hidden');
-          cxoOpt.classList.add('hidden');
-          if (select.value === 'cxo') select.value = 'skynet';
+          if (cxoOpt) cxoOpt.classList.add('hidden');
+          if (select && select.value === 'cxo') select.value = 'skynet';
           return;
         }
-        pairBtn.classList.remove('hidden');
         const isPaired = this.recipient && this.pairedSet && this.pairedSet.has(this.recipient);
-        pairBtn.title = isPaired ? 'Unpair via CXO' : 'Pair via CXO';
-        pairBtn.textContent = isPaired ? '✖' : '⦵';
         if (isPaired) {
-          cxoOpt.classList.remove('hidden');
+          if (cxoOpt) cxoOpt.classList.remove('hidden');
         } else {
-          cxoOpt.classList.add('hidden');
-          if (select.value === 'cxo') select.value = 'skynet';
+          if (cxoOpt) cxoOpt.classList.add('hidden');
+          if (select && select.value === 'cxo') select.value = 'skynet';
         }
         this._renderEpochTag(isPaired);
       }
@@ -6782,20 +6856,40 @@
       // centre-cropped to a square and drawn into a canvas of the target
       // size; what comes out is what gets saved.
       //
-      // Two sizes, for two different constraints. A published avatar is 32x32
-      // because it travels inline in a response frame on a port any stranger
-      // may dial. A local contact picture has no wire cost but does share a
-      // ~5 MB localStorage quota with every cached conversation, so it is
-      // capped too — just at the size the sidebar actually renders it.
+      // One size, two budgets. 256 is what covers the largest box the app
+      // renders an avatar in — the 120px profile dialog — on a retina
+      // screen; below that a face is visibly a thumbnail everywhere it
+      // appears, which is the thing "keep it small" was never asking for.
+      //
+      // The budgets differ because the constraints do. A published avatar
+      // travels inline in a response frame on a port any stranger may dial,
+      // so it must clear profile.MaxAvatarBytes (32 KB) or the visor refuses
+      // it. A local contact picture has no wire cost but does share a ~5 MB
+      // localStorage quota with every cached conversation, so it is bounded
+      // too — just more loosely.
+      //
+      // Note the crop is what makes the budget reachable at all: the encoder
+      // steps quality down until it fits (see _cropToSquare), so these are
+      // ceilings the user never has to think about, not limits they can hit.
 
       _avatarTargets() {
+        const dim = 256;
         return {
-          me: { size: 32, label: 'Published at 32×32 pixels, the size your contacts see.' },
-          contact: { size: 96, label: 'Kept on this device only, at 96×96 pixels.' },
+          me: {
+            size: dim, budget: 32 * 1024,
+            label: `Published at ${dim}×${dim}, the picture your contacts fetch with your name.`,
+          },
+          contact: {
+            size: dim, budget: 64 * 1024,
+            label: `Kept on this device only, at ${dim}×${dim}.`,
+          },
           // Same picture as 'contact', staged in the new-contact form rather
           // than written straight to storage — there is no contact to write
           // it to until Save.
-          newcontact: { size: 96, label: 'Kept on this device only, at 96×96 pixels.' },
+          newcontact: {
+            size: dim, budget: 64 * 1024,
+            label: `Kept on this device only, at ${dim}×${dim}.`,
+          },
         };
       }
 
@@ -6821,7 +6915,7 @@
           return;
         }
         const spec = this._avatarTargets()[target];
-        this._cropToSquare(file, spec.size)
+        this._cropToSquare(file, spec.size, spec.budget)
           .then(dataUrl => {
             this._pendingAvatar = { dataUrl, target };
             document.getElementById('avPreviewLg').src = dataUrl;
@@ -6832,17 +6926,42 @@
           .catch(e => this.showToast(String(e.message || e) || 'Could not read that image.', 'error'));
       }
 
-      // _cropToSquare centre-crops an image file and scales it to size×size,
-      // returning a PNG data URL.
+      // _dataUrlBytes reports how many bytes a data URL's payload decodes to
+      // — which is the number the visor checks, not the string's length.
+      _dataUrlBytes(dataUrl) {
+        const i = String(dataUrl).indexOf(',');
+        if (i < 0) return 0;
+        const b64 = dataUrl.slice(i + 1);
+        const pad = (b64.endsWith('==') ? 2 : (b64.endsWith('=') ? 1 : 0));
+        return Math.max(0, Math.floor(b64.length * 3 / 4) - pad);
+      }
+
+      // _cropToSquare centre-crops an image file, scales it to size×size and
+      // encodes it into `budget` bytes, returning a data URL.
       //
-      // PNG rather than JPEG: at 32 pixels a JPEG's block artefacts are
-      // visible and the file is not meaningfully smaller, and a PNG keeps a
-      // transparent background transparent instead of turning it black.
+      // PNG first, JPEG as the fallback — in that order, not either/or. A
+      // drawn avatar (a logo, a flat illustration) is both smaller and
+      // sharper as a PNG; a photograph at 256px is ~150 KB as a PNG and
+      // ~15 KB as a JPEG, so it has to be the latter. Trying PNG and
+      // measuring is how each picture gets the encoder it wants without
+      // asking the user what kind of picture they just chose.
+      //
+      // The canvas is filled opaque first. JPEG has no alpha and would turn
+      // a transparent background black; filling means the picture looks the
+      // same whichever encoder wins, rather than depending on a size race
+      // the user cannot see. White because it reads as a photo backdrop in
+      // both themes.
+      //
+      // Descending quality rather than one fixed setting: the budget is a
+      // promise to the visor (profile.MaxAvatarBytes), and a picture that
+      // busts it would otherwise surface as a 400 with a Go error string in
+      // a toast, at the end of a flow the user thought had succeeded.
       //
       // createImageBitmap where available — it decodes off the main thread
       // and, unlike an <img>, does not need the picture attached to the
       // document to have dimensions. The <img> path is the fallback.
-      _cropToSquare(file, size) {
+      _cropToSquare(file, size, budget) {
+        const cap = budget || 32 * 1024;
         const draw = src => {
           const canvas = document.createElement('canvas');
           canvas.width = size;
@@ -6854,10 +6973,21 @@
           // Centre crop: the subject of a picture somebody picks as their
           // face is, overwhelmingly, in the middle of it.
           const sx = (w - edge) / 2, sy = (h - edge) / 2;
+          ctx.fillStyle = '#ffffff';
+          ctx.fillRect(0, 0, size, size);
           ctx.imageSmoothingEnabled = true;
           ctx.imageSmoothingQuality = 'high';
           ctx.drawImage(src, sx, sy, edge, edge, 0, 0, size, size);
-          return canvas.toDataURL('image/png');
+
+          const png = canvas.toDataURL('image/png');
+          if (this._dataUrlBytes(png) <= cap) return png;
+          for (const q of [0.92, 0.85, 0.75, 0.65, 0.55, 0.45]) {
+            const jpg = canvas.toDataURL('image/jpeg', q);
+            if (this._dataUrlBytes(jpg) <= cap) return jpg;
+          }
+          // Unreachable for a 256px square at q=0.45; kept because the
+          // alternative is handing the visor something it will refuse.
+          throw new Error('That picture will not compress small enough — try a simpler one.');
         };
 
         if (typeof createImageBitmap === 'function') {
@@ -7000,14 +7130,13 @@
         this._syncSavedControls();
       }
 
-      // _syncSavedControls hides the chat-header buttons that make no sense
-      // for a thread with no peer at the other end.
+      // _syncSavedControls clears the header decoration that makes no sense
+      // for a thread with no peer at the other end. The actions themselves
+      // are the ⋮ menu's problem — _dmMenuItems simply does not build the
+      // rows that would need a peer.
       _syncSavedControls() {
         const saved = this.isSaved();
-        ['dmCallBtn', 'pairToggleBtn'].forEach(id => {
-          const el = document.getElementById(id);
-          if (el && saved) el.classList.add('hidden');
-        });
+        this._refreshHeaderMenu();
         const dot = document.getElementById('headerPresenceDot');
         if (dot && saved) { dot.classList.remove('online'); dot.classList.remove('offline'); }
       }
@@ -7651,15 +7780,11 @@
         }
       }
 
+      // The pin row lives in the header ⋮ menu, which derives its own label
+      // when it opens; this only has to catch a menu that is open while the
+      // pin flips under it.
       _updatePinButtons() {
-        const key = this._currentPinKey();
-        const active = !!key && key === this.pinned;
-        ['dmPinBtn', 'groupPinBtn'].forEach(bid => {
-          const b = document.getElementById(bid);
-          if (!b) return;
-          b.classList.toggle('pinned-active', active);
-          b.title = active ? 'Unpin from top' : 'Pin to top';
-        });
+        this._refreshHeaderMenu();
       }
 
       selectGroup(id) {
@@ -8059,38 +8184,70 @@
           .catch(e => this.showToast(`Create failed: ${e}`, 'error'));
       }
 
-      // ---- Compose menu ----------------------------------------------
+      // ---- Popup menus ------------------------------------------------
+      //
+      // Two of them — the compose menu on the sidebar and the ⋮ on the chat
+      // header — sharing one set of primitives keyed by (menu id, trigger
+      // id). _menuPairs is the registry the document-level dismiss handlers
+      // walk, so a menu added later gets outside-click and Escape for free.
+
+      // A menu lists every id that can open it, not just the current one:
+      // the header ⋮ has two triggers (DM and group) and the dismiss
+      // handlers must recognise a click on either as "not outside".
+      _menuPairs() {
+        return [
+          { menu: 'startMenu', btns: ['startBtn'] },
+          { menu: 'hdrMenu', btns: ['dmMenuBtn', 'groupMenuBtn'] },
+        ];
+      }
+
+      openMenu(menuId, btnId) {
+        const menu = document.getElementById(menuId);
+        if (!menu) return;
+        this._positionMenu(menuId, btnId);
+        menu.classList.add('visible');
+        const btn = document.getElementById(btnId);
+        if (btn) btn.setAttribute('aria-expanded', 'true');
+      }
+
+      closeMenu(menuId, btnId) {
+        const menu = document.getElementById(menuId);
+        if (!menu) return;
+        menu.classList.remove('visible');
+        const btn = document.getElementById(btnId);
+        if (btn) btn.setAttribute('aria-expanded', 'false');
+      }
+
+      closeAllMenus() {
+        this._menuPairs().forEach(p => p.btns.forEach(b => this.closeMenu(p.menu, b)));
+      }
 
       toggleStartMenu(ev) {
         if (ev) ev.stopPropagation();
         const menu = document.getElementById('startMenu');
         if (menu.classList.contains('visible')) { this.closeStartMenu(); return; }
-        this._positionStartMenu();
-        menu.classList.add('visible');
-        document.getElementById('startBtn').setAttribute('aria-expanded', 'true');
+        this.openMenu('startMenu', 'startBtn');
       }
 
-      closeStartMenu() {
-        const menu = document.getElementById('startMenu');
-        if (!menu) return;
-        menu.classList.remove('visible');
-        const btn = document.getElementById('startBtn');
-        if (btn) btn.setAttribute('aria-expanded', 'false');
-      }
+      closeStartMenu() { this.closeMenu('startMenu', 'startBtn'); }
 
-      // _positionStartMenu pins the menu to the button it belongs to.
+      // _positionMenu pins a menu to the button it belongs to.
       //
-      // Measured rather than declared because the button moves: it is in
-      // the sidebar header on a wide screen and a floating button at the
-      // bottom of a phone screen. Opening downward from the header and
-      // upward from the floating button falls out of "is there room
-      // below", so neither case needs its own rule.
-      _positionStartMenu() {
-        const menu = document.getElementById('startMenu');
-        const btn = document.getElementById('startBtn');
+      // Measured rather than declared because the button moves: the compose
+      // button is in the sidebar header on a wide screen and a floating
+      // button at the bottom of a phone screen. Opening downward from the
+      // header and upward from the floating button falls out of "is there
+      // room below", so neither case needs its own rule — and the chat
+      // header's ⋮, which never moves, needs no rule at all.
+      _positionMenu(menuId, btnId) {
+        const menu = document.getElementById(menuId);
+        const btn = document.getElementById(btnId);
         if (!menu || !btn) return;
         // Measure while displayed but still transparent to the user —
-        // offsetWidth is 0 on a display:none element.
+        // offsetWidth is 0 on a display:none element. An already-open menu
+        // is re-measured in place (its rows change as state does), so the
+        // display state is restored rather than assumed closed.
+        const wasVisible = menu.classList.contains('visible');
         menu.style.visibility = 'hidden';
         menu.classList.add('visible');
         const b = btn.getBoundingClientRect();
@@ -8103,8 +8260,209 @@
         top = Math.max(pad, top);
         menu.style.left = `${Math.round(left)}px`;
         menu.style.top = `${Math.round(top)}px`;
-        menu.classList.remove('visible');
+        if (!wasVisible) menu.classList.remove('visible');
         menu.style.visibility = '';
+      }
+
+      // ---- Chat-header ⋮ menu ------------------------------------------
+      //
+      // Every action that used to be an unlabelled icon in the header. The
+      // rows are derived from app state each time the menu opens, so a row
+      // whose label is its state ("Unpin", "Unmute") cannot drift from the
+      // thing it toggles, and a row that would silently do nothing for the
+      // open conversation is simply not built.
+
+      toggleHeaderMenu(ev) {
+        if (ev) ev.stopPropagation();
+        // The per-message ⋯ menu dismisses itself from a BUBBLE-phase document
+        // listener, which the stopPropagation above would rob it of — so it is
+        // closed here rather than left hanging beside a second open menu.
+        this.closeMsgMenu();
+        const btnId = this.group ? 'groupMenuBtn' : 'dmMenuBtn';
+        const menu = document.getElementById('hdrMenu');
+        if (!menu) return;
+        if (menu.classList.contains('visible') && this._hdrMenuBtn === btnId) {
+          this.closeHeaderMenu();
+          return;
+        }
+        this._hdrMenuBtn = btnId;
+        this._renderHeaderMenu();
+        this.openMenu('hdrMenu', btnId);
+        // The menu is a body-level child, so tabbing out of the trigger would
+        // walk the rest of the page before reaching it. Moving focus onto the
+        // first row is what makes the header's actions reachable from the
+        // keyboard at all, now that they are behind one control.
+        const first = menu.querySelector('.hdr-item');
+        if (first) first.focus();
+      }
+
+      closeHeaderMenu() {
+        const menu = document.getElementById('hdrMenu');
+        // Hand focus back to the trigger before the rows holding it vanish —
+        // otherwise Escape drops the caret on <body> and the next Tab starts
+        // from the top of the page. Only when focus is actually inside, so
+        // closing a menu nobody was keyboarding does not steal it.
+        if (menu && menu.contains(document.activeElement)) {
+          const btn = document.getElementById(this._hdrMenuBtn || 'dmMenuBtn');
+          if (btn) btn.focus();
+        }
+        // Both triggers are cleared: which one is "current" changes with the
+        // open conversation, and a stale aria-expanded="true" on the other
+        // one outlives the menu it described.
+        this.closeMenu('hdrMenu', 'dmMenuBtn');
+        this.closeMenu('hdrMenu', 'groupMenuBtn');
+      }
+
+      // _headerMenuItems returns the rows for whatever is open. A row is
+      // {icon, label, act} plus optional flags: `on` / `warn` / `danger`
+      // tint it, `count` puts a number on it, `sep: true` is a divider.
+      _headerMenuItems() {
+        return this.group ? this._groupMenuItems() : this._dmMenuItems();
+      }
+
+      // Saved Messages reuses the DM header but is not a conversation: no
+      // peer to call, pair with, copy a key for or hand an address to; it
+      // already sits at the top of the list, so it cannot be pinned (see
+      // _currentPinKey); and nothing arrives in it, so there is nothing to
+      // silence. Every one of those rows would be a row that does nothing
+      // when tapped, which is worse than an absent one — so the notes
+      // thread's menu is the single action it really has.
+      _dmMenuItems() {
+        if (this.isSaved()) {
+          return [{
+            icon: this._trashIcon(), label: 'Clear notes',
+            act: 'deleteChat', danger: true,
+          }];
+        }
+
+        const key = this._currentPinKey();
+        const pinned = !!key && key === this.pinned;
+        const muted = this._isMuted(this.activeKey());
+        const items = [];
+
+        if (this.voice && this.voice.available) {
+          items.push({ icon: '&#x1F4DE;', label: 'Voice call', act: 'placeCall' });
+        }
+        items.push({
+          icon: '&#x1F4CC;', label: pinned ? 'Unpin' : 'Pin',
+          act: 'togglePin', on: pinned,
+        });
+        items.push({
+          icon: muted ? '&#x1F515;' : '&#x1F514;', label: muted ? 'Unmute' : 'Mute',
+          act: 'toggleMute', warn: muted,
+        });
+        if (this.pairAvailable) {
+          const isPaired = !!(this.recipient && this.pairedSet && this.pairedSet.has(this.recipient));
+          items.push({
+            icon: isPaired ? '&#x2716;' : '&#x29B5;', label: isPaired ? 'Unpair' : 'Pair',
+            act: 'togglePair', on: isPaired,
+          });
+        }
+        items.push({ icon: this._qrIcon(), label: 'QR code', act: 'showQr' });
+        items.push({ icon: '&#x2398;', label: 'Copy key', act: 'copyPk' });
+        items.push({ icon: '&#x2699;', label: 'Settings', act: 'openSettings' });
+        items.push({ sep: true });
+        items.push({
+          icon: this._trashIcon(), label: 'Delete chat',
+          act: 'deleteChat', danger: true,
+        });
+        return items;
+      }
+
+      _groupMenuItems() {
+        const info = this._groupInfo();
+        const isChannel = !!(info && info.kind === 'channel');
+        const noun = isChannel ? 'channel' : 'group';
+        const key = this._currentPinKey();
+        const pinned = !!key && key === this.pinned;
+        const muted = this._isMuted(this.activeKey());
+        const pending = (info && info.pending_joins) || 0;
+
+        return [
+          { icon: '&#x1F4CC;', label: pinned ? 'Unpin' : 'Pin', act: 'togglePin', on: pinned },
+          {
+            icon: muted ? '&#x1F515;' : '&#x1F514;', label: muted ? 'Unmute' : 'Mute',
+            act: 'toggleMute', warn: muted,
+          },
+          { icon: '&#x1F465;', label: 'Members', act: 'openGroupAdmin', count: pending },
+          { icon: '&#x1F517;', label: 'Invite link', act: 'showGroupInvite' },
+          { icon: this._qrIcon(), label: 'QR code', act: 'showQr' },
+          { sep: true },
+          { icon: '&#x21AA;', label: `Leave ${noun}`, act: 'leaveGroup' },
+          { icon: this._trashIcon(), label: `Delete ${noun}`, act: 'deleteGroup', danger: true },
+        ];
+      }
+
+      // The two icons that are drawings rather than characters. Kept as
+      // markup so a menu row reads the same as the header button it
+      // replaced.
+      _qrIcon() {
+        return '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true">' +
+          '<path d="M3 3h7v7H3V3zm2 2v3h3V5H5zM14 3h7v7h-7V3zm2 2v3h3V5h-3zM3 14h7v7H3v-7zm2 2v3h3v-3H5zM14 14h2v2h-2v-2zm3 0h2v2h-2v-2zm2 2h2v2h-2v-2zm-2 2h2v2h-2v-2zm-3 0h2v3h-2v-3zm4 3h4v-2h-2v-1h-2v3z"/></svg>';
+      }
+
+      _trashIcon() {
+        return '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+          'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+          '<polyline points="3 6 5 6 21 6"></polyline>' +
+          '<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>' +
+          '<line x1="10" y1="11" x2="10" y2="17"></line>' +
+          '<line x1="14" y1="11" x2="14" y2="17"></line></svg>';
+      }
+
+      // _renderHeaderMenu draws the rows. Returns the signature it drew so
+      // _refreshHeaderMenu can tell a real change from a poll that found
+      // nothing new — the voice poller calls in every couple of seconds and
+      // a menu that rebuilt itself under the cursor would drop the click.
+      _renderHeaderMenu() {
+        const menu = document.getElementById('hdrMenu');
+        if (!menu) return '';
+        const items = this._headerMenuItems();
+        const sig = JSON.stringify(items);
+        menu.innerHTML = items.map(it => {
+          if (it.sep) return '<div class="hdr-sep"></div>';
+          const cls = ['hdr-item'];
+          if (it.on) cls.push('on');
+          if (it.warn) cls.push('warn');
+          if (it.danger) cls.push('danger');
+          const count = it.count
+            ? `<span class="hi-count">${it.count}</span>` : '';
+          return `<button class="${cls.join(' ')}" role="menuitem" onclick="app.runHeaderAction('${it.act}')">` +
+            `<span class="hi-icon">${it.icon}</span>` +
+            `<span class="hi-label">${this.escapeHtml(it.label)}</span>${count}</button>`;
+        }).join('');
+        menu.dataset.sig = sig;
+        return sig;
+      }
+
+      // _refreshHeaderMenu re-derives an OPEN menu after something it shows
+      // changed. A no-op when the menu is shut (it is rebuilt on open) and
+      // when nothing it draws actually moved.
+      _refreshHeaderMenu() {
+        const menu = document.getElementById('hdrMenu');
+        if (!menu || !menu.classList.contains('visible')) return;
+        if (JSON.stringify(this._headerMenuItems()) === menu.dataset.sig) return;
+        this._renderHeaderMenu();
+        this._positionMenu('hdrMenu', this._hdrMenuBtn || 'dmMenuBtn');
+      }
+
+      // runHeaderAction dismisses the menu, then acts. Dismiss first so a
+      // handler that opens a dialog or tears the conversation down doesn't
+      // leave a menu floating over the result.
+      runHeaderAction(name) {
+        this.closeHeaderMenu();
+        if (typeof this[name] === 'function') this[name]();
+      }
+
+      // _updateHeaderTriggers reflects on the closed ⋮ the one piece of
+      // state the menu can no longer show at a glance: whether this thread
+      // is silenced.
+      _updateHeaderTriggers() {
+        const muted = this._isMuted(this.activeKey());
+        ['dmMenuBtn', 'groupMenuBtn'].forEach(id => {
+          const b = document.getElementById(id);
+          if (b) b.classList.toggle('muted', muted);
+        });
       }
 
       // ---- Add by address --------------------------------------------
@@ -8672,6 +9030,10 @@
       // hopping between five chats leaves one entry to go back through
       // rather than five.
       _enterChatPane() {
+        // The ⋮ menu is a body-level child, so it does not go away with the
+        // header it belongs to. Every conversation switch runs through here,
+        // which makes it the one place that has to say so.
+        this.closeHeaderMenu();
         if (!this._isOnePane()) return;
         const wasOpen = document.body.classList.contains('chat-open');
         document.body.classList.add('chat-open');
@@ -8689,6 +9051,7 @@
       // browser has already moved, and calling back() again would leave
       // the app.
       showChatList(popHistory = true) {
+        this.closeHeaderMenu();
         document.body.classList.remove('chat-open');
         if (popHistory && history.state && history.state.skychat === 'chat') {
           history.back();
@@ -9075,8 +9438,9 @@
         if (btn) btn.classList.add('hidden');
       }
 
-      // _updatePendingBadge shows how many join requests await this
-      // admin on the open group.
+      // _updatePendingBadge shows how many join requests await this admin on
+      // the open group — on the closed ⋮ as a corner count, and on the
+      // Members row inside it.
       _updatePendingBadge() {
         const badge = document.getElementById('groupPendingBadge');
         if (!badge) return;
@@ -9084,6 +9448,7 @@
         const n = (info && info.pending_joins) || 0;
         badge.textContent = n;
         badge.classList.toggle('hidden', n === 0);
+        this._refreshHeaderMenu();
       }
 
       showGroupInvite() {
@@ -9094,23 +9459,38 @@
           .catch(() => this.showToast('Could not get invite link.', 'error'));
       }
 
+      // _groupNoun is what the open room should be called in something the
+      // user reads. The menu row says "Leave channel"; a confirm that then
+      // asks about "this group" reads as being about something else.
+      _groupNoun() {
+        const info = this._groupInfo();
+        return (info && info.kind === 'channel') ? 'channel' : 'group';
+      }
+
       leaveGroup() {
-        if (!this.group || !confirm('Leave this group?')) return;
+        const noun = this._groupNoun();
+        if (!this.group || !confirm(`Leave this ${noun}?`)) return;
         const gid = this.group;
         fetch(`/group/${gid}/leave`, { method: 'POST' })
-          .then(res => { if (res.ok) { this._removeGroup(gid); this.showToast('Left group.'); } else res.text().then(t => this.showToast(t, 'error')); })
+          .then(res => { if (res.ok) { this._removeGroup(gid); this.showToast(`Left ${noun}.`); } else res.text().then(t => this.showToast(t, 'error')); })
           .catch(e => this.showToast(e.message, 'error'));
       }
 
       deleteGroup() {
-        if (!this.group || !confirm('Delete this group? (owner only)')) return;
+        const noun = this._groupNoun();
+        // The "(owner only)" qualifier lives here rather than in the menu
+        // label: the row has to stay short, and this is the last moment
+        // before a request the server will refuse for anyone else.
+        if (!this.group || !confirm(`Delete this ${noun}? (owner only)`)) return;
         const gid = this.group;
+        const done = noun.charAt(0).toUpperCase() + noun.slice(1);
         fetch(`/group/${gid}`, { method: 'DELETE' })
-          .then(res => { if (res.ok) { this._removeGroup(gid); this.showToast('Group deleted.'); } else res.text().then(t => this.showToast(t, 'error')); })
+          .then(res => { if (res.ok) { this._removeGroup(gid); this.showToast(`${done} deleted.`); } else res.text().then(t => this.showToast(t, 'error')); })
           .catch(e => this.showToast(e.message, 'error'));
       }
 
       _removeGroup(gid) {
+        this.closeHeaderMenu();
         this.groups = this.groups.filter(g => g.id !== gid);
         this._unpinIf('grp:' + gid);
         this.renderGroups();
@@ -9254,6 +9634,7 @@
       _purgeSelfThread() {
         const me = this.myPK;
         if (!me || !this.recipients.includes(me)) return;
+        this.closeHeaderMenu();
         this.recipients = this.recipients.filter(v => v !== me);
         this._unpinIf('dm:' + me);
         delete this.messages[me];
@@ -9526,17 +9907,12 @@
         this._updateMuteButtons();
       }
 
-      // _updateMuteButtons reflects the active thread's mute state on the DM and
-      // group header bells (🔕 muted / 🔔 unmuted).
+      // _updateMuteButtons reflects the active thread's mute state: the bell
+      // row inside the header ⋮ menu (🔕 muted / 🔔 unmuted) and the tint on
+      // the closed ⋮ itself.
       _updateMuteButtons() {
-        const muted = this._isMuted(this.activeKey());
-        ['dmMuteBtn', 'groupMuteBtn'].forEach(id => {
-          const btn = document.getElementById(id);
-          if (!btn) return;
-          btn.classList.toggle('muted', muted);
-          btn.innerHTML = muted ? '&#x1F515;' : '&#x1F514;';
-          btn.title = muted ? 'Unmute notifications for this chat' : 'Mute notifications for this chat';
-        });
+        this._updateHeaderTriggers();
+        this._refreshHeaderMenu();
       }
 
       // _notifCapable reports whether THIS browser can currently show a desktop
@@ -9582,8 +9958,10 @@
 
       _setVoiceAvailable(v) {
         this.voice.available = v;
-        const btn = document.getElementById('dmCallBtn');
-        if (btn) btn.classList.toggle('hidden', !v);
+        // The Call row appears and disappears with the visor's voice RPC;
+        // an open menu is re-derived, and the signature check in
+        // _refreshHeaderMenu keeps the poll from redrawing it every tick.
+        this._refreshHeaderMenu();
         if (!v) { // voice went away — tear down any UI
           this.voice.ring = null; this._renderIncoming();
           if (this.voice.activeId) this._endCallUI();
@@ -9868,10 +10246,12 @@
       }
 
       // updatePicture handles a contact's picture. The file goes through the
-      // shared cropper (centre-crop, scale, preview) rather than being stored
-      // as picked: the old path kept up to 250 KB per contact in a
-      // localStorage quota that is ~5 MB for the whole app, cached
-      // conversations included.
+      // shared cropper (centre-crop, scale, encode-to-budget) rather than
+      // being stored as picked: the old path kept up to 250 KB per contact
+      // in a localStorage quota that is ~5 MB for the whole app, cached
+      // conversations included. The budget is what holds that line — the
+      // crop dimension alone would not, since a 256px PNG is bigger than
+      // the 96px one this replaced.
       updatePicture() {
         this._pickAvatar(document.getElementById('profilePicture'), 'contact');
       }
@@ -10447,23 +10827,29 @@
       if (e.target === this) app.closeContacts();
     });
 
-    // Dismiss the start menu on any click outside it. Capture phase so
-    // it fires before a click lands on whatever is underneath.
+    // Dismiss any open popup menu on a click outside it. Capture phase so
+    // it fires before the click lands on whatever is underneath — which is
+    // also why a click on a trigger has to be recognised here rather than
+    // left to the trigger's own stopPropagation: capture runs first.
     document.addEventListener('click', function(e) {
-      const menu = document.getElementById('startMenu');
-      if (!menu.classList.contains('visible')) return;
-      if (menu.contains(e.target)) return;
-      if (document.getElementById('startBtn').contains(e.target)) return;
-      app.closeStartMenu();
+      app._menuPairs().forEach(function(p) {
+        const menu = document.getElementById(p.menu);
+        if (!menu || !menu.classList.contains('visible')) return;
+        if (menu.contains(e.target)) return;
+        const onTrigger = p.btns.some(function(id) {
+          const b = document.getElementById(id);
+          return b && b.contains(e.target);
+        });
+        if (onTrigger) return;
+        p.btns.forEach(function(id) { app.closeMenu(p.menu, id); });
+      });
     }, true);
 
     // Keep the open menu attached to its button when the viewport changes
-    // — a resize can move the button between the header and the floating
-    // position, and an orientation change moves it a long way.
+    // — a resize can move the compose button between the header and the
+    // floating position, and an orientation change moves it a long way.
     window.addEventListener('resize', function() {
-      const menu = document.getElementById('startMenu');
-      if (!menu.classList.contains('visible')) return;
-      app.closeStartMenu();
+      app.closeAllMenus();
     });
 
     // Device / browser back on a phone returns to the conversation list
@@ -10480,7 +10866,7 @@
       if (e.key === 'Escape') {
         app.closeSettings();
         app.closeLightbox();
-        app.closeStartMenu();
+        app.closeAllMenus();
         app.closeModal('createGroupModal');
         app.closeModal('createChannelModal');
         app.closeModal('groupAdminModal');

--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -200,7 +200,11 @@ const envfileLinux = `#
 #SKYCHAT=false
 
 #--	Skychat local address
-#SKYCHATADDR=':8001'
+#SKYCHATADDR='127.0.0.1:8001'
+
+#--	Run skychat with no TCP port at all: the UI is then reachable only
+#--	through the hypervisor. Default: false (skychat binds SKYCHATADDR).
+#SKYCHATPORTLESS=false
 
 #--	Skychat pair-RPC channel to visor (required for group chat).
 #--	Default: true. Set to false to disable group-chat plumbing.
@@ -514,7 +518,11 @@ const envfileWindows = `#
 #$SKYCHAT=$false
 
 #--	Skychat local address
-#$SKYCHATADDR=':8001'
+#$SKYCHATADDR='127.0.0.1:8001'
+
+#--	Run skychat with no TCP port at all: the UI is then reachable only
+#--	through the hypervisor. Default: false (skychat binds SKYCHATADDR).
+#$SKYCHATPORTLESS=$false
 
 #--	Skychat pair-RPC channel to visor (required for group chat).
 #--	Default: true. Set to false to disable group-chat plumbing.

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -336,6 +336,10 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "chataddr")
 	genConfigCmd.Flags().BoolVar(&isSkychatPairEnable, "servechatpair", scriptExecBool("${SKYCHATPAIR:-true}"), "skychat pair RPC channel (required for group chat)")
 	gHiddenFlags = append(gHiddenFlags, "servechatpair")
+	// Visible, unlike the other two: it is the one skychat knob that takes
+	// something away (the local UI on --chataddr), so an operator has to be
+	// able to find it without reading the source.
+	genConfigCmd.Flags().BoolVar(&isSkychatPortless, "chatportless", scriptExecBool("${SKYCHATPORTLESS:-false}"), "run skychat with no TCP port; reach its UI only through the hypervisor")
 
 	// Skycoin embedded apps. Default-off for both — operator opts in
 	// per-app via these flags or via SKYENV. The wallet's user-drop
@@ -1749,13 +1753,23 @@ func skychatExternalArgs(addr string, pair bool) []string {
 
 // skychatInternalArgs builds the launcher Args for skychat under the (default)
 // internal-apps mode: apps run inside the visor process. The external-mode
-// "app skychat" prefix is dropped (the launcher routes by app Name), and
-// --addr is replaced by --portless — the in-process skychat binds no TCP port
-// and instead publishes its HTTP surface to the visor's control surface (which
-// serves the hvui's /skychat/proxy/* routes directly). The dmsg/skynet mesh
-// listeners that carry actual chat traffic are unaffected.
-func skychatInternalArgs(pair bool) []string {
-	args := []string{"--portless"}
+// "app skychat" prefix is dropped (the launcher routes by app Name); the
+// --addr it binds is the same one the external form uses, so the local UI,
+// `skywire cli skychat`, and `skywire cli visor doctor` all find skychat in
+// the same place whichever mode the config was generated in.
+//
+// Running in-process does not require giving up the port: skychat publishes
+// its mux to the visor's control surface either way, so the hypervisor keeps
+// its no-loopback path to the same handler this listener serves.
+//
+// portless drops the listener entirely — no TCP port, hypervisor-only access.
+// Opt-in, because "the app is running but nothing answers on its address" is
+// a surprising default to hand someone.
+func skychatInternalArgs(addr string, pair, portless bool) []string {
+	args := []string{"--addr", addr}
+	if portless {
+		args = []string{"--portless"}
+	}
 	if pair {
 		args = append(args, "--pair-enable")
 	}
@@ -1934,9 +1948,9 @@ func configureApps(log *logging.Logger) {
 				// --pair-enable opens chat-app ↔ visor pair-RPC for
 				// group chat. See the external-apps branch above for
 				// the rationale; mirrored here so internal-apps
-				// generated configs behave the same. Portless: no TCP
-				// port — served in-process via the visor control surface.
-				Args: skychatInternalArgs(isSkychatPairEnable),
+				// generated configs behave the same — as is --addr,
+				// so skychat answers on the same place in both modes.
+				Args: skychatInternalArgs(chatAddr, isSkychatPairEnable, isSkychatPortless),
 			},
 			{
 				Name:      skyenv.SkysocksName,

--- a/cmd/skywire-cli/commands/config/gen_skychat_test.go
+++ b/cmd/skywire-cli/commands/config/gen_skychat_test.go
@@ -1,0 +1,65 @@
+// Package cliconfig cmd/skywire-cli/commands/config/gen_skychat_test.go c2-cli
+//
+// What skychat is launched with, pinned.
+//
+// These args decide whether `skywire cli skychat`, `skywire cli visor
+// doctor`, the browser at 127.0.0.1:8001 and the docker e2e suite can reach
+// the chat app at all, and none of those failures surface as a build error —
+// they surface as "the UI is blank" a long way downstream. Nothing else in
+// the repo asserts on them.
+package cliconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+func join(args []string) string { return strings.Join(args, " ") }
+
+// The default is a bound port. An internally-launched skychat must answer on
+// the same address an externally-launched one does — the launch mode is an
+// implementation detail of where the code runs, not a promise about where the
+// app can be found.
+func TestSkychatInternalArgsBindTheConfiguredAddrByDefault(t *testing.T) {
+	got := skychatInternalArgs("127.0.0.1:8001", false, false)
+	if want := "--addr 127.0.0.1:8001"; join(got) != want {
+		t.Fatalf("args = %q, want %q", join(got), want)
+	}
+
+	// The docker e2e configs reach each other by container name, so the
+	// all-interfaces form has to survive verbatim rather than being
+	// normalized to loopback here.
+	got = skychatInternalArgs("*:8001", true, false)
+	if want := "--addr *:8001 --pair-enable"; join(got) != want {
+		t.Fatalf("args = %q, want %q", join(got), want)
+	}
+}
+
+// --portless replaces the listener; it does not merely accompany it. An
+// --addr left alongside it would be a lie about where the app is.
+func TestSkychatInternalArgsPortlessDropsTheAddr(t *testing.T) {
+	got := skychatInternalArgs("127.0.0.1:8001", false, true)
+	if want := "--portless"; join(got) != want {
+		t.Fatalf("args = %q, want %q", join(got), want)
+	}
+	if strings.Contains(join(got), "--addr") {
+		t.Fatalf("portless args still carry an address: %q", join(got))
+	}
+
+	// Pairing is orthogonal to the listener: group chat needs the pair-RPC
+	// channel whether or not anything is listening on TCP.
+	got = skychatInternalArgs("127.0.0.1:8001", true, true)
+	if want := "--portless --pair-enable"; join(got) != want {
+		t.Fatalf("args = %q, want %q", join(got), want)
+	}
+}
+
+// The external form keeps its "app skychat" prefix (it is a command line, not
+// launcher args) and is otherwise the same shape, which is what lets the two
+// modes agree about the address.
+func TestSkychatExternalArgsKeepTheAppPrefix(t *testing.T) {
+	got := skychatExternalArgs("127.0.0.1:8001", true)
+	if want := "app skychat --addr 127.0.0.1:8001 --pair-enable"; join(got) != want {
+		t.Fatalf("args = %q, want %q", join(got), want)
+	}
+}

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -145,6 +145,15 @@ var (
 	// and #2585 admin mirror) to actually propagate messages, so this
 	// should rarely be off in practice.
 	isSkychatPairEnable bool
+	// isSkychatPortless drops --chataddr from the generated internal-apps
+	// config and emits --portless instead: skychat then binds no TCP port
+	// and its UI is reachable only through the hypervisor's control
+	// surface. Off by default — a chat app whose window you cannot open
+	// without the hypervisor is a deployment choice, not a starting point.
+	// Toggle via SKYCHATPORTLESS in /etc/skywire.conf or --chatportless.
+	// Ignored under --extapps, where skychat is a separate process and has
+	// nothing in-process to publish to.
+	isSkychatPortless bool
 	// Skycoin embedded apps — daemon (full node) + web (thin-client
 	// wallet). Default-off for both. SkycoinWebUser drops the wallet
 	// process to a different UID via the launcher's per-app

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -218,6 +218,7 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	// Skychat
 	addBool("SKYCHAT", "skychat", "no-skychat", autoconfigVals.Skychat, autoconfigVals.NoSkychat)
 	addString("SKYCHATADDR", "chataddr", autoconfigVals.ChatAddr)
+	addBool("SKYCHATPORTLESS", "chatportless", "no-chatportless", autoconfigVals.ChatPortless, autoconfigVals.NoChatPortless)
 	addBool("SKYCHATPAIR", "servechatpair", "no-servechatpair", autoconfigVals.ServeChatPair, autoconfigVals.NoServeChatPair)
 
 	// Skymail bridge

--- a/docs/design/gui-app-serving-modes.md
+++ b/docs/design/gui-app-serving-modes.md
@@ -32,11 +32,15 @@ An app's UI/API is reached in exactly one of two ways:
 
 - **Control-surface ("serverless")** — reached *through the visor*: the wasm
   visor's in-tab `skywireVisor.*` hooks, or the native HV's reverse-proxy /
-  RPC. **No separate HTTP port.** This is the default and it makes the wasm and
-  host-native visors behave identically.
+  RPC. This is what makes the wasm and host-native visors behave identically,
+  and every in-process app offers it.
 - **Own-port** — the app binds its own TCP listener (skychat `127.0.0.1:8001`,
   skycoin-web `127.0.0.1:8002`) that the browser/operator reaches directly.
-  Opt-in.
+
+The two are not exclusive. An in-process app publishes its mux to the control
+surface *and* may bind a port for the same mux; the HV prefers the in-process
+path (no loopback hop, no write deadline on SSE) regardless. Suppressing the
+listener is the opt-in — `--portless` for skychat.
 
 "Serverless" here means *no own HTTP port; reached via the visor control
 surface* — **not** "no process runs." Two sub-flavors, invisible to the user
@@ -91,15 +95,18 @@ so there's no control surface to use.
 
 ## Defaults
 
-Both apps default to **control-surface / no own port**, so native == wasm out
-of the box:
+Both apps are reachable through the control surface out of the box, so native
+== wasm without configuration:
 
 - **wallet** → **no-process serverless**: HV serves `/wallet/`, proxies the
   node over dmsg, wallets in the browser. Zero config, zero skycoin change.
-- **skychat** → **in-process, control-surface**: runs in the visor, reached
-  via the HV (RPC / appnet proxy), no `:8001`. The `:8001` HTTP server stays
-  available behind a flag for CI/E2E (and CI can increasingly use
-  `skywire cli skychat` / RPC instead of curling it).
+- **skychat** → **in-process, control-surface + own port**: runs in the visor
+  and publishes its mux to the HV, *and* binds `--chataddr` (default
+  `127.0.0.1:8001`). The HV path is what the chat tab uses; the port is what
+  `skywire cli skychat`, `skywire cli visor doctor`, the e2e suite and a plain
+  browser use. `--chatportless` drops the listener and leaves only the HV
+  path — worth choosing when nothing local should be able to reach the chat
+  app without authenticating to the hypervisor first.
 
 Opt into an **app with own-port** only when you want the full skycoin-web
 server (server-side multi-coin, disk wallets) or direct non-HV access.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -43,8 +43,11 @@ codebase evolved; this is the reference for "what we mean when we say X."
 - **serverless** — reached via the visor control surface, **no own HTTP port**
   — *not* "no process." skychat is serverless on the wasm visor even though its
   logic runs.
-- **portless-internal** — an in-process app whose UI/API is reached via the HV
-  / appnet rather than a TCP port.
+- **portless-internal** — an in-process app that binds *no* TCP port, so its
+  UI/API is reachable only via the HV / appnet. Opt-in (`--portless`): an
+  in-process app normally publishes to the control surface **and** binds its
+  own port, and registering with the control surface says "runs in this
+  process", not "has no port".
 
 ## wasm / PWA
 

--- a/docs/skywire/app/skychat/README.md
+++ b/docs/skywire/app/skychat/README.md
@@ -40,6 +40,7 @@ skywire app skychat
       --persist-ttl int               days to keep persisted messages before sweep (0 disables) (default 30)
       --persist-whitelist string      path to file with one peer PK per line; if set, only these peers are persisted
       --port uint16                   routing port for communication between app and visor
+      --portless                      don't bind a TCP port; reach the UI only through the visor's control surface (the in-process surface is published either way)
       --sk string                     identity SK for TCP-direct (hex). Overrides env + config.
       --skynet                        listen on skynet network (default true)
       --standalone                    run without a parent visor: skip PROC_CONFIG handshake, disable skynet/dmsg listenLoops, keep --tcp-listen/--tcp-peer + the HTTP control surface. Pair-RPC endpoints become 503 (no visor pair-rpc to relay through). Use this to run a long-lived chat-app that survives visor restarts — reachable via TCP-direct only.

--- a/docs/skywire/cli/config/gen/README.md
+++ b/docs/skywire/cli/config/gen/README.md
@@ -82,6 +82,7 @@ skywire cli config gen
       --skynetweb-upstream string   upstream SOCKS5 for non .skynet traffic
       --servechat                   autostart skychat (default true)
       --chataddr string             skychat local address (default "127.0.0.1:8001")
+      --chatportless                run skychat with no TCP port; reach its UI only through the hypervisor
       --servechatpair               skychat pair RPC channel (required for group chat) (default true)
       --skycoind                    autostart skycoin daemon (legacy single instance)
       --skycoindfiber string        legacy FIBER_TOML path (single instance)

--- a/internal/integration/README.md
+++ b/internal/integration/README.md
@@ -89,12 +89,12 @@ PulseAudio/PipeWire daemon, so the call manager reports disabled and the UI
 hides its call controls. Voice/video *messages* are unaffected — the browser
 records them and they ship over the ordinary file-transfer path.
 
-**If you regenerate the visor configs**, keep skychat's args. `make e2e-config`
-emits it as `--portless` (no TCP port at all); the committed configs
-deliberately use `--addr *:8001 --pair-enable`, which is what both the test
-suite (`http://visor-a:8001`) and the published host ports depend on, and what
-enables groups and the `/voice` endpoints. Re-apply those args in
-`docker/integration/visor{A,B,C}.json` afterwards.
+**If you regenerate the visor configs**, check skychat's args still read
+`--addr *:8001 --pair-enable`. `make e2e-config` produces them itself —
+`SKYCHATADDR='*:8001'` in `docker/integration/e2e.conf` supplies the
+all-interfaces bind, and pairing is on by default — but they are what both the
+test suite (`http://visor-a:8001`) and the published host ports depend on, and
+what enables groups and the `/voice` endpoints, so it is worth a look.
 
 ## Test Structure
 

--- a/pkg/app/launcher/registry.go
+++ b/pkg/app/launcher/registry.go
@@ -42,13 +42,16 @@ func GetApp(name string) (AppFunc, bool) {
 }
 
 // httpHandlers holds in-process HTTP handlers published by internal
-// (in-process) apps, keyed by app name. A portless-internal app — one that
-// runs in the visor process with no TCP port of its own — registers its
-// http.Handler here so a same-process consumer (the visor's control surface,
-// which backs the hypervisor UI's /skychat/proxy/* routes) can serve it
-// directly via ServeHTTP with no loopback dial. When the app instead runs
-// externally on its own port, no handler is registered and the consumer falls
-// back to an HTTP proxy to that port.
+// (in-process) apps, keyed by app name. An app running in the visor process
+// registers its http.Handler here so a same-process consumer (the visor's
+// control surface, which backs the hypervisor UI's /skychat/proxy/* routes)
+// can serve it directly via ServeHTTP with no loopback dial.
+//
+// Registration says "this app runs in this process", not "this app has no
+// port": an in-process app may also bind a TCP listener for the same mux, and
+// the two surfaces coexist. What a missing entry means is that the app runs
+// somewhere else — a separate process, whose registry writes this one never
+// sees — so the consumer falls back to an HTTP proxy to its address.
 var (
 	httpHandlersMu sync.RWMutex
 	httpHandlers   = make(map[string]http.Handler)
@@ -73,4 +76,21 @@ func GetHTTPHandler(name string) http.Handler {
 	httpHandlersMu.RLock()
 	defer httpHandlersMu.RUnlock()
 	return httpHandlers[name]
+}
+
+// ClearHTTPHandler removes name's entry only if it currently holds h.
+//
+// This is what a shutting-down app should call instead of
+// RegisterHTTPHandler(name, nil). An app restart re-registers before the old
+// instance finishes unwinding, so a plain delete-by-name races: the old
+// instance's cleanup can land after the new one has published, taking a live
+// handler out of the registry and leaving the consumer with nothing to serve.
+// Compare-and-delete under the write lock closes that window — a Get followed
+// by a conditional Register would not, since the two are separate acquisitions.
+func ClearHTTPHandler(name string, h http.Handler) {
+	httpHandlersMu.Lock()
+	defer httpHandlersMu.Unlock()
+	if httpHandlers[name] == h {
+		delete(httpHandlers, name)
+	}
 }

--- a/pkg/skychat/profile/profile.go
+++ b/pkg/skychat/profile/profile.go
@@ -21,15 +21,25 @@
 // field as untrusted display text from a stranger, because that is exactly
 // what it is.
 //
-// # Why the avatar is 32x32
+// # Why the avatar is capped, and where the cap comes from
 //
 // Two reasons, and the small one is bandwidth. The real one is that this
 // travels inline in a single response frame on a read-only port that any
 // stranger may dial: a picture with no size ceiling turns "ask who this is"
 // into a way to make a visor serve arbitrary bytes to anybody who asks.
-// 32x32 is the size the UI actually renders a contact row at, it re-encodes
-// to a couple of kilobytes, and it is small enough that the cap can be
-// enforced by decoding the image rather than trusting a declared size.
+// So there is a ceiling, and it is enforced by decoding the image rather
+// than by trusting a declared size.
+//
+// The number itself is set by the largest box the UI ever renders a
+// published avatar in — the 120px profile dialog — doubled for a retina
+// screen. That is the whole justification: 256 is small, not tiny. An
+// earlier cap of 32 was small enough to be visibly a thumbnail everywhere
+// it appeared, which is not what "keep it small" was asking for.
+//
+// The byte cap is the one that actually holds the wire promise, and it is
+// the tighter of the two: a photographic 256x256 PNG is ~150 KB and would
+// never fit, so the browser encodes JPEG and re-encodes down until it does.
+// See MaxAvatarBytes for the frame arithmetic.
 //
 // Cropping and scaling happen in the browser before upload — the user is
 // the one who knows which part of their photo is their face. This package
@@ -61,12 +71,28 @@ const (
 
 	// MaxAvatarDim is the edge length an avatar may not exceed, in pixels.
 	// Enforced by decoding the image, never by trusting a caller.
-	MaxAvatarDim = 32
+	//
+	// 256 covers the largest box the UI renders a published avatar in (the
+	// 120px profile dialog) at 2x, so a picture is never visibly upscaled
+	// on the screens people actually use.
+	MaxAvatarDim = 256
 
-	// MaxAvatarBytes bounds the encoded image. A 32x32 PNG is ~1-3 KB;
-	// this leaves generous room for an inefficient encoder while keeping a
-	// profile response far below the 64 KB frame limit even after base64.
-	MaxAvatarBytes = 8 * 1024
+	// MaxAvatarBytes bounds the encoded image, and it is the cap that does
+	// the real work: dimensions alone say nothing about how many bytes a
+	// stranger can make this visor send.
+	//
+	// The arithmetic: the profile answer is one message.MaxFrameSize (64 KB)
+	// frame of JSON, and Avatar is []byte, so it rides as base64 at 4/3 the
+	// raw size. 32 KB raw is ~44 KB of frame, leaving ~21 KB of slack for the
+	// name and the envelope. An oversize frame is not an error the asker can
+	// see — WriteFrame refuses and the peer looks like it has no profile at
+	// all — so the slack is deliberate, not spare.
+	//
+	// 32 KB also holds a 256x256 JPEG at a quality nobody squints at
+	// (~10-25 KB for a photograph). It does not hold a 256x256 photographic
+	// PNG, which is why the browser tries PNG first and falls back to JPEG
+	// rather than committing to either.
+	MaxAvatarBytes = 32 * 1024
 )
 
 // Avatar MIME types. Derived from the decoded image rather than taken from
@@ -83,7 +109,13 @@ var (
 	// ErrAvatarDimensions means the image is bigger than MaxAvatarDim on
 	// one or both edges. Reported separately from ErrAvatarTooLarge
 	// because the fixes differ: one is "crop it", the other "compress it".
-	ErrAvatarDimensions = errors.New("skychat profile: avatar must be at most 32x32 pixels")
+	//
+	// Formatted from the constant so the two cannot drift apart. The
+	// "avatar must be" prefix is load-bearing: the app-side handler
+	// classifies a bad picture as HTTP 400 by matching it across the
+	// net/rpc boundary, where errors.Is cannot reach (see
+	// cmd/apps/skychat/commands/profile.go, isProfileInputError).
+	ErrAvatarDimensions = fmt.Errorf("skychat profile: avatar must be at most %dx%d pixels", MaxAvatarDim, MaxAvatarDim)
 
 	// ErrAvatarFormat means the bytes did not decode as PNG or JPEG.
 	ErrAvatarFormat = errors.New("skychat profile: avatar must be a PNG or JPEG image")

--- a/pkg/skychat/profile/profile_test.go
+++ b/pkg/skychat/profile/profile_test.go
@@ -9,6 +9,8 @@ package profile
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"image"
 	"image/color"
 	"image/jpeg"
@@ -48,7 +50,7 @@ func jpegOf(t *testing.T, w, h int) []byte {
 func TestValidateAvatarAcceptsSmallPNGAndJPEG(t *testing.T) {
 	mime, err := ValidateAvatar(pngOf(t, MaxAvatarDim, MaxAvatarDim))
 	if err != nil {
-		t.Fatalf("32x32 png rejected: %v", err)
+		t.Fatalf("%dx%d png rejected: %v", MaxAvatarDim, MaxAvatarDim, err)
 	}
 	if mime != MimePNG {
 		t.Fatalf("mime = %q, want %q", mime, MimePNG)
@@ -65,15 +67,43 @@ func TestValidateAvatarAcceptsSmallPNGAndJPEG(t *testing.T) {
 
 // The size ceiling is the whole point of the format: it is what stops the
 // describe port becoming a way to make a visor serve arbitrary bytes.
+// Written against MaxAvatarDim rather than a literal: the cap is a product
+// decision that has moved once already, and a test that pins the number
+// pins the wrong thing — what must hold is "one pixel over is refused, and
+// the refusal says what the limit is".
 func TestValidateAvatarRejectsOversizeDimensions(t *testing.T) {
-	for _, dim := range [][2]int{{33, 32}, {32, 33}, {256, 256}} {
+	over := MaxAvatarDim + 1
+	limit := fmt.Sprintf("%dx%d", MaxAvatarDim, MaxAvatarDim)
+	for _, dim := range [][2]int{{over, MaxAvatarDim}, {MaxAvatarDim, over}, {over, over}} {
 		_, err := ValidateAvatar(pngOf(t, dim[0], dim[1]))
 		if err == nil {
 			t.Fatalf("%dx%d accepted, want rejection", dim[0], dim[1])
 		}
-		if !strings.Contains(err.Error(), "32x32") {
+		if !errors.Is(err, ErrAvatarDimensions) {
+			t.Fatalf("%dx%d: err = %v, want ErrAvatarDimensions", dim[0], dim[1], err)
+		}
+		if !strings.Contains(err.Error(), limit) {
 			t.Fatalf("%dx%d: error %q does not say what the limit is", dim[0], dim[1], err)
 		}
+	}
+}
+
+// The app-side HTTP handler maps a rejected picture to 400 by matching this
+// prefix across the net/rpc boundary, where the error is a plain string and
+// errors.Is cannot help. Rewording either sentinel past this point silently
+// turns a bad picture into a 500 — so the contract is pinned here, beside
+// the errors, rather than left to be discovered in the browser.
+func TestAvatarErrorsKeepTheirClassifiablePrefixes(t *testing.T) {
+	for _, err := range []error{ErrAvatarDimensions, ErrAvatarTooLarge} {
+		if !strings.HasPrefix(err.Error(), "skychat profile: avatar ") {
+			t.Fatalf("%q lost the prefix cmd/apps/skychat/commands/profile.go matches on", err)
+		}
+	}
+	if !strings.Contains(ErrAvatarDimensions.Error(), "avatar must be") {
+		t.Fatalf("ErrAvatarDimensions %q no longer matches isProfileInputError", ErrAvatarDimensions)
+	}
+	if !strings.Contains(ErrAvatarTooLarge.Error(), "avatar too large") {
+		t.Fatalf("ErrAvatarTooLarge %q no longer matches isProfileInputError", ErrAvatarTooLarge)
 	}
 }
 

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -190,7 +190,9 @@ type Values struct {
 	Skychat         bool
 	NoSkychat       bool
 	ChatAddr        string // SKYCHATADDR
-	ServeChatPair   bool   // SKYCHATPAIR — default true in config gen
+	ChatPortless    bool   // SKYCHATPORTLESS — no TCP port, hypervisor-only
+	NoChatPortless  bool
+	ServeChatPair   bool // SKYCHATPAIR — default true in config gen
 	NoServeChatPair bool
 
 	// --- Skymail bridge (SMTP↔skywire) ---
@@ -346,6 +348,8 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().BoolVar(&v.Skychat, "skychat", false, "autostart skychat — writes SKYCHAT=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoSkychat, "no-skychat", false, "do not autostart skychat — writes SKYCHAT=false in skywire.conf")
 	cmd.Flags().StringVar(&v.ChatAddr, "chataddr", "", "skychat local address (host:port) — writes SKYCHATADDR in skywire.conf")
+	cmd.Flags().BoolVar(&v.ChatPortless, "chatportless", false, "run skychat with no TCP port, reachable only through the hypervisor — writes SKYCHATPORTLESS=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoChatPortless, "no-chatportless", false, "let skychat bind its local address — writes SKYCHATPORTLESS=false in skywire.conf")
 	cmd.Flags().BoolVar(&v.ServeChatPair, "servechatpair", false, "enable skychat pair RPC channel (required for group chat) — writes SKYCHATPAIR=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoServeChatPair, "no-servechatpair", false, "disable skychat pair RPC channel — writes SKYCHATPAIR=false in skywire.conf")
 
@@ -497,6 +501,8 @@ var envMap = map[string]EnvMapping{
 	"skychat":          {Key: "SKYCHAT", Format: EnvFormatBool},
 	"no-skychat":       {Key: "SKYCHAT", Format: EnvFormatBool, Negate: true},
 	"chataddr":         {Key: "SKYCHATADDR", Format: EnvFormatString, Default: skyenv.SkychatAddr},
+	"chatportless":     {Key: "SKYCHATPORTLESS", Format: EnvFormatBool},
+	"no-chatportless":  {Key: "SKYCHATPORTLESS", Format: EnvFormatBool, Negate: true},
 	"servechatpair":    {Key: "SKYCHATPAIR", Format: EnvFormatBool},
 	"no-servechatpair": {Key: "SKYCHATPAIR", Format: EnvFormatBool, Negate: true},
 

--- a/pkg/visor/api_apps.go
+++ b/pkg/visor/api_apps.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -734,6 +735,41 @@ func (v *Visor) SetAppSecure(appName string, isSecure bool) error {
 	return nil
 }
 
+// validateAppAddress checks a bind address an operator asked an app to use.
+//
+// Three accepted forms, and the third is why this exists: ":PORT" (loopback)
+// and "*:PORT" (all interfaces) are what this setter has always written, but
+// config-gen writes the app's address as an explicit "HOST:PORT" — skychat's
+// default is skyenv.SkychatAddr, "127.0.0.1:8001". A validator that refused
+// what the generator produces would reject the value the UI had just read back
+// to the user, so saving the form without editing it would fail.
+//
+// A host that is neither an IP literal nor "localhost" is refused: resolving
+// it would be the only way to make it mean anything, and this is a bind
+// address — whatever a name resolves to when it is saved is not necessarily
+// what it resolves to when the app comes to bind it.
+func validateAppAddress(address string) error {
+	portStr := ""
+	switch {
+	case strings.HasPrefix(address, "*:"):
+		portStr = address[2:]
+	case strings.HasPrefix(address, ":"):
+		portStr = address[1:]
+	default:
+		host, port, err := net.SplitHostPort(address)
+		if err != nil || host == "" || (net.ParseIP(host) == nil && host != "localhost") {
+			return fmt.Errorf("invalid addr value: %s", address)
+		}
+		portStr = port
+	}
+
+	portNumber, err := strconv.Atoi(portStr)
+	if err != nil || portNumber < 1025 || portNumber > 65536 {
+		return fmt.Errorf("invalid port number: %s", portStr)
+	}
+	return nil
+}
+
 // SetAppAddress implements API.
 func (v *Visor) SetAppAddress(appName string, address string) error {
 	// check app launcher availability
@@ -745,19 +781,8 @@ func (v *Visor) SetAppAddress(appName string, address string) error {
 		return fmt.Errorf("app %s is not allowed to set addr", appName)
 	}
 
-	if len(address) < 5 || (address[:1] != ":" && address[:2] != "*:") {
-		return fmt.Errorf("invalid addr value: %s", address)
-	}
-
-	forLocalhostOnly := address[:1] == ":"
-	prefix := 2
-	if forLocalhostOnly {
-		prefix = 1
-	}
-
-	portNumber, err := strconv.Atoi(address[prefix:])
-	if err != nil || portNumber < 1025 || portNumber > 65536 {
-		return fmt.Errorf("invalid port number: %s", strconv.Itoa(portNumber))
+	if err := validateAppAddress(address); err != nil {
+		return err
 	}
 
 	v.log.Infof("Setting %s addr to %v", appName, address)

--- a/pkg/visor/api_skychat.go
+++ b/pkg/visor/api_skychat.go
@@ -315,7 +315,7 @@ func readAppArg(v *Visor, appName, flag string) string {
 
 // appHasFlag reports whether an app's launcher config carries a valueless
 // flag such as "--portless". Separate from readAppArg because that one only
-// recognises a flag with a value after it, and would never see this one.
+// recognizes a flag with a value after it, and would never see this one.
 func appHasFlag(v *Visor, appName, flag string) bool {
 	if v.conf == nil || v.conf.Launcher == nil {
 		return false

--- a/pkg/visor/api_skychat.go
+++ b/pkg/visor/api_skychat.go
@@ -35,6 +35,7 @@ const (
 	skychatPasswordArg  = "--password-file"
 	skychatTokenArg     = "--internal-token"
 	skychatAddrArg      = "--addr"
+	skychatPortlessArg  = "--portless"
 
 	// passwordSaltLen mirrors the hypervisor user-store value so the
 	// hashing scheme is identical for both surfaces (see
@@ -137,9 +138,10 @@ func (v *Visor) ClearSkychatPassword(oldPassword string) error {
 // "history/peers"). The proxy attaches the internal token so the
 // password gate is bypassed for in-process hvui calls.
 func (v *Visor) SkychatProxy(method, path string, query string, headers http.Header, body io.Reader) (int, http.Header, []byte, error) {
-	// Portless-internal skychat publishes its mux to the in-process handler
-	// registry — serve it directly, no loopback dial. Falls through to the TCP
-	// proxy when skychat runs externally on its own port.
+	// An in-process skychat publishes its mux to the handler registry — serve
+	// it directly, no loopback dial, whether or not it also binds a TCP port
+	// for its own UI. Falls through to the TCP proxy only when skychat runs as
+	// a separate process, whose registry this one cannot see.
 	if h := launcher.GetHTTPHandler(skyenv.SkychatName); h != nil {
 		return v.serveSkychatInProcess(h, method, path, query, headers, body)
 	}
@@ -182,9 +184,9 @@ func (v *Visor) SkychatProxy(method, path string, query string, headers http.Hea
 	return resp.StatusCode, resp.Header, respBody, nil
 }
 
-// serveSkychatInProcess runs the portless-internal skychat mux directly (no
-// TCP), returning the buffered response — the no-loopback twin of the HTTP
-// proxy above. The streaming (SSE) path uses streamSkychatInProcess so the
+// serveSkychatInProcess runs the in-process skychat mux directly (no TCP),
+// returning the buffered response — the no-loopback twin of the HTTP proxy
+// above. The streaming (SSE) path uses streamSkychatInProcess so the
 // live message stream isn't buffered until an end that never comes.
 func (v *Visor) serveSkychatInProcess(h http.Handler, method, path, query string, headers http.Header, body io.Reader) (int, http.Header, []byte, error) {
 	target := "/" + strings.TrimPrefix(path, "/")
@@ -267,7 +269,14 @@ func (v *Visor) skychatInternalToken() string {
 // back to the env-configured default. The "*:PORT" form (used by
 // the docker integration configs) is rewritten to "0.0.0.0:PORT"
 // so a Go HTTP client can reach it from the visor process.
+//
+// Empty when skychat is configured --portless: it binds nothing, so
+// reporting the default here would hand the UI an address to link that
+// nothing answers on.
 func skychatLocalAddr(v *Visor) string {
+	if appHasFlag(v, skyenv.SkychatName, skychatPortlessArg) {
+		return ""
+	}
 	addr := readAppArg(v, skyenv.SkychatName, skychatAddrArg)
 	if addr == "" {
 		addr = skyenv.SkychatAddr
@@ -302,6 +311,27 @@ func readAppArg(v *Visor, appName, flag string) string {
 		}
 	}
 	return ""
+}
+
+// appHasFlag reports whether an app's launcher config carries a valueless
+// flag such as "--portless". Separate from readAppArg because that one only
+// recognises a flag with a value after it, and would never see this one.
+func appHasFlag(v *Visor, appName, flag string) bool {
+	if v.conf == nil || v.conf.Launcher == nil {
+		return false
+	}
+	short := "-" + strings.TrimPrefix(flag, "--")
+	for _, app := range v.conf.Launcher.Apps {
+		if app.Name != appName {
+			continue
+		}
+		for _, a := range app.Args {
+			if a == flag || a == short {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // readSkychatPassword reads the on-disk password record. Returns

--- a/pkg/visor/api_skychat_addr_test.go
+++ b/pkg/visor/api_skychat_addr_test.go
@@ -1,0 +1,92 @@
+// Package visor pkg/visor/api_skychat_addr_test.go c3-vis-core
+//
+// Where the visor thinks skychat is listening, and what it will accept as a
+// new answer. Both sides of that question changed when skychat started
+// binding a port by default, and both are read by the hypervisor UI — one to
+// draw a link, the other to save an edit — so a disagreement between them
+// shows up as a link to nowhere or a save that refuses its own default.
+package visor
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// visorWithSkychatArgs builds the smallest Visor that skychatLocalAddr reads:
+// a config with one launcher app.
+func visorWithSkychatArgs(args []string) *Visor {
+	return &Visor{
+		conf: &visorconfig.V1{
+			Launcher: &visorconfig.Launcher{
+				Apps: []appserver.AppConfig{{Name: skyenv.SkychatName, Args: args}},
+			},
+		},
+	}
+}
+
+func TestSkychatLocalAddrReportsWhatSkychatBinds(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		// The generated default. Reported verbatim — it is already a
+		// dialable host:port.
+		{"explicit host", []string{"--addr", "127.0.0.1:8001"}, "127.0.0.1:8001"},
+		// The docker form. Rewritten to loopback because this address is
+		// used by a client inside the visor process, not by the listener.
+		{"all interfaces", []string{"--addr", "*:8001", "--pair-enable"}, "127.0.0.1:8001"},
+		{"port only", []string{"--addr", ":8080"}, "127.0.0.1:8080"},
+		// No --addr at all: the app's own flag default applies, which is
+		// what skyenv.SkychatAddr names.
+		{"no addr arg", []string{"--pair-enable"}, skyenv.SkychatAddr},
+		// Nothing is listening, so there is no address to report. Reporting
+		// the default here is what used to put a dead link in the UI.
+		{"portless", []string{"--portless", "--pair-enable"}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := skychatLocalAddr(visorWithSkychatArgs(c.args)); got != c.want {
+				t.Fatalf("skychatLocalAddr(%v) = %q, want %q", c.args, got, c.want)
+			}
+		})
+	}
+}
+
+// The hypervisor reads the current address, shows it, and saves what comes
+// back. If the generator's own default cannot survive that round trip, an
+// untouched save fails — which is what happened when this validator accepted
+// only ":PORT" and "*:PORT".
+func TestSetAppAddressAcceptsTheGeneratedDefault(t *testing.T) {
+	for _, addr := range []string{
+		skyenv.SkychatAddr, // "127.0.0.1:8001" — the generated default
+		"127.0.0.1:8001",
+		"localhost:8001",
+		"[::1]:8001",
+		":8001",
+		"*:8001",
+	} {
+		if err := validateAppAddress(addr); err != nil {
+			t.Errorf("validateAppAddress(%q) = %v, want accepted", addr, err)
+		}
+	}
+}
+
+func TestSetAppAddressRejectsNonsense(t *testing.T) {
+	for _, addr := range []string{
+		"",
+		"8001",             // no colon: not an address
+		":80",              // privileged port
+		":70000",           // out of range
+		"example.com:8001", // a name the visor cannot bind
+		"127.0.0.1",        // no port
+		"127.0.0.1:notaport",
+	} {
+		if err := validateAppAddress(addr); err == nil {
+			t.Errorf("validateAppAddress(%q) accepted, want rejection", addr)
+		}
+	}
+}

--- a/pkg/visor/hypervisor_handlers_skychat.go
+++ b/pkg/visor/hypervisor_handlers_skychat.go
@@ -137,9 +137,11 @@ func (hv *Hypervisor) skychatProxyHandler() http.HandlerFunc {
 // (r.Context()). Local visor only, same internal-token bypass as the buffered
 // path.
 func (hv *Hypervisor) streamSkychatProxy(w http.ResponseWriter, r *http.Request, skychatPath string) {
-	// Portless-internal skychat: serve the registered mux directly, streaming
-	// to the client with no loopback dial. Falls through to the TCP proxy when
-	// skychat runs externally on its own port.
+	// In-process skychat: serve the registered mux directly, streaming to the
+	// client with no loopback dial — and so with no http.Server write deadline
+	// on the SSE stream, which is why this path is preferred even when skychat
+	// is also listening on a port. Falls through to the TCP proxy only when
+	// skychat runs as a separate process.
 	if h := launcher.GetHTTPHandler(skyenv.SkychatName); h != nil {
 		hv.streamSkychatInProcess(h, w, r, skychatPath)
 		return
@@ -207,7 +209,7 @@ func (hv *Hypervisor) streamSkychatProxy(w http.ResponseWriter, r *http.Request,
 }
 
 // streamSkychatInProcess serves a long-lived (SSE) request against the
-// portless-internal skychat mux directly. The mux's SSE handler writes and
+// in-process skychat mux directly. The mux's SSE handler writes and
 // flushes events to the client's ResponseWriter, so passing it straight
 // through streams live with no loopback hop — and, since there is no
 // intermediate http.Server, no WriteTimeout to strangle it (the very bug the

--- a/pkg/visor/init_group.go
+++ b/pkg/visor/init_group.go
@@ -72,7 +72,7 @@ func initGrouping(_ context.Context, v *Visor, log *logging.Logger) error {
 			Info("Grouping: re-sealed group keys that were stored in plaintext by a previous build")
 	}
 
-	// The published profile — a name and a 32x32 avatar this visor answers
+	// The published profile — a name and a small avatar this visor answers
 	// describes with. Best effort like everything else here: a store that
 	// will not open costs the profile feature for this run, not group chat.
 	// A nil provider answers every profile request empty, which is exactly

--- a/pkg/visor/profile.go
+++ b/pkg/visor/profile.go
@@ -42,7 +42,8 @@ type Profile struct {
 
 	Name string `json:"name,omitempty"`
 
-	// Avatar is the encoded image, at most 32x32 pixels. Carried as a
+	// Avatar is the encoded image, bounded by profile.MaxAvatarDim and
+	// profile.MaxAvatarBytes on the way in. Carried as a
 	// data URI rather than raw bytes because the only consumer is a
 	// browser <img>, and building it here keeps the declared MIME type
 	// the one the visor actually decoded.


### PR DESCRIPTION
**Did you run `make format && make check`?** Yes

**Fixes:** #_

**Changes:**	
- Collapsed DM and group/channel header actions into a single ⋮ menu with short labels, moved the pending-join badge onto it, and made muted state and channel wording adapt contextually
- Trimmed Saved Messages menu to its one action; generalized compose-menu code into shared popup primitives with keyboard focus, scroll, and z-index handling
- Raised avatar limits (32×32 to 256×256, 8KB to 32KB) and reworked the cropper to opaque fill + PNG-then-JPEG encoding, fixing stale size references
Changed config-gen's internal-apps default to --addr :8001 with --chatportless as opt-in, made skychat publish its mux in both modes, widened SetAppAddress, made port-bind failures non-fatal, and cleaned up related registry/address logic
- Added tests and updated docs (Makefile, glossary, serving-modes, README, VISOR_CONFIG_GEN, env templates, CLI)
- Restructured the forward dialog into four sections (Saved Messages, Chats, Address book, Groups/channels), deduplicated cross-listed peers, cleaned up subtitles and empty sections, and updated styling and search placeholder

**How to test this PR:**
Start e2e-skychat testing ground by `make e2e-build && make e2e-run && make e2e-skychat`, then check new changes there.