### PR TITLE
fix(dmsg): carrier converge dials the wanted carrier only — no fallback churn

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,11 +60,11 @@ require (
 
 require (
 	github.com/0magnet/bbolt v1.5.1-0.20260901223329-c4feec896898
-	github.com/0magnet/bottle v0.0.0-20260903012749-c56103278d72
+	github.com/0magnet/bottle v0.0.0-20260903015103-41ea02c59a55
 	github.com/0magnet/golang-ipc v1.2.5-0.20260901195306-becfc11f7586
 	github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77
 	github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b
-	github.com/0magnet/netscrape v0.0.0-20260902211921-ffd322b843c0
+	github.com/0magnet/netscrape v0.0.0-20260903020822-5d615b86f555
 	github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408
 	github.com/0magnet/realorigin v0.2.0
 	github.com/0magnet/sysinfo v1.1.4-0.20260901201859-b4abd4e87c26

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/0magnet/afero v1.15.1-0.20260816202415-9f9d46a34dcd h1:zhADHH+Lu7o4U1
 github.com/0magnet/afero v1.15.1-0.20260816202415-9f9d46a34dcd/go.mod h1:JsJ3c6VwVpJOB3qUpT6YzgJ8yC+nBLUCcH2nhGLC6fA=
 github.com/0magnet/bbolt v1.5.1-0.20260901223329-c4feec896898 h1:5UyEWEOaKdF8RAfc/fBxqrpEgsga0NCuRYkA9xegoos=
 github.com/0magnet/bbolt v1.5.1-0.20260901223329-c4feec896898/go.mod h1:w+uhwkS5wbYmWTm2Dvvp3AWUR8TNrksPutxoBn4sESY=
-github.com/0magnet/bottle v0.0.0-20260903012749-c56103278d72 h1:gDqLiSalImW3R2dPxCjQcTChj2eXjjQy/6l3j+Dpzdw=
-github.com/0magnet/bottle v0.0.0-20260903012749-c56103278d72/go.mod h1:02z8sWzqF3QH4SjMxnx5bnysFUqsw9CdUTtIj+CIxkw=
+github.com/0magnet/bottle v0.0.0-20260903015103-41ea02c59a55 h1:UwtxPbuT7fRteYkwjbjHIGJavaW5iRXR8sUmnHTfJfE=
+github.com/0magnet/bottle v0.0.0-20260903015103-41ea02c59a55/go.mod h1:02z8sWzqF3QH4SjMxnx5bnysFUqsw9CdUTtIj+CIxkw=
 github.com/0magnet/coloredcobra v1.0.3-0.20260902084726-57ccbecfc077 h1:cWpt53uNQFCMUl8zmh73xb/EuigbO3Qe+KP4ggpwvy8=
 github.com/0magnet/coloredcobra v1.0.3-0.20260902084726-57ccbecfc077/go.mod h1:Kn7dmRJcnVybFNKY0FNUjLcsivW4FCbAec8ZfVmz51I=
 github.com/0magnet/cosmos-go v0.0.0-20260814190035-f5b882c1ea9e h1:fyLB1qUtpMxPeZp4MdZu5yLHHR+kLl2MZfhG0djlGIo=
@@ -80,8 +80,8 @@ github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77 h1:4Th5JTWexd+r
 github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77/go.mod h1:F6WLpAz89R80LgQy9Veg6jZVdfY3FLmxqt23Okck35A=
 github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b h1:l/c7X12CNncX2phqLeQPiNjxu2ou7spv3xslwloyPjE=
 github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b/go.mod h1:SwLy2vvXGWJQxefDI4DncGdXJWIob5IGczxeFMtUIj8=
-github.com/0magnet/netscrape v0.0.0-20260902211921-ffd322b843c0 h1:2qD2goZ+9CQUsIuf3WJiHDwXR9g1wCJDTT2/+jfVF2g=
-github.com/0magnet/netscrape v0.0.0-20260902211921-ffd322b843c0/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
+github.com/0magnet/netscrape v0.0.0-20260903020822-5d615b86f555 h1:Tmp+sFOUnEd/OdUAzn/J/RjYOx0vVggeKTTBK5o9mnw=
+github.com/0magnet/netscrape v0.0.0-20260903020822-5d615b86f555/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
 github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408 h1:iXCaIMD5kmvYINoBhIVv+nGtN4BRRVe64EDkOUtKvqg=
 github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408/go.mod h1:feFjgv6ByEzXixeUOB4gYwq9G8iv35aQJiYc/8ZHDWg=
 github.com/0magnet/realorigin v0.2.0 h1:+xfvyuQzRGKAtQ88WziCVK3/poPTzc4pvc0i5+kPNUc=

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -273,33 +273,8 @@ func (ce *Client) SessionCarriers() []SessionCarrier {
 // No-op when no carrier preference is set (empty Carriers = native default,
 // already optimal). Safe to call on a timer or on demand. Returns the number of
 // sessions re-dialed onto a MORE-preferred carrier this call.
-// probeCarrierErr does a throwaway direct dial of ONE carrier purely to capture
-// its failure reason (dialSession swallows per-carrier errors when it falls back
-// to a working carrier). The session, if it establishes, is never registered —
-// it is closed immediately. Returns "" for carriers with no native dialer.
-func (ce *Client) probeCarrierErr(entry *disc.Entry, carrier string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), carrierConvergeDialTimeout)
-	defer cancel()
-	var (
-		s   ClientSession
-		err error
-	)
-	switch carrier {
-	case CarrierWT:
-		s, err = ce.dialSessionWT(ctx, entry)
-	case CarrierWS:
-		s, err = ce.dialSessionWS(ctx, entry)
-	case CarrierQUIC:
-		s, err = ce.dialSessionQUIC(ctx, entry)
-	default:
-		return ""
-	}
-	if err != nil {
-		return err.Error()
-	}
-	_ = s.Close() //nolint:errcheck // throwaway probe session, never registered
-	return "dial succeeded on retry (transient failure)"
-}
+// (probeCarrierErr is gone: converge now dials the wanted carrier directly
+// via dialSessionOn, so the dial error itself carries the failure reason.)
 
 func (ce *Client) ConvergeCarriers() int {
 	carriers := ce.effectiveCarriers()
@@ -344,28 +319,21 @@ func (ce *Client) ConvergeCarriers() int {
 		if wantRank < 0 || curRank < 0 || wantRank >= curRank {
 			continue
 		}
+		// Dial the WANTED carrier only (dialSessionOn — no fallback). Using
+		// the fallback-capable dialSession here was a session-churn machine:
+		// newest-session-wins registers the dial result BEFORE this code can
+		// judge it, so a WT attempt that fell back to wss REPLACED (and
+		// closed) the healthy wss session with its own twin — every converge
+		// tick, for every server whose preferred carrier was unreachable.
+		// Live symptom: constant "Session stopped … session shutdown" +
+		// re-dials, session counts ballooning past sessions_count, and
+		// transports starving as their signaling sessions flapped.
 		dctx, dcancel := context.WithTimeout(context.Background(), carrierConvergeDialTimeout)
-		ns, derr := ce.dialSession(dctx, entry)
+		_, derr := ce.dialSessionOn(dctx, entry, want)
 		dcancel()
 		if derr != nil {
-			ce.log.WithError(derr).WithField("remote_pk", s.pk).Debug("carrier converge: re-dial failed; backing off")
-			ce.noteCarrierFailure(s.pk, fmt.Sprintf("re-dial to %s failed: %v", want, derr))
-			continue
-		}
-		if ns.carrier != want {
-			// Landed on a less-preferred carrier (preferred endpoint unreachable
-			// → dialSession fell back). Keep the working session, back off.
-			// dialSession swallows the per-carrier error on fallback, so do one
-			// throwaway direct dial of the wanted carrier to capture WHY it
-			// failed — this is the visor-side reproduction of the reachability
-			// the standalone `svc health --carriers` probe measures.
-			note := fmt.Sprintf("wanted %s but dial landed on %s", want, ns.carrier)
-			if detail := ce.probeCarrierErr(entry, want); detail != "" {
-				note += "; " + want + " err: " + detail
-			}
-			ce.log.WithField("remote_pk", s.pk).WithField("want", want).WithField("got", ns.carrier).
-				Debug("carrier converge: dial landed on a less-preferred carrier; backing off")
-			ce.noteCarrierFailure(s.pk, note)
+			ce.log.WithError(derr).WithField("remote_pk", s.pk).Debug("carrier converge: preferred-carrier dial failed; backing off")
+			ce.noteCarrierFailure(s.pk, fmt.Sprintf("%s dial failed: %v", want, derr))
 			continue
 		}
 		ce.log.WithField("remote_pk", s.pk).WithField("from", s.carrier).WithField("to", want).
@@ -630,6 +598,53 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 		}
 	}
 
+	return ce.finishDialedSession(ctx, dSes, network, dialAddr, entry)
+}
+
+// dialSessionOn dials entry over EXACTLY the given carrier — no fallback —
+// and registers the session (newest-session-wins) only on success. The
+// carrier-converge path needs this: dialSession's fallbacks would replace a
+// healthy session with a same-carrier twin (newest-wins closes the original)
+// whenever the preferred carrier was unreachable, churning every session the
+// converge ticker touched.
+func (ce *Client) dialSessionOn(ctx context.Context, entry *disc.Entry, carrier string) (ClientSession, error) {
+	var (
+		dSes     ClientSession
+		err      error
+		dialAddr string
+	)
+	switch carrier {
+	case CarrierWT:
+		dialAddr = entry.Server.AddressWT
+	case CarrierWS:
+		dialAddr = entry.Server.AddressWS
+	case CarrierQUIC:
+		dialAddr = entry.Server.AddressUDP
+	default:
+		return ClientSession{}, fmt.Errorf("dmsg: carrier %q not directly dialable", carrier)
+	}
+	if err = ce.conf.Callbacks.OnSessionDial(carrier, dialAddr); err != nil {
+		return ClientSession{}, fmt.Errorf("session dial is rejected by callback: %w", err)
+	}
+	switch carrier {
+	case CarrierWT:
+		dSes, err = ce.dialSessionWT(ctx, entry)
+	case CarrierWS:
+		dSes, err = ce.dialSessionWS(ctx, entry)
+	case CarrierQUIC:
+		dSes, err = ce.dialSessionQUIC(ctx, entry)
+	}
+	if err != nil {
+		ce.conf.Callbacks.OnSessionDisconnect(carrier, dialAddr, err)
+		return ClientSession{}, err
+	}
+	return ce.finishDialedSession(ctx, dSes, carrier, dialAddr, entry)
+}
+
+// finishDialedSession is dialSession's registration tail, shared with
+// dialSessionOn: stamp the carrier fields, install newest-session-wins under
+// sessionsMx, and start the serve goroutine.
+func (ce *Client) finishDialedSession(ctx context.Context, dSes ClientSession, network, dialAddr string, entry *disc.Entry) (ClientSession, error) {
 	// Atomically: refuse-if-closed, replace-stale, store, and wg.Add(1)
 	// under sessionsMx — pairs with Close which sets ce.closed under the
 	// same lock before wg.Wait. The Add must happen-before any subsequent

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -114,17 +114,75 @@
 			});
 		}).then(function () {
 			var sv = globalThis.skywireVisor;
+			// The desk's REAL visor is the root binary running in a terminal —
+			// a separate wasm instance the page cannot call. The desk host's
+			// own skywireVisor core is deliberately never booted here, so the
+			// nested browser reaches the mesh THROUGH the running visor's
+			// resolving proxy on the virtual loopback (dmsgweb, vnet:4445,
+			// chained to skynetweb + the proxy client): dmsg/skynet fetches go
+			// SOCKS5-over-vnet. Falls back to the in-page core for a page that
+			// booted it (nothing on the desk does today).
+			var RESOLVER_PORT = 4445;
+			function viaResolver() {
+				return !!(globalThis.vnet && globalThis.vnet.listening(RESOLVER_PORT) && globalThis.vnet.socksHttpFetch);
+			}
+			function resolverHost(pkHost) {
+				var h = String(pkHost || '');
+				// bare 66-hex PK → PK.dmsg (the resolver matches by suffix)
+				if (/^[0-9a-f]{66}$/i.test(h)) return h + '.dmsg';
+				return h;
+			}
 			var panel = globalThis.SkywireBrowse.mountPanel(document, {
 				noTour: true, // the tour narrates the classic visor page
-				fetchDmsg: function () { return sv.fetchDmsg.apply(null, arguments); },
+				fetchDmsg: function (pkHost, method, path, body) {
+					if (viaResolver()) {
+						return globalThis.vnet.socksHttpFetch(RESOLVER_PORT, resolverHost(pkHost) + ':80', method, path, body, {});
+					}
+					return sv.fetchDmsg.apply(null, arguments);
+				},
+				dmsgStatus: function () {
+					// The visor's resolver listening IS mesh readiness for this
+					// page (dmsgweb waits on dmsg internally); without it fall
+					// back to the in-page core's own status.
+					if (viaResolver()) { return { dmsg_connected: true }; }
+					try { return sv.status() || {}; } catch (e) { return {}; }
+				},
 				serveContent: function (m) { return sv.serveContent(m); },
-				selfPK: function () { try { return sv.status().pk || ''; } catch (e) { return ''; } },
+				selfPK: function () {
+					// Sync by contract; served from a cache the poller below
+					// fills from THE visor's /api/about the moment its
+					// hypervisor listens. The in-page core's status() is only
+					// a fallback for a page that booted it.
+					if (deskSelfPK) return deskSelfPK;
+					try { return sv.status().pk || ''; } catch (e) { return ''; }
+				},
 				api: function (m, path, body) {
+					// The one visor's hypervisor API on the virtual loopback.
+					if (globalThis.vnet && globalThis.vnet.listening(hvPort)) {
+						return globalThis.vnet.httpFetch(hvPort, m, path, body, {}).then(function (r) {
+							return { status: r.status, body: new TextDecoder().decode(r.body) };
+						});
+					}
 					return sv.hvApi(m, path, body).then(function (r) {
 						return { status: r.status, body: new TextDecoder().decode(r.body) };
 					});
 				},
 			});
+			// selfPK cache: poll the visor's /api/about once its HV listens;
+			// re-check occasionally in case the operator restarts the visor
+			// under a different identity.
+			var deskSelfPK = '';
+			(function pollPK() {
+				if (globalThis.vnet && globalThis.vnet.listening(hvPort)) {
+					globalThis.vnet.httpFetch(hvPort, 'GET', '/api/about', null, {}).then(function (r) {
+						try {
+							var a = JSON.parse(new TextDecoder().decode(r.body));
+							if (a && a.public_key) deskSelfPK = a.public_key;
+						} catch (e) { /* ignore */ }
+					}).catch(function () { /* ignore */ });
+				}
+				setTimeout(pollPK, deskSelfPK ? 60000 : 3000);
+			})();
 			globalThis.__skywireDesk = panel;
 
 			// Session: remember across reloads whether a visor was RUNNING when
@@ -152,7 +210,10 @@
 				startedVisor = startVisor;
 			}
 			if (opts.helpTerminal !== false) {
-				panel.openConsole({ title: 'skywire', initCmd: 'skywire --help' });
+				// bg: a background TAB of the terminal window — the visor's log
+				// stays front, and this tab's session (and its `skywire --help`)
+				// only starts when first clicked.
+				panel.openConsole({ title: 'skywire', initCmd: 'skywire --help', bg: !!startedVisor });
 			}
 			if (opts.hvWindow) {
 				// The hypervisor UI comes up on the virtual loopback a while

--- a/pkg/wasmhv/browseui/skywire-exec.js
+++ b/pkg/wasmhv/browseui/skywire-exec.js
@@ -126,9 +126,19 @@
 		const tailDec = new TextDecoder();
 		const keepTail = (buf) => {
 			try {
-				stderrTail = (stderrTail + tailDec.decode(buf, { stream: true })).slice(-4096);
+				stderrTail = (stderrTail + tailDec.decode(buf, { stream: true })).slice(-16384);
 			} catch (e) { /* ignore */ }
 		};
+		// Live observability: __skywireExecTails[iid]() returns the tail at any
+		// moment (DevTools, CDP probes, the operator) — the only other copy of
+		// a long-running instance's log lives inside an xterm nobody can read
+		// programmatically. Kept after exit (the crash's last words); replaced
+		// naturally as new instances reuse the registry.
+		try {
+			(globalThis.__skywireExecTails = globalThis.__skywireExecTails || {})[iid] =
+				function () { return stderrTail; };
+			globalThis.__skywireExecTails[iid].argv = args.slice();
+		} catch (e) { /* ignore */ }
 		{
 			const userErr = (hooks && hooks.stderr) || null;
 			const fallbackErr = prev.stderr; // no hook → keep the page's default sink

--- a/vendor/github.com/0magnet/bottle/vnet.js
+++ b/vendor/github.com/0magnet/bottle/vnet.js
@@ -34,6 +34,93 @@
 	// Service-worker bridge state (see enableSW below).
 	let swPrefix = null;
 
+	// httpExchange runs ONE HTTP/1.0 request/response over an already-open
+	// pipe (side 'a' of conn `id`) and settles the given resolve/reject with
+	// {status, body:Uint8Array, headers:{lowercased:value}}. Shared by
+	// httpFetch (plain pipe) and socksHttpFetch (pipe with a SOCKS5 CONNECT
+	// prelude). HTTP/1.0 + Connection: close — no chunked encoding, EOF
+	// delimits when Content-Length is absent; Content-Length short-circuits
+	// servers that hold the connection open.
+	function httpExchange(v, id, hostLabel, method, path, body, headers, resolve, reject, timeoutMs) {
+		let done = false;
+		const timer = setTimeout(() => {
+			if (done) return;
+			done = true;
+			v.close(id, 'a');
+			reject(new Error('timeout: ' + hostLabel));
+		}, timeoutMs || 30000);
+		const te = new TextEncoder();
+		let req = (method || 'GET') + ' ' + (path || '/') + ' HTTP/1.0\r\nHost: ' + hostLabel + '\r\n';
+		const h = headers || {};
+		for (const k in h) { if (Object.prototype.hasOwnProperty.call(h, k)) req += k + ': ' + h[k] + '\r\n'; }
+		let bodyBytes = null;
+		if (body != null) {
+			bodyBytes = (body instanceof Uint8Array) ? body : te.encode(String(body));
+			req += 'Content-Length: ' + bodyBytes.length + '\r\n';
+		}
+		req += 'Connection: close\r\n\r\n';
+		v.send(id, 'a', te.encode(req));
+		if (bodyBytes && bodyBytes.length) v.send(id, 'a', bodyBytes);
+		const chunks = [];
+		let total = 0;
+		let parsed = null; // {status, headers, bodyStart, contentLength}
+		const concat = () => {
+			const all = new Uint8Array(total);
+			let off = 0;
+			for (const c of chunks) { all.set(c, off); off += c.length; }
+			return all;
+		};
+		const tryParseHead = (all) => {
+			let sep = -1; // header/body split at CRLFCRLF
+			for (let i = 0; i + 3 < all.length; i++) {
+				if (all[i] === 13 && all[i + 1] === 10 && all[i + 2] === 13 && all[i + 3] === 10) { sep = i; break; }
+			}
+			if (sep < 0) return null;
+			const head = new TextDecoder().decode(all.subarray(0, sep));
+			const lines = head.split('\r\n');
+			const status = parseInt(lines[0].split(' ')[1] || '0', 10) || 0;
+			const hs = {};
+			for (let i = 1; i < lines.length; i++) {
+				const ci = lines[i].indexOf(':');
+				if (ci > 0) hs[lines[i].slice(0, ci).trim().toLowerCase()] = lines[i].slice(ci + 1).trim();
+			}
+			const cl = /^\d+$/.test(hs['content-length'] || '') ? parseInt(hs['content-length'], 10) : -1;
+			return { status: status, headers: hs, bodyStart: sep + 4, contentLength: cl };
+		};
+		const finish = (all) => {
+			if (done) return;
+			done = true;
+			clearTimeout(timer);
+			v.close(id, 'a');
+			if (!all) all = concat();
+			if (!parsed) parsed = tryParseHead(all);
+			if (!parsed) { reject(new Error('malformed HTTP response from ' + hostLabel)); return; }
+			let respBody = all.subarray(parsed.bodyStart);
+			if (parsed.contentLength >= 0 && respBody.length > parsed.contentLength) respBody = respBody.subarray(0, parsed.contentLength);
+			resolve({ status: parsed.status, body: respBody, headers: parsed.headers });
+		};
+		const pump = () => {
+			if (done) return;
+			for (;;) {
+				const b = v.recv(id, 'a');
+				if (b) {
+					chunks.push(b);
+					total += b.length;
+					if (!parsed || parsed.contentLength >= 0) {
+						const all = concat();
+						if (!parsed) parsed = tryParseHead(all);
+						if (parsed && parsed.contentLength >= 0 && total - parsed.bodyStart >= parsed.contentLength) { finish(all); return; }
+					}
+					continue;
+				}
+				if (v.eof(id, 'a')) { finish(null); return; }
+				v.onReadable(id, 'a', pump);
+				return;
+			}
+		};
+		pump();
+	}
+
 	globalThis.vnet = {
 		// listen claims a port; onconn(connId) fires per inbound dial (the
 		// accepter is side 'b' of that conn). Returns false if taken.
@@ -139,89 +226,95 @@
 			return new Promise((resolve, reject) => {
 				const id = this.dial(port);
 				if (id < 0) { reject(new Error('connection refused: 127.0.0.1:' + port)); return; }
-				let done = false;
-				const timer = setTimeout(() => {
-					if (done) return;
-					done = true;
-					this.close(id, 'a');
-					reject(new Error('timeout: 127.0.0.1:' + port));
-				}, 30000);
-				const te = new TextEncoder();
-				let req = (method || 'GET') + ' ' + (path || '/') + ' HTTP/1.0\r\nHost: 127.0.0.1:' + port + '\r\n';
-				const h = headers || {};
-				for (const k in h) { if (Object.prototype.hasOwnProperty.call(h, k)) req += k + ': ' + h[k] + '\r\n'; }
-				let bodyBytes = null;
-				if (body != null) {
-					bodyBytes = (body instanceof Uint8Array) ? body : te.encode(String(body));
-					req += 'Content-Length: ' + bodyBytes.length + '\r\n';
-				}
-				req += 'Connection: close\r\n\r\n';
-				this.send(id, 'a', te.encode(req));
-				if (bodyBytes && bodyBytes.length) this.send(id, 'a', bodyBytes);
-				// Receive: parse the status line + headers as soon as they're
-				// complete, then finish once Content-Length bytes of body have
-				// arrived — servers that keep the connection alive (Go answers
-				// even an HTTP/1.0 Connection: close request without closing
-				// promptly) would hang an EOF-only reader. EOF remains the
-				// fallback delimiter when Content-Length is absent.
-				const chunks = [];
-				let total = 0;
-				let parsed = null; // {status, headers, bodyStart, contentLength}
-				const concat = () => {
-					const all = new Uint8Array(total);
-					let off = 0;
-					for (const c of chunks) { all.set(c, off); off += c.length; }
-					return all;
+				httpExchange(this, id, '127.0.0.1:' + port, method, path, body, headers, resolve, reject, 30000);
+			});
+		},
+
+		// socksHttpFetch performs ONE HTTP request THROUGH a SOCKS5 proxy
+		// listening on a virtual-loopback port (no auth): CONNECT to
+		// targetHostPort ("home.dmsg:80", "<pk>.dmsg:80", …), then the same
+		// HTTP/1.0 exchange httpFetch speaks. This is how page JS reaches the
+		// in-page visor's RESOLVING PROXIES — the desk's nested browser
+		// fetches dmsg/skynet sites via the visor running in a terminal
+		// (dmsgweb on vnet:4445), which the page cannot address any other way
+		// (the visor is a separate wasm instance with no page API).
+		socksHttpFetch(port, targetHostPort, method, path, body, headers) {
+			const v = this;
+			return new Promise((resolve, reject) => {
+				const id = v.dial(port);
+				if (id < 0) { reject(new Error('connection refused: 127.0.0.1:' + port)); return; }
+				let settled = false;
+				const fail = (msg) => {
+					if (settled) return;
+					settled = true;
+					clearTimeout(hsTimer);
+					v.close(id, 'a');
+					reject(new Error(msg));
 				};
-				const tryParseHead = (all) => {
-					let sep = -1; // header/body split at CRLFCRLF
-					for (let i = 0; i + 3 < all.length; i++) {
-						if (all[i] === 13 && all[i + 1] === 10 && all[i + 2] === 13 && all[i + 3] === 10) { sep = i; break; }
-					}
-					if (sep < 0) return null;
-					const head = new TextDecoder().decode(all.subarray(0, sep));
-					const lines = head.split('\r\n');
-					const status = parseInt(lines[0].split(' ')[1] || '0', 10) || 0;
-					const hs = {};
-					for (let i = 1; i < lines.length; i++) {
-						const ci = lines[i].indexOf(':');
-						if (ci > 0) hs[lines[i].slice(0, ci).trim().toLowerCase()] = lines[i].slice(ci + 1).trim();
-					}
-					const cl = /^\d+$/.test(hs['content-length'] || '') ? parseInt(hs['content-length'], 10) : -1;
-					return { status: status, headers: hs, bodyStart: sep + 4, contentLength: cl };
-				};
-				const finish = (all) => {
-					if (done) return;
-					done = true;
-					clearTimeout(timer);
-					this.close(id, 'a');
-					if (!all) all = concat();
-					if (!parsed) parsed = tryParseHead(all);
-					if (!parsed) { reject(new Error('malformed HTTP response from 127.0.0.1:' + port)); return; }
-					let body = all.subarray(parsed.bodyStart);
-					if (parsed.contentLength >= 0 && body.length > parsed.contentLength) body = body.subarray(0, parsed.contentLength);
-					resolve({ status: parsed.status, body: body, headers: parsed.headers });
-				};
+				const hsTimer = setTimeout(() => fail('timeout: SOCKS5 handshake with 127.0.0.1:' + port), 20000);
+				// Buffered reader over recv for the fixed-size handshake replies.
+				let buf = new Uint8Array(0);
+				let need = 0, onBytes = null;
 				const pump = () => {
-					if (done) return;
+					if (settled) return;
 					for (;;) {
-						const b = this.recv(id, 'a');
+						const b = v.recv(id, 'a');
 						if (b) {
-							chunks.push(b);
-							total += b.length;
-							if (!parsed || parsed.contentLength >= 0) {
-								const all = concat();
-								if (!parsed) parsed = tryParseHead(all);
-								if (parsed && parsed.contentLength >= 0 && total - parsed.bodyStart >= parsed.contentLength) { finish(all); return; }
-							}
+							const nb = new Uint8Array(buf.length + b.length);
+							nb.set(buf, 0); nb.set(b, buf.length);
+							buf = nb;
+							if (onBytes && buf.length >= need) { const cb = onBytes; onBytes = null; cb(); }
 							continue;
 						}
-						if (this.eof(id, 'a')) { finish(null); return; }
-						this.onReadable(id, 'a', pump);
+						if (v.eof(id, 'a')) { fail('SOCKS5 proxy closed during handshake'); return; }
+						v.onReadable(id, 'a', pump);
 						return;
 					}
 				};
-				pump();
+				const read = (n, cb) => {
+					need = n; onBytes = () => {
+						const out = buf.subarray(0, n);
+						buf = buf.subarray(n);
+						cb(out);
+					};
+					if (buf.length >= n) { const cb2 = onBytes; onBytes = null; cb2(); } else { pump(); }
+				};
+				const te = new TextEncoder();
+				const hp = String(targetHostPort);
+				const ci = hp.lastIndexOf(':');
+				const host = ci > 0 ? hp.slice(0, ci) : hp;
+				const tport = ci > 0 ? (parseInt(hp.slice(ci + 1), 10) || 80) : 80;
+				const hostBytes = te.encode(host);
+				if (hostBytes.length > 255) { fail('SOCKS5 host too long'); return; }
+				// greeting: VER=5, one method: no-auth
+				v.send(id, 'a', new Uint8Array([5, 1, 0]));
+				read(2, (g) => {
+					if (g[0] !== 5 || g[1] !== 0) { fail('SOCKS5 method negotiation failed'); return; }
+					// CONNECT: VER CMD RSV ATYP=domain len host port
+					const reqB = new Uint8Array(7 + hostBytes.length);
+					reqB[0] = 5; reqB[1] = 1; reqB[2] = 0; reqB[3] = 3; reqB[4] = hostBytes.length;
+					reqB.set(hostBytes, 5);
+					reqB[5 + hostBytes.length] = (tport >> 8) & 0xff;
+					reqB[6 + hostBytes.length] = tport & 0xff;
+					v.send(id, 'a', reqB);
+					read(4, (r) => {
+						if (r[0] !== 5 || r[1] !== 0) { fail('SOCKS5 CONNECT refused (rep=' + r[1] + ') for ' + hp); return; }
+						// consume the bound address: ATYP decides its length
+						const atyp = r[3];
+						const rest = atyp === 1 ? 4 + 2 : atyp === 4 ? 16 + 2 : -1;
+						const afterBind = () => {
+							if (settled) return;
+							settled = true;
+							clearTimeout(hsTimer);
+							// Splice any early bytes the proxy already relayed back
+							// into the conn queue front? None expected: the server
+							// speaks only after our HTTP request. Hand the pipe to
+							// the shared HTTP exchange.
+							httpExchange(v, id, hp, method, path, body, headers, resolve, reject, 45000);
+						};
+						if (rest > 0) { read(rest, afterBind); } else if (atyp === 3) { read(1, (l) => read(l[0] + 2, afterBind)); } else { fail('SOCKS5 bad ATYP ' + atyp); }
+					});
+				});
 			});
 		},
 

--- a/vendor/github.com/0magnet/netscrape/browse.js
+++ b/vendor/github.com/0magnet/netscrape/browse.js
@@ -543,6 +543,11 @@
     // dmsg_sessions}). Returns {} if the core isn't booted yet (status() throws).
     function dmsgStatus() {
       return Promise.resolve().then(function () {
+        // opts.dmsgStatus: the page knows better than the in-tab core — the
+        // desk's visor runs as a SEPARATE wasm instance (skywireVisor stays
+        // un-booted there), so the desk reports readiness from the visor's
+        // vnet listeners instead.
+        if (opts.dmsgStatus) { return opts.dmsgStatus() || {}; }
         var v = globalThis.skywireVisor;
         if (v && v.status) { return v.status() || {}; }
         // Native / hosted HV UI (directViaBackend, no in-tab wasm core to
@@ -1356,7 +1361,7 @@
       // Thread the clearnet + self-PK providers from the panel opts so the engine
       // is host-agnostic: the wasm visor passes none (they fall back to the
       // skywireVisor.* globals), the native HV UI passes /api/browse-backed ones.
-      fetchClearnet: opts.fetchClearnet, selfPK: opts.selfPK, directViaBackend: opts.directViaBackend,
+      fetchClearnet: opts.fetchClearnet, selfPK: opts.selfPK, directViaBackend: opts.directViaBackend, dmsgStatus: opts.dmsgStatus,
       log: function (m) { try { console.log("[skynet] " + m); } catch (e) {} plog(m); },
       // Reflect the current site into this pane's TAB (and the window title
       // when this tab is active) via paneCB.
@@ -2512,6 +2517,27 @@
 
     var tabs = [], active = null, wb = null;
     function setTitle() { try { wb.setTitle(active ? active.title : (opts.title || "terminal")); } catch (e) {} }
+    // ensureOpen starts a tab's shell session the FIRST time the tab is
+    // visible. Opening while hidden would size the xterm 0x0 — everything the
+    // session printed (a foreground visor's whole log) lands garbled in a
+    // zero-width grid, and each write still costs parser + renderer work.
+    // Deferred tabs cost nothing until clicked.
+    function ensureOpen(t) {
+      if (t.opened) return;
+      t.opened = true;
+      ensureShell().then(function (sh) {
+        t.note.remove();
+        t.handle = sh.open(t.mount);
+        if (t.handle && t.handle.error) { t.mount.textContent = "shell: " + t.handle.error; return; }
+        if (active === t && t.handle && t.handle.focus) { try { t.handle.focus(); } catch (e) {} }
+        // initCmd: run one command as if typed — the desk's default layout uses
+        // this ("skywire --help" in the docs playground; "skywire autoconfig"
+        // for a foreground visor terminal).
+        if (t.initCmd && t.handle && t.handle.run) { try { t.handle.run(t.initCmd); } catch (e) {} }
+      }).catch(function (e) {
+        t.note.textContent = "shell failed to start: " + (e.message || e);
+      });
+    }
     function activate(t) {
       if (!t || active === t) return;
       tabs.forEach(function (x) {
@@ -2521,6 +2547,7 @@
       });
       active = t;
       setTitle();
+      ensureOpen(t);
       // xterm sizes itself to a VISIBLE container: refit + refocus on switch.
       try { if (t.handle && t.handle.fit) t.handle.fit(); } catch (e) {}
       try { if (t.handle && t.handle.focus) t.handle.focus(); } catch (e) {}
@@ -2536,13 +2563,13 @@
     }
     function addTab(o) {
       o = o || {};
-      var t = { title: o.title || "shell", handle: null };
+      var t = { title: o.title || "shell", handle: null, initCmd: o.initCmd || "", opened: false };
       t.mount = doc.createElement("div");
       t.mount.style.cssText = "position:absolute;inset:0;background:#000;overflow:hidden;display:none";
-      var note = doc.createElement("div");
-      note.style.cssText = "position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#9aa0a6;font:12px monospace";
-      note.textContent = "starting the shell…";
-      t.mount.appendChild(note);
+      t.note = doc.createElement("div");
+      t.note.style.cssText = "position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#9aa0a6;font:12px monospace";
+      t.note.textContent = "starting the shell…";
+      t.mount.appendChild(t.note);
       body.appendChild(t.mount);
       t.btn = doc.createElement("div");
       t.btn.style.cssText = "display:flex;align-items:center;gap:.45em;max-width:12em;padding:.25em .6em;cursor:pointer;font:11px monospace;border:1px solid #2a2342;border-bottom:0;border-radius:5px 5px 0 0;user-select:none;white-space:nowrap";
@@ -2559,19 +2586,10 @@
       t.btn.onclick = function () { activate(t); };
       strip.insertBefore(t.btn, plus);
       tabs.push(t);
-      activate(t);
-      ensureShell().then(function (sh) {
-        note.remove();
-        t.handle = sh.open(t.mount);
-        if (t.handle && t.handle.error) { t.mount.textContent = "shell: " + t.handle.error; return; }
-        if (active === t && t.handle && t.handle.focus) { try { t.handle.focus(); } catch (e) {} }
-        // initCmd: run one command as if typed — the desk's default layout uses
-        // this ("skywire --help" in the docs playground; "skywire autoconfig"
-        // for a foreground visor terminal).
-        if (o.initCmd && t.handle && t.handle.run) { try { t.handle.run(o.initCmd); } catch (e) {} }
-      }).catch(function (e) {
-        note.textContent = "shell failed to start: " + (e.message || e);
-      });
+      // bg: add WITHOUT stealing the active tab (the desk keeps its visor
+      // terminal front; a background help tab opens lazily on first click).
+      // The first tab always activates.
+      if (!o.bg || tabs.length === 1) { activate(t); }
       return t;
     }
     var plus = doc.createElement("div");
@@ -3188,8 +3206,8 @@
     function openConsole(o) {
       o = o || {};
       if (consoleWin && consoleWin.addTab) {
-        consoleWin.addTab({ title: o.title || "shell", initCmd: o.initCmd || "" });
-        try { consoleWin.wb.minimize(false); consoleWin.wb.focus(); } catch (e) {}
+        consoleWin.addTab({ title: o.title || "shell", initCmd: o.initCmd || "", bg: !!o.bg });
+        try { consoleWin.wb.minimize(false); if (!o.bg) { consoleWin.wb.focus(); } } catch (e) {}
         return consoleWin;
       }
       var win = createShellWindow(doc, withRoot({

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,7 +25,7 @@ github.com/0magnet/bbolt
 github.com/0magnet/bbolt/errors
 github.com/0magnet/bbolt/internal/common
 github.com/0magnet/bbolt/internal/freelist
-# github.com/0magnet/bottle v0.0.0-20260903012749-c56103278d72
+# github.com/0magnet/bottle v0.0.0-20260903015103-41ea02c59a55
 ## explicit; go 1.24
 github.com/0magnet/bottle
 github.com/0magnet/bottle/vnet
@@ -51,7 +51,7 @@ github.com/0magnet/gotop/v4/widgets
 # github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b
 ## explicit; go 1.24.0
 github.com/0magnet/metrics
-# github.com/0magnet/netscrape v0.0.0-20260902211921-ffd322b843c0
+# github.com/0magnet/netscrape v0.0.0-20260903020822-5d615b86f555
 ## explicit; go 1.24
 github.com/0magnet/netscrape
 # github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408


### PR DESCRIPTION
ConvergeCarriers used the fallback-capable dialSession, whose newest-session-wins registration replaced (and closed) a healthy wss session with its own twin whenever the preferred WT dial fell back — every tick, for every server whose WT was unreachable. Live symptoms on the desk: constant session shutdown/re-dial churn, server counts ballooning past sessions_count (6 vs 2), transports starving as their signaling flapped, and ~600ms main-thread stalls from the handshake burn.

dialSession's registration tail is shared (finishDialedSession) and converge now dials via dialSessionOn — exactly the wanted carrier, registered only on success; failures back off with the dial error as the note. Measured after: 2/2 sessions on WT, swtr+swsr transports up, 0 long tasks in 30s (was 10 totaling 1.6s).

Also (desk, browseui + vendored bottle/netscrape): the nested browser reaches the mesh through the visor's resolving proxy (SOCKS5-over-vnet against dmsgweb :4445) instead of the desk host's un-booted core API; terminal tabs open sessions lazily on first visibility (a hidden xterm sized 0x0 garbled the visor terminal); skywire-exec exposes a per-instance stderr tail so the visor log is readable from DevTools/CDP.