### PR TITLE
feat(routing-policy): AR-resolve geo layer for off-path intermediary hops

### DIFF
--- a/pkg/visor/policy_provider.go
+++ b/pkg/visor/policy_provider.go
@@ -14,7 +14,14 @@
 //     dial hot path more than once every refreshTTL.
 //  2. Direct-transport IP → embedded geoip. Catches direct
 //     neighbors that don't advertise as a service.
-//  3. "??" — the policy script's filter falls through.
+//  3. AR-resolve IP → embedded geoip. Catches AR-registered
+//     intermediaries that are neither advertised as a service nor
+//     directly connected — the common geo-avoid hop. The AR
+//     Resolve hits the network, so it runs OFF the dial hot path:
+//     a miss fires a single background resolve (deduped) and
+//     caches the result (including negatives) per-PK on a TTL;
+//     geo-avoid converges over a couple of selections.
+//  4. "??" — the policy script's filter falls through.
 //
 // SD snapshot source is the CXO subscription manager (zero
 // network cost when running) with an HTTP fallback (the existing
@@ -23,6 +30,8 @@
 package visor
 
 import (
+	"context"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +42,7 @@ import (
 	"github.com/skycoin/skywire/pkg/geoip"
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/transport"
+	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
 	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 )
 
@@ -52,6 +62,27 @@ func parsePK(s string) (cipher.PubKey, bool) {
 // 5 minutes keeps the snapshot fresh enough for routing policy
 // without burning CXO walks on every dial.
 const sdGeoRefreshTTL = 5 * time.Minute
+
+// arGeoTTL bounds how long an AR-resolved country (or negative
+// result) is cached per PK. An AR registration's reachable IP —
+// and therefore its country — is stable on the order of hours; a
+// long TTL keeps the AR out of the dial path to at most one
+// resolve per PK per window. arResolveTimeout bounds each
+// background Resolve so a slow/unreachable AR can't leak
+// goroutines.
+const (
+	arGeoTTL         = 30 * time.Minute
+	arResolveTimeout = 4 * time.Second
+)
+
+// arGeoEntry is one cached AR-resolved country. country is the ISO
+// code, or "??" for a negative result (resolve failed / no IP / no
+// geoip hit) so a miss isn't re-resolved on every dial within the
+// TTL.
+type arGeoEntry struct {
+	country string
+	expires time.Time
+}
 
 // visorPolicyProvider implements router/policy.Provider on top of
 // the running visor's state. Construct via newVisorPolicyProvider
@@ -73,6 +104,18 @@ type visorPolicyProvider struct {
 
 	hypervisors map[string]struct{} // hex PK → present
 	trusted     map[string]struct{} // hex PK → present (dmsgpty whitelist + hypervisors)
+
+	// AR-resolve geo cache. Fills the gap between the SD snapshot
+	// (advertised services only) and the direct-transport IP (direct
+	// neighbors only): an intermediary hop that is AR-registered but
+	// neither advertised nor directly connected. Populated
+	// asynchronously — Resolve hits the AR server, so it never runs
+	// on the dial hot path — and cached per-PK (including negatives)
+	// on arGeoTTL. arInFlight dedups concurrent resolves for the
+	// same PK.
+	arMu       sync.Mutex
+	arGeo      map[string]arGeoEntry
+	arInFlight map[string]struct{}
 }
 
 func newVisorPolicyProvider(v *Visor) *visorPolicyProvider {
@@ -81,6 +124,8 @@ func newVisorPolicyProvider(v *Visor) *visorPolicyProvider {
 		visor:       v,
 		hypervisors: make(map[string]struct{}),
 		trusted:     make(map[string]struct{}),
+		arGeo:       make(map[string]arGeoEntry),
+		arInFlight:  make(map[string]struct{}),
 	}
 
 	// Embedded geoip DB. Failure to open isn't fatal — Geo() just
@@ -137,9 +182,118 @@ func (p *visorPolicyProvider) Geo(pk string) string {
 					return res.CountryCode
 				}
 			}
+			// 3. AR-resolve IP + embedded geoip (off hot path).
+			if c := p.arGeoForPK(pubkey, pkLower); c != "" {
+				return c
+			}
 		}
 	}
 	return "??"
+}
+
+// arGeoForPK returns the cached AR-resolved country for pkLower, or
+// "" when it isn't known (yet). On a cache miss — or an expired
+// entry — it fires a SINGLE background resolve (deduped by
+// arInFlight) and returns "" immediately, so the dial hot path
+// never blocks on the AR server. The resolved country lands in the
+// cache for the next dial; a geo-avoid selection converges once the
+// background resolve completes. A cached "??" (negative) is
+// reported as "" so Geo() falls through to its final "??".
+func (p *visorPolicyProvider) arGeoForPK(pk cipher.PubKey, pkLower string) string {
+	p.arMu.Lock()
+	if e, ok := p.arGeo[pkLower]; ok && time.Now().Before(e.expires) {
+		c := e.country
+		p.arMu.Unlock()
+		if c == "??" {
+			return ""
+		}
+		return c
+	}
+	// Miss/expired: only spend a resolve when we actually can (AR
+	// client + geoip db present) and no resolve is already running
+	// for this PK.
+	if p.tpM == nil || p.geoDB == nil {
+		p.arMu.Unlock()
+		return ""
+	}
+	if _, running := p.arInFlight[pkLower]; running {
+		p.arMu.Unlock()
+		return ""
+	}
+	p.arInFlight[pkLower] = struct{}{}
+	p.arMu.Unlock()
+
+	go p.resolveARGeo(pk, pkLower)
+	return ""
+}
+
+// resolveARGeo resolves pk's reachable IP via the AR client and
+// looks up its country in the embedded geoip db, caching the result
+// (or a "??" negative) under arGeoTTL. Runs in its own goroutine off
+// the dial path; always records SOMETHING so arInFlight is cleared
+// and the miss isn't retried until the TTL lapses.
+func (p *visorPolicyProvider) resolveARGeo(pk cipher.PubKey, pkLower string) {
+	country := "??"
+	defer func() {
+		p.arMu.Lock()
+		p.arGeo[pkLower] = arGeoEntry{country: country, expires: time.Now().Add(arGeoTTL)}
+		delete(p.arInFlight, pkLower)
+		p.arMu.Unlock()
+	}()
+
+	if p.tpM == nil {
+		return
+	}
+	ar := p.tpM.ARClient()
+	if ar == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), arResolveTimeout)
+	defer cancel()
+
+	// stcpr and sudph both carry a routable RemoteAddr; try the
+	// preferred direct type first, then the UDP-hole-punched one.
+	for _, netType := range []tptypes.Type{tptypes.STCPR, tptypes.SUDPH} {
+		vd, err := ar.Resolve(ctx, string(netType), pk)
+		if err != nil {
+			continue
+		}
+		if c := p.countryFromVisorData(vd); c != "" {
+			country = c
+			return
+		}
+	}
+}
+
+// countryFromVisorData extracts the reachable IP (v4 preferred, v6
+// fallback) from an AR record and returns its embedded-geoip country
+// code, or "" when no IP resolves to a country.
+func (p *visorPolicyProvider) countryFromVisorData(vd addrresolver.VisorData) string {
+	for _, addr := range []string{vd.RemoteAddr, vd.RemoteAddrV6} {
+		ip := hostFromAddr(addr)
+		if ip == "" {
+			continue
+		}
+		p.geoMu.Lock()
+		res, err := geoip.Lookup(p.geoDB, ip)
+		p.geoMu.Unlock()
+		if err == nil && res != nil && res.CountryCode != "" {
+			return res.CountryCode
+		}
+	}
+	return ""
+}
+
+// hostFromAddr returns the host portion of a "host:port" address, or
+// the input unchanged when it carries no port. Empty in, empty out.
+func hostFromAddr(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	return addr
 }
 
 // sdGeoForPK returns the country code for pk from the SD snapshot,

--- a/pkg/visor/policy_provider_test.go
+++ b/pkg/visor/policy_provider_test.go
@@ -1,0 +1,106 @@
+// Package visor pkg/visor/policy_provider_test.go c3-vis-core
+package visor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/geoip"
+	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+)
+
+// gbIP is a fixed address the embedded GeoLite2 db maps to GB (the
+// same fixture pkg/geoip's own tests rely on).
+const gbIP = "81.2.69.142"
+
+func TestHostFromAddr(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"81.2.69.142:1234", "81.2.69.142"},
+		{"81.2.69.142", "81.2.69.142"}, // no port → unchanged
+		{"[2001:db8::1]:443", "2001:db8::1"},
+	}
+	for _, c := range cases {
+		if got := hostFromAddr(c.in); got != c.want {
+			t.Errorf("hostFromAddr(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestCountryFromVisorData asserts the AR-record → country path: the
+// reachable IP is extracted (v4 preferred, v6 fallback) and looked up
+// in the embedded geoip db, and an AR record with no usable IP yields
+// "".
+func TestCountryFromVisorData(t *testing.T) {
+	db, err := geoip.OpenEmbedded()
+	if err != nil {
+		t.Skipf("embedded geoip db unavailable: %v", err)
+	}
+	defer db.Close() //nolint:errcheck,gosec
+	p := &visorPolicyProvider{geoDB: db}
+
+	if got := p.countryFromVisorData(addrresolver.VisorData{RemoteAddr: gbIP + ":1234"}); got != "GB" {
+		t.Errorf("countryFromVisorData(v4) = %q, want GB", got)
+	}
+	// v6 fallback when v4 is absent.
+	if got := p.countryFromVisorData(addrresolver.VisorData{RemoteAddrV6: gbIP + ":1234"}); got != "GB" {
+		t.Errorf("countryFromVisorData(v6 fallback) = %q, want GB", got)
+	}
+	// No usable address → "".
+	if got := p.countryFromVisorData(addrresolver.VisorData{}); got != "" {
+		t.Errorf("countryFromVisorData(empty) = %q, want \"\"", got)
+	}
+	// Private / non-public IP → no country.
+	if got := p.countryFromVisorData(addrresolver.VisorData{RemoteAddr: "10.0.0.1:1"}); got != "" {
+		t.Errorf("countryFromVisorData(private) = %q, want \"\"", got)
+	}
+}
+
+// TestARGeoForPKCache asserts arGeoForPK serves cached values without
+// touching the AR: a fresh positive entry returns its country, a
+// negative ("??") entry returns "" (so Geo falls through), and a miss
+// with no capability (nil tpM/geoDB) returns "" without spawning a
+// resolve.
+func TestARGeoForPKCache(t *testing.T) {
+	p := &visorPolicyProvider{
+		arGeo:      map[string]arGeoEntry{},
+		arInFlight: map[string]struct{}{},
+	}
+	const hit = "aaaa000000000000000000000000000000000000000000000000000000000001"
+	const neg = "bbbb000000000000000000000000000000000000000000000000000000000002"
+	const miss = "cccc000000000000000000000000000000000000000000000000000000000003"
+	p.arGeo[hit] = arGeoEntry{country: "DE", expires: time.Now().Add(time.Minute)}
+	p.arGeo[neg] = arGeoEntry{country: "??", expires: time.Now().Add(time.Minute)}
+
+	if got := p.arGeoForPK(cipher.PubKey{}, hit); got != "DE" {
+		t.Errorf("arGeoForPK(cached hit) = %q, want DE", got)
+	}
+	if got := p.arGeoForPK(cipher.PubKey{}, neg); got != "" {
+		t.Errorf("arGeoForPK(cached negative) = %q, want \"\"", got)
+	}
+	// Miss with nil tpM/geoDB: no capability → "" and no in-flight
+	// resolve registered (nothing to resolve with).
+	if got := p.arGeoForPK(cipher.PubKey{}, miss); got != "" {
+		t.Errorf("arGeoForPK(miss, no capability) = %q, want \"\"", got)
+	}
+	if _, running := p.arInFlight[miss]; running {
+		t.Error("arGeoForPK spawned a resolve despite nil tpM/geoDB")
+	}
+}
+
+// TestARGeoForPKExpired asserts an expired cache entry is treated as a
+// miss (not served stale) and, lacking capability, returns "".
+func TestARGeoForPKExpired(t *testing.T) {
+	p := &visorPolicyProvider{
+		arGeo:      map[string]arGeoEntry{},
+		arInFlight: map[string]struct{}{},
+	}
+	const pk = "dddd000000000000000000000000000000000000000000000000000000000004"
+	p.arGeo[pk] = arGeoEntry{country: "FR", expires: time.Now().Add(-time.Minute)} // expired
+	if got := p.arGeoForPK(cipher.PubKey{}, pk); got != "" {
+		t.Errorf("arGeoForPK(expired) = %q, want \"\" (not served stale)", got)
+	}
+}


### PR DESCRIPTION
## What

The visor-backed routing-policy `Provider` (`pkg/visor/policy_provider.go`) resolves a hop's country (for the `geo-avoid` / `transport-diverse` / `trust-tiered` presets and Starlark `geo.country()`) from two IP sources today:

1. **SD snapshot** — public proxy/vpn/visor entries that advertise a country.
2. **Direct-transport IP** — the remote IP of a transport we already hold.

An **intermediary hop that is AR-registered but neither advertised as a service nor directly connected** — the common `geo-avoid` case, since relays are usually public AR-registered visors we don't have a direct transport to — had **no IP source** and returned `"??"`, leaving those presets under-constrained on that hop.

## Change

Add a **third geo layer**: resolve the peer's reachable IP via the transport manager's address-resolver client (`tpM.ARClient().Resolve` over `stcpr`/`sudph`) and look it up in the **already-embedded geoip db** (`geoip.OpenEmbedded` + `geoip.Lookup`).

Because `Resolve` hits the network, it runs **off the dial hot path**:
- a cache miss fires a **single deduped background resolve** and returns `"??"` immediately (hot path never blocks on the AR),
- the result — **including negatives** — is cached per-PK on a 30m TTL, so a miss costs one resolve per PK per window, not one per dial,
- `geo-avoid` converges once the background resolve lands.

`Kind()` is unchanged (transport type straight from the manager — the always-available half).

## Scope / safety

- **Native-only.** The change is confined to `pkg/visor`, which the TinyGo wasm-visor never imports; the wasm path keeps `presethook`'s `NopProvider` (dmsg-server geo remains a documented future follow-up). `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor` still compiles.
- **No preset decision logic touched** — this only enriches candidate metadata on native, so the native==wazero **parity suite (`pkg/router/policy/wasm/presets`) still passes**.

## Tests

New `pkg/visor/policy_provider_test.go`:
- `hostFromAddr` (host:port / bare / IPv6),
- `countryFromVisorData` against the embedded db (v4, v6 fallback, none, private IP → `""`),
- `arGeoForPK` cache behavior: cached hit, cached negative → `""`, miss-without-capability spawns no resolve, expired entry not served stale.

## Verification

- `go build .` ✅ · `go vet ./pkg/visor` ✅ · `go test ./pkg/router/...` ✅ (incl. wasm/presets parity) · `go test ./pkg/visor -run 'TestHostFromAddr|TestCountryFromVisorData|TestARGeoForPK'` ✅ · `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor` ✅ · `gofmt`/`goimports` clean.