### PR TITLE
fix(router): retx-buffer tags use transport UUIDs, not leg indices

### DIFF
--- a/pkg/router/fec_mux_integration_test.go
+++ b/pkg/router/fec_mux_integration_test.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"github.com/google/uuid"
+
 	"fmt"
 	"testing"
 
@@ -47,7 +49,7 @@ func TestFECMuxWiredReconstructsSlowLegFrame(t *testing.T) {
 	packets := make([]routing.Packet, k)
 	for i := 0; i < k; i++ {
 		plain[i] = []byte(fmt.Sprintf("frame-%02d-the-quick-brown-fox-jumps", i))
-		pkt, seq, err := send.wrapPayload(routeID, plain[i], 0)
+		pkt, seq, err := send.wrapPayload(routeID, plain[i], uuid.Nil)
 		require.NoError(t, err)
 		require.Equal(t, uint32(i), seq)
 		packets[i] = pkt
@@ -100,7 +102,7 @@ func TestFECMuxWiredInertWhenDisabled(t *testing.T) {
 	plain := make([][]byte, n)
 	for i := 0; i < n; i++ {
 		plain[i] = []byte(fmt.Sprintf("plain-%02d", i))
-		pkt, _, err := send.wrapPayload(routeID, plain[i], 0)
+		pkt, _, err := send.wrapPayload(routeID, plain[i], uuid.Nil)
 		require.NoError(t, err)
 		delivered, _ := recv.deliverData(-1, pkt.SequenceNumber(), pkt.DataPayloadAfterSeq())
 		require.Len(t, delivered, 1, "in-order delivery, one frame at a time")
@@ -151,7 +153,7 @@ func TestFECMuxTailFlushProtectsPartialBlock(t *testing.T) {
 	realPkts := make([]routing.Packet, jReal)
 	for i := 0; i < jReal; i++ {
 		plain[i] = []byte(fmt.Sprintf("tail-frame-%02d-payload", i))
-		pkt, seq, err := send.wrapPayload(routeID, plain[i], 0)
+		pkt, seq, err := send.wrapPayload(routeID, plain[i], uuid.Nil)
 		require.NoError(t, err)
 		require.Equal(t, uint32(i), seq)
 		realPkts[i] = pkt
@@ -163,7 +165,7 @@ func TestFECMuxTailFlushProtectsPartialBlock(t *testing.T) {
 	padPkts := make([]routing.Packet, 0, k-jReal)
 	for i := jReal; i < k; i++ {
 		var empty []byte
-		pkt, seq, err := send.wrapPayload(routeID, empty, 0)
+		pkt, seq, err := send.wrapPayload(routeID, empty, uuid.Nil)
 		require.NoError(t, err)
 		require.Equal(t, uint32(i), seq)
 		padPkts = append(padPkts, pkt)
@@ -214,7 +216,7 @@ func TestFECMuxSingleLegNoRepair(t *testing.T) {
 
 	const routeID = routing.RouteID(13)
 	for i := 0; i < fecDefaultK*3; i++ {
-		_, _, err := send.wrapPayload(routeID, []byte(fmt.Sprintf("f-%02d", i)), 0)
+		_, _, err := send.wrapPayload(routeID, []byte(fmt.Sprintf("f-%02d", i)), uuid.Nil)
 		require.NoError(t, err)
 	}
 	require.Empty(t, send.fecDrainRepairs(), "single-leg group must not emit FEC repair frames")

--- a/pkg/router/hol_retx_test.go
+++ b/pkg/router/hol_retx_test.go
@@ -3,6 +3,8 @@
 package router
 
 import (
+	"github.com/google/uuid"
+
 	"testing"
 	"time"
 
@@ -230,8 +232,8 @@ func TestProactiveRetxSeqs(t *testing.T) {
 
 	t.Run("capability off -> nil fallback", func(t *testing.T) {
 		m := newMux(false)
-		m.retxBuf.Store(101, []byte("a"), 0)
-		m.retxBuf.Store(102, []byte("b"), 0)
+		m.retxBuf.Store(101, []byte("a"), uuid.Nil)
+		m.retxBuf.Store(102, []byte("b"), uuid.Nil)
 		if got := m.proactiveRetxSeqs(last, words, 20, now); got != nil {
 			t.Errorf("HoL disabled must return nil, got %v", got)
 		}
@@ -239,9 +241,9 @@ func TestProactiveRetxSeqs(t *testing.T) {
 
 	t.Run("returns held frontier seqs", func(t *testing.T) {
 		m := newMux(true)
-		m.retxBuf.Store(101, []byte("a"), 0)
-		m.retxBuf.Store(102, []byte("b"), 0)
-		m.retxBuf.Store(103, []byte("c"), 0)
+		m.retxBuf.Store(101, []byte("a"), uuid.Nil)
+		m.retxBuf.Store(102, []byte("b"), uuid.Nil)
+		m.retxBuf.Store(103, []byte("c"), uuid.Nil)
 		got := m.proactiveRetxSeqs(last, words, 20, now)
 		if !equalSeqs(got, []uint32{101, 102, 103}) {
 			t.Errorf("got %v, want [101 102 103]", got)
@@ -251,8 +253,8 @@ func TestProactiveRetxSeqs(t *testing.T) {
 	t.Run("skips seqs not in retx buffer", func(t *testing.T) {
 		m := newMux(true)
 		// 102 already acked/purged -> not retransmitted; 101,103 held.
-		m.retxBuf.Store(101, []byte("a"), 0)
-		m.retxBuf.Store(103, []byte("c"), 0)
+		m.retxBuf.Store(101, []byte("a"), uuid.Nil)
+		m.retxBuf.Store(103, []byte("c"), uuid.Nil)
 		got := m.proactiveRetxSeqs(last, words, 20, now)
 		if !equalSeqs(got, []uint32{101, 103}) {
 			t.Errorf("got %v, want [101 103]", got)
@@ -261,9 +263,9 @@ func TestProactiveRetxSeqs(t *testing.T) {
 
 	t.Run("per-seq rate limit within interval", func(t *testing.T) {
 		m := newMux(true)
-		m.retxBuf.Store(101, []byte("a"), 0)
-		m.retxBuf.Store(102, []byte("b"), 0)
-		m.retxBuf.Store(103, []byte("c"), 0)
+		m.retxBuf.Store(101, []byte("a"), uuid.Nil)
+		m.retxBuf.Store(102, []byte("b"), uuid.Nil)
+		m.retxBuf.Store(103, []byte("c"), uuid.Nil)
 		// fastestMs=20 -> interval 20ms.
 		first := m.proactiveRetxSeqs(last, words, 20, now)
 		if !equalSeqs(first, []uint32{101, 102, 103}) {
@@ -282,7 +284,7 @@ func TestProactiveRetxSeqs(t *testing.T) {
 
 	t.Run("young seq not nudged (age gate)", func(t *testing.T) {
 		m := newMux(true)
-		m.retxBuf.Store(101, []byte("a"), 0)
+		m.retxBuf.Store(101, []byte("a"), uuid.Nil)
 		// Probed immediately after send (age ≈ 0 < one fast-leg RTT): the seq
 		// cannot have been acked yet on ANY leg, so a nudge would be spurious
 		// by construction — this is the ungated behavior that duplicated ~12%
@@ -298,7 +300,7 @@ func TestProactiveRetxSeqs(t *testing.T) {
 
 	t.Run("empty bitmap -> nil (no stall)", func(t *testing.T) {
 		m := newMux(true)
-		m.retxBuf.Store(101, []byte("a"), 0)
+		m.retxBuf.Store(101, []byte("a"), uuid.Nil)
 		if got := m.proactiveRetxSeqs(last, nil, 20, now); got != nil {
 			t.Errorf("empty SACK bitmap must return nil, got %v", got)
 		}

--- a/pkg/router/perframe_noise_test.go
+++ b/pkg/router/perframe_noise_test.go
@@ -2,6 +2,8 @@
 package router
 
 import (
+	"github.com/google/uuid"
+
 	"fmt"
 	"testing"
 
@@ -53,7 +55,7 @@ func TestPerFrameMuxDataPathRoundTrip(t *testing.T) {
 	packets := make([]routing.Packet, n)
 	for i := 0; i < n; i++ {
 		plain[i] = []byte(fmt.Sprintf("payload-%04d-the-quick-brown-fox", i))
-		pkt, seq, err := send.wrapPayload(routeID, plain[i], 0)
+		pkt, seq, err := send.wrapPayload(routeID, plain[i], uuid.Nil)
 		require.NoError(t, err)
 		require.Equal(t, uint32(i), seq)
 		packets[i] = pkt
@@ -87,7 +89,7 @@ func TestPerFrameMuxDataPathRoundTrip(t *testing.T) {
 	_ = nI2
 	recv2.open = func(seq uint32, ct []byte) ([]byte, error) { return nR2.OpenWithNonce(uint64(seq), ct) }
 	// Frame sealed by a DIFFERENT sender (wrong key) must fail to open and deliver nothing.
-	bad, _, err := send.wrapPayload(routeID, []byte("attacker"), 0)
+	bad, _, err := send.wrapPayload(routeID, []byte("attacker"), uuid.Nil)
 	require.NoError(t, err)
 	// reset recv2 to expect seq 0
 	delivered, _ := recv2.deliverData(-1, bad.SequenceNumber()+1000, bad.DataPayloadAfterSeq())

--- a/pkg/router/rack_tlp_test.go
+++ b/pkg/router/rack_tlp_test.go
@@ -2,6 +2,8 @@
 package router
 
 import (
+	"github.com/google/uuid"
+
 	"sync/atomic"
 	"testing"
 	"time"
@@ -62,9 +64,9 @@ func TestTLPProbeSeq(t *testing.T) {
 	}
 
 	// Outstanding data, but the sender is NOT yet idle for a PTO → no probe.
-	m.retxBuf.Store(10, []byte("a"), 0)
-	m.retxBuf.Store(11, []byte("b"), 0)
-	m.retxBuf.Store(12, []byte("c"), 0) // tail = 12
+	m.retxBuf.Store(10, []byte("a"), uuid.Nil)
+	m.retxBuf.Store(11, []byte("b"), uuid.Nil)
+	m.retxBuf.Store(12, []byte("c"), uuid.Nil) // tail = 12
 	atomic.StoreInt64(&m.lastSendNano, now.UnixNano())
 	if _, due := m.tlpProbeSeq(now.Add(10 * time.Millisecond)); due {
 		t.Fatal("probe due before a full PTO of idle")

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -858,7 +858,13 @@ func (rg *RouteGroup) write(data []byte, tp *transport.ManagedTransport, rule ro
 	var packet routing.Packet
 	var err error
 	if rg.mux != nil {
-		packet, _, err = rg.mux.wrapPayload(rule.NextRouteID(), data, leg)
+		// Tag the retx entry with the transport's stable UUID (leg indices
+		// shift on slice compaction, so an index tag goes stale mid-session).
+		tpID := uuid.Nil
+		if tp != nil {
+			tpID = tp.Entry.ID
+		}
+		packet, _, err = rg.mux.wrapPayload(rule.NextRouteID(), data, tpID)
 	} else {
 		packet, err = routing.MakeDataPacket(rule.NextRouteID(), data)
 	}
@@ -1773,7 +1779,18 @@ func (rg *RouteGroup) rotationServiceFn(_ time.Duration) {
 		// whole-window flush this replaces duplicated the entire in-flight
 		// window (measured 33.8MB of dupes against 14.7MB payload on one leg
 		// of a 20MB transfer) on every demote event.
-		if seqs := rg.mux.heldRetxSeqsOnLegs(action.DemoteToStandby); len(seqs) > 0 {
+		// Map the demoted leg INDICES to their transports' stable UUIDs under
+		// rg.mu before consulting the buffer — the retx tags are transport
+		// identities, immune to the index shifts a slice compaction causes.
+		rg.mu.Lock()
+		demotedTps := make([]uuid.UUID, 0, len(action.DemoteToStandby))
+		for _, idx := range action.DemoteToStandby {
+			if idx >= 0 && idx < len(rg.tps) && rg.tps[idx] != nil {
+				demotedTps = append(demotedTps, rg.tps[idx].Entry.ID)
+			}
+		}
+		rg.mu.Unlock()
+		if seqs := rg.mux.heldRetxSeqsOnTps(demotedTps); len(seqs) > 0 {
 			if err := rg.resendSeqs(seqs); err != nil {
 				rg.logger.WithError(err).Debug("demote retx flush: no active leg to resend on")
 			}
@@ -4172,9 +4189,11 @@ func (rg *RouteGroup) resendSeqs(seqs []uint32) error {
 			// retx selector picks fresh, mirroring the data path).
 			rg.mux.recordSent(leg, uint64(retxPacket.Size()))
 			rg.mux.recordRetransmit(leg) // separate loss signal for leg health
-			// Re-tag the sequence's last-send leg so a later demote flush
-			// attributes it to where it now rides, not where it started.
-			rg.mux.retxSetLeg(seq, leg)
+			// Re-tag the sequence's last-send transport so a later demote
+			// flush attributes it to where it now rides, not where it started.
+			if tp != nil {
+				rg.mux.retxSetTp(seq, tp.Entry.ID)
+			}
 			// A frame just went out (incl. a TLP probe) — restart the TLP idle
 			// timer so the next probe waits a fresh PTO rather than back-to-back.
 			atomic.StoreInt64(&rg.mux.lastSendNano, time.Now().UnixNano())

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/routing"
@@ -999,10 +1001,12 @@ func ewmaRate(prev float64, delta uint64, secs float64) float64 {
 }
 
 // wrapPayload creates a sequenced data packet and optionally stores it for
-// retransmission, tagged with the leg it is about to be sent on (-1 = unknown)
-// so the demote-time flush can target only the stranded leg's sequences.
+// retransmission, tagged with the TRANSPORT UUID of the leg it is about to be
+// sent on (uuid.Nil = unknown) so the demote-time flush can target only the
+// stranded leg's sequences. The tag is the transport identity, not the leg
+// index — indices shift on slice compaction.
 // Returns the packet and the sequence number used.
-func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte, leg int) (routing.Packet, uint32, error) {
+func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte, tpID uuid.UUID) (routing.Packet, uint32, error) {
 	seq := atomic.AddUint32(&m.writeSeq, 1) - 1
 	// Per-frame AEAD: seal the app payload under seq as the nonce. The sealed
 	// bytes are what go on the wire AND into the retx buffer, so a SACK
@@ -1018,7 +1022,7 @@ func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte, leg int) (r
 
 	// Store for retransmission before sending
 	if m.sackEnabled && m.retxBuf != nil {
-		m.retxBuf.Store(seq, data, leg) //nolint:errcheck
+		m.retxBuf.Store(seq, data, tpID) //nolint:errcheck
 	}
 
 	// FEC: feed the on-wire (post-seal) payload to the striper. A completed block
@@ -1307,29 +1311,32 @@ func (m *routeMux) heldRetxSeqs() []uint32 {
 	return m.retxBuf.Seqs()
 }
 
-// heldRetxSeqsOnLegs returns the held sequences whose LAST send rode one of the
-// given leg indices (unknown-leg entries included conservatively), ascending.
+// heldRetxSeqsOnTps returns the held sequences whose LAST send rode one of the
+// given transports (unknown-tag entries included conservatively), ascending.
 // The demote-time flush uses this to rescue only the sequences the demoted
 // leg(s) actually strand, instead of duplicating the whole in-flight window
-// onto the surviving legs.
-func (m *routeMux) heldRetxSeqsOnLegs(legIdxs []int) []uint32 {
-	if !m.sackEnabled || m.retxBuf == nil || len(legIdxs) == 0 {
+// onto the surviving legs. Keyed by transport UUID, never leg index — indices
+// shift on slice compaction and a stale index tag wedged live sessions.
+func (m *routeMux) heldRetxSeqsOnTps(tpIDs []uuid.UUID) []uint32 {
+	if !m.sackEnabled || m.retxBuf == nil || len(tpIDs) == 0 {
 		return nil
 	}
-	set := make(map[int]bool, len(legIdxs))
-	for _, idx := range legIdxs {
-		set[idx] = true
+	set := make(map[uuid.UUID]bool, len(tpIDs))
+	for _, id := range tpIDs {
+		if id != uuid.Nil {
+			set[id] = true
+		}
 	}
-	return m.retxBuf.HeldSeqsOnLegs(set)
+	return m.retxBuf.HeldSeqsOnTps(set)
 }
 
-// retxSetLeg re-tags a held sequence's last-send leg after a retransmit moved
-// it to a different leg, keeping the demote-flush attribution honest.
-func (m *routeMux) retxSetLeg(seq uint32, leg int) {
+// retxSetTp re-tags a held sequence's last-send transport after a retransmit
+// moved it to a different leg, keeping the demote-flush attribution honest.
+func (m *routeMux) retxSetTp(seq uint32, tpID uuid.UUID) {
 	if m.retxBuf == nil {
 		return
 	}
-	m.retxBuf.SetLeg(seq, leg)
+	m.retxBuf.SetTpID(seq, tpID)
 }
 
 // rebuildWeights updates transport selection weights based on current latency.

--- a/pkg/router/route_mux_demote_retx_test.go
+++ b/pkg/router/route_mux_demote_retx_test.go
@@ -131,23 +131,29 @@ func (h demoteHook) OnTick(_ DialInfo, _ []LegInfo) RotationAction {
 func TestMuxDemoteFlushesInFlightSeqs(t *testing.T) {
 	rg, conns := createCapturingMuxRouteGroup(t, 2)
 
-	// Sequences in flight ON LEG 1 (the leg about to be demoted) — these are
-	// stranded by the demote and must be flushed.
+	// Tags are TRANSPORT UUIDs (stable across slice compaction), never leg
+	// indices — an index tag went stale the moment pruneDeadTransports
+	// compacted tps[] and the flush then missed genuinely stranded sequences.
+	leg0ID := rg.tps[0].Entry.ID
+	leg1ID := rg.tps[1].Entry.ID
+
+	// Sequences in flight ON LEG 1's transport (the leg about to be demoted) —
+	// these are stranded by the demote and must be flushed.
 	const nPkts = 32
 	want := make([]uint32, 0, nPkts)
 	for i := 0; i < nPkts; i++ {
-		_, seq, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{byte(i), 0xAA, 0xBB}, 1)
+		_, seq, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{byte(i), 0xAA, 0xBB}, leg1ID)
 		if err != nil {
 			t.Fatalf("wrapPayload: %v", err)
 		}
 		want = append(want, seq)
 	}
-	// Sequences in flight on LEG 0 (stays active) — NOT stranded; the narrowed
-	// flush must leave them to the normal SACK path.
+	// Sequences in flight on LEG 0's transport (stays active) — NOT stranded;
+	// the narrowed flush must leave them to the normal SACK path.
 	const nActive = 8
 	activeSeqs := make(map[uint32]bool, nActive)
 	for i := 0; i < nActive; i++ {
-		_, seq, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{0xCC, byte(i)}, 0)
+		_, seq, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{0xCC, byte(i)}, leg0ID)
 		if err != nil {
 			t.Fatalf("wrapPayload(leg0): %v", err)
 		}
@@ -195,7 +201,7 @@ func TestMuxDemoteFlushNoActiveLegIsSafe(t *testing.T) {
 	rg, conns := createCapturingMuxRouteGroup(t, 2)
 
 	for i := 0; i < 8; i++ {
-		if _, _, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{byte(i)}, 0); err != nil {
+		if _, _, err := rg.mux.wrapPayload(routing.RouteID(2), []byte{byte(i)}, uuid.Nil); err != nil {
 			t.Fatalf("wrapPayload: %v", err)
 		}
 	}

--- a/pkg/router/route_mux_e2e_test.go
+++ b/pkg/router/route_mux_e2e_test.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"github.com/google/uuid"
+
 	"sync/atomic"
 	"testing"
 	"time"
@@ -38,7 +40,7 @@ func TestMux_InOrderDelivery(t *testing.T) {
 	var got []byte
 	for i := 0; i < 200; i++ {
 		payload := []byte{byte(i)}
-		_, seq, err := send.wrapPayload(routing.RouteID(1), payload, 0)
+		_, seq, err := send.wrapPayload(routing.RouteID(1), payload, uuid.Nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -69,7 +71,7 @@ func TestMux_InterleavedLegs(t *testing.T) {
 	var evens, odds []pkt
 	for i := 0; i < 200; i++ {
 		payload := []byte{byte(i)}
-		_, seq, err := send.wrapPayload(routing.RouteID(1), payload, 0)
+		_, seq, err := send.wrapPayload(routing.RouteID(1), payload, uuid.Nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -122,7 +124,7 @@ func TestMux_RecoversLostPacketViaRetx(t *testing.T) {
 	var pkts []pkt
 	for i := 0; i < 20; i++ {
 		payload := []byte{byte(i)}
-		_, seq, err := send.wrapPayload(routing.RouteID(1), payload, 0)
+		_, seq, err := send.wrapPayload(routing.RouteID(1), payload, uuid.Nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/router/route_mux_helpers_test.go
+++ b/pkg/router/route_mux_helpers_test.go
@@ -9,6 +9,8 @@
 package router
 
 import (
+	"github.com/google/uuid"
+
 	"testing"
 	"time"
 
@@ -118,11 +120,11 @@ func TestMuxSACKPathEnabled(t *testing.T) {
 
 	routeID := routing.RouteID(7)
 	// wrapPayload stores the payload in the retx buffer for later SACK recovery.
-	pkt0, seq0, err := m.wrapPayload(routeID, []byte("hello"), 0)
+	pkt0, seq0, err := m.wrapPayload(routeID, []byte("hello"), uuid.Nil)
 	require.NoError(t, err)
 	require.NotNil(t, pkt0)
 	require.EqualValues(t, 0, seq0)
-	pkt1, seq1, err := m.wrapPayload(routeID, []byte("world"), 0)
+	pkt1, seq1, err := m.wrapPayload(routeID, []byte("world"), uuid.Nil)
 	require.NoError(t, err)
 	require.NotNil(t, pkt1)
 	require.EqualValues(t, 1, seq1)
@@ -150,7 +152,7 @@ func TestMuxSACKPathEnabled(t *testing.T) {
 func TestMuxSACKPathDisabled(t *testing.T) {
 	m := newBareMux(false)
 
-	_, _, err := m.wrapPayload(routing.RouteID(1), []byte("x"), 0)
+	_, _, err := m.wrapPayload(routing.RouteID(1), []byte("x"), uuid.Nil)
 	require.NoError(t, err)
 	// retxBuf still exists but Store is skipped when sackEnabled is false.
 	require.Empty(t, m.heldRetxSeqs())

--- a/pkg/router/sack.go
+++ b/pkg/router/sack.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // retxMinAge is the FALLBACK reorder-tolerant retransmit age, used only when the
@@ -172,13 +174,17 @@ type retxEntry struct {
 	seq    uint32
 	data   []byte
 	sentAt time.Time
-	// leg is the mux leg index this sequence was LAST sent on (-1 = unknown).
-	// Recorded at Store time and re-tagged on every retransmit, so the
-	// demote-time flush can resend only the sequences actually stranded on the
-	// demoted leg(s) instead of the whole in-flight window (measured live:
-	// a whole-window flush duplicated 33.8MB against 14.7MB of payload on one
-	// leg of a 20MB transfer).
-	leg int
+	// tpID is the TRANSPORT UUID of the leg this sequence was LAST sent on
+	// (uuid.Nil = unknown). Recorded at Store time and re-tagged on every
+	// retransmit, so the demote-time flush can resend only the sequences
+	// actually stranded on the demoted leg(s) instead of the whole in-flight
+	// window (measured live: a whole-window flush duplicated 33.8MB against
+	// 14.7MB of payload on one leg of a 20MB transfer). The tag is the
+	// transport identity, NOT the leg index: indices shift whenever
+	// pruneDeadTransports compacts tps[] after a leg drop, and an index tag
+	// went stale exactly then — the flush missed genuinely stranded sequences
+	// and the receiver's no-skip frontier wedged into a retransmit storm.
+	tpID uuid.UUID
 	// lastTxAt is when this sequence was last handed out for retransmission
 	// (zero until the first retx). retxCount is how many times it has been.
 	// Together they gate re-retransmission: without them every SACK arriving
@@ -225,7 +231,7 @@ func newRetxBuffer(capacity int) *retxBuffer {
 // received sequence above the gap each SACK, so under normal operation the
 // buffer holds only genuine holes plus in-flight sequences and never reaches
 // capacity — this eviction path is a backstop, not the steady state.
-func (rb *retxBuffer) Store(seq uint32, data []byte, leg int) bool {
+func (rb *retxBuffer) Store(seq uint32, data []byte, tpID uuid.UUID) bool {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 
@@ -248,31 +254,33 @@ func (rb *retxBuffer) Store(seq uint32, data []byte, leg int) bool {
 		seq:    seq,
 		data:   cp,
 		sentAt: time.Now(),
-		leg:    leg,
+		tpID:   tpID,
 	}
 	return true
 }
 
-// SetLeg re-tags seq's last-send leg (a retransmit moved it). No-op for a seq
-// no longer held.
-func (rb *retxBuffer) SetLeg(seq uint32, leg int) {
+// SetTpID re-tags seq's last-send transport (a retransmit moved it). No-op for
+// a seq no longer held.
+func (rb *retxBuffer) SetTpID(seq uint32, tpID uuid.UUID) {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 	if e, ok := rb.entries[seq]; ok {
-		e.leg = leg
+		e.tpID = tpID
 	}
 }
 
-// HeldSeqsOnLegs returns the held sequences whose last send rode one of the
-// given legs, sorted ascending. Entries with an unknown leg (-1) are included
-// conservatively — better a redundant resend than a stranded gap. Used by the
-// demote-time flush to rescue only what the demoted leg(s) actually strand.
-func (rb *retxBuffer) HeldSeqsOnLegs(legs map[int]bool) []uint32 {
+// HeldSeqsOnTps returns the held sequences whose last send rode one of the
+// given transports, sorted ascending. Entries with an unknown transport
+// (uuid.Nil) are included conservatively — better a redundant resend than a
+// stranded gap. Used by the demote-time flush to rescue only what the demoted
+// leg(s) actually strand; keyed by transport UUID because leg INDICES shift on
+// slice compaction and a stale index tag wedged live sessions.
+func (rb *retxBuffer) HeldSeqsOnTps(tps map[uuid.UUID]bool) []uint32 {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 	seqs := make([]uint32, 0, len(rb.entries))
 	for seq, e := range rb.entries {
-		if e.leg < 0 || legs[e.leg] {
+		if e.tpID == uuid.Nil || tps[e.tpID] {
 			seqs = append(seqs, seq)
 		}
 	}

--- a/pkg/router/sack_test.go
+++ b/pkg/router/sack_test.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"github.com/google/uuid"
+
 	"testing"
 	"time"
 
@@ -98,7 +100,7 @@ func TestSACKTracker_FullWindowBitmap(t *testing.T) {
 func TestRetxBuffer_StoreAndPurge(t *testing.T) {
 	rb := newRetxBuffer(128)
 	for i := uint32(0); i < 10; i++ {
-		assert.True(t, rb.Store(i, []byte{byte(i)}, 0))
+		assert.True(t, rb.Store(i, []byte{byte(i)}, uuid.Nil))
 	}
 	assert.Equal(t, 10, rb.Len())
 
@@ -111,7 +113,7 @@ func TestRetxBuffer_StoreAndPurge(t *testing.T) {
 func TestRetxBuffer_RetransmitList(t *testing.T) {
 	rb := newRetxBuffer(128)
 	for i := uint32(0); i < 8; i++ {
-		rb.Store(i, []byte{byte(i)}, 0)
+		rb.Store(i, []byte{byte(i)}, uuid.Nil)
 	}
 
 	// Age the stored entries past retxMinAge so ProcessSACK will list missing
@@ -136,7 +138,7 @@ func TestRetxBuffer_RetransmitList(t *testing.T) {
 // with seconds of queueing delay is retransmitted hundreds of times.
 func TestRetxBuffer_RetxBackoffSuppressesDuplicates(t *testing.T) {
 	rb := newRetxBuffer(128)
-	rb.Store(3, []byte{3}, 0)
+	rb.Store(3, []byte{3}, uuid.Nil)
 	rb.entries[3].sentAt = time.Now().Add(-2 * retxMinAge)
 
 	// SACK: lastContiguous=2, seq 3 missing, seq 4 received.
@@ -181,10 +183,10 @@ func TestRetxBuffer_RetxBackoffSuppressesDuplicates(t *testing.T) {
 // the newest, instead of silently refusing to store the newest packet.
 func TestRetxBuffer_CapacityEvictsLowest(t *testing.T) {
 	rb := newRetxBuffer(3)
-	assert.True(t, rb.Store(0, []byte("a"), 0))
-	assert.True(t, rb.Store(1, []byte("b"), 0))
-	assert.True(t, rb.Store(2, []byte("c"), 0))
-	assert.True(t, rb.Store(3, []byte("d"), 0)) // full -> evict lowest (0), store 3
+	assert.True(t, rb.Store(0, []byte("a"), uuid.Nil))
+	assert.True(t, rb.Store(1, []byte("b"), uuid.Nil))
+	assert.True(t, rb.Store(2, []byte("c"), uuid.Nil))
+	assert.True(t, rb.Store(3, []byte("d"), uuid.Nil)) // full -> evict lowest (0), store 3
 	assert.Equal(t, 3, rb.Len())
 	assert.Nil(t, rb.Get(0), "lowest seq evicted")
 	assert.Equal(t, []byte("d"), rb.Get(3), "newest seq retained")
@@ -192,7 +194,7 @@ func TestRetxBuffer_CapacityEvictsLowest(t *testing.T) {
 
 func TestRetxBuffer_Get(t *testing.T) {
 	rb := newRetxBuffer(128)
-	rb.Store(42, []byte("hello"), 0)
+	rb.Store(42, []byte("hello"), uuid.Nil)
 	assert.Equal(t, []byte("hello"), rb.Get(42))
 	assert.Nil(t, rb.Get(99))
 }
@@ -207,7 +209,7 @@ func TestRetxBuffer_NoFillBehindPersistentGap(t *testing.T) {
 	const sent = 3000
 	rb := newRetxBuffer(4096) // large so this isolates purge behavior, not eviction
 	for seq := uint32(1); seq <= sent; seq++ {
-		rb.Store(seq, []byte{byte(seq)}, 0)
+		rb.Store(seq, []byte{byte(seq)}, uuid.Nil)
 	}
 
 	// Receiver got 2..3000 but not seq 1 -> lastContiguous stuck at 0.


### PR DESCRIPTION
The narrowed demote flush (#4446) tagged buffered sequences with the leg INDEX they were sent on — but indices shift whenever pruneDeadTransports compacts the leg slice after a drop, so mid-session the tags went stale: the flush missed genuinely stranded sequences, the receiver's no-skip frontier wedged, and fresh sessions degraded into retransmit storms. Observed live within minutes of the fleet picking up #4446 on the bulk-sending exit side: legs with 22-111 retransmits against near-zero payload and transfers crawling at 14KB/s.

Tags are now the transport's stable Entry.ID (uuid.Nil = unknown, conservatively included in any flush); the demote flush maps demoted leg indices to their transport UUIDs under the group lock before consulting the buffer, and retransmits re-tag each sequence with the transport that actually carried them. The demote-flush wire test now drives the tagging through real transport identities.