### PR TITLE
cxo: publish tp-list on its own dedicated feed so TPD fills it completely

### DIFF
--- a/pkg/services/tpd/tpd.go
+++ b/pkg/services/tpd/tpd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/skycoin/skywire/pkg/metricsutil"
 	"github.com/skycoin/skywire/pkg/services"
 	"github.com/skycoin/skywire/pkg/serviceuptime"
+	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/storeconfig"
 	"github.com/skycoin/skywire/pkg/svcmode"
 	"github.com/skycoin/skywire/pkg/transport"
@@ -283,6 +284,34 @@ func (s *service) startCXO(
 			agg.Close() //nolint:errcheck,gosec
 		}()
 		logger.WithField("feed_pk", agg.FeedPK()).Info("CXO aggregator running: accepting inbound visor stats feeds")
+	}
+
+	// Second aggregator for the visors' DEDICATED tp-list discovery feed
+	// (DmsgVisorTPListCXOPort). That feed's Root is just the compact
+	// transport-list snapshot leaf, so it fills completely in ~1 round-trip
+	// — the durable cure for the ~10% transport under-report on busy hubs,
+	// whose combined telemetry Root on port 50 can't finish its fill in the
+	// announce conn's window. It shares the same sink: only the declarative
+	// ReconcileTransportsFromCXO path fires (the tp-list feed carries no
+	// per-transport telemetry leaves). Kept on its own node/port so a
+	// visor's tp-list Root never head-collides with its telemetry Root.
+	// A visor that publishes only the legacy combined feed (older binary)
+	// simply never dials this port — the port-50 aggregator above still
+	// reconciles its tp-list from the combined feed (back-compat fallback).
+	tplAgg, err := cxoaggregator.New(h.DmsgClient, sink, cxoaggregator.Config{
+		DmsgPort: skyenv.DmsgVisorTPListCXOPort,
+		Logger:   logging.MustGetLogger("tpd-cxo-tplist-aggregator"),
+	})
+	if err != nil {
+		logger.WithError(err).Error("Failed to start CXO tp-list aggregator, continuing without it")
+	} else {
+		tplAgg.Run(ctx)
+		go func() {
+			<-ctx.Done()
+			tplAgg.Close() //nolint:errcheck,gosec
+		}()
+		logger.WithField("feed_pk", tplAgg.FeedPK()).WithField("dmsg_port", skyenv.DmsgVisorTPListCXOPort).
+			Info("CXO tp-list aggregator running: accepting inbound visor tp-list discovery feeds")
 	}
 
 	if pub, perr := api.StartMetricsCXOPublisher(ctx, tpdAPI, h.DmsgClient, sk, logger); perr != nil {

--- a/pkg/skyenv/ports_test.go
+++ b/pkg/skyenv/ports_test.go
@@ -38,6 +38,7 @@ func TestVisorPortsAreUnique(t *testing.T) {
 		"DmsgDMSGDClientsByServerCXOPort": DmsgDMSGDClientsByServerCXOPort,
 		"DmsgTPDAllTransportsCXOPort":     DmsgTPDAllTransportsCXOPort,
 		"DmsgDMSGDRegistrationCXOPort":    DmsgDMSGDRegistrationCXOPort,
+		"DmsgVisorTPListCXOPort":          DmsgVisorTPListCXOPort,
 		"DmsgTransportQueryPort":          DmsgTransportQueryPort,
 		"DmsgWebRTCSignalPort":            DmsgWebRTCSignalPort,
 		"SkychatVoiceSignalPort":          SkychatVoiceSignalPort,

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -121,6 +121,24 @@ const (
 	// needs to be collision-free, which the ports_test guards.
 	DmsgDMSGDRegistrationCXOPort uint16 = 67
 
+	// DmsgVisorTPListCXOPort is the DMSG port the visor's DEDICATED
+	// transport-list (tp-list) discovery feed binds — a second CXO node,
+	// under the SAME visor identity PK as the telemetry publisher on
+	// DmsgCXOPort (50), carrying ONLY the compact tp-list snapshot leaf.
+	// Its Root is a handful of objects, so TPD's aggregator fills it
+	// COMPLETELY in ~1 round-trip — where the combined telemetry Root on
+	// port 50 (hundreds/thousands of transports/<uuid>/current leaves)
+	// routinely breaks its fill partway on a busy hub, landing ~10% of the
+	// transports. Same PK keeps TPD's reporter=feed-PK edge-auth intact
+	// (see cxo_register.go); a distinct node/port keeps the tiny Root out
+	// of the churning telemetry tree AND out of head-collision with it on
+	// the aggregator side (each aggregator node sees one Root per feed PK).
+	// TPD runs a second aggregator here; older TPDs (port 50 only) still
+	// read the tp-list from the combined feed (back-compat fallback).
+	// Numbered 69 (the 50–55 CXO block and 56–68 are all taken); the value
+	// only needs to be collision-free, which ports_test guards.
+	DmsgVisorTPListCXOPort uint16 = 69
+
 	// DmsgTransportQueryPort is the dmsg port a visor listens on to answer
 	// RSN-oracle transport-list queries (see pkg/router/transport_query.go). A
 	// source visor building a 2-hop route dials the destination here, delivers an

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -205,6 +205,15 @@ type Config struct {
 	// satisfy CXO's filling protocol).
 	InMemoryDB bool
 	DataDir    string
+	// DmsgPort is the DMSG port this aggregator's CXO node listens on
+	// (and dials visors back on). Zero falls back to
+	// cxotransport.DefaultCXOPort (50), the visor telemetry feed. TPD
+	// runs a SECOND aggregator on skyenv.DmsgVisorTPListCXOPort (69) for
+	// the visors' dedicated tp-list discovery feed, which fills fully
+	// because its Root is tiny — the two feeds MUST be on separate nodes
+	// (hence separate ports) so the same visor PK doesn't deliver two
+	// different Roots to one node and flap its head.
+	DmsgPort uint16
 }
 
 // Aggregator is the CXO subscriber side of the visor-stats data path.
@@ -351,7 +360,11 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 	if err != nil {
 		return nil, err
 	}
-	factory := cxotransport.NewDMSGFactory(dmsgC, cxotransport.DefaultCXOPort)
+	dmsgPort := conf.DmsgPort
+	if dmsgPort == 0 {
+		dmsgPort = cxotransport.DefaultCXOPort
+	}
+	factory := cxotransport.NewDMSGFactory(dmsgC, dmsgPort)
 	if err := cxoNode.EnableDMSG(factory); err != nil {
 		_ = cxoNode.Close() //nolint:errcheck
 		return nil, err

--- a/pkg/transport-discovery/cxoaggregator/targeted_fetch_test.go
+++ b/pkg/transport-discovery/cxoaggregator/targeted_fetch_test.go
@@ -293,3 +293,106 @@ func TestBoundedGetterBudget(t *testing.T) {
 type getterFunc func(skycipher.SHA256) ([]byte, error)
 
 func (f getterFunc) Get(key skycipher.SHA256) ([]byte, error) { return f(key) }
+
+// walkAllObjects recursively reads every TreeEntry in the Root's tree
+// through a Preview pack backed by g, forcing g to serve (and record)
+// every object the whole tree references — i.e. the full object footprint
+// a subscriber must fill to receive the feed. Returns the count of
+// DISTINCT object hashes requested.
+func walkAllObjects(t *testing.T, aggNode *node.Node, g *servingGetter, r *registry.Root) int {
+	t.Helper()
+	pack, err := aggNode.Container().Preview(r, g)
+	if err != nil {
+		t.Fatalf("Preview: %v", err)
+	}
+	var rootNode treestore.TreeNode
+	if err := r.Refs[0].Value(pack, &rootNode); err != nil {
+		t.Fatalf("root TreeNode: %v", err)
+	}
+	var walk func(n *treestore.TreeNode)
+	walk = func(n *treestore.TreeNode) {
+		count, err := n.Children.Len(pack)
+		if err != nil {
+			return
+		}
+		for i := 0; i < count; i++ {
+			var entry treestore.TreeEntry
+			if _, err := n.Children.ValueByIndex(pack, i, &entry); err != nil {
+				continue
+			}
+			if entry.Sub.Hash != (skycipher.SHA256{}) {
+				var sub treestore.TreeNode
+				if err := entry.Sub.Value(pack, &sub); err == nil {
+					walk(&sub)
+				}
+			}
+		}
+	}
+	walk(&rootNode)
+	distinct := make(map[skycipher.SHA256]struct{}, len(g.requested))
+	for _, k := range g.requested {
+		distinct[k] = struct{}{}
+	}
+	return len(distinct)
+}
+
+// TestDedicatedTPListFeedFillsCompletely is the structural proof behind
+// moving the tp-list onto its OWN CXO feed (skyenv.DmsgVisorTPListCXOPort):
+// a feed that carries ONLY the compact transport-list snapshot leaf (no
+// telemetry) has a tiny object footprint that is INDEPENDENT of the
+// transport count, so its whole Root fills in ~1 round-trip — where the
+// combined telemetry Root's footprint scales with the transport count and
+// routinely can't finish its fill over the short announce conn on a busy
+// hub (the ~10% under-report this fixes). Both are built from the SAME
+// buildBigRoot helper; the only difference is whether the telemetry subtree
+// rides along.
+func TestDedicatedTPListFeedFillsCompletely(t *testing.T) {
+	const nTransports = 500
+
+	// Dedicated feed: tp-list only, NO telemetry — the shape published on
+	// DmsgVisorTPListCXOPort.
+	dedSrc, dedRoot, _ := buildBigRoot(t, nTransports, 0)
+	dedObjs := walkAllObjects(t, newInMemNode(t), &servingGetter{src: dedSrc}, dedRoot)
+
+	// Combined feed: same tp-list PLUS a bulky telemetry tree — the shape on
+	// DmsgCXOPort whose whole-Root fill breaks on a busy hub.
+	combSrc, combRoot, _ := buildBigRoot(t, nTransports, 3000)
+	combObjs := walkAllObjects(t, newInMemNode(t), &servingGetter{src: combSrc}, combRoot)
+
+	t.Logf("Root object footprint at %d transports: dedicated tp-list feed = %d objects, combined telemetry feed (3000 leaves) = %d objects",
+		nTransports, dedObjs, combObjs)
+
+	// The dedicated Root's footprint is a handful of objects and does not
+	// grow with the transport count (the tp-list is one inlined leaf), so it
+	// fits well inside a single fill. The combined Root drags in an object
+	// per telemetry leaf.
+	if dedObjs > maxTargetedFetchObjects {
+		t.Fatalf("dedicated feed footprint = %d objects (> %d): not a one-round-trip fill",
+			dedObjs, maxTargetedFetchObjects)
+	}
+	if combObjs <= dedObjs*10 {
+		t.Fatalf("combined feed footprint = %d vs dedicated %d: expected the telemetry tree to dominate",
+			combObjs, dedObjs)
+	}
+
+	// The dedicated feed lands ALL transports: serving ONLY the objects its
+	// whole tree references (i.e. the entire dedicated feed, telemetry
+	// absent by construction) still reconciles the full list.
+	a := &Aggregator{
+		cxoNode:  newInMemNode(t),
+		sink:     &recordingSink{},
+		log:      logging.MustGetLogger("test"),
+		lastList: make(map[skycipher.PubKey]cachedList),
+		fetching: make(map[skycipher.PubKey]struct{}),
+	}
+	entries, version, ok := a.fetchDiscoveryLeafWithGetter(&servingGetter{src: dedSrc}, dedRoot)
+	if !ok {
+		t.Fatal("dedicated feed: discovery leaf did not land")
+	}
+	if version != "v-test" {
+		t.Errorf("dedicated feed: version = %q, want v-test", version)
+	}
+	if len(entries) != nTransports {
+		t.Fatalf("dedicated feed reconciled %d transports, want all %d", len(entries), nTransports)
+	}
+}

--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -22,6 +22,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/visor/stats"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
@@ -72,6 +73,7 @@ func initStats(_ context.Context, v *Visor, log *logging.Logger) error {
 	// just don't get push updates. Publisher feed PK is the visor's
 	// own PK (one identity per node).
 	pub, sink := buildStatsPublisher(v, log)
+	var tplistPub *treestore.Publisher
 	if pub != nil {
 		// Only the currently-live transports' `current` leaf may be
 		// broadcast to the discovery feed. bbolt retains records for
@@ -86,16 +88,33 @@ func initStats(_ context.Context, v *Visor, log *logging.Logger) error {
 		}
 		tracker.SeedMirroredCurrent(liveIDs)
 		tracker.SetSink(sink)
-		// Wire the same publisher into the transport manager so its
-		// register / deregister loops mirror the canonical entry +
-		// tombstone leaves to TPD's CXO aggregator (dual-write
-		// alongside the HTTP path during migration).
-		if v.tpM != nil {
-			v.tpM.SetTPDLeafPublisher(pub)
+
+		// Dedicated tp-list discovery feed: a SECOND CXO node under the
+		// SAME visor identity PK, on DmsgVisorTPListCXOPort, carrying ONLY
+		// the compact transport-list snapshot leaf (publishTPDList). Its
+		// Root is a handful of objects, so TPD's second aggregator fills it
+		// COMPLETELY in ~1 round-trip — the durable cure for the ~10%
+		// transport under-report on busy hubs, whose combined telemetry
+		// Root on `pub` (DmsgCXOPort) can't finish its whole-Root fill in
+		// the announce conn's window. Same PK keeps TPD's reporter=feed-PK
+		// edge-auth intact. The telemetry leaves (transports/<id>/current)
+		// stay on `pub`. If the dedicated publisher can't start, fall back
+		// to publishing the tp-list on the telemetry feed (legacy combined
+		// behavior) so discovery still works — just without the
+		// fill-completeness win.
+		tplistPub = buildTPListPublisher(v, log)
+		leafPub := pub
+		if tplistPub != nil {
+			leafPub = tplistPub
 		}
-		// Retain the publisher so `skywire cli visor state --jq '.cxo'`
-		// can read its live freeze/publish health (this is the feed TPD
-		// subscribes to for the visor's transport list).
+		// Wire the chosen publisher into the transport manager so its
+		// register / deregister loops mirror the tp-list snapshot leaf to
+		// TPD's CXO aggregator.
+		if v.tpM != nil {
+			v.tpM.SetTPDLeafPublisher(leafPub)
+		}
+		// Retain the telemetry publisher so `skywire cli visor state
+		// --jq '.cxo'` can read its live freeze/publish health.
 		v.setSystemCXOPub(pub)
 	}
 
@@ -105,6 +124,11 @@ func initStats(_ context.Context, v *Visor, log *logging.Logger) error {
 		err := tracker.Close()
 		if pub != nil {
 			if perr := pub.Close(); perr != nil && err == nil {
+				err = perr
+			}
+		}
+		if tplistPub != nil {
+			if perr := tplistPub.Close(); perr != nil && err == nil {
 				err = perr
 			}
 		}
@@ -132,6 +156,12 @@ func initStats(_ context.Context, v *Visor, log *logging.Logger) error {
 	if pub != nil {
 		if tpdPK, ok := tpdCXOPeer(v); ok {
 			go runAnnounceLoop(v.ctx, pub, tpdPK, log)
+			// Announce the dedicated tp-list feed to TPD too, on its own
+			// port (DmsgVisorTPListCXOPort) — this is the conn TPD's second
+			// aggregator accepts and fills the tiny discovery Root over.
+			if tplistPub != nil {
+				go runAnnounceLoop(v.ctx, tplistPub, tpdPK, log)
+			}
 		} else {
 			log.Debug("Stats: no Transport.DiscoveryDmsg PK; skipping CXO announce loop")
 		}
@@ -237,6 +267,43 @@ func buildStatsPublisher(v *Visor, log *logging.Logger) (*treestore.Publisher, s
 	log.WithField("feed_pk", pub.Feed()).WithField("data_dir", dataDir).
 		Info("Stats: CXO publisher running")
 	return pub, &cxoSink{pub: pub, log: log}
+}
+
+// buildTPListPublisher constructs the visor's DEDICATED transport-list
+// (tp-list) discovery feed: a second CXO node, under the SAME identity
+// keypair as the telemetry publisher (so TPD's reporter=feed-PK edge-auth
+// is unchanged), listening on skyenv.DmsgVisorTPListCXOPort. It carries
+// ONLY the compact tp-list snapshot leaf, so its Root stays a handful of
+// objects and TPD's second aggregator fills it completely in ~1 round-trip
+// — the fix for the busy-hub under-report. Returns nil (and the caller
+// falls back to publishing the tp-list on the telemetry feed) when DMSG
+// isn't available or the publisher fails to start.
+func buildTPListPublisher(v *Visor, log *logging.Logger) *treestore.Publisher {
+	if v.dmsgC == nil {
+		return nil
+	}
+	dataDir := filepath.Join(v.conf.LocalPath, "cxo-tplist")
+	pub, err := treestore.NewWithDMSG(v.dmsgC, v.conf.SK, treestore.PubConfig{
+		// The tp-list changes only on transport churn; a short window keeps
+		// discovery prompt. Each republish is a single small leaf, so the
+		// fill/eviction churn that plagues the big telemetry Root does not
+		// apply here.
+		BatchWindow: 2 * time.Second,
+		Logger:      log,
+		DataDir:     dataDir,
+		DmsgPort:    skyenv.DmsgVisorTPListCXOPort,
+		// Content-addressed, rebuilt from the transport manager's live set
+		// on every publishTPDList — safe to skip per-tx fdatasync.
+		NoSyncCXDS: true,
+	})
+	if err != nil {
+		log.WithError(err).Warn("Stats: dedicated tp-list CXO publisher init failed; " +
+			"falling back to the combined telemetry feed for discovery")
+		return nil
+	}
+	log.WithField("feed_pk", pub.Feed()).WithField("dmsg_port", skyenv.DmsgVisorTPListCXOPort).
+		WithField("data_dir", dataDir).Info("Stats: dedicated tp-list CXO publisher running")
+	return pub
 }
 
 // seedSinkFromStore copies the in-window slice of bbolt state into


### PR DESCRIPTION
On a healthy hub the visor publishes one CXO stats feed (visor key, dmsg port 50) whose Root carries the compact tp-list discovery leaf **plus** ~1100 churning `transports/<uuid>/current` telemetry leaves. TPD must fill the whole Root before it can read the leaf; on a busy hub the delivering conn dies mid-fill, so TPD lands only ~10-13% of the hub's transports (the standing local↔TPD transport gap on long-lived hubs — the visor publishes fine, TPD just can't fill the big churning Root).

This gives the tp-list its **own dedicated CXO feed**: same visor key (TPD authorizes each transport by `entry.EdgeIndex(reporter)` — the reporting key must be an edge, so the tp-list must publish under the visor's key), on a **distinct dmsg port (69)** with its own TPD aggregator node (one CXO node sees one Root per key). Its Root stays tiny — a single inlined leaf, ~4 objects regardless of transport count — and advances **only when the transport list changes**, not on every telemetry heartbeat, so it fills 100% in one round-trip. Telemetry stays on port 50. This is the same multi-port-one-key pattern the deployment already uses (visor CXO on 50 + 67; TPD on 50/51/52/55).

**Proof:** `TestDedicatedTPListFeedFillsCompletely` — at 500 transports the dedicated feed's Root is 4 objects vs the combined feed's 12,207, and it reconciles all 500 while serving only its own telemetry-free objects.

**Back-compat is order-independent** (no TPD-first requirement):
- old visor → new TPD: old visor still carries tp-list on port 50; the port-50 aggregator reconciles it via the existing discovery-leaf fallback.
- new visor → old TPD: the port-50 aggregator no longer finds a tp-list leaf → `fetchDiscoveryLeaf` returns `ok=false` → it **re-applies its last-good snapshot** instead of deregistering, and the new visor still publishes telemetry Roots on port 50 that keep it refreshed. No register/deregister flap during a staggered rollout; newly-added transports on such visors simply aren't discovered until TPD updates.

Build (root only) + vet + gofmt clean; `pkg/services/tpd`, `pkg/transport-discovery/cxoaggregator`, `pkg/skyenv`, `pkg/cxo/treestore`, `pkg/transport`, `pkg/visor` all green.