### PR TITLE
fix(router): don't reap the unidirectional light-direction leg as a black-hole

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -2055,7 +2055,16 @@ func (rg *RouteGroup) legDataProgressServiceFn(_ time.Duration) {
 		activeCnt++
 		soleSent, soleRecv = stats[i].SentBytes, stats[i].RecvBytes
 	}
-	if soleLegBlackHoled(activeCnt, soleSent, soleRecv) {
+	// Direction-aware exemption: under unidirectional assignment (CapUniDir) the
+	// sole active leg is the light-direction leg (the direct upload leg on a
+	// download), which receives ~nothing because the download flows on the reverse
+	// mux legs. If the GROUP is receiving on those legs (aggDelta above the floor),
+	// the sole send leg is not a black-hole — reaping it would prune the direct leg
+	// exactly when unidir is doing its job (the leg then re-dials multihop and the
+	// direct/forward binding is lost). Skip the reaping in that case.
+	if soleLegBlackHoleExempt(rg.mux.isDirectional(), aggDelta) {
+		rg.soleBHTicks = 0
+	} else if soleLegBlackHoled(activeCnt, soleSent, soleRecv) {
 		rg.soleBHTicks++
 		if rg.soleBHTicks >= soleBlackHoleTicks {
 			rg.logger.Warnf("sole-leg black-hole: only active route sent %dB but received %dB over %v — dialing a replacement route",

--- a/pkg/router/unidir.go
+++ b/pkg/router/unidir.go
@@ -65,6 +65,32 @@ func (m *routeMux) setFlipped(flipped bool) (changed bool) {
 	return changed
 }
 
+// isDirectional reports whether unidirectional send selection (CapUniDir) is
+// active on this mux.
+func (m *routeMux) isDirectional() bool {
+	m.legMu.RLock()
+	defer m.legMu.RUnlock()
+	return m.directional
+}
+
+// soleBlackHoleExemptRecvFloor is the per-tick GROUP recv above which a
+// directional group's sole ACTIVE (light-direction) leg is exempt from the
+// sole-leg black-hole reaping.
+const soleBlackHoleExemptRecvFloor = 16 * 1024
+
+// soleLegBlackHoleExempt reports whether the sole-leg black-hole reaping should
+// be SKIPPED this tick. Under unidirectional assignment the sole active leg
+// carries only ONE direction — on a download it is the light FORWARD (upload)
+// leg, which sends acks but receives ~nothing because the download flows on the
+// REVERSE (send-standby) mux legs. Judging that leg by its own recv would misread
+// it as a black-hole and prune the direct leg exactly when unidir is working. So
+// skip the reaping when directional AND the GROUP is receiving data on its
+// reverse legs (aggregate recv delta above the floor) — the group is not
+// black-holing even though the sole active leg is quiet on the receive side.
+func soleLegBlackHoleExempt(directional bool, aggRecvDelta uint64) bool {
+	return directional && aggRecvDelta > soleBlackHoleExemptRecvFloor
+}
+
 // dirConfig snapshots the directional state under legMu so the send path reads it
 // once and then uses lock-free pure helpers (avoids re-locking legMu per leg).
 func (m *routeMux) dirConfig() (directional, wantDirect bool, dst, src cipher.PubKey) {

--- a/pkg/router/unidir_test.go
+++ b/pkg/router/unidir_test.go
@@ -81,3 +81,24 @@ func TestLegIsDirect(t *testing.T) {
 		t.Fatal("test endpoints must be distinct")
 	}
 }
+
+// TestSoleLegBlackHoleExempt: a directional group receiving on its reverse legs
+// exempts its sole light-direction leg from black-hole reaping; a non-directional
+// group, or a directional group with no group recv, is not exempt.
+func TestSoleLegBlackHoleExempt(t *testing.T) {
+	// directional + group receiving (aggDelta above floor) → exempt.
+	if !soleLegBlackHoleExempt(true, soleBlackHoleExemptRecvFloor+1) {
+		t.Fatal("directional group with healthy recv should be exempt")
+	}
+	// directional but group NOT receiving (idle) → not exempt (a real black-hole).
+	if soleLegBlackHoleExempt(true, 0) {
+		t.Fatal("directional group with no recv should NOT be exempt")
+	}
+	if soleLegBlackHoleExempt(true, soleBlackHoleExemptRecvFloor) {
+		t.Fatal("recv exactly at the floor should NOT be exempt (strictly above)")
+	}
+	// non-directional group → never exempt (old behavior unchanged).
+	if soleLegBlackHoleExempt(false, 10*soleBlackHoleExemptRecvFloor) {
+		t.Fatal("non-directional group must never be exempt")
+	}
+}


### PR DESCRIPTION
The sole-leg black-hole detector reaps a group's lone active leg when it has *sent* a request but *received* almost nothing — a dead route. Under unidirectional assignment (CapUniDir) it misfires on the **direct leg**:

```
sole-leg black-hole: only active route sent 288B but received 224B over 15s — dialing a replacement route
```

On a download the initiator's sole active leg is the light **forward (upload)** leg — it sends acks but receives ~nothing because the download flows on the **reverse (send-standby) mux legs**. So the detector prunes the direct leg exactly when unidir is working; the leg then re-dials multihop and the direct/forward binding is lost. This is why the direct leg wouldn't stay put during a download.

Fix: make the reaping direction-aware — skip it when the mux is directional **and** the group is receiving on its reverse legs (the aggregate per-tick recv delta, already computed for the data-progress prune, is above a floor). The group is plainly not black-holing while the download streams in on the other legs. Non-directional groups are unaffected. Test covers exempt / not-exempt / non-directional.

Follow-up to #4304/#4305 — makes the unidirectional direct leg survive so the light-direction binding is stable.