### PR TITLE
test(transport): regression guard for outbound re-register nudge (#4122)

### DIFF
--- a/pkg/transport/manager_regnudge_test.go
+++ b/pkg/transport/manager_regnudge_test.go
@@ -1,0 +1,197 @@
+// Package transport — pkg/transport/manager_regnudge_test.go: regression guard
+// for the outbound re-register nudge (#4122).
+//
+// The bug: a dial-only visor (a browser/wasm visor never accepts inbound
+// transports) never hit the transport manager's re-register NUDGE, which was
+// sent only from the transport-ACCEPT path. So after such a visor dialed OUT,
+// its CXO tp-list snapshot was published only on the 90s re-register ticker —
+// leaving it unroutable ("transport not found") for up to 90s, which for a
+// short-lived tab is effectively forever.
+//
+// The fix (manager.go, saveTransportInternal): after a successful OUTBOUND
+// transport save, send on tm.regNudge (non-blocking), symmetric with the accept
+// path. The re-register loop debounces ~5s and publishes the tp-list snapshot.
+//
+// This test asserts the user-visible OUTCOME rather than poking the unexported
+// channel directly: with a CXO leaf publisher installed, a successful outbound
+// SaveTransport causes the publisher's Put("tp-list", …) to fire PROMPTLY —
+// well inside the 90s ticker window. Before the fix, no publish would occur
+// until that 90s ticker; the generous 10s timeout below would then fail.
+package transport
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport/network"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// blockingTransport is a network.Transport whose Read blocks until Close, so a
+// transport installed by a successful SaveTransport stays "serving" for the
+// duration of the test instead of tearing down on an immediate EOF (which would
+// remove it from tm.tps and could itself trigger a deletion-path publish,
+// muddying the assertion). Its non-Read surface mirrors memTransport.
+type blockingTransport struct {
+	done     chan struct{}
+	once     sync.Once
+	lpk, rpk cipher.PubKey
+	nw       types.Type
+}
+
+func newBlockingTransport(lpk, rpk cipher.PubKey, nw types.Type) *blockingTransport {
+	return &blockingTransport{done: make(chan struct{}), lpk: lpk, rpk: rpk, nw: nw}
+}
+
+func (t *blockingTransport) Read([]byte) (int, error) {
+	<-t.done // block until closed, then report EOF
+	return 0, io.EOF
+}
+func (t *blockingTransport) Write(p []byte) (int, error) {
+	select {
+	case <-t.done:
+		return 0, net.ErrClosed
+	default:
+		return len(p), nil
+	}
+}
+func (t *blockingTransport) Close() error {
+	t.once.Do(func() { close(t.done) })
+	return nil
+}
+func (t *blockingTransport) LocalAddr() net.Addr              { return &net.TCPAddr{} }
+func (t *blockingTransport) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
+func (t *blockingTransport) SetDeadline(time.Time) error      { return nil }
+func (t *blockingTransport) SetReadDeadline(time.Time) error  { return nil }
+func (t *blockingTransport) SetWriteDeadline(time.Time) error { return nil }
+func (t *blockingTransport) LocalPK() cipher.PubKey           { return t.lpk }
+func (t *blockingTransport) RemotePK() cipher.PubKey          { return t.rpk }
+func (t *blockingTransport) LocalPort() uint16                { return 0 }
+func (t *blockingTransport) RemotePort() uint16               { return 0 }
+func (t *blockingTransport) LocalRawAddr() net.Addr           { return &net.TCPAddr{} }
+func (t *blockingTransport) RemoteRawAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 5000}
+}
+func (t *blockingTransport) Network() types.Type { return t.nw }
+
+// dialingClient is a network.Client whose Dial always succeeds, handing back the
+// same long-lived blockingTransport. It is enough to drive saveTransportInternal
+// through a real OUTBOUND save: with SaveTransportNoRegister the manager swaps in
+// a noop discovery client, which skips the settlement handshake — so a working
+// Dial is all that's needed for the outbound path (and its nudge) to run.
+type dialingClient struct {
+	pk  cipher.PubKey
+	sk  cipher.SecKey
+	typ types.Type
+	tp  network.Transport
+}
+
+func (c *dialingClient) Dial(context.Context, cipher.PubKey, uint16) (network.Transport, error) {
+	return c.tp, nil
+}
+func (c *dialingClient) Start() error { return nil }
+func (c *dialingClient) Listen(uint16) (network.Listener, error) {
+	return nil, io.ErrClosedPipe
+}
+func (c *dialingClient) LocalAddr() (net.Addr, error) { return &net.TCPAddr{}, nil }
+func (c *dialingClient) PK() cipher.PubKey            { return c.pk }
+func (c *dialingClient) SK() cipher.SecKey            { return c.sk }
+func (c *dialingClient) Close() error                 { return nil }
+func (c *dialingClient) Type() types.Type             { return c.typ }
+
+// nudgeLeafPub records tp-list publishes and signals on tpListCh the first time
+// the snapshot leaf (tpdListPath) is Put — the observable effect of the nudge.
+type nudgeLeafPub struct {
+	mu       sync.Mutex
+	putPaths []string
+	tpListCh chan struct{}
+}
+
+func newNudgeLeafPub() *nudgeLeafPub {
+	return &nudgeLeafPub{tpListCh: make(chan struct{}, 1)}
+}
+
+func (p *nudgeLeafPub) Put(path string, _ []byte) error {
+	p.mu.Lock()
+	p.putPaths = append(p.putPaths, path)
+	p.mu.Unlock()
+	if path == tpdListPath {
+		select {
+		case p.tpListCh <- struct{}{}:
+		default:
+		}
+	}
+	return nil
+}
+func (p *nudgeLeafPub) Delete(string) error { return nil }
+
+// TestOutboundSaveNudgesReRegister is the #4122 regression guard: a successful
+// OUTBOUND SaveTransport must nudge the re-register loop so the tp-list snapshot
+// is published promptly, not only on the 90s ticker.
+func TestOutboundSaveNudgesReRegister(t *testing.T) {
+	tm := newTestManager(t)
+	// saveTransportInternal builds the ManagedTransport with tm.Conf.LogStore;
+	// the bare test manager has none, so give it an in-memory store.
+	tm.Conf.LogStore = InMemoryTransportLogStore()
+
+	const nw = types.STCPR
+	client := &dialingClient{
+		pk:  tm.Conf.PubKey,
+		sk:  tm.Conf.SecKey,
+		typ: nw,
+		tp:  newBlockingTransport(tm.Conf.PubKey, mustPK(t), nw),
+	}
+	tm.mx.Lock()
+	tm.netClients[nw] = client
+	tm.mx.Unlock()
+
+	// Install the CXO leaf publisher so re-registration takes the CXO snapshot
+	// path (publishTPDList) instead of the HTTP fallback.
+	pub := newNudgeLeafPub()
+	tm.SetTPDLeafPublisher(pub)
+
+	// Start the manager's background loops (runReRegisterTransports lives here).
+	// Teardown cancels the context (the loops select on ctx.Done) and closes the
+	// underlying transport to unblock the serving read loop. We deliberately do
+	// NOT call tm.Close(): it waits on the serve WaitGroup while holding tm.mx,
+	// which can wedge a unit test; cancelling the context stops every loop and
+	// the leaked goroutines exit with the process.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		client.tp.Close()
+	}()
+	tm.Serve(ctx)
+
+	// A dial-only visor: dial OUT to a peer. NoRegister keeps this a pure unit
+	// test (noop discovery → no settlement handshake, no live TPD) while still
+	// running the real saveTransportInternal outbound path — including the nudge.
+	remote := mustPK(t)
+	mTp, err := tm.SaveTransportNoRegister(ctx, remote, nw, LabelUser)
+	require.NoError(t, err)
+	require.NotNil(t, mTp)
+
+	// The re-register loop debounces ~5s before publishing. A tp-list Put well
+	// inside 10s proves the outbound nudge fired. Before #4122 the first publish
+	// would wait the full 90s ticker and this would time out.
+	select {
+	case <-pub.tpListCh:
+		// success: prompt snapshot publish triggered by the outbound nudge.
+	case <-time.After(10 * time.Second):
+		t.Fatal("no tp-list snapshot published within 10s of an outbound SaveTransport: " +
+			"the re-register nudge did not fire (regression of #4122; before the fix a " +
+			"dial-only visor waited the full 90s re-register ticker)")
+	}
+
+	// The published leaf must be the transport-list snapshot path.
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	require.Contains(t, pub.putPaths, tpdListPath)
+}

--- a/scripts/wasm-headless/harness.mjs
+++ b/scripts/wasm-headless/harness.mjs
@@ -107,5 +107,55 @@ try { aboutObj = JSON.parse(aboutBody); } catch { die(`/api/about not JSON: ${ab
 if (!aboutObj.dmsg_connected) die(`/api/about reports dmsg_connected=false: ${aboutBody.slice(0, 200)}`);
 console.log('hvApi /api/about OK:', aboutBody.slice(0, 120));
 
-console.log('PASS: headless wasm-visor boot → dmsg(ws) → /api core');
+// --- transport-registration introspection smoke -----------------------------
+// Assert the NEW transport_registration object that visorStats() folds in
+// (#4122's introspection surface). This is a SMOKE of the surface's SHAPE, not
+// of a real registration: the loopback dmsg seed has no transport PEER and no
+// live TPD, so there is nothing to dial and nothing to publish a tp-list FOR.
+// We therefore assert only what must hold in an isolated boot — the in-memory
+// CXO publisher came up (publisher_up) and the object is well-formed — and
+// deliberately do NOT assert live_count>0 or tp_list.publishes>0 (no peer).
+//
+// GAP (known backlog): proving that an actual OUTBOUND transport publishes its
+// tp-list PROMPTLY (the #4122 nudge) and becomes route-findable needs a
+// loopback transport PEER + a TPD to ingest the snapshot — a larger harness
+// build-out. Until that exists, the deterministic guard for the nudge itself is
+// the Go unit test TestOutboundSaveNudgesReRegister in
+// pkg/transport/manager_regnudge_test.go, which drives a real outbound
+// SaveTransport and asserts the tp-list snapshot Put fires within the debounce
+// window (well under the 90s re-register ticker).
+if (typeof globalThis.skywireVisor.visorStats !== 'function') {
+  die('skywireVisor.visorStats is not a function (introspection surface missing)');
+}
+const readStats = () => {
+  const raw = globalThis.skywireVisor.visorStats();
+  return typeof raw === 'string' ? JSON.parse(raw) : raw;
+};
+// The telemetry publisher is brought up during boot; poll briefly so a slow
+// bring-up doesn't flake the shape assertions below.
+let treg;
+const regDeadline = Date.now() + DMSG_TIMEOUT_MS;
+for (;;) {
+  const stats = readStats();
+  treg = stats.transport_registration;
+  if (treg && treg.publisher_up === true) break;
+  if (Date.now() > regDeadline) {
+    die(`transport_registration.publisher_up never became true within ${DMSG_TIMEOUT_MS}ms: ` +
+        JSON.stringify(treg));
+  }
+  await sleep(250);
+}
+if (typeof treg !== 'object' || treg === null) die(`transport_registration is not an object: ${JSON.stringify(treg)}`);
+if (treg.publisher_up !== true) die(`transport_registration.publisher_up !== true: ${JSON.stringify(treg)}`);
+for (const k of ['tp_list', 'announce', 'publish_state', 'feed']) {
+  if (!(k in treg)) die(`transport_registration missing key '${k}': ${JSON.stringify(Object.keys(treg))}`);
+}
+if (typeof treg.tp_list !== 'object' || treg.tp_list === null) die(`transport_registration.tp_list is not an object`);
+if (typeof treg.announce !== 'object' || treg.announce === null) die(`transport_registration.announce is not an object`);
+if (typeof treg.publish_state !== 'object' || treg.publish_state === null) die(`transport_registration.publish_state is not an object`);
+if (typeof treg.publish_state.frozen !== 'boolean') die(`transport_registration.publish_state.frozen is not a boolean: ${JSON.stringify(treg.publish_state)}`);
+if (typeof treg.feed !== 'string' || treg.feed.length === 0) die(`transport_registration.feed is not a non-empty string: ${JSON.stringify(treg.feed)}`);
+console.log(`visorStats transport_registration OK: publisher_up=true feed=${treg.feed.slice(0, 8)} frozen=${treg.publish_state.frozen}`);
+
+console.log('PASS: headless wasm-visor boot → dmsg(ws) → /api core → transport_registration introspection');
 process.exit(0);


### PR DESCRIPTION
Adds regression-test coverage for the #4122 fix: a dial-only visor (browser/wasm, which never accepts inbound transports) never hit the transport manager's re-register nudge, since that nudge was sent only from the accept path. Its CXO `tp-list` snapshot was therefore published only on the 90s re-register ticker, leaving it unroutable ("transport not found") for up to 90s after dialing out. #4122 sends a symmetric nudge after a successful outbound save.

Two guards:

- `pkg/transport/manager_regnudge_test.go` — white-box behavioral test. Drives a real outbound `SaveTransport` (using `NoRegister`, which swaps in the noop discovery client and skips the settlement handshake, so a minimal dialing mock suffices), installs a fake CXO leaf publisher, and asserts the `tp-list` snapshot `Put` fires within the ~5s re-register debounce window (10s timeout, well under the 90s ticker). Confirmed it fails (times out at 10s) when the outbound nudge is removed.

- `scripts/wasm-headless/harness.mjs` — extends the headless wasm smoke to call `skywireVisor.visorStats()` and assert the new `transport_registration` object is present and well-formed: `publisher_up === true`, plus `tp_list`, `announce`, `publish_state` (with a `frozen` boolean) and `feed`. This is a shape smoke of the introspection surface; the loopback has no transport peer or TPD, so it deliberately does not assert `live_count>0` or `tp_list.publishes>0`.

The remaining gap — asserting an actual outbound transport publishes its `tp-list` promptly and becomes route-findable — needs a loopback transport peer + TPD (a larger harness build-out, noted as a known backlog item in the harness comment). The unit test covers the nudge logic deterministically in the meantime.

Verification:
- `go test ./pkg/transport/...` passes (transport package 5.8s).
- `go build .` passes; `go vet ./pkg/transport/...` and gofmt/goimports clean.
- `bash scripts/wasm-headless/run.sh` ran locally end-to-end: `visorStats transport_registration OK: publisher_up=true`, `PASS: headless wasm-visor boot → dmsg(ws) → /api core → transport_registration introspection`.