### PR TITLE
fix(dmsgscp): accept route-group skynet conns (routing.Addr); ensure transport before scp skynet dial

### DIFF
--- a/pkg/dmsg/dmsgscp/host.go
+++ b/pkg/dmsg/dmsgscp/host.go
@@ -32,6 +32,7 @@ import (
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/pty"
+	"github.com/skycoin/skywire/pkg/routing"
 )
 
 // Whitelist is an alias for pty.Whitelist so operators can pass
@@ -107,7 +108,8 @@ func (h *Host) ListenAndServe(ctx context.Context, port uint16) error {
 //
 // Authorization (whitelist check) happens per-stream and works
 // uniformly across listener types because remoteAddrToPK handles
-// both dmsg.Addr and appnet.Addr shapes.
+// dmsg.Addr plus both skynet shapes (appnet.Addr direct-transport +
+// routing.Addr route-group).
 func (h *Host) ServeListener(ctx context.Context, lis net.Listener) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -170,14 +172,30 @@ func (h *Host) ServeListener(ctx context.Context, lis net.Listener) error {
 }
 
 // remoteAddrToPK extracts a cipher.PubKey from an accepted conn's
-// RemoteAddr. Supports dmsg.Addr (dmsg listener) and appnet.Addr
-// (skynet listener via the skywire router). Unrecognized address
-// types return ok=false; the caller logs + closes the connection.
+// RemoteAddr. Supports dmsg.Addr (dmsg listener) and, for the skynet
+// mirror, BOTH address shapes the SkywireNetworker's accepted conns
+// carry:
+//
+//   - appnet.Addr — the direct-transport accept path (a vstream over
+//     an existing direct transport to the peer).
+//   - routing.Addr — the route-group accept path (DialRoutes →
+//     NoiseRouteGroup, whose RemoteAddr resolves to the route
+//     descriptor's source).
+//
+// Recognizing routing.Addr is required for skynet parity: without it,
+// every route-group-backed scp conn (including self-dial, which has no
+// direct transport and always falls into DialRoutes) is silently
+// rejected here and closed, surfacing to the client as a bare EOF on
+// the ready-ack. This mirrors the dmsgpty extractor skywireConnPK in
+// pkg/visor/init_dmsg_skywire.go, which had the identical fix applied.
+// Unrecognized address types return ok=false; the caller logs + closes.
 func remoteAddrToPK(addr net.Addr) (cipher.PubKey, bool) {
 	switch a := addr.(type) {
 	case dmsg.Addr:
 		return a.PK, true
 	case appnet.Addr:
+		return a.PubKey, true
+	case routing.Addr:
 		return a.PubKey, true
 	}
 	return cipher.PubKey{}, false

--- a/pkg/visor/api_visor_scp.go
+++ b/pkg/visor/api_visor_scp.go
@@ -130,6 +130,16 @@ func (v *Visor) dialSCPSkynet(ctx context.Context, rPK cipher.PubKey, port uint1
 	if _, err := appnet.ResolveNetworker(appnet.TypeSkynet); err != nil {
 		return nil, fmt.Errorf("skynet networker not registered: %w", err)
 	}
+	// Best-effort: ensure a direct (stcpr→sudph) transport to the peer
+	// exists so skynet has a real route to dial over instead of
+	// blocking to the caller's deadline. This mirrors the pty skynet
+	// dialer (skywireDialer.DialStream), which is what makes `cli pty
+	// exec --scheme skynet` stable; without it the appnet dial below
+	// has no route and stalls. The error is intentionally swallowed —
+	// exactly as the pty path does — so the dial still runs and
+	// surfaces its own "no route" error if the peer is genuinely
+	// unreachable (or is a non-visor host that can't peer a transport).
+	_ = v.ensureFastTransport(rPK) //nolint:errcheck // best-effort; the dial below handles a genuine miss
 	return appnet.DialContext(ctx, appnet.Addr{
 		Net:    appnet.TypeSkynet,
 		PubKey: rPK,


### PR DESCRIPTION
## What

Fix `dmsg scp --transport skynet` (and the visor's `VisorSCP` skynet path), which failed with `dmsgscp: ready ack: EOF` or hung to the deadline, while `pty exec --scheme skynet` worked to the same peer.

## Root cause

The dmsgscp skynet mirror rejected every **route-group**-backed connection. `remoteAddrToPK` in `pkg/dmsg/dmsgscp/host.go` only recognized `dmsg.Addr` and `appnet.Addr`, but a skynet conn established via `DialRoutes` (`NoiseRouteGroup`) presents a `routing.Addr`. The peer PK could not be extracted, so the host logged "cannot extract peer PK … closing" and closed the stream — the client saw a bare `ready ack: EOF`. Self-dial (no direct transport, always `DialRoutes`) hit this every time; cross-visor transfers hit it whenever the dial fell to the route-group path.

This is the **same bug already fixed for dmsgpty**: `skywireConnPK` in `pkg/visor/init_dmsg_skywire.go` recognizes `appnet.Addr` **and** `routing.Addr` (its comment notes the pre-fix version "silently rejected every route-group-backed dmsgpty skynet conn"). dmsgscp never got the parallel fix — which is exactly why pty-skynet worked and scp-skynet did not.

## Change

1. `dmsgscp/host.go` `remoteAddrToPK` now also accepts `routing.Addr` (the real fix), mirroring the dmsgpty extractor.
2. `pkg/visor/api_visor_scp.go` `dialSCPSkynet` now calls `ensureFastTransport` before `appnet.DialContext`, mirroring the pty skynet dialer (`skywireDialer.DialStream`) so a direct transport is established and the dial takes the fast path instead of stalling to the caller's deadline. Best-effort and error-swallowed, exactly as the pty path does it.

## Validation

- `pty exec --scheme skynet` works to the live far-end; `dmsg scp --transport skynet` to the same peer reproduced the `ready ack: EOF` / timeout — pinpointing the divergence to the host-side extractor (port-22 pty mirror handled route-group conns; port-23 scp mirror did not).
- `go build`, `go vet`, `go test ./pkg/dmsg/dmsgscp` clean; full `make check` clean.

**Mesh-wide skynet-scp proof lands only after the fleet ripples** this change: the failing side is the far end's *serve* loop, so both upload (far end = SINK host) and download (far end = SOURCE host) need the far end running this fix. It cannot be demonstrated end-to-end against an un-updated peer; it validates post-deploy, the same as any host-side fleet fix.

`dmsg scp --transport auto` and `--transport dmsg` are **unaffected and working today** (round-trip verified live) — this only repairs the `skynet` transport.
