### PR TITLE
feat(router): capacity-weighted mux distribution + responder bulk-spread default

### DIFF
--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -242,6 +242,18 @@ const (
 	// round-robin across the rest. Like sticky:5tuple, meaningful
 	// for VPN apps; non-IPv4 payloads default to round-robin.
 	DistributionDSCPPriority
+	// DistributionCapacity spreads packets in proportion to each
+	// leg's recently-measured throughput (bytes carried since the
+	// last weight rebuild), with an exploration floor so every
+	// live leg keeps carrying (and so keeps being measured). It
+	// bootstraps as equal round-robin until legs have moved bytes.
+	// Unlike DistributionAuto (weights by inverse LATENCY, which
+	// dumps a bulk flow onto the single lowest-latency leg and
+	// starves higher-latency-but-fat legs), capacity weighting
+	// FILLS each leg toward its throughput — the right strategy
+	// for aggregating bandwidth across a disjoint multi-leg route.
+	// This is the adaptive default's bulk-spread mode.
+	DistributionCapacity
 )
 
 // LegChangeHook is an optional hook fired by the route group
@@ -372,6 +384,8 @@ func (m DistributionMode) String() string {
 		return "latency-adaptive"
 	case DistributionDSCPPriority:
 		return "dscp-priority"
+	case DistributionCapacity:
+		return "capacity"
 	}
 	return "unknown"
 }

--- a/pkg/router/policy/distribution.go
+++ b/pkg/router/policy/distribution.go
@@ -46,6 +46,8 @@ func ParseDistribution(s string) (router.DistributionConfig, error) {
 		return router.DistributionConfig{Mode: router.DistributionRoundRobin}, nil
 	case "latency-adaptive", "latency-aware":
 		return router.DistributionConfig{Mode: router.DistributionLatencyAdaptive}, nil
+	case "capacity", "capacity-weighted":
+		return router.DistributionConfig{Mode: router.DistributionCapacity}, nil
 	}
 
 	// Prefix-based.

--- a/pkg/router/policy/presethook/presethook.go
+++ b/pkg/router/policy/presethook/presethook.go
@@ -240,6 +240,8 @@ func distributionFor(desc string) router.DistributionConfig {
 		return router.DistributionConfig{Mode: router.DistributionRoundRobin}
 	case "auto":
 		return router.DistributionConfig{Mode: router.DistributionAuto}
+	case "capacity":
+		return router.DistributionConfig{Mode: router.DistributionCapacity}
 	default:
 		return router.DistributionConfig{Mode: router.DistributionUnset}
 	}

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -925,6 +925,8 @@ func (rg *RouteGroup) applyDistribution(cfg DistributionConfig) {
 		wm = WeightModeSticky5Tuple
 	case DistributionLatencyAdaptive:
 		wm = WeightModeLatencyAdaptive
+	case DistributionCapacity:
+		wm = WeightModeCapacity
 	case DistributionDSCPPriority:
 		wm = WeightModeDSCPPriority
 		rg.mux.tpSelector.SetDSCPThreshold(cfg.DSCPThreshold)

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -46,6 +46,11 @@ type legCounters struct {
 	recvBytes   uint64 // atomic
 	recvPackets uint64 // atomic
 	retransmits uint64 // atomic
+	// lastTotalBytes snapshots sentBytes+recvBytes at the previous
+	// capacity-weight rebuild; the delta since then is this leg's
+	// recent throughput, used by WeightModeCapacity. Touched only
+	// under legMu in rebuildWeights, so it needs no atomic.
+	lastTotalBytes uint64
 }
 
 // routeMux encapsulates route multiplexing state and logic.
@@ -563,7 +568,30 @@ func (m *routeMux) heldRetxSeqs() []uint32 {
 
 // rebuildWeights updates transport selection weights based on current latency.
 func (m *routeMux) rebuildWeights(tps []*transport.ManagedTransport) {
-	if m.tpSelector != nil {
-		m.tpSelector.Rebuild(tps)
+	if m.tpSelector == nil {
+		return
 	}
+	// Capacity mode: feed the selector each leg's throughput since
+	// the last rebuild (bytes sent+recv delta) so it can weight the
+	// schedule toward the legs actually moving data. Computed here
+	// (not in the selector) because the mux owns the per-leg byte
+	// counters. The delta resets each rebuild, so the weights track
+	// RECENT throughput, not lifetime totals (which would entrench
+	// whichever leg carried first).
+	if m.tpSelector.Mode() == WeightModeCapacity {
+		m.legMu.Lock()
+		weights := make([]float64, len(m.legs))
+		for i, lc := range m.legs {
+			if lc == nil {
+				continue
+			}
+			total := atomic.LoadUint64(&lc.sentBytes) + atomic.LoadUint64(&lc.recvBytes)
+			delta := total - lc.lastTotalBytes
+			lc.lastTotalBytes = total
+			weights[i] = float64(delta)
+		}
+		m.legMu.Unlock()
+		m.tpSelector.SetCapacityWeights(weights)
+	}
+	m.tpSelector.Rebuild(tps)
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -594,6 +594,13 @@ type router struct {
 	existingTpOnlyMu   sync.Mutex       // protects existingTpOnly
 	forceLocalRoutes   bool             // when true, skip route finder and use local route calculation
 	forceLocalRoutesMu sync.Mutex       // protects forceLocalRoutes
+	// responderBulkSpread, when true (the default), puts a mux-enabled
+	// responder route group into the capacity bulk-spread distribution so the
+	// download it serves aggregates bandwidth across its legs instead of
+	// piling onto the single fastest leg (the auto/latency-weighted default).
+	// See router_serve.go. Runtime-settable via SetResponderBulkSpread.
+	responderBulkSpread   bool
+	responderBulkSpreadMu sync.Mutex
 	// protects conf.MinHops, which SetMinHop changes at runtime while dials
 	// are reading it — see SetMinHop / MinHops.
 	minHopsMu         sync.RWMutex
@@ -718,6 +725,10 @@ func New(dmsgC *dmsg.Client, config *Config, routeSetupHooks []RouteSetupHook) (
 		routeSetupHooks: routeSetupHooks,
 		tpdCache:        newTPDSnapshotCache(),
 		suspects:        newSuspectHopCache(handshakeAwaitTimeout),
+		// Default a mux responder to capacity bulk-spread for the downloads it
+		// serves (see router_serve.go); operators can disable via
+		// SetResponderBulkSpread(false).
+		responderBulkSpread: true,
 	}
 
 	go r.rulesGCLoop()

--- a/pkg/router/router_config.go
+++ b/pkg/router/router_config.go
@@ -98,6 +98,25 @@ func (r *router) SetMuxMode(mode WeightMode) {
 	r.logger.Infof("SetMuxMode: %v", mode)
 }
 
+// ResponderBulkSpread reports whether a mux-enabled responder route group
+// should be put into the capacity bulk-spread distribution for the downloads
+// it serves. Default true; see router_serve.go.
+func (r *router) ResponderBulkSpread() bool {
+	r.responderBulkSpreadMu.Lock()
+	defer r.responderBulkSpreadMu.Unlock()
+	return r.responderBulkSpread
+}
+
+// SetResponderBulkSpread toggles responder-side capacity bulk-spread at
+// runtime. Existing route groups are unaffected until they re-establish; an
+// operator `proxy mux mode <x>` still overrides live groups via SetMuxMode.
+func (r *router) SetResponderBulkSpread(on bool) {
+	r.responderBulkSpreadMu.Lock()
+	r.responderBulkSpread = on
+	r.responderBulkSpreadMu.Unlock()
+	r.logger.Infof("SetResponderBulkSpread: %v", on)
+}
+
 // GetExistingTPOnly returns the current value of the existing-tp-only flag.
 func (r *router) GetExistingTPOnly() bool {
 	r.existingTpOnlyMu.Lock()

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -383,6 +383,24 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 
 			return nil, fmt.Errorf("sendHandshake (%s): %w", &rules.Desc, err)
 		}
+
+		// Responder-side download policy. This visor is the BULK SENDER for
+		// this route group: it serves the initiator's downloads over the
+		// reverse legs. The initiator's forward policy (interactive — narrow
+		// to one low-latency leg) never runs here; historically the responder
+		// had NO policy at all and fell back to the visor-wide muxMode (auto,
+		// latency-weighted), so a multi-leg download piled onto the single
+		// fastest leg and never aggregated bandwidth. Put a mux-enabled
+		// responder into the capacity bulk-spread profile so the download
+		// fills every leg toward its throughput. The keep-alive loop's
+		// periodic rebuildWeights keeps the capacity schedule fresh, so this
+		// is dynamic without a rotation goroutine. An operator `proxy mux
+		// mode <x>` (SetMuxMode) still propagates to and overrides this group
+		// live. (Layer 2 will let the initiator signal a specific reverse
+		// preset; until then capacity is the bulk default.)
+		if rg.mux != nil && r.ResponderBulkSpread() {
+			rg.applyDistribution(DistributionConfig{Mode: DistributionCapacity})
+		}
 	}
 
 	if ok && nrg != nil {

--- a/pkg/router/transport_selector.go
+++ b/pkg/router/transport_selector.go
@@ -49,6 +49,15 @@ const (
 	// others round-robin across the rest. Non-IPv4 payloads
 	// fall back to round-robin.
 	WeightModeDSCPPriority
+	// WeightModeCapacity weights each leg by its recently-measured
+	// throughput (capacityWeights, set by the mux from per-leg
+	// byte deltas), with a per-leg exploration floor so every live
+	// leg keeps a share. Bootstraps as equal round-robin until the
+	// mux has throughput samples. Contrast WeightModeAuto, which
+	// weights by inverse LATENCY and so starves a fat-but-slow leg;
+	// capacity fills each leg toward its bandwidth — the mode that
+	// actually aggregates throughput across a disjoint mux.
+	WeightModeCapacity
 )
 
 // transportSelector implements weighted transport selection based on latency.
@@ -81,6 +90,11 @@ type transportSelector struct {
 	// for adaptive's GetLatency lookups — avoids reaching back
 	// through the route group's tps[] under a lock per packet.
 	liveTps []*transport.ManagedTransport
+	// capacityWeights holds per-leg recent throughput (bytes moved
+	// since the last rebuild), one entry per leg index, used by
+	// WeightModeCapacity. Set by the mux via SetCapacityWeights
+	// before each Rebuild. Empty / all-zero → equal bootstrap.
+	capacityWeights []float64
 }
 
 func newTransportSelector() *transportSelector {
@@ -95,6 +109,16 @@ func newTransportSelector() *transportSelector {
 func (ts *transportSelector) SetExplicitWeights(w []float64) {
 	ts.mu.Lock()
 	ts.explicitWeights = append([]float64(nil), w...)
+	ts.mu.Unlock()
+}
+
+// SetCapacityWeights stores per-leg recent-throughput weights used
+// by WeightModeCapacity. Caller (the mux) recomputes these from
+// per-leg byte deltas and calls Rebuild afterwards. A copy is kept
+// so the caller may reuse its slice.
+func (ts *transportSelector) SetCapacityWeights(w []float64) {
+	ts.mu.Lock()
+	ts.capacityWeights = append([]float64(nil), w...)
 	ts.mu.Unlock()
 }
 
@@ -162,6 +186,59 @@ func (ts *transportSelector) Rebuild(tps []*transport.ManagedTransport) {
 		}
 		ts.schedule = schedule
 		return
+	}
+
+	// Capacity mode: weight each live leg by its recently-measured
+	// throughput (capacityWeights), with a floor of 1 slot per live leg
+	// so no leg is starved (and so keeps being measured). Until there IS
+	// throughput to weigh by (bootstrap, or a fully-quiet flow) this
+	// deliberately falls through to the latency-weighted Auto schedule
+	// below rather than spraying equally — an equal bootstrap would put
+	// 1/N of the very first packets down a slow aux leg and head-of-line
+	// stall a heterogeneous mux before any capacity is known. Latency-
+	// weighting is the safe cold-start; once bytes flow, the per-leg
+	// deltas arrive and the schedule shifts to true capacity weighting.
+	if ts.mode == WeightModeCapacity {
+		type liveLeg struct {
+			idx int
+			w   float64
+		}
+		live := make([]liveLeg, 0, n)
+		maxW := 0.0
+		for i, tp := range tps {
+			if tp == nil || tp.IsClosed() {
+				continue
+			}
+			w := 0.0
+			if i < len(ts.capacityWeights) && ts.capacityWeights[i] > 0 {
+				w = ts.capacityWeights[i]
+			}
+			if w > maxW {
+				maxW = w
+			}
+			live = append(live, liveLeg{idx: i, w: w})
+		}
+		// maxW == 0 → no throughput samples yet: fall through to Auto
+		// (latency-weighted) for a safe cold-start. len(live)==0 can't
+		// happen here (n>1 and closed legs are skipped, but at least one
+		// is live in a real rebuild); guard anyway.
+		if len(live) > 0 && maxW > 0 {
+			// capacityBias caps how many extra slots the fattest leg
+			// gets over the 1-slot floor. 7 → up to 8:1, enough to
+			// steer bulk toward capacity without ever fully starving a
+			// thin leg (its floor of 1 keeps it live and measured).
+			const capacityBias = 7
+			schedule := make([]int, 0, len(live)*(capacityBias+1))
+			for _, l := range live {
+				count := 1 + int(float64(capacityBias)*(l.w/maxW)+0.5)
+				for j := 0; j < count; j++ {
+					schedule = append(schedule, l.idx)
+				}
+			}
+			ts.schedule = schedule
+			return
+		}
+		// else fall through to Auto (latency-weighted) cold-start.
 	}
 
 	// Explicit mode: operator-supplied fractional weights, one

--- a/pkg/router/transport_selector_test.go
+++ b/pkg/router/transport_selector_test.go
@@ -342,3 +342,58 @@ func TestTransportSelector_DSCPPriority_NonIPv4FallsToRR(t *testing.T) {
 		t.Errorf("non-IPv4 should never go to leg 0 (no DSCP read), got %d", counts[0])
 	}
 }
+
+// TestTransportSelector_CapacityBootstrap: with no throughput samples yet
+// (bootstrap), capacity mode degenerates to equal round-robin so every leg
+// is exercised and its capacity discovered.
+func TestTransportSelector_CapacityBootstrap(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeCapacity)
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	counts := make(map[int]int)
+	for i := 0; i < 100; i++ {
+		counts[ts.Select()]++
+	}
+	assert.Equal(t, 50, counts[0])
+	assert.Equal(t, 50, counts[1])
+}
+
+// TestTransportSelector_CapacityWeighted: once throughput is measured, the
+// schedule biases toward the fatter leg — UNLIKE latency-weighting, this is
+// driven by bytes carried, not RTT. leg0 moved 700, leg1 100: leg0 gets
+// 1+round(7*700/700)=8 slots, leg1 gets 1+round(7*100/700)=2.
+func TestTransportSelector_CapacityWeighted(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeCapacity)
+	ts.SetCapacityWeights([]float64{700, 100})
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	counts := make(map[int]int)
+	for i := 0; i < ts.Len()*10; i++ {
+		counts[ts.Select()]++
+	}
+	// leg0 carries ~4x leg1, but leg1 is never starved.
+	assert.Greater(t, counts[0], counts[1]*2)
+	assert.Positive(t, counts[1])
+}
+
+// TestTransportSelector_CapacityFloor: a leg with zero recent throughput
+// still gets a floor slot so it keeps carrying (and keeps being measured) —
+// it must never be starved to zero the way pure proportional weighting would.
+func TestTransportSelector_CapacityFloor(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeCapacity)
+	ts.SetCapacityWeights([]float64{1000, 0})
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	counts := make(map[int]int)
+	for i := 0; i < ts.Len()*5; i++ {
+		counts[ts.Select()]++
+	}
+	assert.Positive(t, counts[1], "zero-throughput leg must keep a floor share")
+	assert.Greater(t, counts[0], counts[1])
+}

--- a/pkg/visor/api_transport.go
+++ b/pkg/visor/api_transport.go
@@ -171,8 +171,10 @@ func (v *Visor) SetMuxMode(mode string) error {
 		m = router.WeightModeAuto
 	case "equal":
 		m = router.WeightModeEqual
+	case "capacity":
+		m = router.WeightModeCapacity
 	default:
-		return fmt.Errorf("unknown mux mode %q (use \"auto\" or \"equal\")", mode)
+		return fmt.Errorf("unknown mux mode %q (use \"auto\", \"equal\", or \"capacity\")", mode)
 	}
 	v.router.SetMuxMode(m)
 	v.log.Infof("SetMuxMode: %v", mode)


### PR DESCRIPTION
Adds a throughput-filling distribution mode for multiplexed route groups and makes the responder use it for the downloads it serves.

**Problem.** `WeightModeAuto` weights mux legs by inverse *latency*, so a single-stream mux piles onto the one lowest-latency leg and starves higher-latency-but-fat legs — it can't aggregate bandwidth across a disjoint route. Worse, a route group's *responder* (the bulk sender for the downloads it serves) ran no policy at all and fell back to that same `auto` default, so multi-leg downloads concentrated on one leg with no way for the far end to influence it.

**Change.**
- `WeightModeCapacity` / `DistributionCapacity`: weight each leg by its recently-measured throughput (per-leg sent+recv byte delta since the last rebuild), with a per-leg floor so no leg is starved. Cold-start falls through to latency-weighting until throughput exists (never an equal spray that would head-of-line-stall a heterogeneous mux); once bytes flow it shifts to true capacity weighting. The existing keep-alive `rebuildWeights` cadence keeps it fresh — dynamic, no new goroutine.
- Responder bulk-spread default: a mux-enabled responder now enters capacity mode for its downloads (gated by `SetResponderBulkSpread`, default on). `SetMuxMode` already propagates to live route groups, so an operator `proxy mux mode <x>` still overrides live without tearing routes down.
- Selectable via `proxy mux mode capacity` and policy descriptors (`distribution=capacity`, parsed by both `policy.ParseDistribution` and `presethook.distributionFor`).

Unit tests cover the cold-start, weighted-bias, and never-starve-floor behaviours. The default is safe: a responder only diverges from today's `auto` behaviour once it has throughput data to weigh by.