### PR TITLE
fix(cli): proxy/forwarding surface audit — status IP bug, geoip help, mux/routes vocab converge (#77)

### DIFF
--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -80,14 +80,20 @@ func init() {
 	startCmd.Flags().BoolVar(&existingTpOnly, "existing-tp", false, "only use existing transports, don't create new ones")
 	startCmd.Flags().BoolVar(&forceLocalRoutes, "local-route", false, "calculate routes locally instead of using route finder")
 	startCmd.Flags().IntVar(&muxRoutes, "mux", 1, "parallel mux routes: 0=unlimited (every distinct path), 1=disabled (default), 2+=N routes")
+	// --routes is the cross-group spelling for the same parallel-route count
+	// (`skynet start --routes`, `proxy mux plot --routes`, `proxy mux auto`).
+	// Bound to the same var as --mux so either spelling works; hidden to keep
+	// the primary `--mux` name on this command. Passing both = last parsed wins.
+	startCmd.Flags().IntVar(&muxRoutes, "routes", 1, "alias for --mux (parallel route count)")
+	startCmd.Flags().MarkHidden("routes") //nolint:errcheck,gosec
 	startCmd.Flags().StringVar(&muxMode, "mux-mode", "auto", "mux weight distribution mode: auto (latency-based) or equal (round-robin)")
 	startCmd.Flags().Uint16Var(&minHops, "min-hops", 1, "minimum routing hops for this session (1=no minimum). Set on the visor before app start; rolled back is not automatic — restart visor or re-run with --min-hops=1 to revert.")
 	startCmd.Flags().BoolVarP(&startVerbose, "verbose", "v", false, "stream the visor's logs scoped to this app's session (app stdout + tagged router/mux/setup events); ctrl+c stops the proxy and exits")
 	startCmd.Flags().StringVar(&startVerboseLevel, "verbose-level", "debug", "minimum log level when --verbose is set: trace|debug|info|warn|error")
 	startCmd.Flags().BoolVar(&reconnect, "reconnect", true, "in-process reconnect on route-group collapse: proxy keeps re-dialing with backoff instead of dropping the SOCKS5 listener; --reconnect=false restores exit-on-failure")
-	startCmd.Flags().StringVar(&startRoutingPolicy, "routing-policy", "", "per-app routing policy: @/path/to/policy.star or @/path/to/policy.wasm (\"\" or \"none\" clears any previously-installed override)")
-	stopCmd.Flags().BoolVar(&allClients, "all", false, "stop all skysocks client")
-	stopCmd.Flags().StringVar(&clientName, "name", "", "specific skysocks client that want stop")
+	startCmd.Flags().StringVar(&startRoutingPolicy, "routing-policy", "", "per-app routing policy: @/path/to/policy.star, @/path/to/policy.wasm, or preset:<name> (\"\" or \"none\" clears any previously-installed override)")
+	stopCmd.Flags().BoolVar(&allClients, "all", false, "stop all skysocks clients")
+	stopCmd.Flags().StringVarP(&clientName, "name", "n", "", "name of the skysocks client to stop")
 	dep := getDeployment()
 	defaultTestEnv := isTestEnv()
 
@@ -547,7 +553,16 @@ var statusCmd = &cobra.Command{
 							tmpSrv = state.Args[idx+1]
 						}
 						if arg == "--addr" {
-							tmpAddr = "127.0.0.1" + state.Args[idx+1]
+							// --addr may be a bare port (":1080") or a full
+							// host:port ("127.0.0.1:1095"). Only prepend the
+							// loopback host for the bare-port short form —
+							// otherwise the display doubled up as
+							// "127.0.0.1127.0.0.1:1095".
+							if strings.HasPrefix(state.Args[idx+1], ":") {
+								tmpAddr = "127.0.0.1" + state.Args[idx+1]
+							} else {
+								tmpAddr = state.Args[idx+1]
+							}
 						}
 					}
 					// For a running client, surface the active route group(s) so

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -134,4 +134,17 @@ var (
 var RootCmd = &cobra.Command{
 	Use:   "proxy",
 	Short: "Skysocks client",
+	Long: `Control the skysocks SOCKS5 proxy client over the Skywire network.
+
+Discover and test public proxy servers, start/stop a local client that
+exposes a SOCKS5 listener (default 127.0.0.1:1080), and inspect or reshape
+the multiplexed route group behind an active session.
+
+  list     discover proxy servers from service discovery
+  test     probe reachability of proxy servers
+  start    start the client against a server PK (--pk / positional)
+  stop     stop the client (--name / --all)
+  status   show client status + active route legs
+  mux      per-leg telemetry + route-group operations (info/plot/set/...)
+  server   control the local skysocks (SOCKS5) server app`,
 }

--- a/cmd/skywire-cli/commands/skynet/root.go
+++ b/cmd/skywire-cli/commands/skynet/root.go
@@ -54,6 +54,11 @@ func init() {
 	startCmd.Flags().BoolVar(&useExternal, "external", false, "force external launcher")
 	startCmd.Flags().StringVarP(&clientName, "name", "n", "", "custom name for this client instance (default: skynet-client-<local-port>)")
 	startCmd.Flags().IntVar(&startRoutes, "routes", 0, "number of parallel skynet mux routes (0 or 1 = single route)")
+	// --mux is the cross-group spelling for the same parallel-route count
+	// (`proxy start --mux`). Bound to the same var as --routes; hidden to keep
+	// --routes primary on this command. Passing both = last parsed wins.
+	startCmd.Flags().IntVar(&startRoutes, "mux", 0, "alias for --routes (parallel route count)")
+	startCmd.Flags().MarkHidden("mux") //nolint:errcheck,gosec
 	startCmd.Flags().IntVar(&startMinHops, "min-hops", 0, "force routes through at least this many intermediates (>=2 rejects direct paths)")
 	startCmd.Flags().IntVar(&startFwdMinHops, "forward-min-hops", 0, "per-direction forward MinHops override (>=2 forces multi-hop on forward only)")
 	startCmd.Flags().IntVar(&startRevMinHops, "reverse-min-hops", 0, "per-direction reverse MinHops override (>=2 forces multi-hop on reverse only; combine with low/0 --min-hops for direct-upstream + multi-hop-downstream)")
@@ -139,7 +144,7 @@ var startCmd = &cobra.Command{
 		// single/direct route out from under a visor-global mux_routes/min_hops>1)
 		// actually reaches the app. Unset flags are omitted → the app inherits the
 		// visor-global default.
-		if cmd.Flags().Changed("routes") {
+		if cmd.Flags().Changed("routes") || cmd.Flags().Changed("mux") {
 			arguments["--routes"] = fmt.Sprintf("%d", startRoutes)
 		}
 

--- a/cmd/skywire-cli/commands/vpn/root.go
+++ b/cmd/skywire-cli/commands/vpn/root.go
@@ -115,4 +115,15 @@ var (
 var RootCmd = &cobra.Command{
 	Use:   "vpn",
 	Short: "VPN client",
+	Long: `Control the VPN client over the Skywire network.
+
+Discover VPN servers, start/stop a full-tunnel vpn-client against a server
+PK, check status, and open the VPN web UI.
+
+  list     discover VPN servers from service discovery
+  start    start the tunnel against a server PK (--pk / positional)
+  stop     stop the vpn client
+  status   show vpn client status
+  server   control the local vpn-server app (Linux only)
+  ui/url   open or print the VPN web-UI URL`,
 }

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -38,7 +38,7 @@ func init() {
 		listCmd,
 	)
 	startCmd.Flags().StringVarP(&pk, "pk", "k", "", "server public key")
-	startCmd.Flags().StringVar(&geoipURL, "geoip", deployment.Prod.GeoIP, "server public key")
+	startCmd.Flags().StringVar(&geoipURL, "geoip", deployment.Prod.GeoIP, "geoip service URL queried through the tunnel to confirm the VPN changed the exit IP")
 	startCmd.Flags().IntVarP(&startingTimeout, "timeout", "t", 0, "starting timeout value in second")
 	startCmd.Flags().BoolVar(&useInternal, "internal", false, "force internal launcher")
 	startCmd.Flags().BoolVar(&useExternal, "external", false, "force external launcher")


### PR DESCRIPTION
Audit + fix + standardization of the proxy/forwarding CLI groups
(`proxy`, `skynet`, `vpn`, `serve`, `resolver`). This is the #77
"audit + converge `proxy` + `skynet` control surfaces" work. Strictly
backward-compatible: no flag renames — new spellings are hidden aliases.

## Bug fixes
- **`proxy status`**: stopped double-printing the loopback host for a full
  `host:port` `--addr` (previously rendered `127.0.0.1127.0.0.1:1095`);
  now only prepends `127.0.0.1` for the bare `:port` short form.
- **`vpn start --geoip`**: corrected the help text — it read `server public
  key` (copy-paste error); it is the geoip probe URL queried through the
  tunnel to confirm the exit IP changed.

## Cross-group vocabulary convergence (backward-compatible)
`proxy` spells the parallel-route count `--mux`; `skynet` (and `proxy mux
plot`/`auto`) spell it `--routes`. Converged with hidden aliases so a single
vocabulary works everywhere:
- `proxy start` gains `--routes` (hidden alias of `--mux`)
- `skynet start` gains `--mux` (hidden alias of `--routes`)

## Help / consistency polish
- `proxy stop --name` gains `-n` (parity with `proxy start` / `skynet` /
  `proxy mux` which all use `-n`); tidied wording.
- `proxy start --routing-policy` help now lists `preset:<name>` (parity with
  `skynet`/`vpn`).
- Added `Long` descriptions to the terse `proxy` and `vpn` root commands
  (parity with `skynet`/`serve`/`resolver`).

## Testing
- All five command packages build; `go vet` + `golangci-lint` clean on the
  changed packages.
- Read-only live-visor verification: `proxy status` no longer double-prints
  the address; `proxy stop -n`, the `--geoip` help, and both `--routes`/
  `--mux` aliases parse and render correctly (help hides the alias, shows the
  primary name).
- Flag-alias acceptance checked via pre-Run validation errors so no app on
  the live visor was started/stopped.

## Follow-ups (not in this PR)
- `vpn ui` / `vpn url` print a malformed port (`http://127.0.0.1:{8000 TCP}/`).
  Root cause is `HypervisorPort` in `cmd/skywire-cli/commands/visor/hv.go`
  formatting a `PortDetail` struct with `%s`; the fix is `ports["hypervisor"].Port`.
  Left out of this PR since it lives in the `visor` command group, not the
  forwarding surface.
- `proxy test` uses inverted short flags vs the rest of the surface
  (`-s`=`--pk`, `-k`=`--country`, while everywhere else `-k`=`--pk`). Not
  changed here to preserve backward compatibility; worth a deprecation cycle.
- `skynet start` has no `--verbose`/`--verbose-level` (proxy/vpn do).