### PR TITLE
feat(skywire-cli): unified transport vocabulary + scheme targets for the remote-access trinity

### DIFF
--- a/cmd/skywire-cli/cliutil/transport.go
+++ b/cmd/skywire-cli/cliutil/transport.go
@@ -1,0 +1,79 @@
+// Package cliutil cmd/skywire-cli/cliutil/transport.go c4-vis-cli
+// Shared transport vocabulary for the remote-access commands
+// (pty exec/start, pty shell, dmsg scp, pty fs mount). Each command
+// supports a ragged subset of these transports — see each command's
+// help for its own matrix. This file only defines the vocabulary and
+// the flag-vs-target-scheme precedence; it does not itself dial.
+package cliutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Canonical transport names shared across the remote-access commands.
+//
+//	auto   each command's current default behavior.
+//	dmsg   via-visor dmsg.
+//	skynet via-visor skynet.
+//	tcp    direct noise-TCP to a host:port (needs a host:port target).
+const (
+	TransportAuto   = "auto"
+	TransportDmsg   = "dmsg"
+	TransportSkynet = "skynet"
+	TransportTCP    = "tcp"
+)
+
+// targetSchemes are the recognized `<scheme>://` prefixes on a
+// positional remote-access target. They mirror the --transport
+// vocabulary minus auto (auto is a flag-only default, never spelled on
+// a target).
+var targetSchemes = []string{TransportDmsg, TransportSkynet, TransportTCP}
+
+// SplitTargetScheme detects a leading dmsg:// / skynet:// / tcp://
+// scheme on a positional target. On a recognized prefix it returns the
+// scheme name (without "://") and the remainder after "://"; otherwise
+// ("", target) with target unchanged. Bare targets — a plain PK,
+// <pk>:path, <pk>@host:port — therefore pass through byte-identical, so
+// every pre-existing target form keeps working.
+func SplitTargetScheme(target string) (scheme, rest string) {
+	for _, s := range targetSchemes {
+		pfx := s + "://"
+		if strings.HasPrefix(target, pfx) {
+			return s, target[len(pfx):]
+		}
+	}
+	return "", target
+}
+
+// ResolveTransport reconciles an explicit --transport / --scheme flag
+// with a scheme carried on the positional target, returning the
+// effective transport.
+//
+//	flagVal      the --transport value; "" is treated as auto.
+//	flagChanged  whether the user explicitly set the flag.
+//	targetScheme the scheme parsed from the target ("" if the target
+//	             is bare).
+//
+// Precedence:
+//   - target bare              -> flagVal (default auto).
+//   - only the target scheme'd -> the target scheme.
+//   - both, and they agree     -> that transport.
+//   - both, and they conflict  -> error (an explicit non-auto flag that
+//     disagrees with the target scheme is ambiguous — the caller must
+//     drop one).
+//
+// An explicit --transport auto never conflicts: an operator asking for
+// auto alongside a scheme'd target is read as "let the target decide".
+func ResolveTransport(flagVal string, flagChanged bool, targetScheme string) (string, error) {
+	if flagVal == "" {
+		flagVal = TransportAuto
+	}
+	if targetScheme == "" {
+		return flagVal, nil
+	}
+	if flagChanged && flagVal != TransportAuto && flagVal != targetScheme {
+		return "", fmt.Errorf("target scheme %s:// conflicts with --transport %s; specify one", targetScheme, flagVal)
+	}
+	return targetScheme, nil
+}

--- a/cmd/skywire-cli/cliutil/transport_test.go
+++ b/cmd/skywire-cli/cliutil/transport_test.go
@@ -1,0 +1,65 @@
+// Package cliutil cmd/skywire-cli/cliutil/transport_test.go c4-vis-cli
+package cliutil
+
+import "testing"
+
+func TestSplitTargetScheme(t *testing.T) {
+	const pk = "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c"
+	cases := []struct {
+		in         string
+		wantScheme string
+		wantRest   string
+	}{
+		{pk, "", pk}, // bare PK unchanged
+		{pk + ":remote.bin", "", pk + ":remote.bin"},                   // bare pk:path unchanged
+		{pk + "@1.2.3.4:2022", "", pk + "@1.2.3.4:2022"},               // bare pk@host:port unchanged
+		{"dmsg://" + pk, "dmsg", pk},                                   // dmsg scheme stripped
+		{"skynet://" + pk + ":f", "skynet", pk + ":f"},                 // skynet scheme + path
+		{"tcp://" + pk + "@1.2.3.4:2022", "tcp", pk + "@1.2.3.4:2022"}, // tcp scheme stripped
+		{"./local/path", "", "./local/path"},                           // local path unchanged
+		{"http://example", "", "http://example"},                       // unrecognized scheme untouched
+	}
+	for _, c := range cases {
+		gotScheme, gotRest := SplitTargetScheme(c.in)
+		if gotScheme != c.wantScheme || gotRest != c.wantRest {
+			t.Errorf("SplitTargetScheme(%q) = (%q,%q); want (%q,%q)", c.in, gotScheme, gotRest, c.wantScheme, c.wantRest)
+		}
+	}
+}
+
+func TestResolveTransport(t *testing.T) {
+	cases := []struct {
+		name         string
+		flagVal      string
+		flagChanged  bool
+		targetScheme string
+		want         string
+		wantErr      bool
+	}{
+		{"default auto, bare target", "auto", false, "", "auto", false},
+		{"empty flag treated as auto", "", false, "", "auto", false},
+		{"explicit dmsg, bare target", "dmsg", true, "", "dmsg", false},
+		{"only target scheme", "auto", false, "skynet", "skynet", false},
+		{"flag + target agree", "dmsg", true, "dmsg", "dmsg", false},
+		{"flag auto yields to target scheme", "auto", true, "tcp", "tcp", false},
+		{"conflict errors", "dmsg", true, "skynet", "", true},
+		{"unchanged flag never conflicts", "dmsg", false, "skynet", "skynet", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ResolveTransport(c.flagVal, c.flagChanged, c.targetScheme)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("ResolveTransport(%q,%v,%q) = %q, nil; want error", c.flagVal, c.flagChanged, c.targetScheme, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveTransport(%q,%v,%q) unexpected error: %v", c.flagVal, c.flagChanged, c.targetScheme, err)
+			}
+			if got != c.want {
+				t.Errorf("ResolveTransport(%q,%v,%q) = %q; want %q", c.flagVal, c.flagChanged, c.targetScheme, got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/skywire-cli/commands/dmsg/pty.go
+++ b/cmd/skywire-cli/commands/dmsg/pty.go
@@ -59,6 +59,22 @@ var (
 	// forces skynet-only. Useful for unblocking debug when one
 	// strategy in the chain hangs without honoring ctx.
 	ptyScheme string
+	// ptyTransport is the canonical unified transport selector shared
+	// with the other remote-access commands: auto|dmsg|skynet|tcp.
+	// It is the visible spelling of the legacy --scheme (exec) and the
+	// --via direct-TCP path. Default "auto" preserves the historical
+	// behavior (exec: the visor's MultiDialer chain; start: the local
+	// dmsgpty-host proxy).
+	ptyTransport string
+	// ptyStandalone accepts the unified --standalone flag for vocabulary
+	// parity. exec/start have no standalone-dmsg path today, so setting
+	// it returns a clear error rather than silently doing nothing.
+	ptyStandalone bool
+	// ptyVisorKey is the canonical spelling of "borrow the local visor
+	// SK for the noise handshake". The legacy opt-in --via-visor is a
+	// hidden alias; --visor-key wins when both are set. Default false
+	// matches exec/start's historical opt-in behavior.
+	ptyVisorKey bool
 )
 
 // ptyTCPViaRE matches `tcp://<66-hex-pk>@<host:port>` for the --via
@@ -88,6 +104,13 @@ func init() {
 		"local secret key for the --via direct-TCP path's noise handshake (random if unset; pin for stable whitelist authorization)")
 	ptyStartCmd.Flags().BoolVar(&ptyViaVisor, "via-visor", false,
 		"borrow local visor's secret key from "+visorconfig.SkywireConfig()+" for the --via noise handshake (--sk wins if set)")
+	ptyStartCmd.Flags().StringVar(&ptyTransport, "transport", "auto",
+		"transport: auto (local dmsgpty-host proxy) | dmsg (same path) | tcp (direct-TCP, needs a host:port target); skynet is exec-only")
+	ptyStartCmd.Flags().BoolVar(&ptyStandalone, "standalone", false,
+		"(not supported for pty start yet — accepted for vocabulary parity; errors if set)")
+	ptyStartCmd.Flags().BoolVar(&ptyVisorKey, "visor-key", false,
+		"borrow the local visor's SK from "+visorconfig.SkywireConfig()+" for the tcp noise handshake (default false: opt-in; --sk wins)")
+	_ = ptyStartCmd.Flags().MarkHidden("via-visor")
 
 	// Flags for exec command
 	ptyExecCmd.PersistentFlags().StringVarP(&ptyRpcAddr, "rpc", "", "localhost:3435", "RPC server address")
@@ -102,6 +125,14 @@ func init() {
 		"borrow local visor's secret key from "+visorconfig.SkywireConfig()+" for the --via noise handshake (--sk wins if set)")
 	ptyExecCmd.Flags().StringVar(&ptyScheme, "scheme", "",
 		"pin transport: \"dmsg\" (force dmsg only), \"skynet\" (force skynet only), or empty (default MultiDialer chain: skynet first, dmsg fallback)")
+	ptyExecCmd.Flags().StringVar(&ptyTransport, "transport", "auto",
+		"transport: auto (MultiDialer: skynet first, dmsg fallback) | dmsg | skynet (all via-visor) | tcp (direct-TCP, needs a host:port target)")
+	ptyExecCmd.Flags().BoolVar(&ptyStandalone, "standalone", false,
+		"(not supported for pty exec yet — accepted for vocabulary parity; errors if set)")
+	ptyExecCmd.Flags().BoolVar(&ptyVisorKey, "visor-key", false,
+		"borrow the local visor's SK from "+visorconfig.SkywireConfig()+" for the tcp noise handshake (default false: opt-in; --sk wins)")
+	_ = ptyExecCmd.Flags().MarkHidden("scheme")
+	_ = ptyExecCmd.Flags().MarkHidden("via-visor")
 
 	// Flags for ui command
 	ptyUICmd.Flags().StringVarP(&ptyPath, "input", "i", "", "read from specified config file")
@@ -147,19 +178,56 @@ var ptyStartCmd = &cobra.Command{
 		ctx, cancel := cmdutil.SignalContext(context.Background(), nil)
 		defer cancel()
 
-		// --via tcp://<pk>@<host:port> bypasses local visor. <pk> in
-		// the URL pins the remote (server) PK; positional <pk> arg is
-		// then optional and ignored if supplied.
+		if ptyStandalone {
+			return fmt.Errorf("pty start: --standalone not supported yet (no standalone-dmsg start path); use the default (via the local dmsgpty-host) or --transport tcp / --via for direct-TCP")
+		}
+		useVisorKey := resolveVisorKeyBorrow(cmd, ptyVisorKey, ptyViaVisor)
+
+		// Normalize the target. A tcp://<pk>@host:port positional or the
+		// --via flag both select direct-TCP; dmsg://<pk> selects the
+		// via-visor path. A bare <pk> uses --transport.
+		via := ptyVia
+		transportChanged := cmd.Flags().Changed("transport")
+		targetScheme := ""
+		if via == "" && len(args) >= 1 {
+			scheme, rest := internal.SplitTargetScheme(args[0])
+			targetScheme = scheme
+			switch scheme {
+			case internal.TransportTCP:
+				via = "tcp://" + rest
+				args = args[1:] // drop the target; no positional command for start
+			case internal.TransportDmsg, internal.TransportSkynet:
+				args = append([]string{rest}, args[1:]...) // bare <pk> in args[0]
+			}
+		}
+		resolveScheme := targetScheme
 		if ptyVia != "" {
-			rPK, addr, err := parseTCPVia(ptyVia)
+			resolveScheme = internal.TransportTCP
+		}
+		eff, err := internal.ResolveTransport(ptyTransport, transportChanged, resolveScheme)
+		if err != nil {
+			return fmt.Errorf("pty start: %w", err)
+		}
+
+		// Direct-TCP: --via flag or a tcp target.
+		if via != "" || eff == internal.TransportTCP {
+			if via == "" {
+				return fmt.Errorf("pty start: --transport tcp needs a host:port target (tcp://<pk>@host:port or --via tcp://<pk>@host:port)")
+			}
+			rPK, addr, err := parseTCPVia(via)
 			if err != nil {
 				return err
 			}
-			myPK, mySK := resolveTCPIdentity(ptySK)
+			myPK, mySK := resolveTCPIdentity(ptySK, useVisorKey)
 			tcpCli := pty.DefaultCLI()
 			return (&tcpCli).StartRemotePtyTCP(ctx, rPK, addr, myPK, mySK, pty.DefaultCmd)
 		}
 
+		// via-visor path (local dmsgpty-host proxy). This path is dmsg;
+		// skynet is not wired for the interactive start command.
+		if eff == internal.TransportSkynet {
+			return fmt.Errorf("pty start: --transport skynet not wired for the interactive start path; use `cli pty exec --transport skynet` for a via-visor skynet exec")
+		}
 		if len(args) < 1 {
 			return fmt.Errorf("pty start: <pk> required (or use --via tcp://<pk>@<host:port>)")
 		}
@@ -190,7 +258,21 @@ Examples:
 
 The local CLI exit code mirrors the remote command's exit code (0 on
 success, the remote's exit code on non-zero exit, 124 on timeout, 1 on
-RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
+RPC-layer failure). stdout flows to local stdout, stderr to local stderr.
+
+Transport (--transport, default auto):
+  auto    the visor's MultiDialer chain (skynet first, dmsg fallback).
+  dmsg    force via-visor dmsg.
+  skynet  force via-visor skynet.
+  tcp     direct noise-TCP; needs a host:port target (--via or a
+          tcp://<pk>@host:port positional).
+--standalone is not supported here (no standalone-dmsg exec path yet).
+
+Target grammar — in addition to the bare <pk>:
+  dmsg://<pk>              select dmsg    (== --transport dmsg)
+  skynet://<pk>            select skynet  (== --transport skynet)
+  tcp://<pk>@host:port     select direct-TCP (command follows the target)
+A target scheme that disagrees with an explicit --transport errors.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		internal.CheckDirectViaScheme(cmd.Flags(), ptyVia, "a direct noise-TCP target (tcp://<pk>@host:port)")
@@ -201,18 +283,68 @@ RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
 		ctx, cancel := cmdutil.SignalContext(context.Background(), nil)
 		defer cancel()
 
-		// --via tcp://<pk>@<host:port> shifts argument layout: pk is
-		// in the URL, so args are just `<command> [args...]` (no
-		// leading positional pk).
+		if ptyStandalone {
+			return fmt.Errorf("pty exec: --standalone not supported yet (no standalone-dmsg exec path); use --transport dmsg|skynet for the via-visor path or --transport tcp / --via for direct-TCP")
+		}
+		useVisorKey := resolveVisorKeyBorrow(cmd, ptyVisorKey, ptyViaVisor)
+
+		// The legacy --scheme is the hidden alias of --transport. When
+		// only --scheme is set, fold it into --transport so the rest of
+		// the resolution has a single source of truth.
+		transportChanged := cmd.Flags().Changed("transport")
+		if !transportChanged && cmd.Flags().Changed("scheme") {
+			switch ptyScheme {
+			case "":
+				ptyTransport = internal.TransportAuto
+			case "dmsg":
+				ptyTransport = internal.TransportDmsg
+			case "skynet":
+				ptyTransport = internal.TransportSkynet
+			default:
+				return fmt.Errorf("pty exec: bad --scheme %q (want dmsg|skynet or empty)", ptyScheme)
+			}
+			transportChanged = true
+		}
+
+		// Normalize the target. A tcp://<pk>@host:port positional or the
+		// --via flag both select direct-TCP; dmsg://<pk> / skynet://<pk>
+		// select the via-visor scheme. A bare <pk> uses --transport.
+		via := ptyVia
+		targetScheme := ""
+		if via == "" && len(args) >= 1 {
+			scheme, rest := internal.SplitTargetScheme(args[0])
+			targetScheme = scheme
+			switch scheme {
+			case internal.TransportTCP:
+				via = "tcp://" + rest
+				args = args[1:] // drop the target; command starts at args[0]
+			case internal.TransportDmsg, internal.TransportSkynet:
+				args = append([]string{rest}, args[1:]...) // bare <pk> in args[0]
+			}
+		}
+		resolveScheme := targetScheme
 		if ptyVia != "" {
+			resolveScheme = internal.TransportTCP
+		}
+		eff, err := internal.ResolveTransport(ptyTransport, transportChanged, resolveScheme)
+		if err != nil {
+			return fmt.Errorf("pty exec: %w", err)
+		}
+
+		// Direct-TCP: --via flag or a tcp target. pk is in the URL, so
+		// args are just `<command> [args...]`.
+		if via != "" || eff == internal.TransportTCP {
+			if via == "" {
+				return fmt.Errorf("pty exec: --transport tcp needs a host:port target (tcp://<pk>@host:port or --via tcp://<pk>@host:port)")
+			}
 			if len(args) < 1 {
 				return fmt.Errorf("pty exec --via: <command> required")
 			}
-			rPK, addr, err := parseTCPVia(ptyVia)
+			rPK, addr, err := parseTCPVia(via)
 			if err != nil {
 				return err
 			}
-			myPK, mySK := resolveTCPIdentity(ptySK)
+			myPK, mySK := resolveTCPIdentity(ptySK, useVisorKey)
 			name := args[0]
 			var cmdArgs []string
 			if len(args) > 1 {
@@ -226,6 +358,19 @@ RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
 			}
 			reportExecResult(cmd, resp)
 			return nil
+		}
+
+		// via-visor path (visor RPC DmsgPtyExec). eff maps onto the RPC
+		// Scheme: auto -> "" (MultiDialer), dmsg -> "dmsg", skynet ->
+		// "skynet".
+		scheme := ""
+		switch eff {
+		case internal.TransportAuto:
+			scheme = ""
+		case internal.TransportDmsg:
+			scheme = "dmsg"
+		case internal.TransportSkynet:
+			scheme = "skynet"
 		}
 
 		if len(args) < 2 {
@@ -269,7 +414,7 @@ RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
 				Env:       ptyExecEnv,
 				TimeoutMS: timeout.Milliseconds(),
 			},
-			Scheme: ptyScheme,
+			Scheme: scheme,
 		})
 		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "exec: %v\n", err) //nolint:errcheck
@@ -309,6 +454,21 @@ func reportExecResult(cmd *cobra.Command, resp *pty.CommandExecResult) {
 	}
 }
 
+// resolveVisorKeyBorrow decides whether to borrow the local visor's SK
+// for the direct-TCP noise handshake. The canonical --visor-key wins
+// when explicitly set; the legacy opt-in --via-visor is honored only
+// when --visor-key was not set. When neither is set the historical
+// default holds: exec/start do NOT borrow (they were opt-in).
+func resolveVisorKeyBorrow(cmd *cobra.Command, visorKey, viaVisor bool) bool {
+	if cmd.Flags().Changed("visor-key") {
+		return visorKey
+	}
+	if cmd.Flags().Changed("via-visor") {
+		return viaVisor
+	}
+	return false
+}
+
 // parseTCPVia splits a `tcp://<pk>@<host:port>` URL into the pinned
 // remote PK and the dial-target address. The PK must be the
 // canonical 66-char-hex form; the address is passed through to
@@ -341,7 +501,12 @@ func parseTCPVia(via string) (cipher.PubKey, string, error) {
 //
 // Fatal-exits with a helpful message on a malformed identity
 // source — the caller can't proceed without a valid keypair.
-func resolveTCPIdentity(skFlag cipher.SecKey) (cipher.PubKey, cipher.SecKey) {
+//
+// useVisorKey is the resolved decision (see resolveVisorKeyBorrow)
+// about whether to borrow the local visor's SK; it replaces the direct
+// read of the legacy --via-visor flag so the canonical --visor-key can
+// drive it.
+func resolveTCPIdentity(skFlag cipher.SecKey, useVisorKey bool) (cipher.PubKey, cipher.SecKey) {
 	var zero cipher.SecKey
 	sk := skFlag
 	if sk == zero {
@@ -349,15 +514,15 @@ func resolveTCPIdentity(skFlag cipher.SecKey) (cipher.PubKey, cipher.SecKey) {
 			_ = sk.Set(env) //nolint:errcheck,gosec
 		}
 	}
-	if sk == zero && ptyViaVisor {
+	if sk == zero && useVisorKey {
 		confPath := visorconfig.SkywireConfig()
 		conf, err := visorconfig.ReadFile(confPath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "pty --via-visor: read %s: %v\n", confPath, err) //nolint:errcheck
+			fmt.Fprintf(os.Stderr, "pty --visor-key: read %s: %v\n", confPath, err) //nolint:errcheck
 			os.Exit(1)
 		}
 		if conf.SK == zero {
-			fmt.Fprintf(os.Stderr, "pty --via-visor: visor config %s has empty SK\n", confPath) //nolint:errcheck
+			fmt.Fprintf(os.Stderr, "pty --visor-key: visor config %s has empty SK\n", confPath) //nolint:errcheck
 			os.Exit(1)
 		}
 		sk = conf.SK

--- a/cmd/skywire-cli/commands/dmsg/scp.go
+++ b/cmd/skywire-cli/commands/dmsg/scp.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
@@ -35,9 +36,11 @@ import (
 var scpPKPathRe = regexp.MustCompile(`^([a-f0-9]{66}):(.*)$`)
 
 var (
-	scpPort      uint16
-	scpTimeout   time.Duration
-	scpTransport string
+	scpPort       uint16
+	scpTimeout    time.Duration
+	scpTransport  string
+	scpStandalone bool
+	scpVisorKey   bool
 )
 
 // scpTransportAuto is the default for --transport: try the local
@@ -58,7 +61,11 @@ func init() {
 	scpCmd.Flags().DurationVarP(&scpTimeout, "timeout", "t", 5*time.Minute,
 		"transfer timeout (includes dial + payload)")
 	scpCmd.Flags().StringVar(&scpTransport, "transport", scpTransportAuto,
-		"transport: auto (try visor first, fallback dmsg) | dmsg | skynet")
+		"transport: auto (try visor first, fallback dmsg) | dmsg | skynet | tcp (not supported yet)")
+	scpCmd.Flags().BoolVar(&scpStandalone, "standalone", false,
+		"force the standalone-dmsg client path (skip the visor RPC); needs --sk for a stable identity")
+	scpCmd.Flags().BoolVar(&scpVisorKey, "visor-key", true,
+		"via-visor transports run under the visor's own identity; standalone uses --sk (see help)")
 	scpCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr,
 		"local visor RPC server address (env: SKYWIRE_RPC). Used for skynet / auto transports.")
 	scpCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal",
@@ -95,6 +102,17 @@ Transport selection (--transport):
   - skynet  routes the transfer over the skywire router via the
             visor's VisorSCP RPC. Requires a local visor with
             appnet TypeSkynet registered.
+  - tcp     not supported yet (there is no dmsgscp TCP host); asking
+            for it errors rather than silently falling back.
+
+--standalone forces the standalone-dmsg client path (same as
+--transport dmsg, but explicit) even when a local visor is reachable.
+
+Target grammar — the PK-bearing arg may also carry a scheme, which
+selects the transport (and must agree with an explicit --transport):
+  skywire cli dmsg scp ./f skynet://<pk>:remote.bin   (upload over skynet)
+  skywire cli dmsg scp dmsg://<pk>:remote.bin ./f     (download over dmsg)
+A bare <pk>:path keeps using --transport.
 
 Identity: --sk gives the standalone dmsg client a stable PK so the
 host's whitelist can authorize it. Without --sk you get a fresh
@@ -114,28 +132,69 @@ standalone dmsg path; the VisorSCP RPC uses the visor's own PK.`,
 			}
 		}
 
-		direction, peerPK, remotePath, localPath, err := classifyArgs(args[0], args[1])
+		// A `<scheme>://` prefix may ride on whichever arg carries the
+		// PK (e.g. skynet://<pk>:remote.bin). Strip it before classify;
+		// the scheme selects the transport (subject to --transport
+		// precedence). A bare <pk>:path is untouched.
+		srcScheme, srcRest := internal.SplitTargetScheme(args[0])
+		dstScheme, dstRest := internal.SplitTargetScheme(args[1])
+
+		direction, peerPK, remotePath, localPath, err := classifyArgs(srcRest, dstRest)
 		if err != nil {
 			return err
 		}
 
-		switch scpTransport {
-		case scpTransportAuto, scpTransportDmsg, scpTransportSkynet:
-		default:
-			return fmt.Errorf("dmsg scp: bad --transport %q (want auto|dmsg|skynet)", scpTransport)
+		// The transport scheme lives on the PK-bearing side.
+		targetScheme := dstScheme
+		if direction == scpDirDownload {
+			targetScheme = srcScheme
+		}
+		eff, err := internal.ResolveTransport(scpTransport, cmd.Flags().Changed("transport"), targetScheme)
+		if err != nil {
+			return fmt.Errorf("dmsg scp: %w", err)
 		}
 
-		// Skynet path requires the visor (CLI has no appnet runtime).
-		if scpTransport == scpTransportSkynet {
+		switch eff {
+		case scpTransportAuto, scpTransportDmsg, scpTransportSkynet:
+		case internal.TransportTCP:
+			return fmt.Errorf("dmsg scp: --transport tcp not supported yet (no dmsgscp TCP host); use dmsg|skynet|auto")
+		default:
+			return fmt.Errorf("dmsg scp: bad --transport %q (want auto|dmsg|skynet)", eff)
+		}
+
+		// The standalone-dmsg path is taken explicitly via --standalone
+		// or implicitly via --transport dmsg; auto (without --standalone)
+		// prefers the visor RPC and only falls back to standalone.
+		standalonePath := scpStandalone || eff == scpTransportDmsg
+
+		// --visor-key is honest about scp's identity model: via-visor
+		// transports run under the visor's own key; the standalone dmsg
+		// path uses --sk (a second client on the visor's PK would collide
+		// in dmsg discovery). Only act when the user set it explicitly.
+		if cmd.Flags().Changed("visor-key") {
+			if scpVisorKey && standalonePath {
+				return fmt.Errorf("dmsg scp: --standalone / --transport dmsg cannot borrow the visor key (dmsg discovery collision); it uses --sk / a random identity")
+			}
+			if !scpVisorKey && !standalonePath {
+				return fmt.Errorf("dmsg scp: --visor-key=false has no effect on the via-visor transports; use --standalone --sk <sk> for a separate identity")
+			}
+		}
+
+		// Skynet path requires the visor (CLI has no appnet runtime) and
+		// has no standalone form.
+		if eff == scpTransportSkynet {
+			if scpStandalone {
+				return fmt.Errorf("dmsg scp: --standalone is dmsg-only; skynet requires the local visor")
+			}
 			return runVisorSCP(visor.VisorSCPTransportSkynet, peerPK, direction, localPath, remotePath, cmd)
 		}
 
-		// Auto path: try the visor's RPC first. The visor's own PK is
-		// stable + already on the peer's whitelist, so we save the
-		// operator from threading --sk. Fall back to standalone dmsg
-		// when --rpc is unreachable (typical for an operator running
-		// the CLI on a host without a local visor).
-		if scpTransport == scpTransportAuto {
+		// Auto path (without --standalone): try the visor's RPC first.
+		// The visor's own PK is stable + already on the peer's whitelist,
+		// so we save the operator from threading --sk. Fall back to
+		// standalone dmsg when --rpc is unreachable (typical for an
+		// operator running the CLI on a host without a local visor).
+		if eff == scpTransportAuto && !scpStandalone {
 			err := runVisorSCP(visor.VisorSCPTransportDmsg, peerPK, direction, localPath, remotePath, cmd)
 			if err == nil {
 				return nil

--- a/cmd/skywire-cli/commands/ptyfs/mount_linux.go
+++ b/cmd/skywire-cli/commands/ptyfs/mount_linux.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pkg/sftp"
 	"github.com/spf13/cobra"
 
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -94,6 +95,14 @@ selected by the target shape and the --standalone flag:
                         listener (cli pty host):
                           skywire cli pty fs mount <pk>@1.2.3.4:2022 ~/mnt/peer
 
+Unified transport (--transport, default auto):
+  auto|dmsg  via-visor bridge (default). dmsg://<pk> selects it too.
+  tcp        direct-TCP; a <pk>@host:port target (or tcp://<pk>@host:port)
+             selects it automatically.
+  skynet     not wired yet (no skynet-via-visor sftp bridge) — errors.
+--standalone still forces the dmsg-standalone client path on a bare <pk>.
+A target scheme that disagrees with an explicit --transport errors.
+
 Runs in the foreground. Send SIGINT (Ctrl-C) or SIGTERM to unmount
 and exit. For a background mount use 'nohup ... &' or a systemd
 unit — there is no daemonize flag by design (operators can compose
@@ -118,50 +127,77 @@ their own supervision).`,
 		ctx, cancel := cmdutil.SignalContext(cmd.Context(), nil)
 		defer cancel()
 
-		switch {
-		case strings.Contains(target, "@"):
+		// A <scheme>:// prefix selects the transport; a bare
+		// <pk>@host:port still implies tcp. dmsg://<pk> is via-visor (or
+		// dmsg-standalone with --standalone); skynet is not wired here.
+		scheme, rest := internal.SplitTargetScheme(target)
+		targetScheme := scheme
+		if targetScheme == "" && strings.Contains(rest, "@") {
+			targetScheme = internal.TransportTCP
+		}
+		eff, err := internal.ResolveTransport(ptyfsTransport, cmd.Flags().Changed("transport"), targetScheme)
+		if err != nil {
+			return fmt.Errorf("ptyfs: %w", err)
+		}
+
+		// --visor-key is canonical; --no-visor-key is the hidden opt-out
+		// alias. --visor-key wins when both are set. Consulted only on
+		// the direct-TCP path — the dmsg paths never borrow the visor key
+		// (a second client on the visor's PK collides in dmsg discovery).
+		useVisorKey := ptyfsVisorKey
+		if !cmd.Flags().Changed("visor-key") && cmd.Flags().Changed("no-visor-key") {
+			useVisorKey = !ptyfsNoVisor
+		}
+
+		switch eff {
+		case internal.TransportSkynet:
+			return fmt.Errorf("ptyfs: --transport skynet not wired yet (no skynet-via-visor sftp bridge); use dmsg|auto (via-visor), --standalone (dmsg-standalone), or tcp")
+
+		case internal.TransportTCP:
 			// standalone-tcp: direct noise-XK TCP to the peer's pty-host.
 			if mountStandalone {
 				return fmt.Errorf("ptyfs: --standalone is for the bare-<pk> dmsg path; a <pk>@host:port target is already standalone TCP")
 			}
-			dest := injectDefaultPort(target, ptyfsDefPort)
+			dest := injectDefaultPort(rest, ptyfsDefPort)
 			rPK, addr, err := parsePTYFSDestination(dest)
 			if err != nil {
 				return err
 			}
-			myPK, mySK := resolvePTYFSIdentity(ptyfsSK, !ptyfsNoVisor)
+			myPK, mySK := resolvePTYFSIdentity(ptyfsSK, useVisorKey)
 			rwc, err := pty.DialSftpTCP(ctx, addr, myPK, mySK, rPK)
 			if err != nil {
 				return err
 			}
 			return runMount(ctx, rwc, rPK, mountpoint, fmt.Sprintf("%s@%s (tcp)", rPK, addr))
 
-		case mountStandalone:
-			// dmsg-standalone: ephemeral dmsg client. NEVER the visor SK
-			// here — a second client registering the visor's PK collides
-			// with the running visor in dmsg discovery — so don't borrow it.
-			rPK, err := parseBarePK(target)
-			if err != nil {
-				return err
-			}
-			myPK, mySK := resolvePTYFSIdentity(ptyfsSK, false)
-			dmsgC, stop, err := startPTYFSDmsgClient(ctx, myPK, mySK)
-			if err != nil {
-				return err
-			}
-			defer stop()
-			rwc, err := pty.DialSftpDmsg(ctx, dmsgC, rPK, skyenv.DmsgPtyPort)
-			if err != nil {
-				return err
-			}
-			return runMount(ctx, rwc, rPK, mountpoint, fmt.Sprintf("%s (dmsg-standalone)", rPK))
-
 		default:
+			// via-visor (auto/dmsg) or dmsg-standalone (--standalone).
+			if mountStandalone {
+				// dmsg-standalone: ephemeral dmsg client. NEVER the visor
+				// SK here — a second client registering the visor's PK
+				// collides with the running visor in dmsg discovery.
+				rPK, err := parseBarePK(rest)
+				if err != nil {
+					return err
+				}
+				myPK, mySK := resolvePTYFSIdentity(ptyfsSK, false)
+				dmsgC, stop, err := startPTYFSDmsgClient(ctx, myPK, mySK)
+				if err != nil {
+					return err
+				}
+				defer stop()
+				rwc, err := pty.DialSftpDmsg(ctx, dmsgC, rPK, skyenv.DmsgPtyPort)
+				if err != nil {
+					return err
+				}
+				return runMount(ctx, rwc, rPK, mountpoint, fmt.Sprintf("%s (dmsg-standalone)", rPK))
+			}
+
 			// via-visor: bridge through the LOCAL visor's authorized dmsg
 			// client to the peer's dmsgpty (port 22). No CLI key needs
 			// whitelisting and there's no discovery collision — the visor
 			// (e.g. the hypervisor) is already authorized to the peer.
-			rPK, err := parseBarePK(target)
+			rPK, err := parseBarePK(rest)
 			if err != nil {
 				return err
 			}

--- a/cmd/skywire-cli/commands/ptyfs/ptyfs.go
+++ b/cmd/skywire-cli/commands/ptyfs/ptyfs.go
@@ -20,6 +20,7 @@ package cliptyfs
 import (
 	"github.com/spf13/cobra"
 
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
@@ -28,9 +29,11 @@ import (
 // all-platforms file because init() registers them on RootCmd
 // regardless of OS, and the linux-only mount path consumes them.
 var (
-	ptyfsSK      cipher.SecKey
-	ptyfsNoVisor bool
-	ptyfsDefPort string
+	ptyfsSK        cipher.SecKey
+	ptyfsNoVisor   bool
+	ptyfsDefPort   string
+	ptyfsTransport string
+	ptyfsVisorKey  bool
 )
 
 // RootCmd is `skywire cli pty fs`. Subcommands are registered per
@@ -50,7 +53,7 @@ Same trust model as 'skywire cli pty shell':
   authorized keys -> dmsgpty whitelist on the server side
   client auth     -> client PK alone, derived from the local visor's
                      SK by default (override with --sk or
-                     --no-visor-key)
+                     --visor-key=false)
 
 Linux-only — FUSE is required, and the host process must be allowed
 to mount via FUSE (typically by group membership or a passwordless
@@ -76,4 +79,9 @@ func init() {
 		"don't borrow the local visor's SK from "+visorconfig.SkywireConfig()+" — use --sk or a random one instead")
 	RootCmd.PersistentFlags().StringVarP(&ptyfsDefPort, "port", "p", "2022",
 		"default port when the destination omits one (e.g. '<pk>@host' resolves to <pk>@host:<port>)")
+	RootCmd.PersistentFlags().StringVar(&ptyfsTransport, "transport", internal.TransportAuto,
+		"transport: auto|dmsg (via-visor) | tcp (direct, needs a <pk>@host:port target); skynet is not wired, --standalone forces standalone-dmsg")
+	RootCmd.PersistentFlags().BoolVar(&ptyfsVisorKey, "visor-key", true,
+		"borrow the local visor's SK from "+visorconfig.SkywireConfig()+" for the tcp noise handshake (default true; --sk wins)")
+	_ = RootCmd.PersistentFlags().MarkHidden("no-visor-key")
 }

--- a/cmd/skywire-cli/commands/ssh/ssh.go
+++ b/cmd/skywire-cli/commands/ssh/ssh.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/pty"
@@ -39,13 +40,16 @@ var sshDestRE = regexp.MustCompile(`^(?:tcp://)?([a-f0-9]{66})@(.+:[^:]+)$`)
 
 // Flags (package-level so cobra can wire them once).
 var (
-	sshSK       cipher.SecKey
-	sshNoVisor  bool
-	sshEnv      []string
-	sshTimeout  string
-	sshNoPty    bool
-	sshDefPort  string
-	sshLegacyPK string //nolint:unused // kept for future "ssh <pk>" + --host shape
+	sshSK         cipher.SecKey
+	sshNoVisor    bool
+	sshEnv        []string
+	sshTimeout    string
+	sshNoPty      bool
+	sshDefPort    string
+	sshTransport  string
+	sshStandalone bool
+	sshVisorKey   bool
+	sshLegacyPK   string //nolint:unused // kept for future "ssh <pk>" + --host shape
 )
 
 func init() {
@@ -62,6 +66,13 @@ func init() {
 		"force exec mode even when no command is given (rarely useful — defaults to interactive when no command, exec when command is present, matching ssh's behavior)")
 	RootCmd.Flags().StringVarP(&sshDefPort, "port", "p", "2022",
 		"default port when the destination omits one (e.g. 'ssh <pk>@host' resolves to <pk>@host:<port>)")
+	RootCmd.Flags().StringVar(&sshTransport, "transport", "auto",
+		"transport: auto|tcp (pty shell is direct-TCP only; dmsg|skynet error — use 'cli pty exec' for those)")
+	RootCmd.Flags().BoolVar(&sshStandalone, "standalone", false,
+		"(not supported for pty shell — accepted for vocabulary parity; errors if set)")
+	RootCmd.Flags().BoolVar(&sshVisorKey, "visor-key", true,
+		"borrow the local visor's SK from "+visorconfig.SkywireConfig()+" for the noise handshake (default true; --sk wins)")
+	_ = RootCmd.Flags().MarkHidden("no-visor-key")
 }
 
 // RootCmd is the `skywire cli pty shell` command — OpenSSH-equivalent client
@@ -98,6 +109,13 @@ Examples:
   # Use a pinned client SK instead of the visor's
   skywire cli pty shell 0323...@1.2.3.4:2022 --sk <hex> -- whoami
 
+Transport: this command is direct-TCP only. --transport auto and
+--transport tcp both select that single path; --transport dmsg /
+skynet error with a pointer to 'cli pty exec', which has the via-visor
+paths. A tcp://<pk>@host:port destination is accepted (the scheme is
+optional); dmsg:// / skynet:// destinations are rejected here.
+--standalone is not supported (errors if set).
+
 The underlying transport is identical to 'cli dmsg pty exec/start
 --via tcp://<pk>@<host>:<port>'; this command is the discoverable
 ssh-shaped alias over that path.`,
@@ -107,7 +125,27 @@ ssh-shaped alias over that path.`,
 	DisableSuggestions:    true,
 	DisableFlagsInUseLine: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if sshStandalone {
+			return fmt.Errorf("pty shell: --standalone not supported (this command is direct-TCP only); for a via-visor path use `cli pty exec` / `cli pty start`")
+		}
 		dest := args[0]
+
+		// A tcp:// scheme on the destination is stripped and accepted;
+		// dmsg:// / skynet:// are rejected — pty shell is direct-TCP
+		// only. --transport auto|tcp map to the same TCP path.
+		scheme, rest := internal.SplitTargetScheme(dest)
+		eff, err := internal.ResolveTransport(sshTransport, cmd.Flags().Changed("transport"), scheme)
+		if err != nil {
+			return fmt.Errorf("pty shell: %w", err)
+		}
+		switch eff {
+		case internal.TransportAuto, internal.TransportTCP:
+			// direct-TCP — the only path this command has.
+		default:
+			return fmt.Errorf("pty shell is direct-TCP only; use `cli pty exec --transport %s` for the via-visor path", eff)
+		}
+		dest = rest
+
 		// If the destination omits a port, splice in --port. Doing it
 		// here (not in the regex) avoids ambiguity with IPv6 literals.
 		dest = injectDefaultPort(dest, sshDefPort)
@@ -117,7 +155,13 @@ ssh-shaped alias over that path.`,
 			return err
 		}
 
-		myPK, mySK := resolveSSHIdentity(sshSK, !sshNoVisor)
+		// --visor-key is the canonical spelling; the legacy --no-visor-key
+		// is a hidden opt-out alias. --visor-key wins when both are set.
+		useVisorKey := sshVisorKey
+		if !cmd.Flags().Changed("visor-key") && cmd.Flags().Changed("no-visor-key") {
+			useVisorKey = !sshNoVisor
+		}
+		myPK, mySK := resolveSSHIdentity(sshSK, useVisorKey)
 
 		ctx, cancel := cmdutil.SignalContext(context.Background(), nil)
 		defer cancel()


### PR DESCRIPTION
## What

A strictly-additive, backward-compatible transport vocabulary + scheme-prefixed targets for the remote-access "trinity" — `pty exec`/`pty start`, `pty shell`, `dmsg scp`, `pty fs mount` — so the same words select the transport across all of them. No existing invocation changes.

## Unified flags (added to each command)

- `--transport auto|dmsg|skynet|tcp` (default `auto` = each command's current behavior). Values a command does not support today return a **clear error** instead of silently doing nothing (e.g. `dmsg scp --transport tcp`, `pty shell --transport dmsg`, `pty fs mount --transport skynet`).
- `--standalone` — real no-visor path on scp (force standalone-dmsg) and fs (existing); accepted-but-erroring on exec/start/shell where no such path exists yet.
- `--visor-key` (default matches each command's historical default) — canonical spelling of "borrow the local visor SK for the noise handshake".

## Scheme-prefixed targets

`dmsg://<pk>`, `skynet://<pk>`, `tcp://<pk>@host:port` — the URL scheme selects the transport inline (scp also keeps the remote `:path`, e.g. `skynet://<pk>:remote.bin`). Bare targets (`<pk>`, `<pk>:path`, `<pk>@host:port`) are byte-identical to before.

**Precedence** (`cliutil.ResolveTransport`): bare target → `--transport` (default auto); only the target scheme'd → target scheme wins; both and they agree → that transport; both and they conflict → clear error; explicit `--transport auto` yields to the target scheme.

## Backward compatibility (strictly additive)

Every legacy spelling is preserved as a **hidden alias** that maps to the new flag:

| Command | Hidden alias | Maps to |
|---|---|---|
| pty exec | `--scheme` | `--transport` (`""`→auto, `dmsg`, `skynet`) |
| pty exec/start | `--via-visor` | `--visor-key` |
| pty shell, pty fs | `--no-visor-key` | `--visor-key=false` |

The new `--visor-key` wins when both it and the legacy alias are set (`cmd.Flags().Changed`); otherwise the legacy flag is honored; otherwise each command's historical default holds. `--via tcp://…` and all bare positional forms are untouched.

## Ragged matrix, documented honestly

The commands genuinely support different transport subsets; help text states this per command rather than claiming unwired support:
- exec/start: via-visor dmsg + skynet + direct-TCP (start has no skynet knob → errors, pointing at exec). No standalone.
- shell: direct-TCP only (`dmsg://`/`skynet://` error).
- scp: via-visor dmsg + skynet + standalone-dmsg. No tcp (no dmsgscp TCP host).
- fs mount: via-visor dmsg + standalone-dmsg + direct-TCP. No skynet-via-visor.

## Shared code + tests

`cmd/skywire-cli/cliutil/transport.go` (new): `SplitTargetScheme`, `ResolveTransport`, transport constants — with unit tests (`transport_test.go`).

## Validation

`go build ./...`, `go vet ./cmd/skywire-cli/...`, `go test ./cmd/skywire-cli/... ./pkg/pty/...`, and `make check-help` all clean. Live-verified against a running visor: legacy bare `pty exec <pk> -- …` works unchanged; the new `pty exec dmsg://<pk> -- …` works; a `--transport dmsg` vs `skynet://` target conflict errors cleanly; the hidden `--scheme` alias still parses. Does not touch the global `--via dmsg://<pk>` root flag.
