### PR TITLE
fix(router): confine upload to the primary leg when there is no direct leg

### DIFF
--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -388,6 +388,20 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 		if tp, rule, idx, ok := m.selectByDirection(tps, fwd, wantDirect, dstPK, srcPK); ok {
 			return tp, rule, idx, nil
 		}
+		// No leg of the wanted class exists. For the LIGHT direction (wantDirect
+		// true = the initiator's forward/upload send, which the unidir model puts
+		// on the DIRECT leg), a multihop-only path has no direct leg to confine to
+		// — falling through to the weighted scheduler would SPRAY the upload across
+		// every forward leg, over-subscribing the no-skip reorder frontier (measured
+		// 67-172MB sent for a 10MB upload from a public node with no direct transport
+		// to the exit, plus stalls). Confine it to the primary leg (0) instead: it is
+		// always active and single, so the upload stays on one leg (full-duplex with
+		// whatever download rides it) rather than spraying. The heavy/download
+		// direction (wantDirect false) keeps its existing fall-through: with no
+		// reverse leg there is genuinely nothing to confine to.
+		if wantDirect && tps[0] != nil && !tps[0].IsClosed() {
+			return tps[0], fwd[0], 0, nil
+		}
 	}
 
 	// Payload-inspecting modes: ask the selector for a leg


### PR DESCRIPTION
The unidir model puts the initiator's forward/upload send on the **direct** (1-hop) leg. `selectByDirection` confines it to direct-class legs and returns `ok=false` when none exist; `selectTransport` then falls through to the weighted scheduler, which **sprays** the upload across every forward leg. On a multihop-only path (the initiator has no direct transport to the peer — common on a real mesh) this over-subscribes the no-skip reorder frontier.

Measured from a public node (magnetosphere) with no direct leg to the exit: a 10 MB upload sent **67–172 MB across the multihop legs (~7–17×)** and one transfer stalled to 0 bytes. The local vantage (which *has* a direct leg) uploaded cleanly (~1×), so the defect is specifically the no-direct-leg case.

Fix: when `selectByDirection` finds no wanted-class leg **and** this is the light/upload direction (`wantDirect`), confine to the primary leg (0) instead of spraying — it's always active and single, so the upload rides one full-duplex leg. The heavy/download direction keeps its fall-through (no reverse leg = nothing to confine to). Full `pkg/router` `-race` green.