### PR TITLE
feat(routeviz): route visualizer scaffold — live per-leg route view + /route-mux HTTP seam

### DIFF
--- a/docs/design/route-visualizer.md
+++ b/docs/design/route-visualizer.md
@@ -1,0 +1,168 @@
+# Route Visualizer + Route-Selection UI
+
+Status: **design + first-increment scaffold**. This document describes a
+ROUTE-oriented view for skywire — distinct from, but modeled on, the existing
+network (transport-graph) visualizer — and lands a minimal working slice that
+proves the live per-leg data pipeline into a browser.
+
+## 1. Motivation
+
+The network visualizer (`pkg/tpviz`, mounted at `/tp-viz`, and the Angular
+`network-visualizer` host that embeds its bundle) renders the **transport
+graph**: undirected edges between visor nodes, keyed by transport type. It is a
+topology view. It does *not* render **routes** — the actual multi-hop
+forward/reverse paths a session uses to reach a destination.
+
+We now have rich per-route, per-leg data that nothing visual consumes:
+
+- The adaptive mux runs **multiple parallel legs** (routes) inside one route
+  group, each with its own transport, latency, and live byte/packet counters.
+- Legs carry a **gate state**: `alive` (transport up) and `standby` (a warm
+  standby — rules kept, not currently sending; see
+  `docs/warm_standby_legs_rfc.md`). The routing-policy engine promotes/demotes
+  these adaptively.
+- Operators already actuate route sets from the CLI
+  (`cli proxy mux add/rm/set/grow`, `cli route calc|find`), and the
+  routing-policy `ForwardMux`/`ReverseMux` surfaces pick legs by policy.
+
+The goal is a view that, for a chosen destination/app, shows the route group's
+legs as paths — per-leg next-hop/intermediate PKs, transport kind, latency,
+bandwidth, and active/standby/dead state — updating live, with a seam for a
+future route-**selection** UI (pick/pin which route(s) a session uses, exclude
+hops).
+
+## 2. Available data (what already exists)
+
+The data plane is essentially complete; the gap is *exposure* and *rendering*.
+
+| Data | Type | Reachable via | Notes |
+|------|------|---------------|-------|
+| Per-leg live telemetry | `router.MuxInfo` / `visor.MuxRouteGroupInfo` + `MuxLegInfo` | `Visor.RouteGroupMuxInfo(app)` RPC | per-leg tp id/type, next-hop `remote_pk`, `latency_ms`, sent/recv bytes+packets, `retransmits`, `alive`, `standby` |
+| Active routes by app | `visor.AppRouteStatus` / `router.RouteStatus` | `Visor.ActiveRoutes()` RPC | per-app; rg bandwidth up/down, `RouteTransport[]` (per-leg fwd/rev rule IDs + latency), `Hops[]` |
+| Route groups + hop path | `visor.RouteGroupInfo` + `RouteHopInfo` | `Visor.RouteGroups()` RPC → **HTTP** `/api/visors/{pk}/routegroups` | descriptor, initiator, fwd/consume rule IDs, forward hop path |
+| Route candidates | route-finder / local BFS | HTTP `/api/visors/{pk}/route-find`, `/route-calc` | hop lists ready to draw (candidate routes) |
+| Routing policy state | `RoutingPoliciesSummary` | HTTP `/api/visors/{pk}/routing-policies` | default + per-app policy |
+| Actuation | — | RPC `AddMuxRoute` / `RemoveMuxRoute` / `GrowMuxRoute`; `cli proxy mux add/rm/grow`; policy `ForwardMux`/`ReverseMux` | the seam for route-selection |
+
+Key source files:
+
+- `pkg/router/route_group.go` — `MuxInfo`, `MuxLeg`, `MuxStats()`,
+  `RouteHopDetails()`.
+- `pkg/router/route_status.go` — `RouteStatus`, `RouteTransport`,
+  `ActiveRouteStatuses()`.
+- `pkg/visor/api_routing.go` — `RouteGroupMuxInfo`, `ActiveRoutes`,
+  `RouteGroups`, `AddMuxRoute`, `GrowMuxRoute`, `RemoveMuxRoute`.
+- `pkg/visor/rpc.go` / `api.go` — wire types (`MuxRouteGroupInfo`,
+  `MuxLegInfo`, `RouteGroupInfo`, `RouteHopInfo`, `AppRouteStatus`).
+- `pkg/visor/hypervisor.go` + `hypervisor_handlers_routes.go` — HTTP surface.
+- `cmd/skywire-cli/commands/proxy/mux_info.go` — the CLI's per-leg render +
+  byte-delta rate tracker (reference model for the page).
+
+### Two data gaps
+
+1. **No HTTP seam for live per-leg telemetry.** `RouteGroupMuxInfo` and
+   `ActiveRoutes` were RPC-only; `/routegroups` gives the static hop path but
+   not the live mux legs. → **Closed by this increment** (new
+   `/api/visors/{pk}/route-mux`).
+2. **No per-leg full path.** `RouteHopDetails()` records only the *primary*
+   leg's `forwardHops`; secondary mux legs expose only their **next-hop**
+   `remote_pk`, not their full intermediate-PK chain. A true per-leg
+   path-over-graph render needs the router to record each leg's hop list.
+   This lives in `pkg/router` and is **designed-only / deferred** here.
+
+## 3. Design
+
+### 3.1 The route view
+
+For a selected **(visor, app)** — and, when disambiguation is needed, a
+specific route group by src-port:
+
+- **Route-group cards.** One card per active rg: `src:port → dst:port`, mux
+  on/off, SACK on/off, leg count.
+- **Per-leg rows.** leg index · transport-type badge + short tp id · next-hop
+  PK · latency · recv/s · sent/s · **share bar** (this leg's fraction of rg
+  throughput) · retransmits · **gate-state pill** (active / warm-standby /
+  dead) · cumulative recv/sent. Rates are derived from byte deltas between
+  polls, keyed by `rg-descriptor#leg-index` (the model already proven in
+  `mux_info.go`).
+- **Per-leg mini-path.** `SRC ──(tp)──▶ next-hop ┄┄▶ DST`. Upgrades to a full
+  intermediate-PK chain once gap #2 is closed.
+
+**Full feature (designed):** a route-centric *graph* layout — the rg's legs
+drawn as coloured paths over the node graph (active solid, standby dashed,
+dead greyed), reusing tpviz's node-positioning. Candidate routes from
+`/route-find` and `/route-calc` overlay as selectable ghost paths. Live
+recolour from the same poll.
+
+### 3.2 The route-selection seam (designed)
+
+The view is the read side of a select/actuate loop whose write side already
+exists:
+
+- **Pin / add a leg:** `AddMuxRoute(app, fwd, rev, srcPort)` — hop lists have
+  the exact shape `cli route calc --json` emits. UI: pick a candidate path
+  from the `/route-find|/route-calc` overlay → POST it as a new leg.
+- **Grow for redundancy:** `GrowMuxRoute(app, target, minHops, srcPort)`.
+- **Drop / exclude a leg or hop:** `RemoveMuxRoute(app, tpID, srcPort)`;
+  hop-exclusion is expressed to the route planner as a constraint (future).
+- **Policy-level pin:** the routing-policy `ForwardMux`/`ReverseMux` primitives
+  express "prefer/require these legs" declaratively; the UI can emit a policy
+  rather than one-shot mux edits. (Policy authoring is owned by another effort
+  — this view only *reads* policy state and offers the imperative mux edits.)
+
+New HTTP writes needed for the full selection UI (thin wrappers over existing
+RPC, mirroring `postMinHops`): `POST /api/visors/{pk}/route-mux` (add leg),
+`DELETE …/route-mux/{tpID}` (drop leg), `POST …/route-mux/grow`. Not in this
+increment.
+
+### 3.3 Where it belongs
+
+| Option | Fit | Cost |
+|--------|-----|------|
+| **Angular HV UI** (`routing.component.ts` already models `groups/find/calc/policies`) | Natural long-term home; where routes are managed and where selection/actuation belongs | Heavy: `make build-ui` (minutes) + committed bundle gated by `make check-ui`; eager (non-lazy) modules |
+| **tpviz bundle** (`pkg/tpviz/ui`) | Owns node-graph rendering → best for the path-over-graph layout | Large TS/esbuild SPA; separate committed bundle |
+| **Standalone visor-served page** (`/route-viz`) | Zero build step, self-contained, instantly iterable | Not integrated into the SPA chrome |
+| wasm-visor UI | Browser-native visor context | wasm build/size overhead |
+
+**Recommendation.** Land the **standalone `/route-viz` page** first (this
+increment) to prove the pipeline with no build cost, then graduate the
+route-**selection** actuation + the path-over-graph layout into the **Angular
+`routing` page** (its `RoutingView` already has a slot; add a `'mux'` /
+`'routeviz'` view and reuse `route.service.ts`), embedding the tpviz bundle for
+the graph exactly as `network-visualizer.component.ts` does. The standalone
+page remains the lightweight/headless diagnostic surface.
+
+## 4. First increment (this PR) — what is scaffolded vs designed
+
+**Scaffolded (working):**
+
+- `GET /api/visors/{pk}/route-mux?app=<name>` — new hypervisor HTTP handler
+  (`getRouteMux`, `pkg/visor/hypervisor_handlers_routes.go`) wrapping
+  `RouteGroupMuxInfo`. First browser-reachable seam for live per-leg route
+  telemetry. Read-only.
+- `/route-viz` — self-contained embedded page (`pkg/visor/routeviz/routeviz.html`,
+  served by `getRouteViz`, `pkg/visor/routeviz_embed.go`). Visor + app pickers,
+  live poll, per-leg rows with rate/share/gate-state, per-leg mini-path. No
+  Angular/tpviz rebuild.
+
+**Designed-only (deferred):**
+
+- Route-over-graph layout (needs tpviz node positioning + gap #2).
+- Per-leg full intermediate-PK path (needs `pkg/router` to record each leg's
+  hop list — out of scope; that package is owned elsewhere).
+- Route-**selection** write actions (add/drop/grow legs, hop exclusion) and
+  their HTTP wrappers.
+- Candidate-route overlay from `/route-find` + `/route-calc`.
+- Promotion into the Angular `routing` page.
+
+## 5. Try it
+
+```
+# on a hypervisor/visor with the manager UI:
+#   open  http://<hv-host>:8000/route-viz
+#   pick a visor + app (default skysocks-client), watch legs update live
+# raw data:
+curl -s http://<hv>/api/visors/<pk>/route-mux?app=skysocks-client | jq
+# CLI equivalent (the render model this page mirrors):
+skywire-cli proxy mux info -n skysocks-client --watch 1s
+```

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -854,6 +854,7 @@ func (hv *Hypervisor) makeMux() chi.Router {
 				r.Delete("/visors/{pk}/routes/{rid}", hv.deleteRoute())
 				r.Delete("/visors/{pk}/routes/", hv.deleteRoutes())
 				r.Get("/visors/{pk}/routegroups", hv.getRouteGroups())
+				r.Get("/visors/{pk}/route-mux", hv.getRouteMux())
 				r.Get("/visors/{pk}/routing-policies", hv.getRoutingPolicies())
 				r.Post("/visors/{pk}/shutdown", hv.shutdown())
 				r.Post("/visors/{pk}/restart", hv.restart())
@@ -1073,6 +1074,14 @@ func (hv *Hypervisor) makeMux() chi.Router {
 			r.Get("/api/dmsg/entries", tpvHandler.ServeHTTP)
 			r.Get("/api/dmsg/health", tpvHandler.ServeHTTP)
 		}
+
+		// Route visualizer: a self-contained static page (no Angular build)
+		// that live-renders an app's active route group(s) per-leg from the
+		// /api/visors/{pk}/route-mux endpoint. Mounted before the SPA catch-all
+		// so /route-viz is claimed here; the page fetches the authed /api same
+		// origin. See docs/design/route-visualizer.md.
+		r.Get("/route-viz", hv.getRouteViz())
+		r.Get("/route-viz/", hv.getRouteViz())
 
 		// HV-served skycoin wallet: embedded /wallet/ static + node API proxied
 		// over the visor's dmsg client — no skycoin-web process/port, the native

--- a/pkg/visor/hypervisor_handlers_routes.go
+++ b/pkg/visor/hypervisor_handlers_routes.go
@@ -192,6 +192,36 @@ func (hv *Hypervisor) getRouteGroups() http.HandlerFunc {
 	})
 }
 
+// getRouteMux surfaces live per-mux-leg route telemetry for one app's
+// active route group(s) over HTTP — the browser-reachable seam behind the
+// route visualizer (/route-viz). It wraps the visor's RouteGroupMuxInfo RPC,
+// which until now was only reachable from `cli proxy mux info`.
+//
+//	GET /api/visors/{pk}/route-mux?app=<name>   (app defaults to skysocks-client)
+//
+// Each returned route group carries its descriptor plus a per-leg list with
+// transport id/type, next-hop PK, smoothed latency, rg-scoped byte/packet
+// counters, SACK retransmits, and the leg's alive/standby gate state — enough
+// for the page to render the legs live and derive throughput from the byte
+// deltas between polls.
+func (hv *Hypervisor) getRouteMux() http.HandlerFunc {
+	return hv.withCtx(hv.visorCtx, func(w http.ResponseWriter, r *http.Request, ctx *httpCtx) {
+		app := r.URL.Query().Get("app")
+		if app == "" {
+			app = "skysocks-client"
+		}
+		infos, err := ctx.API.RouteGroupMuxInfo(app)
+		if err != nil {
+			httputil.WriteJSON(w, r, http.StatusInternalServerError, err)
+			return
+		}
+		if infos == nil {
+			infos = []MuxRouteGroupInfo{}
+		}
+		httputil.WriteJSON(w, r, http.StatusOK, infos)
+	})
+}
+
 // getRoutingPolicies surfaces the installed routing-policy state
 // for the hypervisor UI's routing tab. Returns
 // {default?, per_app: {appName: PolicyInfo}}.

--- a/pkg/visor/routeviz/routeviz.html
+++ b/pkg/visor/routeviz/routeviz.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Skywire Route Visualizer</title>
+<style>
+  :root {
+    --bg:#f6f7f9; --panel:#ffffff; --ink:#1a1d21;
+    --muted:#6b7280; --line:#e3e6ea; --accent:#3f6fff; --accent-ink:#fff;
+    --active:#12a150; --standby:#c98a00; --dead:#d13438;
+    --stcp:#3f6fff; --stcpr:#8a5cf6; --sudp:#0ea5a4; --dmsg:#e0731d; --other:#6b7280;
+    --shadow:0 1px 2px rgba(0,0,0,.06),0 2px 8px rgba(0,0,0,.05);
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+  }
+  @media (prefers-color-scheme:dark){
+    :root{ --bg:#14171c; --panel:#1c2027; --ink:#e6e9ee; --muted:#9aa3af;
+      --line:#2a2f38; --accent:#5b83ff; --shadow:0 1px 2px rgba(0,0,0,.3); }
+  }
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);background:var(--bg);color:var(--ink);font-size:14px;line-height:1.45}
+  header{position:sticky;top:0;z-index:5;background:var(--panel);border-bottom:1px solid var(--line);
+    padding:12px 20px;display:flex;flex-wrap:wrap;gap:14px;align-items:center;box-shadow:var(--shadow)}
+  h1{font-size:16px;margin:0;font-weight:650;letter-spacing:.2px}
+  h1 .tag{font-size:10px;font-weight:600;color:var(--accent);border:1px solid var(--accent);
+    border-radius:4px;padding:1px 5px;margin-left:8px;vertical-align:middle;text-transform:uppercase;letter-spacing:.5px}
+  .ctrls{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin-left:auto}
+  label{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:2px}
+  select,input{font-family:inherit;font-size:13px;padding:5px 8px;border:1px solid var(--line);
+    border-radius:6px;background:var(--bg);color:var(--ink)}
+  select{min-width:190px}
+  input[type=text]{width:150px}
+  input[type=number]{width:70px}
+  button{font-family:inherit;font-size:13px;padding:6px 12px;border:1px solid var(--line);border-radius:6px;
+    background:var(--accent);color:var(--accent-ink);cursor:pointer;font-weight:600}
+  button.ghost{background:var(--bg);color:var(--ink)}
+  main{padding:20px;max-width:1180px;margin:0 auto}
+  .status{font-size:12px;color:var(--muted);margin-bottom:14px;display:flex;gap:14px;align-items:center;flex-wrap:wrap}
+  .dot{width:8px;height:8px;border-radius:50%;display:inline-block;background:var(--muted)}
+  .dot.live{background:var(--active);box-shadow:0 0 0 3px rgba(18,161,80,.18)}
+  .empty{padding:48px 20px;text-align:center;color:var(--muted);border:1px dashed var(--line);border-radius:10px}
+  .rg{background:var(--panel);border:1px solid var(--line);border-radius:10px;box-shadow:var(--shadow);
+    margin-bottom:18px;overflow:hidden}
+  .rg-head{padding:12px 16px;border-bottom:1px solid var(--line);display:flex;gap:14px;align-items:baseline;flex-wrap:wrap}
+  .rg-desc{font-family:var(--mono);font-size:13px;font-weight:600}
+  .rg-meta{font-size:12px;color:var(--muted);display:flex;gap:12px;flex-wrap:wrap}
+  .pill{font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.4px;
+    padding:2px 7px;border-radius:100px;color:#fff;white-space:nowrap}
+  .pill.active{background:var(--active)} .pill.standby{background:var(--standby)} .pill.dead{background:var(--dead)}
+  table{width:100%;border-collapse:collapse;font-size:13px}
+  th{text-align:left;font-size:10.5px;text-transform:uppercase;letter-spacing:.4px;color:var(--muted);
+    font-weight:600;padding:8px 12px;border-bottom:1px solid var(--line);white-space:nowrap}
+  td{padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:middle}
+  tr:last-child td{border-bottom:none}
+  .mono{font-family:var(--mono);font-size:12.5px}
+  .tp{font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.3px;
+    padding:2px 7px;border-radius:5px;color:#fff}
+  .tp.stcp{background:var(--stcp)} .tp.stcpr{background:var(--stcpr)} .tp.sudp{background:var(--sudp)}
+  .tp.dmsg{background:var(--dmsg)} .tp.other{background:var(--other)}
+  .share{position:relative;min-width:90px}
+  .share .bar{height:6px;border-radius:3px;background:var(--accent);opacity:.85}
+  .share .track{height:6px;border-radius:3px;background:var(--line)}
+  .share span{font-size:11px;color:var(--muted)}
+  .path{font-family:var(--mono);font-size:12px;color:var(--muted);padding:6px 16px 12px;display:flex;
+    align-items:center;gap:6px;flex-wrap:wrap}
+  .path b{color:var(--ink)} .path .arrow{color:var(--accent)}
+  .num{font-variant-numeric:tabular-nums}
+  .err{color:var(--dead);font-size:12px}
+  .foot{font-size:11.5px;color:var(--muted);margin-top:24px;line-height:1.6}
+  code{font-family:var(--mono);background:var(--bg);padding:1px 5px;border-radius:4px;border:1px solid var(--line)}
+</style>
+</head>
+<body>
+<header>
+  <h1>Route Visualizer <span class="tag">scaffold</span></h1>
+  <div class="ctrls">
+    <div><label for="visor">Visor</label><select id="visor"></select></div>
+    <div><label for="app">App</label><input id="app" type="text" list="apps" value="skysocks-client"><datalist id="apps"></datalist></div>
+    <div><label for="iv">Refresh</label><input id="iv" type="number" min="0" step="0.5" value="1"> s</div>
+    <div><label>&nbsp;</label><button id="pause" class="ghost">Pause</button></div>
+  </div>
+</header>
+<main>
+  <div class="status">
+    <span><span class="dot" id="livedot"></span> <span id="statustxt">starting…</span></span>
+    <span id="polltxt"></span>
+  </div>
+  <div id="out"></div>
+  <div class="foot">
+    <b>What this shows.</b> Each card is one active <em>route group</em> for the selected app; each row is a
+    <em>mux leg</em> — a parallel route to the same destination. Rates are derived from the byte deltas between
+    polls (rg-scoped, this visor's view). Gate state: <span class="pill active">active</span>
+    <span class="pill standby">warm standby</span> <span class="pill dead">dead</span>.<br>
+    <b>Scaffold scope.</b> Data source is the live <code>/api/visors/{pk}/route-mux</code> endpoint
+    (RouteGroupMuxInfo). Per-leg rows show the leg's <em>next-hop</em> PK + transport; full multi-hop
+    per-leg paths and a route-over-graph layout are designed but not yet wired
+    (see <code>docs/design/route-visualizer.md</code>).
+  </div>
+</main>
+<script>
+(function(){
+  const $ = s => document.querySelector(s);
+  const visorSel=$('#visor'), appIn=$('#app'), ivIn=$('#iv'), pauseBtn=$('#pause'),
+        out=$('#out'), statustxt=$('#statustxt'), polltxt=$('#polltxt'), livedot=$('#livedot'),
+        appsList=$('#apps');
+  let timer=null, paused=false, prev=new Map(), prevAt=0;
+
+  const shortPK = pk => !pk?'?':(pk.length<=12?pk:pk.slice(0,6)+'…'+pk.slice(-4));
+  const shortTp = id => !id?'-':(id.length<=10?id:id.slice(0,8)+'…');
+  const tpClass = t => ['stcp','stcpr','sudp','dmsg'].includes((t||'').toLowerCase())?(t||'').toLowerCase():'other';
+  function human(n){ n=+n||0; const u=['B','K','M','G','T']; let i=0; while(n>=1024&&i<u.length-1){n/=1024;i++;} return (i?n.toFixed(1):n.toFixed(0))+u[i]; }
+  function rate(bps){ return bps>0? human(bps)+'/s':'0B/s'; }
+
+  async function loadVisors(){
+    try{
+      const r=await fetch('/api/visors',{credentials:'same-origin'});
+      const v=await r.json();
+      visorSel.innerHTML='';
+      (v||[]).forEach(o=>{
+        const pk=o.local_pk||o.public_key||''; if(!pk) return;
+        const opt=document.createElement('option'); opt.value=pk;
+        opt.textContent=shortPK(pk)+(o.hostname?(' · '+o.hostname):'');
+        visorSel.appendChild(opt);
+        opt._apps=(o.apps||[]).map(a=>a.name).filter(Boolean);
+      });
+      onVisorChange();
+    }catch(e){ statustxt.innerHTML='<span class="err">could not list visors: '+e+'</span>'; }
+  }
+  function onVisorChange(){
+    const opt=visorSel.selectedOptions[0];
+    appsList.innerHTML='';
+    (opt&&opt._apps||['skysocks-client','vpn-client']).forEach(n=>{
+      const o=document.createElement('option'); o.value=n; appsList.appendChild(o);
+    });
+  }
+
+  function render(rgs){
+    if(!rgs||!rgs.length){ out.innerHTML='<div class="empty">No active route group for <b>'+appIn.value+'</b> on this visor.<br>Start the app and generate traffic, then it appears here.</div>'; prev.clear(); return; }
+    const now=Date.now()/1000, elapsed=now-prevAt, haveRates=prevAt>0&&elapsed>0, next=new Map();
+    let html='';
+    rgs.forEach((rg,ri)=>{
+      const d=rg.desc||{}, key=`${d.src_pk}:${d.src_port}>${d.dst_pk}:${d.dst_port}`;
+      const legs=(rg.legs||[]).slice().sort((a,b)=>a.index-b.index);
+      // pass 1: rates + totals
+      let totR=0,totS=0; const rr=[],sr=[];
+      legs.forEach((l,i)=>{
+        const k=key+'#'+l.index, p=prev.get(k);
+        let r=0,s=0;
+        if(haveRates&&p){ if(l.recv_bytes>=p.r) r=(l.recv_bytes-p.r)/elapsed; if(l.sent_bytes>=p.s) s=(l.sent_bytes-p.s)/elapsed; }
+        rr[i]=r; sr[i]=s; totR+=r; totS+=s; next.set(k,{r:l.recv_bytes,s:l.sent_bytes});
+      });
+      let active=0;
+      html+='<div class="rg"><div class="rg-head">'+
+        '<span class="rg-desc">'+shortPK(d.src_pk)+':'+d.src_port+' <span class="path arrow" style="padding:0">→</span> '+shortPK(d.dst_pk)+':'+d.dst_port+'</span>'+
+        '<span class="rg-meta"><span>mux '+(rg.mux_enabled?'on':'off')+'</span><span>sack '+(rg.sack_enabled?'on':'off')+'</span><span>'+legs.length+' leg'+(legs.length!=1?'s':'')+'</span></span></div>';
+      html+='<table><thead><tr><th>Leg</th><th>Transport</th><th>Next hop</th><th>Latency</th><th class="num">Recv/s</th><th class="num">Sent/s</th><th>Share</th><th class="num">Retx</th><th>State</th><th class="num">Recv</th><th class="num">Sent</th></tr></thead><tbody>';
+      legs.forEach((l,i)=>{
+        const gate = !l.alive?['dead','dead']:(l.standby?['standby','standby']:['active','active']);
+        if(gate[0]==='active'&&(rr[i]>0||sr[i]>0)) active++;
+        const share = totR>0? Math.round(rr[i]/totR*100):0;
+        html+='<tr>'+
+          '<td class="mono">'+l.index+'</td>'+
+          '<td><span class="tp '+tpClass(l.tp_type)+'">'+(l.tp_type||'?')+'</span> <span class="mono" style="color:var(--muted)">'+shortTp(l.transport_id)+'</span></td>'+
+          '<td class="mono">'+shortPK(l.remote_pk)+'</td>'+
+          '<td class="num">'+(l.latency_ms>0?Math.round(l.latency_ms)+'ms':'–')+'</td>'+
+          '<td class="num">'+(haveRates?rate(rr[i]):'–')+'</td>'+
+          '<td class="num">'+(haveRates?rate(sr[i]):'–')+'</td>'+
+          '<td class="share">'+(haveRates?('<div class="track"><div class="bar" style="width:'+share+'%"></div></div><span>'+share+'%</span>'):'<span>–</span>')+'</td>'+
+          '<td class="num">'+(l.retransmits||0)+'</td>'+
+          '<td><span class="pill '+gate[0]+'">'+gate[1]+'</span></td>'+
+          '<td class="num">'+human(l.recv_bytes)+'</td>'+
+          '<td class="num">'+human(l.sent_bytes)+'</td>'+
+          '</tr>';
+      });
+      html+='</tbody></table>';
+      // per-leg mini route path (SRC → next-hop → DST); full intermediate path is a design gap.
+      legs.forEach(l=>{
+        html+='<div class="path"><b>'+shortPK(d.src_pk)+'</b><span class="arrow">──('+(l.tp_type||'?')+')──▶</span><b>'+shortPK(l.remote_pk)+'</b><span class="arrow">┄┄▶</span><b>'+shortPK(d.dst_pk)+'</b> <span>leg '+l.index+'</span></div>';
+      });
+      if(haveRates) html+='<div class="path">total recv/s '+rate(totR)+' · sent/s '+rate(totS)+' · '+active+'/'+legs.length+' legs active</div>';
+      html+='</div>';
+    });
+    out.innerHTML=html; prev=next; prevAt=now;
+  }
+
+  async function poll(){
+    const pk=visorSel.value; if(!pk){ return; }
+    const app=encodeURIComponent(appIn.value||'skysocks-client');
+    try{
+      const r=await fetch('/api/visors/'+pk+'/route-mux?app='+app,{credentials:'same-origin'});
+      if(!r.ok){ throw new Error('HTTP '+r.status); }
+      const data=await r.json();
+      render(data);
+      livedot.classList.add('live'); statustxt.textContent='connected'; polltxt.textContent='updated '+new Date().toLocaleTimeString();
+    }catch(e){
+      livedot.classList.remove('live'); statustxt.innerHTML='<span class="err">'+e+'</span>';
+    }
+  }
+  function schedule(){
+    if(timer) clearInterval(timer); timer=null;
+    const s=parseFloat(ivIn.value); if(paused||!(s>0)) return;
+    timer=setInterval(poll, s*1000);
+  }
+  visorSel.addEventListener('change',()=>{ onVisorChange(); prev.clear(); prevAt=0; poll(); });
+  appIn.addEventListener('change',()=>{ prev.clear(); prevAt=0; poll(); });
+  ivIn.addEventListener('change',schedule);
+  pauseBtn.addEventListener('click',()=>{ paused=!paused; pauseBtn.textContent=paused?'Resume':'Pause'; schedule(); if(!paused) poll(); });
+
+  loadVisors().then(()=>{ poll(); schedule(); });
+})();
+</script>
+</body>
+</html>

--- a/pkg/visor/routeviz_embed.go
+++ b/pkg/visor/routeviz_embed.go
@@ -1,0 +1,25 @@
+// Package visor pkg/visor/routeviz_embed.go c3-vis-core
+package visor
+
+import (
+	_ "embed"
+	"net/http"
+)
+
+// routeVizHTML is the self-contained route-visualizer page (vanilla JS, no
+// build step). Served at /route-viz; it fetches /api/visors and
+// /api/visors/{pk}/route-mux same-origin to live-render an app's active
+// route group(s) per leg. See docs/design/route-visualizer.md.
+//
+//go:embed routeviz/routeviz.html
+var routeVizHTML []byte
+
+// getRouteViz serves the embedded route-visualizer page. Static, no auth of
+// its own — the data it fetches (/api/...) carries the hypervisor's auth.
+func (hv *Hypervisor) getRouteViz() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		_, _ = w.Write(routeVizHTML)
+	}
+}

--- a/pkg/visor/routeviz_embed_test.go
+++ b/pkg/visor/routeviz_embed_test.go
@@ -1,0 +1,37 @@
+//go:build !mobile
+
+package visor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGetRouteViz checks the embedded route-visualizer page is served with the
+// right content-type and carries its data-endpoint + telemetry field wiring, so
+// a rename of the /route-mux seam or the MuxLegInfo JSON tags is caught here.
+func TestGetRouteViz(t *testing.T) {
+	hv := &Hypervisor{}
+	w := httptest.NewRecorder()
+	hv.getRouteViz()(w, httptest.NewRequest(http.MethodGet, "/route-viz", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+		t.Errorf("Content-Type=%q, want text/html", ct)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"/api/visors/",            // visor list fetch
+		"/route-mux?app=",         // the live per-leg data endpoint
+		"remote_pk", "latency_ms", // MuxLegInfo JSON contract the page renders
+		"standby", "retransmits", // gate-state + loss signal
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("route-viz page missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## What

A **ROUTE-oriented view**, distinct from the transport-graph network visualizer (`pkg/tpviz`). For a chosen **(visor, app)** it live-renders each active **route group's mux legs** — the parallel routes to the destination — as a per-leg table: transport kind, next-hop PK, latency, recv/sent rate + share, retransmits, and **alive / warm-standby / dead** gate state.

This is primarily **design + a scaffolded first increment**, not a finished visualizer. It proves the live per-leg data pipeline into a browser with no UI rebuild.

## Changes

- **`getRouteMux`** — new hypervisor HTTP handler exposing `RouteGroupMuxInfo` at `GET /api/visors/{pk}/route-mux?app=<name>`. The per-leg mux telemetry was previously reachable only from `cli proxy mux info` (RPC-only); this is the first browser-reachable seam for live per-leg route data.
- **`/route-viz`** — self-contained embedded page (`pkg/visor/routeviz/routeviz.html`, vanilla JS, no Angular/tpviz build step). Visor + app pickers, live poll, per-leg rows with byte-delta rate/share (the render model from `cmd/skywire-cli/commands/proxy/mux_info.go`), gate-state pills, per-leg mini-path.
- **`docs/design/route-visualizer.md`** — design note: available route data, the two data gaps, the route-**selection** actuation seam (`AddMuxRoute`/`GrowMuxRoute`/`RemoveMuxRoute` + policy `ForwardMux`/`ReverseMux`), and the recommended long-term home.

## Scaffolded vs designed-only

**Scaffolded (working):** the `/route-mux` HTTP endpoint + the live `/route-viz` per-leg page + a handler test.

**Designed-only (deferred):** route-over-graph layout; per-leg *full* intermediate-PK path (needs `pkg/router` to record each leg's hop list — out of scope here); route-selection write actions; candidate-route overlay from `/route-find`+`/route-calc`; promotion into the Angular `routing` page.

## Recommended home

Standalone `/route-viz` now (zero build cost, iterable); graduate the selection actuation + path-over-graph layout into the Angular `routing` page (its `RoutingView` already has a slot) embedding the tpviz bundle for the graph. Rationale in the design note.

## Scope / safety

Read-only and additive. **No changes to `pkg/router` or routing policy.** `go build .` green; `go vet` + `gofmt` clean; `TestGetRouteViz` passes.

## Try it

```
open http://<hv-host>:8000/route-viz     # pick a visor + app, watch legs update live
curl -s http://<hv>/api/visors/<pk>/route-mux?app=skysocks-client | jq
skywire-cli proxy mux info -n skysocks-client --watch 1s   # the CLI render this mirrors
```