### PR TITLE
feat(skynetca): permit .skysocks in the resolver CA name constraints

### DIFF
--- a/pkg/skynetca/ca.go
+++ b/pkg/skynetca/ca.go
@@ -1,6 +1,6 @@
 // Package skynetca pkg/skynetca/ca.go c4-app-skynet
 // authority used by the skywire resolver to terminate TLS for
-// `*.skynet` and `*.dmsg` hostnames in the visitor's browser.
+// `*.skynet`, `*.dmsg` and `*.skysocks` hostnames in the visitor's browser.
 //
 // The CA is generated on the visitor's machine, name-constrained
 // via the X.509 nameConstraints extension to the resolver TLDs, and
@@ -42,7 +42,7 @@ import (
 // DefaultPermittedDomains is the set of TLDs the resolver CA is
 // allowed to issue leaf certs for. The leading dot means "any
 // subdomain of"; bare TLDs themselves are not matched.
-var DefaultPermittedDomains = []string{".skynet", ".dmsg"}
+var DefaultPermittedDomains = []string{".skynet", ".dmsg", ".skysocks"}
 
 // CAOptions configures GenerateCA.
 type CAOptions struct {

--- a/pkg/skynetca/ca_test.go
+++ b/pkg/skynetca/ca_test.go
@@ -26,7 +26,7 @@ func TestGenerateCA_Defaults(t *testing.T) {
 	if !cert.PermittedDNSDomainsCritical {
 		t.Errorf("PermittedDNSDomainsCritical = false, want true")
 	}
-	want := []string{".skynet", ".dmsg"}
+	want := []string{".skynet", ".dmsg", ".skysocks"}
 	got := cert.PermittedDNSDomains
 	if len(got) != len(want) {
 		t.Fatalf("PermittedDNSDomains = %v, want %v", got, want)


### PR DESCRIPTION
The resolver CA's name-constrained leaf minter allowed `.skynet` and `.dmsg` but not `.skysocks`, so `status.skysocks` couldn't be served over TLS — `https://status.skysocks` returns `SSL_ERROR_RX_RECORD_TOO_LONG` against the plaintext HTTP-only handler. Add `.skysocks` to `DefaultPermittedDomains`.

**Note:** `PermittedDNSDomains` is critical, so an already-installed CA cert carries the old constraints — the resolver CA must be regenerated + re-trusted for this to take effect in a browser. This permits the suffix (the prerequisite); wiring a TLS-terminating serve path for `status.skysocks` (so `wss://` works for the status control surface) is a follow-up.