### PR TITLE
feat(cli): proxy mux plot --pk — live per-route chart of a controlled measured mux

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_plot.go
+++ b/cmd/skywire-cli/commands/proxy/mux_plot.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"sort"
+	"strings"
 	"syscall"
 	"time"
 
@@ -16,6 +18,7 @@ import (
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 )
 
 var (
@@ -25,6 +28,21 @@ var (
 	muxPlotHeight   int
 	muxPlotSmooth   int
 	muxPlotRecv     bool
+
+	// --pk mode: measure an ad-hoc mux route rather than poll a running app.
+	muxPlotPK       string
+	muxPlotRoutes   int
+	muxPlotMinHops  int
+	muxPlotDuration time.Duration
+	muxPlotPolicy   string
+	muxPlotSizeKb   int
+
+	// muxPlotSubject is the caption/header label for the current run (the app
+	// name in poll mode, or a peer descriptor in --pk mode).
+	muxPlotSubject string
+	// muxPlotEvents is a rolling log of policy leg-lifecycle / route events,
+	// shown as markers beneath the chart in --pk mode.
+	muxPlotEvents []string
 )
 
 func init() {
@@ -34,6 +52,14 @@ func init() {
 	muxPlotCmd.Flags().IntVar(&muxPlotHeight, "height", 10, "rows per chart panel")
 	muxPlotCmd.Flags().IntVar(&muxPlotSmooth, "smooth", 0, "EWMA smoothing window in samples (0 = raw)")
 	muxPlotCmd.Flags().BoolVar(&muxPlotRecv, "recv", false, "plot received bandwidth instead of sent")
+	// --pk mode: plot a controlled, self-measured mux route (StreamMuxBandwidth)
+	// instead of a running app's route group — the reliable multi-leg demonstrator.
+	muxPlotCmd.Flags().StringVar(&muxPlotPK, "pk", "", "measure an ad-hoc mux route to this peer PK instead of polling a running app")
+	muxPlotCmd.Flags().IntVar(&muxPlotRoutes, "routes", 4, "[--pk] number of parallel routes to set up")
+	muxPlotCmd.Flags().IntVar(&muxPlotMinHops, "min-hops", 2, "[--pk] route-finder min hops (>=2 excludes the direct transport)")
+	muxPlotCmd.Flags().DurationVar(&muxPlotDuration, "duration", 5*time.Minute, "[--pk] how long to pump bytes")
+	muxPlotCmd.Flags().StringVar(&muxPlotPolicy, "policy", "", "[--pk] routing-policy preset (e.g. preset:rotating-bw); empty = static mux")
+	muxPlotCmd.Flags().IntVar(&muxPlotSizeKb, "size", 32, "[--pk] per-write block size in KB")
 	addMuxSub(muxPlotCmd, "mux-plot")
 }
 
@@ -42,26 +68,48 @@ var muxPlotCmd = &cobra.Command{
 	Short: "Live per-leg bandwidth + RTT chart for a mux'd route group (terminal)",
 	Long: `Live terminal chart of each multiplexed route's bandwidth and RTT.
 
-Polls the same per-leg telemetry the routing-policy on_tick ABI sees
-(RouteGroupMuxInfo) once per --interval and redraws two stacked charts —
-per-leg bandwidth (Mbps) over per-leg RTT (ms) — one colored line per
-route. A warm-standby (parked) leg reads 0 bandwidth but keeps its RTT.
+Two sources:
+
+  (default) poll a running app's route group. Reads the same per-leg
+  telemetry the routing-policy on_tick ABI sees (RouteGroupMuxInfo) once
+  per --interval. Shows exactly the legs the app's route group has right now.
+
+  --pk <peer>  measure a controlled, self-driven mux route to a peer you
+  control (StreamMuxBandwidth) — the reliable multi-leg demonstrator, since
+  it does not depend on a live app's (churn-prone) route group. With
+  --policy preset:<name> the same per-leg {bps,rtt} stream feeds the policy
+  (on_tick), so you watch an adaptive preset decide on measurement live;
+  leg promote/demote/drop/fail events print as markers beneath the chart.
+
+Both redraw two stacked charts — per-leg bandwidth (Mbps) over per-leg RTT
+(ms), one colored line per route. A warm-standby (parked) leg reads 0
+bandwidth but keeps its RTT and is tagged (standby).
 
 Examples:
   skywire cli proxy mux plot                     # default app, 1s
   skywire cli proxy mux plot -n vpn-client -i 500ms
-  skywire cli proxy mux plot --smooth 5 --window 90`,
+  skywire cli proxy mux plot --smooth 5 --window 90
+  # controlled 4-leg route to a peer, rotating-bw preset, 5 min:
+  skywire cli proxy mux plot --pk <peer-pk> --routes 4 --policy preset:rotating-bw
+  # static 5-wide multi-hop mux, watch received bandwidth:
+  skywire cli proxy mux plot --pk <peer-pk> --routes 5 --min-hops 2 --recv`,
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, _ []string) {
+		if muxPlotWindow < 8 {
+			muxPlotWindow = 8
+		}
+		if muxPlotPK != "" {
+			runMuxPlotStream(cmd)
+			return
+		}
+
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
 		}
 		defer rpcClient.Close() //nolint:errcheck,gosec
 
-		if muxPlotWindow < 8 {
-			muxPlotWindow = 8
-		}
+		muxPlotSubject = muxPlotApp
 		runMuxPlot(func() (any, error) { return rpcClient.RouteGroupMuxInfo(muxPlotApp) })
 	},
 }
@@ -111,6 +159,157 @@ func runMuxPlot(poll func() (any, error)) {
 		case <-ticker.C:
 		}
 	}
+}
+
+// runMuxPlotStream drives the --pk mode: it opens the StreamMuxBandwidth RPC
+// (the same controlled far-end pump the NDJSON harness uses), and renders each
+// per-leg sample live. With --policy set, the identical {bps,rtt} stream is what
+// the policy's on_tick decides on, so the chart shows the preset adapting.
+func runMuxPlotStream(cmd *cobra.Command) {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	muxPlotSubject = fmt.Sprintf("mux→%s r%d%s", shortPK(muxPlotPK), muxPlotRoutes, leadIf(" ", muxPlotPolicy))
+
+	client, err := rpcgrpc.NewPingClient(clirpc.Addr)
+	if err != nil {
+		internal.PrintFatalError(cmd.Flags(), fmt.Errorf("gRPC client connect: %w", err))
+	}
+	defer client.Close() //nolint:errcheck,gosec
+
+	req := &rpcgrpc.MuxBandwidthRequest{
+		TargetPk:         muxPlotPK,
+		Routes:           int32(muxPlotRoutes), //nolint:gosec
+		DurationNs:       muxPlotDuration.Nanoseconds(),
+		PacketSizeKb:     int32(muxPlotSizeKb),  //nolint:gosec
+		MinHops:          int32(muxPlotMinHops), //nolint:gosec
+		SetupTimeoutNs:   (30 * time.Second).Nanoseconds(),
+		SampleIntervalNs: muxPlotInterval.Nanoseconds(),
+		RoutingPolicy:    muxPlotPolicy,
+	}
+	stream, err := client.StreamMuxBandwidth(ctx, req)
+	if err != nil {
+		internal.PrintFatalError(cmd.Flags(), fmt.Errorf("StreamMuxBandwidth: %w", err))
+	}
+
+	tracks := map[int]*legTrack{}
+	for {
+		ev, recvErr := stream.Recv()
+		if recvErr != nil {
+			if recvErr == io.EOF || recvErr == context.Canceled {
+				fmt.Print("\n")
+				return
+			}
+			fmt.Fprintf(os.Stderr, "\nstream recv: %v\n", recvErr)
+			return
+		}
+		switch p := ev.Payload.(type) {
+		case *rpcgrpc.MuxBandwidthEvent_Sample:
+			updateTracksFromLegs(tracks, p.Sample.Legs)
+			render(tracks)
+		case *rpcgrpc.MuxBandwidthEvent_RouteEstablished:
+			if r := p.RouteEstablished; r.Failed {
+				pushMuxPlotEvent(fmt.Sprintf("R%d ✗ setup-failed %s", r.RouteIndex, r.SetupErr))
+			} else {
+				pushMuxPlotEvent(fmt.Sprintf("R%d ✓ established", r.RouteIndex))
+			}
+		case *rpcgrpc.MuxBandwidthEvent_LegLifecycle:
+			l := p.LegLifecycle
+			pushMuxPlotEvent(fmt.Sprintf("R%d ⟳ %s gate=%s", l.RouteIndex, strings.ToUpper(l.Event), l.GateState))
+		case *rpcgrpc.MuxBandwidthEvent_RouteFailure:
+			pushMuxPlotEvent(fmt.Sprintf("R%d ✗ pump-failed %s", p.RouteFailure.RouteIndex, p.RouteFailure.ErrorMessage))
+		case *rpcgrpc.MuxBandwidthEvent_Done:
+			render(tracks)
+			fmt.Printf("\ndone: %s\n", p.Done.TerminationReason)
+			return
+		case *rpcgrpc.MuxBandwidthEvent_Error:
+			fmt.Fprintf(os.Stderr, "\nerror: %s: %s\n", p.Error.Code, p.Error.Message)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			fmt.Print("\n")
+			return
+		default:
+		}
+	}
+}
+
+// updateTracksFromLegs feeds one StreamMuxBandwidth sample's per-leg breakdown
+// into the render tracks. Unlike the poll path it needs no byte-delta math —
+// InstSendBps / LatencyMs / Standby come straight off the wire.
+func updateTracksFromLegs(tracks map[int]*legTrack, legs []*rpcgrpc.MuxLegSample) {
+	seen := map[int]bool{}
+	for _, leg := range legs {
+		idx := int(leg.RouteIndex)
+		seen[idx] = true
+		t, ok := tracks[idx]
+		if !ok {
+			t = &legTrack{
+				label: fmt.Sprintf("R%d·%s·%s", idx, orDash(leg.TransportKind), hopLabel(leg.IntermediatePk)),
+				bw:    make([]float64, muxPlotWindow),
+				rtt:   make([]float64, muxPlotWindow),
+				color: plotPalette[len(tracks)%len(plotPalette)],
+			}
+			tracks[idx] = t
+		}
+		bps := leg.InstSendBps
+		if muxPlotRecv {
+			bps = leg.InstRecvBps
+		}
+		mbps := bps / 1e6
+		if muxPlotSmooth > 1 {
+			a := 2.0 / float64(muxPlotSmooth+1)
+			if t.ewmaSeeded {
+				t.ewmaBw = a*mbps + (1-a)*t.ewmaBw
+			} else {
+				t.ewmaBw, t.ewmaSeeded = mbps, true
+			}
+			mbps = t.ewmaBw
+		}
+		t.bw = append(t.bw[1:], mbps)
+		t.rtt = append(t.rtt[1:], float64(leg.LatencyMs))
+		t.standbyNow = leg.Standby
+	}
+	for idx, t := range tracks {
+		if !seen[idx] {
+			t.bw = append(t.bw[1:], 0)
+			t.rtt = append(t.rtt[1:], t.rtt[len(t.rtt)-1])
+		}
+	}
+}
+
+// pushMuxPlotEvent appends a timestamped policy/route event to the rolling log
+// rendered beneath the chart.
+func pushMuxPlotEvent(s string) {
+	muxPlotEvents = append(muxPlotEvents, time.Now().Format("15:04:05")+" "+s)
+	if len(muxPlotEvents) > 64 {
+		muxPlotEvents = muxPlotEvents[len(muxPlotEvents)-64:]
+	}
+}
+
+// orDash renders an empty transport kind as "-".
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// hopLabel renders a leg's intermediate PK short, or "direct" when it has none.
+func hopLabel(pk string) string {
+	if pk == "" {
+		return "direct"
+	}
+	return shortPK(pk)
+}
+
+// leadIf returns prefix+s when s is non-empty, else "".
+func leadIf(prefix, s string) string {
+	if s == "" {
+		return ""
+	}
+	return prefix + s
 }
 
 func pollMuxRGs(poll func() (any, error)) ([]muxRouteGroupInfo, error) {
@@ -211,19 +410,34 @@ func render(tracks map[int]*legTrack) {
 	}
 	agg = fmt.Sprintf("aggregate %s: %.1f Mbps across %d legs", dir, total, len(idxs))
 
+	subject := muxPlotSubject
+	if subject == "" {
+		subject = muxPlotApp
+	}
 	bw := asciigraph.PlotMany(bwSeries, asciigraph.Height(muxPlotHeight), asciigraph.Width(0),
 		asciigraph.SeriesColors(colors...), asciigraph.Precision(1),
-		asciigraph.Caption(fmt.Sprintf("bandwidth  Mbps %s  ·  %s", dir, muxPlotApp)))
+		asciigraph.Caption(fmt.Sprintf("bandwidth  Mbps %s  ·  %s", dir, subject)))
 	rt := asciigraph.PlotMany(rttSeries, asciigraph.Height(muxPlotHeight/2+2), asciigraph.Width(0),
 		asciigraph.SeriesColors(colors...), asciigraph.Precision(0),
 		asciigraph.Caption("RTT  ms"))
 
 	fmt.Print("\x1b[H\x1b[2J") // clear + home
-	fmt.Printf("skywire mux · %s · %s\n\n", muxPlotApp, time.Now().Format("15:04:05"))
+	fmt.Printf("skywire mux · %s · %s\n\n", subject, time.Now().Format("15:04:05"))
 	fmt.Println(bw)
 	fmt.Print("\n\n")
 	fmt.Println(rt)
 	fmt.Printf("\n%s\n%s\n", legend, agg)
+	if len(muxPlotEvents) > 0 {
+		fmt.Printf("\nevents: %s\n", strings.Join(tailStrings(muxPlotEvents, 4), "   "))
+	}
+}
+
+// tailStrings returns the last n elements of s (or all if fewer).
+func tailStrings(s []string, n int) []string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
 }
 
 // ansi renders an asciigraph color as its SGR escape for the legend swatches.


### PR DESCRIPTION
Adds a `--pk <peer>` source to `proxy mux plot` (which today polls a running app's route group).

**Why:** the reliable way to watch *each individual route within a multiplexed route* is against a controlled far-end, not a live app whose mux route group is churn-prone under #80/#86. `--pk` opens the `StreamMuxBandwidth` RPC — the same controlled pump the NDJSON harness uses — and renders each `MuxLegSample` live: one colored bandwidth line + one RTT line per route, with route/leg-lifecycle events as markers beneath the chart.

**Adaptive presets on measurement:** with `--policy preset:<name>` the identical per-leg `{bps,rtt}` stream is what the policy `on_tick` decides on. Per-leg `LatencyMs`/`Standby` populate only on policy runs, so you can watch an adaptive preset decide on live measurement.

**Implementation:** reuses the existing `legTrack`/`render` path; `InstSendBps`/`LatencyMs`/`Standby` come straight off the wire (no byte-delta math). New flags `--routes --min-hops --duration --policy --size` share the plot's `--interval/--window/--height/--smooth/--recv`.

**Verified live** against a 2-hop controlled far-end:
- static `--routes 3`: three **disjoint** stcpr legs rendered, aggregate 0.7 Mbps, establishment markers.
- `--policy preset:rotating-bw --routes 4`: 5 legs rendered, **RTT panel populated** (per-leg 480–1287 ms — the on_tick latency probe), aggregate 2.5 Mbps. One leg's #86 carry-stall showed as a 0-bandwidth line, which is the tool doing its job.

`gofmt` + `golangci-lint` clean; `go build ./cmd/skywire-cli/...` OK.