### PR TITLE
feat(visor): surface the dedicated tp-list CXO feed in visor state

### DIFF
--- a/pkg/visor/cxo_user_feeds.go
+++ b/pkg/visor/cxo_user_feeds.go
@@ -34,6 +34,11 @@ import (
 // so user-registered feeds can't collide with it.
 const systemCXOFeedName = "stats"
 
+// tplistCXOFeedName is the well-known name of the visor's dedicated
+// transport-list discovery feed (the second CXO node initStats wires
+// up on skyenv.DmsgVisorTPListCXOPort).
+const tplistCXOFeedName = "tp-list"
+
 // cxoUserFeed wraps a treestore.Publisher with the metadata needed for
 // /feeds discovery and clean teardown.
 type cxoUserFeed struct {
@@ -212,6 +217,16 @@ func (v *Visor) setSystemCXOPub(pub *treestore.Publisher) {
 	v.cxoUserFeedsMu.Unlock()
 }
 
+// setTPListCXOPub retains the dedicated tp-list discovery feed publisher
+// so CXOFeedStates can read its live PublishState. Called once by
+// initStats; pub is nil when the dedicated publisher didn't start (the
+// combined-feed fallback), in which case no second .cxo entry is emitted.
+func (v *Visor) setTPListCXOPub(pub *treestore.Publisher) {
+	v.cxoUserFeedsMu.Lock()
+	v.tplistCXOPub = pub
+	v.cxoUserFeedsMu.Unlock()
+}
+
 // CXOFeedState pairs a feed's identity (name + dmsg port) with its live
 // publish-health snapshot. Surfaced by StateSnapshot under .cxo.
 type CXOFeedState struct {
@@ -228,6 +243,7 @@ type CXOFeedState struct {
 func (v *Visor) CXOFeedStates() []CXOFeedState {
 	v.cxoUserFeedsMu.Lock()
 	sysPub := v.systemCXOPub
+	tplistPub := v.tplistCXOPub
 	users := make([]*cxoUserFeed, 0, len(v.cxoUserFeeds))
 	for _, fd := range v.cxoUserFeeds {
 		users = append(users, fd)
@@ -240,6 +256,16 @@ func (v *Visor) CXOFeedStates() []CXOFeedState {
 			Name:         systemCXOFeedName,
 			Port:         skyenv.DmsgCXOPort,
 			PublishState: sysPub.PublishState(),
+		})
+	}
+	// The dedicated tp-list discovery feed (a second CXO node under the
+	// same visor PK). nil when initStats fell back to the combined feed —
+	// then there is only the one telemetry entry above.
+	if tplistPub != nil {
+		out = append(out, CXOFeedState{
+			Name:         tplistCXOFeedName,
+			Port:         skyenv.DmsgVisorTPListCXOPort,
+			PublishState: tplistPub.PublishState(),
 		})
 	}
 	for _, fd := range users {

--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -114,8 +114,12 @@ func initStats(_ context.Context, v *Visor, log *logging.Logger) error {
 			v.tpM.SetTPDLeafPublisher(leafPub)
 		}
 		// Retain the telemetry publisher so `skywire cli visor state
-		// --jq '.cxo'` can read its live freeze/publish health.
+		// --jq '.cxo'` can read its live freeze/publish health. Retain
+		// the dedicated tp-list publisher the same way so it surfaces as
+		// a second .cxo entry (nil here = combined-feed fallback, no
+		// second entry).
 		v.setSystemCXOPub(pub)
+		v.setTPListCXOPub(tplistPub)
 	}
 
 	tracker.Run(v.ctx)

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -267,6 +267,16 @@ type Visor struct {
 	// cxoUserFeedsMu. nil until initStats runs (or if Stats.Disabled).
 	systemCXOPub *treestore.Publisher
 
+	// tplistCXOPub is the DEDICATED transport-list discovery feed
+	// publisher (the SECOND CXO node initStats wires under the same visor
+	// identity PK on skyenv.DmsgVisorTPListCXOPort, carrying only the
+	// compact tp-list snapshot leaf). Retained here — beyond being closed
+	// in the stats close-stack — so CXOFeedStates can surface its live
+	// PublishState alongside the telemetry feed. Guarded by
+	// cxoUserFeedsMu. nil when the dedicated publisher didn't start and
+	// initStats fell back to the combined telemetry feed.
+	tplistCXOPub *treestore.Publisher
+
 	// pairing holds the chat-pair feed manager + bbolt store +
 	// inbound message ring. Populated by init_pairing.go after
 	// dmsgC is up. nil when pairing is disabled (dmsgC absent or


### PR DESCRIPTION
The tp-list discovery publisher added in #4152 (a second CXO node under the same visor PK, on `DmsgVisorTPListCXOPort` = 69, carrying only the compact transport-list snapshot leaf) runs but was invisible to `skywire cli visor state --jq '.cxo'`, which only listed the port-50 telemetry feed. Its freeze / leaf_count / secs_since_ok_publish health is exactly what's needed when debugging the visor↔TPD transport-list gap.

Retain the tp-list publisher on the Visor struct alongside the stats publisher and emit it as a second `.cxo` entry with the same `CXOFeedState` shape (name `tp-list`, port 69), so the two feeds are directly comparable. When the dedicated publisher didn't start and initStats fell back to the combined feed, `tplistCXOPub` is nil and no second entry is emitted.

Minimal, no refactor of the introspection. Build + `go test ./pkg/visor/... ./pkg/cxo/...` pass; gofmt and go vet clean.