### PR TITLE
feat(routing): per-app override of the visor-global min_hops/mux_routes

### DIFF
--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -225,7 +225,12 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 	appCl.Log().Infof("Per-accept dial shape: %s", dialShape)
 
 	rawDial := func() (net.Conn, error) {
-		if direct || routes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 || fwdMux > 1 || revMux > 1 {
+		// Any EXPLICIT per-call value (>=1), including 1, is a per-app override
+		// of the visor-global min_hops/mux_routes — so `--routes 1` / `--min-hops 1`
+		// force a single / direct route out from under a global mux_routes/min_hops>1
+		// (which otherwise forces this 1:1 forward into multi-hop mux and breaks it).
+		// Unset (0) still inherits the global default via the plain Dial path.
+		if direct || routes >= 1 || minHops >= 1 || fwdMinHops >= 1 || revMinHops >= 1 || fwdMux >= 1 || revMux >= 1 {
 			return appCl.DialWithOptions(connApp, routes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
 		}
 		return appCl.Dial(connApp)

--- a/cmd/skywire-cli/commands/skynet/root.go
+++ b/cmd/skywire-cli/commands/skynet/root.go
@@ -134,27 +134,32 @@ var startCmd = &cobra.Command{
 			arguments["appPort"] = clientAppPort
 		}
 
-		if startRoutes > 1 {
+		// Forward a routing flag whenever the operator EXPLICITLY set it — even to
+		// 1 — so a per-app override (e.g. --routes 1 / --min-hops 1 to force a
+		// single/direct route out from under a visor-global mux_routes/min_hops>1)
+		// actually reaches the app. Unset flags are omitted → the app inherits the
+		// visor-global default.
+		if cmd.Flags().Changed("routes") {
 			arguments["--routes"] = fmt.Sprintf("%d", startRoutes)
 		}
 
-		if startMinHops > 1 {
+		if cmd.Flags().Changed("min-hops") {
 			arguments["--min-hops"] = fmt.Sprintf("%d", startMinHops)
 		}
 
-		if startFwdMinHops > 1 {
+		if cmd.Flags().Changed("forward-min-hops") {
 			arguments["--forward-min-hops"] = fmt.Sprintf("%d", startFwdMinHops)
 		}
 
-		if startRevMinHops > 1 {
+		if cmd.Flags().Changed("reverse-min-hops") {
 			arguments["--reverse-min-hops"] = fmt.Sprintf("%d", startRevMinHops)
 		}
 
-		if startFwdMux > 0 {
+		if cmd.Flags().Changed("forward-mux") {
 			arguments["--forward-mux"] = fmt.Sprintf("%d", startFwdMux)
 		}
 
-		if startRevMux > 0 {
+		if cmd.Flags().Changed("reverse-mux") {
 			arguments["--reverse-mux"] = fmt.Sprintf("%d", startRevMux)
 		}
 

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -280,9 +280,16 @@ func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, req *DialOptionsReq
 // mock or future alternative networker silently degrades to single-
 // route, preserving correctness with no extra plumbing).
 func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, req *DialOptionsReq) (net.Conn, error) {
-	if req == nil || (!req.Direct && req.MuxRoutes <= 1 && req.MinHops <= 1 &&
-		req.ForwardMinHops <= 1 && req.ReverseMinHops <= 1 &&
-		req.ForwardMuxRoutes <= 1 && req.ReverseMuxRoutes <= 1) {
+	// Take the default (global-inheriting) path only when the app requested
+	// NOTHING explicit — every per-call field left at its zero value. Any
+	// explicit value, INCLUDING 1, is a per-app override that must reach the
+	// networker: e.g. MuxRoutes=1 / MinHops=1 lets an app force a single /
+	// direct route out from under a visor-global min_hops/mux_routes>1 (which
+	// otherwise forces every skynet app dial into multi-hop mux — wrong for a
+	// 1:1 forward). Zero still means "inherit the visor-global default".
+	if req == nil || (!req.Direct && req.MuxRoutes == 0 && req.MinHops == 0 &&
+		req.ForwardMinHops == 0 && req.ReverseMinHops == 0 &&
+		req.ForwardMuxRoutes == 0 && req.ReverseMuxRoutes == 0) {
 		return appnet.DialContext(ctx, remote)
 	}
 	nw, err := appnet.ResolveNetworker(remote.Net)


### PR DESCRIPTION
A visor configured with `min_hops>1` / `mux_routes>1` forced **every** skynet app dial into multi-hop mux, with no way for an individual app to opt out. Two problems:

1. It breaks a **1:1 forward** — `skynet-client` dials the built-in forwarding service on `SkyForwardingServerPort` (a single-route port); a forced 4-way mux route group to it fails (0 bytes). Root-caused live: `mux-bw` to the same peer with the identical `routes=4 min-hops=2` works (15.6 Mbps), and the in-process resolver works — only the app-path forward, which blindly inherits the global mux, fails.
2. It's just **annoying**: an app couldn't ask for a single/direct route when the global default is aggressive.

The networker already honors an explicit opts value (it applies the global only when `opts.MuxRoutes==0`), but an explicit **1** never reached it:
- CLI `skynet start` only forwarded `--routes`/`--min-hops` when `> 1` → `--routes 1` was silently dropped.
- `skynet-client` only took the `DialWithOptions` path when a field was `> 1`.
- app-server ingress `dialWithMuxRoutes` treated `<= 1` as unset → global-inheriting default dial.

**Fix:** any *explicit* per-call value (including `1`) is a per-app override that reaches the router; only a zero value inherits the visor-global. So `skynet start --routes 1 --min-hops 1` forces a single/direct route out from under a global `mux_routes=4/min_hops=2`.

Verified live: `--routes 1` now lands in the app's args (previously swallowed as ≤1). `go build .` + `golangci-lint` clean. (Full byte-level forward proof pending a stable far-end sink.)