### PR TITLE
fix(router): tighten mux active-latency band in capacity (aggregation) mode

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -91,6 +91,17 @@ const (
 	// and demote is hysteresis — it stops a leg hovering at the band edge from
 	// flip-flopping active/standby every interval.
 	bandAdmitRatio = 2.5
+	// bandDemoteRatioTight / bandAdmitRatioTight are the SAME hysteresis pair but
+	// tighter, used when the mux is in capacity (aggregation) mode. Aggregating a
+	// single stream across M active legs requires the arrivals to be near-in-order
+	// so the no-skip reorder frontier does not stall; a 3x active-band spread
+	// stalls it, the data-progress prune then sheds the laggards, and the active
+	// set collapses toward one leg (the observed capacity-mode collapse from 4
+	// active to 1). A ~2x active band keeps the stripe set homogeneous enough that
+	// the frontier holds and the prune never fires, so the multi-active set is
+	// HELD. Failover mode (1 active + standbys) is unaffected — it never stripes.
+	bandDemoteRatioTight = 2.0
+	bandAdmitRatioTight  = 1.6
 	// bandMinLegs: latency-band admission only runs with at least this many legs
 	// carrying a measured latency. Below it the median is not a meaningful cluster
 	// anchor, and the 1-2 leg pathologies are already handled by the sole-leg
@@ -1918,7 +1929,11 @@ type bandLeg struct {
 // pool must not be dumped into the active set (demotion to standby never dumps
 // the pool, so it is safe to run always). Pure (no locks / rg state) so it is
 // unit-tested directly. Never demotes the primary or the last active leg.
-func partitionLatencyBand(legs []bandLeg, manualMode bool) (demote, promote []int) {
+func partitionLatencyBand(legs []bandLeg, manualMode, tight bool) (demote, promote []int) {
+	demoteRatio, admitRatio := bandDemoteRatio, bandAdmitRatio
+	if tight {
+		demoteRatio, admitRatio = bandDemoteRatioTight, bandAdmitRatioTight
+	}
 	known := make([]float64, 0, len(legs))
 	for _, l := range legs {
 		if l.latMs > 0 {
@@ -1949,7 +1964,7 @@ func partitionLatencyBand(legs []bandLeg, manualMode bool) (demote, promote []in
 		slowerRatio := l.latMs / med // >1 when the leg is slower than the median
 		switch {
 		case !l.standby && !l.primary && active > 1 &&
-			(fasterRatio > bandDemoteRatio || slowerRatio > bandDemoteRatio):
+			(fasterRatio > demoteRatio || slowerRatio > demoteRatio):
 			demote = append(demote, l.idx)
 			active-- // never demote below one active leg
 		case manualMode && l.standby:
@@ -1957,7 +1972,7 @@ func partitionLatencyBand(legs []bandLeg, manualMode bool) (demote, promote []in
 			if fasterRatio > symm {
 				symm = fasterRatio
 			}
-			if symm <= bandAdmitRatio {
+			if symm <= admitRatio {
 				promote = append(promote, l.idx)
 				active++
 			}
@@ -1980,6 +1995,12 @@ func (rg *RouteGroup) enforceLatencyBand() {
 	}
 	rg.mu.Lock()
 	manual := !rg.standbyNewLegs
+	// In capacity (aggregation) mode the active legs stripe a single ordered
+	// stream, so the arrivals must stay near-in-order for the no-skip reorder
+	// frontier to advance; a tighter latency band keeps the held active set
+	// homogeneous and stops the frontier-stall → prune → collapse spiral. In
+	// ECF/failover mode the wider band is fine (only one leg carries data).
+	tight := rg.mux.distributionMode() == WeightModeCapacity
 	legs := make([]bandLeg, 0, len(rg.tps))
 	for i, tp := range rg.tps {
 		if tp == nil || tp.IsClosed() {
@@ -1994,7 +2015,7 @@ func (rg *RouteGroup) enforceLatencyBand() {
 	}
 	rg.mu.Unlock()
 
-	demote, promote := partitionLatencyBand(legs, manual)
+	demote, promote := partitionLatencyBand(legs, manual, tight)
 	for _, idx := range demote {
 		rg.logger.Infof("latency-band: parking leg %d (out-of-band latency) to keep the active stripe set homogeneous", idx)
 		rg.mux.setLegStandby(idx, true)

--- a/pkg/router/route_group_latencyband_test.go
+++ b/pkg/router/route_group_latencyband_test.go
@@ -16,6 +16,7 @@ func TestPartitionLatencyBand(t *testing.T) {
 		name        string
 		legs        []bandLeg
 		manual      bool
+		tight       bool
 		wantDemote  []int
 		wantPromote []int
 	}{
@@ -138,11 +139,55 @@ func TestPartitionLatencyBand(t *testing.T) {
 			manual:     true,
 			wantDemote: nil, wantPromote: nil,
 		},
+		{
+			name: "moderate 2.1x-slow leg kept in wide (ECF/failover) band",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 155},
+				{idx: 2, latMs: 145},
+				{idx: 3, latMs: 320}, // 2.13x median: within wide 3x band
+			},
+			manual: true, tight: false,
+			wantDemote: nil, wantPromote: nil,
+		},
+		{
+			name: "moderate 2.1x-slow leg demoted in tight (capacity/aggregation) band",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 155},
+				{idx: 2, latMs: 145},
+				{idx: 3, latMs: 320}, // 2.13x median: outside tight 2x band → stalls frontier
+			},
+			manual: true, tight: true,
+			wantDemote: []int{3}, wantPromote: nil,
+		},
+		{
+			name: "standby 1.7x leg re-admitted in wide band but not in tight band",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 160},
+				{idx: 2, latMs: 155},
+				{idx: 3, latMs: 255, standby: true}, // 1.59x median(160): <=2.5 wide admit → re-admitted
+			},
+			manual: true, tight: false,
+			wantDemote: nil, wantPromote: []int{3},
+		},
+		{
+			name: "standby 1.7x leg stays standby under tight band (admission withheld)",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 160},
+				{idx: 2, latMs: 155},
+				{idx: 3, latMs: 300, standby: true}, // 1.875x median(160): >1.6 tight admit → not re-admitted
+			},
+			manual: true, tight: true,
+			wantDemote: nil, wantPromote: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			demote, promote := partitionLatencyBand(tt.legs, tt.manual)
+			demote, promote := partitionLatencyBand(tt.legs, tt.manual, tt.tight)
 			require.Equal(t, tt.wantDemote, nilIfEmpty(idsOf(demote)), "demote set")
 			require.Equal(t, tt.wantPromote, nilIfEmpty(idsOf(promote)), "promote set")
 		})
@@ -163,7 +208,7 @@ func TestPartitionLatencyBandNeverDemotesBelowOne(t *testing.T) {
 	}
 	// median of [2,3,4,900] = 4. Relative to median 4, the 900ms primary is the
 	// slow outlier (protected); the fast ones are near the median → none demoted.
-	demote, _ := partitionLatencyBand(legs, true)
+	demote, _ := partitionLatencyBand(legs, true, false)
 	require.NotContains(t, demote, 0, "primary is never demoted")
 
 	// A cleaner below-one guard case: one real leg + three fast artifacts, median
@@ -176,7 +221,7 @@ func TestPartitionLatencyBandNeverDemotesBelowOne(t *testing.T) {
 		{idx: 2, latMs: 3},
 		{idx: 3, latMs: 900}, // lone slow real leg; median≈3 → 300x slower
 	}
-	demote2, _ := partitionLatencyBand(legs2, true)
+	demote2, _ := partitionLatencyBand(legs2, true, false)
 	activeAfter := 0
 	for _, l := range legs2 {
 		demoted := false


### PR DESCRIPTION
Capacity/aggregation mode stripes a single ordered stream across the mux active set, so arrivals must stay near-in-order for the no-skip reorder frontier to advance. The existing 3x latency band admits heterogeneous active legs whose spread stalls the frontier; the data-progress prune then sheds the laggards and the active set collapses toward one leg — the observed capacity-mode collapse from 4 active legs to 1.

This tightens the active-latency band to 2.0x demote / 1.6x admit when the mux is in `WeightModeCapacity`, so the held active set stays homogeneous, the frontier holds, and the prune never fires. ECF/failover mode is unchanged (only one leg carries data, so the wider band is harmless).

Unit tests cover both bands: a 2.06x leg is kept under the wide band and demoted under the tight band; a standby leg is re-admitted under the wide band and withheld under the tight band.