### PR TITLE
feat(tpd): server-side transport summary endpoint (tp -s without fetching all)

### DIFF
--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -597,6 +597,9 @@ func (s *memoryStore) GetTransportByID(context.Context, uuid.UUID) (*transport.E
 func (s *memoryStore) GetNumberOfTransports(context.Context) (map[tptypes.Type]int, error) {
 	return nil, nil
 }
+func (s *memoryStore) GetTransportSummary(context.Context, bool) (*store.TransportSummary, error) {
+	return &store.TransportSummary{ByType: map[string]int{}}, nil
+}
 func (s *memoryStore) GetAllTransports(context.Context, bool) ([]*transport.Entry, error) {
 	return s.entries, nil
 }

--- a/cmd/skywire-cli/commands/tp/tp-stats_test.go
+++ b/cmd/skywire-cli/commands/tp/tp-stats_test.go
@@ -1,0 +1,46 @@
+// Package clitp cmd/skywire-cli/commands/tp/tp-stats_test.go c4-vis-cli
+package clitp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCountTransportList covers the client-side fallback path of
+// `tp -s -N`: when TPD lacks the /all-transports/stats aggregate endpoint,
+// the CLI fetches the full /all-transports list and counts it into the same
+// summary shape the endpoint would have returned.
+func TestCountTransportList(t *testing.T) {
+	// Two stcpr sharing edge "a", one sudph between "c"/"d" — 3 transports,
+	// two types, 5 unique visors (a,b1,b2,c,d).
+	body := []byte(`[
+		{"t_id":"1","edges":["a","b1"],"type":"stcpr"},
+		{"t_id":"2","edges":["a","b2"],"type":"stcpr"},
+		{"t_id":"3","edges":["c","d"],"type":"sudph"}
+	]`)
+
+	ns, err := countTransportList(body)
+	require.NoError(t, err)
+	require.Equal(t, 3, ns.Total)
+	require.Equal(t, 2, ns.ByType["stcpr"])
+	require.Equal(t, 1, ns.ByType["sudph"])
+	require.Equal(t, 5, ns.UniqueVisors)
+}
+
+// TestCountTransportListEmpty confirms an empty list yields zeroed counts
+// rather than an error.
+func TestCountTransportListEmpty(t *testing.T) {
+	ns, err := countTransportList([]byte(`[]`))
+	require.NoError(t, err)
+	require.Equal(t, 0, ns.Total)
+	require.Equal(t, 0, ns.UniqueVisors)
+	require.Empty(t, ns.ByType)
+}
+
+// TestCountTransportListBadJSON confirms malformed input is reported as an
+// error (the caller turns it into a fatal CLI error) rather than panicking.
+func TestCountTransportListBadJSON(t *testing.T) {
+	_, err := countTransportList([]byte(`not-json`))
+	require.Error(t, err)
+}

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -40,6 +40,7 @@ var (
 	logger           = logging.MustGetLogger("skywire-cli")
 	tpTypes          bool
 	showStats        bool
+	statsNetwork     bool
 	utURL            string
 	sdURL            string
 	listRemoteVisors []string
@@ -90,6 +91,7 @@ func init() {
 	tpCmd.Flags().StringVarP(&tpID, "id", "i", "", "display transport matching ID")
 	tpCmd.Flags().BoolVarP(&tpTypes, "tptypes", "u", false, "display transport types used by the local visor")
 	tpCmd.Flags().BoolVarP(&showStats, "stats", "s", false, "show transport statistics (count by type, unique visors)")
+	tpCmd.Flags().BoolVarP(&statsNetwork, "network", "N", false, "with --stats: show the network-wide summary from Transport Discovery instead of the local visor")
 	tpCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
 	tpCmd.Flags().StringSliceVar(&listRemoteVisors, "remote", nil, "list transports on remote visor(s) via TPS (comma-separated PKs)")
 	tpCmd.Flags().BoolVarP(&tpLive, "live", "L", false, "live-refresh mode (bubbletea TUI, 1s tick); shows transport bandwidth/latency updating in place. Skips --more service-disc fetches per tick; not compatible with --remote/--id/--tptypes")
@@ -256,6 +258,32 @@ var tpCmd = &cobra.Command{
 			types, err := rpcClient.TransportTypes()
 			internal.Catch(cmd.Flags(), err)
 			internal.PrintOutput(cmd.Flags(), types, fmt.Sprintln(strings.Join(types, "\n")))
+			return
+		}
+
+		if showStats && statsNetwork {
+			// Network-wide summary from Transport Discovery. The aggregate is
+			// computed server-side (GET /all-transports/stats), so we fetch a
+			// small JSON summary instead of the whole transport list. Older
+			// TPDs without that endpoint fall back to the full /all-transports
+			// fetch, counted client-side.
+			ns := fetchNetworkTransportStats(cmd)
+
+			var b strings.Builder
+			fmt.Fprintf(&b, "Network transports:  %d\n", ns.Total)
+			fmt.Fprintf(&b, "Unique visors:       %d\n\n", ns.UniqueVisors)
+			fmt.Fprintf(&b, "  %-10s %s\n", "type", "total")
+			typeNames := make([]string, 0, len(ns.ByType))
+			for t := range ns.ByType {
+				typeNames = append(typeNames, t)
+			}
+			sort.Strings(typeNames)
+			for _, t := range typeNames {
+				fmt.Fprintf(&b, "  %-10s %d\n", t, ns.ByType[t])
+			}
+			fmt.Fprintf(&b, "  %-10s %d\n", "total", ns.Total)
+
+			internal.PrintOutput(cmd.Flags(), ns, b.String())
 			return
 		}
 
@@ -429,6 +457,67 @@ type statsOutput struct {
 	Outgoing     int                  `json:"outgoing"`
 	UniqueVisors int                  `json:"unique_visors"`
 	ByType       map[string]*typeStat `json:"by_type"`
+}
+
+// netStatsOutput is the JSON/text payload for `tp -s -N` (the network-wide
+// summary from Transport Discovery). Direction (in/out) is a per-visor
+// concept with no network-wide meaning, so only totals are reported.
+type netStatsOutput struct {
+	Total        int            `json:"total_transports"`
+	ByType       map[string]int `json:"by_type"`
+	UniqueVisors int            `json:"unique_visors"`
+}
+
+// fetchNetworkTransportStats returns the network-wide transport summary from
+// Transport Discovery. It prefers the server-side aggregate endpoint
+// (GET /all-transports/stats), so it fetches a small JSON summary rather than
+// the whole transport list. If that endpoint is unavailable (older TPD), it
+// falls back to fetching /all-transports and counting client-side.
+func fetchNetworkTransportStats(cmd *cobra.Command) netStatsOutput {
+	base := strings.TrimRight(utURL, "/")
+	if body, err := clirpc.FetchServiceURL(cmd.Flags(), base+"/all-transports/stats"); err == nil {
+		var ns netStatsOutput
+		if json.Unmarshal(body, &ns) == nil && ns.ByType != nil {
+			return ns
+		}
+	}
+
+	// Fallback for older TPDs: fetch the full list and count client-side.
+	body, err := clirpc.FetchServiceURL(cmd.Flags(), base+"/all-transports")
+	if err != nil {
+		internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to fetch network transport summary: %w", err))
+	}
+	ns, err := countTransportList(body)
+	if err != nil {
+		internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to parse transport list: %w", err))
+	}
+	return ns
+}
+
+// countTransportList aggregates an /all-transports JSON array into the same
+// summary shape the server-side /all-transports/stats endpoint returns. It is
+// the client-side fallback used against TPDs that predate the stats endpoint.
+func countTransportList(body []byte) (netStatsOutput, error) {
+	var entries []struct {
+		Edges []string `json:"edges"`
+		Type  string   `json:"type"`
+	}
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return netStatsOutput{}, err
+	}
+	ns := netStatsOutput{ByType: make(map[string]int)}
+	uniqueVisors := make(map[string]struct{})
+	for _, e := range entries {
+		ns.Total++
+		ns.ByType[e.Type]++
+		for _, edge := range e.Edges {
+			if edge != "" {
+				uniqueVisors[edge] = struct{}{}
+			}
+		}
+	}
+	ns.UniqueVisors = len(uniqueVisors)
+	return ns, nil
 }
 
 // inactiveTransport represents a transport that is no longer active but has bandwidth history

--- a/pkg/deployment/tpd/api/api_test.go
+++ b/pkg/deployment/tpd/api/api_test.go
@@ -112,6 +112,46 @@ func TestRegisterTransport(t *testing.T) {
 	assert.Equal(t, sEntry.Entry, resp[0].Entry)
 }
 
+func TestGETAllTransportsStats(t *testing.T) {
+	mock := newTestStore(t)
+	ctx := context.Background()
+	nonceStoreConfig := storeconfig.Config{Type: storeconfig.Memory}
+	nonceMock, err := httpauth.NewNonceStore(ctx, nonceStoreConfig, "")
+	require.NoError(t, err)
+
+	// Seed: two stcpr sharing edge a1, one sudph — 3 transports, 3 types
+	// counted, and 5 unique visors (a1,b1,b2 + the two sudph edges).
+	a1, _ := cipher.GenerateKeyPair()
+	b1, _ := cipher.GenerateKeyPair()
+	b2, _ := cipher.GenerateKeyPair()
+	c1, _ := cipher.GenerateKeyPair()
+	c2, _ := cipher.GenerateKeyPair()
+	seed := []*transport.SignedEntry{
+		{Entry: &transport.Entry{ID: uuid.New(), Edges: transport.SortEdges(a1, b1), Type: "stcpr"}},
+		{Entry: &transport.Entry{ID: uuid.New(), Edges: transport.SortEdges(a1, b2), Type: "stcpr"}},
+		{Entry: &transport.Entry{ID: uuid.New(), Edges: transport.SortEdges(c1, c2), Type: "sudph"}},
+	}
+	require.NoError(t, mock.RegisterTransportsBatch(ctx, cipher.PubKey{}, seed))
+
+	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty(), "", "")
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/all-transports/stats", nil)
+	api.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp struct {
+		Total        int            `json:"total_transports"`
+		ByType       map[string]int `json:"by_type"`
+		UniqueVisors int            `json:"unique_visors"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 3, resp.Total)
+	assert.Equal(t, 2, resp.ByType["stcpr"])
+	assert.Equal(t, 1, resp.ByType["sudph"])
+	assert.Equal(t, 5, resp.UniqueVisors)
+}
+
 func TestRegisterTimeout(t *testing.T) {
 	const timeout = 10 * time.Millisecond
 

--- a/pkg/deployment/tpd/api/endpoints.go
+++ b/pkg/deployment/tpd/api/endpoints.go
@@ -392,38 +392,36 @@ func (api *API) getAllTransportsStats(w http.ResponseWriter, r *http.Request) {
 		selfTransports = false
 	}
 
-	entries := api.getTransportsFromCache(selfTransports)
-	if entries == nil {
+	// Warm path: the background-refreshed all-transports cache is already
+	// in RAM, so count off it (no redis round-trip). Cold path: count in
+	// the store via GetTransportSummary — a single index+MGET pass that
+	// never materializes []*transport.Entry.
+	var summary *store.TransportSummary
+	if entries := api.getTransportsFromCache(selfTransports); entries != nil {
+		summary = &store.TransportSummary{ByType: make(map[string]int)}
+		uniqueVisors := make(map[cipher.PubKey]struct{})
+		for _, entry := range entries {
+			summary.Total++
+			summary.ByType[string(entry.Type)]++
+			for _, edge := range entry.Edges {
+				uniqueVisors[edge] = struct{}{}
+			}
+		}
+		summary.UniqueVisors = len(uniqueVisors)
+	} else {
 		var err error
-		entries, err = api.store.GetAllTransports(r.Context(), selfTransports)
+		summary, err = api.store.GetTransportSummary(r.Context(), selfTransports)
 		if err != nil {
 			api.writeError(w, r, err)
 			return
 		}
 	}
-	if len(entries) == 0 {
+	if summary.Total == 0 {
 		api.writeError(w, r, store.ErrTransportNotFound)
 		return
 	}
 
-	// Calculate network-wide statistics
-	byType := make(map[string]int)
-	uniqueVisors := make(map[cipher.PubKey]struct{})
-
-	for _, entry := range entries {
-		byType[string(entry.Type)]++
-		for _, edge := range entry.Edges {
-			uniqueVisors[edge] = struct{}{}
-		}
-	}
-
-	stats := map[string]interface{}{
-		"total_transports": len(entries),
-		"by_type":          byType,
-		"unique_visors":    len(uniqueVisors),
-	}
-
-	httputil.WriteJSON(w, r, http.StatusOK, stats)
+	httputil.WriteJSON(w, r, http.StatusOK, summary)
 }
 
 func (api *API) getAllTransportsPerKeyStats(w http.ResponseWriter, r *http.Request) {

--- a/pkg/deployment/tpd/store/memory_store.go
+++ b/pkg/deployment/tpd/store/memory_store.go
@@ -131,6 +131,28 @@ func (s *memoryStore) GetNumberOfTransports(context.Context) (map[types.Type]int
 	return response, nil
 }
 
+func (s *memoryStore) GetTransportSummary(_ context.Context, selfTransports bool) (*TransportSummary, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	summary := &TransportSummary{ByType: make(map[string]int)}
+	uniqueVisors := make(map[cipher.PubKey]struct{})
+	for _, entry := range s.transports {
+		if entry == nil {
+			continue
+		}
+		if !selfTransports && entry.Edges[0] == entry.Edges[1] {
+			continue
+		}
+		summary.Total++
+		summary.ByType[string(entry.Type)]++
+		for _, edge := range entry.Edges {
+			uniqueVisors[edge] = struct{}{}
+		}
+	}
+	summary.UniqueVisors = len(uniqueVisors)
+	return summary, nil
+}
+
 func (s *memoryStore) GetAllTransports(_ context.Context, selfTransports bool) ([]*transport.Entry, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/deployment/tpd/store/memory_store_test.go
+++ b/pkg/deployment/tpd/store/memory_store_test.go
@@ -124,6 +124,43 @@ func TestMemoryStore_SelfTransportFilter(t *testing.T) {
 	require.Empty(t, withoutSelf)
 }
 
+func TestMemoryStore_GetTransportSummary(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStore()
+
+	// Two stcpr, one sudph. e1 and e2 share edge a1 so the unique-visor
+	// count is < 2*transports.
+	a1, _ := cipher.GenerateKeyPair()
+	b1, _ := cipher.GenerateKeyPair()
+	b2, _ := cipher.GenerateKeyPair()
+	e1 := &transport.Entry{ID: uuid.New(), Edges: transport.SortEdges(a1, b1), Type: types.STCPR}
+	e2 := &transport.Entry{ID: uuid.New(), Edges: transport.SortEdges(a1, b2), Type: types.STCPR}
+	e3, _, _ := memEntry(t, types.SUDPH)
+	require.NoError(t, s.RegisterTransportsBatch(ctx, cipher.PubKey{}, []*transport.SignedEntry{signed(e1), signed(e2), signed(e3)}))
+
+	sum, err := s.GetTransportSummary(ctx, true)
+	require.NoError(t, err)
+	require.Equal(t, 3, sum.Total)
+	require.Equal(t, 2, sum.ByType[string(types.STCPR)])
+	require.Equal(t, 1, sum.ByType[string(types.SUDPH)])
+	// Visors: a1, b1, b2, plus the two edges of e3 = 5 unique.
+	require.Equal(t, 5, sum.UniqueVisors)
+
+	// A self-transport is excluded when selfTransports=false.
+	self, _ := cipher.GenerateKeyPair()
+	selfEntry := &transport.Entry{ID: uuid.New(), Edges: [2]cipher.PubKey{self, self}, Type: types.STCPR}
+	require.NoError(t, s.RegisterTransport(ctx, cipher.PubKey{}, signed(selfEntry)))
+
+	withSelf, err := s.GetTransportSummary(ctx, true)
+	require.NoError(t, err)
+	require.Equal(t, 4, withSelf.Total)
+
+	withoutSelf, err := s.GetTransportSummary(ctx, false)
+	require.NoError(t, err)
+	require.Equal(t, 3, withoutSelf.Total)
+	require.Equal(t, 5, withoutSelf.UniqueVisors)
+}
+
 func TestMemoryStore_NoopAndEmptyMethods(t *testing.T) {
 	ctx := context.Background()
 	s := newMemoryStore()

--- a/pkg/deployment/tpd/store/redis_transport.go
+++ b/pkg/deployment/tpd/store/redis_transport.go
@@ -401,6 +401,60 @@ func (s *redisStore) GetNumberOfTransports(ctx context.Context) (map[types.Type]
 	return response, nil
 }
 
+// GetTransportSummary counts total transports, per-type totals and unique
+// visors in a single index+MGET pass. It decodes only Type and the two
+// edge PKs from each blob — no *transport.Entry allocation and no durable
+// latency overlay — so /all-transports/stats can answer on a cold cache
+// without materializing the whole list.
+func (s *redisStore) GetTransportSummary(ctx context.Context, selfTransports bool) (*TransportSummary, error) {
+	keys, ids, err := s.allTransportKeysFromIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := &TransportSummary{ByType: make(map[string]int)}
+	uniqueVisors := make(map[string]struct{})
+
+	const mgetBatch = 10000
+	var stale []interface{}
+	for i := 0; i < len(keys); i += mgetBatch {
+		end := i + mgetBatch
+		if end > len(keys) {
+			end = len(keys)
+		}
+		vals, err := s.client.MGet(ctx, keys[i:end]...).Result()
+		if err != nil {
+			continue
+		}
+		for j, val := range vals {
+			raw, ok := val.(string)
+			if !ok || raw == "" {
+				stale = append(stale, ids[i+j])
+				continue
+			}
+			var data TransportData
+			if err := json.Unmarshal([]byte(raw), &data); err != nil {
+				continue
+			}
+			if !selfTransports && data.EdgeA == data.EdgeB {
+				continue
+			}
+			summary.Total++
+			summary.ByType[data.Type]++
+			if data.EdgeA != "" {
+				uniqueVisors[data.EdgeA] = struct{}{}
+			}
+			if data.EdgeB != "" {
+				uniqueVisors[data.EdgeB] = struct{}{}
+			}
+		}
+	}
+	s.maybeReapStaleTransports(stale)
+
+	summary.UniqueVisors = len(uniqueVisors)
+	return summary, nil
+}
+
 func (s *redisStore) GetAllTransports(ctx context.Context, selfTransports bool) ([]*transport.Entry, error) {
 	if entries, ok := s.allTpsCache.Get(selfTransports, false); ok {
 		return entries, nil

--- a/pkg/deployment/tpd/store/store.go
+++ b/pkg/deployment/tpd/store/store.go
@@ -166,6 +166,16 @@ type TransportUptimeSummary struct {
 	Timeline map[string]string `json:"timeline,omitempty"`
 }
 
+// TransportSummary is a network-wide aggregate of registered transports,
+// computed server-side so a client can obtain the counts without fetching
+// (and counting) the full transport list. Marshals to the same JSON shape
+// as GET /all-transports/stats.
+type TransportSummary struct {
+	Total        int            `json:"total_transports"`
+	ByType       map[string]int `json:"by_type"`
+	UniqueVisors int            `json:"unique_visors"`
+}
+
 // Store stores Transport metadata and generated nonce values.
 type Store interface {
 	TransportStore
@@ -189,6 +199,13 @@ type TransportStore interface {
 	// keys and the JSON decode that follows.
 	GetTransportsByEdgeNoLatency(context.Context, cipher.PubKey) ([]*transport.Entry, error)
 	GetNumberOfTransports(context.Context) (map[types.Type]int, error)
+	// GetTransportSummary returns network-wide aggregate counts (total,
+	// per-type, unique visors) computed in a single index+MGET pass that
+	// never materializes []*transport.Entry — the cheap path behind GET
+	// /all-transports/stats, so a client counting transports doesn't have
+	// to fetch every entry. selfTransports=false excludes loopback
+	// self-transports (Edges[0]==Edges[1]), matching GetAllTransports.
+	GetTransportSummary(ctx context.Context, selfTransports bool) (*TransportSummary, error)
 	GetAllTransports(context.Context, bool) ([]*transport.Entry, error)
 	// Bandwidth ingest (called by the CXO aggregator with the
 	// reporter's cumulative counters; deltas are computed

--- a/pkg/visor/hypervisor_handlers_routing_tools.go
+++ b/pkg/visor/hypervisor_handlers_routing_tools.go
@@ -279,6 +279,9 @@ func (s *hvCalcStore) GetTransportByID(context.Context, uuid.UUID) (*transport.E
 func (s *hvCalcStore) GetNumberOfTransports(context.Context) (map[tptypes.Type]int, error) {
 	return nil, nil
 }
+func (s *hvCalcStore) GetTransportSummary(context.Context, bool) (*tpdstore.TransportSummary, error) {
+	return &tpdstore.TransportSummary{ByType: map[string]int{}}, nil
+}
 func (s *hvCalcStore) GetAllTransports(context.Context, bool) ([]*transport.Entry, error) {
 	return nil, nil
 }

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -989,6 +989,9 @@ func (s *calcMemStore) GetTransportByID(context.Context, uuid.UUID) (*transport.
 func (s *calcMemStore) GetNumberOfTransports(context.Context) (map[tptypes.Type]int, error) {
 	return nil, nil
 }
+func (s *calcMemStore) GetTransportSummary(context.Context, bool) (*tpdstore.TransportSummary, error) {
+	return &tpdstore.TransportSummary{ByType: map[string]int{}}, nil
+}
 func (s *calcMemStore) GetAllTransports(context.Context, bool) ([]*transport.Entry, error) {
 	return nil, nil
 }


### PR DESCRIPTION
`GET /all-transports/stats` already returns the network-wide `{total_transports, by_type, unique_visors}` aggregate, but on a cold cache it materialized the full `[]*transport.Entry` list just to count it. This adds `store.GetTransportSummary`, a single index+MGET pass that counts total, per-type and unique visors without building Entry objects or the latency overlay, and the handler now uses it on the cold path (the warm background-cache path is unchanged; the JSON is identical).

On the CLI side, `tp -s -N/--network` fetches that compact summary from Transport Discovery instead of counting the local visor's transports, with a fallback to the full `/all-transports` fetch counted client-side for TPDs that predate the endpoint. Default `tp -s` stays the local-visor summary.

Tests cover the store summary counts against a seeded store, the stats handler response, and the client-side fallback counter.