### PR TITLE
ci(release): GOPROXY=proxy.golang.org,direct (dead-repo dep resilience)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Build skywire release binary
         env:
-          GOPROXY: direct
+          GOPROXY: "https://proxy.golang.org,direct"
           GOSUMDB: "off"
           CGO_ENABLED: "1"
           CC: ${{ github.workspace }}/musl-data/${{ matrix.toolchain }}-cross/bin/${{ matrix.toolchain }}-gcc
@@ -166,7 +166,7 @@ jobs:
 
       - name: Build skywire
         env:
-          GOPROXY: direct
+          GOPROXY: "https://proxy.golang.org,direct"
           GOSUMDB: "off"
           CGO_ENABLED: "1"
           CGO_CFLAGS: -I/usr/local/include -I/opt/homebrew/include -I/opt/homebrew/opt/hidapi/include -I/opt/homebrew/opt/libusb/include
@@ -229,7 +229,7 @@ jobs:
 
       - name: Build skywire
         env:
-          GOPROXY: direct
+          GOPROXY: "https://proxy.golang.org,direct"
           GOSUMDB: "off"
           CGO_ENABLED: "1"
           CGO_CFLAGS: -I/opt/homebrew/include -I/opt/homebrew/opt/hidapi/include -I/opt/homebrew/opt/libusb/include
@@ -329,7 +329,7 @@ jobs:
 
       - name: Build skywire
         env:
-          GOPROXY: direct
+          GOPROXY: "https://proxy.golang.org,direct"
           GOSUMDB: "off"
           GOOS: windows
           GOARCH: ${{ matrix.goarch }}
@@ -364,7 +364,7 @@ jobs:
       - name: Build hardware wallet utility
         if: matrix.arch == 'amd64'
         env:
-          GOPROXY: direct
+          GOPROXY: "https://proxy.golang.org,direct"
           GOSUMDB: "off"
           CGO_ENABLED: "1"
           CGO_CFLAGS: -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/libusb-1.0


### PR DESCRIPTION
## Problem
Every v1.3.92 release build published **zero linux/darwin binaries**. Root cause: the release jobs set `GOPROXY: direct`, which fetches every module straight from its VCS. `github.com/droundy/goopt` (transitively via `third_party/xxxserxxx/gotop`) had its **GitHub repo deleted**, so `git ls-remote https://github.com/droundy/goopt` returns `fatal: Repository not found` and the build dies at module resolution. (v1.3.91 built in July, before the repo was removed.)

## Fix
`GOPROXY: "https://proxy.golang.org,direct"` on all release build jobs. The module is still served by proxy.golang.org, so proxy-first resolves it; the `,direct` fallback still covers a just-pushed tag the proxy hasn't indexed yet.

## Verified locally
```
GOPROXY=direct               go mod download github.com/droundy/goopt@... → exit 1 (Repository not found)
GOPROXY=proxy.golang.org,direct  go mod download github.com/droundy/goopt@... → exit 0
```