### PR TITLE
test(skysocks,skyroute): cover SOCKS5 sniff/whitelist and mux pool branches

### DIFF
--- a/pkg/skyroute/pool_extra_test.go
+++ b/pkg/skyroute/pool_extra_test.go
@@ -1,0 +1,201 @@
+package skyroute
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
+	"github.com/stretchr/testify/require"
+)
+
+// OpenStream after Close returns a "pool closed" error, not a dial.
+func TestPool_OpenStreamAfterClose(t *testing.T) {
+	p := New(time.Minute, nil)
+	require.NoError(t, p.Close())
+
+	var dials int32
+	dial := func(_ context.Context, _ uint16) (net.Conn, error) {
+		atomic.AddInt32(&dials, 1)
+		a, b := net.Pipe()
+		go echoServer(b)
+		return a, nil
+	}
+	_, err := p.OpenStream(context.Background(), testKey(10), dial)
+	require.Error(t, err)
+	require.EqualValues(t, 0, atomic.LoadInt32(&dials), "closed pool must not dial")
+}
+
+// Close is idempotent.
+func TestPool_CloseIdempotent(t *testing.T) {
+	p := New(time.Minute, nil)
+	require.NoError(t, p.Close())
+	require.NoError(t, p.Close())
+}
+
+// Release on an unknown key is a no-op (does not panic).
+func TestPool_ReleaseUnknownKey(t *testing.T) {
+	p := New(time.Minute, nil)
+	defer p.Close()        //nolint:errcheck
+	p.Release(testKey(11)) // must not panic
+}
+
+// A closed underlying session is dropped and OpenStream transparently re-dials.
+func TestPool_ReuseDropsClosedSession(t *testing.T) {
+	var dials int32
+	dial := func(_ context.Context, _ uint16) (net.Conn, error) {
+		atomic.AddInt32(&dials, 1)
+		a, b := net.Pipe()
+		go echoServer(b)
+		return a, nil
+	}
+	p := New(time.Minute, nil)
+	defer p.Close() //nolint:errcheck
+
+	key := testKey(12)
+	s, err := p.OpenStream(context.Background(), key, dial)
+	require.NoError(t, err)
+	roundtrip(t, s, "hi")
+	require.NoError(t, s.Close())
+
+	// Kill the held session out from under the pool.
+	p.mu.Lock()
+	held := p.sessions[key]
+	p.mu.Unlock()
+	require.NotNil(t, held)
+	require.NoError(t, held.sess.Close())
+
+	// Next OpenStream sees the closed session, drops it, and re-dials.
+	s2, err := p.OpenStream(context.Background(), key, dial)
+	require.NoError(t, err)
+	roundtrip(t, s2, "yo")
+	require.NoError(t, s2.Close())
+	require.EqualValues(t, 2, atomic.LoadInt32(&dials), "closed session must force a re-dial")
+}
+
+// reap deletes sessions whose underlying yamux session has closed and expires
+// stale negative-cache entries.
+func TestPool_ReapClosedAndNegativeExpiry(t *testing.T) {
+	p := New(time.Minute, nil)
+	defer p.Close() //nolint:errcheck
+
+	a, b := net.Pipe()
+	sess, err := yamux.Client(a, yamux.DefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, sess.Close()) // closed session
+	_ = b.Close()                    //nolint:errcheck
+
+	p.mu.Lock()
+	p.sessions["closed"] = &heldSession{sess: sess, lastActive: time.Now()}
+	p.negative["stale"] = time.Now().Add(-time.Minute) // already expired
+	p.negative["fresh"] = time.Now().Add(time.Hour)    // still valid
+	p.mu.Unlock()
+
+	p.reap()
+
+	p.mu.Lock()
+	_, hasClosed := p.sessions["closed"]
+	_, hasStale := p.negative["stale"]
+	_, hasFresh := p.negative["fresh"]
+	p.mu.Unlock()
+
+	require.False(t, hasClosed, "reap must drop a closed session")
+	require.False(t, hasStale, "reap must expire a stale negative-cache entry")
+	require.True(t, hasFresh, "reap must keep a still-valid negative-cache entry")
+}
+
+// reap keeps a session that still has an open stream (lastActive refreshed), so a
+// busy route group is never reclaimed mid-use.
+func TestPool_ReapKeepsBusySession(t *testing.T) {
+	dial := func(_ context.Context, _ uint16) (net.Conn, error) {
+		a, b := net.Pipe()
+		go echoServer(b)
+		return a, nil
+	}
+	p := New(20*time.Millisecond, nil)
+	defer p.Close() //nolint:errcheck
+
+	key := testKey(13)
+	s, err := p.OpenStream(context.Background(), key, dial)
+	require.NoError(t, err)
+	defer s.Close() //nolint:errcheck
+
+	// Leave the stream OPEN across several reap cycles.
+	time.Sleep(120 * time.Millisecond)
+
+	p.mu.Lock()
+	_, held := p.sessions[key]
+	p.mu.Unlock()
+	require.True(t, held, "a session with an open stream must not be reaped")
+}
+
+// openWithTimeout returns the context error when ctx is already done.
+func TestOpenWithTimeout_ContextCanceled(t *testing.T) {
+	a, b := net.Pipe()
+	defer a.Close() //nolint:errcheck
+	defer b.Close() //nolint:errcheck
+	// No peer speaking yamux → Ping/Open would block; ctx should win.
+	sess, err := yamux.Client(a, yamux.DefaultConfig())
+	require.NoError(t, err)
+	defer sess.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = openWithTimeout(ctx, sess, 5*time.Second)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// openWithTimeout returns a timeout error when the far end never answers within d.
+func TestOpenWithTimeout_Deadline(t *testing.T) {
+	a, b := net.Pipe()
+	defer a.Close() //nolint:errcheck
+	defer b.Close() //nolint:errcheck
+	sess, err := yamux.Client(a, yamux.DefaultConfig())
+	require.NoError(t, err)
+	defer sess.Close() //nolint:errcheck
+
+	_, err = openWithTimeout(context.Background(), sess, 50*time.Millisecond)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out")
+}
+
+// Concurrent OpenStream calls for the same key converge on a single held route
+// group; every caller gets a usable stream and the losers reuse the winner.
+func TestPool_ConcurrentOpenSameKey(t *testing.T) {
+	dial := func(_ context.Context, _ uint16) (net.Conn, error) {
+		a, b := net.Pipe()
+		go echoServer(b)
+		return a, nil
+	}
+	p := New(time.Minute, nil)
+	defer p.Close() //nolint:errcheck
+
+	key := testKey(14)
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s, err := p.OpenStream(context.Background(), key, dial)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			roundtrip(t, s, "z")
+			_ = s.Close() //nolint:errcheck
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		require.NoError(t, err, "concurrent OpenStream %d", i)
+	}
+	p.mu.Lock()
+	nSessions := len(p.sessions)
+	p.mu.Unlock()
+	require.Equal(t, 1, nSessions, "concurrent opens must converge on one held session")
+}

--- a/pkg/skysocks/client_sniff_test.go
+++ b/pkg/skysocks/client_sniff_test.go
@@ -1,0 +1,196 @@
+// Package skysocks SOCKS5 sniff / status-snapshot coverage tests.
+package skysocks
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// socks5ConnectATYP performs a greeting + CONNECT using an explicit ATYP/addr so
+// the IPv4 (0x01) and IPv6 (0x04) request-parsing branches of sniffSOCKS5Status
+// are exercised (the existing tests only use the domain 0x03 branch).
+func socks5ConnectATYP(t *testing.T, addr string, atyp byte, rawAddr []byte, port uint16) net.Conn {
+	t.Helper()
+	conn, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	_, err = conn.Write([]byte{0x05, 0x01, 0x00})
+	require.NoError(t, err)
+	method := make([]byte, 2)
+	_, err = io.ReadFull(conn, method)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x05, 0x00}, method)
+
+	req := []byte{0x05, 0x01, 0x00, atyp}
+	req = append(req, rawAddr...)
+	req = append(req, byte(port>>8), byte(port)) //nolint:gosec
+	_, err = conn.Write(req)
+	require.NoError(t, err)
+	reply := make([]byte, 10)
+	_, err = io.ReadFull(conn, reply)
+	require.NoError(t, err)
+	return conn
+}
+
+func startClientListener(t *testing.T, c *Client) string {
+	t.Helper()
+	addr := freeAddr(t)
+	go func() { _ = c.ListenAndServe(addr) }() //nolint:errcheck
+	waitDial(t, addr)
+	return addr
+}
+
+// A CONNECT with an IPv4 ATYP is forwarded to the exit unchanged.
+func TestSniff_IPv4Forwarded(t *testing.T) {
+	c, exit := newTestClient(t)
+	defer c.Close() //nolint:errcheck
+	addr := startClientListener(t, c)
+
+	conn := socks5ConnectATYP(t, addr, 0x01, []byte{93, 184, 216, 34}, 80)
+	defer conn.Close() //nolint:errcheck
+
+	select {
+	case h := <-exit.hostC:
+		require.Equal(t, "93.184.216.34", h)
+	case <-time.After(2 * time.Second):
+		t.Fatal("exit never received the IPv4 CONNECT")
+	}
+}
+
+// A CONNECT with an IPv6 ATYP is forwarded to the exit unchanged.
+func TestSniff_IPv6Forwarded(t *testing.T) {
+	c, exit := newTestClient(t)
+	defer c.Close() //nolint:errcheck
+	addr := startClientListener(t, c)
+
+	v6 := net.ParseIP("2001:4860:4860::8888").To16()
+	require.NotNil(t, v6)
+	conn := socks5ConnectATYP(t, addr, 0x04, v6, 443)
+	defer conn.Close() //nolint:errcheck
+
+	select {
+	case h := <-exit.hostC:
+		require.Equal(t, "2001:4860:4860::8888", h)
+	case <-time.After(2 * time.Second):
+		t.Fatal("exit never received the IPv6 CONNECT")
+	}
+}
+
+// runSniff drives c.sniffSOCKS5Status against two in-memory pipe pairs and hands
+// the test the browser and exit ends so it can feed a scripted negotiation and
+// assert the proceed result. This unit-tests the sniff's branch logic directly,
+// without the yamux/ListenAndServe machinery.
+func runSniff(t *testing.T, c *Client) (browser, exit net.Conn, result <-chan bool) {
+	t.Helper()
+	connSniff, browserEnd := net.Pipe()
+	streamSniff, exitEnd := net.Pipe()
+	res := make(chan bool, 1)
+	go func() {
+		res <- c.sniffSOCKS5Status(connSniff, streamSniff)
+		_ = connSniff.Close()   //nolint:errcheck
+		_ = streamSniff.Close() //nolint:errcheck
+	}()
+	return browserEnd, exitEnd, res
+}
+
+// When the exit selects a method other than no-auth, the client hands off
+// transparently (proceed=true) without buffering/parsing the CONNECT request.
+func TestSniff_NonNoAuthHandoff(t *testing.T) {
+	c, _ := newTestClient(t)
+	defer c.Close() //nolint:errcheck
+	browser, exit, res := runSniff(t, c)
+	defer browser.Close() //nolint:errcheck
+	defer exit.Close()    //nolint:errcheck
+
+	// Browser greeting → forwarded to exit verbatim.
+	_, err := browser.Write([]byte{0x05, 0x01, 0x00})
+	require.NoError(t, err)
+	got := make([]byte, 3)
+	_, err = io.ReadFull(exit, got)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x05, 0x01, 0x00}, got)
+
+	// Exit picks user/pass auth (05 02) → forwarded to browser; sniff hands off.
+	_, err = exit.Write([]byte{0x05, 0x02})
+	require.NoError(t, err)
+	reply := make([]byte, 2)
+	_, err = io.ReadFull(browser, reply)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x05, 0x02}, reply)
+
+	select {
+	case proceed := <-res:
+		require.True(t, proceed, "non-no-auth reply must proceed to a transparent splice")
+	case <-time.After(2 * time.Second):
+		t.Fatal("sniff did not return after non-no-auth handoff")
+	}
+}
+
+// An unknown CONNECT address type is forwarded to the exit as-is and the sniff
+// hands off (proceed=true) rather than parsing it.
+func TestSniff_UnknownATYPHandoff(t *testing.T) {
+	c, _ := newTestClient(t)
+	defer c.Close() //nolint:errcheck
+	browser, exit, res := runSniff(t, c)
+	defer browser.Close() //nolint:errcheck
+	defer exit.Close()    //nolint:errcheck
+
+	_, err := browser.Write([]byte{0x05, 0x01, 0x00}) // greeting
+	require.NoError(t, err)
+	_, _ = io.ReadFull(exit, make([]byte, 3)) //nolint:errcheck
+	_, err = exit.Write([]byte{0x05, 0x00})   // no-auth selected
+	require.NoError(t, err)
+	_, _ = io.ReadFull(browser, make([]byte, 2)) //nolint:errcheck
+
+	// CONNECT with an unknown ATYP (0x09).
+	_, err = browser.Write([]byte{0x05, 0x01, 0x00, 0x09})
+	require.NoError(t, err)
+	fwd := make([]byte, 4)
+	_, err = io.ReadFull(exit, fwd)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x09), fwd[3])
+
+	select {
+	case proceed := <-res:
+		require.True(t, proceed, "unknown ATYP must be forwarded and proceed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("sniff did not return for unknown ATYP")
+	}
+}
+
+// A greeting that is not SOCKS5 (bad version byte) is rejected (proceed=false).
+func TestSniff_BadVersionRejected(t *testing.T) {
+	c, _ := newTestClient(t)
+	defer c.Close() //nolint:errcheck
+	browser, exit, res := runSniff(t, c)
+	defer browser.Close() //nolint:errcheck
+	defer exit.Close()    //nolint:errcheck
+
+	_, err := browser.Write([]byte{0x04, 0x01}) // SOCKS4 version → not 0x05
+	require.NoError(t, err)
+	select {
+	case proceed := <-res:
+		require.False(t, proceed, "a non-SOCKS5 greeting must not proceed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("sniff did not reject a bad version")
+	}
+}
+
+// statusSnapshot reflects a live session (running, stream count) and a torn-down
+// one (not running).
+func TestStatusSnapshot(t *testing.T) {
+	c, exit := newTestClient(t)
+	_ = exit
+
+	snap := c.statusSnapshot()
+	require.True(t, snap.Running, "fresh session should report running")
+	require.Contains(t, snap.Note, "session to the exit is up")
+
+	require.NoError(t, c.Close())
+	snap = c.statusSnapshot()
+	require.False(t, snap.Running, "closed session should report not running")
+	require.Contains(t, snap.Note, "no active session")
+}

--- a/pkg/skysocks/coverage_test.go
+++ b/pkg/skysocks/coverage_test.go
@@ -1,0 +1,291 @@
+// Package skysocks additional client/server coverage tests.
+package skysocks
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
+)
+
+// addrConn wraps a net.Conn but reports a caller-supplied RemoteAddr, letting a
+// test drive the server's whitelist path without a real mesh transport.
+type addrConn struct {
+	net.Conn
+	remote net.Addr
+}
+
+func (a addrConn) RemoteAddr() net.Addr { return a.remote }
+
+// chanListener hands out a fixed set of conns then blocks until Close, so
+// Server.Serve can be exercised deterministically over a known sequence.
+type chanListener struct {
+	conns  chan net.Conn
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newChanListener(conns ...net.Conn) *chanListener {
+	l := &chanListener{conns: make(chan net.Conn, len(conns)), closed: make(chan struct{})}
+	for _, c := range conns {
+		l.conns <- c
+	}
+	return l
+}
+
+func (l *chanListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.conns:
+		return c, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *chanListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *chanListener) Addr() net.Addr { return testAddr{} }
+
+func wlPK(b byte) cipher.PubKey {
+	var pk cipher.PubKey
+	pk[0] = 0x02
+	pk[1] = b
+	return pk
+}
+
+// IsPublic reflects whether a whitelist was configured.
+func TestServer_IsPublic(t *testing.T) {
+	pub, err := NewServer(nil, nil)
+	require.NoError(t, err)
+	require.True(t, pub.IsPublic(), "no whitelist → public")
+
+	priv, err := NewServer([]cipher.PubKey{wlPK(1)}, nil)
+	require.NoError(t, err)
+	require.False(t, priv.IsPublic(), "whitelist set → not public")
+}
+
+// getRemotePK returns the PK for an appnet.Addr conn and errors for an
+// un-convertible (plain TCP) address.
+func TestServer_GetRemotePK(t *testing.T) {
+	s, err := NewServer(nil, nil)
+	require.NoError(t, err)
+
+	want := wlPK(7)
+	c1, c2 := net.Pipe()
+	defer c1.Close() //nolint:errcheck
+	defer c2.Close() //nolint:errcheck
+
+	wrapped := addrConn{Conn: c1, remote: appnet.Addr{Net: appnet.TypeSkynet, PubKey: want, Port: routing.Port(3)}}
+	got, err := s.getRemotePK(wrapped)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	// A plain pipe conn (fake non-convertible addr) yields an error.
+	_, err = s.getRemotePK(addrConn{Conn: c1, remote: testAddr{}})
+	require.Error(t, err)
+}
+
+// Serve rejects a connection whose PK is not in the whitelist (conn closed,
+// loop continues) and rejects one whose address can't be resolved.
+func TestServer_Serve_WhitelistRejects(t *testing.T) {
+	allowed := wlPK(1)
+	s, err := NewServer([]cipher.PubKey{allowed}, nil)
+	require.NoError(t, err)
+
+	// Conn 1: PK not in whitelist → rejected+closed.
+	notAllowed := wlPK(2)
+	r1a, r1b := net.Pipe()
+	defer r1b.Close() //nolint:errcheck
+	c1 := addrConn{Conn: r1a, remote: appnet.Addr{Net: appnet.TypeSkynet, PubKey: notAllowed, Port: routing.Port(1)}}
+
+	// Conn 2: address not convertible → getRemotePK fails → rejected+closed.
+	r2a, r2b := net.Pipe()
+	defer r2b.Close() //nolint:errcheck
+	c2 := addrConn{Conn: r2a, remote: testAddr{}}
+
+	l := newChanListener(c1, c2)
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Serve(l) }()
+
+	// Both rejected conns must be closed by the server.
+	requireClosed(t, r1a)
+	requireClosed(t, r2a)
+
+	require.NoError(t, s.Close())
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after Close")
+	}
+}
+
+// Serve admits a whitelisted connection: it passes the whitelist check and a
+// yamux server is started over it (the client half completes a yamux handshake).
+func TestServer_Serve_WhitelistAdmits(t *testing.T) {
+	allowed := wlPK(1)
+	s, err := NewServer([]cipher.PubKey{allowed}, nil)
+	require.NoError(t, err)
+
+	srvSide, cliSide := net.Pipe()
+	admitted := addrConn{Conn: srvSide, remote: appnet.Addr{Net: appnet.TypeSkynet, PubKey: allowed, Port: routing.Port(1)}}
+
+	l := newChanListener(admitted)
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Serve(l) }()
+
+	// The server side runs yamux.Server; a yamux client on the other end must
+	// handshake successfully, proving the conn was admitted (not closed).
+	done := make(chan error, 1)
+	go func() {
+		sess, e := yamux.Client(cliSide, yamux.DefaultConfig())
+		if e != nil {
+			done <- e
+			return
+		}
+		_, e = sess.Ping()
+		done <- e
+	}()
+
+	select {
+	case e := <-done:
+		require.NoError(t, e, "whitelisted conn should be admitted and yamux-served")
+	case <-time.After(3 * time.Second):
+		t.Fatal("yamux handshake over admitted conn timed out")
+	}
+
+	_ = cliSide.Close() //nolint:errcheck
+	require.NoError(t, s.Close())
+	<-errCh
+}
+
+// Serve returns nil immediately when the server is already closed.
+func TestServer_Serve_AlreadyClosed(t *testing.T) {
+	s, err := NewServer(nil, nil)
+	require.NoError(t, err)
+	l := newChanListener()
+	s.close() // mark closed before Serve loops
+	// Serve needs a listener to store; give it one and expect an immediate nil.
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Serve(l) }()
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve on a closed server should return nil immediately")
+	}
+	require.NoError(t, l.Close())
+}
+
+// Server.Close on a nil receiver is safe.
+func TestServer_CloseNil(t *testing.T) {
+	var s *Server
+	require.NoError(t, s.Close())
+}
+
+// ListenAndServe surfaces a listen error via the returned error.
+func TestClient_ListenAndServe_ListenError(t *testing.T) {
+	a, b := net.Pipe()
+	defer a.Close() //nolint:errcheck
+	go func() {     // minimal yamux server so NewClient succeeds
+		sess, e := yamux.Server(b, yamux.DefaultConfig())
+		if e == nil {
+			_, _ = sess.Accept() //nolint:errcheck
+		}
+	}()
+	c, err := NewClient(a, nil)
+	require.NoError(t, err)
+	defer c.Close() //nolint:errcheck
+
+	// An unbindable address forces net.Listen to fail.
+	err = c.ListenAndServe("256.256.256.256:99999")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "listen")
+}
+
+// Client.Close on a nil receiver is safe; Close on a live client is idempotent.
+func TestClient_CloseNilAndIdempotent(t *testing.T) {
+	var nilC *Client
+	require.NoError(t, nilC.Close())
+
+	a, b := net.Pipe()
+	defer b.Close() //nolint:errcheck
+	go func() {
+		sess, e := yamux.Server(b, yamux.DefaultConfig())
+		if e == nil {
+			_, _ = sess.Accept() //nolint:errcheck
+		}
+	}()
+	c, err := NewClient(a, nil)
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+	require.NoError(t, c.Close(), "second Close is a no-op via sync.Once")
+}
+
+// When the yamux session is dead, ListenAndServe accepts a connection, its
+// session.Open fails, it serves the route-down interstitial, and tears the
+// client down — surfacing the stream-open error to the caller.
+func TestClient_ListenAndServe_SessionOpenError(t *testing.T) {
+	cconn, sconn := net.Pipe()
+	// Bring up a real server session then close it so client stream-open fails.
+	srvSess, err := yamux.Server(sconn, yamux.DefaultConfig())
+	require.NoError(t, err)
+
+	c, err := NewClient(cconn, nil)
+	require.NoError(t, err)
+	defer c.Close() //nolint:errcheck
+
+	// Kill the session so c.session.Open() fails inside the accept loop.
+	require.NoError(t, srvSess.Close())
+	require.NoError(t, sconn.Close())
+
+	addr := freeAddr(t)
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- c.ListenAndServe(addr) }()
+
+	// Drive one browser connection into the accept loop once it is listening.
+	require.Eventually(t, func() bool {
+		conn, derr := net.Dial("tcp", addr)
+		if derr != nil {
+			return false
+		}
+		_ = conn.Close() //nolint:errcheck
+		return true
+	}, 3*time.Second, 20*time.Millisecond)
+
+	select {
+	case err := <-serveErr:
+		require.Error(t, err, "ListenAndServe should exit with the stream-open error")
+	case <-time.After(3 * time.Second):
+		t.Fatal("ListenAndServe did not exit after session-open failure")
+	}
+}
+
+// freeAddr returns a currently-free loopback address (host:port).
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := l.Addr().String()
+	require.NoError(t, l.Close())
+	return addr
+}
+
+// requireClosed asserts a pipe conn was closed by the peer within a short window.
+func requireClosed(t *testing.T, c net.Conn) {
+	t.Helper()
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+	buf := make([]byte, 1)
+	_, err := c.Read(buf)
+	require.Error(t, err, "expected conn to be closed by server")
+}


### PR DESCRIPTION
Adds deterministic unit tests (net.Pipe/loopback, no real network) for previously-uncovered branches in `pkg/skysocks` and `pkg/skyroute`. No non-test code changed.

Coverage:
- `pkg/skyroute`: 70.9% -> 87.2%
- `pkg/skysocks`: 58.1% -> 71.3%
- combined: 58.6% -> 76.0%

skyroute (`pool_extra_test.go`): OpenStream-after-close, closed-session drop+redial, reap of closed sessions and stale negative-cache entries, busy-session retention, `openWithTimeout` ctx-cancel and deadline paths, concurrent same-key convergence on one held session.

skysocks (`coverage_test.go`, `client_sniff_test.go`): `IsPublic`, `getRemotePK`, whitelist accept/reject through `Serve`, already-closed `Serve`, nil/idempotent `Close`, `ListenAndServe` listen-error and dead-session interstitial paths, plus direct `sniffSOCKS5Status` coverage for the IPv4/IPv6/unknown-ATYP request branches, the non-no-auth hand-off, and bad-version rejection.