### PR TITLE
fix(log): stop truncating PKs in logs/CLI and demote teardown frame WARN

### DIFF
--- a/cmd/skywire-cli/commands/mdisc/check.go
+++ b/cmd/skywire-cli/commands/mdisc/check.go
@@ -79,7 +79,7 @@ scheduled CI job.`,
 			if e.Server == nil {
 				continue
 			}
-			label := e.Static.String()[:8]
+			label := e.Static.String()
 			ws := e.Server.AddressWS
 			if ws == "" {
 				cmd.Printf("!  %s  %-21s  NO AddressWS — unreachable for browser/wasm visors\n", label, e.Server.Address)

--- a/cmd/skywire-cli/commands/svc/health.go
+++ b/cmd/skywire-cli/commands/svc/health.go
@@ -289,7 +289,7 @@ func queryServiceViaServer(cmd *cobra.Command) skyvisor.ServiceHealthEntry {
 	if err != nil {
 		internal.PrintFatalError(cmd.Flags(), err)
 	}
-	entry.Transport = "dmsg via " + srv.Static.String()[:8]
+	entry.Transport = "dmsg via " + srv.Static.String()
 
 	myPK, mySK := cipher.GenerateKeyPair()
 	dClient := direct.NewClient(direct.GetAllEntries(cipher.PubKeys{myPK, svcPK}, []*disc.Entry{srv}), log)

--- a/pkg/dmsg/dmsg/stream.go
+++ b/pkg/dmsg/dmsg/stream.go
@@ -321,7 +321,7 @@ func (s *Stream) prepareFields(init bool, lAddr, rAddr Addr) error {
 	// this dmsg stream (yamux/smux/QUIC) — identical across transports, so the
 	// relay never sees client↔client plaintext regardless of dmsg-over-QUIC.
 	s.nsConn = noise.NewReadWriter(s.muxStream(), s.ns)
-	s.log = s.ses.log.WithField("stream", s.lAddr.ShortString()+"->"+s.rAddr.ShortString())
+	s.log = s.ses.log.WithField("stream", s.lAddr.String()+"->"+s.rAddr.String())
 	return nil
 }
 

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -181,7 +181,14 @@ func (r *router) serveTransportManager(ctx context.Context) {
 				return
 			}
 
-			r.logger.Warnf("Failed to handle transport frame: %v", err)
+			// Rule-not-found / route-descriptor-does-not-exist fire per-packet
+			// for stale or torn-down routes and are normal during teardown, so
+			// demote them to DEBUG; keep genuinely unexpected frame errors at WARN.
+			if errors.Is(err, routing.ErrRuleNotFound) || errors.Is(err, errRouteDescNotExist) {
+				r.logger.WithError(err).Debug("Dropped transport frame for stale route")
+			} else {
+				r.logger.Warnf("Failed to handle transport frame: %v", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Three small, self-contained logging fixes. Public keys must always render in full (64-hex), and a per-packet WARN was flooding the router log on route teardown.

- **dmsg stream log field** (`pkg/dmsg/dmsg/stream.go`): the `stream` log field used `Addr.ShortString()`, which truncates the PK to 8 chars. Switched to `Addr.String()` so the full PK appears. `ShortString()` had no other callers.
- **CLI output** (`cmd/skywire-cli/commands/svc/health.go`, `cmd/skywire-cli/commands/mdisc/check.go`): both truncated the server's static PK to 8 chars with `[:8]`. Now print the full key. Columns use `%s` for the fixed-length key so alignment is preserved.
- **router serve loop** (`pkg/router/router_serve.go`): `Failed to handle transport frame` logged at WARN for every packet hitting a stale/torn-down route — normal during teardown, and a large share of log volume. Only the two expected teardown sentinels (`routing.ErrRuleNotFound`, `errRouteDescNotExist`, matched via `errors.Is` since they propagate wrapped with `%w`) are demoted to DEBUG; all other frame errors stay at WARN.

`go build .` passes. `go test ./pkg/router/ ./pkg/dmsg/...` passes except the two Redis store tests, which fail only because no local Redis is running (`dial tcp [::1]:6379: connection refused`) — pre-existing, environmental, unrelated to this change.