### PR TITLE
fix(router): unidirectional DIRECTION governs send-selection, not the standby flag

### DIFF
--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -360,14 +360,19 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 		return nil, nil, -1, ErrNoRules
 	}
 
-	// Unidirectional send selection (CapUniDir): restrict this end's send to legs
-	// matching its direction (initiator→direct, acceptor→multihop, swapped when
-	// flipped) — but only when at least one ready leg matches, so a send never
-	// fails for lack of a direction-matching leg. dirOK gates every pick below.
-	directional, wantDirect, dstPK, srcPK := m.dirConfig()
-	restrictDir := directional && m.dirRestrict(tps, wantDirect, dstPK, srcPK)
-	dirOK := func(tp *transport.ManagedTransport) bool {
-		return !restrictDir || legIsDirect(tp, dstPK, srcPK) == wantDirect
+	// Unidirectional send selection (CapUniDir).
+	// DIRECTION — not the send-side standby flag — governs which legs carry this
+	// end's traffic. A reverse (mux) leg is standby on the INITIATOR's send side
+	// (it doesn't upload on it), yet the EXIT must send the download on it; the old
+	// standby-gated filter (legReadyAt excludes standby) found no ready reverse leg
+	// on the exit and fell back to the active direct leg, landing the whole
+	// download on the wrong direction. So select among direction-matching legs with
+	// readiness that IGNORES standby (selectByDirection); fall through to the
+	// standard, standby-aware path only when no direction-matching leg is available.
+	if directional, wantDirect, dstPK, srcPK := m.dirConfig(); directional {
+		if tp, rule, idx, ok := m.selectByDirection(tps, fwd, wantDirect, dstPK, srcPK); ok {
+			return tp, rule, idx, nil
+		}
 	}
 
 	// Payload-inspecting modes: ask the selector for a leg
@@ -383,7 +388,7 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 			idx := m.tpSelector.SelectForPayload(payload)
 			if idx < len(tps) {
 				tp := tps[idx]
-				if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) && dirOK(tp) {
+				if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) {
 					return tp, fwd[idx], idx, nil
 				}
 			}
@@ -395,7 +400,7 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 		idx := m.tpSelector.Select()
 		if idx < len(tps) {
 			tp := tps[idx]
-			if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) && dirOK(tp) {
+			if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) {
 				return tp, fwd[idx], idx, nil
 			}
 		}
@@ -411,7 +416,7 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 	for i := uint32(0); i < n; i++ {
 		idx := int((start + i) % n) //nolint:gosec
 		tp := tps[idx]
-		if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) && dirOK(tp) {
+		if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) {
 			return tp, fwd[idx], idx, nil
 		}
 	}

--- a/pkg/router/unidir.go
+++ b/pkg/router/unidir.go
@@ -2,9 +2,11 @@
 package router
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/transport"
 )
 
@@ -189,16 +191,41 @@ func (m *routeMux) flipStep(up, down float64) (flipped, changed bool) {
 	return cur, false
 }
 
-// dirRestrict reports whether direction filtering should be enforced this pick:
-// true only when directional AND at least one READY leg matches the wanted
-// direction. When no matching leg is available it returns false so selection
-// falls back to any ready leg (a send is never dropped for lack of a
-// direction-matching leg).
-func (m *routeMux) dirRestrict(tps []*transport.ManagedTransport, wantDirect bool, dst, src cipher.PubKey) bool {
-	for idx, tp := range tps {
-		if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) && legIsDirect(tp, dst, src) == wantDirect {
-			return true
+// selectByDirection picks a leg matching this end's send direction, using
+// readiness that IGNORES the standby flag (legSelectableIgnoringStandby) —
+// because under unidirectional assignment DIRECTION governs, and a reverse leg
+// the initiator parked as standby must still be selectable by the exit for the
+// download. It prefers the weighted selector's pick when that pick matches the
+// direction, else round-robins among direction-matching legs. Returns ok=false
+// when no direction-matching leg is ready, so selectTransport falls through to
+// the standard (standby-aware) path rather than dropping the send.
+func (m *routeMux) selectByDirection(tps []*transport.ManagedTransport, fwd []routing.Rule, wantDirect bool, dst, src cipher.PubKey) (*transport.ManagedTransport, routing.Rule, int, bool) {
+	n := len(tps)
+	if n == 0 || len(fwd) == 0 {
+		return nil, nil, -1, false
+	}
+	match := func(idx int) bool {
+		tp := tps[idx]
+		return idx < len(fwd) && tp != nil && !tp.IsClosed() &&
+			m.legSelectableIgnoringStandby(idx) && legIsDirect(tp, dst, src) == wantDirect
+	}
+	// Prefer the scheduler's pick when it already matches the direction, so the
+	// heavy direction still spreads across legs per the mux weights/ECF.
+	if m.tpSelector != nil && m.tpSelector.Len() > 0 {
+		if idx := m.tpSelector.Select(); idx >= 0 && idx < n && match(idx) {
+			return tps[idx], fwd[idx], idx, true
 		}
 	}
-	return false
+	// Round-robin among direction-matching legs.
+	start := int(atomic.AddUint32(&m.tpIndex, 1) - 1)
+	for i := 0; i < n; i++ {
+		idx := ((start % n) + i) % n
+		if idx < 0 {
+			idx += n
+		}
+		if match(idx) {
+			return tps[idx], fwd[idx], idx, true
+		}
+	}
+	return nil, nil, -1, false
 }


### PR DESCRIPTION
The download landed on the **direct leg** — the opposite of the unidirectional design — because two earlier changes fought each other.

On a download the initiator marks the direct leg active and the mux legs standby, and #4300/#4302 mirror that to the exit. The exit then sends the download, but its direction filter (`dirRestrict`) only engaged when a **ready (non-standby)** reverse leg existed — and the initiator had just marked all the exit's reverse legs standby. So the filter disengaged and the exit fell back to its one active leg: the direct leg. **The standby signal disabled the very filter meant to route the download to the mux.**

Fix: decouple direction from standby. When directional, select among direction-matching legs with readiness that **ignores** the standby flag (`selectByDirection`, built on `legSelectableIgnoringStandby`). The exit now sends the download on its reverse (multihop) legs even though they're standby on the initiator's send side; the initiator still sends its upload on the direct leg. Falls through to the standard standby-aware path only when no direction-matching leg is ready, so a send is never dropped. Replaces `dirRestrict`.

Both endpoints must be on this build to bind end-to-end (the exit's send-side is what routes the download). Follow-up to #4304/#4305/#4310.