### PR TITLE
fix(lint): clear the golangci-lint debt blocking every open PR

### DIFF
--- a/pkg/proxystatus/routegraph_test.go
+++ b/pkg/proxystatus/routegraph_test.go
@@ -2,6 +2,7 @@ package proxystatus
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -25,15 +26,15 @@ func twoStreamSnap() Snapshot {
 		return Leg{Index: idx, RemotePK: rgExit, Direct: true, Alive: true, Standby: standby,
 			LatencyMS: 42, RouteLatencyMS: 42, SentBytes: 2048, RecvBytes: 1024,
 			GoodputUpBps: 800, GoodputDownBps: 400,
-			Hops: []Hop{hop("tp-direct-"+string(rune('0'+idx)), rgSrc, rgExit, "stcpr", 42)}}
+			Hops: []Hop{hop("tp-direct-"+strconv.Itoa(idx), rgSrc, rgExit, "stcpr", 42)}}
 	}
 	multiLeg := func(idx int, standby bool) Leg {
 		return Leg{Index: idx, RemotePK: rgExit, Direct: false, Alive: true, Standby: standby,
 			LatencyMS: 30, RouteLatencyMS: 300, SentBytes: 512, RecvBytes: 256,
 			GoodputUpBps: 100, GoodputDownBps: 50,
 			Hops: []Hop{
-				hop("tp-a-"+string(rune('0'+idx)), rgSrc, rgHopA, "sudph", 30),
-				hop("tp-b-"+string(rune('0'+idx)), rgHopA, rgExit, "stcpr", 270),
+				hop("tp-a-"+strconv.Itoa(idx), rgSrc, rgHopA, "sudph", 30),
+				hop("tp-b-"+strconv.Itoa(idx), rgHopA, rgExit, "stcpr", 270),
 			}}
 	}
 	return Snapshot{

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -2738,7 +2738,7 @@ func (r *router) addOneAuxLeg(ctx context.Context, nrg *NoiseRouteGroup, opts *D
 	// gate below, so a stale plan is rejected exactly like a fresh bad one and a
 	// miss falls through to fetchBestRoutes — the cache can only save work, never
 	// change the leg that gets built. See docs/design/shared-warm-route-pool.md.
-	keyMinHops := uint16(r.conf.MinHops) //nolint:gosec
+	keyMinHops := r.conf.MinHops
 	if e := muxOpts.EffectiveMinHops(true); e > 0 {
 		keyMinHops = uint16(e) //nolint:gosec
 	}


### PR DESCRIPTION
**Did you run `make format && make check`?** `golangci-lint run -c .golangci.yml ./...` reports **0 issues**; `gofmt` clean; `go build .`, `go vet` and `go test ./pkg/proxystatus/` pass.

**Fixes:** the red `linux` / `darwin` / `windows` lanes

**Changes:**
Four findings landed today, from #4338 and the shared route-plan cache. They fail the lint step, which on these lanes runs in the same shell step as `go test ./pkg/...` — so the whole suite is skipped on all three platforms until they are cleared (see #4326).

- `pkg/proxystatus/routegraph_test.go` — `string(rune('0'+idx))` trips `G115` on the int→rune conversion. Replaced with `strconv.Itoa(idx)`, which is what the label actually means and keeps working past `idx == 9`, where the arithmetic would silently produce punctuation.
- `pkg/router/router_dial.go:2741` — `uint16(r.conf.MinHops)` converts a value that is already `uint16` (`visorconfig/v1.go:647`). Conversion and its now-redundant `//nolint:gosec` both removed.

No behaviour changes.

**How to test this PR:**
`golangci-lint run -c .golangci.yml ./...` — 0 issues.