### PR TITLE
fix(transport): stale write-deadline causes ping/pong writes to fail on idle transports (half-open leak)

### DIFF
--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -134,6 +134,21 @@ type ManagedTransport struct {
 	// hundreds of them, driving the scheduler/timer load.
 	lastRecvNanos atomic.Int64
 
+	// pingWriteFails counts consecutive transport-ping WRITES that
+	// errored (e.g. i/o timeout to a peer that vanished). Reset to 0 on
+	// any successful write and whenever the underlying transport is
+	// (re)set. This closes the reaper gap the two counters above miss:
+	// an ASYMMETRIC half-open link where the peer still sends us data
+	// (so the readLoop's read deadline never fires and lastRecvNanos
+	// stays fresh — unarmed-silence never triggers) but our writes to it
+	// fail. Because our pings never reach the peer, it never pongs, so
+	// pongSeen stays false and the missedPongs half-open detector never
+	// arms either. Such a transport cannot carry a route (writes fail)
+	// yet was never reaped — on a public hub these pile up in the
+	// thousands and get re-published to TPD every cycle. Once writes
+	// have failed pongMissThreshold consecutive ticks the link is closed.
+	pingWriteFails atomic.Int64
+
 	// cascadeHandler handles cascade protocol packets (route ID 0).
 	// Set by the transport manager from the router's CascadeHandler.
 	cascadeHandler func(p routing.Packet, mt *ManagedTransport)
@@ -535,8 +550,22 @@ func (mt *ManagedTransport) sendTransportPing() {
 	n, err := tp.Write(p)
 	if err != nil {
 		mt.log.WithError(err).Debug("Failed to send transport ping")
+		// A persistently failing write means the link is dead in the
+		// send direction — it cannot carry a route even if the peer keeps
+		// dribbling data to us (which keeps the read deadline alive and,
+		// with no pong reaching us, leaves pongSeen false so neither the
+		// half-open nor the unarmed-silence reaper fires). Reap after
+		// pongMissThreshold consecutive failures, matching the missed-pong
+		// debounce. Reset happens on the first successful write below.
+		if mt.pingWriteFails.Add(1) >= pongMissThreshold {
+			mt.log.WithField("write_fails", mt.pingWriteFails.Load()).
+				WithField("remote", mt.Remote()).
+				Warn("Transport unwritable across consecutive pings; closing dead half-open link")
+			mt.close()
+		}
 		return
 	}
+	mt.pingWriteFails.Store(0)
 	// Count this ping as awaiting a pong; handleTransportPong resets it.
 	mt.missedPongs.Add(1)
 	if n > routing.PacketHeaderSize {
@@ -583,6 +612,7 @@ func (mt *ManagedTransport) handleTransportPong(p routing.Packet) {
 	// below (an outlier-RTT pong still proves liveness).
 	mt.pongSeen.Store(true)
 	mt.missedPongs.Store(0)
+	mt.pingWriteFails.Store(0)
 	sentAt := int64(binary.BigEndian.Uint64(payload[:8])) //nolint:gosec
 	rttMs := float64(time.Now().UnixNano()-sentAt) / 1e6
 	if rttMs <= 0 {
@@ -793,6 +823,7 @@ func (mt *ManagedTransport) setTransport(newTransport network.Transport) {
 	// Fresh underlying connection — reset the half-open miss counter so a
 	// stale count from a prior connection can't immediately reap the new one.
 	mt.missedPongs.Store(0)
+	mt.pingWriteFails.Store(0)
 
 	// Set new underlying transport.
 	mt.transport = newTransport

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -546,6 +546,18 @@ func (mt *ManagedTransport) sendTransportPing() {
 		return
 	}
 
+	// Set a fresh write deadline. SetWriteDeadline is absolute and sticky
+	// on the conn: WritePacket/WriteRawPacket set it to now+writeTimeout on
+	// every route write, and it is NEVER cleared. Without resetting it here,
+	// an idle transport that last carried route traffic > writeTimeout ago
+	// writes against a deadline that already passed — so this ping fails
+	// instantly with "i/o timeout" even though the link is perfectly alive.
+	// That is the self-inflicted "receives fine but can't send" state that
+	// piled up half-open transports on hubs (types that honor the deadline —
+	// stcpr/sudph/squicr; webrtc's SetWriteDeadline is a no-op and was immune).
+	if err := tp.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		mt.log.WithError(err).Debug("Failed to set ping write deadline")
+	}
 	p := routing.MakeTransportPingPacket(time.Now().UnixNano())
 	n, err := tp.Write(p)
 	if err != nil {
@@ -590,6 +602,12 @@ func (mt *ManagedTransport) handleTransportPing(p routing.Packet) {
 		return
 	}
 
+	// Fresh write deadline — same stale-absolute-deadline hazard as
+	// sendTransportPing (a bare Write here inherits the last route write's
+	// now-passed deadline, so we fail to pong a live peer that just pinged us).
+	if err := tp.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		mt.log.WithError(err).Debug("Failed to set pong write deadline")
+	}
 	pong := routing.MakeTransportPongPacket(timestamp)
 	n, err := tp.Write(pong)
 	if err != nil {

--- a/pkg/transport/managed_transport_pong_test.go
+++ b/pkg/transport/managed_transport_pong_test.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -33,6 +34,14 @@ func (o *okTransport) RemotePort() uint16               { return 0 }
 func (o *okTransport) LocalRawAddr() net.Addr           { return &net.TCPAddr{} }
 func (o *okTransport) RemoteRawAddr() net.Addr          { return &net.TCPAddr{} }
 func (o *okTransport) Network() types.Type              { return "test" }
+
+// failWriteTransport models an asymmetric half-open link: writes always error
+// (the peer is unreachable in the send direction) while reads block (the local
+// socket still looks alive and the peer may keep sending). It reuses
+// okTransport for every method except Write.
+type failWriteTransport struct{ okTransport }
+
+func (o *failWriteTransport) Write([]byte) (int, error) { return 0, errors.New("i/o timeout") }
 
 func testPong() routing.Packet { return routing.MakeTransportPongPacket(time.Now().UnixNano()) }
 
@@ -91,4 +100,39 @@ func TestManagedTransport_HealthyPeerStaysOpen(t *testing.T) {
 		mt.handleTransportPong(testPong())
 	}
 	assert.False(t, mt.IsClosed(), "a peer that keeps answering pings must stay open")
+}
+
+// TestManagedTransport_UnwritableClosesAfterFailedPings: a transport whose
+// writes persistently fail (peer unreachable in the send direction) must be
+// closed after pongMissThreshold consecutive ping-write failures — even though
+// it never armed (pongSeen stays false, so the missed-pong reaper is inert) and
+// keeps receiving (lastRecv fresh, so the unarmed-silence reaper never fires).
+// This is the receive-alive/write-dead half-open that otherwise leaked by the
+// thousands on public hubs and got re-published to TPD every cycle.
+func TestManagedTransport_UnwritableClosesAfterFailedPings(t *testing.T) {
+	mt := NewManagedTransportForTest(&failWriteTransport{})
+	require.False(t, mt.pongSeen.Load(), "precondition: never armed")
+
+	closed := false
+	for i := 0; i < pongMissThreshold+3; i++ {
+		mt.lastRecvNanos.Store(time.Now().UnixNano()) // still receiving — unarmed-silence must NOT be the reason
+		mt.tickPing()
+		if mt.IsClosed() {
+			closed = true
+			break
+		}
+	}
+	assert.True(t, closed, "unwritable transport must close after pongMissThreshold failed ping writes")
+}
+
+// TestManagedTransport_TransientWriteFailureRecovers: a single write failure
+// followed by a success must NOT reap — pingWriteFails resets on any successful
+// write, so only a sustained unwritable link (pongMissThreshold in a row) closes.
+func TestManagedTransport_TransientWriteFailureRecovers(t *testing.T) {
+	mt := NewManagedTransportForTest(&okTransport{})
+	// Simulate a couple of failures short of the threshold, then a success.
+	mt.pingWriteFails.Store(pongMissThreshold - 1)
+	mt.tickPing() // okTransport.Write succeeds → pingWriteFails resets to 0
+	assert.Equal(t, int64(0), mt.pingWriteFails.Load(), "a successful write must reset the failure counter")
+	assert.False(t, mt.IsClosed(), "a recovered transport must stay open")
 }


### PR DESCRIPTION
## Symptom

A public/hub visor's local transport count diverges massively from the Transport Discovery. Observed live on a NAT'd hub: **1523** local transports (1477 inbound) vs **~111** in TPD for the same PK. The visor re-registers the full set every 90s, and the 1400 excess are *open* (not un-GC'd husks) — confirmed by the publish log and a goroutine dump (1521 live read-loops, only 2 goroutines on any mutex, so not lock starvation). The excess are inbound transports stuck "receiving fine but unable to send" (`write tcp …: i/o timeout` on every ping).

## Root cause (commit 2) — stale, sticky write deadline

`SetWriteDeadline` is **absolute and sticky** on a conn. `WritePacket`/`WriteRawPacket` set it to `now+writeTimeout` (1m) on every route write and never clear it. But `sendTransportPing` and `handleTransportPing` (pong) did **bare `Write`s with no deadline of their own**. So once a transport that last carried route traffic sits idle longer than 1m, its next ping/pong write runs against a deadline that **already passed** → instant `i/o timeout`, even though the link is perfectly alive and the peer is still pinging us (keeping our read side fresh).

Result: our pings *and* pongs fail → the peer never receives a pong → it never arms our missed-pong detector → the transport is never reaped, and gets re-published to TPD every cycle. TPD's ~111 is the genuinely-live set.

**The type distribution proves it:** stcpr/sudph/squicr (which honor `SetWriteDeadline`) piled up in the hundreds each; **webrtc, whose `SetWriteDeadline` is a no-op** and therefore can't inherit a stale deadline, did **not** leak (3–20 vs 300–650).

Fix: set a fresh `now+writeTimeout` deadline before each ping and pong write.

## Backstop (commit 1) — reap genuinely-unwritable links

Independent of the deadline bug, a link we truly cannot write to can't carry a route in either direction, yet slips through all three reapers (half-open needs a pong to arm; unarmed-silence needs receive-silence; the read deadline only reaps silent links). Track consecutive ping-**write** failures and close after `pongMissThreshold` (~3m), independent of `pongSeen`; reset on any successful write and on transport (re)set. With the deadline fix in place, this now only fires on *real* failures.

## Tests

- New: unwritable link closes after the threshold; a transient failure followed by a success does not.
- Unchanged: armed missed-pong close, never-ponged-but-receiving stays open, unarmed-silence close, healthy stays open.

## Note

Reward-adjacent (transport set → routes → bandwidth). Local-visor validation (watch the count converge toward the TPD set after restart) to follow before merge.