### PR TITLE
fix(router): fast-cluster latency band + mux data-plane observability

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -318,6 +318,13 @@ type RouteGroup struct {
 	// tested. Guarded by legLivenessMu (NEVER held while taking rg.mu).
 	legLivenessMu sync.Mutex
 	legPongSeen   map[uuid.UUID]bool
+
+	// reorderWedge* track the reorder-stall service's WARN throttling: ticks since
+	// the current wedge started (0 = not wedged) and the gap age at the last log,
+	// so a sustained wedge logs ~once per reorderTimeout instead of every tick.
+	// Touched only from the single reorder-stall service goroutine.
+	reorderWedgeTicks    int
+	reorderWedgeLoggedAt time.Duration
 	legMissed     map[uuid.UUID]int
 	inflightPings map[int64]uuid.UUID
 	// legE2ELatency is the EWMA-smoothed END-TO-END round-trip latency per leg,
@@ -1754,10 +1761,30 @@ func (rg *RouteGroup) reorderStallServiceFn(_ time.Duration) {
 	// gap: the RouteGroup is a reliable ordered net.Conn (TCP/TLS rides it), so
 	// delivering past a hole corrupts the stream. The leg-dataprogress prune
 	// concurrently removes a genuinely dead leg so its seqs retransmit on survivors.
-	if rg.mux.gapAge() > reorderTimeout {
+	gapAge := rg.mux.gapAge()
+	if gapAge > reorderTimeout {
+		// Observability for the reorder WEDGE (the multi-leg-collapse-to-0-B/s
+		// failure): the frontier has been stuck past the timeout, so the sender's
+		// retransmit isn't refilling the missing seq. Log the stuck seq, how many
+		// packets are dammed behind it, the gap age, and the active-leg count so a
+		// wedge is diagnosable from the log. Throttled to ~once per reorderTimeout
+		// (the service fires every reorderStallInterval) via a transition/decay
+		// counter so a sustained wedge doesn't spam.
+		rg.reorderWedgeTicks++
+		if rg.reorderWedgeTicks == 1 || gapAge > rg.reorderWedgeLoggedAt+reorderTimeout {
+			active := rg.mux.activeLegCount()
+			rg.logger.Warnf("reorder-WEDGE: frontier stuck at seq=%d for %v, pending=%d packets dammed, active_legs=%d — sender retransmit not refilling the gap (SACK re-sent)",
+				rg.mux.reorderNextSeq(), gapAge.Truncate(time.Millisecond), rg.mux.reorderPending(), active)
+			rg.reorderWedgeLoggedAt = gapAge
+		}
 		if err := rg.sendSACK(); err != nil {
 			rg.logger.WithError(err).Debug("reorder-stall SACK failed")
 		}
+	} else if rg.reorderWedgeTicks > 0 {
+		// Gap cleared — log the recovery so the wedge's duration is bounded in the log.
+		rg.logger.Infof("reorder-wedge CLEARED after %d stall ticks (frontier advancing again)", rg.reorderWedgeTicks)
+		rg.reorderWedgeTicks = 0
+		rg.reorderWedgeLoggedAt = 0
 	}
 }
 
@@ -2158,12 +2185,28 @@ func (rg *RouteGroup) enforceLatencyBand() {
 	}
 
 	demote, promote := partitionLatencyBand(legs, manual, tight)
+	// latMs lookup for diagnostics (which latency triggered each decision).
+	latOf := make(map[int]float64, len(legs))
+	for _, l := range legs {
+		latOf[l.idx] = l.latMs
+	}
+	if len(demote) > 0 || len(promote) > 0 {
+		mode := "adaptive"
+		if manual {
+			mode = "manual"
+		}
+		band := "wide"
+		if tight {
+			band = "tight"
+		}
+		rg.logger.Infof("latency-band[%s/%s]: %d active legs, demote=%v promote=%v", mode, band, len(legs), demote, promote)
+	}
 	for _, idx := range demote {
-		rg.logger.Infof("latency-band: parking leg %d (out-of-band latency) to keep the active stripe set homogeneous", idx)
+		rg.logger.Infof("latency-band: parking leg %d to warm standby (latency %.0fms out-of-band, keeping the active stripe set homogeneous)", idx, latOf[idx])
 		rg.mux.setLegStandby(idx, true)
 	}
 	for _, idx := range promote {
-		rg.logger.Debugf("latency-band: re-admitting leg %d (back within band)", idx)
+		rg.logger.Infof("latency-band: re-admitting leg %d to active (latency %.0fms back within band)", idx, latOf[idx])
 		rg.mux.setLegStandby(idx, false)
 	}
 	if len(demote) > 0 || len(promote) > 0 {

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1957,22 +1957,51 @@ type bandLeg struct {
 	primary bool
 }
 
+// fastClusterAnchor returns the anchor latency of the FAST cluster in a sorted
+// (ascending) latency slice: the fastest latency whose band window
+// [anchor, demoteRatio*anchor] contains the most legs. The active stripe set is
+// held within [anchor, demoteRatio*anchor].
+//
+// Why not the median: with a small, slow-skewed active set (e.g. 185, 257, 456,
+// 809 ms) the median lands HIGH (456), so the slow legs look "in band" (<2x the
+// median) while the genuinely-fast 185 ms leg looks like the outlier — the band
+// then keeps the slow legs and HoL-throttles the aggregate BELOW a single fast
+// leg (the measured A1 failure). Anchoring on the fast cluster keeps {185, 257}
+// active and parks {456, 809}. Isolated LAN short-circuit artifacts (a 2 ms leg
+// beside a 250 ms cluster) are already kept out of the active set at mux-set time
+// (#4253); the fastest-window-on-tie rule here is chosen for the slow-skew case,
+// so a lone artifact anchors a 1-leg window and loses to the real cluster.
+func fastClusterAnchor(known []float64, demoteRatio float64) float64 {
+	anchor, bestCount := 0.0, -1
+	for _, a := range known {
+		if a <= 0 {
+			continue
+		}
+		cnt := 0
+		for _, l := range known {
+			if l >= a && l <= a*demoteRatio {
+				cnt++
+			}
+		}
+		if cnt > bestCount {
+			bestCount, anchor = cnt, a
+		}
+	}
+	return anchor
+}
+
 // partitionLatencyBand decides which legs to demote to / promote from warm
-// standby so the ACTIVE stripe set stays within a tight latency band around the
-// median. Striping across latency-disparate legs opens a reorder gap the size of
-// the difference (a 2ms LAN short-circuit beside a 300ms route), HoL-capping or
-// stalling the no-skip reorder buffer — the multi-leg collapse. LOW-side demotion
-// (a leg far FASTER than the median — the classic LAN short-circuit artifact that
-// neither the adaptive engine's high-side outlier logic nor a manual preset
-// excludes today) is universal. HIGH-side DEMOTION is now also universal: a leg
-// whose latency exceeds bandDemoteRatio*median stalls the no-skip reorder
-// frontier (a self-healed or churned-in 1200ms+ leg beside a 60ms band collapses
-// the mux to ~0), so it is demoted to warm standby in every mode — the observed
-// cause of multi-leg download collapse. Only re-PROMOTION stays gated to
-// manualMode: in adaptive mode the tick owns re-admission and its 512-deep warm
-// pool must not be dumped into the active set (demotion to standby never dumps
-// the pool, so it is safe to run always). Pure (no locks / rg state) so it is
-// unit-tested directly. Never demotes the primary or the last active leg.
+// standby so the ACTIVE stripe set stays within a tight latency band anchored on
+// the FAST cluster (see fastClusterAnchor). Striping across latency-disparate
+// legs opens a reorder gap the size of the difference (a 2ms LAN short-circuit
+// beside a 300ms route), HoL-capping or stalling the no-skip reorder buffer — the
+// multi-leg collapse. A leg outside [anchor, demoteRatio*anchor] — too slow
+// (high-side stall) OR faster than the fast cluster's floor (a LAN short-circuit
+// artifact) — is demoted to warm standby in every mode. Only re-PROMOTION stays
+// gated to manualMode: in adaptive mode the tick owns re-admission and its
+// 512-deep warm pool must not be dumped into the active set (demotion to standby
+// never dumps the pool, so it is safe to run always). Pure (no locks / rg state)
+// so it is unit-tested directly. Never demotes the primary or the last active leg.
 func partitionLatencyBand(legs []bandLeg, manualMode, tight bool) (demote, promote []int) {
 	demoteRatio, admitRatio := bandDemoteRatio, bandAdmitRatio
 	if tight {
@@ -1988,10 +2017,12 @@ func partitionLatencyBand(legs []bandLeg, manualMode, tight bool) (demote, promo
 		return nil, nil
 	}
 	sort.Float64s(known)
-	med := known[len(known)/2]
-	if med <= 0 {
+	anchor := fastClusterAnchor(known, demoteRatio)
+	if anchor <= 0 {
 		return nil, nil
 	}
+	demoteHi := demoteRatio * anchor // slower than this → high-side stall demote
+	admitHi := admitRatio * anchor   // re-admit only within this tighter band
 
 	active := 0
 	for _, l := range legs {
@@ -2004,22 +2035,14 @@ func partitionLatencyBand(legs []bandLeg, manualMode, tight bool) (demote, promo
 		if l.latMs <= 0 {
 			continue // unknown latency — leave the leg's state untouched
 		}
-		fasterRatio := med / l.latMs // >1 when the leg is faster than the median
-		slowerRatio := l.latMs / med // >1 when the leg is slower than the median
+		inBand := l.latMs >= anchor && l.latMs <= demoteHi
 		switch {
-		case !l.standby && !l.primary && active > 1 &&
-			(fasterRatio > demoteRatio || slowerRatio > demoteRatio):
+		case !l.standby && !l.primary && active > 1 && !inBand:
 			demote = append(demote, l.idx)
 			active-- // never demote below one active leg
-		case manualMode && l.standby:
-			symm := slowerRatio
-			if fasterRatio > symm {
-				symm = fasterRatio
-			}
-			if symm <= admitRatio {
-				promote = append(promote, l.idx)
-				active++
-			}
+		case manualMode && l.standby && l.latMs >= anchor && l.latMs <= admitHi:
+			promote = append(promote, l.idx)
+			active++
 		}
 	}
 	return demote, promote
@@ -2032,13 +2055,16 @@ func partitionLatencyBand(legs []bandLeg, manualMode, tight bool) (demote, promo
 // outlier (a 2ms LAN short-circuit artifact, or a self-healed 14000ms leg that
 // landed at index 0) permanently anchors the active set off-band and wastes an
 // active slot. This picker names a replacement so the primary can CHANGE
-// dynamically instead of being protected in place: when leg 0 is out of band
-// (its faster/slower ratio to the median exceeds demoteRatio) AND a non-primary
-// ACTIVE leg sits within admitRatio of the median, it returns that leg's index —
-// the lowest-latency in-band active candidate, which becomes the new primary via
-// a make-before-break swap (reelectPrimary). It returns ok=false unless a
-// replacement exists, so the group never gives up its anchor without one. Pure
-// (no locks / rg state) so it is unit-tested directly.
+// dynamically instead of being protected in place: when leg 0 is outside the
+// fast-cluster band [anchor, demoteRatio*anchor] AND a non-primary ACTIVE leg
+// sits inside it, it returns that leg's index — the lowest-latency in-band active
+// candidate, which becomes the new primary via a make-before-break swap
+// (reelectPrimary). It returns ok=false unless a replacement exists, so the group
+// never gives up its anchor without one. Anchoring on the fast cluster (not the
+// median) matters here too: a slow-skewed set inflates the median so a genuinely-
+// fast primary looks in-band, or a slow primary looks in-band — the fast-cluster
+// anchor names the real fast leg to promote into the primary slot. Pure (no locks
+// / rg state) so it is unit-tested directly.
 func pickPrimaryReelection(legs []bandLeg, tight bool) (newPrimaryIdx int, ok bool) {
 	demoteRatio, admitRatio := bandDemoteRatio, bandAdmitRatio
 	if tight {
@@ -2058,28 +2084,24 @@ func pickPrimaryReelection(legs []bandLeg, tight bool) (newPrimaryIdx int, ok bo
 		return 0, false
 	}
 	sort.Float64s(known)
-	med := known[len(known)/2]
-	if med <= 0 {
+	anchor := fastClusterAnchor(known, demoteRatio)
+	if anchor <= 0 {
 		return 0, false
 	}
-	// Is the primary itself a gross outlier?
-	pFaster, pSlower := med/primary.latMs, primary.latMs/med
-	if pFaster <= demoteRatio && pSlower <= demoteRatio {
-		return 0, false // primary is in band — leave it
+	// Is the primary itself outside the fast-cluster band?
+	if primary.latMs >= anchor && primary.latMs <= demoteRatio*anchor {
+		return 0, false // primary is in the fast band — leave it
 	}
 	// Find the best (lowest-latency) in-band ACTIVE non-primary replacement.
+	admitHi := admitRatio * anchor
 	bestIdx, bestLat := -1, 0.0
 	for i := range legs {
 		l := legs[i]
 		if l.primary || l.standby || l.latMs <= 0 {
 			continue
 		}
-		symm := l.latMs / med
-		if med/l.latMs > symm {
-			symm = med / l.latMs
-		}
-		if symm > admitRatio {
-			continue // candidate must itself be in band
+		if l.latMs < anchor || l.latMs > admitHi {
+			continue // candidate must itself be in the fast band
 		}
 		if bestIdx == -1 || l.latMs < bestLat {
 			bestIdx, bestLat = l.idx, l.latMs

--- a/pkg/router/route_group_latencyband_test.go
+++ b/pkg/router/route_group_latencyband_test.go
@@ -173,6 +173,20 @@ func TestPartitionLatencyBand(t *testing.T) {
 			wantDemote: nil, wantPromote: []int{3},
 		},
 		{
+			name: "slow-skewed set: fast cluster kept, slow legs parked (the A1 HoL fix)",
+			legs: []bandLeg{
+				{idx: 0, latMs: 185, primary: true}, // fast cluster
+				{idx: 1, latMs: 257},                // fast cluster
+				{idx: 2, latMs: 456},                // slow — median(456) would keep it
+				{idx: 3, latMs: 809},                // slow
+			},
+			// median is 456; a median-anchored band would call 185 the outlier and
+			// keep {456,809}. The fast-cluster anchor (185) keeps {185,257} and
+			// parks {456,809} so the stripe set is homogeneous and doesn't HoL.
+			manual: true, tight: true,
+			wantDemote: []int{2, 3}, wantPromote: nil,
+		},
+		{
 			name: "standby 1.7x leg stays standby under tight band (admission withheld)",
 			legs: []bandLeg{
 				{idx: 0, latMs: 150, primary: true},

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -585,6 +585,23 @@ func (m *routeMux) swapLegs(i, j int) {
 	}
 }
 
+// activeLegCount reports how many legs are currently active (not warm standby)
+// — the striped set width. Used for wedge/hold diagnostics.
+func (m *routeMux) activeLegCount() int {
+	m.legMu.RLock()
+	defer m.legMu.RUnlock()
+	if len(m.standby) == 0 {
+		return len(m.legs)
+	}
+	active := 0
+	for _, s := range m.standby {
+		if !s {
+			active++
+		}
+	}
+	return active
+}
+
 // isLegStandby reports whether leg idx is a warm standby. Bounds-checked.
 func (m *routeMux) isLegStandby(idx int) bool {
 	if idx < 0 {
@@ -803,6 +820,16 @@ func (m *routeMux) reorderPending() int {
 		return 0
 	}
 	return m.reorderBuf.Pending()
+}
+
+// reorderNextSeq returns the sequence number the receive-side reorder buffer is
+// waiting on (the frontier). When a gap is stuck this is the missing seq whose
+// leg has stalled — the key datum for diagnosing a reorder wedge.
+func (m *routeMux) reorderNextSeq() uint32 {
+	if m.reorderBuf == nil {
+		return 0
+	}
+	return m.reorderBuf.NextSeq()
 }
 
 // writeSeqValue returns the count of DATA frames this mux has emitted (the next


### PR DESCRIPTION
Two Layer-A improvements for holding a homogeneous mux active set (goal A0/A1).

**Fast-cluster latency band.** The active-set band anchored on the median, which fails on a small slow-skewed set: legs at 185/257/456/809ms give a median of 456, so the slow legs look in-band while the fastest (185ms) leg looks like the outlier — the band keeps the slow legs and the no-skip reorder frontier HoL-throttles the aggregate *below* a single fast leg. Now the band anchors on the fast cluster (the fastest latency whose window [anchor, demoteRatio*anchor] holds the most legs): {185,257} stay active, {456,809} are parked. `fastClusterAnchor` is shared with primary re-election so it also targets the real fast leg.

**Observability.** The mux data-plane was silent. Added: reorder-stall WARN when the frontier wedges (stuck seq, packets dammed, gap age, active-leg count) and INFO when it clears; latency-band decisions log the mode (manual/adaptive), band (tight/wide), active count, and the measured latency behind each park/re-admit; new `reorderNextSeq()` / `activeLegCount()` accessors. This is what let us diagnose that the earlier '0 B/s' was a misleading metric and that the set holds under load.

Unit tests cover the slow-skew case and all prior band/reelection cases; full `pkg/router` suite green.