### PR TITLE
feat(config): enable native browse-origin by default for HTTPS proxy-status pages

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -336,6 +336,16 @@ func init() {
 	genConfigCmd.Flags().StringVar(&skynetWebProxyAddr, "skynetweb-addr", scriptExecString("${SKYNETWEBADDR}"), "host the .skynet SOCKS5 proxy binds to (empty=127.0.0.1; 0.0.0.0 or a LAN IP to serve the LAN)")
 	gHiddenFlags = append(gHiddenFlags, "skynetweb-addr")
 
+	// Browse-origin flags: the loopback real-origin browse proxy also serves the
+	// warning-free HTTPS proxy-status pages (status-<surface>.<suffix>) when a real
+	// wildcard cert for *.<suffix> is supplied. Enabled by default (loopback-only).
+	genConfigCmd.Flags().BoolVar(&noBrowseOrigin, "no-browse-origin", scriptExecBool("${NOBROWSEORIGIN:-false}"), "do not serve the loopback real-origin browse proxy / HTTPS proxy-status pages (status-<surface>.<suffix>)")
+	genConfigCmd.Flags().StringVar(&browseOriginSuffix, "browse-suffix", scriptExecString("${BROWSESUFFIX}"), fmt.Sprintf("browse-origin domain suffix (leading dot) for the loopback browse proxy + HTTPS proxy-status pages. Empty = deployment default (%q)", deployment.Prod.BrowseOriginSuffix))
+	genConfigCmd.Flags().StringVar(&browseOriginTLSCert, "browse-tls-cert", scriptExecString("${BROWSETLSCERT}"), "PEM cert for the browse-origin listener — a real wildcard cert for *.<browse-suffix> so status-<surface>.<suffix> loads over warning-free HTTPS. Requires --browse-tls-key; empty = plain HTTP on loopback")
+	gHiddenFlags = append(gHiddenFlags, "browse-tls-cert")
+	genConfigCmd.Flags().StringVar(&browseOriginTLSKey, "browse-tls-key", scriptExecString("${BROWSETLSKEY}"), "PEM key paired with --browse-tls-cert")
+	gHiddenFlags = append(gHiddenFlags, "browse-tls-key")
+
 	// Skychat flags
 	genConfigCmd.Flags().BoolVar(&isSkychatEnable, "servechat", scriptExecBool("${SKYCHAT:-true}"), "autostart skychat")
 	genConfigCmd.Flags().StringVar(&skychatAddr, "chataddr", scriptExecString("${SKYCHATADDR:-"+skyenv.SkychatAddr+"}"), "skychat local address")
@@ -2229,6 +2239,36 @@ func configureResolvingProxies() {
 			Addr:   skyenv.SkymailBridgeAddr,
 			Mode:   "b",
 		}
+	}
+	configureBrowseOrigin()
+}
+
+// configureBrowseOrigin enables, by default, the loopback "real-origin" browse
+// proxy (pkg/visor/meshproxy.go). Its meshStatusHandler serves the proxy-status
+// pages at status-<surface>.<suffix> (e.g. status-skysocks.haltingstate.net) —
+// the native counterpart of the wasm visor's browse origin. Suffix defaults to
+// the deployment's browse_origin_suffix (".haltingstate.net"), matching the wasm
+// surface, so a real single-level wildcard cert *.<suffix> covers the status
+// hosts. TLS activates on that loopback listener ONLY when the operator supplies
+// --browse-tls-cert/--browse-tls-key (the wildcard PRIVATE KEY is a deployment
+// secret and cannot ship in config-gen defaults); until then the listener serves
+// plain HTTP on loopback. There is deliberately NO self-signed fallback: a
+// self-signed cert would defeat the whole point (warning-free HTTPS via a real
+// cert) — the self-signed-leaf path stays on the .skynet TLS-MITM surface
+// (SkynetWebConfig.TLSMITM). Opt out with --no-browse-origin.
+func configureBrowseOrigin() {
+	if noBrowseOrigin {
+		return
+	}
+	suffix := strings.TrimSpace(browseOriginSuffix)
+	if suffix == "" {
+		suffix = deployment.Prod.BrowseOriginSuffix
+	}
+	conf.BrowseOrigin = &visorconfig.BrowseOriginConfig{
+		Enable:  true,
+		Suffix:  suffix,
+		TLSCert: browseOriginTLSCert,
+		TLSKey:  browseOriginTLSKey,
 	}
 }
 

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -126,6 +126,10 @@ var (
 	skynetWebUpstreamSOCKS     string
 	dmsgWebProxyAddr           string
 	skynetWebProxyAddr         string
+	noBrowseOrigin             bool
+	browseOriginSuffix         string
+	browseOriginTLSCert        string
+	browseOriginTLSKey         string
 	configServicePath          string
 	dmsgHTTPPath               string
 	snConfig                   bool


### PR DESCRIPTION
Enable the native "real-origin" browse proxy by default so the proxy-status pages (`status-<surface>.<suffix>`, e.g. `status-skysocks.haltingstate.net`) are reachable over warning-free HTTPS from a native visor — the same browse-origin path the wasm visor already uses — instead of only over the raw-TLS SOCKS surface.

The mechanism already existed in `pkg/visor/meshproxy.go` (`serveMeshSubdomain` + `meshStatusHandler`), but `config gen` never populated `browse_origin`, so it was off on every native visor. Config-gen now emits an enabled `BrowseOrigin` block with `Suffix` defaulting to the deployment's `browse_origin_suffix` (`.haltingstate.net`), on a loopback listener. TLS on that listener activates only when the operator supplies a cert/key — the `*.haltingstate.net` wildcard private key is a deployment secret and cannot ship in defaults — via new flags `--browse-suffix`, `--browse-tls-cert`, `--browse-tls-key`, with `--no-browse-origin` to opt out. There is deliberately no self-signed fallback: a self-signed cert would defeat the warning-free-HTTPS goal, and the self-signed-leaf path stays on the `.skynet` TLS-MITM surface.

To get warning-free HTTPS locally the operator supplies the real wildcard cert/key and points `status-skysocks.haltingstate.net` at loopback (DNS or `/etc/hosts`); with no cert the listener serves plain HTTP on loopback and the existing HTTP `status.skysocks` SOCKS path is unchanged.
