### PR TITLE
fix(stats): change-gate the per-transport current-leaf mirror to stop idle Root churn

### DIFF
--- a/pkg/visor/stats/sink_test.go
+++ b/pkg/visor/stats/sink_test.go
@@ -14,15 +14,17 @@ import (
 // assert on the post-sample mirror state. Concurrency-safe so it can
 // stand in for a real sink wired into the tracker's sampler goroutine.
 type recordingSink struct {
-	mu   sync.Mutex
-	puts map[string][]byte
-	dels map[string]int // count of Delete calls per path
+	mu       sync.Mutex
+	puts     map[string][]byte
+	putCount map[string]int // count of Put calls per path (survives Delete)
+	dels     map[string]int // count of Delete calls per path
 }
 
 func newRecordingSink() *recordingSink {
 	return &recordingSink{
-		puts: make(map[string][]byte),
-		dels: make(map[string]int),
+		puts:     make(map[string][]byte),
+		putCount: make(map[string]int),
+		dels:     make(map[string]int),
 	}
 }
 
@@ -30,6 +32,16 @@ func (s *recordingSink) Put(path string, value []byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.puts[path] = append([]byte(nil), value...)
+	s.putCount[path]++
+}
+
+// putCountFor returns how many times a path was Put across the sink's
+// lifetime — used by the change-gate test to assert idle transports are
+// not re-Put every tick.
+func (s *recordingSink) putCountFor(path string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.putCount[path]
 }
 
 func (s *recordingSink) Delete(path string) {

--- a/pkg/visor/stats/tracker.go
+++ b/pkg/visor/stats/tracker.go
@@ -50,8 +50,21 @@ type Tracker struct {
 	// once while it was live — lingers on the feed for the visor's whole
 	// uptime, accumulating across churn and bloating the Root TPD fills.
 	mirroredCurrent map[uuid.UUID]struct{}
-	lastDay         string // YYYY-MM-DD UTC of the most recent sample
-	lastPruned      time.Time
+	// publishedSig records, per transport, the meaningful signature of
+	// the last `current` leaf actually mirrored to the sink (sent/recv
+	// bytes + latency min/max/avg — NOT SampledAt). A sample tick only
+	// re-Puts a transport's current leaf when its signature differs from
+	// the stored one (or it was never published), so an IDLE transport —
+	// whose only change each tick is SampledAt being bumped to now — no
+	// longer advances the telemetry Root. Without this, every live
+	// transport re-Put its leaf every ~60s (SampledAt alone changing the
+	// content hash), churning the whole Root and starving TPD's whole-Root
+	// fill over the short announce conn. Guarded by mu alongside
+	// mirroredCurrent; entries are dropped when a transport dies (see
+	// reconcileCurrentLeaves) so a returning transport republishes.
+	publishedSig map[uuid.UUID]currentSig
+	lastDay      string // YYYY-MM-DD UTC of the most recent sample
+	lastPruned   time.Time
 
 	cancel context.CancelFunc
 	done   chan struct{}
@@ -103,6 +116,19 @@ type bandwidthBaseline struct {
 	recv uint64
 }
 
+// currentSig is the value-driven signature of a transport's `current`
+// leaf: the fields TPD actually consumes. It deliberately excludes
+// SampledAt so that a mere timestamp bump on an otherwise-unchanged
+// (idle) transport does not count as a change and does not trigger a
+// re-Put onto the mirror sink.
+type currentSig struct {
+	sent   uint64
+	recv   uint64
+	latMin float64
+	latMax float64
+	latAvg float64
+}
+
 // Config bundles tracker tunables. Zero values mean "use defaults".
 type Config struct {
 	SampleInterval time.Duration // default 1m
@@ -142,6 +168,7 @@ func NewTracker(store *Store, probes Probes, conf Config) *Tracker {
 		sink:            noopSink{},
 		baselines:       make(map[uuid.UUID]bandwidthBaseline),
 		mirroredCurrent: make(map[uuid.UUID]struct{}),
+		publishedSig:    make(map[uuid.UUID]currentSig),
 	}
 }
 
@@ -352,10 +379,15 @@ func (t *Tracker) reconcileCurrentLeaves(live map[uuid.UUID]struct{}) {
 	for id := range t.mirroredCurrent {
 		if _, ok := live[id]; !ok {
 			stale = append(stale, id)
+			// Drop the change-gate baseline too, so if this transport
+			// ID ever returns it republishes rather than being silently
+			// suppressed against a stale signature.
+			delete(t.publishedSig, id)
 		}
 	}
-	// Every live transport re-Put its current leaf this tick (idempotent),
-	// so the mirrored set now equals the live set.
+	// A live transport keeps its current leaf on the sink whether or not
+	// it was re-Put this tick (unchanged transports are intentionally not
+	// re-Put), so the mirrored set is exactly the live set.
 	t.mirroredCurrent = live
 	t.mu.Unlock()
 
@@ -379,6 +411,11 @@ func (t *Tracker) sinkPutBatch(mirrors []mirrorPair) {
 	}
 	t.mu.Lock()
 	sink := t.sink
+	// Record the signature we're about to publish so the next tick's
+	// change-gate compares against what actually reached the sink.
+	for _, m := range mirrors {
+		t.publishedSig[m.id] = m.sig
+	}
 	t.mu.Unlock()
 	ops := make([]SinkOp, 0, len(mirrors))
 	for _, m := range mirrors {
@@ -404,7 +441,13 @@ func (t *Tracker) sinkDelete(path string) {
 // timeline bit, and reads the post-update bitmap — all under the
 // caller's SampleTx. Returns the list of (path, bytes) mirror pairs
 // the caller should push to the sink after the tx commits.
-type mirrorPair = struct {
+// mirrorPair is one current-leaf write queued for the sink after the
+// bbolt tx commits. id/sig identify the transport and the meaningful
+// signature this data represents, so sinkPutBatch can record what was
+// actually published (the change-gate baseline for the next tick).
+type mirrorPair struct {
+	id   uuid.UUID
+	sig  currentSig
 	path string
 	data []byte
 }
@@ -434,13 +477,26 @@ func (t *Tracker) recordTransportTx(stx *SampleTx, tp TransportProbe, now time.T
 		Type:         rec.Type,
 	}
 
+	sig := currentSig{
+		sent:   tp.SentBytes,
+		recv:   tp.RecvBytes,
+		latMin: tp.LatencyMS.Min,
+		latMax: tp.LatencyMS.Max,
+		latAvg: tp.LatencyMS.Avg,
+	}
+
 	t.mu.Lock()
 	base, ok := t.baselines[tp.ID]
 	if !ok || base.day != today {
 		base = bandwidthBaseline{day: today, sent: tp.SentBytes, recv: tp.RecvBytes}
 		t.baselines[tp.ID] = base
 	}
+	prevSig, published := t.publishedSig[tp.ID]
 	t.mu.Unlock()
+	// Only mirror the current leaf when a meaningful field moved (or it
+	// was never published). SampledAt alone changing every tick must NOT
+	// re-Put an idle transport — that was the Root churn this fixes.
+	sigChanged := !published || prevSig != sig
 
 	deltaSent := uint64(0)
 	deltaRecv := uint64(0)
@@ -463,8 +519,10 @@ func (t *Tracker) recordTransportTx(stx *SampleTx, tp TransportProbe, now time.T
 
 	var mirrors []mirrorPair
 	idStr := tp.ID.String()
-	if data, err := json.Marshal(rec.Current); err == nil {
-		mirrors = append(mirrors, mirrorPair{path: currentTransportPath(idStr), data: data})
+	if sigChanged {
+		if data, err := json.Marshal(rec.Current); err == nil {
+			mirrors = append(mirrors, mirrorPair{id: tp.ID, sig: sig, path: currentTransportPath(idStr), data: data})
+		}
 	}
 	// The daily rollup (row) is persisted to bbolt above (PutTransportRecord)
 	// but deliberately NOT mirrored to the CXO sink: no subscriber reads it

--- a/pkg/visor/stats/tracker_test.go
+++ b/pkg/visor/stats/tracker_test.go
@@ -84,6 +84,91 @@ func TestTrackerRecordsTransportLifecycle(t *testing.T) {
 	}
 }
 
+// TestTrackerChangeGateSkipsIdleRePuts drives three transports across
+// three same-day ticks and asserts the mirror change-gate:
+//
+//	(a) an IDLE transport (bytes/latency constant, only SampledAt
+//	    advancing) is Put once and NOT re-Put on later idle ticks;
+//	(b) a transport whose sent/recv bytes change IS re-Put on the
+//	    changing tick, then stops being re-Put once it goes idle;
+//	(c) a transport that goes dead has its current leaf sink-Deleted.
+//
+// This is the per-tick Root-churn reduction: with N live transports of
+// which M are idle between samples, the mirror Put count drops from N to
+// (N-M).
+func TestTrackerChangeGateSkipsIdleRePuts(t *testing.T) {
+	sink := newRecordingSink()
+	tr := newTrackerWithSink(t, sink)
+	idle := uuid.New()
+	changing := uuid.New()
+	dying := uuid.New()
+	t0 := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+
+	idleProbe := TransportProbe{
+		ID: idle, Type: "stcpr", SentBytes: 100, RecvBytes: 50,
+		LatencyMS: LatencyTriple{Min: 10, Max: 10, Avg: 10},
+	}
+
+	// Tick 1: all three live — each publishes its current leaf once.
+	tr.probes.Transports = func() []TransportProbe {
+		return []TransportProbe{
+			idleProbe,
+			{ID: changing, Type: "stcpr", SentBytes: 200, RecvBytes: 80},
+			{ID: dying, Type: "stcpr", SentBytes: 5, RecvBytes: 5},
+		}
+	}
+	tr.sample(t0)
+	for _, id := range []uuid.UUID{idle, changing, dying} {
+		if n := sink.putCountFor(currentTransportPath(id.String())); n != 1 {
+			t.Fatalf("tick1: %s Put %d times, want 1", id, n)
+		}
+	}
+
+	// Tick 2: idle unchanged (SampledAt advances only), changing grew,
+	// dying has closed (dropped from the probe).
+	tr.probes.Transports = func() []TransportProbe {
+		return []TransportProbe{
+			idleProbe, // identical bytes+latency; only SampledAt would move
+			{ID: changing, Type: "stcpr", SentBytes: 350, RecvBytes: 120},
+		}
+	}
+	tr.sample(t0.Add(time.Minute))
+
+	if n := sink.putCountFor(currentTransportPath(idle.String())); n != 1 {
+		t.Errorf("(a) idle transport re-Put on unchanged tick: Put %d times, want 1", n)
+	}
+	if n := sink.putCountFor(currentTransportPath(changing.String())); n != 2 {
+		t.Errorf("(b) changed transport not re-Put: Put %d times, want 2", n)
+	}
+	_, dels := sink.snapshot()
+	foundDel := false
+	for _, d := range dels {
+		if d == currentTransportPath(dying.String()) {
+			foundDel = true
+		}
+	}
+	if !foundDel {
+		t.Errorf("(c) dead transport current leaf not sink-Deleted; dels=%v", dels)
+	}
+
+	// Tick 3: both remaining transports idle (changing now constant too).
+	// Neither should be re-Put.
+	tr.probes.Transports = func() []TransportProbe {
+		return []TransportProbe{
+			idleProbe,
+			{ID: changing, Type: "stcpr", SentBytes: 350, RecvBytes: 120},
+		}
+	}
+	tr.sample(t0.Add(2 * time.Minute))
+
+	if n := sink.putCountFor(currentTransportPath(idle.String())); n != 1 {
+		t.Errorf("(a) idle transport re-Put on second idle tick: Put %d times, want 1", n)
+	}
+	if n := sink.putCountFor(currentTransportPath(changing.String())); n != 2 {
+		t.Errorf("(b) now-idle transport re-Put after it stopped changing: Put %d times, want 2", n)
+	}
+}
+
 func TestTrackerDayBoundaryAnchorsNewBaseline(t *testing.T) {
 	f := newTrackerFixture(t)
 	id := uuid.New()


### PR DESCRIPTION
The stats sampler re-Put every live transport's `transports/<id>/current` leaf onto the CXO telemetry mirror on every ~60s sample tick. Each leaf's content hash changed every tick because `LiveSnapshot.SampledAt` (serialized without `omitempty`) is bumped to `now` on every sample, even for zero-traffic transports — so idle transports needlessly advanced the whole telemetry Root every tick. That churn is a large part of why TPD can't finish a whole-Root fill over the short announce conn (the motivation for the #4152 port-69 discovery split), and it's the enabling step toward eventually collapsing the two feeds back into one.

The fix tracks, per transport, the meaningful signature of the last mirrored `current` leaf (sent/recv bytes + latency min/max/avg — not `SampledAt`) and only re-Puts a leaf when that signature changes (or it was never published). `SampledAt` still rides in the leaf body for consumers; it just no longer, by itself, triggers a re-Put. A dead transport still deletes its leaf via `reconcileCurrentLeaves`, which now also drops the change-gate baseline so a returning transport republishes. bbolt retention and the visor's own `/stats` are untouched — only the CXO mirror is gated.

With N live transports of which M are idle between samples, the per-tick mirror Put count drops from N to (N−M).

A unit test drives the tracker across three ticks: an idle transport is Put once and not re-Put on subsequent idle ticks; a transport whose bytes change is re-Put on the changing tick (and stops once it goes idle); a transport that goes dead has its leaf Deleted.
