### PR TITLE
fix(skywire-cli): error on unknown subcommand under combined 'skywire cli'

### DIFF
--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -201,6 +201,24 @@ var RootCmd = &cobra.Command{
 	DisableSuggestions:    true,
 	DisableFlagsInUseLine: true,
 	Version:               buildinfo.Version(),
+	// Reject leftover positional args (i.e. an unknown subcommand).
+	// The standalone `skywire-cli` binary already errors on
+	// `skywire-cli bogus` because cobra's legacyArgs does subcommand
+	// checking for a parent-less root. Under the combined `skywire`
+	// binary `cli` has a parent, so legacyArgs lets the unknown arg
+	// through, and cobra's `!Runnable()` check fires BEFORE arg
+	// validation — so a non-runnable `cli` returns ErrHelp and prints
+	// the ASCII banner instead of an error. Making `cli` runnable (RunE
+	// below) means ValidateArgs runs first; NoArgs then rejects the
+	// stray arg, so `skywire cli bogus` errors cleanly like standalone.
+	Args: cobra.NoArgs,
+	// Runnable so cobra reaches arg validation instead of short-
+	// circuiting to ErrHelp (see Args note). With no args this just
+	// prints help — the same output the previous not-runnable ErrHelp
+	// path produced for a bare `cli` / `skywire cli`.
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	},
 	PreRun: func(cmd *cobra.Command, _ []string) {
 		if cliShowAll {
 			for _, name := range cliHiddenFlags {


### PR DESCRIPTION
## Problem

`skywire cli <unknown-subcommand>` (e.g. `skywire cli bogus`) printed the ASCII banner instead of erroring. The standalone `skywire-cli bogus` errors cleanly.

Cause: under the combined `skywire` binary, `cli` is a **non-root** command. Cobra's `legacyArgs` only does unknown-subcommand checking for a parent-less root, so the stray arg passes; and cobra's `!Runnable()` check fires *before* `ValidateArgs`, so a non-runnable `cli` returns `flag.ErrHelp` and prints the banner. The standalone binary avoids this because `cli`'s RootCmd *is* the root there.

## Fix

In `cmd/skywire-cli/commands/root.go`:
- add `Args: cobra.NoArgs` so a leftover positional (unknown subcommand) is rejected;
- add a `RunE` that prints help, making `cli` runnable so cobra reaches arg validation instead of short-circuiting to `ErrHelp`.

## Validation (combined + standalone binaries built locally)

- `skywire cli bogus` → `unknown command "bogus" for "skywire cli"`, exit 1 (was: banner).
- `skywire cli` (bare) → still prints help (same as before).
- `skywire cli version` and other valid subcommands → unaffected.
- `skywire-cli bogus` (standalone) → still errors; `skywire-cli` bare → still prints help.

Backward-compatible: only the previously-misleading banner-on-typo path changes.