### PR TITLE
ui: restore the blank line before the mode badge's return

### DIFF
--- a/static/skywire-manager-src/src/app/services/app-mode.service.ts
+++ b/static/skywire-manager-src/src/app/services/app-mode.service.ts
@@ -103,6 +103,7 @@ export class AppModeService {
     if (this.harness) {
       parts.push('harness');
     }
+
     return parts.join(' · ');
   }
 


### PR DESCRIPTION
`make lint-ui` fails on develop with a single error:

```
static/skywire-manager-src/src/app/services/app-mode.service.ts
  106:5  error  Expected blank line before this statement  padding-line-between-statements
```

`padding-line-between-statements` wants a blank line before a `return` that follows another statement. The `badge` getter added in 221e1bfa8 does not have one, so the `ui` job has been red on develop and on every branch cut from it. One blank line; no behaviour change.