### PR TITLE
feat(router): per-frame noise inverse-mux (single-stream aggregation), env-gated OFF

### DIFF
--- a/pkg/dmsg/noise/noise.go
+++ b/pkg/dmsg/noise/noise.go
@@ -338,6 +338,36 @@ func (ns *Noise) DecryptUnsafe(ciphertext []byte) ([]byte, error) {
 	return ns.dec.Cipher().Decrypt(nil, recvSeq, nil, ciphertext[nonceSize:])
 }
 
+// SealWithNonce encrypts plaintext under the transport-phase cipher using an
+// EXPLICIT nonce supplied by the caller, and does NOT touch the internal
+// encNonce counter. This is the per-frame AEAD primitive for the mux inverse-
+// multiplexer: each mux DATA frame is sealed with its own stream sequence number
+// as the nonce, so frames can be decrypted INDEPENDENTLY and OUT OF ORDER (no
+// stateful cipher to desync). The caller MUST guarantee nonce uniqueness per key
+// — the mux sequence is assigned exactly once per frame, so it is unique by
+// construction. The 8-byte nonce is NOT prepended (unlike EncryptUnsafe): it is
+// carried in the mux packet's own sequence field. Returns nil if the handshake
+// has not produced a transport cipher yet.
+func (ns *Noise) SealWithNonce(nonce uint64, plaintext []byte) []byte {
+	if ns.enc == nil {
+		return nil
+	}
+	return ns.enc.Cipher().Encrypt(nil, nonce, nil, plaintext)
+}
+
+// OpenWithNonce decrypts a frame sealed by SealWithNonce, using the EXPLICIT
+// nonce (the frame's stream sequence). It does NOT touch decNonce and imposes no
+// ordering requirement, so out-of-order arrival across mux legs is fine. Replay
+// is handled one layer up by the reorder buffer (a sequence at or below the
+// delivered frontier is dropped). Returns an error if the handshake has not
+// produced a transport cipher yet or the tag fails to verify.
+func (ns *Noise) OpenWithNonce(nonce uint64, ciphertext []byte) ([]byte, error) {
+	if ns.dec == nil {
+		return nil, ErrInvalidCipherText
+	}
+	return ns.dec.Cipher().Decrypt(nil, nonce, nil, ciphertext)
+}
+
 // NonceMap is a map of used nonces.
 // Deprecated: Use NonceWindow instead for bounded memory usage.
 type NonceMap map[uint64]struct{}

--- a/pkg/dmsg/noise/noise_test.go
+++ b/pkg/dmsg/noise/noise_test.go
@@ -2,6 +2,7 @@
 package noise
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -211,4 +212,72 @@ func TestPQHandshakeFallbackToClassical(t *testing.T) {
 	pt, err = nI.DecryptUnsafe(ct)
 	require.NoError(t, err)
 	require.Equal(t, "classical", string(pt))
+}
+
+// TestSealOpenWithNonce validates the per-frame AEAD primitive used by the mux
+// inverse-multiplexer: after a KK handshake, SealWithNonce/OpenWithNonce round-
+// trip in BOTH directions, decrypt correctly OUT OF ORDER (each frame carries
+// its own explicit nonce, so there is no stateful cipher to desync), never touch
+// the stream encNonce/decNonce counters, and reject a tampered frame.
+func TestSealOpenWithNonce(t *testing.T) {
+	pkI, skI := cipher.GenerateKeyPair()
+	pkR, skR := cipher.GenerateKeyPair()
+
+	nI, err := New(HandshakeKK, Config{LocalPK: pkI, LocalSK: skI, RemotePK: pkR, Initiator: true})
+	require.NoError(t, err)
+	nR, err := New(HandshakeKK, Config{LocalPK: pkR, LocalSK: skR, RemotePK: pkI, Initiator: false})
+	require.NoError(t, err)
+
+	msg, err := nI.MakeHandshakeMessage()
+	require.NoError(t, err)
+	require.NoError(t, nR.ProcessHandshakeMessage(msg))
+	msg, err = nR.MakeHandshakeMessage()
+	require.NoError(t, err)
+	require.NoError(t, nI.ProcessHandshakeMessage(msg))
+	require.True(t, nI.HandshakeFinished() && nR.HandshakeFinished())
+
+	// Snapshot the stream nonce counters; per-frame seal/open must NOT move them.
+	encN, decN := nI.GetEncNonce(), nR.GetDecNonce()
+
+	// Seal a batch of frames on the initiator, then open them on the responder
+	// in SHUFFLED order — the whole point of per-frame noise.
+	type frame struct {
+		seq uint64
+		pt  []byte
+		ct  []byte
+	}
+	frames := make([]frame, 0, 64)
+	for i := 0; i < 64; i++ {
+		pt := []byte(fmt.Sprintf("frame-payload-%d-xyzzy", i))
+		ct := nI.SealWithNonce(uint64(i), pt)
+		require.NotNil(t, ct)
+		frames = append(frames, frame{seq: uint64(i), pt: pt, ct: ct})
+	}
+	// Deterministic shuffle (no rand dependency): reverse + interleave.
+	for i, j := 0, len(frames)-1; i < j; i, j = i+1, j-1 {
+		frames[i], frames[j] = frames[j], frames[i]
+	}
+	for _, f := range frames {
+		got, err := nR.OpenWithNonce(f.seq, f.ct)
+		require.NoError(t, err, "open seq %d", f.seq)
+		require.Equal(t, f.pt, got)
+	}
+
+	// Reverse direction: responder seals, initiator opens.
+	ct := nR.SealWithNonce(7, []byte("reverse-dir"))
+	got, err := nI.OpenWithNonce(7, ct)
+	require.NoError(t, err)
+	require.Equal(t, []byte("reverse-dir"), got)
+
+	// Wrong nonce and tampered tag must fail (not silently accept).
+	_, err = nR.OpenWithNonce(9999, frames[0].ct)
+	require.Error(t, err, "opening with the wrong nonce must fail")
+	bad := append([]byte(nil), frames[0].ct...)
+	bad[len(bad)-1] ^= 0xff
+	_, err = nR.OpenWithNonce(frames[0].seq, bad)
+	require.Error(t, err, "tampered ciphertext must fail")
+
+	// Stream counters untouched.
+	require.Equal(t, encN, nI.GetEncNonce(), "SealWithNonce must not advance encNonce")
+	require.Equal(t, decN, nR.GetDecNonce(), "OpenWithNonce must not advance decNonce")
 }

--- a/pkg/router/perframe_noise_test.go
+++ b/pkg/router/perframe_noise_test.go
@@ -1,0 +1,96 @@
+// Package router pkg/router/perframe_noise_test.go
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/noise"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// kkPair completes a KK noise handshake and returns the two transport-ready
+// sessions (initiator, responder).
+func kkPair(t *testing.T) (*noise.Noise, *noise.Noise) {
+	t.Helper()
+	pkI, skI := cipher.GenerateKeyPair()
+	pkR, skR := cipher.GenerateKeyPair()
+	nI, err := noise.New(noise.HandshakeKK, noise.Config{LocalPK: pkI, LocalSK: skI, RemotePK: pkR, Initiator: true})
+	require.NoError(t, err)
+	nR, err := noise.New(noise.HandshakeKK, noise.Config{LocalPK: pkR, LocalSK: skR, RemotePK: pkI, Initiator: false})
+	require.NoError(t, err)
+	m, err := nI.MakeHandshakeMessage()
+	require.NoError(t, err)
+	require.NoError(t, nR.ProcessHandshakeMessage(m))
+	m, err = nR.MakeHandshakeMessage()
+	require.NoError(t, err)
+	require.NoError(t, nI.ProcessHandshakeMessage(m))
+	require.True(t, nI.HandshakeFinished() && nR.HandshakeFinished())
+	return nI, nR
+}
+
+// TestPerFrameMuxDataPathRoundTrip exercises the full mux per-frame data path:
+// wrapPayload SEALS under the frame sequence, the wire packet carries the sealed
+// bytes, and deliverData OPENS + reorders back to the original plaintext — in
+// order AND out of order — and a tampered frame is dropped, never delivered.
+func TestPerFrameMuxDataPathRoundTrip(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("perframe-test")
+	nI, nR := kkPair(t)
+
+	send := newRouteMux(log, true)
+	send.seal = func(seq uint32, pt []byte) []byte { return nI.SealWithNonce(uint64(seq), pt) }
+
+	recv := newRouteMux(log, true)
+	recv.open = func(seq uint32, ct []byte) ([]byte, error) { return nR.OpenWithNonce(uint64(seq), ct) }
+	recv.reorderBuf.SetSkipCapable(true)
+
+	const routeID = routing.RouteID(42)
+	const n = 200
+	plain := make([][]byte, n)
+	packets := make([]routing.Packet, n)
+	for i := 0; i < n; i++ {
+		plain[i] = []byte(fmt.Sprintf("payload-%04d-the-quick-brown-fox", i))
+		pkt, seq, err := send.wrapPayload(routeID, plain[i])
+		require.NoError(t, err)
+		require.Equal(t, uint32(i), seq)
+		packets[i] = pkt
+	}
+
+	// Deliver in a scrambled order (swap adjacent pairs, then a few long hops) to
+	// simulate cross-leg latency skew; the reorder buffer must still hand back the
+	// original plaintext in strict order.
+	order := make([]int, n)
+	for i := range order {
+		order[i] = i
+	}
+	for i := 0; i+1 < n; i += 2 {
+		order[i], order[i+1] = order[i+1], order[i]
+	}
+
+	var got [][]byte
+	for _, idx := range order {
+		p := packets[idx]
+		delivered, _ := recv.deliverData(p.SequenceNumber(), p.DataPayloadAfterSeq())
+		got = append(got, delivered...)
+	}
+	require.Len(t, got, n, "every frame must eventually be delivered")
+	for i := 0; i < n; i++ {
+		require.Equal(t, plain[i], got[i], "frame %d delivered in order and intact", i)
+	}
+
+	// A tampered frame must be dropped by the open, not delivered.
+	recv2 := newRouteMux(log, true)
+	nI2, nR2 := kkPair(t)
+	_ = nI2
+	recv2.open = func(seq uint32, ct []byte) ([]byte, error) { return nR2.OpenWithNonce(uint64(seq), ct) }
+	// Frame sealed by a DIFFERENT sender (wrong key) must fail to open and deliver nothing.
+	bad, _, err := send.wrapPayload(routeID, []byte("attacker"))
+	require.NoError(t, err)
+	// reset recv2 to expect seq 0
+	delivered, _ := recv2.deliverData(bad.SequenceNumber()+1000, bad.DataPayloadAfterSeq())
+	require.Empty(t, delivered, "frame that fails AEAD open must not be delivered")
+}

--- a/pkg/router/reorder.go
+++ b/pkg/router/reorder.go
@@ -38,6 +38,22 @@ type reorderBuffer struct {
 	// and stopped delivering, and flushing (lossy) is preferable to stalling
 	// the stream forever while liveness prunes that leg.
 	maxGap int
+
+	// skipCapable is set when the group negotiated per-frame noise. Each mux
+	// DATA frame is then an INDEPENDENT AEAD unit (sealed under its sequence), so
+	// delivering PAST a missing sequence no longer desyncs any cipher — the whole
+	// reason the no-skip rule existed. With it set, a frontier gap that stays open
+	// past reorderTimeout (a leg genuinely stuck, SACK not yet refilled) is
+	// RELEASED (delivered lossy-but-moving) instead of held, and the OOM
+	// force-flush becomes a clean skip rather than a cipher-corrupting one.
+	skipCapable bool
+}
+
+// SetSkipCapable enables/disables the per-frame-noise skip path (see skipCapable).
+func (rb *reorderBuffer) SetSkipCapable(v bool) {
+	rb.mu.Lock()
+	rb.skipCapable = v
+	rb.mu.Unlock()
 }
 
 func newReorderBuffer(maxGap int) *reorderBuffer {
@@ -86,7 +102,15 @@ func (rb *reorderBuffer) Insert(seq uint32, data []byte) [][]byte {
 		// intact. A leg that stays dead is removed by leg-liveness pruning, after
 		// which its unacked seqs are retransmitted on the survivors. reorderTimeout
 		// is retained as the stall threshold for that diagnostics/prune path.
-		_ = reorderTimeout
+		// Per-frame noise: each frame is its own AEAD unit, so releasing a gap no
+		// longer desyncs a cipher. A frontier gap held past reorderTimeout means a
+		// leg is stuck and SACK has not refilled in time; release it (lossy but
+		// moving) rather than hold. In normal operation SACK retransmit refills the
+		// gap well within reorderTimeout, so this only fires on a genuinely stuck
+		// leg — exactly the case that used to wedge a stream-noise mux at 0 goodput.
+		if rb.skipCapable && !rb.gapSince.IsZero() && time.Since(rb.gapSince) > reorderTimeout {
+			return rb.flushAll()
+		}
 
 		// Emergency OOM backstop only: with reliable legs the missing seq arrives
 		// (via skew or SACK retransmit) and drains the buffer, so this never trips

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/ioutil"
+	"github.com/skycoin/skywire/pkg/dmsg/noise"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/transport"
@@ -123,6 +124,22 @@ type RouteGroup struct {
 	handshakeProcessed     chan struct{}
 	handshakeProcessedOnce sync.Once
 	encrypt                bool
+
+	// Per-frame noise (inverse-mux). perFrameNoiseWant advertises CapPerFrameNoise
+	// in our handshake (gated by SKYWIRE_PERFRAME_NOISE so it stays opt-in during
+	// rollout). nsConf carries the KK keys (local SK/PK + peer PK), copied from the
+	// same noise.Config that EncryptConn would use. ns is the per-frame session;
+	// perFrameNoiseMsg caches our outgoing KK message so a handshake RETRANSMIT
+	// resends identical bytes instead of re-advancing the noise state machine.
+	// perFrameNoiseActive flips true once ns's transport cipher is ready and the
+	// mux seal/open are wired; from then on EncryptConn is bypassed. Guarded by rg.mu
+	// (set inside handshake processing / sendHandshake, both under mu).
+	perFrameNoiseWant   bool
+	nsConf              noise.Config
+	ns                  *noise.Noise
+	perFrameNoiseMsg    []byte
+	perFrameNoiseActive bool
+	perFrameNoiseOnce   sync.Once
 
 	// forwardHops stores the complete route path as originally calculated.
 	// This is the full multi-hop route, not just local transports.
@@ -2015,6 +2032,67 @@ func (rg *RouteGroup) sendKeepAlive() error {
 	return nil
 }
 
+// perFrameNoiseCap returns CapPerFrameNoise when we want per-frame noise and the
+// group is encrypted (per-frame noise IS the encryption); 0 otherwise.
+func (rg *RouteGroup) perFrameNoiseCap() uint16 {
+	if rg.perFrameNoiseWant && rg.encrypt {
+		return routing.CapPerFrameNoise
+	}
+	return 0
+}
+
+// nextPerFrameNoiseMsg returns the noise KK message to piggyback on THIS
+// handshake send, creating the session on first use. Idempotent across
+// retransmits: once produced, the same bytes are cached and returned so a resend
+// never advances the noise state machine. Initiator: first call builds ns and
+// produces msg1. Responder: ns was created + fed msg1 in handlePacket, so the
+// first call here produces msg2 and completes the responder cipher. Called with
+// rg.mu held.
+func (rg *RouteGroup) nextPerFrameNoiseMsg() ([]byte, error) {
+	if rg.perFrameNoiseMsg != nil {
+		return rg.perFrameNoiseMsg, nil
+	}
+	if rg.ns == nil {
+		ns, err := noise.New(noise.HandshakeKK, rg.nsConf)
+		if err != nil {
+			return nil, err
+		}
+		rg.ns = ns
+	}
+	msg, err := rg.ns.MakeHandshakeMessage()
+	if err != nil {
+		return nil, err
+	}
+	rg.perFrameNoiseMsg = msg
+	if rg.ns.HandshakeFinished() {
+		rg.wirePerFrameNoise()
+	}
+	return msg, nil
+}
+
+// wirePerFrameNoise installs the per-frame seal/open onto the mux and marks the
+// group active, exactly once, the moment the noise transport cipher is ready.
+// The seal/open use the mux frame SEQUENCE as the AEAD nonce; the cipher's
+// Encrypt/Decrypt take an explicit nonce and are stateless (no per-call mutation),
+// so concurrent per-leg send/recv is safe. Called with rg.mu held.
+func (rg *RouteGroup) wirePerFrameNoise() {
+	rg.perFrameNoiseOnce.Do(func() {
+		ns := rg.ns
+		if ns == nil || rg.mux == nil {
+			return
+		}
+		rg.mux.seal = func(seq uint32, plaintext []byte) []byte {
+			return ns.SealWithNonce(uint64(seq), plaintext)
+		}
+		rg.mux.open = func(seq uint32, ciphertext []byte) ([]byte, error) {
+			return ns.OpenWithNonce(uint64(seq), ciphertext)
+		}
+		rg.mux.reorderBuf.SetSkipCapable(true)
+		rg.perFrameNoiseActive = true
+		rg.logger.Debug("Per-frame noise active: mux seal/open wired, reorder skip-capable, EncryptConn bypassed")
+	})
+}
+
 func (rg *RouteGroup) sendHandshake(encrypt bool) error {
 	rg.mu.Lock()
 	defer rg.mu.Unlock()
@@ -2034,7 +2112,20 @@ func (rg *RouteGroup) sendHandshake(encrypt bool) error {
 		}
 
 		rule := rg.fwd[i]
-		packet := routing.MakeHandshakePacket(rule.NextRouteID(), encrypt, routing.CapMux|routing.CapSACK)
+		caps := routing.CapMux | routing.CapSACK
+		var packet routing.Packet
+		if pfn := rg.perFrameNoiseCap(); pfn != 0 {
+			msg, mErr := rg.nextPerFrameNoiseMsg()
+			if mErr != nil {
+				// Never silently drop to plaintext: if the per-frame noise
+				// message can't be produced, abort this handshake rather than
+				// advertise a capability we can't honor.
+				return fmt.Errorf("per-frame noise handshake message: %w", mErr)
+			}
+			packet = routing.MakeHandshakePacketWithNoise(rule.NextRouteID(), encrypt, caps|pfn, msg)
+		} else {
+			packet = routing.MakeHandshakePacket(rule.NextRouteID(), encrypt, caps)
+		}
 
 		err := rg.writePacket(ctx, tp, packet, rule.KeyRouteID())
 		if err == nil {
@@ -2186,6 +2277,50 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 				if sack {
 					rg.logger.Debug("SACK retransmission enabled (both peers support CapSACK)")
 					go rg.servicePacketLoop("sack", rg.cfg.KeepAliveInterval/2, rg.sackServiceFn, nil)
+				}
+
+				// Per-frame noise negotiation (both edges advertised CapPerFrameNoise
+				// and we want it). Piggybacked on the same handshake as the KK
+				// message. Wiring is SYNCHRONOUS here so perFrameNoiseActive is set
+				// before handshakeProcessed closes and saveRouteGroupRules decides
+				// whether to bypass EncryptConn.
+				if rg.perFrameNoiseWant && rg.encrypt && remoteCaps&routing.CapPerFrameNoise != 0 {
+					noiseMsg := packet.HandshakeNoisePayload()
+					if rg.initiator {
+						// Reverse handshake: process the responder's msg2 (our ns
+						// exists from sending msg1) and wire on completion.
+						if rg.ns != nil {
+							if err := rg.ns.ProcessHandshakeMessage(noiseMsg); err != nil {
+								rg.logger.Warnf("per-frame noise: process responder msg2 failed: %v", err)
+							} else if rg.ns.HandshakeFinished() {
+								rg.wirePerFrameNoise()
+							}
+						}
+					} else {
+						// Forward handshake: create our session, process the
+						// initiator's msg1, produce+cache msg2 (this finishes our
+						// cipher and wires the mux synchronously), then emit the
+						// reverse handshake carrying msg2 from a goroutine so we
+						// never block the router read loop.
+						if ns, err := noise.New(noise.HandshakeKK, rg.nsConf); err != nil {
+							rg.logger.Warnf("per-frame noise: session create failed: %v", err)
+						} else {
+							rg.ns = ns
+							if err := rg.ns.ProcessHandshakeMessage(noiseMsg); err != nil {
+								rg.logger.Warnf("per-frame noise: process initiator msg1 failed: %v", err)
+								rg.ns = nil
+							} else if _, err := rg.nextPerFrameNoiseMsg(); err != nil {
+								rg.logger.Warnf("per-frame noise: produce responder msg2 failed: %v", err)
+								rg.ns = nil
+							} else {
+								go func() {
+									if err := rg.sendHandshake(rg.encrypt); err != nil {
+										rg.logger.Debugf("per-frame noise: reverse handshake send failed: %v", err)
+									}
+								}()
+							}
+						}
+					}
 				}
 			}
 

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -82,6 +82,17 @@ type routeMux struct {
 	sackTracker *sackTracker // receiver: tracks received seqs for SACK generation
 	retxBuf     *retxBuffer  // sender: holds unACKed packets for retransmission
 
+	// Per-frame noise (inverse-mux). When CapPerFrameNoise is negotiated the
+	// RouteGroup installs these: seal AEAD-encrypts each outgoing frame under
+	// its sequence-nonce (in wrapPayload, before retx storage so retransmits
+	// resend the sealed frame verbatim); open AEAD-decrypts an incoming frame
+	// under its sequence-nonce (in deliverData, before the reorder buffer).
+	// Both nil for stream-noise/plain groups (no-op). Set once at handshake
+	// completion, read on the data path; a plain word write/read is safe under
+	// the RouteGroup's ordering (set-before-first-data, mu-guarded install).
+	seal func(seq uint32, plaintext []byte) []byte
+	open func(seq uint32, ciphertext []byte) ([]byte, error)
+
 	// Per-leg traffic counters parallel to the rg's tps[] / fwd[] /
 	// rvs[] slices. Mutated atomically. Read via Snapshot().
 	// legMu guards the slice itself (extended on AppendRoute), not
@@ -510,6 +521,13 @@ func (m *routeMux) snapshotLegs() []LegStats {
 // Returns the packet and the sequence number used.
 func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte) (routing.Packet, uint32, error) {
 	seq := atomic.AddUint32(&m.writeSeq, 1) - 1
+	// Per-frame AEAD: seal the app payload under seq as the nonce. The sealed
+	// bytes are what go on the wire AND into the retx buffer, so a SACK
+	// retransmit resends the identical sealed frame (same seq ⇒ same nonce ⇒
+	// same ciphertext), and the receiver opens it independently, out of order.
+	if m.seal != nil {
+		data = m.seal(seq, data)
+	}
 	packet, err := routing.MakeSequencedDataPacket(routeID, seq, data)
 	if err != nil {
 		return nil, 0, err
@@ -527,6 +545,22 @@ func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte) (routing.Pa
 // and returns any payloads that are now deliverable in order.
 // Also tracks the sequence for SACK generation.
 func (m *routeMux) deliverData(seq uint32, data []byte) (delivered [][]byte, gapDetected bool) {
+	// Per-frame AEAD: open the frame under its sequence-nonce before it enters
+	// the reorder buffer. A frame that fails to open (tamper, or a stale
+	// duplicate whose seq the peer reused after a rekey) is dropped, exactly as
+	// a corrupt packet would be — never delivered. SACK/reorder then treat it as
+	// not-yet-received and it is retransmitted if genuinely missing.
+	if m.open != nil {
+		pt, err := m.open(seq, data)
+		if err != nil {
+			if m.logger != nil {
+				m.logger.WithError(err).Tracef("per-frame open failed for seq %d; dropping", seq)
+			}
+			return nil, false
+		}
+		data = pt
+	}
+
 	// Track for SACK generation
 	if m.sackEnabled && m.sackTracker != nil {
 		gapDetected = m.sackTracker.RecordReceived(seq)

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -25,6 +26,13 @@ import (
 // failure and skip deleting the leg's rules (#80 Fix B). Deleting them here is
 // exactly what black-holes an aux mux leg that raced the primary's setup.
 var errRouteGroupInitializing = errors.New("noise route group already being initialized")
+
+// perFrameNoiseEnabled opts this visor into advertising CapPerFrameNoise (the
+// mux inverse-multiplexer's per-frame AEAD). Gated by an env var so the fleet
+// isn't flipped at once: a route group uses per-frame noise only when BOTH edges
+// have it set, otherwise it falls back to the stream-noise (EncryptConn) wrap.
+// Read once at package init. See docs/inverse_mux_per_frame_noise_rfc.md.
+var perFrameNoiseEnabled = os.Getenv("SKYWIRE_PERFRAME_NOISE") == "1"
 
 // AcceptRoutes should block until we receive an AddRules packet from SetupNode
 // that contains ConsumeRule(s) or ForwardRule(s).
@@ -290,6 +298,13 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 	rg := NewRouteGroup(DefaultRouteGroupConfig(), r.rt, rules.Desc, r.mLogger)
 	rg.SetAppName(appName)
 	rg.initiator = nsConf.Initiator
+	// Per-frame noise (inverse-mux): hand the RG the same KK keys EncryptConn
+	// would use, and opt in per the env gate so the whole fleet isn't flipped at
+	// once. When both edges advertise CapPerFrameNoise the RG runs noise per mux
+	// frame and EncryptConn is bypassed (see below); otherwise it falls back to
+	// the stream-noise wrap unchanged.
+	rg.nsConf = nsConf
+	rg.perFrameNoiseWant = perFrameNoiseEnabled
 	rg.appendRules(rules.Forward, rules.Reverse, tp)
 	// we put raw rg so it can be accessible to the router when handshake packets come in
 	r.rgsRaw[rules.Desc] = rg
@@ -435,7 +450,15 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 		log.Debugf("Successfully closed old noise route group")
 	}
 
-	if rg.encrypt {
+	if rg.encrypt && rg.perFrameNoiseActive {
+		// Per-frame noise negotiated: the mux already seals/opens every DATA frame
+		// under its sequence-nonce, so the RouteGroup hands the app plaintext
+		// directly — no stream-noise wrap. (Both edges agreed via CapPerFrameNoise;
+		// if only one wanted it, perFrameNoiseActive is false and we fall through
+		// to the stream wrap below.)
+		nrg = &NoiseRouteGroup{rg: rg, Conn: rg}
+		log.Debugf("Per-frame noise route group ready (%s): EncryptConn bypassed", &rules.Desc)
+	} else if rg.encrypt {
 		// wrapping rg with noise
 		wrappedRG, err := network.EncryptConn(nsConf, rg)
 		if err != nil {

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -138,6 +138,13 @@ const (
 	CapMux     uint16 = 1 << 0 // Supports route multiplexing (sequenced DataPackets)
 	CapSACK    uint16 = 1 << 1 // Supports SACK retransmission
 	CapCascade uint16 = 1 << 2 // Supports cascade route setup protocol
+	// CapPerFrameNoise: the peer supports per-frame AEAD inside the mux (each
+	// sequenced DATA frame independently sealed with its sequence as the nonce),
+	// so noise is no longer a stateful stream wrapper and the reorder buffer may
+	// deliver out of order. When BOTH edges advertise it, the route-group
+	// handshake also carries a piggybacked noise KK message (after the 3-byte
+	// enc+caps prefix), and network.EncryptConn is bypassed.
+	CapPerFrameNoise uint16 = 1 << 3
 )
 
 // SeqSize is the byte size of the sequence number prepended to DataPacket
@@ -355,6 +362,30 @@ func (p Packet) HandshakeCapabilities() uint16 {
 		return binary.LittleEndian.Uint16(payload[1:3])
 	}
 	return 0
+}
+
+// MakeHandshakePacketWithNoise builds a handshake packet whose payload is the
+// standard [enc][caps] prefix followed by a piggybacked noise KK handshake
+// message. Used only when CapPerFrameNoise is negotiated; a nil/empty noiseMsg
+// yields the same 3-byte payload as MakeHandshakePacket.
+func MakeHandshakePacketWithNoise(id RouteID, supportEncryption bool, capabilities uint16, noiseMsg []byte) Packet {
+	payload := make([]byte, 3+len(noiseMsg))
+	if supportEncryption {
+		payload[0] = 1
+	}
+	binary.LittleEndian.PutUint16(payload[1:3], capabilities)
+	copy(payload[3:], noiseMsg)
+	return MakeHandshakePacketRaw(id, payload)
+}
+
+// HandshakeNoisePayload returns the piggybacked noise handshake message from an
+// extended handshake payload (bytes after the 3-byte enc+caps prefix), or nil.
+func (p Packet) HandshakeNoisePayload() []byte {
+	payload := p.Payload()
+	if len(payload) > 3 {
+		return payload[3:]
+	}
+	return nil
 }
 
 // MakeErrorPacket constructs a new ErrorPacket.


### PR DESCRIPTION
Implements `docs/inverse_mux_per_frame_noise_rfc.md`: each sequenced mux DATA frame is independently AEAD-sealed under its **stream sequence as the nonce**, so frames decrypt out of order and the reorder buffer is no longer chained to a stateful stream cipher. This is the missing half of mesh bandwidth aggregation — #4212 gave connection-striping; this gives **single-stream** inverse-multiplexing so one `curl` can spread across legs. The weighted scheduler (`WeightModeCapacity`) and SACK retransmit already existed and were only masked by the stream-noise head-of-line wall.

**Safety / rollout.** Negotiated only when BOTH edges advertise `CapPerFrameNoise`, gated behind `SKYWIRE_PERFRAME_NOISE=1` (**default OFF**). With the env var unset every hot path is a no-op (seal/open nil, skipCapable false, cap 0), so behavior is byte-for-byte identical to today — it ships **inert** and is enabled per-box for measurement. Mixed old/new and enabled/disabled peers fall back gracefully to the stream-noise `EncryptConn` wrap.

**Pieces**
- `noise`: `SealWithNonce`/`OpenWithNonce` — explicit-nonce AEAD that does not touch the stream nonce counters (the mux sequence is unique per key by construction). Round-trip + out-of-order + tamper test.
- `routing`: `CapPerFrameNoise` + extended handshake helpers; the KK message piggybacks on the existing handshake (msg1 forward, msg2 reverse).
- `route_mux`: seal in `wrapPayload` (before retx store, so a SACK resend replays the identical sealed frame), open in `deliverData` (fail-to-open ⇒ dropped, never delivered). Data-path round-trip + out-of-order + tamper test.
- `reorder`: `SetSkipCapable` — a held gap past `reorderTimeout` is released (lossy-but-moving) instead of wedging, since skipping no longer desyncs a cipher.
- `route_group`: RG-level KK handshake wired into send/receive; responder wires synchronously before `handshakeProcessed` closes so the EncryptConn-bypass decision is race-free.
- `router_serve`: bypass `network.EncryptConn` when per-frame noise is active.

Nonce is the 32-bit frame sequence widened to 64-bit; a rekey epoch before wrap (~4B frames) is RFC phase 5, not needed for bring-up.

Developed with AI assistance (Claude).