### PR TITLE
fix(stats,cxo): publish only current data to TPD, keep history bbolt-only

### DIFF
--- a/pkg/visor/stats/sink.go
+++ b/pkg/visor/stats/sink.go
@@ -94,11 +94,16 @@ func HydrateSink(store *Store, sink Sink, publishWindowDays int, now time.Time) 
 	if publishWindowDays <= 0 {
 		return 0, nil
 	}
-	cutoff := now.UTC().AddDate(0, 0, -publishWindowDays).Format(dateFmt)
 	pushed := 0
 
-	// Transports: per-record, push current + each daily row whose
-	// date is within window.
+	// Push ONLY current per-transport snapshots to the CXO sink. TPD is a
+	// discovery service: the feed it fills over the short announce conn must
+	// stay small (transports/list + transports/<id>/current), so it can be
+	// fetched reliably. Historical telemetry — daily rollups, tier/service
+	// bitmaps, and per-transport timeline bitmaps — remains bbolt-only for
+	// the visor's own /stats + `visor state`; re-broadcasting days of history
+	// grew the Root to ~23k objects and broke TPD's fill (the discovery gap).
+	// TPD accumulates its own uptime history from what it observes each cycle.
 	records, err := store.AllTransportRecords()
 	if err != nil {
 		return pushed, fmt.Errorf("hydrate transports: %w", err)
@@ -109,93 +114,6 @@ func HydrateSink(store *Store, sink Sink, publishWindowDays int, now time.Time) 
 				sink.Put(currentTransportPath(rec.ID.String()), data)
 				pushed++
 			}
-		}
-		// Daily rollups are deliberately NOT hydrated to the CXO sink: no
-		// subscriber consumes them (TPD's aggregator has no /rollup branch;
-		// the visor's own /stats reads them straight from bbolt), and every
-		// byte on this feed competes with transports/list for the announce
-		// conn's short fill budget. They remain persisted in bbolt (the
-		// TransportRecord above) for the local /stats endpoint.
-	}
-
-	// Tiers: per-tier, per-date bitmap if within window.
-	tiers, err := store.TierNames()
-	if err != nil {
-		return pushed, fmt.Errorf("hydrate tiers: %w", err)
-	}
-	for _, tier := range tiers {
-		dates, err := store.TierDates(tier)
-		if err != nil {
-			continue
-		}
-		for _, date := range dates {
-			if date < cutoff {
-				continue
-			}
-			d, err := time.Parse(dateFmt, date)
-			if err != nil {
-				continue
-			}
-			bm, err := store.TierBitmap(tier, d)
-			if err != nil {
-				continue
-			}
-			sink.Put(tierBitmapPath(tier, date), bm)
-			pushed++
-		}
-	}
-
-	// Services: same shape as tiers.
-	services, err := store.ServiceNames()
-	if err != nil {
-		return pushed, fmt.Errorf("hydrate services: %w", err)
-	}
-	for _, svc := range services {
-		dates, err := store.ServiceDates(svc)
-		if err != nil {
-			continue
-		}
-		for _, date := range dates {
-			if date < cutoff {
-				continue
-			}
-			d, err := time.Parse(dateFmt, date)
-			if err != nil {
-				continue
-			}
-			bm, err := store.ServiceBitmap(svc, d)
-			if err != nil {
-				continue
-			}
-			sink.Put(serviceBitmapPath(svc, date), bm)
-			pushed++
-		}
-	}
-
-	// Per-transport timeline bitmaps: same wire shape as tier/service.
-	tpIDs, err := store.TransportBitmapIDs()
-	if err != nil {
-		return pushed, fmt.Errorf("hydrate transport bitmaps: %w", err)
-	}
-	for _, id := range tpIDs {
-		dates, err := store.TransportBitmapDates(id)
-		if err != nil {
-			continue
-		}
-		for _, date := range dates {
-			if date < cutoff {
-				continue
-			}
-			d, err := time.Parse(dateFmt, date)
-			if err != nil {
-				continue
-			}
-			bm, err := store.TransportBitmap(id, d)
-			if err != nil {
-				continue
-			}
-			sink.Put(transportTimelinePath(id, date), bm)
-			pushed++
 		}
 	}
 	return pushed, nil

--- a/pkg/visor/stats/sink_test.go
+++ b/pkg/visor/stats/sink_test.go
@@ -126,7 +126,10 @@ func TestSinkReceivesTransportPutsOnSample(t *testing.T) {
 	}
 }
 
-func TestSinkReceivesTierAndServiceBitmaps(t *testing.T) {
+// TestTierServiceBitmapsAreBboltOnly asserts the current-only CXO contract:
+// tier/service online-slot bitmaps are written to bbolt (for the visor's own
+// /stats + `visor state`) but are NOT mirrored to the CXO sink TPD reads.
+func TestTierServiceBitmapsAreBboltOnly(t *testing.T) {
 	sink := newRecordingSink()
 	tr := newTrackerWithSink(t, sink)
 	day := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
@@ -138,18 +141,22 @@ func TestSinkReceivesTierAndServiceBitmaps(t *testing.T) {
 	}
 	tr.sample(day)
 
+	// NOT on the CXO sink — historical telemetry stays bbolt-only.
 	puts, _ := sink.snapshot()
-	if _, ok := puts["tiers/process/2026-04-27"]; !ok {
-		t.Errorf("missing tiers/process/2026-04-27; got %v", keysOf(puts))
+	for _, p := range []string{
+		"tiers/process/2026-04-27", "tiers/dmsg/2026-04-27",
+		"services/vpn-server/2026-04-27",
+	} {
+		if _, ok := puts[p]; ok {
+			t.Errorf("%s should NOT be mirrored to the CXO sink; got %v", p, keysOf(puts))
+		}
 	}
-	if _, ok := puts["tiers/dmsg/2026-04-27"]; !ok {
-		t.Errorf("missing tiers/dmsg/2026-04-27; got %v", keysOf(puts))
+	// But present in bbolt.
+	if bm, err := tr.store.TierBitmap("dmsg", day); err != nil || len(bm) == 0 {
+		t.Errorf("tier bitmap should be persisted in bbolt: bm=%v err=%v", bm, err)
 	}
-	if _, ok := puts["tiers/skynet/2026-04-27"]; ok {
-		t.Errorf("skynet was offline; should not be in sink puts")
-	}
-	if _, ok := puts["services/vpn-server/2026-04-27"]; !ok {
-		t.Errorf("missing services/vpn-server/2026-04-27; got %v", keysOf(puts))
+	if bm, err := tr.store.ServiceBitmap("vpn-server", day); err != nil || len(bm) == 0 {
+		t.Errorf("service bitmap should be persisted in bbolt: bm=%v err=%v", bm, err)
 	}
 }
 
@@ -248,7 +255,10 @@ func TestSinkDeletedOnBboltRetentionDrop(t *testing.T) {
 	}
 }
 
-func TestHydrateSinkPushesInWindowOnly(t *testing.T) {
+// TestHydrateSinkPushesCurrentOnly asserts the seed path pushes only current
+// per-transport snapshots to the CXO sink — never historical tier/service or
+// timeline bitmaps (those are bbolt-only and would bloat the TPD feed).
+func TestHydrateSinkPushesCurrentOnly(t *testing.T) {
 	store, err := OpenStore(filepath.Join(t.TempDir(), "stats.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -260,10 +270,17 @@ func TestHydrateSinkPushesInWindowOnly(t *testing.T) {
 	}()
 
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
-	if err := store.MarkTierSlot("dmsg", now.AddDate(0, 0, -2), 0); err != nil {
+	// A current transport snapshot (should be pushed) ...
+	id := uuid.New()
+	rec := &TransportRecord{
+		ID: id, Type: "stcpr", FirstSeen: now, LastSeen: now,
+		Current: &LiveSnapshot{SentBytes: 10, RecvBytes: 5, SampledAt: now, Type: "stcpr"},
+	}
+	if err := store.PutTransportRecord(rec); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.MarkTierSlot("dmsg", now.AddDate(0, 0, -10), 0); err != nil {
+	// ... plus a tier bitmap in bbolt (should NOT be pushed).
+	if err := store.MarkTierSlot("dmsg", now.AddDate(0, 0, -2), 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -273,14 +290,16 @@ func TestHydrateSinkPushesInWindowOnly(t *testing.T) {
 		t.Fatalf("HydrateSink: %v", err)
 	}
 	if pushed != 1 {
-		t.Errorf("pushed = %d, want 1 (only in-window date)", pushed)
+		t.Errorf("pushed = %d, want 1 (only the current snapshot)", pushed)
 	}
 	puts, _ := sink.snapshot()
-	if _, ok := puts["tiers/dmsg/"+now.AddDate(0, 0, -2).Format("2006-01-02")]; !ok {
-		t.Errorf("in-window date missing from sink: %v", keysOf(puts))
+	if _, ok := puts["transports/"+id.String()+"/current"]; !ok {
+		t.Errorf("current snapshot missing from sink: %v", keysOf(puts))
 	}
-	if _, ok := puts["tiers/dmsg/"+now.AddDate(0, 0, -10).Format("2006-01-02")]; ok {
-		t.Errorf("out-of-window date should not be in sink: %v", keysOf(puts))
+	for _, p := range keysOf(puts) {
+		if p != "transports/"+id.String()+"/current" {
+			t.Errorf("only current snapshots should be hydrated to the sink; got unexpected %q", p)
+		}
 	}
 }
 

--- a/pkg/visor/stats/tracker.go
+++ b/pkg/visor/stats/tracker.go
@@ -257,6 +257,10 @@ func (t *Tracker) sample(now time.Time) {
 			}
 		}
 
+		// Tier / service online-slot bitmaps are marked in bbolt for the
+		// visor's own /stats history, but NOT mirrored to the CXO sink —
+		// they are historical telemetry, not current discovery data (see
+		// recordTransportTx for why the TPD feed stays current-only).
 		if probe := t.probes.TierStates; probe != nil {
 			for tier, online := range probe() {
 				if !online {
@@ -265,12 +269,7 @@ func (t *Tracker) sample(now time.Time) {
 				if err := stx.MarkTierSlot(tier, utc, slot); err != nil {
 					t.log.WithError(err).WithField("tier", tier).
 						Debug("Failed to mark tier slot")
-					continue
 				}
-				mirrors = append(mirrors, mirrorPair{
-					path: tierBitmapPath(tier, today),
-					data: stx.TierBitmap(tier, utc),
-				})
 			}
 		}
 
@@ -282,12 +281,7 @@ func (t *Tracker) sample(now time.Time) {
 				if err := stx.MarkServiceSlot(svc, utc, slot); err != nil {
 					t.log.WithError(err).WithField("service", svc).
 						Debug("Failed to mark service slot")
-					continue
 				}
-				mirrors = append(mirrors, mirrorPair{
-					path: serviceBitmapPath(svc, today),
-					data: stx.ServiceBitmap(svc, utc),
-				})
 			}
 		}
 		return nil
@@ -409,15 +403,20 @@ func (t *Tracker) recordTransportTx(stx *SampleTx, tp TransportProbe, now time.T
 	// telemetry feed steals fill budget from transports/list on the
 	// short-lived announce conn — the constraint behind the discovery gap.
 
+	// The per-transport timeline bitmap is marked in bbolt (below) for the
+	// visor's own /stats + `visor state` consumption, but is NOT mirrored to
+	// the CXO sink. TPD is a discovery service: it only needs current data
+	// (transports/list + transports/<id>/current) and derives its own uptime
+	// history from what it observes each cycle (RecordTransportHeartbeat →
+	// Redis per-date keys). Publishing 7–30 days of per-transport-per-day
+	// bitmaps onto the announce feed was the root of the discovery gap — it
+	// grew the Root to ~23k objects, so TPD couldn't fill it over the short
+	// announce conn and under-reported the transport list. Historical
+	// telemetry stays bbolt-only.
 	slot := SlotForTime(now)
 	if err := stx.MarkTransportSlot(idStr, now, slot); err != nil {
 		t.log.WithError(err).WithField("tp_id", idStr).
 			Debug("Stats: MarkTransportSlot failed")
-	} else {
-		mirrors = append(mirrors, mirrorPair{
-			path: transportTimelinePath(idStr, today),
-			data: stx.TransportBitmap(idStr, now),
-		})
 	}
 	return mirrors, nil
 }


### PR DESCRIPTION
TPD is a discovery service — it needs a visor's **current** transport list, not its telemetry history. But the visor's CXO feed (the one TPD subscribes to) mirrored the full rolling window of per-transport-per-day timeline bitmaps plus per-tier/service online bitmaps, growing the feed Root to **~23,000 objects**. TPD couldn't fill that over the short announce connection, so it under-reported the transport list (~11% landing). The same history churn also pinned the visor's CXO store at a **~620 MB** bbolt high-water-mark (~30x the ~21 MB live set).

**The CXO sink now carries only current data:** `transports/<id>/current` + `transports/list`. Historical telemetry (daily rollups, tier/service bitmaps, per-transport timeline bitmaps) stays in bbolt for the visor's own `/stats` + `visor state` — no longer mirrored to CXO, in both the live sampler and the seed path. bbolt writes are unchanged, so local history is intact; TPD derives its own uptime from what it observes each cycle (`RecordTransportHeartbeat`), so no reward/uptime data is lost.

Takes the feed from ~23k objects to a few hundred — the real fix for the discovery gap (a small Root fills reliably) and stops the store bloat at the source. Backward-compatible (publisher-side only; TPD reads whatever leaves exist). Retention still emits sink Deletes, now also cleaning up bitmap leaves from pre-upgrade visors. Tests updated to the current-only contract.