### PR TITLE
fix(stats): sync only live transports' current leaf to the TPD feed

### DIFF
--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
@@ -71,9 +73,18 @@ func initStats(_ context.Context, v *Visor, log *logging.Logger) error {
 	// own PK (one identity per node).
 	pub, sink := buildStatsPublisher(v, log)
 	if pub != nil {
-		if err := seedSinkFromStore(store, sink, publishWindow, log); err != nil {
+		// Only the currently-live transports' `current` leaf may be
+		// broadcast to the discovery feed. bbolt retains records for
+		// recently-closed transports (local /stats history), but pushing
+		// their stale `current` leaves bloats the Root TPD fills over a
+		// short announce conn and starves discovery. Seed the tracker's
+		// mirrored-current set with this same live set so a transport that
+		// dies between hydrate and the first sample is reconciled away.
+		liveIDs := liveTransportIDs(v)
+		if err := seedSinkFromStore(store, sink, publishWindow, liveIDs, log); err != nil {
 			log.WithError(err).Warn("Stats: hydrating CXO publisher from bbolt failed")
 		}
+		tracker.SeedMirroredCurrent(liveIDs)
 		tracker.SetSink(sink)
 		// Wire the same publisher into the transport manager so its
 		// register / deregister loops mirror the canonical entry +
@@ -231,14 +242,37 @@ func buildStatsPublisher(v *Visor, log *logging.Logger) (*treestore.Publisher, s
 // seedSinkFromStore copies the in-window slice of bbolt state into
 // the freshly-initialized publisher so cold subscribers see the full
 // rolling window from the first connect, not just data sampled after
-// the visor restarted.
-func seedSinkFromStore(store *stats.Store, sink stats.Sink, publishWindowDays int, log *logging.Logger) error {
-	pushed, err := stats.HydrateSink(store, sink, publishWindowDays, time.Now())
+// the visor restarted. Only the `current` snapshot leaves of transports
+// in liveIDs are broadcast (dead-but-retained records stay bbolt-only).
+func seedSinkFromStore(store *stats.Store, sink stats.Sink, publishWindowDays int, liveIDs map[uuid.UUID]struct{}, log *logging.Logger) error {
+	isLive := func(id uuid.UUID) bool {
+		_, ok := liveIDs[id]
+		return ok
+	}
+	pushed, err := stats.HydrateSink(store, sink, publishWindowDays, time.Now(), isLive)
 	if err != nil {
 		return err
 	}
 	log.WithField("paths", pushed).Debug("Stats: hydrated CXO publisher from bbolt")
 	return nil
+}
+
+// liveTransportIDs snapshots the IDs of the visor's currently-live
+// (non-closed) transports. Mirrors the IsClosed() filter in
+// transportsProbe / countLiveTransports — this is the set whose
+// `current` telemetry leaf is eligible for the CXO/TPD discovery feed.
+func liveTransportIDs(v *Visor) map[uuid.UUID]struct{} {
+	out := make(map[uuid.UUID]struct{})
+	if v.tpM == nil {
+		return out
+	}
+	v.tpM.WalkTransports(func(tp *transport.ManagedTransport) bool {
+		if !tp.IsClosed() {
+			out[tp.Entry.ID] = struct{}{}
+		}
+		return true
+	})
+	return out
 }
 
 // cxoSink adapts a treestore.Publisher to the stats.Sink contract.

--- a/pkg/visor/stats/sink.go
+++ b/pkg/visor/stats/sink.go
@@ -32,6 +32,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // SinkOp is a single (path, value) pair for a batched Put. A nil
@@ -89,27 +91,38 @@ func (t *Tracker) SetSink(s Sink) {
 // in-memory tree from on-disk state so cold subscribers see the full
 // rolling window immediately, not just samples taken after restart.
 //
+// isLive gates which transports' `current` snapshot leaf is broadcast:
+// only transports still live at hydrate time are pushed. The bbolt
+// store retains records for recently-closed transports (inside the
+// retention window) so the visor's own /stats history stays complete,
+// but those dead records must NOT be mirrored to the CXO/TPD discovery
+// feed — every stale `current` leaf bloats the Root that TPD fills over
+// a short-lived announce conn, breaking the fill and starving discovery
+// (only the top slice of transports lands). A nil predicate means "all
+// records are live" (used by tests that don't exercise the live gate).
+//
 // Returns the number of paths pushed.
-func HydrateSink(store *Store, sink Sink, publishWindowDays int, now time.Time) (int, error) {
+func HydrateSink(store *Store, sink Sink, publishWindowDays int, now time.Time, isLive func(id uuid.UUID) bool) (int, error) {
 	if publishWindowDays <= 0 {
 		return 0, nil
 	}
 	pushed := 0
 
-	// Push ONLY current per-transport snapshots to the CXO sink. TPD is a
-	// discovery service: the feed it fills over the short announce conn must
-	// stay small (transports/list + transports/<id>/current), so it can be
-	// fetched reliably. Historical telemetry — daily rollups, tier/service
-	// bitmaps, and per-transport timeline bitmaps — remains bbolt-only for
-	// the visor's own /stats + `visor state`; re-broadcasting days of history
-	// grew the Root to ~23k objects and broke TPD's fill (the discovery gap).
-	// TPD accumulates its own uptime history from what it observes each cycle.
+	// Push ONLY current per-transport snapshots to the CXO sink, and only for
+	// LIVE transports (see isLive above). TPD is a discovery service: the feed
+	// it fills over the short announce conn must stay small (transports/list +
+	// transports/<id>/current), so it can be fetched reliably. Historical
+	// telemetry — daily rollups, tier/service bitmaps, and per-transport
+	// timeline bitmaps — remains bbolt-only for the visor's own /stats +
+	// `visor state`; re-broadcasting days of history grew the Root to ~23k
+	// objects and broke TPD's fill (the discovery gap). TPD accumulates its
+	// own uptime history from what it observes each cycle.
 	records, err := store.AllTransportRecords()
 	if err != nil {
 		return pushed, fmt.Errorf("hydrate transports: %w", err)
 	}
 	for _, rec := range records {
-		if rec.Current != nil {
+		if rec.Current != nil && (isLive == nil || isLive(rec.ID)) {
 			if data, err := json.Marshal(rec.Current); err == nil {
 				sink.Put(currentTransportPath(rec.ID.String()), data)
 				pushed++

--- a/pkg/visor/stats/sink_test.go
+++ b/pkg/visor/stats/sink_test.go
@@ -255,6 +255,90 @@ func TestSinkDeletedOnBboltRetentionDrop(t *testing.T) {
 	}
 }
 
+// TestSinkDeletesCurrentWhenTransportGoesDead drives two live
+// transports through a sample (both publish a current leaf), then a
+// second sample where one has closed (probe no longer returns it). The
+// closed transport's current leaf must be sink-Deleted; the still-live
+// one's must remain and never be deleted.
+func TestSinkDeletesCurrentWhenTransportGoesDead(t *testing.T) {
+	sink := newRecordingSink()
+	tr := newTrackerWithSink(t, sink)
+	live := uuid.New()
+	dying := uuid.New()
+	t0 := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+
+	probe := func() []TransportProbe {
+		return []TransportProbe{
+			{ID: live, Type: "stcpr", SentBytes: 10, RecvBytes: 10},
+			{ID: dying, Type: "stcpr", SentBytes: 20, RecvBytes: 20},
+		}
+	}
+	tr.probes.Transports = probe
+	tr.sample(t0)
+
+	puts, _ := sink.snapshot()
+	if _, ok := puts[currentTransportPath(live.String())]; !ok {
+		t.Fatalf("live current leaf missing after first sample")
+	}
+	if _, ok := puts[currentTransportPath(dying.String())]; !ok {
+		t.Fatalf("dying current leaf missing after first sample")
+	}
+
+	// Second sample: `dying` has closed and is no longer in the probe.
+	tr.probes.Transports = func() []TransportProbe {
+		return []TransportProbe{{ID: live, Type: "stcpr", SentBytes: 15, RecvBytes: 15}}
+	}
+	tr.sample(t0.Add(time.Minute))
+
+	puts, dels := sink.snapshot()
+	foundDel := false
+	for _, d := range dels {
+		if d == currentTransportPath(dying.String()) {
+			foundDel = true
+		}
+		if d == currentTransportPath(live.String()) {
+			t.Errorf("live transport current leaf was deleted; must persist")
+		}
+	}
+	if !foundDel {
+		t.Errorf("dead transport current leaf was not sink-deleted; dels=%v", dels)
+	}
+	if _, ok := puts[currentTransportPath(dying.String())]; ok {
+		t.Errorf("dead transport current leaf still present in sink puts")
+	}
+	if _, ok := puts[currentTransportPath(live.String())]; !ok {
+		t.Errorf("live transport current leaf missing after second sample")
+	}
+}
+
+// TestSeedMirroredCurrentReconcilesStaleLeaf seeds the tracker with an
+// ID that is not in the first sample's live probe (a transport that
+// died between hydrate and the first sample) and asserts its stale
+// current leaf is reconciled away on that first sample.
+func TestSeedMirroredCurrentReconcilesStaleLeaf(t *testing.T) {
+	sink := newRecordingSink()
+	tr := newTrackerWithSink(t, sink)
+	seededDead := uuid.New()
+	live := uuid.New()
+	tr.SeedMirroredCurrent(map[uuid.UUID]struct{}{seededDead: {}})
+
+	tr.probes.Transports = func() []TransportProbe {
+		return []TransportProbe{{ID: live, Type: "stcpr", SentBytes: 1, RecvBytes: 1}}
+	}
+	tr.sample(time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC))
+
+	_, dels := sink.snapshot()
+	found := false
+	for _, d := range dels {
+		if d == currentTransportPath(seededDead.String()) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("seeded-dead transport current leaf not reconciled away; dels=%v", dels)
+	}
+}
+
 // TestHydrateSinkPushesCurrentOnly asserts the seed path pushes only current
 // per-transport snapshots to the CXO sink — never historical tier/service or
 // timeline bitmaps (those are bbolt-only and would bloat the TPD feed).
@@ -285,7 +369,7 @@ func TestHydrateSinkPushesCurrentOnly(t *testing.T) {
 	}
 
 	sink := newRecordingSink()
-	pushed, err := HydrateSink(store, sink, 7, now)
+	pushed, err := HydrateSink(store, sink, 7, now, nil)
 	if err != nil {
 		t.Fatalf("HydrateSink: %v", err)
 	}
@@ -300,6 +384,70 @@ func TestHydrateSinkPushesCurrentOnly(t *testing.T) {
 		if p != "transports/"+id.String()+"/current" {
 			t.Errorf("only current snapshots should be hydrated to the sink; got unexpected %q", p)
 		}
+	}
+}
+
+// TestHydrateSinkPushesLiveTransportsCurrentOnly seeds the store with a
+// mix of live and dead transport records and asserts HydrateSink pushes
+// a `current` leaf for exactly the live set — the dead-but-retained
+// records stay bbolt-only and off the discovery feed.
+func TestHydrateSinkPushesLiveTransportsCurrentOnly(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "stats.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := store.Close(); err != nil {
+			t.Logf("store.Close: %v", err)
+		}
+	}()
+
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	live := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()} // N = 3
+	dead := []uuid.UUID{uuid.New(), uuid.New()}             // M = 2
+	for _, id := range append(append([]uuid.UUID{}, live...), dead...) {
+		rec := &TransportRecord{
+			ID:        id,
+			Type:      "stcpr",
+			FirstSeen: now.Add(-time.Hour),
+			LastSeen:  now,
+			Current:   &LiveSnapshot{SentBytes: 1, RecvBytes: 1, SampledAt: now, Type: "stcpr"},
+		}
+		if err := store.PutTransportRecord(rec); err != nil {
+			t.Fatalf("PutTransportRecord: %v", err)
+		}
+	}
+
+	liveSet := map[uuid.UUID]struct{}{}
+	for _, id := range live {
+		liveSet[id] = struct{}{}
+	}
+	isLive := func(id uuid.UUID) bool { _, ok := liveSet[id]; return ok }
+
+	sink := newRecordingSink()
+	if _, err := HydrateSink(store, sink, 7, now, isLive); err != nil {
+		t.Fatalf("HydrateSink: %v", err)
+	}
+
+	puts, _ := sink.snapshot()
+	for _, id := range live {
+		if _, ok := puts[currentTransportPath(id.String())]; !ok {
+			t.Errorf("live transport %s: current leaf missing from sink", id)
+		}
+	}
+	for _, id := range dead {
+		if _, ok := puts[currentTransportPath(id.String())]; ok {
+			t.Errorf("dead transport %s: current leaf must NOT be on the sink", id)
+		}
+	}
+	nCurrent := 0
+	for p := range puts {
+		if len(p) > len("/current") && p[len(p)-len("/current"):] == "/current" {
+			nCurrent++
+		}
+	}
+	if nCurrent != len(live) {
+		t.Errorf("current leaves pushed = %d, want %d (live only)", nCurrent, len(live))
 	}
 }
 

--- a/pkg/visor/stats/tracker.go
+++ b/pkg/visor/stats/tracker.go
@@ -38,11 +38,20 @@ type Tracker struct {
 	// exposes only 7.
 	publishKeep time.Duration
 
-	mu         sync.Mutex
-	sink       Sink
-	baselines  map[uuid.UUID]bandwidthBaseline
-	lastDay    string // YYYY-MM-DD UTC of the most recent sample
-	lastPruned time.Time
+	mu        sync.Mutex
+	sink      Sink
+	baselines map[uuid.UUID]bandwidthBaseline
+	// mirroredCurrent is the set of transport IDs whose
+	// transports/<id>/current leaf is currently published to the sink.
+	// Each sample reconciles it against the live probe set: IDs that
+	// dropped out (transport closed) get their current leaf sink-deleted
+	// so the discovery feed reflects only live transports (absence =
+	// dead). Without this, a closed transport's current leaf — published
+	// once while it was live — lingers on the feed for the visor's whole
+	// uptime, accumulating across churn and bloating the Root TPD fills.
+	mirroredCurrent map[uuid.UUID]struct{}
+	lastDay         string // YYYY-MM-DD UTC of the most recent sample
+	lastPruned      time.Time
 
 	cancel context.CancelFunc
 	done   chan struct{}
@@ -124,15 +133,32 @@ func NewTracker(store *Store, probes Probes, conf Config) *Tracker {
 		publishKeep = time.Duration(conf.RetentionDays) * 24 * time.Hour
 	}
 	return &Tracker{
-		store:       store,
-		log:         conf.Logger,
-		probes:      probes,
-		interval:    conf.SampleInterval,
-		keep:        time.Duration(conf.RetentionDays) * 24 * time.Hour,
-		publishKeep: publishKeep,
-		sink:        noopSink{},
-		baselines:   make(map[uuid.UUID]bandwidthBaseline),
+		store:           store,
+		log:             conf.Logger,
+		probes:          probes,
+		interval:        conf.SampleInterval,
+		keep:            time.Duration(conf.RetentionDays) * 24 * time.Hour,
+		publishKeep:     publishKeep,
+		sink:            noopSink{},
+		baselines:       make(map[uuid.UUID]bandwidthBaseline),
+		mirroredCurrent: make(map[uuid.UUID]struct{}),
 	}
+}
+
+// SeedMirroredCurrent records the set of transport IDs whose `current`
+// leaf was already pushed to the sink before the sampler started —
+// typically the live set hydrated by HydrateSink at startup. Seeding it
+// means a transport that was live at hydrate but dies before the first
+// sample still gets its stale current leaf reconciled away (deleted) on
+// that first sample, rather than lingering because the sampler never
+// "saw" it live. Call before Run. The passed map is adopted directly.
+func (t *Tracker) SeedMirroredCurrent(ids map[uuid.UUID]struct{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if ids == nil {
+		ids = make(map[uuid.UUID]struct{})
+	}
+	t.mirroredCurrent = ids
 }
 
 // Store returns the underlying bbolt-backed store. Exposed so HTTP
@@ -244,10 +270,19 @@ func (t *Tracker) sample(now time.Time) {
 	// (post-mutation state), so we snapshot them inside and dispatch
 	// outside.
 	var mirrors []mirrorPair
+	// liveTP is the set of transport IDs the probe reported live this
+	// tick. Non-nil (possibly empty) whenever the Transports probe ran,
+	// so reconcileCurrentLeaves can distinguish "no probe" (leave the
+	// mirrored set alone) from "probe returned zero live transports"
+	// (delete every previously-mirrored current leaf).
+	var liveTP map[uuid.UUID]struct{}
 
 	txErr := t.store.UpdateSample(func(stx *SampleTx) error {
 		if probe := t.probes.Transports; probe != nil {
-			for _, tp := range probe() {
+			tps := probe()
+			liveTP = make(map[uuid.UUID]struct{}, len(tps))
+			for _, tp := range tps {
+				liveTP[tp.ID] = struct{}{}
 				if pairs, err := t.recordTransportTx(stx, tp, utc, today); err != nil {
 					t.log.WithError(err).WithField("tp_id", tp.ID).
 						Debug("Failed to record transport sample")
@@ -292,6 +327,41 @@ func (t *Tracker) sample(now time.Time) {
 	}
 
 	t.sinkPutBatch(mirrors)
+	t.reconcileCurrentLeaves(liveTP)
+}
+
+// reconcileCurrentLeaves diffs the live transport set reported by this
+// tick's probe against the set of current leaves currently mirrored to
+// the sink, and sink-deletes the leaf for any transport that is no
+// longer live (closed transport). This is the per-`current` analog of
+// the date-based sink-prune the retention path already does for daily
+// rollups and timeline bitmaps: a closed transport's current snapshot
+// must reconcile away (absence = dead) so it stops bloating the Root
+// TPD fills. bbolt retention is untouched — the visor's local /stats
+// history for a recently-closed transport stays intact.
+//
+// live == nil means the Transports probe didn't run this tick; leave
+// the mirrored set alone. An empty (non-nil) live set correctly deletes
+// every previously-mirrored current leaf.
+func (t *Tracker) reconcileCurrentLeaves(live map[uuid.UUID]struct{}) {
+	if live == nil {
+		return
+	}
+	t.mu.Lock()
+	var stale []uuid.UUID
+	for id := range t.mirroredCurrent {
+		if _, ok := live[id]; !ok {
+			stale = append(stale, id)
+		}
+	}
+	// Every live transport re-Put its current leaf this tick (idempotent),
+	// so the mirrored set now equals the live set.
+	t.mirroredCurrent = live
+	t.mu.Unlock()
+
+	for _, id := range stale {
+		t.sinkDelete(currentTransportPath(id.String()))
+	}
 }
 
 // sinkPutBatch fans the sample's mirror writes into a single sink


### PR DESCRIPTION
A long-running visor registers only ~8-12% of its live transports into TPD, so route-finding under-enumerates routes and the skysocks mux pool starves. Measured on the live host visor: 178 live transports, 11 in TPD; an exit peer 172 live / 18 in TPD.

Root cause: the CXO telemetry feed TPD's cxo-aggregator fills carried a `transports/<uuid>/current` leaf for every persisted transport record, including transports that had closed but were still inside the stats retention window. #4104 stopped broadcasting daily rollups/timelines; the remaining leak was `current`. Dead leaves are published once while live and never removed, so they accumulate across the visor's uptime and restarts, bloating the Root that TPD fills over a short-lived announce conn. The fill breaks partway and only the top slice of transports lands.

Fix: broadcast `current` for the live transport set only. bbolt retention and the visor's local `/stats` history are untouched — this only changes what is mirrored to the discovery feed.

- `HydrateSink` takes an `isLive` predicate; at startup only live transports' `current` leaf is pushed (dead-but-retained records stay bbolt-only).
- The sampler reconciles a `mirroredCurrent` set against each tick's live probe and sink-deletes the `current` leaf of any transport no longer live (absence = dead) — the per-`current` analog of the existing date-based publish-window prune. The set is seeded from the hydrate live set so a transport that dies between hydrate and the first sample is reconciled away too.

The compact `tp-list` snapshot leaf (the primary discovery leaf TPD targeted-fetches) already carried only the live, non-self-loop set; this change shrinks the rest of the Root so the fill reaches it reliably.

Tests: `pkg/visor/stats` gains coverage that HydrateSink pushes `current` for exactly the live set out of a mixed live/dead store, that a transport going dead across a sample gets its `current` leaf sink-deleted while a live one is never deleted, and that a hydrate-seeded dead ID is reconciled away on the first sample. `go test ./pkg/visor/stats/... ./pkg/visor/` passes; `go vet`, gofmt and golangci-lint clean on the touched files.