### PR TITLE
feat(routing-policy): prefer-connected/balanced/hypervisor-priority presets + has_transport predicate + CLI discovery

### DIFF
--- a/cmd/skywire-cli/commands/route/policy.go
+++ b/cmd/skywire-cli/commands/route/policy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cliout"
 	"github.com/skycoin/skywire/pkg/cliout/cliroute"
 	"github.com/skycoin/skywire/pkg/router/policy"
+	"github.com/skycoin/skywire/pkg/router/policy/presets"
 	policywasm "github.com/skycoin/skywire/pkg/router/policy/wasm"
 )
 
@@ -55,23 +56,112 @@ func loadPolicyEngine(path string, src []byte, clock fixedClock) (policyTestEngi
 
 var (
 	policyScriptPath string
+	policyPresetName string
 	policyDialJSON   string
 	policyBenchIter  int
 )
 
 func init() {
 	routeCmd.AddCommand(policyCmd)
-	policyCmd.AddCommand(policyTestCmd, policyBenchCmd)
+	policyCmd.AddCommand(policyListCmd, policyShowCmd, policyTestCmd, policyBenchCmd)
 
 	policyTestCmd.Flags().StringVarP(&policyScriptPath, "script", "s", "",
 		"path to the skylark policy file (.star)")
+	policyTestCmd.Flags().StringVarP(&policyPresetName, "preset", "p", "",
+		"built-in preset name to test instead of a --script file (see `route policy list`)")
 	policyTestCmd.Flags().StringVarP(&policyDialJSON, "dial", "d", "{}",
 		"synthetic dial context as JSON — see the docs for the schema")
 
 	policyBenchCmd.Flags().StringVarP(&policyScriptPath, "script", "s", "",
 		"path to the skylark policy file (.star)")
+	policyBenchCmd.Flags().StringVarP(&policyPresetName, "preset", "p", "",
+		"built-in preset name to benchmark instead of a --script file")
 	policyBenchCmd.Flags().IntVarP(&policyBenchIter, "iter", "n", 100_000,
 		"number of evaluations to run")
+}
+
+// presetSummary returns the first non-empty comment line of a preset's
+// source — its human-readable one-liner. Empty when the preset is unknown
+// or has no leading comment.
+func presetSummary(name string) string {
+	src, ok := presets.Source(name)
+	if !ok {
+		return ""
+	}
+	for _, line := range strings.Split(src, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			if desc := strings.TrimSpace(strings.TrimPrefix(line, "#")); desc != "" {
+				return desc
+			}
+			continue
+		}
+		if line != "" {
+			break // hit code before any comment
+		}
+	}
+	return ""
+}
+
+var policyListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the built-in routing-policy presets",
+	Long: `Lists the presets embedded in the binary. Select one without
+compiling a file via the config value:
+
+  "routing": { "policy_per_dial": "preset:<name>" }
+
+Preview one with ` + "`route policy test --preset <name>`" + ` or read its
+source with ` + "`route policy show <name>`" + `.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		for _, name := range presets.Names() {
+			if s := presetSummary(name); s != "" {
+				fmt.Printf("%-20s %s\n", name, s)
+			} else {
+				fmt.Println(name)
+			}
+		}
+		return nil
+	},
+}
+
+var policyShowCmd = &cobra.Command{
+	Use:   "show <name>",
+	Short: "Print a built-in preset's Starlark source",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		src, ok := presets.Source(args[0])
+		if !ok {
+			return fmt.Errorf("unknown preset %q; available: %s", args[0], strings.Join(presets.Names(), ", "))
+		}
+		fmt.Print(src)
+		return nil
+	},
+}
+
+// resolvePolicySource returns (path, source) for whichever of --preset or
+// --script the operator supplied, preferring --preset. The returned path is
+// a display/dispatch label (preset:<name> is treated as Starlark). Errors
+// when neither or both are given.
+func resolvePolicySource() (string, []byte, error) {
+	switch {
+	case policyPresetName != "" && policyScriptPath != "":
+		return "", nil, errors.New("pass only one of --preset or --script")
+	case policyPresetName != "":
+		src, ok := presets.Source(policyPresetName)
+		if !ok {
+			return "", nil, fmt.Errorf("unknown preset %q; available: %s", policyPresetName, strings.Join(presets.Names(), ", "))
+		}
+		return "preset:" + policyPresetName + ".star", []byte(src), nil
+	case policyScriptPath != "":
+		src, err := os.ReadFile(policyScriptPath) //nolint:gosec
+		if err != nil {
+			return "", nil, fmt.Errorf("read script: %w", err)
+		}
+		return policyScriptPath, src, nil
+	default:
+		return "", nil, errors.New("one of --preset or --script is required")
+	}
 }
 
 var policyCmd = &cobra.Command{
@@ -108,12 +198,9 @@ The --dial JSON accepts: app (string), peer_pk (string), port
 (int), now (RFC3339 timestamp). Missing fields default to zero
 values.`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		if policyScriptPath == "" {
-			return errors.New("--script is required")
-		}
-		src, err := os.ReadFile(policyScriptPath) //nolint:gosec
+		path, src, err := resolvePolicySource()
 		if err != nil {
-			return fmt.Errorf("read script: %w", err)
+			return err
 		}
 		var dial dialJSON
 		if err := json.Unmarshal([]byte(policyDialJSON), &dial); err != nil {
@@ -128,7 +215,7 @@ values.`,
 		// unset) so the test result is deterministic regardless
 		// of when the operator runs the command.
 		clock := fixedClock{t: rctx.Now}
-		eval, err := loadPolicyEngine(policyScriptPath, src, clock)
+		eval, err := loadPolicyEngine(path, src, clock)
 		if err != nil {
 			return fmt.Errorf("load policy: %w", err)
 		}
@@ -153,14 +240,11 @@ reports p50 + average per-call eval time. Use this before
 deploying a complex policy to confirm it stays inside the
 50ms per-dial timeout budget.`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		if policyScriptPath == "" {
-			return errors.New("--script is required")
-		}
-		src, err := os.ReadFile(policyScriptPath) //nolint:gosec
+		path, src, err := resolvePolicySource()
 		if err != nil {
-			return fmt.Errorf("read script: %w", err)
+			return err
 		}
-		eval, err := loadPolicyEngine(policyScriptPath, src, fixedClock{t: time.Now()})
+		eval, err := loadPolicyEngine(path, src, fixedClock{t: time.Now()})
 		if err != nil {
 			return fmt.Errorf("load policy: %w", err)
 		}
@@ -182,7 +266,7 @@ deploying a complex policy to confirm it stays inside the
 		p50 := percentile(samples, 50)
 		p99 := percentile(samples, 99)
 		if err := cliout.Print(cmd, cliroute.PolicyBench{
-			Script: policyScriptPath, Iterations: policyBenchIter,
+			Script: path, Iterations: policyBenchIter,
 			Total: total.String(), Average: avg.String(),
 			P50: p50.String(), P99: p99.String(),
 		}); err != nil {

--- a/pkg/router/policy/bridge.go
+++ b/pkg/router/policy/bridge.go
@@ -78,6 +78,9 @@ func peersModule(p Provider) *starlarkstruct.Module {
 			"is_hypervisor": starlark.NewBuiltin("is_hypervisor", oneStringArg(func(pk string) starlark.Value {
 				return starlark.Bool(p.IsHypervisor(pk))
 			})),
+			"has_transport": starlark.NewBuiltin("has_transport", oneStringArg(func(pk string) starlark.Value {
+				return starlark.Bool(p.HasTransport(pk))
+			})),
 		},
 	}
 }

--- a/pkg/router/policy/preset_loader_test.go
+++ b/pkg/router/policy/preset_loader_test.go
@@ -72,4 +72,51 @@ func TestPresetLoader(t *testing.T) {
 		assert.Equal(t, 1, spec.Mux)
 		assert.Equal(t, 1, spec.MinHops)
 	})
+
+	t.Run("prefer-connected: direct when a transport already exists", func(t *testing.T) {
+		prov := NewFakeProvider().SetHasTransport("pk_connected")
+		l, err := NewLoader("preset:prefer-connected", WithProvider(prov))
+		require.NoError(t, err)
+		spec, err := l.Decide(context.Background(), RoutingContext{App: "x", PeerPK: "pk_connected"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, spec.Mux, "connected peer → single direct leg")
+		assert.Equal(t, 1, spec.MinHops)
+		assert.Equal(t, 0, spec.RotationIntervalSeconds, "connected path is stable")
+	})
+
+	t.Run("prefer-connected: multihop fan-out when not connected", func(t *testing.T) {
+		// No provider (Nop → has_transport=false), or a provider that
+		// doesn't know this PK: fall back to the cold multihop path.
+		l, err := NewLoader("preset:prefer-connected")
+		require.NoError(t, err)
+		spec, err := l.Decide(context.Background(), RoutingContext{App: "x", PeerPK: "pk_stranger"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 2, spec.Mux, "cold peer → modest fan-out")
+		assert.Equal(t, 2, spec.MinHops)
+		assert.Greater(t, spec.RotationIntervalSeconds, 0, "cold path rotates to spread relays")
+	})
+
+	t.Run("balanced is a two-leg min_hops=1 default", func(t *testing.T) {
+		l, err := NewLoader("preset:balanced")
+		require.NoError(t, err)
+		spec, err := l.Decide(context.Background(), RoutingContext{App: "x"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 2, spec.Mux)
+		assert.Equal(t, 1, spec.MinHops)
+	})
+
+	t.Run("hypervisor-priority fans out to the control plane", func(t *testing.T) {
+		prov := NewFakeProvider().SetHypervisor("pk_hv").SetTrusted("pk_ok")
+		l, err := NewLoader("preset:hypervisor-priority", WithProvider(prov))
+		require.NoError(t, err)
+
+		hv, err := l.Decide(context.Background(), RoutingContext{PeerPK: "pk_hv"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 4, hv.Mux, "hypervisor → wide fan-out")
+		assert.Equal(t, 1, hv.MinHops)
+
+		other, err := l.Decide(context.Background(), RoutingContext{PeerPK: "pk_stranger"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 2, other.MinHops, "untrusted peer → real intermediate")
+	})
 }

--- a/pkg/router/policy/presets/balanced.star
+++ b/pkg/router/policy/presets/balanced.star
@@ -1,0 +1,35 @@
+# balanced — a sensible middle-ground default: a little redundancy and a little
+# privacy, without the latency of forced multihop or the overhead of a wide
+# fan-out.
+#
+# Sits between low-latency-direct (mux=1, RTT-optimal, no privacy/redundancy) and
+# spread-bw / privacy-max (wide fan-out, multihop, higher latency). Two legs give
+# failover if one path dies; min_hops=1 lets the route-finder take the direct
+# transport when that is genuinely the shortest path, so latency stays low for
+# nearby peers while distant ones still pick up an intermediate. A gentle
+# rotation refreshes paths over time to spread reward-eligible relay bandwidth
+# without churning an active flow.
+#
+# Good "I don't have a strong preference" choice for general app traffic. Reach
+# for low-latency-direct when RTT is king, spread-bw/privacy-max when throughput
+# or unlinkability matters more.
+#
+#   "routing": { "policy_per_dial": "preset:balanced" }
+
+def decide_route(ctx, candidates):
+    return RouteSpec(
+        mux=2,
+        min_hops=1,
+        distribution="auto",
+        rotation_interval_seconds=45,
+    )
+
+def on_tick(ctx, legs):
+    # Keep both legs healthy: shed a single dead leg so it re-dials onto a fresh
+    # path, but never drop the last live one. No aggressive badness-shedding —
+    # balanced favours a stable pair over chasing the fastest relay.
+    alive = [l for l in legs if l.alive]
+    dead = [l for l in legs if not l.alive]
+    if len(dead) > 0 and len(alive) >= 1:
+        return Rotation(drop_legs=[dead[0].index], add_leg=True, exclude_hops=dead[0].hops)
+    return None

--- a/pkg/router/policy/presets/hypervisor-priority.star
+++ b/pkg/router/policy/presets/hypervisor-priority.star
@@ -1,0 +1,31 @@
+# hypervisor-priority — fast, resilient paths for the low-bandwidth control
+# channel (visor⇄hypervisor RPC / signalling); modest privacy for everyone else.
+#
+# This shapes CONTROL-PLANE dials — a visor talking to its hypervisor or an
+# operator-trusted peer — which are latency- and resilience-sensitive but tiny
+# in bytes; unlinkability is moot there (the hypervisor already knows its
+# visors). It is NOT a data-plane policy: proxy / VPN bulk traffic should use a
+# throughput preset (spread-bw, asymmetric-fanout, balanced), which — like every
+# preset here — shapes skynet ROUTES over real transports, never the shared dmsg
+# relay. (dmsg is the relay/signalling substrate; routed app traffic rides
+# stcpr/sudph/stcp. Candidates even carry `transport_kinds` so a policy can
+# explicitly prefer direct-tcp over any dmsg-relayed hop.)
+#
+# Uses the trust signals the visor already maintains (conf.Hypervisors and the
+# dmsgpty whitelist) via peers.is_hypervisor / peers.is_trusted.
+#
+#   hypervisor  → mux=4, min_hops=1  → shortest path (direct where available),
+#                 fanned out for resilience so the control channel survives a
+#                 single path dying.
+#   trusted     → mux=2, min_hops=1  → low-latency, lightly redundant.
+#   everyone    → mux=2, min_hops=2  → route through a real intermediate; a
+#                 little unlinkability for ordinary app traffic.
+#
+#   "routing": { "policy_per_dial": "preset:hypervisor-priority" }
+
+def decide_route(ctx, candidates):
+    if peers.is_hypervisor(ctx.peer_pk):
+        return RouteSpec(mux=4, min_hops=1, distribution="auto", rotation_interval_seconds=0)
+    if peers.is_trusted(ctx.peer_pk):
+        return RouteSpec(mux=2, min_hops=1, distribution="auto", rotation_interval_seconds=0)
+    return RouteSpec(mux=2, min_hops=2, distribution="auto", rotation_interval_seconds=30)

--- a/pkg/router/policy/presets/prefer-connected.star
+++ b/pkg/router/policy/presets/prefer-connected.star
@@ -1,0 +1,46 @@
+# prefer-connected — reuse the transports we already hold; don't pay to set up a
+# fresh one on the dial hot path.
+#
+# Route-setup cost is dominated by building NEW transports (noise handshake + AR
+# register + route-finder lookup). When the visor already holds a live transport
+# to the target, the cheapest, fastest, lowest-latency route is the one that
+# rides it. This preset asks the provider whether such a transport exists
+# (peers.has_transport) and shapes the route accordingly:
+#
+#   already connected  → mux=1, min_hops=1  → take the direct transport we hold;
+#                        no fan-out, no churn — there is nothing new to set up.
+#   not connected      → mux=2, min_hops=2  → route through intermediates (which
+#                        are frequently peers we ARE already connected to)
+#                        instead of forcing a brand-new direct transport to a
+#                        stranger; a light fan-out keeps some throughput +
+#                        reward spread while paths warm up.
+#
+# This is the routing-layer companion to proxy/exit selection preferring servers
+# we already have transports to: there the app picks a connected exit; here the
+# router, given whatever target, prefers the path that reuses existing plumbing.
+# Good default for a visor that already maintains a healthy transport set and
+# wants dials to be fast and cheap rather than maximally private.
+#
+# Select without compiling a file:
+#   "routing": { "policy_per_dial": "preset:prefer-connected" }
+
+CONNECTED_MUX = 1
+CONNECTED_MIN_HOPS = 1
+COLD_MUX = 2
+COLD_MIN_HOPS = 2
+COLD_ROTATE_SECS = 30   # only the cold (multihop) path rotates, to spread relays
+
+def decide_route(ctx, candidates):
+    if peers.has_transport(ctx.peer_pk):
+        return RouteSpec(
+            mux=CONNECTED_MUX,
+            min_hops=CONNECTED_MIN_HOPS,
+            distribution="auto",
+            rotation_interval_seconds=0,   # stable: reuse the transport we hold
+        )
+    return RouteSpec(
+        mux=COLD_MUX,
+        min_hops=COLD_MIN_HOPS,
+        distribution="auto",
+        rotation_interval_seconds=COLD_ROTATE_SECS,
+    )

--- a/pkg/router/policy/provider.go
+++ b/pkg/router/policy/provider.go
@@ -48,6 +48,15 @@ type Provider interface {
 	// dial hypervisors with minimum hops + maximum mux for low-
 	// latency control-plane traffic.
 	IsHypervisor(pk string) bool
+
+	// HasTransport reports whether the visor already holds a live
+	// transport to this peer (of any type). Policies use it to
+	// prefer routing over peers we're already connected to —
+	// reusing existing plumbing instead of paying the setup cost of
+	// a fresh transport (handshake + AR register + route-finder) on
+	// the dial hot path. False when the peer is only reachable
+	// through intermediates, or unknown.
+	HasTransport(pk string) bool
 }
 
 // NopProvider returns a Provider that knows nothing — Geo
@@ -63,6 +72,7 @@ func (nopProvider) Latency(string) int       { return 0 }
 func (nopProvider) Kind(string) string       { return "" }
 func (nopProvider) IsTrusted(string) bool    { return false }
 func (nopProvider) IsHypervisor(string) bool { return false }
+func (nopProvider) HasTransport(string) bool { return false }
 
 // FakeProvider is a test helper. Construct via NewFakeProvider
 // with the visor state the test wants to simulate.
@@ -71,19 +81,21 @@ type FakeProvider struct {
 	geo         map[string]string
 	latency     map[string]int
 	kind        map[string]string
-	trusted     map[string]bool
-	hypervisors map[string]bool
+	trusted      map[string]bool
+	hypervisors  map[string]bool
+	hasTransport map[string]bool
 }
 
 // NewFakeProvider returns an empty FakeProvider. Tests call the
 // Set* methods to populate it before passing to the Evaluator.
 func NewFakeProvider() *FakeProvider {
 	return &FakeProvider{
-		geo:         map[string]string{},
-		latency:     map[string]int{},
-		kind:        map[string]string{},
-		trusted:     map[string]bool{},
-		hypervisors: map[string]bool{},
+		geo:          map[string]string{},
+		latency:      map[string]int{},
+		kind:         map[string]string{},
+		trusted:      map[string]bool{},
+		hypervisors:  map[string]bool{},
+		hasTransport: map[string]bool{},
 	}
 }
 
@@ -127,6 +139,15 @@ func (p *FakeProvider) SetHypervisor(pk string) *FakeProvider {
 	return p
 }
 
+// SetHasTransport marks a peer as one the visor already holds a
+// live transport to.
+func (p *FakeProvider) SetHasTransport(pk string) *FakeProvider {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.hasTransport[pk] = true
+	return p
+}
+
 // Geo implements Provider.
 func (p *FakeProvider) Geo(pk string) string {
 	p.mu.RLock()
@@ -163,4 +184,11 @@ func (p *FakeProvider) IsHypervisor(pk string) bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.hypervisors[pk]
+}
+
+// HasTransport implements Provider.
+func (p *FakeProvider) HasTransport(pk string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.hasTransport[pk]
 }

--- a/pkg/router/policy/stdlib_test.go
+++ b/pkg/router/policy/stdlib_test.go
@@ -116,6 +116,39 @@ def decide_route(ctx, candidates):
 	}
 }
 
+func TestPeers_HasTransport(t *testing.T) {
+	prov := NewFakeProvider().SetHasTransport("pk_connected")
+	src := `
+def decide_route(ctx, candidates):
+    if peers.has_transport(ctx.peer_pk):
+        return RouteSpec(mux = 1, min_hops = 1)
+    return RouteSpec(mux = 2, min_hops = 2)
+`
+	eval, err := NewEvaluator("has_transport.star", src, WithProvider(prov))
+	if err != nil {
+		t.Fatalf("NewEvaluator: %v", err)
+	}
+	cases := []struct {
+		pk          string
+		wantMux     int
+		wantMinHops int
+	}{
+		{"pk_connected", 1, 1},
+		{"pk_stranger", 2, 2},
+	}
+	for _, tc := range cases {
+		spec, err := eval.Decide(context.Background(), RoutingContext{PeerPK: tc.pk}, nil)
+		if err != nil {
+			t.Errorf("Decide(%s): %v", tc.pk, err)
+			continue
+		}
+		if spec.Mux != tc.wantMux || spec.MinHops != tc.wantMinHops {
+			t.Errorf("has_transport branch for %s: mux=%d min_hops=%d, want mux=%d min_hops=%d",
+				tc.pk, spec.Mux, spec.MinHops, tc.wantMux, tc.wantMinHops)
+		}
+	}
+}
+
 func TestLogging_InfoAndWarn(t *testing.T) {
 	// Capture the messages the policy emits via logging.info /
 	// logging.warn and assert both reach the logger.

--- a/pkg/visor/policy_provider.go
+++ b/pkg/visor/policy_provider.go
@@ -282,6 +282,23 @@ func (p *visorPolicyProvider) IsHypervisor(pk string) bool {
 	return ok
 }
 
+// HasTransport implements policy.Provider. True when the visor
+// already holds a live transport to the peer (any type). Backed by
+// the same preferred-transport lookup Latency/Kind use, so it's a
+// near-instant map hit in the transport manager — cheap enough for
+// the dial hot path. Lets "prefer-connected" policies bias toward
+// peers we're already wired to, avoiding a fresh-transport setup.
+func (p *visorPolicyProvider) HasTransport(pk string) bool {
+	if p.tpM == nil {
+		return false
+	}
+	pubkey, ok := parsePK(pk)
+	if !ok {
+		return false
+	}
+	return p.preferredTransport(pubkey) != nil
+}
+
 // preferredTransport returns the most-preferred existing transport
 // to the peer (stcpr > sudph > stcp > dmsg) or nil. Used by
 // Latency() and Kind() to get a single representative transport


### PR DESCRIPTION
Rounds out the built-in routing-policy library and closes the CLI discoverability gap.

**New DSL primitive** — `peers.has_transport(pk)`: reports whether the visor already holds a live transport to a peer (backed by the transport manager). Lets policies bias toward peers we're already wired to.

**New presets** (all shape skynet routes over real transports, never the dmsg relay):
- `prefer-connected` — direct when a transport already exists, else multihop through peers we're connected to.
- `balanced` — two-leg `min_hops=1` middle-ground default.
- `hypervisor-priority` — fast, resilient paths for the low-bandwidth control channel (`is_hypervisor`/`is_trusted`); explicitly not a data-plane policy.

**CLI** (`skywire cli route policy`): `list`, `show <name>`, and `test`/`bench --preset <name>` — the built-ins are now discoverable and previewable without extracting source.

Tests cover the `has_transport` branch and all three presets. Full preset suite + `go build ./...` + vet green.
