### PR TITLE
fix(skywire-cli): audit + standardize dmsg/mdisc command groups

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/curl.go
+++ b/cmd/skywire-cli/commands/dmsg/curl.go
@@ -42,7 +42,7 @@ var (
 
 func init() {
 	curlCmd.Flags().SortFlags = false
-	curlCmd.Flags().StringVarP(&rpcAddr, "rpc", "", "localhost:3435", "RPC server address")
+	curlCmd.Flags().StringVarP(&rpcAddr, "rpc", "", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
 	curlCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal", "[ debug | warn | error | fatal | panic | trace | info ]")
 	curlCmd.Flags().VarP(&sk, "sk", "s", "use a custom secret key (starts new dmsg client instead of using visor's)")
 	curlCmd.Flags().StringVarP(&curlData, "data", "d", "", "HTTP POST data")

--- a/cmd/skywire-cli/commands/dmsg/diag.go
+++ b/cmd/skywire-cli/commands/dmsg/diag.go
@@ -12,6 +12,14 @@ import (
 )
 
 func init() {
+	// Every diag subcommand talks to the local visor over RPC, so
+	// each takes --rpc (bound to the shared clirpc.Addr) for parity
+	// with the other visor-RPC dmsg commands.
+	for _, c := range []*cobra.Command{porterStatsCmd, porterResetCmd, porterDiagCmd, reconnectCmd} {
+		c.Flags().SortFlags = false
+		c.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr,
+			"RPC server address (env: SKYWIRE_RPC)")
+	}
 	diagCmd.AddCommand(porterStatsCmd)
 	diagCmd.AddCommand(porterResetCmd)
 	diagCmd.AddCommand(porterDiagCmd)
@@ -22,12 +30,21 @@ func init() {
 var diagCmd = &cobra.Command{
 	Use:   "diag",
 	Short: "DMSG runtime diagnostics",
-	Long:  "Inspect and manage the visor's DMSG subsystem at runtime.",
+	Long: `Inspect and manage this visor's DMSG subsystem at runtime.
+
+Reads/acts on the live visor over --rpc. porter / porter-diag are
+read-only; porter-reset and reconnect are corrective actions that
+disrupt in-flight dmsg streams — use them to recover a wedged client,
+not routinely.`,
 }
 
 var porterStatsCmd = &cobra.Command{
 	Use:   "porter",
 	Short: "Show ephemeral port reservation counts",
+	Long: `Show how many ephemeral dmsg ports are currently reserved on the
+main (and, when present, embedded RSN) dmsg clients, out of the 16384
+ephemeral-port ceiling. A count climbing toward the ceiling points at
+port-space exhaustion; 'dmsg diag porter-reset' recovers it.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
@@ -98,6 +115,10 @@ Use this to investigate ephemeral port exhaustion root causes.`,
 var reconnectCmd = &cobra.Command{
 	Use:   "reconnect",
 	Short: "Force close and reconnect all DMSG sessions",
+	Long: `Force-close every active dmsg session on the visor's main client.
+The reconnect loop re-dials to the configured sessions_count target
+within ~15s. Disruptive: in-flight dmsg streams (routes, proxied
+apps) are torn down — use it to unwedge a stuck client, not routinely.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {

--- a/cmd/skywire-cli/commands/dmsg/probe.go
+++ b/cmd/skywire-cli/commands/dmsg/probe.go
@@ -168,13 +168,32 @@ Examples:
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("probe failed: %w", err))
 		}
 
-		scheme, suffix := probeSchemeSuffix()
-		state := "unreachable"
-		if reachable {
-			state = "reachable"
-		}
-		fmt.Printf("%s://%s:%d%s — %s (%s)\n", scheme, pk, port, suffix, state, latency.Round(time.Millisecond))
+		emitProbeResult(cmd, pk, uint16(port), reachable, latency)
 	},
+}
+
+// emitProbeResult prints one single-port probe result, honoring the
+// global --json flag (the multi-port sweep already does). Keeps the
+// human line identical to what the command has always printed.
+func emitProbeResult(cmd *cobra.Command, pk cipher.PubKey, port uint16, reachable bool, latency time.Duration) {
+	scheme, suffix := probeSchemeSuffix()
+	if jsonMode, _ := cmd.Flags().GetBool(internal.JSONString); jsonMode { //nolint:errcheck
+		b, _ := json.MarshalIndent(struct { //nolint:errcheck
+			PK        string `json:"pk"`
+			Port      uint16 `json:"port"`
+			Transport string `json:"transport"`
+			Server    string `json:"server,omitempty"`
+			Reachable bool   `json:"reachable"`
+			LatencyMS int64  `json:"latency_ms"`
+		}{pk.String(), port, scheme, probeServer, reachable, latency.Milliseconds()}, "", "  ")
+		fmt.Println(string(b))
+		return
+	}
+	state := "unreachable"
+	if reachable {
+		state = "reachable"
+	}
+	fmt.Printf("%s://%s:%d%s — %s (%s)\n", scheme, pk, port, suffix, state, latency.Round(time.Millisecond))
 }
 
 // rpcProbeOne dispatches a single RPC-mode probe by the selected transport.
@@ -250,12 +269,26 @@ func runTCPProbe(cmd *cobra.Command) {
 	start := time.Now()
 	conn, err := tcpnoise.Dial(ctx, hostPort, myPK, mySK, rPK)
 	latency := time.Since(start)
-	if err != nil {
-		fmt.Printf("tcp://%s@%s — unreachable (%s)\n", rPK, hostPort, latency.Round(time.Millisecond))
+	reachable := err == nil
+	if conn != nil {
+		_ = conn.Close() //nolint:errcheck
+	}
+	if jsonMode, _ := cmd.Flags().GetBool(internal.JSONString); jsonMode { //nolint:errcheck
+		b, _ := json.MarshalIndent(struct { //nolint:errcheck
+			PK        string `json:"pk"`
+			Transport string `json:"transport"`
+			Addr      string `json:"addr"`
+			Reachable bool   `json:"reachable"`
+			LatencyMS int64  `json:"latency_ms"`
+		}{rPK.String(), "tcp", hostPort, reachable, latency.Milliseconds()}, "", "  ")
+		fmt.Println(string(b))
 		return
 	}
-	_ = conn.Close() //nolint:errcheck
-	fmt.Printf("tcp://%s@%s — reachable (%s)\n", rPK, hostPort, latency.Round(time.Millisecond))
+	state := "unreachable"
+	if reachable {
+		state = "reachable"
+	}
+	fmt.Printf("tcp://%s@%s — %s (%s)\n", rPK, hostPort, state, latency.Round(time.Millisecond))
 }
 
 // parseViaTCP turns "tcp://<66-hex-pk>@host:port" into (pk, "host:port").
@@ -476,10 +509,5 @@ func runStandaloneProbe(cmd *cobra.Command, pk cipher.PubKey, port uint16) {
 	}
 	latency := time.Since(start)
 
-	_, suffix := probeSchemeSuffix()
-	state := "unreachable"
-	if reachable {
-		state = "reachable"
-	}
-	fmt.Printf("dmsg://%s:%d%s — %s (%s)\n", pk, port, suffix, state, latency.Round(time.Millisecond))
+	emitProbeResult(cmd, pk, port, reachable, latency)
 }

--- a/cmd/skywire-cli/commands/dmsg/root.go
+++ b/cmd/skywire-cli/commands/dmsg/root.go
@@ -17,7 +17,31 @@ var (
 var RootCmd = &cobra.Command{
 	Use:   "dmsg",
 	Short: "Dmsg utilities",
-	Long:  "Commands that use DMSG for communication",
+	Long: `Dmsg utilities.
+
+These commands fall into three families:
+
+  this-visor dmsg client (needs a running visor on --rpc)
+    sessions      list the dmsg servers each visor dmsg client is on
+    converge      re-dial sessions onto their preferred carrier
+    connect-all   open a session to every known server (one-shot)
+    set-sessions  persist dmsg.sessions_count + connect-all
+    port-hits     inbound hits to ports with no listener
+    diag          runtime diagnostics (porter / reconnect)
+
+  standalone dmsg tools (bootstrap their own dmsg client; work with
+  no local visor — pass --sk for a stable identity)
+    curl          fetch data over dmsg (HTTP-over-dmsg)
+    cat           splice stdio with a peer over dmsg or skynet
+    scp           copy a file to/from a remote visor's dmsgscp host
+    iperf         bulk throughput / RTT measurement over a stream
+    chat          interactive 1:1 chat over dmsg
+    probe         test a remote port's reachability
+    sub           standalone UDP-over-dmsg bridge
+    smb           standalone SMTP-over-dmsg bridge
+
+Query the dmsg discovery itself with 'skywire cli mdisc'. Remote
+visor terminals live under 'skywire cli pty' (formerly 'dmsg pty').`,
 }
 
 func init() {

--- a/cmd/skywire-cli/commands/mdisc/check.go
+++ b/cmd/skywire-cli/commands/mdisc/check.go
@@ -41,7 +41,8 @@ var (
 
 func init() {
 	RootCmd.AddCommand(checkCmd)
-	checkCmd.Flags().StringVar(&mdURL, "url", getDeployment().DmsgDiscovery, "specify alternative DMSG discovery url")
+	// --url is a persistent flag on the mdisc root (see root.go), so
+	// `mdisc check --url ...` and `--testenv` are inherited here.
 	checkCmd.Flags().DurationVar(&checkTimeout, "timeout", 15*time.Second, "per-server probe timeout")
 	checkCmd.Flags().BoolVar(&checkWarnOnly, "warn-only", false, "always exit 0 (report problems without failing)")
 }

--- a/cmd/skywire-cli/commands/mdisc/root.go
+++ b/cmd/skywire-cli/commands/mdisc/root.go
@@ -111,34 +111,54 @@ func init() {
 		// `skywire cli ut mdisc` for consistency with the other
 		// uptime-data sources. See cmd/skywire-cli/commands/ut/mdisc.go.
 	)
-	RootCmd.Flags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
-	RootCmd.Flags().StringVar(&cacheDirDMSGD, "cdd", cacheDirPath(dep.DmsgDiscovery), "DMSG cache dir (\"\" to disable)")
-	RootCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache file if older than n minutes")
+	// --testenv / --url / --cdd / --cfa are persistent so every
+	// subcommand (entry, servers, check) honors them, not just the
+	// bare `mdisc` entries listing. The testenv override (below, in
+	// PersistentPreRun) then applies to all of them uniformly.
+	RootCmd.PersistentFlags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
+	RootCmd.PersistentFlags().StringVar(&cacheDirDMSGD, "cdd", cacheDirPath(dep.DmsgDiscovery), "DMSG cache dir (\"\" to disable)")
+	RootCmd.PersistentFlags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache file if older than n minutes")
+	RootCmd.PersistentFlags().StringVar(&mdURL, "url", dep.DmsgDiscovery, "specify alternative DMSG discovery url")
+	// --stats only shapes the bare `mdisc` entries listing (count of
+	// dmsg clients), so it stays local to the root command.
 	RootCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "count the number of results")
-	entryCmd.Flags().StringVar(&mdURL, "url", dep.DmsgDiscovery, "specify alternative DMSG discovery url")
-	RootCmd.Flags().StringVar(&mdURL, "url", dep.DmsgDiscovery, "specify alternative DMSG discovery url")
-	availableServersCmd.Flags().StringVar(&mdURL, "url", dep.DmsgDiscovery, "specify alternative DMSG discovery url")
+}
+
+// applyTestEnv switches mdURL / cache dir to the test deployment when
+// --testenv is set and neither was pinned explicitly. Runs before
+// every mdisc subcommand via PersistentPreRun so `mdisc entry
+// --testenv`, `mdisc servers --testenv`, and `mdisc check --testenv`
+// all behave like the bare `mdisc --testenv`.
+func applyTestEnv(cmd *cobra.Command) {
+	if testEnv && !isTestEnv() {
+		if !cmd.Flags().Changed("url") {
+			mdURL = deployment.Test.DmsgDiscovery
+		}
+		if !cmd.Flags().Changed("cdd") {
+			cacheDirDMSGD = cacheDirPath(deployment.Test.DmsgDiscovery)
+		}
+	}
 }
 
 // RootCmd is the command that contains sub-commands which interacts with DMSG services.
 var RootCmd = &cobra.Command{
 	Use:   "mdisc",
 	Short: "Query DMSG Discovery",
-	Long: `Query DMSG Discovery
-	list entries in dmsg discovery
+	Long: `Query DMSG Discovery.
 
-Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
+The bare command lists the dmsg clients registered in discovery (add
+--stats for just a count). Subcommands:
+  entry <pk>   fetch one registered entry (client or server)
+  servers      list dmsg servers by load (connected~ / avail-sess)
+  check        probe every server's advertised wss front (DNS/TLS/426)
+
+--url points at an alternative discovery; --testenv (or SKYWIRETEST=1)
+selects the test deployment. Both apply to every subcommand.`,
+	// applyTestEnv runs for the root and every subcommand.
+	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+		applyTestEnv(cmd)
+	},
 	Run: func(cmd *cobra.Command, _ []string) {
-		// Handle --testenv flag: override URL and cache dir that weren't explicitly set
-		if testEnv && !isTestEnv() {
-			if !cmd.Flags().Changed("url") {
-				mdURL = deployment.Test.DmsgDiscovery
-			}
-			if !cmd.Flags().Changed("cdd") {
-				cacheDirDMSGD = cacheDirPath(deployment.Test.DmsgDiscovery)
-			}
-		}
-
 		// Build full URL
 		dmsgFullURL := mdURL + "/dmsg-discovery/entries"
 
@@ -153,9 +173,14 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 }
 
 var entryCmd = &cobra.Command{
-	Use:   "entry <visor-public-key>",
-	Short: "Fetch an entry",
-	Args:  cobra.ExactArgs(1),
+	Use:   "entry <public-key>",
+	Short: "Fetch one dmsg-discovery entry (client or server)",
+	Long: `Fetch and print the dmsg-discovery entry for a single public key.
+
+Works for both client and server entries: a client entry shows its
+delegated servers; a server entry shows its address and capacity.
+Resolves over RPC -> dmsg -> HTTP, so a dmsg:// --url works too.`,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		pk := internal.ParsePK(cmd.Flags(), "visor-public-key", args[0])
 		masterLogger.SetLevel(logrus.InfoLevel)


### PR DESCRIPTION
Full per-flag audit of `cli dmsg` + `cli mdisc` (live-tested read-only against a running visor; disruptive/standalone cmds help-only). Fixes (backward-compatible): mdisc `--testenv/--url/--cdd/--cfa` made persistent (were erroring 'unknown flag' on entry/servers/check); `dmsg probe --json` honored in single-port + `--via tcp` modes; `dmsg diag` all 4 subcommands gain `--rpc` (env SKYWIRE_RPC) + long help; `dmsg curl --rpc` honors SKYWIRE_RPC; `dmsg` root long help rewritten into the three command families. Scoped go build/vet/test clean; full make check validated via CI (per resource-constraint guidance — not run locally). No AI attribution.