### PR TITLE
feat(cli): stream 'proxy mux plot' default -n mode over gRPC (smooth, no more 1 Hz unary poll)

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_plot.go
+++ b/cmd/skywire-cli/commands/proxy/mux_plot.go
@@ -77,9 +77,12 @@ var muxPlotCmd = &cobra.Command{
 
 Two sources:
 
-  (default) poll a running app's route group. Reads the same per-leg
-  telemetry the routing-policy on_tick ABI sees (RouteGroupMuxInfo) once
-  per --interval. Shows exactly the legs the app's route group has right now.
+  (default) watch a running app's route group. Reads the same per-leg
+  telemetry the routing-policy on_tick ABI sees (RouteGroupMuxInfo) over a
+  smooth gRPC server-stream (StreamRouteGroupMuxInfo), so it updates
+  continuously like --pk mode rather than choppily per --interval; --interval
+  sets the server-side sample cadence. Shows exactly the legs the app's route
+  group has right now. Falls back to the unary poll against an older visor.
 
   --pk <peer>  measure a controlled, self-driven mux route to a peer you
   control (StreamMuxBandwidth) — the reliable multi-leg demonstrator, since
@@ -125,7 +128,25 @@ Examples:
 		defer rpcClient.Close() //nolint:errcheck,gosec
 
 		muxPlotSubject = muxPlotApp
-		runMuxPlot(func() (any, error) { return rpcClient.RouteGroupMuxInfo(muxPlotApp) })
+		poll := func() (any, error) { return rpcClient.RouteGroupMuxInfo(muxPlotApp) }
+
+		// --tui stays on the unary-poll path: livetui drives its own
+		// interval Refresh loop (poll-shaped), so the blocking-Recv stream
+		// doesn't fit it. The smooth-stream win is for the default ANSI
+		// redraw below.
+		if muxPlotTUI {
+			runMuxPlot(poll)
+			return
+		}
+
+		// Default: consume the StreamRouteGroupMuxInfo server-stream so the
+		// plot updates smoothly/continuously (like --pk's StreamMuxBandwidth)
+		// instead of the choppy per-tick unary gob poll. If the stream RPC is
+		// unavailable (older visor / no gRPC surface) it returns false and we
+		// transparently fall back to the unary poll — same output, just choppy.
+		if !runMuxPlotInfoStream(cmd, poll) {
+			runMuxPlot(poll)
+		}
 	},
 }
 
@@ -308,6 +329,105 @@ func runMuxPlotStream(cmd *cobra.Command) {
 		default:
 		}
 	}
+}
+
+// runMuxPlotInfoStream drives the default (watch-a-running-app) mode over
+// the StreamRouteGroupMuxInfo server-stream — the smooth continuous
+// counterpart of runMuxPlot's per-tick unary poll. It blocks on
+// stream.Recv() and repaints each sample as it lands, so the chart tracks
+// the app's route group the way --pk mode tracks its ad-hoc route.
+//
+// Returns true once it has driven the stream (to EOF / ctrl+c / a mid-run
+// error). Returns FALSE without rendering when the stream is unavailable —
+// the gRPC endpoint won't connect, the RPC is unimplemented on an older
+// visor (first Recv errors before any sample), etc. — so the caller can
+// fall back to the unary poll. --interval sets the server-side sample
+// cadence (sample_interval_ns).
+func runMuxPlotInfoStream(cmd *cobra.Command, _ func() (any, error)) bool {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	client, err := rpcgrpc.NewPingClient(clirpc.Addr)
+	if err != nil {
+		// gRPC surface unreachable — let the caller poll instead.
+		return false
+	}
+	defer client.Close() //nolint:errcheck,gosec
+
+	stream, err := client.StreamRouteGroupMuxInfo(ctx, &rpcgrpc.StreamRouteGroupMuxInfoRequest{
+		AppName:          muxPlotApp,
+		SampleIntervalNs: muxPlotInterval.Nanoseconds(),
+	})
+	if err != nil {
+		return false
+	}
+
+	tracks := map[int]*legTrack{}
+	gotSample := false
+	for {
+		sample, recvErr := stream.Recv()
+		if recvErr != nil {
+			if recvErr == io.EOF || errors.Is(recvErr, context.Canceled) {
+				fmt.Print("\n")
+				return true
+			}
+			// A failure before the FIRST sample most likely means the RPC
+			// is unimplemented on an older visor (gRPC resolves the method
+			// lazily, so an absent handler surfaces here, not at open) —
+			// fall back to the unary poll rather than erroring out.
+			if !gotSample {
+				return false
+			}
+			fmt.Fprintf(os.Stderr, "\nstream recv: %v\n", recvErr)
+			return true
+		}
+		gotSample = true
+		// Mirror the poll path: render only the first (primary) route group,
+		// exactly as runMuxPlot consumes rgs[0]. An empty sample (app has no
+		// route group yet) leaves the last frame in place.
+		if rg, ok := firstMuxRouteGroup(sample); ok {
+			updateTracks(tracks, rg)
+			render(tracks)
+		}
+		select {
+		case <-ctx.Done():
+			fmt.Print("\n")
+			return true
+		default:
+		}
+	}
+}
+
+// firstMuxRouteGroup projects the first route group of a
+// RouteGroupMuxInfoSample into the CLI-side muxRouteGroupInfo the render
+// path (updateTracks) consumes — so the stream feeds exactly the same
+// track-update code the unary poll does. Returns false for an empty sample.
+func firstMuxRouteGroup(sample *rpcgrpc.RouteGroupMuxInfoSample) (muxRouteGroupInfo, bool) {
+	if sample == nil || len(sample.RouteGroups) == 0 {
+		return muxRouteGroupInfo{}, false
+	}
+	g := sample.RouteGroups[0]
+	rg := muxRouteGroupInfo{
+		MuxEnabled:  g.MuxEnabled,
+		SACKEnabled: g.SackEnabled,
+	}
+	for _, leg := range g.Legs {
+		rg.Legs = append(rg.Legs, muxLegInfo{
+			Index:       int(leg.RouteIndex),
+			TransportID: leg.TransportId,
+			TpType:      leg.TransportKind,
+			RemotePK:    leg.RemotePk,
+			LatencyMS:   leg.LatencyMs,
+			SentBytes:   leg.SentBytes,
+			SentPackets: leg.SentPackets,
+			RecvBytes:   leg.RecvBytes,
+			RecvPackets: leg.RecvPackets,
+			Retransmits: leg.Retransmits,
+			Alive:       leg.Alive,
+			Standby:     leg.Standby,
+		})
+	}
+	return rg, true
 }
 
 // updateTracksFromLegs feeds one StreamMuxBandwidth sample's per-leg breakdown

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -512,6 +512,44 @@ func (a *visorPingAdapter) GetTransportLatencyByRemotePK(remotePK cipher.PubKey)
 	return a.v.GetTransportLatencyByRemotePK(remotePK)
 }
 
+// RouteGroupMuxInfo crosses the rpcgrpc → visor boundary by transcribing
+// the visor's []MuxRouteGroupInfo into the rpcgrpc-local mirror slice.
+// Powers the StreamRouteGroupMuxInfo server-stream (smooth 'cli proxy mux
+// plot' telemetry). The rpcgrpc-side structs exist only to keep that
+// package free of pkg/visor imports.
+func (a *visorPingAdapter) RouteGroupMuxInfo(appName string) ([]rpcgrpc.RouteGroupMuxInfoData, error) {
+	infos, err := a.v.RouteGroupMuxInfo(appName)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]rpcgrpc.RouteGroupMuxInfoData, 0, len(infos))
+	for _, info := range infos {
+		g := rpcgrpc.RouteGroupMuxInfoData{
+			MuxEnabled:  info.MuxEnabled,
+			SACKEnabled: info.SACKEnabled,
+			Legs:        make([]rpcgrpc.RouteGroupMuxLegData, 0, len(info.Legs)),
+		}
+		for _, leg := range info.Legs {
+			g.Legs = append(g.Legs, rpcgrpc.RouteGroupMuxLegData{
+				Index:       leg.Index,
+				TransportID: leg.TransportID,
+				TpType:      leg.TpType,
+				RemotePK:    leg.RemotePK,
+				LatencyMS:   leg.LatencyMS,
+				SentBytes:   leg.SentBytes,
+				SentPackets: leg.SentPackets,
+				RecvBytes:   leg.RecvBytes,
+				RecvPackets: leg.RecvPackets,
+				Retransmits: leg.Retransmits,
+				Alive:       leg.Alive,
+				Standby:     leg.Standby,
+			})
+		}
+		out = append(out, g)
+	}
+	return out, nil
+}
+
 func (a *visorPingAdapter) DialDmsgRPC(pk cipher.PubKey) (net.Conn, error) {
 	return a.v.DialDmsgRPC(pk)
 }

--- a/pkg/visor/rpcgrpc/client.go
+++ b/pkg/visor/rpcgrpc/client.go
@@ -69,6 +69,17 @@ func (c *PingClient) StreamMuxBandwidth(ctx context.Context, req *MuxBandwidthRe
 	return c.client.StreamMuxBandwidth(ctx, req)
 }
 
+// StreamRouteGroupMuxInfo opens the running-app per-leg mux telemetry
+// stream — the smooth server-streaming replacement for the unary
+// RouteGroupMuxInfo poll that 'cli proxy mux plot' (default mode) rides.
+// Same event-level-control rationale as StreamMuxBandwidth: the CLI
+// consumer drives Recv() and renders each sample as it arrives. Returns
+// the raw generated stream so the caller can distinguish a never-
+// implemented RPC (first Recv errors) and fall back to the unary poll.
+func (c *PingClient) StreamRouteGroupMuxInfo(ctx context.Context, req *StreamRouteGroupMuxInfoRequest) (PingService_StreamRouteGroupMuxInfoClient, error) {
+	return c.client.StreamRouteGroupMuxInfo(ctx, req)
+}
+
 // StreamPing performs pings and calls the callback for each result
 // timeout applies only to the ping phase (after route setup), 0 means no timeout
 // setupTimeout applies to route setup phase, 0 means no timeout

--- a/pkg/visor/rpcgrpc/grpc_test.go
+++ b/pkg/visor/rpcgrpc/grpc_test.go
@@ -55,6 +55,7 @@ type fakeVisor struct {
 	snapshotHistoryAfterNs func(string, int64) []GroupMessageData
 	fetchAllTransports     func(context.Context) ([]*transport.Entry, error)
 	transportLatency       func(cipher.PubKey) float64
+	routeGroupMuxInfo      func(string) ([]RouteGroupMuxInfoData, error)
 
 	mu             sync.Mutex
 	groupSendCount int
@@ -97,6 +98,7 @@ func newFakeVisor() *fakeVisor {
 		snapshotHistoryAfterNs: func(string, int64) []GroupMessageData { return nil },
 		fetchAllTransports:     func(context.Context) ([]*transport.Entry, error) { return nil, nil },
 		transportLatency:       func(cipher.PubKey) float64 { return 0 },
+		routeGroupMuxInfo:      func(string) ([]RouteGroupMuxInfoData, error) { return nil, nil },
 	}
 }
 
@@ -154,6 +156,9 @@ func (f *fakeVisor) FetchAllTransportEntries(ctx context.Context) ([]*transport.
 }
 func (f *fakeVisor) GetTransportLatencyByRemotePK(pk cipher.PubKey) float64 {
 	return f.transportLatency(pk)
+}
+func (f *fakeVisor) RouteGroupMuxInfo(app string) ([]RouteGroupMuxInfoData, error) {
+	return f.routeGroupMuxInfo(app)
 }
 
 func (f *fakeVisor) groupSends() int {
@@ -634,5 +639,89 @@ func TestStreamGroupMessagesDelivers(t *testing.T) {
 
 	if fv.groupSends() < 3 {
 		t.Errorf("IncGroupStreamSend called %d times, want >= 3", fv.groupSends())
+	}
+}
+
+// --- StreamRouteGroupMuxInfo -----------------------------------------
+
+// TestStreamRouteGroupMuxInfoDelivers drives the smooth per-leg mux
+// telemetry stream backing 'cli proxy mux plot' (default mode) and
+// verifies each sample carries the fakeVisor's route-group legs.
+func TestStreamRouteGroupMuxInfoDelivers(t *testing.T) {
+	fv := newFakeVisor()
+	fv.routeGroupMuxInfo = func(app string) ([]RouteGroupMuxInfoData, error) {
+		if app != "skysocks-client" {
+			t.Errorf("app = %q, want skysocks-client", app)
+		}
+		return []RouteGroupMuxInfoData{{
+			MuxEnabled:  true,
+			SACKEnabled: true,
+			Legs: []RouteGroupMuxLegData{
+				{Index: 0, TpType: "stcpr", RemotePK: "remote-a", SentBytes: 100, RecvBytes: 200, Alive: true},
+				{Index: 1, TpType: "sudph", RemotePK: "remote-b", SentBytes: 10, RecvBytes: 20, Standby: true},
+			},
+		}}, nil
+	}
+	client, cleanup := newTestServer(t, fv)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream, err := client.StreamRouteGroupMuxInfo(ctx, &StreamRouteGroupMuxInfoRequest{
+		AppName:          "skysocks-client",
+		SampleIntervalNs: (20 * time.Millisecond).Nanoseconds(),
+	})
+	if err != nil {
+		t.Fatalf("StreamRouteGroupMuxInfo: %v", err)
+	}
+
+	sample, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("first Recv: %v", err)
+	}
+	if len(sample.RouteGroups) != 1 {
+		t.Fatalf("route groups = %d, want 1", len(sample.RouteGroups))
+	}
+	g := sample.RouteGroups[0]
+	if !g.MuxEnabled || !g.SackEnabled {
+		t.Errorf("mux/sack flags not carried: mux=%v sack=%v", g.MuxEnabled, g.SackEnabled)
+	}
+	if len(g.Legs) != 2 {
+		t.Fatalf("legs = %d, want 2", len(g.Legs))
+	}
+	if g.Legs[0].TransportKind != "stcpr" || g.Legs[0].SentBytes != 100 {
+		t.Errorf("leg0 mismatch: kind=%q sent=%d", g.Legs[0].TransportKind, g.Legs[0].SentBytes)
+	}
+	if !g.Legs[1].Standby {
+		t.Errorf("leg1 standby gate not carried")
+	}
+
+	// A second sample must arrive on the ticker (continuous stream).
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("second Recv: %v", err)
+	}
+}
+
+// TestStreamRouteGroupMuxInfoEmpty verifies an absent route group is NOT
+// a stream error — the handler emits an empty sample and keeps going so
+// the plot renders an empty frame until the app dials.
+func TestStreamRouteGroupMuxInfoEmpty(t *testing.T) {
+	client, cleanup := newTestServer(t, newFakeVisor()) // default returns nil, nil
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream, err := client.StreamRouteGroupMuxInfo(ctx, &StreamRouteGroupMuxInfoRequest{AppName: "vpn-client"})
+	if err != nil {
+		t.Fatalf("StreamRouteGroupMuxInfo: %v", err)
+	}
+	sample, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv on empty route group errored: %v", err)
+	}
+	if len(sample.RouteGroups) != 0 {
+		t.Errorf("route groups = %d, want 0", len(sample.RouteGroups))
 	}
 }

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -7,11 +7,12 @@
 package rpcgrpc
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -4192,6 +4193,329 @@ func (x *MuxBandwidthError) GetMessage() string {
 	return ""
 }
 
+// StreamRouteGroupMuxInfoRequest configures a live route-group mux
+// telemetry stream for a running app. See StreamRouteGroupMuxInfo.
+type StreamRouteGroupMuxInfoRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// AppName scopes the telemetry to route groups tagged with this app
+	// (skysocks-client, vpn-client, ...). Empty returns every mux'd route
+	// group the visor has — matching the unary RouteGroupMuxInfo("").
+	AppName string `protobuf:"bytes,1,opt,name=app_name,json=appName,proto3" json:"app_name,omitempty"`
+	// SampleIntervalNs is how often a RouteGroupMuxInfoSample is emitted.
+	// 0 falls back to 500 ms; the handler floors it to a 100 ms minimum
+	// so a client can't spin the visor. Nanoseconds (proto convention
+	// used throughout this service).
+	SampleIntervalNs int64 `protobuf:"varint,2,opt,name=sample_interval_ns,json=sampleIntervalNs,proto3" json:"sample_interval_ns,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *StreamRouteGroupMuxInfoRequest) Reset() {
+	*x = StreamRouteGroupMuxInfoRequest{}
+	mi := &file_ping_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamRouteGroupMuxInfoRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamRouteGroupMuxInfoRequest) ProtoMessage() {}
+
+func (x *StreamRouteGroupMuxInfoRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamRouteGroupMuxInfoRequest.ProtoReflect.Descriptor instead.
+func (*StreamRouteGroupMuxInfoRequest) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *StreamRouteGroupMuxInfoRequest) GetAppName() string {
+	if x != nil {
+		return x.AppName
+	}
+	return ""
+}
+
+func (x *StreamRouteGroupMuxInfoRequest) GetSampleIntervalNs() int64 {
+	if x != nil {
+		return x.SampleIntervalNs
+	}
+	return 0
+}
+
+// RouteGroupMuxInfoSample is one snapshot of a running app's mux'd
+// route-group telemetry, emitted every sample_interval_ns. Mirrors the
+// []visor.MuxRouteGroupInfo the unary RouteGroupMuxInfo RPC returns.
+type RouteGroupMuxInfoSample struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// TimestampNs is server-side wall time at emit.
+	TimestampNs int64 `protobuf:"varint,1,opt,name=timestamp_ns,json=timestampNs,proto3" json:"timestamp_ns,omitempty"`
+	// RouteGroups is one entry per active route group tagged with the
+	// requested app. Empty when the app has no route group yet — the
+	// stream stays open and keeps sampling rather than erroring.
+	RouteGroups   []*RouteGroupMuxInfo `protobuf:"bytes,2,rep,name=route_groups,json=routeGroups,proto3" json:"route_groups,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RouteGroupMuxInfoSample) Reset() {
+	*x = RouteGroupMuxInfoSample{}
+	mi := &file_ping_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RouteGroupMuxInfoSample) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RouteGroupMuxInfoSample) ProtoMessage() {}
+
+func (x *RouteGroupMuxInfoSample) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RouteGroupMuxInfoSample.ProtoReflect.Descriptor instead.
+func (*RouteGroupMuxInfoSample) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *RouteGroupMuxInfoSample) GetTimestampNs() int64 {
+	if x != nil {
+		return x.TimestampNs
+	}
+	return 0
+}
+
+func (x *RouteGroupMuxInfoSample) GetRouteGroups() []*RouteGroupMuxInfo {
+	if x != nil {
+		return x.RouteGroups
+	}
+	return nil
+}
+
+// RouteGroupMuxInfo is one route group's mux state plus its per-leg
+// counters. Field-for-field mirror of visor.MuxRouteGroupInfo (minus
+// the descriptor, which the plot consumer does not render).
+type RouteGroupMuxInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	MuxEnabled    bool                   `protobuf:"varint,1,opt,name=mux_enabled,json=muxEnabled,proto3" json:"mux_enabled,omitempty"`
+	SackEnabled   bool                   `protobuf:"varint,2,opt,name=sack_enabled,json=sackEnabled,proto3" json:"sack_enabled,omitempty"`
+	Legs          []*RouteGroupMuxLeg    `protobuf:"bytes,3,rep,name=legs,proto3" json:"legs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RouteGroupMuxInfo) Reset() {
+	*x = RouteGroupMuxInfo{}
+	mi := &file_ping_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RouteGroupMuxInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RouteGroupMuxInfo) ProtoMessage() {}
+
+func (x *RouteGroupMuxInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RouteGroupMuxInfo.ProtoReflect.Descriptor instead.
+func (*RouteGroupMuxInfo) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *RouteGroupMuxInfo) GetMuxEnabled() bool {
+	if x != nil {
+		return x.MuxEnabled
+	}
+	return false
+}
+
+func (x *RouteGroupMuxInfo) GetSackEnabled() bool {
+	if x != nil {
+		return x.SackEnabled
+	}
+	return false
+}
+
+func (x *RouteGroupMuxInfo) GetLegs() []*RouteGroupMuxLeg {
+	if x != nil {
+		return x.Legs
+	}
+	return nil
+}
+
+// RouteGroupMuxLeg is one leg (route) within a mux'd group — mirror of
+// visor.MuxLegInfo.
+type RouteGroupMuxLeg struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// RouteIndex is the leg's stable index within the group
+	// (visor.MuxLegInfo.Index).
+	RouteIndex  int32  `protobuf:"varint,1,opt,name=route_index,json=routeIndex,proto3" json:"route_index,omitempty"`
+	TransportId string `protobuf:"bytes,2,opt,name=transport_id,json=transportId,proto3" json:"transport_id,omitempty"`
+	// TransportKind is the leg's transport type (stcpr, sudph, dmsg, ...)
+	// — visor.MuxLegInfo.TpType.
+	TransportKind string  `protobuf:"bytes,3,opt,name=transport_kind,json=transportKind,proto3" json:"transport_kind,omitempty"`
+	RemotePk      string  `protobuf:"bytes,4,opt,name=remote_pk,json=remotePk,proto3" json:"remote_pk,omitempty"`
+	LatencyMs     float64 `protobuf:"fixed64,5,opt,name=latency_ms,json=latencyMs,proto3" json:"latency_ms,omitempty"`
+	SentBytes     uint64  `protobuf:"varint,6,opt,name=sent_bytes,json=sentBytes,proto3" json:"sent_bytes,omitempty"`
+	SentPackets   uint64  `protobuf:"varint,7,opt,name=sent_packets,json=sentPackets,proto3" json:"sent_packets,omitempty"`
+	RecvBytes     uint64  `protobuf:"varint,8,opt,name=recv_bytes,json=recvBytes,proto3" json:"recv_bytes,omitempty"`
+	RecvPackets   uint64  `protobuf:"varint,9,opt,name=recv_packets,json=recvPackets,proto3" json:"recv_packets,omitempty"`
+	Retransmits   uint64  `protobuf:"varint,10,opt,name=retransmits,proto3" json:"retransmits,omitempty"`
+	// Alive is false once the leg's transport is closed; Standby is true
+	// for a warm standby (rules kept, not sending) — the leg's gate_state.
+	Alive         bool `protobuf:"varint,11,opt,name=alive,proto3" json:"alive,omitempty"`
+	Standby       bool `protobuf:"varint,12,opt,name=standby,proto3" json:"standby,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RouteGroupMuxLeg) Reset() {
+	*x = RouteGroupMuxLeg{}
+	mi := &file_ping_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RouteGroupMuxLeg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RouteGroupMuxLeg) ProtoMessage() {}
+
+func (x *RouteGroupMuxLeg) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RouteGroupMuxLeg.ProtoReflect.Descriptor instead.
+func (*RouteGroupMuxLeg) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *RouteGroupMuxLeg) GetRouteIndex() int32 {
+	if x != nil {
+		return x.RouteIndex
+	}
+	return 0
+}
+
+func (x *RouteGroupMuxLeg) GetTransportId() string {
+	if x != nil {
+		return x.TransportId
+	}
+	return ""
+}
+
+func (x *RouteGroupMuxLeg) GetTransportKind() string {
+	if x != nil {
+		return x.TransportKind
+	}
+	return ""
+}
+
+func (x *RouteGroupMuxLeg) GetRemotePk() string {
+	if x != nil {
+		return x.RemotePk
+	}
+	return ""
+}
+
+func (x *RouteGroupMuxLeg) GetLatencyMs() float64 {
+	if x != nil {
+		return x.LatencyMs
+	}
+	return 0
+}
+
+func (x *RouteGroupMuxLeg) GetSentBytes() uint64 {
+	if x != nil {
+		return x.SentBytes
+	}
+	return 0
+}
+
+func (x *RouteGroupMuxLeg) GetSentPackets() uint64 {
+	if x != nil {
+		return x.SentPackets
+	}
+	return 0
+}
+
+func (x *RouteGroupMuxLeg) GetRecvBytes() uint64 {
+	if x != nil {
+		return x.RecvBytes
+	}
+	return 0
+}
+
+func (x *RouteGroupMuxLeg) GetRecvPackets() uint64 {
+	if x != nil {
+		return x.RecvPackets
+	}
+	return 0
+}
+
+func (x *RouteGroupMuxLeg) GetRetransmits() uint64 {
+	if x != nil {
+		return x.Retransmits
+	}
+	return 0
+}
+
+func (x *RouteGroupMuxLeg) GetAlive() bool {
+	if x != nil {
+		return x.Alive
+	}
+	return false
+}
+
+func (x *RouteGroupMuxLeg) GetStandby() bool {
+	if x != nil {
+		return x.Standby
+	}
+	return false
+}
+
 var File_ping_proto protoreflect.FileDescriptor
 
 const file_ping_proto_rawDesc = "" +
@@ -4581,7 +4905,36 @@ const file_ping_proto_rawDesc = "" +
 	"\x14idle_probe_jitter_ns\x18\x16 \x01(\x03R\x11idleProbeJitterNs\"A\n" +
 	"\x11MuxBandwidthError\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage2\xdc\a\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"i\n" +
+	"\x1eStreamRouteGroupMuxInfoRequest\x12\x19\n" +
+	"\bapp_name\x18\x01 \x01(\tR\aappName\x12,\n" +
+	"\x12sample_interval_ns\x18\x02 \x01(\x03R\x10sampleIntervalNs\"{\n" +
+	"\x17RouteGroupMuxInfoSample\x12!\n" +
+	"\ftimestamp_ns\x18\x01 \x01(\x03R\vtimestampNs\x12=\n" +
+	"\froute_groups\x18\x02 \x03(\v2\x1a.rpcgrpc.RouteGroupMuxInfoR\vrouteGroups\"\x86\x01\n" +
+	"\x11RouteGroupMuxInfo\x12\x1f\n" +
+	"\vmux_enabled\x18\x01 \x01(\bR\n" +
+	"muxEnabled\x12!\n" +
+	"\fsack_enabled\x18\x02 \x01(\bR\vsackEnabled\x12-\n" +
+	"\x04legs\x18\x03 \x03(\v2\x19.rpcgrpc.RouteGroupMuxLegR\x04legs\"\x8f\x03\n" +
+	"\x10RouteGroupMuxLeg\x12\x1f\n" +
+	"\vroute_index\x18\x01 \x01(\x05R\n" +
+	"routeIndex\x12!\n" +
+	"\ftransport_id\x18\x02 \x01(\tR\vtransportId\x12%\n" +
+	"\x0etransport_kind\x18\x03 \x01(\tR\rtransportKind\x12\x1b\n" +
+	"\tremote_pk\x18\x04 \x01(\tR\bremotePk\x12\x1d\n" +
+	"\n" +
+	"latency_ms\x18\x05 \x01(\x01R\tlatencyMs\x12\x1d\n" +
+	"\n" +
+	"sent_bytes\x18\x06 \x01(\x04R\tsentBytes\x12!\n" +
+	"\fsent_packets\x18\a \x01(\x04R\vsentPackets\x12\x1d\n" +
+	"\n" +
+	"recv_bytes\x18\b \x01(\x04R\trecvBytes\x12!\n" +
+	"\frecv_packets\x18\t \x01(\x04R\vrecvPackets\x12 \n" +
+	"\vretransmits\x18\n" +
+	" \x01(\x04R\vretransmits\x12\x14\n" +
+	"\x05alive\x18\v \x01(\bR\x05alive\x12\x18\n" +
+	"\astandby\x18\f \x01(\bR\astandby2\xc4\b\n" +
 	"\vPingService\x129\n" +
 	"\n" +
 	"StreamPing\x12\x14.rpcgrpc.PingRequest\x1a\x13.rpcgrpc.PingResult0\x01\x12=\n" +
@@ -4596,7 +4949,8 @@ const file_ping_proto_rawDesc = "" +
 	"\x10StreamCalcRoutes\x12\x1a.rpcgrpc.CalcRoutesRequest\x1a\x12.rpcgrpc.CalcRoute0\x01\x12R\n" +
 	"\x13StreamGroupMessages\x12\x1d.rpcgrpc.GroupMessagesRequest\x1a\x1a.rpcgrpc.GroupMessageEvent0\x01\x12D\n" +
 	"\x0eStreamPingTree\x12\x18.rpcgrpc.PingTreeRequest\x1a\x16.rpcgrpc.PingTreeEvent0\x01\x12P\n" +
-	"\x12StreamMuxBandwidth\x12\x1c.rpcgrpc.MuxBandwidthRequest\x1a\x1a.rpcgrpc.MuxBandwidthEvent0\x01B.Z,github.com/skycoin/skywire/pkg/visor/rpcgrpcb\x06proto3"
+	"\x12StreamMuxBandwidth\x12\x1c.rpcgrpc.MuxBandwidthRequest\x1a\x1a.rpcgrpc.MuxBandwidthEvent0\x01\x12f\n" +
+	"\x17StreamRouteGroupMuxInfo\x12'.rpcgrpc.StreamRouteGroupMuxInfoRequest\x1a .rpcgrpc.RouteGroupMuxInfoSample0\x01B.Z,github.com/skycoin/skywire/pkg/visor/rpcgrpcb\x06proto3"
 
 var (
 	file_ping_proto_rawDescOnce sync.Once
@@ -4610,51 +4964,55 @@ func file_ping_proto_rawDescGZIP() []byte {
 	return file_ping_proto_rawDescData
 }
 
-var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
+var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
 var file_ping_proto_goTypes = []any{
-	(*PingRequest)(nil),              // 0: rpcgrpc.PingRequest
-	(*PingResult)(nil),               // 1: rpcgrpc.PingResult
-	(*DmsgServersRequest)(nil),       // 2: rpcgrpc.DmsgServersRequest
-	(*DmsgServersResponse)(nil),      // 3: rpcgrpc.DmsgServersResponse
-	(*RouteHop)(nil),                 // 4: rpcgrpc.RouteHop
-	(*BandwidthRequest)(nil),         // 5: rpcgrpc.BandwidthRequest
-	(*BandwidthProgress)(nil),        // 6: rpcgrpc.BandwidthProgress
-	(*SystemStatsRequest)(nil),       // 7: rpcgrpc.SystemStatsRequest
-	(*RemoteSystemStatsRequest)(nil), // 8: rpcgrpc.RemoteSystemStatsRequest
-	(*SystemStats)(nil),              // 9: rpcgrpc.SystemStats
-	(*HostInfo)(nil),                 // 10: rpcgrpc.HostInfo
-	(*CpuStat)(nil),                  // 11: rpcgrpc.CpuStat
-	(*MemoryStat)(nil),               // 12: rpcgrpc.MemoryStat
-	(*DiskStat)(nil),                 // 13: rpcgrpc.DiskStat
-	(*NetworkStat)(nil),              // 14: rpcgrpc.NetworkStat
-	(*TempStat)(nil),                 // 15: rpcgrpc.TempStat
-	(*AppLogStreamRequest)(nil),      // 16: rpcgrpc.AppLogStreamRequest
-	(*AppLogEntry)(nil),              // 17: rpcgrpc.AppLogEntry
-	(*CalcRoutesRequest)(nil),        // 18: rpcgrpc.CalcRoutesRequest
-	(*CalcRoute)(nil),                // 19: rpcgrpc.CalcRoute
-	(*CalcHop)(nil),                  // 20: rpcgrpc.CalcHop
-	(*GroupMessagesRequest)(nil),     // 21: rpcgrpc.GroupMessagesRequest
-	(*GroupMessageEvent)(nil),        // 22: rpcgrpc.GroupMessageEvent
-	(*ProcessStat)(nil),              // 23: rpcgrpc.ProcessStat
-	(*PingTreeRequest)(nil),          // 24: rpcgrpc.PingTreeRequest
-	(*PingTreeEvent)(nil),            // 25: rpcgrpc.PingTreeEvent
-	(*PingTreeDiscovered)(nil),       // 26: rpcgrpc.PingTreeDiscovered
-	(*PingTreeResult)(nil),           // 27: rpcgrpc.PingTreeResult
-	(*PingTreeLevelDone)(nil),        // 28: rpcgrpc.PingTreeLevelDone
-	(*PingTreeRunDone)(nil),          // 29: rpcgrpc.PingTreeRunDone
-	(*PingTreeStatusUpdate)(nil),     // 30: rpcgrpc.PingTreeStatusUpdate
-	(*PingTreeServerError)(nil),      // 31: rpcgrpc.PingTreeServerError
-	(*MuxBandwidthRequest)(nil),      // 32: rpcgrpc.MuxBandwidthRequest
-	(*MuxBandwidthEvent)(nil),        // 33: rpcgrpc.MuxBandwidthEvent
-	(*MuxLegLifecycle)(nil),          // 34: rpcgrpc.MuxLegLifecycle
-	(*MuxRouteEstablished)(nil),      // 35: rpcgrpc.MuxRouteEstablished
-	(*MuxRouteFailure)(nil),          // 36: rpcgrpc.MuxRouteFailure
-	(*MuxBandwidthSample)(nil),       // 37: rpcgrpc.MuxBandwidthSample
-	(*MuxLegSample)(nil),             // 38: rpcgrpc.MuxLegSample
-	(*MuxRttProbe)(nil),              // 39: rpcgrpc.MuxRttProbe
-	(*MuxBandwidthDone)(nil),         // 40: rpcgrpc.MuxBandwidthDone
-	(*MuxBandwidthError)(nil),        // 41: rpcgrpc.MuxBandwidthError
-	nil,                              // 42: rpcgrpc.AppLogEntry.FieldsEntry
+	(*PingRequest)(nil),                    // 0: rpcgrpc.PingRequest
+	(*PingResult)(nil),                     // 1: rpcgrpc.PingResult
+	(*DmsgServersRequest)(nil),             // 2: rpcgrpc.DmsgServersRequest
+	(*DmsgServersResponse)(nil),            // 3: rpcgrpc.DmsgServersResponse
+	(*RouteHop)(nil),                       // 4: rpcgrpc.RouteHop
+	(*BandwidthRequest)(nil),               // 5: rpcgrpc.BandwidthRequest
+	(*BandwidthProgress)(nil),              // 6: rpcgrpc.BandwidthProgress
+	(*SystemStatsRequest)(nil),             // 7: rpcgrpc.SystemStatsRequest
+	(*RemoteSystemStatsRequest)(nil),       // 8: rpcgrpc.RemoteSystemStatsRequest
+	(*SystemStats)(nil),                    // 9: rpcgrpc.SystemStats
+	(*HostInfo)(nil),                       // 10: rpcgrpc.HostInfo
+	(*CpuStat)(nil),                        // 11: rpcgrpc.CpuStat
+	(*MemoryStat)(nil),                     // 12: rpcgrpc.MemoryStat
+	(*DiskStat)(nil),                       // 13: rpcgrpc.DiskStat
+	(*NetworkStat)(nil),                    // 14: rpcgrpc.NetworkStat
+	(*TempStat)(nil),                       // 15: rpcgrpc.TempStat
+	(*AppLogStreamRequest)(nil),            // 16: rpcgrpc.AppLogStreamRequest
+	(*AppLogEntry)(nil),                    // 17: rpcgrpc.AppLogEntry
+	(*CalcRoutesRequest)(nil),              // 18: rpcgrpc.CalcRoutesRequest
+	(*CalcRoute)(nil),                      // 19: rpcgrpc.CalcRoute
+	(*CalcHop)(nil),                        // 20: rpcgrpc.CalcHop
+	(*GroupMessagesRequest)(nil),           // 21: rpcgrpc.GroupMessagesRequest
+	(*GroupMessageEvent)(nil),              // 22: rpcgrpc.GroupMessageEvent
+	(*ProcessStat)(nil),                    // 23: rpcgrpc.ProcessStat
+	(*PingTreeRequest)(nil),                // 24: rpcgrpc.PingTreeRequest
+	(*PingTreeEvent)(nil),                  // 25: rpcgrpc.PingTreeEvent
+	(*PingTreeDiscovered)(nil),             // 26: rpcgrpc.PingTreeDiscovered
+	(*PingTreeResult)(nil),                 // 27: rpcgrpc.PingTreeResult
+	(*PingTreeLevelDone)(nil),              // 28: rpcgrpc.PingTreeLevelDone
+	(*PingTreeRunDone)(nil),                // 29: rpcgrpc.PingTreeRunDone
+	(*PingTreeStatusUpdate)(nil),           // 30: rpcgrpc.PingTreeStatusUpdate
+	(*PingTreeServerError)(nil),            // 31: rpcgrpc.PingTreeServerError
+	(*MuxBandwidthRequest)(nil),            // 32: rpcgrpc.MuxBandwidthRequest
+	(*MuxBandwidthEvent)(nil),              // 33: rpcgrpc.MuxBandwidthEvent
+	(*MuxLegLifecycle)(nil),                // 34: rpcgrpc.MuxLegLifecycle
+	(*MuxRouteEstablished)(nil),            // 35: rpcgrpc.MuxRouteEstablished
+	(*MuxRouteFailure)(nil),                // 36: rpcgrpc.MuxRouteFailure
+	(*MuxBandwidthSample)(nil),             // 37: rpcgrpc.MuxBandwidthSample
+	(*MuxLegSample)(nil),                   // 38: rpcgrpc.MuxLegSample
+	(*MuxRttProbe)(nil),                    // 39: rpcgrpc.MuxRttProbe
+	(*MuxBandwidthDone)(nil),               // 40: rpcgrpc.MuxBandwidthDone
+	(*MuxBandwidthError)(nil),              // 41: rpcgrpc.MuxBandwidthError
+	(*StreamRouteGroupMuxInfoRequest)(nil), // 42: rpcgrpc.StreamRouteGroupMuxInfoRequest
+	(*RouteGroupMuxInfoSample)(nil),        // 43: rpcgrpc.RouteGroupMuxInfoSample
+	(*RouteGroupMuxInfo)(nil),              // 44: rpcgrpc.RouteGroupMuxInfo
+	(*RouteGroupMuxLeg)(nil),               // 45: rpcgrpc.RouteGroupMuxLeg
+	nil,                                    // 46: rpcgrpc.AppLogEntry.FieldsEntry
 }
 var file_ping_proto_depIdxs = []int32{
 	4,  // 0: rpcgrpc.PingRequest.forward_hops:type_name -> rpcgrpc.RouteHop
@@ -4668,7 +5026,7 @@ var file_ping_proto_depIdxs = []int32{
 	14, // 8: rpcgrpc.SystemStats.network:type_name -> rpcgrpc.NetworkStat
 	15, // 9: rpcgrpc.SystemStats.temps:type_name -> rpcgrpc.TempStat
 	23, // 10: rpcgrpc.SystemStats.processes:type_name -> rpcgrpc.ProcessStat
-	42, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
+	46, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
 	20, // 12: rpcgrpc.CalcRoute.hops:type_name -> rpcgrpc.CalcHop
 	26, // 13: rpcgrpc.PingTreeEvent.discovered:type_name -> rpcgrpc.PingTreeDiscovered
 	27, // 14: rpcgrpc.PingTreeEvent.ping_result:type_name -> rpcgrpc.PingTreeResult
@@ -4686,37 +5044,41 @@ var file_ping_proto_depIdxs = []int32{
 	34, // 26: rpcgrpc.MuxBandwidthEvent.leg_lifecycle:type_name -> rpcgrpc.MuxLegLifecycle
 	4,  // 27: rpcgrpc.MuxRouteEstablished.hops:type_name -> rpcgrpc.RouteHop
 	38, // 28: rpcgrpc.MuxBandwidthSample.legs:type_name -> rpcgrpc.MuxLegSample
-	0,  // 29: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
-	0,  // 30: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
-	5,  // 31: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	5,  // 32: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	2,  // 33: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
-	7,  // 34: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	7,  // 35: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	8,  // 36: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
-	16, // 37: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
-	18, // 38: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
-	21, // 39: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
-	24, // 40: rpcgrpc.PingService.StreamPingTree:input_type -> rpcgrpc.PingTreeRequest
-	32, // 41: rpcgrpc.PingService.StreamMuxBandwidth:input_type -> rpcgrpc.MuxBandwidthRequest
-	1,  // 42: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
-	1,  // 43: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
-	6,  // 44: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	6,  // 45: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	3,  // 46: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
-	9,  // 47: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 48: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 49: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
-	17, // 50: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
-	19, // 51: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
-	22, // 52: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
-	25, // 53: rpcgrpc.PingService.StreamPingTree:output_type -> rpcgrpc.PingTreeEvent
-	33, // 54: rpcgrpc.PingService.StreamMuxBandwidth:output_type -> rpcgrpc.MuxBandwidthEvent
-	42, // [42:55] is the sub-list for method output_type
-	29, // [29:42] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	44, // 29: rpcgrpc.RouteGroupMuxInfoSample.route_groups:type_name -> rpcgrpc.RouteGroupMuxInfo
+	45, // 30: rpcgrpc.RouteGroupMuxInfo.legs:type_name -> rpcgrpc.RouteGroupMuxLeg
+	0,  // 31: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
+	0,  // 32: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
+	5,  // 33: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	5,  // 34: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	2,  // 35: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
+	7,  // 36: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	7,  // 37: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	8,  // 38: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
+	16, // 39: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
+	18, // 40: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
+	21, // 41: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
+	24, // 42: rpcgrpc.PingService.StreamPingTree:input_type -> rpcgrpc.PingTreeRequest
+	32, // 43: rpcgrpc.PingService.StreamMuxBandwidth:input_type -> rpcgrpc.MuxBandwidthRequest
+	42, // 44: rpcgrpc.PingService.StreamRouteGroupMuxInfo:input_type -> rpcgrpc.StreamRouteGroupMuxInfoRequest
+	1,  // 45: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
+	1,  // 46: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
+	6,  // 47: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	6,  // 48: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	3,  // 49: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
+	9,  // 50: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 51: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 52: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
+	17, // 53: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
+	19, // 54: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
+	22, // 55: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
+	25, // 56: rpcgrpc.PingService.StreamPingTree:output_type -> rpcgrpc.PingTreeEvent
+	33, // 57: rpcgrpc.PingService.StreamMuxBandwidth:output_type -> rpcgrpc.MuxBandwidthEvent
+	43, // 58: rpcgrpc.PingService.StreamRouteGroupMuxInfo:output_type -> rpcgrpc.RouteGroupMuxInfoSample
+	45, // [45:59] is the sub-list for method output_type
+	31, // [31:45] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_ping_proto_init() }
@@ -4747,7 +5109,7 @@ func file_ping_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ping_proto_rawDesc), len(file_ping_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   43,
+			NumMessages:   47,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -104,6 +104,18 @@ service PingService {
   // server-side bandwidth-pump, events stream as they happen,
   // ctx.Done() at every iteration, bounded internal channel.
   rpc StreamMuxBandwidth(MuxBandwidthRequest) returns (stream MuxBandwidthEvent);
+
+  // StreamRouteGroupMuxInfo streams a running app's per-leg mux
+  // telemetry on a fixed cadence — the server-streaming equivalent of
+  // the unary RouteGroupMuxInfo net/rpc call that 'cli proxy mux plot'
+  // (default, watch-a-running-app mode) polls. Lets that plot update
+  // smoothly/continuously like the --pk StreamMuxBandwidth path,
+  // instead of the choppy 1 Hz unary gob poll. Each sample carries the
+  // same []visor.MuxRouteGroupInfo per-leg breakdown the unary RPC
+  // returns. The handler never errors the stream on a transient absent
+  // route group — it emits an empty sample and keeps sampling, so the
+  // plot renders an empty frame until the app dials.
+  rpc StreamRouteGroupMuxInfo(StreamRouteGroupMuxInfoRequest) returns (stream RouteGroupMuxInfoSample);
 }
 
 message PingRequest {
@@ -902,4 +914,62 @@ message MuxBandwidthDone {
 message MuxBandwidthError {
   string code = 1;
   string message = 2;
+}
+
+// StreamRouteGroupMuxInfoRequest configures a live route-group mux
+// telemetry stream for a running app. See StreamRouteGroupMuxInfo.
+message StreamRouteGroupMuxInfoRequest {
+  // AppName scopes the telemetry to route groups tagged with this app
+  // (skysocks-client, vpn-client, ...). Empty returns every mux'd route
+  // group the visor has — matching the unary RouteGroupMuxInfo("").
+  string app_name = 1;
+  // SampleIntervalNs is how often a RouteGroupMuxInfoSample is emitted.
+  // 0 falls back to 500 ms; the handler floors it to a 100 ms minimum
+  // so a client can't spin the visor. Nanoseconds (proto convention
+  // used throughout this service).
+  int64 sample_interval_ns = 2;
+}
+
+// RouteGroupMuxInfoSample is one snapshot of a running app's mux'd
+// route-group telemetry, emitted every sample_interval_ns. Mirrors the
+// []visor.MuxRouteGroupInfo the unary RouteGroupMuxInfo RPC returns.
+message RouteGroupMuxInfoSample {
+  // TimestampNs is server-side wall time at emit.
+  int64 timestamp_ns = 1;
+  // RouteGroups is one entry per active route group tagged with the
+  // requested app. Empty when the app has no route group yet — the
+  // stream stays open and keeps sampling rather than erroring.
+  repeated RouteGroupMuxInfo route_groups = 2;
+}
+
+// RouteGroupMuxInfo is one route group's mux state plus its per-leg
+// counters. Field-for-field mirror of visor.MuxRouteGroupInfo (minus
+// the descriptor, which the plot consumer does not render).
+message RouteGroupMuxInfo {
+  bool mux_enabled = 1;
+  bool sack_enabled = 2;
+  repeated RouteGroupMuxLeg legs = 3;
+}
+
+// RouteGroupMuxLeg is one leg (route) within a mux'd group — mirror of
+// visor.MuxLegInfo.
+message RouteGroupMuxLeg {
+  // RouteIndex is the leg's stable index within the group
+  // (visor.MuxLegInfo.Index).
+  int32 route_index = 1;
+  string transport_id = 2;
+  // TransportKind is the leg's transport type (stcpr, sudph, dmsg, ...)
+  // — visor.MuxLegInfo.TpType.
+  string transport_kind = 3;
+  string remote_pk = 4;
+  double latency_ms = 5;
+  uint64 sent_bytes = 6;
+  uint64 sent_packets = 7;
+  uint64 recv_bytes = 8;
+  uint64 recv_packets = 9;
+  uint64 retransmits = 10;
+  // Alive is false once the leg's transport is closed; Standby is true
+  // for a warm standby (rules kept, not sending) — the leg's gate_state.
+  bool alive = 11;
+  bool standby = 12;
 }

--- a/pkg/visor/rpcgrpc/ping_grpc.pb.go
+++ b/pkg/visor/rpcgrpc/ping_grpc.pb.go
@@ -33,6 +33,7 @@ const (
 	PingService_StreamGroupMessages_FullMethodName     = "/rpcgrpc.PingService/StreamGroupMessages"
 	PingService_StreamPingTree_FullMethodName          = "/rpcgrpc.PingService/StreamPingTree"
 	PingService_StreamMuxBandwidth_FullMethodName      = "/rpcgrpc.PingService/StreamMuxBandwidth"
+	PingService_StreamRouteGroupMuxInfo_FullMethodName = "/rpcgrpc.PingService/StreamRouteGroupMuxInfo"
 )
 
 // PingServiceClient is the client API for PingService service.
@@ -127,6 +128,17 @@ type PingServiceClient interface {
 	// server-side bandwidth-pump, events stream as they happen,
 	// ctx.Done() at every iteration, bounded internal channel.
 	StreamMuxBandwidth(ctx context.Context, in *MuxBandwidthRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[MuxBandwidthEvent], error)
+	// StreamRouteGroupMuxInfo streams a running app's per-leg mux
+	// telemetry on a fixed cadence — the server-streaming equivalent of
+	// the unary RouteGroupMuxInfo net/rpc call that 'cli proxy mux plot'
+	// (default, watch-a-running-app mode) polls. Lets that plot update
+	// smoothly/continuously like the --pk StreamMuxBandwidth path,
+	// instead of the choppy 1 Hz unary gob poll. Each sample carries the
+	// same []visor.MuxRouteGroupInfo per-leg breakdown the unary RPC
+	// returns. The handler never errors the stream on a transient absent
+	// route group — it emits an empty sample and keeps sampling, so the
+	// plot renders an empty frame until the app dials.
+	StreamRouteGroupMuxInfo(ctx context.Context, in *StreamRouteGroupMuxInfoRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[RouteGroupMuxInfoSample], error)
 }
 
 type pingServiceClient struct {
@@ -366,6 +378,25 @@ func (c *pingServiceClient) StreamMuxBandwidth(ctx context.Context, in *MuxBandw
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type PingService_StreamMuxBandwidthClient = grpc.ServerStreamingClient[MuxBandwidthEvent]
 
+func (c *pingServiceClient) StreamRouteGroupMuxInfo(ctx context.Context, in *StreamRouteGroupMuxInfoRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[RouteGroupMuxInfoSample], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &PingService_ServiceDesc.Streams[11], PingService_StreamRouteGroupMuxInfo_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[StreamRouteGroupMuxInfoRequest, RouteGroupMuxInfoSample]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type PingService_StreamRouteGroupMuxInfoClient = grpc.ServerStreamingClient[RouteGroupMuxInfoSample]
+
 // PingServiceServer is the server API for PingService service.
 // All implementations must embed UnimplementedPingServiceServer
 // for forward compatibility.
@@ -458,6 +489,17 @@ type PingServiceServer interface {
 	// server-side bandwidth-pump, events stream as they happen,
 	// ctx.Done() at every iteration, bounded internal channel.
 	StreamMuxBandwidth(*MuxBandwidthRequest, grpc.ServerStreamingServer[MuxBandwidthEvent]) error
+	// StreamRouteGroupMuxInfo streams a running app's per-leg mux
+	// telemetry on a fixed cadence — the server-streaming equivalent of
+	// the unary RouteGroupMuxInfo net/rpc call that 'cli proxy mux plot'
+	// (default, watch-a-running-app mode) polls. Lets that plot update
+	// smoothly/continuously like the --pk StreamMuxBandwidth path,
+	// instead of the choppy 1 Hz unary gob poll. Each sample carries the
+	// same []visor.MuxRouteGroupInfo per-leg breakdown the unary RPC
+	// returns. The handler never errors the stream on a transient absent
+	// route group — it emits an empty sample and keeps sampling, so the
+	// plot renders an empty frame until the app dials.
+	StreamRouteGroupMuxInfo(*StreamRouteGroupMuxInfoRequest, grpc.ServerStreamingServer[RouteGroupMuxInfoSample]) error
 	mustEmbedUnimplementedPingServiceServer()
 }
 
@@ -506,6 +548,9 @@ func (UnimplementedPingServiceServer) StreamPingTree(*PingTreeRequest, grpc.Serv
 }
 func (UnimplementedPingServiceServer) StreamMuxBandwidth(*MuxBandwidthRequest, grpc.ServerStreamingServer[MuxBandwidthEvent]) error {
 	return status.Error(codes.Unimplemented, "method StreamMuxBandwidth not implemented")
+}
+func (UnimplementedPingServiceServer) StreamRouteGroupMuxInfo(*StreamRouteGroupMuxInfoRequest, grpc.ServerStreamingServer[RouteGroupMuxInfoSample]) error {
+	return status.Error(codes.Unimplemented, "method StreamRouteGroupMuxInfo not implemented")
 }
 func (UnimplementedPingServiceServer) mustEmbedUnimplementedPingServiceServer() {}
 func (UnimplementedPingServiceServer) testEmbeddedByValue()                     {}
@@ -685,6 +730,17 @@ func _PingService_StreamMuxBandwidth_Handler(srv interface{}, stream grpc.Server
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type PingService_StreamMuxBandwidthServer = grpc.ServerStreamingServer[MuxBandwidthEvent]
 
+func _PingService_StreamRouteGroupMuxInfo_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(StreamRouteGroupMuxInfoRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(PingServiceServer).StreamRouteGroupMuxInfo(m, &grpc.GenericServerStream[StreamRouteGroupMuxInfoRequest, RouteGroupMuxInfoSample]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type PingService_StreamRouteGroupMuxInfoServer = grpc.ServerStreamingServer[RouteGroupMuxInfoSample]
+
 // PingService_ServiceDesc is the grpc.ServiceDesc for PingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -755,6 +811,11 @@ var PingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "StreamMuxBandwidth",
 			Handler:       _PingService_StreamMuxBandwidth_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "StreamRouteGroupMuxInfo",
+			Handler:       _PingService_StreamRouteGroupMuxInfo_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -116,6 +116,41 @@ type VisorAPI interface {
 	// transport exists or its latency is not yet sampled. Powers the
 	// ping-tree UseTransportLatency fast-path at level-1.
 	GetTransportLatencyByRemotePK(remotePK cipher.PubKey) float64
+	// RouteGroupMuxInfo returns the per-mux-leg counters for every active
+	// route group tagged with appName — the same data the unary
+	// RouteGroupMuxInfo net/rpc call returns, projected into the
+	// rpcgrpc-local mirror so this package stays free of pkg/visor
+	// imports. Powers StreamRouteGroupMuxInfo (the smooth server-stream
+	// backing 'cli proxy mux plot'). Returns an empty slice (not an
+	// error) when the app has no route group yet.
+	RouteGroupMuxInfo(appName string) ([]RouteGroupMuxInfoData, error)
+}
+
+// RouteGroupMuxInfoData mirrors visor.MuxRouteGroupInfo at the rpcgrpc
+// boundary so VisorAPI doesn't pull pkg/visor into rpcgrpc's import
+// graph. The adapter at the visor's init transcribes the visor type
+// into this one.
+type RouteGroupMuxInfoData struct {
+	MuxEnabled  bool
+	SACKEnabled bool
+	Legs        []RouteGroupMuxLegData
+}
+
+// RouteGroupMuxLegData mirrors visor.MuxLegInfo — one leg (route) within
+// a mux'd route group.
+type RouteGroupMuxLegData struct {
+	Index       int
+	TransportID string
+	TpType      string
+	RemotePK    string
+	LatencyMS   float64
+	SentBytes   uint64
+	SentPackets uint64
+	RecvBytes   uint64
+	RecvPackets uint64
+	Retransmits uint64
+	Alive       bool
+	Standby     bool
 }
 
 // GroupMessageData mirrors visor.GroupMessage one-for-one but lives in

--- a/pkg/visor/rpcgrpc/server_routegroup_mux_info.go
+++ b/pkg/visor/rpcgrpc/server_routegroup_mux_info.go
@@ -1,0 +1,112 @@
+// Package rpcgrpc pkg/visor/rpcgrpc/server_routegroup_mux_info.go c3-vis-core
+// server-side implementation of the StreamRouteGroupMuxInfo gRPC RPC.
+//
+// This is the server-streaming counterpart of the unary RouteGroupMuxInfo
+// net/rpc call. 'cli proxy mux plot' (default, watch-a-running-app mode)
+// used to poll that unary RPC once per --interval — a gob round-trip per
+// tick that read choppy next to the --pk StreamMuxBandwidth path. This RPC
+// pushes the same per-leg breakdown on a server-side ticker so the plot
+// updates smoothly/continuously without per-tick connection overhead.
+package rpcgrpc
+
+import (
+	"time"
+)
+
+const (
+	// defaultRouteGroupMuxSampleInterval is the emit cadence when the
+	// request leaves sample_interval_ns at 0.
+	defaultRouteGroupMuxSampleInterval = 500 * time.Millisecond
+	// minRouteGroupMuxSampleInterval floors the cadence so a client can't
+	// spin the visor with a sub-millisecond interval.
+	minRouteGroupMuxSampleInterval = 100 * time.Millisecond
+)
+
+// StreamRouteGroupMuxInfo streams a running app's per-leg mux telemetry
+// on a fixed cadence. See ping.proto for the wire contract.
+//
+// The first sample fires immediately (so the client renders without
+// waiting a full interval), then every sample_interval_ns until the
+// client disconnects / cancels. A transient absent route group is NOT an
+// error — the handler emits an empty sample and keeps sampling, so the
+// plot shows an empty frame until the app dials.
+func (s *PingServer) StreamRouteGroupMuxInfo(req *StreamRouteGroupMuxInfoRequest, stream PingService_StreamRouteGroupMuxInfoServer) error {
+	ctx := stream.Context()
+
+	interval := time.Duration(req.SampleIntervalNs)
+	if interval <= 0 {
+		interval = defaultRouteGroupMuxSampleInterval
+	}
+	if interval < minRouteGroupMuxSampleInterval {
+		interval = minRouteGroupMuxSampleInterval
+	}
+
+	send := func() error {
+		infos, err := s.visor.RouteGroupMuxInfo(req.AppName)
+		if err != nil {
+			// Never tear the stream down on a transient "no route group
+			// yet" — send an empty sample and keep going so the plot
+			// renders an empty frame instead of dying. Real errors are
+			// rare here (the visor returns an empty slice when the app
+			// has no rg); log for diagnostics either way.
+			s.log.Debugf("StreamRouteGroupMuxInfo(app=%q): %v", req.AppName, err)
+			infos = nil
+		}
+		return stream.Send(&RouteGroupMuxInfoSample{
+			TimestampNs: time.Now().UnixNano(),
+			RouteGroups: convertRouteGroupMuxInfo(infos),
+		})
+	}
+
+	// Immediate first sample, then tick.
+	if err := send(); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := send(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// convertRouteGroupMuxInfo projects the rpcgrpc-local mirror slice the
+// VisorAPI returns into the proto wire shape.
+func convertRouteGroupMuxInfo(infos []RouteGroupMuxInfoData) []*RouteGroupMuxInfo {
+	if len(infos) == 0 {
+		return nil
+	}
+	out := make([]*RouteGroupMuxInfo, 0, len(infos))
+	for _, info := range infos {
+		g := &RouteGroupMuxInfo{
+			MuxEnabled:  info.MuxEnabled,
+			SackEnabled: info.SACKEnabled,
+			Legs:        make([]*RouteGroupMuxLeg, 0, len(info.Legs)),
+		}
+		for _, leg := range info.Legs {
+			g.Legs = append(g.Legs, &RouteGroupMuxLeg{
+				RouteIndex:    int32(leg.Index), //nolint:gosec // leg index fits int32
+				TransportId:   leg.TransportID,
+				TransportKind: leg.TpType,
+				RemotePk:      leg.RemotePK,
+				LatencyMs:     leg.LatencyMS,
+				SentBytes:     leg.SentBytes,
+				SentPackets:   leg.SentPackets,
+				RecvBytes:     leg.RecvBytes,
+				RecvPackets:   leg.RecvPackets,
+				Retransmits:   leg.Retransmits,
+				Alive:         leg.Alive,
+				Standby:       leg.Standby,
+			})
+		}
+		out = append(out, g)
+	}
+	return out
+}


### PR DESCRIPTION
## Problem

The default (watch-a-running-app) mode of `skywire cli proxy mux plot`
polled the unary `RouteGroupMuxInfo` net/rpc call once per `--interval` — a
gob round-trip per tick — which rendered **choppy** next to the `--pk` mode,
which already rides a gRPC server-stream (`StreamMuxBandwidth`).

## Change

Mirror the `--pk` streaming pattern for the default mode so it updates
smoothly/continuously.

- **proto**: add `StreamRouteGroupMuxInfo(StreamRouteGroupMuxInfoRequest) returns (stream RouteGroupMuxInfoSample)` to `PingService` (the same service that hosts `StreamMuxBandwidth`). Request carries `{app_name, sample_interval_ns}`; the sample carries the per-leg breakdown (`RouteGroupMuxInfo`/`RouteGroupMuxLeg`) mirroring `[]visor.MuxRouteGroupInfo`. Regenerated with protoc `v25.1` / protoc-gen-go `v1.36.11` / protoc-gen-go-grpc `v1.6.2` (matches the existing generated headers; `ping.pb.go` diff is purely additive).
- **server**: `StreamRouteGroupMuxInfo` emits an immediate first sample then ticks every `sample_interval_ns` (default 500ms, floored to 100ms), reading the same `VisorAPI.RouteGroupMuxInfo` data path the unary RPC uses. A transient absent route group is **not** an error — it sends an empty sample and keeps sampling, so the plot renders an empty frame until the app dials. Stops cleanly on `ctx.Done()`.
- **client**: the default `-n` path consumes the new stream and feeds the same `updateTracks`/`render` code the poll path used. If the stream RPC is unavailable (older visor: first `Recv()` errors before any sample) it **transparently falls back to the unary poll** — same output, just choppy. `--interval` now sets the server-side sample cadence. `--tui` stays on the poll path (livetui drives its own refresh loop).
- **tests**: end-to-end coverage of the new stream (delivers per-leg legs; absent route group does not error the stream).

## Validation

- `go build ./cmd/skywire` passes; `go vet ./pkg/visor/rpcgrpc/` clean.
- New rpcgrpc stream tests pass.
- Smoke-tested `skywire cli proxy mux plot -n skysocks-client` against a running visor — renders a live per-leg chart continuously; the older-visor fallback path was exercised (visor predates the new RPC) and rendered without crashing.