### PR TITLE
proxystatus: visually distinguish the two mux layers in the route tree

### DIFF
--- a/cmd/skywire-cli/commands/proxy/tree.go
+++ b/cmd/skywire-cli/commands/proxy/tree.go
@@ -102,12 +102,13 @@ func wantColor(mode string) bool {
 }
 
 const (
-	ansiReset  = "\x1b[0m"
-	ansiBold   = "\x1b[1m"
-	ansiDim    = "\x1b[2m"
-	ansiCyan   = "\x1b[36m"
-	ansiGreen  = "\x1b[32m"
-	ansiYellow = "\x1b[33m"
+	ansiReset   = "\x1b[0m"
+	ansiBold    = "\x1b[1m"
+	ansiDim     = "\x1b[2m"
+	ansiCyan    = "\x1b[36m"
+	ansiGreen   = "\x1b[32m"
+	ansiYellow  = "\x1b[33m"
+	ansiMagenta = "\x1b[35m"
 )
 
 // ansiStyleCell colorizes the route tree for a terminal without changing any
@@ -120,6 +121,11 @@ func ansiStyleCell(text string, kind bitree.CellKind) string {
 	case bitree.CellRoot:
 		return ansiBold + ansiCyan + text + ansiReset
 	case bitree.CellLabel:
+		// A stream-boundary header (the STREAM layer) reads as a distinct kind of
+		// node — bold magenta — vs a plain-cyan hop PK, mirroring the page's badge.
+		if strings.HasPrefix(strings.TrimSpace(text), proxystatus.StreamHeaderGlyph) {
+			return ansiBold + ansiMagenta + text + ansiReset
+		}
 		return ansiCyan + text + ansiReset
 	case bitree.CellColumn:
 		return ansiDim + text + ansiReset

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -240,6 +240,12 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 	// LEVEL its own hue (see hopClassMap). Captured in the StyleCell closure so the
 	// PK label cells can be wrapped without disturbing bitree's plain-text layout.
 	hopClasses := hopClassMap(snap)
+	// When more than one stream is present, name the two multiplexing LAYERS above
+	// the tree so the stream-boundary nodes and per-stream leg bands below are
+	// self-explanatory.
+	if len(snap.Tunnels) > 1 {
+		writeLayerLegend(b)
+	}
 	b.WriteString(`<div class="tree">`)
 	b.WriteString(`<pre class="bitree">`)
 	b.WriteString(bitree.Render(RouteTree(snap), bitree.Options{
@@ -266,6 +272,17 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 // instead of a separate swatch dot beside each word. The column hints live in
 // the label-header row above the tree (TreeHeader), so the legend only names the
 // color coding. Dead legs are pruned, so there is no dead entry.
+// writeLayerLegend names the TWO route-multiplexing layers the tree shows, so
+// the stream-boundary header nodes (▚) and the per-stream leg accent bands (▏sN)
+// read as two distinct kinds of multiplexing. Rendered only when more than one
+// stream is present (single-stream trees carry no stream chrome to explain).
+func writeLayerLegend(b *strings.Builder) {
+	b.WriteString(`<div class="llayers">` +
+		`<span class="llayer stream-l"><b>` + StreamHeaderGlyph + ` stream</b> · independent route groups (--tunnels)</span>` +
+		`<span class="llayer leg-l"><b>` + StreamBandGlyph + `sN leg</b> · packet-striping mux within a stream</span>` +
+		`</div>`)
+}
+
 func writeTreeLegend(b *strings.Builder) {
 	b.WriteString(`<div class="tlegend">` +
 		`<span class="lgnd src">source · this visor</span>` +
@@ -289,6 +306,12 @@ func htmlStyleCell(text string, kind bitree.CellKind, hopClasses map[string]stri
 	case bitree.CellRoot:
 		return `<span class="src">` + copyablePK(text) + `</span>`
 	case bitree.CellLabel:
+		// A stream-boundary header (the STREAM layer): a different KIND of node than a
+		// hop PK — give it the stream's accent + badge styling rather than PK coloring.
+		if strings.HasPrefix(strings.TrimSpace(text), StreamHeaderGlyph) {
+			return `<span class="streamhdr ` + streamAccentClass(streamIdxOf(text, "stream ")) + `">` +
+				html.EscapeString(text) + `</span>`
+		}
 		// A hop PK: color it by its role/depth (exit red, intermediates by level).
 		// The class wraps copyablePK so the click-to-copy PK is unchanged; the span
 		// is zero-width text, so bitree's monospace column layout is preserved. The
@@ -332,6 +355,23 @@ func htmlLegSummary(text string) string {
 	if strings.TrimSpace(text) == "" {
 		return text // continuation / empty left row
 	}
+	// Peel off an optional leading per-STREAM accent band ("▏s0 "): color it with
+	// that stream's accent (the STREAM layer), OUTSIDE the state-tinted .lsum span,
+	// so the stream accent and the leg's active/standby state coding compose instead
+	// of one overriding the other. The leading padding spaces (bitree's right-
+	// justify) stay ahead of the band. When absent (single-stream view) nothing is
+	// peeled and the summary is styled exactly as before.
+	bandHTML := ""
+	if i := strings.Index(text, StreamBandGlyph); i >= 0 {
+		rest := text[i:]
+		if sp := strings.IndexByte(rest, ' '); sp > 0 {
+			tag := rest[:sp] // "▏s0"
+			bandHTML = html.EscapeString(text[:i]) +
+				`<span class="stream ` + streamAccentClass(streamIdxOf(tag, StreamBandGlyph+"s")) + `">` +
+				html.EscapeString(tag) + `</span> `
+			text = rest[sp+1:] // remainder after the tag + its space
+		}
+	}
 	cls, glyph := "ok", GlyphActive
 	if strings.Contains(text, GlyphStandby) {
 		cls, glyph = "standby", GlyphStandby
@@ -339,7 +379,38 @@ func htmlLegSummary(text string) string {
 	esc := html.EscapeString(text) // the glyphs/arrows are not HTML-special
 	dot := `<span class="tstate ` + cls + `">` + glyph + `</span>`
 	esc = strings.Replace(esc, glyph, dot, 1)
-	return `<span class="lsum ` + cls + `">` + esc + `</span>`
+	return bandHTML + `<span class="lsum ` + cls + `">` + esc + `</span>`
+}
+
+// streamIdxOf extracts the stream index that follows prefix in s (e.g. "stream "
+// in a header label, or "▏s" in a leg band) — the run of digits right after the
+// prefix. Returns 0 when no index is found, so an unparsable label still gets a
+// valid (first) accent rather than no class.
+func streamIdxOf(s, prefix string) int {
+	i := strings.Index(s, prefix)
+	if i < 0 {
+		return 0
+	}
+	j := i + len(prefix)
+	k := j
+	for k < len(s) && s[k] >= '0' && s[k] <= '9' {
+		k++
+	}
+	if k == j {
+		return 0
+	}
+	n := 0
+	for _, c := range s[j:k] {
+		n = n*10 + int(c-'0')
+	}
+	return n
+}
+
+// streamAccentClass maps a stream index to its stable CSS accent class,
+// cycling the small palette (--stream0…) so the accent is stable per index
+// across the ~1s live re-renders.
+func streamAccentClass(idx int) string {
+	return fmt.Sprintf("s%d", ((idx%streamAccentCount)+streamAccentCount)%streamAccentCount)
 }
 
 // legRank orders legs for the tree: the direct active leg (carrying app traffic)
@@ -744,7 +815,13 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	// intermediate hop LEVEL its own hue (level 1..4, then the classes cycle). All
 	// chosen for legibility on the tree's dark ground; the light block re-darkens
 	// them below so they clear the same contrast floor on a light background.
-	`--hop-exit:#ff5c5c;--hop1:#4fc3f7;--hop2:#c48cff;--hop3:#ffb74d;--hop4:#4dd0a0}` +
+	`--hop-exit:#ff5c5c;--hop1:#4fc3f7;--hop2:#c48cff;--hop3:#ffb74d;--hop4:#4dd0a0;` +
+	// Per-STREAM accents (the stream/tunnel layer): a small palette cycled by stream
+	// index (stream N → N % 5), stable per index across live re-renders. Chosen to
+	// stay clear of the state/exit hues (green/amber/red) so the stream accent never
+	// reads as active/standby or exit, and legible on the dark ground; the light
+	// block re-darkens them below to hold the same contrast floor.
+	`--stream0:#7c9cff;--stream1:#ff9e64;--stream2:#e879c9;--stream3:#4dd0e1;--stream4:#c3a6ff}` +
 	`*{box-sizing:border-box}html,body{margin:0;background:var(--bg);color:var(--fg);font:13.5px/1.55 system-ui,-apple-system,Segoe UI,Roboto,sans-serif}` +
 	`body{max-width:60rem;margin:0 auto;padding:1.2rem 1rem 3rem}` +
 	`header{display:flex;align-items:baseline;gap:.8rem;flex-wrap:wrap;border-bottom:1px solid var(--line);padding-bottom:.7rem}` +
@@ -817,6 +894,24 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`pre.bitree .hop-l3 code.fpk{color:var(--hop3)}pre.bitree .hop-l4 code.fpk{color:var(--hop4)}` +
 	`pre.bitree code.ftid{color:var(--muted)}pre.bitree .tcol{color:var(--muted)}` +
 	`pre.bitree .lsum.ok{color:var(--ok)}pre.bitree .lsum.standby{color:var(--standby)}` +
+	// STREAM layer coloring. The stream-boundary HEADER node reads as a badge — bold,
+	// its stream accent, a faint accent underline — clearly a different KIND of node
+	// than a leg/hop row. Each leg's leading "▏sN" band carries the same per-stream
+	// accent, tying the leg to its stream WITHOUT touching the state (●/○) or hop-PK
+	// coloring beside it, so the two layers' signals compose.
+	`pre.bitree .streamhdr{font-weight:700;letter-spacing:.3px;border-bottom:1px solid currentColor}` +
+	`pre.bitree .stream{font-weight:700}` +
+	`pre.bitree .streamhdr.s0,pre.bitree .stream.s0{color:var(--stream0)}` +
+	`pre.bitree .streamhdr.s1,pre.bitree .stream.s1{color:var(--stream1)}` +
+	`pre.bitree .streamhdr.s2,pre.bitree .stream.s2{color:var(--stream2)}` +
+	`pre.bitree .streamhdr.s3,pre.bitree .stream.s3{color:var(--stream3)}` +
+	`pre.bitree .streamhdr.s4,pre.bitree .stream.s4{color:var(--stream4)}` +
+	// Two-layer legend above the tree: names the stream (route-group) layer and the
+	// leg (packet-striping) layer so the ▚ header nodes and ▏sN leg bands are
+	// self-explanatory. The markers themselves carry the layer's accent.
+	`.llayers{display:flex;flex-wrap:wrap;gap:.3rem 1.4rem;font-size:11px;margin:.5rem 0 .2rem}` +
+	`.llayer{color:var(--muted)}.llayer b{font-family:ui-monospace,SFMono-Regular,monospace}` +
+	`.llayer.stream-l b{color:var(--stream0)}.llayer.leg-l b{color:var(--stream1)}` +
 	// Tree legend, BELOW the tree: the WORDS themselves are colored in their state
 	// colors (source accent, active green, standby amber) — no separate swatch dot
 	// beside each word. The column hints now live in the label-header row above the
@@ -871,5 +966,8 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`@media(prefers-color-scheme:light){:root{--bg:#f6f7fb;--fg:#1c1e26;--muted:#4a4f63;--card:#fff;--line:#d3d6e4;--accent:#4149d6;--accent2:#7b3fd0;--ok:#0a7a4c;--warn:#c02a48;--err:#c8102e;--cyan:#0a6c74;--standby:#7a5c00;` +
 	// Re-darken the hop hues for a light background so exit + each hop level stay
 	// legible (the dark-mode brights wash out on white).
-	`--hop-exit:#c8102e;--hop1:#0a6fb0;--hop2:#6a3fd0;--hop3:#a85a00;--hop4:#0a7a4c}` +
+	`--hop-exit:#c8102e;--hop1:#0a6fb0;--hop2:#6a3fd0;--hop3:#a85a00;--hop4:#0a7a4c;` +
+	// Re-darken the stream accents for a light background (the dark-mode pastels
+	// wash out on white) so each stream stays legible at the same contrast floor.
+	`--stream0:#3a5bd0;--stream1:#b85c1a;--stream2:#b03592;--stream3:#0a7c88;--stream4:#6a3fd0}` +
 	`h2,.surface{color:#1c1e26}}`

--- a/pkg/proxystatus/routetree.go
+++ b/pkg/proxystatus/routetree.go
@@ -50,27 +50,61 @@ const (
 	GlyphStandby = "○"
 )
 
+// The two route-multiplexing LAYERS are made visually distinct in the tree:
+//
+//   - StreamBandGlyph is the per-STREAM accent band prefixed onto every leg summary
+//     ("▏s0"), so a leg reads which stream (route group) it belongs to at a
+//     glance; the page colors it per-stream, the terminal shows it monochrome.
+//   - StreamHeaderGlyph marks a STREAM-boundary node on the spine — a different
+//     KIND of node than a leg/hop — so the stream (packet-group) layer reads
+//     clearly apart from the leg (packet-striping) layer beneath it.
+//
+// streamAccentCount is how many distinct per-stream accents the palette cycles
+// before wrapping (stream index N → N % streamAccentCount); the page's CSS
+// defines --stream0…--streamN to match.
+const (
+	// StreamBandGlyph leads a leg's per-stream accent band ("▏sN"); StreamHeaderGlyph
+	// marks a stream-boundary node. Exported so the CLI renderer (a different
+	// package) can detect them to style the two layers, as it does GlyphActive.
+	StreamBandGlyph   = "▏"
+	StreamHeaderGlyph = "▚"
+	streamAccentCount = 5
+)
+
 // RouteTree builds the bilateral route-group model for a Snapshot. Dead legs
 // are pruned; the surviving legs are ordered direct-active first, then active
 // multihop, then standby, matching the page's reading order. The returned root
 // is nil-safe to render (bitree.Render handles a childless root).
+//
+// The two multiplexing LAYERS stack: STREAM level (--tunnels, disjoint route
+// groups) over PACKET level (the mux legs striping one stream's packets). With
+// MORE THAN ONE stream the tree makes both legible — each stream gets a
+// stream-boundary header node on the spine followed by its own legs, and every
+// leg summary carries that stream's accent band — so which legs belong to which
+// stream is instantly clear instead of one flat, indistinguishable leg list.
+// With a single stream (or the flat Legs fallback) there is nothing to
+// distinguish, so the legs render clean with no stream chrome.
 func RouteTree(snap Snapshot) *bitree.Node {
 	root := &bitree.Node{Label: treeSrc(snap)}
-	// TWO-LEVEL view: root → tunnel (stream-level route group) → legs (packet-level
-	// mux). Each tunnel is a --tunnels stream; the legs under it are the mux routes
-	// striping that stream's packets. This makes the two kinds of route
-	// multiplexing legible — which legs belong to which stream — instead of one
-	// flat leg list.
-	if len(snap.Tunnels) > 0 {
+	// Multi-stream: one stream-boundary header per tunnel, then that tunnel's legs
+	// (each summary banded with the stream accent) as sibling spine routes. Legs
+	// stay top-level so their rich left summary (R[n], ●/○ state, route-rtt,
+	// per-direction bandwidth + share bars) renders — bitree draws a left
+	// annotation block only for top-level routes.
+	if len(snap.Tunnels) > 1 {
 		for _, t := range snap.Tunnels {
-			legNodes := legNodesFor(t.Legs)
+			legNodes := legNodesForStream(t.Legs, t.Index)
 			if len(legNodes) == 0 {
 				continue
 			}
-			tn := &bitree.Node{Label: tunnelLabel(t, len(legNodes))}
-			tn.Right = legNodes
-			root.Right = append(root.Right, tn)
+			root.Right = append(root.Right, streamHeaderNode(t, len(legNodes)))
+			root.Right = append(root.Right, legNodes...)
 		}
+		return root
+	}
+	// Single stream: render its legs flat, with no per-stream chrome.
+	if len(snap.Tunnels) == 1 {
+		root.Right = legNodesFor(snap.Tunnels[0].Legs)
 		return root
 	}
 	// Flat fallback: a caller that projects a single route group (Tunnels unset).
@@ -100,21 +134,46 @@ func treeSrc(snap Snapshot) string {
 	return "this visor"
 }
 
-// tunnelLabel names a stream-level tunnel node: its index and how many
-// packet-level legs stripe under it.
-func tunnelLabel(t Tunnel, nLegs int) string {
+// streamHeaderNode builds a STREAM-boundary node for the spine — a different
+// kind of node than a leg/hop. Its label is marked with StreamHeaderGlyph so a
+// renderer can style it as a stream header (the page gives it the stream's
+// accent + a badge; the terminal shows the glyph) and names the stream index,
+// its packet-level leg count, and whether packet mux is on. It carries no left
+// summary and no hop chain, so it reads plainly as a layer boundary above the
+// legs that follow it.
+func streamHeaderNode(t Tunnel, nLegs int) *bitree.Node {
 	legWord := "legs"
 	if nLegs == 1 {
 		legWord = "leg"
 	}
-	return fmt.Sprintf("stream %d · %d %s", t.Index, nLegs, legWord)
+	mux := "mux off"
+	if t.MuxEnabled {
+		mux = "mux on"
+	}
+	return &bitree.Node{Label: fmt.Sprintf("%s stream %d · %d %s · %s", StreamHeaderGlyph, t.Index, nLegs, legWord, mux)}
 }
 
-// legNodesFor prunes dead legs, orders them (direct-active first, then active
-// multihop, then standby), and builds the per-leg route nodes with each leg's
-// share drawn against the aggregate goodput of THIS set (per tunnel when nested,
-// or the whole group in the flat fallback).
-func legNodesFor(all []Leg) []*bitree.Node {
+// streamTag is the per-stream accent band prefixed onto a leg's left summary
+// ("▏s0 ") when the leg belongs to a distinguished stream (multi-stream view).
+// The page colors it with that stream's accent; the terminal shows it plain. A
+// negative index yields no tag (single-stream / flat view).
+func streamTag(streamIdx int) string {
+	if streamIdx < 0 {
+		return ""
+	}
+	return fmt.Sprintf("%ss%d ", StreamBandGlyph, streamIdx)
+}
+
+// legNodesFor builds the per-leg route nodes for a single (undistinguished)
+// stream — no per-stream band on the summaries.
+func legNodesFor(all []Leg) []*bitree.Node { return legNodesForStream(all, -1) }
+
+// legNodesForStream prunes dead legs, orders them (direct-active first, then
+// active multihop, then standby), and builds the per-leg route nodes with each
+// leg's share drawn against the aggregate goodput of THIS stream's set. When
+// streamIdx >= 0 each leg summary is banded with that stream's accent tag so the
+// leg reads as belonging to that stream.
+func legNodesForStream(all []Leg, streamIdx int) []*bitree.Node {
 	legs := make([]Leg, 0, len(all))
 	for _, l := range all {
 		if !l.Alive { // prune dead routes/legs
@@ -141,7 +200,7 @@ func legNodesFor(all []Leg) []*bitree.Node {
 	w := legSumWidths(legs)
 	nodes := make([]*bitree.Node, 0, len(legs))
 	for _, l := range legs {
-		nodes = append(nodes, routeToNode(l, w, aggUp, aggDown))
+		nodes = append(nodes, routeToNode(l, w, aggUp, aggDown, streamIdx))
 	}
 	return nodes
 }
@@ -267,8 +326,8 @@ func TreeHeader() (left, label string, cols []string) {
 // routeToNode turns one leg into a hop-chain right-branch carrying its left
 // summary on the head (spine) row. aggUp/aggDown are the route-group's
 // aggregate up/down goodput, the denominators for this leg's share bars.
-func routeToNode(l Leg, w sumWidths, aggUp, aggDown float64) *bitree.Node {
-	left := &bitree.Node{Label: legSummary(l, w, aggUp, aggDown)}
+func routeToNode(l Leg, w sumWidths, aggUp, aggDown float64, streamIdx int) *bitree.Node {
+	left := &bitree.Node{Label: legSummary(l, w, aggUp, aggDown, streamIdx)}
 
 	if len(l.Hops) == 0 {
 		// No recorded path: a single leaf at the remote PK.
@@ -302,7 +361,7 @@ func hopToNode(h Hop) *bitree.Node {
 // this route's live send-RATE and its share of the group's up-goodput, then the
 // ↓ total, live recv-RATE and its share of the group's down-goodput. aggUp/aggDown
 // are the group's aggregate up/down goodput (the share-bar denominators).
-func legSummary(l Leg, w sumWidths, aggUp, aggDown float64) string {
+func legSummary(l Leg, w sumWidths, aggUp, aggDown float64, streamIdx int) string {
 	g := GlyphActive
 	if l.Standby {
 		g = GlyphStandby
@@ -315,7 +374,7 @@ func legSummary(l Leg, w sumWidths, aggUp, aggDown float64) string {
 	down := padLeftRunes(compactBytes(l.RecvBytes)+"↓", w.down)
 	downRate := padLeftRunes(compactRate(l.GoodputDownBps), w.gp)
 	downBar := shareBar(l.GoodputDownBps, aggDown, shareBarWidth)
-	return idx + " " + g + " " + rtt +
+	return streamTag(streamIdx) + idx + " " + g + " " + rtt +
 		"  " + up + " " + upRate + " " + upBar +
 		"  " + down + " " + downRate + " " + downBar
 }

--- a/pkg/proxystatus/routetree_test.go
+++ b/pkg/proxystatus/routetree_test.go
@@ -1,10 +1,17 @@
 package proxystatus
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-// TestRouteTreeTwoLevel: with Tunnels populated the tree nests root → tunnel
-// (stream) → legs (packet); the flat Legs fallback still applies when Tunnels is
-// empty.
+	"github.com/skycoin/skywire/pkg/bitree"
+)
+
+// TestRouteTreeTwoLevel: with MORE THAN ONE stream the tree exposes both
+// multiplexing layers — a stream-boundary header node per tunnel followed by
+// that tunnel's legs (top-level so their left summaries render), each leg banded
+// with its stream tag. A single stream (or the flat Legs fallback) renders clean
+// with no stream chrome.
 func TestRouteTreeTwoLevel(t *testing.T) {
 	leg := func(idx int, direct bool) Leg {
 		return Leg{Index: idx, Alive: true, Direct: direct, GoodputDownBps: 1000,
@@ -20,18 +27,37 @@ func TestRouteTreeTwoLevel(t *testing.T) {
 	if root == nil {
 		t.Fatal("nil root")
 	}
-	if len(root.Right) != 2 {
-		t.Fatalf("root has %d tunnel children, want 2", len(root.Right))
+	// Two stream headers + (2+3) legs = 7 top-level spine routes.
+	if len(root.Right) != 7 {
+		t.Fatalf("root has %d spine children, want 7 (2 headers + 5 legs)", len(root.Right))
 	}
-	// Tunnel 0 has 2 legs, tunnel 1 has 3 — the packet-level spread under each.
-	if got := len(root.Right[0].Right); got != 2 {
-		t.Errorf("tunnel 0 has %d legs, want 2", got)
+	// The stream-boundary headers carry the marker and differ by index; they lead
+	// each stream's legs.
+	hdr := func(n *bitree.Node) bool { return strings.HasPrefix(n.Label, StreamHeaderGlyph) }
+	if !hdr(root.Right[0]) || !hdr(root.Right[3]) {
+		t.Error("stream headers should lead each stream's legs")
 	}
-	if got := len(root.Right[1].Right); got != 3 {
-		t.Errorf("tunnel 1 has %d legs, want 3", got)
+	if root.Right[0].Label == root.Right[3].Label {
+		t.Error("stream header labels should differ by index")
 	}
-	if root.Right[0].Label == root.Right[1].Label {
-		t.Error("tunnel labels should differ by index")
+	// Legs are top-level (so their left summary renders) and carry their stream band.
+	if len(root.Right[1].Left) == 0 {
+		t.Error("a leg node should carry a left summary")
+	}
+	if !strings.Contains(root.Right[1].Left[0].Label, StreamBandGlyph+"s0") {
+		t.Errorf("stream-0 leg summary missing its band: %q", root.Right[1].Left[0].Label)
+	}
+	if !strings.Contains(root.Right[4].Left[0].Label, StreamBandGlyph+"s1") {
+		t.Errorf("stream-1 leg summary missing its band: %q", root.Right[4].Left[0].Label)
+	}
+
+	// Single stream → no stream chrome: legs hang directly off root, unbanded.
+	one := RouteTree(Snapshot{Tunnels: []Tunnel{{Index: 0, Legs: []Leg{leg(0, true), leg(1, false)}}}})
+	if len(one.Right) != 2 {
+		t.Fatalf("single stream: root has %d children, want 2 legs", len(one.Right))
+	}
+	if strings.Contains(one.Right[0].Left[0].Label, StreamBandGlyph) {
+		t.Error("single-stream leg should not be banded")
 	}
 
 	// Empty Tunnels → flat fallback: legs hang directly off root.


### PR DESCRIPTION
The skysocks proxy-status route tree stacks two independent kinds of route multiplexing — STREAM level (`--tunnels`: disjoint route groups to the exit) over PACKET level (mux legs striping one stream's packets across routes) — but nothing distinguished them, and with multiple streams the nested tunnel→leg layout also dropped each leg's left summary (state, route-rtt, bandwidth, share bars), since `bitree` only draws a left annotation for top-level spine routes.

With more than one stream the tree now renders each stream as a stream-boundary **header node** on the spine (`▚ stream N · k legs · mux on/off`) followed by that stream's legs kept top-level so their rich summaries render again. Each leg summary carries a per-stream accent **band** (`▏sN`), and a small five-colour palette cycles stably by stream index across the ~1s live WebSocket pushes. The per-stream accent composes with — never overrides — the existing active/standby (●/○) and hop-depth/exit PK coloring, and a legend above the tree names the two layers. Colours are chosen clear of the state/exit hues and re-darkened for the light theme to hold the page's contrast floor. A single stream renders clean with no stream chrome.

`skywire cli proxy tree` shares the same `RouteTree` model, so the headers and bands appear there too (bold-magenta header, monochrome bands). Verified with `go build .`, `go vet`, gofmt and `go test ./pkg/proxystatus/...`; a representative three-stream page was rendered to a static HTML file for eyeballing.
