### PR TITLE
fix(cli/visor): unhide 6 invisible subcommands, fix hv-ui port bug, standardize flags

### DIFF
--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -72,7 +72,11 @@ func init() {
 	)
 	registerAppCmd.Flags().StringVarP(&appName, "appname", "a", "", "name of the app")
 	registerAppCmd.Flags().StringVarP(&localPath, "localpath", "p", "./local", "path of the local folder")
-	deregisterAppCmd.Flags().StringVarP(&procKey, "procKey", "k", "", "proc key of the app to deregister")
+	deregisterAppCmd.Flags().StringVarP(&procKey, "proc-key", "k", "", "proc key of the app to deregister")
+	// Backward-compat: the original camelCase spelling. Same target var,
+	// hidden so `--help` shows only the standardized kebab-case flag.
+	deregisterAppCmd.Flags().StringVar(&procKey, "procKey", "", "deprecated alias for --proc-key")
+	_ = deregisterAppCmd.Flags().MarkHidden("procKey") //nolint:errcheck
 	startAppCmd.Flags().BoolVar(&useInternal, "internal", false, "force internal launcher")
 	startAppCmd.Flags().BoolVar(&useExternal, "external", false, "force external launcher")
 	startAppCmd.MarkFlagsMutuallyExclusive("internal", "external")

--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -137,7 +137,15 @@ func HypervisorPort(cmdFlags *pflag.FlagSet) string {
 	if err != nil {
 		return visorconfig.HTTPAddr()
 	}
-	return fmt.Sprintf(":%s", ports["hypervisor"])
+	// ports["hypervisor"] is a PortDetail struct; format only its Port
+	// field. Using the whole struct with %s renders "{8000 TCP}", which
+	// leaked into URLs as "http://127.0.0.1:{8000 TCP}/" for `hv ui`,
+	// `vpn ui`, and `vpn url`.
+	hp := ports["hypervisor"].Port
+	if hp == "" {
+		return visorconfig.HTTPAddr()
+	}
+	return fmt.Sprintf(":%s", hp)
 }
 
 var hvUIEnableCmd = &cobra.Command{

--- a/cmd/skywire-cli/commands/visor/ping/root.go
+++ b/cmd/skywire-cli/commands/visor/ping/root.go
@@ -16,8 +16,12 @@ var RootCmd = &cobra.Command{
 When called with a public key argument, pings that visor directly.
 
 Available subcommands:
-  ping <pk>     - Ping a specific visor
-  ping test     - Test connectivity to public visors
-  ping tree     - Ping visors via transport routes (scrollable TUI)
-  ping stop-all - Stop all active ping connections`,
+  ping <pk>       - Ping a specific visor (route or --dmsg)
+  ping test       - Test connectivity to public visors
+  ping bandwidth  - Sustained throughput test to a visor
+  ping mux-bw     - Multiplexed-route bandwidth + queueing-delay probe
+  ping mux-bw-tui - Interactive TUI for the mux bandwidth probe
+  ping tree       - Ping-tree over the route graph (scrollable TUI)
+  ping tree-stream- Ping-tree as streamed rows / NDJSON
+  ping stop-all   - Stop all active ping connections`,
 }

--- a/cmd/skywire-cli/commands/visor/process.go
+++ b/cmd/skywire-cli/commands/visor/process.go
@@ -93,9 +93,6 @@ var reloadCmd = &cobra.Command{
 	},
 }
 
-func init() {
-}
-
 var suspendCmd = &cobra.Command{
 	Use:   "suspend",
 	Short: "Suspend visor (tear down networking, keep local RPC)",

--- a/cmd/skywire-cli/commands/visor/reinit.go
+++ b/cmd/skywire-cli/commands/visor/reinit.go
@@ -15,7 +15,7 @@ var module string
 
 func init() {
 	RootCmd.AddCommand(reinitCmd)
-	reinitCmd.Flags().StringVarP(&module, "module", "m", "", "target module for reinitiating.")
+	reinitCmd.Flags().StringVarP(&module, "module", "m", "", "target module to reinitiate (required)")
 }
 
 var reinitCmd = &cobra.Command{
@@ -24,7 +24,7 @@ var reinitCmd = &cobra.Command{
 	Long:  "\n  Reinitiate modules",
 	Run: func(cmd *cobra.Command, _ []string) {
 		if module == "" {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("No module choosed for reinitiate"))
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("no module selected; pass --module/-m"))
 		}
 
 		rpcClient, err := clirpc.Client(cmd.Flags())

--- a/cmd/skywire-cli/commands/visor/user.go
+++ b/cmd/skywire-cli/commands/visor/user.go
@@ -16,7 +16,8 @@ import (
 )
 
 func init() {
-	userCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
+	// --rpc is already provided as a persistent flag on RootCmd
+	// (see root.go); no need to redeclare a local one here.
 	RootCmd.AddCommand(userCmd)
 }
 

--- a/cmd/skywire-cli/commands/visor/zgroups.go
+++ b/cmd/skywire-cli/commands/visor/zgroups.go
@@ -1,12 +1,20 @@
 // Package clivisor cmd/skywire-cli/commands/visor/zgroups.go c4-vis-cli
 //
-// Groups the 17 subcommands of `skywire cli visor` so the help output
+// Groups the subcommands of `skywire cli visor` so the help output
 // renders as discoverable sections instead of a flat wall. Filename
 // starts with `z` so this init runs AFTER the per-feature files'
 // inits (Go runs init functions in the order source files are
 // compiled, alphabetically within a package) — by then every
 // subcommand has been AddCommand'd and we can assign GroupIDs by
 // name in one place.
+//
+// Every non-hidden, non-deprecated subcommand MUST appear in the
+// commandGroup map below. The shared help template in pkg/flags
+// (helpTemplateNoUsage / help) renders ONLY grouped commands once any
+// group is defined — it does NOT emit cobra's default "Additional
+// Commands:" block — so a command left out of the map is registered
+// and callable but invisible in `visor --help`. Keep this map in sync
+// when adding a subcommand.
 package clivisor
 
 import (
@@ -43,9 +51,15 @@ var commandGroup = map[string]string{
 	"hv":           groupSubsystems,
 	"proxies":      groupSubsystems,
 	"reward":       groupSubsystems,
+	"cxo":          groupSubsystems,
+	"pair":         groupSubsystems,
 	"log":          groupDiagnostics,
 	"go":           groupDiagnostics,
+	"goroutines":   groupDiagnostics,
 	"ping":         groupDiagnostics,
+	"doctor":       groupDiagnostics,
+	"whois":        groupDiagnostics,
+	"uptime":       groupDiagnostics,
 }
 
 func init() {


### PR DESCRIPTION
## Summary

Audit of the `skywire cli visor` command group (`cmd/skywire-cli/commands/visor/`). Scoped strictly to that directory; no RPC/behavioral changes.

## Fixes

- **hv-ui port bug**: `HypervisorPort` formatted the whole `PortDetail` struct with `%s`, producing `{8000 TCP}`. This leaked into URLs as `http://127.0.0.1:{8000 TCP}/` for `hv ui`, `vpn ui`, and `vpn url`. Now uses `ports["hypervisor"].Port` (with an empty-value fallback to the config HTTP addr).

- **Six invisible subcommands**: the shared help template in `pkg/flags` renders only *grouped* subcommands (it emits no cobra "Additional Commands:" block once any group is defined), so any visor subcommand missing from `zgroups.go`'s group map was registered and callable but absent from `visor --help`. `cxo`, `pair`, `doctor`, `goroutines`, `whois`, and `uptime` were all hidden this way. They are now grouped (Subsystems / Diagnostics) and the invariant is documented so new commands don't regress. (A complementary fix to `pkg/flags` to render an Additional-Commands block is noted for a separate PR.)

- **Flag standardization**: `app deregister` used a camelCase `--procKey` — the only non-kebab flag in the group. Standardized to `--proc-key`; `--procKey` is retained as a hidden backward-compatible alias.

- **Cleanups**: dropped the redundant local `--rpc` redeclaration in `user.go` (it is already a persistent root flag); fixed `reinit`'s `"No module choosed for reinitiate"` grammar and flag help; refreshed the stale subcommand list in `ping`'s root help; removed a dead empty `init()` in `process.go`.

## Testing

Built the CLI and exercised the read-only surface against a live v1.3.92 visor: `info`, `pk`, `pk dnslabel`, `ver`, `user`, `ip`, `ports`, `dmsg-servers`, `ready`, `suspended`, `hv status/pk/cpk/ls (--flat/--load)`, `app ls/conns`, `go`, `goroutines`, `log` (+filters), `uptime` (+timeline), `cxo status`, `cxo feeds ls`, `pair ls`, `doctor`, `whois`, `reward` — plus `--json`/`--shape`. Mutating/lifecycle/ping commands were not run against the live visor; verified via `--help` and the code path. `go vet` on the package is clean.