### PR TITLE
fix(router): acceptor defaults its active set to all-standby, mirror-promoted

### DIFF
--- a/pkg/router/park_aux_test.go
+++ b/pkg/router/park_aux_test.go
@@ -1,0 +1,22 @@
+package router
+
+import "testing"
+
+// TestParkAllAuxStandby: the acceptor's all-standby default parks every aux leg
+// (idx>0) and leaves the primary (leg 0) active.
+func TestParkAllAuxStandby(t *testing.T) {
+	m := &routeMux{}
+	m.growLegs(5)
+	// force a couple active to prove they get parked
+	m.setLegStandby(1, false)
+	m.setLegStandby(3, false)
+	m.parkAllAuxStandby()
+	if m.isLegStandby(0) {
+		t.Fatal("leg 0 (primary) must stay active")
+	}
+	for i := 1; i < 5; i++ {
+		if !m.isLegStandby(i) {
+			t.Fatalf("aux leg %d should be standby after parkAllAuxStandby", i)
+		}
+	}
+}

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -3577,6 +3577,22 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 				if remoteCaps&routing.CapLegState != 0 {
 					rg.mux.legStateEnabled = true
 					rg.logger.Debug("Leg-state signaling enabled (both peers support CapLegState)")
+					if !rg.initiator {
+						// Acceptor: the initiator owns the active set and promotes the
+						// legs it wants via the mirror. Default every aux leg to STANDBY
+						// (born-standby + park any already present) so we never send the
+						// bulk direction across a leg the initiator hasn't activated. The
+						// mirror's active signals + periodic resync then promote exactly
+						// the initiator's active set. Without this the acceptor births aux
+						// legs ACTIVE (no promoting engine → standbyNewLegs stays false)
+						// and sprays the download across every established leg until the
+						// lossy event mirror parks it — measured the acceptor holding 23
+						// active while the initiator had 2 (~11x reorder over-subscription,
+						// wedge). Complements honorsMirrorActiveSet (#4351), which stops the
+						// acceptor's OWN controllers from re-admitting.
+						rg.mux.SetStandbyNewLegs(true)
+						rg.mux.parkAllAuxStandby()
+					}
 				}
 
 				// Unidirectional send selection negotiation. Both edges must

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -683,6 +683,19 @@ func (m *routeMux) setLegStandby(idx int, standby bool) {
 	m.legMu.Unlock()
 }
 
+// parkAllAuxStandby marks every aux leg (index > 0) as warm standby. Used by the
+// acceptor when leg-state signaling is negotiated so its active set starts EMPTY
+// and is filled only by the initiator's mirror promotes — the acceptor must never
+// send the bulk direction across a leg the initiator hasn't activated. Leg 0 (the
+// primary) is left active.
+func (m *routeMux) parkAllAuxStandby() {
+	m.legMu.Lock()
+	for i := 1; i < len(m.standby); i++ {
+		m.standby[i] = true
+	}
+	m.legMu.Unlock()
+}
+
 // swapLegs exchanges the mux's per-leg state (counters, readiness, standby
 // marker) between two leg indices so the primary slot (0) can be RE-ELECTED
 // onto a healthier leg without tearing down any route. The caller (RouteGroup.


### PR DESCRIPTION
Completes the acceptor-honors-the-mirror model (#4351). #4351 stopped the acceptor's OWN homogeneity controllers from re-admitting parked legs, but the acceptor still **birthed new aux legs active**: `standbyNewLegs` is only set when a promoting rotation engine is wired, which the acceptor has none of, so `growLegs` births aux legs active. As the pool churns, the acceptor accumulates active legs and sprays the bulk direction across every established leg until the lossy event mirror parks it — which it can't keep up with.

Measured (reliable, single route group): the acceptor held **active=23 while the initiator had active=2**; a 50 MB download pulled **563 MB** across the legs (~11× over-subscription) with the reorder frontier wedged (790 pending, gap 3.3 s). The download rode ~40 standby legs, not the 2 active.

Fix: when leg-state signaling is negotiated and this side is the acceptor (`!initiator`), default every aux leg to standby (`SetStandbyNewLegs(true)` + `parkAllAuxStandby`) so the active set starts **empty** and is filled only by the initiator's mirror active-signals + periodic resync — the acceptor's active set becomes exactly the initiator's. Leg 0 stays active; initiator side unchanged. Unit test; full `pkg/router` `-race` green.