### PR TITLE
fix(desk): SOCKS-over-vnet handshake pump stands down; repin squashed deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,11 +60,11 @@ require (
 
 require (
 	github.com/0magnet/bbolt v1.5.1-0.20260901223329-c4feec896898
-	github.com/0magnet/bottle v0.0.0-20260903015103-41ea02c59a55
+	github.com/0magnet/bottle v0.0.0-20260903023316-9a05280e70d4
 	github.com/0magnet/golang-ipc v1.2.5-0.20260901195306-becfc11f7586
 	github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77
 	github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b
-	github.com/0magnet/netscrape v0.0.0-20260903020822-5d615b86f555
+	github.com/0magnet/netscrape v0.0.0-20260903022326-6cc0e9b4fe5a
 	github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408
 	github.com/0magnet/realorigin v0.2.0
 	github.com/0magnet/sysinfo v1.1.4-0.20260901201859-b4abd4e87c26

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/0magnet/afero v1.15.1-0.20260816202415-9f9d46a34dcd h1:zhADHH+Lu7o4U1
 github.com/0magnet/afero v1.15.1-0.20260816202415-9f9d46a34dcd/go.mod h1:JsJ3c6VwVpJOB3qUpT6YzgJ8yC+nBLUCcH2nhGLC6fA=
 github.com/0magnet/bbolt v1.5.1-0.20260901223329-c4feec896898 h1:5UyEWEOaKdF8RAfc/fBxqrpEgsga0NCuRYkA9xegoos=
 github.com/0magnet/bbolt v1.5.1-0.20260901223329-c4feec896898/go.mod h1:w+uhwkS5wbYmWTm2Dvvp3AWUR8TNrksPutxoBn4sESY=
-github.com/0magnet/bottle v0.0.0-20260903015103-41ea02c59a55 h1:UwtxPbuT7fRteYkwjbjHIGJavaW5iRXR8sUmnHTfJfE=
-github.com/0magnet/bottle v0.0.0-20260903015103-41ea02c59a55/go.mod h1:02z8sWzqF3QH4SjMxnx5bnysFUqsw9CdUTtIj+CIxkw=
+github.com/0magnet/bottle v0.0.0-20260903023316-9a05280e70d4 h1:OItQoy+PRzbkXonxrZRHXcvKF+HjBCJOYkw2nOdKhRw=
+github.com/0magnet/bottle v0.0.0-20260903023316-9a05280e70d4/go.mod h1:02z8sWzqF3QH4SjMxnx5bnysFUqsw9CdUTtIj+CIxkw=
 github.com/0magnet/coloredcobra v1.0.3-0.20260902084726-57ccbecfc077 h1:cWpt53uNQFCMUl8zmh73xb/EuigbO3Qe+KP4ggpwvy8=
 github.com/0magnet/coloredcobra v1.0.3-0.20260902084726-57ccbecfc077/go.mod h1:Kn7dmRJcnVybFNKY0FNUjLcsivW4FCbAec8ZfVmz51I=
 github.com/0magnet/cosmos-go v0.0.0-20260814190035-f5b882c1ea9e h1:fyLB1qUtpMxPeZp4MdZu5yLHHR+kLl2MZfhG0djlGIo=
@@ -80,8 +80,8 @@ github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77 h1:4Th5JTWexd+r
 github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77/go.mod h1:F6WLpAz89R80LgQy9Veg6jZVdfY3FLmxqt23Okck35A=
 github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b h1:l/c7X12CNncX2phqLeQPiNjxu2ou7spv3xslwloyPjE=
 github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b/go.mod h1:SwLy2vvXGWJQxefDI4DncGdXJWIob5IGczxeFMtUIj8=
-github.com/0magnet/netscrape v0.0.0-20260903020822-5d615b86f555 h1:Tmp+sFOUnEd/OdUAzn/J/RjYOx0vVggeKTTBK5o9mnw=
-github.com/0magnet/netscrape v0.0.0-20260903020822-5d615b86f555/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
+github.com/0magnet/netscrape v0.0.0-20260903022326-6cc0e9b4fe5a h1:I1TKRsiD6EhwSb758dUdBNef0JK5K9dYOACQu1HSLjs=
+github.com/0magnet/netscrape v0.0.0-20260903022326-6cc0e9b4fe5a/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
 github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408 h1:iXCaIMD5kmvYINoBhIVv+nGtN4BRRVe64EDkOUtKvqg=
 github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408/go.mod h1:feFjgv6ByEzXixeUOB4gYwq9G8iv35aQJiYc/8ZHDWg=
 github.com/0magnet/realorigin v0.2.0 h1:+xfvyuQzRGKAtQ88WziCVK3/poPTzc4pvc0i5+kPNUc=

--- a/vendor/github.com/0magnet/bottle/vnet.js
+++ b/vendor/github.com/0magnet/bottle/vnet.js
@@ -41,7 +41,7 @@
 	// prelude). HTTP/1.0 + Connection: close — no chunked encoding, EOF
 	// delimits when Content-Length is absent; Content-Length short-circuits
 	// servers that hold the connection open.
-	function httpExchange(v, id, hostLabel, method, path, body, headers, resolve, reject, timeoutMs) {
+	function httpExchange(v, id, hostLabel, method, path, body, headers, resolve, reject, timeoutMs, preBytes) {
 		let done = false;
 		const timer = setTimeout(() => {
 			if (done) return;
@@ -63,6 +63,9 @@
 		if (bodyBytes && bodyBytes.length) v.send(id, 'a', bodyBytes);
 		const chunks = [];
 		let total = 0;
+		// preBytes: response bytes a caller's prelude reader (the SOCKS
+		// handshake) already pulled off the pipe before handing it over.
+		if (preBytes && preBytes.length) { chunks.push(preBytes); total += preBytes.length; }
 		let parsed = null; // {status, headers, bodyStart, contentLength}
 		const concat = () => {
 			const all = new Uint8Array(total);
@@ -264,6 +267,11 @@
 							nb.set(buf, 0); nb.set(b, buf.length);
 							buf = nb;
 							if (onBytes && buf.length >= need) { const cb = onBytes; onBytes = null; cb(); }
+							// STOP once the handshake settled (afterBind ran inside
+							// that callback): looping on would re-register this pump
+							// as the pipe's one-shot wake callback, stealing every
+							// response byte from the HTTP exchange that took over.
+							if (settled) return;
 							continue;
 						}
 						if (v.eof(id, 'a')) { fail('SOCKS5 proxy closed during handshake'); return; }
@@ -306,11 +314,13 @@
 							if (settled) return;
 							settled = true;
 							clearTimeout(hsTimer);
-							// Splice any early bytes the proxy already relayed back
-							// into the conn queue front? None expected: the server
-							// speaks only after our HTTP request. Hand the pipe to
-							// the shared HTTP exchange.
-							httpExchange(v, id, hp, method, path, body, headers, resolve, reject, 45000);
+							// Hand the pipe to the shared HTTP exchange, along with
+							// any bytes the handshake reader already pulled past the
+							// bind address (a fast server's response can share a
+							// chunk with the reply).
+							const leftover = buf.length ? buf : null;
+							buf = new Uint8Array(0);
+							httpExchange(v, id, hp, method, path, body, headers, resolve, reject, 45000, leftover);
 						};
 						if (rest > 0) { read(rest, afterBind); } else if (atyp === 3) { read(1, (l) => read(l[0] + 2, afterBind)); } else { fail('SOCKS5 bad ATYP ' + atyp); }
 					});

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,7 +25,7 @@ github.com/0magnet/bbolt
 github.com/0magnet/bbolt/errors
 github.com/0magnet/bbolt/internal/common
 github.com/0magnet/bbolt/internal/freelist
-# github.com/0magnet/bottle v0.0.0-20260903015103-41ea02c59a55
+# github.com/0magnet/bottle v0.0.0-20260903023316-9a05280e70d4
 ## explicit; go 1.24
 github.com/0magnet/bottle
 github.com/0magnet/bottle/vnet
@@ -51,7 +51,7 @@ github.com/0magnet/gotop/v4/widgets
 # github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b
 ## explicit; go 1.24.0
 github.com/0magnet/metrics
-# github.com/0magnet/netscrape v0.0.0-20260903020822-5d615b86f555
+# github.com/0magnet/netscrape v0.0.0-20260903022326-6cc0e9b4fe5a
 ## explicit; go 1.24
 github.com/0magnet/netscrape
 # github.com/0magnet/plot-go v0.0.0-20260828164145-80dfd0918408


### PR DESCRIPTION
bottle's socksHttpFetch handshake pump kept looping after CONNECT and re-registered itself as the pipe's one-shot wake callback, starving the HTTP exchange of every response byte — dmsg-site tabs timed out at 45s despite a successful handshake. The pump now stops once the handshake settles and hands any over-read bytes to the exchange. Validated live: home.dmsg + status.skysocks load in the desk's background tabs through the visor's resolver chain, 0 console errors, 50s from cold boot. Also repins bottle/netscrape to their squashed histories (content identical).