### PR TITLE
fix(router): runtime mux standby/width retune re-caps a running route group

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_ops.go
+++ b/cmd/skywire-cli/commands/proxy/mux_ops.go
@@ -103,7 +103,7 @@ Example:
 		if err := rpcClient.SetMuxCap(n); err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("SetMuxCap: %w", err))
 		}
-		internal.Catch(cmd.Flags(), cliout.Print(cmd, cliproxy.MuxOp{Op: "cap", App: muxOpsApp, Mode: args[0]}))
+		internal.Catch(cmd.Flags(), cliout.Print(cmd, cliproxy.MuxOp{Op: "cap", App: muxOpsApp, Value: args[0]}))
 	},
 }
 
@@ -132,7 +132,7 @@ Example:
 		if err := rpcClient.SetMuxWidth(n); err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("SetMuxWidth: %w", err))
 		}
-		internal.Catch(cmd.Flags(), cliout.Print(cmd, cliproxy.MuxOp{Op: "width", App: muxOpsApp, Mode: args[0]}))
+		internal.Catch(cmd.Flags(), cliout.Print(cmd, cliproxy.MuxOp{Op: "width", App: muxOpsApp, Value: args[0]}))
 	},
 }
 
@@ -164,7 +164,7 @@ Example:
 		if err := rpcClient.SetMuxStandby(n); err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("SetMuxStandby: %w", err))
 		}
-		internal.Catch(cmd.Flags(), cliout.Print(cmd, cliproxy.MuxOp{Op: "standby", App: muxOpsApp, Mode: args[0]}))
+		internal.Catch(cmd.Flags(), cliout.Print(cmd, cliproxy.MuxOp{Op: "standby", App: muxOpsApp, Value: args[0]}))
 	},
 }
 

--- a/pkg/cliout/cliproxy/cliproxy.go
+++ b/pkg/cliout/cliproxy/cliproxy.go
@@ -19,7 +19,7 @@ import (
 // The fields that do not apply are omitted rather than zeroed, so their absence
 // is meaningful.
 type MuxOp struct {
-	// Op is "add", "remove" or "mode".
+	// Op is "add", "remove", "cap", "width", "standby", "switch" or "mode".
 	Op  string `json:"op"`
 	App string `json:"app"`
 
@@ -27,8 +27,12 @@ type MuxOp struct {
 	TransportID string `json:"transport_id,omitempty"`
 	// Hops is the leg's length, for add.
 	Hops int `json:"hops,omitempty"`
-	// Mode is the new setting, for a mode change.
+	// Mode is the new setting, for the "mode" op only.
 	Mode string `json:"mode,omitempty"`
+	// Value is the new numeric setting, for the cap/width/standby ops — kept
+	// separate from Mode so a width/standby retune isn't reported as a "mode"
+	// change.
+	Value string `json:"value,omitempty"`
 }
 
 // Human writes the sentence this used to print.
@@ -41,16 +45,22 @@ func (m MuxOp) Human(w io.Writer) error {
 		_, err := fmt.Fprintf(w, "removed mux leg via transport %s on app=%s\n", m.TransportID, m.App)
 		return err
 	case "cap":
-		_, err := fmt.Fprintf(w, "mux active-width cap set to %s\n", m.Mode)
+		_, err := fmt.Fprintf(w, "mux active-width cap set to %s\n", m.Value)
 		return err
 	case "width":
-		_, err := fmt.Fprintf(w, "mux steady active width set to %s\n", m.Mode)
+		_, err := fmt.Fprintf(w, "mux steady active width set to %s\n", m.Value)
+		return err
+	case "standby":
+		_, err := fmt.Fprintf(w, "mux warm-standby reserve set to %s\n", m.Value)
 		return err
 	case "switch":
 		_, err := fmt.Fprintf(w, "switched primary route to a %d-hop leg (first tp=%s) on app=%s; old primary retired\n", m.Hops, m.TransportID, m.App)
 		return err
-	default:
+	case "mode":
 		_, err := fmt.Fprintf(w, "mux mode set to %s\n", m.Mode)
+		return err
+	default:
+		_, err := fmt.Fprintf(w, "mux op %q applied\n", m.Op)
 		return err
 	}
 }

--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -394,6 +394,19 @@ type RotationHook interface {
 	OnTick(info DialInfo, legs []LegInfo) RotationAction
 }
 
+// SelfHealTargeter is an OPTIONAL interface a RotationHook may implement to
+// override the route group's self-heal degree at runtime. A group's self-heal
+// target is otherwise fixed at dial time (SetSelfHeal), but an adaptive
+// preset's pool size is a LIVE tunable (mux width / warm-standby reserve,
+// retuned over the mux-control RPC). A hook that implements this pushes the
+// CURRENT target on every tick, so lowering the pool at runtime actually re-
+// caps the self-heal instead of re-dialing back toward the stale dial-time
+// value. ok=false means "leave the dial-time target unchanged" (a non-adaptive
+// preset, whose target is a fixed policy width).
+type SelfHealTargeter interface {
+	SelfHealTarget() (target int, ok bool)
+}
+
 // String returns the stable label for a DistributionMode. Used
 // by router-side log fields so operator-facing log lines say
 // "round-robin" instead of "1".

--- a/pkg/router/policy/preset/preset_test.go
+++ b/pkg/router/policy/preset/preset_test.go
@@ -1028,3 +1028,70 @@ func TestEngine_OnTick_AdaptiveForwardCollapsesOnIdle(t *testing.T) {
 		t.Errorf("idle steady state must be a single active forward leg; active=%d", s.activeCount())
 	}
 }
+
+// TestEngine_OnTick_AdaptiveShedsExcessStandby is the fix for the runtime
+// warm-standby retune: lowering AdaptStandbyMax at runtime must actually SHRINK
+// an already-over-full reserve, not merely stop it from growing. A group parked
+// at the old (larger) pool size, then retuned to a smaller max, must drop the
+// surplus standby legs SLOWEST-first in one converging tick and then go quiet.
+func TestEngine_OnTick_AdaptiveShedsExcessStandby(t *testing.T) {
+	// Snapshot and restore the process-global tunables (other tests read them).
+	origStandby, origCap, origRev := AdaptStandbyMax(), AdaptCap(), AdaptRevActive()
+	defer func() {
+		SetAdaptStandbyMax(origStandby)
+		SetAdaptCap(origCap)
+		SetAdaptRevActive(origRev)
+	}()
+
+	e := New()
+	// One active primary (leg 0) + 12 warm-standby legs, distinct latencies so
+	// the slowest-first drop order is checkable (idx 1 fastest ... idx 12 slowest).
+	const nStandby = 12
+	legs := make([]LegInfo, nStandby+1)
+	legs[0] = LegInfo{Index: 0, TransportID: "p", Kind: "stcpr", LatencyMs: 30, Alive: true}
+	for i := 1; i <= nStandby; i++ {
+		legs[i] = LegInfo{
+			Index: i, TransportID: string(rune('a' + i)), Kind: "stcpr",
+			LatencyMs: 100 + 10*i, Alive: true, Standby: true,
+		}
+	}
+
+	// Retune the reserve DOWN to 4. Surplus = 12 - 4 = 8 legs must be shed.
+	SetAdaptStandbyMax(4)
+	act := e.OnTick("adaptive", legs)
+
+	const wantDrop = nStandby - 4
+	if len(act.DropLegs) != wantDrop {
+		t.Fatalf("expected %d surplus standby legs shed in one tick, got %d: %+v",
+			wantDrop, len(act.DropLegs), act)
+	}
+	dropped := map[int]bool{}
+	for _, idx := range act.DropLegs {
+		if idx == 0 {
+			t.Fatalf("must never shed leg 0 (primary); got %+v", act.DropLegs)
+		}
+		dropped[idx] = true
+	}
+	// The 4 FASTEST standby legs (idx 1..4) must be kept; the 8 slowest shed.
+	for _, keep := range []int{1, 2, 3, 4} {
+		if dropped[keep] {
+			t.Errorf("fastest standby legs must be kept warm: leg %d was shed; got %+v", keep, act.DropLegs)
+		}
+	}
+	for slow := 5; slow <= nStandby; slow++ {
+		if !dropped[slow] {
+			t.Errorf("slowest standby legs must be shed first: leg %d not shed; got %+v", slow, act.DropLegs)
+		}
+	}
+
+	// Reflect the drop (as the route group would) and tick again: the reserve is
+	// now AT the configured size, so the shed rule must be a no-op (converge, not
+	// churn). Drop-recovery/park don't fire at 1 active + 4 standby either.
+	remain := legs[:1]
+	for i := 1; i <= 4; i++ {
+		remain = append(remain, legs[i])
+	}
+	if act := e.OnTick("adaptive", remain); len(act.DropLegs) != 0 {
+		t.Errorf("at the configured reserve size the shed must be a no-op (no churn); got DropLegs=%+v", act.DropLegs)
+	}
+}

--- a/pkg/router/policy/preset/tick.go
+++ b/pkg/router/policy/preset/tick.go
@@ -1121,6 +1121,54 @@ func (e *Engine) tickAdaptive(legs []LegInfo) RotationAction {
 		return RotationAction{AddLeg: true}
 	}
 
+	// (1b) Converge the warm-standby reserve DOWN after a runtime retune. The
+	// pool size (adaptStandbyMax) is a LIVE tunable — an operator lowering it over
+	// the mux-control RPC (skywire cli proxy mux standby / width) must actually
+	// shrink an already-over-full reserve, not just stop it growing. The park
+	// rules only ever ADD to standby (each gated on standbyCount < adaptStandbyMax),
+	// so without this a reserve parked at the old, larger size would sit forever
+	// and the re-capped self-heal would never draw it back down. Drop the surplus
+	// SLOWEST-first, so the spares we keep warm are the fastest ones. Standby legs
+	// carry no active traffic, so this is safe to run ahead of the anti-churn
+	// cooldown. This is a DELIBERATE one-shot convergence to the configured size,
+	// NOT per-tick reaping: it fires only while standbyCount genuinely exceeds the
+	// max and goes quiet the instant the pool is at size, so a steady-state group
+	// never churns here. Drop recovery (1) runs first, so a needed active slot is
+	// filled by PROMOTING an excess spare before any is dropped.
+	if standbyCount > adaptStandbyMax {
+		type stbyLeg struct {
+			idx int
+			lat float64
+		}
+		var stby []stbyLeg
+		for _, l := range legs {
+			if !l.Alive || !l.Standby || l.Index == 0 {
+				continue
+			}
+			lat := e.adaptLatEWMA[l.TransportID]
+			if lat <= 0 {
+				lat = float64(l.LatencyMs)
+			}
+			if lat <= 0 {
+				lat = adaptLatCeilingMs // unknown → drop first
+			}
+			stby = append(stby, stbyLeg{l.Index, lat})
+		}
+		sort.Slice(stby, func(i, j int) bool { return stby[i].lat > stby[j].lat })
+		surplus := standbyCount - adaptStandbyMax
+		if surplus > len(stby) {
+			surplus = len(stby)
+		}
+		if surplus > 0 {
+			drop := make([]int, surplus)
+			for i := 0; i < surplus; i++ {
+				drop[i] = stby[i].idx
+			}
+			e.adaptCooldown = adaptReshapeCooldown
+			return RotationAction{DropLegs: drop}
+		}
+	}
+
 	// (2) Evict a SUSTAINED-unhealthy active leg (the health gate — the fix for
 	// stuttering connections). Never leg 0, never the last active leg. Hot-swap a
 	// healthy spare in when one exists; else park the bad leg (drop only when the

--- a/pkg/router/policy/presethook/presethook.go
+++ b/pkg/router/policy/presethook/presethook.go
@@ -128,6 +128,21 @@ func (h *Hook) SelectRoute(_ context.Context, info router.DialInfo, forward, rev
 	return sel, nil
 }
 
+// SelfHealTarget implements router.SelfHealTargeter for the adaptive preset,
+// whose self-heal degree is its live pool size — the steady active width plus
+// the warm-standby reserve (Mux = AdaptRevActive()+AdaptStandbyMax(), the same
+// figure decideAdaptive requests at dial). Both are runtime atomics retuned
+// over the mux-control RPC (skywire cli proxy mux width / standby), so pushing
+// the current sum every tick lets a running route group re-cap its self-heal
+// when an operator lowers the reserve — instead of re-dialing back toward the
+// dial-time value. Every other preset keeps its fixed dial-time target (ok=false).
+func (h *Hook) SelfHealTarget() (int, bool) {
+	if h.name == "adaptive" {
+		return preset.AdaptRevActive() + preset.AdaptStandbyMax(), true
+	}
+	return 0, false
+}
+
 // OnTick implements router.RotationHook: it runs the preset's stateful tick
 // controller over the current leg snapshot and returns the structural action
 // (promote/demote/add/drop) for the route group to apply.

--- a/pkg/router/policy/presethook/presethook_test.go
+++ b/pkg/router/policy/presethook/presethook_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/skycoin/skywire/pkg/router"
+	"github.com/skycoin/skywire/pkg/router/policy/preset"
 )
 
 func TestBeforeDial_RotatingBWShape(t *testing.T) {
@@ -79,5 +80,46 @@ func TestOnTick_RotatingBWParksFragile(t *testing.T) {
 	want := router.RotationAction{DemoteToStandby: []int{1}}
 	if !reflect.DeepEqual(act, want) {
 		t.Errorf("OnTick rotating-bw: got %+v want %+v", act, want)
+	}
+}
+
+// TestSelfHealTarget_TracksRuntimeTunables asserts the adaptive hook's self-heal
+// target (the value the route group re-caps maybeSelfHeal with each tick) is the
+// LIVE pool size AdaptRevActive()+AdaptStandbyMax(), so lowering the warm-standby
+// reserve at runtime drops the effective target. Non-adaptive presets report
+// ok=false (keep their fixed dial-time target).
+func TestSelfHealTarget_TracksRuntimeTunables(t *testing.T) {
+	origStandby, origCap, origRev := preset.AdaptStandbyMax(), preset.AdaptCap(), preset.AdaptRevActive()
+	defer func() {
+		preset.SetAdaptStandbyMax(origStandby)
+		preset.SetAdaptCap(origCap)
+		preset.SetAdaptRevActive(origRev)
+	}()
+
+	h := New("adaptive", nil)
+	target, ok := h.SelfHealTarget()
+	if !ok {
+		t.Fatal("adaptive hook must report a live self-heal target")
+	}
+	if want := preset.AdaptRevActive() + preset.AdaptStandbyMax(); target != want {
+		t.Fatalf("self-heal target = %d, want AdaptRevActive+AdaptStandbyMax = %d", target, want)
+	}
+
+	// Lower the reserve; the reported target must DROP with it.
+	preset.SetAdaptStandbyMax(8)
+	lowered, ok := h.SelfHealTarget()
+	if !ok {
+		t.Fatal("adaptive hook must still report a target after retune")
+	}
+	if want := preset.AdaptRevActive() + 8; lowered != want {
+		t.Fatalf("after retune self-heal target = %d, want %d", lowered, want)
+	}
+	if lowered >= target {
+		t.Fatalf("lowering the reserve must lower the self-heal target: was %d, now %d", target, lowered)
+	}
+
+	// A non-adaptive preset keeps its fixed dial-time target.
+	if _, ok := New("ledbat", nil).SelfHealTarget(); ok {
+		t.Error("non-adaptive preset must report ok=false (fixed dial-time target)")
 	}
 }

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1067,6 +1067,18 @@ func (rg *RouteGroup) SetSelfHeal(applyAdd func(excludeHops []string), target in
 	rg.mu.Unlock()
 }
 
+// setSelfHealTarget updates ONLY the self-heal degree, leaving the applyAdd
+// callback in place. The rotation loop calls this each tick for an adaptive
+// group (see SelfHealTargeter) so a runtime mux retune — lowering the warm-
+// standby reserve or the active width over the mux-control RPC — re-caps the
+// live self-heal target instead of letting maybeSelfHeal keep re-dialing back
+// toward the (larger) dial-time value.
+func (rg *RouteGroup) setSelfHealTarget(target int) {
+	rg.mu.Lock()
+	rg.selfHealTarget = target
+	rg.mu.Unlock()
+}
+
 // aliveLegCount returns the number of live legs (non-nil, unclosed
 // transports). Caller must NOT hold rg.mu.
 func (rg *RouteGroup) aliveLegCount() int {
@@ -1647,6 +1659,16 @@ func (rg *RouteGroup) rotationServiceFn(_ time.Duration) {
 	rg.mu.Unlock()
 	if hook == nil {
 		return
+	}
+	// Track the live self-heal target for an adaptive group: its pool size
+	// (active width + warm-standby reserve) is a runtime tunable, so re-read it
+	// each tick and re-cap maybeSelfHeal's target — lowering the reserve at
+	// runtime then actually stops the self-heal from re-dialing beyond the new
+	// size (the excess parked legs are shed by the tick's own converge-down rule).
+	if st, ok := hook.(SelfHealTargeter); ok {
+		if target, ok := st.SelfHealTarget(); ok {
+			rg.setSelfHealTarget(target)
+		}
 	}
 	action := hook.OnTick(info, legs)
 	if len(action.DropLegs) == 0 && !action.AddLeg && !action.AddForwardLeg &&

--- a/pkg/router/route_group_selfheal_target_test.go
+++ b/pkg/router/route_group_selfheal_target_test.go
@@ -1,0 +1,57 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSelfHealHook is a RotationHook that also implements SelfHealTargeter, so
+// the rotation loop can push a live self-heal target the way the adaptive preset
+// hook does. OnTick is a no-op (this test only exercises the target plumbing).
+type fakeSelfHealHook struct {
+	target int
+	ok     bool
+}
+
+func (f fakeSelfHealHook) OnTick(_ DialInfo, _ []LegInfo) RotationAction { return RotationAction{} }
+func (f fakeSelfHealHook) SelfHealTarget() (int, bool)                   { return f.target, f.ok }
+
+// TestRotationServiceFnTracksSelfHealTarget is the fix for the runtime standby
+// retune not reaching a RUNNING route group: the self-heal target is fixed at
+// dial time (SetSelfHeal), but an adaptive group's pool size is a live tunable.
+// The rotation loop must re-read it each tick (via SelfHealTargeter) so lowering
+// the reserve at runtime actually drops maybeSelfHeal's effective target instead
+// of leaving it dialing back toward the stale, larger dial-time value.
+func TestRotationServiceFnTracksSelfHealTarget(t *testing.T) {
+	rg, _, _ := createMuxRouteGroup(t, 1)
+
+	// Dial-time target: the adaptive default (AdaptRevActive+AdaptStandbyMax=513).
+	rg.SetSelfHeal(func(_ []string) {}, 513)
+	rg.mu.Lock()
+	got := rg.selfHealTarget
+	rg.mu.Unlock()
+	require.Equal(t, 513, got, "precondition: dial-time self-heal target")
+
+	// A retune lowers the live pool to 9; the adaptive hook reports it. One tick
+	// of the rotation loop must re-cap the running group's self-heal target.
+	rg.mu.Lock()
+	rg.rotationHook = fakeSelfHealHook{target: 9, ok: true}
+	rg.mu.Unlock()
+	rg.rotationServiceFn(0)
+	rg.mu.Lock()
+	got = rg.selfHealTarget
+	rg.mu.Unlock()
+	require.Equal(t, 9, got, "self-heal target must track the live runtime tunable pushed by the hook")
+
+	// A non-adaptive hook (ok=false) must leave the dial-time target untouched —
+	// its policy width is a fixed dial-time figure, not a live tunable.
+	rg.mu.Lock()
+	rg.rotationHook = fakeSelfHealHook{target: 0, ok: false}
+	rg.mu.Unlock()
+	rg.rotationServiceFn(0)
+	rg.mu.Lock()
+	got = rg.selfHealTarget
+	rg.mu.Unlock()
+	require.Equal(t, 9, got, "a non-adaptive hook (ok=false) must not overwrite the self-heal target")
+}


### PR DESCRIPTION
Follow-up to #4331. Two gaps in the runtime mux-control retune.

**1. `proxy mux standby N` did not cap a RUNNING route group.** A group's self-heal target is fixed at dial time (`SetSelfHeal` stores `AdaptRevActive+AdaptStandbyMax` = 513 for the adaptive default). `#4331` made the reserve a runtime atomic, but the running group's `maybeSelfHeal` kept dialing toward the stale 513, so `mux standby 8` left the pool growing (observed: legs 23 -> 32 after the command).

Fix: the adaptive preset hook now implements an optional `SelfHealTargeter` interface returning the live `AdaptRevActive()+AdaptStandbyMax()`; the rotation loop pushes it into the group each tick, re-capping the self-heal. And the adaptive tick gains a converge-down rule that sheds surplus warm-standby legs (slowest-first, one shot) when the count exceeds the live max — so an over-full reserve actually shrinks to the new size, not just stops growing. No import cycle: the value flows through the existing tick/hook plumbing, `pkg/router` gains no edge to `preset`.

**2. Cosmetic.** `proxy mux standby N` printed "mux mode set to N". The formatter now prints "mux warm-standby reserve set to N" per the actual op, and the numeric setting ops (cap/width/standby) carry a `Value` field instead of misusing `Mode` (reserved for the real mode op).

Tests: adaptive tick sheds excess standby toward a lowered max then goes quiet; the rotation loop re-caps a running group from the hook; the hook's `SelfHealTarget` tracks the live tunables. `go build .`, `go vet`, gofmt, and `go test ./pkg/router/... ./pkg/router/policy/...` all green.