### PR TITLE
feat(router): warm-standby mux leg state (dormant primitive, gate-5 step 1)

### DIFF
--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -92,6 +92,14 @@ type routeMux struct {
 	// stalls on the missing sequence, and the stream hangs until it is
 	// closed (the mux>=2 "0 bytes / close code 0" bug). Guarded by legMu.
 	ready []bool
+	// standby[i] marks leg i as a WARM STANDBY: its rules stay installed and
+	// the keepalive/liveness loops keep it alive, but it is never SELECTED for
+	// sending (folded into legReadyAt). A demoted leg still receives on its
+	// reverse rule — standby is a send-side decision. Promoting a standby leg
+	// is instant (clear the flag) with no route setup, vs the drop→re-dial
+	// tear-and-rebuild. Parallel to ready[]; grown/compacted in lockstep.
+	// Guarded by legMu. See docs/warm_standby_legs_rfc.md.
+	standby []bool
 }
 
 // reorderWindow bounds how far the receiver's reorder buffer will hold
@@ -209,6 +217,10 @@ func (m *routeMux) growLegs(n int) {
 		// not-ready and are marked ready on the first inbound packet.
 		m.ready = append(m.ready, len(m.ready) == 0)
 	}
+	for len(m.standby) < n {
+		// New legs are active, never standby.
+		m.standby = append(m.standby, false)
+	}
 	m.legMu.Unlock()
 }
 
@@ -252,6 +264,18 @@ func (m *routeMux) removeLegs(indices ...int) {
 			m.ready[0] = true // the (possibly newly-promoted) primary is always ready
 		}
 	}
+	if len(m.standby) > 0 {
+		kept := make([]bool, 0, len(m.standby))
+		for i, s := range m.standby {
+			if !drop[i] {
+				kept = append(kept, s)
+			}
+		}
+		m.standby = kept
+		if len(m.standby) > 0 {
+			m.standby[0] = false // the primary leg is never standby
+		}
+	}
 	m.legMu.Unlock()
 }
 
@@ -278,10 +302,40 @@ func (m *routeMux) legReadyAt(idx int) bool {
 	}
 	m.legMu.RLock()
 	defer m.legMu.RUnlock()
+	// A warm-standby leg is never selected for sending, regardless of
+	// readiness — its rules stay installed but it carries no forward traffic.
+	if idx < len(m.standby) && m.standby[idx] {
+		return false
+	}
 	if idx >= len(m.ready) {
 		return idx == 0
 	}
 	return m.ready[idx]
+}
+
+// setLegStandby marks (or clears) leg idx as a warm standby: kept alive but
+// not selected for sending. Bounds-checked; the primary leg (0) cannot be put
+// on standby (a group must always have a selectable send leg). Clearing the
+// flag PROMOTES the leg back to active instantly, with no route setup.
+func (m *routeMux) setLegStandby(idx int, standby bool) {
+	if idx <= 0 {
+		return // leg 0 is never standby
+	}
+	m.legMu.Lock()
+	if idx < len(m.standby) {
+		m.standby[idx] = standby
+	}
+	m.legMu.Unlock()
+}
+
+// isLegStandby reports whether leg idx is a warm standby. Bounds-checked.
+func (m *routeMux) isLegStandby(idx int) bool {
+	if idx < 0 {
+		return false
+	}
+	m.legMu.RLock()
+	defer m.legMu.RUnlock()
+	return idx < len(m.standby) && m.standby[idx]
 }
 
 // recordSent atomically increments the sent-bytes/packets counters

--- a/pkg/router/route_mux_standby_test.go
+++ b/pkg/router/route_mux_standby_test.go
@@ -1,0 +1,82 @@
+//go:build !tinygo || (js && wasm)
+
+package router
+
+import "testing"
+
+// TestMuxStandbyLegNotSelected pins the warm-standby leg semantics: a leg put
+// on standby is never reported selectable (legReadyAt=false), while its rules
+// stay in place; clearing the flag promotes it back instantly. The primary leg
+// (0) can never be put on standby. See docs/warm_standby_legs_rfc.md.
+func TestMuxStandbyLegNotSelected(t *testing.T) {
+	m := &routeMux{}
+	m.growLegs(3)
+	// All aux legs must be ready before selection to isolate the standby effect.
+	m.markLegReady(1)
+	m.markLegReady(2)
+
+	for _, idx := range []int{0, 1, 2} {
+		if !m.legReadyAt(idx) {
+			t.Fatalf("leg %d should be ready before standby", idx)
+		}
+		if m.isLegStandby(idx) {
+			t.Fatalf("leg %d should not start on standby", idx)
+		}
+	}
+
+	// Demote leg 1 to warm standby: no longer selectable, still tracked.
+	m.setLegStandby(1, true)
+	if m.legReadyAt(1) {
+		t.Error("standby leg 1 must not be selectable")
+	}
+	if !m.isLegStandby(1) {
+		t.Error("leg 1 should report standby")
+	}
+	if !m.legReadyAt(0) || !m.legReadyAt(2) {
+		t.Error("standby of leg 1 must not affect legs 0 and 2")
+	}
+
+	// Promote leg 1 back to active: instant, no route setup.
+	m.setLegStandby(1, false)
+	if !m.legReadyAt(1) {
+		t.Error("promoted leg 1 must be selectable again")
+	}
+	if m.isLegStandby(1) {
+		t.Error("leg 1 should no longer report standby")
+	}
+
+	// The primary leg cannot be parked on standby.
+	m.setLegStandby(0, true)
+	if m.isLegStandby(0) || !m.legReadyAt(0) {
+		t.Error("primary leg 0 must never be standby")
+	}
+}
+
+// TestMuxStandbyCompactedOnLegRemoval pins the lockstep invariant: when a leg
+// is removed the standby[] slice stays aligned with the remaining legs, so a
+// standby flag never attaches to the wrong leg after compaction.
+func TestMuxStandbyCompactedOnLegRemoval(t *testing.T) {
+	m := &routeMux{}
+	m.growLegs(4)
+	m.markLegReady(1)
+	m.markLegReady(2)
+	m.markLegReady(3)
+	m.setLegStandby(3, true) // leg 3 on standby
+
+	// Remove leg 1 (original index). Remaining original legs 0,2,3 compact to
+	// new indices 0,1,2 — the old standby leg 3 is now index 2.
+	m.removeLegs(1)
+
+	if m.isLegStandby(2) != true {
+		t.Error("after removing leg 1, the standby flag should follow the old leg 3 to new index 2")
+	}
+	if m.isLegStandby(0) || m.isLegStandby(1) {
+		t.Error("non-standby legs must remain non-standby after compaction")
+	}
+	if !m.legReadyAt(0) || !m.legReadyAt(1) {
+		t.Error("remaining active legs must stay selectable")
+	}
+	if m.legReadyAt(2) {
+		t.Error("the compacted standby leg must remain unselectable")
+	}
+}


### PR DESCRIPTION
First implementation increment of the warm-standby routing primitive (design in docs/warm_standby_legs_rfc.md, #3973).

Adds a per-leg `standby[]` flag to `routeMux`, parallel to `ready[]` and grown/compacted in lockstep (`growLegs`/`removeLegs`). A standby leg is folded into `legReadyAt`, so it is uniformly skipped by **every** send path (payload-mode, weighted, and round-robin all gate on `legReadyAt`) — while its rules stay installed and the keepalive/liveness loops keep it alive, and it still **receives** on its reverse rule (standby is a send-side decision). `setLegStandby`/`isLegStandby` demote/promote instantly with no route setup; the primary leg (0) can never be parked.

**Dormant:** nothing calls `setLegStandby` in a live path yet, so routing behaviour is unchanged. This is deliberately the smallest safe step — the rotation-demote wiring and the policy ABI (`PromoteStandby`/`DemoteToStandby`) land in follow-up PRs, each with its own live validation.

Unit-tested: skip-on-standby semantics + the lockstep-compaction invariant (a standby flag follows its leg through removal). `go test ./pkg/router/` + `golangci-lint run pkg/router/` green.