### PR TITLE
fix(router): guarantee mux legs are fully disjoint and loop-free

### DIFF
--- a/pkg/router/mux_route_invariants_test.go
+++ b/pkg/router/mux_route_invariants_test.go
@@ -1,0 +1,110 @@
+// Package router pkg/router/mux_route_invariants_test.go
+package router
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// pathHops builds a forward hop chain visiting the given ordered visor PKs
+// (src, i1, i2, ..., dst). Each hop's transport ID is left zero — the mux
+// invariant helpers under test key on PKs only.
+func pathHops(pks ...cipher.PubKey) []routing.Hop {
+	if len(pks) < 2 {
+		return nil
+	}
+	hops := make([]routing.Hop, 0, len(pks)-1)
+	for i := 0; i < len(pks)-1; i++ {
+		hops = append(hops, routing.Hop{From: pks[i], To: pks[i+1]})
+	}
+	return hops
+}
+
+func TestRouteIntermediates(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	x, _ := cipher.GenerateKeyPair()
+	y, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+
+	// Direct (0-intermediate) leg has no intermediates.
+	require.Empty(t, routeIntermediates(pathHops(src, dst), src, dst))
+
+	// Two-hop leg src->x->dst yields [x].
+	got := routeIntermediates(pathHops(src, x, dst), src, dst)
+	require.Equal(t, []cipher.PubKey{x}, got)
+
+	// Three-hop leg src->x->y->dst yields [x, y].
+	got = routeIntermediates(pathHops(src, x, y, dst), src, dst)
+	require.ElementsMatch(t, []cipher.PubKey{x, y}, got)
+
+	// src and dst are never counted as intermediates even if a From lists them.
+	require.NotContains(t, routeIntermediates(pathHops(src, x, dst), src, dst), src)
+	require.NotContains(t, routeIntermediates(pathHops(src, x, dst), src, dst), dst)
+}
+
+func TestHasLoop(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	x, _ := cipher.GenerateKeyPair()
+	y, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+
+	require.False(t, hasLoop(nil))
+	require.False(t, hasLoop(pathHops(src, dst)))
+	require.False(t, hasLoop(pathHops(src, x, y, dst)))
+
+	// Loop: src->x->src->dst passes through src twice.
+	require.True(t, hasLoop(pathHops(src, x, src, dst)))
+	// Loop: an intermediate repeats (src->x->y->x->dst).
+	require.True(t, hasLoop(pathHops(src, x, y, x, dst)))
+	// Loop: the destination appears mid-path (src->dst->y->dst).
+	require.True(t, hasLoop(pathHops(src, dst, y, dst)))
+}
+
+func TestDisjointFrom(t *testing.T) {
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	c, _ := cipher.GenerateKeyPair()
+
+	// Empty candidate (direct leg) is always disjoint.
+	require.True(t, disjointFrom(nil, []cipher.PubKey{a, b}))
+	// Empty used set accepts anything.
+	require.True(t, disjointFrom([]cipher.PubKey{a}, nil))
+	// No overlap.
+	require.True(t, disjointFrom([]cipher.PubKey{a}, []cipher.PubKey{b, c}))
+	// Overlap on a.
+	require.False(t, disjointFrom([]cipher.PubKey{a, c}, []cipher.PubKey{a, b}))
+}
+
+func TestValidMuxLeg(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	x, _ := cipher.GenerateKeyPair() // used by an existing leg
+	y, _ := cipher.GenerateKeyPair() // free
+	z, _ := cipher.GenerateKeyPair() // free
+
+	// Existing legs already route through x (both directions).
+	usedFwd := []cipher.PubKey{x}
+	usedRev := []cipher.PubKey{x}
+
+	fwdVia := func(mid cipher.PubKey) []routing.Hop { return pathHops(src, mid, dst) }
+	revVia := func(mid cipher.PubKey) []routing.Hop { return pathHops(dst, mid, src) }
+
+	// Disjoint candidate (via y fwd, z rev) accepted.
+	require.True(t, validMuxLeg(fwdVia(y), revVia(z), src, dst, usedFwd, usedRev))
+
+	// Overlapping-intermediate candidate rejected — forward reuses x.
+	require.False(t, validMuxLeg(fwdVia(x), revVia(z), src, dst, usedFwd, usedRev))
+	// Overlapping on the reverse direction is rejected too.
+	require.False(t, validMuxLeg(fwdVia(y), revVia(x), src, dst, usedFwd, usedRev))
+
+	// Looping candidate rejected even when it would otherwise be disjoint.
+	loopFwd := pathHops(src, y, z, y, dst) // y appears twice
+	require.False(t, validMuxLeg(loopFwd, revVia(z), src, dst, usedFwd, usedRev))
+
+	// Direct (0-intermediate) leg is always accepted, regardless of used set.
+	require.True(t, validMuxLeg(pathHops(src, dst), pathHops(dst, src), src, dst, usedFwd, usedRev))
+}

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -2353,6 +2353,22 @@ func (r *router) establishMuxRoutes(
 		}
 		consecutiveFailures = 0
 
+		// Hard mux invariants (post-fetch gate). Even though excludePKs is fed
+		// to the finder as ExcludeIntermediatePKs, the local-calc fallback and
+		// finder misses can still return a leg that overlaps an existing leg's
+		// intermediates or loops through a visor twice. Reject such a candidate
+		// HERE — before the setup-node dial — and claim its intermediates so the
+		// next slot diverges from it. excludePKs is the running union of every
+		// prior leg's intermediates (both directions), so it serves as the used
+		// set for the forward and reverse checks alike.
+		if !validMuxLeg(muxFwd, muxRev, lPK, rPK, excludePKs, excludePKs) {
+			log.Debugf("Mux route %d/%d: candidate rejected — intra-route loop or intermediate overlap with an existing leg; skipping",
+				i+1, maxCount)
+			excludePKs = append(excludePKs, intermediatesOfHops(muxFwd, lPK, rPK)...)
+			excludePKs = append(excludePKs, intermediatesOfHops(muxRev, rPK, lPK)...)
+			continue
+		}
+
 		// The route-finder fallback ignores ExcludeTransportIDs, so it can hand
 		// back a leg whose first hop reuses a transport already used by the
 		// group (or an earlier planned leg). If we planned + dialed it, the
@@ -2524,6 +2540,15 @@ func (r *router) addOneAuxForwardLeg(ctx context.Context, nrg *NoiseRouteGroup, 
 			return fmt.Errorf("rotation add-leg: no route found (route-finder=%v, local-calc=%v)", err, lcErr)
 		}
 		muxFwd, muxRev = lcFwd, lcRev
+	}
+
+	// Hard mux invariants (post-fetch gate): the planned leg must be loop-free
+	// and its intermediates disjoint from every existing leg. excludePKs holds
+	// the group's intermediates plus the caller's exclude hints, so it is the
+	// used set for both directions. A violating candidate is skipped (the
+	// rotation goroutine keeps the current leg set and retries next tick).
+	if !validMuxLeg(muxFwd, muxRev, lPK, rPK, excludePKs, excludePKs) {
+		return errors.New("rotation add-leg: planned leg violates mux invariants (intra-route loop or intermediate overlap with an existing leg)")
 	}
 
 	// The route-finder honors ExcludeIntermediatePKs but NOT ExcludeTransportIDs,
@@ -2793,4 +2818,90 @@ func intermediatePKsOfPath(hops []routing.Hop, src, dst cipher.PubKey) []cipher.
 		out = append(out, pk)
 	}
 	return out
+}
+
+// routeIntermediates returns the de-duplicated set of intermediate-visor PKs
+// of a hop sequence: every visor appearing as a hop endpoint (From or To)
+// other than this visor (src) and the destination (dst). For a direct 1-hop
+// route src->dst it returns nil (no intermediates). Unlike
+// intermediatePKsOfPath it inspects BOTH edges of every hop, so an
+// intermediate that a malformed candidate lists only as a From (never a To)
+// is still reported — the disjointness guarantee must not depend on the
+// route being well-formed.
+func routeIntermediates(fwd []routing.Hop, src, dst cipher.PubKey) []cipher.PubKey {
+	seen := make(map[cipher.PubKey]struct{}, 2*len(fwd))
+	var out []cipher.PubKey
+	add := func(pk cipher.PubKey) {
+		if pk == src || pk == dst || pk == (cipher.PubKey{}) {
+			return
+		}
+		if _, ok := seen[pk]; ok {
+			return
+		}
+		seen[pk] = struct{}{}
+		out = append(out, pk)
+	}
+	for _, h := range fwd {
+		add(h.From)
+		add(h.To)
+	}
+	return out
+}
+
+// hasLoop reports whether a forward hop chain passes through the same visor
+// more than once (an intra-route loop). The visor visit order is the first
+// hop's From followed by every hop's To; a repeat anywhere in that sequence
+// is a loop. A route that loops through a visor twice can send traffic in a
+// circle with no way for the endpoints to detect it.
+func hasLoop(fwd []routing.Hop) bool {
+	if len(fwd) == 0 {
+		return false
+	}
+	seen := make(map[cipher.PubKey]struct{}, len(fwd)+1)
+	seen[fwd[0].From] = struct{}{}
+	for _, h := range fwd {
+		if _, ok := seen[h.To]; ok {
+			return true
+		}
+		seen[h.To] = struct{}{}
+	}
+	return false
+}
+
+// disjointFrom reports whether cand shares no PK with used (the set
+// intersection is empty). An empty cand — a direct, zero-intermediate leg —
+// is trivially disjoint and always accepted.
+func disjointFrom(cand, used []cipher.PubKey) bool {
+	if len(cand) == 0 || len(used) == 0 {
+		return true
+	}
+	set := make(map[cipher.PubKey]struct{}, len(used))
+	for _, pk := range used {
+		set[pk] = struct{}{}
+	}
+	for _, pk := range cand {
+		if _, ok := set[pk]; ok {
+			return false
+		}
+	}
+	return true
+}
+
+// validMuxLeg reports whether a candidate leg satisfies the two hard mux
+// invariants given the intermediates already claimed by the group's other
+// legs (usedFwd for the forward direction, usedRev for the reverse): the
+// forward and reverse paths must each be loop-free, and each direction's
+// intermediates must be fully disjoint from the corresponding used set. It
+// is the post-fetch gate applied to every candidate before it is committed
+// as a leg — the route-finder honors ExcludeIntermediatePKs but its
+// local-calc fallback and finder misses can still return an overlapping or
+// looping path.
+func validMuxLeg(fwd, rev []routing.Hop, src, dst cipher.PubKey, usedFwd, usedRev []cipher.PubKey) bool {
+	if hasLoop(fwd) || hasLoop(rev) {
+		return false
+	}
+	if !disjointFrom(routeIntermediates(fwd, src, dst), usedFwd) {
+		return false
+	}
+	return disjointFrom(routeIntermediates(rev, dst, src), usedRev)
 }

--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -239,6 +239,19 @@ func (r *router) AddMuxRouteByHops(desc routing.RouteDescriptor, fwd, rev []rout
 	}
 	nrg.rg.mu.Unlock()
 
+	// Hard mux invariants, enforced at the commit boundary so they hold for
+	// every caller (GrowMuxRoute's planner and external callers that supply
+	// explicit hops alike): (b) neither the forward nor the reverse path may
+	// loop through the same visor twice, and (a) the new leg's intermediates
+	// must be fully disjoint from those already used by the group's legs. This
+	// is the one chokepoint that sees the full hop chain — appendRouteToGroup
+	// only knows the next transport ID — so it is where the whole-path checks
+	// belong.
+	used := intermediatesOfRouteGroup(nrg, lPK, rPK)
+	if !validMuxLeg(fwd, rev, lPK, rPK, used, used) {
+		return errors.New("refusing mux leg: intra-route loop or intermediate overlap with an existing leg (mux legs must be fully disjoint and loop-free)")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -363,6 +376,25 @@ func (r *router) GrowMuxRoute(desc routing.RouteDescriptor, target, minHops int)
 		if err != nil {
 			consecutiveFailures++
 			log.Debugf("GrowMuxRoute: no disjoint path for leg %d/%d: %v", current+added+1, target, err)
+			if consecutiveFailures >= maxConsecutiveFailures {
+				break
+			}
+			continue
+		}
+
+		// Hard mux invariants (post-fetch gate): the finder honors
+		// ExcludeIntermediatePKs but its local-calc fallback / a finder miss can
+		// still return a leg that overlaps an existing leg's intermediates or
+		// loops through a visor twice. Reject it, claim its intermediates so the
+		// re-request diverges, and retry. excludePKs is the running union of the
+		// live legs' intermediates plus every prior iteration's, for both
+		// directions.
+		if !validMuxLeg(fwd, rev, lPK, rPK, excludePKs, excludePKs) {
+			excludePKs = append(excludePKs, intermediatesOfHops(fwd, lPK, rPK)...)
+			excludePKs = append(excludePKs, intermediatesOfHops(rev, rPK, lPK)...)
+			consecutiveFailures++
+			log.Debugf("GrowMuxRoute: candidate for leg %d/%d rejected — intra-route loop or intermediate overlap; re-requesting with strengthened excludes",
+				current+added+1, target)
 			if consecutiveFailures >= maxConsecutiveFailures {
 				break
 			}


### PR DESCRIPTION
Two mux-route invariants were only best-effort and are now enforced:

(a) no two legs of a multiplexed route group may share any intermediate visor;
(b) no single multihop leg may pass through the same visor twice.

The route-finder honors `ExcludeIntermediatePKs` but not `ExcludeTransportIDs`, and its local-calc fallback plans over a narrower graph, so a fetched candidate could still overlap an existing legs intermediates or loop through a visor. This adds a post-fetch validation applied to every candidate before it is committed as a leg.

New pure helpers in `pkg/router/router_dial.go`: `routeIntermediates`, `hasLoop`, `disjointFrom`, plus a `validMuxLeg` gate.

Enforcement points:
- `establishMuxRoutes`, `GrowMuxRoute`, `addOneAuxForwardLeg` reject a candidate that loops or overlaps the running union of the groups intermediates, claim its intermediates, and re-request with a strengthened exclude set (or skip the leg).
- `AddMuxRouteByHops` enforces the same at the commit boundary — the one chokepoint that sees the full hop chain (`appendRouteToGroup` only knows the next transport ID) — so caller-supplied explicit paths are covered too.

Unit tests (`mux_route_invariants_test.go`) cover overlapping-intermediate rejected, disjoint accepted, loop rejected, and direct (0-intermediate) leg always accepted.

`go build .` passes; `go test ./pkg/router/...` passes.