### PR TITLE
feat(proxystatus): GPU route-graph view on status.skysocks

### DIFF
--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -73,11 +73,19 @@ func Render(snap Snapshot) []byte {
 	writeLiveRegion(&b, snap)
 	b.WriteString(`</main>`)
 
+	// The GPU route-graph view sits between the live region and the control seam.
+	// It is STATIC (outside <main id="live">) so its WebGL context/layout survive
+	// the live swaps; the live region only restreams the #rgdata JSON it feeds on.
+	if live {
+		writeGraphSection(&b)
+	}
+
 	writeControlSeam(&b, snap)
 	writeFooter(&b, snap)
 
 	if live {
 		b.WriteString(liveScript)
+		b.WriteString(graphScript)
 	}
 
 	b.WriteString("</body></html>")
@@ -183,6 +191,52 @@ const liveScript = `<script>(function(){var t,ws,pend=null,last=null,pv=null;` +
 	`var el0=document.getElementById("live");if(el0){meters(el0);var lg0=el0.querySelector("pre.log");if(lg0){lg0.scrollTop=lg0.scrollHeight;}}` +
 	`document.body.classList.add("js");connect();})();</script>`
 
+// graphScript drives the GPU route-graph view. It reuses the network
+// visualizer's engine WITHOUT any new wasm: it loads the one wasm-visor blob in
+// its "netview" role (globalThis.__SKYWIRE_WASM_ROLE__="netview" before go.run,
+// exactly as pkg/tpviz/ui/src/cosmos-go-graph.ts does), which publishes the
+// generic cosmos-go graph API on globalThis.tpvizGL (pkg/tpviz/wasmgl.Register),
+// then drives tpvizGL.init/setData with the route subgraph the page emits in the
+// #rgdata JSON. /main.wasm and /wasm_exec.js are served same-origin by the
+// skysocks status handler (pkg/skysocks/client.go) out of pkg/wasmhv/wasmbin.
+//
+// Lazy: the ~3 MB blob is fetched only the first time the graph view is opened,
+// so a user who stays on the tree pays nothing. Live: a MutationObserver on the
+// live region re-reads #rgdata on each ~1s push and refreshes the hover-tooltip
+// data every time, but re-feeds the force layout (setData) ONLY when the
+// topology signature changes — so watching bytes tick doesn't relayout the
+// graph. The canvas is static (outside the swapped region) so the settled layout
+// and WebGL context persist. setRouteView flips a <body> class (static, survives
+// swaps) that CSS uses to show/hide the tree vs graph and to light the toggle.
+const graphScript = `<script>(function(){` +
+	`var booted=false,booting=false,nodes=[],sig=null,io=null;` +
+	`function gl(){return window.tpvizGL;}` +
+	`function data(){var el=document.getElementById("rgdata");if(!el){return null;}try{return JSON.parse(el.textContent||"null");}catch(e){return null;}}` +
+	`function tip(){return document.getElementById("rgtip");}` +
+	`function showTip(i,x,y){var n=nodes[i],t=tip();if(!n||!t){return;}t.textContent=n.tip||"";t.style.display="block";t.style.left=(x+14)+"px";t.style.top=(y+14)+"px";}` +
+	`function hideTip(){var t=tip();if(t){t.style.display="none";}}` +
+	`function onEvent(kind,index){var a=arguments;if(kind==="over"){showTip(index,a[2],a[3]);}else if(kind==="out"||kind==="bgclick"){hideTip();}}` +
+	`function payload(d){var n=d.nodes.length,pc=new Array(n),ps=new Float32Array(n),idx={},i;` +
+	`for(i=0;i<n;i++){var nd=d.nodes[i];idx[nd.id]=i;pc[i]=nd.color;ps[i]=nd.size;}` +
+	`var L=d.links.length,lk=new Float32Array(L*2),lw=new Float32Array(L),lc=new Array(L),w=0,j;` +
+	`for(j=0;j<L;j++){var e=d.links[j],s=idx[e.source],t=idx[e.target];if(s===undefined||t===undefined){continue;}lk[w*2]=s;lk[w*2+1]=t;lc[w]=e.color;lw[w]=e.width;w++;}` +
+	`return {positions:new Float32Array(0),pointColors:pc,pointSizes:ps,links:lk.subarray(0,w*2),linkColors:lc.slice(0,w),linkWidths:lw.subarray(0,w),grouped:false,boundaries:[]};}` +
+	`function apply(force){var d=data();if(!d){return;}nodes=d.nodes||[];var g=gl();if(!g){return;}if(force||d.sig!==sig){sig=d.sig;g.setData(payload(d));}}` +
+	`function observe(){if(io){return;}var live=document.getElementById("live");if(!live){return;}io=new MutationObserver(function(){apply(false);});io.observe(live,{childList:true,subtree:true});}` +
+	`function fail(){var c=document.getElementById("rgcanvas");if(c){c.innerHTML='<div class="rgfail">The GPU graph view failed to load (main.wasm). The tree view shows the same routes.</div>';}}` +
+	`function ready(){var g=gl();if(g&&g.ready){booted=true;booting=false;if(!g.init("rgcanvas",onEvent)){setTimeout(function(){g.init("rgcanvas",onEvent);apply(true);observe();},80);}else{apply(true);observe();}return true;}return false;}` +
+	`function boot(){if(booted||booting){return;}booting=true;window.__SKYWIRE_WASM_ROLE__="netview";` +
+	`var s=document.createElement("script");s.src="/wasm_exec.js";s.onerror=function(){booting=false;fail();};` +
+	`s.onload=function(){var G=window.Go;if(!G){booting=false;fail();return;}var go=new G();` +
+	`WebAssembly.instantiateStreaming(fetch("/main.wasm"),go.importObject).then(function(res){go.run(res.instance);` +
+	`var tries=0;(function wait(){if(ready()){return;}if(++tries>150){booting=false;fail();return;}setTimeout(wait,20);})();` +
+	`}).catch(function(){booting=false;fail();});};document.head.appendChild(s);}` +
+	`window.setRouteView=function(v){try{localStorage.setItem("rv",v);}catch(e){}var g=(v==="graph");` +
+	`document.body.classList.toggle("gv-graph",g);document.body.classList.toggle("gv-tree",!g);` +
+	`if(g){if(booted){var gg=gl();if(gg){setTimeout(function(){gg.fit();},60);}}else{boot();}}};` +
+	`var v="tree";try{v=localStorage.getItem("rv")||"tree";}catch(e){}setRouteView(v);` +
+	`})();</script>`
+
 // writeLiveRegion writes the dynamic status content (pills, per-leg mux, events,
 // recent log) shared by Render (page shell) and RenderFragment (SSE push).
 func writeLiveRegion(b *strings.Builder, snap Snapshot) {
@@ -224,6 +278,17 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 	fmt.Fprintf(b, `<span class="stat" data-bytes="up" data-val="%d" hidden></span>`, totSent)
 	fmt.Fprintf(b, `<span class="stat" data-bytes="down" data-val="%d" hidden></span>`, totRecv)
 
+	// View toggle (skysocks only): the same route group is shown two ways — the
+	// ASCII bilateral tree (default, no-JS) and a GPU force-directed GRAPH
+	// (routegraph.go → cosmos-go, the network visualizer's engine, served from
+	// the one wasm-visor "netview" blob). The tree is wrapped in .muxtree so the
+	// toggle can hide it when the graph view is active; the graph itself lives in
+	// its own static section (writeGraphSection) whose WebGL context must survive
+	// the ~1s live-region swaps, and is fed the route subgraph from the
+	// #rgdata JSON emitted below (restreamed with the live region).
+	writeViewToggle(b, snap)
+	b.WriteString(`<div class="muxtree">`)
+
 	// The route tree itself: ONE shared bilateral model (pkg/proxystatus.RouteTree)
 	// rendered by pkg/bitree — the exact model + geometry `skywire cli proxy tree`
 	// prints, so the page and the terminal never drift. Root = this visor (right-
@@ -262,7 +327,62 @@ func writeMuxSection(b *strings.Builder, snap Snapshot) {
 	// active green, standby amber) — no separate swatch dot.
 	writeTreeLegend(b)
 	b.WriteString(`<p class="hint">The same tree prints from <code>skywire cli proxy tree</code>; for a live chart use ` +
-		`<code>skywire cli proxy mux plot</code>.</p></section>`)
+		`<code>skywire cli proxy mux plot</code>.</p>`)
+	b.WriteString(`</div>`) // .muxtree
+	// The route subgraph the GPU graph view renders, as inert JSON inside the live
+	// region so each ~1s WebSocket push restreams it; the static driver
+	// (graphScript) re-reads it and re-feeds cosmos-go only when the topology
+	// signature changes (routegraph.go topoSig), so live metric updates don't jerk
+	// the force layout. Skysocks only (the only surface that serves the wasm blob).
+	if snap.Surface == SurfaceSkysocks {
+		fmt.Fprintf(b, `<script type="application/json" id="rgdata">%s</script>`, RouteGraphJSON(snap))
+	}
+	b.WriteString(`</section>`)
+}
+
+// writeViewToggle emits the tree/graph view switch (skysocks only, and only when
+// there is a route to graph). The buttons flip a class on <body> — a STATIC
+// element that survives the live-region innerHTML swaps — so the choice sticks
+// across the ~1s pushes even though the buttons themselves are re-rendered each
+// push; their active styling is derived from the body class in CSS. setRouteView
+// (graphScript) also persists the choice in localStorage and lazily boots the
+// wasm the first time the graph is shown.
+func writeViewToggle(b *strings.Builder, snap Snapshot) {
+	if snap.Surface != SurfaceSkysocks || !hasRouteGraph(snap) {
+		return
+	}
+	b.WriteString(`<div class="vtoggle" role="tablist" aria-label="route view">` +
+		`<button type="button" class="vt-tree" onclick="setRouteView('tree')">tree</button>` +
+		`<button type="button" class="vt-graph" onclick="setRouteView('graph')">graph</button>` +
+		`</div>`)
+}
+
+// writeGraphSection emits the STATIC route-graph section (skysocks only): the
+// cosmos-go canvas container, a color legend, and the fixed hover tooltip. It
+// lives OUTSIDE <main id="live"> on purpose — the WebGL context and the settled
+// force layout must persist across the live region's ~1s innerHTML swaps, so the
+// container is never re-created; only the #rgdata JSON inside the live region
+// updates, and the driver re-feeds the engine in place. Hidden by default (the
+// tree is the default view); the toggle reveals it.
+func writeGraphSection(b *strings.Builder) {
+	b.WriteString(`<section id="rgraphsec" aria-label="route graph">`)
+	b.WriteString(`<div id="rgcanvas" class="rgcanvas"></div>`)
+	// Legend: the same color language as the tree (source/exit/hop by depth,
+	// per-stream edge accents) plus active/standby edge styling. The swatch words
+	// carry their own color so the coding is self-documenting.
+	b.WriteString(`<div class="rglegend">` +
+		`<span class="rgl src">● source</span>` +
+		`<span class="rgl exit">● exit</span>` +
+		`<span class="rgl hop1">● hop</span>` +
+		`<span class="rgl s0">— stream 0</span>` +
+		`<span class="rgl s1">— stream 1</span>` +
+		`<span class="rgl standby">— standby (dim)</span>` +
+		`</div>`)
+	b.WriteString(`<p class="hint">GPU force-directed graph of this proxy's routes — the same engine (cosmos-go) ` +
+		`as the network visualizer, driving only THIS visor, its hops and the exit. Hover a node for its ` +
+		`transports and per-leg detail; drag to pan, scroll to zoom. Needs WebGL; the tree view above is the ` +
+		`no-JS fallback.</p></section>`)
+	b.WriteString(`<div id="rgtip" class="rgtip" role="tooltip"></div>`)
 }
 
 // writeTreeLegend prints a compact legend BELOW the route tree. The words
@@ -995,6 +1115,28 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`code{color:var(--accent);font-size:11.5px}` +
 	`footer{margin-top:2rem;padding-top:.7rem;border-top:1px solid var(--line);color:var(--muted);font-size:12px}` +
 	`footer a{color:var(--accent);text-decoration:none}footer a:hover{text-decoration:underline}` +
+	// Tree/graph view toggle. The active button is lit from the <body> class the
+	// toggle sets (gv-tree / gv-graph) — a static hook that survives the ~1s live
+	// swaps — rather than any per-render state, so the highlight stays put.
+	`.vtoggle{display:inline-flex;gap:.3rem;margin:.1rem 0 .6rem}` +
+	`.vtoggle button{font:inherit;font-size:11px;padding:.15rem .7rem;border:1px solid var(--line);border-radius:6px;background:transparent;color:var(--muted);cursor:pointer}` +
+	`.vtoggle button:hover{border-color:var(--accent);color:var(--fg)}` +
+	`body.gv-graph .vtoggle .vt-graph,body:not(.gv-graph) .vtoggle .vt-tree{background:var(--accent);border-color:var(--accent);color:#fff}` +
+	// The GPU graph section is hidden until the graph view is chosen; choosing it
+	// hides the ASCII tree (.muxtree) in the live region. The canvas is a fixed,
+	// user-resizable dark GL surface (cosmos paints its own dark background).
+	`#rgraphsec{display:none;margin-top:.2rem}body.gv-graph #rgraphsec{display:block}body.gv-graph .muxtree{display:none}` +
+	`.rgcanvas{position:relative;width:100%;height:30rem;min-height:18rem;border:1px solid var(--line);border-radius:8px;background:#0b1020;overflow:hidden;resize:vertical}` +
+	`.rgfail{padding:1rem;color:var(--warn);font-size:12px}` +
+	// Node hover tooltip: a fixed, pointer-transparent monospace panel positioned
+	// at the cursor by the driver; pre-wrap keeps the multi-line leg detail + full
+	// (untruncated) PK readable.
+	`.rgtip{display:none;position:fixed;z-index:50;max-width:36rem;white-space:pre-wrap;word-break:break-all;pointer-events:none;background:rgba(6,8,20,.96);color:#c7cbe6;border:1px solid var(--line);border-radius:6px;padding:.4rem .55rem;font:11px/1.45 ui-monospace,SFMono-Regular,monospace;box-shadow:0 4px 18px rgba(0,0,0,.5)}` +
+	// Graph legend: the swatch words carry their own tree/stream colors.
+	`.rglegend{display:flex;flex-wrap:wrap;gap:.15rem 1.1rem;font-size:10px;text-transform:uppercase;letter-spacing:.3px;margin-top:.45rem}` +
+	`.rgl{font-weight:600;white-space:nowrap}` +
+	`.rgl.src{color:var(--accent)}.rgl.exit{color:var(--hop-exit)}.rgl.hop1{color:var(--hop1)}` +
+	`.rgl.s0{color:var(--stream0)}.rgl.s1{color:var(--stream1)}.rgl.standby{color:var(--standby)}` +
 	`@media(prefers-color-scheme:light){:root{--bg:#f6f7fb;--fg:#1c1e26;--muted:#4a4f63;--card:#fff;--line:#d3d6e4;--accent:#4149d6;--accent2:#7b3fd0;--ok:#0a7a4c;--warn:#c02a48;--err:#c8102e;--cyan:#0a6c74;--standby:#7a5c00;` +
 	// Re-darken the hop hues for a light background so exit + each hop level stay
 	// legible (the dark-mode brights wash out on white).

--- a/pkg/proxystatus/routegraph.go
+++ b/pkg/proxystatus/routegraph.go
@@ -1,0 +1,420 @@
+// Package proxystatus pkg/proxystatus/routegraph.go c4-app-web
+//
+// RouteGraph projects a surface Snapshot's live route-group state into the small
+// node/edge subgraph the status.skysocks page hands to the GPU force-directed
+// view (github.com/0magnet/cosmos-go, reused from pkg/tpviz/wasmgl via the one
+// wasm-visor "netview" blob). It is the graph counterpart of routetree.go's
+// ASCII tree: the SAME Snapshot data, shaped as a graph rather than a tree.
+//
+// Scope is deliberately SMALL — only the nodes and edges ON the proxy's actual
+// routes: this visor (root), each intermediate hop, and the exit, plus the
+// per-hop transport each leg traverses. It is NOT the whole mesh; an
+// intermediate's other transports are not fetched. A hop PK shared by several
+// legs is ONE node (deduplicated). Edges are colored by their STREAM (tunnel)
+// with the same per-stream accent palette the tree uses, styled active vs
+// standby, and widthed by the leg's live byte-rate.
+//
+// The engine renders points (no on-canvas text), so a node's FULL public key is
+// never truncated on screen — it rides untruncated in the node's hover tooltip
+// (Tip), with a short hex only as the tooltip's heading. The driver JS
+// (render.go graphGLScript) maps this JSON to cosmos-go's typed-array setData
+// payload (positions seeded, colors as CSS strings, links as index pairs).
+package proxystatus
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Route-graph palette. These are the DARK-theme hex values of the page's CSS
+// accent variables (--accent, --hop-exit, --hop1..4, --stream0..4). The GL view
+// is an inherently dark canvas (cosmos BackgroundColor is fixed dark in
+// wasmgl), like tpviz, so the graph uses the dark palette regardless of the
+// page's light/dark theme — matching the network visualizer it is modeled on.
+const (
+	rgRootColor = "#7c83ff" // --accent: this visor (root)
+	rgExitColor = "#ff5c5c" // --hop-exit: the exit (destination)
+)
+
+// rgHopColors cycles the intermediate-hop hues by DEPTH (--hop1..4), the same
+// levels routetree.go colors hop PKs with, so a hop at a given depth reads the
+// same hue in both the tree and the graph.
+var rgHopColors = []string{"#4fc3f7", "#c48cff", "#ffb74d", "#4dd0a0"}
+
+// rgStreamColors cycles the per-STREAM accents (--stream0..4) by tunnel index,
+// so each --tunnels stream's edges read as one colored fan root→exit.
+var rgStreamColors = []string{"#7c9cff", "#ff9e64", "#e879c9", "#4dd0e1", "#c3a6ff"}
+
+// Node display sizes (cosmos point pixel radii). Root and exit are emphasized
+// over the intermediate hops so the two endpoints of every route stand out.
+const (
+	rgRootSize = 15.0
+	rgExitSize = 14.0
+	rgHopSize  = 9.0
+)
+
+// rgNode is one deduplicated node — this visor, an intermediate hop, or the
+// exit. ID is the FULL public key (the dedup key and the driver's index key);
+// PK repeats it for the tooltip's copy affordance; Label is a short hex heading
+// only. Color/Size drive the point; Tip is the multi-line hover text.
+type rgNode struct {
+	ID    string  `json:"id"`
+	Label string  `json:"label"`
+	Role  string  `json:"role"` // "root" | "hop" | "exit"
+	Color string  `json:"color"`
+	Size  float64 `json:"size"`
+	Tip   string  `json:"tip"`
+	PK    string  `json:"pk"`
+}
+
+// rgLink is one hop segment of a leg's forward route (from → to). Color is the
+// leg's STREAM accent; Width reflects the leg's live byte-rate; Active is false
+// for a standby leg (the driver dims it). Stream is the tunnel index; Tip is the
+// segment's transport/leg detail (also folded into each endpoint node's tip,
+// since the engine hovers points, not links).
+type rgLink struct {
+	Source string  `json:"source"`
+	Target string  `json:"target"`
+	Color  string  `json:"color"`
+	Width  float64 `json:"width"`
+	Active bool    `json:"active"`
+	Stream int     `json:"stream"`
+	Tip    string  `json:"tip"`
+}
+
+// rgGraph is the whole route subgraph. Sig is a topology signature (node ids +
+// link endpoints, order-independent) the driver uses to decide when a live push
+// actually changed the SHAPE — so it only re-runs the force layout on a
+// topology change, not on every ~1s metric update (which would jerk the graph).
+type rgGraph struct {
+	Nodes []rgNode `json:"nodes"`
+	Links []rgLink `json:"links"`
+	Sig   string   `json:"sig"`
+}
+
+// effectiveTunnels yields the stream-level route groups to graph: the snapshot's
+// Tunnels when present, else a single synthetic tunnel wrapping the flat Legs
+// list (a caller that projected only one route group). Empty when there is
+// nothing routed.
+func effectiveTunnels(snap Snapshot) []Tunnel {
+	if len(snap.Tunnels) > 0 {
+		return snap.Tunnels
+	}
+	if len(snap.Legs) == 0 {
+		return nil
+	}
+	exit := ""
+	for _, l := range snap.Legs {
+		if l.RemotePK != "" {
+			exit = l.RemotePK
+			break
+		}
+	}
+	return []Tunnel{{Index: 0, ExitPK: exit, Legs: snap.Legs}}
+}
+
+// hasRouteGraph reports whether snap has any alive route to graph.
+func hasRouteGraph(snap Snapshot) bool {
+	for _, t := range effectiveTunnels(snap) {
+		for _, l := range t.Legs {
+			if l.Alive {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// nodeAcc accumulates a node's role, hop depth (for color) and incident-leg tip
+// lines as the route walk visits it from multiple legs.
+type nodeAcc struct {
+	node   *rgNode
+	lines  []string
+	level  int // shallowest intermediate hop depth (1-based); 0 for root/exit
+	isRoot bool
+	isExit bool
+}
+
+// RouteGraphJSON builds the route subgraph as the JSON the status page embeds in
+// its <script type="application/json" id="rgdata"> and the cosmos-go driver
+// consumes. Dead legs are pruned (matching the tree). Returns a valid, possibly
+// empty ({"nodes":[],"links":[],"sig":""}) document — never nil — so the driver
+// can always parse it.
+func RouteGraphJSON(snap Snapshot) []byte {
+	g := buildRouteGraph(snap)
+	b, err := json.Marshal(g) // default HTML-escaping neutralizes any </script>
+	if err != nil || b == nil {
+		return []byte(`{"nodes":[],"links":[],"sig":""}`)
+	}
+	return b
+}
+
+// buildRouteGraph walks the Snapshot's tunnels/legs/hops into the dedup'd
+// node/link model. Nodes are kept in first-encounter order (deterministic:
+// root, then per stream in order, per leg in tree order, per hop). Each hop
+// segment becomes a link and its detail line is folded into BOTH endpoint
+// nodes' tooltips.
+func buildRouteGraph(snap Snapshot) rgGraph {
+	if !hasRouteGraph(snap) {
+		return rgGraph{Nodes: []rgNode{}, Links: []rgLink{}}
+	}
+	tunnels := effectiveTunnels(snap)
+	src := treeSrc(snap)
+	nStreams := len(tunnels)
+
+	accByPK := map[string]*nodeAcc{}
+	var order []*nodeAcc
+	get := func(pk string) *nodeAcc {
+		if a, ok := accByPK[pk]; ok {
+			return a
+		}
+		a := &nodeAcc{node: &rgNode{ID: pk, PK: pk, Label: shortPK(pk), Role: "hop"}}
+		accByPK[pk] = a
+		order = append(order, a)
+		return a
+	}
+
+	root := get(src)
+	root.isRoot = true
+
+	var links []rgLink
+	maxRate := 0.0
+
+	for _, t := range tunnels {
+		streamIdx := t.Index
+		for _, l := range t.Legs {
+			if !l.Alive {
+				continue
+			}
+			rate := l.GoodputUpBps + l.GoodputDownBps
+			if rate > maxRate {
+				maxRate = rate
+			}
+			hops := l.Hops
+			if len(hops) == 0 {
+				// No recorded path: a single edge src → remote(exit).
+				exitPK := l.RemotePK
+				if exitPK == "" {
+					exitPK = t.ExitPK
+				}
+				if exitPK == "" {
+					continue
+				}
+				ex := get(exitPK)
+				ex.isExit = true
+				line := legLine(streamIdx, l, "", "", l.TpType, l.LatencyMS)
+				root.lines = append(root.lines, line)
+				ex.lines = append(ex.lines, line)
+				links = append(links, rgLink{
+					Source: src, Target: exitPK, Stream: streamIdx,
+					Color: streamColor(streamIdx), Active: !l.Standby, Width: rate, Tip: line,
+				})
+				continue
+			}
+			n := len(hops)
+			for i, h := range hops {
+				isExit := i == n-1
+				to := get(h.To)
+				if isExit {
+					to.isExit = true
+				} else if lvl := i + 1; to.level == 0 || lvl < to.level {
+					to.level = lvl
+				}
+				from := h.From
+				if from == "" {
+					from = src
+				}
+				line := legLine(streamIdx, l, h.TpID, h.To, h.TpType, h.LatencyMS)
+				get(from).lines = append(get(from).lines, line)
+				to.lines = append(to.lines, line)
+				links = append(links, rgLink{
+					Source: from, Target: h.To, Stream: streamIdx,
+					Color: streamColor(streamIdx), Active: !l.Standby, Width: rate, Tip: line,
+				})
+			}
+		}
+	}
+
+	// Finalize node visuals + tooltips.
+	nodes := make([]rgNode, 0, len(order))
+	for _, a := range order {
+		switch {
+		case a.isRoot:
+			a.node.Role, a.node.Color, a.node.Size, a.node.Label = "root", rgRootColor, rgRootSize, "source"
+		case a.isExit:
+			a.node.Role, a.node.Color, a.node.Size = "exit", rgExitColor, rgExitSize
+		default:
+			a.node.Role, a.node.Color, a.node.Size = "hop", hopColorFor(a.level), rgHopSize
+		}
+		a.node.Tip = nodeTip(a, nStreams)
+		nodes = append(nodes, *a.node)
+	}
+
+	// Normalize link widths from the byte-rates into a readable pixel range;
+	// standby legs are drawn dim + thin regardless of rate.
+	for i := range links {
+		links[i].Width = linkWidth(links[i].Width, maxRate, links[i].Active)
+		if !links[i].Active {
+			links[i].Color = dimColor(links[i].Color)
+		}
+	}
+
+	return rgGraph{Nodes: nodes, Links: links, Sig: topoSig(nodes, links)}
+}
+
+// nodeTip renders a node's hover text: a role heading (with a short PK), the
+// FULL public key on its own line (never truncated), and the routes/transports
+// incident to this node.
+func nodeTip(a *nodeAcc, nStreams int) string {
+	var b strings.Builder
+	role := a.node.Role
+	fmt.Fprintf(&b, "%s · %s\n%s", strings.ToUpper(role), shortPK(a.node.ID), a.node.ID)
+	if len(a.lines) > 0 {
+		b.WriteString("\nroutes here:")
+		for _, ln := range a.lines {
+			b.WriteString("\n  ")
+			b.WriteString(ln)
+		}
+	}
+	_ = nStreams
+	return b.String()
+}
+
+// legLine is one incident-leg detail line: stream, R[idx], state, direction,
+// transport (type + id), hop rtt, route rtt, and the leg's cumulative ↑/↓ bytes
+// with live rate. Shown in the endpoint nodes' tooltips (the engine hovers
+// points, not links) and carried on the link's own Tip.
+func legLine(streamIdx int, l Leg, tpID, to, tpType string, hopRTT float64) string {
+	state := "active"
+	if l.Standby {
+		state = "standby"
+	}
+	dir := "multihop"
+	if l.Direct {
+		dir = "direct"
+	}
+	tp := "[" + orDash(tpType) + "]"
+	if tpID != "" {
+		tp += " " + tpID
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "s%d R[%d] %s %s · %s · hop %s · route %s · ↑%s(%s) ↓%s(%s)",
+		streamIdx, l.Index, state, dir, tp,
+		tpRTT(hopRTT), routeRTTCompact(l.RouteLatencyMS),
+		compactBytes(l.SentBytes), compactRate(l.GoodputUpBps),
+		compactBytes(l.RecvBytes), compactRate(l.GoodputDownBps))
+	_ = to
+	return b.String()
+}
+
+// streamColor is the per-stream accent for a tunnel index (cycling the palette).
+func streamColor(idx int) string {
+	i := ((idx % len(rgStreamColors)) + len(rgStreamColors)) % len(rgStreamColors)
+	return rgStreamColors[i]
+}
+
+// hopColorFor is the intermediate-hop color at a given depth (cycling the hop
+// palette), matching routetree.go's per-depth hop coloring.
+func hopColorFor(level int) string {
+	if level < 1 {
+		level = 1
+	}
+	return rgHopColors[(level-1)%len(rgHopColors)]
+}
+
+// linkWidth maps a leg's byte-rate to a cosmos link width. Active legs scale
+// 1.0..3.5 with their share of the busiest leg's rate (so the fattest edge is
+// the fastest); standby legs are a thin constant.
+func linkWidth(rate, maxRate float64, active bool) float64 {
+	if !active {
+		return 0.6
+	}
+	if maxRate <= 0 || rate <= 0 {
+		return 1.0
+	}
+	return 1.0 + rate/maxRate*2.5
+}
+
+// dimColor turns a "#rrggbb" accent into a translucent rgba() so a standby
+// leg's edge recedes behind the active ones. cosmos-go's GetRgbaColor parses
+// rgba() strings. A non-hex input is returned unchanged.
+func dimColor(hex string) string {
+	r, g, bl, ok := parseHexRGB(hex)
+	if !ok {
+		return hex
+	}
+	return fmt.Sprintf("rgba(%d,%d,%d,0.4)", r, g, bl)
+}
+
+// parseHexRGB parses "#rrggbb" into 0..255 components.
+func parseHexRGB(s string) (r, g, b int, ok bool) {
+	s = strings.TrimPrefix(strings.TrimSpace(s), "#")
+	if len(s) != 6 {
+		return 0, 0, 0, false
+	}
+	v := func(i int) (int, bool) {
+		var n int
+		for _, c := range s[i : i+2] {
+			switch {
+			case c >= '0' && c <= '9':
+				n = n*16 + int(c-'0')
+			case c >= 'a' && c <= 'f':
+				n = n*16 + int(c-'a') + 10
+			case c >= 'A' && c <= 'F':
+				n = n*16 + int(c-'A') + 10
+			default:
+				return 0, false
+			}
+		}
+		return n, true
+	}
+	r, ok1 := v(0)
+	g, ok2 := v(2)
+	b, ok3 := v(4)
+	return r, g, b, ok1 && ok2 && ok3
+}
+
+// shortPK is a short hex heading for a node's tooltip — a prefix only, never
+// shown on the canvas and always paired with the full PK on the next line, so no
+// truncated key is ever presented as complete. "this visor" (the src fallback)
+// passes through unchanged.
+func shortPK(pk string) string {
+	pk = strings.TrimSpace(pk)
+	if len(pk) <= 8 || strings.Contains(pk, " ") {
+		return pk
+	}
+	return pk[:8]
+}
+
+// topoSig is an order-independent signature of the graph's SHAPE (node ids +
+// link endpoints), so the live driver re-runs the force layout only when the
+// topology actually changes, not on every metric refresh.
+func topoSig(nodes []rgNode, links []rgLink) string {
+	ids := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		ids = append(ids, n.ID)
+	}
+	pairs := make([]string, 0, len(links))
+	for _, l := range links {
+		// Order-independent per edge so a reordering of equal edges is not a change.
+		if l.Source <= l.Target {
+			pairs = append(pairs, l.Source+">"+l.Target)
+		} else {
+			pairs = append(pairs, l.Target+">"+l.Source)
+		}
+	}
+	sortStrings(ids)
+	sortStrings(pairs)
+	return strings.Join(ids, ",") + "|" + strings.Join(pairs, ",")
+}
+
+// sortStrings is a tiny in-place insertion sort (avoids importing sort here for
+// two short slices).
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/pkg/proxystatus/routegraph_test.go
+++ b/pkg/proxystatus/routegraph_test.go
@@ -1,0 +1,206 @@
+package proxystatus
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// sample route PKs (full, never truncated).
+const (
+	rgSrc  = "02aa11223344556677889900aabbccddeeff00112233445566778899aabbccddee"
+	rgExit = "0311223344556677889900aabbccddeeff00112233445566778899aabbccddeeff"
+	rgHopA = "03bb223344556677889900aabbccddeeff00112233445566778899aabbccddeeff"
+)
+
+func hop(id, from, to, typ string, rtt float64) Hop {
+	return Hop{TpID: id, From: from, To: to, TpType: typ, LatencyMS: rtt}
+}
+
+// twoStreamSnap is a multi-stream snapshot: two tunnels, each with a direct leg
+// and a multihop leg through a SHARED intermediate (rgHopA) to a SHARED exit —
+// so the graph must dedup rgHopA and rgExit to one node each. One leg is standby.
+func twoStreamSnap() Snapshot {
+	directLeg := func(idx int, standby bool) Leg {
+		return Leg{Index: idx, RemotePK: rgExit, Direct: true, Alive: true, Standby: standby,
+			LatencyMS: 42, RouteLatencyMS: 42, SentBytes: 2048, RecvBytes: 1024,
+			GoodputUpBps: 800, GoodputDownBps: 400,
+			Hops: []Hop{hop("tp-direct-"+string(rune('0'+idx)), rgSrc, rgExit, "stcpr", 42)}}
+	}
+	multiLeg := func(idx int, standby bool) Leg {
+		return Leg{Index: idx, RemotePK: rgExit, Direct: false, Alive: true, Standby: standby,
+			LatencyMS: 30, RouteLatencyMS: 300, SentBytes: 512, RecvBytes: 256,
+			GoodputUpBps: 100, GoodputDownBps: 50,
+			Hops: []Hop{
+				hop("tp-a-"+string(rune('0'+idx)), rgSrc, rgHopA, "sudph", 30),
+				hop("tp-b-"+string(rune('0'+idx)), rgHopA, rgExit, "stcpr", 270),
+			}}
+	}
+	return Snapshot{
+		Surface: SurfaceSkysocks, App: "skysocks-client", Running: true, MuxEnabled: true,
+		Tunnels: []Tunnel{
+			{Index: 0, ExitPK: rgExit, MuxEnabled: true, Legs: []Leg{directLeg(0, false), multiLeg(1, false)}},
+			{Index: 1, ExitPK: rgExit, MuxEnabled: true, Legs: []Leg{directLeg(2, true), multiLeg(3, false)}},
+		},
+		Legs: []Leg{directLeg(0, false), multiLeg(1, false)}, // back-compat mirror of Tunnels[0]
+	}
+}
+
+func TestBuildRouteGraph_DedupRolesColors(t *testing.T) {
+	g := buildRouteGraph(twoStreamSnap())
+
+	// Dedup: src + exit + one shared intermediate = exactly 3 nodes.
+	if len(g.Nodes) != 3 {
+		ids := make([]string, len(g.Nodes))
+		for i, n := range g.Nodes {
+			ids[i] = n.ID
+		}
+		t.Fatalf("want 3 deduped nodes, got %d: %v", len(g.Nodes), ids)
+	}
+
+	byID := map[string]rgNode{}
+	for _, n := range g.Nodes {
+		byID[n.ID] = n
+	}
+	if n := byID[rgSrc]; n.Role != "root" || n.Color != rgRootColor {
+		t.Errorf("root node = %+v", n)
+	}
+	if n := byID[rgExit]; n.Role != "exit" || n.Color != rgExitColor {
+		t.Errorf("exit node = %+v", n)
+	}
+	if n := byID[rgHopA]; n.Role != "hop" || n.Color != rgHopColors[0] {
+		t.Errorf("hop node = %+v (want hop / %s)", n, rgHopColors[0])
+	}
+
+	// Every node tooltip carries the FULL (untruncated) PK.
+	for _, n := range g.Nodes {
+		if !strings.Contains(n.Tip, n.ID) {
+			t.Errorf("node %s tip must contain the full PK", n.ID)
+		}
+	}
+
+	// The exit node is reached by legs from BOTH streams, so its tip lists s0 and s1.
+	exitTip := byID[rgExit].Tip
+	if !strings.Contains(exitTip, "s0 ") || !strings.Contains(exitTip, "s1 ") {
+		t.Errorf("exit tip should mention both streams:\n%s", exitTip)
+	}
+}
+
+func TestBuildRouteGraph_StreamColorsAndStandby(t *testing.T) {
+	g := buildRouteGraph(twoStreamSnap())
+
+	var haveS0, haveS1, haveDim, haveActiveWide bool
+	for _, l := range g.Links {
+		switch l.Stream {
+		case 0:
+			if l.Color == rgStreamColors[0] {
+				haveS0 = true
+			}
+		case 1:
+			// stream1 active edges keep the accent; the standby direct leg is dimmed.
+			if l.Color == rgStreamColors[1] {
+				haveS1 = true
+			}
+		}
+		if !l.Active {
+			haveDim = true
+			if !strings.HasPrefix(l.Color, "rgba(") {
+				t.Errorf("standby link color should be dimmed rgba(), got %q", l.Color)
+			}
+			if l.Width > 0.7 {
+				t.Errorf("standby link width should be thin, got %v", l.Width)
+			}
+		}
+		if l.Active && l.Width > 1.0 {
+			haveActiveWide = true // rate-scaled width above the 1.0 floor
+		}
+	}
+	if !haveS0 || !haveS1 {
+		t.Errorf("expected per-stream accent colors on edges (s0=%v s1=%v)", haveS0, haveS1)
+	}
+	if !haveDim {
+		t.Error("expected at least one standby (dimmed) edge")
+	}
+	if !haveActiveWide {
+		t.Error("expected the busiest active edge to be widened by its rate")
+	}
+}
+
+func TestBuildRouteGraph_PrunesDeadAndSig(t *testing.T) {
+	snap := twoStreamSnap()
+	// Kill one leg; it must not contribute nodes/edges.
+	snap.Tunnels[0].Legs[1].Alive = false
+	g := buildRouteGraph(snap)
+	for _, l := range g.Links {
+		if l.Stream == 0 && l.Target == rgHopA {
+			t.Error("dead leg's hop edge should be pruned")
+		}
+	}
+
+	// topoSig is stable under a pure metric change (bytes/rate) but changes when a
+	// node/edge is added or removed.
+	base := buildRouteGraph(twoStreamSnap()).Sig
+	snap2 := twoStreamSnap()
+	snap2.Tunnels[0].Legs[0].SentBytes = 999999
+	snap2.Tunnels[0].Legs[0].GoodputUpBps = 12345
+	if buildRouteGraph(snap2).Sig != base {
+		t.Error("topoSig must be invariant to metric-only changes")
+	}
+	snap3 := twoStreamSnap()
+	snap3.Tunnels[0].Legs[1].Alive = false
+	if buildRouteGraph(snap3).Sig == base {
+		t.Error("topoSig must change when the topology changes")
+	}
+}
+
+func TestRouteGraphJSON_Valid(t *testing.T) {
+	// Empty snapshot yields a valid, parseable, empty document.
+	var empty rgGraph
+	if err := json.Unmarshal(RouteGraphJSON(Snapshot{Surface: SurfaceSkysocks}), &empty); err != nil {
+		t.Fatalf("empty graph JSON invalid: %v", err)
+	}
+	if len(empty.Nodes) != 0 || len(empty.Links) != 0 {
+		t.Errorf("empty snapshot should yield no nodes/links, got %+v", empty)
+	}
+
+	var g rgGraph
+	if err := json.Unmarshal(RouteGraphJSON(twoStreamSnap()), &g); err != nil {
+		t.Fatalf("graph JSON invalid: %v", err)
+	}
+	if len(g.Nodes) != 3 || len(g.Links) == 0 || g.Sig == "" {
+		t.Errorf("round-tripped graph looks wrong: nodes=%d links=%d sig=%q", len(g.Nodes), len(g.Links), g.Sig)
+	}
+}
+
+// TestRenderGraphView asserts the page wires the GPU graph view: the toggle, the
+// static canvas + tooltip, the #rgdata JSON payload, and the driver that boots
+// the wasm-visor netview blob and drives cosmos-go (tpvizGL) — all self-contained
+// and same-origin.
+func TestRenderGraphView(t *testing.T) {
+	page := string(Render(twoStreamSnap()))
+	for _, want := range []string{
+		// toggle + view containers
+		`class="vtoggle"`, `onclick="setRouteView('tree')"`, `onclick="setRouteView('graph')"`,
+		`class="muxtree"`, `id="rgraphsec"`, `id="rgcanvas"`, `id="rgtip"`,
+		// route subgraph payload embedded as inert JSON in the live region
+		`<script type="application/json" id="rgdata">`, `"nodes":`, `"links":`, `"sig":`,
+		// driver reuses the network visualizer's engine with no new wasm:
+		// netview role → tpvizGL (cosmos-go), served same-origin
+		`__SKYWIRE_WASM_ROLE__`, `"netview"`, "/main.wasm", "/wasm_exec.js",
+		"tpvizGL", "instantiateStreaming", "MutationObserver", "setData",
+		// per-stream + exit colors reach the payload
+		rgExitColor, rgStreamColors[0], rgStreamColors[1],
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("graph-view page missing %q", want)
+		}
+	}
+	// Non-skysocks surfaces get no graph (no wasm route to serve it): no driver,
+	// no canvas, no payload.
+	dmsg := string(Render(Snapshot{Surface: SurfaceDmsg, App: "dmsgweb", Legs: twoStreamSnap().Legs}))
+	for _, gone := range []string{`id="rgdata"`, `id="rgcanvas"`, "tpvizGL", "setRouteView"} {
+		if strings.Contains(dmsg, gone) {
+			t.Errorf("non-skysocks page must not contain graph markup %q", gone)
+		}
+	}
+}

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/skycoin/skywire/pkg/proxyinterstitial"
 	"github.com/skycoin/skywire/pkg/proxystatus"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/wasmhv/wasmbin"
 	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 )
 
@@ -1065,7 +1066,8 @@ func (c *Client) serveStatusPage(conn, stream net.Conn) {
 	n, _ := conn.Read(buf)                //nolint:errcheck // best-effort; page is fixed
 	_ = conn.SetReadDeadline(time.Time{}) //nolint:errcheck
 
-	if statusRequestPath(buf[:n]) == "/ws" {
+	switch statusRequestPath(buf[:n]) {
+	case "/ws":
 		// status is served entirely in-process, so the exit-side yamux stream is
 		// unused — close it now so the long-lived WS loop doesn't pin one open.
 		stream.Close() //nolint:errcheck,gosec
@@ -1074,10 +1076,96 @@ func (c *Client) serveStatusPage(conn, stream net.Conn) {
 		}
 		c.serveStatusWS(conn)
 		return
+	case "/main.wasm":
+		// The GPU route-graph view's engine: the one wasm-visor blob run in its
+		// "netview" role (it publishes the generic cosmos-go graph API the page
+		// drives), served same-origin so the page's strict self-contained context
+		// can instantiate it. Same blob pkg/tpviz serves at /tpviz-gl.wasm; served
+		// here straight from pkg/wasmhv/wasmbin. In-process, no exit round-trip.
+		stream.Close()                          //nolint:errcheck,gosec
+		_, _ = conn.Write(statusWasmResponse()) //nolint:errcheck
+		return
+	case "/wasm_exec.js":
+		stream.Close()                              //nolint:errcheck,gosec
+		_, _ = conn.Write(statusWasmExecResponse()) //nolint:errcheck
+		return
 	}
 
 	body := proxystatus.Render(c.statusSnapshot())
 	_, _ = conn.Write(statusHTTPResponse(body)) //nolint:errcheck
+}
+
+// statusWasmVariant picks which embedded wasm-visor variant backs the route-graph
+// view, preferring the smaller TinyGo blob when present (a ~3 MB download vs the
+// ~9.5 MB standard-Go one). Mirrors pkg/tpviz's tpvizNetviewVariant. The second
+// return is false when no blob is embedded, in which case the page silently
+// falls back to the ASCII tree view.
+func statusWasmVariant() (wasmbin.Variant, bool) {
+	switch {
+	case !wasmbin.Embedded():
+		return wasmbin.Default(), false
+	case wasmbin.Has(wasmbin.TinyGo):
+		return wasmbin.TinyGo, true
+	default:
+		return wasmbin.Default(), true
+	}
+}
+
+// statusWasmResponse returns the raw HTTP/1.1 response carrying the wasm-visor
+// blob for /main.wasm. It serves the gzip-committed bytes verbatim with
+// Content-Encoding: gzip (the browser inflates; WebAssembly.instantiateStreaming
+// is happy with the result), avoiding inflating megabytes per request. A 503 is
+// returned when no blob is embedded.
+func statusWasmResponse() []byte {
+	v, ok := statusWasmVariant()
+	if !ok {
+		return statusServiceUnavailable("no wasm-visor blob embedded in this build")
+	}
+	gz := wasmbin.GetVariantGz(v)
+	if len(gz) == 0 {
+		return statusServiceUnavailable("wasm-visor blob unavailable")
+	}
+	var b bytes.Buffer
+	b.WriteString("HTTP/1.1 200 OK\r\n")
+	b.WriteString("Content-Type: application/wasm\r\n")
+	b.WriteString("Content-Encoding: gzip\r\n")
+	fmt.Fprintf(&b, "Content-Length: %d\r\n", len(gz))
+	b.WriteString("Cache-Control: no-store\r\nConnection: close\r\n\r\n")
+	b.Write(gz)
+	return b.Bytes()
+}
+
+// statusWasmExecResponse returns the raw HTTP/1.1 response for /wasm_exec.js —
+// the loader that matches the served blob's toolchain (a TinyGo blob needs
+// TinyGo's loader). Small, so served uncompressed.
+func statusWasmExecResponse() []byte {
+	v, ok := statusWasmVariant()
+	if !ok {
+		return statusServiceUnavailable("no wasm-visor blob embedded in this build")
+	}
+	js := wasmbin.WasmExecJSVariant(v)
+	if len(js) == 0 {
+		return statusServiceUnavailable("wasm loader unavailable")
+	}
+	var b bytes.Buffer
+	b.WriteString("HTTP/1.1 200 OK\r\n")
+	b.WriteString("Content-Type: application/javascript; charset=utf-8\r\n")
+	fmt.Fprintf(&b, "Content-Length: %d\r\n", len(js))
+	b.WriteString("Cache-Control: no-store\r\nConnection: close\r\n\r\n")
+	b.Write(js)
+	return b.Bytes()
+}
+
+// statusServiceUnavailable builds a tiny 503 response (the page treats a failed
+// wasm fetch as "graph unavailable" and keeps the tree view).
+func statusServiceUnavailable(msg string) []byte {
+	var b bytes.Buffer
+	b.WriteString("HTTP/1.1 503 Service Unavailable\r\n")
+	b.WriteString("Content-Type: text/plain; charset=utf-8\r\n")
+	fmt.Fprintf(&b, "Content-Length: %d\r\n", len(msg))
+	b.WriteString("Cache-Control: no-store\r\nConnection: close\r\n\r\n")
+	b.WriteString(msg)
+	return b.Bytes()
 }
 
 // statusRequestPath extracts the request-target path from an HTTP request line

--- a/pkg/skysocks/client_statuswasm_test.go
+++ b/pkg/skysocks/client_statuswasm_test.go
@@ -1,0 +1,48 @@
+package skysocks
+
+import (
+	"bufio"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestStatusWasmResponses checks the /main.wasm and /wasm_exec.js status routes
+// serve the wasm-visor "netview" blob (and its matching loader) that the GPU
+// route-graph view instantiates same-origin. When a blob is embedded (the normal
+// build) both are 200 with the right content types; the wasm rides gzip-encoded.
+func TestStatusWasmResponses(t *testing.T) {
+	v, ok := statusWasmVariant()
+	if !ok {
+		t.Skip("no wasm-visor blob embedded in this build")
+	}
+	t.Logf("serving wasm-visor variant %q", v)
+
+	wasmResp := parseResp(t, statusWasmResponse())
+	if wasmResp.StatusCode != http.StatusOK {
+		t.Fatalf("/main.wasm status = %d", wasmResp.StatusCode)
+	}
+	if ct := wasmResp.Header.Get("Content-Type"); ct != "application/wasm" {
+		t.Errorf("/main.wasm content-type = %q, want application/wasm", ct)
+	}
+	if ce := wasmResp.Header.Get("Content-Encoding"); ce != "gzip" {
+		t.Errorf("/main.wasm content-encoding = %q, want gzip", ce)
+	}
+
+	execResp := parseResp(t, statusWasmExecResponse())
+	if execResp.StatusCode != http.StatusOK {
+		t.Fatalf("/wasm_exec.js status = %d", execResp.StatusCode)
+	}
+	if ct := execResp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/javascript") {
+		t.Errorf("/wasm_exec.js content-type = %q", ct)
+	}
+}
+
+func parseResp(t *testing.T, raw []byte) *http.Response {
+	t.Helper()
+	resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(string(raw))), nil)
+	if err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	return resp
+}


### PR DESCRIPTION
Adds a graphical route visualizer next to the existing ASCII route tree on the
status.skysocks page, modeled on the network visualizer (pkg/tpviz). A tree/graph
toggle switches between the two views of the same route group.

**Engine reuse, no new wasm.** The graph reuses the network visualizer's engine:
the page loads the one wasm-visor blob in its "netview" role — which publishes the
generic cosmos-go graph API on `globalThis.tpvizGL` (pkg/tpviz/wasmgl) — and drives
it from a small inline driver. `/main.wasm` and `/wasm_exec.js` are served
same-origin by the skysocks status handler out of pkg/wasmhv/wasmbin (the same blob
pkg/tpviz serves at `/tpviz-gl.wasm`), so the strict self-contained page fetches
nothing external. The TinyGo blob is preferred (~3 MB) and fetched lazily on first
opening the graph.

**Route-scoped subgraph.** `routegraph.go` shapes the proxy's own routes from the
status Snapshot — this visor (root), each intermediate hop and the exit,
deduplicated (a hop PK shared by several legs is one node), with the per-hop
transports the legs traverse. It is not the whole mesh. Edges are colored by stream
(the tree's per-stream palette), active vs standby styled, and widthed by the leg's
live byte-rate; nodes carry the full untruncated PK and per-leg transport detail in
their hover tooltip.

**Live + robust.** The canvas lives outside the live region so its WebGL context
and settled layout survive the ~1s WebSocket swaps; the subgraph rides as inert JSON
in the live region and the driver re-feeds cosmos-go in place, re-running the force
layout only when the topology changes. With no blob embedded or WebGL unavailable
the page keeps the ASCII tree view (also the no-JS fallback).

Tests: route-graph builder (dedup, per-stream colors, standby, topology signature,
JSON validity), rendered page wiring, and the wasm-serving responses.