### PR TITLE
feat(status): make status.skysocks live-update a WebSocket control channel

### DIFF
--- a/pkg/proxystatus/proxystatus_test.go
+++ b/pkg/proxystatus/proxystatus_test.go
@@ -64,9 +64,12 @@ func TestRenderSections(t *testing.T) {
 	for _, want := range []string{
 		"<!doctype html>", "proxy status", "skysocks-client", "per-leg mux",
 		"stcpr", "recent log", "line two", "route control", "read-only preview",
-		// live push (skysocks): the SSE script + swap target replace the old meta
-		// refresh, which must be gone for this surface.
-		"<main id=\"live\">", "EventSource", "/sse",
+		// live push (skysocks): the WebSocket script + swap target replace the old
+		// meta refresh, which must be gone for this surface. The WS URL is derived
+		// from the page origin (never a hardcoded http://), and sendCmd is the
+		// browser→server control seam.
+		"<main id=\"live\">", "new WebSocket", "/ws",
+		`location.origin.replace(/^http/,"ws")`, "sendCmd",
 		"standby", "status.dmsg", "status.skynet",
 		// route observability: route-latency column, direct/multihop badge, recv bar
 		"route rtt", "recv share", "direct", "multihop", "480 ms", "bar recv",
@@ -87,17 +90,17 @@ func TestRenderSections(t *testing.T) {
 	if strings.Contains(page, `href="http://status.skysocks/"`) {
 		t.Error("footer should not link the current surface to itself")
 	}
-	// The skysocks surface is kept live by SSE, so the old meta refresh must be
-	// gone (it would fight the in-place swap with a full-page reload).
+	// The skysocks surface is kept live by the WebSocket, so the old meta refresh
+	// must be gone (it would fight the in-place swap with a full-page reload).
 	if strings.Contains(page, `http-equiv="refresh"`) {
-		t.Error("skysocks status page must not use meta refresh (SSE live-push replaces it)")
+		t.Error("skysocks status page must not use meta refresh (WebSocket live-push replaces it)")
 	}
 }
 
 // TestRenderFragmentIsLiveRegionOnly verifies RenderFragment emits the live
-// content (pills/mux/log) WITHOUT the page shell, so it can be pushed as an SSE
-// payload and swapped into <main id="live">. It must be identical to the shell's
-// live region — same source of truth.
+// content (pills/mux/log) WITHOUT the page shell, so it can be pushed as a
+// WebSocket TEXT frame and swapped into <main id="live">. It must be identical to
+// the shell's live region — same source of truth.
 func TestRenderFragmentIsLiveRegionOnly(t *testing.T) {
 	snap := Snapshot{
 		Surface: SurfaceSkysocks, App: "skysocks-client", Running: true,
@@ -109,7 +112,7 @@ func TestRenderFragmentIsLiveRegionOnly(t *testing.T) {
 			t.Errorf("fragment missing %q", want)
 		}
 	}
-	for _, unwanted := range []string{"<!doctype", "<html", "<head", "<style", "<main", "EventSource", "route control", "<footer"} {
+	for _, unwanted := range []string{"<!doctype", "<html", "<head", "<style", "<main", "new WebSocket", "route control", "<footer"} {
 		if strings.Contains(frag, unwanted) {
 			t.Errorf("fragment must not contain shell/static markup %q", unwanted)
 		}
@@ -127,15 +130,16 @@ func TestRenderFragmentIsLiveRegionOnly(t *testing.T) {
 	}
 }
 
-// TestRenderDmsgKeepsMetaRefresh guards that non-skysocks surfaces (no SSE
-// endpoint) keep the meta-refresh fallback and do NOT get the skysocks SSE script.
+// TestRenderDmsgKeepsMetaRefresh guards that non-skysocks surfaces (no WebSocket
+// endpoint) keep the meta-refresh fallback and do NOT get the skysocks WebSocket
+// script.
 func TestRenderDmsgKeepsMetaRefresh(t *testing.T) {
 	page := string(Render(Snapshot{Surface: SurfaceDmsg, App: "dmsgweb"}))
 	if !strings.Contains(page, `http-equiv="refresh"`) {
 		t.Error("dmsg status page should keep the meta-refresh fallback")
 	}
-	if strings.Contains(page, "EventSource") {
-		t.Error("dmsg status page must not emit the skysocks SSE script")
+	if strings.Contains(page, "new WebSocket") {
+		t.Error("dmsg status page must not emit the skysocks WebSocket script")
 	}
 }
 

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -9,8 +9,8 @@ import (
 
 // refreshSeconds is the fallback full-page reload cadence for surfaces that have
 // no live-push endpoint (status.dmsg, status.skynet). status.skysocks is kept in
-// sync by an SSE stream instead (see liveScript / RenderFragment) and omits the
-// meta refresh entirely.
+// sync by a WebSocket stream instead (see liveScript / RenderFragment) and omits
+// the meta refresh entirely.
 const refreshSeconds = 4
 
 // maxLogLines caps how many recent log lines the page renders, newest at the
@@ -22,10 +22,10 @@ const maxLogLines = 200
 // (matching the proxies' strict no-network serving context).
 //
 // For the skysocks surface the live region (pills, per-leg mux, events, log) is
-// wrapped in <main id="live"> and kept current by an inline SSE script that swaps
-// just that element on each server push — the server-rendered markup is the
-// initial paint, so the page still works with JS/SSE unavailable. Other surfaces
-// have no SSE endpoint and fall back to a meta refresh, as before.
+// wrapped in <main id="live"> and kept current by an inline WebSocket script that
+// swaps just that element on each server push — the server-rendered markup is the
+// initial paint, so the page still works with JS/WebSocket unavailable. Other
+// surfaces have no WebSocket endpoint and fall back to a meta refresh, as before.
 func Render(snap Snapshot) []byte {
 	var b strings.Builder
 	surface := html.EscapeString(string(snap.Surface))
@@ -62,28 +62,43 @@ func Render(snap Snapshot) []byte {
 // RenderFragment renders ONLY the live region — the inner HTML of
 // <main id="live"> (pills, per-leg mux, events, recent log) — with no
 // <html>/<head>/<style> shell. It is the single source of truth for the live
-// markup: Render composes the page shell around it, and the skysocks-client SSE
-// handler pushes it verbatim so the browser swaps the region in place without a
-// full-page reload. Newlines in the fragment (the <pre> log block) are preserved
-// by the SSE framing (one data: line per source line), so no escaping is needed.
+// markup: Render composes the page shell around it, and the skysocks-client
+// WebSocket handler pushes it verbatim as one TEXT frame so the browser swaps the
+// region in place (el.innerHTML = frame) without a full-page reload. Newlines in
+// the fragment (the <pre> log block) ride through the TEXT frame as-is, so no
+// escaping is needed.
 func RenderFragment(snap Snapshot) []byte {
 	var b strings.Builder
 	writeLiveRegion(&b, snap)
 	return []byte(b.String())
 }
 
-// liveScript opens an EventSource to http://status.skysocks/sse and replaces the
-// live region's innerHTML on each push — a seamless live update in place of the
-// old jarring full-page meta refresh. Progressive enhancement: the server-
-// rendered initial paint stands alone, so the page still works with JS or SSE
-// unavailable. A healthy message cancels any pending fallback; if the stream
-// breaks and does not recover, it falls back to a slow (15s) reload rather than
-// the old 1–4s one. Emitted only for the skysocks surface (the only one with an
-// /sse handler).
-const liveScript = `<script>(function(){var t;function slow(){if(!t){t=setTimeout(function(){location.reload();},15000);}}` +
-	`try{var es=new EventSource("http://status.skysocks/sse");` +
-	`es.onmessage=function(e){if(t){clearTimeout(t);t=null;}var el=document.getElementById("live");if(el){el.innerHTML=e.data;}};` +
-	`es.onerror=function(){slow();};}catch(err){slow();}})();</script>`
+// liveScript opens a WebSocket to <origin>/ws and replaces the live region's
+// innerHTML on each server push — a seamless live update in place of the old
+// jarring full-page meta refresh, and a duplex channel so the page can send
+// control commands back (window.sendCmd). The URL is derived from the page's OWN
+// origin — location.origin.replace(/^http/,"ws") + "/ws" — never a hardcoded
+// http://status.skysocks/… absolute: an absolute http:// subrequest is force-
+// upgraded to https by the browser's HTTPS-Only Mode and then fails on the HTTP-
+// only .skysocks host, whereas the relative form inherits the page's actual
+// (non-upgraded) ws:// scheme and host.
+//
+// Progressive enhancement: the server-rendered initial paint stands alone, so the
+// page still works with JS or WebSocket unavailable. A healthy message cancels any
+// pending fallback. On close/error it reconnects after a short backoff (2s);
+// only if reconnects never recover does the slow (15s) full reload fire as a last
+// resort. window.sendCmd(obj) sends a JSON control frame (e.g. {cmd:"resync"}) and
+// is the seam the route-control buttons use. Emitted only for the skysocks surface
+// (the only one with a /ws handler).
+const liveScript = `<script>(function(){var t,ws;` +
+	`function slow(){if(!t){t=setTimeout(function(){location.reload();},15000);}}` +
+	`function url(){return location.origin.replace(/^http/,"ws")+"/ws";}` +
+	`function connect(){try{ws=new WebSocket(url());}catch(e){slow();return;}` +
+	`ws.onmessage=function(e){if(t){clearTimeout(t);t=null;}var el=document.getElementById("live");if(el){el.innerHTML=e.data;}};` +
+	`ws.onclose=function(){ws=null;slow();setTimeout(connect,2000);};` +
+	`ws.onerror=function(){try{ws.close();}catch(e){}};}` +
+	`window.sendCmd=function(o){try{if(ws&&ws.readyState===1){ws.send(JSON.stringify(o));}}catch(e){}};` +
+	`connect();})();</script>`
 
 // writeLiveRegion writes the dynamic status content (pills, per-leg mux, events,
 // recent log) shared by Render (page shell) and RenderFragment (SSE push).
@@ -258,20 +273,39 @@ func writeLogsSection(b *strings.Builder, snap Snapshot) {
 	b.WriteString(`</pre></section>`)
 }
 
-// writeControlSeam renders the (disabled) route-control preview. This is the
-// documented extension point: a future write-capable page enables these
-// controls and calls a mutating Provider method. It is intentionally inert now
-// so the MVP stays read-only.
+// writeControlSeam renders the route-control panel. For skysocks the "resync"
+// button is live — it proves the WebSocket send path by calling window.sendCmd
+// (defined in liveScript), which the server answers with an immediate fragment
+// push. The mux-op buttons (add/drop leg, mux mode, rebuild) stay disabled: they
+// mutate the route group and need an app→visor mux-control RPC that does not exist
+// yet (see the TODO in pkg/skysocks/client.go handleStatusControl). Non-skysocks
+// surfaces have no WebSocket and keep the fully-inert preview.
 func writeControlSeam(b *strings.Builder, snap Snapshot) {
 	b.WriteString(`<section class="seam"><h2>route control <small>read-only preview</small></h2>`)
-	b.WriteString(`<p>Selecting routes and relays from here is planned. Today these are inert; ` +
-		`the MVP status page is read-only.</p><div class="controls">`)
 	switch snap.Surface {
-	case SurfaceSkynet, SurfaceSkysocks:
+	case SurfaceSkysocks:
+		b.WriteString(`<p>The live view refreshes over a WebSocket; <b>resync</b> forces an ` +
+			`immediate push. Route mutation (add/drop leg, mux mode, rebuild) is planned — ` +
+			`those controls are inert until the mux-control RPC lands.</p><div class="controls">`)
+		// Live: sends {cmd:"resync"} over the WebSocket (see liveScript / handleStatusControl).
+		b.WriteString(`<button type="button" class="live" onclick="sendCmd({cmd:'resync'})">resync</button>`)
+		// TODO(mux-control): enable once the app→visor mux-control RPC exists.
+		b.WriteString(`<button disabled title="needs the mux-control RPC (TODO)">add leg</button>` +
+			`<button disabled title="needs the mux-control RPC (TODO)">drop leg</button>` +
+			`<button disabled title="needs the mux-control RPC (TODO)">mux mode…</button>` +
+			`<button disabled title="needs the mux-control RPC (TODO)">rebuild route</button>`)
+	case SurfaceSkynet:
+		b.WriteString(`<p>Selecting routes and relays from here is planned. Today these are inert; ` +
+			`the MVP status page is read-only.</p><div class="controls">`)
 		b.WriteString(`<button disabled>add leg</button><button disabled>drop leg</button>` +
 			`<button disabled>mux mode…</button><button disabled>rebuild route</button>`)
 	case SurfaceDmsg:
+		b.WriteString(`<p>Selecting routes and relays from here is planned. Today these are inert; ` +
+			`the MVP status page is read-only.</p><div class="controls">`)
 		b.WriteString(`<button disabled>pick dmsg relay…</button><button disabled>reconnect</button>`)
+	default:
+		b.WriteString(`<p>Selecting routes and relays from here is planned. Today these are inert; ` +
+			`the MVP status page is read-only.</p><div class="controls">`)
 	}
 	b.WriteString(`</div></section>`)
 }
@@ -366,6 +400,8 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`ul.events{margin:.3rem 0;padding-left:1.1rem;font-size:12px}ul.events li{margin:.1rem 0}` +
 	`.seam{opacity:.9}.controls{display:flex;flex-wrap:wrap;gap:.4rem;margin-top:.4rem}` +
 	`.controls button{font:inherit;font-size:12px;padding:.2rem .6rem;border:1px dashed var(--line);border-radius:6px;background:transparent;color:var(--muted);cursor:not-allowed}` +
+	`.controls button.live{border:1px solid var(--accent);color:var(--accent);cursor:pointer}` +
+	`.controls button.live:hover{background:rgba(124,131,255,.12)}` +
 	`code{color:var(--accent);font-size:11.5px}` +
 	`footer{margin-top:2rem;padding-top:.7rem;border-top:1px solid var(--line);color:var(--muted);font-size:12px}` +
 	`footer a{color:var(--accent);text-decoration:none}footer a:hover{text-decoration:underline}` +

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -3,9 +3,14 @@ package skysocks
 
 import (
 	"bytes"
+	"crypto/sha1" //nolint:gosec // RFC6455 mandates SHA-1 for the WebSocket accept key
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -354,9 +359,9 @@ func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool) {
 // being shadowed by the interstitial. Any other host returns nil, leaving the
 // interstitial in place. statusSnapshot already reports "no active session to
 // the exit" when the session is down, which is the correct content here. (Only
-// the one-shot page is served on this path — the SSE variant needs a live
-// stream that the override's fixed-body model can't carry; the page's own
-// meta-refresh keeps it current.)
+// the one-shot page is served on this path — the live WebSocket needs a duplex
+// stream that the override's fixed-body model can't carry; the page's inline
+// script reconnects the WebSocket once the conn is back.)
 func (c *Client) statusOverride(host string) []byte {
 	if surface, ok := proxystatus.Match(host); ok && surface == proxystatus.SurfaceSkysocks {
 		return statusHTTPResponse(proxystatus.Render(c.statusSnapshot()))
@@ -365,9 +370,10 @@ func (c *Client) statusOverride(host string) []byte {
 }
 
 // serveStatusPage completes the SOCKS5 CONNECT with a success reply, reads the
-// browser's HTTP request, and routes on its path: "/sse" opens a live Server-Sent
-// Events stream (serveStatusSSE); anything else gets the one-shot rendered
-// status.skysocks page. Best-effort: any write failure just drops the conn.
+// browser's HTTP request, and routes on its path: "/ws" upgrades to a live,
+// bidirectional WebSocket (serveStatusWS); anything else gets the one-shot
+// rendered status.skysocks page. Best-effort: any write failure just drops the
+// conn.
 func (c *Client) serveStatusPage(conn, stream net.Conn) {
 	// CONNECT success with a dummy BND.ADDR/PORT so the browser proceeds to send
 	// its HTTP request.
@@ -383,11 +389,14 @@ func (c *Client) serveStatusPage(conn, stream net.Conn) {
 	n, _ := conn.Read(buf)                //nolint:errcheck // best-effort; page is fixed
 	_ = conn.SetReadDeadline(time.Time{}) //nolint:errcheck
 
-	if statusRequestPath(buf[:n]) == "/sse" {
+	if statusRequestPath(buf[:n]) == "/ws" {
 		// status is served entirely in-process, so the exit-side yamux stream is
-		// unused — close it now so a long-lived SSE stream doesn't pin one open.
+		// unused — close it now so the long-lived WS loop doesn't pin one open.
 		stream.Close() //nolint:errcheck,gosec
-		c.serveStatusSSE(conn)
+		if !wsHandshake(conn, buf[:n]) {
+			return
+		}
+		c.serveStatusWS(conn)
 		return
 	}
 
@@ -398,7 +407,7 @@ func (c *Client) serveStatusPage(conn, stream net.Conn) {
 // statusRequestPath extracts the request-target path from an HTTP request line
 // ("METHOD SP PATH SP VERSION"), stripping any query string. It defaults to "/"
 // for anything it can't parse, so a malformed request falls through to the
-// full-page render rather than the SSE stream.
+// full-page render rather than the WebSocket upgrade.
 func statusRequestPath(req []byte) string {
 	line := req
 	if i := bytes.IndexByte(line, '\n'); i >= 0 {
@@ -415,70 +424,277 @@ func statusRequestPath(req []byte) string {
 	return string(p)
 }
 
-// SSE stream tuning. sseTickInterval is how often a fresh live-region fragment is
-// pushed — ~1s is responsive enough to watch a route warm without thrashing.
-// sseWriteTimeout bounds each write so a wedged/stalled browser conn errors out
-// (ending the goroutine) instead of blocking on a full send buffer forever.
+// --- status.skysocks WebSocket control channel -------------------------------
+//
+// The live status region is pushed to the browser over a WebSocket (RFC6455)
+// carried on the hijacked plaintext SOCKS stream, replacing the earlier one-way
+// SSE stream. WebSocket is bidirectional: the same conn carries fragment pushes
+// server→browser AND control commands browser→server, so the page can become a
+// proxy control surface. The handshake and framing are hand-rolled (a few dozen
+// lines) rather than pulling in a library, because the conn is an already-
+// hijacked raw net.Conn with no http.ResponseWriter for a library's server
+// Accept() to hijack.
+
+// WebSocket loop tuning. wsPushInterval is how often a fresh live-region fragment
+// is pushed — ~1s is responsive enough to watch a route warm without thrashing.
+// wsPingInterval keeps an idle conn alive (the browser auto-replies PONG, which
+// also resets the read deadline). wsReadTimeout must exceed wsPingInterval so an
+// idle-but-healthy conn is not torn down; wsWriteTimeout bounds each write so a
+// wedged browser errors out instead of blocking forever.
 const (
-	sseTickInterval = time.Second
-	sseWriteTimeout = 10 * time.Second
+	wsPushInterval = time.Second
+	wsPingInterval = 25 * time.Second
+	wsReadTimeout  = 90 * time.Second
+	wsWriteTimeout = 10 * time.Second
 )
 
-// serveStatusSSE streams the live status region to the browser as Server-Sent
-// Events over the hijacked (plaintext HTTP/1.1) SOCKS stream: no TLS/upgrade
-// handshake, just an event-stream response the browser's EventSource consumes. It
-// writes the SSE header, pushes the current fragment immediately, then once per
-// tick. It returns — releasing this goroutine and the conn — when the client goes
-// away (write error / write deadline) or the client shuts down (closeC), so a
-// session reconnect or proxy restart cannot leak the goroutine. The loop is
-// ctx/timer-light (one ticker, no per-tick goroutine) so it is safe under the
-// single-threaded wasm runtime, though that path is not normally exercised there.
-func (c *Client) serveStatusSSE(conn net.Conn) {
-	const hdr = "HTTP/1.1 200 OK\r\n" +
-		"Content-Type: text/event-stream\r\n" +
-		"Cache-Control: no-store\r\n" +
-		"Connection: keep-alive\r\n\r\n"
-	_ = conn.SetWriteDeadline(time.Now().Add(sseWriteTimeout)) //nolint:errcheck
-	if _, err := conn.Write([]byte(hdr)); err != nil {
-		return
-	}
+// RFC6455 opcodes (only the ones this endpoint uses).
+const (
+	wsOpText  = 0x1
+	wsOpClose = 0x8
+	wsOpPing  = 0x9
+	wsOpPong  = 0xA
+)
 
-	// Push once immediately so the client syncs without waiting a full tick.
-	if !c.writeSSEFragment(conn) {
+// wsGUID is the RFC6455 magic appended to Sec-WebSocket-Key before the SHA-1.
+const wsGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+// wsHandshake completes the RFC6455 opening handshake over the hijacked plaintext
+// stream: it reads the client's Sec-WebSocket-Key out of the already-buffered
+// request bytes and replies "101 Switching Protocols" with the computed
+// Sec-WebSocket-Accept (base64(sha1(key + wsGUID))). Returns false (dropping the
+// conn) when the request is not a well-formed upgrade.
+func wsHandshake(conn net.Conn, req []byte) bool {
+	key := httpHeaderValue(req, "Sec-WebSocket-Key")
+	if key == "" || !strings.EqualFold(httpHeaderValue(req, "Upgrade"), "websocket") {
+		return false
+	}
+	sum := sha1.Sum([]byte(key + wsGUID)) //nolint:gosec // RFC6455 mandates SHA-1 here
+	accept := base64.StdEncoding.EncodeToString(sum[:])
+	resp := "HTTP/1.1 101 Switching Protocols\r\n" +
+		"Upgrade: websocket\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Sec-WebSocket-Accept: " + accept + "\r\n\r\n"
+	_ = conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout)) //nolint:errcheck
+	_, err := conn.Write([]byte(resp))
+	_ = conn.SetWriteDeadline(time.Time{}) //nolint:errcheck
+	return err == nil
+}
+
+// httpHeaderValue returns the value of the named header (case-insensitive) from a
+// raw HTTP request, or "" if absent.
+func httpHeaderValue(req []byte, name string) string {
+	for _, ln := range strings.Split(string(req), "\n") {
+		ln = strings.TrimRight(ln, "\r")
+		i := strings.IndexByte(ln, ':')
+		if i < 0 {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(ln[:i]), name) {
+			return strings.TrimSpace(ln[i+1:])
+		}
+	}
+	return ""
+}
+
+// wsConn serializes server→client frame writes (the push loop, PONG replies and
+// resync responses all share one conn) behind a mutex.
+type wsConn struct {
+	conn net.Conn
+	mu   sync.Mutex
+}
+
+// write emits one server→client frame (never masked, per RFC6455) with a bounded
+// write deadline.
+func (w *wsConn) write(opcode byte, payload []byte) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_ = w.conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout)) //nolint:errcheck
+	return wsWriteFrame(w.conn, opcode, payload)
+}
+
+// statusControlCmd is the JSON shape of a browser→server control frame on the
+// status.skysocks WebSocket, e.g. {"cmd":"resync"}. Kept deliberately small; the
+// mux-control commands add fields here when they land (see handleStatusControl).
+type statusControlCmd struct {
+	Cmd string `json:"cmd"`
+}
+
+// serveStatusWS runs the bidirectional status WebSocket over the hijacked
+// (already-upgraded) plaintext SOCKS stream. A reader goroutine consumes
+// browser→server frames (control commands, PING, CLOSE) while the main loop
+// pushes a fresh live-region fragment every wsPushInterval and a keepalive PING
+// every wsPingInterval. It returns — releasing this goroutine, the reader and the
+// conn — when the browser goes away (read/write error or CLOSE) or the client
+// shuts down (closeC), so a session reconnect or proxy restart cannot leak it.
+// The loop is ctx/timer-light (two tickers, no per-tick goroutine) so it is safe
+// under the single-threaded wasm runtime, though that path is not normally
+// exercised there.
+func (c *Client) serveStatusWS(conn net.Conn) {
+	w := &wsConn{conn: conn}
+	stopC := make(chan struct{})
+	var stopOnce sync.Once
+	stop := func() { stopOnce.Do(func() { close(stopC) }) }
+
+	// Reader: browser→server frames. Blocks in wsReadFrame; the read deadline
+	// (reset each iteration) plus closeC/stopC guarantee it can't wedge.
+	go func() {
+		defer stop()
+		for {
+			select {
+			case <-stopC:
+				return
+			case <-c.closeC:
+				return
+			default:
+			}
+			_ = conn.SetReadDeadline(time.Now().Add(wsReadTimeout)) //nolint:errcheck
+			op, payload, err := wsReadFrame(conn)
+			if err != nil {
+				return
+			}
+			switch op {
+			case wsOpText:
+				c.handleStatusControl(payload, w)
+			case wsOpPing:
+				if err := w.write(wsOpPong, payload); err != nil {
+					return
+				}
+			case wsOpClose:
+				return
+			default:
+				// wsOpPong / continuation / binary: ignore.
+			}
+		}
+	}()
+
+	// Push once immediately so the browser syncs without waiting a full tick.
+	if err := w.write(wsOpText, proxystatus.RenderFragment(c.statusSnapshot())); err != nil {
+		stop()
 		return
 	}
-	ticker := time.NewTicker(sseTickInterval)
-	defer ticker.Stop()
+	push := time.NewTicker(wsPushInterval)
+	ping := time.NewTicker(wsPingInterval)
+	defer push.Stop()
+	defer ping.Stop()
 	for {
 		select {
 		case <-c.closeC:
+			stop()
 			return
-		case <-ticker.C:
-			if !c.writeSSEFragment(conn) {
+		case <-stopC:
+			return
+		case <-push.C:
+			if err := w.write(wsOpText, proxystatus.RenderFragment(c.statusSnapshot())); err != nil {
+				stop()
+				return
+			}
+		case <-ping.C:
+			if err := w.write(wsOpPing, nil); err != nil {
+				stop()
 				return
 			}
 		}
 	}
 }
 
-// writeSSEFragment renders the current live-region fragment (rebuilt each tick via
-// the same statusSnapshot() path the full page uses) and writes it as one SSE
-// event. The fragment's internal newlines (the <pre> log block) are preserved by
-// emitting one "data:" line per source line — the browser's EventSource rejoins
-// them with '\n' — so no newline escaping is needed. Returns false when the write
-// fails (client gone / past its write deadline), signaling the caller to stop.
-func (c *Client) writeSSEFragment(conn net.Conn) bool {
-	frag := proxystatus.RenderFragment(c.statusSnapshot())
-	var b bytes.Buffer
-	for _, line := range bytes.Split(frag, []byte("\n")) {
-		b.WriteString("data: ")
-		b.Write(line)
-		b.WriteByte('\n')
+// handleStatusControl dispatches a browser→server control frame (JSON, e.g.
+// {"cmd":"resync"}). This is the seam that turns the read-only status page into a
+// proxy control surface. Only SAFE, already-available actions are wired here:
+//
+//   - "resync": push a fresh live-region fragment immediately.
+//
+// TODO(mux-control): the mux-op commands the page previews as disabled buttons —
+// "add_leg", "drop_leg", "mux_mode", "rebuild" — are the next step. They mutate
+// the surface's route group and so need an app→visor mux-control RPC that does not
+// exist yet. The building blocks are already present (visor.RouteGroupMuxInfo for
+// the current legs, router.AddMuxRoute to grow one, and the `cli proxy mux set`
+// reconcile path for mode/rebuild); exposing them over the app RPC as a mutating
+// proxystatus.Provider method is OUT OF SCOPE here. When that lands, add the cases
+// below and enable the matching buttons in pkg/proxystatus/render.go.
+func (c *Client) handleStatusControl(payload []byte, w *wsConn) {
+	var cmd statusControlCmd
+	if err := json.Unmarshal(payload, &cmd); err != nil {
+		return
 	}
-	b.WriteByte('\n')                                          // blank line terminates the event
-	_ = conn.SetWriteDeadline(time.Now().Add(sseWriteTimeout)) //nolint:errcheck
-	_, err := conn.Write(b.Bytes())
-	return err == nil
+	switch cmd.Cmd {
+	case "resync":
+		_ = w.write(wsOpText, proxystatus.RenderFragment(c.statusSnapshot())) //nolint:errcheck
+	case "add_leg", "drop_leg", "mux_mode", "rebuild":
+		// TODO(mux-control): wire once the app→visor mux-control RPC exists.
+	default:
+		// Unknown/unwired command: ignore.
+	}
+}
+
+// wsWriteFrame writes a single unmasked (server→client) RFC6455 frame: FIN set,
+// the given opcode, and payload. It implements the 7-bit, 16-bit (126) and 64-bit
+// (127) length forms; the status fragment is a few KB, so the 16-bit path is the
+// common one.
+func wsWriteFrame(conn net.Conn, opcode byte, payload []byte) error {
+	var hdr []byte
+	b0 := byte(0x80) | opcode // FIN + opcode
+	n := len(payload)
+	switch {
+	case n < 126:
+		hdr = []byte{b0, byte(n)} //nolint:gosec // n<126 fits one byte
+	case n < 1<<16:
+		hdr = []byte{b0, 126, byte(n >> 8), byte(n)} //nolint:gosec // n<65536: high+low bytes
+	default:
+		var ext [8]byte
+		binary.BigEndian.PutUint64(ext[:], uint64(n)) //nolint:gosec // len() is non-negative
+		hdr = append([]byte{b0, 127}, ext[:]...)
+	}
+	if _, err := conn.Write(hdr); err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
+	_, err := conn.Write(payload)
+	return err
+}
+
+// wsReadFrame reads a single client→server RFC6455 frame and returns its opcode
+// and unmasked payload. Client frames MUST be masked (RFC6455 §5.1); the 4-byte
+// masking key is applied to the payload here. The 7-bit and 16-bit length forms
+// are handled (a control command is tiny); a 64-bit length is rejected as
+// oversized rather than trusted.
+func wsReadFrame(conn net.Conn) (opcode byte, payload []byte, err error) {
+	h := make([]byte, 2)
+	if _, err = io.ReadFull(conn, h); err != nil {
+		return 0, nil, err
+	}
+	opcode = h[0] & 0x0f
+	masked := h[1]&0x80 != 0
+	n := int(h[1] & 0x7f)
+	switch n {
+	case 126:
+		ext := make([]byte, 2)
+		if _, err = io.ReadFull(conn, ext); err != nil {
+			return 0, nil, err
+		}
+		n = int(ext[0])<<8 | int(ext[1])
+	case 127:
+		return 0, nil, fmt.Errorf("ws frame too large")
+	}
+	var mask []byte
+	if masked {
+		mask = make([]byte, 4)
+		if _, err = io.ReadFull(conn, mask); err != nil {
+			return 0, nil, err
+		}
+	}
+	payload = make([]byte, n)
+	if _, err = io.ReadFull(conn, payload); err != nil {
+		return 0, nil, err
+	}
+	if masked {
+		for i := range payload {
+			payload[i] ^= mask[i&3]
+		}
+	}
+	return opcode, payload, nil
 }
 
 // statusSnapshot builds the read-only status.skysocks snapshot. The rich

--- a/pkg/skysocks/client_status_test.go
+++ b/pkg/skysocks/client_status_test.go
@@ -3,6 +3,7 @@ package skysocks
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"net"
 	"net/http"
@@ -176,11 +177,59 @@ func TestStatusSkysocksIntercepted(t *testing.T) {
 	}
 }
 
-// TestStatusSkysocksSSEStream verifies that a CONNECT to status.skysocks with an
-// HTTP request for /sse is answered in-process with an SSE event stream (the live
-// live-region fragment), not the one-shot full page, and is never forwarded to
-// the exit.
-func TestStatusSkysocksSSEStream(t *testing.T) {
+// wsExpectedAccept is Sec-WebSocket-Accept for wsSampleKey — the RFC6455 §1.3
+// worked example (base64(sha1("dGhlIHNhbXBsZSBub25jZQ==" + GUID))). Asserting the
+// exact value validates the server's accept-key computation.
+const (
+	wsSampleKey   = "dGhlIHNhbXBsZSBub25jZQ=="
+	wsExpectedAcc = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+)
+
+// readServerWSFrame reads one server→client (unmasked) RFC6455 frame from br,
+// handling the 7-bit and 16-bit (126) length forms. It is the test-side mirror of
+// the browser's frame reader.
+func readServerWSFrame(t *testing.T, br *bufio.Reader) (opcode byte, payload []byte) {
+	t.Helper()
+	h := make([]byte, 2)
+	if _, err := io.ReadFull(br, h); err != nil {
+		t.Fatalf("read frame header: %v", err)
+	}
+	opcode = h[0] & 0x0f
+	if h[1]&0x80 != 0 {
+		t.Fatal("server frame must not be masked")
+	}
+	n := int(h[1] & 0x7f)
+	if n == 126 {
+		ext := make([]byte, 2)
+		if _, err := io.ReadFull(br, ext); err != nil {
+			t.Fatalf("read ext len: %v", err)
+		}
+		n = int(ext[0])<<8 | int(ext[1])
+	}
+	payload = make([]byte, n)
+	if _, err := io.ReadFull(br, payload); err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	return opcode, payload
+}
+
+// maskedClientFrame builds a masked client→server RFC6455 frame (FIN set) for a
+// <126-byte payload, as a browser would send it.
+func maskedClientFrame(opcode byte, payload []byte) []byte {
+	mask := []byte{0xa1, 0xb2, 0xc3, 0xd4}
+	frame := []byte{0x80 | opcode, byte(0x80 | len(payload))} //nolint:gosec // test payloads are <126 bytes
+	frame = append(frame, mask...)
+	for i, b := range payload {
+		frame = append(frame, b^mask[i&3])
+	}
+	return frame
+}
+
+// TestStatusSkysocksWSStream verifies that a CONNECT to status.skysocks with an
+// HTTP request for /ws is upgraded in-process to a WebSocket (101 + a valid
+// Sec-WebSocket-Accept), pushes the live-region fragment as a TEXT frame, accepts
+// a masked {"cmd":"resync"} control frame, and is never forwarded to the exit.
+func TestStatusSkysocksWSStream(t *testing.T) {
 	c, exit := newTestClient(t)
 	defer c.Close() //nolint:errcheck
 
@@ -195,62 +244,105 @@ func TestStatusSkysocksSSEStream(t *testing.T) {
 
 	conn := socks5Connect(t, addr, "status.skysocks", 80)
 	defer conn.Close() //nolint:errcheck
-	if _, err := conn.Write([]byte("GET /sse HTTP/1.1\r\nHost: status.skysocks\r\nAccept: text/event-stream\r\n\r\n")); err != nil {
+	req := "GET /ws HTTP/1.1\r\nHost: status.skysocks\r\n" +
+		"Upgrade: websocket\r\nConnection: Upgrade\r\n" +
+		"Sec-WebSocket-Key: " + wsSampleKey + "\r\n\r\n"
+	if _, err := conn.Write([]byte(req)); err != nil {
 		t.Fatal(err)
 	}
 
 	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
 	br := bufio.NewReader(conn)
-	// Status line + headers: must be an event-stream, not text/html.
+	// Handshake: 101 Switching Protocols + the RFC6455 accept key.
 	statusLine, err := br.ReadString('\n')
-	if err != nil || !strings.HasPrefix(statusLine, "HTTP/1.1 200") {
-		t.Fatalf("bad SSE status line %q err=%v", statusLine, err)
+	if err != nil || !strings.HasPrefix(statusLine, "HTTP/1.1 101") {
+		t.Fatalf("bad WS status line %q err=%v", statusLine, err)
 	}
-	var sawEventStream bool
+	var accept string
 	for {
 		line, err := br.ReadString('\n')
 		if err != nil {
-			t.Fatalf("reading SSE headers: %v", err)
+			t.Fatalf("reading WS handshake headers: %v", err)
 		}
-		if strings.Contains(strings.ToLower(line), "text/event-stream") {
-			sawEventStream = true
+		if v, ok := strings.CutPrefix(line, "Sec-WebSocket-Accept: "); ok {
+			accept = strings.TrimSpace(v)
 		}
 		if line == "\r\n" || line == "\n" {
 			break // end of headers
 		}
 	}
-	if !sawEventStream {
-		t.Fatal("SSE response missing text/event-stream content-type")
+	if accept != wsExpectedAcc {
+		t.Fatalf("Sec-WebSocket-Accept = %q, want %q", accept, wsExpectedAcc)
 	}
-	// First pushed event: at least one data: line carrying the live fragment.
-	var gotData bool
-	for i := 0; i < 200; i++ {
-		line, err := br.ReadString('\n')
-		if err != nil {
-			t.Fatalf("reading SSE event: %v", err)
-		}
-		if strings.HasPrefix(line, "data: ") {
-			gotData = true
-			if strings.Contains(line, "per-leg mux") {
-				break // reconstructed fragment reached the live region
-			}
-		}
-		if gotData && (line == "\n" || line == "\r\n") {
-			break // event terminated
-		}
+
+	// First server push: a TEXT frame carrying the live-region fragment.
+	op, payload := readServerWSFrame(t, br)
+	if op != 0x1 {
+		t.Fatalf("first frame opcode = %#x, want TEXT", op)
 	}
-	if !gotData {
-		t.Fatal("SSE stream produced no data: event")
+	if !bytes.Contains(payload, []byte("per-leg mux")) {
+		t.Fatalf("pushed fragment missing live region; got %q", string(payload))
+	}
+
+	// Send a masked control command; the server must parse it and push a fresh
+	// fragment in response (proving the browser→server control path).
+	if _, err := conn.Write(maskedClientFrame(0x1, []byte(`{"cmd":"resync"}`))); err != nil {
+		t.Fatal(err)
+	}
+	op2, payload2 := readServerWSFrame(t, br)
+	if op2 != 0x1 {
+		t.Fatalf("post-resync frame opcode = %#x, want TEXT", op2)
+	}
+	if !bytes.Contains(payload2, []byte("per-leg mux")) {
+		t.Fatalf("post-resync fragment missing live region; got %q", string(payload2))
 	}
 
 	// The exit must never have received a status.skysocks CONNECT.
 	select {
 	case h := <-exit.hostC:
 		if h == "status.skysocks" {
-			t.Fatal("status.skysocks /sse leaked to the exit")
+			t.Fatal("status.skysocks /ws leaked to the exit")
 		}
 	case <-time.After(200 * time.Millisecond):
 	}
+}
+
+// TestWSFrameCodec unit-tests the hand-rolled framing: wsWriteFrame emits a valid
+// unmasked server frame (exercising the 16-bit extended-length path for a payload
+// > 125 bytes) that round-trips through wsReadFrame, and wsReadFrame correctly
+// unmasks a masked client control frame.
+func TestWSFrameCodec(t *testing.T) {
+	// Server write (unmasked), >125 bytes -> 16-bit length path, read back.
+	big := bytes.Repeat([]byte("x"), 300)
+	cli, srv := net.Pipe()
+	go func() {
+		_ = wsWriteFrame(srv, wsOpText, big) //nolint:errcheck
+		_ = srv.Close()                      //nolint:errcheck
+	}()
+	op, got, err := wsReadFrame(cli)
+	if err != nil {
+		t.Fatalf("wsReadFrame(server frame): %v", err)
+	}
+	if op != wsOpText || !bytes.Equal(got, big) {
+		t.Fatalf("round-trip mismatch: op=%#x len=%d", op, len(got))
+	}
+	_ = cli.Close() //nolint:errcheck
+
+	// Masked client control frame -> wsReadFrame must unmask it.
+	cmd := []byte(`{"cmd":"resync"}`)
+	cli2, srv2 := net.Pipe()
+	go func() {
+		_, _ = cli2.Write(maskedClientFrame(wsOpText, cmd)) //nolint:errcheck
+		_ = cli2.Close()                                    //nolint:errcheck
+	}()
+	op, got, err = wsReadFrame(srv2)
+	if err != nil {
+		t.Fatalf("wsReadFrame(masked client frame): %v", err)
+	}
+	if op != wsOpText || !bytes.Equal(got, cmd) {
+		t.Fatalf("masked parse mismatch: op=%#x payload=%q", op, string(got))
+	}
+	_ = srv2.Close() //nolint:errcheck
 }
 
 // TestNonStatusForwardedToExit verifies a regular CONNECT is transparently


### PR DESCRIPTION
## What

Convert the `status.skysocks` live-update transport from SSE to a WebSocket, and structure it as a bidirectional control channel so the page can grow into a proxy control surface.

## Why

The old page opened `new EventSource("http://status.skysocks/sse")`. That absolute `http://` URL is force-upgraded to `https` by the browser's HTTPS-Only Mode and then fails on the HTTP-only `.skysocks` host, so the EventSource errored and the page fell back to a full reload. SSE is also one-way, so the page could never send anything back.

## How

**Server (`pkg/skysocks/client.go`):** on request path `/ws`, the skysocks-client (which already sniffs the hijacked SOCKS5 CONNECT stream for `status.skysocks`) performs the RFC6455 handshake — reads `Sec-WebSocket-Key`, replies `101` with `Sec-WebSocket-Accept = base64(sha1(key + GUID))` — then runs a bidirectional loop:
- push: renders `proxystatus.RenderFragment(statusSnapshot())` as a TEXT frame every ~1s, plus periodic PINGs; replies PONG to client PINGs.
- receive: a reader goroutine decodes client TEXT frames as JSON control commands and dispatches via `handleStatusControl`.

Framing is hand-rolled (7/16/64-bit lengths; client→server frames are unmasked here) because the conn is an already-hijacked raw `net.Conn` with no `http.ResponseWriter` for a library `Accept()` to wrap. The loop is read/write-deadline- and `closeC`-bounded so it can't leak, and the unused exit-side yamux stream is closed before the long-lived loop (mirroring the old SSE lifecycle).

**Control protocol:** `{"cmd":"<name>"}`. Wired now: `resync` (immediate fragment push). Left as documented TODO seams: `add_leg` / `drop_leg` / `mux_mode` / `rebuild`, which mutate the route group and need an app→visor mux-control RPC (building blocks — `RouteGroupMuxInfo`, `AddMuxRoute`, the `cli proxy mux set` reconcile path — exist but wiring them is out of scope here).

**Client (`pkg/proxystatus/render.go`):** the inline script derives the URL from the page's own origin (`location.origin.replace(/^http/,"ws") + "/ws"`) instead of a hardcoded `http://`, swaps `#live` innerHTML on each message, reconnects with a 2s backoff (the slow 15s full-reload survives only as a last resort), and exposes `window.sendCmd(obj)`. The control panel's `resync` button is now live; the mux-op buttons stay disabled with a TODO. The no-JS server-rendered initial paint is unchanged (progressive enhancement).

## Tests

`pkg/skysocks/client_status_test.go`: WS handshake returns `101` + the RFC6455 example `Sec-WebSocket-Accept`, a server TEXT frame decodes to the live fragment, and a masked `{"cmd":"resync"}` client frame is parsed (plus a `net.Pipe` codec round-trip exercising the 16-bit length path). `go build .`, `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor`, `go vet`, gofmt and golangci-lint are clean.
