### PR TITLE
perf(transport/webrtc): empty MediaEngine — no media goroutines for data-channel-only PeerConnections

### DIFF
--- a/pkg/transport/network/webrtc_native.go
+++ b/pkg/transport/network/webrtc_native.go
@@ -43,7 +43,15 @@ const dcReadBuf = 96 * 1024
 func newWebRTCAPI() *webrtc.API {
 	se := webrtc.SettingEngine{}
 	se.DetachDataChannels()
-	return webrtc.NewAPI(webrtc.WithSettingEngine(se))
+	// Empty MediaEngine: skywire uses WebRTC for DATA CHANNELS ONLY, never audio/
+	// video. With the default MediaEngine pion registers audio/video codecs and
+	// starts SRTP/SRTCP + RTP/RTCP media-processor goroutines per PeerConnection
+	// (observed on public exits: ~4-5 parked media goroutines each — hundreds on a
+	// busy node, e.g. a Raspberry Pi exit at 1000+ goroutines, wasting CPU the
+	// route-setup handshake then competes for). Data channels (SCTP over the
+	// application m-line) need no media codecs, so a MediaEngine with none
+	// suppresses all that machinery.
+	return webrtc.NewAPI(webrtc.WithSettingEngine(se), webrtc.WithMediaEngine(&webrtc.MediaEngine{}))
 }
 
 func webrtcConfig(iceURLs []string) webrtc.Configuration {


### PR DESCRIPTION
skywire uses WebRTC for **data channels only**, never audio/video. The default pion `MediaEngine` registers audio/video codecs and spawns SRTP/SRTCP + RTP/RTCP media-processor goroutines per `PeerConnection` — observed ~4-5 parked media goroutines each on public exits, which reaches hundreds on a busy node (e.g. a Raspberry Pi exit carrying 1000+ goroutines), wasting CPU the route-setup handshake then competes for.

A `MediaEngine` with no registered codecs suppresses all of that machinery. Data channels ride SCTP over the application m-line and need no media codecs, so nothing is lost.

`go build .` and `go test ./pkg/transport/network/` pass.