### PR TITLE
feat(dmsg): optional in-process dmsg server sharing the visor key (dmsg.server, default off)

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -85,6 +85,15 @@ type Config struct {
 	// ["wt"] or ["ws"]) and is set to ["ws"] in the js/wasm build, which has no
 	// raw socket. Unknown names are ignored.
 	Carriers []string
+
+	// SkipSelfServer, when true, makes the serve loop skip any discovered
+	// server entry whose PK equals this client's own PK. It exists for the
+	// visor that runs a dmsg SERVER in-process under the same PK: without
+	// this the client would try to open a transit session to itself. Default
+	// false — the standalone dmsg-server's transit client relies on reaching
+	// its own PK (see self_session_test.go), so only the co-resident-server
+	// visor sets it.
+	SkipSelfServer bool
 }
 
 // Carrier names for Config.Carriers.
@@ -542,6 +551,14 @@ func (ce *Client) Serve(ctx context.Context) {
 		for n, entry := range entries {
 			if isClosed(ce.done) {
 				return
+			}
+
+			// A visor running its own dmsg server in-process (same PK) must
+			// not open a transit session to itself. Conditional: the
+			// standalone server's transit client DOES reach its own PK, so
+			// this is gated on SkipSelfServer (default false).
+			if ce.conf.SkipSelfServer && entry.Static == ce.pk {
+				continue
 			}
 
 			// Skip dmsg servers without user specific types: official, community, all

--- a/pkg/dmsgc/dmsgc.go
+++ b/pkg/dmsgc/dmsgc.go
@@ -94,6 +94,10 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 		},
 		ConnectedServersType: primary.ConnectedServersType,
 		Protocol:             primary.Protocol,
+		// When this visor runs a dmsg server in-process under the same PK,
+		// the client must skip its own server entry in the serve loop rather
+		// than dial a transit session to itself.
+		SkipSelfServer: conf.Server != nil && conf.Server.Enabled,
 	}
 	dmsgConf.ClientType = "visor"
 

--- a/pkg/dmsgc/spec/spec.go
+++ b/pkg/dmsgc/spec/spec.go
@@ -94,6 +94,30 @@ type DmsgConfig struct {
 	// rewards-eligible), a stealthy leaf reaching only statically-known
 	// services/servers. Experimental; default stays discovery.
 	DirectOnly bool `json:"direct_only,omitempty"`
+
+	// Server, when non-nil AND Enabled, runs a dmsg SERVER in-process under
+	// the visor's own PK/SK (shared identity), reusing the visor's existing
+	// dmsg client for discovery rather than standing up a second transit
+	// client. Nil (the default) = no in-process server. See DmsgServerConfig.
+	Server *DmsgServerConfig `json:"server,omitempty"`
+}
+
+// DmsgServerConfig configures the OPTIONAL in-process dmsg server co-resident
+// with the visor. Default off (the whole struct is nil in generated configs).
+// The server shares the visor's PK/SK and its dmsg client, so it advertises
+// under the same PK the visor already uses — no second identity, no second
+// transit client.
+type DmsgServerConfig struct {
+	// Enabled gates the in-process server. False (or a nil *DmsgServerConfig)
+	// = the visor runs no server.
+	Enabled bool `json:"enabled"`
+	// LocalAddress is the TCP listen address for inbound sessions. Empty
+	// defaults to ":8081".
+	LocalAddress string `json:"local_address,omitempty"`
+	// PublicAddress is the externally-reachable address advertised in the
+	// server's discovery entry. Empty = don't advertise a public address
+	// (the server is reachable only over whatever the listener resolves to).
+	PublicAddress string `json:"public_address,omitempty"`
 }
 
 // MarshalJSON and UnmarshalJSON live in spec_native.go under

--- a/pkg/dmsgc/spec/spec_native.go
+++ b/pkg/dmsgc/spec/spec_native.go
@@ -13,6 +13,18 @@ import (
 	"encoding/json"
 )
 
+// deploymentWithServer inlines a Deployment's fields (embedded, no json
+// tag, so its exported fields are promoted into the surrounding object)
+// and adds the visor-wide `server` key. It is the single-object wire
+// shape so the in-process dmsg-server config round-trips alongside the
+// primary deployment's fields. The array (multi-deployment) shape has no
+// sibling slot for a top-level key, so Server is only (de)serialized in
+// the single-object shape.
+type deploymentWithServer struct {
+	Deployment
+	Server *DmsgServerConfig `json:"server,omitempty"`
+}
+
 // UnmarshalJSON accepts either a single Deployment object or an
 // array of Deployments and populates Deployments + the legacy
 // top-level mirror fields accordingly.
@@ -23,11 +35,12 @@ func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	} else {
-		var single Deployment
+		var single deploymentWithServer
 		if err := json.Unmarshal(data, &single); err != nil {
 			return err
 		}
-		c.Deployments = []Deployment{single}
+		c.Deployments = []Deployment{single.Deployment}
+		c.Server = single.Server
 	}
 	c.mirrorPrimary()
 	return nil
@@ -41,11 +54,11 @@ func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
 // so the JSON output is correct.
 func (c DmsgConfig) MarshalJSON() ([]byte, error) {
 	deployments := c.Deployments
-	if len(deployments) == 0 && (c.Discovery != "" || c.DiscoveryDmsg != "" || len(c.Servers) > 0 || c.SessionsCount != 0 || c.ConnectedServersType != "" || c.Protocol != "" || len(c.LANServers) > 0 || c.HypervisorDiscovery != "") {
+	if len(deployments) == 0 && (c.Discovery != "" || c.DiscoveryDmsg != "" || len(c.Servers) > 0 || c.SessionsCount != 0 || c.ConnectedServersType != "" || c.Protocol != "" || len(c.LANServers) > 0 || c.HypervisorDiscovery != "" || c.Server != nil) {
 		deployments = []Deployment{c.toDeployment()}
 	}
 	if len(deployments) == 1 {
-		return json.Marshal(deployments[0])
+		return json.Marshal(deploymentWithServer{Deployment: deployments[0], Server: c.Server})
 	}
 	return json.Marshal(deployments)
 }

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -111,6 +111,8 @@ var (
 	pi vinit.Module
 	// Dmsg ping module (dmsg direct connection)
 	dmsgPi vinit.Module
+	// In-process dmsg server sharing the visor's PK/SK (config-gated, default off)
+	dmsgSrv vinit.Module
 	// Dmsg server latency tracking (self-ping via each server)
 	dmsgServerLatency vinit.Module
 	// Embedded Transport Setup Node (separate dmsg client with TPS identity)
@@ -225,6 +227,7 @@ func registerModules(logger *logging.MasterLogger) {
 	skyFwd = maker("sky_forward_conn", initSkywireForwardConn, &dmsgC, &dmsgCtrl, &tr, &launch)
 	pi = maker("ping", initPing, &dmsgC, &tm)
 	dmsgPi = maker("dmsg_ping", initDmsgPing, &dmsgC)
+	dmsgSrv = maker("dmsg_server", initDmsgServer, &dmsgC)
 	dmsgServerLatency = maker("dmsg_server_latency", initDmsgServerLatency, &dmsgPi)
 	tc = maker("transportable", initEnsureVisorIsTransportable, &dmsgC, &tm, &stcprC)
 	tpdco = maker("tpd_concurrency", initEnsureTPDConcurrency, &dmsgC, &tm)
@@ -265,7 +268,7 @@ func registerModules(logger *logging.MasterLogger) {
 	// init_registration_cxo.go.
 	regCXOMod = maker("registration_cxo", initRegistrationCXO, &dmsgC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &ptyModule,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &meshProxy, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod, &voiceMod, &coinNodesMod, &regCXOMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgSrv, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &meshProxy, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod, &voiceMod, &coinNodesMod, &regCXOMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -31,6 +31,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/direct"
 	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	dmsgmetrics "github.com/skycoin/skywire/pkg/dmsg/dmsg/metrics"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgctrl"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgscp"
@@ -981,6 +982,95 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 			return err
 		})
 	}
+
+	return nil
+}
+
+// dmsgOnlyDisc returns a disc.APIClient that registers + resolves the
+// discovery STRICTLY over dmsg, riding the visor's existing dmsg client —
+// no plain-HTTP egress and no second transit client. Replicated from
+// pkg/services/dmsgsrv.newDmsgOnly to avoid pulling that heavy service
+// package (and its import cycle) into pkg/visor. dmsgC must be able to
+// resolve discPK over dmsg.
+func dmsgOnlyDisc(dmsgC *dmsg.Client, discPK cipher.PubKey, log *logging.Logger) dmsgdisc.APIClient {
+	dmsgURL := fmt.Sprintf("http://%s:%d", discPK.Hex(), dmsg.DefaultDmsgHTTPPort)
+	tr := dmsghttp.MakeHTTPTransport(context.Background(), dmsgC)
+	return dmsgdisc.NewHTTP(dmsgURL, &http.Client{Transport: tr}, log)
+}
+
+// initDmsgServer optionally runs a dmsg SERVER in-process under the visor's
+// own PK/SK, reusing the visor's existing dmsg client (v.dmsgC) for discovery
+// instead of standing up a second transit client. Config-gated and default
+// off: it is a no-op unless Dmsg.Server.Enabled is set. The whole point is
+// shared identity + a single dmsg client — so a visor can also be a dmsg
+// server without a redundant transit client. The client-side self-session
+// guard (SkipSelfServer, wired in dmsgc.New) keeps v.dmsgC from dialing this
+// co-resident server.
+func initDmsgServer(ctx context.Context, v *Visor, log *logging.Logger) error {
+	if v.conf.Dmsg == nil || v.conf.Dmsg.Server == nil || !v.conf.Dmsg.Server.Enabled {
+		return nil
+	}
+	srvCfg := v.conf.Dmsg.Server
+
+	dmsgC := v.dmsgC
+	if dmsgC == nil {
+		return nil
+	}
+
+	// Wait for the visor's dmsg client to be ready — the server's discovery
+	// registration rides its sessions.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-dmsgC.Ready():
+	}
+
+	// Discovery PK for dmsg-only registration: the visor's dmsg discovery
+	// URL is dmsg://<pk>:port. Without a resolvable discovery PK the server
+	// can't register over dmsg; log and no-op rather than fail visor init.
+	discPK := cmdutil.PKFromDmsgURL(v.conf.Dmsg.DiscoveryDmsg)
+	if discPK == (cipher.PubKey{}) {
+		discPK = cmdutil.PKFromDmsgURL(v.conf.Dmsg.Discovery)
+	}
+	if discPK == (cipher.PubKey{}) {
+		log.Warn("in-process dmsg server enabled but no dmsg discovery PK (Dmsg.DiscoveryDmsg); not starting")
+		return nil
+	}
+
+	localAddr := srvCfg.LocalAddress
+	if localAddr == "" {
+		localAddr = ":8081"
+	}
+
+	srvConf := dmsg.DefaultServerConfig()
+	srv := dmsg.NewServer(v.conf.PK, v.conf.SK, dmsgOnlyDisc(dmsgC, discPK, log), srvConf, dmsgmetrics.NewEmpty())
+	srv.SetLogger(log)
+
+	lis, err := net.Listen("tcp", localAddr)
+	if err != nil {
+		return fmt.Errorf("in-process dmsg server: listen on %s: %w", localAddr, err)
+	}
+
+	go func() {
+		// srv.Serve blocks until the server is closed; PublicAddress is the
+		// advertised address ("" = advertise whatever the listener resolves).
+		if serr := srv.Serve(lis, srvCfg.PublicAddress); serr != nil && !errors.Is(serr, dmsg.ErrClosed) {
+			log.WithError(serr).Warn("in-process dmsg server stopped")
+		}
+	}()
+
+	log.WithField("local_pk", v.conf.PK).
+		WithField("local_address", localAddr).
+		WithField("public_address", srvCfg.PublicAddress).
+		Info("Started in-process dmsg server on the visor key")
+
+	v.pushCloseStack("dmsg_server", func() error {
+		cerr := srv.Close()
+		if lerr := lis.Close(); lerr != nil && !errors.Is(lerr, net.ErrClosed) && cerr == nil {
+			cerr = lerr
+		}
+		return cerr
+	})
 
 	return nil
 }


### PR DESCRIPTION
A visor can now run a dmsg **server in-process under its own PK/SK**, instead of as a separate process with a separate key. **Config-gated, default OFF** via a new `dmsg.server` block (`enabled`/`local_address`/`public_address`) — nil/absent = off, so existing configs and behaviour are unchanged.

- **pkg/dmsgc/spec**: `DmsgServerConfig` + `Server` field on `DmsgConfig`, round-tripped through the custom Marshal/UnmarshalJSON (single-object wire shape).
- **pkg/visor**: new `dmsg_server` module (`initDmsgServer`) that **reuses the visor's existing dmsg client (`v.dmsgC`) for discovery** — no redundant transit client — and serves `dmsg.NewServer` under `v.conf.PK/SK` on `local_address`.
- **pkg/dmsg/dmsg**: `dmsg.Config.SkipSelfServer` (default false) + a gated serve-loop guard so a visor running its own co-resident server doesn't open a transit session to itself; the standalone server's self-reaching transit client is unaffected.

First step toward collapsing the co-located dmsg-server + visor process pairs (all 9 deployment dmsg servers currently run beside a visor, separate key/process) into a single shared identity. Build + vet clean; `dmsg` self-session/server tests pass; config-gen emits nothing by default.