### PR TITLE
third_party: sync vendored 0magnet/sh/v3 to fork @84701f5d

### DIFF
--- a/third_party/0magnet/sh/v3/expand/arith.go
+++ b/third_party/0magnet/sh/v3/expand/arith.go
@@ -89,6 +89,23 @@ func Arithm(cfg *Config, expr syntax.ArithmExpr) (int, error) {
 				return Arithm(cfg, b2.X)
 			}
 			return Arithm(cfg, b2.Y)
+		case syntax.AndArit, syntax.OrArit:
+			// Like Bash, short-circuit the right operand.
+			left, err := Arithm(cfg, expr.X)
+			if err != nil {
+				return 0, err
+			}
+			if expr.Op == syntax.AndArit && left == 0 {
+				return 0, nil
+			}
+			if expr.Op == syntax.OrArit && left != 0 {
+				return 1, nil
+			}
+			right, err := Arithm(cfg, expr.Y)
+			if err != nil {
+				return 0, err
+			}
+			return oneIf(right != 0), nil
 		}
 		left, err := Arithm(cfg, expr.X)
 		if err != nil {
@@ -290,10 +307,6 @@ func binArit(op syntax.BinAritOperator, x, y int) (int, error) {
 		return x >> uint(y), nil
 	case syntax.Shl:
 		return x << uint(y), nil
-	case syntax.AndArit:
-		return oneIf(x != 0 && y != 0), nil
-	case syntax.OrArit:
-		return oneIf(x != 0 || y != 0), nil
 	case syntax.Comma:
 		// x is executed but its result discarded
 		return y, nil

--- a/third_party/0magnet/sh/v3/expand/environ.go
+++ b/third_party/0magnet/sh/v3/expand/environ.go
@@ -7,6 +7,7 @@ import (
 	"cmp"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 )
 
@@ -101,6 +102,12 @@ type Variable struct {
 	Str  string            // Used when Kind is String or NameRef.
 	List []string          // Used when Kind is Indexed.
 	Map  map[string]string // Used when Kind is Associative.
+
+	// Indexes records the index of each [Variable.List] element when an
+	// indexed array is sparse, such as `a=([2]=x [5]=y)`. The indices
+	// must be unique, non-negative, sorted, and as many as the List
+	// elements. Nil means the array is dense: element i has index i.
+	Indexes []int
 }
 
 // IsSet reports whether the variable has been set to a value.
@@ -144,13 +151,42 @@ func (v Variable) String() string {
 	case String:
 		return v.Str
 	case Indexed:
-		if len(v.List) > 0 {
-			return v.List[0]
+		if str, ok := v.indexedVal(0); ok {
+			return str
 		}
 	case Associative:
 		// nothing to do
 	}
 	return ""
+}
+
+// indexedVal returns the element of an indexed array at index i,
+// taking [Variable.Indexes] into account for sparse arrays.
+func (v Variable) indexedVal(i int) (string, bool) {
+	if v.Indexes != nil {
+		if pos, ok := slices.BinarySearch(v.Indexes, i); ok {
+			return v.List[pos], true
+		}
+		return "", false
+	}
+	if i < len(v.List) {
+		return v.List[i], true
+	}
+	return "", false
+}
+
+// indexedKeys returns the index of each element of an indexed array as a
+// string, for the sake of expansions like "${!a[@]}".
+func (v Variable) indexedKeys() []string {
+	keys := make([]string, len(v.List))
+	for i := range v.List {
+		if v.Indexes != nil {
+			keys[i] = strconv.Itoa(v.Indexes[i])
+		} else {
+			keys[i] = strconv.Itoa(i)
+		}
+	}
+	return keys
 }
 
 // maxNameRefDepth defines the maximum number of times to follow references when

--- a/third_party/0magnet/sh/v3/expand/expand.go
+++ b/third_party/0magnet/sh/v3/expand/expand.go
@@ -427,21 +427,31 @@ func (cfg *Config) fieldJoin(parts []fieldPart) string {
 }
 
 func (cfg *Config) escapedGlobField(parts []fieldPart) (escaped string, glob bool) {
+	candidate := false
+	for _, part := range parts {
+		if part.quote == quoteNone && strings.ContainsAny(part.val, "*?[") {
+			candidate = true
+			break
+		}
+	}
+	if !candidate {
+		return "", false
+	}
 	sb := cfg.strBuilder()
 	for _, part := range parts {
 		if part.quote > quoteNone {
 			sb.WriteString(pattern.QuoteMeta(part.val, 0))
-			continue
-		}
-		sb.WriteString(part.val)
-		if pattern.HasMeta(part.val, 0) {
-			glob = true
+		} else {
+			sb.WriteString(part.val)
 		}
 	}
-	if glob { // only copy the string if it will be used
-		escaped = sb.String()
+	// Check the entire escaped word, as a bracket expression could span
+	// multiple unquoted parts, such as `[a$x` where x holds "]".
+	escaped = sb.String()
+	if pattern.HasMeta(escaped, 0) {
+		return escaped, true
 	}
-	return escaped, glob
+	return "", false
 }
 
 // Fields is a pre-iterators API which now wraps [FieldsSeq].
@@ -795,13 +805,13 @@ func (cfg *Config) listElems(pe *syntax.ParamExp) (elems []string, star, ok bool
 	}
 	switch name := pe.Param.Value; name {
 	case "*", "@":
-		return cfg.sliceElems(pe, cfg.Env.Get(name).List, true), name == "*", true
+		return cfg.sliceElems(pe, cfg.Env.Get(name).List, nil, true), name == "*", true
 	}
 	switch lit := nodeLit(pe.Index); lit {
 	case "@", "*":
 		switch vr := cfg.Env.Get(pe.Param.Value); vr.Kind {
 		case Indexed:
-			return cfg.sliceElems(pe, vr.List, false), lit == "*", true
+			return cfg.sliceElems(pe, vr.List, vr.Indexes, false), lit == "*", true
 		case Associative:
 			return slices.Sorted(maps.Values(vr.Map)), lit == "*", true
 		}
@@ -838,13 +848,7 @@ func (cfg *Config) quotedElemFields(pe *syntax.ParamExp) ([]string, error) {
 		case "@": // "${!name[@]}"
 			switch vr := cfg.Env.Get(name); vr.Kind {
 			case Indexed:
-				// TODO: if an indexed array only has elements 0 and 10,
-				// we should not return all indices in between those.
-				keys := make([]string, 0, len(vr.List))
-				for key := range vr.List {
-					keys = append(keys, strconv.Itoa(key))
-				}
-				return keys, nil
+				return vr.indexedKeys(), nil
 			case Associative:
 				return slices.Collect(maps.Keys(vr.Map)), nil
 			}
@@ -874,7 +878,9 @@ func (cfg *Config) quotedElemFields(pe *syntax.ParamExp) ([]string, error) {
 // In bash, positional parameter offsets ($@ and $*) are 1-based and
 // offset 0 includes $0 (the shell or script name). Negative offsets
 // count from $# + 1, so $0 is reachable via large enough negative values.
-func (cfg *Config) sliceElems(pe *syntax.ParamExp, elems []string, positional bool) []string {
+// A non-nil indexes records the index of each element in a sparse array;
+// see [Variable.Indexes].
+func (cfg *Config) sliceElems(pe *syntax.ParamExp, elems []string, indexes []int, positional bool) []string {
 	if pe.Slice == nil {
 		return elems
 	}
@@ -897,7 +903,21 @@ func (cfg *Config) sliceElems(pe *syntax.ParamExp, elems []string, positional bo
 		if err != nil {
 			return elems
 		}
-		elems = elems[slicePos(offset):]
+		if len(indexes) > 0 {
+			// Sparse arrays slice by index: a negative offset counts
+			// from one past the maximum index, and the result begins
+			// with the first element whose index is at least the offset.
+			if offset < 0 {
+				offset += indexes[len(indexes)-1] + 1
+				if offset < 0 {
+					offset = indexes[len(indexes)-1] + 1
+				}
+			}
+			pos, _ := slices.BinarySearch(indexes, offset)
+			elems = elems[pos:]
+		} else {
+			elems = elems[slicePos(offset):]
+		}
 	}
 	if pe.Slice.Length != nil {
 		length, err := Arithm(cfg, pe.Slice.Length)

--- a/third_party/0magnet/sh/v3/expand/param.go
+++ b/third_party/0magnet/sh/v3/expand/param.go
@@ -13,6 +13,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/skycoin/skywire/third_party/0magnet/sh/v3/internal"
 	"github.com/skycoin/skywire/third_party/0magnet/sh/v3/pattern"
 	"github.com/skycoin/skywire/third_party/0magnet/sh/v3/syntax"
 )
@@ -117,6 +118,7 @@ func (cfg *Config) paramExp(pe *syntax.ParamExp) (string, error) {
 
 		indexAllElements bool // true if var has been accessed with * or @ index
 		callVarInd       = true
+		set              = vr.IsSet()
 	)
 
 	switch nodeLit(index) {
@@ -128,13 +130,13 @@ func (cfg *Config) paramExp(pe *syntax.ParamExp) (string, error) {
 		case Indexed:
 			indexAllElements = true
 			callVarInd = false
-			elems = cfg.sliceElems(pe, vr.List, name == "@" || name == "*")
+			elems = cfg.sliceElems(pe, vr.List, vr.Indexes, name == "@" || name == "*")
 			str = join(elems)
 		}
 	}
 	if callVarInd {
 		var err error
-		str, err = cfg.varInd(vr, index)
+		str, set, err = cfg.varInd(vr, index)
 		if err != nil {
 			return "", err
 		}
@@ -160,11 +162,7 @@ func (cfg *Config) paramExp(pe *syntax.ParamExp) (string, error) {
 		case orig.Kind == NameRef:
 			strs = append(strs, orig.Str)
 		case pe.Index != nil && vr.Kind == Indexed:
-			// TODO: this is only correct for dense lists, as we
-			// cannot represent the unset elements of a sparse array.
-			for i := range vr.List {
-				strs = append(strs, strconv.Itoa(i))
-			}
+			strs = vr.indexedKeys()
 		case pe.Index != nil && vr.Kind == Associative:
 			strs = slices.Sorted(maps.Keys(vr.Map))
 		case !vr.IsSet():
@@ -221,11 +219,11 @@ func (cfg *Config) paramExp(pe *syntax.ParamExp) (string, error) {
 			}
 			fallthrough
 		case syntax.AlternateUnset:
-			if vr.IsSet() {
+			if set {
 				str = arg
 			}
 		case syntax.DefaultUnset:
-			if vr.IsSet() {
+			if set {
 				break
 			}
 			fallthrough
@@ -234,7 +232,7 @@ func (cfg *Config) paramExp(pe *syntax.ParamExp) (string, error) {
 				str = arg
 			}
 		case syntax.ErrorUnset:
-			if vr.IsSet() {
+			if set {
 				break
 			}
 			fallthrough
@@ -246,13 +244,13 @@ func (cfg *Config) paramExp(pe *syntax.ParamExp) (string, error) {
 				}
 			}
 		case syntax.AssignUnset:
-			if vr.IsSet() {
+			if set {
 				break
 			}
 			fallthrough
 		case syntax.AssignUnsetOrNull:
 			if str == "" {
-				if err := cfg.envSet(name, arg); err != nil {
+				if err := cfg.assignElem(name, vr, index, arg); err != nil {
 					return "", err
 				}
 				str = arg
@@ -449,50 +447,124 @@ func (cfg *Config) caseConvElems(op syntax.ParExpOperator, arg string, elems []s
 	return out
 }
 
-func (cfg *Config) varInd(vr Variable, idx syntax.ArithmExpr) (string, error) {
+// varInd expands an indexed variable expansion like ${a[i]}, also reporting
+// whether the resulting element is set, which may be false for missing array
+// elements such as the holes in a sparse array.
+func (cfg *Config) varInd(vr Variable, idx syntax.ArithmExpr) (string, bool, error) {
 	if idx == nil {
-		return vr.String(), nil
+		switch vr.Kind {
+		case Indexed:
+			// A bare $a is the element at index zero, which may be unset.
+			str, ok := vr.indexedVal(0)
+			return str, ok, nil
+		case Associative:
+			str, ok := vr.Map["0"]
+			return str, ok, nil
+		}
+		return vr.String(), vr.IsSet(), nil
 	}
 	switch vr.Kind {
 	case String:
 		n, err := Arithm(cfg, idx)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
 		if n == 0 {
-			return vr.Str, nil
+			return vr.Str, vr.IsSet(), nil
 		}
 	case Indexed:
 		switch nodeLit(idx) {
 		case "*", "@":
-			return strings.Join(vr.List, " "), nil
+			return strings.Join(vr.List, " "), vr.IsSet(), nil
 		}
 		i, err := Arithm(cfg, idx)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
 		if i < 0 {
-			return "", fmt.Errorf("negative array index")
+			// Negative indices count from one past the maximum index.
+			if i += internal.IndexedMax(vr.List, vr.Indexes) + 1; i < 0 {
+				return "", false, fmt.Errorf("negative array index")
+			}
 		}
-		if i < len(vr.List) {
-			return vr.List[i], nil
+		if str, ok := vr.indexedVal(i); ok {
+			return str, true, nil
 		}
 	case Associative:
 		switch lit := nodeLit(idx); lit {
 		case "@", "*":
 			strs := slices.Sorted(maps.Values(vr.Map))
 			if lit == "*" {
-				return cfg.ifsJoin(strs), nil
+				return cfg.ifsJoin(strs), vr.IsSet(), nil
 			}
-			return strings.Join(strs, " "), nil
+			return strings.Join(strs, " "), vr.IsSet(), nil
 		}
 		val, err := Literal(cfg, idx.(*syntax.Word))
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
-		return vr.Map[val], nil
+		str, ok := vr.Map[val]
+		return str, ok, nil
 	}
-	return "", nil
+	return "", false, nil
+}
+
+// assignElem assigns a variable via an expansion like ${a=val} or
+// ${a[i]=val}, setting a single element when the variable is an array or is
+// indexed, like Bash. ${a[i]=val} on a whole scalar converts it to an array.
+func (cfg *Config) assignElem(name string, vr Variable, idx syntax.ArithmExpr, val string) error {
+	wenv, ok := cfg.Env.(WriteEnviron)
+	if !ok {
+		return fmt.Errorf("environment is read-only")
+	}
+	arrayWise := false
+	switch nodeLit(idx) {
+	case "@", "*":
+		// ${a[@]=val} assigns the element at index zero.
+		arrayWise = true
+		idx = nil
+	}
+	if idx == nil && !arrayWise && vr.Kind != Indexed && vr.Kind != Associative {
+		// A plain scalar assignment like ${x=val}.
+		return wenv.Set(name, Variable{Set: true, Kind: String, Str: val})
+	}
+	switch vr.Kind {
+	case Associative:
+		key := "0"
+		if idx != nil {
+			var err error
+			if key, err = Literal(cfg, idx.(*syntax.Word)); err != nil {
+				return err
+			}
+		}
+		vr.Map = maps.Clone(vr.Map)
+		if vr.Map == nil {
+			vr.Map = make(map[string]string, 1)
+		}
+		vr.Map[key] = val
+	default: // assign a single indexed element
+		i := 0
+		if idx != nil {
+			var err error
+			if i, err = Arithm(cfg, idx); err != nil {
+				return err
+			}
+			if i < 0 {
+				// Negative indices count from one past the maximum index.
+				if i += internal.IndexedMax(vr.List, vr.Indexes) + 1; i < 0 {
+					return fmt.Errorf("negative array index")
+				}
+			}
+		}
+		list, indexes := slices.Clone(vr.List), slices.Clone(vr.Indexes)
+		if vr.Kind == String {
+			list, indexes = []string{vr.Str}, nil
+		}
+		list, indexes = internal.SetIndexedElem(list, indexes, i, val)
+		vr.Kind, vr.Str, vr.List, vr.Indexes = Indexed, "", list, indexes
+	}
+	vr.Set = true
+	return wenv.Set(name, vr)
 }
 
 func (cfg *Config) namesByPrefix(prefix string) []string {

--- a/third_party/0magnet/sh/v3/internal/sparse.go
+++ b/third_party/0magnet/sh/v3/internal/sparse.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026, Daniel Martí <mvdan@mvdan.cc>
+// See LICENSE for licensing information
+
+package internal
+
+import "slices"
+
+// The helpers below manipulate indexed array variables held as a list of
+// elements plus the index of each element when the array is sparse.
+// A nil indexes slice means the array is dense: each element's index is its
+// position in the list. See the expand.Variable.Indexes field.
+
+// IndexedMax returns the maximum index of an indexed array,
+// or -1 when the array is empty.
+func IndexedMax(list []string, indexes []int) int {
+	if len(indexes) > 0 {
+		return indexes[len(indexes)-1]
+	}
+	return len(list) - 1
+}
+
+// SetIndexedElem returns list and indexes with the element at index k set,
+// converting a dense array to a sparse one when setting index k would
+// otherwise leave a hole. The index k must not be negative.
+func SetIndexedElem(list []string, indexes []int, k int, val string) ([]string, []int) {
+	if indexes == nil {
+		if k < len(list) {
+			list[k] = val
+			return list, nil
+		}
+		if k == len(list) {
+			return append(list, val), nil
+		}
+		indexes = make([]int, len(list), len(list)+1)
+		for i := range indexes {
+			indexes[i] = i
+		}
+	}
+	pos, ok := slices.BinarySearch(indexes, k)
+	if ok {
+		list[pos] = val
+		return list, indexes
+	}
+	list = slices.Insert(list, pos, val)
+	indexes = slices.Insert(indexes, pos, k)
+	return list, CanonicalIndexes(indexes)
+}
+
+// DeleteIndexedElem is like [SetIndexedElem], but unsetting the element at
+// index k, which may leave a hole.
+func DeleteIndexedElem(list []string, indexes []int, k int) ([]string, []int) {
+	if indexes == nil {
+		if k < 0 || k >= len(list) {
+			return list, nil
+		}
+		if k == len(list)-1 {
+			return list[:k], nil
+		}
+		indexes = make([]int, len(list))
+		for i := range indexes {
+			indexes[i] = i
+		}
+	}
+	pos, ok := slices.BinarySearch(indexes, k)
+	if !ok {
+		return list, indexes
+	}
+	list = slices.Delete(list, pos, pos+1)
+	indexes = slices.Delete(indexes, pos, pos+1)
+	return list, CanonicalIndexes(indexes)
+}
+
+// CanonicalIndexes returns nil when indexes is simply 0, 1, 2, and so on,
+// as a dense array should leave the indexes nil.
+func CanonicalIndexes(indexes []int) []int {
+	for i, k := range indexes {
+		if k != i {
+			return indexes
+		}
+	}
+	return nil
+}

--- a/third_party/0magnet/sh/v3/interp/builtin.go
+++ b/third_party/0magnet/sh/v3/interp/builtin.go
@@ -264,7 +264,9 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 		}
 
 		for _, arg := range args {
-			if vars && r.lookupVar(arg).IsSet() {
+			if name, sub, ok := cutElemSubscript(arg); vars && ok {
+				r.unsetElem(name, sub)
+			} else if vars && r.lookupVar(arg).IsSet() {
 				r.delVar(arg)
 			} else if _, ok := r.Funcs[arg]; ok && funcs {
 				delete(r.Funcs, arg)

--- a/third_party/0magnet/sh/v3/interp/runner.go
+++ b/third_party/0magnet/sh/v3/interp/runner.go
@@ -786,7 +786,11 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 						if i > 0 {
 							r.out(" ")
 						}
-						r.outf("[%d]=%q", i, v)
+						idx := i
+						if vr.Indexes != nil {
+							idx = vr.Indexes[i]
+						}
+						r.outf("[%d]=%q", idx, v)
 					}
 					r.out(")\n")
 				case expand.Associative:

--- a/third_party/0magnet/sh/v3/interp/vars.go
+++ b/third_party/0magnet/sh/v3/interp/vars.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/skycoin/skywire/third_party/0magnet/sh/v3/expand"
+	"github.com/skycoin/skywire/third_party/0magnet/sh/v3/internal"
 	"github.com/skycoin/skywire/third_party/0magnet/sh/v3/syntax"
 )
 
@@ -97,6 +98,7 @@ func (o *overlayEnviron) Set(name string, vr expand.Variable) error {
 		vr.Kind = prev.Kind
 		vr.Str = prev.Str
 		vr.List = prev.List
+		vr.Indexes = prev.Indexes
 		vr.Map = prev.Map
 	} else if prev.ReadOnly {
 		return fmt.Errorf("readonly variable")
@@ -259,12 +261,14 @@ func (r *Runner) setVarWithIndex(prev expand.Variable, name string, index syntax
 	valStr := vr.Str
 
 	var list []string
+	var indexes []int
 	switch prev.Kind {
 	case expand.String:
 		list = append(list, prev.Str)
 	case expand.Indexed:
 		// TODO: only clone when inside a subshell and getting a var from outside for the first time
 		list = slices.Clone(prev.List)
+		indexes = slices.Clone(prev.Indexes)
 	case expand.Associative:
 		// if the existing variable is already an AssocArray, try our
 		// best to convert the key to a string
@@ -284,13 +288,85 @@ func (r *Runner) setVarWithIndex(prev expand.Variable, name string, index syntax
 		return
 	}
 	k := r.arithm(index)
-	for len(list) < k+1 {
-		list = append(list, "")
+	if k < 0 {
+		// Negative indices count from one past the maximum index.
+		if k += internal.IndexedMax(list, indexes) + 1; k < 0 {
+			r.errf("%s: bad array subscript\n", name)
+			r.exit.code = 1
+			return
+		}
 	}
-	list[k] = valStr
+	list, indexes = internal.SetIndexedElem(list, indexes, k, valStr)
 	prev.Kind = expand.Indexed
 	prev.List = list
+	prev.Indexes = indexes
 	r.setVar(name, prev)
+}
+
+// cutElemSubscript splits an array element argument like `a[3]`, as used by
+// the unset builtin, into the array name and the subscript between brackets.
+func cutElemSubscript(arg string) (name, sub string, ok bool) {
+	i := strings.IndexByte(arg, '[')
+	if i > 0 && strings.HasSuffix(arg, "]") && syntax.ValidName(arg[:i]) {
+		return arg[:i], arg[i+1 : len(arg)-1], true
+	}
+	return "", "", false
+}
+
+// unsetElem unsets a single element of an indexed or associative array, like
+// `unset 'a[3]'`. Unsetting an indexed array element may leave a hole.
+func (r *Runner) unsetElem(name, sub string) {
+	vr := r.lookupVar(name)
+	if n, v := vr.Resolve(r.writeEnv); n != "" {
+		name, vr = n, v
+	}
+	switch vr.Kind {
+	case expand.Indexed:
+		if sub == "@" || sub == "*" {
+			r.delVar(name)
+			return
+		}
+		expr, err := syntax.NewParser().Arithmetic(strings.NewReader(sub))
+		if err != nil {
+			r.errf("unset: %s[%s]: bad array subscript\n", name, sub)
+			r.exit.code = 1
+			return
+		}
+		if expr == nil {
+			return // an empty subscript like `unset 'a[]'` is a no-op
+		}
+		k := r.arithm(expr)
+		if k < 0 {
+			// Negative indices count from one past the maximum index.
+			if k += internal.IndexedMax(vr.List, vr.Indexes) + 1; k < 0 {
+				r.errf("unset: %s[%s]: bad array subscript\n", name, sub)
+				r.exit.code = 1
+				return
+			}
+		}
+		// TODO: only clone when inside a subshell and getting a var from outside for the first time
+		vr.List = slices.Clone(vr.List)
+		vr.Indexes = slices.Clone(vr.Indexes)
+		vr.List, vr.Indexes = internal.DeleteIndexedElem(vr.List, vr.Indexes, k)
+		r.setVar(name, vr)
+	case expand.Associative:
+		if sub == "@" || sub == "*" {
+			r.delVar(name)
+			return
+		}
+		// TODO: only clone when inside a subshell and getting a var from outside for the first time
+		vr.Map = maps.Clone(vr.Map)
+		delete(vr.Map, sub)
+		r.setVar(name, vr)
+	case expand.String:
+		// A scalar can be unset via subscript zero.
+		if sub == "0" {
+			r.delVar(name)
+		} else {
+			r.errf("unset: %s: not an array variable\n", name)
+			r.exit.code = 1
+		}
+	}
 }
 
 func (r *Runner) setFunc(name string, body *syntax.Stmt) {
@@ -334,10 +410,12 @@ func (r *Runner) assignVal(name string, prev expand.Variable, as *syntax.Assign,
 			prev.Kind = expand.String
 			prev.Str += s
 		case expand.Indexed:
-			if len(prev.List) == 0 {
-				prev.List = append(prev.List, "")
+			// Appends to the element at index 0, creating it if unset.
+			if len(prev.List) > 0 && (prev.Indexes == nil || prev.Indexes[0] == 0) {
+				prev.List[0] += s
+			} else {
+				prev.List, prev.Indexes = internal.SetIndexedElem(prev.List, prev.Indexes, 0, s)
 			}
-			prev.List[0] += s
 		case expand.Associative:
 			// TODO
 		}
@@ -374,51 +452,59 @@ func (r *Runner) assignVal(name string, prev expand.Variable, as *syntax.Assign,
 		// TODO
 		return name, prev
 	}
-	// Evaluate values for each array element.
-	elemValues := make([]struct {
-		index  int
-		values []string
-	}, len(elems))
-	var index, maxIndex int
-	for i, elem := range elems {
+	// The base array which the new elements are set on; empty unless
+	// we are appending to an existing value.
+	var list []string
+	var indexes []int
+	if as.Append {
+		switch prev.Kind {
+		case expand.Unknown:
+		case expand.String:
+			list = []string{prev.Str}
+		case expand.Indexed:
+			// TODO: only clone when inside a subshell and getting a var from outside for the first time
+			list = slices.Clone(prev.List)
+			indexes = slices.Clone(prev.Indexes)
+		case expand.Associative:
+			// TODO
+			return name, prev
+		default:
+			// Should only happen if we forgot a case above.
+			panic(fmt.Sprintf("unexpected conversion of kind %d", prev.Kind))
+		}
+	}
+	// Evaluate values for each array element. An explicit index like
+	// [5]=x resets our index counter, which otherwise advances for every
+	// value, starting after the maximum index of the base array.
+	index := internal.IndexedMax(list, indexes) + 1
+	for _, elem := range elems {
 		if elem.Index != nil {
 			// Index resets our index with a literal value.
 			index = r.arithm(elem.Index)
-			elemValues[i].values = []string{r.literal(elem.Value)}
+			if index < 0 {
+				// Negative indices count from one past the maximum index.
+				if index += internal.IndexedMax(list, indexes) + 1; index < 0 {
+					r.errf("%s: bad array subscript\n", name)
+					r.exit.code = 1
+					break
+				}
+			}
+			list, indexes = internal.SetIndexedElem(list, indexes, index, r.literal(elem.Value))
+			index++
 		} else {
 			// Implicit index, advancing for every word.
-			elemValues[i].values = r.fields(elem.Value)
-		}
-		elemValues[i].index = index
-		index += len(elemValues[i].values)
-		maxIndex = max(maxIndex, index)
-	}
-	// Flatten down the values.
-	strs := make([]string, maxIndex)
-	for _, ev := range elemValues {
-		for i, str := range ev.values {
-			strs[ev.index+i] = str
+			for _, val := range r.fields(elem.Value) {
+				list, indexes = internal.SetIndexedElem(list, indexes, index, val)
+				index++
+			}
 		}
 	}
-	if !as.Append {
-		prev.Kind = expand.Indexed
-		prev.List = strs
-		return name, prev
+	if list == nil {
+		// An empty array like a=() must still expand to zero fields.
+		list = []string{}
 	}
-	switch prev.Kind {
-	case expand.Unknown:
-		prev.Kind = expand.Indexed
-		prev.List = strs
-	case expand.String:
-		prev.Kind = expand.Indexed
-		prev.List = append([]string{prev.Str}, strs...)
-	case expand.Indexed:
-		prev.List = append(prev.List, strs...)
-	case expand.Associative:
-		// TODO
-	default:
-		// Should only happen if we forgot a case above.
-		panic(fmt.Sprintf("unexpected conversion of kind %d", prev.Kind))
-	}
+	prev.Kind = expand.Indexed
+	prev.List = list
+	prev.Indexes = indexes
 	return name, prev
 }

--- a/third_party/0magnet/sh/v3/pattern/pattern.go
+++ b/third_party/0magnet/sh/v3/pattern/pattern.go
@@ -266,36 +266,42 @@ func regexpNext(sb *strings.Builder, sl *stringLexer, mode Mode) error {
 		var bsb strings.Builder
 		bsb.WriteByte('[')
 		hasSlash := false
-		var deferredErr error // reported only if the bracket isn't literal
+		var deferredErr error // reported only if the bracket expression closes
+		var classErr error    // reported even if the bracket is unmatched
+		// Like Bash, an unmatched "[" is a literal; emit it and reparse
+		// the rest of the pattern.
+		literalBracket := func() error {
+			sl.i = lit
+			sb.WriteString(`\[`)
+			return nil
+		}
 		if c = sl.next(); c == '\x00' {
-			return &SyntaxError{msg: "[ was not matched with a closing ]"}
+			return literalBracket()
 		}
 		switch c {
 		case '!', '^':
 			bsb.WriteByte('^')
 			if c = sl.next(); c == '\x00' {
-				return &SyntaxError{msg: "[ was not matched with a closing ]"}
+				return literalBracket()
 			}
 		}
 		if c == ']' {
 			bsb.WriteByte(']')
 			if c = sl.next(); c == '\x00' {
-				return &SyntaxError{msg: "[ was not matched with a closing ]"}
+				return literalBracket()
 			}
 		}
 		for {
 			switch c {
 			case '\x00':
-				if hasSlash {
-					// e.g. "[a/": emit "[" literally and reparse the rest.
-					sl.i = lit
-					sb.WriteString(`\[`)
-					return nil
+				// Bash is inconsistent about invalid character classes
+				// in an unmatched bracket: `case` treats the whole
+				// bracket as literal, but ${a//[[:} refuses to match.
+				// We follow the latter, keeping the error.
+				if classErr != nil {
+					return classErr
 				}
-				if deferredErr != nil {
-					return deferredErr
-				}
-				return &SyntaxError{msg: "[ was not matched with a closing ]"}
+				return literalBracket()
 			case '\\':
 				// An escaped character matches itself; quote it so that
 				// the regexp doesn't give it a special meaning, such as
@@ -339,8 +345,13 @@ func regexpNext(sb *strings.Builder, sl *stringLexer, mode Mode) error {
 			case '[':
 				rest := sl.peekRest()
 				n, err := charClass(rest)
-				if err != nil && deferredErr == nil {
-					deferredErr = &SyntaxError{msg: "charClass invalid", err: err}
+				if err != nil {
+					if classErr == nil {
+						classErr = &SyntaxError{msg: "charClass invalid", err: err}
+					}
+					if deferredErr == nil {
+						deferredErr = classErr
+					}
 				}
 				bsb.WriteByte('[')
 				if n > 0 {
@@ -402,8 +413,8 @@ func charClass(s string) (int, error) {
 }
 
 // HasMeta returns whether a string contains any unescaped pattern
-// metacharacters: '*', '?', or '['. When the function returns false, the given
-// pattern can only match at most one string.
+// metacharacters: '*', '?', or '[' followed by a matching ']'. When the
+// function returns false, the given pattern can only match at most one string.
 //
 // For example, HasMeta(`foo\*bar`) returns false, but HasMeta(`foo*bar`)
 // returns true.
@@ -414,12 +425,21 @@ func charClass(s string) (int, error) {
 //
 // The [Mode] parameter is unused, and will be removed in v4.
 func HasMeta(pat string, mode Mode) bool {
+	openBracket := false
 	for i := 0; i < len(pat); i++ {
 		switch pat[i] {
 		case '\\':
 			i++
-		case '*', '?', '[':
+		case '*', '?':
 			return true
+		case '[':
+			openBracket = true
+		case ']':
+			// Like Bash, an unmatched '[' is a literal,
+			// so it can only match one string.
+			if openBracket {
+				return true
+			}
 		}
 	}
 	return false

--- a/third_party/0magnet/sh/v3/syntax/lexer.go
+++ b/third_party/0magnet/sh/v3/syntax/lexer.go
@@ -107,8 +107,10 @@ retry:
 			}
 			// TODO: why is this necessary to ensure correct position info?
 			p.readEOF = false
-			if p.openBquotes > 0 && bquotes < p.openBquotes &&
-				p.bsp < uint(len(p.bs)) && bquoteEscaped(p.bs[p.bsp]) {
+			if p.openBquotes > 0 && p.bsp < uint(len(p.bs)) &&
+				((bquotes < p.openBquotes && bquoteEscaped(p.bs[p.bsp])) ||
+					// Backquotes within double quotes also escape double quotes.
+					(bquotes < p.openBquoteDbls && p.bs[p.bsp] == '"')) {
 				// We turn backquote command substitutions into $(),
 				// so we remove the extra backslashes needed by the backquotes.
 				bquotes++
@@ -985,7 +987,14 @@ func (p *Parser) endLit() (s string) {
 func (p *Parser) isLitRedir() bool {
 	lit := p.litBs[:len(p.litBs)-1]
 	if lit[0] == '{' && lit[len(lit)-1] == '}' {
-		return ValidName(string(lit[1 : len(lit)-1]))
+		name := lit[1 : len(lit)-1]
+		// Bash also allows an array element such as {name[idx]}.
+		if p.lang.in(langBashLike) && len(name) > 0 && name[len(name)-1] == ']' {
+			if i := bytes.IndexByte(name, '['); i > 0 && i < len(name)-2 {
+				name = name[:i]
+			}
+		}
+		return ValidName(string(name))
 	}
 	return numberLiteral(lit)
 }
@@ -1118,7 +1127,20 @@ loop:
 			if p.eqlOffs < 0 {
 				p.eqlOffs = len(p.litBs) - 1
 			}
+		case '}':
+			if p.quote == subCmdBraces && len(p.litBs) == 1 {
+				// A word-initial `}` closes the substitution even if
+				// more characters follow, as in `${ foo;}bar`.
+				p.rune()
+				break loop
+			}
 		case '[':
+			if p.litBs[0] == '{' && p.lang.in(langBashLike) {
+				// In bash, words beginning with '{' are always kept whole,
+				// so that {name[idx]} literals can prefix a redirect
+				// operator below.
+				break
+			}
 			if p.lang.in(langBashLike|LangMirBSDKorn|LangZsh) && len(p.litBs) > 1 && p.litBs[0] != '[' {
 				tok = _Lit
 				break loop

--- a/third_party/0magnet/sh/v3/syntax/parser.go
+++ b/third_party/0magnet/sh/v3/syntax/parser.go
@@ -527,6 +527,9 @@ type Parser struct {
 	openNodes int
 	// openBquotes is how many levels of backquotes are open at the moment.
 	openBquotes int
+	// openBquoteDbls is how many of those backquote levels began inside
+	// double quotes, where backslashes also escape double quotes.
+	openBquoteDbls int
 
 	// lastBquoteEsc is how many times the last backquote token was escaped
 	lastBquoteEsc int
@@ -572,6 +575,7 @@ func (p *Parser) reset() {
 	p.hdocStops = nil
 	p.parsingDoc = false
 	p.openBquotes = 0
+	p.openBquoteDbls = 0
 	p.accComs = nil
 	p.accComs, p.curComs = nil, &p.accComs
 	p.litBatch = nil
@@ -661,6 +665,9 @@ const (
 
 	subCmd
 	subCmdBckquo
+	// subCmdBraces is like subCmd, but for `${ stmts;}` and `${|stmts;}`,
+	// whose bodies end at a word beginning with `}`.
+	subCmdBraces
 	dblQuotes
 	hdocWord
 	hdocBody
@@ -678,8 +685,8 @@ const (
 
 	allKeepSpaces = runeByRune | paramExpRepl | dblQuotes | hdocBody |
 		hdocBodyTabs | paramExpRepl | paramExpExp
-	allRegTokens = noState | unquotedWordCont | subCmd | subCmdBckquo | hdocWord |
-		switchCase | arrayElems | testExpr
+	allRegTokens = noState | unquotedWordCont | subCmd | subCmdBckquo | subCmdBraces |
+		hdocWord | switchCase | arrayElems | testExpr
 	allArithmExpr = arithmExpr | arithmExprLet | arithmExprCmd | paramExpArithm
 	allParamExp   = paramExpArithm | paramExpRepl | paramExpExp
 )
@@ -1211,7 +1218,7 @@ func (p *Parser) wordPart() WordPart {
 				TempFile: p.r != '|',
 				ReplyVar: p.r == '|',
 			}
-			old := p.preNested(subCmd)
+			old := p.preNested(subCmdBraces)
 			p.rune() // don't tokenize '|'
 			p.next()
 			cs.Stmts, cs.Last = p.stmtList("}")
@@ -1238,6 +1245,10 @@ func (p *Parser) wordPart() WordPart {
 		ar.X = p.followArithm(left, ar.Left)
 		if ar.Bracket {
 			if p.tok != rightBrack {
+				if p.recoverError() {
+					ar.Right = recoveredPos
+					return ar
+				}
 				p.arithmMatchingErr(ar.Left, dollBrack, rightBrack)
 			}
 			p.postNested(old)
@@ -1313,6 +1324,9 @@ func (p *Parser) wordPart() WordPart {
 		cs := &CmdSubst{Left: p.pos, Backquotes: true}
 		old := p.preNested(subCmdBckquo)
 		p.openBquotes++
+		if old.quote == dblQuotes {
+			p.openBquoteDbls++
+		}
 
 		// The lexer didn't call p.rune for us, so that it could have
 		// the right p.openBquotes to properly handle backslashes.
@@ -1327,6 +1341,9 @@ func (p *Parser) wordPart() WordPart {
 		}
 		p.postNested(old)
 		p.openBquotes--
+		if old.quote == dblQuotes {
+			p.openBquoteDbls--
+		}
 		cs.Right = p.pos
 
 		// Like above, the lexer didn't call p.rune for us.

--- a/third_party/0magnet/sh/v3/syntax/printer.go
+++ b/third_party/0magnet/sh/v3/syntax/printer.go
@@ -656,6 +656,13 @@ func (p *Printer) wordPart(wp, next WordPart) {
 	switch wp := wp.(type) {
 	case *Lit:
 		p.writeLit(wp.Value)
+		// An odd number of trailing backslashes would escape whatever
+		// follows, such as the newline ending a file; escape the last
+		// backslash to keep the literal value intact. Parsed source can
+		// only hit this case via a lone backslash at the end of a file.
+		if n := len(wp.Value) - len(strings.TrimRight(wp.Value, `\`)); n%2 == 1 {
+			p.w.WriteByte('\\')
+		}
 	case *SglQuoted:
 		if wp.Dollar {
 			p.w.WriteByte('$')


### PR DESCRIPTION
Syncs the vendored `third_party/0magnet/sh/v3` to the upstream 0magnet/sh fork (`84701f5d`), which had drifted ~15 upstream mvdan/sh commits ahead.

- **11 files** with real content drift re-synced (the upstream sparse indexed-array work): `expand/{arith,environ,expand,param}.go`, `interp/{builtin,runner,vars}.go`, `pattern/pattern.go`, `syntax/{lexer,parser,printer}.go`. The other vendored files were already identical.
- **Added** `internal/sparse.go` (new upstream file, referenced by `interp/vars.go` + `expand/param.go`).
- Import-path rewrite (`github.com/0magnet/sh/v3` → `github.com/skycoin/skywire/third_party/0magnet/sh/v3`) is the only skywire-local delta — verified, no hidden patch clobbered. `_test.go`/`cmd/`/`CHANGELOG.md` intentionally not vendored.

`go build .`, `go vet`, `go test ./third_party/0magnet/sh/v3/...`, `go test ./third_party/0magnet/websh/...`, and `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor` all green.
