### PR TITLE
feat(dmsgscp): idle (no-progress) transfer deadline, not a fixed total timeout

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/scp.go
+++ b/cmd/skywire-cli/commands/dmsg/scp.go
@@ -58,8 +58,8 @@ func init() {
 		"secret key for the standalone dmsg client (random if unset)")
 	scpCmd.Flags().Uint16VarP(&scpPort, "port", "p", dmsgscp.DefaultPort,
 		"remote dmsg port for the dmsgscp host")
-	scpCmd.Flags().DurationVarP(&scpTimeout, "timeout", "t", 5*time.Minute,
-		"transfer timeout (includes dial + payload)")
+	scpCmd.Flags().DurationVarP(&scpTimeout, "timeout", "t", 60*time.Second,
+		"no-progress (idle) timeout: the transfer aborts only after this long with ZERO bytes moving — a progressing transfer of any size never times out (the payload is not capped by total duration)")
 	scpCmd.Flags().StringVar(&scpTransport, "transport", scpTransportAuto,
 		"transport: auto (try visor first, fallback dmsg) | dmsg | skynet | tcp (not supported yet)")
 	scpCmd.Flags().BoolVar(&scpStandalone, "standalone", false,
@@ -204,10 +204,13 @@ standalone dmsg path; the VisorSCP RPC uses the visor's own PK.`,
 
 		// Standalone dmsg path — the CLI bootstraps its own
 		// dmsg.Client and dials peer:port directly.
+		// The signal context is long-lived (no total deadline): the dmsg client
+		// bootstrapped below rides it, and capping it would cap the whole
+		// transfer. Dial gets its own bounded context; the payload is governed by
+		// the client's idle (no-progress) timeout, so a large but progressing
+		// transfer is never cut off.
 		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
 		defer cancel()
-		ctx, timeoutCancel := context.WithTimeout(ctx, scpTimeout)
-		defer timeoutCancel()
 
 		myPK, mySK := resolveChatIdentity(sk)
 		if !cmd.Flags().Changed("sk") && os.Getenv("DMSG_SK") == "" {
@@ -222,11 +225,14 @@ standalone dmsg path; the VisorSCP RPC uses the visor's own PK.`,
 		}
 		defer closeDmsg()
 
-		c, err := dmsgscp.Dial(ctx, dmsgC, peerPK, scpPort)
+		dialCtx, dialCancel := context.WithTimeout(ctx, scpTimeout)
+		c, err := dmsgscp.Dial(dialCtx, dmsgC, peerPK, scpPort)
+		dialCancel()
 		if err != nil {
 			return err
 		}
 		defer c.Close() //nolint:errcheck
+		c.SetIdleTimeout(scpTimeout)
 
 		switch direction {
 		case scpDirDownload:

--- a/pkg/dmsg/dmsgscp/client.go
+++ b/pkg/dmsg/dmsgscp/client.go
@@ -14,10 +14,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
@@ -35,6 +35,18 @@ type Client struct {
 	conn   net.Conn
 	reader *bufio.Reader
 	remote cipher.PubKey
+	// idle is the no-progress deadline applied to the payload copy (see
+	// copyNIdle): the transfer aborts only after this long with zero bytes
+	// moving, never on total duration. Defaults to DefaultIdleTimeout.
+	idle time.Duration
+}
+
+// SetIdleTimeout overrides the payload copy's no-progress deadline. A value
+// <= 0 is ignored (the default stands). Call before Upload/Download.
+func (c *Client) SetIdleTimeout(d time.Duration) {
+	if d > 0 {
+		c.idle = d
+	}
 }
 
 // Dial opens a dmsg.Stream to (rPK:port) and returns a Client
@@ -63,6 +75,7 @@ func NewClient(conn net.Conn, remote cipher.PubKey) *Client {
 		conn:   conn,
 		reader: bufio.NewReader(conn),
 		remote: remote,
+		idle:   DefaultIdleTimeout,
 	}
 }
 
@@ -135,7 +148,7 @@ func (c *Client) Download(remotePath, localPath string) error {
 		return closeErr
 	}
 
-	if _, err := io.CopyN(f, c.reader, hdr.Size); err != nil {
+	if _, err := copyNIdle(f, c.reader, hdr.Size, c.conn, c.idle); err != nil {
 		_ = cleanup(false) //nolint:errcheck
 		return fmt.Errorf("dmsgscp: read payload: %w", err)
 	}
@@ -209,7 +222,7 @@ func (c *Client) Upload(localPath, remotePath string) error {
 	}
 	defer f.Close() //nolint:errcheck
 
-	if _, err := io.CopyN(c.conn, f, info.Size()); err != nil {
+	if _, err := copyNIdle(c.conn, f, info.Size(), c.conn, c.idle); err != nil {
 		return fmt.Errorf("dmsgscp: write payload: %w", err)
 	}
 

--- a/pkg/dmsg/dmsgscp/copyidle.go
+++ b/pkg/dmsg/dmsgscp/copyidle.go
@@ -1,0 +1,64 @@
+// Package dmsgscp pkg/dmsg/dmsgscp/copyidle.go c1-net-dmsg
+package dmsgscp
+
+import (
+	"io"
+	"net"
+	"time"
+)
+
+// DefaultIdleTimeout is the no-progress deadline used when a caller does not
+// supply one: a transfer aborts only after this long with zero bytes moving. It
+// bounds a genuine stall without capping the total duration of a healthy
+// transfer of any size.
+const DefaultIdleTimeout = 60 * time.Second
+
+// copyNIdle copies exactly n bytes from src to dst, arming an IDLE (no-progress)
+// deadline on conn before every chunk. The deadline is pushed forward to
+// now+idle on each iteration, so a transfer that keeps moving bytes never times
+// out — regardless of total size or how slow the link is — while a genuine stall
+// (nothing read or written for `idle`) aborts within that window instead of
+// hanging until the underlying conn happens to error, or being cut off by a
+// coarse whole-transfer cap that also kills healthy long transfers.
+//
+// idle <= 0 disables the deadline (unbounded, the old behavior). The deadline is
+// cleared on return so a following control frame (e.g. the final ack) is not
+// bounded by a stale deadline.
+func copyNIdle(dst io.Writer, src io.Reader, n int64, conn net.Conn, idle time.Duration) (int64, error) {
+	const chunk = 64 * 1024
+	buf := make([]byte, chunk)
+	var done int64
+	for done < n {
+		if idle > 0 {
+			_ = conn.SetDeadline(time.Now().Add(idle))
+		}
+		want := n - done
+		if want > int64(len(buf)) {
+			want = int64(len(buf))
+		}
+		nr, rerr := src.Read(buf[:want])
+		if nr > 0 {
+			nw, werr := dst.Write(buf[:nr])
+			done += int64(nw)
+			if werr != nil {
+				return done, werr
+			}
+			if nw < nr {
+				return done, io.ErrShortWrite
+			}
+		}
+		if rerr != nil {
+			if rerr == io.EOF {
+				break
+			}
+			return done, rerr
+		}
+	}
+	if idle > 0 {
+		_ = conn.SetDeadline(time.Time{})
+	}
+	if done < n {
+		return done, io.ErrUnexpectedEOF
+	}
+	return done, nil
+}

--- a/pkg/dmsg/dmsgscp/copyidle_test.go
+++ b/pkg/dmsg/dmsgscp/copyidle_test.go
@@ -1,0 +1,74 @@
+// Package dmsgscp pkg/dmsg/dmsgscp/copyidle_test.go c1-net-dmsg
+package dmsgscp
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCopyNIdle_ProgressNeverTimesOut: a transfer whose TOTAL duration far
+// exceeds the idle timeout completes anyway, because bytes keep moving with
+// each gap under the idle window. This is the property the old fixed
+// whole-transfer cap lacked.
+func TestCopyNIdle_ProgressNeverTimesOut(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close() //nolint:errcheck
+	defer c2.Close() //nolint:errcheck
+
+	chunk := bytes.Repeat([]byte("x"), 4096)
+	const chunks = 10
+	total := chunks * len(chunk)
+
+	go func() {
+		for i := 0; i < chunks; i++ {
+			_ = c2.SetWriteDeadline(time.Now().Add(2 * time.Second))
+			if _, err := c2.Write(chunk); err != nil {
+				return
+			}
+			time.Sleep(15 * time.Millisecond) // gap < idle, but sum >> idle
+		}
+	}()
+
+	var buf bytes.Buffer
+	// idle 60ms; total transfer ~150ms+. Must NOT time out.
+	n, err := copyNIdle(&buf, c1, int64(total), c1, 60*time.Millisecond)
+	require.NoError(t, err)
+	require.Equal(t, int64(total), n)
+	require.Equal(t, total, buf.Len())
+}
+
+// TestCopyNIdle_StallAbortsFast: a stalled transfer (no bytes moving) aborts
+// within a small multiple of the idle window — not never, and not after a
+// coarse whole-transfer cap.
+func TestCopyNIdle_StallAbortsFast(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close() //nolint:errcheck
+	defer c2.Close() //nolint:errcheck
+
+	var buf bytes.Buffer
+	start := time.Now()
+	_, err := copyNIdle(&buf, c1, 100, c1, 30*time.Millisecond) // peer never writes
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Less(t, elapsed, 300*time.Millisecond, "a stall must abort within a few idle windows")
+}
+
+// TestCopyNIdle_ZeroIdleUnbounded: idle<=0 disables the deadline entirely (the
+// legacy behavior) and still copies correctly from a non-blocking source.
+func TestCopyNIdle_ZeroIdleUnbounded(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close() //nolint:errcheck
+	defer c2.Close() //nolint:errcheck
+
+	src := bytes.NewReader(bytes.Repeat([]byte("y"), 5000))
+	var buf bytes.Buffer
+	n, err := copyNIdle(&buf, src, 5000, c1, 0) // conn unused when idle<=0
+	require.NoError(t, err)
+	require.Equal(t, int64(5000), n)
+	require.Equal(t, 5000, buf.Len())
+}

--- a/pkg/dmsg/dmsgscp/host.go
+++ b/pkg/dmsg/dmsgscp/host.go
@@ -305,7 +305,7 @@ func (h *Host) serveSource(_ context.Context, log logrus.FieldLogger, conn net.C
 
 	// io.CopyN exactly the claimed size — guards against runaway
 	// writes if Stat lied between the header write and the read.
-	if _, err := io.CopyN(conn, f, info.Size()); err != nil {
+	if _, err := copyNIdle(conn, f, info.Size(), conn, DefaultIdleTimeout); err != nil {
 		log.WithError(err).Debug("dmsgscp: payload copy failed.")
 		return
 	}
@@ -406,7 +406,7 @@ func (h *Host) serveSink(_ context.Context, log logrus.FieldLogger, conn net.Con
 		}
 	}
 
-	if _, err := io.CopyN(f, r, hdr.Size); err != nil {
+	if _, err := copyNIdle(f, r, hdr.Size, conn, DefaultIdleTimeout); err != nil {
 		log.WithError(err).Debug("dmsgscp: payload copy failed.")
 		cleanup(false)
 		return

--- a/pkg/visor/api_visor_scp.go
+++ b/pkg/visor/api_visor_scp.go
@@ -94,6 +94,7 @@ func (v *Visor) VisorSCP(req VisorSCPRequest) error {
 			transport, req.RemotePK, req.Port, err)
 	}
 	client := dmsgscp.NewClient(conn, req.RemotePK)
+	client.SetIdleTimeout(timeout)
 	defer client.Close() //nolint:errcheck,gosec
 
 	switch req.Direction {


### PR DESCRIPTION
A large `dmsg scp` transfer was governed only by a **fixed whole-transfer timeout** (the 5-minute context wrapping dial+payload), while the payload copy itself — `io.CopyN` in both the host's `serveSource`/`serveSink` and the client's `Upload`/`Download` — had **no deadline at all**. Consequences: a healthy but slow or large transfer could be cut off at the cap despite making steady progress, and a stalled one hung until the cap (or until the conn happened to error). This surfaced pushing a ~124 MB binary over a busy mesh.

The fix replaces the payload `io.CopyN` at all four sites with `copyNIdle`, which arms a deadline on the stream and pushes it to `now+idle` on every chunk. A transfer that keeps moving bytes **never times out — any size, any duration** — while a genuine stall (no bytes for `idle`) aborts within that window instead of hanging or waiting out a coarse total cap. The CLI `--timeout` flag now means the idle/no-progress timeout (default 60s); the visor and standalone paths set it via `SetIdleTimeout`, and the standalone dmsg client now rides a long-lived context (only the dial is bounded) so the transfer is not capped by total duration.

New unit tests cover progress-never-times-out (total duration ≫ idle), stall-aborts-fast, and the `idle<=0` unbounded fallback.