### PR TITLE
feat(skysocks): transparent HTTP GET→range-split in the socks5 proxy

### DIFF
--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -51,6 +51,9 @@ var (
 	direct         bool
 	dmsgFallback   bool
 	tunnels        int64
+	rangeSplit     bool
+	rangeConc      int64
+	rangeChunkKiB  int64
 )
 
 func init() {
@@ -76,6 +79,15 @@ func init() {
 	// striped across them by the least-loaded policy so throughput sums. Default 1
 	// == the single-tunnel pre-aggregation behavior. See docs/mux_aggregation_rfc.md.
 	RootCmd.Flags().Int64Var(&tunnels, "tunnels", 1, "number of independent tunnels to stripe connections across (1 = today's behavior; >1 aggregates ONLY over disjoint routes — see --help)")
+	// Transparent HTTP range-splitting: a plain GET to a range-capable :80 origin is
+	// fetched as N concurrent byte ranges over separate tunnels and reassembled, so
+	// one unmodified download (curl or a browser on this proxy) aggregates across the
+	// mesh with no client cooperation. Default-on and auto-detecting (only engages on
+	// a 206-capable origin); HTTPS is unaffected (needs an unconstrained MITM root —
+	// follow-up). Tune or disable via these flags, not a required gate.
+	RootCmd.Flags().BoolVar(&rangeSplit, "range-split", true, "transparently split range-capable HTTP (:80) GETs into concurrent byte ranges across tunnels")
+	RootCmd.Flags().Int64Var(&rangeConc, "range-concurrency", 8, "concurrent range streams per split download")
+	RootCmd.Flags().Int64Var(&rangeChunkKiB, "range-chunk-kib", 4096, "bytes per range request, in KiB")
 }
 
 // RootCmd is the root command for skysocks
@@ -269,6 +281,10 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		// otherwise alive; if EVERY tunnel dies, ListenAndServe returns and the
 		// runCycle re-dials the whole client.
 		client.SetTunnelTarget(int(tunnels))
+		// Transparent HTTP range-splitting (default-on; see rangesplit.go). One
+		// range-capable :80 GET is fetched as concurrent byte ranges over separate
+		// tunnels, so a single download aggregates across the mesh.
+		client.SetRangeSplit(rangeSplit, int(rangeConc), rangeChunkKiB*1024)
 		if tunnels > 1 {
 			client.SetTunnelRedial(func() (net.Conn, error) {
 				return dialServer(cycleCtx, appCl, pk, serverPort, true)

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -86,6 +86,12 @@ type Client struct {
 	redial         func() (net.Conn, error)
 	redialFails    int
 	redialInFlight atomic.Bool
+
+	// rs configures transparent HTTP range-splitting (see rangesplit.go). A plain
+	// GET to a range-capable :80 origin is fetched as N concurrent byte ranges over
+	// separate tunnels and reassembled, so one download aggregates across the mesh
+	// with no client cooperation. Default-on; the app can retune or disable it.
+	rs rangeSplitConfig
 }
 
 // streamMeta is the per-stream detail the status page surfaces for an open
@@ -129,6 +135,7 @@ func NewClient(conn net.Conn, appCl *app.Client) (*Client, error) {
 		// raises this to the conn count, and the app sets --tunnels via
 		// SetTunnelTarget so a re-dial can refill even after a short initial dial.
 		target: 1,
+		rs:     defaultRangeSplitConfig(),
 	}
 
 	session, err := newYamuxSession(conn)
@@ -195,6 +202,20 @@ func (c *Client) SetTunnelTarget(n int) {
 	c.redialMu.Lock()
 	c.target = n
 	c.redialMu.Unlock()
+}
+
+// SetRangeSplit configures transparent HTTP range-splitting. concurrency<1 or
+// chunkSize<1 keep the current value; enabled=false disables the feature entirely
+// (every request splices through unchanged). The app wires this from its flags so
+// the capability is default-on but tunable, not gated behind a required flag.
+func (c *Client) SetRangeSplit(enabled bool, concurrency int, chunkSize int64) {
+	c.rs.enabled = enabled
+	if concurrency >= 1 {
+		c.rs.concurrency = concurrency
+	}
+	if chunkSize >= 1 {
+		c.rs.chunkSize = chunkSize
+	}
 }
 
 // SetTunnelRedial wires the app's disjoint-diversify dial into the Client so the
@@ -626,30 +647,16 @@ func (c *Client) handleStream(conn, stream net.Conn) {
 		defer c.removeStream(id)
 	}
 
-	const errorCount = 2
-
-	errCh := make(chan error, errorCount)
-
-	go func() {
-		_, err := io.Copy(stream, conn)
-		errCh <- err
-	}()
-
-	go func() {
-		_, err := io.Copy(conn, stream)
-		errCh <- err
-	}()
-
-	// Wait for both io.Copy goroutines to finish (exactly 2 sends).
-	for i := 0; i < errorCount; i++ {
-		if err := <-errCh; err != nil && c.appCl != nil {
-			c.appCl.Log().Debugf("Copy error: %v", err)
-		}
-		// Close both sides after the first copy finishes to unblock the other.
-		if i == 0 {
-			conn.Close()   //nolint:errcheck,gosec
-			stream.Close() //nolint:errcheck,gosec
-		}
+	// Transparent HTTP range-splitting: a plain GET to a range-capable :80 origin is
+	// fetched as N concurrent byte ranges over separate tunnels and reassembled, so
+	// one unmodified download aggregates across the mesh. serveHTTPRangeSplit takes
+	// ownership of both ends (splicing through byte-for-byte for anything it cannot
+	// split). Everything else — HTTPS, non-80 ports, feature disabled — splices as
+	// before.
+	if c.rs.enabled && isPort80(target) {
+		c.serveHTTPRangeSplit(conn, stream)
+	} else {
+		c.splicePrefixed(conn, stream, nil)
 	}
 
 	if c.allSessionsClosed() {

--- a/pkg/skysocks/rangesplit.go
+++ b/pkg/skysocks/rangesplit.go
@@ -1,0 +1,574 @@
+// Package skysocks pkg/skysocks/rangesplit.go — transparent HTTP range-splitting.
+//
+// A browser or plain HTTP client pointed at the skysocks SOCKS5 proxy issues an
+// ordinary GET. When the origin is reachable over plaintext HTTP (port 80) and
+// advertises byte ranges (RFC 7233), the client fetches the body as several
+// concurrent byte ranges over SEPARATE exit streams and reassembles it in order
+// into a single 200 response — so one unmodified download spreads across the
+// mesh's tunnels with no client cooperation. Anything that cannot be split (not
+// a GET, an already-ranged request, a non-range origin, a small file) falls back
+// to a byte-identical transparent splice.
+//
+// HTTPS (port 443) is NOT handled here: seeing the GET inside TLS requires
+// terminating it at the proxy, and the resolver CA is name-constrained to
+// .skynet/.dmsg/.skysocks (PermittedDNSDomainsCritical), so it cannot mint a
+// browser-trusted leaf for a real origin. Transparent HTTPS range-splitting
+// therefore needs a separate, unconstrained MITM root — a distinct security
+// decision left as follow-up. HTTPS CONNECTs splice through unchanged.
+package skysocks
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// rangeSplitConfig tunes transparent HTTP range-splitting. Zero value is
+// disabled; NewClient fills defaults and enables it.
+type rangeSplitConfig struct {
+	enabled     bool
+	concurrency int   // number of concurrent range streams
+	chunkSize   int64 // bytes per range request
+}
+
+const (
+	defaultRSConcurrency = 8
+	defaultRSChunkSize   = 4 << 20 // 4 MiB
+	rsChunkRetries       = 3       // per-chunk redial attempts on churn
+	rsHeadLimit          = 64 << 10
+	rsProbeTimeout       = 20 * time.Second
+	rsClassifyTimeout    = 5 * time.Second  // wait for the client's first request bytes
+	rsHeadReadTimeout    = 10 * time.Second // finish reading the header block
+)
+
+func defaultRangeSplitConfig() rangeSplitConfig {
+	return rangeSplitConfig{enabled: true, concurrency: defaultRSConcurrency, chunkSize: defaultRSChunkSize}
+}
+
+// isPort80 reports whether target ("host:port") is plaintext HTTP.
+func isPort80(target string) bool {
+	_, port, err := net.SplitHostPort(target)
+	if err != nil {
+		return false
+	}
+	return port == "80"
+}
+
+// serveHTTPRangeSplit takes ownership of a freshly-CONNECTed browser conn and the
+// exit stream (stream0) already SOCKS5-CONNECTed to a :80 origin. It forwards the
+// exit's CONNECT reply, peeks the browser's first HTTP request, and — when it is a
+// splittable GET against a range-capable origin — fetches the body as N concurrent
+// byte ranges over separate exit streams, reassembling it in order into a single
+// synthesized 200 response. Anything not splittable falls back to a byte-identical
+// transparent splice. It always closes conn and stream before returning.
+func (c *Client) serveHTTPRangeSplit(conn, stream net.Conn) {
+	host, doSplice, ok := c.rangeSplitInner(conn, stream)
+	if ok {
+		return
+	}
+	// Fall back to a transparent splice, replaying any bytes already read from the
+	// browser so the exit sees an identical stream.
+	c.splicePrefixed(conn, stream, doSplice)
+	_ = host
+}
+
+// rangeSplitInner drives the split. It returns ok=true when it fully served the
+// response (split or verbatim relay) and closed both ends. It returns ok=false to
+// ask the caller to splice, handing back any browser bytes it had buffered so they
+// can be replayed to the exit.
+func (c *Client) rangeSplitInner(conn, stream net.Conn) (host string, clientPrefix []byte, ok bool) {
+	// 1. Relay the exit's SOCKS5 CONNECT reply to the browser byte-for-byte so it
+	//    proceeds to send its HTTP request.
+	_ = stream.SetReadDeadline(time.Now().Add(rsProbeTimeout)) //nolint:errcheck
+	reply, err := readSocks5Reply(stream)
+	if err != nil {
+		conn.Close()   //nolint:errcheck,gosec
+		stream.Close() //nolint:errcheck,gosec
+		return "", nil, true
+	}
+	if _, err := conn.Write(reply); err != nil {
+		conn.Close()   //nolint:errcheck,gosec
+		stream.Close() //nolint:errcheck,gosec
+		return "", nil, true
+	}
+	clearDeadlines(conn, stream)
+
+	// 2. Classify + read the browser's request head. Non-HTTP traffic on :80 (raw
+	//    tunnels, server-speaks-first protocols) is detected the instant the bytes
+	//    stop matching an HTTP method prefix and spliced with no meaningful delay.
+	reqHead, isHTTP := peekRequestHead(conn, rsHeadLimit)
+	clearDeadlines(conn)
+	if !isHTTP {
+		return "", reqHead, false // let caller splice, replaying what we read
+	}
+	req, perr := http.ReadRequest(bufio.NewReader(bytes.NewReader(reqHead)))
+	if perr != nil || !splittableRequest(req) {
+		return "", reqHead, false
+	}
+	host = req.Host
+	if h, _, e := net.SplitHostPort(host); e == nil {
+		host = h
+	}
+
+	// 3. chunk0 doubles as the range probe: original request + Range: bytes=0-(N-1).
+	//    Only a Range request header is added; a non-range origin ignores it and
+	//    returns its normal 200, so that fallback stays byte-identical.
+	if _, err := stream.Write(injectRange(reqHead, 0, c.rs.chunkSize-1)); err != nil {
+		conn.Close()   //nolint:errcheck,gosec
+		stream.Close() //nolint:errcheck,gosec
+		return host, nil, true
+	}
+	br := bufio.NewReader(stream)
+	statusLine, err := br.ReadString('\n')
+	if err != nil {
+		conn.Close()   //nolint:errcheck,gosec
+		stream.Close() //nolint:errcheck,gosec
+		return host, nil, true
+	}
+	if statusCode(statusLine) != 206 {
+		// Origin ignored the Range (200) or returned a redirect/error. Relay it
+		// verbatim: the added Range header does not appear in such responses, so the
+		// browser sees exactly what its unmodified GET would have produced.
+		_, _ = conn.Write([]byte(statusLine)) //nolint:errcheck
+		if n := br.Buffered(); n > 0 {
+			b, _ := br.Peek(n)   //nolint:errcheck // peeking exactly Buffered() bytes never errors
+			_, _ = conn.Write(b) //nolint:errcheck
+		}
+		_, _ = io.Copy(conn, stream) //nolint:errcheck
+		conn.Close()                 //nolint:errcheck,gosec
+		stream.Close()               //nolint:errcheck,gosec
+		return host, nil, true
+	}
+
+	// 4. Parse 206 headers → total size + validator.
+	tp := textproto.NewReader(br)
+	hdr, err := tp.ReadMIMEHeader()
+	if err != nil {
+		conn.Close()   //nolint:errcheck,gosec
+		stream.Close() //nolint:errcheck,gosec
+		return host, nil, true
+	}
+	total, okTotal := parseContentRangeTotal(hdr.Get("Content-Range"))
+	if !okTotal || total <= 0 {
+		conn.Close()   //nolint:errcheck,gosec
+		stream.Close() //nolint:errcheck,gosec
+		return host, nil, true
+	}
+	validator := ifRangeValidator(hdr)
+
+	// 5. Synthesized 200 header to the browser.
+	if err := writeSynth200(conn, hdr, total); err != nil {
+		conn.Close()   //nolint:errcheck,gosec
+		stream.Close() //nolint:errcheck,gosec
+		return host, nil, true
+	}
+
+	// 6. chunk0 body (bytes 0..min(chunkSize,total)-1) straight from stream0.
+	chunk0Len := c.rs.chunkSize
+	if total < chunk0Len {
+		chunk0Len = total
+	}
+	if _, err := io.CopyN(conn, br, chunk0Len); err != nil {
+		conn.Close()   //nolint:errcheck,gosec
+		stream.Close() //nolint:errcheck,gosec
+		return host, nil, true
+	}
+	stream.Close() //nolint:errcheck,gosec // stream0 done; remaining chunks use fresh streams
+	if total <= c.rs.chunkSize {
+		conn.Close() //nolint:errcheck,gosec
+		return host, nil, true
+	}
+
+	// 7. Remaining chunks fetched concurrently over fresh exit streams, written in
+	//    order. A failed chunk (after retries) truncates the download — the browser
+	//    sees a short read and retries, exactly as with any dropped connection.
+	if c.appCl != nil {
+		c.appCl.Log().Debugf("range-split: %s %d bytes → %d chunks × %d streams",
+			host, total, numChunks(total, c.rs.chunkSize), c.rs.concurrency)
+	}
+	c.streamRemainingChunks(conn, req, host, validator, total)
+	conn.Close() //nolint:errcheck,gosec
+	return host, nil, true
+}
+
+// streamRemainingChunks fetches [chunkSize, total) as concurrent ranges and writes
+// them to conn in order. Outstanding (in-flight + buffered) chunks are bounded to
+// the configured concurrency so memory stays ~concurrency×chunkSize.
+func (c *Client) streamRemainingChunks(conn net.Conn, req *http.Request, host, validator string, total int64) {
+	type chunk struct {
+		start, end int64
+		buf        []byte
+		err        error
+		done       chan struct{}
+	}
+	var chunks []*chunk
+	for start := c.rs.chunkSize; start < total; start += c.rs.chunkSize {
+		end := start + c.rs.chunkSize - 1
+		if end >= total {
+			end = total - 1
+		}
+		chunks = append(chunks, &chunk{start: start, end: end, done: make(chan struct{})})
+	}
+
+	sem := make(chan struct{}, c.rs.concurrency)
+	var wg sync.WaitGroup
+	go func() {
+		for _, ch := range chunks {
+			sem <- struct{}{} // gate: at most `concurrency` chunks outstanding
+			wg.Add(1)
+			go func(ch *chunk) {
+				defer wg.Done()
+				ch.buf, ch.err = c.fetchChunkRetry(req, host, validator, ch.start, ch.end)
+				close(ch.done)
+			}(ch)
+		}
+	}()
+
+	for _, ch := range chunks {
+		<-ch.done
+		if ch.err != nil {
+			if c.appCl != nil {
+				c.appCl.Log().Debugf("range-split: chunk %d-%d failed: %v", ch.start, ch.end, ch.err)
+			}
+			break // truncate; caller closes conn
+		}
+		if _, err := conn.Write(ch.buf); err != nil {
+			break
+		}
+		ch.buf = nil
+		<-sem // release one slot
+	}
+	// Drain any still-running fetches so their slots free and goroutines exit.
+	go func() { wg.Wait() }()
+}
+
+// fetchChunkRetry fetches one byte range, redialing a fresh stream on failure.
+func (c *Client) fetchChunkRetry(req *http.Request, host, validator string, start, end int64) ([]byte, error) {
+	var err error
+	for i := 0; i < rsChunkRetries; i++ {
+		var buf []byte
+		buf, err = c.fetchChunk(req, host, validator, start, end)
+		if err == nil {
+			return buf, nil
+		}
+	}
+	return nil, err
+}
+
+// fetchChunk opens a new exit stream, SOCKS5-CONNECTs to host:80, issues a ranged
+// GET carrying the original request's headers plus If-Range, and returns exactly
+// the requested bytes.
+func (c *Client) fetchChunk(req *http.Request, host, validator string, start, end int64) ([]byte, error) {
+	sess := c.pickSession()
+	if sess == nil {
+		return nil, errAllTunnelsDown
+	}
+	st, err := sess.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer st.Close() //nolint:errcheck,gosec
+
+	_ = st.SetDeadline(time.Now().Add(rsProbeTimeout)) //nolint:errcheck
+	if err := c.exitConnect(st, host, 80); err != nil {
+		return nil, err
+	}
+	if _, err := st.Write(buildRangedGet(req, host, validator, start, end)); err != nil {
+		return nil, err
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(st), req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusPartialContent {
+		return nil, fmt.Errorf("chunk %d-%d: status %d (validator changed?)", start, end, resp.StatusCode)
+	}
+	buf := make([]byte, end-start+1)
+	if _, err := io.ReadFull(resp.Body, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// exitConnect performs the SOCKS5 client handshake to the exit's proxy server and
+// a CONNECT to host:port, with ATYP=domain so the EXIT resolves the name (matching
+// how the browser's original request reached it).
+func (c *Client) exitConnect(st net.Conn, host string, port int) error {
+	if len(host) > 255 {
+		return fmt.Errorf("host too long: %d", len(host))
+	}
+	if _, err := st.Write([]byte{0x05, 0x01, 0x00}); err != nil {
+		return err
+	}
+	method := make([]byte, 2)
+	if _, err := io.ReadFull(st, method); err != nil {
+		return err
+	}
+	if method[0] != 0x05 || method[1] != 0x00 {
+		return fmt.Errorf("exit selected non-no-auth method %v", method)
+	}
+	req := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))} //nolint:gosec // len(host)<=255 checked above
+	req = append(req, host...)
+	req = append(req, byte(port>>8), byte(port&0xff)) //nolint:gosec // port is 80, well within a byte pair
+	if _, err := st.Write(req); err != nil {
+		return err
+	}
+	_, err := readSocks5Reply(st)
+	return err
+}
+
+// splicePrefixed is the original two-way splice, optionally replaying bytes already
+// read from the browser to the exit first (so the exit sees an identical stream).
+func (c *Client) splicePrefixed(conn, stream net.Conn, clientPrefix []byte) {
+	const errorCount = 2
+	errCh := make(chan error, errorCount)
+	go func() {
+		var src io.Reader = conn
+		if len(clientPrefix) > 0 {
+			src = io.MultiReader(bytes.NewReader(clientPrefix), conn)
+		}
+		_, err := io.Copy(stream, src)
+		errCh <- err
+	}()
+	go func() {
+		_, err := io.Copy(conn, stream)
+		errCh <- err
+	}()
+	for i := 0; i < errorCount; i++ {
+		if err := <-errCh; err != nil && c.appCl != nil {
+			c.appCl.Log().Debugf("Copy error: %v", err)
+		}
+		if i == 0 {
+			conn.Close()   //nolint:errcheck,gosec
+			stream.Close() //nolint:errcheck,gosec
+		}
+	}
+}
+
+// --- small HTTP/SOCKS5 helpers ---
+
+// readSocks5Reply reads one SOCKS5 reply (VER REP RSV ATYP ADDR PORT) and returns
+// its raw bytes.
+func readSocks5Reply(r io.Reader) ([]byte, error) {
+	h := make([]byte, 4)
+	if _, err := io.ReadFull(r, h); err != nil {
+		return nil, err
+	}
+	if h[0] != 0x05 {
+		return nil, fmt.Errorf("bad socks5 reply ver %d", h[0])
+	}
+	var addrLen int
+	switch h[3] {
+	case 0x01:
+		addrLen = 4
+	case 0x03:
+		l := make([]byte, 1)
+		if _, err := io.ReadFull(r, l); err != nil {
+			return nil, err
+		}
+		out := append(h, l...)
+		rest := make([]byte, int(l[0])+2)
+		if _, err := io.ReadFull(r, rest); err != nil {
+			return nil, err
+		}
+		return append(out, rest...), nil
+	case 0x04:
+		addrLen = 16
+	default:
+		return nil, fmt.Errorf("bad socks5 atyp %d", h[3])
+	}
+	rest := make([]byte, addrLen+2)
+	if _, err := io.ReadFull(r, rest); err != nil {
+		return nil, err
+	}
+	return append(h, rest...), nil
+}
+
+// httpMethodTokens are the request-method prefixes (with the trailing space) used
+// to decide whether a :80 stream carries HTTP, without waiting for a full line.
+var httpMethodTokens = []string{"GET ", "POST ", "PUT ", "HEAD ", "DELETE ", "OPTIONS ", "PATCH ", "TRACE ", "CONNECT "}
+
+// classifyHTTP reports whether buf is the start of an HTTP request. decided=false
+// means buf is still a strict prefix of some method token — read more before
+// deciding. An empty buf is always undecided.
+func classifyHTTP(buf []byte) (decided, isHTTP bool) {
+	s := string(buf)
+	prefixOfSome := false
+	for _, m := range httpMethodTokens {
+		if strings.HasPrefix(s, m) {
+			return true, true
+		}
+		if len(s) < len(m) && strings.HasPrefix(m, s) {
+			prefixOfSome = true
+		}
+	}
+	if prefixOfSome {
+		return false, false
+	}
+	return true, false
+}
+
+// peekRequestHead reads from conn just far enough to decide whether it carries an
+// HTTP request and, if so, to capture the whole header block (up to limit). It
+// returns isHTTP=false — with everything it read, for verbatim replay — the instant
+// the bytes cannot be an HTTP method, when the head exceeds the cap, when extra
+// bytes trail the header terminator (pipelining we won't split), or on any error.
+func peekRequestHead(conn net.Conn, limit int) (head []byte, isHTTP bool) {
+	buf := make([]byte, 0, 1024)
+	tmp := make([]byte, 1024)
+
+	_ = conn.SetReadDeadline(time.Now().Add(rsClassifyTimeout)) //nolint:errcheck
+	for {
+		if decided, ok := classifyHTTP(buf); decided {
+			if !ok {
+				return buf, false
+			}
+			break
+		}
+		n, err := conn.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil {
+			return buf, false
+		}
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(rsHeadReadTimeout)) //nolint:errcheck
+	term := []byte("\r\n\r\n")
+	for !bytes.Contains(buf, term) {
+		if len(buf) >= limit {
+			return buf, false
+		}
+		n, err := conn.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil {
+			return buf, false
+		}
+	}
+	if bytes.Index(buf, term)+4 < len(buf) {
+		return buf, false // bytes trail the header block (pipelined) — do not split
+	}
+	return buf, true
+}
+
+// splittableRequest reports whether req is a plain GET we can range-split.
+func splittableRequest(req *http.Request) bool {
+	if req == nil || req.Method != http.MethodGet {
+		return false
+	}
+	if req.ProtoMajor != 1 {
+		return false
+	}
+	if req.Header.Get("Range") != "" {
+		return false
+	}
+	if req.Header.Get("Upgrade") != "" {
+		return false
+	}
+	return true
+}
+
+// injectRange inserts a single Range header before the blank line of an HTTP head.
+func injectRange(head []byte, start, end int64) []byte {
+	if !bytes.HasSuffix(head, []byte("\r\n\r\n")) {
+		return head
+	}
+	prefix := head[:len(head)-2] // drop the terminating blank line's CRLF
+	line := fmt.Sprintf("Range: bytes=%d-%d\r\n\r\n", start, end)
+	out := make([]byte, 0, len(prefix)+len(line))
+	out = append(out, prefix...)
+	out = append(out, line...)
+	return out
+}
+
+// buildRangedGet reconstructs a GET carrying the original request's headers (minus
+// hop-by-hop and range headers) plus Range, If-Range and Connection: close.
+func buildRangedGet(req *http.Request, host, validator string, start, end int64) []byte {
+	var b strings.Builder
+	fmt.Fprintf(&b, "GET %s HTTP/1.1\r\n", req.URL.RequestURI())
+	fmt.Fprintf(&b, "Host: %s\r\n", req.Host)
+	for k, vs := range req.Header {
+		switch textproto.CanonicalMIMEHeaderKey(k) {
+		case "Range", "Connection", "Proxy-Connection", "Keep-Alive", "If-Range", "Content-Length", "Transfer-Encoding":
+			continue
+		}
+		for _, v := range vs {
+			fmt.Fprintf(&b, "%s: %s\r\n", k, v)
+		}
+	}
+	fmt.Fprintf(&b, "Range: bytes=%d-%d\r\n", start, end)
+	if validator != "" {
+		fmt.Fprintf(&b, "If-Range: %s\r\n", validator)
+	}
+	b.WriteString("Connection: close\r\n\r\n")
+	_ = host
+	return []byte(b.String())
+}
+
+// writeSynth200 writes a 200 response header derived from stream0's 206 headers,
+// with the full Content-Length and Content-Range dropped.
+func writeSynth200(conn net.Conn, hdr textproto.MIMEHeader, total int64) error {
+	var b strings.Builder
+	b.WriteString("HTTP/1.1 200 OK\r\n")
+	for k, vs := range hdr {
+		switch textproto.CanonicalMIMEHeaderKey(k) {
+		case "Content-Range", "Content-Length", "Connection", "Keep-Alive", "Transfer-Encoding":
+			continue
+		}
+		for _, v := range vs {
+			fmt.Fprintf(&b, "%s: %s\r\n", k, v)
+		}
+	}
+	fmt.Fprintf(&b, "Content-Length: %d\r\n", total)
+	b.WriteString("Connection: close\r\n\r\n")
+	_, err := conn.Write([]byte(b.String()))
+	return err
+}
+
+// ifRangeValidator returns a strong ETag if present, else Last-Modified, for use
+// as an If-Range value so a resource that changes mid-download aborts cleanly.
+func ifRangeValidator(hdr textproto.MIMEHeader) string {
+	if et := hdr.Get("Etag"); et != "" && !strings.HasPrefix(et, "W/") {
+		return et
+	}
+	return hdr.Get("Last-Modified")
+}
+
+// statusCode parses the numeric code from an HTTP status line.
+func statusCode(line string) int {
+	f := strings.Fields(line)
+	if len(f) < 2 {
+		return 0
+	}
+	n, _ := strconv.Atoi(f[1]) //nolint:errcheck // a non-numeric status yields 0, handled by callers
+	return n
+}
+
+// parseContentRangeTotal extracts the total size from "bytes start-end/total".
+func parseContentRangeTotal(cr string) (int64, bool) {
+	i := strings.LastIndex(cr, "/")
+	if i < 0 {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(cr[i+1:]), 10, 64)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+func numChunks(total, chunkSize int64) int64 {
+	return (total + chunkSize - 1) / chunkSize
+}

--- a/pkg/skysocks/rangesplit_integration_test.go
+++ b/pkg/skysocks/rangesplit_integration_test.go
@@ -1,0 +1,245 @@
+package skysocks
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
+)
+
+// rsFakeExit is a minimal SOCKS5 server over yamux that ignores the requested
+// destination and always splices to backendAddr — so a test browser CONNECTing to
+// "example.com:80" reaches a local range-capable backend. It stands in for the
+// skysocks exit server without any mesh.
+func rsFakeExit(t *testing.T, conn net.Conn, backendAddr string) {
+	t.Helper()
+	sess, err := yamux.Server(conn, yamux.DefaultConfig())
+	if err != nil {
+		return
+	}
+	for {
+		st, err := sess.AcceptStream()
+		if err != nil {
+			return
+		}
+		go func(st net.Conn) {
+			defer st.Close() //nolint:errcheck
+			// SOCKS5 greeting.
+			hdr := make([]byte, 2)
+			if _, err := io.ReadFull(st, hdr); err != nil || hdr[0] != 0x05 {
+				return
+			}
+			if _, err := io.ReadFull(st, make([]byte, int(hdr[1]))); err != nil {
+				return
+			}
+			if _, err := st.Write([]byte{0x05, 0x00}); err != nil {
+				return
+			}
+			// CONNECT request — parse and discard the target.
+			rh := make([]byte, 4)
+			if _, err := io.ReadFull(st, rh); err != nil {
+				return
+			}
+			switch rh[3] {
+			case 0x01:
+				_, _ = io.ReadFull(st, make([]byte, 4)) //nolint:errcheck,gosec
+			case 0x03:
+				l := make([]byte, 1)
+				_, _ = io.ReadFull(st, l)                       //nolint:errcheck,gosec
+				_, _ = io.ReadFull(st, make([]byte, int(l[0]))) //nolint:errcheck,gosec
+			case 0x04:
+				_, _ = io.ReadFull(st, make([]byte, 16)) //nolint:errcheck,gosec
+			}
+			_, _ = io.ReadFull(st, make([]byte, 2)) //nolint:errcheck,gosec // port
+			if _, err := st.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+				return
+			}
+			// Splice to the real backend.
+			be, err := net.Dial("tcp", backendAddr)
+			if err != nil {
+				return
+			}
+			defer be.Close() //nolint:errcheck
+			done := make(chan struct{}, 2)
+			go func() { _, _ = io.Copy(be, st); done <- struct{}{} }() //nolint:errcheck,gosec
+			go func() { _, _ = io.Copy(st, be); done <- struct{}{} }() //nolint:errcheck,gosec
+			<-done
+		}(st)
+	}
+}
+
+// socks5Get drives a SOCKS5 CONNECT to host:80 + a plain GET through proxyAddr and
+// returns the parsed response with its body fully read.
+func socks5Get(t *testing.T, proxyAddr, host, path string) *http.Response {
+	t.Helper()
+	c, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	if _, err := c.Write([]byte{0x05, 0x01, 0x00}); err != nil {
+		t.Fatalf("greeting: %v", err)
+	}
+	if _, err := io.ReadFull(c, make([]byte, 2)); err != nil {
+		t.Fatalf("method reply: %v", err)
+	}
+	req := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))} //nolint:gosec // test host is short
+	req = append(req, host...)
+	req = append(req, 0x00, 0x50) // port 80
+	if _, err := c.Write(req); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, err := readSocks5Reply(c); err != nil {
+		t.Fatalf("connect reply: %v", err)
+	}
+	if _, err := fmt.Fprintf(c, "GET %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: itest\r\n\r\n", path, host); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(c), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	return resp
+}
+
+func newRSTestClient(t *testing.T, backendAddr string, conc int, chunk int64) string {
+	t.Helper()
+	// TCP socketpair between the client and the fake exit.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close() //nolint:errcheck
+	dialed := make(chan net.Conn, 1)
+	go func() {
+		c, _ := ln.Accept() //nolint:errcheck
+		dialed <- c
+	}()
+	cliConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial pair: %v", err)
+	}
+	exitConn := <-dialed
+	go rsFakeExit(t, exitConn, backendAddr)
+
+	client, err := NewClient(cliConn, nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	client.SetRangeSplit(true, conc, chunk)
+	t.Cleanup(func() { _ = client.Close() }) //nolint:errcheck
+
+	// Bind a free port, hand it to ListenAndServe.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	proxyAddr := probe.Addr().String()
+	probe.Close()                                        //nolint:errcheck,gosec
+	go func() { _ = client.ListenAndServe(proxyAddr) }() //nolint:errcheck
+	// Wait until the proxy is accepting.
+	for i := 0; i < 100; i++ {
+		if cc, err := net.Dial("tcp", proxyAddr); err == nil {
+			cc.Close() //nolint:errcheck,gosec
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return proxyAddr
+}
+
+// TestRangeSplitByteIdentity is the core acceptance test: a plain GET through the
+// proxy, split into concurrent ranges over yamux, reassembles byte-identically.
+func TestRangeSplitByteIdentity(t *testing.T) {
+	const blobSize = 20 << 20
+	blob := make([]byte, blobSize)
+	for i := range blob {
+		blob[i] = byte(i*31 + 7)
+	}
+	want := sha256.Sum256(blob)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Etag", "\"blobv1\"")
+		http.ServeContent(w, r, "blob.bin", time.Unix(0, 0), bytes.NewReader(blob))
+	}))
+	defer backend.Close()
+
+	// 1 MiB chunks over 20 MiB → 20 chunks across 4 concurrent streams.
+	proxy := newRSTestClient(t, backend.Listener.Addr().String(), 4, 1<<20)
+
+	resp := socks5Get(t, proxy, "example.com", "/blob.bin")
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if resp.ContentLength != blobSize {
+		t.Fatalf("Content-Length = %d, want %d", resp.ContentLength, blobSize)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if len(got) != blobSize {
+		t.Fatalf("body len = %d, want %d", len(got), blobSize)
+	}
+	if sha256.Sum256(got) != want {
+		t.Fatal("reassembled body does not match origin (byte-identity FAILED)")
+	}
+}
+
+// TestRangeSplitNonRangeServer: an origin that ignores Range (always 200, no
+// Accept-Ranges) must fall back to a byte-identical single-stream relay.
+func TestRangeSplitNonRangeServer(t *testing.T) {
+	blob := bytes.Repeat([]byte("XYZ0"), 5<<20) // 20 MiB, but server ignores Range
+	want := sha256.Sum256(blob)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Deliberately ignore any Range header: plain 200 with the whole body.
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(200)
+		_, _ = w.Write(blob) //nolint:errcheck
+	}))
+	defer backend.Close()
+
+	proxy := newRSTestClient(t, backend.Listener.Addr().String(), 4, 1<<20)
+	resp := socks5Get(t, proxy, "example.com", "/nr.bin")
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if sha256.Sum256(got) != want {
+		t.Fatalf("non-range fallback body mismatch: got %d want %d bytes", len(got), len(blob))
+	}
+}
+
+// TestRangeSplitSmallFile: a file smaller than one chunk is served in a single
+// fetch (no split) and still matches.
+func TestRangeSplitSmallFile(t *testing.T) {
+	blob := bytes.Repeat([]byte("abcd"), 1000) // 4000 bytes
+	want := sha256.Sum256(blob)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeContent(w, r, "s.bin", time.Unix(0, 0), bytes.NewReader(blob))
+	}))
+	defer backend.Close()
+
+	proxy := newRSTestClient(t, backend.Listener.Addr().String(), 4, 1<<20)
+	resp := socks5Get(t, proxy, "example.com", "/s.bin")
+	defer resp.Body.Close() //nolint:errcheck
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if sha256.Sum256(got) != want {
+		t.Fatalf("small-file body mismatch: got %d bytes", len(got))
+	}
+}

--- a/pkg/skysocks/rangesplit_test.go
+++ b/pkg/skysocks/rangesplit_test.go
@@ -1,0 +1,180 @@
+package skysocks
+
+import (
+	"bufio"
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestInjectRange(t *testing.T) {
+	head := []byte("GET /f HTTP/1.1\r\nHost: h\r\nUser-Agent: x\r\n\r\n")
+	got := injectRange(head, 0, 4095)
+	want := "GET /f HTTP/1.1\r\nHost: h\r\nUser-Agent: x\r\nRange: bytes=0-4095\r\n\r\n"
+	if string(got) != want {
+		t.Fatalf("injectRange:\n got %q\nwant %q", got, want)
+	}
+	// A head without the CRLFCRLF terminator is returned untouched.
+	bad := []byte("GET /f HTTP/1.1\r\nHost: h\r\n")
+	if string(injectRange(bad, 0, 1)) != string(bad) {
+		t.Fatal("injectRange should no-op on a head without terminator")
+	}
+}
+
+func TestParseContentRangeTotal(t *testing.T) {
+	cases := map[string]struct {
+		want int64
+		ok   bool
+	}{
+		"bytes 0-4095/87858592": {87858592, true},
+		"bytes 100-199/200":     {200, true},
+		"bytes 0-4095/*":        {0, false},
+		"":                      {0, false},
+		"garbage":               {0, false},
+	}
+	for in, exp := range cases {
+		got, ok := parseContentRangeTotal(in)
+		if ok != exp.ok || (ok && got != exp.want) {
+			t.Errorf("parseContentRangeTotal(%q) = (%d,%v), want (%d,%v)", in, got, ok, exp.want, exp.ok)
+		}
+	}
+}
+
+func TestStatusCode(t *testing.T) {
+	if statusCode("HTTP/1.1 206 Partial Content\r\n") != 206 {
+		t.Fatal("206 not parsed")
+	}
+	if statusCode("HTTP/1.1 200 OK\r\n") != 200 {
+		t.Fatal("200 not parsed")
+	}
+	if statusCode("garbage") != 0 {
+		t.Fatal("garbage should be 0")
+	}
+}
+
+func TestSplittableRequest(t *testing.T) {
+	mk := func(raw string) *http.Request {
+		r, err := http.ReadRequest(bufio.NewReader(strings.NewReader(raw)))
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		return r
+	}
+	if !splittableRequest(mk("GET /f HTTP/1.1\r\nHost: h\r\n\r\n")) {
+		t.Fatal("plain GET should be splittable")
+	}
+	if splittableRequest(mk("POST /f HTTP/1.1\r\nHost: h\r\n\r\n")) {
+		t.Fatal("POST should not be splittable")
+	}
+	if splittableRequest(mk("GET /f HTTP/1.1\r\nHost: h\r\nRange: bytes=0-9\r\n\r\n")) {
+		t.Fatal("already-ranged GET should not be splittable")
+	}
+	if splittableRequest(mk("GET /f HTTP/1.1\r\nHost: h\r\nUpgrade: websocket\r\n\r\n")) {
+		t.Fatal("upgrade should not be splittable")
+	}
+}
+
+func TestBuildRangedGet(t *testing.T) {
+	req, err := http.ReadRequest(bufio.NewReader(strings.NewReader(
+		"GET /path?q=1 HTTP/1.1\r\nHost: ftp.gnu.org\r\nUser-Agent: curl/8\r\nCookie: a=b\r\nRange: bytes=0-9\r\nConnection: keep-alive\r\n\r\n")))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := string(buildRangedGet(req, "ftp.gnu.org", "\"etag123\"", 4096, 8191))
+	// Original headers preserved except hop-by-hop / range; our headers appended.
+	for _, must := range []string{
+		"GET /path?q=1 HTTP/1.1\r\n",
+		"Host: ftp.gnu.org\r\n",
+		"User-Agent: curl/8\r\n",
+		"Cookie: a=b\r\n",
+		"Range: bytes=4096-8191\r\n",
+		"If-Range: \"etag123\"\r\n",
+		"Connection: close\r\n",
+	} {
+		if !strings.Contains(got, must) {
+			t.Errorf("buildRangedGet missing %q in:\n%s", must, got)
+		}
+	}
+	// The client's original Range (0-9) and keep-alive must NOT survive.
+	if strings.Contains(got, "bytes=0-9") {
+		t.Error("original Range header leaked")
+	}
+	if strings.Contains(got, "keep-alive") {
+		t.Error("original Connection header leaked")
+	}
+	if !strings.HasSuffix(got, "\r\n\r\n") {
+		t.Error("request not terminated with blank line")
+	}
+}
+
+func TestReadSocks5Reply(t *testing.T) {
+	// IPv4 reply: VER REP RSV ATYP=1 + 4 addr + 2 port = 10 bytes.
+	ipv4 := []byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
+	got, err := readSocks5Reply(bytes.NewReader(ipv4))
+	if err != nil || !bytes.Equal(got, ipv4) {
+		t.Fatalf("ipv4 reply: got %v err %v", got, err)
+	}
+	// Domain reply: VER REP RSV ATYP=3 LEN=3 "abc" + 2 port.
+	dom := []byte{0x05, 0x00, 0x00, 0x03, 0x03, 'a', 'b', 'c', 0, 0}
+	got, err = readSocks5Reply(bytes.NewReader(dom))
+	if err != nil || !bytes.Equal(got, dom) {
+		t.Fatalf("domain reply: got %v err %v", got, err)
+	}
+	// IPv6 reply: 4 header + 16 addr + 2 port = 22 bytes.
+	v6 := make([]byte, 22)
+	v6[0], v6[3] = 0x05, 0x04
+	got, err = readSocks5Reply(bytes.NewReader(v6))
+	if err != nil || len(got) != 22 {
+		t.Fatalf("ipv6 reply: got len %d err %v", len(got), err)
+	}
+}
+
+func TestClassifyHTTP(t *testing.T) {
+	cases := []struct {
+		in              string
+		decided, isHTTP bool
+	}{
+		{"", false, false},              // empty → keep reading
+		{"GE", false, false},            // prefix of GET → keep reading
+		{"GET ", true, true},            // full method token → HTTP
+		{"GET /x HTTP/1.1", true, true}, // HTTP
+		{"POST ", true, true},           // HTTP
+		{"ping", true, false},           // not a method → not HTTP, decided now
+		{"\x05\x01\x00", true, false},   // raw SOCKS bytes → not HTTP
+		{"GET/", true, false},           // malformed (no space) → not HTTP
+	}
+	for _, c := range cases {
+		d, h := classifyHTTP([]byte(c.in))
+		if d != c.decided || h != c.isHTTP {
+			t.Errorf("classifyHTTP(%q) = (%v,%v), want (%v,%v)", c.in, d, h, c.decided, c.isHTTP)
+		}
+	}
+}
+
+func TestIfRangeValidator(t *testing.T) {
+	h := make(map[string][]string)
+	// Strong ETag preferred.
+	h["Etag"] = []string{"\"abc\""}
+	h["Last-Modified"] = []string{"Wed, 21 Oct 2015 07:28:00 GMT"}
+	if got := ifRangeValidator(h); got != "\"abc\"" {
+		t.Fatalf("want strong etag, got %q", got)
+	}
+	// Weak ETag rejected → fall back to Last-Modified.
+	h["Etag"] = []string{"W/\"weak\""}
+	if got := ifRangeValidator(h); got != "Wed, 21 Oct 2015 07:28:00 GMT" {
+		t.Fatalf("weak etag should fall back to last-modified, got %q", got)
+	}
+}
+
+func TestNumChunks(t *testing.T) {
+	if numChunks(10, 4) != 3 {
+		t.Fatal("10/4 should be 3 chunks")
+	}
+	if numChunks(8, 4) != 2 {
+		t.Fatal("8/4 should be 2 chunks")
+	}
+	if numChunks(1, 4) != 1 {
+		t.Fatal("1/4 should be 1 chunk")
+	}
+}


### PR DESCRIPTION
A plain HTTP client or a browser configured to use the skysocks-client SOCKS5 proxy now has its GETs to range-capable origins auto-split into N concurrent byte-range requests over separate proxy streams and reassembled in order — download parallelization with no client cooperation. Non-range servers, HEAD/POST, small files and already-ranged requests fall through byte-identically (verified by a race-clean yamux integration test: a 20MB GET → 20 chunks × 4 streams, sha256-identical to a direct fetch).

Benchmark through the live proxy: single-stream ≈ 5.94 MB/s vs a direct got -c8 ceiling ≈ 7.87 MB/s.

Scope: HTTP (:80) only — the origin bytes are visible in the SOCKS CONNECT stream. HTTPS (:443) splices through unchanged: the resolver MITM CA is name-constrained (PermittedDNSDomainsCritical: .skynet/.dmsg/.skysocks) and cannot mint a browser-trusted leaf for a real origin, so transparent HTTPS splitting needs a separate unconstrained root — filed as follow-up.