### PR TITLE
fix(proxyinterstitial): mechanism-specific copy + Skywire cloud branding

### DIFF
--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -324,7 +324,7 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 					}
 					log.WithField("host", target).WithField("err", dialErr).
 						Debug("SOCKS5 → serving branded route interstitial")
-					conn, dialErr = proxyinterstitial.Conn(target, "", false), nil
+					conn, dialErr = proxyinterstitial.Conn(target, "", "dmsg", false), nil
 				}
 			}()
 

--- a/pkg/proxyinterstitial/interstitial.go
+++ b/pkg/proxyinterstitial/interstitial.go
@@ -34,15 +34,31 @@ import (
 // two cycles.
 const refreshSeconds = 3
 
-// Page returns the full HTML document for the interstitial. target is the
-// host the browser was trying to reach (shown verbatim, HTML-escaped); detail
-// is an optional one-line status/error string. When isError is true the page
-// renders the hard-failure variant (error styling, no auto-refresh, manual
-// retry button); otherwise it renders the transient variant (spinner +
-// meta-refresh auto-retry).
-func Page(target, detail string, isError bool) string {
+// mechanismLabel maps a transport-mechanism key to the user-facing name shown
+// in the "Fetching the page over …" step. The three native proxy surfaces that
+// serve this page each pass their own: skysocks-client → "skysocks", the
+// dmsgweb resolving proxy → "dmsg", the skynetweb resolving proxy → "skynet".
+// An empty/unknown key degrades to the generic "skywire".
+func mechanismLabel(mechanism string) string {
+	switch strings.ToLower(strings.TrimSpace(mechanism)) {
+	case "skysocks", "dmsg", "skynet":
+		return strings.ToLower(strings.TrimSpace(mechanism))
+	default:
+		return "skywire"
+	}
+}
+
+// Page returns the full HTML document for the interstitial. target is the host
+// the browser was trying to reach (shown verbatim, HTML-escaped); detail is an
+// optional one-line status/error string; mechanism names the forwarding surface
+// ("skysocks" / "dmsg" / "skynet") so the fetch step is specific rather than a
+// generic "over skywire". When isError is true the page renders the
+// hard-failure variant (error styling, no auto-refresh, manual retry button);
+// otherwise it renders the transient variant (spinner + meta-refresh auto-retry).
+func Page(target, detail, mechanism string, isError bool) string {
 	target = html.EscapeString(strings.TrimSpace(target))
 	detail = html.EscapeString(strings.TrimSpace(detail))
+	mech := mechanismLabel(mechanism)
 
 	title := "Connecting over skywire…"
 	heading := "Building a route over the mesh…"
@@ -75,6 +91,11 @@ func Page(target, detail string, isError bool) string {
 		retry = `<button class="btn" onclick="location.reload()">Retry</button>`
 	}
 
+	// Steps describe what is ACTUALLY happening. The page is served BY this
+	// visor's own proxy, so "reaching your visor" is a given, not a step; and
+	// the exit is already selected, so the work is route-building, not
+	// "finding an exit". The fetch step names the concrete mechanism.
+	fetchStep := `<li>Fetching the page over ` + html.EscapeString(mech) + `</li>`
 	return `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
 		`<meta name="viewport" content="width=device-width, initial-scale=1">` +
 		refreshMeta +
@@ -86,20 +107,24 @@ func Page(target, detail string, isError bool) string {
 		`<p id="mesh-msg">` + html.EscapeString(msg) + `</p>` +
 		detailBlock +
 		`<ul class="steps" id="mesh-steps">` +
-		`<li class="done">Reaching your skywire visor</li>` +
-		`<li class="active">Finding a working exit &amp; route</li>` +
-		`<li>Loading the page over skywire</li>` +
+		`<li class="active">Building a route across the mesh</li>` +
+		`<li>Opening the encrypted tunnel</li>` +
+		fetchStep +
 		`</ul>` +
 		retry +
 		hostBlock +
 		`</div></div></body></html>`
 }
 
+// brandSVG is the Skywire cloud mark (Skycoin cloud silhouette) filled with the
+// skywire accent gradient, plus the wordmark. Inline + self-contained (no
+// external asset) so it renders under the proxies' strict, no-network context.
 const brandSVG = `<div class="brand">` +
-	`<svg viewBox="0 0 24 24" fill="none" aria-hidden="true">` +
-	`<circle cx="12" cy="4.5" r="2.3" fill="#7c83ff"/><circle cx="4.5" cy="17" r="2.3" fill="#a06bff"/>` +
-	`<circle cx="19.5" cy="17" r="2.3" fill="#a06bff"/><circle cx="12" cy="12" r="1.7" fill="#c7cbe6"/>` +
-	`<path d="M12 6.8 12 10.3M10.6 12.9 6.2 15.6M13.4 12.9 17.8 15.6" stroke="#4a5199" stroke-width="1.3" stroke-linecap="round"/>` +
+	`<svg viewBox="0 0 24 24" aria-hidden="true">` +
+	`<defs><linearGradient id="skcloud" x1="0" y1="0" x2="1" y2="1">` +
+	`<stop offset="0" stop-color="#7c83ff"/><stop offset="1" stop-color="#a06bff"/></linearGradient></defs>` +
+	`<path fill="url(#skcloud)" d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 ` +
+	`2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z"/>` +
 	`</svg><b>skywire</b></div>`
 
 const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#7a80a8;--accent:#7c83ff;--accent2:#a06bff;--err:#ff6b8a;--card:#131629;--line:#2b3163}` +
@@ -128,8 +153,8 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#7a80a8;--accent:#7c83ff;--
 // httpResponse wraps the HTML in a minimal HTTP/1.1 response. Connection:close
 // so the browser tears the socket down and honors the meta-refresh cleanly;
 // no-store so a transient page is never cached in place of the real content.
-func httpResponse(target, detail string, isError bool) []byte {
-	bodyStr := Page(target, detail, isError)
+func httpResponse(target, detail, mechanism string, isError bool) []byte {
+	bodyStr := Page(target, detail, mechanism, isError)
 	status := "200 OK"
 	if isError {
 		status = "502 Bad Gateway"
@@ -150,8 +175,8 @@ func httpResponse(target, detail string, isError bool) []byte {
 // request) are discarded. LocalAddr/RemoteAddr return *net.TCPAddr so it can
 // be handed straight to go-socks5, which unconditionally type-asserts the
 // address to *net.TCPAddr when building its BND reply.
-func Conn(target, detail string, isError bool) net.Conn {
-	return &interstitialConn{r: bytes.NewReader(httpResponse(target, detail, isError))}
+func Conn(target, detail, mechanism string, isError bool) net.Conn {
+	return &interstitialConn{r: bytes.NewReader(httpResponse(target, detail, mechanism, isError))}
 }
 
 type interstitialConn struct {
@@ -202,7 +227,7 @@ func ShouldServe(port string) bool {
 // corrupted. Best-effort and deadline-bounded so it never stalls the client's
 // reconnect. Returns nil if it served a page, an error otherwise; the caller
 // closes conn regardless.
-func ServeSOCKS5(conn net.Conn, detail string) error {
+func ServeSOCKS5(conn net.Conn, detail, mechanism string) error {
 	_ = conn.SetDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
 	defer conn.SetDeadline(time.Time{})                   //nolint:errcheck
 
@@ -278,7 +303,7 @@ func ServeSOCKS5(conn net.Conn, detail string) error {
 	// completes, then answer with the interstitial. We don't need the request
 	// contents — the page is fixed. Bounded single read; ignore EOF.
 	_, _ = conn.Read(make([]byte, 1024)) //nolint:errcheck
-	_, err := conn.Write(httpResponse(host, detail, false))
+	_, err := conn.Write(httpResponse(host, detail, mechanism, false))
 	return err
 }
 

--- a/pkg/proxyinterstitial/interstitial_test.go
+++ b/pkg/proxyinterstitial/interstitial_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPageTransient(t *testing.T) {
-	p := Page("magnetosphere.net", "", false)
+	p := Page("magnetosphere.net", "", "skysocks", false)
 	for _, want := range []string{"<!doctype html>", "http-equiv=\"refresh\"", "skywire", "magnetosphere.net", "Building a route"} {
 		if !strings.Contains(p, want) {
 			t.Errorf("transient page missing %q", want)
@@ -24,7 +24,7 @@ func TestPageTransient(t *testing.T) {
 }
 
 func TestPageError(t *testing.T) {
-	p := Page("example.dmsg", "no route to host", true)
+	p := Page("example.dmsg", "no route to host", "dmsg", true)
 	if strings.Contains(p, "http-equiv=\"refresh\"") {
 		t.Error("error page must not auto-refresh")
 	}
@@ -36,14 +36,14 @@ func TestPageError(t *testing.T) {
 }
 
 func TestPageEscapesTarget(t *testing.T) {
-	p := Page("<script>evil()</script>", "", false)
+	p := Page("<script>evil()</script>", "", "skysocks", false)
 	if strings.Contains(p, "<script>evil()") {
 		t.Error("target host was not HTML-escaped")
 	}
 }
 
 func TestConnServesHTTP(t *testing.T) {
-	c := Conn("host.skynet", "", false)
+	c := Conn("host.skynet", "", "skynet", false)
 	// Write (the browser's request) is discarded but must not error.
 	if _, err := c.Write([]byte("GET / HTTP/1.1\r\nHost: host.skynet\r\n\r\n")); err != nil {
 		t.Fatalf("write: %v", err)
@@ -84,7 +84,7 @@ func TestServeSOCKS5_HTTPPort(t *testing.T) {
 	cli, srv := net.Pipe()
 	defer cli.Close() //nolint:errcheck
 	done := make(chan error, 1)
-	go func() { done <- ServeSOCKS5(srv, ""); srv.Close() }() //nolint:errcheck,gosec
+	go func() { done <- ServeSOCKS5(srv, "", "skysocks"); srv.Close() }() //nolint:errcheck,gosec
 
 	_ = cli.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
 	// greeting: VER=5, 1 method, no-auth
@@ -128,7 +128,7 @@ func TestServeSOCKS5_HTTPSDeclined(t *testing.T) {
 	cli, srv := net.Pipe()
 	defer cli.Close() //nolint:errcheck
 	done := make(chan error, 1)
-	go func() { done <- ServeSOCKS5(srv, ""); srv.Close() }() //nolint:errcheck,gosec
+	go func() { done <- ServeSOCKS5(srv, "", "skysocks"); srv.Close() }() //nolint:errcheck,gosec
 
 	_ = cli.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
 	cli.Write([]byte{0x05, 0x01, 0x00})                  //nolint:errcheck,gosec
@@ -147,6 +147,36 @@ func TestDumpSamples(t *testing.T) {
 	if dir == "" {
 		t.Skip("set INTERSTITIAL_DUMP_DIR to dump sample HTML")
 	}
-	_ = os.WriteFile(dir+"/interstitial_transient.html", []byte(Page("magnetosphere.net", "", false)), 0644)       //nolint:errcheck,gosec
-	_ = os.WriteFile(dir+"/interstitial_error.html", []byte(Page("skycoin.dmsg", "no route to host", true)), 0644) //nolint:errcheck,gosec
+	_ = os.WriteFile(dir+"/interstitial_transient.html", []byte(Page("magnetosphere.net", "", "skysocks", false)), 0644)   //nolint:errcheck,gosec
+	_ = os.WriteFile(dir+"/interstitial_error.html", []byte(Page("skycoin.dmsg", "no route to host", "dmsg", true)), 0644) //nolint:errcheck,gosec
+}
+
+// TestPageMechanismAndSteps pins the interstitial-copy fixes: the fetch step
+// names the concrete mechanism (skysocks/dmsg/skynet, not a generic "over
+// skywire"), the misleading "Finding a working exit" / redundant "Reaching your
+// visor" steps are gone, and the branded Skywire cloud mark is present.
+func TestPageMechanismAndSteps(t *testing.T) {
+	for mech, want := range map[string]string{
+		"skysocks": "Fetching the page over skysocks",
+		"dmsg":     "Fetching the page over dmsg",
+		"skynet":   "Fetching the page over skynet",
+		"":         "Fetching the page over skywire", // unknown → generic
+	} {
+		p := Page("host.example", "", mech, false)
+		if !strings.Contains(p, want) {
+			t.Errorf("mechanism %q: page missing %q", mech, want)
+		}
+	}
+
+	p := Page("host.example", "", "skysocks", false)
+	for _, gone := range []string{"Finding a working exit", "Reaching your skywire visor"} {
+		if strings.Contains(p, gone) {
+			t.Errorf("page still contains stale step %q", gone)
+		}
+	}
+	for _, want := range []string{"Building a route across the mesh", "skcloud"} { // skcloud = the cloud-logo gradient
+		if !strings.Contains(p, want) {
+			t.Errorf("page missing %q", want)
+		}
+	}
 }

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -250,7 +250,7 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 					}
 					log.WithField("host", target).WithField("err", retErr).
 						Debug("SOCKS5 → serving branded route interstitial")
-					retConn, retErr = proxyinterstitial.Conn(target, "", false), nil
+					retConn, retErr = proxyinterstitial.Conn(target, "", "skynet", false), nil
 				}
 			}()
 

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -98,7 +98,7 @@ func (c *Client) ListenAndServe(addr string) error {
 			// ports. Runs in a goroutine that owns conn so the reconnect below
 			// isn't delayed by a slow browser.
 			go func(bc net.Conn) {
-				if serr := proxyinterstitial.ServeSOCKS5(bc, ""); serr != nil && c.appCl != nil {
+				if serr := proxyinterstitial.ServeSOCKS5(bc, "", "skysocks"); serr != nil && c.appCl != nil {
 					c.appCl.Log().Debugf("route-down interstitial not served: %v", serr)
 				}
 				bc.Close() //nolint:errcheck,gosec

--- a/pkg/visor/meshproxy.go
+++ b/pkg/visor/meshproxy.go
@@ -365,7 +365,8 @@ func (rt *meshInterstitialRT) RoundTrip(req *http.Request) (*http.Response, erro
 // upstream response (ModifyResponse's rewriteMeshLocation only touches 3xx, so a
 // 200/502 interstitial passes through untouched).
 func (rt *meshInterstitialRT) interstitialResponse(req *http.Request, detail string, isError bool) *http.Response {
-	body := proxyinterstitial.Page(meshInterstitialTarget(req), detail, isError)
+	target := meshInterstitialTarget(req)
+	body := proxyinterstitial.Page(target, detail, meshInterstitialMechanism(target), isError)
 	status := http.StatusOK
 	if isError {
 		status = http.StatusBadGateway
@@ -388,6 +389,21 @@ func (rt *meshInterstitialRT) interstitialResponse(req *http.Request, detail str
 
 // meshInterstitialTarget is the human-facing host shown on the interstitial:
 // prefer the upstream vhost, fall back to the inbound frame host.
+// meshInterstitialMechanism picks the forwarding-surface label for the
+// interstitial's fetch step from the target host: a ".skynet" host is served
+// over skynet, a ".dmsg" host over dmsg. Empty (→ generic "skywire") when the
+// target carries neither suffix.
+func meshInterstitialMechanism(target string) string {
+	switch {
+	case strings.Contains(target, "skynet"):
+		return "skynet"
+	case strings.Contains(target, "dmsg"):
+		return "dmsg"
+	default:
+		return ""
+	}
+}
+
 func meshInterstitialTarget(req *http.Request) string {
 	ctx := req.Context()
 	if vhost, _ := ctx.Value(meshVhostKey).(string); vhost != "" {
@@ -489,7 +505,8 @@ func (v *Visor) newMeshReverseProxy(resolve meshResolveFn) (*httputil.ReversePro
 			w.WriteHeader(status)
 			// proxyinterstitial.Page HTML-escapes target and detail, so the rendered
 			// document carries no unescaped request-derived content (no XSS).
-			_, _ = io.WriteString(w, proxyinterstitial.Page(meshInterstitialTarget(r), detail, isError)) //nolint:errcheck,gosec // G705: Page escapes all interpolated values
+			mt := meshInterstitialTarget(r)
+			_, _ = io.WriteString(w, proxyinterstitial.Page(mt, detail, meshInterstitialMechanism(mt), isError)) //nolint:errcheck,gosec // G705: Page escapes all interpolated values
 		},
 	}, nil
 }


### PR DESCRIPTION
Operator feedback on the native proxy interstitial — the page `skysocks-client` and the `dmsgweb`/`skynetweb` resolving proxies serve while a route to the target is still setting up:

| before | after | why |
|---|---|---|
| `Reaching your skywire visor` | *(removed)* | redundant — the page **is** served by that visor's own proxy |
| `Finding a working exit & route` | `Building a route across the mesh` | the exit is already selected; the work is route-building, not exit-hunting |
| `Loading the page over skywire` | `Fetching the page over {skysocks\|dmsg\|skynet}` | too generic — each surface now names its concrete mechanism |
| node-graph glyph | Skywire **cloud** mark (silhouette + accent gradient) | branding |

Threads a `mechanism` argument through `Page`/`httpResponse`/`Conn`/`ServeSOCKS5` and its five call sites; `meshproxy` derives the mechanism from the `.dmsg`/`.skynet` host suffix. Steps sequence is now **Building a route → Opening the encrypted tunnel → Fetching the page over \<mechanism\>**. Fully self-contained (no external asset), inline SVG. Unit-tested (mechanism labels + stale-step removal + branding present); `go build .`, `go test ./pkg/proxyinterstitial/`, `golangci-lint` clean.

Follow-up (not in this PR): stream a live connection log into the page via chunked transfer-encoding (replacing the 3s meta-refresh), which also addresses the Waterfox `CookieBanner`/actor-destroyed console churn the meta-refresh document-teardown triggers.