### PR TITLE
cli(sd/ut/svc): fix min-version + tpd-uptime handling, standardize flags & help

### DIFF
--- a/cmd/skywire-cli/commands/sd/root.go
+++ b/cmd/skywire-cli/commands/sd/root.go
@@ -132,13 +132,17 @@ func init() {
 var RootCmd = &cobra.Command{
 	Use:   "sd",
 	Short: "Service discovery network statistics",
-	Long: fmt.Sprintf(`Display combined service discovery and transport statistics
+	Long: fmt.Sprintf(`Display combined service discovery and transport statistics.
 
 Combines data from:
-- Service Discovery: %v/api/services
-- Transport Discovery: %v/all-transports
+- Service Discovery: %v/api/services (proxy / vpn / visor entries)
+- Transport Discovery: %v/all-transports (transport counts by type)
+- Uptime Tracker: online/offline status (color-coded rows)
 
-Shows public keys with their services and transport counts by type.
+Shows public keys with their advertised services and transport counts by
+type (stcpr/sudph/dmsg/stcp). Filter with --country, --version, --min
+(minimum transport count); --noton keeps offline/not-in-UT visors. --json
+emits the combined rows as machine-readable output.
 
 Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 		getDeployment().ServiceDiscovery,

--- a/cmd/skywire-cli/commands/svc/fetch.go
+++ b/cmd/skywire-cli/commands/svc/fetch.go
@@ -68,7 +68,12 @@ func emitPretty(cmd *cobra.Command, data []byte) {
 var tpdCmd = &cobra.Command{
 	Use:   "tpd",
 	Short: "Transport Discovery endpoints",
-	Long:  "\n    Query Transport Discovery service endpoints",
+	Long: `Query Transport Discovery (TPD) read endpoints over the mesh.
+
+By default each subcommand fetches via the local visor's RPC (DMSG-HTTP);
+pass --direct to fetch with a CLI-owned client instead. All output honors
+--json. Network-wide views (stats, versions, bandwidth without --pk) need no
+arguments; per-visor / per-transport views take --pk / --id / --pks / --ids.`,
 }
 
 func init() {
@@ -141,8 +146,10 @@ func init() {
 }
 
 var tpdVisorStatsCmd = &cobra.Command{
-	Use:   "visor-stats",
-	Short: "Transport count statistics for a specific visor",
+	Use:     "visor-stats",
+	Short:   "Transport count statistics for a specific visor",
+	Long:    "Transport count statistics for one visor (TPD /transports/stats/<pk>).\n\n  skywire cli svc tpd visor-stats -p <visor-pk>",
+	Example: "  skywire cli svc tpd visor-stats -p 02b3...",
 	Run: func(cmd *cobra.Command, _ []string) {
 		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/transports/stats/"+tpdVisorStatsPK, deployment.Prod.TransportDiscovery)
 		if err != nil {
@@ -161,6 +168,7 @@ func init() {
 var tpdBandwidthCmd = &cobra.Command{
 	Use:   "bandwidth",
 	Short: "Bandwidth data (network-wide or per-visor)",
+	Long:  "Bandwidth data from TPD. With no --pk: the network-wide /metric rollup.\nWith --pk <visor-pk>: that visor's /bandwidth/visor/<pk> history.",
 	Run: func(cmd *cobra.Command, _ []string) {
 		path := "/metric"
 		if tpdBandwidthVisorPK != "" {
@@ -184,6 +192,7 @@ func init() {
 var tpdBandwidthTpCmd = &cobra.Command{
 	Use:   "bandwidth-tp",
 	Short: "Bandwidth history for a specific transport",
+	Long:  "Bandwidth history for one transport (TPD /bandwidth/transport/<id>).\n\n  skywire cli svc tpd bandwidth-tp -i <transport-uuid>",
 	Run: func(cmd *cobra.Command, _ []string) {
 		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/bandwidth/transport/"+tpdBandwidthTpID, deployment.Prod.TransportDiscovery)
 		if err != nil {
@@ -203,6 +212,7 @@ func init() {
 var tpdVersionsPKCmd = &cobra.Command{
 	Use:   "versions-pk",
 	Short: "Version info for specific public keys",
+	Long:  "Version info for one or more visors (TPD /versions/<pks>).\n\n  skywire cli svc tpd versions-pk -p <pk1>,<pk2>",
 	Run: func(cmd *cobra.Command, _ []string) {
 		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/versions/"+tpdVersionsPKs, deployment.Prod.TransportDiscovery)
 		if err != nil {
@@ -222,6 +232,7 @@ func init() {
 var tpdMetricsVisorCmd = &cobra.Command{
 	Use:   "metrics-visor",
 	Short: "Metrics for specific visor(s)",
+	Long:  "Transport metrics for one or more visors (TPD /metrics/visor/<pks>).\n\n  skywire cli svc tpd metrics-visor -p <pk1>,<pk2>",
 	Run: func(cmd *cobra.Command, _ []string) {
 		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/metrics/visor/"+tpdMetricsVisorPKs, deployment.Prod.TransportDiscovery)
 		if err != nil {
@@ -241,6 +252,7 @@ func init() {
 var tpdMetricsTpCmd = &cobra.Command{
 	Use:   "metrics-tp",
 	Short: "Metrics for specific transport(s)",
+	Long:  "Metrics for one or more transports (TPD /metrics/<ids>).\n\n  skywire cli svc tpd metrics-tp -i <id1>,<id2>",
 	Run: func(cmd *cobra.Command, _ []string) {
 		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/metrics/"+tpdMetricsTpIDs, deployment.Prod.TransportDiscovery)
 		if err != nil {
@@ -255,7 +267,14 @@ var tpdMetricsTpCmd = &cobra.Command{
 var dmsgdCmd = &cobra.Command{
 	Use:   "dmsgd",
 	Short: "DMSG Discovery endpoints",
-	Long:  "\n    Query DMSG Discovery service endpoints",
+	Long: `Query DMSG Discovery read endpoints over the mesh.
+
+  all-servers     every registered dmsg server entry
+  server-clients  clients grouped by the server they session with
+  clients --pk    clients currently sessioned with one dmsg server
+
+Fetches via the local visor's RPC by default; --direct uses a CLI-owned
+client. Output honors --json.`,
 }
 
 func init() {
@@ -300,6 +319,7 @@ func init() {
 var dmsgdServerClientsPKCmd = &cobra.Command{
 	Use:   "clients",
 	Short: "List clients for a specific DMSG server",
+	Long:  "List the clients currently sessioned with one dmsg server\n(DMSG-discovery /dmsg-discovery/server/<pk>/clients).\n\n  skywire cli svc dmsgd clients -p <server-pk>",
 	Run: func(cmd *cobra.Command, _ []string) {
 		data, err := fetchViaVisorOrDirect(cmd, "dmsgd", "/dmsg-discovery/server/"+dmsgdServerClientsPK+"/clients", deployment.Prod.DmsgDiscovery)
 		if err != nil {
@@ -314,7 +334,12 @@ var dmsgdServerClientsPKCmd = &cobra.Command{
 var arCmd = &cobra.Command{
 	Use:   "ar",
 	Short: "Address Resolver endpoints",
-	Long:  "\n    Query Address Resolver service endpoints",
+	Long: `Query the Address Resolver (AR) over the mesh.
+
+Bare 'ar' fetches /transports — the AR's view of stcpr/sudph-registered
+edges. 'ar check <pk>' asks whether one visor is registered (without
+revealing its IP). Fetches via the local visor's RPC by default; --direct
+uses a CLI-owned client. Output honors --json.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		data, err := fetchViaVisorOrDirect(cmd, "ar", "/transports", deployment.Prod.AddressResolver)
 		if err != nil {
@@ -350,6 +375,16 @@ sessions show as "(down: <duration>)"; sessions shorter than
 		}
 		data, err := fetchViaVisorOrDirect(cmd, "tpd", path, deployment.Prod.TransportDiscovery)
 		if err != nil {
+			// A 503 here means the TPD is up but has no session recorder
+			// enabled (pkg/serviceuptime not wired on this deployment's
+			// build), or the endpoint predates it. That's an expected,
+			// operator-actionable state — not a CLI failure — so report it
+			// plainly instead of dumping a raw RPC/HTTP error + exit 1.
+			if strings.Contains(err.Error(), "503") || strings.Contains(err.Error(), "404") {
+				fmt.Fprintln(cmd.ErrOrStderr(), "svc tpd uptime: the transport-discovery reports no session history (HTTP 503/404 from /uptime/sessions).") //nolint:errcheck
+				fmt.Fprintln(cmd.ErrOrStderr(), "This deployment's TPD build does not record its own session history (pkg/serviceuptime not enabled).")    //nolint:errcheck
+				return
+			}
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 		var sessions []serviceuptime.SessionRecord
@@ -372,13 +407,23 @@ sessions show as "(down: <duration>)"; sessions shorter than
 
 // --- NM subcommand ---
 
+// nmCmd is a stand-in: the network-monitor has no URL in the embedded
+// deployment.Services set (only keyring PKs exist for it), so there is no
+// dedicated endpoint to query. Until one is wired in, this probes the
+// transport-discovery /health as the closest liveness signal and says so.
+// FOLLOW-UP: give the network monitor a real deployment URL + endpoint, or
+// drop this subcommand.
 var nmCmd = &cobra.Command{
 	Use:   "nm",
-	Short: "Network Monitor status",
-	Long:  "\n    Query Network Monitor service status",
+	Short: "Network Monitor status (currently probes TPD /health — no NM endpoint deployed)",
+	Long: `Query network-monitor liveness.
+
+NOTE: the network monitor has no URL in the embedded deployment set (only
+keyring public keys), so there is no dedicated endpoint to hit yet. This
+command probes the transport-discovery /health as the closest available
+liveness signal — treat the result as "is the discovery tier up", not as a
+network-monitor-specific status.`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		// Network monitor URL isn't in the standard deployment config,
-		// so we try a known path or fall back
 		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/health", deployment.Prod.TransportDiscovery)
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)

--- a/cmd/skywire-cli/commands/svc/health.go
+++ b/cmd/skywire-cli/commands/svc/health.go
@@ -51,7 +51,17 @@ type CarrierProbe struct {
 var RootCmd = &cobra.Command{
 	Use:   "svc",
 	Short: "Query skywire deployment services",
-	Long:  "\n    Query skywire deployment services (health, stats)",
+	Long: `Query the skywire DEPLOYMENT services over the mesh (read-only).
+
+  health  /health of every deployment service (fast first look; also lists PKs)
+  tpd     Transport Discovery read endpoints (stats, versions, bandwidth, ...)
+  dmsgd   DMSG Discovery read endpoints (servers, clients)
+  ar      Address Resolver (/transports; 'ar check <pk>' for registration)
+  nm      network-monitor liveness (stand-in: probes TPD /health)
+
+Deployment services are DMSG-only. Subcommands fetch via the local visor's
+RPC by default and fall back to a CLI-owned client; pass --direct to force
+the direct path. Output honors --json.`,
 }
 
 func init() {

--- a/cmd/skywire-cli/commands/ut/root.go
+++ b/cmd/skywire-cli/commands/ut/root.go
@@ -128,12 +128,17 @@ func init() {
 	utCmd.Flags().StringVarP(&pk, "pk", "k", "", "check uptime for the specified key")
 	utCmd.Flags().BoolVarP(&online, "on", "o", false, "list currently online visors")
 	utCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "count the number of results")
-	utCmd.Flags().BoolVarP(&isMoreStats, "stats2", "t", false, "count of versions")
+	utCmd.Flags().BoolVarP(&isMoreStats, "stats2", "t", false, "with --on: tally online visors by version instead of listing PKs")
 	utCmd.Flags().IntVarP(&minUT, "min", "n", 75, "list visors meeting minimum uptime percentage\n\r")
 	utCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.TransportDiscovery), "UT cache dir (\"\" to disable)\n\r")
 	utCmd.Flags().StringVar(&cacheDirTPD, "cdt", cacheDirPath(dep.TransportDiscovery), "TPD cache dir (\"\" to disable)\n\r")
 	utCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes\n\r")
 	utCmd.Flags().StringVarP(&utURL, "url", "u", dep.TransportDiscovery, "specify alternative (TPD-integrated) uptime tracker url\n\r")
+	// --uturl is a hidden alias for --url, matching the flag name `skywire cli
+	// sd` uses for the same discovery. Lets the two discovery commands' URL
+	// flags be spelled the same way without breaking the older --url / -u form.
+	utCmd.Flags().StringVar(&utURL, "uturl", dep.TransportDiscovery, "(alias for --url) TPD-integrated uptime tracker url")
+	utCmd.Flags().MarkHidden("uturl") //nolint:errcheck,gosec
 	utCmd.Flags().StringVar(&tpdURL, "tpdurl", dep.TransportDiscovery, "transport discovery url")
 	utCmd.Flags().StringVarP(&versionFilter, "version", "v", "", "filter visors by exact version")
 	utCmd.Flags().StringVar(&minVersion, "min-version", "", "filter visors with version >= specified (e.g. v1.3.34)")
@@ -147,11 +152,28 @@ func init() {
 var utCmd = &cobra.Command{
 	Use:   "ut",
 	Short: "Query uptime tracker",
-	Long:  fmt.Sprintf("query the TPD-integrated uptime tracker\n\n%v/uptimes?v=v3\n\nCheck local visor daily uptime percent with:\n\n$ skywire-cli ut -n0 -k $(skywire-cli visor pk)\n\nSet cache dir to \"\" to avoid using cache files\n\nUse --testenv or SKYWIRETEST=1 to use test deployment services.", getDeployment().TransportDiscovery),
+	Long: fmt.Sprintf(`Query the TPD-integrated uptime tracker.
+
+  %v/uptimes?v=v3
+
+Bare 'ut' reports per-day uptime percentages from the transport-discovery
+integrated endpoint. The same uptime data is published by every discovery;
+subcommands query the other sources with an identical output/flag shape:
+
+  ut sd     service-discovery integrated /uptimes
+  ut mdisc  dmsg-discovery integrated /uptimes (most accurate 'reachable via dmsg')
+  ut tpd    transport-discovery integrated /uptimes (feeds the rewards pipeline)
+
+Check the local visor's daily uptime percent with:
+
+  $ skywire cli ut -n0 -k $(skywire cli visor pk)
+
+Set the cache dir to "" to avoid using cache files.
+Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment().TransportDiscovery),
 	Run: func(cmd *cobra.Command, _ []string) {
 		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
 		if testEnv && !isTestEnv() {
-			if !cmd.Flags().Changed("url") {
+			if !cmd.Flags().Changed("url") && !cmd.Flags().Changed("uturl") {
 				utURL = deployment.Test.TransportDiscovery
 			}
 			if !cmd.Flags().Changed("tpdurl") {
@@ -222,14 +244,19 @@ var utCmd = &cobra.Command{
 			return filtered
 		}
 
-		// Helper to parse version string like "v1.3.34" or "v1.3.34 dirty"
+		// Helper to parse version string like "v1.3.34", "v1.3.34 dirty",
+		// or a git-describe build "v1.3.92-0-c190075ad0a7".
 		parseVersion := func(v string) (major, minor, patch int, ok bool) {
 			if v == "" {
 				return 0, 0, 0, false
 			}
-			// Remove "v" prefix and anything after space
+			// Remove "v" prefix and any build/commit suffix. Cut at the
+			// first space OR hyphen so the trailing "-<n>-g<commit>" of a
+			// git-describe version doesn't make the patch segment
+			// unparseable (which previously dropped every -suffixed build
+			// from --min-version results).
 			v = strings.TrimPrefix(v, "v")
-			if idx := strings.Index(v, " "); idx != -1 {
+			if idx := strings.IndexAny(v, " -"); idx != -1 {
 				v = v[:idx]
 			}
 			parts := strings.Split(v, ".")


### PR DESCRIPTION
Audit + cleanup of the discovery/services CLI groups: `skywire cli sd` (combined service+transport network stats), `ut` (uptime tracker), and `svc` (deployment-service read endpoints). Every subcommand and flag was live-tested against the prod deployment over dmsg.

## Bug fixes
- **`ut --min-version` dropped git-describe builds.** `parseVersion` cut the version string only at a space, so a patch segment like `92-0-gc190075` failed to parse and *every* `-suffixed` build was excluded from the results. Now cuts at the first space **or** hyphen. Live: `--min-version v1.3.91` went from 955 → 970 visors (the 15 were `-suffixed` builds); `--min-version v1.3.92` now correctly matches the `v1.3.92-0-…` fleet.
- **`svc tpd uptime` fataled on a 503.** The deployed TPD has no session recorder (`pkg/serviceuptime` not enabled), so `/uptime/sessions` returns 503 — which made the fetch error out and hit `PrintFatalError` (raw RPC/HTTP error + exit 1) before the intended graceful-fallback could run. It now prints a one-line explanation and exits cleanly on 503/404.
- **`svc nm` was mislabeled.** The network monitor has no URL in the embedded deployment set (only keyring PKs), so the command silently probed transport-discovery `/health` while presenting itself as network-monitor status. Its help now states it's a stand-in TPD `/health` probe. (Follow-up: give NM a real endpoint or drop the subcommand.)

## Standardization (backward compatible)
- **`ut`** gains a hidden `--uturl` alias for `--url`, matching the flag name `sd` already uses for the same discovery. The long-standing `--url` / `-u` spelling is unchanged.

## Help / documentation
- Rewrote long-descriptions for the `sd` and `svc` roots, the `svc tpd`/`dmsgd`/`ar` group commands, and added endpoint paths + examples to the arg-taking `svc tpd`/`dmsgd` subcommands.
- `ut` long help now documents the sd/mdisc/tpd uptime sources and the `--stats2` semantics.

All old flag spellings continue to work; no flags were removed or renamed. Verified with `make check` locally.