### PR TITLE
feat(interstitial): stream live route-setup progress via chunked encoding

### DIFF
--- a/docs/proxy-status-and-interstitial.md
+++ b/docs/proxy-status-and-interstitial.md
@@ -34,6 +34,50 @@ anyway) cleanly falls through to the real error instead of a per-request log
 spam. The page itself gained a footer with a deep-link to the surface's status
 host (below).
 
+## 1b. Streaming interstitial (live route-setup progress)
+
+The interstitial can hold the browser connection OPEN and stream **live** route-
+setup progress via HTTP chunked transfer-encoding, instead of the one-shot
+`Content-Length` page + client meta-refresh. `pkg/proxyinterstitial/stream.go`
+(`StreamConn` / `DriveStream` / `StreamOpen`+`StreamStep`+`StreamClose`) renders a
+progressive-HTML shell and flushes a line per real attempt, then — once the route
+is up — flushes a final chunk that reloads the page into the now-live content.
+
+**What signal is real (the seam).** The interstitial is minted *after* a dial has
+already failed transiently; there is no in-flight route-setup to subscribe to at
+that point, and `pkg/router` exposes **no** per-hop / noise-handshake progress
+hook — `DialOptions` has no observer, and even the mux-telemetry harness only
+synthesizes coarse `RouteEstablished`/failed events around its own `DialRoutes`
+call. So the granular `finding route → 2-hop via <pk> → noise handshake → route
+group up` narrative is **not observable today**. Two honest sources are used
+instead:
+
+- **browse-origin** (`meshInterstitialRT`): it already runs the real cold-route
+  round-trip in the background; the stream renders that actual in-flight
+  attempt's outcome (`streamingInterstitialResponse`, flushed via the reverse
+  proxy's `FlushInterval < 0`).
+- **SOCKS resolving proxies** (`dmsgweb` / `skynetweb`): the mint point has no
+  live attempt, so the streamer DRIVES a fresh one via a `Probe` (`dmsgRedialProbe`
+  / `skynetRedialProbe`) and streams each real attempt's `StatusLine` + the
+  success. Coarse, but real.
+
+The **missing seam** to get the granular lines is a router-side progress callback
+— e.g. `DialOptions.OnProgress func(phase RouteSetupPhase)` invoked by
+`DialRoutes` / the cascade setup path as hops resolve and the noise handshake
+completes. That lives in `pkg/router` (owned separately) and is intentionally
+**not** added here; this PR streams only the coarse signal actually available and
+does not fabricate per-hop events. `pkg/skysocks`'s `ServeSOCKS5` mint point is
+also left one-shot: it tears its session down for reconnect, with no attempt to
+drive/observe from that function.
+
+**Fallback.** `StreamConn` reads the request first and serves the existing
+one-shot meta-refresh page to an HTTP/1.0 client; a nil probe / absent event
+source likewise degrades to the static page.
+
+**Liveness tie-in.** The same probe *is* the "is-my-connection-up" signal; a
+future `status.*` mux view can share it as a WS/WT liveness indicator (extension
+point, not built here).
+
 ## 2. Per-proxy status hosts
 
 Each proxy serves a read-only diagnostic page at a reserved, well-known host

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -355,9 +355,20 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 				}
 				switch {
 				case proxyinterstitial.ShouldServe(origPort):
+					// Stream REAL route-setup progress: hold the browser open with a
+					// chunked response and drive a fresh dial via a probe, flushing a
+					// line per real attempt, then reload into live content once the
+					// route is warm. Falls back to the one-shot page for an HTTP/1.0
+					// client (handled inside StreamConn). Wrapped in tcpAddrConn: the
+					// stream conn is a net.Pipe (pipeAddr), and go-socks5 asserts
+					// *net.TCPAddr on the returned conn when building its BND reply.
 					log.WithField("host", target).WithField("err", dialErr).
-						Debug("SOCKS5 → serving branded route interstitial")
-					conn, dialErr = proxyinterstitial.Conn(target, proxyinterstitial.StatusLine(dialErr), "dmsg", false), nil
+						Debug("SOCKS5 → serving streaming route interstitial")
+					conn, dialErr = &tcpAddrConn{Conn: proxyinterstitial.StreamConn(context.Background(), proxyinterstitial.StreamConfig{
+						Target:    target,
+						Mechanism: "dmsg",
+						Probe:     dmsgRedialProbe(dmsgC, upstream, cfg, origHost, addr, origPort),
+					})}, nil
 				case cfg.TLSMITM && isTLSPort(origPort, cfg.TLSPort) && skynetca.Permits(cfg.LeafMinter, origHost):
 					// HTTPS request whose route is still warming: terminate the
 					// browser's TLS locally with a per-host leaf and serve the
@@ -584,6 +595,51 @@ func (f *upstreamForwarder) dial(network, addr string) (net.Conn, error) {
 	}
 	f.mu.Unlock()
 	return conn, err
+}
+
+// dmsgRedialProbe builds a proxyinterstitial.Probe that re-attempts the dial the
+// streaming interstitial stands in for, reporting the route ready (nil) once it
+// succeeds. It is a READINESS probe: for a .dmsg destination it re-dials the
+// destination directly (the common case) — a coarse but real signal, since
+// pkg/router/dmsg expose no per-hop setup event to observe (see
+// pkg/proxyinterstitial/stream.go). A non-.dmsg target re-attempts the
+// upstream/direct forward. On success the opened stream is closed immediately;
+// the browser's reload then rides the now-warm session/route.
+func dmsgRedialProbe(dmsgC *dmsg.Client, upstream *upstreamForwarder, cfg Config, origHost, addr, origPort string) proxyinterstitial.Probe {
+	return func(ctx context.Context) error {
+		hostOnly := origHost
+		if i := strings.IndexByte(hostOnly, ':'); i >= 0 {
+			hostOnly = hostOnly[:i]
+		}
+		if strings.HasSuffix(hostOnly, cfg.DomainSuffix) {
+			hp := origHost
+			if origPort != "" && origPort != "80" {
+				hp = origHost + ":" + origPort
+			}
+			_, _, dest, port, perr := skynetweb.ParseResolverHost(hp, cfg.DomainSuffix, cfg.Aliases)
+			if perr != nil {
+				return perr
+			}
+			c, e := dmsgC.Dial(ctx, dmsg.Addr{PK: dest, Port: port})
+			if e == nil {
+				_ = c.Close() //nolint:errcheck
+			}
+			return e
+		}
+		var (
+			c net.Conn
+			e error
+		)
+		if upstream != nil {
+			c, e = upstream.dial("tcp", addr)
+		} else {
+			c, e = net.Dial("tcp", addr)
+		}
+		if e == nil {
+			_ = c.Close() //nolint:errcheck
+		}
+		return e
+	}
 }
 
 // Context keys used by the SOCKS5 resolver ↔ Dial callback handshake.

--- a/pkg/proxyinterstitial/interstitial.go
+++ b/pkg/proxyinterstitial/interstitial.go
@@ -183,6 +183,10 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#7a80a8;--accent:#7c83ff;--
 	`#mesh-host{display:block;margin-top:14px;font:12px/1.4 ui-monospace,SFMono-Regular,monospace;color:var(--muted);opacity:.75;word-break:break-all}` +
 	`.foot{margin-top:16px;padding-top:12px;border-top:1px solid var(--line);font-size:11.5px;color:var(--muted)}` +
 	`.foot a{color:var(--accent);text-decoration:none}.foot a:hover{text-decoration:underline}` +
+	// Streaming (chunked) variant: live per-attempt progress lines. Reuses the
+	// .steps list; adds a completed (◐→●), errored (✗) and "route up" style.
+	`.steps li.err{color:var(--err)}.steps li.err::before{content:"✗";color:var(--err);animation:none}` +
+	`.ready{color:var(--accent);margin:12px 0 0;font-size:13px;font-weight:600}` +
 	`.err #mesh-title{color:var(--err)}.err .sp{display:none}`
 
 // httpResponse wraps the HTML in a minimal HTTP/1.1 response. Connection:close

--- a/pkg/proxyinterstitial/stream.go
+++ b/pkg/proxyinterstitial/stream.go
@@ -1,0 +1,250 @@
+// Package proxyinterstitial pkg/proxyinterstitial/stream.go c4-app-web
+//
+// Streaming (HTTP chunked-transfer) variant of the route interstitial. Instead
+// of the one-shot Content-Length page + client-side meta-refresh (interstitial.go),
+// this holds the browser connection OPEN and flushes a progressive-HTML chunk per
+// REAL route-setup attempt as it happens, then — once the route is up — flushes a
+// final chunk that reloads the page into the now-live content.
+//
+// What "real" means here, precisely. The interstitial is minted AFTER a dial has
+// already failed transiently; there is no in-flight route-setup to subscribe to
+// at that point, and pkg/router exposes no per-hop / noise-handshake progress
+// hook (DialOptions has no observer; even the mux-telemetry harness only
+// synthesizes coarse "established/failed" events around its own DialRoutes call).
+// So the streamer DRIVES a fresh attempt via a caller-supplied Probe and streams
+// the real outcome of each attempt (StatusLine of the actual error, then success).
+// That is the honest, coarse signal available today; the granular
+// "2-hop via <pk> → noise handshake → route group up" lines the design sketches
+// require a NEW router-side progress callback — see the package doc / the
+// docs/proxy-status-and-interstitial.md "streaming seam" note. This file does not
+// invent those events.
+//
+// Graceful fallback: an HTTP/1.0 client (no reliable chunked/progressive render)
+// is served the existing one-shot page instead.
+package proxyinterstitial
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"html"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Probe attempts to establish/verify the route to the interstitial's target.
+// It returns nil when the route is ready (the browser should reload into live
+// content), or an error while still warming. The streamer calls it on a loop
+// (StreamConfig.Interval) until it succeeds, a non-transient error occurs, or
+// StreamConfig.Deadline elapses. A successful Probe should leave the route warm
+// (e.g. in the resolver's route pool) so the browser's reload hits real content.
+type Probe func(ctx context.Context) error
+
+// StreamConfig configures a streaming interstitial.
+type StreamConfig struct {
+	Target    string // host shown on the page (HTML-escaped by the renderer)
+	Mechanism string // "skysocks" / "dmsg" / "skynet" — brands the copy
+	Probe     Probe  // drives + observes the real route-setup attempt
+	Interval  time.Duration
+	Deadline  time.Duration
+}
+
+func (c StreamConfig) withDefaults() StreamConfig {
+	if c.Interval <= 0 {
+		c.Interval = 1 * time.Second
+	}
+	if c.Deadline <= 0 {
+		c.Deadline = 30 * time.Second
+	}
+	return c
+}
+
+// StreamConn returns a net.Conn that serves a chunked, progressively-rendered
+// interstitial driven by cfg.Probe, suitable for handing to go-socks5 as the
+// tunnel conn (same injection model as Conn). Writes (the browser's request) are
+// read to completion first; an HTTP/1.0 request falls back to the one-shot page.
+func StreamConn(ctx context.Context, cfg StreamConfig) net.Conn {
+	cfg = cfg.withDefaults()
+	srvConn, cliConn := net.Pipe()
+	go func() {
+		defer srvConn.Close() //nolint:errcheck
+		br := bufio.NewReader(srvConn)
+		req, err := http.ReadRequest(br)
+		if err != nil {
+			return
+		}
+		// HTTP/1.0 clients don't reliably render a streamed/chunked body — serve
+		// the one-shot page (still branded + auto-refreshing) instead.
+		if req.ProtoMajor == 1 && req.ProtoMinor == 0 {
+			_, _ = srvConn.Write(httpResponse(cfg.Target, "", cfg.Mechanism, false)) //nolint:errcheck
+			return
+		}
+		head := "HTTP/1.1 200 OK\r\n" +
+			"Content-Type: text/html; charset=utf-8\r\n" +
+			"Transfer-Encoding: chunked\r\n" +
+			"Cache-Control: no-store, must-revalidate\r\n" +
+			"Connection: close\r\n\r\n"
+		if _, err := io.WriteString(srvConn, head); err != nil {
+			return
+		}
+		cw := &chunkWriter{w: srvConn}
+		DriveStream(ctx, cw, cfg)
+		_ = cw.End() //nolint:errcheck
+	}()
+	return cliConn
+}
+
+// DriveStream renders the streaming interstitial to w: the opening shell, one
+// progress line per real Probe attempt, and a closing chunk (reload-into-content
+// on success, or an error + manual-retry on a hard failure / deadline). Exported
+// so a caller that already streams over an http.ResponseWriter / io.Pipe (e.g.
+// the browse-origin reverse proxy) can reuse the exact same rendering without the
+// chunked-conn framing. w is written as raw HTML fragments; the HTTP layer
+// (chunkWriter for the SOCKS path, the net/http server for the proxy path) frames
+// and flushes them.
+func DriveStream(ctx context.Context, w io.Writer, cfg StreamConfig) {
+	cfg = cfg.withDefaults()
+	emit := func(s string) bool { _, err := io.WriteString(w, s); return err == nil }
+	if f, ok := w.(flusher); ok {
+		orig := emit
+		emit = func(s string) bool {
+			if !orig(s) {
+				return false
+			}
+			f.Flush()
+			return true
+		}
+	}
+
+	if !emit(StreamOpen(cfg.Target, cfg.Mechanism)) {
+		return
+	}
+	emit(StreamStep("Building a route over "+mechanismLabel(cfg.Mechanism)+"…", "active"))
+
+	if cfg.Probe == nil {
+		emit(StreamClose(false, "no route-setup probe available"))
+		return
+	}
+
+	deadline := time.Now().Add(cfg.Deadline)
+	ticker := time.NewTicker(cfg.Interval)
+	defer ticker.Stop()
+	for {
+		err := cfg.Probe(ctx)
+		if err == nil {
+			emit(StreamStep("Route group up", "done"))
+			emit(StreamClose(true, ""))
+			return
+		}
+		if !IsTransient(err) {
+			emit(StreamStep(StatusLine(err), "err"))
+			emit(StreamClose(false, err.Error()))
+			return
+		}
+		if time.Now().After(deadline) {
+			emit(StreamStep(StatusLine(err), "err"))
+			emit(StreamClose(false, "route still warming — try again"))
+			return
+		}
+		emit(StreamStep(StatusLine(err), "active"))
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// flusher is net/http's http.Flusher without importing it here (the SOCKS path's
+// chunkWriter also implements it), so DriveStream flushes each fragment on either
+// transport.
+type flusher interface{ Flush() }
+
+// StreamOpen is the opening HTML of a streaming interstitial: the branded card
+// header and the (open) live progress list. Subsequent StreamStep fragments
+// append <li> rows to it; StreamClose finishes the list and the document.
+func StreamOpen(target, _ string) string {
+	title := "Connecting over skywire…"
+	heading := "Building a route over the mesh…"
+	msg := "Establishing a private route to this site. Live progress below."
+	return `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+		`<meta name="viewport" content="width=device-width, initial-scale=1">` +
+		`<title>` + title + `</title><style>` + css + `</style></head>` +
+		`<body><div id="mesh-boot"><div class="card" id="mesh-card">` +
+		brandMark +
+		`<div class="sp" id="mesh-sp"></div>` +
+		`<h1 id="mesh-title">` + html.EscapeString(heading) + `</h1>` +
+		`<p id="mesh-msg">` + html.EscapeString(msg) + `</p>` +
+		`<small id="mesh-host">` + html.EscapeString(strings.TrimSpace(target)) + `</small>` +
+		`<ul class="steps" id="mesh-steps">` +
+		// Enough leading padding so browsers begin incremental render immediately
+		// rather than buffering a minimum before first paint.
+		"<!-- " + strings.Repeat("skywire ", 128) + "-->"
+}
+
+// StreamStep is one live progress line. state is "active" (in progress),
+// "done" (completed) or "err" (failed). text is HTML-escaped.
+func StreamStep(text, state string) string {
+	cls := "active"
+	switch state {
+	case "done":
+		cls = "done"
+	case "err":
+		cls = "err"
+	}
+	return `<li class="` + cls + `">` + html.EscapeString(text) + `</li>`
+}
+
+// StreamClose finishes the document. On ok it appends a "route up" line and a
+// script that reloads the SAME URL — which now streams real content because the
+// successful probe left the route warm. On failure it shows detail + a manual
+// retry, and does NOT auto-reload.
+func StreamClose(ok bool, detail string) string {
+	var b strings.Builder
+	b.WriteString(`</ul>`)
+	if ok {
+		b.WriteString(`<p class="ready">Route up — loading the page…</p>`)
+		// replace() so the interstitial isn't left in history; the reload
+		// re-requests through the proxy and hits the now-warm route.
+		b.WriteString(`<script>location.replace(location.href)</script>`)
+	} else {
+		if d := strings.TrimSpace(detail); d != "" {
+			b.WriteString(`<p id="mesh-detail" style="display:block">` + html.EscapeString(d) + `</p>`)
+		}
+		b.WriteString(`<button class="btn" onclick="location.reload()">Retry</button>`)
+	}
+	b.WriteString(`</div></div></body></html>`)
+	return b.String()
+}
+
+// chunkWriter frames each Write as a single HTTP/1.1 chunk and flushes it (a
+// net.Pipe Write already delivers synchronously, so Flush is a no-op but lets
+// chunkWriter satisfy the flusher interface DriveStream keys on).
+type chunkWriter struct{ w io.Writer }
+
+func (c *chunkWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if _, err := fmt.Fprintf(c.w, "%x\r\n", len(p)); err != nil {
+		return 0, err
+	}
+	if _, err := c.w.Write(p); err != nil {
+		return 0, err
+	}
+	if _, err := io.WriteString(c.w, "\r\n"); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *chunkWriter) Flush() {}
+
+// End writes the terminating zero-length chunk.
+func (c *chunkWriter) End() error {
+	_, err := io.WriteString(c.w, "0\r\n\r\n")
+	return err
+}

--- a/pkg/proxyinterstitial/stream_test.go
+++ b/pkg/proxyinterstitial/stream_test.go
@@ -1,0 +1,108 @@
+package proxyinterstitial
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// readStreamBody drives one request/response over the streaming conn and returns
+// the fully de-chunked body.
+func readStreamBody(t *testing.T, c net.Conn, reqLine string) string {
+	t.Helper()
+	go func() { _, _ = c.Write([]byte(reqLine)) }()
+	resp, err := http.ReadResponse(bufio.NewReader(c), nil)
+	if err != nil {
+		t.Fatalf("ReadResponse: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return string(body)
+}
+
+func TestStreamConnReloadsOnReady(t *testing.T) {
+	var n int32
+	cfg := StreamConfig{
+		Target: "host.skynet", Mechanism: "skynet",
+		Interval: 2 * time.Millisecond, Deadline: 2 * time.Second,
+		Probe: func(context.Context) error {
+			if atomic.AddInt32(&n, 1) < 3 { // fail twice, then succeed
+				return errors.New("no route to host")
+			}
+			return nil
+		},
+	}
+	c := StreamConn(context.Background(), cfg)
+	body := readStreamBody(t, c, "GET / HTTP/1.1\r\nHost: host.skynet\r\n\r\n")
+
+	for _, want := range []string{"skywire", "host.skynet", "Building a route", "Route group up", "location.replace(location.href)"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("streamed body missing %q\n---\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "Retry") {
+		t.Error("success stream must not offer a manual retry")
+	}
+	if got := atomic.LoadInt32(&n); got < 3 {
+		t.Errorf("probe called %d times, expected >=3", got)
+	}
+}
+
+func TestStreamConnHardError(t *testing.T) {
+	cfg := StreamConfig{
+		Target: "host.dmsg", Mechanism: "dmsg",
+		Interval: 2 * time.Millisecond, Deadline: 2 * time.Second,
+		Probe: func(context.Context) error {
+			return errors.New("permanently broken widget") // not transient
+		},
+	}
+	c := StreamConn(context.Background(), cfg)
+	body := readStreamBody(t, c, "GET / HTTP/1.1\r\nHost: host.dmsg\r\n\r\n")
+
+	if !strings.Contains(body, "Retry") {
+		t.Errorf("hard-error stream should offer a manual retry\n%s", body)
+	}
+	if strings.Contains(body, "location.replace") {
+		t.Error("hard-error stream must not auto-reload")
+	}
+}
+
+func TestStreamConnHTTP10Fallback(t *testing.T) {
+	cfg := StreamConfig{
+		Target: "host.skynet", Mechanism: "skynet",
+		Probe: func(context.Context) error { return nil },
+	}
+	c := StreamConn(context.Background(), cfg)
+	body := readStreamBody(t, c, "GET / HTTP/1.0\r\nHost: host.skynet\r\n\r\n")
+
+	// The one-shot page (auto-refresh), not the streamed one.
+	if !strings.Contains(body, `http-equiv="refresh"`) {
+		t.Errorf("HTTP/1.0 client should get the one-shot meta-refresh page\n%s", body)
+	}
+	if strings.Contains(body, "location.replace") {
+		t.Error("fallback page should not carry the stream reload script")
+	}
+}
+
+func TestStreamConnEscapesTarget(t *testing.T) {
+	cfg := StreamConfig{
+		Target: "<script>evil()</script>", Mechanism: "skynet",
+		Interval: time.Millisecond, Deadline: time.Second,
+		Probe: func(context.Context) error { return nil },
+	}
+	c := StreamConn(context.Background(), cfg)
+	body := readStreamBody(t, c, "GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+	if strings.Contains(body, "<script>evil()") {
+		t.Error("target host was not HTML-escaped in the stream")
+	}
+}

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -274,9 +274,19 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 				}
 				switch {
 				case proxyinterstitial.ShouldServe(port):
+					// Stream REAL route-setup progress over a chunked response,
+					// driving a fresh skynet dial via a probe and reloading into live
+					// content once the route is warm; HTTP/1.0 clients fall back to the
+					// one-shot page inside StreamConn. Wrapped in tcpAddrConn for
+					// go-socks5's *net.TCPAddr BND assertion (the stream conn is a
+					// net.Pipe). See pkg/dmsgweb/runtime.go for the rationale.
 					log.WithField("host", target).WithField("err", retErr).
-						Debug("SOCKS5 → serving branded route interstitial")
-					retConn, retErr = proxyinterstitial.Conn(target, proxyinterstitial.StatusLine(retErr), "skynet", false), nil
+						Debug("SOCKS5 → serving streaming route interstitial")
+					retConn, retErr = &tcpAddrConn{Conn: proxyinterstitial.StreamConn(context.Background(), proxyinterstitial.StreamConfig{
+						Target:    target,
+						Mechanism: "skynet",
+						Probe:     skynetRedialProbe(dialer, cfg, upstream, origHost, addr),
+					})}, nil
 				case cfg.TLSMITM && isTLSPort(port, cfg.TLSPort) && skynetca.Permits(cfg.LeafMinter, origHost):
 					// HTTPS request whose route is still warming: terminate the
 					// browser's TLS locally with a per-host leaf and serve the
@@ -517,6 +527,47 @@ func (c *tcpAddrConn) LocalAddr() net.Addr {
 // isTLSPort reports whether the string port equals the configured TLS-MITM port.
 func isTLSPort(port string, tlsPort uint16) bool {
 	return port != "" && port == fmt.Sprintf("%d", tlsPort)
+}
+
+// skynetRedialProbe builds a proxyinterstitial.Probe that re-attempts the dial
+// the streaming interstitial stands in for. For a .skynet target it re-drives a
+// real skynet dial (route setup + handshake) via the same SkynetDialer and
+// reports ready (nil) once it succeeds — a coarse but real signal, since the
+// router exposes no per-hop setup event to observe. A non-.skynet target
+// re-attempts the upstream/direct forward. The probe closes the opened
+// conn immediately; the browser's reload then rides the now-warm route.
+func skynetRedialProbe(dialer SkynetDialer, cfg Config, upstream *upstreamForwarder, origHost, addr string) proxyinterstitial.Probe {
+	return func(ctx context.Context) error {
+		if origHost != "" && isSkynetHost(origHost, cfg.DomainSuffix) {
+			_, addrPort, _ := net.SplitHostPort(addr) //nolint:errcheck
+			hostWithPort := origHost
+			if addrPort != "" && addrPort != "80" {
+				hostWithPort = origHost + ":" + addrPort
+			}
+			_, route, dest, hport, err := ParseResolverHost(hostWithPort, cfg.DomainSuffix, cfg.Aliases)
+			if err != nil {
+				return err
+			}
+			c, e := dialer.DialSkynet(ctx, dest, hport, route)
+			if e == nil {
+				_ = c.Close() //nolint:errcheck
+			}
+			return e
+		}
+		var (
+			c net.Conn
+			e error
+		)
+		if upstream != nil {
+			c, e = upstream.dial("tcp", addr)
+		} else {
+			c, e = net.Dial("tcp", addr)
+		}
+		if e == nil {
+			_ = c.Close() //nolint:errcheck
+		}
+		return e
+	}
 }
 
 func isSkynetHost(host, suffix string) bool {

--- a/pkg/visor/meshproxy.go
+++ b/pkg/visor/meshproxy.go
@@ -208,18 +208,27 @@ const meshInterstitialSoftTimeout = 4 * time.Second
 type meshInterstitialRT struct {
 	next http.RoundTripper
 	soft time.Duration
+	// streamMax bounds how long the streaming interstitial holds the browser
+	// open waiting on the detached round-trip before it stops streaming and
+	// offers a manual retry (the background round-trip keeps running).
+	streamMax time.Duration
 
 	mu       sync.Mutex
 	warm     map[string]struct{} // destinations with a confirmed round-trip
 	inFlight map[string]struct{} // destinations with a warm-up dial in progress
 }
 
+// meshStreamMax is the default streaming-interstitial hold time (a touch above a
+// cold multi-hop route's worst case, so the "route up → reload" lands live).
+const meshStreamMax = 25 * time.Second
+
 func newMeshInterstitialRT(next http.RoundTripper, soft time.Duration) *meshInterstitialRT {
 	return &meshInterstitialRT{
-		next:     next,
-		soft:     soft,
-		warm:     map[string]struct{}{},
-		inFlight: map[string]struct{}{},
+		next:      next,
+		soft:      soft,
+		streamMax: meshStreamMax,
+		warm:      map[string]struct{}{},
+		inFlight:  map[string]struct{}{},
 	}
 }
 
@@ -346,18 +355,76 @@ func (rt *meshInterstitialRT) RoundTrip(req *http.Request) (*http.Response, erro
 		rt.markWarm(key)
 		return res.resp, nil
 	case <-timer.C:
-		// Still warming. Keep the detached round-trip running in the background so
-		// the dmsg session / skynet route establishes and the stream recycles into
-		// the idle pool; then serve the interstitial now.
-		go func() {
-			res := <-ch
+		// Still warming. Stream the branded interstitial with LIVE progress from
+		// the SAME detached round-trip (the real in-flight attempt) and reload
+		// into content the moment it lands — instead of a static page + blind
+		// meta-refresh. The detached round-trip keeps running regardless, so the
+		// route establishes and the warmed stream recycles into the idle pool.
+		return rt.streamingInterstitialResponse(req, ch, key), nil
+	}
+}
+
+// streamingInterstitialResponse returns a chunked/streamed interstitial whose
+// body renders live route-setup progress driven by the detached round-trip on
+// ch: an initial "building a route" line, then — when the real round-trip lands
+// — either a "route up" line + a reload into live content (success), or the real
+// error + a manual retry. It shares the exact rendering (StreamOpen/Step/Close)
+// with the SOCKS-path streaming interstitial. The ReverseProxy flushes each
+// fragment (FlushInterval < 0 in newMeshReverseProxy), so the browser paints
+// progressively. This is the interstitial surface with a genuine in-flight
+// attempt to observe (the others re-drive one via a probe).
+func (rt *meshInterstitialRT) streamingInterstitialResponse(req *http.Request, ch <-chan meshRTResult, key string) *http.Response {
+	target := meshInterstitialTarget(req)
+	mech := meshInterstitialMechanism(target)
+	label := mech
+	if label == "" {
+		label = "skywire"
+	}
+	pr, pw := io.Pipe()
+	go func() {
+		defer pw.Close()                                                                                      //nolint:errcheck
+		_, _ = io.WriteString(pw, proxyinterstitial.StreamOpen(target, mech))                                 //nolint:errcheck
+		_, _ = io.WriteString(pw, proxyinterstitial.StreamStep("Building a route over "+label+"…", "active")) //nolint:errcheck
+		timer := time.NewTimer(rt.streamMax)
+		defer timer.Stop()
+		select {
+		case res := <-ch:
 			rt.releaseWarmup(key)
 			if res.err == nil {
 				rt.markWarm(key)
 				drainAndClose(res.resp)
+				_, _ = io.WriteString(pw, proxyinterstitial.StreamStep("Route group up", "done")) //nolint:errcheck
+				_, _ = io.WriteString(pw, proxyinterstitial.StreamClose(true, ""))                //nolint:errcheck
+				return
 			}
-		}()
-		return rt.interstitialResponse(req, "", false), nil
+			_, _ = io.WriteString(pw, proxyinterstitial.StreamStep(proxyinterstitial.StatusLine(res.err), "err")) //nolint:errcheck
+			_, _ = io.WriteString(pw, proxyinterstitial.StreamClose(false, res.err.Error()))                      //nolint:errcheck
+		case <-timer.C:
+			// Stop streaming but let the detached round-trip finish + recycle.
+			go func() {
+				res := <-ch
+				rt.releaseWarmup(key)
+				if res.err == nil {
+					rt.markWarm(key)
+					drainAndClose(res.resp)
+				}
+			}()
+			_, _ = io.WriteString(pw, proxyinterstitial.StreamStep("route still warming — try again", "err")) //nolint:errcheck
+			_, _ = io.WriteString(pw, proxyinterstitial.StreamClose(false, "route still warming"))            //nolint:errcheck
+		}
+	}()
+	h := make(http.Header)
+	h.Set("Content-Type", "text/html; charset=utf-8")
+	h.Set("Cache-Control", "no-store, must-revalidate")
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     h,
+		Body:       pr,
+		Request:    req,
 	}
 }
 
@@ -447,8 +514,13 @@ func (v *Visor) newMeshReverseProxy(resolve meshResolveFn) (*httputil.ReversePro
 	}
 	return &httputil.ReverseProxy{
 		// dmsg/skynet dispatcher (streaming), wrapped with the cold-route fast-path
-		// that serves the branded auto-refreshing interstitial while a route warms.
+		// that serves the branded interstitial (now streaming live route-setup
+		// progress) while a route warms.
 		Transport: newMeshInterstitialRT(v.meshRoundTripper(), meshInterstitialSoftTimeout),
+		// Flush each write to the client immediately: the streaming interstitial
+		// paints progress fragments as they arrive, and mesh sites that stream
+		// (SSE / chunked) reach the browser promptly rather than being buffered.
+		FlushInterval: -1,
 		// Rewrite (not Director): does NOT auto-add X-Forwarded-* (privacy) and lets
 		// us stash per-request state in the outbound context instead of leaking
 		// X-Mesh-* headers to the upstream site.

--- a/pkg/visor/meshproxy_test.go
+++ b/pkg/visor/meshproxy_test.go
@@ -222,6 +222,7 @@ func TestInterstitialRTColdServesTransient(t *testing.T) {
 	g := &gateRT{release: make(chan struct{})} // blocks until released
 	defer close(g.release)                     // let the warm-up dial finish at teardown
 	rt := newMeshInterstitialRT(g, 30*time.Millisecond)
+	rt.streamMax = 60 * time.Millisecond // bound the streaming hold so the test is fast
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req := meshCtxReq(t, ctx, "dmsg", true)
@@ -238,10 +239,17 @@ func TestInterstitialRTColdServesTransient(t *testing.T) {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
 	body := readBody(t, resp)
-	for _, want := range []string{"Building a route", `http-equiv="refresh"`, "site.example"} {
+	// The cold path now STREAMS live progress (chunked) rather than serving a
+	// one-shot meta-refresh page: the opening shell + a progress line, and — since
+	// the warm-up dial stays gated past streamMax here — a manual retry, with NO
+	// client meta-refresh (the streamed page reloads via script on success).
+	for _, want := range []string{"Building a route", "site.example", "Retry"} {
 		if !strings.Contains(body, want) {
-			t.Errorf("interstitial body missing %q", want)
+			t.Errorf("streamed interstitial body missing %q", want)
 		}
+	}
+	if strings.Contains(body, `http-equiv="refresh"`) {
+		t.Error("streaming interstitial should not use a client meta-refresh")
 	}
 
 	// A background warm-up dial was started, and it ran on a detached context that
@@ -252,6 +260,35 @@ func TestInterstitialRTColdServesTransient(t *testing.T) {
 	cancel() // cancel the inbound request
 	if dctx := g.ctx(); dctx.Err() != nil {
 		t.Fatalf("detached upstream context was canceled by the inbound request: %v", dctx.Err())
+	}
+}
+
+// When the detached round-trip lands while the streaming interstitial is still
+// held open, the stream finishes with a "route up" line and a reload-into-content
+// script (no manual retry) — the live-progress success path.
+func TestInterstitialRTStreamingReloadsOnReady(t *testing.T) {
+	g := &gateRT{release: make(chan struct{})} // gated, then released to succeed
+	rt := newMeshInterstitialRT(g, 30*time.Millisecond)
+	rt.streamMax = 5 * time.Second
+
+	req := meshCtxReq(t, context.Background(), "dmsg", true)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	close(g.release) // let the detached (real) round-trip complete successfully
+
+	body := readBody(t, resp)
+	for _, want := range []string{"Building a route", "Route group up", "location.replace(location.href)"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("streamed success body missing %q\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "Retry") {
+		t.Error("streamed success should not show a manual retry")
+	}
+	if !rt.isWarm(meshDestKey(req)) {
+		t.Error("destination should be marked warm after the streamed round-trip succeeded")
 	}
 }
 


### PR DESCRIPTION
Third refinement in the proxy status/interstitial series (after #4050 status pages and #4053 HTTPS+contrast). Makes the route interstitial show **live** route-setup progress instead of a canned CSS animation + blind meta-refresh.

## What changed

New `pkg/proxyinterstitial/stream.go`: the interstitial can hold the browser connection **open** and stream progress via HTTP **chunked transfer-encoding**, flushing a chunk per real attempt, then — once the route is up — flushing a final chunk that reloads the page into the now-live content.

- `StreamConn(ctx, StreamConfig)` — a chunked `net.Conn` for the SOCKS mint path (handed to go-socks5 like the one-shot `Conn`).
- `DriveStream` + `StreamOpen`/`StreamStep`/`StreamClose` — shared progressive-HTML rendering, reused by the reverse-proxy path.
- A caller-supplied `Probe` drives a real route-setup attempt; each attempt's real `StatusLine` is streamed as a progress line; success streams a `location.replace()` reload.

## The event-source seam (investigated first, reported honestly)

The interstitial is minted **after** a dial has already failed transiently — there's no in-flight setup to subscribe to at that point, and **`pkg/router` exposes no per-hop / noise-handshake progress hook**: `DialOptions` has no observer, and even the mux-telemetry harness only *synthesizes* coarse `RouteEstablished`/failed events around its own `DialRoutes` call. So the granular `finding route → 2-hop via <pk> → noise handshake → route group up` narrative **is not observable today** and is **not fabricated** here. Two real (coarse) sources are used:

- **browse-origin** (`meshInterstitialRT`): it already runs the real cold-route round-trip in the background — the one surface with a genuine in-flight attempt — so the stream renders *that* attempt's outcome and reloads on success (`streamingInterstitialResponse`; `ReverseProxy.FlushInterval < 0` flushes fragments).
- **SOCKS resolving proxies** (`dmsgweb` / `skynetweb`): no live attempt at the mint point, so the streamer **drives a fresh one** via a re-dial `Probe` (`dmsgRedialProbe` / `skynetRedialProbe`) and streams each real attempt.

**Missing seam to add later (in `pkg/router`, owned separately):** a `DialOptions.OnProgress func(phase)` callback invoked by `DialRoutes` / the cascade setup path as hops resolve and the noise handshake completes — that's what would turn the coarse lines into the granular narrative. Not added here. `pkg/skysocks` `ServeSOCKS5` is also left one-shot (its mint point tears the session down for reconnect — nothing to observe/drive from there).

## Fallback

`StreamConn` reads the request first and serves the existing one-shot meta-refresh page to an **HTTP/1.0** client; a nil probe / absent source likewise degrades to the static page. The pre-soft-deadline error paths (browse-origin) remain one-shot.

## Liveness tie-in

The probe *is* the "is-my-connection-up" signal; a future `status.*` mux view can share it as a WS/WT liveness indicator — noted as an extension point, not built here.

## Testing / scope

`pkg/proxyinterstitial`: streamed success / hard-error / HTTP-1.0-fallback / escaping. `pkg/visor`: updated the cold `meshInterstitialRT` test for the streamed body + added a streamed-success test. `go build .`, `go vet`, `goimports -local` clean; touched-package tests pass. Contained to `pkg/proxyinterstitial`, the two resolving-proxy runtimes, and `pkg/visor/meshproxy.go`; `pkg/router`/policy untouched.

**Live-validation caveat:** the chunked serve + go-socks5 splice and the browse-origin flush path are unit-tested via `http.ReadResponse`/pipe mechanics, but not exercised against a real browser in this environment — worth a live smoke test (cold-route navigation shows streamed lines then reloads).