### PR TITLE
fix(router): acceptor honors the initiator's mirrored active set (stop re-admitting parked legs)

### DIFF
--- a/pkg/router/honor_mirror_test.go
+++ b/pkg/router/honor_mirror_test.go
@@ -1,0 +1,30 @@
+package router
+
+import "testing"
+
+// TestHonorsMirrorActiveSet: only the ACCEPTOR (initiator==false) with leg-state
+// signaling negotiated defers its active set to the peer's mirror. This is what
+// stops the acceptor's latency-band / bottleneck controllers from re-admitting
+// legs the initiator parked (the wide-mux download over-subscription).
+func TestHonorsMirrorActiveSet(t *testing.T) {
+	cases := []struct {
+		name       string
+		mux        *routeMux
+		initiator  bool
+		wantHonors bool
+	}{
+		{"acceptor-with-signaling", &routeMux{legStateEnabled: true}, false, true},
+		{"initiator-with-signaling", &routeMux{legStateEnabled: true}, true, false},
+		{"acceptor-no-signaling", &routeMux{legStateEnabled: false}, false, false},
+		{"initiator-no-signaling", &routeMux{legStateEnabled: false}, true, false},
+		{"nil-mux", nil, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rg := &RouteGroup{mux: c.mux, initiator: c.initiator}
+			if got := rg.honorsMirrorActiveSet(); got != c.wantHonors {
+				t.Fatalf("honorsMirrorActiveSet = %v, want %v", got, c.wantHonors)
+			}
+		})
+	}
+}

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1590,6 +1590,21 @@ func (rg *RouteGroup) Initiator() bool {
 	return rg.initiator
 }
 
+// honorsMirrorActiveSet reports whether this side must DEFER its active/standby
+// set to the peer's mirror (CapLegState) rather than run its own promote/demote
+// controllers. The initiator owns the active-set decision and mirrors park/promote
+// to the acceptor (see the unidir/mirror comments on routeMux); the ACCEPTOR must
+// honor that mirror. When leg-state signaling is negotiated, the acceptor's own
+// homogeneity controllers (enforceLatencyBand / enforceBottleneckGroups) must NOT
+// run — otherwise they re-admit legs the initiator parked and the bulk sender
+// sprays its send traffic across them (the wide-mux download over-subscription:
+// measured the acceptor holding ~33 active legs while the initiator had ~8, so
+// ~99% of a download rode legs the initiator had parked). With signaling off,
+// both ends keep their local behavior (no mirror to honor).
+func (rg *RouteGroup) honorsMirrorActiveSet() bool {
+	return rg.mux != nil && rg.mux.legStateEnabled && !rg.initiator
+}
+
 // RouteHopDetails returns detailed information about each hop in the route,
 // including transport IDs and types.
 func (rg *RouteGroup) RouteHopDetails() []RouteHopInfo {
@@ -2571,6 +2586,9 @@ func (rg *RouteGroup) enforceBottleneckGroups(recvDeltas map[uuid.UUID]uint64) {
 	if rg.isClosed() || rg.mux == nil {
 		return
 	}
+	if rg.honorsMirrorActiveSet() {
+		return // acceptor: the active set is the initiator's mirror, not ours to size
+	}
 	rg.mu.Lock()
 	tpsCopy := append([]*transport.ManagedTransport(nil), rg.tps...)
 	rg.mu.Unlock()
@@ -2633,6 +2651,9 @@ func (rg *RouteGroup) enforceBottleneckGroups(recvDeltas map[uuid.UUID]uint64) {
 func (rg *RouteGroup) enforceLatencyBand(recvDeltas map[uuid.UUID]uint64) {
 	if rg.isClosed() || rg.mux == nil {
 		return
+	}
+	if rg.honorsMirrorActiveSet() {
+		return // acceptor: honor the initiator's mirrored active set; do not re-admit
 	}
 	rg.mu.Lock()
 	manual := !rg.standbyNewLegs


### PR DESCRIPTION
The unidir/CapLegState design gives the **initiator** the active-set decision and mirrors park/promote to the acceptor, which must honor it. But `enforceLatencyBand` and `enforceBottleneckGroups` ran on **both** ends with no initiator gate, so the acceptor re-admitted legs the initiator had parked.

Proven live from the exit's own journal: while this client parked legs and mirrored them (exit logged `peer marked leg N standby`), the exit's own latency-band immediately logged `re-admitting leg N to active` for those same legs and kept sending the download across them — exit held ~33 active vs this client's ~8; a steady transport_id-keyed window showed ~99% of a download riding legs the initiator had parked (standby ~800 MB vs active ~52 MB, ~8 MB delivered).

Fix: `honorsMirrorActiveSet()` gates both controllers off on the acceptor when leg-state signaling is negotiated (`legStateEnabled && !initiator`); the initiator still owns the decision. Dead/stalled-leg pruning unaffected; signaling-off keeps prior behavior. Table test; full `pkg/router` `-race` green.