### PR TITLE
feat(router): unidirectional per-leg send selection (CapUniDir)

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -2990,7 +2990,7 @@ func (rg *RouteGroup) sendHandshake(encrypt bool) error {
 		// it only ACTIVATES when the peer also advertises it (both ends on a build
 		// that has it), so an old peer simply never negotiates it and is
 		// unaffected. No config knob — on by default wherever both edges support it.
-		caps := routing.CapMux | routing.CapSACK | routing.CapHOLRetx | routing.CapFEC | routing.CapLegState
+		caps := routing.CapMux | routing.CapSACK | routing.CapHOLRetx | routing.CapFEC | routing.CapLegState | routing.CapUniDir
 		var packet routing.Packet
 		if pfn := rg.perFrameNoiseCap(encrypt); pfn != 0 {
 			msg, mErr := rg.nextPerFrameNoiseMsg()
@@ -3215,6 +3215,18 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 				if remoteCaps&routing.CapLegState != 0 {
 					rg.mux.legStateEnabled = true
 					rg.logger.Debug("Leg-state signaling enabled (both peers support CapLegState)")
+				}
+
+				// Unidirectional send selection negotiation. Both edges must
+				// advertise CapUniDir; then each end restricts its own send to legs
+				// matching its direction (initiator→direct upload, acceptor→multihop
+				// download by default), so the two directions ride disjoint legs
+				// instead of both striping every leg. Local decision from role + leg
+				// directness; the endpoints identify a direct leg (its transport's
+				// remote is one of them).
+				if remoteCaps&routing.CapUniDir != 0 {
+					rg.mux.setDirectional(rg.initiator, rg.desc.DstPK(), rg.desc.SrcPK())
+					rg.logger.Debug("Unidirectional send selection enabled (both peers support CapUniDir)")
 				}
 
 				// FEC negotiation. Requires CapMux (rg.mux set above); both edges

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/transport"
@@ -184,6 +185,19 @@ type routeMux struct {
 	// download stall). See handleLegStatePacket / sendLegState in route_group.go.
 	legStateEnabled bool
 
+	// Unidirectional per-leg send selection (CapUniDir, see unidir.go). When
+	// directional is set (both peers advertised CapUniDir), each end restricts its
+	// OWN send to legs matching its direction: the initiator uploads on the DIRECT
+	// (1-hop) leg, the acceptor downloads on the MULTIHOP legs. flipped swaps that
+	// mapping (heavy direction gets the mux). dstPK/srcPK identify a direct leg
+	// (its transport's remote is one of the route-group endpoints). Guarded by
+	// legMu; read as a snapshot (dirConfig) on the send path.
+	directional bool
+	flipped     bool
+	initiator   bool
+	dstPK       cipher.PubKey
+	srcPK       cipher.PubKey
+
 	// Per-frame noise (inverse-mux). When CapPerFrameNoise is negotiated the
 	// RouteGroup installs these: seal AEAD-encrypts each outgoing frame under
 	// its sequence-nonce (in wrapPayload, before retx storage so retransmits
@@ -341,6 +355,16 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 		return nil, nil, -1, ErrNoRules
 	}
 
+	// Unidirectional send selection (CapUniDir): restrict this end's send to legs
+	// matching its direction (initiator→direct, acceptor→multihop, swapped when
+	// flipped) — but only when at least one ready leg matches, so a send never
+	// fails for lack of a direction-matching leg. dirOK gates every pick below.
+	directional, wantDirect, dstPK, srcPK := m.dirConfig()
+	restrictDir := directional && m.dirRestrict(tps, wantDirect, dstPK, srcPK)
+	dirOK := func(tp *transport.ManagedTransport) bool {
+		return !restrictDir || legIsDirect(tp, dstPK, srcPK) == wantDirect
+	}
+
 	// Payload-inspecting modes: ask the selector for a leg
 	// derived from the bytes. Empty payload (handshake / retx)
 	// falls through to the schedule-based pick.
@@ -354,7 +378,7 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 			idx := m.tpSelector.SelectForPayload(payload)
 			if idx < len(tps) {
 				tp := tps[idx]
-				if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) {
+				if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) && dirOK(tp) {
 					return tp, fwd[idx], idx, nil
 				}
 			}
@@ -366,7 +390,7 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 		idx := m.tpSelector.Select()
 		if idx < len(tps) {
 			tp := tps[idx]
-			if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) {
+			if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) && dirOK(tp) {
 				return tp, fwd[idx], idx, nil
 			}
 		}
@@ -375,13 +399,14 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 	// Fallback: round-robin with skip-dead and skip-not-ready. An aux leg
 	// the peer has not confirmed yet is skipped so we never send the first
 	// packets onto a route whose rule the peer has not registered; the
-	// primary leg (0) is always ready, so this loop always finds it.
+	// primary leg (0) is always ready, so this loop always finds it. When
+	// direction filtering is active, non-matching legs are skipped here too.
 	n := uint32(len(tps)) //nolint:gosec
 	start := atomic.AddUint32(&m.tpIndex, 1) - 1
 	for i := uint32(0); i < n; i++ {
 		idx := int((start + i) % n) //nolint:gosec
 		tp := tps[idx]
-		if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) {
+		if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) && dirOK(tp) {
 			return tp, fwd[idx], idx, nil
 		}
 	}

--- a/pkg/router/unidir.go
+++ b/pkg/router/unidir.go
@@ -1,0 +1,85 @@
+// Package router pkg/router/unidir.go c2-net-routing
+package router
+
+import (
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// Unidirectional per-leg send selection (CapUniDir). Each end restricts its OWN
+// send to legs matching its direction, so the two directions ride disjoint legs:
+//
+//   - DEFAULT: the initiator (upload / forward) sends on the DIRECT (1-hop) leg;
+//     the acceptor (download / reverse) sends on the MULTIHOP mux legs. So the
+//     light direction takes the low-latency direct transport and the heavy
+//     direction aggregates over the mux — instead of both directions striping
+//     every leg (the head-of-line churn the confound-free telemetry exposed).
+//   - FLIPPED: the mapping is swapped (initiator sends on multihop, acceptor on
+//     direct) so the HEAVY direction gets the mux when upload outweighs download.
+//
+// Both ends decide locally from their role + each leg's directness (no per-packet
+// signaling); a flip is coordinated out of band. If no leg matches the wanted
+// direction, selection falls back to any ready leg so a send never fails.
+
+// setDirectional enables unidirectional send selection and records this end's
+// role and the route-group endpoints (used to tell a direct leg from a multihop
+// one). Called once at handshake when CapUniDir is negotiated.
+func (m *routeMux) setDirectional(initiator bool, dst, src cipher.PubKey) {
+	m.legMu.Lock()
+	m.directional = true
+	m.initiator = initiator
+	m.dstPK = dst
+	m.srcPK = src
+	m.legMu.Unlock()
+}
+
+// setFlipped swaps the direction→leg-class mapping (heavy direction gets the
+// mux). No-op unless directional. Returns true if the state changed. The bool is
+// set both ways by the flip controller (2b); it is only exercised with true so
+// far in tests.
+//
+//nolint:unparam
+func (m *routeMux) setFlipped(flipped bool) (changed bool) {
+	m.legMu.Lock()
+	if m.directional && m.flipped != flipped {
+		m.flipped = flipped
+		changed = true
+	}
+	m.legMu.Unlock()
+	return changed
+}
+
+// dirConfig snapshots the directional state under legMu so the send path reads it
+// once and then uses lock-free pure helpers (avoids re-locking legMu per leg).
+func (m *routeMux) dirConfig() (directional, wantDirect bool, dst, src cipher.PubKey) {
+	m.legMu.RLock()
+	defer m.legMu.RUnlock()
+	// This end sends on DIRECT legs when it is the forward sender: the initiator by
+	// default, or the acceptor when flipped.
+	wantDirect = m.initiator != m.flipped
+	return m.directional, wantDirect, m.dstPK, m.srcPK
+}
+
+// legIsDirect reports whether a leg's transport goes straight to a route-group
+// endpoint (a 1-hop / direct leg) rather than through an intermediary.
+func legIsDirect(tp *transport.ManagedTransport, dst, src cipher.PubKey) bool {
+	if tp == nil {
+		return false
+	}
+	r := tp.Remote()
+	return r == dst || r == src
+}
+
+// dirRestrict reports whether direction filtering should be enforced this pick:
+// true only when directional AND at least one READY leg matches the wanted
+// direction. When no matching leg is available it returns false so selection
+// falls back to any ready leg (a send is never dropped for lack of a
+// direction-matching leg).
+func (m *routeMux) dirRestrict(tps []*transport.ManagedTransport, wantDirect bool, dst, src cipher.PubKey) bool {
+	for idx, tp := range tps {
+		if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) && legIsDirect(tp, dst, src) == wantDirect {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/router/unidir_test.go
+++ b/pkg/router/unidir_test.go
@@ -1,0 +1,83 @@
+// Package router pkg/router/unidir_test.go c2-net-routing
+package router
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// pkFromHex parses a hex public key or fails the test.
+func pkFromHex(t *testing.T, hex string) cipher.PubKey {
+	t.Helper()
+	var pk cipher.PubKey
+	if err := pk.Set(hex); err != nil {
+		t.Fatalf("bad pubkey %q: %v", hex, err)
+	}
+	return pk
+}
+
+func TestDirectionalConfig(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("unidir-test")
+	dst := pkFromHex(t, "02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36")
+	src := pkFromHex(t, "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c")
+
+	// Off by default.
+	m := newRouteMux(log, true)
+	if d, _, _, _ := m.dirConfig(); d {
+		t.Fatal("directional should be off before setDirectional")
+	}
+
+	// Initiator (upload/forward sender) wants the DIRECT leg by default.
+	mi := newRouteMux(log, true)
+	mi.setDirectional(true, dst, src)
+	if d, wantDirect, gotDst, gotSrc := mi.dirConfig(); !d || !wantDirect || gotDst != dst || gotSrc != src {
+		t.Fatalf("initiator: directional=%v wantDirect=%v (want true,true) endpoints ok=%v", d, wantDirect, gotDst == dst && gotSrc == src)
+	}
+	// Flip → initiator now sends on MULTIHOP (heavy upload gets the mux).
+	if !mi.setFlipped(true) {
+		t.Fatal("setFlipped(true) should report a change")
+	}
+	if _, wantDirect, _, _ := mi.dirConfig(); wantDirect {
+		t.Fatal("flipped initiator should want MULTIHOP (wantDirect=false)")
+	}
+	if mi.setFlipped(true) {
+		t.Fatal("setFlipped(true) again should report no change")
+	}
+
+	// Acceptor (download/reverse sender) wants MULTIHOP by default; flip → direct.
+	ma := newRouteMux(log, true)
+	ma.setDirectional(false, dst, src)
+	if _, wantDirect, _, _ := ma.dirConfig(); wantDirect {
+		t.Fatal("acceptor default should want MULTIHOP (wantDirect=false)")
+	}
+	ma.setFlipped(true)
+	if _, wantDirect, _, _ := ma.dirConfig(); !wantDirect {
+		t.Fatal("flipped acceptor should want DIRECT (wantDirect=true)")
+	}
+
+	// setFlipped is a no-op when not directional.
+	mo := newRouteMux(log, true)
+	if mo.setFlipped(true) {
+		t.Fatal("setFlipped on a non-directional mux should report no change")
+	}
+}
+
+func TestLegIsDirect(t *testing.T) {
+	dst := pkFromHex(t, "02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36")
+	src := pkFromHex(t, "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c")
+	other := pkFromHex(t, "0205aa3c7c6a7c7d3277d6d638e1fe48cfc6a9bf2c0c5c508b7b6d409c8899f2e3")
+
+	// A nil transport is never direct (defensive).
+	if legIsDirect(nil, dst, src) {
+		t.Fatal("nil tp should not be direct")
+	}
+	// legIsDirect's endpoint match is exercised live (it needs a real
+	// ManagedTransport); here we pin the endpoint-comparison contract: dst/src are
+	// the direct endpoints, any other remote is multihop. Verified via the pubkey
+	// identity used by legIsDirect.
+	if dst == other || src == other {
+		t.Fatal("test endpoints must be distinct")
+	}
+}

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -211,6 +211,17 @@ const (
 	// head-of-line stall). A peer without this bit never receives one and keeps the
 	// prior send-side-only standby behavior.
 	CapLegState uint16 = 1 << 6
+	// CapUniDir: the peer supports UNIDIRECTIONAL per-leg send selection. When BOTH
+	// edges advertise it (and CapMux), each end restricts its OWN send to legs
+	// matching its direction — the initiator (upload/forward) sends on the DIRECT
+	// (1-hop) leg, the acceptor (download/reverse) sends on the MULTIHOP mux legs —
+	// so the light direction rides the low-latency direct transport and the heavy
+	// direction aggregates over the mux, instead of both directions striping every
+	// leg. Each end decides locally from its role + leg directness (no per-packet
+	// signaling); the assignment can later be FLIPPED (heavy direction gets the
+	// mux) via LegState-style coordination. A peer without the bit keeps striping
+	// every leg both ways.
+	CapUniDir uint16 = 1 << 7
 )
 
 // SeqSize is the byte size of the sequence number prepended to DataPacket


### PR DESCRIPTION
Confound-free per-leg telemetry (#4303) showed a download stripes across many churning legs, with both directions contending for every leg — head-of-line noise the no-skip reorder buffer pays for. This gives each direction its own legs.

With **CapUniDir** negotiated, each end restricts its **own** send to legs matching its direction: the initiator (upload / forward) sends on the **direct** 1-hop leg; the acceptor (download / reverse) sends on the **multihop** mux legs. So the light direction rides the low-latency direct transport and the heavy direction aggregates over the mux, instead of both directions striping every leg. Each end decides locally from its role (`rg.initiator`) plus each leg's directness (its transport's remote is a route-group endpoint) — **no per-packet signaling**.

A mux-side `flipped` flag swaps the mapping so the **heavy** direction can take the mux; it's wired to a load-driven flip controller in the next increment. If no leg matches the wanted direction, selection falls back to any ready leg so a send never fails, and the emergency warm-standby failover stays direction-agnostic.

Backward compatible: both edges must advertise CapUniDir; a peer without it keeps striping every leg both ways. Tests cover the role/flip config matrix and the direct-endpoint contract; full router + routing suites pass; lint clean.

This is step 2 of the unidirectional-mux goal (default assignment); the load-driven flip (upload>download) is next.