### PR TITLE
fix(ci): binary channel + module-integrity build the repo-root skywire, not ./cmd/skywire

### DIFF
--- a/.github/workflows/module-integrity.yml
+++ b/.github/workflows/module-integrity.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           GOFLAGS: ""
           GOPROXY: "proxy.golang.org,direct"
-        run: go build -mod=mod -o /dev/null ./cmd/skywire
+        run: go build -mod=mod -o /dev/null .
 
       # tidy must be a no-op on a healthy tree; drift here means go.mod/go.sum
       # don't match the actual imports (what `go install @ref` resolves against).

--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -65,7 +65,7 @@ jobs:
           for arch in amd64 arm64 arm; do
             echo "==> building linux/${arch}"
             GOOS=linux GOARCH="${arch}" GOARM=7 CGO_ENABLED=0 \
-              go build -trimpath -mod=vendor -ldflags="${LDFLAGS}" -o skywire ./cmd/skywire
+              go build -trimpath -mod=vendor -ldflags="${LDFLAGS}" -o skywire .
             zstd -19 -q -f -o "dist/skywire-linux-${arch}.zst" skywire
             rm -f skywire
           done


### PR DESCRIPTION
The default skywire compilation is the **repo root** main package (`skywire.go`) — what `go build .` and `go install github.com/skycoin/skywire@ref` produce. The root imports `cmd/skycoin/commands` (embedded Skycoin daemon + thin-client wallet); `./cmd/skywire` does not (18 fewer packages).

`publish-binary.yml` (the `UPDATE_CHANNEL=binary` artifact, #4030) was building `./cmd/skywire`, so binary-channel hosts would get a **different, smaller** binary than the source-build (`go install @ref`) channel installs — silently missing the skycoin-daemon feature. Both workflows now build `.`; `module-integrity.yml` now truly mirrors the updater's module-mode `go install @ref` (root).