### PR TITLE
feat(router): default the mux scheduler to ECF (completion-aware) to stop the multi-leg collapse

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1138,7 +1138,13 @@ func (rg *RouteGroup) applyDistribution(cfg DistributionConfig) {
 	case DistributionRoundRobin:
 		wm = WeightModeEqual
 	case DistributionAuto:
-		wm = WeightModeAuto
+		// "auto" now resolves to ECF (completion-aware) rather than the old
+		// latency-weighted schedule: latency-weighting over-assigns a low-latency
+		// but low-bandwidth leg, which lags and stalls the no-skip reorder
+		// frontier, collapsing the mux below single-leg rate. ECF only spills once
+		// the fast leg is saturated, so multi-leg is >= single-leg and aggregates
+		// as the fast leg fills. WeightModeAuto remains available for explicit use.
+		wm = WeightModeECF
 	case DistributionWeighted:
 		wm = WeightModeExplicit
 		rg.mux.tpSelector.SetExplicitWeights(cfg.Weights)

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -229,6 +229,15 @@ func newRouteMux(logger *logging.Logger, sackEnabled bool) *routeMux {
 		// while the receiver is holding the gap open for it.
 		retxBuf: newRetxBuffer(reorderWindow),
 	}
+	// Default every mux to ECF (Earliest Completion First). It only spills a
+	// frame onto a slower leg once the fastest leg is saturated (a full BDP in
+	// flight), so it never over-assigns a slow leg and stalls the no-skip reorder
+	// frontier — the failure mode of the old latency-weighted default, where a
+	// low-latency but low-bandwidth leg drew traffic it couldn't clear and the
+	// whole mux collapsed BELOW single-leg rate. Cold/empty ECF state and
+	// single-leg groups fall back to the round-robin schedule in SelectECF, so
+	// they are unaffected. A routing-policy distribution can still override this.
+	m.tpSelector.SetMode(WeightModeECF)
 	return m
 }
 

--- a/pkg/router/route_mux_ecf_default_test.go
+++ b/pkg/router/route_mux_ecf_default_test.go
@@ -1,0 +1,21 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestNewRouteMuxDefaultsToECF locks in that every mux defaults to the ECF
+// scheduler, which only spills onto a slower leg once the fast leg is saturated
+// — so multi-leg never over-assigns a slow leg and collapses below single-leg
+// rate (the old latency-weighted default's failure mode).
+func TestNewRouteMuxDefaultsToECF(t *testing.T) {
+	m := newRouteMux(logging.NewMasterLogger().PackageLogger("mux"), true)
+	require.Equal(t, WeightModeECF, m.tpSelector.Mode())
+	// Cold ECF state (no SetECFState yet) must not panic and must fall back to
+	// the schedule (leg 0) rather than erroring.
+	require.Equal(t, 0, m.tpSelector.SelectECF(1200))
+}


### PR DESCRIPTION
The default mux scheduler was latency-weighted (`WeightModeAuto`), which over-assigns a low-latency but low-**bandwidth** leg: it draws traffic it cannot clear, lags, and stalls the no-skip reorder frontier — collapsing a multi-leg download **below** single-leg rate. Measured live: single-leg 4.05 MB/s vs a striping mux 0.18 MB/s to the same exit at the same instant (per-leg `visor state` counters confirmed the exit striped across 5 legs and the node received across 6 — packet-level striping works; the reorder just cannot advance while a slow leg holds the frontier).

This defaults every mux (both ends, in `newRouteMux`) to `WeightModeECF` and resolves `DistributionAuto` to ECF. ECF (Earliest Completion First, filter variant) only spills a frame onto a slower leg **once the fastest leg is saturated** (a full bandwidth-delay-product in flight), so it never over-assigns a slow leg: worst case it behaves like "use the fastest leg" (multi-leg ≥ single-leg — the Stage-1 floor), and it aggregates onto the next-fastest leg only as the fast one fills. Cold/empty ECF state and single-leg groups fall back to the round-robin schedule in `SelectECF`, so they are unaffected; a routing policy can still override the mode, and `WeightModeAuto` stays available for explicit use.

The ECF machinery (per-leg RTT/jitter/rate/BDP/inflight, hold-back hysteresis, `SetECFState` refresh on the rebuild cadence) already existed — this makes it the default. New test locks in the default + cold-start fallback; full router suite green.