### PR TITLE
feat(dmsgdisc): resolve dmsg entries over CXO (clients-by-server feed) with HTTP fallback

### DIFF
--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -125,6 +125,12 @@ const (
 	// geo.country(pk) can resolve multihop intermediates that
 	// advertise themselves as proxy/vpn/visor services.
 	TabRoutingPolicy
+	// TabDmsgEntryLookup is the visor's dmsg-entry-lookup-over-CXO
+	// consumer. Held for the lifetime of the dmsg client so the
+	// clients-by-server snapshot stays warm, letting peer entry
+	// lookups resolve from CXO instead of a fresh HTTP-over-dmsg
+	// Noise handshake. HTTP stays the fallback on a snapshot miss.
+	TabDmsgEntryLookup
 )
 
 // tabFeedDeps maps each tab to the set of feeds it depends on.
@@ -138,6 +144,7 @@ var tabFeedDeps = map[Tab][]Feed{
 	TabCLIServices:       {FeedSDServices},
 	TabCLITransports:     {FeedTPDAllTransports},
 	TabRoutingPolicy:     {FeedSDServices},
+	TabDmsgEntryLookup:   {FeedDMSGDClientsByServer},
 }
 
 // Deps are the host-injected dependencies the manager needs. They
@@ -652,6 +659,26 @@ func (m *Manager) LastError(feed Feed) error {
 	f.snapMu.RLock()
 	defer f.snapMu.RUnlock()
 	return f.lastErr
+}
+
+// LastSync returns the wall-clock time of the feed's most recent
+// successful sync, or the zero time if no cycle has ever completed.
+// Consumers use it as a cheap snapshot-version to memoize a derived
+// index and rebuild it only when the underlying snapshot advances.
+// Safe on a nil receiver.
+func (m *Manager) LastSync(feed Feed) time.Time {
+	if m == nil {
+		return time.Time{}
+	}
+	m.mu.Lock()
+	f, ok := m.feeds[feed]
+	m.mu.Unlock()
+	if !ok || f == nil {
+		return time.Time{}
+	}
+	f.snapMu.RLock()
+	defer f.snapMu.RUnlock()
+	return f.lastSyncAt
 }
 
 // acquireFeedLocked must be called under m.mu.

--- a/pkg/dmsg/disc/cxo_entry.go
+++ b/pkg/dmsg/disc/cxo_entry.go
@@ -1,0 +1,80 @@
+//go:build !tinygo || (js && wasm)
+
+// Package disc pkg/dmsg/disc/cxo_entry.go c1-net-dmsg
+//
+// Build-tag-gated off the WASM path like fallback.go — it imports
+// pkg/logging (logrus → encoding/json). Constructed only from
+// pkg/dmsgc at visor runtime.
+//
+// cxoEntryClient wraps an APIClient and answers Entry() for peer
+// CLIENT lookups from a locally-held CXO index FIRST, falling back to
+// the wrapped client (HTTP-over-dmsg) on a miss. Every other method
+// passes straight through.
+//
+// This exists to kill the per-lookup dmsg Noise + post-quantum
+// handshake that dominates dmsg-discovery CPU (profiled 76% CPU in
+// GC from handshake crypto): each HTTP-over-dmsg Entry() lookup opens
+// a fresh session with a full handshake. The visor already ingests
+// dmsg-discovery's clients-by-server CXO feed into a snapshot for the
+// network visualizer; this reuses that snapshot as a resolution path
+// so a peer entry that's already in the local index is served with no
+// network round-trip at all.
+//
+// Back-compat contract (see the deployment-services-over-CXO
+// roadmap): dual-path, HTTP stays the source of truth. A resolver
+// MISS (peer not in the local index, or an index that hasn't synced
+// yet) falls through to the wrapped client — "not in my CXO tree" is
+// NEVER treated as "doesn't exist". The resolver only answers when it
+// holds a usable client entry (Client != nil with a non-empty
+// DelegatedServers list); server-entry lookups and the visor's own
+// registration read-back always miss here and take the HTTP path.
+package disc
+
+import (
+	"context"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// EntryResolveFunc resolves a peer's discovery entry from a local,
+// non-network source (the CXO clients-by-server snapshot). It returns
+// ok=false to signal a miss, in which case the caller falls back to
+// the HTTP discovery client. Implementations MUST return a usable
+// client entry (Entry.Client != nil) on a hit, or ok=false; a partial
+// or malformed entry must be reported as a miss so the HTTP path can
+// resolve it authoritatively.
+type EntryResolveFunc func(context.Context, cipher.PubKey) (*Entry, bool)
+
+// cxoEntryClient decorates an APIClient so peer client-entry lookups
+// consult a CXO-backed resolver before the wrapped HTTP client.
+type cxoEntryClient struct {
+	APIClient
+	resolve EntryResolveFunc
+	log     *logging.Logger
+}
+
+// NewCXOEntryClient wraps primary so Entry() consults resolve first,
+// falling back to primary on a miss. resolve may be nil (the wrapper
+// then behaves exactly like primary). primary must be non-nil.
+func NewCXOEntryClient(primary APIClient, resolve EntryResolveFunc, log *logging.Logger) APIClient {
+	if resolve == nil {
+		return primary
+	}
+	return &cxoEntryClient{APIClient: primary, resolve: resolve, log: log}
+}
+
+// Entry resolves pk's discovery entry from the CXO index first,
+// falling back to the wrapped client on a miss. Only client entries
+// with a non-empty delegated-server list are served from CXO; every
+// other case (miss, server entry, empty delegation) delegates to the
+// wrapped client so the HTTP path stays authoritative.
+func (c *cxoEntryClient) Entry(ctx context.Context, pk cipher.PubKey) (*Entry, error) {
+	if entry, ok := c.resolve(ctx, pk); ok && entry != nil && entry.Client != nil && len(entry.Client.DelegatedServers) > 0 {
+		if c.log != nil {
+			c.log.WithField("client", pk.String()).Debug("Resolved dmsg entry from CXO index (no HTTP handshake)")
+		}
+		return entry, nil
+	}
+	return c.APIClient.Entry(ctx, pk)
+}

--- a/pkg/dmsg/disc/cxo_entry_test.go
+++ b/pkg/dmsg/disc/cxo_entry_test.go
@@ -1,0 +1,115 @@
+//go:build !tinygo || (js && wasm)
+
+package disc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// stubAPIClient records Entry calls and returns a fixed result. Only
+// Entry is exercised; the rest satisfy the interface.
+type stubAPIClient struct {
+	entryCalls int
+	entry      *Entry
+	err        error
+}
+
+func (s *stubAPIClient) Entry(context.Context, cipher.PubKey) (*Entry, error) {
+	s.entryCalls++
+	return s.entry, s.err
+}
+func (s *stubAPIClient) AvailableServers(context.Context) ([]*Entry, error) { return nil, nil }
+func (s *stubAPIClient) AllServers(context.Context) ([]*Entry, error)       { return nil, nil }
+func (s *stubAPIClient) PostEntry(context.Context, *Entry) error            { return nil }
+func (s *stubAPIClient) PutEntry(context.Context, cipher.SecKey, *Entry) error {
+	return nil
+}
+func (s *stubAPIClient) DelEntry(context.Context, *Entry) error       { return nil }
+func (s *stubAPIClient) AllEntries(context.Context) ([]string, error) { return nil, nil }
+func (s *stubAPIClient) AllClientsByServer(context.Context) (map[string][]*Entry, error) {
+	return nil, nil
+}
+func (s *stubAPIClient) ClientsByServer(context.Context, cipher.PubKey) ([]*Entry, error) {
+	return nil, nil
+}
+
+func clientEntry(pk cipher.PubKey, servers ...cipher.PubKey) *Entry {
+	return &Entry{Static: pk, Client: &Client{DelegatedServers: servers}}
+}
+
+func TestCXOEntryClient_NilResolverPassesThrough(t *testing.T) {
+	stub := &stubAPIClient{}
+	got := NewCXOEntryClient(stub, nil, nil)
+	if got != APIClient(stub) {
+		t.Fatalf("nil resolver should return the primary unchanged")
+	}
+}
+
+func TestCXOEntryClient_HitServesFromCXO(t *testing.T) {
+	var pk, srv cipher.PubKey
+	_ = pk.Set("02e40731f3ab6d11d31c466429297f4869f299a7821108409c5e36b840253e4ba7")
+	_ = srv.Set("02190003862c24f69e2cf47e1cf0efaa3dc1d866ba6a24067de34c363058212c73")
+
+	resolved := clientEntry(pk, srv)
+	stub := &stubAPIClient{entry: nil, err: errors.New("HTTP should not be called")}
+	c := NewCXOEntryClient(stub, func(context.Context, cipher.PubKey) (*Entry, bool) {
+		return resolved, true
+	}, nil)
+
+	got, err := c.Entry(context.Background(), pk)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != resolved {
+		t.Fatalf("expected CXO-resolved entry, got %v", got)
+	}
+	if stub.entryCalls != 0 {
+		t.Fatalf("wrapped HTTP client must not be called on a CXO hit; got %d calls", stub.entryCalls)
+	}
+}
+
+func TestCXOEntryClient_MissFallsBackToHTTP(t *testing.T) {
+	var pk cipher.PubKey
+	_ = pk.Set("02e40731f3ab6d11d31c466429297f4869f299a7821108409c5e36b840253e4ba7")
+
+	httpEntry := clientEntry(pk)
+	stub := &stubAPIClient{entry: httpEntry}
+	c := NewCXOEntryClient(stub, func(context.Context, cipher.PubKey) (*Entry, bool) {
+		return nil, false // miss
+	}, nil)
+
+	got, err := c.Entry(context.Background(), pk)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != httpEntry {
+		t.Fatalf("expected HTTP fallback entry")
+	}
+	if stub.entryCalls != 1 {
+		t.Fatalf("expected exactly one HTTP fallback call, got %d", stub.entryCalls)
+	}
+}
+
+func TestCXOEntryClient_HitWithoutDelegatedServersFallsBack(t *testing.T) {
+	var pk cipher.PubKey
+	_ = pk.Set("02e40731f3ab6d11d31c466429297f4869f299a7821108409c5e36b840253e4ba7")
+
+	// Resolver "hits" but the entry has no delegated servers — useless
+	// for dialing, so the wrapped client must still be consulted.
+	empty := clientEntry(pk) // no servers
+	stub := &stubAPIClient{entry: clientEntry(pk)}
+	c := NewCXOEntryClient(stub, func(context.Context, cipher.PubKey) (*Entry, bool) {
+		return empty, true
+	}, nil)
+
+	if _, err := c.Entry(context.Background(), pk); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stub.entryCalls != 1 {
+		t.Fatalf("entry without delegated servers must fall back to HTTP; got %d calls", stub.entryCalls)
+	}
+}

--- a/pkg/dmsg/dmsgc/dmsgc.go
+++ b/pkg/dmsg/dmsgc/dmsgc.go
@@ -74,7 +74,7 @@ func (d *lanPriorityDisc) AllServers(ctx context.Context) ([]*disc.Entry, error)
 // The caller wires httpC.Transport = MakeHTTPTransport(ctx, dmsgC) AFTER this
 // returns, so discovery HTTP rides the client's own sessions (the empty
 // transport is never used before Serve).
-func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *DmsgConfig, httpC *http.Client, directClient disc.APIClient, directOnly bool, masterLogger *logging.MasterLogger) *dmsg.Client {
+func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *DmsgConfig, httpC *http.Client, directClient disc.APIClient, directOnly bool, entryResolve disc.EntryResolveFunc, masterLogger *logging.MasterLogger) *dmsg.Client {
 	primary := conf.Primary()
 	dmsgConf := &dmsg.Config{
 		MinSessions: primary.SessionsCount,
@@ -154,6 +154,14 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 			primaryC = dmsgclient.NewRegisteringFallbackDiscClient(directClient, primaryC, masterLogger.PackageLogger("dmsgC:disc:fallback"))
 		}
 	}
+
+	// CXO entry-lookup shim, OUTERMOST so it fronts Entry() for peer
+	// client lookups before the direct/HTTP chain: a peer entry already
+	// in the local clients-by-server snapshot resolves with no dmsg
+	// Noise handshake, while a MISS (or a server/self lookup) falls
+	// straight through to the chain below — HTTP stays authoritative.
+	// nil resolver (LookupCXO off) leaves primaryC untouched.
+	primaryC = disc.NewCXOEntryClient(primaryC, entryResolve, masterLogger.PackageLogger("dmsgC:disc:cxo-lookup"))
 
 	dmsgC := dmsg.NewClient(pk, sk, primaryC, dmsgConf)
 	dmsgC.SetLogger(masterLogger.PackageLogger("dmsgC"))

--- a/pkg/dmsg/dmsgc/new_test.go
+++ b/pkg/dmsg/dmsgc/new_test.go
@@ -30,7 +30,7 @@ func newClient(t *testing.T, conf *DmsgConfig, direct disc.APIClient, directOnly
 	t.Helper()
 	pk, sk := cipher.GenerateKeyPair()
 	mLog := logging.NewMasterLogger()
-	c := New(pk, sk, testBroadcaster(), conf, &http.Client{}, direct, directOnly, mLog)
+	c := New(pk, sk, testBroadcaster(), conf, &http.Client{}, direct, directOnly, nil, mLog)
 	require.NotNil(t, c)
 	require.Equal(t, pk, c.LocalPK())
 }

--- a/pkg/dmsg/dmsgc/spec/lookup_cxo_test.go
+++ b/pkg/dmsg/dmsgc/spec/lookup_cxo_test.go
@@ -1,0 +1,40 @@
+//go:build !js
+
+package spec
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestLookupCXO_RoundTrip verifies the visor-wide lookup_cxo flag
+// survives Marshal → Unmarshal in the single-object shape and is
+// omitted when false.
+func TestLookupCXO_RoundTrip(t *testing.T) {
+	var c DmsgConfig
+	if err := json.Unmarshal([]byte(`{"discovery":"http://disc.example","lookup_cxo":true}`), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !c.LookupCXO {
+		t.Fatalf("LookupCXO not parsed from JSON")
+	}
+
+	out, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"lookup_cxo":true`) {
+		t.Fatalf("LookupCXO not emitted: %s", out)
+	}
+
+	// Default false is omitted.
+	c.LookupCXO = false
+	out, err = json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal default: %v", err)
+	}
+	if strings.Contains(string(out), "lookup_cxo") {
+		t.Fatalf("LookupCXO false should be omitted: %s", out)
+	}
+}

--- a/pkg/dmsg/dmsgc/spec/spec.go
+++ b/pkg/dmsg/dmsgc/spec/spec.go
@@ -95,6 +95,20 @@ type DmsgConfig struct {
 	// services/servers. Experimental; default stays discovery.
 	DirectOnly bool `json:"direct_only,omitempty"`
 
+	// LookupCXO opts the visor into resolving peer dmsg discovery
+	// entries from the local CXO clients-by-server snapshot before
+	// falling back to an HTTP-over-dmsg lookup. Default false. When
+	// true the visor holds dmsg-discovery's clients-by-server feed
+	// warm (via cxosub) and serves peer entry lookups already in the
+	// snapshot with no per-lookup Noise handshake — the discovery-
+	// service CPU cost the deployment-services-over-CXO roadmap
+	// targets. HTTP stays the fallback on any snapshot miss, so
+	// correctness is unchanged; the flag only trades a periodic bulk
+	// snapshot sync for the per-lookup handshake. Conservative
+	// default-off, matching how CXO features roll out (opt-in first,
+	// then always-on once proven).
+	LookupCXO bool `json:"lookup_cxo,omitempty"`
+
 	// Server, when non-nil AND Enabled, runs a dmsg SERVER in-process under
 	// the visor's own PK/SK (shared identity), reusing the visor's existing
 	// dmsg client for discovery rather than standing up a second transit

--- a/pkg/dmsg/dmsgc/spec/spec_native.go
+++ b/pkg/dmsg/dmsgc/spec/spec_native.go
@@ -23,6 +23,10 @@ import (
 type deploymentWithServer struct {
 	Deployment
 	Server *DmsgServerConfig `json:"server,omitempty"`
+	// LookupCXO is a visor-wide flag carried alongside the primary
+	// deployment in the single-object shape (like Server). See
+	// DmsgConfig.LookupCXO.
+	LookupCXO bool `json:"lookup_cxo,omitempty"`
 }
 
 // UnmarshalJSON accepts either a single Deployment object or an
@@ -41,6 +45,7 @@ func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
 		}
 		c.Deployments = []Deployment{single.Deployment}
 		c.Server = single.Server
+		c.LookupCXO = single.LookupCXO
 	}
 	c.mirrorPrimary()
 	return nil
@@ -58,7 +63,7 @@ func (c DmsgConfig) MarshalJSON() ([]byte, error) {
 		deployments = []Deployment{c.toDeployment()}
 	}
 	if len(deployments) == 1 {
-		return json.Marshal(deploymentWithServer{Deployment: deployments[0], Server: c.Server})
+		return json.Marshal(deploymentWithServer{Deployment: deployments[0], Server: c.Server, LookupCXO: c.LookupCXO})
 	}
 	return json.Marshal(deployments)
 }

--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -58,6 +58,7 @@ const (
 	TabCLIServices       = cxosub.TabCLIServices
 	TabCLITransports     = cxosub.TabCLITransports
 	TabRoutingPolicy     = cxosub.TabRoutingPolicy
+	TabDmsgEntryLookup   = cxosub.TabDmsgEntryLookup
 )
 
 // feedFirstSyncTimeout forwards to cxosub so the RPC fetch/refresh default

--- a/pkg/visor/dmsg_lookup_cxo.go
+++ b/pkg/visor/dmsg_lookup_cxo.go
@@ -1,0 +1,196 @@
+// Package visor pkg/visor/dmsg_lookup_cxo.go c3-vis-core
+//
+// dmsg-entry LOOKUP over CXO — the consumer/resolver shim that lets a
+// visor's dmsg client resolve a peer's discovery entry from the local
+// CXO clients-by-server snapshot instead of a fresh HTTP-over-dmsg
+// Noise handshake to dmsg-discovery (profiled 76% CPU in handshake
+// crypto). The publish side is dmsg-discovery's
+// ClientsByServerCXOPublisher (DmsgDMSGDClientsByServerCXOPort, 54),
+// which mirrors every client's signed dmsgdisc.Entry into a TreeStore
+// feed under clients-by-server/<server>/<client>/entry. The visor
+// already ingests that feed for the hypervisor's network visualizer;
+// this reuses the same cxosub-managed snapshot as a resolution path.
+//
+// Wiring: init_dmsg installs the resolver returned here into the dmsg
+// client's discovery client (disc.NewCXOEntryClient), where it fronts
+// the existing HTTP/direct chain for Entry() only. On a hit the peer
+// entry is served with no network round-trip; on ANY miss the wrapped
+// client resolves it over HTTP — "not in my CXO tree" is never
+// "doesn't exist" (see the deployment-services-over-CXO roadmap's
+// back-compat rules).
+//
+// Provenance: the snapshot comes from exactly one authoritative
+// publisher — the configured dmsg-discovery PK (cxoFeedSpec resolves
+// FeedDMSGDClientsByServer to dmsgdCXOPeer). There is no per-record
+// reporter to police here: dmsg-discovery is the single signer of
+// every entry in the feed, so the feed-PK gate already enforces
+// provenance. The snapshot's own bodies are dmsg-disc-signed
+// dmsgdisc.Entry values.
+//
+// Lifecycle: cxosub runs the feed as a periodic subscribe → snapshot
+// → unsubscribe cycle (no long-lived subscription), so the orphan-
+// feed reclaim the roadmap calls for is handled by the manager — the
+// visor holds no unbounded CXDS here.
+//
+// SecKey binding: the cxosub manager subscribes over the visor's
+// single dmsg client (v.dmsgC, keyed to the visor SecKey); there is no
+// second dmsg client and no zero/random keypair (see
+// feedback_never_two_dmsg_clients_same_key).
+package visor
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// clientsByServerPrefix is the TreeStore path prefix the
+// clients-by-server feed publishes under. Leaves are
+// clients-by-server/<server-pk-hex>/<client-pk-hex>/entry.
+const clientsByServerPrefix = "clients-by-server/"
+
+// dmsgEntryCXOIndex resolves peer discovery entries from the visor's
+// CXO clients-by-server snapshot. It memoizes a client-PK → entry
+// index built from the snapshot, rebuilding only when the manager
+// reports a newer sync (cheap snapshot-version via LastSync), so the
+// common lookup is a map read under an RLock.
+type dmsgEntryCXOIndex struct {
+	v   *Visor
+	log *logging.Logger
+
+	acquireOnce sync.Once
+
+	mu      sync.RWMutex
+	builtAt time.Time
+	index   map[cipher.PubKey]*dmsgdisc.Entry
+}
+
+// newDmsgEntryCXOResolver returns the EntryResolveFunc to install into
+// the dmsg client's discovery chain, or nil if the resolver can't be
+// built (no visor). The returned func is safe for concurrent use.
+func (v *Visor) newDmsgEntryCXOResolver() dmsgdisc.EntryResolveFunc {
+	if v == nil {
+		return nil
+	}
+	idx := &dmsgEntryCXOIndex{
+		v:   v,
+		log: v.MasterLogger().PackageLogger("dmsg_lookup_cxo"),
+	}
+	return idx.resolve
+}
+
+// resolve looks up pk in the CXO clients-by-server snapshot. Returns
+// ok=false on any miss (own PK, no manager, no snapshot yet, or pk
+// absent) so the caller falls back to HTTP discovery.
+func (idx *dmsgEntryCXOIndex) resolve(_ context.Context, pk cipher.PubKey) (*dmsgdisc.Entry, bool) {
+	// Never shadow the visor's own entry: registration reads its own
+	// entry back to bump the sequence number, and a stale CXO copy
+	// would break that. Always take the HTTP path for self.
+	if idx.v.conf != nil && pk == idx.v.conf.PK {
+		return nil, false
+	}
+	mgr := idx.v.CXOSubMgr()
+	if mgr == nil {
+		return nil, false
+	}
+	// Hold the feed for the client's lifetime so its snapshot stays
+	// warm. Idempotent-but-refcounted: acquire exactly once.
+	idx.acquireOnce.Do(func() { mgr.AcquireFor(TabDmsgEntryLookup) })
+
+	last := mgr.LastSync(FeedDMSGDClientsByServer)
+	if last.IsZero() {
+		// No successful sync yet — cache miss, fall back to HTTP.
+		return nil, false
+	}
+
+	idx.mu.RLock()
+	if idx.index != nil && idx.builtAt.Equal(last) {
+		entry, ok := idx.index[pk]
+		idx.mu.RUnlock()
+		return entry, ok
+	}
+	idx.mu.RUnlock()
+
+	idx.rebuild(mgr, last)
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	entry, ok := idx.index[pk]
+	return entry, ok
+}
+
+// rebuild walks the clients-by-server snapshot into a fresh client-PK
+// → entry index. A client appears under every server it is delegated
+// to with an identical entry body, so the last one wins (same
+// content). Guarded so a concurrent rebuild for the same snapshot
+// version runs at most once.
+func (idx *dmsgEntryCXOIndex) rebuild(mgr *CXOSubscriptionManager, version time.Time) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	// Another goroutine may have rebuilt this exact version while we
+	// waited for the write lock.
+	if idx.index != nil && idx.builtAt.Equal(version) {
+		return
+	}
+
+	built := make(map[cipher.PubKey]*dmsgdisc.Entry)
+	mgr.Walk(FeedDMSGDClientsByServer, clientsByServerPrefix, func(path string, body []byte) bool {
+		clientPK, ok := clientPKFromLeafPath(path)
+		if !ok {
+			return true
+		}
+		if len(body) == 0 {
+			return true
+		}
+		entry := new(dmsgdisc.Entry)
+		if err := json.Unmarshal(body, entry); err != nil {
+			return true
+		}
+		// Only client entries with a usable delegated-server list are
+		// worth serving from CXO; anything else must take the HTTP
+		// path so it resolves authoritatively.
+		if entry.Client == nil || len(entry.Client.DelegatedServers) == 0 {
+			return true
+		}
+		built[clientPK] = entry
+		return true
+	})
+
+	idx.index = built
+	idx.builtAt = version
+	if idx.log != nil {
+		idx.log.WithField("clients", len(built)).WithField("snapshot_at", version).
+			Debug("Rebuilt dmsg clients-by-server CXO lookup index")
+	}
+}
+
+// clientPKFromLeafPath parses the <client-pk> out of a
+// clients-by-server/<server-pk>/<client-pk>/entry leaf path. Returns
+// ok=false for any path that isn't a live entry leaf (e.g. a legacy
+// tombstone or a malformed segment).
+func clientPKFromLeafPath(path string) (cipher.PubKey, bool) {
+	if !strings.HasSuffix(path, "/entry") {
+		return cipher.PubKey{}, false
+	}
+	core := strings.TrimSuffix(strings.TrimPrefix(path, clientsByServerPrefix), "/entry")
+	// core == "<server-pk>/<client-pk>"
+	slash := strings.LastIndexByte(core, '/')
+	if slash < 0 {
+		return cipher.PubKey{}, false
+	}
+	clientHex := core[slash+1:]
+	if clientHex == "" {
+		return cipher.PubKey{}, false
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(clientHex); err != nil {
+		return cipher.PubKey{}, false
+	}
+	return pk, true
+}

--- a/pkg/visor/dmsg_lookup_cxo_test.go
+++ b/pkg/visor/dmsg_lookup_cxo_test.go
@@ -1,0 +1,58 @@
+package visor
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestClientPKFromLeafPath(t *testing.T) {
+	const (
+		serverHex = "02190003862c24f69e2cf47e1cf0efaa3dc1d866ba6a24067de34c363058212c73"
+		clientHex = "02e40731f3ab6d11d31c466429297f4869f299a7821108409c5e36b840253e4ba7"
+	)
+	var wantPK cipher.PubKey
+	if err := wantPK.Set(clientHex); err != nil {
+		t.Fatalf("bad test client hex: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		path   string
+		wantOK bool
+		wantPK cipher.PubKey
+	}{
+		{
+			name:   "valid entry leaf",
+			path:   "clients-by-server/" + serverHex + "/" + clientHex + "/entry",
+			wantOK: true,
+			wantPK: wantPK,
+		},
+		{
+			name:   "tombstone suffix rejected",
+			path:   "clients-by-server/" + serverHex + "/" + clientHex + "/tombstone",
+			wantOK: false,
+		},
+		{
+			name:   "missing client segment",
+			path:   "clients-by-server/" + serverHex + "/entry",
+			wantOK: false,
+		},
+		{
+			name:   "malformed client hex",
+			path:   "clients-by-server/" + serverHex + "/nothex/entry",
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pk, ok := clientPKFromLeafPath(tt.path)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && pk != tt.wantPK {
+				t.Fatalf("pk = %s, want %s", pk, tt.wantPK)
+			}
+		})
+	}
+}

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -218,7 +218,16 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 	// (dmsgDC) that self-evicted on the dmsg servers.
 	httpC := &http.Client{}
 	directOnly := v.conf.Dmsg != nil && v.conf.Dmsg.DirectOnly
-	dmsgC := dmsgc.New(v.conf.PK, v.conf.SK, v.ebc, &dmsgConf, httpC, v.dClient, directOnly, v.MasterLogger())
+	// When LookupCXO is enabled, front the discovery client with a
+	// resolver that serves peer entries from the local CXO
+	// clients-by-server snapshot (no per-lookup dmsg Noise handshake),
+	// falling back to HTTP on a miss. nil resolver leaves the dmsg
+	// client's discovery chain unchanged.
+	var entryResolve dmsgdisc.EntryResolveFunc
+	if v.conf.Dmsg != nil && v.conf.Dmsg.LookupCXO {
+		entryResolve = v.newDmsgEntryCXOResolver()
+	}
+	dmsgC := dmsgc.New(v.conf.PK, v.conf.SK, v.ebc, &dmsgConf, httpC, v.dClient, directOnly, entryResolve, v.MasterLogger())
 	httpC.Transport = dmsghttp.MakeHTTPTransport(ctx, dmsgC)
 
 	wg := new(sync.WaitGroup)


### PR DESCRIPTION
Each dmsg-discovery entry lookup opens a fresh HTTP-over-dmsg session with a full Noise + post-quantum handshake — the crypto that dominated dmsg-discovery CPU (profiled 76% in GC). Registration-over-CXO already offloaded the write side (#3828/#3829); this adds the lookup side.

dmsg-discovery already mirrors every client entry into a CXO feed (`clients-by-server/<server>/<client>/entry`, port 54), today consumed only by the network visualizer. This wires a consumer/resolver shim that ingests it into a local client→entry index and fronts the dmsg client discovery `Entry()` with it: a peer entry already in the snapshot resolves with no handshake; any miss falls through to the HTTP client, which stays authoritative.

- `disc.NewCXOEntryClient`: generic `Entry()`-only decorator; nil resolver = passthrough; serves only client entries with a non-empty delegated-server list (server/self/empty lookups take HTTP).
- visor `dmsgEntryCXOIndex`: memoized index rebuilt only when the snapshot advances; never resolves the visor own PK (registration read-back).
- cxosub `TabDmsgEntryLookup` holds the feed warm; `LastSync` exposes the snapshot version.
- Gated by `dmsg.lookup_cxo` (default off, opt-in rollout; HTTP path unchanged when off). Reuses port 54 — no new CXO port.

SecKey binding: subscribes over the visor single dmsg client (visor SecKey) — no second client, no random keypair. Provenance is the single authoritative dmsg-discovery publisher feed.

Tests: decorator hit/miss/empty-delegation fallback, leaf-path parser, config round-trip. Build + vet + touched-package tests green; WASM disc build green.