### PR TITLE
feat(router): per-leg unique-payload counter for confound-free per-direction telemetry

### DIFF
--- a/pkg/router/fec_mux_integration_test.go
+++ b/pkg/router/fec_mux_integration_test.go
@@ -65,7 +65,7 @@ func TestFECMuxWiredReconstructsSlowLegFrame(t *testing.T) {
 			continue
 		}
 		p := packets[i]
-		delivered, _ := recv.deliverData(p.SequenceNumber(), p.DataPayloadAfterSeq())
+		delivered, _ := recv.deliverData(-1, p.SequenceNumber(), p.DataPayloadAfterSeq())
 		got = append(got, delivered...)
 	}
 	// HoL proof: only the contiguous prefix before the gap (0,1,2) came out.
@@ -102,7 +102,7 @@ func TestFECMuxWiredInertWhenDisabled(t *testing.T) {
 		plain[i] = []byte(fmt.Sprintf("plain-%02d", i))
 		pkt, _, err := send.wrapPayload(routeID, plain[i])
 		require.NoError(t, err)
-		delivered, _ := recv.deliverData(pkt.SequenceNumber(), pkt.DataPayloadAfterSeq())
+		delivered, _ := recv.deliverData(-1, pkt.SequenceNumber(), pkt.DataPayloadAfterSeq())
 		require.Len(t, delivered, 1, "in-order delivery, one frame at a time")
 		require.Equal(t, plain[i], delivered[0])
 	}
@@ -137,7 +137,7 @@ func TestFECMuxTailFlushProtectsPartialBlock(t *testing.T) {
 	// helper: collect only non-empty delivered frames (the mux loop filters empties)
 	var got [][]byte
 	deliver := func(pkt routing.Packet) {
-		d, _ := recv.deliverData(pkt.SequenceNumber(), pkt.DataPayloadAfterSeq())
+		d, _ := recv.deliverData(-1, pkt.SequenceNumber(), pkt.DataPayloadAfterSeq())
 		for _, x := range d {
 			if len(x) == 0 {
 				continue

--- a/pkg/router/leg_payload_test.go
+++ b/pkg/router/leg_payload_test.go
@@ -1,0 +1,69 @@
+// Package router pkg/router/leg_payload_test.go c2-net-routing
+package router
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestLegPayloadAttribution verifies per-leg payloadBytes credits each sequence's
+// unique payload to the leg it FIRST arrived on, and a retransmit of an
+// already-seen seq on another leg is NOT double-counted — so the per-leg sum
+// equals the unique-payload total (the confound-free per-direction basis).
+func TestLegPayloadAttribution(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("legpayload-test")
+	m := newRouteMux(log, true)
+	m.growLegs(3)
+
+	p := func(n int) []byte { b := make([]byte, n); return b }
+
+	// Unique seqs arrive spread across legs 0,1,2.
+	m.deliverData(0, 0, p(100)) // leg 0
+	m.deliverData(1, 1, p(100)) // leg 1
+	m.deliverData(2, 2, p(100)) // leg 2
+	m.deliverData(1, 3, p(100)) // leg 1 again
+	// Retransmit of seq 1 arrives on leg 2 — already seen, must NOT be credited.
+	m.deliverData(2, 1, p(100))
+
+	stats := m.snapshotLegs()
+	got := map[int]uint64{}
+	var sum uint64
+	for _, s := range stats {
+		got[s.Index] = s.PayloadBytes
+		sum += s.PayloadBytes
+	}
+
+	// leg0: seq0 (100). leg1: seq1 + seq3 (200). leg2: seq2 (100); the seq-1
+	// retransmit on leg2 is a duplicate → not counted.
+	if got[0] != 100 {
+		t.Errorf("leg0 payloadBytes = %d, want 100", got[0])
+	}
+	if got[1] != 200 {
+		t.Errorf("leg1 payloadBytes = %d, want 200", got[1])
+	}
+	if got[2] != 100 {
+		t.Errorf("leg2 payloadBytes = %d, want 100 (retransmit of seq1 excluded)", got[2])
+	}
+	// Sum equals the 4 UNIQUE seqs' payload (400), not the 5 arrivals (500).
+	if sum != 400 {
+		t.Fatalf("total payloadBytes = %d, want 400 (unique payload, dup excluded)", sum)
+	}
+}
+
+// TestLegPayloadNegativeLegSkips confirms a negative leg index skips attribution
+// (the callers/tests that have no leg context), without affecting delivery.
+func TestLegPayloadNegativeLegSkips(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("legpayload-test")
+	m := newRouteMux(log, true)
+	m.growLegs(2)
+
+	if d, _ := m.deliverData(-1, 0, []byte("hello")); len(d) != 1 || string(d[0]) != "hello" {
+		t.Fatalf("delivery broke with leg=-1: %v", d)
+	}
+	for _, s := range m.snapshotLegs() {
+		if s.PayloadBytes != 0 {
+			t.Fatalf("leg %d credited %d despite leg=-1", s.Index, s.PayloadBytes)
+		}
+	}
+}

--- a/pkg/router/perframe_noise_test.go
+++ b/pkg/router/perframe_noise_test.go
@@ -73,7 +73,7 @@ func TestPerFrameMuxDataPathRoundTrip(t *testing.T) {
 	var got [][]byte
 	for _, idx := range order {
 		p := packets[idx]
-		delivered, _ := recv.deliverData(p.SequenceNumber(), p.DataPayloadAfterSeq())
+		delivered, _ := recv.deliverData(-1, p.SequenceNumber(), p.DataPayloadAfterSeq())
 		got = append(got, delivered...)
 	}
 	require.Len(t, got, n, "every frame must eventually be delivered")
@@ -90,7 +90,7 @@ func TestPerFrameMuxDataPathRoundTrip(t *testing.T) {
 	bad, _, err := send.wrapPayload(routeID, []byte("attacker"))
 	require.NoError(t, err)
 	// reset recv2 to expect seq 0
-	delivered, _ := recv2.deliverData(bad.SequenceNumber()+1000, bad.DataPayloadAfterSeq())
+	delivered, _ := recv2.deliverData(-1, bad.SequenceNumber()+1000, bad.DataPayloadAfterSeq())
 	require.Empty(t, delivered, "frame that fails AEAD open must not be delivered")
 }
 

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -3336,12 +3336,14 @@ func (rg *RouteGroup) handleDataPacket(packet routing.Packet) (err error) {
 	// each leg has its own consume rule). The lookup is O(legs)
 	// but legs is small (typically 1-16) and this only runs for
 	// data packets after we've already paid for noise decryption.
+	arrivalLeg := -1
 	if rg.mux != nil {
 		rg.mu.Lock()
 		rid := packet.RouteID()
 		for i, rule := range rg.rvs {
 			if rule != nil && rule.KeyRouteID() == rid {
 				rg.mux.recordRecv(i, uint64(packet.Size()))
+				arrivalLeg = i
 				// Inbound traffic on leg i proves the peer registered its
 				// rule for this leg, so it is now safe to send on it.
 				rg.mux.markLegReady(i)
@@ -3355,7 +3357,9 @@ func (rg *RouteGroup) handleDataPacket(packet routing.Packet) (err error) {
 		seq := packet.SequenceNumber()
 		data := packet.DataPayloadAfterSeq()
 
-		delivered, gapDetected := rg.mux.deliverData(seq, data)
+		// arrivalLeg lets deliverData credit this leg's UNIQUE payload share
+		// (first arrival of a seq), the confound-free per-direction attribution.
+		delivered, gapDetected := rg.mux.deliverData(arrivalLeg, seq, data)
 
 		// A gap is the normal case for mux (legs interleave), so rate-limit the
 		// SACK: without this, latency-skew reordering fires a SACK goroutine per

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -33,6 +33,12 @@ type LegStats struct {
 	// not what the peer said it sent.
 	RecvBytes   uint64
 	RecvPackets uint64
+	// PayloadBytes is the UNIQUE in-order payload this leg delivered (each seq
+	// counted once, on the leg it first arrived on) — retransmits/duplicates
+	// excluded, so the per-leg values sum to the transfer size and give a
+	// confound-free per-direction attribution (which legs carried the download vs
+	// the upload), unlike RecvBytes which includes retransmit/duplicate inflation.
+	PayloadBytes uint64
 	// Retransmits is how many SACK retransmit packets THIS leg has
 	// carried. A high retransmits:sentPackets ratio marks a lossy leg —
 	// the signal a routing policy needs to shed lossy intermediates and
@@ -74,6 +80,13 @@ type legCounters struct {
 	recvBytes   uint64 // atomic
 	recvPackets uint64 // atomic
 	retransmits uint64 // atomic
+	// payloadBytes is the UNIQUE in-order payload this leg delivered: each
+	// sequence credited once, to the leg it FIRST arrived on. Unlike recvBytes
+	// (every inbound frame, incl. retransmits/duplicates), a retransmit of a seq
+	// already seen on another leg is NOT counted, so the per-leg payloadBytes sum
+	// equals the transfer size and cleanly attributes which legs carried a
+	// direction's data — the confound-free basis for per-direction leg telemetry.
+	payloadBytes uint64 // atomic
 	// lastTotalBytes snapshots sentBytes+recvBytes at the previous
 	// capacity-weight rebuild; the delta since then is this leg's
 	// recent throughput, used by WeightModeCapacity. Touched only
@@ -689,6 +702,19 @@ func (m *routeMux) recordRecv(idx int, n uint64) {
 	m.legMu.RUnlock()
 }
 
+// recordPayload atomically credits leg idx with n bytes of UNIQUE in-order
+// payload (a seq's first arrival). Same bounds-check semantics as recordRecv.
+func (m *routeMux) recordPayload(idx int, n uint64) {
+	if idx < 0 {
+		return
+	}
+	m.legMu.RLock()
+	if idx < len(m.legs) {
+		atomic.AddUint64(&m.legs[idx].payloadBytes, n)
+	}
+	m.legMu.RUnlock()
+}
+
 // recordRetransmit atomically increments the retransmit counter for leg
 // idx (the leg that carried a SACK retransmit). The retransmitted bytes
 // are still recorded via recordSent; this is the separate loss signal.
@@ -737,6 +763,7 @@ func (m *routeMux) snapshotLegs() []LegStats {
 			SentPackets:    atomic.LoadUint64(&c.sentPackets),
 			RecvBytes:      recv,
 			RecvPackets:    atomic.LoadUint64(&c.recvPackets),
+			PayloadBytes:   atomic.LoadUint64(&c.payloadBytes),
 			Retransmits:    atomic.LoadUint64(&c.retransmits),
 			GoodputUpBps:   c.goodputUpBps,
 			GoodputDownBps: c.goodputDownBps,
@@ -827,7 +854,13 @@ func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte) (routing.Pa
 // deliverData inserts a received sequenced packet into the reorder buffer
 // and returns any payloads that are now deliverable in order.
 // Also tracks the sequence for SACK generation.
-func (m *routeMux) deliverData(seq uint32, data []byte) (delivered [][]byte, gapDetected bool) {
+//
+// leg is the arrival leg index (the transport this frame came in on). A seq seen
+// here for the FIRST time credits that leg's payloadBytes with the frame's app
+// payload — so per-leg payloadBytes attributes the transfer's unique payload to
+// the legs that actually carried it, retransmits/duplicates excluded. Pass a
+// negative leg to skip attribution (callers/tests without a leg context).
+func (m *routeMux) deliverData(leg int, seq uint32, data []byte) (delivered [][]byte, gapDetected bool) {
 	// FEC: record the on-wire (pre-open) payload so a sibling in this block can be
 	// reconstructed if it is late/lost on a slow leg. Inert unless CapFEC
 	// negotiated. Must run BEFORE open — reconstruction reproduces the on-wire
@@ -848,6 +881,24 @@ func (m *routeMux) deliverData(seq uint32, data []byte) (delivered [][]byte, gap
 			return nil, false
 		}
 		data = pt
+	}
+
+	// Attribute UNIQUE payload to the arrival leg: credit this leg only the FIRST
+	// time a seq arrives, so a retransmit of a seq already seen on another leg is
+	// not double-counted and the per-leg payloadBytes sum equals the transfer
+	// size. Already-delivered is seq < reorderBuf.NextSeq (no seq-0 ambiguity);
+	// already-buffered-out-of-order is the received set. Checked BEFORE
+	// RecordReceived/Insert record this seq.
+	if leg >= 0 {
+		isNew := true
+		if m.reorderBuf != nil && seq < m.reorderBuf.NextSeq() {
+			isNew = false // already delivered
+		} else if m.sackTracker != nil && m.sackTracker.alreadyBuffered(seq) {
+			isNew = false // already buffered out of order
+		}
+		if isNew {
+			m.recordPayload(leg, uint64(len(data)))
+		}
 	}
 
 	// Track for SACK generation

--- a/pkg/router/route_mux_e2e_test.go
+++ b/pkg/router/route_mux_e2e_test.go
@@ -42,7 +42,7 @@ func TestMux_InOrderDelivery(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		delivered, _ := recv.deliverData(seq, payload)
+		delivered, _ := recv.deliverData(-1, seq, payload)
 		collect(&got, delivered)
 	}
 	if len(got) != 200 {
@@ -85,12 +85,12 @@ func TestMux_InterleavedLegs(t *testing.T) {
 	ei, oi := 0, 0
 	for ei < len(evens) || oi < len(odds) {
 		for b := 0; b < 4 && ei < len(evens); b++ {
-			d, _ := recv.deliverData(evens[ei].seq, evens[ei].data)
+			d, _ := recv.deliverData(-1, evens[ei].seq, evens[ei].data)
 			collect(&got, d)
 			ei++
 		}
 		for b := 0; b < 4 && oi < len(odds); b++ {
-			d, _ := recv.deliverData(odds[oi].seq, odds[oi].data)
+			d, _ := recv.deliverData(-1, odds[oi].seq, odds[oi].data)
 			collect(&got, d)
 			oi++
 		}
@@ -135,7 +135,7 @@ func TestMux_RecoversLostPacketViaRetx(t *testing.T) {
 		if p.seq == lost {
 			continue // simulate loss
 		}
-		d, _ := recv.deliverData(p.seq, p.data)
+		d, _ := recv.deliverData(-1, p.seq, p.data)
 		collect(&got, d)
 	}
 	// At this point only seqs 0..4 are deliverable; 6..19 are buffered behind
@@ -151,7 +151,7 @@ func TestMux_RecoversLostPacketViaRetx(t *testing.T) {
 		t.Fatalf("retx buffer dropped lost seq %d — sender cannot recover it", lost)
 	}
 	// Retransmit it.
-	d, _ := recv.deliverData(lost, retx)
+	d, _ := recv.deliverData(-1, lost, retx)
 	collect(&got, d)
 
 	if len(got) != 20 {

--- a/pkg/router/route_mux_helpers_test.go
+++ b/pkg/router/route_mux_helpers_test.go
@@ -77,15 +77,15 @@ func TestMuxGapAge(t *testing.T) {
 	require.Zero(t, m.gapAge(), "fresh mux has no gap")
 
 	// seq 0 is expected next; delivering seq 2 opens a frontier gap at seq 0.
-	delivered, gap := m.deliverData(2, []byte("c"))
+	delivered, gap := m.deliverData(-1, 2, []byte("c"))
 	require.Empty(t, delivered, "out-of-order packet is held, not delivered")
 	require.True(t, gap, "SACK tracker reports the gap")
 	require.Greater(t, m.gapAge(), time.Duration(0), "an open gap has a non-zero age")
 
 	// Fill the gap: seq 0 then seq 1 drains 0,1,2 in order and closes the gap.
-	d0, _ := m.deliverData(0, []byte("a"))
+	d0, _ := m.deliverData(-1, 0, []byte("a"))
 	require.Equal(t, [][]byte{[]byte("a")}, d0)
-	d1, _ := m.deliverData(1, []byte("b"))
+	d1, _ := m.deliverData(-1, 1, []byte("b"))
 	require.Equal(t, [][]byte{[]byte("b"), []byte("c")}, d1)
 	require.Zero(t, m.gapAge(), "gap closed once contiguous again")
 }
@@ -134,8 +134,8 @@ func TestMuxSACKPathEnabled(t *testing.T) {
 	require.Nil(t, m.getRetxPayload(99), "unknown seq has no stored payload")
 
 	// The receiver has seen seq 0 and 1: generate a SACK and feed it back.
-	m.deliverData(0, []byte("hello"))
-	m.deliverData(1, []byte("world"))
+	m.deliverData(-1, 0, []byte("hello"))
+	m.deliverData(-1, 1, []byte("world"))
 	lastContig, words := m.generateSACK()
 	require.EqualValues(t, 1, lastContig)
 

--- a/pkg/router/sack.go
+++ b/pkg/router/sack.go
@@ -53,6 +53,17 @@ func newSACKTracker() *sackTracker {
 	}
 }
 
+// alreadyBuffered reports whether seq is already held out-of-order in the
+// received set (a buffered duplicate). Read-only; the contiguous/delivered check
+// is done separately against the reorder buffer's NextSeq (which, unlike
+// lastContiguous, has no seq-0-vs-nothing ambiguity). Used to credit a leg's
+// UNIQUE payload only on a seq's FIRST arrival.
+func (st *sackTracker) alreadyBuffered(seq uint32) bool {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return st.received[seq]
+}
+
 // RecordReceived records that seq has been received. Returns true if this
 // created an out-of-order gap (caller should trigger immediate SACK).
 func (st *sackTracker) RecordReceived(seq uint32) (gapDetected bool) {

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -169,6 +169,7 @@ func muxRouteGroupInfoFrom(infos []router.MuxInfo) []MuxRouteGroupInfo {
 				SentPackets:    leg.SentPackets,
 				RecvBytes:      leg.RecvBytes,
 				RecvPackets:    leg.RecvPackets,
+				PayloadBytes:   leg.PayloadBytes,
 				Retransmits:    leg.Retransmits,
 				GoodputBps:     leg.GoodputBps,
 				GoodputUpBps:   leg.GoodputUpBps,

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -345,6 +345,11 @@ type MuxLegInfo struct {
 	SentPackets    uint64  `json:"sent_packets"`
 	RecvBytes      uint64  `json:"recv_bytes"`
 	RecvPackets    uint64  `json:"recv_packets"`
+	// PayloadBytes is the UNIQUE in-order payload this leg delivered (each seq
+	// counted once, retransmits/duplicates excluded) — so per-leg values sum to
+	// the transfer size and cleanly attribute which legs carried a direction's
+	// data, unlike RecvBytes which includes retransmit inflation.
+	PayloadBytes uint64 `json:"payload_bytes"`
 	// Retransmits is SACK retransmit packets carried by this leg (loss
 	// signal). Alive/Standby are the leg's gate_state: Alive=false once the
 	// transport is closed; Standby=true for a warm standby (rules kept,


### PR DESCRIPTION
Attributing which legs carry a direction's data from the existing `recv_bytes` counter is confounded: it counts every inbound frame — retransmits and duplicates included — so a lossy multi-leg download inflates far past the payload (measured ~8–13× on a churny mux) and per-leg shares can't be trusted.

Add `payload_bytes` per leg: each sequence credited exactly once, to the leg it **first** arrived on. A retransmit of a seq already delivered (`seq < reorderBuf.NextSeq`) or already buffered out of order (the received set) is not counted, so the per-leg `payload_bytes` **sum equals the transfer size** and the distribution is a clean basis for per-direction leg attribution. Newness is checked before `RecordReceived`/`Insert` record the seq; the delivered check uses the reorder buffer's `NextSeq`, which — unlike `lastContiguous` — has no seq-0-vs-nothing ambiguity. Surfaced in `visor state .mux_route_groups[].legs[].payload_bytes`.

`deliverData` now takes the arrival leg index (resolved from the reverse rule in `handleDataPacket`); a negative leg skips attribution (callers/tests without a leg context). Tests cover first-arrival crediting, dedup of a cross-leg retransmit, the sum invariant, and the negative-leg skip. Full router + visor suites pass; lint clean.