### PR TITLE
fix(dmsgd): coalesce clients-by-server leaf re-encode (was ~1.6 cores in gzip)

### DIFF
--- a/pkg/dmsg/discovery/api/cxo_publisher.go
+++ b/pkg/dmsg/discovery/api/cxo_publisher.go
@@ -109,6 +109,19 @@ const clientsByServerBatchVersion = 1
 // publishers run 60s; this sits between that and the old 1s.)
 const clientsByServerCXOBatchWindow = 30 * time.Second
 
+// clientsByServerFlushWindow coalesces the per-server LEAF re-encode (sort +
+// concat + gzip in encodeClientsBatch) the way BatchWindow coalesces the
+// whole-tree publish. Without it, flushServers re-gzipped an affected server's
+// entire client leaf on EVERY materially-changed entry — so under fleet
+// session/delegated-server churn dmsg-discovery burned ~1.6 cores almost entirely
+// in flate (53% of CPU, observed 2026-08-29), re-encoding leaves whose bytes the
+// treestore's content-addressed Put then coalesced away unpublished. Marking the
+// affected servers dirty and re-encoding each at most once per this window
+// collapses the redundant gzips; the encode still reflects the latest state at
+// flush time, so correctness is unchanged. Kept well under BatchWindow so a
+// server's leaf is current in the tree before the 30s publish captures it.
+const clientsByServerFlushWindow = 3 * time.Second
+
 // json is the package-scope jsoniter.ConfigFastest value declared
 // in api.go. We reuse it here to avoid pulling in encoding/json
 // (which collides with the package-scope name) and to match the
@@ -143,6 +156,11 @@ type ClientsByServerCXOPublisher struct {
 	// server's batched leaf reads only from here.
 	state map[cipher.PubKey]map[cipher.PubKey][]byte
 
+	// pendingDirty is the set of servers whose leaf needs re-encoding, drained
+	// on the flush ticker (clientsByServerFlushWindow) instead of per-mutation so
+	// bursty churn re-gzips each server at most once per window. Worker-only.
+	pendingDirty map[cipher.PubKey]struct{}
+
 	mu        sync.Mutex
 	lastError error
 }
@@ -169,11 +187,12 @@ func StartClientsByServerCXOPublisher(dmsgC *dmsg.Client, sk cipher.SecKey, logg
 	pub.SetAllowlist(nil)
 
 	p := &ClientsByServerCXOPublisher{
-		pub:    pub,
-		log:    log,
-		events: make(chan func(), publishQueueDepth),
-		done:   make(chan struct{}),
-		state:  make(map[cipher.PubKey]map[cipher.PubKey][]byte),
+		pub:          pub,
+		log:          log,
+		events:       make(chan func(), publishQueueDepth),
+		done:         make(chan struct{}),
+		state:        make(map[cipher.PubKey]map[cipher.PubKey][]byte),
+		pendingDirty: make(map[cipher.PubKey]struct{}),
 	}
 	p.wg.Add(1)
 	go p.run()
@@ -192,13 +211,40 @@ func StartClientsByServerCXOPublisher(dmsgC *dmsg.Client, sk cipher.SecKey, logg
 // HTTP goroutine never blocks on the mutex.
 func (p *ClientsByServerCXOPublisher) run() {
 	defer p.wg.Done()
+	ticker := time.NewTicker(clientsByServerFlushWindow)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-p.done:
+			p.flushDirty() // best-effort final flush of pending re-encodes
 			return
 		case fn := <-p.events:
 			fn()
+		case <-ticker.C:
+			p.flushDirty()
 		}
+	}
+}
+
+// flushDirty re-encodes + Puts the leaves of every server accumulated in
+// pendingDirty since the last flush, then clears the set. Worker-only; called on
+// the flush ticker (and once more on close). Coalescing the encode here instead
+// of per-mutation is what removes the redundant gzip storm (see
+// clientsByServerFlushWindow).
+func (p *ClientsByServerCXOPublisher) flushDirty() {
+	if len(p.pendingDirty) == 0 {
+		return
+	}
+	dirty := p.pendingDirty
+	p.pendingDirty = make(map[cipher.PubKey]struct{})
+	p.flushServers(dirty)
+}
+
+// markDirty records that each server's leaf needs re-encoding on the next flush
+// tick. Worker-only (called from the submitted mutation closures).
+func (p *ClientsByServerCXOPublisher) markDirty(dirty map[cipher.PubKey]struct{}) {
+	for srv := range dirty {
+		p.pendingDirty[srv] = struct{}{}
 	}
 }
 
@@ -303,7 +349,7 @@ func (p *ClientsByServerCXOPublisher) PublishSetEntry(oldEntry, newEntry *disc.E
 			p.stateDel(srv, clientPK)
 			dirty[srv] = struct{}{}
 		}
-		p.flushServers(dirty)
+		p.markDirty(dirty)
 	})
 }
 
@@ -328,7 +374,7 @@ func (p *ClientsByServerCXOPublisher) PublishDelEntry(oldEntry *disc.Entry) {
 			p.stateDel(srv, clientPK)
 			dirty[srv] = struct{}{}
 		}
-		p.flushServers(dirty)
+		p.markDirty(dirty)
 	})
 }
 

--- a/pkg/dmsg/discovery/api/cxo_publisher_batch_test.go
+++ b/pkg/dmsg/discovery/api/cxo_publisher_batch_test.go
@@ -16,7 +16,10 @@ import (
 // so stateSet / encodeClientsBatch can be exercised without a live
 // treestore.Publisher (pub stays nil; these helpers never touch it).
 func newTestPub() *ClientsByServerCXOPublisher {
-	return &ClientsByServerCXOPublisher{state: make(map[cipher.PubKey]map[cipher.PubKey][]byte)}
+	return &ClientsByServerCXOPublisher{
+		state:        make(map[cipher.PubKey]map[cipher.PubKey][]byte),
+		pendingDirty: make(map[cipher.PubKey]struct{}),
+	}
 }
 
 func mustEntry(t *testing.T, clientPK cipher.PubKey, servers []cipher.PubKey) []byte {
@@ -122,5 +125,34 @@ func TestBatchDelEmptiesServer(t *testing.T) {
 	p.stateDel(srv, clientPK)
 	if got := len(p.state[srv]); got != 0 {
 		t.Fatalf("after del: want 0 clients, got %d", got)
+	}
+}
+
+// TestMarkDirtyCoalesces proves the per-server re-encode is coalesced: repeated
+// markDirty of the same server accumulates a de-duplicated pending set (so the
+// flush ticker re-gzips each server at most once per window instead of per
+// mutation), and flushDirty on an empty set is a safe no-op.
+func TestMarkDirtyCoalesces(t *testing.T) {
+	p := newTestPub()
+	var s1, s2, s3 cipher.PubKey
+	s1[0], s2[0], s3[0] = 1, 2, 3
+
+	// Empty flush is a no-op (must not touch the nil publisher).
+	p.flushDirty()
+	if len(p.pendingDirty) != 0 {
+		t.Fatalf("pendingDirty non-empty after empty flushDirty: %d", len(p.pendingDirty))
+	}
+
+	// Three mutations touching overlapping servers coalesce to the distinct set.
+	p.markDirty(map[cipher.PubKey]struct{}{s1: {}, s2: {}})
+	p.markDirty(map[cipher.PubKey]struct{}{s2: {}}) // s2 again — no duplicate
+	p.markDirty(map[cipher.PubKey]struct{}{s3: {}})
+	if len(p.pendingDirty) != 3 {
+		t.Fatalf("pendingDirty = %d servers, want 3 (deduped)", len(p.pendingDirty))
+	}
+	for _, s := range []cipher.PubKey{s1, s2, s3} {
+		if _, ok := p.pendingDirty[s]; !ok {
+			t.Fatalf("server %x missing from pendingDirty", s[0])
+		}
 	}
 }


### PR DESCRIPTION
A live CPU profile of dmsg-discovery caught it burning **~1.6 cores steady-state**, with **53% of all CPU** in one chain: `flushServers → encodeClientsBatch → FrameGzip → flate`.

`flushServers` re-encoded (sort + concat + gzip) an affected server's **entire** client leaf on **every** materially-changed entry. Under fleet session/delegated-server churn a single server's leaf was re-gzipped many times a second — and the treestore's content-addressed `Put` (already coalesced to a 30s window) then discarded most of those re-encodes unpublished. CPU scaled with clients-per-server × churn, so it climbed on a long-lived process and reset only on redeploy.

**Fix:** coalesce the encode the way the publish is already coalesced. Mutation closures now mark the affected servers dirty instead of flushing inline; a 3s ticker (well under the 30s publish window) re-encodes each dirty server at most once per window, draining once more on close. The encode still reads the latest state at flush time, so the published view is unchanged — only the redundant intra-window re-gzips are removed. State mutations stay immediate.

Test covers dirty-set accumulation/dedup and the empty-flush no-op. (sd and TPD were profiled too and are near-idle — no comparable path.)