### PR TITLE
feat(router): parallel candidate route-group setup (steady-connection fix)

### DIFF
--- a/pkg/router/parallel_route_config.go
+++ b/pkg/router/parallel_route_config.go
@@ -1,0 +1,102 @@
+// Package router pkg/router/parallel_route_config.go c2-net-routing
+//
+// This file holds the pieces of the parallel-route-setup feature that must
+// compile for EVERY build target (including the plain-tinygo edge whose
+// router.go still calls newSuspectHopCache and whose SetDefaults reads the
+// K bounds): the config bounds and the minimal suspect-hop penalty cache. The
+// race machinery itself (which references the route-setup dialer, NoiseRouteGroup,
+// route-finder, etc.) lives in parallel_route_setup.go behind the non-tinygo
+// build tag. Keep this file free of route-setup-only symbols.
+package router
+
+import (
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+const (
+	// defaultParallelRouteSetup is the number of candidate route groups
+	// DialRoutes races per attempt when routing.parallel_route_setup is
+	// unset. Small on purpose: a few concurrent reservations are enough to
+	// route around the odd dead intermediate without fanning the setup load
+	// out across the whole candidate set.
+	defaultParallelRouteSetup = 3
+	// maxParallelRouteSetup bounds the fan-out so a misconfigured value can't
+	// flood the route-setup control plane with concurrent reservations.
+	maxParallelRouteSetup = 5
+)
+
+// suspectHopCache is a lightweight, self-contained penalty cache: an
+// intermediate PK that just lost a route-setup race — or failed setup on the
+// handshake-timeout OR ctx-deadline / setup-canceled path — is marked
+// "suspect" for a short TTL so the NEXT dial deprioritizes routes through it,
+// front-loading known-good hops.
+//
+// It is intentionally minimal and GLOBAL (per-intermediate, TTL-bounded).
+// Companion PR #4063 (branch fix/router-suspect-hop-failover, file
+// pkg/router/suspect_hops.go) adds a richer PER-DESTINATION TTL suspect cache
+// keyed off handshakeAwaitTimeout. This cache is structured to compose with —
+// or be superseded by — that one: the router holds a single `suspects` field,
+// and the arm points (raceCandidateSetup's onLoser, and DialRoutes' failure
+// paths incl. ctx-deadline) are the only call sites. To reconcile with #4063,
+// point those call sites at its cache (add the destination PK) and delete this
+// cache. Arming on the ctx-deadline path is deliberate: that is the path #4063
+// alone did not fire on live, which is why a dead hop kept being re-picked.
+type suspectHopCache struct {
+	mu  sync.Mutex
+	ttl time.Duration
+	m   map[cipher.PubKey]time.Time // intermediate PK -> penalized-until
+}
+
+func newSuspectHopCache(ttl time.Duration) *suspectHopCache {
+	if ttl <= 0 {
+		ttl = handshakeAwaitTimeout
+	}
+	return &suspectHopCache{ttl: ttl, m: make(map[cipher.PubKey]time.Time)}
+}
+
+// arm marks a single intermediate PK suspect until now+ttl.
+func (c *suspectHopCache) arm(pk cipher.PubKey) {
+	if c == nil || pk.Null() {
+		return
+	}
+	c.mu.Lock()
+	c.m[pk] = time.Now().Add(c.ttl)
+	c.mu.Unlock()
+}
+
+// armAll marks every PK in pks suspect. No-op on nil/empty.
+func (c *suspectHopCache) armAll(pks []cipher.PubKey) {
+	if c == nil || len(pks) == 0 {
+		return
+	}
+	until := time.Now().Add(c.ttl)
+	c.mu.Lock()
+	for _, pk := range pks {
+		if !pk.Null() {
+			c.m[pk] = until
+		}
+	}
+	c.mu.Unlock()
+}
+
+// isSuspect reports whether pk is currently penalized (and lazily evicts it
+// once its TTL has passed so the map does not grow unbounded).
+func (c *suspectHopCache) isSuspect(pk cipher.PubKey, now time.Time) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	until, ok := c.m[pk]
+	if !ok {
+		return false
+	}
+	if now.After(until) {
+		delete(c.m, pk)
+		return false
+	}
+	return true
+}

--- a/pkg/router/parallel_route_setup.go
+++ b/pkg/router/parallel_route_setup.go
@@ -1,0 +1,409 @@
+//go:build !tinygo || (js && wasm)
+
+// Package router pkg/router/parallel_route_setup.go c2-net-routing
+//
+// parallel_route_setup.go implements PARALLEL candidate route-group setup:
+// the steady-connection fix. Instead of the old one-candidate-at-a-time
+// retry loop — where every dead / non-forwarding candidate burned the full
+// handshakeAwaitTimeout (~10s) before the next was tried, so a run of bad
+// candidates could burn the whole ~90s dial ceiling and wedge the app in
+// "starting" — DialRoutes now sets up the top-K candidate routes CONCURRENTLY
+// and the FIRST to complete its reciprocal handshake WINS and becomes the
+// working route. Losing / failed candidates are canceled, torn down, and
+// their intermediate hops marked suspect for a short TTL so the NEXT dial
+// front-loads known-good hops.
+//
+// Data-model constraint (why the two phases below): incoming handshake / data
+// packets are demuxed to a route group by RouteDescriptor (see
+// dispatchToRouteGroup), and every candidate of one dial shares the SAME
+// descriptor (same src/dst/ports). The router therefore holds at most ONE raw
+// route group per descriptor (r.rgsRaw[desc]), so two candidates cannot run
+// their reciprocal handshakes concurrently — the second would collide on the
+// descriptor. The race is consequently two-phase:
+//
+//	phase 1 (CONCURRENT): dial/reserve route IDs across every candidate's hops.
+//	    This is where an unreachable intermediate fails id_reservation and loses
+//	    the race cheaply, instead of blocking the whole dial. This is the
+//	    dominant live failure mode (dead/non-forwarding intermediate).
+//	phase 2 (SERIAL, fastest-reservation-first): complete the reciprocal
+//	    handshake on reserved candidates; the FIRST to complete wins and is
+//	    returned immediately (it is the never-dropped working base — additional
+//	    mux legs grow on top later and must never unseat it). Because the
+//	    candidates are already reserved, walking to the next one on a handshake
+//	    failure costs no re-fetch and no re-reservation — unlike the old loop.
+package router
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/rfclient"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// suspectHopPenaltyMs is the per-suspect-intermediate cost added to a
+// candidate path's latency score when ranking, so a path through a hop that
+// just lost / failed a setup race sorts BELOW any clean path (2x the
+// unknown-latency cost). Soft, not a hard exclude: if every candidate touches
+// a suspect, the least-bad one is still tried — the goal is to converge to
+// SOME working route, never to wedge.
+const suspectHopPenaltyMs = 2000.0
+
+// suspectCount returns how many INTERMEDIATE hops of a forward path are
+// currently suspect. Endpoints (src/dst) are never counted.
+func (c *suspectHopCache) suspectCount(path []routing.Hop, src, dst cipher.PubKey, now time.Time) int {
+	if c == nil || len(path) == 0 {
+		return 0
+	}
+	n := 0
+	for _, pk := range intermediatePKsOfPath(path, src, dst) {
+		if c.isSuspect(pk, now) {
+			n++
+		}
+	}
+	return n
+}
+
+// effectiveParallelK resolves the number of candidates to race for a dial:
+// the per-call opts override if > 0, else the visor config, clamped to
+// [1, maxParallelRouteSetup]. 1 means strictly-sequential setup.
+func (r *router) effectiveParallelK(opts *DialOptions) int {
+	k := 0
+	if opts != nil && opts.ParallelRouteSetup > 0 {
+		k = opts.ParallelRouteSetup
+	} else if r.conf != nil {
+		k = r.conf.ParallelRouteSetup
+	}
+	if k <= 0 {
+		k = 1
+	}
+	if k > maxParallelRouteSetup {
+		k = maxParallelRouteSetup
+	}
+	return k
+}
+
+// hasRouteSelectingHook reports whether an operator routing policy explicitly
+// selects the route (RouteSelectingHook). When it does, the race is skipped:
+// the policy picks a specific candidate, so racing several would defeat the
+// operator's choice. The dial falls back to the sequential selecting path.
+func (r *router) hasRouteSelectingHook() bool {
+	if r.conf == nil || r.conf.DialHook == nil {
+		return false
+	}
+	_, ok := r.conf.DialHook.(RouteSelectingHook)
+	return ok
+}
+
+// candidateOutcome is one candidate's phase-1 (dial/reserve) result.
+type candidateOutcome struct {
+	idx   int
+	rules routing.EdgeRules
+	node  cipher.PubKey // connected setup node (for ReorderSetupNodes); may be null
+	err   error
+}
+
+// dialFn reserves route IDs across one candidate's hops (phase 1, concurrent).
+type dialFn func(ctx context.Context, cand routing.BidirectionalRoute) (routing.EdgeRules, cipher.PubKey, error)
+
+// handshakeFn installs local rules and completes the reciprocal handshake for
+// one reserved candidate (phase 2, serial). On failure it must leave no local
+// rules/route-group behind.
+type handshakeFn func(ctx context.Context, cand routing.BidirectionalRoute, rules routing.EdgeRules) (*NoiseRouteGroup, error)
+
+// raceCandidateSetup runs the two-phase concurrent race described in the file
+// header. It returns the winning route group, its installed rules, and the
+// winning candidate index. onLoser is invoked for every candidate that fails
+// its reservation OR its handshake (used to arm the suspect penalty); it is
+// NOT invoked for the winner.
+//
+// Guarantees:
+//   - first candidate to complete its handshake wins and is returned at once;
+//   - remaining in-flight reservations are canceled via a child context, so no
+//     goroutine leaks (the result channel is buffered to len(candidates));
+//   - losers install no local rules (un-tried reservations are never saved;
+//     tried-but-failed handshakes clean up inside handshake). Orphaned REMOTE
+//     reservations expire via the remote visors' rule GC, exactly as failed
+//     candidates in the legacy sequential loop did.
+func (r *router) raceCandidateSetup(
+	ctx context.Context,
+	log *logging.Logger,
+	candidates []routing.BidirectionalRoute,
+	dial dialFn,
+	handshake handshakeFn,
+	onLoser func(cand routing.BidirectionalRoute),
+) (*NoiseRouteGroup, routing.EdgeRules, int, error) {
+	if log == nil {
+		log = r.logger
+	}
+	if len(candidates) == 0 {
+		return nil, routing.EdgeRules{}, -1, ErrNoRouteFound
+	}
+
+	raceCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	ch := make(chan candidateOutcome, len(candidates))
+	for i, c := range candidates {
+		go func(i int, c routing.BidirectionalRoute) {
+			rules, node, err := dial(raceCtx, c)
+			ch <- candidateOutcome{idx: i, rules: rules, node: node, err: err}
+		}(i, c)
+	}
+
+	pending := len(candidates)
+	var lastErr error
+	for pending > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, routing.EdgeRules{}, -1, ctx.Err()
+		case out := <-ch:
+			pending--
+			if out.err != nil {
+				lastErr = out.err
+				// A dead/unreachable reservation: penalize its intermediates
+				// so the next dial routes around them, then let a healthier
+				// candidate carry the race.
+				if onLoser != nil {
+					onLoser(candidates[out.idx])
+				}
+				continue
+			}
+			// Reservation succeeded. Prioritize the setup node that worked for
+			// the next dial (same as the sequential path).
+			if !out.node.Null() {
+				r.conf.SetupNodes = ReorderSetupNodes(r.conf.SetupNodes, out.node)
+			}
+			// Serial handshake stage (shared descriptor forbids concurrency).
+			nrg, herr := handshake(ctx, candidates[out.idx], out.rules)
+			if herr != nil {
+				lastErr = herr
+				if onLoser != nil {
+					onLoser(candidates[out.idx])
+				}
+				// If the parent dial ctx died, stop — the whole dial is done.
+				if ctx.Err() != nil {
+					return nil, routing.EdgeRules{}, -1, ctx.Err()
+				}
+				log.WithError(herr).Debugf("raced candidate %d failed handshake; trying next reserved candidate", out.idx)
+				continue
+			}
+			// WINNER. Cancel remaining in-flight reservations and return the
+			// working route immediately.
+			cancel()
+			log.Debugf("raced candidate %d won route setup (of %d)", out.idx, len(candidates))
+			return nrg, out.rules, out.idx, nil
+		}
+	}
+	if lastErr == nil {
+		lastErr = ErrNoRouteFound
+	}
+	return nil, routing.EdgeRules{}, -1, lastErr
+}
+
+// fetchCandidateRoutes queries the route finder ONCE and extracts up to k
+// candidate bidirectional routes for the race, ranked by (suspect-penalized)
+// latency and preferring pairwise intermediate-disjoint candidates. It is a
+// best-effort helper: on a finder error, or when fewer than 2 candidates can
+// be assembled, it returns what it has (possibly nil) and the caller falls
+// back to the full sequential fetchBestRoutes path (which has the local-calc
+// fallback and retry machinery). It intentionally does NOT reimplement that
+// machinery — the sequential path remains the source of truth for the hard
+// cases.
+//
+// It respects opts.ExcludeIntermediatePKs (hard) and the visor min-hops /
+// per-direction / mux constraints exactly as fetchBestRoutes does, and applies
+// the same DMSG-multihop rejection.
+func (r *router) fetchCandidateRoutes(
+	ctx context.Context,
+	log *logging.Logger,
+	src, dst cipher.PubKey,
+	opts *DialOptions,
+	baseMinHops uint16,
+	keepAlive time.Duration,
+	desc routing.RouteDescriptor,
+	k int,
+) ([]routing.BidirectionalRoute, error) {
+	if log == nil {
+		log = r.logger
+	}
+	if opts == nil {
+		opts = DefaultDialOptions() // nolint
+	}
+	if k < 1 {
+		k = 1
+	}
+
+	forward := [2]cipher.PubKey{src, dst}
+	backward := [2]cipher.PubKey{dst, src}
+
+	fwdEff := opts.EffectiveMinHops(true)
+	revEff := opts.EffectiveMinHops(false)
+	fwdMinHops := baseMinHops
+	revMinHops := baseMinHops
+	if fwdEff > 0 {
+		fwdMinHops = uint16(fwdEff) //nolint:gosec // CLI-bounded small values
+	}
+	if revEff > 0 {
+		revMinHops = uint16(revEff) //nolint:gosec // CLI-bounded small values
+	}
+
+	// Request enough candidates to actually have K to race — the mux degree
+	// OR k + headroom, whichever is larger.
+	num := findRouteNum(opts.EffectiveMuxRoutes(true))
+	if rn := findRouteNum(opts.EffectiveMuxRoutes(false)); rn > num {
+		num = rn
+	}
+	wantK := uint16(k + muxRouteHeadroom) //nolint:gosec // k is clamped small
+	if wantK > num {
+		num = wantK
+	}
+	if num < baseRouteCandidates {
+		num = baseRouteCandidates
+	}
+
+	var paths map[routing.PathEdges][][]routing.Hop
+	var err error
+	if fwdMinHops == revMinHops {
+		paths, err = r.conf.RouteFinder.FindRoutes(ctx, []routing.PathEdges{forward, backward},
+			&rfclient.RouteOptions{MinHops: fwdMinHops, MaxHops: r.conf.MaxHops, NumRoutes: num})
+	} else {
+		var fwdPaths, revPaths map[routing.PathEdges][][]routing.Hop
+		fwdPaths, err = r.conf.RouteFinder.FindRoutes(ctx, []routing.PathEdges{forward},
+			&rfclient.RouteOptions{MinHops: fwdMinHops, MaxHops: r.conf.MaxHops, NumRoutes: num})
+		if err == nil {
+			revPaths, err = r.conf.RouteFinder.FindRoutes(ctx, []routing.PathEdges{backward},
+				&rfclient.RouteOptions{MinHops: revMinHops, MaxHops: r.conf.MaxHops, NumRoutes: num})
+		}
+		if err == nil {
+			paths = make(map[routing.PathEdges][][]routing.Hop, 2)
+			for kk, v := range fwdPaths {
+				paths[kk] = v
+			}
+			for kk, v := range revPaths {
+				paths[kk] = v
+			}
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	latencyFor, typeFor, throughputFor := r.buildHopLookups(ctx, paths[forward], paths[backward])
+	fwdCands := rejectDMSGMultihop(paths[forward], typeFor)
+	revCands := rejectDMSGMultihop(paths[backward], typeFor)
+
+	fwdRanked := r.rankCandidatePaths(fwdCands, src, dst, opts.ExcludeIntermediatePKs, latencyFor, typeFor, throughputFor, k)
+	revRanked := r.rankCandidatePaths(revCands, dst, src, opts.ExcludeIntermediatePKs, latencyFor, typeFor, throughputFor, k)
+	if len(fwdRanked) == 0 || len(revRanked) == 0 {
+		return nil, ErrNoRouteFound
+	}
+
+	// Zip forward[i] with reverse[i]; reuse the best reverse when the reverse
+	// direction returned fewer candidates. Each pair is a distinct candidate
+	// route group to race.
+	n := len(fwdRanked)
+	out := make([]routing.BidirectionalRoute, 0, n)
+	for i := 0; i < n; i++ {
+		rev := revRanked[i%len(revRanked)]
+		out = append(out, routing.BidirectionalRoute{
+			Desc:      desc,
+			KeepAlive: keepAlive,
+			Forward:   fwdRanked[i],
+			Reverse:   rev,
+		})
+	}
+	log.Debugf("assembled %d race candidate(s) to %s (requested k=%d)", len(out), dst, k)
+	return out, nil
+}
+
+// rankCandidatePaths filters, scores, and returns up to k candidate paths for
+// ONE direction. Endpoints for the direction are (from, to). Hard-excluded
+// intermediates (opts.ExcludeIntermediatePKs) are dropped. Remaining paths are
+// scored by summed per-hop latency PLUS a penalty per currently-suspect
+// intermediate, then the lowest-scoring are taken — preferring paths that are
+// pairwise intermediate-disjoint from those already chosen, and filling with
+// the next-best (possibly overlapping) paths if fewer than k disjoint ones
+// exist (more candidates => better odds of converging to a working route).
+func (r *router) rankCandidatePaths(
+	paths [][]routing.Hop,
+	from, to cipher.PubKey,
+	hardExclude []cipher.PubKey,
+	latencyFor func(uuid.UUID) float64,
+	typeFor func(uuid.UUID) string,
+	throughputFor func(uuid.UUID) float64,
+	k int,
+) [][]routing.Hop {
+	if len(paths) == 0 || k < 1 {
+		return nil
+	}
+	excludeSet := make(map[cipher.PubKey]struct{}, len(hardExclude))
+	for _, pk := range hardExclude {
+		excludeSet[pk] = struct{}{}
+	}
+	now := time.Now()
+
+	type scored struct {
+		path  []routing.Hop
+		score float64
+	}
+	acc := make([]scored, 0, len(paths))
+	for _, p := range paths {
+		if pathTouchesIntermediate(p, excludeSet) {
+			continue
+		}
+		s := pathLatencyScore(p, latencyFor, typeFor, throughputFor)
+		s += float64(r.suspects.suspectCount(p, from, to, now)) * suspectHopPenaltyMs
+		acc = append(acc, scored{path: p, score: s})
+	}
+	if len(acc) == 0 {
+		return nil
+	}
+	// Stable sort by ascending score.
+	for i := 1; i < len(acc); i++ {
+		for j := i; j > 0 && acc[j].score < acc[j-1].score; j-- {
+			acc[j], acc[j-1] = acc[j-1], acc[j]
+		}
+	}
+
+	out := make([][]routing.Hop, 0, k)
+	used := make(map[cipher.PubKey]struct{})
+	taken := make([]bool, len(acc))
+	// Pass 1: greedily take disjoint candidates.
+	for i := range acc {
+		if len(out) >= k {
+			break
+		}
+		inter := intermediatePKsOfPath(acc[i].path, from, to)
+		overlap := false
+		for _, pk := range inter {
+			if _, hit := used[pk]; hit {
+				overlap = true
+				break
+			}
+		}
+		if overlap {
+			continue
+		}
+		out = append(out, acc[i].path)
+		taken[i] = true
+		for _, pk := range inter {
+			used[pk] = struct{}{}
+		}
+	}
+	// Pass 2: fill remaining slots with the next-best untaken candidates.
+	for i := range acc {
+		if len(out) >= k {
+			break
+		}
+		if taken[i] {
+			continue
+		}
+		out = append(out, acc[i].path)
+	}
+	return out
+}

--- a/pkg/router/parallel_route_setup_test.go
+++ b/pkg/router/parallel_route_setup_test.go
@@ -1,0 +1,337 @@
+// parallel_route_setup_test.go — unit tests for the PARALLEL candidate
+// route-group setup (the steady-connection fix). These cover the pure /
+// injectable pieces so the race logic is verified without standing up real
+// transports or a peer visor:
+//
+//   - raceCandidateSetup: winner selection (first handshake to complete wins),
+//     handshake-failure fall-through to the next reserved candidate, loser
+//     penalty arming, all-fail, and K=1 single-candidate (sequential-equivalent).
+//   - suspectHopCache: arm / isSuspect / TTL eviction / suspectCount.
+//   - effectiveParallelK: opts override, config default, clamping.
+//   - rankCandidatePaths: suspect deprioritization + disjoint preference.
+package router
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// testRouter builds a minimal router sufficient for the injectable race /
+// ranking helpers (no transports, no dmsg).
+func testRouter() *router {
+	return &router{
+		conf:     &Config{},
+		logger:   logging.MustGetLogger("parallel_test"),
+		suspects: newSuspectHopCache(5 * time.Second),
+	}
+}
+
+// twoHop builds a forward path src -> mid -> dst so the intermediate is `mid`.
+func twoHop(src, mid, dst cipher.PubKey) []routing.Hop {
+	return []routing.Hop{
+		{TpID: uuid.New(), From: src, To: mid},
+		{TpID: uuid.New(), From: mid, To: dst},
+	}
+}
+
+func candidate(fwd []routing.Hop) routing.BidirectionalRoute {
+	return routing.BidirectionalRoute{Forward: fwd, Reverse: fwd}
+}
+
+// nullNode is returned by fake dials so raceCandidateSetup skips ReorderSetupNodes.
+var nullNode = cipher.PubKey{}
+
+func TestRaceCandidateSetup_FirstToCompleteWins(t *testing.T) {
+	r := testRouter()
+	src, dst := mustPK(t), mustPK(t)
+	// Three candidates; index 1 dials fastest and its handshake succeeds.
+	cands := []routing.BidirectionalRoute{
+		candidate(twoHop(src, mustPK(t), dst)),
+		candidate(twoHop(src, mustPK(t), dst)),
+		candidate(twoHop(src, mustPK(t), dst)),
+	}
+
+	winnerNRG := &NoiseRouteGroup{}
+	dial := func(ctx context.Context, c routing.BidirectionalRoute) (routing.EdgeRules, cipher.PubKey, error) {
+		// Candidate 1 returns immediately; the others are slow so candidate 1's
+		// reservation result is consumed first.
+		if !sameFwd(c.Forward, cands[1].Forward) {
+			select {
+			case <-ctx.Done():
+			case <-time.After(60 * time.Millisecond):
+			}
+		}
+		return routing.EdgeRules{}, nullNode, nil
+	}
+	handshake := func(ctx context.Context, c routing.BidirectionalRoute, _ routing.EdgeRules) (*NoiseRouteGroup, error) {
+		return winnerNRG, nil
+	}
+
+	nrg, _, winIdx, err := r.raceCandidateSetup(context.Background(), r.logger, cands, dial, handshake, nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if winIdx != 1 {
+		t.Fatalf("winIdx=%d, want 1 (fastest reservation)", winIdx)
+	}
+	if nrg != winnerNRG {
+		t.Fatalf("returned nrg is not the handshake winner")
+	}
+}
+
+func TestRaceCandidateSetup_HandshakeFailFallsThrough(t *testing.T) {
+	r := testRouter()
+	src, dst := mustPK(t), mustPK(t)
+	deadMid := mustPK(t)
+	goodMid := mustPK(t)
+	// Candidate 0 reserves fastest but its handshake FAILS (ACKed reservation,
+	// won't forward). Candidate 1 reserves slightly slower and succeeds.
+	cands := []routing.BidirectionalRoute{
+		candidate(twoHop(src, deadMid, dst)),
+		candidate(twoHop(src, goodMid, dst)),
+	}
+
+	dial := func(ctx context.Context, c routing.BidirectionalRoute) (routing.EdgeRules, cipher.PubKey, error) {
+		if sameFwd(c.Forward, cands[1].Forward) {
+			select {
+			case <-ctx.Done():
+			case <-time.After(40 * time.Millisecond):
+			}
+		}
+		return routing.EdgeRules{}, nullNode, nil
+	}
+	winnerNRG := &NoiseRouteGroup{}
+	handshake := func(ctx context.Context, c routing.BidirectionalRoute, _ routing.EdgeRules) (*NoiseRouteGroup, error) {
+		if sameFwd(c.Forward, cands[0].Forward) {
+			return nil, errors.New("handshake timeout: dead intermediate")
+		}
+		return winnerNRG, nil
+	}
+
+	var mu sync.Mutex
+	var lost []cipher.PubKey
+	onLoser := func(c routing.BidirectionalRoute) {
+		// Mirror the production onLoser: arm suspects + record for assertion.
+		r.suspects.armAll(intermediatePKsOfPath(c.Forward, src, dst))
+		mu.Lock()
+		lost = append(lost, intermediatePKsOfPath(c.Forward, src, dst)...)
+		mu.Unlock()
+	}
+
+	nrg, _, winIdx, err := r.raceCandidateSetup(context.Background(), r.logger, cands, dial, handshake, onLoser)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if winIdx != 1 || nrg != winnerNRG {
+		t.Fatalf("winIdx=%d nrg=%p, want winIdx=1 with winner nrg", winIdx, nrg)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(lost) != 1 || lost[0] != deadMid {
+		t.Fatalf("onLoser intermediates=%v, want exactly [deadMid]", lost)
+	}
+	// The dead intermediate must now be suspect for the next dial.
+	if !r.suspects.isSuspect(deadMid, time.Now()) {
+		t.Fatalf("deadMid not armed suspect after handshake failure")
+	}
+}
+
+func TestRaceCandidateSetup_AllFail(t *testing.T) {
+	r := testRouter()
+	src, dst := mustPK(t), mustPK(t)
+	cands := []routing.BidirectionalRoute{
+		candidate(twoHop(src, mustPK(t), dst)),
+		candidate(twoHop(src, mustPK(t), dst)),
+	}
+	dialErr := errors.New("reserve failed: unreachable")
+	dial := func(ctx context.Context, c routing.BidirectionalRoute) (routing.EdgeRules, cipher.PubKey, error) {
+		return routing.EdgeRules{}, nullNode, dialErr
+	}
+	handshake := func(ctx context.Context, c routing.BidirectionalRoute, _ routing.EdgeRules) (*NoiseRouteGroup, error) {
+		t.Error("handshake must not run when every reservation fails")
+		return nil, nil
+	}
+	var losers int
+	var mu sync.Mutex
+	onLoser := func(c routing.BidirectionalRoute) { mu.Lock(); losers++; mu.Unlock() }
+
+	nrg, _, winIdx, err := r.raceCandidateSetup(context.Background(), r.logger, cands, dial, handshake, onLoser)
+	if err == nil {
+		t.Fatal("want error when all candidates fail, got nil")
+	}
+	if nrg != nil || winIdx != -1 {
+		t.Fatalf("nrg=%p winIdx=%d, want nil/-1", nrg, winIdx)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if losers != len(cands) {
+		t.Fatalf("onLoser called %d times, want %d", losers, len(cands))
+	}
+}
+
+func TestRaceCandidateSetup_SingleCandidateSequentialEquivalent(t *testing.T) {
+	// K resolving to 1 candidate must behave exactly like the sequential path:
+	// one dial, one handshake, that candidate is the winner.
+	r := testRouter()
+	src, dst := mustPK(t), mustPK(t)
+	cands := []routing.BidirectionalRoute{candidate(twoHop(src, mustPK(t), dst))}
+
+	var dials, handshakes int
+	dial := func(ctx context.Context, c routing.BidirectionalRoute) (routing.EdgeRules, cipher.PubKey, error) {
+		dials++
+		return routing.EdgeRules{}, nullNode, nil
+	}
+	win := &NoiseRouteGroup{}
+	handshake := func(ctx context.Context, c routing.BidirectionalRoute, _ routing.EdgeRules) (*NoiseRouteGroup, error) {
+		handshakes++
+		return win, nil
+	}
+	nrg, _, winIdx, err := r.raceCandidateSetup(context.Background(), r.logger, cands, dial, handshake, nil)
+	if err != nil || winIdx != 0 || nrg != win {
+		t.Fatalf("single-candidate race: nrg=%p winIdx=%d err=%v", nrg, winIdx, err)
+	}
+	if dials != 1 || handshakes != 1 {
+		t.Fatalf("dials=%d handshakes=%d, want 1/1 (sequential-equivalent)", dials, handshakes)
+	}
+}
+
+func TestRaceCandidateSetup_CtxCanceled(t *testing.T) {
+	r := testRouter()
+	src, dst := mustPK(t), mustPK(t)
+	cands := []routing.BidirectionalRoute{candidate(twoHop(src, mustPK(t), dst))}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	dial := func(ctx context.Context, c routing.BidirectionalRoute) (routing.EdgeRules, cipher.PubKey, error) {
+		<-ctx.Done()
+		return routing.EdgeRules{}, nullNode, ctx.Err()
+	}
+	handshake := func(ctx context.Context, c routing.BidirectionalRoute, _ routing.EdgeRules) (*NoiseRouteGroup, error) {
+		return &NoiseRouteGroup{}, nil
+	}
+	_, _, _, err := r.raceCandidateSetup(ctx, r.logger, cands, dial, handshake, nil)
+	if err == nil {
+		t.Fatal("want ctx error, got nil")
+	}
+}
+
+func TestEffectiveParallelK(t *testing.T) {
+	r := testRouter()
+	r.conf.ParallelRouteSetup = 3
+
+	if got := r.effectiveParallelK(nil); got != 3 {
+		t.Errorf("nil opts: k=%d, want 3 (config)", got)
+	}
+	if got := r.effectiveParallelK(&DialOptions{ParallelRouteSetup: 1}); got != 1 {
+		t.Errorf("opts override 1: k=%d, want 1", got)
+	}
+	if got := r.effectiveParallelK(&DialOptions{ParallelRouteSetup: 99}); got != maxParallelRouteSetup {
+		t.Errorf("opts override 99: k=%d, want clamp %d", got, maxParallelRouteSetup)
+	}
+	r.conf.ParallelRouteSetup = 0
+	if got := r.effectiveParallelK(nil); got != 1 {
+		t.Errorf("unset config: k=%d, want 1 (safe default at read time)", got)
+	}
+}
+
+func TestSuspectHopCache(t *testing.T) {
+	c := newSuspectHopCache(30 * time.Millisecond)
+	pk := cipher.PubKey{1, 2, 3}
+	if c.isSuspect(pk, time.Now()) {
+		t.Fatal("fresh cache reports suspect")
+	}
+	c.arm(pk)
+	if !c.isSuspect(pk, time.Now()) {
+		t.Fatal("armed pk not suspect")
+	}
+	// TTL eviction.
+	if c.isSuspect(pk, time.Now().Add(time.Second)) {
+		t.Fatal("pk still suspect past TTL")
+	}
+	// Null PK is a no-op.
+	c.arm(cipher.PubKey{})
+	if c.isSuspect(cipher.PubKey{}, time.Now()) {
+		t.Fatal("null pk should never be suspect")
+	}
+}
+
+func TestSuspectCount(t *testing.T) {
+	c := newSuspectHopCache(time.Minute)
+	src, mid, dst := cipher.PubKey{1}, cipher.PubKey{2}, cipher.PubKey{3}
+	path := twoHop(src, mid, dst)
+	if n := c.suspectCount(path, src, dst, time.Now()); n != 0 {
+		t.Fatalf("no suspects: count=%d, want 0", n)
+	}
+	c.arm(mid)
+	if n := c.suspectCount(path, src, dst, time.Now()); n != 1 {
+		t.Fatalf("armed mid: count=%d, want 1", n)
+	}
+}
+
+func TestRankCandidatePaths_SuspectDeprioritized(t *testing.T) {
+	r := testRouter()
+	src, dst := cipher.PubKey{9}, cipher.PubKey{10}
+	suspectMid := cipher.PubKey{1}
+	goodMid := cipher.PubKey{2}
+	suspectPath := twoHop(src, suspectMid, dst)
+	goodPath := twoHop(src, goodMid, dst)
+	r.suspects.arm(suspectMid)
+
+	latency := func(uuid.UUID) float64 { return 0 } // all unknown => equal base score
+	// Present the suspect path FIRST; ranking must still float the good one up.
+	out := r.rankCandidatePaths([][]routing.Hop{suspectPath, goodPath}, src, dst, nil, latency, nil, nil, 2)
+	if len(out) != 2 {
+		t.Fatalf("got %d candidates, want 2", len(out))
+	}
+	if !sameFwd(out[0], goodPath) {
+		t.Fatalf("first candidate is not the non-suspect path")
+	}
+}
+
+func TestRankCandidatePaths_HardExcludeAndDisjoint(t *testing.T) {
+	r := testRouter()
+	src, dst := cipher.PubKey{9}, cipher.PubKey{10}
+	excl := cipher.PubKey{1}
+	a := cipher.PubKey{2}
+	b := cipher.PubKey{3}
+	exclPath := twoHop(src, excl, dst)
+	aPath := twoHop(src, a, dst)
+	bPath := twoHop(src, b, dst)
+	latency := func(uuid.UUID) float64 { return 100 }
+
+	out := r.rankCandidatePaths([][]routing.Hop{exclPath, aPath, bPath}, src, dst,
+		[]cipher.PubKey{excl}, latency, nil, nil, 3)
+	// Excluded path dropped; two disjoint candidates remain.
+	if len(out) != 2 {
+		t.Fatalf("got %d, want 2 (excluded dropped)", len(out))
+	}
+	for _, p := range out {
+		for _, ipk := range intermediatePKsOfPath(p, src, dst) {
+			if ipk == excl {
+				t.Fatalf("hard-excluded intermediate present in ranked output")
+			}
+		}
+	}
+}
+
+// sameFwd reports whether two forward paths share the same intermediate PK
+// sequence (TpIDs are random per construction, so compare by From/To edges).
+func sameFwd(a, b []routing.Hop) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].From != b[i].From || a[i].To != b[i].To {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -146,6 +146,27 @@ type Config struct {
 	// (~20s worst-case) transport dial first. Set true to restore the legacy
 	// synchronous behavior (create-transport-then-route) as a safety valve.
 	DisableRaceRouteSetup bool
+	// ParallelRouteSetup is the number of candidate route groups whose
+	// reciprocal-handshake setup DialRoutes races CONCURRENTLY per dial
+	// attempt (top-K candidates the route-finder returned, ranked by
+	// latency/suspect-liveness). The FIRST candidate to complete its
+	// handshake WINS and immediately becomes the working route — the dial
+	// returns on it without waiting for a "better" one; the losers are
+	// canceled and torn down. This collapses establishment from "up to
+	// N×handshakeAwaitTimeout" (the old one-candidate-at-a-time retry loop,
+	// where every dead / non-forwarding candidate burned the full ~10s
+	// handshake await before the next was tried — up to the ~90s dial ceiling,
+	// leaving the app wedged in "starting") down to roughly one RTT. A dead-hop
+	// candidate simply loses the race instead of blocking the whole dial, so
+	// the app converges to a working route (single multihop at min_hops>=2,
+	// or direct at min_hops==1) instead of wedging.
+	//
+	// 1 = strictly-sequential behavior (a clean rollback switch). 0 (unset)
+	// is normalized to defaultParallelRouteSetup by SetDefaults; values above
+	// maxParallelRouteSetup are clamped. Losing / failed candidates' intermediate
+	// hops are marked suspect for a short TTL so the NEXT dial front-loads
+	// known-good hops (see suspectHopCache; composes with #4063).
+	ParallelRouteSetup int
 	// AwaitSetupListener, if non-nil, is used instead of opening a fresh
 	// listener on DmsgAwaitSetupPort. This lets callers reserve the port
 	// earlier in init (before the transport manager is ready) so peers
@@ -199,6 +220,15 @@ func (c *Config) SetDefaults() {
 
 	if c.MaxHops == 0 {
 		c.MaxHops = maxHops
+	}
+
+	// 0 (unset) => race the default number of candidates. An operator who
+	// wants the legacy strictly-sequential setup sets this to 1 explicitly.
+	if c.ParallelRouteSetup == 0 {
+		c.ParallelRouteSetup = defaultParallelRouteSetup
+	}
+	if c.ParallelRouteSetup > maxParallelRouteSetup {
+		c.ParallelRouteSetup = maxParallelRouteSetup
 	}
 }
 
@@ -266,6 +296,12 @@ type DialOptions struct {
 	// router's visor-wide muxMode default."
 	Distribution DistributionConfig
 	KeepAlive    time.Duration // Route keepalive (0 = DefaultRouteKeepAlive). Routes idle longer expire.
+	// ParallelRouteSetup, when > 0, overrides Config.ParallelRouteSetup
+	// for this dial only — the number of candidate route groups whose
+	// setup is raced concurrently (first to complete its handshake wins).
+	// 1 forces sequential setup for this dial; 0 inherits the visor
+	// config. See Config.ParallelRouteSetup.
+	ParallelRouteSetup int
 	// AppName is the originating app's name. Set by appnet's
 	// DialContextWithOptions when the caller threaded a context
 	// carrying it (RPCIngressGateway.Dial uses appnet.WithAppName).
@@ -545,6 +581,7 @@ type router struct {
 	lastRouteCalcTime time.Duration     // last route calculation time (for local routes)
 	lastRouteCalcMu   sync.Mutex        // protects lastRouteCalcTime
 	tpdCache          *tpdSnapshotCache // one-snapshot TTL cache of GetAllTransports, see tpd_cache.go
+	suspects          *suspectHopCache  // short-TTL penalty cache for intermediates that lost/failed a setup race (see parallel_route_setup.go)
 	// dstTpOracle fetches a destination visor's OWN transport list
 	// authoritatively from the destination (via an RSN-signed transport-query),
 	// for the RSN-oracle 2-hop route path (rsn_oracle_routes.go). nil by default
@@ -659,6 +696,7 @@ func New(dmsgC *dmsg.Client, config *Config, routeSetupHooks []RouteSetupHook) (
 		trustedVisors:   trustedVisors,
 		routeSetupHooks: routeSetupHooks,
 		tpdCache:        newTPDSnapshotCache(),
+		suspects:        newSuspectHopCache(handshakeAwaitTimeout),
 	}
 
 	go r.rulesGCLoop()

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -270,6 +270,81 @@ func (r *router) DialRoutes(
 	escalateToLegacy := false
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
+		// PARALLEL candidate route-group setup — the steady-connection fix.
+		// When configured (K>1) and this isn't the cold-start transport-
+		// creation race (hookDone==nil), local-route mode, or an operator
+		// route-selecting policy, fetch the top-K candidates in ONE finder
+		// query and race their setup concurrently. The FIRST candidate to
+		// complete its reciprocal handshake WINS and is returned immediately
+		// as the working base — a dead/non-forwarding candidate loses the race
+		// instead of burning the full handshake await and blocking the dial.
+		// On total race failure we exclude the raced intermediates (already
+		// marked suspect) and fall through to the sequential path this same
+		// attempt, which carries the local-calc fallback.
+		if K := r.effectiveParallelK(opts); K > 1 && hookDone == nil && !forceLocal && !r.hasRouteSelectingHook() {
+			keepAlive := DefaultRouteKeepAlive
+			if opts != nil && opts.KeepAlive > 0 {
+				keepAlive = opts.KeepAlive
+			}
+			candidates, ferr := r.fetchCandidateRoutes(ctx, log, lPK, rPK, opts, baseMinHops, keepAlive, forwardDesc, K)
+			if ferr == nil && len(candidates) >= 2 {
+				nsConf := noise.Config{
+					LocalPK:   r.conf.PubKey,
+					LocalSK:   r.conf.SecKey,
+					RemotePK:  rPK,
+					Initiator: true,
+				}
+				appName := ""
+				datagram := false
+				if opts != nil {
+					appName = opts.AppName
+					datagram = opts.Datagram
+				}
+				dial := func(dctx context.Context, c routing.BidirectionalRoute) (routing.EdgeRules, cipher.PubKey, error) {
+					return r.conf.RouteGroupDialer.Dial(dctx, log, r.dmsgC, r.conf.SetupNodes, c)
+				}
+				handshake := func(hctx context.Context, _ routing.BidirectionalRoute, rules routing.EdgeRules) (*NoiseRouteGroup, error) {
+					if err := r.SaveRoutingRules(rules.Forward, rules.Reverse); err != nil {
+						return nil, err
+					}
+					nrg, err := r.saveRouteGroupRules(hctx, rules, nsConf, appName, datagram)
+					if err != nil {
+						// Free the local key route IDs so the next candidate /
+						// attempt can reserve cleanly (mirrors the sequential path).
+						r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
+						return nil, err
+					}
+					return nrg, nil
+				}
+				onLoser := func(c routing.BidirectionalRoute) {
+					// Penalize the losing/failed candidate's intermediates so the
+					// NEXT dial front-loads known-good hops. Armed here for EVERY
+					// failure mode (reservation, handshake-timeout, ctx-deadline),
+					// which is the arming gap #4063 alone had.
+					r.suspects.armAll(intermediatePKsOfPath(c.Forward, lPK, rPK))
+				}
+				nrg, rules, winIdx, rerr := r.raceCandidateSetup(ctx, log, candidates, dial, handshake, onLoser)
+				if rerr == nil {
+					return r.finishDial(ctx, log, nrg, rules, candidates[winIdx].Forward, forwardDesc, opts, rPK, lPort, rPort), nil
+				}
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+				// Every raced candidate failed. Exclude their intermediates and
+				// fall through to the sequential path (fresh finder query +
+				// local-calc fallback) this same attempt.
+				for _, c := range candidates {
+					for _, ipk := range intermediatePKsOfPath(c.Forward, lPK, rPK) {
+						opts = appendExcludeIntermediate(opts, ipk)
+					}
+				}
+				log.WithError(rerr).Warnf("Parallel route setup: all %d candidate(s) failed (attempt %d/%d); excluding intermediates, falling back to sequential setup",
+					len(candidates), attempt, maxRetries)
+			}
+			// ferr != nil or <2 candidates: fall through to the sequential path,
+			// which has the full retry/local-calc machinery.
+		}
+
 		var forwardPath, reversePath []routing.Hop
 		var err error
 		if hookDone != nil {
@@ -492,100 +567,123 @@ func (r *router) DialRoutes(
 			return nil, fmt.Errorf("saveRouteGroupRules: %w", err)
 		}
 
-		// Store the complete forward route hops for later retrieval
-		nrg.SetForwardHops(forwardPath)
-
-		nrg.rg.startOffServiceLoops()
-
-		log.Debugf("Created new routes to %s on port %d", rPK, lPort)
-
-		// Establish additional mux routes if requested
-		r.establishMuxRoutes(ctx, nrg, opts, forwardDesc, rules.Forward.NextTransportID())
-
-		// Apply per-dial distribution policy (from a routing-
-		// policy script via DialAdjustment.Distribution, or a
-		// CLI caller populating DialOptions.Distribution
-		// directly). No-op when Mode is DistributionUnset.
-		// Must run AFTER establishMuxRoutes so the selector's
-		// rebuild sees every leg, not just the primary.
-		nrg.rg.applyDistribution(opts.Distribution)
-
-		// Wire the post-setup leg-change hook (RFC #2882 phase 6).
-		// The dial-side DialHook may also implement LegChangeHook;
-		// when it does, the route group fires on_leg_change
-		// callbacks whenever its leg set mutates after this point
-		// (additional aux legs from appendRouteToGroup, or
-		// transport-close pruning).
-		if lch, ok := r.conf.DialHook.(LegChangeHook); ok && lch != nil {
-			nrg.rg.SetLegChangeHook(lch, DialInfo{
-				AppName: opts.AppName,
-				PeerPK:  rPK,
-				LPort:   lPort,
-				RPort:   rPort,
-			})
-		}
-
-		// Add-leg callback for any multiplexed dial. It closes over the
-		// dial context + forwardDesc so a replacement leg matches the
-		// original dial shape (same peer, ports, min-hops, app). Used by
-		// BOTH the route group's self-healing (restore the degree in the
-		// background when a leg dies) AND the periodic rotation hook
-		// (policy on_tick / bandwidth-spreading, RFC #2882).
-		muxTarget := 1
-		if opts != nil {
-			if eff := opts.EffectiveMuxRoutes(true); eff > muxTarget {
-				muxTarget = eff
-			}
-			if eff := opts.EffectiveMuxRoutes(false); eff > muxTarget {
-				muxTarget = eff
-			}
-		}
-		if muxTarget > 1 {
-			optsCopy := *opts
-			fwdDescCopy := forwardDesc
-			nrgCapture := nrg
-			applyAdd := func(excludeHops []string) {
-				addCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-				defer cancel()
-				excludePKs := make([]cipher.PubKey, 0, len(excludeHops))
-				for _, h := range excludeHops {
-					var pk cipher.PubKey
-					if err := pk.Set(h); err == nil {
-						excludePKs = append(excludePKs, pk)
-					}
-				}
-				if err := r.addOneAuxForwardLeg(addCtx, nrgCapture, &optsCopy, fwdDescCopy, excludePKs); err != nil {
-					r.logger.WithError(err).Debug("Mux add-leg failed; route group keeps current leg set")
-				}
-			}
-			// Self-healing: any leg death triggers a background replacement
-			// dial to restore the requested degree, while surviving legs
-			// carry the traffic. General to every mux dial, not just ones
-			// with a rotation policy.
-			nrg.rg.SetSelfHeal(applyAdd, muxTarget)
-
-			// Top up an initial shortfall: establishMuxRoutes sets up aux
-			// legs best-effort, so a flaky intermediate can leave the group
-			// below the requested degree at dial time. Heal it now in the
-			// background (same mechanism as runtime leg death) — the dial
-			// still returns immediately on the legs that did establish.
-			nrg.rg.maybeSelfHeal()
-
-			// Periodic rotation (policy on_tick) reuses the same callback.
-			if rh, ok := r.conf.DialHook.(RotationHook); ok && rh != nil && opts.RotationIntervalSeconds > 0 {
-				interval := time.Duration(opts.RotationIntervalSeconds) * time.Second
-				nrg.rg.SetRotation(rh, applyAdd, interval)
-			}
-		}
-
-		// NOTE: no MinHops restore needed — baseMinHops is a local var now,
-		// r.conf.MinHops is never mutated by the dial path.
-
-		return nrg, nil
+		// The route group is up: this is the working base. Wire mux
+		// growth / self-heal / hooks on top and return.
+		return r.finishDial(ctx, log, nrg, rules, forwardPath, forwardDesc, opts, rPK, lPort, rPort), nil
 	}
 
 	// Should never reach here, but handle it gracefully
 	return nil, fmt.Errorf("failed to establish route after %d attempts", maxRetries)
+}
+
+// finishDial wires the post-setup machinery onto a freshly-established route
+// group (the never-dropped working base) and returns it as a net.Conn: stores
+// the forward hops, starts the service loops, grows any requested mux legs on
+// top (best-effort, in the background — they never unseat the base), applies
+// the per-dial distribution policy, and installs the leg-change / rotation /
+// self-heal hooks. Shared by the sequential setup path and the parallel race
+// winner so both converge to identical post-setup behavior.
+func (r *router) finishDial(
+	ctx context.Context,
+	log *logging.Logger,
+	nrg *NoiseRouteGroup,
+	rules routing.EdgeRules,
+	forwardPath []routing.Hop,
+	forwardDesc routing.RouteDescriptor,
+	opts *DialOptions,
+	rPK cipher.PubKey,
+	lPort, rPort routing.Port,
+) net.Conn {
+	// Store the complete forward route hops for later retrieval
+	nrg.SetForwardHops(forwardPath)
+
+	nrg.rg.startOffServiceLoops()
+
+	log.Debugf("Created new routes to %s on port %d", rPK, lPort)
+
+	// Establish additional mux routes if requested
+	r.establishMuxRoutes(ctx, nrg, opts, forwardDesc, rules.Forward.NextTransportID())
+
+	// Apply per-dial distribution policy (from a routing-
+	// policy script via DialAdjustment.Distribution, or a
+	// CLI caller populating DialOptions.Distribution
+	// directly). No-op when Mode is DistributionUnset.
+	// Must run AFTER establishMuxRoutes so the selector's
+	// rebuild sees every leg, not just the primary.
+	nrg.rg.applyDistribution(opts.Distribution)
+
+	// Wire the post-setup leg-change hook (RFC #2882 phase 6).
+	// The dial-side DialHook may also implement LegChangeHook;
+	// when it does, the route group fires on_leg_change
+	// callbacks whenever its leg set mutates after this point
+	// (additional aux legs from appendRouteToGroup, or
+	// transport-close pruning).
+	if lch, ok := r.conf.DialHook.(LegChangeHook); ok && lch != nil {
+		nrg.rg.SetLegChangeHook(lch, DialInfo{
+			AppName: opts.AppName,
+			PeerPK:  rPK,
+			LPort:   lPort,
+			RPort:   rPort,
+		})
+	}
+
+	// Add-leg callback for any multiplexed dial. It closes over the
+	// dial context + forwardDesc so a replacement leg matches the
+	// original dial shape (same peer, ports, min-hops, app). Used by
+	// BOTH the route group's self-healing (restore the degree in the
+	// background when a leg dies) AND the periodic rotation hook
+	// (policy on_tick / bandwidth-spreading, RFC #2882).
+	muxTarget := 1
+	if opts != nil {
+		if eff := opts.EffectiveMuxRoutes(true); eff > muxTarget {
+			muxTarget = eff
+		}
+		if eff := opts.EffectiveMuxRoutes(false); eff > muxTarget {
+			muxTarget = eff
+		}
+	}
+	if muxTarget > 1 {
+		optsCopy := *opts
+		fwdDescCopy := forwardDesc
+		nrgCapture := nrg
+		applyAdd := func(excludeHops []string) {
+			addCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			excludePKs := make([]cipher.PubKey, 0, len(excludeHops))
+			for _, h := range excludeHops {
+				var pk cipher.PubKey
+				if err := pk.Set(h); err == nil {
+					excludePKs = append(excludePKs, pk)
+				}
+			}
+			if err := r.addOneAuxForwardLeg(addCtx, nrgCapture, &optsCopy, fwdDescCopy, excludePKs); err != nil {
+				r.logger.WithError(err).Debug("Mux add-leg failed; route group keeps current leg set")
+			}
+		}
+		// Self-healing: any leg death triggers a background replacement
+		// dial to restore the requested degree, while surviving legs
+		// carry the traffic. General to every mux dial, not just ones
+		// with a rotation policy.
+		nrg.rg.SetSelfHeal(applyAdd, muxTarget)
+
+		// Top up an initial shortfall: establishMuxRoutes sets up aux
+		// legs best-effort, so a flaky intermediate can leave the group
+		// below the requested degree at dial time. Heal it now in the
+		// background (same mechanism as runtime leg death) — the dial
+		// still returns immediately on the legs that did establish.
+		nrg.rg.maybeSelfHeal()
+
+		// Periodic rotation (policy on_tick) reuses the same callback.
+		if rh, ok := r.conf.DialHook.(RotationHook); ok && rh != nil && opts.RotationIntervalSeconds > 0 {
+			interval := time.Duration(opts.RotationIntervalSeconds) * time.Second
+			nrg.rg.SetRotation(rh, applyAdd, interval)
+		}
+	}
+
+	// NOTE: no MinHops restore needed — baseMinHops is a local var now,
+	// r.conf.MinHops is never mutated by the dial path.
+
+	return nrg
 }
 
 // setupPingRoute sets up a ping route with the given forward and reverse paths.

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -291,6 +291,7 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 		SetupNodes:            v.conf.EffectiveRouteSetupNodes(),
 		MinHops:               v.conf.Routing.MinHops,
 		MuxRoutes:             v.conf.Routing.MuxRoutes,
+		ParallelRouteSetup:    v.conf.Routing.ParallelRouteSetup,
 		AwaitSetupListener:    v.awaitSetupListener,
 		Logger:                logger,
 		MasterLogger:          v.MasterLogger(),

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -629,6 +629,13 @@ type Routing struct {
 	// MuxRoutes is the number of parallel routes to establish per connection.
 	// 0 or 1 = single route (default), >1 = route multiplexing across transports.
 	MuxRoutes int `json:"mux_routes,omitempty"`
+	// ParallelRouteSetup is the number of candidate route groups whose setup
+	// DialRoutes races concurrently per attempt (first to complete its
+	// handshake wins). 0 (unset) uses the built-in default (a small N); 1
+	// forces the legacy strictly-sequential setup (clean rollback switch).
+	// This is the steady-connection fix: it stops a run of dead candidates
+	// from burning the dial ceiling and wedging an app in "starting".
+	ParallelRouteSetup int `json:"parallel_route_setup,omitempty"`
 	// TransportPreference is the transport-type priority order, most-preferred
 	// first. It decides both which existing transport a route rides when
 	// several reach the same peer, and which type the visor tries to CREATE

--- a/pkg/visor/visorcore/router.go
+++ b/pkg/visor/visorcore/router.go
@@ -33,6 +33,7 @@ type RouterDeps struct {
 	SetupNodes         []cipher.PubKey
 	MinHops            uint16
 	MuxRoutes          int
+	ParallelRouteSetup int
 	AwaitSetupListener *dmsg.Listener
 	Logger             *logging.Logger
 	MasterLogger       *logging.MasterLogger
@@ -67,6 +68,7 @@ func BuildRouter(serveCtx context.Context, deps RouterDeps) (router.Router, erro
 		SetupNodes:            deps.SetupNodes,
 		MinHops:               deps.MinHops,
 		MuxRoutes:             deps.MuxRoutes,
+		ParallelRouteSetup:    deps.ParallelRouteSetup,
 		AwaitSetupListener:    deps.AwaitSetupListener,
 		AppLookup:             deps.AppLookup,
 		DialHook:              deps.DialHook,


### PR DESCRIPTION
## Problem (root-caused live)

Route-group setup walked candidate routes **sequentially**. In `DialRoutes`, the policy picked ONE route, `saveRouteGroupRules` set it up with one handshake + the #4057 retransmit over `handshakeAwaitTimeout` (~10s); only on failure did a bounded retry loop query a fresh route and try the next candidate — one at a time. Each dead / non-forwarding candidate cost up to the full ~10s handshake await, so a run of bad candidates burned the whole ~90s dial ceiling → `Route group setup canceled … context deadline exceeded` and the app wedged in **"starting"**. Observed live: skysocks-client → Frankfurt at `min_hops>=2` sitting in "starting" for minutes.

## Fix

`DialRoutes` now sets up the **top-K candidates concurrently**; the **first candidate to complete its reciprocal handshake wins** and becomes the working base (the dial returns on it immediately — mux legs grow on top later and never unseat it). Losing / failed candidates are canceled + torn down. This collapses establishment from "up to N×`handshakeAwaitTimeout`" to ~one RTT and makes a dead-hop candidate **lose the race instead of blocking** — so the app converges to a working route (single multihop at `min_hops>=2`, or direct at `min_hops==1`) instead of wedging. min-hops-agnostic.

### Where the race goes
Top of the `DialRoutes` retry loop, gated on `K>1 && hookDone==nil && !forceLocal && !RouteSelectingHook`. It fetches the top-K candidates in ONE route-finder query (`fetchCandidateRoutes`) and runs `raceCandidateSetup`. On total race failure it excludes the raced intermediates and falls through to the existing sequential path (with its local-calc fallback) in the same attempt. The old sequential path is fully preserved for `K==1`, cold-start (`hookDone`), local-route mode, and route-selecting policies. Post-setup wiring (mux/self-heal/hooks) was extracted into `finishDial`, shared by both paths.

### Data-model constraint (why two phases)
Incoming handshake/data packets demux to a route group by **RouteDescriptor**, and every candidate of one dial shares one descriptor, so two reciprocal handshakes cannot run concurrently on it. The race is therefore two-phase:
- **phase 1 (concurrent):** reserve route IDs across every candidate's hops — where an unreachable intermediate fails `id_reservation` and loses cheaply (the dominant live failure mode);
- **phase 2 (serial, fastest-reservation-first):** complete the handshake on reserved candidates; first to complete wins. Because candidates are pre-reserved, moving to the next on a handshake failure costs **no re-fetch and no re-reservation**, unlike the old loop.

No leaked goroutines/route-IDs on cancel (child ctx + buffered result channel); winner's rules stay installed, losers' local rules removed (orphaned remote reservations expire via remote rule GC, same as failed candidates before).

## Config knob
`routing.parallel_route_setup` → `router.Config.ParallelRouteSetup`, with a per-dial `DialOptions.ParallelRouteSetup` override. **Default a small N (3)**; **`1` restores strictly-sequential** setup (clean rollback). Concurrency is bounded by `maxParallelRouteSetup` (5) and by the number of candidates the finder returns.

## Loser penalty + composition with #4063
A candidate that loses or fails setup has its intermediate hops marked **suspect** for a short TTL (`suspectHopCache`), so the NEXT dial front-loads known-good hops (soft deprioritize in candidate ranking, not a hard exclude). Armed on **every** failure path — reservation failure, handshake timeout, **and ctx-deadline / setup-canceled** — which is the arming gap #4063 alone did not fire on live.

**Composition with #4063** (`fix/router-suspect-hop-failover`, `pkg/router/suspect_hops.go`, per-destination TTL suspect cache): the router holds a single `suspects` field, consulted only in candidate ranking and armed only at the race's `onLoser` / `DialRoutes` failure paths. To reconcile, point those call sites at #4063's per-destination cache (add the destination PK) and drop this global one — the two are structured to be swapped without touching the race logic.

## Tests
`pkg/router/parallel_route_setup_test.go`: winner selection (first handshake to complete wins), handshake-failure fall-through to the next reserved candidate, all-fail, **single-candidate sequential-equivalent**, ctx-cancel, suspect cache arm/TTL/count, K resolution + clamping, and candidate ranking (suspect deprioritization, hard-exclude, disjoint preference). Race-detector clean.

## Validation done
`go build ./...` (root + router + visorcore), `go vet ./pkg/router/`, targeted `go test ./pkg/router/ -race`. Not merged — core routing; leaving for live validation.

## Suggested live validation (coordinator)
On the native visor: with `routing.parallel_route_setup: 3` (default), start skysocks-client to a Frankfurt exit at `min_hops=2` and measure re-establishment time after a route drop vs. `parallel_route_setup: 1` (sequential). Expect: sequential wedges/takes minutes on dead candidates; parallel reaches "running" in ~one RTT and never wedges in "starting". Also confirm a `min_hops=1` direct dial still behaves (single-candidate → sequential path, no race).
