### PR TITLE
fix(logging): ringbuffer.go misspell (unblock CI lint)

### DIFF
--- a/pkg/logging/ringbuffer.go
+++ b/pkg/logging/ringbuffer.go
@@ -64,7 +64,7 @@ func (rb *RingBuffer) Write(p []byte) (int, error) {
 
 // Bytes returns a copy of the current buffer contents, oldest first. Once the
 // ring has wrapped (is full) the result is trimmed to the next line boundary so
-// it never starts mid-line — matching the original append-based behaviour.
+// it never starts mid-line — matching the original append-based behavior.
 func (rb *RingBuffer) Bytes() []byte {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()


### PR DESCRIPTION
Follow-up to #3937: the "behaviour"→"behavior" misspell fix intended for that PR was dropped by a failed `git add` (a same-command pathspec error aborted staging), so #3937 merged with the misspell still present and every new PR now fails the `misspell` linter on `pkg/logging/ringbuffer.go:67`. This one-character change fixes it.