### PR TITLE
fix(router): control-plane ports stay single-route (no warm-standby mux)

### DIFF
--- a/pkg/router/control_port_mux_test.go
+++ b/pkg/router/control_port_mux_test.go
@@ -1,0 +1,37 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// TestIsControlPlanePort locks the no-mux port set: control/telemetry ports are
+// control-plane (single-route), bulk-data app ports are not (keep their mux).
+func TestIsControlPlanePort(t *testing.T) {
+	control := []uint16{
+		skyenv.DmsgPtyPort, skyenv.DmsgCtrlPort, skyenv.DmsgPingPort,
+		skyenv.DmsgSetupPort, skyenv.DmsgHypervisorPort, skyenv.DmsgGRPCPort,
+		skyenv.DmsgVisorRPCPort, skyenv.DmsgTransportSetupPort,
+	}
+	for _, p := range control {
+		if !isControlPlanePort(routing.Port(p)) {
+			t.Errorf("port %d should be control-plane (no mux)", p)
+		}
+	}
+	// Bulk-data app ports MUST keep their mux (not control-plane).
+	dataPorts := []uint16{
+		1,  // skychat
+		3,  // skysocks
+		13, // skysocks-client
+		43, // vpn-client
+		44, // vpn-server
+		59, // skynet-client forward pool (bulk mux carry)
+	}
+	for _, p := range dataPorts {
+		if isControlPlanePort(routing.Port(p)) {
+			t.Errorf("data port %d must NOT be treated as control-plane (would kill its mux)", p)
+		}
+	}
+}

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -20,6 +20,7 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/rfclient"
 	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport"
 	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 )
@@ -651,6 +652,21 @@ func (r *router) finishDial(
 	if muxTarget > 1 && r.isSameLANDest(forwardDesc.DstPK()) {
 		r.logger.WithField("dst", forwardDesc.DstPK().String()).
 			Debug("same-LAN destination: forcing direct (no warm-standby mux)")
+		muxTarget = 1
+	}
+	// A control-plane destination port (dmsgpty, RPC, setup-node, hypervisor,
+	// transport-setup, CXO telemetry, …) carries small request/response control
+	// traffic, never bulk data — so the bandwidth-spreading warm-standby mux is
+	// pure cost: it grows a large pool of multi-hop aux legs whose setup-node
+	// dials churn (context deadline exceeded), and a multi-round-trip control
+	// handshake (e.g. dmsgpty noise-XK) times out over the churning legs while a
+	// single 1-hop request would have completed. Observed live as a 32-leg mux on
+	// the pty port (22) that never carried a byte. Keep control channels direct;
+	// this is the port-keyed complement to the --direct / same-LAN no-mux gates.
+	if muxTarget > 1 && isControlPlanePort(rPort) {
+		r.logger.WithField("dst", forwardDesc.DstPK().String()).
+			WithField("port", rPort).
+			Debug("control-plane destination port: forcing direct (no warm-standby mux)")
 		muxTarget = 1
 	}
 	if muxTarget > 1 {
@@ -2683,6 +2699,36 @@ func (r *router) sameLANExcludedPKs() []cipher.PubKey {
 		self = r.conf.SelfPublicIP()
 	}
 	return r.tm.SameLANPeers(self)
+}
+
+// controlPlanePorts is the set of reserved skywire service ports that carry
+// small control / telemetry traffic (never bulk data). A route group whose
+// destination lands on one of these must not grow a bandwidth-spreading
+// warm-standby mux (see the gate in dialRoutesFwd). Mirrors the reserved
+// service ports in pkg/skyenv; app data ports (skysocks 3, skysocks-client 13,
+// vpn 43/44, the port-59 forward pool, skychat 1, dynamic ports) are absent so
+// they keep their mux.
+var controlPlanePorts = map[uint16]struct{}{
+	skyenv.DmsgCtrlPort:                  {}, // 7
+	skyenv.DmsgPingPort:                  {}, // 8
+	skyenv.DmsgPtyPort:                   {}, // 22 — the observed 32-leg-mux victim
+	skyenv.DmsgSetupPort:                 {}, // 36
+	skyenv.DmsgHypervisorPort:            {}, // 46
+	skyenv.DmsgTransportSetupPort:        {}, // 47
+	skyenv.DmsgTransportSetupServicePort: {}, // 48
+	skyenv.DmsgGRPCPort:                  {}, // 49
+	skyenv.DmsgVisorRPCPort:              {}, // 65
+	skyenv.DmsgTransportQueryPort:        {}, // 68
+	skyenv.DmsgDHTPort:                   {}, // 100
+	skyenv.DmsgAwaitSetupPort:            {}, // 136
+}
+
+// isControlPlanePort reports whether p is a reserved control/telemetry service
+// port (not bulk data) — such route groups stay single-route (no warm-standby
+// mux). See controlPlanePorts.
+func isControlPlanePort(p routing.Port) bool {
+	_, ok := controlPlanePorts[uint16(p)]
+	return ok
 }
 
 // isSameLANDest reports whether dst is a peer on this visor's own local network


### PR DESCRIPTION
A `dmsgpty exec` over skynet to a peer was timing out. **Root cause:** the adaptive default grows a warm-standby mux (large pool) on *every* route group, including control channels. Observed live as a **32-leg mux on the pty port (22)** whose aux legs never established — `Mux self-heal: dialing replacement leg … alive=0 target=32`, each failing `rotation add-leg: setup-node dial: context deadline exceeded`. The multi-round-trip pty noise-XK handshake times out over the churning legs, while a single 1-hop request completes (a `visor ver` over the same skynet route returns instantly). It even dialed a fresh sudph transport despite an existing direct stcpr.

Control-plane destination ports (dmsgpty, RPC, setup-node, hypervisor, transport-setup, ctrl, ping, DHT, await-setup, transport-query) carry small request/response traffic, never bulk data — the bandwidth-spreading mux is pure cost. Force `muxTarget=1` for them: the port-keyed complement to the existing `--direct` and same-LAN no-mux gates (#4099/#4100).

Data ports keep their mux (asserted): skysocks 3, skysocks-client 13, vpn 43/44, and the **port-59** skynet-client forward pool.