### PR TITLE
fix(router): bound unidirectional download fan-out to the mirrored active set

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -328,6 +328,10 @@ type RouteGroup struct {
 	selfHealTarget int
 	healInFlight   atomic.Bool
 
+	// dirFanoutTicks throttles the directional confinement/fan-out summary logged
+	// by legDataProgressServiceFn (see there) so a busy download does not spam it.
+	dirFanoutTicks int
+
 	// Per-leg end-to-end liveness (issue #2). Keyed by leg transport ID so the
 	// state survives index shifts from prune/append. legPongSeen records
 	// whether the echo for a leg's probe came back since the last tick;
@@ -1977,13 +1981,19 @@ func (rg *RouteGroup) legDataProgressServiceFn(_ time.Duration) {
 		id      uuid.UUID
 		recv    uint64
 		standby bool
+		direct  bool
 	}
 	legs := make([]legRecv, 0, len(tpsCopy))
 	for i, tp := range tpsCopy {
 		if tp == nil || i >= len(stats) {
 			continue
 		}
-		legs = append(legs, legRecv{id: tp.Entry.ID, recv: stats[i].RecvBytes, standby: rg.mux.isLegStandby(i)})
+		legs = append(legs, legRecv{
+			id:      tp.Entry.ID,
+			recv:    stats[i].RecvBytes,
+			standby: rg.mux.isLegStandby(i),
+			direct:  rg.mux.legIsDirectTp(tp),
+		})
 	}
 
 	// Only judge when the receiver is genuinely stuck on a missing sequence.
@@ -2013,6 +2023,45 @@ func (rg *RouteGroup) legDataProgressServiceFn(_ time.Duration) {
 	deltas := make([]legRecvDelta, 0, len(legs))
 	for _, l := range legs {
 		deltas = append(deltas, legRecvDelta{id: l.id, delta: perDelta[l.id], standby: l.standby})
+	}
+
+	// Directional confinement / fan-out observability. Under CapUniDir the download
+	// must ride only the ACTIVE reverse (multihop) legs — the initiator-mirrored
+	// active set. Two failure signatures make the collapse-to-0 diagnosable:
+	//   reverse_standby_recv > 0 — the exit is spraying the download onto standby
+	//     reverse legs it should not use (the fan-out bug that over-subscribes the
+	//     reorder frontier and wedges the group), and
+	//   direct_recv > 0 during a download — confinement broke and payload is
+	//     landing on the wrong-direction direct leg.
+	// Logged only while data is actually moving, throttled, and immediately when a
+	// failure signature appears so a wedge's cause is in the log next to it.
+	if rg.mux.isDirectional() && aggDelta > 0 {
+		var revActive, revStandby, directRecv int
+		for _, l := range legs {
+			if perDelta[l.id] == 0 {
+				continue
+			}
+			switch {
+			case l.direct:
+				directRecv++
+			case l.standby:
+				revStandby++
+			default:
+				revActive++
+			}
+		}
+		rg.dirFanoutTicks++
+		badSignature := revStandby > 0 || directRecv > 0
+		if badSignature || rg.dirFanoutTicks == 1 || rg.dirFanoutTicks%10 == 0 {
+			lvl := rg.logger.Debugf
+			if badSignature {
+				lvl = rg.logger.Warnf
+			}
+			lvl("unidir fan-out: download on reverse_active=%d reverse_STANDBY=%d direct=%d legs (moved %dB; STANDBY/direct recv should be 0 — nonzero = exit not honoring the mirrored active set → reorder-frontier over-subscription)",
+				revActive, revStandby, directRecv, aggDelta)
+		}
+	} else {
+		rg.dirFanoutTicks = 0
 	}
 	dead := selectDataStalledLegs(deltas, gapStuck)
 	if len(dead) > 0 {

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -361,14 +361,16 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 	}
 
 	// Unidirectional send selection (CapUniDir).
-	// DIRECTION — not the send-side standby flag — governs which legs carry this
-	// end's traffic. A reverse (mux) leg is standby on the INITIATOR's send side
-	// (it doesn't upload on it), yet the EXIT must send the download on it; the old
-	// standby-gated filter (legReadyAt excludes standby) found no ready reverse leg
-	// on the exit and fell back to the active direct leg, landing the whole
-	// download on the wrong direction. So select among direction-matching legs with
-	// readiness that IGNORES standby (selectByDirection); fall through to the
-	// standard, standby-aware path only when no direction-matching leg is available.
+	// DIRECTION governs which CLASS of leg (direct vs multihop) carries this end's
+	// traffic; WITHIN the class the initiator-mirrored ACTIVE set governs which
+	// legs. selectByDirection is two-tier: it prefers active (standby-aware)
+	// direction-matching legs — so the exit's download fan-out stays bounded to the
+	// few reverse legs the initiator parked active, instead of spraying every
+	// warm-standby reverse leg (which over-subscribes the no-skip reorder frontier,
+	// amplifies retransmits, and wedges the group → the observed collapse-to-0).
+	// Only when NO active leg of the wanted direction exists does it fall back to a
+	// standby leg of that direction (Tier 2), preserving confinement without the
+	// wrong-direction fallback that landed the whole download on the direct leg.
 	if directional, wantDirect, dstPK, srcPK := m.dirConfig(); directional {
 		if tp, rule, idx, ok := m.selectByDirection(tps, fwd, wantDirect, dstPK, srcPK); ok {
 			return tp, rule, idx, nil

--- a/pkg/router/unidir.go
+++ b/pkg/router/unidir.go
@@ -104,6 +104,17 @@ func (m *routeMux) dirConfig() (directional, wantDirect bool, dst, src cipher.Pu
 	return m.directional, wantDirect, m.dstPK, m.srcPK
 }
 
+// legIsDirectTp reports whether tp is this route group's DIRECT (1-hop) leg,
+// using the directional endpoints recorded at handshake. Returns false when the
+// mux is not directional (the endpoints are zero). Used for confinement
+// observability (legDataProgressServiceFn).
+func (m *routeMux) legIsDirectTp(tp *transport.ManagedTransport) bool {
+	m.legMu.RLock()
+	dst, src := m.dstPK, m.srcPK
+	m.legMu.RUnlock()
+	return legIsDirect(tp, dst, src)
+}
+
 // legIsDirect reports whether a leg's transport goes straight to a route-group
 // endpoint (a 1-hop / direct leg) rather than through an intermediary.
 func legIsDirect(tp *transport.ManagedTransport, dst, src cipher.PubKey) bool {
@@ -191,39 +202,71 @@ func (m *routeMux) flipStep(up, down float64) (flipped, changed bool) {
 	return cur, false
 }
 
-// selectByDirection picks a leg matching this end's send direction, using
-// readiness that IGNORES the standby flag (legSelectableIgnoringStandby) —
-// because under unidirectional assignment DIRECTION governs, and a reverse leg
-// the initiator parked as standby must still be selectable by the exit for the
-// download. It prefers the weighted selector's pick when that pick matches the
-// direction, else round-robins among direction-matching legs. Returns ok=false
-// when no direction-matching leg is ready, so selectTransport falls through to
-// the standard (standby-aware) path rather than dropping the send.
+// selectByDirection picks a leg matching this end's send direction. Under
+// unidirectional assignment DIRECTION governs which CLASS of leg carries the
+// send (direct vs multihop); WITHIN that class the initiator-mirrored active set
+// (LegState / CapLegState) governs WHICH legs — so the exit's download fan-out
+// stays bounded to the few legs the initiator parked active instead of spraying
+// every warm-standby reverse leg.
+//
+// Two tiers:
+//
+//	Tier 1 (normal): active (non-standby), ready, direction-matching legs. This
+//	   honors the mirrored active set — the exit sends the download on the same
+//	   small set the initiator selected, so the reorder frontier is not
+//	   over-subscribed and retransmits do not amplify. The heavy direction still
+//	   spreads across THOSE legs via the weighted selector / round-robin.
+//	Tier 2 (degenerate): if NO active direction-matching leg exists — the
+//	   initiator parked every leg of this direction as standby, e.g. mid-rotation
+//	   — fall back to any alive, ready standby leg of the wanted direction. This
+//	   keeps confinement (the #4311 guarantee: never fall through to the
+//	   standby-aware path, which could pick the wrong-direction direct leg) while
+//	   still bounding to the wanted class. It is the warm-reserve failover, not
+//	   the steady state.
+//
+// Returns ok=false only when NO direction-matching leg is selectable at all, so
+// selectTransport falls through to the standard path rather than dropping the send.
 func (m *routeMux) selectByDirection(tps []*transport.ManagedTransport, fwd []routing.Rule, wantDirect bool, dst, src cipher.PubKey) (*transport.ManagedTransport, routing.Rule, int, bool) {
 	n := len(tps)
 	if n == 0 || len(fwd) == 0 {
 		return nil, nil, -1, false
 	}
-	match := func(idx int) bool {
+	// Tier 1: active, ready, direction-matching (standby-aware — bounds fan-out).
+	matchActive := func(idx int) bool {
 		tp := tps[idx]
 		return idx < len(fwd) && tp != nil && !tp.IsClosed() &&
-			m.legSelectableIgnoringStandby(idx) && legIsDirect(tp, dst, src) == wantDirect
+			m.legReadyAt(idx) && legIsDirect(tp, dst, src) == wantDirect
 	}
-	// Prefer the scheduler's pick when it already matches the direction, so the
-	// heavy direction still spreads across legs per the mux weights/ECF.
+	// Prefer the scheduler's pick when it matches AND is active, so the heavy
+	// direction spreads across the active legs per the mux weights/ECF.
 	if m.tpSelector != nil && m.tpSelector.Len() > 0 {
-		if idx := m.tpSelector.Select(); idx >= 0 && idx < n && match(idx) {
+		if idx := m.tpSelector.Select(); idx >= 0 && idx < n && matchActive(idx) {
 			return tps[idx], fwd[idx], idx, true
 		}
 	}
-	// Round-robin among direction-matching legs.
 	start := int(atomic.AddUint32(&m.tpIndex, 1) - 1)
 	for i := 0; i < n; i++ {
 		idx := ((start % n) + i) % n
 		if idx < 0 {
 			idx += n
 		}
-		if match(idx) {
+		if matchActive(idx) {
+			return tps[idx], fwd[idx], idx, true
+		}
+	}
+	// Tier 2: no ACTIVE direction-matching leg — warm-reserve failover on the
+	// wanted class only (confinement preserved). Rare; logged by the caller.
+	matchAny := func(idx int) bool {
+		tp := tps[idx]
+		return idx < len(fwd) && tp != nil && !tp.IsClosed() &&
+			m.legSelectableIgnoringStandby(idx) && legIsDirect(tp, dst, src) == wantDirect
+	}
+	for i := 0; i < n; i++ {
+		idx := ((start % n) + i) % n
+		if idx < 0 {
+			idx += n
+		}
+		if matchAny(idx) {
 			return tps[idx], fwd[idx], idx, true
 		}
 	}

--- a/pkg/router/unidir_fanout_test.go
+++ b/pkg/router/unidir_fanout_test.go
@@ -1,0 +1,107 @@
+// Package router pkg/router/unidir_fanout_test.go c2-net-routing
+package router
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// setRemoteForTest sets the unexported rPK field of a ManagedTransport so a test
+// can distinguish a DIRECT leg (remote == a route-group endpoint) from a MULTIHOP
+// leg (remote == an intermediary). The production API intentionally has no setter
+// for rPK; a router-package test reaches it via reflection rather than widening
+// the transport API for tests.
+func setRemoteForTest(tp *transport.ManagedTransport, pk cipher.PubKey) {
+	f := reflect.ValueOf(tp).Elem().FieldByName("rPK")
+	//nolint:gosec // G103: test-only reflection to set the unexported rPK field
+	reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem().Set(reflect.ValueOf(pk))
+}
+
+// TestSelectByDirectionBoundsFanoutToActive is the regression guard for the exit
+// download fan-out bug: with CapUniDir the exit must send the download only on the
+// ACTIVE reverse (multihop) legs — the initiator-mirrored active set — not spray
+// every warm-standby reverse leg (which over-subscribes the no-skip reorder
+// frontier, amplifies retransmits, and wedges the group → collapse-to-0). It also
+// pins the Tier-2 guarantee: when NO active reverse leg exists, selection falls
+// back to a STANDBY reverse leg, never to the wrong-direction direct leg.
+func TestSelectByDirectionBoundsFanoutToActive(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("unidir-fanout-test")
+	dst := pkFromHex(t, "02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36") // an endpoint (the exit's peer)
+	src := pkFromHex(t, "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c") // the other endpoint
+	hopA := pkFromHex(t, "021b17d2d884d9d73eeca0572143ac97de97e30ca61a682c71b5b968f37c86d206")
+	hopB := pkFromHex(t, "0224f0b6a1b017a1d3cb4a949a6047d13cac1c0580060888dcf1b9b3e09e123e6a")
+	hopC := pkFromHex(t, "02304cb299849723102c4d3032e6b4d8a049c7ebdd4fd4fc7b0d250557c224652b")
+
+	// Exit side = the ACCEPTOR: it sends the DOWNLOAD, which by default rides the
+	// MULTIHOP legs (wantDirect == false).
+	m := newRouteMux(log, true)
+	m.setDirectional(false, dst, src)
+	if _, wantDirect, _, _ := m.dirConfig(); wantDirect {
+		t.Fatal("acceptor default should want MULTIHOP (wantDirect=false)")
+	}
+
+	// leg0 = DIRECT (remote is an endpoint); legs 1..3 = MULTIHOP (remote is a hop).
+	tps := []*transport.ManagedTransport{
+		{}, {}, {}, {},
+	}
+	setRemoteForTest(tps[0], dst)  // direct
+	setRemoteForTest(tps[1], hopA) // multihop
+	setRemoteForTest(tps[2], hopB) // multihop
+	setRemoteForTest(tps[3], hopC) // multihop
+	fwd := make([]routing.Rule, 4)
+
+	m.growLegs(4)
+	for i := 0; i < 4; i++ {
+		m.markLegReady(i)
+	}
+	// Initiator-mirrored active set: legs 1 and 2 active; leg 3 parked standby; the
+	// direct leg 0 parked standby (the exit does not upload on it during a download).
+	m.setLegStandby(0, true)
+	m.setLegStandby(3, true)
+	// legs 1,2 remain active (growLegs leaves them non-standby by default).
+
+	seen := map[int]int{}
+	for i := 0; i < 400; i++ {
+		_, _, idx, ok := m.selectByDirection(tps, fwd, false, dst, src)
+		if !ok {
+			t.Fatalf("iteration %d: selectByDirection returned ok=false with two active reverse legs", i)
+		}
+		seen[idx]++
+	}
+	// Tier 1: only the ACTIVE multihop legs (1,2) may ever be chosen — never the
+	// standby multihop leg (3) and never the direct leg (0).
+	if seen[0] != 0 {
+		t.Errorf("download landed on the DIRECT leg %d time(s) — confinement broke", seen[0])
+	}
+	if seen[3] != 0 {
+		t.Errorf("download landed on the STANDBY reverse leg 3 %d time(s) — fan-out not bounded to the active set", seen[3])
+	}
+	if seen[1] == 0 || seen[2] == 0 {
+		t.Errorf("expected the download to spread across BOTH active reverse legs; got legs=%v", seen)
+	}
+
+	// Tier 2 (degenerate): park EVERY reverse leg standby. Selection must still find
+	// a reverse leg (warm-reserve failover) and must never fall to the direct leg.
+	m.setLegStandby(1, true)
+	m.setLegStandby(2, true)
+	seen2 := map[int]int{}
+	for i := 0; i < 200; i++ {
+		_, _, idx, ok := m.selectByDirection(tps, fwd, false, dst, src)
+		if !ok {
+			t.Fatalf("tier-2 iteration %d: ok=false — should fall back to a standby reverse leg", i)
+		}
+		seen2[idx]++
+	}
+	if seen2[0] != 0 {
+		t.Errorf("tier-2 fallback landed on the DIRECT leg %d time(s) — confinement must hold even when all reverse legs are standby", seen2[0])
+	}
+	if seen2[1]+seen2[2]+seen2[3] != 200 {
+		t.Errorf("tier-2 fallback should pick only reverse legs; got %v", seen2)
+	}
+}


### PR DESCRIPTION
The exit's unidirectional download-leg selection ignored the standby flag (from the #4311 confinement fix), so it sprayed the download across every warm-standby reverse leg instead of the few the initiator parked active. Live measurement: a 10MB download rode 44+ reverse legs with ~84MB of leg-level recv for 10MB delivered (~8x retransmit amplification), 13 standby legs receiving — the over-subscribed no-skip reorder frontier wedged the group and the route collapsed to zero on status.skysocks, failing subsequent transfers.

Direction selection is now two-tier: prefer active (standby-aware) direction-matching legs so the exit honors the initiator-mirrored active set and the download stays bounded to it; fall back to a standby leg of the wanted direction only when no active one exists, keeping the #4311 confinement without the wrong-direction direct fallback. Adds a throttled confinement/fan-out log so a wedge's cause is visible.

Unit test (`TestSelectByDirectionBoundsFanoutToActive`) pins both tiers; full `pkg/router` suite passes.