### PR TITLE
feat(dmsgd): batch clients-by-server CXO feed to one leaf per server

### DIFF
--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -65,7 +65,8 @@ const (
 	// (services/<type>/<pk>/{entry,tombstone}).
 	FeedSDServices
 	// FeedDMSGDClientsByServer is DMSG-D's clients-by-server publisher
-	// (clients-by-server/<server>/<client>/{entry,tombstone}).
+	// (one batched leaf per server at clients-by-server/<server>; older
+	// publishers used clients-by-server/<server>/<client>/entry).
 	FeedDMSGDClientsByServer
 	// FeedTPDAllTransports is TPD's all-transports snapshot publisher
 	// (transports/all/{with-self,without-self}). Used by the CLI's

--- a/pkg/cxo/cxoutils/frame.go
+++ b/pkg/cxo/cxoutils/frame.go
@@ -1,0 +1,46 @@
+// Package cxoutils pkg/cxo/cxoutils/frame.go c2-net-cxo
+//
+// Versioned+gzipped framing for batched CXO leaves. Feeds that used to
+// publish ONE tiny JSON leaf per item (per transport, per (server,
+// client) pair, per service) collapse to a FEW batched leaves whose
+// body is a JSON array of the shard's members. Two things wrap that
+// array on the wire:
+//
+//   - a single leading VERSION byte, so old/new readers branch on the
+//     format explicitly (an old reader rejects a bumped version cleanly
+//     rather than misparsing it — the same gate telemetrywire's binary
+//     codec uses); and
+//   - gzip, because CXO stores + propagates object bytes verbatim (no
+//     built-in compression), so a batched JSON array travels
+//     uncompressed unless the publisher compresses it.
+//
+// The frame is deliberately format-agnostic: it carries opaque payload
+// bytes, so a feed can put JSON (the common case for awkward,
+// variable-length, signed records like disc.Entry / servicedisc.Service)
+// or any other encoding behind the same version gate. Fixed-layout
+// records that ARE amenable to compact binary should use a dedicated
+// binary codec instead (see pkg/telemetrywire).
+package cxoutils
+
+// FrameGzip wraps payload as [version byte][gzip(payload)]. Callers pick
+// a per-feed version const; readers compare it in UnframeGzip and branch.
+func FrameGzip(version byte, payload []byte) []byte {
+	gz := Gzip(payload)
+	out := make([]byte, 0, 1+len(gz))
+	out = append(out, version)
+	out = append(out, gz...)
+	return out
+}
+
+// UnframeGzip splits a FrameGzip blob into its version byte and the
+// decompressed payload. ok=false only for an empty blob; the caller is
+// responsible for checking the returned version against what it
+// understands (an unknown version means "skip this leaf, fall back").
+// Gunzip auto-detects the gzip magic, so a non-gzipped payload (or a
+// future uncompressed variant) round-trips unchanged.
+func UnframeGzip(body []byte) (version byte, payload []byte, ok bool) {
+	if len(body) < 1 {
+		return 0, nil, false
+	}
+	return body[0], Gunzip(body[1:]), true
+}

--- a/pkg/cxo/cxoutils/frame_test.go
+++ b/pkg/cxo/cxoutils/frame_test.go
@@ -1,0 +1,43 @@
+package cxoutils
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestFrameGzipRoundTrip(t *testing.T) {
+	payload := []byte(`[{"a":1},{"b":2}]`)
+	blob := FrameGzip(7, payload)
+	if blob[0] != 7 {
+		t.Fatalf("version byte = %d, want 7", blob[0])
+	}
+	// gzip should actually compress a repetitive-ish JSON array of any size;
+	// at minimum the framed blob carries the version byte + gzip stream.
+	if len(blob) < 3 {
+		t.Fatalf("framed blob too short: %d", len(blob))
+	}
+	version, got, ok := UnframeGzip(blob)
+	if !ok || version != 7 {
+		t.Fatalf("unframe: ok=%v version=%d", ok, version)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("payload round-trip mismatch: got %q want %q", got, payload)
+	}
+}
+
+func TestUnframeGzipEmpty(t *testing.T) {
+	if _, _, ok := UnframeGzip(nil); ok {
+		t.Fatal("empty blob should report ok=false")
+	}
+}
+
+func TestUnframeGzipRawPayload(t *testing.T) {
+	// A non-gzipped payload behind the version byte round-trips unchanged
+	// (Gunzip passes through anything lacking the gzip magic).
+	raw := []byte("not-gzip")
+	blob := append([]byte{9}, raw...)
+	version, got, ok := UnframeGzip(blob)
+	if !ok || version != 9 || !bytes.Equal(got, raw) {
+		t.Fatalf("raw passthrough failed: ok=%v version=%d got=%q", ok, version, got)
+	}
+}

--- a/pkg/dmsg/discovery/api/cxo_publisher.go
+++ b/pkg/dmsg/discovery/api/cxo_publisher.go
@@ -5,32 +5,51 @@
 // The hypervisor's network visualizer needs to know "which clients
 // are currently delegated to each dmsg server" — the same view
 // AllClientsByServer / ClientsByServer expose over HTTP. This
-// publisher mirrors that as a TreeStore feed:
+// publisher mirrors that as a TreeStore feed.
 //
-//	clients-by-server/<server-pk>/<client-pk>/entry        // JSON disc.Entry
+// # Wire shape: ONE batched leaf per server
 //
-// We deliberately do NOT publish a separate entries/<pk> tree (the
-// non-denormalized form) because no consumer we know of subscribes
-// to per-PK lookups; the network-visualizer pattern is always
-// server-grouped, and AllClientsByServer / ClientsByServer is what
-// the existing http path serves.
+// Each dmsg server gets exactly one leaf carrying that server's whole
+// delegated-client set:
 //
-// On a client SetEntry, the publisher diffs the new DelegatedServers
-// list against the old (if any) and emits:
-//   - Put on clients-by-server/<server>/<client>/entry for every
-//     server in the new list.
-//   - Delete on clients-by-server/<server>/<client>/entry for every
-//     server that was in the old list but not the new (the client
-//     moved off that server). Subscribers learn of removals through
-//     CXO's standard leaf-disappearance event; pre-2026-05-18 we also
-//     wrote a tombstone leaf carrying DeletedAt, but no consumer in
-//     the codebase reads tombstone bodies (tpviz and visor/autoconnect
-//     both explicitly skip them) and the leaves accumulated forever in
-//     the publisher's in-memory CXDS, driving runaway RAM growth on
-//     the deployment box (observed: 327 MB → 921 MB over 12h, with
-//     ~70% of heap in cipher/encoder.Serialize / memoryCXDS.Set under
-//     Refs.AppendValues). Dropping the tombstone write closes the
-//     leak without losing any semantics that's currently read.
+//	clients-by-server/<server-pk>        // FrameGzip(v1, JSON []disc.Entry)
+//
+// Older builds published one leaf PER (server, client) PAIR at
+// clients-by-server/<server>/<client>/entry — O(#pairs), thousands of
+// tiny objects in one Root. A large deployment's Root then could not
+// finish filling over a subscriber's short-lived delivering dmsg conn
+// (only the top slice landed). Batching to one leaf per server drops
+// the object count to O(#servers) (~tens–120), which is what lets the
+// Root fill complete. The only consumers (the visor dmsg-entry lookup
+// resolver and tpviz's network visualizer) want server-grouped data, so
+// per-server batching loses no used addressability.
+//
+// Encoding is JSON+gzip, not fixed-layout binary: a client's disc.Entry
+// carries a signature and a variable-length delegated-server list, so it
+// is the "awkward for binary" case — unlike telemetrywire's fixed 53-byte
+// rows. The per-server array is JSON-marshalled (entries sorted by client
+// PK so unchanged content re-encodes to identical bytes → a wire no-op on
+// CXO's content-addressed store), then framed with a leading version byte
+// and gzipped (cxoutils.FrameGzip). The version byte gates the format:
+// a bumped version is rejected cleanly by an old reader rather than
+// misparsed.
+//
+// # Interop / deploy order
+//
+// Deploy is SERVICE-FIRST. A not-yet-upgraded reader walking the feed
+// looks for the OLD .../<client>/entry leaves, finds none under the new
+// batched shape, reports an empty snapshot, and falls back to HTTP — safe
+// degradation, never a wrong answer. Upgraded readers prefer the batched
+// leaf and still parse an OLD per-item leaf as a fallback, so either
+// publisher shape resolves.
+//
+// A deregistration is the ABSENCE of a client from its server's batched
+// leaf — there is no tombstone leaf class (the old per-(server,client)
+// tombstones were write-only across the codebase and leaked RAM in the
+// publisher's CXDS; observed 327 MB → 921 MB over 12h). Re-encoding a
+// server's single leaf on a membership change is far cheaper than the old
+// whole-tree churn: the tree is now O(#servers) leaves, so each publish
+// clones + encodes a tiny tree.
 //
 // Server entries are ignored by this publisher — a server PK is the
 // path-prefix bucket, not a member of the view.
@@ -41,12 +60,15 @@
 // (mirrors SD's pattern) so the HTTP goroutine never blocks on the
 // treestore.Publisher mutex — which under load is contended by
 // subscriber I/O and can stall register throughput long enough to
-// time out visor heartbeats. Overflow drops are counted; CXO data
-// quality degrades gracefully, HTTP stays fast.
+// time out visor heartbeats. The per-server client state map is owned
+// by that single worker goroutine, so its mutations need no lock.
+// Overflow drops are counted; CXO data quality degrades gracefully,
+// HTTP stays fast.
 package api
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -54,12 +76,18 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
+
+// clientsByServerBatchVersion is the wire-format version byte of the
+// batched per-server leaf body (FrameGzip). Bump on any breaking change
+// to the leaf encoding; readers reject other values and fall back.
+const clientsByServerBatchVersion = 1
 
 // clientsByServerCXOBatchWindow coalesces the publisher's tree mutations before
 // it re-encodes + publishes the clients-by-server tree.
@@ -109,6 +137,12 @@ type ClientsByServerCXOPublisher struct {
 
 	dropped uint64 // atomic; incremented on queue overflow
 
+	// state is the live per-server client set: server PK -> client PK ->
+	// that client's full JSON disc.Entry. Owned exclusively by the single
+	// worker goroutine (run), so it needs no lock; the encode of a
+	// server's batched leaf reads only from here.
+	state map[cipher.PubKey]map[cipher.PubKey][]byte
+
 	mu        sync.Mutex
 	lastError error
 }
@@ -139,6 +173,7 @@ func StartClientsByServerCXOPublisher(dmsgC *dmsg.Client, sk cipher.SecKey, logg
 		log:    log,
 		events: make(chan func(), publishQueueDepth),
 		done:   make(chan struct{}),
+		state:  make(map[cipher.PubKey]map[cipher.PubKey][]byte),
 	}
 	p.wg.Add(1)
 	go p.run()
@@ -211,13 +246,16 @@ func (p *ClientsByServerCXOPublisher) Close() error {
 	return p.pub.Close()
 }
 
-// PublishSetEntry mirrors a set/update of a client entry. Emits Puts
-// for every server in the new DelegatedServers list and tombstones
-// for any server that dropped out (compared to old). Does nothing
-// for server entries (they're path buckets here, not members) or
-// for client entries with empty DelegatedServers (nothing to publish).
-// Non-blocking: the diff and JSON encode happen on the caller's
-// goroutine; the per-server Put/Delete fan-out runs on the worker.
+// PublishSetEntry mirrors a set/update of a client entry. Updates the
+// worker's per-server client state — adding the client to every server
+// in the new DelegatedServers list, removing it from any server it left
+// (compared to old) — and re-encodes each affected server's batched
+// leaf. Does nothing for server entries (they're path buckets here, not
+// members) or for client entries with empty DelegatedServers (the client
+// is absent from every server's leaf, which is exactly a deregistration).
+// Non-blocking: the diff and JSON encode of the entry happen on the
+// caller's goroutine; the state mutation + per-server re-encode/Put runs
+// on the worker.
 func (p *ClientsByServerCXOPublisher) PublishSetEntry(oldEntry, newEntry *disc.Entry) {
 	if p == nil || p.pub == nil || newEntry == nil || newEntry.Client == nil {
 		return
@@ -251,52 +289,30 @@ func (p *ClientsByServerCXOPublisher) PublishSetEntry(oldEntry, newEntry *disc.E
 	}
 
 	p.submit(func() {
-		// Put / re-Put for every server in the new list. CXO is
-		// content-addressed so unchanged bytes are wire-no-ops.
+		dirty := make(map[cipher.PubKey]struct{}, len(newServers)+len(oldServers))
+		// Add / refresh the client under every server in the new list.
 		for srv := range newServers {
-			path := entryLeafPath(srv, clientPK)
-			if err := p.pub.Put(path, body); err != nil {
-				p.log.WithError(err).WithField("path", path).Debug("Failed to publish clients-by-server entry leaf")
-				p.recordError(err)
-				continue
-			}
-			// Defensive: also Delete any tombstone left from an
-			// older binary that wrote them. Idempotent — no-op if
-			// none exists. Avoids a stale tombstone surviving the
-			// upgrade and confusing a future consumer that does
-			// read them.
-			if err := p.pub.Delete(tombstoneLeafPath(srv, clientPK)); err != nil {
-				p.log.WithError(err).Debug("Failed to clear legacy clients-by-server tombstone")
-			}
+			p.stateSet(srv, clientPK, body)
+			dirty[srv] = struct{}{}
 		}
-
-		// Delete the leaf for every server that was in the old list
-		// but not the new. Subscribers see the leaf disappear via
-		// CXO's normal update channel; we deliberately don't write a
-		// tombstone leaf — see the package docstring for the leak
-		// rationale.
+		// Remove the client from every server it left.
 		for srv := range oldServers {
 			if _, kept := newServers[srv]; kept {
 				continue
 			}
-			entryPath := entryLeafPath(srv, clientPK)
-			if err := p.pub.Delete(entryPath); err != nil {
-				p.log.WithError(err).WithField("path", entryPath).
-					Debug("Failed to delete dropped clients-by-server entry leaf")
-			}
+			p.stateDel(srv, clientPK)
+			dirty[srv] = struct{}{}
 		}
+		p.flushServers(dirty)
 	})
 }
 
-// PublishDelEntry mirrors a full client-entry delete: deletes the
-// (server, client) entry leaves for every server the client was
-// previously delegated to. oldEntry is the entry being deleted
-// (caller fetches it from store before the DelEntry call).
-// Non-blocking.
-//
-// Pre-2026-05-18 this also wrote a tombstone leaf per server; see
-// the package docstring for why tombstones were dropped (write-only
-// across the codebase + unbounded in-memory growth).
+// PublishDelEntry mirrors a full client-entry delete: removes the client
+// from every server it was delegated to and re-encodes those servers'
+// batched leaves. oldEntry is the entry being deleted (caller fetches it
+// from store before the DelEntry call). The client's absence from a
+// server's leaf IS the deregistration signal — there is no tombstone
+// leaf (see the package docstring). Non-blocking.
 func (p *ClientsByServerCXOPublisher) PublishDelEntry(oldEntry *disc.Entry) {
 	if p == nil || p.pub == nil || oldEntry == nil || oldEntry.Client == nil {
 		return
@@ -307,18 +323,84 @@ func (p *ClientsByServerCXOPublisher) PublishDelEntry(oldEntry *disc.Entry) {
 		return
 	}
 	p.submit(func() {
+		dirty := make(map[cipher.PubKey]struct{}, len(servers))
 		for srv := range servers {
-			entryPath := entryLeafPath(srv, clientPK)
-			if err := p.pub.Delete(entryPath); err != nil {
-				p.log.WithError(err).Debug("Failed to delete clients-by-server entry leaf on full delete")
-			}
-			// Defensive: clear any tombstone left from an older
-			// binary; idempotent if none exists.
-			if err := p.pub.Delete(tombstoneLeafPath(srv, clientPK)); err != nil {
-				p.log.WithError(err).Debug("Failed to clear legacy clients-by-server tombstone on full delete")
-			}
+			p.stateDel(srv, clientPK)
+			dirty[srv] = struct{}{}
 		}
+		p.flushServers(dirty)
 	})
+}
+
+// stateSet records clientPK's entry body under serverPK. Worker-only.
+func (p *ClientsByServerCXOPublisher) stateSet(serverPK, clientPK cipher.PubKey, body []byte) {
+	clients := p.state[serverPK]
+	if clients == nil {
+		clients = make(map[cipher.PubKey][]byte)
+		p.state[serverPK] = clients
+	}
+	clients[clientPK] = body
+}
+
+// stateDel removes clientPK from serverPK's set. Worker-only.
+func (p *ClientsByServerCXOPublisher) stateDel(serverPK, clientPK cipher.PubKey) {
+	if clients := p.state[serverPK]; clients != nil {
+		delete(clients, clientPK)
+	}
+}
+
+// flushServers re-encodes and Puts the batched leaf for each dirty
+// server, or Deletes it (and drops the server from state) when the
+// server has no delegated clients left. CXO is content-addressed, so a
+// re-Put of an unchanged leaf is a wire no-op. Worker-only.
+func (p *ClientsByServerCXOPublisher) flushServers(dirty map[cipher.PubKey]struct{}) {
+	for srv := range dirty {
+		clients := p.state[srv]
+		path := batchLeafPath(srv)
+		if len(clients) == 0 {
+			delete(p.state, srv)
+			if err := p.pub.Delete(path); err != nil {
+				p.log.WithError(err).WithField("path", path).
+					Debug("Failed to delete emptied clients-by-server leaf")
+			}
+			continue
+		}
+		blob, err := encodeClientsBatch(clients)
+		if err != nil {
+			p.log.WithError(err).WithField("path", path).Debug("Failed to encode clients-by-server batch leaf")
+			p.recordError(err)
+			continue
+		}
+		if err := p.pub.Put(path, blob); err != nil {
+			p.log.WithError(err).WithField("path", path).Debug("Failed to publish clients-by-server batch leaf")
+			p.recordError(err)
+		}
+	}
+}
+
+// encodeClientsBatch serializes a server's client set into one batched
+// leaf body: a JSON array of the clients' disc.Entry objects, sorted by
+// client PK so an unchanged set re-encodes to identical bytes (a CXO
+// wire no-op), then version-framed + gzipped. The array is assembled by
+// concatenating the already-marshalled per-client entry bodies, so each
+// client is encoded exactly once (on the caller's goroutine, in
+// PublishSetEntry) rather than re-marshalled here.
+func encodeClientsBatch(clients map[cipher.PubKey][]byte) ([]byte, error) {
+	pks := make([]cipher.PubKey, 0, len(clients))
+	for pk := range clients {
+		pks = append(pks, pk)
+	}
+	sort.Slice(pks, func(i, j int) bool { return pks[i].Hex() < pks[j].Hex() })
+	payload := make([]byte, 0, 2+len(pks)*256)
+	payload = append(payload, '[')
+	for i, pk := range pks {
+		if i > 0 {
+			payload = append(payload, ',')
+		}
+		payload = append(payload, clients[pk]...)
+	}
+	payload = append(payload, ']')
+	return cxoutils.FrameGzip(clientsByServerBatchVersion, payload), nil
 }
 
 func (p *ClientsByServerCXOPublisher) recordError(err error) {
@@ -334,20 +416,12 @@ func (p *ClientsByServerCXOPublisher) LastError() error {
 	return p.lastError
 }
 
-// EntryLeafPath / TombstoneLeafPath are exported so subscribers can
-// reconstruct paths without duplicating the format string.
-func EntryLeafPath(serverPK, clientPK cipher.PubKey) string {
-	return entryLeafPath(serverPK, clientPK)
-}
-func TombstoneLeafPath(serverPK, clientPK cipher.PubKey) string {
-	return tombstoneLeafPath(serverPK, clientPK)
-}
+// BatchLeafPath is exported so subscribers can reconstruct the batched
+// per-server leaf path without duplicating the format string.
+func BatchLeafPath(serverPK cipher.PubKey) string { return batchLeafPath(serverPK) }
 
-func entryLeafPath(serverPK, clientPK cipher.PubKey) string {
-	return fmt.Sprintf("clients-by-server/%s/%s/entry", serverPK.Hex(), clientPK.Hex())
-}
-func tombstoneLeafPath(serverPK, clientPK cipher.PubKey) string {
-	return fmt.Sprintf("clients-by-server/%s/%s/tombstone", serverPK.Hex(), clientPK.Hex())
+func batchLeafPath(serverPK cipher.PubKey) string {
+	return fmt.Sprintf("clients-by-server/%s", serverPK.Hex())
 }
 
 // pkSet builds a set-of-PK from a slice; small helper to avoid

--- a/pkg/dmsg/discovery/api/cxo_publisher_batch_test.go
+++ b/pkg/dmsg/discovery/api/cxo_publisher_batch_test.go
@@ -1,0 +1,135 @@
+// Package api — cxo_publisher_batch_test.go proves the clients-by-server
+// publisher batches to ONE leaf per server (object count O(#servers), not
+// O(#pairs)) and that a batched leaf round-trips through the exported
+// version-framed encoding.
+package api
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+// newTestPub builds a publisher with only the in-memory state map wired,
+// so stateSet / encodeClientsBatch can be exercised without a live
+// treestore.Publisher (pub stays nil; these helpers never touch it).
+func newTestPub() *ClientsByServerCXOPublisher {
+	return &ClientsByServerCXOPublisher{state: make(map[cipher.PubKey]map[cipher.PubKey][]byte)}
+}
+
+func mustEntry(t *testing.T, clientPK cipher.PubKey, servers []cipher.PubKey) []byte {
+	t.Helper()
+	e := &disc.Entry{
+		Version:    "0.0.1",
+		Static:     clientPK,
+		Client:     &disc.Client{DelegatedServers: servers},
+		ClientType: "visor",
+		Signature:  "sig",
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	return b
+}
+
+// TestBatchLeafCountIsPerServer feeds a large client population across a
+// small server set and asserts the number of batch leaves (== non-empty
+// servers in state) is bounded by #servers, NOT #(server,client) pairs.
+func TestBatchLeafCountIsPerServer(t *testing.T) {
+	p := newTestPub()
+
+	const nServers = 8
+	const nClients = 500
+	servers := make([]cipher.PubKey, nServers)
+	for i := range servers {
+		servers[i], _ = cipher.GenerateKeyPair()
+	}
+
+	pairs := 0
+	for i := 0; i < nClients; i++ {
+		clientPK, _ := cipher.GenerateKeyPair()
+		// Each client is delegated to 3 servers → 3 pairs.
+		deleg := []cipher.PubKey{servers[i%nServers], servers[(i+1)%nServers], servers[(i+3)%nServers]}
+		body := mustEntry(t, clientPK, deleg)
+		for _, srv := range deleg {
+			p.stateSet(srv, clientPK, body)
+			pairs++
+		}
+	}
+
+	// The OLD wire shape produced one leaf per pair; the batched shape
+	// produces one leaf per server. Prove the collapse.
+	if got := len(p.state); got > nServers {
+		t.Fatalf("batch leaf count = %d, want <= %d servers", got, nServers)
+	}
+	if pairs <= nServers {
+		t.Fatalf("test is trivial: pairs=%d not >> servers=%d", pairs, nServers)
+	}
+	t.Logf("pairs=%d collapsed to %d server leaves", pairs, len(p.state))
+
+	// Every server leaf must decode back to exactly its client set.
+	total := 0
+	for srv, clients := range p.state {
+		blob, err := encodeClientsBatch(clients)
+		if err != nil {
+			t.Fatalf("encode server %s: %v", srv.Hex(), err)
+		}
+		version, payload, ok := cxoutils.UnframeGzip(blob)
+		if !ok || version != clientsByServerBatchVersion {
+			t.Fatalf("unframe server %s: ok=%v version=%d", srv.Hex(), ok, version)
+		}
+		var entries []*disc.Entry
+		if err := json.Unmarshal(payload, &entries); err != nil {
+			t.Fatalf("decode server %s: %v", srv.Hex(), err)
+		}
+		if len(entries) != len(clients) {
+			t.Fatalf("server %s: decoded %d entries, want %d", srv.Hex(), len(entries), len(clients))
+		}
+		total += len(entries)
+	}
+	if total != pairs {
+		t.Fatalf("sum of decoded entries = %d, want %d pairs", total, pairs)
+	}
+}
+
+// TestBatchEncodeDeterministic pins that an unchanged client set
+// re-encodes to identical bytes (sorted by client PK), so a re-Put is a
+// CXO wire no-op.
+func TestBatchEncodeDeterministic(t *testing.T) {
+	p := newTestPub()
+	srv, _ := cipher.GenerateKeyPair()
+	for i := 0; i < 20; i++ {
+		clientPK, _ := cipher.GenerateKeyPair()
+		p.stateSet(srv, clientPK, mustEntry(t, clientPK, []cipher.PubKey{srv}))
+	}
+	a, err := encodeClientsBatch(p.state[srv])
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := encodeClientsBatch(p.state[srv])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a) != string(b) {
+		t.Fatal("encodeClientsBatch not deterministic for an unchanged set")
+	}
+}
+
+// TestBatchDelEmptiesServer proves a server with no clients left is
+// dropped from state (its leaf would be Deleted, not left as a tombstone).
+func TestBatchDelEmptiesServer(t *testing.T) {
+	p := newTestPub()
+	srv, _ := cipher.GenerateKeyPair()
+	clientPK, _ := cipher.GenerateKeyPair()
+	p.stateSet(srv, clientPK, mustEntry(t, clientPK, []cipher.PubKey{srv}))
+	if len(p.state[srv]) != 1 {
+		t.Fatalf("setup: want 1 client, got %d", len(p.state[srv]))
+	}
+	p.stateDel(srv, clientPK)
+	if got := len(p.state[srv]); got != 0 {
+		t.Fatalf("after del: want 0 clients, got %d", got)
+	}
+}

--- a/pkg/tpviz/cxo_subscriber.go
+++ b/pkg/tpviz/cxo_subscriber.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/servicedisc"
 )
 
@@ -37,7 +38,7 @@ const (
 	CXOFeedTPDMetrics           = 0 // metrics/days/<n>
 	CXOFeedTPDUptime            = 1 // uptimes/days/<n> — []VisorSummary
 	CXOFeedSDServices           = 2 // services/<type>/<pk>/{entry,tombstone}
-	CXOFeedDMSGDClientsByServer = 3 // clients-by-server/<server>/<client>/{entry,tombstone}
+	CXOFeedDMSGDClientsByServer = 3 // clients-by-server/<server> (batched; legacy .../<client>/entry)
 	CXOFeedTPDAllTransports     = 4 // transports/all/{with-self,without-self}
 )
 
@@ -144,11 +145,11 @@ func (s *Server) tryCXOServices() (map[string]ServiceInfo, bool) {
 // snapshot is empty, or every entry leaf fails to parse — caller
 // falls through to its existing HTTP path.
 //
-// Tombstones are skipped (live entries only). Each leaf carries the
-// full disc.Entry as JSON; the (server, client) PK pair is derivable
-// from the path (clients-by-server/<server>/<client>/entry) but we
-// re-use the server segment for the result map key directly so the
-// shape exactly matches AllClientsByServer's hex-string keys.
+// The current publisher writes ONE batched leaf per server at
+// clients-by-server/<server> (a version-framed, gzipped JSON []Entry);
+// the server segment is the map key and the array is that server's whole
+// client set. Older publishers wrote one leaf per pair at
+// clients-by-server/<server>/<client>/entry — both shapes are read here.
 func (s *Server) tryCXOClientsByServer() (map[string][]*discEntry, bool) {
 	mgr := s.cxoMgr()
 	if mgr == nil {
@@ -157,20 +158,29 @@ func (s *Server) tryCXOClientsByServer() (map[string][]*discEntry, bool) {
 	out := make(map[string][]*discEntry)
 	any := false
 	mgr.Walk(CXOFeedDMSGDClientsByServer, "clients-by-server/", func(path string, body []byte) bool {
-		if !strings.HasSuffix(path, "/entry") {
+		if len(body) == 0 {
 			return true
 		}
-		// path = clients-by-server/<server>/<client>/entry
 		parts := strings.Split(path, "/")
-		if len(parts) != 4 {
+		// Batched per-server leaf: ["clients-by-server", "<server>"].
+		if len(parts) == 2 && parts[1] != "" {
+			entries := decodeClientsBatch(body)
+			if len(entries) == 0 {
+				return true
+			}
+			out[parts[1]] = append(out[parts[1]], entries...)
+			any = true
 			return true
 		}
-		server := parts[1]
+		// Legacy per-item leaf: clients-by-server/<server>/<client>/entry.
+		if len(parts) != 4 || !strings.HasSuffix(path, "/entry") {
+			return true
+		}
 		var entry discEntry
 		if err := json.Unmarshal(body, &entry); err != nil {
 			return true
 		}
-		out[server] = append(out[server], &entry)
+		out[parts[1]] = append(out[parts[1]], &entry)
 		any = true
 		return true
 	})
@@ -178,6 +188,26 @@ func (s *Server) tryCXOClientsByServer() (map[string][]*discEntry, bool) {
 		return nil, false
 	}
 	return out, true
+}
+
+// clientsByServerBatchVersion is the wire-format version byte of the
+// batched per-server leaf (must match the dmsg-discovery publisher's
+// clientsByServerBatchVersion). A leaf with any other version is skipped.
+const clientsByServerBatchVersion = 1
+
+// decodeClientsBatch decodes a batched per-server leaf body into its
+// client entries (tpviz's local discEntry shape). Returns nil on any
+// framing/version/JSON error so a bad leaf is skipped, not misparsed.
+func decodeClientsBatch(body []byte) []*discEntry {
+	version, payload, ok := cxoutils.UnframeGzip(body)
+	if !ok || version != clientsByServerBatchVersion {
+		return nil
+	}
+	var entries []*discEntry
+	if err := json.Unmarshal(payload, &entries); err != nil {
+		return nil
+	}
+	return entries
 }
 
 // discEntry is a tpviz-local mirror of the disc.Entry JSON shape.

--- a/pkg/visor/dmsg_lookup_cxo.go
+++ b/pkg/visor/dmsg_lookup_cxo.go
@@ -46,14 +46,25 @@ import (
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
 // clientsByServerPrefix is the TreeStore path prefix the
-// clients-by-server feed publishes under. Leaves are
-// clients-by-server/<server-pk-hex>/<client-pk-hex>/entry.
+// clients-by-server feed publishes under. The current publisher writes
+// ONE batched leaf per server at clients-by-server/<server-pk-hex>
+// (a version-framed, gzipped JSON []disc.Entry). Older publishers wrote
+// one leaf per pair at clients-by-server/<server>/<client>/entry; the
+// rebuild below reads both shapes.
 const clientsByServerPrefix = "clients-by-server/"
+
+// clientsByServerBatchVersion is the wire-format version byte of the
+// batched per-server leaf (must match the dmsg-discovery publisher's
+// clientsByServerBatchVersion). A leaf with any other version is skipped
+// so a future format bump degrades to the HTTP fallback rather than
+// misparsing.
+const clientsByServerBatchVersion = 1
 
 // dmsgEntryCXOIndex resolves peer discovery entries from the visor's
 // CXO clients-by-server snapshot. It memoizes a client-PK → entry
@@ -140,25 +151,36 @@ func (idx *dmsgEntryCXOIndex) rebuild(mgr *CXOSubscriptionManager, version time.
 	}
 
 	built := make(map[cipher.PubKey]*dmsgdisc.Entry)
+	index := func(entry *dmsgdisc.Entry) {
+		// Only client entries with a usable delegated-server list are
+		// worth serving from CXO; anything else must take the HTTP
+		// path so it resolves authoritatively.
+		if entry == nil || entry.Client == nil || len(entry.Client.DelegatedServers) == 0 {
+			return
+		}
+		built[entry.Static] = entry
+	}
 	mgr.Walk(FeedDMSGDClientsByServer, clientsByServerPrefix, func(path string, body []byte) bool {
-		clientPK, ok := clientPKFromLeafPath(path)
-		if !ok {
+		if len(body) == 0 {
 			return true
 		}
-		if len(body) == 0 {
+		// Batched per-server leaf: clients-by-server/<server> (no extra
+		// path segment). Body is a version-framed gzipped JSON []Entry.
+		if rel := strings.TrimPrefix(path, clientsByServerPrefix); rel != "" && !strings.Contains(rel, "/") {
+			for _, entry := range decodeClientsBatch(body) {
+				index(entry)
+			}
+			return true
+		}
+		// Legacy per-item leaf: clients-by-server/<server>/<client>/entry.
+		if !strings.HasSuffix(path, "/entry") {
 			return true
 		}
 		entry := new(dmsgdisc.Entry)
 		if err := json.Unmarshal(body, entry); err != nil {
 			return true
 		}
-		// Only client entries with a usable delegated-server list are
-		// worth serving from CXO; anything else must take the HTTP
-		// path so it resolves authoritatively.
-		if entry.Client == nil || len(entry.Client.DelegatedServers) == 0 {
-			return true
-		}
-		built[clientPK] = entry
+		index(entry)
 		return true
 	})
 
@@ -170,27 +192,19 @@ func (idx *dmsgEntryCXOIndex) rebuild(mgr *CXOSubscriptionManager, version time.
 	}
 }
 
-// clientPKFromLeafPath parses the <client-pk> out of a
-// clients-by-server/<server-pk>/<client-pk>/entry leaf path. Returns
-// ok=false for any path that isn't a live entry leaf (e.g. a legacy
-// tombstone or a malformed segment).
-func clientPKFromLeafPath(path string) (cipher.PubKey, bool) {
-	if !strings.HasSuffix(path, "/entry") {
-		return cipher.PubKey{}, false
+// decodeClientsBatch decodes a batched per-server leaf body into its
+// client entries. Returns nil on an empty body, an unknown version byte,
+// a gunzip/JSON error, or a malformed array — every failure degrades to
+// "no entries from this leaf" so the resolver falls back to HTTP rather
+// than serving a misparse.
+func decodeClientsBatch(body []byte) []*dmsgdisc.Entry {
+	version, payload, ok := cxoutils.UnframeGzip(body)
+	if !ok || version != clientsByServerBatchVersion {
+		return nil
 	}
-	core := strings.TrimSuffix(strings.TrimPrefix(path, clientsByServerPrefix), "/entry")
-	// core == "<server-pk>/<client-pk>"
-	slash := strings.LastIndexByte(core, '/')
-	if slash < 0 {
-		return cipher.PubKey{}, false
+	var entries []*dmsgdisc.Entry
+	if err := json.Unmarshal(payload, &entries); err != nil {
+		return nil
 	}
-	clientHex := core[slash+1:]
-	if clientHex == "" {
-		return cipher.PubKey{}, false
-	}
-	var pk cipher.PubKey
-	if err := pk.Set(clientHex); err != nil {
-		return cipher.PubKey{}, false
-	}
-	return pk, true
+	return entries
 }

--- a/pkg/visor/dmsg_lookup_cxo_test.go
+++ b/pkg/visor/dmsg_lookup_cxo_test.go
@@ -1,58 +1,71 @@
 package visor
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
 )
 
-func TestClientPKFromLeafPath(t *testing.T) {
-	const (
-		serverHex = "02190003862c24f69e2cf47e1cf0efaa3dc1d866ba6a24067de34c363058212c73"
-		clientHex = "02e40731f3ab6d11d31c466429297f4869f299a7821108409c5e36b840253e4ba7"
-	)
-	var wantPK cipher.PubKey
-	if err := wantPK.Set(clientHex); err != nil {
-		t.Fatalf("bad test client hex: %v", err)
+// TestDecodeClientsBatch proves the batched per-server leaf body decodes
+// back to its client entries, and that framing/version errors degrade to
+// an empty result (caller then falls back to HTTP).
+func TestDecodeClientsBatch(t *testing.T) {
+	srv, _ := cipher.GenerateKeyPair()
+	c1, _ := cipher.GenerateKeyPair()
+	c2, _ := cipher.GenerateKeyPair()
+	entries := []*dmsgdisc.Entry{
+		{Version: "0.0.1", Static: c1, Client: &dmsgdisc.Client{DelegatedServers: []cipher.PubKey{srv}}},
+		{Version: "0.0.1", Static: c2, Client: &dmsgdisc.Client{DelegatedServers: []cipher.PubKey{srv}}},
+	}
+	payload, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	tests := []struct {
-		name   string
-		path   string
-		wantOK bool
-		wantPK cipher.PubKey
-	}{
-		{
-			name:   "valid entry leaf",
-			path:   "clients-by-server/" + serverHex + "/" + clientHex + "/entry",
-			wantOK: true,
-			wantPK: wantPK,
-		},
-		{
-			name:   "tombstone suffix rejected",
-			path:   "clients-by-server/" + serverHex + "/" + clientHex + "/tombstone",
-			wantOK: false,
-		},
-		{
-			name:   "missing client segment",
-			path:   "clients-by-server/" + serverHex + "/entry",
-			wantOK: false,
-		},
-		{
-			name:   "malformed client hex",
-			path:   "clients-by-server/" + serverHex + "/nothex/entry",
-			wantOK: false,
-		},
+	// Correct version → full decode.
+	blob := cxoutils.FrameGzip(clientsByServerBatchVersion, payload)
+	got := decodeClientsBatch(blob)
+	if len(got) != 2 {
+		t.Fatalf("decoded %d entries, want 2", len(got))
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pk, ok := clientPKFromLeafPath(tt.path)
-			if ok != tt.wantOK {
-				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
-			}
-			if ok && pk != tt.wantPK {
-				t.Fatalf("pk = %s, want %s", pk, tt.wantPK)
-			}
-		})
+	if got[0].Static != c1 || got[1].Static != c2 {
+		t.Fatal("decoded entries lost their client PKs")
+	}
+
+	// Wrong version byte → skipped (empty), so the resolver falls back.
+	bad := cxoutils.FrameGzip(clientsByServerBatchVersion+1, payload)
+	if n := len(decodeClientsBatch(bad)); n != 0 {
+		t.Fatalf("wrong-version blob decoded %d entries, want 0", n)
+	}
+
+	// Garbage body → skipped, not a panic.
+	if n := len(decodeClientsBatch([]byte{clientsByServerBatchVersion, 0x00, 0x01})); n != 0 {
+		t.Fatalf("garbage blob decoded %d entries, want 0", n)
+	}
+	if n := len(decodeClientsBatch(nil)); n != 0 {
+		t.Fatalf("nil blob decoded %d entries, want 0", n)
+	}
+}
+
+// TestLegacyPerItemLeafStillParses pins that a legacy single-entry leaf
+// body (raw JSON disc.Entry, the pre-batch shape) still unmarshals, so an
+// upgraded reader interoperates with a not-yet-upgraded publisher.
+func TestLegacyPerItemLeafStillParses(t *testing.T) {
+	c1, _ := cipher.GenerateKeyPair()
+	srv, _ := cipher.GenerateKeyPair()
+	e := &dmsgdisc.Entry{Version: "0.0.1", Static: c1, Client: &dmsgdisc.Client{DelegatedServers: []cipher.PubKey{srv}}}
+	body, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got dmsgdisc.Entry
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("legacy per-item leaf failed to parse: %v", err)
+	}
+	if got.Static != c1 {
+		t.Fatal("legacy leaf lost client PK")
 	}
 }


### PR DESCRIPTION
The clients-by-server CXO feed (dmsg CXO port 54) published one leaf per **(server, client) pair** at `clients-by-server/<server>/<client>/entry` — O(#pairs), thousands of tiny objects in one Root. A large deployment's Root then can't finish filling over a subscriber's short-lived delivering dmsg conn (only the top slice lands).

**Batch to one leaf per server** at `clients-by-server/<server>`, carrying that server's whole delegated-client set. Object count: **O(#pairs) → O(#servers)** (~tens–120). The only consumers (visor dmsg-entry lookup resolver, tpviz network-viz) want server-grouped data, so no used addressability is lost.

**Encoding — JSON+gzip, version-framed** (`cxoutils.FrameGzip`): a client's `disc.Entry` carries a signature and a variable-length delegated-server list, so it is the "awkward for binary" case the fixed-layout `telemetrywire` codec doesn't fit. Entries are sorted by client PK, so an unchanged set re-encodes to identical bytes — a CXO content-addressed wire no-op. A leading **version byte** gates the format; an old reader rejects a bumped version cleanly instead of misparsing.

**No tombstone class.** A deregistration is the client's ABSENCE from its server's leaf. The old per-pair tombstone leaves were write-only across the codebase and leaked publisher RAM (observed 327 MB → 921 MB / 12h). The publisher now keeps the live per-server set in a worker-owned map and re-encodes only the servers a mutation touched — the tree is O(#servers) leaves, so each publish clones+encodes a tiny tree. The 30s batch window + heartbeat short-circuit are preserved.

**Deploy is service/consumer-first.** A not-yet-upgraded reader finds no legacy `.../entry` leaves under the new shape, reports an empty snapshot, and falls back to HTTP — safe degradation, never a wrong answer. Upgraded readers prefer the batched leaf and still parse legacy per-item leaves, so either publisher shape resolves.

Reuses dmsg CXO port 54 (no new skyenv port). Tests: `TestBatchLeafCountIsPerServer` proves 1500 pairs collapse to ≤ #servers (8) leaves and each leaf round-trips; frame codec + legacy-leaf fallback covered. `go build .`, `go vet`, and `go test` pass on cxoutils, dmsg/discovery/api, tpviz, and visor.