### PR TITLE
feat(mux-bw): rank disjoint route candidates by transport cost (no more webrtc legs)

### DIFF
--- a/pkg/visor/rpcgrpc/server_mux_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth.go
@@ -38,6 +38,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	routeFinder "github.com/skycoin/skywire/pkg/route-finder/store"
 	"github.com/skycoin/skywire/pkg/routing"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 )
 
 // Defaults for unset MuxBandwidthRequest fields.
@@ -516,12 +517,20 @@ func (s *PingServer) muxBwPlanDisjointRoutes(
 		return nil, fmt.Errorf("no transport entries available")
 	}
 
-	// TpID -> carrier kind, so each planned hop can carry its transport
-	// type for per-leg telemetry (routing.Hop drops it).
+	// TpID -> carrier kind + measured throughput. The type feeds per-leg
+	// telemetry (routing.Hop drops it); both feed muxBwTransportCostMs so
+	// disjoint candidates are ranked by transport quality — a slow webrtc
+	// leg loses to a stcpr/quic one, mirroring the client-side ranking
+	// (pkg/router transportCostMs, PR #3989). Previously this planner took
+	// routes in BFS shortest-first order and skipped only for
+	// intermediate-disjointness, so webrtc legs were selected purely because
+	// BFS reached them first — measurably worse under load.
 	tpTypes := make(map[string]string, len(entries))
+	tpThroughput := make(map[string]float64, len(entries))
 	for _, e := range entries {
 		if e != nil {
 			tpTypes[e.ID.String()] = string(e.Type)
+			tpThroughput[e.ID.String()] = e.ThroughputBps
 		}
 	}
 
@@ -530,31 +539,119 @@ func (s *PingServer) muxBwPlanDisjointRoutes(
 		return nil, fmt.Errorf("build graph: %w", err)
 	}
 
-	plans := make([]muxBwRoutePlan, 0, count)
-	usedInter := make(map[cipher.PubKey]struct{})
+	// Collect a bounded candidate pool, then rank by summed transport cost so
+	// disjoint selection prefers fast transports. The cap keeps BFS work
+	// bounded while giving enough diversity to choose between transport types
+	// at the same hop-count.
+	type muxBwCandidate struct {
+		plan  muxBwRoutePlan
+		inter []cipher.PubKey
+		cost  float64
+		hops  int
+	}
+	const muxBwCandidateCap = 128
+	candidates := make([]muxBwCandidate, 0, muxBwCandidateCap)
 	streamErr := graph.StreamRoutesWithCap(ctx, srcPK, dstPK, minHops, maxHops, routeFinder.DefaultMaxBFSQueue,
 		func(r routing.Route) bool {
-			inter := muxBwIntermediates(r, srcPK, dstPK)
-			for _, pk := range inter {
-				if _, seen := usedInter[pk]; seen {
-					// Shares an intermediate with an already-selected
-					// route — not disjoint; keep searching.
-					return true
-				}
-			}
 			fwd := muxBwRoutingHopsToInfo(r.Hops, tpTypes)
-			plans = append(plans, muxBwRoutePlan{forward: fwd, reverse: muxBwReverseHops(fwd)})
-			for _, pk := range inter {
-				usedInter[pk] = struct{}{}
-			}
-			return len(plans) < count
+			candidates = append(candidates, muxBwCandidate{
+				plan:  muxBwRoutePlan{forward: fwd, reverse: muxBwReverseHops(fwd)},
+				inter: muxBwIntermediates(r, srcPK, dstPK),
+				cost:  muxBwRouteCostMs(r.Hops, tpTypes, tpThroughput),
+				hops:  len(r.Hops),
+			})
+			return len(candidates) < muxBwCandidateCap
 		})
 	// ErrRouteNotFound after emitting ≥1 route is a clean end-of-search,
 	// not a failure — same translation StreamCalcRoutes applies.
-	if streamErr != nil && (len(plans) == 0 || streamErr != routeFinder.ErrRouteNotFound) {
-		return plans, streamErr
+	if streamErr != nil && (len(candidates) == 0 || streamErr != routeFinder.ErrRouteNotFound) {
+		return nil, streamErr
+	}
+
+	// Cheapest (fastest transports) first; break ties toward fewer hops. Stable
+	// so equal-cost routes keep BFS order (shortest-first) as the sub-tie-break.
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].cost != candidates[j].cost {
+			return candidates[i].cost < candidates[j].cost
+		}
+		return candidates[i].hops < candidates[j].hops
+	})
+
+	plans := make([]muxBwRoutePlan, 0, count)
+	usedInter := make(map[cipher.PubKey]struct{})
+	for _, c := range candidates {
+		overlap := false
+		for _, pk := range c.inter {
+			if _, seen := usedInter[pk]; seen {
+				overlap = true
+				break
+			}
+		}
+		if overlap {
+			continue
+		}
+		plans = append(plans, c.plan)
+		for _, pk := range c.inter {
+			usedInter[pk] = struct{}{}
+		}
+		if len(plans) >= count {
+			break
+		}
 	}
 	return plans, nil
+}
+
+// muxBwRouteCostMs sums the per-hop transport cost across a route — the ranking
+// key that biases disjoint mux-leg selection toward fast transports. It mirrors
+// pkg/router.transportCostMs (PR #3989): a MEASURED throughput estimate
+// (throughput_bps > 0, from the passive observer / packet-pair probe) is used
+// directly, so a link measured fast scores 0 regardless of type and a congested
+// one is penalized regardless of type; the transport-type prior applies only
+// until a measurement exists. Kept in sync with that function by intent.
+func muxBwRouteCostMs(hops []routing.Hop, tpTypes map[string]string, tpThroughput map[string]float64) float64 {
+	var total float64
+	for _, h := range hops {
+		id := h.TpID.String()
+		total += muxBwTransportCostMs(tpTypes[id], tpThroughput[id])
+	}
+	return total
+}
+
+// muxBwTransportCostMs is the per-hop cost — a mirror of
+// pkg/router.transportCostMs / transportTypeCostMs (PR #3989). Bytes/sec
+// thresholds ≈ 40/10/2/0.4 Mbps; the type prior ranks stcpr/quic best and
+// webrtc/dmsg worst.
+func muxBwTransportCostMs(tpType string, throughputBps float64) float64 {
+	if throughputBps > 0 {
+		switch {
+		case throughputBps >= 5_000_000:
+			return 0
+		case throughputBps >= 1_250_000:
+			return 25
+		case throughputBps >= 250_000:
+			return 100
+		case throughputBps >= 50_000:
+			return 250
+		default:
+			return 400 // measured slow — worse than the webrtc prior
+		}
+	}
+	switch tptypes.Type(tpType) {
+	case tptypes.STCPR, tptypes.QUIC, tptypes.QUICLegacy, tptypes.QUICLegacy2:
+		return 0
+	case tptypes.SUDPH:
+		return 25
+	case tptypes.STCP:
+		return 50
+	case tptypes.WT, tptypes.WTLegacy, tptypes.WS, tptypes.WSLegacy:
+		return 150
+	case tptypes.WEBRTC:
+		return 300
+	case tptypes.DMSG:
+		return 400
+	default:
+		return 100 // unknown type — mild penalty, below webrtc
+	}
 }
 
 // muxBwIntermediates returns the DISTINCT intermediate visor PKs of a route

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth_cost_test.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth_cost_test.go
@@ -1,0 +1,71 @@
+package rpcgrpc
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// TestMuxBwTransportCostMs pins the per-hop ranking cost: the transport-type
+// prior orders stcpr/quic best and webrtc/dmsg worst, but a MEASURED throughput
+// estimate overrides the type entirely — a fast webrtc link beats a slow stcpr
+// one. Mirrors pkg/router.transportCostMs (PR #3989).
+func TestMuxBwTransportCostMs(t *testing.T) {
+	// Type prior (no measurement).
+	cases := []struct {
+		tp   string
+		want float64
+	}{
+		{"stcpr", 0}, {"squicr", 0}, {"sudph", 25}, {"stcp", 50},
+		{"webrtc", 300}, {"dmsg", 400}, {"mystery", 100},
+	}
+	for _, c := range cases {
+		if got := muxBwTransportCostMs(c.tp, 0); got != c.want {
+			t.Errorf("muxBwTransportCostMs(%q, 0) = %v, want %v", c.tp, got, c.want)
+		}
+	}
+
+	// Measured overrides type: a webrtc link measured fast scores 0, beating a
+	// stcpr link measured slow (400).
+	if fast := muxBwTransportCostMs("webrtc", 40_000_000); fast != 0 {
+		t.Errorf("measured-fast webrtc = %v, want 0", fast)
+	}
+	if slow := muxBwTransportCostMs("stcpr", 30_000); slow != 400 {
+		t.Errorf("measured-slow stcpr = %v, want 400", slow)
+	}
+	if muxBwTransportCostMs("webrtc", 40_000_000) >= muxBwTransportCostMs("stcpr", 30_000) {
+		t.Error("a measured-fast webrtc leg must rank ahead of a measured-slow stcpr leg")
+	}
+}
+
+// TestMuxBwRouteCostMs verifies the route cost sums per-hop costs, so a route
+// over webrtc is ranked worse than an otherwise-equal route over stcpr — which
+// is what steers disjoint mux-leg selection away from webrtc.
+func TestMuxBwRouteCostMs(t *testing.T) {
+	idA, idB := uuid.New(), uuid.New()
+	tpTypes := map[string]string{idA.String(): "stcpr", idB.String(): "webrtc"}
+	tpThroughput := map[string]float64{} // no measurements → type prior
+
+	stcprRoute := []routing.Hop{{TpID: idA}}
+	webrtcRoute := []routing.Hop{{TpID: idB}}
+
+	cStcpr := muxBwRouteCostMs(stcprRoute, tpTypes, tpThroughput)
+	cWebrtc := muxBwRouteCostMs(webrtcRoute, tpTypes, tpThroughput)
+	if cStcpr != 0 {
+		t.Errorf("stcpr route cost = %v, want 0", cStcpr)
+	}
+	if cWebrtc != 300 {
+		t.Errorf("webrtc route cost = %v, want 300", cWebrtc)
+	}
+	if cStcpr >= cWebrtc {
+		t.Errorf("stcpr route (%v) must rank cheaper than webrtc route (%v)", cStcpr, cWebrtc)
+	}
+
+	// A measured-fast webrtc hop flips the ranking: evidence beats the prior.
+	tpThroughput[idB.String()] = 40_000_000
+	if muxBwRouteCostMs(webrtcRoute, tpTypes, tpThroughput) != 0 {
+		t.Error("measured-fast webrtc route should cost 0")
+	}
+}


### PR DESCRIPTION
The `StreamMuxBandwidth` disjoint-route planner (`muxBwPlanDisjointRoutes`) selected routes in **BFS shortest-first** order, skipping only for intermediate-disjointness — so it grabbed whatever transports BFS reached first, including **webrtc** (SCTP-over-DTLS: low RTT but poor goodput, 24-28 goroutines/transport). The client-side app/proxy planner already ranks by transport cost (`pathLatencyScore`/`transportCostMs`, #3989); the mux-bw rig did not, so its legs kept landing on webrtc.

**Fix:** collect a bounded candidate pool, score each route by summed per-hop `muxBwTransportCostMs` (measured throughput when known — from #3987/#3988 — else the transport-type prior, mirroring `pkg/router.transportCostMs`), sort cheapest-first, then greedily select disjoint. Same measured-overrides-type semantics: a link measured fast scores 0 regardless of type; a congested one is penalized regardless of type.

**Live validation** — `mux-bw --routes 3 --min-hops 2` to a controlled peer:
- before: legs = {stcpr, webrtc, webrtc}
- after: legs = {stcpr, stcpr, stcpr}, disjoint, ~3.6 Mbps aggregate (3x a single route)

Unit-tested (type prior + measured override + route-sum ranking). `go test ./pkg/visor/rpcgrpc/` + `golangci-lint` clean.