### PR TITLE
fix(router): GrowMuxRoute plans aux legs route-finder-first (cost-ranked), like the other two mux planners

### DIFF
--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -340,18 +340,21 @@ func (r *router) GrowMuxRoute(desc routing.RouteDescriptor, target, minHops int)
 			ExcludeDMSG:            true,
 		}
 
-		// Local calc FIRST, route-finder as fallback — mirroring establishMuxRoutes
-		// and addOneAuxForwardLeg. calculateLocalRoutes honors ExcludeTransportIDs
-		// (and ExcludeIntermediatePKs), so it returns a leg disjoint from the ones
-		// already in the group. The route-finder SERVICE ignores ExcludeTransportIDs,
-		// so querying it first for a direct pair hands back the very transport we are
-		// excluding; the append then rejects it ("refusing to append mux leg over
-		// transport already in the group") and the self-heal loops without ever
-		// growing. The route-finder is still the fallback for a disjoint deep-hop the
-		// local transport cache doesn't cover.
-		fwd, rev, err := r.calculateLocalRoutes(ctx, log, lPK, rPK, muxOpts)
+		// Route-finder FIRST, local calc as fallback — matching the initial mux
+		// planning in establishMuxRoutes/addOneAuxForwardLeg (router_dial.go:2118,
+		// 2297) since #3986/#3990. The route-finder plans over the WHOLE TPD graph
+		// and its transport-type-aware ranking (transportTypeCostMs) makes the
+		// disjoint pick prefer stcpr/quic over webrtc — the difference that lets a
+		// grown leg land on a reliable intermediate (like mux-bw's planner) instead
+		// of a flaky webrtc one that collapses under load. Disjointness is enforced
+		// by ExcludeIntermediatePKs (which the finder honors via the disjoint
+		// post-filter); the stale ExcludeTransportIDs concern only bit the DIRECT
+		// (1-hop) case, and aux mux legs are multi-hop (min_hops>=1 here, and >=2
+		// for the multi-hop presets). Local calc is the fallback for a disjoint
+		// deep hop the finder can't reach.
+		fwd, rev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
 		if err != nil {
-			fwd, rev, err = r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
+			fwd, rev, err = r.calculateLocalRoutes(ctx, log, lPK, rPK, muxOpts)
 		}
 		if err != nil {
 			consecutiveFailures++


### PR DESCRIPTION
GrowMuxRoute — the runtime **self-heal / on_tick grow** path that tops up mux legs after a leg dies — planned replacement legs **local-calc-first**, unlike the initial mux planners (`establishMuxRoutes`/`addOneAuxForwardLeg`, router_dial.go:2118/2297) which were flipped to **route-finder-first** in #3986/#3990. `calculateLocalRoutes` picks whatever local/on-demand transport is handy — often **webrtc** — so a grown leg lands on a flaky webrtc intermediate that collapses under load, while `mux-bw`'s cost-ranked route-finder planner reliably lands **stcpr/quic** legs and sustains multi-Mbps (measured: mux-bw held 3 disjoint stcpr/squicr legs at **2.46 Mbps for 2 min**; the app-dial grow path got webrtc and stalled).

Flip GrowMuxRoute to the same order: route-finder first (whole-TPD, transport-type-cost-ranked → prefers stcpr/quic over webrtc; disjointness enforced by `ExcludeIntermediatePKs`), local calc as fallback. The stale `ExcludeTransportIDs` concern in the old comment only bit the direct (1-hop) case; aux mux legs are multi-hop. **Now all three mux-leg planners agree.** Router build + mux tests green.