### PR TITLE
fix(test): repair develop Test lane (2 real races + flaky-test deflakes)

### DIFF
--- a/pkg/cxo/node/connect_adopt_test.go
+++ b/pkg/cxo/node/connect_adopt_test.go
@@ -81,9 +81,17 @@ func TestConnectPKAdoptsExistingConn(t *testing.T) {
 	defer cancel()
 
 	// A dials B (the visor's AnnounceTo). B accepts an inbound conn.
-	connAB, err := nodeA.DMSG().ConnectPK(ctx, pkB)
-	require.NoError(t, err)
-	require.NotNil(t, connAB)
+	// Retry the first dial: both clients are Ready() (each has a session
+	// and a published entry), but the shared dmsg server can still be
+	// finishing its side of B's session registration, so the very first
+	// forward occasionally 202s ("cannot connect to delegated server").
+	// Production dmsg dials retry through the RSN/circuit-breaker for the
+	// same reason; this settles the in-memory test env deterministically.
+	var connAB *Conn
+	require.Eventually(t, func() bool {
+		connAB, err = nodeA.DMSG().ConnectPK(ctx, pkB)
+		return err == nil && connAB != nil
+	}, 10*time.Second, 100*time.Millisecond, "A could not connect to B: %v", err)
 
 	// B's cxo NodeID for A is pkA (identity == dmsg PK).
 	var idA skycipher.PubKey

--- a/pkg/cxo/treestore/churn_lag_test.go
+++ b/pkg/cxo/treestore/churn_lag_test.go
@@ -53,6 +53,13 @@ func (c *churnSub) size() int {
 	return len(c.present)
 }
 
+func (c *churnSub) has(path string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.present[path]
+	return ok
+}
+
 func (c *churnSub) snapshot() (int, int, int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -101,9 +108,45 @@ func newChurnPair(t *testing.T, batchWindow time.Duration) (*Publisher, *churnSu
 	t.Cleanup(func() { _ = sub.Close() }) //nolint:errcheck
 	sub.OnUpdate(cs.apply)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	require.NoError(t, sub.ConnectTCP(ctx, addr), "ConnectTCP")
+
+	// Verify the subscription is actually LIVE before the caller starts
+	// measuring. Plain ConnectTCP returns as soon as the Subscribe frame is
+	// queued; on a loaded CI runner it can stay half-attached and deliver
+	// nothing — the observed present=0/events=0/roots=0 flake — and the
+	// reconnect watchdog never rescues it, because it skips any feed that has
+	// not yet seen a single Root (lastUpdateNs==0). (An empty tree pushes no
+	// initial Root, so we cannot just wait for one.) Publish a probe, wait for
+	// it to arrive, and re-Connect if it does not; then delete it and wait for
+	// the removal to propagate, so the caller starts from an empty, verifiably
+	// live subscription.
+	const probe = "__probe__/live"
+	live := false
+	for attempt := 0; attempt < 10 && !live; attempt++ {
+		if attempt > 0 {
+			_ = sub.ConnectTCP(ctx, addr) //nolint:errcheck // best-effort re-attach
+		}
+		require.NoError(t, pub.Put(probe, []byte("x")))
+		require.NoError(t, pub.Flush())
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if cs.has(probe) {
+				live = true
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	require.True(t, live, "subscription never became live (no Root delivered after probe)")
+
+	// Remove the probe and wait for the subscriber to drop it, so present
+	// starts empty and the caller's target counts are exact.
+	require.NoError(t, pub.Delete(probe))
+	require.NoError(t, pub.Flush())
+	require.Eventually(t, func() bool { return !cs.has(probe) }, 10*time.Second, 10*time.Millisecond,
+		"probe deletion never propagated to the subscriber")
 	return pub, cs
 }
 

--- a/pkg/dmsg/dmsgscp/copyidle_test.go
+++ b/pkg/dmsg/dmsgscp/copyidle_test.go
@@ -20,22 +20,27 @@ func TestCopyNIdle_ProgressNeverTimesOut(t *testing.T) {
 	defer c2.Close() //nolint:errcheck
 
 	chunk := bytes.Repeat([]byte("x"), 4096)
-	const chunks = 10
+	const chunks = 15
 	total := chunks * len(chunk)
 
+	// Gap and idle window are kept a full order of magnitude apart (50ms vs
+	// 500ms) so ordinary CI scheduling jitter — which on a loaded Windows
+	// runner once stretched a nominal 15ms gap past a 60ms window and tripped
+	// a spurious "read pipe: i/o timeout" — cannot cross the idle deadline.
+	const gap = 50 * time.Millisecond
 	go func() {
 		for i := 0; i < chunks; i++ {
-			_ = c2.SetWriteDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck // test writer deadline is best-effort
+			_ = c2.SetWriteDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck // test writer deadline is best-effort
 			if _, err := c2.Write(chunk); err != nil {
 				return
 			}
-			time.Sleep(15 * time.Millisecond) // gap < idle, but sum >> idle
+			time.Sleep(gap) // gap << idle, but sum >> idle
 		}
 	}()
 
 	var buf bytes.Buffer
-	// idle 60ms; total transfer ~150ms+. Must NOT time out.
-	n, err := copyNIdle(&buf, c1, int64(total), c1, 60*time.Millisecond)
+	// idle 500ms; total transfer ~750ms. Must NOT time out.
+	n, err := copyNIdle(&buf, c1, int64(total), c1, 500*time.Millisecond)
 	require.NoError(t, err)
 	require.Equal(t, int64(total), n)
 	require.Equal(t, total, buf.Len())

--- a/pkg/pty/exec_http_test.go
+++ b/pkg/pty/exec_http_test.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/binary"
 	"io"
 	"net"
 	"net/http"
@@ -453,10 +454,25 @@ func TestExecStreamClientDisconnectKillsCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadResponse: %v", err)
 	}
-	// Wait until the command has actually started before walking away.
+	// Wait until the command has actually started before walking away, and
+	// drain the WHOLE first frame (header + payload), not just its header.
+	// Reading only the header can leave the server mid-write on the
+	// synchronous net.Pipe — the trailing bytes of the chunked-transfer frame
+	// still pending. A client Close while a server write is in flight surfaces
+	// as a write error, which net/http does NOT turn into a request-context
+	// cancellation; the command then runs to its 30-minute default timeout and
+	// this test fails at its own 20s bound (the intermittent CI orphan). By
+	// draining the payload the server returns to an idle read (its
+	// disconnect-detection background read armed), so the Close below reliably
+	// cancels r.Context() and tears the command down.
 	hdr := make([]byte, execStreamFrameHdr)
 	if _, err := io.ReadFull(resp.Body, hdr); err != nil {
 		t.Fatalf("reading first frame header: %v", err)
+	}
+	if payloadLen := binary.BigEndian.Uint32(hdr[1:]); payloadLen > 0 {
+		if _, err := io.ReadFull(resp.Body, make([]byte, payloadLen)); err != nil {
+			t.Fatalf("reading first frame payload: %v", err)
+		}
 	}
 
 	_ = cliConn.Close() //nolint:errcheck

--- a/pkg/router/client_pool_test.go
+++ b/pkg/router/client_pool_test.go
@@ -4,6 +4,7 @@ package router
 import (
 	"context"
 	"net"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -18,13 +19,17 @@ import (
 // so a test can distinguish "reused a pooled connection" from "dialed fresh".
 type countingDialer struct {
 	dials int32
+	mu    sync.Mutex
 	conns []net.Conn // kept so the pipe peers aren't GC'd mid-test
 }
 
 func (d *countingDialer) Dial(_ context.Context, _ cipher.PubKey, _ uint16) (net.Conn, error) {
 	atomic.AddInt32(&d.dials, 1)
 	ours, theirs := net.Pipe()
+	// MakePooledMap dials several PKs concurrently, so guard the slice append.
+	d.mu.Lock()
 	d.conns = append(d.conns, ours, theirs)
+	d.mu.Unlock()
 	return ours, nil
 }
 func (d *countingDialer) Probe(_ context.Context, _ cipher.PubKey, _ uint16) bool { return true }

--- a/pkg/router/fec_endtoend_test.go
+++ b/pkg/router/fec_endtoend_test.go
@@ -261,9 +261,27 @@ func TestFECMuxEndToEndThroughput(t *testing.T) {
 		return elapsed, perLeg
 	}
 
-	noFEC, noLegs := run(false, hetero)
-	withFEC, fecLegs := run(true, hetero)
-	singleT, _ := run(false, single)
+	// Best-of-N: these are sub-100ms wall-clock measurements over simulated
+	// millisecond legs, so a single GC pause or scheduler hiccup on a loaded
+	// CI runner can inflate one run 3x (observed: a lone withFEC sample at
+	// 163ms against a ~50ms norm) and break the ratio assertions below. Taking
+	// the minimum across a few attempts rejects that transient noise while
+	// still measuring the real pipeline cost — standard practice for a timing
+	// microbenchmark.
+	best := func(fec bool, lats []time.Duration) (time.Duration, []int64) {
+		var bt time.Duration
+		var bl []int64
+		for i := 0; i < 3; i++ {
+			el, legs := run(fec, lats)
+			if i == 0 || el < bt {
+				bt, bl = el, legs
+			}
+		}
+		return bt, bl
+	}
+	noFEC, noLegs := best(false, hetero)
+	withFEC, fecLegs := best(true, hetero)
+	singleT, _ := best(false, single)
 
 	t.Logf("heterogeneous legs %v", hetero)
 	t.Logf("  mux/no-FEC : %v   per-leg bytes=%v", noFEC.Round(time.Millisecond), noLegs)

--- a/pkg/skychat/group/joincost_test.go
+++ b/pkg/skychat/group/joincost_test.go
@@ -60,8 +60,13 @@ func TestJoinPoWBinding(t *testing.T) {
 	}
 
 	// Asking for more than was paid is refused — that is what lets a group
-	// raise its price and have old proofs stop working.
-	if valid, _ := VerifyJoinPoW("group-a", pk, p, bits+8, now); valid {
+	// raise its price and have old proofs stop working. Verify against one
+	// bit more than the proof ACTUALLY achieved: the solver stops at the
+	// first nonce clearing `bits`, but that digest carries >= bits leading
+	// zeros and lands on bits+8 ~1/256 of the time by luck, which used to
+	// flake this assertion. strength+1 can never be satisfied by definition.
+	solved := joinPoWStrength("group-a", pk, p)
+	if valid, _ := VerifyJoinPoW("group-a", pk, p, solved+1, now); valid {
 		t.Error("a proof verified against a higher difficulty than it solved")
 	}
 }

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -430,7 +430,10 @@ func (mt *ManagedTransport) Serve(readCh chan<- routing.Packet) {
 	// dispatches arrive over real unreliable datagrams (no HOL blocking). The
 	// context is canceled when Serve returns (i.e. mt.done fires), unblocking
 	// the blocking ReadDatagram.
-	if dc, ok := datagramConnOf(mt.transport); ok {
+	mt.transportMx.Lock()
+	tp := mt.transport
+	mt.transportMx.Unlock()
+	if dc, ok := datagramConnOf(tp); ok {
 		mt.wg.Add(1)
 		// Serve is a transport-lifetime goroutine with no request-scoped
 		// parent; Background is correct here. Canceled below when Serve returns.

--- a/pkg/transport/network/dmsg_test.go
+++ b/pkg/transport/network/dmsg_test.go
@@ -50,11 +50,19 @@ func TestDmsgAdapters_EndToEnd(t *testing.T) {
 		}
 	}()
 
-	// A dials B.
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	// A dials B. Retry the first dial: both dmsg clients are Ready() (each
+	// holds MinSessions sessions and a published entry), but the shared dmsg
+	// servers can still be finishing their side of B's session registration,
+	// so the very first forward occasionally 202s ("cannot connect to
+	// delegated server"). Production dmsg dials retry for the same reason;
+	// this settles the in-memory test env deterministically.
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 	defer cancel()
-	dialed, err := aClient.Dial(ctx, dcB.LocalPK(), port)
-	require.NoError(t, err)
+	var dialed Transport
+	require.Eventually(t, func() bool {
+		dialed, err = aClient.Dial(ctx, dcB.LocalPK(), port)
+		return err == nil && dialed != nil
+	}, 20*time.Second, 100*time.Millisecond, "A could not dial B: %v", err)
 
 	var accepted Transport
 	select {

--- a/pkg/transport/network/handshake/handshake_extra_test.go
+++ b/pkg/transport/network/handshake/handshake_extra_test.go
@@ -7,7 +7,6 @@ package handshake
 
 import (
 	"errors"
-	"net"
 	"testing"
 	"time"
 
@@ -57,7 +56,7 @@ func TestResponderRejection(t *testing.T) {
 	iAddr := dmsg.Addr{PK: initPK, Port: 10}
 	rAddr := dmsg.Addr{PK: respPK, Port: 11}
 
-	initC, respC := net.Pipe()
+	initC, respC := bufferedPipe()
 	deadline := time.Now().Add(Timeout)
 
 	respErrCh := make(chan error, 1)

--- a/pkg/transport/network/handshake/handshake_test.go
+++ b/pkg/transport/network/handshake/handshake_test.go
@@ -20,6 +20,27 @@ const (
 	port2 = 11
 )
 
+// bufferedPipe returns an in-memory net.Conn pair that, unlike a raw net.Pipe,
+// does not require every byte of a Write to be consumed before the Write
+// returns. Each direction is pumped by an io.Copy goroutine whose 32KB read
+// buffer swallows a whole frame at once, so the writer is released immediately.
+//
+// A raw net.Pipe deadlocks this handshake on ~6% of runs: json.Encoder emits a
+// frame plus a trailing '\n' (e.g. frame1 is 65 bytes), but the peer's
+// json.Decoder parses the value and stops after the 64 JSON bytes, never
+// reading the newline. On an unbuffered net.Pipe the responder's Write then
+// blocks forever on that one byte while the initiator advances to write the
+// next frame — both sides wedge until the deadline. Real transports (TCP, QUIC,
+// dmsg streams) are buffered, so the stray newline is harmless there; this
+// helper restores that property for the test.
+func bufferedPipe() (net.Conn, net.Conn) {
+	x, p1 := net.Pipe()
+	y, p2 := net.Pipe()
+	go func() { _, _ = io.Copy(p2, p1) }()
+	go func() { _, _ = io.Copy(p1, p2) }()
+	return x, y
+}
+
 func TestHandshake(t *testing.T) {
 	type hsResult struct {
 		lAddr dmsg.Addr
@@ -37,7 +58,7 @@ func TestHandshake(t *testing.T) {
 		iAddr := dmsg.Addr{PK: initPK, Port: port1}
 		rAddr := dmsg.Addr{PK: respPK, Port: port2}
 
-		initC, respC := net.Pipe()
+		initC, respC := bufferedPipe()
 
 		deadline := time.Now().Add(Timeout)
 


### PR DESCRIPTION
The lint/test split in #4326 (Test now runs even when lint fails) surfaced a
pile of `./pkg/...` failures that had been silently skipped for weeks. This
fixes the real bugs and deflakes the timing/settling-sensitive tests.

**Real (`-race`)**
- `transport`: the one unlocked read of `mt.transport` in `Serve`
  (`datagramConnOf`) raced `close()`'s `mt.transport = nil`; snapshot it under
  `transportMx` like every other read. (`TestOutboundSaveNudgesReRegister`)
- `router`: the test `countingDialer.conns` append raced under
  `MakePooledMap`'s concurrent dials; add a mutex. Same race also aborted
  `TestSampleThroughputCounterReset`. (`TestMap_PooledAndDiscard`)

**Flaky**
- `handshake` `TestHandshake`: deadlocked ~6% on a raw `net.Pipe` — the
  `json.Encoder` trailing `\n` is left unread by the peer's `json.Decoder`,
  wedging the writer on the unbuffered pipe. Use a buffered in-memory pipe;
  real transports are buffered so this never occurs off `net.Pipe`.
- `skychat/group` `TestJoinPoWBinding`: verified a 12-bit proof against
  `bits+8`, which a solved proof satisfies ~1/256 of the time. Verify against
  the proof's actual `strength+1` (deterministic).
- `dmsgscp` `TestCopyNIdle_ProgressNeverTimesOut`: widened idle-vs-gap margin
  (60ms/15ms → 500ms/50ms) so CI jitter cannot cross the idle deadline.
- `cxo/node`, `transport/network`: retry the first dmsg dial — both clients are
  `Ready()`, but the shared server can still be registering the peer's session,
  so the first forward 202s.
- `cxo/treestore` `TestCXOChurn_*`: plain `ConnectTCP` returns once the
  Subscribe frame is queued; on a loaded runner the subscription stayed
  half-attached (`present=0`) and the reconnect watchdog never rescues a feed
  that has seen no Root. Probe for a live subscription (with reconnect) before
  measuring.
- `router` `TestFECMuxEndToEndThroughput`: best-of-3 for its sub-100ms
  measurements so a lone GC/scheduler spike can't break the ratio asserts.
- `pty` `TestExecStreamClientDisconnectKillsCommand`: drain the whole first
  frame before closing, so the client Close lands while the server is idle
  (disconnect-detection read armed) rather than mid-write on the sync pipe.

Each fix verified locally per-package, the two races under `-race -count`.
Already handled separately and not touched here: `skywireconfig/genvisor`
(#4332) and the wasm preset bundle (#4331).