### PR TITLE
fix(skysocks): break the IPC read loop on error instead of spinning

### DIFF
--- a/pkg/skysocks/common.go
+++ b/pkg/skysocks/common.go
@@ -19,7 +19,15 @@ func listenIPC(ipcClient *ipc.Client, appName string, log logrus.FieldLogger, on
 	for {
 		m, err := ipcClient.Read()
 		if err != nil {
-			log.Errorf("%s IPC received error: %v", appName, err)
+			// A read error is terminal: golang-ipc closes the receive channel
+			// on error, so every subsequent Read returns immediately with the
+			// same error. Without breaking, this loop spins at full tilt
+			// (hundreds of log lines per millisecond), pegging a CPU core and
+			// starving the app's real work — the same regression already fixed
+			// for skychat's IPC signal loop. Stop the handler and run onClose so
+			// the app tears down cleanly instead of busy-looping.
+			log.Errorf("%s IPC read error, stopping IPC handler: %v", appName, err)
+			break
 		}
 
 		if m != nil {


### PR DESCRIPTION
ListenIPC logged a read error and fell through to loop again. golang-ipc closes its receive channel on the first error, so every subsequent `Read()` returns immediately with the same error — the loop then spins at full tilt (hundreds of log lines/ms), pegs a CPU core, and never runs `onClose`, so the app neither exits nor stops. It hits both `Server.ListenIPC` and `Client.ListenIPC`, i.e. **every native visor running skysocks / skysocks-client**. Break on the error (and let the trailing `onClose` run) — the same fix already applied to skychats IPC loop (commit `8df44f6e9`).

Found while investigating a wasm-visor CPU spin; this is the native-IPC analogue of that class of bug. Developed with AI assistance (Claude).