### PR TITLE
fix(status.skysocks): stable leg order so the tree/graph stop reshuffling

### DIFF
--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -625,6 +625,12 @@ func legRank(l Leg) int {
 	}
 }
 
+// legStableKey is a leg's stable render identity — its intermediate (RemotePK)
+// then its transport id. Used to order legs WITHIN a role group so a given route
+// keeps its slot across refreshes even as the leg set (and thus per-leg indices)
+// churns while the warm-standby pool grows and shrinks.
+func legStableKey(l Leg) string { return l.RemotePK + "|" + l.TransportID }
+
 // writeStreamsSection expands the "N open stream(s)" count into per-stream rows
 // when the surface tracks them (skysocks-client records id + CONNECT target +
 // age, plus this stream's own up/down byte totals and smoothed transfer rate).

--- a/pkg/proxystatus/routegraph.go
+++ b/pkg/proxystatus/routegraph.go
@@ -24,6 +24,7 @@ package proxystatus
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -200,7 +201,13 @@ func buildRouteGraph(snap Snapshot) rgGraph {
 
 	for ord, t := range tunnels {
 		streamIdx := t.Index
-		for _, l := range t.Legs {
+		// Walk legs in a stable identity order (intermediate, then transport) so the
+		// deterministic seed layout places each route at the same spot across
+		// refreshes — otherwise a churning leg set reshuffled node first-encounter
+		// order and jittered the graph as the pool grew.
+		legs := append([]Leg(nil), t.Legs...)
+		sort.SliceStable(legs, func(i, j int) bool { return legStableKey(legs[i]) < legStableKey(legs[j]) })
+		for _, l := range legs {
 			if !l.Alive {
 				continue
 			}

--- a/pkg/proxystatus/routetree.go
+++ b/pkg/proxystatus/routetree.go
@@ -199,7 +199,12 @@ func legNodesForStream(all []Leg, streamIdx int) []*bitree.Node {
 		if ri, rj := legRank(legs[i]), legRank(legs[j]); ri != rj {
 			return ri < rj
 		}
-		return legs[i].Index < legs[j].Index
+		// Stable within a role group: key on the leg's IDENTITY (its intermediate,
+		// then its transport), not its Index. The leg set churns as standby routes
+		// are added/dropped, which reassigns indices and made the tree branches jump
+		// around every ~1s refresh; keying on the peer keeps a given route in the
+		// same slot so the tree stays readable while the pool grows.
+		return legStableKey(legs[i]) < legStableKey(legs[j])
 	})
 	// Aggregate per-direction goodput across the surviving legs — the denominator
 	// each route's share bar is drawn against.

--- a/pkg/proxystatus/routetree_test.go
+++ b/pkg/proxystatus/routetree_test.go
@@ -78,3 +78,24 @@ func TestRouteTreeTwoLevel(t *testing.T) {
 		t.Error("flat fallback should not nest a tunnel level")
 	}
 }
+
+// TestLegOrderStableUnderIndexChurn verifies that legs render in a stable order
+// keyed on identity (intermediate PK), not on their churning Index — so the tree
+// does not reshuffle its branches as the warm-standby pool adds/drops legs.
+func TestLegOrderStableUnderIndexChurn(t *testing.T) {
+	mk := func(idx int, remote string) Leg {
+		return Leg{Index: idx, RemotePK: remote, TransportID: "tp-" + remote, Alive: true, Standby: true,
+			Hops: []Hop{{From: "src", To: remote, TpType: "stcpr"}}}
+	}
+	// Same three routes (by intermediate), presented with DIFFERENT indices/order.
+	a := legNodesForStream([]Leg{mk(0, "pkC"), mk(1, "pkA"), mk(2, "pkB")}, -1)
+	b := legNodesForStream([]Leg{mk(7, "pkB"), mk(3, "pkC"), mk(9, "pkA")}, -1)
+	if len(a) != len(b) || len(a) == 0 {
+		t.Fatalf("leg node counts differ: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i].Label != b[i].Label {
+			t.Fatalf("leg order not stable under index churn at %d: %q vs %q", i, a[i].Label, b[i].Label)
+		}
+	}
+}


### PR DESCRIPTION
The route tree and graph ordered legs within each role group by their `Index`, which is reassigned as the warm-standby pool adds and drops legs — so the branches (and the graph's node placement) jumped around on every ~1s refresh, making them hard to read while the pool churns.

Order within a role group by leg **identity** (the intermediate PK, then the transport id) instead, so a given route keeps its slot as the pool grows and shrinks. Role grouping (direct/active/standby/dead) is unchanged. Tested that permuting indices doesn't change render order.