### PR TITLE
fix(wasm-visor): cap concurrent skysocks pool-probe route setups (#80 wasm-browse)

### DIFF
--- a/cmd/wasm-visor/proxyinstance_js.go
+++ b/cmd/wasm-visor/proxyinstance_js.go
@@ -113,6 +113,18 @@ const (
 	//                connected fine natively in 0.5-0.9s. 4 keeps a little
 	//                selection choice while giving each probe enough CPU to finish.
 	proxyPoolTarget = 2 // vetted exits kept: 1 active + 1 hot standby
+
+	// proxyProbeConcurrency caps how many candidate exits are route-established
+	// simultaneously. Same root cause as the 8→4 proxyRaceN reduction above: each
+	// probe drives a CPU-heavy noise + ML-KEM PQ handshake on the ONE JS thread,
+	// and running several at once starves each so its per-route handshake misses
+	// the router's handshakeAwaitTimeout — observed as a 0/15 wasm-browse failure
+	// (reverse-leg "rule not found" / "handshake not received") even with 45
+	// transports and through an exit the native client uses reliably. Capping the
+	// in-flight probes to 2 (from 4) roughly doubles the CPU each handshake gets
+	// while still racing for a fast first success; the pool still fills to
+	// proxyPoolTarget as the remaining candidates drain.
+	proxyProbeConcurrency = 2
 )
 
 var (
@@ -376,8 +388,19 @@ func selectProxyPool(ctx context.Context, sdPK cipher.PubKey, avoid cipher.PubKe
 		ok bool
 	}
 	resc := make(chan probeRes, len(cands))
+	// Bound how many exits are route-established AT ONCE. Each probeExit sets
+	// up a real multi-hop skysocks route; firing all proxyRaceN concurrently
+	// makes several route-group setups contend for the same route-ID space,
+	// setup-node and dmsg client at once, which under a browser visor's slow
+	// multi-hop setup manifests as reverse-leg route-ID churn ("rule not found"
+	// / "handshake not received") — the wasm-browse #80 failure. A small
+	// concurrency cap keeps a fast first-success race while cutting that
+	// contention; the result loop below still drains every candidate.
+	sem := make(chan struct{}, proxyProbeConcurrency)
 	for _, pk := range cands {
 		go func(pk cipher.PubKey) {
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			resc <- probeRes{pk, probeExit(pk)}
 		}(pk)
 	}


### PR DESCRIPTION
## Problem (part of #80, wasm-browse slice)
The wasm visor's clearnet-browse-through-skysocks fails **reliably** — measured live this session at **0/15 fetches with 45 transports available**, failing with reverse-leg `rule not found (routeID=…, pktType=Handshake)` / `handshake not received within timeout`, **even through an exit the native `skysocks-client` uses reliably in ~0.5s**.

## Root cause
`selectProxyPool` route-establishes **all `proxyRaceN`(=4) candidate exits concurrently**. Each `probeExit` drives a CPU-heavy noise + ML-KEM PQ handshake, and the wasm visor runs on **one JS thread** — so 4 simultaneous route setups starve each other's CPU and the per-route handshake misses the router's `handshakeAwaitTimeout`. This is the *same* root cause the existing `proxyRaceN` comment documents when it was reduced 8→4; 4 is still too many under a browser visor's slow multi-hop setup.

## Fix
Cap in-flight probes with a `proxyProbeConcurrency`(=2) semaphore — roughly doubles the CPU each handshake gets while still racing for a fast first success; the result loop still drains every candidate to fill the pool to `proxyPoolTarget`.

- **wasm-only** (`//go:build js && wasm`) — cannot affect native/fleet routing.
- `GOOS=js GOARCH=wasm go build` clean; gofmt clean.

## Validation status (honest)
Build-checked and root-cause-confirmed by the file's own comment. **Full runtime before/after (0/15 → ?) is pending a fleet window where the wasm visor acquires transports** — during this session the fleet WT endpoints were intermittently unreachable (boots alternated 0 and 45 transports), so I couldn't hold a stable window to measure the delta. Not merging until that runtime delta is confirmed. This is one slice of #80; the deeper native-mux reverse-leg route-ID coherence is separate.