### PR TITLE
fix(routing): honor mux_routes=1 as a single-route-group dial

### DIFF
--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -104,7 +104,12 @@ func (r *SkywireNetworker) DialContextWithOptions(ctx context.Context, addr Addr
 	if opts == nil {
 		opts = router.DefaultDialOptions()
 	}
-	if r.MuxRoutes > 1 && opts.MuxRoutes == 0 {
+	// Apply the visor-global mux_routes as the default when the caller didn't
+	// set a per-dial value. `>= 1` (was `> 1`) so an explicit mux_routes=1 is
+	// honored as a single-route-group dial rather than being swallowed as
+	// "unset" (which would take the 0-hop direct shortcut below and never form
+	// a route group).
+	if r.MuxRoutes >= 1 && opts.MuxRoutes == 0 {
 		opts.MuxRoutes = r.MuxRoutes
 	}
 	// If the caller threaded an app name on the context (e.g.
@@ -114,20 +119,26 @@ func (r *SkywireNetworker) DialContextWithOptions(ctx context.Context, addr Addr
 		opts.AppName = AppNameFromContext(ctx)
 	}
 
-	// Only take the direct shortcut when the caller is fine with a
-	// single 0-hop conn. opts.MinHops > 1 means the caller wants
-	// intermediates (direct is 0 hops); opts.MuxRoutes > 1 means the
-	// caller wants N parallel routes (direct returns one conn).
-	// Without this gate, --routes N / --min-hops K on a skynet
-	// client were silently dropped whenever AppDirectMux had a
-	// transport — see ping-path counterpart #2751.
+	// Only take the direct shortcut when the caller expressed NO routing
+	// preference: min-hops <= 1 AND no explicit mux request. opts.MinHops > 1
+	// means the caller wants intermediates (direct is 0 hops).
+	//
+	// opts.MuxRoutes == 0 (was `<= 1`) is the key distinction: 0 means "unset —
+	// take the fast path"; an EXPLICIT opts.MuxRoutes >= 1 (from `--mux 1`, or
+	// the visor-global mux_routes=1 propagated above) means "form a route group,
+	// even a single-route one" — so mux_routes=1 no longer silently collapses to
+	// the 0-hop direct shortcut and actually establishes a route group. mux >= 2
+	// (N parallel routes) already skipped the shortcut; this extends the same
+	// treatment to an explicit single route. Without this gate, --routes N /
+	// --min-hops K on a skynet client were silently dropped whenever
+	// AppDirectMux had a transport — see ping-path counterpart #2751.
 	//
 	// The visor-global setting counts as much as the per-dial one, and
 	// asking the router is the only way to see it: opts.MinHops == 0 means
 	// "inherit Config.MinHops", so testing opts alone let a VPN client
 	// configured for min_hops=3 take this shortcut and get a single direct
 	// hop — the constraint bypassed before route setup was ever reached.
-	if r.r.EffectiveMinHops(opts) <= 1 && opts.MuxRoutes <= 1 {
+	if r.directShortcutEligible(opts) {
 		if directConn, ok := r.tryDirectDial(addr, opts.AppName); ok {
 			return &SkywireConn{
 				Conn:     directConn,
@@ -146,6 +157,21 @@ func (r *SkywireNetworker) DialContextWithOptions(ctx context.Context, addr Addr
 		nrg:      conn.(*router.NoiseRouteGroup),
 		freePort: freePort,
 	}, nil
+}
+
+// directShortcutEligible reports whether a dial with these opts may take the
+// 0-hop AppDirectMux shortcut (bypassing route-group setup). It is eligible
+// only when the caller expressed NO routing preference:
+//
+//   - min-hops <= 1 (the caller isn't demanding intermediates), AND
+//   - opts.MuxRoutes == 0 (UNSET — "take the fast path"). An explicit
+//     opts.MuxRoutes >= 1 (from `--mux 1`, or the visor-global mux_routes=1
+//     propagated onto opts above) means "form a route group, even a single
+//     one", so mux_routes=1 no longer silently collapses to a 0-hop direct
+//     conn and never forming a route group. mux >= 2 already skipped the
+//     shortcut; this extends the same treatment to an explicit single route.
+func (r *SkywireNetworker) directShortcutEligible(opts *router.DialOptions) bool {
+	return r.r.EffectiveMinHops(opts) <= 1 && opts.MuxRoutes == 0
 }
 
 // DialPacketContext implements PacketNetworker — it opens a faithful-UDP

--- a/pkg/app/appnet/skywire_networker_router_test.go
+++ b/pkg/app/appnet/skywire_networker_router_test.go
@@ -99,6 +99,30 @@ func TestSkywireNetworker_ServeRouteGroupStops(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestSkywireNetworker_DirectShortcutEligible locks the mux_routes=1 fix: the
+// 0-hop direct shortcut is taken ONLY for an unset mux (MuxRoutes==0), so an
+// explicit single route (MuxRoutes==1) forms a route group instead of silently
+// collapsing to a bare direct conn. mux>=2 also skips the shortcut (unchanged).
+// stubRouter.EffectiveMinHops returns 1, so min-hops never gates here.
+func TestSkywireNetworker_DirectShortcutEligible(t *testing.T) {
+	r := stubNetworker(nil)
+	cases := []struct {
+		mux  int
+		want bool
+	}{
+		{0, true},  // unset → fast path
+		{1, false}, // explicit single route → route group
+		{2, false}, // mux → route group
+		{4, false},
+	}
+	for _, c := range cases {
+		got := r.directShortcutEligible(&router.DialOptions{MuxRoutes: c.mux})
+		if got != c.want {
+			t.Errorf("directShortcutEligible(MuxRoutes=%d) = %v, want %v", c.mux, got, c.want)
+		}
+	}
+}
+
 func TestSkywireNetworker_TryDirectDialNoMux(t *testing.T) {
 	r := stubNetworker(nil)
 	pk, _ := cipher.GenerateKeyPair()

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -97,7 +97,13 @@ func NewLauncher(log logrus.FieldLogger, conf AppLauncherConfig, dmsgC *dmsg.Cli
 
 	// Prepare networks.
 	skyN := appnet.NewSkywireNetworker(log.WithField("_", appnet.TypeSkynet), r)
-	if sn, ok := skyN.(*appnet.SkywireNetworker); ok && conf.MuxRoutes > 1 {
+	// Propagate an EXPLICIT mux_routes setting (>= 1) to the networker. The old
+	// `> 1` gate made mux_routes=1 indistinguishable from unset (both left
+	// sn.MuxRoutes=0), so a visor could not express "exactly one route via a
+	// route group" — mux_routes=1 was silently swallowed and every single-route
+	// dial took the 0-hop direct shortcut instead of forming a route group.
+	// sn.MuxRoutes=1 lets the networker honor that as a single-route-group dial.
+	if sn, ok := skyN.(*appnet.SkywireNetworker); ok && conf.MuxRoutes >= 1 {
 		sn.MuxRoutes = conf.MuxRoutes
 	}
 	if err := appnet.AddNetworker(appnet.TypeSkynet, skyN); err != nil {


### PR DESCRIPTION
## Problem

A visor configured with `routing.mux_routes=1` (or an app dialing with `--mux 1`) formed **no route group** — the dial silently took the 0-hop `AppDirectMux` shortcut instead. `mux_routes=2` worked because only `mux>=2` skipped the shortcut.

## Cause

Two gates lumped an explicit "1" together with "unset":
- **launcher**: `conf.MuxRoutes > 1` left `sn.MuxRoutes=0` for `mux_routes=1`, making an explicit `1` indistinguishable from unset. Now `>= 1`.
- **networker**: the direct-shortcut gate `opts.MuxRoutes <= 1` bypassed route setup even for an explicit single route. The decision is now `opts.MuxRoutes == 0` (extracted into `directShortcutEligible`): UNSET (0) keeps the fast path; an EXPLICIT `mux_routes >= 1` forms a route group. `mux>=2` behavior is unchanged.

The default (mux unset / 0) still takes the direct fast path, so this only changes visors/apps that **explicitly** ask for a single route.

## Test
`directShortcutEligible` across mux 0/1/2/4. `go build`, `go test ./pkg/app/...`, `golangci-lint` green.

## Live validation still needed
Confirm a `mux_routes=1` proxy establishes a route group and passes traffic on a rebuilt visor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)