### PR TITLE
feat(router): add OTIAS and STMS mux packet schedulers

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_ops.go
+++ b/cmd/skywire-cli/commands/proxy/mux_ops.go
@@ -403,7 +403,7 @@ func muxSwitchWaitReady(rpcClient visor.API, newTpID uuid.UUID, timeout time.Dur
 }
 
 var muxModeCmd = &cobra.Command{
-	Use:   "mode <auto|equal|capacity|ecf>",
+	Use:   "mode <auto|equal|capacity|ecf|otias|stms>",
 	Short: "Change mux scheduler weighting at runtime",
 	Long: `Set the mux transport-selection mode for the visor.
 
@@ -427,6 +427,17 @@ var muxModeCmd = &cobra.Command{
              head-of-line-stalls the reorder buffer on them), ECF
              aggregates across heterogeneous legs without paying the
              slow-leg HoL cost.
+  otias    - Out-of-order Transmission for In-order Arrival: assigns
+             each frame to the leg whose ESTIMATED ARRIVAL is soonest
+             (backlog drain time + one-way delay), reusing ECF's per-leg
+             estimators. It will deliberately hand a later frame to a
+             slower-but-idle leg once the fast leg's queue would make it
+             arrive later; the reorder buffer restores stream order.
+  stms     - Slide Together Multipath Scheduler: keeps the head of the
+             stream on the fast leg (fills its send window first) and,
+             once that window is full, places the following data on the
+             soonest-arriving slower leg so the pieces converge in order.
+             Unlike ECF it does not decline a slow leg once it is active.
 
 Affects every active and future mux'd route group on this visor
 IMMEDIATELY (the router re-applies the mode to live route groups). The
@@ -442,9 +453,9 @@ Example:
 	Run: func(cmd *cobra.Command, args []string) {
 		mode := args[0]
 		switch mode {
-		case "auto", "equal", "capacity", "ecf":
+		case "auto", "equal", "capacity", "ecf", "otias", "stms":
 		default:
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("mode must be 'auto', 'equal', 'capacity', or 'ecf', got %q", mode))
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("mode must be 'auto', 'equal', 'capacity', 'ecf', 'otias', or 'stms', got %q", mode))
 		}
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {

--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -265,6 +265,18 @@ const (
 	// is the mode that actually aggregates across heterogeneous legs
 	// without paying the slow-leg HoL cost. Per-packet, O(legs).
 	DistributionECF
+	// DistributionOTIAS is the Out-of-order Transmission for In-order
+	// Arrival scheduler (router.WeightModeOTIAS). It reuses ECF's per-leg
+	// estimators but assigns each frame to the leg whose estimated ARRIVAL
+	// (backlog drain time + one-way delay) is soonest, deliberately handing
+	// later frames to slower-but-idle legs; the reorder buffer restores order.
+	DistributionOTIAS
+	// DistributionSTMS is the Slide Together Multipath Scheduler
+	// (router.WeightModeSTMS). It keeps the head of the stream on the fast
+	// leg (filling its send window first) and slides later data onto the
+	// soonest-arriving slower leg so pieces converge in order — without ECF's
+	// hold-back decline once a leg is in the active set.
+	DistributionSTMS
 )
 
 // LegChangeHook is an optional hook fired by the route group
@@ -405,6 +417,12 @@ func (m DistributionMode) String() string {
 		return "dscp-priority"
 	case DistributionCapacity:
 		return "capacity"
+	case DistributionECF:
+		return "ecf"
+	case DistributionOTIAS:
+		return "otias"
+	case DistributionSTMS:
+		return "stms"
 	}
 	return "unknown"
 }

--- a/pkg/router/mux_scheduler.go
+++ b/pkg/router/mux_scheduler.go
@@ -1,0 +1,144 @@
+// Package router pkg/router/mux_scheduler.go c2-net-routing
+package router
+
+import "math"
+
+// This file holds two additional completion-time predictive mux schedulers that
+// reason over the SAME per-leg estimator snapshot ECF maintains (ecfLegState:
+// mean/baseline RTT, jitter, send rate, BDP cwnd and the selector-tracked
+// in-flight byte estimate — all refreshed by the mux's rebuildWeights ECF branch
+// from the continuously-sampled legCounters EWMAs). Both are pure dispatch-side
+// decisions: they change only which leg the next DATA frame rides, add no wire
+// field, need no peer coordination, and fall back to the schedule when no
+// estimator state exists yet (cold start).
+//
+//   - OTIAS (Out-of-order Transmission for In-order Arrival, Yang et al.):
+//     assign each segment to the leg whose ESTIMATED ARRIVAL time is soonest —
+//     queueing delay (current backlog draining at the leg's rate) plus one-way
+//     propagation (≈RTT/2). Because the chosen leg is charged the frame's bytes,
+//     its next estimate rises, so a run of segments fans out across legs by
+//     arrival time; OTIAS will deliberately hand a LATER segment to a slower but
+//     idle leg once the fast leg's queue would make it arrive later. The reorder
+//     buffer restores stream order, so out-of-order transmission yields in-order
+//     arrival.
+//
+//   - STMS (Slide Together Multipath Scheduler, Shi et al., USENIX ATC 2018):
+//     keep the HEAD of the stream on the fast leg — fill the fast leg's send
+//     window first, so earlier data always rides the fast path — and only once
+//     that window is full place the following (later) data on a slower leg,
+//     picking the slow leg by soonest arrival so the pieces "slide together" and
+//     converge in order at the receiver. The distinction from ECF is the
+//     hold-back: ECF, when the fast leg is saturated, may DECLINE the slow leg
+//     (hold the frame on the fast leg if the fast leg would drain before the
+//     slow leg delivers even one frame — refusing to seed a reorder gap). STMS
+//     does not decline; once a leg is in the active set STMS commits later data
+//     to it and lets the reorder buffer absorb the gap. Its per-leg send window
+//     is the BDP cwnd, adapted as the in-flight estimate drains at the leg's
+//     send rate (the ack-progress proxy the mux already uses — skywire has no
+//     per-leg ACK attribution on the wire, so both schedulers, like ECF, drain
+//     against rate rather than a per-leg ack signal).
+
+// schedDefaultRttMs is the fallback one-way/queueing RTT (ms) used by the
+// arrival estimator when a leg has no RTT sample yet, so a cold leg still gets a
+// finite arrival estimate instead of sorting to the front or the back
+// arbitrarily.
+const schedDefaultRttMs = 100.0
+
+// legArrivalMs estimates, in milliseconds, when a frame handed to leg l right
+// now would be DELIVERED to the receiver: the time to drain the leg's current
+// in-flight backlog at its send rate (queueing delay) plus one-way propagation
+// (≈ RTT/2). This is the shared OTIAS/STMS estimator, built entirely from the
+// ecfLegState fields the mux already refreshes from legCounters.
+//
+// A leg with no rate sample yet (cold) is charged a nominal drain rate derived
+// from the same bounded cold-probe budget ECF uses (ecfColdBootstrapBytes over
+// one baseline RTT), so its queueing term still grows as it is charged and cold
+// start fans out across the ready legs instead of dumping the whole stream on
+// the single lowest-RTT leg until the first rate refresh.
+func legArrivalMs(l ecfLegState) float64 {
+	rtt := l.rttMs
+	if rtt <= 0 {
+		rtt = schedDefaultRttMs
+	}
+	rate := l.rateBps
+	if rate <= 0 {
+		rate = ecfColdBootstrapBytes / (rtt / 1000.0)
+	}
+	queueMs := 0.0
+	if rate > 0 {
+		queueMs = l.inflightBytes / rate * 1000.0
+	}
+	return queueMs + rtt/2.0
+}
+
+// otiasPick returns the ready leg with the earliest estimated arrival time, or
+// -1 when no leg is ready (caller falls back to the schedule). Ties break toward
+// the lower-index (primary/fast) leg so a cold flow's first frames ride the fast
+// leg deterministically. Charging the chosen leg's in-flight bytes (done by the
+// caller) is what makes successive picks fan out by arrival time.
+func otiasPick(legs []ecfLegState) int {
+	best := -1
+	bestArr := math.MaxFloat64
+	for i := range legs {
+		if !legs[i].ready {
+			continue
+		}
+		arr := legArrivalMs(legs[i])
+		if best < 0 || arr < bestArr {
+			best = i
+			bestArr = arr
+		}
+	}
+	return best
+}
+
+// stmsPick implements the Slide-Together placement: the head of the stream rides
+// the fast leg while that leg's send window (BDP cwnd) has room; once the fast
+// leg's window is full, the following data is committed to a slower leg — chosen
+// by soonest arrival among ready legs that still have window room — so the
+// pieces converge in order. Returns -1 when no leg is ready.
+//
+// The contrast with ecfPick is deliberate and is the whole point of STMS: where
+// ECF, on a saturated fast leg, runs the hold-back predicate and may return the
+// fast leg anyway (declining to seed the slow leg), STMS unconditionally spills
+// to the best slow leg with capacity. It only falls back to the fast leg when NO
+// slow leg has window room (every leg saturated) — then the frame queues on the
+// fast leg's reliable transport rather than being held by the scheduler.
+func stmsPick(legs []ecfLegState) int {
+	// Fast leg = lowest-RTT ready leg; unknown-RTT legs are worst candidates.
+	fast := -1
+	for i := range legs {
+		if !legs[i].ready {
+			continue
+		}
+		if fast < 0 || ecfBetterRTT(legs[i], legs[fast]) { //nolint:gosec // fast is in range or <0
+			fast = i
+		}
+	}
+	if fast < 0 {
+		return -1
+	}
+	// Earlier data on the fast leg: keep filling its send window first.
+	if !ecfSaturated(legs[fast]) {
+		return fast
+	}
+	// Fast window full: place the later data on the soonest-arriving slower leg
+	// that still has window room. No hold-back decline (the ECF distinction).
+	best := -1
+	bestArr := math.MaxFloat64
+	for i := range legs {
+		if i == fast || !legs[i].ready || ecfSaturated(legs[i]) {
+			continue
+		}
+		arr := legArrivalMs(legs[i])
+		if best < 0 || arr < bestArr {
+			best = i
+			bestArr = arr
+		}
+	}
+	if best < 0 {
+		// Every ready leg saturated: queue on the fast leg's transport.
+		return fast
+	}
+	return best
+}

--- a/pkg/router/mux_scheduler_test.go
+++ b/pkg/router/mux_scheduler_test.go
@@ -1,0 +1,233 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// schedLeg builds an ecfLegState with the fields the OTIAS/STMS estimators read
+// (rate is what makes their arrival/queue terms non-degenerate, unlike the ECF
+// table which drives most cases off cwnd/inflight alone).
+func schedLeg(rttMs, rateBps, cwndBytes, inflightBytes float64, ready bool) ecfLegState {
+	return ecfLegState{
+		rttMs:         rttMs,
+		rateBps:       rateBps,
+		cwndBytes:     cwndBytes,
+		inflightBytes: inflightBytes,
+		ready:         ready,
+	}
+}
+
+// TestOTIASPick_InOrderSoonestLeg is the core OTIAS assertion: it picks the leg
+// with the earliest ESTIMATED ARRIVAL, which is NOT always the lowest-RTT leg —
+// a fast leg carrying a big backlog can arrive later than a slower idle leg.
+func TestOTIASPick(t *testing.T) {
+	tests := []struct {
+		name string
+		legs []ecfLegState
+		want int
+	}{
+		{
+			name: "no ready leg returns -1",
+			legs: []ecfLegState{
+				schedLeg(10, 1e6, 1e6, 0, false),
+				schedLeg(100, 1e6, 1e6, 0, false),
+			},
+			want: -1,
+		},
+		{
+			name: "two idle legs: lowest-RTT (soonest arrival) wins",
+			legs: []ecfLegState{
+				schedLeg(10, 1e6, 1e6, 0, true),  // arrival ~5ms
+				schedLeg(100, 1e6, 1e6, 0, true), // arrival ~50ms
+			},
+			want: 0,
+		},
+		{
+			// Fast leg has a large backlog it drains slowly (1 MB @ 1 MB/s =
+			// 1000ms queue + 5ms one-way = ~1005ms). The slow-RTT leg is idle
+			// (arrival ~50ms). OTIAS must pick the slower-RTT leg because the
+			// segment ARRIVES sooner there — the whole point of the scheduler.
+			name: "backlogged fast leg loses to idle slow leg on arrival time",
+			legs: []ecfLegState{
+				schedLeg(10, 1e6, 1e6, 1e6, true), // arrival ~1005ms
+				schedLeg(100, 1e6, 1e6, 0, true),  // arrival ~50ms
+			},
+			want: 1,
+		},
+		{
+			// Three legs: pick the true arrival minimum. leg0 backlogged
+			// (~1005ms), leg1 idle 100ms (~50ms), leg2 idle 40ms (~20ms).
+			name: "three legs: soonest arrival among all",
+			legs: []ecfLegState{
+				schedLeg(10, 1e6, 1e6, 1e6, true),
+				schedLeg(100, 1e6, 1e6, 0, true),
+				schedLeg(40, 1e6, 1e6, 0, true),
+			},
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, otiasPick(tt.legs))
+		})
+	}
+}
+
+// TestOTIASPick_FansOutUnderCharge proves the out-of-order-for-in-order behavior
+// end-to-end: with a fast and a slow leg both idle, OTIAS front-loads the fast
+// leg, but as that leg's charged in-flight backlog grows its estimated arrival
+// rises past the idle slow leg's and OTIAS diverts later segments to the slow
+// leg. So both legs carry data — it does not dump the whole stream on one leg.
+func TestSelectOTIAS_FansOut(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeOTIAS)
+
+	// Fast leg: 10ms, ~1 MB/s. Slow leg: 120ms, ~1 MB/s. rate=0 draining is
+	// avoided by giving a real rate; the per-pick charge is what shifts arrivals.
+	ts.SetECFState([]ecfLegState{
+		{rttMs: 10, rateBps: 1e6, cwndBytes: 1e9, ready: true},
+		{rttMs: 120, rateBps: 1e6, cwndBytes: 1e9, ready: true},
+	})
+
+	counts := map[int]int{}
+	payload := make([]byte, 1400)
+	for i := 0; i < 400; i++ {
+		counts[ts.SelectForPayload(payload)]++
+	}
+	assert.Greater(t, counts[0], 0, "fast leg carries the head of the stream")
+	assert.Greater(t, counts[1], 0, "slow leg carries later segments once the fast leg's queue builds")
+	assert.Greater(t, counts[0], counts[1], "fast leg still carries the larger share")
+}
+
+// TestSTMSPick_EarlierDataOnFastLeg is the core STMS assertion: while the fast
+// leg's send window has room, every frame rides it (earlier data on the fast
+// path). Once the fast window is full, later data slides onto a slower leg.
+func TestSTMSPick(t *testing.T) {
+	tests := []struct {
+		name string
+		legs []ecfLegState
+		want int
+	}{
+		{
+			name: "no ready leg returns -1",
+			legs: []ecfLegState{
+				schedLeg(10, 1e6, 1e6, 0, false),
+			},
+			want: -1,
+		},
+		{
+			name: "fast leg with window room takes the frame (earlier data on fast)",
+			legs: []ecfLegState{
+				schedLeg(10, 1e6, 1e6, 0, true), // window wide open
+				schedLeg(100, 1e6, 1e6, 0, true),
+			},
+			want: 0,
+		},
+		{
+			// Fast leg's window is FULL (inflight >= cwnd): later data slides to
+			// the slower leg that still has room.
+			name: "fast window full: slide later data onto the slow leg",
+			legs: []ecfLegState{
+				schedLeg(10, 1e6, 1000, 5000, true), // saturated
+				schedLeg(100, 1e6, 1e9, 0, true),    // room
+			},
+			want: 1,
+		},
+		{
+			// Fast window full and the ONLY slow candidate also full: queue on
+			// the fast leg (STMS never returns NO-LEG).
+			name: "all legs saturated: stay on fast leg",
+			legs: []ecfLegState{
+				schedLeg(10, 1e6, 1000, 5000, true),
+				schedLeg(100, 1e6, 1000, 5000, true),
+			},
+			want: 0,
+		},
+		{
+			// Two slow candidates with room: STMS slides to the soonest-arriving
+			// one. leg1 40ms idle (~20ms) beats leg2 200ms idle (~100ms).
+			name: "fast full: slide to soonest-arriving slow leg",
+			legs: []ecfLegState{
+				schedLeg(10, 1e6, 1000, 5000, true), // saturated fast
+				schedLeg(40, 1e6, 1e9, 0, true),
+				schedLeg(200, 1e6, 1e9, 0, true),
+			},
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stmsPick(tt.legs))
+		})
+	}
+}
+
+// TestSTMS_vs_ECF_HoldbackDistinction pins the defining behavioral difference:
+// on identical legs where ECF's hold-back predicate DECLINES the slow leg (the
+// fast leg drains its backlog before the slow leg delivers one frame, so ECF
+// holds on the fast leg), STMS instead commits the later data to the slow leg.
+func TestSTMS_vs_ECF_HoldbackDistinction(t *testing.T) {
+	// Canonical ECF hold case (from TestECFPick): fast 10ms cwnd 10000 backlog
+	// 20000 (n=3, n*rttF=30) vs slow 100ms idle -> 30 < 100 so ECF holds on 0.
+	legs := []ecfLegState{
+		schedLeg(10, 0, 10000, 20000, true),
+		schedLeg(100, 0, 1e9, 0, true),
+	}
+	assert.Equal(t, 0, ecfPick(legs, false, nil), "ECF holds the frame on the fast leg")
+	assert.Equal(t, 1, stmsPick(legs), "STMS slides later data onto the slow leg (no hold-back decline)")
+}
+
+// TestSelectSTMS_Integration drives STMS through the selector: the fast leg with
+// window room wins every frame until it saturates, then frames spill to the slow
+// leg. Also confirms in-flight is charged to the chosen leg.
+func TestSelectSTMS_Integration(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeSTMS)
+
+	// Fast leg window = 1400 bytes (one frame) so it saturates immediately after
+	// the first charge; rate 0 so the time-drain never clears it within the test.
+	ts.SetECFState([]ecfLegState{
+		{rttMs: 10, cwndBytes: 1400, rateBps: 0, ready: true},
+		{rttMs: 100, cwndBytes: 1e9, rateBps: 0, ready: true},
+	})
+
+	payload := make([]byte, 1400)
+	first := ts.SelectForPayload(payload)
+	require.Equal(t, 0, first, "first (earliest) frame rides the fast leg")
+
+	// Fast leg is now saturated; subsequent frames slide to the slow leg.
+	spill := ts.SelectForPayload(payload)
+	assert.Equal(t, 1, spill, "later frames slide onto the slow leg once the fast window is full")
+
+	ts.mu.RLock()
+	slowInflight := ts.ecfLegs[1].inflightBytes
+	ts.mu.RUnlock()
+	assert.Greater(t, slowInflight, 0.0, "the slid frame charges the slow leg's in-flight")
+}
+
+// TestSelectPredictive_BootstrapFallsBackToSchedule confirms OTIAS and STMS,
+// like ECF, fall back to the mirrored schedule when no estimator state exists.
+func TestSelectPredictive_BootstrapFallsBackToSchedule(t *testing.T) {
+	for _, mode := range []WeightMode{WeightModeOTIAS, WeightModeSTMS} {
+		ts := newTransportSelector()
+		ts.SetMode(mode)
+		ts.mu.Lock()
+		ts.schedule = []int{0, 1}
+		ts.mu.Unlock()
+		idx := ts.SelectForPayload(make([]byte, 512))
+		assert.Contains(t, []int{0, 1}, idx, "%v bootstrap falls back to a schedule index", mode)
+	}
+}
+
+// TestPredictiveModeStrings pins the operator-facing mode tokens.
+func TestPredictiveModeStrings(t *testing.T) {
+	assert.Equal(t, "otias", WeightModeOTIAS.String())
+	assert.Equal(t, "stms", WeightModeSTMS.String())
+	assert.True(t, WeightModeOTIAS.isPredictive())
+	assert.True(t, WeightModeSTMS.isPredictive())
+	assert.True(t, WeightModeECF.isPredictive())
+	assert.False(t, WeightModeCapacity.isPredictive())
+}

--- a/pkg/router/policy/distribution.go
+++ b/pkg/router/policy/distribution.go
@@ -50,6 +50,10 @@ func ParseDistribution(s string) (router.DistributionConfig, error) {
 		return router.DistributionConfig{Mode: router.DistributionCapacity}, nil
 	case "ecf":
 		return router.DistributionConfig{Mode: router.DistributionECF}, nil
+	case "otias":
+		return router.DistributionConfig{Mode: router.DistributionOTIAS}, nil
+	case "stms":
+		return router.DistributionConfig{Mode: router.DistributionSTMS}, nil
 	}
 
 	// Prefix-based.

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1358,6 +1358,10 @@ func (rg *RouteGroup) applyDistribution(cfg DistributionConfig) {
 		wm = WeightModeCapacity
 	case DistributionECF:
 		wm = WeightModeECF
+	case DistributionOTIAS:
+		wm = WeightModeOTIAS
+	case DistributionSTMS:
+		wm = WeightModeSTMS
 	case DistributionDSCPPriority:
 		wm = WeightModeDSCPPriority
 		rg.mux.tpSelector.SetDSCPThreshold(cfg.DSCPThreshold)

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -386,7 +386,9 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 			WeightModeSticky5Tuple,
 			WeightModeLatencyAdaptive,
 			WeightModeDSCPPriority,
-			WeightModeECF:
+			WeightModeECF,
+			WeightModeOTIAS,
+			WeightModeSTMS:
 			idx := m.tpSelector.SelectForPayload(payload)
 			if idx < len(tps) {
 				tp := tps[idx]
@@ -1214,7 +1216,12 @@ func (m *routeMux) rebuildWeights(tps []*transport.ManagedTransport) {
 	// transport latency (tp.GetLatency(), ms) — the end-to-end route latency
 	// would be more accurate but is not reachable from the mux; noted as a
 	// follow-up. Jitter is an EWMA of |RTT-mean|, the ECF sigma margin.
-	if m.tpSelector.Mode() == WeightModeECF {
+	//
+	// OTIAS and STMS reason over the SAME ecfLegState snapshot (rate + RTT +
+	// jitter + BDP + the selector-tracked in-flight estimate), so this one
+	// branch feeds all three predictive schedulers; only the per-frame pick in
+	// the selector differs (ecfPick vs otiasPick vs stmsPick).
+	if m.tpSelector.Mode().isPredictive() {
 		m.legMu.Lock()
 		now := time.Now().UnixNano()
 		var elapsed float64

--- a/pkg/router/transport_selector.go
+++ b/pkg/router/transport_selector.go
@@ -74,6 +74,24 @@ const (
 	// byte estimate; see ecfPick and SelectECF. This is the aggregation mode
 	// that stops a heterogeneous mux from HoL-stalling on its slow legs.
 	WeightModeECF
+	// WeightModeOTIAS is the Out-of-order Transmission for In-order Arrival
+	// scheduler (Yang et al.). It reasons over the SAME per-leg estimator
+	// snapshot as ECF (ecfLegState), but instead of ECF's fast-leg-with-hold-back
+	// rule it assigns each segment to the leg whose ESTIMATED ARRIVAL is soonest:
+	// queueing delay (current backlog / send rate) + one-way propagation (RTT/2).
+	// Charging the chosen leg makes successive picks fan out by arrival time, so
+	// OTIAS deliberately hands a later segment to a slower-but-idle leg once the
+	// fast leg's queue would make it arrive later. See otiasPick / SelectOTIAS.
+	WeightModeOTIAS
+	// WeightModeSTMS is the Slide Together Multipath Scheduler (Shi et al.,
+	// USENIX ATC 2018). It keeps the head of the stream on the fast leg — filling
+	// that leg's BDP send window first so EARLIER data always rides the fast path
+	// — and only once the fast window is full places the following (later) data
+	// on the soonest-arriving slower leg, so the pieces converge in order. Unlike
+	// ECF, STMS does not decline a slow leg once it is in the active set (ECF's
+	// hold-back predicate); it commits later data to it and lets the reorder
+	// buffer absorb the gap. See stmsPick / SelectSTMS.
+	WeightModeSTMS
 )
 
 // ECF (WeightModeECF) tuning constants. Starting values — expect a live-tuning
@@ -286,8 +304,22 @@ func (m WeightMode) String() string {
 		return "capacity"
 	case WeightModeECF:
 		return "ecf"
+	case WeightModeOTIAS:
+		return "otias"
+	case WeightModeSTMS:
+		return "stms"
 	}
 	return "unknown"
+}
+
+// isPredictive reports whether the mode is one of the completion-time predictive
+// schedulers (ECF/OTIAS/STMS). They all reason over the per-leg ecfLegState
+// snapshot the mux refreshes via SetECFState (RTT/jitter/rate/BDP + the
+// selector-tracked in-flight estimate) rather than a precomputed schedule, so
+// the mux builds that snapshot and the selector mirrors the live legs for the
+// same set of modes.
+func (m WeightMode) isPredictive() bool {
+	return m == WeightModeECF || m == WeightModeOTIAS || m == WeightModeSTMS
 }
 
 // SetECFState stores the per-leg ECF state used by WeightModeECF. Caller (the
@@ -500,10 +532,11 @@ func (ts *transportSelector) Rebuild(tps []*transport.ManagedTransport) {
 	// GetLatency. The primary schedule is also populated so a
 	// caller using Select() (no payload) still gets a reasonable
 	// leg.
-	// ECF also builds the live-leg arrays: SelectECF reasons over ecfLegs
-	// (set separately via SetECFState) but the mirrored schedule is the
-	// Select() fallback for control/handshake frames that carry no payload.
-	if ts.mode == WeightModeSticky5Tuple || ts.mode == WeightModeLatencyAdaptive || ts.mode == WeightModeECF {
+	// The predictive schedulers (ECF/OTIAS/STMS) also build the live-leg arrays:
+	// they reason over ecfLegs (set separately via SetECFState) but the mirrored
+	// schedule is the Select() fallback for control/handshake frames that carry
+	// no payload, and for the cold-start bootstrap before any estimator state.
+	if ts.mode == WeightModeSticky5Tuple || ts.mode == WeightModeLatencyAdaptive || ts.mode.isPredictive() {
 		live := make([]int, 0, n)
 		liveTps := make([]*transport.ManagedTransport, 0, n)
 		for i, tp := range tps {
@@ -682,6 +715,10 @@ func (ts *transportSelector) SelectForPayload(p []byte) int {
 		return pickLowestLatency(live, liveTps)
 	case WeightModeECF:
 		return ts.SelectECF(len(p))
+	case WeightModeOTIAS:
+		return ts.SelectOTIAS(len(p))
+	case WeightModeSTMS:
+		return ts.SelectSTMS(len(p))
 	case WeightModeDSCPPriority:
 		if isIPv4DSCPGE(p, dscpThreshold) {
 			return 0
@@ -763,11 +800,70 @@ func (ts *transportSelector) SelectECF(size int) int {
 	if len(ts.ecfLegs) == 0 {
 		return ts.scheduleIndexLocked()
 	}
+	ts.drainInflightLocked()
 
-	// Drain inflight by rate*elapsed since the last pick. Because the leg
-	// transports are reliable, a frame put on leg i is delivered ~rttᵢ later;
-	// draining at the leg's send rate approximates that clearance without a
-	// per-frame ack signal (skywire has no per-leg ack attribution).
+	idx := ecfPick(ts.ecfLegs, ts.ecfWaiting, &ts.ecfWaiting)
+	if idx < 0 {
+		return ts.scheduleIndexLocked()
+	}
+	ts.chargeInflightLocked(idx, size)
+	return idx
+}
+
+// SelectOTIAS returns the leg index for the next DATA frame under the OTIAS
+// scheduler (WeightModeOTIAS): the ready leg whose estimated ARRIVAL time is
+// soonest (queueing + one-way delay), computed from the same ecfLegState the
+// mux refreshes. Drains the in-flight estimate for the elapsed gap, runs
+// otiasPick, and charges the chosen leg. Falls back to the schedule when there
+// is no estimator state yet or no leg is ready. Takes the write lock because it
+// mutates in-flight state (per-route-group picks are already serialized by the
+// caller's rg.mu, so it only contends with the periodic SetECFState refresh).
+func (ts *transportSelector) SelectOTIAS(size int) int {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	if len(ts.ecfLegs) == 0 {
+		return ts.scheduleIndexLocked()
+	}
+	ts.drainInflightLocked()
+
+	idx := otiasPick(ts.ecfLegs)
+	if idx < 0 {
+		return ts.scheduleIndexLocked()
+	}
+	ts.chargeInflightLocked(idx, size)
+	return idx
+}
+
+// SelectSTMS returns the leg index for the next DATA frame under the STMS
+// scheduler (WeightModeSTMS): the fast leg while its BDP send window has room
+// (head of the stream on the fast path), else the soonest-arriving slower leg
+// with window room (later data slides onto the slow path to converge in order).
+// Same drain/charge accounting as SelectECF/SelectOTIAS; falls back to the
+// schedule when there is no estimator state yet or no leg is ready.
+func (ts *transportSelector) SelectSTMS(size int) int {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	if len(ts.ecfLegs) == 0 {
+		return ts.scheduleIndexLocked()
+	}
+	ts.drainInflightLocked()
+
+	idx := stmsPick(ts.ecfLegs)
+	if idx < 0 {
+		return ts.scheduleIndexLocked()
+	}
+	ts.chargeInflightLocked(idx, size)
+	return idx
+}
+
+// drainInflightLocked drains each leg's in-flight byte estimate by rate*elapsed
+// since the previous predictive pick, then stamps the clock. Shared by the
+// ECF/OTIAS/STMS schedulers: skywire has no per-leg ACK attribution, so a frame
+// put on a reliable leg is modeled as clearing at that leg's send rate (it is
+// delivered ~RTT later). Caller holds ts.mu.
+func (ts *transportSelector) drainInflightLocked() {
 	now := time.Now().UnixNano()
 	if ts.ecfLastNano != 0 {
 		dt := float64(now-ts.ecfLastNano) / float64(time.Second)
@@ -781,16 +877,16 @@ func (ts *transportSelector) SelectECF(size int) int {
 		}
 	}
 	ts.ecfLastNano = now
+}
 
-	idx := ecfPick(ts.ecfLegs, ts.ecfWaiting, &ts.ecfWaiting)
-	if idx < 0 {
-		return ts.scheduleIndexLocked()
-	}
+// chargeInflightLocked adds this frame's bytes to leg idx's in-flight estimate
+// (the amount later picks reason about draining). A non-positive size is charged
+// the defensive default. Caller holds ts.mu.
+func (ts *transportSelector) chargeInflightLocked(idx, size int) {
 	if size <= 0 {
 		size = ecfDefaultFrameBytes
 	}
 	ts.ecfLegs[idx].inflightBytes += float64(size)
-	return idx
 }
 
 // scheduleIndexLocked returns the next schedule-based leg index. Caller holds

--- a/pkg/visor/api_transport.go
+++ b/pkg/visor/api_transport.go
@@ -176,8 +176,12 @@ func (v *Visor) SetMuxMode(mode string) error {
 		m = router.WeightModeCapacity
 	case "ecf":
 		m = router.WeightModeECF
+	case "otias":
+		m = router.WeightModeOTIAS
+	case "stms":
+		m = router.WeightModeSTMS
 	default:
-		return fmt.Errorf("unknown mux mode %q (use \"auto\", \"equal\", \"capacity\", or \"ecf\")", mode)
+		return fmt.Errorf("unknown mux mode %q (use \"auto\", \"equal\", \"capacity\", \"ecf\", \"otias\", or \"stms\")", mode)
 	}
 	v.router.SetMuxMode(m)
 	v.log.Infof("SetMuxMode: %v", mode)


### PR DESCRIPTION
Adds two completion-time predictive mux schedulers alongside the existing ECF/capacity modes, selectable at runtime via `skywire cli proxy mux mode otias|stms` (and the routing-policy `distribution=` descriptor). Both are dispatch-side decisions only — no wire-format change, no capability bit, no peer coordination, and the default is unchanged. They reuse the exact per-leg estimator snapshot ECF already refreshes from the continuously-sampled `legCounters` EWMAs (mean/baseline RTT, jitter, send rate, BDP cwnd, plus the selector-tracked in-flight estimate), so there is no parallel sampler — one `rebuildWeights` branch now feeds all three predictive schedulers and only the per-frame pick differs.

`otias` (Out-of-order Transmission for In-order Arrival) assigns each frame to the leg whose estimated arrival is soonest — backlog drain time (inflight/rate) plus one-way delay (RTT/2) — so it deliberately hands a later frame to a slower-but-idle leg once the fast leg's queue would make it land later; the reorder buffer restores stream order. `stms` (Slide Together Multipath Scheduler, Shi et al., ATC 2018) keeps the head of the stream on the fast leg by filling its send window first, then slides the following data onto the soonest-arriving slower leg so pieces converge in order. STMS differs from ECF in the hold-back: ECF may decline a saturated-fast-leg's slow spill to avoid seeding a reorder gap, whereas STMS commits later data to the slow leg once it is in the active set.

skywire has no per-leg ACK attribution on the wire, so STMS adapts its per-leg send window against the same rate-drain in-flight model ECF already uses rather than a per-leg ack signal — the one scoped approximation. `go build`, `go vet`, and gofmt are clean; unit tests cover both picks (OTIAS chooses the in-order-soonest leg even when it is not the lowest-RTT; STMS keeps earlier data on the fast leg and slides later data onto the slow leg; and STMS diverges from ECF on the canonical hold-back case).