### PR TITLE
fix(routing-policy): serialize policy-bw leg_lifecycle events to NDJSON

### DIFF
--- a/cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go
+++ b/cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go
@@ -649,6 +649,12 @@ func classifyMuxBwEvent(ev *rpcgrpc.MuxBandwidthEvent) (string, proto.Message) {
 		return "error", p.Error
 	case *rpcgrpc.MuxBandwidthEvent_RouteFailure:
 		return "route_failure", p.RouteFailure
+	case *rpcgrpc.MuxBandwidthEvent_LegLifecycle:
+		// policy-bw leg-set mutations (added/dropped/promoted/demoted +
+		// gate_state). Without this case the NDJSON emitted them as
+		// {"type":"unknown","data":{}} — invisible to the gate-2 chart, which
+		// renders policy events as markers over the per-leg time series.
+		return "leg_lifecycle", p.LegLifecycle
 	}
 	return "unknown", &rpcgrpc.MuxBandwidthError{}
 }


### PR DESCRIPTION
The `policy-bw` NDJSON type-mapper (`classifyMuxBwEvent`) was missing the `MuxBandwidthEvent_LegLifecycle` case, so every policy leg-set mutation (added/dropped/promoted/demoted + `gate_state`) serialized as `{"type":"unknown","data":{}}`. The events fired on the preset's cadence but carried no payload — so the gate-2 telemetry chart couldn't render policy-event markers.

Found while running the first live per-preset proofs (#4015): a 5-min rotating-bw run emitted 5 lifecycle events at its 90s cadence, all empty. The human-readable printer already handled this case (mux_bandwidth.go:374); only the NDJSON mapper was missing it. One-line + comment; no behavior change to the rig.

Part of proving the presets adaptive (gate-2/4): rotating-bw (warm-standby leg rotates every 90s, disjoint, ~16.5 Mbps sustained) and elastic-mux (width 2→6) are demonstrably adaptive live; this makes their policy events legible in the NDJSON/chart.