### PR TITLE
fix(build): update dmsgweb/skynetweb ServeSOCKS5 test callers for new arg

### DIFF
--- a/pkg/dmsgweb/status_scoping_test.go
+++ b/pkg/dmsgweb/status_scoping_test.go
@@ -46,7 +46,7 @@ func TestSOCKS5StatusScoping(t *testing.T) {
 				return
 			}
 			go func(c net.Conn) {
-				_ = proxyinterstitial.ServeSOCKS5(c, "upstream-sink", "skysocks") //nolint:errcheck
+				_ = proxyinterstitial.ServeSOCKS5(c, "upstream-sink", "skysocks", nil) //nolint:errcheck
 				_ = c.Close()                                                     //nolint:errcheck
 			}(c)
 		}

--- a/pkg/skynetweb/status_scoping_test.go
+++ b/pkg/skynetweb/status_scoping_test.go
@@ -40,7 +40,7 @@ func TestSOCKS5StatusScoping(t *testing.T) {
 				return
 			}
 			go func(c net.Conn) {
-				_ = proxyinterstitial.ServeSOCKS5(c, "upstream-sink", "skysocks") //nolint:errcheck
+				_ = proxyinterstitial.ServeSOCKS5(c, "upstream-sink", "skysocks", nil) //nolint:errcheck
 				_ = c.Close()                                                     //nolint:errcheck
 			}(c)
 		}


### PR DESCRIPTION
#4128 added a `statusOverride` param to `proxyinterstitial.ServeSOCKS5` but missed two test call sites (`pkg/dmsgweb/status_scoping_test.go`, `pkg/skynetweb/status_scoping_test.go`), breaking the build/lint on develop. Pass `nil`.