### PR TITLE
fix(interstitial): auto-reload after 'Route up' instead of stalling until manual reload

### DIFF
--- a/pkg/proxyinterstitial/stream.go
+++ b/pkg/proxyinterstitial/stream.go
@@ -207,9 +207,18 @@ func StreamClose(ok bool, detail string) string {
 	b.WriteString(`</ul>`)
 	if ok {
 		b.WriteString(`<p class="ready">Route up — loading the page…</p>`)
-		// replace() so the interstitial isn't left in history; the reload
-		// re-requests through the proxy and hits the now-warm route.
-		b.WriteString(`<script>location.replace(location.href)</script>`)
+		// Reload the SAME URL — now warm — via replace() so the interstitial isn't
+		// left in history. CRUCIAL: defer the navigation to the load event. This
+		// fragment is parsed while the chunked document is still streaming, and a
+		// browser drops a same-URL replace() issued during load — leaving the page
+		// stuck on "Route up…" until a manual reload. Firing after load (the stream
+		// has closed by then) makes it commit; the readyState guard covers the race
+		// where load already fired, and the timer is a last-resort fallback.
+		b.WriteString(`<script>(function(){var g=false;function go(){if(g)return;g=true;location.replace(location.href);}` +
+			`if(document.readyState==='complete'){go();}else{window.addEventListener('load',go);}` +
+			`setTimeout(go,600);})();</script>`)
+		// No-JS fallback: a body meta-refresh reloads once parsing completes.
+		b.WriteString(`<noscript><meta http-equiv="refresh" content="0"></noscript>`)
 	} else {
 		if d := strings.TrimSpace(detail); d != "" {
 			b.WriteString(`<p id="mesh-detail" style="display:block">` + html.EscapeString(d) + `</p>`)


### PR DESCRIPTION
The streaming route interstitial's success chunk fired `location.replace(location.href)` **inline while the chunked document was still streaming**. Browsers drop a same-URL `replace()` issued during load, so the page sat on "Route up — loading the page…" until the user manually reloaded — even though the route was already warm by then.

Defer the navigation to the `load` event (the stream has closed by then, so it commits), guard the already-loaded race via `readyState`, add a timer fallback, and a `<noscript>` meta-refresh for the no-JS path. `StreamClose` is shared by both the SOCKS and browse-origin proxy interstitial paths, so one change fixes both.