### PR TITLE
feat(routing-policy): --override key=value on `mux plot --pk` → policy CLIOverrides

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_plot.go
+++ b/cmd/skywire-cli/commands/proxy/mux_plot.go
@@ -41,6 +41,7 @@ var (
 	muxPlotDuration time.Duration
 	muxPlotPolicy   string
 	muxPlotSizeKb   int
+	muxPlotOverride []string
 
 	// muxPlotSubject is the caption/header label for the current run (the app
 	// name in poll mode, or a peer descriptor in --pk mode).
@@ -67,6 +68,7 @@ func init() {
 	muxPlotCmd.Flags().DurationVar(&muxPlotDuration, "duration", 5*time.Minute, "[--pk] how long to pump bytes")
 	muxPlotCmd.Flags().StringVar(&muxPlotPolicy, "policy", "", "[--pk] routing-policy preset (e.g. preset:rotating-bw); empty = static mux")
 	muxPlotCmd.Flags().IntVar(&muxPlotSizeKb, "size", 32, "[--pk] per-write block size in KB")
+	muxPlotCmd.Flags().StringArrayVar(&muxPlotOverride, "override", nil, "[--pk] routing-policy CLI override key=value (repeatable): e.g. --override avoid_geo=RU,CN (geo-avoid), --override trusted_pks=<pk,pk> (trust-tiered), --override business_hours=9-17 (time-of-day)")
 	addMuxSub(muxPlotCmd, "mux-plot")
 }
 
@@ -273,6 +275,11 @@ func runMuxPlotStream(cmd *cobra.Command) {
 	}
 	defer client.Close() //nolint:errcheck,gosec
 
+	overrides, err := parseMuxPlotOverrides(muxPlotOverride)
+	if err != nil {
+		internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--override: %w", err))
+	}
+
 	req := &rpcgrpc.MuxBandwidthRequest{
 		TargetPk:         muxPlotPK,
 		Routes:           int32(muxPlotRoutes), //nolint:gosec
@@ -282,6 +289,7 @@ func runMuxPlotStream(cmd *cobra.Command) {
 		SetupTimeoutNs:   (30 * time.Second).Nanoseconds(),
 		SampleIntervalNs: muxPlotInterval.Nanoseconds(),
 		RoutingPolicy:    muxPlotPolicy,
+		CliOverrides:     overrides,
 	}
 	stream, err := client.StreamMuxBandwidth(ctx, req)
 	if err != nil {
@@ -329,6 +337,28 @@ func runMuxPlotStream(cmd *cobra.Command) {
 		default:
 		}
 	}
+}
+
+// parseMuxPlotOverrides turns the repeatable `--override key=value` flag into
+// the CLIOverrides map the routing-policy engine reads (the conditional presets
+// key off avoid_geo / trusted_pks / business_hours). Returns nil for no flags so
+// an absent --override leaves every preset on its built-in defaults. The value
+// may itself contain '=' (only the first splits key from value); an empty key
+// is rejected.
+func parseMuxPlotOverrides(pairs []string) (map[string]string, error) {
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(pairs))
+	for _, p := range pairs {
+		k, v, ok := strings.Cut(p, "=")
+		k = strings.TrimSpace(k)
+		if !ok || k == "" {
+			return nil, fmt.Errorf("invalid override %q (want key=value)", p)
+		}
+		out[k] = v
+	}
+	return out, nil
 }
 
 // runMuxPlotInfoStream drives the default (watch-a-running-app) mode over

--- a/cmd/skywire-cli/commands/proxy/mux_plot_test.go
+++ b/cmd/skywire-cli/commands/proxy/mux_plot_test.go
@@ -1,0 +1,49 @@
+// Package skysocksc cmd/skywire-cli/commands/proxy/mux_plot_test.go c4-vis-cli
+package skysocksc
+
+import (
+	"testing"
+)
+
+// TestParseMuxPlotOverrides pins the `--override key=value` parser that feeds
+// the routing-policy CLIOverrides the conditional presets read (avoid_geo /
+// trusted_pks / business_hours).
+func TestParseMuxPlotOverrides(t *testing.T) {
+	t.Run("nil for no flags leaves presets on defaults", func(t *testing.T) {
+		m, err := parseMuxPlotOverrides(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m != nil {
+			t.Errorf("want nil map for no --override, got %v", m)
+		}
+	})
+
+	t.Run("repeatable pairs parse into the map", func(t *testing.T) {
+		m, err := parseMuxPlotOverrides([]string{"avoid_geo=RU,CN", "business_hours=9-17"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m["avoid_geo"] != "RU,CN" || m["business_hours"] != "9-17" {
+			t.Errorf("parsed map wrong: %v", m)
+		}
+	})
+
+	t.Run("value may contain '=' (only first splits)", func(t *testing.T) {
+		m, err := parseMuxPlotOverrides([]string{"k=a=b"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m["k"] != "a=b" {
+			t.Errorf("want value a=b, got %q", m["k"])
+		}
+	})
+
+	t.Run("missing '=' or empty key rejected", func(t *testing.T) {
+		for _, bad := range []string{"noequals", "=noKey"} {
+			if _, err := parseMuxPlotOverrides([]string{bad}); err == nil {
+				t.Errorf("expected error for %q, got nil", bad)
+			}
+		}
+	})
+}

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -2960,7 +2960,15 @@ type MuxBandwidthRequest struct {
 	// vpn-client/skysocks-client/skynet-client; app-mux is per-app). Only
 	// meaningful when routing_policy is set; the handler defaults it to
 	// "skysocks-client" so the bandwidth-oriented presets are exercised.
-	PolicyApp     string `protobuf:"bytes,13,opt,name=policy_app,json=policyApp,proto3" json:"policy_app,omitempty"`
+	PolicyApp string `protobuf:"bytes,13,opt,name=policy_app,json=policyApp,proto3" json:"policy_app,omitempty"`
+	// CliOverrides surfaces the operator's ad-hoc `--override key=value` flags
+	// into the routing-policy engine's RoutingContext.CLIOverrides — the same
+	// map the conditional presets read: geo-avoid (avoid_geo=<CC,CC>),
+	// trust-tiered (trusted_pks=<PK,PK>), time-of-day (business_hours=START-END).
+	// Only meaningful when routing_policy is set. Absent/empty = the preset's
+	// built-in defaults (unchanged behavior). Keys collide-last with the
+	// handler-derived mux_routes / min_hops entries the controller already sets.
+	CliOverrides  map[string]string `protobuf:"bytes,14,rep,name=cli_overrides,json=cliOverrides,proto3" json:"cli_overrides,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3084,6 +3092,13 @@ func (x *MuxBandwidthRequest) GetPolicyApp() string {
 		return x.PolicyApp
 	}
 	return ""
+}
+
+func (x *MuxBandwidthRequest) GetCliOverrides() map[string]string {
+	if x != nil {
+		return x.CliOverrides
+	}
+	return nil
 }
 
 // MuxBandwidthEvent is one entry on the stream. Exactly one oneof
@@ -4779,7 +4794,7 @@ const file_ping_proto_rawDesc = "" +
 	"\amessage\x18\x04 \x01(\tR\amessage\"C\n" +
 	"\x13PingTreeServerError\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"\xef\x03\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"\x85\x05\n" +
 	"\x13MuxBandwidthRequest\x12\x1b\n" +
 	"\ttarget_pk\x18\x01 \x01(\tR\btargetPk\x12\x16\n" +
 	"\x06routes\x18\x02 \x01(\x05R\x06routes\x12\x1f\n" +
@@ -4797,7 +4812,11 @@ const file_ping_proto_rawDesc = "" +
 	"\x19idle_baseline_duration_ns\x18\v \x01(\x03R\x16idleBaselineDurationNs\x12%\n" +
 	"\x0erouting_policy\x18\f \x01(\tR\rroutingPolicy\x12\x1d\n" +
 	"\n" +
-	"policy_app\x18\r \x01(\tR\tpolicyApp\"\xe1\x03\n" +
+	"policy_app\x18\r \x01(\tR\tpolicyApp\x12S\n" +
+	"\rcli_overrides\x18\x0e \x03(\v2..rpcgrpc.MuxBandwidthRequest.CliOverridesEntryR\fcliOverrides\x1a?\n" +
+	"\x11CliOverridesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe1\x03\n" +
 	"\x11MuxBandwidthEvent\x12!\n" +
 	"\ftimestamp_ns\x18\x01 \x01(\x03R\vtimestampNs\x12K\n" +
 	"\x11route_established\x18\n" +
@@ -4964,7 +4983,7 @@ func file_ping_proto_rawDescGZIP() []byte {
 	return file_ping_proto_rawDescData
 }
 
-var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
+var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
 var file_ping_proto_goTypes = []any{
 	(*PingRequest)(nil),                    // 0: rpcgrpc.PingRequest
 	(*PingResult)(nil),                     // 1: rpcgrpc.PingResult
@@ -5013,6 +5032,7 @@ var file_ping_proto_goTypes = []any{
 	(*RouteGroupMuxInfo)(nil),              // 44: rpcgrpc.RouteGroupMuxInfo
 	(*RouteGroupMuxLeg)(nil),               // 45: rpcgrpc.RouteGroupMuxLeg
 	nil,                                    // 46: rpcgrpc.AppLogEntry.FieldsEntry
+	nil,                                    // 47: rpcgrpc.MuxBandwidthRequest.CliOverridesEntry
 }
 var file_ping_proto_depIdxs = []int32{
 	4,  // 0: rpcgrpc.PingRequest.forward_hops:type_name -> rpcgrpc.RouteHop
@@ -5035,50 +5055,51 @@ var file_ping_proto_depIdxs = []int32{
 	30, // 17: rpcgrpc.PingTreeEvent.status_update:type_name -> rpcgrpc.PingTreeStatusUpdate
 	31, // 18: rpcgrpc.PingTreeEvent.server_error:type_name -> rpcgrpc.PingTreeServerError
 	4,  // 19: rpcgrpc.PingTreeResult.route:type_name -> rpcgrpc.RouteHop
-	35, // 20: rpcgrpc.MuxBandwidthEvent.route_established:type_name -> rpcgrpc.MuxRouteEstablished
-	37, // 21: rpcgrpc.MuxBandwidthEvent.sample:type_name -> rpcgrpc.MuxBandwidthSample
-	39, // 22: rpcgrpc.MuxBandwidthEvent.rtt_probe:type_name -> rpcgrpc.MuxRttProbe
-	40, // 23: rpcgrpc.MuxBandwidthEvent.done:type_name -> rpcgrpc.MuxBandwidthDone
-	41, // 24: rpcgrpc.MuxBandwidthEvent.error:type_name -> rpcgrpc.MuxBandwidthError
-	36, // 25: rpcgrpc.MuxBandwidthEvent.route_failure:type_name -> rpcgrpc.MuxRouteFailure
-	34, // 26: rpcgrpc.MuxBandwidthEvent.leg_lifecycle:type_name -> rpcgrpc.MuxLegLifecycle
-	4,  // 27: rpcgrpc.MuxRouteEstablished.hops:type_name -> rpcgrpc.RouteHop
-	38, // 28: rpcgrpc.MuxBandwidthSample.legs:type_name -> rpcgrpc.MuxLegSample
-	44, // 29: rpcgrpc.RouteGroupMuxInfoSample.route_groups:type_name -> rpcgrpc.RouteGroupMuxInfo
-	45, // 30: rpcgrpc.RouteGroupMuxInfo.legs:type_name -> rpcgrpc.RouteGroupMuxLeg
-	0,  // 31: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
-	0,  // 32: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
-	5,  // 33: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	5,  // 34: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	2,  // 35: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
-	7,  // 36: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	7,  // 37: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	8,  // 38: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
-	16, // 39: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
-	18, // 40: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
-	21, // 41: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
-	24, // 42: rpcgrpc.PingService.StreamPingTree:input_type -> rpcgrpc.PingTreeRequest
-	32, // 43: rpcgrpc.PingService.StreamMuxBandwidth:input_type -> rpcgrpc.MuxBandwidthRequest
-	42, // 44: rpcgrpc.PingService.StreamRouteGroupMuxInfo:input_type -> rpcgrpc.StreamRouteGroupMuxInfoRequest
-	1,  // 45: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
-	1,  // 46: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
-	6,  // 47: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	6,  // 48: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	3,  // 49: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
-	9,  // 50: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 51: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 52: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
-	17, // 53: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
-	19, // 54: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
-	22, // 55: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
-	25, // 56: rpcgrpc.PingService.StreamPingTree:output_type -> rpcgrpc.PingTreeEvent
-	33, // 57: rpcgrpc.PingService.StreamMuxBandwidth:output_type -> rpcgrpc.MuxBandwidthEvent
-	43, // 58: rpcgrpc.PingService.StreamRouteGroupMuxInfo:output_type -> rpcgrpc.RouteGroupMuxInfoSample
-	45, // [45:59] is the sub-list for method output_type
-	31, // [31:45] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	47, // 20: rpcgrpc.MuxBandwidthRequest.cli_overrides:type_name -> rpcgrpc.MuxBandwidthRequest.CliOverridesEntry
+	35, // 21: rpcgrpc.MuxBandwidthEvent.route_established:type_name -> rpcgrpc.MuxRouteEstablished
+	37, // 22: rpcgrpc.MuxBandwidthEvent.sample:type_name -> rpcgrpc.MuxBandwidthSample
+	39, // 23: rpcgrpc.MuxBandwidthEvent.rtt_probe:type_name -> rpcgrpc.MuxRttProbe
+	40, // 24: rpcgrpc.MuxBandwidthEvent.done:type_name -> rpcgrpc.MuxBandwidthDone
+	41, // 25: rpcgrpc.MuxBandwidthEvent.error:type_name -> rpcgrpc.MuxBandwidthError
+	36, // 26: rpcgrpc.MuxBandwidthEvent.route_failure:type_name -> rpcgrpc.MuxRouteFailure
+	34, // 27: rpcgrpc.MuxBandwidthEvent.leg_lifecycle:type_name -> rpcgrpc.MuxLegLifecycle
+	4,  // 28: rpcgrpc.MuxRouteEstablished.hops:type_name -> rpcgrpc.RouteHop
+	38, // 29: rpcgrpc.MuxBandwidthSample.legs:type_name -> rpcgrpc.MuxLegSample
+	44, // 30: rpcgrpc.RouteGroupMuxInfoSample.route_groups:type_name -> rpcgrpc.RouteGroupMuxInfo
+	45, // 31: rpcgrpc.RouteGroupMuxInfo.legs:type_name -> rpcgrpc.RouteGroupMuxLeg
+	0,  // 32: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
+	0,  // 33: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
+	5,  // 34: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	5,  // 35: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	2,  // 36: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
+	7,  // 37: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	7,  // 38: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	8,  // 39: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
+	16, // 40: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
+	18, // 41: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
+	21, // 42: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
+	24, // 43: rpcgrpc.PingService.StreamPingTree:input_type -> rpcgrpc.PingTreeRequest
+	32, // 44: rpcgrpc.PingService.StreamMuxBandwidth:input_type -> rpcgrpc.MuxBandwidthRequest
+	42, // 45: rpcgrpc.PingService.StreamRouteGroupMuxInfo:input_type -> rpcgrpc.StreamRouteGroupMuxInfoRequest
+	1,  // 46: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
+	1,  // 47: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
+	6,  // 48: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	6,  // 49: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	3,  // 50: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
+	9,  // 51: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 52: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 53: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
+	17, // 54: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
+	19, // 55: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
+	22, // 56: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
+	25, // 57: rpcgrpc.PingService.StreamPingTree:output_type -> rpcgrpc.PingTreeEvent
+	33, // 58: rpcgrpc.PingService.StreamMuxBandwidth:output_type -> rpcgrpc.MuxBandwidthEvent
+	43, // 59: rpcgrpc.PingService.StreamRouteGroupMuxInfo:output_type -> rpcgrpc.RouteGroupMuxInfoSample
+	46, // [46:60] is the sub-list for method output_type
+	32, // [32:46] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_ping_proto_init() }
@@ -5109,7 +5130,7 @@ func file_ping_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ping_proto_rawDesc), len(file_ping_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   47,
+			NumMessages:   48,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -668,6 +668,15 @@ message MuxBandwidthRequest {
   // meaningful when routing_policy is set; the handler defaults it to
   // "skysocks-client" so the bandwidth-oriented presets are exercised.
   string policy_app = 13;
+
+  // CliOverrides surfaces the operator's ad-hoc `--override key=value` flags
+  // into the routing-policy engine's RoutingContext.CLIOverrides — the same
+  // map the conditional presets read: geo-avoid (avoid_geo=<CC,CC>),
+  // trust-tiered (trusted_pks=<PK,PK>), time-of-day (business_hours=START-END).
+  // Only meaningful when routing_policy is set. Absent/empty = the preset's
+  // built-in defaults (unchanged behavior). Keys collide-last with the
+  // handler-derived mux_routes / min_hops entries the controller already sets.
+  map<string, string> cli_overrides = 14;
 }
 
 // MuxBandwidthEvent is one entry on the stream. Exactly one oneof

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth.go
@@ -92,6 +92,13 @@ type muxBwCfg struct {
 	// skynet-client; app-mux is per-app). Defaults to "skysocks-client" so the
 	// bandwidth-oriented presets are exercised out of the box.
 	PolicyApp string
+	// CliOverrides carries the operator's ad-hoc `--override key=value` flags
+	// into the routing-policy engine's RoutingContext.CLIOverrides — the map the
+	// conditional presets read (geo-avoid=avoid_geo, trust-tiered=trusted_pks,
+	// time-of-day=business_hours). Nil/empty leaves every preset on its built-in
+	// defaults, so the baseline and the adaptive presets are byte-for-byte
+	// unchanged. See MuxBandwidthRequest.cli_overrides.
+	CliOverrides map[string]string
 }
 
 func normalizeMuxBwRequest(req *MuxBandwidthRequest) (muxBwCfg, error) {
@@ -111,6 +118,7 @@ func normalizeMuxBwRequest(req *MuxBandwidthRequest) (muxBwCfg, error) {
 	c.IdleBaselineDuration = time.Duration(req.IdleBaselineDurationNs)
 	c.RoutingPolicy = req.RoutingPolicy
 	c.PolicyApp = req.PolicyApp
+	c.CliOverrides = req.CliOverrides
 	if c.RoutingPolicy != "" && c.PolicyApp == "" {
 		c.PolicyApp = "skysocks-client"
 	}

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth_test.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth_test.go
@@ -221,6 +221,37 @@ func TestNormalizeMuxBwRequest(t *testing.T) {
 		}
 	})
 
+	t.Run("cli_overrides carried through verbatim", func(t *testing.T) {
+		req := &MuxBandwidthRequest{
+			TargetPk:      validPK,
+			RoutingPolicy: "preset:geo-avoid",
+			CliOverrides: map[string]string{
+				"avoid_geo":      "RU,CN",
+				"trusted_pks":    "aa,bb",
+				"business_hours": "9-17",
+			},
+		}
+		c, err := normalizeMuxBwRequest(req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for k, want := range req.CliOverrides {
+			if got := c.CliOverrides[k]; got != want {
+				t.Errorf("CliOverrides[%q] = %q, want %q", k, got, want)
+			}
+		}
+	})
+
+	t.Run("nil cli_overrides stays nil (baseline unchanged)", func(t *testing.T) {
+		c, err := normalizeMuxBwRequest(&MuxBandwidthRequest{TargetPk: validPK})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.CliOverrides != nil {
+			t.Errorf("CliOverrides = %v, want nil for an absent override map", c.CliOverrides)
+		}
+	})
+
 	t.Run("negative values fall back to defaults", func(t *testing.T) {
 		// Proto int32 lets negatives through the wire; the handler
 		// should treat them as "default" rather than propagate

--- a/pkg/visor/rpcgrpc/server_policy_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_policy_bandwidth.go
@@ -137,7 +137,9 @@ func (c *muxBwController) close() {
 
 // routingContext builds the RoutingContext the engine sees. App drives the
 // preset's per-app branching; CLIOverrides surface the operator's leg-count /
-// min-hops so a preset can honor or override them.
+// min-hops so a preset can honor or override them, plus any ad-hoc
+// `--override key=value` flags — the map the conditional presets read
+// (geo-avoid=avoid_geo, trust-tiered=trusted_pks, time-of-day=business_hours).
 func (c *muxBwController) routingContext() policy.RoutingContext {
 	overrides := map[string]string{}
 	if c.cfg.Routes > 0 {
@@ -145,6 +147,13 @@ func (c *muxBwController) routingContext() policy.RoutingContext {
 	}
 	if c.cfg.MinHops > 0 {
 		overrides["min_hops"] = strconv.Itoa(c.cfg.MinHops)
+	}
+	// Operator-supplied `--override key=value` pairs land last so an explicit
+	// flag wins over the handler-derived mux_routes / min_hops entries. Nil map
+	// (the baseline / no --override) is a no-op, so every preset keeps its
+	// built-in defaults.
+	for k, v := range c.cfg.CliOverrides {
+		overrides[k] = v
 	}
 	return policy.RoutingContext{
 		App:          c.cfg.PolicyApp,

--- a/pkg/visor/rpcgrpc/server_policy_bandwidth_test.go
+++ b/pkg/visor/rpcgrpc/server_policy_bandwidth_test.go
@@ -170,3 +170,45 @@ func TestSnapshotLegsTransportIDStable(t *testing.T) {
 		t.Errorf("leg 1 TransportID=%q want idx:1 fallback", legs[1].TransportID)
 	}
 }
+
+// TestRoutingContextMergesCliOverrides pins the threading point that lets the
+// conditional presets (geo-avoid / trust-tiered / time-of-day) be exercised on
+// the mux-bw rig: the operator's `--override key=value` flags, carried on
+// muxBwCfg.CliOverrides, must land in RoutingContext.CLIOverrides — the map
+// preset.Decide reads — alongside the handler-derived mux_routes / min_hops.
+// An explicit override wins over the handler-derived entry (collide-last).
+func TestRoutingContextMergesCliOverrides(t *testing.T) {
+	c := &muxBwController{cfg: &muxBwCfg{
+		PolicyApp: "skysocks-client",
+		Routes:    4,
+		MinHops:   2,
+		CliOverrides: map[string]string{
+			"avoid_geo": "RU,CN",
+			"min_hops":  "3", // operator override must win over the derived value
+		},
+	}}
+	rctx := c.routingContext()
+	if rctx.CLIOverrides["avoid_geo"] != "RU,CN" {
+		t.Errorf("avoid_geo not threaded: %v", rctx.CLIOverrides)
+	}
+	if rctx.CLIOverrides["mux_routes"] != "4" {
+		t.Errorf("mux_routes derived entry lost: %v", rctx.CLIOverrides)
+	}
+	if rctx.CLIOverrides["min_hops"] != "3" {
+		t.Errorf("operator min_hops override should win (collide-last): %v", rctx.CLIOverrides)
+	}
+}
+
+// TestRoutingContextNilCliOverrides pins that with no --override the derived
+// mux_routes / min_hops are still present and no preset default is disturbed —
+// the baseline / adaptive-preset path is unchanged.
+func TestRoutingContextNilCliOverrides(t *testing.T) {
+	c := &muxBwController{cfg: &muxBwCfg{Routes: 5, MinHops: 2}}
+	rctx := c.routingContext()
+	if rctx.CLIOverrides["mux_routes"] != "5" || rctx.CLIOverrides["min_hops"] != "2" {
+		t.Errorf("derived overrides missing: %v", rctx.CLIOverrides)
+	}
+	if _, ok := rctx.CLIOverrides["avoid_geo"]; ok {
+		t.Errorf("no --override was given, yet a conditional key appeared: %v", rctx.CLIOverrides)
+	}
+}


### PR DESCRIPTION
## What

Adds a repeatable `--override key=value` flag to `skywire cli proxy mux plot` (the `--pk` ad-hoc mux mode) and plumbs it through the `StreamMuxBandwidth` gRPC into the ad-hoc mux's routing-policy `RoutingContext.CLIOverrides` — the map the conditional presets already read:

- **geo-avoid** → `avoid_geo=<CC,CC>` (comma-separated ISO country codes)
- **trust-tiered** → `trusted_pks=<pk,pk>`
- **time-of-day** → `business_hours=START-END` (default `9-17`)

This unblocks live-proving those three constraint presets on the `mux plot --pk` rig, e.g.:

```
skywire cli proxy mux plot --pk <far> --routes 4 --policy preset:geo-avoid --override avoid_geo=RU,CN --duration 300s
```

## How

- **proto**: new `MuxBandwidthRequest.cli_overrides` (`map<string,string>`, field tag **14**). `ping.pb.go` regenerated with `protoc` + `protoc-gen-go` (`paths=source_relative`). The service RPC signature is unchanged, so `ping_grpc.pb.go` is untouched.
- **cli** (`cmd/skywire-cli/commands/proxy/mux_plot.go`): `--override` is a repeatable `StringArrayVar`, parsed into a `map[string]string` (`parseMuxPlotOverrides`) and set on the request. No `--override` → `nil` map.
- **visor** (`pkg/visor/rpcgrpc/`): `muxBwCfg.CliOverrides` is carried in `normalizeMuxBwRequest`, then merged **collide-last** (operator override wins over the handler-derived `mux_routes` / `min_hops`) into `muxBwController.routingContext()`'s `CLIOverrides` — which flows to `preset.Context.CLIOverrides` read by `decideGeoAvoid` / `decideTrustTiered` / `decideTimeOfDay`.

## Compatibility

Purely additive. An absent/empty override map behaves exactly as today (nil → each preset keeps its built-in defaults), so the pure mux-bw baseline and the adaptive presets are byte-for-byte unchanged. No change to `pkg/router/policy/preset` decision logic and no change to the wasm bundle.

## Tests

- `parseMuxPlotOverrides` (CLI parser: nil-for-none, repeatable pairs, value-with-`=`, malformed rejection)
- `normalizeMuxBwRequest` cli_overrides pass-through + nil-stays-nil
- `routingContext()` merges cli_overrides, precedence (operator wins), and nil case leaves no conditional key

`go build .`, `go vet`, and `go test ./pkg/visor/rpcgrpc/... ./pkg/router/...` all pass (including the wasm preset/parity suites).