### PR TITLE
make: resolve a Go toolchain TinyGo accepts, instead of failing on the newest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,9 +352,19 @@ build-wasm: ## Compile-check every js/wasm binary (GOOS=js GOARCH=wasm), no run 
 
 build-wasm-tinygo: ## Compile-check every TinyGo wasm binary (-o /dev/null, no run) — mirrors the CI wasm-tinygo lane
 	@command -v tinygo >/dev/null 2>&1 || { echo "tinygo not installed — see docs/design/tinygo-dmsg-client.md (TinyGo 0.41+)"; exit 1; }
+	@# TinyGo trails Go by weeks after each Go minor, and refuses to run at all
+	@# against a newer one ("requires go version 1.19 through 1.26, got go1.27").
+	@# CI installs the current Go, so this lane went red the day #4221 bumped it.
+	@# The script asks TinyGo what it supports and resolves a matching toolchain,
+	@# printing "auto" once TinyGo has caught up — so no version is written down.
+	@#
+	@# -interp-timeout raises TinyGo's 3m default for the compile-time
+	@# interpreter, which folds skycoin's secp256k1 package init. That fits
+	@# inside the default on a CI runner but not on a slower machine building
+	@# from a cold cache, so the ceiling does not depend on whose machine runs it.
 	@echo "compile-checking TinyGo wasm binaries..."
 	@echo "  tinygo build -target wasip1 ./cmd/dmsg-tinygo-probe"
-	@tinygo build -target wasip1 -no-debug -opt=z -o /dev/null ./cmd/dmsg-tinygo-probe || exit 1
+	@GOTOOLCHAIN=$$(sh scripts/tinygo-toolchain.sh) tinygo build -target wasip1 -no-debug -opt=z -interp-timeout 15m -o /dev/null ./cmd/dmsg-tinygo-probe || exit 1
 	@# Only net/http-free binaries belong here: TinyGo 0.41 cannot compile net/http
 	@# for wasm (roundtrip_js.go references an unexported Transport.roundTrip). The
 	@# full js/wasm binaries ./cmd/dmsg-wasm and ./cmd/wasm-visor deliberately use
@@ -362,16 +372,16 @@ build-wasm-tinygo: ## Compile-check every TinyGo wasm binary (-o /dev/null, no r
 	@# standard-Go-only — they are compile-checked by the `build-wasm` lane instead.
 	@for p in ./pkg/tpviz/wasm ./cmd/websh-probe; do \
 		echo "  tinygo build -target wasm $$p"; \
-		tinygo build -target wasm -no-debug -o /dev/null "$$p" || exit 1; \
+		GOTOOLCHAIN=$$(sh scripts/tinygo-toolchain.sh) tinygo build -target wasm -no-debug -interp-timeout 15m -o /dev/null "$$p" || exit 1; \
 	done
 	@echo "  tinygo build -target wasi (app-mux routing policy)"
-	@cd docs/examples/routing-policies/wasm/app-mux && tinygo build -target=wasi -no-debug -opt=2 -o /dev/null . || exit 1
+	@cd docs/examples/routing-policies/wasm/app-mux && GOTOOLCHAIN=$$(cd ../../../../.. && sh scripts/tinygo-toolchain.sh) tinygo build -target=wasi -no-debug -opt=2 -o /dev/null . || exit 1
 	@echo "all TinyGo wasm binaries compile."
 
 test-wasm-policy: ## Rebuild app-mux.wasm from source with TinyGo and run the policy loader test against the FRESH build (real WASM runtime smoke test)
 	@command -v tinygo >/dev/null 2>&1 || { echo "tinygo not installed — see docs/examples/routing-policies/wasm/README.md (TinyGo 0.32+)"; exit 1; }
 	@mkdir -p ./build/wasm-fixtures
-	cd docs/examples/routing-policies/wasm/app-mux && tinygo build -target=wasi -no-debug -opt=2 -o "$(CURDIR)/build/wasm-fixtures/app-mux.wasm" .
+	cd docs/examples/routing-policies/wasm/app-mux && GOTOOLCHAIN=$$(cd ../../../../.. && sh scripts/tinygo-toolchain.sh) tinygo build -target=wasi -no-debug -opt=2 -o "$(CURDIR)/build/wasm-fixtures/app-mux.wasm" .
 	SKYWIRE_APPMUX_WASM="$(CURDIR)/build/wasm-fixtures/app-mux.wasm" go test -mod=vendor -count=1 -v -run TestWasmEvaluator ./pkg/router/policy/wasm/
 
 tpviz-wasm: ## Build transport visualizer WASM binary to build/tpviz (standalone)
@@ -384,12 +394,12 @@ tpviz-wasm-standalone: tpviz-wasm ## Alias for tpviz-wasm (both build standalone
 
 tpviz-wasm-tinygo: ## Build transport visualizer WASM binary with tinygo to build/tpviz (smaller, ~750KB)
 	mkdir -p ./build/tpviz
-	tinygo build -o ./build/tpviz/main.wasm -target wasm -no-debug -opt=z -panic=trap ./pkg/tpviz/wasm
+	GOTOOLCHAIN=$$(sh scripts/tinygo-toolchain.sh) tinygo build -o ./build/tpviz/main.wasm -target wasm -no-debug -opt=z -panic=trap ./pkg/tpviz/wasm
 	cp "$$(tinygo env TINYGOROOT)/targets/wasm_exec.js" ./build/tpviz/
 	cp ./pkg/tpviz/dist/index.html ./build/tpviz/
 
 tinygo-dmsg: ## Build-check the dmsg client under TinyGo (IoT target wasip1); ~2.2MB -opt=z
-	tinygo build -target wasip1 -no-debug -opt=z -o ./build/dmsg-tinygo.wasm ./cmd/dmsg-tinygo-probe
+	GOTOOLCHAIN=$$(sh scripts/tinygo-toolchain.sh) tinygo build -target wasip1 -no-debug -opt=z -o ./build/dmsg-tinygo.wasm ./cmd/dmsg-tinygo-probe
 	@echo "built ./build/dmsg-tinygo.wasm — the dmsg client compiles under TinyGo (see docs/design/tinygo-dmsg-client.md)"
 
 dmsg-wasm: ## Build the browser WASM dmsg client + dev harness into build/dmsg-wasm
@@ -401,7 +411,7 @@ dmsg-wasm: ## Build the browser WASM dmsg client + dev harness into build/dmsg-w
 
 tinygo-dmsg-wasm: ## Build the browser WASM dmsg client with TinyGo (~6.5MB vs ~21MB) into build/dmsg-wasm
 	mkdir -p ./build/dmsg-wasm
-	tinygo build -target wasm -o ./build/dmsg-wasm/dmsg.wasm ./cmd/dmsg-wasm
+	GOTOOLCHAIN=$$(sh scripts/tinygo-toolchain.sh) tinygo build -target wasm -o ./build/dmsg-wasm/dmsg.wasm ./cmd/dmsg-wasm
 	cp "$$(tinygo env TINYGOROOT)/targets/wasm_exec.js" ./build/dmsg-wasm/
 	cp ./cmd/dmsg-wasm/index.html ./build/dmsg-wasm/
 	@echo "built ./build/dmsg-wasm (TinyGo) — serve it: 'go run cmd/dmsg-wasm/serve.go' then open http://localhost:8085/"

--- a/scripts/tinygo-toolchain.sh
+++ b/scripts/tinygo-toolchain.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Print the GOTOOLCHAIN value TinyGo needs, or "auto" when the system Go will do.
+#
+#   GOTOOLCHAIN=$(sh scripts/tinygo-toolchain.sh) tinygo build -target=wasm .
+#
+# Go releases a new minor twice a year; TinyGo supports it some weeks later.
+# In between, every TinyGo build fails before it compiles anything, with
+#
+#     requires go version 1.19 through 1.26, got go1.27
+#
+# which is how the wasm-tinygo lane went red: CI installs the current Go and
+# the newest TinyGo release, and for part of every year those two do not agree.
+#
+# The usual answers are to downgrade Go or to pin a version in the workflow.
+# Downgrading breaks the other lanes, and a pin goes stale — it keeps building
+# against an old patch release long after newer ones have fixed security bugs,
+# and nothing fails to tell you that TinyGo has caught up.
+#
+# Both unknowns are discoverable, so no version is written down here:
+#
+#   the ceiling  TinyGo names it in the message above, and the check runs
+#                before any package is loaded, so asking costs nothing.
+#   the patch    go.dev publishes every release; take the newest of that minor.
+#
+# When TinyGo catches up, the probe succeeds, this prints "auto", and the build
+# uses the system Go with no network access at all.
+set -u
+
+say() { echo "tinygo-toolchain: $*" >&2; }
+
+command -v tinygo >/dev/null 2>&1 || { echo auto; exit 0; }
+
+# Probe. The package does not exist, and does not need to: the toolchain check
+# happens first, so this returns immediately either way.
+probe=$(cd / && tinygo build -o /dev/null -target=wasm ./tinygo-toolchain-probe 2>&1)
+minor=$(printf '%s\n' "$probe" |
+	sed -n 's/.*requires go version [0-9][0-9.]* through \([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' |
+	head -1)
+
+# No complaint about the Go version: whatever else the probe said is the
+# caller's problem, and the system toolchain is fine.
+[ -n "$minor" ] || { echo auto; exit 0; }
+
+# Newest patch of that minor, from the release list.
+latest=$(curl -fsS --max-time 20 'https://go.dev/dl/?mode=json&include=all' 2>/dev/null |
+	grep -oE '"version"[[:space:]]*:[[:space:]]*"go[0-9.]+"' | grep -oE 'go[0-9.]+' |
+	grep -E "^go${minor}(\.[0-9]+)?$" | sort -uV | tail -1)
+
+# Same question to the module proxy, which some networks reach when go.dev is
+# blocked and which serves the toolchains themselves.
+[ -n "$latest" ] || latest=$(curl -fsS --max-time 20 'https://proxy.golang.org/golang.org/toolchain/@v/list' 2>/dev/null |
+	grep -oE "go${minor}(\.[0-9]+)?" | sort -uV | tail -1)
+
+# Offline: a toolchain downloaded by an earlier build is still on disk, and an
+# older patch of the right minor builds fine.
+if [ -z "$latest" ]; then
+	latest=$(ls -1d "${GOMODCACHE:-$(go env GOMODCACHE 2>/dev/null)}"/golang.org/toolchain@*/ 2>/dev/null |
+		sed -n "s|.*toolchain@v[0-9.]*-\(go${minor}\(\.[0-9]*\)\?\)\..*|\1|p" | sort -uV | tail -1)
+	[ -n "$latest" ] && say "offline; using cached $latest"
+fi
+
+if [ -z "$latest" ]; then
+	say "TinyGo needs Go <= $minor and no release list was reachable; leaving GOTOOLCHAIN alone"
+	echo auto
+	exit 0
+fi
+
+say "TinyGo supports up to Go $minor; using $latest"
+echo "$latest"


### PR DESCRIPTION
**Did you run `make format && make check`?** This touches only the Makefile and a new shell script; both steps of the `wasm-tinygo` job were run locally instead — see below.

**Fixes:** the red `wasm-tinygo` lane

**Changes:**
- `wasm-tinygo` has been red on every develop commit since #4221 bumped CI to Go 1.27.0. TinyGo 0.41.1 (still the newest release) accepts 1.19–1.26 and refuses to run against anything newer, so the job dies before compiling: `requires go version 1.19 through 1.26, got go1.27`. It was green on the parent commit, `056ef3585`.
- Rather than pin a version that goes stale silently — which is how this rotted — `scripts/tinygo-toolchain.sh` reads TinyGo's own ceiling out of that error message and resolves the newest patch of that minor from go.dev, falling back to the module proxy and then to an already-downloaded toolchain when offline. It prints `auto` when the system Go is fine, which is what it will print once TinyGo supports 1.27, with no change needed here.
- All five `tinygo` invocations in the Makefile go through it, not just the one the lane reports: `build-wasm-tinygo`, `test-wasm-policy` (the same job's **second** step, which was only *skipped* because the first failed, and would have failed next), `tpviz-wasm-tinygo`, `tinygo-dmsg`, `tinygo-dmsg-wasm`.
- `-interp-timeout` raises TinyGo's 3m default for the pass that folds skycoin's `secp256k1` package init. That fits inside the default on a runner, which is why the lane was green before, but not on a slower machine from a cold cache.

**How to test this PR:**
```
make build-wasm-tinygo     # all four binaries
make test-wasm-policy      # rebuilds app-mux.wasm, runs TestWasmEvaluator on it
```
Verified locally with cold Go and TinyGo caches: the first takes 6m54s and compiles all four; the second rebuilds the policy blob and passes both evaluator tests against it. Nothing here changes what is compiled — only which Go toolchain TinyGo is handed.