### PR TITLE
fix(lint): rf/store test compile break + datagram/gosec/gofmt

### DIFF
--- a/pkg/deployment/rf/store/graph_test.go
+++ b/pkg/deployment/rf/store/graph_test.go
@@ -59,6 +59,10 @@ func (m *mockStore) GetNumberOfTransports(context.Context) (map[tptypes.Type]int
 func (m *mockStore) GetAllTransports(context.Context, bool) ([]*transport.Entry, error) {
 	return nil, nil
 }
+func (m *mockStore) GetTransportSummary(context.Context, bool) (*tpdstore.TransportSummary, error) {
+	return &tpdstore.TransportSummary{}, nil
+}
+
 func (m *mockStore) Close() {}
 
 func (m *mockStore) UpdateBandwidth(_ context.Context, _ string, _ cipher.PubKey, _, _ uint64) error {

--- a/pkg/router/datagram_route_group.go
+++ b/pkg/router/datagram_route_group.go
@@ -247,7 +247,7 @@ func (dg *DatagramRouteGroup) WriteTo(data []byte, addr net.Addr) (int, error) {
 		return 0, ErrPayloadTooBig
 	}
 	if addr != nil {
-		if want := dg.RemoteAddr(); want != nil && addr.String() != want.String() {
+		if want := dg.RemoteAddr(); addr.String() != want.String() {
 			return 0, fmt.Errorf("datagram-route-group: WriteTo addr %s does not match group remote %s", addr, want)
 		}
 	}

--- a/pkg/router/reorder_test.go
+++ b/pkg/router/reorder_test.go
@@ -169,7 +169,7 @@ func TestReorderBuffer_FlushIfStalled(t *testing.T) {
 	// Not skip-capable: never releases, even when stalled.
 	rb := newReorderBuffer(64)
 	assert.Equal(t, [][]byte{[]byte("a")}, rb.Insert(0, []byte("a"))) // delivered in order
-	_ = rb.Insert(2, []byte("c"))                    // gap at seq 1, buffered
+	_ = rb.Insert(2, []byte("c"))                                     // gap at seq 1, buffered
 	time.Sleep(40 * time.Millisecond)
 	assert.Nil(t, rb.FlushIfStalled(), "non-skip-capable buffer must never release a gap")
 	assert.Equal(t, 1, rb.Pending(), "seq 2 still held")

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -360,8 +360,9 @@ func getHTTPClient(ctx context.Context, v *Visor, service string) (*http.Client,
 		if err != nil {
 			return nil, fmt.Errorf("error getting AvailableServers: %w", err)
 		}
-		// randomize dmsg servers list
-		rand.Shuffle(len(servers), func(i, j int) {
+		// randomize dmsg servers list for load distribution (not security-
+		// sensitive — a weak RNG is fine and crypto/rand would be needless).
+		rand.Shuffle(len(servers), func(i, j int) { //nolint:gosec // non-crypto shuffle for dmsg-server load distribution
 			servers[i], servers[j] = servers[j], servers[i]
 		})
 		for _, server := range servers {


### PR DESCRIPTION
Clears CI lint/compile failures found by a full-repo `golangci-lint run ./...`:

- **`pkg/deployment/rf/store`** — the test `mockStore` was missing `GetTransportSummary`, so the package test binary failed to compile (a CI-blocking `typecheck` failure). Added the method.
- **`datagram_route_group.go` SA4023** — dropped the always-true `want != nil` (`RemoteAddr` never returns a nil interface).
- **`init.go`** — justified `//nolint:gosec` on the dmsg-server shuffle (non-crypto load distribution).
- gofmt on `reorder_test.go`.

A follow-up PR will clear the remaining unrelated lint debt (errcheck/misspell/staticcheck/unparam). Developed with AI assistance (Claude).