### PR TITLE
feat(router): transport-type-aware route ranking — deprioritize slow transports for route legs

### DIFF
--- a/docs/examples/routing-policies/telemetry/README.md
+++ b/docs/examples/routing-policies/telemetry/README.md
@@ -56,6 +56,36 @@ skywire cli proxy mux info --ndjson - --watch 500ms | tee run.ndjson
 skywire cli proxy mux info -n vpn-client --ndjson run.ndjson
 ```
 
+## Running the rig
+
+`run-rig.sh` ties the three pieces together for a reproducible per-preset run:
+install the preset, drive steady load, sample per-leg telemetry to NDJSON.
+
+```sh
+# adaptive, 5 min, forcing multi-hop so a mux group forms, load via the proxy:
+LOAD_URL=http://host/big.bin \
+  docs/examples/routing-policies/telemetry/run-rig.sh adaptive skysocks-client 300 2
+```
+
+Args: `<preset> [app=skysocks-client] [duration_s=300] [min_hops=0]`. Set
+`min_hops` > 1 to force multi-hop so the size/membership dimensions have legs to
+work over even when the exit is directly reachable.
+
+## Controlled far-end (gate 3)
+
+The load the harness measures **must ride the policy app's route group** — i.e.
+go through the proxy. So the controlled far-end is a steady sink reachable via
+the proxy's **exit**, pointed at by `LOAD_URL`, chosen so the far-end is never
+the bottleneck (throughput deltas then attribute to the policy, not peer noise):
+
+- a `/dev/zero` server on the exit visor's localhost (`while true; do nc -lp 8888 </dev/zero; done`, or an HTTP handler streaming zeros), or
+- a stable high-bandwidth file.
+
+`skywire cli visor ping bandwidth <PK>` and `mux-bw <PK>` are a **complementary
+router-level baseline** to a visor you control — steady continuous send/receive
+with per-leg telemetry — but they use their own ping/mux routes, *not* the
+policy app's route group, so they measure raw mux capacity, not a preset.
+
 ## Charting
 
 Open `mux-telemetry-chart.html` in a browser and load `run.ndjson` (file picker

--- a/docs/examples/routing-policies/telemetry/run-rig.sh
+++ b/docs/examples/routing-policies/telemetry/run-rig.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# run-rig.sh — the routing-policy measurement rig.
+#
+# Ties the three pieces together for a reproducible per-preset run:
+#   1. install a preset on the carrying app (no restart),
+#   2. drive STEADY controlled load so throughput deltas attribute to the
+#      policy, not peer noise, and
+#   3. sample the live per-leg telemetry to NDJSON while it runs.
+#
+# The NDJSON is rendered by mux-telemetry-chart.html (per-leg bandwidth + RTT,
+# lifecycle events as markers). See README.md for the record shapes.
+#
+# Controlled far-end (gate 3): the load the harness measures MUST ride the
+# policy app's route group. Point LOAD_URL at a steady sink you control that is
+# reachable via the proxy's EXIT — e.g. a /dev/zero HTTP server on the exit
+# visor's localhost, or a stable high-bandwidth file — so the far-end is never
+# the bottleneck and throughput deltas attribute to the policy, not peer noise.
+#   Exit-side sink (on the controlled exit visor):
+#     while true; do nc -lp 8888 </dev/zero; done   # or an http /dev/zero handler
+#
+# (`skywire cli visor ping bandwidth <PK>` / `mux-bw <PK>` are a COMPLEMENTARY
+#  router-level baseline to a controlled visor — steady send/receive, per-leg
+#  telemetry — but they use their own ping/mux routes, NOT the policy app's
+#  route group, so they are measured separately, not via this harness.)
+#
+# Usage:
+#   LOAD_URL=http://host/big.bin ./run-rig.sh rotating-bw skysocks-client 300 2
+#
+# Args: <preset> [app=skysocks-client] [duration_s=300] [min_hops=0]
+set -o pipefail
+cd "$(dirname "$0")/../../../.." || exit 1 # repo root
+
+PRESET="${1:?usage: run-rig.sh <preset> [app] [duration_s] [min_hops]}"
+APP="${2:-skysocks-client}"
+DUR="${3:-300}"
+MINHOPS="${4:-0}"
+CLI="${SKYWIRE_CLI:-./skywire cli}"
+OUT="${OUT:-run-${PRESET}-$(printf %s "$DUR")s.ndjson}"
+
+echo ">>> rig: preset=$PRESET app=$APP duration=${DUR}s min_hops=$MINHOPS out=$OUT"
+
+# 1. (Re)start the app under the preset. min_hops>1 forces multi-hop so a mux
+#    group forms even to a directly-connected peer (needed to exercise the
+#    membership/size dimensions); min_hops=0 leaves the operator's floor.
+startflags=(--routing-policy "preset:$PRESET")
+[ "$MINHOPS" -gt 0 ] && startflags+=(--min-hops "$MINHOPS")
+$CLI proxy start -n "$APP" "${startflags[@]}" >/dev/null 2>&1
+sleep 20
+$CLI proxy status 2>&1 | sed -n "/Name: $APP\$/,/Route:/p" | grep -E "Status|Route" | head -3
+
+# 2. Steady controlled load in the background for the whole window. This MUST
+#    ride the policy app's route group (i.e. go through the proxy), so the
+#    harness samples the loaded legs.
+if [ -n "$LOAD_URL" ]; then
+	echo ">>> steady load: sustained fetch of $LOAD_URL through :1080"
+	( timeout "$DUR" curl -sS --max-time "$DUR" -x socks5h://127.0.0.1:1080 -o /dev/null "$LOAD_URL" >/dev/null 2>&1 ) &
+	LOADPID=$!
+else
+	echo ">>> no LOAD_URL set — sampling idle (leg formation/rotation only, no throughput)"
+	LOADPID=""
+fi
+
+# 3. Sample per-leg telemetry to NDJSON for the window.
+$CLI proxy mux info -n "$APP" --ndjson "$OUT" --watch 1s --duration "${DUR}s"
+
+[ -n "$LOADPID" ] && kill "$LOADPID" 2>/dev/null
+echo ">>> done. $(wc -l <"$OUT") records → $OUT"
+echo ">>> open docs/examples/routing-policies/telemetry/mux-telemetry-chart.html and load $OUT"

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -1034,7 +1034,7 @@ fetchRoutesAgain:
 				for _, pk := range intermediates {
 					hopHex = append(hopHex, pk.Hex())
 				}
-				latSum := pathLatencyScore(hops, latencyFor)
+				latSum := pathLatencyScore(hops, latencyFor, typeFor)
 				out = append(out, CandidateInfo{
 					Hops:         hopHex,
 					EstLatencyMs: int(latSum),
@@ -1070,12 +1070,12 @@ fetchRoutesAgain:
 				var chosenFwd, chosenRev []routing.Hop
 				if haveFwd {
 					chosenFwd = paths[forward][sel.Chosen]
-				} else if best, ok := pickBestDirection(paths[forward], excludeSet, latencyFor); ok {
+				} else if best, ok := pickBestDirection(paths[forward], excludeSet, latencyFor, typeFor); ok {
 					chosenFwd = best
 				}
 				if haveRev {
 					chosenRev = paths[backward][sel.ReverseChosen]
-				} else if best, ok := pickBestDirection(paths[backward], excludeSet, latencyFor); ok {
+				} else if best, ok := pickBestDirection(paths[backward], excludeSet, latencyFor, typeFor); ok {
 					chosenRev = best
 				}
 				if chosenFwd != nil && chosenRev != nil {
@@ -1090,7 +1090,7 @@ fetchRoutesAgain:
 		}
 	}
 
-	fwdPath, revPath, ok := pickDisjointPath(paths[forward], paths[backward], opts.ExcludeIntermediatePKs, latencyFor)
+	fwdPath, revPath, ok := pickDisjointPath(paths[forward], paths[backward], opts.ExcludeIntermediatePKs, latencyFor, typeFor)
 	if !ok {
 		log.Debugf("No route-finder path avoids the %d excluded intermediates; trying local route calc fallback", len(opts.ExcludeIntermediatePKs))
 		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, src, dst, opts)
@@ -1136,11 +1136,11 @@ fetchRoutesAgain:
 // different intermediates means each direction can pick its best
 // available wire, not the best PAIR — which is strictly weaker when
 // the per-direction optimums sit at different indices.
-func pickDisjointPath(forward, reverse [][]routing.Hop, exclude []cipher.PubKey, latencyFor func(uuid.UUID) float64) ([]routing.Hop, []routing.Hop, bool) {
+func pickDisjointPath(forward, reverse [][]routing.Hop, exclude []cipher.PubKey, latencyFor func(uuid.UUID) float64, typeFor func(uuid.UUID) string) ([]routing.Hop, []routing.Hop, bool) {
 	if len(forward) == 0 || len(reverse) == 0 {
 		return nil, nil, false
 	}
-	if len(exclude) == 0 && latencyFor == nil {
+	if len(exclude) == 0 && latencyFor == nil && typeFor == nil {
 		// Hot path: no constraint, no ranker. Preserve the original
 		// first-element behavior so back-compat single-route callers
 		// are unaffected (tests that don't pass a latencyFor).
@@ -1150,8 +1150,8 @@ func pickDisjointPath(forward, reverse [][]routing.Hop, exclude []cipher.PubKey,
 	for _, pk := range exclude {
 		excludeSet[pk] = struct{}{}
 	}
-	fwdPath, fwdOK := pickBestDirection(forward, excludeSet, latencyFor)
-	revPath, revOK := pickBestDirection(reverse, excludeSet, latencyFor)
+	fwdPath, fwdOK := pickBestDirection(forward, excludeSet, latencyFor, typeFor)
+	revPath, revOK := pickBestDirection(reverse, excludeSet, latencyFor, typeFor)
 	if !fwdOK || !revOK {
 		return nil, nil, false
 	}
@@ -1163,17 +1163,17 @@ func pickDisjointPath(forward, reverse [][]routing.Hop, exclude []cipher.PubKey,
 // When latencyFor is nil, returns the first acceptable candidate (the
 // legacy first-after-exclude behavior — preserved for callers that
 // don't opt into ranking, e.g. the existing tests).
-func pickBestDirection(paths [][]routing.Hop, excludeSet map[cipher.PubKey]struct{}, latencyFor func(uuid.UUID) float64) ([]routing.Hop, bool) {
+func pickBestDirection(paths [][]routing.Hop, excludeSet map[cipher.PubKey]struct{}, latencyFor func(uuid.UUID) float64, typeFor func(uuid.UUID) string) ([]routing.Hop, bool) {
 	bestIdx := -1
 	bestScore := 0.0
 	for i, p := range paths {
 		if pathTouchesIntermediate(p, excludeSet) {
 			continue
 		}
-		if latencyFor == nil {
+		if latencyFor == nil && typeFor == nil {
 			return p, true
 		}
-		score := pathLatencyScore(p, latencyFor)
+		score := pathLatencyScore(p, latencyFor, typeFor)
 		if bestIdx < 0 || score < bestScore {
 			bestIdx = i
 			bestScore = score
@@ -1185,6 +1185,36 @@ func pickBestDirection(paths [][]routing.Hop, excludeSet map[cipher.PubKey]struc
 	return paths[bestIdx], true
 }
 
+// transportTypeCostMs is a per-hop, latency-equivalent penalty that biases
+// route ranking toward high-THROUGHPUT transports. RTT alone can't do this: a
+// webrtc DTLS/SCTP datachannel has LOW ping/pong RTT but POOR throughput, so
+// without this term the ranker scores a webrtc hop as cheap as an stcpr one,
+// and disjoint mux legs pile onto the few webrtc-only intermediates (webrtc is
+// ~5% of network transports yet dominated the mux legs). The magnitudes are
+// ordered by the transport's throughput class — TCP (stcpr) and QUIC (squicr)
+// fast; UDP hole-punch (sudph) ok; SCTP-over-DTLS (webrtc) and relayed (dmsg)
+// slow — expressed in ms so they compose additively with the RTT score. It is a
+// bias, not a filter: a genuinely fast webrtc hop can still win on total score,
+// but all else equal a fast transport is preferred.
+func transportTypeCostMs(tpType string) float64 {
+	switch tptypes.Type(tpType) {
+	case tptypes.STCPR, tptypes.QUIC, tptypes.QUICLegacy, tptypes.QUICLegacy2:
+		return 0
+	case tptypes.SUDPH:
+		return 25
+	case tptypes.STCP:
+		return 50
+	case tptypes.WT, tptypes.WTLegacy, tptypes.WS, tptypes.WSLegacy:
+		return 150
+	case tptypes.WEBRTC:
+		return 300
+	case tptypes.DMSG:
+		return 400
+	default:
+		return 100 // unknown type — mild penalty, below webrtc
+	}
+}
+
 // pathLatencyScore returns the sum of per-hop avg-latency-ms across a
 // path, treating unknown latencies (latencyFor returning 0) as a high
 // cost so paths with measured latency outrank paths with no signal at
@@ -1192,16 +1222,27 @@ func pickBestDirection(paths [][]routing.Hop, excludeSet map[cipher.PubKey]struc
 // upper bound of healthy single-hop latency — currently 1000ms — so a
 // single unknown hop already loses to a known 500ms hop, but a path
 // composed entirely of unknown hops is still preferred over no path.
-func pathLatencyScore(path []routing.Hop, latencyFor func(uuid.UUID) float64) float64 {
+//
+// typeFor adds the per-hop transport-type throughput penalty (see
+// transportTypeCostMs) so fast transports outrank slow ones at equal RTT. It
+// is nil-safe: a nil typeFor scores on RTT alone (back-compat for callers /
+// tests that don't thread transport type).
+func pathLatencyScore(path []routing.Hop, latencyFor func(uuid.UUID) float64, typeFor func(uuid.UUID) string) float64 {
 	const unknownLatencyCostMs = 1000.0
 	var total float64
 	for _, h := range path {
-		ms := latencyFor(h.TpID)
+		var ms float64
+		if latencyFor != nil {
+			ms = latencyFor(h.TpID)
+		}
 		if ms <= 0 {
 			total += unknownLatencyCostMs
-			continue
+		} else {
+			total += ms
 		}
-		total += ms
+		if typeFor != nil {
+			total += transportTypeCostMs(typeFor(h.TpID))
+		}
 	}
 	return total
 }
@@ -1747,6 +1788,13 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 		}
 	}
 	localLatencyFor := func(id uuid.UUID) float64 { return tpLatencyMs[id] }
+	tpTypeOf := make(map[uuid.UUID]string)
+	for _, entry := range allEntries {
+		if entry != nil {
+			tpTypeOf[entry.ID] = string(entry.Type)
+		}
+	}
+	localTypeFor := func(id uuid.UUID) string { return tpTypeOf[id] }
 
 	queue := seed
 	for level := 1; level <= maxHops && len(queue) > 0; level++ {
@@ -1829,9 +1877,9 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 		// among same-hop-count candidates.
 		if len(dstCandidates) > 0 {
 			best := dstCandidates[0]
-			bestScore := pathLatencyScore(best, localLatencyFor)
+			bestScore := pathLatencyScore(best, localLatencyFor, localTypeFor)
 			for _, p := range dstCandidates[1:] {
-				if s := pathLatencyScore(p, localLatencyFor); s < bestScore {
+				if s := pathLatencyScore(p, localLatencyFor, localTypeFor); s < bestScore {
 					best = p
 					bestScore = s
 				}

--- a/pkg/router/router_dial_disjoint_test.go
+++ b/pkg/router/router_dial_disjoint_test.go
@@ -88,7 +88,7 @@ func TestPickDisjointPath_NoExcludeReturnsFirst(t *testing.T) {
 		{hop(dst, mid2), hop(mid2, src)},
 	}
 
-	f, r, ok := pickDisjointPath(fwd, rev, nil, nil)
+	f, r, ok := pickDisjointPath(fwd, rev, nil, nil, nil)
 	if !ok {
 		t.Fatal("no-exclude: expected ok=true")
 	}
@@ -118,7 +118,7 @@ func TestPickDisjointPath_SkipsExcludedIntermediate(t *testing.T) {
 		{hop(dst, mid3), hop(mid3, src)},
 	}
 
-	f, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mid1, mid2}, nil)
+	f, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mid1, mid2}, nil, nil)
 	if !ok {
 		t.Fatal("exclude mid1+mid2 with mid3 available: expected ok=true")
 	}
@@ -142,7 +142,7 @@ func TestPickDisjointPath_AllExcluded(t *testing.T) {
 		{hop(dst, mid2), hop(mid2, src)},
 	}
 
-	_, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mid1, mid2}, nil)
+	_, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mid1, mid2}, nil, nil)
 	if ok {
 		t.Error("all paths excluded: expected ok=false")
 	}
@@ -164,7 +164,7 @@ func TestPickDisjointPath_ReverseAlsoFiltered(t *testing.T) {
 		{hop(dst, midR), hop(midR, src)},
 	}
 
-	_, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{midR}, nil)
+	_, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{midR}, nil, nil)
 	if ok {
 		t.Error("midR excluded but in reverse path: expected ok=false")
 	}
@@ -228,7 +228,7 @@ func TestPathLatencyScore_KnownAndUnknown(t *testing.T) {
 
 	// All hops known: score is the simple sum.
 	lat := map[uuid.UUID]float64{h1.TpID: 50, h2.TpID: 30}
-	score := pathLatencyScore([]routing.Hop{h1, h2}, func(id uuid.UUID) float64 { return lat[id] })
+	score := pathLatencyScore([]routing.Hop{h1, h2}, func(id uuid.UUID) float64 { return lat[id] }, nil)
 	if score != 80.0 {
 		t.Errorf("known-only: want 80.0, got %.1f", score)
 	}
@@ -237,7 +237,7 @@ func TestPathLatencyScore_KnownAndUnknown(t *testing.T) {
 	// Penalty constant (1000ms) ensures known-good paths outrank
 	// any path with an unknown hop unless the known path is also slow.
 	lat2 := map[uuid.UUID]float64{h1.TpID: 50}
-	score2 := pathLatencyScore([]routing.Hop{h1, h2}, func(id uuid.UUID) float64 { return lat2[id] })
+	score2 := pathLatencyScore([]routing.Hop{h1, h2}, func(id uuid.UUID) float64 { return lat2[id] }, nil)
 	if score2 != 1050.0 {
 		t.Errorf("one-unknown: want 1050.0 (50 known + 1000 unknown penalty), got %.1f", score2)
 	}
@@ -280,7 +280,7 @@ func TestPickDisjointPath_LatencyRanking(t *testing.T) {
 		latency[p.TpID] = 40
 	}
 
-	f, _, ok := pickDisjointPath(fwd, rev, nil, func(id uuid.UUID) float64 { return latency[id] })
+	f, _, ok := pickDisjointPath(fwd, rev, nil, func(id uuid.UUID) float64 { return latency[id] }, nil)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -319,7 +319,7 @@ func TestPickDisjointPath_LatencyRankingWithExclude(t *testing.T) {
 		latency[p.TpID] = 40
 	}
 
-	f, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{midBad}, func(id uuid.UUID) float64 { return latency[id] })
+	f, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{midBad}, func(id uuid.UUID) float64 { return latency[id] }, nil)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -349,7 +349,7 @@ func TestPickDisjointPath_NoLatencyRankerLegacyBehavior(t *testing.T) {
 	// Non-empty exclude (just to make the function iterate), but no
 	// ranker. Result should be the first-after-exclude — here, mid1
 	// is not excluded so [0] passes.
-	f, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mustPK(t)}, nil)
+	f, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mustPK(t)}, nil, nil)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -398,7 +398,7 @@ func TestPickDisjointPath_AsymmetricForwardReverse(t *testing.T) {
 		hSlowRev0.TpID: 300, hSlowRev1.TpID: 300, // 600ms total
 	}
 
-	f, r, ok := pickDisjointPath(fwd, rev, nil, func(id uuid.UUID) float64 { return latency[id] })
+	f, r, ok := pickDisjointPath(fwd, rev, nil, func(id uuid.UUID) float64 { return latency[id] }, nil)
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
@@ -430,8 +430,44 @@ func TestPickDisjointPath_AsymmetricExcludeIntersection(t *testing.T) {
 		{hop(dst, mid), hop(mid, src)},
 	}
 
-	_, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mid}, nil)
+	_, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mid}, nil, nil)
 	if ok {
 		t.Error("expected ok=false when every reverse candidate touches exclude set")
+	}
+}
+
+// TestTransportTypeCostBiasesRanking pins that the per-type throughput penalty
+// makes an equal-RTT path over a slow transport (webrtc) score WORSE than one
+// over a fast transport (stcpr) — so disjoint mux legs stop piling onto the few
+// webrtc-only intermediates when a fast alternative exists.
+func TestTransportTypeCostBiasesRanking(t *testing.T) {
+	// stcpr is free; webrtc carries a throughput penalty.
+	if transportTypeCostMs("stcpr") != 0 {
+		t.Errorf("stcpr cost = %v, want 0", transportTypeCostMs("stcpr"))
+	}
+	if transportTypeCostMs("squicr") != 0 {
+		t.Errorf("squicr cost = %v, want 0", transportTypeCostMs("squicr"))
+	}
+	if !(transportTypeCostMs("webrtc") > transportTypeCostMs("sudph")) {
+		t.Error("webrtc should cost more than sudph")
+	}
+	if !(transportTypeCostMs("sudph") > transportTypeCostMs("stcpr")) {
+		t.Error("sudph should cost more than stcpr")
+	}
+
+	// Same RTT on both hops; only the transport type differs. The typeFor-aware
+	// score must rank the stcpr hop below (better than) the webrtc hop.
+	h := routing.Hop{TpID: uuid.New()}
+	latSame := func(uuid.UUID) float64 { return 100 }
+	typeStcpr := func(uuid.UUID) string { return "stcpr" }
+	typeWebrtc := func(uuid.UUID) string { return "webrtc" }
+	sFast := pathLatencyScore([]routing.Hop{h}, latSame, typeStcpr)
+	sSlow := pathLatencyScore([]routing.Hop{h}, latSame, typeWebrtc)
+	if !(sFast < sSlow) {
+		t.Errorf("stcpr score %v should be < webrtc score %v at equal RTT", sFast, sSlow)
+	}
+	// And nil typeFor is back-compat: RTT only, no type term.
+	if got := pathLatencyScore([]routing.Hop{h}, latSame, nil); got != 100 {
+		t.Errorf("nil typeFor score = %v, want 100 (RTT only)", got)
 	}
 }


### PR DESCRIPTION
## The blind spot
The route finder sorts by summed per-hop latency (`GetRouteWeighted(byLatency=true)`), and the client re-ranks disjoint mux legs the same way — but "latency" is **ping/pong RTT**, and a webrtc DTLS/SCTP datachannel has **low RTT and poor throughput**. So the ranker scored a webrtc hop as cheap as an stcpr one, and disjoint mux legs piled onto the few webrtc-only intermediates.

Live survey (`tp ls net-stats`): **webrtc is ~5% of network transports** (20/393; stcpr 190, squicr 123, sudph 60) yet dominated the mux legs. Route-selection blind spot, not scarcity.

## The fix
A per-hop, latency-equivalent **transport-type cost** ordered by throughput class:

| type | penalty (ms) |
|---|---|
| stcpr, squicr (QUIC) | 0 |
| sudph | 25 |
| stcp | 50 |
| wt / ws | 150 |
| webrtc | 300 |
| dmsg | 400 |

Threaded (nil-safe) through the scorers `pathLatencyScore → pickBestDirection → pickDisjointPath` and the local-BFS tiebreak. The transport type was already resolved in `buildHopLookups`; this just feeds it into scoring.

It's a **bias, not a filter**: a genuinely fast webrtc hop can still win on total score, but all else equal a fast transport (stcpr/quic) is preferred — so disjoint legs stop landing on slow webrtc-only nodes when a fast path exists.

## Tests
`make check` clean; new `TestTransportTypeCostBiasesRanking`; existing disjoint/latency tests updated for the nil-safe `typeFor` arg (RTT-only when nil).

Part of making multiplexed routing actually outperform a single route. Complementary to the receive-side scheduling work (retransmit-on-fast-leg / redundancy) being designed separately.