### PR TITLE
feat(router): signal mux leg standby/active to the peer (CapLegState)

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1628,9 +1628,15 @@ func (rg *RouteGroup) rotationServiceFn(_ time.Duration) {
 	if rg.mux != nil {
 		for _, idx := range action.PromoteFromStandby {
 			rg.mux.setLegStandby(idx, false)
+			// Tell the remote so it also promotes this leg into its send set.
+			rg.sendLegState(idx, false)
 		}
 		for _, idx := range action.DemoteToStandby {
 			rg.mux.setLegStandby(idx, true)
+			// Tell the remote so it stops striping its send traffic across this
+			// leg — the fix for the wide-mux download stall where the bulk-sending
+			// peer fanned data over every established leg, standby or not.
+			rg.sendLegState(idx, true)
 			demoted = true
 		}
 	}
@@ -2984,7 +2990,7 @@ func (rg *RouteGroup) sendHandshake(encrypt bool) error {
 		// it only ACTIVATES when the peer also advertises it (both ends on a build
 		// that has it), so an old peer simply never negotiates it and is
 		// unaffected. No config knob — on by default wherever both edges support it.
-		caps := routing.CapMux | routing.CapSACK | routing.CapHOLRetx | routing.CapFEC
+		caps := routing.CapMux | routing.CapSACK | routing.CapHOLRetx | routing.CapFEC | routing.CapLegState
 		var packet routing.Packet
 		if pfn := rg.perFrameNoiseCap(encrypt); pfn != 0 {
 			msg, mErr := rg.nextPerFrameNoiseMsg()
@@ -3121,6 +3127,8 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 		return rg.handleDataPacket(packet)
 	case routing.RepairPacket:
 		return rg.handleRepairPacket(packet)
+	case routing.LegStatePacket:
+		return rg.handleLegStatePacket(packet)
 	case routing.HandshakePacket:
 		// A handshake on an aux leg proves the peer registered that leg's
 		// rule, so it is safe to start sending on it. The primary leg's
@@ -3181,6 +3189,17 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 						rg.mux.holRetxEnabled = true
 						rg.logger.Debug("Proactive HoL retransmit enabled (both peers support CapHOLRetx)")
 					}
+				}
+
+				// Leg-state signaling negotiation. Both edges must advertise
+				// CapLegState; then a park/promote is mirrored to the remote so it
+				// stops striping its send traffic across a leg the other end parked
+				// (the wide-mux download stall). No new loop — it rides the existing
+				// rotation park/promote path. A peer without the bit never receives a
+				// LegStatePacket and keeps the send-side-only standby behavior.
+				if remoteCaps&routing.CapLegState != 0 {
+					rg.mux.legStateEnabled = true
+					rg.logger.Debug("Leg-state signaling enabled (both peers support CapLegState)")
 				}
 
 				// FEC negotiation. Requires CapMux (rg.mux set above); both edges
@@ -3415,6 +3434,64 @@ func (rg *RouteGroup) handleRepairPacket(packet routing.Packet) error {
 		}
 	}
 	return nil
+}
+
+// handleLegStatePacket mirrors a peer's leg active/standby decision onto this
+// side's mux, so a leg the peer parked is also parked HERE — i.e. this side stops
+// striping its send traffic across it. The leg is identified by the route ID the
+// packet arrived on (the peer sent it ON that leg), matched against the reverse
+// rules exactly like an aux-leg handshake (markLegReady). Ignored unless
+// CapLegState was negotiated. Never parks leg 0 (setLegStandby enforces that).
+func (rg *RouteGroup) handleLegStatePacket(packet routing.Packet) error {
+	if rg.mux == nil || !rg.mux.legStateEnabled {
+		return nil
+	}
+	standby := packet.LegStateStandby()
+	rid := packet.RouteID()
+	rg.mu.Lock()
+	idx := -1
+	for i, rule := range rg.rvs {
+		if rule != nil && rule.KeyRouteID() == rid {
+			idx = i
+			break
+		}
+	}
+	rg.mu.Unlock()
+	if idx < 0 {
+		return nil // no matching leg (already pruned / unknown route)
+	}
+	rg.mux.setLegStandby(idx, standby)
+	if rg.logger != nil {
+		rg.logger.Debugf("LegState: peer marked leg %d %s", idx, map[bool]string{true: "standby", false: "active"}[standby])
+	}
+	return nil
+}
+
+// sendLegState signals leg idx's new active/standby state to the remote so it
+// mirrors the parking on its send side (CapLegState). Sent ON the leg (its
+// forward rule + transport) so the remote identifies the leg by the route the
+// packet arrives on — the same identity an aux-leg handshake uses. Best-effort:
+// parking keeps the leg's rules and transport installed, so the signal still
+// rides a just-demoted leg. No-op unless CapLegState was negotiated.
+func (rg *RouteGroup) sendLegState(idx int, standby bool) {
+	if rg.mux == nil || !rg.mux.legStateEnabled {
+		return
+	}
+	rg.mu.Lock()
+	var tp *transport.ManagedTransport
+	var rule routing.Rule
+	if idx >= 0 && idx < len(rg.tps) && idx < len(rg.fwd) {
+		tp = rg.tps[idx]
+		rule = rg.fwd[idx]
+	}
+	rg.mu.Unlock()
+	if tp == nil || rule == nil {
+		return
+	}
+	packet := routing.MakeLegStatePacket(rule.NextRouteID(), standby)
+	if err := rg.writePacket(context.Background(), tp, packet, rule.KeyRouteID()); err != nil {
+		rg.logger.WithError(err).Debugf("LegState: failed to signal leg %d", idx)
+	}
 }
 
 func (rg *RouteGroup) handleErrorPacket(packet routing.Packet) error {

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -163,6 +163,14 @@ type routeMux struct {
 	holRetx        *holRetxTracker
 	holSACKNano    int64 // atomic: UnixNano of the last proactive HoL SACK we sent
 
+	// legStateEnabled is true when both peers advertised CapLegState. When set, a
+	// park/promote of a leg is signaled to the remote (LegStatePacket) so it
+	// mirrors the active/standby set on its send side — otherwise standby is a
+	// send-side-only decision and the bulk-sending peer stripes across every
+	// established leg, head-of-line-stalling the reorder frontier (the wide-mux
+	// download stall). See handleLegStatePacket / sendLegState in route_group.go.
+	legStateEnabled bool
+
 	// Per-frame noise (inverse-mux). When CapPerFrameNoise is negotiated the
 	// RouteGroup installs these: seal AEAD-encrypts each outgoing frame under
 	// its sequence-nonce (in wrapPayload, before retx storage so retransmits

--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -56,6 +56,13 @@ func (r *router) handleTransportPacket(ctx context.Context, packet routing.Packe
 		// router dropped every repair packet as ErrUnknownPacketType, so FEC
 		// repair never reached the receiver on ANY route (direct or multihop).
 		return r.dispatchToRouteGroup(ctx, packet)
+	case routing.LegStatePacket:
+		// Mux leg active/standby signal (CapLegState): same route-ID-driven path as
+		// data/repair — forwarded when this visor is an intermediary, else delivered
+		// to the destination route group, which mirrors the leg's state on its send
+		// side. Without this case an intermediary/destination drops it as
+		// ErrUnknownPacketType (the RepairPacket #4297 failure mode).
+		return r.dispatchToRouteGroup(ctx, packet)
 	case routing.DatagramPacket:
 		return r.handleDatagramPacket(ctx, packet)
 	case routing.TransportPingPacket, routing.TransportPongPacket,
@@ -353,6 +360,12 @@ func (r *router) forwardPacket(ctx context.Context, packet routing.Packet, rule 
 		if err != nil {
 			return err
 		}
+	case routing.LegStatePacket:
+		// Mux leg active/standby signal (CapLegState): re-stamp the next-hop route
+		// ID and pass the one state byte through. Without this an intermediate hits
+		// the default and DROPS the signal, so a multihop leg's parking never
+		// reaches the far sender (the RepairPacket #4297 failure mode).
+		p = routing.MakeLegStatePacket(rule.NextRouteID(), packet.LegStateStandby())
 	default:
 		return fmt.Errorf("packet of type %s can't be forwarded", packet.Type())
 	}

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -79,6 +79,8 @@ func (t PacketType) String() string {
 		return "TransportBwAck"
 	case RepairPacket:
 		return "Repair"
+	case LegStatePacket:
+		return "LegState"
 	default:
 		return fmt.Sprintf("Unknown(%d)", t)
 	}
@@ -139,6 +141,17 @@ const (
 	// symbol/block framing agnostic about WHO makes repair symbols so the hop-wise
 	// path stays open without a format change.
 	RepairPacket
+	// LegStatePacket signals a mux leg's active/standby state to the REMOTE end
+	// (route ID > 0, same route group as the leg it names — the packet is sent ON
+	// that leg, so the leg is identified by the route ID it arrives stamped with,
+	// exactly like an aux-leg HandshakePacket). Payload: one byte, 1 = standby,
+	// 0 = active. Standby is otherwise a purely send-side decision, so on a
+	// DOWNLOAD (the remote is the bulk sender) the remote would stripe across every
+	// established leg — including ones this side has parked — head-of-line-stalling
+	// the no-skip reorder buffer on the slowest. This packet mirrors the parking to
+	// the sender so both ends stripe over the same active set. Gated by CapLegState;
+	// a peer without it never receives one and keeps the send-side-only behavior.
+	LegStatePacket
 )
 
 // FECRepairHdr is the fixed prefix of a RepairPacket payload: blockID(4) + idx(1)
@@ -190,6 +203,14 @@ const (
 	// bound by the FAST legs, not the slow one. A peer without this bit never
 	// receives RepairPackets and falls back cleanly to reorder+SACK.
 	CapFEC uint16 = 1 << 5
+	// CapLegState: the peer supports leg active/standby signaling (LegStatePacket).
+	// When BOTH edges advertise it (and CapMux, which it requires), the side that
+	// parks/promotes a mux leg tells the other end, which mirrors the state on ITS
+	// send side — so on a download the bulk sender stripes only across the legs the
+	// receiver has kept active, instead of every established leg (the wide-mux
+	// head-of-line stall). A peer without this bit never receives one and keeps the
+	// prior send-side-only standby behavior.
+	CapLegState uint16 = 1 << 6
 )
 
 // SeqSize is the byte size of the sequence number prepended to DataPacket
@@ -447,6 +468,33 @@ func (p Packet) RepairSymLen() int {
 // RepairSymbol returns the repair symbol bytes of a RepairPacket.
 func (p Packet) RepairSymbol() []byte {
 	return p[PacketPayloadOffset+FECRepairHdr:]
+}
+
+// LegStatePayloadSize is the LegStatePacket payload: one byte (1=standby, 0=active).
+const LegStatePayloadSize = 1
+
+// MakeLegStatePacket constructs a LegStatePacket announcing that the leg it is
+// sent on is now standby (true) or active (false) on this side, so the remote can
+// mirror the state on its send side. id is the leg's next-hop route ID (the packet
+// is sent ON that leg, exactly like an aux-leg handshake, so the leg is identified
+// by the route it arrives on — no leg index is carried).
+func MakeLegStatePacket(id RouteID, standby bool) Packet {
+	packet := make([]byte, PacketHeaderSize+LegStatePayloadSize)
+	packet[PacketTypeOffset] = byte(LegStatePacket)
+	binary.BigEndian.PutUint32(packet[PacketRouteIDOffset:], uint32(id))
+	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], LegStatePayloadSize)
+	if standby {
+		packet[PacketPayloadOffset] = 1
+	}
+	return packet
+}
+
+// LegStateStandby reports whether a LegStatePacket announces standby (true) or
+// active (false). A malformed/empty payload reads as active (the safe default —
+// it never parks a leg the sender still wants to use).
+func (p Packet) LegStateStandby() bool {
+	payload := p.Payload()
+	return len(payload) >= LegStatePayloadSize && payload[0] == 1
 }
 
 // HandshakeCapabilities extracts the capability bitmap from an extended handshake payload.

--- a/pkg/routing/packet_test.go
+++ b/pkg/routing/packet_test.go
@@ -113,6 +113,25 @@ func TestPacketTypeStringDatagram(t *testing.T) {
 	assert.Equal(t, "Datagram", DatagramPacket.String())
 }
 
+func TestMakeLegStatePacket(t *testing.T) {
+	// Standby=true encodes a 1 byte; the type + route ID round-trip.
+	sb := MakeLegStatePacket(7, true)
+	assert.Equal(t, LegStatePacket, sb.Type())
+	assert.Equal(t, "LegState", sb.Type().String())
+	assert.Equal(t, RouteID(7), sb.RouteID())
+	assert.Equal(t, uint16(LegStatePayloadSize), sb.Size())
+	assert.True(t, sb.LegStateStandby())
+
+	// Active=false encodes a 0 byte.
+	act := MakeLegStatePacket(7, false)
+	assert.False(t, act.LegStateStandby())
+
+	// A truncated/empty payload reads as active (the safe default — never parks a
+	// leg the sender still wants).
+	var empty Packet = []byte{byte(LegStatePacket), 0, 0, 0, 7, 0, 0}
+	assert.False(t, empty.LegStateStandby())
+}
+
 func TestMakePingPacket(t *testing.T) {
 	staticTime, _ := time.Parse(time.RFC3339, "2012-11-01T22:08:41+00:00") //nolint:errcheck
 	timestamp := staticTime.UTC().UnixNano() / int64(time.Millisecond)


### PR DESCRIPTION
Fixes the wide-mux download stall — the multi-leg instability that has been masking clean FEC measurements.

**Root cause.** Warm-standby was a purely *send-side* decision. `SetRotation` (which parks newly-grown aux legs into warm standby) is wired only on the **dial** side, so the **accept** side (a proxy exit) never learns a leg is standby and keeps every established leg in its active send set. On a download the exit is the bulk sender, so it fanned the transfer across all of them — dozens of 2-hop legs of wildly mixed latency (measured 33 ms to 315 ms on one exit) — and the receiver's no-skip reorder buffer head-of-line-stalled on the slowest, truncating the transfer. Confirmed live: capping the *receiver's* own active width changed nothing, because the receiver isn't the sender on a download.

**Fix.** Add `CapLegState` and a `LegStatePacket` (one byte: standby/active) sent *on* the leg it names, so the leg is identified by the route it arrives on — exactly like an aux-leg handshake. When a leg is parked or promoted, the state is mirrored to the peer, which parks/promotes the same leg on its send side, so both ends stripe over the same active set. It is routed and forwarded through intermediaries the same way as `DataPacket`/`RepairPacket` (a missing forward case would drop it at a relay — the #4297 failure mode).

**Compatibility.** Both edges must advertise `CapLegState`, so an old peer never receives one and keeps the prior send-side-only behavior. The end-to-end effect requires both endpoints (and the transited relays) on this build; until they update, the signal degrades to a no-op, never a break.

Tests cover the `LegStatePacket` round-trip, type string, and empty-payload-reads-active. Full router + routing suites pass; lint clean.