### PR TITLE
fix(cxo): pin the transport feed so route-calc doesn't re-handshake CXO

### DIFF
--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -174,8 +174,9 @@ type Manager struct {
 	interval time.Duration // cycle period (cxo_subscribe_interval)
 	grace    time.Duration // delay after last release before stopping the cycle
 
-	mu    sync.Mutex
-	feeds map[Feed]*managedFeed
+	mu     sync.Mutex
+	feeds  map[Feed]*managedFeed
+	pinned map[Feed]bool // feeds held continuously (never grace-stopped)
 }
 
 // managedFeed holds a single feed's runtime state.
@@ -707,6 +708,32 @@ func (m *Manager) LastSync(feed Feed) time.Time {
 	f.snapMu.RLock()
 	defer f.snapMu.RUnlock()
 	return f.lastSyncAt
+}
+
+// Pin keeps a feed's sync cycle running continuously by taking one
+// permanent reference: the refcount never falls to zero, so the
+// grace-period teardown never fires. Use it for a feed a core subsystem
+// consults constantly — the router's transport snapshot (FeedTPDAllTransports)
+// is read on every dial's route calculation. Without a pin the ~10s-grace
+// teardown tears the CXO subscription down whenever the last transient
+// consumer goes briefly idle, and the next read re-establishes it — a
+// fresh dmsg + Noise/PQ handshake each time, which on the single-threaded
+// wasm visor is pure churn. Idempotent per feed; the pin is released only
+// by Close.
+func (m *Manager) Pin(fk Feed) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.pinned[fk] {
+		return
+	}
+	if m.pinned == nil {
+		m.pinned = make(map[Feed]bool)
+	}
+	m.pinned[fk] = true
+	m.acquireFeedLocked(fk)
 }
 
 // acquireFeedLocked must be called under m.mu.

--- a/pkg/cxo/cxosub/manager_pin_test.go
+++ b/pkg/cxo/cxosub/manager_pin_test.go
@@ -1,0 +1,59 @@
+// pkg/cxo/cxosub/manager_pin_test.go — verifies Pin keeps a feed's CXO
+// subscription up continuously so route calculation never triggers a
+// grace-teardown-and-rehandshake cycle on the transport snapshot.
+
+package cxosub
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+func TestManagerPin_HoldsFeedThroughTransientRelease(t *testing.T) {
+	// nil dmsg → liveServe errors and backs off; we only assert refcount
+	// bookkeeping, which is independent of an actual sync.
+	m := NewManager(Deps{Dmsg: func() *dmsg.Client { return nil }}, time.Minute)
+	defer m.Close()
+
+	m.Pin(FeedTPDAllTransports)
+
+	rc, hasFeed := feedRefcount(m, FeedTPDAllTransports)
+	require.True(t, hasFeed, "Pin must create + hold the feed")
+	assert.Equal(t, 1, rc, "pinned feed sits at refcount 1")
+
+	// A transient consumer acquires then releases; the pin must keep the
+	// feed alive (no grace-stop scheduled).
+	m.AcquireFor(TabCLITransports)
+	m.ReleaseFor(TabCLITransports)
+
+	rc, _ = feedRefcount(m, FeedTPDAllTransports)
+	assert.Equal(t, 1, rc, "pin holds refcount at 1 after transient release")
+	assert.False(t, feedHasStopTimer(m, FeedTPDAllTransports), "pinned feed must never schedule a grace-stop")
+
+	// Pin is idempotent — a second call doesn't leak a reference.
+	m.Pin(FeedTPDAllTransports)
+	rc, _ = feedRefcount(m, FeedTPDAllTransports)
+	assert.Equal(t, 1, rc, "Pin is idempotent")
+}
+
+func feedRefcount(m *Manager, fk Feed) (int, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	f, ok := m.feeds[fk]
+	if !ok || f == nil {
+		return 0, false
+	}
+	return f.refcount, true
+}
+
+func feedHasStopTimer(m *Manager, fk Feed) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	f, ok := m.feeds[fk]
+	return ok && f != nil && f.stopTimer != nil
+}

--- a/pkg/router/tpd_cache.go
+++ b/pkg/router/tpd_cache.go
@@ -86,14 +86,13 @@ type tpdSnapshot struct {
 	typeByID       map[uuid.UUID]string
 	throughputByID map[uuid.UUID]float64
 	// version is the CXO snapshot timestamp this snapshot was built from
-	// (zero when built off the wall-clock TTL path, e.g. a non-CXO
-	// discovery client). When set, the cache reuses this snapshot until
-	// the source reports a newer timestamp — CXO-cadence invalidation
-	// rather than an independent timer.
+	// (zero when built off the non-CXO TTL path). When set, the cache
+	// reuses this snapshot until the pinned CXO subscription pushes a newer
+	// Root — event-driven invalidation, no timer.
 	version time.Time
-	// expires is the wall-clock TTL floor, always set. It governs the
-	// non-CXO path and bounds staleness if the version probe later stops
-	// answering (CXO feed dropped) so the cache can't pin forever.
+	// expires is the wall-clock TTL, set for the non-CXO fallback path
+	// (a discovery client with no version signal — tests, bare HTTP). It is
+	// not consulted on the CXO path.
 	expires time.Time
 }
 
@@ -218,29 +217,28 @@ func (c *tpdSnapshotCache) snapshot(
 	fetchAll func(context.Context) ([]*transport.Entry, error),
 	version func() (time.Time, bool),
 ) (*tpdSnapshot, error) {
-	// CXO-driven path: serve until the source's snapshot timestamp moves
-	// — but keep the TTL as a liveness floor. The CXO transport feed is
-	// refcount-gated (TabCloseGrace ~10s): once route-calc stops holding
-	// it the sync cycle stops and lastSyncAt FREEZES (the snapshot is not
-	// cleared). Cache hits here deliberately don't re-acquire the feed, so
-	// without the floor a stable-but-frozen version would pin this cache
-	// to an old snapshot forever and transports would never refresh. The
-	// floor forces a refetch every TTL even when the version hasn't moved;
-	// that refetch goes through GetAllTransports, which re-acquires the
-	// feed (restarting its cycle) and picks up anything new. So: refresh
-	// immediately when CXO advances, and at worst once per TTL when CXO is
-	// idle — never per call.
+	// CXO-driven path: serve until the source's snapshot timestamp moves —
+	// no wall clock involved. The visor pins FeedTPDAllTransports (see
+	// Manager.Pin), so its CXO subscription is held continuously and
+	// liveServe pushes each new Root into the snapshot; lastSyncAt advances
+	// only on a real transport change. Rebuilding the derived lookups
+	// exactly then — and not otherwise — is correct and event-driven: a
+	// steady network rebuilds nothing, a changed one rebuilds once. There
+	// is deliberately no TTL here; a periodic refetch over an already-live
+	// CXO snapshot would just be a timer cache, which is the thing this
+	// replaces. (The TTL below still governs the non-CXO fallback, where
+	// there is no version signal at all.)
 	if version != nil {
 		if ts, ok := version(); ok {
 			c.mu.RLock()
 			cur := c.snap
 			c.mu.RUnlock()
-			if cur != nil && !cur.version.IsZero() && cur.version.Equal(ts) && c.clock().Before(cur.expires) {
+			if cur != nil && !cur.version.IsZero() && cur.version.Equal(ts) {
 				return cur, nil
 			}
 			c.mu.Lock()
 			defer c.mu.Unlock()
-			if c.snap != nil && !c.snap.version.IsZero() && c.snap.version.Equal(ts) && c.clock().Before(c.snap.expires) {
+			if c.snap != nil && !c.snap.version.IsZero() && c.snap.version.Equal(ts) {
 				return c.snap, nil
 			}
 			entries, err := fetchAll(ctx)

--- a/pkg/router/tpd_cache_test.go
+++ b/pkg/router/tpd_cache_test.go
@@ -217,21 +217,21 @@ func TestTPDSnapshotCache_VersionKeyedInvalidation(t *testing.T) {
 	}
 	assert.Equal(t, 1, calls, "stable CXO version within TTL must collapse to one fetch")
 
-	// A new CXO snapshot timestamp triggers exactly one refetch, no clock
-	// movement needed — freshness tracks CXO, not the wall clock.
-	ver = time.Unix(2_000, 0)
+	// Advancing the wall clock past the TTL must NOT refetch while the CXO
+	// version is unchanged: the pinned subscription keeps lastSyncAt live,
+	// so a stable version means transports genuinely haven't changed — no
+	// timer refresh over an already-live CXO snapshot.
+	clk.advance(10 * defaultTPDSnapshotTTL)
 	_, err := c.snapshot(context.Background(), fetch, version)
 	require.NoError(t, err)
-	assert.Equal(t, 2, calls, "advanced CXO version must refetch once")
+	assert.Equal(t, 1, calls, "stable CXO version must not refetch on the wall clock")
 
-	// Liveness floor: because the CXO transport feed is refcount-gated and
-	// its lastSyncAt FREEZES when idle, a stable version past the TTL must
-	// still refetch (that refetch re-acquires the feed). Otherwise a frozen
-	// version would pin the cache to a stale snapshot forever.
-	clk.advance(defaultTPDSnapshotTTL + time.Second)
+	// A new CXO snapshot timestamp (a real transport change pushed by the
+	// live subscription) triggers exactly one refetch — no clock movement.
+	ver = time.Unix(2_000, 0)
 	_, err = c.snapshot(context.Background(), fetch, version)
 	require.NoError(t, err)
-	assert.Equal(t, 3, calls, "TTL floor must force a refetch when a frozen version outlives the TTL")
+	assert.Equal(t, 2, calls, "advanced CXO version must refetch once")
 }
 
 // TestTPDSnapshotCache_VersionFallsBackToTTL: a version probe that reports

--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -106,6 +106,15 @@ func (v *Visor) CXOSubMgr() *CXOSubscriptionManager {
 		}
 	}
 	v.cxoSubMgr = NewCXOSubscriptionManager(v, interval, v.MasterLogger().PackageLogger("cxo_subscription_manager"))
+	// Keep the transport-snapshot subscription up continuously. Route
+	// calculation reads FeedTPDAllTransports on every dial; letting the
+	// ~10s-grace teardown drop it between dials just forces a fresh CXO
+	// subscription — a new dmsg dial + Noise/PQ handshake — on the next
+	// one, which on the single-threaded wasm visor is pure churn. Pinned
+	// once here (released only on Close), so liveServe stays connected and
+	// pushes Root updates live; the router's route-calc cache then tracks
+	// real transport changes instead of a timer.
+	v.cxoSubMgr.Pin(FeedTPDAllTransports)
 	return v.cxoSubMgr
 }
 


### PR DESCRIPTION
Follow-up to #4382. The CXO subscription manager is refcount-gated: a feed's live subscription (`liveServe`, a persistent push-based TreeStore subscription) is torn down ~10s (`TabCloseGrace`) after the last consumer releases it. Route calculation reads `FeedTPDAllTransports` on every dial, so between dial bursts the feed drops and the next dial re-establishes it — a fresh dmsg dial + Noise/PQ handshake each time. On the single-threaded wasm visor that churn is pure overhead, and it also froze `lastSyncAt` between holds.

Pin `FeedTPDAllTransports` at manager construction: one permanent reference so the grace-teardown never fires and `liveServe` stays connected, pushing Root updates live. `lastSyncAt` then advances only on real transport changes — which is what #4382's route-calc cache keys on, so it rebuilds its derived lookups on an actual change, never on a timer. Drops the TTL floor from that cache's CXO path (the pin makes it unnecessary; the TTL remains only for non-CXO discovery clients, which have no version signal). Same path for wasm and native visors.

Adds `Manager.Pin` (idempotent) + a unit test that a transient acquire/release can't drop a pinned feed. `go test ./pkg/router/ ./pkg/cxo/cxosub/ -race` green.