### PR TITLE
feat(proxystatus): anchor tree root, live log pane, bw meters, stream detail; interstitial fall-through

### DIFF
--- a/pkg/bitree/bitree.go
+++ b/pkg/bitree/bitree.go
@@ -306,8 +306,7 @@ func Render(root *Node, opts Options) string {
 		routes    [][]row
 		leftWidth int // max width of any left block line, across all routes
 	)
-	nRoutes := len(root.Right)
-	for i, route := range root.Right {
+	for _, route := range root.Right {
 		rlines := rightLayout(route, g)
 		var llines []string
 		if len(route.Left) > 0 {
@@ -326,8 +325,13 @@ func Render(root *Node, opts Options) string {
 				leftWidth = dw
 			}
 		}
-		up := i > 0
-		down := i < nRoutes-1
+		// Routes no longer join through a central vertical spine; the root sits
+		// at the top-left and each route hangs off it via a Unix-tree connector
+		// (├──/└──/│) in the left gutter (added in the assembly loop below). So a
+		// route's own junction reflects only left (its summary) and right (its
+		// hops), never an up/down neighbor — a plain horizontal arm.
+		up := false
+		down := false
 		n := len(rlines)
 		if len(llines) > n {
 			n = len(llines)
@@ -389,37 +393,44 @@ func Render(root *Node, opts Options) string {
 		b.WriteByte('\n')
 	}
 
-	// Root label centered over the right region.
-	spineCol := opts.LeftGutter + leftWidth + 1 + 2 // gutter + leftfield + space + 2-cell arm
-	rightStart := spineCol + 1 + 3                  // spine glyph + "── "
-	// Estimate right region width from the widest assembled right side.
-	rightRegionW := treeWidth
-	// account for columns
-	colsTotal := 0
-	for _, cw := range colW {
-		colsTotal += cw + dispWidth(sep)
-	}
-	rightRegionW += colsTotal
-	rootCol := rightStart + (rightRegionW-dispWidth(root.Label))/2
-	if rootCol < 0 {
-		rootCol = 0
-	}
-	writeLine(strings.Repeat(" ", rootCol) + opts.style(root.Label, CellRoot))
+	// Root label anchored at the top-LEFT (the Unix `tree` root), from which every
+	// route hangs via a box-drawing connector in the left gutter — so the whole
+	// thing reads as one connected tree, not a label floating over the branches.
+	writeLine(gutter + opts.style(root.Label, CellRoot))
 
-	for _, rows := range routes {
-		for _, rw := range rows {
+	nRoutes := len(routes)
+	for ri, rows := range routes {
+		lastRoute := ri == nRoutes-1
+		for rj, rw := range rows {
+			// Unix-tree connector joining this route up to the root: the route's
+			// first (anchor) row gets ├──/└──; its continuation rows get │/blank so
+			// the trunk keeps descending past a multi-row route to the next branch.
+			var conn string
+			if rj == 0 {
+				if lastRoute {
+					conn = g.CornerUR + h + h + " " // "└── "
+				} else {
+					conn = g.TeeRight + h + h + " " // "├── "
+				}
+			} else if lastRoute {
+				conn = "    "
+			} else {
+				conn = g.Vertical + "   " // "│   "
+			}
+
 			// Left field (right-justified to leftWidth). Styled after layout so a
 			// color/HTML wrapper may decorate glyphs within it without disturbing
 			// column math (StyleCell must preserve display width).
 			left := opts.style(padLeft(rw.left, leftWidth), CellLeft)
-			// Middle connector: gutter + left field + space + arm(2) + spine.
+			// Middle connector: gutter + trunk connector + left field + space +
+			// arm(2) + spine.
 			var arm string
 			if rw.anchor && rw.hasLeft {
 				arm = h + h
 			} else {
 				arm = "  "
 			}
-			mid := gutter + left + " " + arm + rw.spine
+			mid := gutter + conn + left + " " + arm + rw.spine
 
 			// Right region.
 			var rightText string

--- a/pkg/bitree/bitree_test.go
+++ b/pkg/bitree/bitree_test.go
@@ -19,8 +19,8 @@ func TestSingleRoute(t *testing.T) {
 		Label: "EXITPK", Cols: []string{"[stcpr]", "9a3a17e0…", "143ms"},
 		Left: ann("R[0] ● 1.6K↑ 1.5K↓"),
 	}}}
-	want := "                                    this visor\n" +
-		"R[0] ● 1.6K↑ 1.5K↓ ───── EXITPK  [stcpr]  9a3a17e0…  143ms"
+	want := "this visor\n" +
+		"└── R[0] ● 1.6K↑ 1.5K↓ ───── EXITPK  [stcpr]  9a3a17e0…  143ms"
 	check(t, "single", Render(root, Options{}), want)
 }
 
@@ -36,13 +36,13 @@ func TestMockupTree(t *testing.T) {
 			Right: []*Node{{Label: "HOP2PK", Cols: []string{"[squicr]", "85086f0c…", "74ms"},
 				Right: []*Node{leaf("EXITPK", "[stcpr]", "da5c74a8…", "133ms")}}}},
 	}}
-	want := "                                         this visor\n" +
-		"R[0] ● 1.6K↑ 1.5K↓ ──┬── EXITPK          [stcpr]   9a3a17e0…  143ms\n" +
-		"R[1] ● 0.5K↑ 0.4K↓ ──┼── HOP1PK          [sudph]   72512b4b…  47ms\n" +
-		"                     │   └── EXITPK      [stcpr]   1fafe896…  88ms\n" +
-		"R[2] ● 0.2K↑ 0.1K↓ ──┴── HOP1PK          [webrtc]  38252d68…  61ms\n" +
-		"                         └── HOP2PK      [squicr]  85086f0c…  74ms\n" +
-		"                             └── EXITPK  [stcpr]   da5c74a8…  133ms"
+	want := "this visor\n" +
+		"├── R[0] ● 1.6K↑ 1.5K↓ ───── EXITPK          [stcpr]   9a3a17e0…  143ms\n" +
+		"├── R[1] ● 0.5K↑ 0.4K↓ ───── HOP1PK          [sudph]   72512b4b…  47ms\n" +
+		"│                            └── EXITPK      [stcpr]   1fafe896…  88ms\n" +
+		"└── R[2] ● 0.2K↑ 0.1K↓ ───── HOP1PK          [webrtc]  38252d68…  61ms\n" +
+		"                             └── HOP2PK      [squicr]  85086f0c…  74ms\n" +
+		"                                 └── EXITPK  [stcpr]   da5c74a8…  133ms"
 	check(t, "mockup", Render(root, Options{}), want)
 }
 
@@ -59,13 +59,13 @@ func TestLeftSubtreeNesting(t *testing.T) {
 		{Label: "HOP1PK", Cols: []string{"[sudph]", "72512b4b…", "47ms"}, Left: ann("R[1] ● 0.5K↑ 0.4K↓"),
 			Right: []*Node{leaf("EXITPK", "[stcpr]", "1fafe896…", "88ms")}},
 	}}
-	want := "                                      this visor\n" +
-		"            R[0] ● ──┬── EXITPK      [stcpr]  9a3a17e0…  143ms\n" +
-		"   1.6K↑ 1.5K↓ ──┤   │\n" +
-		" rtt 143ms ──┘   │   │\n" +
-		"     via stcpr ──┘   │\n" +
-		"R[1] ● 0.5K↑ 0.4K↓ ──┴── HOP1PK      [sudph]  72512b4b…  47ms\n" +
-		"                         └── EXITPK  [stcpr]  1fafe896…  88ms"
+	want := "this visor\n" +
+		"├──             R[0] ● ───── EXITPK      [stcpr]  9a3a17e0…  143ms\n" +
+		"│      1.6K↑ 1.5K↓ ──┤\n" +
+		"│    rtt 143ms ──┘   │\n" +
+		"│        via stcpr ──┘\n" +
+		"└── R[1] ● 0.5K↑ 0.4K↓ ───── HOP1PK      [sudph]  72512b4b…  47ms\n" +
+		"                             └── EXITPK  [stcpr]  1fafe896…  88ms"
 	check(t, "nest", Render(root, Options{}), want)
 }
 
@@ -78,8 +78,8 @@ func TestAlignColumns(t *testing.T) {
 	got := Render(root, Options{AlignColumns: 20})
 	// The single column "x" must appear at a fixed offset regardless of the
 	// short "A" label: tree portion padded to 20 (+3 arm) then ColSep.
-	want := "                 root\n" +
-		"L ───── A                     x"
+	want := "root\n" +
+		"└── L ───── A                     x"
 	check(t, "aligncols", got, want)
 }
 

--- a/pkg/proxyinterstitial/interstitial.go
+++ b/pkg/proxyinterstitial/interstitial.go
@@ -276,7 +276,15 @@ func ShouldServe(port string) bool {
 // moment the user most needs to see why — which the interstitial would otherwise
 // shadow. Pass nil for the plain interstitial-only behavior. The closure lives
 // in the caller so this package stays free of any pkg/proxystatus dependency.
-func ServeSOCKS5(conn net.Conn, detail, mechanism string, statusOverride func(host string) []byte) error {
+//
+// exitReachable is the symmetric fall-through: this function is minted on a dial
+// failure, but that failure can be transient (a single stream open failing while
+// the session is actually up). If exitReachable != nil and reports the exit IS
+// reachable at serve time, the waiting "building a route" interstitial would just
+// pin the browser on a spinner even though the route is live — so instead a tiny
+// reload page is served that immediately re-requests the original URL, letting it
+// fall through to the real content. Pass nil to always serve the interstitial.
+func ServeSOCKS5(conn net.Conn, detail, mechanism string, statusOverride func(host string) []byte, exitReachable func() bool) error {
 	_ = conn.SetDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
 	defer conn.SetDeadline(time.Time{})                   //nolint:errcheck
 
@@ -361,8 +369,40 @@ func ServeSOCKS5(conn net.Conn, detail, mechanism string, statusOverride func(ho
 			return err
 		}
 	}
+	// The exit is reachable again (the dial failure was transient) — don't pin the
+	// browser on the waiting spinner; serve a reload that falls through to the
+	// intended page, which now loads over the live route.
+	if exitReachable != nil && exitReachable() {
+		_, err := conn.Write(reloadHTTPResponse())
+		return err
+	}
 	_, err := conn.Write(httpResponse(host, detail, mechanism, false))
 	return err
+}
+
+// ReloadPage is the minimal fall-through page served once the exit is reachable
+// again: it immediately re-requests the SAME URL (via location.replace so the
+// interstitial is not left in history), with a meta-refresh=0 fallback for a
+// no-JS browser. The re-request loads the real content over the now-live route.
+func ReloadPage() string {
+	return `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+		`<meta http-equiv="refresh" content="0">` +
+		`<title>Loading…</title></head><body>` +
+		`<script>location.replace(location.href)</script>` +
+		`</body></html>`
+}
+
+// reloadHTTPResponse wraps ReloadPage in a no-store HTTP/1.1 response.
+func reloadHTTPResponse() []byte {
+	body := ReloadPage()
+	var b bytes.Buffer
+	b.WriteString("HTTP/1.1 200 OK\r\n")
+	b.WriteString("Content-Type: text/html; charset=utf-8\r\n")
+	fmt.Fprintf(&b, "Content-Length: %d\r\n", len(body))
+	b.WriteString("Cache-Control: no-store, must-revalidate\r\n")
+	b.WriteString("Connection: close\r\n\r\n")
+	b.WriteString(body)
+	return b.Bytes()
 }
 
 // readFull is io.ReadFull without pulling io into a file that otherwise

--- a/pkg/proxyinterstitial/interstitial_test.go
+++ b/pkg/proxyinterstitial/interstitial_test.go
@@ -99,7 +99,7 @@ func TestServeSOCKS5_HTTPPort(t *testing.T) {
 	cli, srv := net.Pipe()
 	defer cli.Close() //nolint:errcheck
 	done := make(chan error, 1)
-	go func() { done <- ServeSOCKS5(srv, "", "skysocks", nil); srv.Close() }() //nolint:errcheck,gosec
+	go func() { done <- ServeSOCKS5(srv, "", "skysocks", nil, nil); srv.Close() }() //nolint:errcheck,gosec
 
 	_ = cli.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
 	// greeting: VER=5, 1 method, no-auth
@@ -153,7 +153,7 @@ func TestServeSOCKS5_HTTPSDeclined(t *testing.T) {
 	cli, srv := net.Pipe()
 	defer cli.Close() //nolint:errcheck
 	done := make(chan error, 1)
-	go func() { done <- ServeSOCKS5(srv, "", "skysocks", nil); srv.Close() }() //nolint:errcheck,gosec
+	go func() { done <- ServeSOCKS5(srv, "", "skysocks", nil, nil); srv.Close() }() //nolint:errcheck,gosec
 
 	_ = cli.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
 	cli.Write([]byte{0x05, 0x01, 0x00})                  //nolint:errcheck,gosec
@@ -224,7 +224,7 @@ func TestServeSOCKS5_StatusOverride(t *testing.T) {
 		cli, srv := net.Pipe()
 		defer cli.Close() //nolint:errcheck
 		done := make(chan error, 1)
-		go func() { done <- ServeSOCKS5(srv, "", "skysocks", override); srv.Close() }() //nolint:errcheck,gosec
+		go func() { done <- ServeSOCKS5(srv, "", "skysocks", override, nil); srv.Close() }() //nolint:errcheck,gosec
 		got := serveSOCKS5CONNECT(t, cli, statusHost, 80)
 		if !strings.Contains(got, "STATUS-PAGE") {
 			t.Errorf("status host did not receive override; got %q", got)
@@ -241,7 +241,7 @@ func TestServeSOCKS5_StatusOverride(t *testing.T) {
 		cli, srv := net.Pipe()
 		defer cli.Close() //nolint:errcheck
 		done := make(chan error, 1)
-		go func() { done <- ServeSOCKS5(srv, "", "skysocks", override); srv.Close() }() //nolint:errcheck,gosec
+		go func() { done <- ServeSOCKS5(srv, "", "skysocks", override, nil); srv.Close() }() //nolint:errcheck,gosec
 		got := serveSOCKS5CONNECT(t, cli, "example.com", 80)
 		if !strings.Contains(got, "Building a route") {
 			t.Errorf("normal host did not receive interstitial; got %q", got)
@@ -253,6 +253,61 @@ func TestServeSOCKS5_StatusOverride(t *testing.T) {
 			t.Errorf("ServeSOCKS5: %v", err)
 		}
 	})
+}
+
+// TestServeSOCKS5_ExitReachableFallThrough verifies the fall-through fix: when
+// exitReachable reports the exit is up (the dial failure was transient), a normal
+// HTTP CONNECT is answered with the reload page that re-requests the original URL
+// — NOT the waiting "Building a route" interstitial that would pin the browser on
+// a spinner. When exitReachable reports the exit is still down, the interstitial
+// is served as before.
+func TestServeSOCKS5_ExitReachableFallThrough(t *testing.T) {
+	t.Run("reachable serves reload fall-through", func(t *testing.T) {
+		cli, srv := net.Pipe()
+		defer cli.Close() //nolint:errcheck
+		done := make(chan error, 1)
+		up := func() bool { return true }
+		go func() { done <- ServeSOCKS5(srv, "", "skysocks", nil, up); srv.Close() }() //nolint:errcheck,gosec
+		got := serveSOCKS5CONNECT(t, cli, "example.com", 80)
+		if !strings.Contains(got, "location.replace(location.href)") {
+			t.Errorf("reachable exit did not fall through to the reload page; got %q", got)
+		}
+		if strings.Contains(got, "Building a route") {
+			t.Errorf("reachable exit was pinned on the interstitial; got %q", got)
+		}
+		if err := <-done; err != nil {
+			t.Errorf("ServeSOCKS5: %v", err)
+		}
+	})
+
+	t.Run("unreachable still serves interstitial", func(t *testing.T) {
+		cli, srv := net.Pipe()
+		defer cli.Close() //nolint:errcheck
+		done := make(chan error, 1)
+		down := func() bool { return false }
+		go func() { done <- ServeSOCKS5(srv, "", "skysocks", nil, down); srv.Close() }() //nolint:errcheck,gosec
+		got := serveSOCKS5CONNECT(t, cli, "example.com", 80)
+		if !strings.Contains(got, "Building a route") {
+			t.Errorf("unreachable exit did not serve the interstitial; got %q", got)
+		}
+		if strings.Contains(got, "location.replace(location.href)") {
+			t.Errorf("unreachable exit wrongly fell through; got %q", got)
+		}
+		if err := <-done; err != nil {
+			t.Errorf("ServeSOCKS5: %v", err)
+		}
+	})
+}
+
+// TestReloadPage checks the fall-through page re-requests the original URL and
+// does not auto-linger (meta-refresh=0 no-JS fallback + location.replace).
+func TestReloadPage(t *testing.T) {
+	p := ReloadPage()
+	for _, want := range []string{`http-equiv="refresh" content="0"`, "location.replace(location.href)"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("reload page missing %q", want)
+		}
+	}
 }
 
 // TestDumpSamples writes the two page variants to the scratchpad for a manual

--- a/pkg/proxystatus/provider.go
+++ b/pkg/proxystatus/provider.go
@@ -99,7 +99,19 @@ type Snapshot struct {
 	Legs       []Leg    // current per-leg mux state (empty when no active route group)
 	Logs       []string // recent log lines, oldest first
 	Events     []string // route/transport events affecting this surface, oldest first
+	Streams    []Stream // per-stream detail for the open session (skysocks tunnel), when tracked
 	Note       string   // optional human note (e.g. why a section is empty)
+}
+
+// Stream is one open tunneled stream on the surface's session to the exit — the
+// per-stream detail behind the "N open stream(s)" count. The skysocks-client
+// tracks these locally (id + CONNECT target + age); the underlying yamux layer
+// does not meter per-stream bytes, so bytes are intentionally absent (the
+// route-group totals in the mux section are the byte counters that exist).
+type Stream struct {
+	ID     uint32 // yamux stream id
+	Target string // the CONNECT target host:port the stream carries (never a PK)
+	AgeMS  int64  // how long the stream has been open, milliseconds
 }
 
 // Provider yields a live Snapshot for a surface. Implemented by the visor

--- a/pkg/proxystatus/proxystatus_test.go
+++ b/pkg/proxystatus/proxystatus_test.go
@@ -57,13 +57,14 @@ func TestRenderSections(t *testing.T) {
 					{TpID: "tp2ccccccc-2222-2222-2222-222222222222", From: "03bb223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", To: "03cc223344556677889900aabbccddeeff00112233445566778899aabbccddeeff", TpType: "stcpr", LatencyMS: 450},
 				}},
 		},
-		Logs:   []string{"line one", "line two"},
-		Events: nil,
+		Logs:    []string{"line two", "[2025-06-01T00:00:00.0000Z] INFO [skysocks-client]: app is running"},
+		Events:  []string{"[2025-06-01T00:00:01.0000Z] WARN [router]: leg demoted"},
+		Streams: []Stream{{ID: 7, Target: "example.com:80", AgeMS: 65000}},
 	}
 	page := string(Render(snap))
 	for _, want := range []string{
 		"<!doctype html>", "proxy status", "skysocks-client", "per-leg mux",
-		"stcpr", "recent log", "line two", "route control", "read-only preview",
+		"stcpr", "route, transport", "line two", "route control", "read-only preview",
 		// live push (skysocks): the WebSocket script + swap target replace the old
 		// meta refresh, which must be gone for this surface. The WS URL is derived
 		// from the page origin (never a hardcoded http://), and sendCmd is the
@@ -72,20 +73,22 @@ func TestRenderSections(t *testing.T) {
 		`location.origin.replace(/^http/,"ws")`, "sendCmd",
 		"standby", "status.dmsg", "status.skynet",
 		// route observability: the left per-route summary carries the end-to-end
-		// route rtt; "route rtt" is also named in the hint prose. The multihop
+		// route rtt; "route-rtt" is also named in the tree legend. The multihop
 		// standby leg's route rtt (480) renders compact ("480ms").
-		"route rtt", "480ms",
+		"route-rtt", "480ms",
 		// ONE shared bilateral route tree (pkg/proxystatus.RouteTree) rendered by
 		// pkg/bitree into a monospace <pre>: root = this visor (source PK), each
 		// active route a right branch (its hop chain), a left summary block, and
 		// aligned trailing hop columns. The exact model+shape `proxy tree` prints.
-		`class="tree"`, `class="bitree"`, "──┬──", "└──",
+		// Unix-tree root anchoring: the source PK is the top-left root and each
+		// route hangs off it via ├──/└── trunk connectors (item 1).
+		`class="tree"`, `class="bitree"`, "├──", "└──",
 		// Tree header/legend (tp-tree style): color swatches name the source PK
 		// accent and the active/standby state dots, then the column hints — dead legs
 		// are pruned so there is no dead swatch.
 		`class="tlegend"`, `class="lgnd src"`,
 		`class="lgnd ok"`, `class="lgnd standby"`, `class="lgnd cols"`,
-		"this visor", "exit", "peer · [type] · tpid",
+		"this visor", "peer · [type] · tpid",
 		// FULL (never truncated) PKs: the source (root) and the multihop exit.
 		"03cc223344556677889900aabbccddeeff00112233445566778899aabbccddeeff",
 		"02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee",
@@ -112,6 +115,17 @@ func TestRenderSections(t *testing.T) {
 		// Embedded mononoki monospace font so the tree's box-drawing glyphs align:
 		// an @font-face woff2 data-URI in the shell + the family on the tree/PK cells.
 		"@font-face", "'Mononoki'", "data:font/woff2;base64,",
+		// item 3: ONE combined route+transport+log stream, terminal-colored by level
+		// (INFO green / WARN amber / …) in a scrollable window (newest pinned by the
+		// live script). The event + log lines merge in timestamp order.
+		"route, transport &amp; log", `class="ll-info"`, `class="ll-warn"`,
+		"app is running", "leg demoted",
+		// item 5: live up/down rate meters differenced from the cumulative byte totals
+		// by the inline script over the WebSocket pushes.
+		`data-bytes="up"`, `data-bytes="down"`, `data-rate="up"`, `data-rate="down"`, `class="rate"`, "fmtRate",
+		// item 4: the "N open stream(s)" count expands into per-stream rows (id /
+		// target / age) in an expandable section.
+		`class="streams"`, "open streams", "example.com:80",
 	} {
 		if !strings.Contains(page, want) {
 			t.Errorf("rendered page missing %q", want)
@@ -161,7 +175,7 @@ func TestRenderFragmentIsLiveRegionOnly(t *testing.T) {
 		Logs: []string{"frag line"},
 	}
 	frag := string(RenderFragment(snap))
-	for _, want := range []string{"per-leg mux", "recent log", "frag line", `class="pills"`} {
+	for _, want := range []string{"per-leg mux", "route, transport", "frag line", `class="pills"`} {
 		if !strings.Contains(frag, want) {
 			t.Errorf("fragment missing %q", want)
 		}

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html"
 	"strings"
+	"time"
 
 	"github.com/skycoin/skywire/pkg/bitree"
 )
@@ -18,11 +19,6 @@ const refreshSeconds = 4
 // maxLogLines caps how many recent log lines the page renders, newest at the
 // bottom (terminal-tail order). The Provider may return fewer.
 const maxLogLines = 200
-
-// maxEventLines caps how many recent route/transport event lines the page
-// renders (oldest first, matching the Provider's ordering). The Provider may
-// return fewer.
-const maxEventLines = 200
 
 // Render returns the full, self-contained HTML status page for snap. All
 // interpolated values are HTML-escaped; the page loads no external resource
@@ -129,15 +125,28 @@ func RenderFragment(snap Snapshot) []byte {
 // Clipboard API when available and falling back to execCommand('copy') so it works
 // over plain HTTP (status.skysocks is not a secure context). It flashes the element
 // green briefly. The live indicator (#wsstat) is driven here too.
-const liveScript = `<script>(function(){var t,ws,pend=null,last=null;` +
+const liveScript = `<script>(function(){var t,ws,pend=null,last=null,pv=null;` +
 	`function stat(s,c){var el=document.getElementById("wsstat");if(el){el.textContent=s;el.className="wsstat "+c;el.insertAdjacentHTML("afterbegin",'<i class="dot"></i>');}}` +
 	`function slow(){if(!t){t=setTimeout(function(){location.reload();},15000);}}` +
 	`function url(){return location.origin.replace(/^http/,"ws")+"/ws";}` +
 	`function selecting(){var s=window.getSelection();return !!(s&&!s.isCollapsed&&String(s));}` +
+	// Live up/down rate meters: difference the cumulative data-val byte totals of the
+	// two rgsummary stats between pushes and divide by elapsed wall time. Counter
+	// resets (route rebuild) clamp to 0. Seeded from the initial render so the first
+	// push measures over the real interval.
+	`function fmtRate(b){b=b||0;if(b>=1048576){return (b/1048576).toFixed(1)+"M";}if(b>=1024){return (b/1024).toFixed(1)+"K";}return Math.round(b)+"B";}` +
+	`function meters(el){var now=Date.now(),cur={},ss=el.querySelectorAll(".stat[data-bytes]"),i;` +
+	`for(i=0;i<ss.length;i++){cur[ss[i].getAttribute("data-bytes")]=parseFloat(ss[i].getAttribute("data-val"))||0;}` +
+	`if(pv&&now>pv.t){var dt=(now-pv.t)/1000,rs=el.querySelectorAll(".rate[data-rate]"),k;` +
+	`for(k=0;k<rs.length;k++){var key=rs[k].getAttribute("data-rate"),d=(cur[key]||0)-(pv[key]||0);if(d<0){d=0;}rs[k].textContent="· "+fmtRate(d/dt)+"/s";}}` +
+	`pv={up:cur.up||0,down:cur.down||0,t:now};}` +
+	// Pin the log pane to the newest line unless the user has scrolled up to read
+	// back; restore any horizontal offset and the window offset as before.
 	`function apply(h){if(h===last){return;}var el=document.getElementById("live");if(!el){return;}` +
-	`var sx=window.scrollX,sy=window.scrollY,lg=el.querySelector("pre.log"),lt=lg?lg.scrollTop:0,ll=lg?lg.scrollLeft:0;` +
+	`var sx=window.scrollX,sy=window.scrollY,lg=el.querySelector("pre.log");` +
+	`var lt=lg?lg.scrollTop:0,ll=lg?lg.scrollLeft:0,pin=lg?(lg.scrollTop+lg.clientHeight>=lg.scrollHeight-4):true;` +
 	`el.innerHTML=h;last=h;` +
-	`var lg2=el.querySelector("pre.log");if(lg2){lg2.scrollTop=lt;lg2.scrollLeft=ll;}window.scrollTo(sx,sy);}` +
+	`var lg2=el.querySelector("pre.log");if(lg2){lg2.scrollTop=pin?lg2.scrollHeight:lt;lg2.scrollLeft=ll;}meters(el);window.scrollTo(sx,sy);}` +
 	`function push(h){if(selecting()){pend=h;return;}apply(h);}` +
 	`document.addEventListener("selectionchange",function(){if(pend!==null&&!selecting()){var h=pend;pend=null;apply(h);}});` +
 	`function connect(){stat("connecting","wait");try{ws=new WebSocket(url());}catch(e){slow();return;}` +
@@ -151,6 +160,9 @@ const liveScript = `<script>(function(){var t,ws,pend=null,last=null;` +
 	`function copy(txt,el){function ok(){flash(el,"copied");}if(navigator.clipboard&&navigator.clipboard.writeText&&window.isSecureContext){navigator.clipboard.writeText(txt).then(ok,function(){if(fb(txt)){ok();}});}else if(fb(txt)){ok();}}` +
 	`document.addEventListener("click",function(e){var el=e.target.closest?e.target.closest("[data-copy]"):null;if(el){e.preventDefault();copy(el.getAttribute("data-copy")||el.textContent,el);}});` +
 	`window.rsync=function(btn){var ok=sendCmd({cmd:"resync"});flash(btn,ok?"flash":"deny");return ok;};` +
+	// Seed the rate baseline from the server-rendered paint and pin the log pane to
+	// its newest line so the tail is visible before the first live push arrives.
+	`var el0=document.getElementById("live");if(el0){meters(el0);var lg0=el0.querySelector("pre.log");if(lg0){lg0.scrollTop=lg0.scrollHeight;}}` +
 	`document.body.classList.add("js");connect();})();</script>`
 
 // writeLiveRegion writes the dynamic status content (pills, per-leg mux, events,
@@ -181,9 +193,9 @@ func writeLiveRegion(b *strings.Builder, snap Snapshot) {
 		fmt.Fprintf(b, `<p class="note">%s</p>`, html.EscapeString(snap.Note))
 	}
 
+	writeStreamsSection(b, snap)
 	writeMuxSection(b, snap)
-	writeEventsSection(b, snap)
-	writeLogsSection(b, snap)
+	writeLogSection(b, snap)
 }
 
 func writePill(b *strings.Builder, k, v, cls string) {
@@ -226,7 +238,11 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 		}
 	}
 	// Scannable route-group summary: leg census + aggregate throughput, so the
-	// operator gets the shape of the group before reading the route tree.
+	// operator gets the shape of the group before reading the route tree. The
+	// cumulative sent/recv totals carry machine-readable data-bytes attributes so
+	// the live script can difference successive ~1s WebSocket pushes into the live
+	// up/down RATE meters (bytes/sec) beside them — no server-side rate needed and
+	// no per-leg speed field on the wire.
 	b.WriteString(`<div class="rgsummary">`)
 	writeStat(b, "legs", fmt.Sprintf("%d", len(snap.Legs)), "")
 	writeStat(b, "active", fmt.Sprintf("%d", nActive), "ok")
@@ -236,8 +252,8 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 	if nClosed > 0 {
 		writeStat(b, "closed", fmt.Sprintf("%d", nClosed), "warn")
 	}
-	writeStat(b, "sent", humanBytes(totSent), "")
-	writeStat(b, "recv", humanBytes(totRecv), "")
+	fmt.Fprintf(b, `<span class="stat" data-bytes="up" data-val="%d"><i>up</i> %s <b class="rate" data-rate="up">· —/s</b></span>`, totSent, humanBytes(totSent))
+	fmt.Fprintf(b, `<span class="stat" data-bytes="down" data-val="%d"><i>down</i> %s <b class="rate" data-rate="down">· —/s</b></span>`, totRecv, humanBytes(totRecv))
 	b.WriteString(`</div>`)
 
 	// The route tree itself: ONE shared bilateral model (pkg/proxystatus.RouteTree)
@@ -253,13 +269,7 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 	b.WriteString(bitree.Render(RouteTree(snap), bitree.Options{StyleCell: htmlStyleCell}))
 	b.WriteString(`</pre>`)
 	b.WriteString(`</div>`)
-	b.WriteString(`<p class="hint">One route tree rooted at this visor (source accent); each active route is a ` +
-		`branch — its hop chain to the exit, each hop carrying the transport (type · id · rtt) — with a left ` +
-		`summary block (R[n], a <b>color-coded</b> state dot — active green, standby amber — the route rtt and ` +
-		`its bandwidth X↑ Y↓). Dead legs are pruned. ` +
-		`<b>tp rtt</b> (a hop's column) is that transport; <b>route rtt</b> (the left summary) is the true ` +
-		`end-to-end route latency across all hops. Click any public key (or transport id) to copy it. ` +
-		`The same tree prints from <code>skywire cli proxy tree</code>; for a live chart use ` +
+	b.WriteString(`<p class="hint">The same tree prints from <code>skywire cli proxy tree</code>; for a live chart use ` +
 		`<code>skywire cli proxy mux plot</code>.</p></section>`)
 }
 
@@ -346,43 +356,158 @@ func legRank(l Leg) int {
 	}
 }
 
-func writeEventsSection(b *strings.Builder, snap Snapshot) {
-	b.WriteString(`<section><h2>route &amp; transport events</h2>`)
-	if len(snap.Events) == 0 {
-		// Scaffold: event capture is wired but may be empty on an idle surface,
-		// and the richer per-surface event stream (leg promote/demote, transport
-		// drop) is an extension point — see the control seam below.
-		b.WriteString(`<p class="empty">No route or transport events captured for this surface yet.</p>`)
-	} else {
-		events := snap.Events
-		if len(events) > maxEventLines {
-			events = events[len(events)-maxEventLines:]
-		}
-		b.WriteString(`<ul class="events">`)
-		for _, e := range events {
-			fmt.Fprintf(b, `<li>%s</li>`, html.EscapeString(e))
-		}
-		b.WriteString(`</ul>`)
+// writeStreamsSection expands the "N open stream(s)" count into per-stream rows
+// when the surface tracks them (skysocks-client records id + CONNECT target +
+// age locally). It is a native <details> so it stays collapsed by default and
+// costs nothing to skip. Per-stream BYTES are deliberately not shown: the yamux
+// layer carrying the streams does not meter them per stream — the byte counters
+// that exist are the route-group sent/recv totals in the mux section above.
+func writeStreamsSection(b *strings.Builder, snap Snapshot) {
+	if len(snap.Streams) == 0 {
+		return
 	}
-	b.WriteString(`</section>`)
+	fmt.Fprintf(b, `<details class="streams"><summary>open streams <b>%d</b></summary>`, len(snap.Streams))
+	b.WriteString(`<table class="strm"><thead><tr><th>id</th><th>target</th><th>age</th></tr></thead><tbody>`)
+	for _, s := range snap.Streams {
+		fmt.Fprintf(b, `<tr><td>%d</td><td>%s</td><td>%s</td></tr>`,
+			s.ID, html.EscapeString(orDash(s.Target)), html.EscapeString(compactAge(s.AgeMS)))
+	}
+	b.WriteString(`</tbody></table>`)
+	b.WriteString(`<p class="hint">Per-stream byte counts are not metered at the tunnel (yamux) layer; ` +
+		`the route-group <b>sent/recv</b> totals above are the byte counters that exist.</p>`)
+	b.WriteString(`</details>`)
 }
 
-func writeLogsSection(b *strings.Builder, snap Snapshot) {
-	b.WriteString(`<section><h2>recent log</h2>`)
-	lines := snap.Logs
-	if len(lines) > maxLogLines {
-		lines = lines[len(lines)-maxLogLines:]
+// logLevelClass maps a formatted log line ("[ts] LEVEL [module]: msg") to the
+// CSS class that colors it the way `skywire cli proxy start --verbose` colors
+// the level in a terminal: INFO green, WARN amber, ERROR/FATAL/PANIC red, DEBUG
+// blue, TRACE grey. The level token is the first word after the "[timestamp]"
+// prefix; anything unrecognized is left unclassed (default foreground).
+func logLevelClass(line string) string {
+	s := line
+	if strings.HasPrefix(s, "[") {
+		if i := strings.IndexByte(s, ']'); i >= 0 {
+			s = s[i+1:]
+		}
 	}
+	switch strings.ToUpper(strings.TrimSpace(firstToken(s))) {
+	case "INFO":
+		return "ll-info"
+	case "WARN", "WARNING":
+		return "ll-warn"
+	case "ERRO", "ERROR", "FATA", "FATAL", "PANI", "PANIC":
+		return "ll-error"
+	case "DEBU", "DEBUG":
+		return "ll-debug"
+	case "TRAC", "TRACE":
+		return "ll-trace"
+	default:
+		return ""
+	}
+}
+
+// firstToken returns the first whitespace-delimited token of s.
+func firstToken(s string) string {
+	s = strings.TrimLeft(s, " \t")
+	if i := strings.IndexAny(s, " \t"); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// writeLogSection renders the single, combined route+transport+log stream — the
+// same content `proxy start --verbose` prints — as one terminal-colored,
+// scrollable window (fixed max-height, newest at the bottom). The Snapshot's
+// route/transport lifecycle Events and the process Logs are two views of the one
+// per-app log ring; they are merged in timestamp order into a single tail here so
+// the operator reads one chronological stream instead of two disjoint lists. The
+// live WebSocket restreams this fragment, and the inline script pins the pane to
+// the bottom so the newest line stays visible.
+func writeLogSection(b *strings.Builder, snap Snapshot) {
+	b.WriteString(`<section><h2>route, transport &amp; log</h2>`)
+	lines := combinedLogLines(snap.Events, snap.Logs, maxLogLines)
 	if len(lines) == 0 {
-		b.WriteString(`<p class="empty">No recent log lines for this process.</p></section>`)
+		b.WriteString(`<p class="empty">No route, transport, or log events for this process yet.</p></section>`)
 		return
 	}
 	b.WriteString(`<pre class="log">`)
 	for _, ln := range lines {
-		b.WriteString(html.EscapeString(strings.TrimRight(ln, "\r\n")))
+		ln = strings.TrimRight(ln, "\r\n")
+		if cls := logLevelClass(ln); cls != "" {
+			fmt.Fprintf(b, `<span class="%s">%s</span>`, cls, html.EscapeString(ln))
+		} else {
+			b.WriteString(html.EscapeString(ln))
+		}
 		b.WriteByte('\n')
 	}
 	b.WriteString(`</pre></section>`)
+}
+
+// combinedLogLines merges the route/transport lifecycle events and the process
+// log lines — both formatted "[ts] LEVEL [module]: msg", both oldest-first — into
+// one chronological tail of at most limit lines. Each input is already sorted, so
+// a stable two-pointer merge on the parsed leading timestamp suffices; a line
+// whose timestamp can't be parsed inherits the last seen time so it keeps its
+// relative position instead of jumping.
+func combinedLogLines(events, logs []string, limit int) []string {
+	out := make([]string, 0, len(events)+len(logs))
+	var last time.Time
+	tOf := func(s string) time.Time {
+		if t, ok := parseLogTime(s); ok {
+			last = t
+			return t
+		}
+		return last
+	}
+	i, j := 0, 0
+	for i < len(events) && j < len(logs) {
+		if !tOf(events[i]).After(tOf(logs[j])) {
+			out = append(out, events[i])
+			i++
+		} else {
+			out = append(out, logs[j])
+			j++
+		}
+	}
+	out = append(out, events[i:]...)
+	out = append(out, logs[j:]...)
+	if len(out) > limit {
+		out = out[len(out)-limit:]
+	}
+	return out
+}
+
+// logTimeLayout is the timestamp format the log ring's formatter emits (see
+// pkg/logging recordFormatter): "[2006-01-02T15:04:05.0000Z07:00]".
+const logTimeLayout = "2006-01-02T15:04:05.0000Z07:00"
+
+// parseLogTime extracts the leading "[timestamp]" from a formatted log line.
+func parseLogTime(line string) (time.Time, bool) {
+	if len(line) == 0 || line[0] != '[' {
+		return time.Time{}, false
+	}
+	i := strings.IndexByte(line, ']')
+	if i < 0 {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(logTimeLayout, line[1:i])
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// compactAge formats a stream age (milliseconds) as a terse "12s" / "3m" / "1h".
+func compactAge(ms int64) string {
+	d := time.Duration(ms) * time.Millisecond
+	switch {
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
 }
 
 // writeControlSeam renders the route-control panel. For skysocks the "resync"
@@ -572,7 +697,19 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	// inner scroll — lines wrap (pre-wrap + break-word) so any width is page-level.
 	`pre.log{background:var(--card);border:1px solid var(--line);border-radius:8px;padding:.7rem;font:11.5px/1.5 'Mononoki',ui-monospace,SFMono-Regular,monospace;` +
 	`white-space:pre-wrap;word-break:break-word;max-height:26rem;overflow-y:auto;color:var(--fg)}` +
-	`ul.events{margin:.3rem 0;padding-left:1.1rem;font-size:12px}ul.events li{margin:.1rem 0}` +
+	// Terminal-colored log levels, matching `proxy start --verbose`: INFO green,
+	// WARN amber, ERROR/FATAL/PANIC red, DEBUG blue, TRACE grey. The tokens already
+	// carry contrast-safe light-mode values, so the coloring holds in both schemes.
+	`pre.log .ll-info{color:var(--ok)}pre.log .ll-warn{color:var(--standby)}pre.log .ll-error{color:var(--warn)}` +
+	`pre.log .ll-debug{color:var(--accent)}pre.log .ll-trace{color:var(--muted)}` +
+	// Per-stream detail (expandable) behind the "N open stream(s)" count.
+	`details.streams{margin:.5rem 0}details.streams summary{cursor:pointer;font-size:12px;color:var(--muted)}` +
+	`details.streams summary b{color:var(--fg);margin-left:.2rem}` +
+	`table.strm{border-collapse:collapse;font-size:11.5px;margin:.4rem 0;font-family:'Mononoki',ui-monospace,SFMono-Regular,monospace}` +
+	`table.strm th,table.strm td{text-align:left;padding:.1rem 1rem .1rem 0;color:var(--fg);white-space:nowrap}` +
+	`table.strm th{color:var(--muted);text-transform:uppercase;font-size:9.5px;letter-spacing:.4px}` +
+	// Live up/down rate meters computed by the inline script from successive pushes.
+	`.stat .rate{margin-left:.2rem;color:var(--accent);font-weight:600;font-size:11px}` +
 	`.seam{opacity:.9}.controls{display:flex;flex-wrap:wrap;gap:.4rem;margin-top:.4rem}` +
 	`.controls button{font:inherit;font-size:12px;padding:.2rem .6rem;border:1px dashed var(--line);border-radius:6px;background:transparent;color:var(--muted);cursor:not-allowed}` +
 	`.controls button{position:relative}` +

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -30,13 +31,28 @@ type Client struct {
 	listener net.Listener
 	once     sync.Once
 	closeC   chan struct{}
+
+	// streams tracks the currently open tunneled streams so the status page can
+	// expand the "N open stream(s)" count into per-stream rows (id + CONNECT
+	// target + age). yamux does not meter per-stream bytes, so bytes are not
+	// tracked here; only the cheap identity/target/age the sniff already parses.
+	streamsMu sync.Mutex
+	streams   map[uint32]streamMeta
+}
+
+// streamMeta is the per-stream detail the status page surfaces for an open
+// tunneled stream.
+type streamMeta struct {
+	target string
+	since  time.Time
 }
 
 // NewClient constructs a new Client.
 func NewClient(conn net.Conn, appCl *app.Client) (*Client, error) {
 	c := &Client{
-		appCl:  appCl,
-		closeC: make(chan struct{}),
+		appCl:   appCl,
+		closeC:  make(chan struct{}),
+		streams: make(map[uint32]streamMeta),
 	}
 
 	sessionCfg := yamux.DefaultConfig()
@@ -107,12 +123,26 @@ func (c *Client) ListenAndServe(addr string) error {
 			// keeps the in-process status page reachable even now (exit down)
 			// instead of being shadowed by the interstitial — status.skysocks
 			// needs no exit stream, and this is exactly when the user wants it.
+			// A single Open failing does NOT always mean the session is dead: if
+			// the session is still up, the failure was transient and the exit is
+			// reachable. In that case ServeSOCKS5 serves a fall-through reload
+			// (exitReachable=true) instead of pinning the browser on the waiting
+			// interstitial, and we keep listening rather than tearing down — the
+			// browser's reload gets a working stream. Only a genuinely closed
+			// session serves the waiting interstitial and triggers reconnect.
+			reachable := c.session != nil && !c.session.IsClosed()
 			go func(bc net.Conn) {
-				if serr := proxyinterstitial.ServeSOCKS5(bc, proxyinterstitial.StatusLine(err), "skysocks", c.statusOverride); serr != nil && c.appCl != nil {
+				if serr := proxyinterstitial.ServeSOCKS5(bc, proxyinterstitial.StatusLine(err), "skysocks", c.statusOverride, c.exitReachable); serr != nil && c.appCl != nil {
 					c.appCl.Log().Debugf("route-down interstitial not served: %v", serr)
 				}
 				bc.Close() //nolint:errcheck,gosec
 			}(conn)
+			if reachable {
+				if c.appCl != nil {
+					c.appCl.Log().Debugf("yamux stream open failed but session is up; keeping listener: %v", err)
+				}
+				continue
+			}
 			c.close()
 
 			return fmt.Errorf("error opening yamux stream: %w", err)
@@ -196,13 +226,21 @@ func (c *Client) handleStream(conn, stream net.Conn) {
 	// exit. For every non-status request the greeting/method negotiation and the
 	// CONNECT request are forwarded to the exit byte-for-byte, so the exit sees an
 	// identical stream — only status.skysocks diverges.
-	if !c.sniffSOCKS5Status(conn, stream) {
+	proceed, target := c.sniffSOCKS5Status(conn, stream)
+	if !proceed {
 		conn.Close()   //nolint:errcheck,gosec
 		stream.Close() //nolint:errcheck,gosec
 		if c.session.IsClosed() {
 			c.close()
 		}
 		return
+	}
+
+	// Track this stream for the status page's per-stream detail (id + target +
+	// age). Registered here, deregistered when the splice below returns.
+	if id, ok := streamID(stream); ok {
+		c.addStream(id, target)
+		defer c.removeStream(id)
 	}
 
 	const errorCount = 2
@@ -251,46 +289,48 @@ const statusSniffTimeout = 15 * time.Second
 //
 // Returns proceed=true when the caller should continue with the normal
 // bidirectional splice (conn and stream are positioned just past the forwarded
-// handshake). Returns false when the request was served in-process or the
-// connection is unusable; the caller then closes both sides.
-func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool) {
+// handshake); target is then the CONNECT "host:port" the stream carries (or ""
+// when it could not be parsed), for the status page's per-stream detail. Returns
+// false when the request was served in-process or the connection is unusable; the
+// caller then closes both sides.
+func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool, target string) {
 	_ = conn.SetReadDeadline(time.Now().Add(statusSniffTimeout))   //nolint:errcheck
 	_ = stream.SetReadDeadline(time.Now().Add(statusSniffTimeout)) //nolint:errcheck
 
 	// Greeting: VER, NMETHODS, METHODS[NMETHODS] — forwarded to the exit verbatim.
 	hdr := make([]byte, 2)
 	if _, err := io.ReadFull(conn, hdr); err != nil || hdr[0] != 0x05 {
-		return false
+		return false, ""
 	}
 	greeting := make([]byte, 2+int(hdr[1]))
 	greeting[0], greeting[1] = hdr[0], hdr[1]
 	if _, err := io.ReadFull(conn, greeting[2:]); err != nil {
-		return false
+		return false, ""
 	}
 	if _, err := stream.Write(greeting); err != nil {
-		return false
+		return false, ""
 	}
 
 	// Method-selection reply (2 bytes) from the exit — forwarded to the browser.
 	method := make([]byte, 2)
 	if _, err := io.ReadFull(stream, method); err != nil {
-		return false
+		return false, ""
 	}
 	if _, err := conn.Write(method); err != nil {
-		return false
+		return false, ""
 	}
 	// Anything but no-auth accepted: hand the rest off untouched — the auth
 	// sub-negotiation and CONNECT ride through transparently.
 	if method[0] != 0x05 || method[1] != 0x00 {
 		clearDeadlines(conn, stream)
-		return true
+		return true, ""
 	}
 
 	// CONNECT request: VER, CMD, RSV, ATYP, ADDR, PORT. Buffered so a non-status
 	// target is forwarded to the exit byte-for-byte.
 	rhdr := make([]byte, 4)
 	if _, err := io.ReadFull(conn, rhdr); err != nil || rhdr[0] != 0x05 {
-		return false
+		return false, ""
 	}
 	req := append([]byte{}, rhdr...)
 	var host string
@@ -298,18 +338,18 @@ func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool) {
 	case 0x01: // IPv4
 		b := make([]byte, 4)
 		if _, err := io.ReadFull(conn, b); err != nil {
-			return false
+			return false, ""
 		}
 		host = net.IP(b).String()
 		req = append(req, b...)
 	case 0x03: // domain
 		l := make([]byte, 1)
 		if _, err := io.ReadFull(conn, l); err != nil {
-			return false
+			return false, ""
 		}
 		b := make([]byte, int(l[0]))
 		if _, err := io.ReadFull(conn, b); err != nil {
-			return false
+			return false, ""
 		}
 		host = string(b)
 		req = append(req, l[0])
@@ -317,23 +357,24 @@ func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool) {
 	case 0x04: // IPv6
 		b := make([]byte, 16)
 		if _, err := io.ReadFull(conn, b); err != nil {
-			return false
+			return false, ""
 		}
 		host = net.IP(b).String()
 		req = append(req, b...)
 	default:
 		// Unknown ATYP: forward what we have and let the exit deal with it.
 		if _, err := stream.Write(req); err != nil {
-			return false
+			return false, ""
 		}
 		clearDeadlines(conn, stream)
-		return true
+		return true, ""
 	}
 	portB := make([]byte, 2)
 	if _, err := io.ReadFull(conn, portB); err != nil {
-		return false
+		return false, ""
 	}
 	req = append(req, portB...)
+	port := int(portB[0])<<8 | int(portB[1])
 
 	// Reserved status host: serve the in-process page over HTTP instead of
 	// tunneling to the exit. HTTP only — the resolver CA forbids a .skysocks TLS
@@ -341,15 +382,72 @@ func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool) {
 	if surface, ok := proxystatus.Match(host); ok && surface == proxystatus.SurfaceSkysocks {
 		clearDeadlines(conn, stream)
 		c.serveStatusPage(conn, stream)
-		return false
+		return false, ""
 	}
 
 	// Non-status: forward the buffered CONNECT request to the exit and splice.
 	if _, err := stream.Write(req); err != nil {
-		return false
+		return false, ""
 	}
 	clearDeadlines(conn, stream)
-	return true
+	return true, fmt.Sprintf("%s:%d", host, port)
+}
+
+// streamID extracts the yamux stream id from the net.Conn session.Open returns
+// (a *yamux.Stream), for the status page's per-stream detail. Best-effort: an
+// unexpected conn type yields ok=false and the stream simply isn't tracked.
+func streamID(stream net.Conn) (uint32, bool) {
+	if s, ok := stream.(interface{ StreamID() uint32 }); ok {
+		return s.StreamID(), true
+	}
+	return 0, false
+}
+
+// addStream/removeStream/streamSnapshot maintain the open-stream registry the
+// status page reads. All are mutex-guarded and cheap (no per-stream byte
+// metering — yamux does not expose it).
+func (c *Client) addStream(id uint32, target string) {
+	c.streamsMu.Lock()
+	if c.streams == nil {
+		c.streams = make(map[uint32]streamMeta)
+	}
+	c.streams[id] = streamMeta{target: target, since: time.Now()}
+	c.streamsMu.Unlock()
+}
+
+func (c *Client) removeStream(id uint32) {
+	c.streamsMu.Lock()
+	delete(c.streams, id)
+	c.streamsMu.Unlock()
+}
+
+// streamSnapshot returns the currently open streams as sorted proxystatus.Stream
+// rows (by id) for the status page.
+func (c *Client) streamSnapshot() []proxystatus.Stream {
+	c.streamsMu.Lock()
+	defer c.streamsMu.Unlock()
+	if len(c.streams) == 0 {
+		return nil
+	}
+	now := time.Now()
+	out := make([]proxystatus.Stream, 0, len(c.streams))
+	for id, m := range c.streams {
+		out = append(out, proxystatus.Stream{
+			ID:     id,
+			Target: m.target,
+			AgeMS:  now.Sub(m.since).Milliseconds(),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// exitReachable reports whether the yamux session to the exit is currently live.
+// It is the fall-through probe handed to proxyinterstitial.ServeSOCKS5: when the
+// exit is reachable again, the interstitial is replaced by a reload page so the
+// browser proceeds to the intended destination instead of waiting on a spinner.
+func (c *Client) exitReachable() bool {
+	return c.session != nil && !c.session.IsClosed()
 }
 
 // statusOverride is the reserved-host answer handed to
@@ -711,6 +809,8 @@ func (c *Client) statusSnapshot() proxystatus.Snapshot {
 	if c.session != nil && !c.session.IsClosed() {
 		snap.Running = true
 		snap.Note = fmt.Sprintf("session to the exit is up · %d open stream(s)", c.session.NumStreams())
+		// Per-stream detail (id + target + age) behind the count, when tracked.
+		snap.Streams = c.streamSnapshot()
 	} else {
 		snap.Note = "no active session to the exit"
 	}

--- a/pkg/skysocks/client_sniff_test.go
+++ b/pkg/skysocks/client_sniff_test.go
@@ -89,7 +89,8 @@ func runSniff(t *testing.T, c *Client) (browser, exit net.Conn, result <-chan bo
 	streamSniff, exitEnd := net.Pipe()
 	res := make(chan bool, 1)
 	go func() {
-		res <- c.sniffSOCKS5Status(connSniff, streamSniff)
+		proceed, _ := c.sniffSOCKS5Status(connSniff, streamSniff)
+		res <- proceed
 		_ = connSniff.Close()   //nolint:errcheck
 		_ = streamSniff.Close() //nolint:errcheck
 	}()

--- a/pkg/skysocks/client_status_test.go
+++ b/pkg/skysocks/client_status_test.go
@@ -177,6 +177,70 @@ func TestStatusSkysocksIntercepted(t *testing.T) {
 	}
 }
 
+// TestStreamRegistryTracksTarget verifies the per-stream detail plumbing (item
+// 4): a normal (non-status) tunneled CONNECT registers an open stream whose
+// CONNECT target the status snapshot surfaces, and the stream is dropped from the
+// registry once the browser conn closes.
+func TestStreamRegistryTracksTarget(t *testing.T) {
+	c, exit := newTestClient(t)
+	defer c.Close() //nolint:errcheck
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()                              //nolint:errcheck
+	go func() { _ = c.ListenAndServe(addr) }() //nolint:errcheck
+	waitDial(t, addr)
+
+	conn := socks5Connect(t, addr, "example.com", 80)
+
+	// The exit received the forwarded CONNECT — the stream is a real tunnel.
+	select {
+	case h := <-exit.hostC:
+		if h != "example.com" {
+			t.Fatalf("exit received host %q, want example.com", h)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("exit never received the CONNECT")
+	}
+
+	// The open stream is tracked with its target in the status snapshot.
+	found := false
+	for i := 0; i < 100 && !found; i++ {
+		for _, s := range c.statusSnapshot().Streams {
+			if s.Target == "example.com:80" {
+				found = true
+			}
+		}
+		if !found {
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+	if !found {
+		t.Fatal("open stream not tracked in status snapshot")
+	}
+
+	// Closing the browser side tears the stream down and deregisters it.
+	_ = conn.Close() //nolint:errcheck
+	gone := false
+	for i := 0; i < 100 && !gone; i++ {
+		gone = true
+		for _, s := range c.statusSnapshot().Streams {
+			if s.Target == "example.com:80" {
+				gone = false
+			}
+		}
+		if !gone {
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+	if !gone {
+		t.Fatal("closed stream still tracked in status snapshot")
+	}
+}
+
 // wsExpectedAccept is Sec-WebSocket-Accept for wsSampleKey — the RFC6455 §1.3
 // worked example (base64(sha1("dGhlIHNhbXBsZSBub25jZQ==" + GUID))). Asserting the
 // exact value validates the server's accept-key computation.


### PR DESCRIPTION
Fixes to `http://status.skysocks/` and the shared route tree (also used by `skywire cli proxy tree`), plus the proxy interstitial fall-through.

**Route tree (pkg/bitree).** The source PK was floating detached at the top-right, disconnected from the branches. It is now a proper top-left Unix-`tree` root with box-drawing connectors (├──/└──/│) down into each `R[n]` route branch, so the whole thing reads as one connected tree. The same renderer backs the status page and `proxy tree`, so both stay in sync (verified against live route data in `--color never` and `--color always`).

**Status page (pkg/proxystatus).** Trimmed the tree explainer to one sentence; merged the separate route/transport "events" list and "recent log" into a single terminal-colored, scrollable log window (INFO/DEBUG/WARN/ERROR colored to match `proxy start --verbose`), combined in timestamp order and pinned to the newest line; added live up/down rate meters (bytes/sec) derived by the inline script from the cumulative sent/recv totals over the existing WebSocket; and expanded the "N open stream(s)" count into a per-stream id/target/age table. skysocks-client now tracks open tunneled streams for that detail (yamux does not meter per-stream bytes, so bytes are omitted).

**Interstitial fall-through (pkg/proxyinterstitial).** `ServeSOCKS5` gains an `exitReachable` probe: a single yamux stream-open failure does not always mean the session is dead, so when the exit is reachable again the browser is served a reload page that re-requests the original URL (falling through to live content) instead of being pinned on the spinner, and the client keeps its listener up instead of tearing down.

Tests updated/added across pkg/bitree, pkg/proxystatus, pkg/skysocks, and pkg/proxyinterstitial (all green locally); full `go build .` passes.