### PR TITLE
lint: fix errcheck/misspell/unparam on develop (make check clean)

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_plot.go
+++ b/cmd/skywire-cli/commands/proxy/mux_plot.go
@@ -373,7 +373,7 @@ func parseMuxPlotOverrides(pairs []string) (map[string]string, error) {
 // visor (first Recv errors before any sample), etc. — so the caller can
 // fall back to the unary poll. --interval sets the server-side sample
 // cadence (sample_interval_ns).
-func runMuxPlotInfoStream(cmd *cobra.Command, _ func() (any, error)) bool {
+func runMuxPlotInfoStream(_ *cobra.Command, _ func() (any, error)) bool {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 

--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -951,7 +951,7 @@ func (c *Cache) setFilling(
 		// missing backing and returns "not found". That is exactly the
 		// TPD / [stats] publisher freeze — treestore's self-heal re-encode
 		// (#4036) drops its encode cache and re-Set's every object to
-		// re-materialise the evicted one, but for a filling placeholder
+		// re-materialize the evicted one, but for a filling placeholder
 		// this path silently refused to write, so the retry failed
 		// identically and the served Root froze forever (heartbeat
 		// "republish failed: not found" every tick). #4036's own test only

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -1193,7 +1193,7 @@ func (p *Publisher) publishRoot(root *memNode) ([]freshSub, error) {
 	}
 	if err != nil {
 		// Wrap with which-operation context so a future freeze
-		// self-localises in the log. isMissingObject still matches through
+		// self-localizes in the log. isMissingObject still matches through
 		// the %w wrap (errors.Is + a lowercase "not found" substring both
 		// see the wrapped sentinel), and the self-heal check above runs on
 		// the unwrapped attempt() error, so this wrapping changes nothing

--- a/pkg/cxo/treestore/publisher_filling_trap_test.go
+++ b/pkg/cxo/treestore/publisher_filling_trap_test.go
@@ -18,7 +18,7 @@ import (
 //
 // #4036 added a self-heal to publishRoot: on a "not found" during
 // encode+save it drops the encode cache on the snapshot and re-encodes
-// from memory (re-Set'ing every object) to re-materialise an evicted
+// from memory (re-Set'ing every object) to re-materialize an evicted
 // object, then retries once. Its regression test (TestPublisherSelfHeals
 // EvictedCachedObject) runs on a CACHE-DISABLED node, where Cache.Set
 // writes straight to the CXDS — so the re-Set always restores the object
@@ -133,7 +133,7 @@ func TestPublisherSelfHealsFillingTrapObject(t *testing.T) {
 	}
 
 	// The trapped object must be back in the store — proving Set (not just
-	// Inc) re-materialised it via the setFilling repair.
+	// Inc) re-materialized it via the setFilling repair.
 	if _, _, err := cxds.Get(staticHash, 0); err != nil {
 		t.Fatalf("staticHash should be restored by the setFilling repair: %v", err)
 	}

--- a/pkg/transport-discovery/cxoaggregator/targeted_fetch_test.go
+++ b/pkg/transport-discovery/cxoaggregator/targeted_fetch_test.go
@@ -33,7 +33,11 @@ func newInMemNode(t *testing.T) *node.Node {
 	if err != nil {
 		t.Fatalf("NewNode: %v", err)
 	}
-	t.Cleanup(func() { _ = n.Close() })
+	t.Cleanup(func() {
+		if err := n.Close(); err != nil {
+			t.Logf("node close: %v", err)
+		}
+	})
 	return n
 }
 
@@ -50,7 +54,11 @@ func buildBigRoot(t *testing.T, nTransports, nTelemetry int) (*skyobject.Contain
 	if err != nil {
 		t.Fatalf("treestore.New: %v", err)
 	}
-	t.Cleanup(func() { _ = pub.Close() })
+	t.Cleanup(func() {
+		if err := pub.Close(); err != nil {
+			t.Logf("publisher close: %v", err)
+		}
+	})
 
 	// tp-list: the full transport set as one inlined snapshot leaf, compact form.
 	compact := make([]transport.CompactEntry, 0, nTransports)
@@ -69,7 +77,10 @@ func buildBigRoot(t *testing.T, nTransports, nTelemetry int) (*skyobject.Contain
 	// A bulky telemetry subtree: this is the part whose whole-Root fill
 	// times out in production. The targeted fetch must NOT need any of it.
 	for i := 0; i < nTelemetry; i++ {
-		snap, _ := json.Marshal(liveSnapshot{SentBytes: uint64(i), RecvBytes: uint64(i), SampledAt: time.Now().UTC(), Type: "stcpr"})
+		snap, err := json.Marshal(liveSnapshot{SentBytes: uint64(i), RecvBytes: uint64(i), SampledAt: time.Now().UTC(), Type: "stcpr"})
+		if err != nil {
+			t.Fatalf("marshal telemetry: %v", err)
+		}
 		path := fmt.Sprintf("transports/%040x-telemetry-%d/current", i, i)
 		if err := pub.Put(path, snap); err != nil {
 			t.Fatalf("Put telemetry: %v", err)
@@ -219,7 +230,11 @@ func TestTargetedFetchMissingLeafCleanMiss(t *testing.T) {
 	if err != nil {
 		t.Fatalf("treestore.New: %v", err)
 	}
-	t.Cleanup(func() { _ = pub.Close() })
+	t.Cleanup(func() {
+		if err := pub.Close(); err != nil {
+			t.Logf("publisher close: %v", err)
+		}
+	})
 	// Only telemetry, no tp-list leaf.
 	if err := pub.Put("transports/deadbeef/current", []byte(`{"sent_bytes":1,"recv_bytes":1}`)); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
`make check` (golangci-lint: errcheck with check-blank, misspell, unparam) was red on develop from recently-merged PRs. Mechanical fixes only, no behavior change:

- `cxoaggregator/targeted_fetch_test.go` — check the discarded `n.Close`/`pub.Close`/`json.Marshal` errors.
- `cxo/skyobject/cache.go`, `cxo/treestore/publisher.go`, `publisher_filling_trap_test.go` — US spelling (materialize/localizes).
- `skywire-cli/commands/proxy/mux_plot.go` — drop the unused `cmd` param on `runMuxPlotInfoStream`.

golangci-lint clean on the touched packages; `go build`/`go vet` green.