### PR TITLE
fix(skysocks): range-split degrades to sequential streaming instead of truncating

### DIFF
--- a/pkg/skysocks/rangesplit.go
+++ b/pkg/skysocks/rangesplit.go
@@ -222,6 +222,8 @@ func (c *Client) rangeSplitInner(conn, stream net.Conn) (host string, clientPref
 	c.rsActive.Add(1)
 	c.streamRemainingChunks(conn, total, func(start, end int64) ([]byte, error) {
 		return c.fetchChunkRetry(req, host, validator, start, end)
+	}, func(w net.Conn, start int64) (int64, error) {
+		return c.streamTailOnce(w, req, host, validator, start, total)
 	})
 	c.rsActive.Add(-1)
 	conn.Close() //nolint:errcheck,gosec
@@ -233,7 +235,18 @@ func (c *Client) rangeSplitInner(conn, stream net.Conn) (host string, clientPref
 // caller supplies the plaintext or TLS-over-exit fetch). Outstanding (in-flight +
 // buffered) chunks are bounded to the configured concurrency so memory stays
 // ~concurrency×chunkSize.
-func (c *Client) streamRemainingChunks(conn net.Conn, total int64, fetch func(start, end int64) ([]byte, error)) {
+//
+// When a chunk exhausts its retry budget, the split does NOT truncate the
+// download: it degrades to the SEQUENTIAL rescue path — rescue streams
+// [start, total) as one ranged request straight to conn, resumed from the byte
+// offset actually delivered across attempts, so a degraded-but-alive session
+// completes the download slowly instead of emitting a clean-looking short body
+// (observed live: a 50MB download "succeeding" with exactly the first 4MiB
+// chunk). Only when the rescue itself makes no progress does the download end
+// short — and then the browser still detects it (Content-Length mismatch).
+// rescue may be nil (a caller without a sequential path keeps the old
+// truncating behavior).
+func (c *Client) streamRemainingChunks(conn net.Conn, total int64, fetch func(start, end int64) ([]byte, error), rescue func(w net.Conn, start int64) (int64, error)) {
 	type chunk struct {
 		start, end int64
 		buf        []byte
@@ -269,7 +282,10 @@ func (c *Client) streamRemainingChunks(conn net.Conn, total int64, fetch func(st
 			if c.appCl != nil {
 				c.appCl.Log().Debugf("range-split: chunk %d-%d failed: %v", ch.start, ch.end, ch.err)
 			}
-			break // truncate; caller closes conn
+			if rescue != nil {
+				c.rescueTail(conn, ch.start, total, rescue)
+			}
+			break // rescued (or truncated with no rescue); caller closes conn
 		}
 		if _, err := conn.Write(ch.buf); err != nil {
 			break
@@ -279,6 +295,42 @@ func (c *Client) streamRemainingChunks(conn net.Conn, total int64, fetch func(st
 	}
 	// Drain any still-running fetches so their slots free and goroutines exit.
 	go func() { wg.Wait() }()
+}
+
+// rsRescueAttempts is how many consecutive ZERO-PROGRESS rescue attempts end the
+// download. An attempt that delivers any bytes resets the count — the rescue
+// resumes from the delivered offset, so a slow-but-alive session keeps making
+// progress until the download completes, however long that takes.
+const rsRescueAttempts = 3
+
+// rescueTail sequentially streams [start, total) to conn via rescue, resuming
+// from the delivered offset after a failed attempt. It gives up only after
+// rsRescueAttempts consecutive attempts deliver nothing.
+func (c *Client) rescueTail(conn net.Conn, start, total int64, rescue func(w net.Conn, start int64) (int64, error)) {
+	if c.appCl != nil {
+		c.appCl.Log().Warnf("range-split: parallel fetch failed at byte %d/%d — degrading to sequential streaming for the remainder", start, total)
+	}
+	cur := start
+	zero := 0
+	for cur < total && zero < rsRescueAttempts {
+		n, err := rescue(conn, cur)
+		cur += n
+		if n > 0 {
+			zero = 0
+		} else {
+			zero++
+		}
+		if err == nil && cur >= total {
+			break
+		}
+	}
+	if c.appCl != nil {
+		if cur >= total {
+			c.appCl.Log().Infof("range-split: sequential rescue completed the download (%d bytes)", total)
+		} else {
+			c.appCl.Log().Warnf("range-split: sequential rescue gave up at byte %d/%d — download ends short (client detects via Content-Length)", cur, total)
+		}
+	}
 }
 
 // fetchChunkRetry fetches one byte range, redialing a fresh stream on failure and
@@ -313,6 +365,76 @@ func retryWithBudget(fetch func() ([]byte, error), budget, backoff, backoffMax t
 			}
 		}
 	}
+}
+
+// rsRescueIdleTimeout is the per-read progress window of a sequential rescue
+// stream: each successful read refreshes it, so a slow-but-moving tail runs to
+// completion while a genuinely silent stream fails within one window (the same
+// bytes-are-liveness standard the tunnel keepalive applies).
+const rsRescueIdleTimeout = 60 * time.Second
+
+// streamTailOnce makes ONE attempt to stream [start, total) to w over a fresh
+// exit stream: ranged GET like fetchChunk, but the body is copied straight
+// through (never buffered — the tail can be most of the file) under a
+// progress-refreshed idle timeout. Returns the bytes actually written, so the
+// caller resumes from start+written on failure.
+func (c *Client) streamTailOnce(w net.Conn, req *http.Request, host, validator string, start, total int64) (int64, error) {
+	sess := c.pickSession()
+	if sess == nil {
+		return 0, errAllTunnelsDown
+	}
+	st, err := sess.Open()
+	if err != nil {
+		return 0, err
+	}
+	defer st.Close() //nolint:errcheck,gosec
+
+	_ = st.SetDeadline(time.Now().Add(rsProbeTimeout)) //nolint:errcheck
+	if err := c.exitConnect(st, host, 80); err != nil {
+		return 0, err
+	}
+	if _, err := st.Write(buildRangedGet(req, host, validator, start, total-1)); err != nil {
+		return 0, err
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(st), req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusPartialContent {
+		return 0, fmt.Errorf("tail %d-%d: status %d (validator changed?)", start, total-1, resp.StatusCode)
+	}
+	return copyWithIdleTimeout(w, resp.Body, st, total-start, rsRescueIdleTimeout)
+}
+
+// copyWithIdleTimeout copies up to limit bytes from body to dst, refreshing a
+// read deadline on the underlying conn before every read — progress keeps the
+// copy alive indefinitely; idle silence fails it within one window. Returns the
+// bytes written (the caller's resume offset).
+func copyWithIdleTimeout(dst io.Writer, body io.Reader, under net.Conn, limit int64, idle time.Duration) (int64, error) {
+	var written int64
+	buf := make([]byte, 32<<10)
+	for written < limit {
+		_ = under.SetReadDeadline(time.Now().Add(idle)) //nolint:errcheck
+		room := int64(len(buf))
+		if rem := limit - written; rem < room {
+			room = rem
+		}
+		n, err := body.Read(buf[:room])
+		if n > 0 {
+			if _, werr := dst.Write(buf[:n]); werr != nil {
+				return written, werr
+			}
+			written += int64(n)
+		}
+		if err != nil {
+			if err == io.EOF && written >= limit {
+				return written, nil
+			}
+			return written, err
+		}
+	}
+	return written, nil
 }
 
 // fetchChunk opens a new exit stream, SOCKS5-CONNECTs to host:80, issues a ranged

--- a/pkg/skysocks/rangesplit_https.go
+++ b/pkg/skysocks/rangesplit_https.go
@@ -269,6 +269,8 @@ func (c *Client) httpsRangeSplitDrive(btls, otls net.Conn, req *http.Request, re
 	c.rsActive.Add(1)
 	c.streamRemainingChunks(btls, total, func(start, end int64) ([]byte, error) {
 		return c.fetchChunkTLSRetry(req, host, validator, start, end)
+	}, func(w net.Conn, start int64) (int64, error) {
+		return c.streamTailTLSOnce(w, req, host, validator, start, total)
 	})
 	c.rsActive.Add(-1)
 	btls.Close() //nolint:errcheck,gosec
@@ -326,6 +328,44 @@ func (c *Client) fetchChunkTLS(req *http.Request, host, validator string, start,
 		return nil, err
 	}
 	return buf, nil
+}
+
+// streamTailTLSOnce makes ONE attempt to stream [start, total) to w over a
+// fresh TLS-to-origin stream — the HTTPS analog of streamTailOnce, used by the
+// sequential rescue when a parallel chunk exhausts its retries. The body is
+// copied straight through under a progress-refreshed idle timeout; returns the
+// bytes written so the caller resumes from start+written.
+func (c *Client) streamTailTLSOnce(w net.Conn, req *http.Request, host, validator string, start, total int64) (int64, error) {
+	sess := c.pickSession()
+	if sess == nil {
+		return 0, errAllTunnelsDown
+	}
+	st, err := sess.Open()
+	if err != nil {
+		return 0, err
+	}
+	defer st.Close() //nolint:errcheck,gosec
+
+	_ = st.SetDeadline(time.Now().Add(rsProbeTimeout)) //nolint:errcheck
+	if err := c.exitConnect(st, host, 443); err != nil {
+		return 0, err
+	}
+	tconn := tls.Client(st, c.originTLSConfig(host))
+	if err := tconn.Handshake(); err != nil {
+		return 0, err
+	}
+	if _, err := tconn.Write(buildRangedGet(req, host, validator, start, total-1)); err != nil {
+		return 0, err
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(tconn), req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusPartialContent {
+		return 0, fmt.Errorf("tail %d-%d: status %d (validator changed?)", start, total-1, resp.StatusCode)
+	}
+	return copyWithIdleTimeout(w, resp.Body, st, total-start, rsRescueIdleTimeout)
 }
 
 // closeBoth closes two conns, ignoring errors.

--- a/pkg/skysocks/rangesplit_rescue_test.go
+++ b/pkg/skysocks/rangesplit_rescue_test.go
@@ -1,0 +1,219 @@
+// Package skysocks range-split sequential-rescue tests: a chunk that exhausts
+// its retries must degrade to sequential streaming of the remainder — never a
+// clean-looking short body (the silent 4MiB truncation observed live).
+package skysocks
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// collectConn drains one end of a net.Pipe into a buffer so the writer side
+// (streamRemainingChunks) never blocks.
+func collectConn(t *testing.T) (net.Conn, *sync.Mutex, *bytes.Buffer) {
+	t.Helper()
+	a, b := net.Pipe()
+	var mu sync.Mutex
+	var buf bytes.Buffer
+	go func() {
+		tmp := make([]byte, 4096)
+		for {
+			n, err := b.Read(tmp)
+			if n > 0 {
+				mu.Lock()
+				buf.Write(tmp[:n])
+				mu.Unlock()
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		a.Close() //nolint:errcheck,gosec
+		b.Close() //nolint:errcheck,gosec
+	})
+	return a, &mu, &buf
+}
+
+// rescueClient builds a minimal Client whose chunkSize/concurrency drive
+// streamRemainingChunks directly (no network).
+func rescueClient(chunkSize int64) *Client {
+	c := &Client{closeC: make(chan struct{})}
+	c.rs = rangeSplitConfig{enabled: true, concurrency: 2, chunkSize: chunkSize}
+	return c
+}
+
+// TestStreamRemainingChunks_RescueCompletesDownload: chunk 2 fails permanently;
+// the rescue streams the remainder (resuming across a partial first attempt),
+// so the client receives every byte of [chunkSize, total).
+func TestStreamRemainingChunks_RescueCompletesDownload(t *testing.T) {
+	const chunk = 8
+	const total = 40 // chunk0 (8B, not part of this call) + 4 chunks of 8
+	c := rescueClient(chunk)
+	conn, mu, got := collectConn(t)
+
+	pattern := func(start, end int64) []byte {
+		out := make([]byte, end-start+1)
+		for i := range out {
+			out[i] = byte((start + int64(i)) % 251)
+		}
+		return out
+	}
+
+	fetch := func(start, end int64) ([]byte, error) {
+		if start == 2*chunk { // third chunk (bytes 16-23) always fails
+			return nil, errors.New("chunk permanently unavailable")
+		}
+		return pattern(start, end), nil
+	}
+	// Rescue: first attempt delivers 5 bytes then errors; the retry (resumed at
+	// the advanced offset) delivers the rest.
+	attempt := 0
+	rescue := func(w net.Conn, start int64) (int64, error) {
+		attempt++
+		if attempt == 1 {
+			p := pattern(start, start+4)
+			n, _ := w.Write(p)
+			return int64(n), errors.New("stream died mid-tail")
+		}
+		p := pattern(start, total-1)
+		n, err := w.Write(p)
+		return int64(n), err
+	}
+
+	c.streamRemainingChunks(conn, total, fetch, rescue)
+
+	want := pattern(chunk, total-1) // [chunkSize, total) in order
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		ok := bytes.Equal(got.Bytes(), want)
+		n := got.Len()
+		mu.Unlock()
+		if ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("rescued stream = %d bytes, want %d contiguous bytes", n, len(want))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if attempt != 2 {
+		t.Errorf("rescue attempts = %d, want 2 (partial then resumed)", attempt)
+	}
+}
+
+// TestStreamRemainingChunks_NoRescueKeepsTruncation: with a nil rescue the old
+// behavior stands — the stream ends at the failed chunk boundary.
+func TestStreamRemainingChunks_NoRescueKeepsTruncation(t *testing.T) {
+	const chunk = 8
+	const total = 32
+	c := rescueClient(chunk)
+	conn, mu, got := collectConn(t)
+
+	fetch := func(start, end int64) ([]byte, error) {
+		if start == 2*chunk {
+			return nil, errors.New("gone")
+		}
+		return make([]byte, end-start+1), nil
+	}
+	c.streamRemainingChunks(conn, total, fetch, nil)
+
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	n := got.Len()
+	mu.Unlock()
+	if n != chunk { // only the second chunk (bytes 8-15) made it
+		t.Errorf("truncation point = %d bytes, want %d", n, chunk)
+	}
+}
+
+// TestStreamRemainingChunks_RescueGivesUpWithoutProgress: a rescue that never
+// delivers a byte is abandoned after rsRescueAttempts tries.
+func TestStreamRemainingChunks_RescueGivesUpWithoutProgress(t *testing.T) {
+	const chunk = 8
+	const total = 32
+	c := rescueClient(chunk)
+	conn, _, _ := collectConn(t)
+
+	fetch := func(start, end int64) ([]byte, error) {
+		return nil, errors.New("all chunks fail")
+	}
+	calls := 0
+	rescue := func(w net.Conn, start int64) (int64, error) {
+		calls++
+		return 0, errors.New("still dead")
+	}
+	done := make(chan struct{})
+	go func() {
+		c.streamRemainingChunks(conn, total, fetch, rescue)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamRemainingChunks did not return — zero-progress rescue must give up")
+	}
+	if calls != rsRescueAttempts {
+		t.Errorf("zero-progress rescue attempts = %d, want %d", calls, rsRescueAttempts)
+	}
+}
+
+// TestCopyWithIdleTimeout_ProgressBeatsIdle: a source that trickles slower than
+// the idle window per chunk still completes (progress refreshes the deadline),
+// and the byte count is exact.
+func TestCopyWithIdleTimeout_ProgressBeatsIdle(t *testing.T) {
+	src, feeder := net.Pipe()
+	defer src.Close()    //nolint:errcheck
+	defer feeder.Close() //nolint:errcheck
+	go func() {
+		for i := 0; i < 4; i++ {
+			time.Sleep(30 * time.Millisecond)
+			feeder.Write([]byte{byte(i), byte(i), byte(i)}) //nolint:errcheck,gosec
+		}
+	}()
+	var out bytes.Buffer
+	n, err := copyWithIdleTimeout(&out, src, src, 12, 100*time.Millisecond)
+	if err != nil || n != 12 {
+		t.Fatalf("copyWithIdleTimeout = (%d, %v), want (12, nil)", n, err)
+	}
+}
+
+// TestCopyWithIdleTimeout_SilenceFails: a source that stops sending fails within
+// one idle window, reporting the bytes delivered so far.
+func TestCopyWithIdleTimeout_SilenceFails(t *testing.T) {
+	src, feeder := net.Pipe()
+	defer src.Close()    //nolint:errcheck
+	defer feeder.Close() //nolint:errcheck
+	go func() {
+		feeder.Write([]byte("abcde")) //nolint:errcheck,gosec
+		// then silence — never close, never send
+	}()
+	var out bytes.Buffer
+	start := time.Now()
+	n, err := copyWithIdleTimeout(&out, src, src, 100, 80*time.Millisecond)
+	if err == nil {
+		t.Fatal("silent source must fail the copy")
+	}
+	if n != 5 {
+		t.Errorf("delivered bytes = %d, want 5", n)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("silence detection took %v, want ~one idle window", elapsed)
+	}
+	if !errors.Is(err, io.EOF) && !isTimeout(err) {
+		t.Logf("failure error (acceptable): %v", err)
+	}
+}
+
+// isTimeout reports whether err is a net timeout.
+func isTimeout(err error) bool {
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
+}


### PR DESCRIPTION
When a follow-up chunk exhausted its retry budget, range-split ended the response at the failed chunk boundary — observed live in soak testing as 50MB downloads "succeeding" with exactly the first 4MiB chunk while the path degraded. On a degraded-but-alive session that silently trades a slow download for a truncated one.

A failed chunk now triggers a sequential rescue: the remaining range is streamed through one ranged request (both HTTP and HTTPS-MITM paths), resumed from the delivered byte offset across attempts, under a progress-refreshed 60s idle window — progress keeps it alive indefinitely, silence fails it within one window. Only a rescue that repeatedly delivers nothing ends the download short, which the client still detects via Content-Length. Regression tests cover rescue completion with resume, zero-progress give-up, nil-rescue truncation compatibility, and the idle-timeout copy.