### PR TITLE
fix(tpd): a reporter with no prior transports is not a reconcile error

### DIFF
--- a/pkg/transport-discovery/api/cxo_register.go
+++ b/pkg/transport-discovery/api/cxo_register.go
@@ -136,6 +136,16 @@ func (api *API) ReconcileTransportsFromCXO(ctx context.Context, entries []*trans
 	// exactly what a tombstone was in the delta model.
 	existing, err := api.store.GetTransportsByEdgeNoLatency(ctx, reporter)
 	if err != nil {
+		// A reporter with no prior transports in the store (first snapshot, or all
+		// aged out) returns ErrTransportNotFound here. That is not a reconcile
+		// failure — the register step above already landed this snapshot's
+		// entries, and there is simply nothing absent to deregister. Treating it
+		// as an error made every fresh/re-announcing visor's reconcile log
+		// "ReconcileTransportsFromCXO failed: get existing: transport not found"
+		// and return non-nil, which the aggregator surfaces as a fill failure.
+		if errors.Is(err, store.ErrTransportNotFound) {
+			return nil
+		}
 		return fmt.Errorf("get existing: %w", err)
 	}
 	for _, e := range existing {


### PR DESCRIPTION
The CXO aggregator's per-Root reconcile registered the snapshot's entries, then called `GetTransportsByEdgeNoLatency(reporter)` to deregister absent ones. A reporter with no prior transports (first snapshot / all aged out) returns `ErrTransportNotFound`, which the reconcile returned as an error — so the aggregator logged `ReconcileTransportsFromCXO failed: get existing: transport not found` and surfaced it as a fill failure even though the register step already landed. Treat not-found as an empty existing-set (matching the per-entry path's existing `errors.Is` handling). Removes a recurring spurious aggregator error seen while diagnosing the local-vs-TPD under-report. Build/vet/test clean.