### PR TITLE
fix(router): mirror native-controller leg parks to the peer (CapLegState)

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -2576,6 +2576,10 @@ func (rg *RouteGroup) enforceBottleneckGroups(recvDeltas map[uuid.UUID]uint64) {
 	for _, idx := range demote {
 		rg.logger.Infof("shared-bottleneck: parking leg %d to warm standby (co-bottlenecked with a kept active leg in group %d — one pipe, not two; striping it adds only reorder cost)", idx, groups[idx])
 		rg.mux.setLegStandby(idx, true)
+		// Mirror the park to the remote (CapLegState) so the bulk-sending peer
+		// stops striping across this leg — without this the native park is
+		// send-side-only here and the peer keeps spraying the download over it.
+		rg.sendLegState(idx, true)
 	}
 }
 
@@ -2661,10 +2665,14 @@ func (rg *RouteGroup) enforceLatencyBand(recvDeltas map[uuid.UUID]uint64) {
 	for _, idx := range demote {
 		rg.logger.Infof("latency-band: parking leg %d to warm standby (latency %.0fms out-of-band, keeping the active stripe set homogeneous)", idx, latOf[idx])
 		rg.mux.setLegStandby(idx, true)
+		// Mirror to the remote so the bulk sender stops striping across this leg
+		// (CapLegState) — the native park is otherwise send-side-only here.
+		rg.sendLegState(idx, true)
 	}
 	for _, idx := range promote {
 		rg.logger.Infof("latency-band: re-admitting leg %d to active (latency %.0fms back within band)", idx, latOf[idx])
 		rg.mux.setLegStandby(idx, false)
+		rg.sendLegState(idx, false)
 	}
 	if len(demote) > 0 || len(promote) > 0 {
 		rg.mu.Lock()
@@ -2800,6 +2808,9 @@ func (rg *RouteGroup) demoteStalledLegs(deadIDs []uuid.UUID) {
 	rg.mu.Unlock()
 	for _, i := range idxs {
 		rg.mux.setLegStandby(i, true)
+		// Mirror to the remote so it also stops sending on the dead leg
+		// (CapLegState); the native park is otherwise send-side-only here.
+		rg.sendLegState(i, true)
 	}
 	if len(idxs) > 0 {
 		rg.mu.Lock()


### PR DESCRIPTION
The rotation engine's demote/promote path signals every park to the remote via `sendLegState` (CapLegState) so the bulk-sending peer stops striping its send traffic across a parked leg — the comment there calls it the fix for the wide-mux download stall. But the **native** homogeneity controllers (`enforceBottleneckGroups`, `enforceLatencyBand`) and the dead-leg park called `rg.mux.setLegStandby` directly **without** `sendLegState`, so those parks were send-side-only. Legs those controllers parked stayed "active" in the peer's mirrored set, so the exit kept spraying the download across them.

Measured live (steady, no-collapse generation, transport_id-keyed): the download rode standby legs ~800 MB vs ~52 MB on active legs, delivering only ~8 MB to the app (~55× over-subscription of the no-skip reorder frontier). The client had active legs; the exit was simply never told the other legs were parked.

Fix: call `rg.sendLegState(idx, standby)` after every native `setLegStandby` in the three originating park sites, mirroring the rotation path. `handleLegStatePacket` (the receiver) is unchanged. All sites are outside `rg.mu`; `sendLegState` takes it itself and is a no-op unless CapLegState was negotiated. Full `pkg/router` suite green under `-race`.