### PR TITLE
fix(lint): clear develop lint failures (misspell, errcheck check-blank)

### DIFF
--- a/internal/nativee2e/env_test.go
+++ b/internal/nativee2e/env_test.go
@@ -3,7 +3,7 @@
 
 // Package nativee2e — internal/nativee2e/env_test.go: a NATIVE (no-Docker)
 // client-side e2e harness that runs a small skywire deployment + two visors as
-// host processes on 127.0.0.1, so client behaviour (visor, hypervisor,
+// host processes on 127.0.0.1, so client behavior (visor, hypervisor,
 // skysocks-client, vpn-client) can be tested on macOS and Windows — where the
 // Docker-based internal/integration suite can't run.
 //

--- a/pkg/transport/manager_regnudge_test.go
+++ b/pkg/transport/manager_regnudge_test.go
@@ -166,7 +166,9 @@ func TestOutboundSaveNudgesReRegister(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer func() {
 		cancel()
-		_ = client.tp.Close()
+		if err := client.tp.Close(); err != nil {
+			t.Logf("client.tp.Close: %v", err)
+		}
 	}()
 	tm.Serve(ctx)
 

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -1003,7 +1003,7 @@ func initHypervisors(_ context.Context, v *Visor, _ *logging.Logger) error {
 		// and skypty dials ride a fast p2p path instead of the dmsg
 		// relay. See init_hypervisor_transport.go for the policy +
 		// reconciliation cadence. Gated by transport.hypervisor_autoconnect
-		// (nil/absent = on, preserving the prior always-on behaviour).
+		// (nil/absent = on, preserving the prior always-on behavior).
 		if v.conf.Transport == nil || v.conf.Transport.HypervisorAutoconnect == nil || *v.conf.Transport.HypervisorAutoconnect {
 			go v.autoUpgradeHypervisorTransport(ctx,
 				hvPK,

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -522,7 +522,7 @@ type Transport struct {
 	// HypervisorAutoconnect gates the background dialing of a direct (stcpr/sudph)
 	// transport to each configured hypervisor. A nil pointer means "on" (default),
 	// so configs written before this field existed keep the prior always-on
-	// behaviour; set it to false to keep the hypervisor link on the dmsg relay only.
+	// behavior; set it to false to keep the hypervisor link on the dmsg relay only.
 	HypervisorAutoconnect *bool           `json:"hypervisor_autoconnect,omitempty"`
 	TransportSetupPKs     []cipher.PubKey `json:"transport_setup"`
 	UserTransportSetupPKs []cipher.PubKey `json:"user_transport_setup,omitempty"` // user-added keys, preserved across config refresh


### PR DESCRIPTION
The Test workflow has failed on every develop commit since #4146, so every PR opened against develop inherits a red build.

Three issues, all reported by `golangci-lint`:

- `pkg/visor/init_apps.go` and `pkg/visor/visorconfig/v1.go` use "behaviour", which `misspell` flags. `internal/nativee2e/env_test.go` has the same word and is corrected too so it does not surface later.
- `pkg/transport/manager_regnudge_test.go` discarded a teardown `Close` with `_ =`. `errcheck` runs with `check-blank: true` here, so the blank assignment is itself an error. Logged instead, matching `pkg/visor/stats`.

Comment and test-teardown changes only; no behaviour change. `golangci-lint` is clean on the three affected trees and `go test ./pkg/transport/` passes.