### PR TITLE
feat(cli): app arg routing-policy — set an app's routing policy at runtime (no restart)

### DIFF
--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -69,6 +69,7 @@ func init() {
 		setAppWhitelistCmd,
 		setAppNetworkInterfaceCmd,
 		setAppPKCmd,
+		setAppRoutingPolicyCmd,
 	)
 	registerAppCmd.Flags().StringVarP(&appName, "appname", "a", "", "name of the app")
 	registerAppCmd.Flags().StringVarP(&localPath, "localpath", "p", "./local", "path of the local folder")
@@ -445,6 +446,27 @@ var setAppAutostartCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		internal.Catch(cmd.Flags(), rpcClient.SetAutoStart(args[0], autostart))
+		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
+	},
+}
+
+var setAppRoutingPolicyCmd = &cobra.Command{
+	Use:   "routing-policy <name> <policy>",
+	Short: "Set an app's routing policy at runtime (no restart)",
+	Long: "\n  Install or replace an app's per-dial routing policy on a RUNNING app\n" +
+		"  without restarting it — the route-selection hook is swapped live.\n\n" +
+		"  <policy> accepts:\n" +
+		"    preset:<name>   a built-in preset (see 'route policy list')\n" +
+		"    @/path.star     a Starlark policy file (hot-reloaded on change)\n" +
+		"    @/path.wasm     a compiled WASM policy file (hot-reloaded on change)\n" +
+		"    \"\" or \"none\"     clear any previously-installed override",
+	Args: cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		internal.Catch(cmd.Flags(), rpcClient.SetAppRoutingPolicy(args[0], args[1]))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }


### PR DESCRIPTION
## What

`visor app start --routing-policy` installs a policy only *before* the app starts — on a running app it errors `app already started`. The live-swap `SetAppRoutingPolicy` RPC (registers the new route-selection hook without restarting the app) had no CLI verb. Adds:

```
skywire cli visor app arg routing-policy <name> <policy>
```

`<policy>` accepts `preset:<name>`, `@/path.star`, `@/path.wasm` (hot-reloaded), or `""`/`none` to clear. Wraps `rpcClient.SetAppRoutingPolicy` — hook swapped live, no restart.

## Test

Live on a native visor: `app arg routing-policy skysocks-client preset:rotating-bw` → `OK` in ~1s, app still `running` (no restart); `none` clears it. `go build ./cmd/skywire-cli/`, `golangci-lint` (0 issues).