### PR TITLE
ci: persist $GOCACHE across runs so unchanged packages skip re-test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,24 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
+      # Persist the Go build/test cache ($GOCACHE) across runs so unchanged
+      # packages return cached test results ("ok ... (cached)") on incremental
+      # pushes. setup-go's own cache keys GOCACHE on go.sum only (too coarse for
+      # the test cache); the per-sha key below saves a fresh entry each run and
+      # restore-keys pull the most recent prior cache.
+      - name: Locate Go build cache
+        id: gocache
+        run: echo "dir=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Go build/test cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.gocache.outputs.dir }}
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}-
+            ${{ runner.os }}-gobuild-
+
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
@@ -94,6 +112,21 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
+      # Persist the Go build/test cache ($GOCACHE) across runs so unchanged
+      # packages return cached test results on incremental pushes (see linux job).
+      - name: Locate Go build cache
+        id: gocache
+        run: echo "dir=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Go build/test cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.gocache.outputs.dir }}
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}-
+            ${{ runner.os }}-gobuild-
+
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
@@ -116,6 +149,22 @@ jobs:
           go-version: '1.26.5'
           cache: true
           cache-dependency-path: go.sum
+
+      # Persist the Go build/test cache ($GOCACHE) across runs so unchanged
+      # packages return cached test results on incremental pushes (see linux job).
+      - name: Locate Go build cache
+        id: gocache
+        shell: pwsh
+        run: echo "dir=$(go env GOCACHE)" >> $env:GITHUB_OUTPUT
+
+      - name: Cache Go build/test cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.gocache.outputs.dir }}
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}-
+            ${{ runner.os }}-gobuild-
 
       - uses: golangci/golangci-lint-action@v9
         with:


### PR DESCRIPTION
The `linux`/`darwin`/`windows` unit-test jobs run `go test` on a cold runner every time, recompiling and rerunning every package. Go's test cache is content-addressed, so persisting `$GOCACHE` (the Go build/test cache) across runs lets unchanged packages return cached results (`ok ... (cached)`) on incremental pushes — cutting those ~20-30 min jobs on small PRs.

## What this does
For the three unit-test jobs (`linux`, `darwin`, `windows`), adds after `actions/setup-go`:
- a step to locate `$GOCACHE` (`go env GOCACHE`) cross-platform, and
- an `actions/cache@v4` step for that path keyed `${{ runner.os }}-gobuild-<go.sum-hash>-<sha>` with `restore-keys` that fall back to the most recent prior cache.

`setup-go`'s built-in cache already keys `$GOCACHE` on `go.sum` only, which is too coarse for the test cache (it busts on any source change). The per-sha key here saves a fresh entry each run and the `restore-keys` pull the most recent prior cache so `go test` reuses unchanged package results.

## Scope / safety
- Only the unit-test jobs are touched. The Docker `e2e` suite is untouched — those tests are uncacheable and would not benefit.
- Test invocation, lint config, and Go setup are unchanged.
- Test correctness is unchanged: Go's cache is content-addressed, so a cached result is only reused when the package's inputs are byte-identical.