### PR TITLE
fix(cxo): repair filling-item so treestore self-heal can restore evicted objects (real TPD/[stats] freeze)

### DIFF
--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -935,7 +935,47 @@ func (c *Cache) setFilling(
 	// incItem instead of the Set, but for filling items
 	// it's equal to call incFilling
 
-	return c.incFilling(key, inc, it)
+	rc, err = c.incFilling(key, inc, it)
+	if err == data.ErrNotFound {
+		// Filling-invariant repair. A "filling" item (val==nil, so
+		// isFilling()==true) is tracked on the assumption that its value
+		// still lives in the CXDS — incFilling only Get/Inc's it, never
+		// writes. That invariant is violated when the backing object is
+		// deleted (refcount GC / prune racing a cache eviction, or a
+		// crash-restart residue) while the placeholder lingers in c.is.
+		// A plain Inc can't recover, but Set carries the value, so persist
+		// it afresh instead of returning "not found".
+		//
+		// Without this, an evicted object that is ALSO a filling
+		// placeholder can never be restored: every re-Set re-hits the
+		// missing backing and returns "not found". That is exactly the
+		// TPD / [stats] publisher freeze — treestore's self-heal re-encode
+		// (#4036) drops its encode cache and re-Set's every object to
+		// re-materialise the evicted one, but for a filling placeholder
+		// this path silently refused to write, so the retry failed
+		// identically and the served Root froze forever (heartbeat
+		// "republish failed: not found" every tick). #4036's own test only
+		// exercised a cache-DISABLED node, where Set writes straight to the
+		// DB and this trap can't arise.
+		if len(val) == 0 {
+			return rc, err // nothing to restore with
+		}
+		if len(val) > c.c.conf.MaxObjectSize {
+			return rc, &ObjectIsTooLargeError{key}
+		}
+		// Write with inc PLUS the outstanding filler incs (it.fc), so the
+		// stored refcount accounts for both the caller's new reference and
+		// the fillers already tracked against this placeholder — mirroring
+		// setWanted's inc+wincs accounting. hard rc = urc - it.fc.
+		var urc uint32
+		if urc, err = c.db().Set(key, val, inc+it.fc); err != nil {
+			return rc, err
+		}
+		c.stat.addWritingDBRequest()
+		rc = int(urc) - it.fc
+		err = c.putFillingItem(val, int(urc), it)
+	}
+	return rc, err
 }
 
 // Set adds value to DB and to the Cache if it's enabled.

--- a/pkg/cxo/skyobject/cache_filling_repair_test.go
+++ b/pkg/cxo/skyobject/cache_filling_repair_test.go
@@ -1,0 +1,75 @@
+package skyobject
+
+import (
+	"testing"
+
+	"github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cxo/data"
+)
+
+// TestCacheSetRepairsFillingItemWithMissingBacking proves the
+// filling-invariant repair in Cache.setFilling.
+//
+// A "filling" cache item (val==nil, so isFilling()==true) is tracked on
+// the assumption that its value already lives in the CXDS — incFilling
+// only Get/Inc's it. When the backing object is deleted while the
+// placeholder lingers in c.is (refcount GC / prune racing a cache
+// eviction), that invariant is violated. Before the repair, Cache.Set on
+// such an item routed to setFilling->incFilling->db.Get, which returns
+// "not found" and never writes the value — so the object could never be
+// restored (the treestore self-heal freeze). After the repair, Set
+// carries the value and persists it, restoring the object.
+func TestCacheSetRepairsFillingItemWithMissingBacking(t *testing.T) {
+	conf := NewConfig()
+	conf.InMemoryDB = true
+	c, err := NewContainer(conf)
+	if err != nil {
+		t.Fatalf("NewContainer: %v", err)
+	}
+	defer c.Close() //nolint:errcheck
+
+	val := []byte("payload")
+	key := cipher.SumSHA256(val)
+
+	// Create a regular cached object (rc=1).
+	if _, err := c.Set(key, val, 1); err != nil {
+		t.Fatalf("initial Set: %v", err)
+	}
+	// Register a filler inc so that eviction keeps a filling placeholder.
+	ch := make(chan Object, 1)
+	if err := c.Want(key, ch, 1); err != nil {
+		t.Fatalf("Want: %v", err)
+	}
+	// Drive the cached rc to zero: delete() evicts the value but, because
+	// fc>0, retains the c.is entry as a filling placeholder (val==nil).
+	if _, err := c.Inc(key, -1<<20); err != nil {
+		t.Fatalf("Inc down: %v", err)
+	}
+	if !c.IsCached(key) {
+		t.Fatalf("expected a filling placeholder retained in the cache")
+	}
+	// Delete the backing object from the CXDS — the invariant violation.
+	cxds := c.DB().CXDS()
+	if err := cxds.Del(key); err != nil {
+		t.Fatalf("Del: %v", err)
+	}
+	if _, _, err := cxds.Get(key, 0); err != data.ErrNotFound {
+		t.Fatalf("backing object should be gone; Get err=%v", err)
+	}
+
+	// Set the value again (what the treestore self-heal re-encode does).
+	// The repair must persist it rather than returning "not found".
+	if _, err := c.Set(key, val, 1); err != nil {
+		t.Fatalf("Set on filling item with missing backing should repair, got: %v", err)
+	}
+
+	// The value must now be retrievable from the CXDS again.
+	got, _, err := cxds.Get(key, 0)
+	if err != nil {
+		t.Fatalf("value should be restored in the CXDS after the repair Set: %v", err)
+	}
+	if string(got) != string(val) {
+		t.Fatalf("restored value = %q, want %q", got, val)
+	}
+}

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -899,7 +899,9 @@ func (p *Publisher) runLoop() {
 		case <-p.done:
 			// Final publish attempt to flush any in-flight dirty
 			// state (Close already flushed but be defensive).
-			_ = p.publishIfDirty() //nolint:errcheck
+			if err := p.publishIfDirty(); err != nil {
+				p.log.WithError(err).Debug("treestore: final flush on shutdown failed")
+			}
 			return
 		case <-hb.C:
 			// Re-publish the current Root if nothing has published for a
@@ -919,7 +921,9 @@ func (p *Publisher) runLoop() {
 			case <-timer.C:
 			case <-p.done:
 				timer.Stop()
-				_ = p.publishIfDirty() //nolint:errcheck
+				if err := p.publishIfDirty(); err != nil {
+					p.log.WithError(err).Debug("treestore: final flush on shutdown failed")
+				}
 				return
 			}
 			if err := p.publishIfDirty(); err != nil {
@@ -1106,7 +1110,7 @@ func (p *Publisher) publishRoot(root *memNode) ([]freshSub, error) {
 
 	up, err := c.Unpack(skyfromCipher, Registry)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("treestore unpack: %w", err)
 	}
 	defer up.Close() //nolint:errcheck
 
@@ -1188,7 +1192,13 @@ func (p *Publisher) publishRoot(root *memNode) ([]freshSub, error) {
 		err = attempt()
 	}
 	if err != nil {
-		return nil, err
+		// Wrap with which-operation context so a future freeze
+		// self-localises in the log. isMissingObject still matches through
+		// the %w wrap (errors.Is + a lowercase "not found" substring both
+		// see the wrapped sentinel), and the self-heal check above runs on
+		// the unwrapped attempt() error, so this wrapping changes nothing
+		// about the retry decision — it only annotates the terminal error.
+		return nil, fmt.Errorf("treestore encode/save: %w", err)
 	}
 	p.cxoNode.Publish(r)
 

--- a/pkg/cxo/treestore/publisher_filling_trap_test.go
+++ b/pkg/cxo/treestore/publisher_filling_trap_test.go
@@ -1,0 +1,185 @@
+package treestore
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	skycipher "github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/data"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject"
+)
+
+// TestPublisherSelfHealsFillingTrapObject reproduces the PRODUCTION
+// [stats]/TPD publisher freeze that #4036 did NOT fix, and proves the
+// root-cause repair in Cache.setFilling.
+//
+// #4036 added a self-heal to publishRoot: on a "not found" during
+// encode+save it drops the encode cache on the snapshot and re-encodes
+// from memory (re-Set'ing every object) to re-materialise an evicted
+// object, then retries once. Its regression test (TestPublisherSelfHeals
+// EvictedCachedObject) runs on a CACHE-DISABLED node, where Cache.Set
+// writes straight to the CXDS — so the re-Set always restores the object
+// and the retry succeeds.
+//
+// Production runs with the write-behind cache ENABLED. There a
+// content-addressed object can be tracked as a "filling" cache item
+// (val==nil, retained in c.is because a filler inc keeps it) while its
+// backing CXDS object is deleted (refcount GC / prune racing eviction).
+// This happens naturally on a densely-shared transport graph: a
+// transport A<->B is published in BOTH A's and B's tp-list, so the two
+// visors' trees share the SAME content hash; when a visor also fills a
+// peer's Root it registers that shared hash as a filler item, and its
+// own published object becomes a filling placeholder. Before this fix,
+// Cache.Set on such an item routed to setFilling->incFilling->db.Get —
+// which only READS and returns "not found", never writing the value. So
+// the self-heal re-encode could not restore the object: the retry failed
+// identically and the served Root froze forever (heartbeat "republish
+// failed: not found" every tick; TPD stuck reflecting a stale fraction).
+//
+// The tree mirrors the #4036 test: a "static" (cached) sibling and a
+// "growing" (churning) sibling. We put the static branch's sub-TreeNode
+// into the filling+missing-backing state, and additionally evict its
+// parent TreeEntry element so the changed-root reference walk descends
+// into it and reaches the trapped object. WITHOUT the fix publishRoot
+// returns "not found" and growing/n1 is dropped (frozen Root); WITH the
+// fix the re-encode's Set persists the value, the retry succeeds, and the
+// served Root advances to the full current tree.
+func TestPublisherSelfHealsFillingTrapObject(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+	n := nopNode(t) // cache ENABLED (default CacheMaxAmount), unlike the #4036 test
+	skyPK := skycipher.PubKey(pk)
+	if err := n.Share(skyPK); err != nil {
+		t.Fatalf("Share: %v", err)
+	}
+	p := &Publisher{
+		log: mustLogger(), cxoNode: n, pk: pk, sk: sk,
+		root:         newMemNode(),
+		allow:        newAllowState(nil),
+		batchWindow:  10 * time.Millisecond,
+		wakeup:       make(chan struct{}, 1),
+		done:         make(chan struct{}),
+		cleanupNudge: make(chan struct{}, 1),
+		cleanupDone:  make(chan struct{}),
+	}
+	close(p.cleanupDone)
+
+	c := p.cxoNode.Container()
+	cxds := c.DB().CXDS()
+
+	if err := p.Put("static/x", []byte("v1")); err != nil {
+		t.Fatalf("Put(static/x): %v", err)
+	}
+	if err := p.Put("growing/n0", []byte("d0")); err != nil {
+		t.Fatalf("Put(growing/n0): %v", err)
+	}
+	if err := p.publishIfDirty(); err != nil {
+		t.Fatalf("first publishIfDirty: %v", err)
+	}
+
+	staticNode := p.root.subs["static"]
+	if staticNode == nil || !staticNode.cached || staticNode.pubHash == (skycipher.SHA256{}) {
+		t.Fatalf("expected static sub-node cached with a pubHash; got %+v", staticNode)
+	}
+	staticHash := staticNode.pubHash
+
+	// Put the static sub-TreeNode into the filling+missing-backing state:
+	// give it a filler inc (so eviction keeps it as a filling placeholder),
+	// drive its cached rc to zero (evicts the value but retains the c.is
+	// entry because fc>0), then delete its backing object from the CXDS.
+	fillCh := make(chan skyobject.Object, 1)
+	if err := c.Want(staticHash, fillCh, 1); err != nil {
+		t.Fatalf("Want(staticHash): %v", err)
+	}
+	if _, err := c.Inc(staticHash, -1<<20); err != nil {
+		t.Fatalf("Inc(staticHash) down: %v", err)
+	}
+	if !c.IsCached(staticHash) {
+		t.Fatalf("expected staticHash retained as a filling cache item")
+	}
+	if _, _, err := cxds.Get(staticHash, 0); err == nil {
+		if err := cxds.Del(staticHash); err != nil {
+			t.Fatalf("Del(staticHash): %v", err)
+		}
+	}
+	if _, _, err := cxds.Get(staticHash, 0); err != data.ErrNotFound {
+		t.Fatalf("staticHash should be gone from CXDS; Get err=%v", err)
+	}
+
+	// Fully evict the parent "static" TreeEntry element (from cache AND
+	// CXDS) so the next re-encode re-creates it fresh (created=true) and
+	// Save's reference walk DESCENDS into it, reaching the trapped
+	// staticHash — otherwise the unchanged-subtree dedup would skip it.
+	entryHash := staticTreeEntryHash(t, c, skyPK, sk)
+	if _, err := c.Inc(entryHash, -1<<20); err != nil {
+		t.Fatalf("Inc(entryHash) down: %v", err)
+	}
+	if _, _, err := cxds.Get(entryHash, 0); err == nil {
+		if err := cxds.Del(entryHash); err != nil {
+			t.Fatalf("Del(entryHash): %v", err)
+		}
+	}
+
+	// Advance the churning sibling and republish. The reference walk hits
+	// the trapped staticHash; the self-heal re-encodes and must now be able
+	// to Set the value back. WITHOUT the fix this returns "not found".
+	if err := p.Put("growing/n1", []byte("d1")); err != nil {
+		t.Fatalf("Put(growing/n1): %v", err)
+	}
+	if err := p.publishIfDirty(); err != nil {
+		t.Fatalf("republish should self-heal the filling-trap object, got: %v", err)
+	}
+
+	// The trapped object must be back in the store — proving Set (not just
+	// Inc) re-materialised it via the setFilling repair.
+	if _, _, err := cxds.Get(staticHash, 0); err != nil {
+		t.Fatalf("staticHash should be restored by the setFilling repair: %v", err)
+	}
+
+	// The served Root must reflect the CURRENT tree, not a frozen one.
+	nonce := c.ActiveHead(skyPK)
+	if nonce == 0 {
+		t.Fatalf("ActiveHead returned zero after publish")
+	}
+	r, err := c.LastRoot(skyPK, nonce)
+	if err != nil {
+		t.Fatalf("LastRoot: %v", err)
+	}
+	up, err := c.Unpack(skycipher.SecKey(sk), Registry)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	defer up.Close() //nolint:errcheck
+
+	var rootNode TreeNode
+	if err := r.Refs[0].Value(up, &rootNode); err != nil {
+		t.Fatalf("decode rootNode: %v", err)
+	}
+	served := make(map[string][]byte)
+	if err := walkTree(up, &rootNode, "", served); err != nil {
+		t.Fatalf("walkTree (a dangling reference here means the Root is broken): %v", err)
+	}
+
+	want := map[string][]byte{
+		"static/x":   []byte("v1"),
+		"growing/n0": []byte("d0"),
+		"growing/n1": []byte("d1"), // the advance a frozen Root would drop
+	}
+	for path, wantVal := range want {
+		got, ok := served[path]
+		if !ok {
+			t.Errorf("served Root missing %q — Root is frozen (the pre-fix bug)", path)
+			continue
+		}
+		if !bytes.Equal(got, wantVal) {
+			t.Errorf("served Root %q = %q, want %q", path, got, wantVal)
+		}
+	}
+	for path := range served {
+		if _, ok := want[path]; !ok {
+			t.Errorf("served Root has unexpected path %q", path)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

A CXO treestore publisher freeze breaks transport-discovery fleet-wide, and #4036 did **not** resolve it. A live HV built with #4036 still logs `[stats]: treestore: heartbeat republish failed error="not found"` every ~20s indefinitely, while its served tp-list CXO leaf stays frozen (~9% of the live transport set) and never advances.

## Why #4036 didn't fix it

#4036's self-heal (`publishRoot`) drops the encode cache on a "not found" and re-encodes from memory, re-`Set`'ing every object to re-materialise the one evicted from the CXDS, then retries once. Its regression test runs on a **cache-DISABLED** node — there `Cache.Set` writes straight to the CXDS, so the re-Set always restores the object and the retry succeeds.

Production runs with the write-behind cache **ENABLED**, and there the retry still fails.

## Root cause (traced + reproduced)

A content-addressed object can be tracked as a **"filling"** cache item (`val==nil`, so `isFilling()==true`, retained in `c.is` because a filler inc keeps it) while its backing CXDS object is deleted (refcount GC / prune racing a cache eviction). On a densely-shared transport graph this arises naturally: a transport A↔B is published in **both** visors' tp-lists (same content hash), so when a visor fills a peer's Root it registers that shared hash as a filler placeholder — and the visor's own published object becomes a filling item.

`Cache.Set` on a filling item routed to `setFilling → incFilling → db.Get`, which only **reads** and returns `data.ErrNotFound` — it never writes the value. So the self-heal re-encode could not restore the object; the retry failed identically and the served Root froze forever.

This was proven at the cache layer (a `Set` on a filling item with a deleted backing returns `not found` and writes nothing) and at the publisher layer (a faithful cache-enabled reproduction freezes the Root: the self-heal WARN fires, the retry returns `not found`, and the churning sibling's new leaf is dropped from the served tree).

## Fix

`Cache.setFilling` now repairs the violated invariant: when `incFilling` reports the backing object is missing and `Set` has a value to write, it persists the value afresh — with `inc + it.fc` so the stored refcount accounts for both the caller's reference and the outstanding filler incs, mirroring `setWanted`'s accounting — instead of returning `not found`. This makes #4036's self-heal re-encode actually restore evicted-and-filling objects under the enabled cache, so the Root advances.

## Instrumentation (safe, valuable regardless)

- `publishRoot`'s error returns now carry which-operation context (`treestore unpack:` / `treestore encode/save:`, `%w`-wrapped so `isMissingObject`'s `errors.Is` + lowercase `"not found"` substring both still match; the self-heal check runs on the unwrapped `attempt()` error, so retry behaviour is unchanged).
- The two previously-swallowed shutdown-flush `publishIfDirty()` calls now log at Debug like the heartbeat path.

## Tests

Both new tests **fail without the fix and pass with it**, on a cache-ENABLED node:
- `pkg/cxo/skyobject`: `Cache.Set` restores a filling item whose backing was deleted (proves the repair at its layer).
- `pkg/cxo/treestore`: the publisher self-heals a filling-trap object and the served Root advances to the full current tree instead of freezing (mirrors #4036's evicted-object test with the deep object made a filling placeholder).

#4036's own cache-disabled self-heal test and the heartbeat/leak tests still pass; `go build ./pkg/cxo/... .`, `go vet`, and `go test ./pkg/cxo/...` are green.

## Recovery of an already-frozen node

The fix advances the Root **from the current frozen on-disk CXDS state** — no extra unstick step is needed. On the next heartbeat after rebuilding onto this fix, the walk still hits the missing object and the self-heal fires, but now the re-encode's `Set` persists the value (the content is reconstructed from the in-memory tree), the retry succeeds, and the tp-list republishes in full. Transport-discovery then converges as the fresh Root propagates.
