### PR TITLE
desk: native hypervisor-UI rendering (vnet service worker), reload persistence fixes, CI round-4

### DIFF
--- a/cmd/skywire-cli/commands/config/gen_test.go
+++ b/cmd/skywire-cli/commands/config/gen_test.go
@@ -149,8 +149,11 @@ func runConfigGenWithEnv(t *testing.T, envContent string, extraFlags ...string) 
 	if i := strings.Index(jsonOut, "{"); i > 0 {
 		jsonOut = jsonOut[i:]
 	}
+	// Decode (not Unmarshal): a stray log line can land AFTER the config dump
+	// too — the decoder stops at the end of the first JSON value instead of
+	// rejecting the trailing text.
 	var conf visorconfig.V1
-	if err := json.Unmarshal([]byte(jsonOut), &conf); err != nil {
+	if err := json.NewDecoder(strings.NewReader(jsonOut)).Decode(&conf); err != nil {
 		t.Fatalf("failed to parse config JSON: %v\noutput: %.200s", err, out)
 	}
 	return &conf

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -580,7 +580,15 @@ func generateConfig(r resolvedConfig, hvArg string) error {
 		// no hypervisor
 	case "":
 		// New install? Default to enabling the local hypervisor.
+		// An EXISTING config keeps whatever it has: regen rewrites the
+		// whole file, so without re-asserting -i here a hypervisor that
+		// was only ever enabled by this same implicit default (no
+		// ISHYPERVISOR=true in the env file) would silently lose its UI
+		// on the next autoconfig run.
 		if _, err := os.Stat(r.configPath); os.IsNotExist(err) {
+			args = append(args, "-i")
+			printableArgs = append(printableArgs, "-i")
+		} else if conf, err := visorconfig.ReadFile(r.configPath); err == nil && conf.Hypervisor != nil && conf.Hypervisor.Enable {
 			args = append(args, "-i")
 			printableArgs = append(printableArgs, "-i")
 		}

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 
 require (
 	github.com/0magnet/bbolt v1.5.1-0.20260901223329-c4feec896898
-	github.com/0magnet/bottle v0.0.0-20260902082749-b333a0d36741
+	github.com/0magnet/bottle v0.0.0-20260902192631-211d2d030c2b
 	github.com/0magnet/golang-ipc v1.2.5-0.20260901195306-becfc11f7586
 	github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77
 	github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b

--- a/go.mod
+++ b/go.mod
@@ -60,11 +60,11 @@ require (
 
 require (
 	github.com/0magnet/bbolt v1.5.1-0.20260901223329-c4feec896898
-	github.com/0magnet/bottle v0.0.0-20260902192631-211d2d030c2b
+	github.com/0magnet/bottle v0.0.0-20260902200243-44a3a636767a
 	github.com/0magnet/golang-ipc v1.2.5-0.20260901195306-becfc11f7586
 	github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77
 	github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b
-	github.com/0magnet/netscrape v0.0.0-20260902082747-92e7877355d4
+	github.com/0magnet/netscrape v0.0.0-20260902195455-ed17b71dd13b
 	github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408
 	github.com/0magnet/realorigin v0.2.0
 	github.com/0magnet/sysinfo v1.1.4-0.20260901201859-b4abd4e87c26

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/0magnet/afero v1.15.1-0.20260816202415-9f9d46a34dcd h1:zhADHH+Lu7o4U1
 github.com/0magnet/afero v1.15.1-0.20260816202415-9f9d46a34dcd/go.mod h1:JsJ3c6VwVpJOB3qUpT6YzgJ8yC+nBLUCcH2nhGLC6fA=
 github.com/0magnet/bbolt v1.5.1-0.20260901223329-c4feec896898 h1:5UyEWEOaKdF8RAfc/fBxqrpEgsga0NCuRYkA9xegoos=
 github.com/0magnet/bbolt v1.5.1-0.20260901223329-c4feec896898/go.mod h1:w+uhwkS5wbYmWTm2Dvvp3AWUR8TNrksPutxoBn4sESY=
-github.com/0magnet/bottle v0.0.0-20260902082749-b333a0d36741 h1:pG8Khjiim9uG72t0H5weqXeI1gZ2IQq4WSwlQLcpquQ=
-github.com/0magnet/bottle v0.0.0-20260902082749-b333a0d36741/go.mod h1:02z8sWzqF3QH4SjMxnx5bnysFUqsw9CdUTtIj+CIxkw=
+github.com/0magnet/bottle v0.0.0-20260902192631-211d2d030c2b h1:hjOY9M5g2Ibqf95SfyE1PgaSDcwcUUWISmNn5w3+z0c=
+github.com/0magnet/bottle v0.0.0-20260902192631-211d2d030c2b/go.mod h1:02z8sWzqF3QH4SjMxnx5bnysFUqsw9CdUTtIj+CIxkw=
 github.com/0magnet/coloredcobra v1.0.3-0.20260902084726-57ccbecfc077 h1:cWpt53uNQFCMUl8zmh73xb/EuigbO3Qe+KP4ggpwvy8=
 github.com/0magnet/coloredcobra v1.0.3-0.20260902084726-57ccbecfc077/go.mod h1:Kn7dmRJcnVybFNKY0FNUjLcsivW4FCbAec8ZfVmz51I=
 github.com/0magnet/cosmos-go v0.0.0-20260814190035-f5b882c1ea9e h1:fyLB1qUtpMxPeZp4MdZu5yLHHR+kLl2MZfhG0djlGIo=

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/0magnet/afero v1.15.1-0.20260816202415-9f9d46a34dcd h1:zhADHH+Lu7o4U1
 github.com/0magnet/afero v1.15.1-0.20260816202415-9f9d46a34dcd/go.mod h1:JsJ3c6VwVpJOB3qUpT6YzgJ8yC+nBLUCcH2nhGLC6fA=
 github.com/0magnet/bbolt v1.5.1-0.20260901223329-c4feec896898 h1:5UyEWEOaKdF8RAfc/fBxqrpEgsga0NCuRYkA9xegoos=
 github.com/0magnet/bbolt v1.5.1-0.20260901223329-c4feec896898/go.mod h1:w+uhwkS5wbYmWTm2Dvvp3AWUR8TNrksPutxoBn4sESY=
-github.com/0magnet/bottle v0.0.0-20260902192631-211d2d030c2b h1:hjOY9M5g2Ibqf95SfyE1PgaSDcwcUUWISmNn5w3+z0c=
-github.com/0magnet/bottle v0.0.0-20260902192631-211d2d030c2b/go.mod h1:02z8sWzqF3QH4SjMxnx5bnysFUqsw9CdUTtIj+CIxkw=
+github.com/0magnet/bottle v0.0.0-20260902200243-44a3a636767a h1:WuLGy4De3VZauQ+jpegRFn+SYaHQHAJOmmTC5wME+V0=
+github.com/0magnet/bottle v0.0.0-20260902200243-44a3a636767a/go.mod h1:02z8sWzqF3QH4SjMxnx5bnysFUqsw9CdUTtIj+CIxkw=
 github.com/0magnet/coloredcobra v1.0.3-0.20260902084726-57ccbecfc077 h1:cWpt53uNQFCMUl8zmh73xb/EuigbO3Qe+KP4ggpwvy8=
 github.com/0magnet/coloredcobra v1.0.3-0.20260902084726-57ccbecfc077/go.mod h1:Kn7dmRJcnVybFNKY0FNUjLcsivW4FCbAec8ZfVmz51I=
 github.com/0magnet/cosmos-go v0.0.0-20260814190035-f5b882c1ea9e h1:fyLB1qUtpMxPeZp4MdZu5yLHHR+kLl2MZfhG0djlGIo=
@@ -80,8 +80,8 @@ github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77 h1:4Th5JTWexd+r
 github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77/go.mod h1:F6WLpAz89R80LgQy9Veg6jZVdfY3FLmxqt23Okck35A=
 github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b h1:l/c7X12CNncX2phqLeQPiNjxu2ou7spv3xslwloyPjE=
 github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b/go.mod h1:SwLy2vvXGWJQxefDI4DncGdXJWIob5IGczxeFMtUIj8=
-github.com/0magnet/netscrape v0.0.0-20260902082747-92e7877355d4 h1:OJEi5t1Apymjs450Y3i6URlzgbPQiZhqayFYKxqazB4=
-github.com/0magnet/netscrape v0.0.0-20260902082747-92e7877355d4/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
+github.com/0magnet/netscrape v0.0.0-20260902195455-ed17b71dd13b h1:ImdwmeLEaTkEP3kQrEG3A0Rbmhthg1614MThb8/IWtE=
+github.com/0magnet/netscrape v0.0.0-20260902195455-ed17b71dd13b/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
 github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408 h1:iXCaIMD5kmvYINoBhIVv+nGtN4BRRVe64EDkOUtKvqg=
 github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408/go.mod h1:feFjgv6ByEzXixeUOB4gYwq9G8iv35aQJiYc/8ZHDWg=
 github.com/0magnet/realorigin v0.2.0 h1:+xfvyuQzRGKAtQ88WziCVK3/poPTzc4pvc0i5+kPNUc=

--- a/pkg/pty/exec_http.go
+++ b/pkg/pty/exec_http.go
@@ -150,7 +150,14 @@ const execStreamMaxFrame = 1 << 20 // 1 MiB
 //
 // The text/plain fallback has no such place, and therefore inherits the
 // 2-minute quiet limit. That is acceptable for a debugging mode.
-const execStreamKeepalive = 45 * time.Second
+//
+// 10s rather than 45s: the keepalive doubles as DISCONNECT DETECTION for an
+// idle command — a client that vanished mid-frame surfaces only when the next
+// write fails (net/http never cancels r.Context() for write errors), so the
+// interval bounds how long an orphaned idle command lingers. 45s left it
+// beyond the disconnect test's 20s patience, and beyond reasonable teardown
+// latency generally.
+const execStreamKeepalive = 10 * time.Second
 
 // execStreamDefaultTimeout and execStreamMaxTimeout are far longer than the
 // buffered path's 30s / 5min. Those exist to stop `tail -f` being mis-used as

--- a/pkg/skyenv/skyenv_js.go
+++ b/pkg/skyenv/skyenv_js.go
@@ -31,8 +31,13 @@ func PackageConfig() PkgConfig {
 		LauncherBinPath: "/opt/skywire/bin",
 		LocalPath:       "/opt/skywire/local",
 		Hypervisor: Hypervisor{
-			DbPath:     "/opt/skywire/users.db",
-			EnableAuth: true,
+			DbPath: "/opt/skywire/users.db",
+			// No password gate in the tab: the UI is reachable only through
+			// the page's own vnet (same-origin service worker included), so
+			// auth guards nothing — and users.db is deliberately excluded
+			// from filesystem snapshots (bbolt stores restore corrupt), so a
+			// password would evaporate on every reload anyway.
+			EnableAuth: false,
 		},
 	}
 	return pkgConfig

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -63,6 +63,14 @@ func (hv *Hypervisor) uiHandler() http.Handler {
 		case "/browse.js":
 			serveJS(w, browseui.BrowseJS)
 			return
+		case "/vnet-sw.js":
+			// bottle's vnet service worker: pages that run in-page servers
+			// (a wasm visor in a tab) register it to give their nested
+			// browser real /vnet/<port>/ URLs. Same asset on every desk-ish
+			// origin, so a page served by the native HV behaves like one
+			// served by `hv serve`.
+			serveJS(w, browseui.VNetSWJS())
+			return
 		case "/winbox.wasm":
 			// The window manager the browse bundle loads. instantiateStreaming
 			// refuses a module that does not arrive as application/wasm.

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -277,6 +277,10 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	serveBytes("/hv-boot.js", "text/javascript", wasmhv.HvBootJS)
 	serveBytes("/worker.js", "text/javascript", wasmhv.WorkerJS)
 	serveBytes("/browse.js", "text/javascript", wasmhv.BrowseJS)
+	// The vnet service worker: real same-origin /vnet/<port>/ URLs into the
+	// page's virtual loopback, so the nested browser renders in-page servers
+	// (the hypervisor UI SPA) natively. Must live beside the pages (scope cap).
+	serveBytes("/vnet-sw.js", "text/javascript", wasmhv.VNetSWJS())
 	// The full skywire CLI module for the terminal's `skywire` command —
 	// served from disk (too large to embed), gzip left to the transport.
 	// Absent path = 404, and the shell simply doesn't register the command.

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -79,7 +79,15 @@
 		globalThis.__WINBOX_WASM_URL__ = opts.winboxURL || 'winbox.wasm';
 
 		status('restoring filesystem…');
-		return jsfs.persist.enable(opts.persistDB || 'skywire-desk').then(function (p) {
+		return jsfs.persist.enable(opts.persistDB || 'skywire-desk', {
+			// Persist identity + config + user files; NEVER the runtime
+			// stores. A bbolt database snapshotted mid-write restores corrupt
+			// and hangs its consumer on the next boot (the hypervisor module
+			// stalling on a restored users.db) — caches rebuild, keys don't.
+			exclude: function (p) {
+				return /\.db$/.test(p) || p.indexOf('/opt/skywire/local/') === 0 || p === '/opt/skywire/local';
+			},
+		}).then(function (p) {
 			status((p.restored ? 'filesystem restored — ' : '') + 'starting the desk…');
 			// The desk host: the wasm-visor binary in-page. It installs the
 			// shell + the skywireVisor API and waits — boot() is never called,

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -51,10 +51,19 @@
 	function loadSession() {
 		try { return JSON.parse(localStorage.getItem(SESSION_KEY) || 'null'); } catch (e) { return null; }
 	}
+	// visorSawUp: whether THIS page ever observed its visor listening. The
+	// session records "stopped" ONLY after up-then-down — a save that fires
+	// while the visor is still booting (visibilitychange the moment another
+	// tab covers the page) must not masquerade as an operator stop, or every
+	// later load skips the autostart forever.
+	var visorSawUp = false;
 	function saveSession() {
 		try {
+			var up = !!(globalThis.vnet && globalThis.vnet.listening(3435));
+			if (up) { visorSawUp = true; }
+			if (!up && !visorSawUp) { return; } // still booting (or never started) — keep the previous verdict
 			localStorage.setItem(SESSION_KEY, JSON.stringify({
-				visorRunning: !!(globalThis.vnet && globalThis.vnet.listening(3435)),
+				visorRunning: up,
 				at: Date.now(),
 			}));
 		} catch (e) { /* storage denied — session just resets to defaults */ }
@@ -104,10 +113,17 @@
 			// Session: remember across reloads whether a visor was RUNNING when
 			// the page went away — a visor the operator stopped stays stopped.
 			var session = loadSession();
-			addEventListener('pagehide', saveSession);
-			addEventListener('visibilitychange', function () {
-				if (document.visibilityState === 'hidden') saveSession();
-			});
+			if (opts.autostartVisor) {
+				addEventListener('pagehide', saveSession);
+				addEventListener('visibilitychange', function () {
+					if (document.visibilityState === 'hidden') saveSession();
+				});
+				// Track up-transitions continuously so a save after a stop can
+				// tell "operator stopped it" from "it never came up".
+				setInterval(function () {
+					if (globalThis.vnet && globalThis.vnet.listening(3435)) { visorSawUp = true; }
+				}, 2000);
+			}
 
 			var startVisor = !!opts.autostartVisor && !(session && session.visorRunning === false);
 			var startedVisor = false;

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -78,6 +78,15 @@
 		skywireExec.wasmExecURL = opts.wasmExecURL || 'wasm_exec.js';
 		globalThis.__WINBOX_WASM_URL__ = opts.winboxURL || 'winbox.wasm';
 
+		// The vnet service worker: registered up front (it takes a moment to
+		// activate), so by the time anything opens a loopback window the
+		// nested browser can use real /vnet/<port>/ URLs — native rendering
+		// for the hypervisor UI. Resolves false where SWs are unavailable;
+		// the browser falls back to its transcoder, as before.
+		var swReady = (globalThis.vnet && globalThis.vnet.enableSW)
+			? globalThis.vnet.enableSW(opts.vnetSWURL || 'vnet-sw.js').catch(function () { return false; })
+			: Promise.resolve(false);
+
 		status('restoring filesystem…');
 		return jsfs.persist.enable(opts.persistDB || 'skywire-desk', {
 			// Persist identity + config + user files; NEVER the runtime
@@ -155,11 +164,16 @@
 				// the page lives.
 				(function waitHV(n) {
 					if (globalThis.vnet && globalThis.vnet.listening(hvPort)) {
-						try {
-							var win = panel.openWindow(true); // skipLanding
-							win.browser.browseTo('127.0.0.1:' + hvPort, '/');
-							if (win.wb && win.wb.maximize) win.wb.maximize(true);
-						} catch (e) { console.error('hv window:', e); }
+						// Hold the open until the service-worker question is
+						// settled either way — opening a beat earlier would
+						// route this first load through the transcoder.
+						swReady.then(function () {
+							try {
+								var win = panel.openWindow(true); // skipLanding
+								win.browser.browseTo('127.0.0.1:' + hvPort, '/');
+								if (win.wb && win.wb.maximize) win.wb.maximize(true);
+							} catch (e) { console.error('hv window:', e); }
+						});
 						return;
 					}
 					if (startVisor && n > 360) return; // ~3min — the autostarted visor never served a UI

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -137,10 +137,14 @@
 			if (opts.helpTerminal !== false) {
 				panel.openConsole({ title: 'skywire', initCmd: 'skywire --help' });
 			}
-			if (opts.hvWindow && startVisor) {
+			if (opts.hvWindow) {
 				// The hypervisor UI comes up on the virtual loopback a while
 				// after boot (its module waits on the visor tree + dmsg).
-				// Open the window once something actually listens.
+				// Open the window once something actually listens — armed even
+				// when the session suppressed the autostart, so a visor the
+				// operator starts BY HAND still gets its UI window. Autostarted
+				// visors get a bounded wait; the manual case waits as long as
+				// the page lives.
 				(function waitHV(n) {
 					if (globalThis.vnet && globalThis.vnet.listening(hvPort)) {
 						try {
@@ -150,7 +154,7 @@
 						} catch (e) { console.error('hv window:', e); }
 						return;
 					}
-					if (n > 360) return; // ~3min — visor never served a UI; skip
+					if (startVisor && n > 360) return; // ~3min — the autostarted visor never served a UI
 					setTimeout(function () { waitHV(n + 1); }, 500);
 				})(0);
 			}

--- a/pkg/wasmhv/browseui/embed.go
+++ b/pkg/wasmhv/browseui/embed.go
@@ -82,6 +82,14 @@ var BrowseJS = func() []byte {
 	return out
 }()
 
+// VNetSWJS is bottle's vnet service worker — served BESIDE each desk page as
+// vnet-sw.js (a service worker's scope is capped at its script's directory,
+// so it cannot ride inside the bundle). vnet.enableSW() registers it; from
+// then on /vnet/<port>/… are real same-origin URLs into the page's port
+// table, and the nested browser loads in-page servers (the hypervisor UI)
+// with native resolution instead of the transcoder.
+func VNetSWJS() []byte { return bottle.VNetSWJS() }
+
 // WinBoxWasmGz is the compressed module, for a consumer that ships it inside a
 // page (the single-file generator base64s exactly these bytes) rather than
 // serving it.

--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -42,6 +42,11 @@ func WinBoxWasmGz() []byte { return browseui.WinBoxWasmGz() }
 // browseui leaf like BrowseJS.
 func DeskBootJS() []byte { return browseui.DeskBootJS() }
 
+// VNetSWJS is bottle's vnet service worker, served beside the desk pages as
+// /vnet-sw.js (a service worker's scope is capped at its script's directory).
+// Re-exported from the browseui leaf like BrowseJS.
+func VNetSWJS() []byte { return browseui.VNetSWJS() }
+
 // WalletConfigHTML is the single wallet-config page (served at /wallet/config by
 // both the native HV and `hv serve`, embedded via iframe by the ☰ wallet window
 // and the Angular wallet tab). Re-exported from the browseui leaf like BrowseJS.

--- a/scripts/stage-playground/main.go
+++ b/scripts/stage-playground/main.go
@@ -27,6 +27,7 @@ func main() {
 	files := map[string][]byte{
 		"bundle.js":    browseui.BrowseJS,
 		"desk-boot.js": browseui.DeskBootJS(),
+		"vnet-sw.js":   browseui.VNetSWJS(),
 		"winbox.wasm":  browseui.WinBoxWasm(),
 	}
 	for name, data := range files {

--- a/scripts/tabshot/main.go
+++ b/scripts/tabshot/main.go
@@ -1,0 +1,64 @@
+// Command tabshot captures a PNG screenshot of an existing CDP page target.
+//
+//	go run ./scripts/tabshot ws://127.0.0.1:9222/devtools/page/<id> out.png
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: tabshot <webSocketDebuggerUrl> <out.png>")
+		os.Exit(2)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, os.Args[1], &websocket.DialOptions{})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "dial:", err)
+		os.Exit(1)
+	}
+	c.SetReadLimit(64 << 20)
+	defer c.Close(websocket.StatusNormalClosure, "")
+	req := map[string]interface{}{"id": 1, "method": "Page.captureScreenshot", "params": map[string]interface{}{"format": "png"}}
+	b, _ := json.Marshal(req)
+	if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+		fmt.Fprintln(os.Stderr, "write:", err)
+		os.Exit(1)
+	}
+	for {
+		_, msg, err := c.Read(ctx)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "read:", err)
+			os.Exit(1)
+		}
+		var m struct {
+			ID     int `json:"id"`
+			Result struct {
+				Data string `json:"data"`
+			} `json:"result"`
+		}
+		if json.Unmarshal(msg, &m) != nil || m.ID != 1 {
+			continue
+		}
+		png, err := base64.StdEncoding.DecodeString(m.Result.Data)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "b64:", err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(os.Args[2], png, 0644); err != nil {
+			fmt.Fprintln(os.Stderr, "save:", err)
+			os.Exit(1)
+		}
+		fmt.Println("saved", os.Args[2], len(png), "bytes")
+		return
+	}
+}

--- a/vendor/github.com/0magnet/bottle/bottle.go
+++ b/vendor/github.com/0magnet/bottle/bottle.go
@@ -33,8 +33,17 @@ var jsfs []byte
 //go:embed vnet.js
 var vnetJS []byte
 
+//go:embed vnet-sw.js
+var vnetSWJS []byte
+
 // JSFS returns jsfs.js — the globalThis.fs / globalThis.process filesystem.
 func JSFS() []byte { return jsfs }
 
 // VNetJS returns vnet.js — the globalThis.vnet virtual loopback network.
 func VNetJS() []byte { return vnetJS }
+
+// VNetSWJS returns vnet-sw.js — the service worker that turns virtual
+// loopback ports into real same-origin URLs (/vnet/<port>/…), so iframes can
+// load in-page servers with native resolution. Serve it at the page's
+// directory as vnet-sw.js and call vnet.enableSW() from the page.
+func VNetSWJS() []byte { return vnetSWJS }

--- a/vendor/github.com/0magnet/bottle/jsfs.js
+++ b/vendor/github.com/0magnet/bottle/jsfs.js
@@ -405,12 +405,19 @@
 		let timer = null;
 		let lastSave = 0;
 		let saveChain = Promise.resolve();
+		// exclude(path) → true skips the file (and, for a dir, its whole
+		// subtree) from snapshots. The host uses it to keep DATABASES out:
+		// a store snapshotted mid-write restores corrupt and can hang its
+		// consumer on the next boot — runtime caches must be rebuilt, not
+		// carried. Configs, keys and user files persist; caches don't.
+		let excludeFn = null;
 
 		function serialize() {
 			const out = [];
 			(function walk(node, path) {
 				for (const [name, child] of node.entries) {
 					const p = path + '/' + name;
+					if (excludeFn && excludeFn(p)) continue;
 					const t = child.mode & 0o170000;
 					if (t === S_IFDIR) {
 						out.push({ p, t: 'd', m: child.mode & 0o7777, mt: child.mtimeMs });
@@ -516,9 +523,10 @@
 		}
 
 		return {
-			enable(dbName) {
+			enable(dbName, opts) {
 				if (enabled) return Promise.resolve({ restored: false });
 				if (typeof indexedDB === 'undefined') return Promise.resolve({ restored: false });
+				if (opts && typeof opts.exclude === 'function') excludeFn = opts.exclude;
 				return idbOpen(dbName || 'jsfs').then((d) => {
 					db = d;
 					return idbGet();

--- a/vendor/github.com/0magnet/bottle/vnet-sw.js
+++ b/vendor/github.com/0magnet/bottle/vnet-sw.js
@@ -1,0 +1,103 @@
+// vnet-sw.js — the service-worker half of the virtual loopback network.
+//
+// vnet.js gives a page an in-memory port table, which covers dialers that
+// live in the page: wasm instances, page scripts, the transcoding browser.
+// What it cannot cover is the browser engine itself — an <iframe> whose
+// document wants to load its own subresources (module graphs, XHR, fonts)
+// with NATIVE resolution needs real same-origin URLs, not a transcoder.
+//
+// This worker provides those URLs. It intercepts GET /vnet/<port>/<path>
+// (the prefix is configurable at register time via ?prefix=), forwards each
+// request to a window client over a MessageChannel, and the page answers
+// from its vnet port table (vnet.enableSW installs the responder). The
+// result: iframe.src = '/vnet/8001/' renders a server running INSIDE the
+// page as if it were a normal same-origin site — module imports, XHR and
+// history all behave natively.
+//
+// Navigations get one adjustment: <base href> is rewritten (or injected) to
+// point at /vnet/<port>/, so a document written for a server root resolves
+// its relative URLs back into the worker's scope.
+//
+// Multi-tab caveat (v1): requests are offered to every window client of the
+// origin and the first non-refusing answer wins. Two tabs both listening on
+// the same virtual port are ambiguous — the same way two page-loads of one
+// visor identity already are.
+'use strict';
+
+const PREFIX = (() => {
+	try {
+		const p = new URL(self.location.href).searchParams.get('prefix');
+		if (p && /^(\/[A-Za-z0-9._-]+)+\/$/.test(p)) return p;
+	} catch (e) { /* fall through */ }
+	return '/vnet/';
+})();
+
+self.addEventListener('install', (e) => { self.skipWaiting(); });
+self.addEventListener('activate', (e) => { e.waitUntil(self.clients.claim()); });
+
+function askClient(client, req) {
+	return new Promise((resolve) => {
+		const ch = new MessageChannel();
+		let done = false;
+		const timer = setTimeout(() => { if (!done) { done = true; resolve(null); } }, 8000);
+		ch.port1.onmessage = (ev) => {
+			if (done) return;
+			done = true;
+			clearTimeout(timer);
+			const m = ev.data || {};
+			resolve(m.refused ? null : m);
+		};
+		client.postMessage({ type: 'vnet-fetch', port: req.port, method: req.method, path: req.path, headers: req.headers, body: req.body }, [ch.port2]);
+	});
+}
+
+function rewriteBase(html, port) {
+	const href = PREFIX + port + '/';
+	if (/<base\b[^>]*>/i.test(html)) return html.replace(/<base\b[^>]*>/i, '<base href="' + href + '">');
+	if (/<head\b[^>]*>/i.test(html)) return html.replace(/(<head\b[^>]*>)/i, '$1<base href="' + href + '">');
+	return '<base href="' + href + '">' + html;
+}
+
+self.addEventListener('fetch', (event) => {
+	const url = new URL(event.request.url);
+	if (url.origin !== self.location.origin || !url.pathname.startsWith(PREFIX)) return;
+	const rest = url.pathname.slice(PREFIX.length);
+	const slash = rest.indexOf('/');
+	const portStr = slash < 0 ? rest : rest.slice(0, slash);
+	const port = parseInt(portStr, 10);
+	if (!port || String(port) !== portStr) return;
+	const path = (slash < 0 ? '/' : rest.slice(slash)) + (url.search || '');
+
+	event.respondWith((async () => {
+		const headers = {};
+		for (const [k, v] of event.request.headers.entries()) {
+			// Hop-by-hop / browser-managed headers stay out of the virtual wire.
+			if (/^(host|connection|content-length|accept-encoding|upgrade|via)$/i.test(k)) continue;
+			headers[k] = v;
+		}
+		let body = null;
+		if (!/^(GET|HEAD)$/i.test(event.request.method)) {
+			try { body = new Uint8Array(await event.request.arrayBuffer()); } catch (e) { body = null; }
+		}
+		const req = { port: port, method: event.request.method, path: path, headers: headers, body: body };
+
+		const clis = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+		for (const c of clis) {
+			const m = await askClient(c, req);
+			if (!m) continue;
+			const respHeaders = new Headers();
+			const hs = m.headers || {};
+			for (const k in hs) { if (Object.prototype.hasOwnProperty.call(hs, k)) { try { respHeaders.set(k, hs[k]); } catch (e) { /* forbidden name */ } } }
+			respHeaders.set('cache-control', 'no-store');
+			let bodyBytes = m.body instanceof Uint8Array ? m.body : new Uint8Array(0);
+			const ct = (hs['content-type'] || '').toLowerCase();
+			if (event.request.mode === 'navigate' && ct.indexOf('text/html') >= 0) {
+				const html = rewriteBase(new TextDecoder().decode(bodyBytes), port);
+				bodyBytes = new TextEncoder().encode(html);
+				respHeaders.delete('content-length');
+			}
+			return new Response(bodyBytes, { status: m.status || 200, headers: respHeaders });
+		}
+		return new Response('vnet: no page answered for port ' + port, { status: 504, headers: { 'content-type': 'text/plain' } });
+	})());
+});

--- a/vendor/github.com/0magnet/bottle/vnet.js
+++ b/vendor/github.com/0magnet/bottle/vnet.js
@@ -31,6 +31,9 @@
 		if (cb) { c.wake[side] = null; queueMicrotask(cb); }
 	}
 
+	// Service-worker bridge state (see enableSW below).
+	let swPrefix = null;
+
 	globalThis.vnet = {
 		// listen claims a port; onconn(connId) fires per inbound dial (the
 		// accepter is side 'b' of that conn). Returns false if taken.
@@ -195,6 +198,66 @@
 				};
 				pump();
 			});
+		},
+
+		// enableSW registers the vnet service worker (vnet-sw.js) and installs
+		// the responder that answers its forwarded requests from this page's
+		// port table. Once resolved, swURL() returns REAL same-origin URLs for
+		// virtual ports — an <iframe src=vnet.swURL(8001)> loads a server
+		// running inside this page with fully native resolution (module
+		// graphs, XHR, history), no transcoding. Resolves to true when the
+		// bridge is live, false when service workers are unavailable (no
+		// secure context, file://, browser policy) — callers fall back to
+		// whatever they did before.
+		enableSW(swPath, prefix) {
+			// Default the scope to a vnet/ directory BESIDE the page, so the
+			// bridge works for pages deployed under a subdirectory (GitHub
+			// Pages) exactly as at a server root.
+			if (!prefix) {
+				try { prefix = new URL('vnet/', location.href).pathname; } catch (e) { prefix = '/vnet/'; }
+			}
+			if (swPrefix) return Promise.resolve(true);
+			if (!('serviceWorker' in navigator)) return Promise.resolve(false);
+			navigator.serviceWorker.addEventListener('message', (ev) => {
+				const m = ev.data || {};
+				if (m.type !== 'vnet-fetch' || !ev.ports || !ev.ports[0]) return;
+				const reply = ev.ports[0];
+				if (!this.listening(m.port)) { reply.postMessage({ refused: true }); return; }
+				this.httpFetch(m.port, m.method, m.path, m.body, m.headers)
+					.then((r) => {
+						// Uint8Array bodies structured-clone fine; pass headers as
+						// a plain object (already lowercased by httpFetch).
+						reply.postMessage({ status: r.status, headers: r.headers, body: r.body });
+					})
+					.catch(() => { reply.postMessage({ status: 502, headers: { 'content-type': 'text/plain' }, body: new TextEncoder().encode('vnet: fetch failed') }); });
+			});
+			const url = (swPath || 'vnet-sw.js') + '?prefix=' + encodeURIComponent(prefix);
+			return navigator.serviceWorker.register(url, { scope: prefix })
+				.then((reg) => new Promise((resolve) => {
+					// Wait on THIS registration's worker reaching 'activated'.
+					// (navigator.serviceWorker.ready is the wrong wait here: it
+					// tracks the registration matching the PAGE's URL, and the
+					// registering page normally lives outside the vnet scope —
+					// it would never resolve.)
+					const settle = (w) => {
+						if (!w) { resolve(false); return; }
+						if (w.state === 'activated') { resolve(true); return; }
+						w.addEventListener('statechange', () => {
+							if (w.state === 'activated') resolve(true);
+							else if (w.state === 'redundant') resolve(false);
+						});
+					};
+					settle(reg.active || reg.waiting || reg.installing);
+				}))
+				.then((ok) => { if (ok) swPrefix = prefix; return ok; })
+				.catch(() => false);
+		},
+
+		// swURL returns the real same-origin URL prefix for a virtual port
+		// ('/vnet/8001/'), or null when the service-worker bridge is not live.
+		swURL(port, path) {
+			if (!swPrefix) return null;
+			return swPrefix + port + (path || '/');
 		},
 	};
 })();

--- a/vendor/github.com/0magnet/netscrape/browse.js
+++ b/vendor/github.com/0magnet/netscrape/browse.js
@@ -289,6 +289,18 @@
   function createBrowser(opts) {
     var frame = opts.frame;
     var fetchDmsg = opts.fetchDmsg || function () { return globalThis.skywireVisor.fetchDmsg.apply(null, arguments); };
+    // The iframe's sandbox is per-navigation state: transcoded/remote content
+    // keeps the original sandbox, while a service-worker vnet load must run
+    // UNsandboxed (an opaque-origin document is not controlled by the page's
+    // service worker, so its module/XHR subresources would bypass the vnet
+    // bridge). The attribute only applies at load time, so flipping it right
+    // before each navigation is exact.
+    var frameSandbox = frame.getAttribute && frame.getAttribute("sandbox");
+    function frameTrusted(on) {
+      if (frameSandbox == null) return; // page runs frames unsandboxed anyway (real-origin build)
+      if (on) frame.removeAttribute("sandbox");
+      else frame.setAttribute("sandbox", frameSandbox);
+    }
     // Virtual-loopback channel: a host of 127.0.0.1[:port] / localhost[:port]
     // routes over the page's vnet port table — the listeners of a wasm visor
     // running IN this page (hypervisor UI :8000, etc.) — instead of dmsg.
@@ -646,6 +658,7 @@
       var gen = ++loadGen;
       resetFavicon(); // default icon now; the site's own favicon replaces it once fetched
       setLoading(true);
+      frameTrusted(false); // every navigation defaults to sandboxed; trusted branches upgrade
       try {
         // Real-origin: hand the whole load to the browser via an isolated origin.
         // (Not for virtual-loopback targets — those live inside THIS page's vnet,
@@ -684,6 +697,23 @@
           if (opts.setAddr) opts.setAddr(durl);
           try { if (typeof hideConnecting === "function") { hideConnecting(); } } catch (e) {}
           log("loopback direct (no vnet listener): " + durl);
+          setLoading(false);
+          return { status: 0, direct: true };
+        }
+        // Virtual-loopback with the service-worker bridge live: load the
+        // in-page server through its REAL same-origin URL (/vnet/<port>/…)
+        // instead of the transcoder. Native resolution end to end — module
+        // graphs (an Angular UI's chunk imports), XHR, history — the
+        // transcoder can't express a module graph in a srcdoc.
+        if (lp0 && globalThis.vnet && globalThis.vnet.swURL && globalThis.vnet.swURL(lp0)) {
+          var surl = globalThis.vnet.swURL(lp0, entry.path || "/");
+          currentSitePK = "";
+          frameTrusted(true); // in-page server: same-trust as the page itself
+          frame.removeAttribute("srcdoc");
+          frame.src = surl;
+          if (opts.setAddr) opts.setAddr("http://" + entry.pk + (entry.path || "/"));
+          try { if (typeof hideConnecting === "function") { hideConnecting(); } } catch (e) {}
+          log("loopback via vnet service worker: " + surl);
           setLoading(false);
           return { status: 0, direct: true };
         }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,7 +25,7 @@ github.com/0magnet/bbolt
 github.com/0magnet/bbolt/errors
 github.com/0magnet/bbolt/internal/common
 github.com/0magnet/bbolt/internal/freelist
-# github.com/0magnet/bottle v0.0.0-20260902192631-211d2d030c2b
+# github.com/0magnet/bottle v0.0.0-20260902200243-44a3a636767a
 ## explicit; go 1.24
 github.com/0magnet/bottle
 github.com/0magnet/bottle/vnet
@@ -51,7 +51,7 @@ github.com/0magnet/gotop/v4/widgets
 # github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b
 ## explicit; go 1.24.0
 github.com/0magnet/metrics
-# github.com/0magnet/netscrape v0.0.0-20260902082747-92e7877355d4
+# github.com/0magnet/netscrape v0.0.0-20260902195455-ed17b71dd13b
 ## explicit; go 1.24
 github.com/0magnet/netscrape
 # github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,7 +25,7 @@ github.com/0magnet/bbolt
 github.com/0magnet/bbolt/errors
 github.com/0magnet/bbolt/internal/common
 github.com/0magnet/bbolt/internal/freelist
-# github.com/0magnet/bottle v0.0.0-20260902082749-b333a0d36741
+# github.com/0magnet/bottle v0.0.0-20260902192631-211d2d030c2b
 ## explicit; go 1.24
 github.com/0magnet/bottle
 github.com/0magnet/bottle/vnet


### PR DESCRIPTION
Four fixes for the converged /desk page plus the round-4 CI items.

**vnet service worker (bottle) + native SPA rendering (netscrape).** The nested browser's transcoder inlines module scripts as data: URIs, but the Angular HV UI's main bundle statically imports ./chunk-*.js — unresolvable from a data: base, so the app never bootstrapped (empty app-root while its API poller ran). bottle's new vnet-sw.js intercepts /vnet/<port>/* and bridges each request to the page's port table over a MessageChannel; netscrape loads loopback windows through those real same-origin URLs, unsandboxed (an opaque-origin document escapes the worker). The full SPA — chunks, XHR, router — now renders natively in the window. The worker is served beside every desk-ish page (hv serve, /desk, native HV dashboard, docs playground).

**autoconfig: preserve an existing config's hypervisor.** The implicit new-install hypervisor enable was recorded nowhere; the next autoconfig run regenerated the config without -i and the UI silently disappeared (every /desk reload runs autoconfig, but the same footgun exists on native). The no-directive path now re-asserts -i when the existing config has the hypervisor enabled.

**Store exclusion + session capture.** bbolt stores snapshotted mid-write restore corrupt and stall their consumer, so *.db and /opt/skywire/local stay out of fs snapshots; the desk session records an operator stop only after the visor was seen up. The js build also drops the HV password gate (reachable only through the page's own vnet; users.db is excluded from snapshots by design).

**CI round 4:** pty exec-stream cancels the command on write error with a 10s keepalive bounding disconnect detection; gen_test tolerates stray log lines after the JSON.

Validated in Brave: fresh boot HV-up 10s; reload with persisted state HV-up 11.5s, same visor PK, dashboard rendering in the nested browser, 0 console errors. TestCommittedWasmNotStale fails as expected until the follow-up blob-refresh PR.