### PR TITLE
feat(router): latency-band admission keeps the mux active set homogeneous

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -63,6 +64,27 @@ const (
 	// RouteGroup.reorderStallServiceFn). Shorter than reorderTimeout (1.5s) so a
 	// stalled gap is nudged within ~one reorderTimeout of going silent.
 	reorderStallInterval = 500 * time.Millisecond
+
+	// bandDemoteRatio: an ACTIVE leg whose end-to-end latency is more than this
+	// factor off the active-set median (either tail) is demoted to warm standby
+	// so the mux never STRIPES across latency-disparate legs. Striping a 2ms LAN
+	// short-circuit beside a 300ms route opens a reorder gap the size of the
+	// difference on every interleave, HoL-capping (or, if the fast leg
+	// black-holes, stalling) the no-skip reorder buffer — the multi-leg
+	// collapse-to-~0 measured against a healthy single-leg reference. 3.0 matches
+	// the adaptive engine's own high-side outlier multiplier so the two never
+	// fight over the same leg.
+	bandDemoteRatio = 3.0
+	// bandAdmitRatio: a warm-standby leg is re-admitted to the active set only
+	// once it is within this tighter factor of the median. The gap between admit
+	// and demote is hysteresis — it stops a leg hovering at the band edge from
+	// flip-flopping active/standby every interval.
+	bandAdmitRatio = 2.5
+	// bandMinLegs: latency-band admission only runs with at least this many legs
+	// carrying a measured latency. Below it the median is not a meaningful cluster
+	// anchor, and the 1-2 leg pathologies are already handled by the sole-leg
+	// black-hole heal and the data-progress prune.
+	bandMinLegs = 3
 )
 
 var (
@@ -1772,6 +1794,13 @@ func (rg *RouteGroup) legDataProgressServiceFn(_ time.Duration) {
 		rg.mux.rebuildWeights(rg.tps)
 	}
 	rg.mu.Unlock()
+
+	// Keep the active stripe set within a tight latency band so one out-of-band
+	// leg (classically a 2ms LAN short-circuit beside 300ms routes) can't open a
+	// reorder gap that HoL-caps or stalls the whole mux. Same cadence as the
+	// data-progress prune; complementary — the prune sheds a leg that stops
+	// delivering, this parks a leg whose latency is too disparate to stripe with.
+	rg.enforceLatencyBand()
 }
 
 // legRecvDelta is one active-or-standby leg's rg-scoped recv progress over a
@@ -1823,6 +1852,121 @@ func selectDataStalledLegs(legs []legRecvDelta, gapStuck bool) []uuid.UUID {
 		dead = dead[:active-1]
 	}
 	return dead
+}
+
+// bandLeg is one leg's latency-band inputs: its index, measured end-to-end
+// latency (ms; <=0 == not yet measured), whether it is currently a warm standby,
+// and whether it is the primary (index 0, never demoted).
+type bandLeg struct {
+	idx     int
+	latMs   float64
+	standby bool
+	primary bool
+}
+
+// partitionLatencyBand decides which legs to demote to / promote from warm
+// standby so the ACTIVE stripe set stays within a tight latency band around the
+// median. Striping across latency-disparate legs opens a reorder gap the size of
+// the difference (a 2ms LAN short-circuit beside a 300ms route), HoL-capping or
+// stalling the no-skip reorder buffer — the multi-leg collapse. LOW-side demotion
+// (a leg far FASTER than the median — the classic LAN short-circuit artifact that
+// neither the adaptive engine's high-side outlier logic nor a manual preset
+// excludes today) is universal. HIGH-side demotion and re-promotion are gated to
+// manualMode: in adaptive mode the tick owns the high side and a 512-deep warm
+// pool that must not be dumped into the active set. Pure (no locks / rg state) so
+// it is unit-tested directly. Never demotes the primary or the last active leg.
+func partitionLatencyBand(legs []bandLeg, manualMode bool) (demote, promote []int) {
+	known := make([]float64, 0, len(legs))
+	for _, l := range legs {
+		if l.latMs > 0 {
+			known = append(known, l.latMs)
+		}
+	}
+	if len(known) < bandMinLegs {
+		return nil, nil
+	}
+	sort.Float64s(known)
+	med := known[len(known)/2]
+	if med <= 0 {
+		return nil, nil
+	}
+
+	active := 0
+	for _, l := range legs {
+		if !l.standby {
+			active++
+		}
+	}
+
+	for _, l := range legs {
+		if l.latMs <= 0 {
+			continue // unknown latency — leave the leg's state untouched
+		}
+		fasterRatio := med / l.latMs // >1 when the leg is faster than the median
+		slowerRatio := l.latMs / med // >1 when the leg is slower than the median
+		switch {
+		case !l.standby && !l.primary && active > 1 &&
+			(fasterRatio > bandDemoteRatio || (manualMode && slowerRatio > bandDemoteRatio)):
+			demote = append(demote, l.idx)
+			active-- // never demote below one active leg
+		case manualMode && l.standby:
+			symm := slowerRatio
+			if fasterRatio > symm {
+				symm = fasterRatio
+			}
+			if symm <= bandAdmitRatio {
+				promote = append(promote, l.idx)
+				active++
+			}
+		}
+	}
+	return demote, promote
+}
+
+// enforceLatencyBand keeps the mux's active stripe set within a tight latency
+// band (see partitionLatencyBand). Runs on the data-progress cadence so it holds
+// even in a manual (non-adaptive) preset, where nothing else manages the active
+// set. Reads each leg's EWMA end-to-end latency, decides demotions/promotions,
+// and applies them via the mux's send-side standby marker — a demoted leg gets
+// zero scheduler weight and is never striped, so it can no longer open a reorder
+// gap, while its rules stay installed (a warm standby, promotable again if it
+// returns to the band).
+func (rg *RouteGroup) enforceLatencyBand() {
+	if rg.isClosed() || rg.mux == nil {
+		return
+	}
+	rg.mu.Lock()
+	manual := !rg.standbyNewLegs
+	legs := make([]bandLeg, 0, len(rg.tps))
+	for i, tp := range rg.tps {
+		if tp == nil || tp.IsClosed() {
+			continue
+		}
+		legs = append(legs, bandLeg{
+			idx:     i,
+			latMs:   rg.legEndToEndLatencyMs(tp.Entry.ID),
+			standby: rg.mux.isLegStandby(i),
+			primary: i == 0,
+		})
+	}
+	rg.mu.Unlock()
+
+	demote, promote := partitionLatencyBand(legs, manual)
+	for _, idx := range demote {
+		rg.logger.Infof("latency-band: parking leg %d (out-of-band latency) to keep the active stripe set homogeneous", idx)
+		rg.mux.setLegStandby(idx, true)
+	}
+	for _, idx := range promote {
+		rg.logger.Debugf("latency-band: re-admitting leg %d (back within band)", idx)
+		rg.mux.setLegStandby(idx, false)
+	}
+	if len(demote) > 0 || len(promote) > 0 {
+		rg.mu.Lock()
+		if rg.mux != nil {
+			rg.mux.rebuildWeights(rg.tps)
+		}
+		rg.mu.Unlock()
+	}
 }
 
 // pruneLivenessDeadLegs drops the given black-holing legs (by transport ID) from

--- a/pkg/router/route_group_latencyband_test.go
+++ b/pkg/router/route_group_latencyband_test.go
@@ -1,0 +1,222 @@
+package router
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/stretchr/testify/require"
+)
+
+func idsOf(v []int) []int { sort.Ints(v); return v }
+
+func TestPartitionLatencyBand(t *testing.T) {
+	tests := []struct {
+		name        string
+		legs        []bandLeg
+		manual      bool
+		wantDemote  []int
+		wantPromote []int
+	}{
+		{
+			name: "homogeneous cluster is left fully active",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 160},
+				{idx: 2, latMs: 140},
+				{idx: 3, latMs: 155},
+			},
+			manual:     true,
+			wantDemote: nil, wantPromote: nil,
+		},
+		{
+			name: "low-side LAN-artifact leg is demoted (universal, even non-manual)",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 155},
+				{idx: 2, latMs: 2}, // 2ms beside 150ms cluster: >3x faster than median
+				{idx: 3, latMs: 145},
+			},
+			manual:     false, // adaptive mode: low-side still demoted, high-side/promote suppressed
+			wantDemote: []int{2}, wantPromote: nil,
+		},
+		{
+			name: "high-side outlier demoted only in manual mode",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 155},
+				{idx: 2, latMs: 145},
+				{idx: 3, latMs: 700}, // ~4.6x median
+			},
+			manual:     true,
+			wantDemote: []int{3}, wantPromote: nil,
+		},
+		{
+			name: "high-side outlier kept active in adaptive mode (tick owns the high side)",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 155},
+				{idx: 2, latMs: 145},
+				{idx: 3, latMs: 700},
+			},
+			manual:     false,
+			wantDemote: nil, wantPromote: nil,
+		},
+		{
+			name: "primary is never demoted even when it is the outlier",
+			legs: []bandLeg{
+				{idx: 0, latMs: 2, primary: true}, // primary happens to be the fast artifact
+				{idx: 1, latMs: 150},
+				{idx: 2, latMs: 155},
+				{idx: 3, latMs: 145},
+			},
+			manual:     true,
+			wantDemote: nil, wantPromote: nil, // median=150, primary 2ms is out-of-band but protected
+		},
+		{
+			name: "standby leg back within band is re-admitted (manual, hysteresis)",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 160},
+				{idx: 2, latMs: 155},
+				{idx: 3, latMs: 200, standby: true}, // 1.33x median <= admit 2.5
+			},
+			manual:     true,
+			wantDemote: nil, wantPromote: []int{3},
+		},
+		{
+			name: "standby leg still out-of-band stays standby",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 160},
+				{idx: 2, latMs: 155},
+				{idx: 3, latMs: 900, standby: true}, // 6x median > admit
+			},
+			manual:     true,
+			wantDemote: nil, wantPromote: nil,
+		},
+		{
+			name: "no promotion in adaptive mode (warm pool untouched)",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 160},
+				{idx: 2, latMs: 155},
+				{idx: 3, latMs: 150, standby: true}, // in-band but adaptive owns the pool
+			},
+			manual:     false,
+			wantDemote: nil, wantPromote: nil,
+		},
+		{
+			name: "fewer than bandMinLegs measured: no action",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 2},
+			},
+			manual:     true,
+			wantDemote: nil, wantPromote: nil,
+		},
+		{
+			name: "unknown-latency legs are ignored, not demoted",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 155},
+				{idx: 2, latMs: 145},
+				{idx: 3, latMs: 0}, // not measured yet
+			},
+			manual:     true,
+			wantDemote: nil, wantPromote: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			demote, promote := partitionLatencyBand(tt.legs, tt.manual)
+			require.Equal(t, tt.wantDemote, nilIfEmpty(idsOf(demote)), "demote set")
+			require.Equal(t, tt.wantPromote, nilIfEmpty(idsOf(promote)), "promote set")
+		})
+	}
+}
+
+// TestPartitionLatencyBandNeverDemotesBelowOne verifies that when several active
+// legs are all out-of-band, the guard still leaves at least one active leg.
+func TestPartitionLatencyBandNeverDemotesBelowOne(t *testing.T) {
+	// median of [4,150,150,300] = 150. Legs 1 (4ms, 37x fast) and 3 (300ms, 2x —
+	// within 3x, kept) — only leg 1 is a demote candidate here, so craft a case
+	// where two legs are out-of-band on the fast side.
+	legs := []bandLeg{
+		{idx: 0, latMs: 900, primary: true}, // primary protected
+		{idx: 1, latMs: 2},                  // fast artifact
+		{idx: 2, latMs: 3},                  // fast artifact
+		{idx: 3, latMs: 4},                  // fast artifact
+	}
+	// median of [2,3,4,900] = 4. Relative to median 4, the 900ms primary is the
+	// slow outlier (protected); the fast ones are near the median → none demoted.
+	demote, _ := partitionLatencyBand(legs, true)
+	require.NotContains(t, demote, 0, "primary is never demoted")
+
+	// A cleaner below-one guard case: one real leg + three fast artifacts, median
+	// falls among the artifacts so the single real leg is the slow one (manual
+	// high-side demote) but must be kept because demoting it would leave the
+	// artifacts — guard keeps >=1 active regardless.
+	legs2 := []bandLeg{
+		{idx: 0, latMs: 2, primary: true},
+		{idx: 1, latMs: 2},
+		{idx: 2, latMs: 3},
+		{idx: 3, latMs: 900}, // lone slow real leg; median≈3 → 300x slower
+	}
+	demote2, _ := partitionLatencyBand(legs2, true)
+	activeAfter := 0
+	for _, l := range legs2 {
+		demoted := false
+		for _, d := range demote2 {
+			if d == l.idx {
+				demoted = true
+			}
+		}
+		if !l.standby && !demoted {
+			activeAfter++
+		}
+	}
+	require.GreaterOrEqual(t, activeAfter, 1, "must always leave at least one active leg")
+}
+
+func nilIfEmpty(v []int) []int {
+	if len(v) == 0 {
+		return nil
+	}
+	return v
+}
+
+// TestEnforceLatencyBandParksArtifactLeg drives the full rg path: four active
+// legs where one is a 2ms LAN-short-circuit artifact beside a 150ms cluster. In
+// manual mode enforceLatencyBand must park the artifact into warm standby (so it
+// is never striped) while leaving the homogeneous cluster active.
+func TestEnforceLatencyBandParksArtifactLeg(t *testing.T) {
+	rg, mts, _ := createMuxRouteGroup(t, 4)
+
+	rg.legLivenessMu.Lock()
+	if rg.legE2ELatency == nil {
+		rg.legE2ELatency = map[uuid.UUID]float64{}
+	}
+	rg.legE2ELatency[mts[0].Entry.ID] = 150
+	rg.legE2ELatency[mts[1].Entry.ID] = 155
+	rg.legE2ELatency[mts[2].Entry.ID] = 145
+	rg.legE2ELatency[mts[3].Entry.ID] = 2 // LAN short-circuit artifact
+	rg.legLivenessMu.Unlock()
+
+	// createMuxRouteGroup starts every leg active (standbyNewLegs=false == manual).
+	rg.enforceLatencyBand()
+
+	require.True(t, rg.mux.isLegStandby(3), "the 2ms artifact leg must be parked to warm standby")
+	for _, i := range []int{0, 1, 2} {
+		require.False(t, rg.mux.isLegStandby(i), "homogeneous cluster leg %d stays active", i)
+	}
+
+	// Idempotent: a second pass with the artifact now back in-band re-admits it.
+	rg.legLivenessMu.Lock()
+	rg.legE2ELatency[mts[3].Entry.ID] = 150
+	rg.legLivenessMu.Unlock()
+	rg.enforceLatencyBand()
+	require.False(t, rg.mux.isLegStandby(3), "leg back within band is re-admitted in manual mode")
+}


### PR DESCRIPTION
Striping a single connection across latency-disparate legs — a 2ms LAN short-circuit beside a 300ms route — opens a reorder gap the size of the difference on every interleave, HoL-capping or (when the fast leg black-holes) stalling the no-skip reorder buffer. This was measured directly: a 7-leg mux delivered ~0 MB/s against a healthy single-leg reference to the *same* exit at the *same* instant (the exit itself confirmed up via its dmsg `/health`).

`enforceLatencyBand` runs on the data-progress cadence and parks any active leg whose EWMA end-to-end latency is more than `bandDemoteRatio` (3x) off the active-set median into warm standby, so it is never striped; a leg back within `bandAdmitRatio` (2.5x) is re-admitted, the gap providing hysteresis against edge flip-flop.

To avoid fighting the adaptive engine: **low-side** demotion (the LAN-artifact tail that neither the adaptive tick's high-side outlier logic nor a manual preset excludes today) is **universal**; **high-side** demotion and re-promotion are **manual-mode only**, so the adaptive tick keeps sole ownership of the high side and its 512-deep warm-standby pool is never dumped into the active set. Never demotes the primary (idx 0) or the last active leg — a false positive can only cost a leg its active slot, never cause an outage.

This is the Stage-1 mechanism to kill the multi-leg HoL collapse; it composes with #4247 (single-leg black-hole heal). Decision logic is a pure function (`partitionLatencyBand`) unit-tested across homogeneous / low-artifact / high-outlier / hysteresis / adaptive-vs-manual / never-below-one cases, plus an rg-level test through the mux.