### PR TITLE
feat(proxystatus): two-level route tree — stream (tunnels) over packet (legs)

### DIFF
--- a/cmd/skywire-cli/commands/proxy/tree.go
+++ b/cmd/skywire-cli/commands/proxy/tree.go
@@ -79,7 +79,7 @@ the tree companion to 'proxy log' (which streams the events/log).
 			return
 		}
 
-		snap := rgs[0].toSnapshot()
+		snap := snapshotFromGroups(rgs)
 		opts := bitree.Options{}
 		if wantColor(treeColor) {
 			opts.StyleCell = ansiStyleCell
@@ -174,15 +174,10 @@ type treeHopInfo struct {
 	LatencyMS float64 `json:"latency_ms,omitempty"`
 }
 
-// toSnapshot projects the wire route group into the shared proxystatus.Snapshot
-// shape the RouteTree adapter consumes — the exact structure the visor builds
-// for the status page, so the CLI and the page render identically.
-func (rg treeRouteGroup) toSnapshot() proxystatus.Snapshot {
-	snap := proxystatus.Snapshot{
-		Surface:    proxystatus.SurfaceSkysocks,
-		App:        clientName,
-		MuxEnabled: rg.MuxEnabled,
-	}
+// toLegs projects one wire route group's legs into the shared proxystatus.Leg
+// shape the RouteTree adapter consumes.
+func (rg treeRouteGroup) toLegs() []proxystatus.Leg {
+	legs := make([]proxystatus.Leg, 0, len(rg.Legs))
 	for _, l := range rg.Legs {
 		leg := proxystatus.Leg{
 			Index:          l.Index,
@@ -209,7 +204,28 @@ func (rg treeRouteGroup) toSnapshot() proxystatus.Snapshot {
 				LatencyMS: h.LatencyMS,
 			})
 		}
-		snap.Legs = append(snap.Legs, leg)
+		legs = append(legs, leg)
+	}
+	return legs
+}
+
+// snapshotFromGroups projects EVERY wire route group into the shared
+// proxystatus.Snapshot, one Tunnel (stream-level) per group with its own
+// packet-level Legs — the exact structure the visor builds for the status page,
+// so the CLI and the page render the identical two-level tree.
+func snapshotFromGroups(rgs []treeRouteGroup) proxystatus.Snapshot {
+	snap := proxystatus.Snapshot{Surface: proxystatus.SurfaceSkysocks, App: clientName}
+	for i, rg := range rgs {
+		snap.Tunnels = append(snap.Tunnels, proxystatus.Tunnel{
+			Index:      i,
+			ExitPK:     rg.Desc.DstPK,
+			MuxEnabled: rg.MuxEnabled,
+			Legs:       rg.toLegs(),
+		})
+	}
+	if len(snap.Tunnels) > 0 {
+		snap.MuxEnabled = snap.Tunnels[0].MuxEnabled
+		snap.Legs = snap.Tunnels[0].Legs
 	}
 	return snap
 }

--- a/pkg/proxystatus/provider.go
+++ b/pkg/proxystatus/provider.go
@@ -102,14 +102,33 @@ type Hop struct {
 // wire change. Keep additions additive.
 type Snapshot struct {
 	Surface    Surface
-	App        string   // underlying app/logger name (dmsgweb / skynetweb / skysocks-client)
-	Running    bool     // whether the surface's process/runtime is currently alive
-	MuxEnabled bool     // route group has multiplexing enabled
-	Legs       []Leg    // current per-leg mux state (empty when no active route group)
-	Logs       []string // recent log lines, oldest first
-	Events     []string // route/transport events affecting this surface, oldest first
-	Streams    []Stream // per-stream detail for the open session (skysocks tunnel), when tracked
-	Note       string   // optional human note (e.g. why a section is empty)
+	App        string // underlying app/logger name (dmsgweb / skynetweb / skysocks-client)
+	Running    bool   // whether the surface's process/runtime is currently alive
+	MuxEnabled bool   // route group has multiplexing enabled
+	Legs       []Leg  // current per-leg mux state (empty when no active route group)
+	// Tunnels is the STREAM-level view: one entry per active route group (a
+	// --tunnels stream), each carrying its own PACKET-level mux Legs. The two
+	// levels of route multiplexing are stream (tunnels, disjoint route groups)
+	// over packet (mux legs striping within a group). When populated the route
+	// tree nests tunnel → legs; when empty the tree falls back to the flat Legs
+	// list above (a caller that only projects a single route group). Legs mirrors
+	// Tunnels[0].Legs for back-compat.
+	Tunnels []Tunnel
+	Logs    []string // recent log lines, oldest first
+	Events  []string // route/transport events affecting this surface, oldest first
+	Streams []Stream // per-stream detail for the open session (skysocks tunnel), when tracked
+	Note    string   // optional human note (e.g. why a section is empty)
+}
+
+// Tunnel is one STREAM-level route group — a single --tunnels stream to the exit,
+// carrying its own PACKET-level mux Legs. With --tunnels N there are N tunnels,
+// each auto-steered onto a disjoint first-hop transport; with a single tunnel
+// there is one entry whose Legs are the mux's packet-striped routes.
+type Tunnel struct {
+	Index      int    // tunnel index in dial order (0-based)
+	ExitPK     string // destination exit PK (full, never truncated); same across tunnels
+	MuxEnabled bool   // this tunnel's route group has packet-level mux enabled
+	Legs       []Leg  // this tunnel's packet-level mux legs
 }
 
 // Stream is one open tunneled stream on the surface's session to the exit — the

--- a/pkg/proxystatus/routetree.go
+++ b/pkg/proxystatus/routetree.go
@@ -55,21 +55,75 @@ const (
 // multihop, then standby, matching the page's reading order. The returned root
 // is nil-safe to render (bitree.Render handles a childless root).
 func RouteTree(snap Snapshot) *bitree.Node {
-	src := "this visor"
-	for _, l := range snap.Legs {
-		if len(l.Hops) > 0 && l.Hops[0].From != "" {
-			src = l.Hops[0].From
-			break
+	root := &bitree.Node{Label: treeSrc(snap)}
+	// TWO-LEVEL view: root → tunnel (stream-level route group) → legs (packet-level
+	// mux). Each tunnel is a --tunnels stream; the legs under it are the mux routes
+	// striping that stream's packets. This makes the two kinds of route
+	// multiplexing legible — which legs belong to which stream — instead of one
+	// flat leg list.
+	if len(snap.Tunnels) > 0 {
+		for _, t := range snap.Tunnels {
+			legNodes := legNodesFor(t.Legs)
+			if len(legNodes) == 0 {
+				continue
+			}
+			tn := &bitree.Node{Label: tunnelLabel(t, len(legNodes))}
+			tn.Right = legNodes
+			root.Right = append(root.Right, tn)
+		}
+		return root
+	}
+	// Flat fallback: a caller that projects a single route group (Tunnels unset).
+	root.Right = legNodesFor(snap.Legs)
+	return root
+}
+
+// treeSrc finds the source PK to label the tree root — this visor, taken from any
+// leg's first hop, across all tunnels (or the flat Legs list).
+func treeSrc(snap Snapshot) string {
+	pick := func(legs []Leg) string {
+		for _, l := range legs {
+			if len(l.Hops) > 0 && l.Hops[0].From != "" {
+				return l.Hops[0].From
+			}
+		}
+		return ""
+	}
+	for _, t := range snap.Tunnels {
+		if s := pick(t.Legs); s != "" {
+			return s
 		}
 	}
-	root := &bitree.Node{Label: src}
+	if s := pick(snap.Legs); s != "" {
+		return s
+	}
+	return "this visor"
+}
 
-	legs := make([]Leg, 0, len(snap.Legs))
-	for _, l := range snap.Legs {
+// tunnelLabel names a stream-level tunnel node: its index and how many
+// packet-level legs stripe under it.
+func tunnelLabel(t Tunnel, nLegs int) string {
+	legWord := "legs"
+	if nLegs == 1 {
+		legWord = "leg"
+	}
+	return fmt.Sprintf("stream %d · %d %s", t.Index, nLegs, legWord)
+}
+
+// legNodesFor prunes dead legs, orders them (direct-active first, then active
+// multihop, then standby), and builds the per-leg route nodes with each leg's
+// share drawn against the aggregate goodput of THIS set (per tunnel when nested,
+// or the whole group in the flat fallback).
+func legNodesFor(all []Leg) []*bitree.Node {
+	legs := make([]Leg, 0, len(all))
+	for _, l := range all {
 		if !l.Alive { // prune dead routes/legs
 			continue
 		}
 		legs = append(legs, l)
+	}
+	if len(legs) == 0 {
+		return nil
 	}
 	sort.SliceStable(legs, func(i, j int) bool {
 		if ri, rj := legRank(legs[i]), legRank(legs[j]); ri != rj {
@@ -77,23 +131,19 @@ func RouteTree(snap Snapshot) *bitree.Node {
 		}
 		return legs[i].Index < legs[j].Index
 	})
-
-	// Aggregate per-direction goodput across the surviving (alive) legs — the
-	// denominator each route's share bar is drawn against (this route's fraction
-	// of the whole group's up / down goodput). Summed here rather than plumbed
-	// from AggGoodput*Bps so the shared adapter stays self-contained on the leg
-	// list both surfaces already carry.
+	// Aggregate per-direction goodput across the surviving legs — the denominator
+	// each route's share bar is drawn against.
 	var aggUp, aggDown float64
 	for _, l := range legs {
 		aggUp += l.GoodputUpBps
 		aggDown += l.GoodputDownBps
 	}
-
 	w := legSumWidths(legs)
+	nodes := make([]*bitree.Node, 0, len(legs))
 	for _, l := range legs {
-		root.Right = append(root.Right, routeToNode(l, w, aggUp, aggDown))
+		nodes = append(nodes, routeToNode(l, w, aggUp, aggDown))
 	}
-	return root
+	return nodes
 }
 
 // sumWidths holds the per-field display widths used to pad every route's left

--- a/pkg/proxystatus/routetree_test.go
+++ b/pkg/proxystatus/routetree_test.go
@@ -1,0 +1,45 @@
+package proxystatus
+
+import "testing"
+
+// TestRouteTreeTwoLevel: with Tunnels populated the tree nests root → tunnel
+// (stream) → legs (packet); the flat Legs fallback still applies when Tunnels is
+// empty.
+func TestRouteTreeTwoLevel(t *testing.T) {
+	leg := func(idx int, direct bool) Leg {
+		return Leg{Index: idx, Alive: true, Direct: direct, GoodputDownBps: 1000,
+			Hops: []Hop{{From: "srcpk", To: "dstpk"}}}
+	}
+	snap := Snapshot{
+		Tunnels: []Tunnel{
+			{Index: 0, Legs: []Leg{leg(0, true), leg(1, false)}},
+			{Index: 1, Legs: []Leg{leg(0, false), leg(1, false), leg(2, false)}},
+		},
+	}
+	root := RouteTree(snap)
+	if root == nil {
+		t.Fatal("nil root")
+	}
+	if len(root.Right) != 2 {
+		t.Fatalf("root has %d tunnel children, want 2", len(root.Right))
+	}
+	// Tunnel 0 has 2 legs, tunnel 1 has 3 — the packet-level spread under each.
+	if got := len(root.Right[0].Right); got != 2 {
+		t.Errorf("tunnel 0 has %d legs, want 2", got)
+	}
+	if got := len(root.Right[1].Right); got != 3 {
+		t.Errorf("tunnel 1 has %d legs, want 3", got)
+	}
+	if root.Right[0].Label == root.Right[1].Label {
+		t.Error("tunnel labels should differ by index")
+	}
+
+	// Empty Tunnels → flat fallback: legs hang directly off root.
+	flat := RouteTree(Snapshot{Legs: []Leg{leg(0, true), leg(1, false)}})
+	if len(flat.Right) != 2 {
+		t.Fatalf("flat fallback: root has %d leg children, want 2", len(flat.Right))
+	}
+	if len(flat.Right[0].Right) != 0 {
+		t.Error("flat fallback should not nest a tunnel level")
+	}
+}

--- a/pkg/visor/embedded_proxystatus.go
+++ b/pkg/visor/embedded_proxystatus.go
@@ -117,30 +117,25 @@ func (p *visorStatusProvider) StatusSnapshot(surface proxystatus.Surface) (proxy
 		snap.Note = appendNote(snap.Note, "logs unavailable: "+err.Error())
 	}
 
-	// Mux legs (best-effort): the surface may have no active route group.
+	// Mux legs (best-effort): the surface may have no active route group. Each
+	// route group is one --tunnels STREAM; its Legs are the PACKET-level mux. Model
+	// every tunnel (not just the first) so the status tree can nest tunnel → legs;
+	// mirror the first tunnel's legs into snap.Legs for back-compat.
 	if infos, err := p.v.RouteGroupMuxInfo(app); err == nil {
-		if len(infos) > 0 {
-			snap.MuxEnabled = infos[0].MuxEnabled
-			for _, leg := range infos[0].Legs {
-				snap.Legs = append(snap.Legs, proxystatus.Leg{
-					Index:          leg.Index,
-					TransportID:    leg.TransportID,
-					TpType:         leg.TpType,
-					RemotePK:       leg.RemotePK,
-					LatencyMS:      leg.LatencyMS,
-					RouteLatencyMS: leg.RouteLatencyMS,
-					Direct:         leg.Direct,
-					SentBytes:      leg.SentBytes,
-					RecvBytes:      leg.RecvBytes,
-					Retransmits:    leg.Retransmits,
-					GoodputBps:     leg.GoodputBps,
-					GoodputUpBps:   leg.GoodputUpBps,
-					GoodputDownBps: leg.GoodputDownBps,
-					Alive:          leg.Alive,
-					Standby:        leg.Standby,
-					Hops:           proxyHopsFrom(leg.Hops),
-				})
+		for ti, info := range infos {
+			t := proxystatus.Tunnel{
+				Index:      ti,
+				ExitPK:     info.Desc.DstPK.String(),
+				MuxEnabled: info.MuxEnabled,
 			}
+			for _, leg := range info.Legs {
+				t.Legs = append(t.Legs, proxyLegFrom(leg))
+			}
+			snap.Tunnels = append(snap.Tunnels, t)
+		}
+		if len(snap.Tunnels) > 0 {
+			snap.MuxEnabled = snap.Tunnels[0].MuxEnabled
+			snap.Legs = snap.Tunnels[0].Legs
 		}
 	} else {
 		snap.Note = appendNote(snap.Note, "mux info unavailable: "+err.Error())
@@ -157,6 +152,29 @@ func appendNote(existing, add string) string {
 		return add
 	}
 	return existing + " · " + add
+}
+
+// proxyLegFrom transcribes one visor MuxLegInfo into the proxystatus.Leg shape
+// the status tree renders. Shared by every tunnel's leg list.
+func proxyLegFrom(leg MuxLegInfo) proxystatus.Leg {
+	return proxystatus.Leg{
+		Index:          leg.Index,
+		TransportID:    leg.TransportID,
+		TpType:         leg.TpType,
+		RemotePK:       leg.RemotePK,
+		LatencyMS:      leg.LatencyMS,
+		RouteLatencyMS: leg.RouteLatencyMS,
+		Direct:         leg.Direct,
+		SentBytes:      leg.SentBytes,
+		RecvBytes:      leg.RecvBytes,
+		Retransmits:    leg.Retransmits,
+		GoodputBps:     leg.GoodputBps,
+		GoodputUpBps:   leg.GoodputUpBps,
+		GoodputDownBps: leg.GoodputDownBps,
+		Alive:          leg.Alive,
+		Standby:        leg.Standby,
+		Hops:           proxyHopsFrom(leg.Hops),
+	}
 }
 
 // proxyHopsFrom transcribes the visor's per-leg MuxHopInfo into the


### PR DESCRIPTION
status.skysocks and `cli proxy tree` flattened every route group into one leg list, so with `--tunnels` (multiple disjoint route groups) you couldn't tell which legs belonged to which stream — the two kinds of route multiplexing, **stream-level (tunnels) over packet-level (mux legs)**, were invisible.

Model both levels: `Snapshot` gains `Tunnels []Tunnel` (one per route group, each carrying its own packet-level `Legs`). The provider and the CLI now project **every** route group (both used only `infos[0]`/`rgs[0]` before), and the shared `RouteTree` adapter nests `root → tunnel (stream) → legs (packet)`. Page and CLI render the identical two-level tree since they share the adapter. `Legs` still mirrors the first tunnel for back-compat, and `RouteTree` falls back to the flat layout when `Tunnels` is unset. Test covers the nested two-tunnel shape and the flat fallback.