### PR TITLE
feat(router,proxystatus): full per-leg route — every hop, full PKs, per-hop type+latency

### DIFF
--- a/pkg/proxystatus/provider.go
+++ b/pkg/proxystatus/provider.go
@@ -66,6 +66,20 @@ type Leg struct {
 	Retransmits    uint64
 	Alive          bool
 	Standby        bool
+	// Hops is the leg's full forward route (every hop to the destination),
+	// full PKs, per-hop transport type + latency where known.
+	Hops []Hop
+}
+
+// Hop is one hop of a leg's forward route. From/To are FULL public keys —
+// the status page never truncates them. LatencyMS is the hop's transport
+// RTT where known (first hop owned; single-intermediate far hop derived).
+type Hop struct {
+	TpID      string
+	From      string
+	To        string
+	TpType    string
+	LatencyMS float64
 }
 
 // Snapshot is everything a status page renders for one surface. It is a

--- a/pkg/proxystatus/proxystatus_test.go
+++ b/pkg/proxystatus/proxystatus_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"math"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -48,8 +49,13 @@ func TestRenderSections(t *testing.T) {
 		Running:    true,
 		MuxEnabled: true,
 		Legs: []Leg{
-			{Index: 0, TpType: "stcpr", RemotePK: "0311223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", SentBytes: 2048, RecvBytes: 1024, LatencyMS: 42, RouteLatencyMS: 42, Direct: true, Alive: true},
-			{Index: 1, TpType: "sudph", SentBytes: 512, RecvBytes: 256, LatencyMS: 30, RouteLatencyMS: 480, Direct: false, Standby: true, Alive: true},
+			{Index: 0, TpType: "stcpr", RemotePK: "0311223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", SentBytes: 2048, RecvBytes: 1024, LatencyMS: 42, RouteLatencyMS: 42, Direct: true, Alive: true,
+				Hops: []Hop{{From: "02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee", To: "0311223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", TpType: "stcpr", LatencyMS: 42}}},
+			{Index: 1, TpType: "sudph", RemotePK: "03bb223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", SentBytes: 512, RecvBytes: 256, LatencyMS: 30, RouteLatencyMS: 480, Direct: false, Standby: true, Alive: true,
+				Hops: []Hop{
+					{From: "02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee", To: "03bb223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", TpType: "sudph", LatencyMS: 30},
+					{From: "03bb223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", To: "03cc223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", TpType: "stcpr", LatencyMS: 450},
+				}},
 		},
 		Logs:   []string{"line one", "line two"},
 		Events: nil,
@@ -61,10 +67,18 @@ func TestRenderSections(t *testing.T) {
 		"http-equiv=\"refresh\"", "standby", "status.dmsg", "status.skynet",
 		// route observability: route-latency column, direct/multihop badge, recv bar
 		"route rtt", "recv share", "direct", "multihop", "480 ms", "bar recv",
+		// full routes: section + full (untruncated) hop PKs + per-hop type/latency
+		"full routes", "03cc223344556677889900aabbccddeeff00112233445566778899aabbccddeeff",
+		"02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee", "450ms",
 	} {
 		if !strings.Contains(page, want) {
 			t.Errorf("rendered page missing %q", want)
 		}
+	}
+	// PKs must never be truncated: no "<hex>…<hex>" shortPK pattern on the page.
+	// (Bare "…" is fine in UI affordances like the disabled "mux mode…" button.)
+	if regexp.MustCompile(`[0-9a-f]…[0-9a-f]`).MatchString(page) {
+		t.Error("status page must not truncate public keys (found hex…hex)")
 	}
 	// The current surface should not be linked back to itself in the footer.
 	if strings.Contains(page, `href="http://status.skysocks/"`) {

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -109,8 +109,8 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 		if l.Direct {
 			routeLabel, routeCls = "direct", "route-direct"
 		}
-		fmt.Fprintf(b, `<tr><td>R%d</td><td><span class="rtag %s">%s</span></td><td>%s</td><td class="pk">%s</td>`,
-			l.Index, routeCls, routeLabel, html.EscapeString(orDash(l.TpType)), html.EscapeString(shortPK(l.RemotePK)))
+		fmt.Fprintf(b, `<tr><td>R%d</td><td><span class="rtag %s">%s</span></td><td>%s</td><td class="pk"><code class="fpk">%s</code></td>`,
+			l.Index, routeCls, routeLabel, html.EscapeString(orDash(l.TpType)), html.EscapeString(orDash(l.RemotePK)))
 		fmt.Fprintf(b, `<td>%s</td><td class="barcell"><span class="bar %s" style="width:%d%%"></span></td>`,
 			humanBytes(l.SentBytes), scls, sentShare)
 		fmt.Fprintf(b, `<td>%s</td><td class="barcell"><span class="bar recv %s" style="width:%d%%"></span></td>`,
@@ -119,9 +119,44 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 			l.LatencyMS, routeRTT(l.RouteLatencyMS), l.Retransmits, scls, state)
 	}
 	b.WriteString(`</tbody></table>`)
+	writeMuxRoutes(b, snap.Legs)
 	b.WriteString(`<p class="hint">Bars are each leg's sent / recv bytes relative to the busiest leg. ` +
 		`<b>tp rtt</b> is the first-hop transport; <b>route rtt</b> is the true end-to-end route latency (all hops). ` +
 		`For a live terminal chart use <code>skywire cli proxy mux plot</code>.</p></section>`)
+}
+
+// writeMuxRoutes renders each leg's FULL forward route as a hop chain:
+// origin PK ─[tptype rtt]→ hop PK ─[…]→ destination PK. Public keys are
+// shown in full (never truncated); per-hop latency is shown where known.
+func writeMuxRoutes(b *strings.Builder, legs []Leg) {
+	any := false
+	for _, l := range legs {
+		if len(l.Hops) > 0 {
+			any = true
+			break
+		}
+	}
+	if !any {
+		return
+	}
+	b.WriteString(`<h3>full routes</h3><div class="routes">`)
+	for _, l := range legs {
+		if len(l.Hops) == 0 {
+			continue
+		}
+		fmt.Fprintf(b, `<div class="route"><span class="rlabel">R%d</span> <code class="fpk">%s</code>`,
+			l.Index, html.EscapeString(l.Hops[0].From))
+		for _, h := range l.Hops {
+			lat := ""
+			if h.LatencyMS > 0 {
+				lat = fmt.Sprintf(" %.0fms", h.LatencyMS)
+			}
+			fmt.Fprintf(b, ` <span class="hop">─[%s%s]→</span> <code class="fpk">%s</code>`,
+				html.EscapeString(orDash(h.TpType)), html.EscapeString(lat), html.EscapeString(h.To))
+		}
+		b.WriteString(`</div>`)
+	}
+	b.WriteString(`</div>`)
 }
 
 func legState(l Leg) (label, cls string) {
@@ -224,19 +259,6 @@ func routeRTT(ms float64) string {
 	return fmt.Sprintf("%.0f ms", ms)
 }
 
-// shortPK renders a public key as its first+last 4 hex chars, or "direct"/"-"
-// for an empty peer.
-func shortPK(pk string) string {
-	pk = strings.TrimSpace(pk)
-	if pk == "" {
-		return "-"
-	}
-	if len(pk) <= 12 {
-		return pk
-	}
-	return pk[:6] + "…" + pk[len(pk)-4:]
-}
-
 // humanBytes formats a byte count with a binary unit suffix.
 func humanBytes(n uint64) string {
 	const unit = 1024
@@ -280,6 +302,11 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`.rtag{display:inline-block;padding:0 .4rem;border-radius:3px;font-size:11px;font-weight:600}` +
 	`.rtag.route-direct{background:rgba(60,180,120,.18);color:#2a8}` +
 	`.rtag.route-relay{background:rgba(120,140,200,.18);color:#68a}` +
+	`.fpk{font-family:ui-monospace,monospace;font-size:11px;word-break:break-all}` +
+	`.routes{display:flex;flex-direction:column;gap:.5rem;margin:.4rem 0}` +
+	`.route{font-size:12px;line-height:1.7;padding:.4rem .6rem;border:1px solid var(--border,#3334);border-radius:5px;overflow-wrap:anywhere}` +
+	`.route .rlabel{font-weight:700;margin-right:.3rem}` +
+	`.route .hop{color:var(--muted,#8a94a6);white-space:nowrap;font-family:ui-monospace,monospace}` +
 	`td.ok{color:var(--ok)}td.warn{color:var(--warn)}td.standby{color:var(--standby)}` +
 	`pre.log{background:var(--card);border:1px solid var(--line);border-radius:8px;padding:.7rem;font:11.5px/1.5 ui-monospace,SFMono-Regular,monospace;` +
 	`white-space:pre-wrap;word-break:break-word;max-height:26rem;overflow:auto;color:var(--fg)}` +

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -128,6 +128,15 @@ type RouteGroup struct {
 	// This is the full multi-hop route, not just local transports.
 	forwardHops []routing.Hop
 
+	// legForwardHops stores EACH mux leg's full forward route, keyed by the
+	// leg's first-hop transport ID (survives index shifts, like
+	// legE2ELatency). forwardHops above records only the primary leg; this
+	// captures every leg so the per-leg mux view can show each leg's whole
+	// path (all hops, full PKs, per-hop transport type), not just its first
+	// transport. Populated by SetForwardHops (primary) + AddMuxRouteByHops
+	// (aux legs). Guarded by rg.mu.
+	legForwardHops map[uuid.UUID][]routing.Hop
+
 	// initiator is true when this visor dialed the remote end (called
 	// router.DialRoutes); false when this visor accepted the route via
 	// AcceptRoutes / saveRouteGroupRules from a setup-node request.
@@ -272,6 +281,7 @@ func NewRouteGroup(cfg *RouteGroupConfig, rt routing.Table, desc routing.RouteDe
 		legMissed:          make(map[uuid.UUID]int),
 		inflightPings:      make(map[int64]uuid.UUID),
 		legE2ELatency:      make(map[uuid.UUID]float64),
+		legForwardHops:     make(map[uuid.UUID][]routing.Hop),
 		legRecvSnap:        make(map[uuid.UUID]uint64),
 	}
 
@@ -345,6 +355,12 @@ type MuxLeg struct {
 	// the leg's gate_state for the per-leg telemetry harness.
 	Alive   bool `json:"alive"`
 	Standby bool `json:"standby"`
+	// Hops is this leg's FULL forward route — every hop from this visor to
+	// the destination, with full (untruncated) From/To PKs and per-hop
+	// transport type. Per-hop LatencyMS is filled where known (first hop
+	// owned; single-intermediate far hop derived from route−transport RTT).
+	// Empty when the route path wasn't recorded (legacy/accepted routes).
+	Hops []RouteHopInfo `json:"hops,omitempty"`
 }
 
 // MuxStats returns a point-in-time snapshot of the rg's per-leg
@@ -385,6 +401,25 @@ func (rg *RouteGroup) MuxStats() MuxInfo {
 			// i.e. a 1-hop route; otherwise it is relayed (multihop).
 			leg.Direct = tp.Remote() == dstPK
 			leg.Alive = !tp.IsClosed()
+			// Full forward route for this leg (all hops, full PKs, per-hop
+			// transport type). Per-hop latency: hop 0 is the owned transport
+			// RTT; a single-intermediate leg's far hop is derived from
+			// route−transport RTT. legHopsFor takes rg.mu itself (unlocked here).
+			if hops := rg.legHopsFor(tp.Entry.ID); len(hops) > 0 {
+				leg.Hops = make([]RouteHopInfo, len(hops))
+				for hi, h := range hops {
+					leg.Hops[hi] = RouteHopInfo{
+						TpID:   h.TpID.String(),
+						From:   h.From.String(),
+						To:     h.To.String(),
+						TpType: string(transport.TypeFromTransportID(h.TpID, h.From, h.To)),
+					}
+				}
+				leg.Hops[0].LatencyMS = leg.LatencyMS
+				if len(leg.Hops) == 2 && leg.RouteLatencyMS > leg.LatencyMS {
+					leg.Hops[1].LatencyMS = leg.RouteLatencyMS - leg.LatencyMS
+				}
+			}
 		}
 		if rg.mux != nil {
 			leg.Standby = rg.mux.isLegStandby(i)
@@ -1063,9 +1098,14 @@ func (rg *RouteGroup) RouteHops() []cipher.PubKey {
 // RouteHopInfo contains detailed information about a single hop in a route.
 type RouteHopInfo struct {
 	TpID   string `json:"tp_id"`   // Transport ID
-	From   string `json:"from"`    // Source public key
-	To     string `json:"to"`      // Destination public key
+	From   string `json:"from"`    // Source public key (full, never truncated)
+	To     string `json:"to"`      // Destination public key (full, never truncated)
 	TpType string `json:"tp_type"` // Transport type (stcpr, sudph, dmsg)
+	// LatencyMS is this hop's transport RTT in ms, when known. The first
+	// hop is owned locally (tp.GetLatency). For a single-intermediate leg
+	// the far hop is derived (route RTT − first-hop RTT). Deeper hops are
+	// 0 here until sourced from TPD / the setup node's per-transport data.
+	LatencyMS float64 `json:"latency_ms,omitempty"`
 }
 
 // SetForwardHops sets the complete forward route hops.
@@ -1074,6 +1114,35 @@ func (rg *RouteGroup) SetForwardHops(hops []routing.Hop) {
 	rg.mu.Lock()
 	defer rg.mu.Unlock()
 	rg.forwardHops = hops
+	// Also record under the leg's first-hop transport ID so the per-leg mux
+	// view can show the primary leg's whole path (aux legs are recorded by
+	// AddMuxRouteByHops → recordLegHops).
+	if len(hops) > 0 {
+		rg.legForwardHops[hops[0].TpID] = hops
+	}
+}
+
+// recordLegHops stores a mux leg's full forward route keyed by its
+// first-hop transport ID. Called by AddMuxRouteByHops for aux legs.
+func (rg *RouteGroup) recordLegHops(hops []routing.Hop) {
+	if len(hops) == 0 {
+		return
+	}
+	rg.mu.Lock()
+	rg.legForwardHops[hops[0].TpID] = hops
+	rg.mu.Unlock()
+}
+
+// legHopsFor returns a copy of the full forward route for the leg on
+// transport tpID (nil if not recorded). Callers must NOT hold rg.mu.
+func (rg *RouteGroup) legHopsFor(tpID uuid.UUID) []routing.Hop {
+	rg.mu.Lock()
+	defer rg.mu.Unlock()
+	h, ok := rg.legForwardHops[tpID]
+	if !ok {
+		return nil
+	}
+	return append([]routing.Hop(nil), h...)
 }
 
 // Initiator reports whether this visor dialed the remote end of the route

--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -260,6 +260,10 @@ func (r *router) AddMuxRouteByHops(desc routing.RouteDescriptor, fwd, rev []rout
 		return fmt.Errorf("append route failed: %w", err)
 	}
 
+	// Record this leg's full forward route so the per-leg mux view can show
+	// its whole path (all hops, full PKs, per-hop transport type).
+	nrg.rg.recordLegHops(fwd)
+
 	r.logger.Infof("Added mux route via %d-hop path (first tp=%s) to route group %s", len(fwd), tpID, desc.String())
 	return nil
 }

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -142,23 +142,43 @@ func muxRouteGroupInfoFrom(infos []router.MuxInfo) []MuxRouteGroupInfo {
 		}
 		for _, leg := range info.Legs {
 			entry.Legs = append(entry.Legs, MuxLegInfo{
-				Index:       leg.Index,
-				TransportID: leg.TransportID,
-				TpType:      leg.TpType,
+				Index:          leg.Index,
+				TransportID:    leg.TransportID,
+				TpType:         leg.TpType,
 				RemotePK:       leg.RemotePK,
 				LatencyMS:      leg.LatencyMS,
 				RouteLatencyMS: leg.RouteLatencyMS,
 				Direct:         leg.Direct,
-				SentBytes:   leg.SentBytes,
-				SentPackets: leg.SentPackets,
-				RecvBytes:   leg.RecvBytes,
-				RecvPackets: leg.RecvPackets,
-				Retransmits: leg.Retransmits,
-				Alive:       leg.Alive,
-				Standby:     leg.Standby,
+				Hops:           muxHopsFrom(leg.Hops),
+				SentBytes:      leg.SentBytes,
+				SentPackets:    leg.SentPackets,
+				RecvBytes:      leg.RecvBytes,
+				RecvPackets:    leg.RecvPackets,
+				Retransmits:    leg.Retransmits,
+				Alive:          leg.Alive,
+				Standby:        leg.Standby,
 			})
 		}
 		out = append(out, entry)
+	}
+	return out
+}
+
+// muxHopsFrom transcribes the router's per-leg RouteHopInfo slice into the
+// wire-friendly MuxHopInfo shape (full PKs preserved).
+func muxHopsFrom(hops []router.RouteHopInfo) []MuxHopInfo {
+	if len(hops) == 0 {
+		return nil
+	}
+	out := make([]MuxHopInfo, len(hops))
+	for i, h := range hops {
+		out[i] = MuxHopInfo{
+			TpID:      h.TpID,
+			From:      h.From,
+			To:        h.To,
+			TpType:    h.TpType,
+			LatencyMS: h.LatencyMS,
+		}
 	}
 	return out
 }

--- a/pkg/visor/embedded_proxystatus.go
+++ b/pkg/visor/embedded_proxystatus.go
@@ -96,6 +96,7 @@ func (p *visorStatusProvider) StatusSnapshot(surface proxystatus.Surface) (proxy
 					Retransmits:    leg.Retransmits,
 					Alive:          leg.Alive,
 					Standby:        leg.Standby,
+					Hops:           proxyHopsFrom(leg.Hops),
 				})
 			}
 		}
@@ -114,4 +115,23 @@ func appendNote(existing, add string) string {
 		return add
 	}
 	return existing + " · " + add
+}
+
+// proxyHopsFrom transcribes the visor's per-leg MuxHopInfo into the
+// proxystatus.Hop shape the status page renders (full PKs preserved).
+func proxyHopsFrom(hops []MuxHopInfo) []proxystatus.Hop {
+	if len(hops) == 0 {
+		return nil
+	}
+	out := make([]proxystatus.Hop, len(hops))
+	for i, h := range hops {
+		out[i] = proxystatus.Hop{
+			TpID:      h.TpID,
+			From:      h.From,
+			To:        h.To,
+			TpType:    h.TpType,
+			LatencyMS: h.LatencyMS,
+		}
+	}
+	return out
 }

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -282,10 +282,10 @@ type MuxRouteGroupInfo struct {
 
 // MuxLegInfo is one route in a mux'd group.
 type MuxLegInfo struct {
-	Index       int     `json:"index"`
-	TransportID string  `json:"transport_id"`
-	TpType      string  `json:"tp_type"`
-	RemotePK    string  `json:"remote_pk"`
+	Index       int    `json:"index"`
+	TransportID string `json:"transport_id"`
+	TpType      string `json:"tp_type"`
+	RemotePK    string `json:"remote_pk"`
 	// LatencyMS is the FIRST-HOP transport RTT; RouteLatencyMS is the leg's
 	// TRUE end-to-end route latency (all hops, from the leg-liveness pong) —
 	// on a multihop leg the two differ sharply. Direct is true for a 1-hop
@@ -295,8 +295,8 @@ type MuxLegInfo struct {
 	Direct         bool    `json:"direct"`
 	SentBytes      uint64  `json:"sent_bytes"`
 	SentPackets    uint64  `json:"sent_packets"`
-	RecvBytes   uint64  `json:"recv_bytes"`
-	RecvPackets uint64  `json:"recv_packets"`
+	RecvBytes      uint64  `json:"recv_bytes"`
+	RecvPackets    uint64  `json:"recv_packets"`
 	// Retransmits is SACK retransmit packets carried by this leg (loss
 	// signal). Alive/Standby are the leg's gate_state: Alive=false once the
 	// transport is closed; Standby=true for a warm standby (rules kept,
@@ -304,6 +304,20 @@ type MuxLegInfo struct {
 	Retransmits uint64 `json:"retransmits"`
 	Alive       bool   `json:"alive"`
 	Standby     bool   `json:"standby"`
+	// Hops is the leg's full forward route (every hop to the destination),
+	// with full PKs and per-hop transport type + latency where known.
+	Hops []MuxHopInfo `json:"hops,omitempty"`
+}
+
+// MuxHopInfo is one hop of a mux leg's forward route. From/To are FULL
+// public keys (never truncated). LatencyMS is the hop's transport RTT
+// where known (first hop owned; single-intermediate far hop derived).
+type MuxHopInfo struct {
+	TpID      string  `json:"tp_id"`
+	From      string  `json:"from"`
+	To        string  `json:"to"`
+	TpType    string  `json:"tp_type"`
+	LatencyMS float64 `json:"latency_ms,omitempty"`
 }
 type FetchServiceDataIn struct {
 	Service string


### PR DESCRIPTION
Builds on #4106. The mux view still showed only each leg's first hop and truncated peer PKs. Now each leg carries its **full forward route**.

- `RouteGroup` records per-leg forward hops (`legForwardHops`, keyed by first-hop transport ID) — primary leg via `SetForwardHops`, aux legs via `AddMuxRouteByHops`. `MuxLeg.Hops` exposes the whole path.
- Each hop carries **full (untruncated) From/To PKs** + transport type + **latency where known**: owned first hop from `tp.GetLatency`; a single-intermediate leg's far hop derived from route−transport RTT. Deeper hops await TPD / setup-node per-transport data (follow-up).
- Threaded router → `MuxHopInfo` → `proxystatus.Hop`; `visor state --jq '.mux_route_groups'` carries it too.
- **status.skysocks:** peer column now shows the FULL PK (dropped `shortPK`), plus a new *full routes* section rendering each leg's hop chain (origin ─[tptype latency]→ hop ─[…]→ destination). No truncation anywhere.

Test asserts full routes, untruncated hop PKs, per-hop latency, and that no hex…hex shortPK pattern survives.