### PR TITLE
fix(router): --direct actually bypasses the routing policy

### DIFF
--- a/pkg/router/control_port_mux_test.go
+++ b/pkg/router/control_port_mux_test.go
@@ -43,6 +43,28 @@ func TestEffectiveDialHook(t *testing.T) {
 	}
 }
 
+// TestDialPolicyHookDirectBypass: a --direct dial (EnsureDirectTransport) is
+// policy-free — dialPolicyHook returns nil even on a data port with a hook
+// configured, so the global adaptive policy can't re-impose its mux. Non-direct
+// dials still get the hook exactly as effectiveDialHook decides.
+func TestDialPolicyHookDirectBypass(t *testing.T) {
+	hook := stubDialHook{}
+	r := &router{conf: &Config{DialHook: hook}}
+	const dataPort = routing.Port(3) // skysocks — a data port that normally gets the hook
+
+	// Sanity: without --direct the data port gets the hook.
+	if r.dialPolicyHook(&DialOptions{}, dataPort) == nil {
+		t.Fatal("non-direct data-port dial should get the policy hook")
+	}
+	if r.dialPolicyHook(nil, dataPort) == nil {
+		t.Fatal("nil-opts data-port dial should get the policy hook")
+	}
+	// --direct bypasses policy entirely.
+	if r.dialPolicyHook(&DialOptions{EnsureDirectTransport: true}, dataPort) != nil {
+		t.Fatal("--direct dial must bypass the routing policy (dialPolicyHook should be nil)")
+	}
+}
+
 // TestIsControlPlanePort locks the no-mux port set: control/telemetry ports are
 // control-plane (single-route), bulk-data app ports are not (keep their mux).
 func TestIsControlPlanePort(t *testing.T) {

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -63,7 +63,12 @@ func (r *router) DialRoutes(
 	// opts.MinHops before route setup, and can refuse the dial
 	// entirely via Fallback="drop". A nil hook short-circuits
 	// the entire block so policy-free deployments pay zero cost.
-	if hook := r.effectiveDialHook(rPort); hook != nil {
+	// dialPolicyHook also returns nil for a --direct dial, which is
+	// policy-free by definition (see its doc).
+	if opts != nil && opts.EnsureDirectTransport {
+		log.Debug("--direct dial: bypassing routing policy (policy-free 1-hop direct leg)")
+	}
+	if hook := r.dialPolicyHook(opts, rPort); hook != nil {
 		if opts == nil {
 			opts = &DialOptions{}
 		}
@@ -2952,6 +2957,22 @@ func (r *router) effectiveDialHook(rPort routing.Port) DialHook {
 		return nil
 	}
 	return r.conf.DialHook
+}
+
+// dialPolicyHook returns the routing-policy hook that should adjust THIS dial, or
+// nil to skip policy entirely. It layers a --direct exemption over
+// effectiveDialHook: a dial with EnsureDirectTransport asked for a single,
+// stable, 1-hop direct leg (no route-finder, no setup node, no adaptive mux), so
+// it is policy-free by definition. Without this, effectiveDialHook still returns
+// the GLOBAL default hook even after the per-app policy override was cleared, and
+// that hook re-imposes the adaptive mux (e.g. policy_mux=513) — sending the router
+// off to chase RSN-oracle / route-finder aux legs alongside the direct primary,
+// which is exactly what --direct exists to avoid.
+func (r *router) dialPolicyHook(opts *DialOptions, rPort routing.Port) DialHook {
+	if opts != nil && opts.EnsureDirectTransport {
+		return nil
+	}
+	return r.effectiveDialHook(rPort)
 }
 
 // isSameLANDest reports whether dst is a peer on this visor's own local network


### PR DESCRIPTION
`--direct` (EnsureDirectTransport) is meant to be a single, stable, policy-free 1-hop direct leg. But it only cleared the **per-app** policy override — `effectiveDialHook` still returned the **global** default hook, which re-imposed the adaptive mux:

```
Per-app routing policy cleared at runtime. app="skysocks-client"
Routing policy adjusted dial opts. policy_mux="513" policy_min_hops="0"
Direct transport ready; using 1-hop route (route-finder query abandoned)
RSN-oracle 2-hop path missed; falling through to route finder
Requesting new routes ...
```

So alongside the direct primary the router chased 513 adaptive mux legs via RSN-oracle + the route finder — exactly what `--direct` exists to avoid.

Fix: add `dialPolicyHook`, which layers a `--direct` exemption over `effectiveDialHook` — an `EnsureDirectTransport` dial gets no policy hook, so `opts.MuxRoutes` stays 1 and `establishMuxRoutes`/`maybeSelfHeal` both early-return (no aux legs, no RSN-oracle, no route-finder). Matches the flag's contract and its documented mutual-exclusion with `--routing-policy`. Test covers the direct-bypass and the unchanged non-direct path.