### PR TITLE
feat(proxystatus): live-push status.skysocks via SSE (drop full-page meta refresh)

### DIFF
--- a/pkg/proxystatus/proxystatus_test.go
+++ b/pkg/proxystatus/proxystatus_test.go
@@ -64,7 +64,10 @@ func TestRenderSections(t *testing.T) {
 	for _, want := range []string{
 		"<!doctype html>", "proxy status", "skysocks-client", "per-leg mux",
 		"stcpr", "recent log", "line two", "route control", "read-only preview",
-		"http-equiv=\"refresh\"", "standby", "status.dmsg", "status.skynet",
+		// live push (skysocks): the SSE script + swap target replace the old meta
+		// refresh, which must be gone for this surface.
+		"<main id=\"live\">", "EventSource", "/sse",
+		"standby", "status.dmsg", "status.skynet",
 		// route observability: route-latency column, direct/multihop badge, recv bar
 		"route rtt", "recv share", "direct", "multihop", "480 ms", "bar recv",
 		// full routes: section + full (untruncated) hop PKs + per-hop type/latency
@@ -83,6 +86,56 @@ func TestRenderSections(t *testing.T) {
 	// The current surface should not be linked back to itself in the footer.
 	if strings.Contains(page, `href="http://status.skysocks/"`) {
 		t.Error("footer should not link the current surface to itself")
+	}
+	// The skysocks surface is kept live by SSE, so the old meta refresh must be
+	// gone (it would fight the in-place swap with a full-page reload).
+	if strings.Contains(page, `http-equiv="refresh"`) {
+		t.Error("skysocks status page must not use meta refresh (SSE live-push replaces it)")
+	}
+}
+
+// TestRenderFragmentIsLiveRegionOnly verifies RenderFragment emits the live
+// content (pills/mux/log) WITHOUT the page shell, so it can be pushed as an SSE
+// payload and swapped into <main id="live">. It must be identical to the shell's
+// live region — same source of truth.
+func TestRenderFragmentIsLiveRegionOnly(t *testing.T) {
+	snap := Snapshot{
+		Surface: SurfaceSkysocks, App: "skysocks-client", Running: true,
+		Logs: []string{"frag line"},
+	}
+	frag := string(RenderFragment(snap))
+	for _, want := range []string{"per-leg mux", "recent log", "frag line", `class="pills"`} {
+		if !strings.Contains(frag, want) {
+			t.Errorf("fragment missing %q", want)
+		}
+	}
+	for _, unwanted := range []string{"<!doctype", "<html", "<head", "<style", "<main", "EventSource", "route control", "<footer"} {
+		if strings.Contains(frag, unwanted) {
+			t.Errorf("fragment must not contain shell/static markup %q", unwanted)
+		}
+	}
+	// The fragment must be exactly the inner HTML of the shell's <main id="live">.
+	page := string(Render(snap))
+	const open, closeTag = `<main id="live">`, `</main>`
+	i := strings.Index(page, open)
+	j := strings.Index(page, closeTag)
+	if i < 0 || j < 0 || j < i {
+		t.Fatal("shell is missing the <main id=\"live\"> live region")
+	}
+	if inner := page[i+len(open) : j]; inner != frag {
+		t.Errorf("fragment differs from shell live region:\n frag=%q\ninner=%q", frag, inner)
+	}
+}
+
+// TestRenderDmsgKeepsMetaRefresh guards that non-skysocks surfaces (no SSE
+// endpoint) keep the meta-refresh fallback and do NOT get the skysocks SSE script.
+func TestRenderDmsgKeepsMetaRefresh(t *testing.T) {
+	page := string(Render(Snapshot{Surface: SurfaceDmsg, App: "dmsgweb"}))
+	if !strings.Contains(page, `http-equiv="refresh"`) {
+		t.Error("dmsg status page should keep the meta-refresh fallback")
+	}
+	if strings.Contains(page, "EventSource") {
+		t.Error("dmsg status page must not emit the skysocks SSE script")
 	}
 }
 

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 )
 
-// refreshSeconds is how often the status page re-fetches itself. The page is a
-// point-in-time Snapshot rendered server-side (no JS/websocket), so a meta
-// refresh is how it stays live — frequent enough to watch a route warm, slow
-// enough not to thrash the proxy.
+// refreshSeconds is the fallback full-page reload cadence for surfaces that have
+// no live-push endpoint (status.dmsg, status.skynet). status.skysocks is kept in
+// sync by an SSE stream instead (see liveScript / RenderFragment) and omits the
+// meta refresh entirely.
 const refreshSeconds = 4
 
 // maxLogLines caps how many recent log lines the page renders, newest at the
@@ -20,49 +20,102 @@ const maxLogLines = 200
 // Render returns the full, self-contained HTML status page for snap. All
 // interpolated values are HTML-escaped; the page loads no external resource
 // (matching the proxies' strict no-network serving context).
+//
+// For the skysocks surface the live region (pills, per-leg mux, events, log) is
+// wrapped in <main id="live"> and kept current by an inline SSE script that swaps
+// just that element on each server push — the server-rendered markup is the
+// initial paint, so the page still works with JS/SSE unavailable. Other surfaces
+// have no SSE endpoint and fall back to a meta refresh, as before.
 func Render(snap Snapshot) []byte {
 	var b strings.Builder
 	surface := html.EscapeString(string(snap.Surface))
+	live := snap.Surface == SurfaceSkysocks
 	b.WriteString("<!doctype html><html lang=en><head><meta charset=utf-8>")
 	b.WriteString(`<meta name=viewport content="width=device-width, initial-scale=1">`)
-	fmt.Fprintf(&b, `<meta http-equiv="refresh" content="%d">`, refreshSeconds)
+	if !live {
+		fmt.Fprintf(&b, `<meta http-equiv="refresh" content="%d">`, refreshSeconds)
+	}
 	fmt.Fprintf(&b, "<title>%s proxy status · skywire</title><style>%s</style></head><body>", surface, css)
 
 	// Header + brand.
 	b.WriteString(`<header><div class="brand"><b>skywire</b> proxy status</div>`)
 	fmt.Fprintf(&b, `<div class="surface">%s</div></header>`, surface)
 
+	// Live region: server-rendered here for the initial paint, then (skysocks)
+	// swapped in place by the SSE script. RenderFragment renders the identical
+	// inner markup so there is one source of truth.
+	b.WriteString(`<main id="live">`)
+	writeLiveRegion(&b, snap)
+	b.WriteString(`</main>`)
+
+	writeControlSeam(&b, snap)
+	writeFooter(&b, snap)
+
+	if live {
+		b.WriteString(liveScript)
+	}
+
+	b.WriteString("</body></html>")
+	return []byte(b.String())
+}
+
+// RenderFragment renders ONLY the live region — the inner HTML of
+// <main id="live"> (pills, per-leg mux, events, recent log) — with no
+// <html>/<head>/<style> shell. It is the single source of truth for the live
+// markup: Render composes the page shell around it, and the skysocks-client SSE
+// handler pushes it verbatim so the browser swaps the region in place without a
+// full-page reload. Newlines in the fragment (the <pre> log block) are preserved
+// by the SSE framing (one data: line per source line), so no escaping is needed.
+func RenderFragment(snap Snapshot) []byte {
+	var b strings.Builder
+	writeLiveRegion(&b, snap)
+	return []byte(b.String())
+}
+
+// liveScript opens an EventSource to http://status.skysocks/sse and replaces the
+// live region's innerHTML on each push — a seamless live update in place of the
+// old jarring full-page meta refresh. Progressive enhancement: the server-
+// rendered initial paint stands alone, so the page still works with JS or SSE
+// unavailable. A healthy message cancels any pending fallback; if the stream
+// breaks and does not recover, it falls back to a slow (15s) reload rather than
+// the old 1–4s one. Emitted only for the skysocks surface (the only one with an
+// /sse handler).
+const liveScript = `<script>(function(){var t;function slow(){if(!t){t=setTimeout(function(){location.reload();},15000);}}` +
+	`try{var es=new EventSource("http://status.skysocks/sse");` +
+	`es.onmessage=function(e){if(t){clearTimeout(t);t=null;}var el=document.getElementById("live");if(el){el.innerHTML=e.data;}};` +
+	`es.onerror=function(){slow();};}catch(err){slow();}})();</script>`
+
+// writeLiveRegion writes the dynamic status content (pills, per-leg mux, events,
+// recent log) shared by Render (page shell) and RenderFragment (SSE push).
+func writeLiveRegion(b *strings.Builder, snap Snapshot) {
+	surface := html.EscapeString(string(snap.Surface))
+
 	// Status pills.
 	b.WriteString(`<div class="pills">`)
-	writePill(&b, "surface", surface, "")
-	writePill(&b, "app", html.EscapeString(snap.App), "")
+	writePill(b, "surface", surface, "")
+	writePill(b, "app", html.EscapeString(snap.App), "")
 	if snap.Running {
-		writePill(&b, "state", "running", "ok")
+		writePill(b, "state", "running", "ok")
 	} else {
-		writePill(&b, "state", "stopped", "warn")
+		writePill(b, "state", "stopped", "warn")
 	}
 	if len(snap.Legs) > 0 {
 		mux := "off"
 		if snap.MuxEnabled {
 			mux = "on"
 		}
-		writePill(&b, "mux", mux, "")
-		writePill(&b, "legs", fmt.Sprintf("%d", len(snap.Legs)), "")
+		writePill(b, "mux", mux, "")
+		writePill(b, "legs", fmt.Sprintf("%d", len(snap.Legs)), "")
 	}
 	b.WriteString(`</div>`)
 
 	if snap.Note != "" {
-		fmt.Fprintf(&b, `<p class="note">%s</p>`, html.EscapeString(snap.Note))
+		fmt.Fprintf(b, `<p class="note">%s</p>`, html.EscapeString(snap.Note))
 	}
 
-	writeMuxSection(&b, snap)
-	writeEventsSection(&b, snap)
-	writeLogsSection(&b, snap)
-	writeControlSeam(&b, snap)
-	writeFooter(&b, snap)
-
-	b.WriteString("</body></html>")
-	return []byte(b.String())
+	writeMuxSection(b, snap)
+	writeEventsSection(b, snap)
+	writeLogsSection(b, snap)
 }
 
 func writePill(b *strings.Builder, k, v, cls string) {

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -332,7 +332,7 @@ func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool) {
 	// leaf, so status.skysocks is HTTP-only by design.
 	if surface, ok := proxystatus.Match(host); ok && surface == proxystatus.SurfaceSkysocks {
 		clearDeadlines(conn, stream)
-		c.serveStatusPage(conn)
+		c.serveStatusPage(conn, stream)
 		return false
 	}
 
@@ -344,20 +344,121 @@ func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool) {
 	return true
 }
 
-// serveStatusPage completes the SOCKS5 CONNECT with a success reply, drains the
-// browser's (short, fixed-response) HTTP request, then writes the rendered
+// serveStatusPage completes the SOCKS5 CONNECT with a success reply, reads the
+// browser's HTTP request, and routes on its path: "/sse" opens a live Server-Sent
+// Events stream (serveStatusSSE); anything else gets the one-shot rendered
 // status.skysocks page. Best-effort: any write failure just drops the conn.
-func (c *Client) serveStatusPage(conn net.Conn) {
+func (c *Client) serveStatusPage(conn, stream net.Conn) {
 	// CONNECT success with a dummy BND.ADDR/PORT so the browser proceeds to send
 	// its HTTP request.
 	if _, err := conn.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
 		return
 	}
+	// Read the request so we can route on its path. status.skysocks is HTTP-only
+	// (the resolver CA forbids a .skysocks TLS leaf), so this is plaintext; a GET's
+	// request line + headers arrive in the first packet, so one bounded read is
+	// enough.
 	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
-	_, _ = conn.Read(make([]byte, 2048))                      //nolint:errcheck // drain request; page is fixed
-	_ = conn.SetReadDeadline(time.Time{})                     //nolint:errcheck
+	buf := make([]byte, 2048)
+	n, _ := conn.Read(buf)                //nolint:errcheck // best-effort; page is fixed
+	_ = conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+
+	if statusRequestPath(buf[:n]) == "/sse" {
+		// status is served entirely in-process, so the exit-side yamux stream is
+		// unused — close it now so a long-lived SSE stream doesn't pin one open.
+		stream.Close() //nolint:errcheck,gosec
+		c.serveStatusSSE(conn)
+		return
+	}
+
 	body := proxystatus.Render(c.statusSnapshot())
 	_, _ = conn.Write(statusHTTPResponse(body)) //nolint:errcheck
+}
+
+// statusRequestPath extracts the request-target path from an HTTP request line
+// ("METHOD SP PATH SP VERSION"), stripping any query string. It defaults to "/"
+// for anything it can't parse, so a malformed request falls through to the
+// full-page render rather than the SSE stream.
+func statusRequestPath(req []byte) string {
+	line := req
+	if i := bytes.IndexByte(line, '\n'); i >= 0 {
+		line = line[:i]
+	}
+	fields := bytes.Fields(line)
+	if len(fields) < 2 {
+		return "/"
+	}
+	p := fields[1]
+	if i := bytes.IndexByte(p, '?'); i >= 0 {
+		p = p[:i]
+	}
+	return string(p)
+}
+
+// SSE stream tuning. sseTickInterval is how often a fresh live-region fragment is
+// pushed — ~1s is responsive enough to watch a route warm without thrashing.
+// sseWriteTimeout bounds each write so a wedged/stalled browser conn errors out
+// (ending the goroutine) instead of blocking on a full send buffer forever.
+const (
+	sseTickInterval = time.Second
+	sseWriteTimeout = 10 * time.Second
+)
+
+// serveStatusSSE streams the live status region to the browser as Server-Sent
+// Events over the hijacked (plaintext HTTP/1.1) SOCKS stream: no TLS/upgrade
+// handshake, just an event-stream response the browser's EventSource consumes. It
+// writes the SSE header, pushes the current fragment immediately, then once per
+// tick. It returns — releasing this goroutine and the conn — when the client goes
+// away (write error / write deadline) or the client shuts down (closeC), so a
+// session reconnect or proxy restart cannot leak the goroutine. The loop is
+// ctx/timer-light (one ticker, no per-tick goroutine) so it is safe under the
+// single-threaded wasm runtime, though that path is not normally exercised there.
+func (c *Client) serveStatusSSE(conn net.Conn) {
+	const hdr = "HTTP/1.1 200 OK\r\n" +
+		"Content-Type: text/event-stream\r\n" +
+		"Cache-Control: no-store\r\n" +
+		"Connection: keep-alive\r\n\r\n"
+	_ = conn.SetWriteDeadline(time.Now().Add(sseWriteTimeout)) //nolint:errcheck
+	if _, err := conn.Write([]byte(hdr)); err != nil {
+		return
+	}
+
+	// Push once immediately so the client syncs without waiting a full tick.
+	if !c.writeSSEFragment(conn) {
+		return
+	}
+	ticker := time.NewTicker(sseTickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.closeC:
+			return
+		case <-ticker.C:
+			if !c.writeSSEFragment(conn) {
+				return
+			}
+		}
+	}
+}
+
+// writeSSEFragment renders the current live-region fragment (rebuilt each tick via
+// the same statusSnapshot() path the full page uses) and writes it as one SSE
+// event. The fragment's internal newlines (the <pre> log block) are preserved by
+// emitting one "data:" line per source line — the browser's EventSource rejoins
+// them with '\n' — so no newline escaping is needed. Returns false when the write
+// fails (client gone / past its write deadline), signaling the caller to stop.
+func (c *Client) writeSSEFragment(conn net.Conn) bool {
+	frag := proxystatus.RenderFragment(c.statusSnapshot())
+	var b bytes.Buffer
+	for _, line := range bytes.Split(frag, []byte("\n")) {
+		b.WriteString("data: ")
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	b.WriteByte('\n')                                          // blank line terminates the event
+	_ = conn.SetWriteDeadline(time.Now().Add(sseWriteTimeout)) //nolint:errcheck
+	_, err := conn.Write(b.Bytes())
+	return err == nil
 }
 
 // statusSnapshot builds the read-only status.skysocks snapshot. The rich

--- a/pkg/skysocks/client_status_test.go
+++ b/pkg/skysocks/client_status_test.go
@@ -176,6 +176,83 @@ func TestStatusSkysocksIntercepted(t *testing.T) {
 	}
 }
 
+// TestStatusSkysocksSSEStream verifies that a CONNECT to status.skysocks with an
+// HTTP request for /sse is answered in-process with an SSE event stream (the live
+// live-region fragment), not the one-shot full page, and is never forwarded to
+// the exit.
+func TestStatusSkysocksSSEStream(t *testing.T) {
+	c, exit := newTestClient(t)
+	defer c.Close() //nolint:errcheck
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()                              //nolint:errcheck
+	go func() { _ = c.ListenAndServe(addr) }() //nolint:errcheck
+	waitDial(t, addr)
+
+	conn := socks5Connect(t, addr, "status.skysocks", 80)
+	defer conn.Close() //nolint:errcheck
+	if _, err := conn.Write([]byte("GET /sse HTTP/1.1\r\nHost: status.skysocks\r\nAccept: text/event-stream\r\n\r\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
+	br := bufio.NewReader(conn)
+	// Status line + headers: must be an event-stream, not text/html.
+	statusLine, err := br.ReadString('\n')
+	if err != nil || !strings.HasPrefix(statusLine, "HTTP/1.1 200") {
+		t.Fatalf("bad SSE status line %q err=%v", statusLine, err)
+	}
+	var sawEventStream bool
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("reading SSE headers: %v", err)
+		}
+		if strings.Contains(strings.ToLower(line), "text/event-stream") {
+			sawEventStream = true
+		}
+		if line == "\r\n" || line == "\n" {
+			break // end of headers
+		}
+	}
+	if !sawEventStream {
+		t.Fatal("SSE response missing text/event-stream content-type")
+	}
+	// First pushed event: at least one data: line carrying the live fragment.
+	var gotData bool
+	for i := 0; i < 200; i++ {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("reading SSE event: %v", err)
+		}
+		if strings.HasPrefix(line, "data: ") {
+			gotData = true
+			if strings.Contains(line, "per-leg mux") {
+				break // reconstructed fragment reached the live region
+			}
+		}
+		if gotData && (line == "\n" || line == "\r\n") {
+			break // event terminated
+		}
+	}
+	if !gotData {
+		t.Fatal("SSE stream produced no data: event")
+	}
+
+	// The exit must never have received a status.skysocks CONNECT.
+	select {
+	case h := <-exit.hostC:
+		if h == "status.skysocks" {
+			t.Fatal("status.skysocks /sse leaked to the exit")
+		}
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
 // TestNonStatusForwardedToExit verifies a regular CONNECT is transparently
 // forwarded to the exit (greeting + request byte-for-byte) and the tunnel
 // carries payload end-to-end.


### PR DESCRIPTION
`http://status.skysocks/` currently stays live with a `<meta http-equiv=refresh content=4>` — a full-page reload every 4s that resets scroll and flashes the page. This swaps that for a Server-Sent Events stream so the page is kept in sync by server push and updates in place.

SSE is the right fit here: one-way server→client over plain HTTP/1.1, which is all that works over the HTTP-only hijacked-SOCKS-CONNECT stream that serves this page (`.skysocks` can't get a TLS leaf, so no WebSocket upgrade over TLS).

**proxystatus** — `Render` is split into a page shell plus `RenderFragment`, the single source of truth for the live region (pills, per-leg mux, events, log) wrapped in `<main id="live">`. The server-rendered markup is still the initial paint, so the page works fine with JS/SSE unavailable (progressive enhancement); an inline script opens `EventSource("http://status.skysocks/sse")` and replaces just `#live` on each push, falling back to a slow 15s reload only if the stream breaks and doesn't recover. Only the skysocks surface (the one with an `/sse` handler) gets this — `status.dmsg` and `status.skynet` keep the meta-refresh fallback unchanged.

**skysocks-client** — the CONNECT sniff path already read the browser's HTTP request, so it now routes on the request-line path: `/sse` opens the event stream (event-stream header, then the current fragment immediately and once per second, rebuilt via the same snapshot path the full page uses); anything else gets the one-shot page as before, byte-identical. Each write has a deadline and the loop selects on the client's `closeC`, so a wedged conn or a session reconnect / proxy restart can't leak the goroutine — the browser's EventSource then auto-reconnects against the fresh client. Fragment newlines (the `<pre>` log block) are preserved by emitting one `data:` line per source line, which the browser rejoins. The unused exit-side yamux stream is closed before entering a long-lived SSE loop so it isn't pinned open.

No change to the #4125 data path or the per-layer status scoping.

Verified locally: `go build .` and `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor` both pass; `go vet` and `go test ./pkg/skysocks/... ./pkg/proxystatus/...` green (added an end-to-end `/sse` interception test and fragment/shell-parity tests). Not exercised against a live browser over SOCKS in this run.