### PR TITLE
chore(deps): bump 0magnet/xterm-go for cursor-blink Dispose fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/0magnet/cosmos-go v0.0.0-20260814190035-f5b882c1ea9e
 	github.com/0magnet/sh/v3 v3.13.2-0.20260814172914-eff537668adf
 	github.com/0magnet/websh v0.0.0-20260816200521-e9f14eb862c7
-	github.com/0magnet/xterm-go v0.0.0-20260816193539-5beca79629c0
+	github.com/0magnet/xterm-go v0.0.0-20260820124923-c0b6b4f69bb7
 	github.com/benhoyt/goawk v1.31.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/0magnet/websh v0.0.0-20260816200521-e9f14eb862c7 h1:09IjBB/rJMVtrkn4i
 github.com/0magnet/websh v0.0.0-20260816200521-e9f14eb862c7/go.mod h1:ziOzkV+FQYYYC4ivM/F2FwvuloQpljwetB5nyS4ElLI=
 github.com/0magnet/xterm-go v0.0.0-20260816193539-5beca79629c0 h1:vKuI1woBzCSkJiopdq6dgKAIEH8U2oJVpMh3AAI9/zk=
 github.com/0magnet/xterm-go v0.0.0-20260816193539-5beca79629c0/go.mod h1:W6c6ofSTsxXuQEr1rSZ3qmfOj5a3LGB3uLQBL0/TiKc=
+github.com/0magnet/xterm-go v0.0.0-20260820124923-c0b6b4f69bb7 h1:ZeiXWCwdYUfeWWWLs6IpgZ9tYOqyGPbZLLlNGYJi2Lo=
+github.com/0magnet/xterm-go v0.0.0-20260820124923-c0b6b4f69bb7/go.mod h1:W6c6ofSTsxXuQEr1rSZ3qmfOj5a3LGB3uLQBL0/TiKc=
 github.com/ActiveState/termtest/conpty v0.5.0 h1:JLUe6YDs4Jw4xNPCU+8VwTpniYOGeKzQg4SM2YHQNA8=
 github.com/ActiveState/termtest/conpty v0.5.0/go.mod h1:LO4208FLsxw6DcNZ1UtuGUMW+ga9PFtX4ntv8Ymg9og=
 github.com/AudriusButkevicius/pfilter v0.0.11 h1:6emuvqNeH1gGlqkML35pEizyPcaxdAN4JO9sdgwcx78=

--- a/vendor/github.com/0magnet/xterm-go/.golangci.yml
+++ b/vendor/github.com/0magnet/xterm-go/.golangci.yml
@@ -1,12 +1,11 @@
-# Mirrors the linter selection and settings used by skywire, so that code
-# shared between this repo and skywire's third_party copy is held to one
-# standard. Deliberate differences: skywire vendors its dependencies and this
-# repo does not, so modules-download-mode is left at the default; skywire's
-# repo-specific path exclusions and staticcheck text suppressions are not
-# carried over — findings here are fixed rather than silenced.
+# Kept in step with 0pcom/skywire, which is the reference for these repos.
+# The linter set and their settings are copied from there unchanged; what is
+# dropped is only skywire's own path exclusions, which name files that do not
+# exist here.
 version: "2"
 run:
   concurrency: 4
+  modules-download-mode: readonly
   issues-exit-code: 1
   tests: true
 output:
@@ -63,13 +62,41 @@ linters:
       - vendor/
       - third_party/
       - node_modules
+      - builtin$
+      - examples$
+    rules:
+      # The staticcheck suggestions skywire turns off. They are style
+      # preferences rather than defects, and the point of copying this file is
+      # that the same code passes in both places.
+      - linters:
+          - staticcheck
+        text: "QF1001:" # could apply De Morgan's law
+      - linters:
+          - staticcheck
+        text: "QF1002:" # could use tagged switch
+      - linters:
+          - staticcheck
+        text: "QF1003:" # could use tagged switch on error code
+      - linters:
+          - staticcheck
+        text: "QF1004:" # could use strings.ReplaceAll instead
+      - linters:
+          - staticcheck
+        text: "QF1006:" # could lift into loop condition
+      - linters:
+          - staticcheck
+        text: "QF1008:" # could remove embedded field from selector
+      - linters:
+          - staticcheck
+        text: "QF1010:" # could convert argument to string
+      - linters:
+          - staticcheck
+        text: "QF1012:" # could use fmt.Fprintf instead of WriteString(fmt.Sprintf)
+      - linters:
+          - staticcheck
+        text: "ST1005:" # error strings should not be capitalized
 issues:
   new: false
-  # golangci-lint truncates by default (50 per linter, 3 per identical
-  # message), which silently hides most findings in a repo like this one
-  # where the same idiom repeats across every applet. Report everything.
-  max-issues-per-linter: 0
-  max-same-issues: 0
 formatters:
   enable:
     - gofmt

--- a/vendor/github.com/0magnet/xterm-go/Makefile
+++ b/vendor/github.com/0magnet/xterm-go/Makefile
@@ -1,0 +1,136 @@
+.DEFAULT_GOAL := help
+.PHONY: help format tidy lint vet test test-wasm test-browser cover check install-linters docs
+
+# The targets that matter are `format` and `check`, and they mean the same
+# thing here as in 0pcom/skywire, which is the reference for these repos.
+# .golangci.yml is copied from there.
+
+PROJECT_BASE := github.com/0magnet/xterm-go
+OPTS ?= GO111MODULE=on
+
+# Whether the host checks run with cgo. 0 matches skywire, which is pure Go.
+# Repos whose real build needs cgo — a GUI, audio, anything binding a C library
+# — set this to 1, because linting them without it type-checks almost nothing.
+CGO ?= 0
+
+# Packages this toolchain cannot build at all — firmware for a different
+# target, say. Not the same as code that merely does not build for this host:
+# js/wasm is handled below by running the checks again in that context, which
+# is the better answer whenever it is available. Empty in most repos.
+SKIP ?=
+
+# Directories rather than import paths, because golangci-lint resolves a bare
+# import path against the working directory and then cannot find it.
+#
+# Listed with the same CGO_ENABLED the checks use. Listed with cgo on and
+# linted with it off, a cgo-only package is named and then found to have no
+# files in it, which fails the run rather than reporting anything about it.
+#
+# -e so that one package that cannot be listed does not empty the list. Without
+# it, a single unbuildable package makes `go list` fail for the whole module,
+# this comes back blank, and the run below reports that there is nothing to
+# check — which reads exactly like passing.
+PKGS = $(shell CGO_ENABLED=$(CGO) go list -e -f '{{.Dir}}' ./... 2>/dev/null $(if $(SKIP),| grep -vE '$(SKIP)'))
+JSPKGS = $(shell CGO_ENABLED=0 GOOS=js GOARCH=wasm go list -e -f '{{.Dir}}' ./... 2>/dev/null $(if $(SKIP),| grep -vE '$(SKIP)'))
+
+help: ## Show this help
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+tidy: ## Tidy dependencies
+	${OPTS} go mod tidy -v
+
+format: tidy ## Format the code. Needs goimports (make install-linters)
+	@if grep -qE '^(replace|exclude)' go.mod; then \
+		echo "ERROR: go.mod contains replace or exclude directives which break go install @version"; \
+		grep -E '^(replace|exclude)' go.mod; \
+		exit 1; \
+	fi
+	${OPTS} goimports -w -local ${PROJECT_BASE} $(shell go list -f '{{.Dir}}' ./... 2>/dev/null | grep -v /vendor/)
+
+lint: ## Run golangci-lint. Needs it installed (make install-linters)
+	command -v golangci-lint || go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	golangci-lint --version
+	@# Some of these repos are entirely js/wasm-tagged, so the host context has
+	@# nothing in it and linting it is an error rather than a pass.
+	@if [ -n "$(PKGS)" ]; then \
+		CGO_ENABLED=$(CGO) ${OPTS} golangci-lint run -c .golangci.yml $(PKGS); \
+	else \
+		echo '--- nothing builds for this host; skipping the host pass'; \
+	fi
+	@# A host run cannot see js/wasm-tagged files, so anything only they use
+	@# reads as dead — and anything wrong inside them is never checked at all.
+	@if grep -rlq '^//go:build js' --include='*.go' . 2>/dev/null; then \
+		echo '--- again in the js/wasm build context'; \
+		CGO_ENABLED=0 GOOS=js GOARCH=wasm ${OPTS} golangci-lint run -c .golangci.yml $(JSPKGS); \
+	fi
+
+vet: ## Run go vet
+	@if [ -n "$(PKGS)" ]; then \
+		CGO_ENABLED=$(CGO) ${OPTS} go vet $(PKGS); \
+	fi
+	@if grep -rlq '^//go:build js' --include='*.go' . 2>/dev/null; then \
+		CGO_ENABLED=0 GOOS=js GOARCH=wasm ${OPTS} go vet $(JSPKGS); \
+	fi
+
+test: ## Run tests. Falls back to the js/wasm ones where nothing builds here
+	@if [ -n "$(PKGS)" ]; then \
+		${OPTS} go test $(PKGS); \
+	else \
+		echo '--- nothing builds for this host; running the js/wasm tests instead'; \
+		$(MAKE) --no-print-directory test-wasm; \
+	fi
+
+# The exec wrapper Go ships for running a js/wasm binary under Node. It is what
+# makes `go test` work for code the host cannot build at all.
+WASMEXEC = $(shell go env GOROOT)/lib/wasm/go_js_wasm_exec
+
+test-wasm: ## Run the js/wasm tests under Node
+	@if [ ! -x "$(WASMEXEC)" ]; then \
+		echo 'no js/wasm exec wrapper in this Go installation; skipping'; exit 0; fi
+	@command -v node >/dev/null || { echo 'node is not installed; skipping'; exit 0; }
+	@# Node has no DOM: document, window and requestAnimationFrame are all
+	@# undefined. JS core is there, and a fake document can be installed from
+	@# Go with js.Global().Set, which is how the DOM-facing code is covered.
+	@if [ -n "$(JSPKGS)" ]; then \
+		CGO_ENABLED=0 GOOS=js GOARCH=wasm ${OPTS} go test -exec="$(WASMEXEC)" $(JSPKGS); \
+	else \
+		echo 'no js/wasm packages'; \
+	fi
+
+# Running the js/wasm tests in a real browser instead of Node. Node has no DOM;
+# a browser has one, plus canvas and WebGL. Tests that build a fake DOM should
+# detect a real one and use it, so the same tests run both ways — anything the
+# fake gets wrong then shows up as a test that passes under Node and fails here.
+#
+# CHROME may name any Chrome-compatible binary. Brave is one. Not called BROWSER:
+# that is a conventional environment variable (xdg uses it) and ?= would take
+# whatever it happens to be set to — firefox, on this machine.
+CHROME ?= $(shell command -v google-chrome chromium chromium-browser brave 2>/dev/null | head -1)
+
+test-browser: ## Run the js/wasm tests in a headless browser (needs wasmbrowsertest)
+	@command -v wasmbrowsertest >/dev/null || { \
+		echo 'wasmbrowsertest is not installed; go install github.com/agnivade/wasmbrowsertest@latest'; exit 0; }
+	@[ -n "$(CHROME)" ] || { echo 'no Chrome-compatible browser found (set CHROME=); skipping'; exit 0; }
+	@if [ -z "$(JSPKGS)" ]; then echo 'no js/wasm packages'; exit 0; fi
+	@# chromedp looks for a binary called google-chrome and does not pass
+	@# --no-sandbox, which some environments require. A shim supplies both.
+	@d=$$(mktemp -d); printf '#!/bin/sh\nexec %s --no-sandbox "$$@"\n' '$(CHROME)' > $$d/google-chrome; \
+		chmod +x $$d/google-chrome; \
+		PATH=$$d:$$PATH CGO_ENABLED=0 GOOS=js GOARCH=wasm ${OPTS} \
+			go test -exec=wasmbrowsertest $(JSPKGS); \
+		rc=$$?; rm -rf $$d; exit $$rc
+
+cover: ## Report test coverage per package
+	@if [ -n "$(PKGS)" ]; then \
+		CGO_ENABLED=$(CGO) ${OPTS} go test -cover $(PKGS) 2>&1 | grep -v '^ok.*no test files'; \
+	fi
+
+check: lint vet test ## Run linters, vet and tests
+
+install-linters: ## Install the linters
+	${OPTS} go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	${OPTS} go install golang.org/x/tools/cmd/goimports@latest
+
+docs: ## Regenerate the dependency graph and code counts in the README
+	./gendocs.sh

--- a/vendor/github.com/0magnet/xterm-go/README.md
+++ b/vendor/github.com/0magnet/xterm-go/README.md
@@ -131,3 +131,37 @@ Copyright (c) 2017-2022, The xterm.js authors (MIT License)<br>
 Copyright (c) 2014-2016, SourceLair Private Company (MIT License)<br>
 Copyright (c) 2012-2013, Christopher Jeffrey (MIT License)<br>
 Go port copyright (c) 2026 (MIT License)
+## Dependency Graph
+
+Made with [goda](https://github.com/loov/goda):
+
+```
+# GOOS=js: the import edges of a wasm program live in js/wasm-tagged
+# files and are invisible to a host-context run
+GOOS=js GOARCH=wasm go run github.com/loov/goda@latest graph github.com/0magnet/xterm-go/... | dot -Tsvg -o docs/xterm-go-goda-graph.svg
+```
+
+![Dependency Graph](docs/xterm-go-goda-graph.svg "github.com/0magnet/xterm-go Dependency Graph")
+
+## Lines of Code
+
+Made with [gocloc](https://github.com/hhatto/gocloc) (excludes `vendor/`, `node_modules/`, `.git/`):
+
+```
+gocloc --not-match-d='(vendor|node_modules|\.git)' .
+```
+
+```
+-------------------------------------------------------------------------------
+Language                     files          blank        comment           code
+-------------------------------------------------------------------------------
+Go                              36           1201           1535          11108
+JavaScript                       1             56             46            457
+Markdown                         1             40              0             93
+YAML                             1              0              9             69
+HTML                             1              0              0             30
+JSON                             2              0              0             28
+-------------------------------------------------------------------------------
+TOTAL                           42           1297           1590          11785
+-------------------------------------------------------------------------------
+```

--- a/vendor/github.com/0magnet/xterm-go/colors.go
+++ b/vendor/github.com/0magnet/xterm-go/colors.go
@@ -2,6 +2,8 @@ package xterm
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/0magnet/xterm-go/vt"
 )
@@ -63,7 +65,19 @@ type ColorSet struct {
 	Cursor       string
 	CursorAccent string
 	SelectionBg  string
-	Ansi         [256]string
+	// SelectionBgOpaque is SelectionBg composited over Background.
+	//
+	// A selection is conventionally translucent, and neither renderer can
+	// draw it that way: the WebGL rectangle renderer emits opaque quads, and
+	// the DOM renderer would have to know what is behind each span. Doing the
+	// compositing here, once, against the terminal background is what xterm.js
+	// does for the same reason, and it is right wherever the selection lies on
+	// the default background — which is nearly everywhere.
+	SelectionBgOpaque string
+	// SelectionFg recolors selected text, or is empty to leave each cell its
+	// own foreground.
+	SelectionFg string
+	Ansi        [256]string
 }
 
 // NewColorSet resolves a theme into concrete CSS colors.
@@ -93,7 +107,103 @@ func NewColorSet(theme vt.Theme) *ColorSet {
 	if theme.SelectionBackground != "" {
 		cs.SelectionBg = theme.SelectionBackground
 	}
+	cs.SelectionFg = theme.SelectionForeground
+	cs.SelectionBgOpaque = compositeOver(cs.SelectionBg, cs.Background)
 	return cs
+}
+
+// compositeOver flattens a possibly translucent color onto an opaque one.
+// Either being unreadable leaves the top color as it stands, which at worst
+// draws the selection solid rather than not at all.
+func compositeOver(top, bottom string) string {
+	tr, tg, tb, alpha, ok := parseRGBA(top)
+	if !ok {
+		return top
+	}
+	if alpha >= 1 {
+		return rgbCSS([3]int{tr, tg, tb})
+	}
+	br, bg, bb, _, ok := parseRGBA(bottom)
+	if !ok {
+		return top
+	}
+	blend := func(t, b int) int {
+		return int(float64(t)*alpha + float64(b)*(1-alpha) + 0.5)
+	}
+	return rgbCSS([3]int{blend(tr, br), blend(tg, bg), blend(tb, bb)})
+}
+
+// parseRGBA reads the CSS colors a theme is likely to hold. vt.ParseColor
+// covers the hex and X11 forms but has no notion of alpha, which is exactly
+// what a selection color is usually written with, so rgb()/rgba() and the
+// eight-digit hex form are read here.
+func parseRGBA(css string) (r, g, b int, alpha float64, ok bool) {
+	s := strings.TrimSpace(strings.ToLower(css))
+
+	if open := strings.IndexByte(s, '('); open >= 0 && strings.HasSuffix(s, ")") &&
+		(strings.HasPrefix(s, "rgb(") || strings.HasPrefix(s, "rgba(")) {
+		fields := strings.FieldsFunc(s[open+1:len(s)-1], func(r rune) bool {
+			return r == ',' || r == '/' || r == ' '
+		})
+		if len(fields) < 3 {
+			return 0, 0, 0, 0, false
+		}
+		var ch [3]int
+		for i := 0; i < 3; i++ {
+			v, err := strconv.ParseFloat(fields[i], 64)
+			if err != nil {
+				return 0, 0, 0, 0, false
+			}
+			if strings.HasSuffix(fields[i], "%") {
+				v = v * 255 / 100
+			}
+			ch[i] = clamp255(int(v + 0.5))
+		}
+		alpha = 1
+		if len(fields) > 3 {
+			v, err := strconv.ParseFloat(strings.TrimSuffix(fields[3], "%"), 64)
+			if err != nil {
+				return 0, 0, 0, 0, false
+			}
+			if strings.HasSuffix(fields[3], "%") {
+				v /= 100
+			}
+			alpha = min(max(v, 0), 1)
+		}
+		return ch[0], ch[1], ch[2], alpha, true
+	}
+
+	// #rrggbbaa: CSS's own alpha form, which the X11 parser reads as an
+	// invalid length rather than as a color with an alpha channel.
+	if len(s) == 9 && s[0] == '#' {
+		var ch [4]int
+		for i := 0; i < 4; i++ {
+			v, err := strconv.ParseUint(s[1+i*2:3+i*2], 16, 8)
+			if err != nil {
+				return 0, 0, 0, 0, false
+			}
+			ch[i] = int(v)
+		}
+		return ch[0], ch[1], ch[2], float64(ch[3]) / 255, true
+	}
+
+	if rgb, k := vt.ParseColor(css); k {
+		return rgb[0], rgb[1], rgb[2], 1, true
+	}
+	return 0, 0, 0, 0, false
+}
+
+func clamp255(v int) int { return min(max(v, 0), 255) }
+
+// rgbCSS renders a color as #rrggbb.
+func rgbCSS(c [3]int) string {
+	const hex = "0123456789abcdef"
+	b := []byte{'#', 0, 0, 0, 0, 0, 0}
+	for i, v := range c {
+		b[1+i*2] = hex[(v>>4)&0xf]
+		b[2+i*2] = hex[v&0xf]
+	}
+	return string(b)
 }
 
 // ResolveCellColors returns the fg/bg CSS colors of a cell ("" =

--- a/vendor/github.com/0magnet/xterm-go/contextmenu_js.go
+++ b/vendor/github.com/0magnet/xterm-go/contextmenu_js.go
@@ -1,0 +1,239 @@
+//go:build js && wasm
+
+package xterm
+
+import (
+	"syscall/js"
+)
+
+// The right-click menu.
+//
+// A browser's own Copy acts on the document's selection, and the terminal's is
+// not one: it is a range of buffer cells that the renderer draws, with no DOM
+// text behind it for the browser to have selected. So the browser offers no
+// Copy over a terminal, however much is highlighted — the keyboard shortcut
+// worked and the obvious gesture did not.
+//
+// The alternative to a menu of our own was to mirror the selection into the
+// hidden textarea and slide it under the pointer, so that the browser's menu
+// would be operating on a real editable field. That works until it does not:
+// the textarea has to cover the click, which means covering the terminal, and
+// there is no event for the menu closing again to uncover it.
+//
+// So the terminal draws its own, which is what every terminal emulator does
+// anyway. It also gets to offer Paste, which a browser will not do for a
+// non-editable element at all.
+
+// contextMenu is the popup and what it is currently offering.
+type contextMenu struct {
+	t *Terminal
+
+	el      js.Value // the menu, parented to the body
+	onClose js.Func  // dismisses it: a click anywhere, a scroll, a key
+	open    bool
+}
+
+// dismissCapturing are the events that close the menu wherever they happen.
+var dismissCapturing = []string{"mousedown", "wheel", "keydown", "resize"}
+
+// contextMenuCSS styles the menu against the terminal's own theme rather than
+// the page's, so it belongs to the terminal it pops out of.
+const contextMenuCSS = `
+.xterm-menu {
+  position: fixed; z-index: 2147483000; min-width: 148px; padding: 4px;
+  border: 1px solid #3a4150; border-radius: 6px; background: #1b1f27;
+  box-shadow: 0 6px 24px rgba(0,0,0,.45); user-select: none;
+  font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.xterm-menu button {
+  display: flex; justify-content: space-between; gap: 18px; width: 100%;
+  padding: 5px 9px; border: 0; border-radius: 4px; background: transparent;
+  color: #d3d7cf; font: inherit; text-align: left; cursor: default;
+}
+.xterm-menu button:hover:not(:disabled) { background: #2c333f; }
+.xterm-menu button:disabled { color: #5b626e; }
+.xterm-menu button span { color: #6b7280; }
+.xterm-menu hr { margin: 4px 2px; border: 0; border-top: 1px solid #2c333f; }
+`
+
+// wireContextMenu attaches the right-click handler.
+func (t *Terminal) wireContextMenu() {
+	t.menu = &contextMenu{t: t}
+	t.element.Call("addEventListener", "contextmenu", t.fn(func(_ js.Value, args []js.Value) any {
+		if t.NoContextMenu {
+			return nil
+		}
+		ev := args[0]
+		// An application that asked for mouse reporting may well want the
+		// right button; shift takes it back, as it does for selecting.
+		if t.Core.MouseService().AreMouseEventsActive() && !ev.Get("shiftKey").Bool() {
+			return nil
+		}
+		ev.Call("preventDefault")
+		t.menu.show(ev.Get("clientX").Float(), ev.Get("clientY").Float())
+		return nil
+	}))
+
+	// If a copy does reach us by some other route, it should carry the
+	// terminal's selection rather than whatever the page thinks is selected.
+	t.element.Call("addEventListener", "copy", t.fn(func(_ js.Value, args []js.Value) any {
+		if !t.HasSelection() {
+			return nil
+		}
+		ev := args[0]
+		if cd := ev.Get("clipboardData"); cd.Truthy() {
+			cd.Call("setData", "text/plain", t.Selection())
+			ev.Call("preventDefault")
+		}
+		return nil
+	}))
+}
+
+// show pops the menu up at a point in the viewport, nudged back inside it if it
+// would hang off the right or the bottom.
+func (m *contextMenu) show(x, y float64) {
+	m.hide()
+	ensureStylesheet()
+
+	m.el = document.Call("createElement", "div")
+	m.el.Set("className", "xterm-menu")
+
+	has := m.t.HasSelection()
+	m.item("Copy", "Ctrl+Shift+C", has, func() { m.t.CopySelection() })
+	m.item("Paste", "Ctrl+Shift+V", true, func() { m.t.PasteFromClipboard() })
+	m.el.Call("appendChild", document.Call("createElement", "hr"))
+	m.item("Select All", "Ctrl+Shift+A", true, func() { m.t.SelectAll() })
+
+	document.Get("body").Call("appendChild", m.el)
+
+	// Measured after it is in the document, because until then it has no size.
+	rect := m.el.Call("getBoundingClientRect")
+	w, h := rect.Get("width").Float(), rect.Get("height").Float()
+	vw := window.Get("innerWidth").Float()
+	vh := window.Get("innerHeight").Float()
+	if x+w > vw-4 {
+		x = max(vw-w-4, 4)
+	}
+	if y+h > vh-4 {
+		y = max(vh-h-4, 4)
+	}
+	m.el.Get("style").Set("left", jsPx(x))
+	m.el.Get("style").Set("top", jsPx(y))
+
+	// Anything else dismisses it, which is what a menu should do. The listeners
+	// capture so that dismissing does not also press whatever is underneath.
+	m.onClose = js.FuncOf(func(_ js.Value, args []js.Value) any {
+		if len(args) > 0 && args[0].Truthy() {
+			if target := args[0].Get("target"); target.Truthy() &&
+				m.el.Truthy() && m.el.Call("contains", target).Bool() {
+				return nil // a click on the menu is the menu's own business
+			}
+		}
+		m.hide()
+		return nil
+	})
+	for _, e := range dismissCapturing {
+		window.Call("addEventListener", e, m.onClose, true)
+	}
+	// The page losing focus should close the menu; the textarea losing it to a
+	// menu button should not, and blur does not bubble — so this one is not
+	// capturing, or pressing an item would dismiss the menu before the press
+	// became a click and nothing would ever be chosen.
+	window.Call("addEventListener", "blur", m.onClose)
+	m.open = true
+}
+
+// item adds a row. A disabled row is shown rather than hidden, so the menu does
+// not change shape depending on whether anything is selected.
+func (m *contextMenu) item(label, accel string, enabled bool, do func()) {
+	b := document.Call("createElement", "button")
+	b.Set("type", "button")
+	b.Set("disabled", !enabled)
+
+	name := document.Call("createElement", "span")
+	name.Set("textContent", label)
+	name.Get("style").Set("color", "inherit")
+	key := document.Call("createElement", "span")
+	key.Set("textContent", accel)
+	b.Call("appendChild", name)
+	b.Call("appendChild", key)
+
+	if enabled {
+		// Pressing a button would otherwise focus it, taking focus off the
+		// terminal for the moment it takes to choose something.
+		var down js.Func
+		down = js.FuncOf(func(_ js.Value, args []js.Value) any {
+			if len(args) > 0 {
+				args[0].Call("preventDefault")
+			}
+			down.Release()
+			return nil
+		})
+		b.Call("addEventListener", "mousedown", down)
+
+		var fn js.Func
+		fn = js.FuncOf(func(_ js.Value, args []js.Value) any {
+			if len(args) > 0 {
+				args[0].Call("preventDefault")
+				args[0].Call("stopPropagation")
+			}
+			m.hide()
+			do()
+			fn.Release()
+			return nil
+		})
+		b.Call("addEventListener", "click", fn)
+	}
+	m.el.Call("appendChild", b)
+}
+
+// hide takes the menu down and gives back everything it was holding.
+func (m *contextMenu) hide() {
+	if m == nil || !m.open {
+		return
+	}
+	m.open = false
+	for _, e := range dismissCapturing {
+		window.Call("removeEventListener", e, m.onClose, true)
+	}
+	window.Call("removeEventListener", "blur", m.onClose)
+	m.onClose.Release()
+	if m.el.Truthy() {
+		m.el.Call("remove")
+		m.el = js.Value{}
+	}
+	m.t.Focus()
+}
+
+// PasteFromClipboard reads the system clipboard and sends it to the terminal.
+//
+// Ctrl+Shift+V and the browser's own paste arrive as a paste event with the
+// data attached, which needs no permission. Asking for the clipboard rather
+// than being handed it does, so this may prompt, and does nothing if refused.
+func (t *Terminal) PasteFromClipboard() {
+	clipboard := window.Get("navigator").Get("clipboard")
+	if !clipboard.Truthy() || clipboard.Get("readText").Type() != js.TypeFunction {
+		return
+	}
+	promise := clipboard.Call("readText")
+	if !promise.Truthy() || promise.Get("then").Type() != js.TypeFunction {
+		return
+	}
+	var ok, failed js.Func
+	release := func() {
+		ok.Release()
+		failed.Release()
+	}
+	ok = js.FuncOf(func(_ js.Value, args []js.Value) any {
+		if len(args) > 0 && args[0].Type() == js.TypeString {
+			t.Paste(args[0].String())
+		}
+		release()
+		return nil
+	})
+	failed = js.FuncOf(func(js.Value, []js.Value) any {
+		release()
+		return nil
+	})
+	promise.Call("then", ok, failed)
+}

--- a/vendor/github.com/0magnet/xterm-go/gendocs.sh
+++ b/vendor/github.com/0magnet/xterm-go/gendocs.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Regenerate the dependency graph and the lines-of-code table in the README.
+#
+#   ./gendocs.sh          (or: make docs)
+#
+# Both sections are generated, so they drift the moment they are not
+# regenerated — which is how one of them ended up pointing at an image that
+# had never been committed. Run it when the dependencies or the code change.
+#
+# Needs goda, graphviz's dot, and gocloc:
+#   go install github.com/loov/goda@latest
+#   go install github.com/hhatto/gocloc/cmd/gocloc@latest
+set -eu
+
+cd "$(dirname "$0")"
+
+mod=$(awk '/^module /{print $2; exit}' go.mod)
+name=${mod##*/}
+svg="docs/$name-goda-graph.svg"
+
+for t in goda dot gocloc; do
+	command -v "$t" >/dev/null 2>&1 || { echo "gendocs: $t not found on PATH" >&2; exit 1; }
+done
+
+# A wasm program's import edges live in js/wasm-tagged files, and a run in the
+# host build context cannot see them — the graph comes out all but empty. So
+# the build context follows the code.
+if grep -rlq '^//go:build js' --include='*.go' . 2>/dev/null; then
+	env GOOS=js GOARCH=wasm goda graph "$mod/..." | dot -Tsvg -o "$svg"
+	cmd="GOOS=js GOARCH=wasm go run github.com/loov/goda@latest graph $mod/... | dot -Tsvg -o $svg"
+	note='# GOOS=js: the import edges of a wasm program live in js/wasm-tagged
+# files and are invisible to a host-context run'
+else
+	goda graph "$mod/..." | dot -Tsvg -o "$svg"
+	cmd="go run github.com/loov/goda@latest graph $mod/... | dot -Tsvg -o $svg"
+	note=''
+fi
+
+cloc=$(gocloc --not-match-d='(vendor|node_modules|\.git)' .)
+
+# Rewritten rather than patched, so the two sections cannot drift apart.
+awk '/^## Dependency Graph$/{exit} {print}' README.md > README.gendocs
+
+{
+	printf '## Dependency Graph\n\nMade with [goda](https://github.com/loov/goda):\n\n```\n'
+	[ -n "$note" ] && printf '%s\n' "$note"
+	printf '%s\n```\n\n![Dependency Graph](%s "%s Dependency Graph")\n\n' "$cmd" "$svg" "$mod"
+	printf '## Lines of Code\n\nMade with [gocloc](https://github.com/hhatto/gocloc) (excludes `vendor/`, `node_modules/`, `.git/`):\n\n'
+	printf '```\ngocloc --not-match-d='"'"'(vendor|node_modules|\\.git)'"'"' .\n```\n\n'
+	printf '```\n%s\n```\n' "$cloc"
+} >> README.gendocs
+
+mv README.gendocs README.md
+echo "gendocs: $svg and the code counts are up to date"

--- a/vendor/github.com/0magnet/xterm-go/selection.go
+++ b/vendor/github.com/0magnet/xterm-go/selection.go
@@ -1,0 +1,370 @@
+package xterm
+
+import (
+	"strings"
+
+	"github.com/0magnet/xterm-go/vt"
+)
+
+// Selecting text with the mouse.
+//
+// xterm.js keeps its selection in the DOM: the rows are real elements holding
+// real text, and dragging across them is the browser's own selection. That
+// stops working the moment the WebGL renderer is switched on, because then
+// every glyph is a textured quad on a canvas and the rows are hidden — there is
+// no text under the pointer to select. The addon says as much and leaves it at
+// that.
+//
+// So the selection is kept here instead, as a range of buffer cells, and drawn
+// by whichever renderer is active by recoloring the cells inside it. That has
+// three consequences worth stating, all of them improvements:
+//
+//   - it works identically under both renderers, so switching is invisible;
+//   - it copies what the terminal knows rather than what the DOM happens to
+//     hold, so a line that wrapped comes back as one line and trailing blanks
+//     are not copied;
+//   - it is testable without a browser, which is why this file takes the two
+//     things it needs as functions and knows nothing about a Terminal, while
+//     the mouse, the clipboard and the drawing live next door.
+//
+// The browser's own selection is disabled over the terminal, so there is
+// exactly one selection rather than two that disagree.
+
+// pos is a cell: a column, and an index into the buffer's lines rather than a
+// viewport row, so a selection stays on its text when the view is scrolled.
+type pos struct{ col, line int }
+
+func (p pos) before(q pos) bool {
+	return p.line < q.line || (p.line == q.line && p.col < q.col)
+}
+
+// Selection modes, in the order a repeated click steps through them.
+const (
+	selectChar = iota
+	selectWord
+	selectLine
+)
+
+// wordSeparators are the characters a double-click will not cross. It is
+// xterm.js's default set: notably it does not include the path separator, so
+// double-clicking a filename selects the whole path.
+const wordSeparators = " ()[]{}'\"`"
+
+// selection is a range of cells in one buffer.
+//
+// It holds an anchor and a focus rather than a start and an end because a drag
+// can go either way, and because in word and line mode the range is the union
+// of the whole unit under each — which is what makes dragging back across the
+// origin keep the word you started on.
+type selection struct {
+	cols   func() int
+	buffer func() *vt.Buffer
+
+	// dirty is told which rows need redrawing; changed that there is a new
+	// selection to report. Either may be nil.
+	dirty   func(start, end pos)
+	changed func()
+
+	// buf is the buffer the selection was made in. Switching to the alternate
+	// screen and back leaves the coordinates meaningless, so they are dropped
+	// rather than drawn somewhere arbitrary.
+	buf *vt.Buffer
+
+	has    bool // there is something to draw and copy
+	active bool // a drag is in progress
+	moved  bool // the drag has left the cell it started on
+	mode   int
+
+	anchor, focus pos
+}
+
+func newSelection(cols func() int, buffer func() *vt.Buffer) *selection {
+	return &selection{cols: cols, buffer: buffer}
+}
+
+// valid reports whether the selection still describes the live buffer.
+func (s *selection) valid() bool {
+	return s != nil && s.has && s.buf != nil && s.buf == s.buffer()
+}
+
+func (s *selection) markDirty(start, end pos) {
+	if s.dirty != nil {
+		s.dirty(start, end)
+	}
+}
+
+func (s *selection) notify() {
+	if s.changed != nil {
+		s.changed()
+	}
+}
+
+// drop forgets the selection. It is called when the coordinates stop meaning
+// anything: a buffer switch, a scrollback trim, a resize, or new input.
+func (s *selection) drop() {
+	if s == nil || (!s.has && !s.active) {
+		return
+	}
+	start, end, ok := s.span()
+	s.has = false
+	s.active = false
+	s.moved = false
+	s.buf = nil
+	if ok {
+		s.markDirty(start, end)
+	}
+	s.notify()
+}
+
+// span is the selected range, normalized: start is the first selected cell and
+// end is one past the last, so an end column may be the width of the terminal.
+func (s *selection) span() (start, end pos, ok bool) {
+	if s == nil || !s.has {
+		return start, end, false
+	}
+	start, end = s.unit(s.anchor)
+	fs, fe := s.unit(s.focus)
+	if fs.before(start) {
+		start = fs
+	}
+	if end.before(fe) {
+		end = fe
+	}
+	return start, end, true
+}
+
+// unit is the range a single position selects on its own: the cell in
+// character mode, the word around it in word mode, the whole logical line in
+// line mode.
+func (s *selection) unit(p pos) (start, end pos) {
+	switch s.mode {
+	case selectWord:
+		return s.wordAround(p)
+	case selectLine:
+		return s.lineAround(p)
+	default:
+		return p, s.after(p)
+	}
+}
+
+// contains reports whether a cell is selected. col is a column and line is an
+// index into the buffer's lines, not a viewport row.
+func (s *selection) contains(col, line int) bool {
+	if !s.valid() {
+		return false
+	}
+	start, end, ok := s.span()
+	if !ok {
+		return false
+	}
+	if line < start.line || line > end.line {
+		return false
+	}
+	if line == start.line && col < start.col {
+		return false
+	}
+	if line == end.line && col >= end.col {
+		return false
+	}
+	return true
+}
+
+// text is the selected text.
+//
+// Two things distinguish it from reading the same cells off the screen. A row
+// whose successor is a continuation of it was never ended by a newline, so the
+// two are joined without one and its trailing blanks are kept; every other row
+// is trimmed, because the blanks to the right of a line are padding the
+// terminal added and not something anyone selected.
+func (s *selection) text() string {
+	start, end, ok := s.span()
+	if !ok || !s.valid() {
+		return ""
+	}
+	b := s.buffer()
+	var sb strings.Builder
+	for i := max(start.line, 0); i <= end.line && i < b.Lines.Length(); i++ {
+		line := b.Lines.Get(i)
+		from, to := 0, line.Length
+		if i == start.line {
+			from = max(start.col, 0)
+		}
+		if i == end.line {
+			to = end.col
+		}
+		to = min(to, line.Length)
+		wrapped := i+1 < b.Lines.Length() && b.Lines.Get(i+1).IsWrapped
+		if from < to {
+			sb.WriteString(line.TranslateToString(!wrapped, from, to))
+		}
+		if i != end.line && !wrapped {
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+// cell is the text of one cell, or "" where there is none.
+func (s *selection) cell(p pos) string {
+	b := s.buffer()
+	if p.line < 0 || p.line >= b.Lines.Length() {
+		return ""
+	}
+	line := b.Lines.Get(p.line)
+	if p.col < 0 || p.col >= line.Length {
+		return ""
+	}
+	return line.GetString(p.col)
+}
+
+func (s *selection) isSeparator(p pos) bool {
+	c := s.cell(p)
+	return c == "" || strings.ContainsAny(c, wordSeparators)
+}
+
+// stepBack moves one cell left, crossing into the row above only when this row
+// is a continuation of it — a word broken across a wrap is still one word.
+func (s *selection) stepBack(p pos) (pos, bool) {
+	if p.col > 0 {
+		return pos{p.col - 1, p.line}, true
+	}
+	b := s.buffer()
+	if p.line <= 0 || p.line >= b.Lines.Length() || !b.Lines.Get(p.line).IsWrapped {
+		return p, false
+	}
+	return pos{s.cols() - 1, p.line - 1}, true
+}
+
+// stepForward is stepBack the other way.
+func (s *selection) stepForward(p pos) (pos, bool) {
+	if p.col < s.cols()-1 {
+		return pos{p.col + 1, p.line}, true
+	}
+	b := s.buffer()
+	if p.line+1 >= b.Lines.Length() || !b.Lines.Get(p.line+1).IsWrapped {
+		return p, false
+	}
+	return pos{0, p.line + 1}, true
+}
+
+// after is the exclusive position one past p.
+func (s *selection) after(p pos) pos {
+	if q, ok := s.stepForward(p); ok {
+		return q
+	}
+	return pos{p.col + 1, p.line}
+}
+
+// wordAround expands to the run of non-separators containing p. Landing on a
+// separator selects just that cell rather than the run either side of it,
+// which is what feels right when you were aiming at a word and missed.
+func (s *selection) wordAround(p pos) (start, end pos) {
+	if s.isSeparator(p) {
+		return p, s.after(p)
+	}
+	start = p
+	for {
+		q, ok := s.stepBack(start)
+		if !ok || s.isSeparator(q) {
+			break
+		}
+		start = q
+	}
+	last := p
+	for {
+		q, ok := s.stepForward(last)
+		if !ok || s.isSeparator(q) {
+			break
+		}
+		last = q
+	}
+	return start, s.after(last)
+}
+
+// lineAround expands to the whole logical line, following the wrap in both
+// directions so a triple-click on a wrapped command selects all of it.
+func (s *selection) lineAround(p pos) (start, end pos) {
+	b := s.buffer()
+	top, bottom := p.line, p.line
+	for top > 0 && top < b.Lines.Length() && b.Lines.Get(top).IsWrapped {
+		top--
+	}
+	for bottom+1 < b.Lines.Length() && b.Lines.Get(bottom+1).IsWrapped {
+		bottom++
+	}
+	return pos{0, top}, pos{s.cols(), bottom}
+}
+
+// begin starts a selection at p in the given mode.
+func (s *selection) begin(p pos, mode int) {
+	s.drop()
+	s.buf = s.buffer()
+	s.mode = mode
+	s.anchor, s.focus = p, p
+	s.active = true
+	s.moved = false
+	// A bare click selects nothing until it becomes a drag; a double or triple
+	// click has already selected its unit and should show it at once.
+	s.has = mode != selectChar
+	if s.has {
+		if start, end, ok := s.span(); ok {
+			s.markDirty(start, end)
+		}
+		s.notify()
+	}
+}
+
+// extend moves the focus, which is the whole of what a drag does.
+func (s *selection) extend(p pos) {
+	if !s.active || p == s.focus {
+		return
+	}
+	oldStart, oldEnd, had := s.span()
+	s.focus = p
+	if p != s.anchor {
+		s.moved = true
+	}
+	if s.mode == selectChar && !s.moved {
+		return
+	}
+	s.has = true
+	newStart, newEnd, _ := s.span()
+	if had {
+		s.markDirty(oldStart, oldEnd)
+	}
+	s.markDirty(newStart, newEnd)
+	s.notify()
+}
+
+// finish ends a drag, leaving whatever it selected in place.
+//
+// Only selection_js.go calls it, and that file is js/wasm-only, so a
+// host-context lint sees no caller and reports this as dead.
+func (s *selection) finish() { //nolint:unused
+	if !s.active {
+		return
+	}
+	s.active = false
+	if !s.has {
+		s.buf = nil
+	}
+}
+
+// selectAll takes the whole buffer, scrollback included.
+func (s *selection) selectAll() {
+	b := s.buffer()
+	if b.Lines.Length() == 0 {
+		return
+	}
+	s.drop()
+	s.buf = b
+	s.mode = selectChar
+	s.anchor = pos{0, 0}
+	s.focus = pos{s.cols() - 1, b.Lines.Length() - 1}
+	s.has = true
+	s.moved = true
+	if start, end, ok := s.span(); ok {
+		s.markDirty(start, end)
+	}
+	s.notify()
+}

--- a/vendor/github.com/0magnet/xterm-go/selection_js.go
+++ b/vendor/github.com/0magnet/xterm-go/selection_js.go
@@ -1,0 +1,351 @@
+//go:build js && wasm
+
+package xterm
+
+import (
+	"syscall/js"
+
+	"github.com/0magnet/xterm-go/vt"
+)
+
+// The browser side of the selection: turning pointer events into a range,
+// keeping a drag alive past the edge of the terminal, and getting the result
+// onto the system clipboard.
+
+// selectionAutoScrollMS is how often a drag held past the top or bottom edge
+// scrolls by one line. Slow enough to aim with, fast enough to get somewhere.
+const selectionAutoScrollMS = 50
+
+// selectionInput wires the pointer to the selection.
+type selectionInput struct {
+	t *Terminal
+
+	// A drag continues while the button is held, wherever the pointer goes, so
+	// move and up are watched on the document rather than on the terminal.
+	moveFn, upFn js.Func
+	wired        bool
+
+	scrollTimer js.Value
+	scrollBy    int
+}
+
+// mouseDown starts, extends or ignores a selection, and reports whether it took
+// the event.
+//
+// An application that has asked for mouse reporting gets the mouse, because it
+// asked; holding shift takes it back, which is the convention every terminal
+// emulator uses for exactly this conflict.
+func (t *Terminal) selectionMouseDown(ev js.Value) bool {
+	if ev.Get("button").Int() != 0 {
+		return false
+	}
+	if t.Core.MouseService().AreMouseEventsActive() && !ev.Get("shiftKey").Bool() {
+		return false
+	}
+
+	p := t.selectionPos(ev)
+
+	// Shift-clicking extends the selection rather than starting a new one.
+	if ev.Get("shiftKey").Bool() && t.sel.valid() {
+		t.sel.active = true
+		t.sel.extend(p)
+	} else {
+		// The browser counts the clicks for us: detail is 1, 2, 3 and then on
+		// past 3, so a fourth click starts over at a character.
+		mode := selectChar
+		switch (ev.Get("detail").Int() - 1) % 3 {
+		case 1:
+			mode = selectWord
+		case 2:
+			mode = selectLine
+		}
+		t.sel.begin(p, mode)
+	}
+
+	// Without this the browser starts its own drag — of the page's selection,
+	// or of an image — over the top of ours.
+	ev.Call("preventDefault")
+	t.Focus()
+	t.scheduleRender(false)
+	return true
+}
+
+func (t *Terminal) selectionMouseMove(ev js.Value) {
+	if !t.sel.active {
+		return
+	}
+	t.sel.extend(t.selectionPos(ev))
+	t.selectionAutoScroll(ev)
+	t.scheduleRender(false)
+}
+
+func (t *Terminal) selectionMouseUp() {
+	if !t.sel.active {
+		return
+	}
+	t.selectionStopAutoScroll()
+	t.sel.finish()
+	if t.CopyOnSelect && t.sel.valid() {
+		t.CopySelection()
+	}
+	t.scheduleRender(false)
+}
+
+// selectionPos is the cell under the pointer, in buffer coordinates.
+//
+// The row is clamped into the viewport rather than dropped, so a drag that has
+// left the terminal still selects up to the edge it left by; the column is
+// clamped the same way, which is what makes dragging off the right-hand side
+// select to the end of the row.
+func (t *Terminal) selectionPos(ev js.Value) pos {
+	col, row, _, _ := t.mouseCell(ev)
+	col = clampInt(col, t.Core.Cols()-1)
+	row = clampInt(row, t.Core.Rows()-1)
+	b := t.Core.Buffer()
+	return pos{col: col, line: clampInt(b.YDisp+row, b.Lines.Length()-1)}
+}
+
+// selectionAutoScroll keeps a drag going once it reaches the top or bottom of
+// the terminal, which is the only way to select more than a screenful.
+func (t *Terminal) selectionAutoScroll(ev js.Value) {
+	rect := t.screen.Call("getBoundingClientRect")
+	y := ev.Get("clientY").Float()
+	switch {
+	case y < rect.Get("top").Float():
+		t.startAutoScroll(-1)
+	case y > rect.Get("bottom").Float():
+		t.startAutoScroll(1)
+	default:
+		t.selectionStopAutoScroll()
+	}
+}
+
+func (t *Terminal) startAutoScroll(by int) {
+	if t.selInput.scrollBy == by && t.selInput.scrollTimer.Truthy() {
+		return
+	}
+	t.selectionStopAutoScroll()
+	t.selInput.scrollBy = by
+	tick := t.fn(func(js.Value, []js.Value) any {
+		if !t.sel.active {
+			t.selectionStopAutoScroll()
+			return nil
+		}
+		before := t.Core.Buffer().YDisp
+		t.Core.ScrollLines(by)
+		b := t.Core.Buffer()
+		if b.YDisp == before {
+			return nil // already at the end of the scrollback
+		}
+		// The pointer has not moved; the text under it has. Following the edge
+		// it is held against is what makes the selection grow.
+		row := 0
+		if by > 0 {
+			row = t.Core.Rows() - 1
+		}
+		t.sel.extend(pos{col: t.sel.focus.col, line: clampInt(b.YDisp+row, b.Lines.Length()-1)})
+		t.scheduleRender(false)
+		return nil
+	})
+	t.selInput.scrollTimer = window.Call("setInterval", tick, selectionAutoScrollMS)
+}
+
+func (t *Terminal) selectionStopAutoScroll() {
+	if t.selInput.scrollTimer.Truthy() {
+		window.Call("clearInterval", t.selInput.scrollTimer)
+		t.selInput.scrollTimer = js.Value{}
+	}
+	t.selInput.scrollBy = 0
+}
+
+// wireSelection attaches the pointer handlers. Move and up go on the document
+// so that a drag survives leaving the terminal; they are removed by Dispose,
+// which is why they are kept rather than passed to fn and forgotten.
+func (t *Terminal) wireSelection() {
+	if t.selInput.wired {
+		return
+	}
+	t.selInput.wired = true
+	t.selInput.moveFn = js.FuncOf(func(_ js.Value, args []js.Value) any {
+		t.selectionMouseMove(args[0])
+		return nil
+	})
+	t.selInput.upFn = js.FuncOf(func(js.Value, []js.Value) any {
+		t.selectionMouseUp()
+		return nil
+	})
+	document.Call("addEventListener", "mousemove", t.selInput.moveFn)
+	document.Call("addEventListener", "mouseup", t.selInput.upFn)
+}
+
+func (t *Terminal) unwireSelection() {
+	if !t.selInput.wired {
+		return
+	}
+	t.selInput.wired = false
+	t.selectionStopAutoScroll()
+	document.Call("removeEventListener", "mousemove", t.selInput.moveFn)
+	document.Call("removeEventListener", "mouseup", t.selInput.upFn)
+	t.selInput.moveFn.Release()
+	t.selInput.upFn.Release()
+}
+
+// selectionKeydown handles the keys that act on a selection, and reports
+// whether it took the event.
+//
+// Ctrl+Shift+C rather than Ctrl+C, because Ctrl+C has to keep interrupting the
+// program: that is the whole reason terminals moved copy onto the shifted key.
+// On a Mac the command key is free, so Cmd+C means copy there and nothing has
+// to be given up.
+func (t *Terminal) selectionKeydown(ev js.Value) bool {
+	key := ev.Get("key").String()
+	if len(key) != 1 {
+		return false
+	}
+	lower := key
+	if key[0] >= 'A' && key[0] <= 'Z' {
+		lower = string(rune(key[0] - 'A' + 'a'))
+	}
+	ctrlShift := ev.Get("ctrlKey").Bool() && ev.Get("shiftKey").Bool()
+	meta := ev.Get("metaKey").Bool() && !ev.Get("ctrlKey").Bool()
+
+	switch lower {
+	case "c":
+		if (ctrlShift || meta) && t.HasSelection() {
+			t.CopySelection()
+			ev.Call("preventDefault")
+			ev.Call("stopPropagation")
+			return true
+		}
+	case "a":
+		if ctrlShift || meta {
+			t.SelectAll()
+			t.scheduleRender(false)
+			ev.Call("preventDefault")
+			ev.Call("stopPropagation")
+			return true
+		}
+	}
+	return false
+}
+
+// HasSelection reports whether any text is selected.
+func (t *Terminal) HasSelection() bool { return t.sel.valid() }
+
+// Selection is the selected text, or "" if there is none.
+func (t *Terminal) Selection() string {
+	if !t.sel.valid() {
+		return ""
+	}
+	return t.sel.text()
+}
+
+// ClearSelection deselects.
+func (t *Terminal) ClearSelection() {
+	t.sel.drop()
+	t.scheduleRender(false)
+}
+
+// SelectAll selects the whole buffer, scrollback included.
+func (t *Terminal) SelectAll() {
+	t.sel.selectAll()
+	t.scheduleRender(false)
+}
+
+// CopySelection puts the selected text on the system clipboard.
+func (t *Terminal) CopySelection() {
+	text := t.Selection()
+	if text == "" {
+		return
+	}
+	t.writeClipboard(text)
+}
+
+// writeClipboard prefers the asynchronous clipboard API and falls back to the
+// old hidden-textarea trick, which needs no permission and works in the
+// insecure contexts where navigator.clipboard is simply absent.
+func (t *Terminal) writeClipboard(text string) {
+	clipboard := window.Get("navigator").Get("clipboard")
+	if !clipboard.Truthy() || clipboard.Get("writeText").Type() != js.TypeFunction {
+		t.copyViaTextarea(text)
+		return
+	}
+	promise := clipboard.Call("writeText", text)
+	if !promise.Truthy() || promise.Get("then").Type() != js.TypeFunction {
+		return
+	}
+	// A rejected promise nobody is listening to is an unhandled rejection in
+	// the console, and the rejection is the interesting case: it means the page
+	// lacks permission and the fallback is the only way through.
+	var ok, failed js.Func
+	release := func() {
+		ok.Release()
+		failed.Release()
+	}
+	ok = js.FuncOf(func(js.Value, []js.Value) any {
+		release()
+		return nil
+	})
+	failed = js.FuncOf(func(js.Value, []js.Value) any {
+		t.copyViaTextarea(text)
+		release()
+		return nil
+	})
+	promise.Call("then", ok, failed)
+}
+
+func (t *Terminal) copyViaTextarea(text string) {
+	ta := document.Call("createElement", "textarea")
+	ta.Set("value", text)
+	style := ta.Get("style")
+	style.Set("position", "fixed")
+	style.Set("top", "0")
+	style.Set("left", "-9999px")
+	style.Set("opacity", "0")
+	document.Get("body").Call("appendChild", ta)
+	ta.Call("focus")
+	ta.Call("select")
+	document.Call("execCommand", "copy")
+	ta.Call("remove")
+	// execCommand needed the focus; the terminal needs it back.
+	t.Focus()
+}
+
+// markSelectionDirty redraws the viewport rows a range covers. A selection in
+// the scrollback that is not on screen costs nothing.
+func (t *Terminal) markSelectionDirty(start, end pos) {
+	b := t.Core.Buffer()
+	first := start.line - b.YDisp
+	last := end.line - b.YDisp
+	if last < 0 || first > t.Core.Rows()-1 {
+		return
+	}
+	t.markDirty(clampInt(first, t.Core.Rows()-1), clampInt(last, t.Core.Rows()-1))
+}
+
+func (t *Terminal) notifySelection() {
+	if t.OnSelectionChange != nil {
+		t.OnSelectionChange()
+	}
+}
+
+// selectionColors substitutes the colors of a selected cell. The background is
+// the theme's selection color already flattened onto the terminal background;
+// the foreground is left alone unless the theme names one, which keeps colored
+// output readable through a selection.
+func (t *Terminal) selectionColors(fg, bg uint32) (uint32, uint32) {
+	// Only the color mode and the color itself are replaced; bold, italic and
+	// the link to the extended attributes are the cell's own and survive being
+	// selected.
+	setRGB := func(attr, rgb uint32) uint32 {
+		return (attr &^ (vt.AttrCMMask | vt.AttrRGBMask)) | vt.AttrCMRGB | (rgb & vt.AttrRGBMask)
+	}
+	bg = setRGB(bg, cssToRGB(t.colors.SelectionBgOpaque))
+	if t.colors.SelectionFg != "" {
+		fg = setRGB(fg, cssToRGB(t.colors.SelectionFg))
+	}
+	// Inverse video would swap the two back again, and the cell is already
+	// being given the colors it should end up with.
+	fg &^= vt.FgInverse
+	return fg, bg
+}

--- a/vendor/github.com/0magnet/xterm-go/vt/buffer.go
+++ b/vendor/github.com/0magnet/xterm-go/vt/buffer.go
@@ -468,7 +468,13 @@ func (b *Buffer) reflowSmaller(newCols, newRows int) {
 		for i := min(b.Lines.MaxLength()-1, originalLinesLength+countToInsert-1); i >= 0; i-- {
 			if nextToInsert != nil && nextToInsert.start > originalLineIndex+countInsertedSoFar {
 				// insert extra lines here, adjusting i as needed
-				for nextI := len(nextToInsert.newLines) - 1; nextI >= 0; nextI-- {
+				//
+				// i is bounded here as well as by the outer loop. Narrowing to
+				// very few columns wraps one original line into more lines than
+				// the buffer can hold, and without the bound this walks i below
+				// zero and panics with an index of -1. Lines that no longer fit
+				// are dropped, which is what the trim below already assumes.
+				for nextI := len(nextToInsert.newLines) - 1; nextI >= 0 && i >= 0; nextI-- {
 					b.Lines.Set(i, nextToInsert.newLines[nextI])
 					i--
 				}

--- a/vendor/github.com/0magnet/xterm-go/vt/options.go
+++ b/vendor/github.com/0magnet/xterm-go/vt/options.go
@@ -58,6 +58,10 @@ type Theme struct {
 	Cursor              string
 	CursorAccent        string
 	SelectionBackground string
+	// SelectionForeground recolors selected text. Empty leaves each cell its
+	// own foreground, which is what xterm.js does by default and what keeps
+	// syntax coloring readable through a selection.
+	SelectionForeground string
 	Black               string
 	Red                 string
 	Green               string

--- a/vendor/github.com/0magnet/xterm-go/webgl.go
+++ b/vendor/github.com/0magnet/xterm-go/webgl.go
@@ -6,9 +6,15 @@ package xterm
 // RectangleRenderer, RenderModel and WebglUtils. Backgrounds and
 // glyphs are drawn as instanced quads; glyphs sample the texture
 // atlas. Divergences from upstream: single atlas page (one sampler in
-// the fragment shader), no selection/decoration/ligature-joiner
-// overrides in the color resolver, cursor blink comes from the
-// terminal's shared blink timer instead of CursorBlinkStateManager.
+// the fragment shader), no decoration or ligature-joiner overrides in
+// the color resolver, cursor blink comes from the terminal's shared
+// blink timer instead of CursorBlinkStateManager.
+//
+// The selection is the one place this does more than the addon rather
+// than less. xterm.js leaves selecting to the DOM, which cannot work
+// here because these rows are hidden and the text is a texture; see
+// selection.go, which keeps the selection as buffer cells so that both
+// renderers can draw it.
 
 import (
 	"errors"
@@ -860,8 +866,8 @@ func (r *webglRenderer) updateModel(start, end int) {
 	b := core.Buffer()
 	cell := r.workCell
 
-	start = clampInt(start, rows-1, 0)
-	end = clampInt(end, rows-1, 0)
+	start = clampInt(start, rows-1)
+	end = clampInt(end, rows-1)
 
 	cursorStyle := term.cursorStyle()
 	cursorY := b.YBase + b.Y
@@ -881,6 +887,7 @@ func (r *webglRenderer) updateModel(start, end int) {
 
 	cursorAccentRGB := cssToRGB(term.colors.CursorAccent)
 	cursorRGB := cssToRGB(term.colors.Cursor)
+	selected := term.sel.valid()
 
 	var lastBg uint32
 	for y := start; y <= end; y++ {
@@ -901,9 +908,17 @@ func (r *webglRenderer) updateModel(start, end int) {
 			code := uint32(cell.GetCode()) // #nosec G115 -- a cell code is a Unicode codepoint
 			i := (y*cols + x) * modelIndiciesPerCell
 
-			// resolve colors (no selection/decoration overrides)
+			// resolve colors (no decoration overrides)
 			resFg := cell.Fg
 			resBg := cell.Bg
+			// A selected cell is drawn in the selection's colors, which the
+			// background rectangles and the glyphs then pick up on their own —
+			// there is no separate selection layer to keep in step, and the
+			// model's unchanged-cell check redraws exactly the cells whose
+			// selected-ness changed.
+			if selected && term.sel.contains(x, row) {
+				resFg, resBg = term.selectionColors(resFg, resBg)
+			}
 			var resExt uint32
 			if cell.Bg&vt.BgHasExtended != 0 && cell.Extended != nil {
 				resExt = cell.Extended.Ext()
@@ -972,12 +987,14 @@ func (r *webglRenderer) updateModel(start, end int) {
 	r.rects.updateCursor(&r.model)
 }
 
-func clampInt(value, max, min int) int {
+// clampInt confines a value to 0..max. Every caller clamps an index into a
+// row, column or line count, so the lower bound was always zero.
+func clampInt(value, max int) int {
 	if value > max {
 		return max
 	}
-	if value < min {
-		return min
+	if value < 0 {
+		return 0
 	}
 	return value
 }

--- a/vendor/github.com/0magnet/xterm-go/xterm.go
+++ b/vendor/github.com/0magnet/xterm-go/xterm.go
@@ -40,6 +40,21 @@ type Terminal struct {
 	OnTitleChange func(title string)
 	// OnBell fires on BEL.
 	OnBell func()
+	// OnSelectionChange fires when the selected text changes, including when
+	// it is cleared.
+	OnSelectionChange func()
+
+	// CopyOnSelect puts the selection on the clipboard as soon as the mouse is
+	// released, the way X11 fills its primary selection. Off by default: it
+	// overwrites whatever the clipboard was holding, which is not a decision
+	// a terminal should make for everyone.
+	CopyOnSelect bool
+
+	// NoContextMenu leaves the right button to the browser. The terminal draws
+	// its own menu by default, because a browser's Copy acts on the document's
+	// selection and the terminal's is not one — so the browser offers no Copy
+	// over a terminal however much is highlighted.
+	NoContextMenu bool
 
 	colors *ColorSet
 
@@ -56,10 +71,15 @@ type Terminal struct {
 	renderer       renderer
 	resizeObserver js.Value // set by AutoFit
 
+	sel      *selection
+	selInput selectionInput
+	menu     *contextMenu
+
 	cellW, cellH float64
 
 	keyDownHandled       bool
 	renderQueued         bool
+	fitQueued            bool
 	allDirty             bool
 	dirtyStart, dirtyEnd int
 	syncingScroll        bool
@@ -82,6 +102,10 @@ func New(options *vt.Options) *Terminal {
 		blinkVisible: true,
 	}
 	t.colors = NewColorSet(t.Core.Options.Theme)
+	t.sel = newSelection(t.Core.Cols, t.Core.Buffer)
+	t.sel.dirty = t.markSelectionDirty
+	t.sel.changed = t.notifySelection
+	t.selInput.t = t
 	return t
 }
 
@@ -234,11 +258,21 @@ func (t *Terminal) wireCoreEvents() {
 		t.scheduleRender(false)
 	}
 	t.Core.OnScroll = func(int) {
+		// Once the scrollback is full each new line evicts the oldest, and
+		// every line index below it shifts by one — including the ones the
+		// selection is pinned to. Rather than track the drift, drop the
+		// selection at the point it stops meaning what it says.
+		if t.Core.Buffer().Lines.IsFull() {
+			t.sel.drop()
+		}
 		t.allDirty = true
 		t.updateScrollArea()
 		t.scheduleRender(false)
 	}
 	t.Core.OnResize = func(cols, rows int) {
+		// Reflow rewraps the buffer, so the cells a selection names are no
+		// longer the cells it meant.
+		t.sel.drop()
 		t.refreshRowEls()
 		t.updateScrollArea()
 		t.renderer.onResize()
@@ -325,6 +359,11 @@ func (t *Terminal) wireDomEvents() {
 	// keyboard
 	t.textarea.Call("addEventListener", "keydown", t.fn(func(_ js.Value, args []js.Value) any {
 		ev := args[0]
+		// copy and select-all first: they act on the selection rather than
+		// on the program, and must not be forwarded as input
+		if t.selectionKeydown(ev) {
+			return nil
+		}
 		// route through the composition helper first; while composing,
 		// keys must reach the textarea/IME untouched
 		if !t.composition.Keydown(ev.Get("keyCode").Int()) {
@@ -355,6 +394,8 @@ func (t *Terminal) wireDomEvents() {
 			ev.Call("preventDefault")
 			return nil
 		case vt.KeySelectAll:
+			t.SelectAll()
+			ev.Call("preventDefault")
 			return nil
 		}
 		t.keyDownHandled = false
@@ -369,6 +410,8 @@ func (t *Terminal) wireDomEvents() {
 			ev.Call("preventDefault")
 			ev.Call("stopPropagation")
 			t.keyDownHandled = true
+			// Typing is the end of caring about what was selected.
+			t.sel.drop()
 			t.Core.Input(result.Key, true)
 		} else if result.Cancel {
 			ev.Call("preventDefault")
@@ -391,6 +434,7 @@ func (t *Terminal) wireDomEvents() {
 		if len(vt.Utf16Units(key)) == 1 {
 			ev.Call("preventDefault")
 			ev.Call("stopPropagation")
+			t.sel.drop()
 			t.Core.Input(key, true)
 		}
 		return nil
@@ -405,8 +449,12 @@ func (t *Terminal) wireDomEvents() {
 		return nil
 	}))
 
-	// focus terminal on click
+	// focus terminal on click, and start a selection unless the application
+	// has asked for the mouse itself
 	t.element.Call("addEventListener", "mousedown", t.fn(func(_ js.Value, args []js.Value) any {
+		if t.selectionMouseDown(args[0]) {
+			return nil
+		}
 		t.reportMouse(args[0], vt.MouseActionDown)
 		return nil
 	}))
@@ -421,6 +469,10 @@ func (t *Terminal) wireDomEvents() {
 		}
 		return nil
 	}))
+	// A drag carries on wherever the pointer goes, so the rest of it is
+	// watched on the document.
+	t.wireSelection()
+	t.wireContextMenu()
 
 	// wheel: scroll our own viewport (or report to the app)
 	t.element.Call("addEventListener", "wheel", t.fn(func(_ js.Value, args []js.Value) any {
@@ -556,6 +608,36 @@ func (t *Terminal) markCursorRowDirty() {
 	}
 }
 
+// scheduleFit refits on the next frame rather than inside the notification.
+//
+// A ResizeObserver fires for every step of a layout, so a window being dragged
+// or a desktop arranging itself produces a burst of them, and refitting inside
+// each one reflows the buffer that many times to reach one final size.
+//
+// It also keeps Fit out of the callback itself. Compiled with TinyGo, calling
+// into JavaScript from inside a ResizeObserver notification returned an
+// address the shim would not store to —
+//
+//	RangeError: Offset is outside the bounds of the DataView
+//	  at storeValue -> syscall/js.valueCall -> Terminal.Fit -> AutoFit
+//
+// — thrown once per notification, which under a window manager is constant.
+// Deferring to an animation frame does the same work outside that reentrancy.
+func (t *Terminal) scheduleFit() {
+	if t.fitQueued || !t.opened {
+		return
+	}
+	t.fitQueued = true
+	var raf js.Func
+	raf = js.FuncOf(func(js.Value, []js.Value) any {
+		t.fitQueued = false
+		t.Fit()
+		raf.Release()
+		return nil
+	})
+	window.Call("requestAnimationFrame", raf)
+}
+
 func (t *Terminal) scheduleRender(all bool) {
 	if all {
 		t.allDirty = true
@@ -615,7 +697,7 @@ func (d *domRenderer) renderRows(start, end int) {
 		if y == cursorRow {
 			cursorCol = min(b.X, t.Core.Cols()-1)
 		}
-		t.rowEls[y].Set("innerHTML", t.rowHTML(b.Lines.Get(lineIdx), cursorCol))
+		t.rowEls[y].Set("innerHTML", t.rowHTML(b.Lines.Get(lineIdx), lineIdx, cursorCol))
 	}
 }
 
@@ -658,10 +740,11 @@ func (t *Terminal) DisableWebGL() {
 
 // rowHTML builds a row's spans, splitting runs on attribute changes
 // (the DomRendererRowFactory equivalent).
-func (t *Terminal) rowHTML(l *vt.BufferLine, cursorCol int) string {
+func (t *Terminal) rowHTML(l *vt.BufferLine, lineIdx, cursorCol int) string {
 	var sb strings.Builder
 	cols := t.Core.Cols()
 	cell := vt.NewCellData()
+	selected := t.sel.valid()
 
 	var runText strings.Builder
 	var runStyle, runClass string
@@ -692,7 +775,8 @@ func (t *Terminal) rowHTML(l *vt.BufferLine, cursorCol int) string {
 		if chars == "" {
 			chars = " "
 		}
-		style, class := t.cellStyle(&cell.AttributeData, x == cursorCol)
+		style, class := t.cellStyle(&cell.AttributeData, x == cursorCol,
+			selected && t.sel.contains(x, lineIdx))
 		if style != runStyle || class != runClass {
 			flush()
 			runStyle, runClass = style, class
@@ -703,10 +787,22 @@ func (t *Terminal) rowHTML(l *vt.BufferLine, cursorCol int) string {
 	return sb.String()
 }
 
-func (t *Terminal) cellStyle(attr *vt.AttributeData, isCursor bool) (style, class string) {
+func (t *Terminal) cellStyle(attr *vt.AttributeData, isCursor, isSelected bool) (style, class string) {
 	fg, bg := t.colors.ResolveCellColors(attr)
 	var s strings.Builder
 	var classes []string
+
+	// The selection is drawn the same way here as in the WebGL renderer:
+	// by recoloring the cell rather than by overlaying anything, so the two
+	// renderers cannot disagree about what is selected.
+	if isSelected {
+		bg = t.colors.SelectionBgOpaque
+		if t.colors.SelectionFg != "" {
+			fg = t.colors.SelectionFg
+		} else if fg == "" {
+			fg = t.colors.Foreground
+		}
+	}
 
 	if isCursor {
 		switch t.cursorStyle() {
@@ -817,13 +913,13 @@ func (t *Terminal) AutoFit() {
 		// but falling back to the window keeps this from being worse than
 		// not calling it at all.
 		js.Global().Call("addEventListener", "resize", t.fn(func(js.Value, []js.Value) any {
-			t.Fit()
+			t.scheduleFit()
 			return nil
 		}))
 		return
 	}
 	t.resizeObserver = ctor.New(t.fn(func(js.Value, []js.Value) any {
-		t.Fit()
+		t.scheduleFit()
 		return nil
 	}))
 	t.resizeObserver.Call("observe", parent)
@@ -878,13 +974,13 @@ func (t *Terminal) Dispose() {
 		window.Call("clearInterval", t.blinkTimer)
 		t.blinkTimer = js.Undefined()
 	}
+	t.menu.hide()
+	t.unwireSelection()
 	if t.resizeObserver.Truthy() {
 		t.resizeObserver.Call("disconnect")
 		t.resizeObserver = js.Value{}
 	}
-	// Mark closed first so any in-flight scheduleRender/rAF bails (it checks opened).
-	t.opened = false
-	if !t.element.IsUndefined() {
+	if t.opened && !t.element.IsUndefined() {
 		parent := t.element.Get("parentElement")
 		if !parent.IsNull() && !parent.IsUndefined() {
 			parent.Call("removeChild", t.element)
@@ -894,6 +990,7 @@ func (t *Terminal) Dispose() {
 		f.Release()
 	}
 	t.funcs = nil
+	t.opened = false
 }
 
 var stylesheetInstalled = false
@@ -920,8 +1017,13 @@ func ensureStylesheet() {
 .xterm .xterm-viewport::-webkit-scrollbar-thumb { background: #4a4f57; border-radius: 5px; }
 .xterm .xterm-viewport::-webkit-scrollbar-thumb:hover { background: #6b727c; }
 .xterm .xterm-viewport::-webkit-scrollbar-corner { background: transparent; }
-.xterm .xterm-screen { position: relative; z-index: 1; }
-.xterm .xterm-rows { line-height: normal; letter-spacing: 0; white-space: pre; user-select: text; cursor: text; }
+.xterm .xterm-screen { position: relative; z-index: 1; cursor: text; }
+/* The terminal draws its own selection, as a range of buffer cells, so that
+   selecting works the same under both renderers — the WebGL one hides these
+   rows entirely and paints to a canvas, where there is no text for the browser
+   to select. Leaving the browser's selection enabled as well would give two
+   selections that disagree with each other. */
+.xterm .xterm-rows { line-height: normal; letter-spacing: 0; white-space: pre; user-select: none; }
 .xterm .xterm-rows > div { overflow: hidden; }
 .xterm .xterm-rows span { display: inline-block; }
 .xterm .xb { font-weight: bold; }
@@ -933,7 +1035,7 @@ func ensureStylesheet() {
   display: none; position: absolute; white-space: nowrap; z-index: 5;
 }
 .xterm .xterm-composition-view.active { display: block; }
-`
+` + contextMenuCSS
 	styleEl := document.Call("createElement", "style")
 	styleEl.Set("textContent", css)
 	document.Get("head").Call("appendChild", styleEl)
@@ -941,16 +1043,6 @@ func ensureStylesheet() {
 
 func jsPx(v float64) string {
 	return strconv.FormatFloat(v, 'f', -1, 64) + "px"
-}
-
-func rgbCSS(c [3]int) string {
-	const hex = "0123456789abcdef"
-	b := []byte{'#', 0, 0, 0, 0, 0, 0}
-	for i, v := range c {
-		b[1+i*2] = hex[(v>>4)&0xf]
-		b[2+i*2] = hex[v&0xf]
-	}
-	return string(b)
 }
 
 func escapeHTML(s string) string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,7 +40,7 @@ github.com/0magnet/u-root/pkg/ls
 ## explicit; go 1.25.7
 github.com/0magnet/websh/shell
 github.com/0magnet/websh/shell/browser
-# github.com/0magnet/xterm-go v0.0.0-20260816193539-5beca79629c0
+# github.com/0magnet/xterm-go v0.0.0-20260820124923-c0b6b4f69bb7
 ## explicit; go 1.24
 github.com/0magnet/xterm-go
 github.com/0magnet/xterm-go/vt


### PR DESCRIPTION
Bumps `github.com/0magnet/xterm-go` `5beca79` → `c0b6b4f`.

**Why:** the cursor-blink tick is a window-scoped `setInterval` whose callback is a registered `js.Func`. `Terminal.Dispose()` released the funcs and removed the DOM element but never cleared that interval, so after a wasm-HV terminal's window is closed the browser keeps invoking the released blink func every 600ms → `panic: call to released function`. The upstream top commit tracks the handle in a `blinkTimer` field and `clearInterval`s it at the top of `Dispose()`.

**Why a bump, not a vendor edit:** the fix previously existed only as a hand-applied patch in `vendor/…/xterm.go`, which `go mod vendor` silently reverted. It now lives upstream on `0magnet/xterm-go@main`, so vendoring reproduces it cleanly. This bump also pulls in the intervening upstream selection/webgl/lint commits.

**Build:** `cmd/wasm-visor` + `cmd/websh-probe` (the only importers) build under `GOOS=js GOARCH=wasm`; native root `go build .` unaffected (xterm-go is js/wasm-only).