### PR TITLE
feat(visor): expose per_frame_noise on route groups in visor state / mux info

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_info.go
+++ b/cmd/skywire-cli/commands/proxy/mux_info.go
@@ -108,9 +108,10 @@ type muxRouteGroupInfo struct {
 		DstPort int    `json:"dst_port"`
 		SrcPort int    `json:"src_port"`
 	} `json:"desc"`
-	MuxEnabled  bool         `json:"mux_enabled"`
-	SACKEnabled bool         `json:"sack_enabled"`
-	Legs        []muxLegInfo `json:"legs"`
+	MuxEnabled    bool         `json:"mux_enabled"`
+	SACKEnabled   bool         `json:"sack_enabled"`
+	PerFrameNoise bool         `json:"per_frame_noise"`
+	Legs          []muxLegInfo `json:"legs"`
 }
 
 type muxLegInfo struct {
@@ -191,11 +192,11 @@ func (t *muxRateTracker) render(cmd *cobra.Command, infos any) {
 	next := make(map[string]muxLegBytes)
 
 	for ri, rg := range rgs {
-		fmt.Printf("rg[%d] %s:%d → %s:%d  mux=%v sack=%v  legs=%d\n",
+		fmt.Printf("rg[%d] %s:%d → %s:%d  mux=%v sack=%v perframe=%v  legs=%d\n",
 			ri,
 			shortPK(rg.Desc.SrcPK), rg.Desc.SrcPort,
 			shortPK(rg.Desc.DstPK), rg.Desc.DstPort,
-			rg.MuxEnabled, rg.SACKEnabled, len(rg.Legs))
+			rg.MuxEnabled, rg.SACKEnabled, rg.PerFrameNoise, len(rg.Legs))
 
 		// Sort legs by index so the row order is stable across snapshots.
 		sort.SliceStable(rg.Legs, func(i, j int) bool { return rg.Legs[i].Index < rg.Legs[j].Index })

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -349,6 +349,11 @@ type MuxInfo struct {
 	MuxEnabled bool
 	// SACKEnabled is true when the peers negotiated SACK retx.
 	SACKEnabled bool
+	// PerFrameNoise is true when both edges negotiated CapPerFrameNoise and the
+	// mux is sealing/opening each DATA frame under its own sequence-nonce (the
+	// inverse-multiplexer path, network.EncryptConn bypassed). False means the
+	// group runs the classic stream-noise wrap.
+	PerFrameNoise bool
 	// Legs is in tps[] order. One entry per active mux leg.
 	Legs []MuxLeg
 }
@@ -401,6 +406,7 @@ func (rg *RouteGroup) MuxStats() MuxInfo {
 		info.MuxEnabled = true
 		info.SACKEnabled = rg.mux.sackEnabled
 	}
+	info.PerFrameNoise = rg.perFrameNoiseActive
 	tpsCopy := append([]*transport.ManagedTransport(nil), rg.tps...)
 	rg.mu.Unlock()
 

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -136,9 +136,10 @@ func muxRouteGroupInfoFrom(infos []router.MuxInfo) []MuxRouteGroupInfo {
 				DstPort: info.Desc.DstPort(),
 				SrcPort: info.Desc.SrcPort(),
 			},
-			MuxEnabled:  info.MuxEnabled,
-			SACKEnabled: info.SACKEnabled,
-			Legs:        make([]MuxLegInfo, 0, len(info.Legs)),
+			MuxEnabled:    info.MuxEnabled,
+			SACKEnabled:   info.SACKEnabled,
+			PerFrameNoise: info.PerFrameNoise,
+			Legs:          make([]MuxLegInfo, 0, len(info.Legs)),
 		}
 		for _, leg := range info.Legs {
 			entry.Legs = append(entry.Legs, MuxLegInfo{

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -284,10 +284,11 @@ type RouteGroupInfo struct {
 // MuxRouteGroupInfo is one route-group's mux state plus per-leg
 // counters. Returned by RouteGroupMuxInfo for 'cli proxy mux-info'.
 type MuxRouteGroupInfo struct {
-	Desc        routing.RouteDescriptorFields `json:"desc"`
-	MuxEnabled  bool                          `json:"mux_enabled"`
-	SACKEnabled bool                          `json:"sack_enabled"`
-	Legs        []MuxLegInfo                  `json:"legs"`
+	Desc          routing.RouteDescriptorFields `json:"desc"`
+	MuxEnabled    bool                          `json:"mux_enabled"`
+	SACKEnabled   bool                          `json:"sack_enabled"`
+	PerFrameNoise bool                          `json:"per_frame_noise"`
+	Legs          []MuxLegInfo                  `json:"legs"`
 }
 
 // MuxLegInfo is one route in a mux'd group.


### PR DESCRIPTION
Adds `PerFrameNoise` to `MuxInfo`/`MuxRouteGroupInfo` (json `per_frame_noise`), populated from the route groups live `perFrameNoiseActive`, so operators can see directly whether a group negotiated the per-frame inverse-mux vs the stream-noise wrap — via `visor state --jq ".mux_route_groups[].per_frame_noise"` and the `proxy mux info` line — instead of grepping debug logs. Developed with AI assistance (Claude).