### PR TITLE
diag(cxo): name the object behind the treestore publish-freeze (#4088)

### DIFF
--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -1090,7 +1090,19 @@ func (c *Cache) incItem(
 	}
 
 	if it.isFilling() == true { //nolint:staticcheck
-		return c.incFilling(key, inc, it)
+		rc, err = c.incFilling(key, inc, it)
+		if err == data.ErrNotFound {
+			// Diagnostic (#4088): the reference-walk Inc path cannot repair a
+			// filling placeholder whose CXDS backing was evicted (refcount
+			// GC / prune racing eviction) — unlike setFilling (the Set path,
+			// which carries the value). Name the object so the treestore
+			// publish-freeze log identifies its culprit hash instead of a bare
+			// "not found", letting us classify it (Registry/Root/TreeNode) and
+			// target the real fix. %w keeps the ErrNotFound sentinel intact for
+			// the self-heal's isMissingObject (errors.Is + "not found") checks.
+			err = fmt.Errorf("filling object %s missing CXDS backing (Inc path, unrepairable): %w", key.Hex()[:16], err)
+		}
+		return rc, err
 	}
 
 	// remove item if it's cc is zero


### PR DESCRIPTION
The TPD transport fill-gap is a publisher-side treestore freeze that logs only `treestore encode/save: not found` every heartbeat — no object identity, so fixes keep getting mis-aimed (this is the 'looked right, never verified' loop on #4088).

#4041 repaired the filling-invariant on the `Set` path (`setFilling`) but not the reference-walk `Inc` path (`incItem`→`incFilling`), which `Container.Save`'s refcount walk uses. This wraps that specific `ErrNotFound` with the object's hash so the existing publish-freeze WARN self-identifies its culprit, letting us classify it (Registry / Root / TreeNode) from live logs and target the real fix.

`%w` keeps the `ErrNotFound` sentinel intact for the self-heal's `isMissingObject` (`errors.Is` + "not found" substring) check — the #4041 filling-trap self-heal test still passes. Diagnostic only; no behavior change.