### PR TITLE
feat(dmsg): per-carrier server probe, carrier-preserving conf pull, fix quic-erasing Protocol stomp

### DIFF
--- a/cmd/dmsg/conf/commands/commands_test.go
+++ b/cmd/dmsg/conf/commands/commands_test.go
@@ -9,6 +9,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 	"strings"
@@ -102,6 +103,37 @@ func TestFormatDmsgServers(t *testing.T) {
 func TestFormatDmsgServersSingle(t *testing.T) {
 	out := formatDmsgServers([]*disc.Entry{entry(t, "3.3.3.3:80")})
 	assert.Equal(t, 0, strings.Count(out, "},"))
+}
+
+// TestFormatDmsgServersOptionalEndpoints verifies the pull format PRESERVES the
+// optional advertised endpoints — address_ws, address_udp, protocol. Dropping
+// address_ws (the pre-fix behavior) left the embedded snapshot with no wss://
+// URLs, so an HTTPS-served wasm-visor could only bootstrap from the few servers
+// whose entries were hand-edited. WT fields must stay out: cert_hash_wt rotates.
+func TestFormatDmsgServersOptionalEndpoints(t *testing.T) {
+	e := entry(t, "4.4.4.4:30080")
+	e.Protocol = "quic"
+	e.Server.AddressUDP = "4.4.4.4:30080"
+	e.Server.AddressWS = "wss://example.test/dmsg"
+	e.Server.AddressWT = "https://4.4.4.4:30080/dmsg"
+	e.Server.CertHashWT = "deadbeef"
+
+	out := formatDmsgServers([]*disc.Entry{e})
+
+	assert.Contains(t, out, `"protocol": "quic"`)
+	assert.Contains(t, out, `"address_udp": "4.4.4.4:30080"`)
+	assert.Contains(t, out, `"address_ws": "wss://example.test/dmsg"`)
+	assert.NotContains(t, out, "address_wt")
+	assert.NotContains(t, out, "cert_hash_wt")
+
+	// The rendered block must round-trip as JSON with the fields intact.
+	var parsed struct {
+		DmsgServers []disc.Entry `json:"dmsg_servers"`
+	}
+	require.NoError(t, json.Unmarshal([]byte("{"+out+"}"), &parsed))
+	require.Len(t, parsed.DmsgServers, 1)
+	assert.Equal(t, "quic", parsed.DmsgServers[0].Protocol)
+	assert.Equal(t, "wss://example.test/dmsg", parsed.DmsgServers[0].Server.AddressWS)
 }
 
 const sampleConfig = `{

--- a/cmd/dmsg/conf/commands/probe.go
+++ b/cmd/dmsg/conf/commands/probe.go
@@ -1,0 +1,312 @@
+// Package commands cmd/dmsg/conf/commands/probe.go c1-net-dmsg
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/direct"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+var (
+	probeTimeout  time.Duration
+	probeEmbedded bool
+	probeServerPK string
+	probeCarriers []string
+	probeJSON     bool
+	probeParallel int
+)
+
+func init() {
+	probeCmd.Flags().DurationVar(&probeTimeout, "timeout", 20*time.Second, "per-probe timeout (one carrier of one server)")
+	probeCmd.Flags().BoolVar(&probeEmbedded, "embedded", false, "probe the embedded server set instead of the live discovery list")
+	probeCmd.Flags().StringVar(&probeServerPK, "server", "", "probe only the server with this public key")
+	probeCmd.Flags().StringSliceVar(&probeCarriers, "carrier", nil, "carriers to probe (tcp,quic,ws,wt); default: every carrier the server advertises")
+	probeCmd.Flags().BoolVar(&probeJSON, "json", false, "emit results as JSON")
+	probeCmd.Flags().IntVar(&probeParallel, "parallel", 8, "concurrent probes")
+	RootCmd.AddCommand(probeCmd)
+}
+
+// probeResult is one carrier probe of one server.
+type probeResult struct {
+	PK        string `json:"pk"`
+	Carrier   string `json:"carrier"` // tcp | quic | ws | wss | wt
+	Addr      string `json:"addr"`
+	OK        bool   `json:"ok"`
+	LatencyMs int64  `json:"latency_ms"`
+	Err       string `json:"error,omitempty"`
+}
+
+var probeCmd = &cobra.Command{
+	Use:   "probe",
+	Short: "Probe every advertised carrier of every dmsg server with a real session",
+	Long: `Establish a REAL dmsg session (Noise handshake included) with each dmsg
+server over each carrier its discovery entry advertises — tcp, quic,
+ws/wss (the browser WebSocket carrier), and wt (WebTransport) — and
+report per-carrier reachability and session-establishment latency.
+
+This dials exactly what a client of that carrier would dial: the wss
+probe validates the TLS front + WebSocket upgrade + Noise handshake a
+browser wasm-visor performs, not just a TCP connect.
+
+Server entries come from the live discovery (fetched over dmsg, like
+'conf pull') unless --embedded selects the set embedded in this binary.`,
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableFlagsInUseLine: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		entries, err := probeEntrySet()
+		if err != nil {
+			return err
+		}
+		if probeServerPK != "" {
+			var pk cipher.PubKey
+			if err := pk.Set(probeServerPK); err != nil {
+				return fmt.Errorf("invalid --server public key: %w", err)
+			}
+			filtered := entries[:0]
+			for _, e := range entries {
+				if e.Static == pk {
+					filtered = append(filtered, e)
+				}
+			}
+			entries = filtered
+			if len(entries) == 0 {
+				return fmt.Errorf("server %s not in the %s set", pk, probeSourceName())
+			}
+		}
+		sort.Slice(entries, func(i, j int) bool { return entries[i].Static.Hex() < entries[j].Static.Hex() })
+
+		type job struct {
+			entry   *disc.Entry
+			carrier string
+		}
+		var jobs []job
+		for _, e := range entries {
+			for _, c := range carriersOf(e) {
+				if len(probeCarriers) > 0 && !carrierRequested(c) {
+					continue
+				}
+				jobs = append(jobs, job{entry: e, carrier: c})
+			}
+		}
+		if len(jobs) == 0 {
+			return fmt.Errorf("nothing to probe (no advertised carrier matches the filter)")
+		}
+
+		results := make([]probeResult, len(jobs))
+		sem := make(chan struct{}, probeParallel)
+		var wg sync.WaitGroup
+		for i, j := range jobs {
+			wg.Add(1)
+			go func(i int, j job) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				results[i] = probeOne(j.entry, j.carrier)
+			}(i, j)
+		}
+		wg.Wait()
+
+		if probeJSON {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(results)
+		}
+		printProbeTable(entries, results)
+		for _, r := range results {
+			if !r.OK {
+				os.Exit(1)
+			}
+		}
+		return nil
+	},
+}
+
+func probeSourceName() string {
+	if probeEmbedded {
+		return "embedded"
+	}
+	return "discovery"
+}
+
+// probeEntrySet returns the server entries to probe: the live discovery list
+// (over dmsg, the same fetch 'conf pull' does) or the embedded set.
+func probeEntrySet() ([]*disc.Entry, error) {
+	if probeEmbedded {
+		entries := deployment.Prod.ToDiscEntries()
+		if len(entries) == 0 {
+			return nil, fmt.Errorf("no embedded dmsg servers")
+		}
+		return entries, nil
+	}
+	// Reaching the discovery over dmsg means guessing a relay server it is
+	// connected to (it publishes no client entry of its own), so a fetch can
+	// fail with "202 - cannot connect to delegated server" purely by drawing an
+	// unlucky relay. Each retry bootstraps fresh sessions and redraws.
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		entries, ferr := fetchAllServersOverDmsg(ctx)
+		cancel()
+		if ferr == nil {
+			return entries, nil
+		}
+		err = ferr
+	}
+	return nil, fmt.Errorf("fetch all_servers over dmsg (3 attempts; use --embedded to skip): %w", err)
+}
+
+// carriersOf lists the carriers entry advertises, in probe order. The ws
+// carrier is reported as wss when the advertised URL is TLS-fronted.
+func carriersOf(e *disc.Entry) []string {
+	var cs []string
+	if e.Server.Address != "" {
+		cs = append(cs, dmsg.CarrierTCP)
+	}
+	if e.Protocol == "quic" && e.Server.AddressUDP != "" {
+		cs = append(cs, dmsg.CarrierQUIC)
+	}
+	if e.Server.AddressWS != "" {
+		cs = append(cs, dmsg.CarrierWS)
+	}
+	if e.Server.AddressWT != "" {
+		cs = append(cs, dmsg.CarrierWT)
+	}
+	return cs
+}
+
+func carrierRequested(c string) bool {
+	for _, want := range probeCarriers {
+		w := strings.ToLower(strings.TrimSpace(want))
+		if w == c || (w == "wss" && c == dmsg.CarrierWS) {
+			return true
+		}
+	}
+	return false
+}
+
+// probeOne establishes one session with entry over exactly the given carrier
+// (Carriers=[c] has no cross-carrier fallback) and reports the outcome.
+func probeOne(entry *disc.Entry, carrier string) probeResult {
+	e := *entry // copy: the client mutates nothing, but keep probes independent
+	label := dmsg.ProtocolLabel(carrier, carrierAddr(&e, carrier))
+	res := probeResult{PK: e.Static.Hex(), Carrier: label, Addr: carrierAddr(&e, carrier)}
+
+	log := logging.MustGetLogger("dmsg-conf-probe")
+	pk, sk := cipher.GenerateKeyPair()
+	dClient := direct.NewClient(direct.GetAllEntries(cipher.PubKeys{pk}, []*disc.Entry{&e}), log)
+
+	// Surface the real dial failure: StartDmsg retries until ctx expires and
+	// then returns a generic error, so capture the per-dial error instead.
+	var mu sync.Mutex
+	var lastErr error
+	conf := dmsg.DefaultConfig()
+	conf.MinSessions = 1
+	conf.Carriers = []string{carrier}
+	conf.Callbacks = &dmsg.ClientCallbacks{
+		OnSessionDisconnect: func(_, _ string, err error) {
+			if err != nil {
+				mu.Lock()
+				lastErr = err
+				mu.Unlock()
+			}
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+	defer cancel()
+	start := time.Now()
+	_, stop, err := direct.StartDmsg(ctx, log, pk, sk, dClient, conf)
+	if err != nil {
+		mu.Lock()
+		if lastErr != nil {
+			err = lastErr
+		}
+		mu.Unlock()
+		res.Err = err.Error()
+		return res
+	}
+	res.OK = true
+	res.LatencyMs = time.Since(start).Milliseconds()
+	stop()
+	return res
+}
+
+func carrierAddr(e *disc.Entry, carrier string) string {
+	switch carrier {
+	case dmsg.CarrierTCP:
+		return e.Server.Address
+	case dmsg.CarrierQUIC:
+		return e.Server.AddressUDP
+	case dmsg.CarrierWS:
+		return e.Server.AddressWS
+	case dmsg.CarrierWT:
+		return e.Server.AddressWT
+	}
+	return ""
+}
+
+// printProbeTable renders one row per server with a column per carrier.
+func printProbeTable(entries []*disc.Entry, results []probeResult) {
+	byPK := map[string]map[string]probeResult{}
+	carrierSet := map[string]bool{}
+	for _, r := range results {
+		if byPK[r.PK] == nil {
+			byPK[r.PK] = map[string]probeResult{}
+		}
+		byPK[r.PK][r.Carrier] = r
+		carrierSet[r.Carrier] = true
+	}
+	// Stable column order.
+	var cols []string
+	for _, c := range []string{"tcp", "quic", "ws", "wss", "webtransport"} {
+		if carrierSet[c] {
+			cols = append(cols, c)
+		}
+	}
+	fmt.Printf("%-66s", "server")
+	for _, c := range cols {
+		fmt.Printf(" %-12s", c)
+	}
+	fmt.Println()
+	for _, e := range entries {
+		pk := e.Static.Hex()
+		row, ok := byPK[pk]
+		if !ok {
+			continue
+		}
+		fmt.Printf("%-66s", pk)
+		for _, c := range cols {
+			r, ok := row[c]
+			switch {
+			case !ok:
+				fmt.Printf(" %-12s", "-")
+			case r.OK:
+				fmt.Printf(" %-12s", fmt.Sprintf("ok %dms", r.LatencyMs))
+			default:
+				fmt.Printf(" %-12s", "FAIL")
+			}
+		}
+		fmt.Println()
+	}
+	// Failure details below the table so rows stay scannable.
+	for _, r := range results {
+		if !r.OK {
+			fmt.Printf("FAIL %s %s (%s): %s\n", r.PK, r.Carrier, r.Addr, r.Err)
+		}
+	}
+}

--- a/cmd/dmsg/conf/commands/pull.go
+++ b/cmd/dmsg/conf/commands/pull.go
@@ -141,15 +141,32 @@ func spliceDmsgServers(content []byte, entries []*disc.Entry) ([]byte, int) {
 	return out, count
 }
 
+// formatDmsgServers renders the entries with every STABLE advertised endpoint:
+// address, address_udp (+ protocol) and address_ws. Dropping address_ws here
+// (as this once did) breaks the browser wasm-visor's boot seeding — on an HTTPS
+// page it can only dial servers whose EMBEDDED entry carries a wss:// URL, so a
+// pull that stripped the field left it bootstrapping from a fraction of the
+// fleet. WT endpoints are deliberately NOT embedded: cert_hash_wt rotates with
+// the server's short-lived self-signed cert, so a static snapshot would pin a
+// stale hash — WT is discovered live instead.
 func formatDmsgServers(entries []*disc.Entry) string {
 	var b strings.Builder
 	b.WriteString(`"dmsg_servers": [`)
 	for i, e := range entries {
 		b.WriteString("\n      {\n")
 		fmt.Fprintf(&b, "        \"static\": %q,\n", e.Static.Hex())
+		if e.Protocol != "" {
+			fmt.Fprintf(&b, "        \"protocol\": %q,\n", e.Protocol)
+		}
 		b.WriteString("        \"server\": {\n")
-		fmt.Fprintf(&b, "          \"address\": %q\n", e.Server.Address)
-		b.WriteString("        }\n      }")
+		fmt.Fprintf(&b, "          \"address\": %q", e.Server.Address)
+		if e.Server.AddressUDP != "" {
+			fmt.Fprintf(&b, ",\n          \"address_udp\": %q", e.Server.AddressUDP)
+		}
+		if e.Server.AddressWS != "" {
+			fmt.Fprintf(&b, ",\n          \"address_ws\": %q", e.Server.AddressWS)
+		}
+		b.WriteString("\n        }\n      }")
 		if i < len(entries)-1 {
 			b.WriteString(",")
 		}

--- a/deployment/data_static_js.go
+++ b/deployment/data_static_js.go
@@ -56,42 +56,42 @@ var prodData = Services{
 	WSSDomainSuffix:    "theskywirenetwork.net",
 	BrowseOriginSuffix: ".haltingstate.net",
 	DmsgServers: []DmsgServerEntry{
+		{Static: "0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7", Server: struct {
+			Address   string `json:"address"`
+			AddressWS string `json:"address_ws,omitempty"`
+		}{Address: "172.105.179.5:30085", AddressWS: "wss://ajkrc67y2ruh3lgv66weyja7acagb4mxfeivkks3m63w6dtzel24o.theskywirenetwork.net/dmsg"}},
 		{Static: "0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb", Server: struct {
 			Address   string `json:"address"`
 			AddressWS string `json:"address_ws,omitempty"`
 		}{Address: "139.162.160.227:30086", AddressWS: "wss://aka2cawifaqoqejwrsgqfdhrdmnjqucdw4tldpg3r7hitmttqszmw.theskywirenetwork.net/dmsg"}},
+		{Static: "02a2d4c346dabd165fd555dfdba4a7f4d18786fe7e055e562397cd5102bdd7f8dd", Server: struct {
+			Address   string `json:"address"`
+			AddressWS string `json:"address_ws,omitempty"`
+		}{Address: "45.79.124.73:30082", AddressWS: "wss://akrnjq2g3k6rmx6vkxp5xjfh6tiypbx6pycv4vrds7gvcav5274n2.theskywirenetwork.net/dmsg"}},
+		{Static: "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0", Server: struct {
+			Address   string `json:"address"`
+			AddressWS string `json:"address_ws,omitempty"`
+		}{Address: "143.42.59.213:30088", AddressWS: "wss://aksjxqfkdnnxr5ry5emjxzhnbfn2yxlihhecqrs2qnipqcwaoyu4a.theskywirenetwork.net/dmsg"}},
+		{Static: "02c483938539bd7820f72e48ed6056bab68e221e1108d23965a2903221495e4af7", Server: struct {
+			Address   string `json:"address"`
+			AddressWS string `json:"address_ws,omitempty"`
+		}{Address: "172.104.166.8:30084", AddressWS: "wss://alcihe4fhg6xqihxfzeo2ycwxk3i4iq6ceeneolfukideikjlzfpo.theskywirenetwork.net/dmsg"}},
+		{Static: "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7", Server: struct {
+			Address   string `json:"address"`
+			AddressWS string `json:"address_ws,omitempty"`
+		}{Address: "70.121.13.123:9083", AddressWS: "wss://amtjpd22kox7kn63wr762wfr6er26oyacmwtmxytbgqu3nawrxh7o.theskywirenetwork.net/dmsg"}},
+		{Static: "03717576ada5b1744e395c66c2bb11cea73b0e23d0dcd54422139b1a7f12e962c4", Server: struct {
+			Address   string `json:"address"`
+			AddressWS string `json:"address_ws,omitempty"`
+		}{Address: "172.105.110.46:30083", AddressWS: "wss://anyxk5vnuwyxitrzlrtmfoyrz2ttwdrd2donkrbcconru7ys5frmi.theskywirenetwork.net/dmsg"}},
 		{Static: "0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13", Server: struct {
 			Address   string `json:"address"`
 			AddressWS string `json:"address_ws,omitempty"`
 		}{Address: "45.79.213.251:30087", AddressWS: "wss://any2ws6p66ysd5fzd5ufnvtubrxz3qp6ofuxpbik5noyin4lgafbg.theskywirenetwork.net/dmsg"}},
-		{Static: "0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7", Server: struct {
-			Address   string `json:"address"`
-			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "172.105.179.5:30085"}},
-		{Static: "02c483938539bd7820f72e48ed6056bab68e221e1108d23965a2903221495e4af7", Server: struct {
-			Address   string `json:"address"`
-			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "172.104.166.8:30084"}},
 		{Static: "03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf", Server: struct {
 			Address   string `json:"address"`
 			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "172.235.168.146:30081"}},
-		{Static: "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7", Server: struct {
-			Address   string `json:"address"`
-			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "70.121.13.123:9083"}},
-		{Static: "02a2d4c346dabd165fd555dfdba4a7f4d18786fe7e055e562397cd5102bdd7f8dd", Server: struct {
-			Address   string `json:"address"`
-			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "45.79.124.73:30082"}},
-		{Static: "03717576ada5b1744e395c66c2bb11cea73b0e23d0dcd54422139b1a7f12e962c4", Server: struct {
-			Address   string `json:"address"`
-			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "172.105.110.46:30083"}},
-		{Static: "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0", Server: struct {
-			Address   string `json:"address"`
-			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "143.42.59.213:30088"}},
+		}{Address: "172.235.168.146:30081", AddressWS: "wss://ap2x47hsnqdwjrnlmwnga2w5avw57c722t23y7ugcpfnaxs7ekfn6.theskywirenetwork.net/dmsg"}},
 	},
 	DmsgDiscoveryDmsg:      "dmsg://022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa:80",
 	TransportDiscoveryDmsg: "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80",
@@ -138,38 +138,42 @@ var testData = Services{
 	WSSDomainSuffix:    "theskywirenetwork.net",
 	BrowseOriginSuffix: ".haltingstate.net",
 	DmsgServers: []DmsgServerEntry{
-		{Static: "0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb", Server: struct {
-			Address   string `json:"address"`
-			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "139.162.160.227:30086"}},
-		{Static: "0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13", Server: struct {
-			Address   string `json:"address"`
-			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "45.79.213.251:30087"}},
 		{Static: "0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7", Server: struct {
 			Address   string `json:"address"`
 			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "172.105.179.5:30085"}},
-		{Static: "02c483938539bd7820f72e48ed6056bab68e221e1108d23965a2903221495e4af7", Server: struct {
+		}{Address: "172.105.179.5:30085", AddressWS: "wss://ajkrc67y2ruh3lgv66weyja7acagb4mxfeivkks3m63w6dtzel24o.theskywirenetwork.net/dmsg"}},
+		{Static: "0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb", Server: struct {
 			Address   string `json:"address"`
 			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "172.104.166.8:30084"}},
-		{Static: "03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf", Server: struct {
-			Address   string `json:"address"`
-			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "172.235.168.146:30081"}},
-		{Static: "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7", Server: struct {
-			Address   string `json:"address"`
-			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "70.121.13.123:9083"}},
+		}{Address: "139.162.160.227:30086", AddressWS: "wss://aka2cawifaqoqejwrsgqfdhrdmnjqucdw4tldpg3r7hitmttqszmw.theskywirenetwork.net/dmsg"}},
 		{Static: "02a2d4c346dabd165fd555dfdba4a7f4d18786fe7e055e562397cd5102bdd7f8dd", Server: struct {
 			Address   string `json:"address"`
 			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "45.79.124.73:30082"}},
+		}{Address: "45.79.124.73:30082", AddressWS: "wss://akrnjq2g3k6rmx6vkxp5xjfh6tiypbx6pycv4vrds7gvcav5274n2.theskywirenetwork.net/dmsg"}},
+		{Static: "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0", Server: struct {
+			Address   string `json:"address"`
+			AddressWS string `json:"address_ws,omitempty"`
+		}{Address: "143.42.59.213:30088", AddressWS: "wss://aksjxqfkdnnxr5ry5emjxzhnbfn2yxlihhecqrs2qnipqcwaoyu4a.theskywirenetwork.net/dmsg"}},
+		{Static: "02c483938539bd7820f72e48ed6056bab68e221e1108d23965a2903221495e4af7", Server: struct {
+			Address   string `json:"address"`
+			AddressWS string `json:"address_ws,omitempty"`
+		}{Address: "172.104.166.8:30084", AddressWS: "wss://alcihe4fhg6xqihxfzeo2ycwxk3i4iq6ceeneolfukideikjlzfpo.theskywirenetwork.net/dmsg"}},
+		{Static: "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7", Server: struct {
+			Address   string `json:"address"`
+			AddressWS string `json:"address_ws,omitempty"`
+		}{Address: "70.121.13.123:9083", AddressWS: "wss://amtjpd22kox7kn63wr762wfr6er26oyacmwtmxytbgqu3nawrxh7o.theskywirenetwork.net/dmsg"}},
 		{Static: "03717576ada5b1744e395c66c2bb11cea73b0e23d0dcd54422139b1a7f12e962c4", Server: struct {
 			Address   string `json:"address"`
 			AddressWS string `json:"address_ws,omitempty"`
-		}{Address: "172.105.110.46:30083"}},
+		}{Address: "172.105.110.46:30083", AddressWS: "wss://anyxk5vnuwyxitrzlrtmfoyrz2ttwdrd2donkrbcconru7ys5frmi.theskywirenetwork.net/dmsg"}},
+		{Static: "0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13", Server: struct {
+			Address   string `json:"address"`
+			AddressWS string `json:"address_ws,omitempty"`
+		}{Address: "45.79.213.251:30087", AddressWS: "wss://any2ws6p66ysd5fzd5ufnvtubrxz3qp6ofuxpbik5noyin4lgafbg.theskywirenetwork.net/dmsg"}},
+		{Static: "03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf", Server: struct {
+			Address   string `json:"address"`
+			AddressWS string `json:"address_ws,omitempty"`
+		}{Address: "172.235.168.146:30081", AddressWS: "wss://ap2x47hsnqdwjrnlmwnga2w5avw57c722t23y7ugcpfnaxs7ekfn6.theskywirenetwork.net/dmsg"}},
 	},
 	DmsgDiscoveryDmsg:      "dmsg://022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa:80",
 	TransportDiscoveryDmsg: "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80",

--- a/deployment/services-config.json
+++ b/deployment/services-config.json
@@ -39,51 +39,84 @@
     ],
     "dmsg_servers": [
       {
-        "static": "0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb",
-        "server": {
-          "address": "139.162.160.227:30086"
-        }
-      },
-      {
-        "static": "0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13",
-        "server": {
-          "address": "45.79.213.251:30087"
-        }
-      },
-      {
         "static": "0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7",
+        "protocol": "quic",
         "server": {
-          "address": "172.105.179.5:30085"
+          "address": "172.105.179.5:30085",
+          "address_udp": "172.105.179.5:30085",
+          "address_ws": "wss://ajkrc67y2ruh3lgv66weyja7acagb4mxfeivkks3m63w6dtzel24o.theskywirenetwork.net/dmsg"
         }
       },
       {
-        "static": "02c483938539bd7820f72e48ed6056bab68e221e1108d23965a2903221495e4af7",
+        "static": "0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb",
+        "protocol": "quic",
         "server": {
-          "address": "172.104.166.8:30084"
-        }
-      },
-      {
-        "static": "03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf",
-        "server": {
-          "address": "172.235.168.146:30081"
-        }
-      },
-      {
-        "static": "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7",
-        "server": {
-          "address": "70.121.13.123:9083"
+          "address": "139.162.160.227:30086",
+          "address_udp": "139.162.160.227:30086",
+          "address_ws": "wss://aka2cawifaqoqejwrsgqfdhrdmnjqucdw4tldpg3r7hitmttqszmw.theskywirenetwork.net/dmsg"
         }
       },
       {
         "static": "02a2d4c346dabd165fd555dfdba4a7f4d18786fe7e055e562397cd5102bdd7f8dd",
+        "protocol": "quic",
         "server": {
-          "address": "45.79.124.73:30082"
+          "address": "45.79.124.73:30082",
+          "address_udp": "45.79.124.73:30082",
+          "address_ws": "wss://akrnjq2g3k6rmx6vkxp5xjfh6tiypbx6pycv4vrds7gvcav5274n2.theskywirenetwork.net/dmsg"
+        }
+      },
+      {
+        "static": "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0",
+        "protocol": "quic",
+        "server": {
+          "address": "143.42.59.213:30088",
+          "address_udp": "143.42.59.213:30088",
+          "address_ws": "wss://aksjxqfkdnnxr5ry5emjxzhnbfn2yxlihhecqrs2qnipqcwaoyu4a.theskywirenetwork.net/dmsg"
+        }
+      },
+      {
+        "static": "02c483938539bd7820f72e48ed6056bab68e221e1108d23965a2903221495e4af7",
+        "protocol": "quic",
+        "server": {
+          "address": "172.104.166.8:30084",
+          "address_udp": "172.104.166.8:30084",
+          "address_ws": "wss://alcihe4fhg6xqihxfzeo2ycwxk3i4iq6ceeneolfukideikjlzfpo.theskywirenetwork.net/dmsg"
+        }
+      },
+      {
+        "static": "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7",
+        "protocol": "quic",
+        "server": {
+          "address": "70.121.13.123:9083",
+          "address_udp": "70.121.13.123:9083",
+          "address_ws": "wss://amtjpd22kox7kn63wr762wfr6er26oyacmwtmxytbgqu3nawrxh7o.theskywirenetwork.net/dmsg"
         }
       },
       {
         "static": "03717576ada5b1744e395c66c2bb11cea73b0e23d0dcd54422139b1a7f12e962c4",
+        "protocol": "quic",
         "server": {
-          "address": "172.105.110.46:30083"
+          "address": "172.105.110.46:30083",
+          "address_udp": "172.105.110.46:30083",
+          "address_ws": "wss://anyxk5vnuwyxitrzlrtmfoyrz2ttwdrd2donkrbcconru7ys5frmi.theskywirenetwork.net/dmsg"
+        }
+      },
+      {
+        "static": "0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13",
+        "protocol": "quic",
+        "server": {
+          "address": "45.79.213.251:30087",
+          "address_udp": "45.79.213.251:30087",
+          "address_ws": "wss://any2ws6p66ysd5fzd5ufnvtubrxz3qp6ofuxpbik5noyin4lgafbg.theskywirenetwork.net/dmsg"
+        }
+      },
+      {
+        "static": "03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf",
+        "protocol": "quic",
+        "server": {
+          "address": "172.235.168.146:30081",
+          "address_udp": "172.235.168.146:30081",
+          "address_ws": "wss://ap2x47hsnqdwjrnlmwnga2w5avw57c722t23y7ugcpfnaxs7ekfn6.theskywirenetwork.net/dmsg"
         }
       }
     ],
@@ -135,59 +168,84 @@
     ],
     "dmsg_servers": [
       {
+        "static": "0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7",
+        "protocol": "quic",
+        "server": {
+          "address": "172.105.179.5:30085",
+          "address_udp": "172.105.179.5:30085",
+          "address_ws": "wss://ajkrc67y2ruh3lgv66weyja7acagb4mxfeivkks3m63w6dtzel24o.theskywirenetwork.net/dmsg"
+        }
+      },
+      {
         "static": "0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb",
+        "protocol": "quic",
         "server": {
           "address": "139.162.160.227:30086",
+          "address_udp": "139.162.160.227:30086",
           "address_ws": "wss://aka2cawifaqoqejwrsgqfdhrdmnjqucdw4tldpg3r7hitmttqszmw.theskywirenetwork.net/dmsg"
         }
       },
       {
-        "static": "0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13",
-        "server": {
-          "address": "45.79.213.251:30087",
-          "address_ws": "wss://any2ws6p66ysd5fzd5ufnvtubrxz3qp6ofuxpbik5noyin4lgafbg.theskywirenetwork.net/dmsg"
-        }
-      },
-      {
-        "static": "0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7",
-        "server": {
-          "address": "172.105.179.5:30085"
-        }
-      },
-      {
-        "static": "02c483938539bd7820f72e48ed6056bab68e221e1108d23965a2903221495e4af7",
-        "server": {
-          "address": "172.104.166.8:30084"
-        }
-      },
-      {
-        "static": "03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf",
-        "server": {
-          "address": "172.235.168.146:30081"
-        }
-      },
-      {
-        "static": "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7",
-        "server": {
-          "address": "70.121.13.123:9083"
-        }
-      },
-      {
         "static": "02a2d4c346dabd165fd555dfdba4a7f4d18786fe7e055e562397cd5102bdd7f8dd",
+        "protocol": "quic",
         "server": {
-          "address": "45.79.124.73:30082"
-        }
-      },
-      {
-        "static": "03717576ada5b1744e395c66c2bb11cea73b0e23d0dcd54422139b1a7f12e962c4",
-        "server": {
-          "address": "172.105.110.46:30083"
+          "address": "45.79.124.73:30082",
+          "address_udp": "45.79.124.73:30082",
+          "address_ws": "wss://akrnjq2g3k6rmx6vkxp5xjfh6tiypbx6pycv4vrds7gvcav5274n2.theskywirenetwork.net/dmsg"
         }
       },
       {
         "static": "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0",
+        "protocol": "quic",
         "server": {
-          "address": "143.42.59.213:30088"
+          "address": "143.42.59.213:30088",
+          "address_udp": "143.42.59.213:30088",
+          "address_ws": "wss://aksjxqfkdnnxr5ry5emjxzhnbfn2yxlihhecqrs2qnipqcwaoyu4a.theskywirenetwork.net/dmsg"
+        }
+      },
+      {
+        "static": "02c483938539bd7820f72e48ed6056bab68e221e1108d23965a2903221495e4af7",
+        "protocol": "quic",
+        "server": {
+          "address": "172.104.166.8:30084",
+          "address_udp": "172.104.166.8:30084",
+          "address_ws": "wss://alcihe4fhg6xqihxfzeo2ycwxk3i4iq6ceeneolfukideikjlzfpo.theskywirenetwork.net/dmsg"
+        }
+      },
+      {
+        "static": "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7",
+        "protocol": "quic",
+        "server": {
+          "address": "70.121.13.123:9083",
+          "address_udp": "70.121.13.123:9083",
+          "address_ws": "wss://amtjpd22kox7kn63wr762wfr6er26oyacmwtmxytbgqu3nawrxh7o.theskywirenetwork.net/dmsg"
+        }
+      },
+      {
+        "static": "03717576ada5b1744e395c66c2bb11cea73b0e23d0dcd54422139b1a7f12e962c4",
+        "protocol": "quic",
+        "server": {
+          "address": "172.105.110.46:30083",
+          "address_udp": "172.105.110.46:30083",
+          "address_ws": "wss://anyxk5vnuwyxitrzlrtmfoyrz2ttwdrd2donkrbcconru7ys5frmi.theskywirenetwork.net/dmsg"
+        }
+      },
+      {
+        "static": "0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13",
+        "protocol": "quic",
+        "server": {
+          "address": "45.79.213.251:30087",
+          "address_udp": "45.79.213.251:30087",
+          "address_ws": "wss://any2ws6p66ysd5fzd5ufnvtubrxz3qp6ofuxpbik5noyin4lgafbg.theskywirenetwork.net/dmsg"
+        }
+      },
+      {
+        "static": "03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf",
+        "protocol": "quic",
+        "server": {
+          "address": "172.235.168.146:30081",
+          "address_udp": "172.235.168.146:30081",
+          "address_ws": "wss://ap2x47hsnqdwjrnlmwnga2w5avw57c722t23y7ugcpfnaxs7ekfn6.theskywirenetwork.net/dmsg"
         }
       }
     ],

--- a/pkg/dmsg/disc/entry.go
+++ b/pkg/dmsg/disc/entry.go
@@ -370,4 +370,8 @@ func Copy(dst, src *Entry) {
 	dst.Version = src.Version
 	dst.Sequence = src.Sequence
 	dst.Timestamp = src.Timestamp
+	dst.ClientType = src.ClientType
+	// Protocol is signed like every other field; dropping it here silently
+	// stripped "quic" from entries read back through the mock discovery.
+	dst.Protocol = src.Protocol
 }

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -92,7 +92,13 @@ func (ce *Client) EnsureSession(ctx context.Context, entry *disc.Entry) error {
 	// mutating entry.Protocol in place is a data race against those readers.
 	// The shallow copy shares the read-only Server pointer, which is fine.
 	e := *entry
-	e.Protocol = ce.conf.Protocol
+	// Override the entry's Protocol only when this client explicitly configures
+	// one. Unconditionally assigning conf.Protocol (usually "") erased the
+	// server's advertised "quic", so every EnsureSession-path dial silently
+	// downgraded to TCP — pickCarrier never saw the QUIC endpoint.
+	if ce.conf.Protocol != "" {
+		e.Protocol = ce.conf.Protocol
+	}
 	// Dial WITHOUT holding sesMx — same re-entrancy hazard as
 	// EnsureAndObtainSession: the dial path can re-enter session
 	// establishment via the self-hosted transport, which would

--- a/pkg/dmsg/dmsg/serve_unified_quic_wt_test.go
+++ b/pkg/dmsg/dmsg/serve_unified_quic_wt_test.go
@@ -1,11 +1,10 @@
 //go:build !tinygo && !(js && wasm)
 
-// Package dmsg pkg/dmsg/dmsg/serve_unified_quic_wt_test.go
+// Package dmsg pkg/dmsg/dmsg/serve_unified_quic_wt_test.go c1-net-dmsg
 package dmsg
 
 import (
 	"context"
-	"io"
 	"net"
 	"testing"
 	"time"
@@ -17,82 +16,106 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
-// TestServeUnifiedQUIC_QUICThroughDemux proves that co-hosting WebTransport on the
-// shared quic.Transport (ServeUnifiedQUIC with a non-empty WT URL) does NOT break
-// native dmsg-over-QUIC. The rewrite replaced the broken two-listener design (a
-// quic.Transport permits only ONE listener, so the WT ListenEarly always failed)
-// with a SINGLE ListenEarly whose GetConfigForClient hands back the dmsg identity
-// TLS config for the skywire ALPN and the WT config for "h3". This test drives two
-// QUIC clients through that demux listener and bridges a stream A→B, so a
-// regression in the skywire-ALPN (mutual-TLS) handshake selection would fail here.
-func TestServeUnifiedQUIC_QUICThroughDemux(t *testing.T) {
+// TestUnifiedQUICWTSessions covers the production UDP path (api.go →
+// ServeUnifiedQUIC): dmsg-over-QUIC and dmsg-over-WebTransport ALPN-demuxed on
+// ONE socket. The pre-existing QUIC/WT tests each exercise a dedicated
+// listener (ServeQUIC / ServeWebTransport), so a regression that broke one
+// ALPN branch of the SHARED listener — what every deployed server actually
+// runs — was invisible to the suite.
+func TestUnifiedQUICWTSessions(t *testing.T) {
 	dc := disc.NewMock(0)
 	const maxSessions = 10
 
 	pkSrv, skSrv := GenKeyPair(t, "server")
-	srv := NewServer(pkSrv, skSrv, dc, &ServerConfig{MaxSessions: maxSessions, UpdateInterval: 0}, nil)
-	srv.SetLogger(logging.MustGetLogger("uquic_server"))
+	// A fast UpdateInterval matters: the FIRST self-registration posts only the
+	// TCP address — the optional endpoints (UDP/WS/WT) are merged in by the
+	// periodic read-modify-write refresh, which defaults to one minute.
+	srv := NewServer(pkSrv, skSrv, dc, &ServerConfig{MaxSessions: maxSessions, UpdateInterval: 300 * time.Millisecond}, nil)
+	srv.SetLogger(logging.MustGetLogger("unified_server"))
 
-	udpConn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	// TCP listener: Serve owns the discovery self-registration loop, exactly
+	// like production (api.go runs Serve and ServeUnifiedQUIC side by side).
+	tcpLis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	udpAddr := udpConn.LocalAddr().String()
+	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
 
-	// Serve QUIC + WebTransport on ONE socket. The non-empty WT URL exercises
-	// buildWTServer + the GetConfigForClient ALPN demux (the path that was dead).
-	chSrv := make(chan error, 1)
-	go func() { chSrv <- srv.ServeUnifiedQUIC(udpConn, udpAddr, "https://"+udpAddr+"/dmsg") }()
+	wtURL := "https://" + udpConn.LocalAddr().String() + wtPath
+	chSrv := make(chan error, 2)
+	go func() { chSrv <- srv.Serve(tcpLis, tcpLis.Addr().String()) }()
+	go func() { chSrv <- srv.ServeUnifiedQUIC(udpConn, udpConn.LocalAddr().String(), wtURL) }()
+	t.Cleanup(func() {
+		require.NoError(t, srv.Close())
+		// Drain the serve goroutines best-effort: teardown latency (e.g. the WT
+		// h3 server unwinding) must not hang the suite past its deadline.
+		for i := 0; i < 2; i++ {
+			select {
+			case err := <-chSrv:
+				require.NoError(t, err)
+			case <-time.After(5 * time.Second):
+				return
+			}
+		}
+	})
 
-	srvEntry := disc.NewServerEntry(pkSrv, 0, "", maxSessions)
-	srvEntry.Server.Address = ""
-	srvEntry.Server.AddressUDP = udpAddr
-	srvEntry.Protocol = "quic"
-	require.NoError(t, srvEntry.Sign(skSrv))
-	require.NoError(t, dc.PostEntry(context.Background(), srvEntry))
+	// Wait until the self-registered entry advertises BOTH UDP (quic) and WT.
+	require.Eventually(t, func() bool {
+		e, eerr := dc.Entry(context.Background(), pkSrv)
+		return eerr == nil && e.Server != nil &&
+			e.Protocol == "quic" && e.Server.AddressUDP != "" &&
+			e.Server.AddressWT != "" && e.Server.CertHashWT != ""
+	}, 10*time.Second, 50*time.Millisecond, "server entry never advertised quic+wt")
 
-	quicConf := func() *Config {
-		c := DefaultConfig()
-		c.Protocol = "quic"
+	// One client forced onto each carrier of the shared socket.
+	newClient := func(name, carrier string) *Client {
+		conf := DefaultConfig()
+		conf.Carriers = []string{carrier}
+		pk, sk := GenKeyPair(t, name)
+		c := NewClient(pk, sk, dc, conf)
+		c.SetLogger(logging.MustGetLogger(name))
+		go c.Serve(context.Background())
+		t.Cleanup(func() { require.NoError(t, c.Close()) })
 		return c
 	}
-	pkA, skA := GenKeyPair(t, "client A")
-	clientA := NewClient(pkA, skA, dc, quicConf())
-	clientA.SetLogger(logging.MustGetLogger("uquic_client_A"))
-	go clientA.Serve(context.Background())
+	quicClient := newClient("quic_client", CarrierQUIC)
+	wtClient := newClient("wt_client", CarrierWT)
 
-	pkB, skB := GenKeyPair(t, "client B")
-	clientB := NewClient(pkB, skB, dc, quicConf())
-	clientB.SetLogger(logging.MustGetLogger("uquic_client_B"))
-	go clientB.Serve(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 
-	require.Eventually(t, func() bool {
-		return clientA.SessionCount() > 0 && clientB.SessionCount() > 0
-	}, 10*time.Second, 200*time.Millisecond, "QUIC clients failed to connect through the WT-demux listener")
+	// Raw dmsg-over-QUIC session on the shared listener.
+	require.NoError(t, quicClient.EnsureSession(ctx, entrySnapshot(t, dc, pkSrv)),
+		"raw dmsg-QUIC session over the unified listener")
 
-	sesA, okA := clientA.Session(pkSrv)
-	require.True(t, okA, "client A has no session to the unified server")
-	require.True(t, sesA.SupportsDatagrams(), "session is not a genuine QUIC session")
+	// WebTransport session on the same UDP socket.
+	require.NoError(t, wtClient.EnsureSession(ctx, entrySnapshot(t, dc, pkSrv)),
+		"WebTransport session over the unified listener")
 
-	// Full data path: bridge a stream A→B through the server and round-trip a payload.
-	const port = 8080
-	lis, err := clientB.Listen(port)
+	// A stream through the server proves both sessions relay, not just dial:
+	// wtClient listens, quicClient dials it through the shared-socket server.
+	lis, err := wtClient.Listen(49152)
 	require.NoError(t, err)
-	defer lis.Close() //nolint:errcheck
+	t.Cleanup(func() { require.NoError(t, lis.Close()) })
 
-	connA, err := clientA.DialStream(context.TODO(), Addr{PK: pkB, Port: port})
-	require.NoError(t, err)
-	defer connA.Close() //nolint:errcheck
-	connB, err := lis.Accept()
-	require.NoError(t, err)
-	defer connB.Close() //nolint:errcheck
+	accepted := make(chan error, 1)
+	go func() {
+		s, aerr := lis.AcceptStream()
+		if aerr == nil {
+			_ = s.Close() //nolint:errcheck
+		}
+		accepted <- aerr
+	}()
 
-	payload := cipher.RandByte(4096)
-	go func() { _, _ = connA.Write(payload) }() //nolint:errcheck
-	got := make([]byte, len(payload))
-	_, err = io.ReadFull(connB, got)
-	require.NoError(t, err)
-	require.Equal(t, payload, got, "payload mismatch over QUIC through the WT-demux listener")
+	stream, err := quicClient.DialStream(ctx, Addr{PK: wtClient.LocalPK(), Port: 49152})
+	require.NoError(t, err, "stream QUIC client → WT client through the unified server")
+	require.NoError(t, stream.Close())
+	require.NoError(t, <-accepted)
+}
 
-	require.NoError(t, clientA.Close())
-	require.NoError(t, clientB.Close())
-	require.NoError(t, srv.Close())
+// entrySnapshot fetches pk's current entry from the mock discovery.
+func entrySnapshot(t *testing.T, dc disc.APIClient, pk cipher.PubKey) *disc.Entry {
+	t.Helper()
+	e, err := dc.Entry(context.Background(), pk)
+	require.NoError(t, err)
+	return e
 }

--- a/pkg/dmsg/dmsgc/dmsgc.go
+++ b/pkg/dmsg/dmsgc/dmsgc.go
@@ -94,6 +94,9 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 		},
 		ConnectedServersType: primary.ConnectedServersType,
 		Protocol:             primary.Protocol,
+		// Ordered carrier preference (tcp/quic/ws/wt) from the visor config —
+		// how this client reaches dmsg servers. Empty = native default.
+		Carriers: primary.Carriers,
 		// When this visor runs a dmsg server in-process under the same PK,
 		// the client must skip its own server entry in the serve loop rather
 		// than dial a transit session to itself.

--- a/pkg/dmsg/dmsgc/spec/spec.go
+++ b/pkg/dmsg/dmsgc/spec/spec.go
@@ -44,7 +44,12 @@ type Deployment struct {
 	Servers              []*disc.Entry `json:"servers,omitempty"`
 	ConnectedServersType string        `json:"servers_type,omitempty"`
 	Protocol             string        `json:"protocol,omitempty"`
-	LANServers           []*disc.Entry `json:"lan_servers,omitempty"`
+	// Carriers is the ordered carrier preference for reaching dmsg servers —
+	// "tcp", "quic", "ws", "wt" (see dmsg.Config.Carriers). Empty = the native
+	// default (QUIC when the server advertises it, else TCP). Set e.g. ["ws"]
+	// or ["wt"] on networks that only allow 443/HTTPS egress.
+	Carriers   []string      `json:"carriers,omitempty"`
+	LANServers []*disc.Entry `json:"lan_servers,omitempty"`
 	// HypervisorDiscovery is an optional override URL pointing at a
 	// hypervisor-hosted dmsg-discovery proxy. When set, the dmsg client
 	// queries this URL first and falls back to Discovery (the canonical
@@ -83,6 +88,7 @@ type DmsgConfig struct {
 	Servers              []*disc.Entry `json:"-"`
 	ConnectedServersType string        `json:"-"`
 	Protocol             string        `json:"-"`
+	Carriers             []string      `json:"-"`
 	LANServers           []*disc.Entry `json:"-"`
 	HypervisorDiscovery  string        `json:"-"`
 
@@ -156,6 +162,7 @@ func (c *DmsgConfig) mirrorPrimary() {
 	c.Servers = d.Servers
 	c.ConnectedServersType = d.ConnectedServersType
 	c.Protocol = d.Protocol
+	c.Carriers = d.Carriers
 	c.LANServers = d.LANServers
 	c.HypervisorDiscovery = d.HypervisorDiscovery
 }
@@ -169,6 +176,7 @@ func (c *DmsgConfig) toDeployment() Deployment {
 		Servers:              c.Servers,
 		ConnectedServersType: c.ConnectedServersType,
 		Protocol:             c.Protocol,
+		Carriers:             c.Carriers,
 		LANServers:           c.LANServers,
 		HypervisorDiscovery:  c.HypervisorDiscovery,
 	}

--- a/pkg/dmsg/dmsgc/spec/spec_native.go
+++ b/pkg/dmsg/dmsgc/spec/spec_native.go
@@ -59,7 +59,7 @@ func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
 // so the JSON output is correct.
 func (c DmsgConfig) MarshalJSON() ([]byte, error) {
 	deployments := c.Deployments
-	if len(deployments) == 0 && (c.Discovery != "" || c.DiscoveryDmsg != "" || len(c.Servers) > 0 || c.SessionsCount != 0 || c.ConnectedServersType != "" || c.Protocol != "" || len(c.LANServers) > 0 || c.HypervisorDiscovery != "" || c.Server != nil) {
+	if len(deployments) == 0 && (c.Discovery != "" || c.DiscoveryDmsg != "" || len(c.Servers) > 0 || c.SessionsCount != 0 || c.ConnectedServersType != "" || c.Protocol != "" || len(c.Carriers) > 0 || len(c.LANServers) > 0 || c.HypervisorDiscovery != "" || c.Server != nil) {
 		deployments = []Deployment{c.toDeployment()}
 	}
 	if len(deployments) == 1 {


### PR DESCRIPTION
Adds `skywire dmsg conf probe` — a real-session (Noise included) reachability matrix of every dmsg server over every carrier it advertises (tcp / quic / ws-wss / wt). This is the first way to verify from the CLI what a browser wasm-visor actually dials.

The probe immediately caught a client bug: `EnsureSession` overwrote the server entry's `Protocol` with the client's (usually empty) `conf.Protocol`, erasing the "quic" advert — every EnsureSession-path dial silently downgraded to TCP. Also fixed: `disc.Copy` dropped `Protocol`/`ClientType`, and `dmsg conf pull` stripped `address_ws`/`address_udp`/`protocol` when rewriting services-config.json, which is why the embedded snapshot advertised wss for only 2 of 9 servers (an HTTPS-served wasm-visor could only bootstrap from those 2). The refreshed snapshot carries wss + quic endpoints for all 9.

Also adds `dmsg.carriers` to the visor config (ordered carrier preference, e.g. ["wt","ws"] for 443-only networks) and `TestUnifiedQUICWTSessions`, the first test of the shared-UDP ALPN demux every deployed server runs.

Live matrix after the fix: tcp 9/9, quic 8/9, wss 9/9, wt 9/9 — the one quic failure is a stale docker server image rejecting the raw-QUIC ALPN (ops follow-up).