### PR TITLE
feat(skysocks): TLS-terminating HTTPS range-splitting (opt-in MITM root)

### DIFF
--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -54,6 +55,8 @@ var (
 	rangeSplit     bool
 	rangeConc      int64
 	rangeChunkKiB  int64
+	rangeHTTPS     bool
+	rangeHTTPSCA   string
 )
 
 func init() {
@@ -83,11 +86,17 @@ func init() {
 	// fetched as N concurrent byte ranges over separate tunnels and reassembled, so
 	// one unmodified download (curl or a browser on this proxy) aggregates across the
 	// mesh with no client cooperation. Default-on and auto-detecting (only engages on
-	// a 206-capable origin); HTTPS is unaffected (needs an unconstrained MITM root —
-	// follow-up). Tune or disable via these flags, not a required gate.
+	// a 206-capable origin). Tune or disable via these flags, not a required gate.
 	RootCmd.Flags().BoolVar(&rangeSplit, "range-split", true, "transparently split range-capable HTTP (:80) GETs into concurrent byte ranges across tunnels")
 	RootCmd.Flags().Int64Var(&rangeConc, "range-concurrency", 8, "concurrent range streams per split download")
 	RootCmd.Flags().Int64Var(&rangeChunkKiB, "range-chunk-kib", 4096, "bytes per range request, in KiB")
+	// HTTPS (:443) range-splitting terminates the browser's TLS with a leaf minted
+	// by a local UNCONSTRAINED root so the same split works inside TLS. Off by
+	// default and a deliberate security opt-in: the root can forge any host, and the
+	// browser must import it (printed on startup) for the terminated TLS to be
+	// trusted. The origin is still verified normally.
+	RootCmd.Flags().BoolVar(&rangeHTTPS, "range-split-https", false, "ALSO split HTTPS (:443) GETs by terminating TLS with a local MITM root (opt-in; import the printed CA into the browser)")
+	RootCmd.Flags().StringVar(&rangeHTTPSCA, "range-split-https-ca-dir", "", "directory holding the HTTPS range-split MITM root (ca.crt/ca.key); created on first use (default: <home>/.skywire/rangesplit-mitm)")
 }
 
 // RootCmd is the root command for skysocks
@@ -124,6 +133,14 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		fs.BoolVar(&direct, "direct", false, "force a direct-transport-only route to the server (1-hop, bypass the route-finder + setup node); self-heals on server restart")
 		fs.BoolVar(&dmsgFallback, "dmsg-fallback", false, "fall back to a direct dmsg stream if the skynet dial fails")
 		fs.Int64Var(&tunnels, "tunnels", 1, "number of independent tunnels to stripe connections across")
+		// Range-split flags were absent from this launcher subset, so passing any of
+		// them via the visor's app args errored. Bind them here too (same vars as the
+		// cobra flags) so the feature is configurable when the visor launches the app.
+		fs.BoolVar(&rangeSplit, "range-split", true, "split range-capable HTTP (:80) GETs across tunnels")
+		fs.Int64Var(&rangeConc, "range-concurrency", 8, "concurrent range streams per split download")
+		fs.Int64Var(&rangeChunkKiB, "range-chunk-kib", 4096, "bytes per range request, in KiB")
+		fs.BoolVar(&rangeHTTPS, "range-split-https", false, "also split HTTPS (:443) GETs via a local MITM root (opt-in)")
+		fs.StringVar(&rangeHTTPSCA, "range-split-https-ca-dir", "", "directory for the HTTPS range-split MITM root")
 		if err := fs.Parse(args); err != nil {
 			return fmt.Errorf("failed to parse flags: %w", err)
 		}
@@ -285,6 +302,24 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		// range-capable :80 GET is fetched as concurrent byte ranges over separate
 		// tunnels, so a single download aggregates across the mesh.
 		client.SetRangeSplit(rangeSplit, int(rangeConc), rangeChunkKiB*1024)
+		// HTTPS (:443) range-splitting is an explicit security opt-in: enabling it
+		// mints browser leaves from a forge-any-host root, so it is only wired when
+		// asked, and the operator is told exactly which CA to import.
+		if rangeHTTPS {
+			caDir := rangeHTTPSCA
+			if caDir == "" {
+				home, herr := os.UserHomeDir()
+				if herr != nil {
+					home = "."
+				}
+				caDir = filepath.Join(home, ".skywire", "rangesplit-mitm")
+			}
+			if herr := client.SetHTTPSRangeSplit(caDir); herr != nil {
+				log.WithError(herr).Warn("HTTPS range-splitting requested but its MITM root could not be initialised; :443 will splice through unchanged")
+			} else if pemBytes, ok := client.MITMCACertPEM(); ok {
+				log.Warnf("HTTPS range-splitting ENABLED — import this root into your browser to trust intercepted origins; it can forge any host, so remove it when done:\n  CA file: %s\n%s", filepath.Join(caDir, "ca.crt"), string(pemBytes))
+			}
+		}
 		if tunnels > 1 {
 			client.SetTunnelRedial(func() (net.Conn, error) {
 				return dialServer(cycleCtx, appCl, pk, serverPort, true)

--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -315,7 +315,7 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 				caDir = filepath.Join(home, ".skywire", "rangesplit-mitm")
 			}
 			if herr := client.SetHTTPSRangeSplit(caDir); herr != nil {
-				log.WithError(herr).Warn("HTTPS range-splitting requested but its MITM root could not be initialised; :443 will splice through unchanged")
+				log.WithError(herr).Warn("HTTPS range-splitting requested but its MITM root could not be initialized; :443 will splice through unchanged")
 			} else if pemBytes, ok := client.MITMCACertPEM(); ok {
 				log.Warnf("HTTPS range-splitting ENABLED — import this root into your browser to trust intercepted origins; it can forge any host, so remove it when done:\n  CA file: %s\n%s", filepath.Join(caDir, "ca.crt"), string(pemBytes))
 			}

--- a/pkg/skynetca/ca.go
+++ b/pkg/skynetca/ca.go
@@ -49,6 +49,12 @@ type CAOptions struct {
 	CommonName       string
 	Validity         time.Duration
 	PermittedDomains []string
+	// Unconstrained omits the X.509 nameConstraints extension entirely, so the CA
+	// can sign a leaf for ANY dnsName. This is the "forge any host" root a real
+	// clearnet HTTPS MITM (e.g. the skysocks-client HTTPS range-splitter) needs,
+	// and is a deliberate security decision: such a root must be created
+	// explicitly, never defaulted. PermittedDomains is ignored when this is set.
+	Unconstrained bool
 }
 
 func (o CAOptions) withDefaults() CAOptions {
@@ -58,14 +64,17 @@ func (o CAOptions) withDefaults() CAOptions {
 	if o.Validity == 0 {
 		o.Validity = 10 * 365 * 24 * time.Hour
 	}
-	if len(o.PermittedDomains) == 0 {
+	// An unconstrained CA carries no permitted-domain list; do not backfill the
+	// resolver defaults onto it.
+	if len(o.PermittedDomains) == 0 && !o.Unconstrained {
 		o.PermittedDomains = append([]string{}, DefaultPermittedDomains...)
 	}
 	return o
 }
 
 // GenerateCA returns a fresh ECDSA P-256 CA suitable for signing
-// leaf certs. Name constraints are applied per opts.PermittedDomains.
+// leaf certs. Name constraints are applied per opts.PermittedDomains,
+// unless opts.Unconstrained is set (no nameConstraints at all).
 func GenerateCA(opts CAOptions) (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	o := opts.withDefaults()
 
@@ -89,11 +98,14 @@ func GenerateCA(opts CAOptions) (*x509.Certificate, *ecdsa.PrivateKey, error) {
 		MaxPathLen:            0,
 		MaxPathLenZero:        true,
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-		// Name constraints are the load-bearing security property:
-		// a leaf signed by this CA can only have a dnsName whose
-		// labels end in one of these suffixes.
-		PermittedDNSDomains:         o.PermittedDomains,
-		PermittedDNSDomainsCritical: true,
+	}
+	// Name constraints are the load-bearing security property: a leaf signed by a
+	// constrained CA can only have a dnsName whose labels end in one of these
+	// suffixes. An unconstrained CA omits the extension so it can sign any host —
+	// only used where the caller has made that MITM decision explicitly.
+	if !o.Unconstrained {
+		tmpl.PermittedDNSDomains = o.PermittedDomains
+		tmpl.PermittedDNSDomainsCritical = true
 	}
 
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -4,6 +4,7 @@ package skysocks
 import (
 	"bytes"
 	"crypto/sha1" //nolint:gosec // RFC6455 mandates SHA-1 for the WebSocket accept key
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -271,6 +272,32 @@ func (c *Client) SetRangeSplit(enabled bool, concurrency int, chunkSize int64) {
 		c.rs.chunkSize = chunkSize
 	}
 }
+
+// SetHTTPSRangeSplit enables TLS-terminating (:443) range-splitting, loading or
+// creating the unconstrained MITM root under caDir (caDir/ca.crt + ca.key). It is a
+// deliberate security opt-in: the returned root can forge a leaf for any host, so it
+// is never enabled by default, and the operator must import caDir/ca.crt into the
+// browser for the terminated TLS to be trusted (MITMCACertPEM returns it). Errors
+// (unreadable/creatable CA) leave HTTPS range-splitting off.
+func (c *Client) SetHTTPSRangeSplit(caDir string) error {
+	cert, minter, err := loadOrCreateMITMCA(caDir)
+	if err != nil {
+		return err
+	}
+	c.rs.caCert = cert
+	c.rs.minter = minter
+	c.rs.httpsEnabled = true
+	return nil
+}
+
+// SetHTTPSRangeSplitOriginRoots overrides the roots used to verify the REAL origin's
+// certificate (nil = system roots). Intended for tests that stand up an httptest TLS
+// origin; production leaves it nil so origin security is never downgraded.
+func (c *Client) SetHTTPSRangeSplitOriginRoots(pool *x509.CertPool) { c.rs.originRoots = pool }
+
+// MITMCACertPEM returns the PEM of the HTTPS range-split MITM root for the operator
+// to import into a browser. ok is false when HTTPS range-splitting is not configured.
+func (c *Client) MITMCACertPEM() ([]byte, bool) { return c.mitmCACertPEM() }
 
 // SetTunnelRedial wires the app's disjoint-diversify dial into the Client so the
 // keepalive loop can re-dial a dead tunnel's replacement. The dial itself lives in
@@ -769,6 +796,10 @@ func (c *Client) handleStream(conn, stream net.Conn) {
 	// before.
 	if c.rs.enabled && isPort80(target) {
 		c.serveHTTPRangeSplit(conn, stream)
+	} else if c.rs.httpsEnabled && c.rs.minter != nil && isPort443(target) {
+		// Opt-in TLS-terminating split (rangesplit_https.go). Only reached when the
+		// operator enabled it and a minter exists; a plain :443 splices as before.
+		c.serveHTTPSRangeSplit(conn, stream, target)
 	} else {
 		c.splicePrefixed(conn, stream, nil)
 	}

--- a/pkg/skysocks/rangesplit.go
+++ b/pkg/skysocks/rangesplit.go
@@ -9,17 +9,19 @@
 // a GET, an already-ranged request, a non-range origin, a small file) falls back
 // to a byte-identical transparent splice.
 //
-// HTTPS (port 443) is NOT handled here: seeing the GET inside TLS requires
-// terminating it at the proxy, and the resolver CA is name-constrained to
-// .skynet/.dmsg/.skysocks (PermittedDNSDomainsCritical), so it cannot mint a
-// browser-trusted leaf for a real origin. Transparent HTTPS range-splitting
-// therefore needs a separate, unconstrained MITM root — a distinct security
-// decision left as follow-up. HTTPS CONNECTs splice through unchanged.
+// HTTPS (port 443) is handled in rangesplit_https.go, but only when the operator
+// has explicitly enabled it: seeing the GET inside TLS requires terminating it at
+// the proxy with a leaf minted by an UNCONSTRAINED local root (the resolver CA is
+// name-constrained to .skynet/.dmsg/.skysocks and cannot cover a real origin). That
+// root can forge any host, so HTTPS range-splitting is off by default and the
+// browser must be told to trust the root; a plain :443 CONNECT splices through
+// unchanged until then.
 package skysocks
 
 import (
 	"bufio"
 	"bytes"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
@@ -29,6 +31,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/skycoin/skywire/pkg/skynetca"
 )
 
 // rangeSplitConfig tunes transparent HTTP range-splitting. Zero value is
@@ -37,6 +41,13 @@ type rangeSplitConfig struct {
 	enabled     bool
 	concurrency int   // number of concurrent range streams
 	chunkSize   int64 // bytes per range request
+
+	// HTTPS (:443) range-splitting is off unless the operator opts in — it needs a
+	// forge-any-host root the browser is told to trust (see rangesplit_https.go).
+	httpsEnabled bool
+	minter       skynetca.LeafMinter // mints per-host leaves for browser-side TLS termination
+	caCert       *x509.Certificate   // the MITM root, for operator export/import
+	originRoots  *x509.CertPool      // origin-side verification roots (nil = system); tests inject here
 }
 
 const (
@@ -201,16 +212,20 @@ func (c *Client) rangeSplitInner(conn, stream net.Conn) (host string, clientPref
 	c.rsChunks.Add(uint64(numChunks(total, c.rs.chunkSize))) //nolint:gosec // numChunks>0 here (total>chunkSize)
 	c.rsBytes.Add(uint64(total))                             //nolint:gosec // total>0 checked above
 	c.rsActive.Add(1)
-	c.streamRemainingChunks(conn, req, host, validator, total)
+	c.streamRemainingChunks(conn, total, func(start, end int64) ([]byte, error) {
+		return c.fetchChunkRetry(req, host, validator, start, end)
+	})
 	c.rsActive.Add(-1)
 	conn.Close() //nolint:errcheck,gosec
 	return host, nil, true
 }
 
 // streamRemainingChunks fetches [chunkSize, total) as concurrent ranges and writes
-// them to conn in order. Outstanding (in-flight + buffered) chunks are bounded to
-// the configured concurrency so memory stays ~concurrency×chunkSize.
-func (c *Client) streamRemainingChunks(conn net.Conn, req *http.Request, host, validator string, total int64) {
+// them to conn in order, using fetch to retrieve one [start,end] byte range (the
+// caller supplies the plaintext or TLS-over-exit fetch). Outstanding (in-flight +
+// buffered) chunks are bounded to the configured concurrency so memory stays
+// ~concurrency×chunkSize.
+func (c *Client) streamRemainingChunks(conn net.Conn, total int64, fetch func(start, end int64) ([]byte, error)) {
 	type chunk struct {
 		start, end int64
 		buf        []byte
@@ -234,7 +249,7 @@ func (c *Client) streamRemainingChunks(conn net.Conn, req *http.Request, host, v
 			wg.Add(1)
 			go func(ch *chunk) {
 				defer wg.Done()
-				ch.buf, ch.err = c.fetchChunkRetry(req, host, validator, ch.start, ch.end)
+				ch.buf, ch.err = fetch(ch.start, ch.end)
 				close(ch.done)
 			}(ch)
 		}

--- a/pkg/skysocks/rangesplit_https.go
+++ b/pkg/skysocks/rangesplit_https.go
@@ -192,29 +192,26 @@ func (c *Client) serveHTTPSRangeSplit(conn, stream net.Conn, target string) {
 	}
 
 	// 5. Drive the split over the terminated browser conn (btls) and origin conn (otls).
-	if !c.httpsRangeSplitDrive(btls, otls, req, reqHead, host) {
-		// Nothing recoverable remains once we have started consuming the origin
-		// response; drive() has already closed both ends on every exit path.
-		return
-	}
+	//    drive() owns both ends from here and closes them on every path.
+	c.httpsRangeSplitDrive(btls, otls, req, reqHead, host)
 }
 
 // httpsRangeSplitDrive performs the range probe on otls and, on a 206, reassembles
-// the body onto btls. It returns true once it has fully served the response (split,
-// verbatim relay, or a clean truncation) and closed both ends. reqHead is the raw
+// the body onto btls. It owns both ends and closes them once it has served the response (split,
+// verbatim relay, or a clean truncation). reqHead is the raw
 // request block; req is its parsed form.
-func (c *Client) httpsRangeSplitDrive(btls, otls net.Conn, req *http.Request, reqHead []byte, host string) bool {
+func (c *Client) httpsRangeSplitDrive(btls, otls net.Conn, req *http.Request, reqHead []byte, host string) {
 	// Probe: original request + Range: bytes=0-(chunk-1). A non-range origin ignores
 	// it and returns its normal 200, kept byte-identical by the relay path below.
 	if _, err := otls.Write(injectRange(reqHead, 0, c.rs.chunkSize-1)); err != nil {
 		closeBoth(btls, otls)
-		return true
+		return
 	}
 	br := bufio.NewReader(otls)
 	statusLine, err := br.ReadString('\n')
 	if err != nil {
 		closeBoth(btls, otls)
-		return true
+		return
 	}
 	if statusCode(statusLine) != 206 {
 		// Origin ignored Range (200) or returned redirect/error: relay verbatim so the
@@ -226,25 +223,25 @@ func (c *Client) httpsRangeSplitDrive(btls, otls net.Conn, req *http.Request, re
 		}
 		_, _ = io.Copy(btls, otls) //nolint:errcheck
 		closeBoth(btls, otls)
-		return true
+		return
 	}
 
 	tp := textproto.NewReader(br)
 	hdr, err := tp.ReadMIMEHeader()
 	if err != nil {
 		closeBoth(btls, otls)
-		return true
+		return
 	}
 	total, okTotal := parseContentRangeTotal(hdr.Get("Content-Range"))
 	if !okTotal || total <= 0 {
 		closeBoth(btls, otls)
-		return true
+		return
 	}
 	validator := ifRangeValidator(hdr)
 
 	if err := writeSynth200(btls, hdr, total); err != nil {
 		closeBoth(btls, otls)
-		return true
+		return
 	}
 
 	// chunk0 body straight from the probe response.
@@ -254,12 +251,12 @@ func (c *Client) httpsRangeSplitDrive(btls, otls net.Conn, req *http.Request, re
 	}
 	if _, err := io.CopyN(btls, br, chunk0Len); err != nil {
 		closeBoth(btls, otls)
-		return true
+		return
 	}
 	otls.Close() //nolint:errcheck,gosec // origin stream0 done; remaining chunks use fresh TLS streams
 	if total <= c.rs.chunkSize {
 		btls.Close() //nolint:errcheck,gosec
-		return true
+		return
 	}
 
 	if c.appCl != nil {
@@ -275,11 +272,10 @@ func (c *Client) httpsRangeSplitDrive(btls, otls net.Conn, req *http.Request, re
 	})
 	c.rsActive.Add(-1)
 	btls.Close() //nolint:errcheck,gosec
-	return true
 }
 
 // fetchChunkTLSRetry fetches one byte range over a fresh TLS-to-origin stream,
-// redialing on churn — the HTTPS analogue of fetchChunkRetry.
+// redialing on churn — the HTTPS analog of fetchChunkRetry.
 func (c *Client) fetchChunkTLSRetry(req *http.Request, host, validator string, start, end int64) ([]byte, error) {
 	var err error
 	for i := 0; i < rsChunkRetries; i++ {

--- a/pkg/skysocks/rangesplit_https.go
+++ b/pkg/skysocks/rangesplit_https.go
@@ -1,0 +1,339 @@
+// Package skysocks pkg/skysocks/rangesplit_https.go — HTTPS (TLS-terminating)
+// range-splitting.
+//
+// The plaintext splitter (rangesplit.go) cannot see the GET inside a :443 CONNECT.
+// This file terminates that TLS at the proxy — presenting the browser a leaf minted
+// on demand by a local UNCONSTRAINED root — reads the plaintext GET, and fetches the
+// body as N concurrent byte ranges over separate exit streams, each wrapped in a
+// fresh TLS client connection to the REAL origin (verified against the system roots,
+// so the proxy never downgrades origin security). The reassembled 200 is written
+// back to the browser over the terminated TLS. Anything not splittable becomes a
+// transparent plaintext MITM splice between the browser TLS conn and one origin TLS
+// conn.
+//
+// This is a deliberate security decision and therefore OFF by default:
+//   - The minting root can forge a leaf for ANY host, so it is generated explicitly
+//     (skynetca.CAOptions.Unconstrained) and the operator must import it into the
+//     browser's trust store for the terminated TLS to be accepted.
+//   - The origin side is verified normally; a MITM here interposes on the mesh path
+//     the exit already sees, it does not weaken what the origin proves.
+package skysocks
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/skynetca"
+)
+
+// mitmCACommonName names the unconstrained root in the browser's cert manager so an
+// operator can find (and later remove) exactly what they trusted.
+const mitmCACommonName = "Skywire Range-Split MITM CA"
+
+// isPort443 reports whether target ("host:port") is HTTPS.
+func isPort443(target string) bool {
+	_, port, err := net.SplitHostPort(target)
+	if err != nil {
+		return false
+	}
+	return port == "443"
+}
+
+// loadOrCreateMITMCA loads the unconstrained MITM root from dir, generating and
+// persisting one on first use. dir/ca.crt is the cert to import into the browser;
+// dir/ca.key is its private key (0600). Returns the cert, a leaf minter that will
+// sign for any host, and the cert itself for export.
+func loadOrCreateMITMCA(dir string) (*x509.Certificate, skynetca.LeafMinter, error) {
+	certPath := filepath.Join(dir, "ca.crt")
+	keyPath := filepath.Join(dir, "ca.key")
+
+	cert, key, err := skynetca.LoadCA(certPath, keyPath)
+	if err != nil {
+		if !os.IsNotExist(errCause(err)) {
+			// A present-but-unreadable CA is a real error — do not silently mint a
+			// second root over it.
+			return nil, nil, fmt.Errorf("load MITM CA: %w", err)
+		}
+		cert, key, err = skynetca.GenerateCA(skynetca.CAOptions{
+			CommonName:    mitmCACommonName,
+			Unconstrained: true,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("generate MITM CA: %w", err)
+		}
+		if err := skynetca.SaveCA(cert, key, certPath, keyPath); err != nil {
+			return nil, nil, fmt.Errorf("save MITM CA: %w", err)
+		}
+	}
+	return cert, newUnconstrainedMinter(cert, key), nil
+}
+
+// newUnconstrainedMinter builds a minter that permits any host. The empty suffix
+// matches every non-empty hostname (see CachedMinter.permitted), which is exactly
+// what an unconstrained MITM root is for.
+func newUnconstrainedMinter(cert *x509.Certificate, key *ecdsa.PrivateKey) skynetca.LeafMinter {
+	return skynetca.NewMinter(cert, key, skynetca.LeafOptions{PermittedSuffixes: []string{""}})
+}
+
+// errCause unwraps to the innermost error so os.IsNotExist sees the syscall error
+// through skynetca's fmt.Errorf wrapping.
+func errCause(err error) error {
+	for {
+		u, ok := err.(interface{ Unwrap() error })
+		if !ok || u.Unwrap() == nil {
+			return err
+		}
+		err = u.Unwrap()
+	}
+}
+
+// mitmCACertPEM returns the PEM encoding of the MITM root, for the operator to
+// import into a browser. ok is false when HTTPS range-splitting is not configured.
+func (c *Client) mitmCACertPEM() ([]byte, bool) {
+	if c.rs.caCert == nil {
+		return nil, false
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: c.rs.caCert.Raw}), true
+}
+
+// originTLSConfig is the client-side TLS config used to reach the REAL origin. It
+// verifies against originRoots (nil = system roots), so the proxy does not weaken
+// what the origin must prove; tests inject the httptest server's cert here.
+func (c *Client) originTLSConfig(host string) *tls.Config {
+	return &tls.Config{
+		ServerName: host,
+		RootCAs:    c.rs.originRoots,
+		MinVersion: tls.VersionTLS12,
+	}
+}
+
+// serveHTTPSRangeSplit takes ownership of a freshly-CONNECTed browser conn and the
+// exit stream (already CONNECTing to host:443 on the browser's behalf). It relays the
+// exit's SOCKS5 reply, terminates the browser's TLS with a minted leaf, and — when the
+// first request is a splittable GET against a range-capable origin — fetches the body
+// as N concurrent ranges over fresh TLS-to-origin streams, reassembling it into one
+// 200. Non-splittable traffic becomes a plaintext MITM splice. It always closes both
+// ends before returning.
+func (c *Client) serveHTTPSRangeSplit(conn, stream net.Conn, target string) {
+	host, _, err := net.SplitHostPort(target)
+	if err != nil {
+		host = target
+	}
+
+	// 1. Read the exit's SOCKS5 reply (stream is now a raw pipe to host:443) and
+	//    relay it to the browser so it proceeds to send its TLS ClientHello.
+	_ = stream.SetReadDeadline(time.Now().Add(rsProbeTimeout)) //nolint:errcheck
+	reply, err := readSocks5Reply(stream)
+	if err != nil {
+		closeBoth(conn, stream)
+		return
+	}
+	if _, err := conn.Write(reply); err != nil {
+		closeBoth(conn, stream)
+		return
+	}
+	clearDeadlines(conn, stream)
+
+	// 2. Mint a leaf for host. If we cannot (no minter / bad host), fall back to a
+	//    verbatim splice: the browser's TLS goes straight to the origin unchanged.
+	leaf, err := c.rs.minter.For(host)
+	if err != nil {
+		if c.appCl != nil {
+			c.appCl.Log().Debugf("https range-split: no leaf for %s: %v; splicing", host, err)
+		}
+		c.splicePrefixed(conn, stream, nil)
+		return
+	}
+
+	// 3. Terminate the browser TLS with our leaf, and open a verified TLS client to
+	//    the real origin over the exit stream. Either handshake failing is fatal for
+	//    this connection (we have already committed to interposing).
+	btls := tls.Server(conn, &tls.Config{
+		Certificates: []tls.Certificate{*leaf},
+		MinVersion:   tls.VersionTLS12,
+	})
+	if err := btls.Handshake(); err != nil {
+		closeBoth(btls, stream)
+		return
+	}
+	otls := tls.Client(stream, c.originTLSConfig(host))
+	if err := otls.Handshake(); err != nil {
+		if c.appCl != nil {
+			c.appCl.Log().Debugf("https range-split: origin %s handshake failed: %v", host, err)
+		}
+		closeBoth(btls, otls)
+		return
+	}
+
+	// 4. Read the browser's first plaintext request. Non-HTTP or non-splittable
+	//    traffic becomes a plaintext MITM splice, replaying what we read to the origin.
+	reqHead, isHTTP := peekRequestHead(btls, rsHeadLimit)
+	clearDeadlines(btls)
+	if !isHTTP {
+		c.splicePrefixed(btls, otls, reqHead)
+		return
+	}
+	req, perr := http.ReadRequest(bufio.NewReader(bytes.NewReader(reqHead)))
+	if perr != nil || !splittableRequest(req) {
+		c.splicePrefixed(btls, otls, reqHead)
+		return
+	}
+
+	// 5. Drive the split over the terminated browser conn (btls) and origin conn (otls).
+	if !c.httpsRangeSplitDrive(btls, otls, req, reqHead, host) {
+		// Nothing recoverable remains once we have started consuming the origin
+		// response; drive() has already closed both ends on every exit path.
+		return
+	}
+}
+
+// httpsRangeSplitDrive performs the range probe on otls and, on a 206, reassembles
+// the body onto btls. It returns true once it has fully served the response (split,
+// verbatim relay, or a clean truncation) and closed both ends. reqHead is the raw
+// request block; req is its parsed form.
+func (c *Client) httpsRangeSplitDrive(btls, otls net.Conn, req *http.Request, reqHead []byte, host string) bool {
+	// Probe: original request + Range: bytes=0-(chunk-1). A non-range origin ignores
+	// it and returns its normal 200, kept byte-identical by the relay path below.
+	if _, err := otls.Write(injectRange(reqHead, 0, c.rs.chunkSize-1)); err != nil {
+		closeBoth(btls, otls)
+		return true
+	}
+	br := bufio.NewReader(otls)
+	statusLine, err := br.ReadString('\n')
+	if err != nil {
+		closeBoth(btls, otls)
+		return true
+	}
+	if statusCode(statusLine) != 206 {
+		// Origin ignored Range (200) or returned redirect/error: relay verbatim so the
+		// browser sees exactly what its unmodified GET would have produced.
+		_, _ = btls.Write([]byte(statusLine)) //nolint:errcheck
+		if n := br.Buffered(); n > 0 {
+			b, _ := br.Peek(n)   //nolint:errcheck // peeking exactly Buffered() bytes never errors
+			_, _ = btls.Write(b) //nolint:errcheck
+		}
+		_, _ = io.Copy(btls, otls) //nolint:errcheck
+		closeBoth(btls, otls)
+		return true
+	}
+
+	tp := textproto.NewReader(br)
+	hdr, err := tp.ReadMIMEHeader()
+	if err != nil {
+		closeBoth(btls, otls)
+		return true
+	}
+	total, okTotal := parseContentRangeTotal(hdr.Get("Content-Range"))
+	if !okTotal || total <= 0 {
+		closeBoth(btls, otls)
+		return true
+	}
+	validator := ifRangeValidator(hdr)
+
+	if err := writeSynth200(btls, hdr, total); err != nil {
+		closeBoth(btls, otls)
+		return true
+	}
+
+	// chunk0 body straight from the probe response.
+	chunk0Len := c.rs.chunkSize
+	if total < chunk0Len {
+		chunk0Len = total
+	}
+	if _, err := io.CopyN(btls, br, chunk0Len); err != nil {
+		closeBoth(btls, otls)
+		return true
+	}
+	otls.Close() //nolint:errcheck,gosec // origin stream0 done; remaining chunks use fresh TLS streams
+	if total <= c.rs.chunkSize {
+		btls.Close() //nolint:errcheck,gosec
+		return true
+	}
+
+	if c.appCl != nil {
+		c.appCl.Log().Debugf("https range-split: %s %d bytes → %d chunks × %d streams",
+			host, total, numChunks(total, c.rs.chunkSize), c.rs.concurrency)
+	}
+	c.rsSplits.Add(1)
+	c.rsChunks.Add(uint64(numChunks(total, c.rs.chunkSize))) //nolint:gosec // numChunks>0 here (total>chunkSize)
+	c.rsBytes.Add(uint64(total))                             //nolint:gosec // total>0 checked above
+	c.rsActive.Add(1)
+	c.streamRemainingChunks(btls, total, func(start, end int64) ([]byte, error) {
+		return c.fetchChunkTLSRetry(req, host, validator, start, end)
+	})
+	c.rsActive.Add(-1)
+	btls.Close() //nolint:errcheck,gosec
+	return true
+}
+
+// fetchChunkTLSRetry fetches one byte range over a fresh TLS-to-origin stream,
+// redialing on churn — the HTTPS analogue of fetchChunkRetry.
+func (c *Client) fetchChunkTLSRetry(req *http.Request, host, validator string, start, end int64) ([]byte, error) {
+	var err error
+	for i := 0; i < rsChunkRetries; i++ {
+		var buf []byte
+		buf, err = c.fetchChunkTLS(req, host, validator, start, end)
+		if err == nil {
+			return buf, nil
+		}
+	}
+	return nil, err
+}
+
+// fetchChunkTLS opens a new exit stream, SOCKS5-CONNECTs to host:443, wraps it in a
+// verified TLS client to the origin, issues a ranged GET carrying the original
+// request's headers plus If-Range, and returns exactly the requested bytes.
+func (c *Client) fetchChunkTLS(req *http.Request, host, validator string, start, end int64) ([]byte, error) {
+	sess := c.pickSession()
+	if sess == nil {
+		return nil, errAllTunnelsDown
+	}
+	st, err := sess.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer st.Close() //nolint:errcheck,gosec
+
+	_ = st.SetDeadline(time.Now().Add(rsProbeTimeout)) //nolint:errcheck
+	if err := c.exitConnect(st, host, 443); err != nil {
+		return nil, err
+	}
+	tconn := tls.Client(st, c.originTLSConfig(host))
+	if err := tconn.Handshake(); err != nil {
+		return nil, err
+	}
+	if _, err := tconn.Write(buildRangedGet(req, host, validator, start, end)); err != nil {
+		return nil, err
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(tconn), req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusPartialContent {
+		return nil, fmt.Errorf("chunk %d-%d: status %d (validator changed?)", start, end, resp.StatusCode)
+	}
+	buf := make([]byte, end-start+1)
+	if _, err := io.ReadFull(resp.Body, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// closeBoth closes two conns, ignoring errors.
+func closeBoth(a, b net.Conn) {
+	a.Close() //nolint:errcheck,gosec
+	b.Close() //nolint:errcheck,gosec
+}

--- a/pkg/skysocks/rangesplit_https_test.go
+++ b/pkg/skysocks/rangesplit_https_test.go
@@ -120,7 +120,7 @@ func TestHTTPSRangeSplitByteIdentity(t *testing.T) {
 	const blobSize = 8 << 20
 	blob := make([]byte, blobSize)
 	for i := range blob {
-		blob[i] = byte(i*131 + 17)
+		blob[i] = byte(i*131 + 17) //nolint:gosec // deterministic test fill; byte wrap is intended
 	}
 	want := sha256Sum(blob)
 

--- a/pkg/skysocks/rangesplit_https_test.go
+++ b/pkg/skysocks/rangesplit_https_test.go
@@ -1,0 +1,216 @@
+package skysocks
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// newHTTPSRSTestClient stands up a range-split client with HTTPS termination enabled,
+// wired to a fake exit that splices to backendAddr (a TLS origin). It returns the
+// proxy address, the client (for counter assertions) and a cert pool trusting the
+// MITM root (for the test browser). originRoots must trust the TLS origin.
+func newHTTPSRSTestClient(t *testing.T, backendAddr string, originRoots *x509.CertPool, conc int, chunk int64) (string, *Client, *x509.CertPool) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close() //nolint:errcheck
+	dialed := make(chan net.Conn, 1)
+	go func() {
+		c, _ := ln.Accept() //nolint:errcheck
+		dialed <- c
+	}()
+	cliConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial pair: %v", err)
+	}
+	exitConn := <-dialed
+	go rsFakeExit(t, exitConn, backendAddr)
+
+	client, err := NewClient(cliConn, nil)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	client.SetRangeSplit(true, conc, chunk)
+	if err := client.SetHTTPSRangeSplit(t.TempDir()); err != nil {
+		t.Fatalf("enable https range-split: %v", err)
+	}
+	client.SetHTTPSRangeSplitOriginRoots(originRoots)
+	t.Cleanup(func() { _ = client.Close() }) //nolint:errcheck
+
+	caPEM, ok := client.MITMCACertPEM()
+	if !ok {
+		t.Fatal("MITMCACertPEM returned ok=false after enabling https range-split")
+	}
+	browserRoots := x509.NewCertPool()
+	if !browserRoots.AppendCertsFromPEM(caPEM) {
+		t.Fatal("failed to add MITM CA to browser pool")
+	}
+
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	proxyAddr := probe.Addr().String()
+	probe.Close()                                        //nolint:errcheck,gosec
+	go func() { _ = client.ListenAndServe(proxyAddr) }() //nolint:errcheck
+	for i := 0; i < 100; i++ {
+		if cc, err := net.Dial("tcp", proxyAddr); err == nil {
+			cc.Close() //nolint:errcheck,gosec
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return proxyAddr, client, browserRoots
+}
+
+// socks5GetTLS drives a SOCKS5 CONNECT to host:443, a TLS handshake (trusting
+// browserRoots, i.e. the proxy's MITM root), and a plain GET, returning the parsed
+// response with its body fully read.
+func socks5GetTLS(t *testing.T, proxyAddr, host, path string, browserRoots *x509.CertPool) *http.Response {
+	t.Helper()
+	c, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	if _, err := c.Write([]byte{0x05, 0x01, 0x00}); err != nil {
+		t.Fatalf("greeting: %v", err)
+	}
+	if _, err := io.ReadFull(c, make([]byte, 2)); err != nil {
+		t.Fatalf("method reply: %v", err)
+	}
+	req := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))} //nolint:gosec // test host is short
+	req = append(req, host...)
+	req = append(req, 0x01, 0xbb) // port 443
+	if _, err := c.Write(req); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, err := readSocks5Reply(c); err != nil {
+		t.Fatalf("connect reply: %v", err)
+	}
+	tc := tls.Client(c, &tls.Config{ServerName: host, RootCAs: browserRoots, MinVersion: tls.VersionTLS12})
+	if err := tc.Handshake(); err != nil {
+		t.Fatalf("browser TLS handshake (MITM leaf not trusted?): %v", err)
+	}
+	if _, err := fmt.Fprintf(tc, "GET %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: itest\r\n\r\n", path, host); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(tc), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	return resp
+}
+
+// TestHTTPSRangeSplitByteIdentity is the HTTPS acceptance test: a plain GET over a
+// MITM-terminated TLS connection, split into concurrent ranges over separate
+// TLS-to-origin streams, reassembles byte-identically — and records a real split.
+func TestHTTPSRangeSplitByteIdentity(t *testing.T) {
+	const blobSize = 8 << 20
+	blob := make([]byte, blobSize)
+	for i := range blob {
+		blob[i] = byte(i*131 + 17)
+	}
+	want := sha256Sum(blob)
+
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Etag", "\"tlsv1\"")
+		http.ServeContent(w, r, "blob.bin", time.Unix(0, 0), bytes.NewReader(blob))
+	}))
+	defer backend.Close()
+
+	originRoots := x509.NewCertPool()
+	originRoots.AddCert(backend.Certificate())
+
+	// 1 MiB chunks over 8 MiB → 8 chunks across 4 concurrent TLS streams.
+	proxy, client, browserRoots := newHTTPSRSTestClient(t, backend.Listener.Addr().String(), originRoots, 4, 1<<20)
+
+	resp := socks5GetTLS(t, proxy, "example.com", "/blob.bin", browserRoots)
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if resp.ContentLength != blobSize {
+		t.Fatalf("Content-Length = %d, want %d", resp.ContentLength, blobSize)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if sha256Sum(got) != want {
+		t.Fatal("reassembled HTTPS body does not match origin (byte-identity FAILED)")
+	}
+	if n := client.rsSplits.Load(); n < 1 {
+		t.Fatalf("rsSplits = %d, want >=1 (the transfer was not actually split)", n)
+	}
+}
+
+// TestHTTPSRangeSplitNonRangeOrigin: a TLS origin that ignores Range must fall back
+// to a byte-identical relay over the terminated TLS.
+func TestHTTPSRangeSplitNonRangeOrigin(t *testing.T) {
+	blob := bytes.Repeat([]byte("QRS7"), 2<<20) // 8 MiB, server ignores Range
+	want := sha256Sum(blob)
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write(blob) //nolint:errcheck
+	}))
+	defer backend.Close()
+
+	originRoots := x509.NewCertPool()
+	originRoots.AddCert(backend.Certificate())
+	proxy, _, browserRoots := newHTTPSRSTestClient(t, backend.Listener.Addr().String(), originRoots, 4, 1<<20)
+
+	resp := socks5GetTLS(t, proxy, "example.com", "/nr.bin", browserRoots)
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if sha256Sum(got) != want {
+		t.Fatalf("non-range HTTPS fallback mismatch: got %d want %d bytes", len(got), len(blob))
+	}
+}
+
+// TestUnconstrainedCAMintsRealHost verifies the security-critical new primitive: an
+// unconstrained CA mints a leaf for an arbitrary clearnet host that verifies against
+// the CA — which a name-constrained CA (the resolver default) cannot do.
+func TestUnconstrainedCAMintsRealHost(t *testing.T) {
+	cert, minter, err := loadOrCreateMITMCA(t.TempDir())
+	if err != nil {
+		t.Fatalf("create MITM CA: %v", err)
+	}
+	if len(cert.PermittedDNSDomains) != 0 {
+		t.Fatalf("MITM CA carries name constraints %v — it must be unconstrained", cert.PermittedDNSDomains)
+	}
+	leaf, err := minter.For("download.example.com")
+	if err != nil {
+		t.Fatalf("mint leaf for real host: %v", err)
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(cert)
+	x, err := x509.ParseCertificate(leaf.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	if _, err := x.Verify(x509.VerifyOptions{DNSName: "download.example.com", Roots: roots}); err != nil {
+		t.Fatalf("leaf for real host does not verify against MITM CA: %v", err)
+	}
+}
+
+// sha256Sum is a tiny local helper so this file does not depend on the exact import
+// set of the sibling integration test.
+func sha256Sum(b []byte) [32]byte { return sha256.Sum256(b) }


### PR DESCRIPTION
The transparent range-splitter only fired on plain `:80` GETs — so HTTPS, the bulk of real traffic, spliced through untouched. This implements the deferred follow-up.

On an **opt-in** basis (`--range-split-https`, off by default), the skysocks-client terminates the browser's `:443` TLS with a leaf minted on demand by a local **unconstrained** root, reads the plaintext GET, and fetches the body as N concurrent byte ranges over fresh TLS-to-origin streams — the origin verified against the system roots, so the proxy never downgrades what the origin proves. The reassembled 200 is written back over the terminated TLS; anything not splittable becomes a transparent plaintext MITM splice. The range-fetch/reassembly core is shared with the `:80` path via a fetch closure.

It is a deliberate security decision and therefore off by default: the minting root can forge a leaf for any host, so `skynetca` gains an explicit `Unconstrained` CA path (never defaulted), and the operator must import the root into the browser — the app prints the CA cert + its path on startup.

Tested: byte-identity over a MITM-terminated TLS transfer split across concurrent TLS-to-origin streams; non-range origin falls back byte-identically; an unconstrained CA mints a leaf for an arbitrary clearnet host that verifies against the root. Also binds the range-split flags into the internal-launcher flag subset, which had omitted them.

Note: origins using HSTS/HPKP pinning will reject the interposed leaf, as with any MITM — expected, and why this stays opt-in.