### PR TITLE
fix(router): new aux legs enter warm standby on add, engine promotes them paced

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -242,6 +242,13 @@ type RouteGroup struct {
 	rotationApplyAddForward func(excludeHops []string)
 	rotationInterval        time.Duration
 
+	// standbyNewLegs mirrors onto the mux (SetStandbyNewLegs) so newly-grown
+	// aux legs enter warm standby on add and the rotation engine promotes them
+	// one per tick, goodput-gated, instead of every dialed leg going hot at
+	// once and churning the group. Set true when SetRotation wires a promoting
+	// engine. See routeMux.standbyNewLegs.
+	standbyNewLegs bool
+
 	// selfHealAdd restores the multiplexed degree in the background when a
 	// leg dies. pruneDeadTransports drops the dead leg (surviving legs
 	// immediately carry its share via the selector), then maybeSelfHeal
@@ -810,6 +817,15 @@ func (rg *RouteGroup) SetRotation(hook RotationHook, applyAdd, applyAddForward f
 	rg.rotationApplyAdd = applyAdd
 	rg.rotationApplyAddForward = applyAddForward
 	rg.rotationInterval = interval
+	// A promoting rotation engine is wired: route new aux legs through the warm
+	// standby pool on add so the engine admits them one per tick, goodput-gated,
+	// instead of every dialed leg going hot at once. Propagate to the mux if it
+	// already exists; otherwise mux creation in handleHandshake applies it.
+	promoting := interval > 0 && hook != nil
+	rg.standbyNewLegs = promoting
+	if promoting && rg.mux != nil {
+		rg.mux.SetStandbyNewLegs(true)
+	}
 	rg.mu.Unlock()
 	// Start the rotation goroutine now (startOffServiceLoops fired
 	// during initial setup before SetRotation was called, so the
@@ -2328,6 +2344,13 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 			if remoteCaps&routing.CapMux != 0 {
 				sack := remoteCaps&routing.CapSACK != 0
 				rg.mux = newRouteMux(rg.logger, sack)
+				// If a promoting rotation engine was already wired (SetRotation
+				// before the handshake), route new aux legs through warm standby
+				// on add. Set BEFORE growLegs so it governs any aux legs already
+				// present in tps[]; the primary (index 0) is always active.
+				if rg.standbyNewLegs {
+					rg.mux.SetStandbyNewLegs(true)
+				}
 				// rg.tps already has the primary transport at this
 				// point; size the leg counters to match. Subsequent
 				// AppendRoute calls (mux 2/N+) extend the slice via

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -144,6 +144,19 @@ type routeMux struct {
 	// tear-and-rebuild. Parallel to ready[]; grown/compacted in lockstep.
 	// Guarded by legMu. See docs/warm_standby_legs_rfc.md.
 	standby []bool
+
+	// standbyNewLegs makes every NEWLY-grown aux leg (index > 0) enter the
+	// warm-standby pool instead of going straight into the active send set.
+	// The primary leg (index 0) is never affected. Set only when a promoting
+	// rotation engine is wired (SetRotation), so the engine's paced,
+	// goodput-gated growActive/promote path admits legs one per tick as its
+	// throughput signal warrants — instead of every dialed leg going hot the
+	// instant it receives its first inbound packet (markLegReady), which
+	// floods the active set faster than the reactive stall gate can demote and
+	// churns the group into collapse. When false (no rotation engine) new legs
+	// stay active-on-add so a non-adaptive group never strands aux legs in
+	// standby. Guarded by legMu.
+	standbyNewLegs bool
 }
 
 // reorderWindow bounds how far the receiver's reorder buffer will hold
@@ -328,9 +341,21 @@ func (m *routeMux) growLegs(n int) {
 		m.ready = append(m.ready, len(m.ready) == 0)
 	}
 	for len(m.standby) < n {
-		// New legs are active, never standby.
-		m.standby = append(m.standby, false)
+		// The primary leg (index 0, the first append) is always active. Aux
+		// legs enter warm standby when standbyNewLegs is set (a promoting
+		// rotation engine is wired), so the engine promotes them one per tick
+		// as its goodput signal warrants instead of all going hot at once.
+		m.standby = append(m.standby, m.standbyNewLegs && len(m.standby) > 0)
 	}
+	m.legMu.Unlock()
+}
+
+// SetStandbyNewLegs controls whether newly-grown aux legs enter warm standby on
+// add (see the standbyNewLegs field). Called by the route group when a promoting
+// rotation engine is wired, before aux legs are appended. Idempotent.
+func (m *routeMux) SetStandbyNewLegs(v bool) {
+	m.legMu.Lock()
+	m.standbyNewLegs = v
 	m.legMu.Unlock()
 }
 

--- a/pkg/router/route_mux_standby_test.go
+++ b/pkg/router/route_mux_standby_test.go
@@ -80,3 +80,44 @@ func TestMuxStandbyCompactedOnLegRemoval(t *testing.T) {
 		t.Error("the compacted standby leg must remain unselectable")
 	}
 }
+
+// TestMuxStandbyNewLegsOnAdd pins the standby-on-add behavior: with
+// SetStandbyNewLegs(true) (a promoting rotation engine wired), every NEWLY-grown
+// aux leg enters warm standby so the engine promotes them one per tick,
+// goodput-gated, instead of every dialed leg going hot the instant it becomes
+// ready — the flood that churned the group into collapse. The primary leg (0) is
+// always active. With the default (false) new legs stay active-on-add.
+func TestMuxStandbyNewLegsOnAdd(t *testing.T) {
+	// Default: new legs active-on-add (no regression for non-adaptive groups).
+	def := &routeMux{}
+	def.growLegs(3)
+	for _, idx := range []int{0, 1, 2} {
+		if def.isLegStandby(idx) {
+			t.Fatalf("default: leg %d must be active-on-add, got standby", idx)
+		}
+	}
+
+	// Promoting engine wired: aux legs (index > 0) enter standby on add; the
+	// primary stays active.
+	m := &routeMux{}
+	m.SetStandbyNewLegs(true)
+	m.growLegs(4)
+	if m.isLegStandby(0) {
+		t.Error("primary leg 0 must never enter standby on add")
+	}
+	for _, idx := range []int{1, 2, 3} {
+		if !m.isLegStandby(idx) {
+			t.Errorf("aux leg %d must enter standby on add when standbyNewLegs is set", idx)
+		}
+	}
+	// Even after a leg becomes ready (inbound packet), a standby leg is not
+	// selectable until the engine promotes it (clears the flag).
+	m.markLegReady(1)
+	if m.legReadyAt(1) {
+		t.Error("ready-but-standby aux leg must not be selectable until promoted")
+	}
+	m.setLegStandby(1, false) // engine promotes
+	if !m.legReadyAt(1) {
+		t.Error("promoted, ready aux leg must be selectable")
+	}
+}


### PR DESCRIPTION
Every dialed aux leg went straight into the active send set the instant it received its first inbound packet (`markLegReady`). An adaptive group that dials many disjoint legs therefore floods its active set faster than the reactive throughput stall-gate can demote the slow ones. Each unproven active leg opens a reorder frontier gap (its sequences lag), and with dozens going hot at once the head-of-line stalls compound and the group churns into collapse.

Observed live (both edges on the per-frame build): active legs ran up 9→52, reorder `gap_age` to ~573ms, and the route group collapsed mid-transfer — throughput bursty (8.6 MB/s) but unsustained.

Fix: route new aux legs through the warm-standby pool on add. When a promoting rotation engine is wired (`SetRotation`), `growLegs` marks each new aux leg (index > 0) standby, so the engine’s existing `growActive`/promote path admits them **one per tick, gated on the per-leg goodput EWMA it already computes** (`adaptRecvRate` stall gate, #4229). The active set grows smoothly and only admits legs that deliver; a slow leg never gets a share, so it can’t open a reorder gap. The primary leg (0) is always active; with no rotation engine the default is unchanged (active-on-add) so non-adaptive groups never strand aux legs in standby. Worst case degrades to stable single-leg throughput, not churn. Emergency failover is unaffected (the selector still falls back to any alive standby leg). Developed with AI assistance (Claude).