### PR TITLE
perf(stats): stop mirroring unused daily rollup leaf to CXO

### DIFF
--- a/pkg/visor/stats/sink.go
+++ b/pkg/visor/stats/sink.go
@@ -110,16 +110,12 @@ func HydrateSink(store *Store, sink Sink, publishWindowDays int, now time.Time) 
 				pushed++
 			}
 		}
-		for i := range rec.Daily {
-			d := &rec.Daily[i]
-			if d.Date < cutoff {
-				continue
-			}
-			if data, err := json.Marshal(d); err == nil {
-				sink.Put(dailyTransportPath(rec.ID.String(), d.Date), data)
-				pushed++
-			}
-		}
+		// Daily rollups are deliberately NOT hydrated to the CXO sink: no
+		// subscriber consumes them (TPD's aggregator has no /rollup branch;
+		// the visor's own /stats reads them straight from bbolt), and every
+		// byte on this feed competes with transports/list for the announce
+		// conn's short fill budget. They remain persisted in bbolt (the
+		// TransportRecord above) for the local /stats endpoint.
 	}
 
 	// Tiers: per-tier, per-date bitmap if within window.

--- a/pkg/visor/stats/sink_test.go
+++ b/pkg/visor/stats/sink_test.go
@@ -114,12 +114,15 @@ func TestSinkReceivesTransportPutsOnSample(t *testing.T) {
 
 	puts, _ := sink.snapshot()
 	wantCurrent := "transports/" + id.String() + "/current"
-	wantDaily := "transports/" + id.String() + "/2026-04-27/rollup"
 	if _, ok := puts[wantCurrent]; !ok {
 		t.Errorf("missing %s in sink puts; got %v", wantCurrent, keysOf(puts))
 	}
-	if _, ok := puts[wantDaily]; !ok {
-		t.Errorf("missing %s in sink puts; got %v", wantDaily, keysOf(puts))
+	// The daily rollup is persisted to bbolt but intentionally NOT mirrored to
+	// the CXO sink (no subscriber consumes it; it would only steal fill budget
+	// from transports/list on the announce conn). It must be absent here.
+	dontWantDaily := "transports/" + id.String() + "/2026-04-27/rollup"
+	if _, ok := puts[dontWantDaily]; ok {
+		t.Errorf("rollup %s should NOT be published to the CXO sink; got %v", dontWantDaily, keysOf(puts))
 	}
 }
 

--- a/pkg/visor/stats/tracker.go
+++ b/pkg/visor/stats/tracker.go
@@ -402,9 +402,12 @@ func (t *Tracker) recordTransportTx(stx *SampleTx, tp TransportProbe, now time.T
 	if data, err := json.Marshal(rec.Current); err == nil {
 		mirrors = append(mirrors, mirrorPair{path: currentTransportPath(idStr), data: data})
 	}
-	if data, err := json.Marshal(row); err == nil {
-		mirrors = append(mirrors, mirrorPair{path: dailyTransportPath(idStr, today), data: data})
-	}
+	// The daily rollup (row) is persisted to bbolt above (PutTransportRecord)
+	// but deliberately NOT mirrored to the CXO sink: no subscriber reads it
+	// (TPD's aggregator has no /rollup branch; the visor's own /stats reads it
+	// from bbolt), and publishing a per-transport-per-minute leaf onto the
+	// telemetry feed steals fill budget from transports/list on the
+	// short-lived announce conn — the constraint behind the discovery gap.
 
 	slot := SlotForTime(now)
 	if err := stx.MarkTransportSlot(idStr, now, slot); err != nil {


### PR DESCRIPTION
## Problem

The per-transport daily rollup (`transports/<uuid>/<date>/rollup`) is published to the visor's CXO telemetry feed **every 1-minute sample tick, per transport** — but **nothing consumes it**:
- TPD's aggregator has no `/rollup` dispatch branch (`aggregator.go` notes daily rollups "are received but not yet dispatched anywhere").
- The visor's own `/stats` endpoint reads rollups straight from **bbolt**, not CXO.

That dead-weight leaf lands on the exact feed whose Root TPD must fill over the short-lived announce conn — every rollup byte competes with `transports/list` for the fill budget, which is what left discovery reflecting ~9% of the graph (#4009/#4010). For a busy visor (hundreds of transports) this removes **hundreds of per-minute objects** from each published Root.

## Change
- Drop the rollup mirror from the sample tick (`tracker.go`) and from `HydrateSink` cold-start (`sink.go`).
- Rollups remain persisted in **bbolt** (`PutTransportRecord`) for the local `/stats` endpoint — only the CXO mirror is removed.
- The retention-driven `sinkDelete` of stale rollup paths is **kept**, so a visor updating from an older build still cleans up rollups it previously published to TPD.

## Test
- `go build ./pkg/visor/stats/...` clean
- `go test ./pkg/visor/stats/...` green
- `TestSinkReceivesTransportPutsOnSample` updated to assert rollup is **absent** from CXO puts (`current` + `timeline` still published).

Part of the discovery-gap series (#4009 partial-fill recovery, #4010 compact list). This is the first of the follow-up telemetry-slimming changes surfaced by a wire-shape audit.