### PR TITLE
cli(hv/log/util/pv/survey/completion): fix small bugs, standardize help

### DIFF
--- a/cmd/skywire-cli/commands/completion/completion.go
+++ b/cmd/skywire-cli/commands/completion/completion.go
@@ -9,11 +9,32 @@ import (
 
 // RootCmd contains commands that interact with the auto-completion scripts of skywire-cli
 var RootCmd = &cobra.Command{
-	Use:                   "completion [bash|zsh|fish|powershell]",
-	Short:                 "Generate completion script",
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate a shell completion script",
+	Long: `Generate a shell completion script for skywire-cli and write it to stdout.
+
+Load it into the current shell, or install it where your shell looks for
+completions:
+
+  # bash (current shell)
+  source <(skywire-cli completion bash)
+  # bash (persistent, Linux)
+  skywire-cli completion bash > /etc/bash_completion.d/skywire-cli
+
+  # zsh
+  skywire-cli completion zsh > "${fpath[1]}/_skywire-cli"
+
+  # fish
+  skywire-cli completion fish > ~/.config/fish/completions/skywire-cli.fish
+
+  # powershell
+  skywire-cli completion powershell | Out-String | Invoke-Expression`,
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-	Args:                  cobra.MatchAll(cobra.ExactArgs(1)),
+	// OnlyValidArgs rejects an unknown shell name (e.g. `completion foo`)
+	// instead of silently doing nothing — ExactArgs alone doesn't validate
+	// the value against ValidArgs.
+	Args: cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		switch args[0] {
 		case "bash":

--- a/cmd/skywire-cli/commands/hv/root.go
+++ b/cmd/skywire-cli/commands/hv/root.go
@@ -5,11 +5,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RootCmd is the `hv` command group: tools for the hypervisor UI, including the
-// standalone single-file generator.
+// RootCmd is the `hv` command group: tools for building, serving, driving and
+// bridging the hypervisor UI / wasm-visor.
 var RootCmd = &cobra.Command{
 	Use:   "hv",
-	Short: "Hypervisor UI tools",
+	Short: "Hypervisor / wasm-visor tools",
+	Long: `Tools for building, serving, driving and bridging the hypervisor UI and the
+standalone wasm-visor.
+
+Build & serve:
+  gen      generate a self-contained standalone hypervisor.html (opens from file://)
+  serve    serve the keyless standalone wasm-visor over HTTP (reverse-proxy with Caddy)
+
+Desktop bridge:
+  notify   show a remote visor's app notifications on THIS machine (SSE bridge)
+
+Browser automation (CDP — needs --remote-debugging-port=9222):
+  probe    watch one page load and stream console, exceptions and crashes
+  shell    drive the visor shell in a browser tab and capture the result
+  eval     evaluate JavaScript on a specific CDP target by webSocketDebuggerUrl`,
 }
 
 func init() {

--- a/cmd/skywire-cli/commands/jq/jq.go
+++ b/cmd/skywire-cli/commands/jq/jq.go
@@ -27,11 +27,24 @@ func init() {
 	RootCmd.Flags().BoolVarP(&compactOutput, "compact-output", "c", false, "compact output (no pretty printing)")
 }
 
-// RootCmd is the jq command
+// RootCmd is the jq command. It is exposed to users as `skywire cli util jq`
+// (the util parent unhides it); it stays Hidden as a bare top-level command so
+// it doesn't clutter the root help. To filter the JSON output of ANY skywire
+// command, prefer the built-in `--jq` global flag (e.g. `cli visor info --jq
+// .overview`) — this standalone processor is for piping arbitrary JSON.
 var RootCmd = &cobra.Command{
-	Use:    "jq <filter> [file...]",
-	Short:  "jq-like JSON processor (gojq)",
-	Long:   "Process JSON using jq filter syntax (powered by gojq)",
+	Use:   "jq <filter> [file...]",
+	Short: "jq-like JSON processor (gojq)",
+	Long: `Process JSON using jq filter syntax (powered by gojq).
+
+Reads JSON from stdin (or the given files) and applies the filter, the same way
+the standard jq(1) does. Canonically invoked as ` + "`skywire cli util jq`" + `.
+
+  echo '{"a":1,"b":2}' | skywire cli util jq '.a'
+  skywire cli util jq -r '.items[].name' data.json
+
+To filter the output of another skywire command, use the built-in --jq global
+flag instead of piping through this:  skywire cli pv --stats --jq '.count'.`,
 	Hidden: true,
 	Args:   cobra.MinimumNArgs(1),
 	Run: func(_ *cobra.Command, args []string) {

--- a/cmd/skywire-cli/commands/log/log.go
+++ b/cmd/skywire-cli/commands/log/log.go
@@ -63,7 +63,7 @@ func init() {
 
 var logCmd = &cobra.Command{
 	Use:   "log",
-	Short: "survey & transport log collection",
+	Short: "Survey & transport-log collection",
 	Long:  fmt.Sprintf("Fetch health, survey, and transport logging from visors which are online in the TPD-integrated uptime tracker\n%[1]s/uptimes?v=v3\n%[1]s/uptimes?v=v3&visors=<pk1>;<pk2>;<pk3>", deployment.Prod.TransportDiscovery),
 	Run: func(cmd *cobra.Command, _ []string) {
 		log := logging.MustGetLogger("log-collecting")

--- a/cmd/skywire-cli/commands/log/st.go
+++ b/cmd/skywire-cli/commands/log/st.go
@@ -27,7 +27,13 @@ func init() {
 //nolint:errcheck
 var stCmd = &cobra.Command{
 	Use:   "st",
-	Short: "survey tree",
+	Short: "Render collected surveys as a color tree",
+	Long: `Render the surveys collected by ` + "`cli log`" + ` as a color-coded tree.
+
+Walks the collection directory (--lcdir) and prints, per visor: health.json
+(green if fetched within the hour, else red), node-info.json (with the reported
+skywire_version), and any transport-bandwidth CSVs. With --ut it also shows each
+visor's current online status + last-two-days uptime, read from /tmp/ut.json.`,
 	Run: func(_ *cobra.Command, _ []string) {
 		if pubKey != "" { //nolint:errcheck
 			pks := strings.Split(pubKey, ",")

--- a/cmd/skywire-cli/commands/log/tplogs.go
+++ b/cmd/skywire-cli/commands/log/tplogs.go
@@ -17,7 +17,13 @@ func init() {
 
 var tpCmd = &cobra.Command{
 	Use:   "tp",
-	Short: "display collected transport bandwidth logging",
+	Short: "Display collected transport-bandwidth logs",
+	Long: `Collate and display the per-transport bandwidth CSVs collected by ` + "`cli log`" + `.
+
+Reads the daily *.csv files under --dir, sorts and de-duplicates the rows, and
+color-codes them: blue = unchanged counters between samples, yellow = changed,
+red = a zero reading. Registered only when /bin/bash is present (the collation
+is a bundled bash+awk script).`,
 	Run: func(_ *cobra.Command, _ []string) {
 		tmpFile, err := os.CreateTemp(os.TempDir(), "*.sh")
 		if err != nil {

--- a/cmd/skywire-cli/commands/pv/pv.go
+++ b/cmd/skywire-cli/commands/pv/pv.go
@@ -115,7 +115,7 @@ func init() {
 	RootCmd.Flags().BoolVarP(&noFilterOnline, "noton", "o", false, "do not filter by online status")
 	RootCmd.Flags().StringVar(&cacheDirSD, "cds", cacheDirPath(dep.ServiceDiscovery), "SD cache dir (\"\" to disable)")
 	RootCmd.Flags().StringVar(&cacheDirTPD, "cdt", cacheDirPath(dep.TransportDiscovery), "TPD cache dir, shared by transports + uptime (\"\" to disable)")
-	RootCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "refetch cached data older than n minutes (0 = always fetch fresh, e.g. for `watch`)")
+	RootCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "refetch cached data older than n minutes (0 = always fetch fresh, e.g. for 'watch')")
 	RootCmd.Flags().StringVarP(&country, "country", "c", "", "filter by country code")
 	RootCmd.Flags().StringVarP(&version, "version", "v", "", "filter by version")
 	RootCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "return only a count of the results")

--- a/cmd/skywire-cli/commands/survey/root.go
+++ b/cmd/skywire-cli/commands/survey/root.go
@@ -63,8 +63,15 @@ var RootCmd = surveyCmd
 var surveyCmd = &cobra.Command{
 	Use:                   "survey",
 	DisableFlagsInUseLine: true,
-	Short:                 "system survey",
-	Long:                  "print the system survey",
+	Short:                 "Print the local system survey",
+	Long: `Print this machine's system survey as JSON — the same document a visor
+publishes for reward-eligibility and diagnostics: hardware/OS facts, the
+skywire version, the configured deployment service URLs, the reward address,
+and (with --config) the visor public key.
+
+With --config / --pkg / --user the survey is enriched from a visor config
+(public key + service URLs). --dmsg-disc looks the machine's public IP up via
+the given dmsg discovery. Output honors --json / --jq like every other command.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		if pkg {
 			confPath = skyenv.SkywirePath + "/" + skyenv.ConfigJSON

--- a/cmd/skywire-cli/commands/util/foreach.go
+++ b/cmd/skywire-cli/commands/util/foreach.go
@@ -120,6 +120,12 @@ Exit codes:
 		}
 
 		jsonMode, _ := cmd.Flags().GetBool("json") //nolint:errcheck
+		// --json emits a clean NDJSON stream; the human per-target headers
+		// would otherwise interleave with it on stdout and corrupt the
+		// output for downstream parsers. So --json implies --quiet.
+		if jsonMode {
+			foreachQuiet = true
+		}
 		results := runForeach(cmd.Context(), targets, template)
 
 		anyNonZero, anyTimeout := false, false


### PR DESCRIPTION
Audit + polish of the smaller skywire-cli utility command groups: `hv`, `log`,
`survey`, `got`, `gotop`, `util` (foreach/nc/serve/jq/edit), `pv`, `version`,
`completion`, and the top-level `jq`. Every subcommand and flag was enumerated
and exercised (TUIs via their non-TTY/help paths; live queries read-only). No
flag renames — all changes are backward-compatible bug fixes and help
improvements.

## Bug fixes
- **completion**: `completion foo` (unknown shell) silently did nothing —
  `ValidArgs` without `OnlyValidArgs` doesn't validate. Now errors
  `invalid argument "foo"`.
- **util foreach**: `--json` interleaved the human per-target headers with the
  NDJSON on stdout, corrupting it for parsers. `--json` now implies quiet.
- **pv**: the `--cfa` flag rendered its value placeholder as `watch` because
  backticks in the usage string hijack pflag's arg-name detection; quoted
  plainly so it reads `--cfa int`.

## Help / long-description improvements
- **hv**: added a group `Long` enumerating `gen`/`serve`/`notify` and the CDP
  browser rigs (`probe`/`shell`/`eval`); `Short` broadened to
  "Hypervisor / wasm-visor tools" (the group is more than UI tools).
- **jq**: documented that it is canonically `util jq`, and that `--jq` is the
  global output filter — resolving the jq-vs-util-jq confusion.
- **survey**: capitalized + expanded `Short`/`Long` (was "system survey").
- **completion**: added a `Long` with per-shell install one-liners.
- **log**: capitalized the root `Short`; added `Long` to `log st` and `log tp`.

## Verified
Built `./cmd/skywire-cli`; exercised got (dl/head/req over a local server),
util nc (probe exit codes + TCP roundtrip), util serve, util foreach
(streaming/json/stop-on), util jq, version --local, completion, and the
help/non-TTY paths of the TUIs (gotop/edit correctly require a real TTY).

## Follow-up (shared, out of scope for these command dirs)
Bare `skywire cli jq` — and any unknown subcommand — prints the ASCII banner in
the **combined** binary instead of erroring, because cobra `legacyArgs` treats
`cli` as a non-root parent. The standalone `skywire-cli` binary already errors
cleanly. The fix belongs in `commands/root.go` (an `Args` validator / `RunE` on
the root) and is left for a separate change.
