### PR TITLE
perf(rf): memoize weighted route results per graph (kill repeated BFS)

### DIFF
--- a/pkg/deployment/rf/store/finder.go
+++ b/pkg/deployment/rf/store/finder.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/routing"
@@ -80,10 +81,56 @@ func (g *Graph) routeLatency(r routing.Route) float64 {
 // high-latency one); when false it returns the shortest-hop routes — identical
 // to GetRoute. Latency mode collects a bounded candidate pool from the same BFS
 // and sorts it, so it stays memory-safe on dense graphs.
+// routeKey identifies a memoized GetRouteWeighted result on a Graph. All
+// fields are comparable, so it is a usable map/sync.Map key directly.
+type routeKey struct {
+	source, destination cipher.PubKey
+	minLen, maxLen      int
+	number              int
+	byLatency           bool
+}
+
+// routeEntry is a once-computed cache slot. once guards the single BFS; the
+// result is immutable afterwards and shared read-only by every caller that
+// hit the same key.
+type routeEntry struct {
+	once   sync.Once
+	routes []routing.Route
+	err    error
+}
+
+// GetRouteWeighted returns up to `number` routes source→destination, memoized
+// per Graph. The exhaustive BFS over the (dense) transport graph is expensive
+// — seconds per request for well-connected pairs — and the fleet re-asks for
+// the same pairs constantly (session churn), so without a cache the
+// route-finder re-runs an identical search on every repeat. The memo collapses
+// those to one BFS per unique request for the life of this graph, and its
+// sync.Once also deduplicates a concurrent thundering herd of identical
+// requests into a single search rather than N. Failures are not cached (the
+// entry is dropped) so a transient miss can be retried immediately; only
+// successful route sets persist, until the next graph rebuild swaps in a fresh
+// (empty) memo. Callers must treat the returned slice as read-only.
 func (g *Graph) GetRouteWeighted(ctx context.Context, source, destination cipher.PubKey, minLen, maxLen, number int, byLatency bool) ([]routing.Route, error) {
 	if number <= 0 {
 		number = 1
 	}
+	key := routeKey{source, destination, minLen, maxLen, number, byLatency}
+	ei, _ := g.routeMemo.LoadOrStore(key, &routeEntry{})
+	e := ei.(*routeEntry)
+	e.once.Do(func() {
+		e.routes, e.err = g.computeRouteWeighted(ctx, source, destination, minLen, maxLen, number, byLatency)
+		if e.err != nil {
+			// Don't cache failures — a later request (or a warmer graph)
+			// may succeed. Concurrent waiters on this same once still see
+			// this error, which is correct: they were part of this attempt.
+			g.routeMemo.Delete(key)
+		}
+	})
+	return e.routes, e.err
+}
+
+// computeRouteWeighted is the uncached search behind GetRouteWeighted.
+func (g *Graph) computeRouteWeighted(ctx context.Context, source, destination cipher.PubKey, minLen, maxLen, number int, byLatency bool) ([]routing.Route, error) {
 	if !byLatency {
 		return g.GetRoute(ctx, source, destination, minLen, maxLen, number)
 	}

--- a/pkg/deployment/rf/store/finder_bench_test.go
+++ b/pkg/deployment/rf/store/finder_bench_test.go
@@ -52,3 +52,33 @@ func BenchmarkStreamRoutesDense(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkGetRouteWeightedUncached is the raw per-request search cost — what
+// the route-finder paid on EVERY repeated request before the per-graph memo.
+func BenchmarkGetRouteWeightedUncached(b *testing.B) {
+	g, src, dst := buildDenseGraph(b, 5, 6)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := g.computeRouteWeighted(context.Background(), src, dst, 0, 6, 5, true); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkGetRouteWeightedCached is the fleet's actual pattern: the same
+// (src,dst,params) requested repeatedly against one graph. Every request after
+// the first is a memo hit — the search runs once per graph, not per request.
+func BenchmarkGetRouteWeightedCached(b *testing.B) {
+	g, src, dst := buildDenseGraph(b, 5, 6)
+	if _, err := g.GetRouteWeighted(context.Background(), src, dst, 0, 6, 5, true); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := g.GetRouteWeighted(context.Background(), src, dst, 0, 6, 5, true); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/deployment/rf/store/mark_and_sweep.go
+++ b/pkg/deployment/rf/store/mark_and_sweep.go
@@ -3,6 +3,7 @@ package store
 
 import (
 	"context"
+	"sync"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/deployment/tpd/store"
@@ -56,6 +57,15 @@ type Graph struct {
 	store   store.Store
 	visited map[cipher.PubKey]*vertex
 	graph   map[cipher.PubKey]*vertex
+	// routeMemo caches GetRouteWeighted results for THIS graph instance
+	// (routeKey -> *routeEntry). The graph is immutable once built and the
+	// route-finder swaps in a freshly-built *Graph every refresh cycle, so
+	// the cache's lifetime is exactly the graph's — no explicit
+	// invalidation, and no staleness beyond what the graph snapshot already
+	// carries. It collapses the fleet's repeated identical route requests
+	// (churning clients re-asking for the same src→dst) from a full
+	// exhaustive BFS each time to one BFS per unique request per cycle.
+	routeMemo sync.Map
 }
 
 // NewGraph creates a new Graph accessing given transport store, such Graph is created by exploring

--- a/pkg/deployment/rf/store/memo_test.go
+++ b/pkg/deployment/rf/store/memo_test.go
@@ -1,0 +1,68 @@
+// pkg/deployment/rf/store/memo_test.go — verifies GetRouteWeighted's
+// per-graph result memo: a successful search is computed once and reused,
+// concurrent identical searches collapse to one, and failures are not
+// cached so a later request can retry.
+
+package store
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestGetRouteWeightedMemoized(t *testing.T) {
+	src, a, _, _, dst := generateNodesPK(t)
+	m := newMockStore()
+	m.saveEntryLat(src, a, 100)
+	m.saveEntryLat(a, dst, 100)
+
+	g, err := NewGraph(context.Background(), m, src)
+	require.NoError(t, err)
+
+	r1, err := g.GetRouteWeighted(context.Background(), src, dst, 0, 5, 1, true)
+	require.NoError(t, err)
+	require.NotEmpty(t, r1)
+
+	// The successful result is cached under its key...
+	key := routeKey{src, dst, 0, 5, 1, true}
+	ei, ok := g.routeMemo.Load(key)
+	require.True(t, ok, "a successful search must be cached")
+	require.Equal(t, r1, ei.(*routeEntry).routes)
+
+	// ...and a second identical call returns that very slice, not a recompute.
+	r2, err := g.GetRouteWeighted(context.Background(), src, dst, 0, 5, 1, true)
+	require.NoError(t, err)
+	require.Same(t, &r1[0], &r2[0], "second identical call must return the cached slice")
+
+	// A differing key (number) is a distinct entry, computed separately.
+	_, err = g.GetRouteWeighted(context.Background(), src, dst, 0, 5, 2, true)
+	require.NoError(t, err)
+	_, ok = g.routeMemo.Load(routeKey{src, dst, 0, 5, 2, true})
+	require.True(t, ok)
+
+	// Concurrent identical requests are race-free and deduped (run with -race).
+	var wg sync.WaitGroup
+	for i := 0; i < 40; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rr, e := g.GetRouteWeighted(context.Background(), src, dst, 0, 5, 1, true)
+			require.NoError(t, e)
+			require.NotEmpty(t, rr)
+		}()
+	}
+	wg.Wait()
+
+	// A no-route request errors and is NOT cached, so it can be retried.
+	var noDst cipher.PubKey
+	noDst[0] = 0xEE
+	_, err = g.GetRouteWeighted(context.Background(), src, noDst, 0, 5, 1, true)
+	require.Error(t, err)
+	_, cached := g.routeMemo.Load(routeKey{src, noDst, 0, 5, 1, true})
+	require.False(t, cached, "failed lookups must not be cached")
+}


### PR DESCRIPTION
The route-finder re-ran a full exhaustive BFS on every request, even when the fleet asked for the same src→dst pair repeatedly (which it does constantly under session churn). On the dense live graph one such search costs tens of ms to seconds — a churning client's request was measured at **8.4s of RF CPU** — so the route-finder pegged (~258% CPU, load 11) recomputing identical answers.

Memoize `GetRouteWeighted` on the `*Graph`. The graph is immutable once built and the route-finder swaps in a freshly-built graph each refresh cycle (#4380), so the memo's lifetime is exactly the graph's — no explicit invalidation and no staleness beyond what the graph snapshot already carries. A `sync.Once` per key also collapses a concurrent thundering herd of identical requests into a single search. Failures are not cached, so a transient miss retries immediately.

Benchmark (dense graph, repeated identical request — the fleet's pattern): uncached **75ms / 36610 allocs/op** → cached **1.5µs / 2 allocs/op**. `go test ./pkg/deployment/rf/... -race` green.