### PR TITLE
ci(release): fail-fast: false on the linux arch matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
     needs: create-release
     runs-on: ubuntu-latest
     strategy:
+      # Don't let one arch's transient failure (e.g. a flaky module fetch)
+      # cancel the other five — each arch uploads independently.
+      fail-fast: false
       matrix:
         include:
           - arch: amd64


### PR DESCRIPTION
The v1.3.92 release published no linux binaries: a transient `go: downloading` failure on the **riscv64** runner (`fatal: could not read Username for 'https://github.com'`) failed that arch, and because the linux matrix defaults to `fail-fast: true`, GitHub **cancelled all five healthy arches** (amd64/arm64/arm/armhf/386) mid-build.

Each arch uploads to the GH release independently — one arch's flake should never cancel the rest. Setting `fail-fast: false` on the linux matrix. YAML validated locally.