### PR TITLE
fix(router): flush in-flight retx window on mux leg demote (no-dip hot-swap)

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1156,12 +1156,38 @@ func (rg *RouteGroup) rotationServiceFn(_ time.Duration) {
 	// teardown, no compaction), so they must run on the pre-drop indices. A
 	// demoted leg stays in tps[] — kept alive by the keepalive/liveness loops —
 	// but is skipped by selectTransport; promoting re-selects it instantly.
+	demoted := false
 	if rg.mux != nil {
 		for _, idx := range action.PromoteFromStandby {
 			rg.mux.setLegStandby(idx, false)
 		}
 		for _, idx := range action.DemoteToStandby {
 			rg.mux.setLegStandby(idx, true)
+			demoted = true
+		}
+	}
+
+	// Forced retx flush on demote: the instant a leg flips to standby it stops
+	// carrying its in-flight, unACKed sequences. The receiver's post-#4005
+	// no-skip reorder holds that gap open until those sequences arrive; if they
+	// age out of the bounded retx buffer before the receiver's SACK round-trip
+	// asks for them, the sender can no longer resend and the gap wedges forever
+	// (the #86 retx-window aged-out gap, here triggered by the demote itself —
+	// the mechanism behind the live "17MB -> 0 at first demote" stall). So
+	// proactively re-send the whole outstanding in-flight window onto an active,
+	// non-standby leg NOW — a self-issued full SACK recovery — instead of racing
+	// the buffer's aging. The retx buffer is keyed by sequence, not by leg, so
+	// this is a flush of every held sequence, not just the demoted leg's; that is
+	// bounded (retxBuf is bounded), infrequent (rotation cadence), and safe (the
+	// receiver dedups by sequence number, consuming only the actual gap seqs and
+	// dropping the rest). Runs before DropLegs so the data is rescued before any
+	// compaction. If no active leg is available the flush is a safe no-op — leg 0
+	// is never standby, so demoting an aux always leaves a resend target.
+	if demoted && rg.mux != nil {
+		if seqs := rg.mux.heldRetxSeqs(); len(seqs) > 0 {
+			if err := rg.resendSeqs(seqs); err != nil {
+				rg.logger.WithError(err).Debug("demote retx flush: no active leg to resend on")
+			}
 		}
 	}
 
@@ -2134,17 +2160,29 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 
 	rg.logger.Debugf("SACK: retransmitting %d packets", len(retxSeqs))
 
-	for _, seq := range retxSeqs {
+	return rg.resendSeqs(retxSeqs)
+}
+
+// resendSeqs retransmits the given held sequences on the FASTEST live,
+// non-standby leg, mirroring the SACK-driven retransmit path exactly (same wire
+// format via MakeSequencedDataPacket + the same per-leg sent/retransmit
+// accounting). Fastest-leg selection heals a head-of-line-blocking gap on a fast
+// path rather than re-sending it down the slow leg that stalled it — see
+// routeMux.selectFastestTransport. Sequences no longer in the retx buffer are
+// skipped (already acknowledged and purged). Returns the transport-selection
+// error when no active leg is available so the caller decides whether that is
+// fatal (SACK path) or a safe no-op (demote flush — leg 0 is never standby).
+//
+// Shared by handleSACKPacket (receiver asked for these) and the demote-time
+// forced retx flush (rotationServiceFn self-issues the whole in-flight window).
+func (rg *RouteGroup) resendSeqs(seqs []uint32) error {
+	for _, seq := range seqs {
 		data := rg.mux.getRetxPayload(seq)
 		if data == nil {
 			continue
 		}
 
 		rg.mu.Lock()
-		// Retransmit on the FASTEST live leg, not the mode-driven spray pick:
-		// this seq is what the peer's reorder buffer is HoL-blocked on, so heal
-		// it on a fast path instead of possibly re-sending it down the slow leg
-		// that stalled it. See routeMux.selectFastestTransport.
 		tp, rule, leg, err := rg.nextFastestTransport()
 		rg.mu.Unlock()
 		if err != nil {
@@ -2157,7 +2195,7 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 		}
 
 		if err := rg.writePacket(context.Background(), tp, retxPacket, rule.KeyRouteID()); err != nil {
-			rg.logger.WithError(err).Warnf("SACK: failed to retransmit seq %d", seq)
+			rg.logger.WithError(err).Warnf("failed to retransmit seq %d", seq)
 		} else if leg >= 0 {
 			// Count retransmits against the leg that carried them
 			// (which may differ from the original send leg — the

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -550,6 +550,17 @@ func (m *routeMux) getRetxPayload(seq uint32) []byte {
 	return m.retxBuf.Get(seq)
 }
 
+// heldRetxSeqs returns every sequence currently held unACKed in the sender's
+// retx buffer, ascending. Nil when SACK/retx is not in play. Used by the
+// demote-time forced retx flush to re-send a parked leg's in-flight range onto
+// an active leg (see RouteGroup.rotationServiceFn).
+func (m *routeMux) heldRetxSeqs() []uint32 {
+	if !m.sackEnabled || m.retxBuf == nil {
+		return nil
+	}
+	return m.retxBuf.Seqs()
+}
+
 // rebuildWeights updates transport selection weights based on current latency.
 func (m *routeMux) rebuildWeights(tps []*transport.ManagedTransport) {
 	if m.tpSelector != nil {

--- a/pkg/router/route_mux_demote_retx_test.go
+++ b/pkg/router/route_mux_demote_retx_test.go
@@ -1,0 +1,196 @@
+//go:build !tinygo || (js && wasm)
+
+package router
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// capturingTransport is a workingTransport that records every packet written to
+// it, so a test can assert WHICH leg a retransmit went out on and for which
+// sequences. Writes still succeed immediately (no real peer).
+type capturingTransport struct {
+	*workingTransport
+	mu      sync.Mutex
+	written []routing.Packet
+}
+
+func newCapturingTransport() *capturingTransport {
+	return &capturingTransport{workingTransport: newWorkingTransport()}
+}
+
+func (t *capturingTransport) Write(b []byte) (int, error) {
+	n, err := t.workingTransport.Write(b)
+	if err == nil {
+		cp := make([]byte, len(b))
+		copy(cp, b)
+		t.mu.Lock()
+		t.written = append(t.written, routing.Packet(cp))
+		t.mu.Unlock()
+	}
+	return n, err
+}
+
+// dataSeqs returns the sequence numbers of the sequenced DataPackets captured on
+// this transport, in write order.
+func (t *capturingTransport) dataSeqs() []uint32 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var out []uint32
+	for _, p := range t.written {
+		if p.Type() == routing.DataPacket {
+			out = append(out, p.SequenceNumber())
+		}
+	}
+	return out
+}
+
+// createCapturingMuxRouteGroup mirrors createMuxRouteGroup but enables SACK/retx
+// (so wrapPayload populates the retx buffer) and uses capturing transports so
+// the test can observe retransmitted packets per leg.
+func createCapturingMuxRouteGroup(t *testing.T, nTransports int) (*RouteGroup, []*capturingTransport) {
+	t.Helper()
+
+	l := logging.NewMasterLogger()
+	rt := routing.NewTable(l.PackageLogger("rgt-demote"))
+
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+	desc := routing.NewRouteDescriptor(pk1, pk2, 1, 2)
+
+	rg := NewRouteGroup(DefaultRouteGroupConfig(), rt, desc, l)
+	rg.mux = newRouteMux(l.PackageLogger("mux-demote"), true) // SACK/retx ON
+
+	mts := make([]*transport.ManagedTransport, 0, nTransports)
+	conns := make([]*capturingTransport, 0, nTransports)
+	fwds := make([]routing.Rule, 0, nTransports)
+	rvss := make([]routing.Rule, 0, nTransports)
+
+	for i := 0; i < nTransports; i++ {
+		tpID := uuid.New()
+		fwd := routing.ForwardRule(DefaultRouteKeepAlive, routing.RouteID(i+1), routing.RouteID(i+100), tpID, pk2, pk1, 1, 2) //nolint:gosec
+		rvs := routing.ConsumeRule(DefaultRouteKeepAlive, routing.RouteID(i+100), pk1, pk2, 2, 1)                             //nolint:gosec
+		rt.SaveRule(fwd)                                                                                                      //nolint:errcheck,gosec
+		rt.SaveRule(rvs)                                                                                                      //nolint:errcheck,gosec
+
+		conn := newCapturingTransport()
+		mt := transport.NewManagedTransportForTest(conn)
+		mt.Entry = transport.Entry{ID: tpID, Type: "test"}
+
+		mts = append(mts, mt)
+		conns = append(conns, conn)
+		fwds = append(fwds, fwd)
+		rvss = append(rvss, rvs)
+	}
+
+	rg.mu.Lock()
+	rg.tps = mts
+	rg.fwd = fwds
+	rg.rvs = rvss
+	rg.mux.rebuildWeights(mts)
+	rg.mux.growLegs(len(mts))
+	for i := range mts {
+		rg.mux.markLegReady(i)
+	}
+	rg.mu.Unlock()
+
+	return rg, conns
+}
+
+// demoteHook is a one-shot RotationHook that demotes a fixed set of leg indices
+// to warm standby on its next tick.
+type demoteHook struct{ demote []int }
+
+func (h demoteHook) OnTick(_ DialInfo, _ []LegInfo) RotationAction {
+	return RotationAction{DemoteToStandby: h.demote}
+}
+
+// TestMuxDemoteFlushesInFlightSeqs is the wire-correctness proof for the Gate-5
+// no-dip hot-swap. A leg carrying unACKed, in-flight sequences is demoted to
+// warm standby. Those sequences must not be stranded: the demote path must
+// proactively re-send the whole outstanding in-flight window onto an ACTIVE,
+// non-standby leg immediately (a self-issued full SACK recovery), so the peer's
+// no-skip reorder gap fills without waiting for a SACK round-trip that can lose
+// the race with the bounded retx buffer's aging (#86 / the live "17MB -> 0 at
+// first demote" stall).
+//
+// Without the fix the demote merely flips the standby flag and resends nothing,
+// so both capturing legs would record zero DataPackets and this test fails on
+// the "resent onto an active leg" assertion.
+func TestMuxDemoteFlushesInFlightSeqs(t *testing.T) {
+	rg, conns := createCapturingMuxRouteGroup(t, 2)
+
+	// Send data so the sender holds unACKed sequences in its retx buffer with no
+	// SACK received yet (as if leg 1 were carrying them and they are in flight).
+	const nPkts = 32
+	want := make([]uint32, 0, nPkts)
+	for i := 0; i < nPkts; i++ {
+		_, seq, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{byte(i), 0xAA, 0xBB})
+		if err != nil {
+			t.Fatalf("wrapPayload: %v", err)
+		}
+		want = append(want, seq)
+	}
+	if got := rg.mux.retxBuf.Len(); got != nPkts {
+		t.Fatalf("retxBuf holds %d unACKed seqs, want %d", got, nPkts)
+	}
+
+	// Demote leg 1 to warm standby via the real rotation apply path.
+	rg.rotationHook = demoteHook{demote: []int{1}}
+	rg.rotationServiceFn(0)
+
+	if !rg.mux.isLegStandby(1) {
+		t.Fatal("leg 1 should be on standby after demote")
+	}
+
+	// The demoted leg (1) must carry NONE of the flush — it is parked.
+	if got := conns[1].dataSeqs(); len(got) != 0 {
+		t.Errorf("demoted leg 1 carried %d resent DataPackets, want 0 (%v)", len(got), got)
+	}
+
+	// The active leg (0) must have received a resend of EVERY held sequence, in
+	// ascending order (lowest gap first).
+	got := conns[0].dataSeqs()
+	if len(got) != len(want) {
+		t.Fatalf("active leg 0 resent %d seqs, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("resend[%d] = seq %d, want %d (full window: got %v want %v)",
+				i, got[i], want[i], got, want)
+		}
+	}
+}
+
+// TestMuxDemoteFlushNoActiveLegIsSafe: demoting when there is no other active
+// leg to resend on must be a safe no-op, not a panic or a wedge. (In practice
+// leg 0 is never standby, so this is a defensive guard.)
+func TestMuxDemoteFlushNoActiveLegIsSafe(t *testing.T) {
+	rg, conns := createCapturingMuxRouteGroup(t, 2)
+
+	for i := 0; i < 8; i++ {
+		if _, _, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{byte(i)}); err != nil {
+			t.Fatalf("wrapPayload: %v", err)
+		}
+	}
+
+	// Force leg 0 not-ready so no active send leg remains once leg 1 is demoted.
+	rg.mux.legMu.Lock()
+	rg.mux.ready[0] = false
+	rg.mux.legMu.Unlock()
+
+	rg.rotationHook = demoteHook{demote: []int{1}}
+	rg.rotationServiceFn(0) // must not panic
+
+	if n := len(conns[0].dataSeqs()) + len(conns[1].dataSeqs()); n != 0 {
+		t.Errorf("no-active-leg demote resent %d packets, want 0 (safe no-op)", n)
+	}
+}

--- a/pkg/router/sack.go
+++ b/pkg/router/sack.go
@@ -2,6 +2,7 @@
 package router
 
 import (
+	"sort"
 	"sync"
 	"time"
 )
@@ -235,4 +236,23 @@ func (rb *retxBuffer) Len() int {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 	return len(rb.entries)
+}
+
+// Seqs returns the sequence numbers of every currently-held unacknowledged
+// entry, in ascending order. The buffer is keyed by sequence, not by the leg a
+// packet was sent on, so this is the whole outstanding in-flight window — the
+// input to the demote-time forced retx flush, which re-sends that window onto an
+// active leg before the receiver's SACK round-trip can lose the race with the
+// buffer's aging (the #86 retx-window aged-out gap). Ascending so the lowest gap
+// — the one the receiver's reorder buffer is head-of-line blocked on — heals
+// first.
+func (rb *retxBuffer) Seqs() []uint32 {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	out := make([]uint32, 0, len(rb.entries))
+	for s := range rb.entries {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
 }


### PR DESCRIPTION
## Problem

Gate-5 warm-standby demote (#3974/#3977/#3979) is code-complete: a policy `on_tick` can move a mux leg to warm standby via `setLegStandby` (flip a `standby[]` flag so the send path skips it) and promote it back with no teardown. In-process tests pass. But a **live** rotating-bw run under load **stalled permanently at the first demote (17MB -> 0)**, while a no-policy static mux-bw sustained clean.

Root cause: `setLegStandby` does nothing with the demoted leg's **in-flight, unACKed sequences** — it just flips the flag. Retransmission is receiver-SACK-driven and the sender holds unACKed packets in a **bounded** `retxBuf`. When a leg is demoted mid-stream its in-flight seqs stop arriving; if they **age out of the bounded `retxBuf`** before the receiver SACKs and the sender resends, the sender can no longer retransmit them, and the receiver's post-#4005 **no-skip reorder** (never releases past an open gap, by design, to protect the noise cipher) holds the gap **forever -> permanent stall**. This is the #86 "retx-window aged-out gap", now triggered by the demote itself.

## Fix

On demote, **proactively re-send the whole outstanding in-flight window onto an active, non-standby leg immediately** — a self-issued full SACK recovery — instead of waiting for the receiver's SACK round-trip that may lose the race with `retxBuf` aging. So the receiver's reorder gap fills promptly and the hot-swap is no-dip on the wire.

The `retxBuf` is keyed by **sequence, not by leg** (`retxEntry` = seq/data/sentAt; `selectTransport` picks per-send), so there is no per-leg attribution to resend selectively — this is a bounded flush of every held sequence. That is safe: the receiver dedups already-delivered sequences by sequence number, so only the actual gap seqs are consumed. It is bounded (retxBuf is bounded) and infrequent (rotation cadence).

- `retxBuffer.Seqs()` — held unACKed sequences, ascending (lowest/HoL gap first)
- `routeMux.heldRetxSeqs()` — mux-level accessor
- `RouteGroup.resendSeqs()` — the fastest-live-leg retransmit loop, **extracted from `handleSACKPacket`** and reused by the demote flush so the wire format (`MakeSequencedDataPacket`) and per-leg sent/retransmit accounting are identical to SACK-driven retx
- `rotationServiceFn` — run the flush right after the demote, before `DropLegs`; safe no-op if no active leg (leg 0 is never standby)

The reorder buffer (#4005 no-skip) and the promote path are unchanged.

## Test

`TestMuxDemoteFlushesInFlightSeqs`: builds a 2-leg SACK mux, leaves 32 unACKed seqs in `retxBuf` (no SACK yet), demotes leg 1 through the real `rotationServiceFn` apply path, and asserts every held sequence is re-sent on active leg 0 in ascending order and **none** on the parked leg (capturing transports record per-leg writes). Verified to **fail without the fix** (0 resent vs 32). Plus `TestMuxDemoteFlushNoActiveLegIsSafe` for the no-active-leg no-op guard.

`go build .`, `go test ./pkg/router/...`, `go vet ./pkg/router/` all pass; no regressions in reorder/sack/route_group tests.

## Scope

This is the **code fix + unit proof**. The live no-dip proof (rotating-bw >=5min through skysocks with no throughput gap at rotation) is a **separate follow-up** on a settled visor — not included here.