### PR TITLE
feat(dmsgweb,skynetweb): serve the branded interstitial over HTTPS (TLS-MITM) for mesh hosts

### DIFF
--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -58,6 +58,12 @@ func proxyHost(addr string) string {
 	return addr
 }
 
+// isTLSPort reports whether the string port equals the configured TLS-MITM port.
+func isTLSPort(port string, tlsPort uint16) bool {
+	p, err := strconv.ParseUint(strings.TrimSpace(port), 10, 16)
+	return err == nil && uint16(p) == tlsPort
+}
+
 // Config configures a dmsgweb runtime. Two operating modes:
 //
 //  1. ResolveAddr empty → SOCKS5 resolver mode. Any hostname ending
@@ -316,15 +322,34 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 			// ride those). This defer runs before the panic-recover defer on a
 			// normal error return, and no-ops on success (conn != nil).
 			defer func() {
-				if dialErr != nil && conn == nil &&
-					proxyinterstitial.ShouldServe(origPort) && proxyinterstitial.IsTransient(dialErr) {
-					target := origHost
-					if target == "" {
-						target = addr
-					}
+				if dialErr == nil || conn != nil || !proxyinterstitial.IsTransient(dialErr) {
+					return
+				}
+				target := origHost
+				if target == "" {
+					target = addr
+				}
+				switch {
+				case proxyinterstitial.ShouldServe(origPort):
 					log.WithField("host", target).WithField("err", dialErr).
 						Debug("SOCKS5 → serving branded route interstitial")
-					conn, dialErr = proxyinterstitial.Conn(target, "", "dmsg", false), nil
+					conn, dialErr = proxyinterstitial.Conn(target, proxyinterstitial.StatusLine(dialErr), "dmsg", false), nil
+				case cfg.TLSMITM && isTLSPort(origPort, cfg.TLSPort):
+					// HTTPS request whose route is still warming: terminate the
+					// browser's TLS locally with a per-host leaf and serve the
+					// interstitial HTML over it — same MITM path as a warm TLS
+					// dial, but the "upstream" is the fixed interstitial responder.
+					// If minting fails, fall through to the real error.
+					leaf, lerr := cfg.LeafMinter.For(origHost)
+					if lerr != nil {
+						log.WithField("host", target).WithField("err", lerr).
+							Debug("SOCKS5 → TLS interstitial leaf mint failed; surfacing dial error")
+						return
+					}
+					log.WithField("host", target).WithField("err", dialErr).
+						Debug("SOCKS5 → serving branded route interstitial over TLS (MITM)")
+					conn, dialErr = &tcpAddrConn{Conn: skynetca.MITMTerminate(
+						proxyinterstitial.Conn(target, proxyinterstitial.StatusLine(dialErr), "dmsg", false), leaf)}, nil
 				}
 			}()
 

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -239,18 +239,35 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 			// Runs before the panic-recover defer on a normal return; no-ops on
 			// success or panic.
 			defer func() {
-				if retErr == nil || retConn != nil {
+				if retErr == nil || retConn != nil || !proxyinterstitial.IsTransient(retErr) {
 					return
 				}
 				_, port, _ := net.SplitHostPort(addr) //nolint:errcheck
-				if proxyinterstitial.ShouldServe(port) && proxyinterstitial.IsTransient(retErr) {
-					target := origHost
-					if target == "" {
-						target = addr
-					}
+				target := origHost
+				if target == "" {
+					target = addr
+				}
+				switch {
+				case proxyinterstitial.ShouldServe(port):
 					log.WithField("host", target).WithField("err", retErr).
 						Debug("SOCKS5 → serving branded route interstitial")
-					retConn, retErr = proxyinterstitial.Conn(target, "", "skynet", false), nil
+					retConn, retErr = proxyinterstitial.Conn(target, proxyinterstitial.StatusLine(retErr), "skynet", false), nil
+				case cfg.TLSMITM && isTLSPort(port, cfg.TLSPort):
+					// HTTPS request whose route is still warming: terminate the
+					// browser's TLS locally with a per-host leaf and serve the
+					// interstitial HTML over it (same MITM path as a warm TLS dial,
+					// with the fixed interstitial responder as the "upstream").
+					// If minting fails, fall through to the real error.
+					leaf, lerr := cfg.LeafMinter.For(origHost)
+					if lerr != nil {
+						log.WithField("host", target).WithField("err", lerr).
+							Debug("SOCKS5 → TLS interstitial leaf mint failed; surfacing dial error")
+						return
+					}
+					log.WithField("host", target).WithField("err", retErr).
+						Debug("SOCKS5 → serving branded route interstitial over TLS (MITM)")
+					retConn, retErr = &tcpAddrConn{Conn: skynetca.MITMTerminate(
+						proxyinterstitial.Conn(target, proxyinterstitial.StatusLine(retErr), "skynet", false), leaf)}, nil
 				}
 			}()
 
@@ -466,6 +483,11 @@ func (c *tcpAddrConn) RemoteAddr() net.Addr {
 
 func (c *tcpAddrConn) LocalAddr() net.Addr {
 	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+}
+
+// isTLSPort reports whether the string port equals the configured TLS-MITM port.
+func isTLSPort(port string, tlsPort uint16) bool {
+	return port != "" && port == fmt.Sprintf("%d", tlsPort)
 }
 
 func isSkynetHost(host, suffix string) bool {


### PR DESCRIPTION
The resolving proxies only served the mesh-route interstitial on plain HTTP (80/8080); an **HTTPS (:443)** request racing route setup fell through to a bare error page.

The resolver already runs a TLS-MITM stack for mesh-addressed hosts (`skynetca` CA + `LeafMinter`, `TLSMITM` **defaults on**). This serves the interstitial over it: when a dial fails transiently on the TLS port **and** `TLSMITM` is enabled, mint a per-host leaf and terminate TLS with `skynetca.MITMTerminate(proxyinterstitial.Conn(...), leaf)`, so the browser shows the branded "building a route over the mesh…" page instead of a cert/connection error while the route warms. Falls through to the real error if leaf minting fails.

**Scope = the existing warm-dial MITM path**: the CA's `nameConstraints` default to `.skynet`/`.dmsg`, so this signs **only mesh-addressed hosts, never arbitrary clearnet HTTPS**. Gated on the existing `cfg.TLSMITM` (default true; set false to disable — that is the off switch). `skysocks-client` (transparent tunnel, no leaf minter) still declines HTTPS.

Also wires `proxyinterstitial.StatusLine(err)` into both proxies' detail slot (matches the skysocks path). Build + `go test` green for dmsgweb/skynetweb/visor.