### PR TITLE
feat(router): cap per-leg FEC-block striping so a stalled leg stays FEC-recoverable

### DIFF
--- a/pkg/router/fec_mux.go
+++ b/pkg/router/fec_mux.go
@@ -28,6 +28,8 @@ import (
 	"encoding/binary"
 	"sync"
 	"sync/atomic"
+
+	"github.com/skycoin/skywire/pkg/transport"
 )
 
 // FEC block geometry. K data frames + R repair frames per block; recovers all K
@@ -398,6 +400,73 @@ func (m *routeMux) fecOnSend(seq uint32, wire []byte) {
 	m.fecRepairMu.Lock()
 	m.fecRepairQ = append(m.fecRepairQ, frames...)
 	m.fecRepairMu.Unlock()
+}
+
+// fecStripeActive reports whether the FEC-block striping cap applies: FEC is
+// negotiated and the group has >=2 active legs (a single-leg group can't spread and
+// FEC is skipped there anyway, so the cap would be a pointless no-op).
+func (m *routeMux) fecStripeActive() bool {
+	return m.fecEnabled && m.fecStriper != nil && m.activeLegCount() >= 2
+}
+
+// fecStripeSyncLocked resets the per-block leg counts when the FEC block rolls
+// over. Caller holds fecStripeMu.
+func (m *routeMux) fecStripeSyncLocked(block uint32) {
+	if block != m.fecStripeBlock || m.fecStripeUsed == nil {
+		m.fecStripeBlock = block
+		m.fecStripeUsed = make(map[int]int)
+	}
+}
+
+// fecStripeReassign returns an alternative leg when the raw-selected idx already
+// holds fecDefaultR frames of the CURRENT FEC block (seq/fecDefaultK). Spreading
+// the block so no leg exceeds R frames keeps a fully-stalled leg within FEC's
+// R-erasure recovery. ok=false keeps the original pick — when the cap is inactive,
+// idx still has room, or every alive-ready leg is already block-full (never fail a
+// send for the cap; an over-stripe just falls back to SACK-retransmit as before).
+func (m *routeMux) fecStripeReassign(tps []*transport.ManagedTransport, idx int) (int, bool) {
+	if !m.fecStripeActive() || idx < 0 || idx >= len(tps) {
+		return idx, false
+	}
+	block := atomic.LoadUint32(&m.writeSeq) / fecDefaultK
+	m.fecStripeMu.Lock()
+	defer m.fecStripeMu.Unlock()
+	m.fecStripeSyncLocked(block)
+	if m.fecStripeUsed[idx] < fecDefaultR {
+		return idx, false // the raw pick still has room this block
+	}
+	// idx is full for this block — search round-robin from just past it for an
+	// alive-ready leg with room, so successive blocks fan across the leg set
+	// instead of always collapsing onto leg 0.
+	n := len(tps)
+	for off := 1; off <= n; off++ {
+		j := (idx + off) % n
+		if j == idx {
+			continue
+		}
+		tp := tps[j]
+		if tp == nil || tp.IsClosed() || !m.legReadyAt(j) {
+			continue
+		}
+		if m.fecStripeUsed[j] < fecDefaultR {
+			return j, true
+		}
+	}
+	return idx, false // every alive-ready leg is block-full; keep the pick
+}
+
+// fecStripeUse records that a data frame was committed to leg idx in the current
+// FEC block, so subsequent picks in the same block honor the per-leg R cap. Inert
+// unless the cap is active.
+func (m *routeMux) fecStripeUse(idx int) {
+	if !m.fecStripeActive() || idx < 0 {
+		return
+	}
+	block := atomic.LoadUint32(&m.writeSeq) / fecDefaultK
+	m.fecStripeMu.Lock()
+	m.fecStripeSyncLocked(block)
+	m.fecStripeUsed[idx]++
+	m.fecStripeMu.Unlock()
 }
 
 // fecDrainRepairs returns and clears the queued repair frames for the send loop.

--- a/pkg/router/fec_stripe_test.go
+++ b/pkg/router/fec_stripe_test.go
@@ -1,0 +1,83 @@
+package router
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// TestFECStripeCap pins the FEC-block striping cap: no leg exceeds fecDefaultR
+// frames of a K-frame block (so a fully-stalled leg stays within FEC's R-erasure
+// recovery), it never fails a send, and it is inert when FEC is off.
+func TestFECStripeCap(t *testing.T) {
+	m := &routeMux{
+		fecEnabled: true,
+		fecStriper: newFECStriper(fecDefaultK, fecDefaultR),
+		legs:       make([]*legCounters, 4),
+		ready:      []bool{true, true, true, true},
+	}
+	tps := []*transport.ManagedTransport{{}, {}, {}, {}} // zero-value: IsClosed()==false
+
+	if !m.fecStripeActive() {
+		t.Fatal("cap should be active (fecEnabled + 4 active legs)")
+	}
+	// Empty block: the raw pick has room, no reassignment.
+	if alt, ok := m.fecStripeReassign(tps, 0); ok || alt != 0 {
+		t.Fatalf("empty block: got (%d,%v), want (0,false)", alt, ok)
+	}
+	// Fill leg 0 to R; it is now block-full.
+	m.fecStripeUse(0)
+	m.fecStripeUse(0)
+	if got := m.fecStripeUsed[0]; got != fecDefaultR {
+		t.Fatalf("leg0 count=%d, want %d", got, fecDefaultR)
+	}
+	// Selecting leg 0 now reassigns to a leg with room.
+	if alt, ok := m.fecStripeReassign(tps, 0); !ok || alt == 0 {
+		t.Fatalf("full leg0 should reassign to another leg, got (%d,%v)", alt, ok)
+	}
+	// Fill every leg to R → reassignment keeps the original pick (never fail a send).
+	for i := 0; i < 4; i++ {
+		for m.fecStripeUsed[i] < fecDefaultR {
+			m.fecStripeUse(i)
+		}
+	}
+	if alt, ok := m.fecStripeReassign(tps, 0); ok || alt != 0 {
+		t.Fatalf("all legs block-full: got (%d,%v), want (0,false)", alt, ok)
+	}
+	// Advancing to the next block resets the per-leg counts → room again.
+	atomic.StoreUint32(&m.writeSeq, fecDefaultK) // block 1
+	if alt, ok := m.fecStripeReassign(tps, 0); ok || alt != 0 {
+		t.Fatalf("new block: got (%d,%v), want (0,false)", alt, ok)
+	}
+	if got := m.fecStripeUsed[0]; got != 0 {
+		t.Fatalf("block rolled over but leg0 count=%d, want 0", got)
+	}
+	// FEC off → cap is inert: no reassignment, no counting.
+	m.fecEnabled = false
+	m.fecStripeUse(0)
+	if alt, ok := m.fecStripeReassign(tps, 3); ok || alt != 3 {
+		t.Fatalf("fec off: got (%d,%v), want (3,false)", alt, ok)
+	}
+}
+
+// TestFECStripeCapInertSingleLeg: with <2 active legs the cap must be inert (a
+// single-leg group can't spread and FEC is skipped there anyway).
+func TestFECStripeCapInertSingleLeg(t *testing.T) {
+	m := &routeMux{
+		fecEnabled: true,
+		fecStriper: newFECStriper(fecDefaultK, fecDefaultR),
+		legs:       make([]*legCounters, 1),
+		ready:      []bool{true},
+	}
+	if m.fecStripeActive() {
+		t.Fatal("cap must be inactive with a single active leg")
+	}
+	tps := []*transport.ManagedTransport{{}}
+	m.fecStripeUse(0)
+	m.fecStripeUse(0)
+	m.fecStripeUse(0)
+	if alt, ok := m.fecStripeReassign(tps, 0); ok || alt != 0 {
+		t.Fatalf("single leg: got (%d,%v), want (0,false)", alt, ok)
+	}
+}

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -229,6 +229,14 @@ type routeMux struct {
 	fecReassembler *fecReassembler
 	fecRepairMu    sync.Mutex
 	fecRepairQ     []fecRepairFrame
+	// FEC-block striping cap: keep no single leg above fecDefaultR frames of any
+	// K-frame FEC block, so a leg that fully stalls stays within FEC's R-erasure
+	// recovery (a leg carrying >R of a block's K frames exceeds what repair can
+	// reconstruct, and the group falls back to SACK-retransmit — the webrtc wedge).
+	// fecStripeUsed counts, for the CURRENT block, how many frames each leg took.
+	fecStripeMu    sync.Mutex
+	fecStripeBlock uint32
+	fecStripeUsed  map[int]int
 	// FEC telemetry (atomic). fecRepairBytesSent/Recv are cumulative repair-frame
 	// bytes this group scheduled onto / received from legs; fecReconstructs counts
 	// frontier frames recovered from repair (each a slow-leg stall avoided). These
@@ -362,7 +370,25 @@ func newRouteMux(logger *logging.Logger, sackEnabled bool) *routeMux {
 // back to the schedule-based pick.
 //
 // NOTE: not thread-safe, caller must hold the RouteGroup mu.
+// selectTransport picks the leg for the next data frame, then applies the
+// FEC-block striping cap so no leg exceeds fecDefaultR frames per K-frame block.
+// The cap is a thin, best-effort post-pass over selectTransportRaw: it never fails
+// a send (if every alive-ready leg is already block-full it keeps the raw pick),
+// and it is inert unless FEC is negotiated on a multi-leg group — so the
+// pre-integration selection is preserved byte-for-byte when fecEnabled=false.
 func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []routing.Rule, payload []byte) (*transport.ManagedTransport, routing.Rule, int, error) {
+	tp, rule, idx, err := m.selectTransportRaw(tps, fwd, payload)
+	if err != nil || idx < 0 {
+		return tp, rule, idx, err
+	}
+	if alt, ok := m.fecStripeReassign(tps, idx); ok && alt < len(fwd) {
+		tp, rule, idx = tps[alt], fwd[alt], alt
+	}
+	m.fecStripeUse(idx)
+	return tp, rule, idx, nil
+}
+
+func (m *routeMux) selectTransportRaw(tps []*transport.ManagedTransport, fwd []routing.Rule, payload []byte) (*transport.ManagedTransport, routing.Rule, int, error) {
 	if len(tps) == 0 {
 		return nil, nil, -1, ErrNoTransports
 	}


### PR DESCRIPTION
FEC reconstructs up to R=2 erasures per K=8 block, but the scheduler could stripe **more than R** of a block's frames onto a single leg (capacity/ecf favor the fast leg). When that leg fully stalls it exceeds FEC's recovery, so the group falls back to SACK-retransmit + liveness-prune — the **measured webrtc wedge** (webrtc leg froze, stcpr retransmitted ~60 MB for a 4 MB download, transfer truncated at one chunk).

Cap it: keep no leg above `fecDefaultR` frames of any K-frame block. `selectTransport` becomes a thin post-pass over `selectTransportRaw` (renamed, logic unchanged) — if the raw-picked leg is already block-full it reassigns to an alive-ready leg with room. **Best-effort** (never fails a send; all-full keeps the pick) and **inert unless FEC is negotiated on a multi-leg group**, so non-FEC selection is byte-for-byte unchanged. A fully-stalled leg then carries ≤R of each block and FEC reconstructs it instead of wedging. Tested (cap holds, never fails, per-block reset, inert when off/single-leg); full router suite passes.