### PR TITLE
chore: make component tags agree within each package

### DIFF
--- a/cmd/skywire-cli/commands/mdisc/check.go
+++ b/cmd/skywire-cli/commands/mdisc/check.go
@@ -1,4 +1,4 @@
-// Package climdisc cmd/skywire-cli/commands/mdisc/check.go c2-ops-deployment
+// Package climdisc cmd/skywire-cli/commands/mdisc/check.go c4-vis-cli
 //
 // `skywire cli mdisc check` — deployment health probe for the dmsg-server wss
 // fronts. A browser/wasm visor can ONLY bootstrap over wss (the seed entry

--- a/pkg/app/appnet/dial_fallback.go
+++ b/pkg/app/appnet/dial_fallback.go
@@ -1,4 +1,4 @@
-// Package appnet pkg/app/appnet/dial_fallback.go c1-app-net
+// Package appnet pkg/app/appnet/dial_fallback.go c2-vis-appsvc
 package appnet
 
 import (

--- a/pkg/deployment/tpd/store/redis_uptime_backfill_test.go
+++ b/pkg/deployment/tpd/store/redis_uptime_backfill_test.go
@@ -1,4 +1,4 @@
-// Package store pkg/deployment/tpd/store/redis_uptime_backfill_test.go c4-tpd-uptime
+// Package store pkg/deployment/tpd/store/redis_uptime_backfill_test.go c4-net-discovery
 package store
 
 import (

--- a/pkg/skychat/call/codec_opus_test.go
+++ b/pkg/skychat/call/codec_opus_test.go
@@ -1,4 +1,4 @@
-// Package call pkg/skychat/call/codec_opus_test.go c2-app-chat
+// Package call pkg/skychat/call/codec_opus_test.go c4-app-chat
 package call
 
 import (

--- a/pkg/skychat/call/spectrogram/spectrogram_test.go
+++ b/pkg/skychat/call/spectrogram/spectrogram_test.go
@@ -1,4 +1,4 @@
-// Package spectrogram pkg/skychat/call/spectrogram/spectrogram_test.go c2-app-chat
+// Package spectrogram pkg/skychat/call/spectrogram/spectrogram_test.go c4-app-chat
 package spectrogram
 
 import (

--- a/pkg/skychat/xfer/xfer_test.go
+++ b/pkg/skychat/xfer/xfer_test.go
@@ -1,4 +1,4 @@
-// Package xfer pkg/skychat/xfer/xfer_test.go c2-app-chat
+// Package xfer pkg/skychat/xfer/xfer_test.go c4-app-chat
 package xfer
 
 import (

--- a/pkg/transport/lock_watchdog.go
+++ b/pkg/transport/lock_watchdog.go
@@ -1,4 +1,4 @@
-// Package transport pkg/transport/lock_watchdog.go c1-net-transport
+// Package transport pkg/transport/lock_watchdog.go c2-net-transport
 package transport
 
 import (

--- a/pkg/transport/lock_watchdog_test.go
+++ b/pkg/transport/lock_watchdog_test.go
@@ -1,4 +1,4 @@
-// Package transport pkg/transport/lock_watchdog_test.go c1-net-transport
+// Package transport pkg/transport/lock_watchdog_test.go c2-net-transport
 package transport
 
 import (

--- a/pkg/transport/manager_create_gate_test.go
+++ b/pkg/transport/manager_create_gate_test.go
@@ -1,4 +1,4 @@
-// Package transport pkg/transport/manager_create_gate_test.go c1-net-transport
+// Package transport pkg/transport/manager_create_gate_test.go c2-net-transport
 package transport
 
 import (

--- a/pkg/visor/api_state.go
+++ b/pkg/visor/api_state.go
@@ -1,4 +1,4 @@
-// Package visor pkg/visor/api_state.go c1-vis-core
+// Package visor pkg/visor/api_state.go c3-vis-core
 package visor
 
 import (

--- a/pkg/visor/dmsg_over_skynet.go
+++ b/pkg/visor/dmsg_over_skynet.go
@@ -1,4 +1,4 @@
-// Package visor pkg/visor/dmsg_over_skynet.go c2-vis-net
+// Package visor pkg/visor/dmsg_over_skynet.go c3-vis-core
 //
 // "dmsg over skynet transports": serve a .dmsg fetch by reaching the peer's
 // :80 over a skynet transport via the VStreamMux relay (direct → 1-hop relay,

--- a/pkg/visor/meshproxy_test.go
+++ b/pkg/visor/meshproxy_test.go
@@ -1,4 +1,4 @@
-// Package visor pkg/visor/meshproxy_test.go c4-vis-mesh
+// Package visor pkg/visor/meshproxy_test.go c3-vis-core
 package visor
 
 import (

--- a/pkg/visor/skynet_relay_dial.go
+++ b/pkg/visor/skynet_relay_dial.go
@@ -1,4 +1,4 @@
-// Package visor pkg/visor/skynet_relay_dial.go c2-vis-net
+// Package visor pkg/visor/skynet_relay_dial.go c3-vis-core
 //
 // Relay tier for the SKYNET dialer (DialSkynet), i.e. `.skynet` hosts only.
 // When there's no direct transport to a destination, reach it through a 1-hop

--- a/pkg/visor/wasmserve_test.go
+++ b/pkg/visor/wasmserve_test.go
@@ -1,4 +1,4 @@
-// Package visor pkg/visor/wasmserve_test.go c4-vis-mesh
+// Package visor pkg/visor/wasmserve_test.go c3-vis-core
 package visor
 
 import (


### PR DESCRIPTION
Each package's file headers carry one `c<layer>-<domain>-<area>` tag. Fourteen files disagree with their own package: most are test files tagged differently from the code they test (skychat, tpd/store, visor), and three invent a domain used nowhere else in the tree — `tpd`, `ops` and `app-net`.

After this every remaining tag maps to a coherent package. Comment-only, no code changes; `go build .` and `go vet` on the touched packages both pass.