### PR TITLE
fix(router): full-window SACK so a persistent mux gap can't wedge the stream (#86)

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -2113,8 +2113,8 @@ func (rg *RouteGroup) sendSACK() error {
 		return nil
 	}
 
-	lastContig, bitmap := rg.mux.generateSACK()
-	packet := routing.MakeSACKPacket(rule.NextRouteID(), lastContig, bitmap)
+	lastContig, words := rg.mux.generateSACK()
+	packet := routing.MakeSACKPacket(rule.NextRouteID(), lastContig, words)
 	return rg.writePacket(context.Background(), tp, packet, rule.KeyRouteID())
 }
 
@@ -2125,9 +2125,9 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 	}
 
 	lastContig := packet.SACKLastContiguousSeq()
-	bitmap := packet.SACKBitmap()
+	words := packet.SACKWords()
 
-	retxSeqs := rg.mux.processSACK(lastContig, bitmap)
+	retxSeqs := rg.mux.processSACK(lastContig, words)
 	if len(retxSeqs) == 0 {
 		return nil
 	}

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -525,20 +525,21 @@ func (m *routeMux) shouldSendSACK() bool {
 	return atomic.CompareAndSwapInt64(&m.lastSACKNano, prev, now)
 }
 
-// generateSACK returns the current SACK state for sending to the peer.
-func (m *routeMux) generateSACK() (lastContig uint32, bitmap uint64) {
+// generateSACK returns the current SACK state for sending to the peer:
+// the last contiguous sequence plus a full-window received bitmap.
+func (m *routeMux) generateSACK() (lastContig uint32, words []uint64) {
 	if !m.sackEnabled || m.sackTracker == nil {
-		return 0, 0
+		return 0, nil
 	}
 	return m.sackTracker.GenerateSACK()
 }
 
 // processSACK processes a received SACK and returns sequences that need retransmission.
-func (m *routeMux) processSACK(lastContig uint32, bitmap uint64) []uint32 {
+func (m *routeMux) processSACK(lastContig uint32, words []uint64) []uint32 {
 	if !m.sackEnabled || m.retxBuf == nil {
 		return nil
 	}
-	return m.retxBuf.ProcessSACK(lastContig, bitmap)
+	return m.retxBuf.ProcessSACK(lastContig, words)
 }
 
 // getRetxPayload retrieves a stored payload for retransmission.

--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -325,7 +325,7 @@ func (r *router) forwardPacket(ctx context.Context, packet routing.Packet, rule 
 			return err
 		}
 	case routing.SACKPacket:
-		p = routing.MakeSACKPacket(rule.NextRouteID(), packet.SACKLastContiguousSeq(), packet.SACKBitmap())
+		p = routing.MakeSACKPacket(rule.NextRouteID(), packet.SACKLastContiguousSeq(), packet.SACKWords())
 	case routing.DatagramPacket:
 		// Faithful-UDP relay (#2607): re-stamp the next-hop route ID and pass
 		// the opaque (AEAD-sealed) payload through unchanged — intermediaries

--- a/pkg/router/sack.go
+++ b/pkg/router/sack.go
@@ -18,11 +18,21 @@ import (
 // lost one — a dead leg, which liveness prunes — is ever retransmitted.
 const retxMinAge = 750 * time.Millisecond
 
+// sackMaxWords bounds the generated bitmap to the reorder window (32 words *
+// 64 = 2048 sequences). Mirrors routing.SACKMaxWords; kept local to avoid a
+// routing import here.
+const sackMaxWords = 32
+
 // sackTracker tracks received sequence numbers on the receiver side and
-// generates SACK feedback (last contiguous seq + 64-bit bitmap).
+// generates SACK feedback: last contiguous seq + a variable-length bitmap that
+// covers the whole outstanding window up to the highest received sequence.
+// Acking the full window (not just the first 64) is what lets the sender purge
+// received-but-above-the-gap sequences from its retx buffer, so a persistent
+// frontier gap can no longer fill that buffer and wedge the stream (#86).
 type sackTracker struct {
 	mu             sync.Mutex
 	lastContiguous uint32
+	highest        uint32 // highest sequence ever recorded (0 = none yet)
 	received       map[uint32]bool
 }
 
@@ -37,6 +47,10 @@ func newSACKTracker() *sackTracker {
 func (st *sackTracker) RecordReceived(seq uint32) (gapDetected bool) {
 	st.mu.Lock()
 	defer st.mu.Unlock()
+
+	if seq > st.highest {
+		st.highest = seq
+	}
 
 	if seq <= st.lastContiguous {
 		return false // duplicate or old
@@ -74,20 +88,35 @@ func (st *sackTracker) AdvanceContiguous(nextSeq uint32) {
 	}
 }
 
-// GenerateSACK returns the current SACK state: last contiguous sequence
-// number and a 64-bit bitmap where bit i == 1 means
-// (lastContiguous + 1 + i) has been received.
-func (st *sackTracker) GenerateSACK() (lastContiguous uint32, bitmap uint64) {
+// GenerateSACK returns the current SACK state: the last contiguous sequence
+// number and a variable-length bitmap covering the whole outstanding window
+// [lastContiguous+1, highest]. Word w, bit i set means
+// (lastContiguous + 1 + w*64 + i) has been received. The window is capped at
+// sackMaxWords*64 sequences (the reorder-buffer bound); trailing empty words
+// are trimmed by the encoder.
+func (st *sackTracker) GenerateSACK() (lastContiguous uint32, words []uint64) {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
 	lastContiguous = st.lastContiguous
-	for i := uint32(0); i < 64; i++ {
-		if st.received[lastContiguous+1+i] {
-			bitmap |= 1 << i
+	if st.highest <= lastContiguous {
+		return lastContiguous, nil
+	}
+	span := st.highest - lastContiguous // number of sequences above the contiguous point
+	nWords := int((span + 63) / 64)
+	if nWords > sackMaxWords {
+		nWords = sackMaxWords
+	}
+	words = make([]uint64, nWords)
+	for w := 0; w < nWords; w++ {
+		for i := uint32(0); i < 64; i++ {
+			seq := lastContiguous + 1 + uint32(w)*64 + i
+			if st.received[seq] {
+				words[w] |= 1 << i
+			}
 		}
 	}
-	return
+	return lastContiguous, words
 }
 
 // retxEntry holds a sent packet awaiting acknowledgment.
@@ -112,14 +141,34 @@ func newRetxBuffer(capacity int) *retxBuffer {
 	}
 }
 
-// Store saves a sent packet for potential retransmission.
-// Returns false if the buffer is full (backpressure signal).
+// Store saves a sent packet for potential retransmission. When the buffer is
+// full it evicts the LOWEST outstanding sequence to make room, rather than
+// refusing the newest: a full buffer means a frontier gap has stayed open for a
+// whole reorder window, at which point the receiver has already force-flushed
+// past its lowest held sequence, so that entry can never be usefully
+// retransmitted — dropping it and keeping the newest packet (which still can be)
+// is strictly safer than the reverse. Always returns true (the packet is
+// always stored); the bool is retained for callers/tests.
+//
+// With the full-window SACK (GenerateSACK/ProcessSACK), the sender purges every
+// received sequence above the gap each SACK, so under normal operation the
+// buffer holds only genuine holes plus in-flight sequences and never reaches
+// capacity — this eviction path is a backstop, not the steady state.
 func (rb *retxBuffer) Store(seq uint32, data []byte) bool {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 
 	if len(rb.entries) >= rb.capacity {
-		return false
+		var lowest uint32
+		first := true
+		for s := range rb.entries {
+			if first || s < lowest {
+				lowest, first = s, false
+			}
+		}
+		if !first {
+			delete(rb.entries, lowest)
+		}
 	}
 
 	cp := make([]byte, len(data))
@@ -132,33 +181,36 @@ func (rb *retxBuffer) Store(seq uint32, data []byte) bool {
 	return true
 }
 
-// ProcessSACK processes a received SACK and returns sequence numbers that
-// need retransmission (gaps in the bitmap where we have stored data).
-// Also purges acknowledged entries.
-func (rb *retxBuffer) ProcessSACK(lastContiguous uint32, bitmap uint64) []uint32 {
+// ProcessSACK processes a received SACK (last contiguous seq + full-window
+// received bitmap) and returns sequence numbers that need retransmission (holes
+// in the bitmap where we still hold data). It purges every acknowledged entry,
+// including received sequences ABOVE a persistent frontier gap — that whole-
+// window purge is what keeps the buffer from filling behind a stuck gap (#86).
+func (rb *retxBuffer) ProcessSACK(lastContiguous uint32, words []uint64) []uint32 {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 
-	// Purge all entries up to and including lastContiguous
+	// Purge all entries up to and including lastContiguous.
 	for seq := range rb.entries {
 		if seq <= lastContiguous {
 			delete(rb.entries, seq)
 		}
 	}
 
-	// Check bitmap for acknowledged and missing packets
+	// Walk the full received bitmap: set bit -> received, purge; unset bit ->
+	// still missing, retransmit if genuinely overdue (a sequence within
+	// retxMinAge of send is presumed in flight on a slower leg, not lost, so
+	// retransmitting it would be the spurious self-amplifying storm retxMinAge
+	// exists to prevent). Sequences ABOVE the covered window are left in place:
+	// they are the still-in-flight tail the receiver has not reported yet.
 	var retransmit []uint32
-	for i := uint32(0); i < 64; i++ {
-		checkSeq := lastContiguous + 1 + i
-		if bitmap&(1<<i) != 0 {
-			// Bit is set: packet received, purge from buffer
-			delete(rb.entries, checkSeq)
-		} else {
-			// Bit is not set: packet missing. Retransmit only if it is
-			// genuinely overdue — a sequence still within retxMinAge of when it
-			// was sent is presumed in flight on a slower leg (mux latency skew),
-			// not lost, so retransmitting it would be spurious.
-			if e, ok := rb.entries[checkSeq]; ok && time.Since(e.sentAt) >= retxMinAge {
+	for w, word := range words {
+		base := lastContiguous + 1 + uint32(w)*64
+		for i := uint32(0); i < 64; i++ {
+			checkSeq := base + i
+			if word&(1<<i) != 0 {
+				delete(rb.entries, checkSeq)
+			} else if e, ok := rb.entries[checkSeq]; ok && time.Since(e.sentAt) >= retxMinAge {
 				retransmit = append(retransmit, checkSeq)
 			}
 		}

--- a/pkg/router/sack_test.go
+++ b/pkg/router/sack_test.go
@@ -8,15 +8,24 @@ import (
 	"github.com/skycoin/skywire/pkg/routing"
 )
 
+// word0 is a tiny helper: the first bitmap word, or 0 when the SACK carried no
+// words (fully caught up).
+func word0(words []uint64) uint64 {
+	if len(words) == 0 {
+		return 0
+	}
+	return words[0]
+}
+
 func TestSACKTracker_InOrder(t *testing.T) {
 	st := newSACKTracker()
 	assert.False(t, st.RecordReceived(0))
 	assert.False(t, st.RecordReceived(1))
 	assert.False(t, st.RecordReceived(2))
 
-	last, bm := st.GenerateSACK()
+	last, words := st.GenerateSACK()
 	assert.Equal(t, uint32(2), last)
-	assert.Equal(t, uint64(0), bm)
+	assert.Equal(t, uint64(0), word0(words)) // fully contiguous: no bits above
 }
 
 func TestSACKTracker_GapDetection(t *testing.T) {
@@ -28,12 +37,12 @@ func TestSACKTracker_GapDetection(t *testing.T) {
 	gap = st.RecordReceived(3)
 	assert.True(t, gap) // still gap at seq 1
 
-	last, bm := st.GenerateSACK()
+	last, words := st.GenerateSACK()
 	assert.Equal(t, uint32(0), last) // last contiguous is 0
 	// bit 0 = seq 1 (missing) = 0
 	// bit 1 = seq 2 (received) = 1
 	// bit 2 = seq 3 (received) = 1
-	assert.Equal(t, uint64(0b110), bm)
+	assert.Equal(t, uint64(0b110), word0(words))
 }
 
 func TestSACKTracker_GapFill(t *testing.T) {
@@ -46,9 +55,9 @@ func TestSACKTracker_GapFill(t *testing.T) {
 	gap := st.RecordReceived(1)
 	assert.False(t, gap) // seq 1 fills gap, advances contiguous to 3
 
-	last, bm := st.GenerateSACK()
+	last, words := st.GenerateSACK()
 	assert.Equal(t, uint32(3), last)
-	assert.Equal(t, uint64(0), bm)
+	assert.Equal(t, uint64(0), word0(words))
 }
 
 func TestSACKTracker_AdvanceContiguous(t *testing.T) {
@@ -59,9 +68,29 @@ func TestSACKTracker_AdvanceContiguous(t *testing.T) {
 
 	// Simulate reorder buffer delivering up to seq 4 (nextSeq=4)
 	st.AdvanceContiguous(4)
-	last, bm := st.GenerateSACK()
+	last, words := st.GenerateSACK()
 	assert.Equal(t, uint32(3), last)
-	assert.Equal(t, uint64(0), bm)
+	assert.Equal(t, uint64(0), word0(words))
+}
+
+// TestSACKTracker_FullWindowBitmap proves the SACK covers the whole outstanding
+// window, not just the first 64 sequences: with a gap at seq 1 and everything up
+// to seq 200 received, the bitmap must span >64 sequences (multiple words) and
+// mark those high sequences received. This is what lets the sender purge them.
+func TestSACKTracker_FullWindowBitmap(t *testing.T) {
+	st := newSACKTracker()
+	st.RecordReceived(0)
+	// seq 1 missing (frontier gap); receive 2..200
+	for seq := uint32(2); seq <= 200; seq++ {
+		st.RecordReceived(seq)
+	}
+	last, words := st.GenerateSACK()
+	assert.Equal(t, uint32(0), last)
+	assert.GreaterOrEqual(t, len(words), 4, "200 outstanding seqs need >=4 words (>64)")
+	// seq 1 (bit 0 of word 0) missing
+	assert.Equal(t, uint64(0), words[0]&1)
+	// seq 130 received: within word 2, bit (129-128)=1
+	assert.NotEqual(t, uint64(0), words[2]&(1<<1))
 }
 
 func TestRetxBuffer_StoreAndPurge(t *testing.T) {
@@ -71,8 +100,8 @@ func TestRetxBuffer_StoreAndPurge(t *testing.T) {
 	}
 	assert.Equal(t, 10, rb.Len())
 
-	// SACK: lastContiguous=5, all above received
-	retx := rb.ProcessSACK(5, 0xF) // bits 0-3 set = seqs 6,7,8,9 received
+	// SACK: lastContiguous=5, bits 0-3 set = seqs 6,7,8,9 received
+	retx := rb.ProcessSACK(5, []uint64{0xF})
 	assert.Empty(t, retx)
 	assert.Equal(t, 0, rb.Len())
 }
@@ -83,29 +112,32 @@ func TestRetxBuffer_RetransmitList(t *testing.T) {
 		rb.Store(i, []byte{byte(i)})
 	}
 
-	// Age the stored entries past retxMinAge: ProcessSACK only lists a missing
-	// sequence for retransmit once it has been unacknowledged longer than that
-	// guard (a younger gap is presumed in flight on a slower mux leg, not lost).
-	// Without this the freshly-Store'd entries are "too young" and the list is
-	// empty. See retxMinAge in sack.go.
+	// Age the stored entries past retxMinAge so ProcessSACK will list missing
+	// sequences (a younger gap is presumed in flight on a slower mux leg).
 	for _, e := range rb.entries {
 		e.sentAt = e.sentAt.Add(-2 * retxMinAge)
 	}
 
 	// SACK: lastContiguous=2, bitmap=0b1010 (seq 3 missing, 4 received, 5 missing, 6 received)
-	retx := rb.ProcessSACK(2, 0b1010)
+	retx := rb.ProcessSACK(2, []uint64{0b1010})
 	assert.Contains(t, retx, uint32(3))
 	assert.Contains(t, retx, uint32(5))
 	assert.NotContains(t, retx, uint32(4))
 	assert.NotContains(t, retx, uint32(6))
 }
 
-func TestRetxBuffer_Capacity(t *testing.T) {
+// TestRetxBuffer_CapacityEvictsLowest verifies the full-buffer path now evicts
+// the lowest (oldest, already force-flushed on the receiver) sequence and keeps
+// the newest, instead of silently refusing to store the newest packet.
+func TestRetxBuffer_CapacityEvictsLowest(t *testing.T) {
 	rb := newRetxBuffer(3)
 	assert.True(t, rb.Store(0, []byte("a")))
 	assert.True(t, rb.Store(1, []byte("b")))
 	assert.True(t, rb.Store(2, []byte("c")))
-	assert.False(t, rb.Store(3, []byte("d"))) // full
+	assert.True(t, rb.Store(3, []byte("d"))) // full -> evict lowest (0), store 3
+	assert.Equal(t, 3, rb.Len())
+	assert.Nil(t, rb.Get(0), "lowest seq evicted")
+	assert.Equal(t, []byte("d"), rb.Get(3), "newest seq retained")
 }
 
 func TestRetxBuffer_Get(t *testing.T) {
@@ -115,10 +147,59 @@ func TestRetxBuffer_Get(t *testing.T) {
 	assert.Nil(t, rb.Get(99))
 }
 
+// TestRetxBuffer_NoFillBehindPersistentGap is the #86 regression: a frontier gap
+// at seq 1 persists while the sender keeps sending. The full-window SACK must
+// purge every received-above-the-gap sequence so the buffer holds only the hole
+// plus the not-yet-reported tail — never the whole unackable backlog that used
+// to fill it and wedge the stream. (The old 64-bit SACK could only ack seqs
+// 1..64, leaving 65.. stuck in the buffer forever.)
+func TestRetxBuffer_NoFillBehindPersistentGap(t *testing.T) {
+	const sent = 3000
+	rb := newRetxBuffer(4096) // large so this isolates purge behavior, not eviction
+	for seq := uint32(1); seq <= sent; seq++ {
+		rb.Store(seq, []byte{byte(seq)})
+	}
+
+	// Receiver got 2..3000 but not seq 1 -> lastContiguous stuck at 0.
+	st := newSACKTracker()
+	st.RecordReceived(0)
+	for seq := uint32(2); seq <= sent; seq++ {
+		st.RecordReceived(seq)
+	}
+	last, words := st.GenerateSACK()
+	assert.Equal(t, uint32(0), last)
+
+	rb.ProcessSACK(last, words)
+
+	// seq 1 (the hole) retained for retransmit.
+	assert.NotNil(t, rb.Get(1), "the actual gap must stay retransmittable")
+	// Everything the SACK could cover (up to 32 words = seqs 1..2048) that was
+	// received is purged.
+	assert.Nil(t, rb.Get(2), "received seq above the gap must be purged")
+	assert.Nil(t, rb.Get(2048), "received seq at window edge must be purged")
+	// Buffer no longer holds the acknowledged backlog: only the hole + the tail
+	// above the 2048-seq window remain.
+	assert.LessOrEqual(t, rb.Len(), 1+(sent-2048)+8,
+		"buffer must not retain the acknowledged received backlog")
+}
+
 func TestSACKPacket_RoundTrip(t *testing.T) {
-	p := routing.MakeSACKPacket(7, 42, 0xDEADBEEF)
+	words := []uint64{0xDEADBEEF, 0x0, 0xF00D}
+	p := routing.MakeSACKPacket(7, 42, words)
 	assert.Equal(t, routing.SACKPacket, p.Type())
 	assert.Equal(t, routing.RouteID(7), p.RouteID())
 	assert.Equal(t, uint32(42), p.SACKLastContiguousSeq())
-	assert.Equal(t, uint64(0xDEADBEEF), p.SACKBitmap())
+	assert.Equal(t, words, p.SACKWords())
+}
+
+func TestSACKPacket_EmptyAndTrim(t *testing.T) {
+	// No words -> minimal payload, SACKWords returns empty.
+	p := routing.MakeSACKPacket(1, 5, nil)
+	assert.Equal(t, uint32(5), p.SACKLastContiguousSeq())
+	assert.Empty(t, p.SACKWords())
+
+	// Trailing zero words are trimmed on the wire but the meaningful prefix
+	// round-trips.
+	p2 := routing.MakeSACKPacket(1, 5, []uint64{0b101, 0, 0})
+	assert.Equal(t, []uint64{0b101}, p2.SACKWords())
 }

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -144,8 +144,19 @@ const (
 // payloads when mux mode is active.
 const SeqSize = 4
 
-// SACKPayloadSize is the size of a SACK packet payload:
-// last_contiguous_seq (uint32) + bitmap (uint64) = 12 bytes.
+// SACKMaxWords bounds the SACK bitmap to the mux reorder window: each word
+// acknowledges 64 sequences, so 32 words cover 2048 outstanding sequences —
+// the receiver force-flushes its reorder buffer beyond that, so acking further
+// is pointless. Keeps a SACK payload at most 5+32*8 = 261 bytes.
+const SACKMaxWords = 32
+
+// SACKMinPayloadSize is the smallest legal SACK payload:
+// last_contiguous_seq (uint32) + word_count (uint8) = 5 bytes (zero words).
+const SACKMinPayloadSize = 5
+
+// SACKPayloadSize is retained for the wire-compat single-word (legacy 12-byte)
+// SACK shape referenced by size-sensitive callers; the current encoder emits a
+// variable-length body (see MakeSACKPacket).
 const SACKPayloadSize = 12
 
 // CloseCode represents close code for ClosePacket.
@@ -364,16 +375,34 @@ func MakeErrorPacket(id RouteID, errPayload []byte) (Packet, error) {
 }
 
 // MakeSACKPacket constructs a SACK (Selective Acknowledgment) packet.
-// Payload: [last_contiguous_seq (4 bytes BE)][bitmap (8 bytes BE)]
-// bitmap bit i == 1 means (last_contiguous_seq + 1 + i) has been received.
-func MakeSACKPacket(id RouteID, lastContiguousSeq uint32, bitmap uint64) Packet {
-	packet := make([]byte, PacketHeaderSize+SACKPayloadSize)
+// Payload: [last_contiguous_seq (4 bytes BE)][word_count (1 byte)][words...(8 bytes BE each)]
+// For word w and bit i, a set bit means (last_contiguous_seq + 1 + w*64 + i)
+// has been received. The variable-length body lets a SACK acknowledge the whole
+// outstanding window (up to SACKMaxWords*64 sequences), not just the first 64 —
+// without it, a persistent frontier gap leaves the sender unable to purge the
+// received-but-unackable sequences above the gap, its retx buffer fills, new
+// packets stop being stored for retransmission, and a later loss wedges the mux
+// stream permanently (the "carries-then-stalls" failure).
+func MakeSACKPacket(id RouteID, lastContiguousSeq uint32, words []uint64) Packet {
+	if len(words) > SACKMaxWords {
+		words = words[:SACKMaxWords]
+	}
+	// Trim trailing all-zero words: nothing above the last set word is acked,
+	// so they carry no information and only cost bytes.
+	for len(words) > 0 && words[len(words)-1] == 0 {
+		words = words[:len(words)-1]
+	}
+	payloadSize := SACKMinPayloadSize + len(words)*8
+	packet := make([]byte, PacketHeaderSize+payloadSize)
 
 	packet[PacketTypeOffset] = byte(SACKPacket)
 	binary.BigEndian.PutUint32(packet[PacketRouteIDOffset:], uint32(id))
-	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], uint16(SACKPayloadSize))
+	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], uint16(payloadSize)) //nolint:gosec
 	binary.BigEndian.PutUint32(packet[PacketPayloadOffset:], lastContiguousSeq)
-	binary.BigEndian.PutUint64(packet[PacketPayloadOffset+4:], bitmap)
+	packet[PacketPayloadOffset+4] = byte(len(words)) //nolint:gosec // len(words) <= SACKMaxWords (32), capped above
+	for w, word := range words {
+		binary.BigEndian.PutUint64(packet[PacketPayloadOffset+5+w*8:], word)
+	}
 
 	return packet
 }
@@ -383,9 +412,24 @@ func (p Packet) SACKLastContiguousSeq() uint32 {
 	return binary.BigEndian.Uint32(p[PacketPayloadOffset:])
 }
 
-// SACKBitmap extracts the 64-bit bitmap from a SACK packet.
-func (p Packet) SACKBitmap() uint64 {
-	return binary.BigEndian.Uint64(p[PacketPayloadOffset+4:])
+// SACKWords extracts the received-bitmap words from a SACK packet. Bit (w*64+i)
+// set means (SACKLastContiguousSeq + 1 + w*64 + i) has been received. Returns
+// nil for a malformed / truncated payload (treated as "nothing above the
+// contiguous point acked", which is safe — it only forgoes purging).
+func (p Packet) SACKWords() []uint64 {
+	payload := p.Payload()
+	if len(payload) < SACKMinPayloadSize {
+		return nil
+	}
+	n := int(payload[4])
+	if n > SACKMaxWords || len(payload) < SACKMinPayloadSize+n*8 {
+		return nil
+	}
+	words := make([]uint64, n)
+	for w := 0; w < n; w++ {
+		words[w] = binary.BigEndian.Uint64(payload[5+w*8:])
+	}
+	return words
 }
 
 // TransportPingPayloadSize is the size of a transport ping/pong payload (8 bytes for unix nano timestamp).


### PR DESCRIPTION
**Root cause of the mux>1 'carries-then-stalls after ~30–75 s' wedge (#86, gate-4 blocker).** The SACK feedback was `{lastContiguous, 64-bit bitmap}` — it can only acknowledge 64 sequences past the receiver's contiguous pointer. When a frontier gap at seq N persists, `lastContiguous` sticks at N−1 while the sender keeps sending (the gap doesn't flow-control it), so the receiver accumulates received-but-unackable sequences `[N+65 .. writeSeq]`. The sender's `retxBuf` can't purge them, fills to capacity, and `retxBuf.Store` **silently refused new packets**. A later genuine loss then finds no stored copy → retransmit skipped → the receiver's reorder buffer fills to `maxGap`, force-flushes past the hole → noise-cipher desync → permanent 0-byte wedge (~30–75 s = time to fill 2048 under load).

**Fix.** The SACK now carries a variable-length, full-window received bitmap covering `[lastContiguous+1, highest]` (up to `SACKMaxWords*64 = 2048` seqs, the reorder-window bound). The sender purges **every** received sequence above the gap each SACK, so `retxBuf` holds only the genuine hole + the not-yet-reported in-flight tail and never fills behind a stuck gap. `retxBuf.Store` hardened: when full it evicts the lowest (oldest, already force-flushed on the receiver) sequence and keeps the newest, instead of dropping the newest — a backstop the full-window purge means isn't hit normally.

**Wire change** (mux-internal, gated on `CapSACK`): SACK payload `12 bytes` → `[lastContiguous uint32][nWords uint8][words…]` (trailing zero words trimmed). `MakeSACKPacket`/`SACKWords` updated; the intermediary relay passes words through.

**Tests:** words-API migration + two #86 regressions — `TestSACKTracker_FullWindowBitmap` (SACK spans >64 seqs) and `TestRetxBuffer_NoFillBehindPersistentGap` (received-above-gap purged, hole stays retransmittable, backlog not retained). Full `pkg/router` + `pkg/routing` suites pass; gofmt + golangci-lint clean.

⚠️ **Both endpoints must run this build** — the full-window SACK is not wire-compatible with the old 64-bit form. **Holding for a two-endpoint live gate-4 proof (local visor + a controlled far-end, ≥5-min mux run that does NOT wedge) before merge.** Not auto-merged.