### PR TITLE
feat(visor): mirror panic/fatal tracebacks to skywire-crash.log + dev-visor-loop.sh

### DIFF
--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1181,6 +1182,30 @@ func storeLog(conf *visorconfig.V1) {
 	// Create log directory with readable permissions for log access
 	if err := os.MkdirAll(logPath, 0750); err != nil { //nolint:gosec
 		mLog.WithError(err).Warn("Failed to create log directory")
+	}
+
+	// Capture unhandled panics / fatal runtime errors to disk. The Go runtime
+	// writes these straight to stderr (the terminal) and NOT through logrus, so a
+	// crash otherwise leaves nothing in skywire.log — worst of all a panic on a
+	// background goroutine, which a top-level recover() can neither catch nor even
+	// stack-trace correctly (by the time a deferred recover runs the stack has
+	// unwound). SetCrashOutput (Go 1.23+) mirrors the FULL original traceback of
+	// any unrecovered panic/fatal error to skywire-crash.log, in ADDITION to
+	// stderr — so the terminal still shows it live and it survives the run for
+	// postmortem. A crash left there by a previous run is surfaced in skywire.log
+	// on the next boot so it isn't missed.
+	crashPath := logPath + "/skywire-crash.log"
+	if prev, err := os.Stat(crashPath); err == nil && prev.Size() > 0 {
+		mLog.PackageLogger("visor").Warnf(
+			"previous run recorded a crash — full traceback in %s (%d bytes)", crashPath, prev.Size())
+	}
+	if cf, err := os.OpenFile(crashPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err != nil { //nolint:gosec
+		mLog.WithError(err).Warn("Failed to open crash-output file; panics will print to stderr only")
+	} else {
+		if err := debug.SetCrashOutput(cf, debug.CrashOptions{}); err != nil {
+			mLog.WithError(err).Warn("Failed to set crash output; panics will print to stderr only")
+		}
+		_ = cf.Close() //nolint:errcheck // SetCrashOutput dup'd the fd; this handle is no longer needed
 	}
 
 	// Pre-create or fix permissions on the log file to make it readable

--- a/scripts/dev-visor-loop.sh
+++ b/scripts/dev-visor-loop.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# dev-visor-loop.sh — rebuild + run the visor in a loop, preserving logs on crash.
+#
+# Clean exit (0) or Ctrl-C (130) / SIGTERM (143): discard ./local/log and start fresh.
+# Any other exit (panic/crash): move ./local/log aside to
+#   ./local/crashlog-<timestamp>-exit<code>/   (its skywire-crash.log holds the
+#   full traceback, thanks to runtime/debug.SetCrashOutput in storeLog()).
+#
+# Override the visor flags without editing this file:
+#   VISOR_FLAGS="-sl debug -q http" ./dev-visor-loop.sh
+#
+# Runs from the repo root regardless of where it is invoked.
+set -o pipefail
+cd "$(dirname "$0")/.." || exit 1 # script lives in scripts/, build from repo root
+
+VISOR_FLAGS="${VISOR_FLAGS:--sl debug -q http}"
+
+while true; do
+	echo ">>> building…"
+	if ! time go build .; then
+		echo ">>> build failed — not starting a stale binary; retrying in 5s"
+		sleep 5
+		continue
+	fi
+
+	# shellcheck disable=SC2086 # VISOR_FLAGS is intentionally word-split
+	./skywire visor $VISOR_FLAGS
+	code=$?
+
+	case "$code" in
+		0 | 130 | 143) # clean exit / Ctrl-C (SIGINT) / SIGTERM
+			rm -rf ./local/log
+			sleep 5
+			clear
+			;;
+		*) # crash / nonzero — keep everything for postmortem
+			ts=$(date +%Y%m%dT%H%M%S) # sortable, no colons/spaces
+			dest="./local/crashlog-${ts}-exit${code}"
+			mv ./local/log "$dest" 2>/dev/null
+			echo ">>> visor exited ${code} — logs saved to ${dest}/"
+			echo ">>> traceback (if any) is in ${dest}/skywire-crash.log"
+			sleep 10 # no clear: leave the terminal trace on screen
+			;;
+	esac
+done


### PR DESCRIPTION
Unhandled panics and fatal runtime errors are written by the Go runtime straight to stderr and **not** through logrus, so a crash left nothing in `skywire.log` — worst of all a panic on a background goroutine (e.g. an app/proxy launch), which a top-level `recover()` can neither catch nor stack-trace correctly (the stack is already unwound by the time a deferred recover runs).

- `storeLog()` now calls `runtime/debug.SetCrashOutput` (Go 1.23+), mirroring the full original traceback of any unrecovered panic/fatal to `local/log/skywire-crash.log` **in addition to** stderr — the terminal still shows it live, and it survives for postmortem. On boot, a non-empty crash file from a previous run is surfaced in `skywire.log` as a WARN.
- `scripts/dev-visor-loop.sh`: a rebuild+run dev loop that preserves crash evidence — on a clean exit/Ctrl-C it discards `./local/log`, but on a nonzero exit it moves the dir aside to `./local/crashlog-<ts>-exit<code>/`, and skips running a stale binary when the build fails.
