### PR TITLE
fix(lint): misspell signalled -> signaled

### DIFF
--- a/pkg/transport/network/addrresolver/client_bind_test.go
+++ b/pkg/transport/network/addrresolver/client_bind_test.go
@@ -33,7 +33,7 @@ func TestBindQUIC(t *testing.T) {
 		defer srv.Close()
 
 		c := newReadyClient(t, srv)
-		// Public IP already signalled → bind does not wait the full timeout.
+		// Public IP already signaled → bind does not wait the full timeout.
 		c.SetPublicIP("", "")
 		require.NoError(t, c.BindQUIC(context.Background(), "30300"))
 		<-gotCh


### PR DESCRIPTION
golangci-lint (misspell) fails on develop at `pkg/transport/network/addrresolver/client_bind_test.go:36` — a comment typo blocking the lint job on every PR. One-word fix.