### PR TITLE
fix(tpd-cxo): make TPD's published feeds fillable by subscribers (live CXO data)

### DIFF
--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -875,6 +875,18 @@ func (s *Subscriber) handleFillingBreaks(r *registry.Root, err error) {
 	if r.Pub != skycipher.PubKey(s.feedPK) {
 		return
 	}
+	// Best-effort partial-object salvage. CXO fills top-down and keeps
+	// whatever objects it fetched before the break (the filler doesn't roll
+	// the store back), so a truncated fill of a big/deep tree usually still
+	// has SOME leaves present. handleRootFilled never fires for a broken
+	// fill, so without this the subscriber cache stays empty (or stale) until
+	// a later fill completes end-to-end — the failure mode that leaves TPD's
+	// big serve-side feeds (all-transports, per-visor uptimes) permanently
+	// cache-missing over a flaky link. Walk the partially-filled tree,
+	// tolerating unfetched objects, and MERGE whatever leaves landed into the
+	// cache. This is the subscriber-side analog of the aggregator's
+	// recoverTransportListOnBreak (pkg/transport-discovery/cxoaggregator).
+	s.recoverPartialFill(r)
 	// Proactive recovery (the follow-up this hook's comment anticipated):
 	// ask the watchdog to re-Connect so the publisher re-pushes the Root and
 	// the fill retries, instead of waiting out the quiet threshold (~90s).
@@ -954,6 +966,93 @@ func (s *Subscriber) applySnapshot(snap map[string][]byte) {
 	}
 	if len(changes) > 0 {
 		cb(changes)
+	}
+}
+
+// recoverPartialFill is the OnFillingBreaks salvage path. It walks the
+// (partially filled) Root tree tolerantly — skipping any object the fill
+// never fetched instead of aborting on the first miss — and merges whatever
+// leaves ARE present into the cache. Used only to add/refresh leaves: it
+// never deletes (a leaf absent here may simply not have been fetched, not
+// removed by the publisher), so a partial fill can only improve the cache.
+func (s *Subscriber) recoverPartialFill(r *registry.Root) {
+	if r == nil || len(r.Refs) == 0 {
+		return
+	}
+	pack, err := s.cxoNode.Container().Pack(r, Registry)
+	if err != nil {
+		return
+	}
+	var rootNode TreeNode
+	if err := r.Refs[0].Value(pack, &rootNode); err != nil {
+		return // the root TreeNode object itself wasn't fetched before the break
+	}
+	recovered := make(map[string][]byte)
+	walkTreeBestEffort(pack, &rootNode, "", recovered)
+	if len(recovered) == 0 {
+		return
+	}
+	s.mergePartialSnapshot(recovered)
+}
+
+// mergePartialSnapshot merges recovered leaves into the cache (insert or
+// update only, never delete) and fires the change callback for the leaves
+// that actually changed. Unlike applySnapshot it keeps existing entries that
+// aren't in recovered, so a partial salvage never discards good data.
+func (s *Subscriber) mergePartialSnapshot(recovered map[string][]byte) {
+	s.mu.Lock()
+	if s.cache == nil {
+		s.cache = make(map[string][]byte)
+	}
+	var changes []UpdateEvent
+	cb := s.callback
+	prefixes := s.prefixes
+	for path, newVal := range recovered {
+		if old, had := s.cache[path]; had && bytesEqual(old, newVal) {
+			continue
+		}
+		s.cache[path] = newVal
+		if cb != nil && pathMatchesAny(path, prefixes) {
+			changes = append(changes, UpdateEvent{Path: path, Value: append([]byte(nil), newVal...)})
+		}
+	}
+	s.mu.Unlock()
+
+	if cb != nil && len(changes) > 0 {
+		cb(changes)
+	}
+}
+
+// walkTreeBestEffort is the fault-tolerant variant of walkTree used for
+// partial-fill salvage: a child whose index/sub/leaf object was never
+// fetched (its Value call errors) is simply skipped rather than aborting the
+// whole walk, so every leaf that DID land is still collected.
+func walkTreeBestEffort(pack registry.Pack, node *TreeNode, basePath string, out map[string][]byte) {
+	n, err := node.Children.Len(pack)
+	if err != nil {
+		return
+	}
+	for i := 0; i < n; i++ {
+		var entry TreeEntry
+		if _, err := node.Children.ValueByIndex(pack, i, &entry); err != nil {
+			continue // this child's index object wasn't fetched; skip it
+		}
+		fullPath := entry.Name
+		if basePath != "" {
+			fullPath = basePath + "/" + entry.Name
+		}
+		if len(entry.Leaf) > 0 {
+			out[fullPath] = append([]byte(nil), entry.Leaf...)
+			continue
+		}
+		if entry.Sub.Hash == (skycipher.SHA256{}) {
+			continue
+		}
+		var sub TreeNode
+		if err := entry.Sub.Value(pack, &sub); err != nil {
+			continue // sub-node object not fetched before the break; skip
+		}
+		walkTreeBestEffort(pack, &sub, fullPath, out)
 	}
 }
 

--- a/pkg/cxo/treestore/subscriber_test.go
+++ b/pkg/cxo/treestore/subscriber_test.go
@@ -229,6 +229,58 @@ func TestConnectAndWaitForRootResetsSignal(t *testing.T) {
 	}
 }
 
+// TestSubscriberMergePartialSnapshotInsertUpdateOnly verifies the
+// OnFillingBreaks salvage path: recovered leaves are inserted/updated into
+// the cache and fire change events, an unchanged leaf is a no-op, and leaves
+// already in the cache but ABSENT from the partial recovery are preserved
+// (a partial fill must never delete).
+func TestSubscriberMergePartialSnapshotInsertUpdateOnly(t *testing.T) {
+	s := newTestSubscriber(t)
+	// Seed a prior good snapshot.
+	s.applySnapshot(map[string][]byte{
+		"keep/a": []byte("A"),
+		"upd/b":  []byte("B"),
+	})
+
+	var (
+		gotMu sync.Mutex
+		got   []UpdateEvent
+	)
+	s.OnUpdate(func(changes []UpdateEvent) {
+		gotMu.Lock()
+		defer gotMu.Unlock()
+		got = append(got, changes...)
+	})
+
+	// Partial salvage: upd/b changed, keep/a unchanged (no-op), new/c added.
+	// keep/a is intentionally re-supplied unchanged; new/c is new; the
+	// pre-existing keep/a must survive regardless.
+	s.mergePartialSnapshot(map[string][]byte{
+		"keep/a": []byte("A"),
+		"upd/b":  []byte("B2"),
+		"new/c":  []byte("C"),
+	})
+
+	gotMu.Lock()
+	paths := pathsOf(got)
+	gotMu.Unlock()
+	sort.Strings(paths)
+	if len(paths) != 2 || paths[0] != "new/c" || paths[1] != "upd/b" {
+		t.Fatalf("merge fired events for %v, want [new/c upd/b]", paths)
+	}
+
+	// Cache reflects the merge and preserves the untouched prior leaf.
+	if v, ok := s.Get("keep/a"); !ok || string(v) != "A" {
+		t.Errorf("keep/a = %q,%v; want A,true (preserved)", v, ok)
+	}
+	if v, ok := s.Get("upd/b"); !ok || string(v) != "B2" {
+		t.Errorf("upd/b = %q,%v; want B2,true (updated)", v, ok)
+	}
+	if v, ok := s.Get("new/c"); !ok || string(v) != "C" {
+		t.Errorf("new/c = %q,%v; want C,true (inserted)", v, ok)
+	}
+}
+
 func pathsOf(events []UpdateEvent) []string {
 	out := make([]string, 0, len(events))
 	for _, e := range events {

--- a/pkg/tpviz/cxo_standalone.go
+++ b/pkg/tpviz/cxo_standalone.go
@@ -14,11 +14,15 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cxo/cxosub"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/transport-discovery/store"
 )
 
@@ -165,8 +169,9 @@ func (s *Server) tryCXOUptimes() ([]byte, bool) {
 
 // tryCXOTransports returns the all-transports JSON snapshot from the TPD
 // all-transports feed's local snapshot (the network-wide "without-self" leaf),
-// or ok=false on cache miss. The leaf body is the same JSON GET /all-transports
-// serves, so it forwards unchanged.
+// or ok=false on cache miss. The publisher gzips the leaf and drops each
+// entry's derivable t_id, so the body is gunzipped and its t_id recomputed
+// here — yielding the same plain JSON GET /all-transports serves.
 func (s *Server) tryCXOTransports() ([]byte, bool) {
 	mgr := s.cxoMgr()
 	if mgr == nil {
@@ -183,10 +188,39 @@ func (s *Server) tryCXOTransports() ([]byte, bool) {
 		return true
 	})
 	if b, ok := leaves["transports/all/without-self"]; ok {
-		return b, true
+		return restoreAllTransportsBody(b), true
 	}
 	for _, b := range leaves { // any leaf beats a fallback HTTP round-trip
-		return b, true
+		return restoreAllTransportsBody(b), true
 	}
 	return nil, false
+}
+
+// restoreAllTransportsBody gunzips the published all-transports leaf (a no-op
+// on an already-plain body) and recomputes any derivable t_id the publisher
+// dropped, so the UI sees the same shape GET /all-transports returns. On any
+// decode error the gunzipped bytes are returned as-is.
+func restoreAllTransportsBody(body []byte) []byte {
+	body = cxoutils.Gunzip(body)
+	if len(body) == 0 {
+		return body
+	}
+	var entries []*transport.Entry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return body
+	}
+	changed := false
+	for _, e := range entries {
+		if e != nil && e.ID == (uuid.UUID{}) {
+			e.ID = transport.MakeTransportID(e.Edges[0], e.Edges[1], e.Type)
+			changed = true
+		}
+	}
+	if !changed {
+		return body
+	}
+	if out, err := json.Marshal(entries); err == nil {
+		return out
+	}
+	return body
 }

--- a/pkg/tpviz/cxo_standalone.go
+++ b/pkg/tpviz/cxo_standalone.go
@@ -11,6 +11,7 @@
 package tpviz
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -18,7 +19,20 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport-discovery/store"
 )
+
+// compactVisorSummaryLeaf mirrors the per-visor uptime leaf the TPD publisher
+// writes at uptimes/days/<n>/<pkHex> (see cxo_uptime_publisher.go). Re-declared
+// here to keep the dependency direction one-way; the reward-server UI only
+// needs the v2 fields (pk/on/version/daily), so the bitmap timeline is decoded
+// but not carried forward.
+type compactVisorSummaryLeaf struct {
+	PK      cipher.PubKey     `json:"pk"`
+	Online  bool              `json:"on"`
+	Version string            `json:"v,omitempty"`
+	Daily   map[string]string `json:"d,omitempty"`
+}
 
 // SetCXOSubMgrFromDmsg wires an intermittent CXO subscriber over dmsgC so a
 // STANDALONE tp-viz sources deployment data from the TPD/SD/DMSG-D CXO feeds.
@@ -85,11 +99,15 @@ func parseCXOPeer(raw string) cipher.PubKey {
 	return u.Addr.PK
 }
 
-// tryCXOUptimes returns the []VisorSummary JSON from the TPD uptime feed's
-// local snapshot (any day-window leaf carries the current online status), or
-// ok=false when the manager isn't wired / the feed hasn't synced yet — in which
-// case the caller falls through to its HTTP fetch. The body is byte-identical to
-// what GET /uptimes?v=v2 serves, so it's forwarded to the UI unchanged.
+// tryCXOUptimes returns the []VisorSummary (v2: pk/on/version/daily) JSON from
+// the TPD uptime feed's local snapshot, or ok=false when the manager isn't
+// wired / the feed hasn't synced yet — in which case the caller falls through
+// to its HTTP fetch.
+//
+// Dual-parse for the publisher rollout: the current TPD publishes one small
+// per-visor leaf at uptimes/days/<n>/<pkHex> (a compactVisorSummaryLeaf), so
+// the snapshot is reassembled into a []VisorSummary; a legacy publisher's
+// monolithic array leaf (parses as a JSON array) is forwarded verbatim.
 func (s *Server) tryCXOUptimes() ([]byte, bool) {
 	mgr := s.cxoMgr()
 	if mgr == nil {
@@ -98,15 +116,48 @@ func (s *Server) tryCXOUptimes() ([]byte, bool) {
 	mgr.AcquireForTab(CXOTabUptime)
 	defer mgr.ReleaseForTab(CXOTabUptime)
 
-	var out []byte
-	mgr.Walk(CXOFeedTPDUptime, "uptimes/days/", func(_ string, body []byte) bool {
-		if len(body) > 0 && string(body) != "null" {
-			out = append([]byte(nil), body...)
-			return false // first non-empty leaf is enough
+	// The snapshot holds every published day-window (1/7/30). The UI needs only
+	// the current online status, which is identical across windows, so
+	// reassemble a single window to avoid emitting each visor 1x per window.
+	const window = "uptimes/days/1"
+	var (
+		monolith  []byte
+		summaries []store.VisorSummary
+	)
+	mgr.Walk(CXOFeedTPDUptime, "uptimes/days/", func(path string, body []byte) bool {
+		if len(body) == 0 || string(body) == "null" {
+			return true
 		}
+		// Legacy monolith: a whole []VisorSummary array in one leaf at exactly
+		// uptimes/days/<n>. Any window's array carries the online status.
+		if body[0] == '[' {
+			monolith = append([]byte(nil), body...)
+			return false
+		}
+		// Current per-visor leaf: only the chosen window's children.
+		if len(path) <= len(window)+1 || path[:len(window)+1] != window+"/" {
+			return true
+		}
+		var c compactVisorSummaryLeaf
+		if err := json.Unmarshal(body, &c); err != nil {
+			return true // skip a malformed leaf; keep reassembling the rest
+		}
+		summaries = append(summaries, store.VisorSummary{
+			PK:      c.PK,
+			Online:  c.Online,
+			Version: c.Version,
+			Daily:   c.Daily,
+		})
 		return true
 	})
-	if out == nil {
+	if monolith != nil {
+		return monolith, true
+	}
+	if len(summaries) == 0 {
+		return nil, false
+	}
+	out, err := json.Marshal(summaries)
+	if err != nil {
 		return nil, false
 	}
 	return out, true

--- a/pkg/transport-discovery/api/cxo_all_transports_publisher.go
+++ b/pkg/transport-discovery/api/cxo_all_transports_publisher.go
@@ -30,7 +30,46 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/transport"
+	types "github.com/skycoin/skywire/pkg/transport/types"
 )
+
+// allTransportsWireEntry is the published shape of one transport in the
+// all-transports snapshot. It mirrors transport.Entry MINUS the t_id: the ID
+// is a deterministic hash of (edges, type), so it is fully derivable by the
+// reader (transport.MakeTransportID) and shipping it wastes ~25% of the
+// compressed body — a UUID is high-entropy and does not gzip away. The reader
+// (pkg/visor's FetchAllTransportsCXO) reconstructs the full transport.Entry,
+// recomputing t_id. Keep the JSON tags aligned with transport.Entry so an
+// older subscriber that unmarshals straight into transport.Entry still reads
+// every field it recognizes.
+type allTransportsWireEntry struct {
+	Edges         [2]cipher.PubKey `json:"edges"`
+	Type          types.Type       `json:"type"`
+	Label         transport.Label  `json:"label"`
+	Latency       float64          `json:"latency_ms,omitempty"`
+	Bandwidth     uint64           `json:"bandwidth,omitempty"`
+	ThroughputBps float64          `json:"throughput_bps,omitempty"`
+}
+
+// toWireEntries drops the derivable t_id from each entry for publication.
+func toWireEntries(entries []*transport.Entry) []allTransportsWireEntry {
+	out := make([]allTransportsWireEntry, 0, len(entries))
+	for _, e := range entries {
+		if e == nil {
+			continue
+		}
+		out = append(out, allTransportsWireEntry{
+			Edges:         e.Edges,
+			Type:          e.Type,
+			Label:         e.Label,
+			Latency:       e.Latency,
+			Bandwidth:     e.Bandwidth,
+			ThroughputBps: e.ThroughputBps,
+		})
+	}
+	return out
+}
 
 // allTransportsPublishInterval is the recompute cadence. 60s matches
 // the metrics/uptime publishers; the store's allTransportsCache
@@ -138,7 +177,7 @@ func (a *AllTransportsCXOPublisher) publishOnce(ctx context.Context) {
 			a.recordError(err)
 			continue
 		}
-		body, err := json.Marshal(entries)
+		body, err := json.Marshal(toWireEntries(entries))
 		if err != nil {
 			a.log.WithError(err).WithField("path", v.path).Warn("all-transports marshal failed")
 			a.recordError(err)

--- a/pkg/transport-discovery/api/cxo_uptime_publisher.go
+++ b/pkg/transport-discovery/api/cxo_uptime_publisher.go
@@ -41,8 +41,16 @@ var uptimePublishDays = []int{1, 7, 30}
 // would just republish identical Roots.
 const uptimePublishInterval = 60 * time.Second
 
-// UptimeCXOPublisher publishes `[]VisorSummary` (v3 shape) for each
-// of uptimePublishDays at "uptimes/days/<n>". Closed by Close.
+// UptimeCXOPublisher publishes the network-wide visor-uptime aggregate for
+// each of uptimePublishDays. Rather than one monolithic `[]VisorSummary` leaf
+// per window at "uptimes/days/<n>" (which, at fleet scale with the v3 288-char
+// timeline strings, exceeded CXO's 16 MB MaxObjectSize and failed the Put with
+// "object is too large" — the serve-side feed the subscriber could never
+// fill), it writes one small per-visor leaf at "uptimes/days/<n>/<pkHex>". No
+// single object is fleet-sized, so the Put always succeeds; content-addressing
+// re-broadcasts only the visors whose bucket changed; and a subscriber whose
+// fill truncates still salvages every per-visor leaf that landed (see the
+// treestore subscriber's partial-fill recovery). Closed by Close.
 type UptimeCXOPublisher struct {
 	api *API
 	pub *treestore.Publisher
@@ -51,8 +59,31 @@ type UptimeCXOPublisher struct {
 	cancel context.CancelFunc
 	done   chan struct{}
 
+	// prevPKs tracks, per day-window, the set of per-visor leaf hex-PK
+	// segments published on the previous tick, so this tick can emit delete
+	// ops for visors that dropped out of the aggregate (a naive Put-only
+	// refresh would leave their stale leaves lingering forever). Touched only
+	// from the single publish loop goroutine, so no lock.
+	prevPKs map[int]map[string]struct{}
+
 	mu        sync.Mutex
 	lastError error
+}
+
+// compactVisorSummary is the space-optimized per-visor uptime leaf written at
+// "uptimes/days/<n>/<pkHex>". It carries the same data as store.VisorSummary
+// but encodes each day's Timeline as the raw 36-byte MSB-first bitmap (base64
+// in JSON) instead of the 288-char '.'/' ' string — 8x smaller for the field
+// that dominates the payload and the reason the monolithic leaf blew past
+// MaxObjectSize. Re-declared verbatim on the reader side (pkg/visor's
+// FetchVisorUptimeCXO), which reconstructs the full store.VisorSummary v3
+// shape; keep the JSON tags in sync across both.
+type compactVisorSummary struct {
+	PK       cipher.PubKey     `json:"pk"`
+	Online   bool              `json:"on"`
+	Version  string            `json:"v,omitempty"`
+	Daily    map[string]string `json:"d,omitempty"`
+	Timeline map[string][]byte `json:"tb,omitempty"` // date -> 36-byte bitmap
 }
 
 // StartUptimeCXOPublisher constructs a publisher backed by the given
@@ -79,11 +110,12 @@ func StartUptimeCXOPublisher(ctx context.Context, api *API, dmsgC *dmsg.Client, 
 
 	pubCtx, cancel := context.WithCancel(ctx)
 	up := &UptimeCXOPublisher{
-		api:    api,
-		pub:    pub,
-		log:    log,
-		cancel: cancel,
-		done:   make(chan struct{}),
+		api:     api,
+		pub:     pub,
+		log:     log,
+		cancel:  cancel,
+		done:    make(chan struct{}),
+		prevPKs: make(map[int]map[string]struct{}),
 	}
 	if logger != nil {
 		logger.WithField("feed_pk", pub.Feed()).WithField("dmsg_port", skyenv.DmsgTPDUptimeCXOPort).
@@ -149,19 +181,77 @@ func (u *UptimeCXOPublisher) publishOnce(ctx context.Context) {
 		// Trim Daily and Timeline to the requested day window so the
 		// payload doesn't carry more than the subscriber asked for.
 		trimmed := trimSummariesToDays(enriched, days, now)
-		body, err := json.Marshal(trimmed)
+		u.publishWindow(days, trimmed)
+	}
+}
+
+// publishWindow writes one small per-visor leaf at "uptimes/days/<n>/<pkHex>"
+// for every summary, plus delete ops for any visor published last tick that
+// is gone this tick, in a single PutBatch. Splitting the window into per-visor
+// leaves (each a compactVisorSummary with bitmap timelines) keeps every CXO
+// object well under MaxObjectSize — the whole point of the change: the
+// monolithic []VisorSummary leaf failed the Put once the fleet's v3 timelines
+// pushed it past 16 MB.
+func (u *UptimeCXOPublisher) publishWindow(days int, summaries []store.VisorSummary) {
+	base := uptimePath(days)
+	live := make(map[string]struct{}, len(summaries))
+	ops := make([]treestore.PutOp, 0, len(summaries))
+	for i := range summaries {
+		hexPK := summaries[i].PK.Hex()
+		body, err := json.Marshal(toCompactVisorSummary(summaries[i]))
 		if err != nil {
-			u.log.WithError(err).WithField("days", days).Warn("uptime marshal failed")
+			u.log.WithError(err).WithField("days", days).Warn("uptime per-visor marshal failed")
 			u.recordError(err)
 			continue
 		}
-		path := uptimePath(days)
-		if err := u.pub.Put(path, body); err != nil {
-			u.log.WithError(err).WithField("path", path).Warn("uptime publisher Put failed")
-			u.recordError(err)
-			continue
+		live[hexPK] = struct{}{}
+		ops = append(ops, treestore.PutOp{Path: base + "/" + hexPK, Value: body})
+	}
+	// Delete leaves for visors that dropped out of the aggregate since the
+	// previous tick (nil Value = delete). Without this, a visor that leaves
+	// the cache keeps a stale leaf forever.
+	for hexPK := range u.prevPKs[days] {
+		if _, still := live[hexPK]; !still {
+			ops = append(ops, treestore.PutOp{Path: base + "/" + hexPK, Value: nil})
 		}
 	}
+	if err := u.pub.PutBatch(ops); err != nil {
+		u.log.WithError(err).WithField("days", days).Warn("uptime publisher PutBatch failed")
+		u.recordError(err)
+		return
+	}
+	u.prevPKs[days] = live
+}
+
+// toCompactVisorSummary converts a store.VisorSummary (v3 shape, 288-char
+// timeline strings) to the compact per-visor leaf shape, packing each day's
+// timeline into its 36-byte bitmap.
+func toCompactVisorSummary(s store.VisorSummary) compactVisorSummary {
+	c := compactVisorSummary{
+		PK:      s.PK,
+		Online:  s.Online,
+		Version: s.Version,
+		Daily:   s.Daily,
+	}
+	if len(s.Timeline) > 0 {
+		c.Timeline = make(map[string][]byte, len(s.Timeline))
+		for date, line := range s.Timeline {
+			c.Timeline[date] = timelineStringToBitmap(line)
+		}
+	}
+	return c
+}
+
+// timelineStringToBitmap packs a v3 288-char '.'/' ' timeline string into the
+// 36-byte MSB-first bitmap redis/pkg/visor-stats already use ('.' = bit set).
+func timelineStringToBitmap(line string) []byte {
+	bm := make([]byte, 36)
+	for i := 0; i < len(line) && i < 288; i++ {
+		if line[i] == '.' {
+			bm[i/8] |= 1 << uint(7-i%8)
+		}
+	}
+	return bm
 }
 
 func (u *UptimeCXOPublisher) recordError(err error) {

--- a/pkg/transport-discovery/api/cxo_uptime_publisher_test.go
+++ b/pkg/transport-discovery/api/cxo_uptime_publisher_test.go
@@ -1,0 +1,88 @@
+// Package api pkg/transport-discovery/api/cxo_uptime_publisher_test.go c4-net-discovery
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport-discovery/store"
+)
+
+// renderBitmap is the reference inverse of timelineStringToBitmap — the exact
+// logic the reader (pkg/visor) applies. Kept local so this test verifies the
+// publisher's packing against an independent renderer.
+func renderBitmap(bm []byte) string {
+	out := make([]byte, 288)
+	for i := range out {
+		if i/8 < len(bm) && bm[i/8]&(1<<uint(7-i%8)) != 0 {
+			out[i] = '.'
+		} else {
+			out[i] = ' '
+		}
+	}
+	return string(out)
+}
+
+func TestTimelineStringToBitmapRoundTrip(t *testing.T) {
+	// A representative 288-char line: some set slots (incl. bit 0 and bit 7,
+	// which live in the same byte at MSB/LSB), gaps, and a set slot at the end.
+	line := make([]byte, 288)
+	for i := range line {
+		line[i] = ' '
+	}
+	set := []int{0, 7, 8, 100, 200, 287}
+	for _, s := range set {
+		line[s] = '.'
+	}
+	bm := timelineStringToBitmap(string(line))
+	if len(bm) != 36 {
+		t.Fatalf("bitmap length = %d, want 36", len(bm))
+	}
+	if got := renderBitmap(bm); got != string(line) {
+		t.Fatalf("round-trip mismatch:\n got %q\nwant %q", got, string(line))
+	}
+}
+
+func TestToCompactVisorSummaryPreservesFields(t *testing.T) {
+	var pk cipher.PubKey
+	s := store.VisorSummary{
+		PK:      pk,
+		Online:  true,
+		Version: "v1.3.99",
+		Daily:   map[string]string{"2026-08-19": "1.0"},
+		Timeline: map[string]string{
+			"2026-08-19": func() string {
+				b := make([]byte, 288)
+				for i := range b {
+					b[i] = ' '
+				}
+				b[5] = '.'
+				return string(b)
+			}(),
+		},
+	}
+	c := toCompactVisorSummary(s)
+	if c.Online != s.Online || c.Version != s.Version {
+		t.Fatalf("scalar fields not preserved: %+v", c)
+	}
+	if c.Daily["2026-08-19"] != "1.0" {
+		t.Fatalf("daily not preserved: %+v", c.Daily)
+	}
+	bm := c.Timeline["2026-08-19"]
+	if len(bm) != 36 || !(bm[0] == 0x04) { // slot 5 -> bit (7-5)=2 in byte 0 => 0b00000100
+		t.Fatalf("timeline bitmap wrong: %x", bm)
+	}
+	// The whole compact summary must JSON round-trip (base64 for the bitmap).
+	blob, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back compactVisorSummary
+	if err := json.Unmarshal(blob, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if renderBitmap(back.Timeline["2026-08-19"]) != s.Timeline["2026-08-19"] {
+		t.Fatal("timeline did not survive JSON round-trip")
+	}
+}

--- a/pkg/visor/api_all_transports.go
+++ b/pkg/visor/api_all_transports.go
@@ -16,9 +16,13 @@
 package visor
 
 import (
+	"encoding/json"
 	"errors"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/transport"
 	tpdapi "github.com/skycoin/skywire/pkg/transport-discovery/api"
 )
 
@@ -49,5 +53,39 @@ func (v *Visor) FetchAllTransportsCXO(withSelf bool) ([]byte, error) {
 	}
 	// The CXO publisher gzips the snapshot; return decompressed JSON to callers
 	// (raw bodies from an older publisher pass through unchanged).
-	return cxoutils.Gunzip(body), nil
+	return restoreTransportIDs(cxoutils.Gunzip(body)), nil
+}
+
+// restoreTransportIDs reconstitutes the derivable t_id the current publisher
+// drops from each all-transports entry (see allTransportsWireEntry in the TPD
+// publisher). It unmarshals the entries, recomputes any zero t_id from
+// (edges, type) via transport.MakeTransportID, and re-marshals — so downstream
+// consumers (`tp tree`, `tp viz`) see complete entries just like the HTTP
+// /all-transports body. Dual-parse: an entry that already carries a non-zero
+// t_id (older publisher) is left untouched. On any decode error the original
+// bytes are returned verbatim so a wire-shape we don't recognize still flows.
+func restoreTransportIDs(body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	var entries []*transport.Entry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return body
+	}
+	changed := false
+	for _, e := range entries {
+		if e == nil || e.ID != (uuid.UUID{}) {
+			continue
+		}
+		e.ID = transport.MakeTransportID(e.Edges[0], e.Edges[1], e.Type)
+		changed = true
+	}
+	if !changed {
+		return body
+	}
+	out, err := json.Marshal(entries)
+	if err != nil {
+		return body
+	}
+	return out
 }

--- a/pkg/visor/api_tpd_uptime_subscriber.go
+++ b/pkg/visor/api_tpd_uptime_subscriber.go
@@ -15,9 +15,14 @@ package visor
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport-discovery/store"
 )
 
 // ErrTPDUptimeNotReady is returned by FetchVisorUptimeCXO when the
@@ -44,18 +49,121 @@ func (v *Visor) FetchVisorUptimeCXO(days int) ([]byte, time.Time, error) {
 	defer mgr.ReleaseFor(TabUptime)
 
 	path := fmt.Sprintf("uptimes/days/%d", days)
-	body, ts, ok := mgr.Get(FeedTPDUptime, path)
-	if !ok || len(body) == 0 {
-		// Cold snapshot: AcquireFor only started the cycle. Block briefly for the
-		// first sync (over dmsg) so CXO serves this call instead of the caller
-		// falling back to dmsg-http — see the sd-services case in FetchCXO.
-		ctx, cancel := context.WithTimeout(context.Background(), feedFirstSyncTimeout(FeedTPDUptime))
-		_, _ = mgr.RefreshNow(ctx, FeedTPDUptime) //nolint:errcheck
-		cancel()
-		body, ts, ok = mgr.Get(FeedTPDUptime, path)
-		if !ok || len(body) == 0 {
-			return nil, time.Time{}, ErrTPDUptimeNotReady
+	if body, ts, ok := readUptimeWindow(mgr, path); ok {
+		return body, ts, nil
+	}
+	// Cold snapshot: AcquireFor only started the cycle. Block briefly for the
+	// first sync (over dmsg) so CXO serves this call instead of the caller
+	// falling back to dmsg-http — see the sd-services case in FetchCXO.
+	ctx, cancel := context.WithTimeout(context.Background(), feedFirstSyncTimeout(FeedTPDUptime))
+	_, _ = mgr.RefreshNow(ctx, FeedTPDUptime) //nolint:errcheck
+	cancel()
+	if body, ts, ok := readUptimeWindow(mgr, path); ok {
+		return body, ts, nil
+	}
+	return nil, time.Time{}, ErrTPDUptimeNotReady
+}
+
+// uptimeCXOSubMgr is the subset of the CXO subscription manager
+// readUptimeWindow needs. Satisfied by *CXOSubscriptionManager; declared as an
+// interface so the reassembly logic is unit-testable without a live manager.
+type uptimeCXOSubMgr interface {
+	Get(feed CXOFeed, path string) ([]byte, time.Time, bool)
+	Walk(feed CXOFeed, prefix string, fn func(path string, body []byte) bool) bool
+}
+
+// compactVisorSummary mirrors the publisher-side wire shape
+// (pkg/transport-discovery/api/cxo_uptime_publisher.go): a per-visor uptime
+// leaf whose timeline is the raw 36-byte bitmap rather than the 288-char
+// string. Re-declared here to keep the dependency direction one-way; keep the
+// JSON tags in sync with the publisher.
+type compactVisorSummary struct {
+	PK       cipher.PubKey     `json:"pk"`
+	Online   bool              `json:"on"`
+	Version  string            `json:"v,omitempty"`
+	Daily    map[string]string `json:"d,omitempty"`
+	Timeline map[string][]byte `json:"tb,omitempty"` // date -> 36-byte bitmap
+}
+
+// readUptimeWindow serves the v3 `[]store.VisorSummary` JSON for a day window
+// from whichever wire form the connected TPD published (dual-parse for the
+// rollout window where publishers and subscribers redeploy independently):
+//
+//   - Legacy: one monolithic leaf at exactly "uptimes/days/<n>" — returned
+//     verbatim (it is already the v3 shape).
+//   - Current: one per-visor leaf at "uptimes/days/<n>/<pkHex>" carrying a
+//     compactVisorSummary — reassembled into `[]store.VisorSummary`, with each
+//     day's bitmap rendered back to the 288-char string so the CLI/hvui
+//     consumers see the exact HTTP /uptimes?v=v3 shape unchanged.
+//
+// ok is false when neither form has any data yet.
+func readUptimeWindow(mgr uptimeCXOSubMgr, path string) ([]byte, time.Time, bool) {
+	if body, ts, ok := mgr.Get(FeedTPDUptime, path); ok && len(body) > 0 {
+		return body, ts, true
+	}
+	var (
+		summaries []store.VisorSummary
+		firstPath string
+	)
+	mgr.Walk(FeedTPDUptime, path+"/", func(p string, body []byte) bool {
+		var c compactVisorSummary
+		if err := json.Unmarshal(body, &c); err != nil {
+			return true // skip a malformed leaf; keep reassembling the rest
+		}
+		if firstPath == "" {
+			firstPath = p
+		}
+		summaries = append(summaries, fromCompactVisorSummary(c))
+		return true
+	})
+	if len(summaries) == 0 {
+		return nil, time.Time{}, false
+	}
+	// The manager snapshot shares one lastSyncAt across the whole feed; read it
+	// off any one leaf (Get on the prefix itself doesn't address a leaf).
+	var newest time.Time
+	if _, ts, ok := mgr.Get(FeedTPDUptime, firstPath); ok {
+		newest = ts
+	}
+	// Stable order so repeated reads (and cache files) don't churn.
+	sort.Slice(summaries, func(i, j int) bool { return summaries[i].PK.Hex() < summaries[j].PK.Hex() })
+	out, err := json.Marshal(summaries)
+	if err != nil {
+		return nil, time.Time{}, false
+	}
+	return out, newest, true
+}
+
+// fromCompactVisorSummary reconstructs the full v3 store.VisorSummary from a
+// compact per-visor leaf, rendering each day's 36-byte bitmap back to the
+// 288-char '.'/' ' timeline string.
+func fromCompactVisorSummary(c compactVisorSummary) store.VisorSummary {
+	s := store.VisorSummary{
+		PK:      c.PK,
+		Online:  c.Online,
+		Version: c.Version,
+		Daily:   c.Daily,
+	}
+	if len(c.Timeline) > 0 {
+		s.Timeline = make(map[string]string, len(c.Timeline))
+		for date, bm := range c.Timeline {
+			s.Timeline[date] = bitmapToTimelineString(bm)
 		}
 	}
-	return body, ts, nil
+	return s
+}
+
+// bitmapToTimelineString renders a 36-byte MSB-first uptime bitmap back to the
+// v3 288-char timeline string ('.' = bit set, ' ' = unset) — the inverse of
+// the publisher's timelineStringToBitmap.
+func bitmapToTimelineString(bm []byte) string {
+	out := make([]byte, 288)
+	for i := range out {
+		if i/8 < len(bm) && bm[i/8]&(1<<uint(7-i%8)) != 0 {
+			out[i] = '.'
+		} else {
+			out[i] = ' '
+		}
+	}
+	return string(out)
 }

--- a/pkg/visor/api_tpd_uptime_subscriber_test.go
+++ b/pkg/visor/api_tpd_uptime_subscriber_test.go
@@ -1,0 +1,125 @@
+// Package visor pkg/visor/api_tpd_uptime_subscriber_test.go c3-vis-core
+package visor
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport-discovery/store"
+)
+
+// fakeUptimeMgr is a minimal uptimeCXOSubMgr for exercising readUptimeWindow's
+// dual-parse without a live CXO subscription manager.
+type fakeUptimeMgr struct {
+	snap map[string][]byte
+	ts   time.Time
+}
+
+func (f *fakeUptimeMgr) Get(_ CXOFeed, path string) ([]byte, time.Time, bool) {
+	b, ok := f.snap[path]
+	if !ok || len(b) == 0 {
+		return nil, time.Time{}, false
+	}
+	return b, f.ts, true
+}
+
+func (f *fakeUptimeMgr) Walk(_ CXOFeed, prefix string, fn func(path string, body []byte) bool) bool {
+	for p, b := range f.snap {
+		if len(p) <= len(prefix) || p[:len(prefix)] != prefix {
+			continue
+		}
+		if !fn(p, b) {
+			break
+		}
+	}
+	return true
+}
+
+func mkTimeline(setSlot int) string {
+	b := make([]byte, 288)
+	for i := range b {
+		b[i] = ' '
+	}
+	b[setSlot] = '.'
+	return string(b)
+}
+
+func TestReadUptimeWindowLegacyMonolith(t *testing.T) {
+	want := []byte(`[{"pk":"000000...","on":true}]`)
+	mgr := &fakeUptimeMgr{
+		snap: map[string][]byte{"uptimes/days/30": want},
+		ts:   time.Unix(1000, 0),
+	}
+	got, ts, ok := readUptimeWindow(mgr, "uptimes/days/30")
+	if !ok || string(got) != string(want) {
+		t.Fatalf("monolith: got %q,%v want verbatim", got, ok)
+	}
+	if !ts.Equal(time.Unix(1000, 0)) {
+		t.Fatalf("monolith ts = %v", ts)
+	}
+}
+
+func TestReadUptimeWindowReassemblesPerVisorLeaves(t *testing.T) {
+	// Real keys: cipher.PubKey.UnmarshalText validates the point, so the leaves
+	// must carry canonical PKs to survive the reader's json.Unmarshal.
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+	if pkA.Hex() > pkB.Hex() {
+		pkA, pkB = pkB, pkA // the reader sorts by PK hex; fix the expected order
+	}
+
+	leaf := func(pk cipher.PubKey, slot int) []byte {
+		c := compactVisorSummary{
+			PK:       pk,
+			Online:   true,
+			Timeline: map[string][]byte{"2026-08-19": timelineBitmap(mkTimeline(slot))},
+		}
+		b, _ := json.Marshal(c)
+		return b
+	}
+	mgr := &fakeUptimeMgr{
+		snap: map[string][]byte{
+			"uptimes/days/30/" + pkA.Hex(): leaf(pkA, 3),
+			"uptimes/days/30/" + pkB.Hex(): leaf(pkB, 9),
+			"uptimes/days/1/" + pkA.Hex():  leaf(pkA, 0), // different window; must be ignored
+		},
+		ts: time.Unix(2000, 0),
+	}
+
+	body, ts, ok := readUptimeWindow(mgr, "uptimes/days/30")
+	if !ok {
+		t.Fatal("expected reassembly hit")
+	}
+	if !ts.Equal(time.Unix(2000, 0)) {
+		t.Fatalf("ts = %v, want 2000", ts)
+	}
+	var got []store.VisorSummary
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal reassembled body: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d summaries, want 2 (window-30 only)", len(got))
+	}
+	// Sorted by PK hex; pkA (0x00aa..) sorts before pkB (0x00bb..).
+	if got[0].PK != pkA || got[1].PK != pkB {
+		t.Fatalf("summaries not sorted by PK: %v", []cipher.PubKey{got[0].PK, got[1].PK})
+	}
+	// Timeline rendered back to the 288-char v3 string with the right slot set.
+	tl := got[0].Timeline["2026-08-19"]
+	if len(tl) != 288 || tl[3] != '.' {
+		t.Fatalf("pkA timeline not rendered: len=%d slot3=%q", len(tl), string(tl[3]))
+	}
+}
+
+// timelineBitmap mirrors the publisher's packing for the test fixtures.
+func timelineBitmap(line string) []byte {
+	bm := make([]byte, 36)
+	for i := 0; i < len(line) && i < 288; i++ {
+		if line[i] == '.' {
+			bm[i/8] |= 1 << uint(7-i%8)
+		}
+	}
+	return bm
+}

--- a/pkg/visor/cxo_transport_discovery.go
+++ b/pkg/visor/cxo_transport_discovery.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/transport"
 	tpdapi "github.com/skycoin/skywire/pkg/transport-discovery/api"
@@ -56,6 +58,15 @@ func (c *cxoAwareTPD) GetAllTransports(ctx context.Context) ([]*transport.Entry,
 				body = cxoutils.Gunzip(body) // publisher gzips; raw bodies pass through
 				var entries []*transport.Entry
 				if err := json.Unmarshal(body, &entries); err == nil {
+					// The current publisher drops the derivable t_id (see
+					// allTransportsWireEntry in the TPD publisher); recompute any
+					// zero ID from (edges, type). A non-zero ID (older publisher)
+					// is left as-is.
+					for _, e := range entries {
+						if e != nil && e.ID == (uuid.UUID{}) {
+							e.ID = transport.MakeTransportID(e.Edges[0], e.Edges[1], e.Type)
+						}
+					}
 					return entries, nil
 				}
 				// Unmarshal failure: most likely a schema drift between


### PR DESCRIPTION
Fixes the SERVE side of TPD's CXO discovery so a subscriber gets LIVE data (was CXO-miss + stale cache; `sd --no-dmsg --no-rpc` hung/fell back to HTTP).

Root cause = same big-object-over-transient-conn class as ingest (#4009-#4014) + CXO's 16MB object cap. Uptimes published one monolithic []VisorSummary with 288-char timeline strings (8x inflation of the 36-byte bitmap) → exceeded 16MB → Put failed → permanent subscriber miss (the ~200MB failure). All-transports = one ~3MB object; subscriber only surfaces on whole-Root fill, break was log-only.

Three commits:
1. fix(cxo): subscriber salvages leaves from a partially-filled Root on fill-break (merge insert/update only) — generic subscriber-side analog of #4009.
2. fix(tpd-cxo): uptimes per-visor bitmap leaves (uptimes/days/<n>/<pkHex>, 36-byte bitmap not 288-char string) → no fleet-sized object; readers dual-parse to the exact v3 shape.
3. fix(tpd-cxo): drop derivable t_id from all-transports (~25% smaller); readers recompute via MakeTransportID; dual-parse.

go build ./... clean; go test on all touched packages green (5 new tests); gofmt clean. Dual-parse throughout (TPD redeploys from develop alongside subscribers). Verify after deploy: `sd --no-dmsg --no-rpc` returns live data matching `tp disc --pk`. Follow-up: chunk all-transports into many small leaves if the compacted single object still fills unreliably.