### PR TITLE
feat(visor-state): server-side projection + --watch NDJSON stream; range-split as state

### DIFF
--- a/cmd/skywire-cli/commands/visor/state.go
+++ b/cmd/skywire-cli/commands/visor/state.go
@@ -2,7 +2,15 @@
 package clivisor
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -14,9 +22,18 @@ import (
 
 const stateHumanMessage = "visor runtime state snapshot\n" +
 	"  use --json for the full structure, --shape for its schema,\n" +
-	"  or --jq '<filter>' to project a field (e.g. --jq '.health')."
+	"  --jq '<filter>' to project a field (e.g. --jq '.health'),\n" +
+	"  --select <keys> for a cheap server-built subtree, or\n" +
+	"  --watch <interval> to stream snapshots as NDJSON."
+
+var (
+	stateSelect string
+	stateWatch  time.Duration
+)
 
 func init() {
+	stateCmd.Flags().StringVar(&stateSelect, "select", "", "server-side projection: build only these subtree(s), comma-separated ("+strings.Join(visor.StateSelectKeys, ",")+")")
+	stateCmd.Flags().DurationVar(&stateWatch, "watch", 0, "stream snapshots as NDJSON every <interval> (e.g. 1s) until Ctrl-C")
 	RootCmd.AddCommand(stateCmd)
 }
 
@@ -32,12 +49,25 @@ subsystems are wired — into ONE response, so you can project exactly the field
 you want with the global --jq / --shape flags instead of stitching together a
 dozen subcommands. The visor's secret key is never included.
 
+--select builds ONLY the requested subtree(s) SERVER-side, so a cheap
+'--select mux' skips the ~307 KB transports build (full snapshot ~900 KB, mux
+~75 KB). Keys (comma-separated): summary, health, routing, mux, apps,
+transports, modules, cxo, proxy. The projected keys match the full snapshot's
+JSON field names, so --jq expressions transfer unchanged. 'proxy' is opt-in
+(the visor-side skysocks proxystatus: per-leg mux + range-split when pushed).
+
+--watch <interval> opens the RPC once and emits one snapshot per tick as NDJSON
+(newline-delimited JSON, no banners/ANSI) to stdout until Ctrl-C — a clean pipe
+for a chart or Monitor. It composes with --select (cheap projected ticks),
+--jq (each tick filtered to one compact line) and --via (a remote visor).
+
 Examples:
   skywire cli visor state --shape                 # print the output schema skeleton
   skywire cli visor state --json                  # full snapshot as JSON
   skywire cli visor state --jq '.health'          # just the health section
-  skywire cli visor state --jq '.transports | length'
-  skywire cli visor state --jq '.modules'
+  skywire cli visor state --select mux            # server builds ONLY mux_route_groups
+  skywire cli visor state --select health,routing # several subtrees
+  skywire cli visor state --watch 1s --select mux --jq '.mux_route_groups'
   skywire cli visor state --via dmsg://<pk> --jq '.routing_policy'  # a remote visor`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		// --shape only needs the schema, not live data: print the skeleton of a
@@ -47,14 +77,113 @@ Examples:
 			internal.PrintOutput(cmd.Flags(), &visor.StateSnapshot{}, stateHumanMessage)
 			return
 		}
+
+		fields := parseSelect(stateSelect)
+
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
 		}
-		snap, err := rpcClient.StateSnapshot()
+
+		// fetch pulls one snapshot: the projected RPC when --select is set
+		// (server builds only those subtrees), otherwise the full snapshot so
+		// behavior against an older visor is unchanged.
+		fetch := func() (*visor.StateSnapshot, error) {
+			if len(fields) > 0 {
+				return rpcClient.StateSnapshotProjected(fields)
+			}
+			return rpcClient.StateSnapshot()
+		}
+
+		if stateWatch > 0 {
+			watchState(cmd, fetch)
+			return
+		}
+
+		snap, err := fetch()
 		if err != nil {
 			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 		internal.PrintOutput(cmd.Flags(), snap, stateHumanMessage)
 	},
+}
+
+// parseSelect splits a comma-separated --select value into trimmed, non-empty
+// subtree keys. An empty value yields nil (full snapshot).
+func parseSelect(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// watchState streams one snapshot per tick as NDJSON to stdout until an
+// interrupt. It emits immediately, then every stateWatch interval. --jq filters
+// each tick to one compact line; otherwise the whole snapshot is one compact
+// line. A per-tick fetch error goes to stderr and the stream continues, so a
+// transient RPC hiccup does not end the watch.
+func watchState(cmd *cobra.Command, fetch func() (*visor.StateSnapshot, error)) {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	jqFilter := cliout.JQFilter(cmd)
+	emit := func() {
+		snap, err := fetch()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "watch:", err)
+			return
+		}
+		if err := writeNDJSON(os.Stdout, snap, jqFilter); err != nil {
+			fmt.Fprintln(os.Stderr, "watch:", err)
+		}
+	}
+
+	streamTicks(ctx, stateWatch, emit)
+}
+
+// streamTicks emits immediately, then calls emit every interval until ctx is
+// cancelled (Ctrl-C). Extracted so the tick loop is unit-testable without a live
+// RPC or a real signal.
+func streamTicks(ctx context.Context, interval time.Duration, emit func()) {
+	emit()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			emit()
+		}
+	}
+}
+
+// writeNDJSON marshals snap as one NDJSON line (or, when jqFilter is set, one
+// compact line per jq result). It is deliberately banner/ANSI-free so the output
+// pipes cleanly into a chart or Monitor.
+func writeNDJSON(w io.Writer, snap *visor.StateSnapshot, jqFilter string) error {
+	b, err := json.Marshal(snap)
+	if err != nil {
+		return err
+	}
+	if jqFilter == "" {
+		_, err = fmt.Fprintf(w, "%s\n", b)
+		return err
+	}
+	lines, err := cliout.ApplyJQCompact(b, jqFilter)
+	if err != nil {
+		return err
+	}
+	for _, ln := range lines {
+		if _, err := fmt.Fprintf(w, "%s\n", ln); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/skywire-cli/commands/visor/state_test.go
+++ b/cmd/skywire-cli/commands/visor/state_test.go
@@ -1,0 +1,92 @@
+// Package clivisor cmd/skywire-cli/commands/visor/state_test.go
+package clivisor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+func TestParseSelect(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"mux", []string{"mux"}},
+		{"mux,health", []string{"mux", "health"}},
+		{" mux , health ,", []string{"mux", "health"}},
+		{",,", nil},
+	}
+	for _, c := range cases {
+		got := parseSelect(c.in)
+		if strings.Join(got, ",") != strings.Join(c.want, ",") {
+			t.Errorf("parseSelect(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// TestWriteNDJSON_Whole: no --jq → the whole snapshot on ONE line ending in \n,
+// and it parses back as JSON (a clean NDJSON record).
+func TestWriteNDJSON_Whole(t *testing.T) {
+	snap := &visor.StateSnapshot{RouteGroups: 3}
+	var buf bytes.Buffer
+	if err := writeNDJSON(&buf, snap, ""); err != nil {
+		t.Fatalf("writeNDJSON: %v", err)
+	}
+	out := buf.String()
+	if strings.Count(out, "\n") != 1 || !strings.HasSuffix(out, "\n") {
+		t.Fatalf("want exactly one trailing newline, got %q", out)
+	}
+	if strings.Contains(strings.TrimSpace(out), "\n") {
+		t.Fatalf("record must be a single line, got %q", out)
+	}
+	var back visor.StateSnapshot
+	if err := json.Unmarshal([]byte(out), &back); err != nil {
+		t.Fatalf("NDJSON line does not parse: %v", err)
+	}
+	if back.RouteGroups != 3 {
+		t.Errorf("round-trip route_groups = %d, want 3", back.RouteGroups)
+	}
+}
+
+// TestWriteNDJSON_JQ: --jq projects each tick to a compact line (here a scalar).
+func TestWriteNDJSON_JQ(t *testing.T) {
+	snap := &visor.StateSnapshot{RouteGroups: 7}
+	var buf bytes.Buffer
+	if err := writeNDJSON(&buf, snap, ".route_groups"); err != nil {
+		t.Fatalf("writeNDJSON: %v", err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "7" {
+		t.Fatalf("jq NDJSON = %q, want \"7\"", got)
+	}
+}
+
+// TestStreamTicks: emits immediately, keeps ticking, and stops promptly when the
+// context is cancelled (the Ctrl-C path).
+func TestStreamTicks(t *testing.T) {
+	var n atomic.Int64
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		streamTicks(ctx, 5*time.Millisecond, func() { n.Add(1) })
+		close(done)
+	}()
+	time.Sleep(40 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("streamTicks did not return after cancel")
+	}
+	if got := n.Load(); got < 2 {
+		t.Fatalf("expected multiple ticks (immediate + interval), got %d", got)
+	}
+}

--- a/pkg/cliout/filter.go
+++ b/pkg/cliout/filter.go
@@ -144,6 +144,39 @@ func ApplyJQ(src []byte, filter string) (string, error) {
 	return sb.String(), nil
 }
 
+// ApplyJQCompact runs filter over the JSON in src and returns each result as a
+// COMPACT (single-line) JSON string — the NDJSON-friendly counterpart of
+// ApplyJQ, which pretty-prints. A filter that yields several values returns
+// several strings (each a valid standalone JSON line). Used by streaming
+// (`--watch`) callers so a filtered tick stays one line.
+func ApplyJQCompact(src []byte, filter string) ([]string, error) {
+	query, err := gojq.Parse(filter)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --jq filter: %w", err)
+	}
+	var input interface{}
+	if err := json.Unmarshal(src, &input); err != nil {
+		return nil, fmt.Errorf("decode JSON for --jq: %w", err)
+	}
+	var out []string
+	iter := query.Run(input)
+	for {
+		val, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, ok := val.(error); ok {
+			return nil, fmt.Errorf("--jq: %w", err)
+		}
+		b, err := json.Marshal(val)
+		if err != nil {
+			return nil, fmt.Errorf("--jq encode result: %w", err)
+		}
+		out = append(out, string(b))
+	}
+	return out, nil
+}
+
 // orderedMap marshals its entries in insertion order (a Go map sorts keys), so
 // a --shape skeleton preserves struct field order. MarshalIndent re-indents the
 // compact bytes MarshalJSON returns, so nested orderedMaps still pretty-print.

--- a/pkg/proxystatus/provider.go
+++ b/pkg/proxystatus/provider.go
@@ -117,7 +117,28 @@ type Snapshot struct {
 	Logs    []string // recent log lines, oldest first
 	Events  []string // route/transport events affecting this surface, oldest first
 	Streams []Stream // per-stream detail for the open session (skysocks tunnel), when tracked
-	Note    string   // optional human note (e.g. why a section is empty)
+	// RangeSplit summarizes transparent HTTP range-splitting activity on the
+	// surface (skysocks only): whether a split is firing right now and its
+	// cumulative shape. Nil when the surface does not range-split (every
+	// non-skysocks surface, or a skysocks client with the feature disabled). It
+	// makes "is range-split firing" a readable field rather than a log line.
+	RangeSplit *RangeSplit `json:"range_split,omitempty"`
+	Note       string      // optional human note (e.g. why a section is empty)
+}
+
+// RangeSplit is the live range-split summary for the skysocks surface. It is
+// built from the client's atomic counters (pkg/skysocks rangesplit.go), so it is
+// cheap to read at page/watch cadence. ActiveSplits>0 means a splittable download
+// is aggregating across the mesh's tunnels right now; the cumulative totals show
+// it has fired at all and its shape (chunks × streams).
+type RangeSplit struct {
+	Enabled         bool   `json:"enabled"`           // feature is on for this client
+	ActiveSplits    int64  `json:"active_splits"`     // splits in flight right now
+	TotalSplits     uint64 `json:"total_splits"`      // cumulative splits performed
+	TotalChunks     uint64 `json:"total_chunks"`      // cumulative range chunks fetched
+	TotalBytes      uint64 `json:"total_bytes"`       // cumulative bytes delivered via split
+	StreamsPerSplit int    `json:"streams_per_split"` // configured concurrency (streams per split)
+	ChunkSize       int64  `json:"chunk_size"`        // bytes per range request
 }
 
 // Tunnel is one STREAM-level route group — a single --tunnels stream to the exit,

--- a/pkg/proxystatus/rangesplit_render_test.go
+++ b/pkg/proxystatus/rangesplit_render_test.go
@@ -1,0 +1,46 @@
+// Package proxystatus pkg/proxystatus/rangesplit_render_test.go
+package proxystatus
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRenderRangeSplit_Active: an in-flight split renders an ACTIVE pill with the
+// count and the cumulative shape, in the live region (so it also rides the ~1s
+// WebSocket fragment push).
+func TestRenderRangeSplit_Active(t *testing.T) {
+	snap := Snapshot{
+		Surface: SurfaceSkysocks,
+		RangeSplit: &RangeSplit{
+			Enabled: true, ActiveSplits: 2, TotalSplits: 5,
+			TotalChunks: 100, TotalBytes: 20 << 20, StreamsPerSplit: 8, ChunkSize: 4 << 20,
+		},
+	}
+	page := string(Render(snap))
+	frag := string(RenderFragment(snap))
+	for _, out := range []string{page, frag} {
+		if !strings.Contains(out, "range-split") {
+			t.Error("missing range-split label")
+		}
+		if !strings.Contains(out, "rs-active") || !strings.Contains(out, "active") {
+			t.Error("active split must render the ACTIVE pill")
+		}
+		if !strings.Contains(out, "5 splits") {
+			t.Error("must render cumulative split count")
+		}
+	}
+}
+
+// TestRenderRangeSplit_IdleAndAbsent: enabled-but-idle renders an idle pill;
+// a nil RangeSplit omits the section entirely.
+func TestRenderRangeSplit_IdleAndAbsent(t *testing.T) {
+	idle := string(Render(Snapshot{Surface: SurfaceSkysocks, RangeSplit: &RangeSplit{Enabled: true, StreamsPerSplit: 8, ChunkSize: 4 << 20}}))
+	if !strings.Contains(idle, "rs-idle") {
+		t.Error("idle range-split must render the idle pill")
+	}
+	absent := string(Render(Snapshot{Surface: SurfaceSkysocks}))
+	if strings.Contains(absent, "range-split") {
+		t.Error("nil RangeSplit must omit the section")
+	}
+}

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -245,8 +245,31 @@ func writeLiveRegion(b *strings.Builder, snap Snapshot) {
 	}
 
 	writeStreamsSection(b, snap)
+	writeRangeSplitSection(b, snap)
 	writeMuxSection(b, snap)
 	writeLogSection(b, snap)
+}
+
+// writeRangeSplitSection renders the transparent HTTP range-split summary when
+// the surface reports one. It makes "is range-split firing" a visible line: a
+// live pill (ACTIVE with the in-flight split count, or IDLE) plus the cumulative
+// shape (splits · chunks · bytes, streams-per-split × chunk-size). Omitted
+// entirely when the surface does not range-split.
+func writeRangeSplitSection(b *strings.Builder, snap Snapshot) {
+	rs := snap.RangeSplit
+	if rs == nil || !rs.Enabled {
+		return
+	}
+	state, cls := "idle", "rs-idle"
+	if rs.ActiveSplits > 0 {
+		state, cls = fmt.Sprintf("active ×%d", rs.ActiveSplits), "rs-active"
+	}
+	fmt.Fprintf(b, `<p class="rsplit"><b>range-split</b> `+
+		`<span class="pill %s">%s</span> `+
+		`<span class="rsagg">%d splits · %d chunks · %s · %d streams/split × %s</span></p>`,
+		cls, html.EscapeString(state),
+		rs.TotalSplits, rs.TotalChunks, html.EscapeString(compactBytes(rs.TotalBytes)),
+		rs.StreamsPerSplit, html.EscapeString(compactBytes(uint64(rs.ChunkSize)))) //nolint:gosec // chunkSize>0
 }
 
 // writeMuxSection renders the route group as ONE unified route tree rooted at

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -95,6 +95,17 @@ type Client struct {
 	// separate tunnels and reassembled, so one download aggregates across the mesh
 	// with no client cooperation. Default-on; the app can retune or disable it.
 	rs rangeSplitConfig
+
+	// rsActive/rsSplits/rsChunks/rsBytes are the range-split observability
+	// counters the status page surfaces (proxystatus.RangeSplit) so "is
+	// range-split firing" is a live field, not just a Debugf. All atomic — the
+	// snapshot reads them without locking, like the per-stream meters. rsActive
+	// is the in-flight split count (Add(1) on commit, Add(-1) on completion); the
+	// rest are monotonic cumulative totals.
+	rsActive atomic.Int64
+	rsSplits atomic.Uint64
+	rsChunks atomic.Uint64
+	rsBytes  atomic.Uint64
 }
 
 // streamMeta is the per-stream detail the status page surfaces for an open
@@ -968,6 +979,25 @@ func (c *Client) removeStream(id uint32) {
 	c.streamsMu.Unlock()
 }
 
+// rangeSplitSnapshot reports the live range-split summary from the atomic
+// counters. It returns nil when range-splitting is disabled (so the status page
+// simply omits the section); when enabled it always reports, so ActiveSplits==0
+// with zero totals reads as "on, nothing splitting yet".
+func (c *Client) rangeSplitSnapshot() *proxystatus.RangeSplit {
+	if !c.rs.enabled {
+		return nil
+	}
+	return &proxystatus.RangeSplit{
+		Enabled:         true,
+		ActiveSplits:    c.rsActive.Load(),
+		TotalSplits:     c.rsSplits.Load(),
+		TotalChunks:     c.rsChunks.Load(),
+		TotalBytes:      c.rsBytes.Load(),
+		StreamsPerSplit: c.rs.concurrency,
+		ChunkSize:       c.rs.chunkSize,
+	}
+}
+
 // streamSnapshot returns the currently open streams as sorted proxystatus.Stream
 // rows (by id) for the status page, carrying each stream's cumulative up/down
 // bytes and a smoothed up/down rate. The rate is an EWMA differenced from the
@@ -1495,6 +1525,10 @@ func (c *Client) statusSnapshot() proxystatus.Snapshot {
 	} else {
 		snap.Note = "no active session to the exit"
 	}
+	// Range-split summary is local client truth (the counters live here, not in
+	// the visor-built base), overlaid like Streams so status.skysocks shows
+	// whether transparent HTTP range-splitting is firing right now.
+	snap.RangeSplit = c.rangeSplitSnapshot()
 	return snap
 }
 

--- a/pkg/skysocks/rangesplit.go
+++ b/pkg/skysocks/rangesplit.go
@@ -194,7 +194,15 @@ func (c *Client) rangeSplitInner(conn, stream net.Conn) (host string, clientPref
 		c.appCl.Log().Debugf("range-split: %s %d bytes → %d chunks × %d streams",
 			host, total, numChunks(total, c.rs.chunkSize), c.rs.concurrency)
 	}
+	// Observability counters (surfaced as proxystatus.RangeSplit): this is a
+	// committed multi-chunk split, so record it and mark it in flight for the
+	// duration of the concurrent fetch.
+	c.rsSplits.Add(1)
+	c.rsChunks.Add(uint64(numChunks(total, c.rs.chunkSize))) //nolint:gosec // numChunks>0 here (total>chunkSize)
+	c.rsBytes.Add(uint64(total))                             //nolint:gosec // total>0 checked above
+	c.rsActive.Add(1)
 	c.streamRemainingChunks(conn, req, host, validator, total)
+	c.rsActive.Add(-1)
 	conn.Close() //nolint:errcheck,gosec
 	return host, nil, true
 }

--- a/pkg/skysocks/rangesplit_counters_test.go
+++ b/pkg/skysocks/rangesplit_counters_test.go
@@ -1,0 +1,126 @@
+// Package skysocks pkg/skysocks/rangesplit_counters_test.go
+package skysocks
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// newRSTestClientH mirrors newRSTestClient but also returns the *Client so a test
+// can read its range-split observability counters after a request.
+func newRSTestClientH(t *testing.T, backendAddr string, conc int, chunk int64) (string, *Client) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close() //nolint:errcheck
+	dialed := make(chan net.Conn, 1)
+	go func() {
+		c, _ := ln.Accept() //nolint:errcheck
+		dialed <- c
+	}()
+	cliConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial pair: %v", err)
+	}
+	exitConn := <-dialed
+	go rsFakeExit(t, exitConn, backendAddr)
+
+	client, err := NewClient(cliConn, nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	client.SetRangeSplit(true, conc, chunk)
+	t.Cleanup(func() { _ = client.Close() }) //nolint:errcheck
+
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	proxyAddr := probe.Addr().String()
+	probe.Close()                                        //nolint:errcheck,gosec
+	go func() { _ = client.ListenAndServe(proxyAddr) }() //nolint:errcheck
+	for i := 0; i < 100; i++ {
+		if cc, err := net.Dial("tcp", proxyAddr); err == nil {
+			cc.Close() //nolint:errcheck,gosec
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return proxyAddr, client
+}
+
+// TestRangeSplitCountersFire: a committed multi-chunk split increments the
+// observability counters the status page surfaces (proxystatus.RangeSplit), so
+// "is range-split firing" is a readable field, not just a Debugf.
+func TestRangeSplitCountersFire(t *testing.T) {
+	const blobSize = 20 << 20 // 20 MiB
+	blob := make([]byte, blobSize)
+	for i := range blob {
+		blob[i] = byte(i*31 + 7)
+	}
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Etag", "\"blobv1\"")
+		http.ServeContent(w, r, "blob.bin", time.Unix(0, 0), bytes.NewReader(blob))
+	}))
+	defer backend.Close()
+
+	const conc, chunk = 4, 1 << 20 // 20 chunks over 4 streams
+	proxy, client := newRSTestClientH(t, backend.Listener.Addr().String(), conc, chunk)
+
+	// Before any request: enabled, nothing split yet.
+	if rs := client.rangeSplitSnapshot(); rs == nil || !rs.Enabled || rs.TotalSplits != 0 {
+		t.Fatalf("pre-request snapshot = %+v, want enabled with zero splits", rs)
+	}
+
+	resp := socks5Get(t, proxy, "example.com", "/blob.bin")
+	defer resp.Body.Close() //nolint:errcheck
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		t.Fatalf("drain body: %v", err)
+	}
+
+	// ActiveSplits is decremented just after the final byte is delivered, so poll
+	// briefly for it to settle rather than racing the fetch goroutine's exit.
+	var rs = client.rangeSplitSnapshot()
+	for i := 0; i < 100 && rs != nil && rs.ActiveSplits != 0; i++ {
+		time.Sleep(10 * time.Millisecond)
+		rs = client.rangeSplitSnapshot()
+	}
+	if rs == nil {
+		t.Fatal("post-request snapshot is nil")
+	}
+	if rs.TotalSplits != 1 {
+		t.Errorf("TotalSplits = %d, want 1", rs.TotalSplits)
+	}
+	if rs.TotalChunks != 20 {
+		t.Errorf("TotalChunks = %d, want 20", rs.TotalChunks)
+	}
+	if rs.TotalBytes != blobSize {
+		t.Errorf("TotalBytes = %d, want %d", rs.TotalBytes, blobSize)
+	}
+	if rs.StreamsPerSplit != conc {
+		t.Errorf("StreamsPerSplit = %d, want %d", rs.StreamsPerSplit, conc)
+	}
+	if rs.ChunkSize != chunk {
+		t.Errorf("ChunkSize = %d, want %d", rs.ChunkSize, chunk)
+	}
+	if rs.ActiveSplits != 0 {
+		t.Errorf("ActiveSplits = %d, want 0 after completion", rs.ActiveSplits)
+	}
+}
+
+// TestRangeSplitSnapshotDisabled: with the feature off the snapshot is nil, so
+// the status page omits the section entirely.
+func TestRangeSplitSnapshotDisabled(t *testing.T) {
+	c := &Client{}
+	c.SetRangeSplit(false, 0, 0)
+	if rs := c.rangeSplitSnapshot(); rs != nil {
+		t.Fatalf("disabled snapshot = %+v, want nil", rs)
+	}
+}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -34,6 +34,7 @@ type API interface {
 	Overview() (*Overview, error)
 	Summary() (*Summary, error)
 	StateSnapshot() (*StateSnapshot, error)
+	StateSnapshotProjected(fields []string) (*StateSnapshot, error)
 	Health() (*HealthInfo, error)
 	IsStartupComplete() bool
 	EnableHypervisor() error

--- a/pkg/visor/api_state.go
+++ b/pkg/visor/api_state.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/proxystatus"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/transport"
 )
@@ -37,7 +38,7 @@ type StateSnapshot struct {
 	Apps          []*appserver.AppState            `json:"apps,omitempty"`
 	Transports    []*TransportSummary              `json:"transports,omitempty"`
 	Persistent    []transport.PersistentTransports `json:"persistent_transports,omitempty"`
-	Modules       ModulePresence                   `json:"modules"`
+	Modules       *ModulePresence                  `json:"modules,omitempty"`
 
 	// RouterConfig is the routing configuration actually IN FORCE at
 	// runtime (min_hops / mux_routes / force_local / existing_tp_only
@@ -64,9 +65,73 @@ type StateSnapshot struct {
 	// a query against the live visor (local or --via dmsg://<pk>).
 	CXOFeeds []CXOFeedState `json:"cxo,omitempty"`
 
+	// Proxy is the visor-side live proxystatus snapshot for the skysocks
+	// surface — the same per-leg mux telemetry, running flag, and (when the
+	// client pushes it) range-split summary the status.skysocks page renders.
+	// It is OPT-IN: built only for `--select proxy`, never in the full/default
+	// snapshot, so the default payload is unchanged.
+	Proxy *proxystatus.Snapshot `json:"proxy,omitempty"`
+
 	// Notes collects per-section errors ("routing: <err>") so the snapshot is
 	// self-describing about what it could and could not read.
 	Notes []string `json:"notes,omitempty"`
+}
+
+// State*-select keys name the projectable subtrees of a StateSnapshot. Passing a
+// subset to StateSnapshotProjected makes the SERVER build and marshal ONLY those
+// sections, so a cheap `--select mux` skips the expensive transports build (the
+// full snapshot is ~900 KB, dominated by transports at ~307 KB; mux is ~75 KB).
+// The keys match the snapshot's JSON field names (or a short alias) so a --jq
+// expression written against the full snapshot transfers to a projection
+// unchanged.
+const (
+	SelectSummary    = "summary"    // summary
+	SelectHealth     = "health"     // health + service_health
+	SelectRouting    = "routing"    // routing_stats + route_groups + routing_policy + router_config
+	SelectMux        = "mux"        // mux_route_groups (+ route_groups count)
+	SelectApps       = "apps"       // apps
+	SelectTransports = "transports" // transports + persistent_transports
+	SelectModules    = "modules"    // modules
+	SelectCXO        = "cxo"        // cxo feed publish-health
+	SelectProxy      = "proxy"      // visor-side proxystatus snapshot (skysocks); opt-in only
+)
+
+// StateSelectKeys is the documented set of --select keys, in help order.
+var StateSelectKeys = []string{
+	SelectSummary, SelectHealth, SelectRouting, SelectMux,
+	SelectApps, SelectTransports, SelectModules, SelectCXO, SelectProxy,
+}
+
+// stateFieldSet is the parsed --select set. A nil set means "everything in the
+// default full snapshot" (proxy stays opt-in even then). An entry present but
+// unknown is ignored here and surfaced as a Note by the builder.
+type stateFieldSet map[string]bool
+
+// newStateFieldSet parses the requested field keys. An empty/nil fields slice
+// returns a nil set, i.e. build the full default snapshot.
+func newStateFieldSet(fields []string) stateFieldSet {
+	if len(fields) == 0 {
+		return nil
+	}
+	set := make(stateFieldSet, len(fields))
+	for _, f := range fields {
+		if f != "" {
+			set[f] = true
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
+}
+
+// has reports whether section k should be built. A nil set (no --select) builds
+// every default section; proxy is never a default section (see wantProxy).
+func (s stateFieldSet) has(k string) bool {
+	if k == SelectProxy {
+		return s != nil && s[k]
+	}
+	return s == nil || s[k]
 }
 
 // EffectiveRoutingConfig is the routing configuration in force at
@@ -95,10 +160,24 @@ type ModulePresence struct {
 	EmbeddedRouteSetup bool `json:"embedded_route_setup"`
 }
 
-// StateSnapshot assembles the runtime StateSnapshot. Each section is best-effort
-// and never panics on a not-yet-initialized subsystem; failures are recorded in
-// Notes. Secrets are never included (see the StateSnapshot type doc).
+// StateSnapshot assembles the full runtime StateSnapshot (every default
+// section). It is StateSnapshotProjected(nil).
 func (v *Visor) StateSnapshot() (*StateSnapshot, error) {
+	return v.StateSnapshotProjected(nil)
+}
+
+// StateSnapshotProjected assembles the runtime StateSnapshot, building ONLY the
+// sections named in fields (see the StateSelect* keys). A nil/empty fields slice
+// builds the full default snapshot (proxy stays opt-in). This is the efficiency
+// win behind `cli visor state --select`: `--select mux` skips the ~307 KB
+// transports build entirely, so a 1 s mux watch is cheap.
+//
+// Each requested section is best-effort and never panics on a not-yet-
+// initialized subsystem; failures are recorded in Notes. Secrets are never
+// included (see the StateSnapshot type doc). At + Suspended are always populated
+// (both cheap).
+func (v *Visor) StateSnapshotProjected(fields []string) (*StateSnapshot, error) {
+	want := newStateFieldSet(fields)
 	snap := &StateSnapshot{At: time.Now()}
 	note := func(section string, err error) {
 		if err != nil {
@@ -112,95 +191,121 @@ func (v *Visor) StateSnapshot() (*StateSnapshot, error) {
 		snap.Suspended = susp
 	}
 
-	if sum, err := v.Summary(); err != nil {
-		note("summary", err)
-	} else {
-		snap.Summary = sum
-	}
-
-	if h, err := v.Health(); err != nil {
-		note("health", err)
-	} else {
-		snap.Health = h
-	}
-
-	if sh, err := v.ServiceHealth(); err != nil {
-		note("service_health", err)
-	} else {
-		snap.ServiceHealth = sh
-	}
-
-	if rs, err := v.RoutingStats(); err != nil {
-		note("routing_stats", err)
-	} else {
-		snap.RoutingStats = &rs
-	}
-
-	if rgs, err := v.RouteGroups(); err != nil {
-		note("route_groups", err)
-	} else {
-		snap.RouteGroups = len(rgs)
-	}
-
-	if mrgs, err := v.AllRouteGroupMuxInfo(); err != nil {
-		note("mux_route_groups", err)
-	} else if len(mrgs) > 0 {
-		snap.MuxRouteGroups = mrgs
-	}
-
-	if rc, err := v.GetRouterSettings(); err != nil {
-		note("router_config", err)
-	} else {
-		erc := &EffectiveRoutingConfig{
-			MinHops:             rc.MinHops,
-			MuxRoutes:           rc.MuxRoutes,
-			ForceLocalRoutes:    rc.ForceLocalRoutes,
-			ExistingTPOnly:      rc.ExistingTPOnly,
-			TransportPreference: rc.TransportPreference,
+	if want.has(SelectSummary) {
+		if sum, err := v.Summary(); err != nil {
+			note("summary", err)
+		} else {
+			snap.Summary = sum
 		}
-		if v.conf != nil && v.conf.Routing != nil {
-			erc.EnableCascadeRouteSetup = v.conf.Routing.EnableCascadeRouteSetup
-			erc.PolicyPerDial = v.conf.Routing.PolicyPerDial
+	}
+
+	if want.has(SelectHealth) {
+		if h, err := v.Health(); err != nil {
+			note("health", err)
+		} else {
+			snap.Health = h
 		}
-		snap.RouterConfig = erc
+		if sh, err := v.ServiceHealth(); err != nil {
+			note("service_health", err)
+		} else {
+			snap.ServiceHealth = sh
+		}
 	}
 
-	if rp, err := v.RoutingPolicies(); err != nil {
-		note("routing_policy", err)
-	} else {
-		snap.RoutingPolicy = rp
+	if want.has(SelectRouting) {
+		if rs, err := v.RoutingStats(); err != nil {
+			note("routing_stats", err)
+		} else {
+			snap.RoutingStats = &rs
+		}
+		if rc, err := v.GetRouterSettings(); err != nil {
+			note("router_config", err)
+		} else {
+			erc := &EffectiveRoutingConfig{
+				MinHops:             rc.MinHops,
+				MuxRoutes:           rc.MuxRoutes,
+				ForceLocalRoutes:    rc.ForceLocalRoutes,
+				ExistingTPOnly:      rc.ExistingTPOnly,
+				TransportPreference: rc.TransportPreference,
+			}
+			if v.conf != nil && v.conf.Routing != nil {
+				erc.EnableCascadeRouteSetup = v.conf.Routing.EnableCascadeRouteSetup
+				erc.PolicyPerDial = v.conf.Routing.PolicyPerDial
+			}
+			snap.RouterConfig = erc
+		}
+		if rp, err := v.RoutingPolicies(); err != nil {
+			note("routing_policy", err)
+		} else {
+			snap.RoutingPolicy = rp
+		}
 	}
 
-	if apps, err := v.Apps(); err != nil {
-		note("apps", err)
-	} else {
-		snap.Apps = apps
+	// route_groups is a cheap count wanted by both the routing and mux views.
+	if want.has(SelectRouting) || want.has(SelectMux) {
+		if rgs, err := v.RouteGroups(); err != nil {
+			note("route_groups", err)
+		} else {
+			snap.RouteGroups = len(rgs)
+		}
 	}
 
-	// logs=true so each TransportSummary.Log carries the transport's
-	// cumulative recv/sent byte counters — the passive throughput totals an
-	// operator debugging a slow/idle link wants, surfaced without a second call.
-	if tps, err := v.Transports(nil, nil, true); err != nil {
-		note("transports", err)
-	} else {
-		snap.Transports = tps
+	if want.has(SelectMux) {
+		if mrgs, err := v.AllRouteGroupMuxInfo(); err != nil {
+			note("mux_route_groups", err)
+		} else if len(mrgs) > 0 {
+			snap.MuxRouteGroups = mrgs
+		}
 	}
 
-	if pts, err := v.GetPersistentTransports(); err != nil {
-		note("persistent_transports", err)
-	} else {
-		snap.Persistent = pts
+	if want.has(SelectApps) {
+		if apps, err := v.Apps(); err != nil {
+			note("apps", err)
+		} else {
+			snap.Apps = apps
+		}
 	}
 
-	snap.Modules = ModulePresence{
-		StatsTracker:       v.statsTracker != nil,
-		UptimeRecorder:     v.uptimeRecorder != nil,
-		EmbeddedTPS:        v.embeddedTPS != nil,
-		EmbeddedRouteSetup: v.embeddedRouteSetup != nil,
+	if want.has(SelectTransports) {
+		// logs=true so each TransportSummary.Log carries the transport's
+		// cumulative recv/sent byte counters — the passive throughput totals an
+		// operator debugging a slow/idle link wants, surfaced without a second call.
+		if tps, err := v.Transports(nil, nil, true); err != nil {
+			note("transports", err)
+		} else {
+			snap.Transports = tps
+		}
+		if pts, err := v.GetPersistentTransports(); err != nil {
+			note("persistent_transports", err)
+		} else {
+			snap.Persistent = pts
+		}
 	}
 
-	if cf := v.CXOFeedStates(); len(cf) > 0 {
-		snap.CXOFeeds = cf
+	if want.has(SelectModules) {
+		snap.Modules = &ModulePresence{
+			StatsTracker:       v.statsTracker != nil,
+			UptimeRecorder:     v.uptimeRecorder != nil,
+			EmbeddedTPS:        v.embeddedTPS != nil,
+			EmbeddedRouteSetup: v.embeddedRouteSetup != nil,
+		}
+	}
+
+	if want.has(SelectCXO) {
+		if cf := v.CXOFeedStates(); len(cf) > 0 {
+			snap.CXOFeeds = cf
+		}
+	}
+
+	// proxy is opt-in (never in the default snapshot): the visor-side
+	// proxystatus snapshot for the skysocks surface — per-leg mux telemetry,
+	// running flag, and the range-split summary when the client has pushed it.
+	if want.has(SelectProxy) {
+		if ps, err := v.proxyStatusProvider().StatusSnapshot(proxystatus.SurfaceSkysocks); err != nil {
+			note("proxy", err)
+		} else {
+			snap.Proxy = &ps
+		}
 	}
 
 	return snap, nil

--- a/pkg/visor/api_state_projection_test.go
+++ b/pkg/visor/api_state_projection_test.go
@@ -1,0 +1,69 @@
+// Package visor pkg/visor/api_state_projection_test.go
+package visor
+
+import "testing"
+
+// TestStateFieldSet_All: a nil/empty --select builds every DEFAULT section
+// (proxy stays opt-in even for the full snapshot, so its heavy provider call is
+// never made implicitly).
+func TestStateFieldSet_All(t *testing.T) {
+	for _, fields := range [][]string{nil, {}, {""}, {"", ""}} {
+		set := newStateFieldSet(fields)
+		if set != nil {
+			t.Fatalf("newStateFieldSet(%q) = %v, want nil (full snapshot)", fields, set)
+		}
+		for _, k := range StateSelectKeys {
+			want := k != SelectProxy // every default section, proxy excluded
+			if got := set.has(k); got != want {
+				t.Errorf("full snapshot: has(%q) = %v, want %v", k, got, want)
+			}
+		}
+	}
+}
+
+// TestStateFieldSet_Projection: --select mux gates ONLY the mux section (this is
+// the efficiency contract — transports/apps/etc are not built, so their ~307 KB
+// work is skipped).
+func TestStateFieldSet_Projection(t *testing.T) {
+	set := newStateFieldSet([]string{SelectMux})
+	if set == nil {
+		t.Fatal("newStateFieldSet([mux]) = nil, want a set")
+	}
+	built := map[string]bool{}
+	for _, k := range StateSelectKeys {
+		built[k] = set.has(k)
+	}
+	if !built[SelectMux] {
+		t.Error("--select mux must build mux")
+	}
+	for _, k := range []string{SelectSummary, SelectHealth, SelectRouting, SelectApps, SelectTransports, SelectModules, SelectCXO, SelectProxy} {
+		if built[k] {
+			t.Errorf("--select mux must NOT build %q", k)
+		}
+	}
+}
+
+// TestStateFieldSet_ProxyOptIn: proxy is built ONLY when named explicitly, never
+// as a side effect of the full snapshot or another key.
+func TestStateFieldSet_ProxyOptIn(t *testing.T) {
+	if newStateFieldSet([]string{SelectMux}).has(SelectProxy) {
+		t.Error("--select mux must not build proxy")
+	}
+	if !newStateFieldSet([]string{SelectProxy}).has(SelectProxy) {
+		t.Error("--select proxy must build proxy")
+	}
+	if newStateFieldSet(nil).has(SelectProxy) {
+		t.Error("full snapshot must not build proxy")
+	}
+}
+
+// TestStateFieldSet_Multi: comma-selected multiple keys each gate on.
+func TestStateFieldSet_Multi(t *testing.T) {
+	set := newStateFieldSet([]string{SelectHealth, SelectRouting})
+	if !set.has(SelectHealth) || !set.has(SelectRouting) {
+		t.Error("multi-select must build both requested keys")
+	}
+	if set.has(SelectTransports) {
+		t.Error("multi-select must not build an unrequested key")
+	}
+}

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -70,6 +70,10 @@ func (proxyDefaultAPI) StateSnapshot() (*StateSnapshot, error) {
 	return nil, ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) StateSnapshotProjected(_ []string) (*StateSnapshot, error) {
+	return nil, ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) Health() (*HealthInfo, error) {
 	return nil, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -231,6 +231,14 @@ func (rc *rpcClient) StateSnapshot() (*StateSnapshot, error) {
 	return out, err
 }
 
+// StateSnapshotProjected calls StateSnapshotProjected with the requested subtree
+// keys, so the server builds only those sections.
+func (rc *rpcClient) StateSnapshotProjected(fields []string) (*StateSnapshot, error) {
+	out := new(StateSnapshot)
+	err := rc.Call("StateSnapshotProjected", &StateSnapshotReq{Fields: fields}, out)
+	return out, err
+}
+
 // Overview calls Overview.
 func (rc *rpcClient) Overview() (*Overview, error) {
 	out := new(Overview)

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -170,6 +170,18 @@ func (mc *mockRPCClient) StateSnapshot() (*StateSnapshot, error) {
 	return &StateSnapshot{At: time.Now(), Summary: summary}, nil
 }
 
+// StateSnapshotProjected implements API.
+func (mc *mockRPCClient) StateSnapshotProjected(fields []string) (*StateSnapshot, error) {
+	snap, err := mc.StateSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	if set := newStateFieldSet(fields); set != nil && !set.has(SelectSummary) {
+		snap.Summary = nil
+	}
+	return snap, nil
+}
+
 // Summary implements API.
 func (mc *mockRPCClient) Summary() (*Summary, error) {
 	overview, err := mc.Overview()

--- a/pkg/visor/rpc_visor.go
+++ b/pkg/visor/rpc_visor.go
@@ -171,6 +171,29 @@ func (r *RPC) StateSnapshot(_ *struct{}, out *StateSnapshot) (err error) {
 	return nil
 }
 
+// StateSnapshotReq is the argument to StateSnapshotProjected: the subtree keys
+// (see the StateSelect* constants) to build. Empty builds the full snapshot.
+type StateSnapshotReq struct {
+	Fields []string
+}
+
+// StateSnapshotProjected builds only the requested subtree(s) of the snapshot
+// server-side, so a `--select mux` call skips the expensive transports build.
+// See StateSnapshotProjected in api_state.go.
+func (r *RPC) StateSnapshotProjected(in *StateSnapshotReq, out *StateSnapshot) (err error) {
+	defer rpcutil.LogCall(r.log, "StateSnapshotProjected", in)(out, &err)
+	var fields []string
+	if in != nil {
+		fields = in.Fields
+	}
+	snap, err := r.visor.StateSnapshotProjected(fields)
+	if err != nil {
+		return err
+	}
+	*out = *snap
+	return nil
+}
+
 // Overview provides a overview of the AppNode.
 func (r *RPC) Overview(_ *struct{}, out *Overview) (err error) {
 	defer rpcutil.LogCall(r.log, "Overview", nil)(out, &err)


### PR DESCRIPTION
`cli visor state --json` returns the full curated snapshot on every call, and `--jq` filters client-side, so the server builds the whole payload each time. Measured live just now: full snapshot **1.40 MB**, of which `transports` is **450 KB** (~32%) and `mux_route_groups` only **34 KB**. Re-invoking that at 1 s to watch routing state is untenable, and today range-split activity is only a `Debugf`, not observable state.

This adds two flags and a projected RPC.

**`--select <keys>`** projects the snapshot **server-side** via a new `StateSnapshotProjected(fields)` RPC that builds ONLY the requested subtree(s). `--select mux` returns ~34 KB and skips the 450 KB transports build entirely. Keys: `summary, health, routing, mux, apps, transports, modules, cxo, proxy` (comma-separated). Field names match the full snapshot, so existing `--jq` expressions transfer unchanged. `proxy` is opt-in (never in the default snapshot).

**`--watch <interval>`** opens the RPC once and emits one snapshot per tick as NDJSON (no banners/ANSI) until Ctrl-C — a clean pipe for a chart or Monitor. Composes with `--select` (cheap projected ticks), `--jq` (each tick to one compact line) and `--via` (remote visor). Example:

    skywire cli visor state --watch 1s --select mux --jq '.mux_route_groups'

**Range-split as state, not logs.** Atomic counters on the skysocks `Client` (active/total splits, chunks, bytes, streams-per-split) are surfaced as `proxystatus.Snapshot.RangeSplit` and rendered in the live status.skysocks region, which already rides the ~1s WebSocket fragment push — so "is range-split firing" is a readable field. Wiring those client-process counters into `visor state --select proxy` needs an app→visor push and is left as a follow-up; `--select proxy` currently surfaces the visor-side proxystatus (per-leg mux + running).

Tests cover the projection gating (only the requested subtree is built), the watch tick loop (emits then stops on cancel), NDJSON/jq compaction, and the range-split counters incrementing on a committed multi-chunk split.