### PR TITLE
fix(tpd): publish discovery list as top-level leaf so it fills first

### DIFF
--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -242,6 +242,14 @@ type Aggregator struct {
 // unreachable visor doesn't pin a goroutine.
 const ensureConnTimeout = 20 * time.Second
 
+// tpdListLeafName is the current top-level CXO leaf path for a visor's
+// transport-list discovery snapshot (mirrors tpdListPath in
+// pkg/transport/manager.go). It is a direct child of the feed Root so its
+// inline bytes land in the Root's first child-index page — reachable in a
+// truncated partial fill, unlike the legacy "transports/list" which sorted
+// last among the "transports" node's per-uuid children.
+const tpdListLeafName = "tp-list"
+
 // orphanGraceTicks is how many consecutive cleanup ticks a feed must
 // have zero connected conns before it's reclaimed. At the 2-minute
 // default CleanupInterval this is a ~4-minute grace, long enough to
@@ -658,17 +666,34 @@ func (a *Aggregator) recoverTransportListOnBreak(r *registry.Root) {
 	if err := r.Refs[0].Value(pack, &rootNode); err != nil {
 		return // root node object itself wasn't fetched before the break
 	}
-	_, tsub, ok := childByName(pack, &rootNode, "transports")
-	if !ok || tsub == nil {
-		return
-	}
-	leaf, _, ok := childByName(pack, tsub, "list")
+	// Prefer the top-level "tp-list" leaf (current visors): it lives in the
+	// Root's small first child-index page, so a truncated fill almost always
+	// has it. Fall back to the legacy nested "transports"/"list" for visors
+	// that predate the top-level move.
+	leaf, dispatchPath, ok := findDiscoveryLeaf(pack, &rootNode)
 	if !ok || leaf == nil {
 		return
 	}
-	a.log.WithField("visor", reporter).Debug("CXO aggregator: recovered transports/list from partial fill")
+	a.log.WithField("visor", reporter).WithField("path", dispatchPath).
+		Debug("CXO aggregator: recovered transport list from partial fill")
 	leafCopy := append([]byte(nil), leaf...)
-	go a.dispatchLeaf("transports/list", leafCopy, reporter)
+	go a.dispatchLeaf(dispatchPath, leafCopy, reporter)
+}
+
+// findDiscoveryLeaf locates the transport-list snapshot leaf in a (possibly
+// partially filled) Root tree, trying the current top-level "tp-list" path
+// first and the legacy nested "transports"/"list" second. Returns the inline
+// leaf bytes and the dispatch path to hand to dispatchLeaf.
+func findDiscoveryLeaf(pack registry.Pack, rootNode *treestore.TreeNode) (leaf []byte, path string, ok bool) {
+	if l, _, found := childByName(pack, rootNode, tpdListLeafName); found && l != nil {
+		return l, tpdListLeafName, true
+	}
+	if _, tsub, found := childByName(pack, rootNode, "transports"); found && tsub != nil {
+		if l, _, found := childByName(pack, tsub, "list"); found && l != nil {
+			return l, "transports/list", true
+		}
+	}
+	return nil, "", false
 }
 
 // childByName returns the inline leaf bytes or the sub-node of n's child
@@ -747,9 +772,10 @@ func (a *Aggregator) walkAndDispatch(pack registry.Pack, n *treestore.TreeNode, 
 // Tier and service bitmaps still flow through the CXO cache but
 // aren't yet projected into TPD's redis uptime tables.
 func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubKey) {
-	// transports/list — the full-set snapshot (declarative CRUD). Reconcile the
-	// reporter's transport set against it (register new + deregister absent).
-	if path == "transports/list" {
+	// tp-list (current) / transports/list (legacy) — the full-set snapshot
+	// (declarative CRUD). Reconcile the reporter's transport set against it
+	// (register new + deregister absent).
+	if path == tpdListLeafName || path == "transports/list" {
 		var list transportListLeaf
 		if err := json.Unmarshal(leaf, &list); err != nil {
 			a.log.WithError(err).WithField("path", path).Debug("CXO aggregator: transport list leaf decode failed")

--- a/pkg/transport-discovery/cxoaggregator/aggregator_test.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator_test.go
@@ -107,6 +107,45 @@ func TestDispatchLeafTimeline(t *testing.T) {
 	}
 }
 
+// TestDispatchLeafListPaths verifies both the current top-level "tp-list"
+// path and the legacy nested "transports/list" path route to a reconcile,
+// and that the compact rows reconstruct to full entries against the reporter.
+func TestDispatchLeafListPaths(t *testing.T) {
+	reporter, _ := cipher.GenerateKeyPair()
+	remote, _ := cipher.GenerateKeyPair()
+	want := transport.MakeEntry(reporter, remote, "stcpr", transport.LabelAutomatic)
+
+	leaf, err := json.Marshal(transportListLeaf{
+		Version: "v1.2.3",
+		Compact: []transport.CompactEntry{{Remote: remote, Type: "stcpr"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{"tp-list", "transports/list"} {
+		sink := &recordingSink{}
+		a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
+		a.dispatchLeaf(path, leaf, reporter)
+
+		if len(sink.reconciles) != 1 {
+			t.Fatalf("path %q: expected 1 reconcile, got %d", path, len(sink.reconciles))
+		}
+		rc := sink.reconciles[0]
+		if rc.reporter != reporter || rc.version != "v1.2.3" {
+			t.Errorf("path %q: reporter/version mismatch: %v %q", path, rc.reporter, rc.version)
+		}
+		if len(rc.entries) != 1 {
+			t.Fatalf("path %q: expected 1 entry, got %d", path, len(rc.entries))
+		}
+		got := rc.entries[0]
+		if got.ID != want.ID || got.Edges != want.Edges || got.Type != want.Type {
+			t.Errorf("path %q: reconstructed entry mismatch: got id=%v edges=%v; want id=%v edges=%v",
+				path, got.ID, got.Edges, want.ID, want.Edges)
+		}
+	}
+}
+
 func bytesEqual(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -627,8 +627,25 @@ func (tm *Manager) currentBareEntries() []*Entry {
 	return out
 }
 
+// tpdListPath is the CXO leaf path for the transport-list discovery snapshot.
+// It is a TOP-LEVEL leaf (a direct child of the feed Root), deliberately NOT
+// nested under "transports/" with the per-transport telemetry subtrees.
+//
+// Why top-level: TPD fills the entire Root before it can read any leaf, and the
+// announce conn is short-lived, so the fill routinely breaks partway (see the
+// aggregator's partial-fill recovery). CXO fills top-down, and the Root has only
+// a handful of top-level children ("transports", "tiers", "services", this) — so
+// this leaf's inline bytes live in the Root's first (single-page) child index,
+// fetched in the first round-trips and almost always present even in a truncated
+// fill. Under the old "transports/list" path it was one of hundreds of children
+// of the "transports" node and sorted LAST (uuids begin with a hex digit, "list"
+// with 'l'), so a large visor's fill broke long before reaching it and discovery
+// converged only slowly. TPD reads this path first and falls back to the legacy
+// "transports/list" for visors that predate this change.
+const tpdListPath = "tp-list"
+
 // publishTPDList publishes this visor's full transport list as a single CXO snapshot
-// leaf (transports/list). TPD's cxoaggregator RECONCILES against it — registers every
+// leaf (tpdListPath). TPD's cxoaggregator RECONCILES against it — registers every
 // entry and deregisters any of this visor's transports absent from the list — so a
 // removed transport needs no explicit tombstone (absence = deletion) and a missed
 // update self-heals on the next publish. This is the declarative unification of the
@@ -661,7 +678,7 @@ func (tm *Manager) publishTPDList(entries []*Entry) {
 		tm.Logger.WithError(err).Debug("Failed to marshal transport list leaf")
 		return
 	}
-	if err := pub.Put("transports/list", body); err != nil {
+	if err := pub.Put(tpdListPath, body); err != nil {
 		tm.Logger.WithError(err).Debug("Failed to publish transport list leaf to CXO")
 	}
 }


### PR DESCRIPTION
## Problem

Live measurement of the partial-fill recovery (#4009) showed **large visors converge only slowly**: a 470-transport visor's count in TPD climbed ~15/cycle while its real set grew ~30/cycle — it lagged far behind.

**Root cause:** `transports/list` was nested under the `transports` node alongside all N per-transport telemetry subtrees, and it sorts **last** among them — uuids begin with a hex digit (0-9a-f), `list` with `l`. CXO fills a node's children in key order, so for a large visor the fill (over the short-lived announce conn) broke long before reaching `list`, and the recovery — which can only read objects the fill actually fetched — usually couldn't find it. The list landed only on the rare fill that got far enough.

## Fix

Publish the snapshot as a **top-level leaf** (`tp-list`, a direct child of the feed Root) instead of nested under `transports`. The Root has only a handful of top-level children (`transports`, `tiers`, `services`, this), so its single-page child index — which carries this leaf's inline bytes — is fetched in the **first round-trips** and is almost always present even in a truncated fill. Both the normal walk and the partial-fill recovery now find it there first, falling back to the legacy `transports/list` for visors that predate this change. Per-transport telemetry stays under `transports/<uuid>/...`; only the discovery snapshot moves.

## Compatibility

TPD reads **both** paths (`tp-list` preferred). It redeploys from develop alongside the publisher change, and pre-change visors keep working via the legacy path — rollout-safe.

## Test
- `go build ./pkg/transport/... ./pkg/transport-discovery/...` clean
- `go test ./pkg/transport-discovery/cxoaggregator/...` green
- New `TestDispatchLeafListPaths`: both `tp-list` and `transports/list` reconcile; compact rows reconstruct against the reporter.

Third in the discovery series: #4009 (partial-fill recovery), #4010 (compact list), #4011 (drop unused rollup leaf), this (top-level placement). Together: the discovery leaf is small, unburied, and recoverable — so any visor's full set lands promptly.