### PR TITLE
fix(visor): stop killing the shared hypervisor conn on one slow RPC

### DIFF
--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -607,8 +607,16 @@ func (hv *Hypervisor) getAllVisorsSummary() http.HandlerFunc {
 		// deadVisors accumulates PKs that errored Summary inside the
 		// 5s outer arm — evicted from remoteVisors AFTER wg.Wait so
 		// the eviction can't race with the poll goroutines still
-		// reading their captured Conn copies.
-		var deadVisors []cipher.PubKey
+		// reading their captured Conn copies. The failed conn's API is
+		// kept alongside the PK so eviction can verify the map still
+		// holds the SAME conn: a peer that re-registered between our
+		// snapshot and wg.Wait (restart churn does this constantly)
+		// must not have its FRESH conn deleted for the old conn's sins.
+		type deadVisor struct {
+			pk  cipher.PubKey
+			api API
+		}
+		var deadVisors []deadVisor
 		wg := new(sync.WaitGroup)
 		wg.Add(len(remotes))
 
@@ -685,7 +693,7 @@ func (hv *Hypervisor) getAllVisorsSummary() http.HandlerFunc {
 					// peers' state for the next round.
 					hv.logger.WithError(r.rpcErr).WithField("pk", pk).Warn("Failed to obtain summary via RPC")
 					mu.Lock()
-					deadVisors = append(deadVisors, pk)
+					deadVisors = append(deadVisors, deadVisor{pk: pk, api: c.API})
 					mu.Unlock()
 				case <-time.After(5 * time.Second):
 					hv.logger.WithField("pk", pk).
@@ -727,8 +735,13 @@ func (hv *Hypervisor) getAllVisorsSummary() http.HandlerFunc {
 		// via the sweep branch below.
 		if len(deadVisors) > 0 {
 			hv.mu.Lock()
-			for _, pk := range deadVisors {
-				delete(hv.remoteVisors, pk)
+			for _, d := range deadVisors {
+				// Identity check: evict only if the entry is still the
+				// conn that failed. A differing API means the peer
+				// re-registered mid-poll and the new conn is innocent.
+				if cur, ok := hv.remoteVisors[d.pk]; ok && cur.API == d.api {
+					delete(hv.remoteVisors, d.pk)
+				}
 			}
 			hv.mu.Unlock()
 		}

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/rpc"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -39,6 +40,35 @@ var (
 	ErrTimeout = errors.New("rpc client timeout")
 )
 
+// closeOnConsecTimeouts is how many CONSECUTIVE per-call deadline
+// expiries (with no completed call in between) it takes before Call
+// gives up on the underlying conn and closes it.
+//
+// Why not close on the first timeout (the old behavior): the
+// hypervisor holds ONE persistent RPC conn per remote visor, shared
+// by the 30s background summary poll, `hv ls` listings, the
+// sub-hypervisor tree probes, and pty/proxy control. Under load — a
+// fleet-wide update ripple, or the re-registration stampede after
+// the hypervisor itself restarts — a Summary reply (which carries
+// every transport summary, easily 100+ entries) can take longer than
+// the 20s call deadline while the conn is perfectly alive. Closing
+// the conn on that single slow call permanently shuts down the
+// net/rpc client ("connection is shut down" on every later call) and
+// the row stays dead until the remote notices the close — up to its
+// 90s idle timeout when close propagation is unreliable (skynet
+// conns) — and redials. Each listing/poll round then re-kills the
+// freshly re-registered conn, so operators saw half the fleet
+// flapping "connection is shut down (cached Ns ago)" for as long as
+// the congestion lasted.
+//
+// Three consecutive timeouts (~60s of nothing completing at the
+// default 20s deadline) still recovers a genuinely blackholed conn
+// on roughly the same timescale as the remote's own 90s idle-redial,
+// without nuking merely-slow conns. Any completed call — success OR
+// a server-side error reply, both prove the conn round-trips —
+// resets the count.
+const closeOnConsecTimeouts = 3
+
 // API provides methods to call an RPC Server.
 // It implements API
 type rpcClient struct {
@@ -48,6 +78,10 @@ type rpcClient struct {
 	client  *rpc.Client
 	prefix  string
 	FixGob  bool
+
+	// consecTimeouts counts per-call deadline expiries since the last
+	// completed call. See closeOnConsecTimeouts.
+	consecTimeouts atomic.Int32
 
 	// proxyTarget, when non-nil, rewrites every Call so the request
 	// goes to the LOCAL visor's TransportRPCCall method (over the
@@ -150,12 +184,46 @@ func (rc *rpcClient) Call(method string, args, reply interface{}) error {
 
 	select {
 	case call := <-rc.client.Go(rc.prefix+"."+method, args, reply, nil).Done:
+		rc.noteCallCompleted(call.Error)
 		return call.Error
 	case <-ctx.Done():
-		if err := rc.conn.Close(); err != nil {
-			rc.log.WithError(err).Warn("Failed to close rpc client after timeout error.")
-		}
+		rc.noteCallTimeout()
 		return ctx.Err()
+	}
+}
+
+// noteCallCompleted resets the consecutive-timeout count when a call
+// actually round-tripped the conn: err == nil, or a server-side error
+// reply (rpc.ServerError) — the server answering proves the conn is
+// alive. Transport-level failures (rpc.ErrShutdown, io errors) prove
+// nothing and leave the count alone.
+func (rc *rpcClient) noteCallCompleted(err error) {
+	if err == nil {
+		rc.consecTimeouts.Store(0)
+		return
+	}
+	var srvErr rpc.ServerError
+	if errors.As(err, &srvErr) {
+		rc.consecTimeouts.Store(0)
+	}
+}
+
+// noteCallTimeout records a per-call deadline expiry, closing the
+// underlying conn once closeOnConsecTimeouts have accumulated with no
+// completed call in between. Closing shuts down the net/rpc client
+// (pending and future calls fail fast) and, where close propagation
+// works, prompts the peer's serve loop to redial.
+func (rc *rpcClient) noteCallTimeout() {
+	n := rc.consecTimeouts.Add(1)
+	if int(n) < closeOnConsecTimeouts {
+		rc.log.WithField("consecutive_timeouts", n).
+			Debug("RPC call timed out; keeping conn (not yet at close threshold).")
+		return
+	}
+	rc.log.WithField("consecutive_timeouts", n).
+		Warn("Closing rpc conn after consecutive call timeouts.")
+	if err := rc.conn.Close(); err != nil {
+		rc.log.WithError(err).Warn("Failed to close rpc client after timeout error.")
 	}
 }
 
@@ -196,13 +264,12 @@ func (rc *rpcClient) callViaProxy(method string, args, reply interface{}) error 
 	var resultBytes json.RawMessage
 	select {
 	case call := <-rc.client.Go(rc.prefix+".TransportRPCCall", req, &resultBytes, nil).Done:
+		rc.noteCallCompleted(call.Error)
 		if call.Error != nil {
 			return call.Error
 		}
 	case <-ctx.Done():
-		if err := rc.conn.Close(); err != nil {
-			rc.log.WithError(err).Warn("Failed to close rpc client after proxy timeout.")
-		}
+		rc.noteCallTimeout()
 		return ctx.Err()
 	}
 

--- a/pkg/visor/rpc_client_timeout_test.go
+++ b/pkg/visor/rpc_client_timeout_test.go
@@ -1,0 +1,101 @@
+// Package visor pkg/visor/rpc_client_timeout_test.go
+package visor
+
+import (
+	"io"
+	"net/rpc"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockedConn accepts writes and never answers reads — every RPC call
+// through it hits the per-call deadline. Close unblocks readers.
+type blockedConn struct {
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func newBlockedConn() *blockedConn {
+	return &blockedConn{closed: make(chan struct{})}
+}
+
+func (c *blockedConn) Read(_ []byte) (int, error) {
+	<-c.closed
+	return 0, io.EOF
+}
+
+func (c *blockedConn) Write(p []byte) (int, error) {
+	select {
+	case <-c.closed:
+		return 0, io.ErrClosedPipe
+	default:
+		return len(p), nil
+	}
+}
+
+func (c *blockedConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closed) })
+	return nil
+}
+
+func (c *blockedConn) isClosed() bool {
+	select {
+	case <-c.closed:
+		return true
+	default:
+		return false
+	}
+}
+
+// TestRPCClientTimeoutTolerance verifies a single slow call no longer
+// closes the shared conn: the hypervisor holds ONE persistent RPC conn
+// per remote visor, and closing it on the first slow Summary (the old
+// behavior) permanently shut down the net/rpc client — operators saw
+// "connection is shut down (cached Ns ago)" across half the fleet
+// during congestion. The conn must survive closeOnConsecTimeouts-1
+// consecutive timeouts and close on the next one.
+func TestRPCClientTimeoutTolerance(t *testing.T) {
+	conn := newBlockedConn()
+	rc, ok := NewRPCClient(nil, conn, RPCPrefix, 50*time.Millisecond).(*rpcClient)
+	require.True(t, ok)
+
+	for i := 1; i < closeOnConsecTimeouts; i++ {
+		err := rc.Call("Health", &struct{}{}, &HealthInfo{})
+		require.Error(t, err)
+		assert.False(t, conn.isClosed(), "conn must survive %d consecutive timeouts", i)
+	}
+
+	err := rc.Call("Health", &struct{}{}, &HealthInfo{})
+	require.Error(t, err)
+	assert.True(t, conn.isClosed(), "conn must close after %d consecutive timeouts", closeOnConsecTimeouts)
+}
+
+// TestRPCClientTimeoutReset verifies the consecutive-timeout count
+// resets on any COMPLETED call — success or a server-side error reply
+// (both prove the conn round-trips) — but not on transport-level
+// failures like rpc.ErrShutdown.
+func TestRPCClientTimeoutReset(t *testing.T) {
+	conn := newBlockedConn()
+	rc, ok := NewRPCClient(nil, conn, RPCPrefix, 50*time.Millisecond).(*rpcClient)
+	require.True(t, ok)
+
+	rc.consecTimeouts.Store(closeOnConsecTimeouts - 1)
+	rc.noteCallCompleted(rpc.ErrShutdown)
+	assert.Equal(t, int32(closeOnConsecTimeouts-1), rc.consecTimeouts.Load(),
+		"transport failure must not reset the count")
+
+	rc.noteCallCompleted(rpc.ServerError("remote says no"))
+	assert.Equal(t, int32(0), rc.consecTimeouts.Load(),
+		"server-side error reply proves liveness and must reset the count")
+
+	rc.consecTimeouts.Store(closeOnConsecTimeouts - 1)
+	rc.noteCallCompleted(nil)
+	assert.Equal(t, int32(0), rc.consecTimeouts.Load(),
+		"success must reset the count")
+
+	assert.False(t, conn.isClosed())
+}


### PR DESCRIPTION
The hypervisor holds one persistent RPC conn per remote visor, shared by the 30s background summary poll, hv ls listings, and the sub-hypervisor tree probes. rpcClient.Call closed that conn on any single per-call deadline expiry, permanently shutting down the net/rpc client. Under congestion (a fleet update ripple, or the re-registration stampede after the hypervisor restarts) slow Summary replies exceeded the 20s deadline and half the fleet flapped "connection is shut down (cached Ns ago)" in hv ls — each poll round re-killed the freshly re-registered conn, and remotes on skynet conns take up to 90s to notice the close and redial.

Call now closes the conn only after 3 consecutive timeouts with no completed call in between; any round-tripped call (success or a server-side error reply) resets the count. A genuinely blackholed conn still closes within ~60s, on par with the remote's 90s idle-redial.

Also guards the getAllVisorsSummary eviction with a conn identity check, so a peer that re-registers between the poll snapshot and the eviction doesn't lose its fresh conn.