### PR TITLE
help: print the help screen over a still frame of the code rain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 
 require (
 	github.com/0magnet/plot-go v0.0.0-20260820145748-0b260a086d19
+	github.com/0magnet/termanim v0.0.0-20260823195938-f88b1541cfcd
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/DiSiqueira/GoTree v1.0.0
 	github.com/ccding/go-stun v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/0magnet/plot-go v0.0.0-20260820145748-0b260a086d19 h1:HDuBSefzYQcFM69
 github.com/0magnet/plot-go v0.0.0-20260820145748-0b260a086d19/go.mod h1:LCfGAHo2mK7Su2xbCf9xwiLrlXt/YOcGW7LZ4owtiCk=
 github.com/0magnet/sh/v3 v3.13.2-0.20260814172914-eff537668adf h1:3tImGgrBxM3/eC13YeT8WsT5B3E3dxmHtozvgo0xtpo=
 github.com/0magnet/sh/v3 v3.13.2-0.20260814172914-eff537668adf/go.mod h1:IdyC3iqIKArn4KOl0a58dV2spH0PH6pLJKOZYB2kFR0=
+github.com/0magnet/termanim v0.0.0-20260823195938-f88b1541cfcd h1:uIU35LENZsiWRfDWTBAoQKwe4S5MccJXu5dlBB/0u1w=
+github.com/0magnet/termanim v0.0.0-20260823195938-f88b1541cfcd/go.mod h1:z/hEqBGeyX7Az2HZbJqgMEZo5eJf4SBcxKCZTZ1X4jU=
 github.com/0magnet/u-root v0.16.1-0.20260810212217-0890fe5099f9 h1:akt/1o/SlArz8M/n+piy0eyKaBa83wrxQmrLgh6FlPU=
 github.com/0magnet/u-root v0.16.1-0.20260810212217-0890fe5099f9/go.mod h1:fId14v+rNp1A0ZKHJPZZyiu9dfgWKEs7nbyvKrku3bo=
 github.com/0magnet/websh v0.0.0-20260816200521-e9f14eb862c7 h1:09IjBB/rJMVtrkn4i1571Nq+iSMEIsjv7S4zlJzKEuQ=

--- a/pkg/cliout/filter.go
+++ b/pkg/cliout/filter.go
@@ -57,7 +57,7 @@ func RegisterOutputFlags(cmd *cobra.Command) {
 func SetJSONHelp(root *cobra.Command) {
 	defaultHelp := root.HelpFunc()
 	root.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		if !machineMode(cmd) {
+		if !MachineMode(cmd) {
 			defaultHelp(cmd, args)
 			return
 		}
@@ -67,8 +67,10 @@ func SetJSONHelp(root *cobra.Command) {
 	})
 }
 
-// machineMode reports whether any machine-output flag was set.
-func machineMode(cmd *cobra.Command) bool {
+// MachineMode reports whether any machine-output flag was set, which is to say
+// whether Help will print a schema for something else to consume rather than
+// help for someone to read.
+func MachineMode(cmd *cobra.Command) bool {
 	return JSONMode(cmd) || JQFilter(cmd) != "" || ShapeMode(cmd)
 }
 

--- a/pkg/flags/helpall.go
+++ b/pkg/flags/helpall.go
@@ -131,17 +131,22 @@ func findChild(c *cobra.Command, name string) *cobra.Command {
 
 // PrintHelpAll writes root.Help() followed by each subcommand's Help().
 // With recursive=true, every descendant is included.
+//
+// Plain: this produces text to keep rather than to look at, and a frame of
+// help-rain per command in the tree is not that. See withPlainHelp.
 func PrintHelpAll(root *cobra.Command, recursive bool) {
-	printCmdHelp(root)
-	for _, c := range root.Commands() {
-		if !c.IsAvailableCommand() {
-			continue
+	withPlainHelp(func() {
+		printCmdHelp(root)
+		for _, c := range root.Commands() {
+			if !c.IsAvailableCommand() {
+				continue
+			}
+			printCmdHelp(c)
+			if recursive {
+				printDescendantsHelp(c)
+			}
 		}
-		printCmdHelp(c)
-		if recursive {
-			printDescendantsHelp(c)
-		}
-	}
+	})
 }
 
 func printDescendantsHelp(c *cobra.Command) {
@@ -198,9 +203,13 @@ func printTreeChildren(c *cobra.Command, prefix string) {
 // direct children = H2, etc.), capped at H6 to stay within CommonMark.
 // The help text is wrapped in fenced code blocks.
 func PrintCommandDocs(root *cobra.Command) {
-	fmt.Printf("# %s\n\n", root.CommandPath())
-	printCmdDoc(root, 1)
-	walkCmdDocs(root, 2)
+	// Plain: this is markdown for a file. Escape sequences in a fenced code
+	// block are not decoration, they are litter. See withPlainHelp.
+	withPlainHelp(func() {
+		fmt.Printf("# %s\n\n", root.CommandPath())
+		printCmdDoc(root, 1)
+		walkCmdDocs(root, 2)
+	})
 }
 
 func walkCmdDocs(c *cobra.Command, depth int) {

--- a/pkg/flags/rain.go
+++ b/pkg/flags/rain.go
@@ -1,0 +1,100 @@
+// Package flags pkg/flags/rain.go
+//
+// InitRain prints the help screen over a still frame of the Matrix code rain,
+// seeded from the clock so it is different every time. It is decoration and
+// nothing else, and it is confined to the one screen where decoration costs
+// nothing: help is printed once, read, and scrolled past. Nothing parses it.
+//
+// It is off in every case where the output is not a person reading a terminal
+// — see rainOptions.
+package flags
+
+import (
+	"os"
+	"sync"
+
+	"github.com/spf13/cobra"
+
+	"github.com/0magnet/termanim/matrix/backdrop"
+	"github.com/0magnet/termanim/matrix/backdrop/cobrarain"
+
+	"github.com/skycoin/skywire/pkg/cliout"
+)
+
+// NoRainEnv turns the backdrop off while leaving the help colored. NO_COLOR
+// turns off both, which is what NO_COLOR is for; this is for someone who wants
+// the colors and not the rain.
+const NoRainEnv = "SKYWIRE_NO_HELP_RAIN"
+
+var (
+	// plainHelp suppresses the backdrop for the duration of a call that is
+	// producing help text rather than showing it. `help -d` writes markdown
+	// meant to be committed to a file and `help -r` dumps every command in the
+	// tree; neither wants a frame of rain per command, and the markdown would
+	// carry the escapes into the document.
+	plainHelp   bool
+	plainHelpMu sync.Mutex
+
+	// rained records the roots already wired, so calling InitRain twice on one
+	// command does not put the rain behind a screen that already has rain
+	// behind it.
+	rained   = map[*cobra.Command]bool{}
+	rainedMu sync.Mutex
+)
+
+// InitRain makes cmd, and every command under it, print its help over the code
+// rain. Call it once, on the root: cobra looks the help function up on the
+// parent when a command has none of its own, so one call covers the tree.
+//
+// Deliberately not part of InitFlags. That runs for every binary in this
+// repository, including the services, and this is meant for the one people
+// read help in.
+func InitRain(cmd *cobra.Command) {
+	rainedMu.Lock()
+	defer rainedMu.Unlock()
+	if rained[cmd] {
+		return
+	}
+	rained[cmd] = true
+	cobrarain.OnFunc(cmd, rainOptions)
+}
+
+// rainOptions decides, per help screen, whether to draw the rain.
+//
+// Off means "hand back exactly the bytes the help function produced". The
+// cases are every one where the output is not a person reading a terminal:
+//
+//   - machine mode (--json / --jq / --shape), where Help prints a schema for
+//     something else to consume rather than help for someone to read;
+//   - `help -r` and `help -d`, which produce text to keep rather than to look
+//     at, the second of it markdown;
+//   - SKYWIRE_NO_HELP_RAIN, for someone who wants the colors without this.
+//
+// Not a terminal at all — a pipe, a redirect, `--help | less`, a --help pasted
+// into a bug report — is handled inside backdrop, along with NO_COLOR.
+//
+// Machine mode is checked here rather than relied upon by ordering. cliout's
+// own help wrapper and this one are installed in different init functions, and
+// which of them ends up outermost is not something to build on.
+func rainOptions(cmd *cobra.Command) backdrop.Options {
+	plainHelpMu.Lock()
+	plain := plainHelp
+	plainHelpMu.Unlock()
+
+	return backdrop.Options{
+		Off: plain || cliout.MachineMode(cmd) || os.Getenv(NoRainEnv) != "",
+	}
+}
+
+// withPlainHelp runs fn with the backdrop suppressed.
+func withPlainHelp(fn func()) {
+	plainHelpMu.Lock()
+	plainHelp = true
+	plainHelpMu.Unlock()
+	defer func() {
+		plainHelpMu.Lock()
+		plainHelp = false
+		plainHelpMu.Unlock()
+	}()
+	fn()
+}

--- a/pkg/flags/rain_test.go
+++ b/pkg/flags/rain_test.go
@@ -1,0 +1,98 @@
+// Package flags pkg/flags/rain_test.go: unit tests for the help backdrop
+// wiring (InitRain) and, more to the point, for every case in which it must
+// keep its hands off the output.
+package flags
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cliout"
+)
+
+// The backdrop is decoration on one screen. Everything that is not a person
+// reading a terminal must come back exactly as the help function produced it,
+// and that is what Off means.
+func TestRainOptionsOff(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		c := &cobra.Command{Use: "root", Run: func(*cobra.Command, []string) {}}
+		cliout.RegisterOutputFlags(c)
+		return c
+	}
+
+	t.Run("plain terminal help is not off", func(t *testing.T) {
+		t.Setenv(NoRainEnv, "")
+		require.False(t, rainOptions(newCmd()).Off)
+	})
+
+	// --json/--jq/--shape make Help print a schema for something else to
+	// consume. Rain in the middle of that is not decoration, it is corruption.
+	for _, flag := range []string{"json", "shape"} {
+		t.Run("machine mode: --"+flag, func(t *testing.T) {
+			t.Setenv(NoRainEnv, "")
+			c := newCmd()
+			require.NoError(t, c.ParseFlags([]string{"--" + flag}))
+			require.True(t, rainOptions(c).Off)
+		})
+	}
+	t.Run("machine mode: --jq", func(t *testing.T) {
+		t.Setenv(NoRainEnv, "")
+		c := newCmd()
+		require.NoError(t, c.ParseFlags([]string{"--jq", ".name"}))
+		require.True(t, rainOptions(c).Off)
+	})
+
+	// `help -d` writes markdown for a file and `help -r` dumps the whole tree.
+	t.Run("while printing help text to keep", func(t *testing.T) {
+		t.Setenv(NoRainEnv, "")
+		c := newCmd()
+		withPlainHelp(func() { require.True(t, rainOptions(c).Off) })
+		// ...and back on afterwards, or one `help -d` would disable it for
+		// the rest of the process.
+		require.False(t, rainOptions(c).Off)
+	})
+
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv(NoRainEnv, "1")
+		require.True(t, rainOptions(newCmd()).Off)
+	})
+}
+
+// Wiring the same root twice would put the rain behind a screen that already
+// has rain behind it.
+func TestInitRainIsIdempotent(t *testing.T) {
+	root := &cobra.Command{Use: "root", Run: func(*cobra.Command, []string) {}}
+
+	InitRain(root)
+	first := len(rained)
+	InitRain(root)
+
+	require.Equal(t, first, len(rained), "a second InitRain on the same root wrapped it again")
+
+	// Not left in the map for the next test to trip over.
+	rainedMu.Lock()
+	delete(rained, root)
+	rainedMu.Unlock()
+}
+
+// The docs and recursive modes go through the suppressing path. This is the
+// end-to-end version of the withPlainHelp case above: it drives the real help
+// command rather than calling rainOptions directly.
+func TestDocAndRecursiveModesLeaveHelpAlone(t *testing.T) {
+	t.Setenv(NoRainEnv, "")
+	for _, mode := range []string{"-d", "-r"} {
+		root := newTree()
+		InitFlags(root, true)
+		InitRain(root)
+		root.SetArgs([]string{"help", mode})
+
+		out := captureStdout(t, func() { require.NoError(t, root.Execute()) })
+		require.NotContains(t, out, "\x1b[0;38;2;", "mode %s drew a backdrop", mode)
+
+		rainedMu.Lock()
+		delete(rained, root)
+		rainedMu.Unlock()
+	}
+}

--- a/skywire.go
+++ b/skywire.go
@@ -43,6 +43,12 @@ config-gen sets the default node list via SKYCOINWEBNODES.`
 
 func init() {
 	flags.InitFlags(commands.RootCmd, true)
+	// The help screen, over a still frame of the Matrix code rain. Here rather
+	// than in InitFlags because InitFlags runs for every binary in this
+	// repository, including the services, and this is for the one people read
+	// help in. Off for --json/--jq/--shape, for `help -r` and `help -d`, for a
+	// pipe or a redirect, and for NO_COLOR or SKYWIRE_NO_HELP_RAIN.
+	flags.InitRain(commands.RootCmd)
 	// Use/Short/Version and the subcommand tree are set by the package itself
 	// (cmd/skycoin/commands), which assembles skycoin's commands on skywire's
 	// side rather than importing skycoin's own assembly.

--- a/vendor/github.com/0magnet/termanim/LICENSE
+++ b/vendor/github.com/0magnet/termanim/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Moses Narrow
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/0magnet/termanim/canvas/canvas.go
+++ b/vendor/github.com/0magnet/termanim/canvas/canvas.go
@@ -1,0 +1,334 @@
+// Package canvas is the shared machinery every animation in this repository
+// needs: a pixel surface twice the height of the terminal, and a frame loop
+// that survives the places these run.
+//
+// A terminal cell is about twice as tall as it is wide, which makes a naive
+// one-pixel-per-cell animation look squat and coarse. Drawing every cell as an
+// upper half block instead — foreground colouring the top half, background the
+// bottom — gives two independently coloured pixels per cell, roughly square,
+// at no cost. Everything here is built on that.
+package canvas
+
+import (
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// The two glyphs the surface is drawn with. tcell passes them through unchanged
+// on any UTF-8 terminal, and each carries a separate foreground and background,
+// which is what makes one cell into two pixels.
+//
+// Which one is used depends on where the colour is: a cell with both pixels lit
+// is an upper block over a background, and one with a single pixel lit is
+// whichever block puts the colour on the lit half and leaves the other to the
+// terminal. See flush.
+const (
+	upperHalf = '▀'
+	lowerHalf = '▄'
+)
+
+// The same two glyphs as strings, because that is what the screen is given.
+//
+// SetContent takes a rune and is deprecated for it: internally it does
+// string(append([]rune{r}, combining...)), so every cell costs a rune slice and
+// a string. Put takes the string directly, and a constant one is free — no
+// allocation at all. On a full-screen surface that is twenty thousand
+// allocations a frame removed, which measured as three quarters of the cost of
+// drawing one.
+const (
+	upperHalfStr = "▀"
+	// The block the other way up, for a cell whose lower pixel is lit and whose
+	// upper one is not. See flush.
+	lowerHalfStr = "▄"
+	blankStr     = " "
+)
+
+// Surface is a grid of coloured pixels, w wide and h tall, where h is twice
+// the terminal's row count. Animations draw into it and never touch the screen
+// directly.
+type Surface struct {
+	w, h int
+	px   []tcell.Color
+}
+
+// NewSurface returns a surface of w by h pixels, cleared.
+func NewSurface(w, h int) *Surface {
+	s := &Surface{w: w, h: h, px: make([]tcell.Color, w*h)}
+	s.Clear()
+	return s
+}
+
+// Size reports the surface in pixels. The terminal has half as many rows.
+func (s *Surface) Size() (w, h int) { return s.w, s.h }
+
+// Clear resets every pixel to the terminal's own background, so an animation
+// that does not cover the screen sits on whatever colour the user has rather
+// than on a black rectangle.
+func (s *Surface) Clear() {
+	for i := range s.px {
+		s.px[i] = tcell.ColorDefault
+	}
+}
+
+// Set colours one pixel. Coordinates outside the surface are dropped, so
+// animations can be written without clamping at every call site.
+func (s *Surface) Set(x, y int, c tcell.Color) {
+	if x < 0 || y < 0 || x >= s.w || y >= s.h {
+		return
+	}
+	s.px[y*s.w+x] = c
+}
+
+// At returns the colour of one pixel, or ColorDefault if out of bounds.
+func (s *Surface) At(x, y int) tcell.Color {
+	if x < 0 || y < 0 || x >= s.w || y >= s.h {
+		return tcell.ColorDefault
+	}
+	return s.px[y*s.w+x]
+}
+
+// Fill colours every pixel.
+func (s *Surface) Fill(c tcell.Color) {
+	for i := range s.px {
+		s.px[i] = c
+	}
+}
+
+// flush paints the surface onto the screen, two pixel rows per cell row.
+func (s *Surface) flush(screen tcell.Screen) {
+	rows := s.h / 2
+	for cy := 0; cy < rows; cy++ {
+		top := cy * 2 * s.w
+		bot := top + s.w
+		for x := 0; x < s.w; x++ {
+			t, b := s.px[top+x], s.px[bot+x]
+			switch {
+			case t == tcell.ColorDefault && b == tcell.ColorDefault:
+				// Nothing here. A space leaves the terminal's background
+				// showing and is cheaper for tcell to diff than a block in
+				// default-on-default.
+				screen.Put(x, cy, blankStr, tcell.StyleDefault) //nolint:errcheck
+
+			case t == tcell.ColorDefault:
+				// Only the lower pixel is lit, so the block is drawn the other
+				// way up and the empty half becomes the background.
+				//
+				// Drawing it as an upper block with a default foreground does
+				// not do that: a default foreground is a colour — whatever the
+				// terminal writes text in — so the empty half came out solid
+				// white. That is the bar that danced along the top of the fire
+				// and the fringe on everything else that does not fill the
+				// screen, because that edge is exactly where one pixel of a
+				// cell is lit and the other is not.
+				screen.Put(x, cy, lowerHalfStr, //nolint:errcheck
+					tcell.StyleDefault.Foreground(b))
+
+			case b == tcell.ColorDefault:
+				// The mirror of the case above: an upper block and no
+				// background, rather than a background of the default colour.
+				screen.Put(x, cy, upperHalfStr, //nolint:errcheck
+					tcell.StyleDefault.Foreground(t))
+
+			default:
+				st := tcell.StyleDefault.Foreground(t).Background(b)
+				screen.Put(x, cy, upperHalfStr, st) //nolint:errcheck
+			}
+		}
+	}
+}
+
+// Animation is one effect. Resize is called once before the first frame and
+// again whenever the terminal changes size; Frame draws a single frame.
+//
+// Splitting the two means an animation allocates its buffers in Resize and
+// does no allocation per frame, which matters at thirty frames a second in a
+// browser.
+type Animation interface {
+	Resize(w, h int)
+	// Frame draws one frame. dt is the seconds elapsed since the previous
+	// frame, and every motion should be scaled by it.
+	//
+	// Advancing by elapsed time rather than by frame is what lets the target
+	// rate change without changing how fast anything appears to move, and
+	// what keeps a browser tab that misses ticks from running in slow motion
+	// instead of simply dropping frames.
+	Frame(s *Surface, dt float64)
+}
+
+// Options tunes Run. The zero value is sensible.
+type Options struct {
+	// FPS is the target frame rate. Zero means 60.
+	//
+	// It is a target and not a promise. time.Ticker drops ticks rather than
+	// queueing them, so asking for more than the machine can deliver never
+	// builds a backlog — and because animations advance by elapsed time
+	// rather than by frame, missing ticks costs smoothness and not speed.
+	//
+	// 60 fits. Measured on a 200x50 terminal these effects compute a frame in
+	// 0.05 to 4.3 ms, while handing a full screen to tcell costs about 6.8 ms
+	// whatever is being drawn — the output path dominates and is the same for
+	// all of them, so even the heaviest sits inside a 16.7 ms budget.
+	FPS int
+	// MinCols and MinRows refuse to run in a window too small to show
+	// anything. Zero means 8 by 4.
+	MinCols, MinRows int
+}
+
+// CellAnimation is an effect that draws glyphs rather than pixels.
+//
+// Not everything wants half blocks. Falling text is made of characters, and
+// squeezing it onto a pixel surface would throw away the very thing it is
+// made of. Such an animation gets the screen and the cell dimensions, and both
+// shapes share the loop below.
+type CellAnimation interface {
+	Resize(cols, rows int)
+	// Frame draws one frame. dt is the seconds since the previous frame; see
+	// Animation.Frame for why it is passed rather than assumed.
+	Frame(screen tcell.Screen, cols, rows int, dt float64)
+}
+
+// Run drives a pixel animation on the given screen until the user presses q,
+// Escape or Ctrl-C, or the screen goes away.
+//
+// It does not call Init or Fini: the screen belongs to the caller. That is what
+// lets the same animation run in a terminal, in a browser pane, and inside a
+// host application that owns the screen already.
+func Run(screen tcell.Screen, a Animation, opt Options) error {
+	var surf *Surface
+	return run(screen, opt,
+		func(cols, rows int) {
+			surf = NewSurface(cols, rows*2)
+			a.Resize(cols, rows*2)
+		},
+		func(cols, rows int, dt float64) {
+			a.Frame(surf, dt)
+			surf.flush(screen)
+		})
+}
+
+// RunCells drives a glyph animation. Same loop, same keys, same resize
+// handling; the animation paints the screen itself.
+func RunCells(screen tcell.Screen, a CellAnimation, opt Options) error {
+	return run(screen, opt,
+		func(cols, rows int) { a.Resize(cols, rows) },
+		func(cols, rows int, dt float64) { a.Frame(screen, cols, rows, dt) })
+}
+
+// watched is implemented by a screen that knows whether anyone is looking at
+// it. A host that shows several animations at once — windows in a page, panes
+// in a multiplexer — can implement it to say which one is in front.
+//
+// This exists because the cost of an animation is nearly all in drawing it,
+// and drawing is worth nothing when the result is not visible. A frame is a
+// full-surface computation followed by a SetContent for every cell followed by
+// a diff and a flush; skipping the whole thing for a hidden window is the
+// difference between several of these coexisting and the host falling over.
+// It matters most where every animation shares one thread, which is exactly
+// the case in a browser.
+//
+// A screen that does not implement it is always drawn, so nothing changes for
+// a plain terminal.
+type watched interface {
+	// Active reports whether frames drawn now will be seen.
+	Active() bool
+}
+
+// maxStep bounds the elapsed time handed to an animation.
+//
+// A tab that was backgrounded, or a machine that stalled, can leave an
+// arbitrarily long gap since the last frame. Passing that through would
+// teleport every moving thing across the screen in one step — rain would jump
+// the window, a flock would scatter. Clamping trades a brief slow-down for
+// continuity, which is much less noticeable than the alternative.
+const maxStep = 0.1 // seconds
+
+// run is the loop both shapes share. resize is called before the first frame
+// and on every size change; frame is called once per tick, before Show, with
+// the seconds elapsed since the previous frame.
+func run(screen tcell.Screen, opt Options, resize func(cols, rows int), frame func(cols, rows int, dt float64)) error {
+	fps := opt.FPS
+	if fps <= 0 {
+		fps = 30
+	}
+	minCols, minRows := opt.MinCols, opt.MinRows
+	if minCols <= 0 {
+		minCols = 8
+	}
+	if minRows <= 0 {
+		minRows = 4
+	}
+
+	cols, rows := screen.Size()
+	if cols < minCols || rows < minRows {
+		return nil
+	}
+	resize(cols, rows)
+
+	// An animation has no text entry, so a cursor parked in it is only ever a
+	// blinking artefact sitting on top of the picture. It belongs here rather
+	// than in each host: tcell leaves the cursor wherever it was, so every
+	// caller that forgot would show one, and the terminal running these is
+	// often not the caller's own — a pane, a window in a page, a texture in a
+	// scene. Hosts that want the cursor back get it from Fini or by asking for
+	// it after this returns.
+	screen.HideCursor()
+
+	// Events come over a channel so the frame loop never blocks in PollEvent.
+	// tcell closes the channel when the screen is finalised, which is how a
+	// closed pane ends this goroutine instead of leaving it spinning forever.
+	events := make(chan tcell.Event)
+	quit := make(chan struct{})
+	go screen.ChannelEvents(events, quit)
+	defer close(quit)
+
+	tick := time.NewTicker(time.Second / time.Duration(fps))
+	defer tick.Stop()
+
+	// Measured from the wall clock rather than assumed from the tick rate:
+	// the whole point is that a tick the loop did not keep up with should
+	// advance the animation further, not leave it running slow.
+	last := time.Now()
+
+	for {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				return nil
+			}
+			switch ev := ev.(type) {
+			case *tcell.EventKey:
+				switch {
+				case ev.Key() == tcell.KeyEscape,
+					ev.Key() == tcell.KeyCtrlC,
+					ev.Rune() == 'q', ev.Rune() == 'Q':
+					return nil
+				}
+			case *tcell.EventResize:
+				cols, rows = ev.Size()
+				if cols < minCols || rows < minRows {
+					return nil
+				}
+				resize(cols, rows)
+				screen.Clear()
+			}
+		case now := <-tick.C:
+			dt := now.Sub(last).Seconds()
+			last = now
+			// A hidden window costs the same as a visible one unless the frame
+			// is skipped outright — the expense is in drawing, and it is
+			// incurred before anything reaches the screen. Time is still
+			// advanced past the gap, so a window brought back to the front
+			// shows where the animation would have got to rather than
+			// resuming from where it was hidden.
+			if w, ok := screen.(watched); ok && !w.Active() {
+				continue
+			}
+			if dt > maxStep {
+				dt = maxStep
+			}
+			frame(cols, rows, dt)
+			screen.Show()
+		}
+	}
+}

--- a/vendor/github.com/0magnet/termanim/canvas/palette.go
+++ b/vendor/github.com/0magnet/termanim/canvas/palette.go
@@ -1,0 +1,79 @@
+package canvas
+
+import "github.com/gdamore/tcell/v2"
+
+// Palette is a 256-entry colour ramp indexed by intensity.
+//
+// Ramps are built once and looked up per pixel. Computing a colour per pixel
+// per frame would be a needless multiply on every one of tens of thousands of
+// pixels, thirty times a second.
+type Palette [256]tcell.Color
+
+// Stop is one control point in a ramp: a position from 0 to 1 and the colour
+// the ramp passes through there.
+type Stop struct {
+	At      float64
+	R, G, B int
+}
+
+// NewPalette builds a ramp by linearly interpolating between stops. Stops must
+// be in increasing order of At; the first should be at 0 and the last at 1.
+func NewPalette(stops ...Stop) Palette {
+	var p Palette
+	if len(stops) == 0 {
+		return p
+	}
+	for i := range p {
+		t := float64(i) / 255
+		// Find the segment this intensity falls in.
+		lo := stops[0]
+		hi := stops[len(stops)-1]
+		for j := 0; j+1 < len(stops); j++ {
+			if t >= stops[j].At && t <= stops[j+1].At {
+				lo, hi = stops[j], stops[j+1]
+				break
+			}
+		}
+		span := hi.At - lo.At
+		var f float64
+		if span > 0 {
+			f = (t - lo.At) / span
+		}
+		r := float64(lo.R) + (float64(hi.R)-float64(lo.R))*f
+		g := float64(lo.G) + (float64(hi.G)-float64(lo.G))*f
+		b := float64(lo.B) + (float64(hi.B)-float64(lo.B))*f
+		p[i] = tcell.NewRGBColor(int32(r), int32(g), int32(b))
+	}
+	return p
+}
+
+// Fire is the ramp of a flame: black through dark red and orange to a white
+// core. The eye reads this sequence as temperature, which is what makes a grid
+// of numbers look hot.
+var Fire = NewPalette(
+	Stop{At: 0.00, R: 0, G: 0, B: 0},
+	Stop{At: 0.35, R: 255, G: 0, B: 0},
+	Stop{At: 0.65, R: 255, G: 153, B: 0},
+	Stop{At: 0.85, R: 255, G: 255, B: 0},
+	Stop{At: 1.00, R: 255, G: 255, B: 255},
+)
+
+// Plasma cycles through the spectrum and back to where it began, so a value
+// that wraps past 255 to 0 does not jump. A ramp that does not close leaves a
+// visible seam wherever the field wraps.
+var Plasma = NewPalette(
+	Stop{At: 0.00, R: 32, G: 0, B: 96},
+	Stop{At: 0.20, R: 192, G: 0, B: 128},
+	Stop{At: 0.40, R: 255, G: 128, B: 0},
+	Stop{At: 0.60, R: 224, G: 224, B: 32},
+	Stop{At: 0.80, R: 0, G: 160, B: 192},
+	Stop{At: 1.00, R: 32, G: 0, B: 96},
+)
+
+// Matrix runs from a nearly black green to the white head of a falling trail.
+var Matrix = NewPalette(
+	Stop{At: 0.00, R: 0, G: 8, B: 0},
+	Stop{At: 0.60, R: 0, G: 160, B: 40},
+	Stop{At: 0.90, R: 120, G: 255, B: 150},
+	Stop{At: 1.00, R: 255, G: 255, B: 255},
+)

--- a/vendor/github.com/0magnet/termanim/matrix/backdrop/backdrop.go
+++ b/vendor/github.com/0magnet/termanim/matrix/backdrop/backdrop.go
@@ -1,0 +1,459 @@
+// Package backdrop prints a block of text over a still frame of the code rain.
+//
+// It exists for help screens. A CLI's help is the one screen a user reads
+// rather than skims, and it is also the one screen a program is free to make
+// look like something: nothing parses it, nothing depends on its bytes, and it
+// is printed once and scrolled past. Putting the rain behind it costs a
+// dependency and a function call, and because the frame is taken from a
+// simulation seeded off the clock, no two runs are alike.
+//
+// The rain is a still, not an animation. Nothing takes over the terminal,
+// nothing polls for keys, and the output is a string ending in a newline —
+// help that scrolls up the scrollback the way help does.
+//
+// With cobra, the whole of it is:
+//
+//	def := root.HelpFunc()
+//	root.SetHelpFunc(func(c *cobra.Command, a []string) {
+//		var buf bytes.Buffer
+//		c.SetOut(&buf)
+//		def(c, a)
+//		c.SetOut(os.Stdout)
+//		fmt.Print(backdrop.Render(buf.String(), backdrop.Options{}))
+//	})
+//
+// or one line via matrix/backdrop/cobrarain, which is that with the edges
+// handled. Rendering the default help into a buffer rather than writing a help
+// template keeps every one of cobra's own layout rules, so the help still says
+// what it said.
+//
+// Text that is already coloured — coloredcobra, lipgloss, anything that has
+// been through a styler — keeps its own colours: the escapes in it are carried
+// through to the output and are not counted as printable width. That matters
+// more than it sounds. A program that colours its help is exactly the sort of
+// program that would want rain behind it, and measuring an escape sequence as
+// twenty columns of text puts the whole layout out.
+package backdrop
+
+import (
+	"math/rand"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"golang.org/x/term"
+
+	"github.com/0magnet/termanim/canvas"
+	"github.com/0magnet/termanim/matrix"
+)
+
+// Options tunes the backdrop. The zero value is the intended look.
+type Options struct {
+	// Width in columns. Zero asks the terminal and falls back to 80.
+	Width int
+
+	// Seed for the rain. Zero takes one from the clock, which is what makes
+	// every run different; set it to get the same frame every time, which is
+	// what a test wants.
+	Seed int64
+
+	// Steps of simulation to run before the still is taken. Zero picks a
+	// number that always leaves a full screen of rain. See matrix.Advance.
+	Steps int
+
+	// Pad is the rows of rain above and below the text, and the columns the
+	// text is indented by. Zero means 2. Without it the text sits against the
+	// edges and the rain reads as a border rather than as something behind.
+	//
+	// The indent shrinks on its own when the text would not otherwise fit the
+	// width. The rows above and below never do.
+	Pad int
+
+	// Dim scales the rain behind the text, out of 256. Zero means 56: still
+	// visible, not competing with the words. 256 does not dim at all, which
+	// looks like the film and is unreadable.
+	Dim int
+
+	// TextColor is what the text is drawn in. The zero value, ColorDefault,
+	// means a bright green-white that reads against the dimmed rain.
+	//
+	// It is ignored for text that brought its own colours. There is no sense
+	// in overriding a styler and then being asked where the styling went.
+	TextColor tcell.Color
+
+	// Force renders even when stdout is not a terminal.
+	//
+	// By default a pipe or a redirect gets the text back with no rain and
+	// nothing added, because `--help | less` and a --help pasted into a bug
+	// report both want plain text and neither wants two hundred colour
+	// changes a line. NO_COLOR and TERM=dumb are honoured the same way.
+	Force bool
+
+	// Off returns the text unchanged, whatever else is set.
+	//
+	// It is for the caller that decides per call rather than per program. A
+	// CLI that can also print its help into a markdown document wants the
+	// document plain even when it is being written to a terminal, and that is
+	// a decision only the caller is in a position to make.
+	Off bool
+}
+
+const (
+	reset = "\x1b[0m"
+	// unknown stands for "the text's own escapes left something in effect and
+	// this does not know what". Whatever is drawn next resets before it draws.
+	unknown = "\x00"
+)
+
+// Render returns text drawn over a still frame of the rain.
+//
+// It returns text unchanged when stdout is not a terminal or NO_COLOR is set,
+// unless Force says otherwise, so a caller can hand its help to this
+// unconditionally.
+func Render(text string, o Options) string {
+	if o.Off {
+		return text
+	}
+	if !o.Force && !colorOK() {
+		return text
+	}
+
+	pad := o.Pad
+	if pad == 0 {
+		pad = 2
+	}
+	dim := o.Dim
+	if dim == 0 {
+		dim = 56
+	}
+	seed := o.Seed
+	if seed == 0 {
+		seed = time.Now().UnixNano()
+	}
+	textColor := o.TextColor
+	if textColor == tcell.ColorDefault {
+		textColor = tcell.NewRGBColor(190, 255, 190)
+	}
+	textStyle := sgr(textColor, true)
+
+	raw := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	lines := make([][]glyph, len(raw))
+	styled := false
+	for i, l := range raw {
+		var any bool
+		lines[i], any = parse(l)
+		styled = styled || any
+	}
+
+	cols := o.Width
+	if cols == 0 {
+		cols = terminalWidth()
+	}
+	rows := len(lines) + 2*pad
+
+	widest := 0
+	for _, l := range lines {
+		if len(l) > widest {
+			widest = len(l)
+		}
+	}
+
+	// The indent gives way before the text does. A help screen 78 columns
+	// wide in an 80-column terminal can still have rain above and below it;
+	// what it cannot have is two columns taken off the front of every line.
+	indent := pad
+	for indent > 0 && widest+2*indent > cols {
+		indent--
+	}
+
+	// The rain is generated at the full width whatever the text does, so a
+	// short help still gets a screen-wide backdrop rather than a green box.
+	rng := rand.New(rand.NewSource(seed))
+	steps := o.Steps
+	if steps == 0 {
+		// Enough for the first columns to have fallen off the bottom, plus a
+		// spread so two runs a second apart are not near-identical frames.
+		steps = 3*rows + rng.Intn(4*rows+40)
+	}
+	m := matrix.New(seed)
+	m.Resize(cols, rows)
+	m.Advance(steps)
+
+	grid := make([]matrix.Cell, cols*rows)
+	lit := make([]bool, cols*rows)
+	m.Cells(func(x, y int, c matrix.Cell) {
+		grid[y*cols+x] = c
+		lit[y*cols+x] = true
+	})
+
+	// The panel is the box the text sits in, dimmed so the words carry. A
+	// per-line halo that followed the ragged right edge was the other option
+	// and it looks like the text has an aura; a rectangle looks like a panel.
+	panelRight := indent + widest + indent
+	if panelRight > cols {
+		panelRight = cols
+	}
+
+	var b strings.Builder
+	b.Grow(rows * cols * 4)
+	for y := 0; y < rows; y++ {
+		var line []glyph
+		if y >= pad && y-pad < len(lines) {
+			line = lines[y-pad]
+
+			// A line too wide for the terminal is written out as it came in
+			// and gets no rain on its row. The alternative is cutting it at
+			// the last column, and a backdrop is not worth a word of the
+			// help: skywire's `cli --help` runs to 108 columns, which is
+			// wider than the terminal most people read it in. Written plain
+			// it wraps exactly as it would have without any of this.
+			if indent+len(line) > cols {
+				b.WriteString(raw[y-pad])
+				b.WriteByte('\n')
+				continue
+			}
+		}
+		// A line's own span is opaque, spaces and all. Letting the rain
+		// through every gap between words is the obvious thing and it is
+		// unreadable: a glyph lands in the single space between two words and
+		// the eye joins them. Rain shows through the indent, past the end of
+		// the line, and on the blank lines between sections — which is where
+		// it wants to be anyway, since that is where there is room for it.
+		_, to, hasText := span(line)
+		from := -1
+		if hasText {
+			// The span starts at the line's own column 0, not at its first
+			// word: leading indentation is part of the line. In a flag list
+			// the indent is what lines the columns up, and a glyph sitting in
+			// it reads as content — "  ﾚ --json" looks like a typo, not like
+			// something behind the text.
+			//
+			// One clear cell each side of that, or the rain abuts the words:
+			// a glyph hard against the U of Usage reads as part of it.
+			to++
+		}
+
+		// Trailing blanks are dropped, so a row of rain that stops halfway
+		// does not carry sixty spaces and a reset to the end of the line.
+		last := -1
+		for x := 0; x < cols; x++ {
+			if inSpan(x-indent, from, to, hasText) {
+				if printable(line, x-indent) {
+					last = x
+				}
+			} else if lit[y*cols+x] {
+				last = x
+			}
+		}
+
+		prev := ""
+		for x := 0; x <= last; x++ {
+			i := x - indent
+
+			// Text, or one of the blanks inside the text's own span.
+			if inSpan(i, from, to, hasText) {
+				if !printable(line, i) {
+					// A blank inside the text keeps whatever style is in
+					// effect rather than resetting to default. Resetting
+					// breaks a coloured run at its first space: the styler
+					// coloured "-h, --help" once, at the dash, and everything
+					// after the space would come out uncoloured.
+					b.WriteByte(' ')
+					continue
+				}
+				g := line[i]
+				switch {
+				case !styled:
+					if textStyle != prev {
+						b.WriteString(textStyle)
+						prev = textStyle
+					}
+				case g.pre != "":
+					// The styler's own escapes, verbatim. What they leave in
+					// effect is its business, so the style is now unknown.
+					b.WriteString(g.pre)
+					prev = unknown
+				case prev != "" && prev != unknown:
+					// First glyph of a span with a rain colour still in
+					// effect. Without this the words come out green.
+					b.WriteString(reset)
+					prev = ""
+				}
+				b.WriteRune(g.r)
+				continue
+			}
+
+			if !lit[y*cols+x] {
+				if prev != "" {
+					b.WriteString(reset)
+					prev = ""
+				}
+				b.WriteByte(' ')
+				continue
+			}
+			c := grid[y*cols+x]
+			n := c.Intensity
+			if y >= pad && y-pad < len(lines) && x < panelRight {
+				n = n * dim / 256
+			}
+			st := sgr(canvas.Matrix[n], c.Hot)
+			if st != prev {
+				b.WriteString(st)
+				prev = st
+			}
+			b.WriteRune(c.Rune)
+		}
+		if prev != "" {
+			b.WriteString(reset)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// glyph is one printable cell of a line, with whatever escape sequences came
+// immediately before it. Keeping them attached is what lets a line be measured
+// in columns and still be reproduced byte for byte.
+type glyph struct {
+	pre string
+	r   rune
+}
+
+// parse splits a line into printable cells, expands tabs, and reports whether
+// there were any escapes at all.
+//
+// Only CSI is given any structure, which is what a styler emits. Anything else
+// is carried through in pre unexamined; it is not this package's business what
+// a terminal does with it, only that it is not counted as width.
+func parse(s string) ([]glyph, bool) {
+	if !strings.ContainsAny(s, "\x1b\t") {
+		out := make([]glyph, 0, len(s))
+		for _, r := range s {
+			out = append(out, glyph{r: r})
+		}
+		return out, false
+	}
+	var (
+		out  []glyph
+		pre  strings.Builder
+		any  bool
+		rs   = []rune(s)
+		i    int
+		cols int
+	)
+	for i < len(rs) {
+		if rs[i] == 0x1b {
+			any = true
+			start := i
+			i++
+			if i < len(rs) && rs[i] == '[' {
+				i++
+				for i < len(rs) && !isFinal(rs[i]) {
+					i++
+				}
+				if i < len(rs) {
+					i++ // the final byte
+				}
+			} else if i < len(rs) {
+				i++
+			}
+			pre.WriteString(string(rs[start:i]))
+			continue
+		}
+		if rs[i] == '\t' {
+			// A tab is worth what the terminal will make it worth, and
+			// everything here counts columns.
+			n := 8 - cols%8
+			for j := 0; j < n; j++ {
+				out = append(out, glyph{pre: pre.String(), r: ' '})
+				pre.Reset()
+				cols++
+			}
+			i++
+			continue
+		}
+		out = append(out, glyph{pre: pre.String(), r: rs[i]})
+		pre.Reset()
+		cols++
+		i++
+	}
+	return out, any
+}
+
+// isFinal reports whether r ends a CSI sequence.
+func isFinal(r rune) bool { return r >= 0x40 && r <= 0x7e }
+
+// span returns the first and last index of a printable glyph in line, and
+// whether there was one at all — a blank line, of which a help screen has
+// several, is all backdrop.
+func span(line []glyph) (from, to int, ok bool) {
+	from, to = -1, -1
+	for i, g := range line {
+		if g.r != ' ' {
+			if from < 0 {
+				from = i
+			}
+			to = i
+		}
+	}
+	return from, to, from >= 0
+}
+
+func inSpan(i, from, to int, ok bool) bool { return ok && i >= from && i <= to }
+
+// printable reports whether line has a non-space glyph at i. A space inside a
+// line is drawn blank, not as a hole for the rain to come through.
+func printable(line []glyph, i int) bool {
+	return i >= 0 && i < len(line) && line[i].r != ' '
+}
+
+// sgr builds a self-contained style: it resets first, so nothing has to be
+// emitted when going from bold to not bold.
+func sgr(c tcell.Color, bold bool) string {
+	r, g, bl := c.RGB()
+	var s strings.Builder
+	s.WriteString("\x1b[0;")
+	if bold {
+		s.WriteString("1;")
+	}
+	s.WriteString("38;2;")
+	s.WriteString(itoa(int(r)))
+	s.WriteByte(';')
+	s.WriteString(itoa(int(g)))
+	s.WriteByte(';')
+	s.WriteString(itoa(int(bl)))
+	s.WriteByte('m')
+	return s.String()
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [3]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+func colorOK() bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+func terminalWidth() int {
+	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
+		return w
+	}
+	return 80
+}

--- a/vendor/github.com/0magnet/termanim/matrix/backdrop/cobrarain/cobrarain.go
+++ b/vendor/github.com/0magnet/termanim/matrix/backdrop/cobrarain/cobrarain.go
@@ -1,0 +1,66 @@
+// Package cobrarain puts the code rain behind a cobra command's help.
+//
+// It is one call, and it is separate from matrix/backdrop so that package
+// stays free of a CLI framework:
+//
+//	cobrarain.On(rootCmd, backdrop.Options{})
+//
+// Help for every command under the root goes through it, because cobra looks
+// up the help function on the parent when a command has none of its own.
+package cobrarain
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/0magnet/termanim/matrix/backdrop"
+)
+
+// On makes cmd, and everything under it, print its help over a still frame of
+// the rain.
+//
+// The help itself is cobra's — it is rendered into a buffer by whatever help
+// function was in effect and then composited, rather than being replaced by a
+// template of ours. Every rule cobra has about what goes in a help screen and
+// where still applies; the only difference is what is behind it.
+//
+// Only Help, not Usage. Usage is what a command prints to stderr when it is
+// called wrongly, which is a thing scripts capture and people grep, and it
+// should stay plain.
+func On(cmd *cobra.Command, o backdrop.Options) {
+	OnFunc(cmd, func(*cobra.Command) backdrop.Options { return o })
+}
+
+// OnFunc is On with the options decided when the help is printed rather than
+// when it is wired up, and decided per command.
+//
+// Two things need this. A command whose own flags tune the backdrop is one:
+// cobra parses flags before it prints help, so the values are there by then
+// but not at the point On would have been called. The other is a program that
+// has more than one thing behind Help — a --json mode that prints a schema, a
+// docs mode that prints markdown — where the backdrop belongs on one of them
+// and not the others. Those wrappers may have been installed either side of
+// this one, so which is outermost is not something to rely on; return
+// Options{Off: true} for the ones that should stay plain and it does not
+// matter what order anything was wired up in.
+func OnFunc(cmd *cobra.Command, opts func(*cobra.Command) backdrop.Options) {
+	def := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		o := opts(c)
+		out := c.OutOrStdout()
+		if o.Off {
+			// Straight through, with nothing buffered. A mode that streams,
+			// or one that writes to somewhere other than c's own writer,
+			// then behaves exactly as it did before this was wired in.
+			def(c, args)
+			return
+		}
+		var buf bytes.Buffer
+		c.SetOut(&buf)
+		def(c, args)
+		c.SetOut(out)
+		fmt.Fprint(out, backdrop.Render(buf.String(), o))
+	})
+}

--- a/vendor/github.com/0magnet/termanim/matrix/matrix.go
+++ b/vendor/github.com/0magnet/termanim/matrix/matrix.go
@@ -1,0 +1,416 @@
+// Package matrix is falling columns of glyphs.
+//
+// Written from the effect rather than from any implementation of it. Columns of
+// characters fall at differing speeds and the trail fades behind the leading
+// glyph — which is the description everyone starts from, and it is where most
+// reproductions stop. Carl Newton's frame-by-frame analysis of the 1999 title
+// sequence turns up several things that description misses, and they are what
+// separates this from a green screensaver:
+//
+//   - ONLY ABOUT ONE STREAM IN FIVE leads with a highlighted glyph, and only
+//     its leading glyph is ever highlighted. Whitening every head — the obvious
+//     reading — makes a row of white dots racing down the screen. In the film
+//     most of the rain is plain green and the white heads are scattered.
+//
+//   - THE ALPHABET TURNS OVER ON A SHARED BEAT. A glyph holds for three frames
+//     and then changes, and every glyph that is going to change changes on the
+//     same frame. Flickering each one to its own clock reads as static; the
+//     original ticks over all at once and is still in between.
+//
+//   - THE HIGHLIGHTED GLYPHS STAMMER. Every so often all of them hesitate at
+//     the same moment, so the streams carrying them drop a row behind the ones
+//     that did not. It is the least obvious behaviour in the original and the
+//     reason the white heads do not stay in formation.
+//
+//   - The alphabet is half-width katakana and numerals plus exactly one letter
+//     of the English alphabet, Z.
+//
+// One thing cannot be fixed here. The film's katakana are MIRRORED, drawn as a
+// custom typeface by Simon Whiteley, and Unicode encodes no mirrored katakana —
+// so a terminal has no way to ask for them. It is the detail reproductions are
+// most often pulled up on and the only one out of reach without shipping a font.
+//
+//	https://carlnewton.github.io/digital-rain-analysis/
+//
+// Deliberately not derived from TMatrix, neo or cmatrix, all of which are
+// copyleft. Nothing here needs to be.
+package matrix
+
+import (
+	"math/rand"
+
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/0magnet/termanim/canvas"
+)
+
+// Glyphs is the default alphabet: half-width katakana, digits, and the letter
+// Z. Half-width so every glyph is one cell — full-width kana would occupy two
+// and the columns would not line up.
+//
+// The film's alphabet is a custom typeface by Simon Whiteley, and the katakana
+// in it are MIRRORED — flipped horizontally. That is the detail reproductions
+// are most often pulled up on, and it is the one thing here that cannot be
+// fixed: Unicode encodes no mirrored katakana, so a terminal has no way to ask
+// for them. Drawing them would mean shipping a font, which an animation that
+// runs in whatever terminal you already have cannot do.
+//
+// Z is here because it is the only letter of the English alphabet in the film's
+// set. The numerals are in it too, some of them flipped, which again is not
+// something that can be asked for.
+var Glyphs = []rune(
+	"ｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝ0123456789Z")
+
+// column is one falling stream.
+type column struct {
+	head   float64 // row of the leading glyph, fractional so speeds can differ
+	speed  float64 // rows per simulation step
+	length int     // trail length in rows
+	active bool
+
+	// hot marks a stream whose leading glyph is highlighted — drawn white and
+	// bold rather than in the palette's brightest green.
+	//
+	// Only about one stream in five has one, and only its LEADING glyph is ever
+	// highlighted. Highlighting every stream, which is the easy thing to do and
+	// what this did, turns the screen into a row of white dots chasing each
+	// other down it; in the film most of the rain is plain green and the white
+	// heads are scattered through it.
+	hot bool
+}
+
+// Matrix is the animation. The zero value is not usable; call New.
+type Matrix struct {
+	cols, rows int
+	col        []column
+	// glyph holds the character shown at each cell. Keeping them lets the
+	// trail stay stable between frames instead of reshuffling every glyph
+	// every frame, which looks like static rather than falling text.
+	glyph []rune
+	// changed records the tick each cell last took a new glyph, so the frame it
+	// changed on can be drawn differently. See Blend.
+	changed []int
+	rng     *rand.Rand
+
+	// Glyphs is the alphabet drawn. Replace before the first frame.
+	Glyphs []rune
+	// Palette runs from the dim tail to the bright head.
+	Palette canvas.Palette
+	// Density is the chance per simulation step that an idle column starts
+	// falling, as a reciprocal: 40 means roughly one in forty.
+	Density int
+	// StepRate is simulation steps per second. The rain was tuned at one step
+	// per frame at 30 fps, so 30 keeps its old speed while the screen redraws
+	// more often.
+	StepRate float64
+
+	// Hot is the chance a new stream gets a highlighted leading glyph, as a
+	// reciprocal: 5 means roughly one in five, which is what the film has.
+	Hot int
+
+	// ChangeEvery is how many steps a glyph holds before it may change.
+	//
+	// In the film a glyph is static for three frames and then turns into
+	// another one, and — the part that is easy to miss — every glyph that is
+	// going to change changes on the SAME frame. The alphabet does not shimmer
+	// continuously; it ticks over, all at once, and is still in between.
+	ChangeEvery int
+
+	// StammerEvery is roughly how many steps pass between stammers, which is
+	// the oddest behaviour in the original: every so often every highlighted
+	// glyph hesitates at the same moment, and the streams carrying them drop a
+	// row behind the ones that did not. Zero disables it.
+	StammerEvery int
+
+	// Blend dims a glyph on the step it changes, out of 256. Zero disables it.
+	//
+	// In the film a change is a crossfade: "during a single frame, the new and
+	// old glyph occupy the same space, each at 50% opacity". A terminal cell
+	// holds one glyph and cannot draw two, so the half-lit pair is approximated
+	// by the one thing a cell can do — come up dim for that step and reach full
+	// brightness on the next.
+	//
+	// It is what makes the trail pulse. Without it a change is instantaneous and
+	// the rain reads as a field of glyphs being swapped; with it each change has
+	// a visible beat, and a cell that changes twice in a row appears to waver
+	// between two characters, which is what the crossfade looks like.
+	Blend int
+
+	// acc carries the fraction of a step left over from the last frame.
+	acc float64
+	// tick counts simulation steps, for the change cadence and the stammer.
+	tick int
+	// stammerAt is the tick the next stammer falls on.
+	stammerAt int
+}
+
+// New returns a matrix animation. seed of 0 gives a fixed sequence, which
+// makes tests repeatable.
+func New(seed int64) *Matrix {
+	return &Matrix{
+		rng:      rand.New(rand.NewSource(seed)),
+		Glyphs:   Glyphs,
+		Palette:  canvas.Matrix,
+		Density:  40,
+		StepRate: 30,
+		// Roughly one stream in five carries a highlighted glyph.
+		Hot: 5,
+		// Three frames static, then every glyph that is due changes at once.
+		ChangeEvery: 3,
+		// About every two seconds at the default step rate.
+		StammerEvery: 60,
+		// Half-lit on the step a glyph changes, which is the crossfade.
+		Blend: 128,
+	}
+}
+
+// Resize allocates per-column state.
+func (m *Matrix) Resize(cols, rows int) {
+	m.cols, m.rows = cols, rows
+	m.col = make([]column, cols)
+	m.glyph = make([]rune, cols*rows)
+	m.changed = make([]int, cols*rows)
+	for i := range m.changed {
+		m.changed[i] = -1
+	}
+	for i := range m.glyph {
+		m.glyph[i] = m.randGlyph()
+	}
+	// Stagger the start so the screen does not begin with every column
+	// releasing at once.
+	for x := range m.col {
+		if m.rng.Intn(3) == 0 {
+			m.col[x] = m.newColumn(float64(-m.rng.Intn(rows)))
+		}
+	}
+}
+
+func (m *Matrix) randGlyph() rune {
+	if len(m.Glyphs) == 0 {
+		return ' '
+	}
+	return m.Glyphs[m.rng.Intn(len(m.Glyphs))]
+}
+
+func (m *Matrix) newColumn(head float64) column {
+	return column{
+		head:   head,
+		speed:  0.25 + m.rng.Float64()*0.75,
+		length: 6 + m.rng.Intn(m.rows),
+		active: true,
+		hot:    m.Hot > 0 && m.rng.Intn(m.Hot) == 0,
+	}
+}
+
+// Frame advances every column and repaints.
+//
+// The simulation is stepped at a fixed rate from elapsed time rather than once
+// per frame. Everything here is per-step — the fall distance, the chance a
+// column starts, the chance a glyph flickers — so driving it from an
+// accumulator keeps all of that meaning exactly what it did, instead of
+// needing every probability restated as a rate. The columns land on whole
+// cells regardless, so stepping faster than this would buy nothing.
+func (m *Matrix) Frame(screen tcell.Screen, cols, rows int, dt float64) {
+	if m.cols == 0 || m.rows == 0 {
+		return
+	}
+	rate := m.StepRate
+	if rate <= 0 {
+		rate = 30
+	}
+	m.acc += dt * rate
+	if m.acc > 4 {
+		m.acc = 4 // bound the catch-up after a stall
+	}
+	for m.acc >= 1 {
+		m.step()
+		m.acc--
+	}
+	m.draw(screen)
+}
+
+// step advances every column by one simulation tick.
+func (m *Matrix) step() {
+	m.tick++
+
+	// The alphabet turns over on a shared beat rather than each glyph
+	// shimmering to its own clock. Everything that is going to change this step
+	// changes together, and in between the screen is still — which is what the
+	// film does, and what makes it read as text being rewritten rather than as
+	// static.
+	changing := m.ChangeEvery <= 0 || m.tick%m.ChangeEvery == 0
+
+	// A stammer: every highlighted glyph hesitates on the same step, so the
+	// streams carrying them drop a row behind the ones that did not. It is the
+	// least obvious thing in the original and the reason the highlighted heads
+	// do not stay in formation with the rest of the rain.
+	stammer := false
+	if m.StammerEvery > 0 {
+		if m.stammerAt == 0 {
+			m.stammerAt = m.tick + m.StammerEvery/2 + m.rng.Intn(m.StammerEvery)
+		}
+		if m.tick >= m.stammerAt {
+			stammer = true
+			m.stammerAt = m.tick + m.StammerEvery/2 + m.rng.Intn(m.StammerEvery)
+		}
+	}
+
+	for x := 0; x < m.cols; x++ {
+		c := &m.col[x]
+		if !c.active {
+			if m.rng.Intn(m.Density) == 0 {
+				*c = m.newColumn(0)
+			}
+			continue
+		}
+
+		if !(stammer && c.hot) {
+			prev := int(c.head)
+			c.head += c.speed
+			// The glyph the head has just moved onto is new, so it is drawn new
+			// whatever the beat is doing.
+			if int(c.head) != prev {
+				m.setGlyph(x, int(c.head), m.randGlyph())
+			}
+		}
+
+		// One glyph somewhere in the trail turns over, on the beat.
+		if changing && m.rng.Intn(3) == 0 {
+			m.changeGlyph(x, m.rng.Intn(m.rows), m.randGlyph())
+		}
+
+		// Retire the column once its whole trail is off the bottom.
+		if int(c.head)-c.length > m.rows {
+			c.active = false
+		}
+	}
+}
+
+// setGlyph writes a glyph without marking it as a change.
+//
+// Used where the head advances into a row. That cell was below the stream and
+// unlit, so there is no old glyph to cross-fade from — nothing to dim, and
+// dimming it anyway makes the leading glyph flicker instead of lead.
+func (m *Matrix) setGlyph(x, y int, r rune) {
+	if x < 0 || y < 0 || x >= m.cols || y >= m.rows {
+		return
+	}
+	m.glyph[y*m.cols+x] = r
+}
+
+// changeGlyph replaces a glyph that was already lit. That is a cross-fade, so
+// the cell is drawn dim for the step it happens on. See Blend.
+func (m *Matrix) changeGlyph(x, y int, r rune) {
+	if x < 0 || y < 0 || x >= m.cols || y >= m.rows {
+		return
+	}
+	i := y*m.cols + x
+	m.glyph[i] = r
+	m.changed[i] = m.tick
+}
+
+// Cell is one lit cell of a frame: the glyph, how bright it is as an index
+// into Palette, and whether it is a highlighted leading glyph.
+type Cell struct {
+	Rune      rune
+	Intensity int
+	Hot       bool
+}
+
+// cellAt returns what is drawn at x, y, and whether anything is at all.
+//
+// draw and Cells both go through here so that a still taken for a backdrop and
+// the animation on screen cannot drift apart. Everything about how the rain
+// looks — the falloff, which heads go white, the crossfade — is decided once,
+// in this function.
+func (m *Matrix) cellAt(x, y int) (Cell, bool) {
+	c := m.col[x]
+	if !c.active {
+		return Cell{}, false
+	}
+	d := int(c.head) - y // distance behind the head
+	if d < 0 || d >= c.length {
+		return Cell{}, false
+	}
+	// Intensity falls off along the trail, and the leading glyph is the
+	// brightest — which is what gives the effect its sense of direction.
+	//
+	// Only a HIGHLIGHTED stream's head goes white, though, and only about one
+	// in five is. The rest lead in the palette's brightest green like the trail
+	// behind them. Whitening every head is the obvious reading of "the leading
+	// character is bright" and it is wrong: it turns the screen into a row of
+	// white dots racing down it, where the film has plain green rain with white
+	// heads scattered through it.
+	hot := d == 0 && c.hot
+	var i int
+	switch {
+	case hot:
+		i = 255
+	case d == 0:
+		i = 200
+	default:
+		i = 200 - d*200/c.length
+		if i < 0 {
+			i = 0
+		}
+	}
+	// The step a glyph changed on is drawn dim: in the film the old and new
+	// glyph share the cell at half opacity for one frame, and a cell that can
+	// only hold one glyph shows that as a beat instead.
+	if m.Blend > 0 && m.changed[y*m.cols+x] == m.tick {
+		i = i * m.Blend / 256
+	}
+	return Cell{Rune: m.glyph[y*m.cols+x], Intensity: i, Hot: hot}, true
+}
+
+// Cells reports every lit cell of the current frame, left to right and top to
+// bottom. Dark cells are skipped rather than reported blank.
+//
+// This is the frame without a tcell.Screen to put it on, which is what lets a
+// still be composited into ordinary terminal output instead of taking over the
+// terminal. See matrix/backdrop.
+func (m *Matrix) Cells(fn func(x, y int, c Cell)) {
+	for y := 0; y < m.rows; y++ {
+		for x := 0; x < m.cols; x++ {
+			if c, ok := m.cellAt(x, y); ok {
+				fn(x, y, c)
+			}
+		}
+	}
+}
+
+// Advance runs n simulation steps without drawing anything.
+//
+// A still needs this. The rain starts with every column idle, so frame one is
+// an empty screen and frame ten is a scattering of single glyphs at the top;
+// a backdrop wants rain that has been falling for a while.
+func (m *Matrix) Advance(n int) {
+	for i := 0; i < n; i++ {
+		m.step()
+	}
+}
+
+// Size returns the grid the animation was last resized to.
+func (m *Matrix) Size() (cols, rows int) { return m.cols, m.rows }
+
+func (m *Matrix) draw(screen tcell.Screen) {
+	for x := 0; x < m.cols; x++ {
+		for y := 0; y < m.rows; y++ {
+			c, ok := m.cellAt(x, y)
+			if !ok {
+				screen.SetContent(x, y, ' ', nil, tcell.StyleDefault)
+				continue
+			}
+			st := tcell.StyleDefault.Foreground(m.Palette[c.Intensity])
+			if c.Hot {
+				st = st.Bold(true)
+			}
+			screen.SetContent(x, y, c.Rune, nil, st)
+		}
+	}
+}
+
+// Run draws falling glyphs on the screen until the user quits.
+func Run(screen tcell.Screen, seed int64) error {
+	return canvas.RunCells(screen, New(seed), canvas.Options{})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,6 +36,12 @@ github.com/0magnet/sh/v3/internal
 github.com/0magnet/sh/v3/interp
 github.com/0magnet/sh/v3/pattern
 github.com/0magnet/sh/v3/syntax
+# github.com/0magnet/termanim v0.0.0-20260823195938-f88b1541cfcd
+## explicit; go 1.24.0
+github.com/0magnet/termanim/canvas
+github.com/0magnet/termanim/matrix
+github.com/0magnet/termanim/matrix/backdrop
+github.com/0magnet/termanim/matrix/backdrop/cobrarain
 # github.com/0magnet/u-root v0.16.1-0.20260810212217-0890fe5099f9
 ## explicit; go 1.25.7
 github.com/0magnet/u-root/pkg/ls


### PR DESCRIPTION
**Did you run `make format && make check`?**

Partly, and honestly: `goimports -local` on the changed files, `golangci-lint`
and `go vet` with the repo's `withoutsystray withoutgotop` tags, `make
check-help`, and the tests for the touched packages — all clean. I did not run
the full `make check` test suite or `check-cg`, neither of which this touches.

**Fixes:** n/a

**Changes:**

- `skywire --help` draws its help over a still frame of Matrix code rain,
  seeded from the clock, so it is different every time.
- The help text is unchanged. It is rendered into a buffer by the existing help
  function and composited, rather than being replaced by a template, so cobra's
  layout rules and coloredcobra's colors are exactly as they were. Escapes in
  the input are carried through and not counted as printable width.
- Off wherever the output is not a person reading a terminal: a pipe or a
  redirect, `--json`/`--jq`/`--shape`, `help -r`, `help -d`, `NO_COLOR`,
  `TERM=dumb`, and `SKYWIRE_NO_HELP_RAIN` for anyone who wants the colors
  without the rain. Machine mode is checked directly rather than relying on
  which help wrapper ends up outermost, since `cliout.SetJSONHelp` and this are
  installed from different `init` functions.
- A line wider than the terminal is passed through untouched instead of being
  cut — `skywire cli --help` runs to 108 columns. Verified across eight help
  screens at 80 columns: 258 lines in, 0 lost.
- Wired into the root binary only, not into `InitFlags`, so the service
  binaries are unaffected.
- `cliout.machineMode` is exported as `MachineMode`; `PrintHelpAll` and
  `PrintCommandDocs` render plain.

One new dependency, `github.com/0magnet/termanim` (76K vendored, 5 files). It
brings nothing transitive: tcell, go-colorful, uniseg and x/term are already in
the tree, so `go mod vendor` added that package and nothing else.

Happy to flip the default to opt-in, or drop it to `skywire cli` only, if you
would rather it were quieter.

**How to test this PR:**

```
go run . --help          # a few times — the frame differs each run
go run . --help | cat    # plain, byte-identical to rain disabled
go run . --json --help   # still JSON
go run . help -d         # markdown, no escapes
SKYWIRE_NO_HELP_RAIN=1 go run . --help
```