### PR TITLE
fix(cxo): make TPD uptime feed fillable (one gzipped leaf per window)

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -913,17 +913,23 @@ func FetchServiceURL(cmdFlags *pflag.FlagSet, url string) ([]byte, error) {
 			if rpcClient, err := Client(cmdFlags); err == nil {
 				resp, err := rpcClient.FetchCXO(visor.FetchCXOArgs{Feed: feed, Path: path})
 				if err == nil && resp != nil && resp.Hit && len(resp.Body) > 0 {
-					logger.Debugf("CXO hit for %s (feed=%s path=%s, root@%s)",
+					// Trace, not Debug: the deployment-service fetch chain
+					// (CXO → RPC → DMSG) is normal plumbing, and the CLI's
+					// package logger runs at Debug by default — so a Debug
+					// here prints this on ordinary read commands (`tp tree`,
+					// `ut`, `pv`) and pollutes their stdout. Trace keeps it
+					// available under an explicit trace level.
+					logger.Tracef("CXO hit for %s (feed=%s path=%s, root@%s)",
 						url, feed, path, resp.LastRootAt.Format(time.RFC3339))
 					return resp.Body, nil
 				}
 				if err != nil {
-					logger.Debugf("CXO probe error for %s: %v", url, err)
+					logger.Tracef("CXO probe error for %s: %v", url, err)
 				} else if resp != nil {
-					logger.Debugf("CXO miss for %s: %s", url, resp.Reason)
+					logger.Tracef("CXO miss for %s: %s", url, resp.Reason)
 				}
 			} else {
-				logger.Debugf("CXO step skipped (no RPC client): %v", err)
+				logger.Tracef("CXO step skipped (no RPC client): %v", err)
 			}
 		}
 	}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -24,6 +24,15 @@ func (logger *Logger) WithTime(t time.Time) *logrus.Entry {
 	return logger.WithFields(logrus.Fields{}).WithTime(t)
 }
 
+// Tracef logs at trace level (below Debug). The embedded logrus.FieldLogger
+// interface omits the Trace methods, so a *Logger otherwise can't emit at
+// trace without reaching through WithField; this forwards through the entry.
+// Used to keep low-value diagnostics (e.g. the CLI's CXO fetch-chain hit/miss
+// notes) off ordinary stdout, since the CLI's package logger runs at Debug.
+func (logger *Logger) Tracef(format string, args ...interface{}) {
+	logger.WithFields(logrus.Fields{}).Tracef(format, args...)
+}
+
 // WithAppName returns a derived Logger that attaches app_name=<name>
 // to every entry. Empty name is a no-op (returns the receiver).
 // Used by router-side scoping so 'cli proxy start --verbose' can

--- a/pkg/transport-discovery/api/cxo_uptime_publisher.go
+++ b/pkg/transport-discovery/api/cxo_uptime_publisher.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -42,15 +43,23 @@ var uptimePublishDays = []int{1, 7, 30}
 const uptimePublishInterval = 60 * time.Second
 
 // UptimeCXOPublisher publishes the network-wide visor-uptime aggregate for
-// each of uptimePublishDays. Rather than one monolithic `[]VisorSummary` leaf
-// per window at "uptimes/days/<n>" (which, at fleet scale with the v3 288-char
-// timeline strings, exceeded CXO's 16 MB MaxObjectSize and failed the Put with
-// "object is too large" — the serve-side feed the subscriber could never
-// fill), it writes one small per-visor leaf at "uptimes/days/<n>/<pkHex>". No
-// single object is fleet-sized, so the Put always succeeds; content-addressing
-// re-broadcasts only the visors whose bucket changed; and a subscriber whose
-// fill truncates still salvages every per-visor leaf that landed (see the
-// treestore subscriber's partial-fill recovery). Closed by Close.
+// each of uptimePublishDays as ONE gzipped leaf per window at "uptimes/days/<n>"
+// — the same few-large-objects shape as the all-transports publisher, and for
+// the same reason: a subscriber fills a Root over the transient dmsg conn the
+// publisher's re-announce delivers it on, and that conn closes moments later. A
+// Root of a handful of leaves fills in one short burst; a Root fanned out into
+// one leaf PER VISOR PER WINDOW (the previous shape) needs a request round-trip
+// per object, never completes before the conn drops, and every subscriber fill
+// dies with "no connections to fill from" — so the feed published a Root that
+// no one could ever fill (`cli visor cxo status` → tpd-uptime last_err="timeout
+// waiting for Root after 10s", while the 2-leaf all-transports feed synced
+// fine on the same TPD peer).
+//
+// The 16 MB MaxObjectSize that drove the earlier per-visor split is not a
+// problem for a single leaf here: each visor is encoded as a compactVisorSummary
+// (36-byte timeline bitmaps, ~8x smaller than the v3 288-char strings that blew
+// past the limit) and the whole window array is gzipped before the Put, so the
+// stored object is well under 16 MB for any realistic fleet. Closed by Close.
 type UptimeCXOPublisher struct {
 	api *API
 	pub *treestore.Publisher
@@ -58,13 +67,6 @@ type UptimeCXOPublisher struct {
 
 	cancel context.CancelFunc
 	done   chan struct{}
-
-	// prevPKs tracks, per day-window, the set of per-visor leaf hex-PK
-	// segments published on the previous tick, so this tick can emit delete
-	// ops for visors that dropped out of the aggregate (a naive Put-only
-	// refresh would leave their stale leaves lingering forever). Touched only
-	// from the single publish loop goroutine, so no lock.
-	prevPKs map[int]map[string]struct{}
 
 	mu        sync.Mutex
 	lastError error
@@ -110,12 +112,11 @@ func StartUptimeCXOPublisher(ctx context.Context, api *API, dmsgC *dmsg.Client, 
 
 	pubCtx, cancel := context.WithCancel(ctx)
 	up := &UptimeCXOPublisher{
-		api:     api,
-		pub:     pub,
-		log:     log,
-		cancel:  cancel,
-		done:    make(chan struct{}),
-		prevPKs: make(map[int]map[string]struct{}),
+		api:    api,
+		pub:    pub,
+		log:    log,
+		cancel: cancel,
+		done:   make(chan struct{}),
 	}
 	if logger != nil {
 		logger.WithField("feed_pk", pub.Feed()).WithField("dmsg_port", skyenv.DmsgTPDUptimeCXOPort).
@@ -185,42 +186,32 @@ func (u *UptimeCXOPublisher) publishOnce(ctx context.Context) {
 	}
 }
 
-// publishWindow writes one small per-visor leaf at "uptimes/days/<n>/<pkHex>"
-// for every summary, plus delete ops for any visor published last tick that
-// is gone this tick, in a single PutBatch. Splitting the window into per-visor
-// leaves (each a compactVisorSummary with bitmap timelines) keeps every CXO
-// object well under MaxObjectSize — the whole point of the change: the
-// monolithic []VisorSummary leaf failed the Put once the fleet's v3 timelines
-// pushed it past 16 MB.
+// publishWindow writes the whole window as ONE gzipped []compactVisorSummary
+// leaf at "uptimes/days/<n>", overwriting the previous tick's value. One leaf
+// (not one-per-visor) is what keeps a subscriber's Root fill completing over
+// the short-lived delivering dmsg conn — see the type doc. The array is always
+// Put (even empty → "[]"), so a Root always exists for a subscriber to sync,
+// exactly like the all-transports publisher; an empty per-visor batch used to
+// publish no Root at all.
 func (u *UptimeCXOPublisher) publishWindow(days int, summaries []store.VisorSummary) {
-	base := uptimePath(days)
-	live := make(map[string]struct{}, len(summaries))
-	ops := make([]treestore.PutOp, 0, len(summaries))
+	compact := make([]compactVisorSummary, 0, len(summaries))
 	for i := range summaries {
-		hexPK := summaries[i].PK.Hex()
-		body, err := json.Marshal(toCompactVisorSummary(summaries[i]))
-		if err != nil {
-			u.log.WithError(err).WithField("days", days).Warn("uptime per-visor marshal failed")
-			u.recordError(err)
-			continue
-		}
-		live[hexPK] = struct{}{}
-		ops = append(ops, treestore.PutOp{Path: base + "/" + hexPK, Value: body})
+		compact = append(compact, toCompactVisorSummary(summaries[i]))
 	}
-	// Delete leaves for visors that dropped out of the aggregate since the
-	// previous tick (nil Value = delete). Without this, a visor that leaves
-	// the cache keeps a stale leaf forever.
-	for hexPK := range u.prevPKs[days] {
-		if _, still := live[hexPK]; !still {
-			ops = append(ops, treestore.PutOp{Path: base + "/" + hexPK, Value: nil})
-		}
-	}
-	if err := u.pub.PutBatch(ops); err != nil {
-		u.log.WithError(err).WithField("days", days).Warn("uptime publisher PutBatch failed")
+	body, err := json.Marshal(compact)
+	if err != nil {
+		u.log.WithError(err).WithField("days", days).Warn("uptime window marshal failed")
 		u.recordError(err)
 		return
 	}
-	u.prevPKs[days] = live
+	// gzip before Put: CXO stores + propagates object bytes verbatim, so a raw
+	// JSON body travels uncompressed. Subscribers auto-detect + gunzip
+	// (cxoutils.Gunzip). Matches the all-transports publisher.
+	if err := u.pub.Put(uptimePath(days), cxoutils.Gzip(body)); err != nil {
+		u.log.WithError(err).WithField("days", days).Warn("uptime publisher Put failed")
+		u.recordError(err)
+		return
+	}
 }
 
 // toCompactVisorSummary converts a store.VisorSummary (v3 shape, 288-char

--- a/pkg/visor/api_tpd_uptime_subscriber.go
+++ b/pkg/visor/api_tpd_uptime_subscriber.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/transport-discovery/store"
 )
 
@@ -89,17 +90,30 @@ type compactVisorSummary struct {
 // from whichever wire form the connected TPD published (dual-parse for the
 // rollout window where publishers and subscribers redeploy independently):
 //
-//   - Legacy: one monolithic leaf at exactly "uptimes/days/<n>" — returned
-//     verbatim (it is already the v3 shape).
-//   - Current: one per-visor leaf at "uptimes/days/<n>/<pkHex>" carrying a
-//     compactVisorSummary — reassembled into `[]store.VisorSummary`, with each
-//     day's bitmap rendered back to the 288-char string so the CLI/hvui
-//     consumers see the exact HTTP /uptimes?v=v3 shape unchanged.
+//   - Current: one gzipped `[]compactVisorSummary` leaf at exactly
+//     "uptimes/days/<n>" — gunzipped and reassembled into `[]store.VisorSummary`,
+//     with each day's bitmap rendered back to the 288-char string so the
+//     CLI/hvui consumers see the exact HTTP /uptimes?v=v3 shape unchanged. One
+//     leaf (not one-per-visor) is what lets the subscriber's Root fill complete
+//     over the transient dmsg conn — see the publisher's type doc.
+//   - Legacy: one per-visor leaf at "uptimes/days/<n>/<pkHex>" carrying a
+//     compactVisorSummary — the previous shape, reassembled the same way. Kept
+//     so a not-yet-redeployed TPD still reads (its Root rarely fills, but when
+//     it does this salvages it).
 //
 // ok is false when neither form has any data yet.
 func readUptimeWindow(mgr uptimeCXOSubMgr, path string) ([]byte, time.Time, bool) {
 	if body, ts, ok := mgr.Get(FeedTPDUptime, path); ok && len(body) > 0 {
-		return body, ts, true
+		var compact []compactVisorSummary
+		if err := json.Unmarshal(cxoutils.Gunzip(body), &compact); err == nil {
+			summaries := make([]store.VisorSummary, 0, len(compact))
+			for i := range compact {
+				summaries = append(summaries, fromCompactVisorSummary(compact[i]))
+			}
+			if out, ok := marshalSummaries(summaries); ok {
+				return out, ts, true
+			}
+		}
 	}
 	var (
 		summaries []store.VisorSummary
@@ -125,13 +139,22 @@ func readUptimeWindow(mgr uptimeCXOSubMgr, path string) ([]byte, time.Time, bool
 	if _, ts, ok := mgr.Get(FeedTPDUptime, firstPath); ok {
 		newest = ts
 	}
-	// Stable order so repeated reads (and cache files) don't churn.
-	sort.Slice(summaries, func(i, j int) bool { return summaries[i].PK.Hex() < summaries[j].PK.Hex() })
-	out, err := json.Marshal(summaries)
-	if err != nil {
+	out, ok := marshalSummaries(summaries)
+	if !ok {
 		return nil, time.Time{}, false
 	}
 	return out, newest, true
+}
+
+// marshalSummaries sorts by PK (stable output so repeated reads and cache files
+// don't churn) and marshals the v3 `[]store.VisorSummary` body.
+func marshalSummaries(summaries []store.VisorSummary) ([]byte, bool) {
+	sort.Slice(summaries, func(i, j int) bool { return summaries[i].PK.Hex() < summaries[j].PK.Hex() })
+	out, err := json.Marshal(summaries)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
 }
 
 // fromCompactVisorSummary reconstructs the full v3 store.VisorSummary from a

--- a/pkg/visor/api_tpd_uptime_subscriber_test.go
+++ b/pkg/visor/api_tpd_uptime_subscriber_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/transport-discovery/store"
 )
 
@@ -46,18 +47,40 @@ func mkTimeline(setSlot int) string {
 	return string(b)
 }
 
-func TestReadUptimeWindowLegacyMonolith(t *testing.T) {
-	want := []byte(`[{"pk":"000000...","on":true}]`)
+// TestReadUptimeWindowGzippedCompactLeaf exercises the current wire shape: one
+// gzipped []compactVisorSummary leaf at exactly "uptimes/days/<n>". The reader
+// must gunzip, reconstruct the v3 store.VisorSummary shape, and render each
+// bitmap back to the 288-char timeline string.
+func TestReadUptimeWindowGzippedCompactLeaf(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	compact := []compactVisorSummary{{
+		PK:       pk,
+		Online:   true,
+		Version:  "v1.3.99",
+		Timeline: map[string][]byte{"2026-08-19": timelineBitmap(mkTimeline(5))},
+	}}
+	raw, _ := json.Marshal(compact) //nolint:errcheck
 	mgr := &fakeUptimeMgr{
-		snap: map[string][]byte{"uptimes/days/30": want},
+		snap: map[string][]byte{"uptimes/days/30": cxoutils.Gzip(raw)},
 		ts:   time.Unix(1000, 0),
 	}
 	got, ts, ok := readUptimeWindow(mgr, "uptimes/days/30")
-	if !ok || string(got) != string(want) {
-		t.Fatalf("monolith: got %q,%v want verbatim", got, ok)
+	if !ok {
+		t.Fatal("expected gzipped-compact-leaf hit")
 	}
 	if !ts.Equal(time.Unix(1000, 0)) {
-		t.Fatalf("monolith ts = %v", ts)
+		t.Fatalf("ts = %v, want 1000", ts)
+	}
+	var summaries []store.VisorSummary
+	if err := json.Unmarshal(got, &summaries); err != nil {
+		t.Fatalf("unmarshal reconstructed body: %v", err)
+	}
+	if len(summaries) != 1 || summaries[0].PK != pk || !summaries[0].Online {
+		t.Fatalf("summary not reconstructed: %+v", summaries)
+	}
+	tl := summaries[0].Timeline["2026-08-19"]
+	if len(tl) != 288 || tl[5] != '.' {
+		t.Fatalf("timeline not rendered: len=%d slot5=%q", len(tl), string(tl[5]))
 	}
 }
 


### PR DESCRIPTION
### Problem

`cli visor cxo status` showed the `tpd-uptime` feed permanently stuck at
`last_err="timeout waiting for Root after 10s"`, never syncing — while
`tpd-all-transports`, published by the *same* TPD peer on a different dmsg
CXO port, synced fine. The CLI fell back to the DMSG-HTTP `/uptimes` path
and leaked `CXO miss for …/uptimes` / `CXO hit for …/all-transports` DEBUG
lines onto ordinary `tp tree` / `ut` stdout.

### Root cause

The uptime publisher fanned each day-window out into one leaf **per visor**
(`uptimes/days/<n>/<pkHex>`). A subscriber fills a Root's referenced objects
over the transient dmsg conn the publisher's re-announce delivers it on, and
that conn closes moments later. A Root of hundreds of per-visor objects needs
a request round-trip per object and never completes — every fill dies with
`no connections to fill from`, so the feed published a Root nobody could fill.

A standalone third-party CXO probe against the live TPD confirmed it:

- port 52 (uptime): `ROOT RECEIVED` then `FILL-BROKE (received=4 filled=0)`, `no connections to fill from`
- port 55 (all-transports, a 2-leaf gzipped snapshot): `ROOT-FILLED (received=2 filled=2)`

A longer first-sync timeout is not the fix — a 70s probe still filled zero objects.

### Fix

Publish each window as **one gzipped `[]compactVisorSummary` leaf** at
`uptimes/days/<n>`, mirroring the all-transports publisher's few-large-objects
shape that fills reliably. The 16 MB `MaxObjectSize` that originally drove the
per-visor split is not a concern for a single leaf: the compact 36-byte
timeline bitmaps (~8× smaller than the v3 288-char strings) plus gzip keep the
object well under the limit for any realistic fleet. The reader gunzips and
reconstructs the exact v3 `/uptimes?v=v3` shape, and keeps the per-visor `Walk`
as a rollout fallback for a not-yet-redeployed TPD.

Separately, demote the CLI's CXO fetch-chain hit/miss diagnostics from Debug
to Trace (the CLI package logger runs at Debug by default), so they no longer
pollute normal read-command stdout. Adds a `Tracef` forwarder to
`logging.Logger` since the wrapped `logrus.FieldLogger` interface omits the
Trace methods.

### Validation

- `go build .`, `go vet`, `gofmt`, and `go test` for the touched packages pass.
- Reader unit test updated to the new gzipped-compact single-leaf wire shape; the legacy per-visor reassembly test is retained.
- Debug-quieting verified live: the `CXO hit/miss` lines no longer print on `tp tree` / `ut` with the rebuilt CLI.
- The fill fix itself is validated structurally (identical shape to the all-transports feed the probe proved fills) — the production visor/TPD were not restarted, so live `tpd-uptime` sync is confirmed by consistency with the working feed rather than a live re-sync.