### PR TITLE
feat(wasm-visor): serve the visor RPC gateway over dmsg (cli --rpc dmsg://<pk>)

### DIFF
--- a/cmd/wasm-visor/peerserve_js.go
+++ b/cmd/wasm-visor/peerserve_js.go
@@ -42,6 +42,7 @@ import (
 	"github.com/skycoin/skywire/pkg/skyenv"
 	ts "github.com/skycoin/skywire/pkg/transport/setup"
 	"github.com/skycoin/skywire/pkg/visor/logserver/landingpage"
+	"github.com/skycoin/skywire/pkg/wasmhv"
 )
 
 // peerStartedAt is this visor's boot time, reported on /health (StartedAt). Set
@@ -71,6 +72,35 @@ func startPeerServices(mLog *logging.MasterLogger, tsNodes []cipher.PubKey) {
 	go servePeerCtrl()                    // dmsg:7
 	go servePeerPing(mLog)                // dmsg:8
 	go serveTransportSetup(mLog, tsNodes) // dmsg:47
+	go servePeerRPC(mLog, tsNodes)        // dmsg:65 visor net/rpc
+}
+
+// servePeerRPC serves the visor net/rpc gateway (the "app-visor.*" methods the
+// CLI calls — Summary/Health/Transports/StateSnapshot/…) over dmsg on
+// DmsgVisorRPCPort, so `skywire cli ... visor state --via dmsg://<pk>` reaches
+// this browser leaf exactly as it reaches a native visor — not just over the
+// local wasmrpc WebSocket bridge. It serves the SAME gateway rpcbridge_js.go
+// serves (visorSelf + tpController).
+//
+// Gated to the transport-setup trust list (the nodes already authorized to
+// command this visor's transports — the same trust the :47 accept side uses),
+// disabled when that list is empty (fail-closed, like the native visor). Read-only
+// callers outside that list are a follow-up (a broader visor-RPC whitelist).
+func servePeerRPC(mLog *logging.MasterLogger, tsNodes []cipher.PubKey) {
+	log := mLog.PackageLogger("dmsg_visor_rpc")
+	srv, err := wasmhv.NewRPCServer(visorSelf{}, tpController{})
+	if err != nil {
+		vlog("peer: visor-RPC server: " + err.Error())
+		return
+	}
+	authorized := make(map[cipher.PubKey]bool, len(tsNodes))
+	for _, pk := range tsNodes {
+		authorized[pk] = true
+	}
+	vlog(fmt.Sprintf("peer: visor-RPC serving on dmsg:%d (%d trusted node(s))", skyenv.DmsgVisorRPCPort, len(authorized)))
+	if err := wasmhv.ServeRPCOverDmsg(ctx, dmsgC, srv, authorized, log); err != nil {
+		log.WithError(err).Debug("dmsg visor-RPC server stopped")
+	}
 }
 
 // peerDynamicEndpoint serves /health on port 80 with live data, matching the

--- a/pkg/wasmhv/rpc_dmsg.go
+++ b/pkg/wasmhv/rpc_dmsg.go
@@ -1,0 +1,68 @@
+// Package wasmhv pkg/wasmhv/rpc_dmsg.go c3-vis-wasm
+package wasmhv
+
+import (
+	"context"
+	"net/rpc"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// ServeRPCOverDmsg serves the wasm-visor's own RPC gateway (srv, built by
+// NewRPCServer under the "app-visor" prefix) over dmsg on the standard always-on
+// visor-RPC port (skyenv.DmsgVisorRPCPort) — the SAME port and codec the native
+// visor uses (pkg/visor init_apps.go). So `skywire cli ... visor state --via
+// dmsg://<pk>` (and every other gateway method) reaches a browser leaf the way it
+// reaches a native visor, instead of only over the local wasmrpc WebSocket bridge.
+//
+// Auth: each accepted stream's remote PK must be in `authorized`; others are
+// dropped at accept. Fail-closed — an empty authorized set disables the server
+// (returns nil without listening), matching the native visor, which disables its
+// dmsg visor-RPC server when no PKs are authorized. Build-tag-free so the exact
+// serving path is exercised by a native dmsg round-trip test.
+//
+// Blocks until the listener errors or ctx is done; run it in its own goroutine.
+func ServeRPCOverDmsg(ctx context.Context, dmsgC *dmsg.Client, srv *rpc.Server, authorized map[cipher.PubKey]bool, log *logging.Logger) error {
+	if dmsgC == nil || srv == nil || len(authorized) == 0 {
+		if log != nil {
+			log.Debug("dmsg visor-RPC server disabled (no dmsg client, server, or authorized PKs)")
+		}
+		return nil
+	}
+	lis, err := dmsgC.Listen(skyenv.DmsgVisorRPCPort)
+	if err != nil {
+		return err
+	}
+	go func() {
+		<-ctx.Done()
+		lis.Close() //nolint:errcheck,gosec
+	}()
+	if log != nil {
+		log.Infof("dmsg visor-RPC server listening on port %d (%d authorized PK(s))", skyenv.DmsgVisorRPCPort, len(authorized))
+	}
+	for {
+		stream, err := lis.AcceptStream()
+		if err != nil {
+			if strings.Contains(err.Error(), "closed") {
+				return nil
+			}
+			return err
+		}
+		remote := stream.RawRemoteAddr().PK
+		if !authorized[remote] {
+			if log != nil {
+				log.Debugf("dmsg visor-RPC: rejecting unauthorized peer %s", remote)
+			}
+			stream.Close() //nolint:errcheck,gosec
+			continue
+		}
+		go func(s *dmsg.Stream) {
+			defer s.Close() //nolint:errcheck,gosec
+			srv.ServeConn(s)
+		}(stream)
+	}
+}

--- a/pkg/wasmhv/rpc_dmsg_test.go
+++ b/pkg/wasmhv/rpc_dmsg_test.go
@@ -1,0 +1,107 @@
+//go:build !js
+
+// Package wasmhv_test (rpc_dmsg_test.go): a real dmsg round-trip proving the
+// wasm-visor's RPC gateway is reachable over dmsg exactly as `skywire cli ...
+// --rpc dmsg://<pk>` reaches it — the serving path ServeRPCOverDmsg wires into the
+// browser leaf (cmd/wasm-visor/peerserve_js.go). Host-only (!js): dmsgtest and
+// pkg/visor don't build for wasm, which is why the mirror types + ServeRPCOverDmsg
+// (build-tag-free) exist and are exercised here on the native side.
+package wasmhv_test
+
+import (
+	"context"
+	"net/rpc"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgtest"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/visor"
+	"github.com/skycoin/skywire/pkg/wasmhv"
+)
+
+// stubSelf is a minimal SelfProvider for the gateway under test.
+type stubSelf struct{ pk cipher.PubKey }
+
+func (s stubSelf) SelfPK() cipher.PubKey                     { return s.pk }
+func (stubSelf) SelfOverview() wasmhv.Overview               { return wasmhv.Overview{} }
+func (stubSelf) SelfSummary() wasmhv.Summary                 { return wasmhv.Summary{Online: true, MinHops: 2} }
+func (stubSelf) SelfTransports() []*wasmhv.TransportSummary  { return []*wasmhv.TransportSummary{} }
+func (stubSelf) SelfRoutes() []byte                          { return nil }
+func (stubSelf) SelfNetworkView() []byte                     { return nil }
+func (stubSelf) SelfNetworkTransports(_ int) []byte          { return nil }
+func (stubSelf) SelfServiceHealth() []byte                   { return nil }
+func (stubSelf) SelfDmsgSessions() []byte                    { return nil }
+func (stubSelf) SelfDmsgConnectAll() []byte                  { return nil }
+func (stubSelf) SelfRouterSettings() []byte                  { return nil }
+func (stubSelf) SelfRuntimeConfig() []byte                   { return nil }
+func (stubSelf) SelfSetRuntimeConfig(_ []byte) (int, []byte) { return 200, nil }
+func (stubSelf) SelfRuntimeLogs(_ int64) []byte              { return nil }
+func (stubSelf) SelfApps() []byte                            { return nil }
+func (stubSelf) StartApp(_ string) error                     { return nil }
+func (stubSelf) StopApp(_ string) error                      { return nil }
+func (stubSelf) SetAutoStart(_ string, _ bool) error         { return nil }
+
+// TestServeRPCOverDmsg_StateSnapshot stands up two dmsg clients, serves the RPC
+// gateway over dmsg on DmsgVisorRPCPort from one, dials it from the other exactly
+// as the CLI's `--rpc dmsg://<pk>` does (net/rpc over the dmsg stream), and
+// confirms `visor state` (app-visor.StateSnapshot) returns the partial snapshot —
+// decoded into the REAL pkg/visor.StateSnapshot, proving the wire matches.
+func TestServeRPCOverDmsg_StateSnapshot(t *testing.T) {
+	env := dmsgtest.NewEnv(t, dmsgtest.DefaultTimeout)
+	conf := dmsg.Config{MinSessions: 1}
+	require.NoError(t, env.Startup(dmsgtest.DefaultTimeout, 1, 2, &conf))
+	t.Cleanup(env.Shutdown)
+
+	server := env.AllClients()[0]
+	client := env.AllClients()[1]
+
+	srv, err := wasmhv.NewRPCServer(stubSelf{pk: server.LocalPK()}, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Only the client's PK is authorized — mirrors the leaf's whitelist gate.
+	authorized := map[cipher.PubKey]bool{client.LocalPK(): true}
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- wasmhv.ServeRPCOverDmsg(ctx, server, srv, authorized, logging.MustGetLogger("dmsg_visor_rpc_test"))
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-serveErr:
+			require.NoError(t, err) // a clean listener close returns nil
+		case <-time.After(2 * time.Second):
+			t.Error("ServeRPCOverDmsg did not return after ctx cancel")
+		}
+	})
+
+	// Let the listener come up on DmsgVisorRPCPort.
+	time.Sleep(500 * time.Millisecond)
+
+	stream, err := client.DialStream(ctx, dmsg.Addr{PK: server.LocalPK(), Port: skyenv.DmsgVisorRPCPort})
+	require.NoError(t, err)
+	defer stream.Close() //nolint:errcheck
+
+	rc := rpc.NewClient(stream)
+	defer rc.Close() //nolint:errcheck
+
+	var snap visor.StateSnapshot
+	require.NoError(t, rc.Call("app-visor.StateSnapshot", &struct{}{}, &snap))
+	require.NotNil(t, snap.Summary)
+	require.True(t, snap.Summary.Online)
+	require.NotNil(t, snap.Health)
+	require.Equal(t, "healthy", snap.Health.ServicesHealth)
+	require.False(t, snap.At.IsZero())
+
+	// A Summary call (an existing read method) over the same dmsg path, too.
+	var sum visor.Summary
+	require.NoError(t, rc.Call("app-visor.Summary", &struct{}{}, &sum))
+	require.True(t, sum.Online)
+}


### PR DESCRIPTION
Follow-up to #4328. The wasm visor served its `app-visor` RPC gateway only over the local wasmrpc WebSocket bridge, so `skywire cli … --rpc dmsg://<pk>` (visor state/info/…) couldn't reach a browser leaf — its only dmsg listener was the hypervisor role.

Adds `ServeRPCOverDmsg`, a build-tag-free helper that `Listen`s on the standard always-on visor-RPC port (`skyenv.DmsgVisorRPCPort = 65`), auth-gates each accepted stream (fail-closed on an empty set, like the native visor), and serves the SAME gateway (`NewRPCServer`) with net/rpc — mirroring the native visor's dmsg visor-RPC server (`pkg/visor/init_apps.go`). Wired into the wasm visor's peer services (`cmd/wasm-visor/peerserve_js.go`), gated to the transport-setup trust list.

**Verified end-to-end** by a native dmsg round-trip test (`dmsgtest`): serves the gateway over dmsg and calls `app-visor.StateSnapshot` + `Summary` from a second dmsg client, decoding into the REAL `pkg/visor` types — the exact path `--rpc dmsg://` uses. Builds native + `GOOS=js GOARCH=wasm`.

**Scope:** the skynet mirror is still blocked (a NAT'd browser leaf can't accept inbound routes without a relay); a broader read-only visor-RPC whitelist (beyond the transport-setup trust list) is a follow-up.