### PR TITLE
fix(proxyinterstitial): always serve status.skysocks in-process, never the interstitial

### DIFF
--- a/pkg/dmsgweb/status_scoping_test.go
+++ b/pkg/dmsgweb/status_scoping_test.go
@@ -46,8 +46,8 @@ func TestSOCKS5StatusScoping(t *testing.T) {
 				return
 			}
 			go func(c net.Conn) {
-				_ = proxyinterstitial.ServeSOCKS5(c, "upstream-sink", "skysocks", nil) //nolint:errcheck
-				_ = c.Close()                                                          //nolint:errcheck
+				_ = proxyinterstitial.ServeSOCKS5(c, "upstream-sink", "skysocks", nil, nil) //nolint:errcheck
+				_ = c.Close()                                                               //nolint:errcheck
 			}(c)
 		}
 	}()

--- a/pkg/proxyinterstitial/interstitial.go
+++ b/pkg/proxyinterstitial/interstitial.go
@@ -269,13 +269,15 @@ func ShouldServe(port string) bool {
 //
 // statusOverride lets the caller answer a reserved in-process host (e.g.
 // status.skysocks) itself instead of the interstitial: once the CONNECT target
-// host is parsed and the SOCKS5 reply + browser request have been exchanged, if
-// statusOverride != nil and it returns a non-nil body for that host, the body is
-// written verbatim as the HTTP response and the interstitial is skipped. This
-// keeps the reserved status page reachable exactly when the exit is down — the
-// moment the user most needs to see why — which the interstitial would otherwise
-// shadow. Pass nil for the plain interstitial-only behavior. The closure lives
-// in the caller so this package stays free of any pkg/proxystatus dependency.
+// host is parsed, if statusOverride != nil and it returns a non-nil body for that
+// host, the SOCKS5 reply is sent, the browser's request drained, and the body
+// written verbatim as the HTTP response — the interstitial is skipped. The
+// override is resolved BEFORE the HTTP-only port gate and the exit-reachability
+// check, and applies regardless of port, so the reserved status page is never
+// declined or shadowed — it stays reachable exactly when the exit is down, the
+// moment the user most needs to see why. Pass nil for the plain interstitial-only
+// behavior. The closure lives in the caller so this package stays free of any
+// pkg/proxystatus dependency.
 //
 // exitReachable is the symmetric fall-through: this function is minted on a dial
 // failure, but that failure can be transient (a single stream open failing while
@@ -346,9 +348,19 @@ func ServeSOCKS5(conn net.Conn, detail, mechanism string, statusOverride func(ho
 		return err
 	}
 	port := int(portB[0])<<8 | int(portB[1])
-	// Only plaintext HTTP can carry an HTML interstitial; decline the rest so
-	// the caller falls back to tearing down (browser sees a normal failure).
-	if !ShouldServe(fmt.Sprintf("%d", port)) {
+	// Resolve the reserved-host override FIRST (it is a pure render of the status
+	// page for a reserved host, e.g. status.skysocks; nil for anything else). A
+	// reserved host is served regardless of port and BEFORE the interstitial's
+	// HTTP-only gate below, so the status page is never declined or shadowed by
+	// the exit being down — the moment the user most needs to see it.
+	var overrideBody []byte
+	if statusOverride != nil {
+		overrideBody = statusOverride(host)
+	}
+	// Only plaintext HTTP can carry an HTML interstitial; decline the rest so the
+	// caller falls back to tearing down (browser sees a normal failure). The
+	// reserved status host is exempt — it was resolved above.
+	if overrideBody == nil && !ShouldServe(fmt.Sprintf("%d", port)) {
 		return fmt.Errorf("socks5 interstitial: non-HTTP port %d", port)
 	}
 	// Reply success with a dummy BND.ADDR/PORT so the client proceeds to send
@@ -363,11 +375,9 @@ func ServeSOCKS5(conn net.Conn, detail, mechanism string, statusOverride func(ho
 	// A reserved in-process host (e.g. status.skysocks) is answered by the
 	// caller's override rather than the interstitial, so it stays reachable
 	// while the exit is down.
-	if statusOverride != nil {
-		if body := statusOverride(host); body != nil {
-			_, err := conn.Write(body)
-			return err
-		}
+	if overrideBody != nil {
+		_, err := conn.Write(overrideBody)
+		return err
 	}
 	// The exit is reachable again (the dial failure was transient) — don't pin the
 	// browser on the waiting spinner; serve a reload that falls through to the

--- a/pkg/proxyinterstitial/interstitial_test.go
+++ b/pkg/proxyinterstitial/interstitial_test.go
@@ -253,6 +253,23 @@ func TestServeSOCKS5_StatusOverride(t *testing.T) {
 			t.Errorf("ServeSOCKS5: %v", err)
 		}
 	})
+
+	// A reserved host is served regardless of port: the override is resolved before
+	// the HTTP-only port gate, so even a non-80 CONNECT is answered with the status
+	// page rather than declined as non-HTTP.
+	t.Run("reserved host served on a non-80 port", func(t *testing.T) {
+		cli, srv := net.Pipe()
+		defer cli.Close() //nolint:errcheck
+		done := make(chan error, 1)
+		go func() { done <- ServeSOCKS5(srv, "", "skysocks", override, nil); srv.Close() }() //nolint:errcheck,gosec
+		got := serveSOCKS5CONNECT(t, cli, statusHost, 8443)
+		if !strings.Contains(got, "STATUS-PAGE") {
+			t.Errorf("reserved host on non-80 port did not receive override; got %q", got)
+		}
+		if err := <-done; err != nil {
+			t.Errorf("ServeSOCKS5: %v", err)
+		}
+	})
 }
 
 // TestServeSOCKS5_ExitReachableFallThrough verifies the fall-through fix: when

--- a/pkg/skynetweb/status_scoping_test.go
+++ b/pkg/skynetweb/status_scoping_test.go
@@ -40,8 +40,8 @@ func TestSOCKS5StatusScoping(t *testing.T) {
 				return
 			}
 			go func(c net.Conn) {
-				_ = proxyinterstitial.ServeSOCKS5(c, "upstream-sink", "skysocks", nil) //nolint:errcheck
-				_ = c.Close()                                                          //nolint:errcheck
+				_ = proxyinterstitial.ServeSOCKS5(c, "upstream-sink", "skysocks", nil, nil) //nolint:errcheck
+				_ = c.Close()                                                               //nolint:errcheck
 			}(c)
 		}
 	}()

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -281,23 +281,33 @@ func (c *Client) handleStream(conn, stream net.Conn) {
 const statusSniffTimeout = 15 * time.Second
 
 // sniffSOCKS5Status inspects the SOCKS5 CONNECT target to intercept the reserved
-// status.skysocks host. The greeting is forwarded to the exit verbatim and the
-// exit's method-selection reply is forwarded to the browser verbatim; only the
-// CONNECT request is parsed, and only a status.skysocks target diverges — every
-// other target's request is written to the exit byte-for-byte before splicing,
-// so non-status traffic is identical to a plain tunnel.
+// status.skysocks host, and CRUCIALLY does so WITHOUT any round-trip to the exit:
+// the method-selection reply is answered LOCALLY (no-auth) so the CONNECT target
+// can be read and a status.skysocks request served in-process even when the exit
+// is dead or unreachable — which is exactly when the status page matters most. The
+// exit is contacted only AFTER a non-status target is confirmed; at that point the
+// greeting and CONNECT request are replayed to the exit byte-for-byte, so the exit
+// sees an identical stream and non-status traffic is a plain tunnel.
+//
+// A browser that offers no no-auth method (exotic for a loopback SOCKS client) can
+// not be answered locally; that case falls back to the transparent forward-to-exit
+// handshake, where the exit drives the (auth) negotiation and everything rides
+// through. Such a client is never the browser hitting status.skysocks.
 //
 // Returns proceed=true when the caller should continue with the normal
-// bidirectional splice (conn and stream are positioned just past the forwarded
-// handshake); target is then the CONNECT "host:port" the stream carries (or ""
-// when it could not be parsed), for the status page's per-stream detail. Returns
-// false when the request was served in-process or the connection is unusable; the
-// caller then closes both sides.
+// bidirectional splice (conn and stream are positioned just past the handshake);
+// target is then the CONNECT "host:port" the stream carries (or "" when it could
+// not be parsed), for the status page's per-stream detail. Returns false when the
+// request was served in-process or the connection is unusable; the caller then
+// closes both sides.
 func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool, target string) {
-	_ = conn.SetReadDeadline(time.Now().Add(statusSniffTimeout))   //nolint:errcheck
-	_ = stream.SetReadDeadline(time.Now().Add(statusSniffTimeout)) //nolint:errcheck
+	// Only the browser side gets a read deadline up front: the exit must not be
+	// touched (nor block us) until a non-status target is confirmed, so the reserved
+	// status host stays reachable regardless of exit reachability.
+	_ = conn.SetReadDeadline(time.Now().Add(statusSniffTimeout)) //nolint:errcheck
 
-	// Greeting: VER, NMETHODS, METHODS[NMETHODS] — forwarded to the exit verbatim.
+	// Greeting: VER, NMETHODS, METHODS[NMETHODS]. Buffered so a non-status target's
+	// greeting can be replayed to the exit byte-for-byte.
 	hdr := make([]byte, 2)
 	if _, err := io.ReadFull(conn, hdr); err != nil || hdr[0] != 0x05 {
 		return false, ""
@@ -307,27 +317,21 @@ func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool, target 
 	if _, err := io.ReadFull(conn, greeting[2:]); err != nil {
 		return false, ""
 	}
-	if _, err := stream.Write(greeting); err != nil {
-		return false, ""
-	}
 
-	// Method-selection reply (2 bytes) from the exit — forwarded to the browser.
-	method := make([]byte, 2)
-	if _, err := io.ReadFull(stream, method); err != nil {
-		return false, ""
+	// If the browser did not offer no-auth we can't answer locally; fall back to
+	// forwarding the handshake to the exit and letting it drive the negotiation.
+	// (A status.skysocks browser always offers no-auth, so this never shadows it.)
+	if !offersNoAuth(greeting) {
+		return c.forwardExitHandshake(conn, stream, greeting)
 	}
-	if _, err := conn.Write(method); err != nil {
+	// Answer method-selection to the browser ourselves (no-auth) so the CONNECT
+	// target can be read WITHOUT contacting the exit.
+	if _, err := conn.Write([]byte{0x05, 0x00}); err != nil {
 		return false, ""
-	}
-	// Anything but no-auth accepted: hand the rest off untouched — the auth
-	// sub-negotiation and CONNECT ride through transparently.
-	if method[0] != 0x05 || method[1] != 0x00 {
-		clearDeadlines(conn, stream)
-		return true, ""
 	}
 
 	// CONNECT request: VER, CMD, RSV, ATYP, ADDR, PORT. Buffered so a non-status
-	// target is forwarded to the exit byte-for-byte.
+	// target is replayed to the exit byte-for-byte.
 	rhdr := make([]byte, 4)
 	if _, err := io.ReadFull(conn, rhdr); err != nil || rhdr[0] != 0x05 {
 		return false, ""
@@ -362,7 +366,11 @@ func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool, target 
 		host = net.IP(b).String()
 		req = append(req, b...)
 	default:
-		// Unknown ATYP: forward what we have and let the exit deal with it.
+		// Unknown ATYP: not a status host — open the exit handshake, forward what
+		// we have, and let the exit deal with the rest via the splice.
+		if err := c.openExit(stream, greeting); err != nil {
+			return false, ""
+		}
 		if _, err := stream.Write(req); err != nil {
 			return false, ""
 		}
@@ -376,21 +384,80 @@ func (c *Client) sniffSOCKS5Status(conn, stream net.Conn) (proceed bool, target 
 	req = append(req, portB...)
 	port := int(portB[0])<<8 | int(portB[1])
 
-	// Reserved status host: serve the in-process page over HTTP instead of
-	// tunneling to the exit. HTTP only — the resolver CA forbids a .skysocks TLS
-	// leaf, so status.skysocks is HTTP-only by design.
+	// Reserved status host: serve the in-process page over HTTP. This is reached
+	// with NO exit involvement, so status.skysocks stays reachable when the exit is
+	// down. HTTP only — the resolver CA forbids a .skysocks TLS leaf, so
+	// status.skysocks is HTTP-only by design. serveStatusPage routes "/" (page) and
+	// "/ws" (live WebSocket) on the browser's request.
 	if surface, ok := proxystatus.Match(host); ok && surface == proxystatus.SurfaceSkysocks {
 		clearDeadlines(conn, stream)
 		c.serveStatusPage(conn, stream)
 		return false, ""
 	}
 
-	// Non-status: forward the buffered CONNECT request to the exit and splice.
+	// Non-status: open the exit's SOCKS session now (greeting + method reply) and
+	// replay the buffered CONNECT request, then splice.
+	if err := c.openExit(stream, greeting); err != nil {
+		return false, ""
+	}
 	if _, err := stream.Write(req); err != nil {
 		return false, ""
 	}
 	clearDeadlines(conn, stream)
 	return true, fmt.Sprintf("%s:%d", host, port)
+}
+
+// offersNoAuth reports whether a buffered SOCKS5 greeting (VER, NMETHODS, METHODS…)
+// advertises the no-authentication method (0x00) — the one this transparent client
+// can answer locally without consulting the exit.
+func offersNoAuth(greeting []byte) bool {
+	if len(greeting) < 2 {
+		return false
+	}
+	return bytes.IndexByte(greeting[2:], 0x00) >= 0
+}
+
+// openExit performs the client→exit SOCKS5 method negotiation for a confirmed
+// non-status target: it replays the browser's greeting to the exit and consumes
+// the exit's method-selection reply, which the skysocks exit (no-auth) answers
+// with 05 00. It is called only after the local browser handshake, so it never
+// gates recognition of the reserved status host on the exit being reachable. A
+// read deadline bounds a dead exit so it can't wedge the goroutine.
+func (c *Client) openExit(stream net.Conn, greeting []byte) error {
+	_ = stream.SetReadDeadline(time.Now().Add(statusSniffTimeout)) //nolint:errcheck
+	if _, err := stream.Write(greeting); err != nil {
+		return err
+	}
+	method := make([]byte, 2)
+	if _, err := io.ReadFull(stream, method); err != nil {
+		return err
+	}
+	if method[0] != 0x05 || method[1] != 0x00 {
+		return fmt.Errorf("exit selected non-no-auth method %v", method)
+	}
+	return nil
+}
+
+// forwardExitHandshake is the transparent fallback for a browser that offers no
+// no-auth method: the greeting is forwarded to the exit verbatim and the exit's
+// method-selection reply is forwarded back to the browser, then the connection is
+// spliced so the (auth) sub-negotiation and CONNECT ride through end-to-end. Such a
+// client is never the loopback browser hitting status.skysocks, so leaving status
+// interception off this path is correct.
+func (c *Client) forwardExitHandshake(conn, stream net.Conn, greeting []byte) (proceed bool, target string) {
+	_ = stream.SetReadDeadline(time.Now().Add(statusSniffTimeout)) //nolint:errcheck
+	if _, err := stream.Write(greeting); err != nil {
+		return false, ""
+	}
+	method := make([]byte, 2)
+	if _, err := io.ReadFull(stream, method); err != nil {
+		return false, ""
+	}
+	if _, err := conn.Write(method); err != nil {
+		return false, ""
+	}
+	clearDeadlines(conn, stream)
+	return true, ""
 }
 
 // streamID extracts the yamux stream id from the net.Conn session.Open returns

--- a/pkg/skysocks/client_sniff_test.go
+++ b/pkg/skysocks/client_sniff_test.go
@@ -97,8 +97,10 @@ func runSniff(t *testing.T, c *Client) (browser, exit net.Conn, result <-chan bo
 	return browserEnd, exitEnd, res
 }
 
-// When the exit selects a method other than no-auth, the client hands off
-// transparently (proceed=true) without buffering/parsing the CONNECT request.
+// When the browser offers NO no-auth method, the client can't answer locally, so
+// it forwards the greeting to the exit and hands off transparently (proceed=true)
+// without buffering/parsing the CONNECT request — the exit drives the (auth)
+// negotiation end-to-end.
 func TestSniff_NonNoAuthHandoff(t *testing.T) {
 	c, _ := newTestClient(t)
 	defer c.Close() //nolint:errcheck
@@ -106,13 +108,14 @@ func TestSniff_NonNoAuthHandoff(t *testing.T) {
 	defer browser.Close() //nolint:errcheck
 	defer exit.Close()    //nolint:errcheck
 
-	// Browser greeting → forwarded to exit verbatim.
-	_, err := browser.Write([]byte{0x05, 0x01, 0x00})
+	// Browser offers ONLY user/pass auth (0x02), no no-auth → forwarded to exit
+	// verbatim (the client cannot answer this locally).
+	_, err := browser.Write([]byte{0x05, 0x01, 0x02})
 	require.NoError(t, err)
 	got := make([]byte, 3)
 	_, err = io.ReadFull(exit, got)
 	require.NoError(t, err)
-	require.Equal(t, []byte{0x05, 0x01, 0x00}, got)
+	require.Equal(t, []byte{0x05, 0x01, 0x02}, got)
 
 	// Exit picks user/pass auth (05 02) → forwarded to browser; sniff hands off.
 	_, err = exit.Write([]byte{0x05, 0x02})
@@ -124,14 +127,15 @@ func TestSniff_NonNoAuthHandoff(t *testing.T) {
 
 	select {
 	case proceed := <-res:
-		require.True(t, proceed, "non-no-auth reply must proceed to a transparent splice")
+		require.True(t, proceed, "non-no-auth greeting must proceed to a transparent splice")
 	case <-time.After(2 * time.Second):
 		t.Fatal("sniff did not return after non-no-auth handoff")
 	}
 }
 
-// An unknown CONNECT address type is forwarded to the exit as-is and the sniff
-// hands off (proceed=true) rather than parsing it.
+// An unknown CONNECT address type is a non-status target: the client answers the
+// browser's no-auth greeting locally, then opens the exit (greeting + no-auth
+// reply), forwards the request as-is, and hands off (proceed=true).
 func TestSniff_UnknownATYPHandoff(t *testing.T) {
 	c, _ := newTestClient(t)
 	defer c.Close() //nolint:errcheck
@@ -139,16 +143,27 @@ func TestSniff_UnknownATYPHandoff(t *testing.T) {
 	defer browser.Close() //nolint:errcheck
 	defer exit.Close()    //nolint:errcheck
 
-	_, err := browser.Write([]byte{0x05, 0x01, 0x00}) // greeting
+	// Browser greeting (offers no-auth) → answered LOCALLY by the client, not the
+	// exit; the exit is not yet contacted.
+	_, err := browser.Write([]byte{0x05, 0x01, 0x00})
 	require.NoError(t, err)
-	_, _ = io.ReadFull(exit, make([]byte, 3)) //nolint:errcheck
-	_, err = exit.Write([]byte{0x05, 0x00})   // no-auth selected
+	method := make([]byte, 2)
+	_, err = io.ReadFull(browser, method)
 	require.NoError(t, err)
-	_, _ = io.ReadFull(browser, make([]byte, 2)) //nolint:errcheck
+	require.Equal(t, []byte{0x05, 0x00}, method)
 
-	// CONNECT with an unknown ATYP (0x09).
+	// CONNECT with an unknown ATYP (0x09): non-status, so the client now opens the
+	// exit — the exit receives the replayed greeting first and answers no-auth.
 	_, err = browser.Write([]byte{0x05, 0x01, 0x00, 0x09})
 	require.NoError(t, err)
+	greeting := make([]byte, 3)
+	_, err = io.ReadFull(exit, greeting)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x05, 0x01, 0x00}, greeting)
+	_, err = exit.Write([]byte{0x05, 0x00})
+	require.NoError(t, err)
+
+	// Then the forwarded CONNECT request, unknown ATYP preserved.
 	fwd := make([]byte, 4)
 	_, err = io.ReadFull(exit, fwd)
 	require.NoError(t, err)

--- a/pkg/skysocks/client_status_test.go
+++ b/pkg/skysocks/client_status_test.go
@@ -177,6 +177,69 @@ func TestStatusSkysocksIntercepted(t *testing.T) {
 	}
 }
 
+// newDeadExitClient builds a client whose peer is a yamux server that ACCEPTS
+// streams but never speaks SOCKS on them — a dead exit process sitting behind a
+// still-open session/route. session.Open() succeeds (so the request reaches the
+// sniff path, not the ServeSOCKS5 route-down path), but any SOCKS negotiation to
+// the exit would hang. It proves status.skysocks is served with zero exit
+// involvement.
+func newDeadExitClient(t *testing.T) *Client {
+	t.Helper()
+	cliConn, exitConn := net.Pipe()
+	sess, err := yamux.Server(exitConn, yamux.DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for {
+			stream, err := sess.Accept()
+			if err != nil {
+				return
+			}
+			_ = stream // accepted but intentionally never answered
+		}
+	}()
+	c, err := NewClient(cliConn, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// TestStatusSkysocksServedWhenExitDown is the regression test for the bug: a
+// CONNECT to status.skysocks must return the in-process status page even when the
+// exit is unresponsive (session/route up, exit process dead). With the old sniff —
+// which forwarded the greeting to the exit and blocked on the exit's method reply
+// before parsing the CONNECT target — this request stalled on the dead exit and
+// never reached the status handler. The status page must NEVER depend on the exit.
+func TestStatusSkysocksServedWhenExitDown(t *testing.T) {
+	c := newDeadExitClient(t)
+	defer c.Close() //nolint:errcheck
+	addr := startClientListener(t, c)
+
+	// A non-80 CONNECT port also exercises the sniff's port-independent status
+	// match (proxystatus.Match ignores the port): the reserved host is recognized
+	// and served regardless of the port the browser used.
+	conn := socks5Connect(t, addr, "status.skysocks", 8080)
+	defer conn.Close() //nolint:errcheck
+	if _, err := conn.Write([]byte("GET / HTTP/1.1\r\nHost: status.skysocks\r\nConnection: close\r\n\r\n")); err != nil {
+		t.Fatal(err)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("status page not served while exit is down: %v", err)
+	}
+	defer resp.Body.Close()          //nolint:errcheck
+	body, _ := io.ReadAll(resp.Body) //nolint:errcheck
+	if !strings.Contains(string(body), "per-leg mux") {
+		t.Fatalf("status page not served in-process; body=%q", string(body))
+	}
+	if strings.Contains(string(body), "Building a route") {
+		t.Fatalf("status.skysocks was shadowed by the interstitial; body=%q", string(body))
+	}
+}
+
 // TestStreamRegistryTracksTarget verifies the per-stream detail plumbing (item
 // 4): a normal (non-status) tunneled CONNECT registers an open stream whose
 // CONNECT target the status snapshot surfaces, and the stream is dropped from the


### PR DESCRIPTION
`status.skysocks` is a reserved in-process diagnostic host served by the skysocks-client itself. Its whole purpose is to show status when the exit is down — but it was being shadowed by the "building a route" interstitial / stalled on the dead exit.

Two gaps let the exit's reachability gate the reserved host:

- `pkg/skysocks` `sniffSOCKS5Status` forwarded the SOCKS5 greeting to the exit and blocked on the exit's method-selection reply **before** parsing the CONNECT target, so recognizing `status.skysocks` required a live, responsive exit. When the exit process was dead behind a still-open session/route (`session.Open` succeeds), the request stalled on the exit and never reached the status handler. The method reply is now answered locally (no-auth) so the CONNECT target is read with zero exit involvement; the exit is contacted only after a non-status target is confirmed, replaying the greeting + request byte-for-byte. A browser offering no no-auth method still falls back to the transparent forward-to-exit handshake.

- `proxyinterstitial.ServeSOCKS5` now resolves the reserved-host override **before** the HTTP-only port gate and the exit-reachability check (PR #4128 only covered the `session.Open`-fails path), so a reserved host is served regardless of port and never declined or shadowed.

Also updates the pre-existing 4-arg `ServeSOCKS5` callers in the dmsgweb/skynetweb status-scoping tests (left on the old signature after the 5-arg change) so the tree typechecks.

Tests: `status.skysocks` served in-process while the exit is dead (session up), on a non-80 port; reserved-host override served on a non-80 port; sniff handoff tests updated for the local-negotiation behavior.