### PR TITLE
test(cli): allowlist 'proxy mux plot' in the JSON-contract test (fix red develop)

### DIFF
--- a/cmd/skywire-cli/jsoncontract_test.go
+++ b/cmd/skywire-cli/jsoncontract_test.go
@@ -40,6 +40,7 @@ var streamingCommands = map[string]string{
 	"commands/gotop/root.go":                   "a full-screen TUI; there is no document to emit",
 	"commands/visor/top.go":                    "a full-screen TUI; there is no document to emit",
 	"commands/visor/ping/mux_bandwidth_tui.go": "a live bandwidth TUI",
+	"commands/proxy/mux_plot.go":               "a live per-leg bandwidth+RTT terminal chart; there is no document to emit",
 	"commands/tp/tp-viz.go":                    "starts a visualizer HTTP server; it serves pages, it does not return a value",
 	"commands/visor/ping/tree.go":              "an interactive Bubble Tea TUI over a live BFS walk",
 	"commands/reward/rules.go":                 "prints the mainnet rules as markdown or rendered HTML — a document to read, not data",


### PR DESCRIPTION
`TestEveryPrintingCommandHonoursJSON` flags `commands/proxy/mux_plot.go` — it prints without consulting `--json`, so `make check` has been **red on develop** since the live plotter merged (#4020/#4023). `mux plot` is a live per-leg bandwidth+RTT terminal chart (continuously-redrawn TUI, no single document for `--json` to shape) — the same `streamingCommands` category as `mux_bandwidth_tui.go` and `tree.go`. Adds it to that allowlist with a rationale. Restores green `make check`; no behavior change.