### PR TITLE
fix(router): initiator now offers per-frame noise on its first handshake

### DIFF
--- a/pkg/router/perframe_noise_test.go
+++ b/pkg/router/perframe_noise_test.go
@@ -94,3 +94,25 @@ func TestPerFrameMuxDataPathRoundTrip(t *testing.T) {
 	delivered, _ := recv2.deliverData(bad.SequenceNumber()+1000, bad.DataPayloadAfterSeq())
 	require.Empty(t, delivered, "frame that fails AEAD open must not be delivered")
 }
+
+// TestPerFrameNoiseCapUsesEncryptArgNotField is a regression test for the bug
+// where the INITIATOR stripped CapPerFrameNoise (and its KK msg1) from its very
+// first handshake: perFrameNoiseCap gated on the rg.encrypt FIELD, which is only
+// set when a handshake is RECEIVED, so on the initiator's first send (before it
+// has received anything) the field was still false and per-frame was never
+// offered — the group silently fell back to stream noise. The cap must be
+// derived from the encrypt ARGUMENT that sendHandshake carries, independent of
+// the not-yet-set field.
+func TestPerFrameNoiseCapUsesEncryptArgNotField(t *testing.T) {
+	rg := &RouteGroup{perFrameNoiseWant: true}
+	// Field is false — exactly the initiator's state at first send.
+	require.False(t, rg.encrypt)
+	require.Equal(t, routing.CapPerFrameNoise, rg.perFrameNoiseCap(true),
+		"initiator must offer CapPerFrameNoise on its first encrypted send even though rg.encrypt is still false")
+	require.Equal(t, uint16(0), rg.perFrameNoiseCap(false),
+		"an unencrypted handshake must not offer per-frame noise")
+
+	rg.perFrameNoiseWant = false
+	require.Equal(t, uint16(0), rg.perFrameNoiseCap(true),
+		"per-frame noise must not be offered when the group does not want it")
+}

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -2058,8 +2058,18 @@ func (rg *RouteGroup) sendKeepAlive() error {
 
 // perFrameNoiseCap returns CapPerFrameNoise when we want per-frame noise and the
 // group is encrypted (per-frame noise IS the encryption); 0 otherwise.
-func (rg *RouteGroup) perFrameNoiseCap() uint16 {
-	if rg.perFrameNoiseWant && rg.encrypt {
+// perFrameNoiseCap reports the CapPerFrameNoise bit iff this side wants per-frame
+// noise AND the handshake being sent is encrypted. It takes `encrypt` as an
+// argument rather than reading rg.encrypt because rg.encrypt is only set when a
+// handshake is RECEIVED (handlePacket) — on the INITIATOR's first send (from
+// saveRouteGroupRules, before it has received anything) rg.encrypt is still its
+// zero value (false). Gating on the field there would strip the cap + noise
+// message from the initiator's msg1, so the responder never sees per-frame
+// offered and the whole group silently falls back to stream noise. sendHandshake
+// already carries the correct encrypt value as its argument (initiator: always
+// true; responder: rg.encrypt, which is set by then).
+func (rg *RouteGroup) perFrameNoiseCap(encrypt bool) uint16 {
+	if rg.perFrameNoiseWant && encrypt {
 		return routing.CapPerFrameNoise
 	}
 	return 0
@@ -2153,7 +2163,7 @@ func (rg *RouteGroup) sendHandshake(encrypt bool) error {
 		rule := rg.fwd[i]
 		caps := routing.CapMux | routing.CapSACK
 		var packet routing.Packet
-		if pfn := rg.perFrameNoiseCap(); pfn != 0 {
+		if pfn := rg.perFrameNoiseCap(encrypt); pfn != 0 {
 			msg, mErr := rg.nextPerFrameNoiseMsg()
 			if mErr != nil {
 				// Never silently drop to plaintext: if the per-frame noise


### PR DESCRIPTION
The initiator stripped `CapPerFrameNoise` and its KK msg1 from its very first handshake, so per-frame noise never negotiated even when both edges wanted it — `per_frame_noise` stayed `false` in `visor state` and every group fell back to stream noise.

Root cause: `perFrameNoiseCap` gated on the `rg.encrypt` struct field, which is only set when a handshake is *received* (`handlePacket`). The initiator sends its first handshake from `saveRouteGroupRules` *before* receiving anything, so the field was still `false` there. The fix derives the cap from the `encrypt` argument `sendHandshake` already carries (initiator: always true; responder: `rg.encrypt`, set by then). Includes a regression test.

Found via live testing: with both edges on the per-frame build, the route group established but `proxy mux info` showed `perframe=false`; tracing the handshake send path surfaced the field-vs-argument gap. Developed with AI assistance (Claude).