### PR TITLE
feat(router): route_exclude_transport_types — hard-exclude transport types from routes

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -129,6 +129,10 @@ type Config struct {
 	RulesGCInterval  time.Duration
 	MinHops          uint16
 	MaxHops          uint16
+	// ExcludeTransportTypes hard-excludes routes traversing any of these transport
+	// types from the candidate set (see visorconfig.Routing.RouteExcludeTransportTypes).
+	// Empty = nothing excluded. Lowercased type names.
+	ExcludeTransportTypes []string
 	// MuxRoutes seeds the router's runtime parallel-mux-routes value from
 	// routing.mux_routes at construction, the way MinHops already is. The
 	// dial-time default is applied by the app networker (which the launcher

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -1278,6 +1279,22 @@ fetchRoutesAgain:
 		paths[backward] = filtered
 	}
 
+	// Operator-configured hard exclusion (routing.route_exclude_transport_types):
+	// drop any candidate route that traverses an excluded transport type, so it
+	// never enters the mux leg pool. Unlike transportTypeCostMs (deprioritize), this
+	// removes the route entirely — the fix for flaky types (e.g. webrtc) that wedge
+	// the reorder frontier. Opt-in and empty by default.
+	if len(r.conf.ExcludeTransportTypes) > 0 {
+		if filtered := rejectExcludedTypes(paths[forward], typeFor, r.conf.ExcludeTransportTypes); len(filtered) != len(paths[forward]) {
+			log.Debugf("excluded %d forward candidate(s) by transport type %v", len(paths[forward])-len(filtered), r.conf.ExcludeTransportTypes)
+			paths[forward] = filtered
+		}
+		if filtered := rejectExcludedTypes(paths[backward], typeFor, r.conf.ExcludeTransportTypes); len(filtered) != len(paths[backward]) {
+			log.Debugf("excluded %d reverse candidate(s) by transport type %v", len(paths[backward])-len(filtered), r.conf.ExcludeTransportTypes)
+			paths[backward] = filtered
+		}
+	}
+
 	// Multi-tunnel diversify (opts.DiversifyTransports): steer this extra
 	// tunnel's FIRST HOP off the transports its sibling tunnels to the same
 	// exit already occupy (opts.ExcludeTransportIDs, seeded by
@@ -1752,6 +1769,40 @@ func (r *router) buildHopLookups(ctx context.Context, fwd, rev [][]routing.Hop) 
 //
 // Returns the input slice unchanged when nothing was filtered, to
 // avoid an allocation in the common case.
+// rejectExcludedTypes drops any candidate route (single- OR multi-hop) that
+// traverses a transport type in exclude (case-insensitive). Unlike rejectDMSGMultihop
+// (which spares a direct hop of the type), this removes the type ENTIRELY — the
+// operator asked for it not to be used at all — so even a 1-hop leg of that type is
+// dropped. Empty exclude / nil typeFor is a no-op returning paths unchanged.
+func rejectExcludedTypes(paths [][]routing.Hop, typeFor func(uuid.UUID) string, exclude []string) [][]routing.Hop {
+	if len(paths) == 0 || typeFor == nil || len(exclude) == 0 {
+		return paths
+	}
+	excl := make(map[string]struct{}, len(exclude))
+	for _, e := range exclude {
+		if t := strings.ToLower(strings.TrimSpace(e)); t != "" {
+			excl[t] = struct{}{}
+		}
+	}
+	if len(excl) == 0 {
+		return paths
+	}
+	out := make([][]routing.Hop, 0, len(paths))
+	for _, p := range paths {
+		drop := false
+		for _, h := range p {
+			if _, bad := excl[strings.ToLower(typeFor(h.TpID))]; bad {
+				drop = true
+				break
+			}
+		}
+		if !drop {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 func rejectDMSGMultihop(paths [][]routing.Hop, typeFor func(uuid.UUID) string) [][]routing.Hop {
 	if len(paths) == 0 || typeFor == nil {
 		return paths

--- a/pkg/router/router_dial_dmsg_multihop_test.go
+++ b/pkg/router/router_dial_dmsg_multihop_test.go
@@ -138,3 +138,39 @@ func TestRejectDMSGMultihop_UnknownTypeTreatedAsAllowed(t *testing.T) {
 		t.Errorf("unknown type treated as DMSG; len(out)=%d, want 1", len(out))
 	}
 }
+
+func TestRejectExcludedTypes(t *testing.T) {
+	tpWR := uuid.New()  // webrtc leg
+	tpST := uuid.New()  // stcpr leg
+	tpMid := uuid.New() // stcpr intermediate
+	src, _ := cipher.GenerateKeyPair()
+	mid, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	typeFor := func(id uuid.UUID) string {
+		switch id {
+		case tpWR:
+			return "webrtc"
+		default:
+			return "stcpr"
+		}
+	}
+	paths := [][]routing.Hop{
+		{{TpID: tpWR, From: src, To: dst}},                                    // 1-hop webrtc — dropped
+		{{TpID: tpST, From: src, To: dst}},                                    // 1-hop stcpr — kept
+		{{TpID: tpMid, From: src, To: mid}, {TpID: tpWR, From: mid, To: dst}}, // 2-hop with webrtc 2nd leg — dropped
+	}
+	out := rejectExcludedTypes(paths, typeFor, []string{"WebRTC"}) // case-insensitive
+	if len(out) != 1 {
+		t.Fatalf("len(out)=%d, want 1 (only the pure-stcpr route survives)", len(out))
+	}
+	if out[0][0].TpID != tpST {
+		t.Errorf("surviving route is not the stcpr one")
+	}
+	// Empty exclude / nil typeFor are no-ops.
+	if got := rejectExcludedTypes(paths, typeFor, nil); len(got) != len(paths) {
+		t.Errorf("empty exclude should be a no-op, got %d", len(got))
+	}
+	if got := rejectExcludedTypes(paths, nil, []string{"webrtc"}); len(got) != len(paths) {
+		t.Errorf("nil typeFor should be a no-op, got %d", len(got))
+	}
+}

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -293,6 +293,7 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 		MinHops:               v.conf.Routing.MinHops,
 		MuxRoutes:             v.conf.Routing.MuxRoutes,
 		ParallelRouteSetup:    v.conf.Routing.ParallelRouteSetup,
+		ExcludeTransportTypes: v.conf.Routing.RouteExcludeTransportTypes,
 		AwaitSetupListener:    v.awaitSetupListener,
 		Logger:                logger,
 		MasterLogger:          v.MasterLogger(),

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -685,6 +685,17 @@ type Routing struct {
 	// via PUT /api/visors/{pk}/router-settings.
 	TransportPreference []string `json:"transport_preference,omitempty"`
 
+	// RouteExcludeTransportTypes hard-EXCLUDES routes that traverse any of these
+	// transport types, rather than merely deprioritizing them like
+	// TransportPreference does. A route (in either direction) is dropped from the
+	// candidate set if ANY of its hops rides an excluded type — so an excluded type
+	// never enters the mux leg pool. Intended for types whose flakiness poisons the
+	// mux (e.g. "webrtc": a stalled webrtc leg wedges the no-skip reorder frontier
+	// and truncates downloads). Empty by default (nothing excluded), so it stays
+	// opt-in — a visor that NEEDS a type (e.g. webrtc for a wasm/browser peer) simply
+	// leaves it off its own list. Values use the same names as TransportPreference.
+	RouteExcludeTransportTypes []string `json:"route_exclude_transport_types,omitempty"`
+
 	// EnableRSNOracleRoutes opts INTO the RSN-oracle 2-hop route path: for a
 	// single-intermediate route S->I->D the source computes the route LOCALLY
 	// from its OWN transports intersected with the destination's OWN transports

--- a/pkg/visor/visorcore/router.go
+++ b/pkg/visor/visorcore/router.go
@@ -25,19 +25,20 @@ import (
 // Zero values for the optional native-only fields (AppLookup, DialHook,
 // RulesGCInterval, SetupHooks) are correct for a browser edge.
 type RouterDeps struct {
-	DmsgC              *dmsg.Client
-	PubKey             cipher.PubKey
-	SecKey             cipher.SecKey
-	TransportManager   *transport.Manager
-	RouteFinder        rfclient.Client
-	RouteGroupDialer   router.RouteGroupDialer
-	SetupNodes         []cipher.PubKey
-	MinHops            uint16
-	MuxRoutes          int
-	ParallelRouteSetup int
-	AwaitSetupListener *dmsg.Listener
-	Logger             *logging.Logger
-	MasterLogger       *logging.MasterLogger
+	DmsgC                 *dmsg.Client
+	PubKey                cipher.PubKey
+	SecKey                cipher.SecKey
+	TransportManager      *transport.Manager
+	RouteFinder           rfclient.Client
+	RouteGroupDialer      router.RouteGroupDialer
+	SetupNodes            []cipher.PubKey
+	MinHops               uint16
+	MuxRoutes             int
+	ExcludeTransportTypes []string
+	ParallelRouteSetup    int
+	AwaitSetupListener    *dmsg.Listener
+	Logger                *logging.Logger
+	MasterLogger          *logging.MasterLogger
 
 	AppLookup       func(routing.Port) (string, bool)
 	DialHook        router.DialHook
@@ -80,6 +81,7 @@ func BuildRouter(serveCtx context.Context, deps RouterDeps) (router.Router, erro
 		SetupNodes:            deps.SetupNodes,
 		MinHops:               deps.MinHops,
 		MuxRoutes:             deps.MuxRoutes,
+		ExcludeTransportTypes: deps.ExcludeTransportTypes,
 		ParallelRouteSetup:    deps.ParallelRouteSetup,
 		AwaitSetupListener:    deps.AwaitSetupListener,
 		AppLookup:             deps.AppLookup,


### PR DESCRIPTION
`transportTypeCostMs` only *deprioritizes* a transport type (webrtc costs 300); when the mux needs disjoint legs it still pulls webrtc in — and a stalled webrtc leg wedges the no-skip reorder frontier (measured live: the webrtc leg freezes, stcpr retransmits ~60 MB for a 4 MB download, and the transfer truncates at one chunk).

Add `routing.route_exclude_transport_types`: a candidate route (either direction, any hop) is dropped from the set if it traverses an excluded type, so an excluded type never enters the mux leg pool. **Opt-in and empty by default** — a visor that needs a type (e.g. webrtc for a wasm/browser peer) simply leaves it off its own list. Client-side filter in `fetchBestRoutes`, mirroring the existing `rejectDMSGMultihop`. The route-finder-side exclusion (so the RF doesn't return those routes at all) is the natural next layer.