### PR TITLE
fix(stats): prune persisted dead-transport current leaves; introspect feed live/dead

### DIFF
--- a/pkg/visor/cxo_user_feeds.go
+++ b/pkg/visor/cxo_user_feeds.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/cmd/apps/skychat/pairing"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -233,6 +235,42 @@ type CXOFeedState struct {
 	Name string `json:"name"`
 	Port uint16 `json:"port,omitempty"`
 	treestore.PublishState
+	// CurrentLeaves is populated only for the "stats" telemetry feed: it
+	// breaks down the transports/<id>/current leaves the feed carries by
+	// whether each leaf's transport is currently live. Dead > 0 quantifies
+	// the stale-leaf bloat that Fix 1 (pruneDeadCurrentLeaves) removes at
+	// startup and reconcileCurrentLeaves keeps out at steady state.
+	CurrentLeaves *CurrentLeafStats `json:"current_leaves,omitempty"`
+}
+
+// CurrentLeafStats is the live/dead breakdown of the telemetry feed's
+// transports/<id>/current leaf set, computed as the feed's current-leaf
+// path list intersected with the visor's live transport set.
+type CurrentLeafStats struct {
+	Total int `json:"total"`
+	Live  int `json:"live"`
+	Dead  int `json:"dead"`
+}
+
+// currentLeafStats walks the publisher's transports/<id>/current leaves
+// and classifies each by whether its transport is in liveIDs. Cheap: an
+// in-memory tree walk plus a map lookup per leaf.
+func currentLeafStats(pub *treestore.Publisher, liveIDs map[uuid.UUID]struct{}) CurrentLeafStats {
+	var st CurrentLeafStats
+	pub.Walk("transports", func(path string, _ []byte) bool {
+		id, ok := currentLeafUUID(path)
+		if !ok {
+			return true
+		}
+		st.Total++
+		if _, live := liveIDs[id]; live {
+			st.Live++
+		} else {
+			st.Dead++
+		}
+		return true
+	})
+	return st
 }
 
 // CXOFeedStates returns the live PublishState of the system telemetry
@@ -252,10 +290,15 @@ func (v *Visor) CXOFeedStates() []CXOFeedState {
 
 	var out []CXOFeedState
 	if sysPub != nil {
+		// Live/dead current-leaf breakdown for the telemetry feed: the
+		// feed's own current-leaf paths ∩ the live transport set. Directly
+		// quantifies the dead-leaf bloat that starves TPD's Root fill.
+		cls := currentLeafStats(sysPub, liveTransportIDs(v))
 		out = append(out, CXOFeedState{
-			Name:         systemCXOFeedName,
-			Port:         skyenv.DmsgCXOPort,
-			PublishState: sysPub.PublishState(),
+			Name:          systemCXOFeedName,
+			Port:          skyenv.DmsgCXOPort,
+			PublishState:  sysPub.PublishState(),
+			CurrentLeaves: &cls,
 		})
 	}
 	// The dedicated tp-list discovery feed (a second CXO node under the

--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -87,6 +87,19 @@ func initStats(_ context.Context, v *Visor, log *logging.Logger) error {
 			log.WithError(err).Warn("Stats: hydrating CXO publisher from bbolt failed")
 		}
 		tracker.SeedMirroredCurrent(liveIDs)
+		// The publisher hydrates its in-memory tree from the previously-
+		// published Root on startup, so transports/<id>/current leaves for
+		// transports that closed while the visor was down are back on the
+		// feed. They never entered the tracker's mirroredCurrent set (which
+		// only tracks leaves Put since this restart), so the per-tick
+		// reconcile would never prune them. Reconcile them away now, at
+		// hydrate, against the actual live set — making the discovery feed
+		// truly live-only rather than "live-only for leaves written since
+		// the last restart".
+		if pruned := pruneDeadCurrentLeaves(pub, sink, liveIDs); pruned > 0 {
+			log.WithField("pruned", pruned).
+				Info("Stats: pruned dead-transport current leaves persisted on the telemetry feed")
+		}
 		tracker.SetSink(sink)
 
 		// Dedicated tp-list discovery feed: a SECOND CXO node under the
@@ -344,6 +357,52 @@ func liveTransportIDs(v *Visor) map[uuid.UUID]struct{} {
 		return true
 	})
 	return out
+}
+
+// currentLeafUUID parses a telemetry-feed leaf path of the form
+// "transports/<uuid>/current" and returns the transport UUID. ok is
+// false for any path that isn't a well-formed current-snapshot leaf.
+func currentLeafUUID(path string) (uuid.UUID, bool) {
+	segs := strings.Split(path, "/")
+	if len(segs) != 3 || segs[0] != "transports" || segs[2] != "current" {
+		return uuid.UUID{}, false
+	}
+	id, err := uuid.Parse(segs[1])
+	if err != nil {
+		return uuid.UUID{}, false
+	}
+	return id, true
+}
+
+// pruneDeadCurrentLeaves makes the telemetry feed truly live-only at
+// startup. It walks the publisher's existing transports/<id>/current
+// leaves — including any hydrated from the previously-published Root —
+// and sink-deletes every one whose transport isn't in liveIDs. Returns
+// the number pruned.
+//
+// Deletes are collected during the walk and issued after it returns:
+// Publisher.Walk holds the publisher mutex across the visitor and
+// sink.Delete re-enters that mutex through the cxoSink, so deleting
+// inline would deadlock.
+func pruneDeadCurrentLeaves(pub *treestore.Publisher, sink stats.Sink, liveIDs map[uuid.UUID]struct{}) int {
+	if pub == nil || sink == nil {
+		return 0
+	}
+	var stale []string
+	pub.Walk("transports", func(path string, _ []byte) bool {
+		id, ok := currentLeafUUID(path)
+		if !ok {
+			return true
+		}
+		if _, live := liveIDs[id]; !live {
+			stale = append(stale, path)
+		}
+		return true
+	})
+	for _, path := range stale {
+		sink.Delete(path)
+	}
+	return len(stale)
 }
 
 // cxoSink adapts a treestore.Publisher to the stats.Sink contract.

--- a/pkg/visor/init_stats_prune_test.go
+++ b/pkg/visor/init_stats_prune_test.go
@@ -1,0 +1,96 @@
+// Package visor pkg/visor/init_stats_prune_test.go
+//
+// Pins the telemetry-feed live-only invariant: after a visor restart the
+// CXO publisher hydrates its in-memory tree from the previously-published
+// Root, bringing back transports/<id>/current leaves for transports that
+// closed while the visor was down. pruneDeadCurrentLeaves must reconcile
+// every such dead leaf away at startup — not just the ones (re-)written
+// since the restart — so the discovery feed TPD fills stays truly
+// live-only and doesn't accumulate stale-transport bloat across reboots.
+package visor
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+func currentPath(id uuid.UUID) string { return "transports/" + id.String() + "/current" }
+
+func TestPruneDeadCurrentLeavesAfterHydrate(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "cxo-stats")
+	_, sk := cipher.GenerateKeyPair()
+	log := logging.MustGetLogger("test-stats-prune")
+
+	live1, live2 := uuid.New(), uuid.New()
+	dead1, dead2 := uuid.New(), uuid.New()
+
+	// Session 1: publish two live + two dead current leaves, then close so
+	// the Root persists to the on-disk CXO container.
+	pub1, err := treestore.NewWithTCP("127.0.0.1:0", sk, treestore.PubConfig{
+		DataDir:     dir,
+		BatchWindow: 5 * time.Millisecond,
+	})
+	require.NoError(t, err, "session 1 publisher")
+	for _, id := range []uuid.UUID{live1, live2, dead1, dead2} {
+		require.NoError(t, pub1.Put(currentPath(id), []byte(`{"sent_bytes":1}`)))
+	}
+	require.NoError(t, pub1.Flush())
+	require.NoError(t, pub1.Close())
+
+	// Session 2: reopen the same DataDir. hydrateFromContainer rebuilds the
+	// in-memory tree with all four current leaves — the post-restart state
+	// in which dead1/dead2 belong to transports that are no longer live.
+	pub2, err := treestore.NewWithTCP("127.0.0.1:0", sk, treestore.PubConfig{
+		DataDir:     dir,
+		BatchWindow: 5 * time.Millisecond,
+	})
+	require.NoError(t, err, "session 2 publisher")
+	defer func() { _ = pub2.Close() }()
+
+	// Sanity: hydrate brought all four leaves back onto the feed.
+	sink := &cxoSink{pub: pub2, log: log}
+	liveIDs := map[uuid.UUID]struct{}{live1: {}, live2: {}}
+	require.Equal(t, CurrentLeafStats{Total: 4, Live: 2, Dead: 2},
+		currentLeafStats(pub2, liveIDs), "all four current leaves present after hydrate")
+
+	// Prune against the actual live set.
+	require.Equal(t, 2, pruneDeadCurrentLeaves(pub2, sink, liveIDs), "both dead leaves pruned")
+
+	// Only the live leaves remain.
+	require.Equal(t, CurrentLeafStats{Total: 2, Live: 2, Dead: 0},
+		currentLeafStats(pub2, liveIDs), "only live current leaves remain after prune")
+	for _, id := range []uuid.UUID{live1, live2} {
+		_, ok := pub2.Get(currentPath(id))
+		require.True(t, ok, "live leaf %s should remain", id)
+	}
+	for _, id := range []uuid.UUID{dead1, dead2} {
+		_, ok := pub2.Get(currentPath(id))
+		require.False(t, ok, "dead leaf %s should be pruned", id)
+	}
+}
+
+func TestCurrentLeafUUIDParsing(t *testing.T) {
+	id := uuid.New()
+	got, ok := currentLeafUUID("transports/" + id.String() + "/current")
+	require.True(t, ok)
+	require.Equal(t, id, got)
+
+	for _, bad := range []string{
+		"transports/" + id.String(),                 // no /current
+		"transports/" + id.String() + "/2026-01-01", // rollup date, not current
+		"transports/not-a-uuid/current",
+		"tiers/dmsg/2026-01-01",
+		"transports/" + id.String() + "/current/extra",
+	} {
+		_, ok := currentLeafUUID(bad)
+		require.False(t, ok, "path %q must not parse as a current leaf", bad)
+	}
+}


### PR DESCRIPTION
The visor's port-50 telemetry CXO feed is meant to be live-only: one `transports/<id>/current` leaf per LIVE transport, so TPD can fill the Root over a short announce conn. `reconcileCurrentLeaves` already deletes a current leaf when its transport closes at runtime, but it only diffs against `mirroredCurrent` — the set the tracker has Put since the last restart. The publisher hydrates its in-memory tree from the previously-published Root on startup, so a transport that closed while the visor was down comes back as a current leaf that never enters `mirroredCurrent` and is never pruned. These persisted-dead leaves accumulate across reboots and bloat the Root (observed ~1629 leaves vs ~1120 live transports).

**Fix 1** — at hydrate, walk the feed's existing `transports/<id>/current` leaves and sink-delete every one whose transport isn't live now, so the feed is truly live-only rather than "live-only for leaves written since restart".

**Fix 2** — report the feed's current-leaf shape (total / live / dead) for the stats feed under `skywire cli visor state` `.cxo`, computed from the publisher's leaf paths intersected with the live transport set — so the bloat is a single query against the running visor, local or `--via`.

Adds a restart-hydrate unit test (close + reopen the on-disk container, assert the dead leaves are pruned and only live remain) and a path-parser test. `go build .`, `go test ./pkg/visor/... ./pkg/cxo/...`, gofmt and go vet all clean.