### PR TITLE
fix(router): never skip a reorder-buffer gap — the mux carries a noise stream

### DIFF
--- a/pkg/router/reorder.go
+++ b/pkg/router/reorder.go
@@ -65,27 +65,37 @@ func (rb *reorderBuffer) Insert(seq uint32, data []byte) [][]byte {
 		copy(cp, data)
 		rb.buf[seq] = cp
 
-		// Mark when this frontier gap opened, so it can be released if it
-		// stays open too long (a dead leg the SACK retransmit has not yet
-		// refilled).
+		// Mark when this frontier gap opened, so a stalled leg can be timed for
+		// diagnostics / future fast-prune (see below).
 		if rb.gapSince.IsZero() {
 			rb.gapSince = time.Now()
 		}
 
-		// Time-based release: a gap held longer than reorderTimeout is treated
-		// as a dead leg rather than skew — flush past it so the stream keeps
-		// moving (lossy) instead of stalling until liveness prunes the leg.
-		if !rb.gapSince.IsZero() && time.Since(rb.gapSince) >= reorderTimeout {
-			return rb.flushAll()
-		}
+		// NO time-based skip. The mux carries the route group's NOISE-encrypted
+		// byte stream (router_serve.go wraps the RouteGroup with network.EncryptConn
+		// before the app sees it), and noise is a stateful AEAD: delivering PAST a
+		// missing sequence permanently desyncs the cipher — every later frame then
+		// fails its MAC and yields zero plaintext, turning a transient stall into a
+		// PERMANENT 0-byte wedge. The old time-based flushAll() "released" the gap
+		// to keep the stream "moving (lossy)", but on a noise stream lossy == dead:
+		// it manufactured the exact hard stall it meant to avoid, which is why an
+		// N-leg mux with one black-holing (e.g. webrtc-under-load) leg carried ~0
+		// goodput. Instead HOLD the gap: the receiver's SACK keeps reporting the
+		// missing seq and the sender retransmits it CONTIGUOUSLY from its retx
+		// buffer over a live leg, so the buffer drains in order with the cipher
+		// intact. A leg that stays dead is removed by leg-liveness pruning, after
+		// which its unacked seqs are retransmitted on the survivors. reorderTimeout
+		// is retained as the stall threshold for that diagnostics/prune path.
+		_ = reorderTimeout
 
-		// Emergency backstop only: with reliable leg transports the missing
-		// seq arrives within the skew window and drains the buffer, so this
-		// never trips in normal operation. Reaching it means a leg has gone
-		// dead mid-stream; force-flush (lossy, skips the gap) to avoid a
-		// permanent stall until liveness prunes the leg. It is NOT the normal
-		// reorder path — do not lower maxGap to "save memory": that reintroduces
-		// the mux>1 corruption bug.
+		// Emergency OOM backstop only: with reliable legs the missing seq arrives
+		// (via skew or SACK retransmit) and drains the buffer, so this never trips
+		// in normal operation. Reaching it means a leg has gone dead mid-stream AND
+		// retransmit has not refilled within maxGap packets. Force-flushing here
+		// still skips the gap (and so corrupts a noise stream) — it is a
+		// last-resort guard against unbounded memory, not a recovery path; the
+		// route group's liveness prune + teardown is the real handler. Do NOT lower
+		// maxGap to "save memory": that reintroduces the mux>1 corruption bug.
 		if len(rb.buf) >= rb.maxGap {
 			return rb.flushAll()
 		}

--- a/pkg/router/reorder_test.go
+++ b/pkg/router/reorder_test.go
@@ -107,10 +107,14 @@ func TestReorderLosslessBeyondOldMaxGap(t *testing.T) {
 	}
 }
 
-// TestReorderTimeBasedRelease proves a gap that stays open longer than
-// reorderTimeout is released (delivered past the missing sequence) so a dead leg
-// degrades to lossy-but-moving instead of stalling the stream at 0 bytes.
-func TestReorderTimeBasedRelease(t *testing.T) {
+// TestReorderNeverSkipsAcrossTimeout proves a frontier gap is NEVER delivered
+// past, no matter how long it stays open. The mux carries a noise-encrypted
+// (stateful AEAD) byte stream, and skipping a sequence permanently desyncs the
+// cipher — a hard 0-byte wedge, not "lossy but moving". So a stalled leg's gap
+// is HELD until the missing seq arrives (the sender's SACK retransmit refills it
+// contiguously from a live leg), which is what keeps mux>1 usable under a
+// black-holing leg. This is the inverse of the old time-based skip.
+func TestReorderNeverSkipsAcrossTimeout(t *testing.T) {
 	old := reorderTimeout
 	reorderTimeout = 100 * time.Millisecond
 	defer func() { reorderTimeout = old }()
@@ -124,22 +128,31 @@ func TestReorderTimeBasedRelease(t *testing.T) {
 	rb.Insert(2, []byte{2})
 	rb.Insert(3, []byte{3})
 
-	// Before the timeout: another out-of-order packet must NOT release the gap.
+	// Well past the timeout: further out-of-order packets must STILL NOT release
+	// the gap — holding, not skipping, is the only noise-safe behavior.
+	time.Sleep(150 * time.Millisecond)
 	if got := rb.Insert(4, []byte{4}); got != nil {
-		t.Fatalf("gap released before timeout (len=%d): normal skew would be corrupted", len(got))
+		t.Fatalf("gap released across timeout (len=%d): skipping seq corrupts the noise stream", len(got))
+	}
+	if rb.NextSeq() != 1 {
+		t.Fatalf("nextSeq=%d advanced past the held gap, want 1", rb.NextSeq())
 	}
 
-	// After the timeout: the next out-of-order packet releases the gap, skipping
-	// the missing seq 1 so the stream keeps moving.
-	time.Sleep(150 * time.Millisecond)
-	got := rb.Insert(5, []byte{5})
-	if len(got) == 0 {
-		t.Fatalf("gap not released after timeout: dead leg would hard-stall the stream at 0 bytes")
+	// The missing seq 1 finally arrives (SACK retransmit over a live leg): now the
+	// buffer drains in order, contiguously, cipher intact.
+	got := rb.Insert(1, []byte{1})
+	if len(got) != 4 {
+		t.Fatalf("after refill: delivered %d, want 4 (seq 1,2,3,4 in order)", len(got))
 	}
-	if rb.NextSeq() <= 1 {
-		t.Fatalf("nextSeq=%d did not advance past the skipped gap", rb.NextSeq())
+	for i, d := range got {
+		if want := byte(i + 1); d[0] != want {
+			t.Fatalf("delivered[%d]=%d, want %d: not in order", i, d[0], want)
+		}
+	}
+	if rb.NextSeq() != 5 {
+		t.Fatalf("nextSeq=%d after drain, want 5", rb.NextSeq())
 	}
 	if rb.Pending() != 0 {
-		t.Fatalf("pending=%d after release, want 0", rb.Pending())
+		t.Fatalf("pending=%d after full drain, want 0", rb.Pending())
 	}
 }


### PR DESCRIPTION
## Symptom

A multi-leg mux route group **establishes** cleanly (`Route group distribution applied … legs=5`) but carries **~0 application goodput** whenever one leg (e.g. a webrtc leg under load) black-holes its share of the sequence space — an HTTP GET through it returns 0 bytes / `HTTP 000`. Single-route and disjoint-reliable (`AddMuxRouteByHops` / `mux-bw`) paths carry fine.

## Root cause

The reorder buffer's **time-based release** flushed PAST a missing sequence after `reorderTimeout` (1.5s), on the theory that a long-held gap is a dead leg and "lossy but moving" beats stalling.

But the mux carries the route group's **noise-encrypted** byte stream — `router_serve.go` wraps the `RouteGroup` with `network.EncryptConn` before the app sees it — and noise is a **stateful AEAD**: delivering past a skipped sequence permanently desyncs the cipher (every later frame fails its MAC → zero plaintext). So "lossy but moving" is a fiction on a noise stream: the skip manufactures the exact permanent 0-byte wedge it was meant to avoid. A black-holing leg trips the 1.5s skip ~60× before the ~90s leg-liveness prune can remove it, so the stream desyncs almost immediately and never recovers.

#3955 closed the `maxGap` skip door (window 2048) but left this time-based door doing the identical destructive flush.

## Fix

**Never deliver past a frontier gap.** Hold it — the receiver's SACK keeps reporting the missing seq and the sender retransmits it **contiguously** from its retx buffer over a live leg, so the buffer drains in order with the cipher intact. A leg that stays dead is removed by leg-liveness pruning, after which its unacked seqs are retransmitted on the survivors. The `maxGap` force-flush remains only as a last-resort OOM guard (documented as still corrupting; the route group's liveness prune + teardown is the real handler).

## Verification

Live: a 5-leg (`--routes 5 --min-hops 2`) mux forward to a registered far-end sink went from **0 bytes / HTTP 000** → **HTTP 200, 1.1 MB / 25s sustained** — degraded by the fragile leg's retransmitted share, but moving and correct instead of a permanent wedge. `TestReorderNeverSkipsAcrossTimeout` replaces the old `TestReorderTimeBasedRelease` (which asserted the skip); router reorder tests pass.

> Follow-up (separate PR): fast-prune a gap-stalling leg instead of waiting ~90s for liveness, to recover the retransmitted share and lift throughput back toward the disjoint-reliable baseline.