### PR TITLE
feat(cxo): gzip the all-transports CXO feed (bandwidth parity with HTTP)

### DIFF
--- a/pkg/cxo/cxoutils/compress.go
+++ b/pkg/cxo/cxoutils/compress.go
@@ -1,0 +1,63 @@
+// Package cxoutils pkg/cxo/cxoutils/compress.go c2-net-cxo
+// gzip helpers for CXO payloads. CXO propagates and stores object bytes
+// verbatim — it has no built-in compression — so large JSON feeds (e.g. the
+// TPD all-transports snapshot) travel uncompressed unless the publisher
+// compresses the body itself. Gzip on publish + Gunzip on read closes that gap
+// for both storage and propagation.
+package cxoutils
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"sync"
+)
+
+// gzipMagic is the two-byte gzip header (RFC 1952). Gunzip uses it to
+// auto-detect whether a payload is compressed, which makes the format
+// self-describing: a subscriber handles both gzipped and raw bodies, so a
+// publisher can switch to gzip without breaking readers that predate this
+// helper (they simply won't recognize the bytes — callers of such feeds have
+// an HTTP fallback), and readers that postdate it transparently accept the old
+// raw bodies too.
+var gzipMagic = []byte{0x1f, 0x8b}
+
+var gzipWriterPool = sync.Pool{
+	New: func() any { return gzip.NewWriter(io.Discard) },
+}
+
+// Gzip returns the gzip-compressed form of b. Empty input returns nil so the
+// round-trip Gunzip(Gzip(nil)) is nil, not a valid-but-empty gzip stream.
+func Gzip(b []byte) []byte {
+	if len(b) == 0 {
+		return nil
+	}
+	var buf bytes.Buffer
+	zw := gzipWriterPool.Get().(*gzip.Writer)
+	zw.Reset(&buf)
+	_, _ = zw.Write(b) //nolint:errcheck // writing to a bytes.Buffer cannot fail
+	_ = zw.Close()     //nolint:errcheck // flush; the Buffer never errors
+	gzipWriterPool.Put(zw)
+	return buf.Bytes()
+}
+
+// Gunzip returns the decompressed form of b if it is a gzip stream (detected by
+// the gzip magic header), otherwise b unchanged. This lets a reader accept both
+// gzipped and raw payloads on the same feed. On a decompression error the
+// original bytes are returned so a malformed stream degrades to "treat as raw"
+// rather than dropping the payload.
+func Gunzip(b []byte) []byte {
+	if len(b) < 2 || b[0] != gzipMagic[0] || b[1] != gzipMagic[1] {
+		return b
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		return b
+	}
+	defer func() { _ = zr.Close() }() //nolint:errcheck
+	out, err := io.ReadAll(zr)
+	if err != nil {
+		return b
+	}
+	return out
+}

--- a/pkg/cxo/cxoutils/compress_test.go
+++ b/pkg/cxo/cxoutils/compress_test.go
@@ -1,0 +1,44 @@
+package cxoutils
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestGzipRoundTrip(t *testing.T) {
+	orig := []byte(`[{"t_id":"abc","edges":["x","y"],"type":"stcpr"}]`)
+	gz := Gzip(orig)
+	if len(gz) < 2 || gz[0] != 0x1f || gz[1] != 0x8b {
+		t.Fatalf("Gzip output is not a gzip stream: %x", gz[:min(2, len(gz))])
+	}
+	if !bytes.Equal(Gunzip(gz), orig) {
+		t.Errorf("Gunzip(Gzip(x)) != x")
+	}
+}
+
+func TestGunzipPassesThroughRawJSON(t *testing.T) {
+	// A raw (non-gzip) body — e.g. from a publisher that predates compression —
+	// must pass through unchanged (self-describing format, skew-safe).
+	raw := []byte(`{"hello":"world"}`)
+	if !bytes.Equal(Gunzip(raw), raw) {
+		t.Errorf("Gunzip must pass raw JSON through unchanged")
+	}
+}
+
+func TestGzipEmpty(t *testing.T) {
+	if Gzip(nil) != nil {
+		t.Errorf("Gzip(nil) should be nil")
+	}
+	if Gunzip(nil) != nil {
+		t.Errorf("Gunzip(nil) should be nil")
+	}
+}
+
+func TestGunzipMalformedDegradesToRaw(t *testing.T) {
+	// Bytes that start with the gzip magic but aren't a valid stream must not be
+	// dropped — return them unchanged so the caller can try to parse as raw.
+	bad := []byte{0x1f, 0x8b, 0x00, 0x01, 0x02}
+	if !bytes.Equal(Gunzip(bad), bad) {
+		t.Errorf("malformed gzip should degrade to the original bytes")
+	}
+}

--- a/pkg/transport-discovery/api/cxo_all_transports_publisher.go
+++ b/pkg/transport-discovery/api/cxo_all_transports_publisher.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -143,7 +144,11 @@ func (a *AllTransportsCXOPublisher) publishOnce(ctx context.Context) {
 			a.recordError(err)
 			continue
 		}
-		if err := a.pub.Put(v.path, body); err != nil {
+		// gzip the snapshot before publishing: CXO stores + propagates object
+		// bytes verbatim, so a raw JSON body travels uncompressed. Subscribers
+		// auto-detect + gunzip (cxoutils.Gunzip). See docs — this keeps the CXO
+		// feed from being a bandwidth regression vs the gzipped HTTP endpoint.
+		if err := a.pub.Put(v.path, cxoutils.Gzip(body)); err != nil {
 			a.log.WithError(err).WithField("path", v.path).Warn("publisher Put failed")
 			a.recordError(err)
 			continue

--- a/pkg/visor/api_all_transports.go
+++ b/pkg/visor/api_all_transports.go
@@ -18,6 +18,7 @@ package visor
 import (
 	"errors"
 
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	tpdapi "github.com/skycoin/skywire/pkg/transport-discovery/api"
 )
 
@@ -46,5 +47,7 @@ func (v *Visor) FetchAllTransportsCXO(withSelf bool) ([]byte, error) {
 	if !ok || len(body) == 0 {
 		return nil, ErrTPDAllTransportsNotReady
 	}
-	return body, nil
+	// The CXO publisher gzips the snapshot; return decompressed JSON to callers
+	// (raw bodies from an older publisher pass through unchanged).
+	return cxoutils.Gunzip(body), nil
 }

--- a/pkg/visor/cxo_transport_discovery.go
+++ b/pkg/visor/cxo_transport_discovery.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/transport"
 	tpdapi "github.com/skycoin/skywire/pkg/transport-discovery/api"
 )
@@ -52,6 +53,7 @@ func (c *cxoAwareTPD) GetAllTransports(ctx context.Context) ([]*transport.Entry,
 			defer mgr.ReleaseFor(TabCLITransports)
 			body, _, ok := mgr.Get(FeedTPDAllTransports, tpdapi.AllTransportsPathWithoutSelf)
 			if ok && len(body) > 0 {
+				body = cxoutils.Gunzip(body) // publisher gzips; raw bodies pass through
 				var entries []*transport.Entry
 				if err := json.Unmarshal(body, &entries); err == nil {
 					return entries, nil


### PR DESCRIPTION
## What / why

CXO stores and propagates object bytes verbatim — it has **no built-in compression** — so the all-transports snapshot published to CXO (`cxo_all_transports_publisher.go`) travelled as **raw JSON**. That makes the in-progress HTTP→CXO migration a **bandwidth regression** vs the already-gzipped `/all-transports` HTTP endpoint (relevant to the current deployment-egress concern).

Adds `pkg/cxo/cxoutils.Gzip`/`Gunzip` — **magic-byte auto-detecting**, so the format is self-describing and **skew-safe**:
- The TPD publisher gzips the snapshot before `pub.Put`.
- The two visor consumers (`cxo_transport_discovery` read + `api_all_transports`) `Gunzip` on read.
- A subscriber that predates this parses the old **raw** bodies unchanged (passthrough); one that reads a gzip body it can't handle falls back to the gzipped HTTP endpoint (the CXO path is already best-effort with HTTP fallback). No breakage during rollout, in either direction.

Reusable for the other uncompressed CXO feeds (registration-over-CXO, reward) as a follow-up.

## Test

`pkg/cxo/cxoutils/compress_test.go`: gzip round-trip + magic header, raw-JSON passthrough, empty, and malformed-degrades-to-raw. `go build ./pkg/transport-discovery/... ./pkg/visor/ ./pkg/cxo/...`, `go test ./pkg/cxo/cxoutils/`, `golangci-lint` — all green.