### PR TITLE
feat(visor): make hypervisor-transport autoconnect configurable (transport.hypervisor_autoconnect, default on)

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1204,11 +1204,13 @@ func configureTransports() {
 	if isTestEnv {
 		tpLogPath = skyenv.LocalPath + "-testenv/" + skyenv.TpLogStore
 	}
+	hypervisorAutoconnect := skyenv.HypervisorAutoconnect
 	conf.Transport = &visorconfig.Transport{
-		Discovery:         services.TransportDiscovery, //utilenv.TpDiscAddr,
-		AddressResolver:   services.AddressResolver,    //utilenv.AddressResolverAddr,
-		PublicAutoconnect: skyenv.PublicAutoconnect,
-		TransportSetupPKs: services.TransportSetupPKs,
+		Discovery:             services.TransportDiscovery, //utilenv.TpDiscAddr,
+		AddressResolver:       services.AddressResolver,    //utilenv.AddressResolverAddr,
+		PublicAutoconnect:     skyenv.PublicAutoconnect,
+		HypervisorAutoconnect: &hypervisorAutoconnect,
+		TransportSetupPKs:     services.TransportSetupPKs,
 		LogStore: &visorconfig.LogStore{
 			// "file" (the retired on-disk CSV store) is now a no-op that only warns
 			// at boot; default fresh configs to "memory" so they don't carry it.

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -195,6 +195,10 @@ const (
 
 	// PublicAutoconnect determines if the visor automatically creates stcpr transports to public visors
 	PublicAutoconnect = true
+	// HypervisorAutoconnect determines if the visor automatically creates a direct
+	// (stcpr/sudph) transport to each configured hypervisor, so RPC + skypty ride a
+	// fast p2p path instead of the dmsg relay (dmsg stays the bootstrap/fallback).
+	HypervisorAutoconnect = true
 
 	// Dmsgpty constants.
 

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -1002,11 +1002,14 @@ func initHypervisors(_ context.Context, v *Visor, _ *logging.Logger) error {
 		// attempt stcpr / sudph transport creation so subsequent RPC
 		// and skypty dials ride a fast p2p path instead of the dmsg
 		// relay. See init_hypervisor_transport.go for the policy +
-		// reconciliation cadence.
-		go v.autoUpgradeHypervisorTransport(ctx,
-			hvPK,
-			v.MasterLogger().PackageLogger("hypervisor_transport").WithField("hypervisor_pk", hvPK),
-		)
+		// reconciliation cadence. Gated by transport.hypervisor_autoconnect
+		// (nil/absent = on, preserving the prior always-on behaviour).
+		if v.conf.Transport == nil || v.conf.Transport.HypervisorAutoconnect == nil || *v.conf.Transport.HypervisorAutoconnect {
+			go v.autoUpgradeHypervisorTransport(ctx,
+				hvPK,
+				v.MasterLogger().PackageLogger("hypervisor_transport").WithField("hypervisor_pk", hvPK),
+			)
+		}
 
 		v.pushCloseStack("hypervisor."+hvPK.String()[:shortHashLen], func() error {
 			cancel()

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -40,10 +40,12 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 		ConnectedServersType: "all",
 		Protocol:             "yamux",
 	}
+	hypervisorAutoconnect := skyenv.HypervisorAutoconnect
 	conf.Transport = &Transport{
-		Discovery:         services.TransportDiscovery,
-		AddressResolver:   services.AddressResolver,
-		PublicAutoconnect: skyenv.PublicAutoconnect,
+		Discovery:             services.TransportDiscovery,
+		AddressResolver:       services.AddressResolver,
+		PublicAutoconnect:     skyenv.PublicAutoconnect,
+		HypervisorAutoconnect: &hypervisorAutoconnect,
 		LogStore: &LogStore{
 			// The on-disk CSV log store was retired; "file" is now a no-op that
 			// only earns a deprecation warning at boot (init_transport.go). Default

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -514,11 +514,16 @@ type SkymailBridgeConfig struct {
 
 // Transport defines a transport config.
 type Transport struct {
-	Discovery             string          `json:"discovery"`
-	DiscoveryDmsg         string          `json:"discovery_dmsg,omitempty"` // DMSG-HTTP URL for transport discovery (fallback pair with discovery)
-	AddressResolver       string          `json:"address_resolver"`
-	AddressResolverDmsg   string          `json:"address_resolver_dmsg,omitempty"` // DMSG-HTTP URL for address resolver
-	PublicAutoconnect     bool            `json:"public_autoconnect"`
+	Discovery           string `json:"discovery"`
+	DiscoveryDmsg       string `json:"discovery_dmsg,omitempty"` // DMSG-HTTP URL for transport discovery (fallback pair with discovery)
+	AddressResolver     string `json:"address_resolver"`
+	AddressResolverDmsg string `json:"address_resolver_dmsg,omitempty"` // DMSG-HTTP URL for address resolver
+	PublicAutoconnect   bool   `json:"public_autoconnect"`
+	// HypervisorAutoconnect gates the background dialing of a direct (stcpr/sudph)
+	// transport to each configured hypervisor. A nil pointer means "on" (default),
+	// so configs written before this field existed keep the prior always-on
+	// behaviour; set it to false to keep the hypervisor link on the dmsg relay only.
+	HypervisorAutoconnect *bool           `json:"hypervisor_autoconnect,omitempty"`
 	TransportSetupPKs     []cipher.PubKey `json:"transport_setup"`
 	UserTransportSetupPKs []cipher.PubKey `json:"user_transport_setup,omitempty"` // user-added keys, preserved across config refresh
 	TPSetupSK             *cipher.SecKey  `json:"tps_sk,omitempty"`


### PR DESCRIPTION
The visor already auto-dials a direct stcpr/sudph transport to each configured hypervisor (`autoUpgradeHypervisorTransport`), so hv↔visor RPC and skypty ride a fast point-to-point path instead of the dmsg relay — dmsg stays the bootstrap/fallback. This makes that behaviour configurable **without regressing existing deployments**.

- `transport.hypervisor_autoconnect` is a `*bool`: nil/absent = **on** (configs written before this field keep the prior always-on behaviour), `false` keeps the hypervisor link on the dmsg relay only.
- Default is `true` in both config constructors (`MakeBaseConfig` + `cli config gen`).
- The `init_apps` launch of the autoconnect goroutine is gated on the flag.

Part of moving the steady-state control plane off the public dmsg servers (bootstrap/fallback only) and onto direct mesh transports.