### PR TITLE
fix(lint): clear golangci-lint issues from the discovery/routing series

### DIFF
--- a/pkg/cxo/node/transport_dmsg.go
+++ b/pkg/cxo/node/transport_dmsg.go
@@ -176,7 +176,7 @@ func (d *DMSG) ConnectPK(ctx context.Context, remotePK cipher.PubKey) (*Conn, er
 	// still dials a real DMSG conn here rather than adopting the TCP one
 	// into the DMSG cache. The deployment nodes this matters for (the TPD
 	// aggregator, the visor stats publisher) are DMSG-only, so in practice
-	// hasPeer only ever returns the DMSG conn — this is defence in depth.
+	// hasPeer only ever returns the DMSG conn — this is defense in depth.
 	var peerID skycipher.PubKey
 	copy(peerID[:], remotePK[:])
 	if existing, ok := d.n.hasPeer(peerID); ok && !existing.IsTCP() && connIsAlive(existing) {

--- a/pkg/router/transport_query_dmsg_test.go
+++ b/pkg/router/transport_query_dmsg_test.go
@@ -28,7 +28,7 @@ func servePipe(t *testing.T, rcvr interface{}) *gobrpc.Client {
 	}
 	go rpcS.ServeConn(srvConn)
 	cli := gobrpc.NewClient(cliConn)
-	t.Cleanup(func() { _ = cli.Close() })
+	t.Cleanup(func() { cli.Close() }) //nolint:errcheck,gosec
 	return cli
 }
 

--- a/pkg/visor/api_tpd_uptime_subscriber_test.go
+++ b/pkg/visor/api_tpd_uptime_subscriber_test.go
@@ -76,7 +76,7 @@ func TestReadUptimeWindowReassemblesPerVisorLeaves(t *testing.T) {
 			Online:   true,
 			Timeline: map[string][]byte{"2026-08-19": timelineBitmap(mkTimeline(slot))},
 		}
-		b, _ := json.Marshal(c)
+		b, _ := json.Marshal(c) //nolint:errcheck
 		return b
 	}
 	mgr := &fakeUptimeMgr{

--- a/pkg/visor/rpcgrpc/server_policy_bandwidth_test.go
+++ b/pkg/visor/rpcgrpc/server_policy_bandwidth_test.go
@@ -96,16 +96,16 @@ func TestApplyRotationDemotePromote(t *testing.T) {
 
 // TestApplyRotationDropReindexes pins the drop path: the dropped legs leave the
 // active slice (so subsequent snapshots re-index, matching route-group
-// semantics), their pump is cancelled + flagged inactive, and the executor
+// semantics), their pump is canceled + flagged inactive, and the executor
 // never drops the last alive leg.
 func TestApplyRotationDropReindexes(t *testing.T) {
 	c, events := newTestController(4)
 	start := time.Now()
 
-	cancelled := make([]bool, 4)
+	canceled := make([]bool, 4)
 	for i := range c.active {
 		i := i
-		c.active[i].pumpCancel = func() { cancelled[i] = true }
+		c.active[i].pumpCancel = func() { canceled[i] = true }
 	}
 
 	// Drop legs at positions 0 and 2 (original indices 0 and 2).
@@ -119,11 +119,11 @@ func TestApplyRotationDropReindexes(t *testing.T) {
 		t.Fatalf("drop did not compact correctly: survivor indices = %d,%d want 1,3",
 			c.active[0].index, c.active[1].index)
 	}
-	if !cancelled[0] || !cancelled[2] {
-		t.Errorf("dropped legs' pumps not cancelled: %v", cancelled)
+	if !canceled[0] || !canceled[2] {
+		t.Errorf("dropped legs' pumps not canceled: %v", canceled)
 	}
-	if cancelled[1] || cancelled[3] {
-		t.Errorf("surviving legs' pumps wrongly cancelled: %v", cancelled)
+	if canceled[1] || canceled[3] {
+		t.Errorf("surviving legs' pumps wrongly canceled: %v", canceled)
 	}
 	// all[] retains every leg for the Done totals.
 	if len(c.all) != 4 {


### PR DESCRIPTION
`make check` (golangci-lint with `check-blank: true`) flagged 6 issues introduced by #4014/#4015/#4017/#4018 that merged past CI (the lint stage was failing):
- **misspell**: `defence`→`defense`; `cancelled`→`canceled` ×3
- **errcheck (check-blank)**: blank-discarded `json.Marshal`; `cli.Close` in a test cleanup
- **gosec G104**: the same test-cleanup `Close`

Fixes: correct spellings; `//nolint:errcheck` on the marshal (a plain struct never errors); `//nolint:errcheck,gosec` on the test-cleanup Close (matches the repo's `defer Close //nolint` convention). Test/comment/nolint only — no functional change. Verified `golangci-lint run` clean on the affected packages; restores the `make check` lint stage.