### PR TITLE
feat(skywire-cli): standardize + clarify tp/tps transport commands

### DIFF
--- a/cmd/skywire-cli/commands/tp/tp-add.go
+++ b/cmd/skywire-cli/commands/tp/tp-add.go
@@ -46,7 +46,7 @@ var (
 )
 
 func init() {
-	addTpCmd.Flags().StringVarP(&rpk, "rpk", "r", "", "remote public key.")
+	addTpCmd.Flags().StringVarP(&rpk, "rpk", "r", "", "remote public key (alternative to the positional argument)")
 	addTpCmd.Flags().StringVarP(&transportType, "type", "t", "", "type of transport to add.")
 	addTpCmd.Flags().DurationVarP(&timeout, "timeout", "o", 0, "if specified, sets an operation timeout")
 	addTpCmd.Flags().IntVarP(&retries, "retries", "n", 1, "number of times to retry per transport type")
@@ -66,12 +66,21 @@ var addTpCmd = &cobra.Command{
 	Use:   "add <public-key> [public-key]...",
 	Short: "Add transport(s) to one or more remote public keys",
 	Long: `
-    Add transport(s)
-		Accepts one or more remote public keys as arguments.
-		If the transport type is unspecified,
-		the visor will attempt to establish a transport
-		in the following order: stcpr, sudph, dmsg`,
-	Args:                  cobra.MinimumNArgs(1),
+    Add transport(s) from the LOCAL visor to one or more remote public keys.
+		Public keys are given positionally (tp add <pk> [pk]...); a single key
+		may instead be given with -r/--rpk. If the transport type is
+		unspecified, the visor tries each type in preference order, with the
+		dmsg relay last-resort. Use --remote <visor-pk> to instead request the
+		transport on a REMOTE visor via the Transport Setup Node (TPS).`,
+	// Require at least one public key, but allow it to arrive via -r/--rpk
+	// or --remote instead of positionally (so `tp add -r <pk>` works rather
+	// than erroring "requires at least 1 arg").
+	Args: func(_ *cobra.Command, args []string) error {
+		if len(args) == 0 && rpk == "" {
+			return fmt.Errorf("requires at least one remote public key (positional, or via -r/--rpk)")
+		}
+		return nil
+	},
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Validate against the canonical type set (types.Known()) rather than a

--- a/cmd/skywire-cli/commands/tp/tp-all.go
+++ b/cmd/skywire-cli/commands/tp/tp-all.go
@@ -11,17 +11,26 @@ import (
 	"github.com/skycoin/skywire/deployment"
 )
 
+var allTpdURL string
+
 func init() {
+	tpAllCmd.Flags().StringVar(&allTpdURL, "tpdurl", deployment.Prod.TransportDiscovery, "transport discovery url")
+	clirpc.RegisterFetchFlags(tpAllCmd)
 	RootCmd.AddCommand(tpAllCmd)
 }
 
 var tpAllCmd = &cobra.Command{
 	Use:   "all",
-	Short: "List all transports on the network",
-	Long:  `Display all transports registered in the network via the transport discovery HTTP API.`,
+	Short: "Dump every transport registered network-wide (Transport Discovery)",
+	Long: `Dump every transport registered network-wide, as seen by the Transport
+Discovery (TPD) — NOT just the local visor's transports. This is the whole-
+network view; for the local visor's live transports use ` + "`tp`" + `, and for a
+remote visor's live transports use ` + "`tp --remote <pk>`" + ` / ` + "`tps list`" + `.
+
+Fetched over the CXO->DmsgHTTP->DMSG chain (honors --no-cxo/--no-rpc/--no-dmsg).`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		// Fetch from transport discovery HTTP.
-		tpdURL := deployment.Prod.TransportDiscovery + "/all-transports"
+		// Fetch from transport discovery.
+		tpdURL := allTpdURL + "/all-transports"
 		body, fetchErr := clirpc.FetchServiceURL(cmd.Flags(), tpdURL)
 		if fetchErr != nil {
 			internal.PrintFatalError(cmd.Flags(), fetchErr)

--- a/cmd/skywire-cli/commands/tp/tp-rm.go
+++ b/cmd/skywire-cli/commands/tp/tp-rm.go
@@ -20,18 +20,29 @@ var (
 
 func init() {
 	rmTpCmd.Flags().BoolVarP(&removeAll, "all", "a", false, "remove all transports")
-	rmTpCmd.Flags().StringVarP(&tpID, "id", "i", "", "remove transport of given ID")
+	rmTpCmd.Flags().StringVarP(&tpID, "id", "i", "", "transport ID to remove (may also be given positionally: tp rm <id>)")
 	rmTpCmd.Flags().StringSliceVar(&rmRemoteVisors, "remote", nil, "remove transport on remote visor(s) via embedded TPS (comma-separated PKs)")
+	// --tp is the historical spelling for the remote transport ID(s); keep it
+	// working as a hidden alias but steer users to the standard -i/--id
+	// (comma-separated when removing several on a remote via --remote).
 	rmTpCmd.Flags().StringSliceVar(&rmRemoteTransports, "tp", nil, "transport ID(s) to remove on remote visor (comma-separated, use with --remote)")
+	_ = rmTpCmd.Flags().MarkHidden("tp") //nolint:errcheck
 	rmTpCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
 }
 
 var rmTpCmd = &cobra.Command{
-	Use:                   "rm",
+	Use:                   "rm [id]",
 	Short:                 "Remove transport(s) by id",
-	Long:                  "\n    Remove transport(s) by id\n\n    Use --remote with --tp to remove transports on a remote visor via the embedded TPS",
+	Long:                  "\n    Remove transport(s) by id — from the LOCAL visor by default.\n\n    The transport ID may be passed positionally (tp rm <id>) or with -i/--id.\n    Use --remote <visor-pk> with -i/--id to remove transports on a REMOTE\n    visor via the embedded Transport Setup Node (TPS); see also `tps rm`.",
 	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, _ []string) {
+	Args:                  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// Accept the transport ID positionally (tp rm <id>) as well as via
+		// -i/--id, matching `tp add <pk>`. The explicit flag wins if both given.
+		if tpID == "" && len(args) > 0 {
+			tpID = args[0]
+		}
+
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
@@ -39,8 +50,13 @@ var rmTpCmd = &cobra.Command{
 
 		// Handle --remote flag: remove transport on remote visor(s) via embedded TPS
 		if len(rmRemoteVisors) > 0 {
+			// The remote transport ID(s) may come from --tp (legacy, multiple)
+			// or -i/--id / the positional arg (single). Prefer --tp when set.
+			if len(rmRemoteTransports) == 0 && tpID != "" {
+				rmRemoteTransports = []string{tpID}
+			}
 			if len(rmRemoteTransports) == 0 {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--tp flag required with --remote to specify transport ID(s)"))
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("-i/--id (or --tp) required with --remote to specify transport ID(s)"))
 			}
 
 			// Parse all remote visor PKs

--- a/cmd/skywire-cli/commands/tp/tp-uptime.go
+++ b/cmd/skywire-cli/commands/tp/tp-uptime.go
@@ -49,7 +49,11 @@ func defaultTpUptimeCacheDir() string {
 }
 
 func init() {
-	tpUptimeCmd.Flags().StringVar(&tpUptimeBaseURL, "url", deployment.Prod.TransportDiscovery, "transport-discovery base URL")
+	// --tpdurl is the standard spelling shared with `tp disc` / `tp tree`;
+	// --url is kept as a hidden alias so existing invocations keep working.
+	tpUptimeCmd.Flags().StringVar(&tpUptimeBaseURL, "tpdurl", deployment.Prod.TransportDiscovery, "transport-discovery url")
+	tpUptimeCmd.Flags().StringVar(&tpUptimeBaseURL, "url", deployment.Prod.TransportDiscovery, "transport-discovery base URL (alias of --tpdurl)")
+	_ = tpUptimeCmd.Flags().MarkHidden("url") //nolint:errcheck
 	tpUptimeCmd.Flags().StringVarP(&tpUptimeVersion, "v", "v", "v2", "response version (v1|v2|v3)")
 	tpUptimeCmd.Flags().BoolVarP(&tpUptimeMetrics, "metrics", "m", false, "fetch network-wide /metrics/uptime aggregate instead of per-transport rows")
 	tpUptimeCmd.Flags().StringSliceVar(&tpUptimeIDs, "ids", nil, "filter to these transport IDs (comma-separated UUIDs) — uses /metrics/uptime/{ids}")

--- a/cmd/skywire-cli/commands/tp/tp-visor.go
+++ b/cmd/skywire-cli/commands/tp/tp-visor.go
@@ -85,6 +85,9 @@ var (
 func init() {
 	visorListCmd.Flags().StringVarP(&vSDURL, "sdurl", "a", deployment.Prod.ServiceDiscovery, "service discovery url")
 	visorListCmd.Flags().StringVarP(&vUTURL, "uturl", "w", deployment.Prod.TransportDiscovery, "uptime tracker url (TPD integrated)")
+	// --tpdurl is the standard spelling for the transport-discovery url used
+	// across the tp subcommands; alias it onto --uturl (same TPD host).
+	visorListCmd.Flags().StringVar(&vUTURL, "tpdurl", deployment.Prod.TransportDiscovery, "transport-discovery url (alias of --uturl)")
 	visorListCmd.Flags().BoolVarP(&vRawData, "raw", "r", false, "print raw json data")
 	visorListCmd.Flags().BoolVarP(&vNoFilterOnline, "noton", "o", false, "do not filter by online status in UT")
 	visorListCmd.Flags().StringVar(&vCacheFileSD, "cfs", os.TempDir()+"/visorsd.json", "SD cache file location")

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"text/tabwriter"
 	"time"
 
@@ -98,17 +99,22 @@ func init() {
 var tpCmd = &cobra.Command{
 	Use:   "tp",
 	Short: "View and manage transports",
-	Long: `Display and manage transports of the local visor
+	Long: `Display and manage transports of the LOCAL visor.
 
-	Transports are bidirectional communication protocols
-	used between two Skywire Visors (or Transport Edges)
+	Transports are bidirectional communication protocols used between two
+	Skywire Visors (or Transport Edges). Each Transport is a unique 16-byte
+	UUID (the Transport ID) with a Transport Type identifying its
+	implementation. Types: stcp stcpr sudph dmsg squic webrtc ws wt
 
-	Each Transport is represented as a unique 16 byte (128 bit)
-	UUID value called the Transport ID
-	and has a Transport Type that identifies
-	a specific implementation of the Transport.
+	This command has three distinct transport views:
+	  tp                      LOCAL visor's live transports (this command)
+	  tp --remote <pk>        a REMOTE visor's live transports, via the
+	                          Transport Setup Node (see also 'tps list')
+	  tp all / tp tpd-stats   the whole-network view registered in the
+	                          Transport Discovery (TPD)
 
-	Types: stcp stcpr sudph dmsg
+	--more/-m enriches rows with version/country/service info (extra fetches).
+	--live/-L is an interactive TUI and requires a TTY.
 `,
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
@@ -331,11 +337,34 @@ var tpCmd = &cobra.Command{
 		transports, err := rpcClient.Transports(filterTypes, pks, showLogs)
 		internal.Catch(cmd.Flags(), err)
 
-		if showMore {
-			utData = clirpc.FetchIntegratedUptimes(cmd.Flags(), utURL, cacheFileUT, cacheFilesAge)
-			proxyData = clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFileSDProxy, sdURL+"/api/services?type="+servicedisc.ServiceTypeProxy, cacheFilesAge)
-			vpnData = clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFileSDVPN, sdURL+"/api/services?type="+servicedisc.ServiceTypeVPN, cacheFilesAge)
-			visorData = clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFileSDVisor, sdURL+"/api/services?type="+servicedisc.ServiceTypeVisor, cacheFilesAge)
+		// --more enrichment: version (from TPD-integrated uptimes) and
+		// country/service tags (from service-discovery). Only bother when
+		// there are transports to annotate — a filtered query (`-p`/`-i`)
+		// that matches nothing must not pay for four network fetches. The
+		// four are independent, so run them concurrently instead of
+		// serially (they dominate the command's wall time), and pull the
+		// uptimes with days=1: only the .version/.on fields are read here,
+		// so the 30-day daily bitmap for every visor was pure over-fetch.
+		if showMore && len(transports) > 0 {
+			var wg sync.WaitGroup
+			wg.Add(4)
+			go func() {
+				defer wg.Done()
+				utData = clirpc.FetchIntegratedUptimesDays(cmd.Flags(), utURL, cacheFileUT, cacheFilesAge, 1)
+			}()
+			go func() {
+				defer wg.Done()
+				proxyData = clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFileSDProxy, sdURL+"/api/services?type="+servicedisc.ServiceTypeProxy, cacheFilesAge)
+			}()
+			go func() {
+				defer wg.Done()
+				vpnData = clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFileSDVPN, sdURL+"/api/services?type="+servicedisc.ServiceTypeVPN, cacheFilesAge)
+			}()
+			go func() {
+				defer wg.Done()
+				visorData = clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFileSDVisor, sdURL+"/api/services?type="+servicedisc.ServiceTypeVisor, cacheFilesAge)
+			}()
+			wg.Wait()
 		}
 
 		// Get transport logs for bandwidth display

--- a/cmd/skywire-cli/commands/tps/tps.go
+++ b/cmd/skywire-cli/commands/tps/tps.go
@@ -47,9 +47,8 @@ func init() {
 
 	// Remove transport flags
 	rmCmd.Flags().StringVarP(&targetPK, "target", "t", "", "target visor public key")
-	rmCmd.Flags().StringVarP(&tpID, "id", "i", "", "transport ID to remove")
+	rmCmd.Flags().StringVarP(&tpID, "id", "i", "", "transport ID to remove (may also be given positionally: tps rm -t <pk> <id>)")
 	rmCmd.MarkFlagRequired("target") //nolint:errcheck,gosec
-	rmCmd.MarkFlagRequired("id")     //nolint:errcheck,gosec
 
 	// List transports flags
 	listCmd.Flags().StringVarP(&targetPK, "target", "t", "", "target visor public key")
@@ -121,10 +120,22 @@ The target visor must trust this visor's TPS public key.`,
 }
 
 var rmCmd = &cobra.Command{
-	Use:   "rm",
+	Use:   "rm [id]",
 	Short: "Remove transport on target visor",
-	Long:  `Request the target visor to remove a transport by ID.`,
-	Run: func(cmd *cobra.Command, _ []string) {
+	Long: `Request the target visor to remove a transport by ID via TPS.
+
+The transport ID may be passed positionally (tps rm -t <pk> <id>) or with
+-i/--id. Equivalent to ` + "`tp rm --remote <pk> -i <id>`" + `.`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// Accept the transport ID positionally as well as via -i/--id.
+		if tpID == "" && len(args) > 0 {
+			tpID = args[0]
+		}
+		if tpID == "" {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("transport ID required (positionally: tps rm -t <pk> <id>, or with -i/--id)"))
+		}
+
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("RPC connection failed: %w", err))


### PR DESCRIPTION
Backward-compatible polish of the `tp` / `tps` transport command family, from a live audit of the CLI. **Every existing invocation keeps working** — new/consistent forms are added, old spellings kept (hidden where they were confusing). No behavior is removed.

## Flag consistency
- **Positional transport ID.** `tp rm <id>` and `tps rm -t <pk> <id>` now accept the ID positionally, matching `tp add <pk>`. Previously a bare `tp rm <id>` silently printed help — you had to know `-i`. `-i/--id` still works.
- **Standardized remote-remove flag.** `tp rm --remote <pk>` used `--tp` for the transport ID while `tps rm` used `-i`. Both now take `-i/--id`; `tp rm`'s `--tp` is kept as a hidden alias, and the two commands cross-reference each other in help.
- **`tp add -r/--rpk` is now usable.** It previously errored `requires at least 1 arg` because a positional was still mandatory. The arg validator now accepts the key from either the positional or `-r/--rpk`.
- **`--tpdurl` everywhere.** The TPD-querying subcommands (`tp uptime`, `tp v`, `tp all`) now all accept `--tpdurl`, matching `tp disc` / `tp tree`. `tp uptime`'s old `--url` is kept as a hidden alias. `tp all` also gains the shared fetch-chain flags (`--no-cxo`/`--no-rpc`/`--no-dmsg`).

## Clarity
- `tp` long help now names the **three distinct transport views**: LOCAL visor (`tp`), a REMOTE visor via the Transport Setup Node (`tp --remote <pk>` / `tps list`), and the whole-network Transport Discovery view (`tp all` / `tp tpd-stats`); it also notes `--live` needs a TTY. `tp all` help now says it is the network-wide TPD dump, not the local visor's transports.

## Performance
- `tp -m` (`--more` enrichment) fetched four whole-network lists **serially** and pulled the 30-day uptime bitmap when only `.version`/`.on` are read. Now: the four fetches run **concurrently**, uptimes are fetched with `days=1`, and enrichment is skipped entirely when the (possibly filtered) transport set is empty.

**Before / after** (live, single-peer query):
```
tp -m -p <pk>
before: >120s (timed out, no output)
after:  ~40s, completes with real data:
        sudph  <id>  <pk>  in  automatic  v1.3.91  UY  proxy  183ms
```
The remaining ~40s is dominated by the visor-side on-demand CXO probe (~20s) plus the whole-network SD payload over the RPC DmsgHTTP path — infrastructure costs outside the CLI; this change removes the serial multiplication and the 30-day over-fetch on top of them.

`make check` clean (vet, lint 0 issues, tests pass) on the changed packages.