### PR TITLE
fix(lint): clear errcheck/gosec debt in status+interstitial code

### DIFF
--- a/pkg/proxyinterstitial/stream_test.go
+++ b/pkg/proxyinterstitial/stream_test.go
@@ -17,7 +17,11 @@ import (
 // the fully de-chunked body.
 func readStreamBody(t *testing.T, c net.Conn, reqLine string) string {
 	t.Helper()
-	go func() { _, _ = c.Write([]byte(reqLine)) }()
+	go func() {
+		if _, err := c.Write([]byte(reqLine)); err != nil {
+			return // reader finished + closed the pipe first — benign in this test
+		}
+	}()
 	resp, err := http.ReadResponse(bufio.NewReader(c), nil)
 	if err != nil {
 		t.Fatalf("ReadResponse: %v", err)

--- a/pkg/proxystatus/proxystatus_test.go
+++ b/pkg/proxystatus/proxystatus_test.go
@@ -108,7 +108,10 @@ func TestServeConn(t *testing.T) {
 func hexLum(h string) float64 {
 	h = strings.TrimPrefix(h, "#")
 	c := func(i int) float64 {
-		v, _ := strconv.ParseInt(h[i:i+2], 16, 0)
+		v, err := strconv.ParseInt(h[i:i+2], 16, 0)
+		if err != nil {
+			return 0
+		}
 		s := float64(v) / 255
 		if s <= 0.03928 {
 			return s / 12.92

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -93,11 +93,13 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 		`<th>leg</th><th>transport</th><th>peer</th><th>sent</th><th>bandwidth (sent share)</th>` +
 		`<th>recv</th><th>rtt</th><th>rtx</th><th>state</th></tr></thead><tbody>`)
 	for _, l := range snap.Legs {
-		pct := int(l.SentBytes * 100 / maxSent)
+		// share is 0..100 (maxSent is the per-leg max, >=1) — kept as uint64 and
+		// printed directly so there's no uint64->int narrowing to overflow-check.
+		share := l.SentBytes * 100 / maxSent
 		state, scls := legState(l)
 		fmt.Fprintf(b, `<tr><td>R%d</td><td>%s</td><td class="pk">%s</td><td>%s</td>`,
 			l.Index, html.EscapeString(orDash(l.TpType)), html.EscapeString(shortPK(l.RemotePK)), humanBytes(l.SentBytes))
-		fmt.Fprintf(b, `<td class="barcell"><span class="bar %s" style="width:%d%%"></span></td>`, scls, pct)
+		fmt.Fprintf(b, `<td class="barcell"><span class="bar %s" style="width:%d%%"></span></td>`, scls, share)
 		fmt.Fprintf(b, `<td>%s</td><td>%.0f ms</td><td>%d</td><td class="%s">%s</td></tr>`,
 			humanBytes(l.RecvBytes), l.LatencyMS, l.Retransmits, scls, state)
 	}

--- a/pkg/visor/embedded_proxystatus.go
+++ b/pkg/visor/embedded_proxystatus.go
@@ -66,7 +66,8 @@ func (p *visorStatusProvider) StatusSnapshot(surface proxystatus.Surface) (proxy
 	snap := proxystatus.Snapshot{Surface: surface, App: app}
 
 	if p.v.procM != nil {
-		_, snap.Running = p.v.procM.ProcByName(app)
+		proc, ok := p.v.procM.ProcByName(app)
+		snap.Running = ok && proc != nil
 	}
 
 	// Logs (best-effort): the store may not exist for an internal app that has

--- a/pkg/visor/meshproxy.go
+++ b/pkg/visor/meshproxy.go
@@ -746,7 +746,10 @@ func meshStatusHandler(suffix string, status proxystatus.Provider, next http.Han
 				}
 				w.Header().Set("Content-Type", "text/html; charset=utf-8")
 				w.Header().Set("Cache-Control", "no-store")
-				_, _ = w.Write(proxystatus.Render(snap)) //nolint:errcheck
+				// G705: proxystatus.Render emits trusted, server-generated HTML that
+				// HTML-escapes every interpolated value (see pkg/proxystatus/render.go);
+				// it is not tainted request input.
+				_, _ = w.Write(proxystatus.Render(snap)) //nolint:errcheck,gosec
 				return
 			}
 		}

--- a/pkg/visor/routeviz_embed.go
+++ b/pkg/visor/routeviz_embed.go
@@ -20,6 +20,8 @@ func (hv *Hypervisor) getRouteViz() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-cache")
-		_, _ = w.Write(routeVizHTML)
+		if _, err := w.Write(routeVizHTML); err != nil {
+			hv.log(r).WithError(err).Debug("route-viz page write failed")
+		}
 	}
 }


### PR DESCRIPTION
`golangci-lint` 2.12.2 (the local/gate version) flags pre-existing issues in the status/interstitial code that merged via #4050/#4053/#4054 — CI's lint was laxer, so `make check` is currently **RED on develop**. This clears them. **No behavior change.**

Ran `golangci-lint run -c .golangci.yml ./pkg/visor/ ./pkg/proxystatus/ ./pkg/dmsgweb/ ./pkg/skynetweb/ ./pkg/proxyinterstitial/` → **0 issues** after these fixes:

- **`embedded_proxystatus.go`** (errcheck, check-blank): check `ProcByName`'s returns (`proc, ok := …; Running = ok && proc != nil`) instead of blanking.
- **`routeviz_embed.go`** (errcheck): handle the `w.Write` error (debug-log via `hv.log(r)`).
- **`proxystatus/render.go`** (gosec G115): keep the per-leg sent-share as `uint64` and print it directly with `%d` — no `uint64 → int` narrowing to overflow-check.
- **`meshproxy.go`** (gosec G705): justify the status-page `w.Write` with `//nolint:gosec` — `proxystatus.Render` emits trusted, server-generated HTML that HTML-escapes every interpolated value (not tainted input).
- **`stream_test.go` / `proxystatus_test.go`** (errcheck): check the `Write` / `ParseInt` returns.

Verified `make check` (TMPDIR=/var/tmp) — reporting the result in the thread. Unblocks the merge chain.