### PR TITLE
fix(router): full-duplex self-heal mux leg + local-calc-first GROW — make mux>1 carry

### DIFF
--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -2216,7 +2216,17 @@ func (r *router) addOneAuxForwardLeg(ctx context.Context, nrg *NoiseRouteGroup, 
 	if err != nil {
 		return fmt.Errorf("rotation add-leg: setup-node dial: %w", err)
 	}
-	if err := r.appendRouteAsymmetric(nrg, muxRules, true, false); err != nil {
+	// Append the replacement leg FULL-DUPLEX (forward + reverse). Forward-only
+	// deletes the initiator's consume (reverse) rule for this leg — but the
+	// setup-node dial already installed that rule on the far end, which marks the
+	// leg ready on our forward handshake and then spreads its bulk (download)
+	// stream onto it. With the initiator's consume rule gone those packets are
+	// dropped (errRouteDescNotExist), so the leg black-holes (recv=0) and, because
+	// the reorder buffer is lossless, the missing sequences head-of-line-stall the
+	// primary leg too — a net 0-byte transfer. aliveLegCount counts forward legs,
+	// so a send-only leg still satisfies the degree target while being a download
+	// blackhole. Keeping the reverse rule lets the aggregated download land here.
+	if err := r.appendRouteAsymmetric(nrg, muxRules, true, true); err != nil {
 		return fmt.Errorf("rotation add-leg: append: %w", err)
 	}
 	log.Infof("Rotation aux leg established via tp %s", muxRules.Forward.NextTransportID())

--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -340,9 +340,18 @@ func (r *router) GrowMuxRoute(desc routing.RouteDescriptor, target, minHops int)
 			ExcludeDMSG:            true,
 		}
 
-		fwd, rev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
+		// Local calc FIRST, route-finder as fallback — mirroring establishMuxRoutes
+		// and addOneAuxForwardLeg. calculateLocalRoutes honors ExcludeTransportIDs
+		// (and ExcludeIntermediatePKs), so it returns a leg disjoint from the ones
+		// already in the group. The route-finder SERVICE ignores ExcludeTransportIDs,
+		// so querying it first for a direct pair hands back the very transport we are
+		// excluding; the append then rejects it ("refusing to append mux leg over
+		// transport already in the group") and the self-heal loops without ever
+		// growing. The route-finder is still the fallback for a disjoint deep-hop the
+		// local transport cache doesn't cover.
+		fwd, rev, err := r.calculateLocalRoutes(ctx, log, lPK, rPK, muxOpts)
 		if err != nil {
-			fwd, rev, err = r.calculateLocalRoutes(ctx, log, lPK, rPK, muxOpts)
+			fwd, rev, err = r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
 		}
 		if err != nil {
 			consecutiveFailures++


### PR DESCRIPTION
## Problem

Once a multiplexed route group had a second leg, it wedged: the aux leg received **0 bytes** and the primary leg stalled with it → net 0-byte transfer, even though `mux=1` was fine and the leg count reported the degree satisfied. (Follows the data-plane corruption fix #3955; this is the *setup*-side half.)

## Root causes (two, both localized)

1. **Forward-only self-heal leg** (`router_dial.go`, `addOneAuxForwardLeg`). The self-heal/rotation appended the replacement leg `appendRouteAsymmetric(..., true, false)`, which **deletes the initiator's consume (reverse) rule** for that leg — but the setup-node dial already installed it on the far end, which marks the leg ready on our forward handshake and then spreads its bulk (download) stream onto it. With no consume rule those packets are dropped (`errRouteDescNotExist`), so the aux leg **black-holes** (recv=0); and because the reorder buffer is lossless (#3955), the missing sequences **head-of-line-stall the primary leg** too. `aliveLegCount` counts forward legs, so a send-only leg still satisfies the degree target while being a download blackhole. → Append the replacement **full-duplex** (`true, true`) so the aggregated download lands on a leg the initiator can receive on.

2. **RF-first GROW ordering** (`router_mux_ops.go`, `GrowMuxRoute`). It queried the route-finder **service** first and fell back to local calc only on error. The RF service ignores `ExcludeTransportIDs`, so for a direct pair it returns the transport already in the group; the append rejects it (`refusing to append mux leg over transport already in the group`) and the self-heal loops without growing. `calculateLocalRoutes` honors the excludes (it's what `route calc` uses to find disjoint routes). → Local-calc first, RF as deep-hop fallback — matching `establishMuxRoutes` and `addOneAuxForwardLeg`.

## Live validation

On the running visor (develop + this fix), mux=2 to a WAN far-end over two direct transports:
- **Before:** aux leg recv=0, download wedged at 0 bytes.
- **After:** **5/5 downloads complete**, per-leg byte counters split ~50/50 (`L0=260.7M / L1=261.1M`); `mux=1` throughput unchanged (no regression). The aux-leg blackhole is gone.

## Note

This makes mux>1 **carry** correctly (the correctness fix). Demonstrating bandwidth *aggregation* (median throughput of disjoint-intermediate legs exceeding single-route) is a separate, topology-dependent property and is still being validated live on a disjoint-capable far-end; two *direct* legs to the same peer share one pipe and are expected to split, not aggregate. Router package tests pass.