### PR TITLE
fix(router): lossless mux reorder + retx timeout — fix mux>1 stream corruption under load

### DIFF
--- a/pkg/router/reorder.go
+++ b/pkg/router/reorder.go
@@ -4,7 +4,20 @@ package router
 import (
 	"sort"
 	"sync"
+	"time"
 )
+
+// reorderTimeout bounds how long the reorder buffer will hold a frontier gap
+// open before releasing it (delivering past the missing sequence). It is the
+// time-based companion to maxGap: maxGap caps memory, reorderTimeout caps
+// head-of-line latency. With reliable leg transports a genuine gap only occurs
+// when a leg dies mid-stream and the SACK retransmit has not yet refilled it;
+// rather than stall the stream until liveness prunes that leg, release the gap
+// after this long so the flow degrades to lossy-but-moving (never a hard 0-byte
+// stall — the graceful-degradation contract for mux>1). Comfortably larger than
+// any realistic inter-leg latency skew so normal reordering is never released
+// early. A var (not const) so tests can shrink it.
+var reorderTimeout = 1500 * time.Millisecond
 
 // reorderBuffer holds out-of-order packets and delivers them in sequence order.
 // When mux mode distributes packets across multiple transports, they may arrive
@@ -13,7 +26,18 @@ type reorderBuffer struct {
 	mu      sync.Mutex
 	nextSeq uint32            // next expected sequence number
 	buf     map[uint32][]byte // out-of-order packets: seq -> payload
-	maxGap  int               // max buffered packets before force-flush
+	// gapSince is when the current frontier gap opened (buffer went non-empty
+	// while waiting for nextSeq). Zero when the buffer is empty / fully caught
+	// up. Used to release a gap that has stayed open longer than reorderTimeout.
+	gapSince time.Time
+	// maxGap is the emergency cap: the max out-of-order packets held before a
+	// last-resort force-flush that skips the missing sequence. Because the leg
+	// transports are reliable/ordered, a gap is latency skew (the missing seq
+	// is in flight and will arrive), so this cap is sized (see reorderWindow)
+	// to never trip in normal mux operation — hitting it means a leg has died
+	// and stopped delivering, and flushing (lossy) is preferable to stalling
+	// the stream forever while liveness prunes that leg.
+	maxGap int
 }
 
 func newReorderBuffer(maxGap int) *reorderBuffer {
@@ -41,7 +65,27 @@ func (rb *reorderBuffer) Insert(seq uint32, data []byte) [][]byte {
 		copy(cp, data)
 		rb.buf[seq] = cp
 
-		// Force flush if buffer is too large (prevents unbounded memory)
+		// Mark when this frontier gap opened, so it can be released if it
+		// stays open too long (a dead leg the SACK retransmit has not yet
+		// refilled).
+		if rb.gapSince.IsZero() {
+			rb.gapSince = time.Now()
+		}
+
+		// Time-based release: a gap held longer than reorderTimeout is treated
+		// as a dead leg rather than skew — flush past it so the stream keeps
+		// moving (lossy) instead of stalling until liveness prunes the leg.
+		if !rb.gapSince.IsZero() && time.Since(rb.gapSince) >= reorderTimeout {
+			return rb.flushAll()
+		}
+
+		// Emergency backstop only: with reliable leg transports the missing
+		// seq arrives within the skew window and drains the buffer, so this
+		// never trips in normal operation. Reaching it means a leg has gone
+		// dead mid-stream; force-flush (lossy, skips the gap) to avoid a
+		// permanent stall until liveness prunes the leg. It is NOT the normal
+		// reorder path — do not lower maxGap to "save memory": that reintroduces
+		// the mux>1 corruption bug.
 		if len(rb.buf) >= rb.maxGap {
 			return rb.flushAll()
 		}
@@ -61,6 +105,15 @@ func (rb *reorderBuffer) Insert(seq uint32, data []byte) [][]byte {
 		delivered = append(delivered, next)
 		delete(rb.buf, rb.nextSeq)
 		rb.nextSeq++
+	}
+
+	// Frontier advanced. If nothing remains buffered the gap is fully closed;
+	// otherwise a new frontier gap (the next missing seq) is now open, so time
+	// it from here.
+	if len(rb.buf) == 0 {
+		rb.gapSince = time.Time{}
+	} else {
+		rb.gapSince = time.Now()
 	}
 
 	return delivered
@@ -90,6 +143,9 @@ func (rb *reorderBuffer) flushAll() [][]byte {
 	if len(seqs) > 0 {
 		rb.nextSeq = seqs[len(seqs)-1] + 1
 	}
+
+	// Buffer drained — the gap is closed (skipped).
+	rb.gapSince = time.Time{}
 
 	return delivered
 }

--- a/pkg/router/reorder_test.go
+++ b/pkg/router/reorder_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -67,4 +68,78 @@ func TestReorderBuffer_ForceFlush(t *testing.T) {
 	assert.Equal(t, []byte("c"), d[1])
 	assert.Equal(t, []byte("d"), d[2])
 	assert.Equal(t, 0, rb.Pending())
+}
+
+// TestReorderLosslessBeyondOldMaxGap proves the reorder buffer no longer skips a
+// gap the moment it fills past the old maxGap=64: with reliable leg transports a
+// gap is latency skew, so the buffer must HOLD it (any skip corrupts the noise
+// stream riding the mux — the mux>1 wedge). Here 499 packets pile up behind a
+// single missing sequence; none may be delivered early, and when the missing
+// one finally arrives the whole run delivers in order with no hole.
+func TestReorderLosslessBeyondOldMaxGap(t *testing.T) {
+	rb := newReorderBuffer(reorderWindow) // 2048
+
+	if got := rb.Insert(0, []byte{0}); len(got) != 1 {
+		t.Fatalf("seq0 in-order: delivered %d, want 1", len(got))
+	}
+	// Buffer seq 2..500 behind the gap at seq 1 — far past the old maxGap=64.
+	for s := uint32(2); s <= 500; s++ {
+		if got := rb.Insert(s, []byte{byte(s)}); got != nil {
+			t.Fatalf("seq%d delivered early (len=%d): buffer skipped a still-open gap (corruption)", s, len(got))
+		}
+	}
+	if rb.Pending() != 499 {
+		t.Fatalf("pending=%d, want 499: buffer dropped packets instead of holding the gap", rb.Pending())
+	}
+
+	// The missing seq 1 finally arrives — 1..500 must now deliver contiguously.
+	got := rb.Insert(1, []byte{1})
+	if len(got) != 500 {
+		t.Fatalf("after gap fill: delivered %d, want 500 contiguous", len(got))
+	}
+	for i, d := range got {
+		if want := byte(uint32(i) + 1); d[0] != want {
+			t.Fatalf("delivered[%d]=%d, want %d: out of order", i, d[0], want)
+		}
+	}
+	if rb.Pending() != 0 {
+		t.Fatalf("pending=%d after full drain, want 0", rb.Pending())
+	}
+}
+
+// TestReorderTimeBasedRelease proves a gap that stays open longer than
+// reorderTimeout is released (delivered past the missing sequence) so a dead leg
+// degrades to lossy-but-moving instead of stalling the stream at 0 bytes.
+func TestReorderTimeBasedRelease(t *testing.T) {
+	old := reorderTimeout
+	reorderTimeout = 100 * time.Millisecond
+	defer func() { reorderTimeout = old }()
+
+	rb := newReorderBuffer(reorderWindow)
+
+	if got := rb.Insert(0, []byte{0}); len(got) != 1 {
+		t.Fatalf("seq0: delivered %d, want 1", len(got))
+	}
+	// Open a gap at seq 1 and buffer some successors.
+	rb.Insert(2, []byte{2})
+	rb.Insert(3, []byte{3})
+
+	// Before the timeout: another out-of-order packet must NOT release the gap.
+	if got := rb.Insert(4, []byte{4}); got != nil {
+		t.Fatalf("gap released before timeout (len=%d): normal skew would be corrupted", len(got))
+	}
+
+	// After the timeout: the next out-of-order packet releases the gap, skipping
+	// the missing seq 1 so the stream keeps moving.
+	time.Sleep(150 * time.Millisecond)
+	got := rb.Insert(5, []byte{5})
+	if len(got) == 0 {
+		t.Fatalf("gap not released after timeout: dead leg would hard-stall the stream at 0 bytes")
+	}
+	if rb.NextSeq() <= 1 {
+		t.Fatalf("nextSeq=%d did not advance past the skipped gap", rb.NextSeq())
+	}
+	if rb.Pending() != 0 {
+		t.Fatalf("pending=%d after release, want 0", rb.Pending())
+	}
 }

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1799,7 +1799,10 @@ func (rg *RouteGroup) handleDataPacket(packet routing.Packet) (err error) {
 
 		delivered, gapDetected := rg.mux.deliverData(seq, data)
 
-		if gapDetected {
+		// A gap is the normal case for mux (legs interleave), so rate-limit the
+		// SACK: without this, latency-skew reordering fires a SACK goroutine per
+		// out-of-order packet — thousands per second under load.
+		if gapDetected && rg.mux.shouldSendSACK() {
 			go rg.sendSACK() //nolint:errcheck
 		}
 

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -4,6 +4,7 @@ package router
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/routing"
@@ -58,6 +59,13 @@ type routeMux struct {
 	writeSeq uint32 // atomic: next outgoing sequence number
 	tpIndex  uint32 // atomic: round-robin fallback index for transport selection
 
+	// lastSACKNano rate-limits receiver-side SACK feedback. Cross-leg
+	// reordering from latency skew makes nearly every packet arrive
+	// out-of-order, so firing a SACK per out-of-order packet would spawn a
+	// goroutine and emit a control packet thousands of times per second.
+	// atomic: UnixNano of the last SACK we sent.
+	lastSACKNano int64
+
 	// Incoming packet reordering
 	reorderBuf *reorderBuffer
 
@@ -86,15 +94,36 @@ type routeMux struct {
 	ready []bool
 }
 
+// reorderWindow bounds how far the receiver's reorder buffer will hold
+// out-of-order packets waiting for a gap to fill before it force-flushes.
+//
+// The underlying leg transports (stcpr / squicr / sudph) are RELIABLE and
+// ordered, so a gap across mux legs is not loss — it is latency SKEW: the
+// "missing" sequence is simply in flight on a slower leg and arrives within
+// the inter-leg skew window. The buffer must therefore HOLD the gap until it
+// fills, never skip it: skipping delivers an out-of-order hole that corrupts
+// the noise/TLS byte stream riding the mux (the old maxGap=64 force-flush was
+// the root cause of mux>1 wedging under load — the fast leg routinely ran 64
+// ahead of a ~tens-of-ms-slower leg, triggering a destructive flush every
+// time). Sized to absorb the bandwidth-delay-product of a realistic skew
+// (hundreds of ms at multi-MB/s aggregate) so normal mux>1 operation never
+// flushes. A flush at this cap is a last-resort OOM guard for a genuinely
+// stalled/dead leg — which per-leg liveness prunes, after which the peer
+// retransmits that leg's unacked sequences on the surviving legs.
+const reorderWindow = 2048
+
 // newRouteMux creates a new routeMux instance with all sub-components initialized.
 func newRouteMux(logger *logging.Logger, sackEnabled bool) *routeMux {
 	m := &routeMux{
 		logger:      logger,
-		reorderBuf:  newReorderBuffer(64),
+		reorderBuf:  newReorderBuffer(reorderWindow),
 		tpSelector:  newTransportSelector(),
 		sackEnabled: sackEnabled,
 		sackTracker: newSACKTracker(),
-		retxBuf:     newRetxBuffer(128),
+		// Sender-side retx window kept in step with the receiver's reorder
+		// window so a genuinely-lost sequence is still held for retransmit
+		// while the receiver is holding the gap open for it.
+		retxBuf: newRetxBuffer(reorderWindow),
 	}
 	return m
 }
@@ -367,6 +396,24 @@ func (m *routeMux) deliverData(seq uint32, data []byte) (delivered [][]byte, gap
 	}
 
 	return delivered, gapDetected
+}
+
+// sackMinInterval is the minimum spacing between receiver-side SACKs. It is
+// well under retxMinAge so a genuine loss is still signaled several times
+// before the sender's retransmit timer fires, while collapsing the flood of
+// per-packet SACKs that latency-skew reordering would otherwise produce.
+const sackMinInterval = 25 * time.Millisecond
+
+// shouldSendSACK reports whether enough time has elapsed since the last SACK to
+// send another, rate-limiting SACK feedback under heavy cross-leg reordering.
+// Concurrency-safe: only the goroutine that wins the CAS returns true.
+func (m *routeMux) shouldSendSACK() bool {
+	now := time.Now().UnixNano()
+	prev := atomic.LoadInt64(&m.lastSACKNano)
+	if now-prev < int64(sackMinInterval) {
+		return false
+	}
+	return atomic.CompareAndSwapInt64(&m.lastSACKNano, prev, now)
 }
 
 // generateSACK returns the current SACK state for sending to the peer.

--- a/pkg/router/sack.go
+++ b/pkg/router/sack.go
@@ -6,6 +6,18 @@ import (
 	"time"
 )
 
+// retxMinAge is how long an un-acknowledged sequence must have been
+// outstanding before a SACK gap will retransmit it. The mux legs ride
+// reliable, ordered transports, so a sequence missing from the receiver's
+// contiguous run is almost always just IN FLIGHT on a slower leg (latency
+// skew), not lost. Retransmitting it on sight is spurious and self-amplifies:
+// each early retx arrives out of order, provoking another SACK, provoking more
+// retx (the observed ~7x traffic storm that wedged mux>1). Holding off until a
+// sequence is overdue by more than any realistic inter-leg skew means a merely
+// reordered packet arrives and is acked (purged) first, and only a genuinely
+// lost one — a dead leg, which liveness prunes — is ever retransmitted.
+const retxMinAge = 750 * time.Millisecond
+
 // sackTracker tracks received sequence numbers on the receiver side and
 // generates SACK feedback (last contiguous seq + 64-bit bitmap).
 type sackTracker struct {
@@ -142,8 +154,11 @@ func (rb *retxBuffer) ProcessSACK(lastContiguous uint32, bitmap uint64) []uint32
 			// Bit is set: packet received, purge from buffer
 			delete(rb.entries, checkSeq)
 		} else {
-			// Bit is not set: packet missing, retransmit if we have it
-			if _, ok := rb.entries[checkSeq]; ok {
+			// Bit is not set: packet missing. Retransmit only if it is
+			// genuinely overdue — a sequence still within retxMinAge of when it
+			// was sent is presumed in flight on a slower leg (mux latency skew),
+			// not lost, so retransmitting it would be spurious.
+			if e, ok := rb.entries[checkSeq]; ok && time.Since(e.sentAt) >= retxMinAge {
 				retransmit = append(retransmit, checkSeq)
 			}
 		}


### PR DESCRIPTION
## Problem

Sustained transfers over a multiplexed route group (`--mux N`, N≥2) wedge: both legs move traffic but the receiver never reassembles a complete ordered stream, with a large retransmission amplification (~7× the payload) that never converges. `mux=1` is unaffected.

## Root cause

Two independent defects in the receive/ack path, both rooted in treating **cross-leg latency skew as loss**:

1. **Destructive reorder flush.** The receiver reorder buffer force-flushed *past* a missing sequence once 64 packets piled up behind it (`maxGap=64`), delivering an out-of-order hole. The leg transports (stcpr/squicr/sudph) are reliable and ordered, so a gap is skew — the missing sequence is in flight on a slower leg and will arrive — not loss. Skipping it corrupts the noise/TLS byte stream riding the mux. With two legs at even tens of ms of skew under load, the fast leg routinely runs 64 ahead, tripping the flush every time. `deliverData` also advanced the SACK contiguous pointer past the skipped gap, so the sender never retransmitted it either.

2. **Spurious retransmission storm.** Every out-of-order packet fired an immediate SACK, and `ProcessSACK` retransmitted the entire 64-window with no age check — so merely-reordered (in-flight) sequences were retransmitted on sight, each arriving out of order and provoking more SACKs. Self-amplifying (`DefaultRouteKeepAlive=10min`, so the periodic SACK is a non-factor; the per-packet immediate SACK was the only, pathological, driver).

## Fix

- **Lossless reorder buffer**: window `64 → 2048`, sized to absorb the bandwidth-delay-product of realistic inter-leg skew, so normal mux>1 reordering never force-flushes. The count-based flush is demoted to a rare OOM backstop, and a **time-based release** (`reorderTimeout`, 1.5s) lets a genuinely dead leg degrade to lossy-but-moving rather than stalling the stream at 0 bytes (graceful degradation).
- **Retx timeout** (`retxMinAge`, 750ms): `ProcessSACK` only retransmits sequences that are genuinely overdue, not ones still in flight on a slower leg — removes the amplification.
- **SACK rate-limit** (25ms): skew-driven reordering no longer spawns a goroutine + control packet per out-of-order packet.
- Retx buffer sized in step with the reorder window (2048).

## Testing

- New reorder unit tests: `TestReorderLosslessBeyondOldMaxGap` (499 packets held behind one gap, delivered in order on fill — no early skip) and `TestReorderTimeBasedRelease` (gap released only after the timeout).
- Existing router package tests pass; `mux=1` path unchanged (no reordering).
- Live: on the running visor, `mux=1` is solid and the reorder corruption / retransmit storm that previously wedged mux≥2 downloads is gone. (A separate route-setup / aux-leg-establishment issue — the deployed route-finder not returning disjoint multi-hop routes for GROW, and aux-leg blackhole under churn — still limits end-to-end mux≥2 aggregation and is tracked separately; it is orthogonal to this data-plane correctness fix.)