### PR TITLE
fix(tpd): bind CXO aggregator node identity to TPD's key so gated visors accept it

### DIFF
--- a/pkg/cxo/treestore/allowlist.go
+++ b/pkg/cxo/treestore/allowlist.go
@@ -17,13 +17,19 @@ package treestore
 
 import (
 	"errors"
+	"sort"
 	"sync"
+	"time"
 
 	skycipher "github.com/skycoin/skycoin/src/cipher"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cxo/node"
 )
+
+// maxDeniedTracked caps the distinct denied-subscriber PKs allowState
+// remembers, so a flood of probing peers can't grow the map unbounded.
+const maxDeniedTracked = 32
 
 // errSubscribeRejected is the generic error returned by the
 // OnSubscribeRemote hook when an allowlist denies a peer. The text
@@ -36,11 +42,25 @@ var errSubscribeRejected = errors.New("subscribe rejected")
 // the node is constructed.
 func subscribeHook(allow *allowState) func(*node.Conn, skycipher.PubKey) error {
 	return func(c *node.Conn, _ skycipher.PubKey) error {
-		if !allow.permits(cipher.PubKey(c.PeerID())) {
+		pk := cipher.PubKey(c.PeerID())
+		if !allow.permits(pk) {
+			allow.recordDenied(pk)
 			return errSubscribeRejected
 		}
 		return nil
 	}
+}
+
+// DeniedSub records a would-be subscriber the allowlist has turned away:
+// its PK, how many times, and when last. Exposed via Publisher.Denied so
+// `skywire cli visor state` can show WHY a consuming service (e.g. TPD)
+// isn't filling — a denied PK that differs from the one the operator
+// expected to allow is the tell (e.g. a service dialing in under a
+// different CXO node key than its configured service PK).
+type DeniedSub struct {
+	PK        cipher.PubKey
+	Count     int
+	LastNanos int64
 }
 
 // allowState is the shared, mutex-protected allowlist. nil-membership
@@ -50,12 +70,50 @@ type allowState struct {
 	mu      sync.RWMutex
 	set     bool
 	members map[cipher.PubKey]struct{}
+	denied  map[cipher.PubKey]*DeniedSub
 }
 
 func newAllowState(initial []cipher.PubKey) *allowState {
-	a := &allowState{}
+	a := &allowState{denied: make(map[cipher.PubKey]*DeniedSub)}
 	a.replace(initial)
 	return a
+}
+
+// recordDenied notes that pk was turned away. Cheap and best-effort:
+// bumps an existing entry, or adds a new one unless the map is already at
+// maxDeniedTracked distinct PKs (then the denial is counted only if pk is
+// already tracked). Used purely for the `visor state` diagnostic surface.
+func (a *allowState) recordDenied(pk cipher.PubKey) {
+	now := time.Now().UnixNano()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.denied == nil {
+		a.denied = make(map[cipher.PubKey]*DeniedSub)
+	}
+	if d, ok := a.denied[pk]; ok {
+		d.Count++
+		d.LastNanos = now
+		return
+	}
+	if len(a.denied) >= maxDeniedTracked {
+		return
+	}
+	a.denied[pk] = &DeniedSub{PK: pk, Count: 1, LastNanos: now}
+}
+
+// deniedList returns a snapshot of denied subscribers, most-recent first.
+func (a *allowState) deniedList() []DeniedSub {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if len(a.denied) == 0 {
+		return nil
+	}
+	out := make([]DeniedSub, 0, len(a.denied))
+	for _, d := range a.denied {
+		out = append(out, *d)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].LastNanos > out[j].LastNanos })
+	return out
 }
 
 // replace atomically swaps the allowlist. Passing nil disables the

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -651,6 +651,15 @@ func (p *Publisher) Allowlist() []cipher.PubKey {
 	return p.allow.list()
 }
 
+// Denied returns a snapshot of subscribers the allowlist has turned away
+// (most-recent first). Diagnostic surface for `skywire cli visor state`:
+// a denied PK that isn't the consuming service's expected key is the tell
+// that the service dials in under a different CXO node identity than the
+// one the operator allowlisted.
+func (p *Publisher) Denied() []DeniedSub {
+	return p.allow.deniedList()
+}
+
 // AllowsSubscriber reports whether a subscribe request from pk would
 // pass the gate. NewWithDMSG wires this into the underlying CXO
 // node's OnSubscribeRemote hook automatically. Callers using New

--- a/pkg/services/tpd/tpd.go
+++ b/pkg/services/tpd/tpd.go
@@ -273,6 +273,7 @@ func (s *service) startCXO(
 ) {
 	sink := &aggregatorSink{Store: st, api: tpdAPI}
 	agg, err := cxoaggregator.New(h.DmsgClient, sink, cxoaggregator.Config{
+		SecKey: sk,
 		Logger: logging.MustGetLogger("tpd-cxo-aggregator"),
 	})
 	if err != nil {
@@ -299,6 +300,7 @@ func (s *service) startCXO(
 	// simply never dials this port — the port-50 aggregator above still
 	// reconciles its tp-list from the combined feed (back-compat fallback).
 	tplAgg, err := cxoaggregator.New(h.DmsgClient, sink, cxoaggregator.Config{
+		SecKey:   sk,
 		DmsgPort: skyenv.DmsgVisorTPListCXOPort,
 		Logger:   logging.MustGetLogger("tpd-cxo-tplist-aggregator"),
 	})

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -199,6 +199,18 @@ type Config struct {
 	MaxFillingTime time.Duration
 	// Logger overrides the default tagged logger.
 	Logger *logging.Logger
+	// SecKey binds the aggregator's CXO node identity to TPD's service
+	// secret key so the node's handshake-advertised PK is TPD's KNOWN PK.
+	// This matters because the visor's telemetry / tp-list feeds gate their
+	// subscriber allowlist on the CXO node's PeerID (see pkg/cxo/treestore
+	// allowlist + pkg/visor feed gating): visors allow the TPD PK they hold
+	// in transport.discovery_dmsg. Left zero, node.NewNode generates a
+	// RANDOM keypair, so the aggregator dials every gated visor as an
+	// unknown PK and its subscribe is rejected — TPD then never fills that
+	// visor's transports (the persistent visor↔TPD transport-count gap on
+	// any visor running feed gating). The publisher path (treestore.
+	// NewWithDMSG) binds the same way for the same reason.
+	SecKey cipher.SecKey
 	// InMemoryDB / DataDir control the aggregator's CXO storage.
 	// Default is in-memory (subscribed object cache only — TPD's
 	// authoritative store is redis, the CXO cache exists just to
@@ -327,6 +339,13 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 	}
 
 	cfg := node.NewConfig()
+	// Bind the node identity to TPD's service key (when provided) so its
+	// handshake PK is TPD's known PK, matching what gated visors allowlist.
+	// Zero SecKey => node.NewNode mints a random keypair => gated visors
+	// reject the aggregator's subscribe. See Config.SecKey.
+	if conf.SecKey != (cipher.SecKey{}) {
+		cfg.SecKey = skycipher.SecKey(conf.SecKey)
+	}
 	// We're DMSG-only — disable the CXO node's default TCP/UDP/RPC
 	// listeners. node.NewConfig defaults TCP.Listen to ":8870" and RPC to
 	// ":8871", and those hardcoded ports mean two Nodes in the same process

--- a/pkg/visor/cxo_user_feeds.go
+++ b/pkg/visor/cxo_user_feeds.go
@@ -241,6 +241,25 @@ type CXOFeedState struct {
 	// the stale-leaf bloat that Fix 1 (pruneDeadCurrentLeaves) removes at
 	// startup and reconcileCurrentLeaves keeps out at steady state.
 	CurrentLeaves *CurrentLeafStats `json:"current_leaves,omitempty"`
+	// Allowlist is the set of PKs currently permitted to subscribe to this
+	// feed (nil = OPEN to all). For a service-consumed feed (stats,
+	// tp-list, registration) this MUST contain the consuming service's PK
+	// or that service can't fill — its subscribe is rejected and it shows
+	// up under Denied below.
+	Allowlist []string `json:"allowlist,omitempty"`
+	// Denied lists would-be subscribers the allowlist turned away
+	// (most-recent first). A denied PK that isn't a known peer is the
+	// direct signature of a gating misconfiguration — e.g. TPD dialing in
+	// under a CXO node key that differs from the transport_discovery_dmsg
+	// PK the visor allowlisted.
+	Denied []DeniedSubscriber `json:"denied,omitempty"`
+}
+
+// DeniedSubscriber is one rejected-subscriber record for CXOFeedState.
+type DeniedSubscriber struct {
+	PK     string    `json:"pk"`
+	Count  int       `json:"count"`
+	LastAt time.Time `json:"last_at"`
 }
 
 // CurrentLeafStats is the live/dead breakdown of the telemetry feed's
@@ -278,6 +297,25 @@ func currentLeafStats(pub *treestore.Publisher, liveIDs map[uuid.UUID]struct{}) 
 // for a visor's transport list) is first. Empty when no publisher is
 // wired (Stats.Disabled or pre-init). Reads are cheap and concurrency-
 // safe — see treestore.Publisher.PublishState.
+// feedGating snapshots a publisher's subscriber allowlist (as hex PKs;
+// nil = open) and the subscribers it has denied, for CXOFeedState.
+func feedGating(pub *treestore.Publisher) (allow []string, denied []DeniedSubscriber) {
+	if pub == nil {
+		return nil, nil
+	}
+	for _, pk := range pub.Allowlist() {
+		allow = append(allow, pk.Hex())
+	}
+	for _, d := range pub.Denied() {
+		denied = append(denied, DeniedSubscriber{
+			PK:     d.PK.Hex(),
+			Count:  d.Count,
+			LastAt: time.Unix(0, d.LastNanos),
+		})
+	}
+	return allow, denied
+}
+
 func (v *Visor) CXOFeedStates() []CXOFeedState {
 	v.cxoUserFeedsMu.Lock()
 	sysPub := v.systemCXOPub
@@ -294,31 +332,40 @@ func (v *Visor) CXOFeedStates() []CXOFeedState {
 		// feed's own current-leaf paths ∩ the live transport set. Directly
 		// quantifies the dead-leaf bloat that starves TPD's Root fill.
 		cls := currentLeafStats(sysPub, liveTransportIDs(v))
+		allow, denied := feedGating(sysPub)
 		out = append(out, CXOFeedState{
 			Name:          systemCXOFeedName,
 			Port:          skyenv.DmsgCXOPort,
 			PublishState:  sysPub.PublishState(),
 			CurrentLeaves: &cls,
+			Allowlist:     allow,
+			Denied:        denied,
 		})
 	}
 	// The dedicated tp-list discovery feed (a second CXO node under the
 	// same visor PK). nil when initStats fell back to the combined feed —
 	// then there is only the one telemetry entry above.
 	if tplistPub != nil {
+		allow, denied := feedGating(tplistPub)
 		out = append(out, CXOFeedState{
 			Name:         tplistCXOFeedName,
 			Port:         skyenv.DmsgVisorTPListCXOPort,
 			PublishState: tplistPub.PublishState(),
+			Allowlist:    allow,
+			Denied:       denied,
 		})
 	}
 	for _, fd := range users {
 		if fd.pub == nil {
 			continue
 		}
+		allow, denied := feedGating(fd.pub)
 		out = append(out, CXOFeedState{
 			Name:         fd.name,
 			Port:         fd.port,
 			PublishState: fd.pub.PublishState(),
+			Allowlist:    allow,
+			Denied:       denied,
 		})
 	}
 	return out


### PR DESCRIPTION
TPD's `cxoaggregator` built its CXO node with a zero SecKey → `node.NewNode` minted a **random** keypair. The visor's telemetry/tp-list feed gating checks the subscriber's CXO node PeerID against the TPD PK from `transport.discovery_dmsg`, so the aggregator's random PK never matched — every gated visor rejected TPD's subscribe and its transports went unfilled (the visor↔TPD count gap). Fix: bind the aggregator node identity to TPD's service SK, mirroring the publisher path.

Also surfaces each CXO feed's allowlist + denied-subscriber PKs in `skywire cli visor state` so this class of mismatch is directly visible.