### PR TITLE
fix(cxo): don't crash the visor on a recoverable DB miss serving/storing objects

### DIFF
--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -980,7 +980,14 @@ func (c *Conn) handleRqObject(seq uint32, rq *msg.RqObject) {
 	)
 
 	if err := c.n.c.Want(rq.Key, gc, 0); err != nil {
-		c.n.Fatal("DB failure: ", err)
+		// A peer requested an object we can't provide (a "not found" DB miss is
+		// the common case — we simply don't hold it, or don't hold it yet).
+		// This is recoverable: tell the requesting peer we can't serve it and
+		// move on. A peer's object request must NEVER crash this visor.
+		c.n.Errorf(err, "[%s] handleRqObject: cannot serve %s",
+			c.String(), rq.Key.Hex()[:7])
+		c.sendMsg(c.nextSeq(), seq, &msg.Err{}) //nolint:errcheck,gosec
+		return
 	}
 	defer c.n.c.Unwant(rq.Key, gc) // to be memory safe
 

--- a/pkg/cxo/node/head.go
+++ b/pkg/cxo/node/head.go
@@ -580,7 +580,14 @@ func (f *fillHead) request(c *Conn, seq uint64, key cipher.SHA256) {
 
 		// incremented by the Want call(s)
 		if _, err := f.node().c.SetWanted(key, x.Value); err != nil {
-			f.node().Fatal("DB failure:", err)
+			// Recoverable DB error storing a received object — signal the fill
+			// as a failed request (same as any other failure above) instead of
+			// crashing the whole visor.
+			f.node().Errorf(err, "SetWanted for %s failed", key.Hex()[:7])
+			select {
+			case f.failureq <- failedRequest{c, seq, key, err}:
+			case <-f.closeq:
+			}
 			return
 		}
 


### PR DESCRIPTION
**Crash fix.** A peer requesting an object this node doesn't hold crash-loops the whole visor.

`pkg/cxo/node/conn.go:983` (`handleRqObject`) called `node.Fatal("DB failure: ", err)` when `Want()` returned an error — but the common case is a benign **"not found"** (we simply don't hold the requested object). `pkg/cxo/node/head.go:583` had the same `Fatal` on a `SetWanted` DB error during a fill.

Observed live as a crash-loop: `[node] conn.go:983: DB failure: not found`. The transport-discovery CXO work (#4008–4017) increased cross-peer object requests, so this latent `Fatal` now fires readily.

Both are recoverable and now handled like the package's existing failure paths:
- `conn.go`: log at error level + reply to the peer with `msg.Err{}` (same as the existing response-timeout branch) and return.
- `head.go`: route the failure through `failureq` (identical to every other failure in that `switch`) instead of `Fatal`.

A peer's request — or a transient DB miss — must never take down the visor. Builds + `go vet` clean on `./pkg/cxo/node/`.