### PR TITLE
fix(gitignore): anchor dist/ so develop-latest arm builds aren't stamped +dirty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,10 +54,10 @@ go.mod-e
 ./packages
 ./deb
 ./sysroot
-./static/skywire-manager-src/dist/*
-./visor
-./dist-linux
-./dist
+/static/skywire-manager-src/dist/
+/visor
+/dist-linux/
+/dist/
 ./Char
 ./scripts/mac_installer/IconsSkycoin.tar.gz
 ./scripts/mac_installer/icon_128x128.png


### PR DESCRIPTION
`.gitignore` lines 57-60 used a leading `./` (e.g. `./dist`), which git does not honor as an anchor — so `dist/` was never ignored. In `publish-binary.yml`, `build_arch` writes `dist/skywire-linux-<arch>.zst` per arch: amd64 builds first against a clean tree (`vcs.modified=false`), but once its `.zst` lands in the untracked `dist/`, every subsequent arch build sees `?? dist/` and Go stamps `vcs.modified=true` — so armhf/arm develop-latest binaries reported `+dirty` while amd64 didn't (verified via `go version -m` on the published artifacts).

Re-anchor the broken `./`-prefixed patterns so `dist/` (and `/dist-linux/`, `/visor`) are actually ignored → all arches build clean. .gitignore-only, no code change.