### PR TITLE
feat(proxystatus): status.skysocks layout pass (header bw meters, label-tree header, right-anchored root, resizable black log pane)

### DIFF
--- a/pkg/bitree/bitree.go
+++ b/pkg/bitree/bitree.go
@@ -50,6 +50,12 @@ const (
 	// may recolor specific glyphs within it. Styling is applied after layout, so
 	// it must preserve display width.
 	CellLeft
+	// CellHeaderLeft is the label-header row's left field (see Options.Header*).
+	CellHeaderLeft
+	// CellHeaderLabel is the label-header row's right (peer) label.
+	CellHeaderLabel
+	// CellHeaderColumn is a label-header row trailing column label.
+	CellHeaderColumn
 )
 
 // GlyphSet is the set of box-drawing glyphs used by the renderer. The zero
@@ -105,6 +111,21 @@ type Options struct {
 	// (ANSI color codes are fine — they have zero display width). Layout is
 	// computed from the un-styled text, so styling is purely cosmetic.
 	StyleCell func(text string, kind CellKind) string
+	// HeaderLeft/HeaderLabel/HeaderCols, when any is non-empty, render a single
+	// "label header" row shaped like a real tree row but carrying column LABELS
+	// where the data goes: HeaderLeft is the left-summary label group, HeaderLabel
+	// the right (peer) label, and HeaderCols the trailing-column labels. The header
+	// participates in the same leftWidth / tree-width / per-column-width
+	// computation as the data rows, so its labels line up EXACTLY with the columns
+	// beneath it. It is drawn above the root as a horizontal template row (no spine
+	// junction) and styled via CellHeaderLeft / CellHeaderLabel / CellHeaderColumn.
+	HeaderLeft  string
+	HeaderLabel string
+	HeaderCols  []string
+}
+
+func (o Options) hasHeader() bool {
+	return o.HeaderLeft != "" || o.HeaderLabel != "" || len(o.HeaderCols) > 0
 }
 
 func (o Options) glyphs() GlyphSet {
@@ -361,10 +382,29 @@ func Render(root *Node, opts Options) string {
 		routes = append(routes, rows)
 	}
 
+	// The optional label-header row participates in every width computation so its
+	// labels line up exactly with the data columns beneath. Fold its left field
+	// into leftWidth here (before the spine column is derived).
+	if opts.hasHeader() {
+		if dw := dispWidth(opts.HeaderLeft); dw > leftWidth {
+			leftWidth = dw
+		}
+	}
+
 	// Column alignment: max tree width and per-column widths across all
 	// right-side lines.
 	treeWidth := opts.AlignColumns
 	var colW []int
+	foldCols := func(cols []string) {
+		for ci, c := range cols {
+			for len(colW) <= ci {
+				colW = append(colW, 0)
+			}
+			if cw := dispWidth(c); cw > colW[ci] {
+				colW[ci] = cw
+			}
+		}
+	}
 	for _, rows := range routes {
 		for _, rw := range rows {
 			if !rw.hasRight {
@@ -373,15 +413,14 @@ func Render(root *Node, opts Options) string {
 			if tw := rw.right.treeWidth(); tw > treeWidth {
 				treeWidth = tw
 			}
-			for ci, c := range rw.right.cols {
-				for len(colW) <= ci {
-					colW = append(colW, 0)
-				}
-				if cw := dispWidth(c); cw > colW[ci] {
-					colW[ci] = cw
-				}
-			}
+			foldCols(rw.right.cols)
 		}
+	}
+	if opts.hasHeader() {
+		if tw := dispWidth(opts.HeaderLabel); tw > treeWidth {
+			treeWidth = tw
+		}
+		foldCols(opts.HeaderCols)
 	}
 
 	gutter := strings.Repeat(" ", opts.LeftGutter)
@@ -394,16 +433,43 @@ func Render(root *Node, opts Options) string {
 		b.WriteByte('\n')
 	}
 
-	// Root label anchored at the central spine column, with a box-drawing
-	// descender dropping into the top of the spine, so the source PK reads as
-	// connected to the spine rather than floating off over the right-side hops.
 	// spineCol is the 0-based column of the spine glyph: gutter + left field +
 	// the joining space + the 2-cell arm.
 	spineCol := opts.LeftGutter + leftWidth + 1 + 2
-	rootCol := spineCol - dispWidth(root.Label)/2
-	if rootCol < 0 {
-		rootCol = 0
+
+	// Optional label-header row: a template/legend shaped like a data row, drawn
+	// above the root. It uses a horizontal pass-through (g.Horizontal) at the spine
+	// column instead of a junction, so it reads as a column header rather than a
+	// route on the vertical spine. Its columns share leftWidth / treeWidth / colW
+	// with the data, so the labels sit exactly above the values.
+	if opts.hasHeader() {
+		hleft := opts.style(padLeft(opts.HeaderLeft, leftWidth), CellHeaderLeft)
+		hmid := gutter + hleft + " " + h + h + h // left ──<spine=─>
+		htxt := h + h + " " + opts.style(opts.HeaderLabel, CellHeaderLabel)
+		if pad := treeWidth - dispWidth(opts.HeaderLabel); pad > 0 {
+			htxt += strings.Repeat(" ", pad)
+		}
+		for ci, c := range opts.HeaderCols {
+			htxt += sep
+			cell := opts.style(c, CellHeaderColumn)
+			w := 0
+			if ci < len(colW) {
+				w = colW[ci]
+			}
+			if pad := w - dispWidth(c); pad > 0 {
+				cell += strings.Repeat(" ", pad)
+			}
+			htxt += cell
+		}
+		writeLine(hmid + htxt)
 	}
+
+	// Root label right-anchored at the spine column (its first cell sits over the
+	// spine descender), with a box-drawing descender dropping into the top of the
+	// spine. Read without the left summary branches this is a normal downward
+	// tree: the source PK at top, hop chains hanging below it in the same PK
+	// column, so the root aligns with the other PKs instead of floating centered.
+	rootCol := spineCol
 	writeLine(strings.Repeat(" ", rootCol) + opts.style(root.Label, CellRoot))
 	writeLine(strings.Repeat(" ", spineCol) + g.Vertical)
 

--- a/pkg/bitree/bitree_test.go
+++ b/pkg/bitree/bitree_test.go
@@ -1,6 +1,20 @@
 package bitree
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// dispCol returns the display column (rune count) at which sub first appears in
+// s, or -1 if absent.
+func dispCol(s, sub string) int {
+	i := strings.Index(s, sub)
+	if i < 0 {
+		return -1
+	}
+	return utf8.RuneCountInString(s[:i])
+}
 
 func ann(s string) []*Node { return []*Node{{Label: s}} }
 
@@ -19,7 +33,7 @@ func TestSingleRoute(t *testing.T) {
 		Label: "EXITPK", Cols: []string{"[stcpr]", "9a3a17e0…", "143ms"},
 		Left: ann("R[0] ● 1.6K↑ 1.5K↓"),
 	}}}
-	want := "                this visor" + "\n" +
+	want := "                     this visor" + "\n" +
 		"                     │" + "\n" +
 		"R[0] ● 1.6K↑ 1.5K↓ ──┴── EXITPK  [stcpr]  9a3a17e0…  143ms"
 	check(t, "single", Render(root, Options{}), want)
@@ -37,7 +51,7 @@ func TestMockupTree(t *testing.T) {
 			Right: []*Node{{Label: "HOP2PK", Cols: []string{"[squicr]", "85086f0c…", "74ms"},
 				Right: []*Node{leaf("EXITPK", "[stcpr]", "da5c74a8…", "133ms")}}}},
 	}}
-	want := "                this visor" + "\n" +
+	want := "                     this visor" + "\n" +
 		"                     │" + "\n" +
 		"R[0] ● 1.6K↑ 1.5K↓ ──┼── EXITPK          [stcpr]   9a3a17e0…  143ms" + "\n" +
 		"R[1] ● 0.5K↑ 0.4K↓ ──┼── HOP1PK          [sudph]   72512b4b…  47ms" + "\n" +
@@ -61,7 +75,7 @@ func TestLeftSubtreeNesting(t *testing.T) {
 		{Label: "HOP1PK", Cols: []string{"[sudph]", "72512b4b…", "47ms"}, Left: ann("R[1] ● 0.5K↑ 0.4K↓"),
 			Right: []*Node{leaf("EXITPK", "[stcpr]", "1fafe896…", "88ms")}},
 	}}
-	want := "                this visor" + "\n" +
+	want := "                     this visor" + "\n" +
 		"                     │" + "\n" +
 		"            R[0] ● ──┼── EXITPK      [stcpr]  9a3a17e0…  143ms" + "\n" +
 		"   1.6K↑ 1.5K↓ ──┤   │" + "\n" +
@@ -81,10 +95,55 @@ func TestAlignColumns(t *testing.T) {
 	got := Render(root, Options{AlignColumns: 20})
 	// The single column "x" must appear at a fixed offset regardless of the
 	// short "A" label: tree portion padded to 20 (+3 arm) then ColSep.
-	want := "  root" + "\n" +
+	want := "    root" + "\n" +
 		"    │" + "\n" +
 		"L ──┴── A                     x"
 	check(t, "aligncols", got, want)
+}
+
+// TestHeaderRowAligns verifies the optional label-header row is drawn above the
+// root and that its column labels line up EXACTLY with the data columns beneath
+// (the "label tree" header — same peer-pk column, same trailing-column offsets).
+func TestHeaderRowAligns(t *testing.T) {
+	root := &Node{Label: "this visor", Right: []*Node{{
+		Label: "EXITPK", Cols: []string{"[stcpr]", "9a3a17e0…", "143ms"},
+		Left: ann("R[0] ● 1.6K↑ 1.5K↓"),
+	}}}
+	out := Render(root, Options{
+		HeaderLeft:  "R[n]·state·rtt·bw",
+		HeaderLabel: "peer-pk",
+		HeaderCols:  []string{"[type]", "tp-id", "tp-rtt"},
+	})
+	lines := strings.Split(out, "\n")
+	if len(lines) < 4 {
+		t.Fatalf("expected header+root+descender+row, got %d lines:\n%s", len(lines), out)
+	}
+	hdr := lines[0]
+	for _, lbl := range []string{"R[n]", "peer-pk", "[type]", "tp-id", "tp-rtt"} {
+		if !strings.Contains(hdr, lbl) {
+			t.Fatalf("header line missing %q: %q", lbl, hdr)
+		}
+	}
+	if strings.Contains(hdr, "┼") || strings.Contains(hdr, "┬") || strings.Contains(hdr, "┴") {
+		t.Errorf("header row must not carry a spine junction (reads as a route): %q", hdr)
+	}
+	var data string
+	for _, l := range lines {
+		if strings.Contains(l, "EXITPK") {
+			data = l
+		}
+	}
+	// peer label column == data PK label column; each trailing label column ==
+	// its data column.
+	if a, b := dispCol(hdr, "peer-pk"), dispCol(data, "EXITPK"); a != b {
+		t.Errorf("peer-pk col %d != EXITPK col %d\nhdr:  %q\ndata: %q", a, b, hdr, data)
+	}
+	if a, b := dispCol(hdr, "[type]"), dispCol(data, "[stcpr]"); a != b {
+		t.Errorf("[type] col %d != [stcpr] col %d\nhdr:  %q\ndata: %q", a, b, hdr, data)
+	}
+	if a, b := dispCol(hdr, "tp-rtt"), dispCol(data, "143ms"); a != b {
+		t.Errorf("tp-rtt col %d != rtt col %d\nhdr:  %q\ndata: %q", a, b, hdr, data)
+	}
 }
 
 // TestStyleCellPreservesLayout verifies that a zero-width styling wrapper does

--- a/pkg/proxystatus/proxystatus_test.go
+++ b/pkg/proxystatus/proxystatus_test.go
@@ -85,12 +85,19 @@ func TestRenderSections(t *testing.T) {
 		// it; routes join the spine via ┼/┴ junctions; a multihop route's extra
 		// hops hang off the RIGHT with └── connectors.
 		`class="tree"`, `class="bitree"`, "──┼──", "──┴──", "└──", "│",
-		// Tree header/legend (tp-tree style): color swatches name the source PK
-		// accent and the active/standby state dots, then the column hints — dead legs
-		// are pruned so there is no dead swatch.
+		// Tree legend, now BELOW the tree, with the state WORDS themselves colored
+		// (source accent / active green / standby amber) — no swatch dot. Dead legs
+		// are pruned so there is no dead entry.
 		`class="tlegend"`, `class="lgnd src"`,
-		`class="lgnd ok"`, `class="lgnd standby"`, `class="lgnd cols"`,
-		"this visor", "peer · [type] · tpid",
+		`class="lgnd ok"`, `class="lgnd standby"`,
+		"this visor",
+		// Label-header row (TreeHeader) rendered inside the tree <pre> as a template
+		// that lines up with the columns beneath: labels in place of the PKs/values.
+		`class="thead"`, "peer-pk", "tp-id", "tp-rtt", "R[n]",
+		// Header up/down throughput meters (moved to the top, between the brand and
+		// the surface name), driven by the inline script from the hidden cumulative
+		// byte counters.
+		`class="rates"`, `class="rmeter up"`, `class="rmeter down"`,
 		// FULL (never truncated) PKs: the source (root) and the multihop exit.
 		"03cc223344556677889900aabbccddeeff00112233445566778899aabbccddeeff",
 		"02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee",
@@ -106,14 +113,20 @@ func TestRenderSections(t *testing.T) {
 		// the WebSocket live indicator, route-group summary, and staged control tags.
 		"getSelection", "selectionchange", "execCommand",
 		`class="fpk copy"`, "data-copy=", "click to copy",
-		`id="wsstat"`, "reconnecting", `class="rgsummary"`, "rsync(this)", `class="soon"`,
+		`id="wsstat"`, "reconnecting", "rsync(this)", `class="soon"`,
+		// Hidden cumulative byte counters live inside the live region so each push
+		// refreshes them; the visible meters are in the static header.
+		`data-bytes="up" data-val=`, "hidden",
 		// Scroll preservation across the live-swap: apply() captures the window offset
 		// (and the log <pre>'s inner offset) before el.innerHTML=h and restores it, so
 		// scrolling the page horizontally doesn't snap back on the next ~1s push.
 		"window.scrollX", "window.scrollY", "window.scrollTo(", "pre.log",
-		// Page-level layout: the recent-log block keeps only its vertical max-height
-		// scroll (horizontal wraps / is page-level).
-		"overflow-y:auto",
+		// The log pane is a resizable black terminal: black background, user-draggable
+		// height (resize:vertical), its own scroll.
+		"background:#000", "resize:vertical",
+		// The route tree scrolls horizontally in its OWN overflow container (not the
+		// page body) when a long PK runs wide.
+		"overflow-x:auto",
 		// Embedded mononoki monospace font so the tree's box-drawing glyphs align:
 		// an @font-face woff2 data-URI in the shell + the family on the tree/PK cells.
 		"@font-face", "'Mononoki'", "data:font/woff2;base64,",
@@ -174,10 +187,15 @@ func TestRenderSections(t *testing.T) {
 			t.Errorf("status page must not render the removed %q markup", gone)
 		}
 	}
-	// The route tree is now page-level: no inner overflow-x scroll box (the PAGE
-	// scrolls horizontally instead), so a live-swap can restore the window offset.
-	if strings.Contains(page, "overflow-x:auto") {
-		t.Error("route tree must not use an inner overflow-x box (page-level scroll)")
+	// The layout pass removed the status pill row, the leg-census summary line, and
+	// the per-stream metering disclaimer sentence; guard their markup/text is gone.
+	for _, gone := range []string{
+		`class="pills"`, `class="pill"`, `class="rgsummary"`,
+		"not metered at the tunnel",
+	} {
+		if strings.Contains(page, gone) {
+			t.Errorf("status page must no longer contain %q", gone)
+		}
 	}
 }
 
@@ -191,7 +209,7 @@ func TestRenderFragmentIsLiveRegionOnly(t *testing.T) {
 		Logs: []string{"frag line"},
 	}
 	frag := string(RenderFragment(snap))
-	for _, want := range []string{"per-leg mux", "route, transport", "frag line", `class="pills"`} {
+	for _, want := range []string{"per-leg mux", "route, transport", "frag line"} {
 		if !strings.Contains(frag, want) {
 			t.Errorf("fragment missing %q", want)
 		}

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -49,6 +49,17 @@ func Render(snap Snapshot) []byte {
 	// drives it (connecting → live → reconnecting); it renders as a neutral dot for
 	// no-JS / non-skysocks surfaces.
 	b.WriteString(`<header><div class="brand"><b>skywire</b> proxy status</div>`)
+	// Live up/down throughput meters ride in the header, between the brand and the
+	// surface name. They are driven by the inline script, which differences the
+	// cumulative byte counters (kept hidden inside the live region, refreshed on
+	// every ~1s WebSocket push) and writes the rate here. The header is static
+	// (outside the swapped live region), so the script targets these spans
+	// document-wide rather than within the live region.
+	if live {
+		b.WriteString(`<div class="rates" title="live throughput (up / down)">` +
+			`<span class="rmeter up"><i>↑</i> <b class="rate" data-rate="up">—/s</b></span>` +
+			`<span class="rmeter down"><i>↓</i> <b class="rate" data-rate="down">—/s</b></span></div>`)
+	}
 	fmt.Fprintf(&b, `<div class="surface">%s</div>`, surface)
 	if live {
 		b.WriteString(`<span id="wsstat" class="wsstat wait" title="live update stream"><i class="dot"></i>connecting</span>`)
@@ -137,13 +148,14 @@ const liveScript = `<script>(function(){var t,ws,pend=null,last=null,pv=null;` +
 	`function fmtRate(b){b=b||0;if(b>=1048576){return (b/1048576).toFixed(1)+"M";}if(b>=1024){return (b/1024).toFixed(1)+"K";}return Math.round(b)+"B";}` +
 	`function meters(el){var now=Date.now(),cur={},ss=el.querySelectorAll(".stat[data-bytes]"),i;` +
 	`for(i=0;i<ss.length;i++){cur[ss[i].getAttribute("data-bytes")]=parseFloat(ss[i].getAttribute("data-val"))||0;}` +
-	`if(pv&&now>pv.t){var dt=(now-pv.t)/1000,rs=el.querySelectorAll(".rate[data-rate]"),k;` +
-	`for(k=0;k<rs.length;k++){var key=rs[k].getAttribute("data-rate"),d=(cur[key]||0)-(pv[key]||0);if(d<0){d=0;}rs[k].textContent="· "+fmtRate(d/dt)+"/s";}}` +
+	`if(pv&&now>pv.t){var dt=(now-pv.t)/1000,rs=document.querySelectorAll(".rate[data-rate]"),k;` +
+	`for(k=0;k<rs.length;k++){var key=rs[k].getAttribute("data-rate"),d=(cur[key]||0)-(pv[key]||0);if(d<0){d=0;}rs[k].textContent=fmtRate(d/dt)+"/s";}}` +
 	`pv={up:cur.up||0,down:cur.down||0,t:now};}` +
 	// Pin the log pane to the newest line unless the user has scrolled up to read
 	// back; restore any horizontal offset and the window offset as before.
 	`function apply(h){if(h===last){return;}var el=document.getElementById("live");if(!el){return;}` +
 	`var sx=window.scrollX,sy=window.scrollY,lg=el.querySelector("pre.log");` +
+	`var tr=el.querySelector(".tree"),trl=tr?tr.scrollLeft:0;` +
 	`var lt=lg?lg.scrollTop:0,ll=lg?lg.scrollLeft:0,pin=lg?(lg.scrollTop+lg.clientHeight>=lg.scrollHeight-4):true;` +
 	// Preserve the open/closed state of the open-streams <details> across the
 	// innerHTML swap (same idea as the scroll/selection guards): the WS restreams
@@ -151,7 +163,8 @@ const liveScript = `<script>(function(){var t,ws,pend=null,last=null,pv=null;` +
 	`var dop=el.querySelector("details.streams"),dopen=dop?dop.open:false;` +
 	`el.innerHTML=h;last=h;` +
 	`var ds=el.querySelector("details.streams");if(ds){ds.open=dopen;}` +
-	`var lg2=el.querySelector("pre.log");if(lg2){lg2.scrollTop=pin?lg2.scrollHeight:lt;lg2.scrollLeft=ll;}meters(el);window.scrollTo(sx,sy);}` +
+	`var lg2=el.querySelector("pre.log");if(lg2){lg2.scrollTop=pin?lg2.scrollHeight:lt;lg2.scrollLeft=ll;}` +
+	`var tr2=el.querySelector(".tree");if(tr2){tr2.scrollLeft=trl;}meters(el);window.scrollTo(sx,sy);}` +
 	`function push(h){if(selecting()){pend=h;return;}apply(h);}` +
 	`document.addEventListener("selectionchange",function(){if(pend!==null&&!selecting()){var h=pend;pend=null;apply(h);}});` +
 	`function connect(){stat("connecting","wait");try{ws=new WebSocket(url());}catch(e){slow();return;}` +
@@ -173,27 +186,6 @@ const liveScript = `<script>(function(){var t,ws,pend=null,last=null,pv=null;` +
 // writeLiveRegion writes the dynamic status content (pills, per-leg mux, events,
 // recent log) shared by Render (page shell) and RenderFragment (SSE push).
 func writeLiveRegion(b *strings.Builder, snap Snapshot) {
-	surface := html.EscapeString(string(snap.Surface))
-
-	// Status pills.
-	b.WriteString(`<div class="pills">`)
-	writePill(b, "surface", surface, "")
-	writePill(b, "app", html.EscapeString(snap.App), "")
-	if snap.Running {
-		writePill(b, "state", "running", "ok")
-	} else {
-		writePill(b, "state", "stopped", "warn")
-	}
-	if len(snap.Legs) > 0 {
-		mux := "off"
-		if snap.MuxEnabled {
-			mux = "on"
-		}
-		writePill(b, "mux", mux, "")
-		writePill(b, "legs", fmt.Sprintf("%d", len(snap.Legs)), "")
-	}
-	b.WriteString(`</div>`)
-
 	if snap.Note != "" {
 		fmt.Fprintf(b, `<p class="note">%s</p>`, html.EscapeString(snap.Note))
 	}
@@ -201,14 +193,6 @@ func writeLiveRegion(b *strings.Builder, snap Snapshot) {
 	writeStreamsSection(b, snap)
 	writeMuxSection(b, snap)
 	writeLogSection(b, snap)
-}
-
-func writePill(b *strings.Builder, k, v, cls string) {
-	c := "pill"
-	if cls != "" {
-		c += " " + cls
-	}
-	fmt.Fprintf(b, `<span class="%s"><i>%s</i> %s</span>`, c, html.EscapeString(k), v)
 }
 
 // writeMuxSection renders the route group as ONE unified route tree rooted at
@@ -229,67 +213,57 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 		return
 	}
 	var totSent, totRecv uint64
-	var nActive, nStandby, nClosed int
 	for _, l := range snap.Legs {
 		totSent += l.SentBytes
 		totRecv += l.RecvBytes
-		switch {
-		case !l.Alive:
-			nClosed++
-		case l.Standby:
-			nStandby++
-		default:
-			nActive++
-		}
 	}
-	// Scannable route-group summary: leg census + aggregate throughput, so the
-	// operator gets the shape of the group before reading the route tree. The
-	// cumulative sent/recv totals carry machine-readable data-bytes attributes so
-	// the live script can difference successive ~1s WebSocket pushes into the live
-	// up/down RATE meters (bytes/sec) beside them — no server-side rate needed and
-	// no per-leg speed field on the wire.
-	b.WriteString(`<div class="rgsummary">`)
-	writeStat(b, "legs", fmt.Sprintf("%d", len(snap.Legs)), "")
-	writeStat(b, "active", fmt.Sprintf("%d", nActive), "ok")
-	if nStandby > 0 {
-		writeStat(b, "standby", fmt.Sprintf("%d", nStandby), "standby")
-	}
-	if nClosed > 0 {
-		writeStat(b, "closed", fmt.Sprintf("%d", nClosed), "warn")
-	}
-	fmt.Fprintf(b, `<span class="stat" data-bytes="up" data-val="%d"><i>up</i> %s <b class="rate" data-rate="up">· —/s</b></span>`, totSent, humanBytes(totSent))
-	fmt.Fprintf(b, `<span class="stat" data-bytes="down" data-val="%d"><i>down</i> %s <b class="rate" data-rate="down">· —/s</b></span>`, totRecv, humanBytes(totRecv))
-	b.WriteString(`</div>`)
+	// Cumulative sent/recv byte counters, kept HIDDEN inside the live region so
+	// each ~1s WebSocket push refreshes them; the inline script differences them
+	// into the live up/down RATE meters shown in the header. No visible leg-census
+	// summary line here — the route tree below carries per-route state/rtt/bw.
+	fmt.Fprintf(b, `<span class="stat" data-bytes="up" data-val="%d" hidden></span>`, totSent)
+	fmt.Fprintf(b, `<span class="stat" data-bytes="down" data-val="%d" hidden></span>`, totRecv)
 
 	// The route tree itself: ONE shared bilateral model (pkg/proxystatus.RouteTree)
 	// rendered by pkg/bitree — the exact model + geometry `skywire cli proxy tree`
-	// prints, so the page and the terminal never drift. Root = this visor; each
-	// active route is a right branch (its hop chain, dead legs pruned) with a left
-	// summary (R[n], state glyph, route rtt, bandwidth). htmlStyleCell decorates
-	// cells (colored state dot, click-to-copy PKs/tpids) without disturbing the
-	// column alignment (layout is computed from the plain text).
+	// prints, so the page and the terminal never drift. Root = this visor (right-
+	// anchored over the spine); each active route is a right branch (its hop chain,
+	// dead legs pruned) with a left summary (R[n], state glyph, route rtt,
+	// bandwidth) padded into fixed columns. A label-header row (TreeHeader) rides
+	// above the tree as a template/legend that lines up with the columns beneath.
+	// htmlStyleCell decorates cells (colored state dot, click-to-copy PKs/tpids)
+	// without disturbing column alignment (layout is computed from the plain text).
+	// The tree is NOT boxed: it flows with the surrounding text at page margins and
+	// scrolls horizontally in its OWN overflow container only if a long PK runs wide.
+	hLeft, hLabel, hCols := TreeHeader()
 	b.WriteString(`<div class="tree">`)
-	writeTreeLegend(b)
 	b.WriteString(`<pre class="bitree">`)
-	b.WriteString(bitree.Render(RouteTree(snap), bitree.Options{StyleCell: htmlStyleCell}))
+	b.WriteString(bitree.Render(RouteTree(snap), bitree.Options{
+		StyleCell:   htmlStyleCell,
+		HeaderLeft:  hLeft,
+		HeaderLabel: hLabel,
+		HeaderCols:  hCols,
+	}))
 	b.WriteString(`</pre>`)
 	b.WriteString(`</div>`)
+	// Legend BELOW the tree: the state words are themselves colored (source accent,
+	// active green, standby amber) — no separate swatch dot.
+	writeTreeLegend(b)
 	b.WriteString(`<p class="hint">The same tree prints from <code>skywire cli proxy tree</code>; for a live chart use ` +
 		`<code>skywire cli proxy mux plot</code>.</p></section>`)
 }
 
-// writeTreeLegend prints a compact, monospace header/legend above the route tree
-// — mirroring `skywire cli tp tree`'s swatch+column header. It names the color
-// coding (source PK accent, active/standby state dot colors) with swatches, then
-// the left-summary and per-hop column hints, so the tree is self-describing
-// without a per-node word label. Dead legs are pruned, so there is no dead
-// swatch.
+// writeTreeLegend prints a compact legend BELOW the route tree. The words
+// themselves are colored in their state colors — "source · this visor" in the
+// source accent, "active" in green, "standby" in amber — instead of a separate
+// swatch dot beside each word. The column hints live in the label-header row
+// above the tree (TreeHeader), so the legend only names the color coding. Dead
+// legs are pruned, so there is no dead entry.
 func writeTreeLegend(b *strings.Builder) {
 	b.WriteString(`<div class="tlegend">` +
 		`<span class="lgnd src">source · this visor</span>` +
 		`<span class="lgnd ok">active ●</span>` +
 		`<span class="lgnd standby">standby ○</span>` +
-		`<span class="lgnd cols">left: R[n] · state · route-rtt · bw ↑↓ &nbsp; hop: peer · [type] · tpid · tp-rtt</span>` +
 		`</div>`)
 }
 
@@ -309,6 +283,10 @@ func htmlStyleCell(text string, kind bitree.CellKind) string {
 		return htmlTreeColumn(text)
 	case bitree.CellLeft:
 		return htmlLegSummary(text)
+	case bitree.CellHeaderLeft, bitree.CellHeaderLabel, bitree.CellHeaderColumn:
+		// The label-header row: template labels standing in for PKs/values, styled
+		// as a muted legend so it reads as a column header, not live data.
+		return `<span class="thead">` + html.EscapeString(text) + `</span>`
 	default:
 		return html.EscapeString(text)
 	}
@@ -378,8 +356,6 @@ func writeStreamsSection(b *strings.Builder, snap Snapshot) {
 			s.ID, html.EscapeString(orDash(s.Target)), html.EscapeString(compactAge(s.AgeMS)))
 	}
 	b.WriteString(`</tbody></table>`)
-	b.WriteString(`<p class="hint">Per-stream byte counts are not metered at the tunnel (yamux) layer; ` +
-		`the route-group <b>sent/recv</b> totals above are the byte counters that exist.</p>`)
 	b.WriteString(`</details>`)
 }
 
@@ -704,16 +680,6 @@ func writeFooter(b *strings.Builder, snap Snapshot) {
 
 // --- small helpers -----------------------------------------------------------
 
-// writeStat renders one chip in the route-group summary: an uppercase label and
-// its value, optionally tinted (ok/standby/warn) so leg census reads at a glance.
-func writeStat(b *strings.Builder, k, v, cls string) {
-	c := "stat"
-	if cls != "" {
-		c += " " + cls
-	}
-	fmt.Fprintf(b, `<span class="%s"><i>%s</i> %s</span>`, c, html.EscapeString(k), html.EscapeString(v))
-}
-
 // copyablePK renders a FULL (never truncated) public key as a click-to-copy
 // monospace cell. The [data-copy] attribute carries the exact value the delegated
 // copy handler writes to the clipboard; an empty key renders as an inert dash with
@@ -748,20 +714,6 @@ func orDash(s string) string {
 	return s
 }
 
-// humanBytes formats a byte count with a binary unit suffix.
-func humanBytes(n uint64) string {
-	const unit = 1024
-	if n < unit {
-		return fmt.Sprintf("%d B", n)
-	}
-	div, exp := uint64(unit), 0
-	for x := n / unit; x >= unit; x /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
-}
-
 // css: the dark default is tuned so every text token clears WCAG AA (≥4.5:1 for
 // body text) against --bg/--card — notably --muted (#a2a8cc ≈ 8:1 on --bg),
 // which every low-emphasis label (pills, table headers, .hint/.empty, footer,
@@ -774,23 +726,22 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`body{max-width:60rem;margin:0 auto;padding:1.2rem 1rem 3rem}` +
 	`header{display:flex;align-items:baseline;gap:.8rem;flex-wrap:wrap;border-bottom:1px solid var(--line);padding-bottom:.7rem}` +
 	`.brand b{font-weight:600;letter-spacing:.4px;background:linear-gradient(90deg,var(--accent),var(--accent2));-webkit-background-clip:text;background-clip:text;color:transparent}` +
-	`.brand{font-size:1rem}.surface{margin-left:auto;font:600 1.1rem ui-monospace,SFMono-Regular,monospace;color:#e7e9ff}` +
+	`.brand{font-size:1rem}.surface{margin-left:.2rem;font:600 1.1rem ui-monospace,SFMono-Regular,monospace;color:#e7e9ff}` +
+	// Live up/down throughput meters in the header, between the brand and the
+	// surface name. Pushed to the right edge (margin-left:auto) so the brand sits
+	// left and the meters+surface group sits right.
+	`.rates{margin-left:auto;display:inline-flex;gap:.7rem;align-items:baseline}` +
+	`.rmeter{font-size:12px;color:var(--muted)}.rmeter i{font-style:normal;margin-right:.15rem}` +
+	`.rmeter.up i{color:var(--ok)}.rmeter.down i{color:var(--cyan)}` +
+	`.rate{color:var(--accent);font-weight:600;font-size:12px;font-family:ui-monospace,SFMono-Regular,monospace}` +
 	`.wsstat{display:inline-flex;align-items:center;gap:.35rem;margin-left:.7rem;font-size:11px;text-transform:uppercase;letter-spacing:.4px;color:var(--muted)}` +
 	`.wsstat .dot{width:.5rem;height:.5rem;border-radius:50%;background:var(--muted);flex:none}` +
 	`.wsstat.ok{color:var(--ok)}.wsstat.ok .dot{background:var(--ok);box-shadow:0 0 6px var(--ok);animation:pulse 2s infinite}` +
 	`.wsstat.warn{color:var(--warn)}.wsstat.warn .dot{background:var(--warn)}` +
 	`.wsstat.wait{color:var(--standby)}.wsstat.wait .dot{background:var(--standby)}` +
 	`@keyframes pulse{0%,100%{opacity:1}50%{opacity:.35}}` +
-	`.pills{display:flex;flex-wrap:wrap;gap:.4rem;margin:.9rem 0}` +
-	`.pill{background:var(--card);border:1px solid var(--line);border-radius:999px;padding:.15rem .6rem;font-size:12px}` +
-	`.pill i{color:var(--muted);font-style:normal;margin-right:.25rem;text-transform:uppercase;font-size:10px;letter-spacing:.4px}` +
-	`.pill.ok{border-color:var(--ok);color:var(--ok)}.pill.warn{border-color:var(--warn);color:var(--warn)}` +
 	`h2{font-size:.95rem;margin:1.6rem 0 .5rem;color:#e7e9ff;font-weight:600}h2 small{color:var(--muted);font-weight:400;font-size:11px;margin-left:.4rem}` +
 	`.note{color:var(--standby)}.empty,.hint{color:var(--muted);font-size:12px}` +
-	`.rgsummary{display:flex;flex-wrap:wrap;gap:.4rem;margin:.2rem 0 .7rem}` +
-	`.stat{background:var(--card);border:1px solid var(--line);border-radius:6px;padding:.15rem .55rem;font-size:12px}` +
-	`.stat i{color:var(--muted);font-style:normal;margin-right:.3rem;text-transform:uppercase;font-size:10px;letter-spacing:.4px}` +
-	`.stat.ok{color:var(--ok)}.stat.warn{color:var(--warn)}.stat.standby{color:var(--standby)}` +
 	`.bar{display:block;height:.6rem;border-radius:3px;background:var(--accent);min-width:2px}` +
 	`.bar.ok{background:var(--ok)}.bar.standby{background:var(--standby)}.bar.warn{background:var(--warn)}` +
 	`.bar.recv{background:var(--recv,#3b9)}` +
@@ -799,12 +750,13 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`.copy{border-radius:3px;transition:background .15s,color .15s}` +
 	`body.js .copy{cursor:pointer}body.js .copy:hover{background:rgba(124,131,255,.14)}` +
 	`.copy.copied{background:var(--ok);color:#04120c}.copy.copied::after{content:" ✓ copied";font-size:10px;letter-spacing:.3px}` +
-	// One unified route tree (root = local visor; branches = first-hop peers).
-	// No inner overflow-x box: the tree lays out at page width and the PAGE (body)
-	// scrolls horizontally if the long full PKs run wide, so a scroll position is a
-	// window offset the live-swap can restore — not a nested scroll region that
-	// resets on every push.
-	`.tree{font-family:'Mononoki',ui-monospace,SFMono-Regular,monospace;font-size:11.5px;line-height:1.6;padding:.3rem 0;border:1px solid var(--line);border-radius:7px;background:var(--card);padding:.55rem .65rem}` +
+	// One unified route tree (root = local visor; branches = first-hop peers). The
+	// tree is NOT boxed: it flows with the surrounding prose at the same page
+	// margins, centered on the page like the text above and below it. It scrolls
+	// horizontally only if a long full PK runs wider than the page, and that scroll
+	// is confined to the tree's OWN overflow container (never the page body); the
+	// live-swap captures and restores that container's scrollLeft.
+	`.tree{margin:.5rem 0;overflow-x:auto;overflow-y:hidden}` +
 	// The route tree is one <pre class="bitree"> of monospace text laid out by
 	// pkg/bitree; every cell decorated by htmlStyleCell must keep the SAME font
 	// metrics or the aligned columns skew, so all inner code/span inherit the
@@ -824,40 +776,42 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`pre.bitree code.fpk{color:var(--fg)}pre.bitree .src code.fpk{color:var(--accent);font-weight:600}` +
 	`pre.bitree code.ftid{color:var(--muted)}pre.bitree .tcol{color:var(--muted)}` +
 	`pre.bitree .lsum.ok{color:var(--ok)}pre.bitree .lsum.standby{color:var(--standby)}` +
-	// Tree header/legend (mirrors `tp tree`'s swatch+column header): color swatches
-	// name the source/dest PK accents and the active/standby/dead state colors, then
-	// the column hints for what each tree line carries. Self-describes the tree so no
-	// per-node word pill is needed on the root ("this visor") or leaves ("exit").
-	`.tlegend{display:flex;flex-wrap:wrap;gap:.15rem .9rem;font-size:9.5px;text-transform:uppercase;letter-spacing:.3px;color:var(--muted);padding-bottom:.4rem;margin-bottom:.4rem;border-bottom:1px solid var(--line)}` +
-	`.lgnd{display:inline-flex;align-items:center;white-space:nowrap}` +
-	`.lgnd::before{content:"\2b24";margin-right:.3rem;font-size:8px;line-height:1}` +
-	`.lgnd.src::before{color:var(--accent)}.lgnd.dst::before{color:var(--accent2)}` +
-	`.lgnd.ok::before{color:var(--ok)}.lgnd.standby::before{color:var(--standby)}.lgnd.warn::before{color:var(--warn)}` +
-	`.lgnd.cols::before{content:none}.lgnd.cols{color:var(--muted);opacity:.85;text-transform:none;letter-spacing:0}` +
+	// Tree legend, BELOW the tree: the WORDS themselves are colored in their state
+	// colors (source accent, active green, standby amber) — no separate swatch dot
+	// beside each word. The column hints now live in the label-header row above the
+	// tree (.thead), so the legend only names the color coding.
+	`.tlegend{display:flex;flex-wrap:wrap;gap:.15rem 1.1rem;font-size:10px;text-transform:uppercase;letter-spacing:.3px;margin-top:.4rem}` +
+	`.lgnd{display:inline-flex;align-items:center;white-space:nowrap;font-weight:600}` +
+	`.lgnd.src{color:var(--accent)}.lgnd.ok{color:var(--ok)}.lgnd.standby{color:var(--standby)}` +
+	// The label-header row rendered inside the tree <pre>: template labels in place
+	// of PKs/values, muted so it reads as a column legend rather than live data.
+	`pre.bitree .thead{color:var(--muted);opacity:.9}` +
 	// State dot in the left per-route summary (replaces any active/standby word):
 	// color-blind-safe by shape (● active / ○ standby) as well as hue.
 	`pre.bitree .tstate{font-weight:700}` +
 	`pre.bitree .tstate.ok{color:var(--ok)}pre.bitree .tstate.standby{color:var(--standby)}` +
-	// Recent log: keep the vertical max-height scroll, but drop the horizontal
-	// inner scroll — lines wrap (pre-wrap + break-word) so any width is page-level.
-	`pre.log{background:var(--card);border:1px solid var(--line);border-radius:8px;padding:.7rem;font:11.5px/1.5 'Mononoki',ui-monospace,SFMono-Regular,monospace;` +
-	`white-space:pre-wrap;word-break:break-word;max-height:26rem;overflow-y:auto;color:var(--fg)}` +
+	// Recent log: a black terminal pane. The user can drag it taller/shorter
+	// (resize:vertical) — a generous default height, a sensible floor, and its own
+	// vertical scroll. Lines wrap (pre-wrap + break-word) so width stays page-level.
+	// The background is black in BOTH page themes (it reads as a terminal), so the
+	// token colors below are pinned to fixed bright values rather than the theme
+	// tokens (whose light-mode variants would be illegible on black).
+	`pre.log{background:#000;border:1px solid var(--line);border-radius:8px;padding:.7rem;font:11.5px/1.5 'Mononoki',ui-monospace,SFMono-Regular,monospace;` +
+	`white-space:pre-wrap;word-break:break-word;height:32rem;min-height:10rem;max-height:80vh;overflow:auto;resize:vertical;color:#c7cbe6}` +
 	// Per-token log coloring, matching `proxy start --verbose` (pkg/logging
-	// printColored): the [timestamp] is grey, the LEVEL word takes its level color
-	// (INFO green, WARN amber, ERROR/FATAL/PANIC red — a real red, not the pink
-	// --warn — DEBUG blue, TRACE grey), the "[prefix]:" token is cyan, the message
-	// is default, and each field key is tinted to the level color (value default).
-	`pre.log .ll-info{color:var(--ok)}pre.log .ll-warn{color:var(--standby)}pre.log .ll-error{color:var(--err)}` +
-	`pre.log .ll-debug{color:var(--accent)}pre.log .ll-trace{color:var(--muted)}` +
-	`pre.log .ll-ts{color:var(--muted)}pre.log .ll-prefix{color:var(--cyan)}` +
+	// printColored) on the black pane: the [timestamp] grey, the LEVEL word its
+	// level color (INFO green, WARN amber, ERROR/FATAL/PANIC a real red, DEBUG blue,
+	// TRACE grey), the "[prefix]:" token cyan, the message default, each field key
+	// tinted to the level color. Fixed hexes so the terminal look holds in both themes.
+	`pre.log .ll-info{color:#4ad9a4}pre.log .ll-warn{color:#e0b64a}pre.log .ll-error{color:#ff5c5c}` +
+	`pre.log .ll-debug{color:#7c83ff}pre.log .ll-trace{color:#a2a8cc}` +
+	`pre.log .ll-ts{color:#a2a8cc}pre.log .ll-prefix{color:#3fd0d8}` +
 	// Per-stream detail (expandable) behind the "N open stream(s)" count.
 	`details.streams{margin:.5rem 0}details.streams summary{cursor:pointer;font-size:12px;color:var(--muted)}` +
 	`details.streams summary b{color:var(--fg);margin-left:.2rem}` +
 	`table.strm{border-collapse:collapse;font-size:11.5px;margin:.4rem 0;font-family:'Mononoki',ui-monospace,SFMono-Regular,monospace}` +
 	`table.strm th,table.strm td{text-align:left;padding:.1rem 1rem .1rem 0;color:var(--fg);white-space:nowrap}` +
 	`table.strm th{color:var(--muted);text-transform:uppercase;font-size:9.5px;letter-spacing:.4px}` +
-	// Live up/down rate meters computed by the inline script from successive pushes.
-	`.stat .rate{margin-left:.2rem;color:var(--accent);font-weight:600;font-size:11px}` +
 	`.seam{opacity:.9}.controls{display:flex;flex-wrap:wrap;gap:.4rem;margin-top:.4rem}` +
 	`.controls button{font:inherit;font-size:12px;padding:.2rem .6rem;border:1px dashed var(--line);border-radius:6px;background:transparent;color:var(--muted);cursor:not-allowed}` +
 	`.controls button{position:relative}` +

--- a/pkg/proxystatus/routetree.go
+++ b/pkg/proxystatus/routetree.go
@@ -5,12 +5,16 @@
 // status.skysocks page (+ interstitial) and `skywire cli proxy tree` render
 // from this one model, so the terminal and the page always show the same shape.
 //
-// Layout (rendered by bitree, styled by each surface's own StyleCell):
+// Layout (rendered by bitree, styled by each surface's own StyleCell). The root
+// (source PK) is right-anchored over the spine descender, so ignoring the left
+// summary branches it reads as a normal downward tree with the source PK at top
+// in the same PK column as the hops:
 //
-//		                         this visor (source PK)
-//		R[0] ● 143ms 1.6K↑ 1.5K↓ ──┬── <exit PK>          [stcpr]  <tpid>  143ms
-//		R[1] ● 47ms  0.5K↑ 0.4K↓ ──┴── <hop1 PK>          [sudph]  <tpid>  47ms
-//		                               └── <exit PK>       [stcpr]  <tpid>  88ms
+//		                         <this visor / source PK>
+//		                         │
+//		R[0] ● 143ms 1.6K↑ 1.5K↓ ┬── <exit PK>          [stcpr]  <tpid>  143ms
+//		R[1] ● 47ms  0.5K↑ 0.4K↓ ┴── <hop1 PK>          [sudph]  <tpid>  47ms
+//		                          └── <exit PK>          [stcpr]  <tpid>  88ms
 //
 //	  - Root = this visor (the source PK, taken from any leg's first hop).
 //	  - Each ACTIVE route is a top-level right child; DEAD legs are pruned.
@@ -26,6 +30,8 @@ package proxystatus
 import (
 	"fmt"
 	"sort"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/skycoin/skywire/pkg/bitree"
 )
@@ -68,16 +74,52 @@ func RouteTree(snap Snapshot) *bitree.Node {
 		return legs[i].Index < legs[j].Index
 	})
 
+	w := legSumWidths(legs)
 	for _, l := range legs {
-		root.Right = append(root.Right, routeToNode(l))
+		root.Right = append(root.Right, routeToNode(l, w))
 	}
 	return root
 }
 
+// sumWidths holds the per-field display widths used to pad every route's left
+// summary into fixed columns, so R[n], the route-rtt and the ↑/↓ bandwidth line
+// up vertically across all routes instead of being ragged (only the whole block
+// was right-justified before).
+type sumWidths struct{ idx, rtt, up, down int }
+
+// legSumWidths measures the widest value in each left-summary field across the
+// legs, so legSummary can pad every field to a common column width.
+func legSumWidths(legs []Leg) sumWidths {
+	var w sumWidths
+	for _, l := range legs {
+		if n := len(fmt.Sprintf("R[%d]", l.Index)); n > w.idx {
+			w.idx = n
+		}
+		if n := utf8.RuneCountInString(routeRTTCompact(l.RouteLatencyMS)); n > w.rtt {
+			w.rtt = n
+		}
+		if n := utf8.RuneCountInString(compactBytes(l.SentBytes) + "↑"); n > w.up {
+			w.up = n
+		}
+		if n := utf8.RuneCountInString(compactBytes(l.RecvBytes) + "↓"); n > w.down {
+			w.down = n
+		}
+	}
+	return w
+}
+
+// TreeHeader returns the label-header row fields (left group, peer label,
+// trailing-column labels) for a route tree, shaped so bitree can render them as
+// a template row that lines up with the columns of the tree beneath. Only the
+// page uses it; `proxy tree` renders headerless.
+func TreeHeader() (left, label string, cols []string) {
+	return "R[n] · state · route-rtt · bw ↑↓", "peer-pk", []string{"[type]", "tp-id", "tp-rtt"}
+}
+
 // routeToNode turns one leg into a hop-chain right-branch carrying its left
 // summary on the head (spine) row.
-func routeToNode(l Leg) *bitree.Node {
-	left := &bitree.Node{Label: legSummary(l)}
+func routeToNode(l Leg, w sumWidths) *bitree.Node {
+	left := &bitree.Node{Label: legSummary(l, w)}
 
 	if len(l.Hops) == 0 {
 		// No recorded path: a single leaf at the remote PK.
@@ -105,15 +147,36 @@ func hopToNode(h Hop) *bitree.Node {
 
 // legSummary is the left annotation for a route: identity, state glyph,
 // end-to-end route rtt, and bandwidth. No state word — the glyph (colored by
-// the surface's StyleCell) carries active vs standby.
-func legSummary(l Leg) string {
+// the surface's StyleCell) carries active vs standby. Each field is padded to a
+// common width (w) so the fields line up in fixed columns across all routes: the
+// R[n] identity left-justified, the numeric route-rtt and ↑/↓ bandwidth
+// right-justified.
+func legSummary(l Leg, w sumWidths) string {
 	g := GlyphActive
 	if l.Standby {
 		g = GlyphStandby
 	}
-	return fmt.Sprintf("R[%d] %s %s %s↑ %s↓",
-		l.Index, g, routeRTTCompact(l.RouteLatencyMS),
-		compactBytes(l.SentBytes), compactBytes(l.RecvBytes))
+	idx := padRightRunes(fmt.Sprintf("R[%d]", l.Index), w.idx)
+	rtt := padLeftRunes(routeRTTCompact(l.RouteLatencyMS), w.rtt)
+	up := padLeftRunes(compactBytes(l.SentBytes)+"↑", w.up)
+	down := padLeftRunes(compactBytes(l.RecvBytes)+"↓", w.down)
+	return idx + " " + g + " " + rtt + " " + up + " " + down
+}
+
+// padRightRunes/padLeftRunes pad s to n display columns (rune count), on the
+// right (left-justify) and left (right-justify) respectively.
+func padRightRunes(s string, n int) string {
+	if p := n - utf8.RuneCountInString(s); p > 0 {
+		return s + strings.Repeat(" ", p)
+	}
+	return s
+}
+
+func padLeftRunes(s string, n int) string {
+	if p := n - utf8.RuneCountInString(s); p > 0 {
+		return strings.Repeat(" ", p) + s
+	}
+	return s
 }
 
 // orDashPK returns a full (never truncated) PK or a dash when empty.


### PR DESCRIPTION
Layout refinement pass on the status.skysocks page (and the shared bitree route-tree model).

- Header now carries the live up/down throughput meters, between the brand and the surface name; they read hidden cumulative byte counters in the live region and the inline script writes the rate.
- Removed the status pill row and the leg-census summary line.
- Tree legend moved below the tree; the state words are themselves colored (source accent / active green / standby amber) instead of a swatch dot.
- New bitree header option renders a label-header row that lines up with the tree columns beneath (labels in place of PKs/values).
- Root (source) PK is right-anchored over the spine descender, so ignoring the left summary branches it reads as a normal downward tree; left summary fields padded into fixed columns.
- Tree lifted out of its card box: flows with the surrounding text, scrolls horizontally only in its own overflow container.
- Log pane is now a resizable black terminal; per-stream metering disclaimer removed.

`skywire cli proxy tree` renders from the same shared model (headerless), so terminal and page stay in sync. Tests updated in pkg/bitree and pkg/proxystatus.