### PR TITLE
feat(router): retransmit SACK gaps on the fastest leg, not the mode-driven pick

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -936,6 +936,30 @@ func (rg *RouteGroup) nextTransport(payload []byte) (*transport.ManagedTransport
 	return rg.tps[0], rg.fwd[0], 0, nil
 }
 
+// nextFastestTransport is nextTransport's retransmit-path variant: it always
+// routes to the lowest-latency live leg (see routeMux.selectFastestTransport)
+// so a head-of-line-blocking gap is healed on a fast leg, not re-sent down the
+// slow leg that stalled it. Single-leg groups behave identically to
+// nextTransport.
+func (rg *RouteGroup) nextFastestTransport() (*transport.ManagedTransport, routing.Rule, int, error) {
+	if len(rg.tps) == 0 {
+		return nil, nil, -1, ErrNoTransports
+	}
+	if len(rg.fwd) == 0 {
+		return nil, nil, -1, ErrNoRules
+	}
+	if len(rg.tps) != len(rg.fwd) {
+		return nil, nil, -1, ErrRuleTransportMismatch
+	}
+	if rg.mux != nil && len(rg.tps) > 1 {
+		return rg.mux.selectFastestTransport(rg.tps, rg.fwd)
+	}
+	if rg.tps[0] == nil {
+		return nil, nil, -1, ErrBadTransport
+	}
+	return rg.tps[0], rg.fwd[0], 0, nil
+}
+
 // RouteHops returns the list of visor public keys that form the route path.
 // The first element is the first hop from the source, and the last element
 // is the destination visor.
@@ -1926,7 +1950,11 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 		}
 
 		rg.mu.Lock()
-		tp, rule, leg, err := rg.nextTransport(data)
+		// Retransmit on the FASTEST live leg, not the mode-driven spray pick:
+		// this seq is what the peer's reorder buffer is HoL-blocked on, so heal
+		// it on a fast path instead of possibly re-sending it down the slow leg
+		// that stalled it. See routeMux.selectFastestTransport.
+		tp, rule, leg, err := rg.nextFastestTransport()
 		rg.mu.Unlock()
 		if err != nil {
 			return err

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -203,6 +203,52 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 	return nil, nil, -1, ErrNoSuitableTransport
 }
 
+// selectFastestTransport picks the live, ready, non-standby leg with the LOWEST
+// measured latency — the pick for the RETRANSMIT path, independent of the
+// group's configured distribution mode.
+//
+// A retransmitted segment is one the receiver's reorder buffer is head-of-line
+// blocked on: every later segment that already arrived on a fast leg is being
+// withheld until this gap fills. Healing that gap on the FASTEST leg (rather
+// than the normal spray/weight pick, which might re-send it down the very slow
+// leg that stalled it) advances the delivery window in one fast RTT instead of
+// waiting out the reorder timeout. This is what keeps a slow leg from dragging
+// the whole stream: it still carries its share of new data, but its stragglers
+// are rescued on a fast path. Falls back to the first ready leg when no leg has
+// a latency measurement yet.
+func (m *routeMux) selectFastestTransport(tps []*transport.ManagedTransport, fwd []routing.Rule) (*transport.ManagedTransport, routing.Rule, int, error) {
+	if len(tps) == 0 {
+		return nil, nil, -1, ErrNoTransports
+	}
+	if len(fwd) == 0 {
+		return nil, nil, -1, ErrNoRules
+	}
+	bestIdx, firstReady := -1, -1
+	bestLat := -1.0
+	for idx, tp := range tps {
+		if tp == nil || tp.IsClosed() || !m.legReadyAt(idx) {
+			continue
+		}
+		if firstReady < 0 {
+			firstReady = idx
+		}
+		lat := tp.GetLatency()
+		if lat <= 0 {
+			continue // unknown latency — only a last resort
+		}
+		if bestLat < 0 || lat < bestLat {
+			bestLat, bestIdx = lat, idx
+		}
+	}
+	if bestIdx < 0 {
+		bestIdx = firstReady
+	}
+	if bestIdx < 0 {
+		return nil, nil, -1, ErrNoSuitableTransport
+	}
+	return tps[bestIdx], fwd[bestIdx], bestIdx, nil
+}
+
 // growLegs extends the per-leg counter slice to cover at least n
 // legs. Called when transports are appended to the rg (initial setup
 // + AppendRoute). Idempotent — extending past the current size is a

--- a/pkg/router/route_mux_fastretx_test.go
+++ b/pkg/router/route_mux_fastretx_test.go
@@ -1,0 +1,75 @@
+//go:build !tinygo || (js && wasm)
+
+package router
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// TestSelectFastestTransportPicksLowestLatency pins the retransmit-path leg
+// pick: a HoL-blocking gap is healed on the LOWEST-latency live leg, regardless
+// of the group's normal distribution mode — so a slow leg that stalled the
+// stream never gets the retransmit that would keep it stalled.
+func TestSelectFastestTransportPicksLowestLatency(t *testing.T) {
+	m := &routeMux{}
+	m.growLegs(3)
+	m.markLegReady(1)
+	m.markLegReady(2)
+
+	tps := []*transport.ManagedTransport{mockTP(200), mockTP(50), mockTP(300)}
+	fwd := make([]routing.Rule, 3)
+
+	_, _, leg, err := m.selectFastestTransport(tps, fwd)
+	if err != nil {
+		t.Fatalf("selectFastestTransport: %v", err)
+	}
+	if leg != 1 {
+		t.Errorf("fastest leg = %d, want 1 (50ms is lowest)", leg)
+	}
+}
+
+// TestSelectFastestTransportSkipsStandby: a warm-standby leg is never chosen for
+// a retransmit even if it has the lowest latency — it isn't a sending leg.
+func TestSelectFastestTransportSkipsStandby(t *testing.T) {
+	m := &routeMux{}
+	m.growLegs(3)
+	m.markLegReady(1)
+	m.markLegReady(2)
+	m.setLegStandby(1, true) // fastest, but parked
+
+	tps := []*transport.ManagedTransport{mockTP(200), mockTP(50), mockTP(300)}
+	fwd := make([]routing.Rule, 3)
+
+	_, _, leg, err := m.selectFastestTransport(tps, fwd)
+	if err != nil {
+		t.Fatalf("selectFastestTransport: %v", err)
+	}
+	if leg == 1 {
+		t.Error("standby leg 1 must not be chosen for retransmit")
+	}
+	if leg != 0 {
+		t.Errorf("fastest non-standby leg = %d, want 0 (200ms < 300ms)", leg)
+	}
+}
+
+// TestSelectFastestTransportUnknownLatencyFallback: when no leg has a latency
+// measurement, fall back to the first ready leg rather than failing.
+func TestSelectFastestTransportUnknownLatencyFallback(t *testing.T) {
+	m := &routeMux{}
+	m.growLegs(2)
+	m.markLegReady(1)
+
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0)}
+	fwd := make([]routing.Rule, 2)
+
+	_, _, leg, err := m.selectFastestTransport(tps, fwd)
+	if err != nil {
+		t.Fatalf("selectFastestTransport: %v", err)
+	}
+	if leg != 0 {
+		t.Errorf("fallback leg = %d, want 0 (first ready)", leg)
+	}
+}


### PR DESCRIPTION
## The stall, not the slow leg, is the enemy
A mux route group delivers a reliable, **in-order** byte stream. The receiver's reorder buffer holds a gap (missing seq) and **withholds every later segment that already arrived on a fast leg** until the gap fills — head-of-line blocking. So one slow leg stalls the whole stream, which is why a mux with an unequal leg can fall *below* a single fast leg.

## The fix
The retransmitted segment is *exactly* the one the receiver is HoL-blocked on. Today the retx path re-selects the leg via the normal distribution mode (spray / weighted / round-robin) — so a stalled segment can be re-sent down **the very slow leg that stalled it**. Route it on the **fastest live leg** instead: the gap heals in one fast RTT and delivery advances, instead of waiting out the 1500 ms reorder timeout (a lossy skip) or the slow leg's own retransmit.

This is what lets a slow leg *contribute its bandwidth without dragging the stream* — it still carries new data, but its stragglers are rescued on a fast path.

**No wire-format change:** retransmits already re-select the leg fresh (the retx entry never recorded the original leg); this only changes *which* leg — to the lowest-latency ready, non-standby one.

- `route_mux.go`: `selectFastestTransport` — lowest `GetLatency()` among live/ready/non-standby legs, first-ready fallback when no measurement.
- `route_group.go`: `nextFastestTransport` wrapper; `handleSACKPacket` uses it.
- Tests: picks lowest latency, skips standby, unknown-latency fallback.

`make check` clean.

First of a short series to make multiplexed routing actually **outperform** a single route rather than be dragged by its slowest leg. Next: attribute the per-leg end-to-end pong latency to a per-leg EWMA (today it's stored aggregate) for a truer fastest-leg signal + policy input; then an optional per-segment **redundancy** mode (receive-side dedupe already works for free — the global seq means a duplicate is silently dropped).