### PR TITLE
fix(router): return mux route groups in a stable order

### DIFF
--- a/pkg/router/mux_info_order_test.go
+++ b/pkg/router/mux_info_order_test.go
@@ -1,0 +1,45 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// TestSortMuxInfosStable pins the deterministic ordering that keeps the status
+// tree / CLI mux-info rows from reshuffling: same PKs, distinct ports must come
+// back in ascending (dst_port, src_port) order regardless of input order.
+func TestSortMuxInfosStable(t *testing.T) {
+	// All tunnels of one proxy share src/dst PK and differ only by port, so one
+	// valid keypair each is enough — the sort key that matters here is the port.
+	src, _, err := cipher.GenerateDeterministicKeyPair([]byte("mux-order-src"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst, _, err := cipher.GenerateDeterministicKeyPair([]byte("mux-order-dst"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mk := func(dstPort, srcPort routing.Port) MuxInfo {
+		return MuxInfo{Desc: routing.NewRouteDescriptor(src, dst, srcPort, dstPort)}
+	}
+	// scrambled input
+	in := []MuxInfo{mk(49160, 3), mk(49157, 3), mk(49159, 3), mk(49158, 3)}
+	sortMuxInfos(in)
+
+	want := []routing.Port{49157, 49158, 49159, 49160}
+	for i, w := range want {
+		if got := in[i].Desc.DstPort(); got != w {
+			t.Fatalf("pos %d: dst_port=%d want %d (order=%v)", i, got, w,
+				[]routing.Port{in[0].Desc.DstPort(), in[1].Desc.DstPort(), in[2].Desc.DstPort(), in[3].Desc.DstPort()})
+		}
+	}
+	// idempotent: sorting again yields the same order
+	sortMuxInfos(in)
+	if in[0].Desc.DstPort() != 49157 || in[3].Desc.DstPort() != 49160 {
+		t.Fatal("sort not idempotent")
+	}
+}

--- a/pkg/router/router_rules.go
+++ b/pkg/router/router_rules.go
@@ -5,10 +5,33 @@ package router
 import (
 	"fmt"
 	"io"
+	"sort"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/routing"
 )
+
+// sortMuxInfos orders a mux-info slice deterministically by route descriptor
+// (dst PK, src PK, dst port, src port). The router holds route groups in a map,
+// so RouteGroupMuxInfo* would otherwise return them in random iteration order —
+// which reshuffled the `cli visor state` / status.skysocks stream tree and the
+// CLI mux-info rows on every refresh. A stable key keeps each tunnel in the same
+// slot as the pool churns around it.
+func sortMuxInfos(out []MuxInfo) {
+	sort.SliceStable(out, func(i, j int) bool {
+		di, dj := &out[i].Desc, &out[j].Desc
+		if a, b := di.DstPK().String(), dj.DstPK().String(); a != b {
+			return a < b
+		}
+		if a, b := di.SrcPK().String(), dj.SrcPK().String(); a != b {
+			return a < b
+		}
+		if a, b := di.DstPort(), dj.DstPort(); a != b {
+			return a < b
+		}
+		return di.SrcPort() < dj.SrcPort()
+	})
+}
 
 // Saves `rules` to the routing table.
 func (r *router) SaveRoutingRules(rules ...routing.Rule) error {
@@ -110,6 +133,7 @@ func (r *router) RouteGroupMuxInfoForApp(appName string) []MuxInfo {
 		}
 		out = append(out, nrg.rg.MuxStats())
 	}
+	sortMuxInfos(out)
 	return out
 }
 
@@ -131,6 +155,7 @@ func (r *router) RouteGroupMuxInfoAll() []MuxInfo {
 	for _, nrg := range rgs {
 		out = append(out, nrg.rg.MuxStats())
 	}
+	sortMuxInfos(out)
 	return out
 }
 


### PR DESCRIPTION
`RouteGroupMuxInfoForApp` / `RouteGroupMuxInfoAll` built their result by ranging the `rgsNs` **map**, returning route groups in random iteration order every call. With `--tunnels>1` that reshuffled the status.skysocks stream tree and the CLI mux-info rows on every refresh — tunnel branches jumped and per-tunnel deltas landed in shifting rows.

Sort both by route descriptor (dst PK, src PK, dst port, src port) before returning, so each tunnel keeps its slot as the pool churns. Fixes it at the source — the tree, the graph, and `cli proxy mux-info` / `cli visor state` all read the same `MuxStats`. Unit-tested; router suite green.