### PR TITLE
feat(router): RACK-derived retransmit threshold (replace fixed 750ms) [#4287]

### DIFF
--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -940,7 +940,56 @@ func (m *routeMux) processSACK(lastContig uint32, words []uint64) []uint32 {
 	if !m.sackEnabled || m.retxBuf == nil {
 		return nil
 	}
-	return m.retxBuf.ProcessSACK(lastContig, words)
+	return m.retxBuf.ProcessSACK(lastContig, words, m.rackThreshold())
+}
+
+// RACK-TLP retransmit-threshold bounds (RFC 8985 in spirit). Replaces the fixed
+// 750ms retxMinAge with a value derived from the live per-leg RTTs, so loss on a
+// fast path is recovered in tens of ms instead of always waiting ~750ms, while a
+// genuinely slow leg still isn't declared lost prematurely.
+const (
+	rackReorderFactor = 1.25                    // slow-leg RTT × this = the reordering tolerance
+	rackFloor         = 60 * time.Millisecond   // never retransmit sooner than this (anti-storm)
+	rackCeil          = 1500 * time.Millisecond // never wait longer than this
+	rackDefaultNoRTT  = 300 * time.Millisecond  // before any leg RTT is measured
+)
+
+// rackThreshold computes the current reorder-tolerant retransmit threshold from
+// the live ACTIVE-leg RTTs: a sequence is presumed lost (not merely reordered on
+// a slower leg) once it has been outstanding longer than this. The reordering
+// window on a multi-leg mux IS the inter-leg RTT skew, so we bound the threshold
+// at the SLOWEST active leg's RTT × rackReorderFactor — a frame striped onto any
+// leg should arrive within the slow leg's RTT plus a jitter margin; past that it
+// is lost. Adapts per-SACK to the measured path (RFC 8985's RTT-derived expiry),
+// floored/capped to avoid a self-amplifying early-retransmit storm or an
+// unbounded wait. Falls back to a conservative default until RTTs are known.
+func (m *routeMux) rackThreshold() time.Duration {
+	m.legMu.RLock()
+	maxRtt := 0.0
+	for i, lc := range m.legs {
+		if lc == nil {
+			continue
+		}
+		if i < len(m.standby) && m.standby[i] {
+			continue // active legs only
+		}
+		if lc.ecfRttMs > maxRtt {
+			maxRtt = lc.ecfRttMs
+		}
+	}
+	m.legMu.RUnlock()
+
+	if maxRtt <= 0 {
+		return rackDefaultNoRTT
+	}
+	th := time.Duration(maxRtt*rackReorderFactor) * time.Millisecond
+	if th < rackFloor {
+		th = rackFloor
+	}
+	if th > rackCeil {
+		th = rackCeil
+	}
+	return th
 }
 
 // getRetxPayload retrieves a stored payload for retransmission.

--- a/pkg/router/sack.go
+++ b/pkg/router/sack.go
@@ -7,16 +7,18 @@ import (
 	"time"
 )
 
-// retxMinAge is how long an un-acknowledged sequence must have been
-// outstanding before a SACK gap will retransmit it. The mux legs ride
+// retxMinAge is the FALLBACK reorder-tolerant retransmit age, used only when the
+// caller supplies no RTT-derived threshold (a zero threshold to ProcessSACK).
+// The live path now passes routeMux.rackThreshold (RFC 8985 RACK), which derives
+// the age from the measured per-leg RTTs instead of this fixed constant — so a
+// fast path recovers loss in tens of ms rather than always waiting 750ms, while a
+// slow path can wait longer. The rationale is unchanged: the mux legs ride
 // reliable, ordered transports, so a sequence missing from the receiver's
-// contiguous run is almost always just IN FLIGHT on a slower leg (latency
-// skew), not lost. Retransmitting it on sight is spurious and self-amplifies:
-// each early retx arrives out of order, provoking another SACK, provoking more
-// retx (the observed ~7x traffic storm that wedged mux>1). Holding off until a
-// sequence is overdue by more than any realistic inter-leg skew means a merely
-// reordered packet arrives and is acked (purged) first, and only a genuinely
-// lost one — a dead leg, which liveness prunes — is ever retransmitted.
+// contiguous run is almost always just IN FLIGHT on a slower leg (latency skew),
+// not lost; retransmitting on sight is spurious and self-amplifies (the observed
+// ~7x traffic storm that wedged mux>1). Holding off until a sequence is overdue
+// by more than the realistic inter-leg skew — which the RTT-derived threshold
+// measures directly — means a merely reordered packet is acked (purged) first.
 const retxMinAge = 750 * time.Millisecond
 
 // sackMaxWords bounds the generated bitmap to the reorder window (32 words *
@@ -187,7 +189,15 @@ func (rb *retxBuffer) Store(seq uint32, data []byte) bool {
 // in the bitmap where we still hold data). It purges every acknowledged entry,
 // including received sequences ABOVE a persistent frontier gap — that whole-
 // window purge is what keeps the buffer from filling behind a stuck gap (#86).
-func (rb *retxBuffer) ProcessSACK(lastContiguous uint32, words []uint64) []uint32 {
+// threshold is the reorder-tolerant loss-detection age (RACK): a still-missing
+// sequence is retransmitted only once it has been outstanding at least this long,
+// so a merely-reordered packet on a slower leg is acked (purged) first. The mux
+// supplies an RTT-derived value (routeMux.rackThreshold); a zero/negative
+// threshold falls back to the fixed retxMinAge for any caller that doesn't.
+func (rb *retxBuffer) ProcessSACK(lastContiguous uint32, words []uint64, threshold time.Duration) []uint32 {
+	if threshold <= 0 {
+		threshold = retxMinAge
+	}
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 
@@ -211,7 +221,7 @@ func (rb *retxBuffer) ProcessSACK(lastContiguous uint32, words []uint64) []uint3
 			checkSeq := base + i
 			if word&(1<<i) != 0 {
 				delete(rb.entries, checkSeq)
-			} else if e, ok := rb.entries[checkSeq]; ok && time.Since(e.sentAt) >= retxMinAge {
+			} else if e, ok := rb.entries[checkSeq]; ok && time.Since(e.sentAt) >= threshold {
 				retransmit = append(retransmit, checkSeq)
 			}
 		}

--- a/pkg/router/sack_test.go
+++ b/pkg/router/sack_test.go
@@ -2,9 +2,11 @@ package router
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/routing"
 )
 
@@ -101,7 +103,7 @@ func TestRetxBuffer_StoreAndPurge(t *testing.T) {
 	assert.Equal(t, 10, rb.Len())
 
 	// SACK: lastContiguous=5, bits 0-3 set = seqs 6,7,8,9 received
-	retx := rb.ProcessSACK(5, []uint64{0xF})
+	retx := rb.ProcessSACK(5, []uint64{0xF}, 0)
 	assert.Empty(t, retx)
 	assert.Equal(t, 0, rb.Len())
 }
@@ -119,7 +121,7 @@ func TestRetxBuffer_RetransmitList(t *testing.T) {
 	}
 
 	// SACK: lastContiguous=2, bitmap=0b1010 (seq 3 missing, 4 received, 5 missing, 6 received)
-	retx := rb.ProcessSACK(2, []uint64{0b1010})
+	retx := rb.ProcessSACK(2, []uint64{0b1010}, 0)
 	assert.Contains(t, retx, uint32(3))
 	assert.Contains(t, retx, uint32(5))
 	assert.NotContains(t, retx, uint32(4))
@@ -169,7 +171,7 @@ func TestRetxBuffer_NoFillBehindPersistentGap(t *testing.T) {
 	last, words := st.GenerateSACK()
 	assert.Equal(t, uint32(0), last)
 
-	rb.ProcessSACK(last, words)
+	rb.ProcessSACK(last, words, 0)
 
 	// seq 1 (the hole) retained for retransmit.
 	assert.NotNil(t, rb.Get(1), "the actual gap must stay retransmittable")
@@ -202,4 +204,45 @@ func TestSACKPacket_EmptyAndTrim(t *testing.T) {
 	// round-trips.
 	p2 := routing.MakeSACKPacket(1, 5, []uint64{0b101, 0, 0})
 	assert.Equal(t, []uint64{0b101}, p2.SACKWords())
+}
+
+// TestRackThreshold verifies the RACK retransmit threshold is derived from the
+// live active-leg RTTs (not the fixed 750ms), tolerates the slowest leg, and is
+// floored/capped. A fast path recovers loss far sooner than the old constant.
+func TestRackThreshold(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("rack-test")
+	m := newRouteMux(log, true)
+
+	// No RTT measured yet → conservative default.
+	if got := m.rackThreshold(); got != rackDefaultNoRTT {
+		t.Fatalf("no-RTT threshold = %v, want %v", got, rackDefaultNoRTT)
+	}
+
+	// Give it 4 active legs with a heterogeneous RTT spread; the threshold must
+	// track the SLOWEST active leg × factor (a frame on any leg should arrive
+	// within the slow leg's RTT + margin), well under the old fixed 750ms.
+	m.growLegs(4)
+	rtts := []float64{205, 260, 311, 441}
+	m.legMu.Lock()
+	for i, r := range rtts {
+		m.legs[i].ecfRttMs = r
+	}
+	m.legMu.Unlock()
+	want := time.Duration(rtts[3]*rackReorderFactor) * time.Millisecond // slowest leg × factor
+	if got := m.rackThreshold(); got != want {
+		t.Fatalf("heterogeneous threshold = %v, want %v (slowest 441ms × %.2f)", got, want, rackReorderFactor)
+	}
+	if got := m.rackThreshold(); got >= retxMinAge {
+		t.Fatalf("RACK threshold %v should beat the fixed retxMinAge %v on this path", got, retxMinAge)
+	}
+
+	// A tiny-RTT fast path floors at rackFloor (anti-storm), not near-zero.
+	m.legMu.Lock()
+	for i := range m.legs {
+		m.legs[i].ecfRttMs = 5
+	}
+	m.legMu.Unlock()
+	if got := m.rackThreshold(); got != rackFloor {
+		t.Fatalf("fast-path threshold = %v, want floor %v", got, rackFloor)
+	}
 }


### PR DESCRIPTION
First increment of #4287. Replaces the fixed `retxMinAge = 750ms` retransmit gate with an RTT-derived RACK threshold (RFC 8985 in spirit).

`routeMux.rackThreshold` derives the reorder-tolerant loss-detection age from the live active-leg RTTs: a frame striped onto any leg should arrive within the SLOWEST active leg's RTT plus a jitter margin (× 1.25), so past that it is lost, not merely reordered on a slower leg. Floored at 60ms (anti-storm), capped at 1500ms, with a 300ms fallback until RTTs are measured. `ProcessSACK` now takes the threshold (0 → the old `retxMinAge`, so any caller without one is unchanged).

Effect: a fast path recovers loss in tens of ms instead of always waiting 750ms; a genuinely slow path waits proportionally longer — both strictly more principled than the constant, and safe against the self-amplifying reorder storm because the threshold is DERIVED from the leg RTT spread the storm arises from. Unit-tested (no-RTT default, heterogeneous slowest-leg tracking, fast-path floor); full `pkg/router` suite green.

Follow-ups on #4287: TLP (tail-loss probe) for tail-segment loss with no later ACK to trigger RACK, and DSACK-driven reorder-window adaptation.