### PR TITLE
feat(router): RACK-TLP tail-loss probe + DSACK reorder-window adaptation

### DIFF
--- a/pkg/router/rack_tlp.go
+++ b/pkg/router/rack_tlp.go
@@ -1,0 +1,165 @@
+// Package router pkg/router/rack_tlp.go c2-net-routing
+package router
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// RACK-TLP (RFC 8985) completes the mux's loss recovery beyond the RTT-derived
+// retransmit threshold (rackThreshold, route_mux.go) with two pieces:
+//
+//   - Tail-Loss Probe (TLP): the SACK path only recovers a hole once a LATER
+//     sequence arrives to expose it. If the TAIL of a burst is lost there is no
+//     later sequence — the receiver's bitmap simply ends at the last seq it got,
+//     the sender treats the missing tail as still-in-flight, and the stream stalls
+//     until the retx buffer ages the entry out. TLP fixes this: after the sender
+//     goes idle for a probe timeout (PTO ≈ 2×maxLegRTT) with unacked data
+//     outstanding, it re-sends the tail sequence as a probe. That probe either
+//     fills the loss or draws a SACK that finally reports the gap, so normal
+//     recovery proceeds — turning a multi-hundred-ms stall into one PTO.
+//
+//   - DSACK reorder-window adaptation: when the receiver reports a DUPLICATE
+//     (a DSACK — see sackTracker), the sender learns it retransmitted a sequence
+//     that was merely reordered on a slower leg, not lost. It widens the reorder
+//     factor (rackFactor) so rackThreshold waits longer before the next
+//     retransmit; clean acks decay it back toward the static baseline. This is the
+//     closed loop that keeps the anti-spurious-retransmit threshold matched to the
+//     path's real reordering instead of a fixed guess.
+
+// DSACK reorder-factor adaptation bounds (milli-units: factor ×1000).
+const (
+	rackFactorMin     = int64(rackReorderFactor * 1000) // baseline (== 1.25×)
+	rackFactorMax     = 3000                            // cap the widening at 3.0× maxLegRTT
+	rackDSACKGrowStep = 250                             // widen per DSACK (a spurious retransmit observed)
+	rackDecayStep     = 25                              // narrow per clean SACK, back toward baseline
+)
+
+// Tail-Loss Probe timing bounds.
+const (
+	tlpPTOFactor     = 2.0                    // PTO ≈ this × slowest active-leg RTT (RFC 8985)
+	tlpMinPTO        = 100 * time.Millisecond // never probe sooner than this (anti-spurious)
+	tlpMaxPTO        = 2 * time.Second        // never wait longer than this before probing
+	tlpMaxProbes     = 2                      // consecutive probes per stall before deferring to other recovery
+	tlpCheckInterval = 100 * time.Millisecond // service-loop cadence (idle check; sends only when a probe is due)
+)
+
+// rackFactor returns the current DSACK-adapted reorder factor (slow-leg RTT is
+// multiplied by this in rackThreshold). Falls back to the static baseline if the
+// adaptive value was never initialized.
+func (m *routeMux) rackFactor() float64 {
+	v := atomic.LoadInt64(&m.rackFactorMilli)
+	if v <= 0 {
+		return rackReorderFactor
+	}
+	return float64(v) / 1000
+}
+
+// growRackFactor widens the reorder factor after a DSACK (the receiver saw a
+// duplicate ⇒ our retransmit was spurious ⇒ be more reorder-tolerant). Bounded at
+// rackFactorMax. Concurrency-safe (CAS loop).
+func (m *routeMux) growRackFactor(dsackSeq uint32) {
+	for {
+		cur := atomic.LoadInt64(&m.rackFactorMilli)
+		next := cur + rackDSACKGrowStep
+		if next > rackFactorMax {
+			next = rackFactorMax
+		}
+		if next == cur {
+			return
+		}
+		if atomic.CompareAndSwapInt64(&m.rackFactorMilli, cur, next) {
+			if m.logger != nil {
+				m.logger.Debugf("RACK: DSACK seq=%d (spurious retransmit) → reorder factor widened to %.2f×", dsackSeq, float64(next)/1000)
+			}
+			return
+		}
+	}
+}
+
+// decayRackFactor narrows the reorder factor one step toward the baseline on a
+// clean SACK (no duplicate reported), so a transient reordering episode widens the
+// window and then relaxes once the path settles. Never drops below the baseline.
+// Concurrency-safe (CAS loop).
+func (m *routeMux) decayRackFactor() {
+	for {
+		cur := atomic.LoadInt64(&m.rackFactorMilli)
+		if cur <= rackFactorMin {
+			return
+		}
+		next := cur - rackDecayStep
+		if next < rackFactorMin {
+			next = rackFactorMin
+		}
+		if atomic.CompareAndSwapInt64(&m.rackFactorMilli, cur, next) {
+			return
+		}
+	}
+}
+
+// onSACKReceived is the sender-side SACK entry point: it advances the ack-progress
+// edge (resetting the TLP probe budget when the contiguous point moves), adapts
+// the reorder factor from the DSACK signal, and returns the sequences to
+// retransmit. Replaces a bare processSACK call so all three effects stay in step.
+func (m *routeMux) onSACKReceived(lastContig uint32, words []uint64, dsackSeq uint32, hasDSACK bool) []uint32 {
+	if !m.sackEnabled || m.retxBuf == nil {
+		return nil
+	}
+	// Ack progress: the contiguous frontier moved, so the tail is advancing —
+	// clear the probe budget so a later stall is treated as a fresh event.
+	if prev := atomic.LoadUint32(&m.lastAckedContig); lastContig > prev {
+		atomic.StoreUint32(&m.lastAckedContig, lastContig)
+		atomic.StoreInt32(&m.tlpProbeCount, 0)
+	}
+	if hasDSACK {
+		m.growRackFactor(dsackSeq)
+	} else {
+		m.decayRackFactor()
+	}
+	return m.retxBuf.ProcessSACK(lastContig, words, m.rackThreshold())
+}
+
+// ptoInterval is the tail-loss probe timeout: how long the sender stays idle with
+// unacked data before it probes. Derived from the slowest active leg's RTT (a
+// frame should have been acked within one RTT + margin), floored/capped.
+func (m *routeMux) ptoInterval() time.Duration {
+	maxRtt := m.maxActiveLegRTTms()
+	if maxRtt <= 0 {
+		return rackDefaultNoRTT * 2 // no RTT measured yet: conservative
+	}
+	pto := time.Duration(maxRtt*tlpPTOFactor) * time.Millisecond
+	if pto < tlpMinPTO {
+		pto = tlpMinPTO
+	}
+	if pto > tlpMaxPTO {
+		pto = tlpMaxPTO
+	}
+	return pto
+}
+
+// tlpProbeSeq reports the tail sequence to probe now, or (0,false) if no probe is
+// due. A probe is due when SACK is on, unacked data is outstanding, the sender has
+// been idle at least a PTO, and the per-stall probe budget isn't exhausted. It
+// increments the probe counter as a side effect, so each due check yields exactly
+// one probe; the counter is reset by onSACKReceived when the ack frontier moves.
+func (m *routeMux) tlpProbeSeq(now time.Time) (uint32, bool) {
+	if !m.sackEnabled || m.retxBuf == nil {
+		return 0, false
+	}
+	tail, ok := m.retxBuf.MaxSeq()
+	if !ok {
+		return 0, false // nothing outstanding — no tail to probe
+	}
+	if atomic.LoadInt32(&m.tlpProbeCount) >= tlpMaxProbes {
+		return 0, false // budget spent; defer to reactive SACK / retx aging
+	}
+	last := atomic.LoadInt64(&m.lastSendNano)
+	if last == 0 {
+		return 0, false // nothing sent yet
+	}
+	if now.Sub(time.Unix(0, last)) < m.ptoInterval() {
+		return 0, false // not idle long enough
+	}
+	atomic.AddInt32(&m.tlpProbeCount, 1)
+	return tail, true
+}

--- a/pkg/router/rack_tlp_test.go
+++ b/pkg/router/rack_tlp_test.go
@@ -1,0 +1,213 @@
+// Package router pkg/router/rack_tlp_test.go c2-net-routing
+package router
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// setLegRTTs gives the mux n active legs with the given per-leg EWMA RTTs (ms).
+func setLegRTTs(m *routeMux, rtts []float64) {
+	m.growLegs(len(rtts))
+	m.legMu.Lock()
+	for i, r := range rtts {
+		m.legs[i].ecfRttMs = r
+	}
+	m.legMu.Unlock()
+}
+
+func TestPTOInterval(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("tlp-test")
+	m := newRouteMux(log, true)
+
+	// No RTT yet → conservative default (2× the no-RTT rack default).
+	if got, want := m.ptoInterval(), rackDefaultNoRTT*2; got != want {
+		t.Fatalf("no-RTT PTO = %v, want %v", got, want)
+	}
+
+	// PTO tracks 2× the slowest active leg's RTT.
+	setLegRTTs(m, []float64{50, 120, 300})
+	if got, want := m.ptoInterval(), time.Duration(300*tlpPTOFactor)*time.Millisecond; got != want {
+		t.Fatalf("PTO = %v, want %v (slowest 300ms × %.1f)", got, want, tlpPTOFactor)
+	}
+
+	// A very fast path floors (fresh mux: growLegs only grows, never shrinks).
+	mFast := newRouteMux(log, true)
+	setLegRTTs(mFast, []float64{2, 3})
+	if got := mFast.ptoInterval(); got != tlpMinPTO {
+		t.Fatalf("fast-path PTO = %v, want floor %v", got, tlpMinPTO)
+	}
+	// A very slow path caps.
+	mSlow := newRouteMux(log, true)
+	setLegRTTs(mSlow, []float64{5000})
+	if got := mSlow.ptoInterval(); got != tlpMaxPTO {
+		t.Fatalf("slow-path PTO = %v, want cap %v", got, tlpMaxPTO)
+	}
+}
+
+func TestTLPProbeSeq(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("tlp-test")
+	m := newRouteMux(log, true)
+	setLegRTTs(m, []float64{50}) // PTO = 100ms (floored)
+
+	now := time.Now()
+
+	// Nothing outstanding → no probe.
+	if _, due := m.tlpProbeSeq(now); due {
+		t.Fatal("probe due with empty retx buffer")
+	}
+
+	// Outstanding data, but the sender is NOT yet idle for a PTO → no probe.
+	m.retxBuf.Store(10, []byte("a"))
+	m.retxBuf.Store(11, []byte("b"))
+	m.retxBuf.Store(12, []byte("c")) // tail = 12
+	atomic.StoreInt64(&m.lastSendNano, now.UnixNano())
+	if _, due := m.tlpProbeSeq(now.Add(10 * time.Millisecond)); due {
+		t.Fatal("probe due before a full PTO of idle")
+	}
+
+	// Idle past the PTO → probe the TAIL sequence exactly.
+	seq, due := m.tlpProbeSeq(now.Add(m.ptoInterval() + time.Millisecond))
+	if !due {
+		t.Fatal("probe not due after idle PTO with outstanding data")
+	}
+	if seq != 12 {
+		t.Fatalf("probe seq = %d, want tail 12", seq)
+	}
+
+	// Probe budget: a second due check probes again, a third is refused.
+	if _, due := m.tlpProbeSeq(now.Add(time.Hour)); !due {
+		t.Fatal("second probe (within budget) should be due")
+	}
+	if _, due := m.tlpProbeSeq(now.Add(time.Hour)); due {
+		t.Fatalf("probe budget %d exceeded but still firing", tlpMaxProbes)
+	}
+
+	// Ack progress resets the budget → probing resumes.
+	m.onSACKReceived(9, nil, 0, false) // lastContig advances 0→9
+	if _, due := m.tlpProbeSeq(now.Add(time.Hour)); !due {
+		t.Fatal("probe should resume after ack-progress reset the budget")
+	}
+}
+
+func TestDSACKGrowDecay(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("tlp-test")
+	m := newRouteMux(log, true)
+
+	if got := atomic.LoadInt64(&m.rackFactorMilli); got != rackFactorMin {
+		t.Fatalf("initial reorder factor = %d, want baseline %d", got, rackFactorMin)
+	}
+
+	// Each DSACK widens by one grow step, capped at rackFactorMax.
+	m.growRackFactor(5)
+	if got, want := atomic.LoadInt64(&m.rackFactorMilli), rackFactorMin+rackDSACKGrowStep; got != want {
+		t.Fatalf("after 1 DSACK factor = %d, want %d", got, want)
+	}
+	for i := 0; i < 100; i++ {
+		m.growRackFactor(uint32(i))
+	}
+	if got := atomic.LoadInt64(&m.rackFactorMilli); got != rackFactorMax {
+		t.Fatalf("saturated factor = %d, want cap %d", got, rackFactorMax)
+	}
+
+	// Clean SACKs decay it back down, never below the baseline.
+	for i := 0; i < 1000; i++ {
+		m.decayRackFactor()
+	}
+	if got := atomic.LoadInt64(&m.rackFactorMilli); got != rackFactorMin {
+		t.Fatalf("decayed factor = %d, want baseline floor %d", got, rackFactorMin)
+	}
+}
+
+// TestDSACKWidensThreshold proves the closed loop: a DSACK widens the reorder
+// factor, which lengthens the RACK retransmit threshold on a fixed path.
+func TestDSACKWidensThreshold(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("tlp-test")
+	m := newRouteMux(log, true)
+	setLegRTTs(m, []float64{200}) // 200ms slow leg
+
+	base := m.rackThreshold()
+	// Feed a SACK carrying a DSACK → factor widens → threshold grows.
+	m.onSACKReceived(0, nil, 7, true)
+	widened := m.rackThreshold()
+	if !(widened > base) {
+		t.Fatalf("DSACK did not widen threshold: base=%v widened=%v", base, widened)
+	}
+	// A clean SACK decays it back toward the baseline.
+	m.onSACKReceived(0, nil, 0, false)
+	if got := m.rackThreshold(); got >= widened {
+		t.Fatalf("clean SACK did not decay threshold: was=%v now=%v", widened, got)
+	}
+}
+
+func TestSACKTrackerDSACK(t *testing.T) {
+	st := newSACKTracker()
+
+	// In-order delivery: no duplicate.
+	st.RecordReceived(1)
+	st.RecordReceived(2)
+	if _, ok := st.takeDSACK(); ok {
+		t.Fatal("DSACK reported on clean in-order stream")
+	}
+
+	// Re-receiving an already-delivered seq → DSACK for that seq.
+	st.RecordReceived(2)
+	seq, ok := st.takeDSACK()
+	if !ok || seq != 2 {
+		t.Fatalf("duplicate-of-delivered: DSACK = (%d,%v), want (2,true)", seq, ok)
+	}
+	// takeDSACK clears the pending flag (reported once).
+	if _, ok := st.takeDSACK(); ok {
+		t.Fatal("DSACK still pending after being taken")
+	}
+
+	// Re-receiving a buffered out-of-order seq → DSACK too.
+	st.RecordReceived(10) // gap: buffered out of order
+	st.RecordReceived(10) // duplicate of the buffered seq
+	seq, ok = st.takeDSACK()
+	if !ok || seq != 10 {
+		t.Fatalf("duplicate-of-buffered: DSACK = (%d,%v), want (10,true)", seq, ok)
+	}
+}
+
+// TestSACKPacketDSACKRoundTrip covers the wire format: a DSACK SACK round-trips,
+// a plain SACK reports no DSACK, and an old-format reader still reads the bitmap
+// unchanged from a DSACK-bearing packet (backward compatibility).
+func TestSACKPacketDSACKRoundTrip(t *testing.T) {
+	words := []uint64{0b1011, 0x00000000000000FF}
+	lastContig := uint32(4242)
+
+	// Plain SACK: no DSACK field.
+	plain := routing.MakeSACKPacket(1, lastContig, words)
+	if _, ok := plain.SACKDSACK(); ok {
+		t.Fatal("plain SACK reports a DSACK")
+	}
+
+	// DSACK SACK: round-trips seq, lastContig, and the bitmap.
+	d := routing.MakeSACKPacketWithDSACK(1, lastContig, words, 777)
+	if got := d.SACKLastContiguousSeq(); got != lastContig {
+		t.Fatalf("lastContig = %d, want %d", got, lastContig)
+	}
+	if seq, ok := d.SACKDSACK(); !ok || seq != 777 {
+		t.Fatalf("SACKDSACK = (%d,%v), want (777,true)", seq, ok)
+	}
+	gotWords := d.SACKWords()
+	if len(gotWords) != len(words) {
+		t.Fatalf("word count = %d, want %d", len(gotWords), len(words))
+	}
+	for i := range words {
+		if gotWords[i] != words[i] {
+			t.Fatalf("word[%d] = %x, want %x", i, gotWords[i], words[i])
+		}
+	}
+
+	// Backward compat: the trailing DSACK bytes must not corrupt a reader that
+	// only knows the bitmap (SACKWords reads exactly word_count words).
+	if len(d.SACKWords()) != len(words) {
+		t.Fatal("DSACK trailing field corrupted the bitmap read")
+	}
+}

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -3169,6 +3169,11 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 				if sack {
 					rg.logger.Debug("SACK retransmission enabled (both peers support CapSACK)")
 					go rg.servicePacketLoop("sack", rg.cfg.KeepAliveInterval/2, rg.sackServiceFn, nil)
+					// Tail-Loss Probe: re-send the in-flight tail after an idle PTO so a
+					// lost burst-tail (which the receiver never reports — its bitmap ends
+					// at the last seq it got) recovers in one PTO instead of stalling until
+					// the retx entry ages out (RFC 8985). Reuses the SACK retransmit path.
+					go rg.servicePacketLoop("tlp", tlpCheckInterval, rg.tlpServiceFn, nil)
 					// Proactive HoL retransmit reuses the SACK channel, so it is only
 					// enabled when SACK is too. Both peers must advertise CapHOLRetx;
 					// otherwise the group keeps the reactive SACK behavior.
@@ -3446,7 +3451,16 @@ func (rg *RouteGroup) sendSACK() error {
 	}
 
 	lastContig, words := rg.mux.generateSACK()
-	packet := routing.MakeSACKPacket(rule.NextRouteID(), lastContig, words)
+	// Attach a DSACK (duplicate-SACK) when the receiver saw a repeated sequence,
+	// so the sender can widen its RACK reorder window (it retransmitted too
+	// eagerly). Backward compatible: a peer without the field reads only the
+	// bitmap. No duplicate pending → a plain SACK, unchanged from before.
+	var packet routing.Packet
+	if dsackSeq, ok := rg.mux.takeDSACK(); ok {
+		packet = routing.MakeSACKPacketWithDSACK(rule.NextRouteID(), lastContig, words, dsackSeq)
+	} else {
+		packet = routing.MakeSACKPacket(rule.NextRouteID(), lastContig, words)
+	}
 	return rg.writePacket(context.Background(), tp, packet, rule.KeyRouteID())
 }
 
@@ -3458,9 +3472,12 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 
 	lastContig := packet.SACKLastContiguousSeq()
 	words := packet.SACKWords()
+	dsackSeq, hasDSACK := packet.SACKDSACK()
 
-	// Normal reactive retransmit: holes overdue past retxMinAge.
-	retxSeqs := rg.mux.processSACK(lastContig, words)
+	// Normal reactive retransmit: holes overdue past the RACK threshold. Also
+	// advances the ack-progress edge (resets the TLP probe budget) and adapts the
+	// reorder factor from the DSACK signal (widen on a duplicate, decay otherwise).
+	retxSeqs := rg.mux.onSACKReceived(lastContig, words, dsackSeq, hasDSACK)
 
 	// Proactive HoL retransmit (CapHOLRetx): the frontier-blocking seq (and the
 	// next few contiguous holes) retransmitted NOW on the fastest leg, bypassing
@@ -3553,6 +3570,9 @@ func (rg *RouteGroup) resendSeqs(seqs []uint32) error {
 			// retx selector picks fresh, mirroring the data path).
 			rg.mux.recordSent(leg, uint64(retxPacket.Size()))
 			rg.mux.recordRetransmit(leg) // separate loss signal for leg health
+			// A frame just went out (incl. a TLP probe) — restart the TLP idle
+			// timer so the next probe waits a fresh PTO rather than back-to-back.
+			atomic.StoreInt64(&rg.mux.lastSendNano, time.Now().UnixNano())
 		}
 	}
 	return nil
@@ -3565,6 +3585,26 @@ func (rg *RouteGroup) sackServiceFn(_ time.Duration) {
 	}
 	if err := rg.sendSACK(); err != nil {
 		rg.logger.WithError(err).Warn("Failed to send periodic SACK")
+	}
+}
+
+// tlpServiceFn is the tail-loss probe, run as a service loop. On each tick it asks
+// the mux whether a probe is due (idle ≥ PTO with unacked data and probe budget
+// left); if so it re-sends the in-flight tail sequence on the fastest live leg via
+// the shared retransmit path. The probe either fills a lost tail or draws a SACK
+// that reports the gap, unblocking normal recovery. A no-op whenever data is
+// flowing (the idle timer keeps resetting) or nothing is outstanding.
+func (rg *RouteGroup) tlpServiceFn(_ time.Duration) {
+	if rg.mux == nil || !rg.mux.sackEnabled {
+		return
+	}
+	seq, due := rg.mux.tlpProbeSeq(time.Now())
+	if !due {
+		return
+	}
+	rg.logger.Debugf("TLP: probing tail seq=%d after idle PTO", seq)
+	if err := rg.resendSeqs([]uint32{seq}); err != nil {
+		rg.logger.WithError(err).Debug("TLP: tail probe send failed")
 	}
 }
 

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -123,6 +123,18 @@ type routeMux struct {
 	writeSeq uint32 // atomic: next outgoing sequence number
 	tpIndex  uint32 // atomic: round-robin fallback index for transport selection
 
+	// RACK-TLP tail-loss probe + DSACK reorder-window adaptation (see rack_tlp.go).
+	// lastSendNano stamps the last DATA/retransmit frame put on the wire (the TLP
+	// idle timer reads it). tlpProbeCount is the number of consecutive tail probes
+	// fired since the last ack progress — bounded so a truly dead tail doesn't probe
+	// forever. rackFactorMilli is the DSACK-adapted reorder tolerance ×1000: a
+	// duplicate report from the receiver widens it (we retransmitted too eagerly),
+	// clean acks decay it back toward the static baseline. All atomic.
+	lastSendNano    int64
+	tlpProbeCount   int32
+	rackFactorMilli int64
+	lastAckedContig uint32 // atomic: highest SACK lastContiguous seen (ack-progress edge for TLP reset)
+
 	// lastSACKNano rate-limits receiver-side SACK feedback. Cross-leg
 	// reordering from latency skew makes nearly every packet arrive
 	// out-of-order, so firing a SACK per out-of-order packet would spawn a
@@ -271,6 +283,9 @@ func newRouteMux(logger *logging.Logger, sackEnabled bool) *routeMux {
 		// Proactive HoL retransmit tracker is always constructed; it is only
 		// consulted when holRetxEnabled is set at handshake (see hol_retx.go).
 		holRetx: newHolRetxTracker(),
+		// RACK reorder factor starts at the static baseline; DSACK feedback
+		// widens it and clean acks decay it back (see rack_tlp.go).
+		rackFactorMilli: int64(rackReorderFactor * 1000),
 	}
 	// Default every mux to ECF (Earliest Completion First). It only spills a
 	// frame onto a slower leg once the fastest leg is saturated (a full BDP in
@@ -794,6 +809,10 @@ func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte) (routing.Pa
 	// fast leg. Inert unless CapFEC was negotiated.
 	m.fecOnSend(seq, data)
 
+	// Stamp the TLP idle timer: new data just went out, so the tail-loss probe
+	// clock restarts. A probe only fires once this stays quiet for a PTO.
+	atomic.StoreInt64(&m.lastSendNano, time.Now().UnixNano())
+
 	return packet, seq, nil
 }
 
@@ -935,12 +954,24 @@ func (m *routeMux) generateSACK() (lastContig uint32, words []uint64) {
 	return m.sackTracker.GenerateSACK()
 }
 
-// processSACK processes a received SACK and returns sequences that need retransmission.
+// processSACK processes a received SACK and returns sequences that need
+// retransmission. Retained for callers/tests that don't carry the DSACK/ack-edge
+// side effects; the live receive path uses onSACKReceived (see rack_tlp.go).
 func (m *routeMux) processSACK(lastContig uint32, words []uint64) []uint32 {
 	if !m.sackEnabled || m.retxBuf == nil {
 		return nil
 	}
 	return m.retxBuf.ProcessSACK(lastContig, words, m.rackThreshold())
+}
+
+// takeDSACK returns a pending DSACK sequence (a duplicate the receiver saw) to
+// attach to the next outgoing SACK, clearing it so it is reported once. Returns
+// (0, false) when SACK is off or no duplicate is pending.
+func (m *routeMux) takeDSACK() (uint32, bool) {
+	if !m.sackEnabled || m.sackTracker == nil {
+		return 0, false
+	}
+	return m.sackTracker.takeDSACK()
 }
 
 // RACK-TLP retransmit-threshold bounds (RFC 8985 in spirit). Replaces the fixed
@@ -964,7 +995,28 @@ const (
 // floored/capped to avoid a self-amplifying early-retransmit storm or an
 // unbounded wait. Falls back to a conservative default until RTTs are known.
 func (m *routeMux) rackThreshold() time.Duration {
+	maxRtt := m.maxActiveLegRTTms()
+	if maxRtt <= 0 {
+		return rackDefaultNoRTT
+	}
+	th := time.Duration(maxRtt*m.rackFactor()) * time.Millisecond
+	if th < rackFloor {
+		th = rackFloor
+	}
+	if th > rackCeil {
+		th = rackCeil
+	}
+	return th
+}
+
+// maxActiveLegRTTms returns the slowest active (non-standby) leg's EWMA RTT in
+// milliseconds, or 0 when no leg has a measured RTT yet. It is the reordering-
+// window basis: a frame striped onto any active leg should arrive within the
+// slowest leg's RTT plus a margin, so both the RACK loss threshold and the TLP
+// probe timeout are derived from it.
+func (m *routeMux) maxActiveLegRTTms() float64 {
 	m.legMu.RLock()
+	defer m.legMu.RUnlock()
 	maxRtt := 0.0
 	for i, lc := range m.legs {
 		if lc == nil {
@@ -977,19 +1029,7 @@ func (m *routeMux) rackThreshold() time.Duration {
 			maxRtt = lc.ecfRttMs
 		}
 	}
-	m.legMu.RUnlock()
-
-	if maxRtt <= 0 {
-		return rackDefaultNoRTT
-	}
-	th := time.Duration(maxRtt*rackReorderFactor) * time.Millisecond
-	if th < rackFloor {
-		th = rackFloor
-	}
-	if th > rackCeil {
-		th = rackCeil
-	}
-	return th
+	return maxRtt
 }
 
 // getRetxPayload retrieves a stored payload for retransmission.

--- a/pkg/router/sack.go
+++ b/pkg/router/sack.go
@@ -37,6 +37,14 @@ type sackTracker struct {
 	lastContiguous uint32
 	highest        uint32 // highest sequence ever recorded (0 = none yet)
 	received       map[uint32]bool
+
+	// DSACK (duplicate-SACK, RFC 8985 §7.2): a sequence received AGAIN. On the
+	// mux's reliable, ordered legs a duplicate is almost always the sender's own
+	// spurious retransmit, so we surface the most recent one to the sender in the
+	// next SACK; the sender widens its RACK reorder window in response. dsackSeq
+	// holds it, dsackPending gates a single report (cleared once taken).
+	dsackSeq     uint32
+	dsackPending bool
 }
 
 func newSACKTracker() *sackTracker {
@@ -56,7 +64,19 @@ func (st *sackTracker) RecordReceived(seq uint32) (gapDetected bool) {
 	}
 
 	if seq <= st.lastContiguous {
-		return false // duplicate or old
+		// Already delivered in order, now arriving again → a duplicate. Report it
+		// as a DSACK so the sender learns its retransmit of this seq was spurious.
+		st.dsackSeq = seq
+		st.dsackPending = true
+		return false
+	}
+
+	if st.received[seq] {
+		// Duplicate of a still-buffered out-of-order seq → same DSACK signal. Not
+		// a new gap, so report no gap (the original already opened one).
+		st.dsackSeq = seq
+		st.dsackPending = true
+		return false
 	}
 
 	if seq == st.lastContiguous+1 {
@@ -120,6 +140,19 @@ func (st *sackTracker) GenerateSACK() (lastContiguous uint32, words []uint64) {
 		}
 	}
 	return lastContiguous, words
+}
+
+// takeDSACK returns a pending DSACK sequence (a duplicate the receiver saw) and
+// clears the pending flag, so each duplicate is reported to the sender at most
+// once. Returns (0, false) when no duplicate is pending.
+func (st *sackTracker) takeDSACK() (seq uint32, ok bool) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if !st.dsackPending {
+		return 0, false
+	}
+	st.dsackPending = false
+	return st.dsackSeq, true
 }
 
 // retxEntry holds a sent packet awaiting acknowledgment.
@@ -228,6 +261,27 @@ func (rb *retxBuffer) ProcessSACK(lastContiguous uint32, words []uint64, thresho
 	}
 
 	return retransmit
+}
+
+// MaxSeq returns the highest unacknowledged sequence still held (the in-flight
+// tail) and true, or (0, false) when the buffer is empty. It is the sequence a
+// tail-loss probe re-sends: if the tail of a burst was lost the receiver never
+// reports it (its bitmap ends at the last seq it actually got), so only a
+// sender-driven probe of this seq can elicit the SACK that recovers it.
+func (rb *retxBuffer) MaxSeq() (uint32, bool) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	if len(rb.entries) == 0 {
+		return 0, false
+	}
+	var max uint32
+	first := true
+	for s := range rb.entries {
+		if first || s > max {
+			max, first = s, false
+		}
+	}
+	return max, true
 }
 
 // Get returns the stored payload for a given sequence number, or nil.

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -211,6 +211,15 @@ const SACKMinPayloadSize = 5
 // variable-length body (see MakeSACKPacket).
 const SACKPayloadSize = 12
 
+// SACKDSACKFieldSize is the size of the optional trailing DSACK field appended by
+// MakeSACKPacketWithDSACK: [flag:1][dsackSeq:4 BE]. A peer that predates the field
+// reads exactly word_count words and ignores these trailing bytes.
+const SACKDSACKFieldSize = 5
+
+// sackDSACKFlag marks the trailing DSACK field as present (guards against a
+// zero-padded or truncated read being misparsed as a DSACK of seq 0).
+const sackDSACKFlag = 0x01
+
 // CloseCode represents close code for ClosePacket.
 type CloseCode byte
 
@@ -501,6 +510,22 @@ func MakeErrorPacket(id RouteID, errPayload []byte) (Packet, error) {
 // packets stop being stored for retransmission, and a later loss wedges the mux
 // stream permanently (the "carries-then-stalls" failure).
 func MakeSACKPacket(id RouteID, lastContiguousSeq uint32, words []uint64) Packet {
+	return makeSACKPacket(id, lastContiguousSeq, words, 0, false)
+}
+
+// MakeSACKPacketWithDSACK is MakeSACKPacket plus a trailing DSACK (duplicate-SACK)
+// field: dsackSeq is a sequence the receiver got AGAIN (a duplicate). On the mux's
+// reliable, ordered legs a duplicate is almost always the sender's own spurious
+// retransmit, so this tells the sender to WIDEN its RACK reorder window — it
+// retransmitted too eagerly (RFC 8985 §7.2 reorder-window adaptation). The field
+// is appended AFTER the received bitmap as [flag:1=0x01][dsackSeq:4 BE]; a peer
+// that predates it reads exactly word_count words (SACKWords) and ignores the
+// trailing bytes, so the packet stays backward compatible with no capability bit.
+func MakeSACKPacketWithDSACK(id RouteID, lastContiguousSeq uint32, words []uint64, dsackSeq uint32) Packet {
+	return makeSACKPacket(id, lastContiguousSeq, words, dsackSeq, true)
+}
+
+func makeSACKPacket(id RouteID, lastContiguousSeq uint32, words []uint64, dsackSeq uint32, dsack bool) Packet {
 	if len(words) > SACKMaxWords {
 		words = words[:SACKMaxWords]
 	}
@@ -510,6 +535,9 @@ func MakeSACKPacket(id RouteID, lastContiguousSeq uint32, words []uint64) Packet
 		words = words[:len(words)-1]
 	}
 	payloadSize := SACKMinPayloadSize + len(words)*8
+	if dsack {
+		payloadSize += SACKDSACKFieldSize
+	}
 	packet := make([]byte, PacketHeaderSize+payloadSize)
 
 	packet[PacketTypeOffset] = byte(SACKPacket)
@@ -519,6 +547,11 @@ func MakeSACKPacket(id RouteID, lastContiguousSeq uint32, words []uint64) Packet
 	packet[PacketPayloadOffset+4] = byte(len(words)) //nolint:gosec // len(words) <= SACKMaxWords (32), capped above
 	for w, word := range words {
 		binary.BigEndian.PutUint64(packet[PacketPayloadOffset+5+w*8:], word)
+	}
+	if dsack {
+		off := PacketPayloadOffset + 5 + len(words)*8
+		packet[off] = sackDSACKFlag
+		binary.BigEndian.PutUint32(packet[off+1:], dsackSeq)
 	}
 
 	return packet
@@ -547,6 +580,28 @@ func (p Packet) SACKWords() []uint64 {
 		words[w] = binary.BigEndian.Uint64(payload[5+w*8:])
 	}
 	return words
+}
+
+// SACKDSACK extracts the optional trailing DSACK (duplicate-SACK) sequence from a
+// SACK packet: the seq the receiver reported getting twice (see
+// MakeSACKPacketWithDSACK). Returns (seq, true) when present, (0, false) when the
+// SACK carries no DSACK field (the common case) or is truncated. The offset is
+// computed from the word_count byte, so it lands exactly past the bitmap the same
+// way SACKWords reads it.
+func (p Packet) SACKDSACK() (uint32, bool) {
+	payload := p.Payload()
+	if len(payload) < SACKMinPayloadSize {
+		return 0, false
+	}
+	n := int(payload[4])
+	if n > SACKMaxWords {
+		return 0, false
+	}
+	off := SACKMinPayloadSize + n*8
+	if len(payload) < off+SACKDSACKFieldSize || payload[off] != sackDSACKFlag {
+		return 0, false
+	}
+	return binary.BigEndian.Uint32(payload[off+1:]), true
 }
 
 // TransportPingPayloadSize is the size of a transport ping/pong payload (8 bytes for unix nano timestamp).


### PR DESCRIPTION
Completes RFC 8985 loss recovery on the mux, on top of the RTT-derived retransmit threshold merged in #4295.

**Tail-Loss Probe (TLP).** The SACK path only recovers a hole once a later sequence arrives to expose it. If the *tail* of a burst is lost there is no later sequence — the receiver's bitmap ends at the last seq it got, the sender treats the missing tail as still in flight, and the stream stalls until the retx entry ages out. TLP re-sends the in-flight tail after an idle probe timeout (PTO ≈ 2×slowest-leg RTT), which either fills the loss or draws a SACK that finally reports the gap. Probe budget is bounded per stall and reset on ack progress; it reuses the existing SACK retransmit path.

**DSACK reorder-window adaptation.** When the receiver reports a duplicate (a DSACK — on these reliable, ordered legs almost always our own spurious retransmit), the sender widens its reorder factor so the RACK threshold waits longer before the next retransmit; clean acks decay it back toward the static baseline. The DSACK rides an optional trailing field on the existing SACK packet (flag+seq after the bitmap); a peer that predates it reads only the bitmap, so the wire stays backward compatible with no new capability bit.

Both are inert unless SACK was negotiated. Tests cover PTO derivation/floor/cap, TLP due-conditions and budget reset, grow/decay bounds, the DSACK→threshold closed loop, receiver-side duplicate detection, and SACK-packet round-trip + backward-compat.