### PR TITLE
feat(router): exempt control-plane ports from the routing policy by default

### DIFF
--- a/pkg/router/control_port_mux_test.go
+++ b/pkg/router/control_port_mux_test.go
@@ -1,11 +1,47 @@
 package router
 
 import (
+	"context"
 	"testing"
 
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
+
+type stubDialHook struct{}
+
+func (stubDialHook) BeforeDial(_ context.Context, _ DialInfo) (DialAdjustment, error) {
+	return DialAdjustment{}, nil
+}
+
+// TestEffectiveDialHook: control-plane ports bypass the policy by default, opt
+// back in via PolicyOnControlPorts; data ports always get the hook; a nil hook
+// is always nil.
+func TestEffectiveDialHook(t *testing.T) {
+	hook := stubDialHook{}
+	cases := []struct {
+		name      string
+		dialHook  DialHook
+		onControl bool
+		port      uint16
+		wantHook  bool
+	}{
+		{"no hook configured", nil, false, skyenv.DmsgPtyPort, false},
+		{"control port default-exempt", hook, false, skyenv.DmsgPtyPort, false},
+		{"control port opted-in", hook, true, skyenv.DmsgPtyPort, true},
+		{"data port always hooked", hook, false, 3, true},
+		{"data port opted-in still hooked", hook, true, 3, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := &router{conf: &Config{DialHook: c.dialHook, PolicyOnControlPorts: c.onControl}}
+			if got := r.effectiveDialHook(routing.Port(c.port)); (got != nil) != c.wantHook {
+				t.Errorf("effectiveDialHook(port=%d, onControl=%v): got non-nil=%v, want %v",
+					c.port, c.onControl, got != nil, c.wantHook)
+			}
+		})
+	}
+}
 
 // TestIsControlPlanePort locks the no-mux port set: control/telemetry ports are
 // control-plane (single-route), bulk-data app ports are not (keep their mux).

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -192,6 +192,16 @@ type Config struct {
 	// configured.
 	DialHook DialHook
 
+	// PolicyOnControlPorts opts the routing policy (DialHook) BACK IN for
+	// control-plane destination ports (pty, dmsgctrl, setup, hypervisor RPC,
+	// …). Default false: those small noise-XK control channels bypass the
+	// policy entirely and take a plain base route, because its per-dial
+	// evaluation + warm-standby/reshape churn destabilizes their handshakes
+	// (the pty 32-leg-mux footgun). Set true to let the operator's policy
+	// manage control-plane routes too (advanced; e.g. a policy purpose-built
+	// for them). See effectiveDialHook / controlPlanePorts.
+	PolicyOnControlPorts bool
+
 	// EnableRSNOracleRoutes opts INTO the RSN-oracle 2-hop route path: for a
 	// single-intermediate route S->I->D the source computes the route LOCALLY
 	// from its OWN transports intersected with the destination's OWN transports

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -63,7 +63,7 @@ func (r *router) DialRoutes(
 	// opts.MinHops before route setup, and can refuse the dial
 	// entirely via Fallback="drop". A nil hook short-circuits
 	// the entire block so policy-free deployments pay zero cost.
-	if r.conf.DialHook != nil {
+	if hook := r.effectiveDialHook(rPort); hook != nil {
 		if opts == nil {
 			opts = &DialOptions{}
 		}
@@ -78,7 +78,7 @@ func (r *router) DialRoutes(
 			RPort:        rPort,
 			CLIOverrides: buildCLIOverrides(opts),
 		}
-		if adj, hookErr := r.conf.DialHook.BeforeDial(ctx, info); hookErr != nil {
+		if adj, hookErr := hook.BeforeDial(ctx, info); hookErr != nil {
 			// Failure to evaluate the policy is non-fatal — the
 			// hook's own failure-mode wiring decides whether to
 			// return a "drop" adjustment or fall back to defaults.
@@ -619,7 +619,7 @@ func (r *router) finishDial(
 	// callbacks whenever its leg set mutates after this point
 	// (additional aux legs from appendRouteToGroup, or
 	// transport-close pruning).
-	if lch, ok := r.conf.DialHook.(LegChangeHook); ok && lch != nil {
+	if lch, ok := r.effectiveDialHook(rPort).(LegChangeHook); ok && lch != nil {
 		nrg.rg.SetLegChangeHook(lch, DialInfo{
 			AppName: opts.AppName,
 			PeerPK:  rPK,
@@ -701,7 +701,7 @@ func (r *router) finishDial(
 		nrg.rg.maybeSelfHeal()
 
 		// Periodic rotation (policy on_tick) reuses the same callback.
-		if rh, ok := r.conf.DialHook.(RotationHook); ok && rh != nil && opts.RotationIntervalSeconds > 0 {
+		if rh, ok := r.effectiveDialHook(rPort).(RotationHook); ok && rh != nil && opts.RotationIntervalSeconds > 0 {
 			interval := time.Duration(opts.RotationIntervalSeconds) * time.Second
 			// Forward-only add-leg callback: the adaptive preset's AddForwardLeg
 			// (upload-saturation widen) dials an aux leg addFwd=true/addRev=false
@@ -846,7 +846,7 @@ func (r *router) PingRoute(
 	// too. Same shape as DialRoutes' hook block, minus the
 	// post-mux applyDistribution call — setupPingRoute handles
 	// distribution + leg-change hook wiring downstream.
-	if r.conf.DialHook != nil {
+	if hook := r.effectiveDialHook(rPort); hook != nil {
 		appName := ""
 		if opts != nil {
 			appName = opts.AppName
@@ -858,7 +858,7 @@ func (r *router) PingRoute(
 			RPort:        rPort,
 			CLIOverrides: buildCLIOverrides(opts),
 		}
-		if adj, hookErr := r.conf.DialHook.BeforeDial(ctx, info); hookErr != nil {
+		if adj, hookErr := hook.BeforeDial(ctx, info); hookErr != nil {
 			log.WithError(hookErr).Debug("policy hook errored on PingRoute; proceeding without adjustment")
 		} else if err := applyAdjustment(opts, adj); err != nil {
 			log.WithField("policy_decision", "drop").Info("PingRoute refused by routing policy.")
@@ -2813,6 +2813,32 @@ var controlPlanePorts = map[uint16]struct{}{
 func isControlPlanePort(p routing.Port) bool {
 	_, ok := controlPlanePorts[uint16(p)]
 	return ok
+}
+
+// effectiveDialHook returns the routing-policy DialHook to apply for a dial to
+// rPort, or nil when rPort is a control-plane port. Control/telemetry channels
+// (pty, dmsgctrl, setup, hypervisor RPC, transport-setup, …) must never run the
+// operator's routing policy at all: its per-dial evaluation, warm-standby
+// reserve, and reshape/rotation churn destabilize their small noise-XK
+// handshakes — the pty (port 22) 32-leg mux that "never carried a byte" and the
+// ~seconds-of-reshape that time out a request a single 1-hop route would have
+// completed. These channels always take a plain base route. This is the
+// policy-application complement to the muxTarget>1 no-mux gate in dialRoutesFwd:
+// that keeps an already-policied route from GROWING a mux; this keeps the policy
+// from evaluating/managing (BeforeDial/LegChange/Rotation) the route in the
+// first place, regardless of which policy (adaptive or a custom preset) is set.
+//
+// The control-plane exemption is the DEFAULT but not mandatory: setting
+// Config.PolicyOnControlPorts opts the policy back in for these ports too, for
+// an operator who deliberately wants a policy tuned for control traffic.
+func (r *router) effectiveDialHook(rPort routing.Port) DialHook {
+	if r.conf.DialHook == nil {
+		return nil
+	}
+	if isControlPlanePort(rPort) && !r.conf.PolicyOnControlPorts {
+		return nil
+	}
+	return r.conf.DialHook
 }
 
 // isSameLANDest reports whether dst is a peer on this visor's own local network

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -298,6 +298,7 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 		MasterLogger:          v.MasterLogger(),
 		AppLookup:             appLookup,
 		DialHook:              dialHook,
+		PolicyOnControlPorts:  v.conf.Routing.PolicyOnControlPorts,
 		RulesGCInterval:       0, // 0 = DefaultRulesGCInterval (10s)
 		SetupHooks:            routeSetupHooks,
 		EnableRSNOracleRoutes: v.conf.Routing.EnableRSNOracleRoutes,

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -710,6 +710,15 @@ type Routing struct {
 	// WASM ABI + trade-offs, and `skywire cli route policy
 	// test/bench` for iteration tools.
 	PolicyPerDial string `json:"policy_per_dial,omitempty"`
+
+	// PolicyOnControlPorts opts the routing policy (PolicyPerDial / per-app)
+	// BACK IN for control-plane destination ports (pty 22, dmsgctrl 7, setup
+	// 36, hypervisor RPC 46, transport-setup 47/48, …). Default false: those
+	// small noise-XK control channels bypass the policy and take a plain base
+	// route, because a bandwidth-spreading policy (e.g. the adaptive default)
+	// destabilizes their handshakes — the pty 32-leg-mux footgun. Set true
+	// only with a policy purpose-built for control traffic.
+	PolicyOnControlPorts bool `json:"policy_on_control_ports,omitempty"`
 }
 
 // UptimeTracker configures uptime tracker.

--- a/pkg/visor/visorcore/router.go
+++ b/pkg/visor/visorcore/router.go
@@ -44,6 +44,11 @@ type RouterDeps struct {
 	RulesGCInterval time.Duration
 	SetupHooks      []router.RouteSetupHook
 
+	// PolicyOnControlPorts opts the routing policy back in for control-plane
+	// destination ports (default OFF — those ports bypass the policy). Seeded
+	// from Routing.PolicyOnControlPorts. See router.Config.PolicyOnControlPorts.
+	PolicyOnControlPorts bool
+
 	// EnableRSNOracleRoutes opts into the RSN-oracle 2-hop route path (default
 	// OFF). Seeded from Routing.EnableRSNOracleRoutes; inert until the visor also
 	// calls router.SetDstTransportOracle.
@@ -79,6 +84,7 @@ func BuildRouter(serveCtx context.Context, deps RouterDeps) (router.Router, erro
 		AwaitSetupListener:    deps.AwaitSetupListener,
 		AppLookup:             deps.AppLookup,
 		DialHook:              deps.DialHook,
+		PolicyOnControlPorts:  deps.PolicyOnControlPorts,
 		RulesGCInterval:       deps.RulesGCInterval,
 		EnableRSNOracleRoutes: deps.EnableRSNOracleRoutes,
 		ExcludeSameLANHops:    deps.ExcludeSameLANHops,


### PR DESCRIPTION
The per-dial routing policy (adaptive default) ran on every dial including control channels (pty=22, dmsgctrl, setup, hv RPC, …), whose noise-XK handshakes are destabilized by its warm-standby/reshape churn — the 32-leg pty-mux footgun; skynet-pty ~4.2s + timeouts vs dmsg 0.4s. The existing muxTarget>1 gate only stopped mux *growth*. Now control-plane ports bypass the DialHook (BeforeDial/LegChange/Rotation) and take a plain base route. Opt back in with `Routing.PolicyOnControlPorts=true` (default false). New unit test; default config unchanged.