### PR TITLE
fix(ci): publish-binary — literal env prefixes (CGO_ENABLED=0: command not found)

### DIFF
--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -71,8 +71,19 @@ jobs:
           build_arch() {
             local name="$1" goarch="$2" goarm="$3"
             echo "==> building linux/${name} (GOARCH=${goarch}${goarm:+ GOARM=${goarm}})"
-            GOOS=linux GOARCH="${goarch}" ${goarm:+GOARM="${goarm}"} CGO_ENABLED=0 \
-              go build -trimpath -mod=vendor -ldflags="${LDFLAGS}" -o skywire .
+            # Use LITERAL assignment prefixes: bash only recognizes env-var
+            # assignment prefixes for literal words at parse time, so putting a
+            # conditional ${goarm:+GOARM=...} expansion there made bash treat the
+            # trailing CGO_ENABLED=0 as a command ("command not found", exit 127).
+            # An explicit if keeps every prefix literal for both the GOARM and the
+            # no-GOARM arches.
+            if [ -n "${goarm}" ]; then
+              GOOS=linux GOARCH="${goarch}" GOARM="${goarm}" CGO_ENABLED=0 \
+                go build -trimpath -mod=vendor -ldflags="${LDFLAGS}" -o skywire .
+            else
+              GOOS=linux GOARCH="${goarch}" CGO_ENABLED=0 \
+                go build -trimpath -mod=vendor -ldflags="${LDFLAGS}" -o skywire .
+            fi
             zstd -19 -q -f -o "dist/skywire-linux-${name}.zst" skywire
             rm -f skywire
           }


### PR DESCRIPTION
#4087's all-arches `build_arch` put a conditional `${goarm:+GOARM="..."}` expansion in the env-assignment prefix. Bash only recognizes assignment prefixes for **literal** words at parse time, so the expanded `GOARM=...` (and then the trailing `CGO_ENABLED=0`) were treated as **commands** — `CGO_ENABLED=0: command not found`, exit 127 — **breaking the rolling develop-latest binary** the fleet's binary auto-updater pulls.

Split into an explicit `if` so every env prefix is literal for both the GOARM arches (arm/armhf) and the no-GOARM arches. **Verified the shell logic locally**: the old form reproduces the exact error, the new form sets correct GOOS/GOARCH/GOARM/CGO_ENABLED for every arch.