### PR TITLE
chore: keep go.mod at minimal required go (1.26.4)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/skycoin/skywire
 
-go 1.27.0
+go 1.26.4
 
 require (
 	fyne.io/systray v1.12.2


### PR DESCRIPTION
Follow-up to #4221. That PR bumped the go.mod `go` directive to 1.27.0 along with the CI toolchain, but the `go` directive is the **minimum required** version and nothing in the tree needs 1.27 features — raising it forces source-build hosts (some on 1.22) to pull a newer toolchain for no reason. Revert the directive to 1.26.4; CI still runs on the latest Go via the workflow pins. Developed with AI assistance (Claude).