### PR TITLE
fix(router): reorder never skips a gap — fixes proxied-stream corruption (bad record mac)

### DIFF
--- a/pkg/router/perframe_noise_test.go
+++ b/pkg/router/perframe_noise_test.go
@@ -46,7 +46,6 @@ func TestPerFrameMuxDataPathRoundTrip(t *testing.T) {
 
 	recv := newRouteMux(log, true)
 	recv.open = func(seq uint32, ct []byte) ([]byte, error) { return nR.OpenWithNonce(uint64(seq), ct) }
-	recv.reorderBuf.SetSkipCapable(true)
 
 	const routeID = routing.RouteID(42)
 	const n = 200

--- a/pkg/router/reorder.go
+++ b/pkg/router/reorder.go
@@ -38,22 +38,6 @@ type reorderBuffer struct {
 	// and stopped delivering, and flushing (lossy) is preferable to stalling
 	// the stream forever while liveness prunes that leg.
 	maxGap int
-
-	// skipCapable is set when the group negotiated per-frame noise. Each mux
-	// DATA frame is then an INDEPENDENT AEAD unit (sealed under its sequence), so
-	// delivering PAST a missing sequence no longer desyncs any cipher — the whole
-	// reason the no-skip rule existed. With it set, a frontier gap that stays open
-	// past reorderTimeout (a leg genuinely stuck, SACK not yet refilled) is
-	// RELEASED (delivered lossy-but-moving) instead of held, and the OOM
-	// force-flush becomes a clean skip rather than a cipher-corrupting one.
-	skipCapable bool
-}
-
-// SetSkipCapable enables/disables the per-frame-noise skip path (see skipCapable).
-func (rb *reorderBuffer) SetSkipCapable(v bool) {
-	rb.mu.Lock()
-	rb.skipCapable = v
-	rb.mu.Unlock()
 }
 
 func newReorderBuffer(maxGap int) *reorderBuffer {
@@ -101,16 +85,16 @@ func (rb *reorderBuffer) Insert(seq uint32, data []byte) [][]byte {
 		// buffer over a live leg, so the buffer drains in order with the cipher
 		// intact. A leg that stays dead is removed by leg-liveness pruning, after
 		// which its unacked seqs are retransmitted on the survivors. reorderTimeout
-		// is retained as the stall threshold for that diagnostics/prune path.
-		// Per-frame noise: each frame is its own AEAD unit, so releasing a gap no
-		// longer desyncs a cipher. A frontier gap held past reorderTimeout means a
-		// leg is stuck and SACK has not refilled in time; release it (lossy but
-		// moving) rather than hold. In normal operation SACK retransmit refills the
-		// gap well within reorderTimeout, so this only fires on a genuinely stuck
-		// leg — exactly the case that used to wedge a stream-noise mux at 0 goodput.
-		if rb.skipCapable && !rb.gapSince.IsZero() && time.Since(rb.gapSince) > reorderTimeout {
-			return rb.flushAll()
-		}
+		// is retained as the stall threshold for the diagnostics/prune path and to
+		// drive a timer-based SACK (RouteGroup.reorderStallServiceFn) that asks the
+		// sender to RETRANSMIT the stuck sequence on a live leg — filling the gap IN
+		// ORDER. There is deliberately NO time-based SKIP here: the RouteGroup is a
+		// reliable, ordered net.Conn (a TCP/TLS stream rides it), so delivering PAST
+		// a missing sequence leaves a HOLE in the byte stream and the upper protocol
+		// dies ("bad record mac"). Per-frame noise makes each FRAME independently
+		// decryptable, but the reassembled STREAM must still be gapless — so a gap is
+		// only ever closed by the missing seq actually arriving (skew or retransmit),
+		// never by skipping it.
 
 		// Emergency OOM backstop only: with reliable legs the missing seq arrives
 		// (via skew or SACK retransmit) and drains the buffer, so this never trips
@@ -151,27 +135,6 @@ func (rb *reorderBuffer) Insert(seq uint32, data []byte) [][]byte {
 	}
 
 	return delivered
-}
-
-// FlushIfStalled releases a frontier gap that has stayed open past reorderTimeout
-// WITHOUT waiting for a new packet to arrive. The skip check inside Insert only
-// fires on the next out-of-order insert; a leg that goes fully silent delivers
-// nothing to trigger it, so the buffer would otherwise wedge indefinitely — a gap
-// held open with no arrivals to release it (observed live as a reorder gap aging
-// to ~10s while the download stalled to zero). A periodic caller invokes this so a
-// stalled reorder degrades to the surviving legs' rate promptly instead of
-// wedging. Only releases when skip-capable (per-frame noise) — matching Insert's
-// skip gate, since releasing a gap on a stateful stream-noise mux would desync the
-// cipher. Returns the flushed payloads in sequence order, or nil when there is
-// nothing to release.
-func (rb *reorderBuffer) FlushIfStalled() [][]byte {
-	rb.mu.Lock()
-	defer rb.mu.Unlock()
-	if rb.skipCapable && !rb.gapSince.IsZero() && len(rb.buf) > 0 &&
-		time.Since(rb.gapSince) > reorderTimeout {
-		return rb.flushAll()
-	}
-	return nil
 }
 
 // GapAge reports how long the current frontier gap has been open, or 0 if the

--- a/pkg/router/reorder_test.go
+++ b/pkg/router/reorder_test.go
@@ -157,33 +157,26 @@ func TestReorderNeverSkipsAcrossTimeout(t *testing.T) {
 	}
 }
 
-// TestReorderBuffer_FlushIfStalled pins the timer-driven flush: a frontier gap
-// held past reorderTimeout with NO new inserts (the in-Insert skip never fires)
-// must be released by FlushIfStalled — but only when skip-capable (per-frame),
-// since releasing a gap on a stateful stream-noise mux would desync the cipher.
-func TestReorderBuffer_FlushIfStalled(t *testing.T) {
+// TestReorderBuffer_NeverSkipsGap pins the reliability contract: the reorder
+// buffer NEVER delivers past a frontier gap on a time basis, no matter how long
+// the gap has been open. The RouteGroup is a reliable ordered stream (TCP/TLS
+// rides it), so skipping a sequence would leave a hole that corrupts the upper
+// protocol (the observed "bad record mac"). The gap is only ever closed by the
+// missing sequence actually arriving — recovery comes from SACK retransmit + the
+// leg-dataprogress prune, not from skipping.
+func TestReorderBuffer_NeverSkipsGap(t *testing.T) {
 	orig := reorderTimeout
 	reorderTimeout = 20 * time.Millisecond
 	defer func() { reorderTimeout = orig }()
 
-	// Not skip-capable: never releases, even when stalled.
 	rb := newReorderBuffer(64)
-	assert.Equal(t, [][]byte{[]byte("a")}, rb.Insert(0, []byte("a"))) // delivered in order
+	assert.Equal(t, [][]byte{[]byte("a")}, rb.Insert(0, []byte("a"))) // seq 0 in order
 	_ = rb.Insert(2, []byte("c"))                                     // gap at seq 1, buffered
-	time.Sleep(40 * time.Millisecond)
-	assert.Nil(t, rb.FlushIfStalled(), "non-skip-capable buffer must never release a gap")
-	assert.Equal(t, 1, rb.Pending(), "seq 2 still held")
-
-	// Skip-capable: releases the stalled gap without a triggering insert.
-	sb := newReorderBuffer(64)
-	sb.SetSkipCapable(true)
-	got := sb.Insert(0, []byte("a"))
-	assert.Equal(t, [][]byte{[]byte("a")}, got)
-	_ = sb.Insert(2, []byte("c")) // gap at seq 1
-	assert.Nil(t, sb.FlushIfStalled(), "gap not yet aged past reorderTimeout")
-	time.Sleep(40 * time.Millisecond)
-	flushed := sb.FlushIfStalled()
-	assert.Equal(t, [][]byte{[]byte("c")}, flushed, "stalled gap released past seq 1")
-	assert.Equal(t, 0, sb.Pending(), "buffer drained after flush")
-	assert.Nil(t, sb.FlushIfStalled(), "nothing left to release")
+	_ = rb.Insert(3, []byte("d"))                                     // still buffered behind the gap
+	time.Sleep(40 * time.Millisecond)                                 // well past reorderTimeout
+	assert.Equal(t, 2, rb.Pending(), "gap must stay held past reorderTimeout — never skip")
+	assert.True(t, rb.GapAge() > reorderTimeout, "gap is aged but still held, not released")
+	// The missing seq 1 finally arrives → in-order delivery of 1,2,3.
+	assert.Equal(t, [][]byte{[]byte("b"), []byte("c"), []byte("d")}, rb.Insert(1, []byte("b")))
+	assert.Equal(t, 0, rb.Pending(), "buffer drained in order once the gap filled")
 }

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -57,12 +57,12 @@ const (
 	// interleave (which closes in well under a second) never trips it; short
 	// enough to react quickly once a leg genuinely stops delivering its share.
 	legDataStallGapAge = 3 * time.Second
-	// reorderFlushInterval is how often the receive side checks for a reorder
-	// frontier gap that has stalled past reorderTimeout with no arrivals to
-	// trigger the in-Insert skip (see RouteGroup.reorderFlushServiceFn). Shorter
-	// than reorderTimeout (1.5s) so a wedged buffer is released within ~one
-	// reorderTimeout of going silent, not left to hang until the next packet.
-	reorderFlushInterval = 500 * time.Millisecond
+	// reorderStallInterval is how often the receive side checks for a reorder
+	// frontier gap stuck past reorderTimeout and, if so, emits a SACK to prompt
+	// the sender to retransmit the missing seq IN ORDER (see
+	// RouteGroup.reorderStallServiceFn). Shorter than reorderTimeout (1.5s) so a
+	// stalled gap is nudged within ~one reorderTimeout of going silent.
+	reorderStallInterval = 500 * time.Millisecond
 )
 
 var (
@@ -1357,11 +1357,10 @@ func (rg *RouteGroup) startOffServiceLoops() {
 	// reorder gap. Restores mux throughput to the reliable legs' rate instead of
 	// limping at the fragile leg's retransmit tax.
 	go rg.servicePacketLoop("leg-dataprogress", legDataProgressInterval, rg.legDataProgressServiceFn, nil)
-	// Timer-driven reorder flush: release a per-frame reorder frontier gap that
-	// has stalled past reorderTimeout when no packet arrives to trigger the
-	// in-Insert skip. A no-op for non-per-frame groups (flushStalledReorder gates
-	// on skipCapable), so it is safe to start unconditionally.
-	go rg.servicePacketLoop("reorder-flush", reorderFlushInterval, rg.reorderFlushServiceFn, nil)
+	// Timer-driven reorder-stall recovery: when a frontier gap is stuck past
+	// reorderTimeout with no packet arriving to trigger the arrival-driven SACK,
+	// emit a SACK so the sender retransmits the missing seq in order (never skip).
+	go rg.servicePacketLoop("reorder-stall", reorderStallInterval, rg.reorderStallServiceFn, nil)
 	// Note: Automatic ping loop removed. Latency is now measured once at transport creation.
 	// Rotation loop is NOT started here — startOffServiceLoops runs
 	// during initial route-group setup, before the router-side
@@ -1669,32 +1668,25 @@ func (rg *RouteGroup) legLivenessServiceFn(_ time.Duration) {
 // drops the last active leg, keeps a shared transport open, and a false positive
 // merely triggers a self-heal re-dial (see pruneLivenessDeadLegs). Standby legs
 // are excluded (they aren't sent to, so zero recv is expected).
-// reorderFlushServiceFn periodically releases a reorder frontier gap that has
-// stalled past reorderTimeout so a silent/dead leg degrades to the surviving legs'
-// rate instead of wedging the stream. The skip-flush inside reorder.Insert only
-// runs when a packet arrives to trigger it; a leg that goes fully silent delivers
-// nothing, so without this the gap ages unbounded (observed live at ~10s while the
-// download stalled to zero). Only per-frame-noise groups release (skipCapable) —
-// flushStalledReorder is a no-op otherwise. Released payloads are pushed to readCh
-// on the SAME watched-close path as handleDataPacket so a close can't deadlock.
-func (rg *RouteGroup) reorderFlushServiceFn(_ time.Duration) {
+// reorderStallServiceFn drives IN-ORDER recovery of a stuck reorder gap by asking
+// the sender to retransmit the missing sequence (via a SACK), so a silent/dead leg
+// degrades to the surviving legs' rate WITHOUT ever skipping the gap — skipping
+// would corrupt the reliable ordered byte stream the RouteGroup carries (the
+// bad-record-mac failure that skipping produced under multi-leg churn).
+func (rg *RouteGroup) reorderStallServiceFn(_ time.Duration) {
 	if rg.isClosed() || rg.mux == nil || rg.isRemoteClosed() {
 		return
 	}
-	delivered := rg.mux.flushStalledReorder()
-	if len(delivered) == 0 {
-		return
-	}
-	rg.logger.Debugf("reorder flush: released %d buffered payloads past a stalled leg", len(delivered))
-	for _, d := range delivered {
-		select {
-		case <-rg.closed:
-			return
-		case <-rg.remoteClosed:
-			return
-		case rg.readCh <- d:
-		case <-time.After(30 * time.Second):
-			rg.logger.Warn("reorder flush: dropping payload, readCh full for 30s (application not reading)")
+	// A frontier gap held past reorderTimeout means the missing sequence's leg has
+	// likely stalled/died and the normal packet-arrival-driven SACK isn't firing
+	// (nothing is arriving to trigger it). Emit a SACK NOW so the sender resends
+	// the missing seq on a live leg and the gap fills IN ORDER. We never skip the
+	// gap: the RouteGroup is a reliable ordered net.Conn (TCP/TLS rides it), so
+	// delivering past a hole corrupts the stream. The leg-dataprogress prune
+	// concurrently removes a genuinely dead leg so its seqs retransmit on survivors.
+	if rg.mux.gapAge() > reorderTimeout {
+		if err := rg.sendSACK(); err != nil {
+			rg.logger.WithError(err).Debug("reorder-stall SACK failed")
 		}
 	}
 }
@@ -2217,9 +2209,8 @@ func (rg *RouteGroup) wirePerFrameNoise() {
 		rg.mux.open = func(seq uint32, ciphertext []byte) ([]byte, error) {
 			return ns.OpenWithNonce(uint64(seq), ciphertext)
 		}
-		rg.mux.reorderBuf.SetSkipCapable(true)
 		rg.perFrameNoiseActive = true
-		rg.logger.Debug("Per-frame noise active: mux seal/open wired, reorder skip-capable, EncryptConn bypassed")
+		rg.logger.Debug("Per-frame noise active: mux seal/open wired, EncryptConn bypassed")
 	})
 }
 

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -698,23 +698,6 @@ func (m *routeMux) deliverData(seq uint32, data []byte) (delivered [][]byte, gap
 	return delivered, gapDetected
 }
 
-// flushStalledReorder releases a reorder frontier gap that has stalled past
-// reorderTimeout with no arrivals to trigger the in-Insert skip (see
-// reorderBuffer.FlushIfStalled), then advances the SACK tracker to the new
-// contiguous frontier exactly as deliverData does. Returns the released payloads
-// in order (nil when nothing is stalled). A no-op unless the group negotiated
-// per-frame noise (skipCapable), so it is safe to call on every group.
-func (m *routeMux) flushStalledReorder() [][]byte {
-	if m.reorderBuf == nil {
-		return nil
-	}
-	delivered := m.reorderBuf.FlushIfStalled()
-	if len(delivered) > 0 && m.sackEnabled && m.sackTracker != nil {
-		m.sackTracker.AdvanceContiguous(m.reorderBuf.NextSeq())
-	}
-	return delivered
-}
-
 // gapAge exposes the reorder buffer's current frontier-gap age (0 if the stream
 // is contiguous). Used by the route group's fast data-progress prune.
 func (m *routeMux) gapAge() time.Duration {


### PR DESCRIPTION
The per-frame reorder **skip** (release a frontier gap held past `reorderTimeout`) corrupted the reliable stream. The RouteGroup is an ordered `net.Conn` — a TCP/TLS connection rides it — so delivering *past* a missing sequence leaves a hole in the byte stream and the upper protocol dies. Observed live as `OpenSSL SSL_read: bad record mac` partway through a proxied download, under **both** `auto`+cap8 and `capacity`+cap60 (mode-independent), whenever a gap exceeded `reorderTimeout` (common under multi-leg churn). Per-frame noise makes each *frame* independently decryptable, but the reassembled *stream* must still be gapless — the "skip is safe with per-frame" premise was wrong.

Fix: the reorder buffer **never** skips on a time basis; a gap is only closed by the missing sequence arriving. Removed `skipCapable`/`FlushIfStalled`/`flushStalledReorder` and the Insert skip branch. The stall timer now emits a **SACK** instead of flushing — a stuck gap prompts the sender to *retransmit* the missing seq on a live leg so it fills **in order**. A dead leg is still pruned by leg-dataprogress and its seqs retransmit on survivors. Graceful degradation without corruption. Developed with AI assistance (Claude).