### PR TITLE
fix(cxo): best-effort publisher hydrate — skip dangling sub-refs, keep the tree, name the culprit

### DIFF
--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -423,8 +423,20 @@ func (p *Publisher) hydrateFromContainer() error {
 		return fmt.Errorf("decode root TreeNode: %w", err)
 	}
 	hydrated := newMemNode()
-	if err := hydrateMemNode(up, &rootNode, hydrated); err != nil {
+	var dropped []string
+	if err := hydrateMemNode(up, &rootNode, hydrated, &dropped, ""); err != nil {
 		return fmt.Errorf("walk: %w", err)
+	}
+	// A dangling sub-object reference (the filling-trap's persisted form:
+	// a placeholder whose CXDS backing never landed) no longer discards the
+	// WHOLE previously-published tree. hydrateMemNode skips only the affected
+	// subtree; here we surface exactly which object(s) trapped so the culprit
+	// hash is identifiable, then keep the intact remainder as our starting
+	// state. This bounds the TPD under-report to the trapped subtree instead
+	// of dropping every transport this visor had published.
+	if len(dropped) > 0 {
+		p.log.WithField("dropped", dropped).
+			Warn("treestore-pub: hydrate skipped dangling sub-object refs (filling-trap culprits); kept the intact subtrees")
 	}
 	p.root = hydrated
 	return nil
@@ -438,7 +450,11 @@ func (p *Publisher) hydrateFromContainer() error {
 // produces a Root identical to the one we just read — until a Put
 // mutates a path, after which the dirty-path-only re-encode keeps
 // the unchanged subtrees stable.
-func hydrateMemNode(up registry.Pack, node *TreeNode, dest *memNode) error {
+// dropped accumulates "<path>/<name>(<hash16>)" for each sub-object ref that
+// could not be resolved from CXDS (the filling-trap's persisted form). Such a
+// ref is SKIPPED rather than aborting the whole hydrate, so the intact subtrees
+// survive a restart; path threads the ancestor names for a locatable label.
+func hydrateMemNode(up registry.Pack, node *TreeNode, dest *memNode, dropped *[]string, path string) error {
 	n, err := node.Children.Len(up)
 	if err != nil {
 		return err
@@ -455,12 +471,23 @@ func hydrateMemNode(up registry.Pack, node *TreeNode, dest *memNode) error {
 		if entry.Sub.Hash == (skycipher.SHA256{}) {
 			continue
 		}
+		childPath := entry.Name
+		if path != "" {
+			childPath = path + "/" + entry.Name
+		}
 		var sub TreeNode
 		if err := entry.Sub.Value(up, &sub); err != nil {
+			// Best-effort: a missing (unbacked) sub-object drops only its own
+			// subtree — name the culprit hash and continue with the rest. A
+			// non-missing decode error is real corruption; still abort.
+			if isMissingObject(err) {
+				*dropped = append(*dropped, fmt.Sprintf("%s(%s)", childPath, entry.Sub.Hash.Hex()[:16]))
+				continue
+			}
 			return err
 		}
 		child := newMemNode()
-		if err := hydrateMemNode(up, &sub, child); err != nil {
+		if err := hydrateMemNode(up, &sub, child, dropped, childPath); err != nil {
 			return err
 		}
 		dest.subs[entry.Name] = child

--- a/pkg/cxo/treestore/publisher_rehydrate_test.go
+++ b/pkg/cxo/treestore/publisher_rehydrate_test.go
@@ -313,8 +313,12 @@ func TestHydrateMemNodeWalksLeavesAndSubTrees(t *testing.T) {
 	}
 
 	dest := newMemNode()
-	if err := hydrateMemNode(up, &outerNode, dest); err != nil {
+	var dropped []string
+	if err := hydrateMemNode(up, &outerNode, dest, &dropped, ""); err != nil {
 		t.Fatalf("hydrateMemNode: %v", err)
+	}
+	if len(dropped) != 0 {
+		t.Fatalf("hydrateMemNode: unexpected dropped refs on intact tree: %v", dropped)
 	}
 	if got, want := string(dest.leaves["alpha"]), "alpha-value"; got != want {
 		t.Errorf("dest.leaves[alpha]: got %q want %q", got, want)
@@ -325,5 +329,59 @@ func TestHydrateMemNodeWalksLeavesAndSubTrees(t *testing.T) {
 	}
 	if got, want := string(beta.leaves["deep"]), "deep-value"; got != want {
 		t.Errorf("dest.subs[beta].leaves[deep]: got %q want %q", got, want)
+	}
+}
+
+// TestHydrateMemNodeSkipsDanglingSubRef pins the best-effort contract: a
+// sub-entry whose Sub.Hash has no CXDS backing (the filling-trap's persisted
+// form) must NOT abort the whole hydrate. The intact sibling leaf survives,
+// the dangling ref is reported (naming its hash) in `dropped`, and no error is
+// returned — so a single trapped object bounds the loss to its own subtree
+// rather than dropping every previously-published leaf to an empty tree.
+func TestHydrateMemNodeSkipsDanglingSubRef(t *testing.T) {
+	dir := t.TempDir()
+	_, sk := cipher.GenerateKeyPair()
+
+	n := fileBackedNode(t, dir, sk)
+	defer func() {
+		_ = n.Close() //nolint:errcheck
+	}()
+
+	c := n.Container()
+	up, err := c.Unpack(skycipher.SecKey(sk), Registry)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	defer func() {
+		_ = up.Close() //nolint:errcheck
+	}()
+
+	// A real leaf plus a sub-entry pointing at an object that was never
+	// saved through the pack — Value() on it resolves to ErrNotFound.
+	ghostHash := skycipher.SumSHA256([]byte("ghost-treenode-never-saved"))
+	goodLeaf := TreeEntry{Name: "alpha", Leaf: []byte("alpha-value")}
+	danglingSub := TreeEntry{Name: "ghost", Sub: registry.Ref{Hash: ghostHash}}
+	outerNode := TreeNode{}
+	if err := outerNode.Children.AppendValues(up, goodLeaf, danglingSub); err != nil {
+		t.Fatalf("outer.AppendValues: %v", err)
+	}
+
+	dest := newMemNode()
+	var dropped []string
+	if err := hydrateMemNode(up, &outerNode, dest, &dropped, ""); err != nil {
+		t.Fatalf("hydrateMemNode: dangling sub-ref must not abort the walk: %v", err)
+	}
+	if got, want := string(dest.leaves["alpha"]), "alpha-value"; got != want {
+		t.Errorf("intact sibling leaf lost: got %q want %q", got, want)
+	}
+	if _, ok := dest.subs["ghost"]; ok {
+		t.Errorf("dangling subtree should have been skipped, not materialized")
+	}
+	if len(dropped) != 1 {
+		t.Fatalf("dropped: got %v, want exactly one entry naming the ghost ref", dropped)
+	}
+	if !bytes.Contains([]byte(dropped[0]), []byte("ghost")) ||
+		!bytes.Contains([]byte(dropped[0]), []byte(ghostHash.Hex()[:16])) {
+		t.Errorf("dropped entry should name the path and culprit hash: %q", dropped[0])
 	}
 }


### PR DESCRIPTION
The transport publisher's startup hydrate walked the previously-published Root strictly, so a single dangling sub-object reference — the filling-trap's persisted form, a placeholder whose CXDS backing never landed — aborted the whole walk. The publisher then fell back to an empty tree and dropped every previously-published transport until it republished. This is the observed `treestore-pub: hydrate from container failed ... walk: not found` that shows up as a live visor under-reporting its transports to TPD after a restart.

hydrateMemNode now skips only the unbacked subtree and continues; hydrateFromContainer logs exactly which object(s) trapped (path + 16-hex hash) and keeps the intact remainder as the starting state. This bounds the loss to the trapped subtree instead of the whole feed, and finally names the culprit hash for the underlying filling-trap investigation.

Adds a direct unit test for the skip-and-name behavior; full treestore suite green.