### PR TITLE
fix(router): demote gross-latency-outlier mux legs to standby in all modes

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1882,10 +1882,15 @@ type bandLeg struct {
 // stalling the no-skip reorder buffer — the multi-leg collapse. LOW-side demotion
 // (a leg far FASTER than the median — the classic LAN short-circuit artifact that
 // neither the adaptive engine's high-side outlier logic nor a manual preset
-// excludes today) is universal. HIGH-side demotion and re-promotion are gated to
-// manualMode: in adaptive mode the tick owns the high side and a 512-deep warm
-// pool that must not be dumped into the active set. Pure (no locks / rg state) so
-// it is unit-tested directly. Never demotes the primary or the last active leg.
+// excludes today) is universal. HIGH-side DEMOTION is now also universal: a leg
+// whose latency exceeds bandDemoteRatio*median stalls the no-skip reorder
+// frontier (a self-healed or churned-in 1200ms+ leg beside a 60ms band collapses
+// the mux to ~0), so it is demoted to warm standby in every mode — the observed
+// cause of multi-leg download collapse. Only re-PROMOTION stays gated to
+// manualMode: in adaptive mode the tick owns re-admission and its 512-deep warm
+// pool must not be dumped into the active set (demotion to standby never dumps
+// the pool, so it is safe to run always). Pure (no locks / rg state) so it is
+// unit-tested directly. Never demotes the primary or the last active leg.
 func partitionLatencyBand(legs []bandLeg, manualMode bool) (demote, promote []int) {
 	known := make([]float64, 0, len(legs))
 	for _, l := range legs {
@@ -1917,7 +1922,7 @@ func partitionLatencyBand(legs []bandLeg, manualMode bool) (demote, promote []in
 		slowerRatio := l.latMs / med // >1 when the leg is slower than the median
 		switch {
 		case !l.standby && !l.primary && active > 1 &&
-			(fasterRatio > bandDemoteRatio || (manualMode && slowerRatio > bandDemoteRatio)):
+			(fasterRatio > bandDemoteRatio || slowerRatio > bandDemoteRatio):
 			demote = append(demote, l.idx)
 			active-- // never demote below one active leg
 		case manualMode && l.standby:

--- a/pkg/router/route_group_latencyband_test.go
+++ b/pkg/router/route_group_latencyband_test.go
@@ -53,15 +53,26 @@ func TestPartitionLatencyBand(t *testing.T) {
 			wantDemote: []int{3}, wantPromote: nil,
 		},
 		{
-			name: "high-side outlier kept active in adaptive mode (tick owns the high side)",
+			name: "high-side outlier demoted in adaptive mode too (frontier-stall guard)",
 			legs: []bandLeg{
 				{idx: 0, latMs: 150, primary: true},
 				{idx: 1, latMs: 155},
 				{idx: 2, latMs: 145},
-				{idx: 3, latMs: 700},
+				{idx: 3, latMs: 700}, // ~4.6x median: stalls the reorder frontier
+			},
+			manual:     false, // demotion-to-standby is universal; only re-promotion stays manual
+			wantDemote: []int{3}, wantPromote: nil,
+		},
+		{
+			name: "self-healed 1200ms leg demoted out of a 60ms band in adaptive mode",
+			legs: []bandLeg{
+				{idx: 0, latMs: 54, primary: true},
+				{idx: 1, latMs: 64},
+				{idx: 2, latMs: 91},
+				{idx: 3, latMs: 1223}, // the observed collapse-causing churn-in leg
 			},
 			manual:     false,
-			wantDemote: nil, wantPromote: nil,
+			wantDemote: []int{3}, wantPromote: nil,
 		},
 		{
 			name: "primary is never demoted even when it is the outlier",


### PR DESCRIPTION
`partitionLatencyBand` gated high-side demotion to manual mode, so in the adaptive / self-heal path a leg whose latency is far above the active-set median stayed in the active stripe set. Self-heal restores the mux leg *count* on a leg death but re-dials arbitrary legs, routinely pulling in a 1200ms+ route beside a ~60ms band. That leg stalls the no-skip reorder frontier and collapses a multi-leg download to ~0.

Measured on a pinned homogeneous pair (both ends on #4255): the pair holds ~17.7 MB/s with no collapse, but the moment a churned-in 1223ms leg joins the active set, throughput drops to single-digit KB/s. Every multi-leg collapse traced back to a gross-latency-outlier leg in the active set that nothing demoted.

Demotion to warm standby never dumps the adaptive warm pool into the active set (that is re-promotion, which stays manual-gated — the adaptive tick still owns re-admission). So high-side demotion is safe to run in every mode: a leg more than `bandDemoteRatio`×median (either side) is now demoted regardless of mode. Never demotes the primary or the last active leg. Unit tests updated/added for the adaptive-mode high-side cases.