### PR TITLE
fix(proxystatus): fixed-width leg metrics so the tree doesn't shift on updates

### DIFF
--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -778,7 +778,11 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	// drawing perfectly), so text AND glyphs share one set of metrics and connect.
 	// line-height:1 + letter-spacing:0 keep the vertical │ runs and horizontal ──
 	// runs continuous.
-	`pre.bitree{display:inline-block;text-align:left;font-family:'DejaVu Sans Mono','Liberation Mono','Noto Sans Mono',ui-monospace,'Cascadia Mono','Segoe UI Mono',Menlo,Consolas,'Courier New',monospace;font-size:11.5px;line-height:1;letter-spacing:0;margin:0 auto;white-space:pre;color:var(--fg)}` +
+	// font-variant-numeric:tabular-nums renders every digit at equal advance width
+	// (belt-and-suspenders with the fixed-width Go padding of the mutable rtt/byte
+	// fields) so live value updates never shift the aligned tree columns even if a
+	// fallback font's digits are proportional.
+	`pre.bitree{display:inline-block;text-align:left;font-family:'DejaVu Sans Mono','Liberation Mono','Noto Sans Mono',ui-monospace,'Cascadia Mono','Segoe UI Mono',Menlo,Consolas,'Courier New',monospace;font-variant-numeric:tabular-nums;font-size:11.5px;line-height:1;letter-spacing:0;margin:0 auto;white-space:pre;color:var(--fg)}` +
 	`pre.bitree code,pre.bitree span{font:inherit;color:inherit;line-height:1;letter-spacing:0;white-space:pre;word-break:normal;background:none;border:0;padding:0}` +
 	`pre.bitree code.fpk{color:var(--fg)}pre.bitree .src code.fpk{color:var(--accent);font-weight:600}` +
 	`pre.bitree code.ftid{color:var(--muted)}pre.bitree .tcol{color:var(--muted)}` +

--- a/pkg/proxystatus/routetree.go
+++ b/pkg/proxystatus/routetree.go
@@ -87,22 +87,31 @@ func RouteTree(snap Snapshot) *bitree.Node {
 // was right-justified before).
 type sumWidths struct{ idx, rtt, up, down int }
 
-// legSumWidths measures the widest value in each left-summary field across the
-// legs, so legSummary can pad every field to a common column width.
+// Fixed display widths (monospace cells) for the MUTABLE numeric fields of a
+// route's left summary — the route rtt and the ↑/↓ byte counts. These values
+// change on every ~1s live WebSocket push, so measuring their width per snapshot
+// (as the idx field still is) would let the column — and the box-drawing branch
+// and PK that follow it — shift horizontally whenever a digit is added or
+// dropped (1ms→342ms→1203ms, 9B→2.4K→15.3M). Pinning them to a constant width
+// wide enough for the realistic operating range keeps everything to their right
+// column-stable across updates. padLeftRunes only pads (never truncates), so a
+// rare out-of-range value still renders whole.
+const (
+	// rttColWidth fits "—" through "9999ms" (a slower route is pruned as dead).
+	rttColWidth = 6
+	// bwColWidth fits "0B↑" through "999.9K↑" / "15.3M↑" (compactBytes + arrow).
+	bwColWidth = 7
+)
+
+// legSumWidths measures the widest R[n] identity across the legs (that count is
+// structural — it only changes when a route is added or dropped, not on a live
+// value push) and pins the mutable numeric fields to their fixed column widths so
+// they never reflow as the values update. legSummary pads every field to these.
 func legSumWidths(legs []Leg) sumWidths {
-	var w sumWidths
+	w := sumWidths{rtt: rttColWidth, up: bwColWidth, down: bwColWidth}
 	for _, l := range legs {
 		if n := len(fmt.Sprintf("R[%d]", l.Index)); n > w.idx {
 			w.idx = n
-		}
-		if n := utf8.RuneCountInString(routeRTTCompact(l.RouteLatencyMS)); n > w.rtt {
-			w.rtt = n
-		}
-		if n := utf8.RuneCountInString(compactBytes(l.SentBytes) + "↑"); n > w.up {
-			w.up = n
-		}
-		if n := utf8.RuneCountInString(compactBytes(l.RecvBytes) + "↓"); n > w.down {
-			w.down = n
 		}
 	}
 	return w


### PR DESCRIPTION
The status.skysocks route tree sized its route-rtt and ↑/↓ byte columns from the per-snapshot max, so as the live values streamed over the WebSocket (~1s) gained or lost a digit the columns — and the box-drawing branch and PK to their right — jumped horizontally.

Pin those mutable fields to fixed monospace widths (rtt 6, bandwidth 7) in the Go label builder and add `font-variant-numeric:tabular-nums` to `pre.bitree`, so a value crossing 1ms→342ms→1203ms or 9B→2.4K→15.3M no longer reflows the tree. The `R[n]` identity width stays measured since it is structural (changes only when a route is added or dropped).