### PR TITLE
fix(router): narrow the demote retx flush to the demoted legs' sequences

### DIFF
--- a/pkg/router/fec_mux_integration_test.go
+++ b/pkg/router/fec_mux_integration_test.go
@@ -47,7 +47,7 @@ func TestFECMuxWiredReconstructsSlowLegFrame(t *testing.T) {
 	packets := make([]routing.Packet, k)
 	for i := 0; i < k; i++ {
 		plain[i] = []byte(fmt.Sprintf("frame-%02d-the-quick-brown-fox-jumps", i))
-		pkt, seq, err := send.wrapPayload(routeID, plain[i])
+		pkt, seq, err := send.wrapPayload(routeID, plain[i], 0)
 		require.NoError(t, err)
 		require.Equal(t, uint32(i), seq)
 		packets[i] = pkt
@@ -100,7 +100,7 @@ func TestFECMuxWiredInertWhenDisabled(t *testing.T) {
 	plain := make([][]byte, n)
 	for i := 0; i < n; i++ {
 		plain[i] = []byte(fmt.Sprintf("plain-%02d", i))
-		pkt, _, err := send.wrapPayload(routeID, plain[i])
+		pkt, _, err := send.wrapPayload(routeID, plain[i], 0)
 		require.NoError(t, err)
 		delivered, _ := recv.deliverData(-1, pkt.SequenceNumber(), pkt.DataPayloadAfterSeq())
 		require.Len(t, delivered, 1, "in-order delivery, one frame at a time")
@@ -151,7 +151,7 @@ func TestFECMuxTailFlushProtectsPartialBlock(t *testing.T) {
 	realPkts := make([]routing.Packet, jReal)
 	for i := 0; i < jReal; i++ {
 		plain[i] = []byte(fmt.Sprintf("tail-frame-%02d-payload", i))
-		pkt, seq, err := send.wrapPayload(routeID, plain[i])
+		pkt, seq, err := send.wrapPayload(routeID, plain[i], 0)
 		require.NoError(t, err)
 		require.Equal(t, uint32(i), seq)
 		realPkts[i] = pkt
@@ -163,7 +163,7 @@ func TestFECMuxTailFlushProtectsPartialBlock(t *testing.T) {
 	padPkts := make([]routing.Packet, 0, k-jReal)
 	for i := jReal; i < k; i++ {
 		var empty []byte
-		pkt, seq, err := send.wrapPayload(routeID, empty)
+		pkt, seq, err := send.wrapPayload(routeID, empty, 0)
 		require.NoError(t, err)
 		require.Equal(t, uint32(i), seq)
 		padPkts = append(padPkts, pkt)
@@ -214,7 +214,7 @@ func TestFECMuxSingleLegNoRepair(t *testing.T) {
 
 	const routeID = routing.RouteID(13)
 	for i := 0; i < fecDefaultK*3; i++ {
-		_, _, err := send.wrapPayload(routeID, []byte(fmt.Sprintf("f-%02d", i)))
+		_, _, err := send.wrapPayload(routeID, []byte(fmt.Sprintf("f-%02d", i)), 0)
 		require.NoError(t, err)
 	}
 	require.Empty(t, send.fecDrainRepairs(), "single-leg group must not emit FEC repair frames")

--- a/pkg/router/hol_retx_test.go
+++ b/pkg/router/hol_retx_test.go
@@ -230,8 +230,8 @@ func TestProactiveRetxSeqs(t *testing.T) {
 
 	t.Run("capability off -> nil fallback", func(t *testing.T) {
 		m := newMux(false)
-		m.retxBuf.Store(101, []byte("a"))
-		m.retxBuf.Store(102, []byte("b"))
+		m.retxBuf.Store(101, []byte("a"), 0)
+		m.retxBuf.Store(102, []byte("b"), 0)
 		if got := m.proactiveRetxSeqs(last, words, 20, now); got != nil {
 			t.Errorf("HoL disabled must return nil, got %v", got)
 		}
@@ -239,9 +239,9 @@ func TestProactiveRetxSeqs(t *testing.T) {
 
 	t.Run("returns held frontier seqs", func(t *testing.T) {
 		m := newMux(true)
-		m.retxBuf.Store(101, []byte("a"))
-		m.retxBuf.Store(102, []byte("b"))
-		m.retxBuf.Store(103, []byte("c"))
+		m.retxBuf.Store(101, []byte("a"), 0)
+		m.retxBuf.Store(102, []byte("b"), 0)
+		m.retxBuf.Store(103, []byte("c"), 0)
 		got := m.proactiveRetxSeqs(last, words, 20, now)
 		if !equalSeqs(got, []uint32{101, 102, 103}) {
 			t.Errorf("got %v, want [101 102 103]", got)
@@ -251,8 +251,8 @@ func TestProactiveRetxSeqs(t *testing.T) {
 	t.Run("skips seqs not in retx buffer", func(t *testing.T) {
 		m := newMux(true)
 		// 102 already acked/purged -> not retransmitted; 101,103 held.
-		m.retxBuf.Store(101, []byte("a"))
-		m.retxBuf.Store(103, []byte("c"))
+		m.retxBuf.Store(101, []byte("a"), 0)
+		m.retxBuf.Store(103, []byte("c"), 0)
 		got := m.proactiveRetxSeqs(last, words, 20, now)
 		if !equalSeqs(got, []uint32{101, 103}) {
 			t.Errorf("got %v, want [101 103]", got)
@@ -261,9 +261,9 @@ func TestProactiveRetxSeqs(t *testing.T) {
 
 	t.Run("per-seq rate limit within interval", func(t *testing.T) {
 		m := newMux(true)
-		m.retxBuf.Store(101, []byte("a"))
-		m.retxBuf.Store(102, []byte("b"))
-		m.retxBuf.Store(103, []byte("c"))
+		m.retxBuf.Store(101, []byte("a"), 0)
+		m.retxBuf.Store(102, []byte("b"), 0)
+		m.retxBuf.Store(103, []byte("c"), 0)
 		// fastestMs=20 -> interval 20ms.
 		first := m.proactiveRetxSeqs(last, words, 20, now)
 		if !equalSeqs(first, []uint32{101, 102, 103}) {
@@ -282,7 +282,7 @@ func TestProactiveRetxSeqs(t *testing.T) {
 
 	t.Run("young seq not nudged (age gate)", func(t *testing.T) {
 		m := newMux(true)
-		m.retxBuf.Store(101, []byte("a"))
+		m.retxBuf.Store(101, []byte("a"), 0)
 		// Probed immediately after send (age ≈ 0 < one fast-leg RTT): the seq
 		// cannot have been acked yet on ANY leg, so a nudge would be spurious
 		// by construction — this is the ungated behavior that duplicated ~12%
@@ -298,7 +298,7 @@ func TestProactiveRetxSeqs(t *testing.T) {
 
 	t.Run("empty bitmap -> nil (no stall)", func(t *testing.T) {
 		m := newMux(true)
-		m.retxBuf.Store(101, []byte("a"))
+		m.retxBuf.Store(101, []byte("a"), 0)
 		if got := m.proactiveRetxSeqs(last, nil, 20, now); got != nil {
 			t.Errorf("empty SACK bitmap must return nil, got %v", got)
 		}

--- a/pkg/router/perframe_noise_test.go
+++ b/pkg/router/perframe_noise_test.go
@@ -53,7 +53,7 @@ func TestPerFrameMuxDataPathRoundTrip(t *testing.T) {
 	packets := make([]routing.Packet, n)
 	for i := 0; i < n; i++ {
 		plain[i] = []byte(fmt.Sprintf("payload-%04d-the-quick-brown-fox", i))
-		pkt, seq, err := send.wrapPayload(routeID, plain[i])
+		pkt, seq, err := send.wrapPayload(routeID, plain[i], 0)
 		require.NoError(t, err)
 		require.Equal(t, uint32(i), seq)
 		packets[i] = pkt
@@ -87,7 +87,7 @@ func TestPerFrameMuxDataPathRoundTrip(t *testing.T) {
 	_ = nI2
 	recv2.open = func(seq uint32, ct []byte) ([]byte, error) { return nR2.OpenWithNonce(uint64(seq), ct) }
 	// Frame sealed by a DIFFERENT sender (wrong key) must fail to open and deliver nothing.
-	bad, _, err := send.wrapPayload(routeID, []byte("attacker"))
+	bad, _, err := send.wrapPayload(routeID, []byte("attacker"), 0)
 	require.NoError(t, err)
 	// reset recv2 to expect seq 0
 	delivered, _ := recv2.deliverData(-1, bad.SequenceNumber()+1000, bad.DataPayloadAfterSeq())

--- a/pkg/router/rack_tlp_test.go
+++ b/pkg/router/rack_tlp_test.go
@@ -62,9 +62,9 @@ func TestTLPProbeSeq(t *testing.T) {
 	}
 
 	// Outstanding data, but the sender is NOT yet idle for a PTO → no probe.
-	m.retxBuf.Store(10, []byte("a"))
-	m.retxBuf.Store(11, []byte("b"))
-	m.retxBuf.Store(12, []byte("c")) // tail = 12
+	m.retxBuf.Store(10, []byte("a"), 0)
+	m.retxBuf.Store(11, []byte("b"), 0)
+	m.retxBuf.Store(12, []byte("c"), 0) // tail = 12
 	atomic.StoreInt64(&m.lastSendNano, now.UnixNano())
 	if _, due := m.tlpProbeSeq(now.Add(10 * time.Millisecond)); due {
 		t.Fatal("probe due before a full PTO of idle")

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -850,7 +850,7 @@ func (rg *RouteGroup) write(data []byte, tp *transport.ManagedTransport, rule ro
 	var packet routing.Packet
 	var err error
 	if rg.mux != nil {
-		packet, _, err = rg.mux.wrapPayload(rule.NextRouteID(), data)
+		packet, _, err = rg.mux.wrapPayload(rule.NextRouteID(), data, leg)
 	} else {
 		packet, err = routing.MakeDataPacket(rule.NextRouteID(), data)
 	}
@@ -1759,7 +1759,13 @@ func (rg *RouteGroup) rotationServiceFn(_ time.Duration) {
 	// compaction. If no active leg is available the flush is a safe no-op — leg 0
 	// is never standby, so demoting an aux always leaves a resend target.
 	if demoted && rg.mux != nil {
-		if seqs := rg.mux.heldRetxSeqs(); len(seqs) > 0 {
+		// Narrowed to the DEMOTED legs' in-flight sequences (plus any with
+		// unknown attribution): only those are stranded by the demote; the rest
+		// still ride active legs and heal through the normal SACK path. The
+		// whole-window flush this replaces duplicated the entire in-flight
+		// window (measured 33.8MB of dupes against 14.7MB payload on one leg
+		// of a 20MB transfer) on every demote event.
+		if seqs := rg.mux.heldRetxSeqsOnLegs(action.DemoteToStandby); len(seqs) > 0 {
 			if err := rg.resendSeqs(seqs); err != nil {
 				rg.logger.WithError(err).Debug("demote retx flush: no active leg to resend on")
 			}
@@ -4093,6 +4099,9 @@ func (rg *RouteGroup) resendSeqs(seqs []uint32) error {
 			// retx selector picks fresh, mirroring the data path).
 			rg.mux.recordSent(leg, uint64(retxPacket.Size()))
 			rg.mux.recordRetransmit(leg) // separate loss signal for leg health
+			// Re-tag the sequence's last-send leg so a later demote flush
+			// attributes it to where it now rides, not where it started.
+			rg.mux.retxSetLeg(seq, leg)
 			// A frame just went out (incl. a TLP probe) — restart the TLP idle
 			// timer so the next probe waits a fresh PTO rather than back-to-back.
 			atomic.StoreInt64(&rg.mux.lastSendNano, time.Now().UnixNano())

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -993,9 +993,11 @@ func ewmaRate(prev float64, delta uint64, secs float64) float64 {
 	return goodputEWMAAlpha*sample + (1-goodputEWMAAlpha)*prev
 }
 
-// wrapPayload creates a sequenced data packet and optionally stores it for retransmission.
+// wrapPayload creates a sequenced data packet and optionally stores it for
+// retransmission, tagged with the leg it is about to be sent on (-1 = unknown)
+// so the demote-time flush can target only the stranded leg's sequences.
 // Returns the packet and the sequence number used.
-func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte) (routing.Packet, uint32, error) {
+func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte, leg int) (routing.Packet, uint32, error) {
 	seq := atomic.AddUint32(&m.writeSeq, 1) - 1
 	// Per-frame AEAD: seal the app payload under seq as the nonce. The sealed
 	// bytes are what go on the wire AND into the retx buffer, so a SACK
@@ -1011,7 +1013,7 @@ func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte) (routing.Pa
 
 	// Store for retransmission before sending
 	if m.sackEnabled && m.retxBuf != nil {
-		m.retxBuf.Store(seq, data) //nolint:errcheck
+		m.retxBuf.Store(seq, data, leg) //nolint:errcheck
 	}
 
 	// FEC: feed the on-wire (post-seal) payload to the striper. A completed block
@@ -1298,6 +1300,31 @@ func (m *routeMux) heldRetxSeqs() []uint32 {
 		return nil
 	}
 	return m.retxBuf.Seqs()
+}
+
+// heldRetxSeqsOnLegs returns the held sequences whose LAST send rode one of the
+// given leg indices (unknown-leg entries included conservatively), ascending.
+// The demote-time flush uses this to rescue only the sequences the demoted
+// leg(s) actually strand, instead of duplicating the whole in-flight window
+// onto the surviving legs.
+func (m *routeMux) heldRetxSeqsOnLegs(legIdxs []int) []uint32 {
+	if !m.sackEnabled || m.retxBuf == nil || len(legIdxs) == 0 {
+		return nil
+	}
+	set := make(map[int]bool, len(legIdxs))
+	for _, idx := range legIdxs {
+		set[idx] = true
+	}
+	return m.retxBuf.HeldSeqsOnLegs(set)
+}
+
+// retxSetLeg re-tags a held sequence's last-send leg after a retransmit moved
+// it to a different leg, keeping the demote-flush attribution honest.
+func (m *routeMux) retxSetLeg(seq uint32, leg int) {
+	if m.retxBuf == nil {
+		return
+	}
+	m.retxBuf.SetLeg(seq, leg)
 }
 
 // rebuildWeights updates transport selection weights based on current latency.

--- a/pkg/router/route_mux_demote_retx_test.go
+++ b/pkg/router/route_mux_demote_retx_test.go
@@ -116,31 +116,45 @@ func (h demoteHook) OnTick(_ DialInfo, _ []LegInfo) RotationAction {
 // TestMuxDemoteFlushesInFlightSeqs is the wire-correctness proof for the Gate-5
 // no-dip hot-swap. A leg carrying unACKed, in-flight sequences is demoted to
 // warm standby. Those sequences must not be stranded: the demote path must
-// proactively re-send the whole outstanding in-flight window onto an ACTIVE,
-// non-standby leg immediately (a self-issued full SACK recovery), so the peer's
+// proactively re-send the demoted leg's outstanding sequences onto an ACTIVE,
+// non-standby leg immediately (a self-issued SACK recovery), so the peer's
 // no-skip reorder gap fills without waiting for a SACK round-trip that can lose
 // the race with the bounded retx buffer's aging (#86 / the live "17MB -> 0 at
 // first demote" stall).
 //
-// Without the fix the demote merely flips the standby flag and resends nothing,
-// so both capturing legs would record zero DataPackets and this test fails on
-// the "resent onto an active leg" assertion.
+// The flush is NARROWED to the demoted leg's sequences (plus unknown-leg
+// entries): sequences riding still-active legs heal through the normal SACK
+// path, and re-sending them too duplicated the entire in-flight window on
+// every demote (measured live: 33.8MB of duplicates against 14.7MB of payload
+// on one leg of a 20MB transfer). The activeSeqs sent on leg 0 below prove the
+// narrowing: they are held, but must NOT be flushed when leg 1 demotes.
 func TestMuxDemoteFlushesInFlightSeqs(t *testing.T) {
 	rg, conns := createCapturingMuxRouteGroup(t, 2)
 
-	// Send data so the sender holds unACKed sequences in its retx buffer with no
-	// SACK received yet (as if leg 1 were carrying them and they are in flight).
+	// Sequences in flight ON LEG 1 (the leg about to be demoted) — these are
+	// stranded by the demote and must be flushed.
 	const nPkts = 32
 	want := make([]uint32, 0, nPkts)
 	for i := 0; i < nPkts; i++ {
-		_, seq, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{byte(i), 0xAA, 0xBB})
+		_, seq, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{byte(i), 0xAA, 0xBB}, 1)
 		if err != nil {
 			t.Fatalf("wrapPayload: %v", err)
 		}
 		want = append(want, seq)
 	}
-	if got := rg.mux.retxBuf.Len(); got != nPkts {
-		t.Fatalf("retxBuf holds %d unACKed seqs, want %d", got, nPkts)
+	// Sequences in flight on LEG 0 (stays active) — NOT stranded; the narrowed
+	// flush must leave them to the normal SACK path.
+	const nActive = 8
+	activeSeqs := make(map[uint32]bool, nActive)
+	for i := 0; i < nActive; i++ {
+		_, seq, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{0xCC, byte(i)}, 0)
+		if err != nil {
+			t.Fatalf("wrapPayload(leg0): %v", err)
+		}
+		activeSeqs[seq] = true
+	}
+	if got := rg.mux.retxBuf.Len(); got != nPkts+nActive {
+		t.Fatalf("retxBuf holds %d unACKed seqs, want %d", got, nPkts+nActive)
 	}
 
 	// Demote leg 1 to warm standby via the real rotation apply path.
@@ -156,16 +170,20 @@ func TestMuxDemoteFlushesInFlightSeqs(t *testing.T) {
 		t.Errorf("demoted leg 1 carried %d resent DataPackets, want 0 (%v)", len(got), got)
 	}
 
-	// The active leg (0) must have received a resend of EVERY held sequence, in
-	// ascending order (lowest gap first).
+	// The active leg (0) must have received a resend of every DEMOTED-leg
+	// sequence, ascending (lowest gap first) — and none of the leg-0 sequences
+	// (they are not stranded; re-sending them is the measured duplicate storm).
 	got := conns[0].dataSeqs()
 	if len(got) != len(want) {
 		t.Fatalf("active leg 0 resent %d seqs, want %d (%v)", len(got), len(want), got)
 	}
 	for i := range want {
 		if got[i] != want[i] {
-			t.Fatalf("resend[%d] = seq %d, want %d (full window: got %v want %v)",
+			t.Fatalf("resend[%d] = seq %d, want %d (demoted-leg window: got %v want %v)",
 				i, got[i], want[i], got, want)
+		}
+		if activeSeqs[got[i]] {
+			t.Fatalf("resend included seq %d which rides the ACTIVE leg — flush not narrowed", got[i])
 		}
 	}
 }
@@ -177,7 +195,7 @@ func TestMuxDemoteFlushNoActiveLegIsSafe(t *testing.T) {
 	rg, conns := createCapturingMuxRouteGroup(t, 2)
 
 	for i := 0; i < 8; i++ {
-		if _, _, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{byte(i)}); err != nil {
+		if _, _, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{byte(i)}, 0); err != nil {
 			t.Fatalf("wrapPayload: %v", err)
 		}
 	}

--- a/pkg/router/route_mux_e2e_test.go
+++ b/pkg/router/route_mux_e2e_test.go
@@ -38,7 +38,7 @@ func TestMux_InOrderDelivery(t *testing.T) {
 	var got []byte
 	for i := 0; i < 200; i++ {
 		payload := []byte{byte(i)}
-		_, seq, err := send.wrapPayload(routing.RouteID(1), payload)
+		_, seq, err := send.wrapPayload(routing.RouteID(1), payload, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -69,7 +69,7 @@ func TestMux_InterleavedLegs(t *testing.T) {
 	var evens, odds []pkt
 	for i := 0; i < 200; i++ {
 		payload := []byte{byte(i)}
-		_, seq, err := send.wrapPayload(routing.RouteID(1), payload)
+		_, seq, err := send.wrapPayload(routing.RouteID(1), payload, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -122,7 +122,7 @@ func TestMux_RecoversLostPacketViaRetx(t *testing.T) {
 	var pkts []pkt
 	for i := 0; i < 20; i++ {
 		payload := []byte{byte(i)}
-		_, seq, err := send.wrapPayload(routing.RouteID(1), payload)
+		_, seq, err := send.wrapPayload(routing.RouteID(1), payload, 0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/router/route_mux_helpers_test.go
+++ b/pkg/router/route_mux_helpers_test.go
@@ -118,11 +118,11 @@ func TestMuxSACKPathEnabled(t *testing.T) {
 
 	routeID := routing.RouteID(7)
 	// wrapPayload stores the payload in the retx buffer for later SACK recovery.
-	pkt0, seq0, err := m.wrapPayload(routeID, []byte("hello"))
+	pkt0, seq0, err := m.wrapPayload(routeID, []byte("hello"), 0)
 	require.NoError(t, err)
 	require.NotNil(t, pkt0)
 	require.EqualValues(t, 0, seq0)
-	pkt1, seq1, err := m.wrapPayload(routeID, []byte("world"))
+	pkt1, seq1, err := m.wrapPayload(routeID, []byte("world"), 0)
 	require.NoError(t, err)
 	require.NotNil(t, pkt1)
 	require.EqualValues(t, 1, seq1)
@@ -150,7 +150,7 @@ func TestMuxSACKPathEnabled(t *testing.T) {
 func TestMuxSACKPathDisabled(t *testing.T) {
 	m := newBareMux(false)
 
-	_, _, err := m.wrapPayload(routing.RouteID(1), []byte("x"))
+	_, _, err := m.wrapPayload(routing.RouteID(1), []byte("x"), 0)
 	require.NoError(t, err)
 	// retxBuf still exists but Store is skipped when sackEnabled is false.
 	require.Empty(t, m.heldRetxSeqs())

--- a/pkg/router/sack.go
+++ b/pkg/router/sack.go
@@ -172,6 +172,13 @@ type retxEntry struct {
 	seq    uint32
 	data   []byte
 	sentAt time.Time
+	// leg is the mux leg index this sequence was LAST sent on (-1 = unknown).
+	// Recorded at Store time and re-tagged on every retransmit, so the
+	// demote-time flush can resend only the sequences actually stranded on the
+	// demoted leg(s) instead of the whole in-flight window (measured live:
+	// a whole-window flush duplicated 33.8MB against 14.7MB of payload on one
+	// leg of a 20MB transfer).
+	leg int
 	// lastTxAt is when this sequence was last handed out for retransmission
 	// (zero until the first retx). retxCount is how many times it has been.
 	// Together they gate re-retransmission: without them every SACK arriving
@@ -218,7 +225,7 @@ func newRetxBuffer(capacity int) *retxBuffer {
 // received sequence above the gap each SACK, so under normal operation the
 // buffer holds only genuine holes plus in-flight sequences and never reaches
 // capacity — this eviction path is a backstop, not the steady state.
-func (rb *retxBuffer) Store(seq uint32, data []byte) bool {
+func (rb *retxBuffer) Store(seq uint32, data []byte, leg int) bool {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 
@@ -241,8 +248,36 @@ func (rb *retxBuffer) Store(seq uint32, data []byte) bool {
 		seq:    seq,
 		data:   cp,
 		sentAt: time.Now(),
+		leg:    leg,
 	}
 	return true
+}
+
+// SetLeg re-tags seq's last-send leg (a retransmit moved it). No-op for a seq
+// no longer held.
+func (rb *retxBuffer) SetLeg(seq uint32, leg int) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	if e, ok := rb.entries[seq]; ok {
+		e.leg = leg
+	}
+}
+
+// HeldSeqsOnLegs returns the held sequences whose last send rode one of the
+// given legs, sorted ascending. Entries with an unknown leg (-1) are included
+// conservatively — better a redundant resend than a stranded gap. Used by the
+// demote-time flush to rescue only what the demoted leg(s) actually strand.
+func (rb *retxBuffer) HeldSeqsOnLegs(legs map[int]bool) []uint32 {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	seqs := make([]uint32, 0, len(rb.entries))
+	for seq, e := range rb.entries {
+		if e.leg < 0 || legs[e.leg] {
+			seqs = append(seqs, seq)
+		}
+	}
+	sort.Slice(seqs, func(i, j int) bool { return seqs[i] < seqs[j] })
+	return seqs
 }
 
 // ProcessSACK processes a received SACK (last contiguous seq + full-window

--- a/pkg/router/sack_test.go
+++ b/pkg/router/sack_test.go
@@ -98,7 +98,7 @@ func TestSACKTracker_FullWindowBitmap(t *testing.T) {
 func TestRetxBuffer_StoreAndPurge(t *testing.T) {
 	rb := newRetxBuffer(128)
 	for i := uint32(0); i < 10; i++ {
-		assert.True(t, rb.Store(i, []byte{byte(i)}))
+		assert.True(t, rb.Store(i, []byte{byte(i)}, 0))
 	}
 	assert.Equal(t, 10, rb.Len())
 
@@ -111,7 +111,7 @@ func TestRetxBuffer_StoreAndPurge(t *testing.T) {
 func TestRetxBuffer_RetransmitList(t *testing.T) {
 	rb := newRetxBuffer(128)
 	for i := uint32(0); i < 8; i++ {
-		rb.Store(i, []byte{byte(i)})
+		rb.Store(i, []byte{byte(i)}, 0)
 	}
 
 	// Age the stored entries past retxMinAge so ProcessSACK will list missing
@@ -136,7 +136,7 @@ func TestRetxBuffer_RetransmitList(t *testing.T) {
 // with seconds of queueing delay is retransmitted hundreds of times.
 func TestRetxBuffer_RetxBackoffSuppressesDuplicates(t *testing.T) {
 	rb := newRetxBuffer(128)
-	rb.Store(3, []byte{3})
+	rb.Store(3, []byte{3}, 0)
 	rb.entries[3].sentAt = time.Now().Add(-2 * retxMinAge)
 
 	// SACK: lastContiguous=2, seq 3 missing, seq 4 received.
@@ -181,10 +181,10 @@ func TestRetxBuffer_RetxBackoffSuppressesDuplicates(t *testing.T) {
 // the newest, instead of silently refusing to store the newest packet.
 func TestRetxBuffer_CapacityEvictsLowest(t *testing.T) {
 	rb := newRetxBuffer(3)
-	assert.True(t, rb.Store(0, []byte("a")))
-	assert.True(t, rb.Store(1, []byte("b")))
-	assert.True(t, rb.Store(2, []byte("c")))
-	assert.True(t, rb.Store(3, []byte("d"))) // full -> evict lowest (0), store 3
+	assert.True(t, rb.Store(0, []byte("a"), 0))
+	assert.True(t, rb.Store(1, []byte("b"), 0))
+	assert.True(t, rb.Store(2, []byte("c"), 0))
+	assert.True(t, rb.Store(3, []byte("d"), 0)) // full -> evict lowest (0), store 3
 	assert.Equal(t, 3, rb.Len())
 	assert.Nil(t, rb.Get(0), "lowest seq evicted")
 	assert.Equal(t, []byte("d"), rb.Get(3), "newest seq retained")
@@ -192,7 +192,7 @@ func TestRetxBuffer_CapacityEvictsLowest(t *testing.T) {
 
 func TestRetxBuffer_Get(t *testing.T) {
 	rb := newRetxBuffer(128)
-	rb.Store(42, []byte("hello"))
+	rb.Store(42, []byte("hello"), 0)
 	assert.Equal(t, []byte("hello"), rb.Get(42))
 	assert.Nil(t, rb.Get(99))
 }
@@ -207,7 +207,7 @@ func TestRetxBuffer_NoFillBehindPersistentGap(t *testing.T) {
 	const sent = 3000
 	rb := newRetxBuffer(4096) // large so this isolates purge behavior, not eviction
 	for seq := uint32(1); seq <= sent; seq++ {
-		rb.Store(seq, []byte{byte(seq)})
+		rb.Store(seq, []byte{byte(seq)}, 0)
 	}
 
 	// Receiver got 2..3000 but not seq 1 -> lastContiguous stuck at 0.


### PR DESCRIPTION
The demote-time forced retransmit flush re-sent the entire in-flight window on every demote — including sequences riding still-active legs, which heal through the normal SACK path anyway. With a large in-flight window and latency-band demote churn during transfers this duplicated most of a download: measured live with the new per-leg dup telemetry (#4439) as 33.8MB of duplicate bytes against 14.7MB of payload on one leg of a 20MB transfer, with the HoL age gate (#4438) already active on both ends.

Each retx-buffer entry now records the leg it was last sent on (re-tagged when a retransmit moves it to a different leg), and the demote flush resends only the demoted legs' sequences plus unknown-attribution entries. The wedge-prevention purpose (#86 aged-out-gap) is untouched — only the stranded sequences ever needed the rescue. The demote-flush wire test now proves the narrowing: active-leg sequences held in the buffer must not be re-sent.