### PR TITLE
fix(router): confine unidir download to the active reverse leg, never the direct leg

### DIFF
--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -373,14 +373,17 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 	// Unidirectional send selection (CapUniDir).
 	// DIRECTION governs which CLASS of leg (direct vs multihop) carries this end's
 	// traffic; WITHIN the class the initiator-mirrored ACTIVE set governs which
-	// legs. selectByDirection is two-tier: it prefers active (standby-aware)
-	// direction-matching legs — so the exit's download fan-out stays bounded to the
-	// few reverse legs the initiator parked active, instead of spraying every
-	// warm-standby reverse leg (which over-subscribes the no-skip reorder frontier,
-	// amplifies retransmits, and wedges the group → the observed collapse-to-0).
-	// Only when NO active leg of the wanted direction exists does it fall back to a
-	// standby leg of that direction (Tier 2), preserving confinement without the
-	// wrong-direction fallback that landed the whole download on the direct leg.
+	// legs. selectByDirection prefers the active (mirrored) class legs — even a
+	// mirrored-active reverse leg that never received inbound bulk (so its
+	// readiness gate never fired) is preferred over the warm-standby reserve — so
+	// the exit's download fan-out stays bounded to the few reverse legs the
+	// initiator parked active instead of spraying every warm-standby reverse leg
+	// (which over-subscribes the no-skip reorder frontier and wedges the group →
+	// the observed collapse-to-0). It returns ok=true (and we use its pick) as long
+	// as ANY leg of the wanted class exists, so the download is NEVER handed to the
+	// wrong-direction direct leg while a reverse leg is available. Only when there
+	// is genuinely no reverse leg does it return ok=false and selection falls
+	// through to the standard path.
 	if directional, wantDirect, dstPK, srcPK := m.dirConfig(); directional {
 		if tp, rule, idx, ok := m.selectByDirection(tps, fwd, wantDirect, dstPK, srcPK); ok {
 			return tp, rule, idx, nil

--- a/pkg/router/unidir.go
+++ b/pkg/router/unidir.go
@@ -217,66 +217,85 @@ func (m *routeMux) flipStep(up, down float64) (flipped, changed bool) {
 // stays bounded to the few legs the initiator parked active instead of spraying
 // every warm-standby reverse leg.
 //
-// Two tiers:
+// Four tiers, tried in order (each bounded to the wanted CLASS so the wrong
+// direction — the direct leg on a download — is NEVER selected here):
 //
-//	Tier 1 (normal): active (non-standby), ready, direction-matching legs. This
-//	   honors the mirrored active set — the exit sends the download on the same
-//	   small set the initiator selected, so the reorder frontier is not
-//	   over-subscribed and retransmits do not amplify. The heavy direction still
-//	   spreads across THOSE legs via the weighted selector / round-robin.
-//	Tier 2 (degenerate): if NO active direction-matching leg exists — the
-//	   initiator parked every leg of this direction as standby, e.g. mid-rotation
-//	   — fall back to any alive, ready standby leg of the wanted direction. This
-//	   keeps confinement (the #4311 guarantee: never fall through to the
-//	   standby-aware path, which could pick the wrong-direction direct leg) while
-//	   still bounding to the wanted class. It is the warm-reserve failover, not
-//	   the steady state.
+//	Tier 1 (steady state): active (non-standby), ready, class-matching legs. The
+//	   exit sends the download on the same small mirrored-active set the initiator
+//	   selected, so the reorder frontier is not over-subscribed. The heavy
+//	   direction spreads across THOSE legs via the weighted selector / round-robin.
+//	Tier 2 (active-not-ready): an ACTIVE class leg whose readiness gate has not
+//	   fired. Under CapUniDir the initiator sends its light direction ONLY on the
+//	   direct leg, so the exit's active reverse leg may never receive inbound bulk
+//	   and so is never markLegReady'd — yet its rules were installed on both ends
+//	   when the leg joined the group, so it IS sendable. Preferring it here (over
+//	   any ready STANDBY leg) is what confines the download to the one
+//	   mirrored-active reverse leg instead of spraying the warm-standby reserve —
+//	   the fix for the "active leg not preferred / download on standby legs" bug.
+//	Tier 3 (warm-reserve failover): no active class leg at all (the initiator
+//	   parked every leg of this direction, e.g. mid-rotation) — fall back to a
+//	   ready STANDBY class leg. The #4319 bounding: still the wanted class, still
+//	   the warm reserve; steady state never reaches here.
+//	Tier 4 (last resort before the wrong direction): ANY class leg, ignoring both
+//	   standby and readiness. A reverse leg that exists but is neither active nor
+//	   "ready" is still the RIGHT CLASS, so sending on it preserves the #4311
+//	   confinement guarantee (never the wrong-direction direct leg) when the group
+//	   is momentarily between active/ready states.
 //
-// Returns ok=false only when NO direction-matching leg is selectable at all, so
-// selectTransport falls through to the standard path rather than dropping the send.
+// Returns ok=false only when there is genuinely NO leg of the wanted class at
+// all — then selectTransport falls through and may use the direct leg, because
+// there is no reverse leg to confine the download to.
 func (m *routeMux) selectByDirection(tps []*transport.ManagedTransport, fwd []routing.Rule, wantDirect bool, dst, src cipher.PubKey) (*transport.ManagedTransport, routing.Rule, int, bool) {
 	n := len(tps)
 	if n == 0 || len(fwd) == 0 {
 		return nil, nil, -1, false
 	}
-	// Tier 1: active, ready, direction-matching (standby-aware — bounds fan-out).
-	matchActive := func(idx int) bool {
+	// Base gate: a live, ruled leg whose CLASS (direct vs multihop) matches this
+	// end's send direction. The tiers below layer readiness/standby on top.
+	classOK := func(idx int) bool {
 		tp := tps[idx]
 		return idx < len(fwd) && tp != nil && !tp.IsClosed() &&
-			m.legReadyAt(idx) && legIsDirect(tp, dst, src) == wantDirect
-	}
-	// Prefer the scheduler's pick when it matches AND is active, so the heavy
-	// direction spreads across the active legs per the mux weights/ECF.
-	if m.tpSelector != nil && m.tpSelector.Len() > 0 {
-		if idx := m.tpSelector.Select(); idx >= 0 && idx < n && matchActive(idx) {
-			return tps[idx], fwd[idx], idx, true
-		}
+			legIsDirect(tp, dst, src) == wantDirect
 	}
 	start := int(atomic.AddUint32(&m.tpIndex, 1) - 1)
-	for i := 0; i < n; i++ {
-		idx := ((start % n) + i) % n
-		if idx < 0 {
-			idx += n
+	scan := func(match func(idx int) bool) (*transport.ManagedTransport, routing.Rule, int, bool) {
+		for i := 0; i < n; i++ {
+			idx := ((start % n) + i) % n
+			if idx < 0 {
+				idx += n
+			}
+			if match(idx) {
+				return tps[idx], fwd[idx], idx, true
+			}
 		}
-		if matchActive(idx) {
+		return nil, nil, -1, false
+	}
+
+	// Tier 1: active, ready, class-matching (legReadyAt already excludes standby).
+	// Prefer the scheduler's pick when it qualifies, so the heavy direction spreads
+	// across the active legs per the mux weights/ECF.
+	activeReady := func(idx int) bool { return classOK(idx) && m.legReadyAt(idx) }
+	if m.tpSelector != nil && m.tpSelector.Len() > 0 {
+		if idx := m.tpSelector.Select(); idx >= 0 && idx < n && activeReady(idx) {
 			return tps[idx], fwd[idx], idx, true
 		}
 	}
-	// Tier 2: no ACTIVE direction-matching leg — warm-reserve failover on the
-	// wanted class only (confinement preserved). Rare; logged by the caller.
-	matchAny := func(idx int) bool {
-		tp := tps[idx]
-		return idx < len(fwd) && tp != nil && !tp.IsClosed() &&
-			m.legSelectableIgnoringStandby(idx) && legIsDirect(tp, dst, src) == wantDirect
+	if tp, rule, idx, ok := scan(activeReady); ok {
+		return tp, rule, idx, true
 	}
-	for i := 0; i < n; i++ {
-		idx := ((start % n) + i) % n
-		if idx < 0 {
-			idx += n
-		}
-		if matchAny(idx) {
-			return tps[idx], fwd[idx], idx, true
-		}
+	// Tier 2: active class leg, ignoring the readiness gate — the mirrored-active
+	// reverse leg the exit must send bulk on even though it never received inbound.
+	if tp, rule, idx, ok := scan(func(idx int) bool { return classOK(idx) && !m.isLegStandby(idx) }); ok {
+		return tp, rule, idx, true
+	}
+	// Tier 3: ready standby class leg (warm-reserve failover; ignore standby flag).
+	if tp, rule, idx, ok := scan(func(idx int) bool { return classOK(idx) && m.legSelectableIgnoringStandby(idx) }); ok {
+		return tp, rule, idx, true
+	}
+	// Tier 4: any class leg at all (ignore both standby and readiness) — never the
+	// wrong-direction direct leg while a reverse leg exists.
+	if tp, rule, idx, ok := scan(classOK); ok {
+		return tp, rule, idx, true
 	}
 	return nil, nil, -1, false
 }

--- a/pkg/router/unidir_fanout_test.go
+++ b/pkg/router/unidir_fanout_test.go
@@ -105,3 +105,139 @@ func TestSelectByDirectionBoundsFanoutToActive(t *testing.T) {
 		t.Errorf("tier-2 fallback should pick only reverse legs; got %v", seen2)
 	}
 }
+
+// endpointsForTest returns the two route-group endpoint keys plus three
+// intermediary hop keys used to distinguish direct from multihop legs.
+func endpointsForTest(t *testing.T) (dst, src, hopA, hopB, hopC cipher.PubKey) {
+	t.Helper()
+	dst = pkFromHex(t, "02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36")
+	src = pkFromHex(t, "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c")
+	hopA = pkFromHex(t, "021b17d2d884d9d73eeca0572143ac97de97e30ca61a682c71b5b968f37c86d206")
+	hopB = pkFromHex(t, "0224f0b6a1b017a1d3cb4a949a6047d13cac1c0580060888dcf1b9b3e09e123e6a")
+	hopC = pkFromHex(t, "02304cb299849723102c4d3032e6b4d8a049c7ebdd4fd4fc7b0d250557c224652b")
+	return dst, src, hopA, hopB, hopC
+}
+
+// TestSelectByDirectionNeverDirectWhenNoReverseReady is the regression guard for
+// FAILURE 1 (the direct-leg download): with CapUniDir the exit must never hand a
+// download to the wrong-direction DIRECT leg while a reverse (multihop) leg
+// exists — even when NO reverse leg has passed the readiness gate. Before the
+// fix, selectByDirection returned ok=false when no reverse leg was "ready", and
+// selectTransport then fell through to the standby-aware path, which picked the
+// always-ready direct leg (leg 0) and corrupted the direction.
+func TestSelectByDirectionNeverDirectWhenNoReverseReady(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("unidir-never-direct-test")
+	dst, src, hopA, hopB, hopC := endpointsForTest(t)
+
+	m := newRouteMux(log, true)
+	m.setDirectional(false, dst, src) // acceptor → download rides multihop legs
+
+	tps := []*transport.ManagedTransport{{}, {}, {}, {}}
+	setRemoteForTest(tps[0], dst)  // direct
+	setRemoteForTest(tps[1], hopA) // multihop
+	setRemoteForTest(tps[2], hopB) // multihop
+	setRemoteForTest(tps[3], hopC) // multihop
+	fwd := make([]routing.Rule, 4)
+
+	m.growLegs(4)
+	// Only the direct leg is "ready" (leg 0 is ready from growLegs). NONE of the
+	// reverse legs have received inbound, so none are markLegReady'd — exactly the
+	// unidirectional case where the initiator uploads only on the direct leg.
+	if m.legReadyAt(1) || m.legReadyAt(2) || m.legReadyAt(3) {
+		t.Fatal("precondition: reverse legs must start not-ready")
+	}
+
+	seen := map[int]int{}
+	for i := 0; i < 300; i++ {
+		_, _, idx, ok := m.selectByDirection(tps, fwd, false, dst, src)
+		if !ok {
+			t.Fatalf("iteration %d: ok=false — a not-ready reverse leg is still the right CLASS and must be selected over the direct leg", i)
+		}
+		seen[idx]++
+	}
+	if seen[0] != 0 {
+		t.Errorf("download landed on the DIRECT leg %d time(s) despite no reverse leg being ready — confinement broke (failure 1)", seen[0])
+	}
+	if seen[1]+seen[2]+seen[3] != 300 {
+		t.Errorf("all sends should ride reverse legs; got %v", seen)
+	}
+}
+
+// TestSelectByDirectionPrefersActiveOverStandby is the regression guard for
+// FAILURE 2 (active reverse leg not preferred): the ACTIVE (initiator-mirrored)
+// reverse leg must win over ready STANDBY reverse legs even when the active leg
+// itself is NOT ready. Before the fix the readiness gate blocked Tier 1, and the
+// download sprayed onto the ready standby legs (the observed actRev=588K vs
+// stbyRev=61MB split) instead of confining to the one mirrored-active leg.
+func TestSelectByDirectionPrefersActiveOverStandby(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("unidir-active-pref-test")
+	dst, src, hopA, hopB, hopC := endpointsForTest(t)
+
+	m := newRouteMux(log, true)
+	m.setDirectional(false, dst, src)
+
+	tps := []*transport.ManagedTransport{{}, {}, {}, {}}
+	setRemoteForTest(tps[0], dst)  // direct
+	setRemoteForTest(tps[1], hopA) // multihop — the mirrored ACTIVE leg
+	setRemoteForTest(tps[2], hopB) // multihop — standby, ready
+	setRemoteForTest(tps[3], hopC) // multihop — standby, ready
+	fwd := make([]routing.Rule, 4)
+
+	m.growLegs(4)
+	// leg 1 is active but NEVER received inbound → not ready. legs 2,3 are the
+	// initiator-parked standby reserve, but they DID receive inbound so they are
+	// ready. The active leg must still win.
+	m.setLegStandby(2, true)
+	m.setLegStandby(3, true)
+	m.markLegReady(2)
+	m.markLegReady(3)
+	if m.legReadyAt(1) {
+		t.Fatal("precondition: active leg 1 must be not-ready")
+	}
+
+	seen := map[int]int{}
+	for i := 0; i < 300; i++ {
+		_, _, idx, ok := m.selectByDirection(tps, fwd, false, dst, src)
+		if !ok {
+			t.Fatalf("iteration %d: ok=false with a live active reverse leg present", i)
+		}
+		seen[idx]++
+	}
+	if seen[1] != 300 {
+		t.Errorf("download must confine to the mirrored-ACTIVE reverse leg 1; got %v (failure 2)", seen)
+	}
+	if seen[0] != 0 {
+		t.Errorf("download must never ride the direct leg; got %d hits on leg 0", seen[0])
+	}
+}
+
+// TestSelectByDirectionReverseSendableOnceEstablished pins the readiness fix: a
+// single directional reverse leg that has NOT received inbound (never
+// markLegReady'd) is still SENDABLE once the group is established, because its
+// rules are installed on both ends when the leg joins the group. Selection must
+// return it (ok=true) rather than falling through to the direct-capable path.
+func TestSelectByDirectionReverseSendableOnceEstablished(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("unidir-ready-fix-test")
+	dst, src, hopA, _, _ := endpointsForTest(t)
+
+	m := newRouteMux(log, true)
+	m.setDirectional(false, dst, src)
+
+	tps := []*transport.ManagedTransport{{}, {}}
+	setRemoteForTest(tps[0], dst)  // direct
+	setRemoteForTest(tps[1], hopA) // the sole multihop (download) leg
+	fwd := make([]routing.Rule, 2)
+
+	m.growLegs(2)
+	if m.legReadyAt(1) {
+		t.Fatal("precondition: the reverse leg must start not-ready")
+	}
+
+	_, _, idx, ok := m.selectByDirection(tps, fwd, false, dst, src)
+	if !ok {
+		t.Fatal("a not-ready but established reverse leg must be sendable (ok=true)")
+	}
+	if idx != 1 {
+		t.Errorf("expected the reverse leg (idx 1); got idx %d", idx)
+	}
+}


### PR DESCRIPTION
With both ends running the flip-aware CapUniDir mux (#4337), a download still rode STANDBY reverse legs and even the DIRECT leg instead of the ACTIVE reverse (download-class) leg.

Root cause is the send-side readiness gate. Under CapUniDir the initiator uploads only on the direct leg, so the exit's active reverse leg never receives inbound bulk — and `markLegReady` fires only on first inbound. That active leg therefore stays "not ready" on the exit's send side, which produced two failures in `selectByDirection`:

- It returned ok=false when no reverse leg was "ready", so `selectTransport` fell through to the standby-aware path and could pick the wrong-direction direct leg for the download.
- The readiness gate blocked the mirrored-active reverse leg, so the download sprayed onto ready warm-standby reverse legs instead of confining to the one active leg.

`selectByDirection` is restructured into four class-bounded tiers: active+ready, then active ignoring the readiness gate (a mirrored-active reverse leg is sendable once the group is established and its rules are installed on both ends), then ready standby, then any leg of the wanted class. It returns ok=false only when there is genuinely no reverse leg, so the download never lands on the direct leg while a reverse leg exists. The #4311 confinement (never wrong-direction) and #4319 fan-out bounding are preserved, and it stays flip-aware through the existing `wantDirect` mapping.

Adds three regression tests: the download never selects the direct leg when no reverse leg is ready; the active reverse leg is preferred over ready standby legs; a directional reverse leg is sendable once the group is established.

Proven via unit tests and code reasoning; the two-ended live path will be validated on merge.