### PR TITLE
fix(router): buffer aux mux legs racing responder route-group init (#80)

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -597,6 +597,7 @@ type router struct {
 	datagramPorts      map[routing.Port]struct{}                       // local ports with faithful-UDP intent; the accept side builds a datagram sibling only for these (#2607 on-demand-by-local-intent)
 	acceptDatagram     chan datagramAccept                             // accept-side datagram siblings, drained by AcceptDatagram (the forwarded_ports.udp server loop)
 	pending            *pendingPackets                                 // frames parked during the rule-save -> route-group-register window (see router_pending.go)
+	pendingLegs        *pendingLegs                                    // aux mux legs buffered while their route group is still initializing (see router_pending_legs.go, #80)
 	rpcSrv             *rpc.Server
 	accept             chan routing.EdgeRules
 	done               chan struct{}
@@ -731,6 +732,7 @@ func New(dmsgC *dmsg.Client, config *Config, routeSetupHooks []RouteSetupHook) (
 		datagramPorts:   make(map[routing.Port]struct{}),
 		acceptDatagram:  make(chan datagramAccept, acceptDatagramBuf),
 		pending:         newPendingPackets(),
+		pendingLegs:     newPendingLegs(),
 		rpcSrv:          rpc.NewServer(),
 		accept:          make(chan routing.EdgeRules, acceptSize),
 		done:            make(chan struct{}),

--- a/pkg/router/router_mux80_test.go
+++ b/pkg/router/router_mux80_test.go
@@ -1,0 +1,245 @@
+// Package router pkg/router/router_mux80_test.go
+//
+// Regression tests for #80: on the RESPONDER, an aux (2nd..N) mux leg that
+// arrives (via AddEdgeRules -> IntroduceRules) while the primary route group is
+// still initializing (present in rgsRaw, not yet rgsNs) used to be pushed to
+// r.accept, where AcceptRoutes' second saveRouteGroupRules either DELETED the
+// leg's freshly-installed rules or blocked the whole handshake-await — either
+// way the leg black-holed and the mux collapsed back toward a single leg.
+//
+// Fix A buffers such a leg (pendingLegs) and drains it through appendRouteToGroup
+// the moment the group registers; Fix B stops AcceptRoutes deleting the leg's
+// rules for the duplicate-descriptor case.
+package router
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+	"github.com/skycoin/skywire/pkg/transport/network"
+)
+
+// newLegTestRouter builds a minimal responder-side router with a real transport
+// manager (so appendRouteToGroup can resolve injected aux-leg transports) and
+// the maps IntroduceRules / saveRouteGroupRules / AcceptRoutes touch.
+func newLegTestRouter(t *testing.T) *router {
+	t.Helper()
+	pk, sk := cipher.GenerateKeyPair()
+	tm, err := transport.NewManager(nil, nil, nil, &transport.ManagerConfig{
+		PubKey:          pk,
+		SecKey:          sk,
+		DiscoveryClient: transport.NewDiscoveryMock(),
+	}, network.ClientFactory{})
+	require.NoError(t, err)
+
+	return &router{
+		logger:        logging.MustGetLogger("mux80_test"),
+		mLogger:       logging.NewMasterLogger(),
+		conf:          &Config{PubKey: pk, SecKey: sk},
+		tm:            tm,
+		rt:            routing.NewTable(logging.MustGetLogger("mux80_rt")),
+		rgsNs:         make(map[routing.RouteDescriptor]*NoiseRouteGroup),
+		rgsRaw:        make(map[routing.RouteDescriptor]*RouteGroup),
+		rgsDatagrams:  make(map[routing.RouteDescriptor]*DatagramRouteGroup),
+		datagramPorts: make(map[routing.Port]struct{}),
+		pending:       newPendingPackets(),
+		pendingLegs:   newPendingLegs(),
+		accept:        make(chan routing.EdgeRules, acceptSize),
+		done:          make(chan struct{}),
+	}
+}
+
+// legTestKeys are the (peer, local) identities the responder's descriptor is
+// keyed by; a package-level pair keeps every leg for a test sharing one desc.
+func legTestKeys() (peer, local cipher.PubKey) {
+	peer, _ = cipher.GenerateKeyPair()
+	local, _ = cipher.GenerateKeyPair()
+	return peer, local
+}
+
+const (
+	legTestSrcPort routing.Port = 100
+	legTestDstPort routing.Port = 200
+)
+
+// setupInitializingPrimary installs a mux-enabled primary route group for a
+// fresh descriptor into rgsRaw ONLY — modelling the mid-handshake window before
+// the group registers into rgsNs. Returns the group and its descriptor.
+func (r *router) setupInitializingPrimary(t *testing.T) (*RouteGroup, routing.RouteDescriptor) {
+	t.Helper()
+	peer, local := legTestKeys()
+	desc := routing.NewRouteDescriptor(peer, local, legTestSrcPort, legTestDstPort)
+
+	primaryTpID := uuid.New()
+	mt := transport.NewManagedTransportForTest(newWorkingTransport())
+	mt.Entry = transport.Entry{ID: primaryTpID, Type: "test"}
+	r.tm.InjectTransportForTest(mt)
+
+	fwd := routing.ForwardRule(DefaultRouteKeepAlive, routing.RouteID(1), routing.RouteID(101), primaryTpID, local, peer, legTestDstPort, legTestSrcPort)
+	rvs := routing.ConsumeRule(DefaultRouteKeepAlive, routing.RouteID(101), local, peer, legTestSrcPort, legTestDstPort)
+	require.NoError(t, r.rt.SaveRule(fwd))
+	require.NoError(t, r.rt.SaveRule(rvs))
+
+	rg := NewRouteGroup(DefaultRouteGroupConfig(), r.rt, desc, r.mLogger)
+	rg.mux = newRouteMux(r.mLogger.PackageLogger("mux80_mux"), false)
+	rg.initiator = false
+	rg.appendRules(fwd, rvs, mt)
+
+	r.mx.Lock()
+	r.rgsRaw[desc] = rg
+	r.mx.Unlock()
+
+	return rg, desc
+}
+
+// makeAuxRules builds a distinct aux mux leg (unique route IDs + a freshly
+// injected transport) for desc. i must be unique within a test.
+func (r *router) makeAuxRules(t *testing.T, desc routing.RouteDescriptor, i int) routing.EdgeRules {
+	t.Helper()
+	peer := desc.SrcPK()
+	local := desc.DstPK()
+
+	auxTpID := uuid.New()
+	mt := transport.NewManagedTransportForTest(newWorkingTransport())
+	mt.Entry = transport.Entry{ID: auxTpID, Type: "test"}
+	r.tm.InjectTransportForTest(mt)
+
+	fwd := routing.ForwardRule(DefaultRouteKeepAlive, routing.RouteID(1000+i), routing.RouteID(2000+i), auxTpID, local, peer, legTestDstPort, legTestSrcPort)
+	rvs := routing.ConsumeRule(DefaultRouteKeepAlive, routing.RouteID(2000+i), local, peer, legTestSrcPort, legTestDstPort)
+	return routing.EdgeRules{Desc: desc, Forward: fwd, Reverse: rvs}
+}
+
+// registerPrimary runs the exact registration step saveRouteGroupRules performs
+// once the primary's handshake completes: move rgsRaw -> rgsNs, then drain any
+// aux legs buffered during the raw window.
+func (r *router) registerPrimary(rg *RouteGroup, desc routing.RouteDescriptor) {
+	nrg := &NoiseRouteGroup{rg: rg, Conn: rg}
+	r.mx.Lock()
+	r.rgsNs[desc] = nrg
+	delete(r.rgsRaw, desc)
+	r.mx.Unlock()
+	r.drainPendingLegs(nrg, desc)
+}
+
+func legCount(rg *RouteGroup) int {
+	rg.mu.Lock()
+	defer rg.mu.Unlock()
+	return len(rg.tps)
+}
+
+// TestIntroduceRules_AuxLegDuringInitialization is the core Fix A regression:
+// an aux leg arriving while the primary is in rgsRaw must be buffered (not
+// dropped, not pushed to accept, rules not deleted) and appended once the group
+// registers. This assertion set FAILS on develop (the aux leg is pushed to
+// r.accept and never appended).
+func TestIntroduceRules_AuxLegDuringInitialization(t *testing.T) {
+	r := newLegTestRouter(t)
+	rg, desc := r.setupInitializingPrimary(t)
+	require.Equal(t, 1, legCount(rg), "primary starts as a single leg")
+
+	aux := r.makeAuxRules(t, desc, 1)
+	require.NoError(t, r.IntroduceRules(aux))
+
+	// (i) the aux leg's freshly-installed rules must survive.
+	_, errF := r.rt.Rule(aux.Forward.KeyRouteID())
+	require.NoError(t, errF, "aux forward rule must not be deleted")
+	_, errR := r.rt.Rule(aux.Reverse.KeyRouteID())
+	require.NoError(t, errR, "aux reverse rule must not be deleted")
+
+	// (ii) nothing may be pushed to r.accept (that path is what collapses mux).
+	select {
+	case <-r.accept:
+		t.Fatal("aux leg arriving during initialization must not be pushed to r.accept")
+	default:
+	}
+
+	// It is buffered, not yet appended, while the group is still initializing.
+	require.Equal(t, 1, legCount(rg), "aux leg must not append until the group registers")
+
+	// (iii) once the primary registers, the buffered aux leg is appended.
+	r.registerPrimary(rg, desc)
+	require.Equal(t, 2, legCount(rg), "buffered aux leg must be appended on registration")
+	require.False(t, rg.isClosed(), "primary route group must not be closed")
+}
+
+// TestAcceptRoutes_DuplicateDescDoesNotDeleteLeg guards Fix B: if an aux leg for
+// an already-initializing descriptor reaches AcceptRoutes, the leg's rules must
+// survive (AcceptRoutes must not DelRules them). On develop AcceptRoutes deletes
+// them, black-holing the leg.
+func TestAcceptRoutes_DuplicateDescDoesNotDeleteLeg(t *testing.T) {
+	r := newLegTestRouter(t)
+	_, desc := r.setupInitializingPrimary(t)
+
+	aux := r.makeAuxRules(t, desc, 1)
+	// Drive the (pre-Fix-A) path directly: hand the aux leg to the accept loop.
+	r.accept <- aux
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := r.AcceptRoutes(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errRouteGroupInitializing)
+
+	_, errF := r.rt.Rule(aux.Forward.KeyRouteID())
+	require.NoError(t, errF, "forward rule must survive the duplicate-descriptor accept")
+	_, errR := r.rt.Rule(aux.Reverse.KeyRouteID())
+	require.NoError(t, errR, "reverse rule must survive the duplicate-descriptor accept")
+}
+
+// TestMuxSetup_ConcurrentLegsNoCollapse stands up N aux legs concurrently to the
+// same descriptor while the primary sits in rgsRaw, with registration racing the
+// arrivals after a deterministic delay (modelling the responder handshake-await
+// window). The group must converge to N legs, the primary rg must never be
+// closed or replaced, and its src port must be stable. Run under -race.
+func TestMuxSetup_ConcurrentLegsNoCollapse(t *testing.T) {
+	const nAux = 3
+	r := newLegTestRouter(t)
+	rg, desc := r.setupInitializingPrimary(t)
+	srcPortBefore := rg.desc.SrcPort()
+
+	auxRules := make([]routing.EdgeRules, nAux)
+	for i := 0; i < nAux; i++ {
+		auxRules[i] = r.makeAuxRules(t, desc, i+1)
+	}
+
+	var wg sync.WaitGroup
+
+	// Registration races the aux arrivals.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(15 * time.Millisecond)
+		r.registerPrimary(rg, desc)
+	}()
+
+	// Aux legs arrive from parallel goroutines, straddling the registration.
+	for i := 0; i < nAux; i++ {
+		wg.Add(1)
+		go func(rules routing.EdgeRules) {
+			defer wg.Done()
+			require.NoError(t, r.IntroduceRules(rules))
+		}(auxRules[i])
+	}
+	wg.Wait()
+
+	// Every aux leg lands exactly once (buffered+drained if it arrived during the
+	// raw window, immediate-append if after registration) — no collapse.
+	require.Equal(t, 1+nAux, legCount(rg), "group must converge to primary + all aux legs")
+	require.False(t, rg.isClosed(), "primary route group must never be closed")
+
+	r.mx.Lock()
+	nrg, ok := r.rgsNs[desc]
+	r.mx.Unlock()
+	require.True(t, ok, "the group must be registered in rgsNs")
+	require.Same(t, rg, nrg.rg, "the primary rg must never be replaced")
+	require.Equal(t, srcPortBefore, rg.desc.SrcPort(), "the primary src port must be stable")
+}

--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -120,6 +120,19 @@ func (r *router) drainPendingToGroup(nrg *NoiseRouteGroup, desc routing.RouteDes
 	}
 }
 
+// drainPendingLegs appends every aux mux leg buffered for desc while its route
+// group was still initializing (rgsRaw), through the guarded append path. Called
+// by saveRouteGroupRules right after the group registers into rgsNs (#80). Each
+// append carries the DMSG-refusal + duplicate-transport-ID guards, sends the
+// per-leg handshake, and drains any transport frames parked for the new leg.
+func (r *router) drainPendingLegs(nrg *NoiseRouteGroup, desc routing.RouteDescriptor) {
+	for _, pl := range r.pendingLegs.take(desc) {
+		if err := r.appendRouteToGroup(nrg, pl.rules); err != nil {
+			r.logger.WithError(err).Debugf("Failed to append buffered aux mux leg for %s", &desc)
+		}
+	}
+}
+
 // appendRouteToGroup adds an additional transport/rule pair to an existing
 // mux-enabled NoiseRouteGroup. Used for establishing additional parallel routes.
 func (r *router) appendRouteToGroup(nrg *NoiseRouteGroup, rules routing.EdgeRules) error {

--- a/pkg/router/router_pending_legs.go
+++ b/pkg/router/router_pending_legs.go
@@ -1,0 +1,130 @@
+// Package router pkg/router/router_pending_legs.go c2-net-routing
+package router
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// Responder-side mux-leg setup-race mitigation (#80).
+//
+// A route group is registered under rgsNs only AFTER its 10s-bounded setup
+// handshake completes; while it is initializing it lives under rgsRaw and its
+// rg.mux is not yet set (the responder creates the mux lazily when the primary
+// forward handshake lands). An additional (aux) mux leg for the SAME descriptor
+// arrives independently via AddEdgeRules -> IntroduceRules. If that aux leg
+// lands in the initialization window it can neither be appended (mux may be nil)
+// nor treated as a new group (it shares the primary's descriptor) — the old code
+// pushed it to r.accept, where AcceptRoutes' second saveRouteGroupRules either
+// deleted the leg's freshly-installed rules or blocked the whole handshake-await
+// timeout, collapsing the group back toward a single leg.
+//
+// Instead of dropping or misrouting such a leg, we buffer it here and drain it
+// through appendRouteToGroup the moment the primary registers into rgsNs. This
+// mirrors the transport-frame parking in router_pending.go, one level up: that
+// parks a packet whose route group has not registered; this parks a whole leg
+// whose route group has not registered.
+const (
+	// pendingLegTTL must outlast the responder's full handshake-await window
+	// (handshakeAwaitTimeout, router.go) so a leg buffered at the very start of
+	// the initialization window is still deliverable when the primary registers.
+	// A group that never registers (its handshake failed) has its raw entry
+	// deleted; the buffered leg is then reclaimed by the sweep at this TTL.
+	pendingLegTTL = handshakeAwaitTimeout + 2*time.Second
+	// Memory bounds: aux legs for descriptors that never register must not grow
+	// the buffer without limit. A single group tops out well under this per-desc
+	// cap (mux legs are capped far lower); the cap only guards against churn.
+	maxPendingLegsPerDesc = 32
+	maxPendingLegsTotal   = 2048
+)
+
+type pendingLeg struct {
+	rules    routing.EdgeRules
+	deadline time.Time
+}
+
+// pendingLegs buffers aux mux legs whose route group is still initializing
+// (present in rgsRaw, not yet rgsNs). It is safe for concurrent use.
+type pendingLegs struct {
+	mu     sync.Mutex
+	byDesc map[routing.RouteDescriptor][]pendingLeg
+	total  int
+}
+
+func newPendingLegs() *pendingLegs {
+	return &pendingLegs{byDesc: make(map[routing.RouteDescriptor][]pendingLeg)}
+}
+
+// park stores an aux leg's rules for desc until the route group registers
+// (take) or the TTL expires (sweep). Returns false when the buffer is full, in
+// which case the caller reports the append failure to the setup node.
+func (p *pendingLegs) park(desc routing.RouteDescriptor, rules routing.EdgeRules, now time.Time) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.total >= maxPendingLegsTotal || len(p.byDesc[desc]) >= maxPendingLegsPerDesc {
+		return false
+	}
+	p.byDesc[desc] = append(p.byDesc[desc], pendingLeg{rules: rules, deadline: now.Add(pendingLegTTL)})
+	p.total++
+	return true
+}
+
+// take removes and returns all legs parked for desc. Called when the route
+// group for desc registers into rgsNs.
+func (p *pendingLegs) take(desc routing.RouteDescriptor) []pendingLeg {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	legs := p.byDesc[desc]
+	if len(legs) == 0 {
+		return nil
+	}
+	delete(p.byDesc, desc)
+	p.total -= len(legs)
+	return legs
+}
+
+// sweep drops legs past their deadline and returns the count dropped.
+func (p *pendingLegs) sweep(now time.Time) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	dropped := 0
+	for desc, legs := range p.byDesc {
+		kept := legs[:0]
+		for _, pl := range legs {
+			if now.Before(pl.deadline) {
+				kept = append(kept, pl)
+			} else {
+				dropped++
+			}
+		}
+		if len(kept) == 0 {
+			delete(p.byDesc, desc)
+		} else {
+			p.byDesc[desc] = kept
+		}
+	}
+	p.total -= dropped
+	return dropped
+}
+
+// runSweep periodically drops expired buffered legs until ctx is done. Buffered
+// legs are normally taken within the setup window (on route-group registration);
+// the sweep only reclaims legs for descriptors that never register.
+func (p *pendingLegs) runSweep(ctx context.Context, log *logging.Logger) {
+	t := time.NewTicker(pendingSweepInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			if n := p.sweep(now); n > 0 && log != nil {
+				log.WithField("dropped", n).Debug("Dropped buffered aux mux legs whose route group never registered")
+			}
+		}
+	}
+}

--- a/pkg/router/router_rules.go
+++ b/pkg/router/router_rules.go
@@ -5,6 +5,7 @@ package router
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/skycoin/skywire/pkg/routing"
 )
@@ -208,19 +209,35 @@ func (r *router) IntroduceRules(rules routing.EdgeRules) error {
 		return fmt.Errorf("SaveRoutingRules: %w", err)
 	}
 
-	// Check if we already have an active mux-enabled route group for this descriptor.
-	// If so, append the additional route instead of creating a new connection.
+	// Check if we already have a route group for this descriptor. If so, these
+	// rules are an ADDITIONAL (aux) mux leg for it, not a new connection — never
+	// push them to r.accept (that path builds a duplicate group; on the responder
+	// it deletes the leg's rules or blocks the whole handshake-await, collapsing
+	// the mux back toward one leg, #80).
+	//
+	// Two cases:
+	//   - The group is already live (rgsNs) with mux enabled → append now.
+	//   - The group is still initializing (rgsRaw): its rg.mux is not set yet (the
+	//     responder creates it lazily when the primary forward handshake lands),
+	//     so we cannot append yet. Buffer the leg and drain it through the same
+	//     guarded append the moment the group registers (saveRouteGroupRules).
 	r.mx.Lock()
 	if nrg, ok := r.rgsNs[rules.Desc]; ok && nrg != nil && nrg.rg.mux != nil {
 		r.mx.Unlock()
-
-		nextTpID := rules.Forward.NextTransportID()
-		tp := r.tm.Transport(nextTpID)
-		if tp == nil {
-			return fmt.Errorf("transport %s not found for additional mux route", nextTpID)
+		// Route through appendRouteToGroup so the DMSG-refusal and
+		// duplicate-transport-ID guards apply (the old inline append skipped
+		// them), and the peer is handshaked on the new leg.
+		return r.appendRouteToGroup(nrg, rules)
+	}
+	if _, initializing := r.rgsRaw[rules.Desc]; initializing {
+		// Park under r.mx so the group cannot transition rgsRaw -> rgsNs (and
+		// drain) between our check and our park, which would strand this leg.
+		parked := r.pendingLegs.park(rules.Desc, rules, time.Now())
+		r.mx.Unlock()
+		if !parked {
+			return fmt.Errorf("pending-leg buffer full for initializing route group %s", &rules.Desc)
 		}
-		nrg.rg.appendRules(rules.Forward, rules.Reverse, tp)
-		r.logger.Debugf("Appended additional mux route to existing RouteGroup for %s", &rules.Desc)
+		r.logger.Debugf("Buffered aux mux leg for initializing route group %s", &rules.Desc)
 		return nil
 	}
 	r.mx.Unlock()

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -18,6 +18,14 @@ import (
 	"github.com/skycoin/skywire/pkg/transport/network"
 )
 
+// errRouteGroupInitializing is returned by saveRouteGroupRules when a route
+// group for the same descriptor is already being wrapped with noise (present in
+// rgsRaw). It is a typed sentinel so AcceptRoutes can tell this benign
+// "the leg belongs to a group that already exists" case apart from a real
+// failure and skip deleting the leg's rules (#80 Fix B). Deleting them here is
+// exactly what black-holes an aux mux leg that raced the primary's setup.
+var errRouteGroupInitializing = errors.New("noise route group already being initialized")
+
 // AcceptRoutes should block until we receive an AddRules packet from SetupNode
 // that contains ConsumeRule(s) or ForwardRule(s).
 // Then the following should happen:
@@ -63,6 +71,15 @@ func (r *router) AcceptRoutes(ctx context.Context) (net.Conn, error) {
 	datagram := r.isDatagramPort(rules.Desc.DstPort())
 	nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf, "", datagram)
 	if err != nil {
+		// A route group for this descriptor is already initializing: these rules
+		// belong to an additional (aux) mux leg the existing group should adopt,
+		// not to a failed new group. Deleting them would black-hole the leg —
+		// exactly the #80 collapse. With Fix A the leg is buffered and drained on
+		// registration, so leave its rules in place and don't treat this as fatal.
+		if errors.Is(err, errRouteGroupInitializing) {
+			r.logger.WithError(err).Debugf("Aux leg for initializing route group %s; leaving rules for adoption", &rules.Desc)
+			return nil, err
+		}
 		// Clean up saved rules if route group setup fails
 		r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
 		return nil, fmt.Errorf("saveRouteGroupRules: %w", err)
@@ -117,6 +134,10 @@ func (r *router) Serve(ctx context.Context) error {
 	// Reclaim frames parked during the route-group registration window whose
 	// route group never registers (see router_pending.go).
 	go r.pending.runSweep(ctx, r.logger)
+
+	// Reclaim aux mux legs buffered for a route group that never registers
+	// (its setup handshake failed); see router_pending_legs.go, #80.
+	go r.pendingLegs.runSweep(ctx, r.logger)
 
 	return nil
 }
@@ -252,7 +273,7 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 	if _, ok := r.rgsRaw[rules.Desc]; ok {
 		r.mx.Unlock()
 		log.Warnf("Desc %s already reserved, skipping...", &rules.Desc)
-		return nil, fmt.Errorf("noise route group with desc %s already being initialized", &rules.Desc)
+		return nil, fmt.Errorf("%w: desc %s", errRouteGroupInitializing, &rules.Desc)
 	}
 
 	// we need to close currently existing wrapped rg if there's one
@@ -456,6 +477,14 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 	r.rgsNs[rules.Desc] = nrg
 	delete(r.rgsRaw, rules.Desc)
 	r.mx.Unlock()
+
+	// Drain any aux mux legs that arrived (via IntroduceRules) while this group
+	// was still initializing in rgsRaw (#80). They were buffered instead of being
+	// pushed to r.accept — where AcceptRoutes' second saveRouteGroupRules would
+	// have deleted their rules or blocked the whole handshake-await, collapsing
+	// the group. On the initiator this is a no-op: the initiator dials its own aux
+	// legs and never receives them via IntroduceRules.
+	r.drainPendingLegs(nrg, rules.Desc)
 
 	// Faithful-UDP (#2607): when this end intends datagram mode for the
 	// route, build a DatagramRouteGroup sibling over the same rules +


### PR DESCRIPTION
## Problem (#80: mux>1 multi-hop route-setup churn)

On the **responder**, an aux (2nd..N) mux leg arrives independently of the
primary via `AddEdgeRules` → `IntroduceRules`. A route group lives in `rgsRaw`
while its ~10s setup handshake runs and only moves to `rgsNs` afterward. The
mux fast-path that appends a leg to the existing group was guarded by `rgsNs`
only, so an aux leg landing in the `rgsRaw` window missed it and was pushed to
`r.accept`. `AcceptRoutes` then called `saveRouteGroupRules` a *second* time for
the same descriptor, with two bad outcomes:

- **rgsRaw still present** → the second save returned "already being
  initialized" and `AcceptRoutes` treated it as failure, running `DelRules` on
  the aux leg's freshly-installed forward/reverse rules → the leg black-holed →
  the mux pruned it → collapse toward one leg.
- **primary already in rgsNs** → the second save built a duplicate group in
  `rgsRaw` and blocked on the full 10s handshake-await (the aux forward
  handshake was dispatched to the primary, never the duplicate), then deleted
  the leg's rules on timeout.

## Fix

**A — recognize an initializing group; buffer the aux leg; drain on
registration.** `IntroduceRules` now also consults `rgsRaw`. A leg for a group
already live in `rgsNs` is appended immediately through `appendRouteToGroup`
(which — unlike the old inline append — applies the DMSG-refusal and
duplicate-transport-ID guards and handshakes the new leg). A leg for an
*initializing* group is buffered in a new per-descriptor pending-leg queue
(`router_pending_legs.go`, a direct analog of the transport-frame parking in
`router_pending.go`: mutex-guarded map keyed by descriptor, bounded per-desc
and total, TTL-swept) and drained through `appendRouteToGroup` the moment
`saveRouteGroupRules` registers the group into `rgsNs`. Parking is done under
`r.mx` so a leg can never be stranded across the `rgsRaw`→`rgsNs` transition.

**B — never let `AcceptRoutes` destroy a leg's rules for the duplicate
descriptor.** The "already being initialized" branch now returns a typed
sentinel (`errRouteGroupInitializing`); `AcceptRoutes` recognizes it and leaves
the leg's rules in place instead of `DelRules`-ing them.

Route-ID allocation was ruled out as a cause (it is mutex-guarded and
monotonic); "transport not found locally" is a churn symptom, not an
independent cause.

## Tests (run under `-race`)

- `TestIntroduceRules_AuxLegDuringInitialization` — aux leg during the rgsRaw
  window is buffered (not pushed to `accept`, rules not deleted) and appended on
  registration. **Fails on develop, passes with the fix.**
- `TestAcceptRoutes_DuplicateDescDoesNotDeleteLeg` — guards Fix B; the leg's
  rules survive a duplicate-descriptor accept. **Fails on develop, passes with
  the fix.**
- `TestMuxSetup_ConcurrentLegsNoCollapse` — N aux legs from parallel goroutines
  racing registration converge to N legs; the primary rg is never closed or
  replaced and its src port is stable.

`go test -race ./pkg/router/...` passes (the sole failure,
`TestMap_PooledAndDiscard`, is a pre-existing data race unrelated to this change
that also fails on clean develop). `go build .`, the js/wasm visor build,
`go vet`, and gofmt/goimports are clean.

## Follow-up (out of scope)

Fix C — single-flight per-descriptor leg adds across self-heal + rotation — is a
recommended follow-up: it would coalesce concurrent leg-add attempts for the
same descriptor (e.g. GrowMuxRoute racing an incoming aux leg) behind one
in-flight operation. This PR does not change route-ID allocation, the handshake
wire protocol, or the packet-parking code.