### PR TITLE
fix(proxystatus): label a 1-hop leg 'direct' regardless of route-group orientation

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -397,9 +397,18 @@ func (rg *RouteGroup) MuxStats() MuxInfo {
 			// TRUE end-to-end route latency (all hops), from the leg-liveness
 			// pong — distinct from the first-hop transport RTT above.
 			leg.RouteLatencyMS = rg.legEndToEndLatencyMs(tp.Entry.ID)
-			// Direct = this leg's first hop reaches the destination itself,
-			// i.e. a 1-hop route; otherwise it is relayed (multihop).
-			leg.Direct = tp.Remote() == dstPK
+			// Direct = this leg's first hop reaches the route group's FAR
+			// endpoint itself, i.e. a 1-hop route; otherwise it is relayed
+			// (multihop). The far endpoint is whichever descriptor end is not
+			// this visor: for a client-initiated route group (e.g. skysocks-
+			// client → exit) the local visor is the descriptor's Dst and the far
+			// peer is its Src, so comparing only against DstPK mislabels a
+			// genuinely direct leg as multihop. A leg's first-hop transport
+			// remote can never be this visor's own PK (self-loops are excluded),
+			// so matching EITHER descriptor end means it reached the far one
+			// directly — orientation-independent. A relayed leg's first hop lands
+			// on an intermediate (neither Src nor Dst), so this stays false.
+			leg.Direct = tp.Remote() == dstPK || tp.Remote() == rg.desc.SrcPK()
 			leg.Alive = !tp.IsClosed()
 			// Full forward route for this leg (all hops, full PKs, per-hop
 			// transport type). Per-hop latency: hop 0 is the owned transport


### PR DESCRIPTION
The per-leg `Direct` flag (proxy status page: 'direct' vs 'multihop') compared the leg's first-hop transport remote only against the route descriptor's `DstPK`. For a client-initiated route group — e.g. skysocks-client → exit — the local visor IS the descriptor's Dst and the far peer is its `Src`, so a genuinely direct 1-hop leg to the exit was mislabeled 'multihop'.

Fix: a leg is direct if its first-hop transport reaches EITHER descriptor endpoint. A first-hop transport remote is never this visor's own PK (self-loops excluded), so matching either end means it reached the far one directly; a relayed leg's first hop lands on an intermediate and correctly stays multihop. Orientation-independent.