### PR TITLE
test(router): raise pkg/router coverage 38.5% -> 41.8%

### DIFF
--- a/pkg/router/coverage_extras_test.go
+++ b/pkg/router/coverage_extras_test.go
@@ -1,0 +1,305 @@
+// Package router pkg/router/coverage_extras_test.go
+//
+// Focused unit coverage for small, pure-logic helpers that had no direct
+// test: the ClientPool lifecycle ops, the cascade ackRegistry unregister
+// path, the RSNRelayCache, the idReserver query/return helpers, the
+// setup-node reordering helper, and the transport-query JSON codec.
+package router
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// ---- ClientPool -----------------------------------------------------------
+
+// TestClientPool_DiscardSizeAndPut walks the Put/Size/Discard/replace paths and
+// the nil-client guards, using the in-memory countingDialer.
+func TestClientPool_DiscardSizeAndPut(t *testing.T) {
+	d := &countingDialer{}
+	pool := NewClientPool(d, DefaultPoolTTL)
+	t.Cleanup(pool.Close)
+
+	require.Zero(t, pool.Size(), "new pool is empty")
+
+	// nil is a no-op for both Put and Discard.
+	pool.Put(nil)
+	pool.Discard(nil)
+	require.Zero(t, pool.Size())
+
+	pk, _ := cipher.GenerateKeyPair()
+	c1, err := pool.Get(context.Background(), pk)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, d.count())
+
+	pool.Put(c1)
+	require.Equal(t, 1, pool.Size(), "a returned client is pooled")
+
+	// Putting a second client for the same PK replaces (and closes) the older.
+	c2, err := pool.Get(context.Background(), pk) // reuses c1, empties pool
+	require.NoError(t, err)
+	require.Same(t, c1, c2)
+	require.Zero(t, pool.Size())
+	pool.Put(c2)
+	// Dial a genuinely fresh one and Put it under the same PK to hit replace.
+	pool.mu.Lock()
+	pool.clients[pk].lastUsed = pool.clients[pk].lastUsed.Add(-2 * DefaultPoolTTL)
+	pool.mu.Unlock()
+	c3, err := pool.Get(context.Background(), pk) // stale -> fresh dial
+	require.NoError(t, err)
+	require.EqualValues(t, 2, d.count())
+	pool.Put(c3)
+	require.Equal(t, 1, pool.Size())
+
+	// Discard closes a client without pooling it.
+	c4, err := pool.Get(context.Background(), pk)
+	require.NoError(t, err)
+	pool.Discard(c4)
+	require.Zero(t, pool.Size(), "discarded client is not pooled")
+}
+
+// TestClientPool_Evict reaps entries idled past the TTL and leaves fresh ones.
+func TestClientPool_Evict(t *testing.T) {
+	d := &countingDialer{}
+	pool := NewClientPool(d, DefaultPoolTTL)
+	t.Cleanup(pool.Close)
+
+	pk, _ := cipher.GenerateKeyPair()
+	c, err := pool.Get(context.Background(), pk)
+	require.NoError(t, err)
+	pool.Put(c)
+	require.Equal(t, 1, pool.Size())
+
+	// Not yet past TTL: evict keeps it.
+	pool.evict()
+	require.Equal(t, 1, pool.Size())
+
+	// Age it past the TTL: evict reaps it.
+	pool.mu.Lock()
+	pool.clients[pk].lastUsed = pool.clients[pk].lastUsed.Add(-2 * DefaultPoolTTL)
+	pool.mu.Unlock()
+	pool.evict()
+	require.Zero(t, pool.Size(), "entry past TTL is evicted")
+}
+
+// TestClientPool_CloseIdempotent proves Close reaps live entries and can be
+// called more than once safely.
+func TestClientPool_CloseIdempotent(t *testing.T) {
+	d := &countingDialer{}
+	pool := NewClientPool(d, DefaultPoolTTL)
+
+	pk, _ := cipher.GenerateKeyPair()
+	c, err := pool.Get(context.Background(), pk)
+	require.NoError(t, err)
+	pool.Put(c)
+	require.Equal(t, 1, pool.Size())
+
+	pool.Close()
+	require.Zero(t, pool.Size(), "Close reaps all pooled entries")
+	pool.Close() // second Close must not panic
+}
+
+// ---- ackRegistry ----------------------------------------------------------
+
+// TestAckRegistry_Unregister proves unregister drops the wait channel so a
+// later dispatch finds no waiter.
+func TestAckRegistry_Unregister(t *testing.T) {
+	r := newAckRegistry()
+
+	ch := r.register(42)
+	require.NotNil(t, ch)
+
+	r.unregister(42)
+	// After unregister, dispatch reports no waiter and does not block.
+	require.False(t, r.dispatch(42, nil), "dispatch to an unregistered session finds no waiter")
+
+	// unregister of an unknown session is a no-op.
+	r.unregister(999)
+}
+
+// ---- RSNRelayCache --------------------------------------------------------
+
+// TestRSNRelayCache_UpdateGet exercises the cache store/read and the no-peers
+// error path of FindRelayTransport.
+func TestRSNRelayCache_UpdateGet(t *testing.T) {
+	rc := NewRSNRelayCache(logging.MustGetLogger("relaycache_test"))
+
+	rsnPK, _ := cipher.GenerateKeyPair()
+	require.Nil(t, rc.Get(rsnPK), "unknown RSN has no cached peers")
+
+	p1, _ := cipher.GenerateKeyPair()
+	p2, _ := cipher.GenerateKeyPair()
+	rc.Update(rsnPK, []cipher.PubKey{p1, p2})
+	require.Equal(t, []cipher.PubKey{p1, p2}, rc.Get(rsnPK))
+
+	// FindRelayTransport with no cached peers returns a clear error.
+	other, _ := cipher.GenerateKeyPair()
+	_, _, err := rc.FindRelayTransport(context.Background(), other, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no cached relay peers")
+}
+
+// ---- idReserver query / return helpers ------------------------------------
+
+// TestIDReserver_QueryAndReturnToPool covers TotalIDs, Client, String and
+// ReturnToPool on a mock-dialed reserver.
+func TestIDReserver_QueryAndReturnToPool(t *testing.T) {
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+
+	dialer := newMockDialer(t, nil)
+	paths := [][]routing.Hop{makeHops(pkA, pkB), makeHops(pkB, pkA)}
+	rtIDR, err := NewIDReserver(context.Background(), dialer, nil, paths)
+	require.NoError(t, err)
+
+	v := rtIDR.(*idReserver)
+	require.Equal(t, 4, v.TotalIDs())
+	require.NotNil(t, v.Client(pkA))
+	require.NotNil(t, v.Client(pkB))
+
+	// String renders the (empty, pre-reserve) ids map as JSON without error.
+	require.NotEmpty(t, v.String())
+
+	// ReturnToPool hands the clients to a pool for reuse instead of closing.
+	pool := NewClientPool(&countingDialer{}, DefaultPoolTTL)
+	t.Cleanup(pool.Close)
+	v.ReturnToPool(pool)
+	require.Equal(t, 2, pool.Size(), "both clients returned to the pool")
+}
+
+// ---- setup-node reordering ------------------------------------------------
+
+// TestReorderSetupNodes is table-driven over the move-to-front logic.
+func TestReorderSetupNodes(t *testing.T) {
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	c, _ := cipher.GenerateKeyPair()
+	d, _ := cipher.GenerateKeyPair()
+
+	cases := []struct {
+		name    string
+		nodes   []cipher.PubKey
+		success cipher.PubKey
+		want    []cipher.PubKey
+	}{
+		{"empty", nil, a, nil},
+		{"single", []cipher.PubKey{a}, a, []cipher.PubKey{a}},
+		{"already-first", []cipher.PubKey{a, b, c}, a, []cipher.PubKey{a, b, c}},
+		{"not-found", []cipher.PubKey{a, b, c}, d, []cipher.PubKey{a, b, c}},
+		{"middle", []cipher.PubKey{a, b, c}, c, []cipher.PubKey{c, a, b}},
+		{"second", []cipher.PubKey{a, b, c, d}, b, []cipher.PubKey{b, a, c, d}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ReorderSetupNodes(tc.nodes, tc.success)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// ---- transport-query JSON codec -------------------------------------------
+
+// TestTransportQuery_MarshalRoundTrip proves the query and response marshal and
+// unmarshal back to an equal value, and that a malformed payload errors.
+func TestTransportQuery_MarshalRoundTrip(t *testing.T) {
+	rsnPK, _ := cipher.GenerateKeyPair()
+	dstPK, _ := cipher.GenerateKeyPair()
+	srcPK, _ := cipher.GenerateKeyPair()
+
+	q := &TransportQuery{RSNPK: rsnPK, TargetPK: dstPK, RequesterPK: srcPK, Nonce: 1234}
+	raw, err := q.Marshal()
+	require.NoError(t, err)
+
+	q2, err := UnmarshalTransportQuery(raw)
+	require.NoError(t, err)
+	require.Equal(t, q, q2)
+
+	_, err = UnmarshalTransportQuery([]byte("not json"))
+	require.Error(t, err)
+
+	resp := &TransportQueryResponse{
+		TargetPK: dstPK,
+		Entries: []transport.CompactEntry{
+			{Remote: srcPK, Type: "stcpr"},
+		},
+	}
+	rraw, err := resp.Marshal()
+	require.NoError(t, err)
+
+	resp2, err := UnmarshalTransportQueryResponse(rraw)
+	require.NoError(t, err)
+	require.Equal(t, resp, resp2)
+
+	_, err = UnmarshalTransportQueryResponse([]byte("{bad"))
+	require.Error(t, err)
+}
+
+// ---- hasRouteSelectingHook ------------------------------------------------
+
+// plainDialHook implements DialHook only (no SelectRoute).
+type plainDialHook struct{}
+
+func (plainDialHook) BeforeDial(_ context.Context, _ DialInfo) (DialAdjustment, error) {
+	return DialAdjustment{}, nil
+}
+
+// selectingDialHook implements the RouteSelectingHook super-interface.
+type selectingDialHook struct{ plainDialHook }
+
+func (selectingDialHook) SelectRoute(_ context.Context, _ DialInfo, _, _ []CandidateInfo) (RouteSelection, error) {
+	return RouteSelection{}, nil
+}
+
+// TestHasRouteSelectingHook covers the three branches: no config, a plain hook,
+// and a route-selecting hook.
+func TestHasRouteSelectingHook(t *testing.T) {
+	// nil conf -> false.
+	r := &router{}
+	require.False(t, r.hasRouteSelectingHook())
+
+	// conf present, no hook -> false.
+	r.conf = &Config{}
+	require.False(t, r.hasRouteSelectingHook())
+
+	// plain DialHook (not selecting) -> false.
+	r.conf = &Config{DialHook: plainDialHook{}}
+	require.False(t, r.hasRouteSelectingHook())
+
+	// route-selecting hook -> true.
+	r.conf = &Config{DialHook: selectingDialHook{}}
+	require.True(t, r.hasRouteSelectingHook())
+}
+
+// ---- Map pool helpers -----------------------------------------------------
+
+// TestMap_PooledAndDiscard covers MakePooledMap (empty and populated) and
+// Map.DiscardFromPool.
+func TestMap_PooledAndDiscard(t *testing.T) {
+	pool := NewClientPool(&countingDialer{}, DefaultPoolTTL)
+	t.Cleanup(pool.Close)
+
+	// Empty PK set returns an empty map without dialing.
+	empty, err := MakePooledMap(context.Background(), pool, nil)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+	m, err := MakePooledMap(context.Background(), pool, []cipher.PubKey{pkA, pkB})
+	require.NoError(t, err)
+	require.Len(t, m, 2)
+
+	// DiscardFromPool closes every client and empties the map (does NOT pool).
+	m.DiscardFromPool(pool)
+	require.Empty(t, m)
+	require.Zero(t, pool.Size(), "discarded clients are not returned to the pool")
+}

--- a/pkg/router/noise_route_group_delegate_test.go
+++ b/pkg/router/noise_route_group_delegate_test.go
@@ -1,0 +1,133 @@
+// Package router pkg/router/noise_route_group_delegate_test.go
+//
+// Coverage for the NoiseRouteGroup net.Conn/stat delegators (they simply
+// forward to the wrapped RouteGroup but had no direct test), plus the
+// router-level ActiveRouteStatuses / RoutingTableStats observability
+// surface built on top of them, and the networkStats accounting helpers.
+package router
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// TestNoiseRouteGroupDelegators exercises every forwarding method on
+// NoiseRouteGroup against a real (mux'd) RouteGroup.
+func TestNoiseRouteGroupDelegators(t *testing.T) {
+	rg, _, _ := createMuxRouteGroup(t, 2)
+	nrg := &NoiseRouteGroup{rg: rg}
+
+	// Addresses forward to the descriptor endpoints.
+	require.Equal(t, rg.desc.Dst(), nrg.LocalAddr())
+	require.Equal(t, rg.desc.Src(), nrg.RemoteAddr())
+
+	// A freshly-built group is alive and not closed.
+	require.True(t, nrg.IsAlive())
+	require.False(t, nrg.isClosed())
+
+	// Stat reads are zero on a group that has not moved data.
+	require.EqualValues(t, 0, nrg.BandwidthSent())
+	require.EqualValues(t, 0, nrg.BandwidthReceived())
+	require.EqualValues(t, 0, nrg.UploadSpeed())
+	require.EqualValues(t, 0, nrg.DownloadSpeed())
+	require.EqualValues(t, 0, nrg.Latency())
+
+	// Hop details are populated from the forward hops we set.
+	src := rg.desc.SrcPK()
+	dst := rg.desc.DstPK()
+	mid, _ := cipher.GenerateKeyPair()
+	nrg.SetForwardHops([]routing.Hop{
+		{From: src, To: mid},
+		{From: mid, To: dst},
+	})
+	hops := nrg.RouteHops()
+	require.NotEmpty(t, hops)
+	require.Equal(t, dst, hops[len(hops)-1], "path ends at the destination")
+	require.NotEmpty(t, nrg.RouteHopDetails())
+
+	// SetError / GetError round-trip.
+	wantErr := errors.New("boom")
+	nrg.SetError(wantErr)
+	require.Equal(t, wantErr, nrg.GetError())
+
+	// Close chains through to the RouteGroup (nrg.Conn is nil here).
+	require.NoError(t, nrg.Close())
+	require.True(t, nrg.isClosed())
+}
+
+// TestRouterActiveRouteStatuses registers a NoiseRouteGroup on a real router
+// and proves ActiveRouteStatuses reflects it (including the per-transport
+// breakdown), and that RoutingTableStats delegates to the routing table.
+func TestRouterActiveRouteStatuses(t *testing.T) {
+	conf := &Config{
+		Logger:             logging.MustGetLogger("active_route_status_test"),
+		MasterLogger:       logging.NewMasterLogger(),
+		AwaitSetupListener: &dmsg.Listener{},
+	}
+	rIface, err := New(nil, conf, nil)
+	require.NoError(t, err)
+	r := rIface.(*router)
+
+	// Empty router: no active statuses.
+	require.Empty(t, r.ActiveRouteStatuses())
+
+	// Register a 2-leg mux route group. Set forward hops so RouteHopDetails
+	// takes the recorded-path branch instead of the local-transport fallback
+	// (the test ManagedTransports have no live network for tp.Type()).
+	rg, mts, _ := createMuxRouteGroup(t, 2)
+	mid, _ := cipher.GenerateKeyPair()
+	rg.SetForwardHops([]routing.Hop{
+		{From: rg.desc.SrcPK(), To: mid},
+		{From: mid, To: rg.desc.DstPK()},
+	})
+	nrg := &NoiseRouteGroup{rg: rg}
+	r.mx.Lock()
+	r.rgsNs[rg.desc] = nrg
+	r.mx.Unlock()
+
+	statuses := r.ActiveRouteStatuses()
+	require.Len(t, statuses, 1)
+	st := statuses[0]
+	require.Equal(t, rg.desc.DstPK(), st.LocalPK)
+	require.Equal(t, rg.desc.SrcPK(), st.RemotePK)
+	require.True(t, st.MuxEnabled, "the group carries a mux")
+	require.Len(t, st.Transports, len(mts), "one RouteTransport per leg")
+
+	// RoutingTableStats delegates to the router's routing table.
+	stats := r.RoutingTableStats()
+	require.GreaterOrEqual(t, stats.Count, 0)
+}
+
+// TestNetworkStats covers the atomic accounting helpers, including the
+// millisecond->Duration conversion in Latency and the rate calc in
+// RemoteThroughput.
+func TestNetworkStats(t *testing.T) {
+	s := newNetworkStats()
+
+	s.SetLatency(5)
+	require.Equal(t, 5*time.Millisecond, s.Latency())
+
+	s.SetUploadSpeed(1234)
+	require.EqualValues(t, 1234, s.UploadSpeed())
+	s.SetDownloadSpeed(5678)
+	require.EqualValues(t, 5678, s.DownloadSpeed())
+
+	s.AddBandwidthSent(100)
+	s.AddBandwidthSent(50)
+	require.EqualValues(t, 150, s.BandwidthSent())
+
+	s.AddBandwidthReceived(200)
+	require.EqualValues(t, 200, s.BandwidthReceived())
+
+	// RemoteThroughput drains the received-bandwidth window and returns a
+	// non-negative rate.
+	require.GreaterOrEqual(t, s.RemoteThroughput(), int64(0))
+}

--- a/pkg/router/route_mux_helpers_test.go
+++ b/pkg/router/route_mux_helpers_test.go
@@ -1,0 +1,172 @@
+// Package router pkg/router/route_mux_helpers_test.go
+//
+// Unit coverage for the routeMux per-leg accounting and SACK/reorder
+// glue helpers (recordRecv/recordSent, snapshotLegs, gapAge,
+// shouldSendSACK, processSACK, generateSACK, getRetxPayload,
+// heldRetxSeqs, wrapPayload, deliverData). These are exercised directly
+// on a bare newRouteMux — no transports or network — so they are fast
+// and deterministic.
+package router
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+func newBareMux(sack bool) *routeMux {
+	return newRouteMux(logging.MustGetLogger("mux_helpers_test"), sack)
+}
+
+// TestMuxRecordCountersAndSnapshot exercises recordSent/recordRecv/
+// recordRetransmit accumulation and the snapshotLegs read path, plus the
+// bounds-checked out-of-range and negative-index defensive branches.
+func TestMuxRecordCountersAndSnapshot(t *testing.T) {
+	m := newBareMux(false)
+	m.growLegs(2)
+
+	// Out-of-range and negative indices are silently dropped.
+	m.recordSent(-1, 100)
+	m.recordRecv(-1, 100)
+	m.recordRetransmit(-1)
+	m.recordSent(5, 100)
+	m.recordRecv(5, 100)
+	m.recordRetransmit(5)
+	require.EqualValues(t, 0, m.retransmitsAt(-1))
+	require.EqualValues(t, 0, m.retransmitsAt(9))
+
+	// Valid recordings accumulate on the addressed leg only.
+	m.recordSent(0, 40)
+	m.recordSent(0, 60)
+	m.recordRecv(0, 10)
+	m.recordRetransmit(0)
+	m.recordRetransmit(0)
+	m.recordSent(1, 7)
+	m.recordRecv(1, 3)
+
+	snap := m.snapshotLegs()
+	require.Len(t, snap, 2)
+
+	assert.Equal(t, 0, snap[0].Index)
+	assert.EqualValues(t, 100, snap[0].SentBytes)
+	assert.EqualValues(t, 2, snap[0].SentPackets)
+	assert.EqualValues(t, 10, snap[0].RecvBytes)
+	assert.EqualValues(t, 1, snap[0].RecvPackets)
+	assert.EqualValues(t, 2, snap[0].Retransmits)
+	assert.EqualValues(t, 2, m.retransmitsAt(0))
+
+	assert.Equal(t, 1, snap[1].Index)
+	assert.EqualValues(t, 7, snap[1].SentBytes)
+	assert.EqualValues(t, 1, snap[1].SentPackets)
+	assert.EqualValues(t, 3, snap[1].RecvBytes)
+	assert.EqualValues(t, 1, snap[1].RecvPackets)
+	assert.EqualValues(t, 0, snap[1].Retransmits)
+}
+
+// TestMuxGapAge proves gapAge is 0 on a contiguous stream and non-zero once an
+// out-of-order deliverData opens a frontier gap, then closes back to 0 when the
+// gap is filled.
+func TestMuxGapAge(t *testing.T) {
+	m := newBareMux(true)
+
+	require.Zero(t, m.gapAge(), "fresh mux has no gap")
+
+	// seq 0 is expected next; delivering seq 2 opens a frontier gap at seq 0.
+	delivered, gap := m.deliverData(2, []byte("c"))
+	require.Empty(t, delivered, "out-of-order packet is held, not delivered")
+	require.True(t, gap, "SACK tracker reports the gap")
+	require.Greater(t, m.gapAge(), time.Duration(0), "an open gap has a non-zero age")
+
+	// Fill the gap: seq 0 then seq 1 drains 0,1,2 in order and closes the gap.
+	d0, _ := m.deliverData(0, []byte("a"))
+	require.Equal(t, [][]byte{[]byte("a")}, d0)
+	d1, _ := m.deliverData(1, []byte("b"))
+	require.Equal(t, [][]byte{[]byte("b"), []byte("c")}, d1)
+	require.Zero(t, m.gapAge(), "gap closed once contiguous again")
+}
+
+// nilReorderMux constructs a mux with a nil reorderBuf to hit gapAge's nil guard.
+func TestMuxGapAgeNilBuf(t *testing.T) {
+	m := newBareMux(false)
+	m.reorderBuf = nil
+	require.Zero(t, m.gapAge())
+}
+
+// TestMuxShouldSendSACK verifies the rate-limit: the first call wins, an
+// immediate second call is throttled, and a call after the min interval wins
+// again.
+func TestMuxShouldSendSACK(t *testing.T) {
+	m := newBareMux(true)
+
+	require.True(t, m.shouldSendSACK(), "first SACK is always allowed")
+	require.False(t, m.shouldSendSACK(), "immediate second SACK is rate-limited")
+
+	// Backdate the last-SACK timestamp past the min interval.
+	m.lastSACKNano = time.Now().Add(-2 * sackMinInterval).UnixNano()
+	require.True(t, m.shouldSendSACK(), "SACK allowed again after the min interval")
+}
+
+// TestMuxSACKPathEnabled walks wrapPayload -> retx store -> generateSACK ->
+// processSACK -> getRetxPayload/heldRetxSeqs with SACK enabled.
+func TestMuxSACKPathEnabled(t *testing.T) {
+	m := newBareMux(true)
+
+	routeID := routing.RouteID(7)
+	// wrapPayload stores the payload in the retx buffer for later SACK recovery.
+	pkt0, seq0, err := m.wrapPayload(routeID, []byte("hello"))
+	require.NoError(t, err)
+	require.NotNil(t, pkt0)
+	require.EqualValues(t, 0, seq0)
+	pkt1, seq1, err := m.wrapPayload(routeID, []byte("world"))
+	require.NoError(t, err)
+	require.NotNil(t, pkt1)
+	require.EqualValues(t, 1, seq1)
+
+	// Both sequences are held unacked.
+	require.Equal(t, []uint32{0, 1}, m.heldRetxSeqs())
+	require.Equal(t, []byte("hello"), m.getRetxPayload(0))
+	require.Equal(t, []byte("world"), m.getRetxPayload(1))
+	require.Nil(t, m.getRetxPayload(99), "unknown seq has no stored payload")
+
+	// The receiver has seen seq 0 and 1: generate a SACK and feed it back.
+	m.deliverData(0, []byte("hello"))
+	m.deliverData(1, []byte("world"))
+	lastContig, words := m.generateSACK()
+	require.EqualValues(t, 1, lastContig)
+
+	// Processing that SACK purges the acked entries; nothing needs retransmit.
+	retx := m.processSACK(lastContig, words)
+	require.Empty(t, retx)
+	require.Empty(t, m.heldRetxSeqs(), "acked seqs are purged from the retx buffer")
+}
+
+// TestMuxSACKPathDisabled proves the SACK/retx helpers are inert when SACK was
+// not negotiated: no storage, and the guard branches return nil.
+func TestMuxSACKPathDisabled(t *testing.T) {
+	m := newBareMux(false)
+
+	_, _, err := m.wrapPayload(routing.RouteID(1), []byte("x"))
+	require.NoError(t, err)
+	// retxBuf still exists but Store is skipped when sackEnabled is false.
+	require.Empty(t, m.heldRetxSeqs())
+
+	lastContig, words := m.generateSACK()
+	require.Zero(t, lastContig)
+	require.Nil(t, words)
+
+	require.Nil(t, m.processSACK(0, []uint64{0xff}))
+}
+
+// TestMuxGetRetxPayloadNilBuf hits the nil-retxBuf guards.
+func TestMuxGetRetxPayloadNilBuf(t *testing.T) {
+	m := newBareMux(true)
+	m.retxBuf = nil
+	require.Nil(t, m.getRetxPayload(0))
+	require.Nil(t, m.heldRetxSeqs())
+	require.Nil(t, m.processSACK(0, []uint64{1}))
+}


### PR DESCRIPTION
Adds deterministic unit tests (no real network — net.Pipe / in-memory test transports, following the existing flakyReserveDialer / countingDialer / createMuxRouteGroup patterns) for previously-uncovered pure-logic helpers in pkg/router. No non-test code was changed.

Package statement coverage: 38.5% -> 41.8%.

Covered:
- routeMux per-leg accounting + SACK/reorder glue: recordSent/recordRecv, snapshotLegs, gapAge, shouldSendSACK, generateSACK/processSACK, getRetxPayload, heldRetxSeqs, wrapPayload/deliverData — enabled and disabled SACK paths plus the bounds-check and nil-buffer guards.
- ClientPool lifecycle: Discard, Size, Put-replace, evict, idempotent Close.
- cascade ackRegistry.unregister; RSNRelayCache Update/Get and the no-cached-peers error path.
- idReserver TotalIDs/Client/String/ReturnToPool; Map MakePooledMap and DiscardFromPool.
- ReorderSetupNodes (table-driven move-to-front); TransportQuery/TransportQueryResponse JSON codec round-trip + malformed-input errors.
- NoiseRouteGroup net.Conn/stat delegators; router ActiveRouteStatuses + RoutingTableStats observability; networkStats accounting (incl. ms->Duration and throughput calc); hasRouteSelectingHook branches.

go build ., go test ./pkg/router/..., gofmt and go vet are clean.