### PR TITLE
feat(router): shared-bottleneck detection for mux legs (RFC 8382)

### DIFF
--- a/pkg/router/bottleneck.go
+++ b/pkg/router/bottleneck.go
@@ -1,0 +1,357 @@
+// Package router pkg/router/bottleneck.go c2-net-routing
+package router
+
+import (
+	"math"
+	"sort"
+)
+
+// Shared-bottleneck detection (SBD) for mux legs, after RFC 8382.
+//
+// Two mux legs that ride different transports can still funnel through the same
+// physical uplink (the visor's own access link, a shared upstream hop). When
+// they do, the scheduler counts them as N independent pipes and stripes across
+// all N — but there is really ONE pipe, so the legs merely compete: they add
+// reorder cost and self-inflicted queuing for zero extra capacity. The
+// structural same-LAN reject (#4253) only catches co-located INTERMEDIATES; it
+// is blind to two disjoint routes that share an uplink further out.
+//
+// RFC 8382 detects a shared bottleneck from the VARIATION in one-way delay
+// (OWD), not its absolute value: legs behind the same congested queue exhibit
+// the same delay-variation SIGNATURE (variance, skewness, oscillation), because
+// they queue behind the same buffer. It needs neither synchronized clocks nor
+// time-aligned samples — only summary statistics of each leg's own OWD series —
+// which is exactly what the per-leg liveness pong already gives us (a raw
+// round-trip sample per leg per tick, folded here BEFORE the EWMA). RTT stands
+// in for OWD: the variation we key on is dominated by queueing, which RTT and
+// OWD share. No new probe traffic is added.
+//
+// Because raw cross-correlation would need time-aligned samples (our per-leg
+// pongs are sampled independently), we follow RFC 8382 and cluster on the
+// distribution-shape summary statistics instead — legs sharing a bottleneck
+// have the same statistics even when their samples are not aligned in time.
+
+const (
+	// sbdWindowSamples is the moving-window depth (per leg) over which the OWD
+	// summary statistics are computed. The per-leg liveness pong lands roughly
+	// once per legLivenessInterval (30s), so 8 samples is ~4 minutes of history:
+	// enough to estimate variance/skew/oscillation, short enough to follow a real
+	// path change within a few minutes. A finer per-leg OWD sampler (were one ever
+	// added) would let this window shrink toward RFC 8382's ~15s without any change
+	// to the math below. Tuning parameter, not an on/off gate.
+	sbdWindowSamples = 8
+	// sbdMinSamples is the fewest samples a leg needs before its statistics are
+	// trusted for grouping. Below it the leg is treated as its OWN singleton group
+	// (insufficient evidence to merge — the conservative default: never collapse a
+	// leg's capacity on a guess).
+	sbdMinSamples = 4
+	// sbdSkewTol is the maximum |skew_i - skew_j| for two legs to be judged
+	// co-bottlenecked. skew_est is in [-1, 1] (fraction of samples below the mean
+	// minus fraction above), so 0.5 is a half-scale band — legs behind the same
+	// queue share a skew sign and rough magnitude.
+	sbdSkewTol = 0.5
+	// sbdCVTolFrac is the maximum RELATIVE difference in coefficient of variation
+	// (stddev/mean) for two legs to be judged co-bottlenecked. Using CV rather than
+	// raw variance makes the test scale-invariant, so a fast and a slow leg behind
+	// the same bottleneck (different base RTT, same fractional jitter) still match.
+	sbdCVTolFrac = 0.5
+	// sbdFreqTol is the maximum |freq_i - freq_j| for two legs to be judged
+	// co-bottlenecked. freq_est is the fraction of consecutive-sample transitions
+	// that cross the mean (0..1) — the oscillation frequency of the queue. 0.4 is a
+	// wide band appropriate to the small windows the coarse pong cadence yields.
+	sbdFreqTol = 0.4
+)
+
+// sbdWindow is a fixed-capacity ring of a single leg's most recent raw OWD (RTT)
+// samples, in milliseconds. Not safe for concurrent use; the caller serializes
+// pushes and reads under its own lock (RouteGroup.legLivenessMu).
+type sbdWindow struct {
+	buf  []float64
+	next int
+	n    int
+}
+
+// newSBDWindow returns an empty window sized to sbdWindowSamples.
+func newSBDWindow() *sbdWindow {
+	return &sbdWindow{buf: make([]float64, sbdWindowSamples)}
+}
+
+// push appends one raw OWD sample (ms), overwriting the oldest when full.
+// Non-positive samples are ignored (a bad/late pong is already rejected upstream,
+// this is belt-and-suspenders so a stray zero never skews the stats).
+func (w *sbdWindow) push(sampleMs float64) {
+	if w == nil || sampleMs <= 0 {
+		return
+	}
+	if len(w.buf) == 0 {
+		w.buf = make([]float64, sbdWindowSamples)
+	}
+	w.buf[w.next] = sampleMs
+	w.next = (w.next + 1) % len(w.buf)
+	if w.n < len(w.buf) {
+		w.n++
+	}
+}
+
+// samples returns a copy of the window's live samples in chronological order
+// (oldest first), so callers can compute order-dependent statistics (freq_est).
+func (w *sbdWindow) samples() []float64 {
+	if w == nil || w.n == 0 {
+		return nil
+	}
+	out := make([]float64, 0, w.n)
+	if w.n < len(w.buf) {
+		// Not yet wrapped: live samples are buf[0:n] in order.
+		out = append(out, w.buf[:w.n]...)
+		return out
+	}
+	// Wrapped: oldest is at next, read around the ring.
+	for i := 0; i < len(w.buf); i++ {
+		out = append(out, w.buf[(w.next+i)%len(w.buf)])
+	}
+	return out
+}
+
+// sbdStats holds the RFC 8382 summary statistics of one leg's OWD window.
+type sbdStats struct {
+	// n is how many samples the statistics were computed over.
+	n int
+	// mean is the mean OWD (ms).
+	mean float64
+	// variance is the population variance of the OWD samples (ms^2).
+	variance float64
+	// cv is the coefficient of variation (stddev/mean), the scale-invariant
+	// spread used for grouping. 0 when mean<=0.
+	cv float64
+	// skew is RFC 8382's skew_est: (#below-mean - #above-mean)/n, in [-1, 1].
+	// A congested bottleneck queue spends most time near its base delay with
+	// occasional upward spikes, so skew tends POSITIVE behind a real bottleneck.
+	skew float64
+	// freq is RFC 8382's freq_est proxy: the fraction of consecutive-sample steps
+	// that cross the mean (0..1) — the queue's oscillation frequency.
+	freq float64
+}
+
+// computeSBDStats computes the summary statistics of one leg's OWD samples
+// (chronological order). Returns n=0 (and zero stats) for an empty input.
+func computeSBDStats(samples []float64) sbdStats {
+	n := len(samples)
+	if n == 0 {
+		return sbdStats{}
+	}
+	var sum float64
+	for _, s := range samples {
+		sum += s
+	}
+	mean := sum / float64(n)
+
+	var sqSum float64
+	var below, above int
+	for _, s := range samples {
+		d := s - mean
+		sqSum += d * d
+		// A small dead-band around the mean keeps float noise on a flat series
+		// from registering as skew/crossings.
+		switch {
+		case s < mean-sbdMeanEps(mean):
+			below++
+		case s > mean+sbdMeanEps(mean):
+			above++
+		}
+	}
+	variance := sqSum / float64(n)
+	std := math.Sqrt(variance)
+	cv := 0.0
+	if mean > 0 {
+		cv = std / mean
+	}
+	skew := float64(below-above) / float64(n)
+
+	// freq_est: fraction of consecutive steps whose (sample-mean) sign flips.
+	crossings := 0
+	if n > 1 {
+		prev := samples[0] - mean
+		for i := 1; i < n; i++ {
+			cur := samples[i] - mean
+			if (prev < 0 && cur > 0) || (prev > 0 && cur < 0) {
+				crossings++
+			}
+			// Carry the last non-zero sign so a sample sitting exactly on the mean
+			// doesn't reset the oscillation count.
+			if cur != 0 {
+				prev = cur
+			}
+		}
+	}
+	freq := 0.0
+	if n > 1 {
+		freq = float64(crossings) / float64(n-1)
+	}
+
+	return sbdStats{n: n, mean: mean, variance: variance, cv: cv, skew: skew, freq: freq}
+}
+
+// sbdMeanEps is the dead-band half-width around the mean used when classifying a
+// sample as above/below/at the mean, as a tiny fraction of the mean plus an
+// absolute floor for near-zero means.
+func sbdMeanEps(mean float64) float64 {
+	return math.Max(0.001, 1e-6*math.Abs(mean))
+}
+
+// sbdSimilar reports whether two legs' statistics indicate a SHARED bottleneck:
+// both have enough samples AND their skew, coefficient of variation, and
+// oscillation frequency all fall within tolerance. All three must agree — the
+// conjunction is what makes an accidental match on any single axis insufficient
+// to collapse a leg's capacity.
+func sbdSimilar(a, b sbdStats) bool {
+	if a.n < sbdMinSamples || b.n < sbdMinSamples {
+		return false
+	}
+	if math.Abs(a.skew-b.skew) > sbdSkewTol {
+		return false
+	}
+	if math.Abs(a.freq-b.freq) > sbdFreqTol {
+		return false
+	}
+	maxCV := math.Max(a.cv, b.cv)
+	if maxCV < 1e-9 {
+		// Both series are essentially flat (no measurable variation): with no
+		// delay-variation signature there is no evidence of a shared queue, so do
+		// NOT merge. Flat legs stay independent.
+		return false
+	}
+	if math.Abs(a.cv-b.cv)/maxCV > sbdCVTolFrac {
+		return false
+	}
+	return true
+}
+
+// groupLegsBySBD partitions legs into shared-bottleneck groups from their OWD
+// summary statistics and returns a group-id slice PARALLEL to stats: legs with
+// the same group id are judged to share a bottleneck. Group ids are the smallest
+// leg index in each group (stable, deterministic).
+//
+// Heuristic: single-linkage clustering (union-find) over the pairwise sbdSimilar
+// relation. Two legs join when their statistics agree on all three axes; the
+// union then merges their groups transitively. Single-linkage can in principle
+// chain (A~B, B~C but A not ~C all land together); with the handful of legs a mux
+// carries this is acceptable and documented — the practical effect is only ever a
+// more CONSERVATIVE capacity estimate (never fewer distinct pipes than reality).
+// A leg with too few samples is its own singleton (never merged): absent
+// evidence, its capacity is counted in full.
+func groupLegsBySBD(stats []sbdStats) []int {
+	n := len(stats)
+	groups := make([]int, n)
+	// Union-find parent array; each leg starts as its own root.
+	parent := make([]int, n)
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		for parent[x] != x {
+			parent[x] = parent[parent[x]]
+			x = parent[x]
+		}
+		return x
+	}
+	union := func(a, b int) {
+		ra, rb := find(a), find(b)
+		if ra == rb {
+			return
+		}
+		// Point the larger root at the smaller so the canonical id is the smallest
+		// index in the merged set.
+		if ra < rb {
+			parent[rb] = ra
+		} else {
+			parent[ra] = rb
+		}
+	}
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if sbdSimilar(stats[i], stats[j]) {
+				union(i, j)
+			}
+		}
+	}
+	for i := 0; i < n; i++ {
+		groups[i] = find(i)
+	}
+	return groups
+}
+
+// bottleneckLeg is one leg's input to the distinct-group admission decision.
+type bottleneckLeg struct {
+	idx     int
+	group   int    // shared-bottleneck group id (from groupLegsBySBD)
+	standby bool   // already a warm standby (only ACTIVE legs are considered)
+	primary bool   // the primary leg (index 0) — never parked, always the keeper
+	goodput uint64 // recent delivered bytes; higher = better keeper
+	latMs   float64
+}
+
+// pickBottleneckDemotions returns the indices of ACTIVE legs to park to warm
+// standby so at most ONE active leg remains per shared-bottleneck group — the
+// admission rule "prefer legs from DISTINCT groups". Striping two legs that share
+// one pipe buys no capacity and only adds reorder cost, so the redundant members
+// are parked (kept warm for failover, promotable instantly). Per group the keeper
+// is: the primary if the group contains it, else the highest-goodput member,
+// tie-broken by lowest latency then lowest index. The primary is never parked and
+// a group with a single active member is left alone. Pure (no locks / rg state)
+// so it is unit-tested directly.
+//
+// This SUBSUMES the same-LAN structural reject (#4253): two legs whose disjoint
+// routes funnel through one uplink land in the same group here and all but one are
+// parked, which the mux-set structural check (co-located INTERMEDIATE only) cannot
+// see. The structural check is retained as a cheap pre-filter at leg-creation
+// time; this is the general runtime rule.
+func pickBottleneckDemotions(legs []bottleneckLeg) []int {
+	// Bucket active legs by group.
+	byGroup := make(map[int][]bottleneckLeg)
+	for _, l := range legs {
+		if l.standby {
+			continue
+		}
+		byGroup[l.group] = append(byGroup[l.group], l)
+	}
+	var demote []int
+	for _, members := range byGroup {
+		if len(members) < 2 {
+			continue // a distinct pipe with one active leg — nothing to collapse
+		}
+		keeper := -1
+		for i, m := range members {
+			switch {
+			case m.primary:
+				keeper = i // primary always wins
+			case keeper == -1:
+				keeper = i
+			case members[keeper].primary:
+				// keeper already the primary; leave it
+			case betterKeeper(m, members[keeper]):
+				keeper = i
+			}
+		}
+		for i, m := range members {
+			if i == keeper || m.primary {
+				continue
+			}
+			demote = append(demote, m.idx)
+		}
+	}
+	sort.Ints(demote)
+	return demote
+}
+
+// betterKeeper reports whether leg a is a better active representative than b:
+// higher goodput, then lower latency, then lower index.
+func betterKeeper(a, b bottleneckLeg) bool {
+	if a.goodput != b.goodput {
+		return a.goodput > b.goodput
+	}
+	if a.latMs > 0 && b.latMs > 0 && a.latMs != b.latMs {
+		return a.latMs < b.latMs
+	}
+	return a.idx < b.idx
+}

--- a/pkg/router/bottleneck.go
+++ b/pkg/router/bottleneck.go
@@ -247,8 +247,7 @@ func groupLegsBySBD(stats []sbdStats) []int {
 	for i := range parent {
 		parent[i] = i
 	}
-	var find func(int) int
-	find = func(x int) int {
+	find := func(x int) int {
 		for parent[x] != x {
 			parent[x] = parent[parent[x]]
 			x = parent[x]

--- a/pkg/router/bottleneck_test.go
+++ b/pkg/router/bottleneck_test.go
@@ -1,0 +1,227 @@
+// Package router pkg/router/bottleneck_test.go
+//
+// Unit coverage for shared-bottleneck detection (RFC 8382): the per-leg OWD
+// summary statistics, the similarity/grouping heuristic over synthetic sample
+// sets, the distinct-group admission picker, and rebuildWeights collapsing a
+// bottleneck group into one capacity unit. All exercised on pure functions or a
+// bare mux — no transports or network.
+package router
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+func TestSBDWindowPushAndSamples(t *testing.T) {
+	w := newSBDWindow()
+	// Push more than the window depth; only the most recent sbdWindowSamples
+	// remain, in chronological (oldest-first) order.
+	for i := 1; i <= sbdWindowSamples+3; i++ {
+		w.push(float64(i))
+	}
+	got := w.samples()
+	require.Len(t, got, sbdWindowSamples)
+	// The first three (1,2,3) were overwritten; the window holds 4..(N+3).
+	assert.Equal(t, float64(4), got[0])
+	assert.Equal(t, float64(sbdWindowSamples+3), got[len(got)-1])
+	// Non-positive samples are ignored.
+	before := len(w.samples())
+	w.push(0)
+	w.push(-5)
+	assert.Len(t, w.samples(), before)
+}
+
+func TestComputeSBDStats_Flat(t *testing.T) {
+	s := computeSBDStats([]float64{10, 10, 10, 10, 10, 10})
+	assert.Equal(t, 6, s.n)
+	assert.InDelta(t, 10, s.mean, 1e-9)
+	assert.InDelta(t, 0, s.variance, 1e-9)
+	assert.InDelta(t, 0, s.cv, 1e-9)
+	assert.InDelta(t, 0, s.skew, 1e-9)
+	assert.InDelta(t, 0, s.freq, 1e-9)
+}
+
+func TestComputeSBDStats_SpikySkew(t *testing.T) {
+	// Base level with occasional upward spikes: most samples sit BELOW the mean,
+	// so skew_est is positive — the classic bottleneck-queue signature.
+	s := computeSBDStats([]float64{50, 50, 50, 200, 50, 50, 50, 200})
+	assert.Greater(t, s.skew, 0.0)
+	assert.Greater(t, s.cv, 0.0)
+	// mean = (6*50 + 2*200)/8 = 87.5
+	assert.InDelta(t, 87.5, s.mean, 1e-9)
+}
+
+func TestComputeSBDStats_Oscillation(t *testing.T) {
+	// Alternating high/low: every consecutive step crosses the mean, so freq_est
+	// approaches 1 and skew is ~0 (balanced above/below).
+	s := computeSBDStats([]float64{30, 80, 30, 80, 30, 80, 30, 80})
+	assert.InDelta(t, 1.0, s.freq, 1e-9)
+	assert.InDelta(t, 0.0, s.skew, 1e-9)
+}
+
+// TestGroupLegsBySBD_CorrelatedCluster is the core grouping test: two legs with a
+// SIMILAR delay-variation signature cluster into one group; a flat leg and a
+// high-oscillation leg (independent signatures) each stay separate.
+func TestGroupLegsBySBD_CorrelatedCluster(t *testing.T) {
+	legA := computeSBDStats([]float64{50, 52, 51, 90, 50, 53, 51, 88})         // base ~50, spikes
+	legB := computeSBDStats([]float64{48, 50, 49, 86, 49, 51, 50, 85})         // same signature, shifted
+	legC := computeSBDStats([]float64{200, 200, 200, 200, 200, 200, 200, 200}) // flat, independent
+	legD := computeSBDStats([]float64{30, 80, 30, 80, 30, 80, 30, 80})         // high oscillation
+
+	groups := groupLegsBySBD([]sbdStats{legA, legB, legC, legD})
+	require.Len(t, groups, 4)
+
+	// A and B share a bottleneck.
+	assert.Equal(t, groups[0], groups[1], "legs A,B should share a group")
+	// C and D are each their own singleton, distinct from A/B and each other.
+	assert.NotEqual(t, groups[0], groups[2], "flat leg C must not merge")
+	assert.NotEqual(t, groups[0], groups[3], "oscillating leg D must not merge")
+	assert.NotEqual(t, groups[2], groups[3], "C and D are independent")
+	// Group id is the smallest member index.
+	assert.Equal(t, 0, groups[0])
+}
+
+func TestGroupLegsBySBD_IndependentStaySeparate(t *testing.T) {
+	// Three clearly different signatures → three singleton groups.
+	a := computeSBDStats([]float64{10, 10, 10, 60, 10, 10, 10, 60})         // low base, spikes
+	b := computeSBDStats([]float64{100, 105, 100, 103, 101, 104, 100, 102}) // tight, low CV
+	c := computeSBDStats([]float64{20, 90, 20, 90, 20, 90, 20, 90})         // full oscillation
+	groups := groupLegsBySBD([]sbdStats{a, b, c})
+	assert.Equal(t, 0, groups[0])
+	assert.Equal(t, 1, groups[1])
+	assert.Equal(t, 2, groups[2])
+}
+
+func TestGroupLegsBySBD_InsufficientSamples(t *testing.T) {
+	// A leg with fewer than sbdMinSamples must stay a singleton even if its
+	// (thin) stats would otherwise resemble a well-sampled peer.
+	full := computeSBDStats([]float64{50, 52, 51, 90, 50, 53, 51, 88})
+	thin := computeSBDStats([]float64{50, 90}) // n=2 < sbdMinSamples
+	require.Less(t, thin.n, sbdMinSamples)
+	groups := groupLegsBySBD([]sbdStats{full, thin})
+	assert.NotEqual(t, groups[0], groups[1], "under-sampled leg must not merge")
+}
+
+func TestPickBottleneckDemotions_KeepsOnePerGroup(t *testing.T) {
+	// Legs 0,1,2 share group 0; leg 3 is its own group. The highest-goodput
+	// member of group 0 (leg 1) is kept; 0 and 2 are parked. Leg 3 is untouched.
+	legs := []bottleneckLeg{
+		{idx: 0, group: 0, goodput: 100},
+		{idx: 1, group: 0, goodput: 500},
+		{idx: 2, group: 0, goodput: 200},
+		{idx: 3, group: 3, goodput: 300},
+	}
+	demote := pickBottleneckDemotions(legs)
+	assert.Equal(t, []int{0, 2}, demote)
+}
+
+func TestPickBottleneckDemotions_PrimaryAlwaysKept(t *testing.T) {
+	// Even though leg 2 has more goodput, the primary (leg 0) in the same group is
+	// the keeper and is never parked.
+	legs := []bottleneckLeg{
+		{idx: 0, group: 0, primary: true, goodput: 10},
+		{idx: 2, group: 0, goodput: 900},
+	}
+	demote := pickBottleneckDemotions(legs)
+	assert.Equal(t, []int{2}, demote)
+}
+
+func TestPickBottleneckDemotions_SkipsStandbyAndSingletons(t *testing.T) {
+	legs := []bottleneckLeg{
+		{idx: 0, group: 0, primary: true, goodput: 10},
+		{idx: 1, group: 1, goodput: 20}, // distinct group, single active — kept
+		{idx: 2, group: 2, standby: true, goodput: 0},
+	}
+	assert.Empty(t, pickBottleneckDemotions(legs))
+}
+
+// TestRebuildWeightsCollapsesBottleneckGroup verifies rebuildWeights treats a
+// shared-bottleneck group as ONE unit of capacity: the group's representative
+// carries the aggregate throughput and the redundant member gets zero send weight,
+// so a 2-leg group does not out-weight an independent leg.
+func TestRebuildWeightsCollapsesBottleneckGroup(t *testing.T) {
+	m := newBareMux(false)
+	m.tpSelector.SetMode(WeightModeCapacity)
+	m.growLegs(3)
+	for i := 0; i < 3; i++ {
+		m.markLegReady(i)
+	}
+	// Legs 0 and 1 share a bottleneck; leg 2 is independent.
+	m.SetLegGroups([]int{0, 0, 2})
+	// Each leg has moved the same bytes since the last rebuild.
+	m.recordSent(0, 1000)
+	m.recordSent(1, 1000)
+	m.recordSent(2, 1000)
+
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0), mockTP(0)}
+	m.rebuildWeights(tps)
+
+	w := m.tpSelector.capacityWeights
+	require.Len(t, w, 3)
+	// Group {0,1}: representative (leg 0, tie broken to lowest index) carries the
+	// aggregate 2000; leg 1 gets zero. Leg 2 (own group) keeps its own 1000.
+	assert.InDelta(t, 2000, w[0], 1e-9)
+	assert.InDelta(t, 0, w[1], 1e-9)
+	assert.InDelta(t, 1000, w[2], 1e-9)
+	// The shared group and the independent leg compete ~2:1 (one pipe of 2000B vs
+	// one pipe of 1000B) — NOT 2000:1000:... counted as three independent pipes.
+	assert.Greater(t, w[0], w[2])
+}
+
+// TestRebuildWeightsGroupColdFloorPerGroup verifies the cold-leg floor is applied
+// ONCE PER bottleneck group (to the representative), not per redundant member.
+func TestRebuildWeightsGroupColdFloorPerGroup(t *testing.T) {
+	m := newBareMux(false)
+	m.tpSelector.SetMode(WeightModeCapacity)
+	m.growLegs(3)
+	for i := 0; i < 3; i++ {
+		m.markLegReady(i)
+	}
+	m.SetLegGroups([]int{0, 0, 2})
+	// Group {0,1} is hot; the independent leg 2 is cold (no bytes).
+	m.recordSent(0, 1000)
+	m.recordSent(1, 1000)
+
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0), mockTP(0)}
+	m.rebuildWeights(tps)
+
+	w := m.tpSelector.capacityWeights
+	require.Len(t, w, 3)
+	floor := 2000 * capacityColdFloorFrac
+	assert.InDelta(t, 2000, w[0], 1e-9)
+	assert.InDelta(t, 0, w[1], 1e-9, "redundant co-bottlenecked leg is never floored")
+	assert.InDelta(t, floor, w[2], 1e-9, "the cold independent group gets one floor unit")
+}
+
+// TestRebuildWeightsStandbyGroupMemberZero verifies a standby leg contributes no
+// weight and is never chosen as a group representative.
+func TestRebuildWeightsStandbyGroupMemberZero(t *testing.T) {
+	m := newBareMux(false)
+	m.tpSelector.SetMode(WeightModeCapacity)
+	m.growLegs(2)
+	m.markLegReady(0)
+	m.markLegReady(1)
+	m.SetLegGroups([]int{0, 0})
+	m.setLegStandby(1, true)
+	m.recordSent(0, 800)
+	m.recordSent(1, 5000) // standby leg's bytes must not leak into the weight
+
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0)}
+	m.rebuildWeights(tps)
+
+	w := m.tpSelector.capacityWeights
+	require.Len(t, w, 2)
+	assert.InDelta(t, 800, w[0], 1e-9)
+	assert.InDelta(t, 0, w[1], 1e-9)
+}
+
+func TestSBDMeanEps(t *testing.T) {
+	assert.InDelta(t, 0.001, sbdMeanEps(0), 1e-12)
+	assert.True(t, sbdMeanEps(1e6) > 0.001)
+	assert.False(t, math.IsNaN(sbdMeanEps(-100)))
+}

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -357,6 +357,13 @@ type RouteGroup struct {
 	// evicting the "slowest leg" and the fastest-leg retransmit picker judge the
 	// whole path, not just the near edge. Guarded by legLivenessMu.
 	legE2ELatency map[uuid.UUID]float64
+	// legOWD holds each leg's moving window of RAW end-to-end round-trip samples
+	// (ms), keyed by transport ID (survives index shifts), folded from the same
+	// leg-liveness pong as legE2ELatency but BEFORE the EWMA — the OWD-variation
+	// series RFC 8382 shared-bottleneck detection needs (see bottleneck.go). No new
+	// probe traffic: it reuses the pong the liveness loop already sends. Guarded by
+	// legLivenessMu.
+	legOWD map[uuid.UUID]*sbdWindow
 	// legRecvSnap is each leg's last-sampled rg-scoped RecvBytes, keyed by
 	// transport ID (survives index shifts), for the fast data-progress prune:
 	// an ACTIVE leg whose recv is flat across an interval while the group keeps
@@ -397,6 +404,7 @@ func NewRouteGroup(cfg *RouteGroupConfig, rt routing.Table, desc routing.RouteDe
 		legMissed:          make(map[uuid.UUID]int),
 		inflightPings:      make(map[int64]uuid.UUID),
 		legE2ELatency:      make(map[uuid.UUID]float64),
+		legOWD:             make(map[uuid.UUID]*sbdWindow),
 		legForwardHops:     make(map[uuid.UUID][]routing.Hop),
 		legRecvSnap:        make(map[uuid.UUID]uint64),
 	}
@@ -1238,6 +1246,7 @@ func (rg *RouteGroup) snapshotLegs() []LegInfo {
 		for id := range rg.legE2ELatency {
 			if _, ok := live[id]; !ok {
 				delete(rg.legE2ELatency, id)
+				delete(rg.legOWD, id)
 			}
 		}
 	}
@@ -2129,6 +2138,14 @@ func (rg *RouteGroup) legDataProgressServiceFn(_ time.Duration) {
 		rg.soleBHTicks = 0
 	}
 
+	// Detect shared-bottleneck groups from each leg's OWD-variation statistics
+	// (RFC 8382) BEFORE the weight rebuild below, so the capacity weights count
+	// each bottleneck as ONE pipe (not N competing legs) and redundant
+	// co-bottlenecked legs are parked to warm standby. No new probe traffic — the
+	// OWD windows are fed from the leg-liveness pong. The rebuild that follows
+	// picks up both the fresh grouping and any parks.
+	rg.enforceBottleneckGroups(perDelta)
+
 	// Refresh transport-selection weights on this fast cadence so
 	// WeightModeCapacity tracks RECENT goodput within seconds instead of the
 	// ~5min keep-alive cadence — essential for the weighted-ramp (a promoted leg
@@ -2445,6 +2462,71 @@ func (rg *RouteGroup) reelectPrimary(newIdx int) {
 		}
 	}
 	rg.logger.Infof("latency-band: re-elected leg %d into the primary slot (old primary was an out-of-band outlier)", newIdx)
+}
+
+// enforceBottleneckGroups detects SHARED-BOTTLENECK groups among the mux legs
+// from each leg's OWD-variation statistics (RFC 8382; see bottleneck.go), pushes
+// the grouping to the mux (so rebuildWeights counts each bottleneck as ONE unit
+// of capacity instead of N independent competing pipes), and parks redundant
+// co-bottlenecked ACTIVE legs to warm standby (admission prefers legs from
+// DISTINCT groups). Reuses the leg-liveness pong samples already collected — no
+// new probe traffic. Runs on the data-progress cadence, just before the weight
+// rebuild and the latency band; the caller rebuilds the weights immediately after
+// so the parks and grouping take effect the same tick. Never parks the primary or
+// below one active leg per group (pickBottleneckDemotions guarantees this).
+//
+// This is the general-case complement to the same-LAN structural reject (#4253):
+// that check only catches a co-located INTERMEDIATE at leg-creation time; this
+// catches two disjoint routes that funnel through the same uplink, at runtime,
+// from their shared delay-variation signature.
+func (rg *RouteGroup) enforceBottleneckGroups(recvDeltas map[uuid.UUID]uint64) {
+	if rg.isClosed() || rg.mux == nil {
+		return
+	}
+	rg.mu.Lock()
+	tpsCopy := append([]*transport.ManagedTransport(nil), rg.tps...)
+	rg.mu.Unlock()
+	if len(tpsCopy) < 2 {
+		rg.mux.SetLegGroups(nil) // fewer than two legs — nothing to group
+		return
+	}
+
+	// Per-leg OWD summary statistics from the moving windows (legLivenessMu).
+	stats := make([]sbdStats, len(tpsCopy))
+	rg.legLivenessMu.Lock()
+	for i, tp := range tpsCopy {
+		if tp == nil {
+			continue
+		}
+		if w := rg.legOWD[tp.Entry.ID]; w != nil {
+			stats[i] = computeSBDStats(w.samples())
+		}
+	}
+	rg.legLivenessMu.Unlock()
+
+	groups := groupLegsBySBD(stats)
+	rg.mux.SetLegGroups(groups)
+
+	// Distinct-group admission: park any redundant co-bottlenecked active legs.
+	legs := make([]bottleneckLeg, 0, len(tpsCopy))
+	for i, tp := range tpsCopy {
+		if tp == nil || tp.IsClosed() {
+			continue
+		}
+		legs = append(legs, bottleneckLeg{
+			idx:     i,
+			group:   groups[i],
+			standby: rg.mux.isLegStandby(i),
+			primary: i == 0,
+			goodput: recvDeltas[tp.Entry.ID],
+			latMs:   rg.legBandLatencyMs(tp),
+		})
+	}
+	demote := pickBottleneckDemotions(legs)
+	for _, idx := range demote {
+		rg.logger.Infof("shared-bottleneck: parking leg %d to warm standby (co-bottlenecked with a kept active leg in group %d — one pipe, not two; striping it adds only reorder cost)", idx, groups[idx])
+		rg.mux.setLegStandby(idx, true)
+	}
 }
 
 // enforceLatencyBand keeps the mux's active stripe set within a tight latency
@@ -3883,6 +3965,15 @@ func (rg *RouteGroup) handlePongPacket(packet routing.Packet) error {
 		} else {
 			rg.legE2ELatency[pongLegID] = latencyMs
 		}
+		// Fold the RAW sample (pre-EWMA) into this leg's OWD-variation window for
+		// shared-bottleneck detection (RFC 8382). The window records the variation
+		// signature the grouping keys on; the EWMA above records the smoothed level.
+		w := rg.legOWD[pongLegID]
+		if w == nil {
+			w = newSBDWindow()
+			rg.legOWD[pongLegID] = w
+		}
+		w.push(latencyMs)
 		rg.legLivenessMu.Unlock()
 	}
 

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -267,6 +267,16 @@ type routeMux struct {
 	// Touched only under legMu in rebuildWeights' ECF branch.
 	ecfLastRebuildNano int64
 
+	// legGroups holds each leg's SHARED-BOTTLENECK group id (RFC 8382; see
+	// bottleneck.go), parallel to legs[]. Legs with the same id are judged to
+	// funnel through one physical pipe, so rebuildWeights counts the group as ONE
+	// unit of capacity instead of N competing pipes. Recomputed each data-progress
+	// tick by the route group and pushed via SetLegGroups; a leg with no entry (or
+	// a value equal to its own index) is its own singleton group — the default, so
+	// a mux with no bottleneck detection behaves exactly as before. Guarded by
+	// legMu.
+	legGroups []int
+
 	// standbyNewLegs makes every NEWLY-grown aux leg (index > 0) enter the
 	// warm-standby pool instead of going straight into the active send set.
 	// The primary leg (index 0) is never affected. Set only when a promoting
@@ -524,6 +534,27 @@ func (m *routeMux) SetStandbyNewLegs(v bool) {
 	m.legMu.Lock()
 	m.standbyNewLegs = v
 	m.legMu.Unlock()
+}
+
+// SetLegGroups records the per-leg shared-bottleneck group ids (see the
+// legGroups field). The slice is copied and is parallel to legs[] in the rg's
+// tps[] order; a shorter slice leaves the trailing legs as singletons. Cheap and
+// idempotent — called each data-progress tick from the route group after it
+// recomputes groups from per-leg OWD statistics.
+func (m *routeMux) SetLegGroups(groups []int) {
+	m.legMu.Lock()
+	m.legGroups = append([]int(nil), groups...)
+	m.legMu.Unlock()
+}
+
+// groupOf returns leg i's shared-bottleneck group id, defaulting to i itself
+// (its own singleton group) when no grouping is recorded for it. Caller holds
+// legMu.
+func (m *routeMux) groupOf(i int) int {
+	if i < len(m.legGroups) {
+		return m.legGroups[i]
+	}
+	return i
 }
 
 // removeLegs drops the given ORIGINAL leg indices from legs[] and ready[] so
@@ -1163,8 +1194,9 @@ func (m *routeMux) rebuildWeights(tps []*transport.ManagedTransport) {
 	// whichever leg carried first).
 	if m.tpSelector.Mode() == WeightModeCapacity {
 		m.legMu.Lock()
-		weights := make([]float64, len(m.legs))
-		var maxW float64
+		// Per-leg recent throughput (bytes moved since the last rebuild).
+		deltas := make([]float64, len(m.legs))
+		active := make([]bool, len(m.legs))
 		for i, lc := range m.legs {
 			if lc == nil {
 				continue
@@ -1172,37 +1204,60 @@ func (m *routeMux) rebuildWeights(tps []*transport.ManagedTransport) {
 			total := atomic.LoadUint64(&lc.sentBytes) + atomic.LoadUint64(&lc.recvBytes)
 			delta := total - lc.lastTotalBytes
 			lc.lastTotalBytes = total
-			// A warm-standby leg carries no send traffic — it must get zero
-			// weight so the scheduler never steers a packet onto a parked leg
-			// (which the receiver isn't expecting on that route and would stall
-			// the reorder frontier on). Keep sampling its byte counter above so a
-			// later promotion starts from a fresh delta, not a stale backlog.
-			if i < len(m.standby) && m.standby[i] {
-				weights[i] = 0
+			deltas[i] = float64(delta)
+			// A warm-standby leg carries no send traffic — it must get zero weight
+			// so the scheduler never steers a packet onto a parked leg (which the
+			// receiver isn't expecting on that route and would stall the reorder
+			// frontier on). Its byte counter was still sampled above so a later
+			// promotion starts from a fresh delta, not a stale backlog.
+			active[i] = !(i < len(m.standby) && m.standby[i])
+		}
+		// SHARED-BOTTLENECK COLLAPSE (RFC 8382): legs that funnel through the same
+		// physical pipe (groupOf()) must be counted as ONE unit of capacity, not N
+		// competing pipes — otherwise a 3-leg shared group out-weighs a lone
+		// independent leg 3:1 and over-subscribes the one pipe while starving the
+		// distinct route. For each group, ONE representative (the active member
+		// moving the most bytes; ties → lowest index) carries the group's AGGREGATE
+		// throughput (the pipe's real rate = sum of its active members' deltas); the
+		// other members get zero send weight so the scheduler stops striping the same
+		// pipe across redundant legs (which only adds reorder cost). Independent legs
+		// are their own singleton group, so this is a no-op for them and the
+		// pre-grouping behavior is unchanged when no bottleneck is detected.
+		rep := make(map[int]int, len(m.legs)) // group id -> representative leg index
+		groupSum := make(map[int]float64, len(m.legs))
+		for i, lc := range m.legs {
+			if lc == nil || !active[i] {
 				continue
 			}
-			weights[i] = float64(delta)
-			if weights[i] > maxW {
-				maxW = weights[i]
+			g := m.groupOf(i)
+			groupSum[g] += deltas[i]
+			cur, ok := rep[g]
+			if !ok || deltas[i] > deltas[cur] {
+				rep[g] = i
 			}
 		}
-		// Cold-leg floor (the weighted-RAMP): a just-promoted active leg has moved
-		// ~no bytes yet, so its raw delta is ~0 — under pure capacity weighting it
-		// would get ~no traffic and thus never accumulate the goodput it needs to
-		// earn a real share (a starvation deadlock). Give every active, non-standby
-		// leg a floor share = capacityColdFloorFrac of the fastest active leg, so a
-		// fresh leg carries a THIN trickle, measures its goodput, and ramps up as
-		// its delta grows — while a genuinely slow leg stays near the floor and can
-		// never open a big reorder gap. Skipped when the whole group is idle
-		// (maxW == 0) so an idle mux doesn't manufacture phantom weight.
+		weights := make([]float64, len(m.legs))
+		var maxW float64
+		for g, r := range rep {
+			weights[r] = groupSum[g]
+			if weights[r] > maxW {
+				maxW = weights[r]
+			}
+		}
+		// Cold-leg floor (the weighted-RAMP): a just-promoted representative has
+		// moved ~no bytes yet, so its raw delta is ~0 — under pure capacity weighting
+		// it would get ~no traffic and thus never accumulate the goodput it needs to
+		// earn a real share (a starvation deadlock). Give every active group's
+		// REPRESENTATIVE a floor share = capacityColdFloorFrac of the fastest group,
+		// so a fresh pipe carries a THIN trickle, measures its goodput, and ramps up.
+		// Applied per group (one floor unit per distinct pipe, never per redundant
+		// co-bottlenecked leg). Skipped when every group is idle (maxW == 0) so an
+		// idle mux doesn't manufacture phantom weight.
 		if maxW > 0 {
 			floor := maxW * capacityColdFloorFrac
-			for i, lc := range m.legs {
-				if lc == nil || (i < len(m.standby) && m.standby[i]) {
-					continue
-				}
-				if weights[i] < floor {
-					weights[i] = floor
+			for _, r := range rep {
+				if weights[r] < floor {
+					weights[r] = floor
 				}
 			}
 		}


### PR DESCRIPTION
## What

Mux legs only add capacity if they don't share a bottleneck. Today the only guard is structural: the same-LAN reject (#4253) rejects a leg whose *intermediate* is a co-located peer. That misses two legs over **different** transports that funnel through the same uplink further out — the scheduler then counts N legs where there's one pipe, and the legs compete (extra reorder cost, self-inflicted queuing, zero added capacity).

This detects the shared bottleneck at runtime from the **variation** in each leg's one-way delay, per RFC 8382. Legs behind the same congested queue share a delay-variation signature (variance, skewness, oscillation), so they can be grouped without synchronized clocks or time-aligned samples. The per-leg liveness pong already produces a raw RTT sample per leg per tick; it's folded into a short moving window *before* the EWMA, so **no new probe traffic** is added.

## Changes

- **`bottleneck.go`** (new): per-leg OWD summary statistics (mean, variance, coefficient of variation, RFC 8382 skew_est and freq_est) over a moving window, plus single-linkage (union-find) grouping over a skew/CV/oscillation similarity test. A leg with too few samples, or a flat (no-variation) leg, stays its own singleton — absent evidence, its capacity is counted in full.
- **`rebuildWeights`**: a bottleneck group is counted as **one unit of capacity**. One representative (the active member moving the most bytes) carries the group's aggregate throughput; redundant members get zero send weight; the cold-leg floor is applied once per group. Independent legs are singleton groups, so behavior is unchanged when nothing is detected.
- **Admission**: prefer legs from **distinct** groups — redundant co-bottlenecked active legs are parked to warm standby (kept alive for instant failover).
- Runs on the existing data-progress cadence, just before the weight rebuild.

## Same-LAN (#4253)

The runtime grouping is the general rule and subsumes the same-LAN *intent* (co-located legs share a signature and all but one are parked), and additionally catches the cross-transport shared-uplink case the structural check can't see. The structural #4253 check is **retained** as a cheap pre-filter at leg-set time (it blocks a known-bad leg before any samples accumulate); grouping is the general runtime rule layered on top.

## Notes / scope

- Grouping is always on — it only ever makes the capacity estimate *more* correct. Window depth and similarity tolerances are tuning constants, not an on/off gate.
- The pong cadence is ~30s, so the window is ~4 minutes: a slow-moving structural signal (bottleneck topology changes slowly). A finer per-leg OWD sampler, if added later, tightens the window toward RFC 8382's ~15s with no change to the math. The collapse is wired into the capacity (aggregation) weight path; ECF's internal per-leg math is left as-is (it benefits indirectly via the standby markers from admission).

## Tests

`bottleneck_test.go`: OWD statistics on synthetic series; correlated legs cluster into one group while flat/oscillating/under-sampled legs stay separate; distinct-group admission keeps one leg per group (primary always kept); and rebuildWeights collapsing a group to one capacity unit (aggregate on the representative, zero on redundant members, one floor unit per group). `go build .`, `go vet`, gofmt, and the full `pkg/router` suite pass.