### PR TITLE
feat(wasm-visor): optional Go/wasm transport worker for browse origins

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -23,6 +23,7 @@ var (
 	serveBrowseSuffix string
 	serveBrowseOrigin string
 	serveVOrigin      string
+	serveBrowseWasmSW bool
 )
 
 func init() {
@@ -37,6 +38,7 @@ func init() {
 	serveCmd.Flags().StringVar(&serveBrowseSuffix, "browse-suffix", "", fmt.Sprintf("browse-origin domain suffix for the real-origin browser (leading dot). Empty = .mesh.localhost (local); when --browse-origin is set (hosted mode) and this is empty it defaults to the deployment's browse_origin_suffix (%q from services-config.json)", deployment.Prod.BrowseOriginSuffix))
 	serveCmd.Flags().StringVar(&serveBrowseOrigin, "browse-origin", "", "ALSO serve the browse-origin SW bootstrap on this second addr (e.g. 127.0.0.1:7998), for the hosted real-origin browser's B origins. Caddy routes *.<browse-suffix> here; this same process serves V on --addr and B here. Empty = off (V host-routes B on --addr, local mode)")
 	serveCmd.Flags().StringVar(&serveVOrigin, "v-origin", "", "the PUBLIC origin of the visor app V that B's bootstrap postMessages to, e.g. https://theskywirenetwork.net. Only needed with --browse-origin behind a proxy; empty = derive from --addr (local)")
+	serveCmd.Flags().BoolVar(&serveBrowseWasmSW, "browse-origin-wasm", false, "serve the Go/wasm transport worker on the browse origins instead of the JS one. TESTING ONLY — the JS worker is what every deployment serves, and its security property is that a hundred readable lines on the untrusted origin name no transport. This swaps in a slice of the visor binary, which cannot make that claim")
 	RootCmd.AddCommand(serveCmd)
 }
 
@@ -82,6 +84,7 @@ page never asks anyone to type a secret key.`,
 			BrowseSuffix:     browseSuffix,
 			BrowseOriginAddr: serveBrowseOrigin,
 			VOrigin:          serveVOrigin,
+			BrowseWasmSW:     serveBrowseWasmSW,
 		}); err != nil {
 			cmd.PrintErrln("serve:", err)
 			os.Exit(1)

--- a/cmd/wasm-visor/browsesw_js.go
+++ b/cmd/wasm-visor/browsesw_js.go
@@ -1,0 +1,240 @@
+//go:build js && wasm
+
+// Package main cmd/wasm-visor/browsesw_js.go c3-vis-wasm
+// The transport service worker for a real-origin browse frame, in Go.
+//
+// This is an ALTERNATIVE to the JavaScript worker that github.com/0magnet/realorigin
+// ships and that every deployment uses by default. It exists to be tested, not to
+// be deployed: `hv serve --browse-origin-wasm` opts into it explicitly.
+//
+// Understand what it costs before switching it on. The JS worker's security
+// property is that you can read it — a hundred lines that name no transport, on
+// the untrusted origin B. This one is a slice of the visor binary, so the same
+// artifact that holds the visor is served to B, and "B cannot reach a key"
+// stops being provable by inspection and becomes a claim about a role flag.
+// wasmRole() fails closed in a service worker for that reason (see shell_js.go),
+// but a flag defaulting safely is still weaker than code that is not there.
+//
+// The worker does not register its own listeners. A service worker must add its
+// functional event listeners during the initial synchronous evaluation of its
+// script, and this module is instantiated asynchronously — a listener added
+// after that misses the first fetch of every cold start, which shows up as a
+// 404 fallthrough rather than an error. So browse-sw-loader.js registers them
+// and calls what this installs.
+package main
+
+import (
+	"syscall/js"
+)
+
+// installBrowseSW publishes __realOriginSWFetch(request, clientId) -> Promise<Response>,
+// which the loader calls from inside its own synchronously registered handler.
+func installBrowseSW() {
+	js.Global().Set("__realOriginSWFetch", js.FuncOf(func(_ js.Value, args []js.Value) any {
+		if len(args) < 1 {
+			return rejectedPromise("realorigin: no request")
+		}
+		req := args[0]
+		clientID := ""
+		if len(args) > 1 && args[1].Type() == js.TypeString {
+			clientID = args[1].String()
+		}
+		return bridgeFetchPromise(req, clientID)
+	}))
+}
+
+// bridgeFetchPromise mirrors realorigin's sw.js: find a controlling page, hand it
+// the request over a per-request MessagePort, and turn the reply into a Response.
+// A channel per request is what keeps concurrent subresource loads from colliding.
+func bridgeFetchPromise(req js.Value, clientID string) js.Value {
+	g := js.Global()
+	return g.Get("Promise").New(js.FuncOf(func(_ js.Value, pargs []js.Value) any {
+		resolve := pargs[0]
+		go func() {
+			defer func() {
+				// A panic here would otherwise kill the worker and take every
+				// pending request with it; a 502 keeps the page diagnosable.
+				if r := recover(); r != nil {
+					resolve.Invoke(newResponse(g, js.Null(), 502,
+						"real-origin: worker panic"))
+				}
+			}()
+			client := findClient(g, clientID)
+			if !client.Truthy() {
+				resolve.Invoke(newResponse(g, js.Null(), 503,
+					"real-origin: no controlling page to relay through"))
+				return
+			}
+			resolve.Invoke(relay(g, client, req))
+		}()
+		return nil
+	}))
+}
+
+// findClient prefers the client the fetch came from and falls back to any window,
+// which is what lets a frame still load when clientId is empty (a cold worker
+// answering a request whose client it never saw).
+func findClient(g js.Value, clientID string) js.Value {
+	clients := g.Get("clients")
+	if clientID != "" {
+		if c, ok := await(clients.Call("get", clientID)); ok && c.Truthy() {
+			return c
+		}
+	}
+	all, ok := await(clients.Call("matchAll", map[string]any{
+		"type": "window", "includeUncontrolled": true,
+	}))
+	if !ok || !all.Truthy() || all.Length() == 0 {
+		return js.Null()
+	}
+	return all.Index(0)
+}
+
+// relay posts the request to client and blocks until the reply arrives.
+func relay(g js.Value, client, req js.Value) js.Value {
+	method := req.Get("method").String()
+
+	var bodyBuf js.Value = js.Null()
+	if method != "GET" && method != "HEAD" {
+		if b, ok := await(req.Call("clone").Call("arrayBuffer")); ok {
+			bodyBuf = b
+		}
+	}
+
+	headers := map[string]any{}
+	req.Get("headers").Call("forEach", js.FuncOf(func(_ js.Value, a []js.Value) any {
+		if len(a) >= 2 {
+			headers[a[1].String()] = a[0].String()
+		}
+		return nil
+	}))
+
+	mc := g.Get("MessageChannel").New()
+	done := make(chan js.Value, 1)
+	mc.Get("port1").Set("onmessage", js.FuncOf(func(_ js.Value, a []js.Value) any {
+		if len(a) > 0 {
+			done <- a[0].Get("data")
+		} else {
+			done <- js.Null()
+		}
+		return nil
+	}))
+
+	transfer := []any{mc.Get("port2")}
+	if bodyBuf.Truthy() {
+		transfer = append(transfer, bodyBuf)
+	}
+	client.Call("postMessage", map[string]any{
+		"type": "realorigin-fetch",
+		"req": map[string]any{
+			"url": req.Get("url").String(), "method": method,
+			"headers": headers, "body": bodyBuf,
+		},
+	}, transfer)
+
+	// The 60s ceiling matches the JS worker: a mesh route can be slow to build,
+	// but a request that never returns must not hold the frame open forever.
+	timer := g.Call("setTimeout", js.FuncOf(func(_ js.Value, _ []js.Value) any {
+		select {
+		case done <- js.Undefined():
+		default:
+		}
+		return nil
+	}), 60000)
+
+	data := <-done
+	g.Call("clearTimeout", timer)
+
+	if data.Type() == js.TypeUndefined {
+		return newResponse(g, js.Null(), 504, "real-origin: upstream timeout")
+	}
+	if !data.Truthy() {
+		return newResponse(g, js.Null(), 502, "real-origin: empty reply")
+	}
+	if e := data.Get("error"); e.Truthy() {
+		return newResponse(g, js.Null(), 502, "real-origin: "+e.String())
+	}
+
+	status := 200
+	if s := data.Get("status"); s.Type() == js.TypeNumber && s.Int() > 0 {
+		status = s.Int()
+	}
+	h := g.Get("Headers").New()
+	if hv := data.Get("headers"); hv.Truthy() {
+		keys := g.Get("Object").Call("keys", hv)
+		for i := 0; i < keys.Length(); i++ {
+			k := keys.Index(i).String()
+			// Drop hop-by-hop and framing headers: the browser recomputes its
+			// own, and a stale content-length truncates the body.
+			switch lower(k) {
+			case "content-length", "transfer-encoding", "connection":
+				continue
+			}
+			safeSet(h, k, hv.Get(k))
+		}
+	}
+	body := data.Get("body")
+	if !body.Truthy() {
+		body = js.Null()
+	}
+	return g.Get("Response").New(body, map[string]any{"status": status, "headers": h})
+}
+
+// safeSet ignores a header the platform rejects, exactly as the JS worker's
+// try/catch does: one malformed name from upstream must not fail the response.
+func safeSet(h js.Value, k string, v js.Value) {
+	defer func() { _ = recover() }()
+	if v.Type() == js.TypeString {
+		h.Call("set", k, v.String())
+	}
+}
+
+func newResponse(g js.Value, body js.Value, status int, text string) js.Value {
+	if text != "" {
+		return g.Get("Response").New(text, map[string]any{"status": status})
+	}
+	return g.Get("Response").New(body, map[string]any{"status": status})
+}
+
+func rejectedPromise(msg string) js.Value {
+	g := js.Global()
+	return g.Get("Promise").Call("resolve",
+		g.Get("Response").New(msg, map[string]any{"status": 500}))
+}
+
+// await blocks the calling goroutine on a JS promise. Safe only off the event
+// loop's own turn, which is why every caller runs inside the goroutine started
+// by bridgeFetchPromise.
+func await(p js.Value) (js.Value, bool) {
+	if !p.Truthy() || p.Get("then").Type() != js.TypeFunction {
+		return p, p.Truthy()
+	}
+	type res struct {
+		v  js.Value
+		ok bool
+	}
+	ch := make(chan res, 1)
+	p.Call("then",
+		js.FuncOf(func(_ js.Value, a []js.Value) any {
+			if len(a) > 0 {
+				ch <- res{a[0], true}
+			} else {
+				ch <- res{js.Undefined(), true}
+			}
+			return nil
+		}),
+		js.FuncOf(func(_ js.Value, _ []js.Value) any { ch <- res{js.Undefined(), false}; return nil }),
+	)
+	r := <-ch
+	return r.v, r.ok
+}
+
+func lower(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 'a' - 'A'
+		}
+	}
+	return string(b)
+}

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -212,6 +212,18 @@ func main() {
 		installNetView()
 		fmt.Println("wasm-visor: netview role — call tpvizGL.init(elId, onEvent)")
 		keepAlive()
+	case "browse-sw":
+		// The transport service worker for a real-origin browse frame
+		// (browsesw_js.go). Opt-in via `hv serve --browse-origin-wasm`; what
+		// every deployment actually serves is realorigin's JS worker.
+		installBrowseSW()
+		fmt.Println("wasm-visor: browse-sw role — transport worker installed")
+		keepAlive()
+	case "inert":
+		// A service worker that was given no role. Booting a visor here could
+		// put one on an untrusted browse origin, so do nothing at all.
+		fmt.Println("wasm-visor: no role assigned in a service worker — idle")
+		keepAlive()
 	}
 	// Publish the skycoin browser cipher on the same page.
 	//

--- a/cmd/wasm-visor/shell_js.go
+++ b/cmd/wasm-visor/shell_js.go
@@ -62,7 +62,23 @@ func wasmRole() string {
 	if r := js.Global().Get("__SKYWIRE_WASM_ROLE__"); r.Type() == js.TypeString {
 		return r.String()
 	}
+	// Fail closed in a service worker. Everywhere else this binary is loaded on
+	// the visor origin V, so defaulting to a visor is right. A service worker may
+	// be running on an isolated browse origin B, which is untrusted by
+	// construction and must never boot a visor; an absent role there means "do
+	// nothing", never "do the most privileged thing".
+	if inServiceWorker() {
+		return "inert"
+	}
 	return "visor"
+}
+
+// inServiceWorker reports whether this instance is running as a ServiceWorker.
+// clients+registration together are what distinguish it from a dedicated or
+// shared worker, which have neither.
+func inServiceWorker() bool {
+	g := js.Global()
+	return g.Get("clients").Truthy() && g.Get("registration").Truthy()
 }
 
 // hasDOM reports whether this instance can touch the document — false in a

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 
 require (
 	github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408
-	github.com/0magnet/realorigin v0.1.1
+	github.com/0magnet/realorigin v0.2.0
 	github.com/0magnet/termanim v0.0.0-20260827230242-7dd03f4a292e
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/DiSiqueira/GoTree v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/0magnet/cosmos-go v0.0.0-20260814190035-f5b882c1ea9e h1:fyLB1qUtpMxPe
 github.com/0magnet/cosmos-go v0.0.0-20260814190035-f5b882c1ea9e/go.mod h1:dp0q1zfKQmTaohUrPEPZbPExxBWLu9DyeaFxKUBnw6Y=
 github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408 h1:iXCaIMD5kmvYINoBhIVv+nGtN4BRRVe64EDkOUtKvqg=
 github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408/go.mod h1:feFjgv6ByEzXixeUOB4gYwq9G8iv35aQJiYc/8ZHDWg=
-github.com/0magnet/realorigin v0.1.1 h1:C5d6rRJiKkce96Vu6sr7uajb45qnc2P7jg9v+dhg1BM=
-github.com/0magnet/realorigin v0.1.1/go.mod h1:euBTK0AolYVm6OjiDS/MixVUJAKjya315czqqjMg7Go=
+github.com/0magnet/realorigin v0.2.0 h1:+xfvyuQzRGKAtQ88WziCVK3/poPTzc4pvc0i5+kPNUc=
+github.com/0magnet/realorigin v0.2.0/go.mod h1:euBTK0AolYVm6OjiDS/MixVUJAKjya315czqqjMg7Go=
 github.com/0magnet/sh/v3 v3.13.2-0.20260814172914-eff537668adf h1:3tImGgrBxM3/eC13YeT8WsT5B3E3dxmHtozvgo0xtpo=
 github.com/0magnet/sh/v3 v3.13.2-0.20260814172914-eff537668adf/go.mod h1:IdyC3iqIKArn4KOl0a58dV2spH0PH6pLJKOZYB2kFR0=
 github.com/0magnet/termanim v0.0.0-20260827230242-7dd03f4a292e h1:sBYYZ6mOtIoh0pYElS4PYgZ/9ICKX/JSd9ydMBjnqh0=

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -73,7 +73,11 @@ type WasmServeConfig struct {
 	// "https://theskywirenetwork.net") that B's bootstrap postMessages to — used
 	// only with BrowseOriginAddr behind a proxy. Empty = derive from Addr (local).
 	VOrigin string
-	Log     *logging.Logger // nil → package default
+	// BrowseWasmSW serves the Go/wasm transport worker on the browse origins
+	// instead of realorigin's JS one. For testing that implementation only —
+	// see browseSWWasm for what the swap gives up on the untrusted origin.
+	BrowseWasmSW bool
+	Log          *logging.Logger // nil → package default
 }
 
 // ServeWasm builds the standalone wasm-visor handler and serves it on
@@ -189,6 +193,7 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 				TLS:     cfg.TLS,
 				TLSCert: cfg.TLSCert,
 				TLSKey:  cfg.TLSKey,
+				WasmSW:  cfg.BrowseWasmSW,
 				Log:     log,
 			}); err != nil {
 				log.WithError(err).Error("browse-origin bootstrap server failed")
@@ -273,7 +278,21 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	// responder calls, and is the only skywire-specific piece. All three are
 	// static — the same bytes work on every origin. The B navigation shell is
 	// host-routed below, since it needs per-request substitution.
-	serveBytes("/browse-sw.js", "text/javascript", realorigin.ServiceWorkerJS())
+	if cfg.BrowseWasmSW {
+		// Opt-in: the same wasm-visor blob V already serves, loaded into the
+		// worker with the browse-sw role. Testing only — see browseSWWasm.
+		loader, assets, err := browseSWWasm(variant)
+		if err != nil {
+			return err
+		}
+		serveBytes("/browse-sw.js", "text/javascript", loader)
+		for p, b := range assets {
+			serveBytes(p, browseSWAssetType(p), b)
+		}
+		log.Warn("serving the Go/wasm transport worker on browse origins — for testing, not deployment")
+	} else {
+		serveBytes("/browse-sw.js", "text/javascript", realorigin.ServiceWorkerJS())
+	}
 	serveBytes("/browse-responder.js", "text/javascript", realorigin.ResponderJS())
 	serveBytes("/browse-transport.js", "text/javascript", wasmhv.BrowseTransportJS)
 	swJS := bytes.ReplaceAll(wasmhv.ServiceWorkerJS, []byte("__BUILD__"), []byte(wasmVer))
@@ -509,6 +528,11 @@ type BrowseOriginConfig struct {
 	TLSCert string          // optional PEM cert (paired with TLSKey)
 	TLSKey  string          // optional PEM key
 	Log     *logging.Logger // nil → package default
+
+	// WasmSW serves the Go/wasm transport worker instead of realorigin's JS one.
+	// For testing that implementation; leave it off for anything deployed. See
+	// browseSWWasm and browse-sw-loader.js for what the swap gives up.
+	WasmSW bool
 }
 
 // ServeBrowseOrigin runs the browse-origin bootstrap server (RFC §4b, hosted mode):
@@ -538,12 +562,21 @@ func ServeBrowseOrigin(ctx context.Context, cfg BrowseOriginConfig) error {
 	//
 	// The worker sits at /browse-sw.js rather than the library's default, because
 	// /sw.js on this origin is already the PWA's app-shell worker.
-	handler, err := realorigin.Handler(realorigin.Config{
+	roCfg := realorigin.Config{
 		Suffix:    suffix,
 		AppOrigin: cfg.VOrigin,
 		SWPath:    "/browse-sw.js",
 		Shell:     wasmhv.BrowseBootstrapHTML,
-	})
+	}
+	if cfg.WasmSW {
+		loader, assets, err := browseSWWasm(wasmbin.Default())
+		if err != nil {
+			return err
+		}
+		roCfg.Worker, roCfg.Assets = loader, assets
+		log.Warn("browse-origin: serving the Go/wasm transport worker — for testing, not deployment")
+	}
+	handler, err := realorigin.Handler(roCfg)
 	if err != nil {
 		return err
 	}
@@ -801,4 +834,53 @@ func randomHex(n int) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(b), nil
+}
+
+// Paths the Go/wasm browse worker needs on the browse origin B. They sit beside
+// the worker rather than on V because a service worker fetches its own module,
+// and a cross-origin fetch from B to V would be a request the whole design
+// exists to avoid.
+const (
+	browseSWWasmPath = "/browse-sw.wasm"
+	browseSWExecPath = "/browse-sw-exec.js"
+)
+
+// browseSWWasm builds the opt-in Go/wasm transport worker: the loader with its
+// two asset paths substituted, plus the module and the wasm_exec.js that matches
+// it. The blob is the wasm-visor that is already embedded for V, so choosing this
+// worker costs no second binary — only the bytes of the browse-sw role inside it.
+//
+// It is off unless asked for. See browse-sw-loader.js for why: the JS worker can
+// be audited by reading it, and this one cannot.
+func browseSWWasm(variant wasmbin.Variant) ([]byte, map[string][]byte, error) {
+	if !wasmbin.Embedded() {
+		return nil, nil, fmt.Errorf("browse-origin wasm worker: no wasm-visor is embedded in this build")
+	}
+	if !wasmbin.Has(variant) {
+		variant = wasmbin.Default()
+	}
+	wasm, err := wasmbin.GetVariant(variant)
+	if err != nil {
+		return nil, nil, fmt.Errorf("browse-origin wasm worker: %w", err)
+	}
+	execJS := wasmbin.WasmExecJSVariant(variant)
+	if len(execJS) == 0 {
+		return nil, nil, fmt.Errorf("browse-origin wasm worker: variant %q has no wasm_exec.js", variant)
+	}
+	loader := bytes.ReplaceAll(wasmhv.BrowseSWLoaderJS, []byte("__WASM_EXEC__"), []byte(browseSWExecPath))
+	loader = bytes.ReplaceAll(loader, []byte("__WASM_URL__"), []byte(browseSWWasmPath))
+	return loader, map[string][]byte{
+		browseSWWasmPath: wasm,
+		browseSWExecPath: execJS,
+	}, nil
+}
+
+// browseSWAssetType types the worker's companion files. The wasm one matters:
+// instantiateStreaming refuses a module that does not arrive as application/wasm,
+// and the failure reads like a corrupt module rather than a header problem.
+func browseSWAssetType(p string) string {
+	if strings.HasSuffix(p, ".wasm") {
+		return "application/wasm"
+	}
+	return "text/javascript"
 }

--- a/pkg/wasmhv/browse-sw-loader.js
+++ b/pkg/wasmhv/browse-sw-loader.js
@@ -1,0 +1,54 @@
+// pkg/wasmhv/browse-sw-loader.js c3-vis-wasm
+// Loader for the Go/wasm transport service worker (cmd/wasm-visor/browsesw_js.go).
+//
+// Served at the browse origin's worker path INSTEAD of realorigin's JS worker
+// when `hv serve --browse-origin-wasm` is set. Off by default, and deliberately
+// so: the JS worker's security property is that a hundred readable lines on the
+// untrusted origin name no transport, and a wasm module cannot make that claim.
+//
+// The listeners are registered HERE, synchronously, and not by the Go module. A
+// service worker only receives functional events on listeners added during the
+// initial synchronous evaluation of its script; the wasm module is instantiated
+// asynchronously, so a listener it added itself would miss the first fetch after
+// every cold start — a 404 fallthrough that reads like a routing bug rather than
+// an error. respondWith() accepts a promise, so waiting for the boot inside the
+// handler is both legal and the whole trick.
+'use strict';
+
+self.__SKYWIRE_WASM_ROLE__ = 'browse-sw';
+
+importScripts('__WASM_EXEC__');
+
+var ready = (function () {
+  var go = new Go();
+  return WebAssembly.instantiateStreaming(fetch('__WASM_URL__'), go.importObject)
+    .then(function (r) {
+      // go.run resolves only when the program exits; the module keeps itself
+      // alive, so start it and carry on rather than awaiting it.
+      go.run(r.instance);
+      if (typeof self.__realOriginSWFetch !== 'function') {
+        throw new Error('browse-sw: the module installed no fetch handler');
+      }
+      return true;
+    });
+})();
+
+self.addEventListener('install', function () { self.skipWaiting(); });
+self.addEventListener('activate', function (e) { e.waitUntil(self.clients.claim()); });
+
+self.addEventListener('fetch', function (e) {
+  // Navigations are not handled, exactly as in the JS worker: a worker that
+  // served the first page would have to be installed by a page it had not
+  // served yet, so there is no base case. The server serves the shell instead.
+  if (e.request.mode === 'navigate') {
+    return;
+  }
+  var clientId = e.clientId || '';
+  e.respondWith(
+    ready.then(function () {
+      return self.__realOriginSWFetch(e.request, clientId);
+    }).catch(function (err) {
+      return new Response('browse-sw: ' + err, { status: 502 });
+    })
+  );
+});

--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -105,6 +105,14 @@ var BrowseBootstrapHTML []byte
 //go:embed browse-transport.js
 var BrowseTransportJS []byte
 
+// BrowseSWLoaderJS boots the Go/wasm transport worker in place of realorigin's
+// JS one, and is served only when `hv serve --browse-origin-wasm` asks for it.
+// __WASM_EXEC__ and __WASM_URL__ are substituted with the paths the same origin
+// serves those two files from.
+//
+//go:embed browse-sw-loader.js
+var BrowseSWLoaderJS []byte
+
 // PWAIcon192 / PWAIcon512 are the maskable install icons referenced by the
 // manifest, served at /icon-192.png and /icon-512.png.
 //

--- a/vendor/github.com/0magnet/realorigin/serve.go
+++ b/vendor/github.com/0magnet/realorigin/serve.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -50,6 +52,28 @@ type Config struct {
 	// __APP_ORIGIN__ and __SUFFIX__ are substituted here exactly as they are in
 	// the built-in shell.
 	Shell []byte
+
+	// Worker replaces the transport service worker served at SWPath. Empty uses
+	// the built-in one.
+	//
+	// The built-in worker is deliberately small and names no transport, which is
+	// what makes it auditable on the untrusted origin. A replacement inherits that
+	// responsibility: it runs on B, so whatever it can reach, untrusted content can
+	// reach through it. It must speak the same bridge protocol — relay each
+	// non-navigation fetch to a controlling client as {type:realorigin-fetch}
+	// over a MessagePort and answer with the returned {status, headers, body}.
+	//
+	// A worker that needs companion files (a wasm module and its loader, say)
+	// serves them through Assets.
+	Worker []byte
+
+	// Assets are extra paths served verbatim on the browse origin, e.g.
+	// {"/sw.wasm": mod, "/wasm_exec.js": loader}. Keys are absolute paths and win
+	// over the shell; SWPath still wins over both.
+	//
+	// Every byte here is served to the UNTRUSTED origin, so put nothing in it that
+	// the browsed content should not have.
+	Assets map[string][]byte
 }
 
 const defaultSWPath = "/sw.js"
@@ -89,6 +113,25 @@ func Handler(cfg Config) (http.Handler, error) {
 	// The worker needs no substitution: it learns nothing from configuration,
 	// which is the same reason it can be reused across every transport.
 	worker := swJS
+	if len(cfg.Worker) > 0 {
+		worker = cfg.Worker
+	}
+
+	// Copy the asset map so a later mutation by the caller cannot change what an
+	// already-running server hands to the untrusted origin.
+	var assets map[string][]byte
+	if len(cfg.Assets) > 0 {
+		assets = make(map[string][]byte, len(cfg.Assets))
+		for p, b := range cfg.Assets {
+			if !strings.HasPrefix(p, "/") {
+				p = "/" + p
+			}
+			if p == swPath {
+				return nil, fmt.Errorf("realorigin: asset %q collides with SWPath", p)
+			}
+			assets[p] = b
+		}
+	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == swPath {
@@ -97,6 +140,12 @@ func Handler(cfg Config) (http.Handler, error) {
 			// worker keeps answering with an old bridge protocol.
 			w.Header().Set("Cache-Control", "no-cache")
 			_, _ = w.Write(worker) //nolint:errcheck // a short write to a hung client is the client's problem; there is no recovery here
+			return
+		}
+		if b, ok := assets[r.URL.Path]; ok {
+			w.Header().Set("Content-Type", assetContentType(r.URL.Path))
+			w.Header().Set("Cache-Control", "no-cache")
+			_, _ = w.Write(b) //nolint:errcheck // as above
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -141,3 +190,22 @@ func (cfg Config) ListenAndServe(ctx context.Context) error {
 // browse origin itself rather than through Handler — a host-routed setup where B
 // and the app share one listener, say. Serve it at Config.SWPath.
 func ServiceWorkerJS() []byte { return swJS }
+
+// assetContentType maps an asset path to a content type. WebAssembly is the one
+// that matters: instantiateStreaming refuses a module that does not arrive as
+// application/wasm, and the failure looks like a corrupt module rather than a
+// header problem.
+func assetContentType(p string) string {
+	switch {
+	case strings.HasSuffix(p, ".wasm"):
+		return "application/wasm"
+	case strings.HasSuffix(p, ".js"):
+		return "text/javascript; charset=utf-8"
+	case strings.HasSuffix(p, ".json"):
+		return "application/json"
+	case strings.HasSuffix(p, ".css"):
+		return "text/css; charset=utf-8"
+	default:
+		return "application/octet-stream"
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -28,7 +28,7 @@ github.com/0magnet/cosmos-go
 # github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408
 ## explicit; go 1.25
 github.com/0magnet/plot-go
-# github.com/0magnet/realorigin v0.1.1
+# github.com/0magnet/realorigin v0.2.0
 ## explicit; go 1.25
 github.com/0magnet/realorigin
 # github.com/0magnet/sh/v3 v3.13.2-0.20260814172914-eff537668adf


### PR DESCRIPTION
Adds a \`browse-sw\` role to the wasm-visor and \`hv serve --browse-origin-wasm\` to serve it instead of realorigin's JavaScript worker. Off by default — it exists to make that implementation testable, not to be deployed.

The default stays JS deliberately: that worker can be audited by reading it, a hundred lines on the untrusted origin B naming no transport, and a wasm module cannot make that claim. Related: \`wasmRole()\` now fails closed in a service worker, where an absent role previously meant "boot a visor".

Reusing the already-embedded blob costs ~10KB gzipped in the skywire binary, since only the role's own code is new. Cold start is the real cost: waking the worker takes ~914ms for the 50MB module against ~8ms warm. The loader registers the fetch listener itself, because a service worker only gets functional events on listeners added during initial synchronous evaluation — one added after the async boot misses the first fetch of every cold start, as a 404 fallthrough rather than an error.

Verified in Chrome end to end: relay round-trip, header stripping, and both timings above are measured rather than estimated. Needs realorigin v0.2.0, which adds the \`Worker\`/\`Assets\` seams.