### PR TITLE
fix(cli): honor --json/--jq/--shape on rg, skychat alias/pair list, visor reward

### DIFF
--- a/cmd/skywire-cli/commands/rg/rg.go
+++ b/cmd/skywire-cli/commands/rg/rg.go
@@ -4,7 +4,6 @@ package clirg
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -22,7 +21,6 @@ import (
 )
 
 var (
-	statusJSON   bool
 	statusFilter string
 	statusHops   bool
 	statusLive   bool
@@ -55,8 +53,6 @@ var listCmd = &cobra.Command{
 	Use:   "ls",
 	Short: "List active route groups with app associations and live stats",
 	Run: func(cmd *cobra.Command, _ []string) {
-		// The persistent --json, not a second flag of our own.
-		statusJSON = cliout.JSONMode(cmd)
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
@@ -64,12 +60,12 @@ var listCmd = &cobra.Command{
 		defer rpcClient.Close() //nolint:errcheck,gosec
 
 		// --live: bubbletea watch view. Honors --filter and --hops;
-		// not compatible with --json (the structured stream is its own
-		// thing). Re-fetches ActiveRoutes() every tick so bandwidth
-		// counters tick up in place.
+		// not compatible with the machine-output flags (their structured
+		// snapshot is its own thing). Re-fetches ActiveRoutes() every tick
+		// so bandwidth counters tick up in place.
 		if statusLive {
-			if statusJSON {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--live cannot be combined with --json"))
+			if cliout.MachineMode(cmd) {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--live cannot be combined with --json/--jq/--shape"))
 			}
 			err := livetui.Run(func(ctx context.Context) (string, error) {
 				return renderRouteGroupListLive(rpcClient)
@@ -91,10 +87,13 @@ var listCmd = &cobra.Command{
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 
-		if statusJSON {
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "  ")
-			internal.Catch(cmd.Flags(), enc.Encode(routes))
+		// --json / --jq / --shape all route through the shared output
+		// layer so they behave identically to the rest of the CLI:
+		// --json marshals the route-group slice, --jq filters it, --shape
+		// prints its skeleton. The default (no flag) still renders the
+		// human table below, unchanged.
+		if cliout.MachineMode(cmd) {
+			internal.Catch(cmd.Flags(), cliout.Print(cmd, routes))
 			return
 		}
 

--- a/cmd/skywire-cli/commands/skychat/alias.go
+++ b/cmd/skywire-cli/commands/skychat/alias.go
@@ -37,6 +37,7 @@ import (
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cliout"
 )
 
 const aliasFileName = "skywire/skychat-aliases.json"
@@ -218,11 +219,10 @@ var aliasLsCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		jsonMode, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
 		out := cmd.OutOrStdout()
-		if jsonMode {
-			b, _ := json.MarshalIndent(s.entries, "", "  ") //nolint:errcheck
-			_, _ = out.Write(append(b, '\n'))               //nolint:errcheck
+		// --json / --jq / --shape route through the shared output layer.
+		if cliout.MachineMode(cmd) {
+			internal.Catch(cmd.Flags(), cliout.Print(cmd, s.entries))
 			return
 		}
 		if len(s.entries) == 0 {

--- a/cmd/skywire-cli/commands/skychat/pair.go
+++ b/cmd/skywire-cli/commands/skychat/pair.go
@@ -36,6 +36,7 @@ import (
 	"github.com/spf13/cobra"
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	"github.com/skycoin/skywire/pkg/cliout"
 )
 
 var (
@@ -146,10 +147,9 @@ var pairListCmd = &cobra.Command{
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("decode pair list: %w", err))
 		}
 		out := cmd.OutOrStdout()
-		jsonMode, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
-		if jsonMode {
-			b, _ := json.MarshalIndent(pairs, "", "  ") //nolint:errcheck
-			_, _ = out.Write(append(b, '\n'))           //nolint:errcheck
+		// --json / --jq / --shape route through the shared output layer.
+		if cliout.MachineMode(cmd) {
+			internal.Catch(cmd.Flags(), cliout.Print(cmd, pairs))
 			return
 		}
 		if len(pairs) == 0 {

--- a/cmd/skywire-cli/commands/visor/reward.go
+++ b/cmd/skywire-cli/commands/visor/reward.go
@@ -26,18 +26,31 @@ var (
 	rewardDays int
 	rewardPK   string
 	rewardAll  bool
-	rewardJSON bool
 )
+
+// rewardHistory is the reward-system response for one visor: the daily
+// payout history the command renders. Promoted from an anonymous struct
+// so --json / --jq / --shape can route through the shared output layer.
+type rewardHistory struct {
+	PK      string             `json:"pk"`
+	Days    int                `json:"days"`
+	History []rewardHistoryDay `json:"history"`
+}
+
+// rewardHistoryDay is one day's payout row.
+type rewardHistoryDay struct {
+	Date   string  `json:"date"`
+	Amount float64 `json:"amount"`
+	Share  float64 `json:"share"`
+	Sent   bool    `json:"sent"`
+	Txid   string  `json:"txid,omitempty"`
+}
 
 var rewardCmd = &cobra.Command{
 	Use:   "reward",
 	Short: "Show reward history for a visor",
 	Long:  "Fetches reward history from the reward system via the visor's DMSG connection.",
 	Run: func(cmd *cobra.Command, args []string) {
-		// The persistent --json from RootCmd, not a second flag of our own:
-		// two variables for one concept meant the answer depended on where
-		// the user put the word.
-		rewardJSON = cliout.JSONMode(cmd)
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			logger.Fatal("RPC connection failed: ", err)
@@ -78,12 +91,12 @@ var rewardCmd = &cobra.Command{
 			if i > 0 {
 				fmt.Println()
 			}
-			fetchAndDisplayReward(rpcClient, rewardDmsg, pk)
+			fetchAndDisplayReward(cmd, rpcClient, rewardDmsg, pk)
 		}
 	},
 }
 
-func fetchAndDisplayReward(rpcClient visor.API, rewardDmsg, pk string) {
+func fetchAndDisplayReward(cmd *cobra.Command, rpcClient visor.API, rewardDmsg, pk string) {
 	url := fmt.Sprintf("%s/skycoin-rewards/visor/%s?days=%d", rewardDmsg, pk, rewardDays)
 
 	resp, err := rpcClient.DmsgHTTP(visor.DmsgHTTPRequest{
@@ -99,25 +112,26 @@ func fetchAndDisplayReward(rpcClient visor.API, rewardDmsg, pk string) {
 		return
 	}
 
-	if rewardJSON {
-		fmt.Println(string(resp.Body))
+	var result rewardHistory
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		// --json / --jq / --shape still get something structured: emit the
+		// raw body as a string value so the pipe stays parseable; the human
+		// path can't render an unparseable body, so report it.
+		if cliout.MachineMode(cmd) {
+			if pErr := cliout.Print(cmd, string(resp.Body)); pErr != nil {
+				logger.Fatal(pErr)
+			}
+			return
+		}
+		fmt.Fprintf(os.Stderr, "Failed to parse reward data for %s: %v\n", pk, err)
 		return
 	}
 
-	var result struct {
-		PK      string `json:"pk"`
-		Days    int    `json:"days"`
-		History []struct {
-			Date   string  `json:"date"`
-			Amount float64 `json:"amount"`
-			Share  float64 `json:"share"`
-			Sent   bool    `json:"sent"`
-			Txid   string  `json:"txid,omitempty"`
-		} `json:"history"`
-	}
-
-	if err := json.Unmarshal(resp.Body, &result); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to parse reward data for %s: %v\n", pk, err)
+	// --json / --jq / --shape route through the shared output layer.
+	if cliout.MachineMode(cmd) {
+		if err := cliout.Print(cmd, result); err != nil {
+			logger.Fatal(err)
+		}
 		return
 	}
 


### PR DESCRIPTION
Several list/read CLI commands parsed the global `--json` / `--jq '<expr>'` / `--shape` flags but emitted their own text table or raw JSON, so `--jq` and `--shape` were accepted and silently ignored (only `--json` did anything, and only as a raw dump).

Fixed by routing each through the shared `cliout` output layer (`cliout.Print`) — the same path `svc ar check` and the rest of the CLI already use, so `--json` marshals the value, `--jq` filters it, and `--shape` prints its skeleton.

Commands fixed:
- `rg ls` (route-group list)
- `skychat alias ls`
- `skychat pair list`
- `visor reward` (its anonymous response struct is promoted to a named type so it has a real shape)

Default (no-flag) human/text output is unchanged for all four. The `svc tpd/dmsgd/ar/nm` read subs already route through the flag-aware printer (`emitPretty`) and needed no change.

Verified live against a running visor: `rg --jq '.[].app_name'`, `visor reward --jq '.pk'`, `skychat alias ls --jq keys` now emit filtered JSON, and `--shape` prints the skeleton, while the bare commands still print their tables.