### PR TITLE
fix(lint): clear the golangci-lint debt in the FEC code

### DIFF
--- a/pkg/router/fec.go
+++ b/pkg/router/fec.go
@@ -79,7 +79,7 @@ func newFECBlockCoder(k, r, symLen int) *fecBlockCoder {
 		row := make([]byte, k)
 		xi := byte(i)
 		for j := 0; j < k; j++ {
-			yj := byte(r + j)
+			yj := byte(r + j)       //nolint:gosec // r+j < r+k <= 256, rejected above
 			row[j] = gfInv(xi ^ yj) // xi != yj always (i<r<=r+j), so xor != 0
 		}
 		cauchy[i] = row

--- a/pkg/router/fec_endtoend_test.go
+++ b/pkg/router/fec_endtoend_test.go
@@ -175,7 +175,7 @@ func fecE2ESetup(t *testing.T, fec bool, legLatencies []time.Duration) (*RouteGr
 		// Close's teardown handshake would otherwise block on timeouts we don't
 		// need in-test.
 		for _, p := range pipes {
-			p.Close() //nolint:errcheck
+			p.Close() //nolint:errcheck,gosec // see the comment above: teardown is deliberately skipped here
 		}
 	}
 	return rgA, rgB, pipes, cleanup

--- a/pkg/router/fec_mux_test.go
+++ b/pkg/router/fec_mux_test.go
@@ -92,7 +92,7 @@ func TestFECMuxUpToRErasures(t *testing.T) {
 		for _, rf := range repairs {
 			rt.RecordRepair(rf.blockID, rf.idx, rf.symLen, rf.symbol)
 		}
-		got, ok := rt.Reconstruct(uint32(target))
+		got, ok := rt.Reconstruct(uint32(target)) //nolint:gosec // target ranges over the literal drop set above
 		if !ok {
 			t.Fatalf("seq %d: reconstruction failed with R repairs for R erasures", target)
 		}
@@ -117,7 +117,7 @@ func TestFECMuxUpToRErasures(t *testing.T) {
 		reMulti.RecordRepair(rf.blockID, rf.idx, rf.symLen, rf.symbol)
 	}
 	for target := range drop {
-		got, ok := reMulti.Reconstruct(uint32(target))
+		got, ok := reMulti.Reconstruct(uint32(target)) //nolint:gosec // target ranges over the literal drop set above
 		if !ok {
 			t.Fatalf("multi-erasure: sibling seq %d failed to reconstruct independently", target)
 		}

--- a/pkg/router/fec_test.go
+++ b/pkg/router/fec_test.go
@@ -62,11 +62,11 @@ func decodeWithErasures(t *testing.T, c *fecBlockCoder, data [][]byte, erase []i
 }
 
 func mkData(k, symLen int, seed int64) [][]byte {
-	rng := rand.New(rand.NewSource(seed))
+	rng := rand.New(rand.NewSource(seed)) //nolint:gosec // fixed seed: these tests need reproducible data, not entropy
 	data := make([][]byte, k)
 	for i := range data {
 		data[i] = make([]byte, symLen)
-		rng.Read(data[i])
+		_, _ = rng.Read(data[i]) // math/rand.Read never returns an error
 	}
 	return data
 }
@@ -120,7 +120,10 @@ func TestFECRecoversAllErasurePatterns(t *testing.T) {
 func TestFECErasureBeyondRFails(t *testing.T) {
 	c := newFECBlockCoder(4, 2, 16)
 	data := mkData(4, 16, 7)
-	repair, _ := c.Encode(data)
+	repair, err := c.Encode(data)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
 	recv := make([][]byte, 6)
 	present := make([]bool, 6)
 	for i := 0; i < 4; i++ {
@@ -143,7 +146,10 @@ func TestFECErasureBeyondRFails(t *testing.T) {
 func TestFECSystematicFastPath(t *testing.T) {
 	c := newFECBlockCoder(5, 3, 24)
 	data := mkData(5, 24, 99)
-	repair, _ := c.Encode(data)
+	repair, err := c.Encode(data)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
 	recv := make([][]byte, 8)
 	present := make([]bool, 8)
 	for i := 0; i < 5; i++ {
@@ -162,7 +168,7 @@ func TestFECSystematicFastPath(t *testing.T) {
 
 // TestFECFuzz: random data + random erasure patterns of size <= r always recover.
 func TestFECFuzz(t *testing.T) {
-	rng := rand.New(rand.NewSource(12345))
+	rng := rand.New(rand.NewSource(12345)) //nolint:gosec // fixed seed: the fuzz loop must replay identically on failure
 	for iter := 0; iter < 400; iter++ {
 		k := 1 + rng.Intn(12)
 		r := rng.Intn(6)

--- a/pkg/routing/packet_test.go
+++ b/pkg/routing/packet_test.go
@@ -175,7 +175,7 @@ func TestMakeRepairPacketRoundTrip(t *testing.T) {
 	symLen := 4098
 	symbol := make([]byte, symLen)
 	for i := range symbol {
-		symbol[i] = byte(i * 31)
+		symbol[i] = byte((i * 31) & 0xff) // deliberate wrap: just a repeating fill pattern
 	}
 
 	p, err := MakeRepairPacket(id, blockID, idx, symLen, symbol)


### PR DESCRIPTION
**Did you run `make format && make check`?** `golangci-lint run -c .golangci.yml ./...` reports **0 issues**; `gofmt` clean; `go test ./pkg/router/ ./pkg/routing/` passes.

**Fixes:** the red `linux` / `darwin` / `windows` lanes

**Changes:**
Ten findings, all introduced when the FEC work landed on 2026-08-28. #4221 bumped golangci-lint to v2.13.1 on 2026-08-26 — the same day the previous lint-debt PR (#4237) merged — and `G115` is one of the rules that arrived with it, so the FEC PR was written against a linter that did not yet have the check.

Three were real defects, fixed rather than suppressed:
- `fec_test.go:123`, `:146` — `repair, _ := c.Encode(data)` discarded the error, so both tests would pass against a coder that encoded nothing. They now `t.Fatalf`.
- `mkData` — `math/rand`'s `Read` is documented never to return an error, so the result is dropped explicitly.
- `packet_test.go` — `byte(i * 31)` is a repeating fill pattern; the wrap is now explicit as `byte((i * 31) & 0xff)`.

The rest are conversions that cannot overflow, and each `//nolint` carries the invariant rather than just the rule name:
- `fec.go:82` — `byte(r + j)` is bounded by the `k+r > 256` guard eight lines above, with `j < k`.
- `fec_mux_test.go:95`, `:120` — `target` ranges over the three-element literal `drop` map.
- The two fixed `rand.NewSource` seeds stay fixed: one gives the tests reproducible data, the other lets the 400-iteration fuzz loop replay identically on failure. That is the opposite of what `crypto/rand` is for.
- `fec_endtoend_test.go:178` already carried `//nolint:errcheck`, which does not cover gosec reporting the same unchecked `Close` under `G104`.

**How to test this PR:**
`golangci-lint run -c .golangci.yml ./...` — 0 issues. Nothing in the FEC algorithms changes; the only behavioural difference is that two tests now fail on an `Encode` error instead of continuing past it.