### PR TITLE
fix(genvisor): emit hypervisor_autoconnect in the hand-rolled JSON marshaler

### DIFF
--- a/pkg/skywireconfig/genvisor/marshal_compat_native.go
+++ b/pkg/skywireconfig/genvisor/marshal_compat_native.go
@@ -803,6 +803,10 @@ func marshalTransportNative(w *strings.Builder, t *visorconfig.Transport, indent
 	}
 	o.field("public_autoconnect")
 	writeBoolNative(w, t.PublicAutoconnect)
+	if t.HypervisorAutoconnect != nil {
+		o.field("hypervisor_autoconnect")
+		writeBoolNative(w, *t.HypervisorAutoconnect)
+	}
 	o.field("transport_setup")
 	writePubKeyNativeSlice(w, t.TransportSetupPKs, o.indent+1)
 	if len(t.UserTransportSetupPKs) > 0 {

--- a/pkg/skywireconfig/genvisor/marshal_js.go
+++ b/pkg/skywireconfig/genvisor/marshal_js.go
@@ -785,6 +785,10 @@ func marshalTransport(w *strings.Builder, t *visorconfig.Transport, indent int) 
 	}
 	o.field("public_autoconnect")
 	writeBool(w, t.PublicAutoconnect)
+	if t.HypervisorAutoconnect != nil {
+		o.field("hypervisor_autoconnect")
+		writeBool(w, *t.HypervisorAutoconnect)
+	}
 	o.field("transport_setup")
 	writePubKeySlice(w, t.TransportSetupPKs, o.indent+1)
 	if len(t.UserTransportSetupPKs) > 0 {


### PR DESCRIPTION
The WASM-clean streaming marshaler (marshal_js.go + its native mirror) was missing the transport `hypervisor_autoconnect` *bool field, so `MustMarshalJSON` drifted from encoding/json and `TestMustMarshalJSONNative_MatchesStdlib` fails on any config that sets it (surfaced now that #4326 lets the test suite run past lint). Emit it (omitempty-guarded) in both files per the file's drift policy.