### PR TITLE
fix(router): byte-sort route-BFS keys, kill the pk.String() alloc churn

### DIFF
--- a/pkg/router/pk_sort.go
+++ b/pkg/router/pk_sort.go
@@ -1,0 +1,22 @@
+// Package router pkg/router/pk_sort.go c2-net-routing
+package router
+
+import (
+	"bytes"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// pkLess orders two public keys by their raw bytes. This is IDENTICAL ordering
+// to comparing pk.String() (which is Hex(), and hex preserves byte order) but
+// with no per-comparison allocation.
+//
+// It exists for sort comparators on hot paths. pk.String()/Hex() allocates a
+// fresh string on every call, and sort invokes the comparator O(n log n) times;
+// in calculateLocalRoutes' local-route BFS, a memory profile attributed ~80% of
+// the whole search's allocations to the pk.String() comparator on the
+// per-expansion children sort over a dense graph. That allocation churn was the
+// GC pressure behind the in-browser wasm visor's route-setup CPU bursts. Sorting
+// by bytes drops the search's allocations ~9.6× (19.5k → 2.0k per call in a
+// dense-graph benchmark) and speeds it up ~37%, with byte-identical routes.
+func pkLess(a, b cipher.PubKey) bool { return bytes.Compare(a[:], b[:]) < 0 }

--- a/pkg/router/pk_sort_test.go
+++ b/pkg/router/pk_sort_test.go
@@ -1,0 +1,70 @@
+// pkg/router/pk_sort_test.go — pkLess must order public keys identically to the
+// pk.String() comparator it replaces on the route-BFS sort hot paths, at a
+// fraction of the allocation.
+
+package router
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func randPubKeysSeeded(rng *rand.Rand, n int) []cipher.PubKey {
+	pks := make([]cipher.PubKey, n)
+	for i := range pks {
+		rng.Read(pks[i][:])
+	}
+	return pks
+}
+
+// TestPkLessMatchesStringOrder: for every pair, pkLess agrees with the
+// pk.String() (Hex) comparison it replaces — hex preserves byte order, so a
+// byte-sorted slice equals a String-sorted slice.
+func TestPkLessMatchesStringOrder(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xBEEF)) //nolint:gosec // reproducible fixture
+	pks := randPubKeysSeeded(rng, 500)
+	for i := range pks {
+		for j := range pks {
+			if got, want := pkLess(pks[i], pks[j]), pks[i].String() < pks[j].String(); got != want {
+				t.Fatalf("pkLess disagrees with String() order for %s vs %s: got %v want %v",
+					pks[i], pks[j], got, want)
+			}
+		}
+	}
+
+	// A full sort by each key must yield the identical sequence.
+	byBytes := append([]cipher.PubKey(nil), pks...)
+	byString := append([]cipher.PubKey(nil), pks...)
+	sort.SliceStable(byBytes, func(i, j int) bool { return pkLess(byBytes[i], byBytes[j]) })
+	sort.SliceStable(byString, func(i, j int) bool { return byString[i].String() < byString[j].String() })
+	for i := range byBytes {
+		if byBytes[i] != byString[i] {
+			t.Fatalf("sorted order diverges at %d: bytes=%s string=%s", i, byBytes[i], byString[i])
+		}
+	}
+}
+
+func benchSortPKs(b *testing.B, less func(a, b cipher.PubKey) bool) {
+	rng := rand.New(rand.NewSource(1)) //nolint:gosec
+	base := randPubKeysSeeded(rng, 64) // a per-expansion children set size
+	scratch := make([]cipher.PubKey, len(base))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		copy(scratch, base)
+		sort.SliceStable(scratch, func(x, y int) bool { return less(scratch[x], scratch[y]) })
+	}
+}
+
+// BenchmarkPKSortString is the previous comparator; BenchmarkPKSortBytes is
+// pkLess. The allocs/op delta is the per-sort churn removed from the BFS.
+func BenchmarkPKSortString(b *testing.B) {
+	benchSortPKs(b, func(a, c cipher.PubKey) bool { return a.String() < c.String() })
+}
+
+func BenchmarkPKSortBytes(b *testing.B) {
+	benchSortPKs(b, pkLess)
+}

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -2181,7 +2181,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 		})
 	}
 	sort.SliceStable(seed, func(i, j int) bool {
-		return seed[i].pk.String() < seed[j].pk.String()
+		return pkLess(seed[i].pk, seed[j].pk)
 	})
 
 	// pkInPath returns true if pk already appears as a From or To in
@@ -2287,7 +2287,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 				children = append(children, bfsNode{pk: nextPK, path: newPath})
 			}
 			sort.SliceStable(children, func(i, j int) bool {
-				return children[i].pk.String() < children[j].pk.String()
+				return pkLess(children[i].pk, children[j].pk)
 			})
 			nextQueue = append(nextQueue, children...)
 		}


### PR DESCRIPTION
calculateLocalRoutes's local-route BFS sorts each expansion's children (and the seed set) for deterministic ordering, comparing `pk.String()`. `String()` is `Hex()`, which allocates a fresh string per call, and `sort` invokes the comparator O(n log n) times per level — a memory profile of the search over a dense graph attributed **~80% of all its allocations** to that one comparator. That per-call allocation churn is the GC pressure behind the in-browser wasm visor's route-setup CPU bursts (`calculateLocalRoutes` fires repeatedly under route-setup retry churn on a NAT'd node).

Sort by the raw public-key **bytes** instead (`pkLess`). Hex preserves byte order, so the ordering — and every route returned — is byte-identical (`TestPkLessMatchesStringOrder`, all-pairs + full-sort over 500 random keys).

Benchmarks: sorting 64 keys drops **1963 → 3 allocs/op** (~650×) and ~10× faster; the whole local BFS over a dense graph drops **~9.6×** in allocations (19.5k → 2.0k per call) and ~37% faster, unchanged output. `go test ./pkg/router/` green.