### PR TITLE
fix(tpd): cache expired-transport SCAN off the CXO metrics publisher hot path

### DIFF
--- a/pkg/transport-discovery/store/expired_entries_cache.go
+++ b/pkg/transport-discovery/store/expired_entries_cache.go
@@ -1,0 +1,80 @@
+// Package store pkg/transport-discovery/store/expired_entries_cache.go c4-net-discovery
+package store
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// expiredEntriesCacheTTL bounds how long the SCAN-derived expired-transport
+// candidate set is reused before it is recomputed. The expired set changes
+// on a ~daily cadence (a transport ages out of the registered set), not
+// every minute, so a few-minute TTL is safe: a newly-EXPIRED transport may
+// appear up to one TTL late, which is acceptable.
+//
+// This cache exists because the CXO metrics publisher
+// (pkg/transport-discovery/api/cxo_metrics_publisher.go) turned
+// expiredTransportEntries from a low-frequency path (rewards dashboard /
+// daily reward calc) into a per-60s path: publishWindow calls
+// GetAllTransportMetrics on a ticker (1d/60s, 7d/5m, 30d/30m), and each call
+// SCANned the bw:daily:*:<date> keyspace once per day in the window (up to 35
+// passes) over a ~13k-transport keyspace, then recovered edges per candidate.
+// That put expiredTransportEntries at ~12% of TPD CPU with redis I/O
+// dominating. Memoizing the registered-INDEPENDENT SCAN result collapses the
+// repeated ticks onto one SCAN per TTL per window.
+const expiredEntriesCacheTTL = 5 * time.Minute
+
+// expiredEntriesCache memoizes, per day-window, the raw expired-transport
+// candidate set derived purely from the redis SCAN + recoverBandwidthEdges.
+// It deliberately does NOT bake in the caller's `registered` filter: that
+// filter is applied fresh on every call (see expiredTransportEntries) so a
+// transport that just (re)registered is dropped immediately and never counted
+// as expired for up to the TTL. Keyed by `days` because the 1/7/30 windows
+// scan different date ranges.
+type expiredEntriesCache struct {
+	mu     sync.Mutex
+	ttl    time.Duration
+	byDays map[int]expiredEntriesCacheEntry
+}
+
+type expiredEntriesCacheEntry struct {
+	entries    []*transport.Entry
+	expiredIDs map[uuid.UUID]bool
+	cachedAt   time.Time
+}
+
+func newExpiredEntriesCache(ttl time.Duration) *expiredEntriesCache {
+	if ttl <= 0 {
+		ttl = expiredEntriesCacheTTL
+	}
+	return &expiredEntriesCache{ttl: ttl, byDays: make(map[int]expiredEntriesCacheEntry)}
+}
+
+// get returns the cached raw candidate set for the window if present and
+// unexpired. The returned slice/map are the cache's own backing storage —
+// callers must treat them as read-only.
+func (c *expiredEntriesCache) get(days int) ([]*transport.Entry, map[uuid.UUID]bool, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.byDays[days]
+	if !ok || time.Since(e.cachedAt) > c.ttl {
+		return nil, nil, false
+	}
+	return e.entries, e.expiredIDs, true
+}
+
+// put stores the raw candidate set for the window, stamped with the current
+// time so get can treat entries older than the TTL as stale.
+func (c *expiredEntriesCache) put(days int, entries []*transport.Entry, expiredIDs map[uuid.UUID]bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.byDays[days] = expiredEntriesCacheEntry{
+		entries:    entries,
+		expiredIDs: expiredIDs,
+		cachedAt:   time.Now(),
+	}
+}

--- a/pkg/transport-discovery/store/redis_metrics.go
+++ b/pkg/transport-discovery/store/redis_metrics.go
@@ -427,14 +427,52 @@ func (s *redisStore) GetAllTransportMetrics(ctx context.Context, query MetricsQu
 // buildTransportMetrics reports them Live=false. Edges are recovered from the
 // daily-hash field names (see recoverBandwidthEdges).
 //
-// Cost note: this SCANs the bw:daily:*:<date> keyspace once per day in the
-// window. It runs on the metrics path, which is low-frequency (rewards
-// dashboard / daily reward calc) — acceptable, and mirrors the existing
-// BackupAndCleanOldBandwidth SCAN pattern.
+// The expensive part — the multi-day bw:daily:*:<date> SCAN plus per-candidate
+// edge recovery — is memoized by expiredEntriesCache (see scanExpiredCandidates
+// and expired_entries_cache.go). That memoized set is deliberately
+// registered-INDEPENDENT: the `registered` filter is applied FRESH here on
+// every call so a transport that just (re)registered is dropped immediately
+// rather than being wrongly reported as expired for up to the cache TTL.
 func (s *redisStore) expiredTransportEntries(ctx context.Context, registered map[uuid.UUID]bool, days int) ([]*transport.Entry, map[uuid.UUID]bool) {
 	if days <= 0 || days > 35 {
 		days = 35
 	}
+
+	rawEntries, rawIDs, ok := s.expiredCache.get(days)
+	if !ok {
+		rawEntries, rawIDs = s.scanExpiredCandidates(ctx, days)
+		s.expiredCache.put(days, rawEntries, rawIDs)
+	}
+	if len(rawEntries) == 0 {
+		return nil, nil
+	}
+
+	// Apply the registered filter FRESH on every call (hit or miss). Caching
+	// the post-filter result would let a newly-registered transport keep
+	// showing up as expired (and get double-counted) for up to the TTL; a
+	// newly-expired one appearing up to a TTL late is the acceptable trade.
+	expiredIDs := make(map[uuid.UUID]bool, len(rawIDs))
+	entries := make([]*transport.Entry, 0, len(rawEntries))
+	for _, e := range rawEntries {
+		if registered[e.ID] {
+			continue
+		}
+		entries = append(entries, e)
+		expiredIDs[e.ID] = true
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	return entries, expiredIDs
+}
+
+// scanExpiredCandidates performs the raw, registered-INDEPENDENT SCAN of the
+// bw:daily:*:<date> keyspace across the window and recovers edges for every
+// candidate found. Its result is what expiredEntriesCache memoizes; the
+// caller's `registered` filter is layered on top afterwards (see
+// expiredTransportEntries). It SCANs the keyspace once per day in the window,
+// mirroring the existing BackupAndCleanOldBandwidth SCAN pattern.
+func (s *redisStore) scanExpiredCandidates(ctx context.Context, days int) ([]*transport.Entry, map[uuid.UUID]bool) {
 	now := time.Now().UTC()
 	prefix := serviceName + ":bw:daily:"
 
@@ -447,7 +485,7 @@ func (s *redisStore) expiredTransportEntries(ctx context.Context, registered map
 			// key = transport-discovery:bw:daily:<id>:<date>
 			rest := strings.TrimSuffix(strings.TrimPrefix(iter.Val(), prefix), ":"+dateStr)
 			id, err := uuid.Parse(rest)
-			if err != nil || registered[id] || seen[id] {
+			if err != nil || seen[id] {
 				continue
 			}
 			seen[id] = true

--- a/pkg/transport-discovery/store/redis_store.go
+++ b/pkg/transport-discovery/store/redis_store.go
@@ -57,12 +57,13 @@ type LatencyRecord struct {
 const latencyTTL = 35 * 24 * time.Hour
 
 type redisStore struct {
-	client      *redis.Client
-	ttl         time.Duration
-	log         *logging.Logger
-	pkCache     *pubKeyCache
-	edgeCache   *edgeEntriesCache
-	allTpsCache *allTransportsCache
+	client       *redis.Client
+	ttl          time.Duration
+	log          *logging.Logger
+	pkCache      *pubKeyCache
+	edgeCache    *edgeEntriesCache
+	allTpsCache  *allTransportsCache
+	expiredCache *expiredEntriesCache
 }
 
 func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl time.Duration, logger *logging.Logger) (*redisStore, error) {
@@ -97,12 +98,13 @@ func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl
 	}
 
 	return &redisStore{
-		client:      redisCl,
-		ttl:         ttl,
-		log:         logger,
-		pkCache:     newPubKeyCache(defaultPubKeyCacheCap),
-		edgeCache:   newEdgeEntriesCache(defaultEdgeEntriesCacheCap, defaultEdgeEntriesCacheTTL),
-		allTpsCache: newAllTransportsCache(defaultAllTransportsCacheTTL),
+		client:       redisCl,
+		ttl:          ttl,
+		log:          logger,
+		pkCache:      newPubKeyCache(defaultPubKeyCacheCap),
+		edgeCache:    newEdgeEntriesCache(defaultEdgeEntriesCacheCap, defaultEdgeEntriesCacheTTL),
+		allTpsCache:  newAllTransportsCache(defaultAllTransportsCacheTTL),
+		expiredCache: newExpiredEntriesCache(expiredEntriesCacheTTL),
 	}, nil
 }
 func (s *redisStore) Close() {


### PR DESCRIPTION
`GetAllTransportMetrics` calls `expiredTransportEntries`, which SCANs the `bw:daily:*:<date>` redis keyspace once per day in the window (up to 35 passes over a ~13k-transport keyspace) and recovers edges per candidate. Its comment assumed a low-frequency path (rewards dashboard / daily reward calc), but the CXO metrics publisher now calls `GetAllTransportMetrics` on tickers (1d/60s, 7d/5m, 30d/30m), so that SCAN runs ~60x/hour and showed up at ~12% of TPD CPU on a live pprof, with redis I/O dominating.

This memoizes the registered-independent SCAN + edge-recovery result per day window behind a 5-minute in-process cache. Correctness is preserved by applying the `registered` filter fresh on every call (hit or miss) against the current set, so a transport that just (re)registered is never wrongly reported as expired; only a newly-expired transport can appear up to one TTL late, which is acceptable for this path.