### PR TITLE
docs(routing-policy): reproducible measurement rig script + controlled far-end guide (gate-3)

### DIFF
--- a/docs/examples/routing-policies/telemetry/README.md
+++ b/docs/examples/routing-policies/telemetry/README.md
@@ -56,6 +56,36 @@ skywire cli proxy mux info --ndjson - --watch 500ms | tee run.ndjson
 skywire cli proxy mux info -n vpn-client --ndjson run.ndjson
 ```
 
+## Running the rig
+
+`run-rig.sh` ties the three pieces together for a reproducible per-preset run:
+install the preset, drive steady load, sample per-leg telemetry to NDJSON.
+
+```sh
+# adaptive, 5 min, forcing multi-hop so a mux group forms, load via the proxy:
+LOAD_URL=http://host/big.bin \
+  docs/examples/routing-policies/telemetry/run-rig.sh adaptive skysocks-client 300 2
+```
+
+Args: `<preset> [app=skysocks-client] [duration_s=300] [min_hops=0]`. Set
+`min_hops` > 1 to force multi-hop so the size/membership dimensions have legs to
+work over even when the exit is directly reachable.
+
+## Controlled far-end (gate 3)
+
+The load the harness measures **must ride the policy app's route group** — i.e.
+go through the proxy. So the controlled far-end is a steady sink reachable via
+the proxy's **exit**, pointed at by `LOAD_URL`, chosen so the far-end is never
+the bottleneck (throughput deltas then attribute to the policy, not peer noise):
+
+- a `/dev/zero` server on the exit visor's localhost (`while true; do nc -lp 8888 </dev/zero; done`, or an HTTP handler streaming zeros), or
+- a stable high-bandwidth file.
+
+`skywire cli visor ping bandwidth <PK>` and `mux-bw <PK>` are a **complementary
+router-level baseline** to a visor you control — steady continuous send/receive
+with per-leg telemetry — but they use their own ping/mux routes, *not* the
+policy app's route group, so they measure raw mux capacity, not a preset.
+
 ## Charting
 
 Open `mux-telemetry-chart.html` in a browser and load `run.ndjson` (file picker

--- a/docs/examples/routing-policies/telemetry/run-rig.sh
+++ b/docs/examples/routing-policies/telemetry/run-rig.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# run-rig.sh — the routing-policy measurement rig.
+#
+# Ties the three pieces together for a reproducible per-preset run:
+#   1. install a preset on the carrying app (no restart),
+#   2. drive STEADY controlled load so throughput deltas attribute to the
+#      policy, not peer noise, and
+#   3. sample the live per-leg telemetry to NDJSON while it runs.
+#
+# The NDJSON is rendered by mux-telemetry-chart.html (per-leg bandwidth + RTT,
+# lifecycle events as markers). See README.md for the record shapes.
+#
+# Controlled far-end (gate 3): the load the harness measures MUST ride the
+# policy app's route group. Point LOAD_URL at a steady sink you control that is
+# reachable via the proxy's EXIT — e.g. a /dev/zero HTTP server on the exit
+# visor's localhost, or a stable high-bandwidth file — so the far-end is never
+# the bottleneck and throughput deltas attribute to the policy, not peer noise.
+#   Exit-side sink (on the controlled exit visor):
+#     while true; do nc -lp 8888 </dev/zero; done   # or an http /dev/zero handler
+#
+# (`skywire cli visor ping bandwidth <PK>` / `mux-bw <PK>` are a COMPLEMENTARY
+#  router-level baseline to a controlled visor — steady send/receive, per-leg
+#  telemetry — but they use their own ping/mux routes, NOT the policy app's
+#  route group, so they are measured separately, not via this harness.)
+#
+# Usage:
+#   LOAD_URL=http://host/big.bin ./run-rig.sh rotating-bw skysocks-client 300 2
+#
+# Args: <preset> [app=skysocks-client] [duration_s=300] [min_hops=0]
+set -o pipefail
+cd "$(dirname "$0")/../../../.." || exit 1 # repo root
+
+PRESET="${1:?usage: run-rig.sh <preset> [app] [duration_s] [min_hops]}"
+APP="${2:-skysocks-client}"
+DUR="${3:-300}"
+MINHOPS="${4:-0}"
+CLI="${SKYWIRE_CLI:-./skywire cli}"
+OUT="${OUT:-run-${PRESET}-$(printf %s "$DUR")s.ndjson}"
+
+echo ">>> rig: preset=$PRESET app=$APP duration=${DUR}s min_hops=$MINHOPS out=$OUT"
+
+# 1. (Re)start the app under the preset. min_hops>1 forces multi-hop so a mux
+#    group forms even to a directly-connected peer (needed to exercise the
+#    membership/size dimensions); min_hops=0 leaves the operator's floor.
+startflags=(--routing-policy "preset:$PRESET")
+[ "$MINHOPS" -gt 0 ] && startflags+=(--min-hops "$MINHOPS")
+$CLI proxy start -n "$APP" "${startflags[@]}" >/dev/null 2>&1
+sleep 20
+$CLI proxy status 2>&1 | sed -n "/Name: $APP\$/,/Route:/p" | grep -E "Status|Route" | head -3
+
+# 2. Steady controlled load in the background for the whole window. This MUST
+#    ride the policy app's route group (i.e. go through the proxy), so the
+#    harness samples the loaded legs.
+if [ -n "$LOAD_URL" ]; then
+	echo ">>> steady load: sustained fetch of $LOAD_URL through :1080"
+	( timeout "$DUR" curl -sS --max-time "$DUR" -x socks5h://127.0.0.1:1080 -o /dev/null "$LOAD_URL" >/dev/null 2>&1 ) &
+	LOADPID=$!
+else
+	echo ">>> no LOAD_URL set — sampling idle (leg formation/rotation only, no throughput)"
+	LOADPID=""
+fi
+
+# 3. Sample per-leg telemetry to NDJSON for the window.
+$CLI proxy mux info -n "$APP" --ndjson "$OUT" --watch 1s --duration "${DUR}s"
+
+[ -n "$LOADPID" ] && kill "$LOADPID" 2>/dev/null
+echo ">>> done. $(wc -l <"$OUT") records → $OUT"
+echo ">>> open docs/examples/routing-policies/telemetry/mux-telemetry-chart.html and load $OUT"


### PR DESCRIPTION
`run-rig.sh` ties the per-leg telemetry harness (#3980) into a one-command per-preset run: install the preset (no restart), drive steady load **through the policy app's route group**, and sample per-leg NDJSON for the window — rendered by the existing self-contained chart.

## Controlled far-end
Documents the key constraint: the load the harness measures must ride the policy app's route group (through the proxy), so the controlled sink is a steady `/dev/zero`-style endpoint reachable via the proxy's **exit** (pointed at by `LOAD_URL`), chosen so the far-end is never the bottleneck — throughput deltas then attribute to the policy, not peer noise.

`skywire cli visor ping bandwidth <PK>` / `mux-bw <PK>` are noted as a **complementary router-level baseline** to a visor you control (steady continuous send/receive with per-leg telemetry), distinct from a preset's route group.

## Usage
```sh
LOAD_URL=http://host/big.bin \
  docs/examples/routing-policies/telemetry/run-rig.sh adaptive skysocks-client 300 2
```

Makes the per-preset measurement reproducible. Validated end-to-end (produces valid NDJSON the chart parses). Part of the WASM-routing-policy goal (gate 3 rig).