### PR TITLE
fix(router): stop route-setup drops from wedging apps in "starting"; cascade→classic fallback

### DIFF
--- a/pkg/app/appserver/rpc_ingress_client_test.go
+++ b/pkg/app/appserver/rpc_ingress_client_test.go
@@ -55,13 +55,12 @@ func TestRPCIngressClient_Dial(t *testing.T) {
 
 		dmsgLocal, dmsgRemote, _, remote := prepAddrs()
 
-		dialCtx := context.Background()
 		dialConn := &appcommon.MockConn{}
 		dialConn.On("LocalAddr").Return(dmsgLocal)
 		dialConn.On("RemoteAddr").Return(dmsgRemote)
 
 		n := &appnet.MockNetworker{}
-		n.On("DialContext", dialCtx, remote).Return(dialConn, testhelpers.NoErr)
+		n.On("DialContext", mock.Anything, remote).Return(dialConn, testhelpers.NoErr)
 
 		appnet.ClearNetworkers()
 		err := appnet.AddNetworker(appnet.TypeDmsg, n)
@@ -83,12 +82,11 @@ func TestRPCIngressClient_Dial(t *testing.T) {
 
 		_, _, _, remote := prepAddrs()
 
-		dialCtx := context.Background()
 		var dialConn net.Conn
 		dialErr := errors.New("dial error")
 
 		n := &appnet.MockNetworker{}
-		n.On("DialContext", dialCtx, remote).Return(dialConn, dialErr)
+		n.On("DialContext", mock.Anything, remote).Return(dialConn, dialErr)
 
 		appnet.ClearNetworkers()
 		err := appnet.AddNetworker(appnet.TypeDmsg, n)
@@ -114,13 +112,12 @@ func TestRPCIngressClient_DialWithOptions(t *testing.T) {
 
 		dmsgLocal, dmsgRemote, _, remote := prepAddrs()
 
-		dialCtx := context.Background()
 		dialConn := &appcommon.MockConn{}
 		dialConn.On("LocalAddr").Return(dmsgLocal)
 		dialConn.On("RemoteAddr").Return(dmsgRemote)
 
 		n := &appnet.MockNetworker{}
-		n.On("DialContext", dialCtx, remote).Return(dialConn, testhelpers.NoErr)
+		n.On("DialContext", mock.Anything, remote).Return(dialConn, testhelpers.NoErr)
 
 		appnet.ClearNetworkers()
 		require.NoError(t, appnet.AddNetworker(appnet.TypeDmsg, n))
@@ -146,13 +143,12 @@ func TestRPCIngressClient_DialWithOptions(t *testing.T) {
 
 		dmsgLocal, dmsgRemote, _, remote := prepAddrs()
 
-		dialCtx := context.Background()
 		dialConn := &appcommon.MockConn{}
 		dialConn.On("LocalAddr").Return(dmsgLocal)
 		dialConn.On("RemoteAddr").Return(dmsgRemote)
 
 		n := &appnet.MockNetworker{}
-		n.On("DialContext", dialCtx, remote).Return(dialConn, testhelpers.NoErr)
+		n.On("DialContext", mock.Anything, remote).Return(dialConn, testhelpers.NoErr)
 
 		appnet.ClearNetworkers()
 		require.NoError(t, appnet.AddNetworker(appnet.TypeDmsg, n))

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -17,6 +17,19 @@ import (
 	"github.com/skycoin/skywire/pkg/util/rpcutil"
 )
 
+// dialSetupCeiling is the overall deadline for a single app Dial RPC's route
+// setup. The router's DialRoutes bounds each individual setup attempt
+// (routeSetupDialTimeout) and its own retry budget, but the dial context was
+// previously context.Background() with NO deadline: a route-setup path that
+// blocked indefinitely (a setup-node / cascade RPC that accepted but never
+// replied, a destination that dropped the setup conn) left the app's Dial RPC
+// — and its retrier — blocked inside that one call, so a dropped route wedged
+// the app permanently in "starting" even with --reconnect. This ceiling
+// guarantees the Dial RPC returns so the app's reconnect loop can re-try from
+// scratch. It is generous enough to cover a slow multi-hop setup with retries;
+// legitimate setups complete in seconds.
+const dialSetupCeiling = 90 * time.Second
+
 // RPCIOErr is used to return an error coming from network stack.
 //
 // Since client is implemented as an RPC client, we need to correctly
@@ -243,7 +256,12 @@ func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, req *DialOptionsReq
 	if r.proc != nil {
 		appName = r.proc.conf.AppName
 	}
-	dialCtx := appnet.WithAppName(context.Background(), appName)
+	// Bound the whole setup so a stuck route-setup path can't wedge the app in
+	// "starting" forever (see dialSetupCeiling). The ctx scopes only the dial /
+	// route setup, not the returned conn's lifetime, so a long-lived route group
+	// is unaffected.
+	dialCtx, cancelDial := context.WithTimeout(appnet.WithAppName(context.Background(), appName), dialSetupCeiling)
+	defer cancelDial()
 	conn, err := dialWithMuxRoutes(dialCtx, remote, req)
 	if err != nil {
 		free()

--- a/pkg/app/appserver/rpc_ingress_gateway_test.go
+++ b/pkg/app/appserver/rpc_ingress_gateway_test.go
@@ -76,7 +76,6 @@ func testRPCIngressGatewayDialOK(t *testing.T, l *logging.Logger, nType appnet.T
 
 	const localPort routing.Port = 100
 
-	dialCtx := context.Background()
 	dialConn := &appcommon.MockConn{}
 	dialConn.On("LocalAddr").Return(dmsg.Addr{Port: uint16(localPort)})
 	dialConn.On("RemoteAddr").Return(dmsg.Addr{})
@@ -84,7 +83,7 @@ func testRPCIngressGatewayDialOK(t *testing.T, l *logging.Logger, nType appnet.T
 	var dialErr error
 
 	n := &appnet.MockNetworker{}
-	n.On("DialContext", dialCtx, dialAddr).Return(dialConn, dialErr)
+	n.On("DialContext", mock.Anything, dialAddr).Return(dialConn, dialErr)
 
 	err := appnet.AddNetworker(nType, n)
 	require.NoError(t, err)
@@ -124,13 +123,12 @@ func testRPCIngressGatewayDialNoMoreSlots(t *testing.T, l *logging.Logger, dialA
 func testRPCIngressGatewayDialError(t *testing.T, l *logging.Logger, nType appnet.Type, dialAddr appnet.Addr) {
 	appnet.ClearNetworkers()
 
-	dialCtx := context.Background()
 	dialErr := errors.New("dial error")
 
 	var dialConn net.Conn
 
 	n := &appnet.MockNetworker{}
-	n.On("DialContext", dialCtx, dialAddr).Return(dialConn, dialErr)
+	n.On("DialContext", mock.Anything, dialAddr).Return(dialConn, dialErr)
 
 	err := appnet.AddNetworker(nType, n)
 	require.NoError(t, err)
@@ -147,7 +145,6 @@ func testRPCIngressGatewayDialErrorWrappingConn(t *testing.T, l *logging.Logger,
 
 	remoteAddr, localAddr := &appcommon.MockAddr{}, &appcommon.MockAddr{}
 
-	dialCtx := context.Background()
 	dialConn := &appcommon.MockConn{}
 
 	dialConn.On("LocalAddr").Return(localAddr)
@@ -156,7 +153,7 @@ func testRPCIngressGatewayDialErrorWrappingConn(t *testing.T, l *logging.Logger,
 	var dialErr error
 
 	n := &appnet.MockNetworker{}
-	n.On("DialContext", dialCtx, dialAddr).Return(dialConn, dialErr)
+	n.On("DialContext", mock.Anything, dialAddr).Return(dialConn, dialErr)
 
 	err := appnet.AddNetworker(nType, n)
 	require.NoError(t, err)
@@ -186,13 +183,12 @@ func TestRPCIngressGateway_DialWithOptions(t *testing.T) {
 
 		const localPort routing.Port = 200
 
-		dialCtx := context.Background()
 		dialConn := &appcommon.MockConn{}
 		dialConn.On("LocalAddr").Return(dmsg.Addr{Port: uint16(localPort)})
 		dialConn.On("RemoteAddr").Return(dmsg.Addr{})
 
 		n := &appnet.MockNetworker{}
-		n.On("DialContext", dialCtx, dialAddr).Return(dialConn, error(nil))
+		n.On("DialContext", mock.Anything, dialAddr).Return(dialConn, error(nil))
 
 		require.NoError(t, appnet.AddNetworker(nType, n))
 
@@ -211,13 +207,12 @@ func TestRPCIngressGateway_DialWithOptions(t *testing.T) {
 
 		const localPort routing.Port = 201
 
-		dialCtx := context.Background()
 		dialConn := &appcommon.MockConn{}
 		dialConn.On("LocalAddr").Return(dmsg.Addr{Port: uint16(localPort)})
 		dialConn.On("RemoteAddr").Return(dmsg.Addr{})
 
 		n := &appnet.MockNetworker{}
-		n.On("DialContext", dialCtx, dialAddr).Return(dialConn, error(nil))
+		n.On("DialContext", mock.Anything, dialAddr).Return(dialConn, error(nil))
 
 		require.NoError(t, appnet.AddNetworker(nType, n))
 
@@ -239,13 +234,12 @@ func TestRPCIngressGateway_DialWithOptions(t *testing.T) {
 
 		const localPort routing.Port = 202
 
-		dialCtx := context.Background()
 		dialConn := &appcommon.MockConn{}
 		dialConn.On("LocalAddr").Return(dmsg.Addr{Port: uint16(localPort)})
 		dialConn.On("RemoteAddr").Return(dmsg.Addr{})
 
 		n := &appnet.MockNetworker{}
-		n.On("DialContext", dialCtx, dialAddr).Return(dialConn, error(nil))
+		n.On("DialContext", mock.Anything, dialAddr).Return(dialConn, error(nil))
 
 		require.NoError(t, appnet.AddNetworker(nType, n))
 
@@ -266,13 +260,12 @@ func TestRPCIngressGateway_DialWithOptions(t *testing.T) {
 
 		const localPort routing.Port = 203
 
-		dialCtx := context.Background()
 		dialConn := &appcommon.MockConn{}
 		dialConn.On("LocalAddr").Return(dmsg.Addr{Port: uint16(localPort)})
 		dialConn.On("RemoteAddr").Return(dmsg.Addr{})
 
 		n := &appnet.MockNetworker{}
-		n.On("DialContext", dialCtx, dialAddr).Return(dialConn, error(nil))
+		n.On("DialContext", mock.Anything, dialAddr).Return(dialConn, error(nil))
 
 		require.NoError(t, appnet.AddNetworker(nType, n))
 

--- a/pkg/router/route_group_dialer.go
+++ b/pkg/router/route_group_dialer.go
@@ -29,3 +29,32 @@ type RouteGroupDialer interface {
 		req routing.BidirectionalRoute,
 	) (routing.EdgeRules, cipher.PubKey, error) // Returns rules and the connected setup node PK
 }
+
+// forceLegacyCtxKey carries a per-dial request to skip the source-driven
+// cascade and use the classic trusted-setup-node path (the RSN dials each
+// hop, including the destination, over dmsg). It is threaded through the dial
+// context rather than DialOptions so it can be flipped on mid-retry inside
+// DialRoutes without touching the RouteGroupDialer interface.
+type forceLegacyCtxKey struct{}
+
+// WithForceLegacyRouteSetup returns a context that instructs a
+// cascade-capable RouteGroupDialer to bypass the source-driven cascade and use
+// the classic setup-node path for this dial.
+//
+// Rationale: the source-driven cascade installs rules at the destination over
+// transports, verified by the destination's CascadeHandler via the RSN
+// signature. A destination that does NOT run cascade route-setup only trusts
+// the classic setup nodes (route_setup_nodes) and rejects a cascade-installed
+// route — the route group's reciprocal handshake then never completes and the
+// dial fails. The classic path routes setup through an RSN the destination
+// already trusts, so escalating to it recovers the dial against a mixed fleet.
+func WithForceLegacyRouteSetup(ctx context.Context) context.Context {
+	return context.WithValue(ctx, forceLegacyCtxKey{}, true)
+}
+
+// forceLegacyRouteSetup reports whether ctx requests the classic setup-node
+// path (see WithForceLegacyRouteSetup).
+func forceLegacyRouteSetup(ctx context.Context) bool {
+	v, _ := ctx.Value(forceLegacyCtxKey{}).(bool)
+	return v
+}

--- a/pkg/router/route_setup_fallback_test.go
+++ b/pkg/router/route_setup_fallback_test.go
@@ -1,0 +1,74 @@
+//go:build !tinygo || (js && wasm)
+
+// route_setup_fallback_test.go — covers the cascade -> classic (legacy)
+// setup-node fallback plumbing. When a cascade-installed route fails its
+// data-plane handshake (the fingerprint of a destination that does not trust
+// cascade route setup), DialRoutes flips WithForceLegacyRouteSetup on the dial
+// context for the remaining attempts so the RouteGroupDialer uses the classic
+// trusted-setup-node path the destination accepts. These tests lock the
+// context plumbing and the dialer's cascade-vs-classic decision.
+package router
+
+import (
+	"context"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+func TestForceLegacyRouteSetupContext(t *testing.T) {
+	base := context.Background()
+	if forceLegacyRouteSetup(base) {
+		t.Fatal("a plain context must NOT force the legacy setup path")
+	}
+	forced := WithForceLegacyRouteSetup(base)
+	if !forceLegacyRouteSetup(forced) {
+		t.Fatal("WithForceLegacyRouteSetup(ctx) must force the legacy setup path")
+	}
+	// The flag must not leak back to the parent context.
+	if forceLegacyRouteSetup(base) {
+		t.Fatal("force-legacy leaked onto the parent context")
+	}
+	// A child of the forced context inherits the flag.
+	child := context.WithValue(forced, struct{ k int }{1}, "v")
+	if !forceLegacyRouteSetup(child) {
+		t.Fatal("child of a force-legacy context must inherit the flag")
+	}
+}
+
+// stubOrigin is a no-op cascadeOriginProcessor; cascadeEnabled only checks it
+// for nil-ness, so it is never invoked here.
+type stubOrigin struct{}
+
+func (stubOrigin) ProcessLocalOrigin(_ []byte) (*routing.CascadeAck, error) { return nil, nil }
+
+func TestSetupNodeDialer_CascadeEnabled(t *testing.T) {
+	cascade := &CascadeBuilder{}
+	origin := stubOrigin{}
+
+	tests := []struct {
+		name       string
+		srcCascade *CascadeBuilder
+		origin     cascadeOriginProcessor
+		forceLeg   bool
+		want       bool
+	}{
+		{"fully wired, not forced", cascade, origin, false, true},
+		{"fully wired but forced legacy", cascade, origin, true, false},
+		{"no source cascade builder", nil, origin, false, false},
+		{"no origin processor", cascade, nil, false, false},
+		{"nothing wired", nil, nil, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &setupNodeDialer{srcCascade: tc.srcCascade, cascadeOrigin: tc.origin}
+			ctx := context.Background()
+			if tc.forceLeg {
+				ctx = WithForceLegacyRouteSetup(ctx)
+			}
+			if got := d.cascadeEnabled(ctx); got != tc.want {
+				t.Fatalf("cascadeEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -58,6 +58,21 @@ const (
 	// setup budget while tolerating those.
 	handshakeAwaitTimeout = 10 * time.Second
 
+	// routeSetupDialTimeout bounds a SINGLE route-group setup attempt
+	// (reserve+install via the RouteGroupDialer — the source-driven cascade
+	// or the legacy setup-node RPC). Without it, a setup-node / cascade RPC
+	// that accepts the request but never replies (a hung dmsg session, an
+	// intermediate that churned mid-cascade, or a destination that silently
+	// dropped the setup conn) blocks the dial forever. That is the permanent
+	// "starting" wedge: the app-side Dial RPC — and the app's own retrier — are
+	// blocked inside that one unbounded call, so a transient route drop becomes
+	// a permanent stall with no route group, even with --reconnect. Bounding
+	// each attempt lets the DialRoutes retry loop advance to a fresh candidate
+	// and, on exhaustion, return an error so the app's reconnect loop re-tries.
+	// 30s comfortably covers a slow multi-hop cascade (reserve+install ACKs)
+	// while staying well under the per-dial ceiling.
+	routeSetupDialTimeout = 30 * time.Second
+
 	maxHops       = 1000
 	retryDuration = 2 * time.Second
 	retryInterval = 500 * time.Millisecond

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -262,6 +262,13 @@ func (r *router) DialRoutes(
 		return nil, fmt.Errorf("no transports available; route setup skipped")
 	}
 
+	// escalateToLegacy is flipped on when a cascade-installed route fails its
+	// data-plane handshake (the fingerprint of a destination that doesn't trust
+	// cascade-installed routes — a mixed-cascade fleet). Once set, subsequent
+	// attempts dial through the classic trusted-setup-node path the destination
+	// DOES accept. See WithForceLegacyRouteSetup.
+	escalateToLegacy := false
+
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		var forwardPath, reversePath []routing.Hop
 		var err error
@@ -351,8 +358,26 @@ func (r *router) DialRoutes(
 			Reverse:   reversePath,
 		}
 
-		rules, connectedNode, err := r.conf.RouteGroupDialer.Dial(ctx, log, r.dmsgC, r.conf.SetupNodes, req)
+		// Bound this single setup attempt so a setup-node / cascade RPC that
+		// accepts but never replies can't wedge the whole dial (and the app in
+		// "starting"). On timeout we fall through to the retry-with-exclude loop
+		// below, which re-fetches a fresh route and tries again. See
+		// routeSetupDialTimeout.
+		setupCtx := ctx
+		if escalateToLegacy {
+			setupCtx = WithForceLegacyRouteSetup(ctx)
+		}
+		dialCtx, cancelDial := context.WithTimeout(setupCtx, routeSetupDialTimeout)
+		rules, connectedNode, err := r.conf.RouteGroupDialer.Dial(dialCtx, log, r.dmsgC, r.conf.SetupNodes, req)
+		cancelDial()
 		if err != nil {
+			// If the PARENT context (the overall dial deadline) is done, stop
+			// retrying and surface it — the per-attempt timeout above only bounds
+			// one attempt, this bounds the whole dial so the caller's Dial RPC
+			// returns and the app's --reconnect loop can re-try from scratch.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			// On dial failure, attribute to the intermediate that broke
 			// id_reservation and exclude it from the NEXT fetchBestRoutes
 			// pick. The router.DialError carries the PK that failed.
@@ -440,10 +465,26 @@ func (r *router) DialRoutes(
 			// stale-TPD error still fail fast — retrying the same direct path
 			// to a down peer would only burn the budget.
 			deadInter := intermediatePKsOfPath(forwardPath, lPK, rPK)
-			if (len(deadInter) > 0 || errors.Is(err, ErrNoSuitableTransport)) && attempt < maxRetries {
-				for _, ipk := range deadInter {
-					opts = appendExcludeIntermediate(opts, ipk)
-				}
+			// A cascade-installed route that fails its handshake is ALSO the
+			// fingerprint of a destination that does not trust cascade route
+			// setup (rules ACKed over transports, but the destination — running
+			// classic-only setup — rejects the cascade initiator so the
+			// reciprocal route-group handshake never completes). Escalate the
+			// next attempt to the classic trusted-setup-node path the
+			// destination accepts. Worth a retry even for a direct/no-hop route,
+			// since this changes WHO installs the rules (an RSN the destination
+			// trusts), not which intermediates are used.
+			firstLegacyEscalation := false
+			if !escalateToLegacy {
+				escalateToLegacy = true
+				firstLegacyEscalation = true
+				log.WithError(err).Warnf("Route data-plane handshake failed (attempt %d/%d); escalating remaining attempts to the classic setup-node path",
+					attempt, maxRetries)
+			}
+			for _, ipk := range deadInter {
+				opts = appendExcludeIntermediate(opts, ipk)
+			}
+			if (len(deadInter) > 0 || errors.Is(err, ErrNoSuitableTransport) || firstLegacyEscalation) && attempt < maxRetries {
 				log.WithError(err).Warnf("Route setup failed at handshake/data plane (attempt %d/%d); excluding %d intermediate(s) and retrying with a fresh route",
 					attempt, maxRetries, len(deadInter))
 				continue

--- a/pkg/router/wrappers.go
+++ b/pkg/router/wrappers.go
@@ -53,6 +53,16 @@ func (d *setupNodeDialer) SetCascadeOrigin(p cascadeOriginProcessor) {
 	d.cascadeOrigin = p
 }
 
+// cascadeEnabled reports whether this dial should use the source-driven
+// cascade. It requires a configured source-side builder AND origin processor
+// AND that the caller has not forced the classic setup-node path for this dial
+// (see WithForceLegacyRouteSetup — DialRoutes flips it on after a
+// cascade-installed route fails its data-plane handshake, the fingerprint of a
+// destination that doesn't trust cascade route setup).
+func (d *setupNodeDialer) cascadeEnabled(ctx context.Context) bool {
+	return d.srcCascade != nil && d.cascadeOrigin != nil && !forceLegacyRouteSetup(ctx)
+}
+
 // CascadeAckRegistry exposes the source-side cascade builder's ack registry
 // so the router's CascadeHandler can share it. ACKs for source-driven
 // cascades arrive on the visor's single registered cascade handler and must
@@ -191,7 +201,12 @@ func (d *setupNodeDialer) Dial(
 	// transports (not the RSN's). This avoids the RSN having to dial each
 	// hop over dmsg (the dmsg-202 failure mode for zombie sessions). Fall
 	// back to the legacy DMSG DialRouteGroup if the RSN is un-upgraded.
-	if d.srcCascade != nil && d.cascadeOrigin != nil {
+	//
+	// forceLegacyRouteSetup (set by DialRoutes when a prior cascade attempt's
+	// route failed its data-plane handshake — the signature of a destination
+	// that doesn't trust cascade-installed routes) skips the cascade entirely
+	// so this dial goes through the classic setup node the destination trusts.
+	if d.cascadeEnabled(ctx) {
 		rules, cascErr := runSourceCascade(ctx, log, client.RPCClient(), d.cascadeOrigin, req)
 		if cascErr == nil {
 			return rules, connectedNode, nil
@@ -236,8 +251,9 @@ func (d *setupNodeDialer) dialViaTransport(
 
 	// Prefer the source-driven cascade: the RSN only signs, and we inject the
 	// cascades down our own transports. Fall back to the legacy DialRouteGroup
-	// RPC if the RSN doesn't implement the CascadeSign* methods.
-	if d.srcCascade != nil && d.cascadeOrigin != nil {
+	// RPC if the RSN doesn't implement the CascadeSign* methods, or when the
+	// caller forces the classic path (see WithForceLegacyRouteSetup).
+	if d.cascadeEnabled(ctx) {
 		rules, cascErr := runSourceCascade(ctx, log, rpcC, d.cascadeOrigin, req)
 		if cascErr == nil {
 			return rules, nil

--- a/pkg/visor/rpc_apps.go
+++ b/pkg/visor/rpc_apps.go
@@ -36,7 +36,15 @@ func (r *RPC) App(appName *string, reply *appserver.AppState) (err error) {
 	defer rpcutil.LogCall(r.log, "App", nil)(reply, &err)
 
 	app, err := r.visor.App(*appName)
-	*reply = *app
+	// Guard the nil-deref (#85): during the early post-restart window the app
+	// launcher isn't wired yet, so App() returns (nil, ErrAppLauncherNotAvailable).
+	// An app polling its own state over RPC right after a restart (the
+	// --reconnect path does exactly this) would otherwise panic the visor's RPC
+	// handler on `*reply = *app`. Leave reply at its zero value and surface the
+	// error instead.
+	if app != nil {
+		*reply = *app
+	}
 
 	return err
 }

--- a/pkg/visor/rpc_test.go
+++ b/pkg/visor/rpc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
@@ -85,6 +86,24 @@ func TestUptime(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.GreaterOrEqual(t, res, 1.0)
+}
+
+// TestApp_NilLauncherNoPanic covers the #85 nil-deref guard: during the early
+// post-restart window the app launcher (v.appL) isn't wired yet, so
+// Visor.App() returns (nil, ErrAppLauncherNotAvailable). An app polling its own
+// state over RPC right after a restart — exactly what the --reconnect path does
+// — must get the error back, NOT panic the visor's RPC handler on `*reply = *app`.
+func TestApp_NilLauncherNoPanic(t *testing.T) {
+	rpc := &RPC{visor: &Visor{}, log: logrus.New()} // appL is nil
+	name := "skysocks-client"
+	var reply appserver.AppState
+
+	require.NotPanics(t, func() {
+		err := rpc.App(&name, &reply)
+		require.ErrorIs(t, err, ErrAppLauncherNotAvailable)
+	})
+	// reply stays at its zero value (no crash, no bogus state).
+	assert.Equal(t, appserver.AppState{}, reply)
 }
 
 // func TestRegisterAndDeregisterApp(t *testing.T) {


### PR DESCRIPTION
## Problem

A transient route drop could leave a proxy/VPN app stuck in **"starting"** indefinitely with no route group — even with `--reconnect` — until a manual `stop`/`start`. This is the core "proxy cuts in and out and never recovers" failure.

## Root causes + fixes

**1. Unbounded route setup wedged the app.**
`RPCIngressGateway.dialInternal` dialed with `context.Background()` — no deadline. Route setup (`RouteGroupDialer.Dial`) then waits on RSN / cascade-sign RPCs with only `select { <-ctx.Done(); <-call.Done }`, so a setup-node or cascade RPC that *accepts but never replies* blocks forever. The app's `Dial` RPC — and its own retrier — sit inside that one call, so the app never leaves "starting".
- `DialRoutes` now bounds each setup attempt with `routeSetupDialTimeout` (30s) and bails the retry loop the moment the parent ctx is done.
- `dialInternal` bounds the whole app dial with `dialSetupCeiling` (90s) as a backstop, guaranteeing the `Dial` RPC returns so `--reconnect` can re-try. The ctx scopes only setup, not the route group's lifetime.

**2. Cascade route setup had no fallback to the classic setup-node path.**
The source-driven cascade installs rules at the destination over transports; a destination that doesn't run cascade setup only trusts the configured `route_setup_nodes` and rejects the cascade initiator, so the route group's reciprocal handshake never completes (`saveRouteGroupRules` times out at 10s). The dialer only fell back to classic on a cascade *RPC* error — not on this later *data-plane handshake* failure — so a mixed-cascade fleet failed to route.
- `DialRoutes` now escalates: on a handshake/data-plane failure it flips `WithForceLegacyRouteSetup` on for the remaining attempts, and the dialer (`cascadeEnabled`) uses the classic trusted-setup-node path the destination accepts.

**3. Guard the #85 nil-deref on the early post-restart app RPC.**
`RPC.App` did `*reply = *app` unconditionally; in the early restart window `Visor.App()` returns `(nil, ErrAppLauncherNotAvailable)`, so an app polling its own state right after a restart (what `--reconnect` does) panicked the visor's RPC handler. Now guarded.

## Tests
- `route_setup_fallback_test.go`: cascade→classic context plumbing + dialer decision matrix.
- `rpc_test.go`: the nil-deref guard.
- ingress-gateway dial mocks updated to accept the now-bounded context.

`go build .`, `go test ./pkg/router/... ./pkg/visor/... ./pkg/app/...`, `go vet`, and `golangci-lint` (errcheck/misspell/unparam/…) all green.

## Live validation still needed
Rebuild a visor and confirm: a dropped route auto-recovers (the app cycles starting→running, not a permanent wedge), and a `none`/single-route proxy sustains a long transfer. Do not merge before that check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)