### PR TITLE
fix(webrtc): browser peer connections must not leak or panic the runtime

### DIFF
--- a/pkg/transport/network/webrtc_browser.go
+++ b/pkg/transport/network/webrtc_browser.go
@@ -100,7 +100,26 @@ func newPeerConnection(iceServers js.Value) (js.Value, error) {
 	if iceServers.Truthy() {
 		cfg.Set("iceServers", iceServers)
 	}
-	return rtcPC.New(cfg), nil
+	// syscall/js panics when a constructor throws — notably Chrome's hard cap
+	// on concurrent RTCPeerConnections ("Cannot create so many
+	// PeerConnections"), which hours of leaked failed attempts eventually
+	// hit. A dial/accept must FAIL, not take the whole Go runtime down with
+	// it (observed live: the desk visor died at ~5h uptime with exactly that
+	// panic, killing every listener in the instance).
+	var pc js.Value
+	err := func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("webrtc: new RTCPeerConnection: %v", r)
+			}
+		}()
+		pc = rtcPC.New(cfg)
+		return nil
+	}()
+	if err != nil {
+		return js.Value{}, err
+	}
+	return pc, nil
 }
 
 // wireLocalCandidates forwards locally-gathered ICE candidates to the peer over
@@ -187,6 +206,15 @@ func webrtcDial(ctx context.Context, signal io.ReadWriteCloser, iceURLs []string
 	}
 	dc := pc.Call("createDataChannel", "skywire", map[string]interface{}{"ordered": true})
 	conn := newWebRTCConn(dc, pc, signal)
+	// Every failure below must release the peer connection: the page has a
+	// hard budget of concurrent RTCPeerConnections, and leaked failed dials
+	// spent it all over hours until construction itself started throwing.
+	established := false
+	defer func() {
+		if !established {
+			conn.Close() //nolint:errcheck,gosec // closes dc + pc + signal
+		}
+	}()
 
 	wireLocalCandidates(pc, sc)
 	go pumpRemoteSignals(ctx, pc, sc, nil)
@@ -204,6 +232,7 @@ func webrtcDial(ctx context.Context, signal io.ReadWriteCloser, iceURLs []string
 	if err := conn.waitOpen(ctx); err != nil {
 		return nil, err
 	}
+	established = true
 	return conn, nil
 }
 
@@ -215,6 +244,16 @@ func webrtcAccept(ctx context.Context, signal io.ReadWriteCloser, iceURLs []stri
 	if err != nil {
 		return nil, err
 	}
+	// Same close-on-failure discipline as the dial side: an accept that never
+	// completes (offer never arrives, 30s ctx expiry, handshake error) must
+	// not leak its peer connection — these were the bulk of the page-budget
+	// bleed, one per failed inbound signaling attempt.
+	established := false
+	defer func() {
+		if !established {
+			pc.Call("close")
+		}
+	}()
 	dcCh := make(chan js.Value, 1)
 	onDC := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
 		select {
@@ -245,8 +284,10 @@ func webrtcAccept(ctx context.Context, signal io.ReadWriteCloser, iceURLs []stri
 	case dc := <-dcCh:
 		conn := newWebRTCConn(dc, pc, signal)
 		if err := conn.waitOpen(ctx); err != nil {
+			conn.Close() //nolint:errcheck,gosec // closes pc too; the defer's second close is a no-op
 			return nil, err
 		}
+		established = true
 		return conn, nil
 	case <-ctx.Done():
 		return nil, ctx.Err()


### PR DESCRIPTION
Root cause of the desk visor's recurring ~5h death, caught by the crash mirror added in #4428: every failed webrtc dial/accept leaked its RTCPeerConnection — only the established conn's Close ever released one. Hours of attrition spent the page's hard budget, and the next construction threw 'Cannot create so many PeerConnections', which syscall/js turns into a Go panic killing the whole instance and every listener in it.

Fix: construction is recover-guarded (a dial/accept fails instead of killing the runtime), and both dial and accept close their peer connection on every non-established exit.