### PR TITLE
fix(config): autostarted skysocks-client reconnects in-process

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -2217,6 +2217,20 @@ func configureApps(log *logging.Logger) {
 		for i, app := range conf.Launcher.Apps {
 			if app.Name == "skysocks-client" {
 				conf.Launcher.Apps[i].AutoStart = true
+				// An autostarted proxy client is meant to stay connected:
+				// reconnect in-process (serving the status page during the gap)
+				// instead of exiting on total collapse and paying a full proc
+				// restart + re-dial per RestartOnFailure cycle.
+				hasReconnect := false
+				for _, a := range conf.Launcher.Apps[i].Args {
+					if a == "--reconnect" {
+						hasReconnect = true
+						break
+					}
+				}
+				if !hasReconnect {
+					conf.Launcher.Apps[i].Args = append(conf.Launcher.Apps[i].Args, "--reconnect")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
An autostarted skysocks-client without --reconnect exits on total tunnel collapse and pays a full proc restart + re-dial per RestartOnFailure cycle, leaving the SOCKS port dead between cycles (observed live on the browser visor's proxy chain: the app stopped with "serve proxy client: accept: vnet: use of closed listener" after a hard-dead tunnel retire).

config gen now appends --reconnect whenever it enables the app's autostart, so the client stays bound on :1080 and serves the status page while re-dialing. Explicit operator args are respected (no duplicate append).