### PR TITLE
feat(skysocks): re-dial dead multi-tunnels + reliable sequential diversification

### DIFF
--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -218,6 +218,22 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		// DIFFERENT first-hop transport than the tunnels already dialed to this
 		// exit (disjoint-tunnel coordination), so their throughputs sum instead
 		// of splitting one link — see docs/mux_aggregation_rfc.md step 3.
+		//
+		// The loop is SEQUENTIAL by design, and that is what makes the
+		// diversification reliable: the visor's sibling-exclusion scan
+		// (router.siblingRouteGroupExclusions, #4214) diverts tunnel i+1 off the
+		// first-hop transports tunnel i already holds ONLY if tunnel i's route
+		// group is already visible in the visor's live set (rgsNs). It is: the
+		// visor registers the primary route group — with its first-hop transport
+		// in rg.tps — into rgsNs SYNCHRONOUSLY inside saveRouteGroupRules, before
+		// DialRoutes (and thus this RPC dial) returns. #4209 defers only the
+		// AUXILIARY mux legs asynchronously, and skysocks tunnels request no mux
+		// (muxRoutes=0), so each tunnel is single-leg with nothing left to
+		// register late. Because each dialServer call below returns only after its
+		// tunnel is registered, tunnel i is always seen by tunnel i+1's exclusion
+		// scan — no inter-dial delay or route-group poll is needed. (The exclusion
+		// is a soft preference: if fewer than N disjoint transports exist, tunnels
+		// fall back to a shared path.)
 		for i := int64(1); i < tunnels; i++ {
 			extra, derr := dialServer(cycleCtx, appCl, pk, serverPort, true)
 			if derr != nil {
@@ -237,6 +253,26 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		client, err := skysocks.NewMultiClient(conns, appCl)
 		if err != nil {
 			return fmt.Errorf("new client: %w", err)
+		}
+		// Keep N healthy tunnels: when one dies, the client re-dials a fresh
+		// disjoint replacement (docs/mux_aggregation_rfc.md steps 3-4). The dial
+		// lives here (it needs the server PK + retrier + appnet fallback), so we
+		// hand the Client the SAME diversify=true dial the extra tunnels used;
+		// the visor steers the replacement off the survivors' first-hop transports
+		// (#4214). Target the requested --tunnels so a re-dial also refills the
+		// width when some initial dials fell short. Only wire re-dial for N>1: at
+		// N==1 the client never re-dials (its lone tunnel's death is total
+		// collapse, handled by the --reconnect loop above), keeping the default
+		// path byte-identical. The Client bounds re-dial to one in-flight attempt
+		// and backs off on repeated failure, so this cannot fight the outer
+		// runCycle: it only replaces individual dead tunnels while the client is
+		// otherwise alive; if EVERY tunnel dies, ListenAndServe returns and the
+		// runCycle re-dials the whole client.
+		client.SetTunnelTarget(int(tunnels))
+		if tunnels > 1 {
+			client.SetTunnelRedial(func() (net.Conn, error) {
+				return dialServer(cycleCtx, appCl, pk, serverPort, true)
+			})
 		}
 		// Close the client when the outer ctx fires so
 		// ListenAndServe returns. With --reconnect the loop

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	ipc "github.com/james-barrow/golang-ipc"
@@ -48,8 +49,10 @@ const muxStreamWindowBytes = 16 * 1024 * 1024
 // aggregation design in docs/mux_aggregation_rfc.md. N is configurable; the
 // default is a single tunnel (N==1), which is byte-for-byte the pre-aggregation
 // behavior. Multiple tunnels only genuinely aggregate once they leave over
-// disjoint first-hop transports; that disjoint-dial coordination is the required
-// follow-up (RFC step 3) and is NOT implemented here.
+// disjoint first-hop transports; the visor steers the extra tunnels onto disjoint
+// first-hop transports (#4214), and this Client keeps N of them healthy — a dead
+// tunnel is re-dialed as a fresh disjoint replacement (maybeRedial, RFC steps
+// 3-4). Throughput-based eviction of a slow-but-alive tunnel is a follow-up.
 type Client struct {
 	appCl *app.Client
 	// sessions holds the live tunnels (>=1). Guarded by sessionsMu because
@@ -66,6 +69,23 @@ type Client struct {
 	// tracked here; only the cheap identity/target/age the sniff already parses.
 	streamsMu sync.Mutex
 	streams   map[uint32]streamMeta
+
+	// Multi-tunnel liveness management (docs/mux_aggregation_rfc.md steps 3-4).
+	// target is the desired number of live tunnels (N from --tunnels). When a
+	// tunnel dies and the live count falls below target — but at least one tunnel
+	// survives — the keepalive loop re-dials a fresh DISJOINT replacement via the
+	// redial callback, so aggregation width is restored instead of bleeding down.
+	// redial dials one diversify=true tunnel; it is wired FROM the app
+	// (cmd/apps/skysocks-client) because the dial lives there, not in this package
+	// (SetTunnelRedial). redialInFlight bounds it to a single in-flight re-dial;
+	// redialFails backs off after consecutive failures so a persistently
+	// unreachable exit is not hammered. All three are guarded by redialMu except
+	// redialInFlight, which is its own atomic single-flight guard.
+	redialMu       sync.Mutex
+	target         int
+	redial         func() (net.Conn, error)
+	redialFails    int
+	redialInFlight atomic.Bool
 }
 
 // streamMeta is the per-stream detail the status page surfaces for an open
@@ -103,6 +123,12 @@ func NewClient(conn net.Conn, appCl *app.Client) (*Client, error) {
 		appCl:   appCl,
 		closeC:  make(chan struct{}),
 		streams: make(map[uint32]streamMeta),
+		// One tunnel is the default target: with N==1 the sole tunnel's death is
+		// total collapse (handled by the app's --reconnect), so N==1 never
+		// re-dials — byte-identical to the pre-aggregation build. NewMultiClient
+		// raises this to the conn count, and the app sets --tunnels via
+		// SetTunnelTarget so a re-dial can refill even after a short initial dial.
+		target: 1,
 	}
 
 	session, err := newYamuxSession(conn)
@@ -134,6 +160,10 @@ func NewMultiClient(conns []net.Conn, appCl *app.Client) (*Client, error) {
 			return nil, err
 		}
 	}
+	// Target the number of tunnels we actually built. The app overrides this
+	// with the requested --tunnels via SetTunnelTarget so a re-dial refills to
+	// the full width even when some initial dials fell short.
+	c.SetTunnelTarget(len(conns))
 	return c, nil
 }
 
@@ -150,6 +180,139 @@ func (c *Client) AddTunnel(conn net.Conn) error {
 	c.sessions = append(c.sessions, session)
 	c.sessionsMu.Unlock()
 	return nil
+}
+
+// SetTunnelTarget sets the desired number of live tunnels N. When a tunnel dies
+// and the live count falls below N (but at least one tunnel survives), the
+// keepalive loop re-dials a replacement via the SetTunnelRedial callback. The app
+// sets this to --tunnels so a re-dial restores the full aggregation width even if
+// some initial dials fell short. Values < 1 are clamped to 1 — a single tunnel
+// never re-dials (its death is total collapse, owned by the app's --reconnect).
+func (c *Client) SetTunnelTarget(n int) {
+	if n < 1 {
+		n = 1
+	}
+	c.redialMu.Lock()
+	c.target = n
+	c.redialMu.Unlock()
+}
+
+// SetTunnelRedial wires the app's disjoint-diversify dial into the Client so the
+// keepalive loop can re-dial a dead tunnel's replacement. The dial itself lives in
+// the app (cmd/apps/skysocks-client) — it needs the server PK, the retrier and the
+// appnet fallback machinery the Client has no handle on — so the app closes over
+// its dialServer(...,diversify=true) call and hands it here. fn must return a fresh
+// dialed route-group conn (the same kind NewMultiClient wraps); the loop wraps it
+// in a yamux session via AddTunnel. A nil fn (the default, and the single-tunnel
+// case) disables re-dial entirely.
+func (c *Client) SetTunnelRedial(fn func() (net.Conn, error)) {
+	c.redialMu.Lock()
+	c.redial = fn
+	c.redialMu.Unlock()
+}
+
+// liveSessionCount returns the number of tunnels still up.
+func (c *Client) liveSessionCount() int {
+	n := 0
+	for _, s := range c.snapshotSessions() {
+		if s != nil && !s.IsClosed() {
+			n++
+		}
+	}
+	return n
+}
+
+// resetRedialBackoff clears the consecutive-failure counter so re-dial is armed
+// again. Called when a FRESH tunnel death is observed (the live count dropped), so
+// an exit that had gone quiet is retried once it loses another tunnel rather than
+// staying permanently backed off.
+func (c *Client) resetRedialBackoff() {
+	c.redialMu.Lock()
+	c.redialFails = 0
+	c.redialMu.Unlock()
+}
+
+// maxRedialFails bounds consecutive failed re-dials before the keepalive loop
+// stops re-trying until the NEXT tunnel death re-arms it (resetRedialBackoff).
+// Without this a persistently-unreachable exit would spin a re-dial on every
+// liveness tick forever.
+const maxRedialFails = 3
+
+// maybeRedial re-dials ONE replacement tunnel when the live count (passed in, to
+// avoid re-snapshotting) has fallen below the target N — restoring aggregation
+// width after a tunnel dies. It is a no-op unless a re-dial callback is wired
+// (SetTunnelRedial) and:
+//
+//   - never re-dials once EVERY tunnel is closed (live <= 0): that is total
+//     collapse, which the app's outer --reconnect runCycle owns — re-dialing here
+//     would duplicate it and fight the whole-client rebuild. With a single tunnel
+//     (N==1) its death is the only death, so N==1 never re-dials: byte-identical
+//     to the pre-aggregation build.
+//   - bounds itself to a SINGLE in-flight re-dial (redialInFlight, an atomic CAS
+//     mirroring the router's healInFlight guard) so a burst of deaths cannot fan
+//     out a storm of concurrent dials.
+//   - backs off after maxRedialFails consecutive failures until the next death.
+//
+// The replacement uses the SAME diversify=true dial as the initial extra tunnels
+// (the callback closes over dialServer), so it steers onto a first-hop transport
+// the survivors don't already occupy (#4214). AddTunnel appends it under the
+// sessions mutex; the shared keepalive loop and pickSession then pick it up.
+//
+// Throughput-based eviction (retiring a slow-but-ALIVE tunnel to cycle in a
+// faster disjoint one — the "drop the underperforming" half of RFC step 4) is a
+// deliberate follow-up: it needs the gigabit validation rig to tune the
+// slow-leg threshold, and mis-tuned it would thrash healthy tunnels. This method
+// is liveness-only: a DEAD tunnel is replaced; a live one is left alone.
+func (c *Client) maybeRedial(live int) {
+	c.redialMu.Lock()
+	fn := c.redial
+	target := c.target
+	if target < 1 {
+		target = 1
+	}
+	backedOff := c.redialFails >= maxRedialFails
+	c.redialMu.Unlock()
+
+	if fn == nil || backedOff || live >= target || live <= 0 {
+		return
+	}
+	if !c.redialInFlight.CompareAndSwap(false, true) {
+		return // a re-dial is already running
+	}
+	go func() {
+		defer c.redialInFlight.Store(false)
+		conn, err := fn()
+		if err != nil {
+			c.redialMu.Lock()
+			c.redialFails++
+			fails := c.redialFails
+			c.redialMu.Unlock()
+			if c.appCl != nil {
+				if fails >= maxRedialFails {
+					c.appCl.Log().Warnf("Tunnel re-dial failed (%d/%d consecutive); backing off until the next tunnel death: %v", fails, maxRedialFails, err)
+				} else {
+					c.appCl.Log().Warnf("Tunnel re-dial failed (%d/%d); retrying next tick: %v", fails, maxRedialFails, err)
+				}
+			}
+			return
+		}
+		if aerr := c.AddTunnel(conn); aerr != nil {
+			_ = conn.Close() //nolint:errcheck,gosec
+			c.redialMu.Lock()
+			c.redialFails++
+			c.redialMu.Unlock()
+			if c.appCl != nil {
+				c.appCl.Log().Warnf("Tunnel re-dial connected but wrapping it failed: %v", aerr)
+			}
+			return
+		}
+		c.redialMu.Lock()
+		c.redialFails = 0
+		c.redialMu.Unlock()
+		if c.appCl != nil {
+			c.appCl.Log().Infof("Re-dialed a replacement tunnel; %d live tunnel(s) toward target %d", c.liveSessionCount(), target)
+		}
+	}()
 }
 
 // snapshotSessions returns a copy of the current tunnel set for lock-free
@@ -353,13 +516,19 @@ const (
 // stops routing to it (dropping just that tunnel's streams); the whole client is
 // torn down for reconnect only once EVERY tunnel is closed. With a single tunnel
 // (N==1) this is exactly the prior behavior: the one tunnel dying closes the
-// client. Per-tunnel re-dial of a dropped tunnel (instead of only skipping it) is
-// the disjoint-dial follow-up — see docs/mux_aggregation_rfc.md step 3.
+// client.
+//
+// After retiring the dead ones, when the live count has fallen below the target N
+// (but at least one tunnel survives) it re-dials a fresh DISJOINT replacement via
+// maybeRedial — the "cycle in a fresh disjoint tunnel" half of the aggregation
+// convergence (docs/mux_aggregation_rfc.md steps 3-4). A single tunnel never
+// re-dials: its death is total collapse, owned by the app's --reconnect.
 func (c *Client) sessionKeepAliveLoop() {
 	ticker := time.NewTicker(livenessProbeInterval)
 	defer ticker.Stop()
 
 	fails := make(map[*yamux.Session]int)
+	prevLive := -1
 	for {
 		select {
 		case <-c.closeC:
@@ -391,6 +560,15 @@ func (c *Client) sessionKeepAliveLoop() {
 
 				return
 			}
+			// A FRESH death (live count dropped since the last tick) re-arms the
+			// re-dial backoff, so an exit that had gone quiet is retried once it
+			// loses another tunnel instead of staying permanently backed off.
+			live := c.liveSessionCount()
+			if prevLive >= 0 && live < prevLive {
+				c.resetRedialBackoff()
+			}
+			prevLive = live
+			c.maybeRedial(live)
 		}
 	}
 }

--- a/pkg/skysocks/client_redial_test.go
+++ b/pkg/skysocks/client_redial_test.go
@@ -1,0 +1,159 @@
+// Package skysocks multi-tunnel re-dial (health-management) tests.
+package skysocks
+
+import (
+	"errors"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
+)
+
+// newRedialConn returns a fresh net.Conn whose peer runs a yamux server draining
+// accepted streams, so AddTunnel wraps it into a live (non-closed) session. The
+// cleanup tears both ends down. This is what a re-dial callback hands back.
+func newRedialConn(t *testing.T) (net.Conn, func()) {
+	t.Helper()
+	a, b := net.Pipe()
+	go func() {
+		ssess, e := yamux.Server(b, yamux.DefaultConfig())
+		if e != nil {
+			return
+		}
+		for {
+			st, ae := ssess.Accept()
+			if ae != nil {
+				return
+			}
+			go io.Copy(io.Discard, st) //nolint:errcheck
+		}
+	}()
+	return a, func() { _ = a.Close(); _ = b.Close() } //nolint:errcheck
+}
+
+// A Client at target N with one dead tunnel re-dials exactly one replacement,
+// restoring the live count to N, and the in-flight guard prevents a second
+// concurrent re-dial while the first is running.
+func TestMaybeRedial_ReplacesDeadTunnelOnce(t *testing.T) {
+	live, cleanupLive := newTestSession(t)
+	defer cleanupLive()
+	dead, cleanupDead := newTestSession(t)
+	defer cleanupDead()
+	require.NoError(t, dead.Close()) // one tunnel is dead → live count 1 < target 2
+
+	c := &Client{
+		sessions: []*yamux.Session{live, dead},
+		closeC:   make(chan struct{}),
+		target:   2,
+	}
+
+	// The re-dial callback blocks until released, so we can observe the
+	// single-flight guard: a second maybeRedial while the first is in flight must
+	// NOT invoke the callback again.
+	var calls int32
+	release := make(chan struct{})
+	var replacement net.Conn
+	var cleanupReplacement func()
+	c.SetTunnelRedial(func() (net.Conn, error) {
+		atomic.AddInt32(&calls, 1)
+		<-release
+		replacement, cleanupReplacement = newRedialConn(t)
+		return replacement, nil
+	})
+
+	// First trigger: live=1 < target=2 → one re-dial starts and blocks in fn.
+	c.maybeRedial(1)
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&calls) == 1 },
+		time.Second, 5*time.Millisecond, "the dead tunnel triggers one re-dial")
+	require.True(t, c.redialInFlight.Load(), "a re-dial is in flight")
+
+	// Second trigger while the first is still in flight: the single-flight guard
+	// must suppress it — no second callback invocation, still one tunnel added.
+	c.maybeRedial(1)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "in-flight guard blocks a concurrent re-dial")
+
+	// Let the first re-dial finish; AddTunnel restores the count to the target.
+	close(release)
+	require.Eventually(t, func() bool { return c.liveSessionCount() == 2 },
+		time.Second, 5*time.Millisecond, "AddTunnel restores the live count to N")
+	require.Len(t, c.snapshotSessions(), 3, "one live + one dead + the replacement")
+	require.False(t, c.redialInFlight.Load(), "the in-flight guard clears after completion")
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "exactly one re-dial happened")
+	if cleanupReplacement != nil {
+		defer cleanupReplacement()
+	}
+
+	// At/above target no further re-dial fires.
+	c.maybeRedial(c.liveSessionCount())
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "no re-dial when live >= target")
+}
+
+// N==1 (and any all-closed / no-callback state) never re-dials: a single tunnel's
+// death is total collapse the app's --reconnect owns, not a per-tunnel re-dial.
+func TestMaybeRedial_SingleTunnelAndGuards(t *testing.T) {
+	var calls int32
+	countingRedial := func() (net.Conn, error) {
+		atomic.AddInt32(&calls, 1)
+		conn, _ := newRedialConn(t)
+		return conn, nil
+	}
+
+	// N==1: even with a callback wired, live>=target so no re-dial.
+	s, cleanup := newTestSession(t)
+	defer cleanup()
+	c1 := &Client{sessions: []*yamux.Session{s}, closeC: make(chan struct{}), target: 1}
+	c1.SetTunnelRedial(countingRedial)
+	c1.maybeRedial(1)
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, int32(0), atomic.LoadInt32(&calls), "N==1 never re-dials")
+
+	// All tunnels dead (live<=0): total collapse, not a re-dial trigger.
+	c1.maybeRedial(0)
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, int32(0), atomic.LoadInt32(&calls), "all-closed is left to the app's reconnect")
+
+	// No callback wired: no-op even below target.
+	c2 := &Client{sessions: []*yamux.Session{s}, closeC: make(chan struct{}), target: 3}
+	c2.maybeRedial(1)
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, int32(0), atomic.LoadInt32(&calls), "no re-dial without a callback")
+}
+
+// After maxRedialFails consecutive failures the loop backs off (stops re-dialing)
+// until a fresh death re-arms it via resetRedialBackoff.
+func TestMaybeRedial_BacksOffAfterFailuresUntilReset(t *testing.T) {
+	live, cleanup := newTestSession(t)
+	defer cleanup()
+	c := &Client{sessions: []*yamux.Session{live}, closeC: make(chan struct{}), target: 3}
+
+	var calls int32
+	c.SetTunnelRedial(func() (net.Conn, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, errors.New("exit unreachable")
+	})
+
+	// Each attempt fails and increments the counter; the in-flight guard clears
+	// synchronously on failure, so serialized calls accumulate failures.
+	for i := 0; i < maxRedialFails; i++ {
+		c.maybeRedial(1)
+		require.Eventually(t, func() bool { return !c.redialInFlight.Load() },
+			time.Second, 5*time.Millisecond)
+	}
+	require.Equal(t, int32(maxRedialFails), atomic.LoadInt32(&calls))
+
+	// Now backed off: further triggers are suppressed.
+	c.maybeRedial(1)
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, int32(maxRedialFails), atomic.LoadInt32(&calls), "backed off after consecutive failures")
+
+	// A fresh death re-arms it.
+	c.resetRedialBackoff()
+	c.maybeRedial(1)
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&calls) == maxRedialFails+1 },
+		time.Second, 5*time.Millisecond, "reset re-arms re-dial")
+}


### PR DESCRIPTION
Keep N healthy tunnels in the multi-tunnel skysocks client so bandwidth-aggregation width does not bleed down over time. The keepalive loop previously only SKIPPED a dead tunnel (pickSession routes around it) and never replaced one, so a long-lived `--tunnels N` client decayed toward a single tunnel and lost the aggregation.

The Client now stores the target N and, when a tunnel dies and the live count falls below N (but at least one survives), re-dials a fresh DISJOINT replacement via a callback the app wires in (`SetTunnelRedial` closes over the same `diversify=true` dial the initial extra tunnels use, so the visor steers the replacement off the survivors' first-hop transports, #4214). Re-dial is bounded: one in-flight attempt (atomic CAS guard) plus a back-off after consecutive failures until the next death re-arms it, so a persistently unreachable exit does not spin. `N==1` never re-dials — its lone tunnel's death is total collapse, still owned by the app's `--reconnect` runCycle — so the default path is byte-identical.

Sequential diversification is reliable without a router change or an added delay: the visor registers each tunnel's primary route group (with its first-hop transport in `rg.tps`) into `rgsNs` synchronously inside `saveRouteGroupRules`, before the dial RPC returns; #4209 defers only auxiliary mux legs, which skysocks tunnels never request. Because the extra-tunnel loop dials sequentially, tunnel i is always visible to tunnel i+1's sibling-exclusion scan.

Throughput-based eviction of a slow-but-alive tunnel (the "drop the underperforming" half of docs/mux_aggregation_rfc.md step 4) is deferred: it needs the gigabit validation rig to tune the slow-leg threshold. This change is liveness-only.

Builds on #4213/#4214/#4215. Unit tests cover: one dead tunnel triggers exactly one re-dial that restores the count; the in-flight guard suppresses a concurrent re-dial; N==1 / all-closed / no-callback never re-dial; and the failure back-off + reset. `go test ./pkg/skysocks/ -race`, `go vet`, and golangci-lint on the touched files are clean.