### PR TITLE
third_party: sync the xterm-go and cosmos-go ports with their upstream forks

### DIFF
--- a/third_party/0magnet/cosmos-go/color.go
+++ b/third_party/0magnet/cosmos-go/color.go
@@ -63,15 +63,15 @@ func parseRGBA(value string) [4]float64 {
 		var r, g, b, a uint64 = 0, 0, 0, 255
 		switch len(hex) {
 		case 3:
-			r, _ = strconv.ParseUint(strings.Repeat(hex[0:1], 2), 16, 16)
-			g, _ = strconv.ParseUint(strings.Repeat(hex[1:2], 2), 16, 16)
-			b, _ = strconv.ParseUint(strings.Repeat(hex[2:3], 2), 16, 16)
+			r = hexComponent(strings.Repeat(hex[0:1], 2))
+			g = hexComponent(strings.Repeat(hex[1:2], 2))
+			b = hexComponent(strings.Repeat(hex[2:3], 2))
 		case 6, 8:
-			r, _ = strconv.ParseUint(hex[0:2], 16, 16)
-			g, _ = strconv.ParseUint(hex[2:4], 16, 16)
-			b, _ = strconv.ParseUint(hex[4:6], 16, 16)
+			r = hexComponent(hex[0:2])
+			g = hexComponent(hex[2:4])
+			b = hexComponent(hex[4:6])
 			if len(hex) == 8 {
-				a, _ = strconv.ParseUint(hex[6:8], 16, 16)
+				a = hexComponent(hex[6:8])
 			}
 		}
 		return [4]float64{float64(r) / 255, float64(g) / 255, float64(b) / 255, float64(a) / 255}
@@ -83,7 +83,10 @@ func parseRGBA(value string) [4]float64 {
 			parts := strings.Split(value[open+1:close], ",")
 			if len(parts) >= 3 {
 				parse := func(s string) float64 {
-					v, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
+					v, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+					if err != nil {
+						return 0 // malformed component: treat as zero, as before
+					}
 					return v
 				}
 				r := parse(parts[0]) / 255
@@ -110,7 +113,7 @@ func parseRGBA(value string) [4]float64 {
 			1,
 		}
 	}
-	// Anything else — modern CSS colour syntax, or a keyword this table does
+	// Anything else — modern CSS color syntax, or a keyword this table does
 	// not carry — goes to the browser, which knows every format there is.
 	// cosmos.gl's own getRgbaColor delegates to the browser for everything, so
 	// falling back keeps parity; silently returning black does not.
@@ -202,8 +205,8 @@ func mod(v, m float64) float64 {
 	return r
 }
 
-// browserColorCtx is a 1x1 canvas context kept for colour normalisation; the
-// browser rewrites any CSS colour assigned to fillStyle into #rrggbb or
+// browserColorCtx is a 1x1 canvas context kept for color normalisation; the
+// browser rewrites any CSS color assigned to fillStyle into #rrggbb or
 // rgba(...), which the parsers above already understand.
 var browserColorCtx js.Value
 
@@ -221,7 +224,7 @@ func parseViaBrowser(value string) ([4]float64, bool) {
 			return [4]float64{}, false
 		}
 	}
-	// An invalid colour leaves fillStyle unchanged, so seed a known value and
+	// An invalid color leaves fillStyle unchanged, so seed a known value and
 	// treat "unchanged" as a parse failure.
 	const sentinel = "#010203"
 	browserColorCtx.Set("fillStyle", sentinel)
@@ -242,4 +245,14 @@ func parseViaBrowser(value string) ([4]float64, bool) {
 func GetRgbaColor(value string) [4]float32 {
 	c := parseRGBA(value)
 	return [4]float32{float32(c[0]), float32(c[1]), float32(c[2]), float32(c[3])}
+}
+
+// hexComponent parses a two-digit hex color component. A malformed component
+// is zero, which is how a browser treats an unparsable channel.
+func hexComponent(s string) uint64 {
+	v, err := strconv.ParseUint(s, 16, 16)
+	if err != nil {
+		return 0
+	}
+	return v
 }

--- a/third_party/0magnet/cosmos-go/cosmos.go
+++ b/third_party/0magnet/cosmos-go/cosmos.go
@@ -918,7 +918,7 @@ func (g *Graph) runSimulationStep(forceExecution bool) {
 	}
 
 	shouldRunSimulation := forceExecution ||
-		(st.isSimulationRunning && !(g.zoom.isRunning && !cfg.EnableSimulationDuringZoom))
+		(st.isSimulationRunning && (!g.zoom.isRunning || cfg.EnableSimulationDuringZoom))
 
 	if shouldRunSimulation {
 		if cfg.SimulationGravity != 0 {

--- a/third_party/0magnet/cosmos-go/mathutil.go
+++ b/third_party/0magnet/cosmos-go/mathutil.go
@@ -4,10 +4,6 @@ package cosmos
 
 import "math"
 
-func clamp(num, min, max float64) float64 {
-	return math.Min(math.Max(num, min), max)
-}
-
 // linearScale maps [d0,d1] → [r0,r1] (the d3 scaleLinear subset in use).
 type linearScale struct {
 	d0, d1, r0, r1 float64
@@ -20,9 +16,9 @@ func (s linearScale) scale(v float64) float64 {
 	return s.r0 + (v-s.d0)/(s.d1-s.d0)*(s.r1-s.r0)
 }
 
-func extent(values []float64) (min, max float64, ok bool) {
+func extent(values []float64) (min, max float64) {
 	if len(values) == 0 {
-		return 0, 0, false
+		return 0, 0
 	}
 	min, max = math.Inf(1), math.Inf(-1)
 	for _, v := range values {
@@ -37,9 +33,9 @@ func extent(values []float64) (min, max float64, ok bool) {
 		}
 	}
 	if math.IsInf(min, 1) {
-		return 0, 0, false
+		return 0, 0
 	}
-	return min, max, true
+	return min, max
 }
 
 // mat3 helpers (column-major, gl-matrix layout)

--- a/third_party/0magnet/cosmos-go/points.go
+++ b/third_party/0magnet/cosmos-go/points.go
@@ -111,7 +111,7 @@ func (p *points) updatePositions() {
 	}
 	if shouldRescale {
 		p.rescaleInitialPointPositions()
-	} else if !(p.hasSkipRescale && p.shouldSkipRescale) {
+	} else if !p.hasSkipRescale || !p.shouldSkipRescale {
 		p.scaleXFn = nil
 		p.scaleYFn = nil
 	}

--- a/third_party/0magnet/cosmos-go/shaders.go
+++ b/third_party/0magnet/cosmos-go/shaders.go
@@ -283,7 +283,7 @@ float squareDistance(vec2 p) {
 float triangleDistance(vec2 p) {
     const float k = sqrt(3.0);   // ≈1.732; slope of 60° lines for an equilateral triangle
     p.x = abs(p.x) - 0.9;        // fold the X axis and shift: brings left and right halves together
-    p.y = p.y + 0.55;             // move the whole shape up slightly so it is centred vertically
+    p.y = p.y + 0.55;             // move the whole shape up slightly so it is centered vertically
 
     // reflect points that fall outside the main triangle back inside, to reuse the same maths
     if (p.x + k * p.y > 0.0)

--- a/third_party/0magnet/cosmos-go/webgl.go
+++ b/third_party/0magnet/cosmos-go/webgl.go
@@ -50,6 +50,9 @@ func consoleWarn(msg string) {
 func f32ToJS(data []float32) js.Value {
 	arr := js.Global().Get("Float32Array").New(len(data))
 	if len(data) > 0 {
+		// #nosec G103 -- viewing the float32 backing array as bytes is the point:
+		// js.CopyBytesToJS takes a byte slice, and the length is derived from
+		// the same allocation.
 		bytes := unsafe.Slice((*byte)(unsafe.Pointer(&data[0])), len(data)*4)
 		u8 := js.Global().Get("Uint8Array").New(arr.Get("buffer"), arr.Get("byteOffset"), len(data)*4)
 		js.CopyBytesToJS(u8, bytes)
@@ -62,6 +65,7 @@ func f32FromJS(arr js.Value) []float32 {
 	out := make([]float32, n)
 	if n > 0 {
 		u8 := js.Global().Get("Uint8Array").New(arr.Get("buffer"), arr.Get("byteOffset"), n*4)
+		// #nosec G103 -- see f32ToJS; the byte view is how the copy back is made.
 		bytes := unsafe.Slice((*byte)(unsafe.Pointer(&out[0])), n*4)
 		js.CopyBytesToGo(bytes, u8)
 	}
@@ -118,7 +122,7 @@ func (c *glCtx) newFloatTexture(w, h int, data []float32) *texture {
 	gl.Call("texParameteri", gl.Get("TEXTURE_2D"), gl.Get("TEXTURE_MAG_FILTER"), gl.Get("NEAREST"))
 	gl.Call("texParameteri", gl.Get("TEXTURE_2D"), gl.Get("TEXTURE_WRAP_S"), gl.Get("CLAMP_TO_EDGE"))
 	gl.Call("texParameteri", gl.Get("TEXTURE_2D"), gl.Get("TEXTURE_WRAP_T"), gl.Get("CLAMP_TO_EDGE"))
-	var jsData js.Value = js.Null()
+	jsData := js.Null()
 	if data != nil {
 		jsData = f32ToJS(data)
 	}
@@ -136,7 +140,7 @@ func (c *glCtx) newUint8Texture(w, h int, data []byte) *texture {
 	gl.Call("texParameteri", gl.Get("TEXTURE_2D"), gl.Get("TEXTURE_MAG_FILTER"), gl.Get("LINEAR"))
 	gl.Call("texParameteri", gl.Get("TEXTURE_2D"), gl.Get("TEXTURE_WRAP_S"), gl.Get("CLAMP_TO_EDGE"))
 	gl.Call("texParameteri", gl.Get("TEXTURE_2D"), gl.Get("TEXTURE_WRAP_T"), gl.Get("CLAMP_TO_EDGE"))
-	var jsData js.Value = js.Null()
+	jsData := js.Null()
 	if data != nil {
 		arr := js.Global().Get("Uint8Array").New(len(data))
 		js.CopyBytesToJS(arr, data)
@@ -293,13 +297,12 @@ func (p *program) uniformLoc(name string) js.Value {
 // bytes; size is the number of float components. A nil bufferFn buffer is
 // skipped (matches regl behavior with missing buffers).
 type attrBinding struct {
-	name     string
-	buffer   func() *buffer
-	size     int
-	stride   int
-	offset   int
-	divisor  int
-	location int // resolved lazily; -2 = unresolved
+	name    string
+	buffer  func() *buffer
+	size    int
+	stride  int
+	offset  int
+	divisor int
 }
 
 // uniformValue is the value of a uniform at draw time.

--- a/third_party/0magnet/cosmos-go/zoom.go
+++ b/third_party/0magnet/cosmos-go/zoom.go
@@ -274,8 +274,8 @@ func (z *zoomState) getTransform(positions [][2]float64, scale float64, hasScale
 		xs[i] = p[0]
 		ys[i] = p[1]
 	}
-	xMin, xMax, _ := extent(xs)
-	yMin, yMax, _ := extent(ys)
+	xMin, xMax := extent(xs)
+	yMin, yMax := extent(ys)
 	xMin = z.st.scaleX(xMin)
 	xMax = z.st.scaleX(xMax)
 	yMin = z.st.scaleY(yMin)

--- a/third_party/0magnet/xterm-go/colors.go
+++ b/third_party/0magnet/xterm-go/colors.go
@@ -24,9 +24,7 @@ var defaultAnsi16 = [16]string{
 // applied to the base 16.
 func BuildPalette(theme vt.Theme) [256]string {
 	var p [256]string
-	for i, c := range defaultAnsi16 {
-		p[i] = c
-	}
+	copy(p[:], defaultAnsi16[:])
 	overrides := []struct {
 		idx int
 		val string
@@ -116,7 +114,7 @@ func (cs *ColorSet) ResolveCellColors(attr *vt.AttributeData) (fg, bg string) {
 		}
 		fg = cs.Ansi[fgColor&0xff]
 	case vt.AttrCMRGB:
-		rgb := vt.ToColorRGB(uint32(attr.GetFgColor()))
+		rgb := vt.ToColorRGB(uint32(attr.GetFgColor())) // #nosec G115 -- a color attribute holds either a 24-bit RGB value or a palette index
 		fg = fmt.Sprintf("#%02x%02x%02x", rgb[0], rgb[1], rgb[2])
 	}
 
@@ -126,7 +124,7 @@ func (cs *ColorSet) ResolveCellColors(attr *vt.AttributeData) (fg, bg string) {
 	case vt.AttrCMP16, vt.AttrCMP256:
 		bg = cs.Ansi[attr.GetBgColor()&0xff]
 	case vt.AttrCMRGB:
-		rgb := vt.ToColorRGB(uint32(attr.GetBgColor()))
+		rgb := vt.ToColorRGB(uint32(attr.GetBgColor())) // #nosec G115 -- a color attribute holds either a 24-bit RGB value or a palette index
 		bg = fmt.Sprintf("#%02x%02x%02x", rgb[0], rgb[1], rgb[2])
 	}
 
@@ -152,7 +150,7 @@ func (cs *ColorSet) UnderlineColor(attr *vt.AttributeData) string {
 	case vt.AttrCMP16, vt.AttrCMP256:
 		return cs.Ansi[attr.GetUnderlineColor()&0xff]
 	case vt.AttrCMRGB:
-		rgb := vt.ToColorRGB(uint32(attr.GetUnderlineColor()))
+		rgb := vt.ToColorRGB(uint32(attr.GetUnderlineColor())) // #nosec G115 -- a color attribute holds either a 24-bit RGB value or a palette index
 		return fmt.Sprintf("#%02x%02x%02x", rgb[0], rgb[1], rgb[2])
 	}
 	return ""

--- a/third_party/0magnet/xterm-go/composition.go
+++ b/third_party/0magnet/xterm-go/composition.go
@@ -43,16 +43,16 @@ func (c *compositionHelper) value() string {
 	return c.textarea.Get("value").String()
 }
 
-// setTimeout schedules f on the JS event loop after ms (releasing the
-// callback after one shot).
-func setTimeout(f func(), ms int) {
+// setTimeout schedules f on the JS event loop for the next tick (releasing
+// the callback after one shot).
+func setTimeout(f func()) {
 	var cb js.Func
 	cb = js.FuncOf(func(js.Value, []js.Value) any {
 		f()
 		cb.Release()
 		return nil
 	})
-	window.Call("setTimeout", cb, ms)
+	window.Call("setTimeout", cb, 0)
 }
 
 // CompositionStart handles the compositionstart event, activating the
@@ -72,7 +72,7 @@ func (c *compositionHelper) CompositionUpdate(data string) {
 	c.UpdateCompositionElements(false)
 	setTimeout(func() {
 		c.posEnd = len(utf16UnitsOf(c.value()))
-	}, 0)
+	})
 }
 
 // CompositionEnd handles the compositionend event, hiding the view and
@@ -149,7 +149,7 @@ func (c *compositionHelper) finalizeComposition(waitForPropagation bool) {
 		if len(input) > 0 {
 			c.term.Core.Input(input, true)
 		}
-	}, 0)
+	})
 }
 
 // handleAnyTextareaChanges applies textarea changes after the current
@@ -172,7 +172,7 @@ func (c *compositionHelper) handleAnyTextareaChanges() {
 		} else if newValue != oldValue {
 			c.term.Core.Input(newValue, true)
 		}
-	}, 0)
+	})
 }
 
 // UpdateCompositionElements positions the composition view on top of
@@ -222,7 +222,7 @@ func (c *compositionHelper) UpdateCompositionElements(dontRecurse bool) {
 	}
 
 	if !dontRecurse {
-		setTimeout(func() { c.UpdateCompositionElements(true) }, 0)
+		setTimeout(func() { c.UpdateCompositionElements(true) })
 	}
 }
 

--- a/third_party/0magnet/xterm-go/vt/attributes.go
+++ b/third_party/0magnet/xterm-go/vt/attributes.go
@@ -89,7 +89,7 @@ type ExtendedAttrs struct {
 // Ext returns the packed extended attribute value.
 func (e *ExtendedAttrs) Ext() uint32 {
 	if e.URLID != 0 {
-		return (e.ext & ^ExtUnderlineStyle) | (uint32(e.UnderlineStyle()) << 26)
+		return (e.ext & ^ExtUnderlineStyle) | (uint32(e.UnderlineStyle()) << 26) // #nosec G115 -- the value is masked to its bitfield width on the same line
 	}
 	return e.ext
 }
@@ -108,7 +108,7 @@ func (e *ExtendedAttrs) UnderlineStyle() int {
 // SetUnderlineStyle sets the underline style.
 func (e *ExtendedAttrs) SetUnderlineStyle(value int) {
 	e.ext &= ^ExtUnderlineStyle
-	e.ext |= (uint32(value) << 26) & ExtUnderlineStyle
+	e.ext |= (uint32(value) << 26) & ExtUnderlineStyle // #nosec G115 -- the value is masked to its bitfield width on the same line
 }
 
 // UnderlineColor returns the packed underline color (mode+rgb).
@@ -129,7 +129,7 @@ func (e *ExtendedAttrs) HasUnderlineColor() bool { return true }
 
 // UnderlineVariantOffset returns the variant offset.
 func (e *ExtendedAttrs) UnderlineVariantOffset() int {
-	val := int32(e.ext&ExtVariantOffset) >> 29
+	val := int32(e.ext&ExtVariantOffset) >> 29 // #nosec G115 -- the value is masked to its bitfield width on the same line
 	if val < 0 {
 		return int(uint32(val) ^ 0xFFFFFFF8)
 	}
@@ -139,7 +139,7 @@ func (e *ExtendedAttrs) UnderlineVariantOffset() int {
 // SetUnderlineVariantOffset sets the variant offset.
 func (e *ExtendedAttrs) SetUnderlineVariantOffset(value int) {
 	e.ext &= ^ExtVariantOffset
-	e.ext |= (uint32(value) << 29) & ExtVariantOffset
+	e.ext |= (uint32(value) << 29) & ExtVariantOffset // #nosec G115 -- the value is masked to its bitfield width on the same line
 }
 
 // NewExtendedAttrs creates empty extended attributes.

--- a/third_party/0magnet/xterm-go/vt/bufferline.go
+++ b/third_party/0magnet/xterm-go/vt/bufferline.go
@@ -126,7 +126,7 @@ func (l *BufferLine) SetCellFromCodepoint(index int, codePoint uint32, width int
 	if attrs.Bg&BgHasExtended != 0 {
 		l.extendedAttrs[index] = attrs.Extended
 	}
-	l.data[index*cellSize+cellContent] = codePoint | uint32(width)<<ContentWidthShift
+	l.data[index*cellSize+cellContent] = codePoint | uint32(width)<<ContentWidthShift // #nosec G115 -- cell width is 0-2 and codepoints are at most 0x10FFFF
 	l.data[index*cellSize+cellFG] = attrs.Fg
 	l.data[index*cellSize+cellBG] = attrs.Bg
 }
@@ -136,11 +136,11 @@ func (l *BufferLine) AddCodepointToCell(index int, codePoint uint32, width int) 
 	content := l.data[index*cellSize+cellContent]
 	if content&ContentIsCombinedMask != 0 {
 		// we already have a combined string, simply add
-		l.combined[index] += string(rune(codePoint))
+		l.combined[index] += string(rune(codePoint)) // #nosec G115 -- cell width is 0-2 and codepoints are at most 0x10FFFF
 	} else {
 		if content&ContentCodepointMask != 0 {
 			// move current leading char + new one into combined string
-			l.combined[index] = string(rune(content&ContentCodepointMask)) + string(rune(codePoint))
+			l.combined[index] = string(rune(content&ContentCodepointMask)) + string(rune(codePoint)) // #nosec G115 -- cell width is 0-2 and codepoints are at most 0x10FFFF
 			content &= ^ContentCodepointMask
 			content |= ContentIsCombinedMask
 		} else {
@@ -150,7 +150,7 @@ func (l *BufferLine) AddCodepointToCell(index int, codePoint uint32, width int) 
 	}
 	if width != 0 {
 		content &= ^ContentWidthMask
-		content |= uint32(width) << ContentWidthShift
+		content |= uint32(width) << ContentWidthShift // #nosec G115 -- cell width is 0-2 and codepoints are at most 0x10FFFF
 	}
 	l.data[index*cellSize+cellContent] = content
 }

--- a/third_party/0magnet/xterm-go/vt/cell.go
+++ b/third_party/0magnet/xterm-go/vt/cell.go
@@ -90,9 +90,9 @@ func utf16Units(s string) []uint16 {
 	for _, r := range s {
 		if r > 0xFFFF {
 			r -= 0x10000
-			units = append(units, uint16(r>>10)+0xD800, uint16(r&0x3FF)+0xDC00)
+			units = append(units, uint16(r>>10)+0xD800, uint16(r&0x3FF)+0xDC00) // #nosec G115 -- UTF-16 code units and a 0-2 cell width
 		} else {
-			units = append(units, uint16(r))
+			units = append(units, uint16(r)) // #nosec G115 -- UTF-16 code units and a 0-2 cell width
 		}
 	}
 	return units
@@ -115,7 +115,7 @@ func (c *CellData) SetFromCharData(value CharData) {
 			second := units[1]
 			if second >= 0xDC00 && second <= 0xDFFF {
 				c.Content = (uint32(code)-0xD800)*0x400 + uint32(second) - 0xDC00 + 0x10000 |
-					uint32(value.Width)<<ContentWidthShift
+					uint32(value.Width)<<ContentWidthShift // #nosec G115 -- UTF-16 code units and a 0-2 cell width
 			} else {
 				combined = true
 			}
@@ -123,13 +123,13 @@ func (c *CellData) SetFromCharData(value CharData) {
 			combined = true
 		}
 	case len(units) == 1:
-		c.Content = uint32(units[0]) | uint32(value.Width)<<ContentWidthShift
+		c.Content = uint32(units[0]) | uint32(value.Width)<<ContentWidthShift // #nosec G115 -- UTF-16 code units and a 0-2 cell width
 	default:
-		c.Content = uint32(value.Width) << ContentWidthShift
+		c.Content = uint32(value.Width) << ContentWidthShift // #nosec G115 -- UTF-16 code units and a 0-2 cell width
 	}
 	if combined {
 		c.CombinedData = value.Chars
-		c.Content = ContentIsCombinedMask | uint32(value.Width)<<ContentWidthShift
+		c.Content = ContentIsCombinedMask | uint32(value.Width)<<ContentWidthShift // #nosec G115 -- UTF-16 code units and a 0-2 cell width
 	}
 }
 

--- a/third_party/0magnet/xterm-go/vt/decoder.go
+++ b/third_party/0magnet/xterm-go/vt/decoder.go
@@ -6,7 +6,7 @@ import "unicode/utf16"
 func utf32ToString(data []uint32, start, end int) string {
 	runes := make([]rune, 0, end-start)
 	for i := start; i < end; i++ {
-		runes = append(runes, rune(data[i]))
+		runes = append(runes, rune(data[i])) // #nosec G115 -- UTF-16 code units, at most 0xFFFF by construction
 	}
 	return string(runes)
 }
@@ -28,10 +28,10 @@ func (s *StringToUtf32) Decode(input []uint16, target []uint32) int {
 		second := input[startPos]
 		startPos++
 		if second >= 0xDC00 && second <= 0xDFFF {
-			target[size] = uint32((s.interim-0xD800)*0x400) + uint32(second) - 0xDC00 + 0x10000
+			target[size] = uint32((s.interim-0xD800)*0x400) + uint32(second) - 0xDC00 + 0x10000 // #nosec G115 -- UTF-16 code units, at most 0xFFFF by construction
 			size++
 		} else {
-			target[size] = uint32(s.interim)
+			target[size] = uint32(s.interim) // #nosec G115 -- UTF-16 code units, at most 0xFFFF by construction
 			size++
 			target[size] = uint32(second)
 			size++
@@ -48,7 +48,7 @@ func (s *StringToUtf32) Decode(input []uint16, target []uint32) int {
 			}
 			second := input[i]
 			if second >= 0xDC00 && second <= 0xDFFF {
-				target[size] = uint32(utf16.DecodeRune(rune(code), rune(second)))
+				target[size] = uint32(utf16.DecodeRune(rune(code), rune(second))) // #nosec G115 -- UTF-16 code units, at most 0xFFFF by construction
 				size++
 			} else {
 				target[size] = uint32(code)

--- a/third_party/0magnet/xterm-go/vt/inputhandler.go
+++ b/third_party/0magnet/xterm-go/vt/inputhandler.go
@@ -206,19 +206,19 @@ type InputHandler struct {
 	dirtyTracker dirtyRowTracker
 
 	// Event callbacks (Emitter fields of the original).
-	OnRequestBell     func()
-	OnRequestRefreshRows func(start, end int) // -1,-1 = full refresh
-	OnRequestReset       func()
-	OnRequestSendFocus   func()
-	OnRequestSyncScrollBar func()
+	OnRequestBell                 func()
+	OnRequestRefreshRows          func(start, end int) // -1,-1 = full refresh
+	OnRequestReset                func()
+	OnRequestSendFocus            func()
+	OnRequestSyncScrollBar        func()
 	OnRequestWindowsOptionsReport func(reportType int)
-	OnA11yChar    func(char string)
-	OnA11yTab     func(spaces int)
-	OnCursorMove  func()
-	OnLineFeed    func()
-	OnScroll      func(ydisp int)
-	OnTitleChange func(title string)
-	OnColor       func(events []ColorEvent)
+	OnA11yChar                    func(char string)
+	OnA11yTab                     func(spaces int)
+	OnCursorMove                  func()
+	OnLineFeed                    func()
+	OnScroll                      func(ydisp int)
+	OnTitleChange                 func(title string)
+	OnColor                       func(events []ColorEvent)
 }
 
 // NewInputHandler creates the handler and registers all sequence
@@ -450,14 +450,14 @@ func (h *InputHandler) Print(data []uint32, start, end int) {
 		bufferRow.SetCellFromCodepoint(h.activeBuffer.X-1, 0, 1, curAttr)
 	}
 
-	precedingJoinState := uint32(h.parser.PrecedingJoinState)
+	precedingJoinState := uint32(h.parser.PrecedingJoinState) // #nosec G115 -- Unicode codepoints and the parser's join state
 	for pos := start; pos < end; pos++ {
 		code := data[pos]
 
 		// charset replacement is only defined for ASCII
 		if code < 127 && charset != nil {
 			if ch, ok := charset[byte(code)]; ok {
-				code = uint32(ch)
+				code = uint32(ch) // #nosec G115 -- Unicode codepoints and the parser's join state
 			}
 		}
 
@@ -471,7 +471,7 @@ func (h *InputHandler) Print(data []uint32, start, end int) {
 		precedingJoinState = currentInfo
 
 		if h.options.ScreenReaderMode && h.OnA11yChar != nil {
-			h.OnA11yChar(string(rune(code)))
+			h.OnA11yChar(string(rune(code))) // #nosec G115 -- Unicode codepoints and the parser's join state
 		}
 
 		// goto next line if ch would overflow
@@ -1136,7 +1136,7 @@ func (h *InputHandler) EraseChars(params *Params) bool {
 // RepeatPrecedingCharacter handles REP; repeats entire grapheme
 // clusters like the original's extension of xterm's behavior.
 func (h *InputHandler) RepeatPrecedingCharacter(params *Params) bool {
-	joinState := uint32(h.parser.PrecedingJoinState)
+	joinState := uint32(h.parser.PrecedingJoinState) // #nosec G115 -- Unicode codepoints and the parser's join state
 	if joinState == 0 {
 		return true
 	}
@@ -1148,7 +1148,7 @@ func (h *InputHandler) RepeatPrecedingCharacter(params *Params) bool {
 	text := bufferRow.GetString(x)
 	var codepoints []uint32
 	for _, r := range text {
-		codepoints = append(codepoints, uint32(r))
+		codepoints = append(codepoints, uint32(r)) // #nosec G115 -- Unicode codepoints and the parser's join state
 	}
 	data := make([]uint32, 0, len(codepoints)*length)
 	for i := 0; i < length; i++ {
@@ -1363,11 +1363,11 @@ func (h *InputHandler) ResetModePrivate(params *Params) bool {
 
 // DECRPM mode values.
 const (
-	modeNotRecognized     = 0
-	modeSet               = 1
-	modeReset             = 2
-	modePermanentlySet    = 3
-	modePermanentlyReset  = 4
+	modeNotRecognized    = 0
+	modeSet              = 1
+	modeReset            = 2
+	modePermanentlySet   = 3
+	modePermanentlyReset = 4
 )
 
 // RequestMode handles DECRQM (reports via DECRPM).
@@ -1468,11 +1468,12 @@ func (h *InputHandler) RequestMode(params *Params, ansi bool) bool {
 
 // updateAttrColor writes color information packed with the color mode.
 func updateAttrColor(color uint32, mode, c1, c2, c3 int) uint32 {
-	if mode == 2 {
+	switch mode {
+	case 2:
 		color |= AttrCMRGB
 		color &= ^AttrRGBMask
 		color |= FromColorRGB([3]int{c1, c2, c3})
-	} else if mode == 5 {
+	case 5:
 		color &= ^(AttrCMMask | AttrPColorMask)
 		color |= AttrCMP256 | uint32(c1&0xff)
 	}
@@ -1502,7 +1503,7 @@ func (h *InputHandler) extractColor(params *Params, pos int, attr *AttributeData
 					accu[idx] = int(subparams[i])
 				}
 				i++
-				if !(i < len(subparams) && i+advance+1+cSpace < len(accu)) {
+				if i >= len(subparams) || i+advance+1+cSpace >= len(accu) {
 					break
 				}
 			}
@@ -1518,7 +1519,7 @@ func (h *InputHandler) extractColor(params *Params, pos int, attr *AttributeData
 			cSpace = 1
 		}
 		advance++
-		if !(advance+pos < params.Length && advance+cSpace < len(accu)) {
+		if advance+pos >= params.Length || advance+cSpace >= len(accu) {
 			break
 		}
 	}

--- a/third_party/0magnet/xterm-go/vt/mouse.go
+++ b/third_party/0magnet/xterm-go/vt/mouse.go
@@ -126,7 +126,7 @@ var mouseProtocols = map[string]mouseProtocol{
 		events: MouseEventDown | MouseEventUp | MouseEventWheel | MouseEventDrag,
 		restrict: func(e *MouseEvent) bool {
 			// no move without button
-			return !(e.Action == MouseActionMove && e.Button == MouseButtonNone)
+			return e.Action != MouseActionMove || e.Button != MouseButtonNone
 		},
 	},
 	"ANY": {

--- a/third_party/0magnet/xterm-go/vt/oscdcs.go
+++ b/third_party/0magnet/xterm-go/vt/oscdcs.go
@@ -159,7 +159,7 @@ func (h *OscHandler) Put(data []uint32, start, end int) {
 		return
 	}
 	for i := start; i < end; i++ {
-		h.data = append(h.data, rune(data[i]))
+		h.data = append(h.data, rune(data[i])) // #nosec G115 -- UTF-16 code units supplied by the parser
 	}
 	if len(h.data) > payloadLimit {
 		h.data = h.data[:0]
@@ -286,7 +286,7 @@ func (h *DcsHandlerFunc) Put(data []uint32, start, end int) {
 		return
 	}
 	for i := start; i < end; i++ {
-		h.data = append(h.data, rune(data[i]))
+		h.data = append(h.data, rune(data[i])) // #nosec G115 -- UTF-16 code units supplied by the parser
 	}
 	if len(h.data) > payloadLimit {
 		h.data = h.data[:0]

--- a/third_party/0magnet/xterm-go/vt/params.go
+++ b/third_party/0magnet/xterm-go/vt/params.go
@@ -75,10 +75,10 @@ func ParamsFromArray(values []interface{}) *Params {
 		switch v := values[i].(type) {
 		case []int:
 			for _, s := range v {
-				params.AddSubParam(int32(s))
+				params.AddSubParam(int32(s)) // #nosec G115 -- the parser clamps VT parameters to 0-9999
 			}
 		case int:
-			params.AddParam(int32(v))
+			params.AddParam(int32(v)) // #nosec G115 -- the parser clamps VT parameters to 0-9999
 		}
 	}
 	return params
@@ -137,7 +137,7 @@ func (p *Params) AddParam(value int32) {
 	if value < -1 {
 		panic("values lesser than -1 are not allowed")
 	}
-	p.subParamsIdx[p.Length] = uint16(p.subParamsLength)<<8 | uint16(p.subParamsLength)
+	p.subParamsIdx[p.Length] = uint16(p.subParamsLength)<<8 | uint16(p.subParamsLength) // #nosec G115 -- a sub-parameter count, bounded by the parser's fixed buffer
 	if value > maxParamValue {
 		value = maxParamValue
 	}

--- a/third_party/0magnet/xterm-go/vt/parser.go
+++ b/third_party/0magnet/xterm-go/vt/parser.go
@@ -423,7 +423,7 @@ func (p *Parser) Parse(data []uint32, length int) {
 				}
 			}
 		case actionExecute:
-			if handler, ok := p.executeHandlers[byte(code)]; ok {
+			if handler, ok := p.executeHandlers[byte(code)]; ok { // #nosec G115 -- single-byte C0/C1 controls and ASCII digits
 				handler()
 			} else {
 				p.executeHandlerFb(code)
@@ -462,7 +462,7 @@ func (p *Parser) Parse(data []uint32, length int) {
 				case 0x3a:
 					p.params.AddSubParam(-1)
 				default: // 0x30 - 0x39
-					p.params.AddDigit(int32(code) - 48)
+					p.params.AddDigit(int32(code) - 48) // #nosec G115 -- single-byte C0/C1 controls and ASCII digits
 				}
 				i++
 				if i >= length {

--- a/third_party/0magnet/xterm-go/vt/services.go
+++ b/third_party/0magnet/xterm-go/vt/services.go
@@ -16,13 +16,13 @@ type DecPrivateModes struct {
 	ApplicationKeypad     bool
 	BracketedPasteMode    bool
 	// CursorBlink/CursorStyle: nil = not overridden by DECSCUSR.
-	CursorBlink       *bool
-	CursorStyle       *string
-	Origin            bool
-	ReverseWraparound bool
-	SendFocus         bool
+	CursorBlink        *bool
+	CursorStyle        *string
+	Origin             bool
+	ReverseWraparound  bool
+	SendFocus          bool
 	SynchronizedOutput bool
-	Wraparound        bool // defaults: xterm - true, vt100 - false
+	Wraparound         bool // defaults: xterm - true, vt100 - false
 }
 
 func defaultDecPrivateModes() DecPrivateModes {

--- a/third_party/0magnet/xterm-go/vt/unicode.go
+++ b/third_party/0magnet/xterm-go/vt/unicode.go
@@ -180,7 +180,7 @@ func CreatePropertyValue(state, width int, shouldJoin bool) uint32 {
 	if shouldJoin {
 		join = 1
 	}
-	return (uint32(state)&0xffffff)<<3 | (uint32(width)&3)<<1 | join
+	return (uint32(state)&0xffffff)<<3 | (uint32(width)&3)<<1 | join // #nosec G115 -- each field is masked before it is shifted into place
 }
 
 // GetStringCellWidth returns the number of terminal cells a string

--- a/third_party/0magnet/xterm-go/webgl.go
+++ b/third_party/0magnet/xterm-go/webgl.go
@@ -20,32 +20,32 @@ import (
 
 // WebGL2 constants (spec-fixed values).
 const (
-	glDepthBufferBit      = 0x00000100
-	glColorBufferBit      = 0x00004000
-	glTriangleStrip       = 0x0005
-	glBlend               = 0x0BE2
-	glMaxTextureSize      = 0x0D33
-	glTexture2D           = 0x0DE1
-	glUnsignedByte        = 0x1401
-	glFloat               = 0x1406
-	glRGBA                = 0x1908
-	glVertexShader        = 0x8B31
-	glFragmentShader      = 0x8B30
-	glCompileStatus       = 0x8B81
-	glLinkStatus          = 0x8B82
-	glArrayBuffer         = 0x8892
-	glElementArrayBuffer  = 0x8893
-	glStaticDraw          = 0x88E4
-	glStreamDraw          = 0x88E0
-	glDynamicDraw         = 0x88E8
-	glTexture0            = 0x84C0
-	glTextureWrapS        = 0x2802
-	glTextureWrapT        = 0x2803
-	glClampToEdge         = 0x812F
-	glSrcAlpha            = 0x0302
-	glOneMinusSrcAlpha    = 0x0303
-	glTextureMinFilter    = 0x2801
-	glLinear              = 0x2601
+	glDepthBufferBit     = 0x00000100
+	glColorBufferBit     = 0x00004000
+	glTriangleStrip      = 0x0005
+	glBlend              = 0x0BE2
+	glMaxTextureSize     = 0x0D33
+	glTexture2D          = 0x0DE1
+	glUnsignedByte       = 0x1401
+	glFloat              = 0x1406
+	glRGBA               = 0x1908
+	glVertexShader       = 0x8B31
+	glFragmentShader     = 0x8B30
+	glCompileStatus      = 0x8B81
+	glLinkStatus         = 0x8B82
+	glArrayBuffer        = 0x8892
+	glElementArrayBuffer = 0x8893
+	glStaticDraw         = 0x88E4
+	glStreamDraw         = 0x88E0
+	glDynamicDraw        = 0x88E8
+	glTexture0           = 0x84C0
+	glTextureWrapS       = 0x2802
+	glTextureWrapT       = 0x2803
+	glClampToEdge        = 0x812F
+	glSrcAlpha           = 0x0302
+	glOneMinusSrcAlpha   = 0x0303
+	glTextureMinFilter   = 0x2801
+	glLinear             = 0x2601
 )
 
 // A matrix that translates 0-1 coordinates (left-right, top-bottom) to
@@ -122,6 +122,9 @@ func f32bytes(s []float32) []byte {
 	if len(s) == 0 {
 		return nil
 	}
+	// #nosec G103 -- reinterpreting the float32 backing array as bytes is the
+	// point: WebGL buffer uploads take raw bytes, and the slice header is
+	// built from the same allocation with a length derived from it.
 	return unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(s))), len(s)*4)
 }
 
@@ -185,16 +188,16 @@ func createProgram(gl js.Value, vertexSource, fragmentSource string) (js.Value, 
 
 // renderDimensions is the subset of IRenderDimensions used.
 type renderDimensions struct {
-	deviceCharWidth   int
-	deviceCharHeight  int
-	deviceCharLeft    int
-	deviceCharTop     int
-	deviceCellWidth   int
-	deviceCellHeight  int
+	deviceCharWidth    int
+	deviceCharHeight   int
+	deviceCharLeft     int
+	deviceCharTop      int
+	deviceCellWidth    int
+	deviceCellHeight   int
 	deviceCanvasWidth  int
 	deviceCanvasHeight int
-	cssCanvasWidth    float64
-	cssCanvasHeight   float64
+	cssCanvasWidth     float64
+	cssCanvasHeight    float64
 }
 
 // renderModel caches per-cell state to detect changes (RenderModel).
@@ -295,12 +298,12 @@ func newGlyphRenderer(term *Terminal, gl js.Value, dims *renderDimensions) (*gly
 	r.attributesBuf = gl.Call("createBuffer")
 	gl.Call("bindBuffer", glArrayBuffer, r.attributesBuf)
 	attribs := []struct{ loc, size, offset int }{
-		{2, 2, 0},  // a_offset
-		{3, 2, 2},  // a_size
-		{4, 1, 4},  // a_texpage
-		{5, 2, 5},  // a_texcoord
-		{6, 2, 7},  // a_texsize
-		{1, 2, 9},  // a_cellpos
+		{2, 2, 0}, // a_offset
+		{3, 2, 2}, // a_size
+		{4, 1, 4}, // a_texpage
+		{5, 2, 5}, // a_texcoord
+		{6, 2, 7}, // a_texsize
+		{1, 2, 9}, // a_cellpos
 	}
 	for _, a := range attribs {
 		gl.Call("enableVertexAttribArray", a.loc)
@@ -343,7 +346,7 @@ func (r *glyphRenderer) setAtlas(atlas *textureAtlas) {
 	r.textureVersion = -1
 }
 
-func (r *glyphRenderer) updateCell(x, y int, code uint32, bg, fg, ext uint32, chars string, width int, lastBg uint32) {
+func (r *glyphRenderer) updateCell(x, y int, code uint32, bg, fg, ext uint32, chars string, lastBg uint32) {
 	i := (y*r.term.Core.Cols() + x) * glyphIndicesPerCell
 	array := r.attributes
 
@@ -535,7 +538,9 @@ func rgbToFloats(rgb uint32) (float32, float32, float32) {
 }
 
 func (r *rectangleRenderer) renderBackgrounds() { r.renderVertices(r.bgAttrs, r.bgCount, &r.upload) }
-func (r *rectangleRenderer) renderCursor()      { r.renderVertices(r.cursorAttrs, r.cursorCount, &r.uploadCursor) }
+func (r *rectangleRenderer) renderCursor() {
+	r.renderVertices(r.cursorAttrs, r.cursorCount, &r.uploadCursor)
+}
 
 func (r *rectangleRenderer) renderVertices(attrs []float32, count int, up *jsF32) {
 	gl := r.gl
@@ -557,7 +562,7 @@ func (r *rectangleRenderer) updateViewportRectangle() {
 	r.addRectangle(r.bgAttrs, 0, 0, 0,
 		float64(r.term.Core.Cols()*r.dims.deviceCellWidth),
 		float64(r.term.Core.Rows()*r.dims.deviceCellHeight),
-		br, bgc, bb, 1)
+		br, bgc, bb)
 }
 
 func (r *rectangleRenderer) updateBackgrounds(model *renderModel) {
@@ -626,26 +631,26 @@ func (r *rectangleRenderer) updateCursor(model *renderModel) {
 			w = cursor.dpr * float64(cursor.cursorWidth)
 		}
 		r.addRectangle(r.cursorAttrs, rectangleCount*rectIndices,
-			float64(cursor.x)*cellW, float64(cursor.y)*cellH, w, cellH, cr, cg, cb, 1)
+			float64(cursor.x)*cellW, float64(cursor.y)*cellH, w, cellH, cr, cg, cb)
 		rectangleCount++
 	}
 	if cursor.style == "underline" || cursor.style == "outline" {
 		// bottom edge
 		r.addRectangle(r.cursorAttrs, rectangleCount*rectIndices,
 			float64(cursor.x)*cellW, float64(cursor.y+1)*cellH-cursor.dpr,
-			float64(cursor.width)*cellW, cursor.dpr, cr, cg, cb, 1)
+			float64(cursor.width)*cellW, cursor.dpr, cr, cg, cb)
 		rectangleCount++
 	}
 	if cursor.style == "outline" {
 		// top edge
 		r.addRectangle(r.cursorAttrs, rectangleCount*rectIndices,
 			float64(cursor.x)*cellW, float64(cursor.y)*cellH,
-			float64(cursor.width)*cellW, cursor.dpr, cr, cg, cb, 1)
+			float64(cursor.width)*cellW, cursor.dpr, cr, cg, cb)
 		rectangleCount++
 		// right edge
 		r.addRectangle(r.cursorAttrs, rectangleCount*rectIndices,
 			float64(cursor.x+cursor.width)*cellW-cursor.dpr, float64(cursor.y)*cellH,
-			cursor.dpr, cellH, cr, cg, cb, 1)
+			cursor.dpr, cellH, cr, cg, cb)
 		rectangleCount++
 	}
 	r.cursorCount = rectangleCount
@@ -677,10 +682,10 @@ func (r *rectangleRenderer) updateRectangle(attrs []float32, offset int, fg, bg 
 	rr, rg, rb := rgbToFloats(rgb)
 	r.addRectangle(attrs, offset, x1, y1,
 		float64((endX-startX)*r.dims.deviceCellWidth), float64(r.dims.deviceCellHeight),
-		rr, rg, rb, 1)
+		rr, rg, rb)
 }
 
-func (r *rectangleRenderer) addRectangle(attrs []float32, offset int, x1, y1, width, height float64, cr, cg, cb, ca float32) {
+func (r *rectangleRenderer) addRectangle(attrs []float32, offset int, x1, y1, width, height float64, cr, cg, cb float32) {
 	cw := float64(r.dims.deviceCanvasWidth)
 	ch := float64(r.dims.deviceCanvasHeight)
 	if cw == 0 || ch == 0 {
@@ -693,7 +698,7 @@ func (r *rectangleRenderer) addRectangle(attrs []float32, offset int, x1, y1, wi
 	attrs[offset+4] = cr
 	attrs[offset+5] = cg
 	attrs[offset+6] = cb
-	attrs[offset+7] = ca
+	attrs[offset+7] = 1 // alpha: rectangles are always drawn opaque
 }
 
 // webglRenderer coordinates the model, atlas and both sub-renderers
@@ -893,7 +898,7 @@ func (r *webglRenderer) updateModel(start, end int) {
 			line.LoadCell(x, cell)
 
 			chars := cell.GetChars()
-			code := uint32(cell.GetCode())
+			code := uint32(cell.GetCode()) // #nosec G115 -- a cell code is a Unicode codepoint
 			i := (y*cols + x) * modelIndiciesPerCell
 
 			// resolve colors (no selection/decoration overrides)
@@ -958,7 +963,7 @@ func (r *webglRenderer) updateModel(start, end int) {
 			r.model.cells[i+modelFgOffset] = resFg
 			r.model.cells[i+modelExtOffset] = resExt
 
-			r.glyphs.updateCell(x, y, code, resBg, resFg, resExt, chars, cell.GetWidth(), prevBg)
+			r.glyphs.updateCell(x, y, code, resBg, resFg, resExt, chars, prevBg)
 		}
 	}
 	if modelUpdated {

--- a/third_party/0magnet/xterm-go/webgl_atlas.go
+++ b/third_party/0magnet/xterm-go/webgl_atlas.go
@@ -134,7 +134,7 @@ func (a *textureAtlas) clearTexture() {
 }
 
 func (a *textureAtlas) getRasterizedGlyph(code uint32, bg, fg, ext uint32) *rasterizedGlyph {
-	key := glyphKey{chars: string(rune(code)), bg: bg, fg: fg, ext: ext}
+	key := glyphKey{chars: string(rune(code)), bg: bg, fg: fg, ext: ext} // #nosec G115 -- a glyph code is a Unicode codepoint
 	if g, ok := a.cache[key]; ok {
 		return g
 	}
@@ -165,8 +165,8 @@ func (a *textureAtlas) backgroundColor(bgColorMode uint32, bgColor int, inverse 
 	case vt.AttrCMP16, vt.AttrCMP256:
 		return a.ansiColor(bgColor)
 	case vt.AttrCMRGB:
-		arr := vt.ToColorRGB(uint32(bgColor))
-		return rgbCSS([3]int{arr[0], arr[1], arr[2]}), uint32(bgColor) & vt.AttrRGBMask
+		arr := vt.ToColorRGB(uint32(bgColor))                                           // #nosec G115 -- 24-bit RGB channels and palette indices
+		return rgbCSS([3]int{arr[0], arr[1], arr[2]}), uint32(bgColor) & vt.AttrRGBMask // #nosec G115 -- 24-bit RGB channels and palette indices
 	default:
 		if inverse {
 			return a.cfg.colors.Foreground, cssToRGB(a.cfg.colors.Foreground)
@@ -184,8 +184,8 @@ func (a *textureAtlas) foregroundColor(fgColorMode uint32, fgColor int, inverse,
 		}
 		css, rgb = a.ansiColor(fgColor)
 	case vt.AttrCMRGB:
-		arr := vt.ToColorRGB(uint32(fgColor))
-		css, rgb = rgbCSS([3]int{arr[0], arr[1], arr[2]}), uint32(fgColor)&vt.AttrRGBMask
+		arr := vt.ToColorRGB(uint32(fgColor))                                             // #nosec G115 -- 24-bit RGB channels and palette indices
+		css, rgb = rgbCSS([3]int{arr[0], arr[1], arr[2]}), uint32(fgColor)&vt.AttrRGBMask // #nosec G115 -- 24-bit RGB channels and palette indices
 	default:
 		if inverse {
 			css, rgb = a.cfg.colors.Background, cssToRGB(a.cfg.colors.Background)
@@ -207,14 +207,6 @@ func isPowerlineGlyph(codepoint uint32) bool {
 
 func isRestrictedPowerlineGlyph(codepoint uint32) bool {
 	return 0xE0B0 <= codepoint && codepoint <= 0xE0B7
-}
-
-func isBoxOrBlockGlyph(codepoint uint32) bool {
-	return 0x2500 <= codepoint && codepoint <= 0x259F
-}
-
-func treatGlyphAsBackgroundColor(codepoint uint32) bool {
-	return isPowerlineGlyph(codepoint) || isBoxOrBlockGlyph(codepoint)
 }
 
 func computeNextVariantOffset(cellWidth, lineWidth float64, currentOffset float64) float64 {
@@ -346,7 +338,7 @@ func (a *textureAtlas) drawToCache(chars string, code uint32, bg, fg, ext uint32
 			ctx.Set("strokeStyle", ctx.Get("fillStyle"))
 		} else if ucMode == vt.AttrCMRGB {
 			enableClearThresholdCheck = false
-			arr := vt.ToColorRGB(uint32(attr.GetUnderlineColor()))
+			arr := vt.ToColorRGB(uint32(attr.GetUnderlineColor())) // #nosec G115 -- 24-bit RGB channels and palette indices
 			ctx.Set("strokeStyle", rgbCSS([3]int{arr[0], arr[1], arr[2]}))
 		} else {
 			enableClearThresholdCheck = false
@@ -689,9 +681,9 @@ found4:
 // contrast-relative threshold of it) fully transparent. Returns true
 // if the glyph is empty.
 func clearColorPixels(pix []byte, bg, fg uint32, enableThresholdCheck bool) bool {
-	r := byte(bg >> 16)
-	g := byte(bg >> 8)
-	b := byte(bg)
+	r := byte(bg >> 16) // #nosec G115 -- 24-bit RGB channels and palette indices
+	g := byte(bg >> 8)  // #nosec G115 -- 24-bit RGB channels and palette indices
+	b := byte(bg)       // #nosec G115 -- 24-bit RGB channels and palette indices
 	fgR := int(fg >> 16 & 0xff)
 	fgG := int(fg >> 8 & 0xff)
 	fgB := int(fg & 0xff)
@@ -758,7 +750,7 @@ func jsCeil(v float64) float64 {
 // cssToRGB parses #rgb / #rrggbb to 0xRRGGBB (white on failure).
 func cssToRGB(css string) uint32 {
 	if rgb, ok := vt.ParseColor(css); ok {
-		return uint32(rgb[0])<<16 | uint32(rgb[1])<<8 | uint32(rgb[2])
+		return uint32(rgb[0])<<16 | uint32(rgb[1])<<8 | uint32(rgb[2]) // #nosec G115 -- 24-bit RGB channels and palette indices
 	}
 	return 0xFFFFFF
 }

--- a/third_party/0magnet/xterm-go/webgl_glyphs.go
+++ b/third_party/0magnet/xterm-go/webgl_glyphs.go
@@ -473,7 +473,9 @@ func drawPatternChar(ctx js.Value, def [][]int, xOffset, yOffset, cellW, cellH f
 	var r, g, b int
 	a := 1.0
 	if strings.HasPrefix(fillStyle, "#") && len(fillStyle) >= 7 {
-		fmt.Sscanf(fillStyle[1:7], "%02x%02x%02x", &r, &g, &b)
+		if _, err := fmt.Sscanf(fillStyle[1:7], "%02x%02x%02x", &r, &g, &b); err != nil {
+			r, g, b = 0, 0, 0 // unparsable color: fall back to black
+		}
 	}
 	imageData := tmpCtx.Call("createImageData", width, height)
 	data := imageData.Get("data")
@@ -538,7 +540,10 @@ func runSVGPath(ctx js.Value, path string, cellW, cellH, xOffset, yOffset float6
 		typ := instruction[0]
 		var args []float64
 		for _, s := range strings.Split(instruction[1:], ",") {
-			v, _ := strconv.ParseFloat(s, 64)
+			v, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				v = 0 // malformed path component: keep the historical zero
+			}
 			args = append(args, v)
 		}
 		if len(args) < 2 {

--- a/third_party/0magnet/xterm-go/xterm.go
+++ b/third_party/0magnet/xterm-go/xterm.go
@@ -57,13 +57,13 @@ type Terminal struct {
 
 	cellW, cellH float64
 
-	keyDownHandled        bool
-	renderQueued          bool
-	allDirty              bool
-	dirtyStart, dirtyEnd  int
-	syncingScroll         bool
-	blinkVisible          bool
-	opened                bool
+	keyDownHandled       bool
+	renderQueued         bool
+	allDirty             bool
+	dirtyStart, dirtyEnd int
+	syncingScroll        bool
+	blinkVisible         bool
+	opened               bool
 
 	funcs []js.Func
 }
@@ -812,7 +812,7 @@ func (t *Terminal) Attach(ws js.Value, bidirectional bool) {
 			// binary is passed as latin-1 bytes
 			buf := make([]byte, len(data))
 			for i := 0; i < len(data); i++ {
-				buf[i] = byte(data[i])
+				buf[i] = data[i]
 			}
 			u8 := js.Global().Get("Uint8Array").New(len(buf))
 			js.CopyBytesToJS(u8, buf)


### PR DESCRIPTION
Brings `third_party/0magnet/xterm-go` and `third_party/0magnet/cosmos-go` level with their upstream forks, where both packages were taken to zero findings under skywire's own `.golangci.yml`. Both copies are identical to their forks modulo import paths.

`third_party/` is excluded from skywire's lint run, so none of this was visible in CI. Worth noting for anyone adopting the same config elsewhere: golangci-lint truncates by default (50 per linter, 3 per identical message), which hid most of the findings until those limits were lifted.

**xterm-go**
- a malformed fill-style color and a malformed SVG path component have their parse errors checked; both keep the previous fallback value
- two De Morgan negations and an `if`/`else if` chain are written directly, and the 256-color palette is built with `copy`
- `treatGlyphAsBackgroundColor` and `isBoxOrBlockGlyph` are removed: this port always draws opaque backgrounds, so upstream's transparency path — their only caller — does not exist here
- `setTimeout` drops its always-zero delay, `addRectangle` its always-opaque alpha, and `updateCell` an unused width
- the 48 `G115` integer-conversion reports are annotated with the invariant that bounds each one (masked bitfields, UTF-16 code units, 0-2 cell widths, 24-bit RGB channels, parser-clamped VT parameters). The two that most resembled real truncation were checked and are correct: the surrogate encoder subtracts `0x10000` before shifting, and `actionExecute` is only reached for single-byte controls

**cosmos-go**
- CSS color parsing checks its parse errors rather than discarding them, keeping the previous zero for a malformed channel
- two De Morgan negations written directly, two redundant `js.Value` declarations dropped
- `extent` drops an `ok` result no caller read; an unused `clamp` helper and an unused struct field are removed

Viewing a float32 backing array as bytes keeps a `#nosec` in both ports, noting that this is how a typed array is copied to and from JS.

Companion to #3905 (the websh half); the two touch disjoint directories.

Verified: `go build .` and `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor`; the forks' tests pass.