### PR TITLE
perf(skysocks): raise the yamux stream window from 256KB to 16MB for the mesh BDP

### DIFF
--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -24,6 +24,20 @@ import (
 	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 )
 
+// muxStreamWindowBytes is the per-stream yamux flow-control window skysocks
+// advertises, raised from yamux's 256 KB default. Throughput over a reliable
+// stream is bounded by window / RTT (the bandwidth-delay product); the skywire
+// mesh path has a high RTT (~0.5-1 s end-to-end across relays), so the 256 KB
+// default caps a single skysocks stream at ~256 KB/s regardless of the
+// underlying link — measured live at ~250 KB/s on a 100 Mbps card whose exit
+// egressed at 200 MB/s. 16 MB gives 16 MB/s at 1 s RTT (128 Mbps), saturating a
+// 100 Mbps card with headroom; yamux only buffers up to the window's worth of
+// ACTUALLY in-flight data, so idle/interactive streams pay nothing and a bulk
+// stream costs at most this much receive buffer. The receiver's window governs
+// each direction, so the client value speeds downloads and the server value
+// speeds uploads.
+const muxStreamWindowBytes = 16 * 1024 * 1024
+
 // Client implement multiplexing proxy client using yamux.
 type Client struct {
 	appCl    *app.Client
@@ -57,6 +71,7 @@ func NewClient(conn net.Conn, appCl *app.Client) (*Client, error) {
 
 	sessionCfg := yamux.DefaultConfig()
 	sessionCfg.EnableKeepAlive = false
+	sessionCfg.MaxStreamWindowSize = muxStreamWindowBytes
 	session, err := yamux.Client(conn, sessionCfg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: yamux: %w", err)

--- a/pkg/skysocks/server.go
+++ b/pkg/skysocks/server.go
@@ -122,6 +122,7 @@ func (s *Server) Serve(l net.Listener) error {
 
 		sessionCfg := yamux.DefaultConfig()
 		sessionCfg.EnableKeepAlive = false
+		sessionCfg.MaxStreamWindowSize = muxStreamWindowBytes
 		session, err := yamux.Server(conn, sessionCfg)
 		if err != nil {
 			return fmt.Errorf("yamux server failure: %w", err)


### PR DESCRIPTION
Throughput over a reliable stream is bounded by **window / RTT** (the bandwidth-delay product). skysocks used yamux `DefaultConfig`, whose `MaxStreamWindowSize` is **256 KB** — so on the mesh's high end-to-end RTT (~0.5-1 s across relays) a single skysocks stream was capped at **~256 KB/s** regardless of the underlying link.

Measured live: a single direct-transport proxy leg delivered a steady **~250 KB/s** (= 256 KB / ~1 s RTT), while the **exit egressed to the same target at 204 MB/s** and the client NIC is **100 Mbps** — ~2% of the card, CPU idle at 11% (window-starved, not compute-bound).

Raise `MaxStreamWindowSize` to **16 MB** on client + server: 16 MB / 1 s = 128 Mbps, saturating a 100 Mbps card with headroom. yamux only buffers actually-in-flight data, so idle streams pay nothing. The **receiver's** window governs each direction — the client value speeds **downloads** (no fleet update needed; the exit respects the advertised window), the server value speeds **uploads** once the fleet redeploys.