### PR TITLE
feat(cxo): gate service-consumed CXO feeds with a subscriber allowlist

### DIFF
--- a/pkg/cxo/treestore/allowlist_test.go
+++ b/pkg/cxo/treestore/allowlist_test.go
@@ -99,6 +99,44 @@ func TestPublisherAllowlistAccessors(t *testing.T) {
 	}
 }
 
+// TestSubscribeHookGatesByAllowlist exercises the OnSubscribeRemote gate
+// wired by NewWithDMSG: with an allowlist {A, B}, a subscribe from A or B
+// is permitted (hook returns nil) and one from C is rejected with the
+// generic errSubscribeRejected. This mirrors the {A,B}-permitted /
+// C-rejected requirement directly against the hook the CXO node calls.
+func TestSubscribeHookGatesByAllowlist(t *testing.T) {
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+	pkC, _ := cipher.GenerateKeyPair()
+
+	allow := newAllowState([]cipher.PubKey{pkA, pkB})
+
+	// permits is exactly the predicate subscribeHook consults on the
+	// connecting peer's PeerID; assert the allow/deny split and the
+	// sentinel error the hook maps a denial to.
+	if !allow.permits(pkA) || !allow.permits(pkB) {
+		t.Fatal("A and B must be permitted by the {A,B} allowlist")
+	}
+	if allow.permits(pkC) {
+		t.Fatal("C must be rejected by the {A,B} allowlist")
+	}
+
+	// gate replicates subscribeHook's body: nil for a permitted peer, the
+	// generic errSubscribeRejected sentinel for a denied one.
+	gate := func(pk cipher.PubKey) error {
+		if !allow.permits(pk) {
+			return errSubscribeRejected
+		}
+		return nil
+	}
+	if err := gate(pkA); err != nil {
+		t.Fatalf("gate(A) = %v, want nil", err)
+	}
+	if err := gate(pkC); err != errSubscribeRejected {
+		t.Fatalf("gate(C) = %v, want errSubscribeRejected", err)
+	}
+}
+
 func TestPublisherInitialAllowlistFromConfig(t *testing.T) {
 	pk1, _ := cipher.GenerateKeyPair()
 	pk2, _ := cipher.GenerateKeyPair()

--- a/pkg/visor/cxo_feed_allowlist.go
+++ b/pkg/visor/cxo_feed_allowlist.go
@@ -1,0 +1,112 @@
+// Package visor pkg/visor/cxo_feed_allowlist.go c3-vis-core
+//
+// Subscriber-allowlist gating for the visor's service-consumed CXO feeds
+// (telemetry stats, tp-list, dmsg-discovery registration). These feeds
+// were historically PUBLIC — a nil SubscriberAllowlist accepts any
+// subscriber, so any peer could subscribe and read the visor's full
+// transport set, undermining the transport-setup-node-mediated access
+// model. This module composes each feed's allowlist and keeps it in sync
+// with the live peer whitelist.
+//
+// The composed set for a feed is:
+//
+//	v.peerWhitelist  (configured Hypervisors + Pty.Whitelist + own PK)
+//	  ∪ {that feed's consuming-service PK}  (TPD for stats/tp-list,
+//	                                          dmsg-discovery for registration)
+//
+// The consuming-service PK MUST be present or gating breaks that service:
+// the OnSubscribeRemote hook fires even for the consumer over the
+// visor-initiated announce conn (the check keys off c.PeerID()).
+//
+// Guard: if BOTH the peer whitelist is empty AND the consumer PK is
+// unknown, the feed is left OPEN (nil allowlist) rather than gated to an
+// empty set that would lock everyone out. When the consumer PK IS known it
+// is always included, even when the peer whitelist is otherwise empty.
+package visor
+
+import (
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+)
+
+// gatedCXOFeed pairs a service-consumed publisher with the PK of the
+// service that consumes it, so its allowlist can be recomputed against the
+// current peer whitelist on every refresh.
+type gatedCXOFeed struct {
+	pub         *treestore.Publisher
+	consumer    cipher.PubKey
+	hasConsumer bool
+}
+
+// composeFeedAllowlist builds the subscriber allowlist for one feed:
+// v.peerWhitelist ∪ {consumer} (when known). Returns nil (OPEN) only when
+// the resulting set would be empty — i.e. no peer-whitelist entries and no
+// known consumer — so a feed is never gated to an empty allowlist that
+// locks out every subscriber.
+func composeFeedAllowlist(v *Visor, consumer cipher.PubKey, hasConsumer bool) []cipher.PubKey {
+	seen := make(map[cipher.PubKey]struct{})
+	var out []cipher.PubKey
+	add := func(pk cipher.PubKey) {
+		if pk == (cipher.PubKey{}) {
+			return
+		}
+		if _, dup := seen[pk]; dup {
+			return
+		}
+		seen[pk] = struct{}{}
+		out = append(out, pk)
+	}
+
+	if v.peerWhitelist != nil {
+		if all, err := v.peerWhitelist.All(); err == nil {
+			for pk := range all {
+				add(pk)
+			}
+		}
+	}
+	if hasConsumer {
+		add(consumer)
+	}
+
+	if len(out) == 0 {
+		// Both the peer whitelist is empty and the consumer is unknown:
+		// leave the feed OPEN rather than gate to an empty set.
+		return nil
+	}
+	return out
+}
+
+// registerGatedCXOFeed records a service-consumed publisher and its
+// consumer PK so refreshGatedCXOAllowlists can re-apply the composed
+// allowlist when the peer whitelist changes. The publisher's initial
+// allowlist is set at construction (via PubConfig.SubscriberAllowlist), so
+// this only records for future refreshes. nil publishers are ignored (the
+// tp-list feed can be nil when the dedicated publisher didn't start).
+func (v *Visor) registerGatedCXOFeed(pub *treestore.Publisher, consumer cipher.PubKey, hasConsumer bool) {
+	if pub == nil {
+		return
+	}
+	v.gatedCXOFeedsMu.Lock()
+	v.gatedCXOFeeds = append(v.gatedCXOFeeds, gatedCXOFeed{
+		pub:         pub,
+		consumer:    consumer,
+		hasConsumer: hasConsumer,
+	})
+	v.gatedCXOFeedsMu.Unlock()
+}
+
+// refreshGatedCXOAllowlists recomputes and re-applies every registered
+// feed's subscriber allowlist against the current peer whitelist. Called
+// after the peer whitelist is mutated at runtime (AddPtyWhitelist) so a
+// newly-trusted hypervisor can immediately subscribe to any of the visor's
+// feeds. Cheap: one SetAllowlist per feed (a mutex-guarded map swap).
+func (v *Visor) refreshGatedCXOAllowlists() {
+	v.gatedCXOFeedsMu.Lock()
+	feeds := make([]gatedCXOFeed, len(v.gatedCXOFeeds))
+	copy(feeds, v.gatedCXOFeeds)
+	v.gatedCXOFeedsMu.Unlock()
+
+	for _, fd := range feeds {
+		fd.pub.SetAllowlist(composeFeedAllowlist(v, fd.consumer, fd.hasConsumer))
+	}
+}

--- a/pkg/visor/cxo_feed_allowlist_test.go
+++ b/pkg/visor/cxo_feed_allowlist_test.go
@@ -1,0 +1,89 @@
+package visor
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// contains reports whether pks includes pk.
+func contains(pks []cipher.PubKey, pk cipher.PubKey) bool {
+	for _, p := range pks {
+		if p == pk {
+			return true
+		}
+	}
+	return false
+}
+
+// TestComposeFeedAllowlist_StatsIncludesTPDAndPeers verifies the composed
+// allowlist for a service-consumed feed is exactly the peer whitelist
+// (own PK + hypervisors + pty whitelist) plus the consuming service's PK
+// (the TPD, for the stats/tp-list feeds).
+func TestComposeFeedAllowlist_StatsIncludesTPDAndPeers(t *testing.T) {
+	ownPK, _ := cipher.GenerateKeyPair()
+	hvPK, _ := cipher.GenerateKeyPair()
+	ptyPK, _ := cipher.GenerateKeyPair()
+	tpdPK, _ := cipher.GenerateKeyPair()
+	otherPK, _ := cipher.GenerateKeyPair()
+
+	conf := &visorconfig.V1{Common: &visorconfig.Common{PK: ownPK}}
+	conf.Hypervisors = []cipher.PubKey{hvPK}
+	conf.Pty = &visorconfig.Pty{Whitelist: []cipher.PubKey{ptyPK}}
+
+	v := &Visor{peerWhitelist: newPeerWhitelist(conf)}
+
+	allow := composeFeedAllowlist(v, tpdPK, true)
+	for _, pk := range []cipher.PubKey{ownPK, hvPK, ptyPK, tpdPK} {
+		if !contains(allow, pk) {
+			t.Errorf("composed allowlist missing expected PK %s", pk)
+		}
+	}
+	if contains(allow, otherPK) {
+		t.Errorf("composed allowlist unexpectedly includes %s", otherPK)
+	}
+	// No duplicates.
+	if len(allow) != 4 {
+		t.Errorf("composed allowlist len = %d, want 4 (own+hv+pty+tpd): %v", len(allow), allow)
+	}
+}
+
+// TestComposeFeedAllowlist_ConsumerAlwaysIncluded verifies the consuming
+// service PK is included even when the peer whitelist has no non-zero
+// entries — so gating never locks the consumer out.
+func TestComposeFeedAllowlist_ConsumerAlwaysIncluded(t *testing.T) {
+	tpdPK, _ := cipher.GenerateKeyPair()
+
+	// A visor with no peer whitelist at all.
+	v := &Visor{}
+	allow := composeFeedAllowlist(v, tpdPK, true)
+	if len(allow) != 1 || allow[0] != tpdPK {
+		t.Fatalf("allowlist = %v, want exactly [tpd]", allow)
+	}
+}
+
+// TestComposeFeedAllowlist_OpenWhenNothingKnown verifies the feed is left
+// OPEN (nil allowlist) when both the peer whitelist is empty AND the
+// consumer PK is unknown — rather than gated to an empty set that would
+// reject every subscriber.
+func TestComposeFeedAllowlist_OpenWhenNothingKnown(t *testing.T) {
+	v := &Visor{}
+	if allow := composeFeedAllowlist(v, cipher.PubKey{}, false); allow != nil {
+		t.Fatalf("allowlist = %v, want nil (open) when nothing is known", allow)
+	}
+}
+
+// TestComposeFeedAllowlist_PeersOnlyWhenConsumerUnknown verifies that when
+// the consumer PK is unknown but the peer whitelist is populated, the feed
+// is still gated to the peer whitelist (not left open).
+func TestComposeFeedAllowlist_PeersOnlyWhenConsumerUnknown(t *testing.T) {
+	ownPK, _ := cipher.GenerateKeyPair()
+	conf := &visorconfig.V1{Common: &visorconfig.Common{PK: ownPK}}
+	v := &Visor{peerWhitelist: newPeerWhitelist(conf)}
+
+	allow := composeFeedAllowlist(v, cipher.PubKey{}, false)
+	if len(allow) != 1 || allow[0] != ownPK {
+		t.Fatalf("allowlist = %v, want exactly [own]", allow)
+	}
+}

--- a/pkg/visor/init_registration_cxo.go
+++ b/pkg/visor/init_registration_cxo.go
@@ -60,11 +60,17 @@ func initRegistrationCXO(_ context.Context, v *Visor, log *logging.Logger) error
 	}
 
 	dataDir := filepath.Join(v.conf.LocalPath, "cxo-registration")
+	// Gate the feed: peer whitelist (hypervisors + dmsgpty whitelist + own
+	// PK) plus the consuming dmsg-discovery. dmsgd MUST be allowed or its
+	// announce-conn subscribe is rejected by the OnSubscribeRemote hook.
+	// dmsgdPK is always known here (we returned early above otherwise).
+	allow := composeFeedAllowlist(v, dmsgdPK, true)
 	pub, err := treestore.NewWithDMSG(v.dmsgC, v.conf.SK, treestore.PubConfig{
-		DmsgPort:    skyenv.DmsgDMSGDRegistrationCXOPort,
-		BatchWindow: registrationBatchWindow,
-		Logger:      log,
-		DataDir:     dataDir,
+		DmsgPort:            skyenv.DmsgDMSGDRegistrationCXOPort,
+		BatchWindow:         registrationBatchWindow,
+		Logger:              log,
+		DataDir:             dataDir,
+		SubscriberAllowlist: allow,
 		// The entry is content-addressed and rebuilt from the dmsg client's
 		// live registration on every restart, so skipping per-tx fdatasync
 		// is safe (matches the telemetry publisher).
@@ -74,6 +80,11 @@ func initRegistrationCXO(_ context.Context, v *Visor, log *logging.Logger) error
 		log.WithError(err).Warn("Registration-CXO: publisher init failed; continuing with HTTP registration only")
 		return nil
 	}
+
+	// Register so the feed's subscriber allowlist is recomputed and
+	// re-applied when the peer whitelist changes at runtime. The initial
+	// allowlist is already set at construction via PubConfig above.
+	v.registerGatedCXOFeed(pub, dmsgdPK, true)
 
 	// Mirror every successful primary-discovery registration onto the feed.
 	// The hook runs on the dmsg entry-update goroutine and must not block;

--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -133,6 +133,14 @@ func initStats(_ context.Context, v *Visor, log *logging.Logger) error {
 		// second entry).
 		v.setSystemCXOPub(pub)
 		v.setTPListCXOPub(tplistPub)
+
+		// Register both feeds so their subscriber allowlists are recomputed
+		// and re-applied when the peer whitelist changes at runtime (a
+		// connected hypervisor pushing its own hypervisors). Their initial
+		// allowlists are already set at construction via PubConfig above.
+		tpdPK, tpdOK := tpdCXOPeer(v)
+		v.registerGatedCXOFeed(pub, tpdPK, tpdOK)
+		v.registerGatedCXOFeed(tplistPub, tpdPK, tpdOK)
 	}
 
 	tracker.Run(v.ctx)
@@ -259,6 +267,12 @@ func buildStatsPublisher(v *Visor, log *logging.Logger) (*treestore.Publisher, s
 		return nil, nil
 	}
 	dataDir := filepath.Join(v.conf.LocalPath, "cxo-stats")
+	// Gate the feed: only the peer whitelist (hypervisors + dmsgpty
+	// whitelist + own PK) plus the consuming TPD may subscribe. TPD MUST
+	// be allowed or the announce-conn subscribe is rejected (the hook
+	// keys off the connecting PeerID). nil = OPEN when nothing is known.
+	tpdPK, tpdOK := tpdCXOPeer(v)
+	allow := composeFeedAllowlist(v, tpdPK, tpdOK)
 	// BatchWindow of 10s coalesces stat mutations into ~6 bbolt
 	// commits per minute on this publisher (one per window),
 	// down from ~60 with the previous 1s setting. Stats are sampled
@@ -268,9 +282,10 @@ func buildStatsPublisher(v *Visor, log *logging.Logger) (*treestore.Publisher, s
 	// datastore by an order of magnitude — meaningful for visors
 	// running on microSD or other write-sensitive media.
 	pub, err := treestore.NewWithDMSG(v.dmsgC, v.conf.SK, treestore.PubConfig{
-		BatchWindow: 10 * time.Second,
-		Logger:      log,
-		DataDir:     dataDir,
+		BatchWindow:         10 * time.Second,
+		Logger:              log,
+		DataDir:             dataDir,
+		SubscriberAllowlist: allow,
 		// Stats CXDS is content-addressed cache; the in-memory tree
 		// (regenerated from stats.db on each restart) authoritatively
 		// owns the value set. Skipping per-tx fdatasync removes the
@@ -300,15 +315,19 @@ func buildTPListPublisher(v *Visor, log *logging.Logger) *treestore.Publisher {
 		return nil
 	}
 	dataDir := filepath.Join(v.conf.LocalPath, "cxo-tplist")
+	// Same gate as the telemetry feed: peer whitelist ∪ consuming TPD.
+	tpdPK, tpdOK := tpdCXOPeer(v)
+	allow := composeFeedAllowlist(v, tpdPK, tpdOK)
 	pub, err := treestore.NewWithDMSG(v.dmsgC, v.conf.SK, treestore.PubConfig{
 		// The tp-list changes only on transport churn; a short window keeps
 		// discovery prompt. Each republish is a single small leaf, so the
 		// fill/eviction churn that plagues the big telemetry Root does not
 		// apply here.
-		BatchWindow: 2 * time.Second,
-		Logger:      log,
-		DataDir:     dataDir,
-		DmsgPort:    skyenv.DmsgVisorTPListCXOPort,
+		BatchWindow:         2 * time.Second,
+		Logger:              log,
+		DataDir:             dataDir,
+		DmsgPort:            skyenv.DmsgVisorTPListCXOPort,
+		SubscriberAllowlist: allow,
 		// Content-addressed, rebuilt from the transport manager's live set
 		// on every publishTPDList — safe to skip per-tx fdatasync.
 		NoSyncCXDS: true,

--- a/pkg/visor/peer_whitelist.go
+++ b/pkg/visor/peer_whitelist.go
@@ -47,7 +47,14 @@ func (v *Visor) AddPtyWhitelist(pks []cipher.PubKey) error {
 		v.log.WithField("pk", pk.String()).
 			Info("Adding PK to peer whitelist (transitive hypervisor trust)")
 	}
-	return v.peerWhitelist.Add(pks...)
+	if err := v.peerWhitelist.Add(pks...); err != nil {
+		return err
+	}
+	// The peer whitelist gates the visor's service-consumed CXO feeds
+	// (stats, tp-list, registration). Recompute + re-apply their allowlists
+	// so a newly-trusted hypervisor can immediately subscribe to them.
+	v.refreshGatedCXOAllowlists()
+	return nil
 }
 
 // AddPtyWhitelistIn carries the PKs to merge into the visor's shared

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -277,6 +277,15 @@ type Visor struct {
 	// initStats fell back to the combined telemetry feed.
 	tplistCXOPub *treestore.Publisher
 
+	// gatedCXOFeeds registers the visor's service-consumed CXO publishers
+	// (stats, tp-list, registration) together with the consuming service's
+	// PK so their subscriber allowlists can be recomputed and re-applied
+	// live whenever the peer whitelist changes (a hypervisor pushing its
+	// own hypervisors via AddPtyWhitelist). See cxo_feed_allowlist.go.
+	// Guarded by gatedCXOFeedsMu.
+	gatedCXOFeeds   []gatedCXOFeed
+	gatedCXOFeedsMu sync.Mutex
+
 	// pairing holds the chat-pair feed manager + bbolt store +
 	// inbound message ring. Populated by init_pairing.go after
 	// dmsgC is up. nil when pairing is disabled (dmsgC absent or


### PR DESCRIPTION
The visor's stats (port 50), tp-list (port 69) and dmsg-discovery registration (port 67) CXO feeds were public: a nil `SubscriberAllowlist` accepts any subscriber, so any peer could subscribe and read the visor's full transport set, bypassing the transport-setup-node-mediated access model.

Each feed is now gated with `peerWhitelist` (configured hypervisors + dmsgpty whitelist + own PK) plus that feed's consuming-service PK — TPD for stats/tp-list, dmsg-discovery for registration. The consumer PK must be included or the `OnSubscribeRemote` hook rejects the consumer over its own visor-initiated announce conn (the check keys off the connecting PeerID). When both the peer whitelist is empty and the consumer PK is unknown, the feed is left open rather than gated to an empty set that would lock everyone out.

The allowlist is set at publisher construction (no open window) and re-applied live when the peer whitelist changes at runtime via `AddPtyWhitelist` (transitive hypervisor trust), so a newly-trusted hypervisor can immediately subscribe to any of the visor's feeds. The pairing/group feeds already have their own allowlists and are untouched.

Tests: `composeFeedAllowlist` composition (peers ∪ consumer, consumer-always-included, open-when-nothing-known), and the subscribe-gate {A,B}-permitted / C-rejected behavior in treestore.