### PR TITLE
feat(router): proactive head-of-line retransmit for mux route groups

### DIFF
--- a/pkg/router/hol_retx.go
+++ b/pkg/router/hol_retx.go
@@ -1,0 +1,218 @@
+// Package router pkg/router/hol_retx.go c2-net-routing
+package router
+
+import (
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// Proactive head-of-line (HoL) retransmit.
+//
+// The mux carries ONE app connection's ordered byte-stream, framed and striped
+// across N legs under a single global sequence. The receiver's reorderBuffer
+// NEVER skips a gap (delivering past a missing seq corrupts the ordered
+// stream), so when the frontier's next-needed seq is on a slow/lagging leg the
+// whole stream stalls while already-arrived frames from fast legs sit buffered.
+//
+// The existing SACK path DOES eventually heal this: the receiver reports the
+// hole and the sender retransmits it on the fastest live leg
+// (resendSeqs -> selectFastestTransport). But it is REACTIVE and slow — the
+// sender's retxMinAge (750ms) presumes a missing seq is merely in flight on a
+// slower leg and refuses to retransmit before then, and the no-arrival fallback
+// (reorderStallServiceFn) only fires after reorderTimeout (1.5s). Either way the
+// stall is bounded by hundreds of ms, so adding legs makes a single download
+// STRICTLY WORSE.
+//
+// Proactive HoL retransmit bounds the stall to ~one FAST-leg RTT instead: when
+// the frontier gap has stayed open longer than roughly one fastest-live-leg RTT
+// (with a low floor of a few ms), the sender retransmits the frontier-blocking
+// seq (and the next few contiguous missing seqs) IMMEDIATELY on the fastest live
+// leg, without waiting out retxMinAge or the slow leg. It reuses the SACK wire
+// message verbatim (the SACK's lastContiguous conveys the stuck frontier =
+// lastContiguous+1); nothing new goes on the wire. The whole behavior is gated
+// behind CapHOLRetx negotiated at handshake, so a peer that doesn't advertise it
+// cleanly falls back to today's reactive SACK behavior. The no-skip invariant is
+// untouched — this makes the gap FILL faster, it never skips it.
+
+const (
+	// holRetxGapFloor is the low floor on the frontier-gap age that triggers a
+	// proactive HoL retransmit. Below any realistic inter-leg latency skew a gap
+	// is ordinary interleave, not a stall, so never nudge faster than this even
+	// when the fastest leg's RTT is tiny (LAN legs). A few ms.
+	holRetxGapFloor = 4 * time.Millisecond
+	// holRetxRTTFactor scales the fastest-live-leg RTT into the gap-age threshold.
+	// ~1.0 == "one fast-leg RTT": long enough that genuine skew (the missing seq
+	// arriving on its own slower leg) usually resolves without a retransmit, short
+	// enough that a real stall is healed in about one fast round-trip.
+	holRetxRTTFactor = 1.0
+	// holRetxMaxFill bounds how many contiguous missing seqs one proactive nudge
+	// retransmits: the frontier seq plus the next few holes behind it. Small so a
+	// nudge heals the head of the stall without dumping the whole in-flight window
+	// (that is what the demote-time forced flush is for), and so a single SACK
+	// can't provoke a large retransmit burst.
+	holRetxMaxFill = 4
+	// holRetxPerSeqFloor is the low floor on the per-seq re-nudge interval, so a
+	// persistently-stuck frontier seq is not resent in a storm even on tiny-RTT
+	// legs. Mirrors holRetxGapFloor.
+	holRetxPerSeqFloor = 4 * time.Millisecond
+)
+
+// holGapThreshold returns the frontier-gap age past which a proactive HoL
+// retransmit is warranted, given the fastest live leg's RTT in ms. It is
+// max(floor, RTT*factor): a few ms floor, otherwise about one fast-leg RTT. A
+// non-positive RTT (no latency measured yet) falls back to the floor.
+func holGapThreshold(fastestRTTms float64) time.Duration {
+	if fastestRTTms <= 0 {
+		return holRetxGapFloor
+	}
+	d := time.Duration(fastestRTTms*holRetxRTTFactor) * time.Millisecond
+	if d < holRetxGapFloor {
+		return holRetxGapFloor
+	}
+	return d
+}
+
+// holPerSeqInterval returns the minimum spacing between successive proactive
+// retransmits of the SAME seq, given the fastest live leg's RTT in ms. A seq
+// should not be re-nudged before a fresh retransmit could plausibly have arrived
+// and been acked — about one fast-leg RTT — so this is max(floor, RTT). A
+// non-positive RTT falls back to the floor.
+func holPerSeqInterval(fastestRTTms float64) time.Duration {
+	if fastestRTTms <= 0 {
+		return holRetxPerSeqFloor
+	}
+	d := time.Duration(fastestRTTms) * time.Millisecond
+	if d < holRetxPerSeqFloor {
+		return holRetxPerSeqFloor
+	}
+	return d
+}
+
+// frontierMissingSeqs extracts the head-of-line region from a received SACK: the
+// stuck frontier seq (lastContiguous+1) and the run of contiguous MISSING seqs
+// immediately behind it, up to max. It stops at the first RECEIVED seq (a set
+// bit) — those aren't blocking and the receiver already holds them — and at the
+// end of the reported bitmap. Returns nil when the SACK reports no out-of-order
+// window (empty bitmap): with no frames buffered above the contiguous point
+// there is no HoL stall to heal, only a normal in-flight tail.
+//
+// Word w bit i set means seq (lastContiguous+1 + w*64 + i) has been received,
+// matching sackTracker.GenerateSACK / retxBuffer.ProcessSACK.
+func frontierMissingSeqs(lastContiguous uint32, words []uint64, max int) []uint32 {
+	if len(words) == 0 || max <= 0 {
+		return nil
+	}
+	var out []uint32
+	for w, word := range words {
+		for i := uint32(0); i < 64; i++ {
+			if word&(1<<i) != 0 {
+				return out // first received seq ends the contiguous frontier run
+			}
+			seq := lastContiguous + 1 + uint32(w)*64 + i
+			out = append(out, seq)
+			if len(out) >= max {
+				return out
+			}
+		}
+	}
+	return out
+}
+
+// holRetxTracker is the sender-side per-seq rate limiter for proactive HoL
+// retransmits. It records the last time each seq was proactively retransmitted
+// so a persistently-stuck frontier seq is nudged at most once per fast-leg RTT
+// (via Due), rather than resent on every SACK — the self-amplifying storm
+// retxMinAge guards against on the reactive path, which the proactive path must
+// guard against on its own because it deliberately bypasses retxMinAge.
+type holRetxTracker struct {
+	mu       sync.Mutex
+	lastNano map[uint32]int64
+}
+
+func newHolRetxTracker() *holRetxTracker {
+	return &holRetxTracker{lastNano: make(map[uint32]int64)}
+}
+
+// Due reports whether seq may be proactively retransmitted at time now given the
+// minimum per-seq interval, and records now as the send time when it returns
+// true. A seq never nudged before is always due.
+func (t *holRetxTracker) Due(seq uint32, interval time.Duration, now time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	nowNano := now.UnixNano()
+	if prev, ok := t.lastNano[seq]; ok && nowNano-prev < int64(interval) {
+		return false
+	}
+	t.lastNano[seq] = nowNano
+	return true
+}
+
+// Purge drops tracked seqs at or below belowSeq. Called with the SACK's
+// lastContiguous so the map only ever holds still-outstanding frontier seqs and
+// cannot grow without bound as the stream advances.
+func (t *holRetxTracker) Purge(belowSeq uint32) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for seq := range t.lastNano {
+		if seq <= belowSeq {
+			delete(t.lastNano, seq)
+		}
+	}
+}
+
+// fastestLegLatency returns the lowest positive measured RTT (ms) across the
+// mux's live, ready, non-standby legs, or 0 when none has a measurement yet.
+// This is the leg a proactive retransmit will actually ride
+// (selectFastestTransport), so its RTT sets both the gap-age threshold and the
+// per-seq re-nudge interval. Caller holds rg.mu (reads the tps slice).
+func (m *routeMux) fastestLegLatency(tps []*transport.ManagedTransport) float64 {
+	best := 0.0
+	for idx, tp := range tps {
+		if tp == nil || tp.IsClosed() || !m.legReadyAt(idx) {
+			continue
+		}
+		lat := tp.GetLatency()
+		if lat <= 0 {
+			continue
+		}
+		if best == 0 || lat < best {
+			best = lat
+		}
+	}
+	return best
+}
+
+// proactiveRetxSeqs is the sender-side decision for a received SACK: which
+// frontier seqs to retransmit NOW on the fastest leg, bypassing retxMinAge.
+// Returns nil (a clean no-op fallback) when HoL retx was not negotiated, so a
+// peer without CapHOLRetx keeps today's purely reactive behavior. Otherwise it
+// takes the head-of-line run from the SACK (frontierMissingSeqs), keeps only the
+// seqs we still hold in the retx buffer, and per-seq rate-limits them to one
+// nudge per fast-leg RTT (holRetxTracker.Due). fastestRTTms is the fastest live
+// leg's measured RTT, used for the per-seq interval. It also purges the tracker
+// below lastContiguous so it can't grow without bound.
+func (m *routeMux) proactiveRetxSeqs(lastContiguous uint32, words []uint64, fastestRTTms float64, now time.Time) []uint32 {
+	if !m.holRetxEnabled || m.retxBuf == nil || m.holRetx == nil {
+		return nil
+	}
+	m.holRetx.Purge(lastContiguous)
+	cand := frontierMissingSeqs(lastContiguous, words, holRetxMaxFill)
+	if len(cand) == 0 {
+		return nil
+	}
+	interval := holPerSeqInterval(fastestRTTms)
+	var due []uint32
+	for _, seq := range cand {
+		// Only retransmit seqs we still hold: a seq already purged from the retx
+		// buffer was acknowledged, so it is not the one blocking the frontier.
+		if m.retxBuf.Get(seq) == nil {
+			continue
+		}
+		if m.holRetx.Due(seq, interval, now) {
+			due = append(due, seq)
+		}
+	}
+	return due
+}

--- a/pkg/router/hol_retx_test.go
+++ b/pkg/router/hol_retx_test.go
@@ -1,0 +1,341 @@
+//go:build !tinygo || (js && wasm)
+
+package router
+
+import (
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// TestHolGapThreshold pins the frontier-gap-age threshold: a few-ms floor, else
+// about one fastest-live-leg RTT, with a non-positive RTT falling back to floor.
+func TestHolGapThreshold(t *testing.T) {
+	tests := []struct {
+		name      string
+		fastestMs float64
+		want      time.Duration
+	}{
+		{"no measurement -> floor", 0, holRetxGapFloor},
+		{"negative -> floor", -5, holRetxGapFloor},
+		{"tiny LAN RTT clamps to floor", 1, holRetxGapFloor},
+		{"at floor boundary", 4, 4 * time.Millisecond},
+		{"one fast-leg RTT", 20, 20 * time.Millisecond},
+		{"wan RTT", 150, 150 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := holGapThreshold(tt.fastestMs); got != tt.want {
+				t.Errorf("holGapThreshold(%v) = %v, want %v", tt.fastestMs, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHolPerSeqInterval pins the per-seq re-nudge spacing: a floor, else one
+// fast-leg RTT, non-positive RTT falling back to floor.
+func TestHolPerSeqInterval(t *testing.T) {
+	tests := []struct {
+		name      string
+		fastestMs float64
+		want      time.Duration
+	}{
+		{"no measurement -> floor", 0, holRetxPerSeqFloor},
+		{"tiny RTT clamps to floor", 2, holRetxPerSeqFloor},
+		{"one fast-leg RTT", 40, 40 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := holPerSeqInterval(tt.fastestMs); got != tt.want {
+				t.Errorf("holPerSeqInterval(%v) = %v, want %v", tt.fastestMs, got, tt.want)
+			}
+		})
+	}
+}
+
+// bits builds a SACK bitmap word from the set bit indices, so tests can express
+// "seqs at these offsets above lastContiguous are received" readably.
+func bits(idxs ...uint32) uint64 {
+	var w uint64
+	for _, i := range idxs {
+		w |= 1 << i
+	}
+	return w
+}
+
+// TestFrontierMissingSeqs pins extraction of the head-of-line run from a SACK:
+// the stuck frontier (lastContiguous+1) plus contiguous holes behind it, stopping
+// at the first received seq, capped at max, and nil for an empty bitmap.
+func TestFrontierMissingSeqs(t *testing.T) {
+	tests := []struct {
+		name  string
+		last  uint32
+		words []uint64
+		max   int
+		want  []uint32
+	}{
+		{
+			name: "empty bitmap -> nil (no HoL stall)",
+			last: 10, words: nil, max: 4, want: nil,
+		},
+		{
+			name: "max zero -> nil",
+			last: 10, words: []uint64{bits(1, 2)}, max: 0, want: nil,
+		},
+		{
+			// frontier=11 missing (bit0 unset), 12 received (bit1 set) ends the run.
+			name: "single frontier hole, next received",
+			last: 10, words: []uint64{bits(1, 2, 3)}, max: 4, want: []uint32{11},
+		},
+		{
+			// bits 0..2 unset (11,12,13 missing), bit3 set (14 received) ends run.
+			name: "contiguous run of holes then received",
+			last: 10, words: []uint64{bits(3, 5)}, max: 4, want: []uint32{11, 12, 13},
+		},
+		{
+			// all-zero word: every seq in window missing, capped at max.
+			name: "all missing, capped at max",
+			last: 100, words: []uint64{0}, max: 4, want: []uint32{101, 102, 103, 104},
+		},
+		{
+			// hole run spans the 64-bit word boundary: word0 all unset (seqs 1..64),
+			// word1 bit0 unset (seq 65), word1 bit1 set (seq 66 received) ends the
+			// run. max is generous so the word boundary, not the cap, is what stops it.
+			name: "spans word boundary",
+			last: 0, words: []uint64{0, bits(1)}, max: 128, want: seqRange(1, 65),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := frontierMissingSeqs(tt.last, tt.words, tt.max)
+			if !equalSeqs(got, tt.want) {
+				t.Errorf("frontierMissingSeqs(%d,%v,%d) = %v, want %v", tt.last, tt.words, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHolRetxTrackerDue pins the per-seq rate limit: first send always due, a
+// re-send inside the interval refused, a re-send past the interval allowed, and
+// distinct seqs tracked independently.
+func TestHolRetxTrackerDue(t *testing.T) {
+	tr := newHolRetxTracker()
+	base := time.Unix(0, 0)
+	interval := 20 * time.Millisecond
+
+	if !tr.Due(5, interval, base) {
+		t.Fatal("first nudge of seq 5 must be due")
+	}
+	if tr.Due(5, interval, base.Add(5*time.Millisecond)) {
+		t.Error("seq 5 re-nudged inside interval must NOT be due")
+	}
+	if tr.Due(5, interval, base.Add(19*time.Millisecond)) {
+		t.Error("seq 5 just under interval must NOT be due")
+	}
+	if !tr.Due(5, interval, base.Add(25*time.Millisecond)) {
+		t.Error("seq 5 past interval must be due again")
+	}
+	// A different seq is independent — always due on first sight.
+	if !tr.Due(6, interval, base.Add(5*time.Millisecond)) {
+		t.Error("distinct seq 6 must be due on first sight regardless of seq 5")
+	}
+}
+
+// TestHolRetxTrackerPurge: Purge drops tracked seqs at/below the acked frontier
+// so the map stays bounded, and a purged seq is due again immediately.
+func TestHolRetxTrackerPurge(t *testing.T) {
+	tr := newHolRetxTracker()
+	base := time.Unix(0, 0)
+	interval := time.Second
+
+	tr.Due(10, interval, base)
+	tr.Due(11, interval, base)
+	tr.Due(12, interval, base)
+
+	tr.Purge(11) // drop 10 and 11
+
+	// 12 is still tracked -> not due inside interval.
+	if tr.Due(12, interval, base.Add(time.Millisecond)) {
+		t.Error("seq 12 should still be rate-limited after purging <=11")
+	}
+	// 10 was purged -> due again immediately.
+	if !tr.Due(10, interval, base.Add(time.Millisecond)) {
+		t.Error("purged seq 10 must be due again")
+	}
+}
+
+// TestFastestLegLatency: lowest positive RTT among live, ready, non-standby legs;
+// skips standby / not-ready / closed / unmeasured; 0 when none qualifies.
+func TestFastestLegLatency(t *testing.T) {
+	t.Run("lowest positive among ready", func(t *testing.T) {
+		m := &routeMux{}
+		m.growLegs(3)
+		m.markLegReady(1)
+		m.markLegReady(2)
+		tps := []*transport.ManagedTransport{mockTP(200), mockTP(50), mockTP(300)}
+		if got := m.fastestLegLatency(tps); got != 50 {
+			t.Errorf("fastestLegLatency = %v, want 50", got)
+		}
+	})
+	t.Run("skips standby fastest", func(t *testing.T) {
+		m := &routeMux{}
+		m.growLegs(3)
+		m.markLegReady(1)
+		m.markLegReady(2)
+		m.setLegStandby(1, true) // fastest but parked
+		tps := []*transport.ManagedTransport{mockTP(200), mockTP(50), mockTP(300)}
+		if got := m.fastestLegLatency(tps); got != 200 {
+			t.Errorf("fastestLegLatency = %v, want 200 (standby 50 skipped)", got)
+		}
+	})
+	t.Run("skips not-ready aux leg", func(t *testing.T) {
+		m := &routeMux{}
+		m.growLegs(2) // leg 1 never marked ready
+		tps := []*transport.ManagedTransport{mockTP(200), mockTP(20)}
+		if got := m.fastestLegLatency(tps); got != 200 {
+			t.Errorf("fastestLegLatency = %v, want 200 (leg1 not ready)", got)
+		}
+	})
+	t.Run("no measurement -> 0", func(t *testing.T) {
+		m := &routeMux{}
+		m.growLegs(2)
+		m.markLegReady(1)
+		tps := []*transport.ManagedTransport{mockTP(0), mockTP(0)}
+		if got := m.fastestLegLatency(tps); got != 0 {
+			t.Errorf("fastestLegLatency = %v, want 0", got)
+		}
+	})
+}
+
+// TestProactiveRetxSeqs is the sender-side decision, including the
+// capability-gated fallback: with HoL retx OFF it is a clean no-op; with it ON
+// it returns held frontier seqs, skips seqs not in the retx buffer, and per-seq
+// rate-limits a re-nudge inside one interval.
+func TestProactiveRetxSeqs(t *testing.T) {
+	newMux := func(holOn bool) *routeMux {
+		m := newRouteMux(nil, true) // sackEnabled true
+		m.holRetxEnabled = holOn
+		return m
+	}
+	// SACK: lastContiguous=100, bitmap word with bits 0..2 unset (101,102,103
+	// missing) and bit3 set (104 received) — frontier run is 101,102,103.
+	last := uint32(100)
+	words := []uint64{bits(3)}
+	now := time.Unix(0, 0)
+
+	t.Run("capability off -> nil fallback", func(t *testing.T) {
+		m := newMux(false)
+		m.retxBuf.Store(101, []byte("a"))
+		m.retxBuf.Store(102, []byte("b"))
+		if got := m.proactiveRetxSeqs(last, words, 20, now); got != nil {
+			t.Errorf("HoL disabled must return nil, got %v", got)
+		}
+	})
+
+	t.Run("returns held frontier seqs", func(t *testing.T) {
+		m := newMux(true)
+		m.retxBuf.Store(101, []byte("a"))
+		m.retxBuf.Store(102, []byte("b"))
+		m.retxBuf.Store(103, []byte("c"))
+		got := m.proactiveRetxSeqs(last, words, 20, now)
+		if !equalSeqs(got, []uint32{101, 102, 103}) {
+			t.Errorf("got %v, want [101 102 103]", got)
+		}
+	})
+
+	t.Run("skips seqs not in retx buffer", func(t *testing.T) {
+		m := newMux(true)
+		// 102 already acked/purged -> not retransmitted; 101,103 held.
+		m.retxBuf.Store(101, []byte("a"))
+		m.retxBuf.Store(103, []byte("c"))
+		got := m.proactiveRetxSeqs(last, words, 20, now)
+		if !equalSeqs(got, []uint32{101, 103}) {
+			t.Errorf("got %v, want [101 103]", got)
+		}
+	})
+
+	t.Run("per-seq rate limit within interval", func(t *testing.T) {
+		m := newMux(true)
+		m.retxBuf.Store(101, []byte("a"))
+		m.retxBuf.Store(102, []byte("b"))
+		m.retxBuf.Store(103, []byte("c"))
+		// fastestMs=20 -> interval 20ms.
+		first := m.proactiveRetxSeqs(last, words, 20, now)
+		if !equalSeqs(first, []uint32{101, 102, 103}) {
+			t.Fatalf("first nudge got %v, want [101 102 103]", first)
+		}
+		// Immediately again: all inside interval -> nothing due.
+		if again := m.proactiveRetxSeqs(last, words, 20, now.Add(5*time.Millisecond)); again != nil {
+			t.Errorf("re-nudge inside interval must be nil, got %v", again)
+		}
+		// Past the interval -> due again.
+		later := m.proactiveRetxSeqs(last, words, 20, now.Add(25*time.Millisecond))
+		if !equalSeqs(later, []uint32{101, 102, 103}) {
+			t.Errorf("re-nudge past interval got %v, want [101 102 103]", later)
+		}
+	})
+
+	t.Run("empty bitmap -> nil (no stall)", func(t *testing.T) {
+		m := newMux(true)
+		m.retxBuf.Store(101, []byte("a"))
+		if got := m.proactiveRetxSeqs(last, nil, 20, now); got != nil {
+			t.Errorf("empty SACK bitmap must return nil, got %v", got)
+		}
+	})
+}
+
+// TestMergeSeqs pins the de-dup union used to fold a proactive nudge into the
+// reactive SACK retransmit list so a shared seq is sent only once.
+func TestMergeSeqs(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []uint32
+		want []uint32
+	}{
+		{"both empty", nil, nil, nil},
+		{"a empty", nil, []uint32{1, 2}, []uint32{1, 2}},
+		{"b empty", []uint32{3}, nil, []uint32{3}},
+		{"disjoint", []uint32{1, 2}, []uint32{3, 4}, []uint32{1, 2, 3, 4}},
+		{"overlap deduped", []uint32{1, 2, 3}, []uint32{2, 3, 5}, []uint32{1, 2, 3, 5}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergeSeqs(tt.a, tt.b); !equalSeqs(got, tt.want) {
+				t.Errorf("mergeSeqs(%v,%v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- small test helpers ---
+
+func seqRange(lo, hi uint32) []uint32 {
+	out := make([]uint32, 0, hi-lo+1)
+	for s := lo; s <= hi; s++ {
+		out = append(out, s)
+	}
+	return out
+}
+
+func equalSeqs(a, b []uint32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// compile-time assurance the routing capability bit is distinct from its
+// neighbors (a bug here would silently alias two capabilities on the wire).
+var _ = func() bool {
+	if routing.CapHOLRetx == routing.CapPerFrameNoise || routing.CapHOLRetx == routing.CapSACK {
+		panic("CapHOLRetx aliases another capability bit")
+	}
+	return true
+}()

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -384,6 +384,10 @@ type MuxInfo struct {
 	MuxEnabled bool
 	// SACKEnabled is true when the peers negotiated SACK retx.
 	SACKEnabled bool
+	// HOLRetxEnabled is true when the peers negotiated CapHOLRetx (proactive
+	// head-of-line retransmit — the frontier-blocking seq is fast-retransmitted on
+	// the fastest leg after ~one fast-leg RTT instead of the reactive waits).
+	HOLRetxEnabled bool
 	// PerFrameNoise is true when both edges negotiated CapPerFrameNoise and the
 	// mux is sealing/opening each DATA frame under its own sequence-nonce (the
 	// inverse-multiplexer path, network.EncryptConn bypassed). False means the
@@ -454,6 +458,7 @@ func (rg *RouteGroup) MuxStats() MuxInfo {
 	if rg.mux != nil {
 		info.MuxEnabled = true
 		info.SACKEnabled = rg.mux.sackEnabled
+		info.HOLRetxEnabled = rg.mux.holRetxEnabled
 		info.Distribution = rg.mux.distributionMode().String()
 		info.ReorderPending = rg.mux.reorderPending()
 		info.ReorderGapAge = rg.mux.gapAge()
@@ -2448,7 +2453,7 @@ func (rg *RouteGroup) sendHandshake(encrypt bool) error {
 		}
 
 		rule := rg.fwd[i]
-		caps := routing.CapMux | routing.CapSACK
+		caps := routing.CapMux | routing.CapSACK | routing.CapHOLRetx
 		var packet routing.Packet
 		if pfn := rg.perFrameNoiseCap(encrypt); pfn != 0 {
 			msg, mErr := rg.nextPerFrameNoiseMsg()
@@ -2631,6 +2636,13 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 				if sack {
 					rg.logger.Debug("SACK retransmission enabled (both peers support CapSACK)")
 					go rg.servicePacketLoop("sack", rg.cfg.KeepAliveInterval/2, rg.sackServiceFn, nil)
+					// Proactive HoL retransmit reuses the SACK channel, so it is only
+					// enabled when SACK is too. Both peers must advertise CapHOLRetx;
+					// otherwise the group keeps the reactive SACK behavior.
+					if remoteCaps&routing.CapHOLRetx != 0 {
+						rg.mux.holRetxEnabled = true
+						rg.logger.Debug("Proactive HoL retransmit enabled (both peers support CapHOLRetx)")
+					}
 				}
 
 				// Per-frame noise negotiation (both edges advertised CapPerFrameNoise
@@ -2764,6 +2776,25 @@ func (rg *RouteGroup) handleDataPacket(packet routing.Packet) (err error) {
 			go rg.sendSACK() //nolint:errcheck
 		}
 
+		// Proactive HoL nudge (CapHOLRetx). When the reorder frontier has stayed
+		// gap-blocked for ~one fastest-live-leg RTT (low floor of a few ms), promptly
+		// send the sender a SACK so it fast-retransmits the stuck frontier seq on a
+		// fast leg — bounding the stall to a fast-leg RTT instead of the reactive
+		// retxMinAge/reorderTimeout waits. Cheap-guarded (only when a gap is actually
+		// buffered) so the common in-order path pays nothing, and rate-limited to one
+		// nudge per fast-leg RTT via its own holSACKNano clock. Arrival-driven: the
+		// fast legs keep delivering out-of-order frames while blocked, so this fires
+		// promptly once the threshold passes without needing a tight timer.
+		if rg.mux.holRetxEnabled && rg.mux.reorderPending() > 0 {
+			rg.mu.Lock()
+			fastMs := rg.mux.fastestLegLatency(rg.tps)
+			rg.mu.Unlock()
+			interval := holPerSeqInterval(fastMs)
+			if rg.mux.gapAge() > holGapThreshold(fastMs) && rg.mux.shouldSendHolSACK(interval) {
+				go rg.sendSACK() //nolint:errcheck
+			}
+		}
+
 		for _, d := range delivered {
 			// Both rg.closed (local-initiated close) and
 			// rg.remoteClosed (remote-initiated close) must be
@@ -2844,7 +2875,24 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 	lastContig := packet.SACKLastContiguousSeq()
 	words := packet.SACKWords()
 
+	// Normal reactive retransmit: holes overdue past retxMinAge.
 	retxSeqs := rg.mux.processSACK(lastContig, words)
+
+	// Proactive HoL retransmit (CapHOLRetx): the frontier-blocking seq (and the
+	// next few contiguous holes) retransmitted NOW on the fastest leg, bypassing
+	// retxMinAge, per-seq rate-limited to one nudge per fast-leg RTT. No-op (nil)
+	// when HoL retx was not negotiated, so a peer without CapHOLRetx keeps the
+	// reactive-only path above. Merged with retxSeqs and de-duplicated so the same
+	// frontier seq is never sent twice for one SACK.
+	if rg.mux.holRetxEnabled {
+		rg.mu.Lock()
+		fastMs := rg.mux.fastestLegLatency(rg.tps)
+		rg.mu.Unlock()
+		if due := rg.mux.proactiveRetxSeqs(lastContig, words, fastMs, time.Now()); len(due) > 0 {
+			retxSeqs = mergeSeqs(retxSeqs, due)
+		}
+	}
+
 	if len(retxSeqs) == 0 {
 		return nil
 	}
@@ -2852,6 +2900,34 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 	rg.logger.Debugf("SACK: retransmitting %d packets", len(retxSeqs))
 
 	return rg.resendSeqs(retxSeqs)
+}
+
+// mergeSeqs returns the union of two seq lists, de-duplicated, so a proactive
+// HoL retransmit and a reactive SACK retransmit that name the same seq in one
+// SACK resend it only once. Order is not significant to resendSeqs (each seq is
+// selected onto the fastest leg independently), so a simple set union suffices.
+func mergeSeqs(a, b []uint32) []uint32 {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[uint32]struct{}, len(a)+len(b))
+	out := make([]uint32, 0, len(a)+len(b))
+	for _, s := range a {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	for _, s := range b {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // resendSeqs retransmits the given held sequences on the FASTEST live,

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -141,6 +141,16 @@ type routeMux struct {
 	sackTracker *sackTracker // receiver: tracks received seqs for SACK generation
 	retxBuf     *retxBuffer  // sender: holds unACKed packets for retransmission
 
+	// Proactive head-of-line retransmit (see hol_retx.go). holRetxEnabled is true
+	// when both peers advertised CapHOLRetx (implies sackEnabled — it reuses the
+	// SACK wire message). When false the mux keeps today's purely reactive SACK
+	// behavior. holRetx is the sender-side per-seq rate limiter for proactive
+	// retransmits; holSACKNano rate-limits the receiver-side proactive HoL SACK
+	// (separate from lastSACKNano so it doesn't fight the window-ack SACK limiter).
+	holRetxEnabled bool
+	holRetx        *holRetxTracker
+	holSACKNano    int64 // atomic: UnixNano of the last proactive HoL SACK we sent
+
 	// Per-frame noise (inverse-mux). When CapPerFrameNoise is negotiated the
 	// RouteGroup installs these: seal AEAD-encrypts each outgoing frame under
 	// its sequence-nonce (in wrapPayload, before retx storage so retransmits
@@ -234,6 +244,9 @@ func newRouteMux(logger *logging.Logger, sackEnabled bool) *routeMux {
 		// window so a genuinely-lost sequence is still held for retransmit
 		// while the receiver is holding the gap open for it.
 		retxBuf: newRetxBuffer(reorderWindow),
+		// Proactive HoL retransmit tracker is always constructed; it is only
+		// consulted when holRetxEnabled is set at handshake (see hol_retx.go).
+		holRetx: newHolRetxTracker(),
 	}
 	// Default every mux to ECF (Earliest Completion First). It only spills a
 	// frame onto a slower leg once the fastest leg is saturated (a full BDP in
@@ -788,6 +801,22 @@ func (m *routeMux) shouldSendSACK() bool {
 		return false
 	}
 	return atomic.CompareAndSwapInt64(&m.lastSACKNano, prev, now)
+}
+
+// shouldSendHolSACK reports whether enough time has elapsed since the last
+// PROACTIVE HoL SACK to send another, rate-limited to about one fast-leg RTT
+// (interval) so a persistent frontier stall re-nudges the sender roughly once
+// per round-trip rather than on every arriving out-of-order packet. Uses its own
+// holSACKNano clock, independent of the window-ack SACK limiter (shouldSendSACK),
+// so the two never rate-limit each other out. Concurrency-safe: only the
+// goroutine that wins the CAS returns true.
+func (m *routeMux) shouldSendHolSACK(interval time.Duration) bool {
+	now := time.Now().UnixNano()
+	prev := atomic.LoadInt64(&m.holSACKNano)
+	if now-prev < int64(interval) {
+		return false
+	}
+	return atomic.CompareAndSwapInt64(&m.holSACKNano, prev, now)
 }
 
 // generateSACK returns the current SACK state for sending to the peer:

--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -84,7 +84,7 @@ func (r *router) appendRouteAsymmetric(nrg *NoiseRouteGroup, rules routing.EdgeR
 		lastTp := rg.tps[lastIdx]
 		lastRule := rg.fwd[lastIdx]
 		rg.mu.Unlock()
-		packet := routing.MakeHandshakePacket(lastRule.NextRouteID(), rg.encrypt, routing.CapMux|routing.CapSACK)
+		packet := routing.MakeHandshakePacket(lastRule.NextRouteID(), rg.encrypt, routing.CapMux|routing.CapSACK|routing.CapHOLRetx)
 		if err := rg.writePacket(context.Background(), lastTp, packet, lastRule.KeyRouteID()); err != nil {
 			r.logger.WithError(err).Warn("Failed to send handshake on additional mux transport")
 		}
@@ -180,7 +180,7 @@ func (r *router) appendRouteToGroup(nrg *NoiseRouteGroup, rules routing.EdgeRule
 	lastRule := rg.fwd[lastIdx]
 	rg.mu.Unlock()
 
-	packet := routing.MakeHandshakePacket(lastRule.NextRouteID(), rg.encrypt, routing.CapMux|routing.CapSACK)
+	packet := routing.MakeHandshakePacket(lastRule.NextRouteID(), rg.encrypt, routing.CapMux|routing.CapSACK|routing.CapHOLRetx)
 	if err := rg.writePacket(context.Background(), lastTp, packet, lastRule.KeyRouteID()); err != nil {
 		r.logger.WithError(err).Warn("Failed to send handshake on additional mux transport")
 	}

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -145,6 +145,16 @@ const (
 	// handshake also carries a piggybacked noise KK message (after the 3-byte
 	// enc+caps prefix), and network.EncryptConn is bypassed.
 	CapPerFrameNoise uint16 = 1 << 3
+	// CapHOLRetx: the peer supports PROACTIVE head-of-line retransmit inside the
+	// mux. When BOTH edges advertise it (and CapSACK, which it reuses), a receiver
+	// whose reorder frontier has been gap-blocked for ~one fastest-live-leg RTT
+	// prompts the sender with a SACK, and the sender immediately retransmits the
+	// stuck frontier seq on its fastest live leg — bypassing the reactive
+	// retxMinAge/reorderTimeout waits — so a single multi-leg download's stall is
+	// bounded by a fast-leg RTT instead of collapsing below single-leg rate. It
+	// adds NO new wire message (the existing SACK carries the frontier); a peer
+	// without this bit cleanly falls back to the reactive SACK behavior.
+	CapHOLRetx uint16 = 1 << 4
 )
 
 // SeqSize is the byte size of the sequence number prepended to DataPacket


### PR DESCRIPTION
A single `--mux N` proxy connection stripes one ordered byte-stream across N legs under a single global sequence, reassembled by a no-skip reorder buffer. When the frontier's next-needed seq is on a slower leg, the whole stream stalls while already-arrived frames from fast legs sit buffered — head-of-line blocking. Measured: adding legs makes a single download strictly worse (1 leg 7 MB/s → 6 legs 3.5 MB/s).

The existing SACK path already heals this — the receiver reports the hole, the sender retransmits it on the fastest live leg — but reactively: the sender's `retxMinAge` (750ms) assumes a missing seq is merely in flight on a slower leg, and the no-arrival fallback fires only after `reorderTimeout` (1.5s). Either way the stall is hundreds of ms.

This adds a proactive path that bounds the stall to ~one fastest-live-leg RTT. When the frontier gap stays open longer than roughly one fast-leg RTT (few-ms floor), the sender retransmits the frontier-blocking seq (and the next few contiguous holes) immediately on the fastest live leg, bypassing `retxMinAge`. It reuses the SACK wire message verbatim — the SACK's `lastContiguous` conveys the stuck frontier — so nothing new goes on the wire. Storm-guarded by a per-seq rate limiter (one nudge per fast RTT) and `holRetxMaxFill=4` (head of the stall only). The no-skip invariant is untouched: this makes the gap fill faster, never skips it.

Gated behind a new negotiated capability `CapHOLRetx` (handshake bit, requires SACK); a peer that doesn't advertise it falls back to today's reactive behavior, so mixed-version fleets interoperate unchanged.

New pure logic (`hol_retx.go`) is unit-tested (`hol_retx_test.go`): gap-threshold/interval scaling, frontier-hole extraction from a SACK bitmap, per-seq rate limiting, and the capability-gated fallback. Constants (`holRetxRTTFactor=1.0`, 4ms floors, `holRetxMaxFill=4`) are first-cut tuning knobs.