### PR TITLE
fix(wasmhv): raise nested-browser window on iframe body click

### DIFF
--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -1084,6 +1084,39 @@
     return _winZ;
   }
 
+  // Raise-on-body-click for IFRAME windows. WinBox already raises a window when
+  // its own body receives a mousedown (internally: k(a.body,"mousedown",()=>
+  // a.focus())). But a click that lands inside a child <iframe> fires in the
+  // iframe's OWN document and never bubbles up to the parent body, so a browse /
+  // terminal / chat / wallet / files window (whose body is a full-bleed iframe)
+  // only ever raised from the title bar — clicking the covered window's page did
+  // nothing, unlike a normal desktop window. Bridge that gap: focusing an iframe
+  // blurs the top window and makes document.activeElement the <iframe> element
+  // (true even for a sandboxed / cross-origin frame — only the element ref, no
+  // content, is read). On that blur, find the owning WinBox and focus() it, which
+  // reuses WinBox's own raise path so the z-index stack stays consistent with the
+  // title bar. Registry + one shared listener; entries are pruned on close.
+  var _winboxRegistry = [];
+  function _winboxRoot(wb) { return wb && (wb.window || wb.g || wb.dom); }
+  if (!globalThis.__skywireWinboxRaiseHooked) {
+    globalThis.__skywireWinboxRaiseHooked = true;
+    globalThis.addEventListener("blur", function () {
+      // Defer one tick so document.activeElement settles onto the new iframe.
+      setTimeout(function () {
+        var ae = document.activeElement;
+        if (!ae || ae.tagName !== "IFRAME") return;
+        var root = ae.closest ? ae.closest(".winbox") : null;
+        if (!root) return;
+        for (var i = 0; i < _winboxRegistry.length; i++) {
+          if (_winboxRoot(_winboxRegistry[i]) === root) {
+            try { _winboxRegistry[i].focus(); } catch (e) {}
+            return;
+          }
+        }
+      }, 0);
+    }, true);
+  }
+
   function makeWin(doc, opts) {
     var cfg = {
       title: opts.title || "window",
@@ -1109,8 +1142,18 @@
     if (opts.bottom != null) cfg.bottom = opts.bottom;
     if (opts.mount) cfg.mount = opts.mount;
     if (opts.url) cfg.url = opts.url;
-    if (opts.onclose) cfg.onclose = opts.onclose;
+    // Wrap onclose so the raise-on-iframe-click registry drops this window (the
+    // real onclose, if any, still runs). Prune here rather than leaking closed
+    // instances that would keep matching a since-reused DOM subtree.
+    var _userClose = opts.onclose;
+    cfg.onclose = function () {
+      for (var i = _winboxRegistry.length - 1; i >= 0; i--) {
+        if (_winboxRegistry[i] === wb) { _winboxRegistry.splice(i, 1); }
+      }
+      if (_userClose) return _userClose.apply(this, arguments);
+    };
     var wb = new WinBox(cfg);
+    _winboxRegistry.push(wb);
     // Bring the new window to the front + focus it (WinBox raises the focused
     // window's z within its own stack; combined with the incrementing base above
     // this guarantees a new window is never obscured by an older one).


### PR DESCRIPTION
Clicking the body of a partially-covered nested-browser window did not bring it to the front — only clicking its WinBox title bar did. Normal desktop windows raise on any click.

Root cause: WinBox raises a window when its body receives a `mousedown`, but a click that lands inside a child `<iframe>` fires in the iframe's own document and never bubbles up to the parent body. Every mini-desktop window whose body is a full-bleed iframe (browse, terminal, chat, wallet, files) was therefore only raiseable from the title bar.

Fix: focusing an iframe blurs the top window and makes `document.activeElement` the `<iframe>` element (true even for a sandboxed / cross-origin frame — only the element reference is read). On that blur, find the owning WinBox and `focus()` it, reusing WinBox's own raise path so the z-index stack stays consistent with the title bar. A small registry maps each WinBox root element to its instance and is pruned on close.

The change is entirely in the Go-embedded `pkg/wasmhv/browseui/browse.js`; no Angular rebuild is needed.

Validated live over CDP: with two overlapping browse windows (z 2147483005 / 2147483006), simulating a click inside the lower window's iframe raised it to 2147483018, above the other; the title-bar behavior is unchanged.