### PR TITLE
feat(proxy): bilateral route-group tree on status page + `proxy tree` CLI

### DIFF
--- a/cmd/skywire-cli/commands/proxy/tree.go
+++ b/cmd/skywire-cli/commands/proxy/tree.go
@@ -1,0 +1,211 @@
+// Package skysocksc cmd/skywire-cli/commands/proxy/tree.go c4-vis-cli
+package skysocksc
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/bitree"
+	"github.com/skycoin/skywire/pkg/cliout"
+	"github.com/skycoin/skywire/pkg/proxystatus"
+)
+
+var treeColor string
+
+func init() {
+	RootCmd.AddCommand(treeCmd)
+	treeCmd.Flags().StringVarP(&clientName, "name", "n", "skysocks-client", "name of the running proxy client to inspect")
+	treeCmd.Flags().StringVar(&treeColor, "color", "auto", "colorize the tree: auto|always|never")
+}
+
+var treeCmd = &cobra.Command{
+	Use:   "tree",
+	Short: "Render a running proxy's route group as a bilateral route tree",
+	Long: `Render an already-running proxy client's live route group as a bilateral
+route tree — the SAME model + shape the proxy status page
+(http://status.skysocks/) draws, rooted at this visor.
+
+Each active route is a branch: its hop chain to the exit (each hop
+carrying its transport [type] · id · rtt), with a left summary block
+(R[n], a state dot ● active / ○ standby, the end-to-end route rtt, and
+its bandwidth X↑ Y↓). Dead legs are pruned. Public keys are never
+truncated.
+
+This is read-only and attach-only: it queries the visor's route-group
+telemetry over RPC and never starts, stops, or reshapes the app. It is
+the tree companion to 'proxy log' (which streams the events/log).
+
+  proxy tree                  render skysocks-client's route tree
+  proxy tree -n vpn-client    render a different client's route tree
+  proxy tree --json           machine-readable route-group legs
+  proxy tree --color never    plain (no ANSI), e.g. for piping`,
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, _ []string) {
+		if clientName == "" {
+			clientName = "skysocks-client"
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
+		}
+		defer rpcClient.Close() //nolint:errcheck,gosec
+
+		infos, err := rpcClient.RouteGroupMuxInfo(clientName)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("RouteGroupMuxInfo: %w", err))
+		}
+
+		// JSON contract is the stable boundary: re-marshal the wire response and
+		// decode it into a local mirror (so this command doesn't import the visor
+		// type), which also feeds --json.
+		raw, _ := json.Marshal(infos) //nolint:errcheck
+		var rgs []treeRouteGroup
+		_ = json.Unmarshal(raw, &rgs) //nolint:errcheck
+
+		if cliout.JSONMode(cmd) {
+			internal.Catch(cmd.Flags(), cliout.Print(cmd, rgs))
+			return
+		}
+
+		if len(rgs) == 0 {
+			fmt.Printf("no active route group for app=%s (is the proxy running?)\n", clientName)
+			return
+		}
+
+		snap := rgs[0].toSnapshot()
+		opts := bitree.Options{}
+		if wantColor(treeColor) {
+			opts.StyleCell = ansiStyleCell
+		}
+		fmt.Println(bitree.Render(proxystatus.RouteTree(snap), opts))
+	},
+}
+
+// wantColor resolves the --color mode; "auto" colorizes only when stdout is a
+// terminal.
+func wantColor(mode string) bool {
+	switch strings.ToLower(mode) {
+	case "always", "yes", "true":
+		return true
+	case "never", "no", "false":
+		return false
+	default:
+		return term.IsTerminal(int(os.Stdout.Fd()))
+	}
+}
+
+const (
+	ansiReset  = "\x1b[0m"
+	ansiBold   = "\x1b[1m"
+	ansiDim    = "\x1b[2m"
+	ansiCyan   = "\x1b[36m"
+	ansiGreen  = "\x1b[32m"
+	ansiYellow = "\x1b[33m"
+)
+
+// ansiStyleCell colorizes the route tree for a terminal without changing any
+// cell's display width (ANSI escapes are zero-width; bitree lays out from the
+// plain text). PKs/labels cyan, transport columns dim, and the left summary
+// tinted by state (green active / yellow standby) — the state dot the adapter
+// chose selects the hue, so no state word is needed.
+func ansiStyleCell(text string, kind bitree.CellKind) string {
+	switch kind {
+	case bitree.CellRoot:
+		return ansiBold + ansiCyan + text + ansiReset
+	case bitree.CellLabel:
+		return ansiCyan + text + ansiReset
+	case bitree.CellColumn:
+		return ansiDim + text + ansiReset
+	case bitree.CellLeft:
+		if strings.TrimSpace(text) == "" {
+			return text
+		}
+		if strings.Contains(text, proxystatus.GlyphStandby) {
+			return ansiYellow + text + ansiReset
+		}
+		return ansiGreen + text + ansiReset
+	default:
+		return text
+	}
+}
+
+// treeRouteGroup mirrors visor.MuxRouteGroupInfo by its JSON contract (the same
+// approach mux_info.go uses) so this command needs no visor import. It carries
+// the per-leg hop chain + route/transport rtt the bilateral tree needs.
+type treeRouteGroup struct {
+	Desc struct {
+		DstPK string `json:"dst_pk"`
+		SrcPK string `json:"src_pk"`
+	} `json:"desc"`
+	MuxEnabled bool          `json:"mux_enabled"`
+	Legs       []treeLegInfo `json:"legs"`
+}
+
+type treeLegInfo struct {
+	Index          int           `json:"index"`
+	TransportID    string        `json:"transport_id"`
+	TpType         string        `json:"tp_type"`
+	RemotePK       string        `json:"remote_pk"`
+	LatencyMS      float64       `json:"latency_ms,omitempty"`
+	RouteLatencyMS float64       `json:"route_latency_ms,omitempty"`
+	Direct         bool          `json:"direct"`
+	SentBytes      uint64        `json:"sent_bytes"`
+	RecvBytes      uint64        `json:"recv_bytes"`
+	Retransmits    uint64        `json:"retransmits"`
+	Alive          bool          `json:"alive"`
+	Standby        bool          `json:"standby"`
+	Hops           []treeHopInfo `json:"hops,omitempty"`
+}
+
+type treeHopInfo struct {
+	TpID      string  `json:"tp_id"`
+	From      string  `json:"from"`
+	To        string  `json:"to"`
+	TpType    string  `json:"tp_type"`
+	LatencyMS float64 `json:"latency_ms,omitempty"`
+}
+
+// toSnapshot projects the wire route group into the shared proxystatus.Snapshot
+// shape the RouteTree adapter consumes — the exact structure the visor builds
+// for the status page, so the CLI and the page render identically.
+func (rg treeRouteGroup) toSnapshot() proxystatus.Snapshot {
+	snap := proxystatus.Snapshot{
+		Surface:    proxystatus.SurfaceSkysocks,
+		App:        clientName,
+		MuxEnabled: rg.MuxEnabled,
+	}
+	for _, l := range rg.Legs {
+		leg := proxystatus.Leg{
+			Index:          l.Index,
+			TransportID:    l.TransportID,
+			TpType:         l.TpType,
+			RemotePK:       l.RemotePK,
+			LatencyMS:      l.LatencyMS,
+			RouteLatencyMS: l.RouteLatencyMS,
+			Direct:         l.Direct,
+			SentBytes:      l.SentBytes,
+			RecvBytes:      l.RecvBytes,
+			Retransmits:    l.Retransmits,
+			Alive:          l.Alive,
+			Standby:        l.Standby,
+		}
+		for _, h := range l.Hops {
+			leg.Hops = append(leg.Hops, proxystatus.Hop{
+				TpID:      h.TpID,
+				From:      h.From,
+				To:        h.To,
+				TpType:    h.TpType,
+				LatencyMS: h.LatencyMS,
+			})
+		}
+		snap.Legs = append(snap.Legs, leg)
+	}
+	return snap
+}

--- a/pkg/bitree/bitree.go
+++ b/pkg/bitree/bitree.go
@@ -1,0 +1,458 @@
+// Package bitree renders a generic bilateral (two-sided) tree as monospace
+// plain text using box-drawing glyphs.
+//
+// A bilateral tree has a single root whose children extend RIGHTWARD (the
+// normal topology). In addition, any node may carry a mirror subtree that
+// extends LEFTWARD, hanging at the same rows as the right-side branches. The
+// renderer auto-justifies with whitespace so the central spine aligns in one
+// column, left content is right-justified up to the spine, and right content
+// flows out from the spine. Optional trailing columns are aligned in a block
+// regardless of tree depth (like `skywire cli tp tree`).
+//
+// Layout and styling are separable: the geometry is computed from the plain
+// (unstyled) text, and an optional StyleCell hook decorates cells afterwards
+// so a color wrapper or HTML renderer can restyle without disturbing columns.
+package bitree
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// Node is a bilateral tree node.
+//
+//   - Right holds rightward children (the topology): the node's label sits on
+//     its own row and each right child hangs below it, nesting arbitrarily.
+//   - Left holds leftward children (annotations), themselves a full nestable
+//     subtree that mirrors the right connector logic. The left block hangs at
+//     the same rows as the right branches.
+//   - Cols holds optional trailing columns for the node's row; they are padded
+//     into an aligned block across every right-side line.
+type Node struct {
+	Label string
+	Right []*Node
+	Left  []*Node
+	Cols  []string
+}
+
+// CellKind identifies the semantic role of a cell passed to StyleCell.
+type CellKind int
+
+const (
+	// CellRoot is the root label.
+	CellRoot CellKind = iota
+	// CellLabel is a right-side node label.
+	CellLabel
+	// CellColumn is a trailing aligned column cell.
+	CellColumn
+	// CellLeft is a left-side (annotation) block line. It carries the whole
+	// left field for a row (right-justified, connectors included), so a styler
+	// may recolor specific glyphs within it. Styling is applied after layout, so
+	// it must preserve display width.
+	CellLeft
+)
+
+// GlyphSet is the set of box-drawing glyphs used by the renderer. The zero
+// value is unusable; use DefaultGlyphs (or Options with a nil GlyphSet, which
+// falls back to DefaultGlyphs).
+type GlyphSet struct {
+	Horizontal string // ─
+	Vertical   string // │
+	TeeRight   string // ├  (up+down+right)
+	TeeLeft    string // ┤  (up+down+left)
+	TeeDown    string // ┬  (down+left+right)
+	TeeUp      string // ┴  (up+left+right)
+	Cross      string // ┼  (up+down+left+right)
+	CornerUL   string // ┘  (up+left)
+	CornerDR   string // ┌  (down+right)
+	CornerUR   string // └  (up+right)
+}
+
+// DefaultGlyphs returns the light box-drawing glyph set.
+func DefaultGlyphs() GlyphSet {
+	return GlyphSet{
+		Horizontal: "─",
+		Vertical:   "│",
+		TeeRight:   "├",
+		TeeLeft:    "┤",
+		TeeDown:    "┬",
+		TeeUp:      "┴",
+		Cross:      "┼",
+		CornerUL:   "┘",
+		CornerDR:   "┌",
+		CornerUR:   "└",
+	}
+}
+
+// Options controls rendering. The zero value is valid and renders with sane
+// defaults (light glyphs, two-space column separator).
+type Options struct {
+	// Glyphs is the box-drawing glyph set; empty fields fall back to
+	// DefaultGlyphs.
+	Glyphs GlyphSet
+	// LeftGutter is the number of spaces printed at the very start of every
+	// line (before the left block).
+	LeftGutter int
+	// ColSep separates trailing columns. Defaults to two spaces.
+	ColSep string
+	// AlignColumns, if > 0, is the minimum width the right-side tree portion
+	// is padded to before trailing columns are appended. When the tree portion
+	// is wider than this the columns shift right (acceptable). When 0 the pad
+	// is the natural max tree width.
+	AlignColumns int
+	// StyleCell, if non-nil, post-processes each cell's text. It must not
+	// change the cell's display width if column alignment is to be preserved
+	// (ANSI color codes are fine — they have zero display width). Layout is
+	// computed from the un-styled text, so styling is purely cosmetic.
+	StyleCell func(text string, kind CellKind) string
+}
+
+func (o Options) glyphs() GlyphSet {
+	g := o.Glyphs
+	d := DefaultGlyphs()
+	if g.Horizontal == "" {
+		g.Horizontal = d.Horizontal
+	}
+	if g.Vertical == "" {
+		g.Vertical = d.Vertical
+	}
+	if g.TeeRight == "" {
+		g.TeeRight = d.TeeRight
+	}
+	if g.TeeLeft == "" {
+		g.TeeLeft = d.TeeLeft
+	}
+	if g.TeeDown == "" {
+		g.TeeDown = d.TeeDown
+	}
+	if g.TeeUp == "" {
+		g.TeeUp = d.TeeUp
+	}
+	if g.Cross == "" {
+		g.Cross = d.Cross
+	}
+	if g.CornerUL == "" {
+		g.CornerUL = d.CornerUL
+	}
+	if g.CornerDR == "" {
+		g.CornerDR = d.CornerDR
+	}
+	if g.CornerUR == "" {
+		g.CornerUR = d.CornerUR
+	}
+	return g
+}
+
+func (o Options) colSep() string {
+	if o.ColSep == "" {
+		return "  "
+	}
+	return o.ColSep
+}
+
+func (o Options) style(text string, kind CellKind) string {
+	if o.StyleCell == nil {
+		return text
+	}
+	return o.StyleCell(text, kind)
+}
+
+// dispWidth returns the monospace display width of s. All glyphs used here
+// (box-drawing, arrows, the horizontal ellipsis) are single-width runes, so a
+// rune count is correct; callers should avoid wide CJK/emoji in cells.
+func dispWidth(s string) int { return utf8.RuneCountInString(s) }
+
+func padLeft(s string, w int) string {
+	if n := w - dispWidth(s); n > 0 {
+		return strings.Repeat(" ", n) + s
+	}
+	return s
+}
+
+// rline is one rendered right-side line: a plain connector prefix, a plain
+// label, and the node's trailing columns. Keeping the label separate lets the
+// StyleCell hook decorate it without corrupting width math.
+type rline struct {
+	prefix string
+	label  string
+	cols   []string
+}
+
+func (r rline) treeWidth() int { return dispWidth(r.prefix) + dispWidth(r.label) }
+
+// rightLayout renders node as a standard downward tree flowing rightward. The
+// node's label is row 0; each right child hangs below with ├──/└── connectors.
+func rightLayout(node *Node, g GlyphSet) []rline {
+	out := []rline{{prefix: "", label: node.Label, cols: node.Cols}}
+	h := g.Horizontal
+	for i, child := range node.Right {
+		last := i == len(node.Right)-1
+		var head, cont string
+		if last {
+			head = g.CornerUR + h + h + " " // "└── "
+			cont = "    "
+		} else {
+			head = g.TeeRight + h + h + " " // "├── "
+			cont = g.Vertical + "   "       // "│   "
+		}
+		sub := rightLayout(child, g)
+		for j, s := range sub {
+			p := cont
+			if j == 0 {
+				p = head
+			}
+			out = append(out, rline{prefix: p + s.prefix, label: s.label, cols: s.cols})
+		}
+	}
+	return out
+}
+
+// leftLayout renders node as a mirror tree flowing leftward, returned as a
+// rectangle of width w whose rightmost column (w-1) is the connection point on
+// row 0 (the node's label's last cell). Child subtrees hang below-left with
+// mirrored connectors reaching the junction column.
+func leftLayout(node *Node, g GlyphSet) (lines []string, w int) {
+	labelW := dispWidth(node.Label)
+	if len(node.Left) == 0 {
+		return []string{node.Label}, labelW
+	}
+	h := g.Horizontal
+	type cg struct {
+		lines []string
+		w     int
+	}
+	children := make([]cg, len(node.Left))
+	childW := 0
+	for i, c := range node.Left {
+		cl, cw := leftLayout(c, g)
+		children[i] = cg{cl, cw}
+		if cw > childW {
+			childW = cw
+		}
+	}
+	// Junction sits at the block's right edge. A child connects via a 4-cell
+	// segment " ──<glyph>" to its left, so a child's right edge lands at w-5.
+	w = labelW
+	if childW+4 > w {
+		w = childW + 4
+	}
+	lines = append(lines, padLeft(node.Label, w)) // label flush right; junction = last cell
+	for i, c := range children {
+		last := i == len(node.Left)-1
+		for r, cl := range c.lines {
+			body := padLeft(cl, w-4) // child right edge at col w-5
+			var conn string
+			switch {
+			case r == 0 && last:
+				conn = " " + h + h + g.CornerUL // " ──┘"
+			case r == 0:
+				conn = " " + h + h + g.TeeLeft // " ──┤"
+			case last:
+				conn = "    "
+			default:
+				conn = "   " + g.Vertical // "   │"
+			}
+			lines = append(lines, body+conn)
+		}
+	}
+	return lines, w
+}
+
+// spineGlyph returns the junction glyph for a top-level route on the spine.
+// right is always true.
+func spineGlyph(g GlyphSet, up, down, left bool) string {
+	switch {
+	case up && down:
+		if left {
+			return g.Cross
+		}
+		return g.TeeRight
+	case up:
+		if left {
+			return g.TeeUp
+		}
+		return g.CornerUR
+	case down:
+		if left {
+			return g.TeeDown
+		}
+		return g.CornerDR
+	default:
+		return g.Horizontal
+	}
+}
+
+// Render renders the bilateral tree rooted at root and returns monospace
+// plain text (no trailing newline on the final line). root.Right are the
+// top-level "routes" laid out as a vertical spine; each route's Left is its
+// mirrored annotation subtree.
+func Render(root *Node, opts Options) string {
+	if root == nil {
+		return ""
+	}
+	g := opts.glyphs()
+	h := g.Horizontal
+
+	// Build each route (top-level right child) into a set of rows.
+	type row struct {
+		left     string // left block line (plain), un-justified
+		hasLeft  bool
+		anchor   bool   // spine junction row
+		spine    string // spine column glyph for this row
+		right    rline  // right-side tree line
+		hasRight bool
+	}
+	var (
+		routes    [][]row
+		leftWidth int // max width of any left block line, across all routes
+	)
+	nRoutes := len(root.Right)
+	for i, route := range root.Right {
+		rlines := rightLayout(route, g)
+		var llines []string
+		if len(route.Left) > 0 {
+			// A route may carry a forest of left children; stack them as a
+			// single mirror block by wrapping in a synthetic parent whose own
+			// label is empty is awkward, so render each and concatenate with
+			// the first as the spine anchor. In practice the common case is a
+			// single left child (possibly deeply nested).
+			for _, lc := range route.Left {
+				sub, _ := leftLayout(lc, g)
+				llines = append(llines, sub...)
+			}
+		}
+		for _, l := range llines {
+			if dw := dispWidth(l); dw > leftWidth {
+				leftWidth = dw
+			}
+		}
+		up := i > 0
+		down := i < nRoutes-1
+		n := len(rlines)
+		if len(llines) > n {
+			n = len(llines)
+		}
+		rows := make([]row, n)
+		for r := 0; r < n; r++ {
+			var rw row
+			if r < len(llines) {
+				rw.left = llines[r]
+				rw.hasLeft = len(route.Left) > 0 && r == 0
+			}
+			if r < len(rlines) {
+				rw.right = rlines[r]
+				rw.hasRight = true
+			}
+			if r == 0 {
+				rw.anchor = true
+				rw.spine = spineGlyph(g, up, down, len(route.Left) > 0)
+			} else if down {
+				rw.spine = g.Vertical
+			} else {
+				rw.spine = " "
+			}
+			rows[r] = rw
+		}
+		routes = append(routes, rows)
+	}
+
+	// Column alignment: max tree width and per-column widths across all
+	// right-side lines.
+	treeWidth := opts.AlignColumns
+	var colW []int
+	for _, rows := range routes {
+		for _, rw := range rows {
+			if !rw.hasRight {
+				continue
+			}
+			if tw := rw.right.treeWidth(); tw > treeWidth {
+				treeWidth = tw
+			}
+			for ci, c := range rw.right.cols {
+				for len(colW) <= ci {
+					colW = append(colW, 0)
+				}
+				if cw := dispWidth(c); cw > colW[ci] {
+					colW[ci] = cw
+				}
+			}
+		}
+	}
+
+	gutter := strings.Repeat(" ", opts.LeftGutter)
+	sep := opts.colSep()
+
+	// Assemble every line.
+	var b strings.Builder
+	writeLine := func(s string) {
+		b.WriteString(strings.TrimRight(s, " "))
+		b.WriteByte('\n')
+	}
+
+	// Root label centered over the right region.
+	spineCol := opts.LeftGutter + leftWidth + 1 + 2 // gutter + leftfield + space + 2-cell arm
+	rightStart := spineCol + 1 + 3                  // spine glyph + "── "
+	// Estimate right region width from the widest assembled right side.
+	rightRegionW := treeWidth
+	// account for columns
+	colsTotal := 0
+	for _, cw := range colW {
+		colsTotal += cw + dispWidth(sep)
+	}
+	rightRegionW += colsTotal
+	rootCol := rightStart + (rightRegionW-dispWidth(root.Label))/2
+	if rootCol < 0 {
+		rootCol = 0
+	}
+	writeLine(strings.Repeat(" ", rootCol) + opts.style(root.Label, CellRoot))
+
+	for _, rows := range routes {
+		for _, rw := range rows {
+			// Left field (right-justified to leftWidth). Styled after layout so a
+			// color/HTML wrapper may decorate glyphs within it without disturbing
+			// column math (StyleCell must preserve display width).
+			left := opts.style(padLeft(rw.left, leftWidth), CellLeft)
+			// Middle connector: gutter + left field + space + arm(2) + spine.
+			var arm string
+			if rw.anchor && rw.hasLeft {
+				arm = h + h
+			} else {
+				arm = "  "
+			}
+			mid := gutter + left + " " + arm + rw.spine
+
+			// Right region.
+			var rightText string
+			if rw.hasRight {
+				var rprefix string
+				if rw.anchor {
+					rprefix = h + h + " " // right arm "── "
+				} else {
+					rprefix = "   "
+				}
+				tree := rprefix + rw.right.prefix + opts.style(rw.right.label, CellLabel)
+				// pad tree to treeWidth+3 (prefix adds 3) using plain width.
+				plainW := 3 + rw.right.treeWidth()
+				if pad := (treeWidth + 3) - plainW; pad > 0 {
+					tree += strings.Repeat(" ", pad)
+				}
+				rightText = tree
+				if len(rw.right.cols) > 0 {
+					for ci, c := range rw.right.cols {
+						rightText += sep
+						cell := opts.style(c, CellColumn)
+						// pad by plain width
+						if pad := colW[ci] - dispWidth(c); pad > 0 {
+							cell += strings.Repeat(" ", pad)
+						}
+						rightText += cell
+					}
+				}
+			} else {
+				rightText = "   "
+			}
+			writeLine(mid + rightText)
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/pkg/bitree/bitree_test.go
+++ b/pkg/bitree/bitree_test.go
@@ -1,0 +1,110 @@
+package bitree
+
+import "testing"
+
+func ann(s string) []*Node { return []*Node{{Label: s}} }
+
+func leaf(label string, cols ...string) *Node { return &Node{Label: label, Cols: cols} }
+
+func check(t *testing.T, name, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s mismatch:\n--- got ---\n%s\n--- want ---\n%s", name, got, want)
+	}
+}
+
+// TestSingleRoute renders one route with a single flat left annotation.
+func TestSingleRoute(t *testing.T) {
+	root := &Node{Label: "this visor", Right: []*Node{{
+		Label: "EXITPK", Cols: []string{"[stcpr]", "9a3a17e0…", "143ms"},
+		Left: ann("R[0] ● 1.6K↑ 1.5K↓"),
+	}}}
+	want := "                                    this visor\n" +
+		"R[0] ● 1.6K↑ 1.5K↓ ───── EXITPK  [stcpr]  9a3a17e0…  143ms"
+	check(t, "single", Render(root, Options{}), want)
+}
+
+// TestMockupTree reproduces the target route-group mockup: three routes on a
+// vertical spine, each with a left metrics block and right topology that nests
+// arbitrarily, with aligned trailing columns.
+func TestMockupTree(t *testing.T) {
+	root := &Node{Label: "this visor", Right: []*Node{
+		{Label: "EXITPK", Cols: []string{"[stcpr]", "9a3a17e0…", "143ms"}, Left: ann("R[0] ● 1.6K↑ 1.5K↓")},
+		{Label: "HOP1PK", Cols: []string{"[sudph]", "72512b4b…", "47ms"}, Left: ann("R[1] ● 0.5K↑ 0.4K↓"),
+			Right: []*Node{leaf("EXITPK", "[stcpr]", "1fafe896…", "88ms")}},
+		{Label: "HOP1PK", Cols: []string{"[webrtc]", "38252d68…", "61ms"}, Left: ann("R[2] ● 0.2K↑ 0.1K↓"),
+			Right: []*Node{{Label: "HOP2PK", Cols: []string{"[squicr]", "85086f0c…", "74ms"},
+				Right: []*Node{leaf("EXITPK", "[stcpr]", "da5c74a8…", "133ms")}}}},
+	}}
+	want := "                                         this visor\n" +
+		"R[0] ● 1.6K↑ 1.5K↓ ──┬── EXITPK          [stcpr]   9a3a17e0…  143ms\n" +
+		"R[1] ● 0.5K↑ 0.4K↓ ──┼── HOP1PK          [sudph]   72512b4b…  47ms\n" +
+		"                     │   └── EXITPK      [stcpr]   1fafe896…  88ms\n" +
+		"R[2] ● 0.2K↑ 0.1K↓ ──┴── HOP1PK          [webrtc]  38252d68…  61ms\n" +
+		"                         └── HOP2PK      [squicr]  85086f0c…  74ms\n" +
+		"                             └── EXITPK  [stcpr]   da5c74a8…  133ms"
+	check(t, "mockup", Render(root, Options{}), want)
+}
+
+// TestLeftSubtreeNesting proves the left branch is a full nestable subtree:
+// R[0] ● has two descendants, one of which nests a further level, all hanging
+// at the same rows as the right branches.
+func TestLeftSubtreeNesting(t *testing.T) {
+	root := &Node{Label: "this visor", Right: []*Node{
+		{Label: "EXITPK", Cols: []string{"[stcpr]", "9a3a17e0…", "143ms"}, Left: []*Node{{
+			Label: "R[0] ●", Left: []*Node{
+				{Label: "1.6K↑ 1.5K↓", Left: ann("rtt 143ms")},
+				{Label: "via stcpr"},
+			}}}},
+		{Label: "HOP1PK", Cols: []string{"[sudph]", "72512b4b…", "47ms"}, Left: ann("R[1] ● 0.5K↑ 0.4K↓"),
+			Right: []*Node{leaf("EXITPK", "[stcpr]", "1fafe896…", "88ms")}},
+	}}
+	want := "                                      this visor\n" +
+		"            R[0] ● ──┬── EXITPK      [stcpr]  9a3a17e0…  143ms\n" +
+		"   1.6K↑ 1.5K↓ ──┤   │\n" +
+		" rtt 143ms ──┘   │   │\n" +
+		"     via stcpr ──┘   │\n" +
+		"R[1] ● 0.5K↑ 0.4K↓ ──┴── HOP1PK      [sudph]  72512b4b…  47ms\n" +
+		"                         └── EXITPK  [stcpr]  1fafe896…  88ms"
+	check(t, "nest", Render(root, Options{}), want)
+}
+
+// TestAlignColumns pads the tree portion to a fixed width so trailing columns
+// line up even for a shallow tree.
+func TestAlignColumns(t *testing.T) {
+	root := &Node{Label: "root", Right: []*Node{
+		{Label: "A", Cols: []string{"x"}, Left: ann("L")},
+	}}
+	got := Render(root, Options{AlignColumns: 20})
+	// The single column "x" must appear at a fixed offset regardless of the
+	// short "A" label: tree portion padded to 20 (+3 arm) then ColSep.
+	want := "                 root\n" +
+		"L ───── A                     x"
+	check(t, "aligncols", got, want)
+}
+
+// TestStyleCellPreservesLayout verifies that a zero-width styling wrapper does
+// not shift columns: the layout is computed from plain text.
+func TestStyleCellPreservesLayout(t *testing.T) {
+	root := &Node{Label: "this visor", Right: []*Node{
+		{Label: "EXITPK", Cols: []string{"[stcpr]"}, Left: ann("R[0]")},
+	}}
+	plain := Render(root, Options{})
+	styled := Render(root, Options{StyleCell: func(s string, _ CellKind) string {
+		return "\x1b[1m" + s + "\x1b[0m" // bold; zero display width
+	}})
+	// Strip ANSI from styled and compare to plain.
+	stripped := ""
+	inEsc := false
+	for _, r := range styled {
+		switch {
+		case r == '\x1b':
+			inEsc = true
+		case inEsc && r == 'm':
+			inEsc = false
+		case !inEsc:
+			stripped += string(r)
+		}
+	}
+	check(t, "style", stripped, plain)
+}

--- a/pkg/proxystatus/proxystatus_test.go
+++ b/pkg/proxystatus/proxystatus_test.go
@@ -71,33 +71,31 @@ func TestRenderSections(t *testing.T) {
 		"<main id=\"live\">", "new WebSocket", "/ws",
 		`location.origin.replace(/^http/,"ws")`, "sendCmd",
 		"standby", "status.dmsg", "status.skynet",
-		// route observability: route-latency metric (hint) + recv bar still render.
-		// The per-leg hop-count word ("1 hop"/"N hops") is GONE — every hop renders in
-		// the tree, so directness/length is read from the branch (guarded absent below).
-		"route rtt", "480 ms", "bar recv",
-		// ONE unified route tree rooted at the local visor: the flat mux table +
-		// separate "full routes" chains folded into a single box-drawing tree.
-		// Root (source accent), branch + leaf glyphs, dest accent, the FULL
-		// (untruncated) hop PKs, per-edge transport (id + type + latency), and per-leg
-		// telemetry on indented continuation (tdetail) lines.
-		`class="tree"`, `class="guide"`, "├──", "└─┬", "└──",
-		`class="tline src"`, `class="tline dst"`,
-		// Tree header/legend (tp-tree style): color swatches name the source (this
-		// visor) and dest (exit) PK accents and the active/standby state colors, then
-		// the column hints — so the tree is self-describing without per-node word pills.
-		`class="tlegend"`, `class="lgnd src"`, `class="lgnd dst"`,
+		// route observability: the left per-route summary carries the end-to-end
+		// route rtt; "route rtt" is also named in the hint prose. The multihop
+		// standby leg's route rtt (480) renders compact ("480ms").
+		"route rtt", "480ms",
+		// ONE shared bilateral route tree (pkg/proxystatus.RouteTree) rendered by
+		// pkg/bitree into a monospace <pre>: root = this visor (source PK), each
+		// active route a right branch (its hop chain), a left summary block, and
+		// aligned trailing hop columns. The exact model+shape `proxy tree` prints.
+		`class="tree"`, `class="bitree"`, "──┬──", "└──",
+		// Tree header/legend (tp-tree style): color swatches name the source PK
+		// accent and the active/standby state dots, then the column hints — dead legs
+		// are pruned so there is no dead swatch.
+		`class="tlegend"`, `class="lgnd src"`,
 		`class="lgnd ok"`, `class="lgnd standby"`, `class="lgnd cols"`,
-		"this visor", "exit", "peer · transport-id · type · rtt",
+		"this visor", "exit", "peer · [type] · tpid",
+		// FULL (never truncated) PKs: the source (root) and the multihop exit.
 		"03cc223344556677889900aabbccddeeff00112233445566778899aabbccddeeff",
 		"02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee",
-		"via ", "stcpr 450ms", "sudph 30ms",
-		// first-hop transport id is shown and click-to-copy
+		// per-hop transport columns: bracketed type + full tpid (click-to-copy) + rtt.
+		"[stcpr]", "[sudph]", "450ms", "30ms",
 		`class="ftid copy"`, "tp2ccccccc-2222-2222-2222-222222222222",
-		// per-leg telemetry on continuation lines beneath the leaf PK, tinted by leg
-		// STATE (active=ok green, standby=amber) — the state WORD is gone, replaced by
-		// the state color class + a tiny shape marker (● active / ○ standby).
-		`class="tdetail leg ok"`, `class="tdetail leg standby"`, "│",
-		`class="tstate ok"`, `class="tstate standby"`, "●", "○", `class="bar ok"`,
+		// left per-route summary tinted by STATE (ok=active green / standby=amber),
+		// with a color-blind-safe state dot (● active / ○ standby) — no state word.
+		`class="lsum ok"`, `class="lsum standby"`,
+		`class="tstate ok"`, `class="tstate standby"`, "●", "○", "R[0]", "R[1]",
 		// UX pass: selection-guard + identical-fragment skip in the live script,
 		// click-to-copy affordance (execCommand fallback for the HTTP context),
 		// the WebSocket live indicator, route-group summary, and staged control tags.

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -4,8 +4,9 @@ package proxystatus
 import (
 	"fmt"
 	"html"
-	"sort"
 	"strings"
+
+	"github.com/skycoin/skywire/pkg/bitree"
 )
 
 // refreshSeconds is the fallback full-page reload cadence for surfaces that have
@@ -210,15 +211,9 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 			`A leg appears here once a route to a destination is warm.</p></section>`)
 		return
 	}
-	var maxSent, maxRecv, totSent, totRecv uint64 = 1, 1, 0, 0
+	var totSent, totRecv uint64
 	var nActive, nStandby, nClosed int
 	for _, l := range snap.Legs {
-		if l.SentBytes > maxSent {
-			maxSent = l.SentBytes
-		}
-		if l.RecvBytes > maxRecv {
-			maxRecv = l.RecvBytes
-		}
 		totSent += l.SentBytes
 		totRecv += l.RecvBytes
 		switch {
@@ -245,227 +240,99 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 	writeStat(b, "recv", humanBytes(totRecv), "")
 	b.WriteString(`</div>`)
 
-	// Order legs so the branch carrying app traffic — the direct, active leg —
-	// renders first, then active multihop, then warm standby, then dead. Branch
-	// order in the merged tree follows leg insertion order.
-	ordered := make([]Leg, len(snap.Legs))
-	copy(ordered, snap.Legs)
-	sort.SliceStable(ordered, func(i, j int) bool {
-		ri, rj := legRank(ordered[i]), legRank(ordered[j])
-		if ri != rj {
-			return ri < rj
-		}
-		return ordered[i].Index < ordered[j].Index
-	})
-	root := buildRouteTree(ordered)
-
+	// The route tree itself: ONE shared bilateral model (pkg/proxystatus.RouteTree)
+	// rendered by pkg/bitree — the exact model + geometry `skywire cli proxy tree`
+	// prints, so the page and the terminal never drift. Root = this visor; each
+	// active route is a right branch (its hop chain, dead legs pruned) with a left
+	// summary (R[n], state glyph, route rtt, bandwidth). htmlStyleCell decorates
+	// cells (colored state dot, click-to-copy PKs/tpids) without disturbing the
+	// column alignment (layout is computed from the plain text).
 	b.WriteString(`<div class="tree">`)
 	writeTreeLegend(b)
-	writeRouteRoot(b, root, maxSent, maxRecv)
+	b.WriteString(`<pre class="bitree">`)
+	b.WriteString(bitree.Render(RouteTree(snap), bitree.Options{StyleCell: htmlStyleCell}))
+	b.WriteString(`</pre>`)
 	b.WriteString(`</div>`)
-	b.WriteString(`<p class="hint">One route tree rooted at this visor (source accent); branches are the ` +
-		`first-hop peers it dials, each edge showing the transport (id + type + rtt) and continuing to the ` +
-		`exit (dest accent) — so a 1-hop (direct) leg and a multi-hop leg are visible in the branch itself, ` +
-		`no hop-count word needed. Leg state is <b>color-coded</b> (see the legend above): active green, ` +
-		`standby amber, dead red — the state word is dropped where the color already says it. Per-leg mux ` +
-		`telemetry — route rtt, rtx and the sent/recv share bars — hangs off each destination leaf; bars are ` +
-		`relative to the busiest leg. ` +
-		`<b>tp rtt</b> is the first-hop transport; <b>route rtt</b> is the true end-to-end route latency (all hops). ` +
-		`Click any public key (or transport id) to copy it. ` +
-		`For a live terminal chart use <code>skywire cli proxy mux plot</code>.</p></section>`)
+	b.WriteString(`<p class="hint">One route tree rooted at this visor (source accent); each active route is a ` +
+		`branch — its hop chain to the exit, each hop carrying the transport (type · id · rtt) — with a left ` +
+		`summary block (R[n], a <b>color-coded</b> state dot — active green, standby amber — the route rtt and ` +
+		`its bandwidth X↑ Y↓). Dead legs are pruned. ` +
+		`<b>tp rtt</b> (a hop's column) is that transport; <b>route rtt</b> (the left summary) is the true ` +
+		`end-to-end route latency across all hops. Click any public key (or transport id) to copy it. ` +
+		`The same tree prints from <code>skywire cli proxy tree</code>; for a live chart use ` +
+		`<code>skywire cli proxy mux plot</code>.</p></section>`)
 }
 
 // writeTreeLegend prints a compact, monospace header/legend above the route tree
-// — mirroring `skywire cli tp tree`'s "Tree *Online … *source *dest  TPID  Type"
-// line. It names the color coding (source/dest PK accents, active/standby/dead
-// state colors) with swatches, then the columns each tree line carries, so the
-// tree is self-describing without a per-node word label on every root and leaf.
+// — mirroring `skywire cli tp tree`'s swatch+column header. It names the color
+// coding (source PK accent, active/standby state dot colors) with swatches, then
+// the left-summary and per-hop column hints, so the tree is self-describing
+// without a per-node word label. Dead legs are pruned, so there is no dead
+// swatch.
 func writeTreeLegend(b *strings.Builder) {
 	b.WriteString(`<div class="tlegend">` +
 		`<span class="lgnd src">source · this visor</span>` +
-		`<span class="lgnd dst">dest · exit</span>` +
-		`<span class="lgnd ok">active</span>` +
-		`<span class="lgnd standby">standby</span>` +
-		`<span class="lgnd warn">dead</span>` +
-		`<span class="lgnd cols">peer · transport-id · type · rtt</span>` +
+		`<span class="lgnd ok">active ●</span>` +
+		`<span class="lgnd standby">standby ○</span>` +
+		`<span class="lgnd cols">left: R[n] · state · route-rtt · bw ↑↓ &nbsp; hop: peer · [type] · tpid · tp-rtt</span>` +
 		`</div>`)
 }
 
-// rtNode is one visor in the merged route tree. Legs are prefix-merged by their
-// PK sequence, so a node may carry the transport of the edge that reaches it
-// (from its parent) and, when it is the destination of one or more legs, those
-// legs' end-to-end telemetry.
-type rtNode struct {
-	pk         string
-	edgeTpID   string  // transport reaching this node from its parent
-	edgeTpType string  // "" / type where known
-	edgeLat    float64 // hop rtt where measured
-	hasEdge    bool    // false only for the root
-	legs       []Leg   // legs whose destination IS this node
-	order      []string
-	kids       map[string]*rtNode
-}
-
-func (n *rtNode) child(pk string) *rtNode {
-	if n.kids == nil {
-		n.kids = map[string]*rtNode{}
-	}
-	c, ok := n.kids[pk]
-	if !ok {
-		c = &rtNode{pk: pk}
-		n.kids[pk] = c
-		n.order = append(n.order, pk)
-	}
-	return c
-}
-
-// buildRouteTree merges every leg's forward path (local → … → dest) into one
-// tree rooted at the local visor. Legs with no recorded path fall back to a
-// direct root → RemotePK leaf so nothing breaks.
-func buildRouteTree(legs []Leg) *rtNode {
-	root := &rtNode{}
-	for _, l := range legs {
-		if root.pk == "" && len(l.Hops) > 0 {
-			root.pk = l.Hops[0].From // local visor PK (same for every leg)
-		}
-	}
-	for _, l := range legs {
-		if len(l.Hops) == 0 {
-			c := root.child(l.RemotePK)
-			c.legs = append(c.legs, l)
-			continue
-		}
-		cur := root
-		for _, h := range l.Hops {
-			c := cur.child(h.To)
-			if !c.hasEdge {
-				c.edgeTpID, c.edgeTpType, c.edgeLat, c.hasEdge = h.TpID, h.TpType, h.LatencyMS, true
-			}
-			cur = c
-		}
-		cur.legs = append(cur.legs, l) // the final To is this leg's destination
-	}
-	return root
-}
-
-// writeRouteRoot writes the tree root (the local visor) then its branches.
-func writeRouteRoot(b *strings.Builder, root *rtNode, maxSent, maxRecv uint64) {
-	// Root line: no connector, source accent (the .tline.src PK tint IS the "this
-	// visor" marker now — the word pill is dropped; the legend names the color).
-	// An all-legacy group may have no known local PK — copyablePK renders a dash
-	// and nothing breaks.
-	fmt.Fprintf(b, `<div class="tline src"><span class="guide"></span>%s</div>`, copyablePK(root.pk))
-	for i, pk := range root.order {
-		writeRouteNode(b, root.kids[pk], "", i == len(root.order)-1, maxSent, maxRecv)
-	}
-}
-
-// writeRouteNode renders one non-root visor node and recurses. prefix is the
-// box-drawing guide accumulated from ancestors; isLast picks └ vs ├ and whether
-// the descendant guide continues with │ or blank. Each node line shows the FULL
-// click-to-copy PK and the transport of the edge reaching it. A destination node
-// gets the dst (exit) accent — the .tline.dst PK tint IS the "exit" marker now,
-// so the word pill is dropped (the legend names the color); its per-leg mux
-// telemetry is written as indented detail rows beneath it.
-func writeRouteNode(b *strings.Builder, n *rtNode, prefix string, isLast bool, maxSent, maxRecv uint64) {
-	branch := "├─"
-	cont := "│   "
-	if isLast {
-		branch, cont = "└─", "    "
-	}
-	if len(n.order) > 0 {
-		branch += "┬ "
-	} else {
-		branch += "── "
-	}
-	nodeCls := "mid"
-	if len(n.legs) > 0 {
-		nodeCls = "dst" // a leg terminates here (the destination/exit)
-	}
-	fmt.Fprintf(b, `<div class="tline %s"><span class="guide">%s</span>%s`, nodeCls, prefix+branch, copyablePK(n.pk))
-	if edge := edgeInfo(n); edge != "" {
-		fmt.Fprintf(b, `<span class="thop">%s</span>`, edge)
-	}
-	b.WriteString(`</div>`)
-
-	detailPrefix := prefix + cont
-	for _, l := range n.legs {
-		writeLegDetail(b, detailPrefix, l, maxSent, maxRecv)
-	}
-	for i, pk := range n.order {
-		writeRouteNode(b, n.kids[pk], detailPrefix, i == len(n.order)-1, maxSent, maxRecv)
-	}
-}
-
-// edgeInfo renders the transport of the edge reaching a node: "via <tpid> <type>
-// <rtt>ms". The transport id is click-to-copy; a missing id/latency is elided.
-func edgeInfo(n *rtNode) string {
-	if !n.hasEdge {
-		return ""
-	}
-	var s strings.Builder
-	s.WriteString("via ")
-	if strings.TrimSpace(n.edgeTpID) != "" {
-		s.WriteString(copyableID(n.edgeTpID, "transport id"))
-		s.WriteByte(' ')
-	}
-	s.WriteString(html.EscapeString(orDash(n.edgeTpType)))
-	if n.edgeLat > 0 {
-		fmt.Fprintf(&s, " %.0fms", n.edgeLat)
-	}
-	return s.String()
-}
-
-// writeLegDetail writes a destination leg's end-to-end mux telemetry as indented
-// rows under its leaf: a summary row (state marker, route-rtt, rtx) and the dual
-// sent/recv share bars. prefix keeps them aligned under the leaf, carrying any
-// open-ancestor │ guides. maxSent/maxRecv (>=1) scale the bars against the
-// busiest leg.
-//
-// State is conveyed by COLOR now (scls: ok=active green, standby=amber,
-// warn=dead) — the "active"/"standby"/"closed" word is dropped, the tdetail rows
-// are tinted with the state color and a tiny shape marker (● active / ○ standby
-// / ✕ dead) rides along so the state is still distinguishable for color-blind
-// readers without adding a word. Hop count is dropped too: every hop renders in
-// the branch above, so a reader counts tree levels for it.
-func writeLegDetail(b *strings.Builder, prefix string, l Leg, maxSent, maxRecv uint64) {
-	_, scls := legState(l)
-	// Continuation line 1 — compact scalars: state marker, route-rtt (em dash when
-	// unmeasured), rtx. tp-rtt lives on the first-hop edge above (the transport
-	// that reaches this leg's first peer).
-	fmt.Fprintf(b, `<div class="tdetail leg %s"><span class="guide">%s</span>`, scls, prefix)
-	fmt.Fprintf(b, `<span class="tstate %s">%s</span>`, scls, stateMark(l))
-	fmt.Fprintf(b, `<span class="legm"><i>route</i>%s</span><span class="legm"><i>rtx</i>%d</span></div>`,
-		routeRTT(l.RouteLatencyMS), l.Retransmits)
-	// Continuation line 2 — the sent/recv share meters. shares are 0..100
-	// (maxSent/maxRecv are per-leg maxes, >=1) — printed as uint64 directly so
-	// there's no uint64->int narrowing.
-	sentShare := l.SentBytes * 100 / maxSent
-	recvShare := l.RecvBytes * 100 / maxRecv
-	fmt.Fprintf(b, `<div class="tdetail leg %s"><span class="guide">%s</span>`, scls, prefix)
-	fmt.Fprintf(b, `<span class="bwlabel">sent %s</span><span class="barcell"><span class="bar %s" style="width:%d%%"></span></span>`,
-		humanBytes(l.SentBytes), scls, sentShare)
-	fmt.Fprintf(b, `<span class="bwlabel">recv %s</span><span class="barcell"><span class="bar recv %s" style="width:%d%%"></span></span></div>`,
-		humanBytes(l.RecvBytes), scls, recvShare)
-}
-
-// stateMark is the tiny color-blind-safe shape marker for a leg's state: a
-// filled dot for active, a hollow dot for standby, a cross for dead. It carries
-// the same information as the (removed) state word but in one glyph the state
-// color tints.
-func stateMark(l Leg) string {
-	switch {
-	case !l.Alive:
-		return "✕"
-	case l.Standby:
-		return "○"
+// htmlStyleCell is the page's bitree StyleCell: it decorates each cell with the
+// page's existing color/interaction classes WITHOUT changing display width (the
+// spans it injects are zero-width in the monospace <pre>, and bitree computes
+// layout from the plain text before this runs). PKs and transport ids become
+// click-to-copy; the state dot in the left summary is colored; transport
+// columns are muted.
+func htmlStyleCell(text string, kind bitree.CellKind) string {
+	switch kind {
+	case bitree.CellRoot:
+		return `<span class="src">` + copyablePK(text) + `</span>`
+	case bitree.CellLabel:
+		return copyablePK(text)
+	case bitree.CellColumn:
+		return htmlTreeColumn(text)
+	case bitree.CellLeft:
+		return htmlLegSummary(text)
 	default:
-		return "●"
+		return html.EscapeString(text)
 	}
 }
 
-// legRank orders legs for the merged tree: the direct active leg (carrying app
-// traffic) first, then active multihop, warm standby, then dead legs.
+// htmlTreeColumn styles one trailing hop column. The three columns per hop are,
+// in order, [tp-type], tpid, transport-rtt — so a bracketed or ms-suffixed cell
+// is a muted label and anything else is the (click-to-copy) transport id.
+func htmlTreeColumn(text string) string {
+	switch {
+	case text == "" || text == "-":
+		return html.EscapeString(text)
+	case strings.HasPrefix(text, "["), strings.HasSuffix(text, "ms"):
+		return `<span class="thop">` + html.EscapeString(text) + `</span>`
+	default:
+		return copyableID(text, "transport id")
+	}
+}
+
+// htmlLegSummary colors the left per-route summary: the whole block is tinted by
+// state (ok=active green / standby=amber) and the state dot is emphasized. The
+// leading right-justify padding rides inside the span (harmless in a <pre>).
+// State is read from the glyph the adapter chose, so no state word is needed.
+func htmlLegSummary(text string) string {
+	if strings.TrimSpace(text) == "" {
+		return text // continuation / empty left row
+	}
+	cls, glyph := "ok", GlyphActive
+	if strings.Contains(text, GlyphStandby) {
+		cls, glyph = "standby", GlyphStandby
+	}
+	esc := html.EscapeString(text) // the glyphs/arrows are not HTML-special
+	dot := `<span class="tstate ` + cls + `">` + glyph + `</span>`
+	esc = strings.Replace(esc, glyph, dot, 1)
+	return `<span class="lsum ` + cls + `">` + esc + `</span>`
+}
+
+// legRank orders legs for the tree: the direct active leg (carrying app traffic)
+// first, then active multihop, then warm standby, then dead legs.
 func legRank(l Leg) int {
 	switch {
 	case !l.Alive:
@@ -476,17 +343,6 @@ func legRank(l Leg) int {
 		return 0
 	default:
 		return 1
-	}
-}
-
-func legState(l Leg) (label, cls string) {
-	switch {
-	case !l.Alive:
-		return "closed", "warn"
-	case l.Standby:
-		return "standby", "standby"
-	default:
-		return "active", "ok"
 	}
 }
 
@@ -631,16 +487,6 @@ func orDash(s string) string {
 	return s
 }
 
-// routeRTT formats a leg's end-to-end route latency. Zero means no
-// liveness pong has landed yet, shown as an em dash rather than "0 ms"
-// so an unmeasured route isn't misread as instant.
-func routeRTT(ms float64) string {
-	if ms <= 0 {
-		return "—"
-	}
-	return fmt.Sprintf("%.0f ms", ms)
-}
-
 // humanBytes formats a byte count with a binary unit suffix.
 func humanBytes(n uint64) string {
 	const unit = 1024
@@ -698,10 +544,16 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	// window offset the live-swap can restore — not a nested scroll region that
 	// resets on every push.
 	`.tree{font-family:'Mononoki',ui-monospace,SFMono-Regular,monospace;font-size:11.5px;line-height:1.6;padding:.3rem 0;border:1px solid var(--line);border-radius:7px;background:var(--card);padding:.55rem .65rem}` +
-	`.tline,.tdetail{display:flex;align-items:baseline;gap:.3rem;white-space:nowrap}` +
-	`.tline{margin-top:.1rem}` +
-	`.guide{white-space:pre;color:var(--muted);flex:none}` + // box-drawing trunk/branch cells
-	`.tline.src>code.fpk{color:var(--accent);font-weight:600}.tline.dst>code.fpk{color:var(--accent2);font-weight:600}` +
+	// The route tree is one <pre class="bitree"> of monospace text laid out by
+	// pkg/bitree; every cell decorated by htmlStyleCell must keep the SAME font
+	// metrics or the aligned columns skew, so all inner code/span inherit the
+	// pre's font and never break-word. Alignment is spaces from bitree; the spans
+	// add color/interactivity only.
+	`pre.bitree{font-family:'Mononoki',ui-monospace,SFMono-Regular,monospace;font-size:11.5px;line-height:1.55;margin:0;white-space:pre;color:var(--fg)}` +
+	`pre.bitree code,pre.bitree span{font:inherit;color:inherit;white-space:pre;word-break:normal;background:none;border:0;padding:0}` +
+	`pre.bitree code.fpk{color:var(--fg)}pre.bitree .src code.fpk{color:var(--accent);font-weight:600}` +
+	`pre.bitree code.ftid{color:var(--muted)}pre.bitree .tcol{color:var(--muted)}` +
+	`pre.bitree .lsum.ok{color:var(--ok)}pre.bitree .lsum.standby{color:var(--standby)}` +
 	// Tree header/legend (mirrors `tp tree`'s swatch+column header): color swatches
 	// name the source/dest PK accents and the active/standby/dead state colors, then
 	// the column hints for what each tree line carries. Self-describes the tree so no
@@ -712,18 +564,10 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`.lgnd.src::before{color:var(--accent)}.lgnd.dst::before{color:var(--accent2)}` +
 	`.lgnd.ok::before{color:var(--ok)}.lgnd.standby::before{color:var(--standby)}.lgnd.warn::before{color:var(--warn)}` +
 	`.lgnd.cols::before{content:none}.lgnd.cols{color:var(--muted);opacity:.85;text-transform:none;letter-spacing:0}` +
-	`.thop{color:var(--muted);margin-left:.35rem;font-size:11px;flex:none}` +
-	// Per-leg state color (replaces the removed active/standby/closed word): the
-	// tdetail rows are tinted and a small shape marker (.tstate) leads each summary
-	// row, color-blind-safe by shape as well as hue.
-	`.tstate{flex:none;font-weight:700;font-size:10px}` +
-	`.tstate.ok{color:var(--ok)}.tstate.standby{color:var(--standby)}.tstate.warn{color:var(--warn)}` +
-	`.tdetail.leg.ok .legm i{color:var(--ok)}.tdetail.leg.standby .legm i{color:var(--standby)}.tdetail.leg.warn .legm i{color:var(--warn)}` +
-	// Continuation (metadata) lines: no branch glyph, aligned under the leaf PK.
-	`.tdetail{font-size:10.5px;color:var(--muted)}` +
-	`.tdetail .legm{color:var(--fg)}.tdetail .legm i{color:var(--muted);font-style:normal;margin-right:.2rem;text-transform:uppercase;font-size:9px;letter-spacing:.3px}` +
-	`.tdetail .bwlabel{color:var(--muted);white-space:nowrap}` +
-	`.tdetail .barcell{display:inline-block;width:7rem;flex:none}` +
+	// State dot in the left per-route summary (replaces any active/standby word):
+	// color-blind-safe by shape (● active / ○ standby) as well as hue.
+	`pre.bitree .tstate{font-weight:700}` +
+	`pre.bitree .tstate.ok{color:var(--ok)}pre.bitree .tstate.standby{color:var(--standby)}` +
 	// Recent log: keep the vertical max-height scroll, but drop the horizontal
 	// inner scroll — lines wrap (pre-wrap + break-word) so any width is page-level.
 	`pre.log{background:var(--card);border:1px solid var(--line);border-radius:8px;padding:.7rem;font:11.5px/1.5 'Mononoki',ui-monospace,SFMono-Regular,monospace;` +

--- a/pkg/proxystatus/routetree.go
+++ b/pkg/proxystatus/routetree.go
@@ -1,0 +1,162 @@
+// Package proxystatus pkg/proxystatus/routetree.go c4-app-web
+//
+// RouteTree is the single shared adapter that projects a surface Snapshot's
+// live route-group state into a bilateral tree model (pkg/bitree). BOTH the
+// status.skysocks page (+ interstitial) and `skywire cli proxy tree` render
+// from this one model, so the terminal and the page always show the same shape.
+//
+// Layout (rendered by bitree, styled by each surface's own StyleCell):
+//
+//		                         this visor (source PK)
+//		R[0] ● 143ms 1.6K↑ 1.5K↓ ──┬── <exit PK>          [stcpr]  <tpid>  143ms
+//		R[1] ● 47ms  0.5K↑ 0.4K↓ ──┴── <hop1 PK>          [sudph]  <tpid>  47ms
+//		                               └── <exit PK>       [stcpr]  <tpid>  88ms
+//
+//	  - Root = this visor (the source PK, taken from any leg's first hop).
+//	  - Each ACTIVE route is a top-level right child; DEAD legs are pruned.
+//	  - The LEFT block of a route is its per-route summary: R[n], a state glyph
+//	    (● active / ○ standby — the caller colors it, no state words), the
+//	    end-to-end ROUTE rtt, and bandwidth X↑ Y↓.
+//	  - The RIGHT branch of a route is its hop chain; each hop node's label is the
+//	    peer PK (never truncated) and its trailing columns are [<tp-type>],
+//	    <tpid>, <transport-rtt> — the per-hop TRANSPORT rtt (distinct from the
+//	    route rtt on the left).
+package proxystatus
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/skycoin/skywire/pkg/bitree"
+)
+
+// Route-state glyphs. The caller supplies them into the left annotation; a
+// surface's StyleCell colors active vs standby by detecting which glyph is
+// present, so no "active"/"standby" word ever appears in the tree.
+const (
+	// GlyphActive marks an alive, in-rotation route.
+	GlyphActive = "●"
+	// GlyphStandby marks an alive but standby (warm spare) route.
+	GlyphStandby = "○"
+)
+
+// RouteTree builds the bilateral route-group model for a Snapshot. Dead legs
+// are pruned; the surviving legs are ordered direct-active first, then active
+// multihop, then standby, matching the page's reading order. The returned root
+// is nil-safe to render (bitree.Render handles a childless root).
+func RouteTree(snap Snapshot) *bitree.Node {
+	src := "this visor"
+	for _, l := range snap.Legs {
+		if len(l.Hops) > 0 && l.Hops[0].From != "" {
+			src = l.Hops[0].From
+			break
+		}
+	}
+	root := &bitree.Node{Label: src}
+
+	legs := make([]Leg, 0, len(snap.Legs))
+	for _, l := range snap.Legs {
+		if !l.Alive { // prune dead routes/legs
+			continue
+		}
+		legs = append(legs, l)
+	}
+	sort.SliceStable(legs, func(i, j int) bool {
+		if ri, rj := legRank(legs[i]), legRank(legs[j]); ri != rj {
+			return ri < rj
+		}
+		return legs[i].Index < legs[j].Index
+	})
+
+	for _, l := range legs {
+		root.Right = append(root.Right, routeToNode(l))
+	}
+	return root
+}
+
+// routeToNode turns one leg into a hop-chain right-branch carrying its left
+// summary on the head (spine) row.
+func routeToNode(l Leg) *bitree.Node {
+	left := &bitree.Node{Label: legSummary(l)}
+
+	if len(l.Hops) == 0 {
+		// No recorded path: a single leaf at the remote PK.
+		return &bitree.Node{Label: orDashPK(l.RemotePK), Left: []*bitree.Node{left}}
+	}
+	head := hopToNode(l.Hops[0])
+	head.Left = []*bitree.Node{left}
+	cur := head
+	for _, h := range l.Hops[1:] {
+		n := hopToNode(h)
+		cur.Right = append(cur.Right, n)
+		cur = n
+	}
+	return head
+}
+
+// hopToNode renders one forward hop: label = the peer PK (full), columns =
+// [tp-type], tpid, transport-rtt (aligned like `skywire cli tp tree`).
+func hopToNode(h Hop) *bitree.Node {
+	return &bitree.Node{
+		Label: orDashPK(h.To),
+		Cols:  []string{"[" + orDash(h.TpType) + "]", orDash(h.TpID), tpRTT(h.LatencyMS)},
+	}
+}
+
+// legSummary is the left annotation for a route: identity, state glyph,
+// end-to-end route rtt, and bandwidth. No state word — the glyph (colored by
+// the surface's StyleCell) carries active vs standby.
+func legSummary(l Leg) string {
+	g := GlyphActive
+	if l.Standby {
+		g = GlyphStandby
+	}
+	return fmt.Sprintf("R[%d] %s %s %s↑ %s↓",
+		l.Index, g, routeRTTCompact(l.RouteLatencyMS),
+		compactBytes(l.SentBytes), compactBytes(l.RecvBytes))
+}
+
+// orDashPK returns a full (never truncated) PK or a dash when empty.
+func orDashPK(pk string) string {
+	if pk == "" {
+		return "-"
+	}
+	return pk
+}
+
+// routeRTTCompact formats a route rtt for the compact left cell ("143ms" /
+// "—" when unmeasured).
+func routeRTTCompact(ms float64) string {
+	if ms <= 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%.0fms", ms)
+}
+
+// tpRTT formats a per-hop transport rtt for the aligned columns ("143ms" / "-").
+func tpRTT(ms float64) string {
+	if ms <= 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.0fms", ms)
+}
+
+// compactBytes is a terse byte formatter for the space-constrained left cell
+// (1.6K, 2.0M) — distinct from humanBytes' spaced "1.6 KiB" used in prose.
+func compactBytes(n uint64) string {
+	const (
+		k = 1024.0
+		m = k * 1024
+		g = m * 1024
+	)
+	switch f := float64(n); {
+	case f >= g:
+		return fmt.Sprintf("%.1fG", f/g)
+	case f >= m:
+		return fmt.Sprintf("%.1fM", f/m)
+	case f >= k:
+		return fmt.Sprintf("%.1fK", f/k)
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}


### PR DESCRIPTION
Render a proxy's live route group as a bilateral tree from one shared model, so the `status.skysocks` page (and the branded interstitial that links to it) and the terminal always show the same shape.

- `pkg/bitree` — a generic bilateral-tree renderer: a central spine with left annotations, rightward topology that nests arbitrarily, aligned trailing columns, and a width-preserving `StyleCell` hook (layout computed from plain text, so ANSI or HTML styling never skews columns). Ships with its tests.
- `pkg/proxystatus.RouteTree` — the adapter from a surface `Snapshot` to a `bitree.Node`: root = this visor (source PK); each ACTIVE route is a right branch (its hop chain), DEAD legs pruned; a left summary block per route (`R[n]`, a color-coded state dot ● active / ○ standby, the end-to-end route rtt, bandwidth `X↑ Y↓`); each hop node's columns are `[<tp-type>]`, `<tpid>`, `<transport-rtt>`. Public keys are never truncated.
- status page: the previous ad-hoc route tree is replaced by the bitree output in a monospace `<pre>`, decorated via `StyleCell` (colored state dots, click-to-copy PKs / transport ids, aligned columns). The full page and the WebSocket live fragment render the one model.
- `skywire cli proxy tree` — renders the SAME model from the CLI over visor RPC (default `--name skysocks-client`, `--color auto|always|never`, `--json`). Read-only and attach-only; the tree companion to `proxy log`.

Sample (`proxy tree --color never`):

```
                                                            02a1b2c3…（full 66-char source PK）
R[0] ● 143ms 1.6K↑ 1.6K↓ ──┬── 03f0e1d2…（full exit PK）      [stcpr]   9a3a17e0-1c2b-4d5e-8f90-a1b2c3d4e5f6  143ms
R[1] ● 135ms 540B↑ 430B↓ ──┼── 03aa11bb…（full hop PK）       [sudph]   72512b4b-9e8d-4a3f-9012-3456789abcde  47ms
                           │   └── 03c9d8e7…（full exit PK）   [stcpr]   1fafe896-0b1a-4c2d-8e3f-405162738495  88ms
R[2] ○ 150ms 220B↑ 140B↓ ──┴── 03c9d8e7…（full exit PK）      [webrtc]  38252d68-7f6e-4b1c-9d0a-1b2c3d4e5f60  61ms
```

(PKs shown full and untruncated in real output; abbreviated here only for the PR width.)

`go build .` clean; `go test ./pkg/bitree/... ./pkg/proxystatus/... ./pkg/router/... ./cmd/skywire-cli/...` green; gofmt + go vet clean.