### PR TITLE
fix(skynet-client): silence unparam on the DialRoute ctx param (follow-up to #4002)

### DIFF
--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -255,7 +255,9 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 	pool := skyroute.New(skyroute.DefaultIdleTTL, appCl.Log())
 	defer func() { _ = pool.Close() }() //nolint:errcheck
 
-	dialToMux := func(dctx context.Context, muxPort uint16) (net.Conn, error) {
+	// The DialRoute signature carries a ctx for route-setup cancellation,
+	// but appCl's dial helpers take no ctx, so it's intentionally ignored.
+	dialToMux := func(_ context.Context, muxPort uint16) (net.Conn, error) {
 		return dialWithShape(muxPort)
 	}
 


### PR DESCRIPTION
Follow-up to #4002. The `DialRoute` closure must match skyroute's `func(ctx, muxPort)` signature, but appCl's dial helpers take no ctx, so the first param is unused. Rename it to `_` — newer golangci-lint (unparam) flags the named-but-unused param. Build + `golangci-lint` clean.