### PR TITLE
feat(hypervisor): serve the converged desk shell at /desk

### DIFF
--- a/pkg/visor/hypervisor_desk_test.go
+++ b/pkg/visor/hypervisor_desk_test.go
@@ -1,0 +1,141 @@
+//go:build !mobile
+
+// Package visor pkg/visor/hypervisor_desk_test.go c3-vis-core
+package visor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// deskTestHypervisor builds the minimal Hypervisor uiHandler needs: embedded
+// UI assets plus a visor identity (serveNativeDesk injects the local PK the
+// way serveInjectedIndex does).
+func deskTestHypervisor(t *testing.T) (*Hypervisor, cipher.PubKey) {
+	t.Helper()
+	pk, _ := cipher.GenerateKeyPair()
+	hv := &Hypervisor{
+		c: visorconfig.HypervisorConfig{
+			UIAssets: fstest.MapFS{
+				"index.html": &fstest.MapFile{Data: []byte("<html><head></head><body>ANGULAR</body></html>")},
+			},
+		},
+		visor: &Visor{conf: &visorconfig.V1{Common: &visorconfig.Common{PK: pk}}},
+	}
+	return hv, pk
+}
+
+// TestNativeDeskServing pins the /desk serving contract on the NATIVE
+// hypervisor UI port: the converged desk shell is served in native mode, the
+// Angular dashboard stays untouched at its existing routes, and nothing
+// wasm-visor-shaped is exposed (the native visor IS the visor — the desk is a
+// shell over it, so the in-page-visor machinery must have nothing to fetch).
+func TestNativeDeskServing(t *testing.T) {
+	hv, pk := deskTestHypervisor(t)
+	h := hv.uiHandler()
+	get := func(path string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+		return w
+	}
+
+	t.Run("GET /desk serves the desk shell in native mode", func(t *testing.T) {
+		w := get("/desk")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status=%d, want 200", w.Code)
+		}
+		if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+			t.Errorf("Content-Type=%q, want text/html", ct)
+		}
+		body := w.Body.String()
+		// The native-mode marker: desk-boot must take its native branch, which
+		// boots no in-page visor and opens the same-origin dashboard window.
+		if !strings.Contains(body, "native: true") {
+			t.Error("page lacks the native-mode marker (native: true)")
+		}
+		if !strings.Contains(body, "dashboardURL: '/#/?embed=1'") {
+			t.Error("page lacks the same-origin dashboard window URL")
+		}
+		// The shell is assembled from the SAME assets the dashboard injection
+		// uses (launcher providers) plus the shared desk boot.
+		for _, want := range []string{`src="/browse.js"`, `src="/skywire-browse-launcher.js"`, `src="/desk-boot.js"`, "skywireDeskBoot("} {
+			if !strings.Contains(body, want) {
+				t.Errorf("page lacks %s", want)
+			}
+		}
+		if !strings.Contains(body, pk.Hex()) {
+			t.Error("page lacks the injected local PK (launcher providers need it)")
+		}
+		// The ONE-VISOR rule, as served bytes: the native desk page must not
+		// even reference the wasm-visor module or its loader.
+		for _, banned := range []string{"wasm-visor.wasm", "wasm_exec", "skywire.wasm"} {
+			if strings.Contains(body, banned) {
+				t.Errorf("native desk page references %s — the in-page-visor machinery must stay dormant", banned)
+			}
+		}
+	})
+
+	t.Run("Angular root still serves, with the launcher injection intact", func(t *testing.T) {
+		w := get("/")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status=%d, want 200", w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "ANGULAR") {
+			t.Error("Angular index no longer served at /")
+		}
+		if !strings.Contains(body, `src="browse.js"`) || !strings.Contains(body, "__SKYWIRE_LOCAL_PK__") {
+			t.Error("index injection (browse launcher) missing — /desk must not disturb it")
+		}
+	})
+
+	t.Run("desk-boot.js is served beside the page", func(t *testing.T) {
+		w := get("/desk-boot.js")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status=%d, want 200", w.Code)
+		}
+		if !strings.Contains(w.Body.String(), "skywireDeskBoot") {
+			t.Error("/desk-boot.js does not carry the shared desk boot")
+		}
+	})
+
+	t.Run("the wasm-visor module is not exposed on the hypervisor port", func(t *testing.T) {
+		for _, p := range []string{"/wasm-visor.wasm", "/skywire.wasm", "/wasm_exec.js", "/hv-boot.js", "/worker.js"} {
+			if w := get(p); w.Code != http.StatusNotFound {
+				t.Errorf("GET %s → %d, want 404 (native mode must not serve the in-page visor)", p, w.Code)
+			}
+		}
+	})
+}
+
+// TestDeskShellHTMLWasmMode guards the refactor of the wasm /desk page onto
+// the shared skeleton: `hv serve`'s desk must still wire the wasm assets and
+// the harness injection anchor exactly as before.
+func TestDeskShellHTMLWasmMode(t *testing.T) {
+	page := string(deskShellHTML(
+		`<script src="/wasm_exec.js?variant=go"></script>`+"\n"+
+			`<script src="/browse.js"></script>`+"\n"+
+			`<script src="/desk-boot.js"></script>`,
+		deskWasmBootOpts))
+	for _, want := range []string{
+		"deskWasmURL: '/wasm-visor.wasm'",
+		"wasmURL: '/skywire.wasm'",
+		"autostartVisor: true",
+		"skywireDeskBoot(",
+		// The exact tag ServeWasm's --harness injection keys on.
+		`<script src="/desk-boot.js"></script>`,
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("wasm desk page lacks %s", want)
+		}
+	}
+	if strings.Contains(page, "__DESK_SCRIPTS__") || strings.Contains(page, "__DESK_OPTS__") {
+		t.Error("template placeholders leaked into the rendered page")
+	}
+}

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -81,6 +81,15 @@ func (hv *Hypervisor) uiHandler() http.Handler {
 		case "/skywire-browse-launcher.js":
 			serveJS(w, []byte(nativeBrowseLauncherJS))
 			return
+		case "/desk-boot.js":
+			// The shared desk boot (skywireDeskBoot) — same asset `hv serve`
+			// exposes, so /desk below boots through the one entry point both
+			// serving contexts share.
+			serveJS(w, browseui.DeskBootJS())
+			return
+		case "/desk":
+			hv.serveNativeDesk(w)
+			return
 		case "/", "/index.html":
 			hv.serveInjectedIndex(w, r, fileServer)
 			return
@@ -158,6 +167,54 @@ func (hv *Hypervisor) serveInjectedIndex(w http.ResponseWriter, r *http.Request,
 	w.Header().Set("Cache-Control", "no-cache")
 	_, _ = w.Write(out) //nolint:errcheck
 }
+
+// serveNativeDesk serves the converged desk shell at /desk on the NATIVE
+// hypervisor UI port — the same page skeleton `skywire cli hv serve` renders
+// (deskShellTemplate in wasmserve.go), in native mode: the browse launcher
+// (the exact script the dashboard injection loads) mounts the desk panel over
+// its /api-backed providers, and desk-boot's native branch opens the Angular
+// dashboard as a same-origin window inside it. NO wasm-visor module is
+// referenced or served on this port — the native visor IS the visor; the desk
+// here is a shell over it, so the in-page-visor machinery stays dormant.
+func (hv *Hypervisor) serveNativeDesk(w http.ResponseWriter) {
+	localPK, browseJS := "", ""
+	if hv.visor != nil {
+		localPK = hv.visor.conf.PK.Hex()
+		browseJS = browseOriginInjectJS(hv.visor)
+	}
+	// Mirror serveInjectedIndex's page environment (local PK, browse-origin
+	// mode, served-bundle fingerprint + auto-reloader) so the launcher and the
+	// update behavior are identical on /desk and on the dashboard beneath it.
+	var ver string
+	if hv.c.UIAssets != nil {
+		if f, err := hv.c.UIAssets.Open("index.html"); err == nil {
+			if b, rerr := io.ReadAll(f); rerr == nil {
+				ver = uiVersionHash(b)
+			}
+			_ = f.Close() //nolint:errcheck
+		}
+	}
+	scripts := `<script>window.__SKYWIRE_LOCAL_PK__=` + strconv.Quote(localPK) +
+		`;window.__SKYWIRE_UI_VERSION__=` + strconv.Quote(ver) + `;` + browseJS + `</script>` + "\n" +
+		`<script src="/browse.js"></script>` + "\n" +
+		`<script src="/skywire-browse-launcher.js"></script>` + "\n" +
+		`<script>` + uiAutoReloadJS + `</script>` + "\n" +
+		`<script src="/desk-boot.js"></script>`
+	page := deskShellHTML(scripts, nativeDeskBootOpts)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
+	_, _ = w.Write(page) //nolint:errcheck
+}
+
+// nativeDeskBootOpts is the skywireDeskBoot options object for the
+// native-served /desk: native mode (no wasm anything), dashboard window on
+// the same-origin Angular UI. embed=1 rides in the HASH (the Angular UI is
+// hash-routed) so the iframe's own injected launcher hides its taskbar — the
+// same chrome-less guard the ☰ chat/log windows rely on.
+const nativeDeskBootOpts = `{
+  native: true,
+  dashboardURL: '/#/?embed=1',
+}`
 
 // uiVersionHash fingerprints the served UI bundle (short sha256 of index.html,
 // which embeds the content-hashed chunk names).
@@ -256,7 +313,10 @@ const nativeBrowseLauncherJS = `(function () {
     } catch (e) {}
     // The panel is always on (mountPanel renders the persistent taskbar itself),
     // so there's no floating launch button — apps open from the ☰ menu.
-    void p;
+    // Publish the handle under the same global the wasm desk-boot uses, so the
+    // native /desk page (desk-boot's native branch) can wait on the mounted
+    // panel instead of double-mounting one.
+    self.__skywireDesk = p;
   }
   ready();
 })();`

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -298,7 +298,11 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 		// nested browser opens it maximized on top. A visor the operator
 		// stopped stays stopped across reloads (desk-boot's session).
 		serveBytes("/desk-boot.js", "text/javascript", wasmhv.DeskBootJS())
-		deskHTML := []byte(deskPageHTML)
+		deskHTML := deskShellHTML(
+			`<script src="/wasm_exec.js?variant=go"></script>`+"\n"+
+				`<script src="/browse.js"></script>`+"\n"+
+				`<script src="/desk-boot.js"></script>`,
+			deskWasmBootOpts)
 		if cfg.Harness {
 			// Same rule as injectWasmBoot on the standalone page: --harness
 			// injects ctl-bridge.js (its presence IS the harness signal). On
@@ -929,11 +933,32 @@ func browseSWAssetType(p string) string {
 	return "text/javascript"
 }
 
-// deskPageHTML is the converged desk page served at /desk when --exec-wasm is
-// set. Assets come from the routes this server already exposes: /browse.js is
-// the full desk bundle, /wasm-visor.wasm the desk host (raw), /skywire.wasm
-// the command module, /wasm_exec.js?variant=go the matching loader.
-const deskPageHTML = `<!DOCTYPE html>
+// deskWasmBootOpts is the skywireDeskBoot options object for the wasm-served
+// desk (`hv serve --exec-wasm`'s /desk): the tab as a Linux host. Assets come
+// from the routes ServeWasm already exposes: /browse.js is the full desk
+// bundle, /wasm-visor.wasm the desk host (raw), /skywire.wasm the command
+// module, /wasm_exec.js?variant=go the matching loader.
+const deskWasmBootOpts = `{
+  persistDB: 'skywire-desk',
+  deskWasmURL: '/wasm-visor.wasm',
+  wasmURL: '/skywire.wasm',
+  wasmExecURL: '/wasm_exec.js?variant=go',
+  winboxURL: '/winbox.wasm',
+  autostartVisor: true,
+  helpTerminal: true,
+  hvWindow: true,
+}`
+
+// deskShellTemplate is the shared skeleton of the converged desk page (/desk):
+// boot overlay + error capture + the skywireDeskBoot call. ONE skeleton behind
+// both serving contexts — `hv serve`'s wasm desk and the native hypervisor's
+// /desk (hypervisor_handlers_browse.go) — so the two pages cannot drift.
+// __DESK_SCRIPTS__ carries the context's script includes, ending with the
+// /desk-boot.js tag the harness injection keys on; __DESK_OPTS__ carries its
+// skywireDeskBoot options object. onStatus stays in the skeleton (it drives
+// the shared overlay) and is merged UNDER the context opts so a context could
+// still override it.
+const deskShellTemplate = `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -962,21 +987,11 @@ addEventListener('error', function (e) {
   }
 });
 </script>
-<script src="/wasm_exec.js?variant=go"></script>
-<script src="/browse.js"></script>
-<script src="/desk-boot.js"></script>
+__DESK_SCRIPTS__
 <script>
-skywireDeskBoot({
-  persistDB: 'skywire-desk',
-  deskWasmURL: '/wasm-visor.wasm',
-  wasmURL: '/skywire.wasm',
-  wasmExecURL: '/wasm_exec.js?variant=go',
-  winboxURL: '/winbox.wasm',
-  autostartVisor: true,
-  helpTerminal: true,
-  hvWindow: true,
+skywireDeskBoot(Object.assign({
   onStatus: function (s) { var el = document.getElementById('boot-msg'); if (el) el.textContent = s; },
-}).then(function () {
+}, __DESK_OPTS__)).then(function () {
   document.getElementById('boot').className = 'gone';
 }).catch(function (e) {
   var el = document.getElementById('boot-msg');
@@ -986,3 +1001,9 @@ skywireDeskBoot({
 </body>
 </html>
 `
+
+// deskShellHTML renders the shared desk skeleton for one serving context.
+func deskShellHTML(scriptsHTML, deskOptsJS string) []byte {
+	out := strings.ReplaceAll(deskShellTemplate, "__DESK_SCRIPTS__", scriptsHTML)
+	return []byte(strings.ReplaceAll(out, "__DESK_OPTS__", deskOptsJS))
+}

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -20,6 +20,9 @@
 //   hvWindow        once the visor's hypervisor UI listens on the virtual
 //                   loopback, open a browser window on it, maximized on top
 //   hvPort          hypervisor UI port on the virtual loopback (8001)
+//   native          the page is served by a NATIVE hypervisor — see below
+//   dashboardURL    native mode: the same-origin dashboard URL for the
+//                   dashboard window ('/#/?embed=1')
 //   onStatus(msg)   boot progress for the page's overlay
 (function () {
 	'use strict';
@@ -91,6 +94,54 @@
 		opts = opts || {};
 		var status = opts.onStatus || function () {};
 		var hvPort = opts.hvPort || 8001;
+
+		// Native mode: the page is served by a NATIVE hypervisor, whose visor
+		// is the host process — the desk is a shell OVER that visor, never a
+		// second one, so nothing wasm-shaped boots here (no jsfs snapshot, no
+		// desk-host module, no vnet, no skywireExec). The server injects
+		// skywire-browse-launcher.js beside this file; that launcher mounts
+		// the panel with its /api-backed providers (the same ones the Angular
+		// dashboard gets) and publishes it as __skywireDesk. All that is left
+		// to do is open the dashboard window: the SAME-ORIGIN Angular UI in an
+		// iframe (embed=1 rides in the hash so the iframe's own injected
+		// launcher hides its taskbar — a desk never nests inside a desk
+		// window, the same guard the ☰ chat/log windows use).
+		if (opts.native) {
+			status('starting the desk…');
+			return Promise.all([
+				waitFor(function () { return globalThis.__skywireDesk; }, 'the desk panel'),
+				waitFor(function () { return typeof globalThis.WinBox === 'function'; }, 'the window manager'),
+			]).then(function (r) {
+				var panel = r[0];
+				try {
+					// Join the panel's own stacking context (its windows root)
+					// so focus raises the dashboard above/below sibling windows
+					// like any other desk window; keep clear of the taskbar on
+					// whichever edge it is docked (applyDock pins top OR bottom
+					// to "0", persisted across reloads).
+					var root = document.getElementById('skywire-skynet-root') || undefined;
+					var bar = document.getElementById('skywire-skynet-taskbar');
+					var barH = bar ? (bar.offsetHeight || 36) : 0;
+					// applyDock writes bottom:"0" for a bottom dock (read back as
+					// "0px" by most engines) and "auto" for a top dock.
+					var bd = bar ? bar.style.bottom : 'auto';
+					var topDocked = !(bd === '0' || bd === '0px');
+					var wb = new WinBox({
+						title: 'dashboard',
+						url: opts.dashboardURL || '/#/?embed=1',
+						root: root,
+						top: topDocked ? barH : 0,
+						bottom: topDocked ? 0 : barH,
+						// The panel's window chrome (dark header + pointer
+						// events); no-full keeps "maximize" in-tab.
+						'class': ['skywire-wb', 'no-full'],
+						x: 'center', y: 'center', width: '85%', height: '85%',
+					});
+					if (wb.maximize) wb.maximize(true);
+				} catch (e) { console.error('dashboard window:', e); }
+				return { panel: panel, startedVisor: false };
+			});
+		}
 
 		skywireExec.wasmURL = opts.wasmURL || 'skywire.wasm.gz';
 		skywireExec.wasmExecURL = opts.wasmExecURL || 'wasm_exec.js';


### PR DESCRIPTION
The native hypervisor UI now serves the same desk surface `skywire cli hv serve` produces, at /desk on the hypervisor port. The wasm /desk page's skeleton is extracted into a shared `deskShellHTML` factory, desk-boot.js gains a native mode, and the browse launcher's panel doubles as the desk shell with the Angular dashboard opened as a same-origin window inside it.

In native mode nothing wasm-shaped boots or is served — the native visor is the visor; the desk is a shell over it. The dashboard's existing routes are untouched. Serving parity only; no defaults change.

Handler-level tests cover /desk (native marker, no wasm module references), the untouched Angular root, and the wasm-mode skeleton.