### PR TITLE
feat(routing-policy): in-process policy-bw rig — prove WASM presets per-leg over time

### DIFF
--- a/cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go
+++ b/cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go
@@ -66,35 +66,50 @@ var (
 	muxBwJSON           bool
 	muxBwQuiet          bool
 	muxBwOutFile        string
+	muxBwRoutingPolicy  string
+	muxBwPolicyApp      string
 )
 
-func init() {
-	muxBandwidthCmd.Flags().IntVarP(&muxBwRoutes, "routes", "r", 1,
+// addMuxBwCommonFlags registers the flag set shared by `mux-bw` and its
+// policy-driven sibling `policy-bw`, so the two commands stay in lockstep.
+func addMuxBwCommonFlags(cmd *cobra.Command) {
+	cmd.Flags().IntVarP(&muxBwRoutes, "routes", "r", 1,
 		"number of parallel route connections (1 = baseline single route)")
-	muxBandwidthCmd.Flags().DurationVarP(&muxBwDuration, "duration", "d", 30*time.Second,
+	cmd.Flags().DurationVarP(&muxBwDuration, "duration", "d", 30*time.Second,
 		"how long to pump bytes (excludes route-setup time)")
-	muxBandwidthCmd.Flags().IntVarP(&muxBwPacketSizeKb, "size", "s", 32,
+	cmd.Flags().IntVarP(&muxBwPacketSizeKb, "size", "s", 32,
 		"per-write block size in KB")
-	muxBandwidthCmd.Flags().IntVar(&muxBwMinHops, "min-hops", 0,
+	cmd.Flags().IntVar(&muxBwMinHops, "min-hops", 0,
 		"route-finder min hops constraint (>=2 excludes the direct transport)")
-	muxBandwidthCmd.Flags().DurationVar(&muxBwSetupTimeout, "setup-timeout", 30*time.Second,
+	cmd.Flags().DurationVar(&muxBwSetupTimeout, "setup-timeout", 30*time.Second,
 		"per-route setup timeout")
-	muxBandwidthCmd.Flags().BoolVar(&muxBwProbeRTT, "probe-rtt", false,
+	cmd.Flags().BoolVar(&muxBwProbeRTT, "probe-rtt", false,
 		"also send small-packet RTT probes during the load (queueing-delay measurement)")
-	muxBandwidthCmd.Flags().DurationVar(&muxBwProbeInterval, "probe-interval", 100*time.Millisecond,
+	cmd.Flags().DurationVar(&muxBwProbeInterval, "probe-interval", 100*time.Millisecond,
 		"interval between RTT probes when --probe-rtt is set")
-	muxBandwidthCmd.Flags().DurationVar(&muxBwSampleInterval, "sample-interval", 1*time.Second,
+	cmd.Flags().DurationVar(&muxBwSampleInterval, "sample-interval", 1*time.Second,
 		"interval between MuxBandwidthSample events")
-	muxBandwidthCmd.Flags().BoolVar(&muxBwLocalRoute, "local-route", false,
+	cmd.Flags().BoolVar(&muxBwLocalRoute, "local-route", false,
 		"use locally-cached TPD data for route calculation (faster setup; may be stale)")
-	muxBandwidthCmd.Flags().DurationVar(&muxBwIdleBaseline, "idle-baseline", 0,
+	cmd.Flags().DurationVar(&muxBwIdleBaseline, "idle-baseline", 0,
 		"run an idle RTT-probe phase of this duration BEFORE the bulk pump; the summary then prints queueing delay = loaded_pXX - idle_pXX (implies --probe-rtt)")
-	muxBandwidthCmd.Flags().BoolVarP(&muxBwQuiet, "quiet", "q", false,
+	cmd.Flags().BoolVarP(&muxBwQuiet, "quiet", "q", false,
 		"in human mode: suppress per-event rows; print only setup + summary")
-	muxBandwidthCmd.Flags().StringVarP(&muxBwOutFile, "output", "O", "",
+	cmd.Flags().StringVarP(&muxBwOutFile, "output", "O", "",
 		"append NDJSON of every event to FILE (independent of stdout mode)")
+}
 
+func init() {
+	addMuxBwCommonFlags(muxBandwidthCmd)
 	RootCmd.AddCommand(muxBandwidthCmd)
+
+	addMuxBwCommonFlags(policyBandwidthCmd)
+	policyBandwidthCmd.Flags().StringVar(&muxBwRoutingPolicy, "routing-policy", "",
+		"routing-policy engine driving the run: preset:<name> (rotating-bw, latency-adaptive, elastic-mux, adaptive, probe-and-prune, app-mux), @/path/to.wasm, @/path/to.star, or inline Starlark (REQUIRED)")
+	policyBandwidthCmd.Flags().StringVar(&muxBwPolicyApp, "policy-app", "skysocks-client",
+		"app name the policy engine sees (RoutingContext.App); presets branch on it")
+	_ = policyBandwidthCmd.MarkFlagRequired("routing-policy") //nolint:errcheck
+	RootCmd.AddCommand(policyBandwidthCmd)
 }
 
 var muxBandwidthCmd = &cobra.Command{
@@ -139,6 +154,48 @@ Examples:
 	Run:  runMuxBandwidth,
 }
 
+// policyBandwidthCmd is the policy-driven sibling of mux-bw. It runs the SAME
+// in-process bandwidth rig but hands the leg set to a routing-policy engine:
+// decide_route picks the mux width + min-hops, and on_tick adapts the live leg
+// set (add/drop/promote/demote warm standbys) on the preset's cadence. It is a
+// separate command so the pure-measurement `mux-bw` baseline keeps a clean,
+// policy-free surface; the wire request + stream handler are shared (the server
+// only takes the policy path when routing_policy is set).
+var policyBandwidthCmd = &cobra.Command{
+	Use:   "policy-bw <pk>",
+	Short: "Policy-driven multiplexed-route bandwidth rig — proves a routing-policy preset is adaptive over a live mux",
+	Long: `Pump bytes across a multiplexed route to a peer visor, with the mux
+leg set DRIVEN BY A ROUTING-POLICY ENGINE instead of a fixed plan.
+
+Unlike mux-bw (which dials N disjoint routes and pumps them unchanged),
+policy-bw:
+
+  * calls the policy's decide_route hook at setup to pick the mux leg
+    count + min-hops; and
+  * fires the policy's on_tick hook on the preset's rotation cadence,
+    applying the returned leg actions live — dropping a slow leg, adding
+    a fresh disjoint one, or promoting/demoting warm standbys.
+
+Every leg-set mutation is emitted as a leg_lifecycle event (and each
+leg's warm-standby gate_state + EWMA latency ride the per-leg samples),
+so an NDJSON capture shows the preset adapting over time.
+
+Output shapes match mux-bw exactly (human rows + summary by default,
+--json for NDJSON, --output to tee). --routing-policy is REQUIRED.
+
+Examples:
+
+  # Latency-adaptive over a 5-wide multi-hop mux for 5 minutes, NDJSON:
+  skywire cli visor ping policy-bw <peer-pk> --routing-policy preset:latency-adaptive \
+      --routes 5 --min-hops 2 --duration 5m -O /tmp/policy.ndjson
+
+  # Rotating-bw (privacy) preset, watching the warm-standby hot-swaps:
+  skywire cli visor ping policy-bw <peer-pk> --routing-policy preset:rotating-bw \
+      --min-hops 2 --duration 5m --json`,
+	Args: cobra.ExactArgs(1),
+	Run:  runMuxBandwidth,
+}
+
 func runMuxBandwidth(cmd *cobra.Command, args []string) {
 	// The persistent --json, not a second flag of our own. NDJSON is what
 	// this command means by machine output: one event per line, as they
@@ -168,6 +225,8 @@ func runMuxBandwidth(cmd *cobra.Command, args []string) {
 		SampleIntervalNs:       muxBwSampleInterval.Nanoseconds(),
 		LocalRoute:             muxBwLocalRoute,
 		IdleBaselineDurationNs: muxBwIdleBaseline.Nanoseconds(),
+		RoutingPolicy:          muxBwRoutingPolicy,
+		PolicyApp:              muxBwPolicyApp,
 	}
 
 	stream, err := client.StreamMuxBandwidth(ctx, req)
@@ -312,7 +371,26 @@ func muxBwEmitHumanRow(w io.Writer, ev *rpcgrpc.MuxBandwidthEvent, start time.Ti
 			elapsed, f.RouteIndex,
 			fmtBytes(f.BytesSentBeforeFailure), fmtBytes(f.BytesReceivedBeforeFailure),
 			f.ErrorMessage)
+	case *rpcgrpc.MuxBandwidthEvent_LegLifecycle:
+		l := p.LegLifecycle
+		id := l.IntermediatePk
+		if len(id) > 8 {
+			id = id[:8]
+		}
+		//nolint:errcheck // human-mode log write; errors here aren't actionable
+		fmt.Fprintf(w, "[+%6.2fs] R%d ⟳ policy %s (gate=%s%s%s)\n",
+			elapsed, l.RouteIndex, strings.ToUpper(l.Event), l.GateState,
+			leadIf(" via ", id), leadIf(" ", l.TransportKind))
 	}
+}
+
+// leadIf returns prefix+s when s is non-empty, else "". Keeps the lifecycle
+// row compact when a leg has no intermediate / transport kind to show.
+func leadIf(prefix, s string) string {
+	if s == "" {
+		return ""
+	}
+	return prefix + s
 }
 
 // muxBwRenderHopPath returns "A→B→C" given a Hops slice. The hop's

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -7,12 +7,11 @@
 package rpcgrpc
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -2942,8 +2941,27 @@ type MuxBandwidthRequest struct {
 	// true at the handler — without probes there's nothing to
 	// measure.
 	IdleBaselineDurationNs int64 `protobuf:"varint,11,opt,name=idle_baseline_duration_ns,json=idleBaselineDurationNs,proto3" json:"idle_baseline_duration_ns,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// RoutingPolicy, when non-empty, drives this run through the WASM /
+	// Starlark routing-policy engine instead of the pure-measurement path.
+	// Accepts the same values as the visor's routing.policy_per_dial config:
+	// "preset:<name>" (a compiled bundle preset — rotating-bw, elastic-mux,
+	// latency-adaptive, app-mux, adaptive, probe-and-prune), "@/path/to.wasm",
+	// "@/path/to.star", or an inline Starlark string. When set, the handler
+	// (a) calls the engine's decide_route to pick the mux leg count + min-hops
+	// at setup, and (b) fires the engine's on_tick hook against the live per-leg
+	// stats on the sample cadence, applying the returned add/drop/promote/demote
+	// leg actions — the in-process rig that proves a preset is demonstrably
+	// adaptive over a live multiplexed route. Empty = the untouched mux-bw
+	// baseline. This is the `policy-bw` CLI sibling's surface.
+	RoutingPolicy string `protobuf:"bytes,12,opt,name=routing_policy,json=routingPolicy,proto3" json:"routing_policy,omitempty"`
+	// PolicyApp is the app name the routing-policy engine sees as
+	// RoutingContext.App — presets branch on it (latency-adaptive acts on
+	// vpn-client/skysocks-client/skynet-client; app-mux is per-app). Only
+	// meaningful when routing_policy is set; the handler defaults it to
+	// "skysocks-client" so the bandwidth-oriented presets are exercised.
+	PolicyApp     string `protobuf:"bytes,13,opt,name=policy_app,json=policyApp,proto3" json:"policy_app,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *MuxBandwidthRequest) Reset() {
@@ -3053,6 +3071,20 @@ func (x *MuxBandwidthRequest) GetIdleBaselineDurationNs() int64 {
 	return 0
 }
 
+func (x *MuxBandwidthRequest) GetRoutingPolicy() string {
+	if x != nil {
+		return x.RoutingPolicy
+	}
+	return ""
+}
+
+func (x *MuxBandwidthRequest) GetPolicyApp() string {
+	if x != nil {
+		return x.PolicyApp
+	}
+	return ""
+}
+
 // MuxBandwidthEvent is one entry on the stream. Exactly one oneof
 // payload is set per message.
 type MuxBandwidthEvent struct {
@@ -3066,6 +3098,7 @@ type MuxBandwidthEvent struct {
 	//	*MuxBandwidthEvent_Done
 	//	*MuxBandwidthEvent_Error
 	//	*MuxBandwidthEvent_RouteFailure
+	//	*MuxBandwidthEvent_LegLifecycle
 	Payload       isMuxBandwidthEvent_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3169,6 +3202,15 @@ func (x *MuxBandwidthEvent) GetRouteFailure() *MuxRouteFailure {
 	return nil
 }
 
+func (x *MuxBandwidthEvent) GetLegLifecycle() *MuxLegLifecycle {
+	if x != nil {
+		if x, ok := x.Payload.(*MuxBandwidthEvent_LegLifecycle); ok {
+			return x.LegLifecycle
+		}
+	}
+	return nil
+}
+
 type isMuxBandwidthEvent_Payload interface {
 	isMuxBandwidthEvent_Payload()
 }
@@ -3214,6 +3256,16 @@ type MuxBandwidthEvent_RouteFailure struct {
 	RouteFailure *MuxRouteFailure `protobuf:"bytes,15,opt,name=route_failure,json=routeFailure,proto3,oneof"`
 }
 
+type MuxBandwidthEvent_LegLifecycle struct {
+	// LegLifecycle fires when the routing-policy on_tick hook mutates the
+	// leg set — a leg added, dropped, promoted from warm standby, or demoted
+	// to it. Only emitted on policy-driven (`policy-bw`) runs; the pure
+	// mux-bw baseline never mutates its leg set mid-run so never emits these.
+	// Lets the telemetry chart render hot-swaps against the per-leg bandwidth
+	// series.
+	LegLifecycle *MuxLegLifecycle `protobuf:"bytes,16,opt,name=leg_lifecycle,json=legLifecycle,proto3,oneof"`
+}
+
 func (*MuxBandwidthEvent_RouteEstablished) isMuxBandwidthEvent_Payload() {}
 
 func (*MuxBandwidthEvent_Sample) isMuxBandwidthEvent_Payload() {}
@@ -3225,6 +3277,106 @@ func (*MuxBandwidthEvent_Done) isMuxBandwidthEvent_Payload() {}
 func (*MuxBandwidthEvent_Error) isMuxBandwidthEvent_Payload() {}
 
 func (*MuxBandwidthEvent_RouteFailure) isMuxBandwidthEvent_Payload() {}
+
+func (*MuxBandwidthEvent_LegLifecycle) isMuxBandwidthEvent_Payload() {}
+
+// MuxLegLifecycle records one policy-driven leg-set mutation from the
+// on_tick hook. The rig is the in-process analog of the route group's
+// RotationAction executor (add/drop/promote/demote), so a preset's adaptive
+// behavior is visible as a stream of these events interleaved with the
+// per-leg MuxBandwidthSample series.
+type MuxLegLifecycle struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Event is one of "added", "dropped", "promoted", "demoted".
+	Event string `protobuf:"bytes,1,opt,name=event,proto3" json:"event,omitempty"`
+	// RouteIndex is the affected leg's index at the time of the event.
+	RouteIndex int32 `protobuf:"varint,2,opt,name=route_index,json=routeIndex,proto3" json:"route_index,omitempty"`
+	// GateState is the leg's resulting warm-standby gate state: "active"
+	// (selected for pumping) or "standby" (kept alive via keepalive but not
+	// pumped). Mirrors router.LegInfo.Standby observed by the on_tick ABI.
+	GateState string `protobuf:"bytes,3,opt,name=gate_state,json=gateState,proto3" json:"gate_state,omitempty"`
+	// IntermediatePk / TransportKind identify the affected leg's path — same
+	// fields as MuxLegSample so a consumer can join the event to the series.
+	IntermediatePk string `protobuf:"bytes,4,opt,name=intermediate_pk,json=intermediatePk,proto3" json:"intermediate_pk,omitempty"`
+	TransportKind  string `protobuf:"bytes,5,opt,name=transport_kind,json=transportKind,proto3" json:"transport_kind,omitempty"`
+	// ElapsedNs is time since pump-start when the mutation was applied. Same
+	// epoch as MuxBandwidthSample.ElapsedNs.
+	ElapsedNs     int64 `protobuf:"varint,6,opt,name=elapsed_ns,json=elapsedNs,proto3" json:"elapsed_ns,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MuxLegLifecycle) Reset() {
+	*x = MuxLegLifecycle{}
+	mi := &file_ping_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuxLegLifecycle) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuxLegLifecycle) ProtoMessage() {}
+
+func (x *MuxLegLifecycle) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuxLegLifecycle.ProtoReflect.Descriptor instead.
+func (*MuxLegLifecycle) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *MuxLegLifecycle) GetEvent() string {
+	if x != nil {
+		return x.Event
+	}
+	return ""
+}
+
+func (x *MuxLegLifecycle) GetRouteIndex() int32 {
+	if x != nil {
+		return x.RouteIndex
+	}
+	return 0
+}
+
+func (x *MuxLegLifecycle) GetGateState() string {
+	if x != nil {
+		return x.GateState
+	}
+	return ""
+}
+
+func (x *MuxLegLifecycle) GetIntermediatePk() string {
+	if x != nil {
+		return x.IntermediatePk
+	}
+	return ""
+}
+
+func (x *MuxLegLifecycle) GetTransportKind() string {
+	if x != nil {
+		return x.TransportKind
+	}
+	return ""
+}
+
+func (x *MuxLegLifecycle) GetElapsedNs() int64 {
+	if x != nil {
+		return x.ElapsedNs
+	}
+	return 0
+}
 
 // MuxRouteEstablished records one route's setup outcome.
 type MuxRouteEstablished struct {
@@ -3248,7 +3400,7 @@ type MuxRouteEstablished struct {
 
 func (x *MuxRouteEstablished) Reset() {
 	*x = MuxRouteEstablished{}
-	mi := &file_ping_proto_msgTypes[34]
+	mi := &file_ping_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3260,7 +3412,7 @@ func (x *MuxRouteEstablished) String() string {
 func (*MuxRouteEstablished) ProtoMessage() {}
 
 func (x *MuxRouteEstablished) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[34]
+	mi := &file_ping_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3273,7 +3425,7 @@ func (x *MuxRouteEstablished) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MuxRouteEstablished.ProtoReflect.Descriptor instead.
 func (*MuxRouteEstablished) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{34}
+	return file_ping_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *MuxRouteEstablished) GetRouteIndex() int32 {
@@ -3344,7 +3496,7 @@ type MuxRouteFailure struct {
 
 func (x *MuxRouteFailure) Reset() {
 	*x = MuxRouteFailure{}
-	mi := &file_ping_proto_msgTypes[35]
+	mi := &file_ping_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3356,7 +3508,7 @@ func (x *MuxRouteFailure) String() string {
 func (*MuxRouteFailure) ProtoMessage() {}
 
 func (x *MuxRouteFailure) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[35]
+	mi := &file_ping_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3369,7 +3521,7 @@ func (x *MuxRouteFailure) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MuxRouteFailure.ProtoReflect.Descriptor instead.
 func (*MuxRouteFailure) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{35}
+	return file_ping_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *MuxRouteFailure) GetRouteIndex() int32 {
@@ -3441,7 +3593,7 @@ type MuxBandwidthSample struct {
 
 func (x *MuxBandwidthSample) Reset() {
 	*x = MuxBandwidthSample{}
-	mi := &file_ping_proto_msgTypes[36]
+	mi := &file_ping_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3453,7 +3605,7 @@ func (x *MuxBandwidthSample) String() string {
 func (*MuxBandwidthSample) ProtoMessage() {}
 
 func (x *MuxBandwidthSample) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[36]
+	mi := &file_ping_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3466,7 +3618,7 @@ func (x *MuxBandwidthSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MuxBandwidthSample.ProtoReflect.Descriptor instead.
 func (*MuxBandwidthSample) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{36}
+	return file_ping_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *MuxBandwidthSample) GetElapsedNs() int64 {
@@ -3566,14 +3718,25 @@ type MuxLegSample struct {
 	// Alive is the route's not-failed state — true while the leg's
 	// pump goroutine is still running. Matches the accounting behind
 	// MuxBandwidthSample.ActiveRoutes.
-	Alive         bool `protobuf:"varint,8,opt,name=alive,proto3" json:"alive,omitempty"`
+	Alive bool `protobuf:"varint,8,opt,name=alive,proto3" json:"alive,omitempty"`
+	// LatencyMs is the leg's EWMA-smoothed round-trip latency in
+	// milliseconds, sampled by the per-leg policy probe. 0 = unknown (no
+	// measurement yet). Only populated on policy-driven runs — the pure
+	// baseline uses a single dedicated probe route, not per-leg probes.
+	// This is the signal latency-adaptive / adaptive presets evict on.
+	LatencyMs int32 `protobuf:"varint,9,opt,name=latency_ms,json=latencyMs,proto3" json:"latency_ms,omitempty"`
+	// Standby is the leg's warm-standby gate state: true when the policy
+	// demoted this leg (kept alive via keepalive, not pumped). Lets the
+	// telemetry consumer see the gate flip in the per-sample series, not
+	// just at the lifecycle event.
+	Standby       bool `protobuf:"varint,10,opt,name=standby,proto3" json:"standby,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *MuxLegSample) Reset() {
 	*x = MuxLegSample{}
-	mi := &file_ping_proto_msgTypes[37]
+	mi := &file_ping_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3585,7 +3748,7 @@ func (x *MuxLegSample) String() string {
 func (*MuxLegSample) ProtoMessage() {}
 
 func (x *MuxLegSample) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[37]
+	mi := &file_ping_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3598,7 +3761,7 @@ func (x *MuxLegSample) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MuxLegSample.ProtoReflect.Descriptor instead.
 func (*MuxLegSample) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{37}
+	return file_ping_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *MuxLegSample) GetRouteIndex() int32 {
@@ -3657,6 +3820,20 @@ func (x *MuxLegSample) GetAlive() bool {
 	return false
 }
 
+func (x *MuxLegSample) GetLatencyMs() int32 {
+	if x != nil {
+		return x.LatencyMs
+	}
+	return 0
+}
+
+func (x *MuxLegSample) GetStandby() bool {
+	if x != nil {
+		return x.Standby
+	}
+	return false
+}
+
 // MuxRttProbe is one RTT measurement during the pump. Allows
 // consumers to plot loaded-RTT-over-time and compute queueing delay
 // as (loaded_rtt - baseline_rtt).
@@ -3678,7 +3855,7 @@ type MuxRttProbe struct {
 
 func (x *MuxRttProbe) Reset() {
 	*x = MuxRttProbe{}
-	mi := &file_ping_proto_msgTypes[38]
+	mi := &file_ping_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3690,7 +3867,7 @@ func (x *MuxRttProbe) String() string {
 func (*MuxRttProbe) ProtoMessage() {}
 
 func (x *MuxRttProbe) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[38]
+	mi := &file_ping_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3703,7 +3880,7 @@ func (x *MuxRttProbe) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MuxRttProbe.ProtoReflect.Descriptor instead.
 func (*MuxRttProbe) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{38}
+	return file_ping_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *MuxRttProbe) GetSequence() int64 {
@@ -3779,7 +3956,7 @@ type MuxBandwidthDone struct {
 
 func (x *MuxBandwidthDone) Reset() {
 	*x = MuxBandwidthDone{}
-	mi := &file_ping_proto_msgTypes[39]
+	mi := &file_ping_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3791,7 +3968,7 @@ func (x *MuxBandwidthDone) String() string {
 func (*MuxBandwidthDone) ProtoMessage() {}
 
 func (x *MuxBandwidthDone) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[39]
+	mi := &file_ping_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3804,7 +3981,7 @@ func (x *MuxBandwidthDone) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MuxBandwidthDone.ProtoReflect.Descriptor instead.
 func (*MuxBandwidthDone) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{39}
+	return file_ping_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *MuxBandwidthDone) GetTotalBytesSent() uint64 {
@@ -3973,7 +4150,7 @@ type MuxBandwidthError struct {
 
 func (x *MuxBandwidthError) Reset() {
 	*x = MuxBandwidthError{}
-	mi := &file_ping_proto_msgTypes[40]
+	mi := &file_ping_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3985,7 +4162,7 @@ func (x *MuxBandwidthError) String() string {
 func (*MuxBandwidthError) ProtoMessage() {}
 
 func (x *MuxBandwidthError) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[40]
+	mi := &file_ping_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3998,7 +4175,7 @@ func (x *MuxBandwidthError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MuxBandwidthError.ProtoReflect.Descriptor instead.
 func (*MuxBandwidthError) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{40}
+	return file_ping_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *MuxBandwidthError) GetCode() string {
@@ -4278,7 +4455,7 @@ const file_ping_proto_rawDesc = "" +
 	"\amessage\x18\x04 \x01(\tR\amessage\"C\n" +
 	"\x13PingTreeServerError\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"\xa9\x03\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"\xef\x03\n" +
 	"\x13MuxBandwidthRequest\x12\x1b\n" +
 	"\ttarget_pk\x18\x01 \x01(\tR\btargetPk\x12\x16\n" +
 	"\x06routes\x18\x02 \x01(\x05R\x06routes\x12\x1f\n" +
@@ -4293,7 +4470,10 @@ const file_ping_proto_rawDesc = "" +
 	"\vlocal_route\x18\n" +
 	" \x01(\bR\n" +
 	"localRoute\x129\n" +
-	"\x19idle_baseline_duration_ns\x18\v \x01(\x03R\x16idleBaselineDurationNs\"\xa0\x03\n" +
+	"\x19idle_baseline_duration_ns\x18\v \x01(\x03R\x16idleBaselineDurationNs\x12%\n" +
+	"\x0erouting_policy\x18\f \x01(\tR\rroutingPolicy\x12\x1d\n" +
+	"\n" +
+	"policy_app\x18\r \x01(\tR\tpolicyApp\"\xe1\x03\n" +
 	"\x11MuxBandwidthEvent\x12!\n" +
 	"\ftimestamp_ns\x18\x01 \x01(\x03R\vtimestampNs\x12K\n" +
 	"\x11route_established\x18\n" +
@@ -4302,8 +4482,19 @@ const file_ping_proto_rawDesc = "" +
 	"\trtt_probe\x18\f \x01(\v2\x14.rpcgrpc.MuxRttProbeH\x00R\brttProbe\x12/\n" +
 	"\x04done\x18\r \x01(\v2\x19.rpcgrpc.MuxBandwidthDoneH\x00R\x04done\x122\n" +
 	"\x05error\x18\x0e \x01(\v2\x1a.rpcgrpc.MuxBandwidthErrorH\x00R\x05error\x12?\n" +
-	"\rroute_failure\x18\x0f \x01(\v2\x18.rpcgrpc.MuxRouteFailureH\x00R\frouteFailureB\t\n" +
-	"\apayload\"\xbc\x01\n" +
+	"\rroute_failure\x18\x0f \x01(\v2\x18.rpcgrpc.MuxRouteFailureH\x00R\frouteFailure\x12?\n" +
+	"\rleg_lifecycle\x18\x10 \x01(\v2\x18.rpcgrpc.MuxLegLifecycleH\x00R\flegLifecycleB\t\n" +
+	"\apayload\"\xd6\x01\n" +
+	"\x0fMuxLegLifecycle\x12\x14\n" +
+	"\x05event\x18\x01 \x01(\tR\x05event\x12\x1f\n" +
+	"\vroute_index\x18\x02 \x01(\x05R\n" +
+	"routeIndex\x12\x1d\n" +
+	"\n" +
+	"gate_state\x18\x03 \x01(\tR\tgateState\x12'\n" +
+	"\x0fintermediate_pk\x18\x04 \x01(\tR\x0eintermediatePk\x12%\n" +
+	"\x0etransport_kind\x18\x05 \x01(\tR\rtransportKind\x12\x1d\n" +
+	"\n" +
+	"elapsed_ns\x18\x06 \x01(\x03R\telapsedNs\"\xbc\x01\n" +
 	"\x13MuxRouteEstablished\x12\x1f\n" +
 	"\vroute_index\x18\x01 \x01(\x05R\n" +
 	"routeIndex\x12(\n" +
@@ -4332,7 +4523,7 @@ const file_ping_proto_rawDesc = "" +
 	"\favg_recv_bps\x18\a \x01(\x01R\n" +
 	"avgRecvBps\x12#\n" +
 	"\ractive_routes\x18\b \x01(\x05R\factiveRoutes\x12)\n" +
-	"\x04legs\x18\t \x03(\v2\x15.rpcgrpc.MuxLegSampleR\x04legs\"\x9b\x02\n" +
+	"\x04legs\x18\t \x03(\v2\x15.rpcgrpc.MuxLegSampleR\x04legs\"\xd4\x02\n" +
 	"\fMuxLegSample\x12\x1f\n" +
 	"\vroute_index\x18\x01 \x01(\x05R\n" +
 	"routeIndex\x12'\n" +
@@ -4344,7 +4535,11 @@ const file_ping_proto_rawDesc = "" +
 	"bytes_recv\x18\x05 \x01(\x03R\tbytesRecv\x12\"\n" +
 	"\rinst_send_bps\x18\x06 \x01(\x01R\vinstSendBps\x12\"\n" +
 	"\rinst_recv_bps\x18\a \x01(\x01R\vinstRecvBps\x12\x14\n" +
-	"\x05alive\x18\b \x01(\bR\x05alive\"}\n" +
+	"\x05alive\x18\b \x01(\bR\x05alive\x12\x1d\n" +
+	"\n" +
+	"latency_ms\x18\t \x01(\x05R\tlatencyMs\x12\x18\n" +
+	"\astandby\x18\n" +
+	" \x01(\bR\astandby\"}\n" +
 	"\vMuxRttProbe\x12\x1a\n" +
 	"\bsequence\x18\x01 \x01(\x03R\bsequence\x12\x1d\n" +
 	"\n" +
@@ -4415,7 +4610,7 @@ func file_ping_proto_rawDescGZIP() []byte {
 	return file_ping_proto_rawDescData
 }
 
-var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
+var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
 var file_ping_proto_goTypes = []any{
 	(*PingRequest)(nil),              // 0: rpcgrpc.PingRequest
 	(*PingResult)(nil),               // 1: rpcgrpc.PingResult
@@ -4451,14 +4646,15 @@ var file_ping_proto_goTypes = []any{
 	(*PingTreeServerError)(nil),      // 31: rpcgrpc.PingTreeServerError
 	(*MuxBandwidthRequest)(nil),      // 32: rpcgrpc.MuxBandwidthRequest
 	(*MuxBandwidthEvent)(nil),        // 33: rpcgrpc.MuxBandwidthEvent
-	(*MuxRouteEstablished)(nil),      // 34: rpcgrpc.MuxRouteEstablished
-	(*MuxRouteFailure)(nil),          // 35: rpcgrpc.MuxRouteFailure
-	(*MuxBandwidthSample)(nil),       // 36: rpcgrpc.MuxBandwidthSample
-	(*MuxLegSample)(nil),             // 37: rpcgrpc.MuxLegSample
-	(*MuxRttProbe)(nil),              // 38: rpcgrpc.MuxRttProbe
-	(*MuxBandwidthDone)(nil),         // 39: rpcgrpc.MuxBandwidthDone
-	(*MuxBandwidthError)(nil),        // 40: rpcgrpc.MuxBandwidthError
-	nil,                              // 41: rpcgrpc.AppLogEntry.FieldsEntry
+	(*MuxLegLifecycle)(nil),          // 34: rpcgrpc.MuxLegLifecycle
+	(*MuxRouteEstablished)(nil),      // 35: rpcgrpc.MuxRouteEstablished
+	(*MuxRouteFailure)(nil),          // 36: rpcgrpc.MuxRouteFailure
+	(*MuxBandwidthSample)(nil),       // 37: rpcgrpc.MuxBandwidthSample
+	(*MuxLegSample)(nil),             // 38: rpcgrpc.MuxLegSample
+	(*MuxRttProbe)(nil),              // 39: rpcgrpc.MuxRttProbe
+	(*MuxBandwidthDone)(nil),         // 40: rpcgrpc.MuxBandwidthDone
+	(*MuxBandwidthError)(nil),        // 41: rpcgrpc.MuxBandwidthError
+	nil,                              // 42: rpcgrpc.AppLogEntry.FieldsEntry
 }
 var file_ping_proto_depIdxs = []int32{
 	4,  // 0: rpcgrpc.PingRequest.forward_hops:type_name -> rpcgrpc.RouteHop
@@ -4472,7 +4668,7 @@ var file_ping_proto_depIdxs = []int32{
 	14, // 8: rpcgrpc.SystemStats.network:type_name -> rpcgrpc.NetworkStat
 	15, // 9: rpcgrpc.SystemStats.temps:type_name -> rpcgrpc.TempStat
 	23, // 10: rpcgrpc.SystemStats.processes:type_name -> rpcgrpc.ProcessStat
-	41, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
+	42, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
 	20, // 12: rpcgrpc.CalcRoute.hops:type_name -> rpcgrpc.CalcHop
 	26, // 13: rpcgrpc.PingTreeEvent.discovered:type_name -> rpcgrpc.PingTreeDiscovered
 	27, // 14: rpcgrpc.PingTreeEvent.ping_result:type_name -> rpcgrpc.PingTreeResult
@@ -4481,45 +4677,46 @@ var file_ping_proto_depIdxs = []int32{
 	30, // 17: rpcgrpc.PingTreeEvent.status_update:type_name -> rpcgrpc.PingTreeStatusUpdate
 	31, // 18: rpcgrpc.PingTreeEvent.server_error:type_name -> rpcgrpc.PingTreeServerError
 	4,  // 19: rpcgrpc.PingTreeResult.route:type_name -> rpcgrpc.RouteHop
-	34, // 20: rpcgrpc.MuxBandwidthEvent.route_established:type_name -> rpcgrpc.MuxRouteEstablished
-	36, // 21: rpcgrpc.MuxBandwidthEvent.sample:type_name -> rpcgrpc.MuxBandwidthSample
-	38, // 22: rpcgrpc.MuxBandwidthEvent.rtt_probe:type_name -> rpcgrpc.MuxRttProbe
-	39, // 23: rpcgrpc.MuxBandwidthEvent.done:type_name -> rpcgrpc.MuxBandwidthDone
-	40, // 24: rpcgrpc.MuxBandwidthEvent.error:type_name -> rpcgrpc.MuxBandwidthError
-	35, // 25: rpcgrpc.MuxBandwidthEvent.route_failure:type_name -> rpcgrpc.MuxRouteFailure
-	4,  // 26: rpcgrpc.MuxRouteEstablished.hops:type_name -> rpcgrpc.RouteHop
-	37, // 27: rpcgrpc.MuxBandwidthSample.legs:type_name -> rpcgrpc.MuxLegSample
-	0,  // 28: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
-	0,  // 29: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
-	5,  // 30: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	5,  // 31: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	2,  // 32: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
-	7,  // 33: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	7,  // 34: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	8,  // 35: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
-	16, // 36: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
-	18, // 37: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
-	21, // 38: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
-	24, // 39: rpcgrpc.PingService.StreamPingTree:input_type -> rpcgrpc.PingTreeRequest
-	32, // 40: rpcgrpc.PingService.StreamMuxBandwidth:input_type -> rpcgrpc.MuxBandwidthRequest
-	1,  // 41: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
-	1,  // 42: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
-	6,  // 43: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	6,  // 44: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	3,  // 45: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
-	9,  // 46: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 47: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 48: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
-	17, // 49: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
-	19, // 50: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
-	22, // 51: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
-	25, // 52: rpcgrpc.PingService.StreamPingTree:output_type -> rpcgrpc.PingTreeEvent
-	33, // 53: rpcgrpc.PingService.StreamMuxBandwidth:output_type -> rpcgrpc.MuxBandwidthEvent
-	41, // [41:54] is the sub-list for method output_type
-	28, // [28:41] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	35, // 20: rpcgrpc.MuxBandwidthEvent.route_established:type_name -> rpcgrpc.MuxRouteEstablished
+	37, // 21: rpcgrpc.MuxBandwidthEvent.sample:type_name -> rpcgrpc.MuxBandwidthSample
+	39, // 22: rpcgrpc.MuxBandwidthEvent.rtt_probe:type_name -> rpcgrpc.MuxRttProbe
+	40, // 23: rpcgrpc.MuxBandwidthEvent.done:type_name -> rpcgrpc.MuxBandwidthDone
+	41, // 24: rpcgrpc.MuxBandwidthEvent.error:type_name -> rpcgrpc.MuxBandwidthError
+	36, // 25: rpcgrpc.MuxBandwidthEvent.route_failure:type_name -> rpcgrpc.MuxRouteFailure
+	34, // 26: rpcgrpc.MuxBandwidthEvent.leg_lifecycle:type_name -> rpcgrpc.MuxLegLifecycle
+	4,  // 27: rpcgrpc.MuxRouteEstablished.hops:type_name -> rpcgrpc.RouteHop
+	38, // 28: rpcgrpc.MuxBandwidthSample.legs:type_name -> rpcgrpc.MuxLegSample
+	0,  // 29: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
+	0,  // 30: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
+	5,  // 31: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	5,  // 32: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	2,  // 33: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
+	7,  // 34: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	7,  // 35: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	8,  // 36: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
+	16, // 37: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
+	18, // 38: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
+	21, // 39: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
+	24, // 40: rpcgrpc.PingService.StreamPingTree:input_type -> rpcgrpc.PingTreeRequest
+	32, // 41: rpcgrpc.PingService.StreamMuxBandwidth:input_type -> rpcgrpc.MuxBandwidthRequest
+	1,  // 42: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
+	1,  // 43: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
+	6,  // 44: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	6,  // 45: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	3,  // 46: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
+	9,  // 47: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 48: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 49: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
+	17, // 50: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
+	19, // 51: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
+	22, // 52: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
+	25, // 53: rpcgrpc.PingService.StreamPingTree:output_type -> rpcgrpc.PingTreeEvent
+	33, // 54: rpcgrpc.PingService.StreamMuxBandwidth:output_type -> rpcgrpc.MuxBandwidthEvent
+	42, // [42:55] is the sub-list for method output_type
+	29, // [29:42] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_ping_proto_init() }
@@ -4542,6 +4739,7 @@ func file_ping_proto_init() {
 		(*MuxBandwidthEvent_Done)(nil),
 		(*MuxBandwidthEvent_Error)(nil),
 		(*MuxBandwidthEvent_RouteFailure)(nil),
+		(*MuxBandwidthEvent_LegLifecycle)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -4549,7 +4747,7 @@ func file_ping_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ping_proto_rawDesc), len(file_ping_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   42,
+			NumMessages:   43,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -635,6 +635,27 @@ message MuxBandwidthRequest {
   // true at the handler — without probes there's nothing to
   // measure.
   int64 idle_baseline_duration_ns = 11;
+
+  // RoutingPolicy, when non-empty, drives this run through the WASM /
+  // Starlark routing-policy engine instead of the pure-measurement path.
+  // Accepts the same values as the visor's routing.policy_per_dial config:
+  // "preset:<name>" (a compiled bundle preset — rotating-bw, elastic-mux,
+  // latency-adaptive, app-mux, adaptive, probe-and-prune), "@/path/to.wasm",
+  // "@/path/to.star", or an inline Starlark string. When set, the handler
+  // (a) calls the engine's decide_route to pick the mux leg count + min-hops
+  // at setup, and (b) fires the engine's on_tick hook against the live per-leg
+  // stats on the sample cadence, applying the returned add/drop/promote/demote
+  // leg actions — the in-process rig that proves a preset is demonstrably
+  // adaptive over a live multiplexed route. Empty = the untouched mux-bw
+  // baseline. This is the `policy-bw` CLI sibling's surface.
+  string routing_policy = 12;
+
+  // PolicyApp is the app name the routing-policy engine sees as
+  // RoutingContext.App — presets branch on it (latency-adaptive acts on
+  // vpn-client/skysocks-client/skynet-client; app-mux is per-app). Only
+  // meaningful when routing_policy is set; the handler defaults it to
+  // "skysocks-client" so the bandwidth-oriented presets are exercised.
+  string policy_app = 13;
 }
 
 // MuxBandwidthEvent is one entry on the stream. Exactly one oneof
@@ -665,7 +686,37 @@ message MuxBandwidthEvent {
     // the pump goroutine died so the consumer can attribute throughput
     // contributions accurately.
     MuxRouteFailure route_failure = 15;
+    // LegLifecycle fires when the routing-policy on_tick hook mutates the
+    // leg set — a leg added, dropped, promoted from warm standby, or demoted
+    // to it. Only emitted on policy-driven (`policy-bw`) runs; the pure
+    // mux-bw baseline never mutates its leg set mid-run so never emits these.
+    // Lets the telemetry chart render hot-swaps against the per-leg bandwidth
+    // series.
+    MuxLegLifecycle leg_lifecycle = 16;
   }
+}
+
+// MuxLegLifecycle records one policy-driven leg-set mutation from the
+// on_tick hook. The rig is the in-process analog of the route group's
+// RotationAction executor (add/drop/promote/demote), so a preset's adaptive
+// behavior is visible as a stream of these events interleaved with the
+// per-leg MuxBandwidthSample series.
+message MuxLegLifecycle {
+  // Event is one of "added", "dropped", "promoted", "demoted".
+  string event = 1;
+  // RouteIndex is the affected leg's index at the time of the event.
+  int32 route_index = 2;
+  // GateState is the leg's resulting warm-standby gate state: "active"
+  // (selected for pumping) or "standby" (kept alive via keepalive but not
+  // pumped). Mirrors router.LegInfo.Standby observed by the on_tick ABI.
+  string gate_state = 3;
+  // IntermediatePk / TransportKind identify the affected leg's path — same
+  // fields as MuxLegSample so a consumer can join the event to the series.
+  string intermediate_pk = 4;
+  string transport_kind = 5;
+  // ElapsedNs is time since pump-start when the mutation was applied. Same
+  // epoch as MuxBandwidthSample.ElapsedNs.
+  int64 elapsed_ns = 6;
 }
 
 // MuxRouteEstablished records one route's setup outcome.
@@ -776,6 +827,17 @@ message MuxLegSample {
   // pump goroutine is still running. Matches the accounting behind
   // MuxBandwidthSample.ActiveRoutes.
   bool alive = 8;
+  // LatencyMs is the leg's EWMA-smoothed round-trip latency in
+  // milliseconds, sampled by the per-leg policy probe. 0 = unknown (no
+  // measurement yet). Only populated on policy-driven runs — the pure
+  // baseline uses a single dedicated probe route, not per-leg probes.
+  // This is the signal latency-adaptive / adaptive presets evict on.
+  int32 latency_ms = 9;
+  // Standby is the leg's warm-standby gate state: true when the policy
+  // demoted this leg (kept alive via keepalive, not pumped). Lets the
+  // telemetry consumer see the gate flip in the per-sample series, not
+  // just at the lifecycle event.
+  bool standby = 10;
 }
 
 // MuxRttProbe is one RTT measurement during the pump. Allows

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth.go
@@ -83,6 +83,15 @@ type muxBwCfg struct {
 	SampleInterval       time.Duration
 	LocalRoute           bool
 	IdleBaselineDuration time.Duration // 0 = no pre-pump idle probe phase
+	// RoutingPolicy is empty on the pure mux-bw baseline; when set it names the
+	// routing-policy engine driving the run (preset:<name> / @file.wasm /
+	// @file.star / inline Starlark) — see MuxBandwidthRequest.routing_policy.
+	RoutingPolicy string
+	// PolicyApp is the app name the policy engine sees in RoutingContext.App.
+	// Presets branch on it (latency-adaptive acts on vpn-client/skysocks-client/
+	// skynet-client; app-mux is per-app). Defaults to "skysocks-client" so the
+	// bandwidth-oriented presets are exercised out of the box.
+	PolicyApp string
 }
 
 func normalizeMuxBwRequest(req *MuxBandwidthRequest) (muxBwCfg, error) {
@@ -100,6 +109,11 @@ func normalizeMuxBwRequest(req *MuxBandwidthRequest) (muxBwCfg, error) {
 	c.SampleInterval = time.Duration(req.SampleIntervalNs)
 	c.LocalRoute = req.LocalRoute
 	c.IdleBaselineDuration = time.Duration(req.IdleBaselineDurationNs)
+	c.RoutingPolicy = req.RoutingPolicy
+	c.PolicyApp = req.PolicyApp
+	if c.RoutingPolicy != "" && c.PolicyApp == "" {
+		c.PolicyApp = "skysocks-client"
+	}
 
 	// Idle baseline only makes sense when probes are running — force
 	// ProbeRTT on so the operator gets the queueing-delay comparison
@@ -161,6 +175,58 @@ type muxBwRouteState struct {
 	// atomics.
 	intermediatePK string
 	transportKind  string
+
+	// --- policy-bw fields (unused on the pure mux-bw baseline) ---
+	//
+	// standby is the leg's warm-standby gate state, flipped by the on_tick
+	// RotationAction executor (muxBwController.applyRotation). A standby leg
+	// keeps its conn alive via a keepalive PingOnce but is NOT byte-pumped —
+	// the in-process analog of routeMux.setLegStandby. The baseline never sets
+	// it, so muxBwPolicyPumpRoute's standby branch is dead code there.
+	standby atomic.Bool
+	// latencyNsEWMA is the leg's EWMA-smoothed round-trip latency in
+	// nanoseconds (0 = no measurement yet), updated from each echo/keepalive
+	// round-trip. This is the per-leg latency signal the latency-adaptive /
+	// adaptive presets evict on — mux-bw's single dedicated probe route can't
+	// provide it, so the policy path derives it from the pump round-trip.
+	latencyNsEWMA atomic.Int64
+	// pumpCancel cancels JUST this leg's pump goroutine, so the on_tick
+	// executor can drop one leg without tearing down the others. Set by the
+	// controller when it spawns the leg's pump.
+	pumpCancel context.CancelFunc
+}
+
+// muxBwEWMAAlpha weights the newest latency sample when folding it into the
+// per-leg EWMA. 0.3 tracks changes within a handful of samples while damping
+// single-packet spikes — matched to the smoothing the route-group on_tick
+// policies assume when they key an EWMA by TransportID across ticks.
+const muxBwEWMAAlpha = 0.3
+
+// updateLatencyEWMA folds a fresh round-trip sample into the leg's EWMA. The
+// first non-zero sample seeds the average directly. Concurrency-safe via a
+// compare-and-store on the atomic; a lost race just drops one sample, which is
+// harmless for a smoothed signal.
+func (rs *muxBwRouteState) updateLatencyEWMA(sample time.Duration) {
+	if sample <= 0 {
+		return
+	}
+	prev := rs.latencyNsEWMA.Load()
+	if prev == 0 {
+		rs.latencyNsEWMA.Store(sample.Nanoseconds())
+		return
+	}
+	next := int64(muxBwEWMAAlpha*float64(sample.Nanoseconds()) + (1-muxBwEWMAAlpha)*float64(prev))
+	rs.latencyNsEWMA.Store(next)
+}
+
+// latencyMs returns the leg's EWMA latency rounded to whole milliseconds
+// (0 = unknown), for the MuxLegSample / LegInfo wire.
+func (rs *muxBwRouteState) latencyMs() int {
+	ns := rs.latencyNsEWMA.Load()
+	if ns <= 0 {
+		return 0
+	}
+	return int(time.Duration(ns).Milliseconds())
 }
 
 // StreamMuxBandwidth is the canonical implementation of the RPC.
@@ -187,6 +253,21 @@ func (s *PingServer) StreamMuxBandwidth(req *MuxBandwidthRequest, stream PingSer
 		case eventCh <- ev:
 		case <-ctx.Done():
 		}
+	}
+
+	// Phase 0a (policy-bw only): load the routing-policy engine and run its
+	// decide_route hook to pick the mux leg count + min-hops for this run. On
+	// the pure mux-bw baseline (RoutingPolicy=="") ctrl is nil and every policy
+	// branch below is skipped — the baseline path is byte-for-byte unchanged.
+	var ctrl *muxBwController
+	if cfg.RoutingPolicy != "" {
+		var perr error
+		ctrl, perr = s.newMuxBwController(&cfg, emit)
+		if perr != nil {
+			return s.sendMuxBwError(stream, "policy_load", perr.Error())
+		}
+		defer ctrl.close()
+		ctrl.decideAtDial(ctx) // mutates cfg.Routes / cfg.MinHops in place
 	}
 
 	// Phase 0: pre-compute up to cfg.Routes DISJOINT routes to the
@@ -365,24 +446,39 @@ func (s *PingServer) StreamMuxBandwidth(req *MuxBandwidthRequest, stream PingSer
 	var probesMu sync.Mutex
 
 	pumpWg := &sync.WaitGroup{}
-	for _, r := range routes {
-		if !r.established.Load() {
-			continue
-		}
+	if ctrl != nil {
+		// Policy-bw path: the controller owns the pump goroutines (each with
+		// its own cancel + warm-standby awareness) AND the control loop, which
+		// emits the periodic MuxBandwidthSample and fires the engine's on_tick
+		// hook against the live per-leg stats — applying the returned
+		// add/drop/promote/demote leg actions. It replaces both the baseline
+		// pump-spawn and the baseline sampler.
+		ctrl.startPumps(pumpCtx, routes, pumpStart, pumpWg)
 		pumpWg.Add(1)
-		go func(rs *muxBwRouteState) {
+		go func() {
 			defer pumpWg.Done()
-			defer rs.activeFlag.Store(false)
-			s.muxBwPumpRoute(pumpCtx, &cfg, rs, pumpStart, emit)
-		}(r)
-	}
+			ctrl.controlLoop(pumpCtx, pumpStart)
+		}()
+	} else {
+		for _, r := range routes {
+			if !r.established.Load() {
+				continue
+			}
+			pumpWg.Add(1)
+			go func(rs *muxBwRouteState) {
+				defer pumpWg.Done()
+				defer rs.activeFlag.Store(false)
+				s.muxBwPumpRoute(pumpCtx, &cfg, rs, pumpStart, emit)
+			}(r)
+		}
 
-	// Sampler.
-	pumpWg.Add(1)
-	go func() {
-		defer pumpWg.Done()
-		s.muxBwSamplerLoop(pumpCtx, &cfg, routes, pumpStart, &peakSend, &peakRecv, emit)
-	}()
+		// Sampler.
+		pumpWg.Add(1)
+		go func() {
+			defer pumpWg.Done()
+			s.muxBwSamplerLoop(pumpCtx, &cfg, routes, pumpStart, &peakSend, &peakRecv, emit)
+		}()
+	}
 
 	// Probe (optional) — rides the dedicated probe route, NOT a pump conn,
 	// so the pump's per-call deadline clears can't wipe the probe's read
@@ -399,11 +495,19 @@ func (s *PingServer) StreamMuxBandwidth(req *MuxBandwidthRequest, stream PingSer
 	pumpWg.Wait()
 	pumpDuration := time.Since(pumpStart)
 
-	// Aggregate totals + emit Done.
+	// Aggregate totals + emit Done. On the policy path legs may have been
+	// added/dropped mid-run, so sum over the controller's full leg history
+	// (dropped legs' bytes are real traffic that happened) and take its
+	// peak readings; the baseline sums the static routes slice.
 	var totalSent, totalRecv uint64
-	for _, r := range routes {
-		totalSent += r.bytesSent.Load()
-		totalRecv += r.bytesRecv.Load()
+	if ctrl != nil {
+		totalSent, totalRecv = ctrl.totals()
+		peakSend, peakRecv = ctrl.peaks()
+	} else {
+		for _, r := range routes {
+			totalSent += r.bytesSent.Load()
+			totalRecv += r.bytesRecv.Load()
+		}
 	}
 	pumpSec := pumpDuration.Seconds()
 	avgSendBps := 0.0
@@ -910,97 +1014,124 @@ func (s *PingServer) muxBwSamplerLoop(
 	ticker := time.NewTicker(cfg.SampleInterval)
 	defer ticker.Stop()
 
-	var lastSent, lastRecv uint64
-	lastTick := pumpStart
-
-	// Per-leg previous-sample counters, indexed by position in the
-	// routes slice, so each leg's inst_*_bps is a delta since ITS own
-	// last reading — mirroring how the aggregate inst rate is computed
-	// from lastSent/lastRecv.
-	lastLegSent := make([]uint64, len(routes))
-	lastLegRecv := make([]uint64, len(routes))
-
+	tracker := newMuxBwSampleTracker(pumpStart)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			now := time.Now()
-			elapsed := now.Sub(pumpStart)
-			intervalSec := now.Sub(lastTick).Seconds()
-			lastTick = now
-
-			var totalSent, totalRecv uint64
-			var activeRoutes int32
-			// Per-leg breakdown, emitted alongside the aggregate. One
-			// entry per route, in route-index order, carrying the leg's
-			// cumulative bytes, its per-interval instant rates, and its
-			// distinguishing identity (intermediate PK + transport kind).
-			legs := make([]*MuxLegSample, 0, len(routes))
-			for i, r := range routes {
-				legSent := r.bytesSent.Load()
-				legRecv := r.bytesRecv.Load()
-				totalSent += legSent
-				totalRecv += legRecv
-				alive := r.activeFlag.Load()
-				if alive {
-					activeRoutes++
-				}
-
-				legInstSendBps := 0.0
-				legInstRecvBps := 0.0
-				if intervalSec > 0 {
-					legInstSendBps = float64((legSent-lastLegSent[i])*8) / intervalSec
-					legInstRecvBps = float64((legRecv-lastLegRecv[i])*8) / intervalSec
-				}
-				lastLegSent[i], lastLegRecv[i] = legSent, legRecv
-
-				legs = append(legs, &MuxLegSample{
-					RouteIndex:     int32(r.index), //nolint:gosec // route index fits int32
-					IntermediatePk: r.intermediatePK,
-					TransportKind:  r.transportKind,
-					BytesSent:      int64(legSent), //nolint:gosec // pumped byte totals fit int64
-					BytesRecv:      int64(legRecv), //nolint:gosec // pumped byte totals fit int64
-					InstSendBps:    legInstSendBps,
-					InstRecvBps:    legInstRecvBps,
-					Alive:          alive,
-				})
-			}
-
-			instantSendBps := 0.0
-			instantRecvBps := 0.0
-			if intervalSec > 0 {
-				instantSendBps = float64((totalSent-lastSent)*8) / intervalSec
-				instantRecvBps = float64((totalRecv-lastRecv)*8) / intervalSec
-			}
-			if instantSendBps > *peakSend {
-				*peakSend = instantSendBps
-			}
-			if instantRecvBps > *peakRecv {
-				*peakRecv = instantRecvBps
-			}
-			lastSent, lastRecv = totalSent, totalRecv
-
-			avgSendBps := 0.0
-			avgRecvBps := 0.0
-			elapsedSec := elapsed.Seconds()
-			if elapsedSec > 0 {
-				avgSendBps = float64(totalSent*8) / elapsedSec
-				avgRecvBps = float64(totalRecv*8) / elapsedSec
-			}
-
-			emit(&MuxBandwidthEvent_Sample{Sample: &MuxBandwidthSample{
-				ElapsedNs:      elapsed.Nanoseconds(),
-				BytesSent:      totalSent,
-				BytesReceived:  totalRecv,
-				InstantSendBps: instantSendBps,
-				InstantRecvBps: instantRecvBps,
-				AvgSendBps:     avgSendBps,
-				AvgRecvBps:     avgRecvBps,
-				ActiveRoutes:   activeRoutes,
-				Legs:           legs,
-			}})
+			// Baseline path: static leg set, no per-leg latency probe
+			// (the dedicated probe route carries RTT). includeLatency=false
+			// keeps latency_ms / standby at their zero values so the pure
+			// mux-bw output is byte-for-byte what it was before policy-bw.
+			sample := tracker.sample(routes, time.Now(), pumpStart, false)
+			*peakSend = tracker.peakSend
+			*peakRecv = tracker.peakRecv
+			emit(&MuxBandwidthEvent_Sample{Sample: sample})
 		}
+	}
+}
+
+// muxBwSampleTracker holds the previous poll's counters so a poll can compute
+// per-interval instant rates for both the aggregate and each leg. Per-leg
+// previous counters are keyed by the leg's STABLE index (muxBwRouteState.index
+// — the PingRouteRef conn key), not slice position, so the policy path's
+// mid-run add/drop can't misalign a leg's delta with another leg's history.
+// Shared by the pure-baseline sampler and the policy control loop so both emit
+// identically-shaped MuxBandwidthSample events.
+type muxBwSampleTracker struct {
+	lastSent, lastRecv uint64
+	lastLeg            map[int]muxBwLegPrev
+	peakSend, peakRecv float64
+	lastTick           time.Time
+}
+
+type muxBwLegPrev struct{ sent, recv uint64 }
+
+func newMuxBwSampleTracker(start time.Time) *muxBwSampleTracker {
+	return &muxBwSampleTracker{lastLeg: map[int]muxBwLegPrev{}, lastTick: start}
+}
+
+// sample folds the current per-route counters into a MuxBandwidthSample and
+// advances the tracker. includeLatency populates each leg's latency_ms /
+// standby from the route state (policy path); the baseline passes false. The
+// caller supplies now so tests can drive deterministic intervals.
+func (t *muxBwSampleTracker) sample(routes []*muxBwRouteState, now, pumpStart time.Time, includeLatency bool) *MuxBandwidthSample {
+	elapsed := now.Sub(pumpStart)
+	intervalSec := now.Sub(t.lastTick).Seconds()
+	t.lastTick = now
+
+	var totalSent, totalRecv uint64
+	var activeRoutes int32
+	legs := make([]*MuxLegSample, 0, len(routes))
+	for _, r := range routes {
+		legSent := r.bytesSent.Load()
+		legRecv := r.bytesRecv.Load()
+		totalSent += legSent
+		totalRecv += legRecv
+		alive := r.activeFlag.Load()
+		if alive {
+			activeRoutes++
+		}
+
+		prev := t.lastLeg[r.index]
+		legInstSendBps := 0.0
+		legInstRecvBps := 0.0
+		if intervalSec > 0 {
+			legInstSendBps = float64((legSent-prev.sent)*8) / intervalSec
+			legInstRecvBps = float64((legRecv-prev.recv)*8) / intervalSec
+		}
+		t.lastLeg[r.index] = muxBwLegPrev{sent: legSent, recv: legRecv}
+
+		leg := &MuxLegSample{
+			RouteIndex:     int32(r.index), //nolint:gosec // route index fits int32
+			IntermediatePk: r.intermediatePK,
+			TransportKind:  r.transportKind,
+			BytesSent:      int64(legSent), //nolint:gosec // pumped byte totals fit int64
+			BytesRecv:      int64(legRecv), //nolint:gosec // pumped byte totals fit int64
+			InstSendBps:    legInstSendBps,
+			InstRecvBps:    legInstRecvBps,
+			Alive:          alive,
+		}
+		if includeLatency {
+			leg.LatencyMs = int32(r.latencyMs()) //nolint:gosec // latency ms fits int32
+			leg.Standby = r.standby.Load()
+		}
+		legs = append(legs, leg)
+	}
+
+	instantSendBps := 0.0
+	instantRecvBps := 0.0
+	if intervalSec > 0 {
+		instantSendBps = float64((totalSent-t.lastSent)*8) / intervalSec
+		instantRecvBps = float64((totalRecv-t.lastRecv)*8) / intervalSec
+	}
+	if instantSendBps > t.peakSend {
+		t.peakSend = instantSendBps
+	}
+	if instantRecvBps > t.peakRecv {
+		t.peakRecv = instantRecvBps
+	}
+	t.lastSent, t.lastRecv = totalSent, totalRecv
+
+	avgSendBps := 0.0
+	avgRecvBps := 0.0
+	elapsedSec := elapsed.Seconds()
+	if elapsedSec > 0 {
+		avgSendBps = float64(totalSent*8) / elapsedSec
+		avgRecvBps = float64(totalRecv*8) / elapsedSec
+	}
+
+	return &MuxBandwidthSample{
+		ElapsedNs:      elapsed.Nanoseconds(),
+		BytesSent:      totalSent,
+		BytesReceived:  totalRecv,
+		InstantSendBps: instantSendBps,
+		InstantRecvBps: instantRecvBps,
+		AvgSendBps:     avgSendBps,
+		AvgRecvBps:     avgRecvBps,
+		ActiveRoutes:   activeRoutes,
+		Legs:           legs,
 	}
 }
 

--- a/pkg/visor/rpcgrpc/server_policy_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_policy_bandwidth.go
@@ -1,0 +1,530 @@
+// Package rpcgrpc pkg/visor/rpcgrpc/server_policy_bandwidth.go c3-vis-core
+// the `policy-bw` control layer that drives the in-process mux-bandwidth rig
+// through the WASM / Starlark routing-policy engine — proving a preset is
+// demonstrably ADAPTIVE over a live multiplexed route.
+//
+// Where the pure mux-bw baseline (server_mux_bandwidth.go) plans a fixed set of
+// disjoint routes and pumps them unchanged for the whole run, this layer:
+//
+//   - at dial time, calls the engine's decide_route hook to pick the mux leg
+//     count + min-hops (muxBwController.decideAtDial), then reuses the same
+//     disjoint planner + setup path; and
+//   - during the pump, on the preset's rotation cadence, fires the engine's
+//     on_tick hook against the live per-leg stats and applies the returned
+//     RotationAction — dropping / adding legs and promoting / demoting warm
+//     standbys (muxBwController.controlLoop → applyRotation).
+//
+// The leg-management surface is the in-process analog of the route group's
+// RotationAction executor (pkg/router/route_group.go rotationServiceFn): a drop
+// cancels one leg's pump + tears down its conn; an add plans a fresh disjoint
+// route and spawns a pump; a demote parks a leg on warm standby (conn kept
+// alive via a keepalive ping, not byte-pumped) and a promote resumes it
+// instantly with no re-dial. Route-group LegInfo semantics are preserved so a
+// preset written against the app path behaves identically here: leg indices are
+// slice positions that compact after a drop, and each leg's TransportID (the
+// key a preset uses to smooth an EWMA across ticks) is its stable intermediate
+// PK.
+//
+// Concurrency: active/all and the sampler tracker are touched ONLY by the
+// single controlLoop goroutine (after a happens-before init in startPumps), so
+// they need no lock; the pump goroutines share state only through the per-leg
+// atomics on muxBwRouteState. totals()/peaks() are read after pumpWg.Wait(),
+// i.e. once controlLoop has returned.
+package rpcgrpc
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/router/policy"
+	policywasm "github.com/skycoin/skywire/pkg/router/policy/wasm"
+	wasmpresets "github.com/skycoin/skywire/pkg/router/policy/wasm/presets"
+)
+
+// muxBwDefaultTickInterval is the on_tick cadence used when the preset's
+// decide_route did not set rotation_interval_seconds. The on_tick presets set
+// it themselves (rotating-bw=90s, latency-adaptive=30s, …); this only covers a
+// policy that exports on_tick without declaring a cadence.
+const muxBwDefaultTickInterval = 10 * time.Second
+
+// muxBwStandbyKeepalive is how often a warm-standby leg sends a small keepalive
+// ping to hold its conn open (and refresh its latency EWMA) while parked out of
+// the pump set.
+const muxBwStandbyKeepalive = 3 * time.Second
+
+// loadMuxBwPolicyEngine resolves a routing.policy_per_dial-style value into a
+// policy.Engine, mirroring pkg/visor/policy_loader.go: "preset:<name>" prefers
+// the compiled WASM bundle when the name is a bundle preset, else falls through
+// to the Starlark preset registry; a "@*.wasm" path loads a WASM module; any
+// other value (@*.star / inline) loads the Starlark backend.
+func loadMuxBwPolicyEngine(raw string, logger func(string, ...interface{})) (policy.Engine, error) {
+	prov := policy.NopProvider()
+	if name, ok := strings.CutPrefix(raw, "preset:"); ok {
+		if wasmpresets.Has(name) {
+			return policywasm.NewLoaderBytes(name, wasmpresets.Bundle(),
+				policywasm.WithPreset(name),
+				policywasm.WithLogger(logger),
+				policywasm.WithProvider(prov))
+		}
+		// Not a bundle preset — let the Starlark loader resolve preset:<name>
+		// from its registry (or error on an unknown name).
+	}
+	if strings.HasPrefix(raw, "@") &&
+		strings.EqualFold(filepath.Ext(strings.TrimPrefix(raw, "@")), ".wasm") {
+		return policywasm.NewLoader(raw,
+			policywasm.WithLogger(logger),
+			policywasm.WithProvider(prov))
+	}
+	return policy.NewLoader(raw,
+		policy.WithLogger(logger),
+		policy.WithProvider(prov))
+}
+
+// muxBwController owns the policy-driven leg set for one policy-bw run.
+type muxBwController struct {
+	s      *PingServer
+	cfg    *muxBwCfg
+	engine policy.Engine
+	emit   func(isMuxBandwidthEvent_Payload)
+
+	// tickInterval is the on_tick cadence, set by decideAtDial from the
+	// preset's rotation_interval_seconds (or the default).
+	tickInterval time.Duration
+
+	// active is the current leg set — the slice on_tick sees (Index = position,
+	// compacted on drop). all is append-only: every leg ever created, so the
+	// Done totals include the bytes of legs later dropped. Both touched only by
+	// the controlLoop goroutine.
+	active []*muxBwRouteState
+	all    []*muxBwRouteState
+
+	tracker   *muxBwSampleTracker
+	nextIndex int // monotonic RouteIndex for added legs (conn-map key)
+
+	pumpWg *sync.WaitGroup // shared with StreamMuxBandwidth's pump WaitGroup
+}
+
+// newMuxBwController loads the policy engine and returns a controller. The
+// engine's Decide/OnTick are invoked later (decideAtDial / controlLoop).
+func (s *PingServer) newMuxBwController(cfg *muxBwCfg, emit func(isMuxBandwidthEvent_Payload)) (*muxBwController, error) {
+	eng, err := loadMuxBwPolicyEngine(cfg.RoutingPolicy, s.log.Debugf)
+	if err != nil {
+		return nil, fmt.Errorf("routing policy %q: %w", cfg.RoutingPolicy, err)
+	}
+	return &muxBwController{
+		s:            s,
+		cfg:          cfg,
+		engine:       eng,
+		emit:         emit,
+		tickInterval: muxBwDefaultTickInterval,
+		// Added legs start above the pump-route indices AND the dedicated
+		// probe route (index == cfg.Routes), so a fresh conn key never
+		// collides with a still-live route.
+		nextIndex: cfg.Routes + 1,
+	}, nil
+}
+
+func (c *muxBwController) close() {
+	if c.engine != nil {
+		_ = c.engine.Close() //nolint:errcheck
+	}
+}
+
+// routingContext builds the RoutingContext the engine sees. App drives the
+// preset's per-app branching; CLIOverrides surface the operator's leg-count /
+// min-hops so a preset can honor or override them.
+func (c *muxBwController) routingContext() policy.RoutingContext {
+	overrides := map[string]string{}
+	if c.cfg.Routes > 0 {
+		overrides["mux_routes"] = strconv.Itoa(c.cfg.Routes)
+	}
+	if c.cfg.MinHops > 0 {
+		overrides["min_hops"] = strconv.Itoa(c.cfg.MinHops)
+	}
+	return policy.RoutingContext{
+		App:          c.cfg.PolicyApp,
+		PeerPK:       c.cfg.TargetPK.Hex(),
+		CLIOverrides: overrides,
+	}
+}
+
+// decideAtDial runs the engine's decide_route hook and folds the result into
+// cfg: the mux leg count (max of Mux / ForwardMux / ReverseMux — the rig pumps
+// symmetric echo traffic) and min-hops become the setup targets, and the
+// rotation cadence drives the on_tick loop. A nil/empty spec leaves the
+// operator's flags in force, so a static preset is a no-op override.
+func (c *muxBwController) decideAtDial(ctx context.Context) {
+	spec, err := c.engine.Decide(ctx, c.routingContext(), nil)
+	if err != nil {
+		c.s.log.Debugf("policy-bw: decide_route failed (%v); keeping operator flags", err)
+		return
+	}
+	mux := spec.Mux
+	if spec.ForwardMux > mux {
+		mux = spec.ForwardMux
+	}
+	if spec.ReverseMux > mux {
+		mux = spec.ReverseMux
+	}
+	if mux > 0 {
+		c.cfg.Routes = mux
+	}
+	if spec.MinHops > 0 {
+		c.cfg.MinHops = spec.MinHops
+	}
+	if spec.RotationIntervalSeconds > 0 {
+		c.tickInterval = time.Duration(spec.RotationIntervalSeconds) * time.Second
+	}
+	c.s.log.Debugf("policy-bw: decide_route → routes=%d min_hops=%d tick=%s",
+		c.cfg.Routes, c.cfg.MinHops, c.tickInterval)
+}
+
+// startPumps seeds the leg set from the established routes and spawns a pump
+// goroutine per leg. Called once, from the main goroutine, before controlLoop
+// starts (the `go` that follows establishes happens-before on active/all).
+func (c *muxBwController) startPumps(pumpCtx context.Context, routes []*muxBwRouteState, pumpStart time.Time, wg *sync.WaitGroup) {
+	c.pumpWg = wg
+	c.tracker = newMuxBwSampleTracker(pumpStart)
+	for _, r := range routes {
+		if !r.established.Load() {
+			continue
+		}
+		c.all = append(c.all, r)
+		c.active = append(c.active, r)
+		r.activeFlag.Store(true)
+		c.spawnPump(pumpCtx, r, pumpStart)
+	}
+}
+
+// spawnPump starts one leg's pump goroutine with its own cancel so a drop can
+// stop just this leg. Registers on the shared pump WaitGroup.
+func (c *muxBwController) spawnPump(pumpCtx context.Context, rs *muxBwRouteState, pumpStart time.Time) {
+	legCtx, cancel := context.WithCancel(pumpCtx)
+	rs.pumpCancel = cancel
+	c.pumpWg.Add(1)
+	go func() {
+		defer c.pumpWg.Done()
+		defer rs.activeFlag.Store(false)
+		c.pumpLeg(legCtx, rs, pumpStart)
+	}()
+}
+
+// pumpLeg is the policy-aware pump: an ACTIVE leg bulk-pumps echo bytes
+// (accumulating the per-leg counters + latency EWMA); a warm-STANDBY leg only
+// sends a small keepalive ping to hold its conn open (and refresh its EWMA)
+// without contributing bandwidth — the in-process warm-standby gate. Flipping
+// rs.standby (from applyRotation) switches modes on the next iteration with no
+// re-dial. The defer tears down just this leg's conn.
+func (c *muxBwController) pumpLeg(ctx context.Context, rs *muxBwRouteState, pumpStart time.Time) {
+	defer func() {
+		_ = c.s.visor.StopPingRoute(PingRouteRef{PK: c.cfg.TargetPK, Index: rs.index}) //nolint:errcheck
+	}()
+	pumpConf := PingConf{
+		PK:         c.cfg.TargetPK,
+		Tries:      1,
+		PcktSize:   c.cfg.PacketSizeKb,
+		LocalRoute: c.cfg.LocalRoute,
+		RouteIndex: rs.index,
+	}
+	kaConf := pumpConf
+	kaConf.PcktSize = 1
+	kaConf.Timeout = muxBwProbeTimeout
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if rs.standby.Load() {
+			// Warm standby: keepalive only, no bandwidth. Latency from the
+			// small round-trip keeps the EWMA fresh so a promotion decision
+			// has a current signal.
+			lat, err := c.s.visor.PingOnce(kaConf)
+			if err == nil {
+				rs.updateLatencyEWMA(lat)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(muxBwStandbyKeepalive):
+			}
+			continue
+		}
+		bytesSent, bytesRecvd, latency, err := c.s.visor.PingOnceWithEcho(pumpConf, true)
+		if err != nil {
+			if ctx.Err() == nil || rs.bytesSent.Load() == 0 {
+				c.emit(&MuxBandwidthEvent_RouteFailure{
+					RouteFailure: buildRouteFailureEvent(rs, err, pumpStart),
+				})
+			}
+			c.s.log.Debugf("policy-bw: leg %d pump error: %v", rs.index, err)
+			return
+		}
+		rs.bytesSent.Add(bytesSent)
+		rs.bytesRecv.Add(bytesRecvd)
+		rs.updateLatencyEWMA(latency)
+	}
+}
+
+// controlLoop drives the run: it emits the periodic MuxBandwidthSample on the
+// sample cadence and fires the engine's on_tick hook on the (usually slower)
+// rotation cadence, applying the returned RotationAction. Runs as a single
+// goroutine, so it is the sole mutator of active/all + tracker.
+func (c *muxBwController) controlLoop(pumpCtx context.Context, pumpStart time.Time) {
+	sampleTick := time.NewTicker(c.cfg.SampleInterval)
+	defer sampleTick.Stop()
+	tickInterval := c.tickInterval
+	if tickInterval <= 0 {
+		tickInterval = muxBwDefaultTickInterval
+	}
+	policyTick := time.NewTicker(tickInterval)
+	defer policyTick.Stop()
+
+	for {
+		select {
+		case <-pumpCtx.Done():
+			return
+		case <-sampleTick.C:
+			sample := c.tracker.sample(c.active, time.Now(), pumpStart, true)
+			c.emit(&MuxBandwidthEvent_Sample{Sample: sample})
+		case <-policyTick.C:
+			c.onTick(pumpCtx, pumpStart)
+		}
+	}
+}
+
+// snapshotLegs builds the []policy.LegInfo on_tick sees from the current active
+// set. Index is the slice position (route-group semantics: not stable across
+// ticks — a drop compacts). TransportID is the leg's stable intermediate PK so
+// a preset can key an EWMA per leg across ticks (falls back to the route index
+// for a direct leg with no intermediate).
+func (c *muxBwController) snapshotLegs() []policy.LegInfo {
+	legs := make([]policy.LegInfo, 0, len(c.active))
+	for i, r := range c.active {
+		tid := r.intermediatePK
+		if tid == "" {
+			tid = "idx:" + strconv.Itoa(r.index)
+		}
+		hops := make([]string, 0, len(r.fwdHops))
+		for _, h := range r.fwdHops {
+			if h.To != "" {
+				hops = append(hops, h.To)
+			}
+		}
+		legs = append(legs, policy.LegInfo{
+			Index:       i,
+			Kind:        r.transportKind,
+			TransportID: tid,
+			LatencyMs:   r.latencyMs(),
+			Alive:       r.activeFlag.Load(),
+			Standby:     r.standby.Load(),
+			SentBytes:   r.bytesSent.Load(),
+			RecvBytes:   r.bytesRecv.Load(),
+			Hops:        hops,
+		})
+	}
+	return legs
+}
+
+// onTick fires the engine's on_tick hook and applies the RotationAction.
+func (c *muxBwController) onTick(pumpCtx context.Context, pumpStart time.Time) {
+	legs := c.snapshotLegs()
+	if len(legs) == 0 {
+		return
+	}
+	action, err := c.engine.OnTick(pumpCtx, c.routingContext(), legs)
+	if err != nil {
+		c.s.log.Debugf("policy-bw: on_tick error: %v", err)
+		return
+	}
+	c.applyRotation(pumpCtx, action, pumpStart)
+}
+
+// applyRotation applies one RotationAction against the active leg set, in the
+// SAME order as the route group's executor (pkg/router/route_group.go): promote
+// / demote first (they only flip the standby gate, so they run on the pre-drop
+// indices), then drops (which compact the slice), then a best-effort add. All
+// indices are positions into the snapshot the hook just saw.
+func (c *muxBwController) applyRotation(pumpCtx context.Context, action policy.RotationAction, pumpStart time.Time) {
+	elapsed := func() int64 { return time.Since(pumpStart).Nanoseconds() }
+
+	// Promote first, then demote — mirrors route_group.go so a policy that
+	// promotes a spare and demotes an active in the same tick keeps a
+	// selectable leg throughout.
+	for _, idx := range action.PromoteFromStandby {
+		if r := c.legAt(idx); r != nil && r.standby.Load() {
+			r.standby.Store(false)
+			c.emitLifecycle("promoted", r, "active", elapsed())
+		}
+	}
+	for _, idx := range action.DemoteToStandby {
+		// Never park the last active (non-standby) leg — a run must always
+		// have a pumping leg, matching routeMux's "leg 0 is never standby".
+		if r := c.legAt(idx); r != nil && !r.standby.Load() && c.activePumpCount() > 1 {
+			r.standby.Store(true)
+			c.emitLifecycle("demoted", r, "standby", elapsed())
+		}
+	}
+
+	// Drops: cancel each leg's pump (its defer tears down the conn) and remove
+	// it from active so subsequent snapshots re-index. Never drop the last
+	// alive leg — mirrors route_group.go dropLegsByIndex: precompute the alive
+	// count and decrement per drop, and build a FRESH kept slice so the alive
+	// bookkeeping can't alias the compaction.
+	if len(action.DropLegs) > 0 {
+		toDrop := map[int]struct{}{}
+		for _, idx := range action.DropLegs {
+			if idx >= 0 && idx < len(c.active) {
+				toDrop[idx] = struct{}{}
+			}
+		}
+		alive := c.aliveCount()
+		kept := make([]*muxBwRouteState, 0, len(c.active))
+		for i, r := range c.active {
+			if _, drop := toDrop[i]; drop && r.activeFlag.Load() && alive > 1 {
+				if r.pumpCancel != nil {
+					r.pumpCancel()
+				}
+				r.activeFlag.Store(false)
+				alive--
+				c.emitLifecycle("dropped", r, "dropped", elapsed())
+				continue
+			}
+			kept = append(kept, r)
+		}
+		c.active = kept
+	}
+
+	if action.AddLeg {
+		c.addLeg(pumpCtx, action.ExcludeHops, pumpStart)
+	}
+}
+
+// legAt returns the active leg at snapshot position idx, or nil if out of range
+// (a stale index from a snapshot the mutation already invalidated).
+func (c *muxBwController) legAt(idx int) *muxBwRouteState {
+	if idx < 0 || idx >= len(c.active) {
+		return nil
+	}
+	return c.active[idx]
+}
+
+// aliveCount counts active-set legs whose pump goroutine is still running.
+func (c *muxBwController) aliveCount() int {
+	n := 0
+	for _, r := range c.active {
+		if r.activeFlag.Load() {
+			n++
+		}
+	}
+	return n
+}
+
+// activePumpCount counts active-set legs that are actually pumping (alive and
+// not parked on warm standby) — the count a demote must keep >= 1.
+func (c *muxBwController) activePumpCount() int {
+	n := 0
+	for _, r := range c.active {
+		if r.activeFlag.Load() && !r.standby.Load() {
+			n++
+		}
+	}
+	return n
+}
+
+// addLeg plans one fresh disjoint route whose intermediates avoid both the
+// current legs' intermediates and the policy-supplied excludeHops, sets it up,
+// and — on success — appends it to the leg set and spawns its pump. Best-effort:
+// a planning / setup miss is logged and leaves the leg set unchanged, matching
+// the route group's add-leg semantics.
+func (c *muxBwController) addLeg(pumpCtx context.Context, excludeHops []string, pumpStart time.Time) {
+	exclude := map[string]struct{}{}
+	for _, h := range excludeHops {
+		exclude[h] = struct{}{}
+	}
+	for _, r := range c.active {
+		if r.intermediatePK != "" {
+			exclude[r.intermediatePK] = struct{}{}
+		}
+	}
+
+	// Ask for more candidates than we have legs so at least one avoids the
+	// exclude set even after the planner drops overlapping ones.
+	want := len(c.active) + len(exclude) + 2
+	plans, err := c.s.muxBwPlanDisjointRoutes(pumpCtx, c.cfg.TargetPK, c.cfg.MinHops, defaultMuxBwMaxHops, want)
+	if err != nil || len(plans) == 0 {
+		c.s.log.Debugf("policy-bw: add-leg planning yielded nothing (%v); keeping leg set", err)
+		return
+	}
+	var chosen *muxBwRoutePlan
+	for i := range plans {
+		p := &plans[i]
+		if len(p.forward) == 0 {
+			continue
+		}
+		overlap := false
+		for _, h := range p.forward {
+			if _, bad := exclude[h.To]; bad && h.To != "" {
+				overlap = true
+				break
+			}
+		}
+		if !overlap {
+			chosen = p
+			break
+		}
+	}
+	if chosen == nil {
+		c.s.log.Debugf("policy-bw: add-leg found no disjoint path; keeping leg set")
+		return
+	}
+
+	rs := &muxBwRouteState{index: c.nextIndex, fwdHops: chosen.forward, revHops: chosen.reverse}
+	c.nextIndex++
+	c.s.muxBwSetupRoute(pumpCtx, c.cfg, rs, muxBwDropRouteEstablished(c.emit))
+	if !rs.established.Load() {
+		c.s.log.Debugf("policy-bw: add-leg setup failed for index %d; keeping leg set", rs.index)
+		return
+	}
+	rs.activeFlag.Store(true)
+	c.all = append(c.all, rs)
+	c.active = append(c.active, rs)
+	c.spawnPump(pumpCtx, rs, pumpStart)
+	c.emitLifecycle("added", rs, "active", time.Since(pumpStart).Nanoseconds())
+}
+
+// emitLifecycle emits a MuxLegLifecycle event onto the stream.
+func (c *muxBwController) emitLifecycle(event string, rs *muxBwRouteState, gate string, elapsedNs int64) {
+	c.emit(&MuxBandwidthEvent_LegLifecycle{LegLifecycle: &MuxLegLifecycle{
+		Event:          event,
+		RouteIndex:     int32(rs.index), //nolint:gosec // route index fits int32
+		GateState:      gate,
+		IntermediatePk: rs.intermediatePK,
+		TransportKind:  rs.transportKind,
+		ElapsedNs:      elapsedNs,
+	}})
+}
+
+// totals sums the bytes pumped by EVERY leg the run ever had (including legs
+// later dropped — their traffic really happened). Read after controlLoop exits.
+func (c *muxBwController) totals() (sent, recv uint64) {
+	for _, r := range c.all {
+		sent += r.bytesSent.Load()
+		recv += r.bytesRecv.Load()
+	}
+	return sent, recv
+}
+
+// peaks returns the peak instant send/recv rates the sampler observed.
+func (c *muxBwController) peaks() (send, recv float64) {
+	if c.tracker == nil {
+		return 0, 0
+	}
+	return c.tracker.peakSend, c.tracker.peakRecv
+}

--- a/pkg/visor/rpcgrpc/server_policy_bandwidth_test.go
+++ b/pkg/visor/rpcgrpc/server_policy_bandwidth_test.go
@@ -1,0 +1,172 @@
+package rpcgrpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/router/policy"
+)
+
+// newTestController builds a controller with n active legs (indices 0..n-1),
+// each alive with a distinct intermediate PK and a no-op pumpCancel, plus a
+// lifecycle-event sink. No PingServer.visor is wired, so tests must not trigger
+// AddLeg (which needs the disjoint planner). Mirrors the fixture style of
+// route_mux_standby_test.go.
+func newTestController(n int) (*muxBwController, *[]*MuxLegLifecycle) {
+	events := &[]*MuxLegLifecycle{}
+	c := &muxBwController{
+		cfg:       &muxBwCfg{},
+		nextIndex: n,
+		emit: func(p isMuxBandwidthEvent_Payload) {
+			if ev, ok := p.(*MuxBandwidthEvent_LegLifecycle); ok {
+				*events = append(*events, ev.LegLifecycle)
+			}
+		},
+	}
+	for i := 0; i < n; i++ {
+		rs := &muxBwRouteState{index: i, intermediatePK: string(rune('A' + i))}
+		rs.activeFlag.Store(true)
+		rs.pumpCancel = func() {} // drop cancels the pump; no goroutine here
+		c.all = append(c.all, rs)
+		c.active = append(c.active, rs)
+	}
+	return c, events
+}
+
+func gateStates(c *muxBwController) []bool {
+	out := make([]bool, len(c.active))
+	for i, r := range c.active {
+		out[i] = r.standby.Load()
+	}
+	return out
+}
+
+// TestApplyRotationDemotePromote pins the warm-standby executor: a demoted leg
+// flips its standby gate (kept in the active slice, not pumping) and a promote
+// clears it instantly — the in-process analog of routeMux.setLegStandby. Also
+// pins the invariant that the executor refuses to park the last pumping leg.
+func TestApplyRotationDemotePromote(t *testing.T) {
+	c, events := newTestController(3)
+	ctx := context.Background()
+	start := time.Now()
+
+	// Demote leg 1 to warm standby.
+	c.applyRotation(ctx, policy.RotationAction{DemoteToStandby: []int{1}}, start)
+	if got := gateStates(c); got[1] != true || got[0] || got[2] {
+		t.Fatalf("after demote leg 1: gate states = %v, want only leg 1 standby", got)
+	}
+	if len(c.active) != 3 {
+		t.Fatalf("demote must not remove the leg; len(active)=%d want 3", len(c.active))
+	}
+
+	// Promote leg 1 back to active — instant, no re-dial.
+	c.applyRotation(ctx, policy.RotationAction{PromoteFromStandby: []int{1}}, start)
+	if got := gateStates(c); got[1] {
+		t.Fatalf("after promote leg 1: leg 1 still standby (%v)", got)
+	}
+
+	// Refuse to demote the last pumping leg: demote 0 and 1, leaving only 2 —
+	// the executor must keep at least one pumping leg.
+	c.applyRotation(ctx, policy.RotationAction{DemoteToStandby: []int{0, 1, 2}}, start)
+	if c.activePumpCount() < 1 {
+		t.Fatalf("executor parked every leg on standby; activePumpCount=%d", c.activePumpCount())
+	}
+
+	// A promote/demote pair must have emitted lifecycle events with gate_state.
+	sawDemote, sawPromote := false, false
+	for _, ev := range *events {
+		switch ev.Event {
+		case "demoted":
+			if ev.GateState != "standby" {
+				t.Errorf("demoted event gate_state=%q want standby", ev.GateState)
+			}
+			sawDemote = true
+		case "promoted":
+			if ev.GateState != "active" {
+				t.Errorf("promoted event gate_state=%q want active", ev.GateState)
+			}
+			sawPromote = true
+		}
+	}
+	if !sawDemote || !sawPromote {
+		t.Errorf("missing lifecycle events: sawDemote=%v sawPromote=%v", sawDemote, sawPromote)
+	}
+}
+
+// TestApplyRotationDropReindexes pins the drop path: the dropped legs leave the
+// active slice (so subsequent snapshots re-index, matching route-group
+// semantics), their pump is cancelled + flagged inactive, and the executor
+// never drops the last alive leg.
+func TestApplyRotationDropReindexes(t *testing.T) {
+	c, events := newTestController(4)
+	start := time.Now()
+
+	cancelled := make([]bool, 4)
+	for i := range c.active {
+		i := i
+		c.active[i].pumpCancel = func() { cancelled[i] = true }
+	}
+
+	// Drop legs at positions 0 and 2 (original indices 0 and 2).
+	c.applyRotation(context.Background(), policy.RotationAction{DropLegs: []int{0, 2}}, start)
+
+	if len(c.active) != 2 {
+		t.Fatalf("after dropping 2 of 4 legs: len(active)=%d want 2", len(c.active))
+	}
+	// Survivors are the original legs 1 and 3, now at positions 0 and 1.
+	if c.active[0].index != 1 || c.active[1].index != 3 {
+		t.Fatalf("drop did not compact correctly: survivor indices = %d,%d want 1,3",
+			c.active[0].index, c.active[1].index)
+	}
+	if !cancelled[0] || !cancelled[2] {
+		t.Errorf("dropped legs' pumps not cancelled: %v", cancelled)
+	}
+	if cancelled[1] || cancelled[3] {
+		t.Errorf("surviving legs' pumps wrongly cancelled: %v", cancelled)
+	}
+	// all[] retains every leg for the Done totals.
+	if len(c.all) != 4 {
+		t.Errorf("all[] must retain dropped legs for totals; len=%d want 4", len(c.all))
+	}
+
+	// snapshotLegs re-indexes to 0..1 on the compacted set.
+	legs := c.snapshotLegs()
+	if len(legs) != 2 || legs[0].Index != 0 || legs[1].Index != 1 {
+		t.Fatalf("snapshotLegs did not re-index after drop: %+v", legs)
+	}
+
+	// Now attempt to drop both survivors — the executor must keep the last
+	// alive leg.
+	c.applyRotation(context.Background(), policy.RotationAction{DropLegs: []int{0, 1}}, start)
+	if c.aliveCount() < 1 {
+		t.Fatalf("executor dropped the last alive leg; aliveCount=%d", c.aliveCount())
+	}
+
+	dropped := 0
+	for _, ev := range *events {
+		if ev.Event == "dropped" {
+			dropped++
+		}
+	}
+	if dropped < 2 {
+		t.Errorf("expected >=2 dropped lifecycle events, got %d", dropped)
+	}
+}
+
+// TestSnapshotLegsTransportIDStable pins that TransportID keys per leg on the
+// stable intermediate PK (so a preset can smooth an EWMA across ticks), and
+// falls back to the route index for a leg with no intermediate.
+func TestSnapshotLegsTransportIDStable(t *testing.T) {
+	c, _ := newTestController(2)
+	c.active[0].intermediatePK = "PKA"
+	c.active[1].intermediatePK = "" // direct-style leg, no intermediate
+
+	legs := c.snapshotLegs()
+	if legs[0].TransportID != "PKA" {
+		t.Errorf("leg 0 TransportID=%q want PKA", legs[0].TransportID)
+	}
+	if legs[1].TransportID != "idx:1" {
+		t.Errorf("leg 1 TransportID=%q want idx:1 fallback", legs[1].TransportID)
+	}
+}


### PR DESCRIPTION
## Why

To prove the WASM routing-policy presets are demonstrably adaptive, we need a preset *driving* a live multiplexed route with per-leg telemetry against a controlled far-end. The app forward path (`skynet start --routes N --routing-policy preset:X`) runs the policy but carries **0 bytes at mux>1** (#80: yamux-over-multi-route reassembly break). The in-process `mux-bw` rig carries mux fine (proven: 3 routes = 2.9× single, per-leg NDJSON, cascade/setup-node routes, TPD-independent) but plans its own routes and ignores the policy.

This wires the **standalone `policy.Engine`** into the mux-bw rig as a sibling command `policy-bw` — so the real presets drive the leg set over the working in-process mux, sidestepping #80 entirely (independent routes, no shared yamux to break).

## What it does

`skywire cli visor ping policy-bw <peer> --routing-policy preset:<name> --routes N --min-hops 2 --duration 5m -O x.ndjson`

- **on_dial** (`decide_route`) picks the mux leg count + min-hops (`RouteSpec.Mux`/`MinHops`); `muxBwPlanDisjointRoutes` still selects the disjoint intermediates.
- **on_tick** fires on the preset's rotation cadence with per-leg `{SentBytes, RecvBytes, LatencyMs(EWMA), Alive, Standby, TransportID}` — the gate-6 ABI — and applies the returned `RotationAction`: drop a slow leg, add a fresh disjoint one, promote/demote **warm standbys** (kept alive with a keepalive ping, promoted with no re-dial — gate-5 in-process).
- **leg_lifecycle** events (added/dropped/promoted/demoted + `gate_state`) interleave with per-leg `sample` records in the NDJSON, so the gate-2 chart renders hot-swaps.
- Reuses the combined `bundle.wasm` via `wasmpresets.Bundle()` — `preset:<name>` selectable (gate-1 substrate).

The pure `mux-bw` baseline is byte-for-byte unchanged (the policy path is taken only when `routing_policy` is set).

## Test
- `go build ./...` exit 0; `go vet ./pkg/visor/rpcgrpc/` clean; `gofmt` clean.
- `pkg/visor/rpcgrpc` suite (incl. existing mux-bw tests) green; new executor unit tests (`TestApplyRotationDemotePromote`, `TestApplyRotationDropReindexes`, `TestSnapshotLegsTransportIDStable`) pass — the RotationAction executor preserves route-group LegInfo semantics (reindex-on-drop, TransportID-keyed EWMA).
- CLI registers; `--routing-policy` required-flag enforced.

Gives gates 1/4/5/6 in one tool on top of gates 2/3 already proven live. Next: per-preset ≥5-min runs against the controlled far-end (rotating-bw disjoint drift no-dip, latency-adaptive slow-leg eviction, elastic-mux width scaling) as the demonstrable-adaptivity artifacts.