### PR TITLE
fix(rewards): read survey public key from public_key, not pk

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/survey_ingest.go
+++ b/cmd/skywire-cli/commands/rewards/server/survey_ingest.go
@@ -67,7 +67,12 @@ func registerSurveyIngestRoutes(r1 *gin.Engine, wd string) {
 			return
 		}
 		var meta struct {
-			PubKey         string `json:"pk"`
+			// The survey serializes its public key as "public_key" (see
+			// visorconfig.Survey.PubKey json tag). Reading "pk" here left
+			// PubKey empty for every push, so EqualFold below never matched
+			// and every survey was rejected with "survey pk does not match
+			// sender" (the visor↔reward push always failing on the UI).
+			PubKey         string `json:"public_key"`
 			SkywireVersion string `json:"skywire_version"`
 		}
 		if err := json.Unmarshal(body, &meta); err != nil {


### PR DESCRIPTION
The `/node-info` survey-push ingest handler read the JSON field `"pk"`, but `visorconfig.Survey` serializes the public key as `"public_key"` (no `"pk"` field exists). So `meta.PubKey` was always empty and the sender-match check rejected **every** pushed survey with "survey pk does not match sender" — the red reward mark in the hypervisor UI. One-line fix to read the correct field.