### PR TITLE
help: put the rain behind every command's help, not just the root's

### DIFF
--- a/pkg/flags/rain.go
+++ b/pkg/flags/rain.go
@@ -43,8 +43,13 @@ var (
 )
 
 // InitRain makes cmd, and every command under it, print its help over the code
-// rain. Call it once, on the root: cobra looks the help function up on the
-// parent when a command has none of its own, so one call covers the tree.
+// rain.
+//
+// Call it on the root, and call it once the tree is assembled: it walks the
+// commands rather than leaving cobra's inheritance to carry the help function
+// down, so a subcommand added afterwards gets the backdrop only by inheritance
+// and only if nothing in its own subtree installs a help function. See
+// eachDeepestFirst.
 //
 // Deliberately not part of InitFlags. That runs for every binary in this
 // repository, including the services, and this is meant for the one people
@@ -52,11 +57,37 @@ var (
 func InitRain(cmd *cobra.Command) {
 	rainedMu.Lock()
 	defer rainedMu.Unlock()
-	if rained[cmd] {
-		return
+	eachDeepestFirst(cmd, func(c *cobra.Command) {
+		if rained[c] {
+			return
+		}
+		rained[c] = true
+		cobrarain.OnFunc(c, rainOptions)
+	})
+}
+
+// eachDeepestFirst calls fn for every command in the tree, children before
+// parents.
+//
+// Every command rather than just the root, because cobra's inheritance is not
+// enough on its own. It looks the help function up on the parent only when a
+// command has none of its own, and skywire-cli's root installs one for --json
+// — which shadowed the inherited one for the whole of `skywire cli`, so that
+// subtree was the one part of the binary printing its help without a backdrop.
+// Anything else that wraps help in its own init would break the chain the same
+// way, so the tree is covered command by command instead of being relied upon
+// to pass it down.
+//
+// Children before parents is the part that matters. Wrapping a command
+// captures whatever help function it has at that moment, and a command with
+// none of its own reports its parent's — so wrapping a parent first and then
+// its child would wrap the parent's new wrapper a second time and paint the
+// rain twice, over itself.
+func eachDeepestFirst(c *cobra.Command, fn func(*cobra.Command)) {
+	for _, sub := range c.Commands() {
+		eachDeepestFirst(sub, fn)
 	}
-	rained[cmd] = true
-	cobrarain.OnFunc(cmd, rainOptions)
+	fn(c)
 }
 
 // rainOptions decides, per help screen, whether to draw the rain.

--- a/pkg/flags/rain_test.go
+++ b/pkg/flags/rain_test.go
@@ -96,3 +96,48 @@ func TestDocAndRecursiveModesLeaveHelpAlone(t *testing.T) {
 		rainedMu.Unlock()
 	}
 }
+
+// The bug this guards: cobra looks the help function up on the parent only
+// when a command has none of its own, and skywire-cli's root installs one for
+// --json. Wiring just the top command left the whole of `skywire cli` printing
+// its help with no backdrop.
+func TestInitRainCoversASubtreeThatShadowsHelp(t *testing.T) {
+	root := &cobra.Command{Use: "root", Run: func(*cobra.Command, []string) {}}
+	shadow := &cobra.Command{Use: "shadow", Run: func(*cobra.Command, []string) {}}
+	// Exactly what cliout.SetJSONHelp does: its own help function, which
+	// cobra will now use for everything beneath it.
+	shadow.SetHelpFunc(func(*cobra.Command, []string) {})
+	leaf := &cobra.Command{Use: "leaf", Run: func(*cobra.Command, []string) {}}
+	shadow.AddCommand(leaf)
+	root.AddCommand(shadow)
+
+	InitRain(root)
+	defer func() {
+		rainedMu.Lock()
+		defer rainedMu.Unlock()
+		for _, c := range []*cobra.Command{root, shadow, leaf} {
+			delete(rained, c)
+		}
+	}()
+
+	for _, c := range []*cobra.Command{root, shadow, leaf} {
+		require.True(t, rained[c], "%s was left without a backdrop", c.Name())
+	}
+}
+
+// Children before parents. Wrapping a command captures whatever help function
+// it has at that moment, and one with none of its own reports its parent's —
+// so parent-first would wrap the parent's new wrapper again and paint the rain
+// over itself.
+func TestEachDeepestFirstVisitsChildrenFirst(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	mid := &cobra.Command{Use: "mid"}
+	leaf := &cobra.Command{Use: "leaf"}
+	mid.AddCommand(leaf)
+	root.AddCommand(mid)
+
+	var order []string
+	eachDeepestFirst(root, func(c *cobra.Command) { order = append(order, c.Name()) })
+
+	require.Equal(t, []string{"leaf", "mid", "root"}, order)
+}

--- a/pkg/transport/manager_regnudge_test.go
+++ b/pkg/transport/manager_regnudge_test.go
@@ -161,12 +161,12 @@ func TestOutboundSaveNudgesReRegister(t *testing.T) {
 	// Teardown cancels the context (the loops select on ctx.Done) and closes the
 	// underlying transport to unblock the serving read loop. We deliberately do
 	// NOT call tm.Close(): it waits on the serve WaitGroup while holding tm.mx,
-	// which can wedge a unit test; cancelling the context stops every loop and
+	// which can wedge a unit test; canceling the context stops every loop and
 	// the leaked goroutines exit with the process.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer func() {
 		cancel()
-		client.tp.Close()
+		_ = client.tp.Close()
 	}()
 	tm.Serve(ctx)
 

--- a/skywire.go
+++ b/skywire.go
@@ -43,12 +43,6 @@ config-gen sets the default node list via SKYCOINWEBNODES.`
 
 func init() {
 	flags.InitFlags(commands.RootCmd, true)
-	// The help screen, over a still frame of the Matrix code rain. Here rather
-	// than in InitFlags because InitFlags runs for every binary in this
-	// repository, including the services, and this is for the one people read
-	// help in. Off for --json/--jq/--shape, for `help -r` and `help -d`, for a
-	// pipe or a redirect, and for NO_COLOR or SKYWIRE_NO_HELP_RAIN.
-	flags.InitRain(commands.RootCmd)
 	// Use/Short/Version and the subcommand tree are set by the package itself
 	// (cmd/skycoin/commands), which assembles skycoin's commands on skywire's
 	// side rather than importing skycoin's own assembly.
@@ -60,6 +54,16 @@ func init() {
 	// after the fact of importing skycoin-web, so the vendored command
 	// stays transport-agnostic upstream.
 	skycoinweb.RootCmd.Long += skywireSkycoinWebHelp
+
+	// The help screen, over a still frame of the Matrix code rain. Here rather
+	// than in InitFlags because InitFlags runs for every binary in this
+	// repository, including the services, and this is for the one people read
+	// help in. Off for --json/--jq/--shape, for `help -r` and `help -d`, for a
+	// pipe or a redirect, and for NO_COLOR or SKYWIRE_NO_HELP_RAIN.
+	//
+	// Last, once every subcommand is in the tree: it walks the commands rather
+	// than relying on cobra to pass the help function down.
+	flags.InitRain(commands.RootCmd)
 }
 
 func main() {


### PR DESCRIPTION
**Did you run `make format && make check`?**

Partly: `goimports -local`, `golangci-lint` and `go vet` with the repo's
`withoutsystray withoutgotop` tags (both clean), and the `pkg/flags` /
`pkg/cliout` tests. Not the full suite or `check-cg`, neither of which this
touches.

**Fixes:** follow-up to #4134

**Changes:**

`skywire cli --help`, and every command under it, printed with no backdrop.
Cobra looks the help function up on the parent *only* when a command has none
of its own — and `cmd/skywire-cli/commands/root.go` installs one in its own
`init` for `--json`, which shadowed the inherited one for that whole subtree.
`cli reward` does the same thing again a level down. Wiring only the top
command relied on inheritance, and inheritance stopped there.

That subtree is 390 of the binary's 562 commands, so most of the CLI was
affected.

- `InitRain` now walks the tree and wraps each command in turn instead of
  relying on cobra to pass the function down, so anything installing its own
  help in its own `init` is covered too.
- Children before parents. Wrapping a command captures whatever help function
  it has at that moment, and one with none of its own reports its parent's, so
  parent-first would wrap the parent's new wrapper again and paint the rain
  over itself.
- Called from `skywire.go` after the skycoin commands are added rather than
  before, since it now walks what is actually in the tree.

**Coverage.** After the change, every command the binary reports in its own
`--json --help` schema — 562 of them, hidden ones included — was rendered
under a pty and checked for the backdrop: **562 with, 0 without, 0 failures.**

Before the change, spot checks across the affected subtree
(`cli`, `cli visor`, `cli config`, `cli config gen`, `cli dmsg`, `cli reward`)
all showed none, and everything outside it showed one.

The `help` and `completion` commands cobra generates are not in that schema;
they were checked separately at seven levels, including inside the `cli`
subtree, and inherit correctly.

Text integrity was sampled rather than swept: thirteen screens diffed
line-by-line against the same help with `SKYWIRE_NO_HELP_RAIN=1` at 80
columns, 0 lines lost. `--json --help`, `help -d` and a piped `--help` are
unchanged.

**How to test this PR:**

```
go run . cli --help
go run . cli visor --help
go run . cli --help | cat        # still plain
go run . cli --json --help       # still JSON
```