### PR TITLE
feat(proxystatus): per-layer status ownership; move status.skysocks to skysocks-client

### DIFF
--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -154,11 +154,35 @@ type Config struct {
 	DirectServerPKs map[cipher.PubKey]struct{}
 
 	// StatusProvider, when non-nil, enables the reserved in-process status hosts
-	// (http://status.dmsg/ etc.) served through this proxy — a read-only
-	// diagnostic page (logs + route/transport events + per-leg mux view) for a
-	// surface. Nil disables the status hosts (they fall through to a normal
-	// resolve / upstream forward). See pkg/proxystatus.
+	// served through this proxy — a read-only diagnostic page (logs +
+	// route/transport events + per-leg mux view) for a surface. Nil disables the
+	// status hosts (they fall through to a normal resolve / upstream forward).
+	// See pkg/proxystatus.
 	StatusProvider proxystatus.Provider
+	// StatusSurface scopes which reserved status host THIS proxy layer owns and
+	// answers for (e.g. SurfaceDmsg → only http(s)://status.dmsg/). A status host
+	// matching a DIFFERENT surface is NOT served here — it falls through so the
+	// request continues up the proxy chain to the layer that owns it. Empty means
+	// "serve any matched surface" (the pre-scoping behavior), kept so standalone
+	// runtimes and tests need no wiring. Ignored when StatusProvider is nil.
+	StatusSurface proxystatus.Surface
+}
+
+// ownsStatusSurface reports whether this layer should answer for a matched
+// status surface: true when no surface is configured (serve-any) or the matched
+// surface is exactly the one this layer owns.
+func (cfg Config) ownsStatusSurface(s proxystatus.Surface) bool {
+	return cfg.StatusSurface == "" || cfg.StatusSurface == s
+}
+
+// statusSnapshot fetches the surface's snapshot from the provider, degrading a
+// provider error to a rendered note rather than a failed page.
+func statusSnapshot(cfg Config, surface proxystatus.Surface) proxystatus.Snapshot {
+	snap, err := cfg.StatusProvider.StatusSnapshot(surface)
+	if err != nil {
+		return proxystatus.Snapshot{Surface: surface, Note: "status unavailable: " + err.Error()}
+	}
+	return snap
 }
 
 // DmsgTarget is a (publicKey, dmsgPort) pair used in fixed-mapping mode.
@@ -320,19 +344,36 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 				origPort = "80"
 			}
 
-			// Reserved status hosts (http://status.dmsg/ etc.): served in-process,
-			// never dialed out — the read-only diagnostic page for a surface.
-			// Checked before suffix resolution / upstream forwarding so any of the
-			// three status hosts is reachable through this proxy. Recognized only on
-			// plaintext HTTP (a status page can't ride a raw-TLS tunnel).
+			// Reserved status host this layer OWNS (http://status.dmsg/): served
+			// in-process, never dialed out — the read-only diagnostic page for the
+			// surface. Checked before suffix resolution / upstream forwarding. A
+			// status host for a DIFFERENT surface is NOT served here; it falls
+			// through to the upstream forward so the request reaches the layer that
+			// owns it. Plaintext HTTP only (a status page can't ride a raw-TLS
+			// tunnel); the owned host is also served over TLS-MITM below.
 			if cfg.StatusProvider != nil && proxyinterstitial.ShouldServe(origPort) {
-				if surface, ok := proxystatus.Match(origHost); ok {
-					snap, serr := cfg.StatusProvider.StatusSnapshot(surface)
-					if serr != nil {
-						snap = proxystatus.Snapshot{Surface: surface, Note: "status unavailable: " + serr.Error()}
-					}
+				if surface, ok := proxystatus.Match(origHost); ok && cfg.ownsStatusSurface(surface) {
 					log.WithField("surface", string(surface)).Debug("SOCKS5 → serving in-process proxy status page")
-					return &tcpAddrConn{Conn: proxystatus.ServeConn(proxystatus.Render(snap))}, nil
+					return &tcpAddrConn{Conn: proxystatus.ServeConn(proxystatus.Render(statusSnapshot(cfg, surface)))}, nil
+				}
+			}
+
+			// Owned status host over HTTPS: status.dmsg is within the resolver CA's
+			// name constraints (.dmsg), so a per-host leaf is valid. Terminate the
+			// browser's TLS locally and serve the page over it — the TLS analog of
+			// the plaintext branch above. Only for the surface this layer owns; a
+			// different surface falls through to the upstream forward.
+			if cfg.StatusProvider != nil && cfg.TLSMITM && isTLSPort(origPort, cfg.TLSPort) {
+				if surface, ok := proxystatus.Match(origHost); ok && cfg.ownsStatusSurface(surface) {
+					leaf, lerr := cfg.LeafMinter.For(origHost)
+					if lerr != nil {
+						log.WithField("surface", string(surface)).WithField("err", lerr).
+							Debug("SOCKS5 → status-over-TLS leaf mint failed; falling through")
+					} else {
+						log.WithField("surface", string(surface)).Debug("SOCKS5 → serving in-process proxy status page over TLS (MITM)")
+						return &tcpAddrConn{Conn: skynetca.MITMTerminate(
+							proxystatus.ServeConn(proxystatus.Render(statusSnapshot(cfg, surface))), leaf)}, nil
+					}
 				}
 			}
 

--- a/pkg/dmsgweb/status_scoping_test.go
+++ b/pkg/dmsgweb/status_scoping_test.go
@@ -1,0 +1,94 @@
+package dmsgweb
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/proxy"
+
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/proxyinterstitial"
+	"github.com/skycoin/skywire/pkg/proxystatus"
+)
+
+// fakeStatusProvider answers for every surface with a minimal snapshot, so the
+// rendered page is deterministic and identifiable ("per-leg mux" is always in
+// proxystatus.Render output).
+type fakeStatusProvider struct{}
+
+func (fakeStatusProvider) StatusSnapshot(s proxystatus.Surface) (proxystatus.Snapshot, error) {
+	return proxystatus.Snapshot{Surface: s, App: "test-" + string(s)}, nil
+}
+
+// TestSOCKS5StatusScoping proves a dmsg_web-scoped runtime serves ONLY its own
+// status host (status.dmsg) in-process and lets a different surface's status
+// host (status.skynet) fall through up the chain to the upstream forward.
+func TestSOCKS5StatusScoping(t *testing.T) {
+	// Upstream sink: any forwarded CONNECT is answered with a branded
+	// interstitial carrying a recognizable detail line ("upstream-sink"), so a
+	// fall-through is observable and distinct from the in-process status page.
+	upPort := freePort(t)
+	upAddr := fmt.Sprintf("127.0.0.1:%d", upPort)
+	upLis, err := net.Listen("tcp", upAddr)
+	require.NoError(t, err)
+	defer upLis.Close() //nolint:errcheck
+	go func() {
+		for {
+			c, aerr := upLis.Accept()
+			if aerr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				_ = proxyinterstitial.ServeSOCKS5(c, "upstream-sink", "skysocks") //nolint:errcheck
+				_ = c.Close()                                                     //nolint:errcheck
+			}(c)
+		}
+	}()
+
+	port := freePort(t)
+	cfg := Config{
+		DomainSuffix:   ".dmsg",
+		ProxyPort:      uint(port), //nolint:gosec
+		UpstreamSOCKS:  upAddr,
+		StatusProvider: fakeStatusProvider{},
+		StatusSurface:  proxystatus.SurfaceDmsg,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = serveSOCKS5Direct(ctx, logging.MustGetLogger("test"), &dmsg.Client{}, cfg) }() //nolint:errcheck
+
+	proxyAddr := fmt.Sprintf("127.0.0.1:%d", port)
+	waitForListen(t, proxyAddr)
+
+	dialer, err := proxy.SOCKS5("tcp", proxyAddr, nil, proxy.Direct)
+	require.NoError(t, err)
+	httpc := &http.Client{Timeout: 5 * time.Second, Transport: &http.Transport{Dial: dialer.Dial}} //nolint:staticcheck
+
+	// Owned surface: served in-process (never reaches the upstream sink).
+	dmsgBody := getBody(t, httpc, "http://status.dmsg/")
+	require.Contains(t, dmsgBody, "per-leg mux", "status.dmsg should be served in-process")
+	require.NotContains(t, dmsgBody, "upstream-sink", "status.dmsg must not fall through")
+
+	// Non-owned surface: NOT served here — falls through to the upstream sink.
+	skynetBody := getBody(t, httpc, "http://status.skynet/")
+	require.Contains(t, skynetBody, "upstream-sink", "status.skynet should fall through to the upstream")
+	require.NotContains(t, skynetBody, "per-leg mux", "status.skynet must not be served in-process by the dmsg layer")
+}
+
+func getBody(t *testing.T, httpc *http.Client, url string) string {
+	t.Helper()
+	resp, err := httpc.Get(url)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return string(b)
+}

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -148,10 +148,35 @@ type Config struct {
 	Aliases map[string]cipher.PubKey
 
 	// StatusProvider, when non-nil, enables the reserved in-process status hosts
-	// (http://status.skynet/ etc.) served through this proxy — a read-only
-	// diagnostic page (logs + route/transport events + per-leg mux view) for a
-	// surface. Nil disables the status hosts. See pkg/proxystatus.
+	// served through this proxy — a read-only diagnostic page (logs +
+	// route/transport events + per-leg mux view) for a surface. Nil disables the
+	// status hosts. See pkg/proxystatus.
 	StatusProvider proxystatus.Provider
+	// StatusSurface scopes which reserved status host THIS proxy layer owns and
+	// answers for (e.g. SurfaceSkynet → only http(s)://status.skynet/). A status
+	// host matching a DIFFERENT surface is NOT served here — it falls through so
+	// the request continues up the proxy chain to the layer that owns it. Empty
+	// means "serve any matched surface" (the pre-scoping behavior), kept so
+	// standalone runtimes and tests need no wiring. Ignored when StatusProvider is
+	// nil.
+	StatusSurface proxystatus.Surface
+}
+
+// ownsStatusSurface reports whether this layer should answer for a matched
+// status surface: true when no surface is configured (serve-any) or the matched
+// surface is exactly the one this layer owns.
+func (cfg Config) ownsStatusSurface(s proxystatus.Surface) bool {
+	return cfg.StatusSurface == "" || cfg.StatusSurface == s
+}
+
+// statusSnapshot fetches the surface's snapshot from the provider, degrading a
+// provider error to a rendered note rather than a failed page.
+func statusSnapshot(cfg Config, surface proxystatus.Surface) proxystatus.Snapshot {
+	snap, err := cfg.StatusProvider.StatusSnapshot(surface)
+	if err != nil {
+		return proxystatus.Snapshot{Surface: surface, Note: "status unavailable: " + err.Error()}
+	}
+	return snap
 }
 
 // Run starts the SOCKS5 proxy. Blocks until ctx is canceled.
@@ -237,20 +262,40 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 
 			origHost, _ := dialCtx.Value(skynetOrigHostKey{}).(string)
 
-			// Reserved status hosts (http://status.skynet/ etc.): served in-process,
-			// never routed out — the read-only diagnostic page for a surface.
-			// Checked before the .skynet match / upstream forward so any status host
-			// is reachable through this proxy. Plaintext HTTP only.
+			// Reserved status host this layer OWNS (http://status.skynet/): served
+			// in-process, never routed out — the read-only diagnostic page for the
+			// surface. Checked before the .skynet match / upstream forward. A status
+			// host for a DIFFERENT surface is NOT served here; it falls through to
+			// the upstream forward so the request reaches the layer that owns it.
+			// Plaintext HTTP only; the owned host is also served over TLS-MITM below.
 			if cfg.StatusProvider != nil {
 				_, sport, _ := net.SplitHostPort(addr) //nolint:errcheck
 				if proxyinterstitial.ShouldServe(sport) {
-					if surface, ok := proxystatus.Match(origHost); ok {
-						snap, serr := cfg.StatusProvider.StatusSnapshot(surface)
-						if serr != nil {
-							snap = proxystatus.Snapshot{Surface: surface, Note: "status unavailable: " + serr.Error()}
-						}
+					if surface, ok := proxystatus.Match(origHost); ok && cfg.ownsStatusSurface(surface) {
 						log.WithField("surface", string(surface)).Debug("SOCKS5 → serving in-process proxy status page")
-						return &tcpAddrConn{Conn: proxystatus.ServeConn(proxystatus.Render(snap))}, nil
+						return &tcpAddrConn{Conn: proxystatus.ServeConn(proxystatus.Render(statusSnapshot(cfg, surface)))}, nil
+					}
+				}
+			}
+
+			// Owned status host over HTTPS: status.skynet is within the resolver
+			// CA's name constraints (.skynet), so a per-host leaf is valid.
+			// Terminate the browser's TLS locally and serve the page over it — the
+			// TLS analog of the plaintext branch above. Only for the surface this
+			// layer owns; a different surface falls through.
+			if cfg.StatusProvider != nil && cfg.TLSMITM {
+				_, sport, _ := net.SplitHostPort(addr) //nolint:errcheck
+				if isTLSPort(sport, cfg.TLSPort) {
+					if surface, ok := proxystatus.Match(origHost); ok && cfg.ownsStatusSurface(surface) {
+						leaf, lerr := cfg.LeafMinter.For(origHost)
+						if lerr != nil {
+							log.WithField("surface", string(surface)).WithField("err", lerr).
+								Debug("SOCKS5 → status-over-TLS leaf mint failed; falling through")
+						} else {
+							log.WithField("surface", string(surface)).Debug("SOCKS5 → serving in-process proxy status page over TLS (MITM)")
+							return &tcpAddrConn{Conn: skynetca.MITMTerminate(
+								proxystatus.ServeConn(proxystatus.Render(statusSnapshot(cfg, surface))), leaf)}, nil
+						}
 					}
 				}
 			}

--- a/pkg/skynetweb/status_scoping_test.go
+++ b/pkg/skynetweb/status_scoping_test.go
@@ -1,0 +1,108 @@
+package skynetweb
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"golang.org/x/net/proxy"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/proxyinterstitial"
+	"github.com/skycoin/skywire/pkg/proxystatus"
+)
+
+type fakeStatusProvider struct{}
+
+func (fakeStatusProvider) StatusSnapshot(s proxystatus.Surface) (proxystatus.Snapshot, error) {
+	return proxystatus.Snapshot{Surface: s, App: "test-" + string(s)}, nil
+}
+
+// TestSOCKS5StatusScoping proves a skynet_web-scoped runtime serves ONLY its own
+// status host (status.skynet) in-process and lets a different surface's status
+// host (status.dmsg) fall through up the chain to the upstream forward.
+func TestSOCKS5StatusScoping(t *testing.T) {
+	upPort := pickFreePort(t)
+	upAddr := fmt.Sprintf("127.0.0.1:%d", upPort)
+	upLis, err := net.Listen("tcp", upAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upLis.Close() //nolint:errcheck
+	go func() {
+		for {
+			c, aerr := upLis.Accept()
+			if aerr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				_ = proxyinterstitial.ServeSOCKS5(c, "upstream-sink", "skysocks") //nolint:errcheck
+				_ = c.Close()                                                     //nolint:errcheck
+			}(c)
+		}
+	}()
+
+	proxyPort := pickFreePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = Run(ctx, logging.MustGetLogger("skynetweb-test"), fakeDialer{}, Config{ //nolint:errcheck
+			ProxyPort:      proxyPort,
+			UpstreamSOCKS:  upAddr,
+			StatusProvider: fakeStatusProvider{},
+			StatusSurface:  proxystatus.SurfaceSkynet,
+		})
+	}()
+	if err := waitForListener("127.0.0.1", proxyPort, 2*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	socksDialer, err := proxy.SOCKS5("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort), nil, proxy.Direct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpc := &http.Client{Timeout: 5 * time.Second, Transport: &http.Transport{Dial: socksDialer.Dial}} //nolint:staticcheck
+
+	// Owned surface: served in-process.
+	skynetBody := getBody(t, httpc, "http://status.skynet/")
+	if !contains(skynetBody, "per-leg mux") || contains(skynetBody, "upstream-sink") {
+		t.Fatalf("status.skynet not served in-process: %q", truncate(skynetBody))
+	}
+
+	// Non-owned surface: falls through to the upstream sink.
+	dmsgBody := getBody(t, httpc, "http://status.dmsg/")
+	if !contains(dmsgBody, "upstream-sink") || contains(dmsgBody, "per-leg mux") {
+		t.Fatalf("status.dmsg should have fallen through to upstream: %q", truncate(dmsgBody))
+	}
+}
+
+func getBody(t *testing.T, httpc *http.Client, url string) string {
+	t.Helper()
+	resp, err := httpc.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()       //nolint:errcheck
+	b, _ := io.ReadAll(resp.Body) //nolint:errcheck
+	return string(b)
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func truncate(s string) string {
+	if len(s) > 200 {
+		return s[:200]
+	}
+	return s
+}

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -2,6 +2,7 @@
 package skysocks
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/app"
 	"github.com/skycoin/skywire/pkg/proxyinterstitial"
+	"github.com/skycoin/skywire/pkg/proxystatus"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 )
@@ -181,6 +183,20 @@ func (c *Client) sessionAlive(timeout time.Duration) bool {
 }
 
 func (c *Client) handleStream(conn, stream net.Conn) {
+	// Transparently sniff the SOCKS5 CONNECT target so a request for the reserved
+	// status.skysocks host is answered in-process instead of tunneled to the
+	// exit. For every non-status request the greeting/method negotiation and the
+	// CONNECT request are forwarded to the exit byte-for-byte, so the exit sees an
+	// identical stream — only status.skysocks diverges.
+	if !c.sniffSOCKS5Status(conn, stream) {
+		conn.Close()   //nolint:errcheck,gosec
+		stream.Close() //nolint:errcheck,gosec
+		if c.session.IsClosed() {
+			c.close()
+		}
+		return
+	}
+
 	const errorCount = 2
 
 	errCh := make(chan error, errorCount)
@@ -209,6 +225,180 @@ func (c *Client) handleStream(conn, stream net.Conn) {
 
 	if c.session.IsClosed() {
 		c.close()
+	}
+}
+
+// statusSniffTimeout bounds the SOCKS5 handshake sniff so a wedged or
+// non-SOCKS5 client can't pin a handleStream goroutine. The greeting and CONNECT
+// request are sent right after connect, so this window is generous; it is
+// cleared before the bidirectional data splice, which stays deadline-free.
+const statusSniffTimeout = 15 * time.Second
+
+// sniffSOCKS5Status inspects the SOCKS5 CONNECT target to intercept the reserved
+// status.skysocks host. The greeting is forwarded to the exit verbatim and the
+// exit's method-selection reply is forwarded to the browser verbatim; only the
+// CONNECT request is parsed, and only a status.skysocks target diverges — every
+// other target's request is written to the exit byte-for-byte before splicing,
+// so non-status traffic is identical to a plain tunnel.
+//
+// Returns proceed=true when the caller should continue with the normal
+// bidirectional splice (conn and stream are positioned just past the forwarded
+// handshake). Returns false when the request was served in-process or the
+// connection is unusable; the caller then closes both sides.
+func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool) {
+	_ = conn.SetReadDeadline(time.Now().Add(statusSniffTimeout))   //nolint:errcheck
+	_ = stream.SetReadDeadline(time.Now().Add(statusSniffTimeout)) //nolint:errcheck
+
+	// Greeting: VER, NMETHODS, METHODS[NMETHODS] — forwarded to the exit verbatim.
+	hdr := make([]byte, 2)
+	if _, err := io.ReadFull(conn, hdr); err != nil || hdr[0] != 0x05 {
+		return false
+	}
+	greeting := make([]byte, 2+int(hdr[1]))
+	greeting[0], greeting[1] = hdr[0], hdr[1]
+	if _, err := io.ReadFull(conn, greeting[2:]); err != nil {
+		return false
+	}
+	if _, err := stream.Write(greeting); err != nil {
+		return false
+	}
+
+	// Method-selection reply (2 bytes) from the exit — forwarded to the browser.
+	method := make([]byte, 2)
+	if _, err := io.ReadFull(stream, method); err != nil {
+		return false
+	}
+	if _, err := conn.Write(method); err != nil {
+		return false
+	}
+	// Anything but no-auth accepted: hand the rest off untouched — the auth
+	// sub-negotiation and CONNECT ride through transparently.
+	if method[0] != 0x05 || method[1] != 0x00 {
+		clearDeadlines(conn, stream)
+		return true
+	}
+
+	// CONNECT request: VER, CMD, RSV, ATYP, ADDR, PORT. Buffered so a non-status
+	// target is forwarded to the exit byte-for-byte.
+	rhdr := make([]byte, 4)
+	if _, err := io.ReadFull(conn, rhdr); err != nil || rhdr[0] != 0x05 {
+		return false
+	}
+	req := append([]byte{}, rhdr...)
+	var host string
+	switch rhdr[3] {
+	case 0x01: // IPv4
+		b := make([]byte, 4)
+		if _, err := io.ReadFull(conn, b); err != nil {
+			return false
+		}
+		host = net.IP(b).String()
+		req = append(req, b...)
+	case 0x03: // domain
+		l := make([]byte, 1)
+		if _, err := io.ReadFull(conn, l); err != nil {
+			return false
+		}
+		b := make([]byte, int(l[0]))
+		if _, err := io.ReadFull(conn, b); err != nil {
+			return false
+		}
+		host = string(b)
+		req = append(req, l[0])
+		req = append(req, b...)
+	case 0x04: // IPv6
+		b := make([]byte, 16)
+		if _, err := io.ReadFull(conn, b); err != nil {
+			return false
+		}
+		host = net.IP(b).String()
+		req = append(req, b...)
+	default:
+		// Unknown ATYP: forward what we have and let the exit deal with it.
+		if _, err := stream.Write(req); err != nil {
+			return false
+		}
+		clearDeadlines(conn, stream)
+		return true
+	}
+	portB := make([]byte, 2)
+	if _, err := io.ReadFull(conn, portB); err != nil {
+		return false
+	}
+	req = append(req, portB...)
+
+	// Reserved status host: serve the in-process page over HTTP instead of
+	// tunneling to the exit. HTTP only — the resolver CA forbids a .skysocks TLS
+	// leaf, so status.skysocks is HTTP-only by design.
+	if surface, ok := proxystatus.Match(host); ok && surface == proxystatus.SurfaceSkysocks {
+		clearDeadlines(conn, stream)
+		c.serveStatusPage(conn)
+		return false
+	}
+
+	// Non-status: forward the buffered CONNECT request to the exit and splice.
+	if _, err := stream.Write(req); err != nil {
+		return false
+	}
+	clearDeadlines(conn, stream)
+	return true
+}
+
+// serveStatusPage completes the SOCKS5 CONNECT with a success reply, drains the
+// browser's (short, fixed-response) HTTP request, then writes the rendered
+// status.skysocks page. Best-effort: any write failure just drops the conn.
+func (c *Client) serveStatusPage(conn net.Conn) {
+	// CONNECT success with a dummy BND.ADDR/PORT so the browser proceeds to send
+	// its HTTP request.
+	if _, err := conn.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+		return
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
+	_, _ = conn.Read(make([]byte, 2048))                      //nolint:errcheck // drain request; page is fixed
+	_ = conn.SetReadDeadline(time.Time{})                     //nolint:errcheck
+	body := proxystatus.Render(c.statusSnapshot())
+	_, _ = conn.Write(statusHTTPResponse(body)) //nolint:errcheck
+}
+
+// statusSnapshot builds the read-only status.skysocks snapshot from the client's
+// OWN state. The rich per-leg mux/log view is visor-side (see
+// pkg/visor/embedded_proxystatus.go); skysocks-client is a separate app process
+// whose app RPC exposes no status query, so rather than add cross-process
+// plumbing the page reports what the client itself knows: session liveness and
+// the number of open streams to the exit.
+func (c *Client) statusSnapshot() proxystatus.Snapshot {
+	snap := proxystatus.Snapshot{
+		Surface: proxystatus.SurfaceSkysocks,
+		App:     skyenv.SkysocksClientName,
+	}
+	if c.session != nil && !c.session.IsClosed() {
+		snap.Running = true
+		snap.Note = fmt.Sprintf("session to the exit is up · %d open stream(s)", c.session.NumStreams())
+	} else {
+		snap.Note = "no active session to the exit"
+	}
+	return snap
+}
+
+// statusHTTPResponse wraps the page in a minimal close-delimited HTTP/1.1
+// response (mirrors proxystatus.ServeConn's headers, which can't be reused here
+// because we write onto the live browser conn rather than an in-memory pipe).
+func statusHTTPResponse(body []byte) []byte {
+	var b bytes.Buffer
+	b.WriteString("HTTP/1.1 200 OK\r\n")
+	b.WriteString("Content-Type: text/html; charset=utf-8\r\n")
+	fmt.Fprintf(&b, "Content-Length: %d\r\n", len(body))
+	b.WriteString("Cache-Control: no-store\r\n")
+	b.WriteString("Connection: close\r\n\r\n")
+	b.Write(body)
+	return b.Bytes()
+}
+
+// clearDeadlines removes the sniff read deadlines before the deadline-free data
+// splice takes over.
+func clearDeadlines(conns ...net.Conn) {
+	for _, cn := range conns {
+		_ = cn.SetReadDeadline(time.Time{}) //nolint:errcheck
 	}
 }
 

--- a/pkg/skysocks/client_status_test.go
+++ b/pkg/skysocks/client_status_test.go
@@ -1,0 +1,233 @@
+// Package skysocks status.skysocks interception tests.
+package skysocks
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
+)
+
+// fakeExit acts as the skysocks EXIT: a yamux server that, per stream, performs
+// the standard no-auth SOCKS5 server side (greeting → 05 00, CONNECT → success)
+// and then echoes payload back. It records the CONNECT target host of every
+// stream it fully receives, so a test can assert whether a request reached the
+// exit or was intercepted in-process by the client.
+type fakeExit struct {
+	sess  *yamux.Session
+	hostC chan string
+}
+
+func newFakeExit(t *testing.T, conn net.Conn) *fakeExit {
+	t.Helper()
+	sess, err := yamux.Server(conn, yamux.DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := &fakeExit{sess: sess, hostC: make(chan string, 8)}
+	go e.serve()
+	return e
+}
+
+func (e *fakeExit) serve() {
+	for {
+		stream, err := e.sess.Accept()
+		if err != nil {
+			return
+		}
+		go e.handle(stream)
+	}
+}
+
+func (e *fakeExit) handle(stream net.Conn) {
+	defer stream.Close()                                        //nolint:errcheck
+	_ = stream.SetReadDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
+	// Greeting.
+	hdr := make([]byte, 2)
+	if _, err := io.ReadFull(stream, hdr); err != nil || hdr[0] != 0x05 {
+		return
+	}
+	if _, err := io.ReadFull(stream, make([]byte, int(hdr[1]))); err != nil {
+		return
+	}
+	if _, err := stream.Write([]byte{0x05, 0x00}); err != nil {
+		return
+	}
+	// CONNECT request (the client forwards this ONLY for non-status targets).
+	rhdr := make([]byte, 4)
+	if _, err := io.ReadFull(stream, rhdr); err != nil {
+		return
+	}
+	var host string
+	switch rhdr[3] {
+	case 0x01:
+		b := make([]byte, 4)
+		_, _ = io.ReadFull(stream, b) //nolint:errcheck
+		host = net.IP(b).String()
+	case 0x03:
+		l := make([]byte, 1)
+		_, _ = io.ReadFull(stream, l) //nolint:errcheck
+		b := make([]byte, int(l[0]))
+		_, _ = io.ReadFull(stream, b) //nolint:errcheck
+		host = string(b)
+	case 0x04:
+		b := make([]byte, 16)
+		_, _ = io.ReadFull(stream, b) //nolint:errcheck
+		host = net.IP(b).String()
+	}
+	_, _ = io.ReadFull(stream, make([]byte, 2)) //nolint:errcheck // port
+	e.hostC <- host
+	// Success reply, then echo payload so the caller can prove the tunnel is live.
+	_, _ = stream.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}) //nolint:errcheck
+	_ = stream.SetReadDeadline(time.Time{})                               //nolint:errcheck
+	_, _ = io.Copy(stream, stream)                                        //nolint:errcheck
+}
+
+// socks5Connect performs the client-side SOCKS5 greeting + CONNECT to host:port
+// and returns the raw conn positioned just after the server's success reply.
+func socks5Connect(t *testing.T, addr, host string, port uint16) net.Conn {
+	t.Helper()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Write([]byte{0x05, 0x01, 0x00}); err != nil { // greeting: 1 method, no-auth
+		t.Fatal(err)
+	}
+	method := make([]byte, 2)
+	if _, err := io.ReadFull(conn, method); err != nil {
+		t.Fatal(err)
+	}
+	if method[0] != 0x05 || method[1] != 0x00 {
+		t.Fatalf("unexpected method reply %v", method)
+	}
+	req := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))}
+	req = append(req, []byte(host)...)
+	req = append(req, byte(port>>8), byte(port))
+	if _, err := conn.Write(req); err != nil {
+		t.Fatal(err)
+	}
+	reply := make([]byte, 10)
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		t.Fatal(err)
+	}
+	return conn
+}
+
+func newTestClient(t *testing.T) (*Client, *fakeExit) {
+	t.Helper()
+	cliConn, exitConn := net.Pipe()
+	exit := newFakeExit(t, exitConn)
+	c, err := NewClient(cliConn, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c, exit
+}
+
+// TestStatusSkysocksIntercepted verifies that a SOCKS5 CONNECT to status.skysocks
+// is answered in-process with the rendered status page and is NEVER forwarded to
+// the exit.
+func TestStatusSkysocksIntercepted(t *testing.T) {
+	c, exit := newTestClient(t)
+	defer c.Close() //nolint:errcheck
+
+	lisAddr := "127.0.0.1:0"
+	l, err := net.Listen("tcp", lisAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()                              //nolint:errcheck
+	go func() { _ = c.ListenAndServe(addr) }() //nolint:errcheck
+	waitDial(t, addr)
+
+	conn := socks5Connect(t, addr, "status.skysocks", 80)
+	defer conn.Close() //nolint:errcheck
+	if _, err := conn.Write([]byte("GET / HTTP/1.1\r\nHost: status.skysocks\r\nConnection: close\r\n\r\n")); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read status response: %v", err)
+	}
+	defer resp.Body.Close()          //nolint:errcheck
+	body, _ := io.ReadAll(resp.Body) //nolint:errcheck
+	if !strings.Contains(string(body), "per-leg mux") {
+		t.Fatalf("status page not served in-process; body=%q", string(body))
+	}
+	if !strings.Contains(string(body), "skysocks") {
+		t.Fatalf("status page missing skysocks surface; body=%q", string(body))
+	}
+
+	// The exit must not have received a status.skysocks CONNECT.
+	select {
+	case h := <-exit.hostC:
+		if h == "status.skysocks" {
+			t.Fatalf("status.skysocks leaked to the exit")
+		}
+	case <-time.After(300 * time.Millisecond):
+		// expected: nothing forwarded
+	}
+}
+
+// TestNonStatusForwardedToExit verifies a regular CONNECT is transparently
+// forwarded to the exit (greeting + request byte-for-byte) and the tunnel
+// carries payload end-to-end.
+func TestNonStatusForwardedToExit(t *testing.T) {
+	c, exit := newTestClient(t)
+	defer c.Close() //nolint:errcheck
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()                              //nolint:errcheck
+	go func() { _ = c.ListenAndServe(addr) }() //nolint:errcheck
+	waitDial(t, addr)
+
+	conn := socks5Connect(t, addr, "example.com", 80)
+	defer conn.Close() //nolint:errcheck
+
+	select {
+	case h := <-exit.hostC:
+		if h != "example.com" {
+			t.Fatalf("exit saw host %q, want example.com", h)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("exit never received the forwarded CONNECT")
+	}
+
+	// Prove the spliced tunnel carries payload (the exit echoes).
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]byte, 4)
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("echo read: %v", err)
+	}
+	if string(got) != "ping" {
+		t.Fatalf("echo = %q, want ping", string(got))
+	}
+}
+
+func waitDial(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.Dial("tcp", addr)
+		if err == nil {
+			_ = c.Close() //nolint:errcheck
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("listener %s not up", addr)
+}

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -252,8 +252,10 @@ func (e *EmbeddedDmsgWeb) serve(ctx context.Context) {
 	// Direct-client path for non-discovery dmsg servers.
 	cfg.DirectClient = e.directClient
 	cfg.DirectServerPKs = e.directServerPKs
-	// Reserved in-process status hosts (http://status.dmsg/ etc.).
+	// Reserved in-process status host owned by this layer: only status.dmsg is
+	// answered here; status.skynet / status.skysocks fall through up the chain.
 	cfg.StatusProvider = e.statusProvider
+	cfg.StatusSurface = proxystatus.SurfaceDmsg
 
 	// Optional TLS MITM. CA load failure is non-fatal — the
 	// resolver continues without MITM and logs the reason.

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -207,8 +207,10 @@ func (e *EmbeddedSkynetWeb) serve(ctx context.Context) {
 		}
 	}
 	cfg.Aliases = resolverAliasMap(e.cfg.Alias, e.localPK)
-	// Reserved in-process status hosts (http://status.skynet/ etc.).
+	// Reserved in-process status host owned by this layer: only status.skynet is
+	// answered here; status.dmsg / status.skysocks fall through up the chain.
 	cfg.StatusProvider = e.statusProvider
+	cfg.StatusSurface = proxystatus.SurfaceSkynet
 
 	// Optional TLS MITM mode. Loading the CA can fail (file
 	// missing, permissions, malformed) — those failures are not


### PR DESCRIPTION
Each resolving-proxy layer now owns exactly one reserved status host instead of every layer answering for all three.

- **Scope each resolver to its own surface.** A new `StatusSurface` field on the `dmsgweb`/`skynetweb` runtime `Config` (checked right after `proxystatus.Match`) makes `dmsg_web` serve only `status.dmsg` and `skynet_web` serve only `status.skynet`. A matched status host for a different surface is not served — it falls through so the request continues up the chain to the owning layer. Empty surface keeps the old serve-any behavior for standalone runtimes/tests.
- **Serve the owned host over HTTPS too.** `status.dmsg`/`status.skynet` are within the resolver CA name constraints, so the TLS-MITM path mints a per-host leaf and serves the page over terminated TLS, mirroring the existing MITM interstitial branch.
- **`status.skysocks` moves to the skysocks-client.** The resolver CA forbids a `.skysocks` leaf, so it must be HTTP-only and served outside the MITM resolvers. The client transparently sniffs the SOCKS5 CONNECT target — forwarding the greeting/method negotiation and every non-status request to the exit byte-for-byte — and answers a `status.skysocks` CONNECT in-process. The snapshot is rendered from the client's own session state (liveness + open stream count), since skysocks-client is a separate app process whose app RPC exposes no status query.

Existing HTTP `status.dmsg`/`status.skynet`/`status.skysocks` keep working, now each from the right owner. Unit tests cover the scoping (a dmsg_web-scoped runtime serves `status.dmsg` but falls `status.skynet` through, and vice versa) and the skysocks-client interception (status served in-process, non-status forwarded to the exit). `go build .`, `gofmt -l`, and `go vet` are clean on the changed packages.