### PR TITLE
fix(lint): clear golangci-lint failures blocking develop CI

### DIFF
--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -1114,7 +1114,7 @@ func (c *Cache) incItem(
 	}
 
 	rc = it.cc - it.fc // hard rc
-	return
+	return rc, err
 }
 
 // under lock

--- a/pkg/cxo/treestore/churn_lag_test.go
+++ b/pkg/cxo/treestore/churn_lag_test.go
@@ -78,7 +78,7 @@ func (c *churnSub) waitConverge(want int, timeout time.Duration) (time.Duration,
 func newChurnPair(t *testing.T, batchWindow time.Duration) (*Publisher, *churnSub) {
 	t.Helper()
 	_, skA := cipher.GenerateKeyPair()
-	pkA := cipher.PubKey{}
+	var pkA cipher.PubKey
 	{
 		// derive pkA from skA so subscriber can address the feed
 		pk, err := skA.PubKey()

--- a/pkg/skysocks/client_status_test.go
+++ b/pkg/skysocks/client_status_test.go
@@ -106,9 +106,9 @@ func socks5Connect(t *testing.T, addr, host string, port uint16) net.Conn {
 	if method[0] != 0x05 || method[1] != 0x00 {
 		t.Fatalf("unexpected method reply %v", method)
 	}
-	req := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))}
+	req := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))} //nolint:gosec
 	req = append(req, []byte(host)...)
-	req = append(req, byte(port>>8), byte(port))
+	req = append(req, byte(port>>8), byte(port)) //nolint:gosec
 	if _, err := conn.Write(req); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/visor/dmsg_rpc_transport_oracle.go
+++ b/pkg/visor/dmsg_rpc_transport_oracle.go
@@ -56,10 +56,10 @@ func (o *dmsgRPCTransportOracle) DstTransports(ctx context.Context, _, dst ciphe
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = conn.Close() }()
+	defer func() { _ = conn.Close() }() //nolint:errcheck
 	// Bound the RPC round-trip to the oracle's deadline (net/rpc ignores ctx).
 	if dl, ok := ctx.Deadline(); ok {
-		_ = conn.SetDeadline(dl)
+		_ = conn.SetDeadline(dl) //nolint:errcheck
 	}
 
 	api := NewRPCClient(o.log, conn, RPCPrefix, 0)


### PR DESCRIPTION
develop's `golangci-lint-action@v9` job has been red for many commits — the check is non-required, so admin-merges have been landing over it. Six issues, spread across unrelated files, none tied to a single feature. Clearing them so CI is green for the v1.3.92 release.

- `pkg/visor/dmsg_rpc_transport_oracle.go` — `//nolint:errcheck` on the blank-assigned `conn.Close()`/`conn.SetDeadline()` (errcheck runs with `check-blank: true`, which flags even `_ =`).
- `pkg/skysocks/client_status_test.go` — `//nolint:gosec` on the `len(host)`/`port`→`byte` conversions in the test's SOCKS5 request builder (G115).
- `pkg/cxo/treestore/churn_lag_test.go` — `var pkA cipher.PubKey` instead of `:= cipher.PubKey{}` (ineffassign; the value is overwritten immediately below).
- `pkg/cxo/skyobject/cache.go` — explicit `return rc, err` instead of a naked return in `incItem` (nakedret).

`go build .` passes; `golangci-lint run` over the four packages is clean (full-tree run reported exactly these six).