### PR TITLE
feat(router): auto-diversify multi-tunnel dials over disjoint first-hop transports

### DIFF
--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -211,7 +211,7 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 	dialWithShape := func(port uint16) (net.Conn, error) {
 		addr := appnet.Addr{Net: netType, PubKey: remotePK, Port: routing.Port(port)}
 		if direct || routes >= 1 || minHops >= 1 || fwdMinHops >= 1 || revMinHops >= 1 || fwdMux >= 1 || revMux >= 1 {
-			return appCl.DialWithOptions(addr, routes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
+			return appCl.DialWithOptions(addr, routes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct, false)
 		}
 		return appCl.Dial(addr)
 	}

--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -203,7 +203,7 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 			close(ddone)
 		}
 
-		conn, err := dialServer(cycleCtx, appCl, pk, serverPort)
+		conn, err := dialServer(cycleCtx, appCl, pk, serverPort, false)
 		if err != nil {
 			// Stop the disconnected listener and wait for it to release :1080.
 			dcancel()
@@ -214,14 +214,12 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		// Dial the additional tunnels. Each is an independent route group +
 		// noise + yamux; the client stripes browser conns across them. A tunnel
 		// that fails to dial is skipped (degrade to fewer tunnels) rather than
-		// failing the whole cycle. IMPORTANT: dialServer has NO transport /
-		// intermediate exclusion yet, so these dials may land on the SAME path —
-		// same first-hop transport means they SPLIT one link, not sum it, so this
-		// is plumbing, not real aggregation. Per-tunnel first-hop-transport
-		// exclusion (disjoint-tunnel dial coordination) is the REQUIRED follow-up
-		// before aggregation is real — see docs/mux_aggregation_rfc.md step 3.
+		// failing the whole cycle. diversify=true asks the visor to leave over a
+		// DIFFERENT first-hop transport than the tunnels already dialed to this
+		// exit (disjoint-tunnel coordination), so their throughputs sum instead
+		// of splitting one link — see docs/mux_aggregation_rfc.md step 3.
 		for i := int64(1); i < tunnels; i++ {
-			extra, derr := dialServer(cycleCtx, appCl, pk, serverPort)
+			extra, derr := dialServer(cycleCtx, appCl, pk, serverPort, true)
 			if derr != nil {
 				log.WithError(derr).Warnf("tunnel %d/%d dial failed; continuing with %d tunnel(s)", i+1, tunnels, len(conns))
 				continue
@@ -234,7 +232,7 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		<-ddone
 		log.Infof("Connected to %v", pk)
 		if len(conns) > 1 {
-			log.Warnf("skysocks-client: %d tunnels dialed, but disjoint-path coordination is NOT implemented — tunnels may share the same first-hop transport (split, not sum: no real aggregation). Follow-up: per-tunnel transport/intermediate exclusion, docs/mux_aggregation_rfc.md step 3.", len(conns))
+			log.Infof("skysocks-client: %d tunnels dialed with visor-side disjoint-path coordination — each extra tunnel is steered off the first-hop transports the earlier ones claimed (docs/mux_aggregation_rfc.md step 3). Tunnels that could not find a disjoint transport fall back to a shared path.", len(conns))
 		}
 		client, err := skysocks.NewMultiClient(conns, appCl)
 		if err != nil {
@@ -320,15 +318,23 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 	}
 }
 
-func dialServer(ctx context.Context, appCl *app.Client, pk cipher.PubKey, port routing.Port) (net.Conn, error) {
+// dialServer dials one tunnel to the exit. diversify, set for tunnels 2..N of
+// a --tunnels aggregation, asks the visor to steer this tunnel off the
+// first-hop transports/intermediates the earlier tunnels to this same exit
+// already occupy — so the tunnels leave over DIFFERENT first-hop transports
+// and their throughputs sum instead of splitting one link
+// (docs/mux_aggregation_rfc.md step 3). The visor does all the transport-ID
+// bookkeeping; the app just signals intent. It is a no-op for the first tunnel
+// (no sibling route group to diverge from → dial is identical to today).
+func dialServer(ctx context.Context, appCl *app.Client, pk cipher.PubKey, port routing.Port, diversify bool) (net.Conn, error) {
 	//nolint:errcheck
 	appCl.SetDetailedStatus(appserver.AppDetailedStatusStarting) //nolint:errcheck,gosec
 	// dial one network to the server. On skynet, --direct forces a 1-hop
 	// direct-transport-only dial (create-on-demand, bypass the route-finder +
 	// setup node, self-heals on server restart); dmsg is a plain relay stream.
 	dial := func(_ context.Context, a appnet.Addr) (net.Conn, error) {
-		if a.Net == netType && direct {
-			return appCl.DialWithOptions(a, 0, 0, 0, 0, 0, 0, true)
+		if a.Net == netType && (direct || diversify) {
+			return appCl.DialWithOptions(a, 0, 0, 0, 0, 0, 0, direct, diversify)
 		}
 		return appCl.Dial(a)
 	}

--- a/pkg/app/appserver/mock_rpc_ingress_client.go
+++ b/pkg/app/appserver/mock_rpc_ingress_client.go
@@ -127,9 +127,9 @@ func (_m *MockRPCIngressClient) Dial(remote appnet.Addr) (uint16, routing.Port, 
 	return r0, r1, r2
 }
 
-// DialWithOptions provides a mock function with given fields: remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux
-func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int, minHops int, fwdMinHops int, revMinHops int, fwdMux int, revMux int, direct bool) (uint16, routing.Port, error) {
-	ret := _m.Called(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
+// DialWithOptions provides a mock function with given fields: remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct, diversify
+func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int, minHops int, fwdMinHops int, revMinHops int, fwdMux int, revMux int, direct bool, diversify bool) (uint16, routing.Port, error) {
+	ret := _m.Called(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct, diversify)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DialWithOptions")
@@ -138,23 +138,23 @@ func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes in
 	var r0 uint16
 	var r1 routing.Port
 	var r2 error
-	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int, int, int, bool) (uint16, routing.Port, error)); ok {
-		return rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
+	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int, int, int, bool, bool) (uint16, routing.Port, error)); ok {
+		return rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct, diversify)
 	}
-	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int, int, int, bool) uint16); ok {
-		r0 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
+	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int, int, int, bool, bool) uint16); ok {
+		r0 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct, diversify)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(appnet.Addr, int, int, int, int, int, int, bool) routing.Port); ok {
-		r1 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
+	if rf, ok := ret.Get(1).(func(appnet.Addr, int, int, int, int, int, int, bool, bool) routing.Port); ok {
+		r1 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct, diversify)
 	} else {
 		r1 = ret.Get(1).(routing.Port)
 	}
 
-	if rf, ok := ret.Get(2).(func(appnet.Addr, int, int, int, int, int, int, bool) error); ok {
-		r2 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
+	if rf, ok := ret.Get(2).(func(appnet.Addr, int, int, int, int, int, int, bool, bool) error); ok {
+		r2 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct, diversify)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/pkg/app/appserver/mocks_exercise_test.go
+++ b/pkg/app/appserver/mocks_exercise_test.go
@@ -100,7 +100,7 @@ func TestMockRPCIngressClient_AllMethods(t *testing.T) {
 	c.On("CloseConn", uint16(1)).Return(nil)
 	c.On("CloseListener", uint16(1)).Return(nil)
 	c.On("Dial", addr).Return(uint16(3), routing.Port(4), nil)
-	c.On("DialWithOptions", addr, 1, 0, 0, 0, 1, 1, false).Return(uint16(3), routing.Port(4), nil)
+	c.On("DialWithOptions", addr, 1, 0, 0, 0, 1, 1, false, false).Return(uint16(3), routing.Port(4), nil)
 	c.On("Listen", addr).Return(uint16(5), nil)
 	c.On("Read", uint16(1), buf).Return(4, nil)
 	c.On("SetAppPort", routing.Port(7)).Return(nil)
@@ -123,7 +123,7 @@ func TestMockRPCIngressClient_AllMethods(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint16(3), connID)
 
-	_, _, err = c.DialWithOptions(addr, 1, 0, 0, 0, 1, 1, false)
+	_, _, err = c.DialWithOptions(addr, 1, 0, 0, 0, 1, 1, false, false)
 	require.NoError(t, err)
 
 	id, err := c.Listen(addr)

--- a/pkg/app/appserver/rpc_ingress_client.go
+++ b/pkg/app/appserver/rpc_ingress_client.go
@@ -38,8 +38,10 @@ type RPCIngressClient interface {
 	//   - fwdMinHops / revMinHops (per-direction MinHops overrides)
 	//   - fwdMux / revMux (per-direction MuxRoutes overrides; setting
 	//     fwdMux=1 + revMux=N yields 1 forward leg + N reverse legs)
-	// All <= 1 is equivalent to plain Dial.
-	DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int, direct bool) (connID uint16, localPort routing.Port, err error)
+	//   - diversify (opt into visor-side multi-tunnel transport
+	//     diversification — tunnel 2..N of a skysocks aggregation)
+	// All <= 1 (and !direct, !diversify) is equivalent to plain Dial.
+	DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int, direct, diversify bool) (connID uint16, localPort routing.Port, err error)
 	Listen(local appnet.Addr) (uint16, error)
 	Accept(lisID uint16) (connID uint16, remote appnet.Addr, err error)
 	Write(connID uint16, b []byte) (int, error)
@@ -126,16 +128,17 @@ func (c *rpcIngressClient) Dial(remote appnet.Addr) (connID uint16, localPort ro
 // DialWithOptions sends `DialWithOptions` command to the server.
 // All fields <= 1 falls through to plain Dial semantics on the server
 // side (no extra round-trip cost beyond the slightly larger request).
-func (c *rpcIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int, direct bool) (connID uint16, localPort routing.Port, err error) {
+func (c *rpcIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int, direct, diversify bool) (connID uint16, localPort routing.Port, err error) {
 	req := DialOptionsReq{
-		Addr:             remote,
-		MuxRoutes:        muxRoutes,
-		MinHops:          minHops,
-		ForwardMinHops:   fwdMinHops,
-		ReverseMinHops:   revMinHops,
-		ForwardMuxRoutes: fwdMux,
-		ReverseMuxRoutes: revMux,
-		Direct:           direct,
+		Addr:                remote,
+		MuxRoutes:           muxRoutes,
+		MinHops:             minHops,
+		ForwardMinHops:      fwdMinHops,
+		ReverseMinHops:      revMinHops,
+		ForwardMuxRoutes:    fwdMux,
+		ReverseMuxRoutes:    revMux,
+		Direct:              direct,
+		DiversifyTransports: diversify,
 	}
 	var resp DialResp
 	if err := c.rpc.Call(c.formatMethod("DialWithOptions"), &req, &resp); err != nil {

--- a/pkg/app/appserver/rpc_ingress_client_test.go
+++ b/pkg/app/appserver/rpc_ingress_client_test.go
@@ -126,7 +126,7 @@ func TestRPCIngressClient_DialWithOptions(t *testing.T) {
 		// back to plain DialContext; the round-trip still succeeds and
 		// returns a valid ConnID. We're pinning the wire shape, not the
 		// router-level mux behavior (which is integration-tested).
-		connID, localPort, err := rpcC.DialWithOptions(remote, 4, 0, 0, 0, 0, 0, false)
+		connID, localPort, err := rpcC.DialWithOptions(remote, 4, 0, 0, 0, 0, 0, false, false)
 		require.NoError(t, err)
 		require.Equal(t, uint16(1), connID)
 		require.Equal(t, routing.Port(dmsgLocal.Port), localPort)
@@ -156,7 +156,7 @@ func TestRPCIngressClient_DialWithOptions(t *testing.T) {
 		// minHops=2 over a non-skynet networker — same fallthrough as
 		// the muxRoutes case. Pins that MinHops is wire-carried through
 		// DialOptionsReq even when the destination family ignores it.
-		connID, localPort, err := rpcC.DialWithOptions(remote, 0, 2, 0, 0, 0, 0, false)
+		connID, localPort, err := rpcC.DialWithOptions(remote, 0, 2, 0, 0, 0, 0, false, false)
 		require.NoError(t, err)
 		require.Equal(t, uint16(1), connID)
 		require.Equal(t, routing.Port(dmsgLocal.Port), localPort)

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -231,6 +231,15 @@ type DialOptionsReq struct {
 	// 1-hop over it, bypassing the route-finder. The `--direct` skynet flag
 	// sets this. In spirit mutually exclusive with MinHops >= 2.
 	Direct bool
+	// DiversifyTransports opts this dial into visor-side auto-diversification
+	// for multi-tunnel bandwidth aggregation (docs/mux_aggregation_rfc.md
+	// step 3). Set by the skysocks-client for its extra tunnels (2..N): the
+	// router excludes the first-hop transports/intermediates already claimed by
+	// this visor's live route groups to the same dst, so each tunnel leaves
+	// over a different first-hop transport and their throughputs sum. Bounded
+	// visor-side to the case where a sibling route group already exists, so a
+	// lone dial is byte-identical to today. See router.DialOptions.
+	DiversifyTransports bool
 }
 
 // Dial dials to the remote.
@@ -326,7 +335,7 @@ func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, req *DialOptions
 	// direct route out from under a visor-global min_hops/mux_routes>1 (which
 	// otherwise forces every skynet app dial into multi-hop mux — wrong for a
 	// 1:1 forward). Zero still means "inherit the visor-global default".
-	if req == nil || (!req.Direct && req.MuxRoutes == 0 && req.MinHops == 0 &&
+	if req == nil || (!req.Direct && !req.DiversifyTransports && req.MuxRoutes == 0 && req.MinHops == 0 &&
 		req.ForwardMinHops == 0 && req.ReverseMinHops == 0 &&
 		req.ForwardMuxRoutes == 0 && req.ReverseMuxRoutes == 0) {
 		return appnet.DialContext(ctx, remote)
@@ -348,6 +357,7 @@ func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, req *DialOptions
 	opts.ReverseMinHops = req.ReverseMinHops
 	opts.ForwardMuxRoutes = req.ForwardMuxRoutes
 	opts.ReverseMuxRoutes = req.ReverseMuxRoutes
+	opts.DiversifyTransports = req.DiversifyTransports
 	if req.Direct {
 		// Force a 1-hop direct dial that creates the transport on demand and
 		// bypasses the route-finder. Mirrors the policy-layer Fallback="direct"

--- a/pkg/app/client.go
+++ b/pkg/app/client.go
@@ -203,7 +203,7 @@ func (c *Client) SetAppPortOrLog(port routing.Port) {
 
 // Dial dials the remote visor using `remote`.
 func (c *Client) Dial(remote appnet.Addr) (net.Conn, error) {
-	return c.dial(remote, 0, 0, 0, 0, 0, 0, false)
+	return c.dial(remote, 0, 0, 0, 0, 0, 0, false, false)
 }
 
 // DialWithOptions dials remote with per-call dial options.
@@ -230,8 +230,15 @@ func (c *Client) Dial(remote appnet.Addr) (net.Conn, error) {
 //   - direct: when true, forces a direct-transport-only dial — the router
 //     creates a direct transport to the remote if none exists and dials
 //     1-hop over it, bypassing the route-finder (the `--direct` skynet flag).
-func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int, direct bool) (net.Conn, error) {
-	return c.dial(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
+//   - diversify: when true, opts this dial into visor-side multi-tunnel
+//     transport diversification (docs/mux_aggregation_rfc.md step 3). The
+//     visor excludes the first-hop transports/intermediates already claimed
+//     by this visor's live route groups to the same dst, so a new tunnel to
+//     an exit leaves over a DIFFERENT first-hop transport and the tunnels'
+//     throughputs sum. Set by skysocks-client for tunnel 2..N; harmless on a
+//     lone dial (no sibling route group → no exclusions → identical to Dial).
+func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int, direct, diversify bool) (net.Conn, error) {
+	return c.dial(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct, diversify)
 }
 
 // dial is the common body for Dial + DialWithOptions. When all opts
@@ -239,14 +246,14 @@ func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinH
 // existing wire shape for non-mux callers); otherwise sends the
 // DialWithOptions request so the server-side knows to take the
 // SkywireNetworker per-call-opts path.
-func (c *Client) dial(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int, direct bool) (net.Conn, error) {
+func (c *Client) dial(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int, direct, diversify bool) (net.Conn, error) {
 	var (
 		connID    uint16
 		localPort routing.Port
 		err       error
 	)
-	if direct || muxRoutes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 || fwdMux > 1 || revMux > 1 {
-		connID, localPort, err = c.rpcC.DialWithOptions(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
+	if direct || diversify || muxRoutes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 || fwdMux > 1 || revMux > 1 {
+		connID, localPort, err = c.rpcC.DialWithOptions(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct, diversify)
 	} else {
 		connID, localPort, err = c.rpcC.Dial(remote)
 	}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -318,6 +318,26 @@ type DialOptions struct {
 	// they have constraints to express.
 	ExcludeIntermediatePKs []cipher.PubKey
 	ExcludeDMSG            bool // Exclude DMSG transports (for mux — DMSG is a relay, not suitable for multiplexing)
+	// DiversifyTransports opts this dial into visor-side auto-
+	// diversification for bandwidth aggregation (docs/mux_aggregation_rfc.md
+	// step 3). When set, DialRoutes looks up THIS visor's currently-live
+	// route groups to the SAME destination PK:port and seeds
+	// ExcludeTransportIDs / ExcludeIntermediatePKs with their first-hop
+	// transports + intermediates, so a new tunnel to an exit leaves over a
+	// DIFFERENT first-hop transport than the tunnels already established to
+	// it — their throughputs then SUM instead of splitting one link.
+	//
+	// It is bounded and safe by construction: the exclusions are added ONLY
+	// when >= 1 sibling route group to the exact same dst already exists (the
+	// skysocks multi-tunnel "tunnel 2..N" case). A lone dial (tunnel 1, or
+	// any app that dials a dst once) finds no sibling and is byte-identical
+	// to today. It reuses the mux's own disjoint machinery, but across route
+	// groups rather than across legs within one group. Set by the
+	// skysocks-client for its extra tunnels; unset everywhere else, so
+	// single-dials, control-plane forwards and same-LAN/direct dials are
+	// untouched. Falls back gracefully — if no disjoint transport is free the
+	// dial proceeds on a shared path (a shared tunnel beats no tunnel).
+	DiversifyTransports bool
 	// Distribution overrides the route group's per-packet
 	// distribution strategy when set (Mode != DistributionUnset).
 	// Populated either by a routing-policy script (see

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -104,6 +104,28 @@ func (r *router) DialRoutes(
 	lPK := r.conf.PubKey
 	forwardDesc := routing.NewRouteDescriptor(lPK, rPK, lPort, rPort)
 
+	// Multi-tunnel bandwidth aggregation (docs/mux_aggregation_rfc.md step 3).
+	// When the caller opts in (skysocks-client's extra tunnels), diverge this
+	// tunnel from the ones already established to the SAME exit: exclude the
+	// first-hop transports + intermediates that this visor's live route groups
+	// to (rPK, rPort) already occupy, so the new tunnel leaves over a different
+	// first-hop transport and the two tunnels' throughputs SUM. Bounded to
+	// tunnel 2..N — the exclusions are added ONLY when a sibling route group to
+	// this dst already exists (count > 0), so a first/lone dial is untouched.
+	// Additive to any excludes the caller already set (e.g. the mux's own);
+	// the route-finder / local calc treat these as soft preferences and fall
+	// back to a shared path when no disjoint transport is free.
+	if opts.DiversifyTransports {
+		if exIDs, exPKs, count := r.siblingRouteGroupExclusions(lPK, rPK, rPort); count > 0 {
+			opts.ExcludeTransportIDs = append(opts.ExcludeTransportIDs, exIDs...)
+			opts.ExcludeIntermediatePKs = append(opts.ExcludeIntermediatePKs, exPKs...)
+			log.WithField("sibling_tunnels", count).
+				WithField("exclude_tps", len(exIDs)).
+				WithField("exclude_intermediates", len(exPKs)).
+				Debug("Diversifying multi-tunnel dial over disjoint first-hop transports.")
+		}
+	}
+
 	// check if transport exist, then skip minhop value and consider it equal 0.
 	// Per-call opts.MinHops > 1 suppresses this downgrade: the caller has
 	// explicitly demanded a multi-hop path, and silently routing through the
@@ -2754,6 +2776,53 @@ func intermediatesOfRouteGroup(nrg *NoiseRouteGroup, src, dst cipher.PubKey) []c
 		}
 	}
 	return out
+}
+
+// siblingRouteGroupExclusions scans this visor's live route groups for
+// ones that already terminate at the same destination (rPK:rPort) as an
+// about-to-be-dialed tunnel, and returns the first-hop transport IDs and
+// intermediate PKs they occupy. Feeding these into a new dial's
+// ExcludeTransportIDs / ExcludeIntermediatePKs makes the new tunnel leave
+// the source over a DIFFERENT first-hop transport / disjoint intermediate —
+// so N tunnels to one exit aggregate bandwidth instead of splitting a single
+// link (docs/mux_aggregation_rfc.md step 3).
+//
+// rgsNs is keyed by the RECEIVE-side descriptor (Src = remote peer, Dst =
+// this visor), so a sibling group to (rPK, rPort) matches on SrcPK()==rPK &&
+// SrcPort()==rPort; the differing DstPort() is each tunnel's own ephemeral
+// local port. count is the number of matching sibling groups — 0 means this
+// is the first tunnel to that dst and the caller must add NO exclusions
+// (byte-identical to a normal single dial).
+//
+// Locking: the matching *NoiseRouteGroup values are snapshotted under r.mx,
+// then their transports are read WITHOUT r.mx held (each via the group's own
+// rg.mu), so we never hold r.mx while taking a route-group lock.
+func (r *router) siblingRouteGroupExclusions(lPK, rPK cipher.PubKey, rPort routing.Port) (ids []uuid.UUID, pks []cipher.PubKey, count int) {
+	r.mx.Lock()
+	var siblings []*NoiseRouteGroup
+	for desc, nrg := range r.rgsNs {
+		if nrg == nil {
+			continue
+		}
+		if desc.SrcPK() == rPK && desc.SrcPort() == rPort {
+			siblings = append(siblings, nrg)
+		}
+	}
+	r.mx.Unlock()
+
+	count = len(siblings)
+	for _, nrg := range siblings {
+		nrg.rg.mu.Lock()
+		for _, tp := range nrg.rg.tps {
+			if tp == nil {
+				continue
+			}
+			ids = append(ids, tp.Entry.ID)
+		}
+		nrg.rg.mu.Unlock()
+		pks = append(pks, intermediatesOfRouteGroup(nrg, lPK, rPK)...)
+	}
+	return ids, pks, count
 }
 
 // extractFailedIntermediatePK walks an error chain looking for a

--- a/pkg/router/sibling_exclusions_test.go
+++ b/pkg/router/sibling_exclusions_test.go
@@ -1,0 +1,106 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// seedSiblingRG registers a live NoiseRouteGroup from this visor (lPK) to a
+// remote exit (rPK:rPort) that leaves over first-hop transport tpID toward
+// intermediate midPK. rgsNs is keyed by the RECEIVE-side descriptor, so
+// Src = remote peer / Dst = this visor — mirroring how DialRoutes' siblings
+// are actually stored (router_mux_ops.go treats desc.SrcPK() as the peer).
+func seedSiblingRG(t *testing.T, r *router, lPK, rPK, midPK cipher.PubKey, rPort, lPort routing.Port, tpID uuid.UUID) {
+	t.Helper()
+	desc := routing.NewRouteDescriptor(rPK, lPK, rPort, lPort)
+	rg := NewRouteGroup(DefaultRouteGroupConfig(), r.rt, desc, logging.NewMasterLogger())
+
+	mt := transport.NewManagedTransportForTest(nil)
+	mt.Entry = transport.Entry{
+		ID:    tpID,
+		Type:  "test",
+		Edges: [2]cipher.PubKey{lPK, midPK},
+	}
+	rg.mu.Lock()
+	rg.tps = []*transport.ManagedTransport{mt}
+	rg.mu.Unlock()
+
+	r.rgsNs[desc] = &NoiseRouteGroup{rg: rg, Conn: rg}
+}
+
+func newExclusionTestRouter(t *testing.T, lPK cipher.PubKey) *router {
+	t.Helper()
+	l := logging.NewMasterLogger()
+	return &router{
+		logger: l.PackageLogger("router-diversify-test"),
+		conf:   &Config{PubKey: lPK},
+		rt:     routing.NewTable(l.PackageLogger("rt")),
+		rgsNs:  make(map[routing.RouteDescriptor]*NoiseRouteGroup),
+		rgsRaw: make(map[routing.RouteDescriptor]*RouteGroup),
+	}
+}
+
+// TestSiblingRouteGroupExclusions_DiversifiesSecondTunnel proves the core of
+// disjoint-tunnel dial coordination (docs/mux_aggregation_rfc.md step 3): a
+// second dial to the SAME exit collects the first tunnel's first-hop transport
+// + intermediate, so the router excludes them and the tunnels land on
+// different first-hop transports (their throughputs then sum, not split).
+func TestSiblingRouteGroupExclusions_DiversifiesSecondTunnel(t *testing.T) {
+	lPK, _ := cipher.GenerateKeyPair()
+	rPK, _ := cipher.GenerateKeyPair()
+	midPK, _ := cipher.GenerateKeyPair()
+	const rPort = routing.Port(3)
+
+	r := newExclusionTestRouter(t, lPK)
+
+	// Tunnel 1 is already live to the exit over transport tp1 via midPK.
+	tp1 := uuid.New()
+	seedSiblingRG(t, r, lPK, rPK, midPK, rPort, routing.Port(1001), tp1)
+
+	// Tunnel 2 dialing the same exit must see tunnel 1 as a sibling and be
+	// handed its transport + intermediate to exclude.
+	ids, pks, count := r.siblingRouteGroupExclusions(lPK, rPK, rPort)
+	require.Equal(t, 1, count, "tunnel 2 must see exactly one live sibling to the exit")
+	require.Equal(t, []uuid.UUID{tp1}, ids, "tunnel 2 must exclude tunnel 1's first-hop transport")
+	require.Equal(t, []cipher.PubKey{midPK}, pks, "tunnel 2 must exclude tunnel 1's intermediate")
+}
+
+// TestSiblingRouteGroupExclusions_LoneDialUntouched proves the bounding: the
+// first tunnel to a dst (or any app that dials it once) finds no sibling, so
+// no exclusions are added and the dial is byte-identical to today.
+func TestSiblingRouteGroupExclusions_LoneDialUntouched(t *testing.T) {
+	lPK, _ := cipher.GenerateKeyPair()
+	rPK, _ := cipher.GenerateKeyPair()
+	otherPK, _ := cipher.GenerateKeyPair()
+	midPK, _ := cipher.GenerateKeyPair()
+	const rPort = routing.Port(3)
+
+	r := newExclusionTestRouter(t, lPK)
+
+	// No route group to (rPK, rPort) at all → lone dial, no exclusions.
+	ids, pks, count := r.siblingRouteGroupExclusions(lPK, rPK, rPort)
+	require.Zero(t, count)
+	require.Empty(t, ids)
+	require.Empty(t, pks)
+
+	// A live route group to a DIFFERENT exit (otherPK) must not be treated as
+	// a sibling — diversification is scoped to the exact destination.
+	seedSiblingRG(t, r, lPK, otherPK, midPK, rPort, routing.Port(1001), uuid.New())
+	ids, pks, count = r.siblingRouteGroupExclusions(lPK, rPK, rPort)
+	require.Zero(t, count, "a route group to another exit is not a sibling")
+	require.Empty(t, ids)
+	require.Empty(t, pks)
+
+	// A route group to the right exit PK but a DIFFERENT port is not a sibling
+	// either.
+	seedSiblingRG(t, r, lPK, rPK, midPK, routing.Port(9), routing.Port(1002), uuid.New())
+	_, _, count = r.siblingRouteGroupExclusions(lPK, rPK, rPort)
+	require.Zero(t, count, "a route group to a different port on the exit is not a sibling")
+}

--- a/pkg/vpn/client.go
+++ b/pkg/vpn/client.go
@@ -729,7 +729,7 @@ func (c *Client) dialServer(appCl *app.Client, pk cipher.PubKey) (net.Conn, erro
 	// (mux/min-hops) when set; dmsg is a plain relay stream with no such options.
 	dial := func(_ context.Context, a appnet.Addr) (net.Conn, error) {
 		if a.Net == netType && (c.cfg.MuxRoutes > 1 || c.cfg.MinHops >= 2) {
-			return appCl.DialWithOptions(a, c.cfg.MuxRoutes, c.cfg.MinHops, 0, 0, 0, 0, false)
+			return appCl.DialWithOptions(a, c.cfg.MuxRoutes, c.cfg.MinHops, 0, 0, 0, 0, false, false)
 		}
 		return appCl.Dial(a)
 	}


### PR DESCRIPTION
Follow-up to #4213 (skysocks multi-session client), implementing step 3 of docs/mux_aggregation_rfc.md.

#4213 gave the skysocks client N yamux tunnels, but the N dials shared no route diversity, so every tunnel could land on the same first-hop transport and merely split one link instead of summing N. This adds visor-side auto-diversification: when a dial opts in (`DialOptions.DiversifyTransports`), `DialRoutes` looks up this visor's live route groups to the same destination PK:port and seeds `ExcludeTransportIDs` / `ExcludeIntermediatePKs` with the first-hop transports and intermediates they already occupy, so each new tunnel leaves over a different first-hop transport — reusing the mux's own disjoint machinery, but across route groups rather than across legs within one group.

It is opt-in and bounded: only skysocks-client's extra tunnels (2..N) set the flag, and exclusions are added only when a sibling route group to the exact dst already exists, so a lone dial (tunnel 1, or any single-dial app) finds no sibling and is byte-identical to today; control-plane, same-LAN/direct and dmsg dials never reach this path. If no disjoint transport is free the dial falls back to a shared path. This makes #4213's tunnels actually aggregate bandwidth instead of selecting one path.

Verified: whole-binary build, `go test ./pkg/router/ ./pkg/app/... ./pkg/skysocks/`, go vet, and golangci-lint on touched packages all pass. New unit tests in `pkg/router/sibling_exclusions_test.go` prove a second dial to the same exit excludes the first tunnel's first-hop transport + intermediate, and that a lone dial / a dial to a different exit or port adds no exclusions.