### PR TITLE
feat(sd): shard services CXO feed to one leaf per type

### DIFF
--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -61,8 +61,9 @@ const (
 	// FeedTPDUptime is TPD's uptime-aggregate publisher
 	// (uptimes/days/<n>).
 	FeedTPDUptime
-	// FeedSDServices is SD's services publisher
-	// (services/<type>/<pk>/{entry,tombstone}).
+	// FeedSDServices is SD's services publisher (one batched leaf per
+	// type at services/<type>/all; older publishers used
+	// services/<type>/<pk>/entry).
 	FeedSDServices
 	// FeedDMSGDClientsByServer is DMSG-D's clients-by-server publisher
 	// (one batched leaf per server at clients-by-server/<server>; older

--- a/pkg/deployment/sd/api/cxo_publisher.go
+++ b/pkg/deployment/sd/api/cxo_publisher.go
@@ -5,20 +5,52 @@
 // Subscribers (the hypervisor's network visualizer + tab-specific
 // consumers) read the live set of registered services from a single
 // TreeStore feed instead of polling /api/services?type=... over HTTP.
-// Tree shape:
 //
-//	services/<type>/<pk>/entry        // JSON-encoded servicedisc.Service
-//	services/<type>/<pk>/tombstone    // JSON {"deleted_at": "..."}
+// # Wire shape: ONE batched leaf per service type
 //
-// Type-as-prefix lets a consumer that only cares about one service
-// kind (e.g. just VPN) subscribe to services/vpn/ and skip the rest.
+// Each service type gets exactly one leaf carrying that type's whole
+// live service set:
 //
-// Event-driven: register/update calls Put on success; explicit
-// deregister calls Delete (and Put on the tombstone leaf); expiry
-// sweep emits tombstones for entries the redis cleanup found stale.
-// CXO content-addresses, so re-publishing an unchanged entry is a
-// no-op at the wire layer — heartbeats from a still-alive service
-// don't burn bandwidth.
+//	services/<type>/all        // FrameGzip(v1, JSON []servicedisc.Service)
+//
+// Older builds published one leaf PER service at
+// services/<type>/<pk>/entry (+ an optional /tombstone) — O(#services),
+// one tiny object per registered service. A large deployment's Root then
+// could not finish filling over a subscriber's short-lived delivering
+// dmsg conn. Sharding by type collapses the object count to O(#types)
+// (~10). The batch leaf lives UNDER the type dir (…/all, not a bare
+// services/<type>) so every existing consumer prefix — services/,
+// services/visor/, services/<type>/ — still walks straight onto it; a
+// service PK is 66 hex chars and never collides with the "all" segment.
+//
+// Encoding is JSON+gzip, not fixed-layout binary: servicedisc.Service
+// carries several optional, variable-length nested structs (Geo, VPNInfo,
+// CoinInfo, LocalIPs), so it is the "awkward for binary" case — unlike
+// telemetrywire's fixed rows. Services are sorted by PK so an unchanged
+// set re-encodes to identical bytes (a CXO content-addressed wire no-op),
+// then version-framed + gzipped (cxoutils.FrameGzip). The version byte
+// gates the format: a bumped version is rejected cleanly by an old reader
+// rather than misparsed.
+//
+// # Interop / deploy order
+//
+// Deploy is SERVICE-FIRST. A not-yet-upgraded reader walking a type
+// prefix looks for the OLD .../<pk>/entry leaves, finds only the batched
+// …/all leaf, reports an empty snapshot for that type, and falls back to
+// HTTP — safe degradation. Upgraded readers prefer the batched leaf and
+// still parse OLD per-service leaves, so either publisher shape resolves.
+//
+// A deregistration / expiry is the ABSENCE of a service from its type's
+// batched leaf — there is no tombstone leaf class anymore (the old
+// per-service tombstones were write-only across the codebase).
+//
+// # Heartbeat short-circuit
+//
+// SD's register/heartbeat rate is high. The worker holds the live
+// per-type service set and, on a re-register, compares the new marshalled
+// Service against the stored one; when the materially-visible content is
+// unchanged it skips the re-encode entirely, so a steady heartbeat stream
+// does not churn the tree.
 //
 // HTTP-path decoupling: PutEntry / DelEntry are non-blocking. The
 // HTTP register / deregister handlers call them inline, but the
@@ -27,28 +59,36 @@
 // can block the HTTP goroutine long enough to pile up thousands of
 // pending registrations and stall the entire visor refresh loop.
 // Instead we route every publish through a single buffered-channel
-// worker and drop on overflow. CXO data quality (last-write-wins,
-// up to publishQueueDepth events in flight) degrades gracefully;
-// the HTTP path stays fast.
+// worker and drop on overflow. The per-type service state map is owned
+// by that single worker goroutine, so its mutations need no lock. CXO
+// data quality (last-write-wins, up to publishQueueDepth events in
+// flight) degrades gracefully; the HTTP path stays fast.
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
+
+// servicesBatchVersion is the wire-format version byte of the batched
+// per-type leaf body (FrameGzip). Bump on any breaking change to the
+// leaf encoding; readers reject other values and fall back.
+const servicesBatchVersion = 1
 
 // publishQueueDepth bounds in-flight publish operations. Sized for
 // SD's expected register rate (a few hundred entries refreshing
@@ -69,6 +109,12 @@ type ServicesCXOPublisher struct {
 	wg     sync.WaitGroup
 
 	dropped uint64 // atomic; incremented on queue overflow
+
+	// state is the live per-type service set: service type -> service PK ->
+	// that service's full JSON servicedisc.Service. Owned exclusively by
+	// the single worker goroutine (run), so it needs no lock; the encode of
+	// a type's batched leaf reads only from here.
+	state map[string]map[cipher.PubKey][]byte
 
 	mu        sync.Mutex
 	lastError error
@@ -98,6 +144,7 @@ func StartServicesCXOPublisher(_ context.Context, dmsgC *dmsg.Client, sk cipher.
 		log:    log,
 		events: make(chan func(), publishQueueDepth),
 		done:   make(chan struct{}),
+		state:  make(map[string]map[cipher.PubKey][]byte),
 	}
 	p.wg.Add(1)
 	go p.run()
@@ -180,9 +227,12 @@ func (p *ServicesCXOPublisher) Close() error {
 	return p.pub.Close()
 }
 
-// PutEntry mirrors a service register/update. Idempotent: identical
-// bytes are a no-op at the wire layer. Best-effort and non-blocking:
-// queued for the publish worker; dropped on queue overflow.
+// PutEntry mirrors a service register/update. Updates the worker's
+// per-type service state and re-encodes that type's batched leaf — but
+// only when the service's materially-visible content changed (heartbeat
+// short-circuit), so a steady re-register stream does not churn the tree.
+// Best-effort and non-blocking: queued for the publish worker; dropped on
+// queue overflow.
 func (p *ServicesCXOPublisher) PutEntry(svc *servicedisc.Service) {
 	if p == nil || p.pub == nil || svc == nil {
 		return
@@ -204,47 +254,98 @@ func (p *ServicesCXOPublisher) PutEntry(svc *servicedisc.Service) {
 	svcType := svc.Type
 	pk := svc.Addr.PubKey()
 	p.submit(func() {
-		path := entryPath(svcType, pk)
-		if err := p.pub.Put(path, body); err != nil {
-			p.log.WithError(err).WithField("path", path).Debug("Failed to publish service entry leaf")
-			p.recordError(err)
-			// Also clear any stale tombstone so subscribers don't see
-			// a dead-then-alive flap. Best-effort.
-			_ = p.pub.Delete(tombstonePath(svcType, pk)) //nolint:errcheck
+		// Heartbeat short-circuit: a re-register whose marshalled Service
+		// is byte-identical to what we already hold changes nothing a
+		// subscriber sees, so skip the re-encode entirely.
+		if cur := p.state[svcType]; cur != nil && bytes.Equal(cur[pk], body) {
 			return
 		}
-		// Drop any existing tombstone for the same key — re-registration
-		// after expiry should leave only the live entry leaf.
-		if err := p.pub.Delete(tombstonePath(svcType, pk)); err != nil {
-			p.log.WithError(err).Debug("Failed to clear stale services tombstone")
-		}
+		p.stateSet(svcType, pk, body)
+		p.flushType(svcType)
 	})
 }
 
-// DelEntry mirrors a service deregister or expiry. Removes the entry
-// leaf and writes a tombstone leaf so subscribers see the deletion.
-// Best-effort and non-blocking.
+// DelEntry mirrors a service deregister or expiry. Removes the service
+// from its type's set and re-encodes that type's batched leaf; the
+// service's absence from the leaf IS the deletion signal (no tombstone
+// leaf — see the package docstring). Best-effort and non-blocking.
 func (p *ServicesCXOPublisher) DelEntry(svcType string, pk cipher.PubKey) {
 	if p == nil || p.pub == nil || svcType == "" {
 		return
 	}
-	body, err := json.Marshal(struct {
-		DeletedAt time.Time `json:"deleted_at"`
-	}{DeletedAt: time.Now().UTC()})
-	if err != nil {
-		p.log.WithError(err).Debug("Failed to marshal services tombstone")
+	p.submit(func() {
+		if cur := p.state[svcType]; cur == nil || cur[pk] == nil {
+			return // already absent — nothing to re-encode
+		}
+		p.stateDel(svcType, pk)
+		p.flushType(svcType)
+	})
+}
+
+// stateSet records a service's JSON body under its type. Worker-only.
+func (p *ServicesCXOPublisher) stateSet(svcType string, pk cipher.PubKey, body []byte) {
+	svcs := p.state[svcType]
+	if svcs == nil {
+		svcs = make(map[cipher.PubKey][]byte)
+		p.state[svcType] = svcs
+	}
+	svcs[pk] = body
+}
+
+// stateDel removes a service from its type's set. Worker-only.
+func (p *ServicesCXOPublisher) stateDel(svcType string, pk cipher.PubKey) {
+	if svcs := p.state[svcType]; svcs != nil {
+		delete(svcs, pk)
+	}
+}
+
+// flushType re-encodes and Puts the batched leaf for a type, or Deletes
+// it (and drops the type from state) when the type has no services left.
+// CXO is content-addressed, so a re-Put of an unchanged leaf is a wire
+// no-op. Worker-only.
+func (p *ServicesCXOPublisher) flushType(svcType string) {
+	svcs := p.state[svcType]
+	path := batchLeafPath(svcType)
+	if len(svcs) == 0 {
+		delete(p.state, svcType)
+		if err := p.pub.Delete(path); err != nil {
+			p.log.WithError(err).WithField("path", path).Debug("Failed to delete emptied services leaf")
+		}
 		return
 	}
-	p.submit(func() {
-		if err := p.pub.Delete(entryPath(svcType, pk)); err != nil {
-			p.log.WithError(err).WithField("type", svcType).Debug("Failed to delete service entry leaf")
-			p.recordError(err)
+	blob, err := encodeServicesBatch(svcs)
+	if err != nil {
+		p.log.WithError(err).WithField("path", path).Debug("Failed to encode services batch leaf")
+		p.recordError(err)
+		return
+	}
+	if err := p.pub.Put(path, blob); err != nil {
+		p.log.WithError(err).WithField("path", path).Debug("Failed to publish services batch leaf")
+		p.recordError(err)
+	}
+}
+
+// encodeServicesBatch serializes a type's service set into one batched
+// leaf body: a JSON array of the services, sorted by PK so an unchanged
+// set re-encodes to identical bytes (a CXO wire no-op), then version-
+// framed + gzipped. The array is assembled by concatenating the already-
+// marshalled per-service bodies, so each service is encoded exactly once.
+func encodeServicesBatch(svcs map[cipher.PubKey][]byte) ([]byte, error) {
+	pks := make([]cipher.PubKey, 0, len(svcs))
+	for pk := range svcs {
+		pks = append(pks, pk)
+	}
+	sort.Slice(pks, func(i, j int) bool { return pks[i].Hex() < pks[j].Hex() })
+	payload := make([]byte, 0, 2+len(pks)*256)
+	payload = append(payload, '[')
+	for i, pk := range pks {
+		if i > 0 {
+			payload = append(payload, ',')
 		}
-		if err := p.pub.Put(tombstonePath(svcType, pk), body); err != nil {
-			p.log.WithError(err).WithField("type", svcType).Debug("Failed to publish services tombstone")
-			p.recordError(err)
-		}
-	})
+		payload = append(payload, svcs[pk]...)
+	}
+	payload = append(payload, ']')
+	return cxoutils.FrameGzip(servicesBatchVersion, payload), nil
 }
 
 func (p *ServicesCXOPublisher) recordError(err error) {
@@ -261,14 +362,10 @@ func (p *ServicesCXOPublisher) LastError() error {
 	return p.lastError
 }
 
-// EntryPath / TombstonePath are exported so subscribers can construct
-// the same leaf paths without duplicating the format string.
-func EntryPath(svcType string, pk cipher.PubKey) string     { return entryPath(svcType, pk) }
-func TombstonePath(svcType string, pk cipher.PubKey) string { return tombstonePath(svcType, pk) }
+// BatchLeafPath is exported so subscribers can construct the batched
+// per-type leaf path without duplicating the format string.
+func BatchLeafPath(svcType string) string { return batchLeafPath(svcType) }
 
-func entryPath(svcType string, pk cipher.PubKey) string {
-	return fmt.Sprintf("services/%s/%s/entry", svcType, pk.Hex())
-}
-func tombstonePath(svcType string, pk cipher.PubKey) string {
-	return fmt.Sprintf("services/%s/%s/tombstone", svcType, pk.Hex())
+func batchLeafPath(svcType string) string {
+	return fmt.Sprintf("services/%s/all", svcType)
 }

--- a/pkg/deployment/sd/api/cxo_publisher_batch_test.go
+++ b/pkg/deployment/sd/api/cxo_publisher_batch_test.go
@@ -1,0 +1,121 @@
+// Package api — cxo_publisher_batch_test.go proves the SD services
+// publisher shards to ONE leaf per service TYPE (object count O(#types),
+// not O(#services)) and that a batched leaf round-trips through the
+// version-framed encoding.
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/servicedisc"
+)
+
+// newTestPub builds a publisher with only the in-memory state map wired,
+// so stateSet / encodeServicesBatch can be exercised without a live
+// treestore.Publisher (pub stays nil; these helpers never touch it).
+func newTestPub() *ServicesCXOPublisher {
+	return &ServicesCXOPublisher{state: make(map[string]map[cipher.PubKey][]byte)}
+}
+
+func mustSvc(t *testing.T, svcType string, pk cipher.PubKey) []byte {
+	t.Helper()
+	svc := &servicedisc.Service{
+		Addr:    servicedisc.NewSWAddr(pk, 44),
+		Type:    svcType,
+		Version: "v1.0.0",
+	}
+	b, err := json.Marshal(svc)
+	if err != nil {
+		t.Fatalf("marshal service: %v", err)
+	}
+	return b
+}
+
+// TestBatchLeafCountIsPerType feeds a large service population across a
+// small set of types and asserts the number of batch leaves (== types in
+// state) is bounded by #types, NOT #services.
+func TestBatchLeafCountIsPerType(t *testing.T) {
+	p := newTestPub()
+
+	types := []string{"vpn", "visor", "skysocks", "proxy"}
+	const nServices = 600
+	for i := 0; i < nServices; i++ {
+		pk, _ := cipher.GenerateKeyPair()
+		svcType := types[i%len(types)]
+		p.stateSet(svcType, pk, mustSvc(t, svcType, pk))
+	}
+
+	if got := len(p.state); got > len(types) {
+		t.Fatalf("batch leaf count = %d, want <= %d types", got, len(types))
+	}
+	t.Logf("%d services collapsed to %d type leaves", nServices, len(p.state))
+
+	// Every type leaf must decode back to exactly its service set.
+	total := 0
+	for svcType, svcs := range p.state {
+		blob, err := encodeServicesBatch(svcs)
+		if err != nil {
+			t.Fatalf("encode type %s: %v", svcType, err)
+		}
+		version, payload, ok := cxoutils.UnframeGzip(blob)
+		if !ok || version != servicesBatchVersion {
+			t.Fatalf("unframe type %s: ok=%v version=%d", svcType, ok, version)
+		}
+		var decoded []servicedisc.Service
+		if err := json.Unmarshal(payload, &decoded); err != nil {
+			t.Fatalf("decode type %s: %v", svcType, err)
+		}
+		if len(decoded) != len(svcs) {
+			t.Fatalf("type %s: decoded %d services, want %d", svcType, len(decoded), len(svcs))
+		}
+		for i := range decoded {
+			if decoded[i].Type != svcType {
+				t.Fatalf("type %s: decoded service has type %q", svcType, decoded[i].Type)
+			}
+		}
+		total += len(decoded)
+	}
+	if total != nServices {
+		t.Fatalf("sum of decoded services = %d, want %d", total, nServices)
+	}
+}
+
+// TestServicesBatchEncodeDeterministic pins that an unchanged service set
+// re-encodes to identical bytes (sorted by PK), so a re-Put is a CXO wire
+// no-op — the basis of the heartbeat short-circuit.
+func TestServicesBatchEncodeDeterministic(t *testing.T) {
+	p := newTestPub()
+	for i := 0; i < 20; i++ {
+		pk, _ := cipher.GenerateKeyPair()
+		p.stateSet("vpn", pk, mustSvc(t, "vpn", pk))
+	}
+	a, err := encodeServicesBatch(p.state["vpn"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := encodeServicesBatch(p.state["vpn"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a) != string(b) {
+		t.Fatal("encodeServicesBatch not deterministic for an unchanged set")
+	}
+}
+
+// TestServicesBatchDelEmptiesType proves a type with no services left is
+// dropped from state (its leaf would be Deleted, not left as a tombstone).
+func TestServicesBatchDelEmptiesType(t *testing.T) {
+	p := newTestPub()
+	pk, _ := cipher.GenerateKeyPair()
+	p.stateSet("vpn", pk, mustSvc(t, "vpn", pk))
+	if len(p.state["vpn"]) != 1 {
+		t.Fatalf("setup: want 1 service, got %d", len(p.state["vpn"]))
+	}
+	p.stateDel("vpn", pk)
+	if got := len(p.state["vpn"]); got != 0 {
+		t.Fatalf("after del: want 0 services, got %d", got)
+	}
+}

--- a/pkg/tpviz/cxo_subscriber.go
+++ b/pkg/tpviz/cxo_subscriber.go
@@ -37,7 +37,7 @@ const (
 const (
 	CXOFeedTPDMetrics           = 0 // metrics/days/<n>
 	CXOFeedTPDUptime            = 1 // uptimes/days/<n> — []VisorSummary
-	CXOFeedSDServices           = 2 // services/<type>/<pk>/{entry,tombstone}
+	CXOFeedSDServices           = 2 // services/<type>/all (batched; legacy .../<pk>/entry)
 	CXOFeedDMSGDClientsByServer = 3 // clients-by-server/<server> (batched; legacy .../<client>/entry)
 	CXOFeedTPDAllTransports     = 4 // transports/all/{with-self,without-self}
 )
@@ -79,11 +79,11 @@ func (s *Server) cxoMgr() CXOSubMgr {
 // those cases the caller falls through to its existing HTTP
 // fetcher.
 //
-// The walk reconstructs the per-type service grouping that the
-// HTTP path gets from servicedisc's per-type query: the leaf path
-// is services/<type>/<pk>/entry, the body is the JSON-encoded
-// servicedisc.Service. We pluck <type> off the path (cheap) so we
-// don't have to re-parse it from the body.
+// The walk reconstructs the per-type service grouping that the HTTP path
+// gets from servicedisc's per-type query. The current publisher writes
+// ONE batched leaf per type at services/<type>/all (a version-framed,
+// gzipped JSON []Service); older publishers wrote one leaf per service at
+// services/<type>/<pk>/entry. Both shapes are read here.
 func (s *Server) tryCXOServices() (map[string]ServiceInfo, bool) {
 	mgr := s.cxoMgr()
 	if mgr == nil {
@@ -91,51 +91,69 @@ func (s *Server) tryCXOServices() (map[string]ServiceInfo, bool) {
 	}
 	services := make(map[string]ServiceInfo)
 	any := false
+	add := func(svcType, pk, country string) {
+		any = true
+		if info, exists := services[pk]; exists {
+			info.Services = append(info.Services, svcType)
+			if info.Country == "" && country != "" {
+				info.Country = country
+			}
+			services[pk] = info
+			return
+		}
+		services[pk] = ServiceInfo{PK: pk, Services: []string{svcType}, Country: country}
+	}
+	countryOf := func(svc *servicedisc.Service) string {
+		if svc.Geo != nil {
+			return svc.Geo.Country
+		}
+		return ""
+	}
 	ok := mgr.Walk(CXOFeedSDServices, "services/", func(path string, body []byte) bool {
-		// Skip tombstones; we only want live entries.
-		if !strings.HasSuffix(path, "/entry") {
-			return true
-		}
-		// path = services/<type>/<pk>/entry
 		parts := strings.Split(path, "/")
-		if len(parts) != 4 {
+		// Batched per-type leaf: services/<type>/all.
+		if len(parts) == 3 && parts[2] == "all" {
+			svcType := parts[1]
+			for _, svc := range decodeServicesBatch(body) {
+				add(svcType, svc.Addr.PubKey().Hex(), countryOf(&svc))
+			}
 			return true
 		}
-		svcType := parts[1]
-		pk := parts[2]
-
-		// Body is a servicedisc.Service. We want the geo country
-		// for the IP-grouping overlay; the address we already
-		// have from the path.
+		// Legacy per-service leaf: services/<type>/<pk>/entry.
+		if len(parts) != 4 || !strings.HasSuffix(path, "/entry") {
+			return true
+		}
 		var svc servicedisc.Service
 		if err := json.Unmarshal(body, &svc); err != nil {
 			return true
 		}
-
-		any = true
-		if info, exists := services[pk]; exists {
-			info.Services = append(info.Services, svcType)
-			if info.Country == "" && svc.Geo != nil && svc.Geo.Country != "" {
-				info.Country = svc.Geo.Country
-			}
-			services[pk] = info
-			return true
-		}
-		country := ""
-		if svc.Geo != nil {
-			country = svc.Geo.Country
-		}
-		services[pk] = ServiceInfo{
-			PK:       pk,
-			Services: []string{svcType},
-			Country:  country,
-		}
+		add(parts[1], parts[2], countryOf(&svc))
 		return true
 	})
 	if !ok || !any {
 		return nil, false
 	}
 	return services, true
+}
+
+// servicesBatchVersion is the wire-format version byte of the batched
+// per-type SD services leaf (must match the SD publisher's
+// servicesBatchVersion). A leaf with any other version is skipped.
+const servicesBatchVersion = 1
+
+// decodeServicesBatch decodes a batched per-type SD leaf body into its
+// services. Returns nil on any framing/version/JSON error so a bad leaf
+// is skipped, not misparsed.
+func decodeServicesBatch(body []byte) []servicedisc.Service {
+	version, payload, ok := cxoutils.UnframeGzip(body)
+	if !ok || version != servicesBatchVersion {
+		return nil
+	}
+	var svcs []servicedisc.Service
+	if err := json.Unmarshal(payload, &svcs); err != nil {
+		return nil
+	}
+	return svcs
 }
 
 // tryCXOClientsByServer walks the DMSG-D clients-by-server snapshot

--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/pty"
 	"github.com/skycoin/skywire/pkg/servicedisc"
@@ -358,7 +359,27 @@ func (v *Visor) servicesFromCXO(serviceType, version, country string) ([]service
 
 	prefix := "services/" + serviceType + "/"
 	var services []servicedisc.Service
+	keep := func(svc servicedisc.Service) {
+		if version != "" && svc.Version != version {
+			return
+		}
+		if country != "" {
+			if svc.Geo == nil || svc.Geo.Country != country {
+				return
+			}
+		}
+		services = append(services, svc)
+	}
 	mgr.Walk(FeedSDServices, prefix, func(path string, body []byte) bool {
+		// Batched per-type leaf: services/<type>/all (a version-framed,
+		// gzipped JSON []Service).
+		if strings.HasSuffix(path, "/all") {
+			for _, svc := range decodeServicesBatch(body) {
+				keep(svc)
+			}
+			return true
+		}
+		// Legacy per-service leaf: services/<type>/<pk>/entry.
 		if !strings.HasSuffix(path, "/entry") {
 			return true
 		}
@@ -366,21 +387,35 @@ func (v *Visor) servicesFromCXO(serviceType, version, country string) ([]service
 		if err := json.Unmarshal(body, &svc); err != nil {
 			return true
 		}
-		if version != "" && svc.Version != version {
-			return true
-		}
-		if country != "" {
-			if svc.Geo == nil || svc.Geo.Country != country {
-				return true
-			}
-		}
-		services = append(services, svc)
+		keep(svc)
 		return true
 	})
 	if len(services) == 0 {
 		return nil, false
 	}
 	return services, true
+}
+
+// servicesBatchVersion is the wire-format version byte of the batched
+// per-type SD services leaf (must match the SD publisher's
+// servicesBatchVersion). A leaf with any other version is skipped so a
+// future format bump degrades to the HTTP fallback rather than
+// misparsing.
+const servicesBatchVersion = 1
+
+// decodeServicesBatch decodes a batched per-type leaf body into its
+// services. Returns nil on any framing/version/JSON error so a bad leaf
+// is skipped, not misparsed.
+func decodeServicesBatch(body []byte) []servicedisc.Service {
+	version, payload, ok := cxoutils.UnframeGzip(body)
+	if !ok || version != servicesBatchVersion {
+		return nil
+	}
+	var svcs []servicedisc.Service
+	if err := json.Unmarshal(payload, &svcs); err != nil {
+		return nil
+	}
+	return svcs
 }
 
 // VPNServers gets available public VPN servers — CXO snapshot first,

--- a/pkg/visor/autoconnect.go
+++ b/pkg/visor/autoconnect.go
@@ -448,19 +448,26 @@ func (a *autoconnector) fetchPubAddresses(ctx context.Context, v *Visor) ([]ciph
 }
 
 // pubVisorsFromCXOSnapshot walks the SD services tree under
-// services/visor/<pk>/entry and returns the PKs as a slice. Empty
+// services/visor/ and returns the visor PKs as a slice. Reads the
+// batched per-type leaf (services/visor/all) preferred, and the legacy
+// per-service leaves (services/visor/<pk>/entry) as a fallback. Empty
 // slice (rather than nil) when the snapshot exists but has no visor
 // entries; nil when the snapshot is missing entirely (caller falls
 // through to HTTP).
 func pubVisorsFromCXOSnapshot(mgr *CXOSubscriptionManager) []cipher.PubKey {
 	var pks []cipher.PubKey
-	mgr.Walk(FeedSDServices, "services/visor/", func(path string, _ []byte) bool {
-		// path = services/visor/<pk>/{entry,tombstone}.
-		// Skip tombstones; live entries only.
+	mgr.Walk(FeedSDServices, "services/visor/", func(path string, body []byte) bool {
+		// Batched per-type leaf: services/visor/all.
+		if strings.HasSuffix(path, "/all") {
+			for _, svc := range decodeServicesBatch(body) {
+				pks = append(pks, svc.Addr.PubKey())
+			}
+			return true
+		}
+		// Legacy per-service leaf: services/visor/<pk>/entry.
 		if !strings.HasSuffix(path, "/entry") {
 			return true
 		}
-		// Strip the prefix and trailing "/entry" to recover the PK.
 		core := strings.TrimSuffix(strings.TrimPrefix(path, "services/visor/"), "/entry")
 		if core == "" {
 			return true


### PR DESCRIPTION
The SD services CXO feed (dmsg CXO port 53) published one leaf per **service** at `services/<type>/<pk>/entry` (+ an optional `/tombstone`) — O(#services), one tiny object per registered service. A large deployment's Root then can't finish filling over a subscriber's short-lived delivering dmsg conn.

**Shard by type** to one batched leaf per type at `services/<type>/all`, carrying that type's whole live service set. Object count: **O(#services) → O(#types)** (~10). The leaf sits UNDER the type dir (`…/all`), so every existing consumer prefix — `services/`, `services/visor/`, `services/<type>/` — walks straight onto it (a service PK is 66 hex chars and never collides with the `all` segment).

**Encoding — JSON+gzip, version-framed** (`cxoutils.FrameGzip`, the shared codec added in #4191): `servicedisc.Service` carries several optional, variable-length nested structs (Geo, VPNInfo, CoinInfo, LocalIPs), so it is the "awkward for binary" case the fixed-layout `telemetrywire` codec doesn't fit. Services are sorted by PK, so an unchanged set re-encodes to identical bytes — a CXO content-addressed wire no-op. A leading **version byte** gates the format.

**Heartbeat short-circuit.** SD's register/heartbeat rate is high. The worker holds the live per-type set and, on a re-register, compares the new marshalled Service against the stored one; when the visible content is unchanged it skips the re-encode entirely, so a steady heartbeat stream doesn't churn the tree.

**No tombstone class.** A deregistration/expiry is the service's ABSENCE from its type's batched leaf (the old per-service tombstones were write-only across the codebase).

**Deploy is service/consumer-first.** A not-yet-upgraded reader finds no legacy `.../entry` leaves under the new shape, reports an empty snapshot for that type, and falls back to HTTP — safe degradation. Upgraded readers (visor `servicesFromCXO`, autoconnect, tpviz) prefer the batched leaf and still parse legacy per-service leaves, so either publisher shape resolves.

Follows #4191 (clients-by-server, same pattern). Reuses dmsg CXO port 53 (no new skyenv port). Tests: `TestBatchLeafCountIsPerType` proves 600 services collapse to ≤ #types (4) leaves and each leaf round-trips. `go build .`, `go vet`, and `go test` pass on sd/api, tpviz, and visor.