### PR TITLE
fix(lint): clear develop golangci-lint debt (unblocks all open PRs)

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/pty.go
+++ b/cmd/skywire-cli/commands/dmsg/pty.go
@@ -110,7 +110,7 @@ func init() {
 		"(not supported for pty start yet — accepted for vocabulary parity; errors if set)")
 	ptyStartCmd.Flags().BoolVar(&ptyVisorKey, "visor-key", false,
 		"borrow the local visor's SK from "+visorconfig.SkywireConfig()+" for the tcp noise handshake (default false: opt-in; --sk wins)")
-	_ = ptyStartCmd.Flags().MarkHidden("via-visor")
+	_ = ptyStartCmd.Flags().MarkHidden("via-visor") //nolint:errcheck
 
 	// Flags for exec command
 	ptyExecCmd.PersistentFlags().StringVarP(&ptyRpcAddr, "rpc", "", "localhost:3435", "RPC server address")
@@ -131,8 +131,8 @@ func init() {
 		"(not supported for pty exec yet — accepted for vocabulary parity; errors if set)")
 	ptyExecCmd.Flags().BoolVar(&ptyVisorKey, "visor-key", false,
 		"borrow the local visor's SK from "+visorconfig.SkywireConfig()+" for the tcp noise handshake (default false: opt-in; --sk wins)")
-	_ = ptyExecCmd.Flags().MarkHidden("scheme")
-	_ = ptyExecCmd.Flags().MarkHidden("via-visor")
+	_ = ptyExecCmd.Flags().MarkHidden("scheme")    //nolint:errcheck
+	_ = ptyExecCmd.Flags().MarkHidden("via-visor") //nolint:errcheck
 
 	// Flags for ui command
 	ptyUICmd.Flags().StringVarP(&ptyPath, "input", "i", "", "read from specified config file")

--- a/cmd/skywire-cli/commands/svc/fetch.go
+++ b/cmd/skywire-cli/commands/svc/fetch.go
@@ -382,7 +382,7 @@ sessions show as "(down: <duration>)"; sessions shorter than
 			// plainly instead of dumping a raw RPC/HTTP error + exit 1.
 			if strings.Contains(err.Error(), "503") || strings.Contains(err.Error(), "404") {
 				fmt.Fprintln(cmd.ErrOrStderr(), "svc tpd uptime: the transport-discovery reports no session history (HTTP 503/404 from /uptime/sessions).") //nolint:errcheck
-				fmt.Fprintln(cmd.ErrOrStderr(), "This deployment's TPD build does not record its own session history (pkg/serviceuptime not enabled).")    //nolint:errcheck
+				fmt.Fprintln(cmd.ErrOrStderr(), "This deployment's TPD build does not record its own session history (pkg/serviceuptime not enabled).")     //nolint:errcheck
 				return
 			}
 			internal.PrintFatalError(cmd.Flags(), err)

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -222,7 +222,6 @@ type Config struct {
 	// getter or nil result is fine — the private-IP and local-interface /24
 	// checks still apply.
 	SelfPublicIP func() net.IP
-
 }
 
 // SetDefaults sets default values for certain empty values.

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -1537,7 +1537,7 @@ func (tm *Manager) TransportRemoteAddrs() []string {
 // nil when the public IP is not yet known (STUN pending) — the private-IP and
 // local-interface /24 checks still apply.
 func (tm *Manager) SameLANPeers(self net.IP) []cipher.PubKey {
-	localIPs, _ := netutil.LocalNetworkInterfaceIPs()
+	localIPs, _ := netutil.LocalNetworkInterfaceIPs() //nolint:errcheck // best-effort; nil localIPs handled below
 
 	tm.mx.RLock()
 	defer tm.mx.RUnlock()

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -312,7 +312,6 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 			}
 			return nil
 		},
-
 	})
 	if err != nil {
 		cancel()


### PR DESCRIPTION
golangci-lint v2.12.2 is red on develop with 7 issues, so every open PR fails the linux/darwin/windows lint gate — that's why the PR queue backed up.

- **gofmt** (3 files had formatting drift): pkg/router/router.go, pkg/visor/init_router.go, cmd/skywire-cli/commands/svc/fetch.go
- **errcheck** (the config sets `check-blank: true`, so `_ = f()` blank error assignments are flagged): annotate the intentionally-ignored returns — dmsg/pty.go `MarkHidden` ×3 (cosmetic hide of parity flags) and transport/manager.go `LocalNetworkInterfaceIPs` (best-effort; nil result is handled just below).

These slipped in via admin-merges that bypassed the lint gate. Landing this turns develop's lint green so the rebased PRs can pass.