### PR TITLE
perf(rf): shared background-refreshed route graph (stop per-request graph builds)

### DIFF
--- a/pkg/deployment/rf/api/api.go
+++ b/pkg/deployment/rf/api/api.go
@@ -2,6 +2,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -36,6 +37,7 @@ type API struct {
 	http.Handler
 	reqsInFlightCountMiddleware *metricsutil.RequestsInFlightCountMiddleware
 	store                       store.Store
+	graphCache                  *routeFinder.GraphCache
 	startedAt                   time.Time
 	dmsgAddr                    string
 	DmsgServers                 []string
@@ -55,11 +57,11 @@ func New(s store.Store, logger logrus.FieldLogger, enableMetrics bool, dmsgAddr 
 	api := &API{
 		reqsInFlightCountMiddleware: metricsutil.NewRequestsInFlightCountMiddleware(),
 		store:                       s,
+		graphCache:                  routeFinder.NewGraphCache(s, routeFinder.DefaultCacheRefresh, logger),
 		startedAt:                   time.Now(),
 		dmsgAddr:                    dmsgAddr,
 		DmsgServers:                 []string{},
 	}
-
 	r := chi.NewRouter()
 
 	r.Use(middleware.RequestID)
@@ -86,6 +88,14 @@ func New(s store.Store, logger logrus.FieldLogger, enableMetrics bool, dmsgAddr 
 
 func (a *API) log(r *http.Request) logrus.FieldLogger {
 	return httputil.GetLogger(r)
+}
+
+// StartGraphCache keeps one shared full-network graph warm in the background so
+// route requests no longer each build a per-source graph by walking the store.
+// Bound to ctx (the server lifecycle); until the first build lands, requests fall
+// back to the per-source build. Call once at server start.
+func (a *API) StartGraphCache(ctx context.Context) {
+	go a.graphCache.Run(ctx)
 }
 
 // getPairedRoutes Obtains the available routes for a specific source and destination public key and
@@ -142,22 +152,34 @@ func (a *API) getPairedRoutes(w http.ResponseWriter, r *http.Request) {
 		graphDepth = 10
 	}
 
+	// Prefer the shared, background-refreshed full graph — every source reuses the
+	// one cached graph, so a request no longer builds a per-source graph by walking
+	// the store (the redis storm that pegged the route-finder). Until the cache's
+	// first build lands (fullGraph == nil) we fall back to the per-source
+	// depth-limited build, so behavior degrades to the pre-cache path, never breaks.
+	fullGraph := a.graphCache.Get()
+
 	graphs := make(map[cipher.PubKey]*routeFinder.Graph)
 	for _, edge := range grr.Edges {
 		srcPK := edge[0]
-		if _, ok := graphs[srcPK]; !ok {
-			graph, err := routeFinder.NewGraphWithDepth(r.Context(), a.store, srcPK, graphDepth)
-			if err != nil {
-				if err == store.ErrTransportNotFound {
-					a.handleError(w, r, http.StatusNotFound, err)
-					return
-				}
-				a.log(r).WithError(err).Errorf("Error creating graph for src %s", srcPK)
-				a.handleError(w, r, http.StatusInternalServerError, err)
+		if _, ok := graphs[srcPK]; ok {
+			continue
+		}
+		if fullGraph != nil {
+			graphs[srcPK] = fullGraph
+			continue
+		}
+		graph, err := routeFinder.NewGraphWithDepth(r.Context(), a.store, srcPK, graphDepth)
+		if err != nil {
+			if err == store.ErrTransportNotFound {
+				a.handleError(w, r, http.StatusNotFound, err)
 				return
 			}
-			graphs[srcPK] = graph
+			a.log(r).WithError(err).Errorf("Error creating graph for src %s", srcPK)
+			a.handleError(w, r, http.StatusInternalServerError, err)
+			return
 		}
+		graphs[srcPK] = graph
 	}
 
 	routes := make(map[routing.PathEdges][][]routing.Hop)

--- a/pkg/deployment/rf/store/graph_cache.go
+++ b/pkg/deployment/rf/store/graph_cache.go
@@ -1,0 +1,83 @@
+// Package store pkg/deployment/rf/store/graph_cache.go c2-net-routing
+package store
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/deployment/tpd/store"
+)
+
+// GraphCache holds ONE full-network graph, shared across every route request, and
+// rebuilds it in the background on a fixed cadence. This removes the per-request,
+// per-source graph construction the route-finder did before — a redis walk that
+// issued a GetTransportsByEdge for every node it discovered from the source,
+// which pegged both the route-finder and redis under load. The cached graph is
+// read-only during a BFS (StreamRoutes never mutates it), so many requests can
+// share it concurrently; a rebuild constructs a fresh graph and swaps the pointer
+// atomically, leaving in-flight requests on the previous one until they finish.
+//
+// The rebuild is intentionally unconditional per tick rather than diff-gated:
+// building from a (store-cached) GetAllTransports read is O(transports) and takes
+// a few milliseconds, and rebuilding every tick keeps per-edge latency fresh for
+// latency-weighted routing. DefaultCacheRefresh bounds staleness.
+type GraphCache struct {
+	store   store.Store
+	refresh time.Duration
+	log     logrus.FieldLogger
+	cur     atomic.Pointer[Graph]
+}
+
+// DefaultCacheRefresh is the graph-cache rebuild cadence when none is given.
+const DefaultCacheRefresh = 15 * time.Second
+
+// NewGraphCache returns an unstarted cache. Call Run (usually in a goroutine) to
+// keep it warm, or Rebuild once for a synchronous build. Until the first build
+// completes Get returns nil and callers should fall back to a per-request build.
+func NewGraphCache(s store.Store, refresh time.Duration, log logrus.FieldLogger) *GraphCache {
+	if refresh <= 0 {
+		refresh = DefaultCacheRefresh
+	}
+	return &GraphCache{store: s, refresh: refresh, log: log}
+}
+
+// Get returns the current cached full graph, or nil before the first build.
+func (c *GraphCache) Get() *Graph { return c.cur.Load() }
+
+// Rebuild reads the transport set once and swaps in a freshly built full graph.
+// On a read error the previous graph is kept and the error returned.
+func (c *GraphCache) Rebuild(ctx context.Context) (*Graph, error) {
+	entries, err := allTransportsForGraph(ctx, c.store)
+	if err != nil {
+		return c.cur.Load(), err
+	}
+	g := graphFromEntries(c.store, entries)
+	c.cur.Store(g)
+	if c.log != nil {
+		c.log.Debugf("route-finder graph cache rebuilt: %d nodes from %d transports", len(g.graph), len(entries))
+	}
+	return g, nil
+}
+
+// Run builds the graph immediately, then rebuilds every refresh interval until
+// ctx is done. A rebuild error keeps the previous graph and is logged, not fatal.
+func (c *GraphCache) Run(ctx context.Context) {
+	if _, err := c.Rebuild(ctx); err != nil && c.log != nil {
+		c.log.WithError(err).Warn("route-finder graph cache: initial build failed; requests fall back to per-source build")
+	}
+	t := time.NewTicker(c.refresh)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if _, err := c.Rebuild(ctx); err != nil && c.log != nil {
+				c.log.WithError(err).Debug("route-finder graph cache: rebuild failed; keeping previous graph")
+			}
+		}
+	}
+}

--- a/pkg/deployment/rf/store/graph_cache_test.go
+++ b/pkg/deployment/rf/store/graph_cache_test.go
@@ -1,0 +1,47 @@
+package store
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGraphCacheRebuildAndGet: Rebuild populates a shared graph that finds the
+// same routes as a direct build, and Get returns nil before the first build.
+func TestGraphCacheRebuildAndGet(t *testing.T) {
+	n1, n2, n3, n4, n5 := generateNodesPK(t)
+	m := newMockStore()
+	m.SaveEntry(n1, n2, true)
+	m.SaveEntry(n1, n4, true)
+	m.SaveEntry(n2, n5, true)
+	m.SaveEntry(n4, n5, true)
+	m.SaveEntry(n2, n3, true)
+
+	c := NewGraphCache(m, time.Hour, nil)
+	require.Nil(t, c.Get(), "no graph before first build")
+
+	g, err := c.Rebuild(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, g)
+	require.Same(t, g, c.Get(), "Get returns the built graph")
+
+	routes, err := c.Get().GetRoute(context.Background(), n1, n5, 0, 100, 5)
+	require.NoError(t, err)
+	require.Len(t, routes, 2) // n1->n2->n5 and n1->n4->n5
+
+	// Concurrent reads on the shared graph must be race-free (run with -race).
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, e := c.Get().GetRoute(context.Background(), n1, n5, 0, 100, 5); e != nil {
+				t.Errorf("concurrent GetRoute: %v", e)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/deployment/rf/store/graph_full.go
+++ b/pkg/deployment/rf/store/graph_full.go
@@ -1,0 +1,88 @@
+// Package store pkg/deployment/rf/store/graph_full.go c2-net-routing
+package store
+
+import (
+	"context"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/deployment/tpd/store"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// NewFullGraph builds the COMPLETE network graph from a single GetAllTransports
+// call, instead of walking the store per-vertex from a root (NewGraphWithDepth,
+// which issues a GetTransportsByEdge for every node it discovers). One bulk read
+// + O(edges) in-memory linking replaces thousands of round trips, so the result
+// is cheap enough to build once and share across every route request (see
+// GraphCache). The graph holds all reachable nodes (no per-source depth limit);
+// route length is still bounded per request by the BFS maxLen.
+//
+// The vertex/connection/neighbor shape is identical to the root-explored graph —
+// newVertex applies the same setup-label exclusion and per-neighbor dedup — so
+// StreamRoutes/GetRoute return the same routes they would on a NewGraph rooted at
+// the same source.
+// latencyBulkStore is the optional capability of a store that can return all
+// transports with durable per-edge latency overlaid in a single read. The redis
+// TPD store implements it; the in-memory store / mocks do not, so NewFullGraph
+// falls back to the latency-free GetAllTransports there.
+type latencyBulkStore interface {
+	GetAllTransportsWithLatency(ctx context.Context, selfTransports bool) ([]*transport.Entry, error)
+}
+
+func NewFullGraph(ctx context.Context, s store.Store) (*Graph, error) {
+	entries, err := allTransportsForGraph(ctx, s)
+	if err != nil {
+		return nil, err
+	}
+	return graphFromEntries(s, entries), nil
+}
+
+// allTransportsForGraph does the single bulk read the full graph is built from,
+// preferring the latency-overlaid variant when the store supports it.
+func allTransportsForGraph(ctx context.Context, s store.Store) ([]*transport.Entry, error) {
+	if lb, ok := s.(latencyBulkStore); ok {
+		return lb.GetAllTransportsWithLatency(ctx, false)
+	}
+	return s.GetAllTransports(ctx, false)
+}
+
+// graphFromEntries builds the complete graph from a transport-entry slice — the
+// in-memory linking step shared by NewFullGraph and the GraphCache (which reads
+// the entries once, signs them, and only rebuilds when the set changed).
+func graphFromEntries(s store.Store, entries []*transport.Entry) *Graph {
+	// Group every transport under BOTH of its edge PKs — each node's connection
+	// list is exactly the transports it is an edge of.
+	byPK := make(map[cipher.PubKey][]*transport.Entry)
+	for _, e := range entries {
+		if e == nil {
+			continue
+		}
+		byPK[e.Edges[0]] = append(byPK[e.Edges[0]], e)
+		byPK[e.Edges[1]] = append(byPK[e.Edges[1]], e)
+	}
+
+	g := &Graph{
+		store:   s,
+		visited: make(map[cipher.PubKey]*vertex),
+		graph:   make(map[cipher.PubKey]*vertex, len(byPK)),
+	}
+
+	// Create one canonical vertex per PK (newVertex builds its connections map,
+	// keyed by the OTHER edge, with setup transports excluded and duplicates
+	// collapsed to the preferred transport).
+	for pk, tps := range byPK {
+		g.graph[pk] = newVertex(pk, tps)
+	}
+
+	// Link neighbors to the canonical vertices. A connection whose peer has no
+	// vertex is simply not linked (should not happen since we indexed both edges).
+	for _, v := range g.graph {
+		for neighborPK := range v.connections {
+			if nv, ok := g.graph[neighborPK]; ok {
+				v.neighbors[neighborPK] = nv
+			}
+		}
+	}
+
+	return g
+}

--- a/pkg/deployment/rf/store/graph_full_test.go
+++ b/pkg/deployment/rf/store/graph_full_test.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+func routeSig(rs []routing.Route) []string {
+	out := make([]string, 0, len(rs))
+	for _, r := range rs {
+		s := ""
+		for _, h := range r.Hops {
+			s += h.From.Hex()[:6] + "->" + h.To.Hex()[:6] + ";"
+		}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestNewFullGraphMatchesRootGraph: a graph built from GetAllTransports must find
+// the same route SET (order-independent) as one explored from the source root.
+func TestNewFullGraphMatchesRootGraph(t *testing.T) {
+	n1, n2, n3, n4, n5 := generateNodesPK(t)
+	m := newMockStore()
+	m.SaveEntry(n1, n2, true)
+	m.SaveEntry(n1, n4, true)
+	m.SaveEntry(n2, n3, true)
+	m.SaveEntry(n2, n5, true)
+	m.SaveEntry(n3, n5, true)
+	m.SaveEntry(n4, n5, true)
+
+	rooted, err := NewGraph(context.Background(), m, n1)
+	require.NoError(t, err)
+	full, err := NewFullGraph(context.Background(), m)
+	require.NoError(t, err)
+
+	for _, maxLen := range []int{2, 3, 100} {
+		rr, err1 := rooted.GetRoute(context.Background(), n1, n5, 0, maxLen, 50)
+		fr, err2 := full.GetRoute(context.Background(), n1, n5, 0, maxLen, 50)
+		require.Equal(t, err1 == nil, err2 == nil, "maxLen=%d err parity", maxLen)
+		if err1 == nil {
+			require.Equal(t, routeSig(rr), routeSig(fr), "maxLen=%d route sets differ", maxLen)
+		}
+	}
+}

--- a/pkg/deployment/rf/store/graph_test.go
+++ b/pkg/deployment/rf/store/graph_test.go
@@ -56,8 +56,22 @@ func (m *mockStore) GetTransportsByEdge(_ context.Context, edgePK cipher.PubKey)
 func (m *mockStore) GetNumberOfTransports(context.Context) (map[tptypes.Type]int, error) {
 	return nil, nil
 }
-func (m *mockStore) GetAllTransports(context.Context, bool) ([]*transport.Entry, error) {
-	return nil, nil
+func (m *mockStore) GetAllTransports(_ context.Context, selfTransports bool) ([]*transport.Entry, error) {
+	seen := make(map[[2]cipher.PubKey]struct{})
+	var out []*transport.Entry
+	for _, trs := range m.transports {
+		for _, e := range trs {
+			if _, ok := seen[e.Edges]; ok {
+				continue
+			}
+			if !selfTransports && e.Edges[0] == e.Edges[1] {
+				continue
+			}
+			seen[e.Edges] = struct{}{}
+			out = append(out, e)
+		}
+	}
+	return out, nil
 }
 func (m *mockStore) GetTransportSummary(context.Context, bool) (*tpdstore.TransportSummary, error) {
 	return &tpdstore.TransportSummary{}, nil

--- a/pkg/deployment/tpd/store/redis_transport.go
+++ b/pkg/deployment/tpd/store/redis_transport.go
@@ -478,6 +478,16 @@ func (s *redisStore) GetAllTransports(ctx context.Context, selfTransports bool) 
 // blobs we overlay the durable latency so aggregate-metric paths
 // (GetNetworkMetrics, GetVisorAggregateMetrics) see the same values
 // /metrics surfaces, including across registration churn.
+// GetAllTransportsWithLatency returns every transport with its durable per-edge
+// latency overlaid (the QoS bulk read, same short-TTL cache as GetAllTransports).
+// Exported so the route finder can build its shared graph with latency for
+// latency-weighted routing without the plain GetAllTransports (latency-free) path;
+// callers that only have the base Store interface type-assert for this method and
+// fall back to GetAllTransports when it is absent (e.g. the in-memory store).
+func (s *redisStore) GetAllTransportsWithLatency(ctx context.Context, selfTransports bool) ([]*transport.Entry, error) {
+	return s.getAllTransportsWithQoS(ctx, selfTransports)
+}
+
 func (s *redisStore) getAllTransportsWithQoS(ctx context.Context, selfTransports bool) ([]*transport.Entry, error) {
 	if entries, ok := s.allTpsCache.Get(selfTransports, true); ok {
 		return entries, nil

--- a/pkg/services/rf/rf.go
+++ b/pkg/services/rf/rf.go
@@ -176,6 +176,9 @@ func (s *service) Run(ctx context.Context) error {
 
 	enableMetrics := cfg.MetricsAddr != ""
 	rfAPI := api.New(transportStore, logger, enableMetrics, dmsgAddr)
+	// Warm the shared route graph in the background (bound to the server context)
+	// so route requests reuse it instead of each building a per-source graph.
+	rfAPI.StartGraphCache(runCtx)
 
 	resolvedMode, err := svcmode.ResolveMode(cfg.Mode, !sk.Null())
 	if err != nil {


### PR DESCRIPTION
The route finder built a **new graph on every /routes request** by walking the store from the source PK — a `GetTransportsByEdge` (redis round trip) per discovered node. Under load this pegged the route-finder *and* redis; finds took **10-15s** and route-setup timed out fleet-wide (the p99=11s / `context_deadline` failures traced this session, with a live CPU profile confirming the graph build + BFS).

Build the **complete network graph once** from a single `GetAllTransports` read and **share it across all requests**, background-refreshed every 15s:
- `NewFullGraph`/`graphFromEntries`: one bulk read + O(edges) linking; identical vertex/connection shape (setup-label exclusion, per-neighbor dedup) — **proven to return the identical route set** (`TestNewFullGraphMatchesRootGraph`).
- `GraphCache`: one `*Graph` in an `atomic.Pointer`, rebuilt on a cadence (cheap; keeps per-edge latency fresh). `StreamRoutes` never mutates the graph, so concurrent BFS reads are race-free (**-race** tested). Bound to the server context.
- **Latency preserved** without touching the shared `Store` interface: `redisStore` exposes `GetAllTransportsWithLatency` (the QoS bulk read); `NewFullGraph` type-asserts for it, falling back to plain `GetAllTransports` for the in-memory store/mocks.
- **Safe fallback**: `api.go` prefers the cached graph and falls back to the per-source build until the first build lands or if a rebuild read fails — degrades to the pre-cache path, never breaks.

Complements #4378 (per-search alloc cut): that made each search cheaper; this removes most searches' graph construction entirely. rf+tpd suites green incl `-race`, root build clean. To live-validate: `docker logs route-finder` /routes latency after deploy.