### PR TITLE
test(router): age retx entries past retxMinAge in TestRetxBuffer_RetransmitList

### DIFF
--- a/pkg/router/sack_test.go
+++ b/pkg/router/sack_test.go
@@ -83,6 +83,15 @@ func TestRetxBuffer_RetransmitList(t *testing.T) {
 		rb.Store(i, []byte{byte(i)})
 	}
 
+	// Age the stored entries past retxMinAge: ProcessSACK only lists a missing
+	// sequence for retransmit once it has been unacknowledged longer than that
+	// guard (a younger gap is presumed in flight on a slower mux leg, not lost).
+	// Without this the freshly-Store'd entries are "too young" and the list is
+	// empty. See retxMinAge in sack.go.
+	for _, e := range rb.entries {
+		e.sentAt = e.sentAt.Add(-2 * retxMinAge)
+	}
+
 	// SACK: lastContiguous=2, bitmap=0b1010 (seq 3 missing, 4 received, 5 missing, 6 received)
 	retx := rb.ProcessSACK(2, 0b1010)
 	assert.Contains(t, retx, uint32(3))


### PR DESCRIPTION
## What

`TestRetxBuffer_RetransmitList` fails on `develop` (`[]uint32(nil) does not contain 0x3`). The `retxMinAge` guard (from the lossless-reorder/SACK work in #3955) makes `ProcessSACK` list a missing sequence for retransmit only once it has been unacknowledged longer than 750 ms — a younger gap is presumed in flight on a slower mux leg, not lost. The test `Store`s entries and immediately calls `ProcessSACK`, so every gap is "too young" and the list comes back empty.

Fix: backdate the stored entries' `sentAt` past `retxMinAge` before the SACK, so the test exercises the genuinely-overdue retransmit path it was written to check. **No production code change** — test-only, and it unblocks `make check` on develop.

## Test

`go test ./pkg/router/` — full package green (was failing on this one test); `golangci-lint run pkg/router/` clean.