### PR TITLE
feat(deployment): source the browse-origin domain from services-config.json

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -2,10 +2,12 @@
 package clihv
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/visor"
 )
 
@@ -32,7 +34,7 @@ func init() {
 	serveCmd.Flags().StringVar(&servePassword, "password", "", "gate the served PWA behind an access password (cookie login). Empty = open. Use over --tls / behind TLS so the password isn't sent in clear")
 	serveCmd.Flags().StringVarP(&serveVariant, "variant", "W", "", "which embedded wasm-visor to serve: 'go' (larger, full crypto/tls+net/http) or 'tinygo' (~4x smaller — better for the PWA, with the documented TinyGo feature gaps). Empty = the build default. A standard-Go build embeds both; a TinyGo build has only 'tinygo'")
 	serveCmd.Flags().BoolVar(&serveWallet, "wallet", true, "serve the bundled skycoin-web wallet at /wallet/ (custody stays browser-side — the host never sees keys). --wallet=false serves a wallet-less PWA")
-	serveCmd.Flags().StringVar(&serveBrowseSuffix, "browse-suffix", "", "browse-origin domain suffix for the real-origin browser (leading dot). Empty = .mesh.localhost (local). Set e.g. .haltingstate.net for a hosted deploy")
+	serveCmd.Flags().StringVar(&serveBrowseSuffix, "browse-suffix", "", fmt.Sprintf("browse-origin domain suffix for the real-origin browser (leading dot). Empty = .mesh.localhost (local); when --browse-origin is set (hosted mode) and this is empty it defaults to the deployment's browse_origin_suffix (%q from services-config.json)", deployment.Prod.BrowseOriginSuffix))
 	serveCmd.Flags().StringVar(&serveBrowseOrigin, "browse-origin", "", "ALSO serve the browse-origin SW bootstrap on this second addr (e.g. 127.0.0.1:7998), for the hosted real-origin browser's B origins. Caddy routes *.<browse-suffix> here; this same process serves V on --addr and B here. Empty = off (V host-routes B on --addr, local mode)")
 	serveCmd.Flags().StringVar(&serveVOrigin, "v-origin", "", "the PUBLIC origin of the visor app V that B's bootstrap postMessages to, e.g. https://theskywirenetwork.net. Only needed with --browse-origin behind a proxy; empty = derive from --addr (local)")
 	RootCmd.AddCommand(serveCmd)
@@ -59,6 +61,15 @@ Keyless: no key is baked in; each visitor's browser mints + persists its own
 ephemeral key (localStorage). That is what makes serving from a domain safe — the
 page never asks anyone to type a secret key.`,
 	Run: func(cmd *cobra.Command, _ []string) {
+		// Hosted mode (a browse-origin bootstrap addr is set → Caddy fronts
+		// *.<suffix>) with no explicit suffix sources the browse-origin domain
+		// from the embedded deployment config instead of hardcoding it, so the
+		// domain lives in exactly one place (services-config.json). Local mode
+		// (no --browse-origin) keeps the .mesh.localhost default.
+		browseSuffix := serveBrowseSuffix
+		if browseSuffix == "" && serveBrowseOrigin != "" {
+			browseSuffix = deployment.Prod.BrowseOriginSuffix
+		}
 		if err := visor.ServeWasm(cmd.Context(), visor.WasmServeConfig{
 			Addr:             serveAddr,
 			TLS:              serveTLS,
@@ -68,7 +79,7 @@ page never asks anyone to type a secret key.`,
 			Wallet:           serveWallet,
 			Variant:          serveVariant,
 			Password:         servePassword,
-			BrowseSuffix:     serveBrowseSuffix,
+			BrowseSuffix:     browseSuffix,
 			BrowseOriginAddr: serveBrowseOrigin,
 			VOrigin:          serveVOrigin,
 		}); err != nil {

--- a/deployment/cmd/gen/main.go
+++ b/deployment/cmd/gen/main.go
@@ -58,6 +58,7 @@ type services struct {
 	GeoIP              string   `json:"geoip,omitempty"`
 	SurveyWhitelist    []string `json:"survey_whitelist,omitempty"`
 	WSSDomainSuffix    string   `json:"wss_domain_suffix,omitempty"`
+	BrowseOriginSuffix string   `json:"browse_origin_suffix,omitempty"`
 	DmsgServers        []struct {
 		Static string `json:"static"`
 		Server struct {
@@ -178,6 +179,7 @@ func emitServices(buf *bytes.Buffer, s services) {
 	emitPubKeyList(buf, "SurveyWhitelist", s.SurveyWhitelist)
 	emitStringField(buf, "ConfDmsg", s.ConfDmsg)
 	emitStringField(buf, "WSSDomainSuffix", s.WSSDomainSuffix)
+	emitStringField(buf, "BrowseOriginSuffix", s.BrowseOriginSuffix)
 	emitDmsgServers(buf, s.DmsgServers)
 	emitStringField(buf, "DmsgDiscoveryDmsg", s.DmsgDiscoveryDmsg)
 	emitStringField(buf, "TransportDiscoveryDmsg", s.TransportDiscoveryDmsg)

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -214,7 +214,17 @@ type Services struct {
 	// server's local config. A dmsg server applies it only when its own PK is a
 	// known fleet server (IsKnownDmsgServer) — a third party running this binary
 	// never mis-advertises this domain for a PK with no DNS record.
-	WSSDomainSuffix        string `json:"wss_domain_suffix,omitempty"`
+	WSSDomainSuffix string `json:"wss_domain_suffix,omitempty"`
+	// BrowseOriginSuffix is the deployment-wide domain the "real-origin" browse
+	// path (pkg/visor/meshproxy.go, the wasm SW browse origin, and the hosted
+	// Caddy front) serves untrusted mesh content under — e.g. ".haltingstate.net"
+	// (a SEPARATE eTLD+1 from the visor app on WSSDomainSuffix, so untrusted
+	// browsed content is cookie/origin-isolated from the visor identity). Lives
+	// here so the domain is defined in exactly one place instead of being
+	// hardcoded across the serve flags / config-gen / docs; consumers read it via
+	// deployment.Prod.BrowseOriginSuffix. Empty (the local default) means the
+	// browse origin uses ".mesh.localhost" (loopback, secure-context, no cert).
+	BrowseOriginSuffix     string `json:"browse_origin_suffix,omitempty"`
 	DmsgDiscoveryDmsg      string `json:"dmsg_discovery_dmsg,omitempty"`
 	TransportDiscoveryDmsg string `json:"transport_discovery_dmsg,omitempty"`
 	AddressResolverDmsg    string `json:"address_resolver_dmsg,omitempty"`

--- a/deployment/data_static_js.go
+++ b/deployment/data_static_js.go
@@ -52,8 +52,9 @@ var prodData = Services{
 		mustPubKey("0327e2cf1d2e516ecbfdbd616a87489cc92a73af97335d5c8c29eafb5d8882264a"),
 		mustPubKey("03abbb3eff140cf3dce468b3fa5a28c80fa02c6703d7b952be6faaf2050990ebf4"),
 	},
-	ConfDmsg:        "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
-	WSSDomainSuffix: "theskywirenetwork.net",
+	ConfDmsg:           "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
+	WSSDomainSuffix:    "theskywirenetwork.net",
+	BrowseOriginSuffix: ".haltingstate.net",
 	DmsgServers: []DmsgServerEntry{
 		{Static: "0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb", Server: struct {
 			Address   string `json:"address"`
@@ -133,8 +134,9 @@ var testData = Services{
 		mustPubKey("0327e2cf1d2e516ecbfdbd616a87489cc92a73af97335d5c8c29eafb5d8882264a"),
 		mustPubKey("03abbb3eff140cf3dce468b3fa5a28c80fa02c6703d7b952be6faaf2050990ebf4"),
 	},
-	ConfDmsg:        "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
-	WSSDomainSuffix: "theskywirenetwork.net",
+	ConfDmsg:           "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
+	WSSDomainSuffix:    "theskywirenetwork.net",
+	BrowseOriginSuffix: ".haltingstate.net",
 	DmsgServers: []DmsgServerEntry{
 		{Static: "0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb", Server: struct {
 			Address   string `json:"address"`

--- a/deployment/services-config.json
+++ b/deployment/services-config.json
@@ -2,6 +2,7 @@
   "test": {
     "conf_dmsg": "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
     "wss_domain_suffix": "theskywirenetwork.net",
+    "browse_origin_suffix": ".haltingstate.net",
     "route_setup_nodes": [
       "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557",
       "024fbd3997d4260f731b01abcfce60b8967a6d4c6a11d1008812810ea1437ce438"
@@ -97,6 +98,7 @@
   "prod": {
     "conf_dmsg": "dmsg://021f751cb8690a96585e10c4d253513cd208bd659fd4f6c227ad49d2b75eec1ff2:80",
     "wss_domain_suffix": "theskywirenetwork.net",
+    "browse_origin_suffix": ".haltingstate.net",
     "route_setup_nodes": [
       "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557",
       "024fbd3997d4260f731b01abcfce60b8967a6d4c6a11d1008812810ea1437ce438"


### PR DESCRIPTION
## What

The real-origin browse path's domain (`.haltingstate.net` — the separate eTLD+1 that isolates untrusted *browsed* content from the visor app served on `wss_domain_suffix`) was only ever an **example string** in flag help and doc comments; it was never defined in a single source of truth. This adds it to the embedded deployment config as `browse_origin_suffix`, mirroring `wss_domain_suffix` end-to-end.

## Changes

- `deployment.Services` gains `BrowseOriginSuffix` (`json:"browse_origin_suffix"`). Native unmarshals it from `services-config.json`; `deployment/cmd/gen` emits it into the wasm static literals (`data_static_js.go` regenerated).
- `services-config.json` (prod + test) carries `browse_origin_suffix: ".haltingstate.net"`.
- `skywire cli hv serve`: in **hosted mode** (`--browse-origin` set) with no explicit `--browse-suffix`, the browse-origin domain now defaults to `deployment.Prod.BrowseOriginSuffix` instead of the operator hardcoding it; the flag help text is sourced from the embedded value too. **Local mode is unchanged** (empty suffix → `.mesh.localhost`, loopback secure context, no cert).

## Verified

`go build ./...` clean, `go vet`/`golangci-lint` clean; `deployment.Prod.BrowseOriginSuffix` resolves to `".haltingstate.net"` on both native (json) and the regenerated wasm static literal; `hv serve --help` prints the value sourced from the embedded config.