### PR TITLE
fix(desk): a crashed visor is not an operator stop — restart on reload

### DIFF
--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -57,11 +57,29 @@
 	// tab covers the page) must not masquerade as an operator stop, or every
 	// later load skips the autostart forever.
 	var visorSawUp = false;
+	// visorCrashed: whether the visor's exec instance ended ABNORMALLY (panic
+	// or nonzero exit). A crash is not an operator stop — recording it as one
+	// suppressed the autostart on every later load, so an overnight panic
+	// left the desk permanently idle (observed live). Only a clean exit
+	// (code 0, no crash) counts as "the operator stopped it".
+	function visorCrashed() {
+		try {
+			var reg = globalThis.__skywireExecTails || {};
+			var crashed = false;
+			Object.keys(reg).forEach(function (k) {
+				var a = (reg[k].argv || []).join(' ');
+				var xi = reg[k].exitInfo;
+				if (/autoconfig/.test(a) && xi && (xi.crashed || xi.code !== 0)) { crashed = true; }
+			});
+			return crashed;
+		} catch (e) { return false; }
+	}
 	function saveSession() {
 		try {
 			var up = !!(globalThis.vnet && globalThis.vnet.listening(3435));
 			if (up) { visorSawUp = true; }
 			if (!up && !visorSawUp) { return; } // still booting (or never started) — keep the previous verdict
+			if (!up && visorCrashed()) { up = true; } // crashed ≠ stopped: restart on the next load
 			localStorage.setItem(SESSION_KEY, JSON.stringify({
 				visorRunning: up,
 				at: Date.now(),

--- a/pkg/wasmhv/browseui/skywire-exec.js
+++ b/pkg/wasmhv/browseui/skywire-exec.js
@@ -186,6 +186,13 @@
 					if (n > 0) console.warn('[skywire-exec ' + iid + '] released ' + n + ' vnet claim(s) on exit');
 				}
 			} catch (e) { /* ignore */ }
+			// Record how this instance ended, for consumers that must tell a
+			// CRASH from a deliberate stop (the desk session: a crashed visor
+			// restarts on the next load; only a clean exit stays stopped).
+			try {
+				const reg2 = globalThis.__skywireExecTails;
+				if (reg2 && reg2[iid]) reg2[iid].exitInfo = { code: code, crashed: !!runErr };
+			} catch (e) { /* ignore */ }
 			// Mirror abnormal endings to the console with the stderr tail.
 			if (runErr || code !== 0) {
 				try {


### PR DESCRIPTION
The overnight panic (root-caused and fixed in #4430) was recorded by the desk session as up-then-down — an operator stop — so every later load suppressed the autostart and the desk sat idle. skywire-exec now records how each instance ended (exitInfo: code + crashed), and the session records a stop only for a clean exit; a crash restarts on the next load.