### PR TITLE
build(deps): bump 0magnet/xterm-go to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/0magnet/cosmos-go v0.0.0-20260814190035-f5b882c1ea9e
 	github.com/0magnet/sh/v3 v3.13.2-0.20260814172914-eff537668adf
 	github.com/0magnet/websh v0.0.0-20260816200521-e9f14eb862c7
-	github.com/0magnet/xterm-go v0.0.0-20260820124923-c0b6b4f69bb7
+	github.com/0magnet/xterm-go v0.0.0-20260823191622-8d2bbff87cea
 	github.com/benhoyt/goawk v1.31.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/0magnet/u-root v0.16.1-0.20260810212217-0890fe5099f9 h1:akt/1o/SlArz8
 github.com/0magnet/u-root v0.16.1-0.20260810212217-0890fe5099f9/go.mod h1:fId14v+rNp1A0ZKHJPZZyiu9dfgWKEs7nbyvKrku3bo=
 github.com/0magnet/websh v0.0.0-20260816200521-e9f14eb862c7 h1:09IjBB/rJMVtrkn4i1571Nq+iSMEIsjv7S4zlJzKEuQ=
 github.com/0magnet/websh v0.0.0-20260816200521-e9f14eb862c7/go.mod h1:ziOzkV+FQYYYC4ivM/F2FwvuloQpljwetB5nyS4ElLI=
-github.com/0magnet/xterm-go v0.0.0-20260820124923-c0b6b4f69bb7 h1:ZeiXWCwdYUfeWWWLs6IpgZ9tYOqyGPbZLLlNGYJi2Lo=
-github.com/0magnet/xterm-go v0.0.0-20260820124923-c0b6b4f69bb7/go.mod h1:W6c6ofSTsxXuQEr1rSZ3qmfOj5a3LGB3uLQBL0/TiKc=
+github.com/0magnet/xterm-go v0.0.0-20260823191622-8d2bbff87cea h1:L0WfJRVQLorMGQo3DktqAPowITCWbiy8/pcZ2O+7qIA=
+github.com/0magnet/xterm-go v0.0.0-20260823191622-8d2bbff87cea/go.mod h1:W6c6ofSTsxXuQEr1rSZ3qmfOj5a3LGB3uLQBL0/TiKc=
 github.com/ActiveState/termtest/conpty v0.5.0 h1:JLUe6YDs4Jw4xNPCU+8VwTpniYOGeKzQg4SM2YHQNA8=
 github.com/ActiveState/termtest/conpty v0.5.0/go.mod h1:LO4208FLsxw6DcNZ1UtuGUMW+ga9PFtX4ntv8Ymg9og=
 github.com/AudriusButkevicius/pfilter v0.0.11 h1:6emuvqNeH1gGlqkML35pEizyPcaxdAN4JO9sdgwcx78=

--- a/vendor/github.com/0magnet/xterm-go/.gitignore
+++ b/vendor/github.com/0magnet/xterm-go/.gitignore
@@ -1,0 +1,2 @@
+/xterm-go
+/demo

--- a/vendor/github.com/0magnet/xterm-go/Makefile
+++ b/vendor/github.com/0magnet/xterm-go/Makefile
@@ -30,6 +30,36 @@ SKIP ?=
 # it, a single unbuildable package makes `go list` fail for the whole module,
 # this comes back blank, and the run below reports that there is nothing to
 # check — which reads exactly like passing.
+# Nested modules. `go list ./...` STOPS AT A MODULE BOUNDARY, so a repo that
+# keeps a second go.mod — desk's panes, pisano's web — had that half silently
+# unchecked: not failing, not skipped with a message, simply absent, which reads
+# exactly like passing. Each one is handled by re-running this same Makefile
+# inside it, so a submodule is checked the way the root is by construction
+# rather than by remembering to add it somewhere.
+#
+# Discovered rather than listed, so adding a module does not also mean editing
+# this. SUBMODULES= on the recursive call is what stops it recursing forever.
+THIS := $(abspath $(firstword $(MAKEFILE_LIST)))
+# The one lint config, by absolute path: a submodule has no .golangci.yml of
+# its own, and the recursive call runs with that submodule as the working
+# directory, so a relative -c would look for it there and fail.
+LINTCFG := $(dir $(THIS)).golangci.yml
+# Vendor mode only where there IS a vendor directory. The config names one mode
+# for the whole repo, and a submodule that does not vendor cannot satisfy it —
+# golangci-lint then reports "inconsistent vendoring" for a tree that is
+# perfectly consistent, because it was told to look for something that was
+# never there. Evaluated in the working directory, so the recursion gets the
+# answer for the module it is actually in.
+MODMODE = $(if $(wildcard vendor/modules.txt),vendor,readonly)
+SUBMODULES := $(patsubst %/go.mod,%,$(shell find . -mindepth 2 -name go.mod -not -path './vendor/*' -not -path '*/vendor/*' 2>/dev/null | sort))
+
+define recurse
+@for m in $(SUBMODULES); do \
+		echo "--- $$m"; \
+		$(MAKE) --no-print-directory -C $$m -f $(THIS) $@ SUBMODULES= || exit 1; \
+	done
+endef
+
 PKGS = $(shell CGO_ENABLED=$(CGO) go list -e -f '{{.Dir}}' ./... 2>/dev/null $(if $(SKIP),| grep -vE '$(SKIP)'))
 JSPKGS = $(shell CGO_ENABLED=0 GOOS=js GOARCH=wasm go list -e -f '{{.Dir}}' ./... 2>/dev/null $(if $(SKIP),| grep -vE '$(SKIP)'))
 
@@ -54,7 +84,7 @@ lint: ## Run golangci-lint. Needs it installed (make install-linters)
 	@# Some of these repos are entirely js/wasm-tagged, so the host context has
 	@# nothing in it and linting it is an error rather than a pass.
 	@if [ -n "$(PKGS)" ]; then \
-		CGO_ENABLED=$(CGO) ${OPTS} golangci-lint run -c .golangci.yml $(PKGS); \
+		CGO_ENABLED=$(CGO) ${OPTS} golangci-lint run --modules-download-mode=$(MODMODE) -c $(LINTCFG) $(PKGS); \
 	else \
 		echo '--- nothing builds for this host; skipping the host pass'; \
 	fi
@@ -62,8 +92,9 @@ lint: ## Run golangci-lint. Needs it installed (make install-linters)
 	@# reads as dead — and anything wrong inside them is never checked at all.
 	@if grep -rlq '^//go:build js' --include='*.go' . 2>/dev/null; then \
 		echo '--- again in the js/wasm build context'; \
-		CGO_ENABLED=0 GOOS=js GOARCH=wasm ${OPTS} golangci-lint run -c .golangci.yml $(JSPKGS); \
+		CGO_ENABLED=0 GOOS=js GOARCH=wasm ${OPTS} golangci-lint run --modules-download-mode=$(MODMODE) -c $(LINTCFG) $(JSPKGS); \
 	fi
+	$(recurse)
 
 vet: ## Run go vet
 	@if [ -n "$(PKGS)" ]; then \
@@ -72,6 +103,7 @@ vet: ## Run go vet
 	@if grep -rlq '^//go:build js' --include='*.go' . 2>/dev/null; then \
 		CGO_ENABLED=0 GOOS=js GOARCH=wasm ${OPTS} go vet $(JSPKGS); \
 	fi
+	$(recurse)
 
 test: ## Run tests. Falls back to the js/wasm ones where nothing builds here
 	@if [ -n "$(PKGS)" ]; then \
@@ -80,6 +112,7 @@ test: ## Run tests. Falls back to the js/wasm ones where nothing builds here
 		echo '--- nothing builds for this host; running the js/wasm tests instead'; \
 		$(MAKE) --no-print-directory test-wasm; \
 	fi
+	$(recurse)
 
 # The exec wrapper Go ships for running a js/wasm binary under Node. It is what
 # makes `go test` work for code the host cannot build at all.
@@ -97,6 +130,7 @@ test-wasm: ## Run the js/wasm tests under Node
 	else \
 		echo 'no js/wasm packages'; \
 	fi
+	$(recurse)
 
 # Running the js/wasm tests in a real browser instead of Node. Node has no DOM;
 # a browser has one, plus canvas and WebGL. Tests that build a fake DOM should
@@ -120,11 +154,13 @@ test-browser: ## Run the js/wasm tests in a headless browser (needs wasmbrowsert
 		PATH=$$d:$$PATH CGO_ENABLED=0 GOOS=js GOARCH=wasm ${OPTS} \
 			go test -exec=wasmbrowsertest $(JSPKGS); \
 		rc=$$?; rm -rf $$d; exit $$rc
+	$(recurse)
 
 cover: ## Report test coverage per package
 	@if [ -n "$(PKGS)" ]; then \
 		CGO_ENABLED=$(CGO) ${OPTS} go test -cover $(PKGS) 2>&1 | grep -v '^ok.*no test files'; \
 	fi
+	$(recurse)
 
 check: lint vet test ## Run linters, vet and tests
 

--- a/vendor/github.com/0magnet/xterm-go/vt/options.go
+++ b/vendor/github.com/0magnet/xterm-go/vt/options.go
@@ -45,6 +45,27 @@ type Options struct {
 	FontSize   float64
 	// LineHeight multiplier. Default: 1.
 	LineHeight float64
+
+	// MirrorGlyph reports whether a glyph should be drawn flipped left-to-right.
+	// nil, the default, draws everything the way round the font has it.
+	//
+	// This exists because some glyphs are only correct mirrored and no font
+	// supplies them that way. The Matrix's code rain is the case it was added
+	// for: its katakana are flipped horizontally, drawn as a custom typeface for
+	// the film, and Unicode encodes no mirrored kana — so a terminal cannot ask
+	// for them. The WebGL renderer rasterises each glyph onto a canvas before
+	// packing it into its atlas, and a canvas can be told to draw mirrored, so
+	// the flip costs one transform at the point the glyph is first drawn and
+	// nothing per frame.
+	//
+	// It is a rendering transform and not a font: the cell still holds the
+	// ordinary codepoint, so selecting, copying and reading the buffer are
+	// unaffected, and a terminal that cannot do this shows the glyph unflipped
+	// rather than showing nothing.
+	//
+	// Only the WebGL renderer honours it. The DOM renderer draws real text and
+	// has no rasterisation step to hook.
+	MirrorGlyph func(string) bool
 	// LetterSpacing in px. Default: 0.
 	LetterSpacing float64
 	// Theme colors (CSS color strings; empty = defaults).

--- a/vendor/github.com/0magnet/xterm-go/webgl.go
+++ b/vendor/github.com/0magnet/xterm-go/webgl.go
@@ -720,6 +720,12 @@ type webglRenderer struct {
 	glyphs *glyphRenderer
 	atlas  *textureAtlas
 
+	// contextLost is set between webglcontextlost and webglcontextrestored.
+	// Every GL call in that window is a no-op that the driver still has to
+	// reject, and the picture it would produce is not on screen anyway.
+	contextLost bool
+	lossFns     []js.Func
+
 	workCell *vt.CellData
 }
 
@@ -754,8 +760,74 @@ func newWebglRenderer(term *Terminal) (r *webglRenderer, err error) {
 		return nil, err
 	}
 
+	r.wireContextLoss()
 	r.onResize()
 	return r, nil
+}
+
+// wireContextLoss keeps the terminal alive across a lost GPU context.
+//
+// A browser caps how many WebGL contexts a page may hold — Chrome's limit is
+// around sixteen — and when a new one is asked for past the cap it EVICTS THE
+// OLDEST. A page that puts a terminal in a window and lets people open windows
+// reaches that on its own: measured here at fifteen terminals, where the first
+// one's context was taken away while the page went on running.
+//
+// preventDefault on the loss event is the load-bearing line. Without it the
+// browser will never restore the context, and no amount of later work can bring
+// the terminal back — it stays a rectangle that used to be a shell, with the
+// renderer issuing draw calls into a dead context that silently do nothing.
+//
+// With it, the browser may restore, and then the GPU-side objects have to be
+// built again: everything made from the context — programs, buffers, the glyph
+// atlas — died with it, while the terminal's own state (its buffer, its shell)
+// never depended on the GPU and is still exactly where it was.
+func (r *webglRenderer) wireContextLoss() {
+	lost := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		if len(args) > 0 {
+			args[0].Call("preventDefault")
+		}
+		r.contextLost = true
+		return nil
+	})
+	restored := js.FuncOf(func(js.Value, []js.Value) any {
+		r.contextLost = false
+		r.rebuildGPUState()
+		return nil
+	})
+	r.lossFns = append(r.lossFns, lost, restored)
+	r.canvas.Call("addEventListener", "webglcontextlost", lost)
+	r.canvas.Call("addEventListener", "webglcontextrestored", restored)
+}
+
+// rebuildGPUState remakes everything that lived in the lost context.
+//
+// The context object itself is reused by the browser and is valid again by the
+// time this runs, so it is not fetched afresh; what has to be rebuilt is what
+// was created FROM it. A failure here leaves contextLost set rather than
+// half-built, so the terminal stays quiet instead of drawing garbage.
+func (r *webglRenderer) rebuildGPUState() {
+	if r.atlas != nil {
+		r.atlas.dispose()
+		r.atlas = nil
+	}
+	rects, err := newRectangleRenderer(r.term, r.gl, &r.dims, r.term.colors)
+	if err != nil {
+		r.contextLost = true
+		return
+	}
+	glyphs, err := newGlyphRenderer(r.term, r.gl, &r.dims)
+	if err != nil {
+		r.contextLost = true
+		return
+	}
+	r.rects, r.glyphs = rects, glyphs
+	// onResize rebuilds the dimensions and the atlas and clears the model, and
+	// a cleared atlas makes the next frame a full refresh — so one draw here
+	// puts the whole terminal back rather than waiting for output that may
+	// never come. A shell sitting at a prompt produces nothing on its own.
+	r.onResize()
+	r.renderRows(0, r.term.Core.Rows()-1)
 }
 
 func (r *webglRenderer) updateDimensions() {
@@ -802,6 +874,7 @@ func (r *webglRenderer) refreshCharAtlas() {
 		dpr:              dpr,
 		lineHeight:       maxF(r.term.Core.Options.LineHeight, 1),
 		colors:           r.term.colors,
+		mirrorGlyph:      r.term.Core.Options.MirrorGlyph,
 	}
 	if r.atlas != nil {
 		r.atlas.dispose()
@@ -835,6 +908,9 @@ func (r *webglRenderer) onColorsChanged() {
 }
 
 func (r *webglRenderer) renderRows(start, end int) {
+	if r.contextLost {
+		return // nothing drawn into a lost context ever reaches the screen
+	}
 	// the frame begins; a cleared atlas forces a full model refresh
 	if r.glyphs.beginFrame() {
 		r.model.clear()
@@ -855,6 +931,10 @@ func (r *webglRenderer) dispose() {
 	if r.atlas != nil {
 		r.atlas.dispose()
 	}
+	for _, fn := range r.lossFns {
+		fn.Release()
+	}
+	r.lossFns = nil
 	r.canvas.Call("remove")
 }
 

--- a/vendor/github.com/0magnet/xterm-go/webgl_atlas.go
+++ b/vendor/github.com/0magnet/xterm-go/webgl_atlas.go
@@ -39,6 +39,9 @@ type atlasConfig struct {
 	dpr              float64
 	lineHeight       float64
 	colors           *ColorSet
+	// mirrorGlyph reports whether a glyph is drawn flipped left-to-right.
+	// See Options.MirrorGlyph.
+	mirrorGlyph func(string) bool
 }
 
 type rasterizedGlyph struct {
@@ -469,7 +472,24 @@ func (a *textureAtlas) drawToCache(chars string, code uint32, bg, fg, ext uint32
 
 	// draw the character itself
 	if !customGlyph {
-		ctx.Call("fillText", chars, padding, padding+cfg.deviceCharHeight)
+		// A glyph the caller wants mirrored is drawn through a flip about the
+		// middle of its cell. The canvas does the work, once, when the glyph is
+		// first rasterised into the atlas — every frame after that samples the
+		// same texture, so a mirrored terminal costs exactly as much to draw as
+		// an ordinary one.
+		//
+		// The width flipped about is the glyph's own, chWidth cells, so a wide
+		// character lands back on itself rather than beside itself.
+		if cfg.mirrorGlyph != nil && cfg.mirrorGlyph(chars) {
+			w := float64(cfg.deviceCellWidth * chWidth)
+			ctx.Call("save")
+			ctx.Call("translate", float64(padding)*2+w, 0)
+			ctx.Call("scale", -1, 1)
+			ctx.Call("fillText", chars, padding, padding+cfg.deviceCharHeight)
+			ctx.Call("restore")
+		} else {
+			ctx.Call("fillText", chars, padding, padding+cfg.deviceCharHeight)
+		}
 	}
 
 	// strikethrough

--- a/vendor/github.com/0magnet/xterm-go/xterm.go
+++ b/vendor/github.com/0magnet/xterm-go/xterm.go
@@ -38,6 +38,26 @@ type Terminal struct {
 
 	// OnTitleChange fires when the application sets the window title.
 	OnTitleChange func(title string)
+
+	// OnResize fires after the grid changed size, with the new dimensions.
+	//
+	// USE THIS RATHER THAN Core.OnResize. That field looks equally available —
+	// Attach assigns Core.OnData, so assigning Core.OnResize beside it reads as
+	// the same kind of thing — but Open sets it, and ITS handler is what tells
+	// the renderer to reallocate for the new grid. Overwriting it leaves the
+	// render model sized for the old grid while the renderer reads the new
+	// columns and rows, and the next frame indexes past the end of it:
+	//
+	//	panic: index out of range [6889] with length 6888
+	//	  xterm-go.(*rectangleRenderer).updateBackgrounds
+	//
+	// In wasm that panic ends the Go program, so the symptom is not a
+	// misdrawn terminal but every terminal on the page freezing at once. This
+	// field is fanned out from that handler and cannot displace it.
+	//
+	// It is the hook a pty bridge wants: a resize here is what should become a
+	// TIOCSWINSZ at the far end.
+	OnResize func(cols, rows int)
 	// OnBell fires on BEL.
 	OnBell func()
 	// OnSelectionChange fires when the selected text changes, including when
@@ -277,6 +297,12 @@ func (t *Terminal) wireCoreEvents() {
 		t.updateScrollArea()
 		t.renderer.onResize()
 		t.scheduleRender(true)
+		// Last, and after the renderer: a consumer told about the new size
+		// before the renderer has been reallocated for it may act on the new
+		// grid while the next frame is still drawn against the old one.
+		if t.OnResize != nil {
+			t.OnResize(cols, rows)
+		}
 	}
 	t.Core.OnCursorMove = func() {
 		t.markCursorRowDirty()
@@ -1048,4 +1074,22 @@ func jsPx(v float64) string {
 func escapeHTML(s string) string {
 	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
 	return r.Replace(s)
+}
+
+// RefreshGlyphs rebuilds the renderer's glyph cache.
+//
+// Rasterised glyphs are cached, so a change to an option that affects how one
+// is DRAWN rather than which one is drawn — Options.MirrorGlyph is the only one
+// today — is not picked up by itself: the cache still holds the glyphs as they
+// were rasterised before. Everything else that invalidates the cache does so as
+// a side effect of resizing or of the colors changing, which is why this is the
+// only place that needs saying out loud.
+//
+// A no-op on the DOM renderer, which rasterises nothing.
+func (t *Terminal) RefreshGlyphs() {
+	if r, ok := t.renderer.(*webglRenderer); ok {
+		r.refreshCharAtlas()
+		r.model.clear()
+		r.glyphs.clear()
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -49,7 +49,7 @@ github.com/0magnet/u-root/pkg/ls
 ## explicit; go 1.25.7
 github.com/0magnet/websh/shell
 github.com/0magnet/websh/shell/browser
-# github.com/0magnet/xterm-go v0.0.0-20260820124923-c0b6b4f69bb7
+# github.com/0magnet/xterm-go v0.0.0-20260823191622-8d2bbff87cea
 ## explicit; go 1.24
 github.com/0magnet/xterm-go
 github.com/0magnet/xterm-go/vt


### PR DESCRIPTION
Clean bump c0b6b4f → 8d2bbff (picks up the 'draw a glyph mirrored' option + 'survive a lost GPU context' fix). Vendored straight from the upstream commit — no vendor-tree patch. Build clean.