### PR TITLE
fix(skysocks): keep status.skysocks reachable when the exit route is down

### DIFF
--- a/pkg/proxyinterstitial/interstitial.go
+++ b/pkg/proxyinterstitial/interstitial.go
@@ -266,7 +266,17 @@ func ShouldServe(port string) bool {
 // corrupted. Best-effort and deadline-bounded so it never stalls the client's
 // reconnect. Returns nil if it served a page, an error otherwise; the caller
 // closes conn regardless.
-func ServeSOCKS5(conn net.Conn, detail, mechanism string) error {
+//
+// statusOverride lets the caller answer a reserved in-process host (e.g.
+// status.skysocks) itself instead of the interstitial: once the CONNECT target
+// host is parsed and the SOCKS5 reply + browser request have been exchanged, if
+// statusOverride != nil and it returns a non-nil body for that host, the body is
+// written verbatim as the HTTP response and the interstitial is skipped. This
+// keeps the reserved status page reachable exactly when the exit is down — the
+// moment the user most needs to see why — which the interstitial would otherwise
+// shadow. Pass nil for the plain interstitial-only behaviour. The closure lives
+// in the caller so this package stays free of any pkg/proxystatus dependency.
+func ServeSOCKS5(conn net.Conn, detail, mechanism string, statusOverride func(host string) []byte) error {
 	_ = conn.SetDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
 	defer conn.SetDeadline(time.Time{})                   //nolint:errcheck
 
@@ -339,9 +349,18 @@ func ServeSOCKS5(conn net.Conn, detail, mechanism string) error {
 		return err
 	}
 	// Drain a chunk of the (short) HTTP request so the browser's write
-	// completes, then answer with the interstitial. We don't need the request
-	// contents — the page is fixed. Bounded single read; ignore EOF.
+	// completes, then answer. We don't need the request contents — the response
+	// is fixed. Bounded single read; ignore EOF.
 	_, _ = conn.Read(make([]byte, 1024)) //nolint:errcheck
+	// A reserved in-process host (e.g. status.skysocks) is answered by the
+	// caller's override rather than the interstitial, so it stays reachable
+	// while the exit is down.
+	if statusOverride != nil {
+		if body := statusOverride(host); body != nil {
+			_, err := conn.Write(body)
+			return err
+		}
+	}
 	_, err := conn.Write(httpResponse(host, detail, mechanism, false))
 	return err
 }

--- a/pkg/proxyinterstitial/interstitial_test.go
+++ b/pkg/proxyinterstitial/interstitial_test.go
@@ -99,7 +99,7 @@ func TestServeSOCKS5_HTTPPort(t *testing.T) {
 	cli, srv := net.Pipe()
 	defer cli.Close() //nolint:errcheck
 	done := make(chan error, 1)
-	go func() { done <- ServeSOCKS5(srv, "", "skysocks"); srv.Close() }() //nolint:errcheck,gosec
+	go func() { done <- ServeSOCKS5(srv, "", "skysocks", nil); srv.Close() }() //nolint:errcheck,gosec
 
 	_ = cli.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
 	// greeting: VER=5, 1 method, no-auth
@@ -153,7 +153,7 @@ func TestServeSOCKS5_HTTPSDeclined(t *testing.T) {
 	cli, srv := net.Pipe()
 	defer cli.Close() //nolint:errcheck
 	done := make(chan error, 1)
-	go func() { done <- ServeSOCKS5(srv, "", "skysocks"); srv.Close() }() //nolint:errcheck,gosec
+	go func() { done <- ServeSOCKS5(srv, "", "skysocks", nil); srv.Close() }() //nolint:errcheck,gosec
 
 	_ = cli.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
 	cli.Write([]byte{0x05, 0x01, 0x00})                  //nolint:errcheck,gosec
@@ -163,6 +163,96 @@ func TestServeSOCKS5_HTTPSDeclined(t *testing.T) {
 	if err := <-done; err == nil {
 		t.Error("expected ServeSOCKS5 to decline the 443 request")
 	}
+}
+
+// serveSOCKS5CONNECT drives the client half of a SOCKS5 no-auth CONNECT to the
+// given domain:port over cli and returns the full response body the server
+// wrote back (the CONNECT reply is consumed here). Shared by the override tests.
+func serveSOCKS5CONNECT(t *testing.T, cli net.Conn, host string, port uint16) string {
+	t.Helper()
+	_ = cli.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
+	if _, err := cli.Write([]byte{0x05, 0x01, 0x00}); err != nil {
+		t.Fatal(err)
+	}
+	sel := make([]byte, 2)
+	if _, err := io.ReadFull(cli, sel); err != nil {
+		t.Fatal(err)
+	}
+	req := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))}
+	req = append(req, []byte(host)...)
+	req = append(req, byte(port>>8), byte(port))
+	if _, err := cli.Write(req); err != nil {
+		t.Fatal(err)
+	}
+	reply := make([]byte, 10)
+	if _, err := io.ReadFull(cli, reply); err != nil {
+		t.Fatal(err)
+	}
+	if reply[0] != 0x05 || reply[1] != 0x00 {
+		t.Fatalf("connect reply = %v", reply)
+	}
+	if _, err := cli.Write([]byte("GET / HTTP/1.1\r\nHost: " + host + "\r\n\r\n")); err != nil {
+		t.Fatal(err)
+	}
+	var got bytes.Buffer
+	buf := make([]byte, 4096)
+	for {
+		n, err := cli.Read(buf)
+		got.Write(buf[:n])
+		if err != nil {
+			break
+		}
+	}
+	return got.String()
+}
+
+// TestServeSOCKS5_StatusOverride verifies that when a statusOverride is supplied
+// (as skysocks-client does with its status.skysocks page), a CONNECT to the
+// reserved host is answered with the override body — not the interstitial —
+// exactly when the exit is down, while a normal host still gets the interstitial.
+func TestServeSOCKS5_StatusOverride(t *testing.T) {
+	const statusHost = "status.skysocks"
+	const statusBody = "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nSTATUS-PAGE"
+	override := func(host string) []byte {
+		if host == statusHost {
+			return []byte(statusBody)
+		}
+		return nil
+	}
+
+	t.Run("reserved host serves override", func(t *testing.T) {
+		cli, srv := net.Pipe()
+		defer cli.Close() //nolint:errcheck
+		done := make(chan error, 1)
+		go func() { done <- ServeSOCKS5(srv, "", "skysocks", override); srv.Close() }() //nolint:errcheck,gosec
+		got := serveSOCKS5CONNECT(t, cli, statusHost, 80)
+		if !strings.Contains(got, "STATUS-PAGE") {
+			t.Errorf("status host did not receive override; got %q", got)
+		}
+		if strings.Contains(got, "Building a route") {
+			t.Errorf("status host was shadowed by the interstitial; got %q", got)
+		}
+		if err := <-done; err != nil {
+			t.Errorf("ServeSOCKS5: %v", err)
+		}
+	})
+
+	t.Run("normal host still serves interstitial", func(t *testing.T) {
+		cli, srv := net.Pipe()
+		defer cli.Close() //nolint:errcheck
+		done := make(chan error, 1)
+		go func() { done <- ServeSOCKS5(srv, "", "skysocks", override); srv.Close() }() //nolint:errcheck,gosec
+		got := serveSOCKS5CONNECT(t, cli, "example.com", 80)
+		if !strings.Contains(got, "Building a route") {
+			t.Errorf("normal host did not receive interstitial; got %q", got)
+		}
+		if strings.Contains(got, "STATUS-PAGE") {
+			t.Errorf("normal host wrongly got the override; got %q", got)
+		}
+		if err := <-done; err != nil {
+			t.Errorf("ServeSOCKS5: %v", err)
+		}
+	})
 }
 
 // TestDumpSamples writes the two page variants to the scratchpad for a manual

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -98,9 +98,12 @@ func (c *Client) ListenAndServe(addr string) error {
 			// route is back, instead of a bare connection failure. Best-effort
 			// and deadline-bounded (see ServeSOCKS5); declined for HTTPS/other
 			// ports. Runs in a goroutine that owns conn so the reconnect below
-			// isn't delayed by a slow browser.
+			// isn't delayed by a slow browser. The status.skysocks override
+			// keeps the in-process status page reachable even now (exit down)
+			// instead of being shadowed by the interstitial — status.skysocks
+			// needs no exit stream, and this is exactly when the user wants it.
 			go func(bc net.Conn) {
-				if serr := proxyinterstitial.ServeSOCKS5(bc, proxyinterstitial.StatusLine(err), "skysocks"); serr != nil && c.appCl != nil {
+				if serr := proxyinterstitial.ServeSOCKS5(bc, proxyinterstitial.StatusLine(err), "skysocks", c.statusOverride); serr != nil && c.appCl != nil {
 					c.appCl.Log().Debugf("route-down interstitial not served: %v", serr)
 				}
 				bc.Close() //nolint:errcheck,gosec
@@ -342,6 +345,23 @@ func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool) {
 	}
 	clearDeadlines(conn, stream)
 	return true
+}
+
+// statusOverride is the reserved-host answer handed to
+// proxyinterstitial.ServeSOCKS5's route-down path: for the status.skysocks host
+// it returns the rendered status page (the same one-shot bytes serveStatusPage
+// writes), so the page stays reachable while the exit stream is down instead of
+// being shadowed by the interstitial. Any other host returns nil, leaving the
+// interstitial in place. statusSnapshot already reports "no active session to
+// the exit" when the session is down, which is the correct content here. (Only
+// the one-shot page is served on this path — the SSE variant needs a live
+// stream that the override's fixed-body model can't carry; the page's own
+// meta-refresh keeps it current.)
+func (c *Client) statusOverride(host string) []byte {
+	if surface, ok := proxystatus.Match(host); ok && surface == proxystatus.SurfaceSkysocks {
+		return statusHTTPResponse(proxystatus.Render(c.statusSnapshot()))
+	}
+	return nil
 }
 
 // serveStatusPage completes the SOCKS5 CONNECT with a success reply, reads the


### PR DESCRIPTION
When the exit route is down or churning, `http://status.skysocks/` showed the "building a route" interstitial instead of the status page — precisely when a user opens the status page to find out *why* the route is down.

## Cause

`skysocks-client`'s accept loop opens the exit stream (`session.Open`) *before* any `status.skysocks` check. On a failed `Open` (exit restart / all mux legs dropped) it served the route-down interstitial and returned, so `sniffSOCKS5Status` — which answers `status.skysocks` in-process — never ran. The status page needs no exit stream: `statusSnapshot` already reports "no active session to the exit", which is the correct content in that state.

## Fix

`proxyinterstitial.ServeSOCKS5` gains a `statusOverride func(host string) []byte` parameter (nil keeps prior behaviour). After the CONNECT host is parsed and the SOCKS5 reply + browser request are exchanged, a non-nil override body for that host is written in place of the interstitial. `skysocks-client` passes an override that renders the `status.skysocks` page for the reserved host (matched via `proxystatus.Match`). The closure lives in the caller, so `pkg/proxyinterstitial` gains no `pkg/proxystatus` dependency and there is no import cycle.

Only the one-shot page is served on this path; the SSE variant needs a live stream the fixed-body override can't carry, and the page's own meta-refresh keeps it current.

## Tests

Added `TestServeSOCKS5_StatusOverride`: exit-down + a `status.skysocks` CONNECT serves the override (not the interstitial); exit-down + a normal host still serves the interstitial. `go build .`, `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor`, `go vet`, gofmt, and `go test ./pkg/skysocks/... ./pkg/proxyinterstitial/...` all pass.