### PR TITLE
feat(cli): add --bind listen-address flag to rewards ui, deprecate --port

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/cmd.go
+++ b/cmd/skywire-cli/commands/rewards/server/cmd.go
@@ -3,6 +3,7 @@ package clirewardsserver
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"runtime"
@@ -30,6 +31,7 @@ var (
 	wd                  string
 	wlkeys              []cipher.PubKey
 	webPort             uint
+	webBind             string
 	loginNode           string
 	loginNodeAddr       string // resolved URL of login chain node (set at runtime)
 	loginGenesisAddress string // genesis wallet address for login verification (set at runtime)
@@ -49,7 +51,9 @@ var skyenvfile = os.Getenv("SKYENV")
 
 func init() {
 	ServerCmd.CompletionOptions.DisableDefaultCmd = true
-	ServerCmd.Flags().UintVarP(&webPort, "port", "p", scriptExecUint("${WEBPORT:-80}"), "port to serve")
+	defaultWebPort := scriptExecUint("${WEBPORT:-80}")
+	ServerCmd.Flags().UintVarP(&webPort, "port", "p", defaultWebPort, "port to serve (deprecated: use --bind)")
+	ServerCmd.Flags().StringVar(&webBind, "bind", fmt.Sprintf(":%d", defaultWebPort), "listen address host:port to serve on\n(empty host = all interfaces; 127.0.0.1:80 = localhost only)")
 	ServerCmd.Flags().Uint16VarP(&dmsgPort, "dport", "d", scriptExecUint16("${DMSGPORT:-80}"), "dmsg port to serve")
 	ServerCmd.Flags().IntVarP(&dmsgSess, "dsess", "e", scriptExecInt("${DMSGSESSIONS:-1}"), "dmsg sessions")
 	msg := "add whitelist keys, comma separated to permit POST of reward transaction to be broadcast"
@@ -94,10 +98,29 @@ skyenv file detected: ` + skyenvfile
 .conf file may also be specified with
 SKYENV=/path/to/fiber.conf fiber run`
 	}(),
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		r := buildRouter()
-		serveStandalone(r)
+		serveStandalone(r, resolveBindAddr(cmd, webBind, webPort))
 	},
+}
+
+// resolveBindAddr computes the effective listen address for the server.
+// --bind wins if set. Otherwise, if the deprecated --port was set, its value
+// is mapped into the host part of the default --bind address (preserving the
+// all-interfaces-vs-localhost semantics of the default). If neither was
+// changed, the default --bind value is used.
+func resolveBindAddr(cmd *cobra.Command, bind string, port uint) string {
+	if cmd.Flags().Changed("bind") {
+		return bind
+	}
+	if cmd.Flags().Changed("port") {
+		host, _, err := net.SplitHostPort(bind)
+		if err != nil {
+			host = ""
+		}
+		return net.JoinHostPort(host, strconv.FormatUint(uint64(port), 10))
+	}
+	return bind
 }
 
 // RewardConfig holds configuration for the reward system when hosted

--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -1800,7 +1800,8 @@ func BuildHandler() http.Handler {
 }
 
 // serveStandalone starts HTTP and DMSG listeners. Called by the CLI command.
-func serveStandalone(r1 *gin.Engine) {
+// bindAddr is the host:port listen address for the HTTP server.
+func serveStandalone(r1 *gin.Engine, bindAddr string) {
 	log := logging.MustGetLogger("dmsghttp")
 	if dmsgDisc == "" {
 		log.Fatal("Dmsg Discovery URL not specified")
@@ -1855,8 +1856,8 @@ func serveStandalone(r1 *gin.Engine) {
 	// Start serving
 	wg.Add(1)
 	go func() {
-		fmt.Printf("listening on http://127.0.0.1:%d using gin router\n", webPort)
-		r1.Run(fmt.Sprintf(":%d", webPort)) //nolint:errcheck,gosec
+		fmt.Printf("listening on http://%s using gin router\n", bindAddr)
+		r1.Run(bindAddr) //nolint:errcheck,gosec
 		wg.Done()
 	}()
 


### PR DESCRIPTION
## What

`skywire cli rewards ui` bound its HTTP server to `:<port>` on **all interfaces (0.0.0.0)** with no way to restrict it to localhost. This adds a `--bind` flag taking a full `host:port` listen address, so operators can bind `127.0.0.1:80` (localhost only) instead of exposing the reward UI on every interface.

```
--bind string   listen address host:port to serve on
                (empty host = all interfaces; 127.0.0.1:80 = localhost only)
```

## Compatibility — `--port` deprecated, NOT removed

The original request was to "retire `--port` and just use `--bind`". Hard-removing `--port` would break running systemd units / scripts across the fleet that pass `--port`, so instead **`--port` is deprecated but kept fully functional**:

- `--bind` defaults to `:<current-port>` (e.g. `:80`), **preserving the existing all-interfaces behavior**. The default is deliberately **not** switched to localhost — that would silently break remote access to running deployments.
- When only `--port` is given, its value is mapped into the host part of the default `--bind` address, so `--port 8080` still binds `:8080` on all interfaces as before.
- `--bind` wins if both are supplied.
- `--port`'s help text is annotated `(deprecated: use --bind)`. It is left visible (not `MarkDeprecated`-hidden) so it does not emit a per-invocation stderr warning into fleet systemd logs on every service start.

Hard removal of `--port` can be done in a later change once fleet units have migrated to `--bind`.

## Audit of other CLI listen/port flags

Per the request, the other CLI `--port` / listen flags were audited. None needed `--bind`:

| Command | Flag | Verdict |
|---|---|---|
| `hv serve` | `--addr :7999` | Already a full `host:port` bind address (supports localhost) — no change |
| `util static serve` | `--addr 127.0.0.1:0` | Already a full bind address, already defaults to localhost — no change |
| `tp-viz` | `--addr` (host) + `--port` | Already has host control via `--addr`, already defaults to `127.0.0.1` — no change |
| `hv probe` / `hv shell` | `--port 9222` | Remote CDP target port (connects to a browser), not a listener — skip |
| `hv notify` | `--addr` | Hypervisor API target address (client), not a listener — skip |
| `dmsgpty exec/shell` | `--port 22` | Remote visor dmsgpty target port — skip |
| `svc health` | `--port 80` | Remote service dmsg port being queried — skip |
| `dmsg scp` | `--port` | Remote dmsgscp host port — skip |
| `dmsg chat` | `--port 9001` | dmsg PK-addressed listen port — no host/interface concept, `host:port` bind is meaningless on dmsg — skip |
| `skychat` | `--addr 127.0.0.1:8001` | chat-app HTTP target the CLI connects to (client), not a listener — skip |

Only `rewards ui` was a genuine all-interfaces TCP listener whose `--port` lacked host control.

## Verify

- `go build ./cmd/skywire` passes
- `go vet ./cmd/skywire-cli/commands/rewards/...` clean
- imports ordered via goimports-reviser
- `--bind` and deprecated `--port` both appear in `rewards ui --help`