### PR TITLE
feat(visor): surface unidirectional mux direction + flip state in visor state

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -453,6 +453,16 @@ type MuxInfo struct {
 	// inverse-multiplexer path, network.EncryptConn bypassed). False means the
 	// group runs the classic stream-noise wrap.
 	PerFrameNoise bool
+	// Directional is true when unidirectional send selection (CapUniDir) is
+	// active on this mux: each direction rides a disjoint leg class instead of
+	// both striping every leg. Flipped reports the current direction->leg-class
+	// mapping. DEFAULT (Flipped=false): this end sends its FORWARD/upload on the
+	// DIRECT (1-hop) leg and its REVERSE/download on the MULTIHOP mux legs.
+	// FLIPPED=true: the mapping is swapped (the heavy direction took the mux).
+	// With the per-leg Direct flag, a reader can tell which class carries which
+	// direction without log-grepping. Both false on a non-directional mux.
+	Directional bool
+	Flipped     bool
 	// Distribution names how the mux spreads outbound packets across its legs
 	// (the transportSelector weight mode: "auto", "round-robin", "weighted",
 	// "capacity", "latency-adaptive", "sticky:5tuple", "size-threshold",
@@ -535,6 +545,7 @@ func (rg *RouteGroup) MuxStats() MuxInfo {
 		info.FECRepairBytesSent = atomic.LoadUint64(&rg.mux.fecRepairBytesSent)
 		info.FECRepairBytesRecv = atomic.LoadUint64(&rg.mux.fecRepairBytesRecv)
 		info.FECReconstructs = atomic.LoadUint64(&rg.mux.fecReconstructs)
+		info.Directional, info.Flipped = rg.mux.dirState()
 	}
 	info.PerFrameNoise = rg.perFrameNoiseActive
 	tpsCopy := append([]*transport.ManagedTransport(nil), rg.tps...)

--- a/pkg/router/unidir.go
+++ b/pkg/router/unidir.go
@@ -75,6 +75,14 @@ func (m *routeMux) isDirectional() bool {
 	return m.directional
 }
 
+// dirState snapshots the unidirectional send-selection state (directional +
+// current flip) under legMu for telemetry (MuxStats / visor state).
+func (m *routeMux) dirState() (directional, flipped bool) {
+	m.legMu.RLock()
+	defer m.legMu.RUnlock()
+	return m.directional, m.flipped
+}
+
 // soleBlackHoleExemptRecvFloor is the per-tick GROUP recv above which a
 // directional group's sole ACTIVE (light-direction) leg is exempt from the
 // sole-leg black-hole reaping.

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -140,6 +140,8 @@ func muxRouteGroupInfoFrom(infos []router.MuxInfo) []MuxRouteGroupInfo {
 			MuxEnabled:         info.MuxEnabled,
 			SACKEnabled:        info.SACKEnabled,
 			PerFrameNoise:      info.PerFrameNoise,
+			Directional:        info.Directional,
+			Flipped:            info.Flipped,
 			Distribution:       info.Distribution,
 			ReorderPending:     info.ReorderPending,
 			ReorderGapAgeMS:    float64(info.ReorderGapAge) / float64(time.Millisecond),

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -288,6 +288,12 @@ type MuxRouteGroupInfo struct {
 	MuxEnabled    bool                          `json:"mux_enabled"`
 	SACKEnabled   bool                          `json:"sack_enabled"`
 	PerFrameNoise bool                          `json:"per_frame_noise"`
+	// Directional: unidirectional send selection (CapUniDir) is active — each
+	// direction rides a disjoint leg class. Flipped: the direction->leg-class
+	// mapping is swapped (heavy direction took the mux). With per-leg `direct`,
+	// this tells which class carries which direction without log-grepping.
+	Directional bool `json:"directional,omitempty"`
+	Flipped     bool `json:"flipped,omitempty"`
 	// Distribution names how the mux spreads outbound packets across its legs
 	// (weight mode: "auto", "round-robin", "weighted", "capacity",
 	// "latency-adaptive", "sticky:5tuple", "size-threshold", "dscp-priority").


### PR DESCRIPTION
`MuxInfo` / `MuxRouteGroupInfo` now carry `directional` (CapUniDir active) and `flipped` (the direction→leg-class mapping is swapped — the heavy direction took the mux). With the existing per-leg `direct` flag, `cli visor state --json` now shows which leg class carries which direction and whether the load-driven flip has fired, without log-grepping. Both `omitempty`, false on a non-directional mux.