### PR TITLE
fix(router): signal a leg's BORN-standby state to the peer (CapLegState gap)

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -3139,13 +3139,28 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 		if rg.mux != nil {
 			rg.mu.Lock()
 			rid := packet.RouteID()
+			readyLeg := -1
 			for i, rule := range rg.rvs {
 				if rule != nil && rule.KeyRouteID() == rid {
 					rg.mux.markLegReady(i)
+					readyLeg = i
 					break
 				}
 			}
 			rg.mu.Unlock()
+			// Signal the just-ready leg's BORN-standby state to the peer. An aux
+			// leg grown into the warm pool (standbyNewLegs) is standby WITHOUT ever
+			// passing through the rotation engine's demote path — the only place
+			// sendLegState was previously called — so the peer (accept side, no
+			// standby of its own) kept striping its send traffic across it. Now that
+			// the leg's rules are peer-confirmed (this handshake), tell the peer to
+			// park it too, so the bulk-sending direction is bounded to the active
+			// set. Only signals standby legs; leg 0 / active legs are the peer's
+			// default, and the accept side (all-active) never enters this branch.
+			// Sent after the rg.mu unlock — sendLegState takes rg.mu itself.
+			if readyLeg > 0 && rg.mux.isLegStandby(readyLeg) {
+				rg.sendLegState(readyLeg, true)
+			}
 		}
 		firstHandshake := false
 		rg.handshakeProcessedOnce.Do(func() {


### PR DESCRIPTION
Follow-up to #4300. That PR signaled leg standby/active only on the rotation engine's demote/promote transitions. But aux legs grown into the warm pool enter standby *at birth* via `standbyNewLegs` — they never pass through the demote path — so their standby state was never sent to the peer. The accept side (a proxy exit, which has no standby of its own) therefore kept every such leg in its active send set and striped downloads across them.

Measured with per-transport (`transport_id`-keyed) attribution on a completed 3 MB download: the payload spread over **8 distinct standby legs** (4.29 MB received for a 3 MB payload). So the direction was never actually bounded to the active set.

Fix: signal the leg's standby state at the aux-leg handshake — the point its rules are peer-confirmed (`mux.markLegReady`) — so a born-standby leg tells the peer to park it too. Only standby legs signal; leg 0 and active legs are the peer's default, and the accept side (all-active) never enters the branch. The exit already honors incoming `LegStatePacket` (`handleLegStatePacket`, #4300), so this is a dialer-side fix that needs no change on the exit.