### PR TITLE
fix(tpd): compress remaining JSON endpoints + set Vary on both encoding branches

### DIFF
--- a/pkg/transport-discovery/api/api.go
+++ b/pkg/transport-discovery/api/api.go
@@ -135,6 +135,19 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
 	r.Use(middleware.RealIP) //nolint:staticcheck
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+
+	// Compress the remaining JSON endpoints. The two dominant egress paths
+	// (/all-transports and /transports/edge:<PK>) do NOT rely on this: they
+	// serve a pre-gzipped body straight from their response caches, so the
+	// bytes are compressed once per TTL rather than once per request. This
+	// middleware is a no-op for them -- it skips any response that already
+	// set Content-Encoding -- and exists to cover the endpoints that still
+	// marshal fresh JSON per call, chiefly /all-transports/per-key-stats
+	// (a map entry per unique edge PK) and /metrics. Level 5 keeps the CPU
+	// cost modest; these bodies are highly repetitive JSON, so the ratio is
+	// close to what level 9 would buy.
+	r.Use(middleware.Compress(5))
+
 	if enableMetrics {
 		r.Use(api.reqsInFlightCountMiddleware.Handle)
 		r.Use(metricsutil.RequestDurationMiddleware)

--- a/pkg/transport-discovery/api/compress_test.go
+++ b/pkg/transport-discovery/api/compress_test.go
@@ -1,0 +1,147 @@
+// Package api pkg/transport-discovery/api/compress_test.go c4-net-discovery
+package api
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/httpauth"
+	"github.com/skycoin/skywire/pkg/storeconfig"
+	"github.com/skycoin/skywire/pkg/transport"
+	tpdiscmetrics "github.com/skycoin/skywire/pkg/transport-discovery/metrics"
+)
+
+// newCompressTestAPI returns an API backed by a memory store holding n
+// registered transports.
+func newCompressTestAPI(t *testing.T, n int) *API {
+	t.Helper()
+
+	ctx := context.Background()
+	mock := newTestStore(t)
+	nonceMock, err := httpauth.NewNonceStore(ctx, storeconfig.Config{Type: storeconfig.Memory}, "")
+	require.NoError(t, err)
+
+	for i := 0; i < n; i++ {
+		entry := newTestEntry()
+		sEntry := &transport.SignedEntry{Entry: entry, Signatures: [2]cipher.Sig{}}
+		require.NoError(t, mock.RegisterTransport(ctx, cipher.PubKey{}, sEntry))
+	}
+
+	return New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty(), "", "")
+}
+
+// TestCompressMiddlewareOnFreshJSON pins that endpoints which marshal fresh
+// JSON per call (no pre-gzipped response cache) are compressed by the router
+// middleware when the client advertises gzip.
+func TestCompressMiddlewareOnFreshJSON(t *testing.T) {
+	api := newCompressTestAPI(t, 40)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/all-transports/per-key-stats", nil)
+	r.Header = validHeaders(t, nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+	api.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Equal(t, "gzip", w.Header().Get("Content-Encoding"))
+	require.Contains(t, w.Header().Values("Vary"), "Accept-Encoding")
+
+	// Body must be real gzip and decode to the expected JSON shape.
+	zr, err := gzip.NewReader(w.Body)
+	require.NoError(t, err)
+	defer zr.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(zr)
+	require.NoError(t, err)
+
+	var stats map[string]map[string]int
+	require.NoError(t, json.Unmarshal(body, &stats))
+	require.NotEmpty(t, stats)
+}
+
+// TestCompressMiddlewareIdentity pins that a client which does not advertise
+// gzip still gets a readable, uncompressed body.
+func TestCompressMiddlewareIdentity(t *testing.T) {
+	api := newCompressTestAPI(t, 5)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/all-transports/per-key-stats", nil)
+	r.Header = validHeaders(t, nil)
+	r.Header.Set("Accept-Encoding", "identity")
+	api.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Empty(t, w.Header().Get("Content-Encoding"))
+
+	var stats map[string]map[string]int
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &stats))
+}
+
+// TestPreGzippedPathNotDoubleCompressed pins the interaction that makes the
+// middleware safe to add: /all-transports and /transports/edge:<PK> serve a
+// body the response cache already gzipped, and the middleware must leave it
+// alone rather than gzip it a second time. A double-compressed body would
+// still carry a single "Content-Encoding: gzip" and would decode -- once --
+// into gzip bytes rather than JSON, so decode once and require JSON.
+func TestPreGzippedPathNotDoubleCompressed(t *testing.T) {
+	api := newCompressTestAPI(t, 20)
+
+	for _, path := range []string{"/all-transports"} {
+		t.Run(path, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, path, nil)
+			r.Header = validHeaders(t, nil)
+			r.Header.Set("Accept-Encoding", "gzip")
+			api.ServeHTTP(w, r)
+
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			require.Equal(t, "gzip", w.Header().Get("Content-Encoding"))
+			require.Equal(t, []string{"gzip"}, w.Header().Values("Content-Encoding"),
+				"Content-Encoding must not be stacked")
+
+			zr, err := gzip.NewReader(w.Body)
+			require.NoError(t, err)
+			defer zr.Close() //nolint:errcheck
+
+			body, err := io.ReadAll(zr)
+			require.NoError(t, err)
+
+			// One decode must yield JSON. If the middleware had re-compressed
+			// the cached gzip, this would still be gzip bytes and fail.
+			var entries []*transport.Entry
+			require.NoError(t, json.Unmarshal(body, &entries),
+				"one gzip decode must yield JSON (body was double-compressed)")
+			require.Len(t, entries, 20)
+		})
+	}
+}
+
+// TestAllTransportsVaryOnIdentity pins that Vary: Accept-Encoding is sent even
+// when the response is served uncompressed. Without it a shared cache in front
+// of TPD may store the identity body and later hand it to a gzip client.
+func TestAllTransportsVaryOnIdentity(t *testing.T) {
+	api := newCompressTestAPI(t, 3)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/all-transports", nil)
+	r.Header = validHeaders(t, nil)
+	r.Header.Set("Accept-Encoding", "identity")
+	api.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Empty(t, w.Header().Get("Content-Encoding"))
+	require.Contains(t, w.Header().Values("Vary"), "Accept-Encoding",
+		"Vary must be set on the identity branch too")
+
+	var entries []*transport.Entry
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &entries))
+	require.Len(t, entries, 3)
+}

--- a/pkg/transport-discovery/api/endpoints.go
+++ b/pkg/transport-discovery/api/endpoints.go
@@ -276,9 +276,13 @@ func (api *API) getTransportByEdge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	// Vary must be set on BOTH branches: the response body depends on the
+	// request's Accept-Encoding, so a shared cache in front of TPD would
+	// otherwise be free to serve a stored identity body to a gzip client
+	// (or the reverse) after caching whichever it saw first.
+	w.Header().Set("Vary", "Accept-Encoding")
 	if gz != nil && strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
 		w.Header().Set("Content-Encoding", "gzip")
-		w.Header().Set("Vary", "Accept-Encoding")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(gz) //nolint:errcheck
 		return
@@ -356,9 +360,13 @@ func (api *API) getAllTransports(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	// Vary must be set on BOTH branches: the response body depends on the
+	// request's Accept-Encoding, so a shared cache in front of TPD would
+	// otherwise be free to serve a stored identity body to a gzip client
+	// (or the reverse) after caching whichever it saw first.
+	w.Header().Set("Vary", "Accept-Encoding")
 	if gz != nil && strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
 		w.Header().Set("Content-Encoding", "gzip")
-		w.Header().Set("Vary", "Accept-Encoding")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(gz) //nolint:errcheck
 		return


### PR DESCRIPTION
## What

Two changes to transport-discovery's HTTP responses:

1. **`middleware.Compress(5)` on the chi stack** — covers the endpoints that still marshal fresh JSON per call and ship it raw.
2. **`Vary: Accept-Encoding` on both encoding branches** of `/all-transports` and `/transports/edge:<PK>`.

## Why

The two dominant egress paths are *already* compressed: `/all-transports` and `/transports/edge:<PK>` serve a pre-gzipped body straight from their response caches (#2980, #3020), and the dmsg RoundTripper was taught to advertise `Accept-Encoding: gzip` so those cached gzip bodies actually get used. This PR does **not** change those paths.

What is still uncompressed is the rest of the router — chiefly `/all-transports/per-key-stats`, which builds one map entry per unique edge PK and therefore grows with the network, plus `/metrics` and the uptime endpoints.

`middleware.Compress` is a no-op for the two cached paths: chi skips any response that already set `Content-Encoding`, so the pre-gzipped bodies are not re-compressed and the once-per-TTL compression model is preserved. Level 5 keeps CPU modest; these bodies are highly repetitive JSON, so the ratio is close to what level 9 would buy.

The `Vary` change is a genuine caching-correctness fix. `Vary: Accept-Encoding` was set only on the gzip branch, but the body varies by `Accept-Encoding` on **both**. A shared cache in front of TPD (there is a caddy) could store the identity body and later hand it to a gzip client, or the reverse.

## Safety

- No streaming/SSE endpoints in this package, so wrapping the `ResponseWriter` is safe.
- `middleware.Compress` skips responses that already set `Content-Encoding` (verified in the vendored chi source), so no double-compression.
- Clients that send `Accept-Encoding: identity` still get readable JSON.

## Tests

New `compress_test.go` pins:

- fresh-JSON endpoints compress and decode to the expected shape;
- identity clients still get uncompressed, parseable JSON;
- the pre-gzipped path is **not** double-compressed — one gzip decode must yield JSON, and `Content-Encoding` must not stack;
- `Vary` is present on the identity branch.

`go build`, `go vet`, `golangci-lint` (0 issues) and `go test ./pkg/transport-discovery/... ./pkg/transport/tpdclient/...` all pass.

## Note on the bandwidth investigation

This PR is a follow-on, not the fix for the 82 Mbit/s `/all-transports` egress. That endpoint's gzip landed in #2980 on 2026-06-03. If production is still serving ~19 MB per response, the deployed binary predates that merge — worth checking before expecting a further 10× from this change.