### PR TITLE
feat(router): load-driven flip for unidirectional mux (upload-heavy → mux)

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1586,6 +1586,12 @@ func (rg *RouteGroup) startOffServiceLoops() {
 	// reorderTimeout with no packet arriving to trigger the arrival-driven SACK,
 	// emit a SACK so the sender retransmits the missing seq in order (never skip).
 	go rg.servicePacketLoop("reorder-stall", reorderStallInterval, rg.reorderStallServiceFn, nil)
+	// Unidirectional flip controller (CapUniDir): both ends run this, so the
+	// direction→leg-class mapping flips together when the traffic asymmetry
+	// inverts (upload outweighs download → the heavy upload gets the mux). No-op
+	// unless directional; the fn self-gates. Cadence matches the reorder-stall
+	// tick so the hysteresis is a small number of seconds.
+	go rg.servicePacketLoop("unidir-flip", unidirFlipInterval, rg.unidirFlipServiceFn, nil)
 	// Note: Automatic ping loop removed. Latency is now measured once at transport creation.
 	// Rotation loop is NOT started here — startOffServiceLoops runs
 	// during initial route-group setup, before the router-side
@@ -3684,6 +3690,24 @@ func (rg *RouteGroup) resendSeqs(seqs []uint32) error {
 		}
 	}
 	return nil
+}
+
+// unidirFlipServiceFn is the unidirectional flip controller, run as a service
+// loop on BOTH ends. It flips the direction→leg-class mapping when the traffic
+// asymmetry inverts (upload outweighs download → the heavy upload takes the mux,
+// the light download rides the direct leg), and reverts when it swings back.
+// No-op unless CapUniDir negotiated (unidirFlipTick self-gates on directional).
+func (rg *RouteGroup) unidirFlipServiceFn(_ time.Duration) {
+	if rg.mux == nil {
+		return
+	}
+	if flipped, changed := rg.mux.unidirFlipTick(); changed {
+		if flipped {
+			rg.logger.Info("unidir-flip: FLIPPED — upload is now the heavy direction, moved onto the mux (download on the direct leg)")
+		} else {
+			rg.logger.Info("unidir-flip: reverted — download is the heavy direction again, back on the mux (upload on the direct leg)")
+		}
+	}
 }
 
 // sackServiceFn is the periodic SACK sender, run as a service loop.

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -197,6 +197,11 @@ type routeMux struct {
 	initiator   bool
 	dstPK       cipher.PubKey
 	srcPK       cipher.PubKey
+	// Flip-controller hysteresis state (see unidir.go unidirFlipTick). Touched
+	// ONLY by the single unidir-flip loop goroutine, so no lock of their own.
+	flipUpHits   int
+	flipDownHits int
+	flipCooldown int
 
 	// Per-frame noise (inverse-mux). When CapPerFrameNoise is negotiated the
 	// RouteGroup installs these: seal AEAD-encrypts each outgoing frame under

--- a/pkg/router/unidir.go
+++ b/pkg/router/unidir.go
@@ -2,8 +2,24 @@
 package router
 
 import (
+	"time"
+
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// Flip controller (step 2b). Both ends run unidirFlipServiceFn; each measures the
+// ABSOLUTE upload vs download goodput (mapping its local send/recv by role) and,
+// when the asymmetry inverts and holds, flips the direction→leg-class mapping so
+// the HEAVY direction gets the aggregated mux. Both ends see the same absolute
+// asymmetry, so they flip together (a brief transient where only one has flipped
+// self-corrects on the next tick). Hysteresis + cooldown keep it from flapping.
+const (
+	unidirFlipInterval = 1 * time.Second // flip-controller tick cadence
+	flipRatio          = 2.0             // flip when the heavy direction ≥ this × the light one
+	flipHysteresis     = 3               // consecutive qualifying ticks before flipping
+	flipCooldownTicks  = 3               // ticks to hold after a flip before another
+	flipMinGoodput     = 8192.0          // bytes/sec floor — ignore near-idle noise
 )
 
 // Unidirectional per-leg send selection (CapUniDir). Each end restricts its OWN
@@ -68,6 +84,83 @@ func legIsDirect(tp *transport.ManagedTransport, dst, src cipher.PubKey) bool {
 	}
 	r := tp.Remote()
 	return r == dst || r == src
+}
+
+// unidirFlipTick runs one flip-controller tick: it samples the active legs'
+// absolute upload/download goodput and flips (or reverts) the direction mapping
+// when the heavy direction has out-weighed the light one by flipRatio for
+// flipHysteresis consecutive ticks, then holds for flipCooldownTicks. Returns the
+// current flipped state and whether it changed this tick. Called only from the
+// single unidir-flip loop goroutine, so the hysteresis counters need no lock.
+func (m *routeMux) unidirFlipTick() (flipped, changed bool) {
+	m.legMu.RLock()
+	directional := m.directional
+	initiator := m.initiator
+	m.legMu.RUnlock()
+	if !directional {
+		return m.flipped, false
+	}
+
+	stats := m.snapshotLegs() // samples per-leg goodput EWMAs
+	var up, down float64      // ABSOLUTE upload / download bytes/sec
+	m.legMu.RLock()
+	for i, s := range stats {
+		if i < len(m.standby) && m.standby[i] {
+			continue // active legs only
+		}
+		if initiator {
+			// initiator's local send = upload, local recv = download
+			up += s.GoodputUpBps
+			down += s.GoodputDownBps
+		} else {
+			// acceptor's local send = download, local recv = upload
+			up += s.GoodputDownBps
+			down += s.GoodputUpBps
+		}
+	}
+	m.legMu.RUnlock()
+	return m.flipStep(up, down)
+}
+
+// flipStep applies one hysteresis/cooldown step to the flip state given the
+// current ABSOLUTE upload/download goodput. Split from the sampling so it is unit
+// testable with synthetic rates. Single-goroutine (the flip loop); hysteresis
+// counters need no lock.
+func (m *routeMux) flipStep(up, down float64) (flipped, changed bool) {
+	m.legMu.RLock()
+	directional := m.directional
+	cur := m.flipped
+	m.legMu.RUnlock()
+	if !directional {
+		return cur, false
+	}
+	if m.flipCooldown > 0 {
+		m.flipCooldown--
+		return cur, false
+	}
+
+	switch {
+	case up > flipMinGoodput && up >= flipRatio*down:
+		m.flipUpHits++
+		m.flipDownHits = 0
+	case down > flipMinGoodput && down >= flipRatio*up:
+		m.flipDownHits++
+		m.flipUpHits = 0
+	default:
+		m.flipUpHits, m.flipDownHits = 0, 0
+	}
+
+	if !cur && m.flipUpHits >= flipHysteresis && m.setFlipped(true) {
+		m.flipCooldown = flipCooldownTicks
+		m.flipUpHits = 0
+		return true, true
+	}
+	if cur && m.flipDownHits >= flipHysteresis && m.setFlipped(false) {
+		m.flipCooldown = flipCooldownTicks
+		m.flipDownHits = 0
+		return false, true
+	}
+	return cur, false
 }
 
 // dirRestrict reports whether direction filtering should be enforced this pick:

--- a/pkg/router/unidir_flip_test.go
+++ b/pkg/router/unidir_flip_test.go
@@ -1,0 +1,67 @@
+// Package router pkg/router/unidir_flip_test.go c2-net-routing
+package router
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestFlipStep drives the flip hysteresis/cooldown state machine with synthetic
+// absolute upload/download rates.
+func TestFlipStep(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("flip-test")
+	dst := pkFromHex(t, "02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36")
+	src := pkFromHex(t, "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c")
+
+	m := newRouteMux(log, true)
+	m.setDirectional(true, dst, src) // initiator, unflipped (download-heavy default)
+
+	up, down := 5_000_000.0, 100_000.0 // upload-heavy (>2×), well above the floor
+
+	// Needs flipHysteresis consecutive qualifying ticks before flipping.
+	for i := 0; i < flipHysteresis-1; i++ {
+		if _, changed := m.flipStep(up, down); changed {
+			t.Fatalf("flipped after only %d ticks, want %d", i+1, flipHysteresis)
+		}
+	}
+	flipped, changed := m.flipStep(up, down)
+	if !changed || !flipped {
+		t.Fatalf("expected flip on tick %d: flipped=%v changed=%v", flipHysteresis, flipped, changed)
+	}
+
+	// Cooldown: no immediate re-flip even if the signal reverses hard.
+	for i := 0; i < flipCooldownTicks; i++ {
+		if _, changed := m.flipStep(down, up); changed { // download-heavy now
+			t.Fatalf("re-flipped during cooldown at tick %d", i+1)
+		}
+	}
+	// After cooldown, a sustained download-heavy signal reverts.
+	var reverted bool
+	for i := 0; i < flipHysteresis; i++ {
+		if f, c := m.flipStep(down, up); c {
+			reverted = !f
+		}
+	}
+	if !reverted {
+		t.Fatal("expected revert to unflipped after sustained download-heavy signal")
+	}
+
+	// Balanced traffic (below the ratio) never flips.
+	m2 := newRouteMux(log, true)
+	m2.setDirectional(true, dst, src)
+	for i := 0; i < flipHysteresis*3; i++ {
+		if _, c := m2.flipStep(1_000_000, 900_000); c { // ~1.1×, under flipRatio
+			t.Fatal("flipped on near-balanced traffic")
+		}
+	}
+
+	// Near-idle traffic (below the floor) never flips even at a high ratio.
+	m3 := newRouteMux(log, true)
+	m3.setDirectional(true, dst, src)
+	for i := 0; i < flipHysteresis*3; i++ {
+		if _, c := m3.flipStep(flipMinGoodput/2, 1); c {
+			t.Fatal("flipped on sub-floor idle traffic")
+		}
+	}
+}


### PR DESCRIPTION
Completes the unidirectional-mux design; #4304 was the default assignment (direct=upload, mux=download).

A flip controller runs on **both ends** as a service loop: each measures its **absolute** upload vs download goodput (mapping its local send/recv by role) and flips the direction→leg-class mapping when the heavy direction out-weighs the light one by **2×** for **3 consecutive ticks**, with a **3-tick cooldown**. So a download-heavy flow keeps the aggregating mux on the download and the direct leg on the light upload; an **upload-heavy** flow (a POST / seed) **flips** — the heavy upload moves onto the mux, the light download onto the direct leg.

Both ends see the same absolute asymmetry, so they flip together; a one-tick transient where only one has flipped self-corrects on the next tick. Hysteresis + cooldown + an idle-goodput floor keep it from flapping on noise or near-idle traffic. **No new wire message** — each end decides from its own goodput and role.

The hysteresis/cooldown state machine is split into `flipStep` for unit testing; tests cover the flip, the cooldown block, the revert, and the near-balanced / sub-floor no-flip cases. Full router suite passes; lint clean.

This is step 3 of the unidirectional-mux goal. The live demonstration (download-heavy vs upload-heavy per-leg telemetry) follows once both endpoints are on this build.