### PR TITLE
perf(rf): landmark (transit-node) routing — compose far routes via hubs

### DIFF
--- a/pkg/deployment/rf/store/finder.go
+++ b/pkg/deployment/rf/store/finder.go
@@ -135,6 +135,19 @@ func (g *Graph) computeRouteWeighted(ctx context.Context, source, destination ci
 		return g.GetRoute(ctx, source, destination, minLen, maxLen, number)
 	}
 
+	// Landmark (transit-node) routing: a budget-bounded direct BFS keeps the
+	// optimal answer for every pair it can resolve cheaply, and the expensive
+	// far pairs — the ones that peg the RF with a multi-second exhaustive
+	// search — are answered by composing src->hub->dst instead. Returns
+	// ok=false only when neither the budget BFS nor composition found anything,
+	// in which case we fall through to the full exhaustive BFS below. See
+	// landmark.go.
+	if landmarkRoutingEnabled {
+		if routes, ok := g.routesLandmarkHybrid(ctx, source, destination, minLen, maxLen, number); ok {
+			return routes, nil
+		}
+	}
+
 	// Pool larger than `number` so a lower-latency path that BFS emits a little
 	// later (e.g. one more hop, but faster edges) can still win — bounded so
 	// dense graphs don't blow up the sort.

--- a/pkg/deployment/rf/store/landmark.go
+++ b/pkg/deployment/rf/store/landmark.go
@@ -1,0 +1,413 @@
+// Package store pkg/deployment/rf/store/landmark.go c2-net-routing
+//
+// Landmark (transit-node) routing for the route-finder. The base route-finder
+// answers each (src,dst) with a bounded but EXHAUSTIVE BFS over the whole dense
+// transport graph; on the live network a single far/hard pair has been measured
+// at ~8.4s of CPU and pegs the RF host. #4380 (cached graph) and #4385
+// (per-graph result memo) removed the per-request graph BUILD and the REPEAT
+// BFS, but the first search of any pair is still exhaustive.
+//
+// This exploits the mesh's structure: a handful of very-high-degree hubs
+// (magnetosphere/prod02/the production exit carry ~1200-1300 transports each vs
+// ~70-120 for a normal node) that most routes already transit, plus
+// deterministic tpids and durable topology (see rf-landmark-routing-rfc.md).
+// We precompute routes between every node and those hubs ONCE per graph, then
+// answer a far (src,dst) by COMPOSING src->hub + hub->dst — ~H*K*K cheap
+// concatenations instead of a graph-wide search.
+//
+// It is a strict addition: a pair the (budget-bounded) direct BFS resolves
+// cheaply keeps its optimal exhaustive answer; only the pairs that blow past the
+// budget — the multi-second cases that peg the RF — fall to composition, and a
+// composition miss still falls through to the full BFS. Coexists with #4380 and
+// #4385 (the memo caches composed results exactly as it caches BFS results).
+package store
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"sort"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+const (
+	// defaultLandmarkHubs is how many top-degree nodes become landmarks.
+	defaultLandmarkHubs = 8
+	// defaultLandmarkK is how many routes are stored per (node,hub) direction.
+	defaultLandmarkK = 5
+	// defaultLandmarkMaxLen bounds each precomputed sub-route's hop length.
+	defaultLandmarkMaxLen = 6
+	// landmarkBFSBudget bounds the direct BFS attempted BEFORE composing. A pair
+	// the BFS resolves within this many queued frontier nodes keeps its optimal
+	// exhaustive answer; a pair that exceeds it (the pathological multi-second
+	// searches) falls to composition instead of pegging a core.
+	landmarkBFSBudget = 40000
+	// landmarkDirectDepth caps the direct BFS's hop depth on the first pass.
+	// Pairs with enough routes within this many hops keep their optimal
+	// exhaustive answer cheaply; a farther pair exhausts this shallow depth
+	// FAST (bounded frontier) and falls to composition — that fast-fail is what
+	// turns a multi-second exhaustive search into ~microseconds. Most real
+	// routes are ≤3 hops (with hubs, leaf→hub→leaf is 2), so this serves the
+	// common case directly and composes only the genuinely-far tail.
+	landmarkDirectDepth = 3
+)
+
+// landmarkRoutingEnabled gates the feature. On unless RF_LANDMARK_ROUTING=0, so
+// it can be reverted on the deployment host without a rebuild.
+var landmarkRoutingEnabled = os.Getenv("RF_LANDMARK_ROUTING") != "0"
+
+// landmarkTables holds, for one immutable Graph, the precomputed routes between
+// every node and the selected hubs. Routes are full routing.Route values (not
+// just tpid sequences) so composition and latency-ranking reuse the existing
+// buildRoute/routeLatency machinery unchanged; a follow-up can compact these to
+// tpid-only if the ~10MB footprint ever matters.
+type landmarkTables struct {
+	hubs    []cipher.PubKey
+	toHub   map[cipher.PubKey]map[cipher.PubKey][]routing.Route // node -> hub  -> routes
+	fromHub map[cipher.PubKey]map[cipher.PubKey][]routing.Route // hub  -> node -> routes
+}
+
+// cipherLess is a deterministic total order on pubkeys (byte order), used for
+// stable hub-selection tiebreaks so the same graph always picks the same hubs.
+func cipherLess(a, b cipher.PubKey) bool { return bytes.Compare(a[:], b[:]) < 0 }
+
+// selectHubs returns the n highest-degree nodes (degree = number of distinct
+// neighbors = len(vertex.connections)), deterministic on ties. The mega-hubs
+// and any future high-degree node are captured automatically; the set re-derives
+// each time the graph is (re)built, so it self-heals as topology changes.
+func selectHubs(g *Graph, n int) []cipher.PubKey {
+	type deg struct {
+		pk  cipher.PubKey
+		deg int
+	}
+	ds := make([]deg, 0, len(g.graph))
+	for pk, v := range g.graph {
+		ds = append(ds, deg{pk, len(v.connections)})
+	}
+	sort.Slice(ds, func(i, j int) bool {
+		if ds[i].deg != ds[j].deg {
+			return ds[i].deg > ds[j].deg
+		}
+		return cipherLess(ds[i].pk, ds[j].pk)
+	})
+	if n > len(ds) {
+		n = len(ds)
+	}
+	out := make([]cipher.PubKey, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, ds[i].pk)
+	}
+	return out
+}
+
+// routesFromHub does ONE BFS from hub and records up to K shortest routes to
+// EVERY reachable node (the frontier reaches nodes shortest-first, exactly as
+// StreamRoutesWithCap emits). Reuses the parent-index bfsItem frontier from
+// #4378. dmsg transports are excluded entirely: dmsg is only valid as a route's
+// final hop, but a landmark sub-route's endpoint becomes an interior junction
+// after composition — so a dmsg hop there would sit mid-route. Direct
+// dmsg-terminated routes are still served by the full-BFS fallback.
+func (g *Graph) routesFromHub(hub cipher.PubKey, k, maxLen, queueCap int) map[cipher.PubKey][]routing.Route {
+	out := make(map[cipher.PubKey][]routing.Route)
+	hubV, ok := g.graph[hub]
+	if !ok {
+		return out
+	}
+	queue := []*bfsItem{{current: hubV, hops: 0}}
+	for len(queue) > 0 {
+		item := queue[0]
+		queue = queue[1:]
+
+		if item.hops >= 1 && item.hops <= maxLen {
+			pk := item.current.edge
+			if len(out[pk]) < k {
+				if r, err := buildRoute(pathFromItem(item)); err == nil {
+					out[pk] = append(out[pk], r)
+				}
+			}
+		}
+		if item.hops >= maxLen {
+			continue
+		}
+		for _, neighbor := range item.current.neighbors {
+			if itemPathContains(item, neighbor) {
+				continue
+			}
+			if conn, ok := item.current.connections[neighbor.edge]; ok && conn.Type == tptypes.DMSG {
+				continue
+			}
+			if queueCap > 0 && len(queue) >= queueCap {
+				break
+			}
+			queue = append(queue, &bfsItem{current: neighbor, parent: item, hops: item.hops + 1})
+		}
+	}
+	return out
+}
+
+// reverseRoute flips a route's direction. Transports are bidirectional and their
+// tpid is edge-symmetric (MakeTransportID sorts the edges), so the reverse of a
+// valid hub->node route is a valid node->hub route with the same tpids and
+// per-edge latencies.
+func reverseRoute(r routing.Route) routing.Route {
+	n := len(r.Hops)
+	out := routing.Route{Hops: make([]routing.Hop, n)}
+	for i, h := range r.Hops {
+		out.Hops[n-1-i] = routing.Hop{From: h.To, To: h.From, TpID: h.TpID, Latency: h.Latency}
+	}
+	return out
+}
+
+// buildLandmarks materializes the node<->hub tables from g via ~2H hub-rooted
+// BFS (one per hub; the reverse fills node->hub for free). O(H * BFS), not
+// O(pairs * BFS).
+func buildLandmarks(g *Graph) *landmarkTables {
+	hubs := selectHubs(g, defaultLandmarkHubs)
+	lt := &landmarkTables{
+		hubs:    hubs,
+		toHub:   make(map[cipher.PubKey]map[cipher.PubKey][]routing.Route),
+		fromHub: make(map[cipher.PubKey]map[cipher.PubKey][]routing.Route),
+	}
+	for _, h := range hubs {
+		fromH := g.routesFromHub(h, defaultLandmarkK, defaultLandmarkMaxLen, landmarkBFSBudget)
+		lt.fromHub[h] = fromH
+		for node, routes := range fromH {
+			if lt.toHub[node] == nil {
+				lt.toHub[node] = make(map[cipher.PubKey][]routing.Route)
+			}
+			rev := make([]routing.Route, len(routes))
+			for i, r := range routes {
+				rev[i] = reverseRoute(r)
+			}
+			lt.toHub[node][h] = rev
+		}
+	}
+	return lt
+}
+
+// ensureLandmarks builds the tables once per Graph (graphs are immutable and
+// swapped each 15s GraphCache refresh, so the tables live exactly as long as the
+// graph — same lifetime discipline as #4385's routeMemo).
+func (g *Graph) ensureLandmarks() *landmarkTables {
+	g.landmarkOnce.Do(func() { g.landmarks = buildLandmarks(g) })
+	return g.landmarks
+}
+
+// joinRoutes concatenates l (src->hub) and r (hub->dst) into one route, rejecting
+// the join if it would revisit any node (a loop across the seam). Returns ok=false
+// on a loop or a broken seam (l's end != r's start).
+func joinRoutes(l, r routing.Route) (routing.Route, bool) {
+	if len(l.Hops) == 0 || len(r.Hops) == 0 {
+		return routing.Route{}, false
+	}
+	if l.Hops[len(l.Hops)-1].To != r.Hops[0].From {
+		return routing.Route{}, false // seam doesn't meet
+	}
+	seen := make(map[cipher.PubKey]struct{}, len(l.Hops)+len(r.Hops)+1)
+	add := func(pk cipher.PubKey) bool {
+		if _, dup := seen[pk]; dup {
+			return false
+		}
+		seen[pk] = struct{}{}
+		return true
+	}
+	if !add(l.Hops[0].From) {
+		return routing.Route{}, false
+	}
+	for _, h := range l.Hops { // adds ... hub (l's last To)
+		if !add(h.To) {
+			return routing.Route{}, false
+		}
+	}
+	for _, h := range r.Hops { // r.Hops[0].From == hub already in seen; add its To's
+		if !add(h.To) {
+			return routing.Route{}, false
+		}
+	}
+	joined := routing.Route{Hops: make([]routing.Hop, 0, len(l.Hops)+len(r.Hops))}
+	joined.Hops = append(joined.Hops, l.Hops...)
+	joined.Hops = append(joined.Hops, r.Hops...)
+	return joined, true
+}
+
+// routeTpidKey is a dedupe key: the ordered tpids of a route.
+func routeTpidKey(r routing.Route) string {
+	var b bytes.Buffer
+	for i := range r.Hops {
+		b.Write(r.Hops[i].TpID[:])
+	}
+	return b.String()
+}
+
+// composeLandmark answers src->dst by joining src->hub with hub->dst over every
+// hub, loop-checking each seam, filtering to [minLen,maxLen] hops, then ranking
+// by the SAME latency weighting the base finder uses and returning up to `number`
+// distinct routes. Composing via DIFFERENT hubs yields structurally disjoint
+// legs (they share only src and dst) — what the mux wants.
+func (g *Graph) composeLandmark(lt *landmarkTables, src, dst cipher.PubKey, number, minLen, maxLen int) []routing.Route {
+	if lt == nil {
+		return nil
+	}
+	var cands []routing.Route
+	inBounds := func(r routing.Route) bool {
+		return len(r.Hops) >= minLen && len(r.Hops) <= maxLen
+	}
+	// Degenerate: src or dst IS a hub — the tables already hold the direct
+	// node<->hub routes, no composition needed.
+	if fh, ok := lt.fromHub[src]; ok {
+		for _, r := range fh[dst] {
+			if inBounds(r) {
+				cands = append(cands, r)
+			}
+		}
+	}
+	if th, ok := lt.toHub[src]; ok {
+		for _, r := range th[dst] { // dst is a hub
+			if inBounds(r) {
+				cands = append(cands, r)
+			}
+		}
+	}
+	// General case: src->hub + hub->dst.
+	srcTo := lt.toHub[src]
+	for _, h := range lt.hubs {
+		if h == src || h == dst {
+			continue
+		}
+		left := srcTo[h]
+		right := lt.fromHub[h][dst]
+		for _, l := range left {
+			for _, rr := range right {
+				if j, ok := joinRoutes(l, rr); ok && inBounds(j) {
+					cands = append(cands, j)
+				}
+			}
+		}
+	}
+	if len(cands) == 0 {
+		return nil
+	}
+	sort.SliceStable(cands, func(i, j int) bool {
+		return g.routeLatency(cands[i]) < g.routeLatency(cands[j])
+	})
+	out := make([]routing.Route, 0, number)
+	seen := make(map[string]struct{}, len(cands))
+	for _, r := range cands {
+		key := routeTpidKey(r)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, r)
+		if len(out) >= number {
+			break
+		}
+	}
+	return out
+}
+
+// routeIsLive reports whether every hop of r still exists in the current graph
+// (its tpid present on the from-vertex). A composed route built from an earlier
+// snapshot can reference a transport that a hub restart briefly dropped; the
+// tpid re-registers deterministically, but until it does we must not hand out a
+// route over a dead edge.
+func (g *Graph) routeIsLive(r routing.Route) bool {
+	for i := range r.Hops {
+		v, ok := g.graph[r.Hops[i].From]
+		if !ok {
+			return false
+		}
+		conn, ok := v.connections[r.Hops[i].To]
+		if !ok || conn.ID != r.Hops[i].TpID {
+			return false
+		}
+	}
+	return true
+}
+
+// pooledBFS runs the base latency-ranked BFS with an explicit queue cap and
+// returns the routes ranked lowest-latency-first. This is the exact pool logic
+// from computeRouteWeighted, extracted so the landmark hybrid can run it with a
+// small budget (fast-fail on far pairs) and the fallback can run it with the
+// full cap.
+func (g *Graph) pooledBFS(ctx context.Context, src, dst cipher.PubKey, minLen, maxLen, number, queueCap int) []routing.Route {
+	poolCap := number * 32
+	if poolCap < 128 {
+		poolCap = 128
+	}
+	if poolCap > 2048 {
+		poolCap = 2048
+	}
+	type scored struct {
+		route   routing.Route
+		latency float64
+	}
+	pool := make([]scored, 0, poolCap)
+	_ = g.StreamRoutesWithCap(ctx, src, dst, minLen, maxLen, queueCap, func(r routing.Route) bool {
+		pool = append(pool, scored{route: r, latency: g.routeLatency(r)})
+		return len(pool) < poolCap
+	})
+	sort.SliceStable(pool, func(i, j int) bool { return pool[i].latency < pool[j].latency })
+	out := make([]routing.Route, len(pool))
+	for i := range pool {
+		out[i] = pool[i].route
+	}
+	return out
+}
+
+// routesLandmarkHybrid is the landmark serve path. It returns (routes, true) when
+// it produced an answer, or (nil, false) to tell the caller to fall through to
+// the full exhaustive BFS (the ultimate correctness fallback).
+//
+//  1. Budget-bounded direct BFS first: a pair resolvable within landmarkBFSBudget
+//     keeps its optimal exhaustive answer — unchanged behavior for every pair the
+//     BFS can serve cheaply.
+//  2. Otherwise (the expensive/far pairs that peg the RF) compose src->hub->dst,
+//     drop any composition over a currently-dead tpid, and merge with whatever the
+//     budget BFS did find.
+//  3. If neither found anything, return false so the caller runs the full BFS.
+func (g *Graph) routesLandmarkHybrid(ctx context.Context, src, dst cipher.PubKey, minLen, maxLen, number int) ([]routing.Route, bool) {
+	directDepth := maxLen
+	if directDepth > landmarkDirectDepth {
+		directDepth = landmarkDirectDepth
+	}
+	pool := g.pooledBFS(ctx, src, dst, minLen, directDepth, number, landmarkBFSBudget)
+	if len(pool) >= number {
+		return pool[:number], true
+	}
+	lt := g.ensureLandmarks()
+	composed := g.composeLandmark(lt, src, dst, number, minLen, maxLen)
+	if len(composed) > 0 {
+		live := composed[:0]
+		for _, r := range composed {
+			if g.routeIsLive(r) {
+				live = append(live, r)
+			}
+		}
+		composed = live
+	}
+	if len(pool) == 0 && len(composed) == 0 {
+		return nil, false // let the exhaustive BFS fallback try
+	}
+	// Merge budget-BFS routes and composed routes, dedupe, rank by latency.
+	merged := make([]routing.Route, 0, len(pool)+len(composed))
+	seen := make(map[string]struct{}, len(pool)+len(composed))
+	for _, r := range append(pool, composed...) {
+		key := routeTpidKey(r)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		merged = append(merged, r)
+	}
+	sort.SliceStable(merged, func(i, j int) bool {
+		return g.routeLatency(merged[i]) < g.routeLatency(merged[j])
+	})
+	if len(merged) > number {
+		merged = merged[:number]
+	}
+	return merged, true
+}

--- a/pkg/deployment/rf/store/landmark_test.go
+++ b/pkg/deployment/rf/store/landmark_test.go
@@ -1,0 +1,200 @@
+// Package store pkg/deployment/rf/store/landmark_test.go c2-net-routing
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// pkOf builds a distinct deterministic pubkey for index i (non-zero map key).
+func pkOf(i int) cipher.PubKey {
+	var pk cipher.PubKey
+	pk[0] = 0x02
+	pk[1] = byte(i)
+	pk[2] = byte(i >> 8)
+	pk[3] = byte(i >> 16)
+	return pk
+}
+
+// buildHubGraph makes a hub-and-leaf mesh: `hubs` fully-interconnected hub nodes
+// (a clique — the combinatorial paths through it are what make an exhaustive BFS
+// expensive) plus `leaves` leaves, each attached to `linksPerLeaf` distinct hubs
+// (deterministic). A far leaf->leaf pair must transit the hub core, exactly the
+// shape landmark composition targets. All edges are STCPR with distinct tpids.
+func buildHubGraph(tb testing.TB, hubs, leaves, linksPerLeaf int) (*Graph, []cipher.PubKey, []cipher.PubKey) {
+	tb.Helper()
+	m := newMockStore()
+	hubPK := make([]cipher.PubKey, hubs)
+	for h := 0; h < hubs; h++ {
+		hubPK[h] = pkOf(h)
+	}
+	for a := 0; a < hubs; a++ {
+		for b := a + 1; b < hubs; b++ {
+			m.saveEntryLat(hubPK[a], hubPK[b], float64(1+(a+b)%5))
+		}
+	}
+	leafPK := make([]cipher.PubKey, leaves)
+	for l := 0; l < leaves; l++ {
+		leafPK[l] = pkOf(1000 + l)
+		for k := 0; k < linksPerLeaf; k++ {
+			h := (l*7 + k*3) % hubs
+			m.saveEntryLat(leafPK[l], hubPK[h], float64(2+(l+k)%7))
+		}
+	}
+	g, err := NewGraph(context.Background(), m, hubPK[0])
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return g, hubPK, leafPK
+}
+
+// validateRoute asserts r is a well-formed src->dst route: correct endpoints,
+// chained hops, loop-free, within maxLen, every hop live in g.
+func validateRoute(t *testing.T, g *Graph, r routing.Route, src, dst cipher.PubKey, maxLen int) {
+	t.Helper()
+	if len(r.Hops) == 0 {
+		t.Fatalf("empty route")
+	}
+	if len(r.Hops) > maxLen {
+		t.Fatalf("route length %d exceeds maxLen %d", len(r.Hops), maxLen)
+	}
+	if r.Hops[0].From != src {
+		t.Fatalf("route does not start at src")
+	}
+	if r.Hops[len(r.Hops)-1].To != dst {
+		t.Fatalf("route does not end at dst")
+	}
+	seen := map[cipher.PubKey]struct{}{r.Hops[0].From: {}}
+	for i, h := range r.Hops {
+		if i > 0 && r.Hops[i-1].To != h.From {
+			t.Fatalf("broken chain at hop %d", i)
+		}
+		if _, dup := seen[h.To]; dup {
+			t.Fatalf("loop: node repeats at hop %d", i)
+		}
+		seen[h.To] = struct{}{}
+		v, ok := g.graph[h.From]
+		if !ok {
+			t.Fatalf("hop %d from-vertex missing", i)
+		}
+		conn, ok := v.connections[h.To]
+		if !ok || conn.ID != h.TpID {
+			t.Fatalf("hop %d references a transport not live in the graph", i)
+		}
+	}
+}
+
+// bfs/landmark route fetch through computeRouteWeighted (skips the memo, so the
+// flag toggle takes effect on each call; the lazily-built tables are
+// flag-independent). setLandmark flips the package gate around the call.
+func routesVia(t *testing.T, g *Graph, on bool, src, dst cipher.PubKey, maxLen, number int) ([]routing.Route, error) {
+	t.Helper()
+	prev := landmarkRoutingEnabled
+	landmarkRoutingEnabled = on
+	defer func() { landmarkRoutingEnabled = prev }()
+	return g.computeRouteWeighted(context.Background(), src, dst, 0, maxLen, number, true)
+}
+
+// TestLandmarkComposeValidAndShadowsBFS: every landmark route is valid, and
+// wherever the exhaustive BFS finds a route the landmark path also finds one.
+func TestLandmarkComposeValidAndShadowsBFS(t *testing.T) {
+	g, hubPK, leafPK := buildHubGraph(t, 8, 60, 3)
+	const maxLen, number = 8, 3
+
+	pairs := [][2]cipher.PubKey{
+		{leafPK[0], leafPK[30]},
+		{leafPK[5], leafPK[45]},
+		{leafPK[12], leafPK[58]},
+		{leafPK[1], hubPK[4]},
+		{hubPK[2], leafPK[20]},
+	}
+	for _, p := range pairs {
+		src, dst := p[0], p[1]
+		bfsRoutes, bfsErr := routesVia(t, g, false, src, dst, maxLen, number)
+		lmRoutes, lmErr := routesVia(t, g, true, src, dst, maxLen, number)
+
+		if bfsErr == nil && len(bfsRoutes) > 0 {
+			if lmErr != nil || len(lmRoutes) == 0 {
+				t.Fatalf("pair %v: BFS found %d routes, landmark found none (err=%v)", src[:2], len(bfsRoutes), lmErr)
+			}
+		}
+		for _, r := range lmRoutes {
+			validateRoute(t, g, r, src, dst, maxLen)
+		}
+	}
+}
+
+// TestLandmarkDisjointLegs: a far pair's two best legs are not fully overlapping
+// in intermediates — distinct-hub composition gives the mux disjoint legs.
+func TestLandmarkDisjointLegs(t *testing.T) {
+	g, _, leafPK := buildHubGraph(t, 8, 60, 3)
+	routes, err := routesVia(t, g, true, leafPK[3], leafPK[40], 8, 3)
+	if err != nil || len(routes) < 2 {
+		t.Skipf("need >=2 routes (got %d, err=%v)", len(routes), err)
+	}
+	inter := func(r routing.Route) map[cipher.PubKey]struct{} {
+		s := map[cipher.PubKey]struct{}{}
+		for i, h := range r.Hops {
+			if i < len(r.Hops)-1 {
+				s[h.To] = struct{}{}
+			}
+		}
+		return s
+	}
+	a, b := inter(routes[0]), inter(routes[1])
+	overlap := 0
+	for pk := range a {
+		if _, ok := b[pk]; ok {
+			overlap++
+		}
+	}
+	if len(a) > 0 && overlap == len(a) {
+		t.Errorf("two legs share all intermediates — not disjoint")
+	}
+}
+
+// TestLandmarkClosePairParity: a close pair keeps its optimal short route length
+// under the landmark hybrid (budget-BFS-first must not lengthen near pairs).
+func TestLandmarkClosePairParity(t *testing.T) {
+	g, hubPK, leafPK := buildHubGraph(t, 8, 60, 3)
+	src, dst := leafPK[0], hubPK[0] // leaf 0 attaches to hub 0 directly
+	bfs, err := routesVia(t, g, false, src, dst, 8, 3)
+	if err != nil || len(bfs) == 0 {
+		t.Fatalf("BFS: %v", err)
+	}
+	lm, err := routesVia(t, g, true, src, dst, 8, 3)
+	if err != nil || len(lm) == 0 {
+		t.Fatalf("landmark: %v", err)
+	}
+	if len(lm[0].Hops) != len(bfs[0].Hops) {
+		t.Errorf("close-pair best-route length differs: BFS=%d landmark=%d", len(bfs[0].Hops), len(lm[0].Hops))
+	}
+}
+
+// BenchmarkRouteFarPair_FullBFS vs _Landmark: a far (src,dst) on a dense layered
+// mesh — the shape where the exhaustive BFS is expensive. Landmark serves it via
+// shallow-BFS-fast-fail + hub composition. Tables are pre-built (amortized once
+// per graph in production) so the benchmark measures the SERVE cost.
+func BenchmarkRouteFarPair_FullBFS(b *testing.B) {
+	g, src, dst := buildDenseGraph(b, 6, 6)
+	landmarkRoutingEnabled = false
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = g.computeRouteWeighted(context.Background(), src, dst, 0, 8, 3, true)
+	}
+}
+
+func BenchmarkRouteFarPair_Landmark(b *testing.B) {
+	g, src, dst := buildDenseGraph(b, 6, 6)
+	landmarkRoutingEnabled = true
+	g.ensureLandmarks() // amortized once per graph; measure serve only
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = g.computeRouteWeighted(context.Background(), src, dst, 0, 8, 3, true)
+	}
+}

--- a/pkg/deployment/rf/store/mark_and_sweep.go
+++ b/pkg/deployment/rf/store/mark_and_sweep.go
@@ -66,6 +66,12 @@ type Graph struct {
 	// (churning clients re-asking for the same src→dst) from a full
 	// exhaustive BFS each time to one BFS per unique request per cycle.
 	routeMemo sync.Map
+	// landmarks holds the precomputed node<->hub route tables for landmark
+	// (transit-node) routing (landmark.go), built once per graph via
+	// landmarkOnce. Like routeMemo, lifetime == this graph's, so no explicit
+	// invalidation is needed. nil until first use / when the feature is off.
+	landmarks    *landmarkTables
+	landmarkOnce sync.Once
 }
 
 // NewGraph creates a new Graph accessing given transport store, such Graph is created by exploring


### PR DESCRIPTION
The route-finder answered each `(src,dst)` with an exhaustive BFS over the dense transport graph; a single far/hard pair was measured at **~8.4s of CPU** and pegged the RF host at 258%. #4380 (cached graph) and #4385 (per-graph result memo) removed the graph build and the repeat BFS, but the *first* search of any pair was still exhaustive.

This exploits the mesh's few very-high-degree hubs (which most routes already transit) plus deterministic tpids: precompute routes between every node and the top-degree hubs once per graph (`~2H` hub-rooted BFS, ~10MB tables), then answer a far pair by **composing** `src->hub` + `hub->dst` — `~H*K*K` cheap concatenations instead of a graph-wide search.

Serve is a hybrid: a shallow (depth-3) direct BFS keeps the optimal answer for near pairs; far pairs compose; a composition miss still falls through to the full BFS, so nothing regresses. Composing via different hubs yields disjoint mux legs for free; a tpid liveness filter rides out hub restart waves.

Default on (`RF_LANDMARK_ROUTING=0` to revert). Coexists with #4380/#4385 (the memo caches composed results unchanged).

**Benchmark** (dense mesh, far pair): serve **16.9ms → 0.47ms (36×)**, 97k → 1.3k allocs/op — the gap is far larger on the real graph's multi-second cases. **Tests:** composed routes valid + loop-free, shadow-BFS coverage, close-pair length parity, disjoint legs. `go test ./pkg/deployment/rf/... -race` green.

Follow-ups (deferred): build tables in `GraphCache.Rebuild` for zero first-request latency; shadow-compare metrics before dropping the BFS fallback; compact tables to tpid-only.