### PR TITLE
feat(routing-policy): per-leg mux telemetry harness — NDJSON + lifecycle events + chart (gate-2)

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_info.go
+++ b/cmd/skywire-cli/commands/proxy/mux_info.go
@@ -18,15 +18,19 @@ import (
 )
 
 var (
-	muxInfoApp     string
-	muxInfoWatch   time.Duration
-	muxInfoVerbose bool
+	muxInfoApp      string
+	muxInfoWatch    time.Duration
+	muxInfoVerbose  bool
+	muxInfoNDJSON   string
+	muxInfoDuration time.Duration
 )
 
 func init() {
 	muxInfoCmd.Flags().StringVarP(&muxInfoApp, "name", "n", "skysocks-client", "app name to query (e.g. skysocks-client, vpn-client)")
 	muxInfoCmd.Flags().DurationVarP(&muxInfoWatch, "watch", "w", 0, "refresh interval; 0 prints once and exits (e.g. 1s, 500ms)")
 	muxInfoCmd.Flags().BoolVarP(&muxInfoVerbose, "verbose", "v", false, "show full PKs / transport IDs (default: short hex prefixes)")
+	muxInfoCmd.Flags().StringVar(&muxInfoNDJSON, "ndjson", "", "per-leg telemetry harness: stream NDJSON samples + lifecycle events to FILE ('-' for stdout); interval = --watch (default 1s)")
+	muxInfoCmd.Flags().DurationVar(&muxInfoDuration, "duration", 0, "with --ndjson: stop after this long (0 = until ctrl+c)")
 	addMuxSub(muxInfoCmd, "mux-info")
 }
 
@@ -55,6 +59,12 @@ Examples:
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
 		}
 		defer rpcClient.Close() //nolint:errcheck,gosec
+
+		// Per-leg telemetry harness: NDJSON stream for the routing-policy rig.
+		if muxInfoNDJSON != "" {
+			runMuxTelemetry(cmd, func() (any, error) { return rpcClient.RouteGroupMuxInfo(muxInfoApp) })
+			return
+		}
 
 		// One-shot
 		if muxInfoWatch <= 0 {
@@ -113,6 +123,9 @@ type muxLegInfo struct {
 	SentPackets uint64  `json:"sent_packets"`
 	RecvBytes   uint64  `json:"recv_bytes"`
 	RecvPackets uint64  `json:"recv_packets"`
+	Retransmits uint64  `json:"retransmits"`
+	Alive       bool    `json:"alive"`
+	Standby     bool    `json:"standby"`
 }
 
 // muxRateTracker remembers the previous poll's per-leg byte counters so

--- a/cmd/skywire-cli/commands/proxy/mux_telemetry.go
+++ b/cmd/skywire-cli/commands/proxy/mux_telemetry.go
@@ -1,0 +1,297 @@
+// Package skysocksc cmd/skywire-cli/commands/proxy/mux_telemetry.go c4-vis-cli
+package skysocksc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"sort"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+)
+
+// This is the per-leg telemetry harness for the WASM-routing-policy rig. It
+// polls RouteGroupMuxInfo (the same rg.snapshotLegs() the policy on_tick ABI
+// sees, so the harness and the policy read ONE source) and emits, on one clock:
+//
+//   - a "sample" record per route group each tick, carrying every live leg's
+//     {route_index, intermediate_pk, transport_kind, inst_send_bps,
+//     inst_recv_bps, rtt_ms, retransmits, gate_state, alive}; and
+//   - leg-lifecycle event records (established / promoted / demoted / failed /
+//     dropped) derived by diffing this tick's leg set against the last.
+//
+// gate_state is "standby" for a warm standby leg (rules kept, not sending) and
+// "active" otherwise — so a warm-standby hot-swap shows as a demoted+promoted
+// pair with no throughput dip on the sample series. Lifecycle events share the
+// sample's timestamp, so a chart can render them as markers on the leg's line.
+//
+// Events are derived by polling, so their resolution is the sample interval: a
+// leg that appears and vanishes within one tick is not observed. gate_state
+// transitions and drops persist, so a ≥1 Hz poll catches them on the next tick.
+
+// muxTeleLeg is one live leg in a sample record.
+type muxTeleLeg struct {
+	RouteIndex     int     `json:"route_index"`
+	IntermediatePK string  `json:"intermediate_pk"`
+	TransportKind  string  `json:"transport_kind"`
+	InstSendBps    float64 `json:"inst_send_bps"`
+	InstRecvBps    float64 `json:"inst_recv_bps"`
+	RttMs          float64 `json:"rtt_ms"`
+	Retransmits    uint64  `json:"retransmits"`
+	GateState      string  `json:"gate_state"` // "active" | "standby"
+	Alive          bool    `json:"alive"`
+}
+
+// muxTeleRecord is one NDJSON line: either a per-rg "sample" (Legs populated)
+// or a leg-lifecycle event (RouteIndex/IntermediatePK/TransportKind populated).
+type muxTeleRecord struct {
+	Ts   string `json:"ts"`
+	Type string `json:"type"` // sample | established | promoted | demoted | failed | dropped
+	App  string `json:"app"`
+	RG   string `json:"rg"`
+
+	// sample only
+	Legs []muxTeleLeg `json:"legs,omitempty"`
+
+	// event only
+	RouteIndex     int    `json:"route_index,omitempty"`
+	IntermediatePK string `json:"intermediate_pk,omitempty"`
+	TransportKind  string `json:"transport_kind,omitempty"`
+}
+
+// muxTeleLegState is the per-leg carry-over between polls, keyed by
+// rgKey#index, used to compute inst rates and diff lifecycle events.
+type muxTeleLegState struct {
+	rg             string
+	sent, recv     uint64
+	standby, alive bool
+	intermediatePK string
+	transportKind  string
+}
+
+// muxTelemetry holds the previous poll's per-leg state so a poll can compute
+// inst bps and emit lifecycle events. Zero value (via newMuxTelemetry) is
+// ready; the first poll seeds state and emits an "established" per leg.
+type muxTelemetry struct {
+	app  string
+	prev map[string]muxTeleLegState
+	at   time.Time
+}
+
+func newMuxTelemetry(app string) *muxTelemetry {
+	return &muxTelemetry{app: app, prev: map[string]muxTeleLegState{}}
+}
+
+// muxTeleKey is the stable cross-poll identity of a leg: rg descriptor + leg
+// index (transports are appended, never re-ordered, so index is stable for the
+// rg's life).
+func muxTeleKey(rgKey string, index int) string {
+	return fmt.Sprintf("%s#%d", rgKey, index)
+}
+
+func rgDescKey(rg muxRouteGroupInfo) string {
+	return fmt.Sprintf("%s:%d>%s:%d", rg.Desc.SrcPK, rg.Desc.SrcPort, rg.Desc.DstPK, rg.Desc.DstPort)
+}
+
+// build turns one poll into its NDJSON records and advances the tracker. It is
+// deterministic in (rgs, now) given the tracker's prior state, so it is unit
+// testable without a live visor. Records are ordered: for each rg, lifecycle
+// events (sorted by index) first, then that rg's sample; finally "dropped"
+// events for legs that were present last poll but absent now.
+func (mt *muxTelemetry) build(rgs []muxRouteGroupInfo, now time.Time) []muxTeleRecord {
+	ts := now.UTC().Format(time.RFC3339Nano)
+	elapsed := now.Sub(mt.at).Seconds()
+	haveRates := !mt.at.IsZero() && elapsed > 0
+
+	var out []muxTeleRecord
+	next := make(map[string]muxTeleLegState)
+	seen := make(map[string]bool)
+
+	for _, rg := range rgs {
+		rgKey := rgDescKey(rg)
+		legs := append([]muxLegInfo(nil), rg.Legs...)
+		sort.SliceStable(legs, func(i, j int) bool { return legs[i].Index < legs[j].Index })
+
+		var events []muxTeleRecord
+		sample := muxTeleRecord{Ts: ts, Type: "sample", App: mt.app, RG: rgKey}
+
+		for _, leg := range legs {
+			key := muxTeleKey(rgKey, leg.Index)
+			seen[key] = true
+			gate := "active"
+			if leg.Standby {
+				gate = "standby"
+			}
+			var sendBps, recvBps float64
+			prev, hadPrev := mt.prev[key]
+			if haveRates && hadPrev {
+				if leg.SentBytes >= prev.sent {
+					sendBps = float64(leg.SentBytes-prev.sent) / elapsed
+				}
+				if leg.RecvBytes >= prev.recv {
+					recvBps = float64(leg.RecvBytes-prev.recv) / elapsed
+				}
+			}
+			sample.Legs = append(sample.Legs, muxTeleLeg{
+				RouteIndex:     leg.Index,
+				IntermediatePK: leg.RemotePK,
+				TransportKind:  leg.TpType,
+				InstSendBps:    sendBps,
+				InstRecvBps:    recvBps,
+				RttMs:          leg.LatencyMS,
+				Retransmits:    leg.Retransmits,
+				GateState:      gate,
+				Alive:          leg.Alive,
+			})
+
+			// Lifecycle events by diff against last poll. On the first poll a
+			// leg is "established" (session start); thereafter only genuine
+			// transitions fire.
+			if !hadPrev {
+				events = append(events, mt.event("established", ts, rgKey, leg))
+			} else {
+				if prev.standby && !leg.Standby {
+					events = append(events, mt.event("promoted", ts, rgKey, leg))
+				} else if !prev.standby && leg.Standby {
+					events = append(events, mt.event("demoted", ts, rgKey, leg))
+				}
+				if prev.alive && !leg.Alive {
+					events = append(events, mt.event("failed", ts, rgKey, leg))
+				}
+			}
+
+			next[key] = muxTeleLegState{
+				rg:             rgKey,
+				sent:           leg.SentBytes,
+				recv:           leg.RecvBytes,
+				standby:        leg.Standby,
+				alive:          leg.Alive,
+				intermediatePK: leg.RemotePK,
+				transportKind:  leg.TpType,
+			}
+		}
+
+		out = append(out, events...)
+		out = append(out, sample)
+	}
+
+	// "dropped": legs present last poll, absent now. Sort keys for determinism.
+	var droppedKeys []string
+	for key := range mt.prev {
+		if !seen[key] {
+			droppedKeys = append(droppedKeys, key)
+		}
+	}
+	sort.Strings(droppedKeys)
+	for _, key := range droppedKeys {
+		st := mt.prev[key]
+		out = append(out, muxTeleRecord{
+			Ts: ts, Type: "dropped", App: mt.app, RG: st.rg,
+			RouteIndex:     muxTeleIndexFromKey(key),
+			IntermediatePK: st.intermediatePK,
+			TransportKind:  st.transportKind,
+		})
+	}
+
+	mt.prev = next
+	mt.at = now
+	return out
+}
+
+func (mt *muxTelemetry) event(kind, ts, rgKey string, leg muxLegInfo) muxTeleRecord {
+	return muxTeleRecord{
+		Ts: ts, Type: kind, App: mt.app, RG: rgKey,
+		RouteIndex:     leg.Index,
+		IntermediatePK: leg.RemotePK,
+		TransportKind:  leg.TpType,
+	}
+}
+
+// runMuxTelemetry drives the per-leg telemetry harness: poll RouteGroupMuxInfo
+// on a fixed interval and write each poll's NDJSON records to the sink until
+// ctrl+c or --duration elapses. poll returns the raw RPC value, which we
+// round-trip through JSON into the CLI mirror struct (the JSON tags are the
+// stable contract), so the emitter never imports the visor type.
+func runMuxTelemetry(cmd *cobra.Command, poll func() (any, error)) {
+	interval := muxInfoWatch
+	if interval <= 0 {
+		interval = time.Second // the harness's ">=1 Hz" default
+	}
+
+	// Sink: FILE (append) or stdout for "-".
+	sink := os.Stdout
+	if muxInfoNDJSON != "-" {
+		f, err := os.OpenFile(muxInfoNDJSON, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("open --ndjson %s: %w", muxInfoNDJSON, err))
+		}
+		defer f.Close() //nolint:errcheck,gosec
+		sink = f
+		fmt.Fprintf(os.Stderr, "mux telemetry: app=%s interval=%s → %s (ctrl+c to stop)\n", muxInfoApp, interval, muxInfoNDJSON)
+	}
+	enc := json.NewEncoder(sink)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	var deadline time.Time
+	if muxInfoDuration > 0 {
+		deadline = time.Now().Add(muxInfoDuration)
+	}
+
+	mt := newMuxTelemetry(muxInfoApp)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	writeOnce := func() {
+		infos, err := poll()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "RouteGroupMuxInfo: %v\n", err)
+			return
+		}
+		raw, _ := json.Marshal(infos) //nolint:errcheck
+		var rgs []muxRouteGroupInfo   //nolint:prealloc
+		_ = json.Unmarshal(raw, &rgs) //nolint:errcheck
+		for _, rec := range mt.build(rgs, time.Now()) {
+			_ = enc.Encode(rec) //nolint:errcheck
+		}
+	}
+
+	writeOnce() // first sample fires immediately
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			writeOnce()
+			if !deadline.IsZero() && time.Now().After(deadline) {
+				return
+			}
+		}
+	}
+}
+
+// muxTeleIndexFromKey pulls the leg index back out of an "rgKey#index" key.
+// Returns 0 if malformed (never happens for keys we mint).
+func muxTeleIndexFromKey(key string) int {
+	i := -1
+	for p := len(key) - 1; p >= 0; p-- {
+		if key[p] == '#' {
+			i = p
+			break
+		}
+	}
+	if i < 0 || i+1 >= len(key) {
+		return 0
+	}
+	var idx int
+	if _, err := fmt.Sscanf(key[i+1:], "%d", &idx); err != nil {
+		return 0
+	}
+	return idx
+}

--- a/cmd/skywire-cli/commands/proxy/mux_telemetry_test.go
+++ b/cmd/skywire-cli/commands/proxy/mux_telemetry_test.go
@@ -1,0 +1,161 @@
+// Package skysocksc cmd/skywire-cli/commands/proxy/mux_telemetry_test.go c4-vis-cli
+package skysocksc
+
+import (
+	"testing"
+	"time"
+)
+
+func rgWith(legs ...muxLegInfo) muxRouteGroupInfo {
+	rg := muxRouteGroupInfo{MuxEnabled: true}
+	rg.Desc.SrcPK = "src"
+	rg.Desc.SrcPort = 1
+	rg.Desc.DstPK = "dst"
+	rg.Desc.DstPort = 2
+	rg.Legs = legs
+	return rg
+}
+
+func recTypes(recs []muxTeleRecord) map[string]int {
+	m := map[string]int{}
+	for _, r := range recs {
+		m[r.Type]++
+	}
+	return m
+}
+
+// TestTelemetryFirstPollEstablishes: the first poll seeds state and emits an
+// "established" per leg plus one "sample", with zero inst rates (no prior).
+func TestTelemetryFirstPollEstablishes(t *testing.T) {
+	mt := newMuxTelemetry("skysocks-client")
+	t0 := time.Unix(1000, 0)
+	recs := mt.build([]muxRouteGroupInfo{rgWith(
+		muxLegInfo{Index: 0, TpType: "dmsg", RemotePK: "pkA", Alive: true},
+		muxLegInfo{Index: 1, TpType: "dmsg", RemotePK: "pkB", Alive: true},
+	)}, t0)
+
+	types := recTypes(recs)
+	if types["established"] != 2 {
+		t.Errorf("established = %d, want 2; recs=%+v", types["established"], recs)
+	}
+	if types["sample"] != 1 {
+		t.Errorf("sample = %d, want 1", types["sample"])
+	}
+	for _, r := range recs {
+		if r.Type != "sample" {
+			continue
+		}
+		for _, l := range r.Legs {
+			if l.InstSendBps != 0 || l.InstRecvBps != 0 {
+				t.Errorf("first poll leg %d should have 0 rates, got send=%v recv=%v", l.RouteIndex, l.InstSendBps, l.InstRecvBps)
+			}
+		}
+	}
+}
+
+// TestTelemetryInstBpsFromDelta: the second poll computes inst bps from the
+// byte delta over the elapsed interval.
+func TestTelemetryInstBpsFromDelta(t *testing.T) {
+	mt := newMuxTelemetry("skysocks-client")
+	t0 := time.Unix(1000, 0)
+	mt.build([]muxRouteGroupInfo{rgWith(
+		muxLegInfo{Index: 0, TpType: "dmsg", RemotePK: "pkA", Alive: true, SentBytes: 1000, RecvBytes: 2000},
+	)}, t0)
+
+	// +2s, +4000 sent, +8000 recv → 2000 B/s send, 4000 B/s recv.
+	recs := mt.build([]muxRouteGroupInfo{rgWith(
+		muxLegInfo{Index: 0, TpType: "dmsg", RemotePK: "pkA", Alive: true, SentBytes: 5000, RecvBytes: 10000},
+	)}, t0.Add(2*time.Second))
+
+	var sample *muxTeleRecord
+	for i := range recs {
+		if recs[i].Type == "sample" {
+			sample = &recs[i]
+		}
+	}
+	if sample == nil || len(sample.Legs) != 1 {
+		t.Fatalf("expected one sample with one leg, got %+v", recs)
+	}
+	if got := sample.Legs[0].InstSendBps; got != 2000 {
+		t.Errorf("InstSendBps = %v, want 2000", got)
+	}
+	if got := sample.Legs[0].InstRecvBps; got != 4000 {
+		t.Errorf("InstRecvBps = %v, want 4000", got)
+	}
+}
+
+// TestTelemetryHotSwapEvents: a warm-standby hot-swap (leg 2 active→standby,
+// leg 3 standby→active between polls) emits a demoted+promoted pair and marks
+// the legs' gate_state accordingly — the gate-5 no-dip swap made observable.
+func TestTelemetryHotSwapEvents(t *testing.T) {
+	mt := newMuxTelemetry("skysocks-client")
+	t0 := time.Unix(1000, 0)
+	// Poll 1: leg 2 active, leg 3 warm standby.
+	mt.build([]muxRouteGroupInfo{rgWith(
+		muxLegInfo{Index: 2, TpType: "dmsg", RemotePK: "pkC", Alive: true, Standby: false},
+		muxLegInfo{Index: 3, TpType: "dmsg", RemotePK: "pkD", Alive: true, Standby: true},
+	)}, t0)
+	// Poll 2: swapped — leg 2 demoted to standby, leg 3 promoted to active.
+	recs := mt.build([]muxRouteGroupInfo{rgWith(
+		muxLegInfo{Index: 2, TpType: "dmsg", RemotePK: "pkC", Alive: true, Standby: true},
+		muxLegInfo{Index: 3, TpType: "dmsg", RemotePK: "pkD", Alive: true, Standby: false},
+	)}, t0.Add(time.Second))
+
+	types := recTypes(recs)
+	if types["promoted"] != 1 {
+		t.Errorf("promoted = %d, want 1; recs=%+v", types["promoted"], recs)
+	}
+	if types["demoted"] != 1 {
+		t.Errorf("demoted = %d, want 1; recs=%+v", types["demoted"], recs)
+	}
+	// gate_state in the sample must reflect the swap.
+	for _, r := range recs {
+		if r.Type != "sample" {
+			continue
+		}
+		for _, l := range r.Legs {
+			switch l.RouteIndex {
+			case 2:
+				if l.GateState != "standby" {
+					t.Errorf("leg 2 gate_state = %q, want standby", l.GateState)
+				}
+			case 3:
+				if l.GateState != "active" {
+					t.Errorf("leg 3 gate_state = %q, want active", l.GateState)
+				}
+			}
+		}
+	}
+}
+
+// TestTelemetryDropAndFail: a leg that disappears emits "dropped"; a leg that
+// goes not-alive but stays present emits "failed".
+func TestTelemetryDropAndFail(t *testing.T) {
+	mt := newMuxTelemetry("skysocks-client")
+	t0 := time.Unix(1000, 0)
+	mt.build([]muxRouteGroupInfo{rgWith(
+		muxLegInfo{Index: 0, TpType: "dmsg", RemotePK: "pkA", Alive: true},
+		muxLegInfo{Index: 1, TpType: "dmsg", RemotePK: "pkB", Alive: true},
+	)}, t0)
+	// Poll 2: leg 1 gone entirely; leg 0 still present but dead.
+	recs := mt.build([]muxRouteGroupInfo{rgWith(
+		muxLegInfo{Index: 0, TpType: "dmsg", RemotePK: "pkA", Alive: false},
+	)}, t0.Add(time.Second))
+
+	types := recTypes(recs)
+	if types["dropped"] != 1 {
+		t.Errorf("dropped = %d, want 1; recs=%+v", types["dropped"], recs)
+	}
+	if types["failed"] != 1 {
+		t.Errorf("failed = %d, want 1; recs=%+v", types["failed"], recs)
+	}
+}
+
+func TestMuxTeleIndexFromKey(t *testing.T) {
+	cases := map[string]int{"src:1>dst:2#0": 0, "src:1>dst:2#7": 7, "a#b#12": 12, "no-hash": 0}
+	for k, want := range cases {
+		if got := muxTeleIndexFromKey(k); got != want {
+			t.Errorf("muxTeleIndexFromKey(%q) = %d, want %d", k, got, want)
+		}
+	}
+}

--- a/docs/examples/routing-policies/telemetry/README.md
+++ b/docs/examples/routing-policies/telemetry/README.md
@@ -1,0 +1,72 @@
+# Per-leg mux telemetry harness
+
+The routing-policy rig needs to *prove* a WASM policy is adaptive and better —
+per leg, over time, against a controlled far-end. This harness is the
+measurement half.
+
+## What it samples
+
+`skywire cli proxy mux info --ndjson FILE` polls the live route group for an app
+(default `skysocks-client`) once per `--watch` interval (default `1s`, i.e.
+≥1 Hz) and writes newline-delimited JSON. It reads the **same**
+`rg.snapshotLegs()` the policy `on_tick` ABI sees, so the harness and the policy
+observe one source of truth.
+
+Two record shapes, all on one clock (the sample tick's timestamp):
+
+**`sample`** — one per route group per tick:
+
+```json
+{"ts":"2026-08-18T15:40:01.002Z","type":"sample","app":"skysocks-client",
+ "rg":"<src>:3>...:44","legs":[
+   {"route_index":0,"intermediate_pk":"02ab..","transport_kind":"dmsg",
+    "inst_send_bps":81234,"inst_recv_bps":512901,"rtt_ms":42,
+    "retransmits":3,"gate_state":"active","alive":true}]}
+```
+
+**lifecycle events** — derived by diffing each tick's leg set against the last:
+
+| type          | fires when                                    |
+|---------------|-----------------------------------------------|
+| `established` | a leg index appears (or first poll)           |
+| `promoted`    | a leg's `gate_state` goes `standby` → `active` |
+| `demoted`     | a leg's `gate_state` goes `active` → `standby` |
+| `failed`      | a present leg goes `alive:false`              |
+| `dropped`     | a leg index disappears                         |
+
+```json
+{"ts":"2026-08-18T15:40:11.010Z","type":"promoted","app":"skysocks-client",
+ "rg":"<src>:3>...:44","route_index":3,"intermediate_pk":"02cd..","transport_kind":"dmsg"}
+```
+
+Because events are polled, their resolution is the sample interval — a leg that
+appears and vanishes inside one tick is not seen. `gate_state` transitions and
+drops persist, so a ≥1 Hz poll catches them on the next tick.
+
+## Usage
+
+```sh
+# Stream to a file for a fixed 5-minute rig run:
+skywire cli proxy mux info --ndjson run.ndjson --watch 1s --duration 5m
+
+# Or to stdout, piped:
+skywire cli proxy mux info --ndjson - --watch 500ms | tee run.ndjson
+
+# Query a different app:
+skywire cli proxy mux info -n vpn-client --ndjson run.ndjson
+```
+
+## Charting
+
+Open `mux-telemetry-chart.html` in a browser and load `run.ndjson` (file picker
+or drag-and-drop). It renders, per leg:
+
+- **bandwidth** — inst send/recv bps over time, and
+- **RTT** — per-leg `rtt_ms`,
+
+with policy lifecycle events drawn as vertical markers. A warm-standby hot-swap
+(gate-5) shows as a `demoted`+`promoted` marker pair with the aggregate
+throughput line staying flat across it — the "no capacity dip" proof.
+
+The page is fully self-contained (no external scripts/fonts/network) — it works
+opened directly from disk.

--- a/docs/examples/routing-policies/telemetry/mux-telemetry-chart.html
+++ b/docs/examples/routing-policies/telemetry/mux-telemetry-chart.html
@@ -1,0 +1,200 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>skywire mux per-leg telemetry</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 13px/1.4 system-ui, sans-serif; margin: 0; padding: 16px;
+         background: #0d1117; color: #c9d1d9; }
+  h1 { font-size: 16px; margin: 0 0 4px; }
+  .sub { color: #8b949e; margin: 0 0 12px; }
+  #drop { border: 1px dashed #30363d; border-radius: 8px; padding: 18px;
+          text-align: center; color: #8b949e; margin-bottom: 12px; }
+  #drop.hot { border-color: #58a6ff; color: #58a6ff; }
+  .controls { display: flex; gap: 14px; flex-wrap: wrap; align-items: center;
+              margin-bottom: 10px; }
+  label { user-select: none; }
+  canvas { width: 100%; background: #010409; border: 1px solid #21262d;
+           border-radius: 6px; display: block; margin-bottom: 12px; }
+  #legend { display: flex; gap: 14px; flex-wrap: wrap; margin-bottom: 8px; }
+  .lg { display: flex; align-items: center; gap: 5px; }
+  .sw { width: 12px; height: 12px; border-radius: 2px; display: inline-block; }
+  #stats { border-collapse: collapse; font-variant-numeric: tabular-nums; }
+  #stats th, #stats td { border: 1px solid #21262d; padding: 3px 8px; text-align: right; }
+  #stats th:first-child, #stats td:first-child { text-align: left; }
+  .muted { color: #8b949e; }
+  code { background: #161b22; padding: 1px 4px; border-radius: 3px; }
+</style>
+</head>
+<body>
+<h1>skywire mux per-leg telemetry</h1>
+<p class="sub">Load an NDJSON produced by <code>skywire cli proxy mux info --ndjson FILE</code>.</p>
+<div id="drop">Drop <code>run.ndjson</code> here, or <input type="file" id="file" accept=".ndjson,.json,.jsonl,.txt"></div>
+<div class="controls">
+  <label><input type="checkbox" id="mRecv" checked> recv bps</label>
+  <label><input type="checkbox" id="mSend"> send bps</label>
+  <label><input type="checkbox" id="mAgg" checked> aggregate recv</label>
+  <label><input type="checkbox" id="mEvents" checked> policy events</label>
+  <span class="muted" id="summary"></span>
+</div>
+<div id="legend"></div>
+<canvas id="bw" height="300"></canvas>
+<canvas id="rtt" height="200"></canvas>
+<table id="stats"></table>
+
+<script>
+"use strict";
+const COLORS = ["#58a6ff","#3fb950","#f778ba","#d29922","#a371f7","#ff7b72","#79c0ff","#56d364"];
+const EVENT_COLOR = { established:"#3fb950", promoted:"#58a6ff", demoted:"#d29922", failed:"#ff7b72", dropped:"#8b949e" };
+let MODEL = null;
+
+function parseNDJSON(text) {
+  const legs = new Map();      // key legKey -> {rg, idx, kind, color, pts:[{t,send,recv,rtt}]}
+  const events = [];           // {t, type, idx, rg}
+  let t0 = null;
+  const order = [];
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    const s = line.trim();
+    if (!s) continue;
+    let r; try { r = JSON.parse(s); } catch { continue; }
+    if (!r.ts || !r.type) continue;
+    const t = Date.parse(r.ts);
+    if (isNaN(t)) continue;
+    if (t0 === null) t0 = t;
+    const rel = (t - t0) / 1000;
+    if (r.type === "sample") {
+      for (const l of (r.legs || [])) {
+        const key = (r.rg||"") + "#" + l.route_index;
+        let leg = legs.get(key);
+        if (!leg) {
+          leg = { rg:r.rg, idx:l.route_index, kind:l.transport_kind, pk:l.intermediate_pk,
+                  color: COLORS[order.length % COLORS.length], pts:[] };
+          legs.set(key, leg); order.push(key);
+        }
+        leg.pts.push({ t:rel, send:+l.inst_send_bps||0, recv:+l.inst_recv_bps||0,
+                       rtt:+l.rtt_ms||0, gate:l.gate_state });
+      }
+    } else {
+      events.push({ t:rel, type:r.type, idx:r.route_index, rg:r.rg });
+    }
+  }
+  let tMax = 0;
+  for (const leg of legs.values()) for (const p of leg.pts) if (p.t > tMax) tMax = p.t;
+  for (const e of events) if (e.t > tMax) tMax = e.t;
+  return { legs, order, events, tMax: tMax || 1 };
+}
+
+function humanBps(v) {
+  if (v >= 1e9) return (v/1e9).toFixed(1)+"G";
+  if (v >= 1e6) return (v/1e6).toFixed(1)+"M";
+  if (v >= 1e3) return (v/1e3).toFixed(1)+"k";
+  return v.toFixed(0);
+}
+function median(a){ if(!a.length) return 0; const b=[...a].sort((x,y)=>x-y); const m=b.length>>1;
+  return b.length%2 ? b[m] : (b[m-1]+b[m])/2; }
+
+function drawChart(canvas, series, opts) {
+  const dpr = window.devicePixelRatio || 1;
+  const cw = canvas.clientWidth, ch = canvas.clientHeight;
+  canvas.width = cw*dpr; canvas.height = ch*dpr;
+  const g = canvas.getContext("2d"); g.scale(dpr,dpr);
+  g.clearRect(0,0,cw,ch);
+  const padL=64, padR=12, padT=12, padB=22;
+  const W=cw-padL-padR, H=ch-padT-padB;
+  const tMax = MODEL.tMax;
+  let yMax = 0;
+  for (const s of series) for (const p of s.pts) if (p.v > yMax) yMax = p.v;
+  yMax = yMax*1.1 || 1;
+  const X = t => padL + (t/tMax)*W;
+  const Y = v => padT + H - (v/yMax)*H;
+
+  // axes + gridlines
+  g.strokeStyle="#21262d"; g.fillStyle="#8b949e"; g.lineWidth=1; g.font="11px system-ui";
+  for (let i=0;i<=4;i++){ const v=yMax*i/4, y=Y(v);
+    g.beginPath(); g.moveTo(padL,y); g.lineTo(padL+W,y); g.stroke();
+    g.textAlign="right"; g.textBaseline="middle"; g.fillText(opts.fmt(v), padL-6, y); }
+  for (let i=0;i<=6;i++){ const t=tMax*i/6, x=X(t);
+    g.textAlign="center"; g.textBaseline="top"; g.fillText(t.toFixed(0)+"s", x, padT+H+4); }
+
+  // event markers
+  if (opts.events) {
+    for (const e of MODEL.events) {
+      const x=X(e.t); g.strokeStyle=EVENT_COLOR[e.type]||"#8b949e";
+      g.globalAlpha=0.5; g.setLineDash([3,3]);
+      g.beginPath(); g.moveTo(x,padT); g.lineTo(x,padT+H); g.stroke();
+      g.setLineDash([]); g.globalAlpha=1;
+    }
+  }
+  // series
+  for (const s of series) {
+    g.strokeStyle=s.color; g.lineWidth=s.width||1.6; g.globalAlpha=s.alpha||1;
+    if (s.dash) g.setLineDash(s.dash); else g.setLineDash([]);
+    g.beginPath(); let started=false;
+    for (const p of s.pts){ const x=X(p.t), y=Y(p.v);
+      if(!started){g.moveTo(x,y);started=true;} else g.lineTo(x,y); }
+    g.stroke(); g.setLineDash([]); g.globalAlpha=1;
+  }
+}
+
+function render() {
+  if (!MODEL) return;
+  const showRecv=mRecv.checked, showSend=mSend.checked, showAgg=mAgg.checked, showEv=mEvents.checked;
+  const bwSeries=[], rttSeries=[];
+  for (const key of MODEL.order) {
+    const leg = MODEL.legs.get(key);
+    if (showRecv) bwSeries.push({color:leg.color, pts:leg.pts.map(p=>({t:p.t,v:p.recv}))});
+    if (showSend) bwSeries.push({color:leg.color, dash:[4,3], alpha:0.8, pts:leg.pts.map(p=>({t:p.t,v:p.send}))});
+    rttSeries.push({color:leg.color, pts:leg.pts.map(p=>({t:p.t,v:p.rtt}))});
+  }
+  if (showAgg) {
+    // aggregate recv across legs at each distinct timestamp
+    const byT=new Map();
+    for (const leg of MODEL.legs.values()) for (const p of leg.pts)
+      byT.set(p.t,(byT.get(p.t)||0)+p.recv);
+    const pts=[...byT.entries()].sort((a,b)=>a[0]-b[0]).map(([t,v])=>({t,v}));
+    bwSeries.push({color:"#ffffff", width:2.4, pts});
+  }
+  drawChart(bw, bwSeries, {fmt:v=>humanBps(v)+"B/s", events:showEv});
+  drawChart(rtt, rttSeries, {fmt:v=>v.toFixed(0)+"ms", events:showEv});
+  renderLegend(); renderStats();
+  summary.textContent = `${MODEL.legs.size} legs · ${MODEL.events.length} events · ${MODEL.tMax.toFixed(0)}s`;
+}
+
+function renderLegend() {
+  legend.innerHTML="";
+  for (const key of MODEL.order) {
+    const leg=MODEL.legs.get(key);
+    const d=document.createElement("div"); d.className="lg";
+    const pk=(leg.pk||"").slice(0,6);
+    d.innerHTML=`<span class="sw" style="background:${leg.color}"></span>leg ${leg.idx} <span class="muted">${leg.kind||""} ${pk?("· "+pk+"…"):""}</span>`;
+    legend.appendChild(d);
+  }
+}
+
+function renderStats() {
+  let h="<tr><th>leg</th><th>kind</th><th>median recv</th><th>median send</th><th>median rtt</th><th>max retx?</th><th>samples</th></tr>";
+  for (const key of MODEL.order) {
+    const leg=MODEL.legs.get(key);
+    const mr=median(leg.pts.map(p=>p.recv)), ms=median(leg.pts.map(p=>p.send)), mrt=median(leg.pts.map(p=>p.rtt));
+    h+=`<tr><td>${leg.idx}</td><td>${leg.kind||""}</td><td>${humanBps(mr)}B/s</td><td>${humanBps(ms)}B/s</td><td>${mrt.toFixed(0)}ms</td><td>-</td><td>${leg.pts.length}</td></tr>`;
+  }
+  stats.innerHTML=h;
+}
+
+function load(text){ MODEL=parseNDJSON(text); render(); }
+
+const drop=document.getElementById("drop");
+document.getElementById("file").addEventListener("change", e=>{
+  const f=e.target.files[0]; if(!f) return; f.text().then(load);
+});
+["dragover","dragenter"].forEach(ev=>drop.addEventListener(ev,e=>{e.preventDefault();drop.classList.add("hot");}));
+["dragleave","drop"].forEach(ev=>drop.addEventListener(ev,e=>{e.preventDefault();drop.classList.remove("hot");}));
+drop.addEventListener("drop",e=>{ const f=e.dataTransfer.files[0]; if(f) f.text().then(load); });
+for (const id of ["mRecv","mSend","mAgg","mEvents"]) document.getElementById(id).addEventListener("change", render);
+window.addEventListener("resize", render);
+</script>
+</body>
+</html>

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -299,6 +299,12 @@ type MuxLeg struct {
 	// LatencyMS is the transport-level smoothed RTT in ms (the same
 	// value 'tp ls' shows). Zero when no measurement yet.
 	LatencyMS float64 `json:"latency_ms"`
+	// Alive is false once the leg's transport is closed. Standby is true
+	// when the leg is a WARM STANDBY: rules kept alive but not selected
+	// for sending (see docs/warm_standby_legs_rfc.md). Together they are
+	// the leg's gate_state for the per-leg telemetry harness.
+	Alive   bool `json:"alive"`
+	Standby bool `json:"standby"`
 }
 
 // MuxStats returns a point-in-time snapshot of the rg's per-leg
@@ -331,6 +337,10 @@ func (rg *RouteGroup) MuxStats() MuxInfo {
 			leg.TpType = string(tp.Entry.Type)
 			leg.RemotePK = tp.Remote().String()
 			leg.LatencyMS = tp.GetLatency()
+			leg.Alive = !tp.IsClosed()
+		}
+		if rg.mux != nil {
+			leg.Standby = rg.mux.isLegStandby(i)
 		}
 		info.Legs = append(info.Legs, leg)
 	}

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -133,6 +133,9 @@ func (v *Visor) RouteGroupMuxInfo(appName string) ([]MuxRouteGroupInfo, error) {
 				SentPackets: leg.SentPackets,
 				RecvBytes:   leg.RecvBytes,
 				RecvPackets: leg.RecvPackets,
+				Retransmits: leg.Retransmits,
+				Alive:       leg.Alive,
+				Standby:     leg.Standby,
 			})
 		}
 		out = append(out, entry)

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -260,6 +260,13 @@ type MuxLegInfo struct {
 	SentPackets uint64  `json:"sent_packets"`
 	RecvBytes   uint64  `json:"recv_bytes"`
 	RecvPackets uint64  `json:"recv_packets"`
+	// Retransmits is SACK retransmit packets carried by this leg (loss
+	// signal). Alive/Standby are the leg's gate_state: Alive=false once the
+	// transport is closed; Standby=true for a warm standby (rules kept,
+	// not sending). Surfaced for the per-leg telemetry harness.
+	Retransmits uint64 `json:"retransmits"`
+	Alive       bool   `json:"alive"`
+	Standby     bool   `json:"standby"`
 }
 type FetchServiceDataIn struct {
 	Service string


### PR DESCRIPTION
The routing-policy rig needs to **prove** a policy is adaptive and measurably better — per leg, over time, against a controlled far-end. This is the measurement half.

## One source of truth
The harness reads the **same** `rg.snapshotLegs()` the policy `on_tick` ABI sees, so what the policy decides on and what the chart shows are provably the same numbers.

## Surface the dropped per-leg state
`RouteGroup.MuxStats` now populates `Alive` + `Standby` on each `MuxLeg`, and `MuxLegInfo` (the `RouteGroupMuxInfo` RPC) carries `Retransmits` + `Alive` + `Standby`. A poll of the live route group now sees each leg's full gate_state, including whether it's a warm standby.

## NDJSON stream
`skywire cli proxy mux info --ndjson FILE [--watch INTERVAL] [--duration D]` polls once per interval (default `1s`, i.e. ≥1 Hz) and emits newline-delimited JSON on one clock:

- **`sample`** per route group per tick — every live leg's `{route_index, intermediate_pk, transport_kind, inst_send_bps, inst_recv_bps, rtt_ms, retransmits, gate_state, alive}`; and
- **lifecycle events** — `established` / `promoted` / `demoted` / `failed` / `dropped`, derived by diffing each tick's leg set against the last.

A warm-standby **hot-swap** (gate-5) shows as a `demoted`+`promoted` marker pair with the aggregate throughput line flat across it — the "no capacity dip" proof, made observable.

## Chart
`docs/examples/routing-policies/telemetry/` ships a **self-contained** HTML chart (per-leg bandwidth + RTT, policy events as vertical markers; no external network — CSP-safe, opens from disk) plus a README documenting the record shapes and usage.

## Tests
`mux_telemetry_test` covers first-poll `established`, inst-bps-from-delta, the hot-swap `demoted`+`promoted` pair with the `gate_state` flip, `dropped`+`failed`, and the key parser. `make check` clean; `pkg/router` + proxy CLI tests green; 0 lint issues.

Part of the WASM-routing-policy goal (gate 2). Unblocks the controlled-sink run (gate 3) and per-preset validation (gate 4).