### PR TITLE
RFC + phase-1: shared warm-route pool for multiplexed routing

### DIFF
--- a/docs/design/shared-warm-route-pool.md
+++ b/docs/design/shared-warm-route-pool.md
@@ -1,0 +1,224 @@
+# Shared warm-route pool for multiplexed routing
+
+Status: design (phase-1 prototype landed: shared route-plan cache)
+
+## Problem
+
+A multiplexed route group (a `--tunnels` tunnel, or any mux'd session) keeps a
+pool of warm-standby aux legs so it can grow bandwidth onto them without a
+cold-dial stall. Today that pool is **per route group**. Each group:
+
+- targets `Mux = AdaptRevActive() + AdaptStandbyMax()` warm legs
+  (`preset.go:345`; default `1 + 512 = 513`), and
+- runs its **own** self-heal / rotation loop that dials aux legs one at a time
+  toward that target (`route_group.go:1149 maybeSelfHeal`,
+  `router_dial.go:697 applyAdd` → `addOneAuxLeg`).
+
+With **N** tunnels the costs multiply:
+
+1. **N × the route-finder work.** Every group re-discovers its own disjoint
+   aux-leg set: `establishMuxRoutes` and `addOneAuxLeg` each call
+   `fetchBestRoutes` (route-finder round-trip + local disjointness BFS /
+   `validMuxLeg`) **once per leg, per group, per rotation tick**. N tunnels to
+   the same exit run that identical planning work N times over — and the
+   route-finder is the slow, timeout-prone part (a cold dmsg session to the RF
+   stalls tens of seconds; `router_dial.go:2287` calls it "the observed storm").
+2. **N × the setup-node dial storm.** Each warm leg is a full setup-node
+   handshake that reserves route IDs and installs rules at every hop
+   (`addOneAuxLeg` → `RouteGroupDialer.Dial`, `router_dial.go:2705`). At scale
+   these fail and self-heal re-dials, hammering the setup node
+   (`tick.go:586-595`).
+
+The user's question: **shouldn't the warm standby be a SHARED pool that any
+route group can promote a leg from, instead of each group rebuilding its own?**
+
+This RFC answers *what can actually be shared*, given that routing **rules are
+installed per route group**, and proposes a staged path whose first step is
+already prototyped.
+
+## What a "leg" is made of — the three layers
+
+A mux leg is three stacked things. Only the bottom two are shareable.
+
+| Layer | What it is | Keyed by | Shareable across groups? |
+|---|---|---|---|
+| **Transport** | first-hop link `src → intermediate` | `MakeTransportID(src, peer, type)` (`transport.go:19`) | **Already shared** — one `*ManagedTransport` per (peer,type) in `Manager.tps` (`manager.go:81`); groups hold pointers, `SaveTransport` is idempotent (`manager.go:1348`). |
+| **Route plan** | the `[]routing.Hop` path to the exit (`{From,To,TpID}`, **no route IDs**) | `(dst, min-hops)` — independent of source port | **Yes** — the path is group-independent; any group can feed it into its own `Dial`. **Not shared today.** |
+| **Route rules** | the reserved route-ID chain: source `ForwardRule`+`ConsumeRule` (carry the descriptor) and the `IntermediaryForwardRule`s at every hop | route IDs reserved **per dial** by `IDReserver.PopID`; the edge rules embed the full `RouteDescriptor` (src/dst PK **and ports**) | **No** — see below. |
+
+### Why the rules can't be shared (the crux)
+
+`GenerateRules` (`setupnode.go:609`) mints a **fresh route ID at every hop** for
+each dial. The intermediate rules (`IntermediaryForwardRule(keyRID, nextRID,
+tpID)`, `rule.go:443`) carry no descriptor — they are pure `routeID → (routeID,
+transport)` switches — **but** the chain of reserved IDs terminates at exactly
+one `ConsumeRule`, whose descriptor selects one route group at the source
+(`router_packet.go:99`: `desc := rule.RouteDescriptor()` → `r.rgsNs[desc]`).
+
+So an intermediate chain is hard-bound to **one** descriptor / **one** route
+group. Two tunnels have different descriptors (different source ports at
+minimum) and each needs inbound packets to land on **its own** consume rule.
+Handing group B a rule chain that group A reserved would deliver B's return
+traffic to A. To genuinely share intermediate rules, multiple groups would have
+to multiplex onto one shared reserved route-ID chain terminating in one consume
+rule — which the source-side descriptor dispatch does not support. **That is a
+large refactor, not an incremental change** (see Phase 3).
+
+**Conclusion on the shared unit:** the shareable substrate is the **transport**
+(already shared) and the **route plan** (shareable, not yet shared). The
+route-ID-bearing rules must still be minted per group by a `Dial`. Sharing
+therefore saves *planning* and *transport establishment*, **not** rule
+reservation/installation.
+
+## Feasibility verdict
+
+- **True warm-*route* pooling** — promoting a fully-built leg (transports **+
+  intermediate rules to the exit**) from a visor-level pool into an arbitrary
+  route group — is a **large refactor**. It requires reworking route-ID dispatch
+  so one intermediate chain can fan out to multiple descriptors (a shared
+  "trunk" abstraction), plus a wire change at the exit. Not incremental.
+- **Shared warm-*transport* reserve + shared *plan* cache** is a **tractable
+  incremental change**. Transports are already deduped by the manager; the plan
+  cache is a small local read-side component. Together they remove the N×
+  route-finder storm and bound warm-transport establishment, delivering most of
+  the felt cost reduction without touching the rule model or the wire.
+
+### Smallest useful first step (prototyped)
+
+A **visor-level shared route-plan cache** (`pkg/router/warm_route_pool.go`),
+consulted by the per-leg dial path before it calls the route-finder. It caches
+the disjoint `[]Hop` plans discovered for an exit and lends them to any group
+(or later leg, or later tick) dialing an aux leg to that same exit. This is the
+single highest-value, lowest-risk slice: every group's ongoing self-heal /
+rotation funnels through `addOneAuxLeg`, so wiring that one function makes the
+planning work **shared across all groups** while each group still mints its own
+rules.
+
+## Model
+
+### Phase 1 — shared route-plan cache (prototyped)
+
+`warmRoutePool` is one instance on the router, alongside the existing
+`tpdCache`/`suspects` caches (`router.go`). A cached **plan** is a forward +
+reverse `[]routing.Hop` pair (path only, no route IDs) plus its first-hop
+transport ID and intermediate PK set (for disjointness matching).
+
+- `put(dst, minHops, fwd, rev)` — records a freshly-discovered plan, dedup by
+  first-hop transport, TTL-stamped. Bounded per-exit (`warmPlanBucketCap`).
+- `bestPlan(dst, minHops, excludeTps, excludePKs)` — returns a non-stale cached
+  plan whose first-hop transport and intermediates are disjoint from the
+  caller's per-group exclude sets, else a miss.
+- `invalidate(dst)` / `invalidateAll()` — drop plans when transports change.
+
+Wiring (`router_dial.go addOneAuxLeg`): before `fetchBestRoutes`, try
+`bestPlan`; on a hit, use the cached plan; on a miss, fetch as today and `put`
+the result. **Safety by construction:** the cached plan flows through the
+*exact same* downstream gates a fresh plan does — the `validMuxLeg` invariant
+check, the "first hop already in the group" reject, and the setup-node `Dial`
+that re-resolves and re-dials the transport. A stale plan (a since-dead
+transport) is rejected or fails the dial and the caller falls through to a fresh
+fetch. **A miss or a stale hit can only cost a fallback; it can never change the
+leg that gets built.**
+
+Key includes `minHops` so a `min_hops>=2` dial is never served a 1-hop plan.
+TTL (`defaultWarmPlanTTL = 30s`) bounds staleness under the already-cached
+5-minute TPD snapshot; expired buckets are evicted on read.
+
+**Why no capability negotiation / flag gate here.** Phase 1 is entirely
+initiator-local: it changes *how this visor plans a path*, not anything on the
+wire. A peer cannot observe it and is unaffected, so there is nothing to
+negotiate and no flag to gate — it is always on, degrading to today's behavior
+on every miss. (This honors the "no flag gate" rule by making the optimization
+transparent rather than switch-selected.)
+
+### Phase 2 — shared warm-transport pin
+
+Transports are already shared, but a warm transport with **no rule referencing
+it** currently reads as tear-down-able: the manager's `RouteChecker`
+(`init_router.go:336`) answers "in use?" by scanning the routing table for a
+rule whose `NextTransportID` matches. To keep a pre-warmed first-hop transport
+alive between the moment the plan is cached and the moment a group dials it,
+add a **warm-pin set** the `RouteChecker` also honors:
+
+```
+in-use(tpID) := routeTableHasTransport(tpID) OR warmPinned(tpID)
+```
+
+The plan cache pins the first-hop transports of the plans it holds and unpins on
+eviction. A single background maintainer (keyed by the set of exits the visor
+currently tunnels to) calls `EnsureBestTransport` (`manager.go:981`) for each
+cached plan's first hop, sized to the topology's disjoint-route count, filled
+once — **killing the N× transport-establishment cost** and giving every group's
+setup-node dial an already-established first hop. Still initiator-local; still no
+wire change.
+
+### Phase 3 — shared route-ID trunk (large refactor; capability-negotiated)
+
+The only way to stop re-minting *intermediate rules* per group is a shared
+**trunk**: one reserved route-ID chain from this visor to an exit that multiple
+route groups' legs ride, with a demux at the exit that maps the shared inbound
+chain back to per-group consume rules. This changes what the exit must do with
+an inbound chain, so it **is** a wire change and **must** be capability
+negotiated — following the established handshake-bitmap pattern
+(`packet.go:174` cap bits, advertised unconditionally at `route_group.go:3176`,
+activated only on `local & remote` intersection). Reserve the next free bit
+(`CapWarmTrunk = 1 << 8`); a peer lacking it simply never negotiates a trunk and
+keeps today's per-group chains. This phase is out of scope for the incremental
+work and is recorded here as the end-state, not a commitment.
+
+## How promotion / demotion interacts with the existing machinery
+
+Phase 1 needs **no** change to the tick, the per-group standby arrays, or the
+self-heal loop — it only changes where a leg's *plan* comes from. The adaptive
+tick (`pkg/router/policy/preset/tick.go`) keeps owning each group's `standby[]`
+and its promote/demote decisions; `maybeSelfHeal` keeps restoring degree via
+`applyAdd`. The cache sits *under* `applyAdd`, transparently.
+
+Phases 2–3 would move the standby *budget* from per-group to a shared
+accountant: the tick's `standbyCount < adaptStandbyMax` gates
+(`tick.go:1183/1251/1340/1357`) would request/release from the shared pool
+instead of each group owning a full `adaptStandbyMax` reserve, and
+`AdaptStandbyMax()` would become a **global pool ceiling** rather than a
+per-group target. Those changes belong in `tick.go`/the preset and are
+deliberately **not** part of the prototype (that file is under concurrent
+edit); this RFC specifies them as the phase-2 interface.
+
+## Sizing, maintenance, direction/disjointness
+
+- **Sizing.** One shared reserve per exit, sized to the topology's disjoint-route
+  count (what the self-heal no-progress backoff already discovers,
+  `route_group.go:1101 selfHealNoProgressLimit`), filled once — not `N ×
+  adaptStandbyMax`.
+- **Maintenance.** TTL + `invalidate(dst)` on transport register/deregister; the
+  phase-2 pin keeps first hops warm; `EnsureBestTransport` re-dials a dropped
+  warm transport.
+- **Direction / disjointness.** The cache stores each plan's first-hop transport
+  and intermediate set and matches them against the caller's exclude sets, so a
+  group growing its k-th first-hop-**disjoint** leg is handed a plan disjoint
+  from its own k−1 prior legs — the same guarantee `establishMuxRoutes` /
+  `GrowMuxRoute` enforce, preserved on the cached path by the unchanged
+  downstream `validMuxLeg` gate. This dovetails with the `--tunnels`
+  disjoint-first-hop work: the shared plan set *is* the disjoint set to the exit,
+  computed once.
+
+## Migration / coexistence
+
+Phase 1 coexists with the per-group pool with zero negotiation: it is a
+read-through cache under the existing dial path. Groups that never hit the cache
+behave exactly as today. There is no flag and no wire bit because nothing leaves
+the visor. Phases 2–3 layer on top — the pin is still local, and only the trunk
+(phase 3) introduces a capability bit, at which point mixed fleets fall back to
+per-group chains automatically.
+
+## Prototype
+
+- `pkg/router/warm_route_pool.go` — the `warmRoutePool` cache (put / bestPlan /
+  invalidate / stats), fully unit-tested in `warm_route_pool_test.go` (hit,
+  miss, min-hops keying, transport/intermediate exclusion, TTL expiry, first-hop
+  dedup, invalidate, nil-safety).
+- `pkg/router/router.go` — one field + one initializer, mirroring `tpdCache`.
+- `pkg/router/router_dial.go` — `addOneAuxLeg` consults then populates the pool
+  around its `fetchBestRoutes` call; all downstream invariant gates unchanged.
+
+Not prototyped (documented above): the phase-2 warm-transport pin and the
+phase-3 capability-negotiated trunk.

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -654,6 +654,7 @@ type router struct {
 	lastRouteCalcMu   sync.Mutex        // protects lastRouteCalcTime
 	tpdCache          *tpdSnapshotCache // one-snapshot TTL cache of GetAllTransports, see tpd_cache.go
 	suspects          *suspectHopCache  // short-TTL penalty cache for intermediates that lost/failed a setup race (see parallel_route_setup.go)
+	warmRoutes        *warmRoutePool    // visor-level shared cache of disjoint aux-leg PLANS to an exit, shared across route groups (see warm_route_pool.go / docs/design/shared-warm-route-pool.md)
 	// dstTpOracle fetches a destination visor's OWN transport list
 	// authoritatively from the destination (via an RSN-signed transport-query),
 	// for the RSN-oracle 2-hop route path (rsn_oracle_routes.go). nil by default
@@ -770,6 +771,7 @@ func New(dmsgC *dmsg.Client, config *Config, routeSetupHooks []RouteSetupHook) (
 		routeSetupHooks: routeSetupHooks,
 		tpdCache:        newTPDSnapshotCache(),
 		suspects:        newSuspectHopCache(handshakeAwaitTimeout),
+		warmRoutes:      newWarmRoutePool(defaultWarmPlanTTL),
 		// Default a mux responder to capacity bulk-spread for the downloads it
 		// serves (see router_serve.go); operators can disable via
 		// SetResponderBulkSpread(false).

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -2650,20 +2650,48 @@ func (r *router) addOneAuxLeg(ctx context.Context, nrg *NoiseRouteGroup, opts *D
 		ExcludeDMSG:            true,
 	}
 
-	// Plan the replacement/added leg over the GLOBAL TPD graph via the
-	// route-finder first (same rationale as establishMuxRoutes): local calc is
-	// restricted to this visor's live transports (webrtc on a NAT'd client), so
-	// a self-healed/rotated leg re-collapses to a slow webrtc first hop unless
-	// we let the RF reach fast disjoint stcpr intermediates over the full graph.
-	// The disjoint excludes + transport-type-aware ranking keep it disjoint and
-	// off webrtc; local calc is the fallback for a disjoint deep-hop the RF misses.
-	muxFwd, muxRev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
-	if err != nil {
-		lcFwd, lcRev, lcErr := r.calculateLocalRoutes(ctx, log, lPK, rPK, muxOpts)
-		if lcErr != nil {
-			return fmt.Errorf("rotation add-leg: no route found (route-finder=%v, local-calc=%v)", err, lcErr)
+	// SHARED WARM-ROUTE POOL (phase 1): before the route-finder round-trip, try
+	// the visor-level plan cache. Every mux-enabled group's self-heal/rotation
+	// dials an aux leg through here, so N tunnels aggregating to the same exit
+	// would otherwise each re-run the same route-finder + disjointness work per
+	// leg per tick — the "planning storm". A cached plan is a group-independent
+	// path (no route IDs); it is fed into the SAME setup-node Dial + validMuxLeg
+	// gate below, so a stale plan is rejected exactly like a fresh bad one and a
+	// miss falls through to fetchBestRoutes — the cache can only save work, never
+	// change the leg that gets built. See docs/design/shared-warm-route-pool.md.
+	keyMinHops := uint16(r.conf.MinHops) //nolint:gosec
+	if e := muxOpts.EffectiveMinHops(true); e > 0 {
+		keyMinHops = uint16(e) //nolint:gosec
+	}
+	var muxFwd, muxRev []routing.Hop
+	if cf, cr, ok := r.warmRoutes.bestPlan(rPK, keyMinHops, excludeIDs, excludePKs); ok {
+		muxFwd, muxRev = cf, cr
+		log.WithField("first_tp", func() string {
+			if len(cf) > 0 {
+				return cf[0].TpID.String()
+			}
+			return ""
+		}()).Debug("Mux add-leg: served disjoint plan from shared warm-route pool (skipped route-finder)")
+	} else {
+		// Plan the replacement/added leg over the GLOBAL TPD graph via the
+		// route-finder first (same rationale as establishMuxRoutes): local calc is
+		// restricted to this visor's live transports (webrtc on a NAT'd client), so
+		// a self-healed/rotated leg re-collapses to a slow webrtc first hop unless
+		// we let the RF reach fast disjoint stcpr intermediates over the full graph.
+		// The disjoint excludes + transport-type-aware ranking keep it disjoint and
+		// off webrtc; local calc is the fallback for a disjoint deep-hop the RF misses.
+		fFwd, fRev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
+		if err != nil {
+			lcFwd, lcRev, lcErr := r.calculateLocalRoutes(ctx, log, lPK, rPK, muxOpts)
+			if lcErr != nil {
+				return fmt.Errorf("rotation add-leg: no route found (route-finder=%v, local-calc=%v)", err, lcErr)
+			}
+			fFwd, fRev = lcFwd, lcRev
 		}
-		muxFwd, muxRev = lcFwd, lcRev
+		muxFwd, muxRev = fFwd, fRev
+		// Populate the shared pool so the NEXT group/leg to this exit reuses this
+		// freshly-discovered disjoint plan instead of re-querying the finder.
+		r.warmRoutes.put(rPK, keyMinHops, muxFwd, muxRev)
 	}
 
 	// Hard mux invariants (post-fetch gate): the planned leg must be loop-free

--- a/pkg/router/warm_route_pool.go
+++ b/pkg/router/warm_route_pool.go
@@ -1,0 +1,277 @@
+// pkg/router/warm_route_pool.go — a VISOR-LEVEL shared cache of disjoint route
+// PLANS to an exit, shared by every route group that dials aux mux legs to that
+// exit. See docs/design/shared-warm-route-pool.md for the full design.
+//
+// Motivation: today each mux-enabled route group re-discovers its own disjoint
+// aux-leg set. establishMuxRoutes and addOneAuxLeg both call fetchBestRoutes
+// (the route-finder round-trip + the local disjointness BFS/validMuxLeg gate)
+// once PER LEG, PER GROUP. With N tunnels aggregating to the same exit that is
+// N× the same route-finder work — the "planning storm" half of the cost the
+// user flagged (the setup-node DIAL half is intrinsic to per-group rules and is
+// NOT removed by this cache; see the RFC).
+//
+// What is safely shareable: a "plan" is a forward+reverse []routing.Hop pair —
+// PATH ONLY, no route IDs (routing.Hop is {From, To, TpID}). Route IDs are
+// reserved fresh per dial by the IDReserver, and the intermediate rules that
+// carry them are bound to one route group's descriptor; those CANNOT be shared
+// (see the RFC's layer analysis). The path itself is group-independent: any
+// group dialing an aux leg to the same exit can feed a cached plan straight into
+// its own setup-node Dial, which mints that group's own route-ID chain over the
+// (already-shared) transports.
+//
+// Safety: a cached plan is only ever a HINT. Every caller runs the exact same
+// validMuxLeg gate on the returned plan that it already runs on a freshly
+// fetched one, and the setup-node Dial re-resolves/re-dials the first-hop
+// transport — so a stale plan (a transport that has since died) is rejected or
+// fails the dial and the caller falls through to a fresh fetchBestRoutes, i.e.
+// exactly today's behavior. A miss is always a clean fallback: this cache can
+// only save work, never change the leg that gets built.
+//
+// This is purely a local read-side cache. It is initiator-local — no wire
+// protocol change — so unlike the mux data-plane features it needs no
+// capability negotiation to be safe (a peer is unaffected by how the initiator
+// planned the path). Phase 2/3 (a genuinely shared warm-TRANSPORT pin, and
+// eventually shared route-ID trunks) DO touch the wire and would follow the
+// handshake-capability pattern — see the RFC.
+
+// Package router pkg/router/warm_route_pool.go c2-net-routing
+package router
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// defaultWarmPlanTTL bounds staleness of a cached disjoint plan set. Plans are
+// paths over the transport graph, which only changes on transport
+// register/deregister; a short TTL keeps a genuinely-removed transport from
+// lingering in a served plan while still coalescing the burst of per-leg
+// planning that N tunnels to one exit produce in the same few seconds. Kept
+// well under the tpdSnapshotCache 5m TTL the underlying fetch already uses,
+// since a plan is more perishable than the raw TPD dataset.
+const defaultWarmPlanTTL = 30 * time.Second
+
+// warmPlanBucketCap bounds how many distinct disjoint plans are held per exit.
+// A group growing its k-th aux leg needs a cached plan disjoint from its own
+// k-1 prior intermediates, so the bucket must hold several; but it is a cache,
+// not the authority on the topology's disjoint count, so it is capped to keep
+// memory bounded on a visor tunneling to many exits.
+const warmPlanBucketCap = 64
+
+// routePlan is one cached, group-INDEPENDENT path to an exit: a forward +
+// reverse hop sequence (no route IDs) plus the derived keys used to match it
+// against a caller's per-group exclude set.
+type routePlan struct {
+	fwd     []routing.Hop
+	rev     []routing.Hop
+	firstTp uuid.UUID       // fwd[0].TpID — the first-hop transport this plan rides
+	inter   []cipher.PubKey // intermediate visor PKs (for disjointness matching)
+}
+
+// planKey identifies a bucket of disjoint plans to one exit at one min-hops
+// class. min-hops is part of the key because a min_hops>=2 dial must not be
+// served a 1-hop direct plan cached for a min_hops=1 dial.
+type planKey struct {
+	dst     cipher.PubKey
+	minHops uint16
+}
+
+type planBucket struct {
+	plans  []routePlan
+	filled time.Time
+}
+
+// warmRoutePool is the visor-level shared plan cache. Concurrent-safe. One
+// instance is held by the router and consulted by every group's aux-leg dial.
+type warmRoutePool struct {
+	mu     sync.Mutex
+	ttl    time.Duration
+	now    func() time.Time
+	byExit map[planKey]*planBucket
+
+	// metrics (read via stats() for observability; never gate behavior)
+	hits   uint64
+	misses uint64
+	stored uint64
+}
+
+func newWarmRoutePool(ttl time.Duration) *warmRoutePool {
+	if ttl <= 0 {
+		ttl = defaultWarmPlanTTL
+	}
+	return &warmRoutePool{
+		ttl:    ttl,
+		now:    time.Now,
+		byExit: make(map[planKey]*planBucket),
+	}
+}
+
+// planIntermediates extracts intermediate visor PKs from a forward hop
+// sequence (mirrors intermediatesOfHops but on a bare []Hop, src/dst derived
+// from the hops themselves so the pool needs no descriptor).
+func planIntermediates(fwd []routing.Hop) []cipher.PubKey {
+	if len(fwd) <= 1 {
+		return nil
+	}
+	src := fwd[0].From
+	dst := fwd[len(fwd)-1].To
+	out := make([]cipher.PubKey, 0, len(fwd)-1)
+	for i := 0; i < len(fwd)-1; i++ {
+		pk := fwd[i].To
+		if pk == src || pk == dst {
+			continue
+		}
+		out = append(out, pk)
+	}
+	return out
+}
+
+// put records a freshly-discovered plan for (dst, minHops). Called AFTER a
+// caller's own fetchBestRoutes succeeds, so the cache is populated as a
+// side-effect of the first group that plans a leg to this exit and then serves
+// every later group/leg. Deduplicates by first-hop transport (two plans with
+// the same first hop are, for mux purposes, the same leg). Nil/empty forward
+// plans are ignored.
+func (p *warmRoutePool) put(dst cipher.PubKey, minHops uint16, fwd, rev []routing.Hop) {
+	if p == nil || len(fwd) == 0 {
+		return
+	}
+	key := planKey{dst: dst, minHops: minHops}
+	plan := routePlan{
+		fwd:     append([]routing.Hop(nil), fwd...),
+		rev:     append([]routing.Hop(nil), rev...),
+		firstTp: fwd[0].TpID,
+		inter:   planIntermediates(fwd),
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	b := p.byExit[key]
+	now := p.now()
+	if b == nil || now.Sub(b.filled) > p.ttl {
+		// Fresh bucket (new exit, or the old one expired): start clean so a
+		// stale plan can't outlive its TTL by being appended alongside fresh
+		// ones under the same filled stamp.
+		b = &planBucket{plans: make([]routePlan, 0, 4)}
+		p.byExit[key] = b
+	}
+	for i := range b.plans {
+		if b.plans[i].firstTp == plan.firstTp {
+			b.plans[i] = plan // refresh in place
+			b.filled = now
+			return
+		}
+	}
+	if len(b.plans) >= warmPlanBucketCap {
+		b.plans = b.plans[1:] // drop oldest, bounded memory
+	}
+	b.plans = append(b.plans, plan)
+	b.filled = now
+	p.stored++
+}
+
+// disjointFrom reports whether plan's first-hop transport and intermediates
+// avoid the caller's per-group exclude sets — the same disjointness the caller
+// would demand of a freshly-fetched leg.
+func (pl *routePlan) disjointFrom(excludeTps map[uuid.UUID]struct{}, excludePKs map[cipher.PubKey]struct{}) bool {
+	if _, bad := excludeTps[pl.firstTp]; bad {
+		return false
+	}
+	for _, pk := range pl.inter {
+		if _, bad := excludePKs[pk]; bad {
+			return false
+		}
+	}
+	return true
+}
+
+// bestPlan returns a cached, non-stale plan to (dst, minHops) whose first-hop
+// transport and intermediates are disjoint from the caller's exclude sets, or
+// ok=false on a miss. The returned slices are the cached copies — callers feed
+// them into a setup-node Dial (read-only) and run their usual validMuxLeg gate,
+// so aliasing is safe. A miss is a clean signal to fall back to fetchBestRoutes.
+func (p *warmRoutePool) bestPlan(dst cipher.PubKey, minHops uint16, excludeTps []uuid.UUID, excludePKs []cipher.PubKey) (fwd, rev []routing.Hop, ok bool) {
+	if p == nil {
+		return nil, nil, false
+	}
+	key := planKey{dst: dst, minHops: minHops}
+	exTp := make(map[uuid.UUID]struct{}, len(excludeTps))
+	for _, id := range excludeTps {
+		exTp[id] = struct{}{}
+	}
+	exPK := make(map[cipher.PubKey]struct{}, len(excludePKs))
+	for _, pk := range excludePKs {
+		exPK[pk] = struct{}{}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	b := p.byExit[key]
+	if b == nil || p.now().Sub(b.filled) > p.ttl {
+		if b != nil {
+			delete(p.byExit, key) // evict expired bucket
+		}
+		p.misses++
+		return nil, nil, false
+	}
+	for i := range b.plans {
+		if b.plans[i].disjointFrom(exTp, exPK) {
+			p.hits++
+			return b.plans[i].fwd, b.plans[i].rev, true
+		}
+	}
+	p.misses++
+	return nil, nil, false
+}
+
+// invalidate drops all cached plans to one exit — called when a transport to a
+// relevant peer comes or goes (a register/deregister may open or close a
+// disjoint path). Cheap; the next dial re-fills from a fresh fetch.
+func (p *warmRoutePool) invalidate(dst cipher.PubKey) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for k := range p.byExit {
+		if k.dst == dst {
+			delete(p.byExit, k)
+		}
+	}
+}
+
+// invalidateAll drops every cached plan (e.g. a bulk transport-set change).
+func (p *warmRoutePool) invalidateAll() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.byExit = make(map[planKey]*planBucket)
+}
+
+// warmPoolStats is a point-in-time snapshot for observability.
+type warmPoolStats struct {
+	Exits  int
+	Plans  int
+	Hits   uint64
+	Misses uint64
+	Stored uint64
+}
+
+func (p *warmRoutePool) stats() warmPoolStats {
+	if p == nil {
+		return warmPoolStats{}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	s := warmPoolStats{Hits: p.hits, Misses: p.misses, Stored: p.stored}
+	s.Exits = len(p.byExit)
+	for _, b := range p.byExit {
+		s.Plans += len(b.plans)
+	}
+	return s
+}

--- a/pkg/router/warm_route_pool_test.go
+++ b/pkg/router/warm_route_pool_test.go
@@ -1,0 +1,174 @@
+// pkg/router/warm_route_pool_test.go
+package router
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// warmTwoHop builds a src->mid->dst forward plan (one intermediate = mid) whose
+// first hop rides transport firstTp.
+func warmTwoHop(src, mid, dst cipher.PubKey, firstTp, secondTp uuid.UUID) []routing.Hop {
+	return []routing.Hop{
+		{TpID: firstTp, From: src, To: mid},
+		{TpID: secondTp, From: mid, To: dst},
+	}
+}
+
+func TestWarmRoutePool_HitAfterPut(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	mid, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	tp1, tp2 := uuid.New(), uuid.New()
+
+	p := newWarmRoutePool(time.Minute)
+	fwd := warmTwoHop(src, mid, dst, tp1, tp2)
+	rev := warmTwoHop(dst, mid, src, tp2, tp1)
+	p.put(dst, 2, fwd, rev)
+
+	// A second group dialing the same exit with no excludes gets the cached plan.
+	gotF, gotR, ok := p.bestPlan(dst, 2, nil, nil)
+	require.True(t, ok)
+	require.Equal(t, tp1, gotF[0].TpID)
+	require.Len(t, gotR, 2)
+
+	s := p.stats()
+	require.Equal(t, 1, s.Exits)
+	require.Equal(t, 1, s.Plans)
+	require.Equal(t, uint64(1), s.Hits)
+}
+
+func TestWarmRoutePool_MissOnEmpty(t *testing.T) {
+	dst, _ := cipher.GenerateKeyPair()
+	p := newWarmRoutePool(time.Minute)
+	_, _, ok := p.bestPlan(dst, 2, nil, nil)
+	require.False(t, ok)
+	require.Equal(t, uint64(1), p.stats().Misses)
+}
+
+func TestWarmRoutePool_MinHopsIsPartOfKey(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	mid, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	tp1, tp2 := uuid.New(), uuid.New()
+
+	p := newWarmRoutePool(time.Minute)
+	p.put(dst, 1, warmTwoHop(src, mid, dst, tp1, tp2), nil)
+
+	// A min-hops=2 dial must NOT be served the min-hops=1 plan.
+	_, _, ok := p.bestPlan(dst, 2, nil, nil)
+	require.False(t, ok)
+	_, _, ok = p.bestPlan(dst, 1, nil, nil)
+	require.True(t, ok)
+}
+
+func TestWarmRoutePool_ExcludeTransport(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	mid, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	tp1, tp2 := uuid.New(), uuid.New()
+
+	p := newWarmRoutePool(time.Minute)
+	p.put(dst, 2, warmTwoHop(src, mid, dst, tp1, tp2), nil)
+
+	// The only cached plan rides tp1; a caller already using tp1 as a leg must
+	// get a miss (the pool must not hand back a leg the group already has).
+	_, _, ok := p.bestPlan(dst, 2, []uuid.UUID{tp1}, nil)
+	require.False(t, ok)
+}
+
+func TestWarmRoutePool_ExcludeIntermediate(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	midA, _ := cipher.GenerateKeyPair()
+	midB, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	tpA1, tpA2 := uuid.New(), uuid.New()
+	tpB1, tpB2 := uuid.New(), uuid.New()
+
+	p := newWarmRoutePool(time.Minute)
+	p.put(dst, 2, warmTwoHop(src, midA, dst, tpA1, tpA2), nil)
+	p.put(dst, 2, warmTwoHop(src, midB, dst, tpB1, tpB2), nil)
+
+	// A group whose existing leg already goes through midA must be handed the
+	// midB plan (first-hop-disjoint growth from cache).
+	gotF, _, ok := p.bestPlan(dst, 2, []uuid.UUID{tpA1}, []cipher.PubKey{midA})
+	require.True(t, ok)
+	require.Equal(t, tpB1, gotF[0].TpID)
+	require.Equal(t, midB, gotF[0].To)
+
+	// Exclude BOTH intermediates -> no disjoint plan left -> miss.
+	_, _, ok = p.bestPlan(dst, 2, nil, []cipher.PubKey{midA, midB})
+	require.False(t, ok)
+}
+
+func TestWarmRoutePool_TTLExpiry(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	mid, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	tp1, tp2 := uuid.New(), uuid.New()
+
+	now := time.Unix(1_000_000, 0)
+	p := newWarmRoutePool(30 * time.Second)
+	p.now = func() time.Time { return now }
+	p.put(dst, 2, warmTwoHop(src, mid, dst, tp1, tp2), nil)
+
+	_, _, ok := p.bestPlan(dst, 2, nil, nil)
+	require.True(t, ok)
+
+	now = now.Add(31 * time.Second) // past TTL
+	_, _, ok = p.bestPlan(dst, 2, nil, nil)
+	require.False(t, ok, "expired plan must not be served")
+	require.Equal(t, 0, p.stats().Exits, "expired bucket evicted on read")
+}
+
+func TestWarmRoutePool_DedupByFirstHop(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	mid, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	tp1, tp2, tp2b := uuid.New(), uuid.New(), uuid.New()
+
+	p := newWarmRoutePool(time.Minute)
+	p.put(dst, 2, warmTwoHop(src, mid, dst, tp1, tp2), nil)
+	p.put(dst, 2, warmTwoHop(src, mid, dst, tp1, tp2b), nil) // same first hop tp1
+
+	require.Equal(t, 1, p.stats().Plans, "same first-hop transport must dedup")
+}
+
+func TestWarmRoutePool_Invalidate(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	mid, _ := cipher.GenerateKeyPair()
+	dstA, _ := cipher.GenerateKeyPair()
+	dstB, _ := cipher.GenerateKeyPair()
+	tp1, tp2 := uuid.New(), uuid.New()
+
+	p := newWarmRoutePool(time.Minute)
+	p.put(dstA, 2, warmTwoHop(src, mid, dstA, tp1, tp2), nil)
+	p.put(dstB, 2, warmTwoHop(src, mid, dstB, tp1, tp2), nil)
+
+	p.invalidate(dstA)
+	_, _, ok := p.bestPlan(dstA, 2, nil, nil)
+	require.False(t, ok)
+	_, _, ok = p.bestPlan(dstB, 2, nil, nil)
+	require.True(t, ok, "invalidate(dstA) must not touch dstB")
+
+	p.invalidateAll()
+	require.Equal(t, 0, p.stats().Exits)
+}
+
+func TestWarmRoutePool_NilSafe(t *testing.T) {
+	var p *warmRoutePool
+	require.NotPanics(t, func() {
+		p.put(cipher.PubKey{}, 1, nil, nil)
+		_, _, ok := p.bestPlan(cipher.PubKey{}, 1, nil, nil)
+		require.False(t, ok)
+		p.invalidate(cipher.PubKey{})
+		p.invalidateAll()
+		_ = p.stats()
+	})
+}


### PR DESCRIPTION
Today each mux route group keeps its own warm-standby leg pool and runs its own self-heal/rotation dial loop. With N tunnels to the same exit that is N× the route-finder planning work and N× the setup-node dial storm.

This RFC (`docs/design/shared-warm-route-pool.md`) works out what can actually be shared. Only two of a leg`\s three layers are shareable: the first-hop transport (already deduped by the transport manager) and the route plan (the `[]Hop` path, no route IDs). The route-ID-bearing intermediate rules are minted per group by the setup-node dial and bound to that group`\s descriptor, so genuinely pooling a fully-built warm route is a large refactor (documented as a later, capability-negotiated trunk phase). The tractable first step is a shared route-*plan* cache.

Phase-1 prototype: a visor-level `warmRoutePool` caches the disjoint plans discovered for an exit and lends them to any group/leg/tick dialing an aux leg to that same exit, removing the repeated route-finder work. `addOneAuxLeg` consults then populates it around `fetchBestRoutes`; the cached plan flows through the unchanged `validMuxLeg` gate and setup-node dial, so a stale hit or a miss can only cost a fallback, never change the leg that gets built. It is initiator-local (no wire change, no flag gate, always on) and unit-tested.

Phase 2 (shared warm-transport pin) and phase 3 (capability-negotiated route-ID trunk) are specified in the RFC but not implemented here. Not for merge yet — opening for review of the direction.