### PR TITLE
fix(router): replace a sole black-holing mux leg instead of wedging at zero

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1587,7 +1587,10 @@ func (rg *RouteGroup) legLivenessServiceFn(_ time.Duration) {
 	}
 	rg.mu.Unlock()
 
-	if len(probes) < 2 {
+	// A single-leg group is still probed (below): a lone black-holing leg has no
+	// failover and self-heal's target<=1 bail never replaces it, so without this
+	// it would sit at zero throughput forever. Only a truly empty group is skipped.
+	if len(probes) == 0 {
 		return
 	}
 
@@ -1627,7 +1630,14 @@ func (rg *RouteGroup) legLivenessServiceFn(_ time.Duration) {
 	rg.legLivenessMu.Unlock()
 
 	if len(dead) > 0 {
-		rg.pruneLivenessDeadLegs(dead)
+		if len(probes) < 2 {
+			// Sole leg is black-holing. Never drop the last leg (that is an
+			// outage); instead dial a REPLACEMENT via a disjoint path and drop
+			// the dead one only once the replacement is live.
+			rg.healSoleBlackHoledLeg(dead[0])
+		} else {
+			rg.pruneLivenessDeadLegs(dead)
+		}
 	}
 
 	// Probe the surviving legs for the next cycle. Each send-ts is unique
@@ -1886,6 +1896,59 @@ func (rg *RouteGroup) pruneLivenessDeadLegs(deadIDs []uuid.UUID) {
 	}
 	rg.signalRotate()
 	rg.maybeSelfHeal()
+}
+
+// soleLegExcludeHopsLocked returns the intermediate PKs of the route group's
+// recorded (primary) forward path, so a replacement dial can be steered onto a
+// disjoint route. Best-effort: the rg only records the primary forwardHops, so
+// for an aux-only survivor this is a hint, not an exact exclusion — combined with
+// addOneAuxForwardLeg's own avoid-already-used-intermediates planning it is
+// enough to keep the finder off the black-holing path. Caller holds rg.mu.
+func (rg *RouteGroup) soleLegExcludeHopsLocked() []string {
+	if len(rg.forwardHops) <= 1 {
+		return nil
+	}
+	excl := make([]string, 0, len(rg.forwardHops)-1)
+	for _, h := range rg.forwardHops[:len(rg.forwardHops)-1] {
+		excl = append(excl, h.To.String())
+	}
+	return excl
+}
+
+// healSoleBlackHoledLeg replaces a single black-holing leg WITHOUT ever dropping
+// to zero legs. It dials one replacement aux leg via a disjoint path (excluding
+// the current leg's intermediates so the finder cannot re-pick the same
+// black-holing route — classically a deceptively-low-latency LAN short-circuit),
+// and prunes the dead leg only once the replacement is live. maybeSelfHeal cannot
+// do this: it bails when selfHealTarget<=1 (the low-latency-direct / single-route
+// case), which is exactly when a lone leg has no failover and most needs
+// replacing. If no disjoint replacement is available the dead leg is kept (still
+// one leg, not an outage) and a later cycle retries.
+func (rg *RouteGroup) healSoleBlackHoledLeg(deadID uuid.UUID) {
+	rg.mu.Lock()
+	add := rg.selfHealAdd
+	excl := rg.soleLegExcludeHopsLocked()
+	rg.mu.Unlock()
+	if add == nil || rg.isClosed() {
+		return
+	}
+	if !rg.healInFlight.CompareAndSwap(false, true) {
+		return // a replacement is already dialing
+	}
+	go func() {
+		defer rg.healInFlight.Store(false)
+		before := rg.aliveLegCount()
+		add(excl) // dials one disjoint replacement leg (blocks ~one setup dial)
+		if rg.isClosed() {
+			return
+		}
+		if rg.aliveLegCount() > before {
+			// Replacement is live; now it is safe to drop the black-holing leg.
+			rg.pruneLivenessDeadLegs([]uuid.UUID{deadID})
+		} else if rg.logger != nil {
+			rg.logger.Debug("sole-leg heal: no disjoint replacement available; keeping current leg for now")
+		}
+	}()
 }
 
 // servicePacketLoop runs f every interval until the group closes. trigger, when

--- a/pkg/router/route_group_singleleg_heal_test.go
+++ b/pkg/router/route_group_singleleg_heal_test.go
@@ -1,0 +1,135 @@
+package router
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// TestSoleLegExcludeHops verifies the replacement dial is steered off the current
+// leg's intermediate PKs (so the finder cannot re-pick the same black-holing path).
+func TestSoleLegExcludeHops(t *testing.T) {
+	rg, mts, _ := createMuxRouteGroup(t, 1)
+	src := rg.desc.SrcPK()
+	dst := rg.desc.DstPK()
+	mid, _ := cipher.GenerateKeyPair()
+
+	rg.SetForwardHops([]routing.Hop{
+		{TpID: mts[0].Entry.ID, From: src, To: mid},
+		{TpID: uuid.New(), From: mid, To: dst},
+	})
+
+	rg.mu.Lock()
+	excl := rg.soleLegExcludeHopsLocked()
+	rg.mu.Unlock()
+	require.Equal(t, []string{mid.String()}, excl, "exclude the sole leg's intermediate, not the destination")
+}
+
+// TestLegLivenessSwapsSoleBlackHoledLeg is the regression for the terminal wedge:
+// a route group degraded to a SINGLE black-holing leg (classically a deceptively-
+// low-latency LAN short-circuit that self-heal's target<=1 bail never replaces)
+// must dial a disjoint replacement and swap the dead leg out — never sit at one
+// dead leg delivering zero forever. Before the fix legLivenessServiceFn returned
+// early for <2 legs, so the sole leg was never even probed.
+func TestLegLivenessSwapsSoleBlackHoledLeg(t *testing.T) {
+	rg, mts, _ := createMuxRouteGroup(t, 1)
+	deadID := mts[0].Entry.ID
+	src := rg.desc.SrcPK()
+	dst := rg.desc.DstPK()
+	mid, _ := cipher.GenerateKeyPair()
+
+	rg.SetForwardHops([]routing.Hop{
+		{TpID: deadID, From: src, To: mid},
+		{TpID: uuid.New(), From: mid, To: dst},
+	})
+
+	var mu sync.Mutex
+	var gotExcl []string
+	var addCalls int
+	var replID uuid.UUID
+
+	// Model a live disjoint replacement leg coming up on each self-heal add.
+	rg.selfHealAdd = func(excludeHops []string) {
+		tpID := uuid.New()
+		fwd := routing.ForwardRule(DefaultRouteKeepAlive, routing.RouteID(500), routing.RouteID(600), tpID, dst, src, 1, 2) //nolint:gosec
+		rvs := routing.ConsumeRule(DefaultRouteKeepAlive, routing.RouteID(600), src, dst, 2, 1)                             //nolint:gosec
+		rg.rt.SaveRule(fwd)                                                                                                 //nolint:errcheck,gosec
+		rg.rt.SaveRule(rvs)                                                                                                 //nolint:errcheck,gosec
+		conn := newWorkingTransport()
+		mt := transport.NewManagedTransportForTest(conn)
+		mt.Entry = transport.Entry{ID: tpID, Type: "test"}
+
+		rg.mu.Lock()
+		rg.tps = append(rg.tps, mt)
+		rg.fwd = append(rg.fwd, fwd)
+		rg.rvs = append(rg.rvs, rvs)
+		rg.mux.growLegs(len(rg.tps))
+		rg.mux.markLegReady(len(rg.tps) - 1)
+		rg.mux.rebuildWeights(rg.tps)
+		rg.mu.Unlock()
+
+		mu.Lock()
+		addCalls++
+		gotExcl = excludeHops
+		replID = tpID
+		mu.Unlock()
+	}
+
+	// The sole leg never echoes; after legPongMissThreshold cycles it is declared
+	// black-holing and the swap fires. Keep the replacement (once present) echoing
+	// so it is not itself re-declared dead.
+	for i := 0; i < legPongMissThreshold+3; i++ {
+		mu.Lock()
+		r := replID
+		mu.Unlock()
+		if r != (uuid.UUID{}) {
+			rg.legLivenessMu.Lock()
+			rg.legPongSeen[r] = true
+			rg.legLivenessMu.Unlock()
+		}
+		rg.legLivenessServiceFn(legLivenessInterval)
+	}
+
+	require.Eventually(t, func() bool {
+		rg.mu.Lock()
+		defer rg.mu.Unlock()
+		return len(rg.tps) == 1 && rg.tps[0].Entry.ID != deadID
+	}, 2*time.Second, 20*time.Millisecond,
+		"the sole black-holing leg must be swapped for a live replacement, never left at zero throughput")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.GreaterOrEqual(t, addCalls, 1, "a replacement dial must have been attempted")
+	require.Equal(t, []string{mid.String()}, gotExcl, "the replacement must exclude the dead leg's intermediate")
+}
+
+// TestLegLivenessSoleLegKeepsAliveWhenEchoing verifies the new single-leg probing
+// does NOT churn a healthy lone leg: a sole leg that keeps echoing is never
+// swapped, and no replacement is dialed.
+func TestLegLivenessSoleLegKeepsAliveWhenEchoing(t *testing.T) {
+	rg, mts, _ := createMuxRouteGroup(t, 1)
+	keep := mts[0].Entry.ID
+
+	var addCalls int
+	rg.selfHealAdd = func(_ []string) { addCalls++ }
+
+	for i := 0; i < legPongMissThreshold+3; i++ {
+		rg.legLivenessMu.Lock()
+		rg.legPongSeen[keep] = true
+		rg.legLivenessMu.Unlock()
+		rg.legLivenessServiceFn(legLivenessInterval)
+	}
+
+	rg.mu.Lock()
+	defer rg.mu.Unlock()
+	require.Equal(t, 1, len(rg.tps))
+	require.Equal(t, keep, rg.tps[0].Entry.ID, "a healthy lone leg must never be swapped")
+	require.Equal(t, 0, addCalls, "no replacement dial for a healthy lone leg")
+}


### PR DESCRIPTION
A route group that degrades to a single leg had no black-hole recovery. `legLivenessServiceFn` returned early for groups with fewer than two legs, and `maybeSelfHeal` bails when `selfHealTarget <= 1` (the `low-latency-direct` / single-route case). So a lone leg that black-holes data *beyond its first hop* — classically a deceptively-low-latency LAN short-circuit the route finder prefers — left the app `Running` but delivering zero bytes indefinitely, with no mechanism to replace it.

This was reproduced live: a single-leg reference proxy to a healthy exit (confirmed up via its dmsg `/health`) collapsed to one 2ms leg and delivered 0, while the exit itself was fine.

The fix probes the sole leg too, and on a detected black-hole (pong-miss past threshold) dials one disjoint replacement — excluding the dead leg's intermediates so the finder can't re-pick the same path — and swaps the dead leg out only once the replacement is live, never dropping below one leg. `maybeSelfHeal` is unchanged; this covers the `target <= 1` gap it leaves. New tests cover the swap, the exclude-hops steering, and that a healthy lone leg is never churned.