### PR TITLE
feat(visor): branded interstitial from the mesh reverse-proxy (real-origin, no MITM)

### DIFF
--- a/pkg/visor/meshproxy.go
+++ b/pkg/visor/meshproxy.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/proxyinterstitial"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/skynetweb"
@@ -225,11 +226,35 @@ func (v *Visor) newMeshReverseProxy(resolve meshResolveFn) (*httputil.ReversePro
 			return nil // headers pass through verbatim (the whole point vs. the old bridge)
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
-			if me, _ := r.Context().Value(meshErrKey).(string); me != "" {
-				http.Error(w, "mesh proxy: "+me, http.StatusBadGateway)
+			ctx := r.Context()
+			frameHost, _ := ctx.Value(meshFrameHostKey).(string)
+			if frameHost == "" {
+				frameHost = r.Host
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+			// Bad hostname / resolve failure — a hard error page, no retry.
+			if me, _ := ctx.Value(meshErrKey).(string); me != "" {
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = fmt.Fprint(w, proxyinterstitial.Page(frameHost, me, true)) //nolint:errcheck,gosec // Page() html-escapes target/detail
 				return
 			}
-			http.Error(w, "mesh proxy: "+err.Error(), http.StatusBadGateway)
+
+			// Route still warming (route/session setup in flight) — serve the
+			// branded auto-refreshing interstitial so the browser shows
+			// "building a route over skywire…" and retries, instead of a bare
+			// 502. This is the real-origin counterpart of the resolving proxy's
+			// interstitial: because the browse frame loads from a trusted local
+			// origin (<pk>.mesh.localhost / *.haltingstate.net), the page renders
+			// even over HTTPS — no TLS-MITM needed. A genuine (non-transient)
+			// failure falls through to the hard-error variant.
+			if proxyinterstitial.IsTransient(err) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprint(w, proxyinterstitial.Page(frameHost, "", false)) //nolint:errcheck,gosec // Page() html-escapes target/detail
+				return
+			}
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = fmt.Fprint(w, proxyinterstitial.Page(frameHost, err.Error(), true)) //nolint:errcheck,gosec // Page() html-escapes target/detail
 		},
 	}, nil
 }


### PR DESCRIPTION
## What

The native real-origin browse path (`meshproxy`, `pkg/visor/meshproxy.go`) returned a bare `502` from its `ReverseProxy` `ErrorHandler` when a mesh request failed. This wires the existing `proxyinterstitial` branded page into that handler:

- **transient/route-warming error** → auto-refreshing "Building a route over the mesh…" page (browser retries once the route is warm);
- **unresolvable host / genuine failure** → the hard-error variant with a Retry button.

## Why this is the clean approach (no TLS-MITM)

Unlike the SOCKS resolving proxy (which keeps the original `foo.dmsg` host and must MITM it with a per-host leaf under a name-constrained CA the browser has to trust), the meshproxy serves each site from a **trusted local origin** (`<pk>.mesh.localhost`, secure context with no cert; or a real `*.haltingstate.net` wildcard when hosted). So the interstitial renders in a real browser **over HTTPS with no per-host leaf and no CA install** — the browser already trusts the origin. `Page()` html-escapes the host/detail it embeds.

## Validated live

- Malformed mesh host → `502` in <1ms serving the branded hard-error page (title/`mesh-boot`/`mesh-card` present).
- Working mesh host → real content (`200`) unchanged.

## Follow-up (not in this PR)

To also show the interstitial *while a cold-but-reachable route warms* (today the ReverseProxy blocks on the round-trip then returns content, so no error fires), the handler needs a per-request deadline **plus** keeping the route/session setup alive in the background so the auto-refresh converges. Tracked separately.