### PR TITLE
fix(lint): errcheck check-blank in wasm-visor staleness test

### DIFF
--- a/pkg/wasmhv/wasmbin/provenance_test.go
+++ b/pkg/wasmhv/wasmbin/provenance_test.go
@@ -161,7 +161,11 @@ func TestCommittedWasmNotStale(t *testing.T) {
 				t.Skipf("git rev-list against blob revision %s failed (%v): %s", rev[:12], err, bytes.TrimSpace(out))
 			}
 			if n := strings.TrimSpace(string(out)); n != "0" {
-				commits, _ := exec.Command("git", "-C", root, "log", "--oneline", rev+"..HEAD", "--", strings.Join(blob.staleSrcDirs, " ")).CombinedOutput() //nolint:gosec
+				logArgs := append([]string{"-C", root, "log", "--oneline", rev + "..HEAD", "--"}, blob.staleSrcDirs...)
+				commits, err := exec.Command("git", logArgs...).CombinedOutput() //nolint:errcheck,gosec // best-effort detail for the failure message
+				if err != nil {
+					commits = nil
+				}
 				t.Errorf("%s is STALE: %s commit(s) changed %v since it was built (rev %s).\n"+
 					"The committed blob ships older code than its source (this is how #4330's dmsg-RPC\n"+
 					"shipped missing). Run 'make wasm-visor && make embed-wasm-visor' and commit the result.\n%s",


### PR DESCRIPTION
Follow-up to #4356. The merge landed before the lint fix; the git-log detail call in `TestCommittedWasmNotStale` uses a blank discard (`commits, _ :=`), which errcheck `check-blank` rejects, and joined the staleSrcDirs into one pathspec. Check the error and spread the dirs as separate pathspecs.