### PR TITLE
fix(router): make extra --tunnels leave over disjoint first-hop transports

### DIFF
--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -1278,6 +1278,40 @@ fetchRoutesAgain:
 		paths[backward] = filtered
 	}
 
+	// Multi-tunnel diversify (opts.DiversifyTransports): steer this extra
+	// tunnel's FIRST HOP off the transports its sibling tunnels to the same
+	// exit already occupy (opts.ExcludeTransportIDs, seeded by
+	// siblingRouteGroupExclusions). The route-finder ranks by latency and does
+	// NOT honor ExcludeTransportIDs, so without this every tunnel is handed the
+	// same preferred (usually the sole direct) first hop and they contend on one
+	// link instead of aggregating — the disjointness the RFC promises collapses.
+	// A direct (0-intermediate) sibling contributes NO ExcludeIntermediatePKs, so
+	// the intermediate-based pickDisjointPath below cannot break the tie on its
+	// own; the first-hop transport-ID is the only distinguishing signal.
+	//
+	// Preference, not a hard cut: restrict the forward candidates to those whose
+	// first-hop transport is not already claimed; if the finder offers none, try
+	// the local BFS (which can build a disjoint multi-hop path, and skips the
+	// excluded direct transport) before conceding. Only when nothing disjoint
+	// exists anywhere do we keep a shared first hop — a shared tunnel still beats
+	// no tunnel, just with limited aggregation, which we log.
+	if opts.DiversifyTransports && len(opts.ExcludeTransportIDs) > 0 {
+		if disjoint := filterDisjointFirstHop(paths[forward], opts.ExcludeTransportIDs); len(disjoint) > 0 {
+			if len(disjoint) != len(paths[forward]) {
+				log.Debugf("diversify: %d/%d forward candidate(s) leave over a disjoint first-hop transport; preferring those",
+					len(disjoint), len(paths[forward]))
+			}
+			paths[forward] = disjoint
+		} else {
+			localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, src, dst, opts)
+			if localErr == nil && len(localFwd) > 0 && !firstHopTransportExcluded(localFwd, opts.ExcludeTransportIDs) {
+				log.Debug("diversify: no disjoint first-hop from route finder; using local-calc disjoint path")
+				return localFwd, localRev, nil
+			}
+			log.Warnf("diversify: no disjoint first-hop transport to %s is free; extra tunnel shares an existing first hop (aggregation limited)", dst)
+		}
+	}
+
 	// Routing-policy candidate selection. When the configured
 	// DialHook also implements RouteSelectingHook, hand it the
 	// forward-direction candidates so the operator's script can
@@ -1452,6 +1486,51 @@ func pickBestDirection(paths [][]routing.Hop, excludeSet map[cipher.PubKey]struc
 		return nil, false
 	}
 	return paths[bestIdx], true
+}
+
+// filterDisjointFirstHop returns the candidate paths whose FIRST hop leaves
+// over a transport NOT in excludeTpIDs. It is the route-finder-path counterpart
+// to the local-calc's direct-transport exclusion (calculateLocalRoutes skips an
+// excluded direct tp): the finder ranks purely by latency and ignores
+// ExcludeTransportIDs, so this is what actually keeps a multi-tunnel diversify
+// dial off a first-hop transport a sibling tunnel already holds. Returns the
+// input unchanged when there is nothing to exclude; may return an EMPTY slice
+// when every candidate shares an excluded first hop — the caller decides whether
+// to fall back (local calc / shared path) rather than failing here.
+func filterDisjointFirstHop(cands [][]routing.Hop, excludeTpIDs []uuid.UUID) [][]routing.Hop {
+	if len(cands) == 0 || len(excludeTpIDs) == 0 {
+		return cands
+	}
+	excl := make(map[uuid.UUID]struct{}, len(excludeTpIDs))
+	for _, id := range excludeTpIDs {
+		excl[id] = struct{}{}
+	}
+	out := make([][]routing.Hop, 0, len(cands))
+	for _, hops := range cands {
+		if len(hops) == 0 {
+			continue
+		}
+		if _, bad := excl[hops[0].TpID]; bad {
+			continue
+		}
+		out = append(out, hops)
+	}
+	return out
+}
+
+// firstHopTransportExcluded reports whether the path's first hop leaves over one
+// of excludeTpIDs. Used to confirm a local-calc fallback route is genuinely
+// disjoint before returning it for a diversify dial.
+func firstHopTransportExcluded(hops []routing.Hop, excludeTpIDs []uuid.UUID) bool {
+	if len(hops) == 0 {
+		return false
+	}
+	for _, id := range excludeTpIDs {
+		if hops[0].TpID == id {
+			return true
+		}
+	}
+	return false
 }
 
 // transportTypeCostMs is a per-hop, latency-equivalent penalty that biases

--- a/pkg/router/router_dial_disjoint_test.go
+++ b/pkg/router/router_dial_disjoint_test.go
@@ -497,3 +497,76 @@ func TestTransportCostMsMeasuredOverridesType(t *testing.T) {
 		t.Errorf("a sub-400Kbps link should score worst (400), got %v", slowStcpr)
 	}
 }
+
+// hopVia builds a hop whose first-hop transport is tpID (so a candidate's
+// disjointness at the source can be asserted deterministically).
+func hopVia(tpID uuid.UUID, from, to cipher.PubKey) routing.Hop {
+	return routing.Hop{TpID: tpID, From: from, To: to}
+}
+
+// TestFilterDisjointFirstHop is the core of the multi-tunnel diversify fix:
+// N tunnels to one exit must each request a first-hop transport a sibling
+// tunnel does not already hold. The route-finder ignores ExcludeTransportIDs,
+// so filterDisjointFirstHop is what actually drops the shared-first-hop
+// candidates from the finder response.
+func TestFilterDisjointFirstHop(t *testing.T) {
+	src := mustPK(t)
+	mid := mustPK(t)
+	dst := mustPK(t)
+
+	shared := uuid.New() // the direct stcpr a sibling already occupies
+	altDirect := uuid.New()
+	viaMid := uuid.New()
+
+	directShared := []routing.Hop{hopVia(shared, src, dst)}
+	directAlt := []routing.Hop{hopVia(altDirect, src, dst)}
+	multihop := []routing.Hop{hopVia(viaMid, src, mid), hop(mid, dst)}
+
+	t.Run("empty exclude returns input unchanged", func(t *testing.T) {
+		in := [][]routing.Hop{directShared, multihop}
+		got := filterDisjointFirstHop(in, nil)
+		if len(got) != 2 {
+			t.Fatalf("no exclusions: want all %d candidate(s) kept, got %d", len(in), len(got))
+		}
+	})
+
+	t.Run("drops shared first-hop, keeps disjoint", func(t *testing.T) {
+		in := [][]routing.Hop{directShared, directAlt, multihop}
+		got := filterDisjointFirstHop(in, []uuid.UUID{shared})
+		if len(got) != 2 {
+			t.Fatalf("want 2 disjoint candidate(s), got %d", len(got))
+		}
+		for _, p := range got {
+			if firstHopTransportExcluded(p, []uuid.UUID{shared}) {
+				t.Errorf("kept a candidate that reuses the excluded first hop %s", p[0].TpID)
+			}
+		}
+	})
+
+	t.Run("all shared -> empty (caller falls back)", func(t *testing.T) {
+		// N tunnels, one direct transport: every finder candidate leaves over
+		// the same shared first hop. The filter returns empty so the dialer
+		// can try local-calc / concede to a shared path rather than pretending
+		// disjointness exists.
+		in := [][]routing.Hop{directShared, directShared}
+		got := filterDisjointFirstHop(in, []uuid.UUID{shared})
+		if len(got) != 0 {
+			t.Fatalf("all candidates shared: want empty, got %d", len(got))
+		}
+	})
+
+	t.Run("firstHopTransportExcluded direct and multihop", func(t *testing.T) {
+		if !firstHopTransportExcluded(directShared, []uuid.UUID{shared}) {
+			t.Error("direct route over the excluded tp should be reported excluded")
+		}
+		if firstHopTransportExcluded(directAlt, []uuid.UUID{shared}) {
+			t.Error("direct route over a different tp must not be reported excluded")
+		}
+		if firstHopTransportExcluded(multihop, []uuid.UUID{shared}) {
+			t.Error("multihop leaving over a different first hop must not be reported excluded")
+		}
+		if !firstHopTransportExcluded(multihop, []uuid.UUID{viaMid}) {
+			t.Error("multihop whose first hop IS excluded should be reported excluded")
+		}
+	})
+}


### PR DESCRIPTION
`--tunnels N` on skysocks is meant to steer each extra tunnel onto a first-hop transport its siblings don't already hold, so the tunnels aggregate bandwidth instead of contending on one link. The visor already seeds `ExcludeTransportIDs` from sibling route groups to the same exit (`siblingRouteGroupExclusions`, `DiversifyTransports`), but the route-finder path ranked candidates purely by latency and never consulted `ExcludeTransportIDs`. When only one direct transport to the exit exists, every tunnel was handed that same direct route — they collapsed onto one first hop and never aggregated. Observed live: a `--tunnels 3` proxy where all three tunnels' primary legs left over the same direct stcpr.

A direct sibling contributes no intermediate PKs, so the existing intermediate-based disjoint pick can't break the tie — the first-hop transport ID is the only distinguishing signal. `fetchBestRoutes` now, for a diversify dial, prefers forward candidates whose first-hop transport is disjoint, falls back to the local BFS (which can build a disjoint multi-hop path and already skips the excluded direct transport) when the finder offers none, and only shares an existing first hop as a last resort — logged as limited aggregation. A shared tunnel still beats no tunnel, so correctness is preserved when no disjoint hop exists.

Scope is contained to the finder-path selection and gated on `DiversifyTransports`, so mux dials and single dials are unchanged. New unit tests cover `filterDisjointFirstHop` / `firstHopTransportExcluded` over direct, alt-direct and multi-hop candidates, including the all-shared fallback.