### PR TITLE
feat(router): exclude same-LAN peers as routing intermediates (route diversity)

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -202,6 +202,27 @@ type Config struct {
 	// query deliverer is configured (SetTransportQueryDeliverer); see
 	// rsn_oracle_routes.go. TPD is still used for routes with >=2 intermediates.
 	EnableRSNOracleRoutes bool
+
+	// ExcludeSameLANHops, when true (the default the visor wires from
+	// routing.exclude_same_lan_hops), makes route calculation drop candidate
+	// INTERMEDIATE hops that sit on this visor's own local network — a peer
+	// reached over a private/RFC1918 endpoint, or (the NAT-hairpin case) a peer
+	// reached at this visor's own public IP or its /24. Routing a remote-
+	// destination path through a same-LAN peer adds a hop but no path diversity
+	// (same first-mile link, NAT and failure domain) and can fold the path back
+	// onto the source network; for a mux it also starves genuinely-diverse aux
+	// legs because the same-LAN peer wins on latency and is re-picked every
+	// rotation. Same-LAN peers remain fully usable as direct dial DESTINATIONS —
+	// only their use as intermediates is suppressed. The exclusion is computed
+	// from live transports via TransportManager.SameLANPeers(SelfPublicIP()).
+	ExcludeSameLANHops bool
+	// SelfPublicIP returns this visor's current public IP (from STUN), or nil
+	// when not yet known. Used only by the ExcludeSameLANHops filter to catch
+	// the NAT-hairpin case (a same-LAN peer reached at our own public IP). nil
+	// getter or nil result is fine — the private-IP and local-interface /24
+	// checks still apply.
+	SelfPublicIP func() net.IP
+
 }
 
 // SetDefaults sets default values for certain empty values.

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -2204,6 +2204,17 @@ func (r *router) establishMuxRoutes(
 	// aux routes diverge from ALL prior ones.
 	excludePKs := intermediatesOfRouteGroup(nrg, lPK, rPK)
 
+	// Also exclude same-LAN peers as aux-leg intermediates. A leg that hops
+	// through a peer on our OWN local network (a private/RFC1918 endpoint, or —
+	// the NAT-hairpin case — our own public IP) provides ZERO path diversity:
+	// same first-mile link, same NAT, same failure domain. Worse, such a peer
+	// usually has the lowest latency (it's local), so the route-finder ranks it
+	// first and the rotation loop re-selects that same useless leg every tick,
+	// starving genuinely-diverse aux legs. Applying this only to aux legs (never
+	// the primary) keeps connectivity unchanged — the primary may still route
+	// through a same-LAN peer if that is the only path.
+	excludePKs = appendUniquePKs(excludePKs, r.sameLANExcludedPKs())
+
 	// Thread MinHops + AppName from the parent dial through to each
 	// aux route. Without MinHops, fetchBestRoutes for the aux dial
 	// drops back to r.conf.MinHops (usually 1) and the route-finder
@@ -2415,9 +2426,13 @@ func (r *router) addOneAuxForwardLeg(ctx context.Context, nrg *NoiseRouteGroup, 
 	lPK := forwardDesc.SrcPK()
 	rPK := forwardDesc.DstPK()
 
-	// Existing intermediates from the route group + policy excludes.
+	// Existing intermediates from the route group + policy excludes + same-LAN
+	// peers (see establishMuxRoutes: a same-LAN intermediate has best latency but
+	// zero path diversity, so without this the rotation loop re-adds that same
+	// useless leg every tick).
 	excludePKs := intermediatesOfRouteGroup(nrg, lPK, rPK)
 	excludePKs = append(excludePKs, extraExcludePKs...)
+	excludePKs = appendUniquePKs(excludePKs, r.sameLANExcludedPKs())
 
 	// Existing tp IDs to exclude (prevents picking the same
 	// transports the route group already uses).
@@ -2607,6 +2622,43 @@ func appendExcludeIntermediate(opts *DialOptions, pk cipher.PubKey) *DialOptions
 	}
 	opts.ExcludeIntermediatePKs = append(opts.ExcludeIntermediatePKs, pk)
 	return opts
+}
+
+// sameLANExcludedPKs returns the PKs of directly-connected peers that sit on
+// this visor's own local network, to be excluded as routing INTERMEDIATES when
+// routing.exclude_same_lan_hops is enabled (Config.ExcludeSameLANHops). Returns
+// nil when the feature is off, the transport manager is absent, or no peer is
+// same-LAN. See transport.Manager.SameLANPeers for the same-LAN definition. The
+// visor's own public IP (for the NAT-hairpin case) is read from the SelfPublicIP
+// getter; a nil getter or nil result still catches private-endpoint peers.
+func (r *router) sameLANExcludedPKs() []cipher.PubKey {
+	if r.conf == nil || !r.conf.ExcludeSameLANHops || r.tm == nil {
+		return nil
+	}
+	var self net.IP
+	if r.conf.SelfPublicIP != nil {
+		self = r.conf.SelfPublicIP()
+	}
+	return r.tm.SameLANPeers(self)
+}
+
+// appendUniquePKs appends every pk in add that is not already in base,
+// preserving order. Nil-safe on both arguments.
+func appendUniquePKs(base, add []cipher.PubKey) []cipher.PubKey {
+	if len(add) == 0 {
+		return base
+	}
+	seen := make(map[cipher.PubKey]struct{}, len(base))
+	for _, pk := range base {
+		seen[pk] = struct{}{}
+	}
+	for _, pk := range add {
+		if _, ok := seen[pk]; !ok {
+			base = append(base, pk)
+			seen[pk] = struct{}{}
+		}
+	}
+	return base
 }
 
 // intermediatePKsOfPath returns the distinct intermediate-visor PKs of a

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport/network"
@@ -1517,6 +1518,83 @@ func (tm *Manager) TransportRemoteAddrs() []string {
 	}
 
 	return addrs
+}
+
+// SameLANPeers returns the PKs of directly-connected non-DMSG peers whose
+// transport endpoint IP is on the same local network as this visor. Two cases
+// are treated as same-LAN:
+//   - the peer's endpoint is a private / RFC1918 (non-public) IP — a transport
+//     reached over a private address is by definition a LAN neighbor; and
+//   - the NAT-hairpin case: the peer's endpoint is a PUBLIC IP that matches the
+//     visor's own public IP (self) exactly, or shares its /24, or shares the /24
+//     of any local interface IP. Two visors behind one NAT that both registered
+//     their public IP reach each other by hairpinning off that IP.
+//
+// Such peers make poor routing INTERMEDIATES to a remote destination: routing
+// through them adds a hop but no path diversity (same first-mile link, same NAT
+// and failure domain) and can fold the path back onto the source's own network.
+// Callers feed the result into DialOptions.ExcludeIntermediatePKs. self may be
+// nil when the public IP is not yet known (STUN pending) — the private-IP and
+// local-interface /24 checks still apply.
+func (tm *Manager) SameLANPeers(self net.IP) []cipher.PubKey {
+	localIPs, _ := netutil.LocalNetworkInterfaceIPs()
+
+	tm.mx.RLock()
+	defer tm.mx.RUnlock()
+
+	var out []cipher.PubKey
+	for _, tp := range tm.tps {
+		if tp.Entry.Type == types.DMSG {
+			continue
+		}
+		netTp := tp.getTransport()
+		if netTp == nil {
+			continue
+		}
+		host := netTp.RemoteRawAddr().String()
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			continue
+		}
+		if isSameLANEndpoint(ip, self, localIPs) {
+			out = append(out, tp.Remote())
+		}
+	}
+	return out
+}
+
+// isSameLANEndpoint reports whether peer is on the local network relative to the
+// visor's own public IP (self, may be nil) and its local interface IPs.
+func isSameLANEndpoint(peer, self net.IP, localIPs []net.IP) bool {
+	if peer == nil {
+		return false
+	}
+	// A private / non-public endpoint is only reachable over the LAN.
+	if !netutil.IsPublicIP(peer) {
+		return true
+	}
+	// NAT hairpin: peer is reached at our own public IP (or its /24).
+	if self != nil && (peer.Equal(self) || sameIPv4Slash24(peer, self)) {
+		return true
+	}
+	for _, l := range localIPs {
+		if sameIPv4Slash24(peer, l) {
+			return true
+		}
+	}
+	return false
+}
+
+// sameIPv4Slash24 reports whether a and b are IPv4 addresses in the same /24.
+func sameIPv4Slash24(a, b net.IP) bool {
+	a4, b4 := a.To4(), b.To4()
+	if a4 == nil || b4 == nil {
+		return false
+	}
+	return a4[0] == b4[0] && a4[1] == b4[1] && a4[2] == b4[2]
 }
 
 // hostIsIP reports whether raw's host component is a literal IP (accepting an

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -5,6 +5,7 @@ package visor
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/ccding/go-stun/stun"
@@ -300,6 +301,18 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 		RulesGCInterval:       0, // 0 = DefaultRulesGCInterval (10s)
 		SetupHooks:            routeSetupHooks,
 		EnableRSNOracleRoutes: v.conf.Routing.EnableRSNOracleRoutes,
+		// Default ON: a nil field (older configs) or explicit true excludes
+		// same-LAN peers as routing intermediates. See Routing.ExcludeSameLanHops.
+		ExcludeSameLANHops: v.conf.Routing.ExcludeSameLanHops == nil || *v.conf.Routing.ExcludeSameLanHops,
+		// SelfPublicIP feeds the same-LAN filter's NAT-hairpin check (a peer
+		// reached at our own public IP). Read live from STUN; nil until resolved.
+		SelfPublicIP: func() net.IP {
+			if v.stun.client != nil && v.stun.client.PublicIP != nil {
+				return net.ParseIP(v.stun.client.PublicIP.IP())
+			}
+			return nil
+		},
+
 	})
 	if err != nil {
 		cancel()

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -636,6 +636,19 @@ type Routing struct {
 	// This is the steady-connection fix: it stops a run of dead candidates
 	// from burning the dial ceiling and wedging an app in "starting".
 	ParallelRouteSetup int `json:"parallel_route_setup,omitempty"`
+
+	// ExcludeSameLanHops, when nil or true (the default), makes route
+	// calculation drop candidate INTERMEDIATE hops that sit on this visor's own
+	// local network — a peer reached over a private/RFC1918 endpoint, or (the
+	// NAT-hairpin case) a peer reached at this visor's own public IP / its /24.
+	// Routing a remote-destination path through a same-LAN peer adds a hop but
+	// no path diversity (same first-mile link, NAT and failure domain) and
+	// starves a mux of genuinely-diverse aux legs (the same-LAN peer wins on
+	// latency and is re-picked every rotation). Same-LAN peers remain usable as
+	// direct dial DESTINATIONS; only their use as intermediates is suppressed.
+	// Set to false only for deliberate LAN-relay topologies. Pointer so an
+	// absent field (older configs) defaults ON.
+	ExcludeSameLanHops *bool `json:"exclude_same_lan_hops,omitempty"`
 	// TransportPreference is the transport-type priority order, most-preferred
 	// first. It decides both which existing transport a route rides when
 	// several reach the same peer, and which type the visor tries to CREATE

--- a/pkg/visor/visorcore/router.go
+++ b/pkg/visor/visorcore/router.go
@@ -3,6 +3,7 @@ package visorcore
 
 import (
 	"context"
+	"net"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -47,6 +48,12 @@ type RouterDeps struct {
 	// OFF). Seeded from Routing.EnableRSNOracleRoutes; inert until the visor also
 	// calls router.SetDstTransportOracle.
 	EnableRSNOracleRoutes bool
+
+	// ExcludeSameLANHops (default ON) drops same-LAN peers as routing
+	// intermediates; see router.Config.ExcludeSameLANHops. SelfPublicIP feeds its
+	// NAT-hairpin check (nil until STUN resolves).
+	ExcludeSameLANHops bool
+	SelfPublicIP       func() net.IP
 }
 
 // BuildRouter assembles router.Config from deps, creates the router, and starts
@@ -74,6 +81,8 @@ func BuildRouter(serveCtx context.Context, deps RouterDeps) (router.Router, erro
 		DialHook:              deps.DialHook,
 		RulesGCInterval:       deps.RulesGCInterval,
 		EnableRSNOracleRoutes: deps.EnableRSNOracleRoutes,
+		ExcludeSameLANHops:    deps.ExcludeSameLANHops,
+		SelfPublicIP:          deps.SelfPublicIP,
 	}
 	r, err := router.New(deps.DmsgC, rConf, deps.SetupHooks)
 	if err != nil {


### PR DESCRIPTION
## Problem

Route calculation had **no same-LAN awareness**: the route-finder is IP-blind (PK topology only) and the local calc did no self-IP filtering. So a peer on the visor's **own local network** — reached over a private/RFC1918 endpoint, or (the NAT-hairpin case) at the visor's **own public IP** — could be picked as a mux aux-leg intermediate. Being local it has the lowest latency, so the route-finder ranks it first and the rotation loop re-selects that same leg every tick: **zero path diversity** (same first-mile link, NAT, failure domain) and genuinely-diverse legs starve.

Observed live: a mux to a Frankfurt exit kept pinning its only aux leg to a same-network relay reached at the visor's own WAN IP (1-4ms), so the mux never grew a real second path and never spread throughput.

## Fix

- `transport.Manager.SameLANPeers(self net.IP)` — peers whose transport endpoint IP is private/RFC1918, equals the visor's own public IP, or shares its /24 (or a local interface's /24).
- Fed into `ExcludeIntermediatePKs` in **both** the initial aux-leg planner (`establishMuxRoutes`) and the rotation/self-heal add-leg path (`addOneAuxForwardLeg`).
- **Aux legs only** — the primary route is never blocked, so connectivity (never-wedge) is unchanged; a same-LAN peer stays usable as a direct dial **destination**.
- Gated by `routing.exclude_same_lan_hops` (`*bool`, default **ON**; absent/nil = ON). `SelfPublicIP` getter reads STUN live for the hairpin check. Wired through `visorcore.RouterDeps` so native + wasm edges share it.

## Validation

Live: after enabling, a mux to a remote exit no longer selects the same-network relay as its aux leg — route-finder results contained only src+dest, the aux leg came up over a genuinely diverse remote peer, and proxy throughput stayed steady with no wedge.