### PR TITLE
fix(wasm-visor): fast re-warm skysocks-lite proxy on tab wake

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -262,6 +262,7 @@ func main() {
 		"proxyInstances":     js.FuncOf(jsProxyInstances),
 		"setProxyExit":       js.FuncOf(jsSetProxyExit),
 		"proxyKillActive":    js.FuncOf(jsProxyKillActive),
+		"proxyWake":          js.FuncOf(jsProxyWake),
 		"proxyBind":          js.FuncOf(jsProxyBind),
 		"proxyConsumers":     js.FuncOf(jsProxyConsumers),
 		"visorStats":         js.FuncOf(jsVisorStats),

--- a/cmd/wasm-visor/proxyretry_js.go
+++ b/cmd/wasm-visor/proxyretry_js.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"syscall/js"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -32,6 +34,15 @@ const (
 	stickyMaxDelay          = 30 * time.Second // backoff cap
 	proxyKeepalivePeriod    = 15 * time.Second // liveness ping cadence (mirrors native)
 	proxyKeepaliveFailLimit = 2                // consecutive ping failures ⇒ exit declared dead
+	// proxyFreezeGap is the since-last-sweep threshold beyond which a wake is
+	// attributed to the SharedWorker having been FROZEN (timers suspended) rather
+	// than to a normal — even heavily throttled — tick. The keepalive heartbeat
+	// updates proxyLastSweepMs every proxyKeepalivePeriod (15s) while the worker
+	// runs; background tab-throttling can stretch a live timer only to ~1 min, so
+	// 3× the period (45s) since the last sweep means the worker was actually
+	// suspended. Only then do we surface the "resuming" UI notice — a normal
+	// short hide (worker still ticking) keeps the gap small and stays silent.
+	proxyFreezeGap = 3 * proxyKeepalivePeriod
 )
 
 var (
@@ -143,53 +154,173 @@ func proxyKeepaliveLoop(kctx context.Context) {
 		case <-kctx.Done():
 			return
 		case <-time.After(proxyKeepalivePeriod):
+		case <-proxyWakeChan():
+			// A page came back to the foreground (JS resume / visibilitychange →
+			// visible). While the SharedWorker was frozen every setTimeout — and so
+			// every Go WASM timer, including our proxyKeepalivePeriod one — was
+			// suspended, so the active AND standby routes went silently dead
+			// (yamux/dmsg keepalive i/o deadline on the far side) with no sweep to
+			// notice. Do the sweep NOW instead of waiting out the (possibly
+			// intensively-throttled, up to ~1 min) next tick, so recovery starts the
+			// instant the tab is looked at rather than after a user-visible stall.
 		}
-		// Active exit: ping (establishing a keepalive session if needed).
-		if pk, ok := proxyDefaultExit(); ok {
-			if pingProxyExit("keepalive-"+pk.Hex()[:8], pk) {
-				fails[pk] = 0
-			} else {
-				fails[pk]++
-				if fails[pk] >= proxyKeepaliveFailLimit {
-					delete(fails, pk)
-					closeSkysocksWindow("keepalive-" + pk.Hex()[:8])
-					reportProxyExitDead(pk) // policy: sticky (was connected) or rotate
-				}
+		proxyResilienceSweep(fails)
+	}
+}
+
+// proxyResilienceSweep performs one liveness pass: ping the active exit (dead ⇒
+// policy), keep the standby routes warm, and keep the SHARED user-facing sessions
+// hot. Shared by the periodic keepalive loop and the wake hook. `fails` carries
+// consecutive-failure counts across calls so a transient miss doesn't evict.
+func proxyResilienceSweep(fails map[cipher.PubKey]int) {
+	// Freeze detection: this sweep's OWN lateness is the signal. proxyLastSweepMs is
+	// stamped at the END of every sweep, so if more than proxyFreezeGap has elapsed
+	// since the last one, the loop's timer (a JS setTimeout) was suspended — the
+	// SharedWorker was frozen in the background — not merely throttled. Surface the
+	// "resuming" notice. Whichever trigger runs the FIRST post-thaw sweep (the wake
+	// nudge from visibilitychange, or the suspended periodic timer that also fires
+	// immediately on thaw) detects it: because the stamp lands at the sweep's end,
+	// both read the stale timestamp, so there is no race between them — a subtlety
+	// found in runtime testing, where the periodic timer otherwise re-stamped a
+	// fresh time before the wake path could read the stale one.
+	if prev := proxyLastSweepMs.Load(); prev != 0 {
+		if gap := time.Now().UnixMilli() - prev; gap > proxyFreezeGap.Milliseconds() &&
+			proxyFreezeRecovering.CompareAndSwap(false, true) {
+			proxyResumeNotice(true, gap)
+		}
+	}
+	// Active exit: ping (establishing a keepalive session if needed).
+	if pk, ok := proxyDefaultExit(); ok {
+		if pingProxyExit("keepalive-"+pk.Hex()[:8], pk) {
+			fails[pk] = 0
+		} else {
+			fails[pk]++
+			if fails[pk] >= proxyKeepaliveFailLimit {
+				delete(fails, pk)
+				closeSkysocksWindow("keepalive-" + pk.Hex()[:8])
+				reportProxyExitDead(pk) // policy: sticky (was connected) or rotate
 			}
 		}
-		// Standbys (pool[1:]): keep a warm route so promotion is instant + vetted.
-		proxyPoolMu.Lock()
-		standbys := append([]cipher.PubKey(nil), proxyPool...)
-		proxyPoolMu.Unlock()
-		for i, spk := range standbys {
-			if i == 0 || spk.Null() {
-				continue
-			}
-			pingProxyExit("pool-warm-"+spk.Hex()[:8], spk) // best-effort warmth
+	}
+	// Standbys (pool[1:]): keep a warm route so promotion is instant + vetted.
+	proxyPoolMu.Lock()
+	standbys := append([]cipher.PubKey(nil), proxyPool...)
+	proxyPoolMu.Unlock()
+	for i, spk := range standbys {
+		if i == 0 || spk.Null() {
+			continue
 		}
-		// Keep the SHARED user-facing sessions (owner = defaultProxyID, the key a
-		// browser fetch resolves to) HOT for every pool exit — active AND standbys.
-		// The pings above use throwaway windows for liveness POLICY; those do NOT
-		// keep the route a real fetch reuses alive, so without this the shared route
-		// goes cold and each navigation (and every promotion) cold-dials a fresh
-		// multihop route (~30-45s) instead of reusing a live one — the gap vs a
-		// native skysocks-client that holds one persistent route. Ping the live
-		// session to keep it warm; re-establish (best-effort) any that dropped.
-		for _, spk := range standbys {
-			if spk.Null() {
-				continue
-			}
-			skysocksMu.Lock()
-			s, ok := skysocksSessions[skysocksKey(defaultProxyID, spk)]
-			alive := ok && s != nil && !s.IsClosed()
-			skysocksMu.Unlock()
-			if alive {
-				sess := s
-				go func() { _, _ = sess.Ping() }() //nolint:errcheck // keep the shared route warm
-			} else {
-				prewarmDefaultSession(spk) // re-open the shared route in the background
-			}
+		pingProxyExit("pool-warm-"+spk.Hex()[:8], spk) // best-effort warmth
+	}
+	// Keep the SHARED user-facing sessions (owner = defaultProxyID, the key a
+	// browser fetch resolves to) HOT for every pool exit — active AND standbys.
+	// The pings above use throwaway windows for liveness POLICY; those do NOT
+	// keep the route a real fetch reuses alive, so without this the shared route
+	// goes cold and each navigation (and every promotion) cold-dials a fresh
+	// multihop route (~30-45s) instead of reusing a live one — the gap vs a
+	// native skysocks-client that holds one persistent route. Ping the live
+	// session to keep it warm; re-establish (best-effort) any that dropped.
+	for _, spk := range standbys {
+		if spk.Null() {
+			continue
 		}
+		skysocksMu.Lock()
+		s, ok := skysocksSessions[skysocksKey(defaultProxyID, spk)]
+		alive := ok && s != nil && !s.IsClosed()
+		skysocksMu.Unlock()
+		if alive {
+			sess := s
+			go func() { _, _ = sess.Ping() }() //nolint:errcheck // keep the shared route warm
+		} else {
+			prewarmDefaultSession(spk) // re-open the shared route in the background
+		}
+	}
+	// Pool empty (both active and standby died during a freeze, or never filled)?
+	// Kick a fresh selection so recovery doesn't wait for the next auto round.
+	proxyPoolMu.Lock()
+	empty := len(proxyPool) == 0
+	proxyPoolMu.Unlock()
+	if empty {
+		kickDefaultProxyReselect()
+	}
+	// Stamp the liveness heartbeat: a wake compares now against this to tell a real
+	// worker suspension (stale stamp) from a normal throttled tick (fresh stamp).
+	proxyLastSweepMs.Store(time.Now().UnixMilli())
+	// If a freeze-recovery notice is showing, clear it the moment the proxy is
+	// usable again — an active exit with a live shared session — so the operator
+	// sees "resuming" only for as long as recovery actually takes.
+	if proxyFreezeRecovering.Load() && proxyPoolWarm() && proxyFreezeRecovering.CompareAndSwap(true, false) {
+		proxyResumeNotice(false, 0)
+	}
+}
+
+// proxyPoolWarm reports whether the default instance's active exit has a live
+// shared user-facing session — i.e. a browser fetch would reuse a warm route
+// rather than cold-dial. Used to decide when the freeze-recovery notice clears.
+func proxyPoolWarm() bool {
+	pk, ok := proxyDefaultExit()
+	if !ok || pk.Null() {
+		return false
+	}
+	skysocksMu.Lock()
+	s, ok := skysocksSessions[skysocksKey(defaultProxyID, pk)]
+	warm := ok && s != nil && !s.IsClosed()
+	skysocksMu.Unlock()
+	return warm
+}
+
+// Wake / freeze-detection state. The sweep runs on exactly one goroutine (the
+// keepalive loop), and a wake is delivered as another case in that loop's SAME
+// select — so a wake-sweep and the periodic-tick-sweep can never run
+// concurrently, and `fails` plus these atomics are only ever touched from that
+// one goroutine (jsProxyWake merely nudges the channel). The atomics are used so
+// the values are safe to publish, not because there is contended access.
+var (
+	// proxyWakeCh is signalled (non-blocking) by jsProxyWake when a page reports it
+	// returned to the foreground, so the keepalive loop runs a sweep immediately
+	// instead of waiting for its (throttled-while-hidden) timer. Buffered depth 1:
+	// coalesced wakes are fine — one sweep covers them.
+	proxyWakeCh = make(chan struct{}, 1)
+	// proxyLastSweepMs is the wall-clock (UnixMilli) of the last completed sweep —
+	// the liveness heartbeat. 0 until the first sweep, so an early wake (e.g. the
+	// initial visibilitychange at page load) is never mistaken for a thaw.
+	proxyLastSweepMs atomic.Int64
+	// proxyFreezeRecovering latches while the "resuming from background" notice is
+	// shown, so repeated visibilitychange events don't re-emit it and the sweep
+	// clears it exactly once.
+	proxyFreezeRecovering atomic.Bool
+)
+
+func proxyWakeChan() <-chan struct{} { return proxyWakeCh }
+
+// jsProxyWake() is called from the page's Page-Lifecycle `resume` /
+// `visibilitychange`→visible handler (hv-boot.js) when the tab is looked at
+// again. A backgrounded/frozen SharedWorker suspends every timer, so the
+// keepalive loop cannot notice that the active + standby routes died during the
+// idle period; this nudges it to sweep the moment the operator returns, turning a
+// user-visible cold start into a background re-warm. Idempotent + cheap +
+// non-blocking (a plain channel nudge; the sweep — and the freeze detection that
+// drives the "resuming" UI notice — run on the loop, in proxyResilienceSweep).
+func jsProxyWake(_ js.Value, _ []js.Value) interface{} {
+	select {
+	case proxyWakeCh <- struct{}{}:
+	default: // a wake is already pending; the pending sweep covers this one
+	}
+	return nil
+}
+
+// proxyResumeNotice surfaces (recovering=true) or clears (false) the page's
+// "resuming from background" toast via the worker→tab bridge in worker.js, and
+// logs the transition. gapMs is the observed suspension length (ms), used only in
+// the log line. Best-effort: absent bridge ⇒ log only.
+func proxyResumeNotice(recovering bool, gapMs int64) {
+	if h := js.Global().Get("__skywireProxyResume"); h.Type() == js.TypeFunction {
+		h.Invoke(recovering, float64(gapMs))
+	}
+	if recovering {
+		vlog(fmt.Sprintf("[skysocks-lite] worker resumed after ~%ds background suspension — re-establishing proxy", gapMs/1000))
+	} else {
+		vlog("[skysocks-lite] proxy re-warmed after background resume")
 	}
 }
 

--- a/pkg/wasmhv/hv-boot.js
+++ b/pkg/wasmhv/hv-boot.js
@@ -206,6 +206,38 @@
     var d = document.getElementById('skywire-connecting-notice');
     if (d && d.parentNode) d.parentNode.removeChild(d);
   }
+
+  // --- "visor resumed from background" status (non-blocking) ---
+  //
+  // Shown when the worker reports (via {t:'proxy-resume', on:true}) that a wake
+  // found its keepalive heartbeat stale — i.e. Chromium had FROZEN the background
+  // SharedWorker, suspending its timers, so the skysocks-lite routes went silently
+  // dead during the idle period. A small corner toast (same idiom as the
+  // connecting notice) tells the operator the visor was suspended, not broken, and
+  // is re-establishing the proxy. Cleared by {t:'proxy-resume', on:false} once an
+  // active exit is warm again, or by a safety timeout so a stalled recovery can't
+  // leave the toast up forever.
+  var resumeNoticeTimer = null;
+  function showResumeNotice() {
+    function add() {
+      if (document.getElementById('skywire-resume-notice')) return;
+      var d = document.createElement('div');
+      d.id = 'skywire-resume-notice';
+      d.style.cssText = 'position:fixed;left:8px;bottom:8px;z-index:2147483646;background:rgba(31,25,15,.94);color:#f0d9b5;' +
+        'font:12px/1.5 system-ui,sans-serif;padding:6px 12px;border-radius:6px;border:1px solid #6b5324;box-shadow:0 1px 4px rgba(0,0,0,.4)';
+      d.textContent = 'Visor resumed from background — re-establishing proxy…';
+      document.body.appendChild(d);
+    }
+    if (document.body) add(); else document.addEventListener('DOMContentLoaded', add);
+    try { clearTimeout(resumeNoticeTimer); } catch (e) {}
+    resumeNoticeTimer = setTimeout(hideResumeNotice, 120000); // safety: never linger past 2 min
+  }
+  function hideResumeNotice() {
+    try { clearTimeout(resumeNoticeTimer); } catch (e) {}
+    resumeNoticeTimer = null;
+    var d = document.getElementById('skywire-resume-notice');
+    if (d && d.parentNode) d.parentNode.removeChild(d);
+  }
   function becomeLeader(name) {
     if (!(navigator.locks && navigator.locks.request)) {
       try { console.log('[hv-boot] Web Locks unsupported; single-instance guard disabled'); } catch (e) {}
@@ -311,6 +343,11 @@
             // browse.js's per-window pane and the mesh browser's live interstitial.
             try { if (typeof self.__skywireProxyLog === 'function') { self.__skywireProxyLog(m.winId, m.line); } } catch (e) {}
             break;
+          case 'proxy-resume':
+            // The worker was frozen in the background and, on wake, found its
+            // skysocks-lite heartbeat stale — show/clear the "resuming" toast.
+            try { if (m.on) { showResumeNotice(); } else { hideResumeNotice(); } } catch (e) {}
+            break;
           case 'up':
             settled = true;
             hideConnectingNotice();
@@ -369,6 +406,18 @@
       // unloading so it can re-elect the agent / drop the port promptly.
       function reportVis() {
         try { port.postMessage({ t: 'vis', state: (document.visibilityState || 'visible') }); } catch (e) {}
+        // Becoming visible means the SharedWorker just unfroze (Chromium freezes a
+        // background SharedWorker + suspends its timers, so the skysocks-lite
+        // keepalive/pool-warm loops stopped and the active + standby routes went
+        // silently dead during the idle period). Nudge the worker to run a liveness
+        // sweep + re-warm NOW so recovery happens in the background instead of as a
+        // user-visible cold start on the next fetch.
+        try {
+          if ((document.visibilityState || 'visible') === 'visible' &&
+              self.skywireVisor && self.skywireVisor.proxyWake) {
+            self.skywireVisor.proxyWake();
+          }
+        } catch (e) {}
       }
       try {
         document.addEventListener('visibilitychange', reportVis);
@@ -430,6 +479,11 @@
             // the console/log channel). Hand it to the page's proxy-log sink —
             // browse.js's per-window pane and the mesh browser's live interstitial.
             try { if (typeof self.__skywireProxyLog === 'function') { self.__skywireProxyLog(m.winId, m.line); } } catch (e) {}
+            break;
+          case 'proxy-resume':
+            // The worker was frozen in the background and, on wake, found its
+            // skysocks-lite heartbeat stale — show/clear the "resuming" toast.
+            try { if (m.on) { showResumeNotice(); } else { hideResumeNotice(); } } catch (e) {}
             break;
           case 'up':
             clearTimeout(upTimer);

--- a/pkg/wasmhv/worker.js
+++ b/pkg/wasmhv/worker.js
@@ -145,6 +145,16 @@
     try { broadcast({ t: 'proxylog', winId: String(winId == null ? '' : winId), line: String(line == null ? '' : line) }); } catch (e) { /* ignore */ }
   };
 
+  // Freeze-recovery bridge. When a wake finds the keepalive heartbeat stale (the
+  // SharedWorker was frozen), the wasm visor calls
+  // globalThis.__skywireProxyResume(recovering, gapMs) — true when a suspension is
+  // detected, false once the proxy is re-warmed. Broadcast it to every tab as
+  // {t:'proxy-resume'} so hv-boot.js shows/clears a small corner toast telling the
+  // operator the visor was suspended (not broken) and is re-establishing.
+  self.__skywireProxyResume = function (recovering, gapMs) {
+    try { broadcast({ t: 'proxy-resume', on: !!recovering, gap: Number(gapMs) || 0 }); } catch (e) { /* ignore */ }
+  };
+
   // Variant (go|tinygo) arrives on this worker's URL (hv-boot.js appends it —
   // workers can't read localStorage). It selects BOTH the loader and the blob,
   // which must match toolchains. Empty = the server default.


### PR DESCRIPTION
When a tab is backgrounded, Chromium freezes its SharedWorker (or the dedicated-worker fallback): the task queue is suspended, so every Go/WASM timer stops. `proxyKeepaliveLoop` is the only loop pinging the active skysocks-lite exit and warming the standby pool, so during a long idle the far-side yamux/dmsg keepalive times out and both the active and standby routes are torn down. On return the user hits a slow from-scratch re-selection.

A frozen worker cannot run code, so sessions cannot truly be held through a day of idle without far-side changes. This instead recovers *immediately on wake*: hv-boot`s `visibilitychange`->visible handler calls a new exported `jsProxyWake`, which nudges the keepalive loop (added as a case in its `select`) to run the resilience sweep at once rather than waiting out the throttled next tick (up to ~1 min). The sweep re-pings the active exit, re-warms standbys, and kicks a reselect if the pool emptied during the freeze.

It also surfaces the suspension to the operator. The sweep stamps a heartbeat at the end of every pass; when a sweep finds the previous stamp older than 3x the 15s keepalive period it concludes the worker was frozen (not merely throttled) and emits a transient corner toast via the worker->tab bridge — "Visor resumed from background — re-establishing proxy…" — cleared once an active exit is warm again or after a safety timeout. Detecting from the sweep`s own lateness (rather than in the wake callback) avoids a race with the suspended periodic timer, which also fires on thaw and would otherwise re-stamp a fresh time before the wake path could read the stale one.

## Runtime test (CDP, Brave)

Served the rebuilt blob on a spare port and drove it over the DevTools protocol:

- `skywireVisor.proxyWake` propagates to the page proxy (via `methods: Object.keys(api)`); a direct `await skywireVisor.proxyWake()` returns without throwing and triggers a resilience sweep within ~1s (`keepalive-…`, `pool-warm-…`), not after the 15s tick.
- Forcing the dedicated-worker path (freezable with the page) and freezing it for 52s: the worker goes fully silent (far-side sessions die, exactly the diagnosed bug). On thaw the sweep detects the stale heartbeat **within 58ms** and logs `worker resumed after ~52s background suspension — re-establishing proxy`, rendering the toast `Visor resumed from background — re-establishing proxy…`. The toast auto-clears (warm-clear path, or the safety timeout).

## Follow-up (not in this PR)

This makes recovery *fast*, not *unnecessary*: truly surviving a long idle needs far-side work (longer server-side idle timeout, or a server push to hold/rebuild sessions). Live recovery is still gated by cold multi-hop route dials observed at 160s+, above the 30s sticky-retry backoff ceiling — a separate tuning item.