### PR TITLE
feat(router): instant warm-standby failover so a leg death never dead-ends a connection

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -172,6 +172,12 @@ type RouteGroup struct {
 	remoteClosedOnce sync.Once
 	remoteClosed     chan struct{}
 	closed           chan struct{}
+	// rotateNow signals the rotation service loop to run its on_tick controller
+	// IMMEDIATELY, out of band from the periodic interval — fired on a leg death
+	// so a warm standby is promoted the instant an active leg is lost, instead of
+	// waiting up to a full rotation interval. Buffered (1) and sent non-blocking,
+	// so a death during an in-progress tick just coalesces into one extra run.
+	rotateNow chan struct{}
 	// used to wait for all the `Close` packets to run through the loop and come back.
 	// Atomic counter + channel instead of sync.WaitGroup to avoid
 	// "WaitGroup reused before previous Wait returned" panics.
@@ -278,6 +284,7 @@ func NewRouteGroup(cfg *RouteGroupConfig, rt routing.Table, desc routing.RouteDe
 		readBuf:            bytes.Buffer{},
 		remoteClosed:       make(chan struct{}),
 		closed:             make(chan struct{}),
+		rotateNow:          make(chan struct{}, 1),
 		readDeadline:       deadline.MakePipeDeadline(),
 		writeDeadline:      deadline.MakePipeDeadline(),
 		handshakeProcessed: make(chan struct{}),
@@ -771,7 +778,7 @@ func (rg *RouteGroup) SetRotation(hook RotationHook, applyAdd, applyAddForward f
 	// startOffServiceLoops' loops do — a Close() racing with
 	// SetRotation just terminates the loop immediately.
 	if interval > 0 && hook != nil {
-		go rg.servicePacketLoop("rotation", interval, rg.rotationServiceFn)
+		go rg.servicePacketLoop("rotation", interval, rg.rotationServiceFn, rg.rotateNow)
 	}
 }
 
@@ -808,6 +815,20 @@ func (rg *RouteGroup) aliveLegCount() int {
 // setup node for the full uncapped target). A later leg death or newly-online
 // transport re-triggers the heal, so this is a backoff, not a cap.
 const selfHealNoProgressLimit = 4
+
+// signalRotate wakes the rotation loop to run its on_tick controller NOW, out of
+// band from the periodic interval — called on a leg death so drop-recovery
+// promotes a warm standby into the active set immediately instead of on the next
+// interval. Non-blocking (buffered-1 + default): a death during an in-progress
+// tick coalesces into a single extra run, and a nil channel (a route group built
+// without rotation) is a no-op. The selector's emergency standby fallback keeps
+// traffic flowing in the meantime; this restores a proper active set right after.
+func (rg *RouteGroup) signalRotate() {
+	select {
+	case rg.rotateNow <- struct{}{}:
+	default:
+	}
+}
 
 // maybeSelfHeal restores the multiplexed degree after a leg drop. If the live
 // leg count fell below target and no replacement is already in flight, it
@@ -1249,17 +1270,17 @@ func (rg *RouteGroup) RouteHopDetails() []RouteHopInfo {
 }
 
 func (rg *RouteGroup) startOffServiceLoops() {
-	go rg.servicePacketLoop("keep-alive", rg.cfg.KeepAliveInterval, rg.keepAliveServiceFn)
+	go rg.servicePacketLoop("keep-alive", rg.cfg.KeepAliveInterval, rg.keepAliveServiceFn, nil)
 	// Per-leg end-to-end liveness (issue #2): detect mux legs that black-hole
 	// BEYOND the first hop (invisible to pruneDeadTransports' local tp.IsClosed
 	// check) and drop them so self-heal re-dials a live replacement.
-	go rg.servicePacketLoop("leg-liveness", legLivenessInterval, rg.legLivenessServiceFn)
+	go rg.servicePacketLoop("leg-liveness", legLivenessInterval, rg.legLivenessServiceFn, nil)
 	// Fast data-progress prune: catch a leg that black-holes bulk DATA (while
 	// still echoing the tiny liveness ping, so the pong-miss path above never
 	// sees it) in seconds, by watching per-leg recv progress against an open
 	// reorder gap. Restores mux throughput to the reliable legs' rate instead of
 	// limping at the fragile leg's retransmit tax.
-	go rg.servicePacketLoop("leg-dataprogress", legDataProgressInterval, rg.legDataProgressServiceFn)
+	go rg.servicePacketLoop("leg-dataprogress", legDataProgressInterval, rg.legDataProgressServiceFn, nil)
 	// Note: Automatic ping loop removed. Latency is now measured once at transport creation.
 	// Rotation loop is NOT started here — startOffServiceLoops runs
 	// during initial route-group setup, before the router-side
@@ -1397,6 +1418,7 @@ func (rg *RouteGroup) dropLegsByIndex(indices []int) {
 		rg.fireLegChange("dropped", idx)
 	}
 	if len(droppedIdx) > 0 {
+		rg.signalRotate()
 		rg.maybeSelfHeal()
 	}
 	if rg.logger != nil && len(closed) > 0 {
@@ -1746,10 +1768,17 @@ func (rg *RouteGroup) pruneLivenessDeadLegs(deadIDs []uuid.UUID) {
 	for _, idx := range droppedIdx {
 		rg.fireLegChange("liveness-dead", idx)
 	}
+	rg.signalRotate()
 	rg.maybeSelfHeal()
 }
 
-func (rg *RouteGroup) servicePacketLoop(name string, interval time.Duration, f sendServicePacketFn) {
+// servicePacketLoop runs f every interval until the group closes. trigger, when
+// non-nil, is an out-of-band wake channel: a receive on it runs f immediately
+// (in addition to the periodic tick) — used by the rotation loop so a leg death
+// promotes a warm standby at once rather than on the next interval. Pass nil for
+// loops that only need the periodic cadence (a nil channel never fires in the
+// select, so those loops are unchanged).
+func (rg *RouteGroup) servicePacketLoop(name string, interval time.Duration, f sendServicePacketFn, trigger <-chan struct{}) {
 	if interval <= 0 {
 		// No keep-alive — routes persist indefinitely. Just wait for close.
 		select {
@@ -1770,6 +1799,8 @@ func (rg *RouteGroup) servicePacketLoop(name string, interval time.Duration, f s
 			rg.logger.Debugf("RouteGroup closed, stopping %s loop", name)
 			return
 		case <-ticker.C:
+			f(interval)
+		case <-trigger:
 			f(interval)
 		}
 	}
@@ -1812,6 +1843,7 @@ func (rg *RouteGroup) keepAliveServiceFn(interval time.Duration) {
 		rg.fireLegChange("dropped", idx)
 	}
 	if len(droppedLegs) > 0 {
+		rg.signalRotate()
 		rg.maybeSelfHeal()
 	}
 }
@@ -2153,7 +2185,7 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 				rg.logger.Debug("Route multiplexing enabled (both peers support CapMux)")
 				if sack {
 					rg.logger.Debug("SACK retransmission enabled (both peers support CapSACK)")
-					go rg.servicePacketLoop("sack", rg.cfg.KeepAliveInterval/2, rg.sackServiceFn)
+					go rg.servicePacketLoop("sack", rg.cfg.KeepAliveInterval/2, rg.sackServiceFn, nil)
 				}
 			}
 

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -205,6 +205,26 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 			return tp, fwd[idx], idx, nil
 		}
 	}
+
+	// EMERGENCY FAILOVER: no ACTIVE leg is selectable — every active leg is
+	// dead/not-ready. Rather than fail the send (a dead connection), fall through
+	// to any alive, ready WARM-STANDBY leg. The 512-deep standby reserve exists
+	// precisely so the connection survives the instant its active set is lost,
+	// with ZERO promote latency — a parked leg keeps its rules installed and its
+	// transport alive, so it can carry a packet immediately. This is what makes
+	// the warm reserve a real "switch in at a moment's notice" pool instead of
+	// something that only helps on the next 20s rotation tick. The leg-death
+	// trigger + rotation tick restore a proper active set right after; this just
+	// guarantees no gap. legSelectableIgnoringStandby is legReadyAt WITHOUT the
+	// standby exclusion (a parked leg that was active is ready), so it never
+	// picks a leg the peer has not confirmed.
+	for i := uint32(0); i < n; i++ {
+		idx := int((start + i) % n) //nolint:gosec
+		tp := tps[idx]
+		if tp != nil && !tp.IsClosed() && m.legSelectableIgnoringStandby(idx) {
+			return tp, fwd[idx], idx, nil
+		}
+	}
 	return nil, nil, -1, ErrNoSuitableTransport
 }
 
@@ -358,6 +378,25 @@ func (m *routeMux) legReadyAt(idx int) bool {
 	if idx < len(m.standby) && m.standby[idx] {
 		return false
 	}
+	if idx >= len(m.ready) {
+		return idx == 0
+	}
+	return m.ready[idx]
+}
+
+// legSelectableIgnoringStandby reports whether leg idx may carry a packet as an
+// EMERGENCY FAILOVER target — the same readiness gate as legReadyAt but WITHOUT
+// the warm-standby exclusion. A parked leg keeps its rules installed and its
+// transport alive, and was ready (peer-confirmed) before it was parked, so it
+// can carry traffic the instant no active leg is available. selectTransport uses
+// this only as a last resort, after every active leg has been found dead/not-
+// ready, so the connection never dies while ANY leg in the group is alive.
+func (m *routeMux) legSelectableIgnoringStandby(idx int) bool {
+	if idx < 0 {
+		return false
+	}
+	m.legMu.RLock()
+	defer m.legMu.RUnlock()
 	if idx >= len(m.ready) {
 		return idx == 0
 	}

--- a/pkg/router/route_mux_failover_test.go
+++ b/pkg/router/route_mux_failover_test.go
@@ -1,0 +1,47 @@
+//go:build !tinygo || (js && wasm)
+
+package router
+
+import "testing"
+
+// TestMuxStandbySelectableForFailover pins the emergency-failover semantics: a
+// warm-standby leg is excluded from NORMAL selection (legReadyAt=false) but is
+// still usable as a LAST-RESORT failover target (legSelectableIgnoringStandby=
+// true) so the connection survives the instant every active leg is lost — the
+// warm reserve carries traffic with zero promote latency. An unconfirmed
+// (not-ready) leg is never a failover target; the primary (0) always is.
+func TestMuxStandbySelectableForFailover(t *testing.T) {
+	m := &routeMux{}
+	m.growLegs(4)
+	m.markLegReady(1)
+	m.markLegReady(2)
+	// leg 3 is intentionally left NOT ready (peer hasn't confirmed it).
+
+	// Park leg 1 as a warm standby.
+	m.setLegStandby(1, true)
+
+	// Normal selection excludes the standby leg...
+	if m.legReadyAt(1) {
+		t.Error("standby leg 1 must not be a normal selection target")
+	}
+	// ...but emergency failover CAN use it — it is alive, ready, rules installed.
+	if !m.legSelectableIgnoringStandby(1) {
+		t.Error("a ready standby leg must be selectable as an emergency failover target")
+	}
+
+	// A not-yet-ready aux leg (3) is NOT a failover target either — sending onto
+	// a route the peer has not registered would black-hole the packet.
+	if m.legSelectableIgnoringStandby(3) {
+		t.Error("an unconfirmed (not-ready) leg must never be a failover target")
+	}
+
+	// The primary leg (0) is always selectable, active or not.
+	if !m.legSelectableIgnoringStandby(0) {
+		t.Error("primary leg 0 must always be selectable")
+	}
+
+	// An active (non-standby) ready leg is of course selectable both ways.
+	if !m.legReadyAt(2) || !m.legSelectableIgnoringStandby(2) {
+		t.Error("active ready leg 2 must be selectable normally and as failover")
+	}
+}


### PR DESCRIPTION
The warm-standby reserve (now 512 deep) only switched in on the periodic rotation tick — up to a full interval (~20s) after an active leg died. For a lean active set that's a real dead-connection window, defeating a 'switch in at a moment's notice' reserve.

Two changes, both leaving the rotation interval itself untouched (its cadence still governs UDP/sudph keep-alive + anti-churn):

- **Selector emergency fallback** (`route_mux.go`): when `selectTransport` finds no active leg selectable (all dead/not-ready), it falls through to any alive, ready warm-standby leg instead of failing the send. A parked leg keeps its rules + transport alive, so it carries the packet immediately — the connection survives as long as **any** leg is alive, zero promote latency.
- **Event-driven promote** (`route_group.go`): a leg death signals the rotation loop (`rotateNow`, buffered-1, non-blocking) to run its controller **at once**, so drop-recovery promotes a standby immediately. `servicePacketLoop` gained an optional trigger channel (nil for other loops).

Full router suite green; new test covers `legSelectableIgnoringStandby`.