### PR TITLE
fix(cli): proxy switch — gate on leg-alive not non-standby; render switch op

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_ops.go
+++ b/cmd/skywire-cli/commands/proxy/mux_ops.go
@@ -377,17 +377,20 @@ func primaryLegTpID(rg muxRouteGroupInfo) (uuid.UUID, error) {
 	return id, nil
 }
 
-// muxSwitchWaitReady polls until the leg carried over newTpID is present,
-// alive, and out of warm-standby (selectable for sending), or timeout elapses.
-// This is what keeps the switch seamless: the old primary is not retired until
-// the new leg can carry the stream.
+// muxSwitchWaitReady polls until the leg carried over newTpID is present and
+// alive (its rules confirmed end-to-end), or timeout elapses. This is what
+// keeps the switch seamless: the old primary is not retired until the new leg
+// is established and can carry the stream. It need not be out of warm-standby —
+// retiring the old primary promotes the survivor into the active primary slot;
+// requiring non-standby here would deadlock, since the adaptive policy parks a
+// freshly-added leg in the warm pool until load widens the active set.
 func muxSwitchWaitReady(rpcClient visor.API, newTpID uuid.UUID, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	want := newTpID.String()
 	for {
 		if rg, err := muxSwitchSelectRG(rpcClient); err == nil {
 			for _, l := range rg.Legs {
-				if l.TransportID == want && l.Alive && !l.Standby {
+				if l.TransportID == want && l.Alive {
 					return nil
 				}
 			}

--- a/pkg/cliout/cliproxy/cliproxy.go
+++ b/pkg/cliout/cliproxy/cliproxy.go
@@ -46,6 +46,9 @@ func (m MuxOp) Human(w io.Writer) error {
 	case "width":
 		_, err := fmt.Fprintf(w, "mux steady active width set to %s\n", m.Mode)
 		return err
+	case "switch":
+		_, err := fmt.Fprintf(w, "switched primary route to a %d-hop leg (first tp=%s) on app=%s; old primary retired\n", m.Hops, m.TransportID, m.App)
+		return err
 	default:
 		_, err := fmt.Fprintf(w, "mux mode set to %s\n", m.Mode)
 		return err


### PR DESCRIPTION
Two fixes to `proxy switch` (#4258):

- The readiness gate waited for the new leg to be alive **and** out of warm-standby. Under the adaptive policy a freshly-added leg is parked in the warm pool until load widens the active set, so that gate never cleared and every switch timed out (old primary kept — no switch). Retiring the old primary is what promotes the survivor into the active primary slot anyway, so waiting for the leg to be **alive** (rules confirmed end-to-end) is the correct and sufficient seamlessness gate.
- `MuxOp.Human` had no case for `op="switch"`, so it fell through to the default and misprinted "mux mode set to". Added the switch line.

Verified live with the relaxed gate: the primary re-homes onto the new route in flight (observed `027120db` → `0287c628`) while the route group stays up.