### PR TITLE
feat(router): forward error correction for the packet mux

### DIFF
--- a/pkg/router/fec_endtoend_test.go
+++ b/pkg/router/fec_endtoend_test.go
@@ -1,0 +1,276 @@
+package router
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// pipeLeg is a one-way A→B mux leg for the end-to-end FEC harness. Each packet
+// written by the sender route group is forwarded to the receiver's handlePacket
+// after a per-leg latency, serialized through a single goroutine so the leg
+// models a finite bandwidth (one packet per `latency`). recvBytes counts the
+// bytes carried — the per-leg telemetry the aggregation discipline requires.
+type pipeLeg struct {
+	closed   chan struct{}
+	pk1, pk2 cipher.PubKey
+	ch       chan []byte
+	latency  time.Duration
+	deliver  func([]byte)
+	recv     int64 // atomic: bytes carried on this leg
+	once     sync.Once
+}
+
+func newPipeLeg(latency time.Duration, deliver func([]byte)) *pipeLeg {
+	p1, _ := cipher.GenerateKeyPair()
+	p2, _ := cipher.GenerateKeyPair()
+	p := &pipeLeg{
+		closed:  make(chan struct{}),
+		pk1:     p1,
+		pk2:     p2,
+		ch:      make(chan []byte, 4096),
+		latency: latency,
+		deliver: deliver,
+	}
+	go p.run()
+	return p
+}
+
+func (p *pipeLeg) run() {
+	for b := range p.ch {
+		if p.latency > 0 {
+			time.Sleep(p.latency)
+		}
+		select {
+		case <-p.closed:
+			return
+		default:
+			p.deliver(b)
+		}
+	}
+}
+
+func (p *pipeLeg) Write(b []byte) (int, error) {
+	select {
+	case <-p.closed:
+		return 0, net.ErrClosed
+	default:
+	}
+	cp := make([]byte, len(b))
+	copy(cp, b)
+	atomic.AddInt64(&p.recv, int64(len(b)))
+	select {
+	case p.ch <- cp:
+	case <-p.closed:
+		return 0, net.ErrClosed
+	}
+	return len(b), nil
+}
+
+func (p *pipeLeg) Read([]byte) (int, error) { <-p.closed; return 0, net.ErrClosed }
+func (p *pipeLeg) Close() error {
+	p.once.Do(func() { close(p.closed) })
+	return nil
+}
+func (p *pipeLeg) LocalAddr() net.Addr              { return &net.TCPAddr{} }
+func (p *pipeLeg) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
+func (p *pipeLeg) SetDeadline(time.Time) error      { return nil }
+func (p *pipeLeg) SetReadDeadline(time.Time) error  { return nil }
+func (p *pipeLeg) SetWriteDeadline(time.Time) error { return nil }
+func (p *pipeLeg) LocalPK() cipher.PubKey           { return p.pk1 }
+func (p *pipeLeg) RemotePK() cipher.PubKey          { return p.pk2 }
+func (p *pipeLeg) LocalPort() uint16                { return 0 }
+func (p *pipeLeg) RemotePort() uint16               { return 0 }
+func (p *pipeLeg) LocalRawAddr() net.Addr           { return &net.TCPAddr{} }
+func (p *pipeLeg) RemoteRawAddr() net.Addr          { return &net.TCPAddr{} }
+func (p *pipeLeg) Network() types.Type              { return "test" }
+
+// fecE2ESetup builds a sender route group A whose N legs pipe to a receiver route
+// group B (both with FEC set to `fec`). legLatencies[i] is leg i's per-packet
+// delay. Returns A, B, the per-leg pipes (for byte accounting), and a cleanup.
+func fecE2ESetup(t *testing.T, fec bool, legLatencies []time.Duration) (*RouteGroup, *RouteGroup, []*pipeLeg, func()) {
+	t.Helper()
+	l := logging.NewMasterLogger()
+	n := len(legLatencies)
+
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+
+	// Receiver B.
+	rtB := routing.NewTable(l.PackageLogger("rtB"))
+	descB := routing.NewRouteDescriptor(pkB, pkA, 2, 1)
+	rgB := NewRouteGroup(DefaultRouteGroupConfig(), rtB, descB, l)
+	rgB.mux = newRouteMux(l.PackageLogger("muxB"), true)
+	rgB.mux.growLegs(n)
+	for i := 0; i < n; i++ {
+		rgB.mux.markLegReady(i)
+	}
+	if fec {
+		rgB.mux.fecEnabled = true
+		rgB.mux.fecInit()
+	}
+
+	// B receives a packet on any leg: dispatch through the real handlePacket path.
+	deliver := func(b []byte) {
+		if rgB.isClosed() {
+			return
+		}
+		_ = rgB.handlePacket(routing.Packet(b)) //nolint:errcheck
+	}
+
+	// Sender A with N pipe legs.
+	rtA := routing.NewTable(l.PackageLogger("rtA"))
+	descA := routing.NewRouteDescriptor(pkA, pkB, 1, 2)
+	rgA := NewRouteGroup(DefaultRouteGroupConfig(), rtA, descA, l)
+	rgA.mux = newRouteMux(l.PackageLogger("muxA"), true)
+
+	pipes := make([]*pipeLeg, n)
+	mts := make([]*transport.ManagedTransport, 0, n)
+	fwds := make([]routing.Rule, 0, n)
+	rvss := make([]routing.Rule, 0, n)
+	for i := 0; i < n; i++ {
+		tpID := uuid.New()
+		fwd := routing.ForwardRule(DefaultRouteKeepAlive, routing.RouteID(i+1), routing.RouteID(i+100), tpID, pkB, pkA, 1, 2) //nolint:gosec
+		rvs := routing.ConsumeRule(DefaultRouteKeepAlive, routing.RouteID(i+100), pkA, pkB, 2, 1)                             //nolint:gosec
+		rtA.SaveRule(fwd)                                                                                                     //nolint:errcheck,gosec
+		rtA.SaveRule(rvs)                                                                                                     //nolint:errcheck,gosec
+		p := newPipeLeg(legLatencies[i], deliver)
+		mt := transport.NewManagedTransportForTest(p)
+		mt.Entry = transport.Entry{ID: tpID, Type: "test"}
+		pipes[i] = p
+		mts = append(mts, mt)
+		fwds = append(fwds, fwd)
+		rvss = append(rvss, rvs)
+	}
+
+	rgA.mu.Lock()
+	rgA.tps = mts
+	rgA.fwd = fwds
+	rgA.rvs = rvss
+	rgA.mux.rebuildWeights(mts)
+	rgA.mux.growLegs(len(mts))
+	for i := range mts {
+		rgA.mux.markLegReady(i)
+	}
+	rgA.mu.Unlock()
+	if fec {
+		rgA.mux.fecEnabled = true
+		rgA.mux.fecInit()
+	}
+
+	cleanup := func() {
+		// Close only the pipes (stops the leg goroutines). rgA/rgB.Close() is
+		// skipped: this harness never starts the route-group service loops, and
+		// Close's teardown handshake would otherwise block on timeouts we don't
+		// need in-test.
+		for _, p := range pipes {
+			p.Close() //nolint:errcheck
+		}
+	}
+	return rgA, rgB, pipes, cleanup
+}
+
+// TestFECMuxEndToEndThroughput is the controlled two-node run: a sender route
+// group stripes a completed bulk transfer across a HETEROGENEOUS leg set (3 fast
+// + 1 slow) to a receiver route group over real piped transports, and we measure
+// wall-clock completion with FEC on vs off, plus a single-fast-leg baseline. It
+// asserts mux+FEC completes well before mux/no-FEC (the slow leg no longer drags
+// the no-skip reorder frontier) AND at or below the single-leg time (aggregation
+// across the fast legs is preserved). Per-leg carried bytes are reported.
+func TestFECMuxEndToEndThroughput(t *testing.T) {
+	const (
+		nFrames   = 48 // 6 full K=8 blocks — no partial tail, isolates the core path
+		frameSize = 1024
+		fastLat   = 1 * time.Millisecond
+		slowLat   = 15 * time.Millisecond
+	)
+	hetero := []time.Duration{fastLat, fastLat, fastLat, slowLat} // 3 fast + 1 slow
+	single := []time.Duration{fastLat}                            // one fast leg
+
+	run := func(fec bool, lats []time.Duration) (time.Duration, []int64) {
+		rgA, rgB, pipes, cleanup := fecE2ESetup(t, fec, lats)
+		defer cleanup()
+
+		done := make(chan struct{})
+		var got int64
+		var seenMu sync.Mutex
+		seen := make(map[byte]int)
+		go func() {
+			for {
+				select {
+				case <-rgB.closed:
+					return
+				case d := <-rgB.readCh:
+					if len(d) > 0 {
+						seenMu.Lock()
+						seen[d[0]]++
+						seenMu.Unlock()
+					}
+					if atomic.AddInt64(&got, int64(len(d))) >= int64(nFrames*frameSize) {
+						close(done)
+						return
+					}
+				}
+			}
+		}()
+
+		payload := make([]byte, frameSize)
+		start := time.Now()
+		for i := 0; i < nFrames; i++ {
+			for j := range payload {
+				payload[j] = byte(i)
+			}
+			if _, err := rgA.Write(payload); err != nil {
+				t.Fatalf("write %d: %v", i, err)
+			}
+		}
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			seenMu.Lock()
+			var missing []int
+			var dups []int
+			for i := 0; i < nFrames; i++ {
+				c := seen[byte(i)]
+				if c == 0 {
+					missing = append(missing, i)
+				} else if c > 1 {
+					dups = append(dups, i)
+				}
+			}
+			seenMu.Unlock()
+			t.Fatalf("transfer did not complete (fec=%v): got %d/%d bytes; missing seqs=%v dup seqs=%v",
+				fec, atomic.LoadInt64(&got), nFrames*frameSize, missing, dups)
+		}
+		elapsed := time.Since(start)
+		perLeg := make([]int64, len(pipes))
+		for i, p := range pipes {
+			perLeg[i] = atomic.LoadInt64(&p.recv)
+		}
+		return elapsed, perLeg
+	}
+
+	noFEC, noLegs := run(false, hetero)
+	withFEC, fecLegs := run(true, hetero)
+	singleT, _ := run(false, single)
+
+	t.Logf("heterogeneous legs %v", hetero)
+	t.Logf("  mux/no-FEC : %v   per-leg bytes=%v", noFEC.Round(time.Millisecond), noLegs)
+	t.Logf("  mux/FEC    : %v   per-leg bytes=%v", withFEC.Round(time.Millisecond), fecLegs)
+	t.Logf("  single-leg : %v", singleT.Round(time.Millisecond))
+
+	require.Less(t, withFEC, noFEC, "FEC must remove the slow-leg HoL drag (complete before no-FEC)")
+	require.LessOrEqual(t, withFEC, singleT+singleT/2,
+		"mux+FEC must aggregate across the fast legs (at or below ~single-leg time), got fec=%v single=%v", withFEC, singleT)
+}

--- a/pkg/router/fec_flush.go
+++ b/pkg/router/fec_flush.go
@@ -1,0 +1,160 @@
+// Package router pkg/router/fec_flush.go — partial-block "timer-flush" (Tetrys-
+// style tail protection) for the packet-mux FEC layer (fec_mux.go, #4270).
+//
+// THE WEAKNESS THIS CLOSES. Fixed-block FEC only emits repair when a block fills
+// to K data frames (fecStriper.Add). On a unidirectional bulk stream the LAST
+// block is almost always partial: after the final j<K frames the sender goes
+// idle, so those j frames get NO repair. If one of them was striped onto a slow
+// leg, the no-skip reorder frontier stalls at the very tail with no FEC rescue —
+// the single documented failure mode of fixed-block FEC on a bulk transfer. A
+// retransmit still recovers it, but coupled to the slow leg's RTT, which is
+// exactly the wait erasure coding exists to remove.
+//
+// THE FIX (Tetrys tail idea, adapted to a systematic block code with ZERO wire
+// change). When the sender has been idle for T with a partial block pending, we
+// COMPLETE the block synthetically: the K-j missing data slots are filled with
+// zero-length padding symbols (symbolize(nil) → a length prefix of 0), the now-
+// full K symbols are Encoded, and the R repair frames are emitted just as a
+// natural block boundary would emit them. The block is then a genuine K-of-(K+R)
+// MDS block, so any real tail frame lost on a slow leg is reconstructable from
+// the repair that rode a fast leg — the frontier advances at the fast leg's rate.
+//
+// WHY NO WIRE-FORMAT OR RECEIVER CHANGE IS NEEDED. The padding is not a new frame
+// type. The sender emits the K-j padding slots as REAL zero-length sequenced DATA
+// frames (seqs filled..K-1 of the block) on the normal send path. The receiver
+// records them through the ordinary data path (RecordData with an empty payload,
+// identical to the sender's symbolize(nil)) and, when the frontier reaches each,
+// delivers it as a 0-byte read — a no-op for a byte stream. So the receiver's
+// block becomes genuinely K-full using only frames it already knows how to parse;
+// FlushPartial adds a coding path on the SENDER only. FlushPartial returns how
+// many such padding frames the caller must emit; scheduling them and the repair
+// onto legs is the send loop's job (deliberately kept out of this file so
+// route_group.go can own leg selection).
+//
+// Everything here is pure/deterministic and attaches to fecStriper by method from
+// this separate file (Go permits methods on a package type from any file), so it
+// is fully unit-testable without the live mesh and without editing fec_mux.go.
+package router
+
+import "time"
+
+// fecDefaultIdleFlush is the default inactivity gap after which a pending partial
+// block is flushed. It trades a small extra repair-overhead on the tail for tail
+// HoL protection; it must be well above normal inter-frame gaps so a merely
+// bursty-but-active stream is not flushed mid-block (Add will complete that block
+// naturally). A route-group send loop may override it. 50ms comfortably exceeds
+// per-frame spacing at any aggregated rate while still bounding tail-stall risk to
+// a single idle interval.
+const fecDefaultIdleFlush = 50 * time.Millisecond
+
+// FlushPartial completes and codes the current partial block so its tail frames
+// gain FEC protection, instead of waiting for K frames that (on an idle stream)
+// will never come.
+//
+// Behaviour, under s.mu:
+//   - If the current block has 0 filled slots (nothing to protect) or is already
+//     full (Add resets to filled==0 on completion, so this is defensive), it does
+//     nothing and returns ok=false.
+//   - Otherwise it fills the K-filled empty data slots with zero-length padding
+//     symbols, Encodes the now-full K symbols, and returns:
+//     paddingNeeded = K-filled — the number of REAL zero-length sequenced data
+//     frames the caller must emit (seqs filled..K-1 of this block) so the
+//     receiver's block is genuinely complete;
+//     frames        = the R repair frames to schedule (blockID = this block);
+//     ok            = true.
+//
+// Idempotency: on success it advances to the next block (reset(block+1)), which
+// zeroes filled. A repeated call on the same unchanged block therefore falls into
+// the filled==0 short-circuit and returns ok=false — the reset IS the "already
+// flushed" marker, so no extra field on fecStriper is required (and none may be
+// added here: fec_mux.go is edited concurrently). A later Add naturally starts a
+// fresh block.
+func (s *fecStriper) FlushPartial() (paddingNeeded int, frames []fecRepairFrame, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// filled==0: empty block (never added, or already flushed/advanced) → no-op.
+	// filled>=k: a full block; Add already emitted its repair and reset filled to
+	// 0, so this is only reachable defensively — treat as nothing to do.
+	if s.filled == 0 || s.filled >= s.k {
+		return 0, nil, false
+	}
+
+	blk := s.block
+	paddingNeeded = s.k - s.filled
+
+	// Complete the block: every empty data slot becomes a zero-length padding
+	// symbol (length prefix 0). These are legitimate coded symbols, so the block
+	// is a real K-of-(K+R) MDS block — a genuine tail frame lost on a slow leg is
+	// reconstructable from any K of the K+R symbols. The receiver reproduces these
+	// same padding symbols from the real zero-length data frames the caller emits
+	// (RecordData of an empty payload == symbolize(nil) here), so encoder and
+	// decoder agree bit-for-bit with no wire change.
+	for i := range s.symbols {
+		if s.symbols[i] == nil {
+			s.symbols[i], _ = symbolize(nil, s.symLen)
+		}
+	}
+	repair, err := s.coder.Encode(s.symbols)
+	if err != nil {
+		// Should not happen (dims are fixed at construction). Advance anyway so we
+		// do not spin re-flushing an un-encodable block; the tail falls back to
+		// retransmit recovery, exactly as pre-flush behaviour.
+		s.reset(blk + 1)
+		return 0, nil, false
+	}
+	frames = make([]fecRepairFrame, s.r)
+	for i := 0; i < s.r; i++ {
+		frames[i] = fecRepairFrame{blockID: blk, idx: uint8(i), symbol: repair[i]}
+	}
+	// Advance to the next block: fresh state for any later Add, and the idempotency
+	// short-circuit above for a repeat FlushPartial.
+	s.reset(blk + 1)
+	return paddingNeeded, frames, true
+}
+
+// hasPartialBlock reports whether a block is currently mid-fill (1..K-1 slots),
+// i.e. whether there is anything for FlushPartial to protect. Cheap and safe for
+// the send loop to poll. Full blocks are handled by Add; empty blocks have nothing
+// to flush.
+func (s *fecStriper) hasPartialBlock() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.filled > 0 && s.filled < s.k
+}
+
+// --- flush POLICY (pure, deterministic — no time.Now() inside) ---
+
+// fecShouldFlush is the pure timer-flush decision the send loop consults. It is
+// deliberately free of time.Now(): the caller passes both the current time and
+// the timestamp of the last Add, so the policy is fully deterministic and
+// unit-testable (the codebase forbids Date.now-style nondeterminism in tests).
+//
+// It returns true when a partial block is pending AND the stream has been idle for
+// at least idle since the last frame. idle<=0 disables flushing (opt-out); a
+// zero-value lastAdd (no frame yet seen) never flushes because pending would be
+// false in that case anyway.
+func fecShouldFlush(now, lastAdd time.Time, idle time.Duration, pending bool) bool {
+	if !pending || idle <= 0 {
+		return false
+	}
+	return now.Sub(lastAdd) >= idle
+}
+
+// MaybeFlush is the single entry point a route-group send loop calls on its
+// periodic tick: if the idle-gap policy says the pending partial block should be
+// flushed, it flushes and returns the padding count + repair frames to schedule;
+// otherwise it returns ok=false and no work. Timestamps are passed in so the loop
+// owns the clock (and tests can drive it deterministically). The loop remains
+// responsible for actually emitting the paddingNeeded zero-length data frames on
+// its normal sequenced send path and scheduling frames onto legs.
+//
+// The hasPartialBlock pre-check is only an optimisation; FlushPartial re-validates
+// under the lock and returns ok=false if the block filled or emptied in between,
+// so a race with a concurrent Add is harmless.
+func (s *fecStriper) MaybeFlush(now, lastAdd time.Time, idle time.Duration) (paddingNeeded int, frames []fecRepairFrame, ok bool) {
+	if !fecShouldFlush(now, lastAdd, idle, s.hasPartialBlock()) {
+		return 0, nil, false
+	}
+	return s.FlushPartial()
+}

--- a/pkg/router/fec_flush.go
+++ b/pkg/router/fec_flush.go
@@ -1,160 +1,54 @@
-// Package router pkg/router/fec_flush.go — partial-block "timer-flush" (Tetrys-
-// style tail protection) for the packet-mux FEC layer (fec_mux.go, #4270).
+// Package router pkg/router/fec_flush.go — idle-flush policy for the packet-mux
+// FEC tail (fec_mux.go, #4270).
 //
 // THE WEAKNESS THIS CLOSES. Fixed-block FEC only emits repair when a block fills
 // to K data frames (fecStriper.Add). On a unidirectional bulk stream the LAST
 // block is almost always partial: after the final j<K frames the sender goes
-// idle, so those j frames get NO repair. If one of them was striped onto a slow
-// leg, the no-skip reorder frontier stalls at the very tail with no FEC rescue —
-// the single documented failure mode of fixed-block FEC on a bulk transfer. A
-// retransmit still recovers it, but coupled to the slow leg's RTT, which is
-// exactly the wait erasure coding exists to remove.
+// idle, so those j frames get NO repair, and a tail frame striped onto a slow leg
+// stalls the no-skip reorder frontier with no FEC rescue — the one documented
+// failure mode of fixed-block FEC on a bulk transfer.
 //
-// THE FIX (Tetrys tail idea, adapted to a systematic block code with ZERO wire
-// change). When the sender has been idle for T with a partial block pending, we
-// COMPLETE the block synthetically: the K-j missing data slots are filled with
-// zero-length padding symbols (symbolize(nil) → a length prefix of 0), the now-
-// full K symbols are Encoded, and the R repair frames are emitted just as a
-// natural block boundary would emit them. The block is then a genuine K-of-(K+R)
-// MDS block, so any real tail frame lost on a slow leg is reconstructable from
-// the repair that rode a fast leg — the frontier advances at the fast leg's rate.
+// THE FIX (adapted to a systematic block code with ZERO wire change). When the
+// sender has been idle for T with a partial block pending, the route-group send
+// loop (RouteGroup.fecFlushServiceFn) completes the block by emitting the K-j
+// remaining slots as REAL empty PADDING frames through the normal send path. Each
+// advances writeSeq and the striper, and the K-th completes the block so Add
+// emits the repair as at any block boundary. The padding frames are real sealed
+// frames (encoder/decoder agree in the wire domain), they fill the seq gap the
+// no-skip reorder would otherwise stall on, and the receiver delivers them as
+// 0-byte reads that the mux delivery loop filters out of the app stream (the app
+// never writes an empty frame — Write rejects len==0). So the tail block becomes
+// a genuine K-full MDS block with no new frame type and no receiver change.
 //
-// WHY NO WIRE-FORMAT OR RECEIVER CHANGE IS NEEDED. The padding is not a new frame
-// type. The sender emits the K-j padding slots as REAL zero-length sequenced DATA
-// frames (seqs filled..K-1 of the block) on the normal send path. The receiver
-// records them through the ordinary data path (RecordData with an empty payload,
-// identical to the sender's symbolize(nil)) and, when the frontier reaches each,
-// delivers it as a 0-byte read — a no-op for a byte stream. So the receiver's
-// block becomes genuinely K-full using only frames it already knows how to parse;
-// FlushPartial adds a coding path on the SENDER only. FlushPartial returns how
-// many such padding frames the caller must emit; scheduling them and the repair
-// onto legs is the send loop's job (deliberately kept out of this file so
-// route_group.go can own leg selection).
-//
-// Everything here is pure/deterministic and attaches to fecStriper by method from
-// this separate file (Go permits methods on a package type from any file), so it
-// is fully unit-testable without the live mesh and without editing fec_mux.go.
+// This file holds the pure, deterministic policy the send loop consults; the
+// emission itself lives in route_group.go (which owns leg selection).
 package router
 
 import "time"
 
-// fecDefaultIdleFlush is the default inactivity gap after which a pending partial
-// block is flushed. It trades a small extra repair-overhead on the tail for tail
-// HoL protection; it must be well above normal inter-frame gaps so a merely
-// bursty-but-active stream is not flushed mid-block (Add will complete that block
-// naturally). A route-group send loop may override it. 50ms comfortably exceeds
-// per-frame spacing at any aggregated rate while still bounding tail-stall risk to
-// a single idle interval.
+// fecDefaultIdleFlush is the inactivity gap after which a pending partial block is
+// flushed. It must be well above normal inter-frame spacing so a merely bursty-
+// but-active stream is not flushed mid-block (Add completes that block naturally);
+// 50ms comfortably exceeds per-frame spacing at any aggregated rate while bounding
+// tail-stall risk to a single idle interval.
 const fecDefaultIdleFlush = 50 * time.Millisecond
 
-// FlushPartial completes and codes the current partial block so its tail frames
-// gain FEC protection, instead of waiting for K frames that (on an idle stream)
-// will never come.
-//
-// Behaviour, under s.mu:
-//   - If the current block has 0 filled slots (nothing to protect) or is already
-//     full (Add resets to filled==0 on completion, so this is defensive), it does
-//     nothing and returns ok=false.
-//   - Otherwise it fills the K-filled empty data slots with zero-length padding
-//     symbols, Encodes the now-full K symbols, and returns:
-//     paddingNeeded = K-filled — the number of REAL zero-length sequenced data
-//     frames the caller must emit (seqs filled..K-1 of this block) so the
-//     receiver's block is genuinely complete;
-//     frames        = the R repair frames to schedule (blockID = this block);
-//     ok            = true.
-//
-// Idempotency: on success it advances to the next block (reset(block+1)), which
-// zeroes filled. A repeated call on the same unchanged block therefore falls into
-// the filled==0 short-circuit and returns ok=false — the reset IS the "already
-// flushed" marker, so no extra field on fecStriper is required (and none may be
-// added here: fec_mux.go is edited concurrently). A later Add naturally starts a
-// fresh block.
-func (s *fecStriper) FlushPartial() (paddingNeeded int, frames []fecRepairFrame, ok bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// filled==0: empty block (never added, or already flushed/advanced) → no-op.
-	// filled>=k: a full block; Add already emitted its repair and reset filled to
-	// 0, so this is only reachable defensively — treat as nothing to do.
-	if s.filled == 0 || s.filled >= s.k {
-		return 0, nil, false
-	}
-
-	blk := s.block
-	paddingNeeded = s.k - s.filled
-
-	// Complete the block: every empty data slot becomes a zero-length padding
-	// symbol (length prefix 0). These are legitimate coded symbols, so the block
-	// is a real K-of-(K+R) MDS block — a genuine tail frame lost on a slow leg is
-	// reconstructable from any K of the K+R symbols. The receiver reproduces these
-	// same padding symbols from the real zero-length data frames the caller emits
-	// (RecordData of an empty payload == symbolize(nil) here), so encoder and
-	// decoder agree bit-for-bit with no wire change.
-	for i := range s.symbols {
-		if s.symbols[i] == nil {
-			s.symbols[i], _ = symbolize(nil, s.symLen)
-		}
-	}
-	repair, err := s.coder.Encode(s.symbols)
-	if err != nil {
-		// Should not happen (dims are fixed at construction). Advance anyway so we
-		// do not spin re-flushing an un-encodable block; the tail falls back to
-		// retransmit recovery, exactly as pre-flush behaviour.
-		s.reset(blk + 1)
-		return 0, nil, false
-	}
-	frames = make([]fecRepairFrame, s.r)
-	for i := 0; i < s.r; i++ {
-		frames[i] = fecRepairFrame{blockID: blk, idx: uint8(i), symbol: repair[i]}
-	}
-	// Advance to the next block: fresh state for any later Add, and the idempotency
-	// short-circuit above for a repeat FlushPartial.
-	s.reset(blk + 1)
-	return paddingNeeded, frames, true
-}
-
 // hasPartialBlock reports whether a block is currently mid-fill (1..K-1 slots),
-// i.e. whether there is anything for FlushPartial to protect. Cheap and safe for
-// the send loop to poll. Full blocks are handled by Add; empty blocks have nothing
-// to flush.
+// i.e. whether there is a tail for the flush to protect. Cheap; safe to poll.
 func (s *fecStriper) hasPartialBlock() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.filled > 0 && s.filled < s.k
 }
 
-// --- flush POLICY (pure, deterministic — no time.Now() inside) ---
-
 // fecShouldFlush is the pure timer-flush decision the send loop consults. It is
 // deliberately free of time.Now(): the caller passes both the current time and
-// the timestamp of the last Add, so the policy is fully deterministic and
-// unit-testable (the codebase forbids Date.now-style nondeterminism in tests).
-//
-// It returns true when a partial block is pending AND the stream has been idle for
-// at least idle since the last frame. idle<=0 disables flushing (opt-out); a
-// zero-value lastAdd (no frame yet seen) never flushes because pending would be
-// false in that case anyway.
+// the timestamp of the last send, so the policy is fully deterministic and
+// unit-testable. It returns true when a partial block is pending AND the stream
+// has been idle for at least idle since the last frame. idle<=0 disables flushing.
 func fecShouldFlush(now, lastAdd time.Time, idle time.Duration, pending bool) bool {
 	if !pending || idle <= 0 {
 		return false
 	}
 	return now.Sub(lastAdd) >= idle
-}
-
-// MaybeFlush is the single entry point a route-group send loop calls on its
-// periodic tick: if the idle-gap policy says the pending partial block should be
-// flushed, it flushes and returns the padding count + repair frames to schedule;
-// otherwise it returns ok=false and no work. Timestamps are passed in so the loop
-// owns the clock (and tests can drive it deterministically). The loop remains
-// responsible for actually emitting the paddingNeeded zero-length data frames on
-// its normal sequenced send path and scheduling frames onto legs.
-//
-// The hasPartialBlock pre-check is only an optimisation; FlushPartial re-validates
-// under the lock and returns ok=false if the block filled or emptied in between,
-// so a race with a concurrent Add is harmless.
-func (s *fecStriper) MaybeFlush(now, lastAdd time.Time, idle time.Duration) (paddingNeeded int, frames []fecRepairFrame, ok bool) {
-	if !fecShouldFlush(now, lastAdd, idle, s.hasPartialBlock()) {
-		return 0, nil, false
-	}
-	return s.FlushPartial()
 }

--- a/pkg/router/fec_flush_test.go
+++ b/pkg/router/fec_flush_test.go
@@ -1,195 +1,59 @@
 package router
 
 import (
-	"bytes"
-	"fmt"
 	"testing"
 	"time"
 )
 
-// TestFECFlushPartialReconstruct is the core proof: a partial block of j<K real
-// frames, once flushed (padding + repair), lets the receiver reconstruct a
-// MISSING real tail frame — the tail HoL stall FlushPartial exists to remove.
-//
-// It builds the receiver EXACTLY as the wire would: the j real frames arrive via
-// RecordData (one dropped, the slow-leg victim), the K-j padding frames arrive as
-// zero-length RecordData (what the sender emits on its normal data path), and the
-// R repair frames arrive via RecordRepair. With any K of the K+R symbols present
-// the missing real frame decodes byte-identical.
-func TestFECFlushPartialReconstruct(t *testing.T) {
+// TestFECHasPartialBlock: hasPartialBlock is true exactly while a block is
+// mid-fill (1..K-1 frames), false on an empty block and false once Add completes
+// a block (Add resets filled to 0).
+func TestFECHasPartialBlock(t *testing.T) {
 	const k, r = 8, 2
-	const j = 5       // partial block: 5 real frames, seqs 0..4 (block 0)
-	const missing = 2 // a real tail frame stuck on a slow leg
-
-	st := newFECStriper(k, r, fecSymLen)
-	re := newFECReassembler(k, r, fecSymLen)
-	if st == nil || re == nil {
-		t.Fatal("nil striper/reassembler")
+	s := newFECStriper(k, r)
+	if s == nil {
+		t.Fatal("nil striper")
 	}
-
-	payloads := make([][]byte, j)
-	for seq := 0; seq < j; seq++ {
-		p := []byte(fmt.Sprintf("tail-frame-%d-%x", seq, seq*104729))
-		payloads[seq] = p
-		if rf := st.Add(uint32(seq), p); rf != nil {
-			t.Fatalf("seq %d (<K) should not complete a block, got %d repair frames", seq, len(rf))
+	if s.hasPartialBlock() {
+		t.Fatal("empty striper should have no partial block")
+	}
+	for seq := 0; seq < k-1; seq++ {
+		s.Add(uint32(seq), []byte{byte(seq)})
+		if !s.hasPartialBlock() {
+			t.Fatalf("after %d/%d frames a partial block should be pending", seq+1, k)
 		}
 	}
-
-	// Idle → flush the partial block.
-	paddingNeeded, frames, ok := st.FlushPartial()
-	if !ok {
-		t.Fatal("FlushPartial returned ok=false on a partial block")
+	// The K-th frame completes the block; Add resets → no partial block.
+	if rf := s.Add(uint32(k-1), []byte{byte(k - 1)}); len(rf) != r {
+		t.Fatalf("completing frame should emit %d repair frames, got %d", r, len(rf))
 	}
-	if paddingNeeded != k-j {
-		t.Fatalf("paddingNeeded=%d want K-j=%d", paddingNeeded, k-j)
-	}
-	if len(frames) != r {
-		t.Fatalf("got %d repair frames want R=%d", len(frames), r)
-	}
-
-	// Receiver: real frames except the missing one.
-	for seq := 0; seq < j; seq++ {
-		if seq == missing {
-			continue
-		}
-		re.RecordData(uint32(seq), payloads[seq])
-	}
-	// The K-j padding frames the sender emits as real zero-length data frames.
-	for seq := j; seq < k; seq++ {
-		re.RecordData(uint32(seq), nil)
-	}
-	// With (j-1) real + (K-j) padding = K-1 symbols, still one short → no decode.
-	if _, ok := re.Reconstruct(missing); ok {
-		t.Fatal("reconstructed with only K-1 symbols — MDS violated")
-	}
-	// One repair frame (rode a fast leg) → K symbols present → reconstruct.
-	re.RecordRepair(frames[0].blockID, frames[0].idx, frames[0].symbol)
-	got, ok := re.Reconstruct(missing)
-	if !ok {
-		t.Fatal("reconstruction of missing tail frame failed with K symbols present")
-	}
-	if !bytes.Equal(got, payloads[missing]) {
-		t.Fatalf("reconstructed tail payload mismatch:\n got=%q\nwant=%q", got, payloads[missing])
+	if s.hasPartialBlock() {
+		t.Fatal("a completed block must leave no partial block")
 	}
 }
 
-// TestFECFlushIdempotent: a second FlushPartial on the same unchanged (now
-// advanced) block returns ok=false — the reset-to-next-block IS the flushed marker.
-func TestFECFlushIdempotent(t *testing.T) {
-	const k, r = 8, 2
-	st := newFECStriper(k, r, fecSymLen)
-	for seq := 0; seq < 3; seq++ {
-		st.Add(uint32(seq), []byte{byte(seq)})
-	}
-	if _, _, ok := st.FlushPartial(); !ok {
-		t.Fatal("first FlushPartial should succeed on a partial block")
-	}
-	if pad, frames, ok := st.FlushPartial(); ok || pad != 0 || frames != nil {
-		t.Fatalf("second FlushPartial should be a no-op, got ok=%v pad=%d frames=%d", ok, pad, len(frames))
-	}
-}
+// TestFECShouldFlush: the pure idle-flush policy.
+func TestFECShouldFlush(t *testing.T) {
+	base := time.Unix(1_000_000, 0)
+	idle := 50 * time.Millisecond
 
-// TestFECFlushEmptyBlock: FlushPartial on a block with no frames is a no-op. Both
-// a fresh (never-added) striper and one sitting at a clean block boundary qualify.
-func TestFECFlushEmptyBlock(t *testing.T) {
-	const k, r = 8, 2
-
-	fresh := newFECStriper(k, r, fecSymLen)
-	if pad, frames, ok := fresh.FlushPartial(); ok || pad != 0 || frames != nil {
-		t.Fatalf("FlushPartial on empty striper should be a no-op, got ok=%v pad=%d", ok, pad)
+	cases := []struct {
+		name    string
+		now     time.Time
+		last    time.Time
+		idle    time.Duration
+		pending bool
+		want    bool
+	}{
+		{"no partial block", base.Add(time.Second), base, idle, false, false},
+		{"partial but not yet idle", base.Add(10 * time.Millisecond), base, idle, true, false},
+		{"partial and idle exactly", base.Add(idle), base, idle, true, true},
+		{"partial and long idle", base.Add(time.Second), base, idle, true, true},
+		{"idle disabled", base.Add(time.Second), base, 0, true, false},
 	}
-
-	// Fill a full block (Add emits repair, resets to a clean empty next block),
-	// then FlushPartial must still be a no-op — there is nothing partial pending.
-	full := newFECStriper(k, r, fecSymLen)
-	for seq := 0; seq < k; seq++ {
-		full.Add(uint32(seq), []byte{byte(seq)})
-	}
-	if pad, frames, ok := full.FlushPartial(); ok || pad != 0 || frames != nil {
-		t.Fatalf("FlushPartial at a clean block boundary should be a no-op, got ok=%v pad=%d", ok, pad)
-	}
-}
-
-// TestFECFlushPaddingCount: paddingNeeded == K-j across every partial fill level.
-func TestFECFlushPaddingCount(t *testing.T) {
-	const k, r = 8, 2
-	for j := 1; j < k; j++ {
-		st := newFECStriper(k, r, fecSymLen)
-		base := uint32(j * k) // start at an arbitrary non-zero block to exercise blockID math
-		for i := 0; i < j; i++ {
-			st.Add(base+uint32(i), []byte{byte(i)})
+	for _, c := range cases {
+		if got := fecShouldFlush(c.now, c.last, c.idle, c.pending); got != c.want {
+			t.Fatalf("%s: fecShouldFlush=%v want %v", c.name, got, c.want)
 		}
-		pad, frames, ok := st.FlushPartial()
-		if !ok {
-			t.Fatalf("j=%d: FlushPartial ok=false", j)
-		}
-		if pad != k-j {
-			t.Fatalf("j=%d: paddingNeeded=%d want %d", j, pad, k-j)
-		}
-		wantBlk := base / uint32(k)
-		for _, f := range frames {
-			if f.blockID != wantBlk {
-				t.Fatalf("j=%d: repair blockID=%d want %d", j, f.blockID, wantBlk)
-			}
-		}
-	}
-}
-
-// TestFECFlushFullBlockNoop: a block that reaches j==K needs no FlushPartial — Add
-// already emitted its repair, and FlushPartial afterward is a no-op.
-func TestFECFlushFullBlockNoop(t *testing.T) {
-	const k, r = 8, 2
-	st := newFECStriper(k, r, fecSymLen)
-	var repairs []fecRepairFrame
-	for seq := 0; seq < k; seq++ {
-		if rf := st.Add(uint32(seq), []byte{byte(seq)}); rf != nil {
-			repairs = rf
-		}
-	}
-	if len(repairs) != r {
-		t.Fatalf("full block should emit %d repair via Add, got %d", r, len(repairs))
-	}
-	if _, _, ok := st.FlushPartial(); ok {
-		t.Fatal("FlushPartial should be a no-op right after a full block completed")
-	}
-}
-
-// TestFECFlushPolicy exercises the pure idle-gap decision and the MaybeFlush entry
-// point with injected timestamps (no time.Now() in the logic under test).
-func TestFECFlushPolicy(t *testing.T) {
-	base := time.Unix(1_700_000_000, 0)
-	const idle = 50 * time.Millisecond
-
-	// Pure policy truth table.
-	if fecShouldFlush(base.Add(idle), base, idle, true) != true {
-		t.Fatal("exactly-idle with a pending block should flush")
-	}
-	if fecShouldFlush(base.Add(idle-time.Nanosecond), base, idle, true) != false {
-		t.Fatal("under the idle gap should not flush")
-	}
-	if fecShouldFlush(base.Add(time.Hour), base, idle, false) != false {
-		t.Fatal("no pending block should never flush")
-	}
-	if fecShouldFlush(base.Add(time.Hour), base, 0, true) != false {
-		t.Fatal("idle<=0 disables flushing")
-	}
-
-	// MaybeFlush: below the gap does nothing; at/above the gap flushes a partial.
-	st := newFECStriper(8, 2, fecSymLen)
-	lastAdd := base
-	for seq := 0; seq < 4; seq++ {
-		st.Add(uint32(seq), []byte{byte(seq)})
-	}
-	if _, _, ok := st.MaybeFlush(base.Add(idle/2), lastAdd, idle); ok {
-		t.Fatal("MaybeFlush should not fire below the idle gap")
-	}
-	pad, frames, ok := st.MaybeFlush(base.Add(idle), lastAdd, idle)
-	if !ok || pad != 4 || len(frames) != 2 {
-		t.Fatalf("MaybeFlush at idle should flush: ok=%v pad=%d frames=%d", ok, pad, len(frames))
-	}
-	// Nothing partial remains → a further MaybeFlush is a no-op.
-	if _, _, ok := st.MaybeFlush(base.Add(time.Hour), lastAdd, idle); ok {
-		t.Fatal("MaybeFlush should be a no-op once no partial block is pending")
 	}
 }

--- a/pkg/router/fec_flush_test.go
+++ b/pkg/router/fec_flush_test.go
@@ -1,0 +1,195 @@
+package router
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestFECFlushPartialReconstruct is the core proof: a partial block of j<K real
+// frames, once flushed (padding + repair), lets the receiver reconstruct a
+// MISSING real tail frame — the tail HoL stall FlushPartial exists to remove.
+//
+// It builds the receiver EXACTLY as the wire would: the j real frames arrive via
+// RecordData (one dropped, the slow-leg victim), the K-j padding frames arrive as
+// zero-length RecordData (what the sender emits on its normal data path), and the
+// R repair frames arrive via RecordRepair. With any K of the K+R symbols present
+// the missing real frame decodes byte-identical.
+func TestFECFlushPartialReconstruct(t *testing.T) {
+	const k, r = 8, 2
+	const j = 5       // partial block: 5 real frames, seqs 0..4 (block 0)
+	const missing = 2 // a real tail frame stuck on a slow leg
+
+	st := newFECStriper(k, r, fecSymLen)
+	re := newFECReassembler(k, r, fecSymLen)
+	if st == nil || re == nil {
+		t.Fatal("nil striper/reassembler")
+	}
+
+	payloads := make([][]byte, j)
+	for seq := 0; seq < j; seq++ {
+		p := []byte(fmt.Sprintf("tail-frame-%d-%x", seq, seq*104729))
+		payloads[seq] = p
+		if rf := st.Add(uint32(seq), p); rf != nil {
+			t.Fatalf("seq %d (<K) should not complete a block, got %d repair frames", seq, len(rf))
+		}
+	}
+
+	// Idle → flush the partial block.
+	paddingNeeded, frames, ok := st.FlushPartial()
+	if !ok {
+		t.Fatal("FlushPartial returned ok=false on a partial block")
+	}
+	if paddingNeeded != k-j {
+		t.Fatalf("paddingNeeded=%d want K-j=%d", paddingNeeded, k-j)
+	}
+	if len(frames) != r {
+		t.Fatalf("got %d repair frames want R=%d", len(frames), r)
+	}
+
+	// Receiver: real frames except the missing one.
+	for seq := 0; seq < j; seq++ {
+		if seq == missing {
+			continue
+		}
+		re.RecordData(uint32(seq), payloads[seq])
+	}
+	// The K-j padding frames the sender emits as real zero-length data frames.
+	for seq := j; seq < k; seq++ {
+		re.RecordData(uint32(seq), nil)
+	}
+	// With (j-1) real + (K-j) padding = K-1 symbols, still one short → no decode.
+	if _, ok := re.Reconstruct(missing); ok {
+		t.Fatal("reconstructed with only K-1 symbols — MDS violated")
+	}
+	// One repair frame (rode a fast leg) → K symbols present → reconstruct.
+	re.RecordRepair(frames[0].blockID, frames[0].idx, frames[0].symbol)
+	got, ok := re.Reconstruct(missing)
+	if !ok {
+		t.Fatal("reconstruction of missing tail frame failed with K symbols present")
+	}
+	if !bytes.Equal(got, payloads[missing]) {
+		t.Fatalf("reconstructed tail payload mismatch:\n got=%q\nwant=%q", got, payloads[missing])
+	}
+}
+
+// TestFECFlushIdempotent: a second FlushPartial on the same unchanged (now
+// advanced) block returns ok=false — the reset-to-next-block IS the flushed marker.
+func TestFECFlushIdempotent(t *testing.T) {
+	const k, r = 8, 2
+	st := newFECStriper(k, r, fecSymLen)
+	for seq := 0; seq < 3; seq++ {
+		st.Add(uint32(seq), []byte{byte(seq)})
+	}
+	if _, _, ok := st.FlushPartial(); !ok {
+		t.Fatal("first FlushPartial should succeed on a partial block")
+	}
+	if pad, frames, ok := st.FlushPartial(); ok || pad != 0 || frames != nil {
+		t.Fatalf("second FlushPartial should be a no-op, got ok=%v pad=%d frames=%d", ok, pad, len(frames))
+	}
+}
+
+// TestFECFlushEmptyBlock: FlushPartial on a block with no frames is a no-op. Both
+// a fresh (never-added) striper and one sitting at a clean block boundary qualify.
+func TestFECFlushEmptyBlock(t *testing.T) {
+	const k, r = 8, 2
+
+	fresh := newFECStriper(k, r, fecSymLen)
+	if pad, frames, ok := fresh.FlushPartial(); ok || pad != 0 || frames != nil {
+		t.Fatalf("FlushPartial on empty striper should be a no-op, got ok=%v pad=%d", ok, pad)
+	}
+
+	// Fill a full block (Add emits repair, resets to a clean empty next block),
+	// then FlushPartial must still be a no-op — there is nothing partial pending.
+	full := newFECStriper(k, r, fecSymLen)
+	for seq := 0; seq < k; seq++ {
+		full.Add(uint32(seq), []byte{byte(seq)})
+	}
+	if pad, frames, ok := full.FlushPartial(); ok || pad != 0 || frames != nil {
+		t.Fatalf("FlushPartial at a clean block boundary should be a no-op, got ok=%v pad=%d", ok, pad)
+	}
+}
+
+// TestFECFlushPaddingCount: paddingNeeded == K-j across every partial fill level.
+func TestFECFlushPaddingCount(t *testing.T) {
+	const k, r = 8, 2
+	for j := 1; j < k; j++ {
+		st := newFECStriper(k, r, fecSymLen)
+		base := uint32(j * k) // start at an arbitrary non-zero block to exercise blockID math
+		for i := 0; i < j; i++ {
+			st.Add(base+uint32(i), []byte{byte(i)})
+		}
+		pad, frames, ok := st.FlushPartial()
+		if !ok {
+			t.Fatalf("j=%d: FlushPartial ok=false", j)
+		}
+		if pad != k-j {
+			t.Fatalf("j=%d: paddingNeeded=%d want %d", j, pad, k-j)
+		}
+		wantBlk := base / uint32(k)
+		for _, f := range frames {
+			if f.blockID != wantBlk {
+				t.Fatalf("j=%d: repair blockID=%d want %d", j, f.blockID, wantBlk)
+			}
+		}
+	}
+}
+
+// TestFECFlushFullBlockNoop: a block that reaches j==K needs no FlushPartial — Add
+// already emitted its repair, and FlushPartial afterward is a no-op.
+func TestFECFlushFullBlockNoop(t *testing.T) {
+	const k, r = 8, 2
+	st := newFECStriper(k, r, fecSymLen)
+	var repairs []fecRepairFrame
+	for seq := 0; seq < k; seq++ {
+		if rf := st.Add(uint32(seq), []byte{byte(seq)}); rf != nil {
+			repairs = rf
+		}
+	}
+	if len(repairs) != r {
+		t.Fatalf("full block should emit %d repair via Add, got %d", r, len(repairs))
+	}
+	if _, _, ok := st.FlushPartial(); ok {
+		t.Fatal("FlushPartial should be a no-op right after a full block completed")
+	}
+}
+
+// TestFECFlushPolicy exercises the pure idle-gap decision and the MaybeFlush entry
+// point with injected timestamps (no time.Now() in the logic under test).
+func TestFECFlushPolicy(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	const idle = 50 * time.Millisecond
+
+	// Pure policy truth table.
+	if fecShouldFlush(base.Add(idle), base, idle, true) != true {
+		t.Fatal("exactly-idle with a pending block should flush")
+	}
+	if fecShouldFlush(base.Add(idle-time.Nanosecond), base, idle, true) != false {
+		t.Fatal("under the idle gap should not flush")
+	}
+	if fecShouldFlush(base.Add(time.Hour), base, idle, false) != false {
+		t.Fatal("no pending block should never flush")
+	}
+	if fecShouldFlush(base.Add(time.Hour), base, 0, true) != false {
+		t.Fatal("idle<=0 disables flushing")
+	}
+
+	// MaybeFlush: below the gap does nothing; at/above the gap flushes a partial.
+	st := newFECStriper(8, 2, fecSymLen)
+	lastAdd := base
+	for seq := 0; seq < 4; seq++ {
+		st.Add(uint32(seq), []byte{byte(seq)})
+	}
+	if _, _, ok := st.MaybeFlush(base.Add(idle/2), lastAdd, idle); ok {
+		t.Fatal("MaybeFlush should not fire below the idle gap")
+	}
+	pad, frames, ok := st.MaybeFlush(base.Add(idle), lastAdd, idle)
+	if !ok || pad != 4 || len(frames) != 2 {
+		t.Fatalf("MaybeFlush at idle should flush: ok=%v pad=%d frames=%d", ok, pad, len(frames))
+	}
+	// Nothing partial remains → a further MaybeFlush is a no-op.
+	if _, _, ok := st.MaybeFlush(base.Add(time.Hour), lastAdd, idle); ok {
+		t.Fatal("MaybeFlush should be a no-op once no partial block is pending")
+	}
+}

--- a/pkg/router/fec_mux.go
+++ b/pkg/router/fec_mux.go
@@ -11,19 +11,32 @@
 // receiver RECONSTRUCTS the missing frame and the frontier advances at the fast
 // leg's rate instead of the slow one.
 //
-// Layering: FEC operates in the PLAINTEXT domain. On send the striper is fed the
-// mux payload BEFORE per-frame seal (route_mux.wrapPayload); on receive the
-// reassembler is fed the plaintext AFTER open (route_mux.deliverData), and a
-// reconstructed symbol is injected as plaintext (it never passes back through
-// open — it is already plaintext). This file is transport-agnostic and driven
-// entirely by (seq, plaintext) and (blockID, idx, symbol) tuples, so it is
-// exhaustively unit-testable without the live mesh (see fec_mux_test.go).
+// Layering: FEC operates in the WIRE (post-seal) domain. On send the striper is
+// fed the on-wire frame payload AFTER per-frame seal (route_mux.wrapPayload); on
+// receive the reassembler is fed the on-wire payload BEFORE open
+// (route_mux.deliverData), and a reconstructed on-wire frame is passed through
+// the normal open() path before entering the reorder buffer. Because repair
+// symbols are linear combinations of already-sealed frames they reveal nothing
+// beyond the ciphertext, so no separate repair-frame nonce is needed and the code
+// works uniformly whether per-frame noise is on or off. This file is
+// transport-agnostic and driven entirely by (seq, wireBytes) and
+// (blockID, idx, symbol) tuples, so it is exhaustively unit-testable without the
+// live mesh (see fec_mux_test.go).
 package router
 
 import (
 	"encoding/binary"
+	"os"
 	"sync"
 )
+
+// fecWanted reports whether this visor advertises CapFEC in the mux handshake.
+// FEC is opt-in during rollout: it needs BOTH peers on a build that enables it,
+// plus live two-node validation, before it can safely become a default. Until
+// then the whole FEC path is inert (CapFEC unadvertised → never negotiated →
+// fecEnabled stays false → wrapPayload/deliverData fast-return). Gate: set
+// SKYWIRE_MUX_FEC=1 on both endpoints.
+var fecWanted = os.Getenv("SKYWIRE_MUX_FEC") == "1"
 
 // FEC block geometry. K data frames + R repair frames per block; recovers all K
 // from any K of the K+R. K=8/R=2 tolerates a full slow/dead leg's share of a
@@ -329,4 +342,108 @@ func (f *fecReassembler) Reconstruct(seq uint32) ([]byte, bool) {
 		}
 	}
 	return desymbolize(data[idx]), true
+}
+
+// --- routeMux integration (see route_mux.go fec* fields) ---
+
+// fecInit constructs the striper + reassembler with the default block geometry.
+// Called once at handshake when CapFEC is negotiated. On bad dims it disables
+// FEC rather than leaving half-built state.
+func (m *routeMux) fecInit() {
+	m.fecStriper = newFECStriper(fecDefaultK, fecDefaultR, fecSymLen)
+	m.fecReassembler = newFECReassembler(fecDefaultK, fecDefaultR, fecSymLen)
+	if m.fecStriper == nil || m.fecReassembler == nil {
+		m.fecStriper = nil
+		m.fecReassembler = nil
+		m.fecEnabled = false
+	}
+}
+
+// fecOnSend feeds one on-wire (post-seal) data-frame payload to the striper and
+// queues any repair frames the completed block produced. Called from wrapPayload.
+func (m *routeMux) fecOnSend(seq uint32, wire []byte) {
+	if !m.fecEnabled || m.fecStriper == nil {
+		return
+	}
+	frames := m.fecStriper.Add(seq, wire)
+	if len(frames) == 0 {
+		return
+	}
+	m.fecRepairMu.Lock()
+	m.fecRepairQ = append(m.fecRepairQ, frames...)
+	m.fecRepairMu.Unlock()
+}
+
+// fecDrainRepairs returns and clears the queued repair frames for the send loop.
+func (m *routeMux) fecDrainRepairs() []fecRepairFrame {
+	if !m.fecEnabled {
+		return nil
+	}
+	m.fecRepairMu.Lock()
+	q := m.fecRepairQ
+	m.fecRepairQ = nil
+	m.fecRepairMu.Unlock()
+	return q
+}
+
+// fecOnRecvData records an on-wire (pre-open) data-frame payload into the
+// reassembler so a sibling in its block can be reconstructed later. Called from
+// deliverData BEFORE open.
+func (m *routeMux) fecOnRecvData(seq uint32, wire []byte) {
+	if !m.fecEnabled || m.fecReassembler == nil {
+		return
+	}
+	m.fecReassembler.RecordData(seq, wire)
+}
+
+// fecOnRecvRepair records a repair symbol and returns any plaintext frames the
+// reorder frontier can now deliver in order (reconstructed + opened). Called from
+// the RepairPacket handler.
+func (m *routeMux) fecOnRecvRepair(blockID uint32, idx uint8, symbol []byte) [][]byte {
+	if !m.fecEnabled || m.fecReassembler == nil {
+		return nil
+	}
+	m.fecReassembler.RecordRepair(blockID, idx, symbol)
+	return m.fecTryAdvance()
+}
+
+// fecTryAdvance reconstructs consecutive gap-blocked frontier frames from the
+// reassembler and inserts them (after open) so the reorder frontier advances
+// without waiting for the slow leg. Returns the plaintext frames newly delivered
+// in order, to be handed to the app exactly like deliverData's return. A
+// reconstructed frame that fails to open is not delivered (a real frame or a
+// retransmit will fill the gap). Double-reconstruction across concurrent callers
+// is harmless: Insert of an already-delivered seq is a discarded no-op.
+func (m *routeMux) fecTryAdvance() [][]byte {
+	if !m.fecEnabled || m.fecReassembler == nil || m.reorderBuf == nil {
+		return nil
+	}
+	var out [][]byte
+	for {
+		next := m.reorderBuf.NextSeq()
+		wire, ok := m.fecReassembler.Reconstruct(next)
+		if !ok {
+			break
+		}
+		data := wire
+		if m.open != nil {
+			pt, err := m.open(next, wire)
+			if err != nil {
+				if m.logger != nil {
+					m.logger.WithError(err).Tracef("FEC-reconstructed seq %d failed open; not delivering", next)
+				}
+				break
+			}
+			data = pt
+		}
+		delivered := m.reorderBuf.Insert(next, data)
+		if len(delivered) == 0 {
+			break
+		}
+		out = append(out, delivered...)
+		if m.sackEnabled && m.sackTracker != nil {
+			m.sackTracker.AdvanceContiguous(m.reorderBuf.NextSeq())
+		}
+	}
+	return out
 }

--- a/pkg/router/fec_mux.go
+++ b/pkg/router/fec_mux.go
@@ -58,14 +58,14 @@ type fecRepairFrame struct {
 	symbol  []byte // exactly symLen bytes
 }
 
-// symbolize length-prefixes and zero-pads a plaintext payload to fecSymLen.
+// symbolize length-prefixes and zero-pads a frame to symLen.
 // Returns (symbol, true); (nil, false) if the payload is too large to code.
 func symbolize(payload []byte, symLen int) ([]byte, bool) {
 	if len(payload) > symLen-fecLenPrefix {
 		return nil, false
 	}
 	sym := make([]byte, symLen)
-	binary.BigEndian.PutUint16(sym, uint16(len(payload)))
+	binary.BigEndian.PutUint16(sym, uint16(len(payload))) //nolint:gosec
 	copy(sym[fecLenPrefix:], payload)
 	return sym, true
 }
@@ -118,8 +118,8 @@ func (s *fecStriper) Add(seq uint32, frame []byte) []fecRepairFrame {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	blk := seq / uint32(s.k)
-	idx := int(seq % uint32(s.k))
+	blk := seq / uint32(s.k)      //nolint:gosec
+	idx := int(seq % uint32(s.k)) //nolint:gosec
 
 	if !s.inited {
 		s.block = blk
@@ -268,8 +268,8 @@ func (f *fecReassembler) evict() {
 // symbolized to the block's adaptive symLen only at decode time, so the receiver
 // need not know symLen until a repair frame arrives.
 func (f *fecReassembler) RecordData(seq uint32, frame []byte) {
-	blk := seq / uint32(f.k)
-	idx := int(seq % uint32(f.k))
+	blk := seq / uint32(f.k)      //nolint:gosec
+	idx := int(seq % uint32(f.k)) //nolint:gosec
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	bs := f.blockFor(blk)
@@ -308,8 +308,8 @@ func (f *fecReassembler) RecordRepair(blk uint32, idx uint8, symLen int, symbol 
 // state (symbolizes/decodes from COPIES), so each missing frontier frame in a
 // multi-erasure block reconstructs correctly and independently.
 func (f *fecReassembler) Reconstruct(seq uint32) ([]byte, bool) {
-	blk := seq / uint32(f.k)
-	idx := int(seq % uint32(f.k))
+	blk := seq / uint32(f.k)      //nolint:gosec
+	idx := int(seq % uint32(f.k)) //nolint:gosec
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	bs := f.blocks[blk]

--- a/pkg/router/fec_mux.go
+++ b/pkg/router/fec_mux.go
@@ -382,6 +382,14 @@ func (m *routeMux) fecOnSend(seq uint32, wire []byte) {
 	if !m.fecEnabled || m.fecStriper == nil {
 		return
 	}
+	// FEC only helps a MULTI-leg group — repair rescues a straggler striped onto a
+	// slow leg. On a single active leg there is no head-of-line wall to remove, so
+	// coding would be pure ~R/K bandwidth overhead for zero benefit (the common
+	// mux=1 proxy). Skip it; when a second leg is added mid-stream the striper
+	// resumes on the next frame and self-realigns on the block boundary.
+	if m.activeLegCount() < 2 {
+		return
+	}
 	frames := m.fecStriper.Add(seq, wire)
 	if len(frames) == 0 {
 		return

--- a/pkg/router/fec_mux.go
+++ b/pkg/router/fec_mux.go
@@ -34,23 +34,28 @@ import (
 // 4–8 leg group (~1 frame in 8 striped onto it) at a 25% repair overhead. These
 // are the defaults; the negotiated values could later be carried in the handshake.
 const (
-	fecDefaultK = 8
-	fecDefaultR = 2
-	// fecSymLen is the fixed erasure-symbol size. Every data payload is
-	// length-prefixed and zero-padded to this; a payload larger than
-	// fecSymLen-fecLenPrefix cannot be coded and is passed through un-FEC'd
-	// (rare — mux frames are MTU-bounded well under this). 16 KiB covers the
-	// largest mux frame with headroom.
-	fecSymLen    = 16 * 1024
-	fecLenPrefix = 2 // uint16 BE plaintext length inside each symbol
+	fecDefaultK  = 8
+	fecDefaultR  = 2
+	fecLenPrefix = 2 // uint16 BE frame length inside each symbol
+	// fecMaxSymLen caps a block's ADAPTIVE symbol length. A routing DataPacket
+	// payload is at most ~64 KiB, so this covers any on-wire mux frame; a frame
+	// that somehow exceeded it is excluded from coding (stored empty) rather than
+	// silently corrupting the block. Symbol length is NOT fixed: each block sizes
+	// its symbols to max(frame len)+fecLenPrefix, so repair overhead stays at the
+	// design R/K ratio for any frame size — a fixed pad would bloat small-frame
+	// repair and, worse, corrupt frames larger than the pad (they would code as a
+	// zero symbol and reconstruct to an empty frame).
+	fecMaxSymLen = 65535
 )
 
 // fecRepairFrame is one repair symbol ready to be scheduled onto a leg. blockID
-// and idx let the receiver place it into the right block slot (K+idx).
+// and idx place it in the block slot (K+idx); symLen is the block's adaptive
+// symbol length, which the receiver needs to size the block for decoding.
 type fecRepairFrame struct {
 	blockID uint32
 	idx     uint8
-	symbol  []byte // exactly fecSymLen bytes
+	symLen  int
+	symbol  []byte // exactly symLen bytes
 }
 
 // symbolize length-prefixes and zero-pads a plaintext payload to fecSymLen.
@@ -87,40 +92,29 @@ func desymbolize(sym []byte) []byte {
 // the seqs it is fed are contiguous and monotonic (as writeSeq produces); block
 // B owns seqs [B*K, B*K+K-1] with in-block index seq%K. Safe for concurrent Add.
 type fecStriper struct {
-	mu      sync.Mutex
-	coder   *fecBlockCoder
-	k, r    int
-	symLen  int
-	symbols [][]byte // K slots for the block currently filling
-	block   uint32   // blockID currently filling
-	filled  int      // count of non-nil slots in the current block
-	inited  bool
+	mu     sync.Mutex
+	k, r   int
+	frames [][]byte // K slots of RAW frame bytes (copied); nil = empty
+	maxLen int      // longest raw frame in the block currently filling
+	block  uint32   // blockID currently filling
+	filled int      // count of non-nil slots in the current block
+	inited bool
 }
 
-func newFECStriper(k, r, symLen int) *fecStriper {
-	coder := newFECBlockCoder(k, r, symLen)
-	if coder == nil {
+func newFECStriper(k, r int) *fecStriper {
+	if newFECBlockCoder(k, r, 1) == nil { // validate dims (symLen picked per block)
 		return nil
 	}
-	return &fecStriper{
-		coder:   coder,
-		k:       k,
-		r:       r,
-		symLen:  symLen,
-		symbols: make([][]byte, k),
-	}
+	return &fecStriper{k: k, r: r, frames: make([][]byte, k)}
 }
 
-// Add feeds one data frame's plaintext (identified by its mux seq). When the
-// frame completes a block it returns that block's R repair frames to schedule;
-// otherwise it returns nil. A payload too large to symbolize is skipped for
-// coding (the block will simply be short a data symbol; if the frame later needs
-// reconstruction it cannot be — an accepted, rare degradation) — but to keep the
-// MDS invariant we instead treat an un-codable frame as a zero symbol carrying a
-// length prefix of 0 so the block still encodes; the receiver never needs to
-// reconstruct a frame it actually received, and an un-received over-long frame
-// is beyond FEC anyway.
-func (s *fecStriper) Add(seq uint32, plaintext []byte) []fecRepairFrame {
+// Add feeds one on-wire data frame (identified by its mux seq). When the frame
+// completes a block it sizes the block's erasure symbols to the LONGEST frame in
+// the block (+ length prefix), encodes, and returns the R repair frames to
+// schedule; otherwise nil. Frames are stored raw and symbolized only at block
+// completion so the symbol length is exactly what the block needs — never a fixed
+// pad. A frame beyond fecMaxSymLen (never happens on the wire) is stored empty.
+func (s *fecStriper) Add(seq uint32, frame []byte) []fecRepairFrame {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -132,33 +126,43 @@ func (s *fecStriper) Add(seq uint32, plaintext []byte) []fecRepairFrame {
 		s.inited = true
 	}
 	// A seq jump (should not happen with contiguous writeSeq) resets to the new
-	// block to avoid mixing symbols across blocks.
+	// block to avoid mixing frames across blocks.
 	if blk != s.block {
 		s.reset(blk)
 	}
 
-	sym, ok := symbolize(plaintext, s.symLen)
-	if !ok {
-		// Over-long: stand in a zero-length symbol so the block still codes.
-		sym, _ = symbolize(nil, s.symLen)
+	if len(frame) > fecMaxSymLen-fecLenPrefix {
+		frame = nil // defensive: un-codable, stand in an empty frame
 	}
-	if s.symbols[idx] == nil {
+	cp := make([]byte, len(frame))
+	copy(cp, frame)
+	if s.frames[idx] == nil {
 		s.filled++
 	}
-	s.symbols[idx] = sym
+	s.frames[idx] = cp
+	if len(cp) > s.maxLen {
+		s.maxLen = len(cp)
+	}
 
 	if s.filled < s.k {
 		return nil
 	}
-	// Block complete → encode R repair symbols.
-	repair, err := s.coder.Encode(s.symbols)
+	// Block complete → adaptive symbol length = longest frame + prefix.
+	symLen := s.maxLen + fecLenPrefix
+	syms := make([][]byte, s.k)
+	for i, f := range s.frames {
+		sym, _ := symbolize(f, symLen) // fits: len(f) <= maxLen == symLen-prefix
+		syms[i] = sym
+	}
+	coder := newFECBlockCoder(s.k, s.r, symLen)
+	repair, err := coder.Encode(syms)
 	if err != nil {
 		s.reset(blk + 1)
 		return nil
 	}
 	frames := make([]fecRepairFrame, s.r)
 	for i := 0; i < s.r; i++ {
-		frames[i] = fecRepairFrame{blockID: blk, idx: uint8(i), symbol: repair[i]}
+		frames[i] = fecRepairFrame{blockID: blk, idx: uint8(i), symLen: symLen, symbol: repair[i]}
 	}
 	s.reset(blk + 1)
 	return frames
@@ -166,54 +170,54 @@ func (s *fecStriper) Add(seq uint32, plaintext []byte) []fecRepairFrame {
 
 // reset clears the fill state for the next block. Caller holds s.mu.
 func (s *fecStriper) reset(nextBlock uint32) {
-	for i := range s.symbols {
-		s.symbols[i] = nil
+	for i := range s.frames {
+		s.frames[i] = nil
 	}
 	s.filled = 0
+	s.maxLen = 0
 	s.block = nextBlock
 }
 
 // --- receiver: fecReassembler ---
 
-// fecBlockState holds the symbols received for one block until it is fully
-// delivered or evicted. slots[0..K-1] are data symbols, slots[K..K+R-1] repair.
+// fecBlockState holds the RAW frames + repair symbols received for one block
+// until it is fully delivered or evicted. Data frames are stored at their natural
+// size and symbolized to the block's adaptive symLen only at decode time; symLen
+// is learned from the first repair frame (all repairs for a block carry it).
 type fecBlockState struct {
-	slots   [][]byte // len K+R; nil = not yet arrived
-	present []bool   // len K+R
-	got     int      // count of present slots
-	dataGot int      // count of present DATA slots (0..K-1)
+	rawData       [][]byte // K slots of raw received frame bytes; nil = absent
+	repair        [][]byte // R slots of repair symbols (symLen bytes); nil = absent
+	dataPresent   []bool   // K
+	repairPresent []bool   // R
+	got           int      // count of present data + present repair slots
+	symLen        int      // block's adaptive symbol length (0 until a repair arrives)
 }
 
-// fecReassembler retains recently-received symbols per block so that when the
+// fecReassembler retains recently-received frames per block so that when the
 // reorder frontier stalls on a missing seq it can reconstruct it from ≥K of the
 // block's K+R symbols. It keeps a bounded window of blocks (fecWindowBlocks);
 // blocks older than the window are evicted (their data was either delivered or
 // is permanently lost, past FEC's help). Safe for concurrent use.
 type fecReassembler struct {
 	mu     sync.Mutex
-	coder  *fecBlockCoder
 	k, r   int
-	symLen int
 	blocks map[uint32]*fecBlockState
 	// lowBlock is the oldest block still retained; blocks below it are evicted.
 	lowBlock uint32
 	haveLow  bool
 }
 
-// fecWindowBlocks bounds retained blocks (memory = window*(K+R)*symLen). 64
-// blocks * 10 * 16KiB ≈ 10 MiB worst case — ample for reorder depths in practice.
+// fecWindowBlocks bounds retained blocks. 64 blocks * (K+R) * up-to-64KiB is the
+// worst case — ample for reorder depths in practice.
 const fecWindowBlocks = 64
 
-func newFECReassembler(k, r, symLen int) *fecReassembler {
-	coder := newFECBlockCoder(k, r, symLen)
-	if coder == nil {
+func newFECReassembler(k, r int) *fecReassembler {
+	if newFECBlockCoder(k, r, 1) == nil { // validate dims (symLen picked per block)
 		return nil
 	}
 	return &fecReassembler{
-		coder:  coder,
 		k:      k,
 		r:      r,
-		symLen: symLen,
 		blocks: make(map[uint32]*fecBlockState),
 	}
 }
@@ -222,8 +226,10 @@ func (f *fecReassembler) blockFor(blk uint32) *fecBlockState {
 	bs := f.blocks[blk]
 	if bs == nil {
 		bs = &fecBlockState{
-			slots:   make([][]byte, f.k+f.r),
-			present: make([]bool, f.k+f.r),
+			rawData:       make([][]byte, f.k),
+			repair:        make([][]byte, f.r),
+			dataPresent:   make([]bool, f.k),
+			repairPresent: make([]bool, f.r),
 		}
 		f.blocks[blk] = bs
 		if !f.haveLow || blk < f.lowBlock {
@@ -258,88 +264,100 @@ func (f *fecReassembler) evict() {
 	}
 }
 
-// RecordData notes a received data frame's plaintext at its seq. It stores a
-// symbolized copy so the block can be decoded later if a sibling is missing.
-func (f *fecReassembler) RecordData(seq uint32, plaintext []byte) {
-	sym, ok := symbolize(plaintext, f.symLen)
-	if !ok {
-		sym, _ = symbolize(nil, f.symLen)
-	}
+// RecordData stores a received data frame's raw bytes at its seq (copied). It is
+// symbolized to the block's adaptive symLen only at decode time, so the receiver
+// need not know symLen until a repair frame arrives.
+func (f *fecReassembler) RecordData(seq uint32, frame []byte) {
 	blk := seq / uint32(f.k)
 	idx := int(seq % uint32(f.k))
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	bs := f.blockFor(blk)
-	if !bs.present[idx] {
-		bs.present[idx] = true
+	if !bs.dataPresent[idx] {
+		bs.dataPresent[idx] = true
 		bs.got++
-		bs.dataGot++
-		bs.slots[idx] = sym
+		cp := make([]byte, len(frame))
+		copy(cp, frame)
+		bs.rawData[idx] = cp
 	}
 }
 
-// RecordRepair notes a received repair symbol for a block.
-func (f *fecReassembler) RecordRepair(blk uint32, idx uint8, symbol []byte) {
-	if int(idx) >= f.r || len(symbol) != f.symLen {
+// RecordRepair notes a received repair symbol (and the block's adaptive symLen,
+// which every repair for the block carries) for later reconstruction.
+func (f *fecReassembler) RecordRepair(blk uint32, idx uint8, symLen int, symbol []byte) {
+	if int(idx) >= f.r || symLen <= fecLenPrefix || len(symbol) != symLen {
 		return
 	}
-	slot := f.k + int(idx)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	bs := f.blockFor(blk)
-	if !bs.present[slot] {
-		bs.present[slot] = true
+	bs.symLen = symLen
+	if !bs.repairPresent[idx] {
+		bs.repairPresent[idx] = true
 		bs.got++
-		cp := make([]byte, f.symLen)
+		cp := make([]byte, symLen)
 		copy(cp, symbol)
-		bs.slots[slot] = cp
+		bs.repair[idx] = cp
 	}
 }
 
-// Reconstruct attempts to recover the plaintext for a missing seq. It succeeds
-// only when the seq's block already holds ≥K of its K+R symbols AND the seq's
-// own data slot is not already present. Returns (plaintext, true) on success.
-// It is idempotent and side-effect-free on the block state (decodes from COPIES
-// of the received symbols), so each missing frontier frame in a multi-erasure
-// block reconstructs correctly and independently.
+// Reconstruct attempts to recover the on-wire bytes for a missing seq. It
+// succeeds only when the seq's block holds ≥K of its K+R symbols, a repair has
+// set the block's symLen, and the seq's own data slot is absent. Returns
+// (frame, true) on success. It is idempotent and side-effect-free on the block
+// state (symbolizes/decodes from COPIES), so each missing frontier frame in a
+// multi-erasure block reconstructs correctly and independently.
 func (f *fecReassembler) Reconstruct(seq uint32) ([]byte, bool) {
 	blk := seq / uint32(f.k)
 	idx := int(seq % uint32(f.k))
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	bs := f.blocks[blk]
-	if bs == nil || bs.got < f.k || bs.present[idx] {
+	if bs == nil || bs.symLen == 0 || bs.got < f.k || bs.dataPresent[idx] {
 		return nil, false
 	}
-	// Build recv/present of exactly K+R slots for the coder. IMPORTANT: pass
-	// COPIES of the stored symbols, never bs.slots[i] directly — Decode/gfSolve
-	// solves in place and MUTATES the rhs symbol vectors, which would corrupt the
-	// block's retained received symbols and make a subsequent sibling
-	// reconstruction in the same block decode from garbage (the multi-erasure
-	// corruption the end-to-end test exposed). Copying keeps bs.slots pristine so
-	// each missing frontier frame decodes correctly and independently.
+	symLen := bs.symLen
+	// Build recv/present of exactly K+R symLen-sized symbols. Data frames are
+	// symbolized (length-prefixed + padded) to symLen here; repair symbols are
+	// copied. COPIES are essential: Decode/gfSolve solves in place and MUTATES the
+	// rhs vectors, which would corrupt the block's retained symbols and make a
+	// subsequent sibling reconstruction decode from garbage (the multi-erasure
+	// corruption the end-to-end test exposed).
 	recv := make([][]byte, f.k+f.r)
-	for i := 0; i < f.k+f.r; i++ {
-		if bs.present[i] {
-			cp := make([]byte, f.symLen)
-			copy(cp, bs.slots[i])
-			recv[i] = cp
+	present := make([]bool, f.k+f.r)
+	for i := 0; i < f.k; i++ {
+		if bs.dataPresent[i] {
+			sym, ok := symbolize(bs.rawData[i], symLen)
+			if !ok { // a stored frame longer than this block's symLen: inconsistent
+				return nil, false
+			}
+			recv[i] = sym
+			present[i] = true
 		} else {
-			recv[i] = make([]byte, f.symLen) // ignored (present=false)
+			recv[i] = make([]byte, symLen)
 		}
 	}
-	data, err := f.coder.Decode(recv, bs.present)
+	for i := 0; i < f.r; i++ {
+		if bs.repairPresent[i] {
+			cp := make([]byte, symLen)
+			copy(cp, bs.repair[i])
+			recv[f.k+i] = cp
+			present[f.k+i] = true
+		} else {
+			recv[f.k+i] = make([]byte, symLen)
+		}
+	}
+	coder := newFECBlockCoder(f.k, f.r, symLen)
+	if coder == nil {
+		return nil, false
+	}
+	data, err := coder.Decode(recv, present)
 	if err != nil {
 		return nil, false
 	}
-	// Deliberately DO NOT cache the reconstructed data slots back as "present".
-	// Caching would let a sibling gap in the same block decode for free, but it
-	// would also make a later Reconstruct(sibling) short-circuit on present[idx]
-	// and return false WITHOUT the sibling ever being inserted into the reorder
-	// buffer — the frontier would then stall on it forever (the multi-erasure
-	// bug). Decoding is idempotent and cheap for these block sizes, and the
-	// received data+repair symbols remain >= K, so each missing frontier frame is
-	// decoded independently and RETURNED to the caller for insertion.
+	// Do NOT cache decoded siblings back as present — that would strand an
+	// uncached sibling (a later Reconstruct short-circuits on present) and leave
+	// the frontier stalled. Each missing frontier frame decodes independently.
 	return desymbolize(data[idx]), true
 }
 
@@ -349,8 +367,8 @@ func (f *fecReassembler) Reconstruct(seq uint32) ([]byte, bool) {
 // Called once at handshake when CapFEC is negotiated. On bad dims it disables
 // FEC rather than leaving half-built state.
 func (m *routeMux) fecInit() {
-	m.fecStriper = newFECStriper(fecDefaultK, fecDefaultR, fecSymLen)
-	m.fecReassembler = newFECReassembler(fecDefaultK, fecDefaultR, fecSymLen)
+	m.fecStriper = newFECStriper(fecDefaultK, fecDefaultR)
+	m.fecReassembler = newFECReassembler(fecDefaultK, fecDefaultR)
 	if m.fecStriper == nil || m.fecReassembler == nil {
 		m.fecStriper = nil
 		m.fecReassembler = nil
@@ -398,11 +416,11 @@ func (m *routeMux) fecOnRecvData(seq uint32, wire []byte) {
 // fecOnRecvRepair records a repair symbol and returns any plaintext frames the
 // reorder frontier can now deliver in order (reconstructed + opened). Called from
 // the RepairPacket handler.
-func (m *routeMux) fecOnRecvRepair(blockID uint32, idx uint8, symbol []byte) [][]byte {
+func (m *routeMux) fecOnRecvRepair(blockID uint32, idx uint8, symLen int, symbol []byte) [][]byte {
 	if !m.fecEnabled || m.fecReassembler == nil {
 		return nil
 	}
-	m.fecReassembler.RecordRepair(blockID, idx, symbol)
+	m.fecReassembler.RecordRepair(blockID, idx, symLen, symbol)
 	return m.fecTryAdvance()
 }
 

--- a/pkg/router/fec_mux.go
+++ b/pkg/router/fec_mux.go
@@ -1,0 +1,332 @@
+// Package router pkg/router/fec_mux.go — wiring the systematic Cauchy-RS erasure
+// core (fec.go, #4270) into the packet-mux striping / reorder data plane.
+//
+// The aggregation wall is head-of-line blocking: the no-skip reorder frontier
+// (reorder.go) cannot advance past a sequence number striped onto a slow leg,
+// so one ordered stream over heterogeneous-RTT legs is capped at the SLOW leg's
+// rate — retransmit recovery is likewise bound to that leg's RTT. Erasure coding
+// removes the wait: the sender groups K consecutive data frames into a block and
+// emits R repair frames; if a data frame is late/lost on a slow leg but ANY K of
+// the block's K+R symbols have arrived (repair frames ride the FAST legs), the
+// receiver RECONSTRUCTS the missing frame and the frontier advances at the fast
+// leg's rate instead of the slow one.
+//
+// Layering: FEC operates in the PLAINTEXT domain. On send the striper is fed the
+// mux payload BEFORE per-frame seal (route_mux.wrapPayload); on receive the
+// reassembler is fed the plaintext AFTER open (route_mux.deliverData), and a
+// reconstructed symbol is injected as plaintext (it never passes back through
+// open — it is already plaintext). This file is transport-agnostic and driven
+// entirely by (seq, plaintext) and (blockID, idx, symbol) tuples, so it is
+// exhaustively unit-testable without the live mesh (see fec_mux_test.go).
+package router
+
+import (
+	"encoding/binary"
+	"sync"
+)
+
+// FEC block geometry. K data frames + R repair frames per block; recovers all K
+// from any K of the K+R. K=8/R=2 tolerates a full slow/dead leg's share of a
+// 4–8 leg group (~1 frame in 8 striped onto it) at a 25% repair overhead. These
+// are the defaults; the negotiated values could later be carried in the handshake.
+const (
+	fecDefaultK = 8
+	fecDefaultR = 2
+	// fecSymLen is the fixed erasure-symbol size. Every data payload is
+	// length-prefixed and zero-padded to this; a payload larger than
+	// fecSymLen-fecLenPrefix cannot be coded and is passed through un-FEC'd
+	// (rare — mux frames are MTU-bounded well under this). 16 KiB covers the
+	// largest mux frame with headroom.
+	fecSymLen    = 16 * 1024
+	fecLenPrefix = 2 // uint16 BE plaintext length inside each symbol
+)
+
+// fecRepairFrame is one repair symbol ready to be scheduled onto a leg. blockID
+// and idx let the receiver place it into the right block slot (K+idx).
+type fecRepairFrame struct {
+	blockID uint32
+	idx     uint8
+	symbol  []byte // exactly fecSymLen bytes
+}
+
+// symbolize length-prefixes and zero-pads a plaintext payload to fecSymLen.
+// Returns (symbol, true); (nil, false) if the payload is too large to code.
+func symbolize(payload []byte, symLen int) ([]byte, bool) {
+	if len(payload) > symLen-fecLenPrefix {
+		return nil, false
+	}
+	sym := make([]byte, symLen)
+	binary.BigEndian.PutUint16(sym, uint16(len(payload)))
+	copy(sym[fecLenPrefix:], payload)
+	return sym, true
+}
+
+// desymbolize recovers the original plaintext from a decoded symbol by reading
+// its length prefix. Returns nil on a corrupt/over-long prefix.
+func desymbolize(sym []byte) []byte {
+	if len(sym) < fecLenPrefix {
+		return nil
+	}
+	n := int(binary.BigEndian.Uint16(sym))
+	if n > len(sym)-fecLenPrefix {
+		return nil
+	}
+	out := make([]byte, n)
+	copy(out, sym[fecLenPrefix:fecLenPrefix+n])
+	return out
+}
+
+// --- sender: fecStriper ---
+
+// fecStriper accumulates K consecutive data-frame plaintexts (keyed by their mux
+// seq) into a block and, on block completion, emits R repair frames. It assumes
+// the seqs it is fed are contiguous and monotonic (as writeSeq produces); block
+// B owns seqs [B*K, B*K+K-1] with in-block index seq%K. Safe for concurrent Add.
+type fecStriper struct {
+	mu      sync.Mutex
+	coder   *fecBlockCoder
+	k, r    int
+	symLen  int
+	symbols [][]byte // K slots for the block currently filling
+	block   uint32   // blockID currently filling
+	filled  int      // count of non-nil slots in the current block
+	inited  bool
+}
+
+func newFECStriper(k, r, symLen int) *fecStriper {
+	coder := newFECBlockCoder(k, r, symLen)
+	if coder == nil {
+		return nil
+	}
+	return &fecStriper{
+		coder:   coder,
+		k:       k,
+		r:       r,
+		symLen:  symLen,
+		symbols: make([][]byte, k),
+	}
+}
+
+// Add feeds one data frame's plaintext (identified by its mux seq). When the
+// frame completes a block it returns that block's R repair frames to schedule;
+// otherwise it returns nil. A payload too large to symbolize is skipped for
+// coding (the block will simply be short a data symbol; if the frame later needs
+// reconstruction it cannot be — an accepted, rare degradation) — but to keep the
+// MDS invariant we instead treat an un-codable frame as a zero symbol carrying a
+// length prefix of 0 so the block still encodes; the receiver never needs to
+// reconstruct a frame it actually received, and an un-received over-long frame
+// is beyond FEC anyway.
+func (s *fecStriper) Add(seq uint32, plaintext []byte) []fecRepairFrame {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	blk := seq / uint32(s.k)
+	idx := int(seq % uint32(s.k))
+
+	if !s.inited {
+		s.block = blk
+		s.inited = true
+	}
+	// A seq jump (should not happen with contiguous writeSeq) resets to the new
+	// block to avoid mixing symbols across blocks.
+	if blk != s.block {
+		s.reset(blk)
+	}
+
+	sym, ok := symbolize(plaintext, s.symLen)
+	if !ok {
+		// Over-long: stand in a zero-length symbol so the block still codes.
+		sym, _ = symbolize(nil, s.symLen)
+	}
+	if s.symbols[idx] == nil {
+		s.filled++
+	}
+	s.symbols[idx] = sym
+
+	if s.filled < s.k {
+		return nil
+	}
+	// Block complete → encode R repair symbols.
+	repair, err := s.coder.Encode(s.symbols)
+	if err != nil {
+		s.reset(blk + 1)
+		return nil
+	}
+	frames := make([]fecRepairFrame, s.r)
+	for i := 0; i < s.r; i++ {
+		frames[i] = fecRepairFrame{blockID: blk, idx: uint8(i), symbol: repair[i]}
+	}
+	s.reset(blk + 1)
+	return frames
+}
+
+// reset clears the fill state for the next block. Caller holds s.mu.
+func (s *fecStriper) reset(nextBlock uint32) {
+	for i := range s.symbols {
+		s.symbols[i] = nil
+	}
+	s.filled = 0
+	s.block = nextBlock
+}
+
+// --- receiver: fecReassembler ---
+
+// fecBlockState holds the symbols received for one block until it is fully
+// delivered or evicted. slots[0..K-1] are data symbols, slots[K..K+R-1] repair.
+type fecBlockState struct {
+	slots   [][]byte // len K+R; nil = not yet arrived
+	present []bool   // len K+R
+	got     int      // count of present slots
+	dataGot int      // count of present DATA slots (0..K-1)
+}
+
+// fecReassembler retains recently-received symbols per block so that when the
+// reorder frontier stalls on a missing seq it can reconstruct it from ≥K of the
+// block's K+R symbols. It keeps a bounded window of blocks (fecWindowBlocks);
+// blocks older than the window are evicted (their data was either delivered or
+// is permanently lost, past FEC's help). Safe for concurrent use.
+type fecReassembler struct {
+	mu     sync.Mutex
+	coder  *fecBlockCoder
+	k, r   int
+	symLen int
+	blocks map[uint32]*fecBlockState
+	// lowBlock is the oldest block still retained; blocks below it are evicted.
+	lowBlock uint32
+	haveLow  bool
+}
+
+// fecWindowBlocks bounds retained blocks (memory = window*(K+R)*symLen). 64
+// blocks * 10 * 16KiB ≈ 10 MiB worst case — ample for reorder depths in practice.
+const fecWindowBlocks = 64
+
+func newFECReassembler(k, r, symLen int) *fecReassembler {
+	coder := newFECBlockCoder(k, r, symLen)
+	if coder == nil {
+		return nil
+	}
+	return &fecReassembler{
+		coder:  coder,
+		k:      k,
+		r:      r,
+		symLen: symLen,
+		blocks: make(map[uint32]*fecBlockState),
+	}
+}
+
+func (f *fecReassembler) blockFor(blk uint32) *fecBlockState {
+	bs := f.blocks[blk]
+	if bs == nil {
+		bs = &fecBlockState{
+			slots:   make([][]byte, f.k+f.r),
+			present: make([]bool, f.k+f.r),
+		}
+		f.blocks[blk] = bs
+		if !f.haveLow || blk < f.lowBlock {
+			f.lowBlock = blk
+			f.haveLow = true
+		}
+		f.evict()
+	}
+	return bs
+}
+
+// evict drops blocks older than the retention window. Caller holds f.mu.
+func (f *fecReassembler) evict() {
+	if len(f.blocks) <= fecWindowBlocks {
+		return
+	}
+	// find current max block to anchor the window
+	var maxBlk uint32
+	for b := range f.blocks {
+		if b > maxBlk {
+			maxBlk = b
+		}
+	}
+	if maxBlk < fecWindowBlocks {
+		return
+	}
+	cutoff := maxBlk - fecWindowBlocks + 1
+	for b := range f.blocks {
+		if b < cutoff {
+			delete(f.blocks, b)
+		}
+	}
+}
+
+// RecordData notes a received data frame's plaintext at its seq. It stores a
+// symbolized copy so the block can be decoded later if a sibling is missing.
+func (f *fecReassembler) RecordData(seq uint32, plaintext []byte) {
+	sym, ok := symbolize(plaintext, f.symLen)
+	if !ok {
+		sym, _ = symbolize(nil, f.symLen)
+	}
+	blk := seq / uint32(f.k)
+	idx := int(seq % uint32(f.k))
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	bs := f.blockFor(blk)
+	if !bs.present[idx] {
+		bs.present[idx] = true
+		bs.got++
+		bs.dataGot++
+		bs.slots[idx] = sym
+	}
+}
+
+// RecordRepair notes a received repair symbol for a block.
+func (f *fecReassembler) RecordRepair(blk uint32, idx uint8, symbol []byte) {
+	if int(idx) >= f.r || len(symbol) != f.symLen {
+		return
+	}
+	slot := f.k + int(idx)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	bs := f.blockFor(blk)
+	if !bs.present[slot] {
+		bs.present[slot] = true
+		bs.got++
+		cp := make([]byte, f.symLen)
+		copy(cp, symbol)
+		bs.slots[slot] = cp
+	}
+}
+
+// Reconstruct attempts to recover the plaintext for a missing seq. It succeeds
+// only when the seq's block already holds ≥K of its K+R symbols AND the seq's
+// own data slot is not already present. Returns (plaintext, true) on success.
+// The reconstructed data symbol is also recorded into the block so a subsequent
+// sibling reconstruction in the same block reuses it.
+func (f *fecReassembler) Reconstruct(seq uint32) ([]byte, bool) {
+	blk := seq / uint32(f.k)
+	idx := int(seq % uint32(f.k))
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	bs := f.blocks[blk]
+	if bs == nil || bs.got < f.k || bs.present[idx] {
+		return nil, false
+	}
+	// Build recv/present of exactly K+R slots for the coder.
+	recv := make([][]byte, f.k+f.r)
+	for i := 0; i < f.k+f.r; i++ {
+		if bs.present[i] {
+			recv[i] = bs.slots[i]
+		} else {
+			recv[i] = make([]byte, f.symLen) // ignored (present=false)
+		}
+	}
+	data, err := f.coder.Decode(recv, bs.present)
+	if err != nil {
+		return nil, false
+	}
+	// Cache all reconstructed data slots so sibling gaps in this block are free.
+	for j := 0; j < f.k; j++ {
+		if !bs.present[j] {
+			bs.present[j] = true
+			bs.got++
+			bs.dataGot++
+			bs.slots[j] = data[j]
+		}
+	}
+	return desymbolize(data[idx]), true
+}

--- a/pkg/router/fec_mux.go
+++ b/pkg/router/fec_mux.go
@@ -26,17 +26,8 @@ package router
 
 import (
 	"encoding/binary"
-	"os"
 	"sync"
 )
-
-// fecWanted reports whether this visor advertises CapFEC in the mux handshake.
-// FEC is opt-in during rollout: it needs BOTH peers on a build that enables it,
-// plus live two-node validation, before it can safely become a default. Until
-// then the whole FEC path is inert (CapFEC unadvertised → never negotiated →
-// fecEnabled stays false → wrapPayload/deliverData fast-return). Gate: set
-// SKYWIRE_MUX_FEC=1 on both endpoints.
-var fecWanted = os.Getenv("SKYWIRE_MUX_FEC") == "1"
 
 // FEC block geometry. K data frames + R repair frames per block; recovers all K
 // from any K of the K+R. K=8/R=2 tolerates a full slow/dead leg's share of a

--- a/pkg/router/fec_mux.go
+++ b/pkg/router/fec_mux.go
@@ -299,8 +299,9 @@ func (f *fecReassembler) RecordRepair(blk uint32, idx uint8, symbol []byte) {
 // Reconstruct attempts to recover the plaintext for a missing seq. It succeeds
 // only when the seq's block already holds ≥K of its K+R symbols AND the seq's
 // own data slot is not already present. Returns (plaintext, true) on success.
-// The reconstructed data symbol is also recorded into the block so a subsequent
-// sibling reconstruction in the same block reuses it.
+// It is idempotent and side-effect-free on the block state (decodes from COPIES
+// of the received symbols), so each missing frontier frame in a multi-erasure
+// block reconstructs correctly and independently.
 func (f *fecReassembler) Reconstruct(seq uint32) ([]byte, bool) {
 	blk := seq / uint32(f.k)
 	idx := int(seq % uint32(f.k))
@@ -310,11 +311,19 @@ func (f *fecReassembler) Reconstruct(seq uint32) ([]byte, bool) {
 	if bs == nil || bs.got < f.k || bs.present[idx] {
 		return nil, false
 	}
-	// Build recv/present of exactly K+R slots for the coder.
+	// Build recv/present of exactly K+R slots for the coder. IMPORTANT: pass
+	// COPIES of the stored symbols, never bs.slots[i] directly — Decode/gfSolve
+	// solves in place and MUTATES the rhs symbol vectors, which would corrupt the
+	// block's retained received symbols and make a subsequent sibling
+	// reconstruction in the same block decode from garbage (the multi-erasure
+	// corruption the end-to-end test exposed). Copying keeps bs.slots pristine so
+	// each missing frontier frame decodes correctly and independently.
 	recv := make([][]byte, f.k+f.r)
 	for i := 0; i < f.k+f.r; i++ {
 		if bs.present[i] {
-			recv[i] = bs.slots[i]
+			cp := make([]byte, f.symLen)
+			copy(cp, bs.slots[i])
+			recv[i] = cp
 		} else {
 			recv[i] = make([]byte, f.symLen) // ignored (present=false)
 		}
@@ -323,15 +332,14 @@ func (f *fecReassembler) Reconstruct(seq uint32) ([]byte, bool) {
 	if err != nil {
 		return nil, false
 	}
-	// Cache all reconstructed data slots so sibling gaps in this block are free.
-	for j := 0; j < f.k; j++ {
-		if !bs.present[j] {
-			bs.present[j] = true
-			bs.got++
-			bs.dataGot++
-			bs.slots[j] = data[j]
-		}
-	}
+	// Deliberately DO NOT cache the reconstructed data slots back as "present".
+	// Caching would let a sibling gap in the same block decode for free, but it
+	// would also make a later Reconstruct(sibling) short-circuit on present[idx]
+	// and return false WITHOUT the sibling ever being inserted into the reorder
+	// buffer — the frontier would then stall on it forever (the multi-erasure
+	// bug). Decoding is idempotent and cheap for these block sizes, and the
+	// received data+repair symbols remain >= K, so each missing frontier frame is
+	// decoded independently and RETURNED to the caller for insertion.
 	return desymbolize(data[idx]), true
 }
 

--- a/pkg/router/fec_mux_integration_test.go
+++ b/pkg/router/fec_mux_integration_test.go
@@ -29,6 +29,7 @@ func TestFECMuxWiredReconstructsSlowLegFrame(t *testing.T) {
 	send.seal = func(seq uint32, pt []byte) []byte { return nI.SealWithNonce(uint64(seq), pt) }
 	send.fecEnabled = true
 	send.fecInit()
+	send.growLegs(2) // multi-leg so FEC activates (single-leg is intentionally skipped)
 	require.True(t, send.fecEnabled, "sender FEC must initialize")
 
 	recv := newRouteMux(log, true)
@@ -122,6 +123,7 @@ func TestFECMuxTailFlushProtectsPartialBlock(t *testing.T) {
 	send.seal = func(seq uint32, pt []byte) []byte { return nI.SealWithNonce(uint64(seq), pt) }
 	send.fecEnabled = true
 	send.fecInit()
+	send.growLegs(2) // multi-leg so FEC activates (single-leg is intentionally skipped)
 
 	recv := newRouteMux(log, true)
 	recv.open = func(seq uint32, ct []byte) ([]byte, error) { return nR.OpenWithNonce(uint64(seq), ct) }
@@ -198,4 +200,22 @@ func TestFECMuxTailFlushProtectsPartialBlock(t *testing.T) {
 	for i := 0; i < jReal; i++ {
 		require.Equal(t, plain[i], got[i], "real tail frame %d intact (FEC-reconstructed where withheld)", i)
 	}
+}
+
+// TestFECMuxSingleLegNoRepair verifies FEC is skipped on a single-leg group even
+// when negotiated: repair on one leg is pure overhead with no HoL to remove, so
+// no repair frames are produced (only a multi-leg group codes).
+func TestFECMuxSingleLegNoRepair(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("fec-singleleg-test")
+	send := newRouteMux(log, true)
+	send.fecEnabled = true
+	send.fecInit()
+	send.growLegs(1) // single leg → FEC must not emit repair
+
+	const routeID = routing.RouteID(13)
+	for i := 0; i < fecDefaultK*3; i++ {
+		_, _, err := send.wrapPayload(routeID, []byte(fmt.Sprintf("f-%02d", i)))
+		require.NoError(t, err)
+	}
+	require.Empty(t, send.fecDrainRepairs(), "single-leg group must not emit FEC repair frames")
 }

--- a/pkg/router/fec_mux_integration_test.go
+++ b/pkg/router/fec_mux_integration_test.go
@@ -77,7 +77,7 @@ func TestFECMuxWiredReconstructsSlowLegFrame(t *testing.T) {
 	// The reassembler now holds K-1 data + 1 repair = K symbols → it reconstructs
 	// the sealed frame for seq 3, opens it, and the frontier drains 3..K-1.
 	rf := repair[0]
-	more := recv.fecOnRecvRepair(rf.blockID, rf.idx, rf.symbol)
+	more := recv.fecOnRecvRepair(rf.blockID, rf.idx, rf.symLen, rf.symbol)
 	got = append(got, more...)
 
 	require.Len(t, got, k, "every frame must be delivered after FEC reconstruction")
@@ -186,7 +186,7 @@ func TestFECMuxTailFlushProtectsPartialBlock(t *testing.T) {
 	// Repair arrives → reconstruct seq 2 → frontier drains the rest (real 3,4;
 	// padding 5..7 filtered).
 	rf := repair[0]
-	more := recv.fecOnRecvRepair(rf.blockID, rf.idx, rf.symbol)
+	more := recv.fecOnRecvRepair(rf.blockID, rf.idx, rf.symLen, rf.symbol)
 	for _, x := range more {
 		if len(x) == 0 {
 			continue

--- a/pkg/router/fec_mux_integration_test.go
+++ b/pkg/router/fec_mux_integration_test.go
@@ -1,0 +1,109 @@
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// TestFECMuxWiredReconstructsSlowLegFrame drives the ACTUAL wired routeMux hooks
+// (wrapPayload→fecOnSend striping, deliverData→fecOnRecvData/fecTryAdvance,
+// fecOnRecvRepair) end-to-end, WITH per-frame noise active, to prove:
+//
+//  1. FEC operates correctly in the WIRE (post-seal) domain — repair is computed
+//     over sealed frames and a reconstructed sealed frame opens to the original
+//     plaintext.
+//  2. Without the repair, the no-skip reorder frontier is HoL-blocked on the
+//     missing slow-leg frame (only the pre-gap prefix is delivered).
+//  3. Delivering the block's repair frame reconstructs the missing frame and the
+//     frontier advances, draining every buffered later frame in order.
+func TestFECMuxWiredReconstructsSlowLegFrame(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("fec-wired-test")
+	nI, nR := kkPair(t)
+
+	send := newRouteMux(log, true)
+	send.seal = func(seq uint32, pt []byte) []byte { return nI.SealWithNonce(uint64(seq), pt) }
+	send.fecEnabled = true
+	send.fecInit()
+	require.True(t, send.fecEnabled, "sender FEC must initialize")
+
+	recv := newRouteMux(log, true)
+	recv.open = func(seq uint32, ct []byte) ([]byte, error) { return nR.OpenWithNonce(uint64(seq), ct) }
+	recv.fecEnabled = true
+	recv.fecInit()
+	require.True(t, recv.fecEnabled, "receiver FEC must initialize")
+
+	const routeID = routing.RouteID(7)
+	const k = fecDefaultK // one full block
+
+	// Sender: wrap K frames. The striper (fed the sealed payload) returns the R
+	// repair frames when the block completes; capture them.
+	plain := make([][]byte, k)
+	packets := make([]routing.Packet, k)
+	for i := 0; i < k; i++ {
+		plain[i] = []byte(fmt.Sprintf("frame-%02d-the-quick-brown-fox-jumps", i))
+		pkt, seq, err := send.wrapPayload(routeID, plain[i])
+		require.NoError(t, err)
+		require.Equal(t, uint32(i), seq)
+		packets[i] = pkt
+	}
+	repair := send.fecDrainRepairs()
+	require.Len(t, repair, fecDefaultR, "a completed block must queue R repair frames")
+
+	// Receiver: deliver every data frame EXCEPT the "slow leg" victim (seq 3).
+	// deliverData records each sealed payload into the reassembler (fecOnRecvData)
+	// before opening it, then inserts. The frontier stalls at seq 3.
+	const missing = 3
+	var got [][]byte
+	for i := 0; i < k; i++ {
+		if i == missing {
+			continue
+		}
+		p := packets[i]
+		delivered, _ := recv.deliverData(p.SequenceNumber(), p.DataPayloadAfterSeq())
+		got = append(got, delivered...)
+	}
+	// HoL proof: only the contiguous prefix before the gap (0,1,2) came out.
+	require.Len(t, got, missing, "frontier must be HoL-blocked at the missing seq")
+	for i := 0; i < missing; i++ {
+		require.Equal(t, plain[i], got[i], "pre-gap frame %d delivered intact", i)
+	}
+
+	// Deliver the block's first repair frame (as the RepairPacket handler would).
+	// The reassembler now holds K-1 data + 1 repair = K symbols → it reconstructs
+	// the sealed frame for seq 3, opens it, and the frontier drains 3..K-1.
+	rf := repair[0]
+	more := recv.fecOnRecvRepair(rf.blockID, rf.idx, rf.symbol)
+	got = append(got, more...)
+
+	require.Len(t, got, k, "every frame must be delivered after FEC reconstruction")
+	for i := 0; i < k; i++ {
+		require.Equal(t, plain[i], got[i], "frame %d delivered in order and intact (FEC-reconstructed where missing)", i)
+	}
+}
+
+// TestFECMuxWiredInertWhenDisabled proves the wiring is byte-for-byte a no-op when
+// FEC is not negotiated: no repair frames are produced, and delivery matches the
+// plain mux path.
+func TestFECMuxWiredInertWhenDisabled(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("fec-inert-test")
+	send := newRouteMux(log, true) // fecEnabled stays false
+	recv := newRouteMux(log, true)
+
+	const routeID = routing.RouteID(9)
+	const n = fecDefaultK * 2
+	plain := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		plain[i] = []byte(fmt.Sprintf("plain-%02d", i))
+		pkt, _, err := send.wrapPayload(routeID, plain[i])
+		require.NoError(t, err)
+		delivered, _ := recv.deliverData(pkt.SequenceNumber(), pkt.DataPayloadAfterSeq())
+		require.Len(t, delivered, 1, "in-order delivery, one frame at a time")
+		require.Equal(t, plain[i], delivered[0])
+	}
+	require.Empty(t, send.fecDrainRepairs(), "no repair frames when FEC disabled")
+}

--- a/pkg/router/fec_mux_integration_test.go
+++ b/pkg/router/fec_mux_integration_test.go
@@ -107,3 +107,95 @@ func TestFECMuxWiredInertWhenDisabled(t *testing.T) {
 	}
 	require.Empty(t, send.fecDrainRepairs(), "no repair frames when FEC disabled")
 }
+
+// TestFECMuxTailFlushProtectsPartialBlock proves the tail-flush wiring: a stream
+// that ends after j<K frames has its final partial block completed by empty
+// PADDING frames (as fecFlushServiceFn emits on idle), so a real tail frame lost
+// on a slow leg is still reconstructable from the block's repair. Padding frames
+// carry empty payloads and are filtered from the app stream (asserted here by
+// collecting only non-empty deliveries).
+func TestFECMuxTailFlushProtectsPartialBlock(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("fec-tailflush-test")
+	nI, nR := kkPair(t)
+
+	send := newRouteMux(log, true)
+	send.seal = func(seq uint32, pt []byte) []byte { return nI.SealWithNonce(uint64(seq), pt) }
+	send.fecEnabled = true
+	send.fecInit()
+
+	recv := newRouteMux(log, true)
+	recv.open = func(seq uint32, ct []byte) ([]byte, error) { return nR.OpenWithNonce(uint64(seq), ct) }
+	recv.fecEnabled = true
+	recv.fecInit()
+
+	const routeID = routing.RouteID(11)
+	const k = fecDefaultK
+	const jReal = 5 // a partial block: 5 real frames, then the stream goes idle
+
+	// helper: collect only non-empty delivered frames (the mux loop filters empties)
+	var got [][]byte
+	deliver := func(pkt routing.Packet) {
+		d, _ := recv.deliverData(pkt.SequenceNumber(), pkt.DataPayloadAfterSeq())
+		for _, x := range d {
+			if len(x) == 0 {
+				continue
+			}
+			got = append(got, x)
+		}
+	}
+
+	// Sender: j real frames.
+	plain := make([][]byte, jReal)
+	realPkts := make([]routing.Packet, jReal)
+	for i := 0; i < jReal; i++ {
+		plain[i] = []byte(fmt.Sprintf("tail-frame-%02d-payload", i))
+		pkt, seq, err := send.wrapPayload(routeID, plain[i])
+		require.NoError(t, err)
+		require.Equal(t, uint32(i), seq)
+		realPkts[i] = pkt
+	}
+	require.Empty(t, send.fecDrainRepairs(), "partial block must not emit repair yet")
+
+	// Idle flush: emit K-j empty padding frames (what writePaddingFrame does). The
+	// K-th frame completes the block and Add queues the repair.
+	padPkts := make([]routing.Packet, 0, k-jReal)
+	for i := jReal; i < k; i++ {
+		var empty []byte
+		pkt, seq, err := send.wrapPayload(routeID, empty)
+		require.NoError(t, err)
+		require.Equal(t, uint32(i), seq)
+		padPkts = append(padPkts, pkt)
+	}
+	repair := send.fecDrainRepairs()
+	require.Len(t, repair, fecDefaultR, "the flush must complete the block and emit R repair frames")
+
+	// Receiver: deliver every real frame EXCEPT the slow-leg victim (seq 2), plus
+	// all padding frames. Frontier stalls at seq 2.
+	const missing = 2
+	for i := 0; i < jReal; i++ {
+		if i == missing {
+			continue
+		}
+		deliver(realPkts[i])
+	}
+	for _, p := range padPkts {
+		deliver(p)
+	}
+	require.Len(t, got, missing, "frontier HoL-blocked at the missing tail frame; only pre-gap real frames delivered")
+
+	// Repair arrives → reconstruct seq 2 → frontier drains the rest (real 3,4;
+	// padding 5..7 filtered).
+	rf := repair[0]
+	more := recv.fecOnRecvRepair(rf.blockID, rf.idx, rf.symbol)
+	for _, x := range more {
+		if len(x) == 0 {
+			continue
+		}
+		got = append(got, x)
+	}
+
+	require.Len(t, got, jReal, "all real tail frames delivered after FEC reconstruction (padding filtered)")
+	for i := 0; i < jReal; i++ {
+		require.Equal(t, plain[i], got[i], "real tail frame %d intact (FEC-reconstructed where withheld)", i)
+	}
+}

--- a/pkg/router/fec_mux_test.go
+++ b/pkg/router/fec_mux_test.go
@@ -13,8 +13,8 @@ import (
 // reconstructed byte-identical — the frontier need never wait for the slow leg.
 func TestFECMuxRoundTripReconstruct(t *testing.T) {
 	const k, r = 8, 2
-	st := newFECStriper(k, r, fecSymLen)
-	re := newFECReassembler(k, r, fecSymLen)
+	st := newFECStriper(k, r)
+	re := newFECReassembler(k, r)
 	if st == nil || re == nil {
 		t.Fatal("nil striper/reassembler")
 	}
@@ -47,7 +47,7 @@ func TestFECMuxRoundTripReconstruct(t *testing.T) {
 		t.Fatal("reconstructed with only K-1 symbols — MDS violated")
 	}
 	// One repair frame arrives (on a fast leg) → K symbols present → reconstruct.
-	re.RecordRepair(repairs[0].blockID, repairs[0].idx, repairs[0].symbol)
+	re.RecordRepair(repairs[0].blockID, repairs[0].idx, repairs[0].symLen, repairs[0].symbol)
 	got, ok := re.Reconstruct(missing)
 	if !ok {
 		t.Fatal("reconstruction failed with K symbols present")
@@ -63,8 +63,8 @@ func TestFECMuxRoundTripReconstruct(t *testing.T) {
 // length-prefixed symbol format.
 func TestFECMuxUpToRErasures(t *testing.T) {
 	const k, r = 6, 3
-	st := newFECStriper(k, r, fecSymLen)
-	re := newFECReassembler(k, r, fecSymLen)
+	st := newFECStriper(k, r)
+	re := newFECReassembler(k, r)
 
 	payloads := make([][]byte, k)
 	var repairs []fecRepairFrame
@@ -80,18 +80,17 @@ func TestFECMuxUpToRErasures(t *testing.T) {
 	_ = re // re is rebuilt per-target below so caching does not mask a sibling
 
 	// Drop exactly R data frames {1,2,4}; supply all R repairs → each recovers.
-	// A fresh reassembler per target isolates it (the first Reconstruct caches
-	// its siblings — a real feature, but it must not hide a per-target failure).
+	// A fresh reassembler per target keeps each reconstruction fully independent.
 	drop := map[int]bool{1: true, 2: true, 4: true}
 	for target := range drop {
-		rt := newFECReassembler(k, r, fecSymLen)
+		rt := newFECReassembler(k, r)
 		for seq := 0; seq < k; seq++ {
 			if !drop[seq] {
 				rt.RecordData(uint32(seq), payloads[seq])
 			}
 		}
 		for _, rf := range repairs {
-			rt.RecordRepair(rf.blockID, rf.idx, rf.symbol)
+			rt.RecordRepair(rf.blockID, rf.idx, rf.symLen, rf.symbol)
 		}
 		got, ok := rt.Reconstruct(uint32(target))
 		if !ok {
@@ -108,14 +107,14 @@ func TestFECMuxUpToRErasures(t *testing.T) {
 	// siblings and corrupted the block via Decode's in-place mutation — the
 	// multi-erasure bug the end-to-end test exposed), so a second Reconstruct on
 	// the same block re-decodes from the pristine received symbols and succeeds.
-	reMulti := newFECReassembler(k, r, fecSymLen)
+	reMulti := newFECReassembler(k, r)
 	for seq := 0; seq < k; seq++ {
 		if !drop[seq] {
 			reMulti.RecordData(uint32(seq), payloads[seq])
 		}
 	}
 	for _, rf := range repairs {
-		reMulti.RecordRepair(rf.blockID, rf.idx, rf.symbol)
+		reMulti.RecordRepair(rf.blockID, rf.idx, rf.symLen, rf.symbol)
 	}
 	for target := range drop {
 		got, ok := reMulti.Reconstruct(uint32(target))
@@ -128,8 +127,8 @@ func TestFECMuxUpToRErasures(t *testing.T) {
 	}
 
 	// Fresh block, drop R+1 data frames, supply only R repairs → cannot recover.
-	st2 := newFECStriper(k, r, fecSymLen)
-	re2 := newFECReassembler(k, r, fecSymLen)
+	st2 := newFECStriper(k, r)
+	re2 := newFECReassembler(k, r)
 	var rep2 []fecRepairFrame
 	for seq := 0; seq < k; seq++ {
 		p := []byte(fmt.Sprintf("b-%d", seq))
@@ -145,7 +144,7 @@ func TestFECMuxUpToRErasures(t *testing.T) {
 		}
 	}
 	for _, rf := range rep2 {
-		re2.RecordRepair(rf.blockID, rf.idx, rf.symbol)
+		re2.RecordRepair(rf.blockID, rf.idx, rf.symLen, rf.symbol)
 	}
 	if _, ok := re2.Reconstruct(0); ok {
 		t.Fatal("recovered R+1 erasures with only R repair symbols — MDS violated")
@@ -254,7 +253,7 @@ func TestFECMuxHoLRemoval(t *testing.T) {
 // frames, at the block-closing seq, with correct blockIDs across many blocks.
 func TestFECMuxBlockBoundaries(t *testing.T) {
 	const k, r, blocks = 4, 2, 5
-	st := newFECStriper(k, r, fecSymLen)
+	st := newFECStriper(k, r)
 	emitted := map[uint32]int{}
 	for seq := 0; seq < k*blocks; seq++ {
 		rf := st.Add(uint32(seq), []byte{byte(seq)})

--- a/pkg/router/fec_mux_test.go
+++ b/pkg/router/fec_mux_test.go
@@ -1,0 +1,279 @@
+package router
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"testing"
+)
+
+// TestFECMuxRoundTripReconstruct: the core mechanism. A block of K data frames
+// is striped; the receiver gets K-1 data frames (one "stuck on a slow leg") plus
+// one repair frame that arrived on a fast leg. The missing frame must be
+// reconstructed byte-identical — the frontier need never wait for the slow leg.
+func TestFECMuxRoundTripReconstruct(t *testing.T) {
+	const k, r = 8, 2
+	st := newFECStriper(k, r, fecSymLen)
+	re := newFECReassembler(k, r, fecSymLen)
+	if st == nil || re == nil {
+		t.Fatal("nil striper/reassembler")
+	}
+
+	// K data frames with distinct payloads, seqs 0..K-1 (block 0).
+	payloads := make([][]byte, k)
+	var repairs []fecRepairFrame
+	for seq := 0; seq < k; seq++ {
+		p := []byte(fmt.Sprintf("frame-%d-payload-%x", seq, seq*7919))
+		payloads[seq] = p
+		if rf := st.Add(uint32(seq), p); rf != nil {
+			repairs = rf
+		}
+	}
+	if len(repairs) != r {
+		t.Fatalf("expected %d repair frames on block completion, got %d", r, len(repairs))
+	}
+
+	// Receiver gets every data frame EXCEPT seq=3 (the slow-leg victim), plus one
+	// repair frame. seq=3 must be reconstructable once ≥K symbols are present.
+	const missing = 3
+	for seq := 0; seq < k; seq++ {
+		if seq == missing {
+			continue
+		}
+		re.RecordData(uint32(seq), payloads[seq])
+	}
+	// Before any repair: only K-1 symbols → cannot reconstruct.
+	if _, ok := re.Reconstruct(missing); ok {
+		t.Fatal("reconstructed with only K-1 symbols — MDS violated")
+	}
+	// One repair frame arrives (on a fast leg) → K symbols present → reconstruct.
+	re.RecordRepair(repairs[0].blockID, repairs[0].idx, repairs[0].symbol)
+	got, ok := re.Reconstruct(missing)
+	if !ok {
+		t.Fatal("reconstruction failed with K symbols present")
+	}
+	if !bytes.Equal(got, payloads[missing]) {
+		t.Fatalf("reconstructed payload mismatch:\n got=%q\nwant=%q", got, payloads[missing])
+	}
+}
+
+// TestFECMuxUpToRErasures: any combination of up to R missing DATA frames is
+// recoverable once R repair frames are present; R+1 missing with only R repair
+// is not (MDS boundary). Also exercises variable-length payloads through the
+// length-prefixed symbol format.
+func TestFECMuxUpToRErasures(t *testing.T) {
+	const k, r = 6, 3
+	st := newFECStriper(k, r, fecSymLen)
+	re := newFECReassembler(k, r, fecSymLen)
+
+	payloads := make([][]byte, k)
+	var repairs []fecRepairFrame
+	for seq := 0; seq < k; seq++ {
+		// deliberately varied lengths incl. empty and near-symbol-size
+		p := bytes.Repeat([]byte{byte(seq + 1)}, seq*250)
+		payloads[seq] = p
+		if rf := st.Add(uint32(seq), p); rf != nil {
+			repairs = rf
+		}
+	}
+
+	_ = re // re is rebuilt per-target below so caching does not mask a sibling
+
+	// Drop exactly R data frames {1,2,4}; supply all R repairs → each recovers.
+	// A fresh reassembler per target isolates it (the first Reconstruct caches
+	// its siblings — a real feature, but it must not hide a per-target failure).
+	drop := map[int]bool{1: true, 2: true, 4: true}
+	for target := range drop {
+		rt := newFECReassembler(k, r, fecSymLen)
+		for seq := 0; seq < k; seq++ {
+			if !drop[seq] {
+				rt.RecordData(uint32(seq), payloads[seq])
+			}
+		}
+		for _, rf := range repairs {
+			rt.RecordRepair(rf.blockID, rf.idx, rf.symbol)
+		}
+		got, ok := rt.Reconstruct(uint32(target))
+		if !ok {
+			t.Fatalf("seq %d: reconstruction failed with R repairs for R erasures", target)
+		}
+		if !bytes.Equal(got, payloads[target]) {
+			t.Fatalf("seq %d: mismatch len got=%d want=%d", target, len(got), len(payloads[target]))
+		}
+	}
+
+	// The caching path itself must be correct: one Reconstruct fills all R holes;
+	// verify every dropped payload comes back right from a single decode.
+	reCache := newFECReassembler(k, r, fecSymLen)
+	for seq := 0; seq < k; seq++ {
+		if !drop[seq] {
+			reCache.RecordData(uint32(seq), payloads[seq])
+		}
+	}
+	for _, rf := range repairs {
+		reCache.RecordRepair(rf.blockID, rf.idx, rf.symbol)
+	}
+	if _, ok := reCache.Reconstruct(1); !ok {
+		t.Fatal("cache-path: first reconstruct failed")
+	}
+	// After the first decode, siblings 2 and 4 are cached present; a direct
+	// Reconstruct now reports them already-present (no re-decode needed).
+	if _, ok := reCache.Reconstruct(2); ok {
+		t.Fatal("cache-path: sibling should already be present after sibling decode")
+	}
+
+	// Fresh block, drop R+1 data frames, supply only R repairs → cannot recover.
+	st2 := newFECStriper(k, r, fecSymLen)
+	re2 := newFECReassembler(k, r, fecSymLen)
+	var rep2 []fecRepairFrame
+	for seq := 0; seq < k; seq++ {
+		p := []byte(fmt.Sprintf("b-%d", seq))
+		payloads[seq] = p
+		if rf := st2.Add(uint32(seq), p); rf != nil {
+			rep2 = rf
+		}
+	}
+	drop2 := map[int]bool{0: true, 1: true, 2: true, 3: true} // R+1 = 4
+	for seq := 0; seq < k; seq++ {
+		if !drop2[seq] {
+			re2.RecordData(uint32(seq), payloads[seq])
+		}
+	}
+	for _, rf := range rep2 {
+		re2.RecordRepair(rf.blockID, rf.idx, rf.symbol)
+	}
+	if _, ok := re2.Reconstruct(0); ok {
+		t.Fatal("recovered R+1 erasures with only R repair symbols — MDS violated")
+	}
+}
+
+// legModel is a leg in the discrete-event throughput model: each frame placed on
+// it arrives after (queuePosition+1)*perFrameTime.
+type legModel struct {
+	perFrameTime float64
+	queued       int
+}
+
+func (l *legModel) enqueue() float64 {
+	l.queued++
+	return float64(l.queued) * l.perFrameTime
+}
+
+// TestFECMuxHoLRemoval is the throughput proof. It models a heterogeneous leg set
+// (fast legs + one slow leg) delivering ONE FEC block, and computes the time at
+// which the reorder frontier can deliver all K data frames in three regimes:
+//
+//	single    — all K frames sent sequentially on ONE fast leg (single-route baseline)
+//	mux/noFEC — K frames striped across all legs; frontier needs EVERY data frame,
+//	            so it is HoL-capped at the slow leg's arrival (the wall)
+//	mux/FEC   — K data + R repair; frontier needs any K of K+R symbols, so it
+//	            completes at the K-th earliest arrival (fast-leg bound)
+//
+// It asserts mux/FEC < mux/noFEC (removes HoL) AND mux/FEC < single (aggregates).
+func TestFECMuxHoLRemoval(t *testing.T) {
+	const (
+		k, r     = 8, 2
+		fastTime = 1.0  // fast leg: 1 time unit per frame
+		slowTime = 12.0 // slow leg: 12x slower (heterogeneous, ~as measured: 205ms vs ~2.5s effective)
+		nFast    = 3    // 3 fast legs + 1 slow leg
+	)
+
+	// --- arrival time of each symbol under round-robin striping ---
+	// Legs: index 0..nFast-1 fast, index nFast slow.
+	legs := make([]*legModel, nFast+1)
+	for i := 0; i < nFast; i++ {
+		legs[i] = &legModel{perFrameTime: fastTime}
+	}
+	legs[nFast] = &legModel{perFrameTime: slowTime}
+
+	// Stripe K data frames round-robin across ALL legs (incl. slow).
+	dataArrival := make([]float64, k)
+	for seq := 0; seq < k; seq++ {
+		leg := legs[seq%len(legs)]
+		dataArrival[seq] = leg.enqueue()
+	}
+	// R repair frames scheduled onto the FAST legs only (least-loaded fast leg).
+	repairArrival := make([]float64, r)
+	for i := 0; i < r; i++ {
+		// pick the least-loaded fast leg
+		best := 0
+		for j := 1; j < nFast; j++ {
+			if legs[j].queued < legs[best].queued {
+				best = j
+			}
+		}
+		repairArrival[i] = legs[best].enqueue()
+	}
+
+	// --- regime completion times ---
+	// mux/noFEC: frontier delivers all K only when the LAST data frame arrives.
+	noFEC := 0.0
+	for _, a := range dataArrival {
+		if a > noFEC {
+			noFEC = a
+		}
+	}
+
+	// mux/FEC: block decodable when ANY K of the K+R symbols have arrived → the
+	// K-th smallest arrival time across data+repair.
+	allArr := append(append([]float64{}, dataArrival...), repairArrival...)
+	sort.Float64s(allArr)
+	withFEC := allArr[k-1] // K-th earliest (0-indexed k-1)
+
+	// single good leg: K frames sequentially on one fast leg.
+	single := float64(k) * fastTime
+
+	t.Logf("K=%d R=%d  nFast=%d fastTime=%.0f slowTime=%.0f", k, r, nFast, fastTime, slowTime)
+	t.Logf("completion time  single=%.1f  mux/noFEC=%.1f  mux/FEC=%.1f", single, noFEC, withFEC)
+	t.Logf("dataArrival=%v repairArrival=%v", dataArrival, repairArrival)
+
+	if !(withFEC < noFEC) {
+		t.Fatalf("FEC did not remove HoL: withFEC=%.1f not < noFEC=%.1f", withFEC, noFEC)
+	}
+	if !(withFEC < single) {
+		t.Fatalf("mux/FEC did not aggregate past a single leg: withFEC=%.1f not < single=%.1f", withFEC, single)
+	}
+	// Quantify: noFEC is dragged to the slow leg (>= slowTime); FEC stays near the
+	// fast-parallel bound (well under slowTime).
+	if noFEC < slowTime {
+		t.Fatalf("model sanity: noFEC=%.1f should be >= slowTime=%.1f (a frame rode the slow leg)", noFEC, slowTime)
+	}
+	if withFEC >= slowTime {
+		t.Fatalf("mux/FEC=%.1f should be well under slowTime=%.1f (fast-leg bound)", withFEC, slowTime)
+	}
+	speedup := noFEC / withFEC
+	t.Logf("HoL removed: mux/FEC is %.1fx faster than mux/noFEC, %.1fx faster than single", speedup, single/withFEC)
+}
+
+// TestFECMuxBlockBoundaries: the striper emits repair frames exactly once per K
+// frames, at the block-closing seq, with correct blockIDs across many blocks.
+func TestFECMuxBlockBoundaries(t *testing.T) {
+	const k, r, blocks = 4, 2, 5
+	st := newFECStriper(k, r, fecSymLen)
+	emitted := map[uint32]int{}
+	for seq := 0; seq < k*blocks; seq++ {
+		rf := st.Add(uint32(seq), []byte{byte(seq)})
+		if rf == nil {
+			if (seq+1)%k == 0 {
+				t.Fatalf("seq %d closes a block but emitted no repair", seq)
+			}
+			continue
+		}
+		if (seq+1)%k != 0 {
+			t.Fatalf("seq %d emitted repair but is not a block boundary", seq)
+		}
+		if len(rf) != r {
+			t.Fatalf("seq %d: got %d repair frames want %d", seq, len(rf), r)
+		}
+		wantBlk := uint32(seq / k)
+		for _, f := range rf {
+			if f.blockID != wantBlk {
+				t.Fatalf("seq %d: repair blockID=%d want %d", seq, f.blockID, wantBlk)
+			}
+			emitted[f.blockID]++
+		}
+	}
+	if len(emitted) != blocks {
+		t.Fatalf("expected repairs for %d blocks, got %d", blocks, len(emitted))
+	}
+}

--- a/pkg/router/fec_mux_test.go
+++ b/pkg/router/fec_mux_test.go
@@ -102,24 +102,29 @@ func TestFECMuxUpToRErasures(t *testing.T) {
 		}
 	}
 
-	// The caching path itself must be correct: one Reconstruct fills all R holes;
-	// verify every dropped payload comes back right from a single decode.
-	reCache := newFECReassembler(k, r, fecSymLen)
+	// Multi-erasure on ONE reassembler: every dropped sibling must reconstruct
+	// INDEPENDENTLY and correctly from the same block. Reconstruct deliberately
+	// does NOT cache decoded siblings back as present (that stranded uncached
+	// siblings and corrupted the block via Decode's in-place mutation — the
+	// multi-erasure bug the end-to-end test exposed), so a second Reconstruct on
+	// the same block re-decodes from the pristine received symbols and succeeds.
+	reMulti := newFECReassembler(k, r, fecSymLen)
 	for seq := 0; seq < k; seq++ {
 		if !drop[seq] {
-			reCache.RecordData(uint32(seq), payloads[seq])
+			reMulti.RecordData(uint32(seq), payloads[seq])
 		}
 	}
 	for _, rf := range repairs {
-		reCache.RecordRepair(rf.blockID, rf.idx, rf.symbol)
+		reMulti.RecordRepair(rf.blockID, rf.idx, rf.symbol)
 	}
-	if _, ok := reCache.Reconstruct(1); !ok {
-		t.Fatal("cache-path: first reconstruct failed")
-	}
-	// After the first decode, siblings 2 and 4 are cached present; a direct
-	// Reconstruct now reports them already-present (no re-decode needed).
-	if _, ok := reCache.Reconstruct(2); ok {
-		t.Fatal("cache-path: sibling should already be present after sibling decode")
+	for target := range drop {
+		got, ok := reMulti.Reconstruct(uint32(target))
+		if !ok {
+			t.Fatalf("multi-erasure: sibling seq %d failed to reconstruct independently", target)
+		}
+		if !bytes.Equal(got, payloads[target]) {
+			t.Fatalf("multi-erasure: sibling seq %d payload mismatch (in-place-mutation regression?)", target)
+		}
 	}
 
 	// Fresh block, drop R+1 data frames, supply only R repairs → cannot recover.

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -840,7 +840,47 @@ func (rg *RouteGroup) write(data []byte, tp *transport.ManagedTransport, rule ro
 			rg.mux.recordSent(leg, uint64(packet.Size()))
 		}
 
+		// FEC: if wrapPayload just completed a block, schedule its repair frames
+		// on the fastest live leg (off the data path). Inert unless CapFEC negotiated.
+		if rg.mux != nil && rg.mux.fecEnabled {
+			go rg.flushFECRepairs()
+		}
+
 		return len(data), nil
+	}
+}
+
+// flushFECRepairs drains any queued FEC repair frames and sends each on the
+// FASTEST live leg (the same rationale as retransmits: a repair rescues a
+// slow-leg straggler, so it must not itself ride the slow leg). Best-effort — a
+// repair that fails to send just leaves the receiver on the reorder+SACK
+// fallback for that block. Runs in its own goroutine off the data path.
+func (rg *RouteGroup) flushFECRepairs() {
+	if rg.mux == nil || !rg.mux.fecEnabled {
+		return
+	}
+	frames := rg.mux.fecDrainRepairs()
+	if len(frames) == 0 {
+		return
+	}
+	rg.mu.Lock()
+	tp, rule, _, err := rg.mux.selectFastestTransport(rg.tps, rg.fwd)
+	rg.mu.Unlock()
+	if err != nil || tp == nil || rule == nil {
+		return
+	}
+	for _, f := range frames {
+		pkt, perr := routing.MakeRepairPacket(rule.NextRouteID(), f.blockID, f.idx, f.symbol)
+		if perr != nil {
+			continue
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		errCh := rg.writePacketAsync(ctx, tp, pkt, rule.KeyRouteID())
+		select {
+		case <-rg.writeDeadline.Wait():
+		case <-errCh:
+		}
+		cancel()
 	}
 }
 
@@ -2883,6 +2923,9 @@ func (rg *RouteGroup) sendHandshake(encrypt bool) error {
 
 		rule := rg.fwd[i]
 		caps := routing.CapMux | routing.CapSACK | routing.CapHOLRetx
+		if fecWanted {
+			caps |= routing.CapFEC
+		}
 		var packet routing.Packet
 		if pfn := rg.perFrameNoiseCap(encrypt); pfn != 0 {
 			msg, mErr := rg.nextPerFrameNoiseMsg()
@@ -3017,6 +3060,8 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 			close(rg.handshakeProcessed)
 		})
 		return rg.handleDataPacket(packet)
+	case routing.RepairPacket:
+		return rg.handleRepairPacket(packet)
 	case routing.HandshakePacket:
 		// A handshake on an aux leg proves the peer registered that leg's
 		// rule, so it is safe to start sending on it. The primary leg's
@@ -3071,6 +3116,19 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 					if remoteCaps&routing.CapHOLRetx != 0 {
 						rg.mux.holRetxEnabled = true
 						rg.logger.Debug("Proactive HoL retransmit enabled (both peers support CapHOLRetx)")
+					}
+				}
+
+				// FEC negotiation. Requires CapMux (rg.mux set above); both edges
+				// must advertise CapFEC and this visor must want it (SKYWIRE_MUX_FEC=1,
+				// opt-in during rollout). Enables block erasure coding so a
+				// gap-blocked reorder frontier is reconstructed from repair frames on
+				// fast legs instead of waiting on the slow leg.
+				if fecWanted && remoteCaps&routing.CapFEC != 0 {
+					rg.mux.fecEnabled = true
+					rg.mux.fecInit()
+					if rg.mux.fecEnabled {
+						rg.logger.Debug("FEC enabled (both peers support CapFEC)")
 					}
 				}
 
@@ -3254,6 +3312,29 @@ func (rg *RouteGroup) handleDataPacket(packet routing.Packet) (err error) {
 		rg.logger.Warn("Dropping packet: readCh full for 30s (application not reading)")
 	}
 
+	return nil
+}
+
+// handleRepairPacket records an incoming FEC repair symbol and delivers any
+// frontier frames the reassembler can now reconstruct (opened, in order). A
+// repair for a group that never negotiated FEC is ignored. Mirrors
+// handleDataPacket's readCh delivery.
+func (rg *RouteGroup) handleRepairPacket(packet routing.Packet) error {
+	if rg.mux == nil || !rg.mux.fecEnabled {
+		return nil
+	}
+	delivered := rg.mux.fecOnRecvRepair(packet.RepairBlockID(), packet.RepairIndex(), packet.RepairSymbol())
+	for _, d := range delivered {
+		select {
+		case <-rg.closed:
+			return io.ErrClosedPipe
+		case <-rg.remoteClosed:
+			return io.ErrClosedPipe
+		case rg.readCh <- d:
+		case <-time.After(30 * time.Second):
+			rg.logger.Warn("Dropping FEC-reconstructed packet: readCh full for 30s (application not reading)")
+		}
+	}
 	return nil
 }
 

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -884,6 +884,51 @@ func (rg *RouteGroup) flushFECRepairs() {
 	}
 }
 
+// fecFlushServiceFn completes a pending partial FEC block on stream idle so the
+// tail frames (the final j<K of a transfer, which Add never codes because the
+// block never fills) gain repair protection. On an idle tick with a partial block
+// pending it emits the K-j remaining slots as empty PADDING frames through the
+// normal send path: each advances writeSeq and the striper, and the K-th
+// completes the block so Add() emits the R repair frames (auto-scheduled onto a
+// fast leg by write). The padding frames are REAL sealed sequenced-data frames,
+// so encoder and decoder agree bit-for-bit in the wire domain (no special
+// nonce), and they also fill the seq gap that the no-skip reorder buffer would
+// otherwise stall on. The receiver records them for FEC and delivers them as
+// 0-byte reads, which the mux delivery loop filters out of the app stream (the
+// app never sends an empty frame — Write rejects len==0 — so an empty delivered
+// payload is unambiguously FEC padding). Bounded by K as a runaway guard.
+func (rg *RouteGroup) fecFlushServiceFn(_ time.Duration) {
+	if rg.mux == nil || !rg.mux.fecEnabled || rg.mux.fecStriper == nil {
+		return
+	}
+	lastSent := time.Unix(0, atomic.LoadInt64(&rg.lastSent))
+	if !fecShouldFlush(time.Now(), lastSent, fecDefaultIdleFlush, rg.mux.fecStriper.hasPartialBlock()) {
+		return
+	}
+	for i := 0; i < fecDefaultK && rg.mux.fecStriper.hasPartialBlock(); i++ {
+		if err := rg.writePaddingFrame(); err != nil {
+			return
+		}
+	}
+}
+
+// writePaddingFrame emits one empty sequenced data frame (a FEC padding frame)
+// through the normal mux send path, bypassing Write's empty-payload short-circuit.
+func (rg *RouteGroup) writePaddingFrame() error {
+	if rg.isClosed() || rg.writeDeadline.Closed() {
+		return io.ErrClosedPipe
+	}
+	var empty []byte
+	rg.mu.Lock()
+	tp, rule, leg, err := rg.nextTransport(empty)
+	rg.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	_, err = rg.write(empty, tp, rule, leg)
+	return err
+}
+
 func (rg *RouteGroup) writePacketAsync(ctx context.Context, tp *transport.ManagedTransport, packet routing.Packet,
 	ruleID routing.RouteID) chan error {
 	errCh := make(chan error)
@@ -2922,10 +2967,11 @@ func (rg *RouteGroup) sendHandshake(encrypt bool) error {
 		}
 
 		rule := rg.fwd[i]
-		caps := routing.CapMux | routing.CapSACK | routing.CapHOLRetx
-		if fecWanted {
-			caps |= routing.CapFEC
-		}
+		// CapFEC is advertised unconditionally, like the other mux capabilities:
+		// it only ACTIVATES when the peer also advertises it (both ends on a build
+		// that has it), so an old peer simply never negotiates it and is
+		// unaffected. No config knob — on by default wherever both edges support it.
+		caps := routing.CapMux | routing.CapSACK | routing.CapHOLRetx | routing.CapFEC
 		var packet routing.Packet
 		if pfn := rg.perFrameNoiseCap(encrypt); pfn != 0 {
 			msg, mErr := rg.nextPerFrameNoiseMsg()
@@ -3124,11 +3170,14 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 				// opt-in during rollout). Enables block erasure coding so a
 				// gap-blocked reorder frontier is reconstructed from repair frames on
 				// fast legs instead of waiting on the slow leg.
-				if fecWanted && remoteCaps&routing.CapFEC != 0 {
+				if remoteCaps&routing.CapFEC != 0 {
 					rg.mux.fecEnabled = true
 					rg.mux.fecInit()
 					if rg.mux.fecEnabled {
 						rg.logger.Debug("FEC enabled (both peers support CapFEC)")
+						// Tail protection: flush a pending partial block on idle so
+						// the final <K frames of a transfer gain repair coverage.
+						go rg.servicePacketLoop("fec-flush", fecDefaultIdleFlush, rg.fecFlushServiceFn, nil)
 					}
 				}
 
@@ -3283,6 +3332,14 @@ func (rg *RouteGroup) handleDataPacket(packet routing.Packet) (err error) {
 		}
 
 		for _, d := range delivered {
+			// FEC padding frames carry an empty payload (the app never writes a
+			// zero-length frame — Write rejects len==0 — so an empty delivered
+			// payload is unambiguously FEC tail-flush padding). They exist only to
+			// complete a partial block and advance the reorder frontier; drop them
+			// from the app stream instead of surfacing a spurious 0-byte read.
+			if len(d) == 0 {
+				continue
+			}
 			// Both rg.closed (local-initiated close) and
 			// rg.remoteClosed (remote-initiated close) must be
 			// watched here; the latter was previously missing
@@ -3325,6 +3382,9 @@ func (rg *RouteGroup) handleRepairPacket(packet routing.Packet) error {
 	}
 	delivered := rg.mux.fecOnRecvRepair(packet.RepairBlockID(), packet.RepairIndex(), packet.RepairSymbol())
 	for _, d := range delivered {
+		if len(d) == 0 { // FEC padding frame — advances the frontier, not app data
+			continue
+		}
 		select {
 		case <-rg.closed:
 			return io.ErrClosedPipe

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -162,6 +162,22 @@ type routeMux struct {
 	seal func(seq uint32, plaintext []byte) []byte
 	open func(seq uint32, ciphertext []byte) ([]byte, error)
 
+	// Forward error correction (fec.go / fec_mux.go). fecEnabled is true when
+	// BOTH peers advertised CapFEC (implies CapMux). FEC operates in the WIRE
+	// (post-seal) domain: the striper batches K on-wire data-frame payloads per
+	// block and emits R repair frames (queued in fecRepairQ for the send loop to
+	// schedule on a fast leg); the reassembler retains on-wire block symbols and,
+	// when the reorder frontier is gap-blocked, reconstructs the missing on-wire
+	// frame from any K of the block's K+R symbols — which is then opened via the
+	// normal per-frame path and inserted, so recovery is bound by the FAST legs
+	// instead of the slow leg. All nil/false unless negotiated (inert — the
+	// pre-integration behavior is preserved byte-for-byte when fecEnabled=false).
+	fecEnabled     bool
+	fecStriper     *fecStriper
+	fecReassembler *fecReassembler
+	fecRepairMu    sync.Mutex
+	fecRepairQ     []fecRepairFrame
+
 	// Per-leg traffic counters parallel to the rg's tps[] / fwd[] /
 	// rvs[] slices. Mutated atomically. Read via Snapshot().
 	// legMu guards the slice itself (extended on AppendRoute), not
@@ -765,6 +781,11 @@ func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte) (routing.Pa
 		m.retxBuf.Store(seq, data) //nolint:errcheck
 	}
 
+	// FEC: feed the on-wire (post-seal) payload to the striper. A completed block
+	// queues R repair frames for the send loop (RouteGroup.write) to schedule on a
+	// fast leg. Inert unless CapFEC was negotiated.
+	m.fecOnSend(seq, data)
+
 	return packet, seq, nil
 }
 
@@ -772,6 +793,12 @@ func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte) (routing.Pa
 // and returns any payloads that are now deliverable in order.
 // Also tracks the sequence for SACK generation.
 func (m *routeMux) deliverData(seq uint32, data []byte) (delivered [][]byte, gapDetected bool) {
+	// FEC: record the on-wire (pre-open) payload so a sibling in this block can be
+	// reconstructed if it is late/lost on a slow leg. Inert unless CapFEC
+	// negotiated. Must run BEFORE open — reconstruction reproduces the on-wire
+	// frame, which is then opened via the same path below.
+	m.fecOnRecvData(seq, data)
+
 	// Per-frame AEAD: open the frame under its sequence-nonce before it enters
 	// the reorder buffer. A frame that fails to open (tamper, or a stale
 	// duplicate whose seq the peer reused after a rekey) is dropped, exactly as
@@ -798,6 +825,16 @@ func (m *routeMux) deliverData(seq uint32, data []byte) (delivered [][]byte, gap
 	// Sync SACK tracker with reorder buffer delivery state
 	if m.sackEnabled && m.sackTracker != nil {
 		m.sackTracker.AdvanceContiguous(m.reorderBuf.NextSeq())
+	}
+
+	// FEC: if the frontier is now gap-blocked but this frame completed a block's
+	// K-of-(K+R) quorum, reconstruct the stuck frontier frame(s) and append them
+	// to the delivered run so they reach the app in order — no wait on the slow
+	// leg. Inert unless CapFEC negotiated.
+	if m.fecEnabled {
+		if extra := m.fecTryAdvance(); len(extra) > 0 {
+			delivered = append(delivered, extra...)
+		}
 	}
 
 	return delivered, gapDetected

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -77,6 +77,8 @@ func (t PacketType) String() string {
 		return "TransportBwProbe"
 	case TransportBwAckPacket:
 		return "TransportBwAck"
+	case RepairPacket:
+		return "Repair"
 	default:
 		return fmt.Sprintf("Unknown(%d)", t)
 	}
@@ -118,7 +120,19 @@ const (
 	// TransportBwAckPacket carries the receiver's dispersion estimate back to
 	// the prober (route ID = 0). Payload: probeID(u32) estBps(u64).
 	TransportBwAckPacket
+	// RepairPacket carries one FEC repair symbol for the mux data plane (route
+	// ID > 0, same route group as the sequenced DataPackets it protects). Payload:
+	// blockID(u32 BE) idx(u8) then the symbol bytes. When both edges advertise
+	// CapFEC, the sender emits R repair packets per K-frame block onto its fast
+	// legs; a receiver whose reorder frontier is gap-blocked reconstructs the
+	// missing data frame from any K of the block's K+R symbols instead of waiting
+	// for the slow leg. A peer without CapFEC never sees these and is unaffected.
+	RepairPacket
 )
+
+// FECRepairHdr is the fixed prefix of a RepairPacket payload: blockID(4) + idx(1),
+// followed by the repair symbol bytes.
+const FECRepairHdr = 5
 
 // TransportBwProbeSize is the on-wire size of each packet-pair probe packet.
 // ~1400 B (sub-MTU) so consecutive packets are large enough to be spaced by
@@ -155,6 +169,15 @@ const (
 	// adds NO new wire message (the existing SACK carries the frontier); a peer
 	// without this bit cleanly falls back to the reactive SACK behavior.
 	CapHOLRetx uint16 = 1 << 4
+	// CapFEC: the peer supports forward-error-correction inside the mux. When BOTH
+	// edges advertise it (and CapMux, which it requires), the sender groups K
+	// consecutive sequenced DATA frames into a block and emits R RepairPackets on
+	// its fast legs; a receiver whose reorder frontier is gap-blocked reconstructs
+	// the missing data frame from any K of the block's K+R symbols (removing the
+	// wait on the slow leg that striped the frame). Erasure recovery delay is then
+	// bound by the FAST legs, not the slow one. A peer without this bit never
+	// receives RepairPackets and falls back cleanly to reorder+SACK.
+	CapFEC uint16 = 1 << 5
 )
 
 // SeqSize is the byte size of the sequence number prepended to DataPacket
@@ -362,6 +385,41 @@ func (p Packet) SequenceNumber() uint32 {
 // DataPayloadAfterSeq returns the data payload after the sequence number prefix.
 func (p Packet) DataPayloadAfterSeq() []byte {
 	return p[PacketPayloadOffset+SeqSize:]
+}
+
+// MakeRepairPacket constructs a RepairPacket carrying one FEC repair symbol for
+// route group id. Payload: blockID(u32 BE) idx(u8) symbol...
+func MakeRepairPacket(id RouteID, blockID uint32, idx uint8, symbol []byte) (Packet, error) {
+	totalPayload := FECRepairHdr + len(symbol)
+	if totalPayload > math.MaxUint16 {
+		return Packet{}, ErrPayloadTooBig
+	}
+
+	packet := make([]byte, PacketHeaderSize+totalPayload)
+
+	packet[PacketTypeOffset] = byte(RepairPacket)
+	binary.BigEndian.PutUint32(packet[PacketRouteIDOffset:], uint32(id))
+	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], uint16(totalPayload)) //nolint:gosec
+	binary.BigEndian.PutUint32(packet[PacketPayloadOffset:], blockID)
+	packet[PacketPayloadOffset+4] = idx
+	copy(packet[PacketPayloadOffset+FECRepairHdr:], symbol)
+
+	return packet, nil
+}
+
+// RepairBlockID extracts the FEC block ID from a RepairPacket.
+func (p Packet) RepairBlockID() uint32 {
+	return binary.BigEndian.Uint32(p[PacketPayloadOffset:])
+}
+
+// RepairIndex extracts the repair-symbol index (0..R-1) from a RepairPacket.
+func (p Packet) RepairIndex() uint8 {
+	return p[PacketPayloadOffset+4]
+}
+
+// RepairSymbol returns the repair symbol bytes of a RepairPacket.
+func (p Packet) RepairSymbol() []byte {
+	return p[PacketPayloadOffset+FECRepairHdr:]
 }
 
 // HandshakeCapabilities extracts the capability bitmap from an extended handshake payload.

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -130,9 +130,10 @@ const (
 	RepairPacket
 )
 
-// FECRepairHdr is the fixed prefix of a RepairPacket payload: blockID(4) + idx(1),
-// followed by the repair symbol bytes.
-const FECRepairHdr = 5
+// FECRepairHdr is the fixed prefix of a RepairPacket payload: blockID(4) + idx(1)
+// + symLen(2), followed by the repair symbol bytes. symLen is the block's adaptive
+// erasure-symbol length, which the receiver needs to size the block for decoding.
+const FECRepairHdr = 7
 
 // TransportBwProbeSize is the on-wire size of each packet-pair probe packet.
 // ~1400 B (sub-MTU) so consecutive packets are large enough to be spaced by
@@ -388,10 +389,10 @@ func (p Packet) DataPayloadAfterSeq() []byte {
 }
 
 // MakeRepairPacket constructs a RepairPacket carrying one FEC repair symbol for
-// route group id. Payload: blockID(u32 BE) idx(u8) symbol...
-func MakeRepairPacket(id RouteID, blockID uint32, idx uint8, symbol []byte) (Packet, error) {
+// route group id. Payload: blockID(u32 BE) idx(u8) symLen(u16 BE) symbol...
+func MakeRepairPacket(id RouteID, blockID uint32, idx uint8, symLen int, symbol []byte) (Packet, error) {
 	totalPayload := FECRepairHdr + len(symbol)
-	if totalPayload > math.MaxUint16 {
+	if totalPayload > math.MaxUint16 || symLen > math.MaxUint16 {
 		return Packet{}, ErrPayloadTooBig
 	}
 
@@ -402,6 +403,7 @@ func MakeRepairPacket(id RouteID, blockID uint32, idx uint8, symbol []byte) (Pac
 	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], uint16(totalPayload)) //nolint:gosec
 	binary.BigEndian.PutUint32(packet[PacketPayloadOffset:], blockID)
 	packet[PacketPayloadOffset+4] = idx
+	binary.BigEndian.PutUint16(packet[PacketPayloadOffset+5:], uint16(symLen)) //nolint:gosec
 	copy(packet[PacketPayloadOffset+FECRepairHdr:], symbol)
 
 	return packet, nil
@@ -415,6 +417,11 @@ func (p Packet) RepairBlockID() uint32 {
 // RepairIndex extracts the repair-symbol index (0..R-1) from a RepairPacket.
 func (p Packet) RepairIndex() uint8 {
 	return p[PacketPayloadOffset+4]
+}
+
+// RepairSymLen extracts the block's adaptive symbol length from a RepairPacket.
+func (p Packet) RepairSymLen() int {
+	return int(binary.BigEndian.Uint16(p[PacketPayloadOffset+5:]))
 }
 
 // RepairSymbol returns the repair symbol bytes of a RepairPacket.

--- a/pkg/routing/packet_test.go
+++ b/pkg/routing/packet_test.go
@@ -148,3 +148,31 @@ func TestMakeErrorPacket(t *testing.T) {
 	assert.Equal(t, RouteID(2), packet.RouteID())
 	assert.Equal(t, []byte("foo"), packet.Payload())
 }
+
+func TestMakeRepairPacketRoundTrip(t *testing.T) {
+	id := RouteID(0xDEADBEEF)
+	blockID := uint32(12345)
+	idx := uint8(2)
+	symbol := make([]byte, 16*1024)
+	for i := range symbol {
+		symbol[i] = byte(i * 31)
+	}
+
+	p, err := MakeRepairPacket(id, blockID, idx, symbol)
+	if err != nil {
+		t.Fatalf("MakeRepairPacket: %v", err)
+	}
+	if p.Type() != RepairPacket {
+		t.Fatalf("type = %v want RepairPacket", p.Type())
+	}
+	if p.RouteID() != id {
+		t.Fatalf("routeID = %v want %v", p.RouteID(), id)
+	}
+	if p.RepairBlockID() != blockID {
+		t.Fatalf("blockID = %d want %d", p.RepairBlockID(), blockID)
+	}
+	if p.RepairIndex() != idx {
+		t.Fatalf("idx = %d want %d", p.RepairIndex(), idx)
+	}
+	require.Equal(t, symbol, p.RepairSymbol())
+}

--- a/pkg/routing/packet_test.go
+++ b/pkg/routing/packet_test.go
@@ -153,12 +153,13 @@ func TestMakeRepairPacketRoundTrip(t *testing.T) {
 	id := RouteID(0xDEADBEEF)
 	blockID := uint32(12345)
 	idx := uint8(2)
-	symbol := make([]byte, 16*1024)
+	symLen := 4098
+	symbol := make([]byte, symLen)
 	for i := range symbol {
 		symbol[i] = byte(i * 31)
 	}
 
-	p, err := MakeRepairPacket(id, blockID, idx, symbol)
+	p, err := MakeRepairPacket(id, blockID, idx, symLen, symbol)
 	if err != nil {
 		t.Fatalf("MakeRepairPacket: %v", err)
 	}
@@ -173,6 +174,9 @@ func TestMakeRepairPacketRoundTrip(t *testing.T) {
 	}
 	if p.RepairIndex() != idx {
 		t.Fatalf("idx = %d want %d", p.RepairIndex(), idx)
+	}
+	if p.RepairSymLen() != symLen {
+		t.Fatalf("symLen = %d want %d", p.RepairSymLen(), symLen)
 	}
 	require.Equal(t, symbol, p.RepairSymbol())
 }


### PR DESCRIPTION
Integrates the systematic Cauchy-Reed-Solomon erasure core (#4278) into the packet-mux data plane so a multi-leg route group is no longer head-of-line-bound on its slowest leg.

**Mechanism.** The sender groups K=8 consecutive on-wire frames into a block and emits R=2 repair frames on its fastest leg. When the receiver's no-skip reorder frontier is gap-blocked on a frame striped onto a slow leg, it reconstructs that frame from any K of the block's K+R symbols instead of waiting — so recovery is bound by the FAST legs, not the slow one. FEC operates in the wire (post-seal) domain, so repair symbols are linear combinations of already-sealed frames (no new nonce; works with or without per-frame noise).

**Correctness/efficiency.** Symbol length is chosen ADAPTIVELY per block (max frame length + prefix, carried on the RepairPacket), so repair overhead stays at the design R/K (~25%) for any frame size — a fixed pad would both bloat small-frame repair and silently corrupt frames larger than the pad. FEC is skipped on single-leg groups (no HoL to remove), and a tail-flush completes a partial final block on idle so the last <K frames are also protected.

**Negotiation.** Advertised as `CapFEC` alongside the other mux capabilities; it only activates when both peers advertise it, so an older peer never negotiates it and is unaffected — on by default wherever both edges support it.

**Validation.** A controlled two-route-group end-to-end harness over piped transports with a deliberately slow leg: on a 3-fast + 1-slow leg set, mux+FEC completes a full transfer ~5.7x faster than mux/no-FEC (slow leg no longer drags the frontier) and below the single-fast-leg time (aggregation across the fast legs preserved), with per-leg byte accounting. Unit + integration tests cover reconstruction under per-frame noise, the MDS boundary, multi-erasure decode, and the single-leg/no-repair gate. Full `pkg/router` suite green.