### PR TITLE
fix(router): age-gate proactive HoL retransmits with holGapThreshold

### DIFF
--- a/pkg/router/hol_retx.go
+++ b/pkg/router/hol_retx.go
@@ -203,11 +203,24 @@ func (m *routeMux) proactiveRetxSeqs(lastContiguous uint32, words []uint64, fast
 		return nil
 	}
 	interval := holPerSeqInterval(fastestRTTms)
+	gapTh := holGapThreshold(fastestRTTms)
 	var due []uint32
 	for _, seq := range cand {
 		// Only retransmit seqs we still hold: a seq already purged from the retx
 		// buffer was acknowledged, so it is not the one blocking the frontier.
-		if m.retxBuf.Get(seq) == nil {
+		sentAt, held := m.retxBuf.SentAt(seq)
+		if !held {
+			continue
+		}
+		// Age gate (holGapThreshold): a seq younger than ~one fast-leg RTT
+		// cannot have been acked yet no matter which leg it rode, so a nudge is
+		// spurious by construction — SACKs arrive every few ms and, ungated,
+		// the first SACK naming a seq striped onto a slower leg retransmitted
+		// it at ~25ms of age, then every fast-RTT until the original landed
+		// (measured ~12% duplicate bytes concentrated on the fast leg). Gating
+		// the FIRST nudge on age preserves the design's intent: a genuine stall
+		// is still healed in about one fast round-trip.
+		if now.Sub(sentAt) < gapTh {
 			continue
 		}
 		if m.holRetx.Due(seq, interval, now) {

--- a/pkg/router/hol_retx_test.go
+++ b/pkg/router/hol_retx_test.go
@@ -223,7 +223,10 @@ func TestProactiveRetxSeqs(t *testing.T) {
 	// missing) and bit3 set (104 received) — frontier run is 101,102,103.
 	last := uint32(100)
 	words := []uint64{bits(3)}
-	now := time.Unix(0, 0)
+	// Probe one second after the entries are stored (Store stamps sentAt with
+	// the real clock): old enough that the age gate (holGapThreshold) sees a
+	// genuine stall, not a seq still inside its first fast-leg RTT.
+	now := time.Now().Add(time.Second)
 
 	t.Run("capability off -> nil fallback", func(t *testing.T) {
 		m := newMux(false)
@@ -274,6 +277,22 @@ func TestProactiveRetxSeqs(t *testing.T) {
 		later := m.proactiveRetxSeqs(last, words, 20, now.Add(25*time.Millisecond))
 		if !equalSeqs(later, []uint32{101, 102, 103}) {
 			t.Errorf("re-nudge past interval got %v, want [101 102 103]", later)
+		}
+	})
+
+	t.Run("young seq not nudged (age gate)", func(t *testing.T) {
+		m := newMux(true)
+		m.retxBuf.Store(101, []byte("a"))
+		// Probed immediately after send (age ≈ 0 < one fast-leg RTT): the seq
+		// cannot have been acked yet on ANY leg, so a nudge would be spurious
+		// by construction — this is the ungated behavior that duplicated ~12%
+		// of a striped transfer onto the fast leg. Must be nil.
+		if got := m.proactiveRetxSeqs(last, words, 20, time.Now()); got != nil {
+			t.Errorf("seq younger than the gap threshold must not be nudged, got %v", got)
+		}
+		// Same seq once genuinely overdue: nudged.
+		if got := m.proactiveRetxSeqs(last, words, 20, time.Now().Add(time.Second)); !equalSeqs(got, []uint32{101}) {
+			t.Errorf("aged seq must be nudged, got %v, want [101]", got)
 		}
 	})
 

--- a/pkg/router/sack.go
+++ b/pkg/router/sack.go
@@ -346,6 +346,21 @@ func (rb *retxBuffer) Get(seq uint32) []byte {
 	return nil
 }
 
+// SentAt returns when seq was originally sent, and whether the buffer still
+// holds it (an acked/purged seq returns ok=false). The proactive HoL path uses
+// the age to distinguish a seq merely in flight on a slower leg (younger than a
+// reorder window — retransmitting it is spurious by construction) from one
+// genuinely stalling the frontier.
+func (rb *retxBuffer) SentAt(seq uint32) (time.Time, bool) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	if entry, ok := rb.entries[seq]; ok {
+		return entry.sentAt, true
+	}
+	return time.Time{}, false
+}
+
 // Len returns current buffer occupancy.
 func (rb *retxBuffer) Len() int {
 	rb.mu.Lock()


### PR DESCRIPTION
holGapThreshold (the documented frontier-gap age past which a proactive HoL retransmit is warranted) was defined but never called: proactiveRetxSeqs nudged a frontier seq on the first SACK naming it missing, so a seq striped onto a slower leg was retransmitted at ~25ms of age and then every fast-leg RTT until the original landed. Measured live on a 3-leg mux'd 10MB download: ~12% duplicate bytes, concentrated on the fastest leg.

Each seq's nudge is now gated on age-since-send >= holGapThreshold (one fast-leg RTT, floored) via a new retxBuffer.SentAt accessor — younger than one fast-RTT it cannot have been acked on any leg, so the nudge is spurious by construction. A genuine stall is still healed in about one fast round-trip. Regression test added; existing tests' fixture updated to probe after the entries have aged.