### PR TITLE
fix(router): skip mux grow-leg plans reusing an in-group transport before dialing

### DIFF
--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -370,6 +370,35 @@ func (r *router) GrowMuxRoute(desc routing.RouteDescriptor, target, minHops int)
 		excludePKs = append(excludePKs, intermediatesOfHops(fwd, lPK, rPK)...)
 		excludePKs = append(excludePKs, intermediatesOfHops(rev, rPK, lPK)...)
 
+		// The route-finder honors ExcludeIntermediatePKs but NOT
+		// ExcludeTransportIDs, so with a 1-hop-capable min_hops it can hand back a
+		// leg whose FIRST hop reuses a transport already in the group (e.g. the
+		// direct transport that is already the primary leg). Dialing it would burn
+		// a setup-node round-trip only for appendRouteAsymmetric to reject it
+		// locally ("already in the group") — the churn that hammers the setup node
+		// and oscillates the leg set on every rotation tick. Drop such a plan HERE,
+		// before the dial (same discipline as the initial batch in
+		// router_dial.go's establishMuxRoutes). Its intermediates are already
+		// claimed above, so the next iteration diverges.
+		if len(fwd) > 0 {
+			dup := false
+			for _, ex := range excludeIDs {
+				if fwd[0].TpID == ex {
+					dup = true
+					break
+				}
+			}
+			if dup {
+				consecutiveFailures++
+				log.Debugf("GrowMuxRoute: planned leg %d/%d reuses transport %s already in the group (finder ignores ExcludeTransportIDs); skipping before dial",
+					current+added+1, target, fwd[0].TpID)
+				if consecutiveFailures >= maxConsecutiveFailures {
+					break
+				}
+				continue
+			}
+		}
+
 		if err := r.AddMuxRouteByHops(desc, fwd, rev); err != nil {
 			consecutiveFailures++
 			log.Debugf("GrowMuxRoute: add leg %d/%d failed: %v", current+added+1, target, err)


### PR DESCRIPTION
GrowMuxRoute fetched an aux-leg route via the route-finder, which honors ExcludeIntermediatePKs but not ExcludeTransportIDs. With a 1-hop-capable min_hops the finder returns a leg whose first hop reuses a transport already in the group (e.g. the direct transport that is already the primary leg); the plan was dialed all the way to a setup-node round-trip before appendRouteAsymmetric rejected it locally as 'already in the group'.

On the adaptive default's warm-standby rotation this fired every tick — observed 46 append failures / 66 setup-node requests in one live session, oscillating the leg set (32→1→20) and intermittently starving the skysocks-client data path. Fix post-filters the finder's plan by the current group's transport IDs before dialing (the same dedup establishMuxRoutes already applies to the initial batch), so a colliding plan is skipped locally. Router tests + vet pass.