### PR TITLE
feat(router): wire warm-standby demote/promote through on_tick ABI (gate-5 step 2)

### DIFF
--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -324,6 +324,17 @@ type RotationAction struct {
 	// as the disjoint-intermediate filter.
 	AddLeg      bool
 	ExcludeHops []string
+
+	// DemoteToStandby / PromoteFromStandby move legs between the active set
+	// and warm standby WITHOUT teardown: a demoted leg keeps its rules (the
+	// keepalive/liveness loops keep them alive) but is no longer selected for
+	// sending; promoting clears that instantly, with no route setup. This is
+	// the cheap alternative to Drop+re-dial for policy-driven leg moves — see
+	// docs/warm_standby_legs_rfc.md. Indices are current-tick leg indices, like
+	// DropLegs. Applied before DropLegs (which compacts) so the indices stay
+	// valid.
+	DemoteToStandby    []int
+	PromoteFromStandby []int
 }
 
 // RotationHook fires periodically per active route group, giving

--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -379,9 +379,11 @@ func (h *Hook) OnTick(info router.DialInfo, legs []router.LegInfo) router.Rotati
 		return router.RotationAction{}
 	}
 	return router.RotationAction{
-		DropLegs:    append([]int(nil), action.DropLegs...),
-		AddLeg:      action.AddLeg,
-		ExcludeHops: append([]string(nil), action.ExcludeHops...),
+		DropLegs:           append([]int(nil), action.DropLegs...),
+		AddLeg:             action.AddLeg,
+		ExcludeHops:        append([]string(nil), action.ExcludeHops...),
+		DemoteToStandby:    append([]int(nil), action.DemoteToStandby...),
+		PromoteFromStandby: append([]int(nil), action.PromoteFromStandby...),
 	}
 }
 

--- a/pkg/router/policy/types.go
+++ b/pkg/router/policy/types.go
@@ -210,4 +210,9 @@ type RotationAction struct {
 	DropLegs    []int
 	AddLeg      bool
 	ExcludeHops []string
+	// DemoteToStandby / PromoteFromStandby move legs to/from warm standby
+	// without teardown (kept alive, just not selected for sending). See
+	// router.RotationAction and docs/warm_standby_legs_rfc.md.
+	DemoteToStandby    []int
+	PromoteFromStandby []int
 }

--- a/pkg/router/policy/wasm/abi.go
+++ b/pkg/router/policy/wasm/abi.go
@@ -119,7 +119,9 @@ type TickInputWire struct {
 // in — they are not stable across ticks. Policies must re-read
 // the legs slice each tick.
 type RotationActionWire struct {
-	DropLegs    []int    `json:"drop_legs,omitempty"`
-	AddLeg      bool     `json:"add_leg,omitempty"`
-	ExcludeHops []string `json:"exclude_hops,omitempty"`
+	DropLegs           []int    `json:"drop_legs,omitempty"`
+	AddLeg             bool     `json:"add_leg,omitempty"`
+	ExcludeHops        []string `json:"exclude_hops,omitempty"`
+	DemoteToStandby    []int    `json:"demote_to_standby,omitempty"`
+	PromoteFromStandby []int    `json:"promote_from_standby,omitempty"`
 }

--- a/pkg/router/policy/wasm/evaluator.go
+++ b/pkg/router/policy/wasm/evaluator.go
@@ -310,9 +310,11 @@ func (e *Evaluator) callRotation(ctx context.Context, fn api.Function, name stri
 
 func rotationFromWire(w RotationActionWire) policy.RotationAction {
 	return policy.RotationAction{
-		DropLegs:    append([]int(nil), w.DropLegs...),
-		AddLeg:      w.AddLeg,
-		ExcludeHops: append([]string(nil), w.ExcludeHops...),
+		DropLegs:           append([]int(nil), w.DropLegs...),
+		AddLeg:             w.AddLeg,
+		ExcludeHops:        append([]string(nil), w.ExcludeHops...),
+		DemoteToStandby:    append([]int(nil), w.DemoteToStandby...),
+		PromoteFromStandby: append([]int(nil), w.PromoteFromStandby...),
 	}
 }
 

--- a/pkg/router/policy/wasm/rotation_standby_test.go
+++ b/pkg/router/policy/wasm/rotation_standby_test.go
@@ -1,0 +1,24 @@
+package wasm
+
+import "testing"
+
+// TestRotationFromWireCarriesStandby pins that a policy's on_tick can drive the
+// warm-standby primitive: the demote/promote leg lists survive the wasm wire →
+// policy.RotationAction conversion (which the router then applies via
+// setLegStandby, no teardown). See docs/warm_standby_legs_rfc.md.
+func TestRotationFromWireCarriesStandby(t *testing.T) {
+	got := rotationFromWire(RotationActionWire{
+		DemoteToStandby:    []int{2},
+		PromoteFromStandby: []int{1},
+		AddLeg:             true,
+	})
+	if len(got.DemoteToStandby) != 1 || got.DemoteToStandby[0] != 2 {
+		t.Errorf("DemoteToStandby not carried: %v", got.DemoteToStandby)
+	}
+	if len(got.PromoteFromStandby) != 1 || got.PromoteFromStandby[0] != 1 {
+		t.Errorf("PromoteFromStandby not carried: %v", got.PromoteFromStandby)
+	}
+	if !got.AddLeg {
+		t.Error("AddLeg not carried alongside standby moves")
+	}
+}

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1045,8 +1045,22 @@ func (rg *RouteGroup) rotationServiceFn(_ time.Duration) {
 		return
 	}
 	action := hook.OnTick(info, legs)
-	if len(action.DropLegs) == 0 && !action.AddLeg {
+	if len(action.DropLegs) == 0 && !action.AddLeg &&
+		len(action.DemoteToStandby) == 0 && len(action.PromoteFromStandby) == 0 {
 		return
+	}
+
+	// Promote/demote first: they only flip the mux's per-leg standby flag (no
+	// teardown, no compaction), so they must run on the pre-drop indices. A
+	// demoted leg stays in tps[] — kept alive by the keepalive/liveness loops —
+	// but is skipped by selectTransport; promoting re-selects it instantly.
+	if rg.mux != nil {
+		for _, idx := range action.PromoteFromStandby {
+			rg.mux.setLegStandby(idx, false)
+		}
+		for _, idx := range action.DemoteToStandby {
+			rg.mux.setLegStandby(idx, true)
+		}
 	}
 
 	if len(action.DropLegs) > 0 {


### PR DESCRIPTION
Builds on the dormant leg-state (#3974) toward the gate-5 warm-standby primitive (RFC #3973).

A policy's `on_tick` can now move legs **to and from warm standby without teardown**:
- `RotationAction` gains `DemoteToStandby` / `PromoteFromStandby` (current-tick index lists), threaded through the whole policy ABI: `policy.RotationAction`, the `Hook` mapping, the wasm `RotationActionWire` + `rotationFromWire`.
- `rotationServiceFn` applies them via the mux's `setLegStandby` **before** any `DropLegs` — demote/promote only flip a per-leg flag (no teardown, no slice compaction), so they run correctly on the pre-drop indices.
- A demoted leg stays in `tps[]`, kept alive by the keepalive/liveness loops, but is skipped by `selectTransport`; promoting re-selects it **instantly, with no route setup** — the cheap alternative to drop+re-dial that the fleet-collapse measurement showed we need.

Host-side only. The guest bundle wire field + a proof policy that hot-swaps a warm standby leg with no throughput dip land in a follow-up (kept out of this PR to avoid colliding with the in-flight composite-preset bundle edit).

`go test ./pkg/router/... ./pkg/router/policy/...`, `golangci-lint` — green.