### PR TITLE
perf(webrtc): raise SCTP receive window off 1 MiB default + surface dead channels

### DIFF
--- a/pkg/transport/network/webrtc_native.go
+++ b/pkg/transport/network/webrtc_native.go
@@ -39,11 +39,31 @@ const dcLabel = "skywire"
 // the largest frame the upper stack writes (Noise messages are <=64 KiB).
 const dcReadBuf = 96 * 1024
 
+// sctpReceiveBufferBytes is the SCTP receive-window (a_rwnd) this carrier
+// advertises, raised from pion's 1 MiB default (pion/sctp initialRecvBufSize).
+// Throughput over a reliable stream is bounded by window / RTT (the
+// bandwidth-delay product): the advertised receiver-window credit caps how much
+// unacknowledged data may be in flight. The skywire mesh path has a high
+// end-to-end RTT (~0.5-1 s across relays), so the 1 MiB default throttles a
+// single DataChannel to ~1 MB/s regardless of the underlying link — and under a
+// full window SCTP flow-control simply stops advancing, which presents as a
+// silent mid-transfer stall (the same class of bug as the 256 KB yamux window,
+// #4211). 16 MiB gives 16 MB/s at 1 s RTT (128 Mbps), saturating a 100 Mbps card
+// with headroom; SCTP only holds up to a window's worth of actually-received-
+// but-unread data, so idle channels pay nothing. The advertised window governs
+// the peer's send rate INTO us, so this value speeds our downloads; the peer's
+// value speeds our uploads once the fleet redeploys. Fits uint32 (a_rwnd is a
+// 32-bit credit) with room to spare.
+const sctpReceiveBufferBytes = 16 * 1024 * 1024
+
 // newWebRTCAPI builds a pion API with detached DataChannels (so we get an
 // io.ReadWriteCloser to adapt to net.Conn instead of pion's callback model).
 func newWebRTCAPI() *webrtc.API {
 	se := webrtc.SettingEngine{}
 	se.DetachDataChannels()
+	// Raise the SCTP receive window off its 1 MiB default so a high-BDP mesh path
+	// isn't flow-control throttled/stalled — see sctpReceiveBufferBytes.
+	se.SetSCTPMaxReceiveBufferSize(sctpReceiveBufferBytes)
 	// Empty MediaEngine: skywire uses WebRTC for DATA CHANNELS ONLY, never audio/
 	// video. With the default MediaEngine pion registers audio/video codecs and
 	// starts SRTP/SRTCP + RTP/RTCP media-processor goroutines per PeerConnection
@@ -260,6 +280,21 @@ type dcConn struct {
 
 func newDCConn(raw datachannel.ReadWriteCloser, pc *webrtc.PeerConnection, signal io.Closer) *dcConn {
 	c := &dcConn{raw: raw, pc: pc, signal: signal, notify: make(chan struct{})}
+	// Surface a dead path promptly. pion's ICE agent already runs consent-freshness
+	// keepalive (a STUN binding every ~2 s, "disconnected" after ~5 s of silence,
+	// "failed" after ~25 s more) — but that liveness verdict was never wired to the
+	// net.Conn, so a DataChannel whose path had died left dcConn.Read blocked on
+	// raw.Read indefinitely (a SILENT stall the mux's route-group liveness could not
+	// evict). Fail the conn as soon as the PeerConnection reaches Failed or Closed so
+	// the stall trips a read error immediately, without adding a redundant app-level
+	// ping on top of ICE's. (A flow-control stall — the BDP trap Lever 1 addresses —
+	// keeps packets flowing, so ICE stays Connected; that path is handled by the
+	// larger receive window and by write-deadline forwarding below.)
+	pc.OnConnectionStateChange(func(s webrtc.PeerConnectionState) {
+		if s == webrtc.PeerConnectionStateFailed || s == webrtc.PeerConnectionStateClosed {
+			c.fail(fmt.Errorf("webrtc: peer connection %s", s))
+		}
+	})
 	go c.readPump()
 	return c
 }
@@ -414,8 +449,29 @@ func (c *dcConn) SetReadDeadline(t time.Time) error {
 	c.mu.Unlock()
 	return nil
 }
-func (c *dcConn) SetWriteDeadline(time.Time) error { return nil }
-func (c *dcConn) SetDeadline(t time.Time) error    { return c.SetReadDeadline(t) }
+
+// SetWriteDeadline forwards to the underlying SCTP stream when it supports
+// deadlines (pion's detached DataChannel is a datachannel.ReadWriteCloserDeadliner).
+// Writes otherwise block in raw.Write with no bound, so a wedged channel — the
+// receiver stalled and the SCTP send window exhausted — hangs the writer forever
+// and the upper stack's own write timeout can never trip. Honoring the deadline
+// lets a stall surface as a write timeout at the caller's chosen deadline. Reads
+// keep their dcConn-layer deadline (the readPump owns raw.Read), so only the write
+// side is forwarded here.
+func (c *dcConn) SetWriteDeadline(t time.Time) error {
+	if d, ok := c.raw.(datachannel.ReadWriteCloserDeadliner); ok {
+		return d.SetWriteDeadline(t)
+	}
+	return nil
+}
+func (c *dcConn) SetDeadline(t time.Time) error {
+	werr := c.SetWriteDeadline(t)
+	rerr := c.SetReadDeadline(t)
+	if rerr != nil {
+		return rerr
+	}
+	return werr
+}
 
 type dcTimeout struct{}
 

--- a/pkg/transport/network/webrtc_native_test.go
+++ b/pkg/transport/network/webrtc_native_test.go
@@ -3,7 +3,11 @@
 package network
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"errors"
+	"io"
 	"net"
 	"sync"
 	"testing"
@@ -61,5 +65,133 @@ func TestWebRTCCarrier_RoundTrip(t *testing.T) {
 	}
 	if string(buf2) != "pong" {
 		t.Fatalf("offerer got %q, want pong", buf2)
+	}
+}
+
+// TestWebRTCCarrier_LargePayload round-trips a payload many times the old 1 MiB
+// SCTP receive window over the real carrier, exercising the enlarged-window data
+// path for bulk transfer. This is a correctness/liveness check, NOT a throughput
+// claim: on loopback the RTT is ~0, so it cannot demonstrate the BDP speedup —
+// that needs two live peers across a high-RTT mesh path (see the const comment on
+// sctpReceiveBufferBytes).
+func TestWebRTCCarrier_LargePayload(t *testing.T) {
+	sigA, sigB := net.Pipe()
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+	defer cancel()
+
+	var aConn, bConn net.Conn
+	var aErr, bErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); aConn, aErr = webrtcDial(ctx, sigA, nil) }()
+	go func() { defer wg.Done(); bConn, bErr = webrtcAccept(ctx, sigB, nil) }()
+	wg.Wait()
+	if aErr != nil || bErr != nil {
+		t.Fatalf("carrier setup: dial=%v accept=%v", aErr, bErr)
+	}
+	defer aConn.Close() //nolint:errcheck
+	defer bConn.Close() //nolint:errcheck
+
+	const total = 4 * 1024 * 1024
+	payload := make([]byte, total)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+
+	got := make([]byte, total)
+	var rErr error
+	var rwg sync.WaitGroup
+	rwg.Add(1)
+	go func() {
+		defer rwg.Done()
+		rErr = readFull(bConn, got)
+	}()
+
+	// Write in <=dcReadBuf chunks (a single SCTP message must fit the reader's buf).
+	for off := 0; off < total; off += 64 * 1024 {
+		end := off + 64*1024
+		if end > total {
+			end = total
+		}
+		if _, err := aConn.Write(payload[off:end]); err != nil {
+			t.Fatalf("write at %d: %v", off, err)
+		}
+	}
+	rwg.Wait()
+	if rErr != nil {
+		t.Fatalf("read: %v", rErr)
+	}
+	if !bytes.Equal(payload, got) {
+		t.Fatal("payload mismatch across the DataChannel")
+	}
+}
+
+// fakeDeadlineDC is a datachannel.ReadWriteCloserDeadliner stand-in that records
+// the last write deadline set on it, so the dcConn deadline-forwarding can be
+// tested without a live PeerConnection.
+type fakeDeadlineDC struct {
+	wDeadline time.Time
+	rDeadline time.Time
+}
+
+func (f *fakeDeadlineDC) Read([]byte) (int, error)                       { return 0, io.EOF }
+func (f *fakeDeadlineDC) Write(p []byte) (int, error)                    { return len(p), nil }
+func (f *fakeDeadlineDC) ReadDataChannel([]byte) (int, bool, error)      { return 0, false, io.EOF }
+func (f *fakeDeadlineDC) WriteDataChannel(p []byte, _ bool) (int, error) { return len(p), nil }
+func (f *fakeDeadlineDC) Close() error                                   { return nil }
+func (f *fakeDeadlineDC) SetReadDeadline(t time.Time) error              { f.rDeadline = t; return nil }
+func (f *fakeDeadlineDC) SetWriteDeadline(t time.Time) error             { f.wDeadline = t; return nil }
+
+// TestDCConn_SetWriteDeadlineForwards proves SetWriteDeadline reaches the
+// underlying SCTP stream (a deadliner). Without this, writes block in raw.Write
+// unbounded and a wedged channel can never trip the caller's write timeout.
+func TestDCConn_SetWriteDeadlineForwards(t *testing.T) {
+	fake := &fakeDeadlineDC{}
+	c := &dcConn{raw: fake, notify: make(chan struct{})}
+
+	want := time.Now().Add(5 * time.Second)
+	if err := c.SetWriteDeadline(want); err != nil {
+		t.Fatalf("SetWriteDeadline: %v", err)
+	}
+	if !fake.wDeadline.Equal(want) {
+		t.Fatalf("write deadline not forwarded: got %v want %v", fake.wDeadline, want)
+	}
+
+	// SetDeadline must forward the write side too (the read side stays at the
+	// dcConn layer, so we only assert the write deadline reached the stream).
+	fake.wDeadline = time.Time{}
+	want2 := time.Now().Add(9 * time.Second)
+	if err := c.SetDeadline(want2); err != nil {
+		t.Fatalf("SetDeadline: %v", err)
+	}
+	if !fake.wDeadline.Equal(want2) {
+		t.Fatalf("SetDeadline did not forward write deadline: got %v want %v", fake.wDeadline, want2)
+	}
+}
+
+// TestDCConn_FailSurfacesOnRead proves the effect the OnConnectionStateChange
+// handler relies on: once fail() runs (which the handler calls when the
+// PeerConnection reaches Failed/Closed), a blocked Read returns that error
+// promptly instead of hanging — this is what surfaces a silently-dead channel.
+func TestDCConn_FailSurfacesOnRead(t *testing.T) {
+	c := &dcConn{raw: &fakeDeadlineDC{}, notify: make(chan struct{})}
+
+	readErr := make(chan error, 1)
+	go func() {
+		_, err := c.Read(make([]byte, 8))
+		readErr <- err
+	}()
+
+	// Read is blocked (no data, not closed). Simulate the state callback firing.
+	sentinel := errors.New("webrtc: peer connection failed")
+	time.AfterFunc(20*time.Millisecond, func() { c.fail(sentinel) })
+
+	select {
+	case err := <-readErr:
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("Read returned %v, want %v", err, sentinel)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read did not return after fail() — a dead channel would hang")
 	}
 }


### PR DESCRIPTION
The pion WebRTC carrier used pion/sctp's default receive window (a_rwnd), 1 MiB. Throughput over a reliable stream is bounded by window / RTT, so on the mesh's high end-to-end RTT (~0.5-1 s across relays) a single DataChannel was capped near ~1 MB/s and, under a full window, SCTP flow-control stops advancing and presents as a silent mid-transfer stall — the same class of bug as the 256 KB yamux window (#4211). Raise it to 16 MiB via `SetSCTPMaxReceiveBufferSize` (16 MB/s at 1 s RTT). The advertised window governs the peer's send rate into us, so this speeds our downloads; the peer's value speeds uploads once the fleet redeploys.

A dead path was also never surfaced to the `net.Conn`: pion's ICE agent already runs consent-freshness keepalive, but that verdict wasn't wired up, so a DataChannel whose path died left `Read` blocked indefinitely (a silent stall the route-group liveness couldn't evict quickly). Wire `OnConnectionStateChange` to fail the conn on Failed/Closed, and forward the write deadline to the SCTP stream so a wedged write trips the caller's timeout instead of hanging. No redundant app-level ping is added on top of ICE's.

Unit-tested: build/vet/lint clean, deadline forwarding, fail()-surfaces-on-Read, and a 4 MiB carrier round-trip. The BDP throughput gain needs two live peers on a high-RTT path and is **not** asserted in tests (loopback RTT ~0).