### PR TITLE
feat(proxy): per-leg goodput (bytes/sec) on status.skysocks + proxy tree + mux JSON

### DIFF
--- a/pkg/proxystatus/provider.go
+++ b/pkg/proxystatus/provider.go
@@ -64,8 +64,13 @@ type Leg struct {
 	SentBytes      uint64
 	RecvBytes      uint64
 	Retransmits    uint64
-	Alive          bool
-	Standby        bool
+	// GoodputBps is this leg's recent goodput — the EWMA of (sent+recv) bytes
+	// per second over the page's refresh window (~1s), i.e. the RATE the leg is
+	// moving now, distinct from the cumulative SentBytes/RecvBytes counters. 0
+	// until a second sample lands.
+	GoodputBps float64
+	Alive      bool
+	Standby    bool
 	// Hops is the leg's full forward route (every hop to the destination),
 	// full PKs, per-hop transport type + latency where known.
 	Hops []Hop

--- a/pkg/proxystatus/routetree.go
+++ b/pkg/proxystatus/routetree.go
@@ -85,7 +85,7 @@ func RouteTree(snap Snapshot) *bitree.Node {
 // summary into fixed columns, so R[n], the route-rtt and the ↑/↓ bandwidth line
 // up vertically across all routes instead of being ragged (only the whole block
 // was right-justified before).
-type sumWidths struct{ idx, rtt, up, down int }
+type sumWidths struct{ idx, rtt, up, down, gp int }
 
 // Fixed display widths (monospace cells) for the MUTABLE numeric fields of a
 // route's left summary — the route rtt and the ↑/↓ byte counts. These values
@@ -101,6 +101,11 @@ const (
 	rttColWidth = 6
 	// bwColWidth fits "0B↑" through "999.9K↑" / "15.3M↑" (compactBytes + arrow).
 	bwColWidth = 7
+	// gpColWidth fits the per-leg goodput rate cell, "—" through "999.9K/s" /
+	// "15.3M/s" (compactBytes + "/s"). Same pin-the-width reasoning as bwColWidth:
+	// the rate changes on every live push, so a fixed column keeps the tree that
+	// follows it column-stable.
+	gpColWidth = 9
 )
 
 // legSumWidths measures the widest R[n] identity across the legs (that count is
@@ -108,7 +113,7 @@ const (
 // value push) and pins the mutable numeric fields to their fixed column widths so
 // they never reflow as the values update. legSummary pads every field to these.
 func legSumWidths(legs []Leg) sumWidths {
-	w := sumWidths{rtt: rttColWidth, up: bwColWidth, down: bwColWidth}
+	w := sumWidths{rtt: rttColWidth, up: bwColWidth, down: bwColWidth, gp: gpColWidth}
 	for _, l := range legs {
 		if n := len(fmt.Sprintf("R[%d]", l.Index)); n > w.idx {
 			w.idx = n
@@ -186,7 +191,7 @@ func hopClassMap(snap Snapshot) map[string]string {
 // a template row that lines up with the columns of the tree beneath. Only the
 // page uses it; `proxy tree` renders headerless.
 func TreeHeader() (left, label string, cols []string) {
-	return "R[n] · state · route-rtt · bw ↑↓", "peer-pk", []string{"[type]", "tp-id", "tp-rtt"}
+	return "R[n] · state · route-rtt · bw ↑↓ · goodput/s", "peer-pk", []string{"[type]", "tp-id", "tp-rtt"}
 }
 
 // routeToNode turns one leg into a hop-chain right-branch carrying its left
@@ -233,7 +238,19 @@ func legSummary(l Leg, w sumWidths) string {
 	rtt := padLeftRunes(routeRTTCompact(l.RouteLatencyMS), w.rtt)
 	up := padLeftRunes(compactBytes(l.SentBytes)+"↑", w.up)
 	down := padLeftRunes(compactBytes(l.RecvBytes)+"↓", w.down)
-	return idx + " " + g + " " + rtt + " " + up + " " + down
+	gp := padLeftRunes(compactRate(l.GoodputBps), w.gp)
+	return idx + " " + g + " " + rtt + " " + up + " " + down + " " + gp
+}
+
+// compactRate formats a goodput rate (bytes/sec) for the fixed-width leg cell:
+// "12.4K/s" style via compactBytes, or "—" when the rate is zero/unmeasured
+// (no second sample yet, or an idle leg). The rate is the leg's recent goodput,
+// distinct from the cumulative ↑/↓ byte counters beside it.
+func compactRate(bps float64) string {
+	if bps <= 0 {
+		return "—"
+	}
+	return compactBytes(uint64(bps)) + "/s"
 }
 
 // padRightRunes/padLeftRunes pad s to n display columns (rune count), on the

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -38,7 +38,24 @@ type LegStats struct {
 	// the signal a routing policy needs to shed lossy intermediates and
 	// the scheduler needs to deweight them.
 	Retransmits uint64
+	// GoodputBps is this leg's recent goodput — the EWMA of (sent+recv)
+	// bytes per second over the telemetry refresh window (~1s for the
+	// status page). Distinct from the cumulative SentBytes/RecvBytes
+	// counters above: it is the RATE a throughput display (and a
+	// capacity-weighting policy) wants, not the lifetime total. 0 until a
+	// second sample lands. Sampled in snapshotLegs.
+	GoodputBps float64
 }
+
+const (
+	// goodputEWMAAlpha weights the newest goodput sample in the per-leg
+	// bytes/sec EWMA (snapshotLegs). Higher = more responsive, noisier.
+	goodputEWMAAlpha = 0.4
+	// goodputMinSampleNano is the minimum window between goodput samples: two
+	// observers refreshing closer than this reuse the stored rate rather than
+	// dividing a tiny byte delta by a tiny interval into a spurious spike.
+	goodputMinSampleNano = int64(250 * time.Millisecond)
+)
 
 type legCounters struct {
 	sentBytes   uint64 // atomic
@@ -51,6 +68,17 @@ type legCounters struct {
 	// recent throughput, used by WeightModeCapacity. Touched only
 	// under legMu in rebuildWeights, so it needs no atomic.
 	lastTotalBytes uint64
+	// Goodput-rate sampling (bytes/sec EWMA over the observer's refresh
+	// window), maintained by snapshotLegs — NOT the data path and NOT the
+	// capacity rebuild. lastRateBytes/lastRateNano snapshot sent+recv and the
+	// wall clock at the previous sample; the delta over the elapsed window,
+	// EWMA-smoothed, is goodputBps. Kept separate from lastTotalBytes (which
+	// the capacity rebuild resets on its own cadence) so the two samplers
+	// never disturb each other. Touched under legMu (snapshotLegs upgrades to
+	// a write lock for the sample), so no atomic needed.
+	lastRateBytes uint64
+	lastRateNano  int64
+	goodputBps    float64
 }
 
 // routeMux encapsulates route multiplexing state and logic.
@@ -497,24 +525,61 @@ func (m *routeMux) retransmitsAt(idx int) uint64 {
 	return 0
 }
 
-// snapshotLegs returns a stable copy of the current per-leg counters.
-// Atomic loads, no locking against in-flight increments — the
-// snapshot is point-in-time and the underlying counters keep moving.
+// snapshotLegs returns a stable copy of the current per-leg counters and, as a
+// side effect, samples each leg's goodput RATE (bytes/sec EWMA) over the window
+// since the previous snapshot. The byte/packet counters are point-in-time
+// atomic loads; the rate is maintained under legMu (a write lock) so concurrent
+// observers don't corrupt the per-leg sample state. Called at telemetry/UI
+// cadence (the status page's ~1s push, CLI mux-info), never on the data path.
 func (m *routeMux) snapshotLegs() []LegStats {
-	m.legMu.RLock()
+	now := time.Now().UnixNano()
+	m.legMu.Lock()
 	out := make([]LegStats, len(m.legs))
 	for i, c := range m.legs {
+		sent := atomic.LoadUint64(&c.sentBytes)
+		recv := atomic.LoadUint64(&c.recvBytes)
+		m.sampleGoodput(c, sent+recv, now)
 		out[i] = LegStats{
 			Index:       i,
-			SentBytes:   atomic.LoadUint64(&c.sentBytes),
+			SentBytes:   sent,
 			SentPackets: atomic.LoadUint64(&c.sentPackets),
-			RecvBytes:   atomic.LoadUint64(&c.recvBytes),
+			RecvBytes:   recv,
 			RecvPackets: atomic.LoadUint64(&c.recvPackets),
 			Retransmits: atomic.LoadUint64(&c.retransmits),
+			GoodputBps:  c.goodputBps,
 		}
 	}
-	m.legMu.RUnlock()
+	m.legMu.Unlock()
 	return out
+}
+
+// sampleGoodput updates leg c's goodput EWMA from the total (sent+recv) byte
+// count observed at wall-clock now (UnixNano). Caller holds legMu for writing.
+// The first observation only seeds the baseline (no rate emitted). To keep the
+// metric stable when several observers interleave, samples closer together than
+// goodputMinSampleNano are skipped and the stored rate is left unchanged.
+func (m *routeMux) sampleGoodput(c *legCounters, total uint64, now int64) {
+	if c.lastRateNano == 0 {
+		c.lastRateBytes = total
+		c.lastRateNano = now
+		return
+	}
+	elapsed := now - c.lastRateNano
+	if elapsed < goodputMinSampleNano {
+		return
+	}
+	var delta uint64
+	if total >= c.lastRateBytes {
+		delta = total - c.lastRateBytes
+	}
+	sample := float64(delta) / (float64(elapsed) / float64(time.Second))
+	if c.goodputBps == 0 {
+		c.goodputBps = sample
+	} else {
+		c.goodputBps = goodputEWMAAlpha*sample + (1-goodputEWMAAlpha)*c.goodputBps
+	}
+	c.lastRateBytes = total
+	c.lastRateNano = now
 }
 
 // wrapPayload creates a sequenced data packet and optionally stores it for retransmission.

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -149,6 +149,7 @@ func muxRouteGroupInfoFrom(infos []router.MuxInfo) []MuxRouteGroupInfo {
 		for _, leg := range info.Legs {
 			entry.AggSentBytes += leg.SentBytes
 			entry.AggRecvBytes += leg.RecvBytes
+			entry.AggGoodputBps += leg.GoodputBps
 			entry.Legs = append(entry.Legs, MuxLegInfo{
 				Index:          leg.Index,
 				TransportID:    leg.TransportID,
@@ -163,6 +164,7 @@ func muxRouteGroupInfoFrom(infos []router.MuxInfo) []MuxRouteGroupInfo {
 				RecvBytes:      leg.RecvBytes,
 				RecvPackets:    leg.RecvPackets,
 				Retransmits:    leg.Retransmits,
+				GoodputBps:     leg.GoodputBps,
 				Alive:          leg.Alive,
 				Standby:        leg.Standby,
 			})

--- a/pkg/visor/embedded_proxystatus.go
+++ b/pkg/visor/embedded_proxystatus.go
@@ -133,6 +133,7 @@ func (p *visorStatusProvider) StatusSnapshot(surface proxystatus.Surface) (proxy
 					SentBytes:      leg.SentBytes,
 					RecvBytes:      leg.RecvBytes,
 					Retransmits:    leg.Retransmits,
+					GoodputBps:     leg.GoodputBps,
 					Alive:          leg.Alive,
 					Standby:        leg.Standby,
 					Hops:           proxyHopsFrom(leg.Hops),

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -305,9 +305,13 @@ type MuxRouteGroupInfo struct {
 	// AggSentBytes / AggRecvBytes are the rg-scoped totals summed across every
 	// leg (what this route group moved, distinct from per-transport totals that
 	// also count other groups sharing the transport).
-	AggSentBytes uint64       `json:"agg_sent_bytes,omitempty"`
-	AggRecvBytes uint64       `json:"agg_recv_bytes,omitempty"`
-	Legs         []MuxLegInfo `json:"legs"`
+	AggSentBytes uint64 `json:"agg_sent_bytes,omitempty"`
+	AggRecvBytes uint64 `json:"agg_recv_bytes,omitempty"`
+	// AggGoodputBps is the route-group's recent goodput — the sum of the
+	// per-leg goodput RATES (bytes/sec), i.e. what the whole group is moving
+	// right now, distinct from the cumulative AggSentBytes/AggRecvBytes totals.
+	AggGoodputBps float64      `json:"agg_goodput_bps,omitempty"`
+	Legs          []MuxLegInfo `json:"legs"`
 }
 
 // MuxLegInfo is one route in a mux'd group.
@@ -332,8 +336,13 @@ type MuxLegInfo struct {
 	// transport is closed; Standby=true for a warm standby (rules kept,
 	// not sending). Surfaced for the per-leg telemetry harness.
 	Retransmits uint64 `json:"retransmits"`
-	Alive       bool   `json:"alive"`
-	Standby     bool   `json:"standby"`
+	// GoodputBps is this leg's recent goodput — the EWMA of (sent+recv) bytes
+	// per second over the telemetry refresh window (~1s for the status page).
+	// The RATE the leg is currently moving, as opposed to the cumulative
+	// SentBytes/RecvBytes totals. 0 until a second sample lands.
+	GoodputBps float64 `json:"goodput_bps,omitempty"`
+	Alive      bool    `json:"alive"`
+	Standby    bool    `json:"standby"`
 	// Hops is the leg's full forward route (every hop to the destination),
 	// with full PKs and per-hop transport type + latency where known.
 	Hops []MuxHopInfo `json:"hops,omitempty"`


### PR DESCRIPTION
Adds a recent per-leg goodput RATE (EWMA of (sent+recv) bytes/sec over the telemetry window) alongside the cumulative byte counters the proxy status already showed. Plumbed `router LegStats.GoodputBps` → `MuxLegInfo.goodput_bps` + `MuxRouteGroupInfo.agg_goodput_bps` → `proxystatus.Leg` → the status.skysocks route tree (new goodput/s column) and `skywire cli proxy tree`. Sampled in `snapshotLegs` under `legMu` (alpha=0.4, 250ms min window), kept separate from the `WeightModeCapacity` byte-delta sampler.

This gives operators a direct per-route throughput readout, and a single authoritative goodput number to later unify the three current ad-hoc recent-throughput derivations (preset `adaptRecvRate`, capacity rebuild, this) onto — relevant to making adaptive leg promotion goodput-gated. Developed with AI assistance (Claude).