### PR TITLE
fix(router): stop SACK retransmit storms — per-seq retx backoff + RTT-floored RACK ceiling

### DIFF
--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -1188,8 +1188,21 @@ func (m *routeMux) rackThreshold() time.Duration {
 	if th < rackFloor {
 		th = rackFloor
 	}
-	if th > rackCeil {
-		th = rackCeil
+	// The absolute ceiling bounds the wait for a genuine loss, but it must
+	// never undercut one measured RTT: when queueing delay inflates the
+	// slow-leg EWMA past rackCeil (bufferbloat under load can push it to many
+	// seconds), presuming loss at a fixed 1.5s declares EVERY in-flight packet
+	// lost forever — the observed retransmit storm, which the DSACK-widened
+	// factor could not counter because this same clamp overrode it. Floor the
+	// ceiling at one measured RTT: waiting less than one RTT for an ack is
+	// definitionally spurious, and the wait stays bounded (max(rackCeil, RTT))
+	// rather than unbounded.
+	ceil := rackCeil
+	if rttDur := time.Duration(maxRtt) * time.Millisecond; rttDur > ceil {
+		ceil = rttDur
+	}
+	if th > ceil {
+		th = ceil
 	}
 	return th
 }

--- a/pkg/router/sack.go
+++ b/pkg/router/sack.go
@@ -2,6 +2,7 @@
 package router
 
 import (
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -171,7 +172,23 @@ type retxEntry struct {
 	seq    uint32
 	data   []byte
 	sentAt time.Time
+	// lastTxAt is when this sequence was last handed out for retransmission
+	// (zero until the first retx). retxCount is how many times it has been.
+	// Together they gate re-retransmission: without them every SACK arriving
+	// within one bloated RTT re-selects the same overdue hole (SACKs come every
+	// ~25ms, a queued-up path can hold a seq for many seconds), and the same
+	// packet is resent hundreds of times — the observed 20×+ wire amplification
+	// of a retransmit storm.
+	lastTxAt  time.Time
+	retxCount uint8
 }
+
+// retxBackoffMaxShift caps the per-entry exponential backoff between successive
+// retransmissions of the SAME sequence at threshold×2^this. Doubling with a cap
+// bounds the worst-case waste per sequence at ~4 copies even when the loss
+// threshold underestimates the true (bufferbloated) RTT, while a genuinely lost
+// retransmit is still retried on a TCP-like doubling schedule.
+const retxBackoffMaxShift = 3
 
 // retxBuffer is a bounded buffer of unacknowledged sent packets for
 // retransmission on SACK-detected loss.
@@ -258,6 +275,15 @@ func (rb *retxBuffer) ProcessSACK(lastContiguous uint32, words []uint64, thresho
 	// retransmitting it would be the spurious self-amplifying storm retxMinAge
 	// exists to prevent). Sequences ABOVE the covered window are left in place:
 	// they are the still-in-flight tail the receiver has not reported yet.
+	//
+	// A hole is aged from its LAST transmission (original send or most recent
+	// retx), with per-entry exponential backoff — otherwise a seq that crossed
+	// the threshold once is re-selected by every subsequent SACK until acked,
+	// and under a feedback delay of several RTTs that is a self-sustaining
+	// retransmit storm. Selection marks the entry here, under rb.mu, so the
+	// decision and the mark are atomic; if the caller then fails to send (no
+	// active leg), the seq simply retries after its backoff.
+	now := time.Now()
 	var retransmit []uint32
 	for w, word := range words {
 		base := lastContiguous + 1 + uint32(w)*64
@@ -265,8 +291,22 @@ func (rb *retxBuffer) ProcessSACK(lastContiguous uint32, words []uint64, thresho
 			checkSeq := base + i
 			if word&(1<<i) != 0 {
 				delete(rb.entries, checkSeq)
-			} else if e, ok := rb.entries[checkSeq]; ok && time.Since(e.sentAt) >= threshold {
-				retransmit = append(retransmit, checkSeq)
+			} else if e, ok := rb.entries[checkSeq]; ok {
+				ref := e.sentAt
+				if e.lastTxAt.After(ref) {
+					ref = e.lastTxAt
+				}
+				shift := e.retxCount
+				if shift > retxBackoffMaxShift {
+					shift = retxBackoffMaxShift
+				}
+				if now.Sub(ref) >= threshold<<shift {
+					retransmit = append(retransmit, checkSeq)
+					e.lastTxAt = now
+					if e.retxCount < math.MaxUint8 {
+						e.retxCount++
+					}
+				}
 			}
 		}
 	}

--- a/pkg/router/sack_test.go
+++ b/pkg/router/sack_test.go
@@ -128,6 +128,54 @@ func TestRetxBuffer_RetransmitList(t *testing.T) {
 	assert.NotContains(t, retx, uint32(6))
 }
 
+// TestRetxBuffer_RetxBackoffSuppressesDuplicates is the retransmit-storm
+// regression: SACKs arrive every ~25ms, so an overdue hole must be handed out
+// ONCE and then suppressed until its per-entry backoff (threshold, then
+// doubling) elapses — not re-selected by every subsequent SACK for as long as
+// the ack takes to come back. Without the suppression a single hole on a path
+// with seconds of queueing delay is retransmitted hundreds of times.
+func TestRetxBuffer_RetxBackoffSuppressesDuplicates(t *testing.T) {
+	rb := newRetxBuffer(128)
+	rb.Store(3, []byte{3})
+	rb.entries[3].sentAt = time.Now().Add(-2 * retxMinAge)
+
+	// SACK: lastContiguous=2, seq 3 missing, seq 4 received.
+	sack := func() []uint32 { return rb.ProcessSACK(2, []uint64{0b10}, 0) }
+
+	assert.Equal(t, []uint32{3}, sack(), "overdue hole selected on first SACK")
+	assert.Empty(t, sack(), "immediate duplicate SACK must not re-select it")
+	assert.Empty(t, sack())
+
+	// backdate ages the entry's last transmission (both stamps — the selector
+	// keys off the LATER of the two) so the next due-check sees `d` elapsed.
+	backdate := func(d time.Duration) {
+		rb.entries[3].sentAt = time.Now().Add(-d)
+		rb.entries[3].lastTxAt = rb.entries[3].sentAt
+	}
+
+	// After one backoff interval (2×threshold for the 2nd retx) it is due again.
+	backdate(2*retxMinAge + time.Millisecond)
+	assert.Equal(t, []uint32{3}, sack(), "re-selected once the backoff elapses")
+	assert.Empty(t, sack(), "and suppressed again right after")
+
+	// Backoff doubles per retx: the 3rd needs 4×threshold, so 2× is not enough.
+	backdate(2*retxMinAge + time.Millisecond)
+	assert.Empty(t, sack(), "doubled backoff not yet elapsed")
+	backdate(4*retxMinAge + time.Millisecond)
+	assert.Equal(t, []uint32{3}, sack())
+
+	// The cap: retxCount keeps growing but the wait is bounded at
+	// threshold<<retxBackoffMaxShift.
+	for i := 0; i < 10; i++ {
+		backdate(retxMinAge << (retxBackoffMaxShift + 1))
+		assert.Equal(t, []uint32{3}, sack(), "capped backoff stays retryable")
+	}
+
+	// An ack finally purges it regardless of retx state.
+	assert.Empty(t, rb.ProcessSACK(2, []uint64{0b11}, 0))
+	assert.Nil(t, rb.Get(3))
+}
+
 // TestRetxBuffer_CapacityEvictsLowest verifies the full-buffer path now evicts
 // the lowest (oldest, already force-flushed on the receiver) sequence and keeps
 // the newest, instead of silently refusing to store the newest packet.


### PR DESCRIPTION
Under load, queueing delay inflates the mux's in-band RTT far past rackCeil (6–19s observed), so the fixed 1.5s clamp declares every in-flight packet lost — and ProcessSACK re-selected the same overdue holes on every ~25ms SACK, since retx entries were never re-stamped on retransmit. Measured live before the fix: 93% of sent packets were retransmits (50MB wire for 8.6MB goodput) until tunnel liveness tore the stream down.

Two changes: retx entries carry lastTxAt/retxCount and back off exponentially (threshold, ×2 per retx, capped at 8×), and rackThreshold's ceiling is floored at one measured RTT so the DSACK-widened reorder factor is no longer overridden by the absolute clamp. No wire-format change; safe to deploy asymmetrically.

Validated live on a 4-leg mux (20MB upload through skysocks-client, peer unfixed): effective throughput 118→387KB/s, wire amplification 6×→2×, retransmit log bursts 148→59. Remaining under-load resets trace to the unfixed peer plus the absent send-window bound (follow-up).