### PR TITLE
feat(visor): 'visor state' — one-call curated snapshot of live runtime state

### DIFF
--- a/cmd/skywire-cli/commands/visor/state.go
+++ b/cmd/skywire-cli/commands/visor/state.go
@@ -1,0 +1,60 @@
+// Package clivisor cmd/skywire-cli/commands/visor/state.go
+package clivisor
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/cliout"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+const stateHumanMessage = "visor runtime state snapshot\n" +
+	"  use --json for the full structure, --shape for its schema,\n" +
+	"  or --jq '<filter>' to project a field (e.g. --jq '.health')."
+
+func init() {
+	RootCmd.AddCommand(stateCmd)
+}
+
+var stateCmd = &cobra.Command{
+	Use:   "state",
+	Short: "Curated snapshot of the visor's live internal runtime state",
+	Long: `Curated, secrets-free snapshot of the visor's live internal runtime state.
+
+Aggregates the same RPC-safe views the individual subcommands return —
+summary, health, service health, routing stats + route-group count, active
+routing policy, apps, transports, persistent transports, and which optional
+subsystems are wired — into ONE response, so you can project exactly the field
+you want with the global --jq / --shape flags instead of stitching together a
+dozen subcommands. The visor's secret key is never included.
+
+Examples:
+  skywire cli visor state --shape                 # print the output schema skeleton
+  skywire cli visor state --json                  # full snapshot as JSON
+  skywire cli visor state --jq '.health'          # just the health section
+  skywire cli visor state --jq '.transports | length'
+  skywire cli visor state --jq '.modules'
+  skywire cli visor state --via dmsg://<pk> --jq '.routing_policy'  # a remote visor`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		// --shape only needs the schema, not live data: print the skeleton of a
+		// zero snapshot without an RPC round-trip, so it works offline / against
+		// a visor that predates this call.
+		if shape, err := cmd.Flags().GetBool(cliout.ShapeFlag); err == nil && shape {
+			internal.PrintOutput(cmd.Flags(), &visor.StateSnapshot{}, stateHumanMessage)
+			return
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
+		}
+		snap, err := rpcClient.StateSnapshot()
+		if err != nil {
+			internal.PrintFatalRPCError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(), snap, stateHumanMessage)
+	},
+}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -33,6 +33,7 @@ type API interface {
 	//visor
 	Overview() (*Overview, error)
 	Summary() (*Summary, error)
+	StateSnapshot() (*StateSnapshot, error)
 	Health() (*HealthInfo, error)
 	IsStartupComplete() bool
 	EnableHypervisor() error

--- a/pkg/visor/api_state.go
+++ b/pkg/visor/api_state.go
@@ -1,0 +1,136 @@
+// Package visor pkg/visor/api_state.go c1-vis-core
+package visor
+
+import (
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// StateSnapshot is a curated, secrets-free view of the visor's live runtime
+// state, aggregated from the same RPC-safe DTOs the individual CLI subcommands
+// return. It exists so an operator (or an agent) can introspect the whole
+// runtime in ONE call — `skywire cli visor state` — and project exactly the
+// field they want with the shared --jq / --shape flags, instead of stitching
+// together a dozen subcommands.
+//
+// SAFETY: every embedded field is an existing API response type, i.e. already
+// designed to cross the RPC boundary — so this carries no mutexes, channels,
+// contexts, live connections, or secret keys. The visor's secret key is NEVER
+// included; identity is public-key only (via Summary.Overview.PubKey). Each
+// section is populated best-effort: a section that errors (e.g. a subsystem not
+// yet initialized, or the visor suspended) is left nil and the reason recorded
+// in Notes, so a partially-up or suspended visor still returns a useful snapshot
+// rather than failing the whole call.
+type StateSnapshot struct {
+	At        time.Time `json:"at"`
+	Suspended bool      `json:"suspended"`
+
+	Summary       *Summary                         `json:"summary,omitempty"`
+	Health        *HealthInfo                      `json:"health,omitempty"`
+	ServiceHealth []ServiceHealthEntry             `json:"service_health,omitempty"`
+	RoutingStats  *routing.RoutingTableStats       `json:"routing_stats,omitempty"`
+	RouteGroups   int                              `json:"route_groups"`
+	RoutingPolicy *RoutingPoliciesSummary          `json:"routing_policy,omitempty"`
+	Apps          []*appserver.AppState            `json:"apps,omitempty"`
+	Transports    []*TransportSummary              `json:"transports,omitempty"`
+	Persistent    []transport.PersistentTransports `json:"persistent_transports,omitempty"`
+	Modules       ModulePresence                   `json:"modules"`
+
+	// Notes collects per-section errors ("routing: <err>") so the snapshot is
+	// self-describing about what it could and could not read.
+	Notes []string `json:"notes,omitempty"`
+}
+
+// ModulePresence reports which optional subsystems are wired on this visor.
+// A false here means the module was not configured/started (nil), which is
+// often exactly the thing being debugged ("why is there no stats feed?").
+type ModulePresence struct {
+	StatsTracker       bool `json:"stats_tracker"`
+	UptimeRecorder     bool `json:"uptime_recorder"`
+	EmbeddedTPS        bool `json:"embedded_transport_setup"`
+	EmbeddedRouteSetup bool `json:"embedded_route_setup"`
+}
+
+// StateSnapshot assembles the runtime StateSnapshot. Each section is best-effort
+// and never panics on a not-yet-initialized subsystem; failures are recorded in
+// Notes. Secrets are never included (see the StateSnapshot type doc).
+func (v *Visor) StateSnapshot() (*StateSnapshot, error) {
+	snap := &StateSnapshot{At: time.Now()}
+	note := func(section string, err error) {
+		if err != nil {
+			snap.Notes = append(snap.Notes, section+": "+err.Error())
+		}
+	}
+
+	if susp, err := v.IsSuspended(); err != nil {
+		note("suspended", err)
+	} else {
+		snap.Suspended = susp
+	}
+
+	if sum, err := v.Summary(); err != nil {
+		note("summary", err)
+	} else {
+		snap.Summary = sum
+	}
+
+	if h, err := v.Health(); err != nil {
+		note("health", err)
+	} else {
+		snap.Health = h
+	}
+
+	if sh, err := v.ServiceHealth(); err != nil {
+		note("service_health", err)
+	} else {
+		snap.ServiceHealth = sh
+	}
+
+	if rs, err := v.RoutingStats(); err != nil {
+		note("routing_stats", err)
+	} else {
+		snap.RoutingStats = &rs
+	}
+
+	if rgs, err := v.RouteGroups(); err != nil {
+		note("route_groups", err)
+	} else {
+		snap.RouteGroups = len(rgs)
+	}
+
+	if rp, err := v.RoutingPolicies(); err != nil {
+		note("routing_policy", err)
+	} else {
+		snap.RoutingPolicy = rp
+	}
+
+	if apps, err := v.Apps(); err != nil {
+		note("apps", err)
+	} else {
+		snap.Apps = apps
+	}
+
+	if tps, err := v.Transports(nil, nil, false); err != nil {
+		note("transports", err)
+	} else {
+		snap.Transports = tps
+	}
+
+	if pts, err := v.GetPersistentTransports(); err != nil {
+		note("persistent_transports", err)
+	} else {
+		snap.Persistent = pts
+	}
+
+	snap.Modules = ModulePresence{
+		StatsTracker:       v.statsTracker != nil,
+		UptimeRecorder:     v.uptimeRecorder != nil,
+		EmbeddedTPS:        v.embeddedTPS != nil,
+		EmbeddedRouteSetup: v.embeddedRouteSetup != nil,
+	}
+
+	return snap, nil
+}

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -66,6 +66,10 @@ func (proxyDefaultAPI) Summary() (*Summary, error) {
 	return nil, ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) StateSnapshot() (*StateSnapshot, error) {
+	return nil, ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) Health() (*HealthInfo, error) {
 	return nil, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -224,6 +224,13 @@ func (rc *rpcClient) Summary() (*Summary, error) {
 	return out, err
 }
 
+// StateSnapshot calls StateSnapshot.
+func (rc *rpcClient) StateSnapshot() (*StateSnapshot, error) {
+	out := new(StateSnapshot)
+	err := rc.Call("StateSnapshot", &struct{}{}, out)
+	return out, err
+}
+
 // Overview calls Overview.
 func (rc *rpcClient) Overview() (*Overview, error) {
 	out := new(Overview)

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -161,6 +161,15 @@ func (mc *mockRPCClient) Overview() (*Overview, error) {
 	return &out, err
 }
 
+// StateSnapshot implements API.
+func (mc *mockRPCClient) StateSnapshot() (*StateSnapshot, error) {
+	summary, err := mc.Summary()
+	if err != nil {
+		return nil, err
+	}
+	return &StateSnapshot{At: time.Now(), Summary: summary}, nil
+}
+
 // Summary implements API.
 func (mc *mockRPCClient) Summary() (*Summary, error) {
 	overview, err := mc.Overview()

--- a/pkg/visor/rpc_visor.go
+++ b/pkg/visor/rpc_visor.go
@@ -159,6 +159,18 @@ func (r *RPC) Summary(_ *struct{}, out *Summary) (err error) {
 	return nil
 }
 
+// StateSnapshot provides a curated, secrets-free snapshot of the visor's live
+// runtime state (see StateSnapshot in api_state.go).
+func (r *RPC) StateSnapshot(_ *struct{}, out *StateSnapshot) (err error) {
+	defer rpcutil.LogCall(r.log, "StateSnapshot", nil)(out, &err)
+	snap, err := r.visor.StateSnapshot()
+	if err != nil {
+		return err
+	}
+	*out = *snap
+	return nil
+}
+
 // Overview provides a overview of the AppNode.
 func (r *RPC) Overview(_ *struct{}, out *Overview) (err error) {
 	defer rpcutil.LogCall(r.log, "Overview", nil)(out, &err)


### PR DESCRIPTION
Adds `StateSnapshot`: a curated, **secrets-free** view of the visor's live runtime, aggregated from the same RPC-safe DTOs the individual subcommands already return (summary, health, service health, routing stats + route-group count, active routing policy, apps, transports, persistent transports, and which optional subsystems are wired). Exposed as `API.StateSnapshot()`, an RPC method, and `skywire cli visor state`.

**Why:** introspecting a running visor meant stitching together a dozen subcommands. One call now returns the whole runtime and — flowing through the shared `PrintOutput` helper — honors the global `--json / --jq / --shape` flags:
```
skywire cli visor state --shape            # schema skeleton (works offline)
skywire cli visor state --jq '.health'
skywire cli visor state --jq '.transports | length'
skywire cli visor state --via dmsg://<pk> --jq '.routing_policy'
```

**Safety:** every embedded field is an existing API response type — already designed to cross the RPC boundary — so the snapshot carries no mutexes, channels, contexts, live connections, or secret keys. **The visor's secret key is never included** (identity is public-key only). Each section is best-effort: a subsystem that errors (not initialized / suspended) is left nil with the reason in `Notes`, so a partial/suspended visor still returns a useful snapshot. `--shape` short-circuits the RPC so the schema prints even against a visor that predates this call.

Riding the existing gated RPC transport, the dmsg-exposed path inherits the survey-whitelist gating of the other debug surfaces. `proxy_default_api` + `rpc_client_mock` stubs satisfy the `API` interface; the reflection-based `TestMockRPCClient_AllMethods` covers the new method. `--shape` smoke-tested; build + golangci-lint clean.