### PR TITLE
feat(telemetry): sharded compact-binary CXO telemetry leaves (fillable busy-hub Root)

### DIFF
--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -606,6 +606,10 @@ func (s *memoryStore) UpdateBandwidth(context.Context, string, cipher.PubKey, ui
 func (s *memoryStore) UpdateLatency(context.Context, string, float64, float64, float64) error {
 	return nil
 }
+
+func (s *memoryStore) UpdateThroughput(context.Context, string, cipher.PubKey, float64) error {
+	return nil
+}
 func (s *memoryStore) GetTransportBandwidth(context.Context, uuid.UUID, string, int) ([]store.BandwidthAggregation, error) {
 	return nil, nil
 }

--- a/pkg/deployment/rf/store/graph_test.go
+++ b/pkg/deployment/rf/store/graph_test.go
@@ -69,6 +69,10 @@ func (m *mockStore) UpdateLatency(_ context.Context, _ string, _, _, _ float64) 
 	return nil
 }
 
+func (m *mockStore) UpdateThroughput(_ context.Context, _ string, _ cipher.PubKey, _ float64) error {
+	return nil
+}
+
 func (m *mockStore) GetTransportBandwidth(_ context.Context, _ uuid.UUID, _ string, _ int) ([]tpdstore.BandwidthAggregation, error) {
 	return []tpdstore.BandwidthAggregation{}, nil
 }

--- a/pkg/deployment/tpd/cxoaggregator/aggregator.go
+++ b/pkg/deployment/tpd/cxoaggregator/aggregator.go
@@ -53,6 +53,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/telemetrywire"
 	"github.com/skycoin/skywire/pkg/transport"
 )
 
@@ -67,6 +68,13 @@ import (
 type Sink interface {
 	UpdateBandwidth(ctx context.Context, transportID string, reporterPK cipher.PubKey, sent, recv uint64) error
 	UpdateLatency(ctx context.Context, transportID string, minMS, maxMS, avgMS float64) error
+	// UpdateThroughput records a transport's passively-observed PEAK
+	// goodput estimate (bytes/sec), carried on the sharded telemetry feed
+	// alongside the cumulative sent/recv counters. It is a real capacity
+	// metric NOT derivable from those counters (average-over-interval vs
+	// tracked peak). Recorded per-transport, last-writer-wins with a
+	// peak-preserving max.
+	UpdateThroughput(ctx context.Context, transportID string, reporterPK cipher.PubKey, bps float64) error
 	// at is the visor-side observation time (snap.SampledAt), so a
 	// heartbeat that crosses a 5-minute slot boundary in transit
 	// still credits the slot the visor was actually online for.
@@ -106,18 +114,27 @@ type Sink interface {
 // BandwidthSink keep compiling until they migrate.
 type BandwidthSink = Sink
 
-// liveSnapshot mirrors pkg/visor/stats.LiveSnapshot. Re-declared on
-// the TPD side to keep the dependency direction one-way: visor →
-// spec → wire format → TPD-side parser. Field renames must be
-// reflected in both places.
+// liveSnapshot mirrors pkg/visor/stats.LiveSnapshot — the LEGACY,
+// per-transport JSON telemetry leaf published at
+// transports/<uuid>/current by visors that predate the sharded wire
+// format. It is kept as a FALLBACK: a mixed fleet has both upgraded
+// visors (publishing the compact sharded telemetry — see
+// pkg/telemetrywire, dispatched via parseTelemetryShardPath below) and
+// not-yet-upgraded visors (still publishing these current leaves). TPD
+// reads whichever a given visor's Root carries; when a Root has
+// transports/telemetry/* shards it uses those and IGNORES the current
+// leaves (see handleRootFilled's shard-preference). Re-declared here to
+// keep the dependency direction one-way: visor → spec → wire format →
+// TPD-side parser. Field renames must be reflected in both places.
 type liveSnapshot struct {
-	SentBytes    uint64    `json:"sent_bytes"`
-	RecvBytes    uint64    `json:"recv_bytes"`
-	LatencyMinMS float64   `json:"latency_min_ms,omitempty"`
-	LatencyMaxMS float64   `json:"latency_max_ms,omitempty"`
-	LatencyAvgMS float64   `json:"latency_avg_ms,omitempty"`
-	SampledAt    time.Time `json:"sampled_at"`
-	Type         string    `json:"type,omitempty"`
+	SentBytes     uint64    `json:"sent_bytes"`
+	RecvBytes     uint64    `json:"recv_bytes"`
+	ThroughputBps float64   `json:"throughput_bps,omitempty"`
+	LatencyMinMS  float64   `json:"latency_min_ms,omitempty"`
+	LatencyMaxMS  float64   `json:"latency_max_ms,omitempty"`
+	LatencyAvgMS  float64   `json:"latency_avg_ms,omitempty"`
+	SampledAt     time.Time `json:"sampled_at"`
+	Type          string    `json:"type,omitempty"`
 }
 
 // transportEntryLeaf is the wire shape for transports/<uuid>/entry
@@ -748,7 +765,29 @@ func (a *Aggregator) handleRootFilled(r *registry.Root) {
 		a.log.Debug("CXO aggregator: dropping root with zero publisher PK")
 		return
 	}
-	a.walkAndDispatch(pack, &rootNode, "", reporter)
+	// Prefer the compact sharded telemetry when present. An upgraded visor
+	// publishes transports/telemetry/<sh> shards and NO per-transport
+	// current leaves; a not-yet-upgraded visor publishes current leaves and
+	// no shards. If this Root carries any shard, use the shards and ignore
+	// any current leaves (mixed-fleet fallback: current is only consulted
+	// when a Root has no shards at all).
+	skipCurrent := rootHasTelemetryShards(pack, &rootNode)
+	a.walkAndDispatch(pack, &rootNode, "", reporter, skipCurrent)
+}
+
+// rootHasTelemetryShards reports whether the Root's "transports" subtree
+// contains a "telemetry" branch — the marker that this visor publishes
+// the sharded wire format, so its (absent) per-transport current leaves
+// should not be looked for. Tolerant of a partial fill: a missing object
+// simply yields false (treat as legacy), which is safe because a visor
+// that truly publishes shards will have them inline in the small Root.
+func rootHasTelemetryShards(pack registry.Pack, rootNode *treestore.TreeNode) bool {
+	_, tsub, found := childByName(pack, rootNode, "transports")
+	if !found || tsub == nil {
+		return false
+	}
+	_, tel, ok := childByName(pack, tsub, "telemetry")
+	return ok && tel != nil
 }
 
 // recoverTransportListOnBreak is the OnFillingBreaks best-effort path.
@@ -797,7 +836,9 @@ func (a *Aggregator) recoverTransportListOnBreak(r *registry.Root) {
 	a.log.WithField("visor", reporter).WithField("path", dispatchPath).
 		Debug("CXO aggregator: recovered transport list from partial fill")
 	leafCopy := append([]byte(nil), leaf...)
-	go a.dispatchLeaf(dispatchPath, leafCopy, reporter)
+	// This recovery only ever dispatches the tp-list discovery leaf, never a
+	// current leaf, so skipCurrent is irrelevant (pass false).
+	go a.dispatchLeaf(dispatchPath, leafCopy, reporter, false)
 }
 
 // reconcileTargeted decouples discovery from the whole-Root telemetry fill.
@@ -1028,7 +1069,7 @@ func childByName(pack registry.Pack, n *treestore.TreeNode, name string) (leaf [
 // held in CXO's local cache and ignored — daily transport rollups,
 // tier bitmaps, and service bitmaps are received but not yet
 // dispatched anywhere; routing them to redis is a follow-up.
-func (a *Aggregator) walkAndDispatch(pack registry.Pack, n *treestore.TreeNode, basePath string, reporter cipher.PubKey) {
+func (a *Aggregator) walkAndDispatch(pack registry.Pack, n *treestore.TreeNode, basePath string, reporter cipher.PubKey, skipCurrent bool) {
 	count, err := n.Children.Len(pack)
 	if err != nil {
 		return
@@ -1043,13 +1084,13 @@ func (a *Aggregator) walkAndDispatch(pack registry.Pack, n *treestore.TreeNode, 
 			fullPath = basePath + "/" + entry.Name
 		}
 		if len(entry.Leaf) > 0 {
-			a.dispatchLeaf(fullPath, entry.Leaf, reporter)
+			a.dispatchLeaf(fullPath, entry.Leaf, reporter, skipCurrent)
 			continue
 		}
 		if entry.Sub.Hash != (skycipher.SHA256{}) {
 			var sub treestore.TreeNode
 			if err := entry.Sub.Value(pack, &sub); err == nil {
-				a.walkAndDispatch(pack, &sub, fullPath, reporter)
+				a.walkAndDispatch(pack, &sub, fullPath, reporter, skipCurrent)
 			}
 		}
 	}
@@ -1060,12 +1101,26 @@ func (a *Aggregator) walkAndDispatch(pack registry.Pack, n *treestore.TreeNode, 
 //
 //	transports/<uuid>/entry               → register (metadata)
 //	transports/<uuid>/tombstone           → deregister
-//	transports/<uuid>/current             → bandwidth + latency + heartbeat
+//	transports/telemetry/<sh>             → sharded bandwidth+throughput+latency+heartbeat
+//	transports/<uuid>/current             → LEGACY per-transport bandwidth+latency+heartbeat
 //	transports/<uuid>/<YYYY-MM-DD>/timeline → per-transport uptime bitmap
+//
+// skipCurrent suppresses the legacy transports/<uuid>/current path when
+// the same Root already carries transports/telemetry/* shards (an
+// upgraded visor): the shards are authoritative and the current leaves,
+// if any lingered, are ignored to avoid double-applying.
 //
 // Tier and service bitmaps still flow through the CXO cache but
 // aren't yet projected into TPD's redis uptime tables.
-func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubKey) {
+func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubKey, skipCurrent bool) {
+	// Sharded telemetry (upgraded visors): one binary leaf per shard packs
+	// every transport in that shard. Decode and apply each row exactly as a
+	// legacy `current` snapshot is applied — bandwidth, throughput, latency,
+	// and per-type uptime heartbeat.
+	if _, ok := parseTelemetryShardPath(path); ok {
+		a.dispatchTelemetryShard(path, leaf, reporter)
+		return
+	}
 	// Publishers may gzip leaf bodies (bandwidth/storage parity with the
 	// HTTP path). Gunzip is self-describing — it magic-byte-detects gzip and
 	// passes raw bodies through unchanged — so this reads both compressed and
@@ -1131,6 +1186,11 @@ func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubK
 	if !ok {
 		return
 	}
+	// This Root also carries sharded telemetry (upgraded visor); the
+	// shards are authoritative, so ignore any lingering legacy current leaf.
+	if skipCurrent {
+		return
+	}
 	var snap liveSnapshot
 	if err := json.Unmarshal(leaf, &snap); err != nil {
 		a.log.WithError(err).WithField("path", path).Debug("CXO aggregator: live snapshot decode failed")
@@ -1138,29 +1198,104 @@ func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubK
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := a.sink.UpdateBandwidth(ctx, id.String(), reporter, snap.SentBytes, snap.RecvBytes); err != nil {
+	a.applyTelemetry(ctx, id, reporter, snap.SentBytes, snap.RecvBytes, snap.ThroughputBps,
+		snap.LatencyMinMS, snap.LatencyMaxMS, snap.LatencyAvgMS, snap.Type, snap.SampledAt)
+}
+
+// dispatchTelemetryShard decodes one transports/telemetry/<sh> binary
+// leaf and applies every packed transport row exactly as a legacy
+// `current` snapshot is applied. A corrupt/truncated/wrong-version blob
+// is dropped whole (DecodeShard validates strictly) rather than
+// partially applied.
+func (a *Aggregator) dispatchTelemetryShard(path string, leaf []byte, reporter cipher.PubKey) {
+	shard, entries, err := telemetrywire.DecodeShard(leaf)
+	if err != nil {
+		a.log.WithError(err).WithField("path", path).Debug("CXO aggregator: telemetry shard decode failed")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	for i := range entries {
+		e := &entries[i]
+		// Belt-and-suspenders: a row whose ID doesn't belong to this shard
+		// signals a malformed/spoofed blob — skip it rather than mis-apply.
+		if telemetrywire.ShardOf(e.ID) != shard {
+			continue
+		}
+		var at time.Time
+		if e.SampledAtUnix > 0 {
+			at = time.Unix(int64(e.SampledAtUnix), 0).UTC()
+		}
+		a.applyTelemetry(ctx, e.ID, reporter, e.SentBytes, e.RecvBytes, float64(e.ThroughputBps),
+			float64(e.LatMin), float64(e.LatMax), float64(e.LatAvg), telemetrywire.CodeToType(e.Type), at)
+	}
+}
+
+// applyTelemetry is the shared per-transport apply used by both the
+// sharded path and the legacy current-leaf path: bandwidth, throughput,
+// latency (partial-zero-gated), and per-type uptime heartbeat.
+func (a *Aggregator) applyTelemetry(ctx context.Context, id uuid.UUID, reporter cipher.PubKey,
+	sent, recv uint64, throughputBps, latMin, latMax, latAvg float64, tpType string, at time.Time) {
+	if err := a.sink.UpdateBandwidth(ctx, id.String(), reporter, sent, recv); err != nil {
 		a.log.WithError(err).WithField("transport", id).Debug("CXO aggregator: UpdateBandwidth failed")
+	}
+	if throughputBps > 0 {
+		if err := a.sink.UpdateThroughput(ctx, id.String(), reporter, throughputBps); err != nil {
+			a.log.WithError(err).WithField("transport", id).Debug("CXO aggregator: UpdateThroughput failed")
+		}
 	}
 	// Both edges of a transport publish their own snapshot, and TPD's
 	// store is last-writer-wins. Require all three fields to be > 0 so
 	// a partial-zero snapshot from an edge whose probe never completed
 	// can't clobber a good record written by the other edge.
-	if snap.LatencyMinMS > 0 && snap.LatencyMaxMS > 0 && snap.LatencyAvgMS > 0 {
-		if err := a.sink.UpdateLatency(ctx, id.String(), snap.LatencyMinMS, snap.LatencyMaxMS, snap.LatencyAvgMS); err != nil {
+	if latMin > 0 && latMax > 0 && latAvg > 0 {
+		if err := a.sink.UpdateLatency(ctx, id.String(), latMin, latMax, latAvg); err != nil {
 			a.log.WithError(err).WithField("transport", id).Debug("CXO aggregator: UpdateLatency failed")
 		}
 	}
 	// Heartbeat into the per-transport uptime tables (tp-uptime:*),
 	// previously written only by the HTTP /transports/ register path.
-	// Type is empty on snapshots from pre-uptime visors — skip those
-	// rather than push a heartbeat the store would have to drop on
-	// the type filter (RecordTransportHeartbeat early-returns on any
-	// non-p2p type, but routing here saves the redis round-trip).
-	if snap.Type != "" {
-		if err := a.sink.RecordTransportHeartbeat(ctx, id, snap.Type, snap.SampledAt); err != nil {
+	// Type is empty on snapshots from pre-uptime visors / unknown-type
+	// entries — skip those rather than push a heartbeat the store would
+	// drop on the type filter (RecordTransportHeartbeat early-returns on
+	// any non-p2p type, but routing here saves the redis round-trip).
+	if tpType != "" {
+		if err := a.sink.RecordTransportHeartbeat(ctx, id, tpType, at); err != nil {
 			a.log.WithError(err).WithField("transport", id).Debug("CXO aggregator: RecordTransportHeartbeat failed")
 		}
 	}
+}
+
+// parseTelemetryShardPath returns the shard number for paths shaped
+// "transports/telemetry/<sh>" (<sh> = lowercase 2-hex 00..0f), or false
+// otherwise. Mirrors telemetrywire.LeafPath.
+func parseTelemetryShardPath(path string) (uint8, bool) {
+	const prefix = "transports/telemetry/"
+	if !strings.HasPrefix(path, prefix) {
+		return 0, false
+	}
+	rest := path[len(prefix):]
+	if len(rest) != 2 {
+		return 0, false
+	}
+	var sh uint8
+	for i := 0; i < 2; i++ {
+		c := rest[i]
+		var d uint8
+		switch {
+		case c >= '0' && c <= '9':
+			d = c - '0'
+		case c >= 'a' && c <= 'f':
+			d = c - 'a' + 10
+		default:
+			return 0, false
+		}
+		sh = sh<<4 | d
+	}
+	if sh >= telemetrywire.ShardCount {
+		return 0, false
+	}
+	return sh, true
 }
 
 // parseTransportTimelinePath returns the transport UUID and date for

--- a/pkg/deployment/tpd/cxoaggregator/aggregator_test.go
+++ b/pkg/deployment/tpd/cxoaggregator/aggregator_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/telemetrywire"
 	"github.com/skycoin/skywire/pkg/transport"
 )
 
@@ -87,7 +88,7 @@ func TestDispatchLeafTimeline(t *testing.T) {
 
 	sink := &recordingSink{}
 	a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
-	a.dispatchLeaf("transports/"+id.String()+"/2026-05-04/timeline", bitmap, pk)
+	a.dispatchLeaf("transports/"+id.String()+"/2026-05-04/timeline", bitmap, pk, false)
 
 	if len(sink.timelines) != 1 {
 		t.Fatalf("expected 1 timeline call, got %d", len(sink.timelines))
@@ -126,7 +127,7 @@ func TestDispatchLeafListPaths(t *testing.T) {
 	for _, path := range []string{"tp-list", "transports/list"} {
 		sink := &recordingSink{}
 		a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
-		a.dispatchLeaf(path, leaf, reporter)
+		a.dispatchLeaf(path, leaf, reporter, false)
 
 		if len(sink.reconciles) != 1 {
 			t.Fatalf("path %q: expected 1 reconcile, got %d", path, len(sink.reconciles))
@@ -146,6 +147,113 @@ func TestDispatchLeafListPaths(t *testing.T) {
 	}
 }
 
+// TestParseTelemetryShardPath pins the shard-leaf path grammar.
+func TestParseTelemetryShardPath(t *testing.T) {
+	for sh := uint8(0); sh < telemetrywire.ShardCount; sh++ {
+		got, ok := parseTelemetryShardPath(telemetrywire.LeafPath(sh))
+		if !ok || got != sh {
+			t.Errorf("parseTelemetryShardPath(%q) = %d,%v; want %d,true", telemetrywire.LeafPath(sh), got, ok, sh)
+		}
+	}
+	for _, bad := range []string{
+		"transports/telemetry/", "transports/telemetry/0", "transports/telemetry/1g",
+		"transports/telemetry/AA", "transports/telemetry/100", "transports/list",
+		"transports/" + uuid.New().String() + "/current",
+	} {
+		if _, ok := parseTelemetryShardPath(bad); ok {
+			t.Errorf("parseTelemetryShardPath(%q) parsed; want false", bad)
+		}
+	}
+}
+
+// TestDispatchTelemetryShard proves TPD applies each packed row from a
+// shard leaf exactly as a legacy current snapshot: bandwidth, throughput,
+// latency (partial-zero-gated), and per-type heartbeat with the row's
+// sampled-at as the heartbeat time.
+func TestDispatchTelemetryShard(t *testing.T) {
+	reporter, _ := cipher.GenerateKeyPair()
+	shard := uint8(4)
+	mk := func(low byte) uuid.UUID {
+		var id uuid.UUID
+		id[0] = shard << 4
+		id[15] = low
+		return id
+	}
+	sampledUnix := uint32(1_800_000_000)
+	entries := []telemetrywire.Entry{
+		{ID: mk(1), SentBytes: 100, RecvBytes: 50, ThroughputBps: 4242,
+			LatMin: 10, LatMax: 30, LatAvg: 18, SampledAtUnix: sampledUnix, Type: telemetrywire.TypeSTCPR},
+		// Partial-zero latency → latency dropped, but bandwidth+heartbeat apply.
+		{ID: mk(2), SentBytes: 7, RecvBytes: 8, ThroughputBps: 0,
+			LatMin: 0, LatMax: 0, LatAvg: 0, SampledAtUnix: sampledUnix, Type: telemetrywire.TypeSUDPH},
+	}
+	blob := telemetrywire.EncodeShard(shard, entries)
+
+	sink := &recordingSink{}
+	a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
+	a.dispatchTelemetryShard(telemetrywire.LeafPath(shard), blob, reporter)
+
+	if sink.bandwidths != 2 {
+		t.Errorf("bandwidth calls = %d, want 2", sink.bandwidths)
+	}
+	if len(sink.throughputs) != 1 || sink.throughputs[0] != 4242 {
+		t.Errorf("throughput calls = %v, want [4242] (only the >0 row)", sink.throughputs)
+	}
+	if len(sink.latencies) != 1 {
+		t.Errorf("latency calls = %d, want 1 (partial-zero row dropped)", len(sink.latencies))
+	}
+	if len(sink.heartbeats) != 2 {
+		t.Fatalf("heartbeat calls = %d, want 2", len(sink.heartbeats))
+	}
+	wantAt := time.Unix(int64(sampledUnix), 0).UTC()
+	for _, hb := range sink.heartbeats {
+		if !hb.at.Equal(wantAt) {
+			t.Errorf("heartbeat at = %v, want %v (row sampled_at)", hb.at, wantAt)
+		}
+	}
+	types := map[string]bool{sink.heartbeats[0].tpType: true, sink.heartbeats[1].tpType: true}
+	if !types["stcpr"] || !types["sudph"] {
+		t.Errorf("heartbeat types = %v, want stcpr+sudph", types)
+	}
+}
+
+// TestDispatchTelemetryShardRejectsCorrupt asserts a malformed blob is
+// dropped whole (no partial application).
+func TestDispatchTelemetryShardRejectsCorrupt(t *testing.T) {
+	reporter, _ := cipher.GenerateKeyPair()
+	sink := &recordingSink{}
+	a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
+	a.dispatchTelemetryShard("transports/telemetry/00", []byte{0x02, 0x00, 0xFF}, reporter)
+	if sink.bandwidths != 0 || len(sink.latencies) != 0 || len(sink.heartbeats) != 0 || len(sink.throughputs) != 0 {
+		t.Errorf("corrupt shard produced sink calls: bw=%d lat=%d hb=%d tput=%d",
+			sink.bandwidths, len(sink.latencies), len(sink.heartbeats), len(sink.throughputs))
+	}
+}
+
+// TestDispatchLeafSkipsCurrentWhenShardsPresent asserts that when a Root
+// carries shards (skipCurrent=true), a lingering legacy current leaf is
+// ignored — the shards are authoritative and current must not be
+// double-applied.
+func TestDispatchLeafSkipsCurrentWhenShardsPresent(t *testing.T) {
+	reporter, _ := cipher.GenerateKeyPair()
+	id := uuid.New()
+	leaf, err := json.Marshal(liveSnapshot{SentBytes: 100, RecvBytes: 50, Type: "stcpr", SampledAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &recordingSink{}
+	a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
+	a.dispatchLeaf("transports/"+id.String()+"/current", leaf, reporter, true)
+	if sink.bandwidths != 0 || len(sink.heartbeats) != 0 {
+		t.Errorf("current leaf applied despite skipCurrent: bw=%d hb=%d", sink.bandwidths, len(sink.heartbeats))
+	}
+	// Without skipCurrent it applies (fallback path for un-upgraded visors).
+	a.dispatchLeaf("transports/"+id.String()+"/current", leaf, reporter, false)
+	if sink.bandwidths != 1 || len(sink.heartbeats) != 1 {
+		t.Errorf("current leaf not applied on fallback path: bw=%d hb=%d", sink.bandwidths, len(sink.heartbeats))
+	}
+}
+
 func bytesEqual(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false
@@ -161,10 +269,11 @@ func bytesEqual(a, b []byte) bool {
 // recordingSink captures sink calls so tests can assert what dispatchLeaf
 // chose to forward (vs drop on the partial-zero gate).
 type recordingSink struct {
-	mu         sync.Mutex
-	bandwidths int
-	latencies  []struct{ min, max, avg float64 }
-	heartbeats []struct {
+	mu          sync.Mutex
+	bandwidths  int
+	throughputs []float64
+	latencies   []struct{ min, max, avg float64 }
+	heartbeats  []struct {
 		tpType string
 		at     time.Time
 	}
@@ -187,6 +296,12 @@ func (s *recordingSink) UpdateBandwidth(_ context.Context, _ string, _ cipher.Pu
 func (s *recordingSink) UpdateLatency(_ context.Context, _ string, minMS, maxMS, avgMS float64) error {
 	s.mu.Lock()
 	s.latencies = append(s.latencies, struct{ min, max, avg float64 }{minMS, maxMS, avgMS})
+	s.mu.Unlock()
+	return nil
+}
+func (s *recordingSink) UpdateThroughput(_ context.Context, _ string, _ cipher.PubKey, bps float64) error {
+	s.mu.Lock()
+	s.throughputs = append(s.throughputs, bps)
 	s.mu.Unlock()
 	return nil
 }
@@ -293,7 +408,7 @@ func TestDispatchLeafLatencyGate(t *testing.T) {
 			if err != nil {
 				t.Fatalf("marshal: %v", err)
 			}
-			a.dispatchLeaf("transports/"+id.String()+"/current", leaf, pk)
+			a.dispatchLeaf("transports/"+id.String()+"/current", leaf, pk, false)
 			if c.wantBwHit && sink.bandwidths != 1 {
 				t.Errorf("expected 1 bandwidth call, got %d", sink.bandwidths)
 			}
@@ -354,7 +469,7 @@ func TestDispatchLeafHeartbeatGate(t *testing.T) {
 			if err != nil {
 				t.Fatalf("marshal: %v", err)
 			}
-			a.dispatchLeaf("transports/"+id.String()+"/current", leaf, pk)
+			a.dispatchLeaf("transports/"+id.String()+"/current", leaf, pk, false)
 			if c.wantHB {
 				if len(sink.heartbeats) != 1 {
 					t.Fatalf("expected 1 heartbeat call, got %d", len(sink.heartbeats))
@@ -426,7 +541,7 @@ func TestDispatchLeafEntryAndTombstone(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshal: %v", err)
 		}
-		a.dispatchLeaf("transports/"+id.String()+"/entry", body, pkA)
+		a.dispatchLeaf("transports/"+id.String()+"/entry", body, pkA, false)
 		if len(sink.registers) != 1 {
 			t.Fatalf("expected 1 register call, got %d", len(sink.registers))
 		}
@@ -451,7 +566,7 @@ func TestDispatchLeafEntryAndTombstone(t *testing.T) {
 			t.Fatalf("marshal: %v", err)
 		}
 		// path declares `id`, but leaf carries a different UUID — must drop.
-		a.dispatchLeaf("transports/"+id.String()+"/entry", body, pkA)
+		a.dispatchLeaf("transports/"+id.String()+"/entry", body, pkA, false)
 		if len(sink.registers) != 0 {
 			t.Errorf("expected drop on id mismatch, got %d registers", len(sink.registers))
 		}
@@ -464,7 +579,7 @@ func TestDispatchLeafEntryAndTombstone(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshal: %v", err)
 		}
-		a.dispatchLeaf("transports/"+id.String()+"/tombstone", body, pkA)
+		a.dispatchLeaf("transports/"+id.String()+"/tombstone", body, pkA, false)
 		if len(sink.deregisters) != 1 {
 			t.Fatalf("expected 1 deregister call, got %d", len(sink.deregisters))
 		}
@@ -480,7 +595,7 @@ func TestDispatchLeafEntryAndTombstone(t *testing.T) {
 	t.Run("entry leaf with malformed body is dropped", func(t *testing.T) {
 		sink := &recordingSink{}
 		a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
-		a.dispatchLeaf("transports/"+id.String()+"/entry", []byte("not json"), pkA)
+		a.dispatchLeaf("transports/"+id.String()+"/entry", []byte("not json"), pkA, false)
 		if len(sink.registers) != 0 {
 			t.Errorf("expected drop on bad json, got %d registers", len(sink.registers))
 		}
@@ -502,7 +617,7 @@ func TestDispatchLeafTransportListSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	a.dispatchLeaf("transports/list", body, pkA)
+	a.dispatchLeaf("transports/list", body, pkA, false)
 	if len(sink.reconciles) != 1 {
 		t.Fatalf("expected 1 reconcile call, got %d", len(sink.reconciles))
 	}

--- a/pkg/deployment/tpd/store/memory_store.go
+++ b/pkg/deployment/tpd/store/memory_store.go
@@ -162,6 +162,11 @@ func (s *memoryStore) UpdateLatency(_ context.Context, _ string, _, _, _ float64
 	return nil
 }
 
+// UpdateThroughput is a no-op for the same reason as UpdateBandwidth.
+func (s *memoryStore) UpdateThroughput(_ context.Context, _ string, _ cipher.PubKey, _ float64) error {
+	return nil
+}
+
 // GetTransportBandwidth returns empty slice for memory store (no bandwidth tracking).
 func (s *memoryStore) GetTransportBandwidth(_ context.Context, _ uuid.UUID, _ string, _ int) ([]BandwidthAggregation, error) {
 	return []BandwidthAggregation{}, nil

--- a/pkg/deployment/tpd/store/redis_bandwidth.go
+++ b/pkg/deployment/tpd/store/redis_bandwidth.go
@@ -186,6 +186,50 @@ func (s *redisStore) UpdateLatency(ctx context.Context, transportID string, minM
 	return s.client.Set(ctx, s.latencyKey(id), string(raw), latencyTTL).Err()
 }
 
+// UpdateThroughput persists a transport's passively-observed PEAK
+// goodput (bytes/sec) at transport-discovery:tput:<id>, carried on the
+// sharded telemetry feed. It keeps the MAX of the stored value and the
+// incoming one so the higher of the two edges' observations survives a
+// momentarily-idle edge's report (peak, not last-value). Independent of
+// the registration blob, with latency's retention window.
+func (s *redisStore) UpdateThroughput(ctx context.Context, transportID string, reporterPK cipher.PubKey, bps float64) error {
+	// Zero/negative is "no observation this window" — don't overwrite a
+	// good peak with it, and don't attribute to the zero reporter.
+	if bps <= 0 || reporterPK == (cipher.PubKey{}) {
+		return nil
+	}
+	id, err := uuid.Parse(transportID)
+	if err != nil {
+		return fmt.Errorf("invalid transport id %q: %w", transportID, err)
+	}
+	if prev, err := s.getThroughputRecord(ctx, id); err == nil && prev != nil && prev.Bps > bps {
+		bps = prev.Bps // preserve the running peak
+	}
+	rec := ThroughputRecord{Bps: bps, UpdatedAt: time.Now().UTC().Unix()}
+	raw, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	return s.client.Set(ctx, s.throughputKey(id), string(raw), throughputTTL).Err()
+}
+
+// getThroughputRecord reads the durable peak-goodput snapshot for a
+// transport, returning (nil, nil) when no record exists.
+func (s *redisStore) getThroughputRecord(ctx context.Context, id uuid.UUID) (*ThroughputRecord, error) {
+	raw, err := s.client.Get(ctx, s.throughputKey(id)).Result()
+	if errors.Is(err, redis.Nil) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var rec ThroughputRecord
+	if err := json.Unmarshal([]byte(raw), &rec); err != nil {
+		return nil, fmt.Errorf("decode ThroughputRecord: %w", err)
+	}
+	return &rec, nil
+}
+
 // getLatencyRecord reads the durable latency snapshot for a transport,
 // returning (nil, nil) when no record exists.
 func (s *redisStore) getLatencyRecord(ctx context.Context, id uuid.UUID) (*LatencyRecord, error) {

--- a/pkg/deployment/tpd/store/redis_store.go
+++ b/pkg/deployment/tpd/store/redis_store.go
@@ -56,6 +56,22 @@ type LatencyRecord struct {
 // telemetry types share the same observability window.
 const latencyTTL = 35 * 24 * time.Hour
 
+// ThroughputRecord is the durable per-transport PEAK-goodput snapshot
+// persisted at transport-discovery:tput:<id>. Bps is the passively
+// observed peak (an EWMA tracked on the visor and pushed on the sharded
+// telemetry feed); UpdateThroughput keeps the MAX across the two edges'
+// reports so a momentarily-idle edge can't erase the other's peak. Shares
+// latency's retention window and last-writer-wins independence from the
+// registration blob. UpdatedAt is informational (staleness gauge).
+type ThroughputRecord struct {
+	Bps       float64 `json:"bps"`
+	UpdatedAt int64   `json:"updated_at"`
+}
+
+// throughputTTL mirrors latencyTTL — the peak-goodput record shares the
+// same observability window as the other CXO-fed telemetry types.
+const throughputTTL = latencyTTL
+
 type redisStore struct {
 	client       *redis.Client
 	ttl          time.Duration

--- a/pkg/deployment/tpd/store/redis_transport.go
+++ b/pkg/deployment/tpd/store/redis_transport.go
@@ -241,6 +241,10 @@ func (s *redisStore) GetTransportByID(ctx context.Context, id uuid.UUID) (*trans
 	if rec != nil && rec.Avg > 0 {
 		entry.Latency = float64(rec.Avg) / 1000.0
 	}
+	trec, _ := s.getThroughputRecord(ctx, id) //nolint:errcheck // best-effort overlay; entry stays usable without throughput
+	if trec != nil && trec.Bps > 0 {
+		entry.ThroughputBps = trec.Bps
+	}
 	return entry, nil
 }
 
@@ -465,6 +469,38 @@ func (s *redisStore) hydrateDurableLatency(ctx context.Context, entries []*trans
 			entries[i].Latency = float64(rec.Avg) / 1000.0
 		}
 	}
+	s.hydrateDurableThroughput(ctx, entries)
+}
+
+// hydrateDurableThroughput overlays the durable peak-goodput snapshot
+// (tput:<id>) onto each entry's ThroughputBps, mirroring
+// hydrateDurableLatency. Best-effort: a missing or unreadable record
+// leaves the entry's own registered value untouched.
+func (s *redisStore) hydrateDurableThroughput(ctx context.Context, entries []*transport.Entry) {
+	if len(entries) == 0 {
+		return
+	}
+	keys := make([]string, len(entries))
+	for i, e := range entries {
+		keys[i] = s.throughputKey(e.ID)
+	}
+	vals, err := s.client.MGet(ctx, keys...).Result()
+	if err != nil {
+		return
+	}
+	for i, v := range vals {
+		raw, ok := v.(string)
+		if !ok || raw == "" {
+			continue
+		}
+		var rec ThroughputRecord
+		if err := json.Unmarshal([]byte(raw), &rec); err != nil {
+			continue
+		}
+		if rec.Bps > 0 {
+			entries[i].ThroughputBps = rec.Bps
+		}
+	}
 }
 
 // scanAllTransports is the shared implementation for GetAllTransports and getAllTransportsWithQoS.
@@ -576,6 +612,10 @@ func (s *redisStore) transportKey(id uuid.UUID) string {
 
 func (s *redisStore) latencyKey(id uuid.UUID) string {
 	return serviceName + ":lat:" + id.String()
+}
+
+func (s *redisStore) throughputKey(id uuid.UUID) string {
+	return serviceName + ":tput:" + id.String()
 }
 
 func (s *redisStore) edgeKey(pk cipher.PubKey) string {

--- a/pkg/deployment/tpd/store/store.go
+++ b/pkg/deployment/tpd/store/store.go
@@ -198,6 +198,12 @@ type TransportStore interface {
 	// reporter's window min/max/avg in milliseconds). RTT-symmetric,
 	// so last-writer-wins across the two edges is acceptable.
 	UpdateLatency(ctx context.Context, transportID string, minMS, maxMS, avgMS float64) error
+	// Throughput ingest (called by the CXO aggregator with the
+	// reporter's passively-observed PEAK goodput estimate in bytes/sec,
+	// carried on the sharded telemetry feed). Recorded per-transport with
+	// a peak-preserving max so the higher of the two edges' observations
+	// survives; overlaid onto Entry.ThroughputBps on read.
+	UpdateThroughput(ctx context.Context, transportID string, reporterPK cipher.PubKey, bps float64) error
 	// Bandwidth query methods (legacy)
 	GetTransportBandwidth(ctx context.Context, tpID uuid.UUID, period string, limit int) ([]BandwidthAggregation, error)
 	GetVisorBandwidth(ctx context.Context, pk cipher.PubKey, period string, limit int) ([]BandwidthAggregation, error)

--- a/pkg/telemetrywire/telemetrywire.go
+++ b/pkg/telemetrywire/telemetrywire.go
@@ -1,0 +1,254 @@
+// Package telemetrywire pkg/telemetrywire/telemetrywire.go c3-vis-core
+//
+// telemetrywire is the SHARED, compact, sharded binary codec for the
+// visor→TPD CXO telemetry feed. It is imported by BOTH the publishing
+// side (pkg/visor/stats) and the consuming side
+// (pkg/deployment/tpd/cxoaggregator) so the byte layout cannot drift
+// between them — the two halves share one encoder/decoder rather than
+// re-declaring a wire struct on each side.
+//
+// # Why sharded binary
+//
+// The telemetry feed formerly published ONE JSON leaf per live
+// transport at transports/<uuid>/current. A busy hub (~851 transports)
+// produced ~851 leaves → ~1700 CXO objects in one Root, which could not
+// finish filling over TPD's short-lived announce conn (only the top
+// slice landed → busy-hub telemetry undercount). Object count was the
+// fill bottleneck.
+//
+// This codec replaces those N per-transport leaves with 16 FIXED
+// sharded binary leaves: a transport is assigned to shard uuid[0]>>4
+// (0..15), and every transport in a shard is packed into one binary
+// blob published at transports/telemetry/<sh> (<sh> = lowercase 2-hex).
+// A busy hub's telemetry subtree is then 16 leaves regardless of
+// transport count, so the whole-Root fill completes.
+//
+// # Wire layout (little-endian)
+//
+//	off size field
+//	0   1    version  = 0x02
+//	1   1    shard    = 0x00..0x0f
+//	2   2    count    uint16
+//	4   ...  entries[count], 53 bytes each:
+//	       +0   16  transport uuid (raw 16 bytes)
+//	       +16  8   sent_bytes      uint64
+//	       +24  8   recv_bytes      uint64
+//	       +32  4   throughput_bps  float32 (peak goodput EWMA)
+//	       +36  4   latency_min_ms  float32
+//	       +40  4   latency_max_ms  float32
+//	       +44  4   latency_avg_ms  float32
+//	       +48  4   sampled_at      uint32 (unix SECONDS)
+//	       +52  1   type            uint8 enum
+//
+// The version byte gates the format: a future breaking change bumps it
+// (0x03, …) and both sides branch on the value. DecodeShard rejects any
+// other version, so an old reader fails a new blob cleanly rather than
+// misparsing it. This is why the deploy is TPD-FIRST: TPD (which reads
+// shards AND the legacy current leaves as a fallback) must ship before
+// visors switch to shard-only publishing, or an old TPD silently loses
+// a new visor's telemetry during the rollout window.
+package telemetrywire
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/google/uuid"
+
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// Version is the current wire-format version byte. Bump on any breaking
+// change to the header or entry layout; readers reject other values.
+const Version = 0x02
+
+// ShardCount is the fixed number of shards a transport set is spread
+// across — the low nibble of the uuid's first byte (uuid[0]>>4).
+const ShardCount = 16
+
+const (
+	headerLen = 4  // version(1) + shard(1) + count(2)
+	entryLen  = 53 // see the package doc for the field layout
+)
+
+// Transport-type enum codes. 0..7 match the original spec; 8 (swsr / WS)
+// is the deterministic extension for the WS transport that the visor
+// fleet also runs — tptypes.Known() carries it, so both sides map it
+// rather than collapsing it to unknown. Unknown/empty types encode as 0,
+// which TPD treats as "skip uptime" exactly like the legacy empty-type
+// path (RecordTransportHeartbeat is not called for a zero-code entry).
+const (
+	TypeUnknown uint8 = 0
+	TypeSTCPR   uint8 = 1
+	TypeSUDPH   uint8 = 2
+	TypeSTCP    uint8 = 3
+	TypeDMSG    uint8 = 4
+	TypeSQUICR  uint8 = 5 // tptypes.QUIC, wire name "squicr"
+	TypeWEBRTC  uint8 = 6
+	TypeSWTR    uint8 = 7 // tptypes.WT, wire name "swtr"
+	TypeSWSR    uint8 = 8 // tptypes.WS, wire name "swsr"
+)
+
+// Entry is one transport's telemetry row — the decoded form of a 53-byte
+// wire record. Both sides operate on Entry; only this package knows the
+// byte layout.
+type Entry struct {
+	ID            uuid.UUID
+	SentBytes     uint64
+	RecvBytes     uint64
+	ThroughputBps float32
+	LatMin        float32
+	LatMax        float32
+	LatAvg        float32
+	SampledAtUnix uint32
+	Type          uint8
+}
+
+// Errors returned by DecodeShard. All indicate a malformed or
+// wrong-version blob; the caller drops it rather than misparsing.
+var (
+	ErrShort          = errors.New("telemetrywire: blob shorter than header")
+	ErrVersion        = errors.New("telemetrywire: unsupported version byte")
+	ErrShardRange     = errors.New("telemetrywire: shard byte out of range")
+	ErrLengthMismatch = errors.New("telemetrywire: blob length does not match count")
+)
+
+// ShardOf returns the shard a transport ID belongs to: the high nibble
+// of the uuid's first byte (uuid[0]>>4), 0..15.
+func ShardOf(id uuid.UUID) uint8 {
+	return id[0] >> 4
+}
+
+// LeafPath is the stable CXO leaf path for a shard's telemetry blob:
+// "transports/telemetry/<sh>" with <sh> the lowercase 2-hex shard.
+func LeafPath(shard uint8) string {
+	return fmt.Sprintf("transports/telemetry/%02x", shard)
+}
+
+// TypeToCode maps a transport-type wire string to its enum code,
+// normalizing legacy aliases (e.g. "quic"/"squic" → squicr, "wt" →
+// swtr, "ws" → swsr) first. An empty or unrecognized type yields
+// TypeUnknown (0) — TPD treats that as "skip uptime".
+func TypeToCode(s string) uint8 {
+	switch tptypes.NormalizeType(tptypes.Type(s)) {
+	case tptypes.STCPR:
+		return TypeSTCPR
+	case tptypes.SUDPH:
+		return TypeSUDPH
+	case tptypes.STCP:
+		return TypeSTCP
+	case tptypes.DMSG:
+		return TypeDMSG
+	case tptypes.QUIC:
+		return TypeSQUICR
+	case tptypes.WEBRTC:
+		return TypeWEBRTC
+	case tptypes.WT:
+		return TypeSWTR
+	case tptypes.WS:
+		return TypeSWSR
+	default:
+		return TypeUnknown
+	}
+}
+
+// CodeToType maps an enum code back to its canonical transport-type wire
+// string. TypeUnknown (0) and any unrecognized code yield "" — the same
+// value the legacy empty-type path used to signal "skip uptime".
+func CodeToType(c uint8) string {
+	switch c {
+	case TypeSTCPR:
+		return string(tptypes.STCPR)
+	case TypeSUDPH:
+		return string(tptypes.SUDPH)
+	case TypeSTCP:
+		return string(tptypes.STCP)
+	case TypeDMSG:
+		return string(tptypes.DMSG)
+	case TypeSQUICR:
+		return string(tptypes.QUIC)
+	case TypeWEBRTC:
+		return string(tptypes.WEBRTC)
+	case TypeSWTR:
+		return string(tptypes.WT)
+	case TypeSWSR:
+		return string(tptypes.WS)
+	default:
+		return ""
+	}
+}
+
+// EncodeShard packs entries into one shard blob. The caller is
+// responsible for passing only entries that belong to shard (ShardOf ==
+// shard); the shard byte is written to the header verbatim. Entry order
+// is preserved, so a caller that wants a byte-stable blob for change
+// detection should sort entries by ID first.
+func EncodeShard(shard uint8, entries []Entry) []byte {
+	// count is a uint16 field; a shard holds ~1/16 of a hub's transports, so
+	// this ceiling is astronomically above any real fleet, but clamp anyway
+	// so the header can never disagree with the body.
+	if len(entries) > 0xFFFF {
+		entries = entries[:0xFFFF]
+	}
+	buf := make([]byte, headerLen+entryLen*len(entries))
+	buf[0] = Version
+	buf[1] = shard
+	binary.LittleEndian.PutUint16(buf[2:4], uint16(len(entries))) //nolint:gosec // clamped to 0xFFFF above
+	off := headerLen
+	for _, e := range entries {
+		copy(buf[off:off+16], e.ID[:])
+		binary.LittleEndian.PutUint64(buf[off+16:off+24], e.SentBytes)
+		binary.LittleEndian.PutUint64(buf[off+24:off+32], e.RecvBytes)
+		binary.LittleEndian.PutUint32(buf[off+32:off+36], math.Float32bits(e.ThroughputBps))
+		binary.LittleEndian.PutUint32(buf[off+36:off+40], math.Float32bits(e.LatMin))
+		binary.LittleEndian.PutUint32(buf[off+40:off+44], math.Float32bits(e.LatMax))
+		binary.LittleEndian.PutUint32(buf[off+44:off+48], math.Float32bits(e.LatAvg))
+		binary.LittleEndian.PutUint32(buf[off+48:off+52], e.SampledAtUnix)
+		buf[off+52] = e.Type
+		off += entryLen
+	}
+	return buf
+}
+
+// DecodeShard parses a shard blob produced by EncodeShard. It validates
+// the version byte, the shard range, and that the total length matches
+// the declared count exactly — a truncated or over-long blob is rejected
+// rather than partially parsed.
+func DecodeShard(b []byte) (shard uint8, entries []Entry, err error) {
+	if len(b) < headerLen {
+		return 0, nil, ErrShort
+	}
+	if b[0] != Version {
+		return 0, nil, fmt.Errorf("%w: got 0x%02x want 0x%02x", ErrVersion, b[0], Version)
+	}
+	shard = b[1]
+	if shard >= ShardCount {
+		return 0, nil, fmt.Errorf("%w: %d", ErrShardRange, shard)
+	}
+	count := int(binary.LittleEndian.Uint16(b[2:4]))
+	if len(b) != headerLen+entryLen*count {
+		return 0, nil, fmt.Errorf("%w: len=%d count=%d", ErrLengthMismatch, len(b), count)
+	}
+	if count == 0 {
+		return shard, nil, nil
+	}
+	entries = make([]Entry, count)
+	off := headerLen
+	for i := 0; i < count; i++ {
+		var e Entry
+		copy(e.ID[:], b[off:off+16])
+		e.SentBytes = binary.LittleEndian.Uint64(b[off+16 : off+24])
+		e.RecvBytes = binary.LittleEndian.Uint64(b[off+24 : off+32])
+		e.ThroughputBps = math.Float32frombits(binary.LittleEndian.Uint32(b[off+32 : off+36]))
+		e.LatMin = math.Float32frombits(binary.LittleEndian.Uint32(b[off+36 : off+40]))
+		e.LatMax = math.Float32frombits(binary.LittleEndian.Uint32(b[off+40 : off+44]))
+		e.LatAvg = math.Float32frombits(binary.LittleEndian.Uint32(b[off+44 : off+48]))
+		e.SampledAtUnix = binary.LittleEndian.Uint32(b[off+48 : off+52])
+		e.Type = b[off+52] //nolint:gosec // length validated above: len(b) == headerLen+entryLen*count
+		entries[i] = e
+		off += entryLen
+	}
+	return shard, entries, nil
+}

--- a/pkg/telemetrywire/telemetrywire_test.go
+++ b/pkg/telemetrywire/telemetrywire_test.go
@@ -1,0 +1,194 @@
+package telemetrywire
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+func sampleEntry(seed byte) Entry {
+	var id uuid.UUID
+	for i := range id {
+		id[i] = seed + byte(i)
+	}
+	return Entry{
+		ID:            id,
+		SentBytes:     0x1122334455667788,
+		RecvBytes:     0x8877665544332211,
+		ThroughputBps: 123456.75,
+		LatMin:        1.5,
+		LatMax:        250.25,
+		LatAvg:        42.125,
+		SampledAtUnix: 0x5F5E1000,
+		Type:          TypeSTCPR,
+	}
+}
+
+func TestShardOf(t *testing.T) {
+	var id uuid.UUID
+	id[0] = 0xA7 // high nibble 0xA = 10
+	if got := ShardOf(id); got != 0x0A {
+		t.Fatalf("ShardOf = %d, want 10", got)
+	}
+	id[0] = 0x0F
+	if got := ShardOf(id); got != 0 {
+		t.Fatalf("ShardOf = %d, want 0", got)
+	}
+	for sh := uint8(0); sh < ShardCount; sh++ {
+		id[0] = sh << 4
+		if got := ShardOf(id); got != sh {
+			t.Fatalf("ShardOf(byte0=%#x) = %d, want %d", id[0], got, sh)
+		}
+	}
+}
+
+func TestLeafPath(t *testing.T) {
+	cases := map[uint8]string{
+		0:  "transports/telemetry/00",
+		1:  "transports/telemetry/01",
+		10: "transports/telemetry/0a",
+		15: "transports/telemetry/0f",
+	}
+	for sh, want := range cases {
+		if got := LeafPath(sh); got != want {
+			t.Errorf("LeafPath(%d) = %q, want %q", sh, got, want)
+		}
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	for _, count := range []int{0, 1, 2, 53, 800} {
+		entries := make([]Entry, count)
+		for i := 0; i < count; i++ {
+			entries[i] = sampleEntry(byte(i))
+		}
+		blob := EncodeShard(7, entries)
+		shard, got, err := DecodeShard(blob)
+		if err != nil {
+			t.Fatalf("count=%d DecodeShard: %v", count, err)
+		}
+		if shard != 7 {
+			t.Fatalf("count=%d shard = %d, want 7", count, shard)
+		}
+		if len(got) != count {
+			t.Fatalf("count=%d decoded %d entries", count, len(got))
+		}
+		for i := range got {
+			if got[i] != entries[i] {
+				t.Fatalf("count=%d entry %d mismatch:\n got=%+v\nwant=%+v", count, i, got[i], entries[i])
+			}
+		}
+	}
+}
+
+func TestThroughputRoundTrips(t *testing.T) {
+	e := sampleEntry(3)
+	e.ThroughputBps = 987654.5
+	_, got, err := DecodeShard(EncodeShard(0, []Entry{e}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].ThroughputBps != 987654.5 {
+		t.Fatalf("throughput = %v, want 987654.5", got[0].ThroughputBps)
+	}
+}
+
+func TestDecodeRejectsCorruptInput(t *testing.T) {
+	valid := EncodeShard(3, []Entry{sampleEntry(1), sampleEntry(2)})
+
+	// Too short for even a header.
+	if _, _, err := DecodeShard([]byte{0x02, 0x00}); err == nil {
+		t.Error("expected ErrShort for 2-byte blob")
+	}
+	// Wrong version byte.
+	bad := append([]byte(nil), valid...)
+	bad[0] = 0x03
+	if _, _, err := DecodeShard(bad); err == nil {
+		t.Error("expected ErrVersion for wrong version")
+	}
+	// Shard out of range.
+	bad = append([]byte(nil), valid...)
+	bad[1] = 0x10
+	if _, _, err := DecodeShard(bad); err == nil {
+		t.Error("expected ErrShardRange for shard 16")
+	}
+	// Truncated body (drop the last entry's worth of bytes minus one).
+	if _, _, err := DecodeShard(valid[:len(valid)-1]); err == nil {
+		t.Error("expected ErrLengthMismatch for truncated blob")
+	}
+	// Over-long body (extra trailing byte).
+	if _, _, err := DecodeShard(append(append([]byte(nil), valid...), 0x00)); err == nil {
+		t.Error("expected ErrLengthMismatch for over-long blob")
+	}
+	// Count claims more entries than bytes present.
+	shortCount := append([]byte(nil), valid...)
+	shortCount[2] = 0xFF
+	shortCount[3] = 0xFF
+	if _, _, err := DecodeShard(shortCount); err == nil {
+		t.Error("expected ErrLengthMismatch when count exceeds body")
+	}
+}
+
+func TestTypeEnumMapping(t *testing.T) {
+	cases := []struct {
+		s    string
+		code uint8
+	}{
+		{"", TypeUnknown},
+		{"nonsense", TypeUnknown},
+		{string(tptypes.STCPR), TypeSTCPR},
+		{string(tptypes.SUDPH), TypeSUDPH},
+		{string(tptypes.STCP), TypeSTCP},
+		{string(tptypes.DMSG), TypeDMSG},
+		{string(tptypes.QUIC), TypeSQUICR},
+		{string(tptypes.WEBRTC), TypeWEBRTC},
+		{string(tptypes.WT), TypeSWTR},
+		{string(tptypes.WS), TypeSWSR},
+	}
+	for _, c := range cases {
+		if got := TypeToCode(c.s); got != c.code {
+			t.Errorf("TypeToCode(%q) = %d, want %d", c.s, got, c.code)
+		}
+	}
+
+	// Legacy aliases normalize to the canonical code.
+	for _, alias := range []string{"quic", "squic"} {
+		if got := TypeToCode(alias); got != TypeSQUICR {
+			t.Errorf("TypeToCode(%q) = %d, want squicr code %d", alias, got, TypeSQUICR)
+		}
+	}
+	if got := TypeToCode("wt"); got != TypeSWTR {
+		t.Errorf("TypeToCode(wt) = %d, want %d", got, TypeSWTR)
+	}
+	if got := TypeToCode("ws"); got != TypeSWSR {
+		t.Errorf("TypeToCode(ws) = %d, want %d", got, TypeSWSR)
+	}
+
+	// CodeToType is the inverse over the known codes; 0 and unknown → "".
+	roundtrip := []uint8{TypeSTCPR, TypeSUDPH, TypeSTCP, TypeDMSG, TypeSQUICR, TypeWEBRTC, TypeSWTR, TypeSWSR}
+	for _, code := range roundtrip {
+		if TypeToCode(CodeToType(code)) != code {
+			t.Errorf("code %d did not round-trip through CodeToType→TypeToCode", code)
+		}
+	}
+	if CodeToType(TypeUnknown) != "" {
+		t.Error("CodeToType(0) should be empty string")
+	}
+	if CodeToType(200) != "" {
+		t.Error("CodeToType(unknown) should be empty string")
+	}
+}
+
+// TestEncodedSizeIsShardStable proves the blob length is header + 53*count,
+// the fixed record size the wire spec pins.
+func TestEncodedSizeIsShardStable(t *testing.T) {
+	for _, count := range []int{0, 1, 5, 100} {
+		entries := make([]Entry, count)
+		blob := EncodeShard(0, entries)
+		if want := headerLen + entryLen*count; len(blob) != want {
+			t.Errorf("count=%d blob len = %d, want %d", count, len(blob), want)
+		}
+	}
+}

--- a/pkg/visor/cxo_user_feeds.go
+++ b/pkg/visor/cxo_user_feeds.go
@@ -28,6 +28,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/telemetrywire"
 	"github.com/skycoin/skywire/pkg/visor/logserver"
 )
 
@@ -236,10 +237,12 @@ type CXOFeedState struct {
 	Port uint16 `json:"port,omitempty"`
 	treestore.PublishState
 	// CurrentLeaves is populated only for the "stats" telemetry feed: it
-	// breaks down the transports/<id>/current leaves the feed carries by
-	// whether each leaf's transport is currently live. Dead > 0 quantifies
-	// the stale-leaf bloat that Fix 1 (pruneDeadCurrentLeaves) removes at
-	// startup and reconcileCurrentLeaves keeps out at steady state.
+	// reports the count of per-transport telemetry rows the feed carries
+	// across its ≤16 compact sharded leaves (transports/telemetry/<sh>).
+	// With the sharded shape every packed row is a LIVE transport (the
+	// sampler re-encodes each shard from the live set every tick), so Live
+	// == Total and Dead is structurally 0 — the stale-leaf bloat the old
+	// per-transport `current` format accumulated no longer exists.
 	CurrentLeaves *CurrentLeafStats `json:"current_leaves,omitempty"`
 	// Allowlist is the set of PKs currently permitted to subscribe to this
 	// feed (nil = OPEN to all). For a service-consumed feed (stats,
@@ -263,29 +266,37 @@ type DeniedSubscriber struct {
 }
 
 // CurrentLeafStats is the live/dead breakdown of the telemetry feed's
-// transports/<id>/current leaf set, computed as the feed's current-leaf
-// path list intersected with the visor's live transport set.
+// per-transport telemetry rows, decoded from the compact sharded leaves
+// (transports/telemetry/<sh>). Each row is classified by whether its
+// transport is in the visor's live set; with the sharded shape the
+// sampler only ever packs live transports, so Dead is normally 0.
 type CurrentLeafStats struct {
 	Total int `json:"total"`
 	Live  int `json:"live"`
 	Dead  int `json:"dead"`
 }
 
-// currentLeafStats walks the publisher's transports/<id>/current leaves
-// and classifies each by whether its transport is in liveIDs. Cheap: an
-// in-memory tree walk plus a map lookup per leaf.
+// currentLeafStats walks the publisher's transports/telemetry/<sh> shard
+// leaves, decodes each, and classifies every packed transport row by
+// whether it's in liveIDs. Cheap: ≤16 in-memory leaf decodes plus a map
+// lookup per row.
 func currentLeafStats(pub *treestore.Publisher, liveIDs map[uuid.UUID]struct{}) CurrentLeafStats {
 	var st CurrentLeafStats
-	pub.Walk("transports", func(path string, _ []byte) bool {
-		id, ok := currentLeafUUID(path)
-		if !ok {
+	pub.Walk("transports", func(path string, value []byte) bool {
+		if _, ok := telemetryShardOfPath(path); !ok {
 			return true
 		}
-		st.Total++
-		if _, live := liveIDs[id]; live {
-			st.Live++
-		} else {
-			st.Dead++
+		_, entries, err := telemetrywire.DecodeShard(value)
+		if err != nil {
+			return true
+		}
+		for _, e := range entries {
+			st.Total++
+			if _, live := liveIDs[e.ID]; live {
+				st.Live++
+			} else {
+				st.Dead++
+			}
 		}
 		return true
 	})

--- a/pkg/visor/hypervisor_handlers_routing_tools.go
+++ b/pkg/visor/hypervisor_handlers_routing_tools.go
@@ -288,6 +288,10 @@ func (s *hvCalcStore) UpdateBandwidth(context.Context, string, cipher.PubKey, ui
 func (s *hvCalcStore) UpdateLatency(context.Context, string, float64, float64, float64) error {
 	return nil
 }
+
+func (s *hvCalcStore) UpdateThroughput(context.Context, string, cipher.PubKey, float64) error {
+	return nil
+}
 func (s *hvCalcStore) GetTransportBandwidth(context.Context, uuid.UUID, string, int) ([]tpdstore.BandwidthAggregation, error) {
 	return nil, nil
 }

--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -23,6 +23,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/telemetrywire"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/visor/stats"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
@@ -75,47 +76,53 @@ func initStats(_ context.Context, v *Visor, log *logging.Logger) error {
 	pub, sink := buildStatsPublisher(v, log)
 	var tplistPub *treestore.Publisher
 	if pub != nil {
-		// Only the currently-live transports' `current` leaf may be
-		// broadcast to the discovery feed. bbolt retains records for
-		// recently-closed transports (local /stats history), but pushing
-		// their stale `current` leaves bloats the Root TPD fills over a
-		// short announce conn and starves discovery. Seed the tracker's
-		// mirrored-current set with this same live set so a transport that
-		// dies between hydrate and the first sample is reconciled away.
+		// Only currently-live transports are packed into the telemetry
+		// feed's compact sharded leaves. bbolt retains records for
+		// recently-closed transports (local /stats history), but packing
+		// their stale telemetry would bloat the Root TPD fills over a short
+		// announce conn. Hydrate publishes ≤16 shard leaves from the live
+		// set and returns their signatures, which seed the tracker so the
+		// first sample tick doesn't redundantly re-Put identical shards.
 		liveIDs := liveTransportIDs(v)
-		if err := seedSinkFromStore(store, sink, publishWindow, liveIDs, log); err != nil {
+		shardSigs, err := seedSinkFromStore(store, sink, publishWindow, liveIDs, log)
+		if err != nil {
 			log.WithError(err).Warn("Stats: hydrating CXO publisher from bbolt failed")
 		}
-		tracker.SeedMirroredCurrent(liveIDs)
+		tracker.SeedPublishedShards(shardSigs)
 		// The publisher hydrates its in-memory tree from the previously-
-		// published Root on startup, so transports/<id>/current leaves for
-		// transports that closed while the visor was down are back on the
-		// feed. They never entered the tracker's mirroredCurrent set (which
-		// only tracks leaves Put since this restart), so the per-tick
-		// reconcile would never prune them. Reconcile them away now, at
-		// hydrate, against the actual live set — making the discovery feed
-		// truly live-only rather than "live-only for leaves written since
-		// the last restart".
-		if pruned := pruneDeadCurrentLeaves(pub, sink, liveIDs); pruned > 0 {
+		// published Root on startup. On the FIRST run after upgrading from
+		// the per-transport `current`-leaf format, that Root still holds the
+		// legacy transports/<id>/current leaves (and possibly telemetry
+		// shards for transports now gone). Prune both so the telemetry feed
+		// carries only the freshly-hydrated live shards — the legacy leaves
+		// are never republished (the format is removed) and would otherwise
+		// linger, re-bloating the Root the shape was designed to shrink.
+		if pruned := pruneStaleTelemetryLeaves(pub, sink, liveIDs); pruned > 0 {
 			log.WithField("pruned", pruned).
-				Info("Stats: pruned dead-transport current leaves persisted on the telemetry feed")
+				Info("Stats: pruned stale/legacy telemetry leaves persisted on the feed")
 		}
 		tracker.SetSink(sink)
 
-		// Dedicated tp-list discovery feed: a SECOND CXO node under the
-		// SAME visor identity PK, on DmsgVisorTPListCXOPort, carrying ONLY
-		// the compact transport-list snapshot leaf (publishTPDList). Its
-		// Root is a handful of objects, so TPD's second aggregator fills it
-		// COMPLETELY in ~1 round-trip — the durable cure for the ~10%
-		// transport under-report on busy hubs, whose combined telemetry
-		// Root on `pub` (DmsgCXOPort) can't finish its whole-Root fill in
-		// the announce conn's window. Same PK keeps TPD's reporter=feed-PK
-		// edge-auth intact. The telemetry leaves (transports/<id>/current)
-		// stay on `pub`. If the dedicated publisher can't start, fall back
-		// to publishing the tp-list on the telemetry feed (legacy combined
-		// behavior) so discovery still works — just without the
-		// fill-completeness win.
-		tplistPub = buildTPListPublisher(v, log)
+		// Transport-list discovery leaf. CONSOLIDATED default: the tp-list
+		// snapshot rides THIS telemetry feed (`pub`) as a top-level leaf, so
+		// a visor holds ONE CXO node/conn to TPD, not two. TPD's aggregator
+		// extracts the small tp-list leaf via its targeted discovery-leaf
+		// fetch (reconcileTargeted, on every OnRootReceived) — reliable now
+		// that the sharded telemetry keeps the whole Root small (≈16 shard
+		// leaves + 1 tp-list leaf), the exact condition missing when the
+		// earlier consolidation (#4184) was reverted (#4189) over a bulky
+		// per-transport-leaf Root. This halves the visor↔TPD connection
+		// count (and the per-session dmsg handshakes) versus the two-feed
+		// model.
+		//
+		// Opt back into the dedicated port-69 feed with
+		// Stats.DedicatedTPListFeed=true (a SECOND CXO node under the same
+		// visor PK on DmsgVisorTPListCXOPort) — kept only as a transitional
+		// escape hatch in case a busy hub is ever seen under-filling on the
+		// combined feed.
+		if conf != nil && conf.DedicatedTPListFeed {
+			tplistPub = buildTPListPublisher(v, log)
+		}
 		leafPub := pub
 		if tplistPub != nil {
 			leafPub = tplistPub
@@ -342,22 +349,24 @@ func buildTPListPublisher(v *Visor, log *logging.Logger) *treestore.Publisher {
 	return pub
 }
 
-// seedSinkFromStore copies the in-window slice of bbolt state into
-// the freshly-initialized publisher so cold subscribers see the full
-// rolling window from the first connect, not just data sampled after
-// the visor restarted. Only the `current` snapshot leaves of transports
-// in liveIDs are broadcast (dead-but-retained records stay bbolt-only).
-func seedSinkFromStore(store *stats.Store, sink stats.Sink, publishWindowDays int, liveIDs map[uuid.UUID]struct{}, log *logging.Logger) error {
+// seedSinkFromStore copies the in-window live-transport telemetry from
+// bbolt into the freshly-initialized publisher (as ≤16 compact sharded
+// leaves) so cold subscribers see current telemetry from the first
+// connect, not just data sampled after the visor restarted. Only
+// transports in liveIDs are packed (dead-but-retained records stay
+// bbolt-only). Returns the per-shard signatures pushed, for seeding the
+// tracker's change-gate.
+func seedSinkFromStore(store *stats.Store, sink stats.Sink, publishWindowDays int, liveIDs map[uuid.UUID]struct{}, log *logging.Logger) (map[uint8][32]byte, error) {
 	isLive := func(id uuid.UUID) bool {
 		_, ok := liveIDs[id]
 		return ok
 	}
-	pushed, err := stats.HydrateSink(store, sink, publishWindowDays, time.Now(), isLive)
+	sigs, err := stats.HydrateSink(store, sink, publishWindowDays, time.Now(), isLive)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	log.WithField("paths", pushed).Debug("Stats: hydrated CXO publisher from bbolt")
-	return nil
+	log.WithField("shard_leaves", len(sigs)).Debug("Stats: hydrated CXO publisher from bbolt")
+	return sigs, nil
 }
 
 // liveTransportIDs snapshots the IDs of the visor's currently-live
@@ -393,28 +402,71 @@ func currentLeafUUID(path string) (uuid.UUID, bool) {
 	return id, true
 }
 
-// pruneDeadCurrentLeaves makes the telemetry feed truly live-only at
-// startup. It walks the publisher's existing transports/<id>/current
-// leaves — including any hydrated from the previously-published Root —
-// and sink-deletes every one whose transport isn't in liveIDs. Returns
-// the number pruned.
+// telemetryShardOfPath parses a "transports/telemetry/<sh>" leaf path
+// and returns the shard number. ok is false for any other path. Mirrors
+// telemetrywire.LeafPath's lowercase 2-hex encoding.
+func telemetryShardOfPath(path string) (uint8, bool) {
+	const prefix = "transports/telemetry/"
+	if !strings.HasPrefix(path, prefix) {
+		return 0, false
+	}
+	rest := path[len(prefix):]
+	if len(rest) != 2 {
+		return 0, false
+	}
+	var sh uint8
+	for _, c := range []byte(rest) {
+		var d uint8
+		switch {
+		case c >= '0' && c <= '9':
+			d = c - '0'
+		case c >= 'a' && c <= 'f':
+			d = c - 'a' + 10
+		default:
+			return 0, false
+		}
+		sh = sh<<4 | d
+	}
+	if sh >= telemetrywire.ShardCount {
+		return 0, false
+	}
+	return sh, true
+}
+
+// pruneStaleTelemetryLeaves makes the telemetry feed carry only the
+// freshly-hydrated live shards at startup. It walks the publisher's
+// existing "transports" subtree — including anything hydrated from the
+// previously-published Root — and sink-deletes:
 //
-// Deletes are collected during the walk and issued after it returns:
-// Publisher.Walk holds the publisher mutex across the visitor and
-// sink.Delete re-enters that mutex through the cxoSink, so deleting
-// inline would deadlock.
-func pruneDeadCurrentLeaves(pub *treestore.Publisher, sink stats.Sink, liveIDs map[uuid.UUID]struct{}) int {
+//   - every LEGACY transports/<uuid>/current leaf (the pre-shard format,
+//     which the visor no longer republishes — left in place it would
+//     re-bloat the Root the sharded shape exists to shrink), and
+//   - every transports/telemetry/<sh> shard leaf whose shard has NO live
+//     transport now (so a shard that emptied while the visor was down
+//     doesn't linger).
+//
+// Returns the number pruned. Deletes are collected during the walk and
+// issued after it returns: Publisher.Walk holds the publisher mutex
+// across the visitor and sink.Delete re-enters that mutex through the
+// cxoSink, so deleting inline would deadlock.
+func pruneStaleTelemetryLeaves(pub *treestore.Publisher, sink stats.Sink, liveIDs map[uuid.UUID]struct{}) int {
 	if pub == nil || sink == nil {
 		return 0
 	}
+	liveShards := make(map[uint8]struct{})
+	for id := range liveIDs {
+		liveShards[telemetrywire.ShardOf(id)] = struct{}{}
+	}
 	var stale []string
 	pub.Walk("transports", func(path string, _ []byte) bool {
-		id, ok := currentLeafUUID(path)
-		if !ok {
+		if _, ok := currentLeafUUID(path); ok {
+			stale = append(stale, path) // legacy per-transport current leaf
 			return true
 		}
-		if _, live := liveIDs[id]; !live {
-			stale = append(stale, path)
+		if sh, ok := telemetryShardOfPath(path); ok {
+			if _, live := liveShards[sh]; !live {
+				stale = append(stale, path)
+			}
 		}
 		return true
 	})
@@ -549,13 +601,14 @@ func transportsProbe(v *Visor) func() []stats.TransportProbe {
 			bw := tp.GetBandwidth()
 			lat := tp.GetLatencyStats()
 			out = append(out, stats.TransportProbe{
-				ID:        tp.Entry.ID,
-				Edges:     []cipher.PubKey{tp.Entry.Edges[0], tp.Entry.Edges[1]},
-				Type:      string(tp.Entry.Type),
-				Label:     string(tp.Entry.Label),
-				SentBytes: bw.SentBytes,
-				RecvBytes: bw.RecvBytes,
-				LatencyMS: stats.LatencyTriple{Min: lat.Min, Max: lat.Max, Avg: lat.Avg},
+				ID:            tp.Entry.ID,
+				Edges:         []cipher.PubKey{tp.Entry.Edges[0], tp.Entry.Edges[1]},
+				Type:          string(tp.Entry.Type),
+				Label:         string(tp.Entry.Label),
+				SentBytes:     bw.SentBytes,
+				RecvBytes:     bw.RecvBytes,
+				ThroughputBps: tp.GetThroughputBps(),
+				LatencyMS:     stats.LatencyTriple{Min: lat.Min, Max: lat.Max, Avg: lat.Avg},
 			})
 			return true
 		})

--- a/pkg/visor/init_stats_prune_test.go
+++ b/pkg/visor/init_stats_prune_test.go
@@ -1,12 +1,14 @@
 // Package visor pkg/visor/init_stats_prune_test.go
 //
-// Pins the telemetry-feed live-only invariant: after a visor restart the
-// CXO publisher hydrates its in-memory tree from the previously-published
-// Root, bringing back transports/<id>/current leaves for transports that
-// closed while the visor was down. pruneDeadCurrentLeaves must reconcile
-// every such dead leaf away at startup — not just the ones (re-)written
-// since the restart — so the discovery feed TPD fills stays truly
-// live-only and doesn't accumulate stale-transport bloat across reboots.
+// Pins the telemetry-feed startup-prune invariant for the sharded wire
+// format: after a visor restart the CXO publisher hydrates its in-memory
+// tree from the previously-published Root. On the first run after
+// upgrading from the per-transport `current`-leaf format that Root still
+// holds LEGACY transports/<id>/current leaves (never republished now), and
+// it may hold telemetry shards for transports that have since gone away.
+// pruneStaleTelemetryLeaves must delete every legacy current leaf plus any
+// shard with no live transport, leaving only the freshly-hydrated live
+// shards so the feed TPD fills stays small.
 package visor
 
 import (
@@ -20,34 +22,48 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/telemetrywire"
 )
 
 func currentPath(id uuid.UUID) string { return "transports/" + id.String() + "/current" }
 
-func TestPruneDeadCurrentLeavesAfterHydrate(t *testing.T) {
+// uuidInShard returns a UUID whose telemetrywire shard is exactly shard.
+func uuidInShard(shard uint8) uuid.UUID {
+	id := uuid.New()
+	id[0] = shard << 4
+	return id
+}
+
+func TestPruneStaleTelemetryLeavesAfterHydrate(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "cxo-stats")
 	_, sk := cipher.GenerateKeyPair()
-	log := logging.MustGetLogger("test-stats-prune")
 
-	live1, live2 := uuid.New(), uuid.New()
-	dead1, dead2 := uuid.New(), uuid.New()
+	liveID := uuidInShard(1)      // in a live shard — its shard leaf must stay
+	deadShardID := uuidInShard(2) // packed into a shard with no live transport
+	legacy1, legacy2 := uuid.New(), uuid.New()
 
-	// Session 1: publish two live + two dead current leaves, then close so
-	// the Root persists to the on-disk CXO container.
+	encShard := func(id uuid.UUID) []byte {
+		sh := telemetrywire.ShardOf(id)
+		return telemetrywire.EncodeShard(sh, []telemetrywire.Entry{{ID: id, SentBytes: 1, Type: telemetrywire.TypeSTCPR}})
+	}
+
+	// Session 1: publish a live shard, a dead-only shard, and two legacy
+	// per-transport current leaves; close so the Root persists on disk.
 	pub1, err := treestore.NewWithTCP("127.0.0.1:0", sk, treestore.PubConfig{
 		DataDir:     dir,
 		BatchWindow: 5 * time.Millisecond,
 	})
 	require.NoError(t, err, "session 1 publisher")
-	for _, id := range []uuid.UUID{live1, live2, dead1, dead2} {
+	require.NoError(t, pub1.Put(telemetrywire.LeafPath(telemetrywire.ShardOf(liveID)), encShard(liveID)))
+	require.NoError(t, pub1.Put(telemetrywire.LeafPath(telemetrywire.ShardOf(deadShardID)), encShard(deadShardID)))
+	for _, id := range []uuid.UUID{legacy1, legacy2} {
 		require.NoError(t, pub1.Put(currentPath(id), []byte(`{"sent_bytes":1}`)))
 	}
 	require.NoError(t, pub1.Flush())
 	require.NoError(t, pub1.Close())
 
-	// Session 2: reopen the same DataDir. hydrateFromContainer rebuilds the
-	// in-memory tree with all four current leaves — the post-restart state
-	// in which dead1/dead2 belong to transports that are no longer live.
+	// Session 2: reopen the same DataDir — hydrate rebuilds the tree with all
+	// leaves, the post-restart state to prune.
 	pub2, err := treestore.NewWithTCP("127.0.0.1:0", sk, treestore.PubConfig{
 		DataDir:     dir,
 		BatchWindow: 5 * time.Millisecond,
@@ -55,25 +71,28 @@ func TestPruneDeadCurrentLeavesAfterHydrate(t *testing.T) {
 	require.NoError(t, err, "session 2 publisher")
 	defer func() { _ = pub2.Close() }() //nolint:errcheck // best-effort teardown
 
-	// Sanity: hydrate brought all four leaves back onto the feed.
-	sink := &cxoSink{pub: pub2, log: log}
-	liveIDs := map[uuid.UUID]struct{}{live1: {}, live2: {}}
-	require.Equal(t, CurrentLeafStats{Total: 4, Live: 2, Dead: 2},
-		currentLeafStats(pub2, liveIDs), "all four current leaves present after hydrate")
+	sink := &cxoSink{pub: pub2, log: logging.MustGetLogger("test-stats-prune")}
+	liveIDs := map[uuid.UUID]struct{}{liveID: {}}
 
-	// Prune against the actual live set.
-	require.Equal(t, 2, pruneDeadCurrentLeaves(pub2, sink, liveIDs), "both dead leaves pruned")
+	// Sanity: the shard leaves decode; the live shard's row is live, the
+	// dead shard's row is dead. (Legacy current leaves are not shard leaves,
+	// so currentLeafStats — now shard-based — doesn't count them.)
+	require.Equal(t, CurrentLeafStats{Total: 2, Live: 1, Dead: 1},
+		currentLeafStats(pub2, liveIDs), "one live + one dead shard row after hydrate")
 
-	// Only the live leaves remain.
-	require.Equal(t, CurrentLeafStats{Total: 2, Live: 2, Dead: 0},
-		currentLeafStats(pub2, liveIDs), "only live current leaves remain after prune")
-	for _, id := range []uuid.UUID{live1, live2} {
+	// Prune: both legacy current leaves + the dead-only shard = 3 deletes.
+	require.Equal(t, 3, pruneStaleTelemetryLeaves(pub2, sink, liveIDs))
+
+	// Only the live shard leaf remains.
+	require.Equal(t, CurrentLeafStats{Total: 1, Live: 1, Dead: 0},
+		currentLeafStats(pub2, liveIDs), "only the live shard remains after prune")
+	_, ok := pub2.Get(telemetrywire.LeafPath(telemetrywire.ShardOf(liveID)))
+	require.True(t, ok, "live shard leaf should remain")
+	_, ok = pub2.Get(telemetrywire.LeafPath(telemetrywire.ShardOf(deadShardID)))
+	require.False(t, ok, "dead-only shard leaf should be pruned")
+	for _, id := range []uuid.UUID{legacy1, legacy2} {
 		_, ok := pub2.Get(currentPath(id))
-		require.True(t, ok, "live leaf %s should remain", id)
-	}
-	for _, id := range []uuid.UUID{dead1, dead2} {
-		_, ok := pub2.Get(currentPath(id))
-		require.False(t, ok, "dead leaf %s should be pruned", id)
+		require.False(t, ok, "legacy current leaf %s should be pruned", id)
 	}
 }
 
@@ -92,5 +111,24 @@ func TestCurrentLeafUUIDParsing(t *testing.T) {
 	} {
 		_, ok := currentLeafUUID(bad)
 		require.False(t, ok, "path %q must not parse as a current leaf", bad)
+	}
+}
+
+func TestTelemetryShardOfPathParsing(t *testing.T) {
+	for shard := uint8(0); shard < telemetrywire.ShardCount; shard++ {
+		got, ok := telemetryShardOfPath(telemetrywire.LeafPath(shard))
+		require.True(t, ok, "shard %d path must parse", shard)
+		require.Equal(t, shard, got)
+	}
+	for _, bad := range []string{
+		"transports/telemetry/",
+		"transports/telemetry/0",
+		"transports/telemetry/1g",
+		"transports/telemetry/100",
+		"transports/telemetry/AA", // uppercase not emitted
+		"transports/list",
+	} {
+		_, ok := telemetryShardOfPath(bad)
+		require.False(t, ok, "path %q must not parse as a shard leaf", bad)
 	}
 }

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -998,6 +998,10 @@ func (s *calcMemStore) UpdateBandwidth(context.Context, string, cipher.PubKey, u
 func (s *calcMemStore) UpdateLatency(context.Context, string, float64, float64, float64) error {
 	return nil
 }
+
+func (s *calcMemStore) UpdateThroughput(context.Context, string, cipher.PubKey, float64) error {
+	return nil
+}
 func (s *calcMemStore) GetTransportBandwidth(context.Context, uuid.UUID, string, int) ([]tpdstore.BandwidthAggregation, error) {
 	return nil, nil
 }

--- a/pkg/visor/stats/schema.go
+++ b/pkg/visor/stats/schema.go
@@ -40,13 +40,20 @@ type TransportRecord struct {
 // field was added — TPD treats that as "skip uptime, but bandwidth
 // and latency still apply" so old visors keep working.
 type LiveSnapshot struct {
-	SentBytes    uint64    `json:"sent_bytes"`
-	RecvBytes    uint64    `json:"recv_bytes"`
-	LatencyMinMS float64   `json:"latency_min_ms,omitempty"`
-	LatencyMaxMS float64   `json:"latency_max_ms,omitempty"`
-	LatencyAvgMS float64   `json:"latency_avg_ms,omitempty"`
-	SampledAt    time.Time `json:"sampled_at"`
-	Type         string    `json:"type,omitempty"`
+	SentBytes uint64 `json:"sent_bytes"`
+	RecvBytes uint64 `json:"recv_bytes"`
+	// ThroughputBps is the transport's passively-observed PEAK goodput
+	// (a tracked EWMA of sent+recv bytes/sec), sourced from
+	// transport.ManagedTransport.GetThroughputBps(). It is a real
+	// capacity metric NOT derivable from the cumulative SentBytes/RecvBytes
+	// counters (those give average-over-interval; this is the tracked
+	// peak), so it is carried alongside them on the telemetry feed.
+	ThroughputBps float64   `json:"throughput_bps,omitempty"`
+	LatencyMinMS  float64   `json:"latency_min_ms,omitempty"`
+	LatencyMaxMS  float64   `json:"latency_max_ms,omitempty"`
+	LatencyAvgMS  float64   `json:"latency_avg_ms,omitempty"`
+	SampledAt     time.Time `json:"sampled_at"`
+	Type          string    `json:"type,omitempty"`
 }
 
 // DailyRollup is the sealed per-day view. Bandwidth values are deltas

--- a/pkg/visor/stats/sink.go
+++ b/pkg/visor/stats/sink.go
@@ -11,11 +11,15 @@
 //
 // Path conventions (matching §07 of skywire-specs):
 //
-//	transports/<uuid>/current                 → live snapshot (JSON)
-//	transports/<uuid>/<YYYY-MM-DD>/rollup     → that day's rollup (JSON)
-//	transports/<uuid>/<YYYY-MM-DD>/timeline   → 36-byte uptime bitmap
-//	tiers/<tier>/<YYYY-MM-DD>                 → 36-byte bitmap
-//	services/<slug>/<YYYY-MM-DD>              → 36-byte bitmap
+//	transports/telemetry/<sh>                 → compact sharded binary
+//	                                            telemetry (see pkg/telemetrywire;
+//	                                            <sh> = 2-hex shard 00..0f, the
+//	                                            only per-transport telemetry now
+//	                                            mirrored to the CXO/TPD feed)
+//	transports/<uuid>/<YYYY-MM-DD>/rollup     → that day's rollup (JSON, bbolt-only)
+//	transports/<uuid>/<YYYY-MM-DD>/timeline   → 36-byte uptime bitmap (bbolt-only)
+//	tiers/<tier>/<YYYY-MM-DD>                 → 36-byte bitmap (bbolt-only)
+//	services/<slug>/<YYYY-MM-DD>              → 36-byte bitmap (bbolt-only)
 //
 // The rollup and timeline are nested under <YYYY-MM-DD> as siblings.
 // Putting the daily JSON at the bare-date leaf ("transports/<uuid>/<date>")
@@ -29,11 +33,14 @@
 package stats
 
 import (
-	"encoding/json"
+	"bytes"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/telemetrywire"
 )
 
 // SinkOp is a single (path, value) pair for a batched Put. A nil
@@ -85,33 +92,35 @@ func (t *Tracker) SetSink(s Sink) {
 	t.sink = s
 }
 
-// HydrateSink walks the entire bbolt store and pushes every entry
-// within the CXO publish window (the trailing publishWindowDays from
-// now) to the sink. Used at startup to seed the publisher's
-// in-memory tree from on-disk state so cold subscribers see the full
-// rolling window immediately, not just samples taken after restart.
+// HydrateSink walks the entire bbolt store and pushes the live-transport
+// telemetry within the CXO publish window (the trailing publishWindowDays
+// from now) to the sink as compact sharded binary leaves. Used at startup
+// to seed the publisher's in-memory tree from on-disk state so cold
+// subscribers see the current telemetry immediately, not just samples
+// taken after restart.
 //
-// isLive gates which transports' `current` snapshot leaf is broadcast:
-// only transports still live at hydrate time are pushed. The bbolt
-// store retains records for recently-closed transports (inside the
-// retention window) so the visor's own /stats history stays complete,
-// but those dead records must NOT be mirrored to the CXO/TPD discovery
-// feed — every stale `current` leaf bloats the Root that TPD fills over
-// a short-lived announce conn, breaking the fill and starving discovery
-// (only the top slice of transports lands). A nil predicate means "all
-// records are live" (used by tests that don't exercise the live gate).
+// isLive gates which transports are broadcast: only transports still live
+// at hydrate time are packed into the shards. The bbolt store retains
+// records for recently-closed transports (inside the retention window) so
+// the visor's own /stats history stays complete, but those dead records
+// must NOT be mirrored to the CXO/TPD telemetry feed — packing them would
+// bloat the Root that TPD fills over a short-lived announce conn. A nil
+// predicate means "all records are live" (used by tests that don't
+// exercise the live gate).
 //
-// Returns the number of paths pushed.
-func HydrateSink(store *Store, sink Sink, publishWindowDays int, now time.Time, isLive func(id uuid.UUID) bool) (int, error) {
+// Returns the shard-signature map actually pushed (keyed by shard 0..15),
+// which the caller uses to seed the Tracker's publishedShards so the first
+// sample tick doesn't redundantly re-Put identical shards. The number of
+// leaves pushed is len(the returned map).
+func HydrateSink(store *Store, sink Sink, publishWindowDays int, now time.Time, isLive func(id uuid.UUID) bool) (map[uint8][32]byte, error) {
 	if publishWindowDays <= 0 {
-		return 0, nil
+		return nil, nil
 	}
-	pushed := 0
 
-	// Push ONLY current per-transport snapshots to the CXO sink, and only for
-	// LIVE transports (see isLive above). TPD is a discovery service: the feed
-	// it fills over the short announce conn must stay small (transports/list +
-	// transports/<id>/current), so it can be fetched reliably. Historical
+	// Pack ONLY live transports' current telemetry into the 16 fixed shards
+	// (see isLive above). TPD needs only the tp-list discovery leaf plus the
+	// compact sharded telemetry, so the feed it fills over the short announce
+	// conn stays small (≤16 shard leaves + the tp-list leaf). Historical
 	// telemetry — daily rollups, tier/service bitmaps, and per-transport
 	// timeline bitmaps — remains bbolt-only for the visor's own /stats +
 	// `visor state`; re-broadcasting days of history grew the Root to ~23k
@@ -119,25 +128,53 @@ func HydrateSink(store *Store, sink Sink, publishWindowDays int, now time.Time, 
 	// own uptime history from what it observes each cycle.
 	records, err := store.AllTransportRecords()
 	if err != nil {
-		return pushed, fmt.Errorf("hydrate transports: %w", err)
+		return nil, fmt.Errorf("hydrate transports: %w", err)
 	}
+	byShard := make(map[uint8][]telemetrywire.Entry, telemetrywire.ShardCount)
 	for _, rec := range records {
-		if rec.Current != nil && (isLive == nil || isLive(rec.ID)) {
-			if data, err := json.Marshal(rec.Current); err == nil {
-				sink.Put(currentTransportPath(rec.ID.String()), data)
-				pushed++
-			}
+		if rec.Current == nil || (isLive != nil && !isLive(rec.ID)) {
+			continue
+		}
+		sh := telemetrywire.ShardOf(rec.ID)
+		byShard[sh] = append(byShard[sh], snapshotToEntry(rec.ID, rec.Current))
+	}
+	sigs := make(map[uint8][32]byte, len(byShard))
+	for sh, es := range byShard {
+		sort.Slice(es, func(i, j int) bool {
+			return bytes.Compare(es[i].ID[:], es[j].ID[:]) < 0
+		})
+		sink.Put(telemetrywire.LeafPath(sh), telemetrywire.EncodeShard(sh, es))
+		sigs[sh] = shardSig(es)
+	}
+	return sigs, nil
+}
+
+// snapshotToEntry maps a LiveSnapshot (float64 latency, time.Time
+// sampled-at, string type) onto the compact wire Entry (float32 latency,
+// unix-seconds sampled-at, enum type). Shared by HydrateSink and the
+// sampler so both sides build identical entries.
+func snapshotToEntry(id uuid.UUID, s *LiveSnapshot) telemetrywire.Entry {
+	var sampled uint32
+	if !s.SampledAt.IsZero() {
+		if u := s.SampledAt.Unix(); u > 0 {
+			sampled = uint32(u) //nolint:gosec // unix seconds fit uint32 until 2106
 		}
 	}
-	return pushed, nil
+	return telemetrywire.Entry{
+		ID:            id,
+		SentBytes:     s.SentBytes,
+		RecvBytes:     s.RecvBytes,
+		ThroughputBps: float32(s.ThroughputBps),
+		LatMin:        float32(s.LatencyMinMS),
+		LatMax:        float32(s.LatencyMaxMS),
+		LatAvg:        float32(s.LatencyAvgMS),
+		SampledAtUnix: sampled,
+		Type:          telemetrywire.TypeToCode(s.Type),
+	}
 }
 
 // Path builders. Centralized so the sink consumers and the publisher
 // always agree on the wire shape.
-
-func currentTransportPath(id string) string {
-	return "transports/" + id + "/current"
-}
 
 func dailyTransportPath(id, date string) string {
 	return "transports/" + id + "/" + date + "/rollup"

--- a/pkg/visor/stats/sink_test.go
+++ b/pkg/visor/stats/sink_test.go
@@ -3,12 +3,46 @@ package stats
 import (
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/telemetrywire"
 )
+
+// uuidInShard returns a UUID whose telemetrywire shard (byte0>>4) is
+// exactly shard, so a test can place each transport alone in its own
+// shard for deterministic per-shard leaf assertions.
+func uuidInShard(shard uint8) uuid.UUID {
+	id := uuid.New()
+	id[0] = shard << 4 // high nibble = shard, low nibble 0
+	return id
+}
+
+// shardEntries decodes every transports/telemetry/<sh> leaf in the sink
+// snapshot and returns the packed entries keyed by transport ID, plus the
+// set of shard-leaf paths present.
+func shardEntries(puts map[string][]byte) (map[uuid.UUID]telemetrywire.Entry, map[string]struct{}) {
+	entries := make(map[uuid.UUID]telemetrywire.Entry)
+	paths := make(map[string]struct{})
+	for path, v := range puts {
+		if !strings.HasPrefix(path, "transports/telemetry/") {
+			continue
+		}
+		paths[path] = struct{}{}
+		_, es, err := telemetrywire.DecodeShard(v)
+		if err != nil {
+			continue
+		}
+		for _, e := range es {
+			entries[e.ID] = e
+		}
+	}
+	return entries, paths
+}
 
 // recordingSink captures every Put and Delete call so tests can
 // assert on the post-sample mirror state. Concurrency-safe so it can
@@ -125,13 +159,21 @@ func TestSinkReceivesTransportPutsOnSample(t *testing.T) {
 	tr.sample(day)
 
 	puts, _ := sink.snapshot()
-	wantCurrent := "transports/" + id.String() + "/current"
-	if _, ok := puts[wantCurrent]; !ok {
-		t.Errorf("missing %s in sink puts; got %v", wantCurrent, keysOf(puts))
+	wantShard := telemetrywire.LeafPath(telemetrywire.ShardOf(id))
+	if _, ok := puts[wantShard]; !ok {
+		t.Errorf("missing shard leaf %s in sink puts; got %v", wantShard, keysOf(puts))
+	}
+	entries, _ := shardEntries(puts)
+	e, ok := entries[id]
+	if !ok {
+		t.Fatalf("transport %s not packed into any shard leaf; got %v", id, keysOf(puts))
+	}
+	if e.SentBytes != 1000 || e.RecvBytes != 500 {
+		t.Errorf("packed entry bytes = %d/%d, want 1000/500", e.SentBytes, e.RecvBytes)
 	}
 	// The daily rollup is persisted to bbolt but intentionally NOT mirrored to
 	// the CXO sink (no subscriber consumes it; it would only steal fill budget
-	// from transports/list on the announce conn). It must be absent here.
+	// from the discovery leaf on the announce conn). It must be absent here.
 	dontWantDaily := "transports/" + id.String() + "/2026-04-27/rollup"
 	if _, ok := puts[dontWantDaily]; ok {
 		t.Errorf("rollup %s should NOT be published to the CXO sink; got %v", dontWantDaily, keysOf(puts))
@@ -267,33 +309,34 @@ func TestSinkDeletedOnBboltRetentionDrop(t *testing.T) {
 	}
 }
 
-// TestSinkDeletesCurrentWhenTransportGoesDead drives two live
-// transports through a sample (both publish a current leaf), then a
-// second sample where one has closed (probe no longer returns it). The
-// closed transport's current leaf must be sink-Deleted; the still-live
-// one's must remain and never be deleted.
-func TestSinkDeletesCurrentWhenTransportGoesDead(t *testing.T) {
+// TestSinkDeletesShardWhenTransportGoesDead drives two live transports
+// (each alone in its own shard) through a sample, then a second sample
+// where one has closed (probe no longer returns it). The closed
+// transport's now-empty shard leaf must be sink-Deleted; the still-live
+// one's shard remains and is never deleted.
+func TestSinkDeletesShardWhenTransportGoesDead(t *testing.T) {
 	sink := newRecordingSink()
 	tr := newTrackerWithSink(t, sink)
-	live := uuid.New()
-	dying := uuid.New()
+	live := uuidInShard(1)
+	dying := uuidInShard(2)
+	liveLeaf := telemetrywire.LeafPath(telemetrywire.ShardOf(live))
+	dyingLeaf := telemetrywire.LeafPath(telemetrywire.ShardOf(dying))
 	t0 := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 
-	probe := func() []TransportProbe {
+	tr.probes.Transports = func() []TransportProbe {
 		return []TransportProbe{
 			{ID: live, Type: "stcpr", SentBytes: 10, RecvBytes: 10},
 			{ID: dying, Type: "stcpr", SentBytes: 20, RecvBytes: 20},
 		}
 	}
-	tr.probes.Transports = probe
 	tr.sample(t0)
 
 	puts, _ := sink.snapshot()
-	if _, ok := puts[currentTransportPath(live.String())]; !ok {
-		t.Fatalf("live current leaf missing after first sample")
+	if _, ok := puts[liveLeaf]; !ok {
+		t.Fatalf("live shard leaf missing after first sample")
 	}
-	if _, ok := puts[currentTransportPath(dying.String())]; !ok {
-		t.Fatalf("dying current leaf missing after first sample")
+	if _, ok := puts[dyingLeaf]; !ok {
+		t.Fatalf("dying shard leaf missing after first sample")
 	}
 
 	// Second sample: `dying` has closed and is no longer in the probe.
@@ -305,56 +348,76 @@ func TestSinkDeletesCurrentWhenTransportGoesDead(t *testing.T) {
 	puts, dels := sink.snapshot()
 	foundDel := false
 	for _, d := range dels {
-		if d == currentTransportPath(dying.String()) {
+		if d == dyingLeaf {
 			foundDel = true
 		}
-		if d == currentTransportPath(live.String()) {
-			t.Errorf("live transport current leaf was deleted; must persist")
+		if d == liveLeaf {
+			t.Errorf("live shard leaf was deleted; must persist")
 		}
 	}
 	if !foundDel {
-		t.Errorf("dead transport current leaf was not sink-deleted; dels=%v", dels)
+		t.Errorf("emptied shard leaf was not sink-deleted; dels=%v", dels)
 	}
-	if _, ok := puts[currentTransportPath(dying.String())]; ok {
-		t.Errorf("dead transport current leaf still present in sink puts")
+	if _, ok := puts[dyingLeaf]; ok {
+		t.Errorf("emptied shard leaf still present in sink puts")
 	}
-	if _, ok := puts[currentTransportPath(live.String())]; !ok {
-		t.Errorf("live transport current leaf missing after second sample")
+	if _, ok := puts[liveLeaf]; !ok {
+		t.Errorf("live shard leaf missing after second sample")
 	}
 }
 
-// TestSeedMirroredCurrentReconcilesStaleLeaf seeds the tracker with an
-// ID that is not in the first sample's live probe (a transport that
-// died between hydrate and the first sample) and asserts its stale
-// current leaf is reconciled away on that first sample.
-func TestSeedMirroredCurrentReconcilesStaleLeaf(t *testing.T) {
+// TestSeedPublishedShardsSuppressesRedundantRePut seeds the tracker with
+// the shard signature the hydrate path already published, then samples
+// the same live set with identical content. The seeded shard must NOT be
+// re-Put — the change-gate matches the seeded signature, mirroring how
+// startup hydrate primes the sink and the first tick doesn't churn it.
+func TestSeedPublishedShardsSuppressesRedundantRePut(t *testing.T) {
 	sink := newRecordingSink()
 	tr := newTrackerWithSink(t, sink)
-	seededDead := uuid.New()
-	live := uuid.New()
-	tr.SeedMirroredCurrent(map[uuid.UUID]struct{}{seededDead: {}})
+	id := uuidInShard(3)
+	shard := telemetrywire.ShardOf(id)
+	leaf := telemetrywire.LeafPath(shard)
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 
+	probe := func() []TransportProbe {
+		return []TransportProbe{{
+			ID: id, Type: "stcpr", SentBytes: 100, RecvBytes: 50,
+			LatencyMS: LatencyTriple{Min: 10, Max: 10, Avg: 10},
+		}}
+	}
+	// Compute the signature hydrate would have published for this exact
+	// content, and seed the tracker with it.
+	seedEntry := telemetrywire.Entry{
+		ID: id, SentBytes: 100, RecvBytes: 50,
+		LatMin: 10, LatMax: 10, LatAvg: 10, Type: telemetrywire.TypeSTCPR,
+	}
+	tr.SeedPublishedShards(map[uint8][32]byte{shard: shardSig([]telemetrywire.Entry{seedEntry})})
+
+	tr.probes.Transports = probe
+	tr.sample(now)
+
+	if n := sink.putCountFor(leaf); n != 0 {
+		t.Errorf("seeded shard was re-Put despite identical content: Put %d times, want 0", n)
+	}
+
+	// A meaningful change now DOES re-Put the shard.
 	tr.probes.Transports = func() []TransportProbe {
-		return []TransportProbe{{ID: live, Type: "stcpr", SentBytes: 1, RecvBytes: 1}}
+		return []TransportProbe{{
+			ID: id, Type: "stcpr", SentBytes: 200, RecvBytes: 50,
+			LatencyMS: LatencyTriple{Min: 10, Max: 10, Avg: 10},
+		}}
 	}
-	tr.sample(time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC))
-
-	_, dels := sink.snapshot()
-	found := false
-	for _, d := range dels {
-		if d == currentTransportPath(seededDead.String()) {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("seeded-dead transport current leaf not reconciled away; dels=%v", dels)
+	tr.sample(now.Add(time.Minute))
+	if n := sink.putCountFor(leaf); n != 1 {
+		t.Errorf("changed shard not re-Put: Put %d times, want 1", n)
 	}
 }
 
-// TestHydrateSinkPushesCurrentOnly asserts the seed path pushes only current
-// per-transport snapshots to the CXO sink — never historical tier/service or
-// timeline bitmaps (those are bbolt-only and would bloat the TPD feed).
-func TestHydrateSinkPushesCurrentOnly(t *testing.T) {
+// TestHydrateSinkPushesShardsOnly asserts the seed path pushes only the
+// compact sharded telemetry leaves to the CXO sink — never historical
+// tier/service or timeline bitmaps (those are bbolt-only and would bloat
+// the TPD feed).
+func TestHydrateSinkPushesShardsOnly(t *testing.T) {
 	store, err := OpenStore(filepath.Join(t.TempDir(), "stats.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -366,11 +429,11 @@ func TestHydrateSinkPushesCurrentOnly(t *testing.T) {
 	}()
 
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
-	// A current transport snapshot (should be pushed) ...
-	id := uuid.New()
+	// A current transport snapshot (should be packed into a shard) ...
+	id := uuidInShard(5)
 	rec := &TransportRecord{
 		ID: id, Type: "stcpr", FirstSeen: now, LastSeen: now,
-		Current: &LiveSnapshot{SentBytes: 10, RecvBytes: 5, SampledAt: now, Type: "stcpr"},
+		Current: &LiveSnapshot{SentBytes: 10, RecvBytes: 5, ThroughputBps: 4242, SampledAt: now, Type: "stcpr"},
 	}
 	if err := store.PutTransportRecord(rec); err != nil {
 		t.Fatal(err)
@@ -381,29 +444,34 @@ func TestHydrateSinkPushesCurrentOnly(t *testing.T) {
 	}
 
 	sink := newRecordingSink()
-	pushed, err := HydrateSink(store, sink, 7, now, nil)
+	sigs, err := HydrateSink(store, sink, 7, now, nil)
 	if err != nil {
 		t.Fatalf("HydrateSink: %v", err)
 	}
-	if pushed != 1 {
-		t.Errorf("pushed = %d, want 1 (only the current snapshot)", pushed)
+	if len(sigs) != 1 {
+		t.Errorf("shard sigs = %d, want 1 (only the one live transport's shard)", len(sigs))
 	}
 	puts, _ := sink.snapshot()
-	if _, ok := puts["transports/"+id.String()+"/current"]; !ok {
-		t.Errorf("current snapshot missing from sink: %v", keysOf(puts))
+	wantLeaf := telemetrywire.LeafPath(telemetrywire.ShardOf(id))
+	if _, ok := puts[wantLeaf]; !ok {
+		t.Errorf("shard leaf %s missing from sink: %v", wantLeaf, keysOf(puts))
 	}
 	for _, p := range keysOf(puts) {
-		if p != "transports/"+id.String()+"/current" {
-			t.Errorf("only current snapshots should be hydrated to the sink; got unexpected %q", p)
+		if p != wantLeaf {
+			t.Errorf("only shard leaves should be hydrated to the sink; got unexpected %q", p)
 		}
+	}
+	entries, _ := shardEntries(puts)
+	if e := entries[id]; e.ThroughputBps != 4242 {
+		t.Errorf("packed throughput = %v, want 4242 (float32)", e.ThroughputBps)
 	}
 }
 
-// TestHydrateSinkPushesLiveTransportsCurrentOnly seeds the store with a
-// mix of live and dead transport records and asserts HydrateSink pushes
-// a `current` leaf for exactly the live set — the dead-but-retained
-// records stay bbolt-only and off the discovery feed.
-func TestHydrateSinkPushesLiveTransportsCurrentOnly(t *testing.T) {
+// TestHydrateSinkPacksLiveTransportsOnly seeds the store with a mix of
+// live and dead transport records and asserts HydrateSink packs exactly
+// the live set into shard leaves — the dead-but-retained records stay
+// bbolt-only and off the discovery feed.
+func TestHydrateSinkPacksLiveTransportsOnly(t *testing.T) {
 	store, err := OpenStore(filepath.Join(t.TempDir(), "stats.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -442,24 +510,69 @@ func TestHydrateSinkPushesLiveTransportsCurrentOnly(t *testing.T) {
 	}
 
 	puts, _ := sink.snapshot()
+	entries, _ := shardEntries(puts)
 	for _, id := range live {
-		if _, ok := puts[currentTransportPath(id.String())]; !ok {
-			t.Errorf("live transport %s: current leaf missing from sink", id)
+		if _, ok := entries[id]; !ok {
+			t.Errorf("live transport %s: not packed into any shard leaf", id)
 		}
 	}
 	for _, id := range dead {
-		if _, ok := puts[currentTransportPath(id.String())]; ok {
-			t.Errorf("dead transport %s: current leaf must NOT be on the sink", id)
+		if _, ok := entries[id]; ok {
+			t.Errorf("dead transport %s: must NOT be packed into the sharded feed", id)
 		}
 	}
-	nCurrent := 0
-	for p := range puts {
-		if len(p) > len("/current") && p[len(p)-len("/current"):] == "/current" {
-			nCurrent++
+	if len(entries) != len(live) {
+		t.Errorf("packed entries = %d, want %d (live only)", len(entries), len(live))
+	}
+}
+
+// TestBusyHubHydratesAtMost16Leaves is the ≤16-leaves proof: a busy hub
+// with 800 live transports must hydrate to at most 16 shard leaves, not
+// 800 per-transport leaves — the whole point of the sharded shape (the
+// Root's telemetry object count no longer scales with the transport
+// count, so TPD's whole-Root fill can complete).
+func TestBusyHubHydratesAtMost16Leaves(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "stats.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := store.Close(); err != nil {
+			t.Logf("store.Close: %v", err)
+		}
+	}()
+
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	const n = 800
+	for i := 0; i < n; i++ {
+		id := uuid.New()
+		rec := &TransportRecord{
+			ID: id, Type: "stcpr", FirstSeen: now, LastSeen: now,
+			Current: &LiveSnapshot{SentBytes: uint64(i), RecvBytes: uint64(i), SampledAt: now, Type: "stcpr"},
+		}
+		if err := store.PutTransportRecord(rec); err != nil {
+			t.Fatalf("PutTransportRecord: %v", err)
 		}
 	}
-	if nCurrent != len(live) {
-		t.Errorf("current leaves pushed = %d, want %d (live only)", nCurrent, len(live))
+
+	sink := newRecordingSink()
+	sigs, err := HydrateSink(store, sink, 7, now, nil)
+	if err != nil {
+		t.Fatalf("HydrateSink: %v", err)
+	}
+	puts, _ := sink.snapshot()
+	entries, shardPaths := shardEntries(puts)
+	if len(shardPaths) > telemetrywire.ShardCount {
+		t.Errorf("hydrated %d leaves, want ≤ %d for %d transports", len(shardPaths), telemetrywire.ShardCount, n)
+	}
+	if len(puts) > telemetrywire.ShardCount {
+		t.Errorf("total sink puts = %d, want ≤ %d (only shard leaves)", len(puts), telemetrywire.ShardCount)
+	}
+	if len(sigs) != len(shardPaths) {
+		t.Errorf("sigs = %d but shard leaves = %d; should match", len(sigs), len(shardPaths))
+	}
+	if len(entries) != n {
+		t.Errorf("packed %d transports across the shards, want %d", len(entries), n)
 	}
 }
 

--- a/pkg/visor/stats/tracker.go
+++ b/pkg/visor/stats/tracker.go
@@ -12,9 +12,11 @@
 package stats
 
 import (
+	"bytes"
 	"context"
-	"encoding/json"
+	"crypto/sha256"
 	"runtime/debug"
+	"sort"
 	"sync"
 	"time"
 
@@ -22,6 +24,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/telemetrywire"
 )
 
 // Tracker periodically samples transport bandwidth/latency and tier
@@ -41,30 +44,19 @@ type Tracker struct {
 	mu        sync.Mutex
 	sink      Sink
 	baselines map[uuid.UUID]bandwidthBaseline
-	// mirroredCurrent is the set of transport IDs whose
-	// transports/<id>/current leaf is currently published to the sink.
-	// Each sample reconciles it against the live probe set: IDs that
-	// dropped out (transport closed) get their current leaf sink-deleted
-	// so the discovery feed reflects only live transports (absence =
-	// dead). Without this, a closed transport's current leaf — published
-	// once while it was live — lingers on the feed for the visor's whole
-	// uptime, accumulating across churn and bloating the Root TPD fills.
-	mirroredCurrent map[uuid.UUID]struct{}
-	// publishedSig records, per transport, the meaningful signature of
-	// the last `current` leaf actually mirrored to the sink (sent/recv
-	// bytes + latency min/max/avg — NOT SampledAt). A sample tick only
-	// re-Puts a transport's current leaf when its signature differs from
-	// the stored one (or it was never published), so an IDLE transport —
-	// whose only change each tick is SampledAt being bumped to now — no
-	// longer advances the telemetry Root. Without this, every live
-	// transport re-Put its leaf every ~60s (SampledAt alone changing the
-	// content hash), churning the whole Root and starving TPD's whole-Root
-	// fill over the short announce conn. Guarded by mu alongside
-	// mirroredCurrent; entries are dropped when a transport dies (see
-	// reconcileCurrentLeaves) so a returning transport republishes.
-	publishedSig map[uuid.UUID]currentSig
-	lastDay      string // YYYY-MM-DD UTC of the most recent sample
-	lastPruned   time.Time
+	// publishedShards records, per shard (0..15), the MEANINGFUL-content
+	// signature of the shard telemetry blob last mirrored to the sink at
+	// transports/telemetry/<sh>. The signature is computed over every
+	// entry's sent/recv/throughput/latency/type — deliberately EXCLUDING
+	// sampled_at (see shardSig) — so a shard whose transports are all idle
+	// (only their timestamps advancing each tick) does NOT re-Put and does
+	// not churn the telemetry Root. A shard is re-Put only when a
+	// meaningful field of one of its transports moves; a shard that goes
+	// empty (all its transports closed) is sink-Deleted and dropped from
+	// this map so it stops occupying the Root. Guarded by mu.
+	publishedShards map[uint8][32]byte
+	lastDay         string // YYYY-MM-DD UTC of the most recent sample
+	lastPruned      time.Time
 
 	cancel context.CancelFunc
 	done   chan struct{}
@@ -95,13 +87,14 @@ type Probes struct {
 // manager — keeping the type local insulates the package from the
 // wider transport API surface.
 type TransportProbe struct {
-	ID        uuid.UUID
-	Edges     []cipher.PubKey
-	Type      string
-	Label     string
-	SentBytes uint64
-	RecvBytes uint64
-	LatencyMS LatencyTriple
+	ID            uuid.UUID
+	Edges         []cipher.PubKey
+	Type          string
+	Label         string
+	SentBytes     uint64
+	RecvBytes     uint64
+	ThroughputBps float64
+	LatencyMS     LatencyTriple
 }
 
 // LatencyTriple carries the live min/max/avg snapshot. Tracker
@@ -114,19 +107,6 @@ type bandwidthBaseline struct {
 	day  string
 	sent uint64
 	recv uint64
-}
-
-// currentSig is the value-driven signature of a transport's `current`
-// leaf: the fields TPD actually consumes. It deliberately excludes
-// SampledAt so that a mere timestamp bump on an otherwise-unchanged
-// (idle) transport does not count as a change and does not trigger a
-// re-Put onto the mirror sink.
-type currentSig struct {
-	sent   uint64
-	recv   uint64
-	latMin float64
-	latMax float64
-	latAvg float64
 }
 
 // Config bundles tracker tunables. Zero values mean "use defaults".
@@ -167,25 +147,24 @@ func NewTracker(store *Store, probes Probes, conf Config) *Tracker {
 		publishKeep:     publishKeep,
 		sink:            noopSink{},
 		baselines:       make(map[uuid.UUID]bandwidthBaseline),
-		mirroredCurrent: make(map[uuid.UUID]struct{}),
-		publishedSig:    make(map[uuid.UUID]currentSig),
+		publishedShards: make(map[uint8][32]byte),
 	}
 }
 
-// SeedMirroredCurrent records the set of transport IDs whose `current`
-// leaf was already pushed to the sink before the sampler started —
-// typically the live set hydrated by HydrateSink at startup. Seeding it
-// means a transport that was live at hydrate but dies before the first
-// sample still gets its stale current leaf reconciled away (deleted) on
-// that first sample, rather than lingering because the sampler never
-// "saw" it live. Call before Run. The passed map is adopted directly.
-func (t *Tracker) SeedMirroredCurrent(ids map[uuid.UUID]struct{}) {
+// SeedPublishedShards records the shard signatures the sink was already
+// primed with before the sampler started — the live set hydrated by
+// HydrateSink at startup (see the visor's seedSinkFromStore). Seeding
+// them means the first sample tick does NOT redundantly re-Put every
+// shard that hydrate already published with identical content; a shard
+// only re-Puts once one of its transports actually changes. Call before
+// Run. The passed map is adopted directly.
+func (t *Tracker) SeedPublishedShards(sigs map[uint8][32]byte) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if ids == nil {
-		ids = make(map[uuid.UUID]struct{})
+	if sigs == nil {
+		sigs = make(map[uint8][32]byte)
 	}
-	t.mirroredCurrent = ids
+	t.publishedShards = sigs
 }
 
 // Store returns the underlying bbolt-backed store. Exposed so HTTP
@@ -292,29 +271,26 @@ func (t *Tracker) sample(now time.Time) {
 		t.runRetention(utc)
 	}
 
-	// mirrors collects (path, bytes) tuples to push to the sink AFTER
-	// the bbolt tx commits. Reading the bitmaps requires the tx
-	// (post-mutation state), so we snapshot them inside and dispatch
-	// outside.
-	var mirrors []mirrorPair
-	// liveTP is the set of transport IDs the probe reported live this
-	// tick. Non-nil (possibly empty) whenever the Transports probe ran,
-	// so reconcileCurrentLeaves can distinguish "no probe" (leave the
-	// mirrored set alone) from "probe returned zero live transports"
-	// (delete every previously-mirrored current leaf).
-	var liveTP map[uuid.UUID]struct{}
+	// entries collects the per-transport telemetry rows to publish AFTER
+	// the bbolt tx commits, as compact sharded binary leaves. ranProbe
+	// records whether the Transports probe actually ran this tick, so
+	// publishShards can distinguish "no probe" (leave the published shards
+	// alone) from "probe returned zero live transports" (delete every
+	// previously-published shard leaf).
+	var entries []telemetrywire.Entry
+	var ranProbe bool
 
 	txErr := t.store.UpdateSample(func(stx *SampleTx) error {
 		if probe := t.probes.Transports; probe != nil {
+			ranProbe = true
 			tps := probe()
-			liveTP = make(map[uuid.UUID]struct{}, len(tps))
+			entries = make([]telemetrywire.Entry, 0, len(tps))
 			for _, tp := range tps {
-				liveTP[tp.ID] = struct{}{}
-				if pairs, err := t.recordTransportTx(stx, tp, utc, today); err != nil {
+				if e, err := t.recordTransportTx(stx, tp, utc, today); err != nil {
 					t.log.WithError(err).WithField("tp_id", tp.ID).
 						Debug("Failed to record transport sample")
 				} else {
-					mirrors = append(mirrors, pairs...)
+					entries = append(entries, e)
 				}
 			}
 		}
@@ -353,75 +329,97 @@ func (t *Tracker) sample(now time.Time) {
 		return
 	}
 
-	t.sinkPutBatch(mirrors)
-	t.reconcileCurrentLeaves(liveTP)
+	t.publishShards(entries, ranProbe)
 }
 
-// reconcileCurrentLeaves diffs the live transport set reported by this
-// tick's probe against the set of current leaves currently mirrored to
-// the sink, and sink-deletes the leaf for any transport that is no
-// longer live (closed transport). This is the per-`current` analog of
-// the date-based sink-prune the retention path already does for daily
-// rollups and timeline bitmaps: a closed transport's current snapshot
-// must reconcile away (absence = dead) so it stops bloating the Root
-// TPD fills. bbolt retention is untouched — the visor's local /stats
-// history for a recently-closed transport stays intact.
+// publishShards groups this tick's live-transport entries into the 16
+// fixed shards (by telemetrywire.ShardOf), encodes each non-empty shard
+// as one compact binary leaf, and mirrors ONLY the shards whose
+// meaningful content changed since they were last published. A shard
+// that has gone empty (all its transports closed) but was previously
+// published is sink-Deleted, so absence-on-the-feed == dead exactly as
+// the per-transport reconcile used to guarantee. This keeps the
+// telemetry Root at ≤16 telemetry leaves regardless of transport count
+// — the whole point of the sharded shape (a busy hub's ~851
+// per-transport current leaves collapse to ≤16 objects, so TPD's
+// whole-Root fill completes over the short announce conn).
 //
-// live == nil means the Transports probe didn't run this tick; leave
-// the mirrored set alone. An empty (non-nil) live set correctly deletes
-// every previously-mirrored current leaf.
-func (t *Tracker) reconcileCurrentLeaves(live map[uuid.UUID]struct{}) {
-	if live == nil {
+// ranProbe == false means the Transports probe didn't run this tick
+// (no data to reconcile against); leave the published shards untouched.
+//
+// The change-gate signature (shardSig) deliberately excludes each
+// entry's sampled_at, so a shard whose transports are all idle — their
+// only per-tick change being the timestamp advancing — does not re-Put
+// and does not churn the Root, matching the anti-churn guarantee of the
+// old per-transport publishedSig.
+func (t *Tracker) publishShards(entries []telemetrywire.Entry, ranProbe bool) {
+	if !ranProbe {
 		return
 	}
-	t.mu.Lock()
-	var stale []uuid.UUID
-	for id := range t.mirroredCurrent {
-		if _, ok := live[id]; !ok {
-			stale = append(stale, id)
-			// Drop the change-gate baseline too, so if this transport
-			// ID ever returns it republishes rather than being silently
-			// suppressed against a stale signature.
-			delete(t.publishedSig, id)
-		}
-	}
-	// A live transport keeps its current leaf on the sink whether or not
-	// it was re-Put this tick (unchanged transports are intentionally not
-	// re-Put), so the mirrored set is exactly the live set.
-	t.mirroredCurrent = live
-	t.mu.Unlock()
 
-	for _, id := range stale {
-		t.sinkDelete(currentTransportPath(id.String()))
+	// Group by shard, then sort each shard's entries by ID so both the
+	// signature and the encoded blob are byte-stable across ticks.
+	byShard := make(map[uint8][]telemetrywire.Entry, telemetrywire.ShardCount)
+	for _, e := range entries {
+		sh := telemetrywire.ShardOf(e.ID)
+		byShard[sh] = append(byShard[sh], e)
 	}
-}
+	for sh := range byShard {
+		es := byShard[sh]
+		sort.Slice(es, func(i, j int) bool {
+			return bytes.Compare(es[i].ID[:], es[j].ID[:]) < 0
+		})
+		byShard[sh] = es
+	}
 
-// sinkPutBatch fans the sample's mirror writes into a single sink
-// call. The default cxoSink turns this into one Publisher.PutBatch
-// (one mutex acquire, one markDirty) instead of N individual Puts
-// that each contended with transport-manager re-registers and
-// other writers on the publisher's mutex. See pkg/cxo/treestore
-// publisher.go PutBatch for the downstream semantics.
-//
-// Skips when mirrors is empty so an idle sample tick doesn't even
-// take the sink-lookup mutex.
-func (t *Tracker) sinkPutBatch(mirrors []mirrorPair) {
-	if len(mirrors) == 0 {
-		return
-	}
 	t.mu.Lock()
 	sink := t.sink
-	// Record the signature we're about to publish so the next tick's
-	// change-gate compares against what actually reached the sink.
-	for _, m := range mirrors {
-		t.publishedSig[m.id] = m.sig
+	var ops []SinkOp
+	var deletes []string
+	// Re-Put shards whose meaningful content changed; record the new sig.
+	for sh, es := range byShard {
+		sig := shardSig(es)
+		if prev, ok := t.publishedShards[sh]; ok && prev == sig {
+			continue // unchanged — leave the existing leaf in place
+		}
+		t.publishedShards[sh] = sig
+		ops = append(ops, SinkOp{Path: telemetrywire.LeafPath(sh), Value: telemetrywire.EncodeShard(sh, es)})
+	}
+	// Delete shards that were published before but have no live transports now.
+	for sh := range t.publishedShards {
+		if _, still := byShard[sh]; !still {
+			deletes = append(deletes, telemetrywire.LeafPath(sh))
+			delete(t.publishedShards, sh)
+		}
 	}
 	t.mu.Unlock()
-	ops := make([]SinkOp, 0, len(mirrors))
-	for _, m := range mirrors {
-		ops = append(ops, SinkOp{Path: m.path, Value: m.data})
+
+	if len(ops) > 0 {
+		sink.PutBatch(ops)
 	}
-	sink.PutBatch(ops)
+	for _, path := range deletes {
+		sink.Delete(path)
+	}
+}
+
+// shardSig is the byte-stable, sampled_at-EXCLUDING signature of a
+// shard's entries. Two ticks with the same transports carrying the same
+// bandwidth/throughput/latency/type produce the same signature even
+// though each entry's sampled_at advanced — so an idle shard does not
+// re-Put. Entries must already be sorted by ID for stability.
+func shardSig(entries []telemetrywire.Entry) [32]byte {
+	stable := make([]telemetrywire.Entry, len(entries))
+	copy(stable, entries)
+	for i := range stable {
+		stable[i].SampledAtUnix = 0
+	}
+	// Any shard byte works here — the signature only compares content;
+	// ShardOf is identical for every entry in the slice anyway.
+	var sh uint8
+	if len(stable) > 0 {
+		sh = telemetrywire.ShardOf(stable[0].ID)
+	}
+	return sha256.Sum256(telemetrywire.EncodeShard(sh, stable))
 }
 
 // sinkDelete snapshots the sink under the lock and dispatches the
@@ -437,25 +435,15 @@ func (t *Tracker) sinkDelete(path string) {
 }
 
 // recordTransportTx is the in-tx variant of recordTransport. Reads
-// the existing record, merges the new probe, writes back, marks the
-// timeline bit, and reads the post-update bitmap — all under the
-// caller's SampleTx. Returns the list of (path, bytes) mirror pairs
-// the caller should push to the sink after the tx commits.
-// mirrorPair is one current-leaf write queued for the sink after the
-// bbolt tx commits. id/sig identify the transport and the meaningful
-// signature this data represents, so sinkPutBatch can record what was
-// actually published (the change-gate baseline for the next tick).
-type mirrorPair struct {
-	id   uuid.UUID
-	sig  currentSig
-	path string
-	data []byte
-}
-
-func (t *Tracker) recordTransportTx(stx *SampleTx, tp TransportProbe, now time.Time, today string) ([]mirrorPair, error) {
+// the existing record, merges the new probe, writes back, and marks the
+// timeline bit — all under the caller's SampleTx. Returns the compact
+// telemetrywire.Entry for this transport, which the caller collects and
+// hands to publishShards after the tx commits (the sampled_at-excluding
+// change-gate + shard packing happen there, not per-transport).
+func (t *Tracker) recordTransportTx(stx *SampleTx, tp TransportProbe, now time.Time, today string) (telemetrywire.Entry, error) {
 	rec, err := stx.GetTransportRecord(tp.ID)
 	if err != nil {
-		return nil, err
+		return telemetrywire.Entry{}, err
 	}
 	if rec == nil {
 		rec = &TransportRecord{
@@ -468,21 +456,14 @@ func (t *Tracker) recordTransportTx(stx *SampleTx, tp TransportProbe, now time.T
 	}
 	rec.LastSeen = now
 	rec.Current = &LiveSnapshot{
-		SentBytes:    tp.SentBytes,
-		RecvBytes:    tp.RecvBytes,
-		LatencyMinMS: tp.LatencyMS.Min,
-		LatencyMaxMS: tp.LatencyMS.Max,
-		LatencyAvgMS: tp.LatencyMS.Avg,
-		SampledAt:    now,
-		Type:         rec.Type,
-	}
-
-	sig := currentSig{
-		sent:   tp.SentBytes,
-		recv:   tp.RecvBytes,
-		latMin: tp.LatencyMS.Min,
-		latMax: tp.LatencyMS.Max,
-		latAvg: tp.LatencyMS.Avg,
+		SentBytes:     tp.SentBytes,
+		RecvBytes:     tp.RecvBytes,
+		ThroughputBps: tp.ThroughputBps,
+		LatencyMinMS:  tp.LatencyMS.Min,
+		LatencyMaxMS:  tp.LatencyMS.Max,
+		LatencyAvgMS:  tp.LatencyMS.Avg,
+		SampledAt:     now,
+		Type:          rec.Type,
 	}
 
 	t.mu.Lock()
@@ -491,12 +472,7 @@ func (t *Tracker) recordTransportTx(stx *SampleTx, tp TransportProbe, now time.T
 		base = bandwidthBaseline{day: today, sent: tp.SentBytes, recv: tp.RecvBytes}
 		t.baselines[tp.ID] = base
 	}
-	prevSig, published := t.publishedSig[tp.ID]
 	t.mu.Unlock()
-	// Only mirror the current leaf when a meaningful field moved (or it
-	// was never published). SampledAt alone changing every tick must NOT
-	// re-Put an idle transport — that was the Root churn this fixes.
-	sigChanged := !published || prevSig != sig
 
 	deltaSent := uint64(0)
 	deltaRecv := uint64(0)
@@ -514,29 +490,23 @@ func (t *Tracker) recordTransportTx(stx *SampleTx, tp TransportProbe, now time.T
 	row.Samples++
 
 	if err := stx.PutTransportRecord(rec); err != nil {
-		return nil, err
+		return telemetrywire.Entry{}, err
 	}
 
-	var mirrors []mirrorPair
 	idStr := tp.ID.String()
-	if sigChanged {
-		if data, err := json.Marshal(rec.Current); err == nil {
-			mirrors = append(mirrors, mirrorPair{id: tp.ID, sig: sig, path: currentTransportPath(idStr), data: data})
-		}
-	}
 	// The daily rollup (row) is persisted to bbolt above (PutTransportRecord)
 	// but deliberately NOT mirrored to the CXO sink: no subscriber reads it
 	// (TPD's aggregator has no /rollup branch; the visor's own /stats reads it
 	// from bbolt), and publishing a per-transport-per-minute leaf onto the
-	// telemetry feed steals fill budget from transports/list on the
+	// telemetry feed steals fill budget from the discovery leaf on the
 	// short-lived announce conn — the constraint behind the discovery gap.
 
 	// The per-transport timeline bitmap is marked in bbolt (below) for the
 	// visor's own /stats + `visor state` consumption, but is NOT mirrored to
-	// the CXO sink. TPD is a discovery service: it only needs current data
-	// (transports/list + transports/<id>/current) and derives its own uptime
-	// history from what it observes each cycle (RecordTransportHeartbeat →
-	// Redis per-date keys). Publishing 7–30 days of per-transport-per-day
+	// the CXO sink. TPD is a discovery service: it needs only the tp-list
+	// discovery leaf plus the compact sharded telemetry, and derives its own
+	// uptime history from what it observes each cycle (RecordTransportHeartbeat
+	// → Redis per-date keys). Publishing 7–30 days of per-transport-per-day
 	// bitmaps onto the announce feed was the root of the discovery gap — it
 	// grew the Root to ~23k objects, so TPD couldn't fill it over the short
 	// announce conn and under-reported the transport list. Historical
@@ -546,7 +516,7 @@ func (t *Tracker) recordTransportTx(stx *SampleTx, tp TransportProbe, now time.T
 		t.log.WithError(err).WithField("tp_id", idStr).
 			Debug("Stats: MarkTransportSlot failed")
 	}
-	return mirrors, nil
+	return snapshotToEntry(tp.ID, rec.Current), nil
 }
 
 // findOrAppendDaily returns a pointer to today's daily row, creating

--- a/pkg/visor/stats/tracker_test.go
+++ b/pkg/visor/stats/tracker_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/telemetrywire"
 )
 
 // trackerFixture builds a Tracker against a fresh on-disk store and
@@ -84,24 +86,27 @@ func TestTrackerRecordsTransportLifecycle(t *testing.T) {
 	}
 }
 
-// TestTrackerChangeGateSkipsIdleRePuts drives three transports across
-// three same-day ticks and asserts the mirror change-gate:
+// TestTrackerChangeGateSkipsIdleShardRePuts drives three transports —
+// each alone in its own shard so the per-shard change-gate is isolated —
+// across three same-day ticks and asserts:
 //
-//	(a) an IDLE transport (bytes/latency constant, only SampledAt
+//	(a) an IDLE transport's shard (bytes/latency constant, only SampledAt
 //	    advancing) is Put once and NOT re-Put on later idle ticks;
-//	(b) a transport whose sent/recv bytes change IS re-Put on the
+//	(b) a transport whose sent/recv bytes change re-Puts ITS shard on the
 //	    changing tick, then stops being re-Put once it goes idle;
-//	(c) a transport that goes dead has its current leaf sink-Deleted.
+//	(c) a transport that goes dead has its now-empty shard sink-Deleted.
 //
-// This is the per-tick Root-churn reduction: with N live transports of
-// which M are idle between samples, the mirror Put count drops from N to
-// (N-M).
-func TestTrackerChangeGateSkipsIdleRePuts(t *testing.T) {
+// This is the per-tick Root-churn reduction preserved by the sharded
+// shape: an idle shard does not re-Put despite SampledAt advancing.
+func TestTrackerChangeGateSkipsIdleShardRePuts(t *testing.T) {
 	sink := newRecordingSink()
 	tr := newTrackerWithSink(t, sink)
-	idle := uuid.New()
-	changing := uuid.New()
-	dying := uuid.New()
+	idle := uuidInShard(1)
+	changing := uuidInShard(2)
+	dying := uuidInShard(3)
+	idleLeaf := telemetrywire.LeafPath(telemetrywire.ShardOf(idle))
+	changingLeaf := telemetrywire.LeafPath(telemetrywire.ShardOf(changing))
+	dyingLeaf := telemetrywire.LeafPath(telemetrywire.ShardOf(dying))
 	t0 := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 
 	idleProbe := TransportProbe{
@@ -109,7 +114,7 @@ func TestTrackerChangeGateSkipsIdleRePuts(t *testing.T) {
 		LatencyMS: LatencyTriple{Min: 10, Max: 10, Avg: 10},
 	}
 
-	// Tick 1: all three live — each publishes its current leaf once.
+	// Tick 1: all three live — each shard published once.
 	tr.probes.Transports = func() []TransportProbe {
 		return []TransportProbe{
 			idleProbe,
@@ -118,9 +123,9 @@ func TestTrackerChangeGateSkipsIdleRePuts(t *testing.T) {
 		}
 	}
 	tr.sample(t0)
-	for _, id := range []uuid.UUID{idle, changing, dying} {
-		if n := sink.putCountFor(currentTransportPath(id.String())); n != 1 {
-			t.Fatalf("tick1: %s Put %d times, want 1", id, n)
+	for _, leaf := range []string{idleLeaf, changingLeaf, dyingLeaf} {
+		if n := sink.putCountFor(leaf); n != 1 {
+			t.Fatalf("tick1: %s Put %d times, want 1", leaf, n)
 		}
 	}
 
@@ -134,25 +139,25 @@ func TestTrackerChangeGateSkipsIdleRePuts(t *testing.T) {
 	}
 	tr.sample(t0.Add(time.Minute))
 
-	if n := sink.putCountFor(currentTransportPath(idle.String())); n != 1 {
-		t.Errorf("(a) idle transport re-Put on unchanged tick: Put %d times, want 1", n)
+	if n := sink.putCountFor(idleLeaf); n != 1 {
+		t.Errorf("(a) idle shard re-Put on unchanged tick: Put %d times, want 1", n)
 	}
-	if n := sink.putCountFor(currentTransportPath(changing.String())); n != 2 {
-		t.Errorf("(b) changed transport not re-Put: Put %d times, want 2", n)
+	if n := sink.putCountFor(changingLeaf); n != 2 {
+		t.Errorf("(b) changed shard not re-Put: Put %d times, want 2", n)
 	}
 	_, dels := sink.snapshot()
 	foundDel := false
 	for _, d := range dels {
-		if d == currentTransportPath(dying.String()) {
+		if d == dyingLeaf {
 			foundDel = true
 		}
 	}
 	if !foundDel {
-		t.Errorf("(c) dead transport current leaf not sink-Deleted; dels=%v", dels)
+		t.Errorf("(c) dead transport's empty shard not sink-Deleted; dels=%v", dels)
 	}
 
 	// Tick 3: both remaining transports idle (changing now constant too).
-	// Neither should be re-Put.
+	// Neither shard should be re-Put.
 	tr.probes.Transports = func() []TransportProbe {
 		return []TransportProbe{
 			idleProbe,
@@ -161,11 +166,37 @@ func TestTrackerChangeGateSkipsIdleRePuts(t *testing.T) {
 	}
 	tr.sample(t0.Add(2 * time.Minute))
 
-	if n := sink.putCountFor(currentTransportPath(idle.String())); n != 1 {
-		t.Errorf("(a) idle transport re-Put on second idle tick: Put %d times, want 1", n)
+	if n := sink.putCountFor(idleLeaf); n != 1 {
+		t.Errorf("(a) idle shard re-Put on second idle tick: Put %d times, want 1", n)
 	}
-	if n := sink.putCountFor(currentTransportPath(changing.String())); n != 2 {
-		t.Errorf("(b) now-idle transport re-Put after it stopped changing: Put %d times, want 2", n)
+	if n := sink.putCountFor(changingLeaf); n != 2 {
+		t.Errorf("(b) now-idle shard re-Put after it stopped changing: Put %d times, want 2", n)
+	}
+}
+
+// TestBusyHubSamplePublishesAtMost16Leaves is the ≤16-leaves proof at the
+// sampler level: a single sample of 800 live transports must publish at
+// most 16 shard leaves, not 800 per-transport leaves.
+func TestBusyHubSamplePublishesAtMost16Leaves(t *testing.T) {
+	sink := newRecordingSink()
+	tr := newTrackerWithSink(t, sink)
+	const n = 800
+	probe := make([]TransportProbe, 0, n)
+	for i := 0; i < n; i++ {
+		probe = append(probe, TransportProbe{
+			ID: uuid.New(), Type: "stcpr", SentBytes: uint64(i), RecvBytes: uint64(i),
+		})
+	}
+	tr.probes.Transports = func() []TransportProbe { return probe }
+	tr.sample(time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC))
+
+	puts, _ := sink.snapshot()
+	if len(puts) > telemetrywire.ShardCount {
+		t.Errorf("sample published %d leaves for %d transports, want ≤ %d", len(puts), n, telemetrywire.ShardCount)
+	}
+	entries, _ := shardEntries(puts)
+	if len(entries) != n {
+		t.Errorf("packed %d transports across shards, want %d", len(entries), n)
 	}
 }
 

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -255,6 +255,24 @@ type Stats struct {
 	// Disabled, when true, skips the entire telemetry store and
 	// associated /stats/* endpoints + CXO publisher.
 	Disabled bool `json:"disabled,omitempty"`
+	// DedicatedTPListFeed, when true, publishes the transport-list
+	// discovery snapshot on its OWN CXO node/port
+	// (skyenv.DmsgVisorTPListCXOPort) instead of on the telemetry feed.
+	//
+	// Default (false) is the CONSOLIDATED single-feed model: the tp-list
+	// leaf rides the telemetry Root as a top-level leaf, so TPD holds ONE
+	// CXO connection per visor instead of two. TPD's aggregator extracts
+	// the tp-list via its targeted discovery-leaf fetch, which lands the
+	// small leaf reliably now that the compact sharded telemetry keeps the
+	// whole Root small (≈16 shard leaves + 1 tp-list leaf) — the condition
+	// that was missing when the earlier consolidation (#4184) had to be
+	// reverted (#4189) over a bulky per-transport-leaf Root. Halving the
+	// visor↔TPD connections cuts TPD's per-connection goroutines and the
+	// per-session dmsg handshake load on the dmsg servers.
+	//
+	// Set true only as a transitional escape hatch — e.g. if a busy hub's
+	// tp-list is ever observed to under-fill on the combined feed.
+	DedicatedTPListFeed bool `json:"dedicated_tplist_feed,omitempty"`
 }
 
 // LogServer configures the dmsghttp log server's optional localhost endpoint.


### PR DESCRIPTION
## What

Replace the N per-transport `transports/<uuid>/current` JSON telemetry leaves on the visor→TPD CXO telemetry feed (dmsg port 50) with **16 fixed sharded binary leaves** at `transports/telemetry/<sh>` (shard = `uuid[0]>>4`). A busy hub's ~851 per-transport leaves (~1700 CXO objects) collapse to ≤16 leaves, so TPD's whole-Root fill finishes over its short-lived announce conn instead of undercounting busy-hub telemetry.

## Shared codec (no drift)

The byte layout lives in one shared package, `pkg/telemetrywire`, imported by both the visor publisher (`pkg/visor/stats`) and the TPD reader (`pkg/deployment/tpd/cxoaggregator`). Version byte `0x02` gates the format; `DecodeShard` validates version/shard-range/length strictly. Entries are 53 bytes and carry the transport's passively-observed **peak-goodput throughput** estimate (`ManagedTransport.GetThroughputBps`) alongside sent/recv bytes and latency — a capacity metric not derivable from the cumulative counters. TPD records it per-transport (peak-preserving) and overlays it onto `Entry.ThroughputBps`.

## TPD fallback

TPD reads the shard leaves and applies each row exactly as a `current` snapshot (bandwidth, throughput, latency, per-type uptime heartbeat). It keeps the legacy `transports/<uuid>/current` path as a **fallback** for not-yet-upgraded visors, preferring shards when a Root carries any. Deploy is **TPD-FIRST**: TPD (shards + old-current fallback) must ship before visors switch to shard-only publishing.

## tp-list re-consolidation (redo of reverted #4184)

Also re-consolidates the tp-list discovery leaf back onto this telemetry feed so a visor holds **one** CXO connection to TPD, not two. This is the change reverted in #4189 — safe now because the sharded telemetry is exactly what keeps the combined Root small enough to fill. The dedicated port-69 feed stays available behind `Stats.DedicatedTPListFeed` as a transitional escape hatch (default off = consolidated).

## Tests

New codec round-trip/rejection tests; publish-shape tests proving 800 transports publish ≤16 leaves (hydrate and sampler); shard change-gate (idle shard not re-Put); TPD shard-reconcile + old-current fallback + shard-preference. `go build`, `go vet`, and `go test` green across the codec, `pkg/visor/stats`, `pkg/visor`, and the TPD aggregator/store packages.