### PR TITLE
fix(skywire-cli): render ungrouped subcommands in help (Additional Commands block)

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -57,7 +57,8 @@ func initColoredCobra(cmd *cobra.Command) {
 // Both templates below support cobra Command Groups (cobra ≥ 1.6):
 // when a command has defined groups via AddGroup, subcommands render
 // under their group's title; ungrouped subcommands fall through to an
-// "Additional Commands:" block. When no groups are defined the old
+// "Additional Commands:" block (emitted whenever not every child has a
+// group, via .AllChildCommandsHaveGroup). When no groups are defined the old
 // flat "Available Commands:" listing is produced, preserving the
 // existing behavior for commands that haven't opted in.
 const helpTemplateNoUsage = `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
@@ -66,6 +67,9 @@ const helpTemplateNoUsage = `{{with (or .Long .Short)}}{{. | trimTrailingWhitesp
   {{rpad (CommandStyle .Name) (sum .NamePadding 12) }} {{CmdShortStyle .Short}}{{end}}{{end}}
 {{else}}{{$cmds := .Commands}}{{range $group := .Groups}}
 {{HeadingStyle $group.Title}}{{range $cmds}}{{if and (eq .GroupID $group.ID) (ne .Name "completion") .IsAvailableCommand}}
+  {{rpad (CommandStyle .Name) (sum .NamePadding 12) }} {{CmdShortStyle .Short}}{{end}}{{end}}
+{{end}}{{if not .AllChildCommandsHaveGroup}}
+{{HeadingStyle "Additional Commands:"}}{{range $cmds}}{{if and (eq .GroupID "") (ne .Name "completion") .IsAvailableCommand}}
   {{rpad (CommandStyle .Name) (sum .NamePadding 12) }} {{CmdShortStyle .Short}}{{end}}{{end}}
 {{end}}{{end}}
 
@@ -87,6 +91,9 @@ const helpTemplateNoUsage = `{{with (or .Long .Short)}}{{. | trimTrailingWhitesp
 const help = `{{if gt (len .Aliases) 0}}{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}{{if eq (len .Groups) 0}}Available Commands:{{range .Commands}}{{if and (ne .Name "completion") .IsAvailableCommand}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{$cmds := .Commands}}{{range $group := .Groups}}
 {{HeadingStyle $group.Title}}{{range $cmds}}{{if and (eq .GroupID $group.ID) (ne .Name "completion") .IsAvailableCommand}}
+  {{rpad (CommandStyle .Name) (sum .NamePadding 12)}} {{CmdShortStyle .Short}}{{end}}{{end}}
+{{end}}{{if not .AllChildCommandsHaveGroup}}
+{{HeadingStyle "Additional Commands:"}}{{range $cmds}}{{if and (eq .GroupID "") (ne .Name "completion") .IsAvailableCommand}}
   {{rpad (CommandStyle .Name) (sum .NamePadding 12)}} {{CmdShortStyle .Short}}{{end}}{{end}}
 {{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 


### PR DESCRIPTION
## Problem

The grouped help templates in `pkg/flags/flags.go` (`helpTemplateNoUsage` and `help`) render only subcommands assigned to a cobra command group. Any registered-but-ungrouped command is **invisible** in `--help` — even though the template's own comment claims ungrouped commands "fall through to an Additional Commands: block." They never did.

This is CLI-wide: every command group that has an ungrouped child hides those children. Examples:
- root: `hv`, `skycoin`
- `visor` group: `cxo`, `doctor`, `goroutines`, `pair`, `uptime`, `whois` (6 hidden)

## Fix

Add the missing `Additional Commands:` block to both templates, guarded by cobra's `.AllChildCommandsHaveGroup`, rendering ungrouped-but-available commands with the same explicit style functions (`HeadingStyle`/`CommandStyle`/`CmdShortStyle`) the grouped path uses so coloredcobra colorizes them consistently. Hidden commands (`help`, `tree`, `completion`) stay excluded.

## Validation

- `go build ./cmd/skywire-cli/ .` (cli package + combined binary) clean.
- `swcli --help` now shows an `Additional Commands:` block with `hv`/`skycoin`.
- `swcli visor --help` now shows the 6 previously-hidden visor commands.

Strictly additive / backward-compatible: grouped rendering and the no-groups flat listing are unchanged.