### PR TITLE
feat(proxy): per-proxy status hosts + HTTPS interstitial permit-gate

### DIFF
--- a/docs/proxy-status-and-interstitial.md
+++ b/docs/proxy-status-and-interstitial.md
@@ -1,0 +1,80 @@
+# Proxy status hosts + HTTPS interstitial
+
+Two related features on the embedded-web-proxy surface (`dmsg_web`,
+`skynet_web`, and the `skysocks-client` tunnel they chain to).
+
+## 1. Interstitial over HTTPS
+
+The branded "building a route over the mesh…" interstitial
+(`pkg/proxyinterstitial`) is injected by the resolving proxies' SOCKS5 `Dial`
+callback when a route to the target is still warming. For plaintext HTTP it is
+spliced in directly; for HTTPS it must ride a locally-terminated TLS session
+(TLS MITM) because a raw-TLS tunnel can't carry an HTML page.
+
+TLS termination uses a **name-constrained** local CA (`pkg/skynetca`) that can
+only mint leaves for `.skynet` and `.dmsg`. The live bug was that the HTTPS
+interstitial path attempted a mint for **every** TLS-port dial failure —
+including clearnet HTTPS forwarded to the upstream `skysocks-client` — which the
+CA can never cover, producing a `host does not match permitted suffix` error on
+every such request.
+
+Fix: `skynetca.Permits(minter, host)` (a non-breaking optional interface,
+`HostPermitter`, implemented by `CachedMinter`) reports whether the CA can cover
+a host **without** minting. The HTTPS-interstitial path in both resolving
+proxies now gates on it:
+
+```
+case cfg.TLSMITM && isTLSPort(port) && skynetca.Permits(cfg.LeafMinter, origHost):
+    // mint leaf, MITM-terminate, serve interstitial HTML over TLS
+```
+
+So a `.skynet`/`.dmsg` HTTPS target reliably renders the interstitial over TLS,
+while a clearnet HTTPS target (which cannot be MITM'd by a name-constrained CA
+anyway) cleanly falls through to the real error instead of a per-request log
+spam. The page itself gained a footer with a deep-link to the surface's status
+host (below).
+
+## 2. Per-proxy status hosts
+
+Each proxy serves a read-only diagnostic page at a reserved, well-known host
+**through itself**, mirroring the existing in-process `home.<suffix>` host:
+
+| host                | surface   | underlying app    |
+|---------------------|-----------|-------------------|
+| `http://status.dmsg/`      | dmsg     | `dmsgweb`          |
+| `http://status.skynet/`    | skynet   | `skynetweb`        |
+| `http://status.skysocks/`  | skysocks | `skysocks-client`  |
+
+`pkg/proxystatus` owns the surface taxonomy, host matcher (`Match`), the
+in-process HTTP responder (`ServeConn`, same net.Pipe trick as
+`serveHomeInProcess`), the read-only `Snapshot` shape + `Provider` interface, and
+the HTML renderer. Both resolving proxies' `Dial` callbacks check `Match(host)`
+**before** suffix resolution / upstream forwarding, so any of the three hosts is
+reachable through either proxy (a browser typically points at one).
+
+The visor implements `proxystatus.Provider`
+(`pkg/visor/embedded_proxystatus.go`) entirely on **existing** read APIs:
+
+- **logging** — `Visor.LogsSince(app)` tails the app's log store;
+- **mux view** — `Visor.RouteGroupMuxInfo(app)` gives the same per-leg
+  bandwidth/RTT/retransmit telemetry `cli proxy mux plot` renders, drawn as a
+  static per-leg bandwidth-share table (meta-refreshes to stay live);
+- **running** — `procManager.ProcByName(app)`.
+
+MVP status vs. scaffold:
+
+- **`status.skysocks`** is the fully-realized MVP (logs + live mux view for the
+  route group where multiplexing actually happens).
+- **`status.dmsg` / `status.skynet`** share the identical page; their mux
+  section is empty until/unless their route group is tagged for
+  `RouteGroupMuxInfo`.
+- **route/transport events** render an empty section today — the collection
+  buffer is the scaffolded extension point.
+
+### Extension seam: route control
+
+The MVP is deliberately read-only. The page renders a disabled "route control"
+section, and `Snapshot`/`Provider` are shaped so control lands additively: add a
+mutating method to `proxystatus.Provider` and implement it on the existing visor
+mux-reshape API (`AddMuxRoute` / `RemoveMuxRoute` / `SetMuxMode`) plus dmsg relay
+selection — no wire reshape, no new plumbing in the proxies.

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -40,6 +40,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/ioutil"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/proxyinterstitial"
+	"github.com/skycoin/skywire/pkg/proxystatus"
 	"github.com/skycoin/skywire/pkg/skynetca"
 	"github.com/skycoin/skywire/pkg/skynetweb"
 )
@@ -151,6 +152,13 @@ type Config struct {
 	DirectClient *dmsg.Client
 	// DirectServerPKs is the set of destination PKs to dial via DirectClient.
 	DirectServerPKs map[cipher.PubKey]struct{}
+
+	// StatusProvider, when non-nil, enables the reserved in-process status hosts
+	// (http://status.dmsg/ etc.) served through this proxy — a read-only
+	// diagnostic page (logs + route/transport events + per-leg mux view) for a
+	// surface. Nil disables the status hosts (they fall through to a normal
+	// resolve / upstream forward). See pkg/proxystatus.
+	StatusProvider proxystatus.Provider
 }
 
 // DmsgTarget is a (publicKey, dmsgPort) pair used in fixed-mapping mode.
@@ -312,6 +320,22 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 				origPort = "80"
 			}
 
+			// Reserved status hosts (http://status.dmsg/ etc.): served in-process,
+			// never dialed out — the read-only diagnostic page for a surface.
+			// Checked before suffix resolution / upstream forwarding so any of the
+			// three status hosts is reachable through this proxy. Recognized only on
+			// plaintext HTTP (a status page can't ride a raw-TLS tunnel).
+			if cfg.StatusProvider != nil && proxyinterstitial.ShouldServe(origPort) {
+				if surface, ok := proxystatus.Match(origHost); ok {
+					snap, serr := cfg.StatusProvider.StatusSnapshot(surface)
+					if serr != nil {
+						snap = proxystatus.Snapshot{Surface: surface, Note: "status unavailable: " + serr.Error()}
+					}
+					log.WithField("surface", string(surface)).Debug("SOCKS5 → serving in-process proxy status page")
+					return &tcpAddrConn{Conn: proxystatus.ServeConn(proxystatus.Render(snap))}, nil
+				}
+			}
+
 			// On a transient failure (dmsg route/session still warming, or a
 			// not-yet-ready upstream like a booting skysocks-client) for a
 			// plaintext-HTTP request, answer with a branded auto-refreshing
@@ -334,12 +358,16 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 					log.WithField("host", target).WithField("err", dialErr).
 						Debug("SOCKS5 → serving branded route interstitial")
 					conn, dialErr = proxyinterstitial.Conn(target, proxyinterstitial.StatusLine(dialErr), "dmsg", false), nil
-				case cfg.TLSMITM && isTLSPort(origPort, cfg.TLSPort):
+				case cfg.TLSMITM && isTLSPort(origPort, cfg.TLSPort) && skynetca.Permits(cfg.LeafMinter, origHost):
 					// HTTPS request whose route is still warming: terminate the
 					// browser's TLS locally with a per-host leaf and serve the
 					// interstitial HTML over it — same MITM path as a warm TLS
 					// dial, but the "upstream" is the fixed interstitial responder.
-					// If minting fails, fall through to the real error.
+					// Gated on Permits so a clearnet-HTTPS request (whose host the
+					// name-constrained CA can't cover) falls straight through to the
+					// real error instead of a guaranteed "does not match permitted
+					// suffix" mint failure on every attempt. If minting still fails,
+					// fall through to the real error.
 					leaf, lerr := cfg.LeafMinter.For(origHost)
 					if lerr != nil {
 						log.WithField("host", target).WithField("err", lerr).

--- a/pkg/proxyinterstitial/interstitial.go
+++ b/pkg/proxyinterstitial/interstitial.go
@@ -98,6 +98,16 @@ func Page(target, detail, mechanism string, isError bool) string {
 	// the exit is already selected, so the work is route-building, not
 	// "finding an exit". The fetch step names the concrete mechanism.
 	fetchStep := `<li>Fetching the page over ` + html.EscapeString(mech) + `</li>`
+
+	// Footer: a subtle brand line, plus a "view proxy status" affordance that
+	// deep-links to this surface's reserved diagnostic host (served in-process by
+	// the same proxy — see pkg/proxystatus). Only a concrete mechanism has a
+	// status host; the generic "skywire" fallback shows just the brand line.
+	footer := `<div class="foot">routed privately over the skywire mesh`
+	if h := statusHost(mech); h != "" {
+		footer += ` &middot; <a href="http://` + html.EscapeString(h) + `/">proxy status ›</a>`
+	}
+	footer += `</div>`
 	return `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
 		`<meta name="viewport" content="width=device-width, initial-scale=1">` +
 		refreshMeta +
@@ -115,7 +125,21 @@ func Page(target, detail, mechanism string, isError bool) string {
 		`</ul>` +
 		retry +
 		hostBlock +
+		footer +
 		`</div></div></body></html>`
+}
+
+// statusHost returns the reserved status host for a mechanism label
+// ("skysocks" → "status.skysocks"), or "" for the generic "skywire" fallback
+// (which has no dedicated surface). Kept local so this package stays
+// dependency-free; the value mirrors pkg/proxystatus.Host.
+func statusHost(mech string) string {
+	switch mech {
+	case "skysocks", "dmsg", "skynet":
+		return "status." + mech
+	default:
+		return ""
+	}
 }
 
 // skywireCloudPNG is the official Skycoin/Skywire striped-cloud brand mark
@@ -157,6 +181,8 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#7a80a8;--accent:#7c83ff;--
 	`.btn{display:inline-block;margin-top:18px;padding:8px 20px;border:1px solid var(--accent);border-radius:9px;background:transparent;color:var(--accent);font:inherit;font-size:13px;cursor:pointer}` +
 	`.btn:hover{background:var(--accent);color:#0b0d17}` +
 	`#mesh-host{display:block;margin-top:14px;font:12px/1.4 ui-monospace,SFMono-Regular,monospace;color:var(--muted);opacity:.75;word-break:break-all}` +
+	`.foot{margin-top:16px;padding-top:12px;border-top:1px solid var(--line);font-size:11.5px;color:var(--muted)}` +
+	`.foot a{color:var(--accent);text-decoration:none}.foot a:hover{text-decoration:underline}` +
 	`.err #mesh-title{color:var(--err)}.err .sp{display:none}`
 
 // httpResponse wraps the HTML in a minimal HTTP/1.1 response. Connection:close

--- a/pkg/proxyinterstitial/interstitial_test.go
+++ b/pkg/proxyinterstitial/interstitial_test.go
@@ -43,6 +43,20 @@ func TestPageEscapesTarget(t *testing.T) {
 	}
 }
 
+func TestPageStatusFooter(t *testing.T) {
+	// A concrete mechanism links to its reserved status host.
+	for _, mech := range []string{"skysocks", "dmsg", "skynet"} {
+		p := Page("host."+mech, "", mech, false)
+		if !strings.Contains(p, "http://status."+mech+"/") {
+			t.Errorf("mechanism %q: page missing status-host link", mech)
+		}
+	}
+	// The generic fallback has no dedicated surface, so no status link.
+	if p := Page("host", "", "", false); strings.Contains(p, "http://status.") {
+		t.Error("generic mechanism should not link a status host")
+	}
+}
+
 func TestConnServesHTTP(t *testing.T) {
 	c := Conn("host.skynet", "", "skynet", false)
 	// Write (the browser's request) is discarded but must not error.

--- a/pkg/proxystatus/provider.go
+++ b/pkg/proxystatus/provider.go
@@ -1,0 +1,146 @@
+// Package proxystatus pkg/proxystatus/provider.go c4-app-web
+//
+// A read-only, self-contained diagnostic page each native mesh proxy serves at
+// a reserved, well-known host through itself — the proxy counterpart of the
+// branded route interstitial (pkg/proxyinterstitial). Hitting one of the
+// reserved hosts through a resolving proxy shows that surface's live state:
+//
+//   - http://status.dmsg/      → the dmsg resolving proxy (dmsg_web)
+//   - http://status.skynet/    → the skynet resolving proxy (skynet_web)
+//   - http://status.skysocks/  → the skysocks-client SOCKS tunnel
+//
+// Injection model mirrors the resolver's reserved "home" host: the SOCKS5 Dial
+// callback recognizes a status host BEFORE any suffix match / upstream forward,
+// renders the page in-process (nothing is dialed out over the mesh) and splices
+// the rendered HTTP response back to the browser via ServeConn.
+//
+// MVP scope is READ-ONLY: the three data sections a proxy operator wants when a
+// route misbehaves — recent per-process log lines, route/transport events, and a
+// mux-plot-style per-leg bandwidth/RTT view of the surface's route group (the
+// same RouteGroupMuxInfo telemetry `cli proxy mux plot` renders in the
+// terminal). Route CONTROL (change/select routes, pick a dmsg relay) is left as
+// an explicit, clearly-marked seam — see render.go's control section and the
+// Snapshot doc — so it can be added later without reshaping the wire.
+package proxystatus
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// Surface identifies which proxy a status page describes. The string value is
+// the label in the reserved host (status.<surface>) and the human name shown on
+// the page.
+type Surface string
+
+// The three proxy surfaces that serve a status page.
+const (
+	SurfaceDmsg     Surface = "dmsg"
+	SurfaceSkynet   Surface = "skynet"
+	SurfaceSkysocks Surface = "skysocks"
+)
+
+// statusLabel is the reserved first label of every status host.
+const statusLabel = "status"
+
+// Leg is one route in a surface's mux'd route group, decoupled from
+// visor.MuxLegInfo so this package doesn't import pkg/visor (which would be a
+// cycle — the visor implements Provider). Fields mirror the RouteGroupMuxInfo
+// telemetry the `cli proxy mux plot` renderer consumes.
+type Leg struct {
+	Index       int
+	TransportID string
+	TpType      string
+	RemotePK    string
+	LatencyMS   float64
+	SentBytes   uint64
+	RecvBytes   uint64
+	Retransmits uint64
+	Alive       bool
+	Standby     bool
+}
+
+// Snapshot is everything a status page renders for one surface. It is a
+// point-in-time projection; the page meta-refreshes to re-fetch, so a stale
+// Snapshot is self-correcting rather than load-bearing.
+//
+// Extension seam (route control): a future write-capable status page adds a
+// Controls section here (candidate legs, current scheduler mode, selectable dmsg
+// relays) plus a matching mutating method on Provider. The read-only fields
+// below are already shaped so a control UI can render alongside them without a
+// wire change. Keep additions additive.
+type Snapshot struct {
+	Surface    Surface
+	App        string   // underlying app/logger name (dmsgweb / skynetweb / skysocks-client)
+	Running    bool     // whether the surface's process/runtime is currently alive
+	MuxEnabled bool     // route group has multiplexing enabled
+	Legs       []Leg    // current per-leg mux state (empty when no active route group)
+	Logs       []string // recent log lines, oldest first
+	Events     []string // route/transport events affecting this surface, oldest first
+	Note       string   // optional human note (e.g. why a section is empty)
+}
+
+// Provider yields a live Snapshot for a surface. Implemented by the visor
+// (pkg/visor/embedded_proxystatus.go), injected into the resolving-proxy
+// runtimes' Config. A nil Provider disables the status hosts entirely.
+type Provider interface {
+	StatusSnapshot(surface Surface) (Snapshot, error)
+}
+
+// Match reports whether host is one of the reserved status hosts and, if so,
+// which surface it names. host is the raw request host (an optional :port is
+// tolerated and ignored). Matching is case-insensitive and exact on the two
+// labels — "status.skysocks" matches but "x.status.skysocks" and "status" alone
+// do not, so a status host never shadows a real <vhost>.<pk>.<suffix> lookup.
+func Match(host string) (Surface, bool) {
+	h := strings.ToLower(strings.TrimSpace(host))
+	if i := strings.LastIndexByte(h, ':'); i >= 0 && !strings.Contains(h[i+1:], ".") {
+		h = h[:i] // strip a trailing :port (never a dotted label)
+	}
+	label, rest, ok := strings.Cut(h, ".")
+	if !ok || label != statusLabel {
+		return "", false
+	}
+	switch Surface(rest) {
+	case SurfaceDmsg, SurfaceSkynet, SurfaceSkysocks:
+		return Surface(rest), true
+	default:
+		return "", false
+	}
+}
+
+// Host returns the reserved status host for a surface ("status.skysocks"), for
+// links (the interstitial's "view status" affordance) and tests.
+func Host(s Surface) string { return statusLabel + "." + string(s) }
+
+// ServeConn returns one end of an in-memory pipe; the other end is fed body as a
+// single HTTP/1.1 response then closed. Nothing is dialed out — the page exists
+// only as seen THROUGH the proxy. The returned conn is handed to go-socks5,
+// which pipes the browser's request in and the response back. Mirrors dmsgweb's
+// serveHomeInProcess so the two reserved in-process hosts behave identically.
+func ServeConn(body []byte) net.Conn {
+	srvConn, cliConn := net.Pipe()
+	go func() {
+		defer srvConn.Close() //nolint:errcheck
+		br := bufio.NewReader(srvConn)
+		// Consume the request line + headers so the peer's write completes; the
+		// path is ignored (the status page is the same for every path).
+		if _, err := http.ReadRequest(br); err != nil {
+			return
+		}
+		var resp strings.Builder
+		resp.WriteString("HTTP/1.1 200 OK\r\n")
+		resp.WriteString("Content-Type: text/html; charset=utf-8\r\n")
+		fmt.Fprintf(&resp, "Content-Length: %d\r\n", len(body))
+		resp.WriteString("Cache-Control: no-store\r\n")
+		resp.WriteString("Connection: close\r\n\r\n")
+		if _, err := srvConn.Write([]byte(resp.String())); err != nil {
+			return
+		}
+		_, _ = srvConn.Write(body) //nolint:errcheck // best-effort; peer may have gone
+	}()
+	return cliConn
+}

--- a/pkg/proxystatus/proxystatus_test.go
+++ b/pkg/proxystatus/proxystatus_test.go
@@ -1,0 +1,102 @@
+package proxystatus
+
+import (
+	"bufio"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestMatch(t *testing.T) {
+	cases := []struct {
+		host    string
+		want    Surface
+		matched bool
+	}{
+		{"status.dmsg", SurfaceDmsg, true},
+		{"status.skynet", SurfaceSkynet, true},
+		{"status.skysocks", SurfaceSkysocks, true},
+		{"STATUS.SkySocks", SurfaceSkysocks, true}, // case-insensitive
+		{"status.skysocks:80", SurfaceSkysocks, true},
+		{"status.skysocks:8080", SurfaceSkysocks, true},
+		{"status", "", false},            // bare label, no surface
+		{"x.status.skysocks", "", false}, // must be exactly two labels
+		{"status.unknown", "", false},    // unknown surface
+		{"pk.skynet", "", false},         // ordinary resolver host
+		{"home.dmsg", "", false},         // the other reserved host
+	}
+	for _, c := range cases {
+		got, ok := Match(c.host)
+		if ok != c.matched || got != c.want {
+			t.Errorf("Match(%q) = (%q,%v), want (%q,%v)", c.host, got, ok, c.want, c.matched)
+		}
+	}
+}
+
+func TestHost(t *testing.T) {
+	if h := Host(SurfaceSkysocks); h != "status.skysocks" {
+		t.Errorf("Host = %q", h)
+	}
+}
+
+func TestRenderSections(t *testing.T) {
+	snap := Snapshot{
+		Surface:    SurfaceSkysocks,
+		App:        "skysocks-client",
+		Running:    true,
+		MuxEnabled: true,
+		Legs: []Leg{
+			{Index: 0, TpType: "stcpr", RemotePK: "0311223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", SentBytes: 2048, RecvBytes: 1024, LatencyMS: 42, Alive: true},
+			{Index: 1, TpType: "sudph", SentBytes: 512, Standby: true, Alive: true},
+		},
+		Logs:   []string{"line one", "line two"},
+		Events: nil,
+	}
+	page := string(Render(snap))
+	for _, want := range []string{
+		"<!doctype html>", "proxy status", "skysocks-client", "per-leg mux",
+		"stcpr", "recent log", "line two", "route control", "read-only preview",
+		"http-equiv=\"refresh\"", "standby", "status.dmsg", "status.skynet",
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("rendered page missing %q", want)
+		}
+	}
+	// The current surface should not be linked back to itself in the footer.
+	if strings.Contains(page, `href="http://status.skysocks/"`) {
+		t.Error("footer should not link the current surface to itself")
+	}
+}
+
+func TestRenderEscapes(t *testing.T) {
+	snap := Snapshot{Surface: SurfaceDmsg, App: "dmsgweb", Logs: []string{"<script>evil()</script>"}}
+	page := string(Render(snap))
+	if strings.Contains(page, "<script>evil()") {
+		t.Error("log line was not HTML-escaped")
+	}
+}
+
+func TestRenderEmptyMux(t *testing.T) {
+	snap := Snapshot{Surface: SurfaceDmsg, App: "dmsgweb"}
+	page := string(Render(snap))
+	if !strings.Contains(page, "No active route group") {
+		t.Error("empty-mux note missing")
+	}
+}
+
+func TestServeConn(t *testing.T) {
+	c := ServeConn([]byte("<html>ok</html>"))
+	if _, err := c.Write([]byte("GET / HTTP/1.1\r\nHost: status.skysocks\r\n\r\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(c), nil)
+	if err != nil {
+		t.Fatalf("ReadResponse: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("content-type = %q", ct)
+	}
+}

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -1,0 +1,253 @@
+// Package proxystatus pkg/proxystatus/render.go c4-app-web
+package proxystatus
+
+import (
+	"fmt"
+	"html"
+	"strings"
+)
+
+// refreshSeconds is how often the status page re-fetches itself. The page is a
+// point-in-time Snapshot rendered server-side (no JS/websocket), so a meta
+// refresh is how it stays live — frequent enough to watch a route warm, slow
+// enough not to thrash the proxy.
+const refreshSeconds = 4
+
+// maxLogLines caps how many recent log lines the page renders, newest at the
+// bottom (terminal-tail order). The Provider may return fewer.
+const maxLogLines = 200
+
+// Render returns the full, self-contained HTML status page for snap. All
+// interpolated values are HTML-escaped; the page loads no external resource
+// (matching the proxies' strict no-network serving context).
+func Render(snap Snapshot) []byte {
+	var b strings.Builder
+	surface := html.EscapeString(string(snap.Surface))
+	b.WriteString("<!doctype html><html lang=en><head><meta charset=utf-8>")
+	b.WriteString(`<meta name=viewport content="width=device-width, initial-scale=1">`)
+	fmt.Fprintf(&b, `<meta http-equiv="refresh" content="%d">`, refreshSeconds)
+	fmt.Fprintf(&b, "<title>%s proxy status · skywire</title><style>%s</style></head><body>", surface, css)
+
+	// Header + brand.
+	b.WriteString(`<header><div class="brand"><b>skywire</b> proxy status</div>`)
+	fmt.Fprintf(&b, `<div class="surface">%s</div></header>`, surface)
+
+	// Status pills.
+	b.WriteString(`<div class="pills">`)
+	writePill(&b, "surface", surface, "")
+	writePill(&b, "app", html.EscapeString(snap.App), "")
+	if snap.Running {
+		writePill(&b, "state", "running", "ok")
+	} else {
+		writePill(&b, "state", "stopped", "warn")
+	}
+	if len(snap.Legs) > 0 {
+		mux := "off"
+		if snap.MuxEnabled {
+			mux = "on"
+		}
+		writePill(&b, "mux", mux, "")
+		writePill(&b, "legs", fmt.Sprintf("%d", len(snap.Legs)), "")
+	}
+	b.WriteString(`</div>`)
+
+	if snap.Note != "" {
+		fmt.Fprintf(&b, `<p class="note">%s</p>`, html.EscapeString(snap.Note))
+	}
+
+	writeMuxSection(&b, snap)
+	writeEventsSection(&b, snap)
+	writeLogsSection(&b, snap)
+	writeControlSeam(&b, snap)
+	writeFooter(&b, snap)
+
+	b.WriteString("</body></html>")
+	return []byte(b.String())
+}
+
+func writePill(b *strings.Builder, k, v, cls string) {
+	c := "pill"
+	if cls != "" {
+		c += " " + cls
+	}
+	fmt.Fprintf(b, `<span class="%s"><i>%s</i> %s</span>`, c, html.EscapeString(k), v)
+}
+
+// writeMuxSection renders the per-leg mux view: one row per leg with a
+// bandwidth bar sized to its share of the busiest leg (a static, no-JS analog of
+// the `cli proxy mux plot` panel), plus RTT, retransmits and gate state.
+func writeMuxSection(b *strings.Builder, snap Snapshot) {
+	b.WriteString(`<section><h2>route group · per-leg mux</h2>`)
+	if len(snap.Legs) == 0 {
+		b.WriteString(`<p class="empty">No active route group for this surface right now. ` +
+			`A leg appears here once a route to a destination is warm.</p></section>`)
+		return
+	}
+	var maxSent uint64 = 1
+	for _, l := range snap.Legs {
+		if l.SentBytes > maxSent {
+			maxSent = l.SentBytes
+		}
+	}
+	b.WriteString(`<table class="mux"><thead><tr>` +
+		`<th>leg</th><th>transport</th><th>peer</th><th>sent</th><th>bandwidth (sent share)</th>` +
+		`<th>recv</th><th>rtt</th><th>rtx</th><th>state</th></tr></thead><tbody>`)
+	for _, l := range snap.Legs {
+		pct := int(l.SentBytes * 100 / maxSent)
+		state, scls := legState(l)
+		fmt.Fprintf(b, `<tr><td>R%d</td><td>%s</td><td class="pk">%s</td><td>%s</td>`,
+			l.Index, html.EscapeString(orDash(l.TpType)), html.EscapeString(shortPK(l.RemotePK)), humanBytes(l.SentBytes))
+		fmt.Fprintf(b, `<td class="barcell"><span class="bar %s" style="width:%d%%"></span></td>`, scls, pct)
+		fmt.Fprintf(b, `<td>%s</td><td>%.0f ms</td><td>%d</td><td class="%s">%s</td></tr>`,
+			humanBytes(l.RecvBytes), l.LatencyMS, l.Retransmits, scls, state)
+	}
+	b.WriteString(`</tbody></table>`)
+	b.WriteString(`<p class="hint">Bar width is each leg's sent bytes relative to the busiest leg. ` +
+		`For a live terminal chart use <code>skywire cli proxy mux plot</code>.</p></section>`)
+}
+
+func legState(l Leg) (label, cls string) {
+	switch {
+	case !l.Alive:
+		return "closed", "warn"
+	case l.Standby:
+		return "standby", "standby"
+	default:
+		return "active", "ok"
+	}
+}
+
+func writeEventsSection(b *strings.Builder, snap Snapshot) {
+	b.WriteString(`<section><h2>route &amp; transport events</h2>`)
+	if len(snap.Events) == 0 {
+		// Scaffold: event capture is wired but may be empty on an idle surface,
+		// and the richer per-surface event stream (leg promote/demote, transport
+		// drop) is an extension point — see the control seam below.
+		b.WriteString(`<p class="empty">No route or transport events captured for this surface yet.</p>`)
+	} else {
+		b.WriteString(`<ul class="events">`)
+		for _, e := range snap.Events {
+			fmt.Fprintf(b, `<li>%s</li>`, html.EscapeString(e))
+		}
+		b.WriteString(`</ul>`)
+	}
+	b.WriteString(`</section>`)
+}
+
+func writeLogsSection(b *strings.Builder, snap Snapshot) {
+	b.WriteString(`<section><h2>recent log</h2>`)
+	lines := snap.Logs
+	if len(lines) > maxLogLines {
+		lines = lines[len(lines)-maxLogLines:]
+	}
+	if len(lines) == 0 {
+		b.WriteString(`<p class="empty">No recent log lines for this process.</p></section>`)
+		return
+	}
+	b.WriteString(`<pre class="log">`)
+	for _, ln := range lines {
+		b.WriteString(html.EscapeString(strings.TrimRight(ln, "\r\n")))
+		b.WriteByte('\n')
+	}
+	b.WriteString(`</pre></section>`)
+}
+
+// writeControlSeam renders the (disabled) route-control preview. This is the
+// documented extension point: a future write-capable page enables these
+// controls and calls a mutating Provider method. It is intentionally inert now
+// so the MVP stays read-only.
+func writeControlSeam(b *strings.Builder, snap Snapshot) {
+	b.WriteString(`<section class="seam"><h2>route control <small>read-only preview</small></h2>`)
+	b.WriteString(`<p>Selecting routes and relays from here is planned. Today these are inert; ` +
+		`the MVP status page is read-only.</p><div class="controls">`)
+	switch snap.Surface {
+	case SurfaceSkynet, SurfaceSkysocks:
+		b.WriteString(`<button disabled>add leg</button><button disabled>drop leg</button>` +
+			`<button disabled>mux mode…</button><button disabled>rebuild route</button>`)
+	case SurfaceDmsg:
+		b.WriteString(`<button disabled>pick dmsg relay…</button><button disabled>reconnect</button>`)
+	}
+	b.WriteString(`</div></section>`)
+}
+
+func writeFooter(b *strings.Builder, snap Snapshot) {
+	b.WriteString(`<footer>other surfaces: `)
+	first := true
+	for _, s := range []Surface{SurfaceDmsg, SurfaceSkynet, SurfaceSkysocks} {
+		if s == snap.Surface {
+			continue
+		}
+		if !first {
+			b.WriteString(" · ")
+		}
+		first = false
+		host := Host(s)
+		fmt.Fprintf(b, `<a href="http://%s/">%s</a>`, host, html.EscapeString(host))
+	}
+	b.WriteString(`</footer>`)
+}
+
+// --- small helpers -----------------------------------------------------------
+
+func orDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}
+
+// shortPK renders a public key as its first+last 4 hex chars, or "direct"/"-"
+// for an empty peer.
+func shortPK(pk string) string {
+	pk = strings.TrimSpace(pk)
+	if pk == "" {
+		return "-"
+	}
+	if len(pk) <= 12 {
+		return pk
+	}
+	return pk[:6] + "…" + pk[len(pk)-4:]
+}
+
+// humanBytes formats a byte count with a binary unit suffix.
+func humanBytes(n uint64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := uint64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#7a80a8;--accent:#7c83ff;--accent2:#a06bff;--ok:#4ad9a4;--warn:#ff6b8a;--standby:#e0b64a;--card:#131629;--line:#2b3163}` +
+	`*{box-sizing:border-box}html,body{margin:0;background:var(--bg);color:var(--fg);font:13.5px/1.55 system-ui,-apple-system,Segoe UI,Roboto,sans-serif}` +
+	`body{max-width:60rem;margin:0 auto;padding:1.2rem 1rem 3rem}` +
+	`header{display:flex;align-items:baseline;gap:.8rem;flex-wrap:wrap;border-bottom:1px solid var(--line);padding-bottom:.7rem}` +
+	`.brand b{font-weight:600;letter-spacing:.4px;background:linear-gradient(90deg,var(--accent),var(--accent2));-webkit-background-clip:text;background-clip:text;color:transparent}` +
+	`.brand{font-size:1rem}.surface{margin-left:auto;font:600 1.1rem ui-monospace,SFMono-Regular,monospace;color:#e7e9ff}` +
+	`.pills{display:flex;flex-wrap:wrap;gap:.4rem;margin:.9rem 0}` +
+	`.pill{background:var(--card);border:1px solid var(--line);border-radius:999px;padding:.15rem .6rem;font-size:12px}` +
+	`.pill i{color:var(--muted);font-style:normal;margin-right:.25rem;text-transform:uppercase;font-size:10px;letter-spacing:.4px}` +
+	`.pill.ok{border-color:var(--ok);color:var(--ok)}.pill.warn{border-color:var(--warn);color:var(--warn)}` +
+	`h2{font-size:.95rem;margin:1.6rem 0 .5rem;color:#e7e9ff;font-weight:600}h2 small{color:var(--muted);font-weight:400;font-size:11px;margin-left:.4rem}` +
+	`.note{color:var(--standby)}.empty,.hint{color:var(--muted);font-size:12px}` +
+	`table.mux{width:100%;border-collapse:collapse;font-size:12px}` +
+	`table.mux th{text-align:left;color:var(--muted);font-weight:500;border-bottom:1px solid var(--line);padding:.3rem .4rem;text-transform:uppercase;font-size:10px;letter-spacing:.3px}` +
+	`table.mux td{padding:.3rem .4rem;border-bottom:1px solid rgba(43,49,99,.5);white-space:nowrap}` +
+	`td.pk{font-family:ui-monospace,SFMono-Regular,monospace;color:var(--muted)}` +
+	`td.barcell{width:36%}.bar{display:block;height:.7rem;border-radius:3px;background:var(--accent);min-width:2px}` +
+	`.bar.standby{background:var(--standby)}.bar.warn{background:var(--warn)}` +
+	`td.ok{color:var(--ok)}td.warn{color:var(--warn)}td.standby{color:var(--standby)}` +
+	`pre.log{background:var(--card);border:1px solid var(--line);border-radius:8px;padding:.7rem;font:11.5px/1.5 ui-monospace,SFMono-Regular,monospace;` +
+	`white-space:pre-wrap;word-break:break-word;max-height:26rem;overflow:auto;color:var(--fg)}` +
+	`ul.events{margin:.3rem 0;padding-left:1.1rem;font-size:12px}ul.events li{margin:.1rem 0}` +
+	`.seam{opacity:.75}.controls{display:flex;flex-wrap:wrap;gap:.4rem;margin-top:.4rem}` +
+	`.controls button{font:inherit;font-size:12px;padding:.2rem .6rem;border:1px dashed var(--line);border-radius:6px;background:transparent;color:var(--muted);cursor:not-allowed}` +
+	`code{color:var(--accent);font-size:11.5px}` +
+	`footer{margin-top:2rem;padding-top:.7rem;border-top:1px solid var(--line);color:var(--muted);font-size:12px}` +
+	`footer a{color:var(--accent);text-decoration:none}footer a:hover{text-decoration:underline}` +
+	`@media(prefers-color-scheme:light){:root{--bg:#f6f7fb;--fg:#222;--muted:#666;--card:#fff;--line:#e2e4ef;--accent:#5a61e6;--accent2:#8a4fe0}}`

--- a/pkg/skynetca/leaf.go
+++ b/pkg/skynetca/leaf.go
@@ -22,6 +22,27 @@ type LeafMinter interface {
 	For(host string) (*tls.Certificate, error)
 }
 
+// HostPermitter is optionally implemented by a LeafMinter to report — WITHOUT
+// attempting a mint — whether it can issue a leaf for host. Callers that decide
+// whether to route a request down the TLS-MITM path (e.g. the resolving proxies'
+// HTTPS interstitial) use this to skip hosts the name-constrained CA can't cover
+// (arbitrary clearnet HTTPS), rather than calling For and logging its expected
+// "does not match any permitted suffix" failure on every such request.
+type HostPermitter interface {
+	Permits(host string) bool
+}
+
+// Permits reports whether m can mint a leaf for host. A LeafMinter that
+// implements HostPermitter is asked directly; any other implementation is
+// treated optimistically (the mint itself still enforces its constraints). This
+// keeps the check non-breaking — LeafMinter itself is unchanged.
+func Permits(m LeafMinter, host string) bool {
+	if hp, ok := m.(HostPermitter); ok {
+		return hp.Permits(host)
+	}
+	return m != nil
+}
+
 // LeafOptions configures a CachedMinter.
 type LeafOptions struct {
 	Validity          time.Duration
@@ -101,6 +122,10 @@ func (m *CachedMinter) fresh(c *tls.Certificate) bool {
 	return leaf != nil && time.Until(leaf.NotAfter) > m.opts.RenewBefore
 }
 
+// Permits implements HostPermitter: it reports whether host falls under one of
+// this minter's permitted suffixes, without minting or caching anything.
+func (m *CachedMinter) Permits(host string) bool { return m.permitted(host) }
+
 func (m *CachedMinter) permitted(host string) bool {
 	for _, suf := range m.opts.PermittedSuffixes {
 		// Subdomain semantics: the suffix matches when host ends
@@ -171,3 +196,7 @@ func (s staticMinter) For(_ string) (*tls.Certificate, error) {
 	}
 	return s.leaf, nil
 }
+
+// Permits implements HostPermitter: a static minter serves any host (it holds a
+// single fixed leaf), provided it has one.
+func (s staticMinter) Permits(_ string) bool { return s.leaf != nil }

--- a/pkg/skynetca/leaf_test.go
+++ b/pkg/skynetca/leaf_test.go
@@ -22,6 +22,24 @@ func TestMinter_RejectsForbiddenSuffix(t *testing.T) {
 	}
 }
 
+func TestPermits(t *testing.T) {
+	ca, key, _ := GenerateCA(CAOptions{}) //nolint:errcheck,gosec
+	m := NewMinter(ca, key, LeafOptions{})
+
+	// The CachedMinter implements HostPermitter, so the free Permits helper
+	// reports the same verdict the mint would — without minting.
+	if !Permits(m, testPK+".skynet") {
+		t.Error("Permits should allow a .skynet host")
+	}
+	if Permits(m, "example.com") {
+		t.Error("Permits should reject a clearnet host the CA can't cover")
+	}
+	// A nil minter permits nothing.
+	if Permits(nil, testPK+".skynet") {
+		t.Error("Permits(nil, …) should be false")
+	}
+}
+
 func TestMinter_AcceptsSkynetAndDmsg(t *testing.T) {
 	ca, key, _ := GenerateCA(CAOptions{}) //nolint:errcheck,gosec
 	m := NewMinter(ca, key, LeafOptions{})

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -32,6 +32,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/proxyinterstitial"
+	"github.com/skycoin/skywire/pkg/proxystatus"
 	"github.com/skycoin/skywire/pkg/skynet"
 	"github.com/skycoin/skywire/pkg/skynetca"
 )
@@ -145,6 +146,12 @@ type Config struct {
 	// Aliases maps a destination label to a PK (e.g. "skywire" -> LocalPK), so
 	// "skywire.skynet" resolves exactly like "<pk>.skynet".
 	Aliases map[string]cipher.PubKey
+
+	// StatusProvider, when non-nil, enables the reserved in-process status hosts
+	// (http://status.skynet/ etc.) served through this proxy — a read-only
+	// diagnostic page (logs + route/transport events + per-leg mux view) for a
+	// surface. Nil disables the status hosts. See pkg/proxystatus.
+	StatusProvider proxystatus.Provider
 }
 
 // Run starts the SOCKS5 proxy. Blocks until ctx is canceled.
@@ -230,6 +237,24 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 
 			origHost, _ := dialCtx.Value(skynetOrigHostKey{}).(string)
 
+			// Reserved status hosts (http://status.skynet/ etc.): served in-process,
+			// never routed out — the read-only diagnostic page for a surface.
+			// Checked before the .skynet match / upstream forward so any status host
+			// is reachable through this proxy. Plaintext HTTP only.
+			if cfg.StatusProvider != nil {
+				_, sport, _ := net.SplitHostPort(addr) //nolint:errcheck
+				if proxyinterstitial.ShouldServe(sport) {
+					if surface, ok := proxystatus.Match(origHost); ok {
+						snap, serr := cfg.StatusProvider.StatusSnapshot(surface)
+						if serr != nil {
+							snap = proxystatus.Snapshot{Surface: surface, Note: "status unavailable: " + serr.Error()}
+						}
+						log.WithField("surface", string(surface)).Debug("SOCKS5 → serving in-process proxy status page")
+						return &tcpAddrConn{Conn: proxystatus.ServeConn(proxystatus.Render(snap))}, nil
+					}
+				}
+			}
+
 			// Transient-failure interstitial (see pkg/dmsgweb/runtime.go for the
 			// full rationale): on a route-still-warming / upstream-not-ready
 			// failure for a plaintext-HTTP request, serve a branded
@@ -252,12 +277,16 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 					log.WithField("host", target).WithField("err", retErr).
 						Debug("SOCKS5 → serving branded route interstitial")
 					retConn, retErr = proxyinterstitial.Conn(target, proxyinterstitial.StatusLine(retErr), "skynet", false), nil
-				case cfg.TLSMITM && isTLSPort(port, cfg.TLSPort):
+				case cfg.TLSMITM && isTLSPort(port, cfg.TLSPort) && skynetca.Permits(cfg.LeafMinter, origHost):
 					// HTTPS request whose route is still warming: terminate the
 					// browser's TLS locally with a per-host leaf and serve the
 					// interstitial HTML over it (same MITM path as a warm TLS dial,
 					// with the fixed interstitial responder as the "upstream").
-					// If minting fails, fall through to the real error.
+					// Gated on Permits so a clearnet-HTTPS request (a host the
+					// name-constrained CA can't cover) falls through to the real
+					// error rather than logging a guaranteed "does not match
+					// permitted suffix" mint failure. If minting still fails, fall
+					// through to the real error.
 					leaf, lerr := cfg.LeafMinter.For(origHost)
 					if lerr != nil {
 						log.WithField("host", target).WithField("err", lerr).

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -36,6 +36,7 @@ import (
 	dmsgspec "github.com/skycoin/skywire/pkg/dmsgc/spec"
 	"github.com/skycoin/skywire/pkg/dmsgweb"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/proxystatus"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -76,6 +77,11 @@ type EmbeddedDmsgWeb struct {
 	// (v.dmsgDC); nil disables the path.
 	directClient    *dmsg.Client
 	directServerPKs map[cipher.PubKey]struct{}
+
+	// statusProvider serves the reserved in-process status hosts through this
+	// proxy (http://status.dmsg/ etc.). Set by initEmbeddedDmsgWeb; nil disables
+	// the status hosts.
+	statusProvider proxystatus.Provider
 
 	mu        sync.Mutex
 	running   bool
@@ -246,6 +252,8 @@ func (e *EmbeddedDmsgWeb) serve(ctx context.Context) {
 	// Direct-client path for non-discovery dmsg servers.
 	cfg.DirectClient = e.directClient
 	cfg.DirectServerPKs = e.directServerPKs
+	// Reserved in-process status hosts (http://status.dmsg/ etc.).
+	cfg.StatusProvider = e.statusProvider
 
 	// Optional TLS MITM. CA load failure is non-fatal — the
 	// resolver continues without MITM and logs the reason.
@@ -461,6 +469,7 @@ func initEmbeddedDmsgWeb(ctx context.Context, v *Visor, log *logging.Logger) err
 
 	aliases, dmsgSet := resolverAliasesAndDmsgServers(v)
 	runtime := newEmbeddedDmsgWeb(ctx, v.dmsgC, v.dmsgDC, v.conf.PK, v.services.SelfDial, v.services.SelfDialAs, aliases, dmsgSet, cfg, log)
+	runtime.statusProvider = v.proxyStatusProvider()
 	v.initLock.Lock()
 	v.embeddedDmsgWeb = runtime
 	v.initLock.Unlock()

--- a/pkg/visor/embedded_proxystatus.go
+++ b/pkg/visor/embedded_proxystatus.go
@@ -1,0 +1,114 @@
+// Package visor pkg/visor/embedded_proxystatus.go c3-vis-core
+//
+// visorStatusProvider implements pkg/proxystatus.Provider on top of the visor's
+// existing read APIs, so the resolving proxies (dmsg_web / skynet_web) can serve
+// each surface's reserved in-process status host (http://status.<surface>/).
+//
+// It is deliberately READ-ONLY and reuses APIs that already exist:
+//
+//   - logs:   Visor.LogsSince(app)         — the app's bbolt log store tail
+//   - mux:    Visor.RouteGroupMuxInfo(app)  — the same per-leg telemetry the
+//     `cli proxy mux plot` renderer consumes
+//   - running: procManager.ProcByName(app)
+//
+// Route CONTROL is intentionally out of scope for the MVP; the extension seam
+// lives in pkg/proxystatus (Snapshot doc + the disabled control section). When
+// it lands, a mutating method is added to proxystatus.Provider and implemented
+// here on top of the visor's existing mux-reshape API (AddMuxRoute /
+// RemoveMuxRoute / SetMuxMode), which already exists — no new plumbing.
+package visor
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/proxystatus"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// statusLogLookback bounds how far back the status page's log tail reaches. The
+// page renders the most recent lines within this window (capped again in the
+// renderer), so it shows current activity without scanning the whole store.
+const statusLogLookback = 30 * time.Minute
+
+// surfaceApp maps a status surface to the underlying app / logger name whose
+// logs and route group the page reflects. skysocks is the highest-value view:
+// its route group is where multiplexing actually happens.
+func surfaceApp(s proxystatus.Surface) string {
+	switch s {
+	case proxystatus.SurfaceDmsg:
+		return skyenvDmsgWebApp
+	case proxystatus.SurfaceSkynet:
+		return skyenvSkynetWebApp
+	case proxystatus.SurfaceSkysocks:
+		return skyenv.SkysocksClientName
+	default:
+		return ""
+	}
+}
+
+// visorStatusProvider adapts *Visor to proxystatus.Provider.
+type visorStatusProvider struct{ v *Visor }
+
+// proxyStatusProvider returns the provider injected into the resolving proxies'
+// runtime configs. Returns nil-typed provider only when the visor is nil.
+func (v *Visor) proxyStatusProvider() proxystatus.Provider { return &visorStatusProvider{v: v} }
+
+// StatusSnapshot builds the read-only snapshot for a surface. A missing piece
+// (no log store, no active route group) degrades to an empty section with a
+// note rather than failing the whole page — a status page must render even when
+// the surface is idle or half-up.
+func (p *visorStatusProvider) StatusSnapshot(surface proxystatus.Surface) (proxystatus.Snapshot, error) {
+	app := surfaceApp(surface)
+	if app == "" {
+		return proxystatus.Snapshot{Surface: surface}, fmt.Errorf("unknown surface %q", surface)
+	}
+	snap := proxystatus.Snapshot{Surface: surface, App: app}
+
+	if p.v.procM != nil {
+		_, snap.Running = p.v.procM.ProcByName(app)
+	}
+
+	// Logs (best-effort): the store may not exist for an internal app that has
+	// never written, so a fetch error is a note, not a failure.
+	if logs, err := p.v.LogsSince(time.Now().Add(-statusLogLookback), app); err == nil {
+		snap.Logs = logs
+	} else {
+		snap.Note = appendNote(snap.Note, "logs unavailable: "+err.Error())
+	}
+
+	// Mux legs (best-effort): the surface may have no active route group.
+	if infos, err := p.v.RouteGroupMuxInfo(app); err == nil {
+		if len(infos) > 0 {
+			snap.MuxEnabled = infos[0].MuxEnabled
+			for _, leg := range infos[0].Legs {
+				snap.Legs = append(snap.Legs, proxystatus.Leg{
+					Index:       leg.Index,
+					TransportID: leg.TransportID,
+					TpType:      leg.TpType,
+					RemotePK:    leg.RemotePK,
+					LatencyMS:   leg.LatencyMS,
+					SentBytes:   leg.SentBytes,
+					RecvBytes:   leg.RecvBytes,
+					Retransmits: leg.Retransmits,
+					Alive:       leg.Alive,
+					Standby:     leg.Standby,
+				})
+			}
+		}
+	} else {
+		snap.Note = appendNote(snap.Note, "mux info unavailable: "+err.Error())
+	}
+
+	// Events: scaffold. Route/transport lifecycle events for a surface are not
+	// yet collected into a per-surface buffer; the renderer shows an empty
+	// section. This is the extension point that pairs with route control.
+	return snap, nil
+}
+
+func appendNote(existing, add string) string {
+	if existing == "" {
+		return add
+	}
+	return existing + " · " + add
+}

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -29,6 +29,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/proxystatus"
 	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -56,6 +57,10 @@ type EmbeddedSkynetWeb struct {
 	cfg        *visorconfig.SkynetWebConfig
 	log        *logging.Logger
 	stats      *skynetweb.Stats
+	// statusProvider serves the reserved in-process status hosts through this
+	// proxy (http://status.skynet/ etc.). Set by initEmbeddedSkynetWeb; nil
+	// disables the status hosts.
+	statusProvider proxystatus.Provider
 
 	mu        sync.Mutex
 	running   bool
@@ -202,6 +207,8 @@ func (e *EmbeddedSkynetWeb) serve(ctx context.Context) {
 		}
 	}
 	cfg.Aliases = resolverAliasMap(e.cfg.Alias, e.localPK)
+	// Reserved in-process status hosts (http://status.skynet/ etc.).
+	cfg.StatusProvider = e.statusProvider
 
 	// Optional TLS MITM mode. Loading the CA can fail (file
 	// missing, permissions, malformed) — those failures are not
@@ -547,6 +554,7 @@ func initEmbeddedSkynetWeb(ctx context.Context, v *Visor, log *logging.Logger) e
 		return nil
 	}
 	runtime := newEmbeddedSkynetWeb(ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.services.SelfDial, v.services.SelfDialAs, v.conf.SkynetWeb, log)
+	runtime.statusProvider = v.proxyStatusProvider()
 	v.initLock.Lock()
 	v.embeddedSkynetWeb = runtime
 	v.initLock.Unlock()


### PR DESCRIPTION
Two related features on the embedded-web-proxy surface (`dmsg_web`, `skynet_web`, and the `skysocks-client` tunnel they chain to). Design + first working increment; read-only MVP with explicit seams for route control. See `docs/proxy-status-and-interstitial.md`.

## 1. Interstitial over HTTPS

The branded "building a route over the mesh…" interstitial (`pkg/proxyinterstitial`) rides a locally-terminated TLS session (TLS MITM) for HTTPS targets, since a raw-TLS tunnel can't carry an HTML page. TLS termination uses a **name-constrained** local CA (`pkg/skynetca`) that can only mint leaves for `.skynet`/`.dmsg`.

The live bug: the HTTPS-interstitial path attempted a mint for **every** TLS-port dial failure — including clearnet HTTPS forwarded to the upstream `skysocks-client`, which the CA can never cover — producing a `host does not match permitted suffix` error on every such request.

Fix: `skynetca.Permits(minter, host)` — a non-breaking optional interface (`HostPermitter`, implemented by `CachedMinter`) that reports whether the CA can cover a host **without** minting. Both resolving proxies now gate the HTTPS-interstitial mint on it:

- `.skynet`/`.dmsg` HTTPS → interstitial renders over TLS as intended;
- clearnet HTTPS (un-MITM-able by a name-constrained CA) → falls through cleanly to the real error, no per-request log spam.

The interstitial page also gained a footer deep-link to the surface's status host.

## 2. Per-proxy status hosts

Each proxy serves a read-only diagnostic page at a reserved, well-known host **through itself**, mirroring the existing in-process `home.<suffix>` host:

| host | surface | app |
|---|---|---|
| `http://status.dmsg/` | dmsg | `dmsgweb` |
| `http://status.skynet/` | skynet | `skynetweb` |
| `http://status.skysocks/` | skysocks | `skysocks-client` |

New `pkg/proxystatus` owns the surface taxonomy, host matcher (`Match`), the in-process HTTP responder (`ServeConn`, same net.Pipe trick as `serveHomeInProcess`), the read-only `Snapshot`/`Provider` contract, and the HTML renderer. Both resolving proxies' `Dial` callbacks check `Match(host)` **before** suffix resolution / upstream forwarding, so any of the three hosts is reachable through either proxy.

The visor implements `proxystatus.Provider` (`pkg/visor/embedded_proxystatus.go`) entirely on **existing** read APIs:
- **logging** — `LogsSince(app)` tails the app's log store;
- **mux view** — `RouteGroupMuxInfo(app)` gives the same per-leg bandwidth/RTT/retransmit telemetry `cli proxy mux plot` renders, drawn as a per-leg bandwidth-share table (meta-refreshes to stay live);
- **running** — `procManager.ProcByName(app)`.

### Implemented vs. scaffolded

- **`status.skysocks`** — full MVP: logs + live per-leg mux view of the route group where multiplexing actually happens.
- **`status.dmsg` / `status.skynet`** — share the identical page; mux section is empty until their route group is tagged for `RouteGroupMuxInfo`.
- **route/transport events** — empty section today; the collection buffer is the scaffolded extension point.

### Extension seam: route control

MVP is deliberately read-only. The page renders a disabled "route control" section, and `Snapshot`/`Provider` are shaped so control lands **additively**: add a mutating method to `proxystatus.Provider`, implement it on the existing visor mux-reshape API (`AddMuxRoute`/`RemoveMuxRoute`/`SetMuxMode`) + dmsg relay selection. No wire reshape, no new proxy plumbing. Interception in `skysocks-client` for the browser-points-directly-at-:1080 case is a noted future seam.

## Scope / testing

Contained to the embedded-web-proxy packages + `pkg/skynetca` (the permit helper) + a small visor status provider; `pkg/router`/policy untouched. `go build .`, `go vet`, `make format` clean. New unit tests for `pkg/proxystatus` (Match/Render/ServeConn), `skynetca.Permits`, and the interstitial status footer.
