### PR TITLE
feat(skysocks): multi-session client with least-loaded connection striping (aggregation foundation)

### DIFF
--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -50,6 +50,7 @@ var (
 	reconnectDelay int64
 	direct         bool
 	dmsgFallback   bool
+	tunnels        int64
 )
 
 func init() {
@@ -71,6 +72,10 @@ func init() {
 	RootCmd.Flags().Int64Var(&reconnectDelay, "reconnect-delay", 2, "seconds between in-process reconnect attempts")
 	RootCmd.Flags().BoolVar(&direct, "direct", false, "force a direct-transport-only route to the server (create the transport on demand, dial 1-hop, bypass the route-finder + setup node); self-heals when the server restarts")
 	RootCmd.Flags().BoolVar(&dmsgFallback, "dmsg-fallback", false, "if the skynet (route) dial to the server fails, fall back to a direct dmsg stream (opt-in: dmsg relays via a dmsg server — higher latency + the server sees both endpoint PKs)")
+	// N independent tunnels (route group + noise + yamux each); browser conns are
+	// striped across them by the least-loaded policy so throughput sums. Default 1
+	// == the single-tunnel pre-aggregation behavior. See docs/mux_aggregation_rfc.md.
+	RootCmd.Flags().Int64Var(&tunnels, "tunnels", 1, "number of independent tunnels to stripe connections across (1 = today's behavior; >1 aggregates ONLY over disjoint routes — see --help)")
 }
 
 // RootCmd is the root command for skysocks
@@ -106,6 +111,7 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		fs.Int64Var(&reconnectDelay, "reconnect-delay", 2, "seconds between reconnect attempts")
 		fs.BoolVar(&direct, "direct", false, "force a direct-transport-only route to the server (1-hop, bypass the route-finder + setup node); self-heals on server restart")
 		fs.BoolVar(&dmsgFallback, "dmsg-fallback", false, "fall back to a direct dmsg stream if the skynet dial fails")
+		fs.Int64Var(&tunnels, "tunnels", 1, "number of independent tunnels to stripe connections across")
 		if err := fs.Parse(args); err != nil {
 			return fmt.Errorf("failed to parse flags: %w", err)
 		}
@@ -198,15 +204,39 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		}
 
 		conn, err := dialServer(cycleCtx, appCl, pk, serverPort)
+		if err != nil {
+			// Stop the disconnected listener and wait for it to release :1080.
+			dcancel()
+			<-ddone
+			return fmt.Errorf("dial server: %w", err)
+		}
+		conns := []net.Conn{conn}
+		// Dial the additional tunnels. Each is an independent route group +
+		// noise + yamux; the client stripes browser conns across them. A tunnel
+		// that fails to dial is skipped (degrade to fewer tunnels) rather than
+		// failing the whole cycle. IMPORTANT: dialServer has NO transport /
+		// intermediate exclusion yet, so these dials may land on the SAME path —
+		// same first-hop transport means they SPLIT one link, not sum it, so this
+		// is plumbing, not real aggregation. Per-tunnel first-hop-transport
+		// exclusion (disjoint-tunnel dial coordination) is the REQUIRED follow-up
+		// before aggregation is real — see docs/mux_aggregation_rfc.md step 3.
+		for i := int64(1); i < tunnels; i++ {
+			extra, derr := dialServer(cycleCtx, appCl, pk, serverPort)
+			if derr != nil {
+				log.WithError(derr).Warnf("tunnel %d/%d dial failed; continuing with %d tunnel(s)", i+1, tunnels, len(conns))
+				continue
+			}
+			conns = append(conns, extra)
+		}
 		// Stop the disconnected listener and wait for it to release :1080 before the
 		// live Client rebinds the same addr.
 		dcancel()
 		<-ddone
-		if err != nil {
-			return fmt.Errorf("dial server: %w", err)
-		}
 		log.Infof("Connected to %v", pk)
-		client, err := skysocks.NewClient(conn, appCl)
+		if len(conns) > 1 {
+			log.Warnf("skysocks-client: %d tunnels dialed, but disjoint-path coordination is NOT implemented — tunnels may share the same first-hop transport (split, not sum: no real aggregation). Follow-up: per-tunnel transport/intermediate exclusion, docs/mux_aggregation_rfc.md step 3.", len(conns))
+		}
+		client, err := skysocks.NewMultiClient(conns, appCl)
 		if err != nil {
 			return fmt.Errorf("new client: %w", err)
 		}

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -39,12 +40,25 @@ import (
 const muxStreamWindowBytes = 16 * 1024 * 1024
 
 // Client implement multiplexing proxy client using yamux.
+//
+// The client holds N independent yamux sessions ("tunnels"), each over its own
+// dialed route-group conn. Accepted browser connections are striped across the
+// tunnels by pickSession (least-loaded live tunnel), so throughput sums across
+// disjoint routes with zero cross-tunnel reorder — the connection-striped
+// aggregation design in docs/mux_aggregation_rfc.md. N is configurable; the
+// default is a single tunnel (N==1), which is byte-for-byte the pre-aggregation
+// behavior. Multiple tunnels only genuinely aggregate once they leave over
+// disjoint first-hop transports; that disjoint-dial coordination is the required
+// follow-up (RFC step 3) and is NOT implemented here.
 type Client struct {
-	appCl    *app.Client
-	session  *yamux.Session
-	listener net.Listener
-	once     sync.Once
-	closeC   chan struct{}
+	appCl *app.Client
+	// sessions holds the live tunnels (>=1). Guarded by sessionsMu because
+	// AddTunnel appends while the accept loop / keepalive read concurrently.
+	sessions   []*yamux.Session
+	sessionsMu sync.Mutex
+	listener   net.Listener
+	once       sync.Once
+	closeC     chan struct{}
 
 	// streams tracks the currently open tunneled streams so the status page can
 	// expand the "N open stream(s)" count into per-stream rows (id + CONNECT
@@ -61,14 +75,16 @@ type streamMeta struct {
 	since  time.Time
 }
 
-// NewClient constructs a new Client.
-func NewClient(conn net.Conn, appCl *app.Client) (*Client, error) {
-	c := &Client{
-		appCl:   appCl,
-		closeC:  make(chan struct{}),
-		streams: make(map[uint32]streamMeta),
-	}
+// errAllTunnelsDown is the synthetic stream-open error used when every tunnel
+// is closed so pickSession returns nil and there is no live session to Open() a
+// real error from. It drives the same route-down interstitial + reconnect path a
+// single closed session took before.
+var errAllTunnelsDown = errors.New("all tunnels to the exit are down")
 
+// newYamuxSession wraps a dialed route-group conn in a yamux client session with
+// skysocks's flow-control window. Shared by NewClient and AddTunnel so every
+// tunnel is configured identically.
+func newYamuxSession(conn net.Conn) (*yamux.Session, error) {
 	sessionCfg := yamux.DefaultConfig()
 	sessionCfg.EnableKeepAlive = false
 	sessionCfg.MaxStreamWindowSize = muxStreamWindowBytes
@@ -76,12 +92,147 @@ func NewClient(conn net.Conn, appCl *app.Client) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: yamux: %w", err)
 	}
+	return session, nil
+}
 
-	c.session = session
+// NewClient constructs a new single-tunnel Client. Signature unchanged: this is
+// the common case and every existing caller/test builds one tunnel this way. Use
+// AddTunnel (or NewMultiClient) to stripe browser connections across N tunnels.
+func NewClient(conn net.Conn, appCl *app.Client) (*Client, error) {
+	c := &Client{
+		appCl:   appCl,
+		closeC:  make(chan struct{}),
+		streams: make(map[uint32]streamMeta),
+	}
+
+	session, err := newYamuxSession(conn)
+	if err != nil {
+		return nil, err
+	}
+	c.sessions = []*yamux.Session{session}
 
 	go c.sessionKeepAliveLoop()
 
 	return c, nil
+}
+
+// NewMultiClient constructs a Client striping across one tunnel per conn. With a
+// single conn it is identical to NewClient. The N conns must already be dialed
+// (ideally over disjoint routes — see the disjoint-dial follow-up in
+// docs/mux_aggregation_rfc.md step 3); this constructor only wraps them.
+func NewMultiClient(conns []net.Conn, appCl *app.Client) (*Client, error) {
+	if len(conns) == 0 {
+		return nil, errors.New("skysocks: NewMultiClient needs at least one conn")
+	}
+	c, err := NewClient(conns[0], appCl)
+	if err != nil {
+		return nil, err
+	}
+	for _, conn := range conns[1:] {
+		if err := c.AddTunnel(conn); err != nil {
+			_ = c.Close() //nolint:errcheck
+			return nil, err
+		}
+	}
+	return c, nil
+}
+
+// AddTunnel wraps an additional dialed route-group conn in a yamux session and
+// appends it to the tunnel set. The shared keepalive loop and pickSession pick it
+// up automatically. This is the extension point the disjoint-dial coordinator
+// (RFC step 3) will call to grow the tunnel set at runtime.
+func (c *Client) AddTunnel(conn net.Conn) error {
+	session, err := newYamuxSession(conn)
+	if err != nil {
+		return err
+	}
+	c.sessionsMu.Lock()
+	c.sessions = append(c.sessions, session)
+	c.sessionsMu.Unlock()
+	return nil
+}
+
+// snapshotSessions returns a copy of the current tunnel set for lock-free
+// iteration by callers (keepalive, status).
+func (c *Client) snapshotSessions() []*yamux.Session {
+	c.sessionsMu.Lock()
+	defer c.sessionsMu.Unlock()
+	out := make([]*yamux.Session, len(c.sessions))
+	copy(out, c.sessions)
+	return out
+}
+
+// leastLoaded returns the index of the smallest non-negative count, or -1 when
+// every count is negative — the sentinel a closed/skipped tunnel is given. Ties
+// resolve to the lowest index so selection is deterministic. Extracted as a pure
+// function so the least-loaded striping policy is unit-testable without a live
+// yamux session.
+func leastLoaded(counts []int) int {
+	best := -1
+	for i, n := range counts {
+		if n < 0 {
+			continue
+		}
+		if best == -1 || n < counts[best] {
+			best = i
+		}
+	}
+	return best
+}
+
+// pickSession returns the least-loaded live tunnel (fewest open yamux streams),
+// skipping any closed tunnel, or nil when every tunnel is closed. This is the
+// connection-striping policy: each accepted browser conn goes to the tunnel with
+// the most spare capacity. With a single tunnel it always returns that tunnel
+// while it is live (identical to the pre-aggregation c.session).
+func (c *Client) pickSession() *yamux.Session {
+	c.sessionsMu.Lock()
+	defer c.sessionsMu.Unlock()
+	if len(c.sessions) == 0 {
+		return nil
+	}
+	counts := make([]int, len(c.sessions))
+	for i, s := range c.sessions {
+		if s == nil || s.IsClosed() {
+			counts[i] = -1
+			continue
+		}
+		counts[i] = s.NumStreams()
+	}
+	idx := leastLoaded(counts)
+	if idx < 0 {
+		return nil
+	}
+	return c.sessions[idx]
+}
+
+// anySessionLive reports whether at least one tunnel is still up. With a single
+// tunnel this is exactly !session.IsClosed().
+func (c *Client) anySessionLive() bool {
+	for _, s := range c.snapshotSessions() {
+		if s != nil && !s.IsClosed() {
+			return true
+		}
+	}
+	return false
+}
+
+// allSessionsClosed reports whether every tunnel is closed (the whole-client
+// teardown / reconnect trigger). An empty set counts as closed.
+func (c *Client) allSessionsClosed() bool {
+	return !c.anySessionLive()
+}
+
+// totalStreams sums the open stream counts across live tunnels — the aggregate
+// "N open stream(s)" the status page reports.
+func (c *Client) totalStreams() int {
+	total := 0
+	for _, s := range c.snapshotSessions() {
+		if s != nil && !s.IsClosed() {
+			total += s.NumStreams()
+		}
+	}
+	return total
 }
 
 // ListenAndServe start tcp listener on addr and proxies incoming
@@ -125,8 +276,18 @@ func (c *Client) ListenAndServe(addr string) error {
 			c.appCl.Log().Debug("Accepted skysocks client")
 		}
 
-		stream, err := c.session.Open()
-		if err != nil {
+		// Stripe onto the least-loaded live tunnel. pickSession returns nil only
+		// when every tunnel is closed; in that (route-down) case there is no live
+		// session to Open() a real error from, so a sentinel drives the same
+		// interstitial + reconnect path a single closed session took before.
+		sess := c.pickSession()
+		var stream net.Conn
+		if sess != nil {
+			stream, err = sess.Open()
+		} else {
+			err = errAllTunnelsDown
+		}
+		if sess == nil || err != nil {
 			// The mesh route/session to the exit is down (exit restart, all
 			// mux legs dropped). Before tearing down for reconnect, serve the
 			// waiting browser a branded "building a route over skywire…"
@@ -138,14 +299,17 @@ func (c *Client) ListenAndServe(addr string) error {
 			// keeps the in-process status page reachable even now (exit down)
 			// instead of being shadowed by the interstitial — status.skysocks
 			// needs no exit stream, and this is exactly when the user wants it.
-			// A single Open failing does NOT always mean the session is dead: if
-			// the session is still up, the failure was transient and the exit is
-			// reachable. In that case ServeSOCKS5 serves a fall-through reload
-			// (exitReachable=true) instead of pinning the browser on the waiting
-			// interstitial, and we keep listening rather than tearing down — the
-			// browser's reload gets a working stream. Only a genuinely closed
-			// session serves the waiting interstitial and triggers reconnect.
-			reachable := c.session != nil && !c.session.IsClosed()
+			// A single Open failing does NOT always mean all tunnels are dead: if
+			// ANY tunnel is still up, the failure was transient (or just this
+			// tunnel died) and the exit is still reachable. In that case
+			// ServeSOCKS5 serves a fall-through reload (exitReachable=true)
+			// instead of pinning the browser on the waiting interstitial, and we
+			// keep listening rather than tearing down — the browser's reload gets
+			// a working stream on the next-picked tunnel. Only when EVERY tunnel
+			// is closed do we serve the waiting interstitial and trigger
+			// reconnect. With a single tunnel (N==1) this is exactly the prior
+			// behavior.
+			reachable := c.anySessionLive()
 			go func(bc net.Conn) {
 				if serr := proxyinterstitial.ServeSOCKS5(bc, proxyinterstitial.StatusLine(err), "skysocks", c.statusOverride, c.exitReachable); serr != nil && c.appCl != nil {
 					c.appCl.Log().Debugf("route-down interstitial not served: %v", serr)
@@ -154,7 +318,7 @@ func (c *Client) ListenAndServe(addr string) error {
 			}(conn)
 			if reachable {
 				if c.appCl != nil {
-					c.appCl.Log().Debugf("yamux stream open failed but session is up; keeping listener: %v", err)
+					c.appCl.Log().Debugf("yamux stream open failed but a tunnel is up; keeping listener: %v", err)
 				}
 				continue
 			}
@@ -184,31 +348,45 @@ const (
 	livenessFailThreshold = 2
 )
 
+// sessionKeepAliveLoop probes every tunnel and retires the dead ones. A tunnel
+// that fails livenessFailThreshold consecutive pings is closed so pickSession
+// stops routing to it (dropping just that tunnel's streams); the whole client is
+// torn down for reconnect only once EVERY tunnel is closed. With a single tunnel
+// (N==1) this is exactly the prior behavior: the one tunnel dying closes the
+// client. Per-tunnel re-dial of a dropped tunnel (instead of only skipping it) is
+// the disjoint-dial follow-up — see docs/mux_aggregation_rfc.md step 3.
 func (c *Client) sessionKeepAliveLoop() {
 	ticker := time.NewTicker(livenessProbeInterval)
 	defer ticker.Stop()
 
-	fails := 0
+	fails := make(map[*yamux.Session]int)
 	for {
 		select {
 		case <-c.closeC:
 			return
 		case <-ticker.C:
-			if c.session.IsClosed() {
-				c.close()
-
-				return
-			}
-			if c.sessionAlive(livenessProbeTimeout) {
-				fails = 0
-
-				continue
-			}
-			fails++
-			if fails >= livenessFailThreshold {
-				if c.appCl != nil {
-					c.appCl.Log().Warnf("Liveness probe failed %dx; route group gone, closing for reconnect", fails)
+			for _, s := range c.snapshotSessions() {
+				if s.IsClosed() {
+					delete(fails, s)
+					continue
 				}
+				if sessionPingAlive(s, livenessProbeTimeout) {
+					fails[s] = 0
+					continue
+				}
+				fails[s]++
+				if fails[s] >= livenessFailThreshold {
+					if c.appCl != nil {
+						c.appCl.Log().Warnf("Liveness probe failed %dx; tunnel gone, retiring it", fails[s])
+					}
+					// Retire just this tunnel; a closed session is skipped by
+					// pickSession. The whole-client close below fires only when
+					// this leaves no live tunnel.
+					_ = s.Close() //nolint:errcheck
+					delete(fails, s)
+				}
+			}
+			if c.allSessionsClosed() {
 				c.close()
 
 				return
@@ -217,14 +395,14 @@ func (c *Client) sessionKeepAliveLoop() {
 	}
 }
 
-// sessionAlive reports whether a yamux ping round-trips within timeout.
-// A silently torn-down rg conn never pongs; the timer catches that. The
-// ping runs in a goroutine so a wedged ping cannot stall the loop —
+// sessionPingAlive reports whether a yamux ping round-trips on the given session
+// within timeout. A silently torn-down rg conn never pongs; the timer catches
+// that. The ping runs in a goroutine so a wedged ping cannot stall the caller —
 // Close() tears down the session, which unblocks the pending ping.
-func (c *Client) sessionAlive(timeout time.Duration) bool {
+func sessionPingAlive(s *yamux.Session, timeout time.Duration) bool {
 	done := make(chan error, 1)
 	go func() {
-		_, err := c.session.Ping()
+		_, err := s.Ping()
 		done <- err
 	}()
 	select {
@@ -233,6 +411,18 @@ func (c *Client) sessionAlive(timeout time.Duration) bool {
 	case <-time.After(timeout):
 		return false
 	}
+}
+
+// sessionAlive reports whether any tunnel answers a ping within timeout. With a
+// single tunnel it is exactly a ping of that tunnel (retained for the liveness
+// tests and any single-session caller).
+func (c *Client) sessionAlive(timeout time.Duration) bool {
+	for _, s := range c.snapshotSessions() {
+		if s != nil && sessionPingAlive(s, timeout) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) handleStream(conn, stream net.Conn) {
@@ -245,7 +435,7 @@ func (c *Client) handleStream(conn, stream net.Conn) {
 	if !proceed {
 		conn.Close()   //nolint:errcheck,gosec
 		stream.Close() //nolint:errcheck,gosec
-		if c.session.IsClosed() {
+		if c.allSessionsClosed() {
 			c.close()
 		}
 		return
@@ -284,7 +474,7 @@ func (c *Client) handleStream(conn, stream net.Conn) {
 		}
 	}
 
-	if c.session.IsClosed() {
+	if c.allSessionsClosed() {
 		c.close()
 	}
 }
@@ -524,12 +714,13 @@ func (c *Client) streamSnapshot() []proxystatus.Stream {
 	return out
 }
 
-// exitReachable reports whether the yamux session to the exit is currently live.
-// It is the fall-through probe handed to proxyinterstitial.ServeSOCKS5: when the
-// exit is reachable again, the interstitial is replaced by a reload page so the
-// browser proceeds to the intended destination instead of waiting on a spinner.
+// exitReachable reports whether at least one tunnel to the exit is currently
+// live. It is the fall-through probe handed to proxyinterstitial.ServeSOCKS5:
+// when the exit is reachable again, the interstitial is replaced by a reload page
+// so the browser proceeds to the intended destination instead of waiting on a
+// spinner. With a single tunnel it is exactly !session.IsClosed().
 func (c *Client) exitReachable() bool {
-	return c.session != nil && !c.session.IsClosed()
+	return c.anySessionLive()
 }
 
 // statusOverride is the reserved-host answer handed to
@@ -888,9 +1079,15 @@ func wsReadFrame(conn net.Conn) (opcode byte, payload []byte, err error) {
 // snapshot, so status.skysocks always renders.
 func (c *Client) statusSnapshot() proxystatus.Snapshot {
 	snap := c.visorStatusSnapshot()
-	if c.session != nil && !c.session.IsClosed() {
+	if c.anySessionLive() {
 		snap.Running = true
-		snap.Note = fmt.Sprintf("session to the exit is up · %d open stream(s)", c.session.NumStreams())
+		snap.Note = fmt.Sprintf("session to the exit is up · %d open stream(s)", c.totalStreams())
+		// With more than one tunnel, surface how many carry the aggregate. A
+		// single tunnel keeps the note byte-identical to the pre-aggregation
+		// build (no "· N tunnel(s)" suffix).
+		if n := len(c.snapshotSessions()); n > 1 {
+			snap.Note = fmt.Sprintf("%s · %d tunnels", snap.Note, n)
+		}
 		// Per-stream detail (id + target + age) behind the count, when tracked.
 		snap.Streams = c.streamSnapshot()
 	} else {
@@ -999,10 +1196,16 @@ func (c *Client) Close() error {
 		}
 
 		close(c.closeC)
-		// Tear down the yamux session so reconnect builds a fresh one
-		// and any in-flight liveness ping unblocks.
-		if c.session != nil {
-			err = c.session.Close()
+		// Tear down every tunnel so reconnect builds fresh ones and any
+		// in-flight liveness ping unblocks. The first close error (if any) is
+		// returned; all sessions are closed regardless.
+		for _, s := range c.snapshotSessions() {
+			if s == nil {
+				continue
+			}
+			if cerr := s.Close(); cerr != nil && err == nil {
+				err = cerr
+			}
 		}
 	})
 

--- a/pkg/skysocks/client_multitunnel_test.go
+++ b/pkg/skysocks/client_multitunnel_test.go
@@ -1,0 +1,169 @@
+// Package skysocks multi-tunnel (connection-striping) client tests.
+package skysocks
+
+import (
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
+)
+
+// leastLoaded is the pure striping policy: pick the smallest non-negative count
+// (a closed/skipped tunnel is the -1 sentinel), ties to the lowest index.
+func TestLeastLoaded(t *testing.T) {
+	cases := []struct {
+		name   string
+		counts []int
+		want   int
+	}{
+		{"empty", nil, -1},
+		{"single", []int{0}, 0},
+		{"all-closed", []int{-1, -1, -1}, -1},
+		{"pick-min", []int{5, 2, 8}, 1},
+		{"zero-wins", []int{2, 1, 0}, 2},
+		{"ties-lowest-index", []int{3, 3, 3}, 0},
+		{"skip-closed", []int{-1, 3, 1, -1}, 2},
+		{"closed-min-ignored", []int{-1, 0}, 1},
+		{"first-live-when-tie-after-closed", []int{-1, 2, 2}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, leastLoaded(tc.counts))
+		})
+	}
+}
+
+// newTestSession returns a live yamux client session whose peer drains every
+// accepted stream, so Open() completes and NumStreams() reflects opens without
+// wedging. The cleanup tears both sides down.
+func newTestSession(t *testing.T) (*yamux.Session, func()) {
+	t.Helper()
+	a, b := net.Pipe()
+	ssess, err := yamux.Server(b, yamux.DefaultConfig())
+	require.NoError(t, err)
+	go func() {
+		for {
+			st, e := ssess.Accept()
+			if e != nil {
+				return
+			}
+			go io.Copy(io.Discard, st) //nolint:errcheck
+		}
+	}()
+	csess, err := yamux.Client(a, yamux.DefaultConfig())
+	require.NoError(t, err)
+	return csess, func() {
+		_ = csess.Close() //nolint:errcheck
+		_ = ssess.Close() //nolint:errcheck
+		_ = a.Close()     //nolint:errcheck
+		_ = b.Close()     //nolint:errcheck
+	}
+}
+
+// pickSession returns the least-loaded LIVE tunnel and skips closed ones. Build a
+// Client with three real sessions of differing open-stream counts and verify the
+// selection, then that closing tunnels re-routes and finally yields nil.
+func TestPickSession_LeastLoadedAndSkipsClosed(t *testing.T) {
+	s0, c0 := newTestSession(t)
+	defer c0()
+	s1, c1 := newTestSession(t)
+	defer c1()
+	s2, c2 := newTestSession(t)
+	defer c2()
+
+	// s0=2 streams, s1=1, s2=0 → least-loaded is s2.
+	for i := 0; i < 2; i++ {
+		_, err := s0.Open()
+		require.NoError(t, err)
+	}
+	_, err := s1.Open()
+	require.NoError(t, err)
+
+	c := &Client{sessions: []*yamux.Session{s0, s1, s2}, closeC: make(chan struct{})}
+	require.Same(t, s2, c.pickSession(), "empty tunnel is least-loaded")
+
+	// Retire s2 → the next-least-loaded live tunnel (s1) is picked.
+	require.NoError(t, s2.Close())
+	require.Same(t, s1, c.pickSession(), "closed tunnel skipped, s1 next")
+
+	// Retire the rest → no live tunnel → nil (the route-down trigger).
+	require.NoError(t, s0.Close())
+	require.NoError(t, s1.Close())
+	require.Nil(t, c.pickSession(), "all tunnels closed → nil")
+	require.True(t, c.allSessionsClosed())
+	require.False(t, c.anySessionLive())
+}
+
+// A multi-session Client stripes accepted conns across its tunnels: repeatedly
+// selecting the least-loaded tunnel and opening a stream on it spreads N opens
+// evenly across N tunnels (the accept loop's per-conn behavior).
+func TestPickSession_StripesEvenlyAcrossTunnels(t *testing.T) {
+	const n = 3
+	sessions := make([]*yamux.Session, n)
+	for i := 0; i < n; i++ {
+		s, cleanup := newTestSession(t)
+		defer cleanup()
+		sessions[i] = s
+	}
+	c := &Client{sessions: sessions, closeC: make(chan struct{})}
+
+	// 9 conns over 3 tunnels via least-loaded selection → 3 each.
+	for i := 0; i < 3*n; i++ {
+		s := c.pickSession()
+		require.NotNil(t, s)
+		_, err := s.Open()
+		require.NoError(t, err)
+	}
+	for i, s := range sessions {
+		require.Equal(t, 3, s.NumStreams(), "tunnel %d should carry an even share", i)
+	}
+	require.Equal(t, 3*n, c.totalStreams(), "totalStreams sums across tunnels")
+}
+
+// AddTunnel / NewMultiClient grow the tunnel set; a single-conn NewMultiClient is
+// equivalent to NewClient (one tunnel).
+func TestNewMultiClient_And_AddTunnel(t *testing.T) {
+	mk := func(t *testing.T) (net.Conn, func()) {
+		t.Helper()
+		a, b := net.Pipe()
+		go func() {
+			sess, e := yamux.Server(b, yamux.DefaultConfig())
+			if e == nil {
+				for {
+					if _, ae := sess.Accept(); ae != nil {
+						return
+					}
+				}
+			}
+		}()
+		return a, func() { _ = a.Close(); _ = b.Close() } //nolint:errcheck
+	}
+
+	ca, closeA := mk(t)
+	defer closeA()
+	single, err := NewMultiClient([]net.Conn{ca}, nil)
+	require.NoError(t, err)
+	require.Len(t, single.snapshotSessions(), 1)
+	require.NoError(t, single.Close())
+
+	cb, closeB := mk(t)
+	defer closeB()
+	cc, closeC := mk(t)
+	defer closeC()
+	multi, err := NewMultiClient([]net.Conn{cb, cc}, nil)
+	require.NoError(t, err)
+	require.Len(t, multi.snapshotSessions(), 2)
+
+	cd, closeD := mk(t)
+	defer closeD()
+	require.NoError(t, multi.AddTunnel(cd))
+	require.Len(t, multi.snapshotSessions(), 3)
+	require.NoError(t, multi.Close())
+
+	// Zero conns is an error.
+	_, err = NewMultiClient(nil, nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Foundation for connection-striped bandwidth aggregation (docs/mux_aggregation_rfc.md step 2). The skysocks client now holds N independent yamux tunnels — each its own route group + noise + yamux — instead of one, and stripes each accepted browser connection onto the least-loaded live tunnel (min `NumStreams()`), so throughput sums across disjoint routes with zero cross-tunnel reorder.

N is configurable via a new `--tunnels` flag, default 1. With N==1 the path is byte-for-byte today's single-session behavior (same status note, same interstitial/reconnect semantics keyed on the one session dying), so this is safe to merge before the dial-side coordination exists. `NewClient` keeps its signature; `NewMultiClient`/`AddTunnel` add tunnels. Keepalive probes every tunnel and retires dead ones individually, tearing down the whole client only when all tunnels are closed.

The N dials currently have no transport/intermediate exclusion, so multiple tunnels may share the same first-hop transport (split, not sum). Disjoint-tunnel dial coordination (per-tunnel first-hop-transport exclusion) is the required follow-up — RFC step 3 — before aggregation is real; per-tunnel re-dial of a retired tunnel is deferred with it. A runtime warning and code comments flag this. Existing pkg/skysocks tests pass unchanged; added unit tests for the least-loaded selection, closed-tunnel skipping, and even striping.