### PR TITLE
fix(skysocks): keep a range-split chunk retrying through a tunnel rotation

### DIFF
--- a/pkg/skysocks/rangesplit.go
+++ b/pkg/skysocks/rangesplit.go
@@ -53,11 +53,19 @@ type rangeSplitConfig struct {
 const (
 	defaultRSConcurrency = 8
 	defaultRSChunkSize   = 4 << 20 // 4 MiB
-	rsChunkRetries       = 3       // per-chunk redial attempts on churn
-	rsHeadLimit          = 64 << 10
-	rsProbeTimeout       = 20 * time.Second
-	rsClassifyTimeout    = 5 * time.Second  // wait for the client's first request bytes
-	rsHeadReadTimeout    = 10 * time.Second // finish reading the header block
+	rsChunkRetries       = 3       // minimum per-chunk attempts before the time budget governs
+	// rsChunkRetryBudget keeps retrying a failed chunk this long before giving up.
+	// A --tunnels rotation briefly drops every tunnel (pickSession → nil →
+	// errAllTunnelsDown); self-heal re-dials within a few seconds, so waiting out
+	// that window recovers the chunk instead of truncating the whole download (the
+	// old 3 instant retries failed in microseconds and killed it).
+	rsChunkRetryBudget     = 15 * time.Second
+	rsChunkRetryBackoff    = 100 * time.Millisecond
+	rsChunkRetryBackoffMax = 2 * time.Second
+	rsHeadLimit            = 64 << 10
+	rsProbeTimeout         = 20 * time.Second
+	rsClassifyTimeout      = 5 * time.Second  // wait for the client's first request bytes
+	rsHeadReadTimeout      = 10 * time.Second // finish reading the header block
 )
 
 func defaultRangeSplitConfig() rangeSplitConfig {
@@ -273,17 +281,38 @@ func (c *Client) streamRemainingChunks(conn net.Conn, total int64, fetch func(st
 	go func() { wg.Wait() }()
 }
 
-// fetchChunkRetry fetches one byte range, redialing a fresh stream on failure.
+// fetchChunkRetry fetches one byte range, redialing a fresh stream on failure and
+// retrying over a time budget so a transient all-tunnels-down window (a --tunnels
+// rotation) is waited out rather than truncating the download.
 func (c *Client) fetchChunkRetry(req *http.Request, host, validator string, start, end int64) ([]byte, error) {
+	return retryWithBudget(func() ([]byte, error) {
+		return c.fetchChunk(req, host, validator, start, end)
+	}, rsChunkRetryBudget, rsChunkRetryBackoff, rsChunkRetryBackoffMax)
+}
+
+// retryWithBudget calls fetch until it succeeds, or until at least rsChunkRetries
+// tries have been made AND the time budget has elapsed, backing off (capped at
+// backoffMax) between attempts. Factored out of fetchChunkRetry so the retry
+// policy is unit-testable with small durations. On persistent failure it returns
+// the last error.
+func retryWithBudget(fetch func() ([]byte, error), budget, backoff, backoffMax time.Duration) ([]byte, error) {
+	deadline := time.Now().Add(budget)
 	var err error
-	for i := 0; i < rsChunkRetries; i++ {
+	for attempt := 1; ; attempt++ {
 		var buf []byte
-		buf, err = c.fetchChunk(req, host, validator, start, end)
-		if err == nil {
+		if buf, err = fetch(); err == nil {
 			return buf, nil
 		}
+		if attempt >= rsChunkRetries && time.Now().After(deadline) {
+			return nil, err
+		}
+		time.Sleep(backoff)
+		if backoff < backoffMax {
+			if backoff *= 2; backoff > backoffMax {
+				backoff = backoffMax
+			}
+		}
 	}
-	return nil, err
 }
 
 // fetchChunk opens a new exit stream, SOCKS5-CONNECTs to host:80, issues a ranged

--- a/pkg/skysocks/rangesplit_retry_test.go
+++ b/pkg/skysocks/rangesplit_retry_test.go
@@ -1,0 +1,66 @@
+package skysocks
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestRetryWithBudget_RecoversAfterTransientFailure pins the churn-resilience: a
+// chunk that fails a few times (all-tunnels-down during a --tunnels rotation)
+// then succeeds must be recovered, not abandoned.
+func TestRetryWithBudget_RecoversAfterTransientFailure(t *testing.T) {
+	calls := 0
+	buf, err := retryWithBudget(func() ([]byte, error) {
+		calls++
+		if calls < 4 {
+			return nil, errAllTunnelsDown // transient rotation window
+		}
+		return []byte("chunk"), nil
+	}, 2*time.Second, time.Millisecond, 5*time.Millisecond)
+	if err != nil {
+		t.Fatalf("expected recovery, got err=%v after %d calls", err, calls)
+	}
+	if string(buf) != "chunk" {
+		t.Fatalf("got %q, want %q", buf, "chunk")
+	}
+	if calls != 4 {
+		t.Fatalf("expected 4 calls, got %d", calls)
+	}
+}
+
+// TestRetryWithBudget_GivesUpAfterBudget: a chunk that never recovers returns the
+// last error once the budget is spent (bounded, does not hang forever).
+func TestRetryWithBudget_GivesUpAfterBudget(t *testing.T) {
+	calls := 0
+	start := time.Now()
+	_, err := retryWithBudget(func() ([]byte, error) {
+		calls++
+		return nil, errAllTunnelsDown
+	}, 40*time.Millisecond, time.Millisecond, 5*time.Millisecond)
+	if !errors.Is(err, errAllTunnelsDown) {
+		t.Fatalf("want errAllTunnelsDown, got %v", err)
+	}
+	if calls < rsChunkRetries {
+		t.Fatalf("want at least %d attempts, got %d", rsChunkRetries, calls)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("retry loop ran far past its budget")
+	}
+}
+
+// TestRetryWithBudget_MinAttemptsBeforeGivingUp: even with a zero budget the loop
+// makes the minimum attempts (so a one-off blip still gets a couple of tries).
+func TestRetryWithBudget_MinAttemptsBeforeGivingUp(t *testing.T) {
+	calls := 0
+	_, err := retryWithBudget(func() ([]byte, error) {
+		calls++
+		return nil, errAllTunnelsDown
+	}, 0, time.Millisecond, time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != rsChunkRetries {
+		t.Fatalf("want exactly %d min attempts, got %d", rsChunkRetries, calls)
+	}
+}


### PR DESCRIPTION
`fetchChunkRetry` did 3 back-to-back attempts with no backoff. During a `--tunnels` rotation every tunnel is briefly down (`pickSession`→nil→`errAllTunnelsDown`), so all 3 retries failed in microseconds and `streamRemainingChunks` **truncated the whole download** — the intermittent **0-byte / short GETs** seen live while the tunnel set churned (dst_ports rotating together).

Retry over a **15s budget with exponential backoff** (100ms→2s) instead, so a transient all-down window is waited out and the chunk recovers when self-heal re-dials, rather than killing the transfer. Still bounded (returns the last error after the budget) so a dead origin doesn't hang. Policy factored into `retryWithBudget`, unit-tested (recovers after transient failure; gives up after budget; honors minimum attempts). skysocks suite green.