### PR TITLE
fix(lint): clear develop golangci-lint debt

### DIFF
--- a/cmd/dmsg/dmsg-socks5/commands/dmsg-socks5.go
+++ b/cmd/dmsg/dmsg-socks5/commands/dmsg-socks5.go
@@ -296,8 +296,7 @@ var proxyCmd = &cobra.Command{
 		}
 		proxyListenAddr := fmt.Sprintf("127.0.0.1:%d", proxyPort)
 		dlog.Infof("Serving SOCKS5 proxy on %s", proxyListenAddr)
-		if err := server.ListenAndServe("tcp", proxyListenAddr); err != nil {
-			dlog.Fatalf("Error serving SOCKS5 proxy: %v", err)
-		}
+		// ListenAndServe blocks and only ever returns a non-nil error.
+		dlog.Fatalf("Error serving SOCKS5 proxy: %v", server.ListenAndServe("tcp", proxyListenAddr))
 	},
 }

--- a/cmd/dmsg/dmsgcurl/commands/dmsgcurl.go
+++ b/cmd/dmsg/dmsgcurl/commands/dmsgcurl.go
@@ -135,7 +135,7 @@ var RootCmd = &cobra.Command{
 				os.Exit(errorCode["COULDNT_RESOLVE_PROXY"])
 			}
 			transport := &http.Transport{
-				Dial: dialer.Dial,
+				DialContext: dialer.(proxy.ContextDialer).DialContext,
 			}
 			httpClient = &http.Client{
 				Transport: transport,

--- a/cmd/dmsg/dmsghttp/commands/dmsghttp.go
+++ b/cmd/dmsg/dmsghttp/commands/dmsghttp.go
@@ -118,7 +118,7 @@ func server() {
 			dlog.WithError(err).Fatal("Error creating SOCKS5 dialer")
 		}
 		transport := &http.Transport{
-			Dial: dialer.Dial,
+			DialContext: dialer.(proxy.ContextDialer).DialContext,
 		}
 		httpClient = &http.Client{
 			Transport: transport,

--- a/cmd/dmsg/dmsgip/commands/dmsgip.go
+++ b/cmd/dmsg/dmsgip/commands/dmsgip.go
@@ -95,7 +95,7 @@ var RootCmd = &cobra.Command{
 		defer cancel()
 
 		httpClient = &http.Client{}
-		var dialer proxy.Dialer = proxy.Direct
+		var dialer proxy.Dialer
 
 		if proxyAddr != "" {
 			dialer, err = proxy.SOCKS5("tcp", proxyAddr, nil, proxy.Direct)
@@ -103,7 +103,7 @@ var RootCmd = &cobra.Command{
 				dlog.Fatalf("Error creating SOCKS5 dialer: %v", err)
 			}
 			transport := &http.Transport{
-				Dial: dialer.Dial,
+				DialContext: dialer.(proxy.ContextDialer).DialContext,
 			}
 			httpClient = &http.Client{
 				Transport: transport,

--- a/cmd/dmsg/dmsgweb/commands/dmsgweb.go
+++ b/cmd/dmsg/dmsgweb/commands/dmsgweb.go
@@ -159,7 +159,7 @@ dmsgweb conf file detected: ` + dwcfg
 			if err != nil {
 				dlog.WithError(err).Fatal("Error creating SOCKS5 dialer")
 			}
-			outerHTTP = &http.Client{Transport: &http.Transport{Dial: d.Dial}}
+			outerHTTP = &http.Client{Transport: &http.Transport{DialContext: d.(proxy.ContextDialer).DialContext}}
 		} else {
 			outerHTTP = &http.Client{}
 		}

--- a/cmd/dmsg/dmsgweb/commands/dmsgwebsrv.go
+++ b/cmd/dmsg/dmsgweb/commands/dmsgwebsrv.go
@@ -117,7 +117,7 @@ func server() {
 			dlog.WithError(err).Fatal("Error creating SOCKS5 dialer")
 		}
 		transport := &http.Transport{
-			Dial: dialer.Dial,
+			DialContext: dialer.(proxy.ContextDialer).DialContext,
 		}
 		httpClient = &http.Client{
 			Transport: transport,

--- a/cmd/skywire-cli/commands/log/log.go
+++ b/cmd/skywire-cli/commands/log/log.go
@@ -164,6 +164,7 @@ var logCmd = &cobra.Command{
 			return
 		}
 		//randomize the order of the survey collection - workaround for hanging
+		//nolint:gosec // non-crypto shuffle to spread collection order, not security-sensitive
 		rand.Shuffle(len(uptimes), func(i, j int) {
 			uptimes[i], uptimes[j] = uptimes[j], uptimes[i]
 		})

--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -1739,15 +1739,12 @@ func buildRouter() *gin.Engine {
 		r1.GET("/index.html", mainPage)
 		// Login chain auto-setup
 		if loginNode == "auto" {
-			addr, cleanup, err := ensureLoginChain(wd)
-			if err != nil {
-				fmt.Printf("Warning: login chain auto-setup failed: %v\n", err)
-				fmt.Println("Continuing without login chain.")
-				loginNode = ""
-			} else {
-				defer cleanup()
-				loginNode = addr
-			}
+			// --login-node auto is no longer supported; ensureLoginChain
+			// always returns an error pointing at the standalone command.
+			_, _, err := ensureLoginChain(wd)
+			fmt.Printf("Warning: login chain auto-setup failed: %v\n", err)
+			fmt.Println("Continuing without login chain.")
+			loginNode = ""
 		}
 
 		// Set login chain variables for the login routes

--- a/cmd/svc/config-bootstrapper/commands/root.go
+++ b/cmd/svc/config-bootstrapper/commands/root.go
@@ -171,7 +171,6 @@ HTTP Endpoints:
 			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
 			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
 			Log:                 logger,
-			DisableDHT:          true,
 		})
 		if err != nil {
 			logger.WithError(err).Fatal("failed to start listeners")

--- a/cmd/svc/uptime-tracker/commands/root.go
+++ b/cmd/svc/uptime-tracker/commands/root.go
@@ -292,7 +292,6 @@ HTTP Endpoints:
 			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
 			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
 			Log:                 logger,
-			DisableDHT:          true,
 			OnDmsgServersUpdated: func(s []string) {
 				utAPI.DmsgServers = s
 			},

--- a/pkg/app/appcommon/log_store_native.go
+++ b/pkg/app/appcommon/log_store_native.go
@@ -174,6 +174,9 @@ func (l *bBoltLogStore) Fire(entry *log.Entry) error {
 	defer l.mx.Unlock()
 
 	p, err := entry.String()
+	if err != nil {
+		return err
+	}
 	var substitution = ""
 	str := re.ReplaceAllString(p, substitution)
 

--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -580,7 +580,8 @@ func (r *SkywireNetworker) ListenContext(ctx context.Context, addr Addr) (net.Li
 
 	if atomic.CompareAndSwapInt32(&r.isServing, 0, 1) {
 		go func() {
-			if err := r.serveRouteGroup(ctx); err != nil && !errors.Is(err, net.ErrClosed) {
+			// serveRouteGroup only ever returns a non-nil error.
+			if err := r.serveRouteGroup(ctx); !errors.Is(err, net.ErrClosed) {
 				r.log.WithError(err).Error("serveRouteGroup stopped unexpectedly.")
 			}
 		}()

--- a/pkg/cxo/node/swarm.go
+++ b/pkg/cxo/node/swarm.go
@@ -308,6 +308,7 @@ func (s *Swarm) addPeers(peers []msg.PeerInfo) {
 	peers = validPeers
 
 	// Shuffle and cap peers
+	//nolint:gosec // non-crypto peer shuffle for even feed distribution, not security-sensitive
 	mathrand.Shuffle(len(peers), func(i, j int) {
 		peers[i], peers[j] = peers[j], peers[i]
 	})
@@ -529,6 +530,7 @@ func (s *Swarm) randomPeers(count int, filters ...peerFilter) []Peer {
 	}
 
 	var (
+		//nolint:gosec // non-crypto random peer selection for load distribution, not security-sensitive
 		peerIdx = mathrand.Perm(len(filteredPeers))[:count]
 		peers   = make([]Peer, len(peerIdx))
 	)

--- a/pkg/cxo/skyobject/registry/refs_iterate_test.go
+++ b/pkg/cxo/skyobject/registry/refs_iterate_test.go
@@ -843,6 +843,7 @@ func TestRefs_DescendFrom(t *testing.T) {
 		}
 
 		err = refs.DescendFrom(pack, 1,
+			//nolint:unparam // signature required by registry.IterateFunc callback
 			func(i int, hash cipher.SHA256) (err error) {
 				if !(i == 0 || i == 1) {
 					t.Error("wrong index given", i)

--- a/pkg/deployment/sd/api/api.go
+++ b/pkg/deployment/sd/api/api.go
@@ -827,6 +827,7 @@ func serviceAddrFromParam(r *http.Request) (servicedisc.SWAddr, error) {
 func sampleRandom(services []servicedisc.Service, n int) []servicedisc.Service {
 	result := make([]servicedisc.Service, len(services))
 	copy(result, services)
+	//nolint:gosec // non-crypto random sampling for load distribution across services, not security-sensitive
 	rand.Shuffle(len(result), func(i, j int) {
 		result[i], result[j] = result[j], result[i]
 	})

--- a/pkg/deployment/sd/api/cxo_publisher.go
+++ b/pkg/deployment/sd/api/cxo_publisher.go
@@ -47,7 +47,7 @@
 // # Heartbeat short-circuit
 //
 // SD's register/heartbeat rate is high. The worker holds the live
-// per-type service set and, on a re-register, compares the new marshalled
+// per-type service set and, on a re-register, compares the new marshaled
 // Service against the stored one; when the materially-visible content is
 // unchanged it skips the re-encode entirely, so a steady heartbeat stream
 // does not churn the tree.
@@ -254,7 +254,7 @@ func (p *ServicesCXOPublisher) PutEntry(svc *servicedisc.Service) {
 	svcType := svc.Type
 	pk := svc.Addr.PubKey()
 	p.submit(func() {
-		// Heartbeat short-circuit: a re-register whose marshalled Service
+		// Heartbeat short-circuit: a re-register whose marshaled Service
 		// is byte-identical to what we already hold changes nothing a
 		// subscriber sees, so skip the re-encode entirely.
 		if cur := p.state[svcType]; cur != nil && bytes.Equal(cur[pk], body) {
@@ -313,12 +313,7 @@ func (p *ServicesCXOPublisher) flushType(svcType string) {
 		}
 		return
 	}
-	blob, err := encodeServicesBatch(svcs)
-	if err != nil {
-		p.log.WithError(err).WithField("path", path).Debug("Failed to encode services batch leaf")
-		p.recordError(err)
-		return
-	}
+	blob := encodeServicesBatch(svcs)
 	if err := p.pub.Put(path, blob); err != nil {
 		p.log.WithError(err).WithField("path", path).Debug("Failed to publish services batch leaf")
 		p.recordError(err)
@@ -329,8 +324,8 @@ func (p *ServicesCXOPublisher) flushType(svcType string) {
 // leaf body: a JSON array of the services, sorted by PK so an unchanged
 // set re-encodes to identical bytes (a CXO wire no-op), then version-
 // framed + gzipped. The array is assembled by concatenating the already-
-// marshalled per-service bodies, so each service is encoded exactly once.
-func encodeServicesBatch(svcs map[cipher.PubKey][]byte) ([]byte, error) {
+// marshaled per-service bodies, so each service is encoded exactly once.
+func encodeServicesBatch(svcs map[cipher.PubKey][]byte) []byte {
 	pks := make([]cipher.PubKey, 0, len(svcs))
 	for pk := range svcs {
 		pks = append(pks, pk)
@@ -345,7 +340,7 @@ func encodeServicesBatch(svcs map[cipher.PubKey][]byte) ([]byte, error) {
 		payload = append(payload, svcs[pk]...)
 	}
 	payload = append(payload, ']')
-	return cxoutils.FrameGzip(servicesBatchVersion, payload), nil
+	return cxoutils.FrameGzip(servicesBatchVersion, payload)
 }
 
 func (p *ServicesCXOPublisher) recordError(err error) {

--- a/pkg/deployment/sd/api/cxo_publisher_batch_test.go
+++ b/pkg/deployment/sd/api/cxo_publisher_batch_test.go
@@ -56,10 +56,7 @@ func TestBatchLeafCountIsPerType(t *testing.T) {
 	// Every type leaf must decode back to exactly its service set.
 	total := 0
 	for svcType, svcs := range p.state {
-		blob, err := encodeServicesBatch(svcs)
-		if err != nil {
-			t.Fatalf("encode type %s: %v", svcType, err)
-		}
+		blob := encodeServicesBatch(svcs)
 		version, payload, ok := cxoutils.UnframeGzip(blob)
 		if !ok || version != servicesBatchVersion {
 			t.Fatalf("unframe type %s: ok=%v version=%d", svcType, ok, version)
@@ -92,14 +89,8 @@ func TestServicesBatchEncodeDeterministic(t *testing.T) {
 		pk, _ := cipher.GenerateKeyPair()
 		p.stateSet("vpn", pk, mustSvc(t, "vpn", pk))
 	}
-	a, err := encodeServicesBatch(p.state["vpn"])
-	if err != nil {
-		t.Fatal(err)
-	}
-	b, err := encodeServicesBatch(p.state["vpn"])
-	if err != nil {
-		t.Fatal(err)
-	}
+	a := encodeServicesBatch(p.state["vpn"])
+	b := encodeServicesBatch(p.state["vpn"])
 	if string(a) != string(b) {
 		t.Fatal("encodeServicesBatch not deterministic for an unchanged set")
 	}

--- a/pkg/dmsg/disc/cxo_entry_test.go
+++ b/pkg/dmsg/disc/cxo_entry_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/skycoin/skywire/pkg/cipher"
 )
 
@@ -51,8 +53,8 @@ func TestCXOEntryClient_NilResolverPassesThrough(t *testing.T) {
 
 func TestCXOEntryClient_HitServesFromCXO(t *testing.T) {
 	var pk, srv cipher.PubKey
-	_ = pk.Set("02e40731f3ab6d11d31c466429297f4869f299a7821108409c5e36b840253e4ba7")
-	_ = srv.Set("02190003862c24f69e2cf47e1cf0efaa3dc1d866ba6a24067de34c363058212c73")
+	require.NoError(t, pk.Set("02e40731f3ab6d11d31c466429297f4869f299a7821108409c5e36b840253e4ba7"))
+	require.NoError(t, srv.Set("02190003862c24f69e2cf47e1cf0efaa3dc1d866ba6a24067de34c363058212c73"))
 
 	resolved := clientEntry(pk, srv)
 	stub := &stubAPIClient{entry: nil, err: errors.New("HTTP should not be called")}
@@ -74,7 +76,7 @@ func TestCXOEntryClient_HitServesFromCXO(t *testing.T) {
 
 func TestCXOEntryClient_MissFallsBackToHTTP(t *testing.T) {
 	var pk cipher.PubKey
-	_ = pk.Set("02e40731f3ab6d11d31c466429297f4869f299a7821108409c5e36b840253e4ba7")
+	require.NoError(t, pk.Set("02e40731f3ab6d11d31c466429297f4869f299a7821108409c5e36b840253e4ba7"))
 
 	httpEntry := clientEntry(pk)
 	stub := &stubAPIClient{entry: httpEntry}
@@ -96,7 +98,7 @@ func TestCXOEntryClient_MissFallsBackToHTTP(t *testing.T) {
 
 func TestCXOEntryClient_HitWithoutDelegatedServersFallsBack(t *testing.T) {
 	var pk cipher.PubKey
-	_ = pk.Set("02e40731f3ab6d11d31c466429297f4869f299a7821108409c5e36b840253e4ba7")
+	require.NoError(t, pk.Set("02e40731f3ab6d11d31c466429297f4869f299a7821108409c5e36b840253e4ba7"))
 
 	// Resolver "hits" but the entry has no delegated servers — useless
 	// for dialing, so the wrapped client must still be consulted.

--- a/pkg/dmsg/discovery/api/cxo_publisher.go
+++ b/pkg/dmsg/discovery/api/cxo_publisher.go
@@ -27,7 +27,7 @@
 // Encoding is JSON+gzip, not fixed-layout binary: a client's disc.Entry
 // carries a signature and a variable-length delegated-server list, so it
 // is the "awkward for binary" case — unlike telemetrywire's fixed 53-byte
-// rows. The per-server array is JSON-marshalled (entries sorted by client
+// rows. The per-server array is JSON-marshaled (entries sorted by client
 // PK so unchanged content re-encodes to identical bytes → a wire no-op on
 // CXO's content-addressed store), then framed with a leading version byte
 // and gzipped (cxoutils.FrameGzip). The version byte gates the format:
@@ -365,12 +365,7 @@ func (p *ClientsByServerCXOPublisher) flushServers(dirty map[cipher.PubKey]struc
 			}
 			continue
 		}
-		blob, err := encodeClientsBatch(clients)
-		if err != nil {
-			p.log.WithError(err).WithField("path", path).Debug("Failed to encode clients-by-server batch leaf")
-			p.recordError(err)
-			continue
-		}
+		blob := encodeClientsBatch(clients)
 		if err := p.pub.Put(path, blob); err != nil {
 			p.log.WithError(err).WithField("path", path).Debug("Failed to publish clients-by-server batch leaf")
 			p.recordError(err)
@@ -382,10 +377,10 @@ func (p *ClientsByServerCXOPublisher) flushServers(dirty map[cipher.PubKey]struc
 // leaf body: a JSON array of the clients' disc.Entry objects, sorted by
 // client PK so an unchanged set re-encodes to identical bytes (a CXO
 // wire no-op), then version-framed + gzipped. The array is assembled by
-// concatenating the already-marshalled per-client entry bodies, so each
+// concatenating the already-marshaled per-client entry bodies, so each
 // client is encoded exactly once (on the caller's goroutine, in
-// PublishSetEntry) rather than re-marshalled here.
-func encodeClientsBatch(clients map[cipher.PubKey][]byte) ([]byte, error) {
+// PublishSetEntry) rather than re-marshaled here.
+func encodeClientsBatch(clients map[cipher.PubKey][]byte) []byte {
 	pks := make([]cipher.PubKey, 0, len(clients))
 	for pk := range clients {
 		pks = append(pks, pk)
@@ -400,7 +395,7 @@ func encodeClientsBatch(clients map[cipher.PubKey][]byte) ([]byte, error) {
 		payload = append(payload, clients[pk]...)
 	}
 	payload = append(payload, ']')
-	return cxoutils.FrameGzip(clientsByServerBatchVersion, payload), nil
+	return cxoutils.FrameGzip(clientsByServerBatchVersion, payload)
 }
 
 func (p *ClientsByServerCXOPublisher) recordError(err error) {

--- a/pkg/dmsg/discovery/api/cxo_publisher_batch_test.go
+++ b/pkg/dmsg/discovery/api/cxo_publisher_batch_test.go
@@ -73,10 +73,7 @@ func TestBatchLeafCountIsPerServer(t *testing.T) {
 	// Every server leaf must decode back to exactly its client set.
 	total := 0
 	for srv, clients := range p.state {
-		blob, err := encodeClientsBatch(clients)
-		if err != nil {
-			t.Fatalf("encode server %s: %v", srv.Hex(), err)
-		}
+		blob := encodeClientsBatch(clients)
 		version, payload, ok := cxoutils.UnframeGzip(blob)
 		if !ok || version != clientsByServerBatchVersion {
 			t.Fatalf("unframe server %s: ok=%v version=%d", srv.Hex(), ok, version)
@@ -105,14 +102,8 @@ func TestBatchEncodeDeterministic(t *testing.T) {
 		clientPK, _ := cipher.GenerateKeyPair()
 		p.stateSet(srv, clientPK, mustEntry(t, clientPK, []cipher.PubKey{srv}))
 	}
-	a, err := encodeClientsBatch(p.state[srv])
-	if err != nil {
-		t.Fatal(err)
-	}
-	b, err := encodeClientsBatch(p.state[srv])
-	if err != nil {
-		t.Fatal(err)
-	}
+	a := encodeClientsBatch(p.state[srv])
+	b := encodeClientsBatch(p.state[srv])
 	if string(a) != string(b) {
 		t.Fatal("encodeClientsBatch not deterministic for an unchanged set")
 	}

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -578,8 +578,8 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 		<-ctx.Done()
 		_ = lis.Close() //nolint:errcheck
 	}()
-	err = srv.Serve(lis)
-	if err != nil && !errors.Is(err, net.ErrClosed) {
+	// srv.Serve blocks and only ever returns a non-nil error.
+	if err = srv.Serve(lis); !errors.Is(err, net.ErrClosed) {
 		return fmt.Errorf("SOCKS5 serve: %w", err)
 	}
 	return nil

--- a/pkg/services/ar/ar.go
+++ b/pkg/services/ar/ar.go
@@ -191,7 +191,6 @@ func (s *service) Run(ctx context.Context) error {
 		EmbeddedDmsgServers: embeddedServers,
 		SurveyWhitelist:     surveyWL,
 		Log:                 logger,
-		DisableDHT:          true,
 		OnDmsgServersUpdated: func(svrs []string) {
 			arAPI.DmsgServers = svrs
 		},

--- a/pkg/services/rf/rf.go
+++ b/pkg/services/rf/rf.go
@@ -217,7 +217,6 @@ func (s *service) Run(ctx context.Context) error {
 		EmbeddedDmsgServers: embeddedServers,
 		SurveyWhitelist:     surveyWL,
 		Log:                 logger,
-		DisableDHT:          true,
 		OnDmsgServersUpdated: func(svrs []string) {
 			rfAPI.DmsgServers = svrs
 		},

--- a/pkg/services/sd/sd.go
+++ b/pkg/services/sd/sd.go
@@ -174,7 +174,6 @@ func (s *service) Run(ctx context.Context) error {
 		EmbeddedDmsgServers: embeddedServers,
 		SurveyWhitelist:     surveyWL,
 		Log:                 log,
-		DisableDHT:          true,
 		OnDmsgServersUpdated: func(svrs []string) {
 			sdAPI.DmsgServers = svrs
 		},

--- a/pkg/services/tpd/tpd.go
+++ b/pkg/services/tpd/tpd.go
@@ -236,7 +236,6 @@ func (s *service) Run(ctx context.Context) error {
 		EmbeddedDmsgServers: embeddedServers,
 		SurveyWhitelist:     surveyWL,
 		Log:                 logger,
-		DisableDHT:          true,
 		OnDmsgServersUpdated: func(s []string) {
 			tpdAPI.DmsgServers = s
 		},

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -492,7 +492,8 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 		_ = lis.Close() //nolint:errcheck
 	}()
 
-	if err := srv.Serve(lis); err != nil && !errors.Is(err, net.ErrClosed) {
+	// srv.Serve blocks and only ever returns a non-nil error.
+	if err := srv.Serve(lis); !errors.Is(err, net.ErrClosed) {
 		return fmt.Errorf("SOCKS5 serve: %w", err)
 	}
 	return nil

--- a/pkg/skysocks/server.go
+++ b/pkg/skysocks/server.go
@@ -129,10 +129,9 @@ func (s *Server) Serve(l net.Listener) error {
 		}
 
 		go func() {
-			if err := s.socks.Serve(session); err != nil {
-				if s.appCl != nil {
-					s.appCl.Log().Errorf("Failed to start SOCKS5 server: %v", err)
-				}
+			// socks.Serve blocks and only ever returns a non-nil error.
+			if err := s.socks.Serve(session); s.appCl != nil {
+				s.appCl.Log().Errorf("Failed to start SOCKS5 server: %v", err)
 			}
 		}()
 	}

--- a/pkg/skysocks/server_test.go
+++ b/pkg/skysocks/server_test.go
@@ -76,7 +76,7 @@ func TestProxy(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := &http.Client{Transport: &http.Transport{Dial: proxyDial.Dial}}
+	c := &http.Client{Transport: &http.Transport{DialContext: proxyDial.(proxy.ContextDialer).DialContext}}
 	res, err := c.Get(ts.URL)
 	require.NoError(t, err)
 

--- a/pkg/visor/visorconfig/v1_runtime.go
+++ b/pkg/visor/visorconfig/v1_runtime.go
@@ -436,7 +436,6 @@ func updateStringArg(conf *Launcher, appName, argName, value string) bool {
 
 			if value == "" {
 				conf.Apps[i].Args = append(conf.Apps[i].Args[:j], conf.Apps[i].Args[j+2:]...)
-				j-- //nolint:ineffassign
 			} else {
 				conf.Apps[i].Args[j+1] = value
 			}


### PR DESCRIPTION
Clears the remaining golangci-lint findings on `develop` so CI lint goes green: errcheck, gosec (G404), misspell, staticcheck (SA1019/SA4006/SA4023), unparam, and ineffassign.

Notable fixes:
- errcheck: check the errors from `pk.Set`/`srv.Set` in a disc test (check-blank enabled).
- gosec G404: justified `//nolint:gosec` on non-crypto shuffles used for peer/service/collection ordering (load distribution, not security-sensitive).
- misspell: `marshalled` -> `marshaled` in CXO-publisher comments.
- staticcheck SA1019: `http.Transport.Dial` -> `DialContext` via `proxy.ContextDialer`; drop the deprecated no-op `svcmode.Config.DisableDHT` field.
- staticcheck SA4023: remove always-true `err != nil` comparisons on functions that only ever return a non-nil error (blocking `Serve`/accept loops, the `ensureLoginChain` stub).
- staticcheck SA4006: check the previously-discarded `entry.String()` error; drop a dead `j--`.
- unparam: drop the always-nil error return from `encodeServicesBatch`/`encodeClientsBatch` and update all callers; justified `//nolint:unparam` on a test closure whose signature is required by `registry.IterateFunc`.

Verified: `golangci-lint run ./...` reports 0 issues, `go build .` succeeds, and `go test` passes for every package whose non-test code changed.

Developed with AI assistance (Claude).