### PR TITLE
feat(routing): asymmetric-fanout / low-latency-direct / privacy-max policy presets

### DIFF
--- a/pkg/router/policy/preset_loader_test.go
+++ b/pkg/router/policy/preset_loader_test.go
@@ -36,4 +36,40 @@ func TestPresetLoader(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "spread-bw")
 	})
+
+	t.Run("every preset loads and evaluates decide_route", func(t *testing.T) {
+		for _, name := range presets.Names() {
+			l, err := NewLoader("preset:" + name)
+			require.NoError(t, err, name)
+			_, err = l.Decide(context.Background(), RoutingContext{App: "skysocks-client"}, nil)
+			require.NoError(t, err, name)
+		}
+	})
+
+	t.Run("asymmetric-fanout sets per-direction mux", func(t *testing.T) {
+		l, err := NewLoader("preset:asymmetric-fanout")
+		require.NoError(t, err)
+		spec, err := l.Decide(context.Background(), RoutingContext{App: "skysocks-client"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, spec.ForwardMux)
+		assert.Equal(t, 4, spec.ReverseMux)
+	})
+
+	t.Run("privacy-max forces >=3 hops", func(t *testing.T) {
+		l, err := NewLoader("preset:privacy-max")
+		require.NoError(t, err)
+		spec, err := l.Decide(context.Background(), RoutingContext{App: "x"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 3, spec.MinHops)
+		assert.Equal(t, 2, spec.Mux)
+	})
+
+	t.Run("low-latency-direct is a single low-hop path", func(t *testing.T) {
+		l, err := NewLoader("preset:low-latency-direct")
+		require.NoError(t, err)
+		spec, err := l.Decide(context.Background(), RoutingContext{App: "x"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, spec.Mux)
+		assert.Equal(t, 1, spec.MinHops)
+	})
 }

--- a/pkg/router/policy/presets/asymmetric-fanout.star
+++ b/pkg/router/policy/presets/asymmetric-fanout.star
@@ -1,0 +1,74 @@
+# asymmetric-fanout — one lean forward path, a fanned-out reverse path.
+#
+# For download-heavy apps (web browsing, media, VPN pull traffic): the REVERSE
+# direction aggregates multiple parallel download paths while the FORWARD
+# direction rides a single cheap, low-hop path carrying requests + ACKs. This is
+# the asymmetric case the router already supports natively via forward_mux /
+# reverse_mux — a symmetric MUX=4 wastes upstream fan-out on a workload whose
+# bytes are almost all inbound.
+#
+#   forward  = 1 leg,  min_hops 1  → shortest path (uses the direct transport
+#                                    when one exists); low latency for requests.
+#   reverse  = 4 legs, min_hops 2  → real intermediates, fanned out for
+#                                    throughput and to spread reward-eligible
+#                                    relay bandwidth across the network.
+#
+# NOTE: this is a STATIC asymmetry. Flipping the fan-out to whichever direction
+# currently carries more bandwidth is a natural extension — on_tick already sees
+# per-leg sent_bytes/recv_bytes — but needs a Rotation verb to re-balance the
+# per-direction mux, which does not exist yet. Until then this preset assumes the
+# common download-heavy shape.
+#
+# Select without compiling a file:
+#   "routing": { "policy_per_dial": "preset:asymmetric-fanout" }
+
+FWD_MUX = 1
+REV_MUX = 4
+FWD_MIN_HOPS = 1       # forward: shortest path, the direct transport where available
+REV_MIN_HOPS = 2       # reverse: real intermediates (fan-out + reward credit)
+ROTATE_SECS = 15
+LEG_BUDGET = 8000000   # retire a leg after ~8 MB, spreading over relays over time
+
+RETX_PENALTY_MS = 50   # each SACK retransmit adds this much "badness" (loss >> latency)
+BAD_LEG_FACTOR = 2     # shed a leg only when this many times worse than the best
+MIN_BAD_MS = 200       # ...and only above this absolute badness (don't churn fast legs)
+
+def decide_route(ctx, candidates):
+    return RouteSpec(
+        forward_mux=FWD_MUX,
+        reverse_mux=REV_MUX,
+        forward_min_hops=FWD_MIN_HOPS,
+        reverse_min_hops=REV_MIN_HOPS,
+        distribution="auto",
+        rotation_interval_seconds=ROTATE_SECS,
+    )
+
+def _badness(l):
+    # Lossy legs cost far more than merely slow ones.
+    return l.latency_ms + l.retransmits * RETX_PENALTY_MS
+
+def on_tick(ctx, legs):
+    # Maintain the reverse fan-out the same way spread-bw does: shed the single
+    # worst (lossy/slow) leg, else one over its byte budget, never the last live
+    # leg — so downloads keep flowing while paths refresh onto fresh relays.
+    alive = [l for l in legs if l.alive]
+    if len(alive) < 2:
+        return None
+    worst = alive[0]
+    best = alive[0]
+    for l in alive:
+        if _badness(l) > _badness(worst):
+            worst = l
+        if _badness(l) < _badness(best):
+            best = l
+    drop = None
+    if _badness(worst) > MIN_BAD_MS and _badness(worst) > _badness(best) * BAD_LEG_FACTOR:
+        drop = worst
+    else:
+        for l in alive:
+            if (l.sent_bytes + l.recv_bytes) > LEG_BUDGET:
+                drop = l
+                break
+    if drop == None:
+        return None
+    return Rotation(drop_legs=[drop.index], add_leg=True, exclude_hops=drop.hops)

--- a/pkg/router/policy/presets/low-latency-direct.star
+++ b/pkg/router/policy/presets/low-latency-direct.star
@@ -1,0 +1,21 @@
+# low-latency-direct — one shortest, lowest-latency path; no fan-out, no churn.
+#
+# For interactive / round-trip-bound traffic (RPC, remote shell, chat, game-like
+# flows) where latency matters far more than throughput or path diversity. A
+# single leg at min_hops 1 takes the direct transport where one exists, and the
+# latency-weighted route-finder picks the fastest candidate. Rotation is off — an
+# interactive session wants a stable path, not periodic re-routing.
+#
+# Trade-off: no privacy fan-out (a single relay, or none, sees the flow) and no
+# redundancy — if the one path dies the connection re-dials. Use spread-bw or
+# privacy-max instead when unlinkability or resilience matters more than RTT.
+#
+#   "routing": { "policy_per_dial": "preset:low-latency-direct" }
+
+def decide_route(ctx, candidates):
+    return RouteSpec(
+        mux=1,
+        min_hops=1,
+        distribution="auto",
+        rotation_interval_seconds=0,   # 0 = no scheduled rotation; keep the path stable
+    )

--- a/pkg/router/policy/presets/privacy-max.star
+++ b/pkg/router/policy/presets/privacy-max.star
@@ -1,0 +1,39 @@
+# privacy-max — maximum unlinkability, at the cost of latency.
+#
+# >= 3 hops so no single intermediate sees both ends of the flow, 2 parallel
+# paths for resilience, and frequent rotation so any given path is short-lived —
+# a passive relay observes only a brief, partial slice before it's replaced
+# through fresh, country-diverse intermediates. Highest latency of the presets;
+# use for sensitive traffic where being un-followable beats being fast.
+#
+#   "routing": { "policy_per_dial": "preset:privacy-max" }
+
+MIN_HOPS = 3
+MUX = 2
+ROTATE_SECS = 8        # short path lifetime — rotate often
+LEG_BUDGET = 4000000   # and retire a path after ~4 MB regardless
+
+def decide_route(ctx, candidates):
+    return RouteSpec(
+        mux=MUX,
+        min_hops=MIN_HOPS,
+        distribution="auto",
+        rotation_interval_seconds=ROTATE_SECS,
+    )
+
+def on_tick(ctx, legs):
+    # Keep every path short-lived: retire the oldest/most-used live leg once it
+    # crosses the byte budget (never the last one), replacing it through
+    # intermediates disjoint from the one we drop. Country diversity is enforced
+    # by steering the replacement away from this leg's hops.
+    alive = [l for l in legs if l.alive]
+    if len(alive) < 2:
+        return None
+    drop = None
+    for l in alive:
+        if (l.sent_bytes + l.recv_bytes) > LEG_BUDGET:
+            drop = l
+            break
+    if drop == None:
+        return None
+    return Rotation(drop_legs=[drop.index], add_leg=True, exclude_hops=drop.hops)


### PR DESCRIPTION
Three curated Starlark routing-policy presets alongside the existing `spread-bw`, selectable with zero compile via `routing.policy_per_dial: "preset:<name>"` (or per-app `routing_policy`):

- **asymmetric-fanout** — `forward_mux=1` / `reverse_mux=4` (+ `forward_min_hops=1`, `reverse_min_hops=2`): one lean, low-hop upstream carrying requests/ACKs while downloads fan out over multiple multihop paths. Uses the router's native asymmetric mux; ideal for download-heavy apps (browsing, media). A true bandwidth-reactive *flip* of the fan-out direction is noted as a follow-up (needs a Rotation verb to rebalance per-direction mux).
- **low-latency-direct** — `mux=1`, `min_hops=1`, no rotation: shortest, lowest-latency path for interactive/RTT-bound traffic.
- **privacy-max** — `min_hops>=3`, `mux=2`, fast rotation + small byte budget: maximum unlinkability, highest latency.

Extended `TestPresetLoader` to load + evaluate **every** preset (regression-covers these and any future ones), with specific assertions per preset. All pass; `go build`/policy tests green.