### PR TITLE
test(transport): raise transport-layer coverage (manager helpers, AR binds, handshake, setup RPC)

### DIFF
--- a/pkg/transport/manager_lan_test.go
+++ b/pkg/transport/manager_lan_test.go
@@ -1,0 +1,199 @@
+// Package transport — pkg/transport/manager_lan_test.go: white-box unit
+// tests for the network-topology helpers and the transport-list snapshot
+// paths of the Manager that need no live networking: the LAN/hairpin
+// classifiers (isSameLANEndpoint / sameIPv4Slash24 / hostIsIP), the
+// TransportRemoteAddrs / SameLANPeers surface, currentBareEntries'
+// closed/self-loop filtering, the CXO transport-list publisher
+// (publishTPDList, compact form), and the local delete paths.
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+func TestHostIsIP(t *testing.T) {
+	require.True(t, hostIsIP("1.2.3.4"))
+	require.True(t, hostIsIP("1.2.3.4:5000"))
+	require.True(t, hostIsIP("[2001:db8::1]:443"))
+	require.False(t, hostIsIP("example.com:80"))
+	require.False(t, hostIsIP("webrtc-datachannel(pk)"))
+	require.False(t, hostIsIP(""))
+}
+
+func TestSameIPv4Slash24(t *testing.T) {
+	require.True(t, sameIPv4Slash24(net.ParseIP("1.2.3.4"), net.ParseIP("1.2.3.9")))
+	require.False(t, sameIPv4Slash24(net.ParseIP("1.2.3.4"), net.ParseIP("1.2.4.4")))
+	// An IPv6 address has no /24 comparison.
+	require.False(t, sameIPv4Slash24(net.ParseIP("2001:db8::1"), net.ParseIP("2001:db8::2")))
+	require.False(t, sameIPv4Slash24(net.ParseIP("1.2.3.4"), net.ParseIP("2001:db8::2")))
+}
+
+func TestIsSameLANEndpoint(t *testing.T) {
+	self := net.ParseIP("8.8.8.8")
+	locals := []net.IP{net.ParseIP("203.0.113.5")}
+
+	// nil peer is never LAN.
+	require.False(t, isSameLANEndpoint(nil, self, locals))
+	// A private / RFC1918 endpoint is reachable only over the LAN.
+	require.True(t, isSameLANEndpoint(net.ParseIP("192.168.1.20"), self, locals))
+	require.True(t, isSameLANEndpoint(net.ParseIP("10.0.0.7"), nil, nil))
+	// NAT hairpin: peer reached at our own public IP (exact + /24).
+	require.True(t, isSameLANEndpoint(net.ParseIP("8.8.8.8"), self, nil))
+	require.True(t, isSameLANEndpoint(net.ParseIP("8.8.8.20"), self, nil))
+	// Public peer sharing a local interface /24.
+	require.True(t, isSameLANEndpoint(net.ParseIP("203.0.113.99"), self, locals))
+	// Unrelated public peer is not LAN.
+	require.False(t, isSameLANEndpoint(net.ParseIP("1.1.1.1"), self, locals))
+	// Public peer, self not yet known (STUN pending) and no matching local.
+	require.False(t, isSameLANEndpoint(net.ParseIP("1.1.1.1"), nil, nil))
+}
+
+func TestManagerTransportRemoteAddrs(t *testing.T) {
+	tm := newTestManager(t)
+
+	// A non-DMSG transport with a routable IP endpoint is emitted.
+	remote := mustPK(t)
+	servingTransport(t, tm, remote, types.STCPR)
+
+	// A DMSG transport is always skipped (no routable raw IP).
+	servingTransport(t, tm, mustPK(t), types.DMSG)
+
+	addrs := tm.TransportRemoteAddrs()
+	require.Equal(t, []string{"1.2.3.4:5000"}, addrs)
+}
+
+func TestManagerSameLANPeers(t *testing.T) {
+	tm := newTestManager(t)
+	remote := mustPK(t)
+	servingTransport(t, tm, remote, types.STCPR) // memTransport endpoint is 1.2.3.4:5000
+
+	// Hairpin: our own public IP equals the peer endpoint IP → same LAN.
+	peers := tm.SameLANPeers(net.ParseIP("1.2.3.4"))
+	require.Equal(t, []cipher.PubKey{remote}, peers)
+
+	// A DMSG transport is never considered a LAN peer.
+	tm2 := newTestManager(t)
+	servingTransport(t, tm2, mustPK(t), types.DMSG)
+	require.Empty(t, tm2.SameLANPeers(net.ParseIP("1.2.3.4")))
+}
+
+func TestManagerCurrentBareEntries(t *testing.T) {
+	tm := newTestManager(t)
+
+	// Live, ordinary transport → included.
+	live, _ := servingTransport(t, tm, mustPK(t), types.STCPR)
+
+	// Closed transport → excluded even though still in tm.tps.
+	closed, _ := servingTransport(t, tm, mustPK(t), types.STCPR)
+	closed.CloseForTest() // mark closed without the retrying discovery deregister
+
+	// Self-loop transport (both edges the same PK) → excluded.
+	selfMT := NewManagedTransportForTest(newMemTransport())
+	selfMT.Entry = MakeEntry(tm.Conf.PubKey, tm.Conf.PubKey, types.STCPR, LabelUser)
+	tm.tps[selfMT.Entry.ID] = selfMT
+
+	entries := tm.currentBareEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, live.Entry.ID, entries[0].ID)
+}
+
+// captureLeafPub records the last Put/Delete so publishTPDList's compact
+// snapshot can be inspected.
+type captureLeafPub struct {
+	path    string
+	body    []byte
+	deletes []string
+}
+
+func (c *captureLeafPub) Put(path string, value []byte) error {
+	c.path, c.body = path, value
+	return nil
+}
+func (c *captureLeafPub) Delete(path string) error {
+	c.deletes = append(c.deletes, path)
+	return nil
+}
+
+func TestManagerPublishTPDList(t *testing.T) {
+	tm := newTestManager(t)
+	self := tm.Conf.PubKey
+	remote := mustPK(t)
+	entry := MakeEntry(self, remote, types.STCPR, LabelSkycoin)
+
+	// No publisher installed → no-op (must not panic).
+	tm.publishTPDList([]*Entry{&entry})
+
+	cap := &captureLeafPub{}
+	tm.SetTPDLeafPublisher(cap)
+
+	tm.publishTPDList([]*Entry{&entry})
+	require.Equal(t, tpdListPath, cap.path)
+
+	var got struct {
+		Version string         `json:"version,omitempty"`
+		Compact []CompactEntry `json:"c"`
+	}
+	require.NoError(t, json.Unmarshal(cap.body, &got))
+	require.Len(t, got.Compact, 1)
+	// Compact form drops the reporter's own PK and keeps the remote edge + type.
+	require.Equal(t, remote, got.Compact[0].Remote)
+	require.Equal(t, types.STCPR, got.Compact[0].Type)
+	require.Equal(t, LabelSkycoin, got.Compact[0].Label)
+
+	// nil entries publishes an explicit empty list.
+	tm.publishTPDList(nil)
+	require.NoError(t, json.Unmarshal(cap.body, &got))
+	require.Empty(t, got.Compact)
+}
+
+// registerInOwnDisc records mt.Entry in the transport's own discovery mock so
+// the close()/deleteFromDiscovery path succeeds on the first try instead of
+// retrying against an empty mock (which backs off for ~30s).
+func registerInOwnDisc(t *testing.T, mt *ManagedTransport) {
+	t.Helper()
+	require.NoError(t, mt.dc.RegisterTransportsV3(context.Background(), "v3", &mt.Entry))
+}
+
+func TestManagerDeleteTransport(t *testing.T) {
+	tm := newTestManager(t)
+	mt, _ := servingTransport(t, tm, mustPK(t), types.STCPR)
+	registerInOwnDisc(t, mt)
+	id := mt.Entry.ID
+	require.Equal(t, 1, tm.TransportCount())
+
+	// Deleting an unknown id is a safe no-op.
+	tm.DeleteTransport(uuid.New())
+	require.Equal(t, 1, tm.TransportCount())
+
+	tm.DeleteTransport(id)
+	require.Equal(t, 0, tm.TransportCount())
+}
+
+func TestManagerDeleteAllTransports(t *testing.T) {
+	tm := newTestManager(t)
+	mt1, _ := servingTransport(t, tm, mustPK(t), types.STCPR)
+	mt2, _ := servingTransport(t, tm, mustPK(t), types.SUDPH)
+	registerInOwnDisc(t, mt1)
+	registerInOwnDisc(t, mt2)
+	require.Equal(t, 2, tm.TransportCount())
+
+	tm.DeleteAllTransports()
+	require.Equal(t, 0, tm.TransportCount())
+}
+
+func TestManagerTpIDFromPK(t *testing.T) {
+	tm := newTestManager(t)
+	remote := mustPK(t)
+	require.Equal(t,
+		MakeTransportID(tm.Conf.PubKey, remote, types.STCPR),
+		tm.tpIDFromPK(remote, types.STCPR))
+}

--- a/pkg/transport/network/addrresolver/client_bind_test.go
+++ b/pkg/transport/network/addrresolver/client_bind_test.go
@@ -1,0 +1,119 @@
+// Package addrresolver — pkg/transport/network/addrresolver/client_bind_test.go:
+// exercises the QUIC / WT bind POST paths and the public-IP readiness signal
+// (SetPublicIP unblocking awaitPublicIP), all driven against an httptest AR
+// server. The live UDP SUDPH bind path needs a real AR and is not covered here.
+package addrresolver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+func TestBindQUIC(t *testing.T) {
+	t.Run("success posts to quic bind path", func(t *testing.T) {
+		var got LocalAddresses
+		gotCh := make(chan struct{}, 1)
+		mux := chi.NewRouter()
+		mux.Post("/bind/quic", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&got) //nolint
+			gotCh <- struct{}{}
+			w.WriteHeader(http.StatusOK)
+		})
+		srv := httptest.NewServer(arRouter(mux))
+		defer srv.Close()
+
+		c := newReadyClient(t, srv)
+		// Public IP already signalled → bind does not wait the full timeout.
+		c.SetPublicIP("", "")
+		require.NoError(t, c.BindQUIC(context.Background(), "30300"))
+		<-gotCh
+		assert.Equal(t, "30300", got.Port)
+	})
+
+	t.Run("rate limited returns error", func(t *testing.T) {
+		mux := chi.NewRouter()
+		mux.Post("/bind/quic", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+		})
+		srv := httptest.NewServer(arRouter(mux))
+		defer srv.Close()
+
+		c := newReadyClient(t, srv)
+		c.SetPublicIP("", "")
+		err := c.BindQUIC(context.Background(), "30300")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "429")
+	})
+
+	t.Run("non-OK status returns error", func(t *testing.T) {
+		mux := chi.NewRouter()
+		mux.Post("/bind/quic", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "no", http.StatusInternalServerError)
+		})
+		srv := httptest.NewServer(arRouter(mux))
+		defer srv.Close()
+
+		c := newReadyClient(t, srv)
+		c.SetPublicIP("", "")
+		require.Error(t, c.BindQUIC(context.Background(), "30300"))
+	})
+}
+
+func TestBindWT(t *testing.T) {
+	var got LocalAddresses
+	gotCh := make(chan struct{}, 1)
+	mux := chi.NewRouter()
+	mux.Post("/bind/wt", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&got) //nolint
+		gotCh <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(arRouter(mux))
+	defer srv.Close()
+
+	c := newReadyClient(t, srv)
+	// A declared public IP is injected into the advertised address set.
+	c.SetPublicIP("9.9.9.9:1", "")
+	require.NoError(t, c.BindWT(context.Background(), "30301", "deadbeefcert"))
+	<-gotCh
+	assert.Equal(t, "30301", got.Port)
+	assert.Equal(t, "deadbeefcert", got.CertHash)
+	assert.Contains(t, got.Addresses, "9.9.9.9")
+}
+
+func TestSetPublicIPUnblocksAwait(t *testing.T) {
+	c := &httpClient{
+		log:     logging.MustGetLogger("ar-setpub"),
+		closed:  make(chan struct{}),
+		ipReady: make(chan struct{}),
+	}
+
+	// Before SetPublicIP, awaitPublicIP blocks until the timeout.
+	start := time.Now()
+	c.awaitPublicIP(50 * time.Millisecond)
+	assert.GreaterOrEqual(t, time.Since(start), 50*time.Millisecond)
+
+	// SetPublicIP records the IPs and closes ipReady (idempotently).
+	c.SetPublicIP("1.2.3.4:5", "[2001:db8::1]:6")
+	assert.Equal(t, "1.2.3.4", c.LocalPublicIP())
+	assert.Equal(t, "1.2.3.4:5", c.localPublicIPRaw())
+	assert.Equal(t, "[2001:db8::1]:6", c.localPublicIPv6Raw())
+
+	// After the ready signal, awaitPublicIP returns immediately.
+	start = time.Now()
+	c.awaitPublicIP(5 * time.Second)
+	assert.Less(t, time.Since(start), time.Second)
+
+	// Second call is a safe no-op (ipReadyOnce guards the close).
+	c.SetPublicIP("9.9.9.9", "")
+}

--- a/pkg/transport/network/handshake/handshake_extra_test.go
+++ b/pkg/transport/network/handshake/handshake_extra_test.go
@@ -1,0 +1,81 @@
+// Package handshake — pkg/transport/network/handshake/handshake_extra_test.go:
+// unit tests for the handshake error wrapper (Error / IsHandshakeError),
+// the port-checker adapter (MakeF2PortChecker), and the responder-side
+// rejection path (a failing CheckF2 makes the responder write frame3 with
+// the error and both sides surface a wrapped handshake Error).
+package handshake
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+func TestErrorAndIsHandshakeError(t *testing.T) {
+	err := Error("boom")
+	require.Equal(t, "handshake failed: boom", err.Error())
+	require.True(t, IsHandshakeError(err))
+
+	// A plain error is not a handshake Error.
+	require.False(t, IsHandshakeError(errors.New("boom")))
+	require.False(t, IsHandshakeError(nil))
+}
+
+func TestMakeF2PortChecker(t *testing.T) {
+	// The adapter forwards the frame's destination port to the checker.
+	var seen uint16
+	checker := MakeF2PortChecker(func(port uint16) error {
+		seen = port
+		if port == 0 {
+			return errors.New("port 0 refused")
+		}
+		return nil
+	})
+
+	require.NoError(t, checker(Frame2{DstAddr: dmsg.Addr{Port: 42}}))
+	require.EqualValues(t, 42, seen)
+
+	require.Error(t, checker(Frame2{DstAddr: dmsg.Addr{Port: 0}}))
+}
+
+// TestResponderRejection drives a full initiator/responder exchange where the
+// responder's CheckF2 rejects the frame. The responder writes frame3 carrying
+// the error; the initiator surfaces "handshake rejected", and both errors are
+// wrapped as handshake Errors by the middleware.
+func TestResponderRejection(t *testing.T) {
+	initPK, initSK, err := cipher.GenerateDeterministicKeyPair([]byte("reject-init"))
+	require.NoError(t, err)
+	respPK, _, err := cipher.GenerateDeterministicKeyPair([]byte("reject-resp"))
+	require.NoError(t, err)
+
+	iAddr := dmsg.Addr{PK: initPK, Port: 10}
+	rAddr := dmsg.Addr{PK: respPK, Port: 11}
+
+	initC, respC := net.Pipe()
+	deadline := time.Now().Add(Timeout)
+
+	respErrCh := make(chan error, 1)
+	go func() {
+		respHS := ResponderHandshake(func(Frame2) error {
+			return errors.New("policy: port closed")
+		})
+		_, _, e := respHS(respC, deadline)
+		respErrCh <- e
+	}()
+
+	initHS := InitiatorHandshake(initSK, iAddr, rAddr)
+	_, _, initErr := initHS(initC, deadline)
+	require.Error(t, initErr)
+	require.True(t, IsHandshakeError(initErr))
+
+	require.Error(t, <-respErrCh)
+
+	require.NoError(t, initC.Close())
+	require.NoError(t, respC.Close())
+}

--- a/pkg/transport/setup/setup_extra_test.go
+++ b/pkg/transport/setup/setup_extra_test.go
@@ -1,0 +1,52 @@
+// Package setup — pkg/transport/setup/setup_extra_test.go: covers the
+// no-network success branches of the transport-setup RPC gateway that the
+// original suite left to the integration tests — removing a skycoin-labeled
+// transport and listing a populated transport set — using the manager's
+// test-injection seam so no dialing occurs.
+package setup
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/transport"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+func injectTP(t *testing.T, tm *transport.Manager, label transport.Label) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	mt := transport.NewManagedTransportForTest(nil)
+	mt.Entry = transport.Entry{ID: id, Label: label, Type: types.STCPR}
+	tm.InjectTransportForTest(mt)
+	return id
+}
+
+func TestTransportGateway_RemoveTransport_Success(t *testing.T) {
+	gw, tm := newTestGateway(t)
+
+	// A skycoin-labeled transport IS removable via the setup RPC.
+	id := injectTP(t, tm, transport.LabelSkycoin)
+	require.Equal(t, 1, tm.TransportCount())
+
+	var res BoolResponse
+	require.NoError(t, gw.RemoveTransport(UUIDRequest{ID: id}, &res))
+	require.True(t, res.Result)
+	require.Equal(t, 0, tm.TransportCount())
+}
+
+func TestTransportGateway_RemoveTransport_UserLabelRejected(t *testing.T) {
+	gw, tm := newTestGateway(t)
+
+	// A user-labeled transport stays put: RemoveTransport rejects it and the
+	// count is unchanged.
+	id := injectTP(t, tm, transport.LabelUser)
+	require.Equal(t, 1, tm.TransportCount())
+
+	var res BoolResponse
+	require.ErrorIs(t, gw.RemoveTransport(UUIDRequest{ID: id}, &res), ErrIncorrectType)
+	require.False(t, res.Result)
+	require.Equal(t, 1, tm.TransportCount())
+}


### PR DESCRIPTION
Adds deterministic, no-network unit tests for the transport layer. No non-test code changed; `go build .`, `go vet`, and gofmt are clean.

What is covered:
- **pkg/transport** (51.8 -> 57.6%): LAN/hairpin classifiers (`isSameLANEndpoint`, `sameIPv4Slash24`, `hostIsIP`), `TransportRemoteAddrs`/`SameLANPeers`, `currentBareEntries` closed/self-loop filtering, the CXO transport-list publisher (`publishTPDList` compact form), and the local delete paths (`DeleteTransport`/`DeleteAllTransports`/`tpIDFromPK`).
- **network/addrresolver** (47.6 -> 55.2%): `BindQUIC`/`BindWT` POST paths (success, 429, non-OK) and `SetPublicIP` unblocking `awaitPublicIP`, driven against an httptest AR server.
- **network/handshake** (67.6 -> 80.4%): `Error`/`IsHandshakeError`, `MakeF2PortChecker`, and the responder-side rejection path over `net.Pipe`.
- **transport/setup** (28.8 -> 33.3%): `RemoveTransport` success and user-label-rejection branches.

Tests reuse the existing mocks (`NewDiscoveryMock`, AR httptest router) and `net.Pipe`; they are deterministic and use no real network.