### PR TITLE
feat(router): fast-prune a mux leg that black-holes bulk data (recover throughput)

### DIFF
--- a/pkg/router/leg_dataprogress_test.go
+++ b/pkg/router/leg_dataprogress_test.go
@@ -1,0 +1,115 @@
+// Package router leg_dataprogress_test.go
+package router
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestSelectDataStalledLegs exercises the fast data-progress prune decision: a
+// leg delivering a trickle (< 1/16 of the fastest active leg) while the receiver
+// is stuck on a reorder gap is black-holing its share and gets pruned, without
+// ever dropping the last active leg, and standby legs are never touched.
+func TestSelectDataStalledLegs(t *testing.T) {
+	fast := uuid.New()
+	slowA := uuid.New()
+	slowB := uuid.New()
+	spare := uuid.New()
+
+	// contains reports whether got holds exactly the wantIDs (order-independent).
+	contains := func(got []uuid.UUID, want ...uuid.UUID) bool {
+		if len(got) != len(want) {
+			return false
+		}
+		seen := map[uuid.UUID]bool{}
+		for _, g := range got {
+			seen[g] = true
+		}
+		for _, w := range want {
+			if !seen[w] {
+				return false
+			}
+		}
+		return true
+	}
+
+	t.Run("prunes trickle legs while gap stuck", func(t *testing.T) {
+		legs := []legRecvDelta{
+			{id: fast, delta: 16000},
+			{id: slowA, delta: 100}, // < 16000/16 = 1000
+			{id: slowB, delta: 0},
+		}
+		got := selectDataStalledLegs(legs, true)
+		if !contains(got, slowA, slowB) {
+			t.Fatalf("got %v, want the two trickle legs", got)
+		}
+	})
+
+	t.Run("no prune when gap not stuck", func(t *testing.T) {
+		legs := []legRecvDelta{
+			{id: fast, delta: 16000},
+			{id: slowA, delta: 0},
+		}
+		if got := selectDataStalledLegs(legs, false); got != nil {
+			t.Fatalf("got %v, want nil (gap not stuck)", got)
+		}
+	})
+
+	t.Run("no prune when all legs comparable", func(t *testing.T) {
+		legs := []legRecvDelta{
+			{id: fast, delta: 1000},
+			{id: slowA, delta: 900},
+			{id: slowB, delta: 950},
+		}
+		if got := selectDataStalledLegs(legs, true); got != nil {
+			t.Fatalf("got %v, want nil (converged set, no outlier)", got)
+		}
+	})
+
+	t.Run("never prunes the last active leg", func(t *testing.T) {
+		// Only two active legs, both trickle relative to... there is no faster
+		// one, so top is the max of the two; keep at least one regardless.
+		legs := []legRecvDelta{
+			{id: fast, delta: 8000},
+			{id: slowA, delta: 0},
+			{id: slowB, delta: 0},
+		}
+		got := selectDataStalledLegs(legs, true)
+		// slowA and slowB both qualify (0 <= 8000/16); active=3 so pruning 2 keeps 1.
+		if len(got) != 2 {
+			t.Fatalf("got %v, want 2 pruned (one active leg kept)", got)
+		}
+	})
+
+	t.Run("standby legs are never pruned", func(t *testing.T) {
+		legs := []legRecvDelta{
+			{id: fast, delta: 16000},
+			{id: slowA, delta: 100},
+			{id: spare, delta: 0, standby: true}, // parked; zero recv is expected
+		}
+		got := selectDataStalledLegs(legs, true)
+		if !contains(got, slowA) {
+			t.Fatalf("got %v, want only the active trickle leg (never the standby)", got)
+		}
+	})
+
+	t.Run("no prune when group is idle", func(t *testing.T) {
+		legs := []legRecvDelta{
+			{id: fast, delta: 0},
+			{id: slowA, delta: 0},
+		}
+		if got := selectDataStalledLegs(legs, true); got != nil {
+			t.Fatalf("got %v, want nil (group not moving data)", got)
+		}
+	})
+
+	t.Run("single active leg is left alone", func(t *testing.T) {
+		legs := []legRecvDelta{
+			{id: fast, delta: 5000},
+		}
+		if got := selectDataStalledLegs(legs, true); got != nil {
+			t.Fatalf("got %v, want nil (never risk the only leg)", got)
+		}
+	})
+}

--- a/pkg/router/reorder.go
+++ b/pkg/router/reorder.go
@@ -129,6 +129,19 @@ func (rb *reorderBuffer) Insert(seq uint32, data []byte) [][]byte {
 	return delivered
 }
 
+// GapAge reports how long the current frontier gap has been open, or 0 if the
+// buffer is contiguous (no gap). The route group's fast data-progress prune uses
+// it to tell a genuinely stuck receiver (a gap held while SACK retransmits) from
+// ordinary latency-skew interleave.
+func (rb *reorderBuffer) GapAge() time.Duration {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	if rb.gapSince.IsZero() {
+		return 0
+	}
+	return time.Since(rb.gapSince)
+}
+
 // flushAll delivers all buffered packets in sequence order and resets.
 // Called when the gap exceeds maxGap to prevent unbounded memory growth.
 // The caller must hold rb.mu.

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -44,6 +44,18 @@ const (
 	// its (possibly shared) transport is NOT closed, so a false positive simply
 	// triggers a self-heal re-dial — never an outage, and never the last leg.
 	legPongMissThreshold = 3
+	// legDataProgressInterval is how often the fast data-progress prune samples
+	// each leg's rg-scoped RecvBytes. Much tighter than legLivenessInterval so a
+	// leg that black-holes bulk DATA (while still echoing the tiny liveness ping)
+	// is caught in seconds, not the ~90s the pong-miss path takes — the
+	// difference between a mux that limps at the fragile leg's retransmit tax and
+	// one that sheds the leg and runs at the reliable legs' rate.
+	legDataProgressInterval = 5 * time.Second
+	// legDataStallGapAge is how long a reorder frontier gap must stay open before
+	// the data-progress prune will act. Long enough that ordinary latency-skew
+	// interleave (which closes in well under a second) never trips it; short
+	// enough to react quickly once a leg genuinely stops delivering its share.
+	legDataStallGapAge = 3 * time.Second
 )
 
 var (
@@ -221,6 +233,13 @@ type RouteGroup struct {
 	// evicting the "slowest leg" and the fastest-leg retransmit picker judge the
 	// whole path, not just the near edge. Guarded by legLivenessMu.
 	legE2ELatency map[uuid.UUID]float64
+	// legRecvSnap is each leg's last-sampled rg-scoped RecvBytes, keyed by
+	// transport ID (survives index shifts), for the fast data-progress prune:
+	// an ACTIVE leg whose recv is flat across an interval while the group keeps
+	// receiving AND a reorder gap stays open is black-holing DATA (a leg that
+	// still echoes the tiny liveness ping, so pong-miss liveness never catches
+	// it). Guarded by legLivenessMu.
+	legRecvSnap map[uuid.UUID]uint64
 }
 
 // NewRouteGroup creates a new RouteGroup.
@@ -253,6 +272,7 @@ func NewRouteGroup(cfg *RouteGroupConfig, rt routing.Table, desc routing.RouteDe
 		legMissed:          make(map[uuid.UUID]int),
 		inflightPings:      make(map[int64]uuid.UUID),
 		legE2ELatency:      make(map[uuid.UUID]float64),
+		legRecvSnap:        make(map[uuid.UUID]uint64),
 	}
 
 	return rg
@@ -1093,6 +1113,12 @@ func (rg *RouteGroup) startOffServiceLoops() {
 	// BEYOND the first hop (invisible to pruneDeadTransports' local tp.IsClosed
 	// check) and drop them so self-heal re-dials a live replacement.
 	go rg.servicePacketLoop("leg-liveness", legLivenessInterval, rg.legLivenessServiceFn)
+	// Fast data-progress prune: catch a leg that black-holes bulk DATA (while
+	// still echoing the tiny liveness ping, so the pong-miss path above never
+	// sees it) in seconds, by watching per-leg recv progress against an open
+	// reorder gap. Restores mux throughput to the reliable legs' rate instead of
+	// limping at the fragile leg's retransmit tax.
+	go rg.servicePacketLoop("leg-dataprogress", legDataProgressInterval, rg.legDataProgressServiceFn)
 	// Note: Automatic ping loop removed. Latency is now measured once at transport creation.
 	// Rotation loop is NOT started here — startOffServiceLoops runs
 	// during initial route-group setup, before the router-side
@@ -1346,6 +1372,130 @@ func (rg *RouteGroup) legLivenessServiceFn(_ time.Duration) {
 			rg.logger.WithError(err).Debugf("leg-liveness: probe write failed on leg %s", p.id)
 		}
 	}
+}
+
+// legDataProgressServiceFn is the FAST data-plane prune. The pong-miss liveness
+// above only catches a leg that stops echoing the tiny control ping — but a leg
+// (classically webrtc under load) can keep echoing pings while black-holing bulk
+// DATA, so it survives ~90s while taxing the whole mux: every seq it drops is
+// SACK-retransmitted on a live leg, capping aggregate throughput at the fragile
+// leg's rate. This loop samples each leg's rg-scoped RecvBytes every few seconds
+// and, WHEN a reorder frontier gap has stayed open past legDataStallGapAge (i.e.
+// the receiver is genuinely stuck waiting on a missing seq, not just skewed),
+// prunes any ACTIVE leg that delivered ZERO bytes over the interval while the
+// group as a whole kept receiving. Pruning is safe by construction: it never
+// drops the last active leg, keeps a shared transport open, and a false positive
+// merely triggers a self-heal re-dial (see pruneLivenessDeadLegs). Standby legs
+// are excluded (they aren't sent to, so zero recv is expected).
+func (rg *RouteGroup) legDataProgressServiceFn(_ time.Duration) {
+	if rg.isClosed() || rg.mux == nil {
+		return
+	}
+
+	rg.mu.Lock()
+	tpsCopy := append([]*transport.ManagedTransport(nil), rg.tps...)
+	rg.mu.Unlock()
+
+	stats := rg.mux.snapshotLegs()
+
+	type legRecv struct {
+		id      uuid.UUID
+		recv    uint64
+		standby bool
+	}
+	legs := make([]legRecv, 0, len(tpsCopy))
+	for i, tp := range tpsCopy {
+		if tp == nil || i >= len(stats) {
+			continue
+		}
+		legs = append(legs, legRecv{id: tp.Entry.ID, recv: stats[i].RecvBytes, standby: rg.mux.isLegStandby(i)})
+	}
+
+	// Only judge when the receiver is genuinely stuck on a missing sequence.
+	gapStuck := rg.mux.gapAge() >= legDataStallGapAge
+
+	// Compute per-leg recv deltas vs the last sample and refresh the snapshot.
+	rg.legLivenessMu.Lock()
+	perDelta := make(map[uuid.UUID]uint64, len(legs))
+	var aggDelta uint64
+	liveIDs := make(map[uuid.UUID]struct{}, len(legs))
+	for _, l := range legs {
+		liveIDs[l.id] = struct{}{}
+		if prev, ok := rg.legRecvSnap[l.id]; ok && l.recv >= prev {
+			d := l.recv - prev
+			perDelta[l.id] = d
+			aggDelta += d
+		}
+		rg.legRecvSnap[l.id] = l.recv
+	}
+	for id := range rg.legRecvSnap {
+		if _, ok := liveIDs[id]; !ok {
+			delete(rg.legRecvSnap, id)
+		}
+	}
+	rg.legLivenessMu.Unlock()
+
+	deltas := make([]legRecvDelta, 0, len(legs))
+	for _, l := range legs {
+		deltas = append(deltas, legRecvDelta{id: l.id, delta: perDelta[l.id], standby: l.standby})
+	}
+	dead := selectDataStalledLegs(deltas, gapStuck)
+	if len(dead) > 0 {
+		rg.logger.Infof("leg-dataprogress: fast-pruning %d data-black-holing leg(s) (delivered <1/16 of the fastest leg over %v while group moved %dB, reorder gap stuck %v)",
+			len(dead), legDataProgressInterval, aggDelta, rg.mux.gapAge())
+		rg.pruneLivenessDeadLegs(dead)
+	}
+}
+
+// legRecvDelta is one active-or-standby leg's rg-scoped recv progress over a
+// data-progress interval.
+type legRecvDelta struct {
+	id      uuid.UUID
+	delta   uint64
+	standby bool
+}
+
+// selectDataStalledLegs picks the ACTIVE legs to fast-prune: while the receiver
+// is stuck on a reorder gap (gapStuck) and the group as a whole is moving data,
+// any active leg delivering less than 1/16 of the FASTEST active leg's bytes is
+// black-holing its share (dropped to a trickle) rather than merely being a
+// slower path — the fragile (e.g. webrtc-under-load) leg that taxes the whole
+// mux via SACK retransmits. It never selects so many that fewer than one active
+// leg would remain. Pure (no rg state / locks) so it is unit-tested directly.
+func selectDataStalledLegs(legs []legRecvDelta, gapStuck bool) []uuid.UUID {
+	if !gapStuck {
+		return nil
+	}
+	var agg, top uint64
+	active := 0
+	for _, l := range legs {
+		agg += l.delta
+		if l.standby {
+			continue
+		}
+		active++
+		if l.delta > top {
+			top = l.delta
+		}
+	}
+	// Need the group to be moving data, at least two active legs (never risk the
+	// last one on a heuristic), and a real leader to measure the laggards against.
+	if agg == 0 || active < 2 || top == 0 {
+		return nil
+	}
+	threshold := top / 16
+	var dead []uuid.UUID
+	for _, l := range legs {
+		if l.standby || l.delta > threshold {
+			continue
+		}
+		dead = append(dead, l.id)
+	}
+	// Keep at least one active leg even if several trickle at once.
+	if drop := len(dead); drop > 0 && active-drop < 1 {
+		dead = dead[:active-1]
+	}
+	return dead
 }
 
 // pruneLivenessDeadLegs drops the given black-holing legs (by transport ID) from

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -498,6 +498,15 @@ func (m *routeMux) deliverData(seq uint32, data []byte) (delivered [][]byte, gap
 	return delivered, gapDetected
 }
 
+// gapAge exposes the reorder buffer's current frontier-gap age (0 if the stream
+// is contiguous). Used by the route group's fast data-progress prune.
+func (m *routeMux) gapAge() time.Duration {
+	if m.reorderBuf == nil {
+		return 0
+	}
+	return m.reorderBuf.GapAge()
+}
+
 // sackMinInterval is the minimum spacing between receiver-side SACKs. It is
 // well under retxMinAge so a genuine loss is still signaled several times
 // before the sender's retransmit timer fires, while collapsing the flood of


### PR DESCRIPTION
## Problem

The pong-miss leg-liveness (added for issue #2) only catches a leg that stops echoing the tiny control ping. But a leg — classically **webrtc under load** — can keep echoing pings while **black-holing bulk data**: it survives the full ~90s pong-miss window while taxing the whole mux, because every sequence it drops is SACK-retransmitted on a live leg. Aggregate throughput collapses to the fragile leg's rate. On a 5-leg forward with 4 webrtc legs, a mux that should pull the reliable legs' bandwidth limps at a small fraction of it.

Complements #4005 (reorder no-skip): that stops a fragile leg from *wedging* the noise stream (0-byte hang); this *sheds* the fragile leg so throughput returns to the reliable legs' rate.

## Fix

A 5s `leg-dataprogress` loop samples each leg's rg-scoped `RecvBytes` and, **when a reorder frontier gap has stayed open past `legDataStallGapAge`** (the receiver is genuinely stuck on a missing seq, not just latency-skewed), prunes any **active** leg delivering **< 1/16 of the fastest active leg's** bytes over the interval — it has dropped to a trickle, i.e. it's black-holing its share. Detection is seconds, not ~90s.

**Safe by construction:** reuses `pruneLivenessDeadLegs`, which never drops the last active leg, keeps the (possibly shared) transport open, and self-heals a false positive with a re-dial — never an outage. Standby legs are excluded (not sent to, so zero recv is expected).

Exposes `reorderBuffer.GapAge()` / `routeMux.gapAge()` as the stuck-receiver signal.

## Tests

The decision is factored into the pure `selectDataStalledLegs` and unit-tested across trickle / gap-not-stuck / converged / never-the-last-leg / standby-excluded / idle-group / single-leg cases. `go build`, `golangci-lint`, and router tests pass.

> Live firing is opportunistic (it only triggers when a leg actually black-holes for several seconds). In the test run that exercised the deploy, the route group's legs happened to carry (mux held ~1.56 Mbps) so nothing stalled long enough to trigger it — the mechanism is verified by the unit tests; catching it live needs a reproducibly-bad leg.