### PR TITLE
fix(cli-route): validate --source on all paths; standardize route/rg flag vocabulary + help

### DIFF
--- a/cmd/skywire-cli/commands/rg/rg.go
+++ b/cmd/skywire-cli/commands/rg/rg.go
@@ -32,7 +32,14 @@ var (
 var RootCmd = &cobra.Command{
 	Use:   "rg",
 	Short: "Route group management",
-	Long:  "View active route groups, their associated apps, and live traffic stats.",
+	Long: `View active route groups, their associated apps, and live traffic stats.
+
+A route group is the set of installed routing rules that carry one app
+connection (initiator + responder legs, plus any multiplexed transports).
+This is the app-centric, bandwidth-annotated view; ` + "`skywire cli route groups`" + `
+shows the same groups at the rule level, and bare ` + "`skywire cli route`" + `
+lists the individual rules. None of these query the route-finder — for a
+remote path lookup use ` + "`skywire cli route find`" + `.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Default to listing route groups when no subcommand given
 		listCmd.Run(cmd, args)

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -53,7 +53,25 @@ func init() {
 	calcCmd.Flags().StringVar(&calcSource, "source", "tpd", "transport graph source: tpd (HTTP). dht|auto are accepted for compatibility and also read from TPD, since the DHT store was removed; dht additionally forces the non-streaming local-compute path")
 	calcCmd.Flags().IntVar(&calcQueueCap, "queue-cap", 0, "BFS queue cap (0 = server/local default ~200K, negative = unbounded)")
 	calcCmd.Flags().BoolVar(&calcByLatency, "by-latency", false, "rank routes by cumulative transport latency (lowest first); skips the streaming gRPC path since the full set has to be in hand to sort")
+	// Hidden long-form aliases so the hop-bound vocabulary matches
+	// `route find` / `route trace` (--min/--max stay the visible spelling).
+	calcCmd.Flags().Uint16Var(&calcMinHops, "min-hops", 0, "minimum hops (alias for --min)")
+	calcCmd.Flags().Uint16Var(&calcMaxHops, "max-hops", 5, "maximum hops (alias for --max)")
+	calcCmd.Flags().MarkHidden("min-hops") //nolint:errcheck,gosec
+	calcCmd.Flags().MarkHidden("max-hops") //nolint:errcheck,gosec
 	clirpc.RegisterFetchFlags(calcCmd)
+}
+
+// validCalcSource reports whether s is an accepted --source value.
+// Kept as a single source of truth so the up-front validation and the
+// local-compute switch agree on the accepted set (tpd|auto|dht).
+func validCalcSource(s string) bool {
+	switch strings.ToLower(s) {
+	case "tpd", "auto", "dht":
+		return true
+	default:
+		return false
+	}
 }
 
 var calcCmd = &cobra.Command{
@@ -68,6 +86,14 @@ var calcCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if calcEnable && calcDisable {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("cannot use both --enable and --disable"))
+		}
+
+		// Validate --source up front so an unknown value is rejected on
+		// EVERY path. Previously only the local-compute fallback checked
+		// it, so the streaming gRPC path silently accepted (and ignored)
+		// a bogus --source and returned a route anyway.
+		if !validCalcSource(calcSource) {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --source %q; expected tpd|auto|dht", calcSource))
 		}
 
 		// Handle config flags

--- a/cmd/skywire-cli/commands/route/route.go
+++ b/cmd/skywire-cli/commands/route/route.go
@@ -47,15 +47,43 @@ func init() {
 	findCmd.Flags().Uint16VarP(&frMinHops, "min", "n", 1, "minimum hops")
 	findCmd.Flags().Uint16VarP(&frMaxHops, "max", "x", 1000, "maximum hops")
 	findCmd.Flags().DurationVarP(&timeout, "timeout", "t", 10*time.Second, "request timeout")
-	findCmd.Flags().StringVarP(&frAddr, "addr", "a", rfURL, "route finder service address")
+	// --rf is the canonical name for the route-finder address (matches
+	// `route trace --rf`). --addr is kept as a hidden backward-compatible
+	// alias — both write frAddr, and the -a shorthand now belongs to --rf.
+	findCmd.Flags().StringVarP(&frAddr, "rf", "a", rfURL, "route finder service address")
+	findCmd.Flags().StringVar(&frAddr, "addr", rfURL, "route finder service address (deprecated alias for --rf)")
+	findCmd.Flags().MarkHidden("addr") //nolint:errcheck,gosec
+	// --min-hops / --max-hops are hidden long-form aliases for --min /
+	// --max, giving the whole group one greppable hop-bound vocabulary
+	// without breaking the short spellings.
+	findCmd.Flags().Uint16Var(&frMinHops, "min-hops", 1, "minimum hops (alias for --min)")
+	findCmd.Flags().Uint16Var(&frMaxHops, "max-hops", 1000, "maximum hops (alias for --max)")
+	findCmd.Flags().MarkHidden("min-hops") //nolint:errcheck,gosec
+	findCmd.Flags().MarkHidden("max-hops") //nolint:errcheck,gosec
 }
 
-// RootCmd is the command that queries the route finder.
+// findCmd queries the Route Finder service for the hop path(s) between two
+// visors. This is a REMOTE query against the route-finder graph — it does
+// NOT read or install any local routing rules (bare `skywire cli route`
+// does that). A "route" here is the ordered list of hops (transport IDs +
+// visor PKs) the route-finder would stitch into a rule chain; each hop
+// rides exactly one transport between two visors.
 var findCmd = &cobra.Command{
 	Use:   "find <public-key> | <public-key-visor-1> <public-key-visor-2>",
-	Short: "Query the Route Finder",
-	Long: `Query the Route Finder
-Assumes the local visor public key as an argument if only one argument is given`,
+	Short: "Query the Route Finder for a hop path between two visors",
+	Long: `Query the Route Finder service for the route (hop path) between two visors.
+
+This is a live query against the route-finder graph; it neither reads nor
+installs local routing rules. Compare the sibling commands:
+
+  route find    query the route-finder for a path to a destination (REMOTE)
+  route         list the routing rules currently installed here (LOCAL)
+  route calc    compute a path locally from transport-discovery data (no RF)
+
+A route is an ordered chain of hops; each hop traverses one transport
+between two visors (a transport is a single peer-to-peer link, a route is
+the whole chain). If only one public key is given, the local visor's key
+is assumed as the source.`,
 	// Args: cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		var srcPK, dstPK cipher.PubKey
@@ -216,6 +244,7 @@ var RootCmd = routeCmd
 func init() {
 	routeCmd.PersistentFlags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
 	routeCmd.AddCommand(
+		lsRuleCmd,
 		rmRuleCmd,
 		addRuleCmd,
 		findCmd,
@@ -256,8 +285,23 @@ func init() {
 
 var routeCmd = &cobra.Command{
 	Use:   "route",
-	Short: "View and set rules",
-	Long:  "View and set routing rules",
+	Short: "View and set this visor's local routing rules",
+	Long: `View and set the routing rules installed on the LOCAL visor.
+
+Run without a subcommand (or ` + "`route ls`" + `) to list the routing rules
+currently installed here. A route is a chain of rules (forward /
+intermediary-forward / consume) that together carry traffic along a path
+of transports; each forward rule references the next transport and route
+ID in the chain. A rule is local state on THIS visor — distinct from a
+transport (a single link to one peer) and from the route-finder (which
+computes paths but installs nothing).
+
+  route            list installed routing rules (local, this visor)
+  route ls         alias for the bare listing above
+  route find       query the route-finder for a path (remote query)
+  route calc       compute a path locally from transport-discovery data
+  route groups     list active route groups (also: ` + "`skywire cli rg ls`" + `)
+  route add / rm   install / remove individual rules`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
@@ -296,6 +340,30 @@ var routeCmd = &cobra.Command{
 		} else {
 			printRoutingRules(cmd.Flags(), rules...)
 		}
+	},
+}
+
+// lsRuleCmd is an explicit alias for the bare `route` listing, so the
+// local-rules query has the same `ls` verb operators reach for elsewhere
+// (`rg ls`, `tp ls`, ...). It lists every installed routing rule; the
+// bare command's --rid/--nrid/--live selectors stay on `route` itself.
+var lsRuleCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List this visor's installed routing rules (alias for bare `route`)",
+	Long: `List the routing rules currently installed on the local visor.
+
+Same output as running ` + "`skywire cli route`" + ` with no subcommand — a
+convenience alias so local-rule listing uses the same ls verb as
+` + "`route groups`/`rg ls`" + `. To query the route-finder instead (a remote
+path lookup, not local rules) use ` + "`route find`" + `.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		rules, err := rpcClient.RoutingRules()
+		internal.Catch(cmd.Flags(), err)
+		printRoutingRules(cmd.Flags(), rules...)
 	},
 }
 

--- a/cmd/skywire-cli/commands/route/trace.go
+++ b/cmd/skywire-cli/commands/route/trace.go
@@ -53,6 +53,13 @@ func init() {
 	traceCmd.Flags().SortFlags = false
 	traceCmd.Flags().Uint16VarP(&traceMinHops, "min", "n", 1, "minimum hops requested from route finder")
 	traceCmd.Flags().Uint16VarP(&traceMaxHops, "max", "x", 5, "maximum hops requested from route finder")
+	// Hidden long-form aliases; keep the hop-bound vocabulary identical to
+	// `route find` / `route calc` while leaving --min/--max as the spelling
+	// shown in help.
+	traceCmd.Flags().Uint16Var(&traceMinHops, "min-hops", 1, "minimum hops (alias for --min)")
+	traceCmd.Flags().Uint16Var(&traceMaxHops, "max-hops", 5, "maximum hops (alias for --max)")
+	traceCmd.Flags().MarkHidden("min-hops") //nolint:errcheck,gosec
+	traceCmd.Flags().MarkHidden("max-hops") //nolint:errcheck,gosec
 	traceCmd.Flags().DurationVarP(&traceTimeout, "timeout", "t", 10*time.Second,
 		"route-finder request timeout")
 	traceCmd.Flags().StringVarP(&traceRfURL, "rf", "a", deployment.Prod.RouteFinder,


### PR DESCRIPTION
## What

Audit, bug-fix, and standardization pass over the `skywire cli route` and `skywire cli rg` command groups (`cmd/skywire-cli/commands/{route,rg}/`). Every subcommand and flag was enumerated and live-tested against a running visor.

## Bug fixed
- **`route calc --source` validation bypass**: an unknown `--source` was only rejected on the local-compute fallback path. The default streaming gRPC path silently accepted (and ignored) a bogus value and returned a route anyway. `--source` is now validated up front and rejected on every path (`tpd|auto|dht`).

## Standardization (strictly backward-compatible — old spellings kept as hidden aliases)
- **`route find`**: added `--rf` as the canonical route-finder-address flag, matching `route trace --rf`. `--addr` is kept as a hidden alias; the `-a` shorthand now belongs to `--rf`. Both spellings still work.
- **`route find` / `calc` / `trace`**: added hidden `--min-hops` / `--max-hops` aliases for `--min` / `--max`, so the hop-bound vocabulary is consistent and greppable across the group. The short spellings remain what help shows.
- **`route ls`**: new subcommand aliasing the bare rule listing, for verb parity with `rg ls` / `route groups`.

## Help / docs
- Clarified long-help across the group to distinguish **LOCAL installed rules** (bare `route`, `route ls`, `route groups`, `rg ls`) from the **REMOTE route-finder query** (`route find`) and local path computation (`route calc`), and to spell out the **route** (a chain of rules over transports) vs **transport** (a single peer link) distinction.
- Fixed a stale comment that labelled `findCmd` as the route-finder `RootCmd`.

## Compatibility
No breaking changes. `route minhops` and `rg ls --json` (used by `ci_scripts/mux-route-probe.sh`) are unchanged. Existing flag spellings (`--addr`, `--min`, `--max`) continue to work.

## Testing
Every `route`/`rg` subcommand and flag was live-tested against a running visor (read paths: `find`, `calc`, `trace`, `groups`, `rg ls`, `table-stats`, `rsn-*`, `policy`; validation paths for the mutating `add`/`rm`/`minhops`). Rule-mutation on the live visor and the interactive `--live` TUI views were exercised only up to their pre-RPC validation / non-TTY fallback and left for isolated testing.