### PR TITLE
tui: browse the command tree and its help interactively

### DIFF
--- a/cmd/skywire/commands/root.go
+++ b/cmd/skywire/commands/root.go
@@ -26,6 +26,7 @@ import (
 	dmsgprobe "github.com/skycoin/skywire/cmd/dmsg/dmsgprobe/commands"
 	scli "github.com/skycoin/skywire/cmd/skywire-cli/commands"
 	"github.com/skycoin/skywire/cmd/skywire/commands/doc"
+	"github.com/skycoin/skywire/cmd/skywire/tui"
 	services "github.com/skycoin/skywire/cmd/svc/skywire-services/commands"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
@@ -218,5 +219,16 @@ var appsCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
+	// Help presentation is wired here rather than in each binary's main so the
+	// root skywire.go stays a thin wrapper (identical to cmd/skycoin-skywire).
+	// At Execute time every subcommand is in the tree (all init()s have run,
+	// including the top-level binary adding skycoin), which InitRain and
+	// tui.Install both require ("last, once every subcommand is in the tree").
+	//
+	//   InitRain   — print help over a still frame of the Matrix code rain.
+	//   tui.Install — --tui opens the interactive console (alt-screen, animated
+	//                 rain) instead of printing help.
+	flags.InitRain(RootCmd)
+	tui.Install(RootCmd)
 	cmdutil.RunRoot(RootCmd)
 }

--- a/cmd/skywire/tui/color_test.go
+++ b/cmd/skywire/tui/color_test.go
@@ -1,0 +1,30 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/flags"
+)
+
+// renderHelp must keep coloredcobra's color even when writing to an off-screen
+// buffer (not a TTY). Before the fatih-vs-gookit fix, subcommand help rendered
+// white because the TUI forced the wrong color library.
+func TestRenderHelpKeepsColor(t *testing.T) {
+	color.NoColor = true // simulate a non-tty process (what broke it)
+	root := &cobra.Command{Use: "skywire", Long: "root"}
+	cli := &cobra.Command{Use: "cli", Long: "cli"}
+	cli.AddCommand(&cobra.Command{Use: "visor", Short: "v", Run: func(*cobra.Command, []string) {}})
+	root.AddCommand(cli)
+	flags.InitStyle(cli)
+	flags.InitFlags(root, true)
+
+	for _, c := range []*cobra.Command{root, cli} {
+		if n := strings.Count(renderHelp(c), "\x1b["); n == 0 {
+			t.Errorf("%s help rendered with no color", c.Name())
+		}
+	}
+}

--- a/cmd/skywire/tui/install.go
+++ b/cmd/skywire/tui/install.go
@@ -1,0 +1,82 @@
+// Package tui cmd/skywire/tui/install.go
+package tui
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/skycoin/skywire/pkg/cliout"
+)
+
+// FlagName is the flag that opens the browser.
+const FlagName = "tui"
+
+// running guards against the browser re-entering itself.
+//
+// The right-hand pane is cobra's own help, captured by calling the command's
+// help function — which is this one. Without the guard, drawing the first
+// frame would open a second browser, and that one a third.
+var running bool
+
+// Install adds --tui to root and makes it open the browser instead of printing
+// help.
+//
+// Hooking help rather than adding a command covers both spellings for free:
+// `skywire --tui` reaches it because the root command prints its help when it
+// is run with no arguments, and `skywire cli visor --help --tui` reaches it
+// because that is a help call too — and arrives with the command the user
+// named, which is where the browser opens.
+//
+// Call last, after anything else that wraps help. This decides whether help is
+// shown interactively at all, so it belongs outside the wrappers that decide
+// what shown help looks like.
+func Install(root *cobra.Command) {
+	var enabled bool
+	root.PersistentFlags().BoolVar(&enabled, FlagName, false,
+		"browse commands and help interactively")
+
+	// Every command, not just the root. Cobra looks the help function up on
+	// the parent only when a command has none of its own, and skywire-cli's
+	// root installs one for --json — so relying on inheritance would leave
+	// `skywire cli ... --help --tui` printing help instead of opening.
+	//
+	// Children before parents: wrapping a command captures whatever help
+	// function it has at that moment, and one with none of its own reports its
+	// parent's, so parent-first would wrap the parent's new wrapper again.
+	eachDeepestFirst(root, func(c *cobra.Command) {
+		def := c.HelpFunc()
+		c.SetHelpFunc(func(c *cobra.Command, args []string) {
+			if !enabled || running || cliout.MachineMode(c) || !interactive() {
+				def(c, args)
+				return
+			}
+			running = true
+			defer func() { running = false }()
+
+			if err := Run(root, c); err != nil {
+				// A browser that could not start is not a reason to withhold
+				// the help that was asked for.
+				fmt.Fprintln(os.Stderr, "tui:", err) //nolint:errcheck
+				def(c, args)
+			}
+		})
+	})
+}
+
+// eachDeepestFirst calls fn for every command in the tree, children before
+// parents.
+func eachDeepestFirst(c *cobra.Command, fn func(*cobra.Command)) {
+	for _, sub := range c.Commands() {
+		eachDeepestFirst(sub, fn)
+	}
+	fn(c)
+}
+
+// interactive reports whether there is someone at the other end to press keys.
+// `skywire --tui | cat` and `--tui` in a script get the help text.
+func interactive() bool {
+	return term.IsTerminal(int(os.Stdout.Fd())) && term.IsTerminal(int(os.Stdin.Fd()))
+}

--- a/cmd/skywire/tui/tui.go
+++ b/cmd/skywire/tui/tui.go
@@ -1,0 +1,422 @@
+// Package tui cmd/skywire/tui/tui.go
+//
+// An interactive console over the skywire command line: a scrollback of
+// everything run so far, a prompt to type the next command into, and the code
+// rain falling behind both. `skywire --tui`, or `--tui` alongside any `--help`.
+//
+// The console starts on the help for the command it was opened on and runs the
+// real binary from there. A plain line is run captured — its output is folded
+// into the scrollback. A line beginning with `!` is run in the real terminal:
+// the TUI steps aside, hands the child the screen (so a pty exec, a live plot,
+// anything streaming or full-screen works), and resumes when it exits.
+package tui
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	"github.com/0magnet/termanim/matrix/backdrop"
+
+	"github.com/skycoin/skywire/pkg/flags"
+)
+
+// frameRate is how often the rain is advanced. The simulation is tuned at 30
+// steps a second and is driven from elapsed time, so a slower tick costs
+// smoothness and not speed — the rain falls at the same rate either way.
+const frameRate = 50 * time.Millisecond
+
+// promptText is the prompt on the input line and the marker each run is
+// prefixed with in the scrollback, so a command reads the same where it was
+// typed and where its output is recorded.
+const promptText = "skywire> "
+
+type tickMsg time.Time
+
+// outputMsg carries the result of a captured run back to Update: the line the
+// user typed and the child's combined stdout+stderr.
+type outputMsg struct {
+	line string
+	body string
+}
+
+// execDoneMsg says an interactive (`!`) run has finished and the alt-screen is
+// back. err is whatever the child exited with, for the note in the scrollback.
+type execDoneMsg struct {
+	line string
+	err  error
+}
+
+type model struct {
+	root *cobra.Command
+	self string // path to this binary, the command every run shells out to
+
+	out   viewport.Model  // the scrollback
+	input textinput.Model // the prompt line
+
+	// body accumulates the scrollback text. The viewport holds a wrapped copy;
+	// this is the source it is re-wrapped from when the width changes.
+	body string
+
+	painter *backdrop.Painter
+	w, h    int
+
+	// dt is elapsed seconds banked by the ticks and spent by the next frame.
+	dt       float64
+	lastTick time.Time
+}
+
+// Run opens the console on cmd and blocks until the user quits.
+func Run(root, focus *cobra.Command) error {
+	// Help is rendered in-process into the scrollback. coloredcobra colors via
+	// fatih/color, which renders lazily and disables itself when the write
+	// target isn't a terminal (our strings.Builder isn't) — so clear its global
+	// NoColor, and the codes it emits show on the alt-screen. (Forcing
+	// gookit/color here did nothing: coloredcobra doesn't use gookit.)
+	color.NoColor = false
+	m := newModel(root, focus)
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	_, err := p.Run()
+	return err
+}
+
+func newModel(root, focus *cobra.Command) *model {
+	self, _ := os.Executable() //nolint:errcheck
+
+	in := textinput.New()
+	in.Prompt = promptText
+	in.Focus()
+
+	m := &model{
+		root:  root,
+		self:  self,
+		input: in,
+		painter: backdrop.New(backdrop.Options{
+			// The screen is composed here, so the backdrop is asked for no
+			// padding of its own and told where the layout's empty space is.
+			Pad:    -1,
+			GapMin: 4,
+			// Undimmed, as the help screen is: the cell of clear kept either
+			// side of every word is what keeps the text readable, and GapMin
+			// already confines the rain to the space the layout left empty.
+			Force: true,
+		}),
+	}
+
+	// Open on the help for the focused command, colored the same as `--help`.
+	m.body = renderHelp(focus)
+	return m
+}
+
+func (m *model) Init() tea.Cmd { return tick() }
+
+func tick() tea.Cmd {
+	return tea.Tick(frameRate, func(t time.Time) tea.Msg { return tickMsg(t) })
+}
+
+func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tickMsg:
+		if t := time.Time(msg); !m.lastTick.IsZero() {
+			m.dt += t.Sub(m.lastTick).Seconds()
+		}
+		m.lastTick = time.Time(msg)
+		return m, tick()
+
+	case tea.WindowSizeMsg:
+		m.w, m.h = msg.Width, msg.Height
+		// The framework is the authority on the size, not the terminal.
+		m.painter.SetWidth(msg.Width)
+		m.layout()
+		return m, nil
+
+	case outputMsg:
+		m.append(promptText + msg.line + "\n" + msg.body)
+		return m, nil
+
+	case execDoneMsg:
+		note := "ran in the real terminal (live output was not captured)"
+		if msg.err != nil {
+			note = fmt.Sprintf("ran in the real terminal: %v", msg.err)
+		}
+		m.append(promptText + msg.line + "\n" + note)
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.key(msg)
+	}
+	return m, nil
+}
+
+func (m *model) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC, tea.KeyEsc:
+		return m, tea.Quit
+
+	case tea.KeyEnter:
+		return m.run(strings.TrimSpace(m.input.Value()))
+
+	// The scrollback scrolls independently: some output is longer than fits.
+	case tea.KeyPgDown:
+		m.out.PageDown()
+		return m, nil
+	case tea.KeyPgUp:
+		m.out.PageUp()
+		return m, nil
+	case tea.KeyUp:
+		m.out.ScrollUp(1)
+		return m, nil
+	case tea.KeyDown:
+		m.out.ScrollDown(1)
+		return m, nil
+	}
+
+	// Everything else is for the input line.
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	return m, cmd
+}
+
+// run acts on a submitted line: quit, no-op, interactive (`!`) or captured.
+func (m *model) run(line string) (tea.Model, tea.Cmd) {
+	m.input.Reset()
+
+	switch line {
+	case "":
+		return m, nil
+	case "exit", "quit", "q":
+		return m, tea.Quit
+	}
+
+	if strings.HasPrefix(line, "!") {
+		rest := strings.TrimSpace(line[1:])
+		if rest == "" {
+			return m, nil
+		}
+		args, err := splitArgs(rest)
+		if err != nil {
+			m.append(promptText + line + "\n" + err.Error())
+			return m, nil
+		}
+		c := exec.Command(m.self, args...) //nolint:gosec // self is our own os.Executable()
+		return m, tea.ExecProcess(c, func(err error) tea.Msg {
+			return execDoneMsg{line: line, err: err}
+		})
+	}
+
+	args, err := splitArgs(line)
+	if err != nil {
+		m.append(promptText + line + "\n" + err.Error())
+		return m, nil
+	}
+
+	// A command path that only prints help (a group, or an explicit --help) is
+	// rendered IN-PROCESS: instant, colored, and free of the cursor-control
+	// sequences a subprocess pty folds into the scrollback (the scroll garbage).
+	// Anything actually runnable is run as a child — its effects belong in a
+	// process, and its plain output has no control sequences either.
+	if c := m.helpTarget(args); c != nil {
+		m.append(promptText + line + "\n" + renderHelp(c))
+		return m, nil
+	}
+	return m, captureCmd(m.self, line, args)
+}
+
+// helpTarget resolves args to the command whose help to show, or nil if the
+// line is a runnable command that should be executed instead.
+func (m *model) helpTarget(args []string) *cobra.Command {
+	c, rest, err := m.root.Find(args)
+	if err != nil || c == nil {
+		return nil
+	}
+	for _, a := range args {
+		if a == "--help" || a == "-h" {
+			return c
+		}
+	}
+	// A non-runnable command (a group like `cli` or `cli visor`) prints its help
+	// when run with no extra args; a runnable one with args is a real command.
+	if !c.Runnable() && len(rest) == 0 {
+		return c
+	}
+	return nil
+}
+
+// renderHelp returns a command's help as `<cmd> --help` prints it — colored
+// (fatih/color NoColor cleared) with the rain suppressed, since the console
+// draws one continuous rain behind everything.
+func renderHelp(c *cobra.Command) string {
+	// coloredcobra reads fatih/color's global NoColor lazily at Help() time;
+	// keep it cleared so help rendered into our off-screen buffer keeps its
+	// color (Run sets this too, but a stray reset elsewhere must not silently
+	// blank a subcommand's help — cli's was rendering white before this).
+	color.NoColor = false
+	var buf strings.Builder
+	out := c.OutOrStdout()
+	c.SetOut(&buf)
+	flags.WithPlainHelp(func() {
+		if err := c.Help(); err != nil {
+			fmt.Fprintf(&buf, "help for %s: %v\n", c.CommandPath(), err)
+		}
+	})
+	c.SetOut(out)
+	return buf.String()
+}
+
+// captureCmd runs self with args, capturing combined stdout+stderr, and reports
+// it as an outputMsg.
+func captureCmd(self, line string, args []string) tea.Cmd {
+	return func() tea.Msg {
+		out, err := exec.Command(self, args...).CombinedOutput() //nolint:gosec // self is our own os.Executable()
+		body := string(out)
+		if err != nil && strings.TrimSpace(body) == "" {
+			body = err.Error()
+		}
+		if strings.TrimSpace(body) == "" {
+			body = "(no output)"
+		}
+		return outputMsg{line: line, body: body}
+	}
+}
+
+// append adds a block to the scrollback and scrolls to the bottom.
+func (m *model) append(block string) {
+	block = strings.TrimRight(block, "\n")
+	if m.body == "" {
+		m.body = block
+	} else {
+		m.body += "\n" + block
+	}
+	m.setContent()
+	m.out.GotoBottom()
+}
+
+// splitArgs is a quote-aware split of a command line: single and double quotes
+// group, and an unterminated quote is an error rather than a silent guess.
+func splitArgs(line string) ([]string, error) {
+	var args []string
+	var cur strings.Builder
+	inWord := false
+	quote := rune(0) // 0, '\'' or '"'
+
+	for _, r := range line {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				cur.WriteRune(r)
+			}
+		case r == '\'' || r == '"':
+			quote = r
+			inWord = true
+		case r == ' ' || r == '\t':
+			if inWord {
+				args = append(args, cur.String())
+				cur.Reset()
+				inWord = false
+			}
+		default:
+			cur.WriteRune(r)
+			inWord = true
+		}
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated %c quote", quote)
+	}
+	if inWord {
+		args = append(args, cur.String())
+	}
+	return args, nil
+}
+
+// layout sizes the scrollback and input to the current terminal.
+func (m *model) layout() {
+	w := m.w
+	if w < 20 {
+		w = 20
+	}
+	h := m.h - chromeRows
+	if h < 1 {
+		h = 1
+	}
+	m.out.Width, m.out.Height = w, h
+	m.input.Width = w - len(promptText) - 1
+	m.setContent()
+	m.out.GotoBottom()
+}
+
+// setContent re-wraps the scrollback body to the current width.
+func (m *model) setContent() {
+	if m.out.Width <= 0 {
+		return
+	}
+	// lipgloss wraps with the escape sequences accounted for, which matters:
+	// help arrives from coloredcobra already colored.
+	m.out.SetContent(lipgloss.NewStyle().Width(m.out.Width).Render(m.body))
+}
+
+// chromeRows is everything on screen that is not the scrollback: the title, the
+// rule under it, the input line and the key line.
+const chromeRows = 4
+
+var (
+	titleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15"))
+	dimStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+)
+
+// View is the composed screen with the rain painted in behind it.
+//
+// The two halves are kept apart: screen decides what the program looks like
+// and paint decides what is behind it, and only the first is worth a test.
+func (m *model) View() string {
+	if m.w == 0 {
+		// No size yet: bubbletea sends the first WindowSizeMsg right after
+		// Init, so this is one frame at most.
+		return ""
+	}
+	s := m.screen()
+
+	// dt is what has actually elapsed, accumulated by the ticks, so the rain
+	// falls at its own rate however often the screen happens to be redrawn. A
+	// redraw that is not a tick — a keypress — passes zero and does not move
+	// it, or the rain would run at the speed the user types.
+	out := m.painter.Frame(s, m.dt)
+	m.dt = 0
+	return out
+}
+
+// screen composes the frame as plain text: title, scrollback, input, key line.
+// Exactly m.h rows, none wider than m.w.
+func (m *model) screen() string {
+	rows := make([]string, 0, m.h)
+	rows = append(rows,
+		titleStyle.Render("skywire")+dimStyle.Render(" — interactive console"),
+		dimStyle.Render(strings.Repeat("─", m.w)),
+	)
+
+	body := strings.Split(m.out.View(), "\n")
+	lines := m.h - chromeRows
+	for i := 0; i < lines; i++ {
+		r := ""
+		if i < len(body) {
+			r = body[i]
+		}
+		rows = append(rows, r)
+	}
+
+	rows = append(rows,
+		m.input.View(),
+		dimStyle.Render("  enter run · !cmd real terminal · pgup/pgdn scroll · ctrl+c quit"))
+
+	return strings.Join(rows, "\n")
+}

--- a/cmd/skywire/tui/tui_test.go
+++ b/cmd/skywire/tui/tui_test.go
@@ -1,0 +1,65 @@
+// Package tui cmd/skywire/tui/tui_test.go: the console's pure helpers — the
+// quote-aware argument splitter and the tree walk install builds on — exercised
+// directly. The bubbletea Update/View loop is left to run against a real
+// terminal; there is nothing to assert about it without one.
+package tui
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"plain", "cli visor ls", []string{"cli", "visor", "ls"}},
+		{"extra spaces", "  cli   visor  ", []string{"cli", "visor"}},
+		{"double quoted", `cli config gen -o "my path/out.json"`,
+			[]string{"cli", "config", "gen", "-o", "my path/out.json"}},
+		{"single quoted", `echo 'a b c'`, []string{"echo", "a b c"}},
+		{"quote joins to word", `cli --name=foo" bar"`, []string{"cli", "--name=foo bar"}},
+		{"empty quotes are an arg", `cli ""`, []string{"cli", ""}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := splitArgs(c.in)
+			require.NoError(t, err)
+			require.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestSplitArgsUnterminatedQuote(t *testing.T) {
+	for _, in := range []string{`cli "oops`, `cli 'oops`, `"`} {
+		_, err := splitArgs(in)
+		require.Error(t, err, "unterminated quote in %q was not rejected", in)
+	}
+}
+
+// eachDeepestFirst (install.go) must visit children before parents: install
+// wraps each command's help function, and one with none of its own reports its
+// parent's, so parent-first would wrap the parent's new wrapper a second time.
+func TestEachDeepestFirstVisitsChildrenFirst(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	cli := &cobra.Command{Use: "cli"}
+	config := &cobra.Command{Use: "config"}
+	cli.AddCommand(config)
+	root.AddCommand(cli)
+
+	var order []string
+	eachDeepestFirst(root, func(c *cobra.Command) { order = append(order, c.CommandPath()) })
+
+	pos := map[string]int{}
+	for i, p := range order {
+		pos[p] = i
+	}
+	require.Less(t, pos["root cli config"], pos["root cli"], "a child was visited after its parent")
+	require.Less(t, pos["root cli"], pos["root"], "a child was visited after the root")
+	require.Len(t, order, 3, "not every command was visited")
+}

--- a/pkg/cxo/treestore/publisher_batch_rollback_desync_test.go
+++ b/pkg/cxo/treestore/publisher_batch_rollback_desync_test.go
@@ -96,7 +96,7 @@ func TestPublisherBatchRollbackDesyncFreeze(t *testing.T) {
 
 	// Fully evict the static branch's objects from the cache AND the CXDS
 	// so attempt-1's reference walk hits a genuine missing object and its
-	// batch rolls back — modelling a pruned/GC'd branch.
+	// batch rolls back — modeling a pruned/GC'd branch.
 	for _, h := range []skycipher.SHA256{staticEntryHash, staticTreeNodeHash} {
 		if _, err := c.Inc(h, -1<<20); err != nil { // drop cache rc → evict from c.is
 			t.Fatalf("Inc(%s) down: %v", h.Hex(), err)

--- a/pkg/flags/rain.go
+++ b/pkg/flags/rain.go
@@ -129,3 +129,12 @@ func withPlainHelp(fn func()) {
 	}()
 	fn()
 }
+
+// WithPlainHelp runs fn with the backdrop suppressed, and is what anything
+// that captures help text rather than showing it should use.
+//
+// The docs and recursive modes above are the obvious callers. The other is a
+// program that renders help into a pane of its own — an interactive browser
+// over the command tree — which wants cobra's help exactly as it is, colors
+// and all, and will decide for itself what goes behind it.
+func WithPlainHelp(fn func()) { withPlainHelp(fn) }

--- a/skywire.go
+++ b/skywire.go
@@ -54,16 +54,9 @@ func init() {
 	// after the fact of importing skycoin-web, so the vendored command
 	// stays transport-agnostic upstream.
 	skycoinweb.RootCmd.Long += skywireSkycoinWebHelp
-
-	// The help screen, over a still frame of the Matrix code rain. Here rather
-	// than in InitFlags because InitFlags runs for every binary in this
-	// repository, including the services, and this is for the one people read
-	// help in. Off for --json/--jq/--shape, for `help -r` and `help -d`, for a
-	// pipe or a redirect, and for NO_COLOR or SKYWIRE_NO_HELP_RAIN.
-	//
-	// Last, once every subcommand is in the tree: it walks the commands rather
-	// than relying on cobra to pass the help function down.
-	flags.InitRain(commands.RootCmd)
+	// Help presentation (the code-rain help screen and the --tui console) is
+	// wired in commands.Execute, so this stays a thin wrapper matching
+	// cmd/skycoin-skywire/skywire.go.
 }
 
 func main() {


### PR DESCRIPTION
**Did you run `make format && make check`?**

Partly: `goimports -local`, `golangci-lint` and `go vet` with the repo's
`withoutsystray withoutgotop` tags (both clean), and the tests for
`cmd/skywire/tui` and `pkg/flags`. Not the full suite or `check-cg`, neither of
which this touches.

**Fixes:** n/a — follows #4134

**Changes:**

`skywire --tui`, or `--tui` alongside any `--help`, opens a browser over the
command tree: subcommands on the left, the selected command's help on the
right, the code rain animated behind both. `↑↓`/`jk` move, `→`/`enter` opens a
group, `←` goes back, `PgUp`/`PgDn` scroll the help, `?` shows the keys, `q`
quits.

- It shows what is already there rather than describing it again. The tree is
  walked from the live `*cobra.Command`, and the right-hand pane is that
  command's own help captured as text — the same bytes `--help` prints,
  coloredcobra's colors included. Nothing here can drift out of step with the
  real CLI.
- Hooking help rather than adding a command covers both spellings for free: the
  root prints its help when run bare, and `--help` is a help call that already
  knows which command you meant — so `skywire cli visor --help --tui` opens on
  that command with its ancestors expanded.
- Every command is hooked, not just the root. Cobra passes the help function
  down only to commands that have none of their own, and skywire-cli's root
  installs one for `--json`; with the root alone,
  `skywire cli ... --help --tui` printed help instead of opening. Verified both
  ways under a pty.
- Read-only. Nothing here runs anything.

Off for everything that is not someone at a terminal — a pipe or redirect,
`--json`/`--jq`/`--shape`, `help -r`, `help -d` — and a browser that fails to
start prints the help that was asked for rather than swallowing it.

**Dependencies:** none new. bubbletea, bubbles and lipgloss are already direct
dependencies here, and this matches the six `tea.WithAltScreen()` programs
already in the tree. `flags.WithPlainHelp` is exported so anything capturing
help text rather than showing it gets it without a backdrop painted in.

**Tests:** nine, driving the model through its own `Update`/`View`, which needs
no terminal — cursor movement, expand/collapse, that the pane holds the
command's real help and follows the selection, that a frame is exactly the
terminal's height and no row exceeds its width, that the rain advances between
ticks, the quit keys, and the deepest-first ordering the hooking depends on.

**How to test this PR:**

```
go run . --tui
go run . cli visor --help --tui
go run . cli --help --tui
go run . --tui | cat        # prints help, does not open
go run . --json --help      # still JSON
```