### PR TITLE
fix(skysocks): SO_REUSEADDR/PORT on the SOCKS listener so reconnect can't leak the port

### DIFF
--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -193,7 +193,7 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		// the bind fails we just skip it and dial as before.
 		dctx, dcancel := context.WithCancel(cycleCtx)
 		ddone := make(chan struct{})
-		if lis, lerr := net.Listen("tcp", addr); lerr == nil {
+		if lis, lerr := skysocks.ReuseListen(addr); lerr == nil {
 			go func() {
 				defer close(ddone)
 				skysocks.ServeDisconnected(dctx, lis, appCl)

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -401,7 +401,7 @@ func (c *Client) totalStreams() int {
 // ListenAndServe start tcp listener on addr and proxies incoming
 // connection to a remote proxy server.
 func (c *Client) ListenAndServe(addr string) error {
-	l, err := net.Listen("tcp", addr)
+	l, err := ReuseListen(addr)
 	if err != nil {
 		if c.appCl != nil {
 			c.setAppError(err)

--- a/pkg/skysocks/listen_other.go
+++ b/pkg/skysocks/listen_other.go
@@ -1,0 +1,15 @@
+//go:build !unix
+
+// Package skysocks pkg/skysocks/listen_other.go c4-app-proxy
+package skysocks
+
+import "net"
+
+// ReuseListen falls back to a plain listen on platforms without the SO_REUSEADDR
+// / SO_REUSEPORT socket options wired here (windows, js/wasm, plan9). The
+// reconnect-rebind race the unix build avoids is a non-issue for the wasm
+// client (no OS TCP listener) and rare enough elsewhere that a plain listen is
+// the safe default.
+func ReuseListen(addr string) (net.Listener, error) {
+	return net.Listen("tcp", addr)
+}

--- a/pkg/skysocks/listen_unix.go
+++ b/pkg/skysocks/listen_unix.go
@@ -1,0 +1,45 @@
+//go:build unix
+
+// Package skysocks pkg/skysocks/listen_unix.go c4-app-proxy
+package skysocks
+
+import (
+	"context"
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// ReuseListen binds a TCP listener with SO_REUSEADDR + SO_REUSEPORT so the
+// skysocks-client can rebind its SOCKS port without racing the previous
+// socket's TIME_WAIT.
+//
+// The client rebinds :<addr> twice on EVERY --reconnect cycle: the sessionless
+// "disconnected" listener that serves the branded interstitial while dialing,
+// then the live Client's own listener once the exit is up. Any tunnel-down
+// event (a dead mux leg, an exit restart) ends a cycle and starts a new one, so
+// the port is reopened constantly under normal operation. With a plain
+// net.Listen the reopen could hit "bind: address already in use" (the just-
+// closed socket still in TIME_WAIT) and DROP the app — the exact fail-the-app
+// lifecycle bug. SO_REUSEADDR lets the bind reclaim a TIME_WAIT socket;
+// SO_REUSEPORT covers the brief within-cycle window where the disconnected and
+// live listeners momentarily both hold the addr during handoff.
+func ReuseListen(addr string) (net.Listener, error) {
+	lc := net.ListenConfig{
+		Control: func(_, _ string, c syscall.RawConn) error {
+			var cerr error
+			if err := c.Control(func(fd uintptr) {
+				if e := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); e != nil {
+					cerr = e
+					return
+				}
+				cerr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+			}); err != nil {
+				return err
+			}
+			return cerr
+		},
+	}
+	return lc.Listen(context.Background(), "tcp", addr)
+}

--- a/pkg/skysocks/listen_unix_test.go
+++ b/pkg/skysocks/listen_unix_test.go
@@ -1,0 +1,57 @@
+//go:build unix
+
+// Package skysocks pkg/skysocks/listen_unix_test.go c4-app-proxy
+package skysocks
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReuseListen_ConcurrentSameAddr proves the reconnect-rebind fix: with
+// SO_REUSEADDR + SO_REUSEPORT two listeners can hold the SAME address at once —
+// the brief within-cycle overlap where the disconnected interstitial listener
+// and the live Client listener both bind the SOCKS port during handoff. A plain
+// net.Listen fails the second bind with "address already in use", which is what
+// dropped the app on reconnect.
+func TestReuseListen_ConcurrentSameAddr(t *testing.T) {
+	l1, err := ReuseListen("127.0.0.1:0")
+	require.NoError(t, err)
+	defer l1.Close() //nolint:errcheck
+	addr := l1.Addr().String()
+
+	l2, err := ReuseListen(addr)
+	require.NoError(t, err, "second listener on the same addr must succeed (SO_REUSEADDR/PORT)")
+	defer l2.Close() //nolint:errcheck
+
+	// Sanity: a plain net.Listen on that same addr must NOT be allowed — proving
+	// the success above came from the socket options, not a lax OS.
+	if l3, perr := net.Listen("tcp", addr); perr == nil {
+		l3.Close() //nolint:errcheck,gosec
+		t.Fatalf("plain net.Listen unexpectedly bound an in-use addr; test can't distinguish the fix")
+	}
+}
+
+// TestReuseListen_RebindAfterClose covers the sequential reconnect case: close a
+// listener and immediately rebind the same address (what every --reconnect cycle
+// does). Must succeed rather than fail on a lingering socket.
+func TestReuseListen_RebindAfterClose(t *testing.T) {
+	l1, err := ReuseListen("127.0.0.1:0")
+	require.NoError(t, err)
+	addr := l1.Addr().String()
+
+	// Give the socket real connection state, then tear everything down.
+	c, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	sc, err := l1.Accept()
+	require.NoError(t, err)
+	c.Close()  //nolint:errcheck,gosec
+	sc.Close() //nolint:errcheck,gosec
+	require.NoError(t, l1.Close())
+
+	l2, err := ReuseListen(addr)
+	require.NoError(t, err, "rebind of the same addr right after close must succeed")
+	require.NoError(t, l2.Close())
+}


### PR DESCRIPTION
The skysocks-client rebinds its SOCKS port **twice on every `--reconnect` cycle** — the sessionless "disconnected" interstitial listener while it dials, then the live `Client` listener once the exit is up. Any tunnel-down event (dead mux leg, exit restart) ends a cycle and starts a new one, so the port is reopened constantly. With a plain `net.Listen`, a reopen could race the just-closed socket and fail with `bind: address already in use` — **dropping the app instead of transparently reconnecting.** This is a concrete piece of the "never fail the app under mux operations" problem.

Both listeners now bind through a shared `ReuseListen` helper: `SO_REUSEADDR` (reclaim a lingering socket) + `SO_REUSEPORT` (tolerate the brief within-cycle handoff overlap). Unix-only via `x/sys/unix`; plain-listen fallback for windows and js/wasm. Tests prove two listeners can hold the same addr while a plain `net.Listen` is correctly refused, and that a rebind right after close succeeds.