### PR TITLE
fix(router): record full forward hops for every mux leg's telemetry

### DIFF
--- a/pkg/router/route_group_mux_test.go
+++ b/pkg/router/route_group_mux_test.go
@@ -391,3 +391,56 @@ func TestLegLivenessKeepsEchoingLeg(t *testing.T) {
 	require.True(t, found, "a leg that keeps echoing must survive")
 	require.GreaterOrEqual(t, len(rg.tps), 1)
 }
+
+// TestMuxStatsReportsFullMultihopLegChain verifies that a mux leg whose full
+// forward route was recorded (SetForwardHops for the primary, recordLegHops for
+// aux legs — the two paths the dial-side establishment sites feed) reports EVERY
+// hop in MuxStats().Legs[i].Hops, ending at the true destination — not just the
+// leg's first-hop transport remote (the first INTERMEDIATE, which the pre-fix
+// tp.Remote() fallback mislabeled as the exit). It also asserts an unrecorded
+// leg surfaces no hops, so the fix (recording at every establishment site) is
+// what turns a single mislabeled node into the full chain.
+func TestMuxStatsReportsFullMultihopLegChain(t *testing.T) {
+	rg, mts, _ := createMuxRouteGroup(t, 3)
+	src := rg.desc.SrcPK()
+	dst := rg.desc.DstPK()
+
+	// Leg 0 (primary): a 2-hop forward path src -> mid0 -> dst, recorded the
+	// way finishDial does via SetForwardHops. Its first-hop TpID must be the
+	// leg's transport ID so MuxStats' legHopsFor lookup resolves it.
+	mid0, _ := cipher.GenerateKeyPair()
+	rg.SetForwardHops([]routing.Hop{
+		{TpID: mts[0].Entry.ID, From: src, To: mid0},
+		{TpID: uuid.New(), From: mid0, To: dst},
+	})
+
+	// Leg 1 (aux): a 2-hop forward path src -> mid1 -> dst, recorded the way the
+	// establishMuxRoutes / rotation add-leg sites now do via recordLegHops.
+	mid1, _ := cipher.GenerateKeyPair()
+	rg.recordLegHops([]routing.Hop{
+		{TpID: mts[1].Entry.ID, From: src, To: mid1},
+		{TpID: uuid.New(), From: mid1, To: dst},
+	})
+
+	// Leg 2: deliberately NOT recorded — models the pre-fix gap.
+
+	info := rg.MuxStats()
+	require.True(t, info.MuxEnabled)
+	require.Len(t, info.Legs, 3)
+
+	// Both recorded multihop legs report their WHOLE chain, ending at the real
+	// destination (not the first intermediate).
+	for _, li := range []int{0, 1} {
+		hops := info.Legs[li].Hops
+		require.Len(t, hops, 2, "leg %d must report every hop, not a single node", li)
+		require.Equal(t, src.String(), hops[0].From, "leg %d's first hop starts at this visor", li)
+		require.Equal(t, dst.String(), hops[len(hops)-1].To,
+			"leg %d's last hop must end at the true destination, not the first intermediate", li)
+	}
+	require.Equal(t, mid0.String(), info.Legs[0].Hops[0].To, "primary leg's first hop lands on its intermediate")
+	require.Equal(t, mid1.String(), info.Legs[1].Hops[0].To, "aux leg's first hop lands on its intermediate")
+
+	// The unrecorded leg surfaces no hop chain (the pre-fix behavior for EVERY
+	// aux leg): MuxStats has nothing but the first-hop transport to show.
+	require.Empty(t, info.Legs[2].Hops, "an unrecorded leg reports no hop chain")
+}

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -2471,6 +2471,17 @@ func (r *router) establishMuxRoutes(
 					p.slot, maxCount, p.addFwd, p.addRev, err)
 				return
 			}
+			// Record this leg's full forward route so the per-leg mux view shows
+			// its whole path (all hops, full PKs, per-hop transport type) instead
+			// of falling back to the first-hop transport's remote — which for a
+			// multihop leg is the first INTERMEDIATE, mislabeled as the exit. Only
+			// when the forward leg was actually appended (addFwd); a reverse-only
+			// slot installs no forward transport to key the hops on. The forward
+			// path's first-hop TpID matches muxRules.Forward.NextTransportID (the
+			// transport appendRouteAsymmetric registered), so legHopsFor finds it.
+			if p.addFwd {
+				nrg.rg.recordLegHops(p.req.Forward)
+			}
 			log.Infof("Mux route %d/%d established (fwd=%v rev=%v) via tp %s",
 				p.slot, maxCount, p.addFwd, p.addRev, muxRules.Forward.NextTransportID())
 		}(p)
@@ -2639,6 +2650,10 @@ func (r *router) addOneAuxLeg(ctx context.Context, nrg *NoiseRouteGroup, opts *D
 	if err := r.appendRouteAsymmetric(nrg, muxRules, true, addRev); err != nil {
 		return fmt.Errorf("rotation add-leg: append: %w", err)
 	}
+	// Record this leg's full forward route (addFwd is always true here) so the
+	// per-leg mux view shows its whole path instead of the first-hop transport's
+	// remote — which for a multihop leg is the first intermediate, not the exit.
+	nrg.rg.recordLegHops(muxFwd)
 	log.Infof("Rotation aux leg established (addRev=%v) via tp %s", addRev, muxRules.Forward.NextTransportID())
 	return nil
 }


### PR DESCRIPTION
Per-leg mux telemetry (`RouteGroupMuxInfo` -> `Leg.Hops`) only recorded the full hop path for legs added via `AddMuxRouteByHops`/`GrowMuxRoute`. Warm-standby and aux legs set up through `establishMuxRoutes`' parallel dial and the rotation add-leg path (`addOneAuxLeg`) appended their transport without calling `recordLegHops`, so `legForwardHops` stayed empty for those legs. `MuxStats` then fell back to `tp.Remote()` — which for a multihop leg is the FIRST INTERMEDIATE — so the status.skysocks route tree collapsed the leg to a single node and mislabeled that intermediate as the exit.

The fix records each leg's full forward path (already in hand as the plan's `Forward []routing.Hop`, which carries per-hop `TpID` + `From`/`To` PKs — no reconstruction needed) right after the append succeeds, at both establishment sites. The primary leg was already covered by `finishDial`'s `SetForwardHops`; the responder-side `appendRouteToGroup`/pending-leg drain/`IntroduceRules` paths are left as-is since the full path isn't available there.

Adds a router test asserting a recorded multihop leg reports its whole chain ending at the true destination, while an unrecorded leg reports no hops. `go test -race ./pkg/router/...` passes (279 tests); `go vet`, gofmt, `golangci-lint run pkg/router/...` clean on the changed files.