### PR TITLE
fix(skywire-cli): tp v online filter + tp uptime graceful degradation

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -847,6 +847,16 @@ func FetchIntegratedUptimes(cmdFlags *pflag.FlagSet, tpdBase, cachefile string, 
 	return FetchCachedServiceURL(cmdFlags, cachefile, IntegratedUptimeURL(tpdBase), cacheFilesAge)
 }
 
+// FetchIntegratedUptimesDays is FetchIntegratedUptimes with an explicit
+// uptime window (days ∈ {1,7,30}). Online-status-only callers (visor
+// list / online filters) pass days=1: the .on flag is present in every
+// window, so pulling the 30-day daily bitmap for thousands of visors is
+// pure over-fetch that bloats the payload past the RPC DmsgHTTP timeout.
+// Matches the days=1 usage in pv / sd / proxy / vpn.
+func FetchIntegratedUptimesDays(cmdFlags *pflag.FlagSet, tpdBase, cachefile string, cacheFilesAge, days int) string {
+	return FetchCachedServiceURL(cmdFlags, cachefile, IntegratedUptimeURLDays(tpdBase, days), cacheFilesAge)
+}
+
 var (
 	cliCacheOnce sync.Once
 	cliCache     *clicache.Cache

--- a/cmd/skywire-cli/commands/tp/tp-uptime.go
+++ b/cmd/skywire-cli/commands/tp/tp-uptime.go
@@ -139,7 +139,24 @@ transport type, or --json to dump raw JSON for piping.`,
 			if tpUptimeVersion != "" && tpUptimeVersion != "v1" {
 				q = "?v=" + tpUptimeVersion
 			}
-			raw := cachedFetch(cmd, "/uptimes/transports"+q, "uptimes-transports-"+tpUptimeVersion, nil)
+			// The full per-transport list is a large payload (tens of
+			// thousands of rows) and can exceed the visor RPC DmsgHTTP
+			// timeout when the CXO snapshot is cold, returning empty.
+			// Rather than dying with a bare "empty response", degrade to
+			// the small /metrics/uptime aggregate (the same source `-m`
+			// uses) so the user still gets real network numbers, with a
+			// clear note on how to pull the full list.
+			raw := cachedFetchAllowEmpty(cmd, "/uptimes/transports"+q, "uptimes-transports-"+tpUptimeVersion, nil)
+			if raw == "" {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: full per-transport list from /uptimes/transports was unavailable (large payload timed out over the visor RPC); showing the /metrics/uptime aggregate instead. For per-transport rows use --no-rpc (direct DMSG has a longer timeout), scope with --ids/--visors, or try a lighter --v v1.\n") //nolint:errcheck,gosec
+				mraw := cachedFetch(cmd, "/metrics/uptime", "metrics-uptime", nil)
+				var nu uptimestats.NetworkUptime
+				if err := json.Unmarshal([]byte(mraw), &nu); err != nil {
+					fatal(cmd, fmt.Errorf("parse /metrics/uptime: %w", err))
+				}
+				internal.PrintOutput(cmd.Flags(), nu, formatNetworkUptime(nu))
+				return
+			}
 			var entries []uptimestats.TransportSummary
 			if err := json.Unmarshal([]byte(raw), &entries); err != nil {
 				fatal(cmd, fmt.Errorf("parse /uptimes/transports: %w", err))
@@ -154,13 +171,21 @@ transport type, or --json to dump raw JSON for piping.`,
 // every other CLI command. The cacheKey is hashed when filterArgs is
 // non-nil so different filter selections get separate cache files.
 func cachedFetch(cmd *cobra.Command, path, cacheKey string, filterArgs interface{}) string {
-	fullURL := strings.TrimRight(tpUptimeBaseURL, "/") + path
-	cf := tpUptimeCacheFile(cacheKey, filterArgs)
-	raw := clirpc.FetchCachedServiceURL(cmd.Flags(), cf, fullURL, tpUptimeCacheAge)
+	raw := cachedFetchAllowEmpty(cmd, path, cacheKey, filterArgs)
 	if raw == "" {
+		fullURL := strings.TrimRight(tpUptimeBaseURL, "/") + path
 		fatal(cmd, fmt.Errorf("empty response from %s", fullURL))
 	}
 	return raw
+}
+
+// cachedFetchAllowEmpty is cachedFetch without the fatal-on-empty: it
+// returns "" so the caller can degrade gracefully (e.g. fall back to a
+// lighter endpoint) instead of exiting.
+func cachedFetchAllowEmpty(cmd *cobra.Command, path, cacheKey string, filterArgs interface{}) string {
+	fullURL := strings.TrimRight(tpUptimeBaseURL, "/") + path
+	cf := tpUptimeCacheFile(cacheKey, filterArgs)
+	return clirpc.FetchCachedServiceURL(cmd.Flags(), cf, fullURL, tpUptimeCacheAge)
 }
 
 func tpUptimeCacheFile(key string, filterArgs interface{}) string {

--- a/cmd/skywire-cli/commands/tp/tp-visor.go
+++ b/cmd/skywire-cli/commands/tp/tp-visor.go
@@ -15,7 +15,53 @@ import (
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/servicedisc"
+	"github.com/skycoin/skywire/pkg/uptimestats"
 )
+
+// visorOnlineJQFilter builds the jq expression that keeps only the SD
+// visors whose public key appears in the uptime "online" set, optionally
+// narrowing by country/version. The SD visor address is "pk:port" while
+// the uptime .pk is the bare public key, so the address MUST have its
+// port stripped before matching — otherwise the join never hits and
+// every visor is filtered out (the historical "tp v returns 0" bug).
+func visorOnlineJQFilter(country, version string) string {
+	countryCond := ""
+	if country != "" {
+		countryCond = ` | select(.geo.country == "` + country + `")`
+	}
+	versionCond := ""
+	if version != "" {
+		versionCond = ` | select(.version == "` + version + `")`
+	}
+	return `
+	[ .ut[] | select(.on) | .pk ] as $online
+	| .sd[]
+	| select((.address | split(":")[0]) as $pk | $pk | IN($online[]))` + countryCond + versionCond + `
+	| "\(.address) \(.geo.country) \(.version)"
+	`
+}
+
+// onlineDataUsable reports whether an /uptimes payload can drive the
+// online filter: it must be non-empty JSON AND contain at least one
+// visor flagged on. An all-offline (or empty-array) payload means the
+// online-status source is not reporting live state — filtering against
+// it would zero out every visor, which reads as "no public visors
+// exist". Callers treat a false return as "fail open, list unfiltered".
+func onlineDataUsable(uts string) bool {
+	if uts == "" {
+		return false
+	}
+	var entries []uptimestats.VisorSummary
+	if err := json.Unmarshal([]byte(uts), &entries); err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.Online {
+			return true
+		}
+	}
+	return false
+}
 
 var (
 	visorServiceType = servicedisc.ServiceTypeVisor
@@ -91,7 +137,24 @@ Set cache file location to "" to avoid using cache files`,
 			return
 		}
 
-		// --- No filtering case ---
+		// --- Online-status data (days=1: we only read .on) ---
+		// Fetch the uptime data up-front so we can detect the "online
+		// source unavailable" case and fail OPEN rather than silently
+		// filtering every visor out. The full visor-uptime list can time
+		// out over the visor RPC (large payload, CXO miss); when that
+		// happens uts is "" and joining against it would zero the result,
+		// which reads as "no public visors exist" — a lie. Fall through to
+		// the unfiltered (--noton) path with a warning instead.
+		online := ""
+		if !vNoFilterOnline {
+			online = clirpc.FetchIntegratedUptimesDays(cmd.Flags(), vUTURL, vCacheFileUT, vCacheFilesAge, 1)
+			if !onlineDataUsable(online) {
+				fmt.Fprintln(cmd.ErrOrStderr(), "warning: transport-discovery online-status data unavailable (no visor is reporting live-online); listing all registered visors unfiltered (retry, or use -o to silence this)") //nolint:errcheck,gosec
+				vNoFilterOnline = true
+			}
+		}
+
+		// --- No filtering case (or fail-open when online data is missing) ---
 		if vNoFilterOnline {
 			sdJQ := `.[]`
 			if vCountry != "" {
@@ -116,28 +179,11 @@ Set cache file location to "" to avoid using cache files`,
 		}
 
 		// --- Filtering by online status via jq join ---
-		uts := clirpc.FetchIntegratedUptimes(cmd.Flags(), vUTURL, vCacheFileUT, vCacheFilesAge)
-		if uts == "" {
-			uts = "[]"
-		}
-		joinedJSON := fmt.Sprintf(`{"sd": %s, "ut": %s}`, sds, uts)
+		// online is non-empty here: the fail-open branch above already
+		// diverted the empty case to the unfiltered path.
+		joinedJSON := fmt.Sprintf(`{"sd": %s, "ut": %s}`, sds, online)
 
-		// Build jq filter with optional country and version conditions
-		countryCond := ""
-		if vCountry != "" {
-			countryCond = ` | select(.geo.country == "` + vCountry + `")`
-		}
-		versionCond := ""
-		if vVersion != "" {
-			versionCond = ` | select(.version == "` + vVersion + `")`
-		}
-
-		jqFilter := `
-		[ .ut[] | select(.on) | .pk ] as $online
-		| .sd[]
-		| select(.address as $pk | $pk | IN($online[]))` + countryCond + versionCond + `
-		| "\(.address) \(.geo.country) \(.version)"
-		`
+		jqFilter := visorOnlineJQFilter(vCountry, vVersion)
 
 		if vIsStats {
 			count, err := script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, "").CountLines()

--- a/cmd/skywire-cli/commands/tp/tp-visor_test.go
+++ b/cmd/skywire-cli/commands/tp/tp-visor_test.go
@@ -1,0 +1,110 @@
+// Package clitp cmd/skywire-cli/commands/tp/tp-visor_test.go c4-vis-cli
+package clitp
+
+import (
+	"testing"
+
+	"github.com/bitfield/script"
+)
+
+// TestVisorOnlineJQFilter_PortStrip is the regression guard for the
+// "tp v returns 0" bug: the service-discovery visor address carries a
+// ":port" suffix while the uptime .pk is the bare public key, so the
+// join must strip the port before matching. Without the strip the online
+// set never intersects the SD addresses and every visor is dropped.
+func TestVisorOnlineJQFilter_PortStrip(t *testing.T) {
+	// pkOnline is registered in SD as pk:port and is online in UT.
+	// pkOffline is registered but not online. pkPortless exercises an
+	// address with no port (defensive: split(":")[0] is a no-op).
+	const (
+		pkOnline   = "027eac7508598d959e17d4d474d001f0e795e1758f68759eeb74fdb4131c9f9039"
+		pkOffline  = "03160010f0b606918129708b9727a11b10282d99b5475f41c0568b49ade3feda9e"
+		pkPortless = "03dc3488e49ded9250f3cca2827ab16f6331b7ccefdad614353c785a5fc76c1b13"
+	)
+	joined := `{
+		"sd": [
+			{"address": "` + pkOnline + `:9651", "geo": {"country": "US"}, "version": "v1.3.92"},
+			{"address": "` + pkOffline + `:7771", "geo": {"country": "SG"}, "version": "v1.3.91"},
+			{"address": "` + pkPortless + `", "geo": {"country": "IT"}, "version": "v1.3.91"}
+		],
+		"ut": [
+			{"pk": "` + pkOnline + `", "on": true},
+			{"pk": "` + pkOffline + `", "on": false},
+			{"pk": "` + pkPortless + `", "on": true}
+		]
+	}`
+
+	out, err := script.Echo(joined).JQ(visorOnlineJQFilter("", "")).Replace(`"`, "").String()
+	if err != nil {
+		t.Fatalf("jq filter failed: %v", err)
+	}
+
+	if !contains(out, pkOnline) {
+		t.Errorf("online visor with :port address was filtered out (port not stripped); got:\n%s", out)
+	}
+	if !contains(out, pkPortless) {
+		t.Errorf("online visor with portless address was filtered out; got:\n%s", out)
+	}
+	if contains(out, pkOffline) {
+		t.Errorf("offline visor leaked into the online-filtered output; got:\n%s", out)
+	}
+}
+
+// TestVisorOnlineJQFilter_CountryVersion checks the optional narrowing
+// conditions compose with the port-stripped join.
+func TestVisorOnlineJQFilter_CountryVersion(t *testing.T) {
+	const (
+		pkUS = "027eac7508598d959e17d4d474d001f0e795e1758f68759eeb74fdb4131c9f9039"
+		pkDE = "03160010f0b606918129708b9727a11b10282d99b5475f41c0568b49ade3feda9e"
+	)
+	joined := `{
+		"sd": [
+			{"address": "` + pkUS + `:9651", "geo": {"country": "US"}, "version": "v1.3.92"},
+			{"address": "` + pkDE + `:7771", "geo": {"country": "DE"}, "version": "v1.3.92"}
+		],
+		"ut": [
+			{"pk": "` + pkUS + `", "on": true},
+			{"pk": "` + pkDE + `", "on": true}
+		]
+	}`
+
+	out, err := script.Echo(joined).JQ(visorOnlineJQFilter("DE", "")).Replace(`"`, "").String()
+	if err != nil {
+		t.Fatalf("jq filter failed: %v", err)
+	}
+	if contains(out, pkUS) || !contains(out, pkDE) {
+		t.Errorf("country filter did not narrow correctly; got:\n%s", out)
+	}
+}
+
+// TestOnlineDataUsable covers the fail-open predicate that prevents an
+// empty / all-offline uptime payload from silently zeroing the visor list.
+func TestOnlineDataUsable(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty string", "", false},
+		{"empty array", "[]", false},
+		{"malformed json", "not json", false},
+		{"all offline", `[{"pk":"027eac7508598d959e17d4d474d001f0e795e1758f68759eeb74fdb4131c9f9039","on":false}]`, false},
+		{"one online", `[{"pk":"027eac7508598d959e17d4d474d001f0e795e1758f68759eeb74fdb4131c9f9039","on":false},{"pk":"03160010f0b606918129708b9727a11b10282d99b5475f41c0568b49ade3feda9e","on":true}]`, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := onlineDataUsable(c.in); got != c.want {
+				t.Errorf("onlineDataUsable(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

Two related `skywire cli tp` subcommands silently returned empty/zero against the live deployment:

- **`skywire cli tp v`** (list public visors, default online filter) returned **0** — while `tp v -o` (no online filter) returned the real visor list.
- **`skywire cli tp uptime`** (default, per-transport rows) died with `error: empty response from .../uptimes/transports?v=v2` — while `tp uptime -m` (`/metrics/uptime` aggregate) and `tp uptime --ids <id>` returned real data.

## Root cause (client-side)

**`tp v`:** the jq join that intersects service-discovery visors with the online-uptime set compared the SD visor `.address` — which is `pk:port` (e.g. `027eac…9039:9651`) — against the bare public keys (`.pk`, 66 hex chars) from the uptime feed. The two never intersect, so every visor was filtered out. The uptime data itself is fine (hundreds of visors report online); the join was broken by the port suffix.

**`tp uptime`:** the full `/uptimes/transports` payload is tens of thousands of rows (~25k transports; the `v2` body takes ~30s to transfer). That exceeds the visor RPC DmsgHTTP timeout, so the fetch returns empty and the command exited with a bare error. The small `/metrics/uptime` aggregate transfers fine, which is why `-m` and `--ids` worked.

## Fix

- `tp v`: strip the port from the SD address before the online join. Fetch the online set with `days=1` (only the `.on` flag is read — matches `pv`/`sd`/`proxy`). **Fail open** — list all registered visors with a warning — when the uptime source reports no live-online visor, instead of silently returning 0 (which reads as "no visors exist").
- `tp uptime`: when the full per-transport list is unavailable, **degrade gracefully** to the `/metrics/uptime` aggregate (the same source `-m` uses) with a warning that points at `--no-rpc` / `--ids` / `--visors` / `--v v1` for the full list, instead of exiting with an error.
- Adds unit tests for the port-stripped online join (regression guard) and the fail-open predicate.

## Before / after (live, against a running visor)

```
# tp v -s   (online filter)
before: 0
after:  23          # tp v -o -s (all registered) = 69

# tp uptime (default)
before: error: empty response from dmsg://…/uptimes/transports?v=v2
after:  warning: full per-transport list … unavailable; showing /metrics/uptime aggregate instead
        transports: 25924 total, 3297 online (12.7%)
        by type:
          stcpr    524 /  8310 online (6.3%)
          sudph   2773 / 17614 online (15.7%)
```

`make check` clean (vet, lint 0 issues, tests pass) on the changed packages.