### PR TITLE
feat(deployment): gzip UT / SD / RF HTTP responses (Linode egress)

### DIFF
--- a/pkg/route-finder/api/api.go
+++ b/pkg/route-finder/api/api.go
@@ -66,6 +66,9 @@ func New(s store.Store, logger logrus.FieldLogger, enableMetrics bool, dmsgAddr 
 	r.Use(middleware.RealIP) //nolint:staticcheck
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+	// gzip route-finder JSON responses on the wire (skips small bodies,
+	// honors Vary; net/http clients get transparent gzip).
+	r.Use(middleware.Compress(5))
 	if enableMetrics {
 		r.Use(api.reqsInFlightCountMiddleware.Handle)
 		r.Use(metricsutil.RequestDurationMiddleware)

--- a/pkg/service-discovery/api/api.go
+++ b/pkg/service-discovery/api/api.go
@@ -235,6 +235,9 @@ func (a *API) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r := chi.NewRouter()
 	r.Use(middleware.RealIP) //nolint:staticcheck
 	r.Use(middleware.Logger)
+	// gzip service-discovery JSON responses on the wire (skips small bodies,
+	// honors Vary; net/http clients get transparent gzip).
+	r.Use(middleware.Compress(5))
 	if a.enableMetrics {
 		r.Use(a.reqsInFlightCountMiddleware.Handle)
 		r.Use(metricsutil.RequestDurationMiddleware)

--- a/pkg/uptime-tracker/api/api.go
+++ b/pkg/uptime-tracker/api/api.go
@@ -114,6 +114,11 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore, 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP) //nolint:staticcheck
 	r.Use(middleware.Recoverer)
+	// gzip responses on the wire — /uptimes is a fleet-wide JSON body polled
+	// constantly by the reward system + CLIs; it compresses ~80-90%. Clients
+	// using net/http get transparent gzip (Accept-Encoding auto-added +
+	// decoded); the middleware skips small bodies and honors Vary.
+	r.Use(middleware.Compress(5))
 	if enableMetrics {
 		r.Use(api.reqsInFlightCountMiddleware.Handle)
 		r.Use(metricsutil.RequestDurationMiddleware)


### PR DESCRIPTION
TPD already serves `/all-transports` (and `/transports/edge:<PK>`) gzipped with a memoized gzip body. The other deployment services sent **uncompressed** JSON — notably **UT `/uptimes`**, a fleet-wide body polled constantly by the reward system + CLIs (compresses ~80–90%).

Adds `chi middleware.Compress(5)` to the **uptime-tracker**, **service-discovery**, and **route-finder** routers so their JSON is gzipped on the wire. `net/http` clients request + decode gzip transparently (no client change); the middleware skips small bodies and sets `Vary: Accept-Encoding`. Directly reduces deployment egress on the endpoints TPD's per-endpoint gzip didn't cover.

`go build` + `golangci-lint` green for the three services.