### PR TITLE
fix(skysocks-client): create HTTPS range-split MITM root at startup, not on dial

### DIFF
--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -3,6 +3,8 @@ package commands
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"log"
@@ -31,6 +33,7 @@ import (
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/skynetca"
 	"github.com/skycoin/skywire/pkg/skysocks"
 )
 
@@ -190,6 +193,35 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		go httpProxy(httpCtx, httpAddr, addr, log)
 	}
 
+	// HTTPS (:443) range-splitting is an explicit security opt-in. Create/load the
+	// MITM root ONCE here, at startup — independent of any dial — so the operator can
+	// import the printed CA before traffic ever flows, and so the SAME persistent
+	// root is injected into every reconnect's client below (it never changes
+	// underfoot). The root can forge a leaf for any host; that is why it is off by
+	// default and must be trusted explicitly.
+	var (
+		mitmCert   *x509.Certificate
+		mitmMinter skynetca.LeafMinter
+	)
+	if rangeHTTPS {
+		caDir := rangeHTTPSCA
+		if caDir == "" {
+			home, herr := os.UserHomeDir()
+			if herr != nil {
+				home = "."
+			}
+			caDir = filepath.Join(home, ".skywire", "rangesplit-mitm")
+		}
+		cert, minter, herr := skysocks.LoadOrCreateMITMCA(caDir)
+		if herr != nil {
+			log.WithError(herr).Warn("HTTPS range-splitting requested but its MITM root could not be initialized; :443 will splice through unchanged")
+		} else {
+			mitmCert, mitmMinter = cert, minter
+			pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+			log.Warnf("HTTPS range-splitting ENABLED — import this root into your browser to trust intercepted origins; it can forge any host, so remove it when done:\n  CA file: %s\n%s", filepath.Join(caDir, "ca.crt"), string(pemBytes))
+		}
+	}
+
 	// SIGINT goroutine cancels the outer ctx so the cycle loop
 	// breaks out cleanly. Installed once for the proc lifetime;
 	// each cycle's client.ListenAndServe returns when the
@@ -302,23 +334,11 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		// range-capable :80 GET is fetched as concurrent byte ranges over separate
 		// tunnels, so a single download aggregates across the mesh.
 		client.SetRangeSplit(rangeSplit, int(rangeConc), rangeChunkKiB*1024)
-		// HTTPS (:443) range-splitting is an explicit security opt-in: enabling it
-		// mints browser leaves from a forge-any-host root, so it is only wired when
-		// asked, and the operator is told exactly which CA to import.
-		if rangeHTTPS {
-			caDir := rangeHTTPSCA
-			if caDir == "" {
-				home, herr := os.UserHomeDir()
-				if herr != nil {
-					home = "."
-				}
-				caDir = filepath.Join(home, ".skywire", "rangesplit-mitm")
-			}
-			if herr := client.SetHTTPSRangeSplit(caDir); herr != nil {
-				log.WithError(herr).Warn("HTTPS range-splitting requested but its MITM root could not be initialized; :443 will splice through unchanged")
-			} else if pemBytes, ok := client.MITMCACertPEM(); ok {
-				log.Warnf("HTTPS range-splitting ENABLED — import this root into your browser to trust intercepted origins; it can forge any host, so remove it when done:\n  CA file: %s\n%s", filepath.Join(caDir, "ca.crt"), string(pemBytes))
-			}
+		// HTTPS (:443) range-splitting: inject the MITM root minted ONCE at startup
+		// (mitmMinter, below) so it is the same persistent CA across every reconnect
+		// and exists before any dial. nil minter = feature off or CA init failed.
+		if mitmMinter != nil {
+			client.SetHTTPSRangeSplitMinter(mitmCert, mitmMinter)
 		}
 		if tunnels > 1 {
 			client.SetTunnelRedial(func() (net.Conn, error) {

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/skycoin/skywire/pkg/proxyinterstitial"
 	"github.com/skycoin/skywire/pkg/proxystatus"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/skynetca"
 	"github.com/skycoin/skywire/pkg/wasmhv/wasmbin"
 	"github.com/skycoin/skywire/third_party/hashicorp/yamux"
 )
@@ -273,20 +274,32 @@ func (c *Client) SetRangeSplit(enabled bool, concurrency int, chunkSize int64) {
 	}
 }
 
-// SetHTTPSRangeSplit enables TLS-terminating (:443) range-splitting, loading or
-// creating the unconstrained MITM root under caDir (caDir/ca.crt + ca.key). It is a
-// deliberate security opt-in: the returned root can forge a leaf for any host, so it
-// is never enabled by default, and the operator must import caDir/ca.crt into the
-// browser for the terminated TLS to be trusted (MITMCACertPEM returns it). Errors
-// (unreadable/creatable CA) leave HTTPS range-splitting off.
-func (c *Client) SetHTTPSRangeSplit(caDir string) error {
-	cert, minter, err := loadOrCreateMITMCA(caDir)
-	if err != nil {
-		return err
+// SetHTTPSRangeSplitMinter enables TLS-terminating (:443) range-splitting on this
+// client using a MITM root + minter the CALLER already created (via
+// LoadOrCreateMITMCA). This is the production path: the CA is a persistent local
+// identity minted ONCE at app startup — independent of any dial — and the same
+// minter is injected into every reconnect's client, so the operator can import the
+// cert before traffic ever flows and it never changes underfoot.
+func (c *Client) SetHTTPSRangeSplitMinter(cert *x509.Certificate, minter skynetca.LeafMinter) {
+	if cert == nil || minter == nil {
+		return
 	}
 	c.rs.caCert = cert
 	c.rs.minter = minter
 	c.rs.httpsEnabled = true
+}
+
+// SetHTTPSRangeSplit is a convenience that loads/creates the MITM root under caDir
+// and enables the feature on this client in one call. Prefer LoadOrCreateMITMCA +
+// SetHTTPSRangeSplitMinter when the CA must exist before the first client is built
+// (so it can be exported up front). Errors (unreadable/creatable CA) leave the
+// feature off.
+func (c *Client) SetHTTPSRangeSplit(caDir string) error {
+	cert, minter, err := LoadOrCreateMITMCA(caDir)
+	if err != nil {
+		return err
+	}
+	c.SetHTTPSRangeSplitMinter(cert, minter)
 	return nil
 }
 

--- a/pkg/skysocks/rangesplit_https.go
+++ b/pkg/skysocks/rangesplit_https.go
@@ -51,11 +51,11 @@ func isPort443(target string) bool {
 	return port == "443"
 }
 
-// loadOrCreateMITMCA loads the unconstrained MITM root from dir, generating and
+// LoadOrCreateMITMCA loads the unconstrained MITM root from dir, generating and
 // persisting one on first use. dir/ca.crt is the cert to import into the browser;
 // dir/ca.key is its private key (0600). Returns the cert, a leaf minter that will
 // sign for any host, and the cert itself for export.
-func loadOrCreateMITMCA(dir string) (*x509.Certificate, skynetca.LeafMinter, error) {
+func LoadOrCreateMITMCA(dir string) (*x509.Certificate, skynetca.LeafMinter, error) {
 	certPath := filepath.Join(dir, "ca.crt")
 	keyPath := filepath.Join(dir, "ca.key")
 

--- a/pkg/skysocks/rangesplit_https_test.go
+++ b/pkg/skysocks/rangesplit_https_test.go
@@ -189,7 +189,7 @@ func TestHTTPSRangeSplitNonRangeOrigin(t *testing.T) {
 // unconstrained CA mints a leaf for an arbitrary clearnet host that verifies against
 // the CA — which a name-constrained CA (the resolver default) cannot do.
 func TestUnconstrainedCAMintsRealHost(t *testing.T) {
-	cert, minter, err := loadOrCreateMITMCA(t.TempDir())
+	cert, minter, err := LoadOrCreateMITMCA(t.TempDir())
 	if err != nil {
 		t.Fatalf("create MITM CA: %v", err)
 	}


### PR DESCRIPTION
Follow-up to #4359. The MITM root was loaded inside the reconnect cycle, right after a successful exit dial — so with a flaky exit the operator could never obtain the cert to import (chicken-and-egg: the terminated TLS needs a trusted cert, but the cert only appeared once traffic already flowed). The root is a persistent local identity independent of dialing.

Create/load it **once at app startup** when `--range-split-https` is set, print it immediately, and inject that same minter into every reconnect's client via the new `SetHTTPSRangeSplitMinter` (`LoadOrCreateMITMCA` is now exported). The cert exists and is printed before any dial and never changes across reconnects.