### PR TITLE
integration: assert the VPN killswitch outcome, not one error string

### DIFF
--- a/internal/integration/vpn_test.go
+++ b/internal/integration/vpn_test.go
@@ -193,7 +193,11 @@ func TestVPN(t *testing.T) {
 		// Verify traffic no longer goes through VPN server
 		firstHop, err := getFirstTracerouteHop(targetHost, env)
 		if err != nil {
-			require.EqualError(t, err, "no ip found")
+			// Failing to trace a route at all is the outcome under test: with
+			// the killswitch set and the server restarted, traffic must not
+			// flow. The shape of that failure is not the assertion — traceroute
+			// may exit non-zero, or run and yield no parsable hop.
+			t.Logf("traceroute did not complete, which is the expected outcome: %v", err)
 		} else {
 			require.NotEqual(t, serverTUNIP, firstHop.String())
 		}
@@ -258,7 +262,9 @@ func TestVPN(t *testing.T) {
 		// Verify traffic no longer goes through VPN
 		firstHop, err := getFirstTracerouteHop(targetHost, env)
 		if err != nil {
-			require.EqualError(t, err, "no ip found")
+			// As in phase 5: with every transport removed, not tracing a route
+			// is the expected outcome, whatever form the failure takes.
+			t.Logf("traceroute did not complete, which is the expected outcome: %v", err)
 		} else {
 			require.NotEqual(t, serverTUNIP, firstHop.String())
 		}
@@ -345,8 +351,14 @@ func getFirstTracerouteHop(targetHost string, env *TestEnv) (net.IP, error) {
 		return nil, fmt.Errorf("failed to run command %s: %w", fullCmd, cmdErr)
 	}
 
-	stdoutLine := strings.Split(strings.Split(stdout, "\n")[1], " ")
-	if len(stdoutLine) > 2 {
+	// traceroute prints a header line and then one line per hop; the first hop
+	// is the second line. A run that produced neither has no hop to report.
+	lines := strings.Split(stdout, "\n")
+	if len(lines) < 2 {
+		return nil, errors.New("no ip found")
+	}
+	stdoutLine := strings.Split(lines[1], " ")
+	if len(stdoutLine) > 3 {
 		lToken := stdoutLine[3]
 		if lToken != "" {
 			if ip := net.ParseIP(lToken); ip != nil {


### PR DESCRIPTION
`TestVPN/phase5_server_stop` and `phase6_transport_deleted` have been failing on develop since 4024f7ab5. **This is my regression, and this fixes it.**

### What broke

Both phases verify that traffic stops flowing through the VPN server once the killswitch is set and the server (or its transports) goes away. Both asserted it like this:

```go
firstHop, err := getFirstTracerouteHop(targetHost, env)
if err != nil {
    require.EqualError(t, err, "no ip found")
} else {
    require.NotEqual(t, serverTUNIP, firstHop.String())
}
```

`getFirstTracerouteHop` returns two different errors: the `"no ip found"` sentinel when traceroute ran but produced no parsable hop, and a wrapped exec error when the command itself failed. The assertion only tolerates the first.

It held only because `ExecInContainerByID` used to discard the exit code and always return nil. A failing traceroute returned no error, fell through to the parse, and produced the sentinel. Once 4024f7ab5 made a non-zero exit an error — which it is — the exec failure surfaces instead:

- phase 5: `command exited 143` (SIGTERM from `timeout 9`, after hop 1 answered and hop 2 was `*`)
- phase 6: `command exited 1`

Note what the phase-5 output actually shows: the trace reached the container gateway and then nothing. Traffic was **not** going through the VPN server. The behaviour under test was correct the whole time; only the error's shape changed.

### The fix

The outcome under test is that no route is traced. Any failure to trace one satisfies that, so the error is logged rather than string-matched. The assertion that matters — a hop that *does* come back must not be the server's TUN IP — is untouched.

Two panics in the same helper go with it, both newly reachable now that a failing traceroute no longer short-circuits earlier:

- the first hop was read as `strings.Split(stdout, "\n")[1]` with no check that a second line exists
- the token guard tested `len(stdoutLine) > 2` before indexing `stdoutLine[3]`

### Not addressed

The e2e job will still be red. `TestMultiHopRoute/skysocks_proxies_HTTP_over_a_2-hop_STCPR_route_via_visor-b` times out after 90s starting skysocks over the 2-hop route. That one **predates** 4024f7ab5 — I checked the run for 1e846fc8, the last develop commit before my change, and it was already the only e2e failure there. It needs its own investigation and I did not want to bundle a guess with a known fix.

Verified: `go vet` and `go test -c` on the package. The tests themselves need the Docker compose environment, so CI is the real check.