### PR TITLE
feat(proxystatus): status.dmsg + status.skynet pages for the resolving proxies

### DIFF
--- a/pkg/dmsgweb/status_scoping_test.go
+++ b/pkg/dmsgweb/status_scoping_test.go
@@ -81,6 +81,18 @@ func TestSOCKS5StatusScoping(t *testing.T) {
 	skynetBody := getBody(t, httpc, "http://status.skynet/")
 	require.Contains(t, skynetBody, "upstream-sink", "status.skynet should fall through to the upstream")
 	require.NotContains(t, skynetBody, "per-leg mux", "status.skynet must not be served in-process by the dmsg layer")
+
+	// Chain composition: in the real browser chain (dmsgweb :4445 → skynetweb
+	// :4446 → skysocks :1080) the SKYSOCKS status host must traverse this layer
+	// untouched so the skysocks-client can serve it, exactly as it does today.
+	skysocksBody := getBody(t, httpc, "http://status.skysocks/")
+	require.Contains(t, skysocksBody, "upstream-sink", "status.skysocks must reach the skysocks layer through the chain")
+	require.NotContains(t, skysocksBody, "per-leg mux", "status.skysocks must not be served in-process by the dmsg layer")
+
+	// An ordinary host is unaffected by the status interception entirely.
+	plainBody := getBody(t, httpc, "http://example.com/")
+	require.Contains(t, plainBody, "upstream-sink", "a non-status host must forward upstream untouched")
+	require.NotContains(t, plainBody, "per-leg mux", "a non-status host must never get a status page")
 }
 
 func getBody(t *testing.T, httpc *http.Client, url string) string {

--- a/pkg/proxystatus/layer_render_test.go
+++ b/pkg/proxystatus/layer_render_test.go
@@ -1,0 +1,201 @@
+package proxystatus
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// dmsgLayerSnap is a fully-populated dmsg-surface snapshot: a live layer, two
+// sessions, aliases, and NO route-group legs (the dmsg surface has none).
+func dmsgLayerSnap() Snapshot {
+	last := time.Now().Add(-90 * time.Second)
+	started := time.Now().Add(-2 * time.Hour)
+	return Snapshot{
+		Surface: SurfaceDmsg,
+		App:     "dmsgweb",
+		Running: true,
+		Layer: &Layer{
+			Listen:        "127.0.0.1:4445",
+			Suffix:        ".dmsg",
+			Upstream:      "127.0.0.1:4446",
+			UpstreamState: "skynet_web resolving proxy · running",
+			StartedAt:     &started,
+			UptimeSec:     7200,
+			Requests:      41,
+			Successful:    39,
+			Failed:        2,
+			Active:        1,
+			LastRequestAt: &last,
+			LastError:     "dial timeout",
+		},
+		Sessions: []DmsgSession{
+			{ServerPK: "0281a102c82c4bbcf7a13d5e0d9a71b3c5cbf2f0e5f3f0b0e0dcb2a3c9b13ef000", Protocol: "tcp", Addr: "1.2.3.4:8081", Streams: 3, PingMS: 12.5},
+			{ServerPK: "03f1a1b2c3d4e5f60718293a4b5c6d7e8f901a2b3c4d5e6f708192a3b4c5d6e7f0", Protocol: "quic", Addr: "5.6.7.8:8082", Streams: 0},
+		},
+		Names: &Names{
+			Kind:   "dmsg discovery (public key destinations) + configured aliases",
+			Suffix: ".dmsg",
+			Aliases: []Alias{
+				{Name: "tpd", PK: "02b7a1b2c3d4e5f60718293a4b5c6d7e8f901a2b3c4d5e6f708192a3b4c5d6e7f0"},
+			},
+		},
+	}
+}
+
+// TestRenderDmsgLayerSections proves the dmsg status page renders its
+// layer-appropriate content — liveness, uptime, chain target, sessions with FULL
+// server PKs, and the alias table — from the additive Snapshot sections.
+func TestRenderDmsgLayerSections(t *testing.T) {
+	snap := dmsgLayerSnap()
+	page := string(Render(snap))
+
+	for _, want := range []string{
+		"proxy layer",
+		"running",
+		"up 2h0m",              // uptime, compact
+		"127.0.0.1:4445",       // listener
+		"chains to",            // chain line
+		"127.0.0.1:4446",       // downstream target
+		"skynet_web resolving", // honest chain-target label
+		"dmsg sessions",
+		"2 connected",
+		"1m30s ago", // last request, humanized (compactDuration of 90s)
+		"last error: dial timeout",
+		"name resolution",
+		"tpd.dmsg", // alias rendered with the suffix appended
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("dmsg status page missing %q", want)
+		}
+	}
+
+	// PKs are NEVER truncated on a status page.
+	for _, s := range snap.Sessions {
+		if !strings.Contains(page, s.ServerPK) {
+			t.Errorf("session PK %s not rendered in full", s.ServerPK)
+		}
+	}
+
+	// No lookup cache exists, so the page must not imply one.
+	if !strings.Contains(page, "no recent-lookup history") {
+		t.Error("name-resolution section should say there is no lookup cache")
+	}
+}
+
+// TestRenderDmsgEmptyLegsDegrades proves the route-group section degrades to a
+// layer-appropriate explanation for the dmsg surface (which owns no route group
+// at all) rather than the generic "no active route group" fault reading — and
+// that it never fabricates a leg.
+func TestRenderDmsgEmptyLegsDegrades(t *testing.T) {
+	page := string(Render(dmsgLayerSnap()))
+	if !strings.Contains(page, "relays over dmsg <b>sessions</b>") {
+		t.Error("dmsg surface should explain it has no route plane, got generic empty text")
+	}
+	if strings.Contains(page, "No active route group") {
+		t.Error("dmsg surface must not use the generic empty-route-group text")
+	}
+}
+
+// TestRenderSkynetLayerSections proves the skynet page renders its own content:
+// layer summary with the skysocks chain, forwarded ports, and active conns.
+func TestRenderSkynetLayerSections(t *testing.T) {
+	snap := Snapshot{
+		Surface: SurfaceSkynet,
+		App:     "skynetweb",
+		Running: true,
+		Layer: &Layer{
+			Listen:        "127.0.0.1:4446",
+			Suffix:        ".skynet",
+			Upstream:      "127.0.0.1:1080",
+			UpstreamState: "skysocks-client · running",
+			UptimeSec:     45,
+			Requests:      7,
+		},
+		Forwards: []Forward{
+			{Port: 8080, LocalPort: 3000, Label: "web", Skynet: true},
+			{Port: 8081, Skynet: true, UDP: true}, // LocalPort defaults to Port
+		},
+		Conns: []Conn{
+			{ID: "3f2b1c00-0000-4000-8000-000000000001", Network: "skynet", LocalPort: 3000, RemotePort: 8080},
+		},
+	}
+	page := string(Render(snap))
+	for _, want := range []string{
+		"proxy layer", "up 45s", "127.0.0.1:4446",
+		"skysocks-client · running", "127.0.0.1:1080",
+		"forwarded ports", "8080", "3000", "web",
+		"active forwarded conns", "3f2b1c00-0000-4000-8000-000000000001",
+		"No active route group", // skynet CAN have a route group; it just has none now
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("skynet status page missing %q", want)
+		}
+	}
+	// A forward with no explicit local port reports the MESH port as the local
+	// one — the registry's own default (EffectiveLocalPort), not a bare zero.
+	if !strings.Contains(page, `<td class="num">8081</td><td class="num">8081</td>`) {
+		t.Error("a forward with no explicit local port should default it to the mesh port")
+	}
+}
+
+// TestRenderSkysocksUnaffected proves the additive sections are inert for the
+// skysocks surface: no layer/sessions/names/forwards blocks appear, so the
+// existing page is byte-for-byte the page it was.
+func TestRenderSkysocksUnaffected(t *testing.T) {
+	page := string(Render(Snapshot{Surface: SurfaceSkysocks, App: "skysocks-client"}))
+	for _, unwanted := range []string{"proxy layer", "dmsg sessions", "name resolution", "forwarded ports"} {
+		if strings.Contains(page, unwanted) {
+			t.Errorf("skysocks page unexpectedly grew a %q section", unwanted)
+		}
+	}
+}
+
+// TestRenderLayerStoppedAndEmpty proves the honest degraded states: a stopped
+// layer with no chain, no sessions and no aliases renders as such instead of
+// showing blanks or claiming reachability.
+func TestRenderLayerStoppedAndEmpty(t *testing.T) {
+	page := string(Render(Snapshot{
+		Surface: SurfaceDmsg,
+		Layer:   &Layer{Suffix: ".dmsg"},
+		Note:    "dmsg resolving proxy is not enabled on this visor",
+	}))
+	for _, want := range []string{
+		"stopped",
+		"nothing — ",      // no chain target configured
+		"No dmsg session", // sessions section renders its empty state
+		"not enabled on this visor",
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("stopped dmsg page missing %q", want)
+		}
+	}
+	// UpstreamState is empty, so no reachability claim may appear.
+	if strings.Contains(page, "running") {
+		t.Error("a stopped layer with no chain must not claim anything is running")
+	}
+}
+
+func TestCompactDuration(t *testing.T) {
+	cases := map[int64]string{0: "0s", 45: "45s", 60: "1m0s", 90: "1m30s", 3599: "59m59s", 3600: "1h0m", 7380: "2h3m", 86400: "1d0h", 187200: "2d4h"}
+	for sec, want := range cases {
+		if got := compactDuration(sec); got != want {
+			t.Errorf("compactDuration(%d) = %q, want %q", sec, got, want)
+		}
+	}
+}
+
+func TestAgoOrDash(t *testing.T) {
+	if got := agoOrDash(nil); got != "-" {
+		t.Errorf("agoOrDash(nil) = %q, want %q", got, "-")
+	}
+	var zero time.Time
+	if got := agoOrDash(&zero); got != "-" {
+		t.Errorf("agoOrDash(zero) = %q, want %q", got, "-")
+	}
+	// A future timestamp (clock skew) clamps to 0 rather than printing a negative.
+	fut := time.Now().Add(time.Hour)
+	if got := agoOrDash(&fut); got != "0s ago" {
+		t.Errorf("agoOrDash(future) = %q, want %q", got, "0s ago")
+	}
+}

--- a/pkg/proxystatus/provider.go
+++ b/pkg/proxystatus/provider.go
@@ -29,6 +29,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // Surface identifies which proxy a status page describes. The string value is
@@ -61,8 +62,8 @@ type Leg struct {
 	LatencyMS      float64
 	RouteLatencyMS float64
 	Direct         bool
-	SentBytes uint64
-	RecvBytes uint64
+	SentBytes      uint64
+	RecvBytes      uint64
 	// DupBytes is inbound DUPLICATE data (seqs already delivered/buffered when
 	// they arrived on this leg) — the peer's spurious retransmits, which ride
 	// the fastest leg and otherwise read as payload; RepairBytes is inbound FEC
@@ -135,7 +136,102 @@ type Snapshot struct {
 	// non-skysocks surface, or a skysocks client with the feature disabled). It
 	// makes "is range-split firing" a readable field rather than a log line.
 	RangeSplit *RangeSplit `json:"range_split,omitempty"`
-	Note       string      // optional human note (e.g. why a section is empty)
+	// Layer is the RESOLVING-PROXY layer summary — liveness/uptime, the listener
+	// and domain suffix it answers for, its request counters and the downstream
+	// SOCKS5 it chains to. Populated for the dmsg_web / skynet_web surfaces, whose
+	// interesting state is the layer itself rather than a route group; nil for a
+	// surface with no such layer (skysocks, whose tunnel state is Legs/Streams).
+	Layer *Layer `json:"layer,omitempty"`
+	// Sessions is the dmsg client's established sessions to dmsg servers — the
+	// dmsg surface's answer to "what am I actually connected through". Empty for
+	// every other surface (they do not relay over dmsg sessions).
+	Sessions []DmsgSession `json:"sessions,omitempty"`
+	// Names is the layer's name-resolution state: which resolver answers a
+	// <name><suffix> lookup and the aliases actually configured on it. There is no
+	// lookup CACHE in either resolving proxy today, so no "recent lookups" list is
+	// invented here — only the resolution machinery that exists is surfaced.
+	Names *Names `json:"names,omitempty"`
+	// Forwards is what this visor exposes to the mesh through the surface's
+	// forwarding plane (skynet surface: the registered forwarded ports). Empty
+	// when nothing is forwarded, or for a surface with no forwarding plane.
+	Forwards []Forward `json:"forwards,omitempty"`
+	// Conns is the surface's active raw forwarded connections with their metered
+	// port pairs — the conn-level view for layers that have no route-group Legs.
+	Conns []Conn `json:"conns,omitempty"`
+	Note  string // optional human note (e.g. why a section is empty)
+}
+
+// Layer is the live state of one resolving-proxy layer (dmsg_web on :4445,
+// skynet_web on :4446). Every field is read from what the layer itself already
+// tracks — its Stats counters (uptime, requests, last error) and its config
+// (listener, suffix, upstream) — so nothing here is estimated.
+type Layer struct {
+	Listen string `json:"listen,omitempty"` // SOCKS5 listener the layer binds, e.g. "127.0.0.1:4445"
+	Suffix string `json:"suffix,omitempty"` // domain suffix it resolves, e.g. ".dmsg"
+	// Upstream is the DOWNSTREAM chain target: the SOCKS5 a non-matching CONNECT
+	// is forwarded to (dmsg_web → skynet_web → skysocks-client). Empty when the
+	// layer terminates the chain.
+	Upstream string `json:"upstream,omitempty"`
+	// UpstreamState is an honest, non-probing label for the chain target's
+	// liveness — derived from what the visor already knows about the process or
+	// runtime behind that address (e.g. "skynet_web running"). Empty when the
+	// address belongs to something the visor cannot vouch for; the page then shows
+	// the address alone rather than claiming reachability it did not verify.
+	UpstreamState string     `json:"upstream_state,omitempty"`
+	StartedAt     *time.Time `json:"started_at,omitempty"`
+	UptimeSec     int64      `json:"uptime_sec,omitempty"`
+	Requests      uint64     `json:"requests"`
+	Successful    uint64     `json:"successful"`
+	Failed        uint64     `json:"failed"`
+	Active        int64      `json:"active"` // requests in flight right now
+	LastRequestAt *time.Time `json:"last_request_at,omitempty"`
+	LastError     string     `json:"last_error,omitempty"`
+}
+
+// DmsgSession is one established dmsg client session to a dmsg server. PKs are
+// FULL, never truncated. Streams is the session's live stream count; PingMS is
+// the last measured session RTT (0 when never pinged).
+type DmsgSession struct {
+	ServerPK string  `json:"server_pk"`
+	Protocol string  `json:"protocol,omitempty"` // carrier label (tcp / quic / ws / wt)
+	Addr     string  `json:"addr,omitempty"`     // the carrier address the session rides
+	Streams  int     `json:"streams"`
+	PingMS   float64 `json:"ping_ms,omitempty"`
+}
+
+// Names describes a layer's name resolution. Kind names the resolver in use;
+// Aliases are the name→PK bindings the layer was configured with (service
+// aliases, the visor's own alias, dmsg-server aliases) — the only resolution
+// state that is actually stored.
+type Names struct {
+	Kind    string  `json:"kind,omitempty"`
+	Suffix  string  `json:"suffix,omitempty"`
+	Aliases []Alias `json:"aliases,omitempty"`
+}
+
+// Alias is one configured name→PK binding, e.g. "tpd" → the TPD's public key.
+type Alias struct {
+	Name string `json:"name"`
+	PK   string `json:"pk"`
+}
+
+// Forward is one port this visor exposes to the mesh. Port is the mesh-side
+// port; LocalPort is the loopback port it forwards to.
+type Forward struct {
+	Port      int    `json:"port"`
+	LocalPort int    `json:"local_port,omitempty"`
+	Label     string `json:"label,omitempty"`
+	Skynet    bool   `json:"skynet,omitempty"`
+	DMSG      bool   `json:"dmsg,omitempty"`
+	UDP       bool   `json:"udp,omitempty"`
+}
+
+// Conn is one active raw forwarded connection through the surface.
+type Conn struct {
+	ID         string `json:"id"`
+	Network    string `json:"network,omitempty"`
+	LocalPort  int    `json:"local_port,omitempty"`
+	RemotePort int    `json:"remote_port,omitempty"`
 }
 
 // RangeSplit is the live range-split summary for the skysocks surface. It is

--- a/pkg/proxystatus/proxystatus_test.go
+++ b/pkg/proxystatus/proxystatus_test.go
@@ -268,8 +268,12 @@ func TestRenderEscapes(t *testing.T) {
 	}
 }
 
+// TestRenderEmptyMux covers the generic empty-route-group note, on a surface
+// that CAN hold a route group and simply has none right now. The dmsg surface
+// owns no route plane at all and gets its own wording — see
+// TestRenderDmsgEmptyLegsDegrades.
 func TestRenderEmptyMux(t *testing.T) {
-	snap := Snapshot{Surface: SurfaceDmsg, App: "dmsgweb"}
+	snap := Snapshot{Surface: SurfaceSkynet, App: "skynetweb"}
 	page := string(Render(snap))
 	if !strings.Contains(page, "No active route group") {
 		t.Error("empty-mux note missing")

--- a/pkg/proxystatus/render.go
+++ b/pkg/proxystatus/render.go
@@ -281,10 +281,205 @@ func writeLiveRegion(b *strings.Builder, snap Snapshot) {
 		fmt.Fprintf(b, `<p class="note">%s</p>`, html.EscapeString(snap.Note))
 	}
 
+	// Layer-appropriate sections first: for the two RESOLVING proxies these carry
+	// the page's substance (liveness, chain, sessions, names, forwards) while the
+	// route-group tree below is legitimately empty. Each is a no-op when its
+	// section of the Snapshot is unset, so the skysocks page is unchanged.
+	writeLayerSection(b, snap)
+	writeSessionsSection(b, snap)
+	writeNamesSection(b, snap)
+	writeForwardsSection(b, snap)
+	writeConnsSection(b, snap)
+
 	writeStreamsSection(b, snap)
 	writeRangeSplitSection(b, snap)
 	writeMuxSection(b, snap)
 	writeLogSection(b, snap)
+}
+
+// writeLayerSection renders the resolving-proxy layer summary: a liveness pill,
+// uptime, the listener/suffix it answers for, the downstream chain target and the
+// request counters the layer's own Stats already track. Omitted entirely for a
+// surface with no Layer (skysocks), so the existing page is untouched.
+func writeLayerSection(b *strings.Builder, snap Snapshot) {
+	l := snap.Layer
+	if l == nil {
+		return
+	}
+	b.WriteString(`<section><h2>proxy layer</h2>`)
+	state, cls := "stopped", "pill-down"
+	if snap.Running {
+		state, cls = "running", "pill-up"
+	}
+	fmt.Fprintf(b, `<p class="layer"><span class="pill %s">%s</span>`, cls, state)
+	if l.UptimeSec > 0 {
+		fmt.Fprintf(b, ` <span class="lmeta">up %s</span>`, html.EscapeString(compactDuration(l.UptimeSec)))
+	}
+	if l.Listen != "" {
+		fmt.Fprintf(b, ` <span class="lmeta">listening <code>%s</code></span>`, html.EscapeString(l.Listen))
+	}
+	if l.Suffix != "" {
+		fmt.Fprintf(b, ` <span class="lmeta">resolves <code>%s</code></span>`, html.EscapeString(l.Suffix))
+	}
+	b.WriteString(`</p>`)
+
+	// The chain line. UpstreamState is only ever set when the visor could vouch
+	// for what sits behind the address; otherwise the address stands alone rather
+	// than implying a reachability check that never happened.
+	if l.Upstream != "" {
+		fmt.Fprintf(b, `<p class="layer"><b>chains to</b> <code>%s</code>`, html.EscapeString(l.Upstream))
+		if l.UpstreamState != "" {
+			fmt.Fprintf(b, ` <span class="lmeta">%s</span>`, html.EscapeString(l.UpstreamState))
+		}
+		b.WriteString(`</p>`)
+	} else {
+		b.WriteString(`<p class="layer"><b>chains to</b> <span class="lmeta">nothing — ` +
+			`non-matching requests are refused here</span></p>`)
+	}
+
+	b.WriteString(`<table class="strm"><thead><tr>` +
+		`<th class="num">requests</th><th class="num">ok</th><th class="num">failed</th>` +
+		`<th class="num">in flight</th><th>last request</th></tr></thead><tbody><tr>`)
+	fmt.Fprintf(b, `<td class="num">%d</td><td class="num ok">%d</td><td class="num warn">%d</td>`+
+		`<td class="num">%d</td><td>%s</td></tr></tbody></table>`,
+		l.Requests, l.Successful, l.Failed, l.Active, html.EscapeString(agoOrDash(l.LastRequestAt)))
+	if l.LastError != "" {
+		fmt.Fprintf(b, `<p class="note">last error: %s</p>`, html.EscapeString(l.LastError))
+	}
+	b.WriteString(`</section>`)
+}
+
+// writeSessionsSection renders the dmsg client's established server sessions —
+// the dmsg surface's real "am I connected" answer. Server PKs are full and
+// click-to-copy. Omitted when the surface tracks no dmsg sessions.
+func writeSessionsSection(b *strings.Builder, snap Snapshot) {
+	// Rendered (including its "none connected" state, which is the interesting
+	// case) only for the dmsg surface with a populated layer — no other surface
+	// relays over dmsg sessions.
+	if snap.Surface != SurfaceDmsg || snap.Layer == nil {
+		return
+	}
+	fmt.Fprintf(b, `<section><h2>dmsg sessions <small>%d connected</small></h2>`, len(snap.Sessions))
+	if len(snap.Sessions) == 0 {
+		b.WriteString(`<p class="empty">No dmsg session established. A <code>.dmsg</code> lookup ` +
+			`cannot resolve until the client holds at least one session to a dmsg server.</p></section>`)
+		return
+	}
+	b.WriteString(`<table class="strm"><thead><tr><th>dmsg server</th><th>carrier</th><th>addr</th>` +
+		`<th class="num">streams</th><th class="num">rtt</th></tr></thead><tbody>`)
+	for _, s := range snap.Sessions {
+		fmt.Fprintf(b, `<tr><td>%s</td><td>%s</td><td>%s</td><td class="num">%d</td><td class="num rtt">%s</td></tr>`,
+			copyablePK(s.ServerPK), html.EscapeString(orDash(s.Protocol)), html.EscapeString(orDash(s.Addr)),
+			s.Streams, html.EscapeString(routeRTTCompact(s.PingMS)))
+	}
+	b.WriteString(`</tbody></table></section>`)
+}
+
+// writeNamesSection renders the layer's name resolution: which resolver answers
+// and the aliases it was configured with. Deliberately does NOT claim a lookup
+// history — neither resolving proxy caches lookups, so there is none to show.
+func writeNamesSection(b *strings.Builder, snap Snapshot) {
+	n := snap.Names
+	if n == nil {
+		return
+	}
+	b.WriteString(`<section><h2>name resolution</h2>`)
+	fmt.Fprintf(b, `<p class="layer"><b>%s</b>`, html.EscapeString(orDash(n.Kind)))
+	if n.Suffix != "" {
+		fmt.Fprintf(b, ` <span class="lmeta">for <code>&lt;name&gt;%s</code></span>`, html.EscapeString(n.Suffix))
+	}
+	b.WriteString(`</p>`)
+	if len(n.Aliases) == 0 {
+		b.WriteString(`<p class="empty">No name aliases configured; every lookup must spell the ` +
+			`destination public key in full.</p></section>`)
+		return
+	}
+	b.WriteString(`<table class="strm"><thead><tr><th>name</th><th>public key</th></tr></thead><tbody>`)
+	for _, a := range n.Aliases {
+		fmt.Fprintf(b, `<tr><td><code>%s%s</code></td><td>%s</td></tr>`,
+			html.EscapeString(a.Name), html.EscapeString(n.Suffix), copyablePK(a.PK))
+	}
+	b.WriteString(`</tbody></table>`)
+	b.WriteString(`<p class="hint">Lookups are resolved per request; neither resolving proxy keeps a ` +
+		`lookup cache, so there is no recent-lookup history to show.</p></section>`)
+}
+
+// writeForwardsSection renders what this visor exposes to the mesh through the
+// surface's forwarding plane. Omitted when the surface has none.
+func writeForwardsSection(b *strings.Builder, snap Snapshot) {
+	if snap.Surface != SurfaceSkynet || snap.Layer == nil {
+		return
+	}
+	fmt.Fprintf(b, `<section><h2>forwarded ports <small>%d</small></h2>`, len(snap.Forwards))
+	if len(snap.Forwards) == 0 {
+		b.WriteString(`<p class="empty">No port is forwarded over skynet from this visor.</p></section>`)
+		return
+	}
+	b.WriteString(`<table class="strm"><thead><tr><th class="num">mesh port</th><th class="num">local port</th>` +
+		`<th>label</th><th>planes</th></tr></thead><tbody>`)
+	for _, f := range snap.Forwards {
+		local := f.LocalPort
+		if local == 0 {
+			local = f.Port // the registry defaults local to the mesh port
+		}
+		var planes []string
+		if f.Skynet {
+			planes = append(planes, "skynet")
+		}
+		if f.DMSG {
+			planes = append(planes, "dmsg")
+		}
+		if f.UDP {
+			planes = append(planes, "udp")
+		}
+		fmt.Fprintf(b, `<tr><td class="num">%d</td><td class="num">%d</td><td>%s</td><td>%s</td></tr>`,
+			f.Port, local, html.EscapeString(orDash(f.Label)), html.EscapeString(orDash(strings.Join(planes, " · "))))
+	}
+	b.WriteString(`</tbody></table></section>`)
+}
+
+// writeConnsSection renders the surface's active raw forwarded connections.
+// Omitted when none are open, so an idle page stays short.
+func writeConnsSection(b *strings.Builder, snap Snapshot) {
+	if len(snap.Conns) == 0 {
+		return
+	}
+	fmt.Fprintf(b, `<section><h2>active forwarded conns <small>%d</small></h2>`, len(snap.Conns))
+	b.WriteString(`<table class="strm"><thead><tr><th>id</th><th>network</th>` +
+		`<th class="num">local port</th><th class="num">remote port</th></tr></thead><tbody>`)
+	for _, c := range snap.Conns {
+		fmt.Fprintf(b, `<tr><td>%s</td><td>%s</td><td class="num">%d</td><td class="num">%d</td></tr>`,
+			copyableID(c.ID, "conn id"), html.EscapeString(orDash(c.Network)), c.LocalPort, c.RemotePort)
+	}
+	b.WriteString(`</tbody></table></section>`)
+}
+
+// compactDuration renders an uptime in seconds as a short human string
+// (45s / 12m / 3h14m / 2d5h) — the same terse shape compactAge uses for ms.
+func compactDuration(sec int64) string {
+	if sec < 60 {
+		return fmt.Sprintf("%ds", sec)
+	}
+	if sec < 3600 {
+		return fmt.Sprintf("%dm%ds", sec/60, sec%60)
+	}
+	if sec < 86400 {
+		return fmt.Sprintf("%dh%dm", sec/3600, (sec%3600)/60)
+	}
+	return fmt.Sprintf("%dd%dh", sec/86400, (sec%86400)/3600)
+}
+
+// agoOrDash renders "<compact> ago" for a set timestamp, "-" for nil — so a
+// layer that has never served a request says so instead of showing a zero time.
+func agoOrDash(t *time.Time) string {
+	if t == nil || t.IsZero() {
+		return "-"
+	}
+	d := time.Since(*t)
+	if d < 0 {
+		d = 0
+	}
+	return compactDuration(int64(d.Seconds())) + " ago"
 }
 
 // writeRangeSplitSection renders the transparent HTTP range-split summary when
@@ -321,6 +516,16 @@ func writeRangeSplitSection(b *strings.Builder, snap Snapshot) {
 // no-JS analog of the `cli proxy mux plot` panel.
 func writeMuxSection(b *strings.Builder, snap Snapshot) {
 	if len(snap.Legs) == 0 {
+		// The dmsg surface has no route groups AT ALL — it relays over dmsg
+		// sessions, not the route plane — so saying "no active route group" there
+		// would read as a fault. Name the reason instead of faking legs.
+		if snap.Surface == SurfaceDmsg {
+			b.WriteString(`<section><h2>route group · per-leg mux</h2>`)
+			b.WriteString(`<p class="empty">The dmsg resolving proxy relays over dmsg <b>sessions</b>, ` +
+				`not the route plane, so it has no route group or mux legs. See the dmsg sessions ` +
+				`above.</p></section>`)
+			return
+		}
 		b.WriteString(`<section><h2>route group · per-leg mux</h2>`)
 		b.WriteString(`<p class="empty">No active route group for this surface right now. ` +
 			`A leg appears here once a route to a destination is warm.</p></section>`)
@@ -1067,6 +1272,18 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#a2a8cc;--accent:#7c83ff;--
 	`@keyframes pulse{0%,100%{opacity:1}50%{opacity:.35}}` +
 	`h2{font-size:.95rem;margin:1.6rem 0 .5rem;color:#e7e9ff;font-weight:600}h2 small{color:var(--muted);font-weight:400;font-size:11px;margin-left:.4rem}` +
 	`.note{color:var(--standby)}.empty,.hint{color:var(--muted);font-size:12px}` +
+	// Pills: the small state badges used by the layer summary and the range-split
+	// line (which used .pill/.rs-* before any rule defined them). Colors come from
+	// the same tokens as everything else, so both schemes stay legible.
+	`.pill{display:inline-block;padding:.05rem .45rem;border-radius:999px;font-size:10.5px;` +
+	`text-transform:uppercase;letter-spacing:.4px;border:1px solid var(--line);color:var(--muted)}` +
+	`.pill-up,.rs-active{color:var(--ok);border-color:var(--ok)}` +
+	`.pill-down{color:var(--warn);border-color:var(--warn)}` +
+	`.rs-idle{color:var(--muted)}` +
+	`.rsplit,.layer{margin:.35rem 0;font-size:12.5px}` +
+	`.rsagg,.lmeta{color:var(--muted);font-size:11.5px;margin-left:.5rem}` +
+	`.layer code{font-family:'Mononoki',ui-monospace,SFMono-Regular,monospace;font-size:11.5px;color:var(--fg)}` +
+	`td.ok{color:var(--ok)}td.warn{color:var(--warn)}` +
 	`.bar{display:block;height:.6rem;border-radius:3px;background:var(--accent);min-width:2px}` +
 	`.bar.ok{background:var(--ok)}.bar.standby{background:var(--standby)}.bar.warn{background:var(--warn)}` +
 	`.bar.recv{background:var(--recv,#3b9)}` +

--- a/pkg/skynetweb/status_scoping_test.go
+++ b/pkg/skynetweb/status_scoping_test.go
@@ -78,6 +78,19 @@ func TestSOCKS5StatusScoping(t *testing.T) {
 	if !contains(dmsgBody, "upstream-sink") || contains(dmsgBody, "per-leg mux") {
 		t.Fatalf("status.dmsg should have fallen through to upstream: %q", truncate(dmsgBody))
 	}
+
+	// Chain composition: this layer sits between dmsgweb and skysocks, so the
+	// skysocks status host must pass straight through to the layer that owns it.
+	skysocksBody := getBody(t, httpc, "http://status.skysocks/")
+	if !contains(skysocksBody, "upstream-sink") || contains(skysocksBody, "per-leg mux") {
+		t.Fatalf("status.skysocks should have fallen through to upstream: %q", truncate(skysocksBody))
+	}
+
+	// An ordinary host is untouched by the status interception.
+	plainBody := getBody(t, httpc, "http://example.com/")
+	if !contains(plainBody, "upstream-sink") || contains(plainBody, "per-leg mux") {
+		t.Fatalf("a non-status host should forward upstream untouched: %q", truncate(plainBody))
+	}
 }
 
 func getBody(t *testing.T, httpc *http.Client, url string) string {

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -211,6 +211,38 @@ func (e *EmbeddedDmsgWeb) Upstream() string {
 	return e.cfg.UpstreamSOCKS
 }
 
+// ListenAddr returns the SOCKS5 listener the resolver binds, resolved the same
+// way serve() does (loopback default, default port). Read by the status page so
+// it names the listener the browser actually reached it through.
+func (e *EmbeddedDmsgWeb) ListenAddr() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return resolverListenAddr(e.cfg.ProxyAddr, uintOrDefault(e.cfg.ProxyPort, defaultDmsgWebProxyPort))
+}
+
+// Suffix returns the domain suffix the resolver answers for (".dmsg").
+func (e *EmbeddedDmsgWeb) Suffix() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return stringOrDefault(e.cfg.DomainSuffix, dmsgweb.DefaultDomainSuffix)
+}
+
+// Aliases returns the name→PK bindings the resolver resolves by name — the
+// canonical service aliases plus this visor's own alias on top, exactly the
+// merge serve() hands to the runtime. The returned map is a copy.
+func (e *EmbeddedDmsgWeb) Aliases() map[string]cipher.PubKey {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make(map[string]cipher.PubKey, len(e.serviceAliases)+1)
+	for label, pk := range e.serviceAliases {
+		out[label] = pk
+	}
+	for label, pk := range resolverAliasMap(e.cfg.Alias, e.localPK) {
+		out[label] = pk
+	}
+	return out
+}
+
 func (e *EmbeddedDmsgWeb) serve(ctx context.Context) {
 	cfg := dmsgweb.Config{
 		DomainSuffix:  stringOrDefault(e.cfg.DomainSuffix, dmsgweb.DefaultDomainSuffix),

--- a/pkg/visor/embedded_proxystatus.go
+++ b/pkg/visor/embedded_proxystatus.go
@@ -20,13 +20,19 @@ package visor
 
 import (
 	"fmt"
+	"net"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsgweb"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/proxystatus"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/skynetweb"
 )
 
 // statusLogLookback bounds how far back the status page's log tail reaches. The
@@ -109,20 +115,42 @@ func (p *visorStatusProvider) StatusSnapshot(surface proxystatus.Surface) (proxy
 	// Logs: prefer the richer scoped log captured in the ring (app stdout +
 	// tagged lifecycle). Fall back to the app's bbolt log store when the ring
 	// has nothing yet, so an idle-but-previously-run surface still shows a tail.
+	// The procM guard matters: LogsSince dereferences the proc manager, and a
+	// status page must still render on a half-initialized visor (the exact case
+	// an operator hits one) rather than panicking on the request path.
 	if len(ringLogs) > 0 {
 		snap.Logs = tailRecordLines(ringLogs, statusMaxLogLines)
-	} else if logs, err := p.v.LogsSince(time.Now().Add(-statusLogLookback), app); err == nil {
-		snap.Logs = logs
-	} else {
-		snap.Note = appendNote(snap.Note, "logs unavailable: "+err.Error())
+	} else if p.v.procM != nil {
+		if logs, err := p.v.LogsSince(time.Now().Add(-statusLogLookback), app); err == nil {
+			snap.Logs = logs
+		} else {
+			snap.Note = appendNote(snap.Note, "logs unavailable: "+err.Error())
+		}
+	}
+
+	// Layer sections: for the two RESOLVING proxies the page's substance is the
+	// layer itself (liveness, chain, sessions, names, forwards), not a route
+	// group — they own no mux legs, and the renderer degrades to a layer-specific
+	// note rather than an empty leg table. Filled from what each layer already
+	// tracks; nothing is fabricated for a layer that does not know it.
+	switch surface {
+	case proxystatus.SurfaceDmsg:
+		p.fillDmsgLayer(&snap)
+	case proxystatus.SurfaceSkynet:
+		p.fillSkynetLayer(&snap)
+	case proxystatus.SurfaceSkysocks:
+		// The skysocks tunnel's state is Legs/Streams/RangeSplit — no layer section.
 	}
 
 	// Mux legs (best-effort): the surface may have no active route group. Each
 	// route group is one --tunnels STREAM; its Legs are the PACKET-level mux. Model
 	// every tunnel (not just the first) so the status tree can nest tunnel → legs;
 	// mirror the first tunnel's legs into snap.Legs for back-compat.
-	self := p.v.conf.PK
-	snap.SelfPK = self.String()
+	var self cipher.PubKey
+	if p.v.conf != nil && p.v.conf.Common != nil {
+		self = p.v.conf.PK
+		snap.SelfPK = self.String()
+	}
 	if infos, err := p.v.RouteGroupMuxInfo(app); err == nil {
 		for ti, info := range infos {
 			// The exit is the descriptor end that is NOT this visor. A client route
@@ -155,6 +183,231 @@ func (p *visorStatusProvider) StatusSnapshot(surface proxystatus.Surface) (proxy
 	// yet collected into a per-surface buffer; the renderer shows an empty
 	// section. This is the extension point that pairs with route control.
 	return snap, nil
+}
+
+// resolverListenAddr renders a resolving proxy's SOCKS5 listener the way its
+// runtime binds it: an empty ProxyAddr means loopback, and a zero port means the
+// SOCKS5 front-end is disabled (rendered as empty, never as ":0").
+func resolverListenAddr(addr string, port uint) string {
+	if port == 0 {
+		return ""
+	}
+	if strings.TrimSpace(addr) == "" {
+		addr = "127.0.0.1"
+	}
+	return fmt.Sprintf("%s:%d", addr, port)
+}
+
+// chainTargetState labels what the visor KNOWS sits behind a downstream SOCKS5
+// address, so the status page can say "skysocks-client · running" instead of
+// implying it probed the address. Returns "" when the address belongs to
+// something this visor cannot vouch for — the page then shows the bare address.
+//
+// WHY no dial probe: the page renders on the request path of the very proxy the
+// browser is talking through, and the js/wasm visor's chain rides a vnet where a
+// raw TCP dial is meaningless. A claim derived from process state is honest in
+// both builds; a half-second dial is neither cheap nor portable.
+func (p *visorStatusProvider) chainTargetState(addr string) string {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return ""
+	}
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return ""
+	}
+	if rt := p.v.embeddedSkynetWeb; rt != nil {
+		if _, p2, e := net.SplitHostPort(rt.ListenAddr()); e == nil && p2 == port {
+			return "skynet_web resolving proxy · " + runLabel(rt.IsRunning())
+		}
+	}
+	if rt := p.v.embeddedDmsgWeb; rt != nil {
+		if _, p2, e := net.SplitHostPort(rt.ListenAddr()); e == nil && p2 == port {
+			return "dmsg_web resolving proxy · " + runLabel(rt.IsRunning())
+		}
+	}
+	// skysocks-client binds SkysocksClientAddr (":1080"), so its port alone
+	// identifies it; the client is a managed app, so procM knows its liveness.
+	if _, p2, e := net.SplitHostPort("0.0.0.0" + skyenv.SkysocksClientAddr); e == nil && p2 == port {
+		running := false
+		if p.v.procM != nil {
+			proc, ok := p.v.procM.ProcByName(skyenv.SkysocksClientName)
+			running = ok && proc != nil
+		}
+		return "skysocks-client · " + runLabel(running)
+	}
+	return ""
+}
+
+// listForwardedPortsSafe is ListForwardedPorts with the registry-not-yet-built
+// case folded in: a half-initialized visor reports "no forwards" instead of
+// panicking on the status page's request path.
+func (v *Visor) listForwardedPortsSafe() ([]ForwardedPort, error) {
+	if v.forwardedPorts == nil {
+		return nil, nil
+	}
+	return v.ListForwardedPorts()
+}
+
+func runLabel(running bool) string {
+	if running {
+		return "running"
+	}
+	return "stopped"
+}
+
+// layerFromStats projects a resolving proxy's own Stats counters into the shared
+// proxystatus.Layer shape. Both resolvers keep structurally identical Stats, so
+// the two callers differ only in the fields they add around this.
+func layerFromStats(listen, suffix, upstream string, started time.Time, uptimeSec int64,
+	total, ok, failed uint64, active int64, lastReq *time.Time, lastErr string) *proxystatus.Layer {
+	l := &proxystatus.Layer{
+		Listen:        listen,
+		Suffix:        suffix,
+		Upstream:      upstream,
+		UptimeSec:     uptimeSec,
+		Requests:      total,
+		Successful:    ok,
+		Failed:        failed,
+		Active:        active,
+		LastRequestAt: lastReq,
+		LastError:     lastErr,
+	}
+	if !started.IsZero() {
+		t := started
+		l.StartedAt = &t
+	}
+	return l
+}
+
+// aliasList renders a resolver's name→PK map as a stable, name-sorted list of
+// full (never truncated) keys.
+func aliasList(m map[string]cipher.PubKey) []proxystatus.Alias {
+	if len(m) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]proxystatus.Alias, 0, len(names))
+	for _, name := range names {
+		out = append(out, proxystatus.Alias{Name: name, PK: m[name].String()})
+	}
+	return out
+}
+
+// fillDmsgLayer populates the dmsg resolving proxy's sections: its layer summary
+// (uptime + request counters from the runtime's own Stats, listener, suffix,
+// downstream chain), the dmsg client's established server sessions, and the
+// name-resolution state. Every value comes from something the layer already
+// keeps — no lookup history is invented, because neither resolver caches one.
+func (p *visorStatusProvider) fillDmsgLayer(snap *proxystatus.Snapshot) {
+	rt := p.v.embeddedDmsgWeb
+	if rt != nil {
+		snap.Running = rt.IsRunning()
+		st := rt.Stats()
+		upstream := rt.Upstream()
+		snap.Layer = layerFromStats(rt.ListenAddr(), rt.Suffix(), upstream,
+			st.StartedAt, st.UptimeSec, st.TotalRequests, st.Successful, st.Failed,
+			st.Active, st.LastRequestAt, st.LastError)
+		snap.Layer.UpstreamState = p.chainTargetState(upstream)
+		snap.Names = &proxystatus.Names{
+			Kind:    "dmsg discovery (public key destinations) + configured aliases",
+			Suffix:  rt.Suffix(),
+			Aliases: aliasList(rt.Aliases()),
+		}
+	} else {
+		// The runtime is not constructed (resolver disabled): still render a layer
+		// section so the page says "stopped" rather than showing nothing at all.
+		snap.Layer = &proxystatus.Layer{Suffix: dmsgweb.DefaultDomainSuffix}
+		snap.Note = appendNote(snap.Note, "dmsg resolving proxy is not enabled on this visor")
+	}
+
+	// dmsg sessions are the dmsg layer's real transport state: without one, no
+	// .dmsg name can resolve. Read from the visor's dmsg client directly.
+	if p.v.dmsgC == nil {
+		return
+	}
+	for _, ses := range p.v.dmsgC.AllSessions() {
+		s := proxystatus.DmsgSession{
+			ServerPK: ses.RemotePK().String(),
+			Protocol: ses.Protocol(),
+			Streams:  ses.NumStreams(),
+		}
+		if a := ses.RemoteTCPAddr(); a != nil {
+			s.Addr = a.String()
+		}
+		if d := ses.LastPing(); d > 0 {
+			s.PingMS = float64(d) / float64(time.Millisecond)
+		}
+		snap.Sessions = append(snap.Sessions, s)
+	}
+	sort.Slice(snap.Sessions, func(i, j int) bool { return snap.Sessions[i].ServerPK < snap.Sessions[j].ServerPK })
+}
+
+// fillSkynetLayer populates the skynet resolving proxy's sections: its layer
+// summary and upstream chain (the skysocks-client it hands clearnet traffic to),
+// the ports this visor forwards over skynet, and the raw forwarded conns open
+// through the skynet plane right now.
+func (p *visorStatusProvider) fillSkynetLayer(snap *proxystatus.Snapshot) {
+	rt := p.v.embeddedSkynetWeb
+	if rt != nil {
+		snap.Running = rt.IsRunning()
+		st := rt.Stats()
+		upstream := rt.Upstream()
+		snap.Layer = layerFromStats(rt.ListenAddr(), rt.Suffix(), upstream,
+			st.StartedAt, st.UptimeSec, st.TotalRequests, st.Successful, st.Failed,
+			st.Active, st.LastRequestAt, st.LastError)
+		snap.Layer.UpstreamState = p.chainTargetState(upstream)
+		snap.Names = &proxystatus.Names{
+			Kind:    "skynet route plane (public key destinations) + configured aliases",
+			Suffix:  rt.Suffix(),
+			Aliases: aliasList(rt.Aliases()),
+		}
+	} else {
+		snap.Layer = &proxystatus.Layer{Suffix: skynetweb.DefaultDomainSuffix}
+		snap.Note = appendNote(snap.Note, "skynet resolving proxy is not enabled on this visor")
+	}
+
+	// Forwarded ports: what this visor exposes to the mesh over skynet. Only the
+	// skynet-plane entries belong on the skynet page.
+	if fps, err := p.v.listForwardedPortsSafe(); err == nil {
+		for _, f := range fps {
+			if !f.Skynet {
+				continue
+			}
+			snap.Forwards = append(snap.Forwards, proxystatus.Forward{
+				Port:      f.Port,
+				LocalPort: f.LocalPort,
+				Label:     f.Label,
+				Skynet:    f.Skynet,
+				DMSG:      f.DMSG,
+				UDP:       f.UDP,
+			})
+		}
+		sort.Slice(snap.Forwards, func(i, j int) bool { return snap.Forwards[i].Port < snap.Forwards[j].Port })
+	} else {
+		snap.Note = appendNote(snap.Note, "forwarded ports unavailable: "+err.Error())
+	}
+
+	// Active raw forwarded conns through the skynet plane, with their metered
+	// port pairs — the conn-level view standing in for route-group legs.
+	if conns, err := p.v.ListRawTCP(); err == nil {
+		for id, c := range conns {
+			if c == nil || !strings.EqualFold(c.Network, "skynet") {
+				continue
+			}
+			snap.Conns = append(snap.Conns, proxystatus.Conn{
+				ID:         id.String(),
+				Network:    c.Network,
+				LocalPort:  c.LocalPort,
+				RemotePort: c.RemotePort,
+			})
+		}
+		sort.Slice(snap.Conns, func(i, j int) bool { return snap.Conns[i].ID < snap.Conns[j].ID })
+	}
 }
 
 func appendNote(existing, add string) string {

--- a/pkg/visor/embedded_proxystatus_layer_test.go
+++ b/pkg/visor/embedded_proxystatus_layer_test.go
@@ -1,0 +1,196 @@
+package visor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/proxystatus"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// testPK is a deterministic, FULL public key for alias assertions.
+func testPK(t *testing.T) cipher.PubKey {
+	t.Helper()
+	pk, _ := cipher.GenerateKeyPair()
+	return pk
+}
+
+// TestStatusSnapshotDmsgLayer proves the dmsg surface's snapshot is populated
+// from the embedded runtime itself — listener, suffix, chain target and the
+// runtime's own Stats — and that the chain target is labeled from what the visor
+// KNOWS sits behind it (the skynet_web runtime on that port) rather than probed.
+func TestStatusSnapshotDmsgLayer(t *testing.T) {
+	pk := testPK(t)
+	log := logging.MustGetLogger("test")
+	ctx := context.Background()
+
+	v := &Visor{conf: &visorconfig.V1{Common: &visorconfig.Common{PK: pk}}}
+	v.embeddedDmsgWeb = newEmbeddedDmsgWeb(ctx, nil, nil, pk, nil, nil,
+		map[string]cipher.PubKey{"tpd": pk}, nil,
+		&visorconfig.DmsgWebConfig{Enable: true, UpstreamSOCKS: "127.0.0.1:4446"}, log)
+	v.embeddedSkynetWeb = newEmbeddedSkynetWeb(ctx, nil, nil, &v.skynetFwdMux, pk, nil, nil,
+		&visorconfig.SkynetWebConfig{Enable: true}, log)
+
+	snap, err := v.proxyStatusProvider().StatusSnapshot(proxystatus.SurfaceDmsg)
+	if err != nil {
+		t.Fatalf("StatusSnapshot: %v", err)
+	}
+	if snap.Layer == nil {
+		t.Fatal("dmsg snapshot has no layer section")
+	}
+	if snap.Layer.Listen != "127.0.0.1:4445" {
+		t.Errorf("listen = %q, want the default dmsg_web listener", snap.Layer.Listen)
+	}
+	if snap.Layer.Suffix != ".dmsg" {
+		t.Errorf("suffix = %q, want .dmsg", snap.Layer.Suffix)
+	}
+	if snap.Layer.Upstream != "127.0.0.1:4446" {
+		t.Errorf("upstream = %q, want the configured chain target", snap.Layer.Upstream)
+	}
+	// The skynet_web runtime binds :4446 and is NOT started here, so the label
+	// must say stopped — never "running", and never a fabricated reachability.
+	if snap.Layer.UpstreamState != "skynet_web resolving proxy · stopped" {
+		t.Errorf("upstream state = %q, want the skynet_web stopped label", snap.Layer.UpstreamState)
+	}
+	// Stats exist from construction, so uptime is tracked even before a request.
+	if snap.Layer.StartedAt == nil {
+		t.Error("layer has no started-at; Stats should clock from construction")
+	}
+	if snap.Layer.Requests != 0 || snap.Layer.LastRequestAt != nil {
+		t.Error("an untouched layer must report zero requests and no last request")
+	}
+
+	// Names: the configured aliases, with FULL keys.
+	if snap.Names == nil || len(snap.Names.Aliases) == 0 {
+		t.Fatal("dmsg snapshot has no name-resolution section")
+	}
+	found := false
+	for _, a := range snap.Names.Aliases {
+		if a.Name == "tpd" {
+			found = true
+			if a.PK != pk.String() {
+				t.Errorf("alias tpd = %q, want the full key %q", a.PK, pk.String())
+			}
+		}
+	}
+	if !found {
+		t.Error("configured service alias tpd missing from the names section")
+	}
+
+	// No dmsg client wired, so no sessions may be invented.
+	if len(snap.Sessions) != 0 {
+		t.Errorf("sessions = %d, want none without a dmsg client", len(snap.Sessions))
+	}
+	// The dmsg surface owns no route plane, so it must carry no legs.
+	if len(snap.Legs) != 0 || len(snap.Tunnels) != 0 {
+		t.Error("dmsg surface must not carry route-group legs")
+	}
+}
+
+// TestStatusSnapshotSkynetLayer proves the skynet surface's snapshot carries its
+// own layer summary, the skysocks chain label, and the skynet-plane forwarded
+// ports — and that non-skynet forwards are filtered out.
+func TestStatusSnapshotSkynetLayer(t *testing.T) {
+	pk := testPK(t)
+	log := logging.MustGetLogger("test")
+	ctx := context.Background()
+
+	v := &Visor{conf: &visorconfig.V1{Common: &visorconfig.Common{PK: pk}}, forwardedPorts: NewForwardedPorts("")}
+	v.embeddedSkynetWeb = newEmbeddedSkynetWeb(ctx, nil, nil, &v.skynetFwdMux, pk, nil, nil,
+		&visorconfig.SkynetWebConfig{Enable: true, UpstreamSOCKS: "127.0.0.1:1080"}, log)
+
+	// One skynet forward and one dmsg-only forward: only the former belongs on
+	// the skynet page.
+	if err := v.forwardedPorts.Register(ForwardedPort{Port: 8080, LocalPort: 3000, Label: "web", Skynet: true}); err != nil {
+		t.Fatalf("register skynet port: %v", err)
+	}
+	if err := v.forwardedPorts.Register(ForwardedPort{Port: 9090, DMSG: true}); err != nil {
+		t.Fatalf("register dmsg port: %v", err)
+	}
+
+	snap, err := v.proxyStatusProvider().StatusSnapshot(proxystatus.SurfaceSkynet)
+	if err != nil {
+		t.Fatalf("StatusSnapshot: %v", err)
+	}
+	if snap.Layer == nil {
+		t.Fatal("skynet snapshot has no layer section")
+	}
+	if snap.Layer.Listen != "127.0.0.1:4446" || snap.Layer.Suffix != ".skynet" {
+		t.Errorf("listen/suffix = %q/%q, want the skynet_web defaults", snap.Layer.Listen, snap.Layer.Suffix)
+	}
+	// :1080 is the skysocks-client's address; with no proc manager it is stopped.
+	if snap.Layer.UpstreamState != "skysocks-client · stopped" {
+		t.Errorf("upstream state = %q, want the skysocks-client stopped label", snap.Layer.UpstreamState)
+	}
+	if len(snap.Forwards) != 1 {
+		t.Fatalf("forwards = %d, want only the skynet-plane forward", len(snap.Forwards))
+	}
+	if snap.Forwards[0].Port != 8080 || snap.Forwards[0].LocalPort != 3000 || snap.Forwards[0].Label != "web" {
+		t.Errorf("forward = %+v, want the registered skynet forward", snap.Forwards[0])
+	}
+	// The skynet page has no dmsg sessions and no names for a foreign plane.
+	if len(snap.Sessions) != 0 {
+		t.Error("skynet surface must not carry dmsg sessions")
+	}
+}
+
+// TestStatusSnapshotLayerDisabled proves a visor with neither resolver
+// constructed still renders an honest page: a stopped layer plus a note saying
+// why, rather than a panic or a blank section.
+func TestStatusSnapshotLayerDisabled(t *testing.T) {
+	v := &Visor{conf: &visorconfig.V1{Common: &visorconfig.Common{}}}
+	for _, surface := range []proxystatus.Surface{proxystatus.SurfaceDmsg, proxystatus.SurfaceSkynet} {
+		snap, err := v.proxyStatusProvider().StatusSnapshot(surface)
+		if err != nil {
+			t.Fatalf("StatusSnapshot(%s): %v", surface, err)
+		}
+		if snap.Layer == nil {
+			t.Fatalf("%s: no layer section for a disabled resolver", surface)
+		}
+		if snap.Running {
+			t.Errorf("%s: a non-constructed resolver must not report running", surface)
+		}
+		if snap.Note == "" {
+			t.Errorf("%s: expected a note explaining the resolver is not enabled", surface)
+		}
+		if snap.Layer.UpstreamState != "" {
+			t.Errorf("%s: no chain claim may be made without a runtime", surface)
+		}
+		// The page must still render from this snapshot.
+		if len(proxystatus.Render(snap)) == 0 {
+			t.Errorf("%s: empty page rendered", surface)
+		}
+	}
+}
+
+// TestChainTargetStateUnknown proves an address the visor cannot vouch for gets
+// NO liveness label — the page shows the bare address instead of implying it
+// probed something.
+func TestChainTargetStateUnknown(t *testing.T) {
+	v := &Visor{conf: &visorconfig.V1{Common: &visorconfig.Common{}}}
+	p := &visorStatusProvider{v: v}
+	for _, addr := range []string{"", "not-an-address", "127.0.0.1:9999"} {
+		if got := p.chainTargetState(addr); got != "" {
+			t.Errorf("chainTargetState(%q) = %q, want no claim", addr, got)
+		}
+	}
+}
+
+func TestResolverListenAddr(t *testing.T) {
+	cases := []struct {
+		addr string
+		port uint
+		want string
+	}{
+		{"", 4445, "127.0.0.1:4445"},      // empty host means loopback
+		{"0.0.0.0", 4446, "0.0.0.0:4446"}, // an explicit LAN bind is preserved
+		{"", 0, ""},                       // port 0 disables the SOCKS5 front-end
+	}
+	for _, c := range cases {
+		if got := resolverListenAddr(c.addr, c.port); got != c.want {
+			t.Errorf("resolverListenAddr(%q,%d) = %q, want %q", c.addr, c.port, got, c.want)
+		}
+	}
+}

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -181,6 +181,29 @@ func (e *EmbeddedSkynetWeb) Upstream() string {
 	return e.cfg.UpstreamSOCKS
 }
 
+// ListenAddr returns the SOCKS5 listener the resolver binds, resolved the same
+// way serve() does (loopback default, default port).
+func (e *EmbeddedSkynetWeb) ListenAddr() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return resolverListenAddr(e.cfg.ProxyAddr, uintOrDefault(e.cfg.ProxyPort, defaultSkynetWebProxyPort))
+}
+
+// Suffix returns the domain suffix the resolver answers for (".skynet").
+func (e *EmbeddedSkynetWeb) Suffix() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return stringOrDefault(e.cfg.DomainSuffix, skynetweb.DefaultDomainSuffix)
+}
+
+// Aliases returns the name→PK bindings the resolver resolves by name — this
+// visor's own alias. The returned map is a copy.
+func (e *EmbeddedSkynetWeb) Aliases() map[string]cipher.PubKey {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return resolverAliasMap(e.cfg.Alias, e.localPK)
+}
+
 func (e *EmbeddedSkynetWeb) serve(ctx context.Context) {
 	cfg := skynetweb.Config{
 		DomainSuffix:  stringOrDefault(e.cfg.DomainSuffix, skynetweb.DefaultDomainSuffix),


### PR DESCRIPTION
Both resolving proxies already intercepted their own reserved status host and had a Provider wired in, but the snapshot they received was shaped for the skysocks tunnel — an empty route-group table and little else. Each layer now fills the same Snapshot with content it actually knows.

`status.dmsg` (through :4445) shows the dmsg_web layer — listener, suffix, uptime and request counters read from its own Stats, plus the downstream chain target — the dmsg client's established server sessions with full PKs, carrier, stream count and last ping, and the configured name aliases. `status.skynet` (through :4446) shows the skynet_web layer, the skysocks-client it chains to, the ports forwarded over skynet, and the raw forwarded conns open right now. A chain target's liveness is labeled from the runtime or proc state the visor already holds rather than from a dial probe, so the claim is honest and the js/wasm visor behaves the same as the native one.

Snapshot grows five optional sections (Layer, Sessions, Names, Forwards, Conns); existing fields and the skysocks page are untouched. The route-group section degrades per surface — the dmsg page says it relays over sessions rather than reporting a missing route group — and no layer fabricates a leg it does not have. Tests cover chain composition (each layer serves only its own status host and passes the others, and an ordinary host, straight upstream) and each provider's snapshot population, including the disabled-resolver and unknown-chain-target cases. `go build .`, the `GOOS=js GOARCH=wasm` build, `go vet` and `go test` are clean on pkg/{proxystatus,dmsgweb,skynetweb,visor}.