### PR TITLE
help: stop dimming a rectangle around the help text

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 
 require (
 	github.com/0magnet/plot-go v0.0.0-20260820145748-0b260a086d19
-	github.com/0magnet/termanim v0.0.0-20260823195938-f88b1541cfcd
+	github.com/0magnet/termanim v0.0.0-20260823220926-60f3279a072f
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/DiSiqueira/GoTree v1.0.0
 	github.com/ccding/go-stun v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/0magnet/plot-go v0.0.0-20260820145748-0b260a086d19 h1:HDuBSefzYQcFM69
 github.com/0magnet/plot-go v0.0.0-20260820145748-0b260a086d19/go.mod h1:LCfGAHo2mK7Su2xbCf9xwiLrlXt/YOcGW7LZ4owtiCk=
 github.com/0magnet/sh/v3 v3.13.2-0.20260814172914-eff537668adf h1:3tImGgrBxM3/eC13YeT8WsT5B3E3dxmHtozvgo0xtpo=
 github.com/0magnet/sh/v3 v3.13.2-0.20260814172914-eff537668adf/go.mod h1:IdyC3iqIKArn4KOl0a58dV2spH0PH6pLJKOZYB2kFR0=
-github.com/0magnet/termanim v0.0.0-20260823195938-f88b1541cfcd h1:uIU35LENZsiWRfDWTBAoQKwe4S5MccJXu5dlBB/0u1w=
-github.com/0magnet/termanim v0.0.0-20260823195938-f88b1541cfcd/go.mod h1:z/hEqBGeyX7Az2HZbJqgMEZo5eJf4SBcxKCZTZ1X4jU=
+github.com/0magnet/termanim v0.0.0-20260823220926-60f3279a072f h1:ERQdvVBjLtHJSHuDOj3NaayEFINQL53Kfdhrzk5A6gs=
+github.com/0magnet/termanim v0.0.0-20260823220926-60f3279a072f/go.mod h1:z/hEqBGeyX7Az2HZbJqgMEZo5eJf4SBcxKCZTZ1X4jU=
 github.com/0magnet/u-root v0.16.1-0.20260810212217-0890fe5099f9 h1:akt/1o/SlArz8M/n+piy0eyKaBa83wrxQmrLgh6FlPU=
 github.com/0magnet/u-root v0.16.1-0.20260810212217-0890fe5099f9/go.mod h1:fId14v+rNp1A0ZKHJPZZyiu9dfgWKEs7nbyvKrku3bo=
 github.com/0magnet/websh v0.0.0-20260816200521-e9f14eb862c7 h1:09IjBB/rJMVtrkn4i1571Nq+iSMEIsjv7S4zlJzKEuQ=

--- a/vendor/github.com/0magnet/termanim/matrix/backdrop/backdrop.go
+++ b/vendor/github.com/0magnet/termanim/matrix/backdrop/backdrop.go
@@ -70,13 +70,18 @@ type Options struct {
 	// width. The rows above and below never do.
 	Pad int
 
-	// Dim scales the rain behind the text, out of 256. Zero means 56: still
-	// visible, not competing with the words. 256 does not dim at all, which
-	// looks like the film and is unreadable.
+	// Dim scales the rain, out of 256. Zero means 256, which is to say no
+	// dimming at all: the cell of clear kept either side of every word is what
+	// keeps the text readable, so the rain behind it does not also have to be
+	// turned down.
+	//
+	// It is here for a caller with much more rain on screen than a help
+	// screen has — a full window of it behind a dense layout can be worth
+	// taking down a little.
 	Dim int
 
 	// TextColor is what the text is drawn in. The zero value, ColorDefault,
-	// means a bright green-white that reads against the dimmed rain.
+	// means a bright green-white that reads against the rain.
 	//
 	// It is ignored for text that brought its own colours. There is no sense
 	// in overriding a styler and then being asked where the styling went.
@@ -89,6 +94,27 @@ type Options struct {
 	// report both want plain text and neither wants two hundred colour
 	// changes a line. NO_COLOR and TERM=dumb are honoured the same way.
 	Force bool
+
+	// GapMin makes a run of that many spaces or more transparent, so the rain
+	// shows through it. Zero, the default, makes a line opaque from its first
+	// column to its last word.
+	//
+	// The two settings are for the two kinds of caller. A help screen is a
+	// block of prose and wants the default: a glyph landing in the single
+	// space between two words is read as part of them, and the rain belongs
+	// past the end of the line and on the blank lines between sections.
+	//
+	// A caller composing a whole screen — panes, boxes, a status bar — wants
+	// the other. Its layout pads every line out to the full width with spaces,
+	// so under the default rule the screen would be opaque everywhere and no
+	// rain would show at all. With GapMin set, the padding inside and around
+	// its panes becomes the backdrop and the words stay legible. Four or five
+	// is about right: wide enough that ordinary word spacing and column
+	// alignment stay solid, narrow enough that empty space reads as empty.
+	//
+	// A cell of clear is kept either side of any text, whichever rule is in
+	// force, so the rain never abuts a word.
+	GapMin int
 
 	// Off returns the text unchanged, whatever else is set.
 	//
@@ -119,41 +145,88 @@ func Render(text string, o Options) string {
 		return text
 	}
 
-	pad := o.Pad
-	if pad == 0 {
-		pad = 2
+	l := layout(text, o)
+
+	// The rain is generated at the full width whatever the text does, so a
+	// short help still gets a screen-wide backdrop rather than a green box.
+	rng := rand.New(rand.NewSource(l.seed))
+	steps := o.Steps
+	if steps == 0 {
+		// Enough for the first columns to have fallen off the bottom, plus a
+		// spread so two runs a second apart are not near-identical frames.
+		steps = 3*l.rows + rng.Intn(4*l.rows+40)
 	}
-	dim := o.Dim
-	if dim == 0 {
-		dim = 56
+	m := matrix.New(l.seed)
+	m.Resize(l.cols, l.rows)
+	m.Advance(steps)
+
+	return paint(m, l, o)
+}
+
+// sheet is one text block measured out against a grid: what it is made of, how
+// big the grid is, and where on it the text goes.
+//
+// The measuring is the same whether the rain behind is a still or is running,
+// so it is done once here and handed to paint. See Painter.
+type sheet struct {
+	lines      [][]glyph
+	raw        []string
+	cols, rows int
+	pad        int // rows of rain above and below
+	indent     int // columns the text is moved over by
+	styled     bool
+	gapMin     int
+	textStyle  string
+	dim        int
+	seed       int64
+}
+
+// layout measures text against the width and settles everything about where it
+// goes, without deciding what is behind it.
+func layout(text string, o Options) sheet {
+	s := sheet{
+		pad:    o.Pad,
+		dim:    o.Dim,
+		seed:   o.Seed,
+		gapMin: o.GapMin,
 	}
-	seed := o.Seed
-	if seed == 0 {
-		seed = time.Now().UnixNano()
+	if s.pad == 0 {
+		s.pad = 2
+	}
+	if s.pad < 0 {
+		// Negative asks for none, which zero cannot: zero is the zero value
+		// and has to mean the default. A caller composing a whole screen and
+		// handing it over whole wants the text exactly where it put it.
+		s.pad = 0
+	}
+	if s.dim == 0 {
+		s.dim = 256
+	}
+	if s.seed == 0 {
+		s.seed = time.Now().UnixNano()
 	}
 	textColor := o.TextColor
 	if textColor == tcell.ColorDefault {
 		textColor = tcell.NewRGBColor(190, 255, 190)
 	}
-	textStyle := sgr(textColor, true)
+	s.textStyle = sgr(textColor, true)
 
-	raw := strings.Split(strings.TrimRight(text, "\n"), "\n")
-	lines := make([][]glyph, len(raw))
-	styled := false
-	for i, l := range raw {
+	s.raw = strings.Split(strings.TrimRight(text, "\n"), "\n")
+	s.lines = make([][]glyph, len(s.raw))
+	for i, l := range s.raw {
 		var any bool
-		lines[i], any = parse(l)
-		styled = styled || any
+		s.lines[i], any = parse(l)
+		s.styled = s.styled || any
 	}
 
-	cols := o.Width
-	if cols == 0 {
-		cols = terminalWidth()
+	s.cols = o.Width
+	if s.cols == 0 {
+		s.cols = terminalWidth()
 	}
-	rows := len(lines) + 2*pad
+	s.rows = len(s.lines) + 2*s.pad
 
 	widest := 0
-	for _, l := range lines {
+	for _, l := range s.lines {
 		if len(l) > widest {
 			widest = len(l)
 		}
@@ -162,23 +235,19 @@ func Render(text string, o Options) string {
 	// The indent gives way before the text does. A help screen 78 columns
 	// wide in an 80-column terminal can still have rain above and below it;
 	// what it cannot have is two columns taken off the front of every line.
-	indent := pad
-	for indent > 0 && widest+2*indent > cols {
-		indent--
+	s.indent = s.pad
+	for s.indent > 0 && widest+2*s.indent > s.cols {
+		s.indent--
 	}
 
-	// The rain is generated at the full width whatever the text does, so a
-	// short help still gets a screen-wide backdrop rather than a green box.
-	rng := rand.New(rand.NewSource(seed))
-	steps := o.Steps
-	if steps == 0 {
-		// Enough for the first columns to have fallen off the bottom, plus a
-		// spread so two runs a second apart are not near-identical frames.
-		steps = 3*rows + rng.Intn(4*rows+40)
-	}
-	m := matrix.New(seed)
-	m.Resize(cols, rows)
-	m.Advance(steps)
+	return s
+}
+
+// paint composites the text over whatever frame the rain is currently on.
+func paint(m *matrix.Matrix, s sheet, _ Options) string {
+	lines, raw, cols, rows := s.lines, s.raw, s.cols, s.rows
+	pad, indent, dim := s.pad, s.indent, s.dim
+	styled, textStyle := s.styled, s.textStyle
 
 	grid := make([]matrix.Cell, cols*rows)
 	lit := make([]bool, cols*rows)
@@ -186,14 +255,6 @@ func Render(text string, o Options) string {
 		grid[y*cols+x] = c
 		lit[y*cols+x] = true
 	})
-
-	// The panel is the box the text sits in, dimmed so the words carry. A
-	// per-line halo that followed the ragged right edge was the other option
-	// and it looks like the text has an aura; a rectangle looks like a panel.
-	panelRight := indent + widest + indent
-	if panelRight > cols {
-		panelRight = cols
-	}
 
 	var b strings.Builder
 	b.Grow(rows * cols * 4)
@@ -214,31 +275,15 @@ func Render(text string, o Options) string {
 				continue
 			}
 		}
-		// A line's own span is opaque, spaces and all. Letting the rain
-		// through every gap between words is the obvious thing and it is
-		// unreadable: a glyph lands in the single space between two words and
-		// the eye joins them. Rain shows through the indent, past the end of
-		// the line, and on the blank lines between sections — which is where
-		// it wants to be anyway, since that is where there is room for it.
-		_, to, hasText := span(line)
-		from := -1
-		if hasText {
-			// The span starts at the line's own column 0, not at its first
-			// word: leading indentation is part of the line. In a flag list
-			// the indent is what lines the columns up, and a glyph sitting in
-			// it reads as content — "  ﾚ --json" looks like a typo, not like
-			// something behind the text.
-			//
-			// One clear cell each side of that, or the rain abuts the words:
-			// a glyph hard against the U of Usage reads as part of it.
-			to++
-		}
+		// Which cells of this row belong to the text and which the rain shows
+		// through. See solidRow, and GapMin for the two rules.
+		solid := solidRow(line, cols, indent, s.gapMin)
 
 		// Trailing blanks are dropped, so a row of rain that stops halfway
 		// does not carry sixty spaces and a reset to the end of the line.
 		last := -1
 		for x := 0; x < cols; x++ {
-			if inSpan(x-indent, from, to, hasText) {
+			if solid[x] {
 				if printable(line, x-indent) {
 					last = x
 				}
@@ -251,8 +296,8 @@ func Render(text string, o Options) string {
 		for x := 0; x <= last; x++ {
 			i := x - indent
 
-			// Text, or one of the blanks inside the text's own span.
-			if inSpan(i, from, to, hasText) {
+			// Text, or one of the blanks the text keeps to itself.
+			if solid[x] {
 				if !printable(line, i) {
 					// A blank inside the text keeps whatever style is in
 					// effect rather than resetting to default. Resetting
@@ -294,7 +339,7 @@ func Render(text string, o Options) string {
 			}
 			c := grid[y*cols+x]
 			n := c.Intensity
-			if y >= pad && y-pad < len(lines) && x < panelRight {
+			if dim != 256 {
 				n = n * dim / 256
 			}
 			st := sgr(canvas.Matrix[n], c.Hot)
@@ -400,7 +445,63 @@ func span(line []glyph) (from, to int, ok bool) {
 	return from, to, from >= 0
 }
 
-func inSpan(i, from, to int, ok bool) bool { return ok && i >= from && i <= to }
+// solidRow marks, in grid columns, which cells of a row belong to the text
+// rather than to the rain behind it. A solid cell is drawn from the line —
+// as its glyph, or as a blank where the line has a space.
+//
+// Everything about what the rain shows through is decided here. See GapMin.
+func solidRow(line []glyph, cols, indent, gapMin int) []bool {
+	s := make([]bool, cols)
+	_, to, ok := span(line)
+	if !ok {
+		return s // a blank line is all backdrop
+	}
+	mark := func(i int) {
+		if x := i + indent; x >= 0 && x < cols {
+			s[x] = true
+		}
+	}
+
+	if gapMin <= 0 {
+		// Opaque from the line's own column zero to one past its last word.
+		// Leading indentation is part of the line: in a flag list the indent
+		// is what lines the columns up, and a glyph sitting in it reads as
+		// content.
+		for i := -1; i <= to+1; i++ {
+			mark(i)
+		}
+		return s
+	}
+
+	for i := 0; i <= to; {
+		if line[i].r != ' ' {
+			mark(i)
+			i++
+			continue
+		}
+		j := i
+		for j <= to && line[j].r == ' ' {
+			j++
+		}
+		if j-i < gapMin {
+			// Too narrow to be a gap in the layout — it is the space between
+			// two words, and a glyph in it would join them.
+			for k := i; k < j; k++ {
+				mark(k)
+			}
+		} else {
+			// A hole, less one cell at each end so the rain does not abut the
+			// words on either side of it.
+			if i > 0 {
+				mark(i)
+			}
+			mark(j - 1)
+		}
+		i = j
+	}
+	mark(to + 1)
+	return s
+}
 
 // printable reports whether line has a non-space glyph at i. A space inside a
 // line is drawn blank, not as a hole for the rain to come through.

--- a/vendor/github.com/0magnet/termanim/matrix/backdrop/painter.go
+++ b/vendor/github.com/0magnet/termanim/matrix/backdrop/painter.go
@@ -1,0 +1,109 @@
+package backdrop
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/0magnet/termanim/matrix"
+)
+
+// Painter draws text over rain that is falling rather than over a still.
+//
+// Render is the whole of what a help screen needs: it is printed once, so the
+// frame behind it can be generated, used and thrown away. A full-screen
+// program is the other case — it redraws many times a second and the rain
+// should be moving between one redraw and the next, which means the simulation
+// has to live somewhere across frames. That is what this is.
+//
+// It suits a bubbletea View in particular, where a frame is a string: compose
+// the screen with whatever does the layout, hand the result here, and the rain
+// fills every cell the text did not use. Pad: -1 is usually what such a caller
+// wants, since it has already decided where everything goes.
+//
+// Not safe for concurrent use. A View is called from one place.
+type Painter struct {
+	o Options
+	m *matrix.Matrix
+
+	// cols and rows are what m was last sized to. A terminal that has been
+	// resized gets a new simulation rather than a stretched one: the columns
+	// are per-column state and there is no meaningful way to widen them.
+	cols, rows int
+
+	last time.Time
+}
+
+// New returns a painter. The options are the same ones Render takes, and mean
+// the same things; Width and Pad are the two worth setting for a full-screen
+// caller, which usually wants its own width and no padding at all.
+func New(o Options) *Painter { return &Painter{o: o} }
+
+// Frame advances the rain by dt seconds and returns text drawn over it.
+//
+// A dt of zero asks for the frame as it stands, redrawn without moving — which
+// is what a resize or a keypress wants, as against a tick.
+func (p *Painter) Frame(text string, dt float64) string {
+	if p.o.Off {
+		return text
+	}
+	if !p.o.Force && !colorOK() {
+		return text
+	}
+
+	s := layout(text, p.o)
+
+	if p.m == nil || p.cols != s.cols || p.rows != s.rows {
+		p.reset(s)
+	} else if dt > 0 {
+		p.m.AdvanceTime(dt)
+	}
+	return paint(p.m, s, p.o)
+}
+
+// Tick is Frame with dt taken from the clock, for a caller that is driving
+// from a timer and does not want to work out the interval itself. The first
+// call starts the clock and does not advance anything.
+func (p *Painter) Tick(text string) string {
+	now := time.Now()
+	dt := 0.0
+	if !p.last.IsZero() {
+		dt = now.Sub(p.last).Seconds()
+	}
+	p.last = now
+	return p.Frame(text, dt)
+}
+
+// reset builds a simulation for a grid this size and runs it in far enough
+// that the screen is full. Starting from nothing would open on an empty screen
+// and fill from the top over the first second, which reads as the program
+// still loading.
+func (p *Painter) reset(s sheet) {
+	p.m = matrix.New(s.seed)
+	p.m.Resize(s.cols, s.rows)
+	p.cols, p.rows = s.cols, s.rows
+
+	steps := p.o.Steps
+	if steps == 0 {
+		rng := rand.New(rand.NewSource(s.seed))
+		steps = 3*s.rows + rng.Intn(4*s.rows+40)
+	}
+	p.m.Advance(steps)
+}
+
+// SetWidth tells the painter how wide the screen is.
+//
+// Worth doing rather than leaving to the default, for anything that is told
+// its size rather than having to ask. A TUI framework hands its program the
+// width and that is the authority; the terminal's own idea of it is a fallback
+// for a caller that has nothing better, and the two part company the moment
+// output is not the terminal — at which point every row of a screen composed
+// at the real width is wider than the painter thinks the screen is, and is
+// passed through untouched as an over-wide line.
+//
+// The next Frame rebuilds the simulation if this changed it.
+func (p *Painter) SetWidth(w int) { p.o.Width = w }
+
+// Matrix is the running simulation, for a caller that wants to tune it — the
+// palette, the density, the speed. It is nil until the first Frame, since
+// there is nothing to size it to before then.
+func (p *Painter) Matrix() *matrix.Matrix { return p.m }

--- a/vendor/github.com/0magnet/termanim/matrix/matrix.go
+++ b/vendor/github.com/0magnet/termanim/matrix/matrix.go
@@ -214,6 +214,18 @@ func (m *Matrix) Frame(screen tcell.Screen, cols, rows int, dt float64) {
 	if m.cols == 0 || m.rows == 0 {
 		return
 	}
+	m.AdvanceTime(dt)
+	m.draw(screen)
+}
+
+// AdvanceTime runs however many simulation steps dt seconds are worth, keeping
+// the fraction left over for next time.
+//
+// Advance takes whole steps and is what a still frame wants. This is what an
+// animation wants, and it is separate from Frame because not every animation
+// has a tcell.Screen to draw on — one composed into a string a frame at a time
+// needs the clock without the drawing. See matrix/backdrop.
+func (m *Matrix) AdvanceTime(dt float64) {
 	rate := m.StepRate
 	if rate <= 0 {
 		rate = 30
@@ -226,7 +238,6 @@ func (m *Matrix) Frame(screen tcell.Screen, cols, rows int, dt float64) {
 		m.step()
 		m.acc--
 	}
-	m.draw(screen)
 }
 
 // step advances every column by one simulation tick.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,7 +36,7 @@ github.com/0magnet/sh/v3/internal
 github.com/0magnet/sh/v3/interp
 github.com/0magnet/sh/v3/pattern
 github.com/0magnet/sh/v3/syntax
-# github.com/0magnet/termanim v0.0.0-20260823195938-f88b1541cfcd
+# github.com/0magnet/termanim v0.0.0-20260823220926-60f3279a072f
 ## explicit; go 1.24.0
 github.com/0magnet/termanim/canvas
 github.com/0magnet/termanim/matrix


### PR DESCRIPTION
**Did you run `make format && make check`?**

Partly: `goimports -local`, `golangci-lint` and `go vet` with the repo's
`withoutsystray withoutgotop` tags (both clean), the tests for `pkg/flags` and
`pkg/cliout`, and a piped `--help` to confirm it is still byte-plain. Not the
full test suite or `check-cg`, neither of which this touches.

**Fixes:** follow-up to #4134

**Changes:**

- The rain behind the help was scaled down inside a rectangle the size of the
  whole help screen. That was unnecessary — the one cell of clear kept either
  side of every word is what makes the text readable — and it left a visible
  edge where the dimming stopped, with a muddy backdrop inside it. The rain now
  runs at full brightness everywhere.
- Dependency bump only on this side; no skywire code changes. Upstream, `Dim`
  became a plain scale over the whole frame rather than a region and defaults
  to none. Nothing in skywire sets it.

The bump carries the rest of the package forward with it (`go mod vendor` takes
whole packages), so a `painter.go` appears in vendor that skywire does not call.

**How to test this PR:**

```
go run . --help          # rain at full brightness, words still clear
go run . --help | cat    # unchanged: plain text
```