### PR TITLE
fix(lint): clear accumulated errcheck failures on develop

### DIFF
--- a/cmd/skywire-cli/commands/proxy/log.go
+++ b/cmd/skywire-cli/commands/proxy/log.go
@@ -60,7 +60,7 @@ and leaves the running proxy untouched.
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to fetch recent app log: %w", err))
 		}
 		for _, ln := range recent {
-			fmt.Fprintln(os.Stdout, ln)
+			fmt.Fprintln(os.Stdout, ln) //nolint:errcheck // best-effort stdout write
 		}
 
 		if !logFollow {

--- a/pkg/logging/ring_test.go
+++ b/pkg/logging/ring_test.go
@@ -16,7 +16,7 @@ func fireEntry(b *Broadcaster, level logrus.Level, module, msg string, fields lo
 	for k, v := range fields {
 		data[k] = v
 	}
-	_ = b.Fire(&logrus.Entry{
+	_ = b.Fire(&logrus.Entry{ //nolint:errcheck // best-effort test hook fire
 		Time:    time.Now(),
 		Level:   level,
 		Message: msg,
@@ -125,7 +125,7 @@ func TestRecentMergedOrdered(t *testing.T) {
 		for k, v := range fields {
 			data[k] = v
 		}
-		_ = b.Fire(&logrus.Entry{Time: at, Level: logrus.InfoLevel, Message: msg, Data: data})
+		_ = b.Fire(&logrus.Entry{Time: at, Level: logrus.InfoLevel, Message: msg, Data: data}) //nolint:errcheck // best-effort test hook fire
 	}
 	push("proc:app1:k", "log-early", nil, base)
 	push("router", "event-mid", logrus.Fields{"app_name": "app1"}, base.Add(time.Second))

--- a/pkg/visor/init_stats_prune_test.go
+++ b/pkg/visor/init_stats_prune_test.go
@@ -53,7 +53,7 @@ func TestPruneDeadCurrentLeavesAfterHydrate(t *testing.T) {
 		BatchWindow: 5 * time.Millisecond,
 	})
 	require.NoError(t, err, "session 2 publisher")
-	defer func() { _ = pub2.Close() }()
+	defer func() { _ = pub2.Close() }() //nolint:errcheck // best-effort teardown
 
 	// Sanity: hydrate brought all four leaves back onto the feed.
 	sink := &cxoSink{pub: pub2, log: log}


### PR DESCRIPTION
Four unchecked-error returns accumulated on develop after PRs merged via --admin (golangci-lint cannot run on go1.27 locally). This restores the Test/golangci-lint job to green.

- cmd/skywire-cli/commands/proxy/log.go:63 — fmt.Fprintln
- pkg/logging/ring_test.go:19,128 — b.Fire
- pkg/visor/init_stats_prune_test.go:56 — pub2.Close

Each annotated //nolint:errcheck (with reason) matching the existing repo convention; check-blank:true means the bare _ = assignment did not satisfy errcheck.