### PR TITLE
fix(cxo): progress-reset fill stall timer + hard total ceiling

### DIFF
--- a/pkg/cxo/node/config.go
+++ b/pkg/cxo/node/config.go
@@ -18,6 +18,7 @@ const (
 	MaxConnections        int           = 1000 * 1000
 	MaxPendingConnections int           = 1000
 	MaxFillingTime        time.Duration = 2 * time.Minute
+	MaxTotalFillTime      time.Duration = 10 * time.Minute
 	MaxHeads              int           = 10
 	ListenTCP             string        = ":8870"
 	ListenUDP             string        = "" // don't listen
@@ -137,16 +138,29 @@ type Config struct {
 	// MaxHeads is limit of heads per feed.
 	MaxHeads int
 
-	// MaxFillingTime is the time limit for filling of a Root object. A fill
-	// still running after this long is treated as a broken peer and aborted
-	// with ErrTimeout (the Root refills when the publisher republishes). The
-	// default was 10m, which is pathologically generous — a healthy tree fill
-	// completes in seconds, and a fill hung that long pins all its "wanted"
-	// objects in the cache (which cleanDown skips) for the whole window. That
-	// was the residual TPD aggregator leak (#3562/#3569); 2m keeps ~20-40x
-	// margin over a healthy fill while capping hung fills. The TPD aggregator
-	// pins its own tighter 90s override on top of this.
+	// MaxFillingTime is the STALL limit for filling of a Root object: the max
+	// time a fill may go WITHOUT fetching an object. The timer resets on every
+	// successful object fetch, so a large Root that keeps making progress is
+	// never aborted no matter how long its total fill takes — only a genuinely
+	// stalled peer (no object delivered for this long) is treated as broken and
+	// aborted with ErrTimeout (the Root refills when the publisher republishes).
+	// This replaced a fixed TOTAL-time cap that killed big-but-progressing hub
+	// Roots at the wall clock, which is the residual TPD churn (a single-source
+	// feed whose large Root couldn't finish inside the flat cap never landed).
+	// A hung fill still pins its "wanted" objects in the cache (which cleanDown
+	// skips), so MaxTotalFillTime below bounds the absolute window — that pair
+	// preserves the #3562/#3569 leak guard while letting slow fills complete.
+	// The TPD aggregator pins its own tighter 90s stall override on top of this.
 	MaxFillingTime time.Duration
+
+	// MaxTotalFillTime is the HARD ceiling on a single Root's fill, independent
+	// of progress: even a fill that keeps fetching objects is aborted once it
+	// has run this long in total. It backstops the progress-reset MaxFillingTime
+	// stall timer so a pathological source that dribbles one object every stall
+	// window can't pin "wanted" objects indefinitely (the #3562 leak class).
+	// Must be > MaxFillingTime; if <= 0 the package default (MaxTotalFillTime
+	// const) is used, and a value <= the stall timer is bumped to the default.
+	MaxTotalFillTime time.Duration
 
 	// RPC is RPC listening address. Empty string disables RPC.
 	RPC string

--- a/pkg/cxo/node/head.go
+++ b/pkg/cxo/node/head.go
@@ -128,8 +128,12 @@ type fillHead struct {
 	rq chan cipher.SHA256 // request objects (parallelism bounded by filler limit)
 	ff chan error         // filler failure
 
-	ft *time.Timer      // fill timeout
-	tc <-chan time.Time // ------------
+	ft       *time.Timer      // fill STALL timeout (reset on each fetched object)
+	tc       <-chan time.Time // ------------
+	stallDur time.Duration    // the stall window ft is (re)armed with
+
+	hardT  *time.Timer      // hard total-fill ceiling (never reset)
+	hardTc <-chan time.Time // ------------
 
 	tp   time.Time          // start point (start filling, for stat)
 	favg *statutil.Duration // average filling time
@@ -203,7 +207,13 @@ func (n *nodeHead) handle() {
 
 			f.handleDelConn(c)
 
-		case <-f.tc: // filling timeout
+		case <-f.tc: // fill stalled (no object fetched within MaxFillingTime)
+
+			if f.f != nil {
+				f.f.Fail(ErrTimeout)
+			}
+
+		case <-f.hardTc: // hard total-fill ceiling hit (MaxTotalFillTime)
 
 			if f.f != nil {
 				f.f.Fail(ErrTimeout)
@@ -258,8 +268,26 @@ func (f *fillHead) handleSuccess(c *Conn) {
 		// PushBack below until this guard landed.
 		return
 	}
+	f.rearmStall()   // progress: an object arrived, re-arm the stall timer
 	f.fc.PushBack(c) // push
 	f.triggerRequest()
+}
+
+// rearmStall re-arms the MaxFillingTime stall timer after progress (a fetched
+// object). Runs only on the single handle() goroutine, so no lock is needed.
+// Under Go 1.23+ timer semantics Reset alone would suffice, but the Stop+drain
+// keeps it correct on any toolchain if a fire raced into f.tc unread.
+func (f *fillHead) rearmStall() {
+	if f.ft == nil {
+		return
+	}
+	if !f.ft.Stop() {
+		select {
+		case <-f.tc:
+		default:
+		}
+	}
+	f.ft.Reset(f.stallDur)
 }
 
 func (f *fillHead) handleRequestFailure(fr failedRequest) {
@@ -406,7 +434,7 @@ func (f *fillHead) createFiller(cr connRoot) {
 
 	f.tp = time.Now() // time point
 
-	// A non-positive MaxFillingTime would leave f.tc nil and disable the fill
+	// A non-positive MaxFillingTime would leave f.tc nil and disable the stall
 	// timeout entirely, so a peer that flaps mid-fill pins all the fill's
 	// "wanted" objects in the cache until the connection closes (the leak class
 	// behind #3562). Treat <= 0 as "use the default", not "disable".
@@ -414,8 +442,23 @@ func (f *fillHead) createFiller(cr connRoot) {
 	if ft <= 0 {
 		ft = MaxFillingTime
 	}
+	// Hard total-fill ceiling. It must exceed the stall window, or it would
+	// pre-empt the progress-reset stall timer and re-impose a flat total cap
+	// (the very thing that churned big hub Roots). A configured value <= the
+	// stall window (or <= 0) falls back to the package default; if that is
+	// still not larger (an unusually large stall override), use 4x the stall.
+	htime := f.node().config.MaxTotalFillTime
+	if htime <= ft {
+		htime = MaxTotalFillTime
+		if htime <= ft {
+			htime = ft * 4
+		}
+	}
+	f.stallDur = ft
 	f.ft = time.NewTimer(ft)
 	f.tc = f.ft.C
+	f.hardT = time.NewTimer(htime)
+	f.hardTc = f.hardT.C
 
 	f.r = cr
 	f.rq = make(chan cipher.SHA256, f.maxParallel())
@@ -448,10 +491,14 @@ func (f *fillHead) closeFiller() {
 	if f.ft != nil {
 		f.ft.Stop()
 	}
+	if f.hardT != nil {
+		f.hardT.Stop()
+	}
 
 	f.f.Close() //nolint:errcheck,gosec
 
 	f.rqo, f.fc, f.rq = nil, nil, nil
+	f.tc, f.hardTc = nil, nil
 
 	f.r = connRoot{}
 	f.requesting = 0

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -183,20 +183,27 @@ type Config struct {
 	// per feed matters. Defaults to 2m. Mirrors the treestore
 	// Publisher's runCleanup, which the aggregator's node lacked.
 	CleanupInterval time.Duration
-	// MaxFillingTime caps how long the CXO node will keep a single Root
-	// fill in flight before aborting it with ErrTimeout. The node default
-	// (node.NewConfig) is 10m, which is far too generous for TPD's
-	// aggregator: it subscribes to every visor feed, and any flapping peer
-	// leaves its fill hung — holding all the fill's "wanted" objects in the
-	// in-memory cache (which cleanDown skips, so LRU can't evict them) for
-	// the full 10m before the timeout fires Unwant. With hundreds of
-	// unstable peers that standing pool of hung-fill memory is the residual
-	// leak the Root-prune cleanup can't reach. The aggregator is best-effort
-	// (an aborted fill just retries when the visor republishes), so we cap
-	// this low — a healthy transport-tree fill completes in seconds, and a
-	// fill still running after this long is a broken peer, not a slow one.
+	// MaxFillingTime is the per-fill STALL cap: the max time a Root fill may
+	// go WITHOUT fetching an object before the CXO node aborts it with
+	// ErrTimeout. The node re-arms this on every fetched object, so a large
+	// hub Root that keeps making progress is never aborted — only a peer that
+	// has genuinely gone quiet mid-fill is. TPD subscribes to every visor feed
+	// and any flapping peer leaves a hung fill holding its "wanted" objects in
+	// the in-memory cache (which cleanDown skips, so LRU can't evict them), so
+	// a tight stall cap releases a dead peer's objects in seconds. The earlier
+	// flat TOTAL cap did the same for dead peers but ALSO killed big-but-slow
+	// live Roots at the wall clock — the residual TPD churn where a large
+	// single-source feed's Root never landed inside 90s. Splitting into a
+	// stall cap (this) + a hard ceiling (MaxTotalFillTime) fixes that without
+	// re-opening the leak. Best-effort (an aborted fill retries on republish).
 	// Defaults to 90s.
 	MaxFillingTime time.Duration
+	// MaxTotalFillTime is the hard ceiling on one Root's total fill time,
+	// independent of progress — the backstop that keeps the progress-reset
+	// MaxFillingTime stall cap from letting a peer that dribbles one object
+	// per stall window pin "wanted" objects indefinitely. Must exceed
+	// MaxFillingTime. Defaults to 5m.
+	MaxTotalFillTime time.Duration
 	// Logger overrides the default tagged logger.
 	Logger *logging.Logger
 	// SecKey binds the aggregator's CXO node identity to TPD's service
@@ -334,6 +341,9 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 	if conf.MaxFillingTime <= 0 {
 		conf.MaxFillingTime = 90 * time.Second
 	}
+	if conf.MaxTotalFillTime <= conf.MaxFillingTime {
+		conf.MaxTotalFillTime = 5 * time.Minute
+	}
 	if conf.Logger == nil {
 		conf.Logger = logging.MustGetLogger("tpd-cxo-aggregator")
 	}
@@ -366,6 +376,7 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 	// Config.MaxFillingTime doc for why this is the aggregator's residual
 	// memory leak.
 	cfg.MaxFillingTime = conf.MaxFillingTime
+	cfg.MaxTotalFillTime = conf.MaxTotalFillTime
 	cfg.Config = skyobject.NewConfig()
 	cfg.Config.InMemoryDB = conf.InMemoryDB || conf.DataDir == ""
 	if conf.DataDir != "" {


### PR DESCRIPTION
The CXO Root fill aborted with `ErrTimeout` once a single `MaxFillingTime` timer expired, measured as **total** wall-clock from the start of the fill. For a large hub Root fetched from its one publisher, that flat cap (90s at the TPD aggregator) killed fills that were making steady progress but couldn't finish in time — the fill broke, forced a reconnect + re-push + re-walk, and on a persistently-large feed never landed. That's the residual TPD churn where the CXO view disagreed with the live transport set by ~15–30% on busy hubs.

Split the one timer into two, break if **either** fires:
- **`MaxFillingTime`** is now a **stall** cap, re-armed on every fetched object (`handleSuccess`). A fill that keeps making progress is never aborted regardless of total Root size; only a genuinely quiet source trips it.
- **`MaxTotalFillTime`** (new) is a hard ceiling on total fill time, independent of progress, so a source that dribbles one object per stall window can't pin `wanted` objects forever (preserves the #3562/#3569 leak guard).

Node defaults: stall 2m, ceiling 10m. TPD aggregator: stall 90s (unchanged), ceiling 5m. Both timers stop on `closeFiller` (success and break paths), so neither leaks into the next fill.

Tested: `pkg/cxo/node`, `pkg/cxo/treestore`, `pkg/transport-discovery/cxoaggregator` all pass; full binary compiles.