### PR TITLE
feat(router): manual direction pin for the unidirectional mux (wire-coordinated)

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_info.go
+++ b/cmd/skywire-cli/commands/proxy/mux_info.go
@@ -115,8 +115,12 @@ type muxRouteGroupInfo struct {
 	// direction rides a disjoint leg CLASS, and Flipped tells which class carries
 	// which direction. Absent before now, so "is this group directional" was
 	// invisible from the CLI.
-	Directional     bool         `json:"directional,omitempty"`
-	Flipped         bool         `json:"flipped,omitempty"`
+	Directional bool `json:"directional,omitempty"`
+	Flipped     bool `json:"flipped,omitempty"`
+	// FlipPinned is the operator's manual direction pin: "auto" (flip controller
+	// in charge), "default" or "flipped" (mapping held by 'proxy mux direction',
+	// controller dormant). Empty on a non-directional mux.
+	FlipPinned      string       `json:"flip_pinned,omitempty"`
 	Distribution    string       `json:"distribution,omitempty"`
 	ReorderPending  int          `json:"reorder_pending,omitempty"`
 	ReorderGapAgeMS float64      `json:"reorder_gap_age_ms,omitempty"`
@@ -256,6 +260,12 @@ func (t *muxRateTracker) render(cmd *cobra.Command, infos any) {
 			}
 			fmt.Printf("       dist=%s  reorder_pending=%d  gap_age=%s  write_seq=%d\n",
 				rg.Distribution, rg.ReorderPending, gap, rg.WriteSeq)
+			// Directional groups: which class carries which direction, and whether
+			// an operator pin ('proxy mux direction') holds the mapping.
+			if rg.Directional {
+				fmt.Printf("       directional=true  flipped=%v  flip_pinned=%s\n",
+					rg.Flipped, rg.FlipPinned)
+			}
 		}
 
 		// Sort legs by index so the row order is stable across snapshots.

--- a/cmd/skywire-cli/commands/proxy/mux_ops.go
+++ b/cmd/skywire-cli/commands/proxy/mux_ops.go
@@ -72,7 +72,9 @@ func init() {
 	muxSwitchCmd.Flags().StringVar(&muxSwitchRouteSrc, "route", "-", "new route JSON file ('-' = stdin); shape is 'cli route calc --json' output")
 	muxSwitchCmd.Flags().DurationVar(&muxSwitchTimeout, "ready-timeout", 20*time.Second, "how long to wait for the new leg to carry before retiring the old primary")
 	RootCmd.AddCommand(muxSwitchCmd)
+	muxDirectionCmd.Flags().StringVarP(&muxOpsApp, "name", "n", "skysocks-client", "app whose route groups to pin")
 	addMuxSub(muxModeCmd, "mux-mode")
+	addMuxSub(muxDirectionCmd, "mux-direction")
 	addMuxSub(muxCapCmd, "mux-cap")
 	addMuxSub(muxWidthCmd, "mux-width")
 	addMuxSub(muxStandbyCmd, "mux-standby")
@@ -501,6 +503,63 @@ Example:
 		}
 		internal.Catch(cmd.Flags(), cliout.Print(cmd, cliproxy.MuxOp{
 			Op: "mode", App: muxOpsApp, Mode: mode,
+		}))
+	},
+}
+
+var muxDirectionCmd = &cobra.Command{
+	Use:   "direction <auto|default|flipped>",
+	Short: "Pin which leg class carries each data direction on an active session",
+	Long: `Manually control the unidirectional mux's direction→leg-class mapping —
+which class of leg (the DIRECT 1-hop transport vs the MULTIHOP mux legs)
+carries each data direction on the app's active route groups.
+
+Only meaningful on a DIRECTIONAL group (CapUniDir negotiated by both ends —
+'mux info' shows directional=true); errors otherwise.
+
+  auto     - release the pin: the automatic flip controller resumes on both
+             ends, moving the heavy direction onto the mux when the traffic
+             asymmetry inverts and holds.
+  default  - pin the default mapping: this end (the initiator) sends its
+             upload on the DIRECT leg; the download aggregates over the
+             MULTIHOP mux legs. The download-heavy shape.
+  flipped  - pin the swapped mapping: the upload aggregates over the multihop
+             mux and the download rides the direct leg. The upload-heavy shape.
+
+The pin is COORDINATED over the wire: the peer applies the same pin, so both
+ends keep sending on disjoint leg classes and neither end's flip controller
+fights the mapping. Against an old peer (predating the direction packet) the
+pin is best-effort local-only — the packet is silently ignored there, and the
+peer's controller may still flip its own side.
+
+Applies to ALL of the app's active route groups (a proxy session can hold one
+rg per SOCKS5 connection). 'mux info' shows the live state: flipped= is the
+current mapping, flip_pinned= whether an operator pin holds it.
+
+Example:
+  skywire cli proxy mux direction flipped   # force the upload onto the mux
+  skywire cli proxy mux info --watch 1s     # watch which legs carry each way
+  skywire cli proxy mux direction auto      # hand control back`,
+	Args:                  cobra.ExactArgs(1),
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		mode := args[0]
+		switch mode {
+		case "auto", "default", "flipped":
+		default:
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("direction must be 'auto', 'default' or 'flipped', got %q", mode))
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
+		}
+		defer rpcClient.Close() //nolint:errcheck,gosec
+
+		if err := rpcClient.SetMuxDirection(muxOpsApp, mode); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("SetMuxDirection: %w", err))
+		}
+		internal.Catch(cmd.Flags(), cliout.Print(cmd, cliproxy.MuxOp{
+			Op: "direction", App: muxOpsApp, Mode: mode,
 		}))
 	},
 }

--- a/pkg/cliout/cliproxy/cliproxy.go
+++ b/pkg/cliout/cliproxy/cliproxy.go
@@ -19,7 +19,8 @@ import (
 // The fields that do not apply are omitted rather than zeroed, so their absence
 // is meaningful.
 type MuxOp struct {
-	// Op is "add", "remove", "cap", "width", "standby", "switch" or "mode".
+	// Op is "add", "remove", "cap", "width", "standby", "switch", "mode" or
+	// "direction".
 	Op  string `json:"op"`
 	App string `json:"app"`
 
@@ -58,6 +59,13 @@ func (m MuxOp) Human(w io.Writer) error {
 		return err
 	case "mode":
 		_, err := fmt.Fprintf(w, "mux mode set to %s\n", m.Mode)
+		return err
+	case "direction":
+		if m.Mode == "auto" {
+			_, err := fmt.Fprintf(w, "mux direction pin released on app=%s (flip controller resumes)\n", m.App)
+			return err
+		}
+		_, err := fmt.Fprintf(w, "mux direction pinned to %s on app=%s\n", m.Mode, m.App)
 		return err
 	default:
 		_, err := fmt.Fprintf(w, "mux op %q applied\n", m.Op)

--- a/pkg/router/mock_router.go
+++ b/pkg/router/mock_router.go
@@ -524,6 +524,18 @@ func (_m *MockRouter) RouteGroupMuxInfo(_a0 routing.RouteDescriptor) (MuxInfo, b
 	return r0, r1
 }
 
+// SetMuxDirectionForApp provides a mock function
+func (_m *MockRouter) SetMuxDirectionForApp(_a0 string, _a1 byte) (int, error) {
+	ret := _m.Called(_a0, _a1)
+	var r0 int
+	if rf, ok := ret.Get(0).(func(string, byte) int); ok {
+		r0 = rf(_a0, _a1)
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).(int)
+	}
+	return r0, ret.Error(1)
+}
+
 // RouteGroupMuxInfoForApp provides a mock function
 func (_m *MockRouter) RouteGroupMuxInfoForApp(_a0 string) []MuxInfo {
 	ret := _m.Called(_a0)

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -473,6 +473,11 @@ type MuxInfo struct {
 	// direction without log-grepping. Both false on a non-directional mux.
 	Directional bool
 	Flipped     bool
+	// FlipPinned is the operator's MANUAL direction pin on a directional group:
+	// "auto" (the flip controller is in charge — the default), "default" or
+	// "flipped" (the mapping is pinned to that state and the controller is
+	// dormant until released via mode auto). Empty on a non-directional mux.
+	FlipPinned string
 	// Distribution names how the mux spreads outbound packets across its legs
 	// (the transportSelector weight mode: "auto", "round-robin", "weighted",
 	// "capacity", "latency-adaptive", "sticky:5tuple", "size-threshold",
@@ -556,6 +561,9 @@ func (rg *RouteGroup) MuxStats() MuxInfo {
 		info.FECRepairBytesRecv = atomic.LoadUint64(&rg.mux.fecRepairBytesRecv)
 		info.FECReconstructs = atomic.LoadUint64(&rg.mux.fecReconstructs)
 		info.Directional, info.Flipped = rg.mux.dirState()
+		if info.Directional {
+			info.FlipPinned = flipPinString(rg.mux.flipPinMode())
+		}
 	}
 	info.PerFrameNoise = rg.perFrameNoiseActive
 	tpsCopy := append([]*transport.ManagedTransport(nil), rg.tps...)
@@ -3518,6 +3526,8 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 		return rg.handleRepairPacket(packet)
 	case routing.LegStatePacket:
 		return rg.handleLegStatePacket(packet)
+	case routing.DirectionPacket:
+		return rg.handleDirectionPacket(packet)
 	case routing.HandshakePacket:
 		// A handshake on an aux leg proves the peer registered that leg's
 		// rule, so it is safe to start sending on it. The primary leg's
@@ -3944,6 +3954,69 @@ func (rg *RouteGroup) sendLegState(idx int, standby bool) {
 	if err := rg.writePacket(context.Background(), tp, packet, rule.KeyRouteID()); err != nil {
 		rg.logger.WithError(err).Debugf("LegState: failed to signal leg %d", idx)
 	}
+}
+
+// SetDirectionPin applies the operator's MANUAL direction pin to this route
+// group and signals it to the peer. mode is routing.DirectionAuto (release —
+// the flip controller resumes on both ends), DirectionPinDefault (initiator
+// sends on the direct leg / download on the multihop mux) or
+// DirectionPinFlipped (the swapped mapping). Errors unless the group is
+// directional (CapUniDir negotiated) — a pin on a symmetric mux would never be
+// read.
+//
+// The pin is coordinated over the wire (DirectionPacket) because a one-sided
+// pin would DESYNC the ends: both could end up sending on the same leg class.
+// It is sent on the PRIMARY leg (leg 0's rule/transport): the pin addresses the
+// GROUP, not one leg, and leg 0 is the one leg that is never standby — the
+// signal always rides an installed, carrying path. Best-effort: an old peer
+// (no DirectionPacket) ignores the frame, leaving the pin local-only — its
+// controller may then fight the pinned mapping, which is why the caller-facing
+// docs call a pin against an old peer best-effort.
+func (rg *RouteGroup) SetDirectionPin(mode byte) error {
+	if mode > routing.DirectionPinFlipped {
+		return fmt.Errorf("invalid direction pin mode %d", mode)
+	}
+	if rg.mux == nil || !rg.mux.isDirectional() {
+		return errors.New("route group is not directional (CapUniDir not negotiated)")
+	}
+	rg.mux.setFlipPin(mode)
+	rg.logger.Infof("direction-pin: local pin set to %q", flipPinString(mode))
+
+	rg.mu.Lock()
+	var tp *transport.ManagedTransport
+	var rule routing.Rule
+	if len(rg.tps) > 0 && len(rg.fwd) > 0 {
+		tp = rg.tps[0]
+		rule = rg.fwd[0]
+	}
+	rg.mu.Unlock()
+	if tp == nil || rule == nil {
+		return nil // pin applied locally; no leg to signal on
+	}
+	packet := routing.MakeDirectionPacket(rule.NextRouteID(), mode)
+	if err := rg.writePacket(context.Background(), tp, packet, rule.KeyRouteID()); err != nil {
+		rg.logger.WithError(err).Warn("direction-pin: failed to signal peer (pin applied locally only)")
+	}
+	return nil
+}
+
+// handleDirectionPacket applies a peer's manual direction pin to this side's
+// mux, so the two ends keep sending on disjoint leg classes: the pinned
+// mapping is mirrored here AND this side's flip controller goes dormant (it
+// would otherwise fight the pin on its next tick). Mode auto releases both
+// ends' controllers. Ignored unless the group is directional — a symmetric mux
+// has no direction mapping to pin.
+func (rg *RouteGroup) handleDirectionPacket(packet routing.Packet) error {
+	if rg.mux == nil || !rg.mux.isDirectional() {
+		return nil
+	}
+	mode := packet.DirectionMode()
+	if mode > routing.DirectionPinFlipped {
+		return nil // unknown mode from a newer peer — ignore, keep current state
+	}
+	rg.mux.setFlipPin(mode)
+	rg.logger.Infof("direction-pin: peer pinned direction mapping to %q", flipPinString(mode))
+	return nil
 }
 
 func (rg *RouteGroup) handleErrorPacket(packet routing.Packet) error {

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -212,6 +212,11 @@ type routeMux struct {
 	initiator   bool
 	dstPK       cipher.PubKey
 	srcPK       cipher.PubKey
+	// flipPin is the operator's MANUAL direction pin (see unidir.go setFlipPin):
+	// routing.DirectionAuto (0) leaves the flip controller in charge;
+	// DirectionPinDefault/DirectionPinFlipped force the mapping and put the
+	// controller to sleep until released. Guarded by legMu like flipped.
+	flipPin byte
 	// Flip-controller hysteresis state (see unidir.go unidirFlipTick). Touched
 	// ONLY by the single unidir-flip loop goroutine, so no lock of their own.
 	flipUpHits   int

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -573,6 +573,13 @@ type Router interface {
 	GrowMuxRoute(desc routing.RouteDescriptor, target, minHops int) (int, error)
 	RemoveMuxRouteByTransport(desc routing.RouteDescriptor, tpID uuid.UUID) error
 
+	// SetMuxDirectionForApp applies a manual unidirectional direction pin
+	// (routing.DirectionAuto / DirectionPinDefault / DirectionPinFlipped) to
+	// EVERY active directional route group tagged with the named app (a proxy
+	// session can hold several concurrent rg's). Returns how many groups the
+	// pin was applied to; errors when the app has no active directional group.
+	SetMuxDirectionForApp(appName string, mode byte) (int, error)
+
 	// RouteGroupHops returns the stored forward route hops for the route group
 	// matching the given descriptor (or its inversion). Returns nil if no
 	// matching route group is found.

--- a/pkg/router/router_rules.go
+++ b/pkg/router/router_rules.go
@@ -159,6 +159,42 @@ func (r *router) RouteGroupMuxInfoAll() []MuxInfo {
 	return out
 }
 
+// SetMuxDirectionForApp implements Router. Applies the operator's manual
+// direction pin to every active rg tagged with appName (same tag walk as
+// RouteGroupMuxInfoForApp). Each pinned rg coordinates the pin with its peer
+// over the wire (RouteGroup.SetDirectionPin); non-directional rg's are counted
+// as errors so a proxy session without CapUniDir reports why nothing happened.
+func (r *router) SetMuxDirectionForApp(appName string, mode byte) (int, error) {
+	if appName == "" {
+		return 0, fmt.Errorf("app name required")
+	}
+	r.mx.Lock()
+	rgs := make([]*NoiseRouteGroup, 0, len(r.rgsNs))
+	for _, nrg := range r.rgsNs {
+		if nrg != nil && nrg.rg != nil && nrg.rg.AppName() == appName {
+			rgs = append(rgs, nrg)
+		}
+	}
+	r.mx.Unlock()
+	if len(rgs) == 0 {
+		return 0, fmt.Errorf("no active route group for app %q", appName)
+	}
+
+	applied := 0
+	var lastErr error
+	for _, nrg := range rgs {
+		if err := nrg.rg.SetDirectionPin(mode); err != nil {
+			lastErr = err
+			continue
+		}
+		applied++
+	}
+	if applied == 0 {
+		return 0, fmt.Errorf("direction pin applied to none of app %q's %d route group(s): %w", appName, len(rgs), lastErr)
+	}
+	return applied, nil
+}
+
 func (r *router) initializingRouteGroup(desc routing.RouteDescriptor) (*RouteGroup, bool) {
 	r.mx.Lock()
 	defer r.mx.Unlock()

--- a/pkg/router/unidir.go
+++ b/pkg/router/unidir.go
@@ -83,6 +83,45 @@ func (m *routeMux) dirState() (directional, flipped bool) {
 	return m.directional, m.flipped
 }
 
+// setFlipPin applies (or releases) the operator's MANUAL direction pin. mode is
+// routing.DirectionAuto/DirectionPinDefault/DirectionPinFlipped. Pinning also
+// enforces the pinned mapping immediately (no wait for the next controller
+// tick); releasing leaves the mapping where the pin put it — the controller
+// resumes from there and re-flips only when the traffic asymmetry says so.
+// No-op unless directional (a pin on a symmetric mux would never be read).
+func (m *routeMux) setFlipPin(mode byte) {
+	m.legMu.Lock()
+	if !m.directional {
+		m.legMu.Unlock()
+		return
+	}
+	m.flipPin = mode
+	m.legMu.Unlock()
+	if mode != routing.DirectionAuto {
+		m.setFlipped(mode == routing.DirectionPinFlipped)
+	}
+}
+
+// flipPinMode snapshots the manual direction pin under legMu.
+func (m *routeMux) flipPinMode() byte {
+	m.legMu.RLock()
+	defer m.legMu.RUnlock()
+	return m.flipPin
+}
+
+// flipPinString renders a pin mode for telemetry: "auto" (controller in
+// charge), "default" or "flipped" (operator-pinned mapping).
+func flipPinString(mode byte) string {
+	switch mode {
+	case routing.DirectionPinDefault:
+		return "default"
+	case routing.DirectionPinFlipped:
+		return "flipped"
+	default:
+		return "auto"
+	}
+}
+
 // soleBlackHoleExemptRecvFloor is the per-tick GROUP recv above which a
 // directional group's sole ACTIVE (light-direction) leg is exempt from the
 // sole-leg black-hole reaping.
@@ -143,9 +182,15 @@ func (m *routeMux) unidirFlipTick() (flipped, changed bool) {
 	m.legMu.RLock()
 	directional := m.directional
 	initiator := m.initiator
+	pinned := m.flipPin != routing.DirectionAuto
 	m.legMu.RUnlock()
 	if !directional {
 		return m.flipped, false
+	}
+	// Operator pin: skip the goodput sampling entirely — flipStep enforces the
+	// pinned mapping and keeps the hysteresis counters zeroed while dormant.
+	if pinned {
+		return m.flipStep(0, 0)
 	}
 
 	stats := m.snapshotLegs() // samples per-leg goodput EWMAs
@@ -177,9 +222,20 @@ func (m *routeMux) flipStep(up, down float64) (flipped, changed bool) {
 	m.legMu.RLock()
 	directional := m.directional
 	cur := m.flipped
+	pin := m.flipPin
 	m.legMu.RUnlock()
 	if !directional {
 		return cur, false
+	}
+	// MANUAL pin: the controller is dormant. Enforce the pinned mapping every
+	// tick (idempotent — setFlipped only reports a change when the state moves,
+	// e.g. right after the pin landed or if something else touched flipped) and
+	// zero the hysteresis/cooldown counters so releasing the pin hands the
+	// controller a clean slate instead of a half-accumulated flip decision.
+	if pin != routing.DirectionAuto {
+		m.flipUpHits, m.flipDownHits, m.flipCooldown = 0, 0, 0
+		want := pin == routing.DirectionPinFlipped
+		return want, m.setFlipped(want)
 	}
 	if m.flipCooldown > 0 {
 		m.flipCooldown--

--- a/pkg/router/unidir_pin_test.go
+++ b/pkg/router/unidir_pin_test.go
@@ -1,0 +1,182 @@
+// Package router pkg/router/unidir_pin_test.go c2-net-routing
+//
+// Tests for the MANUAL direction pin on the unidirectional mux: the operator
+// pins which leg class (direct vs multihop) carries each data direction, the
+// flip controller goes dormant while pinned, and the pin is coordinated with
+// the peer via routing.DirectionPacket.
+package router
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// TestDirectionPinHoldsAgainstFlipPressure proves a pin forces the mapping and
+// holds it against sustained flipStep pressure that would otherwise flip (or
+// revert) the controller — the controller is dormant while pinned.
+func TestDirectionPinHoldsAgainstFlipPressure(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("pin-test")
+	dst := pkFromHex(t, "02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36")
+	src := pkFromHex(t, "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c")
+
+	// Pin FLIPPED, then push a hard download-heavy signal that would revert an
+	// auto controller: the pin must hold.
+	m := newRouteMux(log, true)
+	m.setDirectional(true, dst, src)
+	m.setFlipPin(routing.DirectionPinFlipped)
+	if _, flipped := m.dirState(); !flipped {
+		t.Fatal("pin-flipped should force flipped=true immediately")
+	}
+	if got := m.flipPinMode(); got != routing.DirectionPinFlipped {
+		t.Fatalf("flipPinMode = %d, want %d", got, routing.DirectionPinFlipped)
+	}
+	for i := 0; i < flipHysteresis*4; i++ {
+		if _, changed := m.flipStep(100_000, 5_000_000); changed { // download-heavy
+			t.Fatalf("controller moved the mapping under a pin at tick %d", i+1)
+		}
+	}
+	if _, flipped := m.dirState(); !flipped {
+		t.Fatal("pinned mapping did not hold against download-heavy pressure")
+	}
+
+	// Pin DEFAULT on a mux the controller would flip (upload-heavy): stays put.
+	m2 := newRouteMux(log, true)
+	m2.setDirectional(true, dst, src)
+	m2.setFlipPin(routing.DirectionPinDefault)
+	for i := 0; i < flipHysteresis*4; i++ {
+		if _, changed := m2.flipStep(5_000_000, 100_000); changed { // upload-heavy
+			t.Fatalf("controller flipped a pin-default mux at tick %d", i+1)
+		}
+	}
+	if _, flipped := m2.dirState(); flipped {
+		t.Fatal("pin-default mapping did not hold against upload-heavy pressure")
+	}
+
+	// unidirFlipTick takes the same dormant path (it skips sampling entirely).
+	if _, changed := m.unidirFlipTick(); changed {
+		t.Fatal("unidirFlipTick changed the mapping under a pin")
+	}
+}
+
+// TestDirectionPinReleaseResumesController proves mode auto hands control back:
+// the mapping stays where the pin put it, and the controller — with clean
+// hysteresis counters — re-flips only after its usual consecutive-tick vote.
+func TestDirectionPinReleaseResumesController(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("pin-test")
+	dst := pkFromHex(t, "02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36")
+	src := pkFromHex(t, "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c")
+
+	m := newRouteMux(log, true)
+	m.setDirectional(true, dst, src)
+	m.setFlipPin(routing.DirectionPinFlipped)
+	// A few dormant ticks under revert pressure keep the counters zeroed.
+	for i := 0; i < flipHysteresis*2; i++ {
+		m.flipStep(100_000, 5_000_000)
+	}
+
+	m.setFlipPin(routing.DirectionAuto)
+	if got := m.flipPinMode(); got != routing.DirectionAuto {
+		t.Fatalf("flipPinMode after release = %d, want auto", got)
+	}
+	if _, flipped := m.dirState(); !flipped {
+		t.Fatal("release must leave the mapping where the pin put it")
+	}
+
+	// The controller resumes from a clean slate: the download-heavy signal must
+	// still take the full hysteresis vote before reverting.
+	for i := 0; i < flipHysteresis-1; i++ {
+		if _, changed := m.flipStep(100_000, 5_000_000); changed {
+			t.Fatalf("reverted after only %d post-release ticks, want %d", i+1, flipHysteresis)
+		}
+	}
+	flipped, changed := m.flipStep(100_000, 5_000_000)
+	if !changed || flipped {
+		t.Fatalf("controller did not revert after release + %d ticks: flipped=%v changed=%v",
+			flipHysteresis, flipped, changed)
+	}
+}
+
+// TestHandleDirectionPacketAppliesAndReleases proves the RECEIVER mirrors a
+// peer's pin (so its controller doesn't fight the sender's) and that mode auto
+// releases it. A non-directional group ignores the packet.
+func TestHandleDirectionPacketAppliesAndReleases(t *testing.T) {
+	rg, _ := createCapturingMuxRouteGroup(t, 2)
+	rg.mux.setDirectional(true, rg.desc.DstPK(), rg.desc.SrcPK())
+
+	if err := rg.handleDirectionPacket(routing.MakeDirectionPacket(2, routing.DirectionPinFlipped)); err != nil {
+		t.Fatalf("handleDirectionPacket(pin-flipped): %v", err)
+	}
+	if got := rg.mux.flipPinMode(); got != routing.DirectionPinFlipped {
+		t.Fatalf("receiver pin = %d, want %d", got, routing.DirectionPinFlipped)
+	}
+	if _, flipped := rg.mux.dirState(); !flipped {
+		t.Fatal("receiver did not apply the pinned flipped mapping")
+	}
+
+	if err := rg.handleDirectionPacket(routing.MakeDirectionPacket(2, routing.DirectionAuto)); err != nil {
+		t.Fatalf("handleDirectionPacket(auto): %v", err)
+	}
+	if got := rg.mux.flipPinMode(); got != routing.DirectionAuto {
+		t.Fatalf("receiver pin after auto = %d, want auto", got)
+	}
+
+	// Non-directional group: the packet is ignored (no CapUniDir mapping to pin).
+	rgSym, _ := createCapturingMuxRouteGroup(t, 2)
+	if err := rgSym.handleDirectionPacket(routing.MakeDirectionPacket(2, routing.DirectionPinFlipped)); err != nil {
+		t.Fatalf("handleDirectionPacket on symmetric rg: %v", err)
+	}
+	if got := rgSym.mux.flipPinMode(); got != routing.DirectionAuto {
+		t.Fatal("symmetric rg must not record a direction pin")
+	}
+}
+
+// TestSetDirectionPinWireAndGating proves SetDirectionPin errors on a
+// non-directional group (and on a garbage mode), applies the pin locally on a
+// directional one, and signals the peer with a DirectionPacket on the PRIMARY
+// leg (leg 0 — the one leg that is never standby).
+func TestSetDirectionPinWireAndGating(t *testing.T) {
+	// Non-directional: refused.
+	rgSym, _ := createCapturingMuxRouteGroup(t, 2)
+	if err := rgSym.SetDirectionPin(routing.DirectionPinFlipped); err == nil {
+		t.Fatal("SetDirectionPin must error on a non-directional group")
+	}
+
+	// Directional: invalid mode refused; valid pin applied + signaled on leg 0.
+	rg, conns := createCapturingMuxRouteGroup(t, 2)
+	rg.mux.setDirectional(true, rg.desc.DstPK(), rg.desc.SrcPK())
+	if err := rg.SetDirectionPin(3); err == nil {
+		t.Fatal("SetDirectionPin must reject an unknown mode byte")
+	}
+	if err := rg.SetDirectionPin(routing.DirectionPinFlipped); err != nil {
+		t.Fatalf("SetDirectionPin(pin-flipped): %v", err)
+	}
+	if got := rg.mux.flipPinMode(); got != routing.DirectionPinFlipped {
+		t.Fatalf("local pin = %d, want %d", got, routing.DirectionPinFlipped)
+	}
+	if _, flipped := rg.mux.dirState(); !flipped {
+		t.Fatal("local mapping not forced to flipped")
+	}
+	found := false
+	conns[0].mu.Lock()
+	for _, p := range conns[0].written {
+		if p.Type() == routing.DirectionPacket {
+			found = true
+			if got := p.DirectionMode(); got != routing.DirectionPinFlipped {
+				t.Errorf("wire DirectionMode = %d, want %d", got, routing.DirectionPinFlipped)
+			}
+		}
+	}
+	conns[0].mu.Unlock()
+	if !found {
+		t.Fatal("no DirectionPacket captured on the primary leg")
+	}
+	conns[1].mu.Lock()
+	for _, p := range conns[1].written {
+		if p.Type() == routing.DirectionPacket {
+			t.Error("DirectionPacket leaked onto a non-primary leg")
+		}
+	}
+	conns[1].mu.Unlock()
+}

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -81,6 +81,8 @@ func (t PacketType) String() string {
 		return "Repair"
 	case LegStatePacket:
 		return "LegState"
+	case DirectionPacket:
+		return "Direction"
 	default:
 		return fmt.Sprintf("Unknown(%d)", t)
 	}
@@ -152,6 +154,18 @@ const (
 	// the sender so both ends stripe over the same active set. Gated by CapLegState;
 	// a peer without it never receives one and keeps the send-side-only behavior.
 	LegStatePacket
+	// DirectionPacket pins (or releases) a unidirectional group's direction→
+	// leg-class mapping — the LegState-style coordination the CapUniDir doc
+	// promises for flips, applied to a MANUAL operator pin (route ID > 0, sent on
+	// the group's primary leg). Payload: one byte — 0 = auto (release the pin, the
+	// flip controller resumes), 1 = pin-default (initiator sends on the direct
+	// leg / the download rides the multihop mux), 2 = pin-flipped (the swapped
+	// mapping). Both ends must hold the same mapping or they send on the same leg
+	// class; the receiver applies the pin too, so its flip controller does not
+	// fight the sender's. The wire framing is length-prefixed and unknown types
+	// fall through handlePacket harmlessly, so an OLD peer ignores this packet —
+	// a pin against such a peer is best-effort local-only.
+	DirectionPacket
 )
 
 // FECRepairHdr is the fixed prefix of a RepairPacket payload: blockID(4) + idx(1)
@@ -506,6 +520,48 @@ func MakeLegStatePacket(id RouteID, standby bool) Packet {
 func (p Packet) LegStateStandby() bool {
 	payload := p.Payload()
 	return len(payload) >= LegStatePayloadSize && payload[0] == 1
+}
+
+// DirectionPacket payload modes: the direction→leg-class mapping an operator
+// pins on a unidirectional (CapUniDir) group, or auto to release the pin.
+const (
+	// DirectionAuto releases a manual pin — the flip controller resumes on both
+	// ends from the current mapping.
+	DirectionAuto byte = 0
+	// DirectionPinDefault pins the DEFAULT mapping: the initiator sends on the
+	// DIRECT (1-hop) leg, the acceptor (the download) on the MULTIHOP mux legs.
+	DirectionPinDefault byte = 1
+	// DirectionPinFlipped pins the FLIPPED mapping: the initiator sends on the
+	// multihop mux legs, the acceptor on the direct leg (upload gets the mux).
+	DirectionPinFlipped byte = 2
+)
+
+// DirectionPayloadSize is the DirectionPacket payload: one mode byte.
+const DirectionPayloadSize = 1
+
+// MakeDirectionPacket constructs a DirectionPacket pinning (mode 1/2) or
+// releasing (mode 0) the unidirectional direction→leg-class mapping, addressed
+// to the route group the id belongs to. Sent on the group's primary leg; the
+// receiver applies the same pin so both ends keep sending on disjoint classes.
+func MakeDirectionPacket(id RouteID, mode byte) Packet {
+	packet := make([]byte, PacketHeaderSize+DirectionPayloadSize)
+	packet[PacketTypeOffset] = byte(DirectionPacket)
+	binary.BigEndian.PutUint32(packet[PacketRouteIDOffset:], uint32(id))
+	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], DirectionPayloadSize)
+	packet[PacketPayloadOffset] = mode
+	return packet
+}
+
+// DirectionMode returns a DirectionPacket's mode byte (DirectionAuto /
+// DirectionPinDefault / DirectionPinFlipped). A malformed/empty payload reads
+// as DirectionAuto — the safe default (it never forces a mapping the sender
+// did not ask for; at worst it releases a pin back to the controller).
+func (p Packet) DirectionMode() byte {
+	payload := p.Payload()
+	if len(payload) < DirectionPayloadSize {
+		return DirectionAuto
+	}
+	return payload[0]
 }
 
 // HandshakeCapabilities extracts the capability bitmap from an extended handshake payload.

--- a/pkg/routing/packet_test.go
+++ b/pkg/routing/packet_test.go
@@ -199,3 +199,24 @@ func TestMakeRepairPacketRoundTrip(t *testing.T) {
 	}
 	require.Equal(t, symbol, p.RepairSymbol())
 }
+
+// TestMakeDirectionPacket round-trips the manual direction pin: type, route ID
+// and mode byte survive Make → accessors, and a malformed (empty-payload)
+// packet reads as the safe DirectionAuto.
+func TestMakeDirectionPacket(t *testing.T) {
+	for _, mode := range []byte{DirectionAuto, DirectionPinDefault, DirectionPinFlipped} {
+		p := MakeDirectionPacket(7, mode)
+		assert.Equal(t, DirectionPacket, p.Type())
+		assert.Equal(t, RouteID(7), p.RouteID())
+		assert.Equal(t, uint16(DirectionPayloadSize), p.Size())
+		assert.Equal(t, mode, p.DirectionMode())
+	}
+	// Exact wire shape for pin-flipped: type after LegStatePacket, 1-byte payload.
+	p := MakeDirectionPacket(7, DirectionPinFlipped)
+	expected := []byte{byte(DirectionPacket), 0x0, 0x0, 0x0, 0x7, 0x0, 0x1, 0x2}
+	assert.Equal(t, expected, []byte(p))
+
+	// Truncated payload → DirectionAuto (never forces an unrequested mapping).
+	trunc := Packet(expected[:PacketHeaderSize])
+	assert.Equal(t, DirectionAuto, trunc.DirectionMode())
+}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -195,6 +195,11 @@ type API interface {
 	AddMuxRoute(appName string, fwd, rev []routing.Hop, srcPort uint16) error
 	GrowMuxRoute(appName string, target, minHops int, srcPort uint16) (int, error)
 	RemoveMuxRoute(appName string, tpID uuid.UUID, srcPort uint16) error
+	// SetMuxDirection pins (mode "default"/"flipped") or releases (mode
+	// "auto") the unidirectional direction→leg-class mapping on ALL of the
+	// app's active directional route groups. The pin is coordinated with the
+	// peer over the wire; RouteGroupMuxInfo reports the live state.
+	SetMuxDirection(appName, mode string) error
 	ServiceHealth() ([]ServiceHealthEntry, error)
 	FetchServiceData(service, path string) ([]byte, error)
 	SetMinHops(uint16) error

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -142,6 +142,7 @@ func muxRouteGroupInfoFrom(infos []router.MuxInfo) []MuxRouteGroupInfo {
 			PerFrameNoise:      info.PerFrameNoise,
 			Directional:        info.Directional,
 			Flipped:            info.Flipped,
+			FlipPinned:         info.FlipPinned,
 			Distribution:       info.Distribution,
 			ReorderPending:     info.ReorderPending,
 			ReorderGapAgeMS:    float64(info.ReorderGapAge) / float64(time.Millisecond),
@@ -341,6 +342,38 @@ func (v *Visor) RemoveMuxRoute(appName string, tpID uuid.UUID, srcPort uint16) e
 		return err
 	}
 	return v.router.RemoveMuxRouteByTransport(desc, tpID)
+}
+
+// SetMuxDirection implements API. Pins (or releases) the unidirectional
+// direction→leg-class mapping on ALL of the app's active directional route
+// groups — a proxy session can hold several concurrent rg's (one per SOCKS5
+// connection), and pinning only one would leave the others' controllers free
+// to diverge. mode is "auto" (release — the flip controller resumes on both
+// ends), "default" (initiator sends on the direct leg / download rides the
+// multihop mux) or "flipped" (the swapped mapping). Each rg signals the pin to
+// its peer over the wire; against an old peer the pin is best-effort
+// local-only.
+func (v *Visor) SetMuxDirection(appName, mode string) error {
+	if v.router == nil {
+		return errors.New("router not available")
+	}
+	var m byte
+	switch mode {
+	case "auto":
+		m = routing.DirectionAuto
+	case "default":
+		m = routing.DirectionPinDefault
+	case "flipped":
+		m = routing.DirectionPinFlipped
+	default:
+		return fmt.Errorf("mode must be 'auto', 'default' or 'flipped', got %q", mode)
+	}
+	applied, err := v.router.SetMuxDirectionForApp(appName, m)
+	if err != nil {
+		return err
+	}
+	v.log.Infof("SetMuxDirection: %s pinned to %q on %d route group(s)", appName, mode, applied)
+	return nil
 }
 
 // SetMinHops sets min_hops routing config of visor

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -566,6 +566,10 @@ func (proxyDefaultAPI) RemoveMuxRoute(_ string, _ uuid.UUID, _ uint16) error {
 	return ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) SetMuxDirection(_, _ string) error {
+	return ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) ServiceHealth() ([]ServiceHealthEntry, error) {
 	return nil, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -294,6 +294,10 @@ type MuxRouteGroupInfo struct {
 	// this tells which class carries which direction without log-grepping.
 	Directional bool `json:"directional,omitempty"`
 	Flipped     bool `json:"flipped,omitempty"`
+	// FlipPinned is the operator's MANUAL direction pin on a directional group:
+	// "auto" (flip controller in charge), "default" or "flipped" (mapping pinned,
+	// controller dormant until released). Empty on a non-directional mux.
+	FlipPinned string `json:"flip_pinned,omitempty"`
 	// Distribution names how the mux spreads outbound packets across its legs
 	// (weight mode: "auto", "round-robin", "weighted", "capacity",
 	// "latency-adaptive", "sticky:5tuple", "size-threshold", "dscp-priority").
@@ -417,6 +421,13 @@ type MuxRouteInput struct {
 	// etc.). Zero means "auto-pick if exactly one rg is active for
 	// the app, error otherwise."
 	SrcPort uint16
+}
+
+// MuxDirectionInput carries the app-scoped manual direction pin for
+// SetMuxDirection: Mode is "auto" (release), "default" or "flipped".
+type MuxDirectionInput struct {
+	AppName string
+	Mode    string
 }
 type FilterServersIn struct {
 	Version string

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -901,6 +901,13 @@ func (rc *rpcClient) RemoveMuxRoute(appName string, tpID uuid.UUID, srcPort uint
 	return rc.Call("RemoveMuxRoute", &MuxRouteInput{AppName: appName, TransportID: tpID, SrcPort: srcPort}, &struct{}{})
 }
 
+// SetMuxDirection pins ("default"/"flipped") or releases ("auto") the
+// unidirectional direction→leg-class mapping on all of the app's active
+// directional route groups.
+func (rc *rpcClient) SetMuxDirection(appName, mode string) error {
+	return rc.Call("SetMuxDirection", &MuxDirectionInput{AppName: appName, Mode: mode}, &struct{}{})
+}
+
 // ActiveRoutes returns all active routes with app associations and live stats.
 func (rc *rpcClient) ActiveRoutes() ([]AppRouteStatus, error) {
 	var routes []AppRouteStatus

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -817,6 +817,10 @@ func (mc *mockRPCClient) RemoveMuxRoute(_ string, _ uuid.UUID, _ uint16) error {
 	return nil
 }
 
+func (mc *mockRPCClient) SetMuxDirection(_, _ string) error {
+	return nil
+}
+
 // RoutingRules implements API.
 func (mc *mockRPCClient) RoutingRules() ([]routing.Rule, error) {
 	return mc.rt.AllRules(), nil

--- a/pkg/visor/rpc_routing.go
+++ b/pkg/visor/rpc_routing.go
@@ -215,3 +215,10 @@ func (r *RPC) RemoveMuxRoute(in *MuxRouteInput, _ *struct{}) (err error) {
 	defer rpcutil.LogCall(r.log, "RemoveMuxRoute", in)(nil, &err)
 	return r.visor.RemoveMuxRoute(in.AppName, in.TransportID, in.SrcPort)
 }
+
+// SetMuxDirection pins or releases the unidirectional direction mapping on all
+// of an app's active directional route groups
+func (r *RPC) SetMuxDirection(in *MuxDirectionInput, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "SetMuxDirection", in)(nil, &err)
+	return r.visor.SetMuxDirection(in.AppName, in.Mode)
+}


### PR DESCRIPTION
Adds operator control over which leg class (direct vs multihop) carries each data direction on a CapUniDir proxy session: `skywire cli proxy mux direction <auto|default|flipped>` pins the direction→leg-class mapping on all of the app's active route groups (`default`: download aggregates over the multihop mux; `flipped`: upload gets the mux), or releases it back to the automatic flip controller. `mux info` shows the live state as `flip_pinned`.

A one-sided pin would desync the ends — both could end up sending on the same leg class — so the pin is coordinated on the wire with a new `DirectionPacket` (one-byte payload: 0=auto, 1=pin-default, 2=pin-flipped) sent on the primary leg, the LegState-style coordination the CapUniDir doc comment promised. The receiver mirrors the pin so its flip controller goes dormant instead of fighting the mapping; unknown packet types fall through `handlePacket`, so a pin against an old peer is best-effort local-only. While pinned, `unidirFlipTick` skips goodput sampling and keeps the hysteresis/cooldown counters zeroed, so releasing hands the controller a clean slate.

Tests: packet round-trip, pin holds against flipStep pressure that would otherwise flip, release resumes the controller with the full hysteresis vote, receiver-side apply/release, and SetDirectionPin gating (non-directional groups refused, signal captured on the primary leg only). Full `pkg/router` + `pkg/routing` suites pass; whole-binary build verified.