### PR TITLE
fix(wallet): serve /wallet/ as an iframe-only surface; bounce top-level navigations to the HV UI

### DIFF
--- a/pkg/visor/hypervisor_handlers_wallet.go
+++ b/pkg/visor/hypervisor_handlers_wallet.go
@@ -168,6 +168,15 @@ func (hv *Hypervisor) walletHandler() http.HandlerFunc {
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		rest := chi.URLParam(r, "*")
+		// The wallet is an IFRAME surface for the HV UI's ☰ wallet / Angular wallet
+		// tab, not a first-class page. A TOP-LEVEL navigation to a wallet HTML page
+		// (Sec-Fetch-Dest: document) is out of context — bounce it into the HV UI.
+		// Framed loads (Sec-Fetch-Dest: iframe / empty) and asset+API requests fall
+		// through and serve normally.
+		if (rest == "" || rest == "index.html" || rest == "config") && r.Header.Get("Sec-Fetch-Dest") == "document" {
+			http.Redirect(w, r, "/", http.StatusSeeOther)
+			return
+		}
 		// The ONE wallet config page (mode / coin nodes / BTC / skysocks exit),
 		// embedded via iframe by the ☰ wallet window AND the Angular wallet tab.
 		if rest == "config" {

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -329,6 +329,20 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 		cipherGz := wasmbin.GetVariantGz(cipherVar)
 		cipherExec := wasmbin.WasmExecJSVariant(cipherVar)
 		mux.HandleFunc("/wallet/", func(w http.ResponseWriter, r *http.Request) {
+			// The wallet is an IFRAME surface for the HV UI's ☰ wallet, not a
+			// first-class page: its node API is routed through
+			// window.parent.skywireVisor, which only exists when it's framed by the
+			// booted HV. A TOP-LEVEL navigation to a wallet HTML page
+			// (Sec-Fetch-Dest: document) is out of context — bounce it into the HV
+			// UI. Framed loads (Sec-Fetch-Dest: iframe / empty on older browsers)
+			// and asset fetches (script/style/fetch/…) fall through and serve
+			// normally. The standalone top-level wallet is the separate
+			// `skywire skycoin web` path, not this one.
+			isWalletDoc := r.URL.Path == "/wallet/" || r.URL.Path == "/wallet/index.html" || r.URL.Path == "/wallet/config"
+			if isWalletDoc && r.Header.Get("Sec-Fetch-Dest") == "document" {
+				http.Redirect(w, r, "/", http.StatusSeeOther)
+				return
+			}
 			if r.URL.Path == "/wallet/" || r.URL.Path == "/wallet/index.html" {
 				w.Header().Set("Content-Type", "text/html; charset=utf-8")
 				w.Header().Set("Cache-Control", "no-cache")


### PR DESCRIPTION
The bundled skycoin-web wallet at `/wallet/` is an **iframe** target for the HV UI's ☰ wallet / Angular wallet tab — its node API is routed through `window.parent.skywireVisor` (`fetchDmsg`/`fetchClearnet` over the mesh), which only exists when it's framed by the booted HV. A **top-level** navigation to a wallet HTML page (e.g. `:8443/wallet/#/wizard/create`) is out of context: no parent visor, a degraded 'node unreachable' state, and the skycoin-web app rendered outside the HV chrome.

Gate on `Sec-Fetch-Dest`: a top-level navigation sends `document` → **303 redirect into the HV UI**; framed loads (`iframe`, or empty on older browsers) and asset/API requests fall through and serve as before. Applied to **both** `ServeWasm` (the `:8443` wasm-visor) and the native HV `walletHandler`. The standalone top-level wallet remains the separate `skywire skycoin web` path (clearnet nodes, visor dormant).

Validated live on `:8443`: `Sec-Fetch-Dest: document` → 303 → `/`; `Sec-Fetch-Dest: iframe` → 200 wallet HTML; `/wallet/config` top-level → 303; cipher assets (script) → 200 ungated. `go build .` + `golangci-lint ./pkg/visor/` pass. Serve-side only.