### PR TITLE
feat(transport): active packet-pair bandwidth probe for idle transports (phase 2 of measured route ranking)

### DIFF
--- a/pkg/routing/bw_probe_packet_test.go
+++ b/pkg/routing/bw_probe_packet_test.go
@@ -1,0 +1,26 @@
+package routing
+
+import "testing"
+
+func TestBwProbePacketRoundTrip(t *testing.T) {
+	p := MakeTransportBwProbePacket(42, 3, 8)
+	if p.Type() != TransportBwProbePacket {
+		t.Fatalf("type = %v", p.Type())
+	}
+	if len(p) != TransportBwProbeSize {
+		t.Errorf("probe packet size = %d, want %d", len(p), TransportBwProbeSize)
+	}
+	id, seq, total, ok := p.BwProbeFields()
+	if !ok || id != 42 || seq != 3 || total != 8 {
+		t.Errorf("probe fields = (%d,%d,%d,%v), want (42,3,8,true)", id, seq, total, ok)
+	}
+
+	a := MakeTransportBwAckPacket(42, 9_999_999)
+	if a.Type() != TransportBwAckPacket {
+		t.Fatalf("ack type = %v", a.Type())
+	}
+	aid, bps, aok := a.BwAckFields()
+	if !aok || aid != 42 || bps != 9_999_999 {
+		t.Errorf("ack fields = (%d,%d,%v), want (42,9999999,true)", aid, bps, aok)
+	}
+}

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -73,6 +73,10 @@ func (t PacketType) String() string {
 		return "AppDirect"
 	case DatagramPacket:
 		return "Datagram"
+	case TransportBwProbePacket:
+		return "TransportBwProbe"
+	case TransportBwAckPacket:
+		return "TransportBwAck"
 	default:
 		return fmt.Sprintf("Unknown(%d)", t)
 	}
@@ -105,7 +109,28 @@ const (
 	SkynetForwardPacket // skynet port forwarding over direct transport (route ID = 0), virtual stream
 	AppDirectPacket     // skywire-network app direct dial over direct transport (route ID = 0), virtual stream
 	DatagramPacket      // faithful-UDP routed datagram (route ID > 0), payload: opaque bytes (AEAD-sealed at the DatagramRouteGroup layer). No sequence number — counter lives in the AEAD nonce (see RFC #2607).
+	// TransportBwProbePacket is one packet of a back-to-back packet-pair
+	// train (route ID = 0) used to estimate a transport's bottleneck
+	// bandwidth from receive-side inter-arrival DISPERSION — a few KB, not a
+	// saturating burst. Payload: probeID(u32) seq(u16) total(u16) + padding to
+	// TransportBwProbeSize so the bottleneck link spaces consecutive packets.
+	TransportBwProbePacket
+	// TransportBwAckPacket carries the receiver's dispersion estimate back to
+	// the prober (route ID = 0). Payload: probeID(u32) estBps(u64).
+	TransportBwAckPacket
 )
+
+// TransportBwProbeSize is the on-wire size of each packet-pair probe packet.
+// ~1400 B (sub-MTU) so consecutive packets are large enough to be spaced by
+// the bottleneck link's serialization delay — the signal dispersion measures.
+const TransportBwProbeSize = 1400
+
+// TransportBwProbeHdr is the meaningful prefix of a probe payload:
+// probeID(4) + seq(2) + total(2); the remainder is padding.
+const TransportBwProbeHdr = 8
+
+// TransportBwAckSize is the ack payload size: probeID(4) + estBps(8).
+const TransportBwAckSize = 12
 
 // Capability bitmap flags for extended handshake negotiation.
 // Transmitted as a little-endian uint16 at HandshakePacket payload bytes 1-2.
@@ -385,6 +410,49 @@ func MakeTransportPongPacket(timestamp int64) Packet {
 	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], TransportPingPayloadSize)
 	binary.BigEndian.PutUint64(packet[PacketPayloadOffset:], uint64(timestamp)) //nolint:gosec
 	return packet
+}
+
+// MakeTransportBwProbePacket constructs one packet of a bandwidth-probe train
+// (route ID = 0), padded to TransportBwProbeSize.
+func MakeTransportBwProbePacket(probeID uint32, seq, total uint16) Packet {
+	payloadLen := TransportBwProbeSize - PacketHeaderSize
+	packet := make([]byte, PacketHeaderSize+payloadLen)
+	packet[PacketTypeOffset] = byte(TransportBwProbePacket)
+	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], uint16(payloadLen)) //nolint:gosec
+	binary.BigEndian.PutUint32(packet[PacketPayloadOffset:], probeID)
+	binary.BigEndian.PutUint16(packet[PacketPayloadOffset+4:], seq)
+	binary.BigEndian.PutUint16(packet[PacketPayloadOffset+6:], total)
+	return packet
+}
+
+// BwProbeFields returns (probeID, seq, total) from a TransportBwProbePacket
+// payload, and false if the payload is too short.
+func (p Packet) BwProbeFields() (probeID uint32, seq, total uint16, ok bool) {
+	pl := p.Payload()
+	if len(pl) < TransportBwProbeHdr {
+		return 0, 0, 0, false
+	}
+	return binary.BigEndian.Uint32(pl), binary.BigEndian.Uint16(pl[4:]), binary.BigEndian.Uint16(pl[6:]), true
+}
+
+// MakeTransportBwAckPacket constructs the prober-bound estimate reply.
+func MakeTransportBwAckPacket(probeID uint32, estBps uint64) Packet {
+	packet := make([]byte, PacketHeaderSize+TransportBwAckSize)
+	packet[PacketTypeOffset] = byte(TransportBwAckPacket)
+	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], TransportBwAckSize)
+	binary.BigEndian.PutUint32(packet[PacketPayloadOffset:], probeID)
+	binary.BigEndian.PutUint64(packet[PacketPayloadOffset+4:], estBps)
+	return packet
+}
+
+// BwAckFields returns (probeID, estBps) from a TransportBwAckPacket payload,
+// and false if the payload is too short.
+func (p Packet) BwAckFields() (probeID uint32, estBps uint64, ok bool) {
+	pl := p.Payload()
+	if len(pl) < TransportBwAckSize {
+		return 0, 0, false
+	}
+	return binary.BigEndian.Uint32(pl), binary.BigEndian.Uint64(pl[4:]), true
 }
 
 // MakeCascadeSetupPacket constructs a cascade setup packet (route ID = 0).

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -105,6 +105,18 @@ type ManagedTransport struct {
 	lastBwSampleSent  uint64
 	lastBwSampleRecv  uint64
 
+	// Active packet-pair bandwidth probe (phase 2). bwProbeID is the last train
+	// we sent; bwLastProbeNanos gates re-probing. The bwRecv* fields track the
+	// train currently being RECEIVED (one at a time), guarded by bwRecvMx, to
+	// compute receive-side inter-arrival dispersion.
+	bwProbeID        atomic.Uint32
+	bwLastProbeNanos atomic.Int64
+	bwRecvMx         sync.Mutex
+	bwRecvProbeID    uint32
+	bwRecvFirstNanos int64
+	bwRecvLastNanos  int64
+	bwRecvCount      int
+
 	// pingReadyAtNanos is the Unix-nanos timestamp captured on the
 	// first tickPing call after the transport reaches the ready state
 	// (mt.transport != nil). Zero means not-yet-ready. Used by
@@ -498,6 +510,12 @@ func (mt *ManagedTransport) readLoop(readCh chan<- routing.Packet) {
 			case routing.TransportPongPacket:
 				mt.handleTransportPong(p)
 				continue
+			case routing.TransportBwProbePacket:
+				mt.handleBwProbe(p)
+				continue
+			case routing.TransportBwAckPacket:
+				mt.handleBwAck(p)
+				continue
 			case routing.CascadeSetupPacket, routing.CascadeAckPacket:
 				if mt.cascadeHandler != nil {
 					mt.cascadeHandler(p, mt)
@@ -711,6 +729,136 @@ func (mt *ManagedTransport) handleTransportPong(p routing.Packet) {
 	}
 	mt.SetLatency(rttMs)
 	mt.log.WithField("rtt_ms", fmt.Sprintf("%.2f", rttMs)).Trace("Transport ping RTT")
+}
+
+const (
+	// transportBwProbeTrain is how many back-to-back packets a probe sends.
+	// Enough for a stable inter-arrival dispersion; the whole train is
+	// transportBwProbeTrain × TransportBwProbeSize ≈ 11 KB (not a saturating
+	// burst).
+	transportBwProbeTrain = 8
+	// maxReasonableBps rejects absurd dispersion estimates (a sub-µs span over
+	// loopback/coalesced arrivals yields near-infinite bps). 10 Gbps in bytes.
+	maxReasonableBps = 1.25e9
+)
+
+// dispersionBps computes the bottleneck-bandwidth estimate (bytes/sec) from a
+// received packet-pair train: the bytes that arrived AFTER the first packet,
+// divided by the span between the first and last arrival (a single receiver
+// clock — no clock sync needed). Returns 0 when the train is too short or the
+// span is non-positive. Pure function → unit-testable.
+func dispersionBps(count int, firstNanos, lastNanos int64, pktSize int) float64 { //nolint:unparam // pktSize is a param for test clarity + future variable-size probes
+	if count < 2 {
+		return 0
+	}
+	spanNs := lastNanos - firstNanos
+	if spanNs <= 0 {
+		return 0
+	}
+	bytesAfterFirst := float64(count-1) * float64(pktSize)
+	return bytesAfterFirst / (float64(spanNs) / 1e9)
+}
+
+// sendBwProbe sends a short back-to-back packet-pair train so the PEER can
+// estimate this transport's bottleneck bandwidth from receive-side dispersion
+// and report it back (handleBwAck records it). It writes ~11 KB, NOT a
+// saturating burst; the caller (Manager.probeUnmeasuredTransports) gates it on
+// idle + never-measured + a global rate limit so it never disrupts a live route
+// or strains the fleet's bandwidth.
+func (mt *ManagedTransport) sendBwProbe() {
+	mt.transportMx.Lock()
+	tp := mt.transport
+	mt.transportMx.Unlock()
+	if tp == nil {
+		return
+	}
+	probeID := mt.bwProbeID.Add(1)
+	mt.bwLastProbeNanos.Store(time.Now().UnixNano())
+
+	// Fresh write deadline — same stale-absolute-deadline hazard as the ping.
+	if err := tp.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		mt.log.WithError(err).Debug("bw-probe: set write deadline")
+	}
+	for seq := 0; seq < transportBwProbeTrain; seq++ {
+		p := routing.MakeTransportBwProbePacket(probeID, uint16(seq), transportBwProbeTrain) //nolint:gosec
+		n, err := tp.Write(p)
+		if err != nil {
+			mt.log.WithError(err).Debug("bw-probe: train write failed")
+			return
+		}
+		if n > routing.PacketHeaderSize {
+			mt.logSent(uint64(n - routing.PacketHeaderSize)) //nolint:gosec
+		}
+	}
+}
+
+// handleBwProbe records the receive time of one probe-train packet; on the last
+// packet of the train it computes the inter-arrival dispersion and replies with
+// a TransportBwAck carrying the estimate.
+func (mt *ManagedTransport) handleBwProbe(p routing.Packet) {
+	probeID, _, total, ok := p.BwProbeFields()
+	if !ok || total < 2 {
+		return
+	}
+	now := time.Now().UnixNano()
+
+	mt.bwRecvMx.Lock()
+	if probeID != mt.bwRecvProbeID {
+		mt.bwRecvProbeID = probeID // new train
+		mt.bwRecvFirstNanos = now
+		mt.bwRecvCount = 1
+	} else {
+		mt.bwRecvCount++
+	}
+	mt.bwRecvLastNanos = now
+	count, first, last := mt.bwRecvCount, mt.bwRecvFirstNanos, mt.bwRecvLastNanos
+	done := count >= int(total)
+	if done {
+		mt.bwRecvProbeID = 0 // reset for the next train
+	}
+	mt.bwRecvMx.Unlock()
+	if !done {
+		return
+	}
+
+	estBps := dispersionBps(count, first, last, routing.TransportBwProbeSize)
+	if estBps <= 0 || estBps > maxReasonableBps {
+		return
+	}
+
+	mt.transportMx.Lock()
+	tp := mt.transport
+	mt.transportMx.Unlock()
+	if tp == nil {
+		return
+	}
+	if err := tp.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		mt.log.WithError(err).Debug("bw-probe: set ack write deadline")
+	}
+	ack := routing.MakeTransportBwAckPacket(probeID, uint64(estBps))
+	if n, err := tp.Write(ack); err != nil {
+		mt.log.WithError(err).Debug("bw-probe: ack write failed")
+	} else if n > routing.PacketHeaderSize {
+		mt.logSent(uint64(n - routing.PacketHeaderSize)) //nolint:gosec
+	}
+}
+
+// handleBwAck folds the peer's dispersion estimate into the throughput
+// high-watermark. An ACTIVE probe measures capacity, so it can raise the
+// estimate above what passive traffic has yet shown.
+func (mt *ManagedTransport) handleBwAck(p routing.Packet) {
+	probeID, estBps, ok := p.BwAckFields()
+	if !ok || probeID != mt.bwProbeID.Load() { // ignore stale / mismatched
+		return
+	}
+	if estBps == 0 || float64(estBps) > maxReasonableBps {
+		return
+	}
+	mt.throughputMx.Lock()
+	if float64(estBps) > mt.throughputBps {
+		mt.throughputBps = float64(estBps)
+	}
+	mt.throughputMx.Unlock()
 }
 
 func (mt *ManagedTransport) isServing() bool {

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -220,8 +220,10 @@ func (tm *Manager) runTransportMaintenance(ctx context.Context) {
 
 	logTicker := time.NewTicker(logWriteInterval)
 	pingTicker := time.NewTicker(transportPingInterval)
+	bwProbeTicker := time.NewTicker(bwProbeInterval)
 	defer logTicker.Stop()
 	defer pingTicker.Stop()
+	defer bwProbeTicker.Stop()
 
 	for {
 		select {
@@ -233,7 +235,58 @@ func (tm *Manager) runTransportMaintenance(ctx context.Context) {
 			tm.recordAllTransportLogs()
 		case <-pingTicker.C:
 			tm.pingAllTransports()
+		case <-bwProbeTicker.C:
+			tm.probeUnmeasuredTransports()
 		}
+	}
+}
+
+const (
+	// bwProbeInterval is how often the maintenance loop runs a bounded
+	// bandwidth-probe pass.
+	bwProbeInterval = 90 * time.Second
+	// maxBwProbesPerPass caps how many transports are actively probed per pass,
+	// so the fleet-wide overhead stays a trickle (each probe ≈ 11 KB).
+	maxBwProbesPerPass = 3
+	// bwProbeStaleness is how long a transport's throughput estimate is trusted
+	// before it's eligible for a re-probe.
+	bwProbeStaleness = 30 * time.Minute
+)
+
+// probeUnmeasuredTransports sends a packet-pair bandwidth probe to a bounded
+// number of transports that have NO throughput estimate yet (passive
+// observation never saw enough traffic) OR whose estimate is stale — never more
+// than maxBwProbesPerPass per pass. Actively-carrying transports already have a
+// passive estimate, so they are skipped: real traffic is the best probe and it
+// costs nothing.
+func (tm *Manager) probeUnmeasuredTransports() {
+	tm.mx.RLock()
+	snapshot := make([]*ManagedTransport, 0, len(tm.tps))
+	for _, mt := range tm.tps {
+		snapshot = append(snapshot, mt)
+	}
+	tm.mx.RUnlock()
+
+	now := time.Now().UnixNano()
+	staleBefore := now - bwProbeStaleness.Nanoseconds()
+	sent := 0
+	for _, mt := range snapshot {
+		if sent >= maxBwProbesPerPass {
+			return
+		}
+		if mt.getTransport() == nil {
+			continue // not ready
+		}
+		// Skip transports that already have a fresh estimate (passive or a
+		// recent probe). Probe only the never-measured or long-stale ones.
+		if mt.GetThroughputBps() > 0 && mt.bwLastProbeNanos.Load() > staleBefore {
+			continue
+		}
+		if last := mt.bwLastProbeNanos.Load(); last > staleBefore {
+			continue // probed recently
+		}
+		mt.sendBwProbe()
+		sent++
 	}
 }
 

--- a/pkg/transport/throughput_estimate_test.go
+++ b/pkg/transport/throughput_estimate_test.go
@@ -1,6 +1,10 @@
 package transport
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/routing"
+)
 
 // TestSampleThroughputHighWatermark pins the passive throughput estimator: it
 // tracks the peak observed goodput, and — critically — an IDLE or SLOW interval
@@ -63,5 +67,53 @@ func TestSampleThroughputCounterReset(t *testing.T) {
 	mt.sampleThroughput(base + 2*s)
 	if mt.GetThroughputBps() != 0 {
 		t.Errorf("counter reset must not produce a spurious rate, got %v", mt.GetThroughputBps())
+	}
+}
+
+// TestDispersionBps: bottleneck estimate = bytes-after-first / arrival span.
+func TestDispersionBps(t *testing.T) {
+	// 8 packets of 1400 B, last arrives 10 ms after first → 7*1400 B / 0.01 s.
+	got := dispersionBps(8, 0, 10_000_000, 1400)
+	want := float64(7*1400) / 0.010
+	if got != want {
+		t.Errorf("dispersionBps = %.0f, want %.0f", got, want)
+	}
+	// Degenerate inputs return 0 (never garbage).
+	if dispersionBps(1, 0, 10_000_000, 1400) != 0 {
+		t.Error("count<2 should be 0")
+	}
+	if dispersionBps(8, 100, 100, 1400) != 0 {
+		t.Error("zero span should be 0")
+	}
+	if dispersionBps(8, 200, 100, 1400) != 0 {
+		t.Error("negative span should be 0")
+	}
+}
+
+// TestHandleBwAckRaisesEstimate: a matching ack raises the throughput
+// high-watermark; a stale/absurd one is ignored.
+func TestHandleBwAckRaisesEstimate(t *testing.T) {
+	mt := NewManagedTransportForTest(nil)
+	mt.bwProbeID.Store(7)
+
+	// Matching probeID, 5 MB/s → estimate rises.
+	mt.handleBwAck(routing.MakeTransportBwAckPacket(7, 5_000_000))
+	if mt.GetThroughputBps() != 5_000_000 {
+		t.Fatalf("matching ack should set estimate to 5e6, got %v", mt.GetThroughputBps())
+	}
+	// Stale probeID → ignored.
+	mt.handleBwAck(routing.MakeTransportBwAckPacket(6, 50_000_000))
+	if mt.GetThroughputBps() != 5_000_000 {
+		t.Errorf("stale ack changed estimate: %v", mt.GetThroughputBps())
+	}
+	// Absurd value (> maxReasonableBps) → ignored.
+	mt.handleBwAck(routing.MakeTransportBwAckPacket(7, uint64(maxReasonableBps)+1))
+	if mt.GetThroughputBps() != 5_000_000 {
+		t.Errorf("absurd ack changed estimate: %v", mt.GetThroughputBps())
+	}
+	// A higher valid estimate raises it (active probe measures capacity).
+	mt.handleBwAck(routing.MakeTransportBwAckPacket(7, 20_000_000))
+	if mt.GetThroughputBps() != 20_000_000 {
+		t.Errorf("higher ack should raise estimate, got %v", mt.GetThroughputBps())
 	}
 }


### PR DESCRIPTION
Phase 1 (#3987) gave a **free passive** throughput estimate, but it only sees what real traffic used — an idle or lightly-loaded fast transport reads low until exercised. Phase 2 fills that gap for **idle / never-measured** transports with an active probe that's deliberately **non-obtrusive: packet-pair dispersion, not a saturating burst.**

## How
The prober sends a short back-to-back train (8 × ~1400 B ≈ **11 KB**) of new route-ID-0 `TransportBwProbe` packets. The receiver timestamps arrivals and, on the last packet, computes bottleneck bandwidth from the inter-arrival **dispersion** — `bytes-after-first / (last−first arrival)`, a single receiver clock, **no clock sync** — and replies with a `TransportBwAck` carrying the estimate. The prober folds it into the throughput high-watermark (an active probe measures *capacity*, so it can raise the estimate above what passive traffic has shown).

## Guardrails (the fleet is near its bandwidth cap)
- probe **only** transports with no estimate yet or a stale one — actively-carrying transports already have a passive estimate and are skipped (real traffic is the best probe, free);
- at most **3 probes per 90 s pass** → fleet-wide overhead is a trickle;
- re-probe no more than every **30 min** per transport.

## Backward-compatible
The two packet types are **appended** to the `PacketType` iota (existing wire values unchanged); a peer that doesn't implement them never acks, so the prober simply gets no estimate and falls back to passive/prior.

## Tests
Dispersion math + degenerate inputs; ack raises estimate / ignores stale + absurd values; probe/ack packet round-trip. `make check` clean; lint clean.

**Next (phase 3):** wire measured throughput into route ranking (`min(hop throughput)` bottleneck), retiring the static transport-type penalty to a *prior*. Directly answers "make sure the route finder isn't returning webrtc when it hinders performance" — on measurement, not type.