### PR TITLE
feat(wasm-visor): answer `cli visor state` from the wasm-visor RPC gateway

### DIFF
--- a/pkg/wasmhv/gob_mirror_test.go
+++ b/pkg/wasmhv/gob_mirror_test.go
@@ -170,3 +170,21 @@ func TestMirrorArgsEncode(t *testing.T) {
 		require.True(t, got.NoRegister)
 	})
 }
+
+// TestMirrorStateSnapshotEncodes confirms the wasm gateway's StateSnapshot mirror
+// gob-encodes into visor.StateSnapshot — the direction the RPC bridge uses so
+// `cli visor state` decodes a real (partial) snapshot from a browser leaf.
+func TestMirrorStateSnapshotEncodes(t *testing.T) {
+	var got visor.StateSnapshot
+	gobRoundTrip(t, &wasmhv.StateSnapshot{
+		At:         time.Unix(1700000000, 0).UTC(),
+		Summary:    &wasmhv.Summary{Online: true, MinHops: 2},
+		Health:     &wasmhv.HealthInfo{ServicesHealth: "healthy"},
+		Transports: []*wasmhv.TransportSummary{},
+	}, &got)
+	require.NotNil(t, got.Summary)
+	require.True(t, got.Summary.Online)
+	require.NotNil(t, got.Health)
+	require.Equal(t, "healthy", got.Health.ServicesHealth)
+	require.False(t, got.At.IsZero())
+}

--- a/pkg/wasmhv/rpc_gateway.go
+++ b/pkg/wasmhv/rpc_gateway.go
@@ -183,3 +183,33 @@ func (g *RPCGateway) Overview(_ *struct{}, out *Overview) error {
 	*out = g.self.SelfOverview()
 	return nil
 }
+
+// StateSnapshot mirrors pkg/visor.StateSnapshot for the subset a browser leaf can
+// answer from its self-view. gob decodes it into the native type by field name,
+// so the fields a wasm visor genuinely lacks (routing stats, service health,
+// per-leg mux route groups, module presence, router config) stay zero — an honest
+// partial rather than "method not found". Populated: the At timestamp, the tab's
+// Summary + Health, and its Transports. Adding the missing views is a matter of
+// widening SelfProvider (notably a mux-telemetry surface for MuxRouteGroups).
+type StateSnapshot struct {
+	At         time.Time
+	Summary    *Summary
+	Health     *HealthInfo
+	Transports []*TransportSummary
+}
+
+// StateSnapshot answers the RPC `cli visor state` calls (rpcClient.StateSnapshot),
+// so `skywire cli visor state` returns a real snapshot from the wasm visor.
+func (g *RPCGateway) StateSnapshot(_ *struct{}, out *StateSnapshot) error {
+	if g.self == nil {
+		return errNoSelf
+	}
+	s := g.self.SelfSummary()
+	*out = StateSnapshot{
+		At:         time.Now(),
+		Summary:    &s,
+		Health:     &HealthInfo{ServicesHealth: "healthy"},
+		Transports: g.self.SelfTransports(),
+	}
+	return nil
+}


### PR DESCRIPTION
The wasm-visor's `app-visor` RPC gateway implemented the read info methods (Summary/Overview/Health/Transports) but not `StateSnapshot`, so `skywire cli visor state` against a browser tab got "can't find method". This adds a `StateSnapshot` method that builds an honest PARTIAL snapshot from the tab's self-view (At, Summary, Health, Transports), leaving the fields a browser leaf genuinely lacks (routing stats, service health, per-leg mux route groups, module presence, router config) zero rather than faked. A gob-mirror round-trip test guards field drift against `pkg/visor.StateSnapshot`.

Scope / follow-ups (larger, tracked): serving this gateway over **dmsg** (`--via dmsg://<pk>`) and **skynet** — the wasm visor has a dmsg listener only for its hypervisor role, not for its own visor RPC, and a NAT'd browser leaf cannot accept inbound skynet routes without a relay — and widening `SelfProvider` with a mux-telemetry surface so `MuxRouteGroups` (per-leg aggregation) is populated.