### PR TITLE
fix(cxo): adopt existing conn instead of redundant reverse-dial that evicts the fill mid-transfer

### DIFF
--- a/pkg/cxo/node/connect_adopt_test.go
+++ b/pkg/cxo/node/connect_adopt_test.go
@@ -1,0 +1,132 @@
+// Package node pkg/cxo/node/connect_adopt_test.go c2-net-cxo
+package node
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	skycipher "github.com/skycoin/skycoin/src/cipher"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	cxotransport "github.com/skycoin/skywire/pkg/cxo/node/transport"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgtest"
+)
+
+// dmsgOnlyNodeConfig builds a DMSG-only node Config (no TCP/UDP/RPC
+// listeners) whose CXO identity is derived from sk — so the node's
+// NodeID equals its dmsg client PK, the production invariant
+// (treestore.NewWithDMSG derives the CXO node SecKey from the visor SK).
+func dmsgOnlyNodeConfig(prefix string, sk skycipher.SecKey) *Config {
+	c := NewConfig()
+	c.Logger.Prefix = "[" + prefix + "] "
+	c.Config.InMemoryDB = true
+	c.SecKey = sk
+	c.TCP.Listen = ""
+	c.TCP.ResponseTimeout = 2 * time.Second
+	c.TCP.Pings = 0
+	c.UDP.Listen = ""
+	c.UDP.ResponseTimeout = 2 * time.Second
+	c.UDP.Pings = 0
+	c.RPC = ""
+	if testing.Verbose() {
+		c.Logger.Debug = true
+	}
+	return c
+}
+
+// TestConnectPKAdoptsExistingConn is the in-process guard for the
+// transport-discovery "delivering conn dies mid-fill" break.
+//
+// Topology mirrors visor<->TPD: node A dials node B (the visor's
+// AnnounceTo), so B holds an INBOUND conn from A that the TPD aggregator
+// would fill a Root over. Then B dials A back (the aggregator's
+// ensureConn). A CXO node enforces one conn per NodeID — a second conn
+// makes handshake.evictStalePeer / DMSG.addConn close the incumbent — so
+// without the ConnectPK adopt guard the reverse dial tears down the very
+// conn the fill runs over. The guard makes the reverse ConnectPK ADOPT
+// the existing conn instead of dialing a second one, so a single stable
+// conn survives for the whole fill.
+func TestConnectPKAdoptsExistingConn(t *testing.T) {
+	const port = cxotransport.DefaultCXOPort
+
+	env := dmsgtest.NewEnv(t, 30*time.Second)
+	require.NoError(t, env.Startup(0, 1, 0, &dmsg.Config{MinSessions: 1}))
+	t.Cleanup(env.Shutdown)
+
+	pkA, skA := cipher.GenerateKeyPair()
+	pkB, skB := cipher.GenerateKeyPair()
+	clientA, err := env.NewClientWithKeys(pkA, skA, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err)
+	clientB, err := env.NewClientWithKeys(pkB, skB, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err)
+
+	var skAsky, skBsky skycipher.SecKey
+	copy(skAsky[:], skA[:])
+	copy(skBsky[:], skB[:])
+
+	nodeA, err := NewNode(dmsgOnlyNodeConfig("A", skAsky))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = nodeA.Close() }) //nolint:errcheck
+	nodeB, err := NewNode(dmsgOnlyNodeConfig("B", skBsky))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = nodeB.Close() }) //nolint:errcheck
+
+	require.NoError(t, nodeA.EnableDMSG(cxotransport.NewDMSGFactory(clientA, port)))
+	require.NoError(t, nodeB.EnableDMSG(cxotransport.NewDMSGFactory(clientB, port)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// A dials B (the visor's AnnounceTo). B accepts an inbound conn.
+	connAB, err := nodeA.DMSG().ConnectPK(ctx, pkB)
+	require.NoError(t, err)
+	require.NotNil(t, connAB)
+
+	// B's cxo NodeID for A is pkA (identity == dmsg PK).
+	var idA skycipher.PubKey
+	copy(idA[:], pkA[:])
+
+	// Wait until B has registered the accepted inbound conn from A.
+	var inbound *Conn
+	require.Eventually(t, func() bool {
+		c, ok := nodeB.hasPeer(idA)
+		if ok {
+			inbound = c
+		}
+		return ok
+	}, 10*time.Second, 20*time.Millisecond, "B never registered the inbound conn from A")
+
+	require.Equal(t, 1, len(nodeA.Connections()))
+	require.Equal(t, 1, len(nodeB.Connections()))
+
+	// Reproduce the window the fix targets: the accepted conn is
+	// registered in the node-level pk->conn map (onConnInit, which runs
+	// before the conn's run loop serves any Root) but NOT yet mirrored
+	// into this DMSG transport's pk->conn cache (d.cs). That window is
+	// live in production between onConnInit and acceptConn's addConn, and
+	// again between removeConn and closeConn on teardown. Simulate it by
+	// dropping B's d.cs entry while the conn stays live and pk-registered.
+	dmsgB := nodeB.DMSG()
+	dmsgB.mx.Lock()
+	delete(dmsgB.cs, pkA)
+	dmsgB.mx.Unlock()
+
+	// B dials A back (the aggregator's ensureConn). d.cs now misses, so
+	// without the adopt guard ConnectPK would DIAL a second conn to A —
+	// which handshake.evictStalePeer / addConn would use to close the
+	// incumbent (the fill source). With the guard it adopts the existing,
+	// pk-registered conn instead.
+	reverse, err := nodeB.DMSG().ConnectPK(ctx, pkA)
+	require.NoError(t, err)
+	require.Same(t, inbound, reverse,
+		"reverse ConnectPK must adopt the existing pk-registered conn, not dial a new one that evicts it")
+
+	// Neither side churned, and the original A->B conn is still alive.
+	require.Equal(t, 1, len(nodeA.Connections()))
+	require.Equal(t, 1, len(nodeB.Connections()))
+	require.True(t, connIsAlive(connAB), "A's original conn must survive the reverse dial")
+	require.True(t, connIsAlive(inbound), "B's inbound conn must survive the reverse dial")
+}

--- a/pkg/cxo/node/transport_dmsg.go
+++ b/pkg/cxo/node/transport_dmsg.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"sync"
 
+	skycipher "github.com/skycoin/skycoin/src/cipher"
+
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cxo/node/transport"
 )
@@ -142,6 +144,48 @@ func (d *DMSG) ConnectPK(ctx context.Context, remotePK cipher.PubKey) (*Conn, er
 		// closing Conn.
 		d.n.Debugf(NewOutConnPin, "[dmsg:%s] cached conn is stale; evicting before re-dial", remotePK.String())
 		d.closeConn(c)
+	}
+
+	// Adopt an existing node-level conn to this same peer instead of
+	// dialing a redundant reverse-direction one.
+	//
+	// d.cs (this transport's pk→conn cache) is populated for an ACCEPTED
+	// conn only AFTER initConn returns (acceptConn's addConn), whereas
+	// the node-level pk→conn map (n.pkConns) is set inside onConnInit,
+	// which runs BEFORE the accepted conn's run loop can serve any Root.
+	// So a conn we already hold — e.g. a visor's inbound AnnounceTo that
+	// the TPD aggregator is actively filling a Root from — can be visible
+	// via hasPeer while still missing from d.cs.
+	//
+	// Without this adopt step, ConnectPK (reached from the aggregator's
+	// ensureConn dial-back, from AnnounceTo, and from Subscriber.Connect)
+	// would DIAL a second conn to a peer we already have one to. A CXO
+	// node enforces one conn per NodeID: both handshake.evictStalePeer
+	// and DMSG.addConn close the incumbent the moment a fresh conn for
+	// the same NodeID completes. That redundant dial therefore tears down
+	// the very conn the aggregator is mid-fill on — the transport-
+	// discovery "delivering conn dies mid-fill / ErrNoConnectionsToFill
+	// From" break. A large visor's Root (its ~54 KB transport-list leaf
+	// plus per-transport telemetry subtrees) never finishes filling
+	// because the reverse dial keeps evicting its source, while a small
+	// visor completes inside the sub-second window before the eviction
+	// lands. Adopting the live conn keeps a single, stable conn per peer
+	// for the whole fill — every leaf, telemetry included.
+	//
+	// Guard on !IsTCP so a node that also holds a TCP conn to this peer
+	// still dials a real DMSG conn here rather than adopting the TCP one
+	// into the DMSG cache. The deployment nodes this matters for (the TPD
+	// aggregator, the visor stats publisher) are DMSG-only, so in practice
+	// hasPeer only ever returns the DMSG conn — this is defence in depth.
+	var peerID skycipher.PubKey
+	copy(peerID[:], remotePK[:])
+	if existing, ok := d.n.hasPeer(peerID); ok && !existing.IsTCP() && connIsAlive(existing) {
+		d.n.Debugf(NewOutConnPin, "[dmsg:%s] adopting existing conn; skipping redundant reverse dial", remotePK.String())
+		// Mirror the adopted conn into d.cs so subsequent getConn hits
+		// and closeConn (on teardown) can evict it. addConn is a no-op
+		// when d.cs already points at this same conn (identity-checked).
+		d.addConn(remotePK, existing)
+		return existing, nil
 	}
 
 	// Dial over DMSG


### PR DESCRIPTION
## Root cause (the last mechanism behind the ~9% discovery reflection for busy visors)

A CXO node enforces **one conn per NodeID**: `handshake.evictStalePeer` and `DMSG.addConn` both close the incumbent the instant a fresh conn for the same NodeID completes. The transport-discovery aggregator fills a visor's Root over exactly the conn that Root arrived on — so any **second** conn to that same visor tears down the fill's only source mid-transfer → `ErrNoConnectionsToFillFrom`.

That redundant second conn came from `ConnectPK` itself (reached from the aggregator's dial-back #4008, from the publisher's `AnnounceTo`, and from the subscriber). `d.cs` (the dmsg transport's pk→conn cache) is populated for an **accepted** conn only *after* `initConn` returns, while the node-level pk→conn map is set earlier in `onConnInit`. In that window `ConnectPK`'s cache misses and **dials a colliding reverse conn** to a peer it already holds, evicting the conn the aggregator is mid-fill on. The announce and dial-back conns then alternate through this window and keep superseding each other — the observed ~1–2s churn (`Subscribe failed error="closed"` + `root filling broke`) where nothing completes.

A small visor's Root fills inside the sub-second pre-eviction window; a **large** visor's (its ~54 KB transport-list leaf + per-transport telemetry subtrees) never does. Measured live: a 620-transport visor froze at 65 reflected.

## Fix

Before dialing, `ConnectPK` **adopts** an existing live node-level conn to the same peer (`n.hasPeer`) instead of dialing a redundant reverse one — a single stable conn per peer for the whole fill, every leaf including telemetry. Guarded on `!IsTCP` (defence in depth; deployment nodes are DMSG-only) and `connIsAlive`. Leaves the legitimate `evictStalePeer` case (a peer genuinely redialing after restart) intact, and **neutralizes #4008's dial-back into a true no-op**.

Completes the discovery-fill series (#4009 partial-fill recovery, #4010 compact list, #4011 drop rollup, #4012 top-level leaf, #4013 conformance guard): those got the *content* small and recoverable; this keeps the *conn* alive long enough to transfer it — so large visors converge too, not just small ones.

## Test
- New `connect_adopt_test.go` (dmsgtest): dials into the cache-miss window — **fails without** the guard (a second `incoming:false` conn to the same peerID), **passes with** it.
- `go build ./pkg/cxo/...` clean; `go vet` clean; `go test ./pkg/cxo/node/` green.

Validate after deploy: a busy visor's repeated `Subscribe failed … closed` + `root filling broke` collapse to a stable subscribe + `root filled`; its `tp-list` count in TPD converges from ~9% toward ~100%.