### PR TITLE
feat(proxystatus): fold per-leg mux table + full routes into one route tree

### DIFF
--- a/pkg/proxystatus/proxystatus_test.go
+++ b/pkg/proxystatus/proxystatus_test.go
@@ -71,11 +71,17 @@ func TestRenderSections(t *testing.T) {
 		"<main id=\"live\">", "new WebSocket", "/ws",
 		`location.origin.replace(/^http/,"ws")`, "sendCmd",
 		"standby", "status.dmsg", "status.skynet",
-		// route observability: route-latency column, direct/multihop badge, recv bar
-		"route rtt", "recv share", "direct", "multihop", "480 ms", "bar recv",
-		// full routes: section + full (untruncated) hop PKs + per-hop type/latency
-		"full routes", "03cc223344556677889900aabbccddeeff00112233445566778899aabbccddeeff",
-		"02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee", "450ms",
+		// route observability: route-latency metric (hint), direct/multihop badge, recv bar
+		"route rtt", "direct", "multihop", "480 ms", "bar recv",
+		// combined per-leg route tree: the flat mux table + separate "full routes"
+		// chains folded into one box-drawing tree per leg — tree container, guides,
+		// source/exit accents, and the FULL (untruncated) hop PKs with per-hop
+		// transport type + latency on the branches.
+		`class="legs-tree"`, `class="tree"`, `class="guide"`, "└─┬", "└──",
+		`class="tline src"`, `class="tline dst"`, "this visor", "exit",
+		"03cc223344556677889900aabbccddeeff00112233445566778899aabbccddeeff",
+		"02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee",
+		"stcpr 450ms", "sudph 30ms",
 		// UX pass: selection-guard + identical-fragment skip in the live script,
 		// click-to-copy affordance (execCommand fallback for the HTTP context),
 		// the WebSocket live indicator, route-group summary, and staged control tags.

--- a/pkg/proxystatus/proxystatus_test.go
+++ b/pkg/proxystatus/proxystatus_test.go
@@ -50,11 +50,11 @@ func TestRenderSections(t *testing.T) {
 		MuxEnabled: true,
 		Legs: []Leg{
 			{Index: 0, TpType: "stcpr", RemotePK: "0311223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", SentBytes: 2048, RecvBytes: 1024, LatencyMS: 42, RouteLatencyMS: 42, Direct: true, Alive: true,
-				Hops: []Hop{{From: "02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee", To: "0311223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", TpType: "stcpr", LatencyMS: 42}}},
+				Hops: []Hop{{TpID: "tp0aaaaaaa-0000-0000-0000-000000000000", From: "02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee", To: "0311223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", TpType: "stcpr", LatencyMS: 42}}},
 			{Index: 1, TpType: "sudph", RemotePK: "03bb223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", SentBytes: 512, RecvBytes: 256, LatencyMS: 30, RouteLatencyMS: 480, Direct: false, Standby: true, Alive: true,
 				Hops: []Hop{
-					{From: "02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee", To: "03bb223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", TpType: "sudph", LatencyMS: 30},
-					{From: "03bb223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", To: "03cc223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", TpType: "stcpr", LatencyMS: 450},
+					{TpID: "tp1bbbbbbb-1111-1111-1111-111111111111", From: "02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee", To: "03bb223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", TpType: "sudph", LatencyMS: 30},
+					{TpID: "tp2ccccccc-2222-2222-2222-222222222222", From: "03bb223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", To: "03cc223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", TpType: "stcpr", LatencyMS: 450},
 				}},
 		},
 		Logs:   []string{"line one", "line two"},
@@ -71,17 +71,22 @@ func TestRenderSections(t *testing.T) {
 		"<main id=\"live\">", "new WebSocket", "/ws",
 		`location.origin.replace(/^http/,"ws")`, "sendCmd",
 		"standby", "status.dmsg", "status.skynet",
-		// route observability: route-latency metric (hint), direct/multihop badge, recv bar
+		// route observability: route-latency metric (hint), direct/multihop tag, recv bar
 		"route rtt", "direct", "multihop", "480 ms", "bar recv",
-		// combined per-leg route tree: the flat mux table + separate "full routes"
-		// chains folded into one box-drawing tree per leg — tree container, guides,
-		// source/exit accents, and the FULL (untruncated) hop PKs with per-hop
-		// transport type + latency on the branches.
-		`class="legs-tree"`, `class="tree"`, `class="guide"`, "└─┬", "└──",
+		// ONE unified route tree rooted at the local visor: the flat mux table +
+		// separate "full routes" chains folded into a single box-drawing tree.
+		// Root (this visor / source accent), branch + leaf glyphs, exit accent, the
+		// FULL (untruncated) hop PKs, per-edge transport (id + type + latency), and
+		// per-leg telemetry on indented continuation (tdetail) lines.
+		`class="tree"`, `class="guide"`, "├──", "└─┬", "└──",
 		`class="tline src"`, `class="tline dst"`, "this visor", "exit",
 		"03cc223344556677889900aabbccddeeff00112233445566778899aabbccddeeff",
 		"02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee",
-		"stcpr 450ms", "sudph 30ms",
+		"via ", "stcpr 450ms", "sudph 30ms",
+		// first-hop transport id is shown and click-to-copy
+		`class="ftid copy"`, "tp2ccccccc-2222-2222-2222-222222222222",
+		// per-leg telemetry relocated onto continuation lines beneath the leaf PK
+		`class="tdetail"`, "│",
 		// UX pass: selection-guard + identical-fragment skip in the live script,
 		// click-to-copy affordance (execCommand fallback for the HTTP context),
 		// the WebSocket live indicator, route-group summary, and staged control tags.

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -4,6 +4,7 @@ package proxystatus
 import (
 	"fmt"
 	"html"
+	"sort"
 	"strings"
 )
 
@@ -174,13 +175,16 @@ func writePill(b *strings.Builder, k, v, cls string) {
 	fmt.Fprintf(b, `<span class="%s"><i>%s</i> %s</span>`, c, html.EscapeString(k), v)
 }
 
-// writeMuxSection renders the per-leg mux view as one ROUTE TREE per leg —
-// the flat mux table and the separate "full routes" hop chains folded into a
-// single view inspired by `skywire cli tp tree`. Each leg is a header line
-// (route kind + gate state + tp/route RTT + rtx + sent/recv share bars) above a
-// box-drawing tree that traces this visor → intermediate relays → destination,
-// every public key shown in full and click-to-copy. A static, no-JS analog of
-// the `cli proxy mux plot` panel.
+// writeMuxSection renders the route group as ONE unified route tree rooted at
+// the local visor — the flat mux table and the separate "full routes" hop
+// chains folded into a single view inspired by `skywire cli visor ping tree`
+// (one root, branches = the peers this visor reaches). Every leg is a path
+// local → … → destination; all paths are prefix-merged into the one tree, so a
+// shared first hop collapses into a single branch that diverges deeper. Each
+// branch/edge carries the transport used for that hop (id + type + rtt) and each
+// leg's end-to-end mux telemetry (direct/multihop, gate state, route-rtt, rtx,
+// sent/recv share bars) hangs off the destination leaf for that leg. A static,
+// no-JS analog of the `cli proxy mux plot` panel.
 func writeMuxSection(b *strings.Builder, snap Snapshot) {
 	b.WriteString(`<section><h2>route group · per-leg mux</h2>`)
 	if len(snap.Legs) == 0 {
@@ -209,7 +213,7 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 		}
 	}
 	// Scannable route-group summary: leg census + aggregate throughput, so the
-	// operator gets the shape of the group before reading the per-leg trees.
+	// operator gets the shape of the group before reading the route tree.
 	b.WriteString(`<div class="rgsummary">`)
 	writeStat(b, "legs", fmt.Sprintf("%d", len(snap.Legs)), "")
 	writeStat(b, "active", fmt.Sprintf("%d", nActive), "ok")
@@ -222,106 +226,204 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 	writeStat(b, "sent", humanBytes(totSent), "")
 	writeStat(b, "recv", humanBytes(totRecv), "")
 	b.WriteString(`</div>`)
-	b.WriteString(`<div class="legs-tree">`)
-	for _, l := range snap.Legs {
-		writeLegTree(b, l, maxSent, maxRecv)
-	}
+
+	// Order legs so the branch carrying app traffic — the direct, active leg —
+	// renders first, then active multihop, then warm standby, then dead. Branch
+	// order in the merged tree follows leg insertion order.
+	ordered := make([]Leg, len(snap.Legs))
+	copy(ordered, snap.Legs)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		ri, rj := legRank(ordered[i]), legRank(ordered[j])
+		if ri != rj {
+			return ri < rj
+		}
+		return ordered[i].Index < ordered[j].Index
+	})
+	root := buildRouteTree(ordered)
+
+	b.WriteString(`<div class="tree">`)
+	writeRouteRoot(b, root, maxSent, maxRecv)
 	b.WriteString(`</div>`)
-	b.WriteString(`<p class="hint">Each leg is a route tree — this visor at the root, ` +
-		`<span class="tlabel src">source</span> then relays, the ` +
-		`<span class="tlabel dst">exit</span> at the leaf; per-hop transport type + RTT sit on each branch. ` +
-		`Bars are each leg's sent / recv bytes relative to the busiest leg. ` +
+	b.WriteString(`<p class="hint">One route tree rooted at ` +
+		`<span class="tlabel src">this visor</span>; branches are the first-hop peers it dials, ` +
+		`each edge showing the transport (id + rtt) and continuing to the ` +
+		`<span class="tlabel dst">exit</span>. Per-leg mux telemetry — direct/multihop, state, ` +
+		`route-rtt, rtx and the sent/recv share bars — hangs off each destination leaf. ` +
+		`Bars are relative to the busiest leg. ` +
 		`<b>tp rtt</b> is the first-hop transport; <b>route rtt</b> is the true end-to-end route latency (all hops). ` +
-		`Click any public key to copy it. ` +
+		`Click any public key (or transport id) to copy it. ` +
 		`For a live terminal chart use <code>skywire cli proxy mux plot</code>.</p></section>`)
 }
 
-// writeLegTree renders one leg as a header line plus its hop tree. The header
-// carries the route kind (direct/multihop), gate state badge, tp/route RTT, rtx
-// and the dual sent/recv share bars; the tree below it traces the leg's forward
-// path with box-drawing glyphs, this visor at the root and the destination/exit
-// at the leaf. maxSent/maxRecv (>=1) scale the share bars against the busiest leg.
-func writeLegTree(b *strings.Builder, l Leg, maxSent, maxRecv uint64) {
+// rtNode is one visor in the merged route tree. Legs are prefix-merged by their
+// PK sequence, so a node may carry the transport of the edge that reaches it
+// (from its parent) and, when it is the destination of one or more legs, those
+// legs' end-to-end telemetry.
+type rtNode struct {
+	pk         string
+	edgeTpID   string  // transport reaching this node from its parent
+	edgeTpType string  // "" / type where known
+	edgeLat    float64 // hop rtt where measured
+	hasEdge    bool    // false only for the root
+	legs       []Leg   // legs whose destination IS this node
+	order      []string
+	kids       map[string]*rtNode
+}
+
+func (n *rtNode) child(pk string) *rtNode {
+	if n.kids == nil {
+		n.kids = map[string]*rtNode{}
+	}
+	c, ok := n.kids[pk]
+	if !ok {
+		c = &rtNode{pk: pk}
+		n.kids[pk] = c
+		n.order = append(n.order, pk)
+	}
+	return c
+}
+
+// buildRouteTree merges every leg's forward path (local → … → dest) into one
+// tree rooted at the local visor. Legs with no recorded path fall back to a
+// direct root → RemotePK leaf so nothing breaks.
+func buildRouteTree(legs []Leg) *rtNode {
+	root := &rtNode{}
+	for _, l := range legs {
+		if root.pk == "" && len(l.Hops) > 0 {
+			root.pk = l.Hops[0].From // local visor PK (same for every leg)
+		}
+	}
+	for _, l := range legs {
+		if len(l.Hops) == 0 {
+			c := root.child(l.RemotePK)
+			c.legs = append(c.legs, l)
+			continue
+		}
+		cur := root
+		for _, h := range l.Hops {
+			c := cur.child(h.To)
+			if !c.hasEdge {
+				c.edgeTpID, c.edgeTpType, c.edgeLat, c.hasEdge = h.TpID, h.TpType, h.LatencyMS, true
+			}
+			cur = c
+		}
+		cur.legs = append(cur.legs, l) // the final To is this leg's destination
+	}
+	return root
+}
+
+// writeRouteRoot writes the tree root (the local visor) then its branches.
+func writeRouteRoot(b *strings.Builder, root *rtNode, maxSent, maxRecv uint64) {
+	// Root line: no connector, source accent. An all-legacy group may have no
+	// known local PK — copyablePK renders a dash and nothing breaks.
+	fmt.Fprintf(b, `<div class="tline src"><span class="guide"></span>%s<span class="tlabel src">this visor</span></div>`,
+		copyablePK(root.pk))
+	for i, pk := range root.order {
+		writeRouteNode(b, root.kids[pk], "", i == len(root.order)-1, maxSent, maxRecv)
+	}
+}
+
+// writeRouteNode renders one non-root visor node and recurses. prefix is the
+// box-drawing guide accumulated from ancestors; isLast picks └ vs ├ and whether
+// the descendant guide continues with │ or blank. Each node line shows the FULL
+// click-to-copy PK, the transport of the edge reaching it, and (for a
+// destination) an exit accent; a destination's per-leg mux telemetry is written
+// as indented detail rows beneath it.
+func writeRouteNode(b *strings.Builder, n *rtNode, prefix string, isLast bool, maxSent, maxRecv uint64) {
+	branch := "├─"
+	cont := "│   "
+	if isLast {
+		branch, cont = "└─", "    "
+	}
+	if len(n.order) > 0 {
+		branch += "┬ "
+	} else {
+		branch += "── "
+	}
+	nodeCls, label := "mid", ""
+	if len(n.legs) > 0 {
+		nodeCls, label = "dst", "exit" // a leg terminates here (the destination/exit)
+	}
+	fmt.Fprintf(b, `<div class="tline %s"><span class="guide">%s</span>%s`, nodeCls, prefix+branch, copyablePK(n.pk))
+	if label != "" {
+		fmt.Fprintf(b, `<span class="tlabel %s">%s</span>`, nodeCls, label)
+	}
+	if edge := edgeInfo(n); edge != "" {
+		fmt.Fprintf(b, `<span class="thop">%s</span>`, edge)
+	}
+	b.WriteString(`</div>`)
+
+	detailPrefix := prefix + cont
+	for _, l := range n.legs {
+		writeLegDetail(b, detailPrefix, l, maxSent, maxRecv)
+	}
+	for i, pk := range n.order {
+		writeRouteNode(b, n.kids[pk], detailPrefix, i == len(n.order)-1, maxSent, maxRecv)
+	}
+}
+
+// edgeInfo renders the transport of the edge reaching a node: "via <tpid> <type>
+// <rtt>ms". The transport id is click-to-copy; a missing id/latency is elided.
+func edgeInfo(n *rtNode) string {
+	if !n.hasEdge {
+		return ""
+	}
+	var s strings.Builder
+	s.WriteString("via ")
+	if strings.TrimSpace(n.edgeTpID) != "" {
+		s.WriteString(copyableID(n.edgeTpID, "transport id"))
+		s.WriteByte(' ')
+	}
+	s.WriteString(html.EscapeString(orDash(n.edgeTpType)))
+	if n.edgeLat > 0 {
+		fmt.Fprintf(&s, " %.0fms", n.edgeLat)
+	}
+	return s.String()
+}
+
+// writeLegDetail writes a destination leg's end-to-end mux telemetry as indented
+// rows under its leaf: a summary row (direct/multihop tag, gate-state badge,
+// route-rtt, rtx) and the dual sent/recv share bars. prefix keeps them aligned
+// under the leaf, carrying any open-ancestor │ guides. maxSent/maxRecv (>=1)
+// scale the bars against the busiest leg.
+func writeLegDetail(b *strings.Builder, prefix string, l Leg, maxSent, maxRecv uint64) {
 	state, scls := legState(l)
-	// route: direct (1-hop) vs multihop (relayed). RouteLatencyMS is the TRUE
-	// end-to-end latency; LatencyMS is only the first-hop transport.
 	routeLabel, routeCls := "multihop", "route-relay"
 	if l.Direct {
 		routeLabel, routeCls = "direct", "route-direct"
 	}
-	b.WriteString(`<div class="leg">`)
-	// Header line.
-	b.WriteString(`<div class="leghdr">`)
-	fmt.Fprintf(b, `<span class="rlabel">R%d</span>`, l.Index)
-	fmt.Fprintf(b, `<span class="rtag %s">%s</span>`, routeCls, routeLabel)
-	fmt.Fprintf(b, `<span class="badge %s">%s</span>`, scls, state)
-	fmt.Fprintf(b, `<span class="legm"><i>tp</i>%.0f ms</span>`, l.LatencyMS)
-	fmt.Fprintf(b, `<span class="legm"><i>route</i>%s</span>`, routeRTT(l.RouteLatencyMS))
-	fmt.Fprintf(b, `<span class="legm"><i>rtx</i>%d</span>`, l.Retransmits)
-	b.WriteString(`</div>`)
-	// Sent/recv share bars (kept from the old table — dual bandwidth shares).
-	// shares are 0..100 (maxSent/maxRecv are per-leg maxes, >=1) — printed as
-	// uint64 directly so there's no uint64->int narrowing.
+	// Continuation line 1 — compact scalars: direct/multihop, gate state,
+	// route-rtt (em dash when unmeasured), rtx. tp-rtt lives on the first-hop
+	// edge above (the transport that reaches this leg's first peer).
+	fmt.Fprintf(b, `<div class="tdetail"><span class="guide">%s</span>`, prefix)
+	fmt.Fprintf(b, `<span class="rtag %s">%s</span><span class="badge %s">%s</span>`, routeCls, routeLabel, scls, state)
+	fmt.Fprintf(b, `<span class="legm"><i>route</i>%s</span><span class="legm"><i>rtx</i>%d</span></div>`,
+		routeRTT(l.RouteLatencyMS), l.Retransmits)
+	// Continuation line 2 — the sent/recv share meters. shares are 0..100
+	// (maxSent/maxRecv are per-leg maxes, >=1) — printed as uint64 directly so
+	// there's no uint64->int narrowing.
 	sentShare := l.SentBytes * 100 / maxSent
 	recvShare := l.RecvBytes * 100 / maxRecv
-	b.WriteString(`<div class="legbw">`)
+	fmt.Fprintf(b, `<div class="tdetail"><span class="guide">%s</span>`, prefix)
 	fmt.Fprintf(b, `<span class="bwlabel">sent %s</span><span class="barcell"><span class="bar %s" style="width:%d%%"></span></span>`,
 		humanBytes(l.SentBytes), scls, sentShare)
-	fmt.Fprintf(b, `<span class="bwlabel">recv %s</span><span class="barcell"><span class="bar recv %s" style="width:%d%%"></span></span>`,
+	fmt.Fprintf(b, `<span class="bwlabel">recv %s</span><span class="barcell"><span class="bar recv %s" style="width:%d%%"></span></span></div>`,
 		humanBytes(l.RecvBytes), scls, recvShare)
-	b.WriteString(`</div>`)
-	// Hop tree.
-	b.WriteString(`<div class="tree">`)
-	if len(l.Hops) == 0 {
-		// Legacy/accepted route with no recorded path: fall back to a single
-		// leaf so nothing breaks — just the destination we do know (RemotePK).
-		writeTreeLine(b, "└── ", "dst", "exit", l.RemotePK, "")
-		b.WriteString(`</div></div>`)
-		return
-	}
-	// Root: the first hop's From is THIS visor (the route source).
-	writeTreeLine(b, "└─┬ ", "src", "this visor", l.Hops[0].From, "")
-	n := len(l.Hops)
-	for i, h := range l.Hops {
-		indent := strings.Repeat("  ", i+1)
-		glyph := indent + "└── "
-		nodeCls, nodeLabel := "mid", ""
-		if i < n-1 {
-			glyph = indent + "└─┬ " // an intermediate relay: more path below
-		} else {
-			nodeCls, nodeLabel = "dst", "exit" // final To is the destination/exit
-		}
-		writeTreeLine(b, glyph, nodeCls, nodeLabel, h.To, formatHop(h))
-	}
-	b.WriteString(`</div></div>`)
 }
 
-// writeTreeLine writes one visor node line of a leg's hop tree: the box-drawing
-// guide prefix (monospace, spaces preserved so nested levels line up), the FULL
-// click-to-copy public key, an optional source/exit accent label, and optional
-// per-hop transport info (type + RTT on the branch leading into this node).
-// nodeCls (src/dst/mid) tints the source and destination the way `tp tree`
-// color-codes them; intermediates are neutral.
-func writeTreeLine(b *strings.Builder, guide, nodeCls, label, pk, hop string) {
-	fmt.Fprintf(b, `<div class="tline %s"><span class="guide">%s</span>%s`,
-		nodeCls, guide, copyablePK(pk))
-	if label != "" {
-		fmt.Fprintf(b, `<span class="tlabel %s">%s</span>`, nodeCls, html.EscapeString(label))
+// legRank orders legs for the merged tree: the direct active leg (carrying app
+// traffic) first, then active multihop, warm standby, then dead legs.
+func legRank(l Leg) int {
+	switch {
+	case !l.Alive:
+		return 3
+	case l.Standby:
+		return 2
+	case l.Direct:
+		return 0
+	default:
+		return 1
 	}
-	if hop != "" {
-		fmt.Fprintf(b, `<span class="thop">%s</span>`, html.EscapeString(hop))
-	}
-	b.WriteString(`</div>`)
-}
-
-// formatHop renders a hop's transport type and (where measured) its RTT, e.g.
-// "stcpr 139ms". Zero latency is elided rather than shown as "0ms".
-func formatHop(h Hop) string {
-	t := orDash(h.TpType)
-	if h.LatencyMS > 0 {
-		return fmt.Sprintf("%s %.0fms", t, h.LatencyMS)
-	}
-	return t
 }
 
 func legState(l Leg) (label, cls string) {
@@ -452,6 +554,19 @@ func copyablePK(pk string) string {
 	return `<code class="fpk copy" data-copy="` + esc + `" title="click to copy">` + esc + `</code>`
 }
 
+// copyableID renders a click-to-copy monospace token (e.g. a transport id) the
+// same way copyablePK does, with a caller-supplied hover title. It sits inside
+// the edge's .thop span, so the source/exit PK tint (a direct-child selector)
+// does not reach it. Empty renders nothing.
+func copyableID(id, what string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	esc := html.EscapeString(id)
+	return `<code class="ftid copy" data-copy="` + esc + `" title="click to copy ` + html.EscapeString(what) + `">` + esc + `</code>`
+}
+
 func orDash(s string) string {
 	if strings.TrimSpace(s) == "" {
 		return "-"
@@ -514,34 +629,33 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`.stat.ok{color:var(--ok)}.stat.warn{color:var(--warn)}.stat.standby{color:var(--standby)}` +
 	`.badge{display:inline-block;padding:.02rem .4rem;border-radius:999px;font-size:10.5px;font-weight:600;text-transform:uppercase;letter-spacing:.3px;border:1px solid currentColor}` +
 	`.badge.ok{color:var(--ok)}.badge.warn{color:var(--warn)}.badge.standby{color:var(--standby)}` +
-	`.barcell{display:block}.bar{display:block;height:.7rem;border-radius:3px;background:var(--accent);min-width:2px}` +
+	`.bar{display:block;height:.6rem;border-radius:3px;background:var(--accent);min-width:2px}` +
 	`.bar.standby{background:var(--standby)}.bar.warn{background:var(--warn)}` +
 	`.bar.recv{background:var(--recv,#3b9)}` +
 	`.rtag{display:inline-block;padding:0 .4rem;border-radius:3px;font-size:11px;font-weight:600}` +
 	`.rtag.route-direct{background:rgba(60,180,120,.18);color:#2a8}` +
 	`.rtag.route-relay{background:rgba(120,140,200,.18);color:#68a}` +
 	`.fpk{font-family:ui-monospace,monospace;font-size:11px;word-break:break-all}` +
+	`.ftid{font-family:ui-monospace,monospace;font-size:10.5px;color:var(--muted)}` +
 	`.copy{border-radius:3px;transition:background .15s,color .15s}` +
 	`body.js .copy{cursor:pointer}body.js .copy:hover{background:rgba(124,131,255,.14)}` +
 	`.copy.copied{background:var(--ok);color:#04120c}.copy.copied::after{content:" ✓ copied";font-size:10px;letter-spacing:.3px}` +
-	// Per-leg route trees.
-	`.legs-tree{display:flex;flex-direction:column;gap:.7rem;margin:.4rem 0}` +
-	`.leg{border:1px solid var(--line);border-radius:7px;padding:.5rem .65rem;background:var(--card)}` +
-	`.leghdr{display:flex;flex-wrap:wrap;align-items:center;gap:.45rem}` +
-	`.leghdr .rlabel{font-weight:700}` +
-	`.legm{font-size:11.5px;color:var(--fg)}` +
-	`.legm i{color:var(--muted);font-style:normal;margin-right:.25rem;text-transform:uppercase;font-size:10px;letter-spacing:.3px}` +
-	`.legbw{display:grid;grid-template-columns:auto minmax(4rem,1fr);gap:.2rem .5rem;align-items:center;margin:.4rem 0;max-width:30rem}` +
-	`.bwlabel{font-size:11px;color:var(--muted);white-space:nowrap}` +
-	`.tree{font-family:ui-monospace,SFMono-Regular,monospace;font-size:11.5px;line-height:1.65;overflow-x:auto;padding-top:.15rem}` +
-	`.tline{display:flex;align-items:baseline;gap:.3rem;white-space:nowrap}` +
-	`.tline .guide{white-space:pre;color:var(--muted);flex:none}` +
-	`.tline.src>code.fpk{color:var(--accent)}.tline.dst>code.fpk{color:var(--accent2)}` +
+	// One unified route tree (root = local visor; branches = first-hop peers).
+	`.tree{font-family:ui-monospace,SFMono-Regular,monospace;font-size:11.5px;line-height:1.6;overflow-x:auto;padding:.3rem 0;border:1px solid var(--line);border-radius:7px;background:var(--card);padding:.55rem .65rem}` +
+	`.tline,.tdetail{display:flex;align-items:baseline;gap:.3rem;white-space:nowrap}` +
+	`.tline{margin-top:.1rem}` +
+	`.guide{white-space:pre;color:var(--muted);flex:none}` + // box-drawing trunk/branch cells
+	`.tline.src>code.fpk{color:var(--accent);font-weight:600}.tline.dst>code.fpk{color:var(--accent2);font-weight:600}` +
 	`.tlabel{font-size:9.5px;font-weight:600;text-transform:uppercase;letter-spacing:.3px;border-radius:3px;padding:0 .3rem;flex:none}` +
 	`.tlabel.src{background:rgba(124,131,255,.2);color:var(--accent)}` +
 	`.tlabel.dst{background:rgba(160,107,255,.2);color:var(--accent2)}` +
 	`.tlabel.mid{color:var(--muted)}` +
-	`.thop{color:var(--muted);margin-left:.4rem;font-size:11px;flex:none}` +
+	`.thop{color:var(--muted);margin-left:.35rem;font-size:11px;flex:none}` +
+	// Continuation (metadata) lines: no branch glyph, aligned under the leaf PK.
+	`.tdetail{font-size:10.5px;color:var(--muted)}` +
+	`.tdetail .legm{color:var(--fg)}.tdetail .legm i{color:var(--muted);font-style:normal;margin-right:.2rem;text-transform:uppercase;font-size:9px;letter-spacing:.3px}` +
+	`.tdetail .bwlabel{color:var(--muted);white-space:nowrap}` +
+	`.tdetail .barcell{display:inline-block;width:7rem;flex:none}` +
 	`pre.log{background:var(--card);border:1px solid var(--line);border-radius:8px;padding:.7rem;font:11.5px/1.5 ui-monospace,SFMono-Regular,monospace;` +
 	`white-space:pre-wrap;word-break:break-word;max-height:26rem;overflow:auto;color:var(--fg)}` +
 	`ul.events{margin:.3rem 0;padding-left:1.1rem;font-size:12px}ul.events li{margin:.1rem 0}` +

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -174,9 +174,13 @@ func writePill(b *strings.Builder, k, v, cls string) {
 	fmt.Fprintf(b, `<span class="%s"><i>%s</i> %s</span>`, c, html.EscapeString(k), v)
 }
 
-// writeMuxSection renders the per-leg mux view: one row per leg with a
-// bandwidth bar sized to its share of the busiest leg (a static, no-JS analog of
-// the `cli proxy mux plot` panel), plus RTT, retransmits and gate state.
+// writeMuxSection renders the per-leg mux view as one ROUTE TREE per leg —
+// the flat mux table and the separate "full routes" hop chains folded into a
+// single view inspired by `skywire cli tp tree`. Each leg is a header line
+// (route kind + gate state + tp/route RTT + rtx + sent/recv share bars) above a
+// box-drawing tree that traces this visor → intermediate relays → destination,
+// every public key shown in full and click-to-copy. A static, no-JS analog of
+// the `cli proxy mux plot` panel.
 func writeMuxSection(b *strings.Builder, snap Snapshot) {
 	b.WriteString(`<section><h2>route group · per-leg mux</h2>`)
 	if len(snap.Legs) == 0 {
@@ -205,7 +209,7 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 		}
 	}
 	// Scannable route-group summary: leg census + aggregate throughput, so the
-	// operator gets the shape of the group before reading the per-leg table.
+	// operator gets the shape of the group before reading the per-leg trees.
 	b.WriteString(`<div class="rgsummary">`)
 	writeStat(b, "legs", fmt.Sprintf("%d", len(snap.Legs)), "")
 	writeStat(b, "active", fmt.Sprintf("%d", nActive), "ok")
@@ -218,72 +222,106 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 	writeStat(b, "sent", humanBytes(totSent), "")
 	writeStat(b, "recv", humanBytes(totRecv), "")
 	b.WriteString(`</div>`)
-	b.WriteString(`<table class="mux"><thead><tr>` +
-		`<th>leg</th><th>route</th><th>transport</th><th>peer</th>` +
-		`<th>sent</th><th>bandwidth (sent share)</th>` +
-		`<th>recv</th><th>bandwidth (recv share)</th>` +
-		`<th>tp rtt</th><th>route rtt</th><th>rtx</th><th>state</th></tr></thead><tbody>`)
+	b.WriteString(`<div class="legs-tree">`)
 	for _, l := range snap.Legs {
-		// shares are 0..100 (maxSent/maxRecv are per-leg maxes, >=1) — kept as
-		// uint64 and printed directly so there's no uint64->int narrowing.
-		sentShare := l.SentBytes * 100 / maxSent
-		recvShare := l.RecvBytes * 100 / maxRecv
-		state, scls := legState(l)
-		// route: direct (1-hop) vs multihop (relayed). RouteLatencyMS is the
-		// TRUE end-to-end latency; LatencyMS is only the first-hop transport.
-		routeLabel, routeCls := "multihop", "route-relay"
-		if l.Direct {
-			routeLabel, routeCls = "direct", "route-direct"
-		}
-		fmt.Fprintf(b, `<tr><td>R%d</td><td><span class="rtag %s">%s</span></td><td>%s</td><td class="pk">%s</td>`,
-			l.Index, routeCls, routeLabel, html.EscapeString(orDash(l.TpType)), copyablePK(l.RemotePK))
-		fmt.Fprintf(b, `<td>%s</td><td class="barcell"><span class="bar %s" style="width:%d%%"></span></td>`,
-			humanBytes(l.SentBytes), scls, sentShare)
-		fmt.Fprintf(b, `<td>%s</td><td class="barcell"><span class="bar recv %s" style="width:%d%%"></span></td>`,
-			humanBytes(l.RecvBytes), scls, recvShare)
-		fmt.Fprintf(b, `<td>%.0f ms</td><td>%s</td><td>%d</td><td><span class="badge %s">%s</span></td></tr>`,
-			l.LatencyMS, routeRTT(l.RouteLatencyMS), l.Retransmits, scls, state)
+		writeLegTree(b, l, maxSent, maxRecv)
 	}
-	b.WriteString(`</tbody></table>`)
-	writeMuxRoutes(b, snap.Legs)
-	b.WriteString(`<p class="hint">Bars are each leg's sent / recv bytes relative to the busiest leg. ` +
+	b.WriteString(`</div>`)
+	b.WriteString(`<p class="hint">Each leg is a route tree — this visor at the root, ` +
+		`<span class="tlabel src">source</span> then relays, the ` +
+		`<span class="tlabel dst">exit</span> at the leaf; per-hop transport type + RTT sit on each branch. ` +
+		`Bars are each leg's sent / recv bytes relative to the busiest leg. ` +
 		`<b>tp rtt</b> is the first-hop transport; <b>route rtt</b> is the true end-to-end route latency (all hops). ` +
 		`Click any public key to copy it. ` +
 		`For a live terminal chart use <code>skywire cli proxy mux plot</code>.</p></section>`)
 }
 
-// writeMuxRoutes renders each leg's FULL forward route as a hop chain:
-// origin PK ─[tptype rtt]→ hop PK ─[…]→ destination PK. Public keys are
-// shown in full (never truncated); per-hop latency is shown where known.
-func writeMuxRoutes(b *strings.Builder, legs []Leg) {
-	any := false
-	for _, l := range legs {
-		if len(l.Hops) > 0 {
-			any = true
-			break
-		}
+// writeLegTree renders one leg as a header line plus its hop tree. The header
+// carries the route kind (direct/multihop), gate state badge, tp/route RTT, rtx
+// and the dual sent/recv share bars; the tree below it traces the leg's forward
+// path with box-drawing glyphs, this visor at the root and the destination/exit
+// at the leaf. maxSent/maxRecv (>=1) scale the share bars against the busiest leg.
+func writeLegTree(b *strings.Builder, l Leg, maxSent, maxRecv uint64) {
+	state, scls := legState(l)
+	// route: direct (1-hop) vs multihop (relayed). RouteLatencyMS is the TRUE
+	// end-to-end latency; LatencyMS is only the first-hop transport.
+	routeLabel, routeCls := "multihop", "route-relay"
+	if l.Direct {
+		routeLabel, routeCls = "direct", "route-direct"
 	}
-	if !any {
+	b.WriteString(`<div class="leg">`)
+	// Header line.
+	b.WriteString(`<div class="leghdr">`)
+	fmt.Fprintf(b, `<span class="rlabel">R%d</span>`, l.Index)
+	fmt.Fprintf(b, `<span class="rtag %s">%s</span>`, routeCls, routeLabel)
+	fmt.Fprintf(b, `<span class="badge %s">%s</span>`, scls, state)
+	fmt.Fprintf(b, `<span class="legm"><i>tp</i>%.0f ms</span>`, l.LatencyMS)
+	fmt.Fprintf(b, `<span class="legm"><i>route</i>%s</span>`, routeRTT(l.RouteLatencyMS))
+	fmt.Fprintf(b, `<span class="legm"><i>rtx</i>%d</span>`, l.Retransmits)
+	b.WriteString(`</div>`)
+	// Sent/recv share bars (kept from the old table — dual bandwidth shares).
+	// shares are 0..100 (maxSent/maxRecv are per-leg maxes, >=1) — printed as
+	// uint64 directly so there's no uint64->int narrowing.
+	sentShare := l.SentBytes * 100 / maxSent
+	recvShare := l.RecvBytes * 100 / maxRecv
+	b.WriteString(`<div class="legbw">`)
+	fmt.Fprintf(b, `<span class="bwlabel">sent %s</span><span class="barcell"><span class="bar %s" style="width:%d%%"></span></span>`,
+		humanBytes(l.SentBytes), scls, sentShare)
+	fmt.Fprintf(b, `<span class="bwlabel">recv %s</span><span class="barcell"><span class="bar recv %s" style="width:%d%%"></span></span>`,
+		humanBytes(l.RecvBytes), scls, recvShare)
+	b.WriteString(`</div>`)
+	// Hop tree.
+	b.WriteString(`<div class="tree">`)
+	if len(l.Hops) == 0 {
+		// Legacy/accepted route with no recorded path: fall back to a single
+		// leaf so nothing breaks — just the destination we do know (RemotePK).
+		writeTreeLine(b, "└── ", "dst", "exit", l.RemotePK, "")
+		b.WriteString(`</div></div>`)
 		return
 	}
-	b.WriteString(`<h3>full routes</h3><div class="routes">`)
-	for _, l := range legs {
-		if len(l.Hops) == 0 {
-			continue
+	// Root: the first hop's From is THIS visor (the route source).
+	writeTreeLine(b, "└─┬ ", "src", "this visor", l.Hops[0].From, "")
+	n := len(l.Hops)
+	for i, h := range l.Hops {
+		indent := strings.Repeat("  ", i+1)
+		glyph := indent + "└── "
+		nodeCls, nodeLabel := "mid", ""
+		if i < n-1 {
+			glyph = indent + "└─┬ " // an intermediate relay: more path below
+		} else {
+			nodeCls, nodeLabel = "dst", "exit" // final To is the destination/exit
 		}
-		fmt.Fprintf(b, `<div class="route"><span class="rlabel">R%d</span> %s`,
-			l.Index, copyablePK(l.Hops[0].From))
-		for _, h := range l.Hops {
-			lat := ""
-			if h.LatencyMS > 0 {
-				lat = fmt.Sprintf(" %.0fms", h.LatencyMS)
-			}
-			fmt.Fprintf(b, ` <span class="hop">─[%s%s]→</span> %s`,
-				html.EscapeString(orDash(h.TpType)), html.EscapeString(lat), copyablePK(h.To))
-		}
-		b.WriteString(`</div>`)
+		writeTreeLine(b, glyph, nodeCls, nodeLabel, h.To, formatHop(h))
+	}
+	b.WriteString(`</div></div>`)
+}
+
+// writeTreeLine writes one visor node line of a leg's hop tree: the box-drawing
+// guide prefix (monospace, spaces preserved so nested levels line up), the FULL
+// click-to-copy public key, an optional source/exit accent label, and optional
+// per-hop transport info (type + RTT on the branch leading into this node).
+// nodeCls (src/dst/mid) tints the source and destination the way `tp tree`
+// color-codes them; intermediates are neutral.
+func writeTreeLine(b *strings.Builder, guide, nodeCls, label, pk, hop string) {
+	fmt.Fprintf(b, `<div class="tline %s"><span class="guide">%s</span>%s`,
+		nodeCls, guide, copyablePK(pk))
+	if label != "" {
+		fmt.Fprintf(b, `<span class="tlabel %s">%s</span>`, nodeCls, html.EscapeString(label))
+	}
+	if hop != "" {
+		fmt.Fprintf(b, `<span class="thop">%s</span>`, html.EscapeString(hop))
 	}
 	b.WriteString(`</div>`)
+}
+
+// formatHop renders a hop's transport type and (where measured) its RTT, e.g.
+// "stcpr 139ms". Zero latency is elided rather than shown as "0ms".
+func formatHop(h Hop) string {
+	t := orDash(h.TpType)
+	if h.LatencyMS > 0 {
+		return fmt.Sprintf("%s %.0fms", t, h.LatencyMS)
+	}
+	return t
 }
 
 func legState(l Leg) (label, cls string) {
@@ -476,11 +514,7 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`.stat.ok{color:var(--ok)}.stat.warn{color:var(--warn)}.stat.standby{color:var(--standby)}` +
 	`.badge{display:inline-block;padding:.02rem .4rem;border-radius:999px;font-size:10.5px;font-weight:600;text-transform:uppercase;letter-spacing:.3px;border:1px solid currentColor}` +
 	`.badge.ok{color:var(--ok)}.badge.warn{color:var(--warn)}.badge.standby{color:var(--standby)}` +
-	`table.mux{width:100%;border-collapse:collapse;font-size:12px}` +
-	`table.mux th{text-align:left;color:var(--muted);font-weight:500;border-bottom:1px solid var(--line);padding:.3rem .4rem;text-transform:uppercase;font-size:10px;letter-spacing:.3px}` +
-	`table.mux td{padding:.3rem .4rem;border-bottom:1px solid rgba(43,49,99,.5);white-space:nowrap}` +
-	`td.pk{font-family:ui-monospace,SFMono-Regular,monospace;color:var(--muted)}` +
-	`td.barcell{width:36%}.bar{display:block;height:.7rem;border-radius:3px;background:var(--accent);min-width:2px}` +
+	`.barcell{display:block}.bar{display:block;height:.7rem;border-radius:3px;background:var(--accent);min-width:2px}` +
 	`.bar.standby{background:var(--standby)}.bar.warn{background:var(--warn)}` +
 	`.bar.recv{background:var(--recv,#3b9)}` +
 	`.rtag{display:inline-block;padding:0 .4rem;border-radius:3px;font-size:11px;font-weight:600}` +
@@ -490,11 +524,24 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`.copy{border-radius:3px;transition:background .15s,color .15s}` +
 	`body.js .copy{cursor:pointer}body.js .copy:hover{background:rgba(124,131,255,.14)}` +
 	`.copy.copied{background:var(--ok);color:#04120c}.copy.copied::after{content:" ✓ copied";font-size:10px;letter-spacing:.3px}` +
-	`.routes{display:flex;flex-direction:column;gap:.5rem;margin:.4rem 0}` +
-	`.route{font-size:12px;line-height:1.7;padding:.4rem .6rem;border:1px solid var(--border,#3334);border-radius:5px;overflow-wrap:anywhere}` +
-	`.route .rlabel{font-weight:700;margin-right:.3rem}` +
-	`.route .hop{color:var(--muted,#8a94a6);white-space:nowrap;font-family:ui-monospace,monospace}` +
-	`td.ok{color:var(--ok)}td.warn{color:var(--warn)}td.standby{color:var(--standby)}` +
+	// Per-leg route trees.
+	`.legs-tree{display:flex;flex-direction:column;gap:.7rem;margin:.4rem 0}` +
+	`.leg{border:1px solid var(--line);border-radius:7px;padding:.5rem .65rem;background:var(--card)}` +
+	`.leghdr{display:flex;flex-wrap:wrap;align-items:center;gap:.45rem}` +
+	`.leghdr .rlabel{font-weight:700}` +
+	`.legm{font-size:11.5px;color:var(--fg)}` +
+	`.legm i{color:var(--muted);font-style:normal;margin-right:.25rem;text-transform:uppercase;font-size:10px;letter-spacing:.3px}` +
+	`.legbw{display:grid;grid-template-columns:auto minmax(4rem,1fr);gap:.2rem .5rem;align-items:center;margin:.4rem 0;max-width:30rem}` +
+	`.bwlabel{font-size:11px;color:var(--muted);white-space:nowrap}` +
+	`.tree{font-family:ui-monospace,SFMono-Regular,monospace;font-size:11.5px;line-height:1.65;overflow-x:auto;padding-top:.15rem}` +
+	`.tline{display:flex;align-items:baseline;gap:.3rem;white-space:nowrap}` +
+	`.tline .guide{white-space:pre;color:var(--muted);flex:none}` +
+	`.tline.src>code.fpk{color:var(--accent)}.tline.dst>code.fpk{color:var(--accent2)}` +
+	`.tlabel{font-size:9.5px;font-weight:600;text-transform:uppercase;letter-spacing:.3px;border-radius:3px;padding:0 .3rem;flex:none}` +
+	`.tlabel.src{background:rgba(124,131,255,.2);color:var(--accent)}` +
+	`.tlabel.dst{background:rgba(160,107,255,.2);color:var(--accent2)}` +
+	`.tlabel.mid{color:var(--muted)}` +
+	`.thop{color:var(--muted);margin-left:.4rem;font-size:11px;flex:none}` +
 	`pre.log{background:var(--card);border:1px solid var(--line);border-radius:8px;padding:.7rem;font:11.5px/1.5 ui-monospace,SFMono-Regular,monospace;` +
 	`white-space:pre-wrap;word-break:break-word;max-height:26rem;overflow:auto;color:var(--fg)}` +
 	`ul.events{margin:.3rem 0;padding-left:1.1rem;font-size:12px}ul.events li{margin:.1rem 0}` +


### PR DESCRIPTION
The status.skysocks route-group view had two sections describing the same legs — a flat mux table and a separate "full routes" hop-chain list. This folds them into ONE unified route tree rooted at the local visor, in the shape of `skywire cli visor ping tree`: one root, branches = the first-hop peers this visor dials.

Every leg is a path `local → … → destination`; all leg paths are prefix-merged into a single tree, so a shared first hop collapses into one branch that diverges deeper (with disjoint adaptive legs each keeps its own branch). Each edge carries the transport that reaches that hop (click-to-copy id + type + rtt). The direct active leg carrying app traffic is ordered first, then active multihop, warm standby, then dead.

Nothing the old table showed is dropped — sent/recv bytes with their share-bar meters, tp-rtt (on the first-hop edge), route-rtt (em dash when unmeasured), rtx, gate state and the direct/multihop tag — all retained, relocated onto indented continuation lines beneath each destination leaf's PK. Those lines carry no branch glyph, and the box-drawing trunk continues through them so the tree's left structure stays contiguous (`│` under still-open ancestors, spaces under the last branch). Full PKs stay untruncated and copyable; source/exit accent, live WebSocket swap, selection guard and progressive enhancement are unchanged.

Pure render change in `pkg/proxystatus/render.go` — all data was already on `Leg`/`Hop`.

Sample (a direct leg + two standby multihop legs, sharing the one root; PKs full/untruncated in the page, abbreviated here for width):

```
0323272a…9d4c  this visor
├─── 02f9aa58…6c36  exit  via 9a3a17e0 stcpr 139ms
│   direct · active · route — · rtx 0
│   sent 42.1 KiB [====]   recv 135.2 KiB [======]
├─┬ 027ce6aa…e6ce  via f05f99d7 webrtc 90ms
│   └─── 02f9aa58…6c36  exit  via stcpr 51ms
│       multihop · standby · route 141 ms · rtx 0
│       sent 0 B [ ]   recv 23.4 KiB [=]
└─┬ 021a025c…50a6  via stcpr 200ms
    └─── 02f9aa58…6c36  exit  via stcpr 174ms
        multihop · standby · route 374 ms · rtx 0
        sent 706 B [ ]   recv 4.4 KiB [=]
```

`│` continues on the meter/detail lines of the first two branches (siblings below) and is spaces under the last branch.

Tests updated to assert the merged-tree markup (root/branch/leaf glyphs, source/exit accents, per-edge transport id + type + latency, continuation `tdetail` lines, trunk `│`) and that PKs remain full + copyable. `go build .`, `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor`, `go vet`, gofmt, `golangci-lint run pkg/proxystatus/...` (0 issues) and `go test ./pkg/proxystatus/...` all pass.
