### PR TITLE
feat(router): per-leg dup/repair recv decomposition + status-page overhead cell

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_info.go
+++ b/cmd/skywire-cli/commands/proxy/mux_info.go
@@ -145,7 +145,12 @@ type muxLegInfo struct {
 	// PayloadBytes is the unique in-order payload this leg delivered (retransmits
 	// excluded), so per-leg values sum to the transfer size — the clean signal for
 	// which legs carried a direction's data.
-	PayloadBytes   uint64  `json:"payload_bytes"`
+	PayloadBytes uint64 `json:"payload_bytes"`
+	// DupBytes / RepairBytes decompose RecvBytes further: inbound duplicates
+	// (the peer's spurious retransmits, concentrated on the fastest leg) and
+	// FEC repair frames (deliberate overhead).
+	DupBytes       uint64  `json:"dup_bytes"`
+	RepairBytes    uint64  `json:"repair_bytes"`
 	Retransmits    uint64  `json:"retransmits"`
 	GoodputBps     float64 `json:"goodput_bps,omitempty"`
 	GoodputUpBps   float64 `json:"goodput_up_bps,omitempty"`

--- a/cmd/skywire-cli/commands/proxy/tree.go
+++ b/cmd/skywire-cli/commands/proxy/tree.go
@@ -164,6 +164,8 @@ type treeLegInfo struct {
 	Direct         bool          `json:"direct"`
 	SentBytes      uint64        `json:"sent_bytes"`
 	RecvBytes      uint64        `json:"recv_bytes"`
+	DupBytes       uint64        `json:"dup_bytes"`
+	RepairBytes    uint64        `json:"repair_bytes"`
 	GoodputUpBps   float64       `json:"goodput_up_bps,omitempty"`
 	GoodputDownBps float64       `json:"goodput_down_bps,omitempty"`
 	Retransmits    uint64        `json:"retransmits"`
@@ -195,6 +197,8 @@ func (rg treeRouteGroup) toLegs() []proxystatus.Leg {
 			Direct:         l.Direct,
 			SentBytes:      l.SentBytes,
 			RecvBytes:      l.RecvBytes,
+			DupBytes:       l.DupBytes,
+			RepairBytes:    l.RepairBytes,
 			GoodputUpBps:   l.GoodputUpBps,
 			GoodputDownBps: l.GoodputDownBps,
 			Retransmits:    l.Retransmits,

--- a/pkg/proxystatus/provider.go
+++ b/pkg/proxystatus/provider.go
@@ -61,9 +61,16 @@ type Leg struct {
 	LatencyMS      float64
 	RouteLatencyMS float64
 	Direct         bool
-	SentBytes      uint64
-	RecvBytes      uint64
-	Retransmits    uint64
+	SentBytes uint64
+	RecvBytes uint64
+	// DupBytes is inbound DUPLICATE data (seqs already delivered/buffered when
+	// they arrived on this leg) — the peer's spurious retransmits, which ride
+	// the fastest leg and otherwise read as payload; RepairBytes is inbound FEC
+	// repair frames. Both decompose RecvBytes so a standby leg showing inbound
+	// traffic is explainable from the page.
+	DupBytes    uint64
+	RepairBytes uint64
+	Retransmits uint64
 	// GoodputBps is this leg's recent goodput — the EWMA of (sent+recv) bytes
 	// per second over the page's refresh window (~1s), i.e. the RATE the leg is
 	// moving now, distinct from the cumulative SentBytes/RecvBytes counters. 0

--- a/pkg/proxystatus/routetree.go
+++ b/pkg/proxystatus/routetree.go
@@ -251,6 +251,10 @@ const (
 	// up-goodput / down-goodput. Constant width by construction, so it never
 	// reflows the tree as the shares shift on a live push.
 	shareBarWidth = 5
+	// overColWidth fits the inbound-overhead cell ("—" through "999.9K×" /
+	// "15.3M×") — cumulative duplicate + FEC-repair bytes on the leg. Same
+	// pin-the-width reasoning as bwColWidth.
+	overColWidth = 8
 )
 
 // legSumWidths measures the widest R[n] identity across the legs (that count is
@@ -336,7 +340,7 @@ func hopClassMap(snap Snapshot) map[string]string {
 // a template row that lines up with the columns of the tree beneath. Only the
 // page uses it; `proxy tree` renders headerless.
 func TreeHeader() (left, label string, cols []string) {
-	return "R[n] · state · route-rtt · ↑bytes rate share · ↓bytes rate share", "peer-pk", []string{"[type]", "tp-id", "tp-rtt"}
+	return "R[n] · state · route-rtt · ↑bytes rate share · ↓bytes rate share ×over", "peer-pk", []string{"[type]", "tp-id", "tp-rtt"}
 }
 
 // routeToNode turns one leg into a hop-chain right-branch carrying its left
@@ -390,9 +394,22 @@ func legSummary(l Leg, w sumWidths, aggUp, aggDown float64, streamIdx int) strin
 	down := padLeftRunes(compactBytes(l.RecvBytes)+"↓", w.down)
 	downRate := padLeftRunes(compactRate(l.GoodputDownBps), w.gp)
 	downBar := shareBar(l.GoodputDownBps, aggDown, shareBarWidth)
+	over := padLeftRunes(compactOverhead(l.DupBytes, l.RepairBytes), overColWidth)
 	return streamTag(streamIdx) + idx + " " + g + " " + rtt +
 		"  " + up + " " + upRate + " " + upBar +
-		"  " + down + " " + downRate + " " + downBar
+		"  " + down + " " + downRate + " " + downBar + " " + over
+}
+
+// compactOverhead formats a leg's cumulative inbound OVERHEAD — duplicate data
+// (the peer's spurious retransmits, which ride the fastest leg) plus FEC repair
+// frames — for the fixed-width "×" cell beside the ↓ figures. This is what
+// explains a standby leg that shows inbound traffic: its RecvBytes are mostly
+// dup/repair, not striped payload. "—" when zero.
+func compactOverhead(dup, repair uint64) string {
+	if dup+repair == 0 {
+		return "—"
+	}
+	return compactBytes(dup+repair) + "×"
 }
 
 // compactRate formats a goodput rate (bytes/sec) for the fixed-width leg cell:

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -3849,6 +3849,21 @@ func (rg *RouteGroup) handleRepairPacket(packet routing.Packet) error {
 		return nil
 	}
 	atomic.AddUint64(&rg.mux.fecRepairBytesRecv, uint64(packet.Size()))
+	// Per-leg repair accounting: resolve the arrival leg from the packet's route
+	// ID (same reverse-rule match as handleDataPacket) and credit both its recv
+	// counters and the repair-specific one — before this, FEC repairs were
+	// invisible in the per-leg telemetry, so a leg carrying repair overhead was
+	// indistinguishable from an idle one.
+	rg.mu.Lock()
+	rid := packet.RouteID()
+	for i, rule := range rg.rvs {
+		if rule != nil && rule.KeyRouteID() == rid {
+			rg.mux.recordRecv(i, uint64(packet.Size()))
+			rg.mux.recordRepair(i, uint64(packet.Size()))
+			break
+		}
+	}
+	rg.mu.Unlock()
 	delivered := rg.mux.fecOnRecvRepair(packet.RepairBlockID(), packet.RepairIndex(), packet.RepairSymLen(), packet.RepairSymbol())
 	for _, d := range delivered {
 		if len(d) == 0 { // FEC padding frame — advances the frontier, not app data

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -40,6 +40,14 @@ type LegStats struct {
 	// confound-free per-direction attribution (which legs carried the download vs
 	// the upload), unlike RecvBytes which includes retransmit/duplicate inflation.
 	PayloadBytes uint64
+	// DupBytes is inbound DUPLICATE data this leg carried (seqs already
+	// delivered/buffered on arrival) — the peer's spurious-retransmit waste,
+	// which selectFastestTransport concentrates on the fastest leg. RepairBytes
+	// is inbound FEC repair frames (deliberate overhead). Together with
+	// PayloadBytes they decompose RecvBytes so "why is this (standby) leg
+	// receiving" is answerable from telemetry.
+	DupBytes    uint64
+	RepairBytes uint64
 	// Retransmits is how many SACK retransmit packets THIS leg has
 	// carried. A high retransmits:sentPackets ratio marks a lossy leg —
 	// the signal a routing policy needs to shed lossy intermediates and
@@ -88,6 +96,13 @@ type legCounters struct {
 	// equals the transfer size and cleanly attributes which legs carried a
 	// direction's data — the confound-free basis for per-direction leg telemetry.
 	payloadBytes uint64 // atomic
+	// dupBytes is inbound DUPLICATE data on this leg (a seq already delivered
+	// or buffered when it arrived here) — the peer's spurious-retransmit waste,
+	// which rides the fastest leg and otherwise masquerades as payload in
+	// recvBytes. repairBytes is inbound FEC repair frames — deliberate overhead,
+	// counted apart from waste. Both atomic.
+	dupBytes    uint64 // atomic
+	repairBytes uint64 // atomic
 	// lastTotalBytes snapshots sentBytes+recvBytes at the previous
 	// capacity-weight rebuild; the delta since then is this leg's
 	// recent throughput, used by WeightModeCapacity. Touched only
@@ -841,6 +856,38 @@ func (m *routeMux) recordPayload(idx int, n uint64) {
 	m.legMu.RUnlock()
 }
 
+// recordDup atomically credits leg idx with n bytes of DUPLICATE data (a seq
+// that had already been delivered or buffered when it arrived on this leg).
+// Splitting dupBytes out of recvBytes is what attributes a "standby leg with
+// traffic" honestly: the peer's spurious retransmits ride the fastest leg
+// (resendSeqs → selectFastestTransport), which is typically the parked direct
+// leg, and without this counter that flow is indistinguishable from striped
+// payload. Same bounds-check semantics as recordRecv.
+func (m *routeMux) recordDup(idx int, n uint64) {
+	if idx < 0 {
+		return
+	}
+	m.legMu.RLock()
+	if idx < len(m.legs) {
+		atomic.AddUint64(&m.legs[idx].dupBytes, n)
+	}
+	m.legMu.RUnlock()
+}
+
+// recordRepair atomically credits leg idx with n bytes of FEC repair frames.
+// Repairs are overhead by design (they buy gap-fill latency); counting them
+// per leg separates that deliberate cost from spurious-retransmit waste.
+func (m *routeMux) recordRepair(idx int, n uint64) {
+	if idx < 0 {
+		return
+	}
+	m.legMu.RLock()
+	if idx < len(m.legs) {
+		atomic.AddUint64(&m.legs[idx].repairBytes, n)
+	}
+	m.legMu.RUnlock()
+}
+
 // recordRetransmit atomically increments the retransmit counter for leg
 // idx (the leg that carried a SACK retransmit). The retransmitted bytes
 // are still recorded via recordSent; this is the separate loss signal.
@@ -890,6 +937,8 @@ func (m *routeMux) snapshotLegs() []LegStats {
 			RecvBytes:      recv,
 			RecvPackets:    atomic.LoadUint64(&c.recvPackets),
 			PayloadBytes:   atomic.LoadUint64(&c.payloadBytes),
+			DupBytes:       atomic.LoadUint64(&c.dupBytes),
+			RepairBytes:    atomic.LoadUint64(&c.repairBytes),
 			Retransmits:    atomic.LoadUint64(&c.retransmits),
 			GoodputUpBps:   c.goodputUpBps,
 			GoodputDownBps: c.goodputDownBps,
@@ -1024,6 +1073,8 @@ func (m *routeMux) deliverData(leg int, seq uint32, data []byte) (delivered [][]
 		}
 		if isNew {
 			m.recordPayload(leg, uint64(len(data)))
+		} else {
+			m.recordDup(leg, uint64(len(data)))
 		}
 	}
 

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -172,6 +172,8 @@ func muxRouteGroupInfoFrom(infos []router.MuxInfo) []MuxRouteGroupInfo {
 				RecvBytes:      leg.RecvBytes,
 				RecvPackets:    leg.RecvPackets,
 				PayloadBytes:   leg.PayloadBytes,
+				DupBytes:       leg.DupBytes,
+				RepairBytes:    leg.RepairBytes,
 				Retransmits:    leg.Retransmits,
 				GoodputBps:     leg.GoodputBps,
 				GoodputUpBps:   leg.GoodputUpBps,

--- a/pkg/visor/embedded_proxystatus.go
+++ b/pkg/visor/embedded_proxystatus.go
@@ -177,6 +177,8 @@ func proxyLegFrom(leg MuxLegInfo) proxystatus.Leg {
 		Direct:         leg.Direct,
 		SentBytes:      leg.SentBytes,
 		RecvBytes:      leg.RecvBytes,
+		DupBytes:       leg.DupBytes,
+		RepairBytes:    leg.RepairBytes,
 		Retransmits:    leg.Retransmits,
 		GoodputBps:     leg.GoodputBps,
 		GoodputUpBps:   leg.GoodputUpBps,

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -356,6 +356,13 @@ type MuxLegInfo struct {
 	// the transfer size and cleanly attribute which legs carried a direction's
 	// data, unlike RecvBytes which includes retransmit inflation.
 	PayloadBytes uint64 `json:"payload_bytes"`
+	// DupBytes is inbound DUPLICATE data (seqs already delivered/buffered on
+	// arrival) — the peer's spurious-retransmit waste, which rides the fastest
+	// leg. RepairBytes is inbound FEC repair frames (deliberate overhead).
+	// With PayloadBytes they decompose RecvBytes, so a standby leg showing
+	// traffic is attributable from telemetry.
+	DupBytes    uint64 `json:"dup_bytes"`
+	RepairBytes uint64 `json:"repair_bytes"`
 	// Retransmits is SACK retransmit packets carried by this leg (loss
 	// signal). Alive/Standby are the leg's gate_state: Alive=false once the
 	// transport is closed; Standby=true for a warm standby (rules kept,


### PR DESCRIPTION
A standby leg showing hundreds of KB/s of inbound traffic (observed live on status.skysocks during mux load testing) was unexplainable from telemetry: per-leg RecvBytes lumps striped payload, the peer's spurious retransmits — which the fastest-leg retransmit path concentrates on the parked direct leg — and FEC repairs into one number, and repair frames had no per-leg accounting at all.

Each leg now counts DupBytes (data arriving for a seq already delivered/buffered) and RepairBytes (FEC repair frames), decomposing RecvBytes. Surfaced through RouteGroupMuxInfo, the visor RPC, cli proxy mux info / tree JSON, and rendered on the status page's route tree as a fixed-width overhead cell beside each leg's down figures.