### PR TITLE
gofmt: format every remaining file so lint stops failing on all PRs

### DIFF
--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -9,8 +9,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 	"github.com/sirupsen/logrus"
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 	"github.com/xtaci/smux"
 
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg/metrics"

--- a/pkg/dmsg/dmsg/session_common.go
+++ b/pkg/dmsg/dmsg/session_common.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/chen3feng/safecast"
-	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 	"github.com/sirupsen/logrus"
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 	"github.com/xtaci/smux"
 
 	"github.com/skycoin/skywire/pkg/cipher"

--- a/pkg/dmsg/dmsg/stream.go
+++ b/pkg/dmsg/dmsg/stream.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 	"github.com/sirupsen/logrus"
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 	"github.com/xtaci/smux"
 
 	"github.com/skycoin/skywire/pkg/cipher"

--- a/pkg/dmsg/dmsg/wt.go
+++ b/pkg/dmsg/dmsg/wt.go
@@ -36,10 +36,10 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/webtransport-go"
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/skyquic"

--- a/pkg/skyroute/pool.go
+++ b/pkg/skyroute/pool.go
@@ -36,8 +36,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 	"github.com/sirupsen/logrus"
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 
 	"github.com/skycoin/skywire/pkg/skyenv"
 )

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 	ipc "github.com/james-barrow/golang-ipc"
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 
 	"github.com/skycoin/skywire/pkg/app"
 	"github.com/skycoin/skywire/pkg/skyenv"

--- a/pkg/skysocks/server.go
+++ b/pkg/skysocks/server.go
@@ -9,9 +9,9 @@ import (
 	"sync/atomic"
 
 	"github.com/armon/go-socks5"
-	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 	ipc "github.com/james-barrow/golang-ipc"
 	"github.com/sirupsen/logrus"
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 
 	"github.com/skycoin/skywire/pkg/app"
 	"github.com/skycoin/skywire/pkg/app/appnet"


### PR DESCRIPTION
`golangci-lint` reports gofmt violations that are already on `develop`. Because the lint step runs over the whole tree, this fails the `linux`, `darwin` and `windows` lanes on **every open pull request**, regardless of what that PR touches — burying each PR's own real findings among failures that belong to nobody.

### Why this took two passes

golangci-lint defaults to `max-same-issues: 3`, so it only ever reports **three** instances of the same message. The first commit here fixed the three it was showing:

```
pkg/skyroute/pool.go:39
pkg/skysocks/client.go:11
pkg/skysocks/server.go:12
```

and the next run promptly reported three more, in `pkg/dmsg/dmsg/`. The second commit fixes every remaining offender in the tree — `gofmt -l .` excluding `vendor/` and `third_party/` — so the next run reports none rather than another batch of three:

```
pkg/dmsg/dmsg/server_session.go
pkg/dmsg/dmsg/session_common.go
pkg/dmsg/dmsg/stream.go
pkg/dmsg/dmsg/wt.go
```

All seven are the same issue: an import out of gofmt's sort order inside a group. One line each, `gofmt -w`, no behaviour change.

### Worth considering separately

That truncation default is worth revisiting for this repo. `max-same-issues: 3` and `max-issues-per-linter: 50` mean a systemic problem shows up three at a time, and fixing it becomes a game of whack-a-mole. Setting both to `0` in `.golangci.yml` would have shown all seven in the first run.
