### PR TITLE
perf(tpd): cut transient allocations in buildTransportMetrics

### DIFF
--- a/pkg/deployment/tpd/store/redis_metrics.go
+++ b/pkg/deployment/tpd/store/redis_metrics.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -627,6 +628,14 @@ func (s *redisStore) GetTransportMetricsByVisors(ctx context.Context, pks []ciph
 	return s.buildTransportMetrics(ctx, entries, nil, query)
 }
 
+// parseBWUint parses a decimal bandwidth counter, returning 0 on malformed
+// input. It replaces fmt.Sscanf in the hot per-(entry×day) loop, which
+// allocated a reflect-based scan state on every call.
+func parseBWUint(s string) uint64 {
+	v, _ := strconv.ParseUint(s, 10, 64)
+	return v
+}
+
 // buildTransportMetrics builds TransportMetric slice from entries.
 // Uses Redis pipelining for efficient bulk fetching.
 func (s *redisStore) buildTransportMetrics(ctx context.Context, entries []*transport.Entry, expiredIDs map[uuid.UUID]bool, query MetricsQuery) ([]TransportMetric, error) {
@@ -673,6 +682,14 @@ func (s *redisStore) buildTransportMetrics(ctx context.Context, entries []*trans
 		return []TransportMetric{}, nil
 	}
 
+	// Precompute uuid.String() once per entry — it was re-run per (entry × day)
+	// building the daily-bandwidth keys below AND again per entry at the end.
+	// On the 30-day window over ~13k transports that is ~390k → ~13k calls.
+	idStrs := make([]string, len(filtered))
+	for i := range filtered {
+		idStrs[i] = filtered[i].entry.ID.String()
+	}
+
 	// Fetch latency data via pipeline. Reads the durable lat:<id> key
 	// (35-day TTL) rather than the tp:<id> registration blob — survives
 	// the 5-minute registration churn that bandwidth has always survived.
@@ -688,21 +705,32 @@ func (s *redisStore) buildTransportMetrics(ctx context.Context, entries []*trans
 
 	// Fetch bandwidth data via pipeline
 	type bwKey struct {
-		idx     int
-		dayIdx  int
-		dateStr string
+		idx    int
+		dayIdx int
 	}
 	var bwKeys []bwKey
 	var bwResults []*redis.StringStringMapCmd
+	// dateStrs[d] is the "2006-01-02" string for day d; shared across all
+	// entries so it is formatted `days` times, not once per (entry × day).
+	var dateStrs []string
 
 	if query.Bandwidth {
+		dateStrs = make([]string, days)
+		for d := 0; d < days; d++ {
+			dateStrs[d] = now.AddDate(0, 0, -d).Format("2006-01-02")
+		}
+		n := len(filtered) * days
+		bwKeys = make([]bwKey, 0, n)
+		bwResults = make([]*redis.StringStringMapCmd, 0, n)
 		pipe := s.client.Pipeline()
-		for i, f := range filtered {
+		for i := range filtered {
+			idStr := idStrs[i]
 			for d := 0; d < days; d++ {
-				t := now.AddDate(0, 0, -d)
-				dateStr := t.Format("2006-01-02")
-				key := s.bandwidthDailyKey(f.entry.ID.String(), t)
-				bwKeys = append(bwKeys, bwKey{idx: i, dayIdx: d, dateStr: dateStr})
+				// Same key as bandwidthDailyKey ("<svc>:bw:daily:<id>:<date>")
+				// but built by concat (single alloc, no fmt reflection) with the
+				// id + date precomputed above rather than re-formatting per day.
+				key := serviceName + ":bw:daily:" + idStr + ":" + dateStrs[d]
+				bwKeys = append(bwKeys, bwKey{idx: i, dayIdx: d})
 				bwResults = append(bwResults, pipe.HGetAll(ctx, key))
 			}
 		}
@@ -711,39 +739,50 @@ func (s *redisStore) buildTransportMetrics(ctx context.Context, entries []*trans
 
 	// Build bandwidth lookup map: entryIdx -> []DailyEdgeBandwidth
 	bwByEntry := make(map[int][]DailyEdgeBandwidth)
+	// Edge hexes and the four field keys depend only on the entry, and bwKeys
+	// are built strictly entry-major, so compute them once per entry (was per
+	// entry × day-with-data — ~390k → ~13k Hex() calls + key concats).
+	lastIdx := -1
+	var kASent, kARecv, kBSent, kBRecv string
 	for i, bk := range bwKeys {
 		result, err := bwResults[i].Result()
 		if err != nil || len(result) == 0 {
 			continue
 		}
 
-		f := filtered[bk.idx]
-		edgeAHex := f.entry.Edges[0].Hex()
-		edgeBHex := f.entry.Edges[1].Hex()
+		if bk.idx != lastIdx {
+			f := filtered[bk.idx]
+			edgeAHex := f.entry.Edges[0].Hex()
+			edgeBHex := f.entry.Edges[1].Hex()
+			kASent, kARecv = edgeAHex+":sent", edgeAHex+":recv"
+			kBSent, kBRecv = edgeBHex+":sent", edgeBHex+":recv"
+			lastIdx = bk.idx
+		}
 
 		// Try to read per-reporter sent/recv fields (new format)
 		var aSent, aRecv, bSent, bRecv uint64
 		hasPerEdge := false
-		if val, ok := result[edgeAHex+":sent"]; ok {
-			fmt.Sscanf(val, "%d", &aSent) //nolint:errcheck,gosec
+		if val, ok := result[kASent]; ok {
+			aSent = parseBWUint(val)
 			hasPerEdge = true
 		}
-		if val, ok := result[edgeAHex+":recv"]; ok {
-			fmt.Sscanf(val, "%d", &aRecv) //nolint:errcheck,gosec
+		if val, ok := result[kARecv]; ok {
+			aRecv = parseBWUint(val)
 			hasPerEdge = true
 		}
-		if val, ok := result[edgeBHex+":sent"]; ok {
-			fmt.Sscanf(val, "%d", &bSent) //nolint:errcheck,gosec
+		if val, ok := result[kBSent]; ok {
+			bSent = parseBWUint(val)
 			hasPerEdge = true
 		}
-		if val, ok := result[edgeBHex+":recv"]; ok {
-			fmt.Sscanf(val, "%d", &bRecv) //nolint:errcheck,gosec
+		if val, ok := result[kBRecv]; ok {
+			bRecv = parseBWUint(val)
 			hasPerEdge = true
 		}
 
+		dateStr := dateStrs[bk.dayIdx]
 		if hasPerEdge && (aSent+aRecv+bSent+bRecv) > 0 {
 			dailyMetric := DailyEdgeBandwidth{
-				Date: bk.dateStr,
+				Date: dateStr,
 				A:    &EdgeBandwidth{Sent: aSent, Recv: aRecv},
 				B:    &EdgeBandwidth{Sent: bSent, Recv: bRecv},
 			}
@@ -752,12 +791,12 @@ func (s *redisStore) buildTransportMetrics(ctx context.Context, entries []*trans
 			// Fallback for old data: split combined total equally
 			var bw uint64
 			if val, ok := result["bandwidth"]; ok {
-				fmt.Sscanf(val, "%d", &bw) //nolint:errcheck,gosec
+				bw = parseBWUint(val)
 			}
 			if bw > 0 {
 				halfBW := bw / 2
 				dailyMetric := DailyEdgeBandwidth{
-					Date: bk.dateStr,
+					Date: dateStr,
 					A:    &EdgeBandwidth{Sent: halfBW, Recv: halfBW},
 					B:    &EdgeBandwidth{Sent: halfBW, Recv: halfBW},
 				}
@@ -767,10 +806,10 @@ func (s *redisStore) buildTransportMetrics(ctx context.Context, entries []*trans
 	}
 
 	// Build results
-	var results []TransportMetric
+	results := make([]TransportMetric, 0, len(filtered))
 	for i, f := range filtered {
 		metric := TransportMetric{
-			ID:    f.entry.ID.String(),
+			ID:    idStrs[i],
 			Type:  string(f.entry.Type),
 			Live:  f.isLive,
 			Daily: bwByEntry[i],

--- a/pkg/deployment/tpd/store/redis_metrics_bench_test.go
+++ b/pkg/deployment/tpd/store/redis_metrics_bench_test.go
@@ -1,0 +1,114 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The benchmarks below isolate the per-(entry × day) hot path of
+// buildTransportMetrics: the daily-bandwidth key generation and the per-edge
+// counter parsing. They model the shape of the real workload (~13k transports
+// over a 30-day window) without a live Redis, so the allocation delta between
+// the old (fmt-based, per-iteration) and new (precomputed + concat + strconv)
+// code is directly measurable with `-benchmem`.
+
+const (
+	benchEntries = 13000
+	benchDays    = 30
+)
+
+func benchIDs(n int) []uuid.UUID {
+	ids := make([]uuid.UUID, n)
+	for i := range ids {
+		// Deterministic, distinct UUIDs (no rand — unavailable in this env).
+		var u uuid.UUID
+		u[0] = byte(i)
+		u[1] = byte(i >> 8)
+		u[15] = 0x42
+		ids[i] = u
+	}
+	return ids
+}
+
+// old key path: uuid.String() + time.Format() + fmt.Sprintf, every iteration.
+func BenchmarkBWKeygen_Old(b *testing.B) {
+	ids := benchIDs(benchEntries)
+	now := time.Now().UTC()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink int
+	for n := 0; n < b.N; n++ {
+		for i := range ids {
+			for d := 0; d < benchDays; d++ {
+				date := now.AddDate(0, 0, -d).Format("2006-01-02")
+				key := fmt.Sprintf("%s:bw:daily:%s:%s", serviceName, ids[i].String(), date)
+				sink += len(key)
+			}
+		}
+	}
+	_ = sink
+}
+
+// new key path: precompute idStr once per entry, dateStr once per window, concat.
+func BenchmarkBWKeygen_New(b *testing.B) {
+	ids := benchIDs(benchEntries)
+	now := time.Now().UTC()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink int
+	for n := 0; n < b.N; n++ {
+		dateStrs := make([]string, benchDays)
+		for d := 0; d < benchDays; d++ {
+			dateStrs[d] = now.AddDate(0, 0, -d).Format("2006-01-02")
+		}
+		idStrs := make([]string, len(ids))
+		for i := range ids {
+			idStrs[i] = ids[i].String()
+		}
+		for i := range ids {
+			idStr := idStrs[i]
+			for d := 0; d < benchDays; d++ {
+				key := serviceName + ":bw:daily:" + idStr + ":" + dateStrs[d]
+				sink += len(key)
+			}
+		}
+	}
+	_ = sink
+}
+
+// old parse path: fmt.Sscanf per counter field (4 per day-with-data).
+func BenchmarkBWParse_Old(b *testing.B) {
+	vals := []string{"1048576", "2097152", "524288", "0"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink uint64
+	for n := 0; n < b.N; n++ {
+		for i := 0; i < benchEntries; i++ {
+			for _, v := range vals {
+				var x uint64
+				_, _ = fmt.Sscanf(v, "%d", &x)
+				sink += x
+			}
+		}
+	}
+	_ = sink
+}
+
+// new parse path: strconv.ParseUint per counter field.
+func BenchmarkBWParse_New(b *testing.B) {
+	vals := []string{"1048576", "2097152", "524288", "0"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink uint64
+	for n := 0; n < b.N; n++ {
+		for i := 0; i < benchEntries; i++ {
+			for _, v := range vals {
+				sink += parseBWUint(v)
+			}
+		}
+	}
+	_ = sink
+}


### PR DESCRIPTION
The CXO metrics publisher rebuilds transport metrics every 60s/5min/30min window, and `buildTransportMetrics` is the top TPD-controllable allocator on the reward/discovery host (per the alloc profile). It feeds the RSS balloon there — RSS sits well above live heap because this per-window garbage outruns GC and Go doesn't return the pages.

Behaviour is unchanged; the Redis keys and parsed values are byte-identical. Four hoists in the per-(entry × day) hot path over ~13k transports × up to 35 days:

- precompute `uuid.String()` once per entry (was per entry × day, and again in the results loop)
- format each day's date string once for the whole window (was per entry × day)
- build the daily-bandwidth key by concat with those precomputed parts instead of `fmt.Sprintf` (same `<svc>:bw:daily:<id>:<date>` key)
- compute the two edge hexes and four field keys once per entry via a `lastIdx` cache (keys are entry-major), and replace `fmt.Sscanf` with `strconv.ParseUint` (zero-alloc)
- preallocate `bwKeys` / `bwResults` / `results` to known capacity

Isolated benchmarks over the 13k × 30 shape (`redis_metrics_bench_test.go`):

| hot path | allocs/op | bytes/op | ns/op |
|---|---|---|---|
| key-gen old | 1,950,178 | 68.7 MB | 257 ms |
| key-gen new | 403,032 (−79%) | 32.0 MB (−53%) | 36.5 ms |
| parse old | 195,005 | 4.06 MB | 32.7 ms |
| parse new | 0 | 0 | 1.17 ms |

~1.75M fewer allocations and ~40 MB less transient garbage per metrics build.

`go test ./pkg/deployment/tpd/... ./pkg/cxo/... -race` green; `go build .` clean.