### PR TITLE
fix(router): don't hold r.mx during the accept send in IntroduceRules

### DIFF
--- a/pkg/router/router_introducerules_deadlock_test.go
+++ b/pkg/router/router_introducerules_deadlock_test.go
@@ -1,0 +1,88 @@
+package router
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// TestIntroduceRules_AcceptSendDoesNotHoldMutex is a regression test for the
+// router-wide deadlock observed live on a loaded exit visor: IntroduceRules
+// handed a NEW route group off to AcceptRoutes with a send to r.accept made
+// WHILE HOLDING r.mx. When the accept buffer filled (a burst of route setups
+// with the app-accept loop mid-handshake), that send blocked with r.mx held —
+// and the only consumer, AcceptRoutes -> saveRouteGroupRules, needs r.mx to
+// drain the next item. Circular wait: the router wedged, every other
+// IntroduceRules / ActiveRouteStatuses / rules-GC piled up behind r.mx (~10k
+// goroutines, route setup failing fleet-wide with "context deadline exceeded").
+//
+// The invariant this test pins: while IntroduceRules is parked on a full accept
+// buffer, r.mx must remain free so the consumer can drain and unwedge it.
+func TestIntroduceRules_AcceptSendDoesNotHoldMutex(t *testing.T) {
+	l := logging.NewMasterLogger()
+	r := &router{
+		logger: l.PackageLogger("router-deadlock-test"),
+		conf:   &Config{},
+		rt:     routing.NewTable(l.PackageLogger("rt")),
+		rgsNs:  make(map[routing.RouteDescriptor]*NoiseRouteGroup),
+		rgsRaw: make(map[routing.RouteDescriptor]*RouteGroup),
+		accept: make(chan routing.EdgeRules, 1),
+		done:   make(chan struct{}),
+	}
+	// Fill the single accept slot so the next send blocks.
+	r.accept <- routing.EdgeRules{}
+
+	initPK, _ := cipher.GenerateKeyPair()
+	respPK, _ := cipher.GenerateKeyPair()
+	desc := routing.NewRouteDescriptor(initPK, respPK, 1, 2)
+	consume := routing.ConsumeRule(time.Hour, routing.RouteID(1), respPK, initPK, 1, 2)
+	rules := routing.EdgeRules{Desc: desc, Forward: consume, Reverse: consume}
+
+	introDone := make(chan struct{})
+	var introErr error
+	go func() {
+		introErr = r.IntroduceRules(rules)
+		close(introDone)
+	}()
+
+	// Let IntroduceRules progress past its brief bookkeeping section (three map
+	// lookups) and park on the blocking accept send. Microsecond-scale work, so
+	// 50ms is a wide margin.
+	time.Sleep(50 * time.Millisecond)
+
+	// IntroduceRules must still be blocked on the send (buffer is full) — this is
+	// the scenario under test, not a no-op.
+	select {
+	case <-introDone:
+		t.Fatal("IntroduceRules returned before the accept buffer was drained; test scenario invalid")
+	default:
+	}
+
+	// The core assertion: r.mx is acquirable while IntroduceRules is parked on
+	// the full send. Before the fix this blocked forever (the deadlock).
+	mxFree := make(chan struct{})
+	go func() {
+		r.mx.Lock()
+		r.mx.Unlock() //nolint:staticcheck // just proving the lock is obtainable
+		close(mxFree)
+	}()
+	select {
+	case <-mxFree:
+	case <-time.After(2 * time.Second):
+		t.Fatal("r.mx held while IntroduceRules blocked on a full accept send — router deadlock regression")
+	}
+
+	// Drain the filler so IntroduceRules' send completes and the goroutine exits.
+	<-r.accept
+	select {
+	case <-introDone:
+		require.NoError(t, introErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("IntroduceRules did not complete after the accept buffer drained")
+	}
+}

--- a/pkg/router/router_rules.go
+++ b/pkg/router/router_rules.go
@@ -242,19 +242,23 @@ func (r *router) IntroduceRules(rules routing.EdgeRules) error {
 	}
 	r.mx.Unlock()
 
+	// Hand the new group off to AcceptRoutes. This send MUST NOT hold r.mx: the
+	// accept buffer can fill (a burst of route setups, or the app-accept loop
+	// mid-handshake), and the only consumer — AcceptRoutes → saveRouteGroupRules
+	// — takes r.mx to drain each item. Holding r.mx across a blocking send
+	// therefore deadlocks the whole router: the sender waits for the consumer to
+	// free a slot while the consumer waits for r.mx, and every other
+	// IntroduceRules, ActiveRouteStatuses and the rules-GC pile up behind the
+	// held lock (observed live: one sender parked in chansend, 1080 waiters, the
+	// visor wedged at ~10k goroutines with route setup failing fleet-wide).
+	// Duplicate sends for the same descriptor are already tolerated downstream —
+	// saveRouteGroupRules detects an initializing group and adopts the rules as
+	// an aux mux leg — so the lock guarded nothing here.
 	select {
+	case r.accept <- rules:
+		return nil
 	case <-r.done:
 		return io.ErrClosedPipe
-	default:
-		r.mx.Lock()
-		defer r.mx.Unlock()
-
-		select {
-		case r.accept <- rules:
-			return nil
-		case <-r.done:
-			return io.ErrClosedPipe
-		}
 	}
 }
 


### PR DESCRIPTION
IntroduceRules handed a new route group to `AcceptRoutes` with a send to `r.accept` made **while holding `r.mx`**. When the accept buffer fills (a burst of route setups with the app-accept loop mid-handshake), that send blocks with `r.mx` still held — and the only consumer, `AcceptRoutes -> saveRouteGroupRules`, takes `r.mx` to drain each item. Circular wait: the router wedges, and every other `IntroduceRules`, `ActiveRouteStatuses` and the rules-GC pile up behind the held lock.

Seen live on a loaded exit (SOCKS server) visor: one sender parked in `chansend`, **1080 waiters on `r.mx`, ~10k goroutines**, and route setup failing fleet-wide with `context deadline exceeded` — setup nodes reserved route IDs fine but `AddEdgeRules` on the destination router timed out, so no client could establish a route group to that exit.

Fix: move the `r.accept` send out from under `r.mx`. A duplicate send for the same descriptor is already tolerated downstream (`saveRouteGroupRules` detects an initializing group and adopts the rules as an aux mux leg), so the lock guarded nothing here.

Includes a regression test that fills the accept buffer and asserts `r.mx` stays acquirable while the send is parked — it fails (2s deadlock timeout) against the old code and passes with the fix.

Developed with AI assistance (Claude).