### PR TITLE
fix(router): forward SelfHealTarget through policy.Hook so wasm presets re-cap the running pool

### DIFF
--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -401,6 +401,28 @@ func (h *Hook) OnTick(info router.DialInfo, legs []router.LegInfo) router.Rotati
 	}
 }
 
+// SelfHealTarget implements the optional router.SelfHealTargeter by delegating
+// to the default engine when it exposes a live self-heal degree. The adaptive
+// wasm preset does (its pool size = AdaptRevActive()+AdaptStandbyMax(), both
+// runtime-tunable over the mux-control RPC); every other engine returns
+// ok=false, leaving the route group's fixed dial-time target in place.
+//
+// Without this the production RotationHook (a *policy.Hook wrapping the wasm
+// Loader) did NOT satisfy router.SelfHealTargeter, so the route group's per-tick
+// re-cap was skipped on every preset:* visor and the self-heal kept storming
+// toward its dial-time degree (513) regardless of `cli proxy mux standby`.
+// presethook.Hook implemented this for the native path only.
+func (h *Hook) SelfHealTarget() (int, bool) {
+	loader := h.loaderFor("")
+	if loader == nil {
+		return 0, false
+	}
+	if st, ok := loader.(interface{ SelfHealTarget() (int, bool) }); ok {
+		return st.SelfHealTarget()
+	}
+	return 0, false
+}
+
 // OnLegChange implements router.LegChangeHook. Called by the
 // route group whenever its leg set mutates. Translates the
 // router-side LegInfo / LegChange to the policy-side equivalents,

--- a/pkg/router/policy/hook_selfheal_test.go
+++ b/pkg/router/policy/hook_selfheal_test.go
@@ -1,0 +1,56 @@
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/router"
+)
+
+// selfHealEngine is a minimal Engine that also reports a self-heal target,
+// modeling the adaptive wasm Loader (which forwards Evaluator.SelfHealTarget).
+type selfHealEngine struct {
+	target int
+	ok     bool
+}
+
+func (selfHealEngine) Decide(context.Context, RoutingContext, []Candidate) (RouteSpec, error) {
+	return RouteSpec{}, nil
+}
+func (selfHealEngine) OnLegChange(context.Context, RoutingContext, []LegInfo, LegChange) (RouteSpec, error) {
+	return RouteSpec{}, nil
+}
+func (selfHealEngine) OnTick(context.Context, RoutingContext, []LegInfo) (RotationAction, error) {
+	return RotationAction{}, nil
+}
+func (selfHealEngine) IsActive() bool                { return true }
+func (selfHealEngine) Source() string                { return "<fake>" }
+func (selfHealEngine) Close() error                  { return nil }
+func (e selfHealEngine) SelfHealTarget() (int, bool) { return e.target, e.ok }
+
+// TestHookSelfHealTarget_ForwardsFromEngine is the regression for the
+// wasm-preset self-heal storm: the production RotationHook is *policy.Hook, so it
+// MUST satisfy router.SelfHealTargeter and forward the engine's live target —
+// otherwise the route group's per-tick re-cap is skipped and the pool storms
+// back toward its dial-time degree (513) regardless of `cli proxy mux standby`.
+func TestHookSelfHealTarget_ForwardsFromEngine(t *testing.T) {
+	h := NewHook(selfHealEngine{target: 41, ok: true})
+
+	var st router.SelfHealTargeter = h // *Hook must satisfy the optional interface
+	got, ok := st.SelfHealTarget()
+	if !ok || got != 41 {
+		t.Fatalf("Hook.SelfHealTarget = (%d,%v), want (41,true)", got, ok)
+	}
+}
+
+// TestHookSelfHealTarget_NoTarget: engines that report no target (non-adaptive
+// preset) or don't implement the optional interface, and a nil-engine hook, all
+// leave the dial-time target in place (ok=false).
+func TestHookSelfHealTarget_NoTarget(t *testing.T) {
+	if _, ok := NewHook(selfHealEngine{ok: false}).SelfHealTarget(); ok {
+		t.Fatal("engine reporting ok=false should yield ok=false")
+	}
+	if _, ok := NewHook(nil).SelfHealTarget(); ok {
+		t.Fatal("nil-engine hook should yield ok=false")
+	}
+}

--- a/pkg/router/policy/wasm/evaluator.go
+++ b/pkg/router/policy/wasm/evaluator.go
@@ -424,6 +424,26 @@ func stampTunables(cap, revActive, standbyMax *int) {
 	*standbyMax = preset.AdaptStandbyMax()
 }
 
+// SelfHealTarget reports the adaptive preset's live pool size — the steady
+// active width plus the warm-standby reserve (AdaptRevActive()+AdaptStandbyMax(),
+// the same figure decideAdaptive requests at dial). Both are runtime atomics
+// retuned over the mux-control RPC (cli proxy mux width / standby), so reporting
+// the current sum lets a running route group re-cap its self-heal when an
+// operator lowers the reserve — instead of storming back toward the dial-time
+// value. Non-adaptive presets keep their fixed dial-time target (ok=false).
+//
+// This mirrors presethook.Hook.SelfHealTarget for the NATIVE preset path. The
+// production hook on a preset:* visor is policy.Hook wrapping the wasm Loader,
+// NOT presethook.Hook, so without this (and the Loader/Hook forwarders) the
+// runtime re-cap never fired on wasm-preset visors and the pool storming toward
+// the dial-time 513 ignored `mux standby`.
+func (e *Evaluator) SelfHealTarget() (int, bool) {
+	if e.preset == "adaptive" {
+		return preset.AdaptRevActive() + preset.AdaptStandbyMax(), true
+	}
+	return 0, false
+}
+
 // wireFromCtx flattens a policy.RoutingContext to its wire shape.
 func wireFromCtx(r policy.RoutingContext) RoutingContextWire {
 	return RoutingContextWire{

--- a/pkg/router/policy/wasm/loader.go
+++ b/pkg/router/policy/wasm/loader.go
@@ -200,6 +200,18 @@ func (l *Loader) OnLegChange(ctx context.Context, rctx policy.RoutingContext, le
 	return eval.OnLegChange(ctx, rctx, legs, change)
 }
 
+// SelfHealTarget forwards to the active Evaluator's SelfHealTarget so the route
+// group's runtime self-heal re-cap (route_group.go, via router.SelfHealTargeter)
+// reaches the adaptive mux tunables. Reports ok=false when no evaluator is
+// loaded or the preset is non-adaptive, leaving the dial-time target in place.
+func (l *Loader) SelfHealTarget() (int, bool) {
+	eval := l.current.Load()
+	if eval == nil {
+		return 0, false
+	}
+	return eval.SelfHealTarget()
+}
+
 // Source returns the human-readable source identifier (file
 // path or "<noop>"). Used by callers for logging.
 func (l *Loader) Source() string { return l.source }


### PR DESCRIPTION
The runtime self-heal re-cap (route_group.go, via `router.SelfHealTargeter`) is what lets `cli proxy mux standby/width` lower a *running* route group's self-heal degree instead of storming back toward the dial-time value. #4333 implemented `SelfHealTarget` on `presethook.Hook` — but that isn't the production RotationHook. Real visors build the hook via `policy.NewHook` (init_router.go), a `*policy.Hook` wrapping the wasm Loader, and `*policy.Hook` didn't implement `SelfHealTargeter`. So the type-assertion at route_group.go was always false on `preset:*` (wasm) visors — the fleet default — and the pool kept dialing toward the dial-time degree (513 = AdaptRevActive 1 + adaptStandbyMax 512), ignoring `mux standby`.

Confirmed live: `SetMuxStandby: applied 40`, yet the group logged `Mux self-heal ... target=513 alive=79` and grew straight past 40.

Fix: `policy.Hook.SelfHealTarget` delegates to its default engine when the engine exposes the optional method; the wasm Loader forwards to the active Evaluator; the Evaluator returns `AdaptRevActive()+AdaptStandbyMax()` for the adaptive preset (mirroring `presethook.Hook` for the native path). Non-adaptive engines return `ok=false` and keep their fixed dial-time target. Regression test asserts `*policy.Hook` satisfies `router.SelfHealTargeter` and forwards the value.