### PR TITLE
fix(router): hold >=2 active download legs and apply the mux floor live

### DIFF
--- a/pkg/router/policy/preset/floor_live_test.go
+++ b/pkg/router/policy/preset/floor_live_test.go
@@ -1,0 +1,31 @@
+package preset
+
+import "testing"
+
+// TestAdaptTargetHonorsFloorLive verifies the floor is applied on every tick, not
+// only when idle: a runtime-raised steady width (SetAdaptRevActive / proxy mux
+// width) must pull an under-floor active set up EVEN under load, so a download can
+// never be stranded on a single over-subscribed leg.
+func TestAdaptTargetHonorsFloorLive(t *testing.T) {
+	saved := AdaptRevActive()
+	defer SetAdaptRevActive(saved)
+	SetAdaptRevActive(3)
+
+	// Saturated engine whose target has shrunk to 1 (below the raised floor).
+	e := seedSaturatedAdaptive(1)
+	legs := []LegInfo{
+		activeLeg(0, "t0", 1_000_000), // single active leg
+		standbyLeg(1, "s0"),
+		standbyLeg(2, "s1"),
+		standbyLeg(3, "s2"),
+	}
+	got := e.OnTick("adaptive", legs)
+	// Floor 3 with 1 active leg → drop-recovery must promote a spare to climb
+	// toward the floor (not sit at 1).
+	if len(got.PromoteFromStandby) == 0 {
+		t.Fatalf("under-floor active set must promote toward the live floor; got %+v", got)
+	}
+	if e.adaptTarget < 3 {
+		t.Fatalf("adaptTarget=%d not clamped up to the live floor 3", e.adaptTarget)
+	}
+}

--- a/pkg/router/policy/preset/preset_test.go
+++ b/pkg/router/policy/preset/preset_test.go
@@ -426,12 +426,13 @@ func standbyLeg(idx int, tid string) LegInfo {
 // floor.
 func TestEngine_OnTick_AdaptiveStandbyFloor(t *testing.T) {
 	// (A) At the floor + sustained saturation → grow with a FRESH leg, never
-	// drain the last warm spare. One active leg (== target 1) + one standby at
-	// the floor.
-	e := seedSaturatedAdaptive(1)
+	// drain the last warm spare. Active legs == the download floor (2) + one
+	// standby at the reserve floor.
+	e := seedSaturatedAdaptive(2)
 	atFloor := []LegInfo{
 		activeLeg(0, "t0", 1_000_000),
-		standbyLeg(1, "s0"),
+		activeLeg(1, "t1", 1_000_000),
+		standbyLeg(2, "s0"),
 	}
 	if got := e.OnTick("adaptive", atFloor); !reflect.DeepEqual(got, RotationAction{AddLeg: true}) {
 		t.Errorf("saturated at the standby floor must AddLeg (not drain the reserve); got %+v", got)
@@ -439,11 +440,12 @@ func TestEngine_OnTick_AdaptiveStandbyFloor(t *testing.T) {
 
 	// (B) Surplus standby ABOVE the floor + saturated → the surplus spare may be
 	// promoted for load (efficient), keeping the floor intact.
-	e = seedSaturatedAdaptive(1)
+	e = seedSaturatedAdaptive(2)
 	surplus := []LegInfo{
 		activeLeg(0, "t0", 1_000_000),
-		standbyLeg(1, "s0"),
-		standbyLeg(2, "s1"),
+		activeLeg(1, "t1", 1_000_000),
+		standbyLeg(2, "s0"),
+		standbyLeg(3, "s1"),
 	}
 	got := e.OnTick("adaptive", surplus)
 	if len(got.PromoteFromStandby) != 1 || got.AddLeg {

--- a/pkg/router/policy/preset/tick.go
+++ b/pkg/router/policy/preset/tick.go
@@ -660,7 +660,14 @@ var (
 )
 
 func init() {
-	adaptRevActiveV.Store(1)
+	// Steady active-download floor of 2, not 1: a single active download leg
+	// over-subscribes the no-skip reorder frontier under sustained bulk load and
+	// wedges the transfer (measured live — 1-leg groups truncate at chunk0 and limp
+	// at ~57 KB/s while 2-leg groups run at multi-MB/s). Two legs give the frontier a
+	// second path to make progress on and keep a single leg-death from stranding the
+	// download on one over-subscribed leg. Still well within adaptCap (8) and FEC's
+	// R=2 erasure budget; the pool parks the rest warm.
+	adaptRevActiveV.Store(2)
 	adaptCapV.Store(8)
 	adaptStandbyMaxV.Store(512)
 }
@@ -1125,6 +1132,17 @@ func (e *Engine) tickAdaptive(legs []LegInfo) RotationAction {
 	// a symmetric group, so this is a no-op there and desiredActive ==
 	// adaptTarget + forwardExtra as before.
 	forwardExtra := e.adaptFwdTarget - adaptFwdActive
+	// Honor the steady active-download floor LIVE, every tick. adaptTarget seeds to
+	// adaptRevActive at init, but a runtime SetAdaptRevActive (proxy mux width) only
+	// reached it via the idle-shrink clamp — so a raised floor never took effect
+	// during an active download, and a target that had shrunk to a single leg stayed
+	// there. A lone active download leg over-subscribes the no-skip reorder frontier
+	// and wedges the transfer (measured: 1-leg groups truncate at chunk0 while 2-leg
+	// groups run at line rate), so clamping up to the floor here keeps drop-recovery
+	// restoring at least adaptRevActive download legs even under sustained load.
+	if e.adaptTarget < adaptRevActive {
+		e.adaptTarget = adaptRevActive
+	}
 	desiredActive := e.adaptTarget + forwardExtra + nonDLActive
 	if desiredActive > adaptCap {
 		desiredActive = adaptCap


### PR DESCRIPTION
A download wedges when its active reverse (download-class) leg set collapses to a **single leg**: that lone leg over-subscribes the no-skip reorder frontier and the transfer truncates. Measured live over a fleet exit — a **1-leg group limps at ~57 KB/s and truncates at 4 MB** of a 20 MB file, while a **2-leg group completes at multiple MB/s**.

Two causes, both fixed:
1. The steady active-download floor (`adaptRevActive`) was only re-applied to the running engine's `adaptTarget` by the **idle**-shrink clamp — so a runtime `SetAdaptRevActive` (`proxy mux width`) never took effect during an active download, and a target shrunk to one leg stayed there under load. Now clamped up to the floor **every tick**.
2. The default floor was **1** (a single over-subscribed leg). Raised to **2** — two legs give the reorder frontier a second path and survive a single leg-death, within `adaptCap=8` and FEC's R=2 budget; the pool parks the rest warm.

Preset + router suites pass; floor test scenarios updated for the new default, live-floor test added.