### PR TITLE
feat(proxy): branded "building a route over skywire" interstitial for the native mesh proxies

### DIFF
--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -39,6 +39,7 @@ import (
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/ioutil"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/proxyinterstitial"
 	"github.com/skycoin/skywire/pkg/skynetca"
 	"github.com/skycoin/skywire/pkg/skynetweb"
 )
@@ -304,6 +305,28 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 			if err != nil || origPort == "" {
 				origPort = "80"
 			}
+
+			// On a transient failure (dmsg route/session still warming, or a
+			// not-yet-ready upstream like a booting skysocks-client) for a
+			// plaintext-HTTP request, answer with a branded auto-refreshing
+			// interstitial instead of a bare SOCKS error — the browser shows
+			// "building a route over skywire…" and retries once the route is
+			// warm, rather than a raw connection reset. Raw-TLS (443) and other
+			// non-HTTP ports fall through to the real error (an HTML page can't
+			// ride those). This defer runs before the panic-recover defer on a
+			// normal error return, and no-ops on success (conn != nil).
+			defer func() {
+				if dialErr != nil && conn == nil &&
+					proxyinterstitial.ShouldServe(origPort) && proxyinterstitial.IsTransient(dialErr) {
+					target := origHost
+					if target == "" {
+						target = addr
+					}
+					log.WithField("host", target).WithField("err", dialErr).
+						Debug("SOCKS5 → serving branded route interstitial")
+					conn, dialErr = proxyinterstitial.Conn(target, "", false), nil
+				}
+			}()
 
 			if _, ok := dialCtx.Value(dmsgResolverPortKey).(string); ok {
 				// Reserved synthetic directory: serve the alias index in-process.

--- a/pkg/proxyinterstitial/interstitial.go
+++ b/pkg/proxyinterstitial/interstitial.go
@@ -1,0 +1,319 @@
+// Package proxyinterstitial pkg/proxyinterstitial/interstitial.go c4-app-web
+//
+// A branded, self-contained "Building a route over skywire…" page that the
+// native mesh proxies (dmsgweb / skynetweb resolving proxies, skysocks-client
+// and -lite) serve to a browser while a route to the target is still being
+// established — instead of a raw connection error or a mute hang.
+//
+// It mirrors the wasm-visor's in-tab interstitial (pkg/wasmhv/browse-bootstrap.html)
+// but is fully static: no SharedWorker, no streamed log. A transient page
+// auto-refreshes so the browser retries the same URL once the route is warm;
+// a hard-failure page stops retrying and offers a manual retry.
+//
+// Injection model: these proxies dial the target inside a SOCKS5 Dial callback
+// (or an io.Copy tunnel). On a *transient* dial failure for a plaintext-HTTP
+// (port 80) request, the proxy returns Conn() in place of the error. The
+// SOCKS5 library then splices the browser to that conn: the browser's HTTP
+// request is read and discarded, and the interstitial HTTP response is written
+// back. Raw-TLS (443) requests can't be intercepted without a MITM CA, so
+// callers pass those straight through (no interstitial).
+package proxyinterstitial
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"net"
+	"strings"
+	"time"
+)
+
+// refreshSeconds is how long the transient page waits before reloading the
+// target URL. Short enough to feel responsive, long enough that a multi-hop
+// route setup (a few seconds on first use) usually completes within one or
+// two cycles.
+const refreshSeconds = 3
+
+// Page returns the full HTML document for the interstitial. target is the
+// host the browser was trying to reach (shown verbatim, HTML-escaped); detail
+// is an optional one-line status/error string. When isError is true the page
+// renders the hard-failure variant (error styling, no auto-refresh, manual
+// retry button); otherwise it renders the transient variant (spinner +
+// meta-refresh auto-retry).
+func Page(target, detail string, isError bool) string {
+	target = html.EscapeString(strings.TrimSpace(target))
+	detail = html.EscapeString(strings.TrimSpace(detail))
+
+	title := "Connecting over skywire…"
+	heading := "Building a route over the mesh…"
+	msg := "Establishing a private route to this site. This can take a few seconds on first use."
+	cls := ""
+	var refreshMeta string
+	if isError {
+		title = "Couldn’t reach this site over skywire"
+		heading = "Couldn’t build a route"
+		msg = "The page did not load through the skywire mesh proxy."
+		cls = " err"
+	} else {
+		// Auto-retry the SAME URL. A browser proxied through the mesh will
+		// re-issue the request; by then the route the first attempt kicked
+		// off is usually warm.
+		refreshMeta = fmt.Sprintf(`<meta http-equiv="refresh" content="%d">`, refreshSeconds)
+	}
+
+	detailBlock := ""
+	if detail != "" {
+		detailBlock = `<p id="mesh-detail" style="display:block">` + detail + `</p>`
+	}
+	hostBlock := ""
+	if target != "" {
+		hostBlock = `<small id="mesh-host">` + target + `</small>`
+	}
+
+	retry := ""
+	if isError {
+		retry = `<button class="btn" onclick="location.reload()">Retry</button>`
+	}
+
+	return `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+		`<meta name="viewport" content="width=device-width, initial-scale=1">` +
+		refreshMeta +
+		`<title>` + title + `</title><style>` + css + `</style></head>` +
+		`<body><div id="mesh-boot"><div class="card` + cls + `" id="mesh-card">` +
+		brandSVG +
+		`<div class="sp" id="mesh-sp"></div>` +
+		`<h1 id="mesh-title">` + html.EscapeString(heading) + `</h1>` +
+		`<p id="mesh-msg">` + html.EscapeString(msg) + `</p>` +
+		detailBlock +
+		`<ul class="steps" id="mesh-steps">` +
+		`<li class="done">Reaching your skywire visor</li>` +
+		`<li class="active">Finding a working exit &amp; route</li>` +
+		`<li>Loading the page over skywire</li>` +
+		`</ul>` +
+		retry +
+		hostBlock +
+		`</div></div></body></html>`
+}
+
+const brandSVG = `<div class="brand">` +
+	`<svg viewBox="0 0 24 24" fill="none" aria-hidden="true">` +
+	`<circle cx="12" cy="4.5" r="2.3" fill="#7c83ff"/><circle cx="4.5" cy="17" r="2.3" fill="#a06bff"/>` +
+	`<circle cx="19.5" cy="17" r="2.3" fill="#a06bff"/><circle cx="12" cy="12" r="1.7" fill="#c7cbe6"/>` +
+	`<path d="M12 6.8 12 10.3M10.6 12.9 6.2 15.6M13.4 12.9 17.8 15.6" stroke="#4a5199" stroke-width="1.3" stroke-linecap="round"/>` +
+	`</svg><b>skywire</b></div>`
+
+const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#7a80a8;--accent:#7c83ff;--accent2:#a06bff;--err:#ff6b8a;--card:#131629;--line:#2b3163}` +
+	`html,body{margin:0;height:100%;background:var(--bg);color:var(--fg);font:14px/1.6 system-ui,-apple-system,Segoe UI,Roboto,sans-serif}` +
+	`#mesh-boot{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:24px;box-sizing:border-box}` +
+	`.card{width:min(440px,92vw);background:var(--card);border:1px solid var(--line);border-radius:14px;padding:26px;box-shadow:0 14px 44px rgba(0,0,0,.5);text-align:center}` +
+	`.brand{display:flex;align-items:center;justify-content:center;gap:9px;margin-bottom:16px}` +
+	`.brand svg{width:24px;height:24px;flex:none}` +
+	`.brand b{font-weight:600;letter-spacing:.4px;font-size:15px;background:linear-gradient(90deg,var(--accent),var(--accent2));-webkit-background-clip:text;background-clip:text;color:transparent}` +
+	`.sp{width:34px;height:34px;margin:8px auto 16px;border:3px solid var(--line);border-top-color:var(--accent);border-radius:50%;animation:spin .9s linear infinite}` +
+	`@keyframes spin{to{transform:rotate(360deg)}}` +
+	`#mesh-title{font-size:16px;font-weight:600;color:#e7e9ff;margin:0 0 6px}` +
+	`#mesh-msg{color:var(--fg);margin:0}` +
+	`#mesh-detail{color:var(--muted);font-size:12.5px;word-break:break-word;margin:9px 0 0;display:none}` +
+	`.steps{list-style:none;padding:0;margin:16px auto 4px;text-align:left;font-size:12.5px;color:var(--muted);max-width:280px}` +
+	`.steps li{padding:3px 0 3px 24px;position:relative}` +
+	`.steps li::before{content:"○";position:absolute;left:3px;color:var(--line)}` +
+	`.steps li.active{color:var(--fg)}` +
+	`.steps li.active::before{content:"◐";color:var(--accent);animation:spin 1.4s linear infinite;display:inline-block}` +
+	`.steps li.done{color:var(--muted)}.steps li.done::before{content:"●";color:var(--accent)}` +
+	`.btn{display:inline-block;margin-top:18px;padding:8px 20px;border:1px solid var(--accent);border-radius:9px;background:transparent;color:var(--accent);font:inherit;font-size:13px;cursor:pointer}` +
+	`.btn:hover{background:var(--accent);color:#0b0d17}` +
+	`#mesh-host{display:block;margin-top:14px;font:12px/1.4 ui-monospace,SFMono-Regular,monospace;color:var(--muted);opacity:.75;word-break:break-all}` +
+	`.err #mesh-title{color:var(--err)}.err .sp{display:none}`
+
+// httpResponse wraps the HTML in a minimal HTTP/1.1 response. Connection:close
+// so the browser tears the socket down and honors the meta-refresh cleanly;
+// no-store so a transient page is never cached in place of the real content.
+func httpResponse(target, detail string, isError bool) []byte {
+	bodyStr := Page(target, detail, isError)
+	status := "200 OK"
+	if isError {
+		status = "502 Bad Gateway"
+	}
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "HTTP/1.1 %s\r\n", status)
+	b.WriteString("Content-Type: text/html; charset=utf-8\r\n")
+	fmt.Fprintf(&b, "Content-Length: %d\r\n", len(bodyStr))
+	b.WriteString("Cache-Control: no-store, must-revalidate\r\n")
+	b.WriteString("Connection: close\r\n")
+	b.WriteString("\r\n")
+	b.WriteString(bodyStr)
+	return b.Bytes()
+}
+
+// Conn returns a net.Conn that serves the interstitial as a one-shot HTTP
+// response. Reads yield the response bytes then EOF; writes (the browser's
+// request) are discarded. LocalAddr/RemoteAddr return *net.TCPAddr so it can
+// be handed straight to go-socks5, which unconditionally type-asserts the
+// address to *net.TCPAddr when building its BND reply.
+func Conn(target, detail string, isError bool) net.Conn {
+	return &interstitialConn{r: bytes.NewReader(httpResponse(target, detail, isError))}
+}
+
+type interstitialConn struct {
+	r      *bytes.Reader
+	closed bool
+}
+
+func (c *interstitialConn) Read(p []byte) (int, error) { return c.r.Read(p) }
+
+// Write discards the browser's request bytes; the response is fixed.
+func (c *interstitialConn) Write(p []byte) (int, error) { return len(p), nil }
+
+func (c *interstitialConn) Close() error { c.closed = true; return nil }
+
+func (c *interstitialConn) LocalAddr() net.Addr  { return loopbackAddr }
+func (c *interstitialConn) RemoteAddr() net.Addr { return loopbackAddr }
+
+func (c *interstitialConn) SetDeadline(time.Time) error      { return nil }
+func (c *interstitialConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *interstitialConn) SetWriteDeadline(time.Time) error { return nil }
+
+var loopbackAddr = &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+
+// ShouldServe reports whether a failed dial to the given target port should be
+// answered with a transient interstitial rather than surfacing the error.
+// Only plaintext HTTP (port 80, or an empty/implicit port) qualifies: a raw
+// TLS (443) or arbitrary non-HTTP stream can't carry an HTML page, and writing
+// one would corrupt the tunnel. err is classified so genuinely permanent
+// failures (bad hostname, refused-by-policy) can be surfaced as the hard
+// variant by the caller if it chooses; see IsTransient.
+func ShouldServe(port string) bool {
+	switch strings.TrimSpace(port) {
+	case "", "80", "8080":
+		return true
+	default:
+		return false
+	}
+}
+
+// ServeSOCKS5 answers a not-yet-connected SOCKS5 client (e.g. a browser
+// pointed at skysocks-client's :1080) with a branded interstitial when the
+// mesh route to the exit is down. skysocks-client is a transparent tunnel —
+// the SOCKS5 handshake normally rides end-to-end to the exit — so when the
+// client can't open a stream it must speak just enough SOCKS5 itself to reach
+// the point of writing an HTTP body: complete the greeting, accept the CONNECT
+// request, then (only for a plaintext-HTTP target, port 80) serve the
+// interstitial. HTTPS/other-port requests are declined so raw TLS is never
+// corrupted. Best-effort and deadline-bounded so it never stalls the client's
+// reconnect. Returns nil if it served a page, an error otherwise; the caller
+// closes conn regardless.
+func ServeSOCKS5(conn net.Conn, detail string) error {
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
+	defer conn.SetDeadline(time.Time{})                   //nolint:errcheck
+
+	tmp := make([]byte, 2)
+	// Greeting: VER=5, NMETHODS, METHODS[NMETHODS].
+	if _, err := readFull(conn, tmp); err != nil {
+		return err
+	}
+	if tmp[0] != 0x05 {
+		return fmt.Errorf("not socks5 (ver=0x%02x)", tmp[0])
+	}
+	nMethods := int(tmp[1])
+	if nMethods > 0 {
+		if _, err := readFull(conn, make([]byte, nMethods)); err != nil {
+			return err
+		}
+	}
+	// Method selection: no-auth (0x00).
+	if _, err := conn.Write([]byte{0x05, 0x00}); err != nil {
+		return err
+	}
+	// Request: VER=5, CMD, RSV, ATYP, ADDR, PORT.
+	head := make([]byte, 4)
+	if _, err := readFull(conn, head); err != nil {
+		return err
+	}
+	if head[0] != 0x05 {
+		return fmt.Errorf("bad socks5 request ver=0x%02x", head[0])
+	}
+	var host string
+	switch head[3] {
+	case 0x01: // IPv4
+		b := make([]byte, 4)
+		if _, err := readFull(conn, b); err != nil {
+			return err
+		}
+		host = net.IP(b).String()
+	case 0x03: // domain
+		l := make([]byte, 1)
+		if _, err := readFull(conn, l); err != nil {
+			return err
+		}
+		b := make([]byte, int(l[0]))
+		if _, err := readFull(conn, b); err != nil {
+			return err
+		}
+		host = string(b)
+	case 0x04: // IPv6
+		b := make([]byte, 16)
+		if _, err := readFull(conn, b); err != nil {
+			return err
+		}
+		host = net.IP(b).String()
+	default:
+		return fmt.Errorf("unsupported socks5 atyp 0x%02x", head[3])
+	}
+	portB := make([]byte, 2)
+	if _, err := readFull(conn, portB); err != nil {
+		return err
+	}
+	port := int(portB[0])<<8 | int(portB[1])
+	// Only plaintext HTTP can carry an HTML interstitial; decline the rest so
+	// the caller falls back to tearing down (browser sees a normal failure).
+	if !ShouldServe(fmt.Sprintf("%d", port)) {
+		return fmt.Errorf("socks5 interstitial: non-HTTP port %d", port)
+	}
+	// Reply success with a dummy BND.ADDR/PORT so the client proceeds to send
+	// its HTTP request.
+	if _, err := conn.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+		return err
+	}
+	// Drain a chunk of the (short) HTTP request so the browser's write
+	// completes, then answer with the interstitial. We don't need the request
+	// contents — the page is fixed. Bounded single read; ignore EOF.
+	_, _ = conn.Read(make([]byte, 1024)) //nolint:errcheck
+	_, err := conn.Write(httpResponse(host, detail, false))
+	return err
+}
+
+// readFull is io.ReadFull without pulling io into a file that otherwise
+// doesn't need it; keeps the SOCKS5 parse self-contained.
+func readFull(conn net.Conn, p []byte) (int, error) {
+	got := 0
+	for got < len(p) {
+		n, err := conn.Read(p[got:])
+		got += n
+		if err != nil {
+			return got, err
+		}
+	}
+	return got, nil
+}
+
+// IsTransient classifies a dial error as a route-setup-in-progress condition
+// (worth an auto-refreshing interstitial) versus a hard failure. The patterns
+// mirror the transient signals the wasm interstitial keys on: dmsg 202 /
+// delegated-server-not-ready, no-route, and generic dial/connect churn during
+// multi-hop setup.
+func IsTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	for _, p := range []string{
+		"202", "delegated", "no route", "route not", "no suitable transport",
+		"session", "timeout", "deadline", "temporarily", "connection refused",
+		"cannot connect", "not ready", "unreachable", "i/o timeout",
+	} {
+		if strings.Contains(s, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/proxyinterstitial/interstitial.go
+++ b/pkg/proxyinterstitial/interstitial.go
@@ -208,7 +208,7 @@ func ServeSOCKS5(conn net.Conn, detail string) error {
 
 	tmp := make([]byte, 2)
 	// Greeting: VER=5, NMETHODS, METHODS[NMETHODS].
-	if _, err := readFull(conn, tmp); err != nil {
+	if err := readFull(conn, tmp); err != nil {
 		return err
 	}
 	if tmp[0] != 0x05 {
@@ -216,7 +216,7 @@ func ServeSOCKS5(conn net.Conn, detail string) error {
 	}
 	nMethods := int(tmp[1])
 	if nMethods > 0 {
-		if _, err := readFull(conn, make([]byte, nMethods)); err != nil {
+		if err := readFull(conn, make([]byte, nMethods)); err != nil {
 			return err
 		}
 	}
@@ -226,7 +226,7 @@ func ServeSOCKS5(conn net.Conn, detail string) error {
 	}
 	// Request: VER=5, CMD, RSV, ATYP, ADDR, PORT.
 	head := make([]byte, 4)
-	if _, err := readFull(conn, head); err != nil {
+	if err := readFull(conn, head); err != nil {
 		return err
 	}
 	if head[0] != 0x05 {
@@ -236,23 +236,23 @@ func ServeSOCKS5(conn net.Conn, detail string) error {
 	switch head[3] {
 	case 0x01: // IPv4
 		b := make([]byte, 4)
-		if _, err := readFull(conn, b); err != nil {
+		if err := readFull(conn, b); err != nil {
 			return err
 		}
 		host = net.IP(b).String()
 	case 0x03: // domain
 		l := make([]byte, 1)
-		if _, err := readFull(conn, l); err != nil {
+		if err := readFull(conn, l); err != nil {
 			return err
 		}
 		b := make([]byte, int(l[0]))
-		if _, err := readFull(conn, b); err != nil {
+		if err := readFull(conn, b); err != nil {
 			return err
 		}
 		host = string(b)
 	case 0x04: // IPv6
 		b := make([]byte, 16)
-		if _, err := readFull(conn, b); err != nil {
+		if err := readFull(conn, b); err != nil {
 			return err
 		}
 		host = net.IP(b).String()
@@ -260,7 +260,7 @@ func ServeSOCKS5(conn net.Conn, detail string) error {
 		return fmt.Errorf("unsupported socks5 atyp 0x%02x", head[3])
 	}
 	portB := make([]byte, 2)
-	if _, err := readFull(conn, portB); err != nil {
+	if err := readFull(conn, portB); err != nil {
 		return err
 	}
 	port := int(portB[0])<<8 | int(portB[1])
@@ -284,16 +284,16 @@ func ServeSOCKS5(conn net.Conn, detail string) error {
 
 // readFull is io.ReadFull without pulling io into a file that otherwise
 // doesn't need it; keeps the SOCKS5 parse self-contained.
-func readFull(conn net.Conn, p []byte) (int, error) {
+func readFull(conn net.Conn, p []byte) error {
 	got := 0
 	for got < len(p) {
 		n, err := conn.Read(p[got:])
 		got += n
 		if err != nil {
-			return got, err
+			return err
 		}
 	}
-	return got, nil
+	return nil
 }
 
 // IsTransient classifies a dial error as a route-setup-in-progress condition

--- a/pkg/proxyinterstitial/interstitial_test.go
+++ b/pkg/proxyinterstitial/interstitial_test.go
@@ -1,0 +1,152 @@
+package proxyinterstitial
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPageTransient(t *testing.T) {
+	p := Page("magnetosphere.net", "", false)
+	for _, want := range []string{"<!doctype html>", "http-equiv=\"refresh\"", "skywire", "magnetosphere.net", "Building a route"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("transient page missing %q", want)
+		}
+	}
+	if strings.Contains(p, "Retry") {
+		t.Error("transient page should not offer a manual retry")
+	}
+}
+
+func TestPageError(t *testing.T) {
+	p := Page("example.dmsg", "no route to host", true)
+	if strings.Contains(p, "http-equiv=\"refresh\"") {
+		t.Error("error page must not auto-refresh")
+	}
+	for _, want := range []string{"Retry", "no route to host", "example.dmsg"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("error page missing %q", want)
+		}
+	}
+}
+
+func TestPageEscapesTarget(t *testing.T) {
+	p := Page("<script>evil()</script>", "", false)
+	if strings.Contains(p, "<script>evil()") {
+		t.Error("target host was not HTML-escaped")
+	}
+}
+
+func TestConnServesHTTP(t *testing.T) {
+	c := Conn("host.skynet", "", false)
+	// Write (the browser's request) is discarded but must not error.
+	if _, err := c.Write([]byte("GET / HTTP/1.1\r\nHost: host.skynet\r\n\r\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(c), nil)
+	if err != nil {
+		t.Fatalf("ReadResponse: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("content-type = %q", ct)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Building a route") {
+		t.Error("body is not the interstitial page")
+	}
+	if _, ok := c.RemoteAddr().(*net.TCPAddr); !ok {
+		t.Error("RemoteAddr must be *net.TCPAddr for go-socks5")
+	}
+}
+
+func TestShouldServe(t *testing.T) {
+	for _, p := range []string{"", "80", "8080"} {
+		if !ShouldServe(p) {
+			t.Errorf("ShouldServe(%q) = false, want true", p)
+		}
+	}
+	for _, p := range []string{"443", "22", "1080"} {
+		if ShouldServe(p) {
+			t.Errorf("ShouldServe(%q) = true, want false", p)
+		}
+	}
+}
+
+func TestServeSOCKS5_HTTPPort(t *testing.T) {
+	cli, srv := net.Pipe()
+	defer cli.Close() //nolint:errcheck
+	done := make(chan error, 1)
+	go func() { done <- ServeSOCKS5(srv, ""); srv.Close() }() //nolint:errcheck
+
+	_ = cli.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
+	// greeting: VER=5, 1 method, no-auth
+	if _, err := cli.Write([]byte{0x05, 0x01, 0x00}); err != nil {
+		t.Fatal(err)
+	}
+	sel := make([]byte, 2)
+	if _, err := io.ReadFull(cli, sel); err != nil {
+		t.Fatal(err)
+	}
+	if sel[0] != 0x05 || sel[1] != 0x00 {
+		t.Fatalf("method select = %v", sel)
+	}
+	// CONNECT domain "a.b" :80
+	req := []byte{0x05, 0x01, 0x00, 0x03, 0x03, 'a', '.', 'b', 0x00, 0x50}
+	if _, err := cli.Write(req); err != nil {
+		t.Fatal(err)
+	}
+	reply := make([]byte, 10)
+	if _, err := io.ReadFull(cli, reply); err != nil {
+		t.Fatal(err)
+	}
+	if reply[0] != 0x05 || reply[1] != 0x00 {
+		t.Fatalf("connect reply = %v", reply)
+	}
+	// Now send the HTTP request; expect the interstitial back.
+	if _, err := cli.Write([]byte("GET / HTTP/1.1\r\nHost: a.b\r\n\r\n")); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 4096)
+	n, _ := cli.Read(buf)
+	if !strings.Contains(string(buf[:n]), "Building a route") {
+		t.Errorf("did not receive interstitial; got %q", string(buf[:n]))
+	}
+	if err := <-done; err != nil {
+		t.Errorf("ServeSOCKS5: %v", err)
+	}
+}
+
+func TestServeSOCKS5_HTTPSDeclined(t *testing.T) {
+	cli, srv := net.Pipe()
+	defer cli.Close() //nolint:errcheck
+	done := make(chan error, 1)
+	go func() { done <- ServeSOCKS5(srv, ""); srv.Close() }() //nolint:errcheck
+
+	_ = cli.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
+	cli.Write([]byte{0x05, 0x01, 0x00})                  //nolint:errcheck
+	io.ReadFull(cli, make([]byte, 2))                    //nolint:errcheck
+	// CONNECT 1.2.3.4:443 (IPv4 atyp)
+	cli.Write([]byte{0x05, 0x01, 0x00, 0x01, 1, 2, 3, 4, 0x01, 0xBB}) //nolint:errcheck
+	if err := <-done; err == nil {
+		t.Error("expected ServeSOCKS5 to decline the 443 request")
+	}
+}
+
+// TestDumpSamples writes the two page variants to the scratchpad for a manual
+// visual check when RUN_DUMP is set; skipped in normal CI.
+func TestDumpSamples(t *testing.T) {
+	dir := os.Getenv("INTERSTITIAL_DUMP_DIR")
+	if dir == "" {
+		t.Skip("set INTERSTITIAL_DUMP_DIR to dump sample HTML")
+	}
+	_ = os.WriteFile(dir+"/interstitial_transient.html", []byte(Page("magnetosphere.net", "", false)), 0644)       //nolint:errcheck,gosec
+	_ = os.WriteFile(dir+"/interstitial_error.html", []byte(Page("skycoin.dmsg", "no route to host", true)), 0644) //nolint:errcheck,gosec
+}

--- a/pkg/proxyinterstitial/interstitial_test.go
+++ b/pkg/proxyinterstitial/interstitial_test.go
@@ -58,7 +58,7 @@ func TestConnServesHTTP(t *testing.T) {
 	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
 		t.Errorf("content-type = %q", ct)
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body) //nolint:errcheck
 	if !strings.Contains(string(body), "Building a route") {
 		t.Error("body is not the interstitial page")
 	}
@@ -84,7 +84,7 @@ func TestServeSOCKS5_HTTPPort(t *testing.T) {
 	cli, srv := net.Pipe()
 	defer cli.Close() //nolint:errcheck
 	done := make(chan error, 1)
-	go func() { done <- ServeSOCKS5(srv, ""); srv.Close() }() //nolint:errcheck
+	go func() { done <- ServeSOCKS5(srv, ""); srv.Close() }() //nolint:errcheck,gosec
 
 	_ = cli.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
 	// greeting: VER=5, 1 method, no-auth
@@ -115,7 +115,7 @@ func TestServeSOCKS5_HTTPPort(t *testing.T) {
 		t.Fatal(err)
 	}
 	buf := make([]byte, 4096)
-	n, _ := cli.Read(buf)
+	n, _ := cli.Read(buf) //nolint:errcheck
 	if !strings.Contains(string(buf[:n]), "Building a route") {
 		t.Errorf("did not receive interstitial; got %q", string(buf[:n]))
 	}
@@ -128,13 +128,13 @@ func TestServeSOCKS5_HTTPSDeclined(t *testing.T) {
 	cli, srv := net.Pipe()
 	defer cli.Close() //nolint:errcheck
 	done := make(chan error, 1)
-	go func() { done <- ServeSOCKS5(srv, ""); srv.Close() }() //nolint:errcheck
+	go func() { done <- ServeSOCKS5(srv, ""); srv.Close() }() //nolint:errcheck,gosec
 
 	_ = cli.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
-	cli.Write([]byte{0x05, 0x01, 0x00})                  //nolint:errcheck
-	io.ReadFull(cli, make([]byte, 2))                    //nolint:errcheck
+	cli.Write([]byte{0x05, 0x01, 0x00})                  //nolint:errcheck,gosec
+	io.ReadFull(cli, make([]byte, 2))                    //nolint:errcheck,gosec
 	// CONNECT 1.2.3.4:443 (IPv4 atyp)
-	cli.Write([]byte{0x05, 0x01, 0x00, 0x01, 1, 2, 3, 4, 0x01, 0xBB}) //nolint:errcheck
+	cli.Write([]byte{0x05, 0x01, 0x00, 0x01, 1, 2, 3, 4, 0x01, 0xBB}) //nolint:errcheck,gosec
 	if err := <-done; err == nil {
 		t.Error("expected ServeSOCKS5 to decline the 443 request")
 	}

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/proxyinterstitial"
 	"github.com/skycoin/skywire/pkg/skynet"
 	"github.com/skycoin/skywire/pkg/skynetca"
 )
@@ -228,6 +229,30 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 			}()
 
 			origHost, _ := dialCtx.Value(skynetOrigHostKey{}).(string)
+
+			// Transient-failure interstitial (see pkg/dmsgweb/runtime.go for the
+			// full rationale): on a route-still-warming / upstream-not-ready
+			// failure for a plaintext-HTTP request, serve a branded
+			// auto-refreshing "building a route over skywire…" page in place of
+			// a bare SOCKS error so the browser retries once the route is warm.
+			// Raw-TLS (443) and non-HTTP ports fall through to the real error.
+			// Runs before the panic-recover defer on a normal return; no-ops on
+			// success or panic.
+			defer func() {
+				if retErr == nil || retConn != nil {
+					return
+				}
+				_, port, _ := net.SplitHostPort(addr) //nolint:errcheck
+				if proxyinterstitial.ShouldServe(port) && proxyinterstitial.IsTransient(retErr) {
+					target := origHost
+					if target == "" {
+						target = addr
+					}
+					log.WithField("host", target).WithField("err", retErr).
+						Debug("SOCKS5 → serving branded route interstitial")
+					retConn, retErr = proxyinterstitial.Conn(target, "", false), nil
+				}
+			}()
 
 			// Check if hostname matches .skynet suffix.
 			if origHost != "" && isSkynetHost(origHost, cfg.DomainSuffix) {

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -9,10 +9,11 @@ import (
 	"time"
 
 	ipc "github.com/james-barrow/golang-ipc"
-	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 
 	"github.com/skycoin/skywire/pkg/app"
+	"github.com/skycoin/skywire/pkg/proxyinterstitial"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 )
 
 // Client implement multiplexing proxy client using yamux.
@@ -88,6 +89,20 @@ func (c *Client) ListenAndServe(addr string) error {
 
 		stream, err := c.session.Open()
 		if err != nil {
+			// The mesh route/session to the exit is down (exit restart, all
+			// mux legs dropped). Before tearing down for reconnect, serve the
+			// waiting browser a branded "building a route over skywire…"
+			// interstitial for a plaintext-HTTP request so it retries once the
+			// route is back, instead of a bare connection failure. Best-effort
+			// and deadline-bounded (see ServeSOCKS5); declined for HTTPS/other
+			// ports. Runs in a goroutine that owns conn so the reconnect below
+			// isn't delayed by a slow browser.
+			go func(bc net.Conn) {
+				if serr := proxyinterstitial.ServeSOCKS5(bc, ""); serr != nil && c.appCl != nil {
+					c.appCl.Log().Debugf("route-down interstitial not served: %v", serr)
+				}
+				bc.Close() //nolint:errcheck,gosec
+			}(conn)
 			c.close()
 
 			return fmt.Errorf("error opening yamux stream: %w", err)


### PR DESCRIPTION
## What

Serve a branded **"Building a route over the mesh…"** interstitial page while a
skywire route to the target is still being established, instead of a raw
connection error or a mute hang. This is the native counterpart of the
wasm-visor's in-tab interstitial (`pkg/wasmhv/browse-bootstrap.html`), for the
native mesh proxies a desktop browser actually points at.

## Where it applies

- **`.dmsg` resolving proxy** (`pkg/dmsgweb`) and **`.skynet` resolving proxy**
  (`pkg/skynetweb`): on a transient route-not-ready / upstream-not-ready dial
  failure for a plaintext-HTTP request, the SOCKS5 `Dial` callback returns the
  interstitial conn (via a named-return defer) instead of the error.
- **skysocks-client** and **skysocks-client-lite** (same code path,
  `pkg/skysocks/client.go`): when the yamux session to the exit is down, the
  client speaks minimal SOCKS5 to the waiting browser and serves the page before
  tearing down for reconnect — in a goroutine that owns the conn so reconnect is
  not delayed.

Raw-TLS (443) and non-HTTP ports fall through to the real error — an HTML body
can't ride those without a MITM CA.

## New package `pkg/proxyinterstitial`

- `Page()` — the branded page: transient variant (spinner + `meta` auto-refresh)
  and hard-error variant (red title, no refresh, Retry). Host is HTML-escaped.
- `Conn()` — a synthetic `net.Conn` that serves the page as a one-shot HTTP
  response; returns `*net.TCPAddr` so it drops straight into go-socks5's BND reply.
- `ServeSOCKS5()` — a minimal, deadline-bounded SOCKS5 responder for the
  transparent-tunnel (skysocks) case.
- `ShouldServe()` / `IsTransient()` classifiers.

## Tests

Page variants, HTML escaping, the synthetic conn's HTTP response + `*net.TCPAddr`,
and the SOCKS5 handshake (HTTP served, HTTPS declined). `pkg/dmsgweb`,
`pkg/skynetweb`, `pkg/skysocks` tests all pass; full `./skywire` builds; vet clean.

## Follow-up (not in this PR)

HTTPS interstitials for the `.dmsg`/`.skynet` resolving proxies via the existing
resolver CA (MITM), so a secure-context load also shows the page rather than a
TLS error.
