### PR TITLE
fix(status.skysocks): render the standby route fan — real source/exit + hop-less legs

### DIFF
--- a/pkg/proxystatus/provider.go
+++ b/pkg/proxystatus/provider.go
@@ -101,11 +101,16 @@ type Hop struct {
 // below are already shaped so a control UI can render alongside them without a
 // wire change. Keep additions additive.
 type Snapshot struct {
-	Surface    Surface
-	App        string // underlying app/logger name (dmsgweb / skynetweb / skysocks-client)
-	Running    bool   // whether the surface's process/runtime is currently alive
-	MuxEnabled bool   // route group has multiplexing enabled
-	Legs       []Leg  // current per-leg mux state (empty when no active route group)
+	Surface Surface
+	App     string // underlying app/logger name (dmsgweb / skynetweb / skysocks-client)
+	// SelfPK is this visor's own public key — the route source. Carried explicitly
+	// so the tree/graph can label the source and place each leg's first hop even
+	// when the legs have no recorded forward-hop path (the router does not always
+	// record it for auto/standby legs); treeSrc falls back to this.
+	SelfPK     string
+	Running    bool  // whether the surface's process/runtime is currently alive
+	MuxEnabled bool  // route group has multiplexing enabled
+	Legs       []Leg // current per-leg mux state (empty when no active route group)
 	// Tunnels is the STREAM-level view: one entry per active route group (a
 	// --tunnels stream), each carrying its own PACKET-level mux Legs. The two
 	// levels of route multiplexing are stream (tunnels, disjoint route groups)

--- a/pkg/proxystatus/routegraph.go
+++ b/pkg/proxystatus/routegraph.go
@@ -210,23 +210,49 @@ func buildRouteGraph(snap Snapshot) rgGraph {
 			}
 			hops := l.Hops
 			if len(hops) == 0 {
-				// No recorded path: a single edge src → remote(exit).
-				exitPK := l.RemotePK
-				if exitPK == "" {
-					exitPK = t.ExitPK
+				// No recorded forward path (common for auto/standby legs, which the
+				// router does not always record hops for). Synthesize from the leg's
+				// own transport, which is accurate: src → RemotePK IS the real first
+				// hop. For a DIRECT leg RemotePK is the exit; for a relayed leg it is
+				// the first intermediate, so add an inferred continuation
+				// RemotePK → exit (t.ExitPK) — otherwise the intermediate was
+				// mislabeled as the exit and the standby fan never converged.
+				realExit := t.ExitPK
+				remote := l.RemotePK
+				if remote == "" {
+					remote = realExit
 				}
-				if exitPK == "" {
+				if remote == "" {
 					continue
 				}
-				ex := get(exitPK)
-				ex.isExit = true
 				line := legLine(streamIdx, l, "", "", l.TpType, l.LatencyMS)
+				if l.Direct || realExit == "" || remote == realExit {
+					ex := get(remote)
+					ex.isExit = true
+					root.lines = append(root.lines, line)
+					ex.lines = append(ex.lines, line)
+					links = append(links, rgLink{
+						Source: src, Target: remote, Stream: streamIdx,
+						Color: streamColor(streamIdx), Active: !l.Standby, Width: rate, Tip: line,
+					})
+					continue
+				}
+				mid := get(remote)
+				if mid.level == 0 {
+					mid.level = 1
+				}
+				if mid.streamOrd < 0 {
+					mid.streamOrd = ord
+				}
+				ex := get(realExit)
+				ex.isExit = true
 				root.lines = append(root.lines, line)
+				mid.lines = append(mid.lines, line)
 				ex.lines = append(ex.lines, line)
-				links = append(links, rgLink{
-					Source: src, Target: exitPK, Stream: streamIdx,
-					Color: streamColor(streamIdx), Active: !l.Standby, Width: rate, Tip: line,
-				})
+				links = append(links,
+					rgLink{Source: src, Target: remote, Stream: streamIdx, Color: streamColor(streamIdx), Active: !l.Standby, Width: rate, Tip: line},
+					rgLink{Source: remote, Target: realExit, Stream: streamIdx, Color: streamColor(streamIdx), Active: !l.Standby, Width: rate, Tip: line},
+				)
 				continue
 			}
 			n := len(hops)

--- a/pkg/proxystatus/routegraph_test.go
+++ b/pkg/proxystatus/routegraph_test.go
@@ -47,6 +47,52 @@ func twoStreamSnap() Snapshot {
 	}
 }
 
+// TestBuildRouteGraph_HoplessLegsSynthesize verifies legs WITHOUT a recorded
+// forward path (auto/standby legs the router did not record hops for) still render
+// from their own transport: a direct hop-less leg draws src→exit, and a relayed
+// hop-less leg draws src→intermediate→exit — converging on the TRUE exit (t.ExitPK)
+// rather than mislabeling the leg's first-hop intermediate as the exit.
+func TestBuildRouteGraph_HoplessLegsSynthesize(t *testing.T) {
+	snap := Snapshot{
+		Surface: SurfaceSkysocks, App: "skysocks-client", Running: true, MuxEnabled: true, SelfPK: rgSrc,
+		Tunnels: []Tunnel{{Index: 0, ExitPK: rgExit, MuxEnabled: true, Legs: []Leg{
+			{Index: 0, RemotePK: rgExit, Direct: true, Alive: true},  // direct, no hops
+			{Index: 1, RemotePK: rgHopA, Direct: false, Alive: true}, // relayed, no hops
+		}}},
+	}
+	g := buildRouteGraph(snap)
+	roleOf := map[string]string{}
+	for _, n := range g.Nodes {
+		roleOf[n.ID] = n.Role
+	}
+	if roleOf[rgExit] != "exit" {
+		t.Fatalf("rgExit role = %q, want exit", roleOf[rgExit])
+	}
+	if roleOf[rgHopA] == "exit" {
+		t.Fatalf("rgHopA (an intermediate) mislabeled as exit")
+	}
+	if roleOf[rgSrc] != "root" {
+		t.Fatalf("rgSrc role = %q, want root (treeSrc should fall back to SelfPK)", roleOf[rgSrc])
+	}
+	has := func(s, d string) bool {
+		for _, l := range g.Links {
+			if l.Source == s && l.Target == d {
+				return true
+			}
+		}
+		return false
+	}
+	if !has(rgSrc, rgExit) {
+		t.Error("missing direct src→exit link")
+	}
+	if !has(rgSrc, rgHopA) {
+		t.Error("missing relayed src→intermediate link")
+	}
+	if !has(rgHopA, rgExit) {
+		t.Error("missing intermediate→exit convergence link (relayed leg must reach the true exit)")
+	}
+}
+
 func TestBuildRouteGraph_DedupRolesColors(t *testing.T) {
 	g := buildRouteGraph(twoStreamSnap())
 

--- a/pkg/proxystatus/routetree.go
+++ b/pkg/proxystatus/routetree.go
@@ -136,6 +136,12 @@ func treeSrc(snap Snapshot) string {
 	if s := pick(snap.Legs); s != "" {
 		return s
 	}
+	// No leg recorded its forward hops (common for auto/standby legs) — fall back to
+	// the visor's own PK, carried explicitly on the snapshot, so the root is still
+	// the real source rather than a placeholder.
+	if snap.SelfPK != "" {
+		return snap.SelfPK
+	}
 	return "this visor"
 }
 

--- a/pkg/visor/embedded_proxystatus.go
+++ b/pkg/visor/embedded_proxystatus.go
@@ -121,11 +121,21 @@ func (p *visorStatusProvider) StatusSnapshot(surface proxystatus.Surface) (proxy
 	// route group is one --tunnels STREAM; its Legs are the PACKET-level mux. Model
 	// every tunnel (not just the first) so the status tree can nest tunnel → legs;
 	// mirror the first tunnel's legs into snap.Legs for back-compat.
+	self := p.v.conf.PK
+	snap.SelfPK = self.String()
 	if infos, err := p.v.RouteGroupMuxInfo(app); err == nil {
 		for ti, info := range infos {
+			// The exit is the descriptor end that is NOT this visor. A client route
+			// group's descriptor carries the local visor as Dst and the exit as Src,
+			// so hardcoding DstPK mislabeled the local visor as the exit; pick the
+			// far end orientation-independently.
+			exit := info.Desc.DstPK
+			if exit == self {
+				exit = info.Desc.SrcPK
+			}
 			t := proxystatus.Tunnel{
 				Index:      ti,
-				ExitPK:     info.Desc.DstPK.String(),
+				ExitPK:     exit.String(),
 				MuxEnabled: info.MuxEnabled,
 			}
 			for _, leg := range info.Legs {


### PR DESCRIPTION
The status.skysocks route graph collapsed to "stream 0 + one edge" because it derived everything from per-leg forward hops, which the router does not record for auto/standby legs. With empty hops: `treeSrc` returned no source, `ExitPK` was hardcoded to `Desc.DstPK` (which is the **local visor** on a client route group, not the exit), and each hop-less leg drew a single `src→RemotePK` edge that **mislabeled its first-hop intermediate as the exit** — so the ~16–20 warm standby legs never fanned out or converged.

Fix, contained to the status projection (no router changes): carry the real source (`SelfPK`) and the far (non-local) exit on the snapshot; have `treeSrc` fall back to `SelfPK`; and synthesize hop-less legs from their own transport (which is accurate) — a direct leg draws `src→exit`, a relayed leg draws `src→intermediate→exit` converging on the true exit. The deep standby pool now renders as a fan of disjoint routes to one exit. Tested.