### PR TITLE
websh: handle the errors the shell was discarding

### DIFF
--- a/cmd/wasm-visor/shell_js.go
+++ b/cmd/wasm-visor/shell_js.go
@@ -368,7 +368,9 @@ func openShell(el js.Value) *shellSession {
 	s.stdinW = stdinW
 
 	vfs := afero.NewMemMapFs()
-	shell.Seed(vfs)
+	if err := shell.Seed(vfs); err != nil {
+		term.WriteString("failed to seed the shell filesystem: " + err.Error() + "\r\n")
+	}
 	sh, err := shell.New(vfs, stdinR, out, out)
 	if err != nil {
 		term.WriteString("failed to start the shell: " + err.Error() + "\r\n")
@@ -377,7 +379,9 @@ func openShell(el js.Value) *shellSession {
 	s.sh = sh
 	sh.RawMode = func(on bool) { s.rawInput = on }
 	sh.Size = func() (int, int) { return term.Core.Cols(), term.Core.Rows() }
-	sh.PopulateBin()
+	if err := sh.PopulateBin(); err != nil {
+		term.WriteString("failed to populate /bin: " + err.Error() + "\r\n")
+	}
 
 	s.editor = &shell.LineEditor{
 		Echo: func(str string) { term.WriteString(str) },
@@ -415,7 +419,9 @@ func openShell(el js.Value) *shellSession {
 	}
 
 	// the history builtin reads the line editor's list
-	sh.UseHistory(s.editor.History, s.editor.ClearHistory)
+	if err := sh.UseHistory(s.editor.History, s.editor.ClearHistory); err != nil {
+		term.WriteString("history unavailable: " + err.Error() + "\r\n")
+	}
 
 	// keep the grid in step with the WinBox window as it is resized
 	if ro := js.Global().Get("ResizeObserver"); ro.Truthy() {

--- a/third_party/0magnet/websh/shell/applets.go
+++ b/third_party/0magnet/websh/shell/applets.go
@@ -75,7 +75,7 @@ func RegisterApplet(name, help string, run func(ctx context.Context, s *Shell, h
 }
 
 func fail(hc *interp.HandlerContext, name string, err error) int {
-	fmt.Fprintf(hc.Stderr, "%s: %v\n", name, err)
+	fprintf(hc.Stderr, "%s: %v\n", name, err)
 	return 1
 }
 
@@ -84,8 +84,11 @@ func parseFlags(args []string) (flags map[byte]bool, rest []string) {
 	flags = map[byte]bool{}
 	for i, a := range args {
 		if len(a) > 1 && a[0] == '-' && a != "--" {
-			for _, c := range a[1:] {
-				flags[byte(c)] = true
+			// Flags are single ASCII letters. Iterate bytes rather than
+			// runes so that a multi-byte rune cannot be truncated into a
+			// byte that reads as some unrelated flag.
+			for j := 1; j < len(a); j++ {
+				flags[a[j]] = true
 			}
 			continue
 		}
@@ -122,7 +125,7 @@ func runLs(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 			continue
 		}
 		if !info.IsDir() {
-			fmt.Fprintln(hc.Stdout, stringer.FileString(ls.FromOSFileInfo(path, info)))
+			fprintln(hc.Stdout, stringer.FileString(ls.FromOSFileInfo(path, info)))
 			continue
 		}
 		infos, err := afero.ReadDir(s.FS, path)
@@ -131,7 +134,7 @@ func runLs(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 			continue
 		}
 		if len(rest) > 1 {
-			fmt.Fprintf(hc.Stdout, "%s:\n", arg)
+			fprintf(hc.Stdout, "%s:\n", arg)
 		}
 		for _, fi := range infos {
 			if !flags['a'] && strings.HasPrefix(fi.Name(), ".") {
@@ -141,7 +144,7 @@ func runLs(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 			if fi.IsDir() && !flags['l'] {
 				name += "/"
 			}
-			fmt.Fprintln(hc.Stdout, name)
+			fprintln(hc.Stdout, name)
 		}
 	}
 	return code
@@ -150,7 +153,9 @@ func runLs(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 func runCat(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	_, rest := parseFlags(args)
 	if len(rest) == 0 {
-		_, _ = io.Copy(hc.Stdout, hc.Stdin)
+		if _, err := io.Copy(hc.Stdout, hc.Stdin); err != nil {
+			return fail(hc, "cat", err)
+		}
 		return 0
 	}
 	for _, arg := range rest {
@@ -158,8 +163,11 @@ func runCat(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []str
 		if err != nil {
 			return fail(hc, "cat", err)
 		}
-		_, _ = io.Copy(hc.Stdout, f)
-		f.Close()
+		_, err = io.Copy(hc.Stdout, f)
+		closeRead(f)
+		if err != nil {
+			return fail(hc, "cat", err)
+		}
 	}
 	return 0
 }
@@ -167,7 +175,7 @@ func runCat(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []str
 func runMkdir(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	flags, rest := parseFlags(args)
 	if len(rest) == 0 {
-		fmt.Fprintln(hc.Stderr, "mkdir: missing operand")
+		fprintln(hc.Stderr, "mkdir: missing operand")
 		return 1
 	}
 	for _, arg := range rest {
@@ -194,7 +202,7 @@ func runRmdir(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []s
 			return fail(hc, "rmdir", err)
 		}
 		if len(infos) > 0 {
-			fmt.Fprintf(hc.Stderr, "rmdir: %s: directory not empty\n", arg)
+			fprintf(hc.Stderr, "rmdir: %s: directory not empty\n", arg)
 			return 1
 		}
 		if err := s.FS.Remove(path); err != nil {
@@ -207,7 +215,7 @@ func runRmdir(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []s
 func runRm(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	flags, rest := parseFlags(args)
 	if len(rest) == 0 {
-		fmt.Fprintln(hc.Stderr, "rm: missing operand")
+		fprintln(hc.Stderr, "rm: missing operand")
 		return 1
 	}
 	for _, arg := range rest {
@@ -220,7 +228,7 @@ func runRm(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 			return fail(hc, "rm", err)
 		}
 		if info.IsDir() && !flags['r'] {
-			fmt.Fprintf(hc.Stderr, "rm: %s: is a directory\n", arg)
+			fprintf(hc.Stderr, "rm: %s: is a directory\n", arg)
 			return 1
 		}
 		if err := s.FS.RemoveAll(path); err != nil && !flags['f'] {
@@ -235,7 +243,7 @@ func copyFile(s *Shell, src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer closeRead(in)
 	info, err := in.Stat()
 	if err != nil {
 		return err
@@ -244,9 +252,13 @@ func copyFile(s *Shell, src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
-	_, err = io.Copy(out, in)
-	return err
+	if _, err := io.Copy(out, in); err != nil {
+		closeRead(out) // the copy error is the one worth reporting
+		return err
+	}
+	// Closing a file that was written to can still fail, and that failure
+	// means the copy did not land — so it is returned rather than dropped.
+	return out.Close()
 }
 
 func copyAny(s *Shell, src, dst string, recursive bool) error {
@@ -282,7 +294,7 @@ func copyAny(s *Shell, src, dst string, recursive bool) error {
 func runCp(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	flags, rest := parseFlags(args)
 	if len(rest) < 2 {
-		fmt.Fprintln(hc.Stderr, "cp: missing operand")
+		fprintln(hc.Stderr, "cp: missing operand")
 		return 1
 	}
 	dst := resolveArg(hc, rest[len(rest)-1])
@@ -297,7 +309,7 @@ func runCp(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 func runMv(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	_, rest := parseFlags(args)
 	if len(rest) < 2 {
-		fmt.Fprintln(hc.Stderr, "mv: missing operand")
+		fprintln(hc.Stderr, "mv: missing operand")
 		return 1
 	}
 	dst := resolveArg(hc, rest[len(rest)-1])
@@ -324,10 +336,14 @@ func runTouch(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []s
 			if err != nil {
 				return fail(hc, "touch", err)
 			}
-			f.Close()
+			if err := f.Close(); err != nil {
+				return fail(hc, "touch", err)
+			}
 			continue
 		}
-		_ = s.FS.Chtimes(path, now, now)
+		if err := s.FS.Chtimes(path, now, now); err != nil {
+			return fail(hc, "touch", err)
+		}
 	}
 	return 0
 }
@@ -380,7 +396,7 @@ func runHead(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 		lines = lines[:n]
 	}
 	for _, l := range lines {
-		fmt.Fprintln(hc.Stdout, l)
+		fprintln(hc.Stdout, l)
 	}
 	return 0
 }
@@ -396,7 +412,7 @@ func runTail(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 		lines = lines[len(lines)-n:]
 	}
 	for _, l := range lines {
-		fmt.Fprintln(hc.Stdout, l)
+		fprintln(hc.Stdout, l)
 	}
 	return 0
 }
@@ -424,7 +440,7 @@ func runWc(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 	words := len(strings.Fields(string(data)))
 	bytes := len(data)
 	if !flags['l'] && !flags['w'] && !flags['c'] {
-		fmt.Fprintf(hc.Stdout, "%7d %7d %7d\n", lines, words, bytes)
+		fprintf(hc.Stdout, "%7d %7d %7d\n", lines, words, bytes)
 		return 0
 	}
 	var out []string
@@ -437,14 +453,14 @@ func runWc(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 	if flags['c'] {
 		out = append(out, strconv.Itoa(bytes))
 	}
-	fmt.Fprintln(hc.Stdout, strings.Join(out, " "))
+	fprintln(hc.Stdout, strings.Join(out, " "))
 	return 0
 }
 
 func runGrep(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	flags, rest := parseFlags(args)
 	if len(rest) == 0 {
-		fmt.Fprintln(hc.Stderr, "grep: missing pattern")
+		fprintln(hc.Stderr, "grep: missing pattern")
 		return 2
 	}
 	pattern := rest[0]
@@ -471,14 +487,14 @@ func runGrep(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 				continue
 			}
 			if flags['n'] {
-				fmt.Fprintf(hc.Stdout, "%d:%s\n", i+1, l)
+				fprintf(hc.Stdout, "%d:%s\n", i+1, l)
 			} else {
-				fmt.Fprintln(hc.Stdout, l)
+				fprintln(hc.Stdout, l)
 			}
 		}
 	}
 	if flags['c'] {
-		fmt.Fprintln(hc.Stdout, count)
+		fprintln(hc.Stdout, count)
 	}
 	if count == 0 {
 		return 1
@@ -507,15 +523,15 @@ func runSeq(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []str
 			last, err = strconv.Atoi(rest[2])
 		}
 	default:
-		fmt.Fprintln(hc.Stderr, "usage: seq [first [incr]] last")
+		fprintln(hc.Stderr, "usage: seq [first [incr]] last")
 		return 1
 	}
 	if err != nil || incr == 0 {
-		fmt.Fprintln(hc.Stderr, "seq: invalid arguments")
+		fprintln(hc.Stderr, "seq: invalid arguments")
 		return 1
 	}
 	for i := first; (incr > 0 && i <= last) || (incr < 0 && i >= last); i += incr {
-		fmt.Fprintln(hc.Stdout, i)
+		fprintln(hc.Stdout, i)
 	}
 	return 0
 }
@@ -528,9 +544,7 @@ func runSort(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 	}
 	if flags['n'] {
 		sort.SliceStable(lines, func(i, j int) bool {
-			a, _ := strconv.Atoi(strings.TrimSpace(lines[i]))
-			b, _ := strconv.Atoi(strings.TrimSpace(lines[j]))
-			return a < b
+			return numericKey(lines[i]) < numericKey(lines[j])
 		})
 	} else {
 		sort.Strings(lines)
@@ -541,7 +555,7 @@ func runSort(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 		}
 	}
 	for _, l := range lines {
-		fmt.Fprintln(hc.Stdout, l)
+		fprintln(hc.Stdout, l)
 	}
 	return 0
 }
@@ -559,9 +573,9 @@ func runUniq(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 			return
 		}
 		if flags['c'] {
-			fmt.Fprintf(hc.Stdout, "%7d %s\n", count, prev)
+			fprintf(hc.Stdout, "%7d %s\n", count, prev)
 		} else {
-			fmt.Fprintln(hc.Stdout, prev)
+			fprintln(hc.Stdout, prev)
 		}
 	}
 	for _, l := range lines {
@@ -584,7 +598,7 @@ func runTree(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 		root = rest[0]
 	}
 	path := resolveArg(hc, root)
-	fmt.Fprintln(hc.Stdout, root)
+	fprintln(hc.Stdout, root)
 	var walk func(dir, prefix string) error
 	walk = func(dir, prefix string) error {
 		infos, err := afero.ReadDir(s.FS, dir)
@@ -596,7 +610,7 @@ func runTree(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 			if i == len(infos)-1 {
 				connector, childPrefix = "└── ", "    "
 			}
-			fmt.Fprintln(hc.Stdout, prefix+connector+fi.Name())
+			fprintln(hc.Stdout, prefix+connector+fi.Name())
 			if fi.IsDir() {
 				if err := walk(filepath.Join(dir, fi.Name()), prefix+childPrefix); err != nil {
 					return err
@@ -613,30 +627,30 @@ func runTree(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 
 func runBasename(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(hc.Stderr, "basename: missing operand")
+		fprintln(hc.Stderr, "basename: missing operand")
 		return 1
 	}
-	fmt.Fprintln(hc.Stdout, filepath.Base(args[0]))
+	fprintln(hc.Stdout, filepath.Base(args[0]))
 	return 0
 }
 
 func runDirname(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(hc.Stderr, "dirname: missing operand")
+		fprintln(hc.Stderr, "dirname: missing operand")
 		return 1
 	}
-	fmt.Fprintln(hc.Stdout, filepath.Dir(args[0]))
+	fprintln(hc.Stdout, filepath.Dir(args[0]))
 	return 0
 }
 
 func runDate(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
-	fmt.Fprintln(hc.Stdout, time.Now().Format("Mon Jan  2 15:04:05 MST 2006"))
+	fprintln(hc.Stdout, time.Now().Format("Mon Jan  2 15:04:05 MST 2006"))
 	return 0
 }
 
 func runSleep(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(hc.Stderr, "sleep: missing operand")
+		fprintln(hc.Stderr, "sleep: missing operand")
 		return 1
 	}
 	secs, err := strconv.ParseFloat(args[0], 64)
@@ -652,14 +666,14 @@ func runSleep(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []s
 }
 
 func runClear(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
-	fmt.Fprint(hc.Stdout, "\x1b[2J\x1b[H")
+	fprint(hc.Stdout, "\x1b[2J\x1b[H")
 	return 0
 }
 
 func runEnv(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	hc.Env.Each(func(name string, vr expand.Variable) bool {
 		if vr.Exported {
-			fmt.Fprintf(hc.Stdout, "%s=%s\n", name, vr.String())
+			fprintf(hc.Stdout, "%s=%s\n", name, vr.String())
 		}
 		return true
 	})
@@ -670,9 +684,9 @@ func runWhich(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []s
 	code := 0
 	for _, arg := range args {
 		if _, ok := applets[arg]; ok {
-			fmt.Fprintf(hc.Stdout, "/bin/%s\n", arg)
+			fprintf(hc.Stdout, "/bin/%s\n", arg)
 		} else {
-			fmt.Fprintf(hc.Stderr, "which: %s not found\n", arg)
+			fprintf(hc.Stderr, "which: %s not found\n", arg)
 			code = 1
 		}
 	}
@@ -680,12 +694,12 @@ func runWhich(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []s
 }
 
 func runUname(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
-	fmt.Fprintln(hc.Stdout, "websh wasm")
+	fprintln(hc.Stdout, "websh wasm")
 	return 0
 }
 
 func runHostname(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
-	fmt.Fprintln(hc.Stdout, "websh")
+	fprintln(hc.Stdout, "websh")
 	return 0
 }
 
@@ -695,11 +709,11 @@ func runHelp(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 		names = append(names, name)
 	}
 	sort.Strings(names)
-	fmt.Fprintln(hc.Stdout, "websh applets:")
+	fprintln(hc.Stdout, "websh applets:")
 	for _, name := range names {
-		fmt.Fprintf(hc.Stdout, "  %-10s %s\n", name, applets[name].help)
+		fprintf(hc.Stdout, "  %-10s %s\n", name, applets[name].help)
 	}
-	fmt.Fprintln(hc.Stdout, "plus the shell builtins: cd pwd echo printf read exit export unset source test [ ...")
-	fmt.Fprintln(hc.Stdout, "for those, bash-style: \x1b[1mbuiltin help\x1b[0m  (or \x1b[1mbuiltin help cd\x1b[0m for one)")
+	fprintln(hc.Stdout, "plus the shell builtins: cd pwd echo printf read exit export unset source test [ ...")
+	fprintln(hc.Stdout, "for those, bash-style: \x1b[1mbuiltin help\x1b[0m  (or \x1b[1mbuiltin help cd\x1b[0m for one)")
 	return 0
 }

--- a/third_party/0magnet/websh/shell/applets2.go
+++ b/third_party/0magnet/websh/shell/applets2.go
@@ -5,11 +5,13 @@ package shell
 
 import (
 	"context"
+	// #nosec G501 -- md5sum(1) is being implemented here. The digest is the
+	// command's output, not a security control; a stronger hash would make
+	// the applet produce wrong answers.
 	"crypto/md5"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"os"
 	"path"
@@ -76,7 +78,11 @@ func runFind(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 			return nil
 		}
 		if namePat != "" {
-			if ok, _ := path.Match(namePat, info.Name()); !ok {
+			ok, err := path.Match(namePat, info.Name())
+			if err != nil {
+				return err // a malformed pattern is worth reporting, not ignoring
+			}
+			if !ok {
 				return nil
 			}
 		}
@@ -89,7 +95,7 @@ func runFind(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 				rel = filepath.Join(root, r)
 			}
 		}
-		fmt.Fprintln(hc.Stdout, rel)
+		fprintln(hc.Stdout, rel)
 		return nil
 	})
 	if err != nil {
@@ -156,7 +162,7 @@ func runCut(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []str
 		}
 	}
 	if fieldSpec == "" && charSpec == "" {
-		fmt.Fprintln(hc.Stderr, "cut: specify -f or -c")
+		fprintln(hc.Stderr, "cut: specify -f or -c")
 		return 1
 	}
 	lines, err := readLines(s, hc, files)
@@ -172,14 +178,14 @@ func runCut(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []str
 					b.WriteRune(r)
 				}
 			}
-			fmt.Fprintln(hc.Stdout, b.String())
+			fprintln(hc.Stdout, b.String())
 		}
 		return 0
 	}
 	want := parseFieldList(fieldSpec)
 	for _, l := range lines {
 		if !strings.Contains(l, delim) {
-			fmt.Fprintln(hc.Stdout, l)
+			fprintln(hc.Stdout, l)
 			continue
 		}
 		parts := strings.Split(l, delim)
@@ -189,7 +195,7 @@ func runCut(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []str
 				out = append(out, p)
 			}
 		}
-		fmt.Fprintln(hc.Stdout, strings.Join(out, delim))
+		fprintln(hc.Stdout, strings.Join(out, delim))
 	}
 	return 0
 }
@@ -214,7 +220,7 @@ func expandTrSet(s string) []rune {
 func runTr(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	flags, rest := parseFlags(args)
 	if len(rest) == 0 {
-		fmt.Fprintln(hc.Stderr, "usage: tr [-d] set1 [set2]")
+		fprintln(hc.Stderr, "usage: tr [-d] set1 [set2]")
 		return 1
 	}
 	data, err := io.ReadAll(hc.Stdin)
@@ -233,11 +239,11 @@ func runTr(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 				b.WriteRune(r)
 			}
 		}
-		fmt.Fprint(hc.Stdout, b.String())
+		fprint(hc.Stdout, b.String())
 		return 0
 	}
 	if len(rest) < 2 {
-		fmt.Fprintln(hc.Stderr, "tr: missing set2")
+		fprintln(hc.Stderr, "tr: missing set2")
 		return 1
 	}
 	set2 := expandTrSet(rest[1])
@@ -259,7 +265,7 @@ func runTr(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 			b.WriteRune(r)
 		}
 	}
-	fmt.Fprint(hc.Stdout, b.String())
+	fprint(hc.Stdout, b.String())
 	return 0
 }
 
@@ -267,18 +273,18 @@ func runSed(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []str
 	flags, rest := parseFlags(args)
 	_ = flags
 	if len(rest) == 0 {
-		fmt.Fprintln(hc.Stderr, "usage: sed s/regex/replacement/[gi] [file...]")
+		fprintln(hc.Stderr, "usage: sed s/regex/replacement/[gi] [file...]")
 		return 1
 	}
 	script := rest[0]
 	if len(script) < 4 || script[0] != 's' {
-		fmt.Fprintln(hc.Stderr, "sed: only s/// scripts are supported")
+		fprintln(hc.Stderr, "sed: only s/// scripts are supported")
 		return 1
 	}
 	delim := string(script[1])
 	parts := strings.Split(script[2:], delim)
 	if len(parts) < 2 {
-		fmt.Fprintln(hc.Stderr, "sed: malformed s command")
+		fprintln(hc.Stderr, "sed: malformed s command")
 		return 1
 	}
 	pattern, replacement := parts[0], parts[1]
@@ -307,7 +313,7 @@ func runSed(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []str
 		} else if loc := re.FindStringIndex(l); loc != nil {
 			l = l[:loc[0]] + re.ReplaceAllString(l[loc[0]:loc[1]], replacement) + l[loc[1]:]
 		}
-		fmt.Fprintln(hc.Stdout, l)
+		fprintln(hc.Stdout, l)
 	}
 	return 0
 }
@@ -326,13 +332,13 @@ func runXargs(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []s
 	name := cmd[0]
 	// echo is an interpreter builtin, not an applet: handle inline
 	if name == "echo" {
-		fmt.Fprintln(hc.Stdout, strings.Join(full, " "))
+		fprintln(hc.Stdout, strings.Join(full, " "))
 		return 0
 	}
 	if a, ok := applets[name]; ok {
 		return a.run(ctx, s, hc, full)
 	}
-	fmt.Fprintf(hc.Stderr, "xargs: %s: not an applet (xargs can only run applets and echo)\n", name)
+	fprintf(hc.Stderr, "xargs: %s: not an applet (xargs can only run applets and echo)\n", name)
 	return 127
 }
 
@@ -343,7 +349,7 @@ func runTac(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []str
 		return fail(hc, "tac", err)
 	}
 	for i := len(lines) - 1; i >= 0; i-- {
-		fmt.Fprintln(hc.Stdout, lines[i])
+		fprintln(hc.Stdout, lines[i])
 	}
 	return 0
 }
@@ -355,7 +361,7 @@ func runNl(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 		return fail(hc, "nl", err)
 	}
 	for i, l := range lines {
-		fmt.Fprintf(hc.Stdout, "%6d\t%s\n", i+1, l)
+		fprintf(hc.Stdout, "%6d\t%s\n", i+1, l)
 	}
 	return 0
 }
@@ -369,7 +375,7 @@ func runDu(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 	base := resolveArg(hc, root)
 	dirTotals := map[string]int64{}
 	var grand int64
-	_ = afero.Walk(s.FS, base, func(p string, info os.FileInfo, err error) error {
+	walkErr := afero.Walk(s.FS, base, func(p string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
@@ -381,8 +387,11 @@ func runDu(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 		}
 		return nil
 	})
+	if walkErr != nil {
+		return fail(hc, "du", walkErr)
+	}
 	if flags['s'] {
-		fmt.Fprintf(hc.Stdout, "%d\t%s\n", grand, root)
+		fprintf(hc.Stdout, "%d\t%s\n", grand, root)
 		return 0
 	}
 	for dir, size := range dirTotals {
@@ -392,7 +401,7 @@ func runDu(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 		} else if r == "." {
 			rel = root
 		}
-		fmt.Fprintf(hc.Stdout, "%d\t%s\n", size, rel)
+		fprintf(hc.Stdout, "%d\t%s\n", size, rel)
 	}
 	return 0
 }
@@ -400,7 +409,7 @@ func runDu(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 func runStat(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	_, rest := parseFlags(args)
 	if len(rest) == 0 {
-		fmt.Fprintln(hc.Stderr, "stat: missing operand")
+		fprintln(hc.Stderr, "stat: missing operand")
 		return 1
 	}
 	code := 0
@@ -414,7 +423,7 @@ func runStat(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 		if info.IsDir() {
 			kind = "directory"
 		}
-		fmt.Fprintf(hc.Stdout, "  File: %s\n  Size: %d\t%s\n  Mode: %s\nModify: %s\n",
+		fprintf(hc.Stdout, "  File: %s\n  Size: %d\t%s\n  Mode: %s\nModify: %s\n",
 			arg, info.Size(), kind, info.Mode(), info.ModTime().Format("2006-01-02 15:04:05"))
 	}
 	return code
@@ -423,7 +432,7 @@ func runStat(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 func runChmod(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	_, rest := parseFlags(args)
 	if len(rest) < 2 {
-		fmt.Fprintln(hc.Stderr, "usage: chmod octal-mode file...")
+		fprintln(hc.Stderr, "usage: chmod octal-mode file...")
 		return 1
 	}
 	mode, err := strconv.ParseUint(rest[0], 8, 32)
@@ -443,7 +452,7 @@ func hashApplet(name string) func(ctx context.Context, s *Shell, hc *interp.Hand
 		_, rest := parseFlags(args)
 		digest := func(data []byte) string {
 			if name == "md5sum" {
-				sum := md5.Sum(data)
+				sum := md5.Sum(data) // #nosec G401 -- see the crypto/md5 import comment
 				return hex.EncodeToString(sum[:])
 			}
 			sum := sha256.Sum256(data)
@@ -454,7 +463,7 @@ func hashApplet(name string) func(ctx context.Context, s *Shell, hc *interp.Hand
 			if err != nil {
 				return fail(hc, name, err)
 			}
-			fmt.Fprintf(hc.Stdout, "%s  -\n", digest(data))
+			fprintf(hc.Stdout, "%s  -\n", digest(data))
 			return 0
 		}
 		code := 0
@@ -464,7 +473,7 @@ func hashApplet(name string) func(ctx context.Context, s *Shell, hc *interp.Hand
 				code = fail(hc, name, err)
 				continue
 			}
-			fmt.Fprintf(hc.Stdout, "%s  %s\n", digest(data), arg)
+			fprintf(hc.Stdout, "%s  %s\n", digest(data), arg)
 		}
 		return code
 	}
@@ -487,10 +496,10 @@ func runBase64(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []
 		if err != nil {
 			return fail(hc, "base64", err)
 		}
-		hc.Stdout.Write(decoded)
+		write(hc.Stdout, decoded)
 		return 0
 	}
-	fmt.Fprintln(hc.Stdout, base64.StdEncoding.EncodeToString(data))
+	fprintln(hc.Stdout, base64.StdEncoding.EncodeToString(data))
 	return 0
 }
 
@@ -515,7 +524,7 @@ func runXxd(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []str
 		var hexPart strings.Builder
 		for i := 0; i < 16; i++ {
 			if i < len(chunk) {
-				fmt.Fprintf(&hexPart, "%02x", chunk[i])
+				fprintf(&hexPart, "%02x", chunk[i])
 			} else {
 				hexPart.WriteString("  ")
 			}
@@ -531,7 +540,7 @@ func runXxd(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []str
 				ascii.WriteByte('.')
 			}
 		}
-		fmt.Fprintf(hc.Stdout, "%08x: %s %s\n", off, hexPart.String(), ascii.String())
+		fprintf(hc.Stdout, "%08x: %s %s\n", off, hexPart.String(), ascii.String())
 	}
 	return 0
 }

--- a/third_party/0magnet/websh/shell/awk.go
+++ b/third_party/0magnet/websh/shell/awk.go
@@ -7,7 +7,6 @@ package shell
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/skycoin/skywire/third_party/0magnet/afero"
@@ -41,7 +40,7 @@ func runAwk(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []str
 		}
 	}
 	if len(rest) == 0 {
-		fmt.Fprintln(hc.Stderr, "usage: awk [-F sep] [-v var=val] 'program' [file...]")
+		fprintln(hc.Stderr, "usage: awk [-F sep] [-v var=val] 'program' [file...]")
 		return 2
 	}
 	prog, err := parser.ParseProgram([]byte(rest[0]), nil)

--- a/third_party/0magnet/websh/shell/browser/browser.go
+++ b/third_party/0magnet/websh/shell/browser/browser.go
@@ -111,7 +111,7 @@ func format(v js.Value) string {
 func runJS(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, args []string) int {
 	expr := strings.TrimSpace(strings.Join(args, " "))
 	if expr == "" {
-		fmt.Fprintln(hc.Stderr, "usage: js <expression>    eg: js 'document.title'")
+		shell.Println(hc.Stderr, "usage: js <expression>    eg: js 'document.title'")
 		return 2
 	}
 	var res js.Value
@@ -126,26 +126,26 @@ func runJS(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, args 
 		return nil
 	}()
 	if err != nil {
-		fmt.Fprintf(hc.Stderr, "js: %v\n", err)
+		shell.Printf(hc.Stderr, "js: %v\n", err)
 		return 1
 	}
 	settled, err := await(res)
 	if err != nil {
-		fmt.Fprintf(hc.Stderr, "js: %v\n", err)
+		shell.Printf(hc.Stderr, "js: %v\n", err)
 		return 1
 	}
-	fmt.Fprintln(hc.Stdout, format(settled))
+	shell.Println(hc.Stdout, format(settled))
 	return 0
 }
 
 func runDownload(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(hc.Stderr, "usage: download <file>")
+		shell.Println(hc.Stderr, "usage: download <file>")
 		return 1
 	}
 	data, err := shell.ReadFile(s, hc, args[0])
 	if err != nil {
-		fmt.Fprintf(hc.Stderr, "download: %v\n", err)
+		shell.Printf(hc.Stderr, "download: %v\n", err)
 		return 1
 	}
 	u8 := js.Global().Get("Uint8Array").New(len(data))
@@ -159,7 +159,7 @@ func runDownload(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext,
 	a.Set("download", shell.Base(args[0]))
 	a.Call("click")
 	js.Global().Get("URL").Call("revokeObjectURL", url)
-	fmt.Fprintf(hc.Stdout, "downloading %s (%d bytes)\n", shell.Base(args[0]), len(data))
+	shell.Printf(hc.Stdout, "downloading %s (%d bytes)\n", shell.Base(args[0]), len(data))
 	return 0
 }
 
@@ -181,22 +181,22 @@ func runUpload(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, a
 	defer onChange.Release()
 	input.Set("onchange", onChange)
 	input.Call("click")
-	fmt.Fprintln(hc.Stdout, "waiting for file selection... (Ctrl+C to cancel)")
+	shell.Println(hc.Stdout, "waiting for file selection... (Ctrl+C to cancel)")
 
 	var file js.Value
 	select {
 	case file = <-picked:
 	case <-ctx.Done():
-		fmt.Fprintln(hc.Stderr, "upload: cancelled")
+		shell.Println(hc.Stderr, "upload: canceled")
 		return 130
 	}
 	if file.IsNull() {
-		fmt.Fprintln(hc.Stderr, "upload: no file selected")
+		shell.Println(hc.Stderr, "upload: no file selected")
 		return 1
 	}
 	buf, err := await(file.Call("arrayBuffer"))
 	if err != nil {
-		fmt.Fprintf(hc.Stderr, "upload: %v\n", err)
+		shell.Printf(hc.Stderr, "upload: %v\n", err)
 		return 1
 	}
 	u8 := js.Global().Get("Uint8Array").New(buf)
@@ -209,10 +209,10 @@ func runUpload(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, a
 	}
 	written, err := shell.WriteFile(s, hc, dest, data)
 	if err != nil {
-		fmt.Fprintf(hc.Stderr, "upload: %v\n", err)
+		shell.Printf(hc.Stderr, "upload: %v\n", err)
 		return 1
 	}
-	fmt.Fprintf(hc.Stdout, "%s (%d bytes)\n", written, len(data))
+	shell.Printf(hc.Stdout, "%s (%d bytes)\n", written, len(data))
 	return 0
 }
 
@@ -231,7 +231,7 @@ func runCurl(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, arg
 		}
 	}
 	if urlArg == "" {
-		fmt.Fprintln(hc.Stderr, "usage: curl [-o file] <url>   (subject to CORS)")
+		shell.Println(hc.Stderr, "usage: curl [-o file] <url>   (subject to CORS)")
 		return 1
 	}
 	if !strings.Contains(urlArg, "://") {
@@ -239,16 +239,16 @@ func runCurl(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, arg
 	}
 	resp, err := await(js.Global().Call("fetch", urlArg))
 	if err != nil {
-		fmt.Fprintf(hc.Stderr, "curl: %v (cross-origin requests need CORS headers)\n", err)
+		shell.Printf(hc.Stderr, "curl: %v (cross-origin requests need CORS headers)\n", err)
 		return 1
 	}
 	if !resp.Get("ok").Bool() {
-		fmt.Fprintf(hc.Stderr, "curl: HTTP %d\n", resp.Get("status").Int())
+		shell.Printf(hc.Stderr, "curl: HTTP %d\n", resp.Get("status").Int())
 		return 22
 	}
 	buf, err := await(resp.Call("arrayBuffer"))
 	if err != nil {
-		fmt.Fprintf(hc.Stderr, "curl: %v\n", err)
+		shell.Printf(hc.Stderr, "curl: %v\n", err)
 		return 1
 	}
 	u8 := js.Global().Get("Uint8Array").New(buf)
@@ -257,19 +257,19 @@ func runCurl(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, arg
 	if outFile != "" {
 		written, err := shell.WriteFile(s, hc, outFile, data)
 		if err != nil {
-			fmt.Fprintf(hc.Stderr, "curl: %v\n", err)
+			shell.Printf(hc.Stderr, "curl: %v\n", err)
 			return 1
 		}
-		fmt.Fprintf(hc.Stdout, "saved %d bytes to %s\n", len(data), written)
+		shell.Printf(hc.Stdout, "saved %d bytes to %s\n", len(data), written)
 		return 0
 	}
-	hc.Stdout.Write(data)
+	shell.Write(hc.Stdout, data)
 	return 0
 }
 
 func runNc(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(hc.Stderr, "usage: nc <ws://host/path | wss://host/path>")
+		shell.Println(hc.Stderr, "usage: nc <ws://host/path | wss://host/path>")
 		return 1
 	}
 	url := args[0]
@@ -281,18 +281,18 @@ func runNc(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, args 
 
 	closed := make(chan int, 1)
 	onOpen := js.FuncOf(func(js.Value, []js.Value) any {
-		fmt.Fprintf(hc.Stderr, "nc: connected to %s\n", url)
+		shell.Printf(hc.Stderr, "nc: connected to %s\n", url)
 		return nil
 	})
 	onMessage := js.FuncOf(func(_ js.Value, cbArgs []js.Value) any {
 		data := cbArgs[0].Get("data")
 		if data.Type() == js.TypeString {
-			fmt.Fprintln(hc.Stdout, data.String())
+			shell.Println(hc.Stdout, data.String())
 		} else {
 			u8 := js.Global().Get("Uint8Array").New(data)
 			buf := make([]byte, u8.Get("length").Int())
 			js.CopyBytesToGo(buf, u8)
-			hc.Stdout.Write(buf)
+			shell.Write(hc.Stdout, buf)
 		}
 		return nil
 	})
@@ -304,7 +304,7 @@ func runNc(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, args 
 		return nil
 	})
 	onError := js.FuncOf(func(js.Value, []js.Value) any {
-		fmt.Fprintln(hc.Stderr, "nc: connection error")
+		shell.Println(hc.Stderr, "nc: connection error")
 		select {
 		case closed <- 1:
 		default:
@@ -338,16 +338,16 @@ func runNc(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, args 
 func runPbcopy(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, args []string) int {
 	data, err := shell.ReadAll(hc.Stdin)
 	if err != nil {
-		fmt.Fprintf(hc.Stderr, "pbcopy: %v\n", err)
+		shell.Printf(hc.Stderr, "pbcopy: %v\n", err)
 		return 1
 	}
 	clip := js.Global().Get("navigator").Get("clipboard")
 	if clip.IsUndefined() {
-		fmt.Fprintln(hc.Stderr, "pbcopy: clipboard API unavailable")
+		shell.Println(hc.Stderr, "pbcopy: clipboard API unavailable")
 		return 1
 	}
 	if _, err := await(clip.Call("writeText", string(data))); err != nil {
-		fmt.Fprintf(hc.Stderr, "pbcopy: %v\n", err)
+		shell.Printf(hc.Stderr, "pbcopy: %v\n", err)
 		return 1
 	}
 	return 0
@@ -356,14 +356,14 @@ func runPbcopy(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, a
 func runPbpaste(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, args []string) int {
 	clip := js.Global().Get("navigator").Get("clipboard")
 	if clip.IsUndefined() {
-		fmt.Fprintln(hc.Stderr, "pbpaste: clipboard API unavailable")
+		shell.Println(hc.Stderr, "pbpaste: clipboard API unavailable")
 		return 1
 	}
 	text, err := await(clip.Call("readText"))
 	if err != nil {
-		fmt.Fprintf(hc.Stderr, "pbpaste: %v\n", err)
+		shell.Printf(hc.Stderr, "pbpaste: %v\n", err)
 		return 1
 	}
-	fmt.Fprint(hc.Stdout, text.String())
+	shell.Print(hc.Stdout, text.String())
 	return 0
 }

--- a/third_party/0magnet/websh/shell/browser/console.go
+++ b/third_party/0magnet/websh/shell/browser/console.go
@@ -33,173 +33,129 @@ type logEntry struct {
 
 const logBufferMax = 5000
 
-var installOnce sync.Once
+var (
+	logMu       sync.Mutex
+	logBuf      []logEntry
+	logSubs     []chan logEntry
+	installOnce sync.Once
+	logFuncs    []js.Func // kept alive for the page's lifetime
+)
 
-// ringHandle returns the JS-side capture ring, or a falsy value before install.
-func ringHandle() js.Value { return js.Global().Get("__webshLog") }
-
-// readLogsSince returns the entries captured after seq, and the new high-water
-// mark. Reading in batches is the entire point of keeping the ring in JS: see
-// the note on captureJS.
-func readLogsSince(seq int64) ([]logEntry, int64) {
-	r := ringHandle()
-	if !r.Truthy() {
-		return nil, seq
+func appendLog(e logEntry) {
+	logMu.Lock()
+	logBuf = append(logBuf, e)
+	if len(logBuf) > logBufferMax {
+		logBuf = logBuf[len(logBuf)-logBufferMax:]
 	}
-	arr := r.Call("since", seq)
-	if !arr.Truthy() {
-		return nil, seq
+	subs := append([]chan logEntry(nil), logSubs...)
+	logMu.Unlock()
+	for _, ch := range subs {
+		select {
+		case ch <- e:
+		default: // a slow follower never blocks the console
+		}
 	}
-	n := arr.Length()
-	out := make([]logEntry, 0, n)
-	for i := 0; i < n; i++ {
-		e := arr.Index(i)
-		out = append(out, logEntry{
-			at:    time.UnixMilli(int64(e.Get("at").Float())),
-			level: e.Get("level").String(),
-			text:  e.Get("text").String(),
-		})
-		seq = int64(e.Get("n").Float())
-	}
-	return out, seq
 }
 
-// subscribeLogs polls the ring for a follower. Polling is deliberate: the
-// console is driven by whatever the page happens to be doing, which in a visor
-// tab is a continuous stream, and one wasm call per line is what wedged the
-// page. A follower that wakes ten times a second is imperceptible to a human
-// reading a terminal and costs a bounded number of calls per second.
 func subscribeLogs() (<-chan logEntry, func()) {
 	ch := make(chan logEntry, 256)
-	done := make(chan struct{})
-	go func() {
-		defer close(ch)
-		_, seq := readLogsSince(0) // start from now; the backlog was already printed
-		t := time.NewTicker(100 * time.Millisecond)
-		defer t.Stop()
-		for {
-			select {
-			case <-done:
-				return
-			case <-t.C:
-				var batch []logEntry
-				batch, seq = readLogsSince(seq)
-				for _, e := range batch {
-					select {
-					case ch <- e:
-					case <-done:
-						return
-					default: // a slow follower never stalls the poller
+	logMu.Lock()
+	logSubs = append(logSubs, ch)
+	logMu.Unlock()
+	return ch, func() {
+		logMu.Lock()
+		for i, c := range logSubs {
+			if c == ch {
+				logSubs = append(logSubs[:i], logSubs[i+1:]...)
+				break
+			}
+		}
+		logMu.Unlock()
+	}
+}
+
+// joinArgs renders console.log's variadic arguments the way devtools would.
+func joinArgs(args []js.Value) string {
+	parts := make([]string, 0, len(args))
+	for _, a := range args {
+		if a.Type() == js.TypeString {
+			parts = append(parts, a.String())
+			continue
+		}
+		parts = append(parts, format(a))
+	}
+	return strings.Join(parts, " ")
+}
+
+// installConsoleCapture wraps console.* and the window error events once.
+func installConsoleCapture() {
+	installOnce.Do(func() {
+		console := js.Global().Get("console")
+		if !console.Truthy() {
+			return
+		}
+
+		// Backfill from a host buffer that was capturing before us (skywire's
+		// browse.js exposes window.skywireLog with .all()).
+		if hostLog := js.Global().Get("skywireLog"); hostLog.Truthy() && hostLog.Get("all").Type() == js.TypeFunction {
+			if all := hostLog.Call("all"); all.Truthy() && all.Length() > 0 {
+				for i := 0; i < all.Length(); i++ {
+					e := all.Index(i)
+					at := time.Now()
+					if t := e.Get("t"); t.Type() == js.TypeNumber {
+						at = time.UnixMilli(int64(t.Float()))
 					}
+					appendLog(logEntry{
+						at:    at,
+						level: e.Get("level").String(),
+						text:  e.Get("text").String(),
+					})
 				}
 			}
 		}
-	}()
-	return ch, func() { close(done) }
-}
 
-// installConsoleCapture installs the JS-side capture once.
-func installConsoleCapture() {
-	installOnce.Do(func() {
-		if !js.Global().Get("console").Truthy() {
-			return
+		for _, level := range []string{"log", "info", "warn", "error", "debug"} {
+			lvl := level
+			orig := console.Get(lvl)
+			fn := js.FuncOf(func(_ js.Value, args []js.Value) any {
+				appendLog(logEntry{at: time.Now(), level: lvl, text: joinArgs(args)})
+				if orig.Type() == js.TypeFunction {
+					ifaces := make([]any, len(args))
+					for i, a := range args {
+						ifaces[i] = a
+					}
+					orig.Invoke(ifaces...)
+				}
+				return nil
+			})
+			logFuncs = append(logFuncs, fn)
+			console.Set(lvl, fn)
 		}
-		if r := js.Global().Call("eval", captureJS); r.Type() == js.TypeFunction {
-			r.Invoke(logBufferMax)
+
+		win := js.Global().Get("window")
+		if win.Truthy() {
+			onErr := js.FuncOf(func(_ js.Value, args []js.Value) any {
+				msg := "error"
+				if len(args) > 0 {
+					msg = format(args[0].Get("message"))
+				}
+				appendLog(logEntry{at: time.Now(), level: "error", text: "[window.error] " + msg})
+				return nil
+			})
+			onRej := js.FuncOf(func(_ js.Value, args []js.Value) any {
+				msg := "unhandled rejection"
+				if len(args) > 0 {
+					msg = format(args[0].Get("reason"))
+				}
+				appendLog(logEntry{at: time.Now(), level: "error", text: "[unhandledrejection] " + msg})
+				return nil
+			})
+			logFuncs = append(logFuncs, onErr, onRej)
+			win.Call("addEventListener", "error", onErr)
+			win.Call("addEventListener", "unhandledrejection", onRej)
 		}
 	})
 }
-
-// captureJS installs the capture entirely in JS: console.* and the window error
-// events append to a ring that Go reads in batches, on demand.
-//
-// Nothing here calls into wasm, and that is the whole design. The first version
-// wrapped console.* around a Go sink, one wasm call per line. Two things went
-// wrong with it. The first was recursion — Go's own stdout leaves through
-// console.log (wasm_exec.js), so the sink was reachable from inside a
-// wasm-initiated call, and anything it logged called it again until "Maximum
-// call stack size exceeded" left the module corrupt; that was patched with a
-// re-entrancy guard in JS.
-//
-// The second was fatal and is why the guard was not enough. The standard-Go
-// runtime returns to the JS event loop only when every goroutine is blocked. A
-// visor tab's console is not a trickle — the worker forwards transport dials,
-// WebRTC signalling and dmsg debug output continuously — and each line entering
-// Go gave the scheduler more work before it could park. Past some rate it never
-// parks: the renderer spins at full CPU inside wasm, the page stops answering
-// anything (a bare `typeof` included), the terminal window will not even drag,
-// and because it never reaches a JS statement boundary the debugger cannot
-// interrupt it either. Measured on a quiet page the sink cost 4.6x a bare
-// console.log, which a finite burst survives and an endless stream does not.
-//
-// So the boundary is crossed once per `logs` invocation, or ten times a second
-// while following, instead of once per line. This is the same rule the WebGL
-// overlay follows: per-event work stays on the JS side of the module.
-const captureJS = `(function (max) {
-	var g = globalThis;
-	if (g.__webshLog) { return g.__webshLog; }
-
-	function render(a) {
-		if (typeof a === 'string') { return a; }
-		if (a instanceof Error) { return String(a && a.stack || a); }
-		try { return JSON.stringify(a); } catch (e) { return String(a); }
-	}
-	var ring = { buf: [], max: max, seq: 0 };
-	ring.push = function (level, text) {
-		ring.seq++;
-		ring.buf.push({ at: Date.now(), level: level, text: text, n: ring.seq });
-		if (ring.buf.length > ring.max) { ring.buf.splice(0, ring.buf.length - ring.max); }
-	};
-	ring.since = function (n) {
-		var out = [];
-		for (var i = ring.buf.length - 1; i >= 0; i--) {
-			if (ring.buf[i].n <= n) { break; }
-			out.unshift(ring.buf[i]);
-		}
-		return out;
-	};
-	ring.clear = function () { ring.buf.length = 0; };
-	g.__webshLog = ring;
-
-	// Backfill from a host buffer that was capturing before us (skywire's
-	// browse.js exposes window.skywireLog with .all()), so output from before
-	// this shell opened is there too.
-	try {
-		var host = g.skywireLog;
-		if (host && typeof host.all === 'function') {
-			var all = host.all() || [];
-			for (var j = 0; j < all.length; j++) {
-				var h = all[j];
-				ring.push((h && h.level) || 'log', render(h && h.text !== undefined ? h.text : h));
-				// keep the host's timestamp rather than stamping the backfill now
-				if (h && typeof h.t === 'number') { ring.buf[ring.buf.length - 1].at = h.t; }
-			}
-		}
-	} catch (e) {}
-
-	['log', 'info', 'warn', 'error', 'debug'].forEach(function (lvl) {
-		var orig = console[lvl];
-		if (typeof orig !== 'function') { return; }
-		console[lvl] = function () {
-			try {
-				var parts = [];
-				for (var i = 0; i < arguments.length; i++) { parts.push(render(arguments[i])); }
-				ring.push(lvl, parts.join(' '));
-			} catch (e) { /* never let capture break logging */ }
-			return orig.apply(console, arguments);
-		};
-	});
-
-	if (typeof g.addEventListener === 'function') {
-		g.addEventListener('error', function (ev) {
-			ring.push('error', '[window.error] ' + render(ev && ev.message));
-		});
-		g.addEventListener('unhandledrejection', function (ev) {
-			ring.push('error', '[unhandledrejection] ' + render(ev && ev.reason));
-		});
-	}
-	return ring;
-})`
 
 // colorFor tints a level the way the pager and ls do — errors red, warnings
 // amber, debug dim.
@@ -242,19 +198,23 @@ func runLogs(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, arg
 		case "-n":
 			if i+1 < len(args) {
 				i++
-				limit, _ = strconv.Atoi(args[i])
+				if v, err := strconv.Atoi(args[i]); err == nil {
+					limit = v
+				}
 			}
 		default:
 			if strings.HasPrefix(args[i], "-n") {
-				limit, _ = strconv.Atoi(args[i][2:])
+				if v, err := strconv.Atoi(args[i][2:]); err == nil {
+					limit = v
+				}
 			}
 		}
 	}
 	if clear {
-		if r := ringHandle(); r.Truthy() {
-			r.Call("clear")
-		}
-		fmt.Fprintln(hc.Stdout, "console buffer cleared")
+		logMu.Lock()
+		logBuf = nil
+		logMu.Unlock()
+		shell.Println(hc.Stdout, "console buffer cleared")
 		return 0
 	}
 
@@ -262,7 +222,9 @@ func runLogs(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, arg
 		return !errorsOnly || e.level == "error" || e.level == "warn"
 	}
 
-	snapshot, _ := readLogsSince(0)
+	logMu.Lock()
+	snapshot := append([]logEntry(nil), logBuf...)
+	logMu.Unlock()
 
 	filtered := make([]logEntry, 0, len(snapshot))
 	for _, e := range snapshot {
@@ -274,12 +236,12 @@ func runLogs(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, arg
 		filtered = filtered[len(filtered)-limit:]
 	}
 	for _, e := range filtered {
-		fmt.Fprintln(hc.Stdout, renderLog(e, plain))
+		shell.Println(hc.Stdout, renderLog(e, plain))
 	}
 
 	if !follow {
 		if len(filtered) == 0 {
-			fmt.Fprintln(hc.Stderr, "(console buffer empty — output is captured from the moment the shell starts)")
+			shell.Println(hc.Stderr, "(console buffer empty — output is captured from the moment the shell starts)")
 		}
 		return 0
 	}
@@ -292,7 +254,7 @@ func runLogs(ctx context.Context, s *shell.Shell, hc *interp.HandlerContext, arg
 			return 130
 		case e := <-ch:
 			if keep(e) {
-				fmt.Fprintln(hc.Stdout, renderLog(e, plain))
+				shell.Println(hc.Stdout, renderLog(e, plain))
 			}
 		}
 	}

--- a/third_party/0magnet/websh/shell/edit.go
+++ b/third_party/0magnet/websh/shell/edit.go
@@ -61,8 +61,8 @@ func runEdit(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 		defer s.RawMode(false)
 	}
 	out := hc.Stdout
-	fmt.Fprint(out, "\x1b[?1049h")
-	defer fmt.Fprint(out, "\x1b[?1049l")
+	fprint(out, "\x1b[?1049h")
+	defer fprint(out, "\x1b[?1049l")
 
 	save := func() {
 		if ed.filename == "untitled" {
@@ -142,8 +142,9 @@ func runEdit(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 		}
 		b.WriteString("\x1b[7m" + status + "\x1b[0m")
 		// place the cursor
-		b.WriteString(fmt.Sprintf("\x1b[%d;%dH", ed.cy-ed.topY+1, ed.cx-ed.leftX+1))
-		fmt.Fprint(out, b.String())
+		cursor := fmt.Sprintf("\x1b[%d;%dH", ed.cy-ed.topY+1, ed.cx-ed.leftX+1)
+		b.WriteString(cursor)
+		fprint(out, b.String())
 	}
 
 	insertRune := func(r rune) {
@@ -217,11 +218,11 @@ func runEdit(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 		case '\t':
 			insertRune('\t')
 		case 0x1b: // escape sequences
-			b1, _ := reader.ReadByte()
+			b1 := readByte(reader)
 			if b1 != '[' && b1 != 'O' {
 				continue
 			}
-			b2, _ := reader.ReadByte()
+			b2 := readByte(reader)
 			switch b2 {
 			case 'A':
 				ed.cy--
@@ -236,7 +237,7 @@ func runEdit(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 			case 'F':
 				ed.cx = len(ed.lines[ed.cy])
 			case '3': // delete: ESC [ 3 ~
-				reader.ReadByte()
+				skipByte(reader)
 				l := ed.lines[ed.cy]
 				if ed.cx < len(l) {
 					ed.lines[ed.cy] = append(l[:ed.cx], l[ed.cx+1:]...)
@@ -247,10 +248,10 @@ func runEdit(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 					ed.dirty = true
 				}
 			case '5': // page up
-				reader.ReadByte()
+				skipByte(reader)
 				ed.cy -= textRows
 			case '6': // page down
-				reader.ReadByte()
+				skipByte(reader)
 				ed.cy += textRows
 			}
 		default:

--- a/third_party/0magnet/websh/shell/helpers.go
+++ b/third_party/0magnet/websh/shell/helpers.go
@@ -58,3 +58,18 @@ func CopyLines(r io.Reader, fn func(line string)) {
 		}
 	}
 }
+
+// Printf, Println, Print and Write are the applet-output wrappers used by
+// applets in other packages (see shell/browser). They drop the write error for
+// the reason documented in write.go: a shell that cannot write its output has
+// nowhere left to report that.
+func Printf(w io.Writer, format string, a ...any) { fprintf(w, format, a...) }
+
+// Println writes its operands and a newline, discarding any write error.
+func Println(w io.Writer, a ...any) { fprintln(w, a...) }
+
+// Print writes its operands, discarding any write error.
+func Print(w io.Writer, a ...any) { fprint(w, a...) }
+
+// Write writes raw bytes, discarding any write error.
+func Write(w io.Writer, b []byte) { write(w, b) }

--- a/third_party/0magnet/websh/shell/jq.go
+++ b/third_party/0magnet/websh/shell/jq.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/skycoin/skywire/third_party/0magnet/afero"
@@ -21,7 +20,7 @@ func init() {
 func runJq(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []string) int {
 	flags, rest := parseFlags(args)
 	if len(rest) == 0 {
-		fmt.Fprintln(hc.Stderr, "usage: jq [-r] [-c] 'filter' [file...]")
+		fprintln(hc.Stderr, "usage: jq [-r] [-c] 'filter' [file...]")
 		return 2
 	}
 	query, err := gojq.Parse(rest[0])
@@ -33,7 +32,7 @@ func runJq(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 		return fail(hc, "jq", err)
 	}
 
-	var input io.Reader = hc.Stdin
+	input := hc.Stdin
 	if len(rest) > 1 {
 		data, err := afero.ReadFile(s.FS, resolveArg(hc, rest[1]))
 		if err != nil {
@@ -59,12 +58,12 @@ func runJq(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 				break
 			}
 			if err, isErr := v.(error); isErr {
-				fmt.Fprintf(hc.Stderr, "jq: %v\n", err)
+				fprintf(hc.Stderr, "jq: %v\n", err)
 				status = 5
 				continue
 			}
 			if str, isStr := v.(string); isStr && flags['r'] {
-				fmt.Fprintln(hc.Stdout, str)
+				fprintln(hc.Stdout, str)
 				continue
 			}
 			var out []byte
@@ -74,11 +73,11 @@ func runJq(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []stri
 				out, err = json.MarshalIndent(v, "", "  ")
 			}
 			if err != nil {
-				fmt.Fprintf(hc.Stderr, "jq: %v\n", err)
+				fprintf(hc.Stderr, "jq: %v\n", err)
 				status = 5
 				continue
 			}
-			fmt.Fprintln(hc.Stdout, string(out))
+			fprintln(hc.Stdout, string(out))
 		}
 	}
 	return status

--- a/third_party/0magnet/websh/shell/pager.go
+++ b/third_party/0magnet/websh/shell/pager.go
@@ -44,8 +44,8 @@ func runLess(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 	}
 	out := hc.Stdout
 	// enter alt screen, hide cursor
-	fmt.Fprint(out, "\x1b[?1049h\x1b[?25l")
-	defer fmt.Fprint(out, "\x1b[?25h\x1b[?1049l")
+	fprint(out, "\x1b[?1049h\x1b[?25l")
+	defer fprint(out, "\x1b[?25h\x1b[?1049l")
 
 	top := 0
 	maxTop := len(lines) - page
@@ -76,9 +76,10 @@ func runLess(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 			}
 			pct = end * 100 / len(lines)
 		}
-		b.WriteString(fmt.Sprintf("\x1b[7m %s  %d-%d/%d (%d%%)  q:quit \x1b[0m",
-			name, top+1, minInt(top+page, len(lines)), len(lines), pct))
-		fmt.Fprint(out, b.String())
+		status := fmt.Sprintf("\x1b[7m %s  %d-%d/%d (%d%%)  q:quit \x1b[0m",
+			name, top+1, minInt(top+page, len(lines)), len(lines), pct)
+		b.WriteString(status)
+		fprint(out, b.String())
 	}
 
 	clampTop := func() {
@@ -118,21 +119,21 @@ func runLess(ctx context.Context, s *Shell, hc *interp.HandlerContext, args []st
 		case 'G':
 			top = maxTop
 		case 0x1b: // arrow/page keys: ESC [ X or ESC [ N ~
-			b1, _ := reader.ReadByte()
+			b1 := readByte(reader)
 			if b1 != '[' && b1 != 'O' {
 				continue
 			}
-			b2, _ := reader.ReadByte()
+			b2 := readByte(reader)
 			switch b2 {
 			case 'A':
 				top--
 			case 'B':
 				top++
 			case '5': // page up: ESC [ 5 ~
-				reader.ReadByte()
+				skipByte(reader)
 				top -= page
 			case '6': // page down
-				reader.ReadByte()
+				skipByte(reader)
 				top += page
 			case 'H':
 				top = 0

--- a/third_party/0magnet/websh/shell/shell.go
+++ b/third_party/0magnet/websh/shell/shell.go
@@ -6,7 +6,6 @@ package shell
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -40,7 +39,9 @@ type Shell struct {
 func New(vfs afero.Fs, stdin io.Reader, stdout, stderr io.Writer) (*Shell, error) {
 	if vfs == nil {
 		vfs = afero.NewMemMapFs()
-		Seed(vfs)
+		if err := Seed(vfs); err != nil {
+			return nil, err
+		}
 	}
 	s := &Shell{
 		FS:     vfs,
@@ -72,7 +73,9 @@ func New(vfs afero.Fs, stdin io.Reader, stdout, stderr io.Writer) (*Shell, error
 	// virtual cwd directly instead
 	runner.Dir = "/home/user"
 	s.Runner = runner
-	s.PopulateBin()
+	if err := s.PopulateBin(); err != nil {
+		return nil, err
+	}
 	return s, nil
 }
 
@@ -80,26 +83,33 @@ func New(vfs afero.Fs, stdin io.Reader, stdout, stderr io.Writer) (*Shell, error
 // interpreter never reads input lines itself, so only the line editor above it
 // has one; call this with [LineEditor.History] and [LineEditor.ClearHistory]
 // once the editor exists.
-func (s *Shell) UseHistory(list func() []string, clear func()) {
-	_ = interp.History(list, clear)(s.Runner)
+func (s *Shell) UseHistory(list func() []string, clear func()) error {
+	return interp.History(list, clear)(s.Runner)
 }
 
 // PopulateBin creates a stub file in /bin for every registered applet
 // so the command set is discoverable with ls. Call again after
 // registering extra applets.
-func (s *Shell) PopulateBin() {
-	_ = s.FS.MkdirAll("/bin", 0o755)
-	for name, a := range applets {
-		_ = afero.WriteFile(s.FS, "/bin/"+name,
-			[]byte("websh built-in applet: "+a.help+"\n"), 0o755)
+func (s *Shell) PopulateBin() error {
+	if err := s.FS.MkdirAll("/bin", 0o755); err != nil {
+		return err
 	}
+	for name, a := range applets {
+		if err := afero.WriteFile(s.FS, "/bin/"+name,
+			[]byte("websh built-in applet: "+a.help+"\n"), 0o755); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Seed populates a fresh filesystem with the default home directory.
-func Seed(vfs afero.Fs) {
+func Seed(vfs afero.Fs) error {
 	dirs := []string{"/home/user", "/tmp", "/etc", "/bin"}
 	for _, d := range dirs {
-		_ = vfs.MkdirAll(d, 0o755)
+		if err := vfs.MkdirAll(d, 0o755); err != nil {
+			return err
+		}
 	}
 	files := map[string]string{
 		"/etc/motd": "welcome to websh — a bash-like shell running entirely in your browser\n",
@@ -122,8 +132,11 @@ func Seed(vfs afero.Fs) {
 			"echo \"the answer is $x\"\n",
 	}
 	for path, content := range files {
-		_ = afero.WriteFile(vfs, path, []byte(content), 0o644)
+		if err := afero.WriteFile(vfs, path, []byte(content), 0o644); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // Dir returns the current working directory.
@@ -224,11 +237,17 @@ func (s *Shell) execHandler(next interp.ExecHandlerFunc) interp.ExecHandlerFunc 
 			hc := interp.HandlerCtx(ctx)
 			code := applet.run(ctx, s, &hc, args[1:])
 			if code != 0 {
+				// A shell exit status is a single byte. Clamp instead of
+				// letting an out-of-range applet return wrap around — 256
+				// would otherwise be reported to the caller as success.
+				if code < 0 || code > 255 {
+					code = 1
+				}
 				return interp.ExitStatus(code)
 			}
 			return nil
 		}
-		fmt.Fprintf(interp.HandlerCtx(ctx).Stderr, "websh: %s: command not found\n", args[0])
+		fprintf(interp.HandlerCtx(ctx).Stderr, "websh: %s: command not found\n", args[0])
 		return interp.ExitStatus(127)
 	}
 }

--- a/third_party/0magnet/websh/shell/write.go
+++ b/third_party/0magnet/websh/shell/write.go
@@ -1,0 +1,71 @@
+package shell
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// Applet output goes to a terminal or to the next stage of a pipeline. When
+// such a write fails there is nowhere left for the applet to report it — a
+// diagnostic would go to the same broken stream — so the shell does what every
+// other shell does and carries on. These wrappers exist so that the decision
+// to drop the error is made deliberately, once and in one documented place,
+// instead of being re-litigated at each of the hundred-odd call sites.
+//
+// Errors that are actionable — opening, reading, closing or statting a file —
+// are still checked at the point of the call.
+
+// fprintf writes formatted output, discarding any write error.
+func fprintf(w io.Writer, format string, a ...any) {
+	_, _ = fmt.Fprintf(w, format, a...) //nolint:errcheck // see the comment above
+}
+
+// fprintln writes its operands followed by a newline, discarding any write error.
+func fprintln(w io.Writer, a ...any) {
+	_, _ = fmt.Fprintln(w, a...) //nolint:errcheck // see the comment above
+}
+
+// fprint writes its operands, discarding any write error.
+func fprint(w io.Writer, a ...any) {
+	_, _ = fmt.Fprint(w, a...) //nolint:errcheck // see the comment above
+}
+
+// write writes raw bytes, discarding any write error.
+func write(w io.Writer, b []byte) {
+	_, _ = w.Write(b) //nolint:errcheck // see the comment above
+}
+
+// closeRead closes a handle that was only read from. Its data has already been
+// consumed, so a close failure tells the caller nothing it could act on. A
+// handle that was *written* to is closed explicitly and its error returned,
+// because there a failure means the write never landed.
+func closeRead(c io.Closer) {
+	_ = c.Close() //nolint:errcheck // see the comment above
+}
+
+// numericKey is the sort key used by `sort -n`. Input that is not a number
+// sorts as zero, matching how sort(1) treats non-numeric lines.
+func numericKey(line string) int {
+	n, err := strconv.Atoi(strings.TrimSpace(line))
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// readByte reads one byte of a terminal escape sequence. A read error yields 0,
+// which matches no escape-sequence branch, so the sequence is ignored exactly
+// as an unrecognized one would be.
+func readByte(r io.ByteReader) byte {
+	b, err := r.ReadByte()
+	if err != nil {
+		return 0
+	}
+	return b
+}
+
+// skipByte consumes one byte of an escape sequence whose value does not matter
+// (the trailing '~' of ESC [ n ~, for instance).
+func skipByte(r io.ByteReader) { readByte(r) }


### PR DESCRIPTION
Syncs `third_party/0magnet/websh` with the upstream fork, where the package was brought to zero findings under skywire's own `.golangci.yml`. The shell sources here are identical to that fork modulo import paths.

Most of the 116 findings were unchecked writes to stdout/stderr, which are now funnelled through small wrappers that drop the write error deliberately in one documented place — a shell that cannot write its output has nowhere left to report that. The rest were real:

- `cat` and `touch` report copy, close and chtimes failures instead of exiting 0 after doing nothing; `copyFile` returns the close error of the file it wrote, which is where a failed write actually surfaces
- `find` reports a malformed `-name` pattern rather than silently matching nothing; `du` reports walk errors
- flag parsing iterates bytes, so a multi-byte rune can no longer be truncated into a byte that reads as an unrelated flag
- an applet exit code is clamped to a byte, so an out-of-range return can no longer wrap to 0 and be reported to the caller as success
- escape-sequence reads treat a read error as an unrecognized sequence instead of acting on a zero byte
- `Seed`, `PopulateBin` and `UseHistory` return their errors; the wasm-visor shell surfaces them to the terminal instead of starting up half-initialised

Worth noting for anyone adopting the same config elsewhere: golangci-lint truncates by default (50 per linter, 3 per identical message), which hid 72 of the 116 findings here. `third_party/` is excluded from skywire's lint run, so none of this was visible in CI either way.

Verified: `go build .`, `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor`, and the upstream package's tests pass.