### PR TITLE
fix(router): control forwards + same-LAN destinations stay direct (stop policy fighting --direct)

### DIFF
--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -185,6 +185,19 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 
 	appCl.SetStatusOrLog(appserver.AppDetailedStatusStarting)
 
+	// A skynet-client is a port-forward — a control/tunnel channel (pprof,
+	// debug, dmsgweb, :4443…), not bulk data. So when the operator has set NO
+	// routing flags at all, default to a direct 1-hop route instead of
+	// inheriting the visor-global routing policy: the adaptive default would
+	// otherwise spread this forward across a churning multi-hop warm-standby mux
+	// (observed: a 3ms same-LAN forward muxed across a 11.5s leg, which broke
+	// :4443). Any explicit flag (--direct, --routes, --min-hops, per-direction
+	// mux/min-hops) opts back into the global/explicit shape and wins.
+	if !direct && routes == 0 && minHops == 0 && fwdMinHops == 0 && revMinHops == 0 && fwdMux == 0 && revMux == 0 {
+		direct = true
+		appCl.Log().Info("skynet-client forward: no routing flags set — defaulting to --direct (1-hop, no mux). Pass --routes/--min-hops to opt into the mux.")
+	}
+
 	// dialWithShape performs the actual app-level dial to a given
 	// forwarding port, applying the mux/min-hops shape. Any EXPLICIT
 	// per-call value (>=1), including 1, is a per-app override of the

--- a/pkg/router/dial_options_test.go
+++ b/pkg/router/dial_options_test.go
@@ -54,6 +54,12 @@ func TestDialOptions_EffectiveMuxRoutes(t *testing.T) {
 		// Canonical asymmetric download shape: fwd=1, rev=N.
 		{"asymmetric: fwd=1 rev=4 fwd", &DialOptions{ForwardMuxRoutes: 1, ReverseMuxRoutes: 4}, true, 1},
 		{"asymmetric: fwd=1 rev=4 rev", &DialOptions{ForwardMuxRoutes: 1, ReverseMuxRoutes: 4}, false, 4},
+		// EnsureDirectTransport (--direct) forces a single route regardless of any
+		// policy-set mux — the adaptive policy must not grow a warm-standby mux
+		// over a control-plane direct forward.
+		{"direct overrides symmetric mux fwd", &DialOptions{MuxRoutes: 8, EnsureDirectTransport: true}, true, 1},
+		{"direct overrides symmetric mux rev", &DialOptions{MuxRoutes: 8, EnsureDirectTransport: true}, false, 1},
+		{"direct overrides per-direction mux", &DialOptions{ForwardMuxRoutes: 4, ReverseMuxRoutes: 8, EnsureDirectTransport: true}, false, 1},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -434,6 +434,14 @@ func (o *DialOptions) EffectiveMuxRoutes(forward bool) int {
 	if o == nil {
 		return 0
 	}
+	// A direct-transport-only dial (--direct / EnsureDirectTransport) is a 1-hop
+	// control-plane route by definition. The adaptive policy must NOT grow a
+	// warm-standby mux over it — that re-introduces exactly the multi-hop churn
+	// --direct exists to avoid (a control forward spread across rotating 2-hop
+	// legs). Force a single route regardless of any policy-set MuxRoutes.
+	if o.EnsureDirectTransport {
+		return 1
+	}
 	if forward {
 		if o.ForwardMuxRoutes > 0 {
 			return o.ForwardMuxRoutes

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -642,6 +642,17 @@ func (r *router) finishDial(
 			muxTarget = eff
 		}
 	}
+	// A same-LAN destination is best reached over its single direct transport
+	// (ms-latency). Growing a warm-standby mux to it forces the aux legs through
+	// REMOTE 2-hop intermediates (same-LAN peers are excluded as intermediates),
+	// adding latency + rotation churn for zero path diversity — the failure that
+	// muxed a 3ms LAN forward across a 11.5s multi-hop leg. f77b928c fixed only
+	// the direct-dial hook; this stops the warm-standby GROWTH too. Keep it direct.
+	if muxTarget > 1 && r.isSameLANDest(forwardDesc.DstPK()) {
+		r.logger.WithField("dst", forwardDesc.DstPK().String()).
+			Debug("same-LAN destination: forcing direct (no warm-standby mux)")
+		muxTarget = 1
+	}
 	if muxTarget > 1 {
 		optsCopy := *opts
 		fwdDescCopy := forwardDesc
@@ -2664,6 +2675,28 @@ func (r *router) sameLANExcludedPKs() []cipher.PubKey {
 		self = r.conf.SelfPublicIP()
 	}
 	return r.tm.SameLANPeers(self)
+}
+
+// isSameLANDest reports whether dst is a peer on this visor's own local network
+// (private-endpoint or NAT-hairpin, per transport.Manager.SameLANPeers). Unlike
+// sameLANExcludedPKs (the INTERMEDIATE exclusion, gated on ExcludeSameLANHops),
+// this is used for the DESTINATION mux decision and applies regardless of that
+// config: a box on our LAN is always best reached over its single direct
+// transport, never a warm-standby mux through remote intermediates.
+func (r *router) isSameLANDest(dst cipher.PubKey) bool {
+	if r.tm == nil {
+		return false
+	}
+	var self net.IP
+	if r.conf != nil && r.conf.SelfPublicIP != nil {
+		self = r.conf.SelfPublicIP()
+	}
+	for _, pk := range r.tm.SameLANPeers(self) {
+		if pk == dst {
+			return true
+		}
+	}
+	return false
 }
 
 // appendUniquePKs appends every pk in add that is not already in base,


### PR DESCRIPTION
The global adaptive routing policy was overriding direct dials and churning control forwards into multi-hop warm-standby muxes — a 3ms same-LAN pprof forward (:4443) got spread across a 32-leg mux with an 11.5s leg and stalled. Three coordinated fixes:

1. `EffectiveMuxRoutes` returns 1 when `EnsureDirectTransport` (--direct) is set — the policy's mux_routes can no longer win over --direct.
2. The mux-growth decision forces a single route when the destination is same-LAN (`router.isSameLANDest`). f77b928c only fixed the direct-dial hook; the warm-standby growth still muxed a same-LAN box through remote 2-hop intermediates.
3. `skynet-client` (always a port-forward / control channel) defaults to --direct when no routing flags are set, instead of inheriting the global adaptive policy. Explicit --routes/--min-hops still opt into the mux and win.

Adds EffectiveMuxRoutes direct-override unit tests. Router + skynet-client build/vet/test clean.