### PR TITLE
fix(router): build local-route lookups once per CXO snapshot, not per dial

### DIFF
--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -349,6 +349,32 @@ func (m *Manager) Get(feed Feed, path string) ([]byte, time.Time, bool) {
 	return out, f.lastSyncAt, true
 }
 
+// SyncedAt returns the timestamp of the most recent successful sync for
+// (feed, path), or ok=false if the feed has no snapshot for that path.
+// Unlike Get it copies no body — it exists so a caller can cheaply key a
+// derived cache on the CXO snapshot's freshness and rebuild only when the
+// timestamp advances, instead of on an independent wall-clock timer.
+func (m *Manager) SyncedAt(feed Feed, path string) (time.Time, bool) {
+	if m == nil {
+		return time.Time{}, false
+	}
+	m.mu.Lock()
+	f, ok := m.feeds[feed]
+	m.mu.Unlock()
+	if !ok || f == nil {
+		return time.Time{}, false
+	}
+	f.snapMu.RLock()
+	defer f.snapMu.RUnlock()
+	if f.snapshot == nil {
+		return time.Time{}, false
+	}
+	if body, ok := f.snapshot[path]; !ok || len(body) == 0 {
+		return time.Time{}, false
+	}
+	return f.lastSyncAt, true
+}
+
 // Walk invokes fn for every (path, body) in the feed's cached
 // snapshot whose path begins with prefix. Returns ok=false (with fn
 // never called) if the feed has no snapshot. Bodies passed to fn

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -1731,7 +1731,7 @@ func (r *router) buildHopLookups(ctx context.Context, fwd, rev [][]routing.Hop) 
 	// so the same data costs one round-trip per TTL instead of one
 	// per hop per dial.
 	if len(misses) > 0 && r.tm != nil && r.tm.Conf != nil && r.tm.Conf.DiscoveryClient != nil && r.tpdCache != nil {
-		snap, err := r.tpdCache.snapshot(ctx, r.tm.Conf.DiscoveryClient.GetAllTransports)
+		snap, err := r.tpdCache.snapshot(ctx, r.tm.Conf.DiscoveryClient.GetAllTransports, versionProbe(r.tm.Conf.DiscoveryClient))
 		if err != nil {
 			// snap is non-nil when a prior snapshot was served stale;
 			// only a cold-cache failure yields nil. Either way, log
@@ -2027,9 +2027,23 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 	// replaces N individual GetTransportsByEdge calls with one bulk
 	// fetch AND amortizes that fetch across dials so repeated local
 	// route calculations don't re-pull the whole dataset each time.
-	var allEntries []*transport.Entry
+	// The by-edge and per-TpID metric lookups are derived ONCE per TPD
+	// snapshot (see tpdSnapshot.deriveTransportLookups) rather than rebuilt
+	// from the whole ~16k-entry set on every call. On a NAT'd visor with no
+	// direct transport to dst the early-return above is skipped, so a browse
+	// dial retry loop used to pay four full-dataset map builds + a per-edge
+	// sort per call — enough to peg the single js/wasm thread in GC. When
+	// there is no cache (tpdCache == nil, tests / bare router) we derive the
+	// same lookups locally from a direct fetch.
+	var (
+		allEntries       []*transport.Entry
+		transportsByEdge map[cipher.PubKey][]*transport.Entry
+		tpLatencyMs      map[uuid.UUID]float64
+		tpTypeOf         map[uuid.UUID]string
+		tpThroughput     map[uuid.UUID]float64
+	)
 	if r.tpdCache != nil {
-		snap, serr := r.tpdCache.snapshot(ctx, dc.GetAllTransports)
+		snap, serr := r.tpdCache.snapshot(ctx, dc.GetAllTransports, versionProbe(dc))
 		if snap == nil {
 			// Cold-cache failure only — a stale snapshot would be
 			// returned non-nil. Nothing to compute routes from.
@@ -2037,36 +2051,17 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 			return nil, nil, fmt.Errorf("failed to fetch transport discovery data: %w", serr)
 		}
 		allEntries = snap.entries
+		transportsByEdge = snap.byEdge
+		tpLatencyMs = snap.latencyByID
+		tpTypeOf = snap.typeByID
+		tpThroughput = snap.throughputByID
 	} else {
 		allEntries, err = dc.GetAllTransports(ctx)
 		if err != nil {
 			log.WithError(err).Warn("Failed to fetch all transports for route calculation")
 			return nil, nil, fmt.Errorf("failed to fetch transport discovery data: %w", err)
 		}
-	}
-
-	// Build lookup map: pubkey -> transports involving that pubkey.
-	// Exclude "setup" labeled transports (RSN control-plane only).
-	transportsByEdge := make(map[cipher.PubKey][]*transport.Entry)
-	for _, entry := range allEntries {
-		if entry == nil {
-			continue
-		}
-		if entry.Label == transport.LabelSetup {
-			continue
-		}
-		for _, edge := range entry.Edges {
-			transportsByEdge[edge] = append(transportsByEdge[edge], entry)
-		}
-	}
-	// Sort each edge's transport list by type preference so iteration tries
-	// direct types before DMSG when picking an intermediate-to-dst hop.
-	for edge := range transportsByEdge {
-		entries := transportsByEdge[edge]
-		sort.SliceStable(entries, func(i, j int) bool {
-			return tptypes.TypePreference(entries[i].Type) <
-				tptypes.TypePreference(entries[j].Type)
-		})
+		transportsByEdge, tpLatencyMs, tpTypeOf, tpThroughput = deriveTransportLookups(allEntries)
 	}
 	log.Debugf("Built transport cache with %d entries covering %d visors", len(allEntries), len(transportsByEdge))
 
@@ -2214,32 +2209,12 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 	// once and the BFS stays linear in graph size.
 	expandedAtDepth := make(map[cipher.PubKey]map[int]bool)
 
-	// Per-TpID latency lookup over the entries we just fetched —
-	// hydrated by the CXO telemetry aggregator on TPD's side. Used to
+	// Per-TpID latency / type / throughput lookups (hydrated by the CXO
+	// telemetry aggregator on TPD's side) come prebuilt from the snapshot
+	// alongside transportsByEdge — see the derive comment above. Used to
 	// rank multiple same-level dst-hits below.
-	tpLatencyMs := make(map[uuid.UUID]float64)
-	for _, entry := range allEntries {
-		if entry == nil {
-			continue
-		}
-		if entry.Latency > 0 {
-			tpLatencyMs[entry.ID] = entry.Latency
-		}
-	}
 	localLatencyFor := func(id uuid.UUID) float64 { return tpLatencyMs[id] }
-	tpTypeOf := make(map[uuid.UUID]string)
-	for _, entry := range allEntries {
-		if entry != nil {
-			tpTypeOf[entry.ID] = string(entry.Type)
-		}
-	}
 	localTypeFor := func(id uuid.UUID) string { return tpTypeOf[id] }
-	tpThroughput := make(map[uuid.UUID]float64)
-	for _, entry := range allEntries {
-		if entry != nil && entry.ThroughputBps > 0 {
-			tpThroughput[entry.ID] = entry.ThroughputBps
-		}
-	}
 	localThroughputFor := func(id uuid.UUID) float64 { return tpThroughput[id] }
 
 	queue := seed

--- a/pkg/router/tpd_cache.go
+++ b/pkg/router/tpd_cache.go
@@ -36,12 +36,15 @@ package router
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 )
 
 // defaultTPDSnapshotTTL is how long a GetAllTransports snapshot is
@@ -62,10 +65,97 @@ type tpdSnapshotCache struct {
 }
 
 // tpdSnapshot is one immutable view of the transport-discovery set.
+//
+// byEdge / latencyByID / typeByID / throughputByID are derived lookups
+// materialized ONCE per snapshot refresh. calculateLocalRoutes used to
+// rebuild all four from the ~16k-entry set on every call; on a NAT'd
+// visor with no direct transport to the destination (e.g. the in-browser
+// wasm visor) that early-return is skipped, so every browse dial paid
+// four full-dataset map builds + a per-edge sort. Under a route-setup
+// retry loop that pegged the single js/wasm thread in mallocgc/GC. These
+// are immutable once built, so serving them from the snapshot is
+// identical output at a fraction of the allocation.
 type tpdSnapshot struct {
 	entries []*transport.Entry
 	byID    map[uuid.UUID]*transport.Entry
+	// byEdge maps a pubkey to the (non-setup) transports touching it,
+	// each edge list sorted by type preference (direct types before DMSG).
+	byEdge map[cipher.PubKey][]*transport.Entry
+	// per-TpID metrics, hydrated by TPD's CXO telemetry aggregator.
+	latencyByID    map[uuid.UUID]float64
+	typeByID       map[uuid.UUID]string
+	throughputByID map[uuid.UUID]float64
+	// version is the CXO snapshot timestamp this snapshot was built from
+	// (zero when built off the wall-clock TTL path, e.g. a non-CXO
+	// discovery client). When set, the cache reuses this snapshot until
+	// the source reports a newer timestamp — CXO-cadence invalidation
+	// rather than an independent timer.
+	version time.Time
+	// expires is the wall-clock TTL floor, always set. It governs the
+	// non-CXO path and bounds staleness if the version probe later stops
+	// answering (CXO feed dropped) so the cache can't pin forever.
 	expires time.Time
+}
+
+// tpdVersioner is implemented by a discovery client whose GetAllTransports
+// snapshot is backed by the visor's event-driven CXO subscription and can
+// report when that snapshot last advanced. When the client implements it,
+// the cache invalidates on the reported timestamp (CXO's own sync cadence)
+// instead of a separate 5-minute wall clock that can drift out of phase
+// with it; clients that don't (plain HTTP, tests) keep the TTL.
+type tpdVersioner interface {
+	AllTransportsSyncedAt() (time.Time, bool)
+}
+
+// versionProbe returns dc's CXO-snapshot-timestamp probe, or nil when dc
+// can't report one (so the caller falls back to the TTL).
+func versionProbe(dc interface{}) func() (time.Time, bool) {
+	if v, ok := dc.(tpdVersioner); ok {
+		return v.AllTransportsSyncedAt
+	}
+	return nil
+}
+
+// deriveTransportLookups materializes the by-edge and per-TpID metric
+// maps used by local route calculation. Setup-labeled transports are
+// excluded from byEdge (RSN control-plane only); each edge list is
+// sorted by type preference so callers try direct types before DMSG.
+func deriveTransportLookups(entries []*transport.Entry) (
+	byEdge map[cipher.PubKey][]*transport.Entry,
+	latencyByID map[uuid.UUID]float64,
+	typeByID map[uuid.UUID]string,
+	throughputByID map[uuid.UUID]float64,
+) {
+	byEdge = make(map[cipher.PubKey][]*transport.Entry)
+	latencyByID = make(map[uuid.UUID]float64)
+	typeByID = make(map[uuid.UUID]string, len(entries))
+	throughputByID = make(map[uuid.UUID]float64)
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		typeByID[entry.ID] = string(entry.Type)
+		if entry.Latency > 0 {
+			latencyByID[entry.ID] = entry.Latency
+		}
+		if entry.ThroughputBps > 0 {
+			throughputByID[entry.ID] = entry.ThroughputBps
+		}
+		if entry.Label == transport.LabelSetup {
+			continue
+		}
+		for _, edge := range entry.Edges {
+			byEdge[edge] = append(byEdge[edge], entry)
+		}
+	}
+	for edge := range byEdge {
+		es := byEdge[edge]
+		sort.SliceStable(es, func(i, j int) bool {
+			return tptypes.TypePreference(es[i].Type) <
+				tptypes.TypePreference(es[j].Type)
+		})
+	}
+	return byEdge, latencyByID, typeByID, throughputByID
 }
 
 // newTPDSnapshotCache returns an empty cache with the default TTL.
@@ -86,18 +176,86 @@ func (c *tpdSnapshotCache) fresh() *tpdSnapshot {
 	return nil
 }
 
-// snapshot returns a fresh transport-discovery snapshot, fetching a
-// new one via fetchAll only when the cache is empty or expired. On a
-// fetch error the previous snapshot is returned stale (with the error)
-// so callers can choose to proceed on slightly-old data rather than
-// fail the dial; only when there is no prior snapshot at all does it
-// return (nil, err).
+// buildSnapshot materializes a snapshot (and its derived lookups) from a
+// freshly-fetched entry set, stamping it with the CXO version (zero on the
+// TTL path) and always setting the wall-clock TTL floor.
+func (c *tpdSnapshotCache) buildSnapshot(entries []*transport.Entry, version time.Time) *tpdSnapshot {
+	byID := make(map[uuid.UUID]*transport.Entry, len(entries))
+	for _, e := range entries {
+		if e != nil {
+			byID[e.ID] = e
+		}
+	}
+	byEdge, latencyByID, typeByID, throughputByID := deriveTransportLookups(entries)
+	return &tpdSnapshot{
+		entries:        entries,
+		byID:           byID,
+		byEdge:         byEdge,
+		latencyByID:    latencyByID,
+		typeByID:       typeByID,
+		throughputByID: throughputByID,
+		version:        version,
+		expires:        c.clock().Add(c.ttl),
+	}
+}
+
+// snapshot returns a fresh transport-discovery snapshot, fetching a new
+// one via fetchAll only when necessary. On a fetch error the previous
+// snapshot is returned stale (with the error) so callers can proceed on
+// slightly-old data rather than fail the dial; only when there is no prior
+// snapshot at all does it return (nil, err).
+//
+// When version is non-nil and reports ok, the cache is CXO-driven: it
+// serves the cached snapshot as long as the reported timestamp is
+// unchanged and refetches exactly when it advances — no wall-clock
+// refresh, so route data tracks the visor's CXO sync cadence rather than
+// an independent 5-minute clock. When version is nil or reports !ok
+// (non-CXO client, or the feed isn't primed yet) it falls back to the TTL.
 //
 // fetchAll is typically DiscoveryClient.GetAllTransports.
 func (c *tpdSnapshotCache) snapshot(
 	ctx context.Context,
 	fetchAll func(context.Context) ([]*transport.Entry, error),
+	version func() (time.Time, bool),
 ) (*tpdSnapshot, error) {
+	// CXO-driven path: serve until the source's snapshot timestamp moves
+	// — but keep the TTL as a liveness floor. The CXO transport feed is
+	// refcount-gated (TabCloseGrace ~10s): once route-calc stops holding
+	// it the sync cycle stops and lastSyncAt FREEZES (the snapshot is not
+	// cleared). Cache hits here deliberately don't re-acquire the feed, so
+	// without the floor a stable-but-frozen version would pin this cache
+	// to an old snapshot forever and transports would never refresh. The
+	// floor forces a refetch every TTL even when the version hasn't moved;
+	// that refetch goes through GetAllTransports, which re-acquires the
+	// feed (restarting its cycle) and picks up anything new. So: refresh
+	// immediately when CXO advances, and at worst once per TTL when CXO is
+	// idle — never per call.
+	if version != nil {
+		if ts, ok := version(); ok {
+			c.mu.RLock()
+			cur := c.snap
+			c.mu.RUnlock()
+			if cur != nil && !cur.version.IsZero() && cur.version.Equal(ts) && c.clock().Before(cur.expires) {
+				return cur, nil
+			}
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			if c.snap != nil && !c.snap.version.IsZero() && c.snap.version.Equal(ts) && c.clock().Before(c.snap.expires) {
+				return c.snap, nil
+			}
+			entries, err := fetchAll(ctx)
+			if err != nil {
+				if c.snap != nil {
+					return c.snap, err
+				}
+				return nil, err
+			}
+			c.snap = c.buildSnapshot(entries, ts)
+			return c.snap, nil
+		}
+	}
+
+	// TTL fallback (non-CXO client, or CXO feed not primed yet).
 	if s := c.fresh(); s != nil {
 		return s, nil
 	}
@@ -120,16 +278,6 @@ func (c *tpdSnapshotCache) snapshot(
 		return nil, err
 	}
 
-	byID := make(map[uuid.UUID]*transport.Entry, len(entries))
-	for _, e := range entries {
-		if e != nil {
-			byID[e.ID] = e
-		}
-	}
-	c.snap = &tpdSnapshot{
-		entries: entries,
-		byID:    byID,
-		expires: c.clock().Add(c.ttl),
-	}
+	c.snap = c.buildSnapshot(entries, time.Time{})
 	return c.snap, nil
 }

--- a/pkg/router/tpd_cache_test.go
+++ b/pkg/router/tpd_cache_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 )
 
 // fakeClock is a controllable time source for deterministic TTL tests.
@@ -63,7 +65,7 @@ func TestTPDSnapshotCache_ReusesWithinTTL(t *testing.T) {
 	}
 
 	for i := 0; i < 20; i++ {
-		snap, err := c.snapshot(context.Background(), fetch)
+		snap, err := c.snapshot(context.Background(), fetch, nil)
 		require.NoError(t, err)
 		require.NotNil(t, snap)
 		assert.Equal(t, 12.0, snap.byID[id].Latency)
@@ -83,19 +85,19 @@ func TestTPDSnapshotCache_RefreshAfterTTL(t *testing.T) {
 		return []*transport.Entry{entry(uuid.New(), 1)}, nil
 	}
 
-	_, err := c.snapshot(context.Background(), fetch)
+	_, err := c.snapshot(context.Background(), fetch, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls)
 
 	// Still fresh just before expiry.
 	clk.advance(defaultTPDSnapshotTTL - time.Second)
-	_, err = c.snapshot(context.Background(), fetch)
+	_, err = c.snapshot(context.Background(), fetch, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls)
 
 	// Expired → refetch.
 	clk.advance(2 * time.Second)
-	_, err = c.snapshot(context.Background(), fetch)
+	_, err = c.snapshot(context.Background(), fetch, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 2, calls)
 }
@@ -111,14 +113,14 @@ func TestTPDSnapshotCache_StaleOnRefreshError(t *testing.T) {
 	good := func(context.Context) ([]*transport.Entry, error) {
 		return []*transport.Entry{entry(id, 7)}, nil
 	}
-	_, err := c.snapshot(context.Background(), good)
+	_, err := c.snapshot(context.Background(), good, nil)
 	require.NoError(t, err)
 
 	clk.advance(defaultTPDSnapshotTTL + time.Second)
 	boom := errors.New("429 Too Many Requests")
 	snap, err := c.snapshot(context.Background(), func(context.Context) ([]*transport.Entry, error) {
 		return nil, boom
-	})
+	}, nil)
 	require.ErrorIs(t, err, boom)
 	require.NotNil(t, snap, "stale snapshot must be served on refresh error")
 	assert.Equal(t, 7.0, snap.byID[id].Latency)
@@ -133,7 +135,7 @@ func TestTPDSnapshotCache_ColdFailureReturnsNil(t *testing.T) {
 	boom := errors.New("cold")
 	snap, err := c.snapshot(context.Background(), func(context.Context) ([]*transport.Entry, error) {
 		return nil, boom
-	})
+	}, nil)
 	require.ErrorIs(t, err, boom)
 	assert.Nil(t, snap)
 }
@@ -147,7 +149,7 @@ func TestTPDSnapshotCache_ByIDSkipsNil(t *testing.T) {
 	id := uuid.New()
 	snap, err := c.snapshot(context.Background(), func(context.Context) ([]*transport.Entry, error) {
 		return []*transport.Entry{nil, entry(id, 3), nil}, nil
-	})
+	}, nil)
 	require.NoError(t, err)
 	assert.Len(t, snap.byID, 1)
 	assert.Equal(t, 3.0, snap.byID[id].Latency)
@@ -176,7 +178,7 @@ func TestTPDSnapshotCache_ConcurrentReads(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			snap, err := c.snapshot(context.Background(), fetch)
+			snap, err := c.snapshot(context.Background(), fetch, nil)
 			assert.NoError(t, err)
 			assert.NotNil(t, snap)
 		}()
@@ -188,6 +190,146 @@ func TestTPDSnapshotCache_ConcurrentReads(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	assert.LessOrEqual(t, calls, 3, "concurrent cold fetches should be deduped to ~1")
+}
+
+// TestTPDSnapshotCache_VersionKeyedInvalidation: when a version probe is
+// supplied (the CXO path), the cache serves until the reported timestamp
+// advances — and does NOT refetch on the wall-clock TTL while the version
+// is unchanged. This is the "no independent 5-minute timer over an
+// already-event-driven CXO snapshot" behavior.
+func TestTPDSnapshotCache_VersionKeyedInvalidation(t *testing.T) {
+	clk := newFakeClock()
+	c := newTestCache(clk)
+
+	var calls int
+	fetch := func(context.Context) ([]*transport.Entry, error) {
+		calls++
+		return []*transport.Entry{entry(uuid.New(), 1)}, nil
+	}
+	ver := time.Unix(1_000, 0)
+	version := func() (time.Time, bool) { return ver, true }
+
+	// Stable version within the TTL: the many repeat calls collapse to ONE
+	// fetch — this is the per-call rebuild the fix removes from the hot path.
+	for i := 0; i < 10; i++ {
+		_, err := c.snapshot(context.Background(), fetch, version)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, calls, "stable CXO version within TTL must collapse to one fetch")
+
+	// A new CXO snapshot timestamp triggers exactly one refetch, no clock
+	// movement needed — freshness tracks CXO, not the wall clock.
+	ver = time.Unix(2_000, 0)
+	_, err := c.snapshot(context.Background(), fetch, version)
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls, "advanced CXO version must refetch once")
+
+	// Liveness floor: because the CXO transport feed is refcount-gated and
+	// its lastSyncAt FREEZES when idle, a stable version past the TTL must
+	// still refetch (that refetch re-acquires the feed). Otherwise a frozen
+	// version would pin the cache to a stale snapshot forever.
+	clk.advance(defaultTPDSnapshotTTL + time.Second)
+	_, err = c.snapshot(context.Background(), fetch, version)
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls, "TTL floor must force a refetch when a frozen version outlives the TTL")
+}
+
+// TestTPDSnapshotCache_VersionFallsBackToTTL: a version probe that reports
+// !ok (CXO feed not primed) leaves the TTL in charge.
+func TestTPDSnapshotCache_VersionFallsBackToTTL(t *testing.T) {
+	clk := newFakeClock()
+	c := newTestCache(clk)
+
+	var calls int
+	fetch := func(context.Context) ([]*transport.Entry, error) {
+		calls++
+		return []*transport.Entry{entry(uuid.New(), 1)}, nil
+	}
+	notPrimed := func() (time.Time, bool) { return time.Time{}, false }
+
+	_, err := c.snapshot(context.Background(), fetch, notPrimed)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+
+	// Within TTL: served from cache.
+	_, err = c.snapshot(context.Background(), fetch, notPrimed)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+
+	// Past TTL: refetch, since version can't drive invalidation.
+	clk.advance(defaultTPDSnapshotTTL + time.Second)
+	_, err = c.snapshot(context.Background(), fetch, notPrimed)
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+// TestDeriveTransportLookups: byEdge excludes setup-labeled transports,
+// sorts each edge list by type preference, and the per-TpID metric maps
+// carry only non-zero values.
+func TestDeriveTransportLookups(t *testing.T) {
+	pkA := cipher.PubKey{0xA}
+	pkB := cipher.PubKey{0xB}
+	dmsgID, stcprID, setupID := uuid.New(), uuid.New(), uuid.New()
+
+	entries := []*transport.Entry{
+		nil, // tolerated
+		{ID: dmsgID, Type: tptypes.DMSG, Edges: [2]cipher.PubKey{pkA, pkB}, Latency: 50, ThroughputBps: 100},
+		{ID: stcprID, Type: tptypes.STCPR, Edges: [2]cipher.PubKey{pkA, pkB}, Latency: 5},
+		{ID: setupID, Type: tptypes.STCPR, Edges: [2]cipher.PubKey{pkA, pkB}, Label: transport.LabelSetup},
+	}
+
+	byEdge, lat, typ, thr := deriveTransportLookups(entries)
+
+	// Setup transport excluded from byEdge; direct type sorts before DMSG.
+	require.Len(t, byEdge[pkA], 2)
+	assert.Equal(t, stcprID, byEdge[pkA][0].ID, "STCPR must sort before DMSG")
+	assert.Equal(t, dmsgID, byEdge[pkA][1].ID)
+
+	// Metric maps: only non-zero values retained; type map covers all.
+	assert.Equal(t, 50.0, lat[dmsgID])
+	_, hasStcprLat := lat[stcprID]
+	assert.True(t, hasStcprLat, "5ms latency is non-zero → present")
+	assert.Equal(t, 100.0, thr[dmsgID])
+	_, hasStcprThr := thr[stcprID]
+	assert.False(t, hasStcprThr, "zero throughput → absent")
+	assert.Equal(t, string(tptypes.STCPR), typ[stcprID])
+	// Setup transport still gets a type/metric entry (only byEdge excludes it).
+	assert.Equal(t, string(tptypes.STCPR), typ[setupID])
+}
+
+// BenchmarkDeriveTransportLookups measures the per-call cost that
+// calculateLocalRoutes used to pay on EVERY dial (it rebuilt these four
+// maps inline from the whole ~16k-entry transport set). The fix builds
+// them once per CXO snapshot instead; this benchmark quantifies the work
+// removed from the hot path — allocs/op × call-frequency is what pegged
+// the single js/wasm thread in mallocgc/GC on the NAT'd wasm visor.
+func BenchmarkDeriveTransportLookups(b *testing.B) {
+	// ~980 visors, ~16k transports — the live network's shape.
+	const nodes, tps = 980, 16000
+	pks := make([]cipher.PubKey, nodes)
+	for i := range pks {
+		pks[i] = cipher.PubKey{byte(i), byte(i >> 8), 0x02}
+	}
+	types := []tptypes.Type{tptypes.STCPR, tptypes.SUDPH, tptypes.DMSG, tptypes.STCP}
+	entries := make([]*transport.Entry, tps)
+	for i := range entries {
+		a := pks[(i*7)%nodes]
+		c := pks[(i*13+1)%nodes]
+		entries[i] = &transport.Entry{
+			ID:      uuid.New(),
+			Type:    types[i%len(types)],
+			Edges:   [2]cipher.PubKey{a, c},
+			Latency: float64(i%200) + 1,
+		}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		byEdge, _, _, _ := deriveTransportLookups(entries)
+		if len(byEdge) == 0 {
+			b.Fatal("empty")
+		}
+	}
 }
 
 // TestFindRouteNum covers the mux-degree → requested-route-count helper.

--- a/pkg/visor/cxo_transport_discovery.go
+++ b/pkg/visor/cxo_transport_discovery.go
@@ -18,6 +18,7 @@ package visor
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -76,6 +77,22 @@ func (c *cxoAwareTPD) GetAllTransports(ctx context.Context) ([]*transport.Entry,
 		}
 	}
 	return c.DiscoveryClient.GetAllTransports(ctx)
+}
+
+// AllTransportsSyncedAt reports when the CXO tpd-all-transports snapshot
+// last advanced, so the router's route-calc cache can invalidate on the
+// CXO sync cadence instead of an independent wall-clock TTL. ok=false
+// (feed not yet primed / CXO unavailable) tells the caller to keep its
+// TTL fallback. Copies no body — a cheap version probe.
+func (c *cxoAwareTPD) AllTransportsSyncedAt() (time.Time, bool) {
+	if c.v == nil {
+		return time.Time{}, false
+	}
+	mgr := c.v.CXOSubMgr()
+	if mgr == nil {
+		return time.Time{}, false
+	}
+	return mgr.SyncedAt(FeedTPDAllTransports, tpdapi.AllTransportsPathWithoutSelf)
 }
 
 // wrapDiscoveryClientWithCXO returns a CXO-aware wrapper around dc.


### PR DESCRIPTION
calculateLocalRoutes rebuilt four whole-network maps (transports-by-edge plus per-TpID latency/type/throughput) from the ~16k-entry discovery set on **every** call. A NAT'd visor with no direct transport to the destination skips the direct-route early return, so every browse-dial retry paid the full rebuild — ~9ms / 4MB / 7.8k allocs per call on amd64 (`BenchmarkDeriveTransportLookups`), far worse on the single-threaded js/wasm runtime. Under a route-setup retry loop this pegged the in-browser wasm visor's one thread in GC (CPU-profiled to `calculateLocalRoutes` + ~30% mallocgc/scan).

Derive the lookups once per TPD snapshot instead. The snapshot source is already the visor's CXO subscription (`cxoAwareTPD`), so invalidate on the CXO snapshot timestamp rather than an independent 5-minute wall clock: refresh when CXO delivers a new root. Because the transport feed is refcount-gated and its `lastSyncAt` freezes when idle, the TTL is kept only as a liveness floor so a frozen version can't pin the cache to a stale snapshot. Same path for wasm and native visors.

Tests: version-keyed invalidation, TTL floor, TTL fallback, derived-lookup correctness (setup exclusion + type-preference sort), and the benchmark. `go test ./pkg/router/ -race` green.