### PR TITLE
feat(transport): per-type connection metadata on `visor state` + `tp`; state snapshot completeness

### DIFF
--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -598,17 +598,20 @@ func PrintTransports(cmdFlags *pflag.FlagSet, tps ...*visor.TransportSummary) {
 		}
 
 		oTP := outputTP{
-			Type:      tp.Type,
-			ID:        tp.ID,
-			Remote:    tp.Remote,
-			TpMode:    tpMode,
-			Label:     tp.Label,
-			Version:   version,
-			Country:   country,
-			Services:  services,
-			LatencyMS: tp.LatencyMS,
-			RecvBytes: recvBytes,
-			SentBytes: sentBytes,
+			Type:          tp.Type,
+			ID:            tp.ID,
+			Remote:        tp.Remote,
+			TpMode:        tpMode,
+			Label:         tp.Label,
+			Version:       version,
+			Country:       country,
+			Services:      services,
+			LatencyMS:     tp.LatencyMS,
+			RecvBytes:     recvBytes,
+			SentBytes:     sentBytes,
+			RemoteIP:      tp.RemoteIP,
+			RemoteCountry: tp.RemoteCountry,
+			Endpoint:      tp.Endpoint,
 		}
 		outputTPS = append(outputTPS, oTP)
 
@@ -836,17 +839,20 @@ func PrintTransportsWithBandwidth(cmdFlags *pflag.FlagSet, bwByTpID map[string]s
 		}
 
 		oTP := outputTP{
-			Type:      tp.Type,
-			ID:        tp.ID,
-			Remote:    tp.Remote,
-			TpMode:    tpMode,
-			Label:     tp.Label,
-			Version:   version,
-			Country:   country,
-			Services:  services,
-			LatencyMS: tp.LatencyMS,
-			RecvBytes: recvBytes,
-			SentBytes: sentBytes,
+			Type:          tp.Type,
+			ID:            tp.ID,
+			Remote:        tp.Remote,
+			TpMode:        tpMode,
+			Label:         tp.Label,
+			Version:       version,
+			Country:       country,
+			Services:      services,
+			LatencyMS:     tp.LatencyMS,
+			RecvBytes:     recvBytes,
+			SentBytes:     sentBytes,
+			RemoteIP:      tp.RemoteIP,
+			RemoteCountry: tp.RemoteCountry,
+			Endpoint:      tp.Endpoint,
 		}
 		outputTPS = append(outputTPS, oTP)
 

--- a/pkg/cliout/clitp/clitp.go
+++ b/pkg/cliout/clitp/clitp.go
@@ -30,6 +30,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/transport"
 	store "github.com/skycoin/skywire/pkg/transport-discovery/store"
+	"github.com/skycoin/skywire/pkg/transport/network"
 	types "github.com/skycoin/skywire/pkg/transport/types"
 )
 
@@ -64,6 +65,21 @@ type Transport struct {
 	// Only the listing that reconciles against the transport discovery sets
 	// it; it was the field the two former copies disagreed about.
 	Inactive bool `json:"inactive,omitempty"`
+
+	// RemoteIP is the direct remote IP of the underlying connection (empty
+	// for dmsg, which relays through a server). RemoteCountry is the ISO
+	// country the embedded geoip db maps it to. Both come straight from the
+	// visor (TransportSummary), independent of the --more service-discovery
+	// enrichment that fills Country above.
+	RemoteIP      string `json:"remote_ip,omitempty"`
+	RemoteCountry string `json:"remote_country,omitempty"`
+
+	// Endpoint is the per-transport-type low-level connection metadata: the
+	// direct IP:port for stcp/stcpr/sudph/squicr, the relaying dmsg server
+	// PK for dmsg, the QUIC TLS fingerprint/ALPN for squicr, the selected
+	// ICE candidate for webrtc. Secrets-free. nil when the visor reports
+	// none. Carried verbatim from visor.TransportSummary.Endpoint.
+	Endpoint *network.ConnDetails `json:"endpoint,omitempty"`
 }
 
 // Transports is the list form, which is what every tp listing emits — a JSON

--- a/pkg/router/mock_router.go
+++ b/pkg/router/mock_router.go
@@ -536,6 +536,18 @@ func (_m *MockRouter) RouteGroupMuxInfoForApp(_a0 string) []MuxInfo {
 	return r0
 }
 
+// RouteGroupMuxInfoAll provides a mock function with no fields
+func (_m *MockRouter) RouteGroupMuxInfoAll() []MuxInfo {
+	ret := _m.Called()
+	var r0 []MuxInfo
+	if rf, ok := ret.Get(0).(func() []MuxInfo); ok {
+		r0 = rf()
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]MuxInfo)
+	}
+	return r0
+}
+
 // ActiveRouteStatuses provides a mock function with no fields
 func (_m *MockRouter) ActiveRouteStatuses() []RouteStatus {
 	ret := _m.Called()

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -556,6 +556,12 @@ type Router interface {
 	// an empty slice if no rg's are active for the app.
 	RouteGroupMuxInfoForApp(appName string) []MuxInfo
 
+	// RouteGroupMuxInfoAll returns mux snapshots for EVERY active
+	// route group, regardless of the app it is tagged with. Powers the
+	// whole-runtime `cli visor state` view where the per-leg mux shape
+	// of all route groups (not just one app's) is wanted at once.
+	RouteGroupMuxInfoAll() []MuxInfo
+
 	// Routing table related methods
 	RoutesCount() int
 	Rules() []routing.Rule

--- a/pkg/router/router_rules.go
+++ b/pkg/router/router_rules.go
@@ -112,6 +112,27 @@ func (r *router) RouteGroupMuxInfoForApp(appName string) []MuxInfo {
 	return out
 }
 
+// RouteGroupMuxInfoAll implements Router. Returns a mux snapshot for
+// every established (noise) route group, with no app-name filter — the
+// whole-runtime view `cli visor state` surfaces. Same MuxStats() the
+// per-app query and 'mux plot' read; only the filter differs.
+func (r *router) RouteGroupMuxInfoAll() []MuxInfo {
+	r.mx.Lock()
+	rgs := make([]*NoiseRouteGroup, 0, len(r.rgsNs))
+	for _, nrg := range r.rgsNs {
+		if nrg != nil && nrg.rg != nil {
+			rgs = append(rgs, nrg)
+		}
+	}
+	r.mx.Unlock()
+
+	out := make([]MuxInfo, 0, len(rgs))
+	for _, nrg := range rgs {
+		out = append(out, nrg.rg.MuxStats())
+	}
+	return out
+}
+
 func (r *router) initializingRouteGroup(desc routing.RouteDescriptor) (*RouteGroup, bool) {
 	r.mx.Lock()
 	defer r.mx.Unlock()

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -1355,3 +1355,22 @@ func (mt *ManagedTransport) RemoteIP() string {
 	}
 	return host
 }
+
+// ConnDetails returns the underlying network.Transport's curated,
+// secrets-free connection metadata (direct remote/local addr, dmsg
+// relay server PK, QUIC TLS identity, webrtc ICE candidate), or nil
+// when the transport isn't serving or its type exposes no details.
+// The visor's TransportSummary carries this onto `cli visor state` /
+// `cli tp`. No secret key is ever included.
+func (mt *ManagedTransport) ConnDetails() *network.ConnDetails {
+	tp := mt.getTransport()
+	if tp == nil {
+		return nil
+	}
+	d, ok := tp.(network.ConnDetailer)
+	if !ok {
+		return nil
+	}
+	cd := d.ConnDetails()
+	return &cd
+}

--- a/pkg/transport/network/conn_details.go
+++ b/pkg/transport/network/conn_details.go
@@ -1,0 +1,77 @@
+// Package network pkg/transport/network/conn_details.go c2-net-transport
+package network
+
+import (
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// ConnDetails is a curated, secrets-free snapshot of the low-level
+// connection metadata that is meaningful for a given transport kind.
+// It is surfaced through pkg/transport.ManagedTransport.ConnDetails and,
+// from there, onto the visor's TransportSummary so `skywire cli visor
+// state` / `skywire cli tp` can show what a transport actually rides on
+// (the direct IP:port, the relaying dmsg server, the TLS identity, …)
+// without leaking any secret key.
+//
+// Every field is optional (omitempty): each transport type populates
+// only what it can expose cleanly. A field left empty is a deliberate
+// "not applicable / not available for this kind" — e.g. dmsg leaves
+// RemoteAddr empty (it relays through a server, there is no direct IP)
+// and instead fills DmsgServerPK.
+type ConnDetails struct {
+	// RemoteAddr is the underlying raw remote network address
+	// ("host:port"): the direct TCP peer for stcp/stcpr, the
+	// hole-punched UDP endpoint for sudph, the QUIC peer for squicr,
+	// the selected ICE candidate for webrtc. Empty for dmsg — an
+	// empty RemoteAddr is itself the signal "relayed, not direct".
+	RemoteAddr string `json:"remote_addr,omitempty"`
+	// LocalAddr is the underlying raw local network address, when the
+	// carrier exposes one.
+	LocalAddr string `json:"local_addr,omitempty"`
+	// ARBackedType is true for the address-resolver-backed carriers
+	// (stcpr/sudph/squicr): their endpoint was discovered via the
+	// address resolver (a static PK-table dial is the rare exception).
+	// Direct carriers (stcp) and relayed dmsg leave it false.
+	ARBackedType bool `json:"ar_backed_type,omitempty"`
+	// DmsgServerPK is the hex public key of the dmsg.Server this
+	// (dmsg) transport relays its frames through. dmsg-only field; it
+	// is a public key, never a secret. Empty for every other type.
+	DmsgServerPK string `json:"dmsg_server_pk,omitempty"`
+	// TLSCertSHA256 is the hex SHA-256 fingerprint of the remote
+	// peer's TLS certificate (the skywire-PK-bound QUIC identity).
+	// squicr-only. Empty for every other type.
+	TLSCertSHA256 string `json:"tls_cert_sha256,omitempty"`
+	// ALPN is the negotiated TLS application protocol (e.g.
+	// "skywire-quic-1"). squicr-only.
+	ALPN string `json:"alpn,omitempty"`
+}
+
+// ConnDetailer is optionally implemented by a network.Transport to
+// expose its curated ConnDetails. pkg/transport.ManagedTransport
+// consumes it via a type assertion, so transports/mocks that do not
+// implement it simply report no details.
+type ConnDetailer interface {
+	ConnDetails() ConnDetails
+}
+
+// rawConnDetailer is optionally implemented by an underlying raw
+// net.Conn (captured before the noise wrapper replaces it) to
+// contribute type-specific fields — the QUIC TLS identity, the webrtc
+// ICE candidate — that are only reachable on the concrete pre-noise
+// connection. Kept as an unexported interface so each concrete conn
+// type populates it from its own (possibly build-tagged) file without
+// dragging quic-go / pion into the shared connection.go.
+type rawConnDetailer interface {
+	rawConnDetails(d *ConnDetails)
+}
+
+// arBackedType reports whether a transport type discovers its remote
+// endpoint through the address resolver.
+func arBackedType(t types.Type) bool {
+	switch t {
+	case types.STCPR, types.SUDPH, types.QUIC:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/transport/network/conn_details_test.go
+++ b/pkg/transport/network/conn_details_test.go
@@ -1,0 +1,107 @@
+// Package network pkg/transport/network/conn_details_test.go c2-net-transport
+package network
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// addrStub is a minimal net.Addr for the conn stubs below.
+type addrStub struct{ s string }
+
+func (a addrStub) Network() string { return "stub" }
+func (a addrStub) String() string  { return a.s }
+
+// connStub satisfies net.Conn enough for ConnDetails to read its
+// Local/RemoteAddr. Only the two address methods are exercised.
+type connStub struct {
+	net.Conn
+	local, remote net.Addr
+}
+
+func (c connStub) LocalAddr() net.Addr  { return c.local }
+func (c connStub) RemoteAddr() net.Addr { return c.remote }
+
+// rawStub is a connStub that also contributes type-specific details,
+// standing in for the quicStreamConn / dcConn rawConnDetailer path.
+type rawStub struct {
+	connStub
+	alpn string
+	cert string
+	// overrideRemote, when set, is written into ConnDetails.RemoteAddr
+	// to model webrtc's ICE-candidate override of the placeholder addr.
+	overrideRemote string
+}
+
+func (r rawStub) rawConnDetails(d *ConnDetails) {
+	d.ALPN = r.alpn
+	d.TLSCertSHA256 = r.cert
+	if r.overrideRemote != "" {
+		d.RemoteAddr = r.overrideRemote
+	}
+}
+
+func TestArBackedType(t *testing.T) {
+	for _, tt := range []struct {
+		typ  types.Type
+		want bool
+	}{
+		{types.STCPR, true},
+		{types.SUDPH, true},
+		{types.QUIC, true}, // squicr
+		{types.STCP, false},
+		{types.DMSG, false},
+	} {
+		assert.Equalf(t, tt.want, arBackedType(tt.typ), "arBackedType(%s)", tt.typ)
+	}
+}
+
+func TestTransportConnDetails_AddrsAndARFlag(t *testing.T) {
+	stub := connStub{
+		local:  addrStub{"10.0.0.1:1000"},
+		remote: addrStub{"1.2.3.4:5000"},
+	}
+	tp := &transport{Conn: stub, transportType: types.STCPR}
+
+	d := tp.ConnDetails()
+	assert.Equal(t, "1.2.3.4:5000", d.RemoteAddr)
+	assert.Equal(t, "10.0.0.1:1000", d.LocalAddr)
+	assert.True(t, d.ARBackedType, "stcpr is an AR-backed carrier")
+	assert.Empty(t, d.DmsgServerPK)
+	assert.Empty(t, d.TLSCertSHA256)
+}
+
+func TestTransportConnDetails_RawContributor(t *testing.T) {
+	raw := rawStub{
+		connStub:       connStub{local: addrStub{"[::]:0"}, remote: addrStub{"9.9.9.9:443"}},
+		alpn:           "skywire-quic-1",
+		cert:           "deadbeef",
+		overrideRemote: "9.9.9.9:443",
+	}
+	// c.Conn provides the base addrs; c.rawConn provides the extra details.
+	tp := &transport{Conn: raw.connStub, rawConn: raw, transportType: types.QUIC}
+
+	d := tp.ConnDetails()
+	require.Equal(t, "9.9.9.9:443", d.RemoteAddr)
+	assert.Equal(t, "skywire-quic-1", d.ALPN)
+	assert.Equal(t, "deadbeef", d.TLSCertSHA256)
+	assert.True(t, d.ARBackedType)
+}
+
+// TestTransportConnDetails_NoRawContributor ensures a transport whose
+// rawConn does not implement rawConnDetailer still reports base details
+// without panicking (the stcp/stcpr/sudph common case).
+func TestTransportConnDetails_NoRawContributor(t *testing.T) {
+	stub := connStub{local: addrStub{"127.0.0.1:1"}, remote: addrStub{"8.8.8.8:2"}}
+	tp := &transport{Conn: stub, rawConn: stub, transportType: types.STCP}
+
+	d := tp.ConnDetails()
+	assert.Equal(t, "8.8.8.8:2", d.RemoteAddr)
+	assert.False(t, d.ARBackedType)
+	assert.Empty(t, d.ALPN)
+}

--- a/pkg/transport/network/connection.go
+++ b/pkg/transport/network/connection.go
@@ -71,6 +71,12 @@ type transport struct {
 	// encrypt() before the noise wrapper (stream-only) replaces c.Conn. Nil
 	// for reliable-only transports.
 	dgram DatagramConn
+	// rawConn is the underlying pre-noise net.Conn, captured at handshake time
+	// (before encrypt() replaces c.Conn with the stream-only noise wrapper).
+	// Retained solely so ConnDetails can reach concrete conn types (the QUIC
+	// connection's TLS identity, the webrtc ICE candidate) that are no longer
+	// reachable through the noise wrapper. Read-only for observability.
+	rawConn net.Conn
 }
 
 // Datagram returns the transport's native datagram channel and true when the
@@ -106,7 +112,7 @@ func doHandshake(rawConn net.Conn, hs handshake.Handshake, netType types.Type, t
 		}
 		return nil, err
 	}
-	handshakedConn := &transport{Conn: rawConn, lAddr: lAddr, rAddr: rAddr, transportType: netType}
+	handshakedConn := &transport{Conn: rawConn, rawConn: rawConn, lAddr: lAddr, rAddr: rAddr, transportType: netType}
 	return handshakedConn, nil
 }
 
@@ -246,3 +252,24 @@ func (c *transport) RemotePort() uint16 { return c.rAddr.Port }
 
 // Network returns network of transport
 func (c *transport) Network() types.Type { return c.transportType }
+
+// ConnDetails implements ConnDetailer. Reports the curated, secrets-free
+// connection metadata for this transport: the raw remote/local addresses
+// (the direct TCP peer for stcp/stcpr, the hole-punched UDP endpoint for
+// sudph, the QUIC/ICE peer for squicr/webrtc), whether the type is
+// address-resolver-backed, and — for conns whose concrete type carries
+// more (the QUIC TLS identity, the webrtc candidate) — whatever the
+// pre-noise rawConn contributes via rawConnDetails.
+func (c *transport) ConnDetails() ConnDetails {
+	d := ConnDetails{ARBackedType: arBackedType(c.transportType)}
+	if a := c.RemoteRawAddr(); a != nil {
+		d.RemoteAddr = a.String()
+	}
+	if a := c.LocalRawAddr(); a != nil {
+		d.LocalAddr = a.String()
+	}
+	if rd, ok := c.rawConn.(rawConnDetailer); ok {
+		rd.rawConnDetails(&d)
+	}
+	return d
+}

--- a/pkg/transport/network/dmsg.go
+++ b/pkg/transport/network/dmsg.go
@@ -145,3 +145,15 @@ func (c *dmsgTransportAdapter) RemoteRawAddr() net.Addr {
 func (c *dmsgTransportAdapter) Network() types.Type {
 	return types.DMSG
 }
+
+// ConnDetails implements ConnDetailer. dmsg relays through a dmsg.Server
+// rather than dialing the peer directly, so there is no direct remote IP
+// to report (RemoteAddr is deliberately left empty — an empty RemoteAddr
+// is itself the "relayed, not direct" signal). Instead it reports the
+// public key of the dmsg.Server the frames ride through. ServerPK is a
+// public key, never a secret.
+func (c *dmsgTransportAdapter) ConnDetails() ConnDetails {
+	return ConnDetails{
+		DmsgServerPK: c.ServerPK().Hex(),
+	}
+}

--- a/pkg/transport/network/quic.go
+++ b/pkg/transport/network/quic.go
@@ -14,7 +14,9 @@ package network
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -117,6 +119,23 @@ func (c *quicStreamConn) ReadDatagram(ctx context.Context) ([]byte, error) {
 
 // compile-time assertion that *quicStreamConn provides the native datagram channel.
 var _ DatagramConn = (*quicStreamConn)(nil)
+
+// rawConnDetails contributes the squicr-specific connection metadata —
+// the remote peer's TLS certificate fingerprint (the skywire-PK-bound
+// QUIC identity) and the negotiated ALPN — to a ConnDetails. Called by
+// transport.ConnDetails via the pre-noise rawConn (this concrete type).
+// Reads only public certificate bytes; no secret is exposed.
+func (c *quicStreamConn) rawConnDetails(d *ConnDetails) {
+	if c.conn == nil {
+		return
+	}
+	tlsState := c.conn.ConnectionState().TLS
+	d.ALPN = tlsState.NegotiatedProtocol
+	if len(tlsState.PeerCertificates) > 0 {
+		sum := sha256.Sum256(tlsState.PeerCertificates[0].Raw)
+		d.TLSCertSHA256 = hex.EncodeToString(sum[:])
+	}
+}
 
 func (c *quicStreamConn) Close() error {
 	_ = c.Stream.Close() //nolint:errcheck,gosec // half-close the stream, then the conn

--- a/pkg/transport/network/webrtc_native.go
+++ b/pkg/transport/network/webrtc_native.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"sync"
 	"time"
 
@@ -369,6 +370,42 @@ func (c *dcConn) Close() error {
 
 func (c *dcConn) LocalAddr() net.Addr  { return webrtcAddr{} }
 func (c *dcConn) RemoteAddr() net.Addr { return webrtcAddr{} }
+
+// rawConnDetails contributes the webrtc-specific connection metadata to
+// a ConnDetails: the selected ICE candidate pair's local/remote
+// endpoints (the addresses the DataChannel actually flows between —
+// dcConn.RemoteAddr() is only the opaque "webrtc-datachannel"
+// placeholder). Best-effort: before the pair is nominated (or if pion
+// can't report it) the placeholder is left in place. The DTLS
+// fingerprint is not exposed by pion's public API and is left as a
+// known gap. Called by transport.ConnDetails via the pre-noise rawConn.
+func (c *dcConn) rawConnDetails(d *ConnDetails) {
+	if c.pc == nil {
+		return
+	}
+	sctp := c.pc.SCTP()
+	if sctp == nil {
+		return
+	}
+	dtls := sctp.Transport()
+	if dtls == nil {
+		return
+	}
+	ice := dtls.ICETransport()
+	if ice == nil {
+		return
+	}
+	pair, err := ice.GetSelectedCandidatePair()
+	if err != nil || pair == nil {
+		return
+	}
+	if pair.Remote != nil {
+		d.RemoteAddr = net.JoinHostPort(pair.Remote.Address, strconv.Itoa(int(pair.Remote.Port)))
+	}
+	if pair.Local != nil {
+		d.LocalAddr = net.JoinHostPort(pair.Local.Address, strconv.Itoa(int(pair.Local.Port)))
+	}
+}
 
 func (c *dcConn) SetReadDeadline(t time.Time) error {
 	c.mu.Lock()

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/routing"
 )
 
@@ -108,7 +109,24 @@ func (v *Visor) RouteGroupMuxInfo(appName string) ([]MuxRouteGroupInfo, error) {
 	if v.router == nil {
 		return nil, nil
 	}
-	infos := v.router.RouteGroupMuxInfoForApp(appName)
+	return muxRouteGroupInfoFrom(v.router.RouteGroupMuxInfoForApp(appName)), nil
+}
+
+// AllRouteGroupMuxInfo implements API. Returns per-mux-leg counters for
+// EVERY active route group on the visor, regardless of app — the
+// whole-runtime view surfaced in `cli visor state`. Same transcription
+// as RouteGroupMuxInfo, only without the app filter.
+func (v *Visor) AllRouteGroupMuxInfo() ([]MuxRouteGroupInfo, error) {
+	if v.router == nil {
+		return nil, nil
+	}
+	return muxRouteGroupInfoFrom(v.router.RouteGroupMuxInfoAll()), nil
+}
+
+// muxRouteGroupInfoFrom transcribes the router's internal MuxInfo slice
+// into the wire-friendly visor-level MuxRouteGroupInfo shape. Shared by
+// the per-app and all-groups queries so the two stay identical.
+func muxRouteGroupInfoFrom(infos []router.MuxInfo) []MuxRouteGroupInfo {
 	out := make([]MuxRouteGroupInfo, 0, len(infos))
 	for _, info := range infos {
 		entry := MuxRouteGroupInfo{
@@ -140,7 +158,7 @@ func (v *Visor) RouteGroupMuxInfo(appName string) ([]MuxRouteGroupInfo, error) {
 		}
 		out = append(out, entry)
 	}
-	return out, nil
+	return out
 }
 
 // ActiveRoutes implements API.

--- a/pkg/visor/api_state.go
+++ b/pkg/visor/api_state.go
@@ -39,9 +39,40 @@ type StateSnapshot struct {
 	Persistent    []transport.PersistentTransports `json:"persistent_transports,omitempty"`
 	Modules       ModulePresence                   `json:"modules"`
 
+	// RouterConfig is the routing configuration actually IN FORCE at
+	// runtime (min_hops / mux_routes / force_local / existing_tp_only
+	// / transport_preference are the live router values, which can
+	// differ from the config file after a runtime set; cascade +
+	// policy_per_dial are the configured source). This is the
+	// policy-vs-globals view — what the router will do independent of
+	// any per-app routing policy.
+	RouterConfig *EffectiveRoutingConfig `json:"router_config,omitempty"`
+	// MuxRouteGroups is the per-leg mux shape of EVERY active route
+	// group (the same RouteGroupMuxInfo 'mux plot' reads), so the live
+	// multipath layout — each leg's transport, type, remote, rtt,
+	// bandwidth, and alive/standby gate state — is visible in one
+	// snapshot rather than one-app-at-a-time.
+	MuxRouteGroups []MuxRouteGroupInfo `json:"mux_route_groups,omitempty"`
+
 	// Notes collects per-section errors ("routing: <err>") so the snapshot is
 	// self-describing about what it could and could not read.
 	Notes []string `json:"notes,omitempty"`
+}
+
+// EffectiveRoutingConfig is the routing configuration in force at
+// runtime. MinHops/MuxRoutes/ForceLocalRoutes/ExistingTPOnly/
+// TransportPreference are read from the live router (GetRouterSettings),
+// so they reflect any runtime set that diverged from the config file;
+// EnableCascadeRouteSetup and PolicyPerDial are the configured source
+// (PolicyPerDial is a path/inline-source string, never a secret).
+type EffectiveRoutingConfig struct {
+	MinHops                 uint16   `json:"min_hops"`
+	MuxRoutes               int      `json:"mux_routes"`
+	ForceLocalRoutes        bool     `json:"force_local_routes"`
+	ExistingTPOnly          bool     `json:"existing_tp_only"`
+	TransportPreference     []string `json:"transport_preference,omitempty"`
+	EnableCascadeRouteSetup bool     `json:"enable_cascade_route_setup"`
+	PolicyPerDial           string   `json:"policy_per_dial,omitempty"`
 }
 
 // ModulePresence reports which optional subsystems are wired on this visor.
@@ -99,6 +130,29 @@ func (v *Visor) StateSnapshot() (*StateSnapshot, error) {
 		note("route_groups", err)
 	} else {
 		snap.RouteGroups = len(rgs)
+	}
+
+	if mrgs, err := v.AllRouteGroupMuxInfo(); err != nil {
+		note("mux_route_groups", err)
+	} else if len(mrgs) > 0 {
+		snap.MuxRouteGroups = mrgs
+	}
+
+	if rc, err := v.GetRouterSettings(); err != nil {
+		note("router_config", err)
+	} else {
+		erc := &EffectiveRoutingConfig{
+			MinHops:             rc.MinHops,
+			MuxRoutes:           rc.MuxRoutes,
+			ForceLocalRoutes:    rc.ForceLocalRoutes,
+			ExistingTPOnly:      rc.ExistingTPOnly,
+			TransportPreference: rc.TransportPreference,
+		}
+		if v.conf != nil && v.conf.Routing != nil {
+			erc.EnableCascadeRouteSetup = v.conf.Routing.EnableCascadeRouteSetup
+			erc.PolicyPerDial = v.conf.Routing.PolicyPerDial
+		}
+		snap.RouterConfig = erc
 	}
 
 	if rp, err := v.RoutingPolicies(); err != nil {

--- a/pkg/visor/geo_summary.go
+++ b/pkg/visor/geo_summary.go
@@ -1,0 +1,50 @@
+// Package visor pkg/visor/geo_summary.go c3-vis-core
+package visor
+
+import (
+	"sync"
+
+	"github.com/oschwald/geoip2-golang/v2"
+
+	"github.com/skycoin/skywire/pkg/geoip"
+)
+
+// geoSummary holds a process-wide, lazily-opened handle to the embedded
+// MaxMind geoip database, reused across TransportSummary enrichments so
+// every `cli visor state` / `cli tp` call doesn't re-open (memory-map)
+// the multi-MB blob per transport. It is the same embedded db the
+// routing-policy provider (policy_provider.go) resolves country codes
+// against, kept consistent so a transport's remote_country matches what
+// a geo-avoid policy would see. Read-only after open.
+var geoSummary struct {
+	once sync.Once
+	mu   sync.Mutex
+	db   *geoip2.Reader // nil when OpenEmbedded failed
+}
+
+// geoCountryForIP returns the ISO country code the embedded geoip db
+// maps ip to, or "" when the db is unavailable, ip is empty, or there
+// is no geoip hit. Concurrency-safe: the reader is opened once and
+// lookups are serialized behind a mutex (cheap — a handful of
+// transports per snapshot), mirroring the routing-policy provider's own
+// guarded access to the shared reader.
+func geoCountryForIP(ip string) string {
+	if ip == "" {
+		return ""
+	}
+	geoSummary.once.Do(func() {
+		if db, err := geoip.OpenEmbedded(); err == nil {
+			geoSummary.db = db
+		}
+	})
+	if geoSummary.db == nil {
+		return ""
+	}
+	geoSummary.mu.Lock()
+	res, err := geoip.Lookup(geoSummary.db, ip)
+	geoSummary.mu.Unlock()
+	if err != nil || res == nil {
+		return ""
+	}
+	return res.CountryCode
+}

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport"
+	"github.com/skycoin/skywire/pkg/transport/network"
 	types "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/util/rpcutil"
 )
@@ -86,6 +87,24 @@ type TransportSummary struct {
 	// (incoming). The transport is bidirectional — this records only
 	// who originated it, for in/out reporting.
 	Initiator bool `json:"initiator"`
+	// RemoteIP is the host portion of the underlying transport's raw
+	// remote address (e.g. "1.2.3.4"). Empty for dmsg — which relays
+	// through a server rather than dialing the peer directly, so an
+	// empty RemoteIP is itself the "relayed, not direct" signal.
+	// Populated from tp.RemoteIP().
+	RemoteIP string `json:"remote_ip,omitempty"`
+	// RemoteCountry is the ISO country code the embedded geoip db maps
+	// RemoteIP to (the same db the routing-policy provider uses). Empty
+	// when there is no direct IP (dmsg) or no geoip hit.
+	RemoteCountry string `json:"remote_country,omitempty"`
+	// Endpoint carries the per-transport-type low-level connection
+	// metadata — the direct IP:port for stcp/stcpr/sudph/squicr, the
+	// relaying dmsg server PK for dmsg, the QUIC TLS fingerprint/ALPN
+	// for squicr, the selected ICE candidate for webrtc. Secrets-free
+	// (dmsg = server PK only, never a secret key). nil when the
+	// transport isn't serving or its type exposes no details.
+	// Populated from tp.ConnDetails().
+	Endpoint *network.ConnDetails `json:"endpoint,omitempty"`
 }
 type TransportLogEntry struct {
 	TpID      uuid.UUID `json:"tp_id"`
@@ -108,6 +127,11 @@ func newTransportSummary(tm *transport.Manager, tp *transport.ManagedTransport, 
 	}
 	if includeLogs {
 		summary.Log = tp.LogEntry
+	}
+	summary.Endpoint = tp.ConnDetails()
+	summary.RemoteIP = tp.RemoteIP()
+	if summary.RemoteIP != "" {
+		summary.RemoteCountry = geoCountryForIP(summary.RemoteIP)
 	}
 	return summary
 }


### PR DESCRIPTION
## What

Adds a curated, **secrets-free per-transport-type connection-metadata** view and surfaces it on `skywire cli visor state` and `skywire cli tp`, plus a handful of additive completeness fields to the `visor state` snapshot. **Strictly additive** — no existing field is removed or renamed.

### Per-transport connection metadata

New `network.ConnDetails` (optional `ConnDetailer` interface). Each transport type populates what it can expose cleanly:

| type | surfaces |
|------|----------|
| **stcp / stcpr / sudph** | raw remote/local `IP:port`; stcpr/sudph flagged `ar_backed_type` (endpoint discovered via the address resolver). For **sudph** the `remote_addr` **is** the hole-punched UDP endpoint. |
| **squicr** | TLS cert **SHA-256 fingerprint** + negotiated **ALPN** + peer `IP:port` |
| **dmsg** | the relaying **dmsg server PK** (public key only). `remote_addr` left empty — an empty `remote_addr` is itself the "relayed, not direct" signal. |
| **webrtc** | selected **ICE candidate pair** local/remote (native pion) |

The underlying pre-noise conn is captured at handshake time so the concrete conn type (quic/webrtc) contributes its details via an unexported `rawConnDetailer`, keeping quic-go / pion out of the shared `connection.go` (and the TinyGo graph).

`TransportSummary` gains `endpoint`, `remote_ip`, and `remote_country` (embedded geoip — the same DB the routing-policy provider resolves against).

### `visor state` completeness additions

- **`router_config`** — the routing config actually **in force** at runtime: `min_hops`, `mux_routes`, `force_local_routes`, `existing_tp_only`, `transport_preference` (live router values, can differ from the config file), plus configured `enable_cascade_route_setup` and `policy_per_dial`. This is the policy-vs-globals view.
- **`mux_route_groups`** — per-leg mux shape of **every** active route group (the same `RouteGroupMuxInfo` `mux plot` reads): per-leg tp_id / type / remote / rtt / bytes / packets / retransmits / alive / standby. Backed by a new `router.RouteGroupMuxInfoAll()` (all rgs, no app filter).

`clitp.Transport` carries `endpoint`/`remote_ip`/`remote_country` so `tp --json` includes them; `visor state --shape` shows the full schema.

## Safety

No secret key is ever included (dmsg = **server PK only**, never a secret; squicr = public cert fingerprint). Consistent with `visor state`'s existing secrets-free contract.

## Known per-type gaps (populate-what-it-can)

- **sudph**: exposes the punched `remote_addr` but not detailed symmetric-NAT / punch-fallback state (not tracked per-conn without deeper plumbing).
- **webrtc**: DTLS fingerprint is not exposed by pion's public API (left as a gap); the selected ICE candidate pair is provided instead.
- **ar_backed_type** reflects the AR-backed carrier *type*; a rare static-PK-table dial is the exception and isn't distinguished per-conn.

## Test

Added `pkg/transport/network/conn_details_test.go` (addr/AR-flag/raw-contributor paths). Targeted `go build ./pkg/transport/... ./pkg/router/... ./pkg/visor/... ./cmd/skywire-cli/...` clean; `gofmt` clean.
