### PR TITLE
fix(skywire-cli): default uptime queries to v3 to match the CXO mirror

### DIFF
--- a/cmd/skywire-cli/cliuptime/cliuptime.go
+++ b/cmd/skywire-cli/cliuptime/cliuptime.go
@@ -124,7 +124,11 @@ func newTableCmd(cfg Config) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&baseURL, "url", cfg.DefaultURL, "discovery base URL")
-	cmd.Flags().StringVarP(&versionStr, "v", "v", "v2", "response version (v1|v2)")
+	// Default to v3: the deployment's CXO feed mirrors the v3&days=30
+	// response, so v3 queries hit the CXO cache. v2 (and v1) always
+	// CXO-miss and fall back to live dmsg, which produces transient
+	// "dmsg 202" errors. v1/v2 remain selectable for the older shapes.
+	cmd.Flags().StringVarP(&versionStr, "v", "v", "v3", "response version (v1|v2|v3)")
 	cmd.Flags().StringVarP(&pkFilter, "pk", "k", "", "only show PKs matching this substring")
 	cmd.Flags().StringSliceVar(&visorFilter, "visors", nil, "server-side filter: only return these PKs (comma-separated)")
 	cmd.Flags().BoolVarP(&onlineOnly, "on", "o", false, "only include online visors")

--- a/cmd/skywire-cli/commands/ut/tpd.go
+++ b/cmd/skywire-cli/commands/ut/tpd.go
@@ -6,7 +6,8 @@
 // shape changed (it fetched v1 but then tried to filter by the v2
 // `daily` field, which doesn't exist at v1). Replaced with the shared
 // cliuptime factory so it behaves identically to the sd / mdisc
-// equivalents and fetches v2 by default.
+// equivalents and fetches v3 by default (the version the deployment
+// mirrors over CXO).
 package cliut
 
 import (
@@ -26,8 +27,10 @@ func init() {
 %s/uptimes
 
 Same response shape as sd / mdisc / ut — v1 (pk+on), v2 (+ daily %%),
-v3 (+ per-5-minute timeline bitmap). Default is v2; pass -T / --timeline
-to request v3 and render the bitmap as 24 hourly blocks.
+v3 (+ per-5-minute timeline bitmap). Default is v3 (the version the
+deployment mirrors over CXO, so it hits the cache instead of live dmsg);
+pass --v v1|v2 for the older shapes, or use the graph subcommand to
+render the v3 bitmap as 24 hourly blocks.
 
 Populated by visor heartbeats + transport registrations; the same
 data feeds into the rewards pipeline.`, dep.TransportDiscovery),


### PR DESCRIPTION
## Problem

The shared `cliuptime` table command (`skywire cli ut {sd,mdisc,tpd}`) defaulted `--v` to **v2**, but the deployment only mirrors the **v3&days=30** `/uptimes` response over CXO. So every default `ut` query CXO-missed and fell back to live dmsg, producing transient `dmsg 202` errors and unnecessary load.

Note: there is no standalone uptime-tracker service anymore — uptime is per-service / TPD-integrated, and v3 is the shape those endpoints publish and mirror.

## Fix

Default `--v` to `v3` in the shared table command (covers sd/mdisc/tpd since they all use the same factory). `v1`/`v2` remain selectable via `--v` for the older response shapes; the v3 payload still carries the `daily` percentages the table renders. Help text and the tpd `Long`/header comments updated.

## Validation

- `go build ./cmd/skywire-cli/` clean.
- `skywire cli ut tpd --stats` now issues `/uptimes?v=v3` and returns data (1014 visors in a live run); with a running visor this hits the CXO cache instead of live dmsg.

Backward-compatible: `--v v1` / `--v v2` still work.