### PR TITLE
fix(proxystatus): uint32 hash so routegraph builds on 32-bit (unblocks develop-latest binary)

### DIFF
--- a/pkg/proxystatus/routegraph.go
+++ b/pkg/proxystatus/routegraph.go
@@ -360,7 +360,10 @@ func seedRouteLayout(order []*nodeAcc, nStreams int) {
 		// (a hash of their order index in ±0.5) so parallel same-depth same-lane
 		// legs don't stack exactly on top of each other.
 		if hop {
-			j := float64((i*2654435761)&0xffff)/65535.0 - 0.5
+			// uint32 hash (golden-ratio constant 0x9E3779B1) so the multiply is
+			// well-defined on 32-bit archs (armv7) — plain int overflows there,
+			// which broke the develop-latest publish-binary build.
+			j := float64((uint32(i)*2654435761)&0xffff)/65535.0 - 0.5
 			x += j * (rgSpaceSize * 0.02)
 			y += j * (rgSpaceSize * 0.05)
 		}


### PR DESCRIPTION
`routegraph.go:363` multiplies a leg index by the golden-ratio constant `0x9E3779B1` (2654435761) in untyped `int`. On 32-bit archs (armv7) `int` is 32-bit and the constant overflows, so `GOARCH=arm go build` fails with `2654435761 (untyped int constant) overflows int`.

amd64 develop CI (64-bit int) never caught it, but **`publish-binary.yml` cross-compiles armv7 and has failed on every develop merge since the routegraph view landed** — so the rolling `develop-latest` release binary that every fleet visor auto-downloads has been **frozen at `ba8d3e291`**, and none of the intervening develop merges reached the fleet.

Fix: do the hash multiply in `uint32` (wraparound is the intended hash behavior; the `&0xffff` mask already discards the high bits). Cross-compiles clean on amd64, arm64, and armv7; proxystatus tests + lint green.