### PR TITLE
fix(router): stop ECF over-feeding a congesting mux leg (BDP trap + cold-start dump)

### DIFF
--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -104,6 +104,12 @@ type legCounters struct {
 	ecfLastSentBytes uint64
 	ecfRttMs         float64
 	ecfJitterMs      float64
+	// ecfRttMinMs is the leg's baseline (minimum observed) RTT — the
+	// uncongested latency. It seeds the stable BDP for cwndBytes and, against
+	// the live ecfRttMs, is the congestion signal ecfSaturated reads. Tracked
+	// as a running minimum with a slow upward creep (ecfRttMinCreep) so a leg
+	// whose true latency genuinely rose is not pinned to a stale floor forever.
+	ecfRttMinMs float64
 }
 
 // routeMux encapsulates route multiplexing state and logic.
@@ -914,6 +920,7 @@ func (m *routeMux) rebuildWeights(tps []*transport.ManagedTransport) {
 			if rttMs > 0 {
 				if lc.ecfRttMs == 0 {
 					lc.ecfRttMs = rttMs
+					lc.ecfRttMinMs = rttMs
 				} else {
 					dev := rttMs - lc.ecfRttMs
 					if dev < 0 {
@@ -921,7 +928,22 @@ func (m *routeMux) rebuildWeights(tps []*transport.ManagedTransport) {
 					}
 					lc.ecfJitterMs = ecfJitterAlpha*dev + (1-ecfJitterAlpha)*lc.ecfJitterMs
 					lc.ecfRttMs = ecfRttAlpha*rttMs + (1-ecfRttAlpha)*lc.ecfRttMs
+					// Baseline RTT = running minimum with a slow upward creep: a
+					// transient congestion spike never raises it, but a leg whose
+					// true latency rose for good is eventually tracked.
+					if rttMs < lc.ecfRttMinMs {
+						lc.ecfRttMinMs = rttMs
+					} else {
+						lc.ecfRttMinMs += ecfRttMinCreep * (lc.ecfRttMs - lc.ecfRttMinMs)
+					}
 				}
+			}
+			// BDP latency = the baseline (uncongested) RTT, never the live RTT,
+			// so a stalling leg's inflating RTT cannot grow its own cwnd and pull
+			// more traffic onto itself.
+			bdpRttMs := lc.ecfRttMinMs
+			if bdpRttMs <= 0 {
+				bdpRttMs = lc.ecfRttMs
 			}
 			ready := true
 			if i < len(m.standby) && m.standby[i] {
@@ -932,9 +954,10 @@ func (m *routeMux) rebuildWeights(tps []*transport.ManagedTransport) {
 			}
 			states[i] = ecfLegState{
 				rttMs:     lc.ecfRttMs,
+				rttMinMs:  lc.ecfRttMinMs,
 				jitterMs:  lc.ecfJitterMs,
 				rateBps:   rate,
-				cwndBytes: rate * lc.ecfRttMs / 1000.0,
+				cwndBytes: rate * bdpRttMs / 1000.0,
 				ready:     ready,
 			}
 		}

--- a/pkg/router/transport_selector.go
+++ b/pkg/router/transport_selector.go
@@ -93,6 +93,28 @@ const (
 	// route_mux.go rebuildWeights). Jitter is the ECF sigma margin.
 	ecfRttAlpha    = 0.3
 	ecfJitterAlpha = 0.3
+	// ecfColdBootstrapBytes bounds how much a leg of unknown capacity (no rate
+	// sample yet, cwndBytes==0) may carry before ecfSaturated forces a spill.
+	// Without it a cold leg is "unlimited", so at download start — when every
+	// leg is cold — ECF returns the single lowest-RTT leg for every frame and
+	// dumps the whole stream on it until the first ~5s rate refresh; that leg
+	// then congests and stalls the global reorder frontier. A bounded probe
+	// budget makes cold start fan out across the ready legs (measuring each)
+	// instead of hammering one. ~1 BDP of a 250ms/2Mbps leg.
+	ecfColdBootstrapBytes = 64 * 1024
+	// ecfCongestRttFactor marks a leg saturated (shed load off it) once its
+	// current mean RTT has ballooned past this multiple of its own baseline
+	// (minimum observed) RTT — the queue-buildup signature of a bandwidth-
+	// congested leg. Guards against the BDP trap: cwnd = rate*RTT grows with
+	// RTT, so an inflating RTT would otherwise raise a stalling leg's apparent
+	// capacity and make ECF feed it more, not less.
+	ecfCongestRttFactor = 4.0
+	// ecfRttMinCreep is the per-refresh fraction of the (mean-baseline) RTT gap
+	// by which a leg's baseline RTT creeps upward when no lower sample is seen.
+	// Keeps the baseline a true floor against transient congestion while still
+	// tracking a leg whose genuine latency has risen for good. Applied on the
+	// ~5s rebuildWeights cadence, so ~0.02 ≈ a minutes-scale adaptation.
+	ecfRttMinCreep = 0.02
 )
 
 // ecfLegState is the per-leg snapshot the ECF scheduler reasons over — one
@@ -105,6 +127,12 @@ type ecfLegState struct {
 	// rttMs is the leg's mean round-trip latency estimate in ms (EWMA of
 	// tp.GetLatency()); 0 = unknown (deprioritized in the fast-leg pick).
 	rttMs float64
+	// rttMinMs is the leg's baseline (minimum observed) RTT in ms — the
+	// uncongested latency. Used two ways: as the stable BDP latency for
+	// cwndBytes (so congestion can't inflate a stalling leg's capacity) and,
+	// against the live rttMs, as the congestion signal in ecfSaturated. 0 =
+	// unknown (no congestion check, cwnd falls back to the live RTT).
+	rttMinMs float64
 	// jitterMs is the ECF sigma: an EWMA of |sample-mean| RTT deviation, used
 	// as the inter-leg jitter margin `d` in the hold-back predicate.
 	jitterMs float64
@@ -847,9 +875,18 @@ func ecfPick(legs []ecfLegState, waiting bool, waitOut *bool) int {
 	// backlog; if xf clears that backlog before xs delivers even one frame
 	// (its RTT plus the jitter margin d), hold on xf instead of spilling.
 	rttF, rttS := legs[xf].rttMs, legs[xs].rttMs
+	// n = how many fast-leg RTTs to drain its current backlog. The drain
+	// denominator is the fast leg's cwnd; for a cold leg (cwnd unknown) fall
+	// back to the same bounded probe budget ecfSaturated uses, so the backlog
+	// registers in the hold-back decision instead of n being pinned at 1 (which
+	// would hold every cold-start frame on the single fastest leg).
+	drain := legs[xf].cwndBytes
+	if drain <= 0 {
+		drain = ecfColdBootstrapBytes
+	}
 	n := 1.0
-	if legs[xf].cwndBytes > 0 {
-		n = 1 + legs[xf].inflightBytes/legs[xf].cwndBytes
+	if drain > 0 {
+		n = 1 + legs[xf].inflightBytes/drain
 	}
 	d := legs[xf].jitterMs
 	if legs[xs].jitterMs > d {
@@ -874,8 +911,20 @@ func ecfPick(legs []ecfLegState, waiting bool, waitOut *bool) int {
 // unknown (no rate/RTT sample yet) is never saturated, so a cold leg is used
 // and measured instead of being assumed full.
 func ecfSaturated(l ecfLegState) bool {
+	// Congestion shed: a leg whose live RTT has ballooned well past its own
+	// uncongested baseline is queue-building — treat it as full so ECF spills
+	// to a healthier leg. This must come before the cwnd check: cwnd grows
+	// with RTT, so without this a congesting leg's rising RTT would raise its
+	// apparent capacity and ECF would feed it more, stalling the reorder
+	// frontier (the observed HoL collapse).
+	if l.rttMinMs > 0 && l.rttMs > ecfCongestRttFactor*l.rttMinMs {
+		return true
+	}
 	if l.cwndBytes <= 0 {
-		return false
+		// Unmeasured leg: allow only a bounded probe budget so cold start fans
+		// out across the ready legs instead of dumping the whole stream on the
+		// single lowest-RTT leg until the first rate refresh.
+		return l.inflightBytes >= ecfColdBootstrapBytes
 	}
 	return l.inflightBytes >= l.cwndBytes
 }

--- a/pkg/router/transport_selector_ecf_test.go
+++ b/pkg/router/transport_selector_ecf_test.go
@@ -220,3 +220,64 @@ func TestSelectECF_BootstrapFallsBackToSchedule(t *testing.T) {
 	idx := ts.SelectECF(512)
 	assert.Contains(t, []int{0, 1}, idx, "bootstrap falls back to a schedule index")
 }
+
+// TestECFSaturated_CongestionShed asserts a leg whose live RTT ballooned past
+// its baseline is treated as saturated even with cwnd headroom — the fix for
+// the BDP trap where a stalling leg's rising RTT would otherwise inflate its
+// cwnd and pull more traffic onto itself.
+func TestECFSaturated_CongestionShed(t *testing.T) {
+	// Baseline 50ms, cwnd 1MB, only 1KB in flight: normally wide-open.
+	healthy := ecfLegState{rttMs: 60, rttMinMs: 50, cwndBytes: 1e6, inflightBytes: 1000}
+	assert.False(t, ecfSaturated(healthy), "leg near its baseline RTT is not saturated")
+
+	// Same leg, live RTT now 5x baseline (queue building): shed it.
+	congested := ecfLegState{rttMs: 250, rttMinMs: 50, cwndBytes: 1e6, inflightBytes: 1000}
+	assert.True(t, ecfSaturated(congested), "leg whose RTT ballooned past its baseline sheds load")
+
+	// Without a baseline (rttMinMs 0) the congestion check is disabled.
+	noBaseline := ecfLegState{rttMs: 250, rttMinMs: 0, cwndBytes: 1e6, inflightBytes: 1000}
+	assert.False(t, ecfSaturated(noBaseline), "no baseline -> no congestion shed")
+}
+
+// TestECFSaturated_ColdBootstrap asserts a leg of unknown capacity (cwnd==0) is
+// usable only up to a bounded probe budget, so cold start fans out across legs
+// instead of dumping the whole stream on one until the first rate refresh.
+func TestECFSaturated_ColdBootstrap(t *testing.T) {
+	cold := ecfLegState{rttMs: 80, cwndBytes: 0, inflightBytes: 0}
+	assert.False(t, ecfSaturated(cold), "cold leg with no backlog is usable")
+
+	probed := ecfLegState{rttMs: 80, cwndBytes: 0, inflightBytes: ecfColdBootstrapBytes}
+	assert.True(t, ecfSaturated(probed), "cold leg spills once its probe budget is spent")
+}
+
+// TestSelectECF_ColdStartFansOut is the integration proof of the cold-start fix
+// on a homogeneous (tight-RTT-band) leg set — the aggregation case. Two cold
+// legs of similar RTT, the fast one already carrying its probe budget. Pre-fix
+// the hold-back predicate pinned n=1 for cold legs and returned leg 0 for every
+// frame (whole stream on one leg until the first rate refresh); now the probe
+// budget registers as backlog so it spills to the sibling and both get measured.
+func TestSelectECF_ColdStartFansOut(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeECF)
+	ts.SetECFState([]ecfLegState{
+		{rttMs: 40, cwndBytes: 0, inflightBytes: ecfColdBootstrapBytes, ready: true},
+		{rttMs: 45, cwndBytes: 0, inflightBytes: 0, ready: true},
+	})
+	idx := ts.SelectForPayload(make([]byte, 512))
+	assert.Equal(t, 1, idx, "cold fast leg past its probe budget spills to the sibling leg")
+}
+
+// TestSelectECF_ColdStartHoldsFarSlowerLeg is the counterpart: a cold fast leg
+// past its probe budget still holds rather than spill to a far-slower leg (3x
+// RTT) — pure ECF is right there, aggregating onto it would only stall the
+// reorder frontier. Guards the cold-start fix against over-spilling.
+func TestSelectECF_ColdStartHoldsFarSlowerLeg(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeECF)
+	ts.SetECFState([]ecfLegState{
+		{rttMs: 40, cwndBytes: 0, inflightBytes: ecfColdBootstrapBytes, ready: true},
+		{rttMs: 300, cwndBytes: 0, inflightBytes: 0, ready: true},
+	})
+	idx := ts.SelectForPayload(make([]byte, 512))
+	assert.Equal(t, 0, idx, "cold fast leg holds rather than spill to a 3x-slower leg")
+}


### PR DESCRIPTION
The ECF mux scheduler collapses a multi-leg download onto one leg and stalls the global reorder frontier — a single `--mux N` connection drops *below* a single leg instead of aggregating. Live trace: a 19-leg group ran at 203 KB/s while one good leg alone does 3+ MB/s, with the whole stream piled on one congested leg (first-hop RTT 66ms→1056ms) and the rest idle.

Two capacity-model defects in the ECF scheduler cause it:

**BDP trap.** `cwnd = rate * RTT` uses the live `GetLatency()` EWMA. When a leg congests, its RTT balloons, which *raises* its cwnd, so `ecfSaturated` fires *less* and ECF feeds the stalling leg *more*. Fix: compute the BDP from a per-leg baseline (minimum-observed) RTT, and mark a leg saturated once its live RTT exceeds 4× that baseline (the queue-buildup signature) so load sheds off it. The baseline is a running minimum with a slow upward creep so a leg whose true latency rose for good is still tracked.

**Cold-start dump.** A leg of unknown capacity (`cwnd==0`) was treated as unlimited, so at download start — every leg cold — ECF returned the single lowest-RTT leg for every frame until the first ~5s rate refresh, and that leg congested. Fix: bound a cold leg to a 64 KB probe budget in both `ecfSaturated` and the hold-back drain term, so cold start fans out across a homogeneous leg set while still correctly holding rather than spilling to a far-slower leg.

Unit tests cover congestion-shed, the cold probe budget, and cold-start fan-out vs. hold on a 3×-slower leg. Constants are first-cut starting values (the ECF block is already marked "expect a live-tuning pass").

Follow-up (not in this PR): `rate` is measured from bytes handed to the send transport, not delivered/acked bytes — a further refinement toward delivery-goodput weighting.