### PR TITLE
fix(router): retry route-ID reservation on a mid-call stream reset

### DIFF
--- a/pkg/router/id_reserver.go
+++ b/pkg/router/id_reserver.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 	"sync"
 
@@ -113,6 +114,26 @@ func isPooledConnShutdown(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "connection is shut down")
 }
 
+// isReserveResetErr reports whether err is a reservation call that failed
+// because the underlying stream was reset/closed — either handed back already
+// dead (isPooledConnShutdown, net/rpc "connection is shut down") OR reset WHILE
+// the ReserveIDs call was in flight. In the mid-call case net/rpc terminates
+// the pending call with the raw read error (io.EOF / io.ErrUnexpectedEOF), and
+// a locally-closed conn surfaces as net.ErrClosed — none of which contain the
+// "connection is shut down" string, so without this they fell straight through
+// as an un-retried hard leg failure ("reserve routeID from <pk> failed: EOF").
+// This is the dominant multi-leg (mux) setup churn: the primary leg sets up
+// alone and succeeds, then the aux legs fan out as a concurrent burst over one
+// shared DMSG client and one of the in-flight reserve streams gets reset. All
+// of these are worth a single fresh-dial retry (a reachable hop succeeds; a
+// genuinely dead one still fails, bounded by the per-call rpcDeadline).
+func isReserveResetErr(err error) bool {
+	return isPooledConnShutdown(err) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, net.ErrClosed)
+}
+
 // redial discards a dead client and dials a fresh one for pk, replacing it in
 // the client map so the later rule-install reuses the live connection. Returns
 // nil when no fresh connection can be established (caller surfaces the original
@@ -175,17 +196,18 @@ func (idr *idReserver) ReserveIDs(ctx context.Context) error {
 				return
 			}
 			rtIDs, err := client.ReserveIDs(ctx, n)
-			if isPooledConnShutdown(err) {
-				// Stale pooled connection. ClientPool.Get's liveness check
-				// (client_pool.go) only discards conns idle past the stream
-				// read deadline — so a conn that died for any OTHER reason (the
-				// intermediate restarted, its dmsg session/transport dropped)
-				// is handed back as a corpse and this first call returns
-				// "connection is shut down". Re-dial fresh ONCE and retry: a
-				// reachable hop succeeds on the retry, a genuinely-dead one
-				// still fails below. This was the dominant route-setup failure
-				// (id_reservation, ~59% on a live RSN) — a single bad pooled
-				// conn was failing the whole reservation with no retry.
+			if isReserveResetErr(err) {
+				// The reserve stream was dead-on-arrival ("connection is shut
+				// down" — ClientPool.Get's liveness check only discards conns
+				// idle past the read deadline, so a conn that died for any
+				// OTHER reason (intermediate restarted, dmsg session/transport
+				// dropped) is handed back as a corpse) OR was reset WHILE the
+				// call was in flight (raw io.EOF, the mux aux-leg burst case).
+				// Re-dial fresh ONCE and retry: a reachable hop succeeds on the
+				// retry, a genuinely-dead one still fails below. This was the
+				// dominant route-setup failure (id_reservation, ~59% on a live
+				// RSN) — a single bad/reset stream failed the whole reservation
+				// with no retry.
 				if fresh := idr.redial(ctx, pk, client); fresh != nil {
 					rtIDs, err = fresh.ReserveIDs(ctx, n)
 				}

--- a/pkg/router/id_reserver_test.go
+++ b/pkg/router/id_reserver_test.go
@@ -4,6 +4,8 @@ package router
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/rpc"
 	"strconv"
@@ -353,4 +355,33 @@ func TestIdReserver_ReserveIDs_RetriesStalePooledConn(t *testing.T) {
 	defer d.mu.Unlock()
 	assert.GreaterOrEqual(t, d.n[pkA], 2, "hop A should have been re-dialed")
 	assert.GreaterOrEqual(t, d.n[pkB], 2, "hop B should have been re-dialed")
+}
+
+// TestIsReserveResetErr covers the Fix-#1 decision logic: a reserve call that
+// failed because its stream was reset/closed mid-flight (raw io.EOF from
+// net/rpc's reader, io.ErrUnexpectedEOF, or net.ErrClosed) must be treated as
+// retryable, not just the already-dead "connection is shut down" case. This is
+// the dominant mux aux-leg setup churn ("reserve routeID from <pk> failed: EOF")
+// that previously fell through un-retried.
+func TestIsReserveResetErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"shutdown-string", errors.New("connection is shut down"), true},
+		{"raw-eof", io.EOF, true},
+		{"wrapped-eof", fmt.Errorf("reserve: %w", io.EOF), true},
+		{"unexpected-eof", io.ErrUnexpectedEOF, true},
+		{"net-closed", net.ErrClosed, true},
+		{"wrapped-net-closed", fmt.Errorf("dial: %w", net.ErrClosed), true},
+		{"unrelated", errors.New("route not found"), false},
+		{"deadline", context.DeadlineExceeded, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, isReserveResetErr(c.err))
+		})
+	}
 }


### PR DESCRIPTION
## Problem
Multi-leg (mux) route setup fails under concurrent load with `reserve routeID from <pk> failed: EOF`. This is the dominant part of the mux>1 setup churn — the *data plane* is healthy (an established mux carries 33 MB across 3 legs cleanly), the failure is purely at concurrent multi-leg **setup**.

## Root cause
`idReserver.ReserveIDs` retried exactly one error shape — `isPooledConnShutdown`, which matches net/rpc's literal `"connection is shut down"` string returned when a call is made on an **already-closed** `rpc.Client` (the stale-pooled-corpse case). When the reserve stream is instead reset **while the `ReserveIDs` call is in flight**, net/rpc terminates the pending call with the raw read error `io.EOF`, which does not contain that string — so it fell straight through un-retried as a hard leg failure.

This is exactly the mux aux-leg pattern: the primary leg sets up alone and succeeds, then the aux legs fan out as a concurrent burst over one shared dmsg client (`establishMuxRoutes` phase 2), and one of the in-flight reserve streams gets reset.

## Fix
Broaden the retry (`isReserveResetErr`) to also cover `io.EOF` / `io.ErrUnexpectedEOF` / `net.ErrClosed` — all reset/closed-stream shapes worth a single fresh-dial retry (a reachable hop succeeds on the retry; a genuinely dead one still fails, bounded by the per-call `rpcDeadline`). Same redial-once mechanism already used for the shutdown case.

## Test
`TestIsReserveResetErr` table-tests the decision logic (raw + wrapped io.EOF, ErrUnexpectedEOF, net.ErrClosed, the shutdown string, and negative cases). The existing `TestIdReserver_ReserveIDs_RetriesStalePooledConn` covers the redial-integration path. `go build .` + `go test ./pkg/router/` green.

Follow-up (separate PR): bound the concurrent aux-leg reserve burst per destination so a single dmsg client isn't asked to open a burst of streams to one peer at once — removes the trigger, not just the symptom.