### PR TITLE
fix(router): retransmit route-group setup handshake to prevent intermittent skynet route drops

### DIFF
--- a/pkg/router/handshake_retransmit_test.go
+++ b/pkg/router/handshake_retransmit_test.go
@@ -1,0 +1,168 @@
+// Package router pkg/router/handshake_retransmit_test.go
+package router
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// countingTransport is a working transport that records how many times Write
+// was called, so a test can observe (re)transmitted handshake packets.
+type countingTransport struct {
+	closed   chan struct{}
+	writes   int32
+	pk1, pk2 cipher.PubKey
+}
+
+func newCountingTransport() *countingTransport {
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+	return &countingTransport{closed: make(chan struct{}), pk1: pk1, pk2: pk2}
+}
+
+func (t *countingTransport) Write(b []byte) (int, error) {
+	select {
+	case <-t.closed:
+		return 0, net.ErrClosed
+	default:
+		atomic.AddInt32(&t.writes, 1)
+		return len(b), nil
+	}
+}
+func (t *countingTransport) writeCount() int { return int(atomic.LoadInt32(&t.writes)) }
+
+func (t *countingTransport) Read([]byte) (int, error) { <-t.closed; return 0, net.ErrClosed }
+func (t *countingTransport) Close() error {
+	select {
+	case <-t.closed:
+	default:
+		close(t.closed)
+	}
+	return nil
+}
+func (t *countingTransport) LocalAddr() net.Addr              { return &net.TCPAddr{} }
+func (t *countingTransport) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
+func (t *countingTransport) SetDeadline(time.Time) error      { return nil }
+func (t *countingTransport) SetReadDeadline(time.Time) error  { return nil }
+func (t *countingTransport) SetWriteDeadline(time.Time) error { return nil }
+func (t *countingTransport) LocalPK() cipher.PubKey           { return t.pk1 }
+func (t *countingTransport) RemotePK() cipher.PubKey          { return t.pk2 }
+func (t *countingTransport) LocalPort() uint16                { return 0 }
+func (t *countingTransport) RemotePort() uint16               { return 0 }
+func (t *countingTransport) LocalRawAddr() net.Addr           { return &net.TCPAddr{} }
+func (t *countingTransport) RemoteRawAddr() net.Addr          { return &net.TCPAddr{} }
+func (t *countingTransport) Network() types.Type              { return "test" }
+
+// The reciprocal handshake arriving stops the retransmit loop and returns nil,
+// even though the initiator had begun retransmitting.
+func TestAwaitHandshakeAck_StopsOnProcessed(t *testing.T) {
+	processed := make(chan struct{})
+	var calls int32
+	retransmit := func() { atomic.AddInt32(&calls, 1) }
+
+	go func() {
+		time.Sleep(35 * time.Millisecond) // let at least one retransmit tick fire
+		close(processed)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := awaitHandshakeAck(ctx, processed, retransmit, 10*time.Millisecond)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, int(atomic.LoadInt32(&calls)), 1, "initiator should retransmit while waiting")
+}
+
+// A responder passes retransmit == nil: it must simply wait for the forward
+// handshake with no retransmission and no panic.
+func TestAwaitHandshakeAck_ResponderNoRetransmit(t *testing.T) {
+	processed := make(chan struct{})
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		close(processed)
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, awaitHandshakeAck(ctx, processed, nil, 0))
+}
+
+// When the peer never acks, the wait returns the context error (the caller then
+// hard-fails the dial) — but only after retransmitting several times, proving a
+// lost handshake would have been given multiple chances to recover.
+func TestAwaitHandshakeAck_TimeoutAfterRetransmits(t *testing.T) {
+	var calls int32
+	retransmit := func() { atomic.AddInt32(&calls, 1) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Millisecond)
+	defer cancel()
+	err := awaitHandshakeAck(ctx, make(chan struct{}), retransmit, 20*time.Millisecond)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.GreaterOrEqual(t, int(atomic.LoadInt32(&calls)), 2, "handshake must be retransmitted multiple times before failing")
+}
+
+// End-to-end at the route-group level: an initiator that never receives the
+// reciprocal handshake keeps re-sending the real handshake packet over its
+// transport (more than the single legacy shot) until the deadline.
+func TestRouteGroup_InitiatorRetransmitsHandshake(t *testing.T) {
+	rg, _, _ := createMuxRouteGroup(t, 1)
+	t.Cleanup(func() { _ = rg.Close() })
+	rg.initiator = true
+
+	conn := newCountingTransport()
+	mt := transport.NewManagedTransportForTest(conn)
+	mt.Entry = transport.Entry{ID: rg.fwd[0].NextTransportID(), Type: "test"}
+	rg.mu.Lock()
+	rg.tps[0] = mt // swap the leg's transport for a counting one
+	rg.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 130*time.Millisecond)
+	defer cancel()
+	retransmit := func() { _ = rg.sendHandshake(true) }
+	err := awaitHandshakeAck(ctx, rg.handshakeProcessed, retransmit, 25*time.Millisecond)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.GreaterOrEqual(t, conn.writeCount(), 2, "initiator should retransmit the handshake packet repeatedly")
+}
+
+// A duplicate forward handshake at the responder (the initiator retransmitting
+// because its reverse ack was lost) must trigger a re-ack: the responder
+// re-sends its handshake so the initiator's retransmit loop can complete.
+func TestRouteGroup_ResponderReAcksDuplicateHandshake(t *testing.T) {
+	rg, _, _ := createMuxRouteGroup(t, 1)
+	t.Cleanup(func() { _ = rg.Close() })
+	require.False(t, rg.initiator, "createMuxRouteGroup builds a responder")
+
+	conn := newCountingTransport()
+	mt := transport.NewManagedTransportForTest(conn)
+	mt.Entry = transport.Entry{ID: rg.fwd[0].NextTransportID(), Type: "test"}
+	rg.mu.Lock()
+	rg.tps[0] = mt
+	rid := rg.rvs[0].KeyRouteID()
+	rg.mu.Unlock()
+
+	hs := routing.MakeHandshakePacket(rid, true, routing.CapMux|routing.CapSACK)
+
+	// First handshake: processed closes, responder does NOT re-ack from here
+	// (its saveRouteGroupRules would send the initial reverse handshake).
+	require.NoError(t, rg.handlePacket(hs))
+	select {
+	case <-rg.handshakeProcessed:
+	default:
+		t.Fatal("first handshake must close handshakeProcessed")
+	}
+	require.Equal(t, 0, conn.writeCount(), "first handshake must not itself re-ack")
+
+	// Duplicate handshake: the reverse ack was lost and the initiator is
+	// retransmitting — the responder must re-emit its handshake.
+	require.NoError(t, rg.handlePacket(hs))
+	require.Eventually(t, func() bool { return conn.writeCount() >= 1 }, time.Second, 10*time.Millisecond,
+		"duplicate forward handshake must trigger a reverse re-ack")
+}

--- a/pkg/router/handshake_retransmit_test.go
+++ b/pkg/router/handshake_retransmit_test.go
@@ -114,7 +114,11 @@ func TestAwaitHandshakeAck_TimeoutAfterRetransmits(t *testing.T) {
 // transport (more than the single legacy shot) until the deadline.
 func TestRouteGroup_InitiatorRetransmitsHandshake(t *testing.T) {
 	rg, _, _ := createMuxRouteGroup(t, 1)
-	t.Cleanup(func() { _ = rg.Close() })
+	t.Cleanup(func() {
+		if cerr := rg.Close(); cerr != nil {
+			t.Logf("route group close: %v", cerr)
+		}
+	})
 	rg.initiator = true
 
 	conn := newCountingTransport()
@@ -126,7 +130,11 @@ func TestRouteGroup_InitiatorRetransmitsHandshake(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 130*time.Millisecond)
 	defer cancel()
-	retransmit := func() { _ = rg.sendHandshake(true) }
+	retransmit := func() {
+		if herr := rg.sendHandshake(true); herr != nil {
+			t.Logf("retransmit handshake: %v", herr)
+		}
+	}
 	err := awaitHandshakeAck(ctx, rg.handshakeProcessed, retransmit, 25*time.Millisecond)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.GreaterOrEqual(t, conn.writeCount(), 2, "initiator should retransmit the handshake packet repeatedly")
@@ -137,7 +145,11 @@ func TestRouteGroup_InitiatorRetransmitsHandshake(t *testing.T) {
 // re-sends its handshake so the initiator's retransmit loop can complete.
 func TestRouteGroup_ResponderReAcksDuplicateHandshake(t *testing.T) {
 	rg, _, _ := createMuxRouteGroup(t, 1)
-	t.Cleanup(func() { _ = rg.Close() })
+	t.Cleanup(func() {
+		if cerr := rg.Close(); cerr != nil {
+			t.Logf("route group close: %v", cerr)
+		}
+	})
 	require.False(t, rg.initiator, "createMuxRouteGroup builds a responder")
 
 	conn := newCountingTransport()

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1978,7 +1978,9 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 			}
 			rg.mu.Unlock()
 		}
+		firstHandshake := false
 		rg.handshakeProcessedOnce.Do(func() {
+			firstHandshake = true
 			// first packet is handshake packet, so we're communicating with the new visor
 			rg.encrypt = true
 			if packet.Payload()[0] == 0 {
@@ -2004,6 +2006,21 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 
 			close(rg.handshakeProcessed)
 		})
+		// A duplicate forward handshake means the initiator's retransmit loop is
+		// still running because its reciprocal (reverse) handshake never arrived —
+		// most likely that single reverse-ack packet was lost. Re-emit our reverse
+		// handshake so the initiator's retransmit can complete instead of eating
+		// the whole handshake-await timeout. Only the responder (which sends its
+		// handshake in reply to the forward one) re-acks; the initiator's own
+		// resends are what drive this. Sent from a goroutine so we never block the
+		// router read loop, and never while holding rg.mu (sendHandshake locks it).
+		if !firstHandshake && !rg.initiator {
+			go func() {
+				if err := rg.sendHandshake(rg.encrypt); err != nil {
+					rg.logger.Debugf("Failed to re-ack duplicate handshake: %v", err)
+				}
+			}()
+		}
 	case routing.PingPacket:
 		return rg.handlePingPacket(packet)
 	case routing.PongPacket:

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -78,6 +78,19 @@ const (
 	retryInterval = 500 * time.Millisecond
 )
 
+// handshakeRetransmitInterval is how often the initiator re-sends its setup
+// handshake packet while waiting (up to handshakeAwaitTimeout) for the peer's
+// reciprocal handshake. The route-group setup handshake is a single unreliable
+// packet over the multi-hop route: unlike data frames it is not carried by the
+// mux reorder/SACK machinery (which is not built until the handshake completes),
+// so a single lost handshake packet on any hop has no ARQ to recover it and the
+// initiator would otherwise block for the entire handshakeAwaitTimeout and drop
+// an otherwise-live dial. Retransmitting on this interval recovers a lost
+// handshake in ~1s instead of failing at 10s. A slow-but-alive path is
+// unaffected: the reciprocal handshake closes handshakeProcessed and stops the
+// retransmits. Set to 0 to disable retransmission (legacy single-shot behavior).
+var handshakeRetransmitInterval = 1 * time.Second
+
 var (
 	// ErrUnknownPacketType is returned when packet type is unknown.
 	ErrUnknownPacketType = errors.New("unknown packet type")

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -200,7 +200,6 @@ func (r *router) serveSetup() {
 
 // nolint: gocyclo
 //
-//gocyclo:ignore
 // awaitHandshakeAck blocks until the peer's reciprocal setup handshake closes
 // processed, or ctx expires (returning ctx.Err()). When retransmit is non-nil
 // and interval > 0 (the initiator), it re-invokes retransmit every interval so
@@ -208,6 +207,8 @@ func (r *router) serveSetup() {
 // the interval instead of eating the whole handshake-await timeout and dropping
 // a live dial. The responder passes retransmit == nil: it has nothing to
 // re-send until the forward handshake arrives (whereupon processed closes).
+//
+//gocyclo:ignore
 func awaitHandshakeAck(ctx context.Context, processed <-chan struct{}, retransmit func(), interval time.Duration) error {
 	var tickC <-chan time.Time
 	if retransmit != nil && interval > 0 {

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -201,6 +201,32 @@ func (r *router) serveSetup() {
 // nolint: gocyclo
 //
 //gocyclo:ignore
+// awaitHandshakeAck blocks until the peer's reciprocal setup handshake closes
+// processed, or ctx expires (returning ctx.Err()). When retransmit is non-nil
+// and interval > 0 (the initiator), it re-invokes retransmit every interval so
+// a single lost setup-handshake packet on the multi-hop route recovers within
+// the interval instead of eating the whole handshake-await timeout and dropping
+// a live dial. The responder passes retransmit == nil: it has nothing to
+// re-send until the forward handshake arrives (whereupon processed closes).
+func awaitHandshakeAck(ctx context.Context, processed <-chan struct{}, retransmit func(), interval time.Duration) error {
+	var tickC <-chan time.Time
+	if retransmit != nil && interval > 0 {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		tickC = ticker.C
+	}
+	for {
+		select {
+		case <-processed:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-tickC:
+			retransmit()
+		}
+	}
+}
+
 func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRules, nsConf noise.Config, appName string, datagram bool) (*NoiseRouteGroup, error) {
 	// Check context before starting
 	if ctx.Err() != nil {
@@ -277,9 +303,23 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 	hsCtx, hsCancel := context.WithTimeout(ctx, handshakeAwaitTimeout)
 	defer hsCancel()
 
-	select {
-	case <-rg.handshakeProcessed:
-	case <-hsCtx.Done():
+	// The initiator re-sends its handshake on handshakeRetransmitInterval while
+	// waiting for the reciprocal handshake: the setup handshake is a single
+	// unreliable packet over the multi-hop route with no ARQ (the mux reorder/SACK
+	// layer does not exist yet), so a single lost handshake packet would otherwise
+	// eat the whole handshakeAwaitTimeout and drop a live dial. The responder
+	// passes no retransmit — it has nothing to re-send until it has received the
+	// forward handshake (after which it re-acks from handlePacket on any duplicate).
+	var retransmit func()
+	if nsConf.Initiator {
+		retransmit = func() {
+			if err := rg.sendHandshake(true); err != nil {
+				log.WithError(err).Debugf("Handshake retransmit failed for %s", &rules.Desc)
+			}
+		}
+	}
+
+	if err := awaitHandshakeAck(hsCtx, rg.handshakeProcessed, retransmit, handshakeRetransmitInterval); err != nil {
 		// Check if parent context was canceled (e.g., setup timeout)
 		if ctx.Err() != nil {
 			log.Debugf("Route group setup canceled for %s: %v", &rules.Desc, ctx.Err())


### PR DESCRIPTION
## Problem

Skynet route setups still intermittently drop with:

```
WARN [router]: Remote handshake not received within timeout — failing dial ... timeout=10s
```

`#4051` made these drops *self-heal* (the dial now returns an error and the app retries) but did not stop them from happening. This PR addresses the residual root cause.

## Root cause

The **route-group setup handshake** (`saveRouteGroupRules`, `pkg/router/router_serve.go`) is a single unreliable packet:

- The initiator calls `rg.sendHandshake(true)` **exactly once**, then blocks on `rg.handshakeProcessed` for the full `handshakeAwaitTimeout` (10s).
- That handshake packet is **not** carried by the mux reorder/SACK machinery — that layer is only built *after* the handshake completes (`handlePacket` → `HandshakePacket` sets up `rg.mux`). So the setup handshake has **no ARQ**: a single lost handshake packet on any hop has nothing to recover it.
- The initiator then waits out the entire 10s and hard-fails an otherwise-live dial.

Raising the deadline cannot help — the history of bumping `6s → 10s` only made each doomed attempt slower to fail. A dropped packet is gone regardless of how long you wait.

Evidence: on a public visor, repeated back-to-back 10s handshake timeouts to a **healthy** exit whose measured ICMP RTT is ~134ms. A 1-RTT setup handshake genuinely exceeding 10s over a 134ms path is packet loss, not latency. The handshake packet also bypasses the reorder buffer (`dispatchToRouteGroup` → `rg.handlePacket` directly), so a *delivered* handshake is always processed — the failure is non-delivery.

## Fix (minimal, configurable-by-default)

- The **initiator** re-sends its setup handshake every `handshakeRetransmitInterval` (default **1s**) while waiting for the reciprocal handshake, so a lost handshake recovers in ~1s instead of failing at 10s. A slow-but-alive path is unaffected — the reciprocal handshake closes `handshakeProcessed` and stops the retransmits immediately.
- The **responder** re-emits its handshake whenever it receives a *duplicate* forward handshake (which only happens because the initiator is still retransmitting), covering the case where the reverse ack itself was the lost packet.
- Setting `handshakeRetransmitInterval = 0` restores the legacy single-shot behavior (no migration shim; the new behavior is just the default).

The wait/retransmit is factored into a small pure helper (`awaitHandshakeAck`) that is unit-tested directly.

## Tests

- `awaitHandshakeAck`: stops on reciprocal handshake, responder path does no retransmit, and it retransmits several times before returning the context error on a dead peer.
- Route-group level: an initiator with no reciprocal ack repeatedly re-sends the real handshake packet over its transport; a responder re-acks on a duplicate forward handshake.
- Full `pkg/router` suite passes under `-race`.

## needs local-visor validation before merge (route-setup core change)

This is core routing. It must be live-validated on a running visor (a restart the maintainer approves) before merge — do **not** auto-merge.
