### PR TITLE
feat(router): apply route_exclude_transport_types to the mux K-candidate path too

### DIFF
--- a/pkg/router/parallel_route_setup.go
+++ b/pkg/router/parallel_route_setup.go
@@ -297,6 +297,22 @@ func (r *router) fetchCandidateRoutes(
 	fwdCands := rejectDMSGMultihop(paths[forward], typeFor)
 	revCands := rejectDMSGMultihop(paths[backward], typeFor)
 
+	// Drop candidates traversing an excluded transport type so they never seed
+	// the initial mux leg pool. The primary/aux dials filter in fetchBestRoutes;
+	// this K-candidate race is the other route-finder path and must match, or a
+	// flaky type (e.g. webrtc) leaks into the standby pool and wedges the reorder
+	// frontier. Opt-in, empty by default.
+	if len(r.conf.ExcludeTransportTypes) > 0 {
+		if filtered := rejectExcludedTypes(fwdCands, typeFor, r.conf.ExcludeTransportTypes); len(filtered) != len(fwdCands) {
+			log.Debugf("excluded %d forward candidate(s) by transport type %v", len(fwdCands)-len(filtered), r.conf.ExcludeTransportTypes)
+			fwdCands = filtered
+		}
+		if filtered := rejectExcludedTypes(revCands, typeFor, r.conf.ExcludeTransportTypes); len(filtered) != len(revCands) {
+			log.Debugf("excluded %d reverse candidate(s) by transport type %v", len(revCands)-len(filtered), r.conf.ExcludeTransportTypes)
+			revCands = filtered
+		}
+	}
+
 	fwdRanked := r.rankCandidatePaths(fwdCands, src, dst, opts.ExcludeIntermediatePKs, latencyFor, typeFor, throughputFor, k)
 	revRanked := r.rankCandidatePaths(revCands, dst, src, opts.ExcludeIntermediatePKs, latencyFor, typeFor, throughputFor, k)
 	if len(fwdRanked) == 0 || len(revRanked) == 0 {


### PR DESCRIPTION
`route_exclude_transport_types` (#4368) dropped excluded types only in `fetchBestRoutes` (primary + aux/self-heal dials). The **initial mux leg pool** is built by `fetchCandidateRoutes` — the K-candidate route-finder race — which applied `rejectDMSGMultihop` but **not** the excluded-type filter. So a flaky type still seeded the standby pool.

Measured live: webrtc legs entered a skysocks mux despite `route_exclude_transport_types: ["webrtc"]` and wedged the no-skip reorder frontier — a 20MB download **truncated at 4MB** while the two direct legs retransmitted **~197MB** (transport_id-keyed `recv_bytes` deltas) to deliver it.

Mirror the `fetchBestRoutes` filter onto `fwdCands`/`revCands` in `fetchCandidateRoutes`, so both route-finder paths honor the list and excluded types never enter the leg pool. Opt-in, empty by default; reuses the already-tested `rejectExcludedTypes`. Router suite passes.