### PR TITLE
chore(ci): latest Go (1.27.0) + golangci-lint (v2.13.1)

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 

--- a/.github/workflows/deployment-health.yml
+++ b/.github/workflows/deployment-health.yml
@@ -26,6 +26,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
       - name: Probe dmsg-server wss fronts
         run: go run ./cmd/skywire cli mdisc check --url https://dmsgd.skywire.dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.27.0'
   MUSL_RELEASE: 'v1.3.29'
   MODULE: github.com/skycoin/skywire
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 
@@ -53,7 +53,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.2
+          version: v2.13.1
 
       - name: Install Dependencies
         shell: bash
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 
@@ -108,7 +108,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 
@@ -129,7 +129,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.2
+          version: v2.13.1
 
       - name: Checking Format and Testing
         run: |
@@ -146,7 +146,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 
@@ -168,7 +168,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.2
+          version: v2.13.1
 
       - name: Install Requirements
         shell: pwsh
@@ -193,7 +193,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 
@@ -221,7 +221,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 
@@ -270,7 +270,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 
@@ -292,7 +292,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 
@@ -314,7 +314,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 
@@ -342,7 +342,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 
@@ -428,7 +428,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.27.0'
           cache: true
           cache-dependency-path: go.sum
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/skycoin/skywire
 
-go 1.26.4
+go 1.27.0
 
 require (
 	fyne.io/systray v1.12.2


### PR DESCRIPTION
Updates every CI Go pin `1.26.5` → `1.27.0` (go-version in codeql/android-app/deployment-health/test, `GO_VERSION` in release), the go.mod `go` directive `1.26.4` → `1.27.0`, and golangci-lint `v2.12.2` → `v2.13.1` in the lint steps. Builds clean on Go 1.27. Developed with AI assistance (Claude).