### PR TITLE
feat(visor): end-to-end proxy-exit verification with rotation; router-line ring

### DIFF
--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/soheilhy/cmux"
+	"golang.org/x/net/proxy"
 	"google.golang.org/grpc"
 
 	"github.com/0magnet/bottle/vnet"
@@ -128,10 +129,20 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 	// a browser visor's proxy chain work out of the box, and turns the
 	// native "autostart but no PK" misconfiguration into something useful.
 	autoProxyClient := false
+	pinnedProxy := false
 	for i, ac := range apps {
-		if ac.Name == skyenv.SkysocksClientName && ac.AutoStart && !argsContain(ac.Args, "--srv") {
-			apps[i].AutoStart = false
+		if ac.Name == skyenv.SkysocksClientName && ac.AutoStart {
 			autoProxyClient = true
+			if argsContain(ac.Args, "--srv") {
+				// A pinned exit (an operator's, or one persisted from an
+				// earlier auto-pick) autostarts as configured — but still
+				// gets VERIFIED below, and rotated off if it's dead: a
+				// stale pin otherwise wedges the whole chain behind the
+				// connecting interstitial forever.
+				pinnedProxy = true
+			} else {
+				apps[i].AutoStart = false
+			}
 		}
 	}
 
@@ -170,7 +181,7 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 	v.initLock.Unlock()
 
 	if autoProxyClient {
-		go v.autoStartProxyClient(v.MasterLogger().PackageLogger("proxy_client_auto")) //nolint:gosec // G118: uses v.ctx, outlives the init ctx by design
+		go v.autoStartProxyClient(v.MasterLogger().PackageLogger("proxy_client_auto"), pinnedProxy) //nolint:gosec // G118: uses v.ctx, outlives the init ctx by design
 	}
 
 	return nil
@@ -186,16 +197,35 @@ func argsContain(args []string, flag string) bool {
 	return false
 }
 
-// autoStartProxyClient picks a proxy exit from service discovery and starts
-// skysocks-client on it — the deferred autostart for a config that says
-// "autostart the proxy client" without pinning a server. Retries the whole
-// cycle while the visor lives: discovery needs dmsg up, and early fetches
-// legitimately fail during boot. Exits once the client starts (the app's own
-// retrier + restart policy take over from there).
-func (v *Visor) autoStartProxyClient(log *logging.Logger) {
+// autoStartProxyClient picks a proxy exit from service discovery, starts
+// skysocks-client on it, and — critically — VERIFIES the exit end to end
+// before accepting it: route formation and even the SOCKS5 CONNECT succeed
+// against a ZOMBIE exit (skysocks server down behind a live visor), so only a
+// real relayed HTTP response proves the exit works. A candidate that fails
+// verification is stopped and the next one tried; without this the deferred
+// autostart could pin a dead exit forever and the whole chain serves the
+// connecting interstitial indefinitely (observed live on the desk). This is
+// the visor-side port of the old wasm edge's honest pool probe.
+func (v *Visor) autoStartProxyClient(log *logging.Logger, pinned bool) {
 	ctx := v.ctx
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if pinned {
+		// The launcher autostarted the configured exit; give it a beat, then
+		// hold it to the same end-to-end bar. A live pin wins and we're done;
+		// a dead one is stopped and the discovery rotation below takes over.
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(15 * time.Second):
+		}
+		if v.verifyProxyExit(ctx, log) {
+			log.Info("Configured proxy exit verified end to end")
+			return
+		}
+		log.Warn("configured proxy exit failed end-to-end verification; rotating to discovery")
+		_ = v.StopSkysocksClients() //nolint:errcheck
 	}
 	for {
 		select {
@@ -211,19 +241,73 @@ func (v *Visor) autoStartProxyClient(log *logging.Logger) {
 		// shouldn't pin the loop, and the whole list shouldn't be dialed.
 		idx := mathrand.Perm(len(svcs))
 		tries := len(idx)
-		if tries > 5 {
-			tries = 5
+		if tries > 4 {
+			tries = 4
 		}
 		for _, i := range idx[:tries] {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			pk := svcs[i].Addr.PubKey().String()
 			if err := v.StartSkysocksClient(pk); err != nil {
-				log.WithError(err).Debug("proxy-client auto-exit candidate failed; trying another")
+				log.WithError(err).Debug("proxy-client auto-exit candidate failed to start; trying another")
 				continue
 			}
-			log.WithField("exit", pk).Info("Proxy client auto-started on a discovered exit")
-			return
+			if v.verifyProxyExit(ctx, log) {
+				log.WithField("exit", pk).Info("Proxy client auto-started on a VERIFIED exit")
+				return
+			}
+			log.WithField("exit", pk).Warn("proxy-client exit failed end-to-end verification; rotating")
+			_ = v.StopSkysocksClients() //nolint:errcheck
 		}
 	}
+}
+
+// verifyProxyExit fetches a tiny plain-HTTP page through the local skysocks-client
+// listener and reports whether a real relayed response arrived. The dial goes
+// through bottle/vnet, so the SAME code verifies a browser visor's listener
+// on the page's virtual loopback and a native visor's on the real one. Route
+// establishment can take a while on a fresh visor, so it retries within a
+// bounded window before giving the verdict.
+func (v *Visor) verifyProxyExit(ctx context.Context, log *logging.Logger) bool {
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(10 * time.Second):
+		}
+		sd, err := proxy.SOCKS5("tcp", skyenv.SkysocksClientAddr, nil, vnetProxyDialer{})
+		if err != nil {
+			continue
+		}
+		conn, err := sd.Dial("tcp", "neverssl.com:80")
+		if err != nil {
+			log.WithError(err).Debug("proxy verify: CONNECT failed; retrying within window")
+			continue
+		}
+		_ = conn.SetDeadline(time.Now().Add(15 * time.Second))                                         //nolint:errcheck
+		_, _ = conn.Write([]byte("GET / HTTP/1.0\r\nHost: neverssl.com\r\nConnection: close\r\n\r\n")) //nolint:errcheck
+		one := make([]byte, 16)
+		n, rerr := conn.Read(one)
+		_ = conn.Close() //nolint:errcheck
+		if n > 0 {
+			return true
+		}
+		log.WithError(rerr).Debug("proxy verify: no response byte; retrying within window")
+	}
+	return false
+}
+
+// vnetProxyDialer adapts bottle/vnet dialing to x/net/proxy's Dialer, so the
+// verification dial reaches the skysocks listener on whichever loopback this
+// build actually uses (page vnet under js, the real one natively).
+type vnetProxyDialer struct{}
+
+func (vnetProxyDialer) Dial(network, addr string) (net.Conn, error) {
+	return vnet.DialTimeout(network, addr, 10*time.Second)
 }
 
 // appsContains reports whether an apps[] slice already contains an

--- a/pkg/wasmhv/browseui/skywire-exec.js
+++ b/pkg/wasmhv/browseui/skywire-exec.js
@@ -123,10 +123,25 @@
 		// scrolled to. The tail is mirrored to the console below so a crash
 		// is diagnosable from DevTools / a CDP probe.
 		let stderrTail = '';
+		// routerTail: a SELECTIVE ring of route-establishment lines. The full
+		// tail churns through its window in seconds under dmsg DEBUG spam, so
+		// the one error that explains a failed dial is gone before anyone
+		// looks; these lines are rare and survive.
+		let routerTail = '';
+		let lineBuf = '';
+		const ROUTERISH = /(router|route_setup|RouteGroup|routegroup|setupclient|rule|cascade|rsn)/i;
 		const tailDec = new TextDecoder();
 		const keepTail = (buf) => {
 			try {
-				stderrTail = (stderrTail + tailDec.decode(buf, { stream: true })).slice(-16384);
+				const s = tailDec.decode(buf, { stream: true });
+				stderrTail = (stderrTail + s).slice(-16384);
+				lineBuf += s;
+				let nl;
+				while ((nl = lineBuf.indexOf('\n')) >= 0) {
+					const line = lineBuf.slice(0, nl);
+					lineBuf = lineBuf.slice(nl + 1);
+					if (ROUTERISH.test(line)) { routerTail = (routerTail + line + '\n').slice(-8192); }
+				}
 			} catch (e) { /* ignore */ }
 		};
 		// Live observability: __skywireExecTails[iid]() returns the tail at any
@@ -138,6 +153,7 @@
 			(globalThis.__skywireExecTails = globalThis.__skywireExecTails || {})[iid] =
 				function () { return stderrTail; };
 			globalThis.__skywireExecTails[iid].argv = args.slice();
+			globalThis.__skywireExecTails[iid].router = function () { return routerTail; };
 		} catch (e) { /* ignore */ }
 		{
 			const userErr = (hooks && hooks.stderr) || null;

--- a/scripts/tabshot/hardreload/main.go
+++ b/scripts/tabshot/hardreload/main.go
@@ -1,0 +1,52 @@
+// Command hardreload reloads a CDP page target bypassing the HTTP cache —
+// what a stale cached bundle needs after the server was rebuilt.
+//
+//	go run ./scripts/tabshot/hardreload ws://127.0.0.1:9222/devtools/page/<id>
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: hardreload <webSocketDebuggerUrl>")
+		os.Exit(2)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, os.Args[1], &websocket.DialOptions{})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "dial:", err)
+		os.Exit(1)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "")
+	send := func(id int, method string, params interface{}) {
+		p, _ := json.Marshal(params)
+		b, _ := json.Marshal(map[string]interface{}{"id": id, "method": method, "params": json.RawMessage(p)})
+		_ = c.Write(ctx, websocket.MessageText, b) //nolint:errcheck
+	}
+	send(1, "Page.enable", map[string]interface{}{})
+	send(2, "Page.reload", map[string]interface{}{"ignoreCache": true})
+	// Wait for the reload command's ack (id 2), then done.
+	for {
+		_, raw, err := c.Read(ctx)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "read:", err)
+			os.Exit(1)
+		}
+		var m struct {
+			ID int `json:"id"`
+		}
+		if json.Unmarshal(raw, &m) == nil && m.ID == 2 {
+			fmt.Println("hard-reloaded")
+			return
+		}
+	}
+}


### PR DESCRIPTION
The deferred proxy autostart now holds every exit to an end-to-end bar: only a real relayed HTTP response through the local listener proves it (route formation and the CONNECT both succeed against half-dead exits). Failing candidates are stopped and rotated; a pinned exit autostarts as configured but meets the same bar — a stale pin otherwise wedges the chain behind the connecting interstitial forever (observed live on the desk). The probe dials through bottle/vnet, so one code path verifies browser and native listeners alike.

Also: a selective ring of route-establishment log lines per exec instance (the full stderr tail churns in seconds under DEBUG spam), and a CDP cache-bypassing reload helper.

Known open, now visible instead of silent: from a browser visor, route groups to exits establish and run their leg loops, then the remote closes them early — while the same exits serve a native visor concurrently. Under investigation.