### PR TITLE
fix(router): route + forward FEC RepairPacket (was dropped on every hop)

### DIFF
--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -49,6 +49,13 @@ func (r *router) handleTransportPacket(ctx context.Context, packet routing.Packe
 		return r.dispatchToRouteGroup(ctx, packet)
 	case routing.SACKPacket:
 		return r.handleSACKRouterPacket(ctx, packet)
+	case routing.RepairPacket:
+		// FEC repair symbol (#4270): same route-ID-driven path as data/ping —
+		// forwarded when this visor is an intermediary, else delivered to the
+		// destination route group (handleRepairPacket). Without this case the
+		// router dropped every repair packet as ErrUnknownPacketType, so FEC
+		// repair never reached the receiver on ANY route (direct or multihop).
+		return r.dispatchToRouteGroup(ctx, packet)
 	case routing.DatagramPacket:
 		return r.handleDatagramPacket(ctx, packet)
 	case routing.TransportPingPacket, routing.TransportPongPacket,
@@ -332,6 +339,17 @@ func (r *router) forwardPacket(ctx context.Context, packet routing.Packet, rule 
 		// never decrypt, the seal is end-to-end.
 		var err error
 		p, err = routing.MakeDatagramPacket(rule.NextRouteID(), packet.Payload())
+		if err != nil {
+			return err
+		}
+	case routing.RepairPacket:
+		// FEC repair symbol (#4270): re-stamp the next-hop route ID and pass the
+		// block coordinates + symbol through unchanged. Without this an
+		// intermediate hits the default and DROPS the repair, so FEC delivered
+		// zero benefit (and pure overhead) on every MULTIHOP mux leg — the repair
+		// was emitted by the sender but never survived the first relay.
+		var err error
+		p, err = routing.MakeRepairPacket(rule.NextRouteID(), packet.RepairBlockID(), packet.RepairIndex(), packet.RepairSymLen(), packet.RepairSymbol())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The router never routed the FEC `RepairPacket` (#4270): `handleTransportPacket` had no case → `default: ErrUnknownPacketType` (dropped at destination AND every intermediary), and `forwardPacket` had no case → `can't be forwarded`. So FEC repair reached the receiver on NO real route — the in-process tests passed only by feeding the route group directly, bypassing the router.

Measured live: the FEC exit emitted **6.17 MB of repair** over a 74.7 MB multi-leg download (`fec_repair_bytes_sent`), the receiver saw `fec_repair_bytes_recv=0`, `fec_reconstructs=0` — FEC was **pure ~8% overhead, zero benefit** on every multihop leg. Fix: add `RepairPacket` to both switches — `dispatchToRouteGroup` forwards it when intermediary (re-stamping the next-hop route ID + passing the symbol through, like DataPacket/SACK) or delivers it to `handleRepairPacket` at the destination. Validated live by re-measuring `fec_repair_bytes_recv`/`fec_reconstructs` after deploy.