### PR TITLE
feat(visor): widen visor state — mux distribution/reorder/agg-bytes + transport byte totals

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_info.go
+++ b/cmd/skywire-cli/commands/proxy/mux_info.go
@@ -108,10 +108,14 @@ type muxRouteGroupInfo struct {
 		DstPort int    `json:"dst_port"`
 		SrcPort int    `json:"src_port"`
 	} `json:"desc"`
-	MuxEnabled    bool         `json:"mux_enabled"`
-	SACKEnabled   bool         `json:"sack_enabled"`
-	PerFrameNoise bool         `json:"per_frame_noise"`
-	Legs          []muxLegInfo `json:"legs"`
+	MuxEnabled      bool         `json:"mux_enabled"`
+	SACKEnabled     bool         `json:"sack_enabled"`
+	PerFrameNoise   bool         `json:"per_frame_noise"`
+	Distribution    string       `json:"distribution,omitempty"`
+	ReorderPending  int          `json:"reorder_pending,omitempty"`
+	ReorderGapAgeMS float64      `json:"reorder_gap_age_ms,omitempty"`
+	WriteSeq        uint32       `json:"write_seq,omitempty"`
+	Legs            []muxLegInfo `json:"legs"`
 }
 
 type muxLegInfo struct {
@@ -197,6 +201,16 @@ func (t *muxRateTracker) render(cmd *cobra.Command, infos any) {
 			shortPK(rg.Desc.SrcPK), rg.Desc.SrcPort,
 			shortPK(rg.Desc.DstPK), rg.Desc.DstPort,
 			rg.MuxEnabled, rg.SACKEnabled, rg.PerFrameNoise, len(rg.Legs))
+		if rg.MuxEnabled {
+			// dist + reorder frontier: a rising pending with a growing gap age is
+			// the head-of-line-blocking stall signal for a black-holing leg.
+			gap := "0"
+			if rg.ReorderGapAgeMS > 0 {
+				gap = fmt.Sprintf("%.0fms", rg.ReorderGapAgeMS)
+			}
+			fmt.Printf("       dist=%s  reorder_pending=%d  gap_age=%s  write_seq=%d\n",
+				rg.Distribution, rg.ReorderPending, gap, rg.WriteSeq)
+		}
 
 		// Sort legs by index so the row order is stable across snapshots.
 		sort.SliceStable(rg.Legs, func(i, j int) bool { return rg.Legs[i].Index < rg.Legs[j].Index })

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -354,6 +354,20 @@ type MuxInfo struct {
 	// inverse-multiplexer path, network.EncryptConn bypassed). False means the
 	// group runs the classic stream-noise wrap.
 	PerFrameNoise bool
+	// Distribution names how the mux spreads outbound packets across its legs
+	// (the transportSelector weight mode: "auto", "round-robin", "weighted",
+	// "capacity", "latency-adaptive", "sticky:5tuple", "size-threshold",
+	// "dscp-priority"). Empty for a non-mux group.
+	Distribution string
+	// ReorderPending is the number of received packets currently buffered
+	// out-of-order (head-of-line-blocking depth); ReorderGapAge is how long the
+	// current reorder frontier gap has stayed open (0 when contiguous). A rising
+	// pending count with a growing gap age is a stalled/black-holing leg.
+	ReorderPending int
+	ReorderGapAge  time.Duration
+	// WriteSeq is the total DATA frames this mux has emitted outbound — a cheap
+	// aggregate send-progress counter across all legs.
+	WriteSeq uint32
 	// Legs is in tps[] order. One entry per active mux leg.
 	Legs []MuxLeg
 }
@@ -405,6 +419,10 @@ func (rg *RouteGroup) MuxStats() MuxInfo {
 	if rg.mux != nil {
 		info.MuxEnabled = true
 		info.SACKEnabled = rg.mux.sackEnabled
+		info.Distribution = rg.mux.distributionMode().String()
+		info.ReorderPending = rg.mux.reorderPending()
+		info.ReorderGapAge = rg.mux.gapAge()
+		info.WriteSeq = rg.mux.writeSeqValue()
 	}
 	info.PerFrameNoise = rg.perFrameNoiseActive
 	tpsCopy := append([]*transport.ManagedTransport(nil), rg.tps...)

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -585,6 +585,31 @@ func (m *routeMux) gapAge() time.Duration {
 	return m.reorderBuf.GapAge()
 }
 
+// reorderPending reports how many packets are currently buffered out-of-order
+// on the receive side (0 when the stream is contiguous). A climbing value while
+// a gap stays open is the head-of-line-blocking signal for a stalled leg.
+func (m *routeMux) reorderPending() int {
+	if m.reorderBuf == nil {
+		return 0
+	}
+	return m.reorderBuf.Pending()
+}
+
+// writeSeqValue returns the count of DATA frames this mux has emitted (the next
+// outgoing sequence number). A cheap aggregate outbound-progress counter.
+func (m *routeMux) writeSeqValue() uint32 {
+	return atomic.LoadUint32(&m.writeSeq)
+}
+
+// distributionMode returns the selector's current weight mode (how packets are
+// spread across the legs). WeightModeAuto when the selector is absent.
+func (m *routeMux) distributionMode() WeightMode {
+	if m.tpSelector == nil {
+		return WeightModeAuto
+	}
+	return m.tpSelector.Mode()
+}
+
 // sackMinInterval is the minimum spacing between receiver-side SACKs. It is
 // well under retxMinAge so a genuine loss is still signaled several times
 // before the sender's retransmit timer fires, while collapsing the flood of

--- a/pkg/router/transport_selector.go
+++ b/pkg/router/transport_selector.go
@@ -155,6 +155,31 @@ func (ts *transportSelector) Mode() WeightMode {
 	return ts.mode
 }
 
+// String renders the weight mode as the same lowercase token the routing-
+// policy DSL's DistributionMode uses, so an operator reading `visor state`
+// sees exactly the value they would set via a policy's `distribution=`.
+func (m WeightMode) String() string {
+	switch m {
+	case WeightModeAuto:
+		return "auto"
+	case WeightModeEqual:
+		return "round-robin"
+	case WeightModeExplicit:
+		return "weighted"
+	case WeightModeSizeThreshold:
+		return "size-threshold"
+	case WeightModeSticky5Tuple:
+		return "sticky:5tuple"
+	case WeightModeLatencyAdaptive:
+		return "latency-adaptive"
+	case WeightModeDSCPPriority:
+		return "dscp-priority"
+	case WeightModeCapacity:
+		return "capacity"
+	}
+	return "unknown"
+}
+
 // Rebuild recomputes the selection schedule from the current transport latencies.
 // Called periodically (e.g., every keep-alive cycle) and when transports change.
 // tps must not be modified concurrently (caller holds RouteGroup.mu or equivalent).

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -136,12 +137,18 @@ func muxRouteGroupInfoFrom(infos []router.MuxInfo) []MuxRouteGroupInfo {
 				DstPort: info.Desc.DstPort(),
 				SrcPort: info.Desc.SrcPort(),
 			},
-			MuxEnabled:    info.MuxEnabled,
-			SACKEnabled:   info.SACKEnabled,
-			PerFrameNoise: info.PerFrameNoise,
-			Legs:          make([]MuxLegInfo, 0, len(info.Legs)),
+			MuxEnabled:      info.MuxEnabled,
+			SACKEnabled:     info.SACKEnabled,
+			PerFrameNoise:   info.PerFrameNoise,
+			Distribution:    info.Distribution,
+			ReorderPending:  info.ReorderPending,
+			ReorderGapAgeMS: float64(info.ReorderGapAge) / float64(time.Millisecond),
+			WriteSeq:        info.WriteSeq,
+			Legs:            make([]MuxLegInfo, 0, len(info.Legs)),
 		}
 		for _, leg := range info.Legs {
+			entry.AggSentBytes += leg.SentBytes
+			entry.AggRecvBytes += leg.RecvBytes
 			entry.Legs = append(entry.Legs, MuxLegInfo{
 				Index:          leg.Index,
 				TransportID:    leg.TransportID,

--- a/pkg/visor/api_state.go
+++ b/pkg/visor/api_state.go
@@ -177,7 +177,10 @@ func (v *Visor) StateSnapshot() (*StateSnapshot, error) {
 		snap.Apps = apps
 	}
 
-	if tps, err := v.Transports(nil, nil, false); err != nil {
+	// logs=true so each TransportSummary.Log carries the transport's
+	// cumulative recv/sent byte counters — the passive throughput totals an
+	// operator debugging a slow/idle link wants, surfaced without a second call.
+	if tps, err := v.Transports(nil, nil, true); err != nil {
 		note("transports", err)
 	} else {
 		snap.Transports = tps

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -288,7 +288,26 @@ type MuxRouteGroupInfo struct {
 	MuxEnabled    bool                          `json:"mux_enabled"`
 	SACKEnabled   bool                          `json:"sack_enabled"`
 	PerFrameNoise bool                          `json:"per_frame_noise"`
-	Legs          []MuxLegInfo                  `json:"legs"`
+	// Distribution names how the mux spreads outbound packets across its legs
+	// (weight mode: "auto", "round-robin", "weighted", "capacity",
+	// "latency-adaptive", "sticky:5tuple", "size-threshold", "dscp-priority").
+	// Empty for a single-leg / non-mux group.
+	Distribution string `json:"distribution,omitempty"`
+	// ReorderPending is the number of received packets buffered out-of-order
+	// (head-of-line-blocking depth); ReorderGapAgeMS is how long the current
+	// reorder frontier gap has stayed open in ms (0 when contiguous). A rising
+	// pending count with a growing gap age marks a stalled/black-holing leg.
+	ReorderPending  int     `json:"reorder_pending,omitempty"`
+	ReorderGapAgeMS float64 `json:"reorder_gap_age_ms,omitempty"`
+	// WriteSeq is the total DATA frames this mux has emitted outbound — a cheap
+	// aggregate send-progress counter across all legs.
+	WriteSeq uint32 `json:"write_seq,omitempty"`
+	// AggSentBytes / AggRecvBytes are the rg-scoped totals summed across every
+	// leg (what this route group moved, distinct from per-transport totals that
+	// also count other groups sharing the transport).
+	AggSentBytes uint64       `json:"agg_sent_bytes,omitempty"`
+	AggRecvBytes uint64       `json:"agg_recv_bytes,omitempty"`
+	Legs         []MuxLegInfo `json:"legs"`
 }
 
 // MuxLegInfo is one route in a mux'd group.


### PR DESCRIPTION
Surfaces router/transport internals already computed but not exposed, so operators can diagnose mux aggregation/stalls directly from `visor state` instead of log-grepping. Per route group (and in `proxy mux info`): `distribution` (weight mode), `reorder_pending` + `reorder_gap_age_ms` (head-of-line depth/age), `write_seq`, `agg_sent_bytes`/`agg_recv_bytes`; and populates `transports[].log` byte counters. All additive JSON (omitempty), read under existing locks/atomics — no new cost. Developed with AI assistance (Claude).