### PR TITLE
fix(cli): proxy mux info no longer drops per-leg hop chains from its output

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_info.go
+++ b/cmd/skywire-cli/commands/proxy/mux_info.go
@@ -157,6 +157,26 @@ type muxLegInfo struct {
 	GoodputDownBps float64 `json:"goodput_down_bps,omitempty"`
 	Alive          bool    `json:"alive"`
 	Standby        bool    `json:"standby"`
+	// Hops is the leg's full forward route (every hop to the destination,
+	// full PKs, per-hop transport type + latency) — the visor has sent it
+	// since the per-leg route telemetry landed, but this mirror struct
+	// lacked the field, so BOTH output paths (which round-trip the RPC
+	// response through this struct — see render) silently dropped it:
+	// `--json`/`--jq` showed every leg with an empty hop list while
+	// `proxy tree` (whose own treeLegInfo mirror carries the field)
+	// rendered the full chains from the very same RPC.
+	Hops []muxHopInfo `json:"hops,omitempty"`
+}
+
+// muxHopInfo is one hop of a leg's forward route — the CLI-side mirror of
+// visor.MuxHopInfo (json tags are the stable contract). From/To are FULL
+// public keys, never truncated.
+type muxHopInfo struct {
+	TpID      string  `json:"tp_id"`
+	From      string  `json:"from"`
+	To        string  `json:"to"`
+	TpType    string  `json:"tp_type"`
+	LatencyMS float64 `json:"latency_ms,omitempty"`
 }
 
 // muxRateTracker remembers the previous poll's per-leg byte counters so

--- a/pkg/router/router_mux_ops_test.go
+++ b/pkg/router/router_mux_ops_test.go
@@ -1,0 +1,100 @@
+// Package router pkg/router/router_mux_ops_test.go
+//
+// Regression coverage for the per-leg hop-chain telemetry on RUNTIME-added mux
+// legs. Every runtime add path — GrowMuxRoute / `cli proxy mux add` (both via
+// AddMuxRouteByHops), the async dial-time aux legs (establishMuxRoutes), and
+// the rotation / self-heal re-dials (addOneAuxLeg) — must record the forward
+// route it dialed with (recordLegHops) so MuxStats reports the leg's WHOLE
+// chain, not just its first-hop transport remote (which for a multihop leg is
+// the first INTERMEDIATE, mislabeled as the exit). This test drives the one
+// path that exercises the full runtime machinery end to end without a network:
+// AddMuxRouteByHops with a stubbed setup-node dialer.
+package router
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// stubLegDialer is a RouteGroupDialer that skips the setup-node round-trip and
+// hands back pre-built edge rules, so the test runs the REAL runtime add-leg
+// sequence (validation → dial → appendRouteToGroup → recordLegHops) in-process.
+type stubLegDialer struct{ rules routing.EdgeRules }
+
+func (d stubLegDialer) Dial(_ context.Context, _ *logging.Logger, _ *dmsg.Client, _ []cipher.PubKey, _ routing.BidirectionalRoute) (routing.EdgeRules, cipher.PubKey, error) {
+	return d.rules, cipher.PubKey{}, nil
+}
+
+// TestAddMuxRouteByHopsRecordsLegHopsInMuxStats proves that a mux leg added at
+// RUNTIME (not the initial dial) surfaces its full forward hop chain through
+// MuxStats — the source `cli proxy mux info` (.legs[].hops), `cli proxy tree`
+// and the status.skysocks route tree all read from. The keying contract under
+// test: recordLegHops stores the dialed route under its first hop's TpID, and
+// MuxStats resolves it via legHopsFor(tp.Entry.ID) — so the planned route's
+// first hop must ride the same transport the committed rules point at.
+func TestAddMuxRouteByHopsRecordsLegHopsInMuxStats(t *testing.T) {
+	r := newLegTestRouter(t)
+
+	// A live, mux-enabled route group registered in rgsNs — the state every
+	// runtime add-leg caller requires before it will append.
+	rg, desc := r.setupInitializingPrimary(t)
+	nrg := &NoiseRouteGroup{rg: rg}
+	r.mx.Lock()
+	delete(r.rgsRaw, desc)
+	r.rgsNs[desc] = nrg
+	r.mx.Unlock()
+
+	// The aux leg's rules + first-hop transport (makeAuxRules injects the
+	// transport into the manager) — exactly what a successful setup-node
+	// dial returns to AddMuxRouteByHops.
+	auxRules := r.makeAuxRules(t, desc, 1)
+	auxTpID := auxRules.Forward.NextTransportID()
+	r.conf.RouteGroupDialer = stubLegDialer{rules: auxRules}
+
+	// The planned 2-hop forward route: this visor → mid → peer. In the
+	// group's descriptor orientation this visor is DstPK (the entry point)
+	// and the far peer is SrcPK — the same orientation AddMuxRouteByHops
+	// validates against.
+	local := desc.DstPK()
+	peer := desc.SrcPK()
+	mid, _ := cipher.GenerateKeyPair()
+	fwd := []routing.Hop{
+		{TpID: auxTpID, From: local, To: mid},
+		{TpID: uuid.New(), From: mid, To: peer},
+	}
+	rev := []routing.Hop{
+		{TpID: uuid.New(), From: peer, To: mid},
+		{TpID: auxTpID, From: mid, To: local},
+	}
+
+	require.NoError(t, r.AddMuxRouteByHops(desc, fwd, rev))
+
+	// The aux-added leg must report EVERY hop, ending at the true
+	// destination. Before hop recording was wired into the runtime add
+	// paths, such a leg showed an empty hop list and only its first-hop
+	// remote — the telemetry gap this file guards against regressing.
+	info := rg.MuxStats()
+	require.True(t, info.MuxEnabled)
+	require.Len(t, info.Legs, 2, "primary + the runtime-added aux leg")
+
+	var aux *MuxLeg
+	for i := range info.Legs {
+		if info.Legs[i].TransportID == auxTpID.String() {
+			aux = &info.Legs[i]
+		}
+	}
+	require.NotNil(t, aux, "the added leg must appear in MuxStats on its first-hop transport")
+	require.Len(t, aux.Hops, 2, "an aux-added leg reports its whole chain, not just the first-hop remote")
+	require.Equal(t, auxTpID.String(), aux.Hops[0].TpID, "hop 0 rides the leg's own transport — the legHopsFor key")
+	require.Equal(t, local.String(), aux.Hops[0].From, "the chain starts at this visor")
+	require.Equal(t, mid.String(), aux.Hops[0].To, "the first hop lands on the intermediate")
+	require.Equal(t, peer.String(), aux.Hops[1].To, "the last hop ends at the destination, not the intermediate")
+}


### PR DESCRIPTION
`cli proxy mux info` rendered every leg with an empty `.legs[].hops` — even for multihop legs — while `cli proxy tree` showed the full chains from the very same RPC. The visor sends each leg's forward route (`MuxLegInfo.Hops`), but the CLI's mirror struct `muxLegInfo` lacked the field, and both the `--json` and text render paths round-trip the response through that mirror, silently dropping it. This adds the `hops` field plus a `muxHopInfo` mirror of `visor.MuxHopInfo`.

While auditing this, every router-side leg-add path was checked for the hop-recording seam (`SetForwardHops`/`recordLegHops`): the initial dial, the async `establishMuxRoutes` aux legs, rotation/self-heal re-dials (`addOneAuxLeg`), and `AddMuxRouteByHops`/`GrowMuxRoute` all record since #4140; only accept-side legs (which have no route to record) stay empty, unchanged. A new regression test drives `AddMuxRouteByHops` end to end with a stubbed setup dialer and asserts a runtime-added leg reports its whole chain through `MuxStats`.