### PR TITLE
feat(desk): tabbed browser + terminal, proxy chain on by default for browser visors

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -574,6 +574,22 @@ var genConfigCmd = &cobra.Command{
 		if isUsrEnv {
 			isHypervisor = true
 		}
+		// Browser visor defaults: the resolving-proxy chain + the proxy
+		// client ARE the page's clearnet path (the nested browser chains
+		// dmsgweb :4445 → skynetweb :4446 → skysocks-client :1080 on the
+		// virtual loopback), so they default ON under js — explicit flags
+		// still win either way.
+		if skyenv.OS == "js" {
+			if !cmd.Flags().Changed("dmsgweb") {
+				enableDmsgWeb = true
+			}
+			if !cmd.Flags().Changed("skynetweb") {
+				enableSkynetWeb = true
+			}
+			if !cmd.Flags().Changed("startproxyclient") {
+				enableProxyClientAutostart = true
+			}
+		}
 		//use test deployment
 		if isTestEnv {
 			serviceConfURL = testServiceConfURL

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/0magnet/golang-ipc v1.2.5-0.20260901195306-becfc11f7586
 	github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77
 	github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b
-	github.com/0magnet/netscrape v0.0.0-20260902195455-ed17b71dd13b
+	github.com/0magnet/netscrape v0.0.0-20260902211921-ffd322b843c0
 	github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408
 	github.com/0magnet/realorigin v0.2.0
 	github.com/0magnet/sysinfo v1.1.4-0.20260901201859-b4abd4e87c26

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77 h1:4Th5JTWexd+r
 github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77/go.mod h1:F6WLpAz89R80LgQy9Veg6jZVdfY3FLmxqt23Okck35A=
 github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b h1:l/c7X12CNncX2phqLeQPiNjxu2ou7spv3xslwloyPjE=
 github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b/go.mod h1:SwLy2vvXGWJQxefDI4DncGdXJWIob5IGczxeFMtUIj8=
-github.com/0magnet/netscrape v0.0.0-20260902195455-ed17b71dd13b h1:ImdwmeLEaTkEP3kQrEG3A0Rbmhthg1614MThb8/IWtE=
-github.com/0magnet/netscrape v0.0.0-20260902195455-ed17b71dd13b/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
+github.com/0magnet/netscrape v0.0.0-20260902211921-ffd322b843c0 h1:2qD2goZ+9CQUsIuf3WJiHDwXR9g1wCJDTT2/+jfVF2g=
+github.com/0magnet/netscrape v0.0.0-20260902211921-ffd322b843c0/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
 github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408 h1:iXCaIMD5kmvYINoBhIVv+nGtN4BRRVe64EDkOUtKvqg=
 github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408/go.mod h1:feFjgv6ByEzXixeUOB4gYwq9G8iv35aQJiYc/8ZHDWg=
 github.com/0magnet/realorigin v0.2.0 h1:+xfvyuQzRGKAtQ88WziCVK3/poPTzc4pvc0i5+kPNUc=

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0magnet/bottle/vnet"
 	"github.com/armon/go-socks5"
 	"github.com/chen3feng/safecast"
 	"github.com/sirupsen/logrus"
@@ -570,7 +571,10 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 	log.WithField("addr", lisAddr).Debug("Serving SOCKS5 direct proxy")
 	// Open the listener ourselves so we can close it on ctx cancel —
 	// armon/go-socks5's Serve returns when the listener is closed.
-	lis, err := net.Listen("tcp", lisAddr)
+	// bottle/vnet: net.Listen natively; the page's virtual-loopback port
+	// table under js/wasm, so a browser visor's resolving proxy is
+	// dialable at vnet 127.0.0.1:<port> (the nested browser's upstream).
+	lis, err := vnet.Listen("tcp", lisAddr)
 	if err != nil {
 		return fmt.Errorf("SOCKS5 listen: %w", err)
 	}

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0magnet/bottle/vnet"
 	"github.com/armon/go-socks5"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/proxy"
@@ -483,7 +484,7 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 
 	// Open the listener ourselves so we can close it on ctx cancel —
 	// armon/go-socks5's Serve returns when the listener is closed.
-	lis, err := net.Listen("tcp", lisAddr)
+	lis, err := vnet.Listen("tcp", lisAddr) // bottle/vnet: real socket natively, page port table under js
 	if err != nil {
 		return fmt.Errorf("SOCKS5 listen: %w", err)
 	}

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -555,7 +555,24 @@ func initEmbeddedSkynetWeb(ctx context.Context, v *Visor, log *logging.Logger) e
 		log.Warn("skynet_web configured but router not available; skipping")
 		return nil
 	}
-	runtime := newEmbeddedSkynetWeb(ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.services.SelfDial, v.services.SelfDialAs, v.conf.SkynetWeb, log)
+	// Auto-chain: no explicit upstream and the proxy client is set to
+	// autostart → forward non-.skynet CONNECTs to it, completing the
+	// dmsgweb → skynetweb → skysocks-client chain from one config. The
+	// upstream may bind later than this proxy (the client's auto-exit
+	// selection runs in the background); until then clearnet CONNECTs
+	// fail exactly as they would with no upstream at all.
+	cfg := v.conf.SkynetWeb
+	if cfg.UpstreamSOCKS == "" && v.conf.Launcher != nil {
+		for _, ac := range v.conf.Launcher.Apps {
+			if ac.Name == skyenv.SkysocksClientName && ac.AutoStart {
+				cfg.UpstreamSOCKS = skyenv.SkysocksClientAddr
+				log.WithField("upstream", cfg.UpstreamSOCKS).
+					Info("Auto-chaining skynetweb → skysocks-client for clearnet")
+				break
+			}
+		}
+	}
+	runtime := newEmbeddedSkynetWeb(ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.services.SelfDial, v.services.SelfDialAs, cfg, log)
 	runtime.statusProvider = v.proxyStatusProvider()
 	v.initLock.Lock()
 	v.embeddedSkynetWeb = runtime

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	mathrand "math/rand"
 	"mime"
 	"net"
 	nrpc "net/rpc"
@@ -119,6 +120,21 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 		})
 	}
 
+	// Proxy-client auto-exit. skysocks-client hard-requires a server key —
+	// autostart with none configured would just crash-loop. Instead of
+	// letting it, defer its autostart and pick an exit from service
+	// discovery in the background (autoStartProxyClient), then start the
+	// app through the same path `cli proxy start` uses. This is what makes
+	// a browser visor's proxy chain work out of the box, and turns the
+	// native "autostart but no PK" misconfiguration into something useful.
+	autoProxyClient := false
+	for i, ac := range apps {
+		if ac.Name == skyenv.SkysocksClientName && ac.AutoStart && !argsContain(ac.Args, "--srv") {
+			apps[i].AutoStart = false
+			autoProxyClient = true
+		}
+	}
+
 	// Prepare launcher.
 	launchConf := launcher.AppLauncherConfig{
 		VisorPK:       v.conf.PK,
@@ -153,7 +169,61 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 	v.appL = launch
 	v.initLock.Unlock()
 
+	if autoProxyClient {
+		go v.autoStartProxyClient(v.MasterLogger().PackageLogger("proxy_client_auto")) //nolint:gosec // G118: uses v.ctx, outlives the init ctx by design
+	}
+
 	return nil
+}
+
+// argsContain reports whether an app's args include the given flag.
+func argsContain(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// autoStartProxyClient picks a proxy exit from service discovery and starts
+// skysocks-client on it — the deferred autostart for a config that says
+// "autostart the proxy client" without pinning a server. Retries the whole
+// cycle while the visor lives: discovery needs dmsg up, and early fetches
+// legitimately fail during boot. Exits once the client starts (the app's own
+// retrier + restart policy take over from there).
+func (v *Visor) autoStartProxyClient(log *logging.Logger) {
+	ctx := v.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(10 * time.Second):
+		}
+		svcs, err := v.ProxyServers("", "")
+		if err != nil || len(svcs) == 0 {
+			continue
+		}
+		// Random order, a handful of candidates per cycle: a dead exit
+		// shouldn't pin the loop, and the whole list shouldn't be dialed.
+		idx := mathrand.Perm(len(svcs))
+		tries := len(idx)
+		if tries > 5 {
+			tries = 5
+		}
+		for _, i := range idx[:tries] {
+			pk := svcs[i].Addr.PubKey().String()
+			if err := v.StartSkysocksClient(pk); err != nil {
+				log.WithError(err).Debug("proxy-client auto-exit candidate failed; trying another")
+				continue
+			}
+			log.WithField("exit", pk).Info("Proxy client auto-started on a discovered exit")
+			return
+		}
+	}
 }
 
 // appsContains reports whether an apps[] slice already contains an

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -171,6 +171,13 @@
 							try {
 								var win = panel.openWindow(true); // skipLanding
 								win.browser.browseTo('127.0.0.1:' + hvPort, '/');
+								// Default background tabs (browser-style): the
+								// deployment landing page and the proxy status
+								// page ride along behind the hypervisor UI.
+								if (win.openTab) {
+									try { win.openTab('home.dmsg', '/', 'http', true); } catch (e2) {}
+									try { win.openTab('status.skysocks', '/', 'http', true); } catch (e2) {}
+								}
 								if (win.wb && win.wb.maximize) win.wb.maximize(true);
 							} catch (e) { console.error('hv window:', e); }
 						});

--- a/vendor/github.com/0magnet/netscrape/browse.js
+++ b/vendor/github.com/0magnet/netscrape/browse.js
@@ -1233,12 +1233,14 @@
     return wb;
   }
 
-  // createWindow builds ONE browse window — a dmsg virtual browser + host/proxy
-  // panels — as a WinBox. WinBox draws the title bar, window buttons and resize
-  // borders; we supply only the body (nav bar + panels + page iframe). opts.root
-  // is the WinBox mount container (so the desktop can be hidden as a unit);
-  // onClose runs when the window is closed. Returns {wb, browser, landHome}.
-  function createWindow(doc, opts, onClose) {
+  // createBrowserPane builds ONE browser TAB's whole surface — nav bar +
+  // collapsible proxy/info panels + the page iframe + its createBrowser
+  // engine. It is the body a browse window shows for its active tab; the
+  // tabbed createWindow below stacks panes and shows one at a time. paneCB
+  // carries {title(t), icon(u)} so the pane reflects its site into its TAB
+  // (and, when active, the window title) instead of owning a WinBox.
+  // Returns {el, browser, landHome, close}.
+  function createBrowserPane(doc, opts, paneCB) {
     var fetchDmsg = opts.fetchDmsg, serveContent = opts.serveContent;
     // The WinBox body: nav bar + collapsible host/proxy panels + the page iframe.
     // No window controls or resize grip here — WinBox draws those.
@@ -1328,17 +1330,7 @@
       '</div>';
 
     function $(id) { return wrap.querySelector("#" + id); }
-    var wb = makeWin(doc, {
-      title: "skynet", root: opts.root, top: opts.top, bottom: opts.bottom, width: "74%", height: "80%", mount: wrap,
-      onclose: function () {
-        // Release this window's skysocks-lite sessions/routes (per-window). browser
-        // is hoisted; it exists by the time onclose fires.
-        try { if (browser && browser.winId && globalThis.skywireVisor && globalThis.skywireVisor.closeWindow) { globalThis.skywireVisor.closeWindow(browser.winId); } } catch (e) {}
-        try { if (browser && browser.winId && globalThis.__skywireBrowserPanes) { delete globalThis.__skywireBrowserPanes[browser.winId]; } } catch (e) {}
-        if (onClose) onClose();
-      }
-    });
-    var win = { wb: wb, el: wrap };
+    var win = { el: wrap };
     var loading = false;
     // Per-window request log: a small ring buffer rendered as a terminal-like pane
     // in the ⚙ panel, so each browser window shows exactly what went through its
@@ -1366,10 +1358,11 @@
       // skywireVisor.* globals), the native HV UI passes /api/browse-backed ones.
       fetchClearnet: opts.fetchClearnet, selfPK: opts.selfPK, directViaBackend: opts.directViaBackend,
       log: function (m) { try { console.log("[skynet] " + m); } catch (e) {} plog(m); },
-      // Reflect the current site into the WinBox title bar.
-      setAddr: function (u) { $("sb-addr").value = u; var t = u.replace(/^https?:\/\//, "").slice(0, 18); try { wb.setTitle(t || "skynet"); } catch (e) {} },
-      // Reflect the site's favicon (fetched over the proxy/dmsg) into the title bar.
-      setIcon: function (u) { try { wb.setIcon(u); } catch (e) {} },
+      // Reflect the current site into this pane's TAB (and the window title
+      // when this tab is active) via paneCB.
+      setAddr: function (u) { $("sb-addr").value = u; var t = u.replace(/^https?:\/\//, "").slice(0, 18); try { paneCB.title(t || "skynet"); } catch (e) {} },
+      // Reflect the site's favicon (fetched over the proxy/dmsg) into the tab.
+      setIcon: function (u) { try { paneCB.icon(u); } catch (e) {} },
       // reflect load state into the reload/cancel button (⟳ idle, ✕ while loading)
       onLoading: function (on) { loading = on; var b = $("sb-reload"); b.textContent = on ? "✕" : "⟳"; b.title = on ? "cancel load" : "reload"; },
       // enable/disable back/forward to match history position
@@ -1523,14 +1516,137 @@
     dynBtn.onclick = function () { browser.setClearnetDynamic(!browser.clearnetDynamic()); renderDynBtn(); try { browser.reload(); } catch (e) {} };
 
     // home.dmsg (resolver alias for the deployment landing page), matching the
-    // socks5 resolving proxy's default — landed once per window.
+    // socks5 resolving proxy's default — landed once per pane.
     win.landHome = function () {
       if (!wrap.dataset.landed) { wrap.dataset.landed = "1"; browser.browseTo("home.dmsg", "/"); }
     };
+    // close releases this pane's skysocks-lite sessions/routes + its log sink —
+    // per-pane state keyed by browser.winId. Called by the tab's × and by the
+    // window's onclose (for every remaining pane).
+    win.close = function () {
+      try { if (browser && browser.winId && globalThis.skywireVisor && globalThis.skywireVisor.closeWindow) { globalThis.skywireVisor.closeWindow(browser.winId); } } catch (e) {}
+      try { if (browser && browser.winId && globalThis.__skywireBrowserPanes) { delete globalThis.__skywireBrowserPanes[browser.winId]; } } catch (e) {}
+    };
+
+    return win;
+  }
+
+  // createWindow builds one browse WINDOW: a tab strip over a stack of
+  // browser panes (createBrowserPane) inside a WinBox — browser-style tabs
+  // instead of one window per site. The active pane's title/favicon flow to
+  // its tab and the window title. Returns {wb, el, browser, landHome,
+  // openTab, addTab}; win.browser always points at the ACTIVE tab's engine,
+  // so single-tab callers (deep links, the desk boot) work unchanged.
+  function createWindow(doc, opts, onClose) {
+    var outer = doc.createElement("div");
+    outer.style.cssText = "position:absolute;inset:0;background:#15131c;display:flex;flex-direction:column;overflow:hidden";
+    var strip = doc.createElement("div");
+    strip.style.cssText = "display:flex;gap:2px;align-items:stretch;background:#100d18;border-bottom:1px solid #2a2342;padding:3px 3px 0;min-height:27px;overflow-x:auto;overflow-y:hidden";
+    var body = doc.createElement("div");
+    body.style.cssText = "position:relative;flex:1;min-height:0";
+    outer.appendChild(strip);
+    outer.appendChild(body);
+
+    var tabs = [], active = null, wb = null;
+    function reflectTitle() {
+      if (!wb || !active) return;
+      try { wb.setTitle(active.title || "skynet"); } catch (e) {}
+      try { if (active.iconURL) wb.setIcon(active.iconURL); } catch (e) {}
+    }
+    function activate(t) {
+      if (!t || active === t) return;
+      tabs.forEach(function (x) {
+        // "flex", not "" — the pane's cssText display:flex was overwritten by
+        // the inline "none", and clearing to "" would land on block (iframe
+        // collapses to its 150px default height).
+        x.pane.el.style.display = x === t ? "flex" : "none";
+        x.btn.style.background = x === t ? "#2a2342" : "transparent";
+        x.lbl.style.color = x === t ? "#fff" : "#9aa0a6";
+      });
+      active = t;
+      win.browser = t.pane.browser;
+      reflectTitle();
+    }
+    function closeTab(t) {
+      try { t.pane.close(); } catch (e) {}
+      t.pane.el.remove();
+      t.btn.remove();
+      var i = tabs.indexOf(t);
+      if (i >= 0) tabs.splice(i, 1);
+      if (!tabs.length) { try { wb.close(); } catch (e) {} return; }
+      if (active === t) { active = null; activate(tabs[Math.max(0, i - 1)]); }
+    }
+    function addTab(bg) {
+      var t = { title: "skynet", iconURL: "" };
+      t.btn = doc.createElement("div");
+      t.btn.style.cssText = "display:flex;align-items:center;gap:.4em;max-width:14em;padding:.25em .55em;cursor:pointer;font:11px monospace;border:1px solid #2a2342;border-bottom:0;border-radius:5px 5px 0 0;user-select:none;white-space:nowrap";
+      t.ico = doc.createElement("img");
+      t.ico.style.cssText = "width:12px;height:12px;display:none";
+      t.lbl = doc.createElement("span");
+      t.lbl.style.cssText = "overflow:hidden;text-overflow:ellipsis;color:#9aa0a6";
+      t.lbl.textContent = t.title;
+      var x = doc.createElement("span");
+      x.textContent = "×";
+      x.title = "close tab";
+      x.style.cssText = "cursor:pointer;opacity:.65;padding:0 .1em";
+      x.onclick = function (ev) { ev.stopPropagation(); closeTab(t); };
+      t.btn.appendChild(t.ico); t.btn.appendChild(t.lbl); t.btn.appendChild(x);
+      t.btn.onclick = function () { activate(t); };
+      strip.insertBefore(t.btn, plus);
+      t.pane = createBrowserPane(doc, opts, {
+        title: function (s) {
+          t.title = s || "skynet";
+          t.lbl.textContent = t.title;
+          t.btn.title = t.title;
+          if (active === t) reflectTitle();
+        },
+        icon: function (u) {
+          t.iconURL = u || "";
+          if (u) { t.ico.src = u; t.ico.style.display = ""; } else { t.ico.style.display = "none"; }
+          if (active === t) reflectTitle();
+        },
+      });
+      t.pane.el.style.display = "none";
+      body.appendChild(t.pane.el);
+      tabs.push(t);
+      // bg: open WITHOUT stealing focus (the desk stacks default tabs behind
+      // the hypervisor UI). The first tab always activates.
+      if (!bg || tabs.length === 1) { activate(t); }
+      return t;
+    }
+    var plus = doc.createElement("div");
+    plus.textContent = "+";
+    plus.title = "new tab";
+    plus.style.cssText = "display:flex;align-items:center;padding:.2em .55em;cursor:pointer;color:#9aa0a6;font:13px monospace;user-select:none";
+    plus.onclick = function () { var t = addTab(); t.pane.landHome(); };
+    strip.appendChild(plus);
+
+    wb = makeWin(doc, {
+      title: "skynet", root: opts.root, top: opts.top, bottom: opts.bottom, width: "74%", height: "80%", mount: outer,
+      onclose: function () {
+        tabs.slice().forEach(function (t) { try { t.pane.close(); } catch (e) {} });
+        tabs = [];
+        if (onClose) onClose();
+      }
+    });
+
+    var win = { wb: wb, el: outer };
+    var first = addTab();
+    win.browser = first.pane.browser;
+    // landHome lands the FIRST tab once (the classic single-tab behavior).
+    win.landHome = function () { first.pane.landHome(); };
+    // openTab opens a NEW tab and (optionally) navigates it: openTab(host,
+    // path, scheme) — host as the address-bar would take it (127.0.0.1:8001,
+    // home.dmsg, a PK…). Returns the tab's pane ({browser, …}).
+    win.openTab = function (host, path, scheme, bg) {
+      var t = addTab(bg);
+      if (host) { try { t.pane.browser.browseTo(host, path || "/", scheme); } catch (e) {} }
+      return t.pane;
+    };
+    win.addTab = function (bg) { return addTab(bg).pane; };
     // On a narrow (mobile) viewport, open maximized — a floating window is fiddly
     // to move/resize on a phone; full-screen is the usable default.
     if (((doc.defaultView || window).innerWidth || 9999) < 640) { try { wb.maximize(true); } catch (e) {} }
-
     return win;
   }
 
@@ -2379,35 +2495,107 @@
   // visors net health apps tps routes hvapi — emit JSON straight into it. Go
   // owns everything inside the mount element; this side supplies the frame and
   // closes the session.
+  // createShellWindow opens the TABBED terminal window: each console the desk
+  // (or the ☰ menu) asks for is a TAB of one window rather than its own
+  // WinBox, and + opens more. Every tab is its own session against the one
+  // shared in-tab shell instance (same filesystem). addTab({title, initCmd})
+  // adds one; closing the last tab closes the window.
   function createShellWindow(doc, opts) {
-    var mount = doc.createElement("div");
-    mount.style.cssText = "position:absolute;inset:0;background:#000;overflow:hidden";
-    var note = doc.createElement("div");
-    note.style.cssText = "position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#9aa0a6;font:12px monospace";
-    note.textContent = "starting the shell…";
-    mount.appendChild(note);
-    var handle = null;
-    var wb = makeWin(doc, {
-      title: opts.title || "shell", root: opts.root, top: opts.top, bottom: opts.bottom,
-      width: "56%", height: "62%", mount: mount,
+    var wrap = doc.createElement("div");
+    wrap.style.cssText = "position:absolute;inset:0;background:#000;overflow:hidden;display:flex;flex-direction:column";
+    var strip = doc.createElement("div");
+    strip.style.cssText = "display:flex;gap:2px;align-items:stretch;background:#15131c;border-bottom:1px solid #2a2342;padding:3px 3px 0;min-height:26px;overflow-x:auto;overflow-y:hidden";
+    var body = doc.createElement("div");
+    body.style.cssText = "position:relative;flex:1;min-height:0";
+    wrap.appendChild(strip);
+    wrap.appendChild(body);
+
+    var tabs = [], active = null, wb = null;
+    function setTitle() { try { wb.setTitle(active ? active.title : (opts.title || "terminal")); } catch (e) {} }
+    function activate(t) {
+      if (!t || active === t) return;
+      tabs.forEach(function (x) {
+        x.mount.style.display = x === t ? "" : "none";
+        x.btn.style.background = x === t ? "#2a2342" : "transparent";
+        x.lbl.style.color = x === t ? "#fff" : "#9aa0a6";
+      });
+      active = t;
+      setTitle();
+      // xterm sizes itself to a VISIBLE container: refit + refocus on switch.
+      try { if (t.handle && t.handle.fit) t.handle.fit(); } catch (e) {}
+      try { if (t.handle && t.handle.focus) t.handle.focus(); } catch (e) {}
+    }
+    function closeTab(t) {
+      try { if (t.handle && t.handle.close) t.handle.close(); } catch (e) {}
+      t.mount.remove();
+      t.btn.remove();
+      var i = tabs.indexOf(t);
+      if (i >= 0) tabs.splice(i, 1);
+      if (!tabs.length) { try { wb.close(); } catch (e) {} return; }
+      if (active === t) { active = null; activate(tabs[Math.max(0, i - 1)]); }
+    }
+    function addTab(o) {
+      o = o || {};
+      var t = { title: o.title || "shell", handle: null };
+      t.mount = doc.createElement("div");
+      t.mount.style.cssText = "position:absolute;inset:0;background:#000;overflow:hidden;display:none";
+      var note = doc.createElement("div");
+      note.style.cssText = "position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#9aa0a6;font:12px monospace";
+      note.textContent = "starting the shell…";
+      t.mount.appendChild(note);
+      body.appendChild(t.mount);
+      t.btn = doc.createElement("div");
+      t.btn.style.cssText = "display:flex;align-items:center;gap:.45em;max-width:12em;padding:.25em .6em;cursor:pointer;font:11px monospace;border:1px solid #2a2342;border-bottom:0;border-radius:5px 5px 0 0;user-select:none;white-space:nowrap";
+      t.lbl = doc.createElement("span");
+      t.lbl.style.cssText = "overflow:hidden;text-overflow:ellipsis;color:#9aa0a6";
+      t.lbl.textContent = t.title;
+      var x = doc.createElement("span");
+      x.textContent = "×";
+      x.title = "close tab";
+      x.style.cssText = "cursor:pointer;opacity:.65;padding:0 .1em";
+      x.onclick = function (ev) { ev.stopPropagation(); closeTab(t); };
+      t.btn.appendChild(t.lbl);
+      t.btn.appendChild(x);
+      t.btn.onclick = function () { activate(t); };
+      strip.insertBefore(t.btn, plus);
+      tabs.push(t);
+      activate(t);
+      ensureShell().then(function (sh) {
+        note.remove();
+        t.handle = sh.open(t.mount);
+        if (t.handle && t.handle.error) { t.mount.textContent = "shell: " + t.handle.error; return; }
+        if (active === t && t.handle && t.handle.focus) { try { t.handle.focus(); } catch (e) {} }
+        // initCmd: run one command as if typed — the desk's default layout uses
+        // this ("skywire --help" in the docs playground; "skywire autoconfig"
+        // for a foreground visor terminal).
+        if (o.initCmd && t.handle && t.handle.run) { try { t.handle.run(o.initCmd); } catch (e) {} }
+      }).catch(function (e) {
+        note.textContent = "shell failed to start: " + (e.message || e);
+      });
+      return t;
+    }
+    var plus = doc.createElement("div");
+    plus.textContent = "+";
+    plus.title = "new terminal tab";
+    plus.style.cssText = "display:flex;align-items:center;padding:.2em .55em;cursor:pointer;color:#9aa0a6;font:13px monospace;user-select:none";
+    plus.onclick = function () { addTab({ title: "shell" }); };
+    strip.appendChild(plus);
+
+    wb = makeWin(doc, {
+      title: opts.title || "terminal", root: opts.root, top: opts.top, bottom: opts.bottom,
+      width: "56%", height: "62%", mount: wrap,
       onclose: function () {
-        try { if (handle && handle.close) { handle.close(); } } catch (e) {}
+        tabs.slice().forEach(function (t) { try { if (t.handle && t.handle.close) { t.handle.close(); } } catch (e) {} });
+        tabs = [];
         if (opts.onClose) { opts.onClose(); }
       }
     });
-    ensureShell().then(function (sh) {
-      note.remove();
-      handle = sh.open(mount);
-      if (handle && handle.error) { mount.textContent = "shell: " + handle.error; return; }
-      if (handle && handle.focus) { handle.focus(); }
-      // initCmd: run one command as if typed — the desk's default layout uses
-      // this ("skywire --help" in the docs playground; "skywire autoconfig"
-      // for a foreground visor terminal).
-      if (opts.initCmd && handle && handle.run) { try { handle.run(opts.initCmd); } catch (e) {} }
-    }).catch(function (e) {
-      note.textContent = "shell failed to start: " + (e.message || e);
-    });
-    return { wb: wb, close: function () { wb.close(); } };
+    addTab({ title: opts.title || "shell", initCmd: opts.initCmd });
+    return {
+      wb: wb,
+      close: function () { wb.close(); },
+      addTab: function (o) { return addTab(o); },
+    };
   }
 
   // createFilesWindow opens a GUI file browser over the SHARED websh filesystem
@@ -2983,27 +3171,34 @@
     }
     var cliWin = null;
     function openCli() {
+      // A tab with a visor in it runs the real shell — as a TAB of the shared
+      // terminal window; the native HV UI overlay (no in-tab visor) keeps the
+      // REPL window.
+      if (globalThis.skywireVisor) { openConsole({ title: "visor shell" }); return; }
       if (focusExisting(cliWin)) { return; }
       var close = function () { untrack(cliWin); cliWin = null; };
-      // A tab with a visor in it runs the real shell; the native HV UI overlay
-      // (no in-tab visor) keeps the REPL.
-      cliWin = globalThis.skywireVisor
-        ? createShellWindow(doc, withRoot({ title: "visor shell", onClose: close }))
-        : createCliWindow(doc, withRoot({ onClose: close }));
+      cliWin = createCliWindow(doc, withRoot({ onClose: close }));
       track(cliWin, "console");
     }
-    // openConsole always opens a NEW shell window (unlike openCli, which
-    // focuses the existing one) — the desk's default layout wants several
-    // (a visor terminal AND a help terminal). o: {title, initCmd}.
+    // openConsole opens a TAB of the shared tabbed terminal window (creating
+    // the window on first use) — the desk's default layout wants several
+    // consoles (a visor terminal AND a help terminal) condensed into tabs
+    // instead of stacked windows. o: {title, initCmd}.
+    var consoleWin = null;
     function openConsole(o) {
       o = o || {};
-      var win = null;
-      win = createShellWindow(doc, withRoot({
+      if (consoleWin && consoleWin.addTab) {
+        consoleWin.addTab({ title: o.title || "shell", initCmd: o.initCmd || "" });
+        try { consoleWin.wb.minimize(false); consoleWin.wb.focus(); } catch (e) {}
+        return consoleWin;
+      }
+      var win = createShellWindow(doc, withRoot({
         title: o.title || "shell",
         initCmd: o.initCmd || "",
-        onClose: function () { untrack(win); },
+        onClose: function () { untrack(win); if (consoleWin === win) { consoleWin = null; } },
       }));
-      track(win, o.title || "shell");
+      consoleWin = win;
+      track(win, "terminal");
       return win;
     }
     var filesWin = null;

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -51,7 +51,7 @@ github.com/0magnet/gotop/v4/widgets
 # github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b
 ## explicit; go 1.24.0
 github.com/0magnet/metrics
-# github.com/0magnet/netscrape v0.0.0-20260902195455-ed17b71dd13b
+# github.com/0magnet/netscrape v0.0.0-20260902211921-ffd322b843c0
 ## explicit; go 1.24
 github.com/0magnet/netscrape
 # github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408


### PR DESCRIPTION
Tabs (netscrape): the browse window becomes a tab strip over browser panes — each tab a full pane with its own engine and per-tab skysocks sessions, + to open more, win.openTab() for programmatic tabs. The terminal window is tabbed the same way; openConsole() adds tabs instead of windows. The desk boots to two windows: a terminal (visor + skywire tabs) and the browser (hypervisor UI active, home.dmsg + status.skysocks as background tabs).

Proxy chain by default under js: config gen enables dmsgweb (:4445), skynetweb (:4446) and proxy-client autostart for browser visors (explicit flags still win); the resolving proxies listen via bottle/vnet so those ports exist on the page's virtual loopback; skynetweb auto-chains to the proxy client the way dmsgweb chains to skynetweb. Proxy-client autostart without a pinned server no longer crash-loops — a background loop picks an exit from service discovery and starts it through the same path cli proxy start uses (native benefits identically).

Validated live: chain 4445→4446→1080 listening 26s after a cold boot, tabbed layout at 32s, 0 console errors. TestCommittedWasmNotStale expected stale until the follow-up blob PR.