### PR TITLE
feat(tpd): compact transports/list discovery snapshot (~62% smaller)

### DIFF
--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -136,7 +136,27 @@ type transportEntryLeaf struct {
 // pkg/transport/manager.go (publishTPDList) publishes the same JSON.
 type transportListLeaf struct {
 	Version string             `json:"version,omitempty"`
-	Entries []*transport.Entry `json:"entries"`
+	Entries []*transport.Entry `json:"entries,omitempty"` // legacy full form (pre-compact visors)
+	// Compact is the space-optimized form: each row is the remote edge +
+	// type only (the reporter's own PK and the derivable transport ID are
+	// dropped — ~62% smaller). Reconstructed to full entries via
+	// transport.EntryFromCompact(reporter, ce). Visors on develop publish
+	// this; older visors still publish Entries, which are read as-is.
+	Compact []transport.CompactEntry `json:"c,omitempty"`
+}
+
+// entries returns the reconstructed full-entry set from whichever form
+// the publisher sent: the compact rows (reconstructed against reporter)
+// when present, else the legacy full Entries.
+func (l *transportListLeaf) entries(reporter cipher.PubKey) []*transport.Entry {
+	if len(l.Compact) > 0 {
+		out := make([]*transport.Entry, 0, len(l.Compact))
+		for _, ce := range l.Compact {
+			out = append(out, transport.EntryFromCompact(reporter, ce))
+		}
+		return out
+	}
+	return l.Entries
 }
 
 // tombstoneLeaf is the wire shape for transports/<uuid>/tombstone
@@ -653,7 +673,7 @@ func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubK
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		if err := a.sink.ReconcileTransportsFromCXO(ctx, list.Entries, reporter, list.Version); err != nil {
+		if err := a.sink.ReconcileTransportsFromCXO(ctx, list.entries(reporter), reporter, list.Version); err != nil {
 			a.log.WithError(err).WithField("reporter", reporter).Debug("CXO aggregator: ReconcileTransportsFromCXO failed")
 		}
 		return

--- a/pkg/transport/entry.go
+++ b/pkg/transport/entry.go
@@ -63,6 +63,45 @@ type Entry struct {
 	ThroughputBps float64 `json:"throughput_bps,omitempty"`
 }
 
+// CompactEntry is the space-optimized wire form of a transport in the
+// transports/list CXO discovery snapshot. The full Entry repeats the
+// reporter's own PK in Edges on EVERY row (a 66-hex-char PK duplicated
+// once per transport) and carries an ID that is a deterministic hash of
+// (edges, type). TPD already knows the reporter and can recompute the
+// ID, so the snapshot ships only the remote edge + type — ~62% smaller
+// on a real transport set. Reconstruct a full Entry with
+// EntryFromCompact(reporter, ce). Label is omitted for the common
+// LabelAutomatic case and reconstructed as such (lossless).
+type CompactEntry struct {
+	Remote cipher.PubKey `json:"r"`
+	Type   types.Type    `json:"t"`
+	Label  Label         `json:"l,omitempty"` // omitted == LabelAutomatic
+}
+
+// ToCompact returns the compact form of e relative to local (the
+// reporting/publishing visor's PK): the remote edge + type, and the
+// label only when it isn't the default LabelAutomatic.
+func (e *Entry) ToCompact(local cipher.PubKey) CompactEntry {
+	ce := CompactEntry{Remote: e.RemoteEdge(local), Type: e.Type}
+	if e.Label != LabelAutomatic {
+		ce.Label = e.Label
+	}
+	return ce
+}
+
+// EntryFromCompact reconstructs the full Entry a publisher would have
+// sent, from a compact row and the reporter PK that published it. Edges
+// are canonicalized (sorted) and the ID recomputed by MakeEntry, exactly
+// matching the full-form Entry.
+func EntryFromCompact(reporter cipher.PubKey, ce CompactEntry) *Entry {
+	label := ce.Label
+	if label == "" {
+		label = LabelAutomatic
+	}
+	e := MakeEntry(reporter, ce.Remote, ce.Type, label)
+	return &e
+}
+
 // MakeEntry creates a new transport entry
 func MakeEntry(aPK, bPK cipher.PubKey, netType types.Type, label Label) Entry {
 	entry := Entry{

--- a/pkg/transport/entry_test.go
+++ b/pkg/transport/entry_test.go
@@ -24,6 +24,43 @@ func TestNewEntry(t *testing.T) {
 	assert.NotNil(t, entryBA.ID)
 }
 
+// TestCompactEntryRoundTrip verifies the compact discovery form
+// reconstructs a byte-identical full Entry from (reporter, remote, type)
+// regardless of which edge the reporter is, and that the default
+// LabelAutomatic is elided-and-restored losslessly.
+func TestCompactEntryRoundTrip(t *testing.T) {
+	reporter, _ := cipher.GenerateKeyPair()
+	remote, _ := cipher.GenerateKeyPair()
+
+	for _, label := range []transport.Label{
+		transport.LabelAutomatic, transport.LabelUser, transport.LabelSkycoin, transport.LabelSetup,
+	} {
+		full := transport.MakeEntry(reporter, remote, "stcpr", label)
+		ce := full.ToCompact(reporter)
+
+		// The reporter's own PK is never present in the compact row.
+		assert.Equal(t, remote, ce.Remote, "compact keeps only the remote edge")
+		if label == transport.LabelAutomatic {
+			assert.Equal(t, transport.Label(""), ce.Label, "default label is elided")
+		}
+
+		got := transport.EntryFromCompact(reporter, ce)
+		assert.Equal(t, full.ID, got.ID, "ID recomputes identically (label=%s)", label)
+		assert.Equal(t, full.Edges, got.Edges, "edges canonicalize identically (label=%s)", label)
+		assert.Equal(t, full.Type, got.Type)
+		assert.Equal(t, label, got.Label, "label restored (label=%s)", label)
+	}
+
+	// Reconstruction is independent of which edge sorts first: build the
+	// compact row from the perspective of BOTH edges and confirm the same
+	// canonical entry comes back.
+	full := transport.MakeEntry(reporter, remote, "squicr", transport.LabelAutomatic)
+	fromReporter := transport.EntryFromCompact(reporter, full.ToCompact(reporter))
+	fromRemote := transport.EntryFromCompact(remote, full.ToCompact(remote))
+	assert.Equal(t, fromReporter.ID, fromRemote.ID)
+	assert.Equal(t, fromReporter.Edges, fromRemote.Edges)
+}
+
 func ExampleSignedEntry_Sign() {
 	pkA, skA := cipher.GenerateKeyPair()
 	pkB, skB := cipher.GenerateKeyPair()

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -642,10 +642,21 @@ func (tm *Manager) publishTPDList(entries []*Entry) {
 	if entries == nil {
 		entries = []*Entry{} // publish an explicit empty list (last transport gone)
 	}
+	// Publish the COMPACT form: every entry's Edges repeats this visor's own
+	// PK (TPD knows it as the reporter) and carries a derivable transport ID,
+	// so the full form wastes ~62% of the leaf on redundancy. TPD reconstructs
+	// full entries via transport.EntryFromCompact(reporter, ce). A smaller
+	// leaf also fills in fewer CXO round-trips, which matters because the
+	// discovery leaf must land inside the announce conn's (short) lifetime.
+	self := tm.Conf.PubKey
+	compact := make([]CompactEntry, 0, len(entries))
+	for _, e := range entries {
+		compact = append(compact, e.ToCompact(self))
+	}
 	body, err := json.Marshal(struct {
-		Version string   `json:"version,omitempty"`
-		Entries []*Entry `json:"entries"`
-	}{Version: tm.Conf.Version, Entries: entries})
+		Version string         `json:"version,omitempty"`
+		Compact []CompactEntry `json:"c"`
+	}{Version: tm.Conf.Version, Compact: compact})
 	if err != nil {
 		tm.Logger.WithError(err).Debug("Failed to marshal transport list leaf")
 		return


### PR DESCRIPTION
## Problem

The `transports/list` CXO snapshot each visor publishes is ~62% redundant:

- Every row's `Edges` repeats the **reporting visor's own PK** (66 hex chars) — but TPD already knows it as the `reporter`.
- Each row carries a transport **ID that is a deterministic hash** of (edges, type) — TPD can recompute it.

Measured on a live 257-transport visor: **59,516 B full vs 22,496 B compact** (232 → 88 B/entry). The visor's own PK was repeated 257× (722× at a full set) and 9.2 KB was derivable IDs.

## Fix

Publish the compact form `{r: remote-edge, t: type, l: label-if-not-default}`. TPD reconstructs full entries via `transport.EntryFromCompact(reporter, ce)` — edges canonicalize (sorted) and the ID recomputes **byte-identically**. `LabelAutomatic` (the common case) is elided and restored losslessly.

**Why it matters beyond bandwidth:** the discovery leaf must fill inside the announce conn's short lifetime; a smaller leaf spans fewer CXO object pages, so it lands in fewer round-trips — lifting the fill-success ceiling that left TPD reflecting ~9% of the graph. Complements #4009 (land `transports/list` from partial fills).

## Compatibility

`transportListLeaf` keeps the legacy `entries` field (omitempty); a pre-compact visor still publishes `entries` and TPD reads them as-is. TPD redeploys from develop alongside the publisher change, so no cross-version gap opens.

## Test
- `go build ./pkg/transport/... ./pkg/transport-discovery/...` clean
- `go test ./pkg/transport/ ./pkg/transport-discovery/cxoaggregator/` green
- New `TestCompactEntryRoundTrip`: ID/edges/label reconstruct identically from either edge's perspective.