### PR TITLE
fix(lint): clear accumulated develop lint debt (misspell/gosec/gofmt)

### DIFF
--- a/pkg/dmsgweb/status_scoping_test.go
+++ b/pkg/dmsgweb/status_scoping_test.go
@@ -47,7 +47,7 @@ func TestSOCKS5StatusScoping(t *testing.T) {
 			}
 			go func(c net.Conn) {
 				_ = proxyinterstitial.ServeSOCKS5(c, "upstream-sink", "skysocks", nil) //nolint:errcheck
-				_ = c.Close()                                                     //nolint:errcheck
+				_ = c.Close()                                                          //nolint:errcheck
 			}(c)
 		}
 	}()

--- a/pkg/proxyinterstitial/interstitial.go
+++ b/pkg/proxyinterstitial/interstitial.go
@@ -274,7 +274,7 @@ func ShouldServe(port string) bool {
 // written verbatim as the HTTP response and the interstitial is skipped. This
 // keeps the reserved status page reachable exactly when the exit is down — the
 // moment the user most needs to see why — which the interstitial would otherwise
-// shadow. Pass nil for the plain interstitial-only behaviour. The closure lives
+// shadow. Pass nil for the plain interstitial-only behavior. The closure lives
 // in the caller so this package stays free of any pkg/proxystatus dependency.
 func ServeSOCKS5(conn net.Conn, detail, mechanism string, statusOverride func(host string) []byte) error {
 	_ = conn.SetDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck

--- a/pkg/proxyinterstitial/interstitial_test.go
+++ b/pkg/proxyinterstitial/interstitial_test.go
@@ -178,9 +178,9 @@ func serveSOCKS5CONNECT(t *testing.T, cli net.Conn, host string, port uint16) st
 	if _, err := io.ReadFull(cli, sel); err != nil {
 		t.Fatal(err)
 	}
-	req := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))}
+	req := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))} //nolint:gosec // G115: fixed test host/port
 	req = append(req, []byte(host)...)
-	req = append(req, byte(port>>8), byte(port))
+	req = append(req, byte(port>>8), byte(port)) //nolint:gosec // G115: fixed test host/port
 	if _, err := cli.Write(req); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/router/router_mux80_test.go
+++ b/pkg/router/router_mux80_test.go
@@ -72,7 +72,7 @@ const (
 )
 
 // setupInitializingPrimary installs a mux-enabled primary route group for a
-// fresh descriptor into rgsRaw ONLY — modelling the mid-handshake window before
+// fresh descriptor into rgsRaw ONLY — modeling the mid-handshake window before
 // the group registers into rgsNs. Returns the group and its descriptor.
 func (r *router) setupInitializingPrimary(t *testing.T) (*RouteGroup, routing.RouteDescriptor) {
 	t.Helper()
@@ -113,8 +113,8 @@ func (r *router) makeAuxRules(t *testing.T, desc routing.RouteDescriptor, i int)
 	mt.Entry = transport.Entry{ID: auxTpID, Type: "test"}
 	r.tm.InjectTransportForTest(mt)
 
-	fwd := routing.ForwardRule(DefaultRouteKeepAlive, routing.RouteID(1000+i), routing.RouteID(2000+i), auxTpID, local, peer, legTestDstPort, legTestSrcPort)
-	rvs := routing.ConsumeRule(DefaultRouteKeepAlive, routing.RouteID(2000+i), local, peer, legTestSrcPort, legTestDstPort)
+	fwd := routing.ForwardRule(DefaultRouteKeepAlive, routing.RouteID(1000+i), routing.RouteID(2000+i), auxTpID, local, peer, legTestDstPort, legTestSrcPort) //nolint:gosec // G115: bounded small test route IDs
+	rvs := routing.ConsumeRule(DefaultRouteKeepAlive, routing.RouteID(2000+i), local, peer, legTestSrcPort, legTestDstPort)                                   //nolint:gosec // G115: bounded small test route IDs
 	return routing.EdgeRules{Desc: desc, Forward: fwd, Reverse: rvs}
 }
 
@@ -197,7 +197,7 @@ func TestAcceptRoutes_DuplicateDescDoesNotDeleteLeg(t *testing.T) {
 
 // TestMuxSetup_ConcurrentLegsNoCollapse stands up N aux legs concurrently to the
 // same descriptor while the primary sits in rgsRaw, with registration racing the
-// arrivals after a deterministic delay (modelling the responder handshake-await
+// arrivals after a deterministic delay (modeling the responder handshake-await
 // window). The group must converge to N legs, the primary rg must never be
 // closed or replaced, and its src port must be stable. Run under -race.
 func TestMuxSetup_ConcurrentLegsNoCollapse(t *testing.T) {

--- a/pkg/skynetweb/status_scoping_test.go
+++ b/pkg/skynetweb/status_scoping_test.go
@@ -41,7 +41,7 @@ func TestSOCKS5StatusScoping(t *testing.T) {
 			}
 			go func(c net.Conn) {
 				_ = proxyinterstitial.ServeSOCKS5(c, "upstream-sink", "skysocks", nil) //nolint:errcheck
-				_ = c.Close()                                                     //nolint:errcheck
+				_ = c.Close()                                                          //nolint:errcheck
 			}(c)
 		}
 	}()


### PR DESCRIPTION
Admin-merges of #4128/#4130/#4131 landed with the golangci-lint checks pending, accumulating lint debt that now fails on every PR (blocking e.g. #4134). Fixes: `modelling`→`modeling`, `behaviour`→`behavior`, gosec G115 nolint on bounded test conversions, gofmt. No behavior change.