### PR TITLE
fix(visor): report /health transport stats for all transport types

### DIFF
--- a/pkg/httputil/health.go
+++ b/pkg/httputil/health.go
@@ -24,8 +24,14 @@ type HealthCheckResponse struct {
 	PublicAutoconnect bool            `json:"public_autoconnect,omitempty"`
 	StcprCount        int             `json:"stcpr_count,omitempty"`
 	SudphCount        int             `json:"sudph_count,omitempty"`
-	NetworkTypes      []string        `json:"network_types,omitempty"`
-	DHTBootstrap      bool            `json:"dht_bootstrap,omitempty"`
+	// TransportCounts is a count of live transports keyed by their actual
+	// network type (stcpr, sudph, stcp, dmsg, squicr, swsr, swtr, webrtc, …).
+	// The key set is derived from the transports present, so every current and
+	// future transport type is represented — not just stcpr/sudph. The legacy
+	// StcprCount/SudphCount fields remain for backward compatibility.
+	TransportCounts map[string]int `json:"transport_counts,omitempty"`
+	NetworkTypes    []string       `json:"network_types,omitempty"`
+	DHTBootstrap    bool           `json:"dht_bootstrap,omitempty"`
 }
 
 // GetServiceHealth gets the response from the given service url

--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -62,6 +62,10 @@ type HealthStatsProvider interface {
 	IsPublicAutoconnectRunning() bool
 	// GetTransportCounts returns the count of STCPR and SUDPH transports (excluding "user" labeled).
 	GetTransportCounts() (stcpr, sudph int)
+	// GetTransportTypeCounts returns a count of live transports keyed by their
+	// actual network type (excluding "user" labeled) — every present type, not
+	// just stcpr/sudph.
+	GetTransportTypeCounts() map[string]int
 	// GetNetworkTypes returns the network types used by the visor.
 	GetNetworkTypes() []string
 }
@@ -513,6 +517,7 @@ func (api *API) health(c *gin.Context) {
 	if api.healthStatsProvider != nil {
 		resp.PublicAutoconnect = api.healthStatsProvider.IsPublicAutoconnectRunning()
 		resp.StcprCount, resp.SudphCount = api.healthStatsProvider.GetTransportCounts()
+		resp.TransportCounts = api.healthStatsProvider.GetTransportTypeCounts()
 		resp.NetworkTypes = api.healthStatsProvider.GetNetworkTypes()
 	}
 

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -1364,23 +1364,31 @@ func setForceColor(conf *visorconfig.V1) {
 
 // HealthStatsProvider implementation for logserver
 
-// GetTransportCounts returns the count of STCPR and SUDPH transports (excluding "user" labeled).
-func (v *Visor) GetTransportCounts() (stcpr, sudph int) {
+// GetTransportTypeCounts returns a count of live transports keyed by their
+// actual network type (excluding "user" labeled). The key set is derived from
+// the transports present rather than a hardcoded subset, so every current and
+// future transport type (stcpr, sudph, stcp, dmsg, squicr, swsr, swtr, webrtc,
+// …) is represented.
+func (v *Visor) GetTransportTypeCounts() map[string]int {
 	if v.tpM == nil {
-		return 0, 0
+		return nil
 	}
 
 	// Get transports that are not user-created (skycoin + automatic labels)
 	tps := v.tpM.GetTransportsByLabels(transport.LabelSkycoin, transport.LabelAutomatic)
+	counts := make(map[string]int)
 	for _, tp := range tps {
-		switch tp.Type() {
-		case tptypes.STCPR:
-			stcpr++
-		case tptypes.SUDPH:
-			sudph++
-		}
+		counts[string(tp.Type())]++
 	}
-	return stcpr, sudph
+	return counts
+}
+
+// GetTransportCounts returns the count of STCPR and SUDPH transports (excluding
+// "user" labeled). Retained for backward compatibility; GetTransportTypeCounts
+// reports every live transport type.
+func (v *Visor) GetTransportCounts() (stcpr, sudph int) {
+	counts := v.GetTransportTypeCounts()
+	return counts[string(tptypes.STCPR)], counts[string(tptypes.SUDPH)]
 }
 
 // GetNetworkTypes returns the network types used by the visor.


### PR DESCRIPTION
The visor's `/health` response only reported transport counts for stcpr and sudph. `GetTransportCounts()` tallied live transports with a `switch tp.Type()` that had only those two cases, so stcp, dmsg, squicr, swsr, swtr and webrtc transports were silently dropped — and the response struct only had `stcpr_count`/`sudph_count` fields to carry them anyway.

Add `GetTransportTypeCounts()` which groups the live (skycoin/automatic-labeled) transports by their actual type instead of a hardcoded subset, and a `transport_counts` map on the health response populated from it, so any current or future transport type is represented automatically. The legacy `stcpr_count`/`sudph_count` fields are unchanged, so the JSON is a backward-compatible superset.