### PR TITLE
feat(cli): --jq / --shape output flags + --help --json, working on both binaries

### DIFF
--- a/cmd/skywire-cli/cliutil/cliutil.go
+++ b/cmd/skywire-cli/cliutil/cliutil.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cliout"
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
@@ -103,12 +104,15 @@ type CLIOutput struct {
 //
 //nolint:errcheck
 func PrintOutput(cmdFlags *pflag.FlagSet, outputJSON, output interface{}) {
-	// --shape: print the output type's skeleton instead of live data.
-	if shape, _ := cmdFlags.GetBool(ShapeString); shape {
+	// --shape / --jq are handled by the canonical cliout package so this
+	// legacy helper and cliout.Print behave identically. Flags are read off
+	// the passed set (they are registered persistently on the root, so they
+	// are present as inherited flags here).
+	if shape, _ := cmdFlags.GetBool(cliout.ShapeFlag); shape {
 		if outputJSON == nil {
 			return
 		}
-		b, err := json.MarshalIndent(jsonSkeleton(outputJSON), "", "  ")
+		b, err := json.MarshalIndent(cliout.Skeleton(outputJSON), "", "  ")
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return
@@ -116,8 +120,7 @@ func PrintOutput(cmdFlags *pflag.FlagSet, outputJSON, output interface{}) {
 		fmt.Print(string(b) + "\n")
 		return
 	}
-	// --jq implies JSON output even without --json.
-	jqFilter, _ := cmdFlags.GetString(JQString)
+	jqFilter, _ := cmdFlags.GetString(cliout.JQFlag)
 	isJSON, _ := cmdFlags.GetBool(JSONString)
 	if isJSON || jqFilter != "" {
 		if outputJSON == nil {
@@ -129,7 +132,7 @@ func PrintOutput(cmdFlags *pflag.FlagSet, outputJSON, output interface{}) {
 			return
 		}
 		if jqFilter != "" {
-			filtered, err := applyJQ(b, jqFilter)
+			filtered, err := cliout.ApplyJQ(b, jqFilter)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				return

--- a/cmd/skywire-cli/cliutil/cliutil.go
+++ b/cmd/skywire-cli/cliutil/cliutil.go
@@ -103,14 +103,38 @@ type CLIOutput struct {
 //
 //nolint:errcheck
 func PrintOutput(cmdFlags *pflag.FlagSet, outputJSON, output interface{}) {
+	// --shape: print the output type's skeleton instead of live data.
+	if shape, _ := cmdFlags.GetBool(ShapeString); shape {
+		if outputJSON == nil {
+			return
+		}
+		b, err := json.MarshalIndent(jsonSkeleton(outputJSON), "", "  ")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return
+		}
+		fmt.Print(string(b) + "\n")
+		return
+	}
+	// --jq implies JSON output even without --json.
+	jqFilter, _ := cmdFlags.GetString(JQString)
 	isJSON, _ := cmdFlags.GetBool(JSONString)
-	if isJSON {
+	if isJSON || jqFilter != "" {
 		if outputJSON == nil {
 			return
 		}
 		b, err := json.MarshalIndent(outputJSON, "", "  ")
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
+			return
+		}
+		if jqFilter != "" {
+			filtered, err := applyJQ(b, jqFilter)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				return
+			}
+			fmt.Print(filtered)
 			return
 		}
 		fmt.Print(string(b) + "\n")

--- a/cmd/skywire-cli/cliutil/jsonfilter.go
+++ b/cmd/skywire-cli/cliutil/jsonfilter.go
@@ -1,0 +1,213 @@
+// Package cliutil cmd/skywire-cli/cliutil/jsonfilter.go c4-vis-cli
+//
+// Output post-processors shared by every command that emits JSON via
+// PrintOutput:
+//
+//   - --jq <filter>: run the JSON value through gojq (already vendored)
+//     before printing, e.g. `visor info --jq '.ar_registration.entries[].type'`.
+//     Implies --json. Lets a coding agent (or human) pull one field out of a
+//     large payload instead of dumping and eyeballing it.
+//   - --shape: print the SKELETON of the output type — every field at its zero
+//     value, with omitempty fields forced visible — instead of live data. Lets
+//     you learn a command's output schema without a populated response.
+//
+// Both hang off PrintOutput's single chokepoint, so all ~68 PrintOutput call
+// sites get them for free.
+package cliutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/itchyny/gojq"
+)
+
+// JQString is the name of the jq-filter flag.
+var JQString = "jq"
+
+// ShapeString is the name of the shape flag.
+var ShapeString = "shape"
+
+// applyJQ runs filter over the JSON in src and returns the printed results
+// (one per line). Object/array results are pretty-printed; scalars print as
+// their JSON literal (a quoted string, number, bool), matching jq's default
+// (non -r) behavior.
+func applyJQ(src []byte, filter string) (string, error) {
+	query, err := gojq.Parse(filter)
+	if err != nil {
+		return "", fmt.Errorf("invalid --jq filter: %w", err)
+	}
+	var input interface{}
+	if err := json.Unmarshal(src, &input); err != nil {
+		return "", fmt.Errorf("decode JSON for --jq: %w", err)
+	}
+	var sb strings.Builder
+	iter := query.Run(input)
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, ok := v.(error); ok {
+			return "", fmt.Errorf("--jq: %w", err)
+		}
+		b, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return "", fmt.Errorf("--jq encode result: %w", err)
+		}
+		sb.Write(b)
+		sb.WriteByte('\n')
+	}
+	return sb.String(), nil
+}
+
+// orderedMap marshals its entries in insertion order (unlike a Go map, which
+// json sorts). Used so a --shape skeleton preserves struct field order.
+// MarshalIndent re-indents the compact bytes MarshalJSON returns, so nested
+// orderedMaps still pretty-print.
+type orderedMap struct {
+	keys []string
+	vals map[string]interface{}
+}
+
+func newOrderedMap() *orderedMap { return &orderedMap{vals: map[string]interface{}{}} }
+
+func (o *orderedMap) set(k string, v interface{}) {
+	if _, ok := o.vals[k]; !ok {
+		o.keys = append(o.keys, k)
+	}
+	o.vals[k] = v
+}
+
+func (o *orderedMap) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, k := range o.keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		kb, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(kb)
+		buf.WriteByte(':')
+		vb, err := json.Marshal(o.vals[k])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(vb)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+var jsonMarshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+
+// jsonSkeleton returns a shape skeleton for v's type: every exported field at
+// its zero value, omitempty ignored so nothing is hidden. Types with a custom
+// MarshalJSON (cipher.PubKey, time.Time, uuid.UUID, …) are rendered as their
+// zero marshaled form rather than recursed into.
+func jsonSkeleton(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+	return skeletonType(reflect.TypeOf(v), map[reflect.Type]bool{})
+}
+
+func skeletonType(t reflect.Type, seen map[reflect.Type]bool) interface{} {
+	if t == nil {
+		return nil
+	}
+	// Custom JSON marshaler → use its zero value's marshaled shape.
+	if t.Implements(jsonMarshalerType) || reflect.PointerTo(t).Implements(jsonMarshalerType) {
+		if s, ok := marshalZero(t); ok {
+			return s
+		}
+	}
+	switch t.Kind() {
+	case reflect.Pointer:
+		return skeletonType(t.Elem(), seen)
+	case reflect.Interface:
+		return nil
+	case reflect.Struct:
+		if seen[t] {
+			return "<recursive:" + t.Name() + ">"
+		}
+		seen[t] = true
+		defer delete(seen, t)
+		om := newOrderedMap()
+		addStructFields(t, om, seen)
+		return om
+	case reflect.Map:
+		inner := newOrderedMap()
+		inner.set("<key>", skeletonType(t.Elem(), seen))
+		return inner
+	case reflect.Slice, reflect.Array:
+		if t.Elem().Kind() == reflect.Uint8 {
+			return "" // []byte marshals as a base64 string
+		}
+		return []interface{}{skeletonType(t.Elem(), seen)}
+	case reflect.String:
+		return ""
+	case reflect.Bool:
+		return false
+	case reflect.Float32, reflect.Float64:
+		return 0.0
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return 0
+	default:
+		return nil
+	}
+}
+
+// addStructFields fills om with the skeleton of t's exported fields, honoring
+// json tags and flattening anonymous (embedded) structs the way encoding/json
+// does.
+func addStructFields(t reflect.Type, om *orderedMap, seen map[reflect.Type]bool) {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+		tag := f.Tag.Get("json")
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "-" {
+			continue
+		}
+		// Anonymous struct with no explicit json name → promote its fields.
+		if f.Anonymous && name == "" {
+			ft := f.Type
+			for ft.Kind() == reflect.Pointer {
+				ft = ft.Elem()
+			}
+			if ft.Kind() == reflect.Struct && !(ft.Implements(jsonMarshalerType) || reflect.PointerTo(ft).Implements(jsonMarshalerType)) {
+				addStructFields(ft, om, seen)
+				continue
+			}
+		}
+		if name == "" {
+			name = f.Name
+		}
+		om.set(name, skeletonType(f.Type, seen))
+	}
+}
+
+// marshalZero marshals a zero value of t and decodes it back into a generic
+// value so it composes into the skeleton. ok is false if t's zero value can't
+// be marshaled (leaves the caller to recurse structurally instead).
+func marshalZero(t reflect.Type) (interface{}, bool) {
+	b, err := json.Marshal(reflect.Zero(t).Interface())
+	if err != nil {
+		return nil, false
+	}
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return nil, false
+	}
+	return v, true
+}

--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	clicompletion "github.com/skycoin/skywire/cmd/skywire-cli/commands/completion"
 	cliconfig "github.com/skycoin/skywire/cmd/skywire-cli/commands/config"
 	clidmsg "github.com/skycoin/skywire/cmd/skywire-cli/commands/dmsg"
@@ -47,7 +46,6 @@ import (
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
 	"github.com/skycoin/skywire/pkg/cliout"
-	"github.com/skycoin/skywire/pkg/cliout/clihelp"
 	"github.com/skycoin/skywire/pkg/flags"
 )
 
@@ -161,12 +159,9 @@ func init() {
 		statusCmd,
 		haltCmd,
 	)
-	var jsonOutput bool
-	RootCmd.PersistentFlags().BoolVar(&jsonOutput, internal.JSONString, false, "print output as JSON")
-	var jqFilter string
-	RootCmd.PersistentFlags().StringVar(&jqFilter, internal.JQString, "", "filter JSON output through a jq/gojq expression (implies --json)")
-	var shapeOutput bool
-	RootCmd.PersistentFlags().BoolVar(&shapeOutput, internal.ShapeString, false, "print the output schema skeleton (zero values, all fields) instead of data")
+	// --json / --jq / --shape output flags, shared with the top-level
+	// `skywire` binary so both roots behave identically.
+	cliout.RegisterOutputFlags(RootCmd)
 	RootCmd.PersistentFlags().IntVar(&clirpc.Timeout, "timeout", 30, "RPC timeout in seconds (0 = unlimited)")
 	RootCmd.PersistentFlags().MarkHidden("timeout") //nolint:errcheck,gosec
 
@@ -186,23 +181,10 @@ func init() {
 	RootCmd.Flags().BoolVar(&cliShowAll, "all", false, "show all flags and subcommands (including hidden)")
 	RootCmd.Flags().MarkHidden("all") //nolint:errcheck,gosec
 
-	// `--help --json` describes the command instead of rendering help for a
-	// person: name, path, flags with their types and defaults, and the whole
-	// subtree beneath it. Registered once here because cobra hands the help
-	// function down to every child, so this covers all of them.
-	//
-	// Help is not a normal command — cobra intercepts --help before Run — so
-	// this cannot live in a Run body; SetHelpFunc is the hook for it.
-	defaultHelp := RootCmd.HelpFunc()
-	RootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		if !cliout.JSONMode(cmd) {
-			defaultHelp(cmd, args)
-			return
-		}
-		if err := cliout.Print(cmd, clihelp.Of(cmd)); err != nil {
-			fmt.Fprintln(os.Stderr, err) //nolint:errcheck
-		}
-	})
+	// `--help --json` describes the command (name, path, flags, subtree) as a
+	// machine-readable value instead of human help. Shared with the top-level
+	// binary via cliout so every command under either root supports it.
+	cliout.SetJSONHelp(RootCmd)
 }
 
 var cliShowAll bool

--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -163,6 +163,10 @@ func init() {
 	)
 	var jsonOutput bool
 	RootCmd.PersistentFlags().BoolVar(&jsonOutput, internal.JSONString, false, "print output as JSON")
+	var jqFilter string
+	RootCmd.PersistentFlags().StringVar(&jqFilter, internal.JQString, "", "filter JSON output through a jq/gojq expression (implies --json)")
+	var shapeOutput bool
+	RootCmd.PersistentFlags().BoolVar(&shapeOutput, internal.ShapeString, false, "print the output schema skeleton (zero values, all fields) instead of data")
 	RootCmd.PersistentFlags().IntVar(&clirpc.Timeout, "timeout", 30, "RPC timeout in seconds (0 = unlimited)")
 	RootCmd.PersistentFlags().MarkHidden("timeout") //nolint:errcheck,gosec
 

--- a/cmd/skywire/commands/root.go
+++ b/cmd/skywire/commands/root.go
@@ -27,6 +27,7 @@ import (
 	services "github.com/skycoin/skywire/cmd/svc/skywire-services/commands"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
+	"github.com/skycoin/skywire/pkg/cliout"
 	"github.com/skycoin/skywire/pkg/flags"
 	"github.com/skycoin/skywire/pkg/visor"
 )
@@ -79,6 +80,13 @@ func init() {
 		appsCmd,
 		doc.RootCmd,
 	)
+
+	// --json / --jq / --shape and the `--help --json` machine description on the
+	// top-level binary root, so they work on top-level commands (e.g.
+	// `skywire tree --json`, `skywire --help --json`) — not only under
+	// `skywire cli`, whose subtree registers them on its own root as well.
+	cliout.RegisterOutputFlags(RootCmd)
+	cliout.SetJSONHelp(RootCmd)
 
 	visor.RootCmd.Long = calvin.AsciiFont("skywire-visor")
 	dmsg.RootCmd.Use = "dmsg"

--- a/pkg/cliout/cliout.go
+++ b/pkg/cliout/cliout.go
@@ -58,7 +58,16 @@ type Output interface {
 // The value is the single source of truth: its json tags define the machine
 // shape, its Human method (when it has one) the text.
 func Print(cmd *cobra.Command, v interface{}) error {
-	return Fprint(cmd.OutOrStdout(), JSONMode(cmd), v)
+	w := cmd.OutOrStdout()
+	// --shape: print the type skeleton instead of the value.
+	if ShapeMode(cmd) {
+		return Fprint(w, true, Skeleton(v))
+	}
+	// --jq: filter the JSON value through gojq (implies --json).
+	if filter := JQFilter(cmd); filter != "" {
+		return printJQ(w, v, filter)
+	}
+	return Fprint(w, JSONMode(cmd), v)
 }
 
 // Fprint is Print against an explicit writer, for callers that are not a

--- a/pkg/cliout/filter.go
+++ b/pkg/cliout/filter.go
@@ -1,0 +1,282 @@
+// Package cliout pkg/cliout/filter.go
+//
+// Output post-processors shared by every command that renders through Print,
+// plus the flag registration and the --help --json hook so a single call wires
+// them onto any root command (the top-level `skywire` binary and the standalone
+// `skywire-cli` both need them):
+//
+//	--jq <filter>  run the JSON value through gojq (already vendored) before
+//	               printing. Implies --json. Lets a caller pull one field out
+//	               of a large payload instead of dumping it.
+//	--shape        print the output type's SKELETON — every field at its zero
+//	               value, omitempty forced visible — instead of live data, so
+//	               the schema is discoverable without a populated response.
+package cliout
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/itchyny/gojq"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/skycoin/skywire/pkg/cliout/clihelp"
+)
+
+// JQFlag / ShapeFlag are the persistent flags added by RegisterOutputFlags.
+const (
+	JQFlag    = "jq"
+	ShapeFlag = "shape"
+)
+
+// RegisterOutputFlags adds --json, --jq and --shape as persistent flags on cmd,
+// so every subcommand inherits them. Call it once per root command.
+func RegisterOutputFlags(cmd *cobra.Command) {
+	fs := cmd.PersistentFlags()
+	if fs.Lookup(JSONFlag) == nil {
+		fs.Bool(JSONFlag, false, "print output as JSON")
+	}
+	if fs.Lookup(JQFlag) == nil {
+		fs.String(JQFlag, "", "filter JSON output through a jq/gojq expression (implies --json)")
+	}
+	if fs.Lookup(ShapeFlag) == nil {
+		fs.Bool(ShapeFlag, false, "print the output schema skeleton (zero values, all fields) instead of data")
+	}
+}
+
+// SetJSONHelp installs a help function on root that, in machine mode
+// (--json/--jq/--shape), prints the command's machine-readable description
+// (clihelp.Of) instead of the human help text. cobra hands the help function
+// down to every child, so one call covers the whole tree.
+func SetJSONHelp(root *cobra.Command) {
+	defaultHelp := root.HelpFunc()
+	root.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		if !machineMode(cmd) {
+			defaultHelp(cmd, args)
+			return
+		}
+		if err := Print(cmd, clihelp.Of(cmd)); err != nil {
+			fmt.Fprintln(os.Stderr, err) //nolint:errcheck
+		}
+	})
+}
+
+// machineMode reports whether any machine-output flag was set.
+func machineMode(cmd *cobra.Command) bool {
+	return JSONMode(cmd) || JQFilter(cmd) != "" || ShapeMode(cmd)
+}
+
+// flagLookup finds a flag on the command's own or inherited set.
+func flagLookup(cmd *cobra.Command, name string) *pflag.Flag {
+	if f := cmd.Flags().Lookup(name); f != nil {
+		return f
+	}
+	return cmd.InheritedFlags().Lookup(name)
+}
+
+// JQFilter returns the --jq expression, or "" if unset.
+func JQFilter(cmd *cobra.Command) string {
+	if f := flagLookup(cmd, JQFlag); f != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+// ShapeMode reports whether --shape was set.
+func ShapeMode(cmd *cobra.Command) bool {
+	if f := flagLookup(cmd, ShapeFlag); f != nil {
+		return f.Value.String() == "true"
+	}
+	return false
+}
+
+// printJQ marshals v, runs it through the jq filter, and writes the results.
+func printJQ(w io.Writer, v interface{}, filter string) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	out, err := ApplyJQ(b, filter)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(w, out)
+	return err
+}
+
+// ApplyJQ runs filter over the JSON in src and returns the printed results (one
+// per line). Object/array results are pretty-printed; scalars print as their
+// JSON literal, matching jq's default (non -r) behavior.
+func ApplyJQ(src []byte, filter string) (string, error) {
+	query, err := gojq.Parse(filter)
+	if err != nil {
+		return "", fmt.Errorf("invalid --jq filter: %w", err)
+	}
+	var input interface{}
+	if err := json.Unmarshal(src, &input); err != nil {
+		return "", fmt.Errorf("decode JSON for --jq: %w", err)
+	}
+	var sb strings.Builder
+	iter := query.Run(input)
+	for {
+		val, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, ok := val.(error); ok {
+			return "", fmt.Errorf("--jq: %w", err)
+		}
+		b, err := json.MarshalIndent(val, "", "  ")
+		if err != nil {
+			return "", fmt.Errorf("--jq encode result: %w", err)
+		}
+		sb.Write(b)
+		sb.WriteByte('\n')
+	}
+	return sb.String(), nil
+}
+
+// orderedMap marshals its entries in insertion order (a Go map sorts keys), so
+// a --shape skeleton preserves struct field order. MarshalIndent re-indents the
+// compact bytes MarshalJSON returns, so nested orderedMaps still pretty-print.
+type orderedMap struct {
+	keys []string
+	vals map[string]interface{}
+}
+
+func newOrderedMap() *orderedMap { return &orderedMap{vals: map[string]interface{}{}} }
+
+func (o *orderedMap) set(k string, v interface{}) {
+	if _, ok := o.vals[k]; !ok {
+		o.keys = append(o.keys, k)
+	}
+	o.vals[k] = v
+}
+
+func (o *orderedMap) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, k := range o.keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		kb, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(kb)
+		buf.WriteByte(':')
+		vb, err := json.Marshal(o.vals[k])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(vb)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+var jsonMarshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+
+// Skeleton returns a shape skeleton for v's type: every exported field at its
+// zero value, omitempty ignored so nothing is hidden. Types with a custom
+// MarshalJSON (cipher.PubKey, time.Time, uuid.UUID, …) render as their zero
+// marshaled form rather than being recursed into. Native-only (the CLI is never
+// built under TinyGo), so reflect is fine here.
+func Skeleton(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+	return skeletonType(reflect.TypeOf(v), map[reflect.Type]bool{})
+}
+
+func skeletonType(t reflect.Type, seen map[reflect.Type]bool) interface{} {
+	if t == nil {
+		return nil
+	}
+	if t.Implements(jsonMarshalerType) || reflect.PointerTo(t).Implements(jsonMarshalerType) {
+		if s, ok := marshalZero(t); ok {
+			return s
+		}
+	}
+	switch t.Kind() {
+	case reflect.Pointer:
+		return skeletonType(t.Elem(), seen)
+	case reflect.Interface:
+		return nil
+	case reflect.Struct:
+		if seen[t] {
+			return "<recursive:" + t.Name() + ">"
+		}
+		seen[t] = true
+		defer delete(seen, t)
+		om := newOrderedMap()
+		addStructFields(t, om, seen)
+		return om
+	case reflect.Map:
+		inner := newOrderedMap()
+		inner.set("<key>", skeletonType(t.Elem(), seen))
+		return inner
+	case reflect.Slice, reflect.Array:
+		if t.Elem().Kind() == reflect.Uint8 {
+			return "" // []byte marshals as a base64 string
+		}
+		return []interface{}{skeletonType(t.Elem(), seen)}
+	case reflect.String:
+		return ""
+	case reflect.Bool:
+		return false
+	case reflect.Float32, reflect.Float64:
+		return 0.0
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return 0
+	default:
+		return nil
+	}
+}
+
+func addStructFields(t reflect.Type, om *orderedMap, seen map[reflect.Type]bool) {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+		name, _, _ := strings.Cut(f.Tag.Get("json"), ",")
+		if name == "-" {
+			continue
+		}
+		if f.Anonymous && name == "" {
+			ft := f.Type
+			for ft.Kind() == reflect.Pointer {
+				ft = ft.Elem()
+			}
+			if ft.Kind() == reflect.Struct && !(ft.Implements(jsonMarshalerType) || reflect.PointerTo(ft).Implements(jsonMarshalerType)) {
+				addStructFields(ft, om, seen)
+				continue
+			}
+		}
+		if name == "" {
+			name = f.Name
+		}
+		om.set(name, skeletonType(f.Type, seen))
+	}
+}
+
+func marshalZero(t reflect.Type) (interface{}, bool) {
+	b, err := json.Marshal(reflect.Zero(t).Interface())
+	if err != nil {
+		return nil, false
+	}
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return nil, false
+	}
+	return v, true
+}


### PR DESCRIPTION
## What

Two machine-output post-processors on the skywire CLI, plus a fix so the existing `--json` and `--help --json` work on the **top-level `skywire` binary** — not only under `skywire cli …`.

- **`--jq <filter>`** — run the JSON value through **gojq** (already vendored) before printing. Implies `--json`.
  ```
  skywire cli visor info --jq '.ar_registration.entries[].type'
  skywire --help --json --jq '.subcommands[].name'
  ```
- **`--shape`** — print the output type's **skeleton** (every field at its zero value, `omitempty` forced visible) instead of live data, so a command's schema is discoverable without a populated response.
- **Top-level parity** — `skywire tree --json`, `skywire --json`, `skywire --help --json` (the full machine-readable command tree) all previously failed with `unknown flag: --json`. Now they work.

## Why / how

The output flags, the jq/shape logic, and the `--help --json` hook lived only on the `cmd/skywire-cli/commands` root, so the combined `skywire` binary (`cmd/skywire/commands`) — a *separate* root that mounts the cli subtree as `cli` — never had them on its own top-level commands.

Moved the reusable pieces into the canonical **`pkg/cliout`** package:
- `RegisterOutputFlags(cmd)` — adds `--json`/`--jq`/`--shape` persistent flags.
- `SetJSONHelp(cmd)` — installs the `--help --json` machine-description hook (`clihelp.Of`).
- `ApplyJQ` / `Skeleton` — the jq filter and reflection skeleton, now honored by `cliout.Print` (25 callers) **and** delegated to by the legacy `cliutil.PrintOutput` (67 callers), so both behave identically.

Both roots (`cmd/skywire` and `cmd/skywire-cli`) call the shared setup.

## Notes

- `--json` stays a **bool** (unchanged) — no invocation breaks; `--jq` is a separate string flag that implies JSON.
- `--shape` reflects over the output type: struct field order preserved, custom `json.Marshaler` types (`cipher.PubKey`, `time.Time`, `uuid`) render as their zero marshaled form, recursion cycle-guarded. CLI is native-only (never TinyGo), so reflect is fine.
- Validated live: `skywire tree --json`, `skywire --help --json`, `--shape`, `--jq`, and plain `--json` all work; `cliout` tests + gofmt green.