### PR TITLE
refactor(cmdutil): dedup Execute/exampleJSON/commaSplit into shared helpers

### DIFF
--- a/cmd/apps/pty/commands/pty.go
+++ b/cmd/apps/pty/commands/pty.go
@@ -33,7 +33,8 @@ package commands
 
 import (
 	"fmt"
-	"log"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
 
 	"github.com/spf13/cobra"
 
@@ -178,7 +179,5 @@ the full surface.`,
 // top-level Execute in cmd/skywire/commands/root.go and doesn't
 // call this.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	ipc "github.com/james-barrow/golang-ipc"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -677,9 +679,7 @@ var RootCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }
 
 // RunSkychat runs the skychat app logic. This can be called from the visor or from the CLI.

--- a/cmd/apps/skydex-client/commands/skydex-client.go
+++ b/cmd/apps/skydex-client/commands/skydex-client.go
@@ -16,6 +16,8 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	skydexclient "github.com/skycoin/skycoin/cmd/skydex-client/commands"
 	skymarket "github.com/skycoin/skycoin/src/skydex/market"
 	"github.com/spf13/cobra"
@@ -96,9 +98,7 @@ var RootCmd = &cobra.Command{
 
 // Execute executes the root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }
 
 // appnetDialer is the skywire MarketDialer: it dials the market's public key

--- a/cmd/apps/skydex-market/commands/root.go
+++ b/cmd/apps/skydex-market/commands/root.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	"github.com/sirupsen/logrus"
 	skydexmarket "github.com/skycoin/skycoin/cmd/skydex-market/commands"
 	"github.com/spf13/cobra"
@@ -69,9 +71,7 @@ var RootCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }
 
 // appHost adapts the visor app client to the engine's Host: it supplies the

--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -11,6 +11,8 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -368,7 +370,5 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/apps/skynet/commands/skynet.go
+++ b/cmd/apps/skynet/commands/skynet.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -183,7 +185,5 @@ func createRPCClient(addr string) (visor.API, error) {
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/apps/skysocks/commands/skysocks.go
+++ b/cmd/apps/skysocks/commands/skysocks.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	ipc "github.com/james-barrow/golang-ipc"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -160,7 +162,5 @@ func RunSkysocks(ctx context.Context, args []string) error {
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/apps/vpn-client/commands/vpn-client.go
+++ b/cmd/apps/vpn-client/commands/vpn-client.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	ipc "github.com/james-barrow/golang-ipc"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -370,9 +372,7 @@ func setAppStatus(appCl *app.Client, log logrus.FieldLogger, status appserver.Ap
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }
 
 func setAppPort(appCl *app.Client, log logrus.FieldLogger, port routing.Port) {

--- a/cmd/apps/vpn-router/commands/vpn-router.go
+++ b/cmd/apps/vpn-router/commands/vpn-router.go
@@ -4,12 +4,13 @@ package commands
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -110,9 +111,7 @@ var RootCmd = &cobra.Command{
 
 // Execute executes the root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }
 
 // RunVPNRouter is the launcher AppFunc: it brings up the downstream interface,

--- a/cmd/apps/vpn-server/commands/vpn-server.go
+++ b/cmd/apps/vpn-server/commands/vpn-server.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -205,9 +207,7 @@ func setAppStatus(appCl *app.Client, log logrus.FieldLogger, status appserver.Ap
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }
 
 func setAppPort(appCl *app.Client, log logrus.FieldLogger, port routing.Port) {

--- a/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery.go
+++ b/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"log"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -141,12 +140,12 @@ func buildConfig() (*dmsgdisc.Config, error) {
 		EntryTimeout:      services.Duration(entryTimeout),
 		Mode:              mode,
 		AuthPassphrase:    authPassphrase,
-		OfficialServers:   commaSplit(officialServers),
+		OfficialServers:   cmdutil.CommaSplit(officialServers),
 		DmsgServerType:    dmsgServerType,
 		TestMode:          testMode,
 		EnableLoadTesting: enableLoadTesting,
 		TestEnvironment:   testEnvironment,
-		Whitelist:         commaSplit(whitelistKeys),
+		Whitelist:         cmdutil.CommaSplit(whitelistKeys),
 		MetricsAddr:       sf.MetricsAddr,
 		PProfMode:         pprofMode,
 		PProfAddr:         pprofAddr,
@@ -219,20 +218,6 @@ func mergeFile(dst, src *dmsgdisc.Config) {
 	if len(src.DmsgServers) > 0 {
 		dst.DmsgServers = src.DmsgServers
 	}
-}
-
-func commaSplit(s string) []string {
-	if s == "" {
-		return nil
-	}
-	out := make([]string, 0, 4)
-	for _, p := range strings.Split(s, ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			out = append(out, p)
-		}
-	}
-	return out
 }
 
 func loadOrGenerateKey(path string) error {

--- a/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery_test.go
+++ b/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/services"
 	"github.com/skycoin/skywire/pkg/services/dmsgdisc"
 )
@@ -40,14 +41,14 @@ func resetGlobals(t *testing.T) {
 // TestCommaSplit covers the comma-list splitter, including trimming and the
 // dropping of empty segments.
 func TestCommaSplit(t *testing.T) {
-	assert.Nil(t, commaSplit(""))
-	assert.Equal(t, []string{"a", "b", "c"}, commaSplit("a,b,c"))
-	assert.Equal(t, []string{"a", "b"}, commaSplit("  a , , b  "))
-	assert.Equal(t, []string{"solo"}, commaSplit("solo"))
+	assert.Nil(t, cmdutil.CommaSplit(""))
+	assert.Equal(t, []string{"a", "b", "c"}, cmdutil.CommaSplit("a,b,c"))
+	assert.Equal(t, []string{"a", "b"}, cmdutil.CommaSplit("  a , , b  "))
+	assert.Equal(t, []string{"solo"}, cmdutil.CommaSplit("solo"))
 	// Only the empty string returns nil; an all-whitespace input returns a
 	// non-nil but empty slice.
-	assert.Empty(t, commaSplit("  ,  , "))
-	assert.Nil(t, commaSplit(""))
+	assert.Empty(t, cmdutil.CommaSplit("  ,  , "))
+	assert.Nil(t, cmdutil.CommaSplit(""))
 }
 
 // TestMergeFile verifies non-zero src fields override dst and zero fields are

--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -3,10 +3,11 @@ package commands
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
 
 	"github.com/spf13/cobra"
 
@@ -238,7 +239,5 @@ var RootCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/skywire/commands/root.go
+++ b/cmd/skywire/commands/root.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	"github.com/spf13/cobra"
 
 	pty "github.com/skycoin/skywire/cmd/apps/pty/commands"
@@ -216,7 +218,5 @@ var appsCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/svc/address-resolver/commands/root.go
+++ b/cmd/svc/address-resolver/commands/root.go
@@ -3,7 +3,6 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -48,14 +47,6 @@ var (
 	mode            string
 )
 
-func exampleJSON(v interface{}) string {
-	b, err := json.MarshalIndent(v, "    ", "  ")
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 func generateExamples() string {
 	pk1 := "02a49bc0aa1b5b78f638e9189be4c5d699e6d1358472d8a47f4c20daacd672d7e5"
 	pk2 := "03b160fa44bac22cae9f7eb1311f1648aaab962e1e55d8d9a22a9586ded871eb5e"
@@ -88,21 +79,21 @@ DEL /deregister/{network} (NM auth headers: NM-PK, NM-Sign)
 
 GET /security/nonces/{pk}
   %s`,
-		exampleJSON(map[string]interface{}{
+		cmdutil.ExampleJSON(map[string]interface{}{
 			"build_info":   map[string]string{"version": "v1.3.29"},
 			"started_at":   "2024-01-15T10:00:00Z",
 			"dmsg_address": pk1 + ":80",
 			"dmsg_servers": []string{pk2},
 		}),
-		exampleJSON(map[string]interface{}{"port": 30178}),
-		exampleJSON(map[string]string{"addr": "192.168.1.100:30178"}),
-		exampleJSON(map[string]interface{}{
+		cmdutil.ExampleJSON(map[string]interface{}{"port": 30178}),
+		cmdutil.ExampleJSON(map[string]string{"addr": "192.168.1.100:30178"}),
+		cmdutil.ExampleJSON(map[string]interface{}{
 			"addr":      "192.168.1.100:30178",
 			"handshake": "<base64_handshake_data>",
 		}),
-		exampleJSON(api.ArData{Sudph: []string{pk1}, Stcpr: []string{pk1, pk2}}),
-		exampleJSON([]string{pk1, pk2}),
-		exampleJSON(map[string]interface{}{"nonce": 12345}),
+		cmdutil.ExampleJSON(api.ArData{Sudph: []string{pk1}, Stcpr: []string{pk1, pk2}}),
+		cmdutil.ExampleJSON([]string{pk1, pk2}),
+		cmdutil.ExampleJSON(map[string]interface{}{"nonce": 12345}),
 	)
 }
 
@@ -204,7 +195,7 @@ func buildConfig() (*ar.Config, error) {
 		LogLevel:        logLvl,
 		Testing:         testing,
 		Mode:            mode,
-		Whitelist:       commaSplit(whitelistKeys),
+		Whitelist:       cmdutil.CommaSplit(whitelistKeys),
 		TestEnvironment: testEnvironment,
 		DmsgPort:        dmsgPort,
 		Dmsg: cmdutil.DmsgConfig{
@@ -285,23 +276,7 @@ func mergeFile(dst, src *ar.Config) {
 	}
 }
 
-func commaSplit(s string) []string {
-	if s == "" {
-		return nil
-	}
-	out := make([]string, 0, 4)
-	for _, p := range strings.Split(s, ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			out = append(out, p)
-		}
-	}
-	return out
-}
-
 // Execute executes root CLI command
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/svc/address-resolver/commands/root_test.go
+++ b/cmd/svc/address-resolver/commands/root_test.go
@@ -27,11 +27,11 @@ import (
 // ---- exampleJSON / generateExamples ----------------------------------------
 
 func TestExampleJSON(t *gotesting.T) {
-	out := exampleJSON(map[string]string{"version": "v1.3.29"})
+	out := cmdutil.ExampleJSON(map[string]string{"version": "v1.3.29"})
 	require.Contains(t, out, "v1.3.29")
 
 	// Unmarshalable value (channel) → json.MarshalIndent fails → "".
-	require.Equal(t, "", exampleJSON(make(chan int)))
+	require.Equal(t, "", cmdutil.ExampleJSON(make(chan int)))
 }
 
 func TestGenerateExamples(t *gotesting.T) {
@@ -46,10 +46,10 @@ func TestGenerateExamples(t *gotesting.T) {
 // ---- commaSplit ------------------------------------------------------------
 
 func TestCommaSplit(t *gotesting.T) {
-	require.Nil(t, commaSplit(""))
-	require.Equal(t, []string{"a", "b", "c"}, commaSplit("a, b ,c"))
-	require.Equal(t, []string{"x"}, commaSplit(" x "))
-	require.Empty(t, commaSplit(" , , ")) // all blank after trim
+	require.Nil(t, cmdutil.CommaSplit(""))
+	require.Equal(t, []string{"a", "b", "c"}, cmdutil.CommaSplit("a, b ,c"))
+	require.Equal(t, []string{"x"}, cmdutil.CommaSplit(" x "))
+	require.Empty(t, cmdutil.CommaSplit(" , , ")) // all blank after trim
 }
 
 // ---- buildConfig -----------------------------------------------------------

--- a/cmd/svc/conf/commands/root.go
+++ b/cmd/svc/conf/commands/root.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/deployment"
@@ -135,7 +137,5 @@ func filterServices(svc deployment.Services, keepHTTP, keepDmsg bool) deployment
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/svc/config-bootstrapper/commands/root.go
+++ b/cmd/svc/config-bootstrapper/commands/root.go
@@ -40,15 +40,6 @@ var (
 	mode           string
 )
 
-// exampleJSON marshals v to indented JSON with color, returning empty string on error
-func exampleJSON(v interface{}) string {
-	b, err := json.MarshalIndent(v, "    ", "  ")
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 // generateExamples creates example responses from actual struct types
 func generateExamples() string {
 	exPK1 := "02a49bc0aa1b5b78f638e9189be4c5d699e6d1358472d8a47f4c20daacd672d7e5"
@@ -89,8 +80,8 @@ GET /health - api.HealthCheckResponse
 
 GET / - visorconfig.Services
 %s`,
-		exampleJSON(healthExample),
-		exampleJSON(servicesExample))
+		cmdutil.ExampleJSON(healthExample),
+		cmdutil.ExampleJSON(servicesExample))
 }
 
 func init() {
@@ -231,7 +222,5 @@ func readConfig(log *logging.Logger, confPath string) (config api.Config) {
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/svc/config-bootstrapper/commands/root_test.go
+++ b/cmd/svc/config-bootstrapper/commands/root_test.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skywire/pkg/config-bootstrapper/api"
@@ -24,11 +26,11 @@ func testLog() *logging.Logger { return logging.MustGetLogger("cb-test") }
 // ---- exampleJSON / generateExamples ----------------------------------------
 
 func TestExampleJSON(t *testing.T) {
-	out := exampleJSON(map[string]string{"version": "v1.3.29"})
+	out := cmdutil.ExampleJSON(map[string]string{"version": "v1.3.29"})
 	require.Contains(t, out, "v1.3.29")
 
 	// Unmarshalable value (channel) → json.MarshalIndent fails → "".
-	require.Equal(t, "", exampleJSON(make(chan int)))
+	require.Equal(t, "", cmdutil.ExampleJSON(make(chan int)))
 }
 
 func TestGenerateExamples(t *testing.T) {

--- a/cmd/svc/geoip/commands/root.go
+++ b/cmd/svc/geoip/commands/root.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"net/netip"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
 
 	"github.com/oschwald/geoip2-golang/v2"
 	"github.com/skycoin/skycoin/src/util/logging"
@@ -40,15 +41,6 @@ func LookupIP(db *geoip2.Reader, ipStr string) (*LookupResult, error) {
 	return lookupIP(db, ipStr)
 }
 
-// exampleJSON marshals v to indented JSON with color, returning empty string on error
-func exampleJSON(v interface{}) string {
-	b, err := json.MarshalIndent(v, "    ", "  ")
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 // generateExamples creates example responses from actual struct types
 func generateExamples() string {
 	lat := 37.751
@@ -62,7 +54,7 @@ GET /?ip=8.8.8.8
 
 CLI: skywire svc ip 8.8.8.8
   (same response as above)`,
-		exampleJSON(lookupResult{
+		cmdutil.ExampleJSON(lookupResult{
 			IP:            "8.8.8.8",
 			Latitude:      &lat,
 			Longitude:     &lon,
@@ -191,9 +183,7 @@ Usage Examples:
 
 // Execute executes root CLI command
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }
 
 func lookupIP(db *geoip2.Reader, ipStr string) (*lookupResult, error) {

--- a/cmd/svc/geoip/commands/root_test.go
+++ b/cmd/svc/geoip/commands/root_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/stretchr/testify/require"
 
@@ -31,8 +33,8 @@ import (
 // ---- example helpers / exported wrappers -----------------------------------
 
 func TestExampleJSON(t *testing.T) {
-	require.Contains(t, exampleJSON(map[string]string{"k": "v"}), "\"k\"")
-	require.Equal(t, "", exampleJSON(make(chan int))) // marshal error → ""
+	require.Contains(t, cmdutil.ExampleJSON(map[string]string{"k": "v"}), "\"k\"")
+	require.Equal(t, "", cmdutil.ExampleJSON(make(chan int))) // marshal error → ""
 }
 
 func TestGenerateExamples(t *testing.T) {

--- a/cmd/svc/network-monitor/commands/root.go
+++ b/cmd/svc/network-monitor/commands/root.go
@@ -58,15 +58,6 @@ var (
 	deregRPCAddr  string // Visor RPC address
 )
 
-// exampleJSON marshals v to indented JSON with color, returning empty string on error
-func exampleJSON(v interface{}) string {
-	b, err := json.MarshalIndent(v, "    ", "  ")
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 // generateExamples creates example responses from actual struct types
 func generateExamples() string {
 	// GET /health - api.HealthCheckResponse
@@ -105,8 +96,8 @@ GET /health - api.HealthCheckResponse
 
 GET /status - nm.Status
 %s`,
-		exampleJSON(healthExample),
-		exampleJSON(statusExample))
+		cmdutil.ExampleJSON(healthExample),
+		cmdutil.ExampleJSON(statusExample))
 }
 
 func init() {

--- a/cmd/svc/network-monitor/commands/root_test.go
+++ b/cmd/svc/network-monitor/commands/root_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -26,8 +28,8 @@ import (
 // ---- example helpers -------------------------------------------------------
 
 func TestExampleJSON(t *testing.T) {
-	require.Contains(t, exampleJSON(map[string]string{"k": "v"}), "\"k\"")
-	require.Equal(t, "", exampleJSON(make(chan int))) // marshal error → ""
+	require.Contains(t, cmdutil.ExampleJSON(map[string]string{"k": "v"}), "\"k\"")
+	require.Equal(t, "", cmdutil.ExampleJSON(make(chan int))) // marshal error → ""
 }
 
 func TestGenerateExamples(t *testing.T) {

--- a/cmd/svc/route-finder/commands/root.go
+++ b/cmd/svc/route-finder/commands/root.go
@@ -3,7 +3,6 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -40,14 +39,6 @@ var (
 	mode           string
 )
 
-func exampleJSON(v interface{}) string {
-	b, err := json.MarshalIndent(v, "    ", "  ")
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 func generateExamples() string {
 	pk1 := "02a49bc0aa1b5b78f638e9189be4c5d699e6d1358472d8a47f4c20daacd672d7e5"
 	pk2 := "03b160fa44bac22cae9f7eb1311f1648aaab962e1e55d8d9a22a9586ded871eb5e"
@@ -62,17 +53,17 @@ GET /health
 POST /routes
   Request:  %s
   Response: %s`,
-		exampleJSON(map[string]interface{}{
+		cmdutil.ExampleJSON(map[string]interface{}{
 			"build_info":   map[string]string{"version": "v1.3.29"},
 			"started_at":   "2024-01-15T10:00:00Z",
 			"dmsg_address": pk1 + ":80",
 			"dmsg_servers": []string{pk2},
 		}),
-		exampleJSON(map[string]interface{}{
+		cmdutil.ExampleJSON(map[string]interface{}{
 			"edges": [][]string{{pk1, pk2}},
 			"opts":  map[string]int{"min_hops": 0, "max_hops": 3},
 		}),
-		exampleJSON(map[string]interface{}{
+		cmdutil.ExampleJSON(map[string]interface{}{
 			pk1 + "-" + pk2: [][]map[string]interface{}{{
 				{"t_id": tpID, "from": pk1, "to": pk2},
 			}},
@@ -229,7 +220,5 @@ func mergeFile(dst, src *rf.Config) {
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/svc/route-finder/commands/root_test.go
+++ b/cmd/svc/route-finder/commands/root_test.go
@@ -25,11 +25,11 @@ import (
 // ---- exampleJSON / generateExamples ----------------------------------------
 
 func TestExampleJSON(t *gotesting.T) {
-	out := exampleJSON(map[string]string{"version": "v1.3.29"})
+	out := cmdutil.ExampleJSON(map[string]string{"version": "v1.3.29"})
 	require.Contains(t, out, "v1.3.29")
 
 	// Unmarshalable value (channel) → json.MarshalIndent fails → "".
-	require.Equal(t, "", exampleJSON(make(chan int)))
+	require.Equal(t, "", cmdutil.ExampleJSON(make(chan int)))
 }
 
 func TestGenerateExamples(t *gotesting.T) {

--- a/cmd/svc/service-discovery/commands/root.go
+++ b/cmd/svc/service-discovery/commands/root.go
@@ -3,7 +3,6 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,15 +42,6 @@ var (
 	mode           string
 )
 
-// exampleJSON marshals v to indented JSON with color, returning empty string on error
-func exampleJSON(v interface{}) string {
-	b, err := json.MarshalIndent(v, "    ", "  ")
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 // generateExamples creates example responses from actual struct types
 func generateExamples() string {
 	pk1 := "02a49bc0aa1b5b78f638e9189be4c5d699e6d1358472d8a47f4c20daacd672d7e5"
@@ -87,19 +77,19 @@ DEL /api/services/deregister/{type} (NM auth headers: NM-PK, NM-Sign)
 
 GET /security/nonces/{pk}
   %s`,
-		exampleJSON(map[string]interface{}{
+		cmdutil.ExampleJSON(map[string]interface{}{
 			"build_info":   map[string]string{"version": "v1.3.29"},
 			"started_at":   "2024-01-15T10:00:00Z",
 			"dmsg_address": pk1 + ":80",
 			"dmsg_servers": []string{pk2},
 		}),
-		exampleJSON([]map[string]interface{}{serviceExample}),
-		exampleJSON(serviceExample),
-		exampleJSON(map[string]interface{}{
+		cmdutil.ExampleJSON([]map[string]interface{}{serviceExample}),
+		cmdutil.ExampleJSON(serviceExample),
+		cmdutil.ExampleJSON(map[string]interface{}{
 			"address": pk1 + ":3", "type": "vpn", "version": "v1.3.29",
 		}),
-		exampleJSON([]string{pk1, pk2}),
-		exampleJSON(map[string]interface{}{"nonce": 12345}),
+		cmdutil.ExampleJSON([]string{pk1, pk2}),
+		cmdutil.ExampleJSON(map[string]interface{}{"nonce": 12345}),
 	)
 }
 
@@ -187,7 +177,7 @@ func buildConfig() (*sd.Config, error) {
 		EntryTimeout: services.Duration(entryTimeout),
 		TestMode:     testMode,
 		Mode:         mode,
-		Whitelist:    commaSplit(whitelistKeys),
+		Whitelist:    cmdutil.CommaSplit(whitelistKeys),
 		GeoIP:        geoipURL,
 		DmsgPort:     dmsgPort,
 		Dmsg: cmdutil.DmsgConfig{
@@ -251,20 +241,6 @@ func mergeFile(dst, src *sd.Config) {
 	if len(src.Dmsg.Servers) > 0 {
 		dst.Dmsg.Servers = src.Dmsg.Servers
 	}
-}
-
-func commaSplit(s string) []string {
-	if s == "" {
-		return nil
-	}
-	out := make([]string, 0, 4)
-	for _, p := range strings.Split(s, ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			out = append(out, p)
-		}
-	}
-	return out
 }
 
 // Execute executes root CLI command.

--- a/cmd/svc/service-discovery/commands/root_test.go
+++ b/cmd/svc/service-discovery/commands/root_test.go
@@ -23,11 +23,11 @@ import (
 // ---- exampleJSON / generateExamples ----------------------------------------
 
 func TestExampleJSON(t *testing.T) {
-	out := exampleJSON(map[string]string{"version": "v1.3.29"})
+	out := cmdutil.ExampleJSON(map[string]string{"version": "v1.3.29"})
 	require.Contains(t, out, "v1.3.29")
 
 	// Unmarshalable value (channel) → json.MarshalIndent fails → "".
-	require.Equal(t, "", exampleJSON(make(chan int)))
+	require.Equal(t, "", cmdutil.ExampleJSON(make(chan int)))
 }
 
 func TestGenerateExamples(t *testing.T) {
@@ -42,10 +42,10 @@ func TestGenerateExamples(t *testing.T) {
 // ---- commaSplit ------------------------------------------------------------
 
 func TestCommaSplit(t *testing.T) {
-	require.Nil(t, commaSplit(""))
-	require.Equal(t, []string{"a", "b", "c"}, commaSplit("a, b ,c"))
-	require.Equal(t, []string{"x"}, commaSplit(" x "))
-	require.Empty(t, commaSplit(" , , ")) // all blank after trim
+	require.Nil(t, cmdutil.CommaSplit(""))
+	require.Equal(t, []string{"a", "b", "c"}, cmdutil.CommaSplit("a, b ,c"))
+	require.Equal(t, []string{"x"}, cmdutil.CommaSplit(" x "))
+	require.Empty(t, cmdutil.CommaSplit(" , , ")) // all blank after trim
 }
 
 // ---- buildConfig -----------------------------------------------------------

--- a/cmd/svc/setup-node/commands/root.go
+++ b/cmd/svc/setup-node/commands/root.go
@@ -37,15 +37,6 @@ var (
 	pprofAddr    string
 )
 
-// exampleJSON marshals v to indented JSON with color, returning empty string on error
-func exampleJSON(v interface{}) string {
-	b, err := json.MarshalIndent(v, "    ", "  ")
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 // generateExamples creates example config
 func generateExamples() string {
 	return fmt.Sprintf(`
@@ -55,7 +46,7 @@ Example Config:
 Generate Keys:
   skywire cli config gen-keys | tee sn-keys.txt
   # Line 1: public_key, Line 2: secret_key`,
-		exampleJSON(router.SetupConfig{
+		cmdutil.ExampleJSON(router.SetupConfig{
 			Dmsg: dmsgc.DmsgConfig{
 				Discovery:     deployment.Prod.DmsgDiscovery,
 				SessionsCount: 1,
@@ -220,7 +211,5 @@ var checkHealthCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/svc/setup-node/commands/root_test.go
+++ b/cmd/svc/setup-node/commands/root_test.go
@@ -9,16 +9,18 @@ import (
 	"os"
 	"testing"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestExampleJSON(t *testing.T) {
-	out := exampleJSON(map[string]string{"k": "v"})
+	out := cmdutil.ExampleJSON(map[string]string{"k": "v"})
 	require.Contains(t, out, "\"k\"")
 	require.Contains(t, out, "v")
 
 	// Unmarshalable value (channel) → json.MarshalIndent fails → "".
-	require.Equal(t, "", exampleJSON(make(chan int)))
+	require.Equal(t, "", cmdutil.ExampleJSON(make(chan int)))
 }
 
 func TestGenerateExamples(t *testing.T) {

--- a/cmd/svc/skywire-services/commands/root.go
+++ b/cmd/svc/skywire-services/commands/root.go
@@ -3,10 +3,11 @@ package commands
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
 
 	"github.com/spf13/cobra"
 
@@ -95,7 +96,5 @@ var RootCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/svc/stun-server/commands/root.go
+++ b/cmd/svc/stun-server/commands/root.go
@@ -4,7 +4,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -74,7 +73,5 @@ Requires two distinct IPs for full NAT type detection.
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/svc/sw-env/commands/root.go
+++ b/cmd/svc/sw-env/commands/root.go
@@ -3,10 +3,11 @@ package commands
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
 
 	"github.com/spf13/cobra"
 
@@ -84,7 +85,5 @@ var setupCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/svc/transport-discovery/commands/root.go
+++ b/cmd/svc/transport-discovery/commands/root.go
@@ -8,7 +8,6 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -77,15 +76,6 @@ func init() {
 	RootCmd.Flags().StringVar(&uptimeDB, "uptime-db", tpd.DefaultUptimeDB, "path for the service-self uptime bbolt store (empty disables)")
 }
 
-// exampleJSON marshals v to indented JSON with color, returning empty string on error
-func exampleJSON(v interface{}) string {
-	b, err := json.MarshalIndent(v, "    ", "  ")
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 // generateExamples creates example responses from actual struct types
 func generateExamples() string {
 	pk1 := "02a49bc0aa1b5b78f638e9189be4c5d699e6d1358472d8a47f4c20daacd672d7e5"
@@ -139,32 +129,32 @@ GET /uptimes
 
 GET /security/nonces/{pk}
   %s`,
-		exampleJSON(map[string]interface{}{
+		cmdutil.ExampleJSON(map[string]interface{}{
 			"build_info": map[string]string{"version": "v1.3.29"}, "started_at": "2024-01-15T10:00:00Z",
 			"dmsg_address": pk1 + ":80", "dmsg_servers": []string{pk2},
 		}),
-		exampleJSON([]map[string]interface{}{{
+		cmdutil.ExampleJSON([]map[string]interface{}{{
 			"entry":      map[string]interface{}{"t_id": tpID, "edges": []string{pk1, pk2}, "type": "stcpr"},
 			"signatures": []string{sig, sig}, "registered": 1705312800, "latency_ms": 45.2,
 		}}),
-		exampleJSON(map[string]interface{}{
+		cmdutil.ExampleJSON(map[string]interface{}{
 			"total_transports": 150, "by_type": map[string]int{"stcpr": 100, "sudph": 50}, "unique_visors": 75,
 		}),
-		exampleJSON(map[string]map[string]int{pk1: {"total": 5, "stcpr": 3, "sudph": 2}}),
-		exampleJSON(map[string]interface{}{
+		cmdutil.ExampleJSON(map[string]map[string]int{pk1: {"total": 5, "stcpr": 3, "sudph": 2}}),
+		cmdutil.ExampleJSON(map[string]interface{}{
 			"entry":      map[string]interface{}{"t_id": tpID, "edges": []string{pk1, pk2}, "type": "stcpr"},
 			"signatures": []string{sig, sig}, "registered": 1705312800,
 		}),
-		exampleJSON(map[string]interface{}{"total": 5, "by_type": map[string]int{"stcpr": 3, "sudph": 2}}),
-		exampleJSON([]map[string]interface{}{{
+		cmdutil.ExampleJSON(map[string]interface{}{"total": 5, "by_type": map[string]int{"stcpr": 3, "sudph": 2}}),
+		cmdutil.ExampleJSON([]map[string]interface{}{{
 			"entry":      map[string]interface{}{"t_id": tpID, "edges": []string{pk1, pk2}, "type": "stcpr"},
 			"signatures": []string{sig, sig},
 		}}),
-		exampleJSON([]string{tpID}),
-		exampleJSON([]transport.BandwidthData{{SentBytes: 1073741824, RecvBytes: 2147483648}}),
-		exampleJSON(transport.BandwidthData{SentBytes: 5368709120, RecvBytes: 10737418240}),
-		exampleJSON([]map[string]interface{}{{"pk": pk1, "on": true, "tp_count": 5}}),
-		exampleJSON(map[string]interface{}{"nonce": 12345}),
+		cmdutil.ExampleJSON([]string{tpID}),
+		cmdutil.ExampleJSON([]transport.BandwidthData{{SentBytes: 1073741824, RecvBytes: 2147483648}}),
+		cmdutil.ExampleJSON(transport.BandwidthData{SentBytes: 5368709120, RecvBytes: 10737418240}),
+		cmdutil.ExampleJSON([]map[string]interface{}{{"pk": pk1, "on": true, "tp_count": 5}}),
+		cmdutil.ExampleJSON(map[string]interface{}{"nonce": 12345}),
 	)
 }
 
@@ -248,7 +238,7 @@ func buildConfig() (*tpd.Config, error) {
 		Tag:             tag,
 		Testing:         testing,
 		Mode:            mode,
-		Whitelist:       commaSplit(whitelistKeys),
+		Whitelist:       cmdutil.CommaSplit(whitelistKeys),
 		TestEnvironment: testEnvironment,
 		StoreDataPath:   storeDataPath,
 		UptimeDB:        uptimeDB,
@@ -334,23 +324,7 @@ func mergeFile(dst, src *tpd.Config) {
 	}
 }
 
-func commaSplit(s string) []string {
-	if s == "" {
-		return nil
-	}
-	out := make([]string, 0, 4)
-	for _, p := range strings.Split(s, ",") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			out = append(out, p)
-		}
-	}
-	return out
-}
-
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/svc/transport-discovery/commands/root_test.go
+++ b/cmd/svc/transport-discovery/commands/root_test.go
@@ -26,11 +26,11 @@ import (
 // ---- exampleJSON / generateExamples ----------------------------------------
 
 func TestExampleJSON(t *gotesting.T) {
-	out := exampleJSON(map[string]string{"version": "v1.3.29"})
+	out := cmdutil.ExampleJSON(map[string]string{"version": "v1.3.29"})
 	require.Contains(t, out, "v1.3.29")
 
 	// Unmarshalable value (channel) → json.MarshalIndent fails → "".
-	require.Equal(t, "", exampleJSON(make(chan int)))
+	require.Equal(t, "", cmdutil.ExampleJSON(make(chan int)))
 }
 
 func TestGenerateExamples(t *gotesting.T) {
@@ -45,10 +45,10 @@ func TestGenerateExamples(t *gotesting.T) {
 // ---- commaSplit ------------------------------------------------------------
 
 func TestCommaSplit(t *gotesting.T) {
-	require.Nil(t, commaSplit(""))
-	require.Equal(t, []string{"a", "b", "c"}, commaSplit("a, b ,c"))
-	require.Equal(t, []string{"x"}, commaSplit(" x "))
-	require.Empty(t, commaSplit(" , , ")) // all blank after trim
+	require.Nil(t, cmdutil.CommaSplit(""))
+	require.Equal(t, []string{"a", "b", "c"}, cmdutil.CommaSplit("a, b ,c"))
+	require.Equal(t, []string{"x"}, cmdutil.CommaSplit(" x "))
+	require.Empty(t, cmdutil.CommaSplit(" , , ")) // all blank after trim
 }
 
 // ---- buildConfig -----------------------------------------------------------

--- a/cmd/svc/transport-setup/commands/root.go
+++ b/cmd/svc/transport-setup/commands/root.go
@@ -40,15 +40,6 @@ var (
 	nice       bool
 )
 
-// exampleJSON marshals v to indented JSON with color, returning empty string on error
-func exampleJSON(v interface{}) string {
-	b, err := json.MarshalIndent(v, "    ", "  ")
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 // generateExamples creates example responses from actual struct types
 func generateExamples() string {
 	exPK1 := "02a49bc0aa1b5b78f638e9189be4c5d699e6d1358472d8a47f4c20daacd672d7e5"
@@ -68,10 +59,10 @@ POST /remove
 
 GET /{pk}/transports
   %s`,
-		exampleJSON(api.TransportRequest{Type: "stcpr"}),
+		cmdutil.ExampleJSON(api.TransportRequest{Type: "stcpr"}),
 		exTPID,
-		exampleJSON(api.UUIDRequest{}),
-		exampleJSON([]map[string]interface{}{{
+		cmdutil.ExampleJSON(api.UUIDRequest{}),
+		cmdutil.ExampleJSON([]map[string]interface{}{{
 			"id": exTPID, "type": "stcpr",
 			"edges": []string{exPK1, exPK2},
 		}}),
@@ -116,7 +107,7 @@ HTTP Endpoints:
 ` + generateExamples() + `
 
 Example Config:
-` + exampleJSON(config.Config{
+` + cmdutil.ExampleJSON(config.Config{
 		Port: 8080,
 		Dmsg: dmsgc.DmsgConfig{
 			Discovery:     deployment.Prod.DmsgDiscovery,
@@ -253,7 +244,5 @@ var listTPCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/svc/transport-setup/commands/root_test.go
+++ b/cmd/svc/transport-setup/commands/root_test.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
@@ -33,11 +35,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestExampleJSON(t *testing.T) {
-	out := exampleJSON(map[string]string{"k": "v"})
+	out := cmdutil.ExampleJSON(map[string]string{"k": "v"})
 	require.Contains(t, out, "\"k\"")
 
 	// Unmarshalable value (channel) → json.MarshalIndent fails → "".
-	require.Equal(t, "", exampleJSON(make(chan int)))
+	require.Equal(t, "", cmdutil.ExampleJSON(make(chan int)))
 }
 
 func TestGenerateExamples(t *testing.T) {

--- a/cmd/svc/uptime-tracker/commands/root.go
+++ b/cmd/svc/uptime-tracker/commands/root.go
@@ -3,7 +3,6 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -89,15 +88,6 @@ func init() {
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dmsg|dual (default dual if --sk, else http; env SKYWIRE_SVC_MODE overrides)")
 }
 
-// exampleJSON marshals v to indented JSON with color, returning empty string on error
-func exampleJSON(v interface{}) string {
-	b, err := json.MarshalIndent(v, "    ", "  ")
-	if err != nil {
-		return ""
-	}
-	return string(b)
-}
-
 // generateExamples creates example responses from actual struct types
 func generateExamples() string {
 	exPK1 := "02a49bc0aa1b5b78f638e9189be4c5d699e6d1358472d8a47f4c20daacd672d7e5"
@@ -135,27 +125,27 @@ GET /visor-ips?month=all (private API)
 
 GET /security/nonces/{pk}
   %s`,
-		exampleJSON(map[string]interface{}{
+		cmdutil.ExampleJSON(map[string]interface{}{
 			"build_info":   map[string]string{"version": "v1.3.29"},
 			"started_at":   "2024-01-15T10:00:00Z",
 			"dmsg_address": exPK1 + ":80",
 			"dmsg_servers": []string{exPK2},
 		}),
-		exampleJSON([]map[string]interface{}{{
+		cmdutil.ExampleJSON([]map[string]interface{}{{
 			"pk": exPK1, "online": true, "version": "v1.3.29",
 			"ip": "192.168.1.1", "country": "US", "city": "New York",
 		}}),
-		exampleJSON(store.UptimeResponse{
+		cmdutil.ExampleJSON(store.UptimeResponse{
 			{Key: exPK1, Online: true, Version: "v1.3.29"},
 			{Key: exPK2, Online: false},
 		}),
-		exampleJSON(store.UptimeResponseV2{{
+		cmdutil.ExampleJSON(store.UptimeResponseV2{{
 			Key: exPK1, Online: true, Version: "v1.3.29",
 			DailyOnlineHistory: map[string]string{"2024-01-15": "95.5", "2024-01-14": "100.0"},
 		}}),
-		exampleJSON(store.UptimeDef{Key: exPK1, Online: true, Version: "v1.3.29"}),
-		exampleJSON(map[string]string{exPK1: "192.168.1.1", exPK2: "10.0.0.1"}),
-		exampleJSON(map[string]interface{}{"nonce": 12345}),
+		cmdutil.ExampleJSON(store.UptimeDef{Key: exPK1, Online: true, Version: "v1.3.29"}),
+		cmdutil.ExampleJSON(map[string]string{exPK1: "192.168.1.1", exPK2: "10.0.0.1"}),
+		cmdutil.ExampleJSON(map[string]interface{}{"nonce": 12345}),
 	)
 }
 

--- a/cmd/svc/uptime-tracker/commands/root_test.go
+++ b/cmd/svc/uptime-tracker/commands/root_test.go
@@ -9,17 +9,19 @@ import (
 	"strings"
 	gotesting "testing"
 
+	"github.com/skycoin/skywire/pkg/cmdutil"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestExampleJSON(t *gotesting.T) {
-	out := exampleJSON(map[string]string{"version": "v1.3.29"})
+	out := cmdutil.ExampleJSON(map[string]string{"version": "v1.3.29"})
 	require.Contains(t, out, "v1.3.29")
 	require.Contains(t, out, "version")
 
 	// An unmarshalable value (channel) makes json.MarshalIndent fail →
 	// exampleJSON returns "".
-	require.Equal(t, "", exampleJSON(make(chan int)))
+	require.Equal(t, "", cmdutil.ExampleJSON(make(chan int)))
 }
 
 func TestGenerateExamples(t *gotesting.T) {

--- a/cmd/version/commands/root.go
+++ b/cmd/version/commands/root.go
@@ -3,10 +3,11 @@ package commands
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
 
 	"github.com/spf13/cobra"
 
@@ -31,7 +32,5 @@ var RootCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal("Failed to execute command: ", err)
-	}
+	cmdutil.RunRoot(RootCmd)
 }

--- a/pkg/cmdutil/climisc.go
+++ b/pkg/cmdutil/climisc.go
@@ -1,0 +1,47 @@
+// Package cmdutil pkg/cmdutil/climisc.go c0-com-util
+package cmdutil
+
+import (
+	stdjson "encoding/json"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// RunRoot executes a cobra root command and exits fatally on error. It
+// centralizes the identical `func Execute()` wrapper that every command
+// package (svc, apps, cli) previously copied verbatim.
+func RunRoot(cmd *cobra.Command) {
+	if err := cmd.Execute(); err != nil {
+		log.Fatal("Failed to execute command: ", err)
+	}
+}
+
+// ExampleJSON renders v as indented JSON for use in CLI --help example
+// blocks. It returns "" on a marshal error. This centralizes the helper
+// that every deployment-service command package previously copied.
+func ExampleJSON(v interface{}) string {
+	b, err := stdjson.MarshalIndent(v, "    ", "  ")
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// CommaSplit splits a comma-separated string into trimmed, non-empty
+// fields. It returns nil for an empty input. This centralizes the helper
+// that several command packages previously copied.
+func CommaSplit(s string) []string {
+	if s == "" {
+		return nil
+	}
+	out := make([]string, 0, 4)
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/pkg/cmdutil/climisc_test.go
+++ b/pkg/cmdutil/climisc_test.go
@@ -1,0 +1,22 @@
+// Package cmdutil pkg/cmdutil/climisc_test.go c0-com-util
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExampleJSON(t *testing.T) {
+	assert.Contains(t, ExampleJSON(map[string]string{"k": "v"}), "\"k\"")
+	// a value that cannot be marshaled yields the empty string, not a panic.
+	assert.Equal(t, "", ExampleJSON(make(chan int)))
+}
+
+func TestCommaSplit(t *testing.T) {
+	assert.Nil(t, CommaSplit(""))
+	assert.Equal(t, []string{"a", "b", "c"}, CommaSplit("a, b ,c"))
+	assert.Equal(t, []string{"x"}, CommaSplit(" x "))
+	// all-blank-after-trim yields a non-nil but empty slice.
+	assert.Empty(t, CommaSplit(" , , "))
+}


### PR DESCRIPTION
Three helpers were copy-pasted verbatim across the command packages. This folds them into `pkg/cmdutil` and updates every call site (and its unit tests).

- `func Execute() { if err := RootCmd.Execute(); err != nil { log.Fatal(...) } }` — 24 byte-identical copies, all using the stdlib `log`. Replaced with `cmdutil.RunRoot(RootCmd)`, mirroring the existing `dmsgclient.Execute` precedent.
- `func exampleJSON(v interface{}) string` (the `json.MarshalIndent` help-example renderer) — 10 byte-identical copies in the `cmd/svc/*` command packages → `cmdutil.ExampleJSON`. The dmsg-discovery *colored* variant (`pretty.Color`) is intentionally left as-is.
- `func commaSplit(s string) []string` — 4 byte-identical copies → `cmdutil.CommaSplit`.

Behavior is preserved exactly: `RunRoot` uses stdlib `log.Fatal` (matching all 24 originals) and `ExampleJSON` uses stdlib `encoding/json` (the package aliases `json` to jsoniter, so the helper imports `encoding/json` explicitly). Net -159 lines across 41 files.

`go build .`, `go vet`, gofmt, and `go test` for every touched package pass locally.