### PR TITLE
feat(cxo,visor): surface per-feed CXO publish health in `visor state` (.cxo)

### DIFF
--- a/pkg/cxo/treestore/publish_state_test.go
+++ b/pkg/cxo/treestore/publish_state_test.go
@@ -1,0 +1,52 @@
+package treestore
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestPublishStateFreezeSignature verifies that PublishState surfaces the
+// exact freeze signature the visor-state diagnostic relies on: a standing
+// publish error plus unpublished (dirty) changes reads back as Frozen,
+// and a subsequent success clears it.
+func TestPublishStateFreezeSignature(t *testing.T) {
+	p := &Publisher{
+		root: &memNode{
+			leaves: map[string][]byte{"tp-list": []byte("blob")},
+			subs: map[string]*memNode{
+				"a": {leaves: map[string][]byte{"x": []byte("1"), "y": []byte("2")}},
+			},
+		},
+	}
+
+	// Healthy: no error recorded, not dirty → not frozen.
+	if st := p.PublishState(); st.Frozen {
+		t.Fatalf("clean publisher reported Frozen=true: %+v", st)
+	}
+
+	// Counts: 1 (tp-list) + 2 (a/x, a/y) leaves; 2 nodes (root + a).
+	if st := p.PublishState(); st.LeafCount != 3 || st.NodeCount != 2 {
+		t.Fatalf("countTree wrong: leaves=%d nodes=%d (want 3/2)", st.LeafCount, st.NodeCount)
+	}
+
+	// Simulate a standing publish failure with an unpublished change.
+	p.dirty = true
+	p.recordPublishErr(errors.New("treestore encode/save: not found"))
+
+	st := p.PublishState()
+	if !st.Frozen {
+		t.Fatalf("dirty + standing error should be Frozen: %+v", st)
+	}
+	if st.LastErr == "" || st.LastErrType == "" {
+		t.Fatalf("LastErr/LastErrType not captured: %+v", st)
+	}
+	if !st.LastErrMissingObj {
+		t.Fatalf("a 'not found' error should read LastErrMissingObj=true: %+v", st)
+	}
+
+	// Recovery: a success clears the standing error → not frozen.
+	p.clearPublishErr()
+	if st := p.PublishState(); st.Frozen || st.LastErr != "" {
+		t.Fatalf("after clearPublishErr should not be Frozen: %+v", st)
+	}
+}

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -74,6 +74,19 @@ type Publisher struct {
 	// encode-cache walk (no re-serialize).
 	lastPublishNs atomic.Int64
 
+	// errMu guards the last-publish-error introspection fields below.
+	// Kept separate from mu so PublishState() (called from `skywire cli
+	// visor state`) never contends with the publish loop that holds mu
+	// across the clone/encode window. recordPublishErr is called on every
+	// publishRoot terminal failure; clearPublishErr on every successful
+	// Publish — so LastErr reflects only a STANDING failure. A transient
+	// error the next tick cleared leaves these empty.
+	errMu          sync.Mutex
+	lastErrMsg     string
+	lastErrType    string
+	lastErrMissing bool
+	lastErrNs      int64
+
 	// allow gates which subscriber PKs may connect. nil-set means the
 	// allowlist is disabled (any subscriber is accepted). NewWithDMSG
 	// wires this state into the CXO node's OnSubscribeRemote hook
@@ -517,6 +530,108 @@ func (p *Publisher) Node() *node.Node {
 // for counter semantics.
 func (p *Publisher) Stats() node.PublisherStats {
 	return p.cxoNode.Stats()
+}
+
+// PublishState is a secrets-free snapshot of this feed's publish
+// health, surfaced by `skywire cli visor state` under .cxo. It exposes
+// the exact freeze signature — Dirty (in-memory changes awaiting
+// publish) alongside a climbing SecsSinceOKPublish and a standing
+// LastErr — so a stuck feed (the failure mode behind TPD under-
+// reporting a visor's transports) is a single query against the live
+// visor, local or --via dmsg://<pk>, not a log hunt.
+type PublishState struct {
+	FeedPK             string  `json:"feed_pk"`
+	Dirty              bool    `json:"dirty"`
+	DirtyGen           uint64  `json:"dirty_gen"`
+	LeafCount          int     `json:"leaf_count"`
+	NodeCount          int     `json:"node_count"`
+	SecsSinceOKPublish float64 `json:"secs_since_ok_publish"`
+	LastErr            string  `json:"last_err,omitempty"`
+	LastErrType        string  `json:"last_err_type,omitempty"`
+	LastErrMissingObj  bool    `json:"last_err_is_missing_object,omitempty"`
+	SecsSinceErr       float64 `json:"secs_since_err,omitempty"`
+	// Frozen is true when there is a STANDING publish error AND the
+	// in-memory tree has unpublished changes: the feed has advanced but
+	// no Root has been saved since the failure, so subscribers (e.g.
+	// TPD) are pinned to a stale snapshot. A transient error the next
+	// tick cleared leaves LastErr empty and this false.
+	Frozen bool `json:"frozen"`
+}
+
+// PublishState returns a live introspection snapshot of this feed's
+// publish health. Cheap: one mu-guarded tree count plus atomic/errMu
+// loads; safe to call concurrently with the publish loop.
+func (p *Publisher) PublishState() PublishState {
+	p.mu.Lock()
+	dirty := p.dirty
+	gen := p.dirtyGen
+	leaves, nodes := countTree(p.root)
+	p.mu.Unlock()
+
+	st := PublishState{
+		FeedPK:    p.pk.Hex(),
+		Dirty:     dirty,
+		DirtyGen:  gen,
+		LeafCount: leaves,
+		NodeCount: nodes,
+	}
+	if last := p.lastPublishNs.Load(); last != 0 {
+		st.SecsSinceOKPublish = time.Since(time.Unix(0, last)).Seconds()
+	}
+
+	p.errMu.Lock()
+	st.LastErr = p.lastErrMsg
+	st.LastErrType = p.lastErrType
+	st.LastErrMissingObj = p.lastErrMissing
+	if p.lastErrNs != 0 {
+		st.SecsSinceErr = time.Since(time.Unix(0, p.lastErrNs)).Seconds()
+	}
+	p.errMu.Unlock()
+
+	st.Frozen = dirty && st.LastErr != ""
+	return st
+}
+
+// recordPublishErr stores a standing publish failure for PublishState.
+func (p *Publisher) recordPublishErr(err error) {
+	p.errMu.Lock()
+	p.lastErrMsg = err.Error()
+	p.lastErrType = fmt.Sprintf("%T", err)
+	p.lastErrMissing = isMissingObject(err)
+	p.lastErrNs = time.Now().UnixNano()
+	p.errMu.Unlock()
+}
+
+// clearPublishErr drops any standing publish failure after a success.
+func (p *Publisher) clearPublishErr() {
+	p.errMu.Lock()
+	if p.lastErrMsg != "" {
+		p.lastErrMsg = ""
+		p.lastErrType = ""
+		p.lastErrMissing = false
+		p.lastErrNs = 0
+	}
+	p.errMu.Unlock()
+}
+
+// countTree walks the in-memory tree and returns the total leaf and
+// node counts. Callers must hold p.mu.
+func countTree(n *memNode) (leaves, nodes int) {
+	if n == nil {
+		return 0, 0
+	}
+	nodes = 1
+	for _, v := range n.leaves {
+		if v != nil {
+			leaves++
+		}
+	}
+	for _, sub := range n.subs {
+		l, nn := countTree(sub)
+		leaves += l
+		nodes += nn
+	}
+	return leaves, nodes
 }
 
 // SetAllowlist atomically replaces the subscriber allowlist. nil
@@ -1219,16 +1334,14 @@ func (p *Publisher) publishRoot(root *memNode) ([]freshSub, error) {
 		err = attempt()
 	}
 	if err != nil {
-		// DIAGNOSTIC (#4102): a live freeze ([stats]/tp-list feed republish
-		// failing "encode/save: not found") reaches this terminal WITHOUT the
-		// self-heal above ever logging — isMissingObject returned false for an
-		// error whose string is "not found", which its substring check should
-		// have matched. Capture the error's concrete TYPE + the isMissingObject
-		// verdict so the real fix can target the actual path.
-		p.log.WithError(err).
-			WithField("err_type", fmt.Sprintf("%T", err)).
-			WithField("is_missing_object", isMissingObject(err)).
-			Warn("treestore: publishRoot terminal failure — capturing freeze path (#4102)")
+		// Record the standing failure for live introspection. `skywire
+		// cli visor state --jq '.cxo'` reads this back (err msg, concrete
+		// %T type, and the isMissingObject verdict) so a frozen feed is a
+		// query against the running visor — locally or --via dmsg://<pk>
+		// against any fleet node — instead of waiting for a log line to
+		// fire and catching it in a grep window. Supersedes the #4102
+		// log-only diagnostic.
+		p.recordPublishErr(err)
 		// Wrap with which-operation context so a future freeze
 		// self-localizes in the log. isMissingObject still matches through
 		// the %w wrap (errors.Is + a lowercase "not found" substring both
@@ -1237,6 +1350,9 @@ func (p *Publisher) publishRoot(root *memNode) ([]freshSub, error) {
 		// about the retry decision — it only annotates the terminal error.
 		return nil, fmt.Errorf("treestore encode/save: %w", err)
 	}
+	// Success: clear any standing error so PublishState().Frozen falls
+	// back to false the moment the feed recovers.
+	p.clearPublishErr()
 	p.cxoNode.Publish(r)
 
 	// Nudge the cleanup goroutine. Non-blocking: if cleanup is already

--- a/pkg/visor/api_state.go
+++ b/pkg/visor/api_state.go
@@ -54,6 +54,16 @@ type StateSnapshot struct {
 	// snapshot rather than one-app-at-a-time.
 	MuxRouteGroups []MuxRouteGroupInfo `json:"mux_route_groups,omitempty"`
 
+	// CXOFeeds is the live publish-health of each CXO feed (system
+	// telemetry/tp-list feed first, then user feeds): dirty state, secs
+	// since last OK publish, in-memory leaf/node counts, and any standing
+	// publish error with its concrete type + isMissingObject verdict.
+	// This is the diagnostic surface for TPD-agreement issues — a frozen
+	// stats feed (Frozen=true, a climbing SecsSinceOKPublish, a LastErr)
+	// is exactly why TPD under-reports a visor's transports, and it's now
+	// a query against the live visor (local or --via dmsg://<pk>).
+	CXOFeeds []CXOFeedState `json:"cxo,omitempty"`
+
 	// Notes collects per-section errors ("routing: <err>") so the snapshot is
 	// self-describing about what it could and could not read.
 	Notes []string `json:"notes,omitempty"`
@@ -184,6 +194,10 @@ func (v *Visor) StateSnapshot() (*StateSnapshot, error) {
 		UptimeRecorder:     v.uptimeRecorder != nil,
 		EmbeddedTPS:        v.embeddedTPS != nil,
 		EmbeddedRouteSetup: v.embeddedRouteSetup != nil,
+	}
+
+	if cf := v.CXOFeedStates(); len(cf) > 0 {
+		snap.CXOFeeds = cf
 	}
 
 	return snap, nil

--- a/pkg/visor/cxo_user_feeds.go
+++ b/pkg/visor/cxo_user_feeds.go
@@ -204,6 +204,57 @@ func (v *Visor) ListCXOFeeds() []logserver.CXOFeedEntry {
 	return out
 }
 
+// setSystemCXOPub retains the telemetry/tp-list feed publisher so
+// CXOFeedStates can read its live PublishState. Called once by initStats.
+func (v *Visor) setSystemCXOPub(pub *treestore.Publisher) {
+	v.cxoUserFeedsMu.Lock()
+	v.systemCXOPub = pub
+	v.cxoUserFeedsMu.Unlock()
+}
+
+// CXOFeedState pairs a feed's identity (name + dmsg port) with its live
+// publish-health snapshot. Surfaced by StateSnapshot under .cxo.
+type CXOFeedState struct {
+	Name string `json:"name"`
+	Port uint16 `json:"port,omitempty"`
+	treestore.PublishState
+}
+
+// CXOFeedStates returns the live PublishState of the system telemetry
+// feed plus every user feed. The system feed (the one TPD subscribes to
+// for a visor's transport list) is first. Empty when no publisher is
+// wired (Stats.Disabled or pre-init). Reads are cheap and concurrency-
+// safe — see treestore.Publisher.PublishState.
+func (v *Visor) CXOFeedStates() []CXOFeedState {
+	v.cxoUserFeedsMu.Lock()
+	sysPub := v.systemCXOPub
+	users := make([]*cxoUserFeed, 0, len(v.cxoUserFeeds))
+	for _, fd := range v.cxoUserFeeds {
+		users = append(users, fd)
+	}
+	v.cxoUserFeedsMu.Unlock()
+
+	var out []CXOFeedState
+	if sysPub != nil {
+		out = append(out, CXOFeedState{
+			Name:         systemCXOFeedName,
+			Port:         skyenv.DmsgCXOPort,
+			PublishState: sysPub.PublishState(),
+		})
+	}
+	for _, fd := range users {
+		if fd.pub == nil {
+			continue
+		}
+		out = append(out, CXOFeedState{
+			Name:         fd.name,
+			Port:         fd.port,
+			PublishState: fd.pub.PublishState(),
+		})
+	}
+	return out
+}
+
 // closeAllCXOUserFeeds stops every user feed. Called from the visor
 // close stack on shutdown.
 func (v *Visor) closeAllCXOUserFeeds() error {

--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -82,6 +82,10 @@ func initStats(_ context.Context, v *Visor, log *logging.Logger) error {
 		if v.tpM != nil {
 			v.tpM.SetTPDLeafPublisher(pub)
 		}
+		// Retain the publisher so `skywire cli visor state --jq '.cxo'`
+		// can read its live freeze/publish health (this is the feed TPD
+		// subscribes to for the visor's transport list).
+		v.setSystemCXOPub(pub)
 	}
 
 	tracker.Run(v.ctx)

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	dmsgcmdutil "github.com/skycoin/skywire/pkg/dmsg/cmdutil"
 	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
@@ -257,6 +258,14 @@ type Visor struct {
 	// in ListCXOFeeds via systemCXOFeed below.
 	cxoUserFeeds   map[string]*cxoUserFeed
 	cxoUserFeedsMu sync.Mutex
+
+	// systemCXOPub is the telemetry/tp-list feed publisher (the one
+	// initStats wires on skyenv.DmsgCXOPort and hands to the transport
+	// manager as the TPD leaf publisher). Retained here — beyond being
+	// closed in the stats close-stack — so CXOFeedStates can read its
+	// live PublishState for `skywire cli visor state`. Guarded by
+	// cxoUserFeedsMu. nil until initStats runs (or if Stats.Disabled).
+	systemCXOPub *treestore.Publisher
 
 	// pairing holds the chat-pair feed manager + bbolt store +
 	// inbound message ring. Populated by init_pairing.go after


### PR DESCRIPTION
Diagnosing why TPD under-reports a visor's transports meant log-archaeology plus a deploy cycle to catch the `[stats]`/tp-list CXO feed freezing. This makes it a live query.

- `treestore.Publisher` records its last `publishRoot` failure (message, concrete `%T` type, `isMissingObject` verdict, timestamp) and clears it on the next success, so only a *standing* failure is reported.
- New `Publisher.PublishState()` exposes dirty state, seconds-since-last-OK-publish, in-memory leaf/node counts, and a derived `Frozen` flag (dirty AND a standing error = advanced-but-unpublished = subscribers pinned to a stale snapshot).
- The visor retains the system telemetry publisher and surfaces every feed's `PublishState` under `.cxo` in `StateSnapshot`, so `skywire cli visor state --jq '.cxo'` shows a frozen feed on the live visor — locally or `--via dmsg://<pk>` against any fleet node.

Supersedes the #4102 log-only diagnostic (that log line is removed; the state surface replaces it). Additive only — no change to publish/routing behavior. Unit test covers the freeze signature + tree counts.