### PR TITLE
feat(transport): passive per-transport throughput estimate (phase 1 of measured route ranking)

### DIFF
--- a/pkg/transport/entry.go
+++ b/pkg/transport/entry.go
@@ -53,6 +53,14 @@ type Entry struct {
 
 	// Bandwidth is total bytes (sent + recv), not included in ToBinary/signatures
 	Bandwidth uint64 `json:"bandwidth,omitempty"`
+
+	// ThroughputBps is the PASSIVELY-observed peak goodput (sent+recv bytes/sec)
+	// this transport has achieved carrying real traffic — a lower-bound CAPACITY
+	// estimate, distinct from Latency (RTT, which is throughput-blind: a webrtc
+	// SCTP datachannel has low RTT but poor goodput). 0 until enough traffic has
+	// flowed to sample. Lets route ranking prefer transports MEASURED to be fast
+	// rather than guessing by type. Not part of ToBinary/signatures.
+	ThroughputBps float64 `json:"throughput_bps,omitempty"`
 }
 
 // MakeEntry creates a new transport entry

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -96,6 +96,15 @@ type ManagedTransport struct {
 	latencyStats LatencyStats
 	latencyMx    sync.RWMutex
 
+	// Passive throughput estimate: the peak goodput this transport has been
+	// OBSERVED to carry (real traffic, no active probe → zero overhead). Guarded
+	// by throughputMx; last* hold the previous sample for the delta.
+	throughputBps     float64
+	throughputMx      sync.RWMutex
+	lastBwSampleNanos int64
+	lastBwSampleSent  uint64
+	lastBwSampleRecv  uint64
+
 	// pingReadyAtNanos is the Unix-nanos timestamp captured on the
 	// first tickPing call after the transport reaches the ready state
 	// (mt.transport != nil). Zero means not-yet-ready. Used by
@@ -286,6 +295,62 @@ func (mt *ManagedTransport) GetBandwidth() *BandwidthData {
 		SentBytes: atomic.LoadUint64(mt.LogEntry.SentBytes),
 		RecvBytes: atomic.LoadUint64(mt.LogEntry.RecvBytes),
 	}
+}
+
+// sampleThroughput folds the goodput achieved SINCE THE LAST SAMPLE into a
+// passive high-watermark capacity estimate. It only observes what real traffic
+// already did (cumulative byte counters) — it never sends anything — so it costs
+// zero bandwidth and never disrupts a live route. Idle intervals (no bytes) do
+// NOT lower the estimate: absence of traffic is not evidence of low capacity.
+// A transport carrying no traffic keeps its last observed peak.
+//
+// Capacity is a lower bound here: passive observation only sees what the traffic
+// used, so a lightly-loaded fast link reads low until it's exercised. The active
+// packet-pair probe (a later phase) fills that gap for idle transports; this
+// phase gives a free, always-correct "this transport HAS done at least X".
+func (mt *ManagedTransport) sampleThroughput(nowNanos int64) {
+	bw := mt.GetBandwidth()
+
+	mt.throughputMx.Lock()
+	defer mt.throughputMx.Unlock()
+
+	// First sample just seeds the baseline; a rate needs two points.
+	if mt.lastBwSampleNanos == 0 {
+		mt.lastBwSampleNanos = nowNanos
+		mt.lastBwSampleSent = bw.SentBytes
+		mt.lastBwSampleRecv = bw.RecvBytes
+		return
+	}
+	elapsed := float64(nowNanos-mt.lastBwSampleNanos) / 1e9
+	if elapsed <= 0 {
+		return
+	}
+	// Guard counter resets (transport re-created): a backwards delta is 0.
+	var d uint64
+	if bw.SentBytes >= mt.lastBwSampleSent {
+		d += bw.SentBytes - mt.lastBwSampleSent
+	}
+	if bw.RecvBytes >= mt.lastBwSampleRecv {
+		d += bw.RecvBytes - mt.lastBwSampleRecv
+	}
+	mt.lastBwSampleNanos = nowNanos
+	mt.lastBwSampleSent = bw.SentBytes
+	mt.lastBwSampleRecv = bw.RecvBytes
+
+	rate := float64(d) / elapsed
+	// High-watermark: capacity is AT LEAST the best goodput ever observed. Blend
+	// a new high with the prior so one spiky interval can't pin it outright.
+	if rate > mt.throughputBps {
+		mt.throughputBps = 0.6*rate + 0.4*mt.throughputBps
+	}
+}
+
+// GetThroughputBps returns the passively-observed peak goodput estimate in
+// bytes/sec (0 if the transport hasn't carried enough traffic to sample yet).
+func (mt *ManagedTransport) GetThroughputBps() float64 {
+	mt.throughputMx.RLock()
+	defer mt.throughputMx.RUnlock()
+	return mt.throughputBps
 }
 
 // transportPingInterval is how often a transport-level ping is sent.

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -250,8 +250,12 @@ func (tm *Manager) recordAllTransportLogs() {
 	}
 	tm.mx.RUnlock()
 
+	now := time.Now().UnixNano()
 	for _, mt := range snapshot {
 		mt.recordLog()
+		// Passively fold this interval's observed goodput into the transport's
+		// throughput estimate — same cadence as the log flush, no extra traffic.
+		mt.sampleThroughput(now)
 	}
 }
 

--- a/pkg/transport/throughput_estimate_test.go
+++ b/pkg/transport/throughput_estimate_test.go
@@ -1,0 +1,67 @@
+package transport
+
+import "testing"
+
+// TestSampleThroughputHighWatermark pins the passive throughput estimator: it
+// tracks the peak observed goodput, and — critically — an IDLE or SLOW interval
+// never lowers it (absence of traffic is not evidence of low capacity).
+func TestSampleThroughputHighWatermark(t *testing.T) {
+	mt := NewManagedTransportForTest(nil)
+	const s = int64(1_000_000_000) // 1 second in ns
+	base := int64(1_000_000_000)
+
+	// Seed the baseline (a rate needs two points).
+	mt.sampleThroughput(base)
+	if mt.GetThroughputBps() != 0 {
+		t.Fatalf("seed should leave estimate 0, got %v", mt.GetThroughputBps())
+	}
+
+	// 10 MB in 1 s → a high goodput sample.
+	mt.LogEntry.AddRecv(10_000_000)
+	mt.sampleThroughput(base + s)
+	peak := mt.GetThroughputBps()
+	if peak < 5_000_000 {
+		t.Fatalf("after 10MB/s the estimate should be multi-MB/s, got %v", peak)
+	}
+
+	// Idle interval: no bytes over 10 s → estimate must NOT drop.
+	mt.sampleThroughput(base + 11*s)
+	if mt.GetThroughputBps() < peak {
+		t.Errorf("idle interval lowered the estimate: %v < %v", mt.GetThroughputBps(), peak)
+	}
+
+	// Slow interval: 100 KB in 1 s (well below peak) → high-watermark holds.
+	mt.LogEntry.AddRecv(100_000)
+	mt.sampleThroughput(base + 12*s)
+	if mt.GetThroughputBps() < peak {
+		t.Errorf("slow interval lowered the high-watermark: %v < %v", mt.GetThroughputBps(), peak)
+	}
+
+	// A NEW, higher burst raises it: 40 MB in 1 s.
+	mt.LogEntry.AddSent(40_000_000)
+	mt.sampleThroughput(base + 13*s)
+	if mt.GetThroughputBps() <= peak {
+		t.Errorf("a faster burst should raise the estimate: %v <= %v", mt.GetThroughputBps(), peak)
+	}
+}
+
+// TestSampleThroughputCounterReset: a backwards byte delta (transport
+// re-created, counters reset) yields a 0 delta, never a negative/garbage rate.
+func TestSampleThroughputCounterReset(t *testing.T) {
+	mt := NewManagedTransportForTest(nil)
+	const s = int64(1_000_000_000)
+	base := int64(1_000_000_000)
+
+	mt.LogEntry.AddSent(5_000_000)
+	mt.sampleThroughput(base)     // seed at 5MB sent
+	mt.sampleThroughput(base + s) // no new bytes → rate 0, estimate stays 0
+	if mt.GetThroughputBps() != 0 {
+		t.Fatalf("no-traffic interval should keep estimate 0, got %v", mt.GetThroughputBps())
+	}
+	// Simulate a counter reset: recreate the log entry with lower counters.
+	mt.LogEntry = NewLogEntry() // sent/recv back to 0 (< last sample's 5MB)
+	mt.sampleThroughput(base + 2*s)
+	if mt.GetThroughputBps() != 0 {
+		t.Errorf("counter reset must not produce a spurious rate, got %v", mt.GetThroughputBps())
+	}
+}

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -75,6 +75,12 @@ type TransportSummary struct {
 	// ping/pong (or RSN-fallback for old peers). Zero means no
 	// measurement yet. Populated from tp.GetLatency().
 	LatencyMS float64 `json:"latency_ms,omitempty"`
+	// ThroughputBps is the passively-observed peak goodput (bytes/sec)
+	// this transport has carried — a measured CAPACITY lower-bound,
+	// distinct from RTT (a low-latency link can still be low-throughput,
+	// e.g. webrtc). Zero until real traffic has flowed. Populated from
+	// tp.GetThroughputBps().
+	ThroughputBps float64 `json:"throughput_bps,omitempty"`
 	// Initiator is true when this visor dialed out to establish the
 	// transport (outgoing); false when it accepted an inbound dial
 	// (incoming). The transport is bidirectional — this records only
@@ -90,14 +96,15 @@ type TransportLogEntry struct {
 
 func newTransportSummary(tm *transport.Manager, tp *transport.ManagedTransport, includeLogs, isSetup bool) *TransportSummary {
 	summary := &TransportSummary{
-		ID:        tp.Entry.ID,
-		Local:     tm.Local(),
-		Remote:    tp.Remote(),
-		Type:      tp.Type(),
-		IsSetup:   isSetup,
-		Label:     tp.Entry.Label,
-		LatencyMS: tp.GetLatency(),
-		Initiator: tp.IsInitiator(),
+		ID:            tp.Entry.ID,
+		Local:         tm.Local(),
+		Remote:        tp.Remote(),
+		Type:          tp.Type(),
+		IsSetup:       isSetup,
+		Label:         tp.Entry.Label,
+		LatencyMS:     tp.GetLatency(),
+		ThroughputBps: tp.GetThroughputBps(),
+		Initiator:     tp.IsInitiator(),
 	}
 	if includeLogs {
 		summary.Log = tp.LogEntry


### PR DESCRIPTION
Route ranking judges transports by **RTT** (`Latency`), which is **throughput-blind** — a webrtc SCTP datachannel has low RTT but poor goodput, so it ranks well and lands on mux legs. Rather than hardcode a per-type penalty (a *guess*), give each transport a **measured** throughput estimate that can feed ranking. This is phase 1 of that.

## Phase 1 — the free half: passive observation
On the existing transport-maintenance loop (same cadence as the log flush, **no new goroutine, zero extra traffic**), fold each interval's observed goodput (sent+recv byte deltas) into a per-transport **high-watermark** estimate:
- reads cumulative counters only — **never sends a probe** — so it can't disrupt a live route or cost bandwidth (the fleet is near its cap);
- idle/slow intervals **never lower** the estimate (absence of traffic ≠ low capacity — a transport keeps its observed peak);
- counter resets (transport re-created) yield a 0 delta, never garbage.

Surfaced on `TransportSummary.ThroughputBps` (visible in `tp ls --json`) via `tp.GetThroughputBps()`, plus a signature-excluded `Entry.ThroughputBps` for the later phases.

## Roadmap (discussed with maintainer)
Capacity here is a **lower bound** — a lightly-loaded fast link reads low until exercised. Next:
- **Phase 2** — active **packet-pair / dispersion probe** for *idle, never-used* transports (a few KB, not a saturating burst — cheap, deliberately non-obtrusive).
- **Phase 3** — wire measured throughput into route ranking (route bottleneck = `min(hop throughput)`), retiring the static type penalty to a *prior* used only until a real measurement exists. A genuinely-fast webrtc link would then be correctly kept.

## Tests
High-watermark holds across idle/slow intervals, rises on a faster burst, survives a counter reset. `make check` clean; lint clean.