### PR TITLE
fix(appnet): back off serveRouteGroup on repeated accept failures (stop CPU spin)

### DIFF
--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -567,6 +567,18 @@ func (r *SkywireNetworker) ListenContext(ctx context.Context, addr Addr) (net.Li
 func (r *SkywireNetworker) serveRouteGroup(ctx context.Context) error {
 	log := r.log.WithField("func", "serveRouteGroup")
 
+	// Exponential backoff between successive non-fatal accept failures, reset on
+	// success. AcceptRoutes returns as soon as the setup node delivers an inbound
+	// route-setup; when those arrive back-to-back and each fails the noise
+	// handshake (a stale route, or a peer only reachable over a flaky webrtc/swtr
+	// transport — the common case on a NAT'd browser wasm visor), the old bare
+	// `continue` spun this loop with no pause, pegging the single-threaded wasm
+	// runtime's scheduler (observed on the in-tab visor: bursts of findRunnable/
+	// checkTimers churn while route-setups churned against a slow route finder).
+	// Same proven pattern as net/http.Server.Serve's Accept-error backoff.
+	const backoffMin, backoffMax = 5 * time.Millisecond, time.Second
+	backoff := time.Duration(0)
+
 	for {
 		log.Debug("Awaiting to accept route group...")
 
@@ -578,10 +590,22 @@ func (r *SkywireNetworker) serveRouteGroup(ctx context.Context) error {
 				return err
 			}
 			// Non-fatal error (e.g., missing transport for a stale route).
-			// Log and continue accepting — don't kill the accept loop.
-			log.WithError(err).Warn("Failed to accept route group, continuing...")
+			// Log and continue accepting — don't kill the accept loop — but back
+			// off so a persistently-failing stream of accepts can't busy-spin.
+			if backoff == 0 {
+				backoff = backoffMin
+			} else if backoff *= 2; backoff > backoffMax {
+				backoff = backoffMax
+			}
+			log.WithError(err).Warnf("Failed to accept route group, retrying in %v...", backoff)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
 			continue
 		}
+		backoff = 0
 
 		log.
 			WithField("local", conn.LocalAddr()).


### PR DESCRIPTION
`serveRouteGroup`'s non-fatal accept-error path did a bare `continue` with no pause. `AcceptRoutes` returns as soon as the setup node delivers an inbound route-setup, so when those arrive back-to-back and each fails the noise handshake — a stale route, or an initiator only reachable over a flaky webrtc/swtr transport (common on a NAT'd browser wasm visor) — the loop busy-spins.

Confirmed on the in-tab wasm visor via CDP CPU profile: bursts of Go scheduler churn (`findRunnable`/`stealWork`/`checkTimersNoP`) with the route-group accept/serve path + noise handshakes (secp256k1) active, while it churned route-setups against a slow route finder (24 transports / 206 goroutines / num_gc 4313).

Adds net/http.Server.Serve-style exponential backoff (5ms→1s) between successive non-fatal accept failures, reset on success, ctx-cancellable. Happy path unchanged (backoff 0 while accepts succeed) so healthy visors are unaffected. Shared code — native visors get it on develop-latest; the browser wasm visor needs a wasm-blob rebuild to pick it up.