### PR TITLE
fix(router): dynamically re-elect the mux primary leg when it is out of band

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1981,6 +1981,106 @@ func partitionLatencyBand(legs []bandLeg, manualMode, tight bool) (demote, promo
 	return demote, promote
 }
 
+// pickPrimaryReelection decides whether the PRIMARY slot (leg 0) should be
+// re-elected onto a healthier leg. The primary is the always-ready, always-
+// selectable anchor, so it is exempt from band demotion (partitionLatencyBand
+// never demotes it) — but that means a primary that is itself a gross latency
+// outlier (a 2ms LAN short-circuit artifact, or a self-healed 14000ms leg that
+// landed at index 0) permanently anchors the active set off-band and wastes an
+// active slot. This picker names a replacement so the primary can CHANGE
+// dynamically instead of being protected in place: when leg 0 is out of band
+// (its faster/slower ratio to the median exceeds demoteRatio) AND a non-primary
+// ACTIVE leg sits within admitRatio of the median, it returns that leg's index —
+// the lowest-latency in-band active candidate, which becomes the new primary via
+// a make-before-break swap (reelectPrimary). It returns ok=false unless a
+// replacement exists, so the group never gives up its anchor without one. Pure
+// (no locks / rg state) so it is unit-tested directly.
+func pickPrimaryReelection(legs []bandLeg, tight bool) (newPrimaryIdx int, ok bool) {
+	demoteRatio, admitRatio := bandDemoteRatio, bandAdmitRatio
+	if tight {
+		demoteRatio, admitRatio = bandDemoteRatioTight, bandAdmitRatioTight
+	}
+	known := make([]float64, 0, len(legs))
+	var primary *bandLeg
+	for i := range legs {
+		if legs[i].primary {
+			primary = &legs[i]
+		}
+		if legs[i].latMs > 0 {
+			known = append(known, legs[i].latMs)
+		}
+	}
+	if primary == nil || primary.latMs <= 0 || len(known) < bandMinLegs {
+		return 0, false
+	}
+	sort.Float64s(known)
+	med := known[len(known)/2]
+	if med <= 0 {
+		return 0, false
+	}
+	// Is the primary itself a gross outlier?
+	pFaster, pSlower := med/primary.latMs, primary.latMs/med
+	if pFaster <= demoteRatio && pSlower <= demoteRatio {
+		return 0, false // primary is in band — leave it
+	}
+	// Find the best (lowest-latency) in-band ACTIVE non-primary replacement.
+	bestIdx, bestLat := -1, 0.0
+	for i := range legs {
+		l := legs[i]
+		if l.primary || l.standby || l.latMs <= 0 {
+			continue
+		}
+		symm := l.latMs / med
+		if med/l.latMs > symm {
+			symm = med / l.latMs
+		}
+		if symm > admitRatio {
+			continue // candidate must itself be in band
+		}
+		if bestIdx == -1 || l.latMs < bestLat {
+			bestIdx, bestLat = l.idx, l.latMs
+		}
+	}
+	if bestIdx == -1 {
+		return 0, false
+	}
+	return bestIdx, true
+}
+
+// reelectPrimary swaps the leg at newIdx into the primary slot (index 0),
+// make-before-break: the parallel tps[]/fwd[]/rvs[] entries and the mux's per-leg
+// counters/readiness/standby markers are exchanged in lockstep so each rule and
+// counter stays attached to its own transport, and the route group — with the
+// noise/yamux session riding it — is never torn down. The chosen leg is already
+// active and carrying (pickPrimaryReelection selects only from the ready, in-band
+// active set), so index 0 has a live send leg the instant the swap returns and
+// the byte stream continues uninterrupted. The displaced old primary lands at
+// newIdx as an ordinary (now demotable) leg, to be parked by the band pass if it
+// is out of band. Caller must NOT hold rg.mu.
+func (rg *RouteGroup) reelectPrimary(newIdx int) {
+	rg.mu.Lock()
+	defer rg.mu.Unlock()
+	if newIdx <= 0 || newIdx >= len(rg.tps) {
+		return
+	}
+	rg.tps[0], rg.tps[newIdx] = rg.tps[newIdx], rg.tps[0]
+	if newIdx < len(rg.fwd) {
+		rg.fwd[0], rg.fwd[newIdx] = rg.fwd[newIdx], rg.fwd[0]
+	}
+	if newIdx < len(rg.rvs) {
+		rg.rvs[0], rg.rvs[newIdx] = rg.rvs[newIdx], rg.rvs[0]
+	}
+	rg.mux.swapLegs(0, newIdx)
+	// forwardHops records the PRIMARY leg's path (used for self-heal shared-hop
+	// exclusion and mux info); re-point it at the new primary's stored hops.
+	if rg.tps[0] != nil {
+		if hops, okHops := rg.legForwardHops[rg.tps[0].Entry.ID]; okHops {
+			rg.forwardHops = hops
+		}
+	}
+	rg.logger.Infof("latency-band: re-elected leg %d into the primary slot (old primary was an out-of-band outlier)", newIdx)
+}
+
 // enforceLatencyBand keeps the mux's active stripe set within a tight latency
 // band (see partitionLatencyBand). Runs on the data-progress cadence so it holds
 // even in a manual (non-adaptive) preset, where nothing else manages the active
@@ -2014,6 +2114,31 @@ func (rg *RouteGroup) enforceLatencyBand() {
 		})
 	}
 	rg.mu.Unlock()
+
+	// If the primary slot itself is a gross latency outlier, re-elect a healthier
+	// active leg into it (make-before-break) BEFORE the band pass. The primary is
+	// exempt from demotion, so without this a bad leg that lands at index 0 (a
+	// LAN-artifact or a self-healed multi-second leg) anchors the active set off-
+	// band forever. After the swap the leg indices have changed, so rebuild the
+	// list; the displaced old primary is now an ordinary leg the band pass can
+	// park.
+	if newPrimary, ok := pickPrimaryReelection(legs, tight); ok {
+		rg.reelectPrimary(newPrimary)
+		rg.mu.Lock()
+		legs = legs[:0]
+		for i, tp := range rg.tps {
+			if tp == nil || tp.IsClosed() {
+				continue
+			}
+			legs = append(legs, bandLeg{
+				idx:     i,
+				latMs:   rg.legEndToEndLatencyMs(tp.Entry.ID),
+				standby: rg.mux.isLegStandby(i),
+				primary: i == 0,
+			})
+		}
+		rg.mu.Unlock()
+	}
 
 	demote, promote := partitionLatencyBand(legs, manual, tight)
 	for _, idx := range demote {

--- a/pkg/router/route_group_latencyband_test.go
+++ b/pkg/router/route_group_latencyband_test.go
@@ -244,6 +244,103 @@ func nilIfEmpty(v []int) []int {
 	return v
 }
 
+func TestPickPrimaryReelection(t *testing.T) {
+	tests := []struct {
+		name        string
+		legs        []bandLeg
+		tight       bool
+		wantIdx     int
+		wantOK      bool
+	}{
+		{
+			name: "primary in band: no re-election",
+			legs: []bandLeg{
+				{idx: 0, latMs: 150, primary: true},
+				{idx: 1, latMs: 160},
+				{idx: 2, latMs: 145},
+			},
+			wantOK: false,
+		},
+		{
+			name: "primary is a 2ms LAN artifact: re-elect fastest in-band active leg",
+			legs: []bandLeg{
+				{idx: 0, latMs: 2, primary: true}, // absurd short-circuit primary
+				{idx: 1, latMs: 160},
+				{idx: 2, latMs: 145}, // fastest in-band non-primary → new primary
+				{idx: 3, latMs: 155},
+			},
+			wantIdx: 2, wantOK: true,
+		},
+		{
+			name: "primary is a 1500ms self-healed leg: re-elect out of the band",
+			legs: []bandLeg{
+				{idx: 0, latMs: 1500, primary: true},
+				{idx: 1, latMs: 240},
+				{idx: 2, latMs: 250},
+				{idx: 3, latMs: 190}, // fastest in-band → new primary
+			},
+			wantIdx: 3, wantOK: true,
+		},
+		{
+			name: "primary out of band but every replacement is standby: keep the anchor",
+			legs: []bandLeg{
+				{idx: 0, latMs: 2, primary: true},
+				{idx: 1, latMs: 240, standby: true},
+				{idx: 2, latMs: 250, standby: true},
+				{idx: 3, latMs: 190, standby: true},
+			},
+			wantOK: false,
+		},
+		{
+			name: "candidate itself out of band is not eligible",
+			legs: []bandLeg{
+				{idx: 0, latMs: 2, primary: true}, // out-of-band primary
+				{idx: 1, latMs: 150},
+				{idx: 2, latMs: 155},
+				{idx: 3, latMs: 900}, // 6x median, not eligible; 1 and 2 are
+			},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name: "fewer than bandMinLegs: no re-election",
+			legs: []bandLeg{
+				{idx: 0, latMs: 2, primary: true},
+				{idx: 1, latMs: 200},
+			},
+			wantOK: false,
+		},
+		{
+			name: "2.1x-slow primary: not re-elected under wide band",
+			legs: []bandLeg{
+				{idx: 0, latMs: 330, primary: true}, // 2.06x median(160): within wide 3x
+				{idx: 1, latMs: 150},
+				{idx: 2, latMs: 155},
+				{idx: 3, latMs: 160},
+			},
+			tight: false, wantOK: false,
+		},
+		{
+			name: "2.1x-slow primary: re-elected under tight (aggregation) band",
+			legs: []bandLeg{
+				{idx: 0, latMs: 330, primary: true}, // 2.06x median(160): outside tight 2x
+				{idx: 1, latMs: 150},
+				{idx: 2, latMs: 155},
+				{idx: 3, latMs: 160},
+			},
+			tight: true, wantIdx: 1, wantOK: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, ok := pickPrimaryReelection(tt.legs, tt.tight)
+			require.Equal(t, tt.wantOK, ok, "ok")
+			if tt.wantOK {
+				require.Equal(t, tt.wantIdx, idx, "new primary index")
+			}
+		})
+	}
+}
+
 // TestEnforceLatencyBandParksArtifactLeg drives the full rg path: four active
 // legs where one is a 2ms LAN-short-circuit artifact beside a 150ms cluster. In
 // manual mode enforceLatencyBand must park the artifact into warm standby (so it
@@ -275,4 +372,48 @@ func TestEnforceLatencyBandParksArtifactLeg(t *testing.T) {
 	rg.legLivenessMu.Unlock()
 	rg.enforceLatencyBand()
 	require.False(t, rg.mux.isLegStandby(3), "leg back within band is re-admitted in manual mode")
+}
+
+// TestEnforceLatencyBandReelectsBadPrimary drives the full rg path when the
+// PRIMARY slot (index 0) is itself the out-of-band leg (a 2ms LAN artifact). The
+// primary is exempt from demotion, so the fix must instead re-elect a healthy
+// in-band active leg into slot 0 (make-before-break) and then park the displaced
+// old primary. Verifies the primary slot changes dynamically instead of anchoring
+// the active set off-band.
+func TestEnforceLatencyBandReelectsBadPrimary(t *testing.T) {
+	rg, mts, _ := createMuxRouteGroup(t, 4)
+
+	oldPrimaryID := mts[0].Entry.ID
+
+	rg.legLivenessMu.Lock()
+	if rg.legE2ELatency == nil {
+		rg.legE2ELatency = map[uuid.UUID]float64{}
+	}
+	rg.legE2ELatency[mts[0].Entry.ID] = 2 // primary is a LAN short-circuit artifact
+	rg.legE2ELatency[mts[1].Entry.ID] = 150
+	rg.legE2ELatency[mts[2].Entry.ID] = 155
+	rg.legE2ELatency[mts[3].Entry.ID] = 145
+	rg.legLivenessMu.Unlock()
+
+	rg.enforceLatencyBand()
+
+	// The primary slot must now hold a healthy in-band leg, not the old 2ms one.
+	rg.mu.Lock()
+	newPrimaryID := rg.tps[0].Entry.ID
+	rg.mu.Unlock()
+	require.NotEqual(t, oldPrimaryID, newPrimaryID, "the out-of-band primary must be re-elected out of slot 0")
+
+	// leg 0 (the new primary) is active; the group still has a selectable anchor.
+	require.False(t, rg.mux.isLegStandby(0), "the re-elected primary is active")
+
+	// The displaced old primary (2ms artifact) must now be parked to warm standby.
+	parkedOld := false
+	rg.mu.Lock()
+	for i, tp := range rg.tps {
+		if tp != nil && tp.Entry.ID == oldPrimaryID {
+			parkedOld = rg.mux.isLegStandby(i)
+		}
+	}
+	rg.mu.Unlock()
+	require.True(t, parkedOld, "the displaced 2ms artifact must be parked to warm standby after re-election")
 }

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -550,6 +550,41 @@ func (m *routeMux) setLegStandby(idx int, standby bool) {
 	m.legMu.Unlock()
 }
 
+// swapLegs exchanges the mux's per-leg state (counters, readiness, standby
+// marker) between two leg indices so the primary slot (0) can be RE-ELECTED
+// onto a healthier leg without tearing down any route. The caller (RouteGroup.
+// reelectPrimary) swaps the parallel tps[]/fwd[]/rvs[] entries in the same
+// critical section, so leg accounting and rules stay attached to their own
+// transport across the swap. After the swap the new primary (whatever leg landed
+// at index 0) is forced ready and out of standby — it is chosen from the active,
+// carrying set, so this is belt-and-suspenders, not a state change. Bounds-
+// checked; a no-op if either index is out of range or i == j.
+func (m *routeMux) swapLegs(i, j int) {
+	if i == j || i < 0 || j < 0 {
+		return
+	}
+	m.legMu.Lock()
+	defer m.legMu.Unlock()
+	if i < len(m.legs) && j < len(m.legs) {
+		m.legs[i], m.legs[j] = m.legs[j], m.legs[i]
+	}
+	if i < len(m.ready) && j < len(m.ready) {
+		m.ready[i], m.ready[j] = m.ready[j], m.ready[i]
+	}
+	if i < len(m.standby) && j < len(m.standby) {
+		m.standby[i], m.standby[j] = m.standby[j], m.standby[i]
+	}
+	// Re-assert the leg-0 invariants: the primary is always ready and never
+	// standby. (The re-elected leg was active and carrying, so this only guards
+	// against a stale flag.)
+	if len(m.ready) > 0 {
+		m.ready[0] = true
+	}
+	if len(m.standby) > 0 {
+		m.standby[0] = false
+	}
+}
+
 // isLegStandby reports whether leg idx is a warm standby. Bounds-checked.
 func (m *routeMux) isLegStandby(idx int) bool {
 	if idx < 0 {


### PR DESCRIPTION
The primary leg (index 0) is the always-ready, always-selectable anchor and is exempt from latency-band demotion. That protection let a bad leg that lands at index 0 — a 2ms LAN short-circuit artifact, or a self-healed multi-second leg — permanently anchor the active stripe set off-band and waste an active slot. Measured live, the mux held only ~2 active legs (a garbage primary + one real leg) instead of the target width, with the primary carrying almost nothing while a single good leg carried the stream.

This makes the primary slot dynamic. When leg 0 is itself a gross latency outlier and a healthy in-band active leg exists, that leg is re-elected into slot 0 via a make-before-break lockstep swap (tps/fwd/rvs plus the mux's per-leg counters/readiness/standby), with no route teardown — the chosen leg is already carrying, so the send path never gaps. The displaced old primary becomes an ordinary demotable leg that the band pass then parks to warm standby. The group never gives up its anchor without a ready replacement.

`pickPrimaryReelection` is pure and unit-tested across both bands; an integration test drives the full route-group path (bad 2ms primary → re-elected, old primary parked).