### PR TITLE
feat(router): optional RSN-oracle 2-hop route calc via the setup-node (TPD-independent)

### DIFF
--- a/docs/rsn-oracle-2hop-routes.md
+++ b/docs/rsn-oracle-2hop-routes.md
@@ -1,0 +1,193 @@
+# RSN-oracle 2-hop route calculation (phase-1)
+
+## Summary
+
+An **OPTIONAL, opt-in** route-calculation path for **single-intermediate
+(2-hop) multiplexed routes** `S → I → D` that gets the destination's transports
+**directly from the destination**, authorized by the transport/route setup-node
+(RSN) acting as a **signing oracle**, instead of relying on the
+transport-discovery service (TPD).
+
+### Why
+
+For a 2-hop route `S → I → D` the only inputs needed are:
+
+- **S's own transports** — known locally, always fresh.
+- **D's own transports** — authoritative and fresh **from D itself**.
+
+The usable intermediate set is exactly the overlap of the two peer sets:
+
+```
+intermediates(S,D) = { I : S has a live transport S–I } ∩ { I : D has a transport I–D }
+```
+
+So a 2-hop route can be computed **entirely locally** once D's transport list is
+in hand — **TPD is only needed for routes with ≥ 2 intermediates**. This makes
+the most common route type independent of TPD's global view (currently ~9%
+complete, being fixed separately).
+
+### Reused mechanism
+
+The RSN is already a **pure signing oracle** in the source-driven cascade
+route-setup protocol (`pkg/router/cascade_source.go:6`): it signs per-hop
+capabilities for a specific target PK and is never on the data path. Targets
+honor only allow-listed RSNs. This design reuses that exact primitive:
+
+- `CascadeSetup.Sign(targetPK, rsnSK)` / `Verify(targetPK)`
+  (`pkg/routing/cascade.go:92,103`) — the RSN signs FOR a target; the target
+  verifies against its own PK.
+- `ErrCascadeUntrustedRSN` + `CascadeHandler.trustedRSNs`
+  (`pkg/router/cascade_handler.go:24,97`) — targets honor only allow-listed RSNs.
+- `transport.CompactEntry` + `EntryFromCompact`
+  (`pkg/transport/entry.go:75,96`) — the compact remote-edge+type wire form D
+  returns, reconstructed by S into canonical entries.
+
+## Protocol: the transport-list query
+
+A new control-plane message, authorized exactly like a cascade layer.
+
+```
+                 (1) SignTransportQuery RPC                (over existing dmsg setup conn)
+   S  ───────────────────────────────────────────────▶  RSN
+      ◀───────────────────────────────────────────────
+                 signed TransportQuery{RSN,Target=D,Requester=S,Nonce,Sig}
+
+                 (2) deliver signed query  (PHASE 1: dmsg-direct to D)
+   S  ───────────────────────────────────────────────▶  D
+      ◀───────────────────────────────────────────────
+                 TransportQueryResponse{Target=D, []CompactEntry}   (D verifies RSN sig + trust)
+
+   (3) S computes  intermediates = (S's own peers) ∩ (D's peers)   — LOCAL, no TPD
+       and builds the disjoint 2-hop mux legs.
+```
+
+1. **S → RSN (RPC):** `SetupRPCGateway.SignTransportQuery` mints a nonce and
+   signs a `TransportQuery` binding `(RSNPK, TargetPK=D, RequesterPK=S, Nonce)`.
+   The RSN reuses the keypair the cascade builder already holds
+   (`g.Cascade.rsnPK/rsnSK`). It does **not** contact D.
+2. **S → D (delivery):** S carries the signed query to D. **Phase 1** delivery is
+   **dmsg-direct to D over the always-available dmsg relay** — the same way
+   `tp --remote` reaches a remote visor over dmsg. **Phase 2 (TODO)** is carrying
+   the query over transports via intermediates, exactly like the cascade's own
+   `RelayTpID` + nested `Payload` hop-by-hop mechanism.
+3. **D verifies + responds:** D checks the RSN signature against **its own PK**
+   and its **trusted-RSN allow-list**, then returns its own live, non-setup
+   transports as `[]transport.CompactEntry` (remote edge + type). Same exclusions
+   as the local route calc: closed/black-holed and `LabelSetup` transports are
+   never advertised.
+4. **S computes locally:** reconstruct D's entries via `EntryFromCompact(D, ce)`,
+   intersect with S's own transports, and build the disjoint 2-hop legs — one per
+   distinct intermediate PK — feeding the existing mux establishment.
+
+### Authorization (the whole point)
+
+The RSN signs; **D checks its trusted-RSN allow-list** — identical to the
+cascade trust model. The signature binds the query to a single `(target,
+requester)` pair, so it cannot be replayed against another visor or claimed by
+another requester. `cipher.Sign/Verify` + the trusted-RSN allow-list are reused
+verbatim (`TransportQuery.Sign/Verify` mirror `CascadeSetup.Sign/Verify`).
+
+## Implementation (this branch)
+
+| Piece | Location |
+|---|---|
+| Query message + `Sign`/`Verify` + JSON marshal | `pkg/router/transport_query.go` (`TransportQuery`) |
+| D-side verify + respond handler | `pkg/router/transport_query.go` (`BuildTransportQueryResponse`) |
+| RSN signing endpoint (RPC) | `pkg/router/setup_rpc_gateway.go` (`SetupRPCGateway.SignTransportQuery`) |
+| S-side RSN RPC client method | `pkg/router/setupclient.go` (`SetupClient.SignTransportQuery`) |
+| **S→D dmsg-direct delivery (deliverer)** | `pkg/router/transport_query_dmsg.go` (`dmsgTransportQueryDeliverer`, `NewDmsgTransportQueryDeliverer`) |
+| **D-side dmsg listener + RPC gateway** | `pkg/router/transport_query_dmsg.go` (`TransportQueryRPCGateway.Query`, `ServeTransportQueryListener`) |
+| Dedicated dmsg port | `pkg/skyenv/skyenv.go` (`DmsgTransportQueryPort = 68`) |
+| Composed production oracle | `pkg/router/transport_query_dmsg.go` (`NewDmsgRSNOracle`) |
+| S-side fetch-D's-transports-via-oracle | `pkg/router/rsn_oracle_routes.go` (`fetchDstTransportsViaOracle`) |
+| **Local 2-hop disjoint route computation (tested crux)** | `pkg/router/rsn_oracle_routes.go` (`computeDisjoint2HopRoutes`) |
+| Router-facing oracle seam | `pkg/router/router.go` (`DstTransportOracle`, `Router.SetDstTransportOracle`), `pkg/router/rsn_oracle_routes.go` (`router.oracle2HopRoutes`) |
+| Dial-path plug-in (gated, default OFF) | `pkg/router/router_dial.go` — top of `fetchBestRoutes` |
+| Config flag (`RouteOption`) | `pkg/router/router.go` (`Config.EnableRSNOracleRoutes`, `DialOptions.UseRSNOracle2Hop`) |
+| Config surface + plumbing | `pkg/visor/visorconfig/v1.go` (`Routing.EnableRSNOracleRoutes`), `pkg/visor/visorcore/router.go`, `pkg/visor/init_router.go` (oracle + listener wiring) |
+| Unit tests | `pkg/router/transport_query_test.go`, `pkg/router/rsn_oracle_routes_test.go`, `pkg/router/transport_query_dmsg_test.go` |
+
+### End-to-end wiring (dmsg-direct, phase-1)
+
+`pkg/visor/init_router.go` (in `setupRouting`, after the route-checker setup):
+when `Routing.EnableRSNOracleRoutes` is true it (a) calls
+`r.SetDstTransportOracle(router.NewDmsgRSNOracle(v.dmsgC, EffectiveRouteSetupNodes(), log))`
+so the **source** side is live, and (b) starts
+`router.ServeTransportQueryListener(serveCtx, v.dmsgC, gw, log)` in a goroutine so
+the **destination** side answers queries. Both are skipped entirely when the flag
+is off — no extra dmsg listener, no dial-path change.
+
+- **Delivery transport:** the deliverer dials the destination at
+  `dmsg.Addr{PK: D, Port: skyenv.DmsgTransportQueryPort(=68)}` and issues the
+  `TransportQueryRPCGateway.Query` RPC over the dmsg stream — the same
+  net/rpc-server + gob-client pairing the setup-node path uses
+  (`embedded_route_setup.go` serves `SetupRPCGateway` the same way), so no new
+  codec or port-multiplexing is introduced.
+- **Listener/port:** a **dedicated** dmsg port `68` (`DmsgTransportQueryPort`),
+  registered in `pkg/skyenv/skyenv.go` and guarded by `ports_test.go`. It is a
+  control-plane listener, bound **only** when the flag is on. It does **not**
+  require any new capability — it reuses the visor's existing dmsg client and PK
+  identity.
+
+### Where it plugs into route setup (exact seams)
+
+- **`fetchBestRoutes`** (`pkg/router/router_dial.go:811`) is the single funnel
+  the whole dial path (primary route + every mux leg via `establishMuxRoutes` /
+  `addOneAuxForwardLeg` / `GrowMuxRoute`) uses to obtain forward/reverse hops.
+  The RSN-oracle fast path is inserted at the **top** of `fetchBestRoutes`, after
+  the `forceLocal` check: gated on
+  `(Config.EnableRSNOracleRoutes || opts.UseRSNOracle2Hop)`, a wired oracle, and
+  a **2-hop-satisfiable** min-hops constraint (`≤ 2`; a `min_hops ≥ 3` request
+  falls through). Because each `establishMuxRoutes` iteration adds the used
+  intermediate to `opts.ExcludeIntermediatePKs`, successive calls return
+  **disjoint** intermediates automatically — the same discipline the existing
+  disjoint-mux code uses.
+- **On any miss** (no oracle wired, no shared intermediate, delivery error) it
+  falls through to the existing route-finder / TPD-backed path. **Zero behavior
+  change when disabled.**
+
+### The local computation (the tested standalone function)
+
+`computeDisjoint2HopRoutes(src, dst, localTps, dstEntries, opts, max)` is a pure
+function of its inputs (no I/O), so it is unit-tested with mock S/D transport
+sets:
+
+- intermediate `I` qualifies iff S has a live **non-DMSG** `S–I` **and** D has a
+  **non-DMSG** `I–D`, `I ∉ {src, dst}`, `I ∉ opts.ExcludeIntermediatePKs`, and
+  the `S–I` id `∉ opts.ExcludeTransportIDs`;
+- DMSG is excluded on both legs (a dmsg relay hop is unaccountable in a multihop
+  route — same rule as the local BFS in `calculateLocalRoutes`);
+- when either side has several transports to the same `I`, the most-preferred
+  type wins (`tptypes.TypePreference`);
+- the `I–D` transport id is the **canonical deterministic** id
+  (`MakeTransportID(I, D, type)`) both endpoints agree on — reconstructed from
+  the compact entry, exactly the id the intermediate uses to relay to D;
+- legs are sorted by intermediate-PK for determinism and capped at `max`
+  (`0` = uncapped). One leg per distinct intermediate ⇒ the set is disjoint.
+
+## What is deferred (phase-2 / optional follow-ups)
+
+Phase-1 is now **end-to-end functional** behind the default-OFF flag: protocol,
+RSN signing endpoint, D-side response builder + dmsg listener, S→D dmsg-direct
+delivery, the composed oracle, the local 2-hop computation, and the dial-path
+plug-in are all implemented, wired, and tested. Remaining items are optional:
+
+1. **Phase-2 delivery over transports via intermediates** — reuse the cascade
+   `RelayTpID` + nested `Payload` carry so the query needs no dmsg at all.
+2. **Config → `DialOptions.UseRSNOracle2Hop`** per-dial mapping if a per-app /
+   per-policy opt-in (rather than the visor-wide `Config.EnableRSNOracleRoutes`)
+   is wanted; the field already exists and is honored by `fetchBestRoutes`.
+3. **Response caching** per `(src,dst)` with a short TTL so a mux build doesn't
+   re-fetch D's list once per leg (functionally correct today; an optimization).
+4. **`SetupClient` reuse** — `dmsgRSNOracle.DstTransports` opens a fresh
+   setup-node connection per call (matching the cascade path's per-request model
+   in `wrappers.go`); a pooled/relay path could be added later.
+
+## Safety / invariants
+
+- **Default OFF**, and inert even when on until an oracle is explicitly wired —
+  no existing dial path changes.
+- Reuses the cascade trust model verbatim: **RSN signs, D checks its trusted-RSN
+  allow-list** — no new trust surface.
+- Never uses DMSG or `LabelSetup` transports as data hops.
+- 2-hop only; anything needing ≥ 2 intermediates still goes through TPD.

--- a/pkg/router/mock_router.go
+++ b/pkg/router/mock_router.go
@@ -444,6 +444,11 @@ func (_m *MockRouter) SetForceLocalRoutes(_a0 bool) {
 	_m.Called(_a0)
 }
 
+// SetDstTransportOracle provides a mock function with given fields: _a0
+func (_m *MockRouter) SetDstTransportOracle(_a0 DstTransportOracle) {
+	_m.Called(_a0)
+}
+
 // SetMuxRoutes provides a mock function with given fields: _a0
 func (_m *MockRouter) SetMuxRoutes(_a0 int) {
 	_m.Called(_a0)

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -142,6 +142,17 @@ type Config struct {
 	// its pre-integration shape — zero-cost when no policy is
 	// configured.
 	DialHook DialHook
+
+	// EnableRSNOracleRoutes opts INTO the RSN-oracle 2-hop route path: for a
+	// single-intermediate route S->I->D the source computes the route LOCALLY
+	// from its OWN transports intersected with the destination's OWN transports
+	// (fetched authoritatively from D via an RSN-signed transport-query), making
+	// the common route type independent of the transport-discovery service
+	// (TPD). OFF by default — existing behavior (route finder / TPD-backed local
+	// calc) is unchanged. Even when true the path is inert until a transport-
+	// query deliverer is configured (SetTransportQueryDeliverer); see
+	// rsn_oracle_routes.go. TPD is still used for routes with >=2 intermediates.
+	EnableRSNOracleRoutes bool
 }
 
 // SetDefaults sets default values for certain empty values.
@@ -276,6 +287,16 @@ type DialOptions struct {
 	// Populated by the policy layer (DialAdjustment) from
 	// RouteSpec.RotationIntervalSeconds; zero = no rotation.
 	RotationIntervalSeconds int
+
+	// UseRSNOracle2Hop is the per-dial opt-in for the RSN-oracle 2-hop route
+	// path (rsn_oracle_routes.go). When set — and the router has a transport-
+	// query deliverer configured — fetchBestRoutes computes a single-
+	// intermediate route from the source's own transports intersected with the
+	// destination's own transports (fetched from the destination via an
+	// RSN-signed query) instead of querying TPD/the route finder. OR-ed with the
+	// router-wide Config.EnableRSNOracleRoutes gate. Default false = existing
+	// behavior.
+	UseRSNOracle2Hop bool
 }
 
 // DefaultDialOptions returns default dial options.
@@ -410,6 +431,10 @@ type Router interface {
 	EffectiveMinHops(opts *DialOptions) uint16
 	SetExistingTPOnly(bool)
 	SetForceLocalRoutes(bool)
+	// SetDstTransportOracle wires the RSN-oracle 2-hop route path's
+	// destination-transport oracle (see rsn_oracle_routes.go). nil leaves the
+	// path inert even when Config.EnableRSNOracleRoutes is set.
+	SetDstTransportOracle(DstTransportOracle)
 	SetMuxRoutes(int)
 	SetMuxMode(WeightMode)
 	GetExistingTPOnly() bool
@@ -492,6 +517,45 @@ type router struct {
 	lastRouteCalcTime time.Duration     // last route calculation time (for local routes)
 	lastRouteCalcMu   sync.Mutex        // protects lastRouteCalcTime
 	tpdCache          *tpdSnapshotCache // one-snapshot TTL cache of GetAllTransports, see tpd_cache.go
+	// dstTpOracle fetches a destination visor's OWN transport list
+	// authoritatively from the destination (via an RSN-signed transport-query),
+	// for the RSN-oracle 2-hop route path (rsn_oracle_routes.go). nil by default
+	// → the oracle path is inert even when Config.EnableRSNOracleRoutes is set.
+	// Set via SetDstTransportOracle.
+	dstTpOracle   DstTransportOracle
+	dstTpOracleMu sync.Mutex
+}
+
+// DstTransportOracle fetches a destination visor's OWN transport list
+// authoritatively from the destination. It is the router-facing seam for the
+// RSN-oracle 2-hop route path: the router calls DstTransports(src, dst) and
+// computes the 2-hop route locally from the result. The visor implements it
+// (typically via fetchDstTransportsViaOracle / NewDmsgRSNOracle) since it owns
+// the RSN RPC connection and the S->D delivery transport; the router stays
+// decoupled from both. Declared here (unbuilt-tagged) so the Router interface
+// referencing it compiles on every target.
+type DstTransportOracle interface {
+	DstTransports(ctx context.Context, src, dst cipher.PubKey) ([]*transport.Entry, error)
+}
+
+// SetDstTransportOracle installs the oracle that fetches a destination's own
+// transport list, enabling the RSN-oracle 2-hop route path when
+// Config.EnableRSNOracleRoutes (or DialOptions.UseRSNOracle2Hop) is also set.
+// Until this is called the path stays inert (fetchBestRoutes falls through to
+// its existing route-finder / TPD behavior). The visor implements the oracle by
+// asking the RSN to sign a transport-query and delivering it to the destination
+// (fetchDstTransportsViaOracle is the reference building block).
+func (r *router) SetDstTransportOracle(o DstTransportOracle) {
+	r.dstTpOracleMu.Lock()
+	r.dstTpOracle = o
+	r.dstTpOracleMu.Unlock()
+}
+
+// dstTransportOracle returns the configured oracle (may be nil).
+func (r *router) dstTransportOracle() DstTransportOracle {
+	r.dstTpOracleMu.Lock()
+	defer r.dstTpOracleMu.Unlock()
+	return r.dstTpOracle
 }
 
 // scopedLog returns a logger augmented with app_name=<n> when the

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -835,6 +835,33 @@ func (r *router) fetchBestRoutes(ctx context.Context, log *logging.Logger, src, 
 		return localFwd, localRev, localErr
 	}
 
+	// RSN-oracle 2-hop fast path (opt-in, default OFF). For a single-
+	// intermediate route the source computes the route locally from its own
+	// transports intersected with the destination's own transports (fetched
+	// authoritatively from the destination via an RSN-signed query) — no TPD /
+	// route-finder round-trip. Only attempted when the path is enabled AND an
+	// oracle is wired AND the min-hops constraint is 2-hop-satisfiable (a 2-hop
+	// route is exactly one intermediate; a min_hops>=3 request cannot be served
+	// this way and falls through). On any miss (no oracle, no shared
+	// intermediate, delivery error) it falls through to the existing behavior —
+	// zero change when disabled.
+	if r.conf != nil && (r.conf.EnableRSNOracleRoutes || opts.UseRSNOracle2Hop) && src != dst {
+		hi := baseMinHops
+		if e := opts.EffectiveMinHops(true); uint16(e) > hi { //nolint:gosec
+			hi = uint16(e) //nolint:gosec
+		}
+		if e := opts.EffectiveMinHops(false); uint16(e) > hi { //nolint:gosec
+			hi = uint16(e) //nolint:gosec
+		}
+		if hi <= 2 {
+			if oFwd, oRev, oErr := r.oracle2HopRoutes(ctx, log, src, dst, opts); oErr == nil {
+				return oFwd, oRev, nil
+			} else if !errors.Is(oErr, errRSNOracleInert) {
+				log.WithError(oErr).Debug("RSN-oracle 2-hop path missed; falling through to route finder")
+			}
+		}
+	}
+
 	retries := opts.Retries
 
 	log.Debugf("Requesting new routes from %s to %s", src, dst)

--- a/pkg/router/rsn_oracle_routes.go
+++ b/pkg/router/rsn_oracle_routes.go
@@ -1,0 +1,323 @@
+//go:build !tinygo || (js && wasm)
+
+// Package router pkg/router/rsn_oracle_routes.go c2-net-routing
+//
+// RSN-oracle 2-hop route computation (phase-1, opt-in).
+//
+// Given the source's OWN transports and the destination's OWN transports
+// (fetched authoritatively from the destination via the RSN-signed
+// transport-query, transport_query.go), the set of single-intermediate (2-hop)
+// routes S->I->D is the overlap of the two peer sets: an intermediate I is
+// usable iff S has a live transport S-I AND D has a transport I-D. No TPD
+// snapshot is consulted — the common route type becomes independent of the
+// transport-discovery service's global view.
+//
+// This is the S-side crux and is deliberately a pure function of its inputs
+// (computeDisjoint2HopRoutes) so it is unit-testable with mock transport sets.
+// The result is a disjoint set of legs (one per distinct intermediate PK) ready
+// to feed the existing mux establishment (establishMuxRoutes consumes
+// ForwardHops/ReverseHops per leg).
+package router
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	rpc "github.com/skycoin/skywire/pkg/gobrpc"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// errRSNOracleInert signals that the RSN-oracle 2-hop path is enabled by config
+// but no oracle is wired (SetDstTransportOracle was never called), so
+// fetchBestRoutes must fall through to its existing behavior.
+var errRSNOracleInert = errors.New("rsn-oracle: no destination-transport oracle configured")
+
+// oracleLocalTp is the minimal view of one of the source's own transports the
+// 2-hop computation needs: which peer it reaches and over which transport ID /
+// type. Callers build it from transport.Manager.WalkTransports.
+type oracleLocalTp struct {
+	id       uuid.UUID
+	remotePK cipher.PubKey
+	tpType   tptypes.Type
+}
+
+// twoHopLeg is one disjoint S->I->D route: the intermediate plus the forward
+// and reverse hop lists ready for DialOptions.ForwardHops / ReverseHops.
+type twoHopLeg struct {
+	Intermediate cipher.PubKey
+	Forward      []routing.Hop // src -> I -> dst
+	Reverse      []routing.Hop // dst -> I -> src
+}
+
+// computeDisjoint2HopRoutes computes the disjoint set of single-intermediate
+// routes from src to dst, using ONLY the source's own transports (localTps) and
+// the destination's own transports (dstEntries, as returned by the destination
+// and reconstructed with transport.EntryFromCompact). It never consults TPD.
+//
+// An intermediate I qualifies iff:
+//   - src has a live non-DMSG transport src-I (from localTps), and
+//   - dst has a non-DMSG transport I-dst (from dstEntries), and
+//   - I is neither src nor dst, and
+//   - I is not in opts.ExcludeIntermediatePKs, and
+//   - the src-I transport ID is not in opts.ExcludeTransportIDs.
+//
+// DMSG is excluded on both legs: a DMSG transport relays through an unobservable
+// dmsg server, so it must never be an intermediate hop (same rule as the local
+// BFS in calculateLocalRoutes). When src and dst each have several transports to
+// the same intermediate, the lowest TypePreference (most-preferred, e.g. stcpr
+// over webrtc) is chosen on each side.
+//
+// Legs are returned sorted by intermediate-PK string for determinism and capped
+// at max (0 = uncapped). Each leg has a distinct intermediate, so the returned
+// set is disjoint in the intermediate-PK sense — exactly what the mux splitter
+// wants for parallel legs.
+func computeDisjoint2HopRoutes(
+	src, dst cipher.PubKey,
+	localTps []oracleLocalTp,
+	dstEntries []*transport.Entry,
+	opts *DialOptions,
+	max int,
+) ([]twoHopLeg, error) {
+	if src == dst {
+		return nil, errors.New("rsn-oracle 2-hop: src == dst")
+	}
+
+	excludeIntermediates := map[cipher.PubKey]struct{}{}
+	excludeTpIDs := map[uuid.UUID]struct{}{}
+	if opts != nil {
+		for _, pk := range opts.ExcludeIntermediatePKs {
+			excludeIntermediates[pk] = struct{}{}
+		}
+		for _, id := range opts.ExcludeTransportIDs {
+			excludeTpIDs[id] = struct{}{}
+		}
+	}
+
+	// Source side: best src-I transport per intermediate peer I (lowest
+	// TypePreference wins). DMSG and excluded transport IDs are dropped.
+	type srcLeg struct {
+		id     uuid.UUID
+		tpType tptypes.Type
+	}
+	srcByPeer := map[cipher.PubKey]srcLeg{}
+	for _, tp := range localTps {
+		if tp.tpType == tptypes.DMSG {
+			continue
+		}
+		if _, hit := excludeTpIDs[tp.id]; hit {
+			continue
+		}
+		peer := tp.remotePK
+		if peer == src || peer == dst {
+			continue
+		}
+		if _, hit := excludeIntermediates[peer]; hit {
+			continue
+		}
+		if cur, ok := srcByPeer[peer]; !ok ||
+			tptypes.TypePreference(tp.tpType) < tptypes.TypePreference(cur.tpType) {
+			srcByPeer[peer] = srcLeg{id: tp.id, tpType: tp.tpType}
+		}
+	}
+
+	// Destination side: best I-dst transport per intermediate peer I. The
+	// reconstructed Entry carries the canonical (deterministic) transport ID the
+	// intermediate would use to reach dst.
+	type dstLeg struct {
+		id     uuid.UUID
+		tpType tptypes.Type
+	}
+	dstByPeer := map[cipher.PubKey]dstLeg{}
+	for _, e := range dstEntries {
+		if e == nil {
+			continue
+		}
+		if e.Type == tptypes.DMSG {
+			continue
+		}
+		if e.Label == transport.LabelSetup {
+			continue
+		}
+		peer := e.RemoteEdge(dst)
+		if peer == src || peer == dst {
+			continue
+		}
+		if cur, ok := dstByPeer[peer]; !ok ||
+			tptypes.TypePreference(e.Type) < tptypes.TypePreference(cur.tpType) {
+			dstByPeer[peer] = dstLeg{id: e.ID, tpType: e.Type}
+		}
+	}
+
+	// Intersection: intermediates reachable from BOTH ends.
+	intermediates := make([]cipher.PubKey, 0, len(srcByPeer))
+	for peer := range srcByPeer {
+		if _, ok := dstByPeer[peer]; ok {
+			intermediates = append(intermediates, peer)
+		}
+	}
+	if len(intermediates) == 0 {
+		return nil, errors.New("rsn-oracle 2-hop: no shared intermediate between src and dst transports")
+	}
+	sort.SliceStable(intermediates, func(i, j int) bool {
+		return intermediates[i].String() < intermediates[j].String()
+	})
+
+	legs := make([]twoHopLeg, 0, len(intermediates))
+	for _, i := range intermediates {
+		s := srcByPeer[i]
+		d := dstByPeer[i]
+		fwd := []routing.Hop{
+			{TpID: s.id, From: src, To: i},
+			{TpID: d.id, From: i, To: dst},
+		}
+		legs = append(legs, twoHopLeg{
+			Intermediate: i,
+			Forward:      fwd,
+			Reverse:      reverseHops(fwd),
+		})
+		if max > 0 && len(legs) >= max {
+			break
+		}
+	}
+	return legs, nil
+}
+
+// reconstructDstEntries rebuilds full transport entries from a destination's
+// compact query response. The reporter is the destination itself (resp.TargetPK
+// / dst), so EntryFromCompact yields the canonical Entry (sorted edges,
+// recomputed ID) both endpoints agree on.
+func reconstructDstEntries(dst cipher.PubKey, resp *TransportQueryResponse) []*transport.Entry {
+	if resp == nil {
+		return nil
+	}
+	out := make([]*transport.Entry, 0, len(resp.Entries))
+	for _, ce := range resp.Entries {
+		out = append(out, transport.EntryFromCompact(dst, ce))
+	}
+	return out
+}
+
+// oracleDeliveryOracle is the reference DstTransportOracle: it asks the RSN
+// (over rsnRPC) to sign a transport-query and delivers it to the destination via
+// deliverer. Constructed by the visor once it has both the RSN RPC client and a
+// delivery transport wired.
+type oracleDeliveryOracle struct {
+	rsnRPC    *rpc.Client
+	deliverer TransportQueryDeliverer
+}
+
+// NewDstTransportOracle builds the reference DstTransportOracle from an RSN RPC
+// client and a query deliverer.
+func NewDstTransportOracle(rsnRPC *rpc.Client, deliverer TransportQueryDeliverer) DstTransportOracle {
+	return &oracleDeliveryOracle{rsnRPC: rsnRPC, deliverer: deliverer}
+}
+
+func (o *oracleDeliveryOracle) DstTransports(ctx context.Context, src, dst cipher.PubKey) ([]*transport.Entry, error) {
+	return fetchDstTransportsViaOracle(ctx, o.rsnRPC, o.deliverer, src, dst)
+}
+
+// oracle2HopRoutes is the router-side seam wired into fetchBestRoutes. When the
+// RSN-oracle path is enabled and an oracle is configured, it fetches the
+// destination's own transports, snapshots the source's own transports, computes
+// the disjoint 2-hop legs locally (honoring opts.ExcludeIntermediatePKs /
+// ExcludeTransportIDs so successive mux-leg calls advance to fresh
+// intermediates), and returns the FIRST leg's forward/reverse hops. Returns
+// errRSNOracleInert when no oracle is configured so the caller falls through to
+// existing behavior.
+func (r *router) oracle2HopRoutes(ctx context.Context, log *logging.Logger, src, dst cipher.PubKey, opts *DialOptions) (fwd, rev []routing.Hop, err error) {
+	if log == nil {
+		log = r.logger
+	}
+	oracle := r.dstTransportOracle()
+	if oracle == nil {
+		return nil, nil, errRSNOracleInert
+	}
+	if r.tm == nil {
+		return nil, nil, errors.New("rsn-oracle: transport manager not available")
+	}
+
+	dstEntries, err := oracle.DstTransports(ctx, src, dst)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var localTps []oracleLocalTp
+	r.tm.WalkTransports(func(tp *transport.ManagedTransport) bool {
+		if tp == nil || tp.IsClosed() {
+			return true
+		}
+		if tp.Entry.Label == transport.LabelSetup {
+			return true
+		}
+		localTps = append(localTps, oracleLocalTp{
+			id:       tp.Entry.ID,
+			remotePK: tp.Entry.RemoteEdge(src),
+			tpType:   tp.Entry.Type,
+		})
+		return true
+	})
+
+	legs, err := computeDisjoint2HopRoutes(src, dst, localTps, dstEntries, opts, 1)
+	if err != nil {
+		return nil, nil, err
+	}
+	leg := legs[0]
+	log.Infof("RSN-oracle 2-hop route via intermediate %s (no TPD)", leg.Intermediate)
+	return leg.Forward, leg.Reverse, nil
+}
+
+// TransportQueryDeliverer carries a signed transport-query to the destination
+// visor and returns its response. PHASE-1 delivery is dmsg-direct to D (the
+// mechanism `tp --remote` already uses to reach a remote visor); PHASE-2 is
+// carrying the query over transports via intermediates like the cascade itself.
+// The interface keeps computeDisjoint2HopRoutes' caller (fetchDstTransportsViaOracle)
+// independent of the transport used, so the delivery seam can be filled in
+// without touching the route computation.
+type TransportQueryDeliverer interface {
+	DeliverTransportQuery(ctx context.Context, dst cipher.PubKey, q *TransportQuery) (*TransportQueryResponse, error)
+}
+
+// fetchDstTransportsViaOracle performs the source-side flow: ask the RSN (over
+// the existing setup RPC connection) to SIGN a transport-query targeting dst,
+// then deliver it to dst and reconstruct dst's transport entries from the
+// response. It never consults TPD.
+//
+// rsnRPC is the RPC client to the RSN (SetupClient.RPCClient). deliverer carries
+// the signed query to dst (see TransportQueryDeliverer). Returns the destination's
+// own transport entries.
+func fetchDstTransportsViaOracle(
+	ctx context.Context,
+	rsnRPC *rpc.Client,
+	deliverer TransportQueryDeliverer,
+	src, dst cipher.PubKey,
+) ([]*transport.Entry, error) {
+	if rsnRPC == nil {
+		return nil, errors.New("rsn-oracle: no RSN RPC client")
+	}
+	if deliverer == nil {
+		return nil, errors.New("rsn-oracle: no query deliverer")
+	}
+
+	var signReply SignTransportQueryReply
+	if err := rpcCall(ctx, rsnRPC, rpcName+".SignTransportQuery",
+		&SignTransportQueryArgs{RequesterPK: src, TargetPK: dst}, &signReply); err != nil {
+		return nil, err
+	}
+	q := signReply.Query
+	if q == nil {
+		return nil, errors.New("rsn-oracle: RSN returned nil query")
+	}
+
+	resp, err := deliverer.DeliverTransportQuery(ctx, dst, q)
+	if err != nil {
+		return nil, err
+	}
+	return reconstructDstEntries(dst, resp), nil
+}

--- a/pkg/router/rsn_oracle_routes_test.go
+++ b/pkg/router/rsn_oracle_routes_test.go
@@ -1,0 +1,213 @@
+//go:build !tinygo || (js && wasm)
+
+package router
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// mkLocal builds one of the source's own transports to peer over tpType.
+func mkLocal(src, peer cipher.PubKey, tpType tptypes.Type) oracleLocalTp {
+	return oracleLocalTp{
+		id:       transport.MakeTransportID(src, peer, tpType),
+		remotePK: peer,
+		tpType:   tpType,
+	}
+}
+
+// mkDstEntry builds a destination-side transport entry (dst<->peer).
+func mkDstEntry(dst, peer cipher.PubKey, tpType tptypes.Type) *transport.Entry {
+	e := transport.MakeEntry(dst, peer, tpType, transport.LabelAutomatic)
+	return &e
+}
+
+func intermediatesOf(legs []twoHopLeg) []string {
+	out := make([]string, 0, len(legs))
+	for _, l := range legs {
+		out = append(out, l.Intermediate.String())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestComputeDisjoint2HopRoutes_Intersection(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	i1, _ := cipher.GenerateKeyPair()
+	i2, _ := cipher.GenerateKeyPair()
+	i3, _ := cipher.GenerateKeyPair() // only src-side → excluded
+	i4, _ := cipher.GenerateKeyPair() // only dst-side → excluded
+	i5, _ := cipher.GenerateKeyPair() // DMSG on both → excluded
+
+	localTps := []oracleLocalTp{
+		mkLocal(src, i1, tptypes.STCPR),
+		mkLocal(src, i2, tptypes.SUDPH),
+		mkLocal(src, i3, tptypes.STCPR),
+		mkLocal(src, i5, tptypes.DMSG),
+	}
+	dstEntries := []*transport.Entry{
+		mkDstEntry(dst, i1, tptypes.STCPR),
+		mkDstEntry(dst, i2, tptypes.STCPR),
+		mkDstEntry(dst, i4, tptypes.STCPR),
+		mkDstEntry(dst, i5, tptypes.DMSG),
+	}
+
+	legs, err := computeDisjoint2HopRoutes(src, dst, localTps, dstEntries, nil, 0)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	got := intermediatesOf(legs)
+	want := []string{i1.String(), i2.String()}
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("intermediates = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("intermediates = %v, want %v", got, want)
+		}
+	}
+
+	// Verify hop shape for one leg (find i1's leg).
+	var leg *twoHopLeg
+	for idx := range legs {
+		if legs[idx].Intermediate == i1 {
+			leg = &legs[idx]
+		}
+	}
+	if leg == nil {
+		t.Fatal("expected a leg via i1")
+	}
+	if len(leg.Forward) != 2 {
+		t.Fatalf("forward hops = %d, want 2", len(leg.Forward))
+	}
+	if leg.Forward[0].From != src || leg.Forward[0].To != i1 {
+		t.Fatalf("forward[0] = %v->%v, want src->i1", leg.Forward[0].From, leg.Forward[0].To)
+	}
+	if leg.Forward[1].From != i1 || leg.Forward[1].To != dst {
+		t.Fatalf("forward[1] = %v->%v, want i1->dst", leg.Forward[1].From, leg.Forward[1].To)
+	}
+	// The i1->dst transport ID must be the canonical (deterministic) ID both
+	// endpoints agree on.
+	wantID := transport.MakeTransportID(i1, dst, tptypes.STCPR)
+	if leg.Forward[1].TpID != wantID {
+		t.Fatalf("forward[1] TpID = %s, want canonical %s", leg.Forward[1].TpID, wantID)
+	}
+	// Reverse mirrors forward.
+	if len(leg.Reverse) != 2 || leg.Reverse[0].From != dst || leg.Reverse[1].To != src {
+		t.Fatalf("reverse hops malformed: %+v", leg.Reverse)
+	}
+}
+
+func TestComputeDisjoint2HopRoutes_ExcludeIntermediate(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	i1, _ := cipher.GenerateKeyPair()
+	i2, _ := cipher.GenerateKeyPair()
+
+	localTps := []oracleLocalTp{
+		mkLocal(src, i1, tptypes.STCPR),
+		mkLocal(src, i2, tptypes.STCPR),
+	}
+	dstEntries := []*transport.Entry{
+		mkDstEntry(dst, i1, tptypes.STCPR),
+		mkDstEntry(dst, i2, tptypes.STCPR),
+	}
+
+	opts := &DialOptions{ExcludeIntermediatePKs: []cipher.PubKey{i1}}
+	legs, err := computeDisjoint2HopRoutes(src, dst, localTps, dstEntries, opts, 0)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if len(legs) != 1 || legs[0].Intermediate != i2 {
+		t.Fatalf("with i1 excluded, want single leg via i2, got %v", intermediatesOf(legs))
+	}
+}
+
+func TestComputeDisjoint2HopRoutes_MaxCap(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	i1, _ := cipher.GenerateKeyPair()
+	i2, _ := cipher.GenerateKeyPair()
+	i3, _ := cipher.GenerateKeyPair()
+
+	var localTps []oracleLocalTp
+	var dstEntries []*transport.Entry
+	for _, i := range []cipher.PubKey{i1, i2, i3} {
+		localTps = append(localTps, mkLocal(src, i, tptypes.STCPR))
+		dstEntries = append(dstEntries, mkDstEntry(dst, i, tptypes.STCPR))
+	}
+
+	legs, err := computeDisjoint2HopRoutes(src, dst, localTps, dstEntries, nil, 2)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if len(legs) != 2 {
+		t.Fatalf("max=2 → want 2 legs, got %d", len(legs))
+	}
+}
+
+func TestComputeDisjoint2HopRoutes_NoSharedIntermediate(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	i1, _ := cipher.GenerateKeyPair()
+	i2, _ := cipher.GenerateKeyPair()
+
+	localTps := []oracleLocalTp{mkLocal(src, i1, tptypes.STCPR)}
+	dstEntries := []*transport.Entry{mkDstEntry(dst, i2, tptypes.STCPR)}
+
+	if _, err := computeDisjoint2HopRoutes(src, dst, localTps, dstEntries, nil, 0); err == nil {
+		t.Fatal("want error when src and dst share no intermediate")
+	}
+}
+
+func TestComputeDisjoint2HopRoutes_PrefersDirectTypeOverDMSG(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	i1, _ := cipher.GenerateKeyPair()
+
+	// src has BOTH a DMSG and an STCPR transport to i1; dst has STCPR to i1.
+	localTps := []oracleLocalTp{
+		mkLocal(src, i1, tptypes.DMSG),
+		mkLocal(src, i1, tptypes.STCPR),
+	}
+	dstEntries := []*transport.Entry{mkDstEntry(dst, i1, tptypes.STCPR)}
+
+	legs, err := computeDisjoint2HopRoutes(src, dst, localTps, dstEntries, nil, 0)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if len(legs) != 1 {
+		t.Fatalf("want 1 leg, got %d", len(legs))
+	}
+	// The src->i1 hop must use the STCPR transport, never DMSG.
+	wantID := transport.MakeTransportID(src, i1, tptypes.STCPR)
+	if legs[0].Forward[0].TpID != wantID {
+		t.Fatalf("src->i1 leg used %s, want STCPR %s (DMSG must be skipped)", legs[0].Forward[0].TpID, wantID)
+	}
+}
+
+func TestReconstructDstEntries(t *testing.T) {
+	dst, _ := cipher.GenerateKeyPair()
+	peer, _ := cipher.GenerateKeyPair()
+
+	resp := &TransportQueryResponse{
+		TargetPK: dst,
+		Entries:  []transport.CompactEntry{{Remote: peer, Type: tptypes.STCPR}},
+	}
+	entries := reconstructDstEntries(dst, resp)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	if !entries[0].HasEdge(dst) || !entries[0].HasEdge(peer) {
+		t.Fatalf("reconstructed entry missing edges: %v", entries[0].Edges)
+	}
+	if entries[0].ID != transport.MakeTransportID(dst, peer, tptypes.STCPR) {
+		t.Fatalf("reconstructed ID mismatch")
+	}
+}

--- a/pkg/router/setup_rpc_gateway.go
+++ b/pkg/router/setup_rpc_gateway.go
@@ -5,6 +5,8 @@ package router
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/binary"
 	"errors"
 	"net"
 	"time"
@@ -150,6 +152,50 @@ func (g *SetupRPCGateway) CascadeSignInstall(args *CascadeSignInstallArgs, reply
 	reply.FwdInstallBytes = fwdBytes
 	reply.RevInstallBytes = revBytes
 	reply.InitEdge = initEdge
+	return nil
+}
+
+// SignTransportQueryArgs is the request for SignTransportQuery: the source asks
+// the RSN to sign a transport-query capability targeting a destination.
+type SignTransportQueryArgs struct {
+	RequesterPK cipher.PubKey // source S making the request
+	TargetPK    cipher.PubKey // destination D whose transports are requested
+}
+
+// SignTransportQueryReply carries the RSN-signed query. The RSN is a pure
+// signing oracle here too: it signs the (RSN, target, requester, nonce) tuple
+// and returns it; it does not contact the destination. The SOURCE carries the
+// signed query to the destination (phase-1: dmsg-direct) and the destination
+// verifies it against its trusted-RSN allowlist before responding.
+type SignTransportQueryReply struct {
+	Query *TransportQuery
+}
+
+// SignTransportQuery is the RSN-side signing endpoint for the RSN-oracle 2-hop
+// route path. It mints a nonce, signs a TransportQuery targeting args.TargetPK
+// on behalf of args.RequesterPK, and returns it. Reuses the RSN keypair the
+// cascade builder already holds (g.Cascade.rsnPK / rsnSK), so the same
+// trusted-RSN authorization that gates cascade route setup gates the query.
+func (g *SetupRPCGateway) SignTransportQuery(args *SignTransportQueryArgs, reply *SignTransportQueryReply) error {
+	log := logging.MustGetLogger("sign-transport-query:" + g.ReqPK.String())
+	if g.Cascade == nil {
+		return errCascadeUnavailable
+	}
+	var nonceBuf [8]byte
+	if _, err := rand.Read(nonceBuf[:]); err != nil {
+		return err
+	}
+	q := &TransportQuery{
+		RSNPK:       g.Cascade.rsnPK,
+		TargetPK:    args.TargetPK,
+		RequesterPK: args.RequesterPK,
+		Nonce:       binary.BigEndian.Uint64(nonceBuf[:]),
+	}
+	if err := q.Sign(g.Cascade.rsnSK); err != nil {
+		log.WithError(err).Warn("SignTransportQuery: sign failed")
+		return err
+	}
+	reply.Query = q
 	return nil
 }
 

--- a/pkg/router/setupclient.go
+++ b/pkg/router/setupclient.go
@@ -144,6 +144,19 @@ func (c *SetupClient) FetchRelayPeers(ctx context.Context) ([]cipher.PubKey, err
 	return resp.Peers, nil
 }
 
+// SignTransportQuery asks the RSN to sign a transport-query capability
+// targeting dst on behalf of src (see the RSN-oracle 2-hop route path). The
+// signed query is carried by the source to dst, which verifies it against its
+// trusted-RSN allowlist before returning its transport list.
+func (c *SetupClient) SignTransportQuery(ctx context.Context, src, dst cipher.PubKey) (*TransportQuery, error) {
+	var resp SignTransportQueryReply
+	if err := c.call(ctx, rpcName+".SignTransportQuery",
+		&SignTransportQueryArgs{RequesterPK: src, TargetPK: dst}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Query, nil
+}
+
 // DialRouteGroup generates rules for routes from a visor and sends them to visors.
 func (c *SetupClient) DialRouteGroup(ctx context.Context, req routing.BidirectionalRoute) (routing.EdgeRules, error) {
 	var resp routing.EdgeRules

--- a/pkg/router/transport_query.go
+++ b/pkg/router/transport_query.go
@@ -1,0 +1,177 @@
+//go:build !tinygo || (js && wasm)
+
+// Package router pkg/router/transport_query.go c2-net-routing
+//
+// RSN-oracle transport-list query protocol (phase-1).
+//
+// A source visor S that wants to build a SINGLE-INTERMEDIATE (2-hop) route
+// S->I->D needs only two transport sets: its OWN (known locally) and the
+// destination D's OWN. The intermediate set is their overlap in peer PKs. D's
+// transports are authoritative and fresh from D itself, so a 2-hop route can be
+// computed WITHOUT the transport-discovery service (TPD) — TPD is only needed
+// for routes with >=2 intermediates.
+//
+// This file defines the query the source carries to the destination, reusing
+// the cascade RSN-signature primitive (cipher.Sign/Verify against a per-visor
+// trusted-RSN allowlist): the setup node (RSN) signs a query CAPABILITY
+// targeting D, and D honors the query only if the RSN is on its trust list and
+// the signature verifies for D's own PK — exactly the authorization model
+// CascadeSetup.Verify already enforces (see cascade.go). The query is a
+// one-shot control-plane message, so it marshals as JSON (the compact-entry
+// response already carries json tags); the cascade's hand-rolled binary form is
+// reserved for the per-hop data-plane-adjacent path.
+package router
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+var (
+	// ErrTransportQueryUntrustedRSN is returned when the query's RSN public key
+	// is not on the responding visor's trusted-RSN allowlist. Mirrors
+	// routing.ErrCascadeUntrustedRSN for the query path.
+	ErrTransportQueryUntrustedRSN = errors.New("transport-query: RSN public key not trusted")
+	// ErrTransportQuerySigInvalid is returned when the RSN signature does not
+	// verify against the responding visor's own PK.
+	ErrTransportQuerySigInvalid = errors.New("transport-query: RSN signature verification failed")
+	// ErrTransportQueryWrongTarget is returned when the query's TargetPK is not
+	// the responding visor's own PK (a query signed for a different destination
+	// must not be answered by this one).
+	ErrTransportQueryWrongTarget = errors.New("transport-query: target PK mismatch")
+)
+
+// TransportQuery is an RSN-signed capability that authorizes the requester S to
+// learn destination D's transport list. The RSN signs (RSNPK, TargetPK,
+// RequesterPK, Nonce); D verifies the signature against its OWN PK and its
+// trusted-RSN allowlist before responding. The signature binds the query to a
+// single destination and requester, so it cannot be replayed against another
+// visor or claimed by another requester.
+type TransportQuery struct {
+	RSNPK       cipher.PubKey `json:"rsn_pk"`       // RSN that authorized this query
+	TargetPK    cipher.PubKey `json:"target_pk"`    // destination D whose transports are requested
+	RequesterPK cipher.PubKey `json:"requester_pk"` // source S making the request
+	Nonce       uint64        `json:"nonce"`        // anti-replay, unique per query
+	RSNSig      cipher.Sig    `json:"rsn_sig"`      // RSN signature over SignablePayload
+}
+
+// SignablePayload returns the bytes signed/verified for this query: the RSN,
+// target and requester PKs plus the nonce. The layout mirrors
+// CascadeSetup.SignablePayload so the same cipher.Sign/Verify discipline applies.
+func (q *TransportQuery) SignablePayload() []byte {
+	// RSNPK(33) + TargetPK(33) + RequesterPK(33) + Nonce(8)
+	buf := make([]byte, 33+33+33+8)
+	off := 0
+	copy(buf[off:], q.RSNPK[:])
+	off += 33
+	copy(buf[off:], q.TargetPK[:])
+	off += 33
+	copy(buf[off:], q.RequesterPK[:])
+	off += 33
+	binary.BigEndian.PutUint64(buf[off:], q.Nonce)
+	return buf
+}
+
+// Sign signs the query with the RSN's secret key. Reuses the cascade signing
+// primitive: SHA256 of the signable payload, signed by the RSN.
+func (q *TransportQuery) Sign(rsnSK cipher.SecKey) error {
+	hash := cipher.SumSHA256(q.SignablePayload())
+	sig, err := cipher.SignPayload(hash[:], rsnSK)
+	if err != nil {
+		return err
+	}
+	q.RSNSig = sig
+	return nil
+}
+
+// Verify checks the query against the responding visor's own PK and its
+// trusted-RSN allowlist. It enforces, in order: (1) TargetPK is us, (2) the RSN
+// is trusted, (3) the signature verifies. Same authorization model as
+// CascadeHandler.handleSetup.
+func (q *TransportQuery) Verify(localPK cipher.PubKey, trustedRSNs map[cipher.PubKey]struct{}) error {
+	if q.TargetPK != localPK {
+		return ErrTransportQueryWrongTarget
+	}
+	if _, ok := trustedRSNs[q.RSNPK]; !ok {
+		return ErrTransportQueryUntrustedRSN
+	}
+	hash := cipher.SumSHA256(q.SignablePayload())
+	if err := cipher.VerifyPubKeySignedPayload(q.RSNPK, q.RSNSig, hash[:]); err != nil {
+		return ErrTransportQuerySigInvalid
+	}
+	return nil
+}
+
+// Marshal serializes the query as JSON.
+func (q *TransportQuery) Marshal() ([]byte, error) { return json.Marshal(q) }
+
+// UnmarshalTransportQuery deserializes a query from JSON.
+func UnmarshalTransportQuery(data []byte) (*TransportQuery, error) {
+	q := &TransportQuery{}
+	if err := json.Unmarshal(data, q); err != nil {
+		return nil, err
+	}
+	return q, nil
+}
+
+// TransportQueryResponse carries destination D's OWN transport list in the
+// compact wire form (remote edge + type; see transport.CompactEntry). The
+// requester reconstructs full entries with transport.EntryFromCompact(TargetPK,
+// entry) — the reporter being D itself.
+type TransportQueryResponse struct {
+	TargetPK cipher.PubKey            `json:"target_pk"`
+	Entries  []transport.CompactEntry `json:"entries"`
+}
+
+// Marshal serializes the response as JSON.
+func (r *TransportQueryResponse) Marshal() ([]byte, error) { return json.Marshal(r) }
+
+// UnmarshalTransportQueryResponse deserializes a response from JSON.
+func UnmarshalTransportQueryResponse(data []byte) (*TransportQueryResponse, error) {
+	r := &TransportQueryResponse{}
+	if err := json.Unmarshal(data, r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// BuildTransportQueryResponse is the DESTINATION-side (D) handler. Given a
+// signed query, the responding visor's PK, its trusted-RSN allowlist and its
+// transport manager, it verifies the RSN authorization and returns D's own live
+// data-plane transports in compact form.
+//
+// It applies the same exclusions the local route calculation uses: closed /
+// black-holed transports and LabelSetup (RSN control-plane) transports are
+// never advertised as route-able edges. The response is built by walking D's
+// transports and compacting each relative to D's own PK, so every entry
+// reconstructs (via EntryFromCompact) to the canonical Entry both endpoints
+// agree on.
+func BuildTransportQueryResponse(
+	q *TransportQuery,
+	localPK cipher.PubKey,
+	trustedRSNs map[cipher.PubKey]struct{},
+	tm *transport.Manager,
+) (*TransportQueryResponse, error) {
+	if err := q.Verify(localPK, trustedRSNs); err != nil {
+		return nil, err
+	}
+	resp := &TransportQueryResponse{TargetPK: localPK}
+	if tm == nil {
+		return resp, nil
+	}
+	tm.WalkTransports(func(tp *transport.ManagedTransport) bool {
+		if tp == nil || tp.IsClosed() {
+			return true
+		}
+		if tp.Entry.Label == transport.LabelSetup {
+			return true
+		}
+		resp.Entries = append(resp.Entries, tp.Entry.ToCompact(localPK))
+		return true
+	})
+	return resp, nil
+}

--- a/pkg/router/transport_query_dmsg.go
+++ b/pkg/router/transport_query_dmsg.go
@@ -1,0 +1,192 @@
+//go:build !tinygo || (js && wasm)
+
+// Package router pkg/router/transport_query_dmsg.go c2-net-routing
+//
+// dmsg-direct (phase-1) delivery for the RSN-oracle transport-list query.
+//
+// A source visor S carries an RSN-signed TransportQuery to destination D over
+// the always-available dmsg relay — the same way `tp --remote` / the setup
+// client reach a remote visor's RPC over dmsg (see setupclient.go). D listens on
+// skyenv.DmsgTransportQueryPort, verifies the RSN signature against its
+// trusted-RSN allowlist, and returns its own transport list.
+//
+// Both halves are served over gob RPC to match the existing setup-node path
+// (net/rpc server, gobrpc client — wire-compatible), so no new codec is
+// introduced. Everything here is inert unless the visor wires it (only started
+// when Routing.EnableRSNOracleRoutes is set — default OFF).
+package router
+
+import (
+	"context"
+	"errors"
+	"net/rpc"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	gobrpc "github.com/skycoin/skywire/pkg/gobrpc"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// transportQueryRPCName is the net/rpc service name the query gateway registers
+// under; the deliverer calls transportQueryRPCName+".Query".
+const transportQueryRPCName = "TransportQueryRPCGateway"
+
+// TransportQueryRPCGateway is the DESTINATION-side (D) RPC gateway that answers
+// RSN-oracle transport-list queries. It verifies the RSN signature against the
+// visor's trusted-RSN allowlist (via TrustedRSNs) and returns D's own transports
+// in compact form.
+type TransportQueryRPCGateway struct {
+	LocalPK cipher.PubKey
+	// TrustedRSNs returns the current trusted-RSN public keys (typically
+	// conf.EffectiveRouteSetupNodes) so allowlist edits at runtime are honored.
+	TrustedRSNs func() []cipher.PubKey
+	TM          *transport.Manager
+	Log         *logging.Logger
+}
+
+// Query is the net/rpc method D exposes. It verifies the signed query and
+// returns D's transport list. Errors (untrusted RSN, bad signature, wrong
+// target) propagate to the requester as RPC errors.
+func (g *TransportQueryRPCGateway) Query(q *TransportQuery, reply *TransportQueryResponse) error {
+	if q == nil {
+		return errors.New("transport-query: nil query")
+	}
+	trusted := map[cipher.PubKey]struct{}{}
+	if g.TrustedRSNs != nil {
+		for _, pk := range g.TrustedRSNs() {
+			trusted[pk] = struct{}{}
+		}
+	}
+	resp, err := BuildTransportQueryResponse(q, g.LocalPK, trusted, g.TM)
+	if err != nil {
+		if g.Log != nil {
+			g.Log.WithError(err).WithField("requester", q.RequesterPK).
+				Warn("transport-query: rejected")
+		}
+		return err
+	}
+	*reply = *resp
+	if g.Log != nil {
+		g.Log.WithField("requester", q.RequesterPK).
+			WithField("entries", len(resp.Entries)).
+			Debug("transport-query: answered")
+	}
+	return nil
+}
+
+// ServeTransportQueryListener listens on skyenv.DmsgTransportQueryPort and serves
+// the gateway to any visor that dials it. Blocks until ctx is canceled or the
+// listener fails. The caller starts it in a goroutine (see the visor init
+// wiring). Only invoked when the RSN-oracle path is enabled — a default visor
+// opens no listener here.
+func ServeTransportQueryListener(ctx context.Context, dmsgC *dmsg.Client, gw *TransportQueryRPCGateway, log *logging.Logger) error {
+	if dmsgC == nil {
+		return errors.New("transport-query: nil dmsg client")
+	}
+	lis, err := dmsgC.Listen(skyenv.DmsgTransportQueryPort)
+	if err != nil {
+		return err
+	}
+	go func() {
+		<-ctx.Done()
+		_ = lis.Close() //nolint:errcheck
+	}()
+
+	rpcS := rpc.NewServer()
+	if err := rpcS.RegisterName(transportQueryRPCName, gw); err != nil {
+		return err
+	}
+
+	if log != nil {
+		log.WithField("dmsg_port", skyenv.DmsgTransportQueryPort).
+			Info("RSN-oracle transport-query listener started")
+	}
+	for {
+		conn, err := lis.AcceptStream()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, dmsg.ErrEntityClosed) {
+				return nil
+			}
+			return err
+		}
+		go func() {
+			defer conn.Close()                                     //nolint:errcheck
+			_ = conn.SetDeadline(time.Now().Add(30 * time.Second)) //nolint:errcheck
+			rpcS.ServeConn(conn)
+		}()
+	}
+}
+
+// dmsgTransportQueryDeliverer implements TransportQueryDeliverer by dialing the
+// destination over dmsg and issuing the Query RPC.
+type dmsgTransportQueryDeliverer struct {
+	dmsgC *dmsg.Client
+	log   *logging.Logger
+}
+
+// NewDmsgTransportQueryDeliverer builds a dmsg-direct query deliverer.
+func NewDmsgTransportQueryDeliverer(dmsgC *dmsg.Client, log *logging.Logger) TransportQueryDeliverer {
+	return &dmsgTransportQueryDeliverer{dmsgC: dmsgC, log: log}
+}
+
+func (d *dmsgTransportQueryDeliverer) DeliverTransportQuery(ctx context.Context, dst cipher.PubKey, q *TransportQuery) (*TransportQueryResponse, error) {
+	if d.dmsgC == nil {
+		return nil, errors.New("transport-query: nil dmsg client")
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	conn, err := d.dmsgC.Dial(dialCtx, dmsg.Addr{PK: dst, Port: skyenv.DmsgTransportQueryPort})
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close() //nolint:errcheck
+
+	rpcC := gobrpc.NewClient(conn)
+	defer rpcC.Close() //nolint:errcheck
+
+	var reply TransportQueryResponse
+	if err := rpcCall(ctx, rpcC, transportQueryRPCName+".Query", q, &reply); err != nil {
+		return nil, err
+	}
+	return &reply, nil
+}
+
+// dmsgRSNOracle is the composed DstTransportOracle used by the visor: per call it
+// opens a fresh setup-node RPC connection (RSN connections are per-request, like
+// the cascade path in wrappers.go), asks the RSN to sign a transport-query, and
+// delivers it to the destination over dmsg.
+type dmsgRSNOracle struct {
+	dmsgC      *dmsg.Client
+	setupNodes []cipher.PubKey
+	deliverer  TransportQueryDeliverer
+	log        *logging.Logger
+}
+
+// NewDmsgRSNOracle builds the production DstTransportOracle: RSN signs over dmsg,
+// query delivered to the destination over dmsg. setupNodes is the trusted-RSN
+// list (conf.EffectiveRouteSetupNodes). Returns nil when no setup nodes are
+// configured, so the caller can leave the oracle unset (path stays inert).
+func NewDmsgRSNOracle(dmsgC *dmsg.Client, setupNodes []cipher.PubKey, log *logging.Logger) DstTransportOracle {
+	if dmsgC == nil || len(setupNodes) == 0 {
+		return nil
+	}
+	return &dmsgRSNOracle{
+		dmsgC:      dmsgC,
+		setupNodes: setupNodes,
+		deliverer:  NewDmsgTransportQueryDeliverer(dmsgC, log),
+		log:        log,
+	}
+}
+
+func (o *dmsgRSNOracle) DstTransports(ctx context.Context, src, dst cipher.PubKey) ([]*transport.Entry, error) {
+	client, err := NewSetupClient(ctx, o.log, o.dmsgC, o.setupNodes)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close() //nolint:errcheck
+	return fetchDstTransportsViaOracle(ctx, client.RPCClient(), o.deliverer, src, dst)
+}

--- a/pkg/router/transport_query_dmsg_test.go
+++ b/pkg/router/transport_query_dmsg_test.go
@@ -1,0 +1,140 @@
+//go:build !tinygo || (js && wasm)
+
+package router
+
+import (
+	"context"
+	"net"
+	"net/rpc"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	gobrpc "github.com/skycoin/skywire/pkg/gobrpc"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// servePipe registers rcvr under transportQueryRPCName on one end of an
+// in-memory pipe (the same net/rpc server + gob codec the dmsg listener uses)
+// and returns a gobrpc client bound to the other end — exercising the full
+// serialize → RPC → deserialize path without needing a real dmsg transport.
+func servePipe(t *testing.T, rcvr interface{}) *gobrpc.Client {
+	t.Helper()
+	srvConn, cliConn := net.Pipe()
+	rpcS := rpc.NewServer()
+	if err := rpcS.RegisterName(transportQueryRPCName, rcvr); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	go rpcS.ServeConn(srvConn)
+	cli := gobrpc.NewClient(cliConn)
+	t.Cleanup(func() { _ = cli.Close() })
+	return cli
+}
+
+func TestTransportQueryGateway_RPCRoundTrip_Valid(t *testing.T) {
+	rsnPK, rsnSK := cipher.GenerateKeyPair()
+	dstPK, _ := cipher.GenerateKeyPair()
+	srcPK, _ := cipher.GenerateKeyPair()
+
+	// Real gateway on D. TM is nil (no transports to advertise) — the verify +
+	// response-shape path is what this exercises over the wire.
+	gw := &TransportQueryRPCGateway{
+		LocalPK:     dstPK,
+		TrustedRSNs: func() []cipher.PubKey { return []cipher.PubKey{rsnPK} },
+		TM:          nil,
+	}
+	cli := servePipe(t, gw)
+
+	q := &TransportQuery{RSNPK: rsnPK, TargetPK: dstPK, RequesterPK: srcPK, Nonce: 5}
+	if err := q.Sign(rsnSK); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var reply TransportQueryResponse
+	if err := rpcCall(ctx, cli, transportQueryRPCName+".Query", q, &reply); err != nil {
+		t.Fatalf("Query RPC: %v", err)
+	}
+	if reply.TargetPK != dstPK {
+		t.Fatalf("reply.TargetPK = %s, want %s", reply.TargetPK, dstPK)
+	}
+}
+
+func TestTransportQueryGateway_RPCRoundTrip_Untrusted(t *testing.T) {
+	rsnPK, rsnSK := cipher.GenerateKeyPair()
+	otherRSN, _ := cipher.GenerateKeyPair()
+	dstPK, _ := cipher.GenerateKeyPair()
+	srcPK, _ := cipher.GenerateKeyPair()
+
+	// D trusts only otherRSN, but the query is signed by rsnPK → RPC must error.
+	gw := &TransportQueryRPCGateway{
+		LocalPK:     dstPK,
+		TrustedRSNs: func() []cipher.PubKey { return []cipher.PubKey{otherRSN} },
+		TM:          nil,
+	}
+	cli := servePipe(t, gw)
+
+	q := &TransportQuery{RSNPK: rsnPK, TargetPK: dstPK, RequesterPK: srcPK, Nonce: 6}
+	if err := q.Sign(rsnSK); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var reply TransportQueryResponse
+	err := rpcCall(ctx, cli, transportQueryRPCName+".Query", q, &reply)
+	if err == nil {
+		t.Fatal("expected RPC error for untrusted RSN, got nil")
+	}
+	if err.Error() != ErrTransportQueryUntrustedRSN.Error() {
+		t.Fatalf("error = %q, want %q", err.Error(), ErrTransportQueryUntrustedRSN.Error())
+	}
+}
+
+// stubQueryGW returns canned CompactEntries, proving the gob codec used by the
+// dmsg deliverer round-trips a []transport.CompactEntry response faithfully.
+type stubQueryGW struct{ resp TransportQueryResponse }
+
+func (s *stubQueryGW) Query(_ *TransportQuery, reply *TransportQueryResponse) error {
+	*reply = s.resp
+	return nil
+}
+
+func TestTransportQueryGateway_CompactEntriesOverWire(t *testing.T) {
+	dstPK, _ := cipher.GenerateKeyPair()
+	peer1, _ := cipher.GenerateKeyPair()
+	peer2, _ := cipher.GenerateKeyPair()
+
+	want := TransportQueryResponse{
+		TargetPK: dstPK,
+		Entries: []transport.CompactEntry{
+			{Remote: peer1, Type: tptypes.STCPR},
+			{Remote: peer2, Type: tptypes.SUDPH, Label: transport.LabelUser},
+		},
+	}
+	cli := servePipe(t, &stubQueryGW{resp: want})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var reply TransportQueryResponse
+	if err := rpcCall(ctx, cli, transportQueryRPCName+".Query", &TransportQuery{}, &reply); err != nil {
+		t.Fatalf("Query RPC: %v", err)
+	}
+	if len(reply.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(reply.Entries))
+	}
+	if reply.Entries[0].Remote != peer1 || reply.Entries[0].Type != tptypes.STCPR {
+		t.Fatalf("entry0 = %+v", reply.Entries[0])
+	}
+	if reply.Entries[1].Remote != peer2 || reply.Entries[1].Label != transport.LabelUser {
+		t.Fatalf("entry1 = %+v", reply.Entries[1])
+	}
+
+	// The requester reconstructs full entries from the compact response.
+	entries := reconstructDstEntries(dstPK, &reply)
+	if len(entries) != 2 || !entries[0].HasEdge(dstPK) || !entries[0].HasEdge(peer1) {
+		t.Fatalf("reconstruct failed: %+v", entries)
+	}
+}

--- a/pkg/router/transport_query_test.go
+++ b/pkg/router/transport_query_test.go
@@ -1,0 +1,108 @@
+//go:build !tinygo || (js && wasm)
+
+package router
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func trustedSet(pks ...cipher.PubKey) map[cipher.PubKey]struct{} {
+	m := make(map[cipher.PubKey]struct{}, len(pks))
+	for _, pk := range pks {
+		m[pk] = struct{}{}
+	}
+	return m
+}
+
+func TestTransportQuery_SignVerify_RoundTrip(t *testing.T) {
+	rsnPK, rsnSK := cipher.GenerateKeyPair()
+	dstPK, _ := cipher.GenerateKeyPair()
+	srcPK, _ := cipher.GenerateKeyPair()
+
+	q := &TransportQuery{RSNPK: rsnPK, TargetPK: dstPK, RequesterPK: srcPK, Nonce: 42}
+	if err := q.Sign(rsnSK); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	// Marshal/unmarshal must preserve the signature and fields.
+	b, err := q.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	q2, err := UnmarshalTransportQuery(b)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// D verifies against its own PK + trusted RSN → OK.
+	if err := q2.Verify(dstPK, trustedSet(rsnPK)); err != nil {
+		t.Fatalf("verify (valid) failed: %v", err)
+	}
+}
+
+func TestTransportQuery_Verify_UntrustedRSN(t *testing.T) {
+	rsnPK, rsnSK := cipher.GenerateKeyPair()
+	otherPK, _ := cipher.GenerateKeyPair()
+	dstPK, _ := cipher.GenerateKeyPair()
+	srcPK, _ := cipher.GenerateKeyPair()
+
+	q := &TransportQuery{RSNPK: rsnPK, TargetPK: dstPK, RequesterPK: srcPK, Nonce: 1}
+	if err := q.Sign(rsnSK); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	// RSN signed correctly, but D does not trust it.
+	if err := q.Verify(dstPK, trustedSet(otherPK)); err != ErrTransportQueryUntrustedRSN {
+		t.Fatalf("want ErrTransportQueryUntrustedRSN, got %v", err)
+	}
+}
+
+func TestTransportQuery_Verify_WrongTarget(t *testing.T) {
+	rsnPK, rsnSK := cipher.GenerateKeyPair()
+	dstPK, _ := cipher.GenerateKeyPair()
+	otherDstPK, _ := cipher.GenerateKeyPair()
+	srcPK, _ := cipher.GenerateKeyPair()
+
+	q := &TransportQuery{RSNPK: rsnPK, TargetPK: dstPK, RequesterPK: srcPK, Nonce: 7}
+	if err := q.Sign(rsnSK); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	// A visor that is NOT the query's target must refuse.
+	if err := q.Verify(otherDstPK, trustedSet(rsnPK)); err != ErrTransportQueryWrongTarget {
+		t.Fatalf("want ErrTransportQueryWrongTarget, got %v", err)
+	}
+}
+
+func TestTransportQuery_Verify_TamperedSignature(t *testing.T) {
+	rsnPK, rsnSK := cipher.GenerateKeyPair()
+	dstPK, _ := cipher.GenerateKeyPair()
+	srcPK, _ := cipher.GenerateKeyPair()
+
+	q := &TransportQuery{RSNPK: rsnPK, TargetPK: dstPK, RequesterPK: srcPK, Nonce: 9}
+	if err := q.Sign(rsnSK); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	// Tamper with the signed content after signing.
+	q.Nonce = 10
+	if err := q.Verify(dstPK, trustedSet(rsnPK)); err != ErrTransportQuerySigInvalid {
+		t.Fatalf("want ErrTransportQuerySigInvalid, got %v", err)
+	}
+}
+
+func TestBuildTransportQueryResponse_RejectsUntrusted(t *testing.T) {
+	rsnPK, rsnSK := cipher.GenerateKeyPair()
+	otherRSN, _ := cipher.GenerateKeyPair()
+	dstPK, _ := cipher.GenerateKeyPair()
+	srcPK, _ := cipher.GenerateKeyPair()
+
+	q := &TransportQuery{RSNPK: rsnPK, TargetPK: dstPK, RequesterPK: srcPK, Nonce: 3}
+	if err := q.Sign(rsnSK); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	// D trusts a DIFFERENT RSN → response builder must refuse (nil tm is fine,
+	// the verify happens first).
+	if _, err := BuildTransportQueryResponse(q, dstPK, trustedSet(otherRSN), nil); err != ErrTransportQueryUntrustedRSN {
+		t.Fatalf("want ErrTransportQueryUntrustedRSN, got %v", err)
+	}
+}

--- a/pkg/skyenv/ports_test.go
+++ b/pkg/skyenv/ports_test.go
@@ -38,6 +38,7 @@ func TestVisorPortsAreUnique(t *testing.T) {
 		"DmsgDMSGDClientsByServerCXOPort": DmsgDMSGDClientsByServerCXOPort,
 		"DmsgTPDAllTransportsCXOPort":     DmsgTPDAllTransportsCXOPort,
 		"DmsgDMSGDRegistrationCXOPort":    DmsgDMSGDRegistrationCXOPort,
+		"DmsgTransportQueryPort":          DmsgTransportQueryPort,
 		"DmsgWebRTCSignalPort":            DmsgWebRTCSignalPort,
 		"SkychatVoiceSignalPort":          SkychatVoiceSignalPort,
 		"SkychatVoiceMediaPort":           SkychatVoiceMediaPort,

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -121,6 +121,14 @@ const (
 	// needs to be collision-free, which the ports_test guards.
 	DmsgDMSGDRegistrationCXOPort uint16 = 67
 
+	// DmsgTransportQueryPort is the dmsg port a visor listens on to answer
+	// RSN-oracle transport-list queries (see pkg/router/transport_query.go). A
+	// source visor building a 2-hop route dials the destination here, delivers an
+	// RSN-signed TransportQuery, and receives the destination's own transport
+	// list. Control-plane only; served solely when Routing.EnableRSNOracleRoutes
+	// is set (default OFF), so it adds no listener on the default configuration.
+	DmsgTransportQueryPort uint16 = 68
+
 	// DmsgWebRTCSignalPort is the dmsg port the WebRTC carrier exchanges its SDP
 	// offer/answer + ICE candidates on (a visor dials a peer here to open a
 	// signaling stream; the answerer listens). It MUST live in this registry: it

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -282,22 +282,23 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 	// threaded through; the edge passes their zero values.
 	serveCtx, cancel := context.WithCancel(context.Background())
 	r, err := visorcore.BuildRouter(serveCtx, visorcore.RouterDeps{
-		DmsgC:              v.dmsgC,
-		PubKey:             v.conf.PK,
-		SecKey:             v.conf.SK,
-		TransportManager:   v.tpM,
-		RouteFinder:        rfClient,
-		RouteGroupDialer:   rgDialer,
-		SetupNodes:         v.conf.EffectiveRouteSetupNodes(),
-		MinHops:            v.conf.Routing.MinHops,
-		MuxRoutes:          v.conf.Routing.MuxRoutes,
-		AwaitSetupListener: v.awaitSetupListener,
-		Logger:             logger,
-		MasterLogger:       v.MasterLogger(),
-		AppLookup:          appLookup,
-		DialHook:           dialHook,
-		RulesGCInterval:    0, // 0 = DefaultRulesGCInterval (10s)
-		SetupHooks:         routeSetupHooks,
+		DmsgC:                 v.dmsgC,
+		PubKey:                v.conf.PK,
+		SecKey:                v.conf.SK,
+		TransportManager:      v.tpM,
+		RouteFinder:           rfClient,
+		RouteGroupDialer:      rgDialer,
+		SetupNodes:            v.conf.EffectiveRouteSetupNodes(),
+		MinHops:               v.conf.Routing.MinHops,
+		MuxRoutes:             v.conf.Routing.MuxRoutes,
+		AwaitSetupListener:    v.awaitSetupListener,
+		Logger:                logger,
+		MasterLogger:          v.MasterLogger(),
+		AppLookup:             appLookup,
+		DialHook:              dialHook,
+		RulesGCInterval:       0, // 0 = DefaultRulesGCInterval (10s)
+		SetupHooks:            routeSetupHooks,
+		EnableRSNOracleRoutes: v.conf.Routing.EnableRSNOracleRoutes,
 	})
 	if err != nil {
 		cancel()
@@ -321,6 +322,33 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 	v.tpM.SetRouteChecker(func(tpID uuid.UUID) bool {
 		return r.Rules() != nil && routeTableHasTransport(r, tpID)
 	})
+
+	// RSN-oracle 2-hop route path (opt-in, default OFF). When enabled, (a) wire
+	// the source-side oracle so 2-hop routes are computed from D's own
+	// transports (fetched via an RSN-signed query) instead of TPD, and (b) start
+	// the destination-side listener so peers can query THIS visor's transports.
+	// Both are inert unless Routing.EnableRSNOracleRoutes is set, so a default
+	// visor opens no extra listener and its dial path is unchanged.
+	if v.conf.Routing.EnableRSNOracleRoutes {
+		setupNodes := v.conf.EffectiveRouteSetupNodes()
+		if oracle := router.NewDmsgRSNOracle(v.dmsgC, setupNodes, logger); oracle != nil {
+			r.SetDstTransportOracle(oracle)
+			logger.Info("RSN-oracle 2-hop route path enabled (source-side oracle wired)")
+		} else {
+			logger.Warn("RSN-oracle 2-hop route path enabled but no route setup nodes configured; oracle inert")
+		}
+		gw := &router.TransportQueryRPCGateway{
+			LocalPK:     v.conf.PK,
+			TrustedRSNs: func() []cipher.PubKey { return v.conf.EffectiveRouteSetupNodes() },
+			TM:          v.tpM,
+			Log:         logger,
+		}
+		go func() {
+			if err := router.ServeTransportQueryListener(serveCtx, v.dmsgC, gw, logger); err != nil {
+				logger.WithError(err).Warn("RSN-oracle transport-query listener stopped")
+			}
+		}()
+	}
 
 	return nil
 }

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -642,6 +642,16 @@ type Routing struct {
 	// via PUT /api/visors/{pk}/router-settings.
 	TransportPreference []string `json:"transport_preference,omitempty"`
 
+	// EnableRSNOracleRoutes opts INTO the RSN-oracle 2-hop route path: for a
+	// single-intermediate route S->I->D the source computes the route LOCALLY
+	// from its OWN transports intersected with the destination's OWN transports
+	// (fetched authoritatively from D via an RSN-signed transport-query), making
+	// the common route type independent of the transport-discovery service
+	// (TPD). OFF by default; even when true the path is inert until the visor
+	// wires a destination-transport oracle (router.SetDstTransportOracle). TPD is
+	// still used for routes with >=2 intermediates.
+	EnableRSNOracleRoutes bool `json:"enable_rsn_oracle_routes,omitempty"`
+
 	// EnableCascadeRouteSetup opts INTO the source-driven cascade route-setup
 	// path (RSN signs, source injects the cascade down its own transports,
 	// avoiding the RSN's dmsg dependency). It is OFF by default: the cascade

--- a/pkg/visor/visorcore/router.go
+++ b/pkg/visor/visorcore/router.go
@@ -41,6 +41,11 @@ type RouterDeps struct {
 	DialHook        router.DialHook
 	RulesGCInterval time.Duration
 	SetupHooks      []router.RouteSetupHook
+
+	// EnableRSNOracleRoutes opts into the RSN-oracle 2-hop route path (default
+	// OFF). Seeded from Routing.EnableRSNOracleRoutes; inert until the visor also
+	// calls router.SetDstTransportOracle.
+	EnableRSNOracleRoutes bool
 }
 
 // BuildRouter assembles router.Config from deps, creates the router, and starts
@@ -52,20 +57,21 @@ type RouterDeps struct {
 // gotcha, or a newly-added Config field reaching only one of the two).
 func BuildRouter(serveCtx context.Context, deps RouterDeps) (router.Router, error) {
 	rConf := &router.Config{
-		Logger:             deps.Logger,
-		MasterLogger:       deps.MasterLogger,
-		PubKey:             deps.PubKey,
-		SecKey:             deps.SecKey,
-		TransportManager:   deps.TransportManager,
-		RouteFinder:        deps.RouteFinder,
-		RouteGroupDialer:   deps.RouteGroupDialer,
-		SetupNodes:         deps.SetupNodes,
-		MinHops:            deps.MinHops,
-		MuxRoutes:          deps.MuxRoutes,
-		AwaitSetupListener: deps.AwaitSetupListener,
-		AppLookup:          deps.AppLookup,
-		DialHook:           deps.DialHook,
-		RulesGCInterval:    deps.RulesGCInterval,
+		Logger:                deps.Logger,
+		MasterLogger:          deps.MasterLogger,
+		PubKey:                deps.PubKey,
+		SecKey:                deps.SecKey,
+		TransportManager:      deps.TransportManager,
+		RouteFinder:           deps.RouteFinder,
+		RouteGroupDialer:      deps.RouteGroupDialer,
+		SetupNodes:            deps.SetupNodes,
+		MinHops:               deps.MinHops,
+		MuxRoutes:             deps.MuxRoutes,
+		AwaitSetupListener:    deps.AwaitSetupListener,
+		AppLookup:             deps.AppLookup,
+		DialHook:              deps.DialHook,
+		RulesGCInterval:       deps.RulesGCInterval,
+		EnableRSNOracleRoutes: deps.EnableRSNOracleRoutes,
 	}
 	r, err := router.New(deps.DmsgC, rConf, deps.SetupHooks)
 	if err != nil {


### PR DESCRIPTION
Opt-in, **default-OFF** path to compute single-intermediate (2-hop) multiplexed routes from the destination's OWN transports — fetched via an RSN(setup-node)-signed query — instead of the transport-discovery service. For S→I→D you only need S's transports (local) ∩ D's transports (authoritative + fresh from D), so the common route type stops depending on TPD's view.

Reuses the cascade trust model: the setup-node (RSN) **signs** a transport-list query for target D; S delivers it to D **dmsg-direct** (new control-plane dmsg port 68, bound only when the flag is on); D **verifies** the RSN signature against its trusted-RSN allowlist and returns `[]transport.CompactEntry`; S computes the disjoint 2-hop route locally. TPD is used only for ≥2 intermediates and as fallback on any miss.

- Query protocol + Sign/Verify (mirrors CascadeSetup): `pkg/router/transport_query.go`
- dmsg-direct delivery + D-side listener (net/rpc over dmsg, port 68): `pkg/router/transport_query_dmsg.go`
- Local 2-hop disjoint computation (pure, tested): `pkg/router/rsn_oracle_routes.go`
- Gated in `fetchBestRoutes` (router_dial.go); wired in `init_router.go`; config `Routing.EnableRSNOracleRoutes` (default false)
- Design + graduation plan: `docs/rsn-oracle-2hop-routes.md`

**Default OFF and inert** — no listener, no dial-path change, zero behavior change unless the flag is set. `go build ./...` + `go build .` clean; `go vet` clean; `go test ./pkg/router/` green (15 tests: sign/verify incl untrusted/tampered/wrong-target, 2-hop disjoint compute, dmsg round-trip); skyenv port-uniqueness test passes.

**Graduation** (in the doc): Phase-1 = default-on as a *fallback-when-TPD-misses* (safe, once the listener ships); Phase-2 = *preferred* for 2-hop per-peer by **capability detection** (auto-graduates as the fleet updates), gated on measured setup-success/latency parity + response caching. Never fully replaces TPD. Deferred: phase-2 relay-over-transports, per-dial policy mapping, response caching, setup-client pooling.