### PR TITLE
cli(survey): honor --json/--jq/--shape global output flags

### DIFF
--- a/cmd/skywire-cli/commands/survey/root.go
+++ b/cmd/skywire-cli/commands/survey/root.go
@@ -12,7 +12,6 @@ import (
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	"github.com/skycoin/skywire/pkg/cipher"
-	"github.com/skycoin/skywire/pkg/cliout"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
@@ -126,9 +125,15 @@ the given dmsg discovery. Output honors --json / --jq like every other command.`
 			}
 		}
 
-		// Always a document: the survey IS the output, so there is no human
-		// rendering to choose between — the printer just decides indentation.
-		internal.Catch(cmd.Flags(), cliout.Fprint(cmd.OutOrStdout(), true, survey))
+		// The survey IS the output, so its human rendering is just the pretty
+		// JSON. Route through the flag-aware printer so --json/--jq/--shape all
+		// work like every other command: default prints the JSON document,
+		// --jq filters it, --shape prints the skeleton.
+		human, merr := json.MarshalIndent(survey, "", "  ")
+		if merr != nil {
+			internal.Catch(cmd.Flags(), merr)
+		}
+		internal.PrintOutput(cmd.Flags(), survey, string(human)+"\n")
 	},
 }
 


### PR DESCRIPTION
Follow-up to #4070. `survey` wrote its JSON straight through `cliout.Fprint`,
bypassing the flag-aware printer — so the global `--jq` filter and `--shape`
skeleton were silently ignored (`--jq` printed the whole document, not the
filtered value). Route the survey through `internal.PrintOutput` with the
pretty JSON as its human form:

- bare `survey` still prints the JSON document,
- `survey --jq '.go_os'` → `"linux"` (now filters),
- `survey --shape` → the zero-value skeleton,

matching every other command and the help text added in #4070.

Verified by building `./cmd/skywire-cli` and exercising all three paths.
