### PR TITLE
feat(router): FEC coding core (systematic Cauchy-Reed-Solomon over GF(2^8)) for #4270

### DIFF
--- a/pkg/router/fec.go
+++ b/pkg/router/fec.go
@@ -1,0 +1,226 @@
+// Package router pkg/router/fec.go — forward-error-correction primitive for the
+// mux data plane (skycoin/skywire #4270). Aggregating one ordered stream across
+// heterogeneous-RTT legs is head-of-line-bound: the no-skip reorder frontier
+// waits for whatever frames were striped onto a slow leg. Retransmit recovery is
+// coupled to that slow leg's RTT. Erasure coding removes the wait: the receiver
+// reconstructs a missing/late data symbol from REPAIR symbols that arrived on the
+// FAST legs, so recovery delay is independent of the slow leg (the escape route
+// (c) from the in-order-stream wall; see the research survey in memory).
+//
+// This file is the coding core only — a systematic Cauchy-Reed-Solomon block
+// erasure code over GF(2^8): K data symbols are transmitted unchanged (systematic
+// → zero decode cost when nothing is lost) plus R repair symbols; the receiver
+// recovers ALL K data symbols from ANY K of the K+R (MDS). Integration into the
+// mux striping / reorder buffer is a separate step; keeping the code standalone
+// makes it exhaustively unit-testable without the live mesh.
+package router
+
+import "errors"
+
+// --- GF(2^8) arithmetic (polynomial 0x11d, the RS/AES field) ---
+
+var (
+	gfExp [512]byte // gfExp[i] = generator^i, doubled so a+b (<510) needs no mod
+	gfLog [256]byte // gfLog[gfExp[i]] = i
+)
+
+func init() {
+	x := byte(1)
+	for i := 0; i < 255; i++ {
+		gfExp[i] = x
+		gfLog[x] = byte(i)
+		// multiply x by the generator (2) in GF(2^8) with poly 0x11d
+		hi := x & 0x80
+		x <<= 1
+		if hi != 0 {
+			x ^= 0x1d
+		}
+	}
+	for i := 255; i < 512; i++ {
+		gfExp[i] = gfExp[i-255]
+	}
+}
+
+func gfMul(a, b byte) byte {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	return gfExp[int(gfLog[a])+int(gfLog[b])]
+}
+
+func gfInv(a byte) byte {
+	// a^(254) = a^(-1) for a != 0; via logs: exp[255 - log[a]].
+	return gfExp[255-int(gfLog[a])]
+}
+
+// --- systematic Cauchy-Reed-Solomon block coder ---
+
+// fecBlockCoder encodes K data symbols into R repair symbols and decodes any K of
+// the K+R back to the original data. Symbols are equal-length byte slices; the
+// caller pads/chunks the stream to symLen. Immutable after construction; safe for
+// concurrent Encode/Decode.
+type fecBlockCoder struct {
+	k, r, symLen int
+	cauchy       [][]byte // R x K generator rows for the repair symbols
+}
+
+// newFECBlockCoder builds a coder for k data + r repair symbols of symLen bytes.
+// The R×K generator is a Cauchy matrix cauchy[i][j] = 1 / (x_i XOR y_j) with
+// x_i = i and y_j = R+j (all distinct in GF(2^8)), which — stacked under the K×K
+// identity for the systematic data rows — makes EVERY K-row subset invertible, so
+// any K received symbols recover the data (the MDS property). Requires
+// k+r <= 256. Returns nil for invalid dimensions.
+func newFECBlockCoder(k, r, symLen int) *fecBlockCoder {
+	if k <= 0 || r < 0 || symLen <= 0 || k+r > 256 {
+		return nil
+	}
+	cauchy := make([][]byte, r)
+	for i := 0; i < r; i++ {
+		row := make([]byte, k)
+		xi := byte(i)
+		for j := 0; j < k; j++ {
+			yj := byte(r + j)
+			row[j] = gfInv(xi ^ yj) // xi != yj always (i<r<=r+j), so xor != 0
+		}
+		cauchy[i] = row
+	}
+	return &fecBlockCoder{k: k, r: r, symLen: symLen, cauchy: cauchy}
+}
+
+// Encode returns the R repair symbols for the K data symbols. data must have
+// exactly K entries, each symLen bytes. repair[i] = Σ_j cauchy[i][j] * data[j].
+func (c *fecBlockCoder) Encode(data [][]byte) ([][]byte, error) {
+	if len(data) != c.k {
+		return nil, errors.New("fec: Encode needs exactly k data symbols")
+	}
+	for _, d := range data {
+		if len(d) != c.symLen {
+			return nil, errors.New("fec: data symbol length mismatch")
+		}
+	}
+	repair := make([][]byte, c.r)
+	for i := 0; i < c.r; i++ {
+		out := make([]byte, c.symLen)
+		for j := 0; j < c.k; j++ {
+			coeff := c.cauchy[i][j]
+			if coeff == 0 {
+				continue
+			}
+			d := data[j]
+			for b := 0; b < c.symLen; b++ {
+				out[b] ^= gfMul(coeff, d[b])
+			}
+		}
+		repair[i] = out
+	}
+	return repair, nil
+}
+
+// Decode recovers all K data symbols. recv has K+R slots (indices 0..K-1 are the
+// data symbols, K..K+R-1 the repair symbols); present[i] reports whether slot i
+// arrived. Requires at least K present slots. Present data slots are returned
+// as-is (systematic); missing ones are reconstructed from the repair rows.
+func (c *fecBlockCoder) Decode(recv [][]byte, present []bool) ([][]byte, error) {
+	n := c.k + c.r
+	if len(recv) != n || len(present) != n {
+		return nil, errors.New("fec: Decode needs k+r recv/present slots")
+	}
+	// Fast path: all data present → nothing to reconstruct.
+	allData := true
+	for i := 0; i < c.k; i++ {
+		if !present[i] {
+			allData = false
+			break
+		}
+	}
+	if allData {
+		out := make([][]byte, c.k)
+		copy(out, recv[:c.k])
+		return out, nil
+	}
+
+	// Collect K present rows of the full generator G = [ I_k ; Cauchy ].
+	// Row for data slot j is e_j; row for repair slot i is cauchy[i].
+	rows := make([][]byte, 0, c.k) // K x K coefficient rows
+	rhs := make([][]byte, 0, c.k)  // the corresponding received symbols
+	for idx := 0; idx < n && len(rows) < c.k; idx++ {
+		if !present[idx] {
+			continue
+		}
+		if len(recv[idx]) != c.symLen {
+			return nil, errors.New("fec: present symbol length mismatch")
+		}
+		row := make([]byte, c.k)
+		if idx < c.k { // systematic data row = unit vector
+			row[idx] = 1
+		} else {
+			copy(row, c.cauchy[idx-c.k])
+		}
+		rows = append(rows, row)
+		rhs = append(rhs, recv[idx])
+	}
+	if len(rows) < c.k {
+		return nil, errors.New("fec: not enough symbols to decode (need k)")
+	}
+
+	// Solve rows * data = rhs for data via Gauss-Jordan over GF(2^8), applying
+	// the same row ops to rhs (each rhs entry is a whole symbol vector).
+	if err := gfSolve(rows, rhs, c.symLen); err != nil {
+		return nil, err
+	}
+	out := make([][]byte, c.k)
+	for j := 0; j < c.k; j++ {
+		out[j] = rhs[j]
+	}
+	return out, nil
+}
+
+// gfSolve solves a[K][K] * x = b (b is K symbol-vectors of symLen bytes) in place
+// by Gauss-Jordan elimination over GF(2^8); on return b holds x. The matrix is a
+// K-subset of the MDS generator so it is always invertible; a zero pivot with no
+// swap available therefore signals a caller/logic error.
+func gfSolve(a [][]byte, b [][]byte, symLen int) error {
+	k := len(a)
+	for col := 0; col < k; col++ {
+		// find pivot
+		piv := -1
+		for r := col; r < k; r++ {
+			if a[r][col] != 0 {
+				piv = r
+				break
+			}
+		}
+		if piv < 0 {
+			return errors.New("fec: singular matrix (should not happen for MDS subset)")
+		}
+		if piv != col {
+			a[piv], a[col] = a[col], a[piv]
+			b[piv], b[col] = b[col], b[piv]
+		}
+		// normalize pivot row so a[col][col] == 1
+		inv := gfInv(a[col][col])
+		if inv != 1 {
+			for j := col; j < k; j++ {
+				a[col][j] = gfMul(a[col][j], inv)
+			}
+			for x := 0; x < symLen; x++ {
+				b[col][x] = gfMul(b[col][x], inv)
+			}
+		}
+		// eliminate the column from every other row
+		for r := 0; r < k; r++ {
+			if r == col || a[r][col] == 0 {
+				continue
+			}
+			f := a[r][col]
+			for j := col; j < k; j++ {
+				a[r][j] ^= gfMul(f, a[col][j])
+			}
+			br, bc := b[r], b[col]
+			for x := 0; x < symLen; x++ {
+				br[x] ^= gfMul(f, bc[x])
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/router/fec_test.go
+++ b/pkg/router/fec_test.go
@@ -1,0 +1,191 @@
+package router
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+// TestGF256Field checks the core field invariants the coder relies on.
+func TestGF256Field(t *testing.T) {
+	// a * inv(a) == 1 for all non-zero a.
+	for a := 1; a < 256; a++ {
+		if got := gfMul(byte(a), gfInv(byte(a))); got != 1 {
+			t.Fatalf("a=%d: a*inv(a)=%d, want 1", a, got)
+		}
+	}
+	// multiply by 0 is 0; multiply by 1 is identity.
+	for a := 0; a < 256; a++ {
+		if gfMul(byte(a), 0) != 0 || gfMul(0, byte(a)) != 0 {
+			t.Fatalf("a=%d: mul by 0 != 0", a)
+		}
+		if gfMul(byte(a), 1) != byte(a) {
+			t.Fatalf("a=%d: mul by 1 != a", a)
+		}
+	}
+	// distributivity spot check: a*(b^c) == a*b ^ a*c.
+	for _, tc := range [][3]byte{{3, 7, 200}, {255, 128, 1}, {17, 17, 42}} {
+		a, b, c := tc[0], tc[1], tc[2]
+		if gfMul(a, b^c) != (gfMul(a, b) ^ gfMul(a, c)) {
+			t.Fatalf("distributivity failed for %v", tc)
+		}
+	}
+}
+
+// decodeWithErasures is a helper: encode data, drop the given slot indices, decode.
+func decodeWithErasures(t *testing.T, c *fecBlockCoder, data [][]byte, erase []int) [][]byte {
+	t.Helper()
+	repair, err := c.Encode(data)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	n := c.k + c.r
+	recv := make([][]byte, n)
+	present := make([]bool, n)
+	for i := 0; i < c.k; i++ {
+		recv[i] = data[i]
+		present[i] = true
+	}
+	for i := 0; i < c.r; i++ {
+		recv[c.k+i] = repair[i]
+		present[c.k+i] = true
+	}
+	for _, e := range erase {
+		recv[e] = nil
+		present[e] = false
+	}
+	out, err := c.Decode(recv, present)
+	if err != nil {
+		t.Fatalf("Decode (erase %v): %v", erase, err)
+	}
+	return out
+}
+
+func mkData(k, symLen int, seed int64) [][]byte {
+	rng := rand.New(rand.NewSource(seed))
+	data := make([][]byte, k)
+	for i := range data {
+		data[i] = make([]byte, symLen)
+		rng.Read(data[i])
+	}
+	return data
+}
+
+func eq(a, b [][]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !bytes.Equal(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// TestFECRecoversAllErasurePatterns: for several (k,r), erasing EVERY subset of up
+// to r of the k+r symbols must recover the original k data symbols exactly.
+func TestFECRecoversAllErasurePatterns(t *testing.T) {
+	cases := []struct{ k, r int }{{4, 2}, {6, 3}, {3, 3}, {1, 1}, {8, 4}}
+	symLen := 37 // deliberately not a power of two
+	for _, tc := range cases {
+		c := newFECBlockCoder(tc.k, tc.r, symLen)
+		if c == nil {
+			t.Fatalf("newFECBlockCoder(%d,%d) nil", tc.k, tc.r)
+		}
+		data := mkData(tc.k, symLen, int64(tc.k*100+tc.r))
+		n := tc.k + tc.r
+		// enumerate all erasure subsets of size 0..r
+		var subsets func(start, need int, cur []int)
+		subsets = func(start, need int, cur []int) {
+			if need == 0 {
+				out := decodeWithErasures(t, c, data, cur)
+				if !eq(out, data) {
+					t.Fatalf("k=%d r=%d erase=%v: decode mismatch", tc.k, tc.r, cur)
+				}
+				return
+			}
+			for i := start; i <= n-need; i++ {
+				subsets(i+1, need-1, append(cur, i))
+			}
+		}
+		for e := 0; e <= tc.r; e++ {
+			subsets(0, e, nil)
+		}
+	}
+}
+
+// TestFECErasureBeyondRFails: erasing more than r symbols must NOT silently return
+// wrong data — Decode must error (not enough symbols).
+func TestFECErasureBeyondRFails(t *testing.T) {
+	c := newFECBlockCoder(4, 2, 16)
+	data := mkData(4, 16, 7)
+	repair, _ := c.Encode(data)
+	recv := make([][]byte, 6)
+	present := make([]bool, 6)
+	for i := 0; i < 4; i++ {
+		recv[i], present[i] = data[i], true
+	}
+	for i := 0; i < 2; i++ {
+		recv[4+i], present[4+i] = repair[i], true
+	}
+	// erase 3 (> r=2)
+	for _, e := range []int{0, 1, 4} {
+		recv[e], present[e] = nil, false
+	}
+	if _, err := c.Decode(recv, present); err == nil {
+		t.Fatal("expected error decoding with >r erasures, got nil")
+	}
+}
+
+// TestFECSystematicFastPath: with all data present, Decode returns the data
+// untouched (systematic, zero reconstruction).
+func TestFECSystematicFastPath(t *testing.T) {
+	c := newFECBlockCoder(5, 3, 24)
+	data := mkData(5, 24, 99)
+	repair, _ := c.Encode(data)
+	recv := make([][]byte, 8)
+	present := make([]bool, 8)
+	for i := 0; i < 5; i++ {
+		recv[i], present[i] = data[i], true
+	}
+	// repair symbols all missing — data still fully present
+	_ = repair
+	out, err := c.Decode(recv, present)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !eq(out, data) {
+		t.Fatal("systematic fast-path mismatch")
+	}
+}
+
+// TestFECFuzz: random data + random erasure patterns of size <= r always recover.
+func TestFECFuzz(t *testing.T) {
+	rng := rand.New(rand.NewSource(12345))
+	for iter := 0; iter < 400; iter++ {
+		k := 1 + rng.Intn(12)
+		r := rng.Intn(6)
+		symLen := 1 + rng.Intn(64)
+		c := newFECBlockCoder(k, r, symLen)
+		if c == nil {
+			continue
+		}
+		data := mkData(k, symLen, int64(iter))
+		n := k + r
+		// choose a random erasure count 0..r and random positions
+		ec := rng.Intn(r + 1)
+		perm := rng.Perm(n)[:ec]
+		out := decodeWithErasures(t, c, data, perm)
+		if !eq(out, data) {
+			t.Fatalf("fuzz iter=%d k=%d r=%d erase=%v: mismatch", iter, k, r, perm)
+		}
+	}
+}
+
+func TestFECInvalidDims(t *testing.T) {
+	if newFECBlockCoder(0, 2, 16) != nil || newFECBlockCoder(200, 100, 16) != nil ||
+		newFECBlockCoder(4, 2, 0) != nil {
+		t.Fatal("expected nil for invalid dimensions")
+	}
+}


### PR DESCRIPTION
First, self-contained, exhaustively-tested piece of #4270 (sliding-window FEC across mux legs to remove head-of-line blocking).

**Why:** measured this session — on heterogeneous legs (140–479ms) both capacity and ECF scheduling deliver ~6× *below* a single leg. Scheduling can't cross the wall: the no-skip reorder frontier still *waits* for whatever frames rode the slow leg. Only coding (route c) removes the wait — the receiver reconstructs a missing/late data symbol from repair symbols that arrived on the fast legs, recovery delay independent of the slow leg's RTT.

**What:** the coding core only (integration into the mux striping/reorder buffer is the next step; kept standalone so it's testable offline): GF(2⁸) arithmetic + a systematic Cauchy-Reed-Solomon block coder. K data symbols transmitted unchanged (systematic → zero decode cost when nothing is lost) + R repair symbols; any K of the K+R recover all K data (MDS).

**Tests:** field invariants; **every** erasure subset of size ≤R for several (k,r); >R-erasure rejection; systematic fast-path; 400-iteration fuzz — all green under `-race`. No integration/behaviour change yet (nothing calls it), so it's inert until wired in.

Next steps on #4270: chunk the mux frame stream into symbols, stripe systematic data + repair across legs, and have the reorder buffer reconstruct a stuck frame from available repair instead of waiting (Tetrys-style sliding window over this block core).