### PR TITLE
feat(proxystatus): per-app event/log ring; populate status Events+Logs; add `proxy log`

### DIFF
--- a/cmd/skywire-cli/commands/proxy/log.go
+++ b/cmd/skywire-cli/commands/proxy/log.go
@@ -1,0 +1,94 @@
+// Package skysocksc cmd/skywire-cli/commands/proxy/log.go c4-vis-cli
+package skysocksc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+)
+
+var (
+	logFollow bool
+	logLevel  string
+)
+
+func init() {
+	RootCmd.AddCommand(logCmd)
+	logCmd.Flags().StringVarP(&clientName, "name", "n", "skysocks-client", "name of the skysocks client to attach to")
+	logCmd.Flags().BoolVarP(&logFollow, "follow", "f", false, "follow: keep streaming new events (ctrl+c detaches without stopping the proxy); off = print recent and exit")
+	logCmd.Flags().StringVar(&logLevel, "level", "debug", "minimum log level: trace|debug|info|warn|error")
+}
+
+var logCmd = &cobra.Command{
+	Use:   "log",
+	Short: "Stream a running proxy client's route/transport events + log",
+	Long: `Attach to an already-running skysocks client and show its app-scoped
+route/transport events + app log — the same class of lines the proxy
+status page (http://status.skysocks/) and the route interstitial render.
+
+This is attach-only: it never starts or stops the app. Ctrl+C detaches
+and leaves the running proxy untouched.
+
+  proxy log                 print the recent events + log for skysocks-client
+  proxy log -f              follow: print recent, then stream new events live
+  proxy log -n myclient     attach to a differently-named client
+  proxy log --level trace   include trace-level entries`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		if clientName == "" {
+			clientName = "skysocks-client"
+		}
+
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
+		}
+		defer rpcClient.Close() //nolint:errcheck,gosec
+
+		// Recent history first (the "same as the status page" view): the
+		// per-app ring already holds the route setup / mux lines even if
+		// nothing new is happening on an established session.
+		recent, err := rpcClient.RecentAppLog(clientName, logLevel)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to fetch recent app log: %w", err))
+		}
+		for _, ln := range recent {
+			fmt.Fprintln(os.Stdout, ln)
+		}
+
+		if !logFollow {
+			if len(recent) == 0 {
+				fmt.Fprintf(os.Stderr, "no recent events for %q (is the proxy running? try -f to wait for new ones)\n", clientName)
+			}
+			return
+		}
+
+		// Follow mode: attach the live gRPC stream (the SAME mechanism
+		// `proxy start --verbose` uses) scoped to this app's session, to
+		// stdout. We do NOT touch the app — ctrl+c just cancels ctx and
+		// detaches.
+		ctx, cancel := cmdutil.SignalContext(context.Background(), &logrus.Logger{})
+		defer cancel()
+
+		vs, err := clirpc.OpenVerboseTo(ctx, clirpc.Addr, clirpc.VerboseFilter{
+			AppName: clientName,
+			Level:   logLevel,
+		}, os.Stdout)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		_ = vs.WaitSubscribed(ctx, 2*time.Second) //nolint:errcheck
+		fmt.Fprintf(os.Stderr, "--- attached to %q; streaming events (ctrl+c to detach) ---\n", clientName)
+
+		<-ctx.Done()
+		fmt.Fprintln(os.Stderr, "detaching...")
+		vs.Close()
+	},
+}

--- a/cmd/skywire-cli/commands/rpc/verbose.go
+++ b/cmd/skywire-cli/commands/rpc/verbose.go
@@ -68,6 +68,14 @@ type VerboseStream struct {
 // rpcAddr is typically clirpc.Addr; the gRPC server is multiplexed
 // onto the same port as the standard RPC server via cmux.
 func OpenVerbose(ctx context.Context, rpcAddr string, filter VerboseFilter) (*VerboseStream, error) {
+	return OpenVerboseTo(ctx, rpcAddr, filter, os.Stderr)
+}
+
+// OpenVerboseTo is OpenVerbose with an explicit destination writer for
+// the formatted entries. `proxy start --verbose` streams to stderr (via
+// OpenVerbose); `cli proxy log` streams to stdout so the log is the
+// command's primary output. Behavior is otherwise identical.
+func OpenVerboseTo(ctx context.Context, rpcAddr string, filter VerboseFilter, w io.Writer) (*VerboseStream, error) {
 	if filter.AppName == "" && len(filter.Modules) == 0 {
 		return nil, errors.New("verbose: filter requires AppName or Modules")
 	}
@@ -89,7 +97,7 @@ func OpenVerbose(ctx context.Context, rpcAddr string, filter VerboseFilter) (*Ve
 		defer close(v.done)
 		defer grpcClient.Close() //nolint:errcheck,gosec
 		err := grpcClient.StreamAppLogs(ctx, filter.AppName, false, level, filter.Modules, v.subscribed, func(e *rpcgrpc.AppLogEntry) {
-			emitEntry(os.Stderr, e)
+			emitEntry(w, e)
 		})
 		if err != nil && ctx.Err() == nil {
 			fmt.Fprintf(os.Stderr, "verbose stream ended: %v\n", err)

--- a/pkg/logging/broadcaster.go
+++ b/pkg/logging/broadcaster.go
@@ -20,11 +20,21 @@ import (
 type Broadcaster struct {
 	mu   sync.RWMutex
 	subs map[*subscription]struct{}
+
+	// ring is a bounded per-app history captured from the same Fire path
+	// that feeds live subscribers (see ring.go). It lets the proxy status
+	// page / `cli proxy log` read back recent app-scoped events + logs
+	// without having held a subscription open.
+	ringMu sync.Mutex
+	rings  map[string]*appRing
 }
 
 // NewBroadcaster constructs an empty Broadcaster.
 func NewBroadcaster() *Broadcaster {
-	return &Broadcaster{subs: make(map[*subscription]struct{})}
+	return &Broadcaster{
+		subs:  make(map[*subscription]struct{}),
+		rings: make(map[string]*appRing),
+	}
 }
 
 // Filter selects which entries reach a subscriber.
@@ -86,6 +96,9 @@ func (b *Broadcaster) Fire(e *logrus.Entry) error {
 		}
 	}
 	b.mu.RUnlock()
+	// Capture into the bounded per-app ring for later read-back. Same tap,
+	// not a second sink.
+	b.record(e)
 	return nil
 }
 

--- a/pkg/logging/ring.go
+++ b/pkg/logging/ring.go
@@ -1,0 +1,276 @@
+// Package logging pkg/logging/ring.go c0-com-log
+//
+// Per-app ring buffer on top of the Broadcaster hook.
+//
+// The Broadcaster is already the single logrus hook the visor installs on its
+// master logger, so its Fire sees every entry. In addition to fanning entries
+// out to live subscribers (the `--verbose` gRPC stream), it records the most
+// recent app-scoped entries into a small bounded ring keyed by app name. This
+// lets a consumer (the proxy status page, `cli proxy log`) read back the recent
+// route/transport events and app log lines for one app WITHOUT having held a
+// subscription open the whole time — reusing the exact same tap the verbose
+// stream uses rather than adding a second log sink.
+//
+// Two buckets per app:
+//
+//   - events: layered router / route-group / transport / setup / mux entries
+//     that happen on behalf of the app (tagged app_name=<n> by the router's
+//     scopedLog / RouteGroup.SetAppName). These are the "[router] …" /
+//     "[RouteGroup …] …" lines.
+//   - logs: the app's own output (_module=proc:<app>:<key> / app:<app>).
+//
+// Both are bounded (ringPerApp) and the number of tracked apps is capped
+// (ringMaxApps, LRU-evicted) so memory never grows unbounded.
+package logging
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// ringMaxApps bounds how many distinct app names the ring tracks at
+	// once; the least-recently-seen app is evicted when a new one arrives
+	// past this cap.
+	ringMaxApps = 32
+	// ringPerApp bounds each app's events bucket and (separately) its logs
+	// bucket. Matches the status renderer's maxLogLines cap so nothing is
+	// captured that could never be shown.
+	ringPerApp = 200
+)
+
+// Record is a value-copy snapshot of a logrus entry captured into the ring.
+// The entry pointer itself must never be retained — logrus pools and reuses
+// Entry values after Fire returns — so the fields we care about are copied out
+// at capture time.
+type Record struct {
+	Time    time.Time
+	Level   logrus.Level
+	Module  string
+	Message string
+	Fields  map[string]string
+	// IsEvent is true for a layered route/transport event (events bucket),
+	// false for the app's own log output (logs bucket).
+	IsEvent bool
+}
+
+type appRing struct {
+	events   []Record
+	logs     []Record
+	lastSeen time.Time
+}
+
+// record captures e into the per-app ring when it resolves to an app. Called
+// from Fire on the hot logging path, so it does the cheap app-resolution first
+// and only locks/copies when there is a bucket to write.
+func (b *Broadcaster) record(e *logrus.Entry) {
+	module := ""
+	if v, ok := e.Data[logModuleKey]; ok {
+		if m, ok := v.(string); ok {
+			module = m
+		}
+	}
+
+	app := ""
+	isEvent := false
+	if a := appFromModule(module); a != "" {
+		app = a // app's own output → logs bucket
+	} else if a := appFromFields(e); a != "" {
+		app = a // layered (router/rg/tp) entry tagged with the app → events bucket
+		isEvent = true
+	}
+	if app == "" {
+		return
+	}
+
+	rec := Record{
+		Time:    e.Time,
+		Level:   e.Level,
+		Module:  module,
+		Message: e.Message,
+		IsEvent: isEvent,
+	}
+	if len(e.Data) > 0 {
+		rec.Fields = make(map[string]string, len(e.Data))
+		for k, v := range e.Data {
+			if k == logModuleKey {
+				continue
+			}
+			if s, ok := v.(string); ok {
+				rec.Fields[k] = s
+			} else {
+				rec.Fields[k] = fmt.Sprintf("%v", v)
+			}
+		}
+	}
+
+	b.ringMu.Lock()
+	defer b.ringMu.Unlock()
+	if b.rings == nil {
+		b.rings = make(map[string]*appRing)
+	}
+	r := b.rings[app]
+	if r == nil {
+		if len(b.rings) >= ringMaxApps {
+			b.evictOldestLocked()
+		}
+		r = &appRing{}
+		b.rings[app] = r
+	}
+	r.lastSeen = rec.Time
+	if isEvent {
+		r.events = appendCapped(r.events, rec)
+	} else {
+		r.logs = appendCapped(r.logs, rec)
+	}
+}
+
+// RecentByApp returns copies of the recent events and logs captured for app,
+// filtered to entries at least as severe as minLevel, oldest first. Returns
+// nil, nil when nothing has been captured for the app.
+func (b *Broadcaster) RecentByApp(app string, minLevel logrus.Level) (events, logs []Record) {
+	if b == nil || app == "" {
+		return nil, nil
+	}
+	b.ringMu.Lock()
+	defer b.ringMu.Unlock()
+	r := b.rings[app]
+	if r == nil {
+		return nil, nil
+	}
+	return filterByLevel(r.events, minLevel), filterByLevel(r.logs, minLevel)
+}
+
+// RecentMerged returns events+logs for app merged into a single time-ordered
+// slice (oldest first), filtered by minLevel. This is the "reading the log"
+// view `cli proxy log` prints.
+func (b *Broadcaster) RecentMerged(app string, minLevel logrus.Level) []Record {
+	events, logs := b.RecentByApp(app, minLevel)
+	if len(events) == 0 && len(logs) == 0 {
+		return nil
+	}
+	out := make([]Record, 0, len(events)+len(logs))
+	out = append(out, events...)
+	out = append(out, logs...)
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Time.Before(out[j].Time) })
+	return out
+}
+
+func filterByLevel(in []Record, minLevel logrus.Level) []Record {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Record, 0, len(in))
+	for _, r := range in {
+		// logrus levels descend from Panic(0) to Trace(6): "at least as
+		// severe as minLevel" means a numerically smaller-or-equal level.
+		if r.Level <= minLevel {
+			out = append(out, r)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// evictOldestLocked drops the least-recently-seen app. Caller holds ringMu.
+func (b *Broadcaster) evictOldestLocked() {
+	var oldestKey string
+	var oldest time.Time
+	first := true
+	for k, r := range b.rings {
+		if first || r.lastSeen.Before(oldest) {
+			oldestKey = k
+			oldest = r.lastSeen
+			first = false
+		}
+	}
+	if oldestKey != "" {
+		delete(b.rings, oldestKey)
+	}
+}
+
+func appendCapped(buf []Record, rec Record) []Record {
+	buf = append(buf, rec)
+	if len(buf) > ringPerApp {
+		// Drop the oldest, keeping the tail. Copy down so the backing
+		// array doesn't grow without bound.
+		n := copy(buf, buf[len(buf)-ringPerApp:])
+		buf = buf[:n]
+	}
+	return buf
+}
+
+// recordFormatter renders a captured Record the same way the visor's
+// MasterLogger (and the `--verbose` gRPC stream) render a live entry, so a
+// read-back line is byte-identical to what streamed live.
+var recordFormatter = &TextFormatter{
+	FullTimestamp:      true,
+	AlwaysQuoteStrings: true,
+	QuoteEmptyFields:   true,
+	ForceFormatting:    true,
+	TimestampFormat:    "2006-01-02T15:04:05.0000Z07:00",
+}
+
+// Format renders the Record as a single log line (no trailing newline),
+// matching the visor's text log format: [timestamp] LEVEL [module]: message
+// key=value…
+func (r Record) Format() string {
+	data := logrus.Fields{}
+	if r.Module != "" {
+		data[logModuleKey] = r.Module
+	}
+	for k, v := range r.Fields {
+		data[k] = v
+	}
+	entry := &logrus.Entry{
+		Time:    r.Time,
+		Level:   r.Level,
+		Message: r.Message,
+		Data:    data,
+	}
+	b, err := recordFormatter.Format(entry)
+	if err != nil {
+		return fmt.Sprintf("[%s] %s [%s]: %s", r.Time.Format(time.RFC3339Nano), r.Level, r.Module, r.Message)
+	}
+	return strings.TrimRight(string(b), "\n")
+}
+
+// appFromModule extracts the app name from a proc/app-scoped _module value
+// (proc:<app>:<key> or app:<app>[:<key>]). Returns "" for layered-module
+// entries (router, RouteGroup …, transport) which are resolved via fields.
+func appFromModule(module string) string {
+	if rest, ok := strings.CutPrefix(module, "proc:"); ok {
+		if app, _, ok := strings.Cut(rest, ":"); ok {
+			return app
+		}
+		return rest
+	}
+	if rest, ok := strings.CutPrefix(module, "app:"); ok {
+		if app, _, ok := strings.Cut(rest, ":"); ok {
+			return app
+		}
+		return rest
+	}
+	return ""
+}
+
+// appFromFields resolves the originating app from the entry's fields. The
+// visor's layers use different field names for the same thing (router rg-scoped
+// logs use app_name; proc-manager uses app/appName; launcher uses cmd), so any
+// of them names the app.
+func appFromFields(e *logrus.Entry) string {
+	for _, k := range []string{"app_name", "app", "appName", "cmd"} {
+		if v, ok := e.Data[k]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/logging/ring_test.go
+++ b/pkg/logging/ring_test.go
@@ -1,0 +1,141 @@
+// Package logging pkg/logging/ring_test.go c0-com-log
+package logging
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func fireEntry(b *Broadcaster, level logrus.Level, module, msg string, fields logrus.Fields) {
+	data := logrus.Fields{}
+	if module != "" {
+		data[logModuleKey] = module
+	}
+	for k, v := range fields {
+		data[k] = v
+	}
+	_ = b.Fire(&logrus.Entry{
+		Time:    time.Now(),
+		Level:   level,
+		Message: msg,
+		Data:    data,
+	})
+}
+
+func TestRingClassifiesEventsAndLogs(t *testing.T) {
+	b := NewBroadcaster()
+
+	// Layered router entry tagged with app_name → events bucket.
+	fireEntry(b, logrus.InfoLevel, "router", "Requesting new routes", logrus.Fields{"app_name": "skysocks-client"})
+	// RouteGroup entry tagged with app_name → events bucket.
+	fireEntry(b, logrus.DebugLevel, "RouteGroup abc", "Sent handshake via transport", logrus.Fields{"app_name": "skysocks-client"})
+	// App's own stdout (proc:<app>:<key>) → logs bucket.
+	fireEntry(b, logrus.InfoLevel, "proc:skysocks-client:xyz", "App is Running", nil)
+	// Unrelated entry with no app association → dropped.
+	fireEntry(b, logrus.InfoLevel, "dmsg", "some dmsg thing", nil)
+
+	events, logs := b.RecentByApp("skysocks-client", logrus.DebugLevel)
+	if len(events) != 2 {
+		t.Fatalf("want 2 events, got %d: %+v", len(events), events)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("want 1 log, got %d: %+v", len(logs), logs)
+	}
+	if !events[0].IsEvent || events[1].IsEvent == false {
+		t.Fatalf("events should be marked IsEvent")
+	}
+	if logs[0].IsEvent {
+		t.Fatalf("log line should not be marked IsEvent")
+	}
+
+	// Nothing captured for an unknown app.
+	e2, l2 := b.RecentByApp("other", logrus.DebugLevel)
+	if len(e2) != 0 || len(l2) != 0 {
+		t.Fatalf("unknown app should be empty, got %d/%d", len(e2), len(l2))
+	}
+}
+
+func TestRingLevelFilter(t *testing.T) {
+	b := NewBroadcaster()
+	fireEntry(b, logrus.TraceLevel, "router", "trace line", logrus.Fields{"app_name": "app1"})
+	fireEntry(b, logrus.InfoLevel, "router", "info line", logrus.Fields{"app_name": "app1"})
+
+	// At info level, the trace entry is excluded.
+	events, _ := b.RecentByApp("app1", logrus.InfoLevel)
+	if len(events) != 1 {
+		t.Fatalf("info filter: want 1 event, got %d", len(events))
+	}
+	// At trace level, both are included.
+	events, _ = b.RecentByApp("app1", logrus.TraceLevel)
+	if len(events) != 2 {
+		t.Fatalf("trace filter: want 2 events, got %d", len(events))
+	}
+}
+
+func TestRingBounded(t *testing.T) {
+	b := NewBroadcaster()
+	for i := 0; i < ringPerApp+50; i++ {
+		fireEntry(b, logrus.InfoLevel, "router", "line", logrus.Fields{"app_name": "app1"})
+	}
+	events, _ := b.RecentByApp("app1", logrus.DebugLevel)
+	if len(events) != ringPerApp {
+		t.Fatalf("ring should cap at %d, got %d", ringPerApp, len(events))
+	}
+}
+
+func TestRingMaxAppsEviction(t *testing.T) {
+	b := NewBroadcaster()
+	for i := 0; i < ringMaxApps+5; i++ {
+		app := "app" + string(rune('A'+i%26)) + string(rune('0'+i/26))
+		fireEntry(b, logrus.InfoLevel, "router", "line", logrus.Fields{"app_name": app})
+	}
+	b.ringMu.Lock()
+	n := len(b.rings)
+	b.ringMu.Unlock()
+	if n > ringMaxApps {
+		t.Fatalf("tracked apps should cap at %d, got %d", ringMaxApps, n)
+	}
+}
+
+func TestRecordFormat(t *testing.T) {
+	r := Record{
+		Time:    time.Unix(0, 0).UTC(),
+		Level:   logrus.InfoLevel,
+		Module:  "router",
+		Message: "Created new routes",
+		Fields:  map[string]string{"app_name": "skysocks-client"},
+	}
+	line := r.Format()
+	if line == "" {
+		t.Fatalf("Format returned empty line")
+	}
+	if got := line[len(line)-1]; got == '\n' {
+		t.Fatalf("Format should not end with newline")
+	}
+}
+
+func TestRecentMergedOrdered(t *testing.T) {
+	b := NewBroadcaster()
+	base := time.Now()
+	// Interleave events and logs with explicit times.
+	push := func(mod, msg string, fields logrus.Fields, at time.Time) {
+		data := logrus.Fields{logModuleKey: mod}
+		for k, v := range fields {
+			data[k] = v
+		}
+		_ = b.Fire(&logrus.Entry{Time: at, Level: logrus.InfoLevel, Message: msg, Data: data})
+	}
+	push("proc:app1:k", "log-early", nil, base)
+	push("router", "event-mid", logrus.Fields{"app_name": "app1"}, base.Add(time.Second))
+	push("proc:app1:k", "log-late", nil, base.Add(2*time.Second))
+
+	merged := b.RecentMerged("app1", logrus.DebugLevel)
+	if len(merged) != 3 {
+		t.Fatalf("want 3 merged, got %d", len(merged))
+	}
+	if merged[0].Message != "log-early" || merged[1].Message != "event-mid" || merged[2].Message != "log-late" {
+		t.Fatalf("merged not time-ordered: %s, %s, %s", merged[0].Message, merged[1].Message, merged[2].Message)
+	}
+}

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -18,6 +18,11 @@ const refreshSeconds = 4
 // bottom (terminal-tail order). The Provider may return fewer.
 const maxLogLines = 200
 
+// maxEventLines caps how many recent route/transport event lines the page
+// renders (oldest first, matching the Provider's ordering). The Provider may
+// return fewer.
+const maxEventLines = 200
+
 // Render returns the full, self-contained HTML status page for snap. All
 // interpolated values are HTML-escaped; the page loads no external resource
 // (matching the proxies' strict no-network serving context).
@@ -493,8 +498,12 @@ func writeEventsSection(b *strings.Builder, snap Snapshot) {
 		// drop) is an extension point — see the control seam below.
 		b.WriteString(`<p class="empty">No route or transport events captured for this surface yet.</p>`)
 	} else {
+		events := snap.Events
+		if len(events) > maxEventLines {
+			events = events[len(events)-maxEventLines:]
+		}
 		b.WriteString(`<ul class="events">`)
-		for _, e := range snap.Events {
+		for _, e := range events {
 			fmt.Fprintf(b, `<li>%s</li>`, html.EscapeString(e))
 		}
 		b.WriteString(`</ul>`)

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -115,6 +115,7 @@ type API interface {
 	SetAppLauncherMode(appName, mode string) error
 	AppHelp(appName string) (string, error)
 	LogsSince(timestamp time.Time, appName string) ([]string, error)
+	RecentAppLog(appName, level string) ([]string, error)
 	GetAppStats(appName string) (appserver.AppStats, error)
 	GetAppError(appName string) (string, error)
 	GetAppConnectionsSummary(appName string) ([]appserver.ConnectionSummary, error)

--- a/pkg/visor/api_apps.go
+++ b/pkg/visor/api_apps.go
@@ -15,10 +15,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/skycoin/skywire/pkg/app/appcommon"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/router/policy"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
@@ -894,6 +897,23 @@ func (v *Visor) LogsSince(timestamp time.Time, appName string) ([]string, error)
 	}
 
 	return res, nil
+}
+
+// RecentAppLog implements API. It returns the recent app-scoped route/transport
+// events + log lines captured for appName by the log broadcaster's per-app
+// ring, merged into one time-ordered slice and formatted as visor log lines.
+// level is the minimum severity ("trace".."error"; empty defaults to "debug").
+func (v *Visor) RecentAppLog(appName, level string) ([]string, error) {
+	minLevel, err := logging.LevelFromString(level)
+	if err != nil {
+		minLevel = logrus.DebugLevel
+	}
+	recs := v.RecentAppLogMerged(appName, minLevel)
+	out := make([]string, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, r.Format())
+	}
+	return out, nil
 }
 
 // GetAppStats implements API.

--- a/pkg/visor/embedded_proxystatus.go
+++ b/pkg/visor/embedded_proxystatus.go
@@ -22,6 +22,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/proxystatus"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
@@ -30,6 +33,28 @@ import (
 // page renders the most recent lines within this window (capped again in the
 // renderer), so it shows current activity without scanning the whole store.
 const statusLogLookback = 30 * time.Minute
+
+// statusEventsCap bounds how many recent route/transport event lines the status
+// page carries for a surface. The ring itself is bounded (pkg/logging), but the
+// snapshot takes only the most recent tail so the page stays readable.
+const statusEventsCap = 200
+
+// statusMaxLogLines mirrors the renderer's maxLogLines cap so the snapshot never
+// carries more log lines than the page would render.
+const statusMaxLogLines = 200
+
+// tailRecordLines formats the most recent up-to-cap Records into log lines
+// (oldest first), matching the visor's live log format.
+func tailRecordLines(recs []logging.Record, limit int) []string {
+	if len(recs) > limit {
+		recs = recs[len(recs)-limit:]
+	}
+	out := make([]string, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, r.Format())
+	}
+	return out
+}
 
 // surfaceApp maps a status surface to the underlying app / logger name whose
 // logs and route group the page reflects. skysocks is the highest-value view:
@@ -70,9 +95,23 @@ func (p *visorStatusProvider) StatusSnapshot(surface proxystatus.Surface) (proxy
 		snap.Running = ok && proc != nil
 	}
 
-	// Logs (best-effort): the store may not exist for an internal app that has
-	// never written, so a fetch error is a note, not a failure.
-	if logs, err := p.v.LogsSince(time.Now().Add(-statusLogLookback), app); err == nil {
+	// Events + Logs come from the log broadcaster's bounded per-app ring — the
+	// same Fire tap that feeds `proxy start --verbose`. Events are the layered
+	// route/transport lifecycle lines (route requests, setup-node connects,
+	// route creation, RSN-oracle legs, handshakes, mux-enable/SACK, mux route
+	// established, distribution, self-heal) tagged app_name=<app>; ring "logs"
+	// are the app's own output.
+	ringEvents, ringLogs := p.v.RecentAppEvents(app, logrus.DebugLevel)
+	if len(ringEvents) > 0 {
+		snap.Events = tailRecordLines(ringEvents, statusEventsCap)
+	}
+
+	// Logs: prefer the richer scoped log captured in the ring (app stdout +
+	// tagged lifecycle). Fall back to the app's bbolt log store when the ring
+	// has nothing yet, so an idle-but-previously-run surface still shows a tail.
+	if len(ringLogs) > 0 {
+		snap.Logs = tailRecordLines(ringLogs, statusMaxLogLines)
+	} else if logs, err := p.v.LogsSince(time.Now().Add(-statusLogLookback), app); err == nil {
 		snap.Logs = logs
 	} else {
 		snap.Note = appendNote(snap.Note, "logs unavailable: "+err.Error())

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -326,6 +326,10 @@ func (proxyDefaultAPI) LogsSince(_ time.Time, _ string) ([]string, error) {
 	return nil, ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) RecentAppLog(_, _ string) ([]string, error) {
+	return nil, ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) GetAppStats(_ string) (appserver.AppStats, error) {
 	return appserver.AppStats{}, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -63,6 +63,16 @@ type AppLogsRequest struct {
 	// AppName should match the app name in visor config
 	AppName string `json:"app_name"`
 }
+
+// RecentAppLogRequest asks for the recent app-scoped route/transport events +
+// log lines captured in the log broadcaster's per-app ring.
+type RecentAppLogRequest struct {
+	// AppName should match the app name in visor config.
+	AppName string `json:"app_name"`
+	// Level is the minimum severity ("trace"|"debug"|"info"|"warn"|"error").
+	// Empty defaults to "debug".
+	Level string `json:"level"`
+}
 type TransportSummary struct {
 	ID      uuid.UUID           `json:"id"`
 	Local   cipher.PubKey       `json:"local_pk"`

--- a/pkg/visor/rpc_apps.go
+++ b/pkg/visor/rpc_apps.go
@@ -17,6 +17,17 @@ func (r *RPC) LogsSince(in *AppLogsRequest, out *[]string) (err error) {
 	return err
 }
 
+// RecentAppLog returns the recent app-scoped route/transport events + log lines
+// captured in the log broadcaster's per-app ring.
+func (r *RPC) RecentAppLog(in *RecentAppLogRequest, out *[]string) (err error) {
+	defer rpcutil.LogCall(r.log, "RecentAppLog", in)(out, &err)
+
+	lines, err := r.visor.RecentAppLog(in.AppName, in.Level)
+	*out = lines
+
+	return err
+}
+
 // SetAppDetailedStatus sets app's detailed status.
 func (r *RPC) SetAppDetailedStatus(in *SetAppStatusIn, _ *struct{}) (err error) {
 	defer rpcutil.LogCall(r.log, "SetAppDetailedStatus", in)(nil, &err)

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -607,6 +607,21 @@ func (rc *rpcClient) LogsSince(timestamp time.Time, appName string) ([]string, e
 	return res, nil
 }
 
+// RecentAppLog calls RecentAppLog.
+func (rc *rpcClient) RecentAppLog(appName, level string) ([]string, error) {
+	res := make([]string, 0)
+
+	err := rc.Call("RecentAppLog", &RecentAppLogRequest{
+		AppName: appName,
+		Level:   level,
+	}, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
 func (rc *rpcClient) GetAppStats(appName string) (appserver.AppStats, error) {
 	var stats appserver.AppStats
 

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -570,6 +570,11 @@ func (mc *mockRPCClient) LogsSince(timestamp time.Time, _ string) ([]string, err
 	return mc.logS.LogsSince(timestamp)
 }
 
+// RecentAppLog implements API.
+func (mc *mockRPCClient) RecentAppLog(_, _ string) ([]string, error) {
+	return nil, nil
+}
+
 func (mc *mockRPCClient) GetAppStats(_ string) (appserver.AppStats, error) {
 	return appserver.AppStats{}, nil
 }

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -1029,6 +1029,27 @@ func (v *Visor) SubscribeLogs(f logging.Filter, capacity int) (<-chan *logrus.En
 	return v.logBcast.Subscribe(f, capacity)
 }
 
+// RecentAppEvents returns the recent app-scoped route/transport events and log
+// lines captured for appName by the log broadcaster's per-app ring, filtered to
+// entries at least as severe as minLevel. Both slices are oldest-first. Returns
+// empty slices (not an error) when nothing has been captured.
+func (v *Visor) RecentAppEvents(appName string, minLevel logrus.Level) (events, logs []logging.Record) {
+	if v.logBcast == nil {
+		return nil, nil
+	}
+	return v.logBcast.RecentByApp(appName, minLevel)
+}
+
+// RecentAppLogMerged returns the recent events+logs for appName merged into one
+// time-ordered slice (oldest first), filtered to entries at least as severe as
+// minLevel. This is the "reading the log" view `cli proxy log` prints.
+func (v *Visor) RecentAppLogMerged(appName string, minLevel logrus.Level) []logging.Record {
+	if v.logBcast == nil {
+		return nil
+	}
+	return v.logBcast.RecentMerged(appName, minLevel)
+}
+
 // SubscribeGroupMessages registers a live subscriber on the visor's
 // group inbox. Every message delivered to the inbox from this point
 // forward is fanned out to the returned channel (bounded; bursts past


### PR DESCRIPTION
## What

The proxy status surface (`http://status.skysocks/` and the route interstitial) renders `pkg/proxystatus.Snapshot`, which has `Events` and `Logs` slots, but `visorStatusProvider.StatusSnapshot` left `Events` empty and `Logs` showing only the app-proc lifecycle line. Meanwhile the rich route/transport activity (`[router] Requesting new routes`, `[router] connected to setup node`, `[router] Created new routes`, RSN-oracle legs, `[RouteGroup …] Sent handshake`, mux-enable/SACK, mux route established, distribution, self-heal) already flows through the visor's master logger tagged `app_name=<app>` — the same stream `proxy start --verbose` scopes to one app — it just wasn't captured for read-back.

## How

- **Tap the existing sink, don't add one.** `logging.Broadcaster` is the single logrus hook on the master logger that already feeds the `--verbose` gRPC stream. Its `Fire` now also records app-scoped entries into a bounded **per-app ring** (`pkg/logging/ring.go`): layered router/RouteGroup/transport/setup/mux entries (resolved via the `app_name`/`app`/`cmd` field) go to an **events** bucket; the app's own proc output (`_module=proc:<app>:…`) to a **logs** bucket. Both buckets are capped per app (200) and the number of tracked apps is LRU-capped (32), so memory never grows unbounded.
- **Populate the snapshot.** `StatusSnapshot` fills `Snapshot.Events` from the ring's event bucket and `Snapshot.Logs` from the richer ring log bucket, falling back to the existing bbolt log store when the ring is empty. Fixes `status.skysocks` and the interstitial at once (both render the same `Snapshot`). The renderer gains an events cap to match the existing log cap.
- **`skywire cli proxy log <name>`** attaches to an already-running skysocks client and prints the same class of lines: recent events+logs one-shot, or with `--follow` it prints recent then live-tails via the same `VerboseStream` mechanism `proxy start --verbose` uses. Attach-only — it never starts/stops the app; ctrl+c detaches. Backed by a new read-only `RecentAppLog` RPC over the ring. Flags: `--name`/`-n` (default `skysocks-client`), `--follow`/`-f`, `--level` (default `debug`).

## Scope

The bilateral-tree route-viz is intentionally left out — that is a separate, still-iterating visual. This PR is events/logs + CLI only.

## Testing

- `go build .` clean; `go vet` and `gofmt` clean on touched packages.
- `go test ./pkg/logging/... ./pkg/proxystatus/... ./pkg/visor/... ./cmd/skywire-cli/... -count=1` all pass, including new `pkg/logging/ring_test.go` (classification, level filter, per-app + max-apps bounds, merged time-ordering, format).