### PR TITLE
fix(tpd): tp-list CXO aggregator never accepted inbound feeds (node listener bind collision)

### DIFF
--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -327,6 +327,21 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 	}
 
 	cfg := node.NewConfig()
+	// We're DMSG-only — disable the CXO node's default TCP/UDP/RPC
+	// listeners. node.NewConfig defaults TCP.Listen to ":8870" and RPC to
+	// ":8871", and those hardcoded ports mean two Nodes in the same process
+	// collide on bind: NewNode's TCP/RPC Listen returns "address already in
+	// use" and the whole aggregator fails to construct. TPD runs TWO
+	// aggregators in one process (the port-50 telemetry feed and the port-69
+	// tp-list feed), so the SECOND New silently failed here — its node never
+	// came up, so it never dmsg-Listened on its DMSG port and never accepted
+	// the visors' tp-list announces (the persistent visor↔TPD transport-count
+	// gap). None of these listeners are reachable over DMSG anyway; the
+	// publisher path (treestore.NewWithDMSG) already zeroes them for the same
+	// reason.
+	cfg.TCP.Listen = ""
+	cfg.UDP.Listen = ""
+	cfg.RPC = ""
 	// Override the 10m node default: cap hung fills from flapping peers so
 	// their "wanted" objects are released in seconds, not minutes. See the
 	// Config.MaxFillingTime doc for why this is the aggregator's residual

--- a/pkg/transport-discovery/cxoaggregator/two_aggregators_test.go
+++ b/pkg/transport-discovery/cxoaggregator/two_aggregators_test.go
@@ -1,0 +1,146 @@
+// Package cxoaggregator — two_aggregators_test.go: guards the regression
+// where TPD's SECOND CXO aggregator (the dedicated tp-list feed on its own
+// DMSG port, #4152) never accepted inbound visor announces.
+//
+// Root cause: cxoaggregator.New built its CXO node from node.NewConfig(),
+// whose defaults bind a TCP listener on :8870 and an RPC listener on :8871.
+// TPD constructs TWO aggregators in one process on ONE dmsg client (port-50
+// telemetry + port-69 tp-list). The first grabbed :8870/:8871; the second's
+// node.NewNode failed on "address already in use", so New returned an error
+// and the tp-list aggregator was never created — it never dmsg-Listened on
+// its port and never accepted the visors' tp-list announces, leaving TPD's
+// transport count short of what the visors actually publish. The publisher
+// path (treestore.NewWithDMSG) has always zeroed those listeners; the fix
+// does the same in the aggregator.
+//
+// This test builds two aggregators on ONE dmsg client (the second on a
+// distinct port), then drives a real visor publisher on that second port to
+// AnnounceTo the TPD and publish a tp-list leaf, and asserts the SECOND
+// aggregator accepted the announce and reconciled the transport into the
+// sink. It fails before the fix at the second New (bind collision) and
+// passes after.
+package cxoaggregator
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	cxotransport "github.com/skycoin/skywire/pkg/cxo/node/transport"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgtest"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+func TestTwoAggregatorsShareOneClientSecondAccepts(t *testing.T) {
+	const timeout = 30 * time.Second
+
+	env := dmsgtest.NewEnv(t, timeout)
+	require.NoError(t, env.Startup(0, 1, 0, &dmsg.Config{MinSessions: 1}))
+	t.Cleanup(env.Shutdown)
+
+	tpdPK, tpdSK := cipher.GenerateKeyPair()
+	visorPK, visorSK := cipher.GenerateKeyPair()
+	remotePK, _ := cipher.GenerateKeyPair() // the transport's remote edge
+	_ = tpdSK
+
+	tpdClient, err := env.NewClientWithKeys(tpdPK, tpdSK, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err, "tpd dmsg client")
+	visorClient, err := env.NewClientWithKeys(visorPK, visorSK, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err, "visor dmsg client")
+
+	sink := &recordingSink{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// FIRST aggregator: the port-50 telemetry feed. Grabs the node's default
+	// TCP(:8870)/RPC(:8871) listeners in the pre-fix code.
+	agg, err := New(tpdClient, sink, Config{
+		DmsgPort: cxotransport.DefaultCXOPort,
+		Logger:   logging.MustGetLogger("tpd-cxo-aggregator"),
+	})
+	require.NoError(t, err, "first aggregator (port %d)", cxotransport.DefaultCXOPort)
+	t.Cleanup(func() { _ = agg.Close() }) //nolint:errcheck
+	agg.Run(ctx)
+
+	// SECOND aggregator: the dedicated tp-list feed on its own port. This is
+	// the call that returned "address already in use" before the fix, because
+	// its node.NewNode tried to bind :8870 again.
+	tplAgg, err := New(tpdClient, sink, Config{
+		DmsgPort: skyenv.DmsgVisorTPListCXOPort,
+		Logger:   logging.MustGetLogger("tpd-cxo-tplist-aggregator"),
+	})
+	require.NoError(t, err, "second aggregator (port %d) must construct on the shared client",
+		skyenv.DmsgVisorTPListCXOPort)
+	t.Cleanup(func() { _ = tplAgg.Close() }) //nolint:errcheck
+	tplAgg.Run(ctx)
+
+	// Visor-side: a dedicated tp-list publisher on the matching port, under
+	// the visor's own keypair (so reporter == feed PK).
+	pub, err := treestore.NewWithDMSG(visorClient, visorSK, treestore.PubConfig{
+		InMemoryDB:  true,
+		BatchWindow: 5 * time.Millisecond,
+		DmsgPort:    skyenv.DmsgVisorTPListCXOPort,
+		Logger:      logging.MustGetLogger("visor-tplist-pub"),
+	})
+	require.NoError(t, err, "visor tp-list publisher")
+	t.Cleanup(func() { _ = pub.Close() }) //nolint:errcheck
+
+	// Publish the compact tp-list leaf (same wire shape as
+	// manager.publishTPDList): one transport, remote edge + type.
+	body, err := json.Marshal(struct {
+		Version string                   `json:"version,omitempty"`
+		Compact []transport.CompactEntry `json:"c"`
+	}{
+		Version: "v-test",
+		Compact: []transport.CompactEntry{{Remote: remotePK, Type: tptypes.STCP}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, pub.Put("tp-list", body), "publish tp-list leaf")
+
+	// Drive the announce loop by hand: dial the TPD's tp-list aggregator over
+	// dmsg. Retry until the in-process dmsg session is bridgeable.
+	deadline := time.Now().Add(timeout)
+	for {
+		actx, acancel := context.WithTimeout(ctx, 3*time.Second)
+		err = pub.AnnounceTo(actx, tpdPK)
+		acancel()
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("visor could never announce its tp-list feed to the TPD: %v", err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// The SECOND aggregator must accept the inbound announce, subscribe, fill
+	// the tiny Root, and reconcile the transport into the sink — proving it is
+	// actually listening on its DMSG port.
+	wantID := transport.MakeTransportID(visorPK, remotePK, tptypes.STCP)
+	require.Eventuallyf(t, func() bool {
+		sink.mu.Lock()
+		defer sink.mu.Unlock()
+		for _, rec := range sink.reconciles {
+			if rec.reporter != visorPK {
+				continue
+			}
+			for _, e := range rec.entries {
+				if e.ID == wantID {
+					return true
+				}
+			}
+		}
+		return false
+	}, timeout, 100*time.Millisecond,
+		"tp-list transport %s never reconciled through the second aggregator", wantID)
+}


### PR DESCRIPTION
TPD's second CXO aggregator — the dedicated tp-list discovery feed on its own DMSG port (#4152) — never accepted the visors' announces, so the visor↔TPD transport-count gap persisted (TPD reflected ~8% of a busy hub's transports while a fresh third-party subscriber saw the full list on the visor's port-69 feed).

**Root cause.** `cxoaggregator.New` builds its CXO node from `node.NewConfig()`, whose defaults bind a TCP listener on `:8870` and an RPC listener on `:8871`. TPD constructs two aggregators in one process on one dmsg client (port-50 telemetry + port-69 tp-list). The first grabbed `:8870`/`:8871`; the second's `node.NewNode` then failed with `listen tcp :8870: bind: address already in use`, so `New` returned an error and the tp-list aggregator was never created. It never dmsg-Listened on port 69 and never accepted the visors' tp-list feeds — the visor's port-69 dial timed out.

The visor side (three `treestore` publishers sharing one dmsg client on ports 50/67/69) works precisely because the publisher path (`treestore.NewWithDMSG`) has always zeroed those built-in listeners for this same reason.

**Fix.** Disable the node's TCP/UDP/RPC listeners in the aggregator too — they are unreachable over DMSG and only exist to collide.

Adds an integration test that stands up two aggregators on one dmsg client (second on a distinct port) and drives a real visor publisher's tp-list announce through the second aggregator into the sink. It fails before this change at the second `New` (`bind: address already in use`) and passes after.

`go build .` clean; `go test ./pkg/transport-discovery/... ./pkg/services/tpd/... ./pkg/cxo/...` green; new test stable under `-race -count=5`; gofmt/vet clean.