### PR TITLE
fix(cli): apps-cli — skycoin daemon list --json, group catalog self-listing, help polish

### DIFF
--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -366,15 +366,26 @@ answers only for its own groups, so discovery still starts from a public key
 somebody gave you.`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
 		var host cipher.PubKey
 		if len(args) == 1 {
 			if err := host.Set(args[0]); err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid host pk: %w", err))
 			}
-		}
-		rpcClient, err := clirpc.Client(cmd.Flags())
-		if err != nil {
-			internal.PrintFatalError(cmd.Flags(), err)
+		} else {
+			// No host given: the visor answers a zero PK as "self", but a
+			// zero cipher.PubKey cannot be gob-encoded over net/rpc (it
+			// fails with "Invalid public key"), so the request never
+			// reaches that branch. Resolve this visor's own PK up front
+			// and send it explicitly — same self-listing, valid on the wire.
+			ov, err := rpcClient.Overview()
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("resolve local visor pk: %w", err))
+			}
+			host = ov.PubKey
 		}
 		entries, truncated, err := rpcClient.GroupCatalog(host)
 		if err != nil {

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -63,7 +63,7 @@ func init() {
 	sendCmd.Flags().StringVarP(&message, "msg", "m", "", "message to send (required)")
 	sendCmd.Flags().StringVarP(&sendNet, "net", "n", "skynet", "network type: skynet or dmsg")
 	sendCmd.Flags().DurationVarP(&sendWait, "wait", "w", 5*time.Second, "wait for peer-receipt ack up to this duration (e.g. 5s, 30s); 0 disables wait and returns success on WriteFrame (fire-and-forget). Default 5s gives delivery confirmation.")
-	sendCmd.Flags().IntVarP(&sendRetries, "retries", "r", 1, "extra retry attempts on HTTP/transport failure (default 1). 0 disables retry. Each retry waits 200ms × attempt before retrying. Ack timeouts (peer-side failures with --wait) are NOT retried.")
+	sendCmd.Flags().IntVarP(&sendRetries, "retries", "r", 1, "extra retry attempts on HTTP/transport failure. 0 disables retry. Each retry waits 200ms × attempt before retrying. Ack timeouts (peer-side failures with --wait) are NOT retried.")
 	sendCmd.Flags().BoolVar(&sendVerbose, "verbose", false, "surface per-layer detail to stderr: POST request URL+payload, HTTP response status+headers, ack timing, /status counter deltas (outbound_msg_count / fail / retry / fallback). Use to debug send failures.")
 	sendCmd.Flags().StringVar(&sendVia, "via", "", "bypass local chat-app and dial the remote chat-app directly via noise-TCP: tcp://<pk>@host:port. Survives visor / dmsg outages. Use --sk / -c / DMSGCURL_SK for identity. When set, --to becomes optional (the PK in --via is used).")
 	sendCmd.Flags().StringVar(&tcpViaSK, "sk", "", "identity SK for --via tcp (hex). Overrides env + config.")

--- a/cmd/skywire-cli/commands/skychat/sendfile.go
+++ b/cmd/skywire-cli/commands/skychat/sendfile.go
@@ -32,7 +32,7 @@ var (
 
 var sendFileCmd = &cobra.Command{
 	Use:   "send-file <path>",
-	Short: "send a file to a peer (--to) or the active group (--group)",
+	Short: "Send a file to a peer (--to) or the active group (--group)",
 	Long: `Send a local file over skychat.
 
 The file streams peer-to-peer over an encrypted skywire transport (skynet or

--- a/cmd/skywire-cli/commands/skycoin/daemon.go
+++ b/cmd/skywire-cli/commands/skycoin/daemon.go
@@ -39,6 +39,18 @@ var daemonListCmd = &cobra.Command{
 		states, err := rpcClient.Apps()
 		internal.Catch(cmd.Flags(), err)
 
+		// daemonEntry is the --json / --jq shape: one row per daemon
+		// instance. Collected alongside the human table so scripted
+		// consumers get structured data instead of the empty object the
+		// prior `nil` argument produced.
+		type daemonEntry struct {
+			Name      string `json:"name"`
+			AutoStart bool   `json:"auto_start"`
+			Status    string `json:"status"`
+			FiberToml string `json:"fiber_toml"`
+		}
+		entries := []daemonEntry{}
+
 		var b bytes.Buffer
 		w := tabwriter.NewWriter(&b, 0, 0, 5, ' ', tabwriter.TabIndent)
 		_, _ = fmt.Fprintln(w, "name\tauto_start\tstatus\tfiber_toml") //nolint:errcheck
@@ -59,10 +71,11 @@ var daemonListCmd = &cobra.Command{
 			if fiber == "" {
 				fiber = "(skycoin defaults)"
 			}
+			entries = append(entries, daemonEntry{Name: s.Name, AutoStart: s.AutoStart, Status: status, FiberToml: fiber})
 			_, _ = fmt.Fprintf(w, "%s\t%t\t%s\t%s\n", s.Name, s.AutoStart, status, fiber) //nolint:errcheck
 		}
 		_ = w.Flush() //nolint:errcheck
-		internal.PrintOutput(cmd.Flags(), nil, b.String())
+		internal.PrintOutput(cmd.Flags(), entries, b.String())
 	},
 }
 


### PR DESCRIPTION
Audit + fixes across the **skychat / skycoin / mail** CLI command groups
(`cmd/skywire-cli/commands/{skychat,skycoin,mail}/`). Strictly backward
compatible — no flag renames, no output-shape changes for existing `--json`
consumers.

## Fixes
- **`skycoin daemon list --json`**: previously passed `nil` to
  `PrintOutput`, so `--json`/`--jq` emitted an empty object. Now collects the
  daemon rows and emits an array of `{name,auto_start,status,fiber_toml}`.
- **`skychat group catalog`** (no host arg): the documented "omit the key to
  see your own listing" form errored with `Invalid public key`. A zero
  `cipher.PubKey` cannot be gob-encoded over net/rpc, so the visor's
  zero-PK-means-self branch was never reached. The CLI now resolves the local
  visor's own PK via `Overview()` and sends it explicitly.
- **`skychat send-file`**: capitalized the `Short` description for consistency
  with every other subcommand.
- **`skychat send`**: removed the redundant `(default 1)` embedded in the
  `--retries` help text (cobra already appends the default, so it rendered
  twice).

## Verification
Built and run against a live visor:
- `skycoin daemon list --json` → proper JSON array; `--jq '.[].name'` works.
- `skychat group catalog` (no arg) → `nothing published` (self listing)
  instead of `Invalid public key`.
- Error paths for send/history/status/listen/pair/group/voice/mail confirmed
  to fail cleanly (no crashes) with clear messages.

## Follow-ups (not in this PR)
- Several hand-rolled-`--json` commands (`alias ls`, `history`, `status`,
  `listen`, `pair list/poll`, `group history/listen`) ignore the global
  `--jq`/`--shape` because they marshal their own shape rather than routing
  through `internal.PrintOutput`. Converging them risks changing established
  output shapes, so it's left as a separate change.