### PR TITLE
fix(tpd): land a busy visor's full transport list via a targeted, bounded discovery-leaf fetch

### DIFF
--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -497,6 +497,22 @@ func (c *Conn) getter() (cg skyobject.Getter) {
 	return &cget{c}
 }
 
+// Getter returns a skyobject.Getter that fetches single objects by hash
+// from this connection's remote peer on demand (one RqObject request per
+// Get, hash-verified, bounded by the connection's ResponseTimeout).
+//
+// Unlike a Root fill it neither walks an object graph nor writes anything
+// to the node's container: each Get is an isolated request/response for
+// exactly the requested object, and the caller decides what (if anything)
+// to keep. Pairing it with (*Container).Preview yields a bounded,
+// on-demand read of one chosen path through a Root without triggering or
+// interfering with a concurrent whole-Root fill. The TPD aggregator uses
+// this to pull just the small tp-list discovery leaf out of a Root whose
+// bulky telemetry subtree can't finish filling within the conn's window.
+func (c *Conn) Getter() skyobject.Getter {
+	return c.getter()
+}
+
 // signalClose idempotently closes closeq to signal shutdown. Multiple paths
 // race to signal it — run()'s receiveMsg/onConnect failure branches, the idle
 // watchdog, and external Close() (including concurrent closeAll iteration) — so

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -33,6 +33,7 @@ package cxoaggregator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"sync"
@@ -236,6 +237,28 @@ type Aggregator struct {
 	// dialing guards in-flight dial-backs so the heartbeat cadence can't
 	// storm ConnectPK for the same visor. Keyed by feed PK. Guarded by mu.
 	dialing map[skycipher.PubKey]struct{}
+
+	// fetching coalesces in-flight targeted discovery-leaf fetches so a
+	// visor that republishes rapidly can't spawn a pile of concurrent
+	// per-object request goroutines for the same feed. Keyed by feed PK.
+	// Guarded by mu.
+	fetching map[skycipher.PubKey]struct{}
+
+	// lastList caches the most-recent successfully decoded transport-list
+	// snapshot per reporter PK. A transient targeted-fetch failure (the
+	// delivering conn closed before the handful of tp-list objects
+	// arrived) re-applies the last good full set on the next Root, holding
+	// the reporter's transports against the redis TTL until a fresh fetch
+	// lands. Dropped when the feed is reclaimed (reclaimOrphanFeeds).
+	// Guarded by mu.
+	lastList map[skycipher.PubKey]cachedList
+}
+
+// cachedList is the last good decoded transport-list snapshot for a
+// reporter, kept so a failed targeted fetch can re-apply it (fallback #2).
+type cachedList struct {
+	entries []*transport.Entry
+	version string
 }
 
 // ensureConnTimeout bounds each dial-back to a visor's CXO node so an
@@ -249,6 +272,27 @@ const ensureConnTimeout = 20 * time.Second
 // truncated partial fill, unlike the legacy "transports/list" which sorted
 // last among the "transports" node's per-uuid children.
 const tpdListLeafName = "tp-list"
+
+// maxTargetedFetchObjects caps how many objects the targeted
+// discovery-leaf fetch (reconcileTargeted) will request from a visor for
+// one Root. The tp-list path is the registry + root TreeNode + the small
+// top-level Children index page(s) + the tp-list TreeEntry — a handful of
+// objects. The cap bounds a malicious or oversized Root so a crafted deep
+// top-level index can't drive unbounded per-object requests to the peer.
+const maxTargetedFetchObjects = 64
+
+// targetedFetchTimeout bounds the whole targeted discovery-leaf fetch
+// (all per-object requests for one Root together). Each underlying object
+// request is separately bounded by the conn's ResponseTimeout; this is
+// the ceiling on the sequential walk so a slow-drip peer can't pin the
+// fetch goroutine.
+const targetedFetchTimeout = 30 * time.Second
+
+// errTargetedFetchBudget is returned by boundedGetter once the object
+// count or wall-clock budget for a targeted fetch is exhausted. It
+// unwinds the treestore walk cleanly (childByName treats an unreadable
+// child as absent) rather than hanging.
+var errTargetedFetchBudget = errors.New("cxoaggregator: targeted discovery fetch budget exceeded")
 
 // orphanGraceTicks is how many consecutive cleanup ticks a feed must
 // have zero connected conns before it's reclaimed. At the 2-minute
@@ -321,6 +365,8 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 		done:          make(chan struct{}),
 		nudge:         make(chan struct{}, 1),
 		orphanStrikes: make(map[skycipher.PubKey]int),
+		fetching:      make(map[skycipher.PubKey]struct{}),
+		lastList:      make(map[skycipher.PubKey]cachedList),
 	}
 	// Subscribe to a visor's feed the moment it dials in, rather than
 	// waiting up to ReconcileInterval (30s) for the next poll. A fresh
@@ -354,7 +400,7 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 	//     failed (timeout, peer drop, missing object). Logged at Warn
 	//     so it surfaces at the default log level — without this,
 	//     fill failures are silent.
-	cxoNode.Config().OnRootReceived = func(_ *node.Conn, r *registry.Root) error {
+	cxoNode.Config().OnRootReceived = func(c *node.Conn, r *registry.Root) error {
 		a.log.WithField("visor", cipher.PubKey(r.Pub)).WithField("seq", r.Nonce).
 			Debug("CXO aggregator: root received")
 		// The inbound conn the visor AnnounceTo'd us on closes moments after
@@ -363,6 +409,16 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 		// conn to the visor — we hold it, so subsequent Roots (the publisher
 		// re-announces on a heartbeat) have a stable source to fill from.
 		a.ensureConn(r.Pub)
+		// Discovery decoupled from the whole-Root telemetry fill: pull JUST
+		// the small tp-list leaf path off this Root now, over the delivering
+		// conn, independent of the 90s MaxFillingTime fill of the bulky
+		// per-transport telemetry subtree (which for a busy visor never
+		// completes in the conn's window — the discovery gap). The full list
+		// lands from a handful of objects, so it survives the same short conn
+		// that a whole-tree fill can't. Detached so its blocking per-object
+		// requests can't stall the CXO node's per-head event loop (this
+		// callback runs on it).
+		a.reconcileTargeted(c, r)
 		return nil
 	}
 	cxoNode.Config().OnRootFilled = func(_ *node.Node, r *registry.Root) {
@@ -511,6 +567,12 @@ func (a *Aggregator) reclaimOrphanFeeds(c *skyobject.Container) {
 				Debug("CXO aggregator: DelFeed orphan feed failed; will retry next tick")
 			continue
 		}
+		// Drop the reporter's cached transport-list snapshot: the feed is
+		// gone (its Roots deleted), so there's nothing to re-apply and the
+		// entry would otherwise pin memory as visor PKs churn.
+		a.mu.Lock()
+		delete(a.lastList, feed)
+		a.mu.Unlock()
 		a.log.WithField("visor", cipher.PubKey(feed)).
 			Debug("CXO aggregator: reclaimed orphan feed (no connected conn)")
 	}
@@ -678,6 +740,179 @@ func (a *Aggregator) recoverTransportListOnBreak(r *registry.Root) {
 		Debug("CXO aggregator: recovered transport list from partial fill")
 	leafCopy := append([]byte(nil), leaf...)
 	go a.dispatchLeaf(dispatchPath, leafCopy, reporter)
+}
+
+// reconcileTargeted decouples discovery from the whole-Root telemetry fill.
+//
+// On every OnRootReceived it does a BOUNDED, TARGETED fetch of just the
+// tp-list leaf path — registry, root TreeNode, the small top-level Children
+// index page(s), and the tp-list TreeEntry — over the delivering conn, and
+// reconciles the reporter's full transport set immediately. This is
+// INDEPENDENT of the 90s MaxFillingTime whole-Root fill and of
+// OnFillingBreaks: the telemetry subtree fill can still run and fail as
+// before; discovery no longer waits on it. Because the tp-list snapshot is a
+// single inlined TreeEntry, landing that handful of path objects lands the
+// ENTIRE transport list — where the whole-tree fill of a busy visor's
+// hundreds of telemetry objects can't complete in the short-lived conn's
+// window (the ~10% discovery gap this fixes).
+//
+// Objects are read through a Preview pack: found in the aggregator's CXO
+// store if the concurrent fill already fetched them, else requested from the
+// remote peer on demand and held in memory only — never written to the store,
+// so this neither competes with nor disturbs the whole-Root fill or the
+// cleanup sweep.
+//
+// Idempotent vs the OnRootFilled path: both call the declarative
+// ReconcileTransportsFromCXO (register-all + deregister-absent), so if the
+// whole-Root fill also later completes it simply re-applies the same set.
+//
+// Runs on a detached goroutine (the per-object requests block on the network)
+// and is coalesced per feed so a rapidly republishing visor can't pile up
+// concurrent fetches.
+func (a *Aggregator) reconcileTargeted(conn *node.Conn, r *registry.Root) {
+	if conn == nil || r == nil || len(r.Refs) == 0 {
+		return
+	}
+	reporter := cipher.PubKey(r.Pub)
+	// A root with no publisher identity can't be attributed to a visor —
+	// same guard as handleRootFilled, so a zero-PK root never writes under
+	// the null key.
+	if reporter == (cipher.PubKey{}) {
+		return
+	}
+
+	// Coalesce: one in-flight targeted fetch per feed. A visor that
+	// republishes rapidly (or delivers the same Root on several conns)
+	// otherwise spawns a goroutine + per-object request burst each time.
+	a.mu.Lock()
+	if a.fetching == nil {
+		a.fetching = make(map[skycipher.PubKey]struct{})
+	}
+	if _, busy := a.fetching[r.Pub]; busy {
+		a.mu.Unlock()
+		return
+	}
+	a.fetching[r.Pub] = struct{}{}
+	a.mu.Unlock()
+
+	go func() {
+		defer func() {
+			a.mu.Lock()
+			delete(a.fetching, r.Pub)
+			a.mu.Unlock()
+		}()
+
+		entries, version, ok := a.fetchDiscoveryLeaf(conn, r)
+		if ok {
+			// Fresh full snapshot: cache it (so a later failed fetch can
+			// re-apply it) and reconcile.
+			a.mu.Lock()
+			a.lastList[r.Pub] = cachedList{entries: entries, version: version}
+			a.mu.Unlock()
+			a.applyReconcile(entries, reporter, version)
+			return
+		}
+		// Fetch failed (conn closed mid-fetch, leaf absent, or budget hit):
+		// re-apply the last good snapshot if we have one so the reporter's
+		// transports survive the redis TTL until a later Root lands fresh.
+		// Gated on receiving a Root, so a truly-gone visor (no more Roots)
+		// stops being refreshed and its transports expire normally.
+		a.mu.Lock()
+		cached, has := a.lastList[r.Pub]
+		a.mu.Unlock()
+		if has {
+			a.applyReconcile(cached.entries, reporter, cached.version)
+		}
+	}()
+}
+
+// fetchDiscoveryLeaf builds a Preview pack over conn (remote on-demand,
+// in-memory object fetch) and walks JUST the tp-list path with the same
+// partial-tolerant helpers the OnFillingBreaks recovery uses. Fetching is
+// bounded by object count (maxTargetedFetchObjects) and wall clock
+// (targetedFetchTimeout) via boundedGetter, so a huge or hostile Root can't
+// wedge the fetch. Returns the reconstructed full entry set and true iff the
+// leaf was present and decoded cleanly.
+func (a *Aggregator) fetchDiscoveryLeaf(conn *node.Conn, r *registry.Root) (entries []*transport.Entry, version string, ok bool) {
+	return a.fetchDiscoveryLeafWithGetter(conn.Getter(), r)
+}
+
+// fetchDiscoveryLeafWithGetter is the getter-parameterized core of
+// fetchDiscoveryLeaf, split out so the targeted walk/decode can be exercised
+// against a synthetic Getter (no live conn) in tests.
+func (a *Aggregator) fetchDiscoveryLeafWithGetter(g skyobject.Getter, r *registry.Root) (entries []*transport.Entry, version string, ok bool) {
+	reporter := cipher.PubKey(r.Pub)
+	bg := newBoundedGetter(g, maxTargetedFetchObjects, targetedFetchTimeout)
+	pack, err := a.cxoNode.Container().Preview(r, bg)
+	if err != nil {
+		a.log.WithError(err).WithField("visor", reporter).
+			Debug("CXO aggregator: targeted preview pack failed")
+		return nil, "", false
+	}
+	var rootNode treestore.TreeNode
+	if err := r.Refs[0].Value(pack, &rootNode); err != nil {
+		a.log.WithError(err).WithField("visor", reporter).
+			Debug("CXO aggregator: targeted root node fetch failed")
+		return nil, "", false
+	}
+	leaf, path, found := findDiscoveryLeaf(pack, &rootNode)
+	if !found || leaf == nil {
+		return nil, "", false
+	}
+	var list transportListLeaf
+	if err := json.Unmarshal(leaf, &list); err != nil {
+		a.log.WithError(err).WithField("visor", reporter).WithField("path", path).
+			Debug("CXO aggregator: targeted transport list decode failed")
+		return nil, "", false
+	}
+	a.log.WithField("visor", reporter).WithField("path", path).
+		Debug("CXO aggregator: targeted discovery-leaf fetch landed transport list")
+	return list.entries(reporter), list.Version, true
+}
+
+// applyReconcile hands a reporter's full transport set to the sink. Shared by
+// the fresh targeted fetch and the cached re-apply; the sink call is
+// declarative (register-all + deregister-absent) so repeated application is a
+// no-op.
+func (a *Aggregator) applyReconcile(entries []*transport.Entry, reporter cipher.PubKey, version string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := a.sink.ReconcileTransportsFromCXO(ctx, entries, reporter, version); err != nil {
+		a.log.WithError(err).WithField("reporter", reporter).
+			Debug("CXO aggregator: targeted ReconcileTransportsFromCXO failed")
+	}
+}
+
+// boundedGetter wraps a skyobject.Getter with an object-count cap and a
+// wall-clock deadline. It bounds the targeted discovery-leaf fetch so a Root
+// with a hostile or oversized top-level index can't drive unbounded
+// per-object requests to a peer or pin the fetch goroutine. Once either bound
+// is exceeded every subsequent Get returns errTargetedFetchBudget, which
+// unwinds the treestore walk cleanly (childByName treats an unreadable child
+// as absent) rather than hanging.
+type boundedGetter struct {
+	inner    skyobject.Getter
+	max      int
+	deadline time.Time
+
+	mu    sync.Mutex
+	count int
+}
+
+func newBoundedGetter(inner skyobject.Getter, max int, within time.Duration) *boundedGetter {
+	return &boundedGetter{inner: inner, max: max, deadline: time.Now().Add(within)}
+}
+
+// Get satisfies skyobject.Getter.
+func (b *boundedGetter) Get(key skycipher.SHA256) (val []byte, err error) {
+	b.mu.Lock()
+	if b.count >= b.max || time.Now().After(b.deadline) {
+		b.mu.Unlock()
+		return nil, errTargetedFetchBudget
+	}
+	b.count++
+	b.mu.Unlock()
+	return b.inner.Get(key)
 }
 
 // findDiscoveryLeaf locates the transport-list snapshot leaf in a (possibly

--- a/pkg/transport-discovery/cxoaggregator/targeted_fetch_test.go
+++ b/pkg/transport-discovery/cxoaggregator/targeted_fetch_test.go
@@ -1,0 +1,280 @@
+package cxoaggregator
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	skycipher "github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/node"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject/registry"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// newInMemNode builds a CXO Node with an in-memory container and no
+// network listeners — sufficient for building a Root (publisher side) or
+// hosting an empty container (aggregator side) in unit tests.
+func newInMemNode(t *testing.T) *node.Node {
+	t.Helper()
+	cfg := node.NewConfig()
+	cfg.TCP.Listen = ""
+	cfg.UDP.Listen = ""
+	cfg.RPC = ""
+	cfg.Config.InMemoryDB = true
+	n, err := node.NewNode(cfg)
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	t.Cleanup(func() { _ = n.Close() })
+	return n
+}
+
+// buildBigRoot publishes a Root that mirrors a busy visor's shape: a
+// single top-level "tp-list" discovery leaf carrying nTransports compact
+// entries, PLUS a bulky per-transport telemetry subtree
+// (transports/<uuid>/current) whose whole-fill is exactly what can't
+// complete over a short-lived conn in production. Returns the publisher's
+// container (source of objects), the latest Root, and the reporter PK.
+func buildBigRoot(t *testing.T, nTransports, nTelemetry int) (*skyobject.Container, *registry.Root, cipher.PubKey) {
+	t.Helper()
+	pk, sk := cipher.GenerateKeyPair()
+	pub, err := treestore.New(newInMemNode(t), sk, treestore.Config{BatchWindow: 5 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("treestore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = pub.Close() })
+
+	// tp-list: the full transport set as one inlined snapshot leaf, compact form.
+	compact := make([]transport.CompactEntry, 0, nTransports)
+	for i := 0; i < nTransports; i++ {
+		remote, _ := cipher.GenerateKeyPair()
+		compact = append(compact, transport.CompactEntry{Remote: remote, Type: types.Type("stcpr")})
+	}
+	leaf, err := json.Marshal(transportListLeaf{Version: "v-test", Compact: compact})
+	if err != nil {
+		t.Fatalf("marshal tp-list: %v", err)
+	}
+	if err := pub.Put(tpdListLeafName, leaf); err != nil {
+		t.Fatalf("Put tp-list: %v", err)
+	}
+
+	// A bulky telemetry subtree: this is the part whose whole-Root fill
+	// times out in production. The targeted fetch must NOT need any of it.
+	for i := 0; i < nTelemetry; i++ {
+		snap, _ := json.Marshal(liveSnapshot{SentBytes: uint64(i), RecvBytes: uint64(i), SampledAt: time.Now().UTC(), Type: "stcpr"})
+		path := fmt.Sprintf("transports/%040x-telemetry-%d/current", i, i)
+		if err := pub.Put(path, snap); err != nil {
+			t.Fatalf("Put telemetry: %v", err)
+		}
+	}
+
+	if err := pub.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	c := pub.Node().Container()
+	skyPK := skycipher.PubKey(pk)
+	nonce := c.ActiveHead(skyPK)
+	if nonce == 0 {
+		nonce = 1
+	}
+	r, err := c.LastRoot(skyPK, nonce)
+	if err != nil {
+		t.Fatalf("LastRoot: %v", err)
+	}
+	if r == nil || len(r.Refs) == 0 {
+		t.Fatal("expected a non-empty Root after Flush")
+	}
+	return c, r, pk
+}
+
+// servingGetter serves objects out of a source container by hash and
+// records every key requested. It optionally restricts service to an
+// allow-set of keys (to simulate a fill that can only fetch the tp-list
+// path, not the bulky telemetry), returning errNotServed otherwise.
+type servingGetter struct {
+	src       *skyobject.Container
+	allow     map[skycipher.SHA256]struct{} // nil => serve anything present
+	requested []skycipher.SHA256
+}
+
+var errNotServed = errors.New("object not served (simulated missing telemetry)")
+
+func (g *servingGetter) Get(key skycipher.SHA256) ([]byte, error) {
+	g.requested = append(g.requested, key)
+	if g.allow != nil {
+		if _, ok := g.allow[key]; !ok {
+			return nil, errNotServed
+		}
+	}
+	if v, _, err := g.src.Get(key, 0); err == nil {
+		return v, nil
+	}
+	// The registry body is not a plain CXDS object; serve the fixed
+	// treestore registry by its reference.
+	if key == skycipher.SHA256(treestore.Registry.Reference()) {
+		return treestore.Registry.Encode(), nil
+	}
+	return nil, errNotServed
+}
+
+// TestTargetedFetchLandsFullListDespiteTelemetry is the core proof: a Root
+// whose whole-fill would time out (a large telemetry subtree) but whose
+// tp-list leaf is present reconciles ALL of its transports via the targeted
+// path — not the ~10% a truncated whole-Root fill lands. It further proves
+// the fetch is BOUNDED to the tp-list path: replaying it against a getter
+// that serves ONLY the path objects (telemetry withheld) still lands the
+// full list.
+func TestTargetedFetchLandsFullListDespiteTelemetry(t *testing.T) {
+	const nTransports = 200
+	const nTelemetry = 200
+	src, r, reporter := buildBigRoot(t, nTransports, nTelemetry)
+
+	sink := &recordingSink{}
+	a := &Aggregator{
+		cxoNode:  newInMemNode(t),
+		sink:     sink,
+		log:      logging.MustGetLogger("test"),
+		lastList: make(map[skycipher.PubKey]cachedList),
+		fetching: make(map[skycipher.PubKey]struct{}),
+	}
+
+	// Phase 1: full getter serves everything. The targeted walk fetches
+	// only the objects it touches; record that set.
+	full := &servingGetter{src: src}
+	entries, version, ok := a.fetchDiscoveryLeafWithGetter(full, r)
+	if !ok {
+		t.Fatal("phase 1: targeted fetch did not land the tp-list leaf")
+	}
+	if version != "v-test" {
+		t.Errorf("phase 1: version = %q, want v-test", version)
+	}
+	if len(entries) != nTransports {
+		t.Fatalf("phase 1: reconciled %d transports, want all %d", len(entries), nTransports)
+	}
+
+	// The path is a handful of objects — far fewer than the telemetry tree,
+	// and within the per-fetch budget. This is what lets it land over a
+	// conn that a whole-tree fill can't finish.
+	if len(full.requested) >= maxTargetedFetchObjects {
+		t.Fatalf("phase 1: targeted fetch requested %d objects (>= budget %d) — not bounded to the path",
+			len(full.requested), maxTargetedFetchObjects)
+	}
+	if len(full.requested) > nTelemetry {
+		t.Fatalf("phase 1: targeted fetch requested %d objects — it is walking the telemetry subtree",
+			len(full.requested))
+	}
+
+	// Phase 2: restrict the getter to ONLY the objects the path touched;
+	// every telemetry object now errors (simulating the fill that can't
+	// complete). The full list must STILL land.
+	allow := make(map[skycipher.SHA256]struct{}, len(full.requested))
+	for _, k := range full.requested {
+		allow[k] = struct{}{}
+	}
+	restricted := &servingGetter{src: src, allow: allow}
+	a2 := &Aggregator{
+		cxoNode:  newInMemNode(t),
+		sink:     sink,
+		log:      logging.MustGetLogger("test"),
+		lastList: make(map[skycipher.PubKey]cachedList),
+		fetching: make(map[skycipher.PubKey]struct{}),
+	}
+	entries2, _, ok2 := a2.fetchDiscoveryLeafWithGetter(restricted, r)
+	if !ok2 {
+		t.Fatal("phase 2: targeted fetch failed with telemetry withheld — it depends on the whole-Root fill")
+	}
+	if len(entries2) != nTransports {
+		t.Fatalf("phase 2: reconciled %d transports with telemetry withheld, want all %d", len(entries2), nTransports)
+	}
+
+	// applyReconcile hands the full set to the sink declaratively.
+	a.applyReconcile(entries, reporter, version)
+	if len(sink.reconciles) != 1 {
+		t.Fatalf("expected 1 ReconcileTransportsFromCXO call, got %d", len(sink.reconciles))
+	}
+	if got := len(sink.reconciles[0].entries); got != nTransports {
+		t.Fatalf("sink reconcile received %d entries, want %d", got, nTransports)
+	}
+	if sink.reconciles[0].reporter != reporter {
+		t.Fatalf("sink reconcile reporter = %v, want %v", sink.reconciles[0].reporter, reporter)
+	}
+}
+
+// TestTargetedFetchMissingLeafCleanMiss: a Root with NO tp-list leaf must
+// return ok=false cleanly (no panic, no partial), so the caller falls back
+// to the cached snapshot rather than reconciling an empty set.
+func TestTargetedFetchMissingLeafCleanMiss(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+	_ = pk
+	pub, err := treestore.New(newInMemNode(t), sk, treestore.Config{BatchWindow: 5 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("treestore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = pub.Close() })
+	// Only telemetry, no tp-list leaf.
+	if err := pub.Put("transports/deadbeef/current", []byte(`{"sent_bytes":1,"recv_bytes":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := pub.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	c := pub.Node().Container()
+	skyPK := skycipher.PubKey(pk)
+	nonce := c.ActiveHead(skyPK)
+	if nonce == 0 {
+		nonce = 1
+	}
+	r, err := c.LastRoot(skyPK, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := &Aggregator{
+		cxoNode:  newInMemNode(t),
+		sink:     &recordingSink{},
+		log:      logging.MustGetLogger("test"),
+		lastList: make(map[skycipher.PubKey]cachedList),
+		fetching: make(map[skycipher.PubKey]struct{}),
+	}
+	full := &servingGetter{src: c}
+	if _, _, ok := a.fetchDiscoveryLeafWithGetter(full, r); ok {
+		t.Fatal("expected ok=false for a Root without a tp-list leaf")
+	}
+}
+
+// TestBoundedGetterBudget checks the object-count and deadline caps: once
+// exceeded every Get errors (so a hostile/oversized Root can't drive
+// unbounded requests or hang the walk).
+func TestBoundedGetterBudget(t *testing.T) {
+	// count cap
+	served := 0
+	inner := getterFunc(func(_ skycipher.SHA256) ([]byte, error) { served++; return []byte("x"), nil })
+	bg := newBoundedGetter(inner, 3, time.Minute)
+	for i := 0; i < 3; i++ {
+		if _, err := bg.Get(skycipher.SHA256{}); err != nil {
+			t.Fatalf("get %d before cap should succeed: %v", i, err)
+		}
+	}
+	if _, err := bg.Get(skycipher.SHA256{}); !errors.Is(err, errTargetedFetchBudget) {
+		t.Fatalf("get past count cap: err = %v, want budget error", err)
+	}
+
+	// deadline cap
+	bg2 := newBoundedGetter(inner, 1000, -1*time.Second) // already expired
+	if _, err := bg2.Get(skycipher.SHA256{}); !errors.Is(err, errTargetedFetchBudget) {
+		t.Fatalf("get past deadline: err = %v, want budget error", err)
+	}
+}
+
+type getterFunc func(skycipher.SHA256) ([]byte, error)
+
+func (f getterFunc) Get(key skycipher.SHA256) ([]byte, error) { return f(key) }


### PR DESCRIPTION
## Problem

A visor publishes its entire transport set as one inlined `tp-list` leaf on its CXO feed, alongside a bulky per-transport telemetry subtree (`transports/<uuid>/current`, timelines, bitmaps). TPD's aggregator only reconciled discovery once CXO finished filling the **whole** Root (`OnRootFilled`) or, best-effort, when a fill broke (`OnFillingBreaks`).

For a busy visor the Root carries hundreds-to-thousands of telemetry objects, and the whole-Root fill can't complete within `MaxFillingTime` (90s) over the short-lived delivering conn before it churns. So `OnRootFilled` rarely fires and TPD reflected only **~10%** of the visor's transports (measured live: 850 local transports → ~51-121 in TPD, decaying), starving the route-finder.

## Fix

**Decouple discovery from the whole-Root telemetry fill.** On `OnRootReceived`, do a bounded, targeted fetch of just the tp-list leaf path — registry + root `TreeNode` + the small top-level `Children` index page(s) + the `tp-list` `TreeEntry` — over the delivering conn, and reconcile the reporter's full transport set immediately. This is **independent** of the 90s whole-Root fill and of `OnFillingBreaks`; the telemetry subtree fill can still run and fail as before.

Because the tp-list snapshot is a single **inlined** `TreeEntry`, landing that handful of path objects lands the **entire** list — and it survives the same short conn a whole-tree fill can't.

### How

- New public `(*node.Conn).Getter()` exposes the connection's existing on-demand single-object getter (one `RqObject` per `Get`, hash-verified, bounded by `ResponseTimeout`). No change to the fill path.
- The aggregator reads the leaf path through the existing `(*skyobject.Container).Preview` pack: objects are found in the local store if the concurrent fill already has them, else pulled from the peer on demand and held **in memory only** (never written to CXDS) — so this neither competes with nor disturbs the whole-Root fill or the cleanup sweep.

### Safety / bounds

- **Bounded:** a `boundedGetter` caps objects (64) and wall-clock (30s) per Root, so a hostile/oversized Root can't drive unbounded per-object requests or hang the walk (budget-exceeded unwinds cleanly — `childByName` treats an unreadable child as absent).
- **Coalesced** per feed so a rapidly republishing visor can't pile up concurrent fetches.
- **Detached** goroutine — the blocking per-object requests never stall the CXO node's per-head event loop.
- **Idempotent** vs the `OnRootFilled` path: both call the declarative `ReconcileTransportsFromCXO` (register-all + deregister-absent).
- **Last-good cache** per reporter, re-applied only when a fresh fetch fails, holding transports against the redis TTL until a later Root lands; gated on receiving a Root (a truly-gone visor stops being refreshed and expires normally) and dropped when the feed is reclaimed.

## Tests

- `TestTargetedFetchLandsFullListDespiteTelemetry`: a Root with a large telemetry subtree whose objects are **withheld** still reconciles **all** 200 of its transports via the targeted path, and the fetch is proven bounded to the tp-list path (telemetry objects never requested).
- `TestTargetedFetchMissingLeafCleanMiss`: a Root with no tp-list leaf is a clean miss (falls back to cache, no panic/partial).
- `TestBoundedGetterBudget`: object-count and deadline caps both enforced.

`go build ./...`, `go vet`, `go test ./pkg/cxo/... ./pkg/transport-discovery/...` (incl. `-race` on the aggregator) all pass; existing aggregator/fill tests unchanged.