### PR TITLE
fix(router): park (not remove) data-stalled mux legs under a stuck frontier

### DIFF
--- a/pkg/router/park_stalled_legs_test.go
+++ b/pkg/router/park_stalled_legs_test.go
@@ -1,0 +1,26 @@
+package router
+
+import "testing"
+
+// TestParkStalledLegs pins the park-vs-remove policy for data-stalled mux legs.
+// The critical case is adaptive mode under a STUCK frontier: parking (not removing)
+// avoids orphaning in-flight sequences, which is what turned a transient HoL stall
+// into the permanent N-leg → 1-leg → 0 B/s wedge.
+func TestParkStalledLegs(t *testing.T) {
+	cases := []struct {
+		name             string
+		manual, gapStuck bool
+		wantPark         bool
+	}{
+		{"adaptive + stuck frontier → PARK (avoid orphaning in-flight)", false, true, true},
+		{"manual + stuck frontier → park", true, true, true},
+		{"manual + healthy frontier → park (pinned set)", true, false, true},
+		{"adaptive + healthy frontier → REMOVE (genuine black-hole)", false, false, false},
+	}
+	for _, c := range cases {
+		if got := parkStalledLegs(c.manual, c.gapStuck); got != c.wantPark {
+			t.Errorf("%s: parkStalledLegs(manual=%v,gapStuck=%v)=%v, want %v",
+				c.name, c.manual, c.gapStuck, got, c.wantPark)
+		}
+	}
+}

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -2181,19 +2181,30 @@ func (rg *RouteGroup) legDataProgressServiceFn(_ time.Duration) {
 	}
 	dead := selectDataStalledLegs(deltas, gapStuck)
 	if len(dead) > 0 {
-		if manual {
-			// Manual mode = the operator (or a static-mux policy, rotation_interval
-			// = 0) pinned this leg set. REMOVING a leg mid-stream orphans the
-			// sequences the sender already stripe-assigned to it, permanently
-			// wedging the no-skip reorder frontier (the observed 3-leg → 1-leg
-			// collapse that then stalls at 0 B/s). Instead PARK the stalled legs to
-			// warm standby: a standby leg is only excluded from SEND scheduling, it
-			// still RECEIVES, so its in-flight sequences keep draining the frontier,
-			// and the operator's pinned set is preserved and re-promotable once it
-			// recovers. Removal + self-heal-redial stays the ADAPTIVE-mode behavior,
-			// where churning a dead leg for a fresh one is the intent.
-			rg.logger.Infof("leg-dataprogress: parking %d stalled leg(s) to warm standby (manual mode — pinned set kept for recovery, not removed; reorder gap age %v, stuck=%v)",
-				len(dead), rg.mux.gapAge(), gapStuck)
+		// PARK (don't remove) whenever REMOVING a stalled leg would orphan the
+		// sequences the sender already stripe-assigned to it — which permanently
+		// wedges the no-skip reorder frontier (the observed N-leg → 1-leg collapse
+		// that then stalls at 0 B/s). Two cases must park:
+		//   - manual mode: the operator / static-mux policy pinned this set, and
+		//   - a STUCK frontier (gapStuck): the receiver is HoL-blocked on a missing
+		//     seq, so most legs read as "stalled" only because delivery is blocked —
+		//     they are not black-holing. Removing them here is exactly what turned a
+		//     transient stall into a permanent wedge: the sender's SACK retransmits
+		//     of the orphaned seqs then landed on a route whose rule was just torn
+		//     down ("Dropped transport frame for stale route"), so the gap could
+		//     never fill. Parking keeps each leg RECEIVING (its in-flight drains and
+		//     retransmits still land) and re-promotable once the gap clears; the
+		//     active-download floor re-promotes the healthy ones.
+		// Only a genuine black-hole caught while the frontier is HEALTHY
+		// (gapStuck == false) is REMOVED + self-heal-redialed: there is no critical
+		// in-flight to orphan, and churning a dead leg for a fresh one is the intent.
+		if parkStalledLegs(manual, gapStuck) {
+			reason := "manual mode — pinned set kept for recovery"
+			if !manual {
+				reason = "frontier stuck — parking avoids orphaning in-flight (retransmits keep landing)"
+			}
+			rg.logger.Infof("leg-dataprogress: parking %d stalled leg(s) to warm standby (%s; reorder gap age %v, stuck=%v)",
+				len(dead), reason, rg.mux.gapAge(), gapStuck)
 			rg.demoteStalledLegs(dead)
 		} else {
 			rg.logger.Infof("leg-dataprogress: fast-pruning %d data-black-holing leg(s) (delivered a negligible share of the fastest leg over %v while group moved %dB; reorder gap age %v, stuck=%v)",
@@ -2290,6 +2301,16 @@ type legRecvDelta struct {
 func soleLegBlackHoled(activeCnt int, sent, recv uint64) bool {
 	return activeCnt == 1 && sent > soleBlackHoleSentFloor && recv < soleBlackHoleRecvFloor
 }
+
+// parkStalledLegs decides whether data-stalled legs are PARKED to warm standby
+// (non-destructive, re-promotable, keeps the leg receiving so in-flight drains and
+// SACK retransmits still land) rather than REMOVED. Park when the set is pinned
+// (manual/static-mux) OR when the reorder frontier is stuck (gapStuck): a stuck
+// frontier makes many legs read as stalled only because delivery is HoL-blocked,
+// and removing them orphans their in-flight sequences — turning a transient stall
+// into a permanent wedge. Remove only a genuine black-hole caught while the
+// frontier is HEALTHY, where no critical in-flight is orphaned.
+func parkStalledLegs(manual, gapStuck bool) bool { return manual || gapStuck }
 
 func selectDataStalledLegs(legs []legRecvDelta, gapStuck bool) []uuid.UUID {
 	var agg, top uint64


### PR DESCRIPTION
When the no-skip reorder frontier HoL-stalls on a missing sequence, delivery is blocked so nearly every active leg reads as making no recv progress. In **adaptive mode** the fast data-progress prune then **removed all of them at once**, orphaning the in-flight sequences the sender had already stripe-assigned. The sender's SACK/TLP retransmits of those seqs then landed on routes whose rules were just torn down (`Dropped transport frame for stale route`), so the gap could **never** fill — a transient HoL stall became a **permanent wedge**: the measured N-leg → 1-leg collapse that stalls at 0 B/s and takes the whole session down (app-restart loop) under sustained download.

Park instead of remove whenever removal would orphan in-flight: manual/static-mux (already did) **and now any time the frontier is stuck** (`gapStuck`). A parked leg still RECEIVES, so its in-flight drains and retransmits keep landing, and the active-download floor re-promotes it once the gap clears. Removal + self-heal-redial is kept only for a genuine black-hole caught while the frontier is HEALTHY. Decision factored into `parkStalledLegs`, unit-tested; router suite passes.

Diagnosed live over a fleet exit (TLP/RACK/SACK all firing correctly — the failure was legs being torn out from under the retransmits, not a recovery bug).