### PR TITLE
fix(router): retire a manually-removed mux leg on the far endpoint (CloseLegRetired)

### DIFF
--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -508,6 +508,32 @@ func (r *router) RemoveMuxRouteByTransport(desc routing.RouteDescriptor, tpID uu
 	// becomes exactly what the operator asks for (`proxy start --route`,
 	// `proxy mux set --prune`), with no un-prunable auto primary left behind.
 
+	// Retire this leg on the FAR endpoint before tearing down local state, so the
+	// exit stops striping data onto it. Unlike the adaptive drop (dropLegsByIndex
+	// closes the transport, which the peer's liveness eventually notices), a manual
+	// removal leaves the transport UP — so without an explicit signal the far side
+	// keeps SENDING on a leg the receiver has dropped: the send-side desync that
+	// strands the whole downlink (measured: a mux group's agg_recv pinned at ~0
+	// even after the bad leg was replaced by a healthy one, because the exit was
+	// still striping onto the dropped leg). MakeClosePacket with CloseLegRetired
+	// follows this leg's own forward path; the far endpoint's router_packet handler
+	// calls pruneLegByConsumeRule to reclaim its matching consume rule IMMEDIATELY,
+	// with no keepalive/liveness wait. Fire-and-forget in a goroutine with a bounded
+	// context so the network write never blocks under rg.mu; it reads only captured
+	// values, which stay valid after the slices below are compacted.
+	if idx < len(rg.fwd) && rg.fwd[idx] != nil && rg.tps[idx] != nil {
+		retireTp := rg.tps[idx]
+		retireRule := rg.fwd[idx]
+		retire := routing.MakeClosePacket(retireRule.NextRouteID(), routing.CloseLegRetired)
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), closeRoutineTimeout)
+			defer cancel()
+			if err := rg.writePacket(ctx, retireTp, retire, retireRule.KeyRouteID()); err != nil {
+				rg.logger.WithError(err).Debugf("leg-retire signal to remote failed for tp %s", tpID)
+			}
+		}()
+	}
+
 	// Collect rule IDs to delete
 	var deadRuleIDs []routing.RouteID
 	if idx < len(rg.fwd) {


### PR DESCRIPTION
The CLI mux actuator `RemoveMuxRouteByTransport` (behind `proxy mux rm` / `mux set --prune` / `proxy start --route`) tore down only the **local** side of a leg and left the transport up. **The far endpoint was never told**, so it kept striping data onto a leg the receiver had dropped — a send-side desync that stalls the whole downlink.

Measured directly while hand-swapping a mux leg: after replacing a dead primary with a healthy leg, `agg_recv` stayed pinned at ~0 — the exit was still sending on the removed leg.

The adaptive drop (`dropLegsByIndex`) dodges this only by closing the *transport* (peer liveness eventually notices) — heavy and slow. Manual removal now sends a `CloseLegRetired` close-packet along the removed legs own forward path (fire-and-forget, bounded ctx, off `rg.mu`); the far endpoint already routes it to `pruneLegByConsumeRule`, which reclaims the matching consume rule immediately. **This is the send half of a protocol that until now only had a receive half** — it makes live route-swapping work: add the new leg, drop the old, and the exit stops feeding the dead one at once. Dormant on the fleet (only the manual RPC hits this path; the adaptive drop is unchanged).