### PR TITLE
fix(lint): gofmt struct field alignment in route_group.go

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -325,8 +325,8 @@ type RouteGroup struct {
 	// Touched only from the single reorder-stall service goroutine.
 	reorderWedgeTicks    int
 	reorderWedgeLoggedAt time.Duration
-	legMissed     map[uuid.UUID]int
-	inflightPings map[int64]uuid.UUID
+	legMissed            map[uuid.UUID]int
+	inflightPings        map[int64]uuid.UUID
 	// legE2ELatency is the EWMA-smoothed END-TO-END round-trip latency per leg,
 	// keyed by transport ID (survives index shifts), folded from the
 	// leg-liveness pong. This is the leg's TRUE route latency (all hops), unlike


### PR DESCRIPTION
The struct fields added in #4272 broke gofmt alignment of the adjacent legMissed/inflightPings fields. This gofmt violation currently fails the lint step on develop, gating the linux/darwin/windows lanes for every PR. Pure gofmt -w, no behavior change.