### PR TITLE
feat(mux-bw): emit per-leg bandwidth + identity samples for policy measurement

### DIFF
--- a/cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go
+++ b/cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go
@@ -340,6 +340,11 @@ type muxBwTracker struct {
 	routeFailure []*rpcgrpc.MuxRouteFailure
 	done         *rpcgrpc.MuxBandwidthDone
 	srvErr       string
+	// lastSample retains the most recent per-second sample so the
+	// final summary can print a one-line-per-leg breakdown (cumulative
+	// bytes + last-interval rates + the leg's intermediate/transport
+	// identity). The aggregate totals still come from the Done event.
+	lastSample *rpcgrpc.MuxBandwidthSample
 }
 
 func newMuxBwTracker() *muxBwTracker {
@@ -352,6 +357,8 @@ func (t *muxBwTracker) record(ev *rpcgrpc.MuxBandwidthEvent) {
 		t.routeSet = append(t.routeSet, p.RouteEstablished)
 	case *rpcgrpc.MuxBandwidthEvent_RouteFailure:
 		t.routeFailure = append(t.routeFailure, p.RouteFailure)
+	case *rpcgrpc.MuxBandwidthEvent_Sample:
+		t.lastSample = p.Sample
 	case *rpcgrpc.MuxBandwidthEvent_Done:
 		t.done = p.Done
 	case *rpcgrpc.MuxBandwidthEvent_Error:
@@ -389,6 +396,41 @@ func (t *muxBwTracker) printSummary(w io.Writer) {
 				float64(r.SetupLatencyNs)/1e6, len(r.Hops), path, extra)
 		}
 		tw.Flush() //nolint:errcheck,gosec
+	}
+
+	// Per-leg bandwidth breakdown, read off the final sample. Cheap
+	// (one line per leg, once) and gives the policy-measurement
+	// operator each leg's cumulative bytes + last-interval rates +
+	// distinguishing intermediate/transport at a glance.
+	if t.lastSample != nil && len(t.lastSample.Legs) > 0 {
+		fmt.Fprintln(w, "\nper-leg (final sample):") //nolint:errcheck
+		lw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		//nolint:errcheck // human-mode summary; errors here aren't actionable
+		fmt.Fprintln(lw, "leg\talive\ttp\tintermediate\tsent\trecv\tinst_send\tinst_recv")
+		legs := t.lastSample.Legs
+		sort.Slice(legs, func(i, j int) bool {
+			return legs[i].RouteIndex < legs[j].RouteIndex
+		})
+		for _, l := range legs {
+			alive := "✓"
+			if !l.Alive {
+				alive = "✗"
+			}
+			inter := l.IntermediatePk
+			if inter == "" {
+				inter = "(direct)"
+			}
+			tp := l.TransportKind
+			if tp == "" {
+				tp = "-"
+			}
+			//nolint:errcheck // human-mode summary; errors here aren't actionable
+			fmt.Fprintf(lw, "R%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				l.RouteIndex, alive, tp, inter,
+				fmtBytes(uint64(l.BytesSent)), fmtBytes(uint64(l.BytesRecv)), //nolint:gosec // non-negative byte totals
+				fmtBps(l.InstSendBps), fmtBps(l.InstRecvBps))
+		}
+		lw.Flush() //nolint:errcheck,gosec
 	}
 
 	if t.done == nil {

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -3427,7 +3427,14 @@ type MuxBandwidthSample struct {
 	AvgRecvBps     float64 `protobuf:"fixed64,7,opt,name=avg_recv_bps,json=avgRecvBps,proto3" json:"avg_recv_bps,omitempty"`
 	// ActiveRoutes is how many of the Routes-requested routes are
 	// still pumping. Drops when a route fails mid-run.
-	ActiveRoutes  int32 `protobuf:"varint,8,opt,name=active_routes,json=activeRoutes,proto3" json:"active_routes,omitempty"`
+	ActiveRoutes int32 `protobuf:"varint,8,opt,name=active_routes,json=activeRoutes,proto3" json:"active_routes,omitempty"`
+	// Legs is the per-route breakdown for this sample interval. One
+	// entry per established route, in route-index order. Additive to
+	// the aggregate fields above: consumers measuring adaptive routing
+	// policies read per-leg bandwidth + identity over time from here,
+	// while consumers wanting only the total keep using the aggregate
+	// fields. Empty on runs where no route came up.
+	Legs          []*MuxLegSample `protobuf:"bytes,9,rep,name=legs,proto3" json:"legs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3518,6 +3525,138 @@ func (x *MuxBandwidthSample) GetActiveRoutes() int32 {
 	return 0
 }
 
+func (x *MuxBandwidthSample) GetLegs() []*MuxLegSample {
+	if x != nil {
+		return x.Legs
+	}
+	return nil
+}
+
+// MuxLegSample is one route's contribution within a single
+// MuxBandwidthSample interval. It carries both the leg's cumulative
+// byte counters and its per-interval instantaneous rates, plus the
+// identity fields (intermediate PK + first-hop transport kind) that
+// distinguish this leg from the others — so a policy-measurement
+// consumer can attribute throughput to a specific path over time.
+type MuxLegSample struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// RouteIndex is the same 0..Routes-1 index from the matching
+	// MuxRouteEstablished event, letting consumers join a leg's
+	// per-sample series back to its established path.
+	RouteIndex int32 `protobuf:"varint,1,opt,name=route_index,json=routeIndex,proto3" json:"route_index,omitempty"`
+	// IntermediatePk is the first hop's `to` PK — the leg's
+	// distinguishing intermediate. Empty when the route is direct
+	// (single hop straight to the target, no intermediate).
+	IntermediatePk string `protobuf:"bytes,2,opt,name=intermediate_pk,json=intermediatePk,proto3" json:"intermediate_pk,omitempty"`
+	// TransportKind is the first hop's transport type (stcpr, sudph,
+	// dmsg, ...). Lets consumers correlate per-leg throughput with the
+	// carrier the leg egresses on.
+	TransportKind string `protobuf:"bytes,3,opt,name=transport_kind,json=transportKind,proto3" json:"transport_kind,omitempty"`
+	// BytesSent / BytesRecv are cumulative for this leg since pump
+	// start (NOT since the last sample) — same epoch as the aggregate
+	// MuxBandwidthSample.BytesSent.
+	BytesSent int64 `protobuf:"varint,4,opt,name=bytes_sent,json=bytesSent,proto3" json:"bytes_sent,omitempty"`
+	BytesRecv int64 `protobuf:"varint,5,opt,name=bytes_recv,json=bytesRecv,proto3" json:"bytes_recv,omitempty"`
+	// InstSendBps / InstRecvBps are this leg's per-interval rates
+	// (delta since the previous sample), in bits-per-second — mirrors
+	// how MuxBandwidthSample.InstantSendBps is computed for the
+	// aggregate.
+	InstSendBps float64 `protobuf:"fixed64,6,opt,name=inst_send_bps,json=instSendBps,proto3" json:"inst_send_bps,omitempty"`
+	InstRecvBps float64 `protobuf:"fixed64,7,opt,name=inst_recv_bps,json=instRecvBps,proto3" json:"inst_recv_bps,omitempty"`
+	// Alive is the route's not-failed state — true while the leg's
+	// pump goroutine is still running. Matches the accounting behind
+	// MuxBandwidthSample.ActiveRoutes.
+	Alive         bool `protobuf:"varint,8,opt,name=alive,proto3" json:"alive,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MuxLegSample) Reset() {
+	*x = MuxLegSample{}
+	mi := &file_ping_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuxLegSample) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuxLegSample) ProtoMessage() {}
+
+func (x *MuxLegSample) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuxLegSample.ProtoReflect.Descriptor instead.
+func (*MuxLegSample) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *MuxLegSample) GetRouteIndex() int32 {
+	if x != nil {
+		return x.RouteIndex
+	}
+	return 0
+}
+
+func (x *MuxLegSample) GetIntermediatePk() string {
+	if x != nil {
+		return x.IntermediatePk
+	}
+	return ""
+}
+
+func (x *MuxLegSample) GetTransportKind() string {
+	if x != nil {
+		return x.TransportKind
+	}
+	return ""
+}
+
+func (x *MuxLegSample) GetBytesSent() int64 {
+	if x != nil {
+		return x.BytesSent
+	}
+	return 0
+}
+
+func (x *MuxLegSample) GetBytesRecv() int64 {
+	if x != nil {
+		return x.BytesRecv
+	}
+	return 0
+}
+
+func (x *MuxLegSample) GetInstSendBps() float64 {
+	if x != nil {
+		return x.InstSendBps
+	}
+	return 0
+}
+
+func (x *MuxLegSample) GetInstRecvBps() float64 {
+	if x != nil {
+		return x.InstRecvBps
+	}
+	return 0
+}
+
+func (x *MuxLegSample) GetAlive() bool {
+	if x != nil {
+		return x.Alive
+	}
+	return false
+}
+
 // MuxRttProbe is one RTT measurement during the pump. Allows
 // consumers to plot loaded-RTT-over-time and compute queueing delay
 // as (loaded_rtt - baseline_rtt).
@@ -3539,7 +3678,7 @@ type MuxRttProbe struct {
 
 func (x *MuxRttProbe) Reset() {
 	*x = MuxRttProbe{}
-	mi := &file_ping_proto_msgTypes[37]
+	mi := &file_ping_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3551,7 +3690,7 @@ func (x *MuxRttProbe) String() string {
 func (*MuxRttProbe) ProtoMessage() {}
 
 func (x *MuxRttProbe) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[37]
+	mi := &file_ping_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3564,7 +3703,7 @@ func (x *MuxRttProbe) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MuxRttProbe.ProtoReflect.Descriptor instead.
 func (*MuxRttProbe) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{37}
+	return file_ping_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *MuxRttProbe) GetSequence() int64 {
@@ -3640,7 +3779,7 @@ type MuxBandwidthDone struct {
 
 func (x *MuxBandwidthDone) Reset() {
 	*x = MuxBandwidthDone{}
-	mi := &file_ping_proto_msgTypes[38]
+	mi := &file_ping_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3652,7 +3791,7 @@ func (x *MuxBandwidthDone) String() string {
 func (*MuxBandwidthDone) ProtoMessage() {}
 
 func (x *MuxBandwidthDone) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[38]
+	mi := &file_ping_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3665,7 +3804,7 @@ func (x *MuxBandwidthDone) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MuxBandwidthDone.ProtoReflect.Descriptor instead.
 func (*MuxBandwidthDone) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{38}
+	return file_ping_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *MuxBandwidthDone) GetTotalBytesSent() uint64 {
@@ -3834,7 +3973,7 @@ type MuxBandwidthError struct {
 
 func (x *MuxBandwidthError) Reset() {
 	*x = MuxBandwidthError{}
-	mi := &file_ping_proto_msgTypes[39]
+	mi := &file_ping_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3846,7 +3985,7 @@ func (x *MuxBandwidthError) String() string {
 func (*MuxBandwidthError) ProtoMessage() {}
 
 func (x *MuxBandwidthError) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[39]
+	mi := &file_ping_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3859,7 +3998,7 @@ func (x *MuxBandwidthError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MuxBandwidthError.ProtoReflect.Descriptor instead.
 func (*MuxBandwidthError) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{39}
+	return file_ping_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *MuxBandwidthError) GetCode() string {
@@ -4179,7 +4318,7 @@ const file_ping_proto_rawDesc = "" +
 	"\x19bytes_sent_before_failure\x18\x03 \x01(\x04R\x16bytesSentBeforeFailure\x12A\n" +
 	"\x1dbytes_received_before_failure\x18\x04 \x01(\x04R\x1abytesReceivedBeforeFailure\x12\x1d\n" +
 	"\n" +
-	"elapsed_ns\x18\x05 \x01(\x03R\telapsedNs\"\xb6\x02\n" +
+	"elapsed_ns\x18\x05 \x01(\x03R\telapsedNs\"\xe1\x02\n" +
 	"\x12MuxBandwidthSample\x12\x1d\n" +
 	"\n" +
 	"elapsed_ns\x18\x01 \x01(\x03R\telapsedNs\x12\x1d\n" +
@@ -4192,7 +4331,20 @@ const file_ping_proto_rawDesc = "" +
 	"avgSendBps\x12 \n" +
 	"\favg_recv_bps\x18\a \x01(\x01R\n" +
 	"avgRecvBps\x12#\n" +
-	"\ractive_routes\x18\b \x01(\x05R\factiveRoutes\"}\n" +
+	"\ractive_routes\x18\b \x01(\x05R\factiveRoutes\x12)\n" +
+	"\x04legs\x18\t \x03(\v2\x15.rpcgrpc.MuxLegSampleR\x04legs\"\x9b\x02\n" +
+	"\fMuxLegSample\x12\x1f\n" +
+	"\vroute_index\x18\x01 \x01(\x05R\n" +
+	"routeIndex\x12'\n" +
+	"\x0fintermediate_pk\x18\x02 \x01(\tR\x0eintermediatePk\x12%\n" +
+	"\x0etransport_kind\x18\x03 \x01(\tR\rtransportKind\x12\x1d\n" +
+	"\n" +
+	"bytes_sent\x18\x04 \x01(\x03R\tbytesSent\x12\x1d\n" +
+	"\n" +
+	"bytes_recv\x18\x05 \x01(\x03R\tbytesRecv\x12\"\n" +
+	"\rinst_send_bps\x18\x06 \x01(\x01R\vinstSendBps\x12\"\n" +
+	"\rinst_recv_bps\x18\a \x01(\x01R\vinstRecvBps\x12\x14\n" +
+	"\x05alive\x18\b \x01(\bR\x05alive\"}\n" +
 	"\vMuxRttProbe\x12\x1a\n" +
 	"\bsequence\x18\x01 \x01(\x03R\bsequence\x12\x1d\n" +
 	"\n" +
@@ -4263,7 +4415,7 @@ func file_ping_proto_rawDescGZIP() []byte {
 	return file_ping_proto_rawDescData
 }
 
-var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 41)
+var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
 var file_ping_proto_goTypes = []any{
 	(*PingRequest)(nil),              // 0: rpcgrpc.PingRequest
 	(*PingResult)(nil),               // 1: rpcgrpc.PingResult
@@ -4302,10 +4454,11 @@ var file_ping_proto_goTypes = []any{
 	(*MuxRouteEstablished)(nil),      // 34: rpcgrpc.MuxRouteEstablished
 	(*MuxRouteFailure)(nil),          // 35: rpcgrpc.MuxRouteFailure
 	(*MuxBandwidthSample)(nil),       // 36: rpcgrpc.MuxBandwidthSample
-	(*MuxRttProbe)(nil),              // 37: rpcgrpc.MuxRttProbe
-	(*MuxBandwidthDone)(nil),         // 38: rpcgrpc.MuxBandwidthDone
-	(*MuxBandwidthError)(nil),        // 39: rpcgrpc.MuxBandwidthError
-	nil,                              // 40: rpcgrpc.AppLogEntry.FieldsEntry
+	(*MuxLegSample)(nil),             // 37: rpcgrpc.MuxLegSample
+	(*MuxRttProbe)(nil),              // 38: rpcgrpc.MuxRttProbe
+	(*MuxBandwidthDone)(nil),         // 39: rpcgrpc.MuxBandwidthDone
+	(*MuxBandwidthError)(nil),        // 40: rpcgrpc.MuxBandwidthError
+	nil,                              // 41: rpcgrpc.AppLogEntry.FieldsEntry
 }
 var file_ping_proto_depIdxs = []int32{
 	4,  // 0: rpcgrpc.PingRequest.forward_hops:type_name -> rpcgrpc.RouteHop
@@ -4319,7 +4472,7 @@ var file_ping_proto_depIdxs = []int32{
 	14, // 8: rpcgrpc.SystemStats.network:type_name -> rpcgrpc.NetworkStat
 	15, // 9: rpcgrpc.SystemStats.temps:type_name -> rpcgrpc.TempStat
 	23, // 10: rpcgrpc.SystemStats.processes:type_name -> rpcgrpc.ProcessStat
-	40, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
+	41, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
 	20, // 12: rpcgrpc.CalcRoute.hops:type_name -> rpcgrpc.CalcHop
 	26, // 13: rpcgrpc.PingTreeEvent.discovered:type_name -> rpcgrpc.PingTreeDiscovered
 	27, // 14: rpcgrpc.PingTreeEvent.ping_result:type_name -> rpcgrpc.PingTreeResult
@@ -4330,42 +4483,43 @@ var file_ping_proto_depIdxs = []int32{
 	4,  // 19: rpcgrpc.PingTreeResult.route:type_name -> rpcgrpc.RouteHop
 	34, // 20: rpcgrpc.MuxBandwidthEvent.route_established:type_name -> rpcgrpc.MuxRouteEstablished
 	36, // 21: rpcgrpc.MuxBandwidthEvent.sample:type_name -> rpcgrpc.MuxBandwidthSample
-	37, // 22: rpcgrpc.MuxBandwidthEvent.rtt_probe:type_name -> rpcgrpc.MuxRttProbe
-	38, // 23: rpcgrpc.MuxBandwidthEvent.done:type_name -> rpcgrpc.MuxBandwidthDone
-	39, // 24: rpcgrpc.MuxBandwidthEvent.error:type_name -> rpcgrpc.MuxBandwidthError
+	38, // 22: rpcgrpc.MuxBandwidthEvent.rtt_probe:type_name -> rpcgrpc.MuxRttProbe
+	39, // 23: rpcgrpc.MuxBandwidthEvent.done:type_name -> rpcgrpc.MuxBandwidthDone
+	40, // 24: rpcgrpc.MuxBandwidthEvent.error:type_name -> rpcgrpc.MuxBandwidthError
 	35, // 25: rpcgrpc.MuxBandwidthEvent.route_failure:type_name -> rpcgrpc.MuxRouteFailure
 	4,  // 26: rpcgrpc.MuxRouteEstablished.hops:type_name -> rpcgrpc.RouteHop
-	0,  // 27: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
-	0,  // 28: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
-	5,  // 29: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	5,  // 30: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	2,  // 31: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
-	7,  // 32: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	7,  // 33: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	8,  // 34: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
-	16, // 35: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
-	18, // 36: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
-	21, // 37: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
-	24, // 38: rpcgrpc.PingService.StreamPingTree:input_type -> rpcgrpc.PingTreeRequest
-	32, // 39: rpcgrpc.PingService.StreamMuxBandwidth:input_type -> rpcgrpc.MuxBandwidthRequest
-	1,  // 40: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
-	1,  // 41: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
-	6,  // 42: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	6,  // 43: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	3,  // 44: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
-	9,  // 45: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 46: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 47: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
-	17, // 48: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
-	19, // 49: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
-	22, // 50: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
-	25, // 51: rpcgrpc.PingService.StreamPingTree:output_type -> rpcgrpc.PingTreeEvent
-	33, // 52: rpcgrpc.PingService.StreamMuxBandwidth:output_type -> rpcgrpc.MuxBandwidthEvent
-	40, // [40:53] is the sub-list for method output_type
-	27, // [27:40] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	37, // 27: rpcgrpc.MuxBandwidthSample.legs:type_name -> rpcgrpc.MuxLegSample
+	0,  // 28: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
+	0,  // 29: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
+	5,  // 30: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	5,  // 31: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	2,  // 32: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
+	7,  // 33: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	7,  // 34: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	8,  // 35: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
+	16, // 36: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
+	18, // 37: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
+	21, // 38: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
+	24, // 39: rpcgrpc.PingService.StreamPingTree:input_type -> rpcgrpc.PingTreeRequest
+	32, // 40: rpcgrpc.PingService.StreamMuxBandwidth:input_type -> rpcgrpc.MuxBandwidthRequest
+	1,  // 41: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
+	1,  // 42: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
+	6,  // 43: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	6,  // 44: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	3,  // 45: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
+	9,  // 46: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 47: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 48: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
+	17, // 49: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
+	19, // 50: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
+	22, // 51: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
+	25, // 52: rpcgrpc.PingService.StreamPingTree:output_type -> rpcgrpc.PingTreeEvent
+	33, // 53: rpcgrpc.PingService.StreamMuxBandwidth:output_type -> rpcgrpc.MuxBandwidthEvent
+	41, // [41:54] is the sub-list for method output_type
+	28, // [28:41] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_ping_proto_init() }
@@ -4395,7 +4549,7 @@ func file_ping_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ping_proto_rawDesc), len(file_ping_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   41,
+			NumMessages:   42,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -733,6 +733,49 @@ message MuxBandwidthSample {
   // ActiveRoutes is how many of the Routes-requested routes are
   // still pumping. Drops when a route fails mid-run.
   int32 active_routes = 8;
+  // Legs is the per-route breakdown for this sample interval. One
+  // entry per established route, in route-index order. Additive to
+  // the aggregate fields above: consumers measuring adaptive routing
+  // policies read per-leg bandwidth + identity over time from here,
+  // while consumers wanting only the total keep using the aggregate
+  // fields. Empty on runs where no route came up.
+  repeated MuxLegSample legs = 9;
+}
+
+// MuxLegSample is one route's contribution within a single
+// MuxBandwidthSample interval. It carries both the leg's cumulative
+// byte counters and its per-interval instantaneous rates, plus the
+// identity fields (intermediate PK + first-hop transport kind) that
+// distinguish this leg from the others — so a policy-measurement
+// consumer can attribute throughput to a specific path over time.
+message MuxLegSample {
+  // RouteIndex is the same 0..Routes-1 index from the matching
+  // MuxRouteEstablished event, letting consumers join a leg's
+  // per-sample series back to its established path.
+  int32 route_index = 1;
+  // IntermediatePk is the first hop's `to` PK — the leg's
+  // distinguishing intermediate. Empty when the route is direct
+  // (single hop straight to the target, no intermediate).
+  string intermediate_pk = 2;
+  // TransportKind is the first hop's transport type (stcpr, sudph,
+  // dmsg, ...). Lets consumers correlate per-leg throughput with the
+  // carrier the leg egresses on.
+  string transport_kind = 3;
+  // BytesSent / BytesRecv are cumulative for this leg since pump
+  // start (NOT since the last sample) — same epoch as the aggregate
+  // MuxBandwidthSample.BytesSent.
+  int64 bytes_sent = 4;
+  int64 bytes_recv = 5;
+  // InstSendBps / InstRecvBps are this leg's per-interval rates
+  // (delta since the previous sample), in bits-per-second — mirrors
+  // how MuxBandwidthSample.InstantSendBps is computed for the
+  // aggregate.
+  double inst_send_bps = 6;
+  double inst_recv_bps = 7;
+  // Alive is the route's not-failed state — true while the leg's
+  // pump goroutine is still running. Matches the accounting behind
+  // MuxBandwidthSample.ActiveRoutes.
+  bool alive = 8;
 }
 
 // MuxRttProbe is one RTT measurement during the pump. Allows

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth.go
@@ -516,6 +516,15 @@ func (s *PingServer) muxBwPlanDisjointRoutes(
 		return nil, fmt.Errorf("no transport entries available")
 	}
 
+	// TpID -> carrier kind, so each planned hop can carry its transport
+	// type for per-leg telemetry (routing.Hop drops it).
+	tpTypes := make(map[string]string, len(entries))
+	for _, e := range entries {
+		if e != nil {
+			tpTypes[e.ID.String()] = string(e.Type)
+		}
+	}
+
 	graph, err := routeFinder.NewGraphWithDepth(ctx, newCalcMemStore(entries), srcPK, maxHops)
 	if err != nil {
 		return nil, fmt.Errorf("build graph: %w", err)
@@ -533,7 +542,7 @@ func (s *PingServer) muxBwPlanDisjointRoutes(
 					return true
 				}
 			}
-			fwd := muxBwRoutingHopsToInfo(r.Hops)
+			fwd := muxBwRoutingHopsToInfo(r.Hops, tpTypes)
 			plans = append(plans, muxBwRoutePlan{forward: fwd, reverse: muxBwReverseHops(fwd)})
 			for _, pk := range inter {
 				usedInter[pk] = struct{}{}
@@ -571,16 +580,21 @@ func muxBwIntermediates(r routing.Route, src, dst cipher.PubKey) []cipher.PubKey
 }
 
 // muxBwRoutingHopsToInfo converts route-finder routing.Hops into the
-// RouteHopInfo wire shape the explicit-hops dial path consumes. Only
-// TpID/From/To are carried — TpType is unused by PingContextWithRoute (it
-// resolves the transport by TpID), matching StreamCalcRoutes' emit.
-func muxBwRoutingHopsToInfo(hops []routing.Hop) []RouteHopInfo {
+// RouteHopInfo wire shape the explicit-hops dial path consumes. TpID/From/To
+// drive the dial (PingContextWithRoute resolves the transport by TpID);
+// TpType is filled from tpTypes (TpID -> carrier kind) purely so the plan can
+// serve as the per-leg identity source for telemetry — the explicit-hops dial
+// leaves the conn's RouteHopDetails empty, so the plan is the only reliable
+// place to read each leg's intermediate PK + carrier from.
+func muxBwRoutingHopsToInfo(hops []routing.Hop, tpTypes map[string]string) []RouteHopInfo {
 	out := make([]RouteHopInfo, 0, len(hops))
 	for _, h := range hops {
+		id := h.TpID.String()
 		out = append(out, RouteHopInfo{
-			TpID: h.TpID.String(),
-			From: h.From.String(),
-			To:   h.To.String(),
+			TpID:   id,
+			From:   h.From.String(),
+			To:     h.To.String(),
+			TpType: tpTypes[id],
 		})
 	}
 	return out
@@ -592,7 +606,7 @@ func muxBwRoutingHopsToInfo(hops []routing.Hop) []RouteHopInfo {
 func muxBwReverseHops(fwd []RouteHopInfo) []RouteHopInfo {
 	rev := make([]RouteHopInfo, len(fwd))
 	for i, h := range fwd {
-		rev[len(fwd)-1-i] = RouteHopInfo{TpID: h.TpID, From: h.To, To: h.From}
+		rev[len(fwd)-1-i] = RouteHopInfo{TpID: h.TpID, From: h.To, To: h.From, TpType: h.TpType}
 	}
 	return rev
 }
@@ -665,13 +679,26 @@ func (s *PingServer) muxBwSetupRoute(
 		// (mux-bw NDJSON, mux-bw-tui dashboard, treeprobe harness)
 		// can verify route diversity from this field.
 		ref := PingRouteRef{PK: cfg.TargetPK, Index: rs.index}
-		hops := s.visor.GetPingRouteDetailsAt(ref)
-		for _, h := range hops {
+		// Normalize the leg's hops to (tpID, from, to, tpType) tuples. Prefer
+		// the conn's recorded details; the explicit-hops dial path (disjoint
+		// planner) leaves those empty, so fall back to this leg's plan hops
+		// (rs.fwdHops) — authoritative for what we actually dialed.
+		type hopTuple struct{ tpID, from, to, tpType string }
+		var hopTuples []hopTuple
+		for _, h := range s.visor.GetPingRouteDetailsAt(ref) {
+			hopTuples = append(hopTuples, hopTuple{h.TpID, h.From, h.To, h.TpType})
+		}
+		if len(hopTuples) == 0 {
+			for _, h := range rs.fwdHops {
+				hopTuples = append(hopTuples, hopTuple{h.TpID, h.From, h.To, h.TpType})
+			}
+		}
+		for _, h := range hopTuples {
 			ev.Hops = append(ev.Hops, &RouteHop{
-				TpId:   h.TpID,
-				From:   h.From,
-				To:     h.To,
-				TpType: h.TpType,
+				TpId:   h.tpID,
+				From:   h.from,
+				To:     h.to,
+				TpType: h.tpType,
 			})
 		}
 		// Capture the leg's identity from its first hop for the
@@ -679,10 +706,10 @@ func (s *PingServer) muxBwSetupRoute(
 		// egresses on; intermediatePK = the first intermediate visor
 		// (first hop's `to`), left empty for a direct route where the
 		// only hop lands straight on the target (no intermediate).
-		if len(hops) > 0 {
-			rs.transportKind = hops[0].TpType
-			if len(hops) > 1 {
-				rs.intermediatePK = hops[0].To
+		if len(hopTuples) > 0 {
+			rs.transportKind = hopTuples[0].tpType
+			if len(hopTuples) > 1 {
+				rs.intermediatePK = hopTuples[0].to
 			}
 		}
 	}

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth.go
@@ -147,6 +147,19 @@ type muxBwRouteState struct {
 	// (MinHops), preserving prior behavior.
 	fwdHops []RouteHopInfo
 	revHops []RouteHopInfo
+	// intermediatePK / transportKind are this leg's distinguishing
+	// identity, captured from the route's chosen FIRST hop during
+	// setup (the same hop data the route_established event carries).
+	// intermediatePK is the first hop's `to` PK — the first
+	// intermediate — left empty for a direct (single-hop) route.
+	// transportKind is the first hop's transport type (stcpr, sudph,
+	// dmsg, ...). Both are written once in muxBwSetupRoute, on the
+	// success path, BEFORE the pump phase begins (the setup
+	// WaitGroup happens-before the sampler goroutine), then only read
+	// by the sampler — so plain fields are race-free and need no
+	// atomics.
+	intermediatePK string
+	transportKind  string
 }
 
 // StreamMuxBandwidth is the canonical implementation of the RPC.
@@ -652,13 +665,25 @@ func (s *PingServer) muxBwSetupRoute(
 		// (mux-bw NDJSON, mux-bw-tui dashboard, treeprobe harness)
 		// can verify route diversity from this field.
 		ref := PingRouteRef{PK: cfg.TargetPK, Index: rs.index}
-		for _, h := range s.visor.GetPingRouteDetailsAt(ref) {
+		hops := s.visor.GetPingRouteDetailsAt(ref)
+		for _, h := range hops {
 			ev.Hops = append(ev.Hops, &RouteHop{
 				TpId:   h.TpID,
 				From:   h.From,
 				To:     h.To,
 				TpType: h.TpType,
 			})
+		}
+		// Capture the leg's identity from its first hop for the
+		// per-leg sampler. transportKind = the carrier this leg
+		// egresses on; intermediatePK = the first intermediate visor
+		// (first hop's `to`), left empty for a direct route where the
+		// only hop lands straight on the target (no intermediate).
+		if len(hops) > 0 {
+			rs.transportKind = hops[0].TpType
+			if len(hops) > 1 {
+				rs.intermediatePK = hops[0].To
+			}
 		}
 	}
 	emit(&MuxBandwidthEvent_RouteEstablished{RouteEstablished: ev})
@@ -764,6 +789,13 @@ func (s *PingServer) muxBwSamplerLoop(
 	var lastSent, lastRecv uint64
 	lastTick := pumpStart
 
+	// Per-leg previous-sample counters, indexed by position in the
+	// routes slice, so each leg's inst_*_bps is a delta since ITS own
+	// last reading — mirroring how the aggregate inst rate is computed
+	// from lastSent/lastRecv.
+	lastLegSent := make([]uint64, len(routes))
+	lastLegRecv := make([]uint64, len(routes))
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -776,12 +808,39 @@ func (s *PingServer) muxBwSamplerLoop(
 
 			var totalSent, totalRecv uint64
 			var activeRoutes int32
-			for _, r := range routes {
-				totalSent += r.bytesSent.Load()
-				totalRecv += r.bytesRecv.Load()
-				if r.activeFlag.Load() {
+			// Per-leg breakdown, emitted alongside the aggregate. One
+			// entry per route, in route-index order, carrying the leg's
+			// cumulative bytes, its per-interval instant rates, and its
+			// distinguishing identity (intermediate PK + transport kind).
+			legs := make([]*MuxLegSample, 0, len(routes))
+			for i, r := range routes {
+				legSent := r.bytesSent.Load()
+				legRecv := r.bytesRecv.Load()
+				totalSent += legSent
+				totalRecv += legRecv
+				alive := r.activeFlag.Load()
+				if alive {
 					activeRoutes++
 				}
+
+				legInstSendBps := 0.0
+				legInstRecvBps := 0.0
+				if intervalSec > 0 {
+					legInstSendBps = float64((legSent-lastLegSent[i])*8) / intervalSec
+					legInstRecvBps = float64((legRecv-lastLegRecv[i])*8) / intervalSec
+				}
+				lastLegSent[i], lastLegRecv[i] = legSent, legRecv
+
+				legs = append(legs, &MuxLegSample{
+					RouteIndex:     int32(r.index), //nolint:gosec // route index fits int32
+					IntermediatePk: r.intermediatePK,
+					TransportKind:  r.transportKind,
+					BytesSent:      int64(legSent), //nolint:gosec // pumped byte totals fit int64
+					BytesRecv:      int64(legRecv), //nolint:gosec // pumped byte totals fit int64
+					InstSendBps:    legInstSendBps,
+					InstRecvBps:    legInstRecvBps,
+					Alive:          alive,
+				})
 			}
 
 			instantSendBps := 0.0
@@ -815,6 +874,7 @@ func (s *PingServer) muxBwSamplerLoop(
 				AvgSendBps:     avgSendBps,
 				AvgRecvBps:     avgRecvBps,
 				ActiveRoutes:   activeRoutes,
+				Legs:           legs,
 			}})
 		}
 	}

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth_test.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth_test.go
@@ -67,38 +67,42 @@ func TestMuxBwIntermediates(t *testing.T) {
 }
 
 // TestMuxBwRoutingHopsToInfoAndReverse pins the calc-route → explicit-dial
-// conversion: forward hops carry TpID/From/To (TpType intentionally dropped,
-// as PingContextWithRoute resolves by TpID), and the reverse is the forward
-// reversed with From/To swapped — matching the shape `route calc` emits and
-// `proxy mux set --legs` dials.
+// conversion: forward hops carry TpID/From/To (TpType filled from the
+// tpTypes map so the plan can serve as the per-leg telemetry identity source),
+// and the reverse is the forward reversed with From/To swapped — matching the
+// shape `route calc` emits and `proxy mux set --legs` dials.
 func TestMuxBwRoutingHopsToInfoAndReverse(t *testing.T) {
 	src := mustPK(t, "03cb5eb5741df4d66492f96f89b55861def1e23850583c499805d96e053f9bceac")
 	dst := mustPK(t, "0248bac07d82b54864959d293181ee6c3dc6e1771e28cca8dd80acac94e36aa164")
 	mid := mustPK(t, "02880cc291ef1620b7d69b3b7b5cadb30d2d97bfe9070e07f6f0c4b6f7a5c8a17a")
 	tp1 := uuid.New()
 	tp2 := uuid.New()
+	tpTypes := map[string]string{tp1.String(): "stcpr", tp2.String(): "sudph"}
 
 	fwd := muxBwRoutingHopsToInfo([]routing.Hop{
 		{From: src, To: mid, TpID: tp1},
 		{From: mid, To: dst, TpID: tp2},
-	})
+	}, tpTypes)
 	if len(fwd) != 2 {
 		t.Fatalf("forward len = %d, want 2", len(fwd))
 	}
 	if fwd[0].TpID != tp1.String() || fwd[0].From != src.String() || fwd[0].To != mid.String() {
 		t.Errorf("forward[0] = %+v", fwd[0])
 	}
-	if fwd[0].TpType != "" {
-		t.Errorf("TpType should be empty (resolved by TpID), got %q", fwd[0].TpType)
+	if fwd[0].TpType != "stcpr" {
+		t.Errorf("TpType should be filled from the type map, got %q", fwd[0].TpType)
 	}
 
 	rev := muxBwReverseHops(fwd)
 	if len(rev) != 2 {
 		t.Fatalf("reverse len = %d, want 2", len(rev))
 	}
-	// reverse[0] is forward[last] with From/To swapped.
+	// reverse[0] is forward[last] with From/To swapped; TpType is preserved.
 	if rev[0].TpID != tp2.String() || rev[0].From != dst.String() || rev[0].To != mid.String() {
 		t.Errorf("reverse[0] = %+v, want swapped last forward hop", rev[0])
+	}
+	if rev[0].TpType != "sudph" {
+		t.Errorf("reverse[0] TpType should be preserved, got %q", rev[0].TpType)
 	}
 	if rev[1].TpID != tp1.String() || rev[1].From != mid.String() || rev[1].To != src.String() {
 		t.Errorf("reverse[1] = %+v, want swapped first forward hop", rev[1])

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth_test.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth_test.go
@@ -1,7 +1,9 @@
 package rpcgrpc
 
 import (
+	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -347,4 +349,122 @@ func TestBuildRouteFailureEvent(t *testing.T) {
 			t.Error("ErrorMessage must be populated even when bytes are zero")
 		}
 	})
+}
+
+// TestMuxBwSamplerEmitsPerLeg pins requirement #3 of the per-leg
+// measurement work: the sampler must emit one MuxLegSample per route
+// alongside the aggregate, carrying that leg's identity (intermediate
+// PK + transport kind), cumulative bytes, and a non-zero instant rate
+// computed from the delta since the previous sample. The sampler
+// touches no PingServer fields, so a zero-value server is enough to
+// drive it — no VisorAPI mock required.
+func TestMuxBwSamplerEmitsPerLeg(t *testing.T) {
+	const (
+		midStcpr = "0323c77f295e4930dbb053b6109dae1a992a996e9858cb000a85636e5967c27ae9"
+	)
+
+	r0 := &muxBwRouteState{index: 0, intermediatePK: midStcpr, transportKind: "stcpr"}
+	r0.established.Store(true)
+	r0.activeFlag.Store(true)
+	r0.bytesSent.Store(40000)
+	r0.bytesRecv.Store(39000)
+
+	// r1 is a "direct" leg: no intermediate, and marked not-alive to
+	// prove the alive flag mirrors activeFlag rather than being hardcoded.
+	r1 := &muxBwRouteState{index: 1, intermediatePK: "", transportKind: "sudph"}
+	r1.established.Store(true)
+	r1.activeFlag.Store(false)
+	r1.bytesSent.Store(10000)
+	r1.bytesRecv.Store(9000)
+
+	routes := []*muxBwRouteState{r0, r1}
+	cfg := &muxBwCfg{SampleInterval: 15 * time.Millisecond}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		mu      sync.Mutex
+		got     *MuxBandwidthSample
+		gotOnce = make(chan struct{})
+	)
+	emit := func(p isMuxBandwidthEvent_Payload) {
+		s, ok := p.(*MuxBandwidthEvent_Sample)
+		if !ok {
+			return
+		}
+		mu.Lock()
+		if got == nil {
+			got = s.Sample
+			close(gotOnce)
+		}
+		mu.Unlock()
+	}
+
+	peakSend, peakRecv := 0.0, 0.0
+	go (&PingServer{}).muxBwSamplerLoop(ctx, cfg, routes, time.Now(), &peakSend, &peakRecv, emit)
+
+	select {
+	case <-gotOnce:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sampler emitted no MuxBandwidthSample within 2s")
+	}
+	cancel()
+
+	mu.Lock()
+	sample := got
+	mu.Unlock()
+
+	if len(sample.Legs) != 2 {
+		t.Fatalf("legs = %d, want 2", len(sample.Legs))
+	}
+
+	// Aggregate must still be the sum of the legs (backward-compatible).
+	if sample.BytesSent != 50000 || sample.BytesReceived != 48000 {
+		t.Errorf("aggregate bytes = %d/%d, want 50000/48000", sample.BytesSent, sample.BytesReceived)
+	}
+	if sample.ActiveRoutes != 1 {
+		t.Errorf("active_routes = %d, want 1 (only r0 alive)", sample.ActiveRoutes)
+	}
+
+	byIdx := map[int32]*MuxLegSample{}
+	for _, l := range sample.Legs {
+		byIdx[l.RouteIndex] = l
+	}
+
+	l0 := byIdx[0]
+	if l0 == nil {
+		t.Fatal("missing leg for route_index 0")
+	}
+	if l0.IntermediatePk != midStcpr {
+		t.Errorf("leg0 intermediate_pk = %q, want %q", l0.IntermediatePk, midStcpr)
+	}
+	if l0.TransportKind != "stcpr" {
+		t.Errorf("leg0 transport_kind = %q, want stcpr", l0.TransportKind)
+	}
+	if l0.BytesSent != 40000 || l0.BytesRecv != 39000 {
+		t.Errorf("leg0 bytes = %d/%d, want 40000/39000", l0.BytesSent, l0.BytesRecv)
+	}
+	if !l0.Alive {
+		t.Error("leg0 alive = false, want true")
+	}
+	// First sample's inst rate is delta-since-zero, so a leg that moved
+	// bytes must report a strictly positive rate.
+	if l0.InstSendBps <= 0 || l0.InstRecvBps <= 0 {
+		t.Errorf("leg0 inst rates = %.1f/%.1f, want > 0", l0.InstSendBps, l0.InstRecvBps)
+	}
+
+	l1 := byIdx[1]
+	if l1 == nil {
+		t.Fatal("missing leg for route_index 1")
+	}
+	if l1.IntermediatePk != "" {
+		t.Errorf("leg1 intermediate_pk = %q, want empty (direct)", l1.IntermediatePk)
+	}
+	if l1.TransportKind != "sudph" {
+		t.Errorf("leg1 transport_kind = %q, want sudph", l1.TransportKind)
+	}
+	if l1.Alive {
+		t.Error("leg1 alive = true, want false (activeFlag false)")
+	}
 }


### PR DESCRIPTION
## What

`visor ping mux-bw` previously emitted only an **aggregate** `MuxBandwidthSample`. To measure adaptive routing policies we need each leg's identity and throughput over time. Adds `MuxLegSample` + `repeated MuxLegSample legs = 9` to `MuxBandwidthSample` (additive):

```proto
message MuxLegSample {
  int32 route_index = 1; string intermediate_pk = 2; string transport_kind = 3;
  int64 bytes_sent = 4; int64 bytes_recv = 5;
  double inst_send_bps = 6; double inst_recv_bps = 7; bool alive = 8;
}
```

The sampler emits one `MuxLegSample` per route each interval (cumulative bytes + per-interval inst rates + `alive`). Per-leg identity (`intermediate_pk`/`transport_kind`) is sourced from the route's **plan hops** (`rs.fwdHops`), which are authoritative for what was dialed — the explicit-hops dial path (#3961's disjoint planner) does not populate the conn's `RouteHopDetails`, so the post-hoc `GetPingRouteDetailsAt` lookup returns empty for planned routes; the finder path still falls back to the lookup. The transport kind is carried into the plan via a `TpID→type` map from the transport entries the planner already fetches (`routing.Hop` drops it).

## Test

- `TestMuxBwSamplerEmitsPerLeg` drives the real sampler (2 legs, correct identity, cumulative bytes, positive inst rates, aggregate == sum of legs, `alive` mirrors the active flag).
- `TestMuxBwRoutingHopsToInfoAndReverse` covers the type-map stamping + reverse preservation.
- Live-verified on a native visor: `--routes 2 --min-hops 2` yields two legs with **distinct intermediates + distinct transport kinds** (stcpr via one intermediate, webrtc via another) each carrying ~1 Mbps.
- `go build`, `go vet`, `golangci-lint` (0 issues), `go test ./pkg/visor/rpcgrpc/` — all green.

Substrate for measuring the WASM routing-policy presets per-leg over time.