### PR TITLE
feat(proxystatus): per-stream bytes, rate, and rtt on status.skysocks

### DIFF
--- a/pkg/proxystatus/provider.go
+++ b/pkg/proxystatus/provider.go
@@ -133,13 +133,25 @@ type Tunnel struct {
 
 // Stream is one open tunneled stream on the surface's session to the exit — the
 // per-stream detail behind the "N open stream(s)" count. The skysocks-client
-// tracks these locally (id + CONNECT target + age); the underlying yamux layer
-// does not meter per-stream bytes, so bytes are intentionally absent (the
-// route-group totals in the mux section are the byte counters that exist).
+// tracks these locally: id + CONNECT target + age, plus the stream's own up/down
+// byte counters and a smoothed transfer rate. The counters are metered by the
+// splice loop that carries the stream (a counting wrapper on the yamux conn), so
+// they are true per-stream totals, distinct from the route-group-wide sent/recv
+// totals in the mux section.
 type Stream struct {
-	ID     uint32 // yamux stream id
-	Target string // the CONNECT target host:port the stream carries (never a PK)
-	AgeMS  int64  // how long the stream has been open, milliseconds
+	ID          uint32  // yamux stream id
+	Target      string  // the CONNECT target host:port the stream carries (never a PK)
+	AgeMS       int64   // how long the stream has been open, milliseconds
+	SentBytes   uint64  // cumulative bytes browser→exit (up) on this stream
+	RecvBytes   uint64  // cumulative bytes exit→browser (down) on this stream
+	SentRateBps float64 // smoothed up rate in bytes/sec (EWMA over the refresh window); 0 until a second sample lands
+	RecvRateBps float64 // smoothed down rate in bytes/sec (EWMA over the refresh window)
+	// LatencyMS is the ROUTE-GROUP latency of the stream's session to the exit,
+	// NOT a per-stream RTT — yamux exposes no per-stream round-trip. It is the
+	// representative route latency of the surface's live legs, attached to every
+	// stream and LABELED as route-group latency by the renderer rather than faked
+	// as a per-stream number. 0 when unmeasured.
+	LatencyMS float64
 }
 
 // Provider yields a live Snapshot for a surface. Implemented by the visor

--- a/pkg/proxystatus/proxystatus_test.go
+++ b/pkg/proxystatus/proxystatus_test.go
@@ -59,7 +59,7 @@ func TestRenderSections(t *testing.T) {
 		},
 		Logs:    []string{"line two", "[2025-06-01T00:00:00.0000Z] INFO [skysocks-client]: app is running app_name=skysocks-client"},
 		Events:  []string{"[2025-06-01T00:00:01.0000Z] WARN [router]: leg demoted", "[2025-06-01T00:00:02.0000Z] ERROR [dmsgC]: handshake failed close_err=broken pipe"},
-		Streams: []Stream{{ID: 7, Target: "example.com:80", AgeMS: 65000}},
+		Streams: []Stream{{ID: 7, Target: "example.com:80", AgeMS: 65000, SentBytes: 4096, RecvBytes: 2 * 1024 * 1024, SentRateBps: 512, RecvRateBps: 1.5 * 1024 * 1024, LatencyMS: 142}},
 	}
 	page := string(Render(snap))
 	for _, want := range []string{
@@ -160,8 +160,14 @@ func TestRenderSections(t *testing.T) {
 		// by the inline script over the WebSocket pushes.
 		`data-bytes="up"`, `data-bytes="down"`, `data-rate="up"`, `data-rate="down"`, `class="rate"`, "fmtRate",
 		// item 4: the "N open stream(s)" count expands into per-stream rows (id /
-		// target / age) in an expandable section.
+		// target / age / up-down bytes / up-down rate / route-group rtt) in an
+		// expandable section. The byte counters are per-stream (metered by the splice
+		// loop); the rate is smoothed; the rtt column is route-group latency, labeled
+		// as such (yamux has no per-stream RTT). The summary carries the aggregate ↑/↓.
 		`class="streams"`, "open streams", "example.com:80",
+		`class="sagg"`, `class="num up"`, `class="num down"`, `class="num rtt"`,
+		"↑ bytes", "↓ bytes", "↑ rate", "↓ rate",
+		"route-group latency", "4.0K", "2.0M", "512B/s", "1.5M/s", "142ms",
 	} {
 		if !strings.Contains(page, want) {
 			t.Errorf("rendered page missing %q", want)

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -430,19 +430,41 @@ func legRank(l Leg) int {
 
 // writeStreamsSection expands the "N open stream(s)" count into per-stream rows
 // when the surface tracks them (skysocks-client records id + CONNECT target +
-// age locally). It is a native <details> so it stays collapsed by default and
-// costs nothing to skip. Per-stream BYTES are deliberately not shown: the yamux
-// layer carrying the streams does not meter them per stream — the byte counters
-// that exist are the route-group sent/recv totals in the mux section above.
+// age, plus this stream's own up/down byte totals and smoothed transfer rate).
+// It is a native <details> so it stays collapsed by default and costs nothing to
+// skip. Each row shows the stream's ↑/↓ bytes and ↑/↓ rate metered by the splice
+// loop carrying it — true per-stream totals, distinct from the route-group-wide
+// sent/recv totals in the mux section above. The latency column carries the
+// ROUTE-GROUP latency (the stream's session RTT to the exit), labeled as such —
+// yamux exposes no per-stream round-trip, so it is not faked per stream. The
+// summary line carries the aggregate ↑/↓ across all open streams.
 func writeStreamsSection(b *strings.Builder, snap Snapshot) {
 	if len(snap.Streams) == 0 {
 		return
 	}
-	fmt.Fprintf(b, `<details class="streams"><summary>open streams <b>%d</b></summary>`, len(snap.Streams))
-	b.WriteString(`<table class="strm"><thead><tr><th>id</th><th>target</th><th>age</th></tr></thead><tbody>`)
+	var aggSent, aggRecv uint64
 	for _, s := range snap.Streams {
-		fmt.Fprintf(b, `<tr><td>%d</td><td>%s</td><td>%s</td></tr>`,
-			s.ID, html.EscapeString(orDash(s.Target)), html.EscapeString(compactAge(s.AgeMS)))
+		aggSent += s.SentBytes
+		aggRecv += s.RecvBytes
+	}
+	fmt.Fprintf(b, `<details class="streams"><summary>open streams <b>%d</b>`+
+		`<span class="sagg"><i class="up">↑</i> %s <i class="down">↓</i> %s</span></summary>`,
+		len(snap.Streams), html.EscapeString(compactBytes(aggSent)), html.EscapeString(compactBytes(aggRecv)))
+	b.WriteString(`<table class="strm"><thead><tr>` +
+		`<th>id</th><th>target</th><th>age</th>` +
+		`<th class="num">↑ bytes</th><th class="num">↓ bytes</th>` +
+		`<th class="num">↑ rate</th><th class="num">↓ rate</th>` +
+		`<th class="num" title="route-group latency (session RTT to the exit) — not per-stream">rg rtt</th>` +
+		`</tr></thead><tbody>`)
+	for _, s := range snap.Streams {
+		fmt.Fprintf(b, `<tr><td>%d</td><td>%s</td><td>%s</td>`+
+			`<td class="num up">%s</td><td class="num down">%s</td>`+
+			`<td class="num up">%s</td><td class="num down">%s</td>`+
+			`<td class="num rtt">%s</td></tr>`,
+			s.ID, html.EscapeString(orDash(s.Target)), html.EscapeString(compactAge(s.AgeMS)),
+			html.EscapeString(compactBytes(s.SentBytes)), html.EscapeString(compactBytes(s.RecvBytes)),
+			html.EscapeString(compactRate(s.SentRateBps)), html.EscapeString(compactRate(s.RecvRateBps)),
+			html.EscapeString(routeRTTCompact(s.LatencyMS)))
 	}
 	b.WriteString(`</tbody></table>`)
 	b.WriteString(`</details>`)
@@ -949,8 +971,18 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	// Per-stream detail (expandable) behind the "N open stream(s)" count.
 	`details.streams{margin:.5rem 0}details.streams summary{cursor:pointer;font-size:12px;color:var(--muted)}` +
 	`details.streams summary b{color:var(--fg);margin-left:.2rem}` +
+	// Aggregate ↑/↓ across all open streams, shown in the summary line beside the
+	// count. The arrows carry the up (green) / down (cyan) accents used elsewhere.
+	`details.streams summary .sagg{margin-left:.6rem;font-family:'Mononoki',ui-monospace,SFMono-Regular,monospace;font-size:11px}` +
+	`details.streams summary .sagg i{font-style:normal;margin:0 .1rem 0 .5rem}` +
+	`details.streams summary .sagg i.up{color:var(--ok)}details.streams summary .sagg i.down{color:var(--cyan)}` +
 	`table.strm{border-collapse:collapse;font-size:11.5px;margin:.4rem 0;font-family:'Mononoki',ui-monospace,SFMono-Regular,monospace}` +
 	`table.strm th,table.strm td{text-align:left;padding:.1rem 1rem .1rem 0;color:var(--fg);white-space:nowrap}` +
+	// Numeric columns (bytes / rate / rtt) are right-aligned and tabular so the
+	// figures line up as they update live; the ↑ columns take the up accent, ↓ the
+	// down/cyan accent, and the route-group rtt stays muted (it is not per-stream).
+	`table.strm td.num,table.strm th.num{text-align:right;font-variant-numeric:tabular-nums}` +
+	`table.strm td.up{color:var(--ok)}table.strm td.down{color:var(--cyan)}table.strm td.rtt{color:var(--muted)}` +
 	`table.strm th{color:var(--muted);text-transform:uppercase;font-size:9.5px;letter-spacing:.4px}` +
 	`.seam{opacity:.9}.controls{display:flex;flex-wrap:wrap;gap:.4rem;margin-top:.4rem}` +
 	`.controls button{font:inherit;font-size:12px;padding:.2rem .6rem;border:1px dashed var(--line);border-radius:6px;background:transparent;color:var(--muted);cursor:not-allowed}` +

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -65,8 +65,10 @@ type Client struct {
 
 	// streams tracks the currently open tunneled streams so the status page can
 	// expand the "N open stream(s)" count into per-stream rows (id + CONNECT
-	// target + age). yamux does not meter per-stream bytes, so bytes are not
-	// tracked here; only the cheap identity/target/age the sniff already parses.
+	// target + age, plus this stream's own up/down byte counters and a smoothed
+	// transfer rate). The byte counters are metered by a counting wrapper the
+	// splice loop reads through (handleStream), so they are true per-stream totals;
+	// the rate is an EWMA differenced from them in streamSnapshot at page cadence.
 	streamsMu sync.Mutex
 	streams   map[uint32]streamMeta
 
@@ -95,10 +97,50 @@ type Client struct {
 }
 
 // streamMeta is the per-stream detail the status page surfaces for an open
-// tunneled stream.
+// tunneled stream. sent/recv are pointers so the map-by-value copy shares the one
+// counter the splice loop increments (handleStream wraps the yamux conn in a
+// countingConn holding these). The rate/sample fields are mutated only under
+// streamsMu in streamSnapshot, which differences the counters at page cadence
+// into a smoothed bytes/sec rate.
 type streamMeta struct {
 	target string
 	since  time.Time
+	sent   *atomic.Uint64 // cumulative bytes browser→exit (up)
+	recv   *atomic.Uint64 // cumulative bytes exit→browser (down)
+
+	// Rate sampling state (guarded by streamsMu, advanced in streamSnapshot).
+	lastSent   uint64    // sent counter at the last rate sample
+	lastRecv   uint64    // recv counter at the last rate sample
+	lastSample time.Time // wall time of the last rate sample
+	upRate     float64   // smoothed up rate, bytes/sec (EWMA)
+	downRate   float64   // smoothed down rate, bytes/sec (EWMA)
+}
+
+// countingConn wraps a net.Conn to meter the bytes flowing each way through it.
+// rd counts bytes READ from the conn, wr counts bytes WRITTEN to it; both are
+// best-effort (a partial read/write still credits what moved). Used to meter a
+// yamux exit stream: reads are exit→browser (down/recv), writes are browser→exit
+// (up/sent). All other net.Conn methods pass through unchanged.
+type countingConn struct {
+	net.Conn
+	rd *atomic.Uint64
+	wr *atomic.Uint64
+}
+
+func (c *countingConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 {
+		c.rd.Add(uint64(n))
+	}
+	return n, err
+}
+
+func (c *countingConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	if n > 0 {
+		c.wr.Add(uint64(n))
+	}
+	return n, err
 }
 
 // errAllTunnelsDown is the synthetic stream-open error used when every tunnel
@@ -641,9 +683,15 @@ func (c *Client) handleStream(conn, stream net.Conn) {
 	}
 
 	// Track this stream for the status page's per-stream detail (id + target +
-	// age). Registered here, deregistered when the splice below returns.
+	// age + up/down bytes). Registered here, deregistered when the splice below
+	// returns. The returned counters are wired into a countingConn wrapping the
+	// yamux stream so every byte the splice/range-split loop moves is metered:
+	// reads (exit→browser) credit recv/down, writes (browser→exit) credit
+	// sent/up. Wrapping the stream itself catches both the plain splice and the
+	// range-split path, which read/write this same conn.
 	if id, ok := streamID(stream); ok {
-		c.addStream(id, target)
+		up, down := c.addStream(id, target)
+		stream = &countingConn{Conn: stream, rd: down, wr: up}
 		defer c.removeStream(id)
 	}
 
@@ -860,16 +908,57 @@ func streamID(stream net.Conn) (uint32, bool) {
 	return 0, false
 }
 
+// rateSampleMin is the minimum wall interval between two rate samples for a
+// stream: below it the delta is too small to divide cleanly, so streamSnapshot
+// keeps the last smoothed rate instead of recomputing. The status page pushes at
+// ~1s, comfortably above this floor.
+const rateSampleMin = 400 * time.Millisecond
+
+// rateEWMAAlpha weights the newest instantaneous sample against the running
+// smoothed rate (0.5 = equal), so a burst shows promptly but single-sample noise
+// is damped — matching the ~1s page cadence.
+const rateEWMAAlpha = 0.5
+
+// representativeRouteRTT picks a single route-group latency to attach to the
+// per-stream rows: the minimum end-to-end route RTT among the alive legs (the
+// fastest live path the session can use), falling back to the min first-hop
+// transport RTT when no leg reports a route RTT. Returns 0 when nothing is
+// measured. Route-group-level, not per-stream — the streams stripe across these
+// legs and yamux exposes no per-stream RTT.
+func representativeRouteRTT(legs []proxystatus.Leg) float64 {
+	best := 0.0
+	for _, l := range legs {
+		if !l.Alive {
+			continue
+		}
+		cand := l.RouteLatencyMS
+		if cand <= 0 {
+			cand = l.LatencyMS
+		}
+		if cand <= 0 {
+			continue
+		}
+		if best == 0 || cand < best {
+			best = cand
+		}
+	}
+	return best
+}
+
 // addStream/removeStream/streamSnapshot maintain the open-stream registry the
-// status page reads. All are mutex-guarded and cheap (no per-stream byte
-// metering — yamux does not expose it).
-func (c *Client) addStream(id uint32, target string) {
+// status page reads. addStream returns the up/down byte counters for the new
+// stream so the caller can wire them into a countingConn on the yamux stream;
+// the splice loop then meters every byte through them.
+func (c *Client) addStream(id uint32, target string) (up, down *atomic.Uint64) {
+	up, down = new(atomic.Uint64), new(atomic.Uint64)
+	now := time.Now()
 	c.streamsMu.Lock()
 	if c.streams == nil {
 		c.streams = make(map[uint32]streamMeta)
 	}
-	c.streams[id] = streamMeta{target: target, since: time.Now()}
+	c.streams[id] = streamMeta{target: target, since: now, sent: up, recv: down, lastSample: now}
 	c.streamsMu.Unlock()
+	return up, down
 }
 
 func (c *Client) removeStream(id uint32) {
@@ -879,7 +968,13 @@ func (c *Client) removeStream(id uint32) {
 }
 
 // streamSnapshot returns the currently open streams as sorted proxystatus.Stream
-// rows (by id) for the status page.
+// rows (by id) for the status page, carrying each stream's cumulative up/down
+// bytes and a smoothed up/down rate. The rate is an EWMA differenced from the
+// cumulative counters against the previous sample; when called faster than
+// rateSampleMin it reports the last smoothed rate without advancing the sample,
+// so a fast redraw does not divide a tiny delta by a tiny interval. Rate state is
+// mutated in place under streamsMu (the map holds streamMeta by value, so each
+// updated meta is written back).
 func (c *Client) streamSnapshot() []proxystatus.Stream {
 	c.streamsMu.Lock()
 	defer c.streamsMu.Unlock()
@@ -889,10 +984,35 @@ func (c *Client) streamSnapshot() []proxystatus.Stream {
 	now := time.Now()
 	out := make([]proxystatus.Stream, 0, len(c.streams))
 	for id, m := range c.streams {
+		var curSent, curRecv uint64
+		if m.sent != nil {
+			curSent = m.sent.Load()
+		}
+		if m.recv != nil {
+			curRecv = m.recv.Load()
+		}
+		if dt := now.Sub(m.lastSample).Seconds(); dt >= rateSampleMin.Seconds() {
+			upInst := float64(curSent-m.lastSent) / dt
+			downInst := float64(curRecv-m.lastRecv) / dt
+			if m.lastSent == 0 && m.lastRecv == 0 && m.upRate == 0 && m.downRate == 0 {
+				// First sample: seed directly so the first shown rate is the real
+				// average over the stream's opening interval, not half of it.
+				m.upRate, m.downRate = upInst, downInst
+			} else {
+				m.upRate = rateEWMAAlpha*upInst + (1-rateEWMAAlpha)*m.upRate
+				m.downRate = rateEWMAAlpha*downInst + (1-rateEWMAAlpha)*m.downRate
+			}
+			m.lastSent, m.lastRecv, m.lastSample = curSent, curRecv, now
+			c.streams[id] = m
+		}
 		out = append(out, proxystatus.Stream{
-			ID:     id,
-			Target: m.target,
-			AgeMS:  now.Sub(m.since).Milliseconds(),
+			ID:          id,
+			Target:      m.target,
+			AgeMS:       now.Sub(m.since).Milliseconds(),
+			SentBytes:   curSent,
+			RecvBytes:   curRecv,
+			SentRateBps: m.upRate,
+			RecvRateBps: m.downRate,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
@@ -1273,8 +1393,17 @@ func (c *Client) statusSnapshot() proxystatus.Snapshot {
 		if n := len(c.snapshotSessions()); n > 1 {
 			snap.Note = fmt.Sprintf("%s · %d tunnels", snap.Note, n)
 		}
-		// Per-stream detail (id + target + age) behind the count, when tracked.
+		// Per-stream detail (id + target + age + up/down bytes/rate) behind the
+		// count, when tracked. yamux exposes no per-stream RTT, so each stream is
+		// tagged with the route-group latency (the session's representative route
+		// RTT to the exit) rather than a faked per-stream number; the renderer
+		// labels the column as route-group latency.
 		snap.Streams = c.streamSnapshot()
+		if rgRTT := representativeRouteRTT(snap.Legs); rgRTT > 0 {
+			for i := range snap.Streams {
+				snap.Streams[i].LatencyMS = rgRTT
+			}
+		}
 	} else {
 		snap.Note = "no active session to the exit"
 	}

--- a/pkg/skysocks/client_streammeter_test.go
+++ b/pkg/skysocks/client_streammeter_test.go
@@ -1,0 +1,97 @@
+// Package skysocks per-stream byte/rate accounting tests.
+package skysocks
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/proxystatus"
+)
+
+// TestCountingConnMetersBothDirections verifies the countingConn credits reads to
+// its rd counter and writes to its wr counter (used to meter a yamux exit stream:
+// reads = exit→browser/down, writes = browser→exit/up).
+func TestCountingConnMetersBothDirections(t *testing.T) {
+	a, b := net.Pipe()
+	defer a.Close() //nolint:errcheck
+	defer b.Close() //nolint:errcheck
+
+	up, down := new(atomic.Uint64), new(atomic.Uint64)
+	cc := &countingConn{Conn: a, rd: down, wr: up}
+
+	// Write 5 bytes through cc (credits wr/up); the peer drains them.
+	go func() {
+		buf := make([]byte, 8)
+		_, _ = b.Read(buf) //nolint:errcheck
+	}()
+	if _, err := cc.Write([]byte("hello")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := up.Load(); got != 5 {
+		t.Fatalf("up counter = %d, want 5", got)
+	}
+
+	// Read 4 bytes through cc (credits rd/down).
+	go func() { _, _ = b.Write([]byte("data")) }() //nolint:errcheck
+	buf := make([]byte, 4)
+	if _, err := cc.Read(buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got := down.Load(); got != 4 {
+		t.Fatalf("down counter = %d, want 4", got)
+	}
+}
+
+// TestStreamSnapshotBytesAndRate verifies streamSnapshot reports the per-stream
+// cumulative bytes and derives a smoothed rate from them.
+func TestStreamSnapshotBytesAndRate(t *testing.T) {
+	c := &Client{}
+	up, down := c.addStream(9, "example.com:443")
+
+	// Simulate 100 KiB up and 400 KiB down having flowed through the stream.
+	up.Add(100 * 1024)
+	down.Add(400 * 1024)
+
+	// Let a real interval elapse so the first sample divides a real delta by a
+	// real dt (well above rateSampleMin), seeding the rate directly.
+	time.Sleep(rateSampleMin + 100*time.Millisecond)
+
+	snaps := c.streamSnapshot()
+	if len(snaps) != 1 {
+		t.Fatalf("streamSnapshot len = %d, want 1", len(snaps))
+	}
+	s := snaps[0]
+	if s.ID != 9 || s.Target != "example.com:443" {
+		t.Fatalf("unexpected stream identity: %+v", s)
+	}
+	if s.SentBytes != 100*1024 || s.RecvBytes != 400*1024 {
+		t.Fatalf("bytes = up %d / down %d, want 102400 / 409600", s.SentBytes, s.RecvBytes)
+	}
+	if s.SentRateBps <= 0 || s.RecvRateBps <= 0 {
+		t.Fatalf("rate not derived: up %.1f down %.1f", s.SentRateBps, s.RecvRateBps)
+	}
+	// Down moved 4x the up bytes over the same interval, so its rate must exceed up.
+	if s.RecvRateBps <= s.SentRateBps {
+		t.Fatalf("down rate %.1f should exceed up rate %.1f", s.RecvRateBps, s.SentRateBps)
+	}
+}
+
+// TestRepresentativeRouteRTT verifies the route-group rtt picks the fastest alive
+// leg's route latency and ignores dead legs and unmeasured ones.
+func TestRepresentativeRouteRTT(t *testing.T) {
+	legs := []proxystatus.Leg{
+		{Alive: false, RouteLatencyMS: 10},              // dead: ignored even though fastest
+		{Alive: true, RouteLatencyMS: 250},              // alive
+		{Alive: true, RouteLatencyMS: 0, LatencyMS: 90}, // no route rtt: falls back to first-hop
+		{Alive: true, RouteLatencyMS: 140},              // alive, fastest live route rtt
+	}
+	if got := representativeRouteRTT(legs); got != 90 {
+		// 90 (first-hop fallback) is the minimum among the alive candidates.
+		t.Fatalf("representativeRouteRTT = %.0f, want 90", got)
+	}
+	if got := representativeRouteRTT(nil); got != 0 {
+		t.Fatalf("representativeRouteRTT(nil) = %.0f, want 0", got)
+	}
+}


### PR DESCRIPTION
The status.skysocks "open streams" section listed only id / target / age — the per-stream `Stream` struct never carried byte detail. This meters and shows, per stream: up/down bytes, a smoothed up/down rate, and a latency column.

`handleStream` wraps the yamux exit stream in a counting conn, so the existing splice (and range-split) loop credits reads to down and writes to up with no separate accounting path. `streamSnapshot` reports the cumulative totals plus an EWMA rate differenced from them at the page's ~1s cadence; the `<details>` summary gains the aggregate up/down.

yamux exposes no per-stream RTT, so each row is tagged with the route-group latency (the fastest alive leg's route rtt) and the column is labeled as route-group latency rather than faking a per-stream number. The route tree is untouched.

Verified by rendering a synthetic snapshot (each row shows all fields) and unit tests for the counting conn, the bytes/rate snapshot, and the rtt selection; `go build .`, `go vet`, gofmt, and `go test ./pkg/proxystatus/... ./pkg/skysocks/...` pass.