### PR TITLE
fix(rewards-cli): reward/rewards surface audit — delete exit code, lazy help RPC, quiet lookup, help + cross-refs

### DIFF
--- a/cmd/skywire-cli/commands/reward/lookup.go
+++ b/cmd/skywire-cli/commands/reward/lookup.go
@@ -28,6 +28,7 @@ var (
 	lookupServer   string
 	lookupFile     string
 	lookupRewarded bool
+	lookupLogLvl   string
 )
 
 func init() {
@@ -36,6 +37,9 @@ func init() {
 	lookupCmd.Flags().StringVarP(&lookupServer, "server", "S", deployment.Prod.RewardSystemDmsg, "reward system dmsg address (dmsg://<pk>:<port>)")
 	lookupCmd.Flags().StringVarP(&lookupFile, "file", "f", "", "file of public keys, one per line")
 	lookupCmd.Flags().BoolVar(&lookupRewarded, "rewarded-only", false, "only show days with a nonzero reward")
+	// Default to 'error' so the dmsg bootstrap's debug chatter doesn't bury
+	// the result table; raise to debug/trace when diagnosing dmsg reachability.
+	lookupCmd.Flags().StringVarP(&lookupLogLvl, "loglvl", "s", "error", "[ debug | info | warn | error | fatal | panic | trace ]")
 }
 
 // lookupDayReward mirrors one entry of the reward server's
@@ -92,6 +96,9 @@ Examples:
 		base := strings.TrimRight(lookupServer, "/")
 		if !strings.HasPrefix(base, "dmsg://") {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--server must be a dmsg:// address (got %q)", base))
+		}
+		if lvl, err := logging.LevelFromString(lookupLogLvl); err == nil {
+			logging.SetLevel(lvl)
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)

--- a/cmd/skywire-cli/commands/reward/root.go
+++ b/cmd/skywire-cli/commands/reward/root.go
@@ -52,7 +52,7 @@ func init() {
 	}
 	rewardCmd.Flags().BoolVarP(&isRead, "read", "r", false, "print the skycoin reward address & exit"+readFlagTxt)
 	cHiddenFlags = append(cHiddenFlags, "read")
-	rewardCmd.Flags().BoolVarP(&isDeleteFile, "delete", "d", false, "delete reward addresss file - opt out of rewards")
+	rewardCmd.Flags().BoolVarP(&isDeleteFile, "delete", "d", false, "delete reward address file - opt out of rewards")
 	cHiddenFlags = append(cHiddenFlags, "delete")
 	rewardCmd.Flags().StringVar(&bulkPKsCSV, "pks", "",
 		"comma-separated visor PKs (via hypervisor) to set reward address on")
@@ -63,6 +63,20 @@ func init() {
 		rewardCmd.Flags().MarkHidden(j) //nolint:errcheck,gosec
 	}
 
+	// Compute the dynamic Long text (which dials the visor RPC to show the
+	// currently-set reward address) lazily — only when help for this command
+	// is actually requested. Evaluating it in the command literal ran the RPC
+	// dial on every single skywire-cli invocation, unrelated commands included.
+	defaultHelpFunc := rewardCmd.HelpFunc()
+	rewardCmd.SetHelpFunc(func(c *cobra.Command, a []string) {
+		// The help func is inherited by subcommands; only recompute the
+		// dynamic Long for the reward command itself, or we'd clobber the
+		// Long of 'reward lookup' / 'reward rules' with the address string.
+		if c == rewardCmd {
+			c.Long = longText()
+		}
+		defaultHelpFunc(c, a)
+	})
 }
 
 // RootCmd is rewardCmd
@@ -70,6 +84,16 @@ var RootCmd = rewardCmd
 
 const longtext = `
 	reward address setting
+
+	This is the node-operator command: it manages THIS visor's reward
+	address and looks up reward history. It is distinct from the plural
+	'skywire cli rewards' command, which is the reward-system operator
+	toolchain (calculate/distribute rewards, collect data, serve the UI).
+
+	Subcommands:
+	  reward            set / read this visor's skycoin reward address
+	  reward lookup     query the reward server for a PK's payout history
+	  reward rules      display the mainnet reward eligibility rules
 
 	Sets the skycoin reward address or xpub key for the visor.
 	Accepts either a skycoin address or a BIP44 account-level xpub key.
@@ -165,8 +189,10 @@ func longText() string {
 var rewardCmd = &cobra.Command{
 	Use:                   "reward <address | xpub> || [flags]",
 	DisableFlagsInUseLine: true,
-	Short:                 "skycoin reward address or xpub key",
-	Long:                  longText(),
+	Short:                 "set or read this visor's skycoin reward address",
+	// Long is set lazily by the SetHelpFunc registered in init() so the
+	// visor-RPC lookup of the current address only runs when help is shown.
+	Long: longtext,
 	PreRun: func(cmd *cobra.Command, _ []string) {
 		//--all unhides flags, prints help menu, and exits
 		if isAll {
@@ -211,7 +237,7 @@ var rewardCmd = &cobra.Command{
 					internal.PrintError(cmd.Flags(), err)
 				}
 			}
-			os.Exit(1)
+			os.Exit(0)
 			return
 		}
 		//print reward address and exit

--- a/cmd/skywire-cli/commands/reward/rules.go
+++ b/cmd/skywire-cli/commands/reward/rules.go
@@ -28,8 +28,11 @@ func init() {
 
 var rulesCmd = &cobra.Command{
 	Use:   "rules",
-	Short: "display the mainnet rules",
-	Long:  "display the mainnet rules",
+	Short: "display the mainnet reward eligibility rules",
+	Long: `Display the mainnet reward eligibility rules (embedded at build time).
+
+By default the markdown is rendered for the terminal. Use --raw to print
+the original markdown source, or --html to render it as an HTML fragment.`,
 	Run: func(_ *cobra.Command, _ []string) {
 		if rawFile {
 			fmt.Println(rewards.MainnetRules)

--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -729,12 +729,23 @@ func init() {
 // RootCmd is the root command for skywire-cli rewards
 var RootCmd = &cobra.Command{
 	Use:   "rewards",
-	Short: "calculate rewards from uptime data & collected surveys",
+	Short: "reward-system operator toolchain (calculate & distribute rewards)",
 	Long: `
-Collect surveys:  skywire-cli log
-Fetch uptimes:    skywire-cli ut > ut.txt
+This plural 'rewards' command is the reward-system OPERATOR toolchain that
+runs the daily reward distribution: collect surveys/transports/bandwidth,
+fetch uptimes, calculate per-visor shares, and serve the metrics UI.
 
-Process rewards:  skywire-cli rewards --process
+Node operators who only want to set their own reward address or check their
+payout history want the singular command instead: 'skywire cli reward'.
+
+Typical manual pipeline:
+  Collect surveys:  skywire-cli log
+  Fetch uptimes:    skywire-cli ut > ut.txt
+  Process rewards:  skywire-cli rewards --process
+
+The 'rewards run' subcommand performs the whole hourly cycle in-process
+(the systemd unit calls it); the bare 'rewards' command calculates a single
+day from data already on disk.
 
 Architectures:
 ` + fmt.Sprintf("%v", append(rewards.Architectures, "null", "all")) + `
@@ -1432,7 +1443,15 @@ func init() {
 
 var testCmd = &cobra.Command{
 	Use:   "svc",
-	Short: "verify services in survey",
+	Short: "verify a visor's service config against the deployment",
+	Long: `Verify that the service configuration reported in a collected survey
+(node-info.json under --lpath/<pk>/) matches the prod deployment's
+services-config.json — i.e. the visor is pointed at the correct
+dmsg-discovery / transport-discovery / route-finder / etc.
+
+Requires a survey for the given --pk to already be present under --lpath
+(collect with 'skywire cli log'). stun_servers are omitted from the
+comparison. Detects both http and dmsghttp service configs.`,
 	Run: func(_ *cobra.Command, _ []string) {
 		var err error
 		if log == nil {

--- a/cmd/skywire-cli/commands/rewards/tgbot/tgbot.go
+++ b/cmd/skywire-cli/commands/rewards/tgbot/tgbot.go
@@ -26,7 +26,14 @@ func init() {
 var RootCmd = &cobra.Command{
 	Use:   "bot",
 	Short: "reward notification telegram bot",
-	Long:  "reward notification telegram bot",
+	Long: `Reward notification telegram bot.
+
+Watches the reward transaction file (--watch) and posts the per-day stats
+for each newly-broadcast reward transaction to a telegram chat.
+
+Requires two environment variables:
+  TG_BOT_TOKEN   telegram bot API token
+  TG_CHAT_ID     numeric telegram chat ID to post into`,
 	Run: func(_ *cobra.Command, _ []string) {
 		chatIDStr := os.Getenv("TG_CHAT_ID")
 		chatID, err := strconv.ParseInt(chatIDStr, 10, 64)


### PR DESCRIPTION
Audit + standardization of the two reward CLI groups in `cmd/skywire-cli/commands/{reward,rewards}/`. Strictly backward-compatible — no flag renamed, no subcommand moved.

## The two groups (finding: NOT redundant)
- **`reward` (singular)** — node-operator command: set/read THIS visor's skycoin reward address, look up its payout history over dmsg, view the mainnet rules.
- **`rewards` (plural)** — reward-system operator toolchain: calculate/distribute rewards, collect transports+bandwidth, run the hourly cycle, serve the metrics UI, systemd units, telegram bot.

They serve different audiences and both are load-bearing (two systemd units + scripts call `skywire cli rewards ...`), so a merge would break callers. Instead each `--help` now names and cross-references the other so the singular/plural distinction stops being confusing.

## Fixes
- **`reward -d` (opt-out) exited 1 on success** → now exits 0.
- **`reward` dynamic help dialed the visor RPC on every skywire-cli invocation** (the `Long` was computed in the command literal, i.e. at package init for every command). Now computed lazily via a guarded `SetHelpFunc` — only when `reward --help` is shown. Guard prevents the inherited help func from clobbering `reward lookup` / `reward rules` Long text.
- **`reward lookup` result table was buried** under dmsg-bootstrap DEBUG logging. Added `-s/--loglvl` (default `error`, matching the plural group's convention) so the table is readable; raise to `debug` to diagnose dmsg reachability.
- Fixed `addresss` typo.

## Help / standardization
- `reward` Short/Long, `reward rules` Long (was a copy of Short), `rewards` Short/Long, `rewards svc` Long (was empty), `rewards bot` Long (documents the watch file + `TG_BOT_TOKEN`/`TG_CHAT_ID`).

## Testing
Every subcommand + flag was inventoried. Read-only paths were exercised live against the prod deployment: `reward` read / `-r` / `--json` / `--all`, `reward lookup` over dmsg (real per-day history returned), `reward rules` (default/`--raw`/`--html`), `rewards tp-collect --all` (866 visors), `rewards bw-collect` (11.8k transports), `rewards svc`, `rewards script`, `rewards systemd`. Mutating and long-running paths (address set/delete, bulk `--pks`/`--all-visors`, `run`, `ui`, `loginchain`, `bot`) were verified by code review + `--help` only.