### PR TITLE
fix(router): per-frame noise handshake writes a KK message only on our turn

### DIFF
--- a/pkg/dmsg/noise/noise.go
+++ b/pkg/dmsg/noise/noise.go
@@ -281,6 +281,23 @@ func (ns *Noise) HandshakeFinished() bool {
 	return ns.hs.MessageIndex() == len(ns.pattern.Messages)
 }
 
+// WriterTurn reports whether the NEXT handshake message is ours to WRITE (via
+// MakeHandshakeMessage) rather than to read. The initiator writes the
+// even-indexed handshake messages and reads the odd ones; the responder is the
+// mirror. Callers use this to avoid MakeHandshakeMessage out of turn, which the
+// underlying state machine rejects ("unexpected call to WriteMessage should be
+// ReadMessage"). Returns false once the handshake is finished.
+func (ns *Noise) WriterTurn() bool {
+	if ns.HandshakeFinished() {
+		return false
+	}
+	even := ns.hs.MessageIndex()%2 == 0
+	if ns.init {
+		return even
+	}
+	return !even
+}
+
 // ChannelBinding returns a value that uniquely identifies the completed
 // handshake session — the Noise handshake hash. Both peers derive an identical
 // value, and it is bound to the full transcript (static keys + ephemerals + any

--- a/pkg/dmsg/noise/noise_test.go
+++ b/pkg/dmsg/noise/noise_test.go
@@ -281,3 +281,40 @@ func TestSealOpenWithNonce(t *testing.T) {
 	require.Equal(t, encN, nI.GetEncNonce(), "SealWithNonce must not advance encNonce")
 	require.Equal(t, decN, nR.GetDecNonce(), "OpenWithNonce must not advance decNonce")
 }
+
+// TestWriterTurn validates the handshake-turn accessor used by the mux per-frame
+// integration to avoid calling MakeHandshakeMessage out of turn (the bug that
+// broke live per-frame route groups: a responder writing msg2 before reading
+// msg1). Initiator writes first (msg1) then reads; responder reads (msg1) then
+// writes (msg2); neither may write when it is not their turn.
+func TestWriterTurn(t *testing.T) {
+	pkI, skI := cipher.GenerateKeyPair()
+	pkR, skR := cipher.GenerateKeyPair()
+	nI, err := New(HandshakeKK, Config{LocalPK: pkI, LocalSK: skI, RemotePK: pkR, Initiator: true})
+	require.NoError(t, err)
+	nR, err := New(HandshakeKK, Config{LocalPK: pkR, LocalSK: skR, RemotePK: pkI, Initiator: false})
+	require.NoError(t, err)
+
+	// Start of KK: initiator writes msg1, responder must NOT write yet.
+	require.True(t, nI.WriterTurn(), "initiator writes msg1 first")
+	require.False(t, nR.WriterTurn(), "responder must read msg1 before writing")
+
+	msg1, err := nI.MakeHandshakeMessage()
+	require.NoError(t, err)
+	// After writing msg1 the initiator reads next; the responder still owes a read.
+	require.False(t, nI.WriterTurn(), "initiator reads msg2 next")
+	require.False(t, nR.WriterTurn(), "responder still must read msg1")
+
+	require.NoError(t, nR.ProcessHandshakeMessage(msg1))
+	// Now it IS the responder's turn to write msg2.
+	require.True(t, nR.WriterTurn(), "responder writes msg2 after reading msg1")
+
+	msg2, err := nR.MakeHandshakeMessage()
+	require.NoError(t, err)
+	require.NoError(t, nI.ProcessHandshakeMessage(msg2))
+
+	// Handshake complete on both sides; neither writes further.
+	require.True(t, nI.HandshakeFinished() && nR.HandshakeFinished())
+	require.False(t, nI.WriterTurn())
+	require.False(t, nR.WriterTurn())
+}

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -2053,11 +2053,26 @@ func (rg *RouteGroup) nextPerFrameNoiseMsg() ([]byte, error) {
 		return rg.perFrameNoiseMsg, nil
 	}
 	if rg.ns == nil {
+		// Only the KK INITIATOR opens the session here (it writes msg1 first).
+		// A responder must READ the initiator's msg1 before it can write msg2 —
+		// that happens in handlePacket, which creates the session. Until then a
+		// responder has nothing to piggyback, so return no message rather than
+		// call MakeHandshakeMessage out of turn (which the noise state machine
+		// rejects: "unexpected call to WriteMessage should be ReadMessage").
+		if !rg.nsConf.Initiator {
+			return nil, nil
+		}
 		ns, err := noise.New(noise.HandshakeKK, rg.nsConf)
 		if err != nil {
 			return nil, err
 		}
 		rg.ns = ns
+	}
+	// Never write out of turn: only produce a message when the noise pattern says
+	// it is ours to write. A resend of an already-produced message returns the
+	// cached bytes above, so this only gates the FIRST production of each message.
+	if !rg.ns.WriterTurn() {
+		return nil, nil
 	}
 	msg, err := rg.ns.MakeHandshakeMessage()
 	if err != nil {
@@ -2122,7 +2137,18 @@ func (rg *RouteGroup) sendHandshake(encrypt bool) error {
 				// advertise a capability we can't honor.
 				return fmt.Errorf("per-frame noise handshake message: %w", mErr)
 			}
-			packet = routing.MakeHandshakePacketWithNoise(rule.NextRouteID(), encrypt, caps|pfn, msg)
+			if msg != nil {
+				packet = routing.MakeHandshakePacketWithNoise(rule.NextRouteID(), encrypt, caps|pfn, msg)
+			} else {
+				// No per-frame message to carry yet (responder that has not read
+				// the initiator's msg1). Send a plain handshake WITHOUT the
+				// CapPerFrameNoise bit this round — advertising it without a
+				// message would make the peer try to open a nil handshake. The
+				// responder emits msg2 (with the cap) from handlePacket once it
+				// has processed the forward handshake; the initiator retransmits
+				// until then.
+				packet = routing.MakeHandshakePacket(rule.NextRouteID(), encrypt, caps)
+			}
 		} else {
 			packet = routing.MakeHandshakePacket(rule.NextRouteID(), encrypt, caps)
 		}


### PR DESCRIPTION
Live per-frame route groups failed to establish with `noise: unexpected call to WriteMessage should be ReadMessage`. `nextPerFrameNoiseMsg` unconditionally created a session and called `MakeHandshakeMessage`, so a responder (or a re-ack firing before the forward handshake was processed) tried to write msg2 before reading msg1 — which the KK state machine rejects, aborting the handshake.

Adds `noise.WriterTurn()` (is the next handshake message ours to write?) and gates message production on it: the initiator opens the session and writes msg1; a responder produces nothing until `handlePacket` has read msg1 and it is its turn to write msg2. `sendHandshake` sends a plain handshake (no `CapPerFrameNoise` that round) when there is no message yet; the peers retransmit drives completion. Found via live testing of #4219/#4220. Adds `TestWriterTurn`. Developed with AI assistance (Claude).