### PR TITLE
fix(config-cli): fix flag bugs + expose policy_per_dial in `config gen`

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -353,6 +353,10 @@ const envfileLinux = `#
 #--	Number of parallel mux routes per connection (default 0)
 #MUXROUTES=0
 
+#--	Per-dial routing policy: preset:<name> (e.g. preset:adaptive),
+#	@/path/policy.star, @/path/policy.wasm, inline Starlark, or empty
+#POLICYPERDIAL=''
+
 ### Auto-Update (skywire-autoupdate package) ############################
 #	These settings are only used by the skywire-update script
 #	installed by the skywire-autoupdate package.
@@ -574,6 +578,10 @@ const envfileWindows = `#
 
 #--	Number of parallel mux routes per connection (default 0)
 #$MUXROUTES=0
+
+#--	Per-dial routing policy: preset:<name> (e.g. preset:adaptive),
+#	@/path/policy.star, @/path/policy.wasm, inline Starlark, or empty
+#$POLICYPERDIAL=''
 
 ### Auto-Update (skywire-autoupdate package) ############################
 #	These settings are only used by the skywire-update script

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -195,7 +195,7 @@ func init() {
 
 	// Transport flags
 	genConfigCmd.Flags().BoolVarP(&disablePublicAutoConn, "autoconn", "y", scriptExecBool("${DISABLEPUBLICAUTOCONN:-false}"), "disable autoconnect to public visors")
-	gHiddenFlags = append(gHiddenFlags, "hide")
+	gHiddenFlags = append(gHiddenFlags, "autoconn")
 	genConfigCmd.Flags().BoolVarP(&isPublic, "public", "z", scriptExecBool("${VISORISPUBLIC:-false}"), "publicize visor in service discovery")
 	gHiddenFlags = append(gHiddenFlags, "public")
 	genConfigCmd.Flags().IntVar(&stcprPort, "stcpr", scriptExecInt("${STCPRPORT:-0}"), "tcp transport listening port (0 = random / shared master port)")
@@ -226,6 +226,8 @@ func init() {
 	genConfigCmd.Flags().StringVar(&transportSetupPKs, "tpsetup", scriptExecArray("${TPSETUPPKS[@]}"), msg)
 	gHiddenFlags = append(gHiddenFlags, "tpsetup")
 	genConfigCmd.Flags().BoolVar(&cascadeRouteSetup, "cascade", false, "opt into source-driven cascade route setup (default: legacy setup-node path)")
+	genConfigCmd.Flags().StringVar(&policyPerDial, "policy", scriptExecString("${POLICYPERDIAL}"), "per-dial routing policy: preset:<name> (e.g. preset:adaptive), @/path/policy.star, @/path/policy.wasm, inline Starlark, or empty for built-in defaults")
+	gHiddenFlags = append(gHiddenFlags, "policy")
 	genConfigCmd.Flags().BoolVar(&snConfig, "sn", false, "generate config for route setup node")
 	gHiddenFlags = append(gHiddenFlags, "sn")
 	genConfigCmd.Flags().BoolVar(&dmsgDiscConfig, "dmsgdisc", false, "generate config for dmsg-discovery service")
@@ -1250,6 +1252,10 @@ func configureRouting() {
 		conf.Routing.MuxRoutes = muxRoutes
 	}
 
+	if policyPerDial != "" {
+		conf.Routing.PolicyPerDial = policyPerDial
+	}
+
 	if oldConfCache != nil && oldConfCache.Routing != nil {
 		// Preserve the previous min_hops across regen UNLESS --min-hops (or
 		// MINHOPS in skywire.conf) was set to a non-default value this run, in
@@ -1262,12 +1268,15 @@ func configureRouting() {
 		if oldConfCache.Routing.EnableCascadeRouteSetup {
 			conf.Routing.EnableCascadeRouteSetup = true
 		}
-		// Respect an explicit routing policy chosen in the previous config
-		// (any non-empty value the operator set, including "none"). Only a
-		// config that never specified one falls through to the adaptive default
-		// above, so regenerating an untouched config opts it into the new
-		// default while never clobbering a deliberate choice.
-		if oldConfCache.Routing.PolicyPerDial != "" {
+		// Preserve a previously-set per-dial routing policy across regen UNLESS
+		// --policy (or POLICYPERDIAL) was passed this run, in which case the new
+		// value already set above wins. A config that never set one (any
+		// non-empty value the operator chose, including "none", counts as set)
+		// falls through to the adaptive default in the literal above — so
+		// regenerating an untouched config opts into the new default while a
+		// deliberate choice is never clobbered. To clear it, edit policy_per_dial
+		// in the JSON directly.
+		if policyPerDial == "" && oldConfCache.Routing.PolicyPerDial != "" {
 			conf.Routing.PolicyPerDial = oldConfCache.Routing.PolicyPerDial
 		}
 	}

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1254,6 +1254,15 @@ func configureRouting() {
 
 	if policyPerDial != "" {
 		conf.Routing.PolicyPerDial = policyPerDial
+	} else {
+		// Default routing policy: the "adaptive" composite preset — scales the
+		// mux leg count to load (AIMD), evicts the slowest leg, periodically
+		// probes a fresh path, and (with the metadata provider) picks the most
+		// transport-diverse forward candidate. It is a no-op for latency-
+		// sensitive/other apps and shapes vpn/skysocks/skynet client dials.
+		// Overridable via --policy (POLICYPERDIAL) or a per-app launcher
+		// routing_policy; preserved across regen (below).
+		conf.Routing.PolicyPerDial = "preset:adaptive"
 	}
 
 	if oldConfCache != nil && oldConfCache.Routing != nil {

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -110,6 +110,7 @@ var (
 	setPublicAutoconnect       string
 	minHops                    int
 	cascadeRouteSetup          bool
+	policyPerDial              string
 	isUsr                      bool
 	isPublic                   bool
 	disablePublicAutoConn      bool

--- a/cmd/skywire-cli/commands/config/services.go
+++ b/cmd/skywire-cli/commands/config/services.go
@@ -40,12 +40,12 @@ var servicesCmd = &cobra.Command{
 
 		servicesConf, err := fetchServicesConf(cmd.Flags())
 		if err != nil {
-			log.WithError(err).Error("Cannot fetching updated services-config data")
+			log.WithError(err).Error("Cannot fetch updated services-config data")
 		}
 
 		file, err := json.MarshalIndent(servicesConf, "", " ")
 		if err != nil {
-			log.WithError(err).Error("Error accurs during marshal content to json file")
+			log.WithError(err).Error("Error marshaling content to json file")
 		}
 
 		err = os.WriteFile(path, file, 0600)

--- a/cmd/skywire-cli/commands/config/update.go
+++ b/cmd/skywire-cli/commands/config/update.go
@@ -89,6 +89,18 @@ func init() {
 var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update a config file",
+	Long: `Update an existing skywire config file in place.
+
+The target file must already exist; use 'config gen' to create one. Select the
+target with -i/--input (read from) and -o/--output (write to); when only one is
+given it is used for both. -p/--pkg targets the package config and -u/--user the
+$HOME config. With no flags the running visor's app/service config subcommands
+(hv, sc, ss, vpnc, vpns) rewrite launcher app args; 'svc' refreshes the local
+services-config.json from the bootstrap service.
+
+Top-level flags update service endpoints (-a/--endpoints), the log level
+(--log-level), public autoconnect (--public-autoconn true|false) and the routing
+min-hops (--set-minhop). Passing -b/--url a value implies --endpoints.`,
 	PreRun: func(_ *cobra.Command, _ []string) {
 		if isUpdateEndpoints && (serviceConfURL == "") {
 			if !isTestEnv {
@@ -101,7 +113,7 @@ var updateCmd = &cobra.Command{
 		checkConfig()
 	},
 	Run: func(cmd *cobra.Command, _ []string) {
-		if cmd.Flags().Changed("serviceConfURL") {
+		if cmd.Flags().Changed("url") {
 			isUpdateEndpoints = true
 		}
 		conf = initUpdate()
@@ -395,7 +407,7 @@ var vpnServerUpdateCmd = &cobra.Command{
 		case "":
 			break
 		default:
-			logger.Fatal("Unrecognized vpn server autostart value: ", setVPNServerSecure)
+			logger.Fatal("Unrecognized vpn server autostart value: ", setVPNServerAutostart)
 		}
 		if isResetVPNServer {
 			resetAppsConfig(conf, "vpn-server")


### PR DESCRIPTION
## Summary

Audit + targeted fixes for the `skywire cli config` command group. Scoped entirely to `cmd/skywire-cli/commands/config/`; strictly backward compatible (no flag renames or removals).

## Bug fixes
- **`gen`: `--autoconn` (`-y`) leaked into the default help.** Its hidden-flags registration appended `"hide"` instead of `"autoconn"`, so the flag intended to be hidden was always visible. Now hidden as intended (behavior of the flag itself is unchanged).
- **`update`: `--url`/`-b` never triggered an endpoint refresh.** The Run body checked `Changed("serviceConfURL")` — a flag name that does not exist — so it was dead. Now checks the real `"url"` flag, so passing a custom service-conf URL implies `--endpoints`.
- **`update vpns`: wrong variable in the autostart error path.** The `autostart` default-case fatal logged `setVPNServerSecure`; now logs `setVPNServerAutostart`.
- **`update svc`: two garbled error strings** cleaned up.

## Improvements
- **`gen`: new `--policy` flag (env `POLICYPERDIAL`)** to set `routing.policy_per_dial`, which previously had no CLI path despite being a supported config knob. Accepts `preset:<name>` (e.g. `preset:adaptive`), `@/path/policy.star`, `@/path/policy.wasm`, inline Starlark, or empty for built-in defaults. Applied in `configureRouting` and **preserved across `--regen`**, matching the existing `min_hops` / `cascade` preservation.
- **`gen`: document `POLICYPERDIAL`** in the `skywire.conf` (SKYENV) template (`config gen -q`), next to the existing `MUXROUTES` entry.
- **`update`: added a Long help** describing target selection (`-i`/`-o`/`-p`/`-u`), the app subcommands (hv/sc/ss/vpnc/vpns/svc), and the top-level flags.

## Testing
- `go build ./cmd/skywire-cli/commands/config/` — clean.
- Config-package unit tests pass (`go test ./cmd/skywire-cli/commands/config/` → ok).
- `gen`/`update` exercised against **temp configs only**; verified `--policy` lands in `policy_per_dial`, survives `--regen`, `--autoconn` is now hidden yet still functional, and the `update` subcommands rewrite a temp config as expected.