### PR TITLE
fix(cxo): cure publisher missing-object freeze from batch-rollback cache desync

### DIFF
--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -137,6 +137,16 @@ type Cache struct {
 	// unpinned store and blocks on bbolt's writer lock, which the tx
 	// owns — while the tx owner blocks on c.mx. See WithBatch.
 	batchTx atomic.Pointer[data.CXDS]
+
+	// batchRec, when non-nil, collects the keys whose object value was
+	// (re)written to the batch-scoped CXDS tx during the active WithBatch.
+	// If that tx rolls back (fn returned an error), WithBatch evicts these
+	// keys from c.is so a value that no longer exists in the store is not
+	// left masquerading as cached — the write-behind invariant "value in
+	// c.is ⇒ value in the store". Guarded by c.mx like the rest of the
+	// Cache; nil outside a WithBatch, so it costs nothing off the publish
+	// path. See WithBatch and recordBatchWrite.
+	batchRec map[cipher.SHA256]struct{}
 }
 
 // initialize the Cache
@@ -262,6 +272,11 @@ func (c *Cache) WithBatch(fn func() error) error {
 	// before ever calling us back.
 	defer unlock()
 
+	// Track object-value writes so a rollback can undo their c.is
+	// residue (see batchRec). Allocated under c.mx before the pin goes
+	// live; cleared under c.mx in step (3).
+	c.batchRec = make(map[cipher.SHA256]struct{})
+
 	return c.c.db.CXDS().RunBatch(func(scoped data.CXDS) (err error) {
 		c.batchTx.Store(&scoped)
 		// (2) The pin is visible to everyone who takes c.mx from here
@@ -272,9 +287,52 @@ func (c *Cache) WithBatch(fn func() error) error {
 			c.mx.Lock()
 			held = true
 			c.batchTx.Store(nil)
+			// A non-nil fn error rolled the tx back: every value it wrote
+			// is gone from the store but still sits in c.is (Cache.Set does
+			// db().Set THEN putItem). Evict exactly those so a later re-Set
+			// takes the miss path and re-persists rather than short-
+			// circuiting as a cache hit — the treestore publisher-freeze
+			// desync. On a clean commit the writes are durable; keep them.
+			if err != nil {
+				c.dropBatchWrites()
+			}
+			c.batchRec = nil
 		}()
-		return fn()
+		err = fn()
+		return err
 	})
+}
+
+// recordBatchWrite notes that key's object value was (re)written to the
+// batch-scoped CXDS tx during an active WithBatch, so a subsequent
+// rollback can evict the now-orphaned c.is entry. No-op outside a batch.
+// Called with c.mx held.
+func (c *Cache) recordBatchWrite(key cipher.SHA256) {
+	if c.batchRec != nil {
+		c.batchRec[key] = struct{}{}
+	}
+}
+
+// dropBatchWrites evicts the c.is entries recorded during a WithBatch fn
+// that returned an error (the tx rolled back). Their backing values no
+// longer exist in the store, so leaving them cached would let a later
+// Cache.Set short-circuit as a cache hit and never re-persist them — the
+// exact desync behind the long-uptime [stats]/TPD publisher freeze:
+// attempt-1's failed encode+save rolls back its object writes, attempt-2's
+// self-heal re-encode re-Set's them as no-ops, and the published Root ends
+// up referencing objects absent from the CXDS. Raw removal (no db().Inc)
+// because the store already discarded these on rollback. Called with
+// c.mx held.
+func (c *Cache) dropBatchWrites() {
+	for key := range c.batchRec {
+		it, ok := c.is[key]
+		if !ok {
+			continue
+		}
+		c.amount--
+		c.volume -= len(it.val)
+		delete(c.is, key)
+	}
 }
 
 // call it under lock
@@ -895,6 +953,7 @@ func (c *Cache) setWanted(
 	if err != nil {
 		return rc, err // DB failure
 	}
+	c.recordBatchWrite(key)
 
 	rc = int(urc) - (wincs + it.fc) // hard rc
 
@@ -971,6 +1030,7 @@ func (c *Cache) setFilling(
 		if urc, err = c.db().Set(key, val, inc+it.fc); err != nil {
 			return rc, err
 		}
+		c.recordBatchWrite(key)
 		c.stat.addWritingDBRequest()
 		rc = int(urc) - it.fc
 		err = c.putFillingItem(val, int(urc), it)
@@ -1038,6 +1098,7 @@ func (c *Cache) Set(
 	if err != nil {
 		return rc, err
 	}
+	c.recordBatchWrite(key)
 
 	rc = int(urc)
 	err = c.putItem(key, val, rc)

--- a/pkg/cxo/treestore/publisher_batch_rollback_desync_test.go
+++ b/pkg/cxo/treestore/publisher_batch_rollback_desync_test.go
@@ -1,0 +1,216 @@
+package treestore
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	skycipher "github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/data"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject/registry"
+)
+
+// TestPublisherBatchRollbackDesyncFreeze reproduces the PRODUCTION hub
+// freeze that the #4036 self-heal re-encode and the #4041 setFilling
+// repair BOTH fail to cure — the residual "long-uptime hub freezes,
+// fresh restart clears it" behavior.
+//
+// Why the existing regression tests miss it: every one of them runs on
+// nopNode / nopNodeNoCache, i.e. the IN-MEMORY CXDS. memoryCXDS.RunBatch
+// is a pure passthrough (fn(m)) with NO transaction and NO rollback, so a
+// failed publish attempt's object writes survive in the store — the
+// self-heal's second attempt then finds them and succeeds. Production
+// runs on the DRIVE (bbolt) backend, where RunBatch == bolt.Update: a
+// non-nil return ROLLS THE TX BACK and discards every object the failed
+// attempt wrote to bbolt.
+//
+// The bug is a write-behind-cache invariant break. Cache.Set on a miss
+// does db().Set(scoped-tx) THEN putItem(c.is) — so after attempt-1 rolls
+// back, the freshly-encoded objects are GONE from bbolt but still SIT in
+// c.is (with a value, cc>0). The #4036 self-heal then clears the encode
+// cache and re-encodes from memory, re-Set'ing every object — but for an
+// object still resident in c.is that re-Set hits Set's "effective cache
+// set" branch (it.cc += inc; touch; return) and NEVER writes to bbolt.
+// So attempt-2 "succeeds" (its reference walk is satisfied from c.is) and
+// the Root advances ONCE, yet the objects it references are absent from
+// CXDS. A subscriber filling that Root, or the publisher itself after the
+// orphaned c.is entries later evict (cleanDown's delete → db().Inc →
+// ErrNotFound), then wedges permanently on "not found" — the frozen hub.
+//
+// The deterministic reduction: publish a static (cacheable) sibling plus
+// a growing (churning) sibling, evict the static branch's objects from
+// BOTH the cache and the CXDS so the next publish's reference walk hits a
+// real missing object (forcing the two-attempt self-heal path with a REAL
+// bbolt rollback of attempt-1), then advance the growing sibling so
+// attempt-1 encodes brand-new objects that the rollback orphans. After
+// the self-heal we assert the invariant the fix must guarantee: EVERY
+// object the freshly-published Root references is present in the CXDS
+// (checked directly, bypassing the cache — exactly what a subscriber or a
+// restarted process sees). On unmodified develop the orphaned growing
+// objects are missing from bbolt and this FAILS.
+func TestPublisherBatchRollbackDesyncFreeze(t *testing.T) {
+	dir := t.TempDir()
+	pk, sk := cipher.GenerateKeyPair()
+
+	// bbolt-backed node with the object cache ENABLED (production shape).
+	n := fileBackedNode(t, filepath.Join(dir, "node"), sk)
+	defer func() { _ = n.Close() }() //nolint:errcheck
+
+	skyPK := skycipher.PubKey(pk)
+	if err := n.Share(skyPK); err != nil {
+		t.Fatalf("Share: %v", err)
+	}
+	p := &Publisher{
+		log: mustLogger(), cxoNode: n, pk: pk, sk: sk,
+		root:         newMemNode(),
+		allow:        newAllowState(nil),
+		batchWindow:  10 * time.Millisecond,
+		wakeup:       make(chan struct{}, 1),
+		done:         make(chan struct{}),
+		cleanupNudge: make(chan struct{}, 1),
+		cleanupDone:  make(chan struct{}),
+	}
+	close(p.cleanupDone)
+
+	c := p.cxoNode.Container()
+	cxds := c.DB().CXDS()
+
+	if err := p.Put("static/x", []byte("v1")); err != nil {
+		t.Fatalf("Put(static/x): %v", err)
+	}
+	if err := p.Put("growing/n0", []byte("d0")); err != nil {
+		t.Fatalf("Put(growing/n0): %v", err)
+	}
+	if err := p.publishIfDirty(); err != nil {
+		t.Fatalf("first publishIfDirty: %v", err)
+	}
+
+	staticNode := p.root.subs["static"]
+	if staticNode == nil || !staticNode.cached || staticNode.pubHash == (skycipher.SHA256{}) {
+		t.Fatalf("expected static sub-node cached with a pubHash; got %+v", staticNode)
+	}
+	staticTreeNodeHash := staticNode.pubHash
+	staticEntryHash := staticTreeEntryHash(t, c, skyPK, sk)
+
+	// Fully evict the static branch's objects from the cache AND the CXDS
+	// so attempt-1's reference walk hits a genuine missing object and its
+	// batch rolls back — modelling a pruned/GC'd branch.
+	for _, h := range []skycipher.SHA256{staticEntryHash, staticTreeNodeHash} {
+		if _, err := c.Inc(h, -1<<20); err != nil { // drop cache rc → evict from c.is
+			t.Fatalf("Inc(%s) down: %v", h.Hex(), err)
+		}
+		if _, _, err := cxds.Get(h, 0); err == nil {
+			if err := cxds.Del(h); err != nil {
+				t.Fatalf("CXDS.Del(%s): %v", h.Hex(), err)
+			}
+		}
+		if _, _, err := cxds.Get(h, 0); err != data.ErrNotFound {
+			t.Fatalf("static object %s should be gone; Get err=%v", h.Hex(), err)
+		}
+	}
+
+	// Advance the churning sibling: attempt-1 now encodes brand-new
+	// objects (the growing TreeNode + leaf + a new root TreeNode) into the
+	// batch tx BEFORE the reference walk hits the evicted static object
+	// and rolls the tx back — orphaning those new objects in c.is.
+	if err := p.Put("growing/n1", []byte("d1")); err != nil {
+		t.Fatalf("Put(growing/n1): %v", err)
+	}
+	if err := p.publishIfDirty(); err != nil {
+		t.Fatalf("republish (self-heal path) returned error: %v", err)
+	}
+
+	// Root must have advanced to include growing/n1.
+	nonce := c.ActiveHead(skyPK)
+	if nonce == 0 {
+		t.Fatalf("ActiveHead returned zero after publish — root not persisted")
+	}
+	r, err := c.LastRoot(skyPK, nonce)
+	if err != nil {
+		t.Fatalf("LastRoot: %v", err)
+	}
+	if r == nil || len(r.Refs) == 0 {
+		t.Fatalf("LastRoot returned empty root")
+	}
+
+	// The invariant: every TreeNode object the published Root references
+	// must be present in the CXDS itself (not merely reachable through the
+	// write-behind cache). Enumerate the Root's TreeNode hashes via the
+	// pack, then check each one directly against the CXDS. On unmodified
+	// develop the growing branch's TreeNode was orphaned by attempt-1's
+	// rollback and its attempt-2 re-Set was a cache-hit no-op, so it is
+	// missing here — the served Root cannot be filled.
+	up, err := c.Unpack(skycipher.SecKey(sk), Registry)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	defer up.Close() //nolint:errcheck
+
+	hashes := map[skycipher.SHA256]string{}
+	if err := collectTreeNodeHashes(up, r.Refs[0].Hash, "", hashes); err != nil {
+		t.Fatalf("collectTreeNodeHashes: %v", err)
+	}
+
+	var missing []string
+	for h, path := range hashes {
+		if _, _, err := cxds.Get(h, 0); err != nil {
+			missing = append(missing, path+" ("+h.Hex()[:16]+"): "+err.Error())
+		}
+	}
+	if len(missing) != 0 {
+		t.Fatalf("published Root references %d object(s) absent from the CXDS — "+
+			"the batch-rollback desync freeze (a subscriber filling this Root, or "+
+			"this publisher after the orphaned cache entries evict, wedges on "+
+			"\"not found\"):\n  %v", len(missing), missing)
+	}
+}
+
+// collectTreeNodeHashes walks the published Root tree via the pack and
+// records the CXDS hash of every TreeNode it reaches (the root node named
+// "" plus each sub-node, keyed by its path). Leaves are inline in their
+// parent's TreeEntry, so the objects that must exist in the CXDS are the
+// TreeNodes themselves; the growing branch's orphaned TreeNode is caught
+// here.
+func collectTreeNodeHashes(up registry.Pack, nodeHash skycipher.SHA256, path string, out map[skycipher.SHA256]string) error {
+	if nodeHash == (skycipher.SHA256{}) {
+		return nil
+	}
+	label := path
+	if label == "" {
+		label = "<root>"
+	}
+	out[nodeHash] = label
+
+	// Decode the TreeNode via a Ref (reads through the pack/cache, which
+	// still holds the orphaned objects — traversal succeeds so we can
+	// enumerate hashes; the CXDS presence check happens in the caller).
+	var node TreeNode
+	ref := registry.Ref{Hash: nodeHash}
+	if err := ref.Value(up, &node); err != nil {
+		// Node object itself is unfetchable; recorded above, caller reports it.
+		return nil //nolint:nilerr
+	}
+	ln, err := node.Children.Len(up)
+	if err != nil {
+		return nil //nolint:nilerr
+	}
+	for i := 0; i < ln; i++ {
+		var te TreeEntry
+		if _, err := node.Children.ValueByIndex(up, i, &te); err != nil {
+			continue
+		}
+		if len(te.Leaf) > 0 || te.Sub.Hash == (skycipher.SHA256{}) {
+			continue
+		}
+		childPath := te.Name
+		if path != "" {
+			childPath = path + "/" + te.Name
+		}
+		if err := collectTreeNodeHashes(up, te.Sub.Hash, childPath, out); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**The bug.** A long-uptime hub's CXO `stats` publisher hits a missing-object ("not found") error during Root republish and **freezes** — never advances its Root again — so TPD serves an hours-stale snapshot and route-finding starves. Only a restart clears it. (Live: a hub with 1328 live transports; `visor state .cxo` = `frozen:true, last_err:"not found", secs_since_ok_publish` growing for hours, 1484 leaves in memory but the published Root pinned at an old ~341 snapshot.)

**Root cause** (drive/bbolt backend only — invisible to every existing test, which use the in-memory CXDS whose `RunBatch` can't roll back): inside `Cache.WithBatch`, an attempt's encode `Set`s objects (`db().Set` + `putItem` into `c.is`); the reference walk `Inc`s an evicted object that isn't present → `ErrNotFound` → `fn` returns error → **bbolt rolls the tx back**. The freshly-written objects are now gone from bbolt but still resident in `c.is`. The #4036 self-heal's retry re-`Set`s them, but a key still in `c.is` takes `Set`'s cache-hit branch and **never writes to bbolt** — so attempt-2 commits a Root referencing objects absent from the store; when those `c.is` entries later evict (or on restart) the publisher wedges permanently on "not found". This resolves the standing contradiction (the self-heal WARN *does* fire, but its re-Set can't re-persist).

**Fix, at the source** (`pkg/cxo/skyobject/cache.go`, +62): `WithBatch` records every object-value write into a per-batch set (`recordBatchWrite` at the `db().Set` value-write sites); on rollback it evicts exactly those keys from `c.is` (`dropBatchWrites`), restoring the invariant **value in `c.is` ⇒ value in the store**. The existing self-heal retry then re-persists from the authoritative in-memory tree, so **no feed can permanently freeze**. No-op on a clean commit and off the publish path.

**Test.** `TestPublisherBatchRollbackDesyncFreeze` (bbolt-backed) asserts every TreeNode the published Root references is present in the CXDS. **Fails on develop** (Root references 2 objects absent), **passes with the fix**. `go build .`, `pkg/cxo/treestore`, `pkg/cxo/skyobject` all green.

Recovery is restart-free: on a frozen hub with the fixed binary, the Root advances and `frozen` clears on the next heartbeat. Follow-up (optional, defense-in-depth): publish the tp-list discovery leaf on its own tiny feed.