### PR TITLE
fix(yamux): return error instead of spinning when a stream's session is shut down mid-read

### DIFF
--- a/third_party/hashicorp/yamux/PATCHES.md
+++ b/third_party/hashicorp/yamux/PATCHES.md
@@ -19,3 +19,21 @@ import path.
   thread at ~370k `time.NewTimer`/s and never recovers. Fix: `return 0,
   ErrSessionShutdown` from the `shutdownCh` case in both `Read` and `write`.
   Upstream PR / issue to follow (tracked in skycoin/skywire).
+
+- **`stream.go` — `Stream.Read` / `Stream.write`: don't rely on select fairness
+  to observe shutdown.** The return case above fires only when the blocking
+  `select` happens to pick `shutdownCh`. `select` chooses uniformly among ready
+  cases, so once the session is shut down a lingering — or repeatedly
+  re-signaled — `recvNotifyCh` / `sendNotifyCh` token can be chosen instead,
+  sending the loop back through `START` with no data / a zero send window and no
+  forward progress. The per-stream state stays `streamEstablished` until
+  `forceClose` runs, and with no read/write deadline set the retry loop
+  allocates nothing, so it never hits a GC safepoint and, on single-threaded
+  js/wasm, never yields — one goroutine pegs the only thread and freezes the
+  runtime (GC included) for as long as the token keeps arriving. Fix: a
+  non-blocking `case <-s.session.shutdownCh: return` / `default:` pre-check at
+  the top of each WAIT path so termination is deterministic and independent of
+  select fairness and of how often the notify channel is signaled. The pre-check
+  is placed after the `START` buffered-data handling so a half-closed stream
+  still drains its receive buffer before returning. Regression coverage:
+  `stream_shutdown_test.go`.

--- a/third_party/hashicorp/yamux/stream.go
+++ b/third_party/hashicorp/yamux/stream.go
@@ -136,6 +136,26 @@ START:
 	return n, err
 
 WAIT:
+	// Terminate deterministically when the session is gone. The select below
+	// picks uniformly among ready cases, so once shutdownCh is closed a
+	// lingering (or repeatedly re-signaled) recvNotifyCh token can be chosen
+	// over it, sending us back through START with no data and no forward
+	// progress. START only inspects the per-stream state, which stays
+	// streamEstablished until forceClose runs, so we loop straight back to
+	// WAIT. With no read deadline set this loop allocates nothing (timer is
+	// nil), so it never triggers a GC safepoint and, on single-threaded
+	// js/wasm, never yields — one goroutine pegs the only thread and freezes
+	// the whole runtime for as long as the token keeps being re-signaled.
+	// (#3924 added the shutdownCh return case below but left termination
+	// dependent on select fairness; this non-blocking pre-check removes that
+	// dependency.) This must come after the START buffered-data handling so a
+	// half-closed stream still drains its receive buffer before returning.
+	select {
+	case <-s.session.shutdownCh:
+		return 0, ErrSessionShutdown
+	default:
+	}
+
 	var timeout <-chan time.Time
 	var timer *time.Timer
 	readDeadline := s.readDeadline.Load().(time.Time)
@@ -146,14 +166,6 @@ WAIT:
 	}
 	select {
 	case <-s.session.shutdownCh:
-		// Session is gone: no more data will ever arrive on this stream. The
-		// bare fall-through to `goto START` upstream ships spins forever here —
-		// START only inspects the per-stream state, which stays streamEstablished
-		// when a session is torn down mid-Read (common when a dmsg WS/WebRTC
-		// carrier drops during an in-flight dial). shutdownCh is a CLOSED channel,
-		// so the select re-fires it every iteration, re-allocating a timer each
-		// pass: a single goroutine pegs the (single) wasm thread at ~370k
-		// time.NewTimer/s. Return instead of looping.
 		return 0, ErrSessionShutdown
 	case <-s.recvNotifyCh:
 	case <-timeout:
@@ -232,6 +244,19 @@ START:
 	return int(max), err
 
 WAIT:
+	// Symmetric to Read: terminate deterministically when the session is gone.
+	// A torn-down session can never drain the send window, so once shutdownCh
+	// is closed a lingering (or re-signaled) sendNotifyCh token chosen by the
+	// select below sends us back through START with window still 0 and no
+	// progress — the same non-allocating, non-preemptible spin that freezes
+	// single-threaded js/wasm. Re-check shutdown first so the loop always
+	// returns rather than relying on select fairness to eventually pick it.
+	select {
+	case <-s.session.shutdownCh:
+		return 0, ErrSessionShutdown
+	default:
+	}
+
 	var timeout <-chan time.Time
 	var timer *time.Timer
 	writeDeadline := s.writeDeadline.Load().(time.Time)
@@ -242,9 +267,6 @@ WAIT:
 	}
 	select {
 	case <-s.session.shutdownCh:
-		// Symmetric to Read: a torn-down session can never drain the send
-		// window, so the upstream fall-through to `goto START` spins on the
-		// closed shutdownCh (window stays 0) instead of failing the write.
 		return 0, ErrSessionShutdown
 	case <-s.sendNotifyCh:
 	case <-timeout:

--- a/third_party/hashicorp/yamux/stream_shutdown_test.go
+++ b/third_party/hashicorp/yamux/stream_shutdown_test.go
@@ -1,0 +1,173 @@
+package yamux
+
+import (
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// testSessionPair wires a client and server Session over an in-memory pipe.
+func testSessionPair(t *testing.T) (client, server *Session) {
+	t.Helper()
+	cConn, sConn := net.Pipe()
+
+	cfg := DefaultConfig()
+	cfg.EnableKeepAlive = false // keep the test deterministic (no background pings)
+
+	var err error
+	client, err = Client(cConn, cfg.Clone())
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	server, err = Server(sConn, cfg.Clone())
+	if err != nil {
+		t.Fatalf("server: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+	return client, server
+}
+
+// TestStreamReadReturnsOnSessionShutdown asserts that a Read blocked with no
+// data available returns promptly once the session is closed, rather than
+// spinning. This is the base guarantee restored by #3924.
+func TestStreamReadReturnsOnSessionShutdown(t *testing.T) {
+	client, server := testSessionPair(t)
+
+	// Establish a stream so both ends have it in streamEstablished.
+	go func() {
+		s, err := server.AcceptStream()
+		if err == nil {
+			// Read once so the server side is parked too; ignore result.
+			buf := make([]byte, 1)
+			_, _ = s.Read(buf)
+		}
+	}()
+
+	stream, err := client.OpenStream()
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 64)
+		_, rerr := stream.Read(buf)
+		done <- rerr
+	}()
+
+	// Give the reader a moment to park in WAIT, then tear the session down.
+	time.Sleep(50 * time.Millisecond)
+	if err := client.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	select {
+	case rerr := <-done:
+		if rerr == nil {
+			t.Fatal("expected an error from Read after session shutdown, got nil")
+		}
+		if rerr != ErrSessionShutdown && rerr != io.EOF {
+			t.Fatalf("unexpected error: %v (want ErrSessionShutdown or io.EOF)", rerr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read did not return within 2s after session shutdown (spin/hang)")
+	}
+}
+
+// TestStreamReadDoesNotSpinOnNotifyAfterShutdown reproduces the residual spin
+// directly and deterministically. It puts a stream in streamEstablished, marks
+// the session shut down, and then hammers recvNotifyCh so the WAIT select's
+// notify case is (essentially) always ready. Without the non-blocking
+// shutdownCh pre-check, the retry loop makes no forward progress and — with no
+// read deadline set — allocates nothing, matching the observed js/wasm freeze
+// (num_gc unchanged, non-preemptible). With the fix, Read returns promptly no
+// matter how aggressively recvNotifyCh is signaled.
+func TestStreamReadDoesNotSpinOnNotifyAfterShutdown(t *testing.T) {
+	client, _ := testSessionPair(t)
+
+	stream := newStream(client, 1, streamEstablished)
+
+	// Mark the session as shut down the same way Session.Close() does, but
+	// WITHOUT forceClosing the stream, so its state stays streamEstablished —
+	// exactly the race window Close() opens between close(shutdownCh) and
+	// forceClose(streams).
+	client.shutdownLock.Lock()
+	if !client.shutdown {
+		client.shutdown = true
+		client.shutdownErr = ErrSessionShutdown
+		close(client.shutdownCh)
+	}
+	client.shutdownLock.Unlock()
+
+	// Continuously re-signal recvNotifyCh to keep the notify case ready.
+	var stop int32
+	go func() {
+		for atomic.LoadInt32(&stop) == 0 {
+			asyncNotify(stream.recvNotifyCh)
+		}
+	}()
+	defer atomic.StoreInt32(&stop, 1)
+
+	done := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 64)
+		_, rerr := stream.Read(buf)
+		done <- rerr
+	}()
+
+	select {
+	case rerr := <-done:
+		if rerr != ErrSessionShutdown {
+			t.Fatalf("expected ErrSessionShutdown, got %v", rerr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read spun on recvNotifyCh instead of returning on shutdown")
+	}
+}
+
+// TestStreamWriteDoesNotSpinOnNotifyAfterShutdown is the write-side analogue:
+// a full send window plus a shut-down session must fail the write promptly even
+// while sendNotifyCh is continuously signaled.
+func TestStreamWriteDoesNotSpinOnNotifyAfterShutdown(t *testing.T) {
+	client, _ := testSessionPair(t)
+
+	stream := newStream(client, 1, streamEstablished)
+	// Exhaust the send window so write() parks in WAIT.
+	atomic.StoreUint32(&stream.sendWindow, 0)
+
+	client.shutdownLock.Lock()
+	if !client.shutdown {
+		client.shutdown = true
+		client.shutdownErr = ErrSessionShutdown
+		close(client.shutdownCh)
+	}
+	client.shutdownLock.Unlock()
+
+	var stop int32
+	go func() {
+		for atomic.LoadInt32(&stop) == 0 {
+			asyncNotify(stream.sendNotifyCh)
+		}
+	}()
+	defer atomic.StoreInt32(&stop, 1)
+
+	done := make(chan error, 1)
+	go func() {
+		_, werr := stream.Write([]byte("payload"))
+		done <- werr
+	}()
+
+	select {
+	case werr := <-done:
+		if werr != ErrSessionShutdown {
+			t.Fatalf("expected ErrSessionShutdown, got %v", werr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Write spun on sendNotifyCh instead of returning on shutdown")
+	}
+}


### PR DESCRIPTION
When a carrier/transport drops mid-dial the session's `shutdownCh` is closed, but a stream's per-stream state stays `streamEstablished` until `forceClose` runs. #3924 added a `shutdownCh` return case to the `Read`/`write` WAIT selects, but a Go `select` picks uniformly among ready cases: a lingering or repeatedly re-signaled `recvNotifyCh`/`sendNotifyCh` token can be chosen over the closed `shutdownCh`, sending the retry loop back through `START` with no data / a zero send window and no forward progress. With no deadline set that loop allocates nothing (num_gc stays flat) and on single-threaded js/wasm never yields, freezing the whole runtime for 45-196s (diagnosed live on the wasm-visor).

The fix adds a non-blocking `shutdownCh` pre-check at the top of each WAIT path so termination is deterministic and independent of select fairness (and of how often the notify channel is signaled), placed after the START buffered-data handling so a half-closed stream still drains its receive buffer first. Regression tests in `stream_shutdown_test.go`; full yamux suite passes with `-race`.

The wasm-visor freeze can only be confirmed after a TinyGo rebuild + re-embed (deferred to the operator), but the fix is correct on its own — yamux is used natively for dmsg sessions and mux route groups, where the same spin is a real (less visible) bug.