### PR TITLE
fix(router): timer-driven reorder flush so a stalled leg degrades gracefully

### DIFF
--- a/pkg/router/reorder.go
+++ b/pkg/router/reorder.go
@@ -153,6 +153,27 @@ func (rb *reorderBuffer) Insert(seq uint32, data []byte) [][]byte {
 	return delivered
 }
 
+// FlushIfStalled releases a frontier gap that has stayed open past reorderTimeout
+// WITHOUT waiting for a new packet to arrive. The skip check inside Insert only
+// fires on the next out-of-order insert; a leg that goes fully silent delivers
+// nothing to trigger it, so the buffer would otherwise wedge indefinitely — a gap
+// held open with no arrivals to release it (observed live as a reorder gap aging
+// to ~10s while the download stalled to zero). A periodic caller invokes this so a
+// stalled reorder degrades to the surviving legs' rate promptly instead of
+// wedging. Only releases when skip-capable (per-frame noise) — matching Insert's
+// skip gate, since releasing a gap on a stateful stream-noise mux would desync the
+// cipher. Returns the flushed payloads in sequence order, or nil when there is
+// nothing to release.
+func (rb *reorderBuffer) FlushIfStalled() [][]byte {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	if rb.skipCapable && !rb.gapSince.IsZero() && len(rb.buf) > 0 &&
+		time.Since(rb.gapSince) > reorderTimeout {
+		return rb.flushAll()
+	}
+	return nil
+}
+
 // GapAge reports how long the current frontier gap has been open, or 0 if the
 // buffer is contiguous (no gap). The route group's fast data-progress prune uses
 // it to tell a genuinely stuck receiver (a gap held while SACK retransmits) from

--- a/pkg/router/reorder_test.go
+++ b/pkg/router/reorder_test.go
@@ -156,3 +156,34 @@ func TestReorderNeverSkipsAcrossTimeout(t *testing.T) {
 		t.Fatalf("pending=%d after full drain, want 0", rb.Pending())
 	}
 }
+
+// TestReorderBuffer_FlushIfStalled pins the timer-driven flush: a frontier gap
+// held past reorderTimeout with NO new inserts (the in-Insert skip never fires)
+// must be released by FlushIfStalled — but only when skip-capable (per-frame),
+// since releasing a gap on a stateful stream-noise mux would desync the cipher.
+func TestReorderBuffer_FlushIfStalled(t *testing.T) {
+	orig := reorderTimeout
+	reorderTimeout = 20 * time.Millisecond
+	defer func() { reorderTimeout = orig }()
+
+	// Not skip-capable: never releases, even when stalled.
+	rb := newReorderBuffer(64)
+	assert.Equal(t, [][]byte{[]byte("a")}, rb.Insert(0, []byte("a"))) // delivered in order
+	_ = rb.Insert(2, []byte("c"))                    // gap at seq 1, buffered
+	time.Sleep(40 * time.Millisecond)
+	assert.Nil(t, rb.FlushIfStalled(), "non-skip-capable buffer must never release a gap")
+	assert.Equal(t, 1, rb.Pending(), "seq 2 still held")
+
+	// Skip-capable: releases the stalled gap without a triggering insert.
+	sb := newReorderBuffer(64)
+	sb.SetSkipCapable(true)
+	got := sb.Insert(0, []byte("a"))
+	assert.Equal(t, [][]byte{[]byte("a")}, got)
+	_ = sb.Insert(2, []byte("c")) // gap at seq 1
+	assert.Nil(t, sb.FlushIfStalled(), "gap not yet aged past reorderTimeout")
+	time.Sleep(40 * time.Millisecond)
+	flushed := sb.FlushIfStalled()
+	assert.Equal(t, [][]byte{[]byte("c")}, flushed, "stalled gap released past seq 1")
+	assert.Equal(t, 0, sb.Pending(), "buffer drained after flush")
+	assert.Nil(t, sb.FlushIfStalled(), "nothing left to release")
+}

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -57,6 +57,12 @@ const (
 	// interleave (which closes in well under a second) never trips it; short
 	// enough to react quickly once a leg genuinely stops delivering its share.
 	legDataStallGapAge = 3 * time.Second
+	// reorderFlushInterval is how often the receive side checks for a reorder
+	// frontier gap that has stalled past reorderTimeout with no arrivals to
+	// trigger the in-Insert skip (see RouteGroup.reorderFlushServiceFn). Shorter
+	// than reorderTimeout (1.5s) so a wedged buffer is released within ~one
+	// reorderTimeout of going silent, not left to hang until the next packet.
+	reorderFlushInterval = 500 * time.Millisecond
 )
 
 var (
@@ -1338,6 +1344,11 @@ func (rg *RouteGroup) startOffServiceLoops() {
 	// reorder gap. Restores mux throughput to the reliable legs' rate instead of
 	// limping at the fragile leg's retransmit tax.
 	go rg.servicePacketLoop("leg-dataprogress", legDataProgressInterval, rg.legDataProgressServiceFn, nil)
+	// Timer-driven reorder flush: release a per-frame reorder frontier gap that
+	// has stalled past reorderTimeout when no packet arrives to trigger the
+	// in-Insert skip. A no-op for non-per-frame groups (flushStalledReorder gates
+	// on skipCapable), so it is safe to start unconditionally.
+	go rg.servicePacketLoop("reorder-flush", reorderFlushInterval, rg.reorderFlushServiceFn, nil)
 	// Note: Automatic ping loop removed. Latency is now measured once at transport creation.
 	// Rotation loop is NOT started here — startOffServiceLoops runs
 	// during initial route-group setup, before the router-side
@@ -1645,6 +1656,36 @@ func (rg *RouteGroup) legLivenessServiceFn(_ time.Duration) {
 // drops the last active leg, keeps a shared transport open, and a false positive
 // merely triggers a self-heal re-dial (see pruneLivenessDeadLegs). Standby legs
 // are excluded (they aren't sent to, so zero recv is expected).
+// reorderFlushServiceFn periodically releases a reorder frontier gap that has
+// stalled past reorderTimeout so a silent/dead leg degrades to the surviving legs'
+// rate instead of wedging the stream. The skip-flush inside reorder.Insert only
+// runs when a packet arrives to trigger it; a leg that goes fully silent delivers
+// nothing, so without this the gap ages unbounded (observed live at ~10s while the
+// download stalled to zero). Only per-frame-noise groups release (skipCapable) —
+// flushStalledReorder is a no-op otherwise. Released payloads are pushed to readCh
+// on the SAME watched-close path as handleDataPacket so a close can't deadlock.
+func (rg *RouteGroup) reorderFlushServiceFn(_ time.Duration) {
+	if rg.isClosed() || rg.mux == nil || rg.isRemoteClosed() {
+		return
+	}
+	delivered := rg.mux.flushStalledReorder()
+	if len(delivered) == 0 {
+		return
+	}
+	rg.logger.Debugf("reorder flush: released %d buffered payloads past a stalled leg", len(delivered))
+	for _, d := range delivered {
+		select {
+		case <-rg.closed:
+			return
+		case <-rg.remoteClosed:
+			return
+		case rg.readCh <- d:
+		case <-time.After(30 * time.Second):
+			rg.logger.Warn("reorder flush: dropping payload, readCh full for 30s (application not reading)")
+		}
+	}
+}
+
 func (rg *RouteGroup) legDataProgressServiceFn(_ time.Duration) {
 	if rg.isClosed() || rg.mux == nil {
 		return

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -666,6 +666,23 @@ func (m *routeMux) deliverData(seq uint32, data []byte) (delivered [][]byte, gap
 	return delivered, gapDetected
 }
 
+// flushStalledReorder releases a reorder frontier gap that has stalled past
+// reorderTimeout with no arrivals to trigger the in-Insert skip (see
+// reorderBuffer.FlushIfStalled), then advances the SACK tracker to the new
+// contiguous frontier exactly as deliverData does. Returns the released payloads
+// in order (nil when nothing is stalled). A no-op unless the group negotiated
+// per-frame noise (skipCapable), so it is safe to call on every group.
+func (m *routeMux) flushStalledReorder() [][]byte {
+	if m.reorderBuf == nil {
+		return nil
+	}
+	delivered := m.reorderBuf.FlushIfStalled()
+	if len(delivered) > 0 && m.sackEnabled && m.sackTracker != nil {
+		m.sackTracker.AdvanceContiguous(m.reorderBuf.NextSeq())
+	}
+	return delivered
+}
+
 // gapAge exposes the reorder buffer's current frontier-gap age (0 if the stream
 // is contiguous). Used by the route group's fast data-progress prune.
 func (m *routeMux) gapAge() time.Duration {


### PR DESCRIPTION
The per-frame reorder skip-flush only ran *inside* `reorder.Insert`, firing on the next out-of-order packet to arrive. A leg that goes fully silent delivers nothing to trigger it, so the frontier gap ages unbounded and the stream wedges to zero — observed live as a reorder `gap_age` of ~10s while a download stalled and the connection dropped mid-transfer.

Adds a periodic release: `FlushIfStalled()` runs the same skip gate (skip-capable + gap held past `reorderTimeout`) without a triggering insert; the mux wrapper advances the SACK tracker like `deliverData`; a 500ms `reorder-flush` service loop pushes released payloads to `readCh` on the same watched-close path as `handleDataPacket`. No-op for non-per-frame groups (gated on `skipCapable`).

Net: a silent/dead legs gap is released within ~one `reorderTimeout` of going quiet, the buffer delivers past it, and SACK/TCP recovers the skipped sequences — the proxy degrades to the surviving legs rate instead of wedging. This is the graceful-degradation half of the mux-stability work. Developed with AI assistance (Claude).