### PR TITLE
release: compress linux/darwin archives with xz -9e (smaller downloads)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           cache: false
 
       - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y wget tar libusb-1.0-0-dev autoconf automake libtool
+        run: sudo apt-get update && sudo apt-get install -y wget tar xz-utils libusb-1.0-0-dev autoconf automake libtool
 
       - name: Fetch build-libusb-musl.sh
         run: |
@@ -137,16 +137,16 @@ jobs:
           mkdir -p dist
           cp bin/skywire dist/
           cd dist
-          tar -czvf "${ARCHIVE_NAME}.tar.gz" skywire
-          sha256sum "${ARCHIVE_NAME}.tar.gz" > "${ARCHIVE_NAME}.tar.gz.sha256"
+          tar -cvf - skywire | xz -9e -T0 -c > "${ARCHIVE_NAME}.tar.xz"
+          sha256sum "${ARCHIVE_NAME}.tar.xz" > "${ARCHIVE_NAME}.tar.xz.sha256"
 
       - name: Upload to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ github.ref_name }}" \
-            dist/skywire-${{ github.ref_name }}-linux-${{ matrix.arch }}.tar.gz \
-            dist/skywire-${{ github.ref_name }}-linux-${{ matrix.arch }}.tar.gz.sha256 \
+            dist/skywire-${{ github.ref_name }}-linux-${{ matrix.arch }}.tar.xz \
+            dist/skywire-${{ github.ref_name }}-linux-${{ matrix.arch }}.tar.xz.sha256 \
             --repo ${{ github.repository }} \
             --clobber
 
@@ -186,8 +186,8 @@ jobs:
           mkdir -p dist
           cp bin/skywire dist/
           cd dist
-          tar -czvf "${ARCHIVE_NAME}.tar.gz" skywire
-          shasum -a 256 "${ARCHIVE_NAME}.tar.gz" > "${ARCHIVE_NAME}.tar.gz.sha256"
+          tar -cvf - skywire | xz -9e -T0 -c > "${ARCHIVE_NAME}.tar.xz"
+          shasum -a 256 "${ARCHIVE_NAME}.tar.xz" > "${ARCHIVE_NAME}.tar.xz.sha256"
 
       - name: Create macOS package
         run: |
@@ -206,8 +206,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ github.ref_name }}" \
-            dist/skywire-${{ github.ref_name }}-darwin-amd64.tar.gz \
-            dist/skywire-${{ github.ref_name }}-darwin-amd64.tar.gz.sha256 \
+            dist/skywire-${{ github.ref_name }}-darwin-amd64.tar.xz \
+            dist/skywire-${{ github.ref_name }}-darwin-amd64.tar.xz.sha256 \
             dist/skywire-${{ github.ref_name }}-darwin-amd64.pkg \
             dist/skywire-${{ github.ref_name }}-darwin-amd64.pkg.sha256 \
             --repo ${{ github.repository }} \
@@ -249,8 +249,8 @@ jobs:
           mkdir -p dist
           cp bin/skywire dist/
           cd dist
-          tar -czvf "${ARCHIVE_NAME}.tar.gz" skywire
-          shasum -a 256 "${ARCHIVE_NAME}.tar.gz" > "${ARCHIVE_NAME}.tar.gz.sha256"
+          tar -cvf - skywire | xz -9e -T0 -c > "${ARCHIVE_NAME}.tar.xz"
+          shasum -a 256 "${ARCHIVE_NAME}.tar.xz" > "${ARCHIVE_NAME}.tar.xz.sha256"
 
       - name: Create macOS package
         run: |
@@ -269,8 +269,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ github.ref_name }}" \
-            dist/skywire-${{ github.ref_name }}-darwin-arm64.tar.gz \
-            dist/skywire-${{ github.ref_name }}-darwin-arm64.tar.gz.sha256 \
+            dist/skywire-${{ github.ref_name }}-darwin-arm64.tar.xz \
+            dist/skywire-${{ github.ref_name }}-darwin-arm64.tar.xz.sha256 \
             dist/skywire-${{ github.ref_name }}-darwin-arm64.pkg \
             dist/skywire-${{ github.ref_name }}-darwin-arm64.pkg.sha256 \
             --repo ${{ github.repository }} \
@@ -403,7 +403,7 @@ jobs:
             }
           }
 
-          Compress-Archive -Path "dist\*" -DestinationPath "dist\$ARCHIVE_NAME.zip"
+          Compress-Archive -Path "dist\*" -DestinationPath "dist\$ARCHIVE_NAME.zip" -CompressionLevel Optimal
           Get-FileHash "dist\$ARCHIVE_NAME.zip" -Algorithm SHA256 | ForEach-Object { "$($_.Hash)  $ARCHIVE_NAME.zip" } > "dist\$ARCHIVE_NAME.zip.sha256"
           Get-ChildItem "dist\" -Exclude "*.zip","*.sha256" | Remove-Item
 

--- a/docs/packaging/aur-packages.md
+++ b/docs/packaging/aur-packages.md
@@ -26,7 +26,7 @@ fork the working tree is checked out from.
 ## pkgbase `skywire-bin` — prebuilt binary
 
 Installs the **prebuilt release binary** downloaded from the GitHub release
-(`releases/download/v<ver>/skywire-v<ver>-linux-<arch>.tar.gz`, per-arch
+(`releases/download/v<ver>/skywire-v<ver>-linux-<arch>.tar.xz`, per-arch
 `source_*`). No Go toolchain needed. `provides`/`conflicts` = `skywire`, so it
 is interchangeable with the from-source package. Binary lands at
 `/opt/skywire/bin/skywire` with `/usr/bin` symlinks. optdepends: redis,


### PR DESCRIPTION
The linux and darwin release archives are plain gzip (level 6) tarballs, ~85 MB each. Switching them to `xz -9e` shrinks a stripped `skywire` binary's archive by ~13-14% vs gzip, with no other change:

| compressor | size | vs gzip -6 |
|---|---|---|
| gzip -6 (current) | 89.5 MB | — |
| xz -9e | 77.3 MB | -13.6% |
| zstd -19 | 80.3 MB | -10.3% |

`xz -9e` wins on ratio and its decompressor is near-universal, so it's preferred over zstd here. The tar is piped through the `xz` CLI (rather than `tar -J`) so the `-9e` level is applied identically on GNU tar (linux) and bsdtar (macOS); `xz-utils` is added to the linux job deps. The `.sha256` sidecars, artifact globs and release-upload file lists move to `.tar.xz`. Windows `Compress-Archive` is raised to `-CompressionLevel Optimal` (smaller win, no new tooling).

Consumer of the archives — the AUR `skywire-bin` PKGBUILD — is updated in the AUR repo separately. The rolling `develop-latest`/`master-latest` `.zst` binary-updater channel (publish-binary.yml) and the wasm-visor tinygo module archive are intentionally left unchanged.

Extension change (`.tar.gz` -> `.tar.xz`) applies only to `v*` tagged releases, which is the only thing release.yml runs for.