### PR TITLE
fix(skysocks): guard the rescue copier against zero-progress reads; add CDP profiler tool

### DIFF
--- a/pkg/skysocks/rangesplit.go
+++ b/pkg/skysocks/rangesplit.go
@@ -413,6 +413,13 @@ func (c *Client) streamTailOnce(w net.Conn, req *http.Request, host, validator s
 // bytes written (the caller's resume offset).
 func copyWithIdleTimeout(dst io.Writer, body io.Reader, under net.Conn, limit int64, idle time.Duration) (int64, error) {
 	var written int64
+	// zeroReads guards the io.Reader contract's discouraged-but-legal (0, nil)
+	// return: a reader stuck returning it would otherwise turn this loop into a
+	// core-pegging spin (no bytes, no error, no block). A handful in a row is
+	// tolerated; a streak means the reader is broken — fail the attempt and let
+	// the caller's resume/retry logic decide.
+	zeroReads := 0
+	const maxZeroReads = 64
 	buf := make([]byte, 32<<10)
 	for written < limit {
 		_ = under.SetReadDeadline(time.Now().Add(idle)) //nolint:errcheck
@@ -422,10 +429,15 @@ func copyWithIdleTimeout(dst io.Writer, body io.Reader, under net.Conn, limit in
 		}
 		n, err := body.Read(buf[:room])
 		if n > 0 {
+			zeroReads = 0
 			if _, werr := dst.Write(buf[:n]); werr != nil {
 				return written, werr
 			}
 			written += int64(n)
+		} else if err == nil {
+			if zeroReads++; zeroReads >= maxZeroReads {
+				return written, fmt.Errorf("reader stuck: %d consecutive zero-byte reads with no error", zeroReads)
+			}
 		}
 		if err != nil {
 			if err == io.EOF && written >= limit {

--- a/scripts/tabshot/profile/main.go
+++ b/scripts/tabshot/profile/main.go
@@ -1,0 +1,119 @@
+// Command profile samples a CDP page target's JS CPU profile for N seconds and
+// prints the hottest functions by self time — the diagnostic for "the wasm desk
+// tab pegs a core": a spin loop names itself at the top of this list, where a
+// screenshot or eval cannot (evals queue behind the spin; the profiler runs in
+// the inspector and samples through it).
+//
+//	go run ./scripts/tabshot/profile ws://127.0.0.1:9222/devtools/page/<id> <seconds>
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+type node struct {
+	ID       int `json:"id"`
+	HitCount int `json:"hitCount"`
+	Frame    struct {
+		FunctionName string `json:"functionName"`
+		URL          string `json:"url"`
+		LineNumber   int    `json:"lineNumber"`
+	} `json:"callFrame"`
+}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: profile <webSocketDebuggerUrl> <seconds>")
+		os.Exit(2)
+	}
+	secs, err := strconv.Atoi(os.Args[2])
+	if err != nil || secs < 1 || secs > 120 {
+		fmt.Fprintln(os.Stderr, "seconds must be 1-120")
+		os.Exit(2)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(secs+60)*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, os.Args[1], &websocket.DialOptions{})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "dial:", err)
+		os.Exit(1)
+	}
+	c.SetReadLimit(256 << 20) // profiles of a busy tab run tens of MB
+	defer c.Close(websocket.StatusNormalClosure, "")
+
+	send := func(id int, method string, params map[string]interface{}) {
+		b, _ := json.Marshal(map[string]interface{}{"id": id, "method": method, "params": params})
+		if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+			fmt.Fprintln(os.Stderr, "write:", err)
+			os.Exit(1)
+		}
+	}
+	// waitID reads until the reply for id arrives (events interleave freely).
+	waitID := func(id int) json.RawMessage {
+		for {
+			_, msg, err := c.Read(ctx)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "read:", err)
+				os.Exit(1)
+			}
+			var m struct {
+				ID     int             `json:"id"`
+				Result json.RawMessage `json:"result"`
+			}
+			if json.Unmarshal(msg, &m) == nil && m.ID == id {
+				return m.Result
+			}
+		}
+	}
+
+	send(1, "Profiler.enable", nil)
+	waitID(1)
+	// 1ms sampling: fine enough to catch a hot loop, cheap enough not to be one.
+	send(2, "Profiler.setSamplingInterval", map[string]interface{}{"interval": 1000})
+	waitID(2)
+	send(3, "Profiler.start", nil)
+	waitID(3)
+	time.Sleep(time.Duration(secs) * time.Second)
+	send(4, "Profiler.stop", nil)
+	res := waitID(4)
+
+	var prof struct {
+		Profile struct {
+			Nodes     []node `json:"nodes"`
+			StartTime int64  `json:"startTime"`
+			EndTime   int64  `json:"endTime"`
+		} `json:"profile"`
+	}
+	if err := json.Unmarshal(res, &prof); err != nil {
+		fmt.Fprintln(os.Stderr, "profile parse:", err)
+		os.Exit(1)
+	}
+	nodes := prof.Profile.Nodes
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].HitCount > nodes[j].HitCount })
+	total := 0
+	for _, n := range nodes {
+		total += n.HitCount
+	}
+	wallMs := float64(prof.Profile.EndTime-prof.Profile.StartTime) / 1000
+	fmt.Printf("samples=%d wall=%.0fms (≈%.0f%% of one core busy)\n", total, wallMs,
+		100*float64(total)/(wallMs)) // 1 sample/ms ⇒ samples/ms ≈ core utilization
+	for i, n := range nodes {
+		if i >= 20 || n.HitCount == 0 {
+			break
+		}
+		name := n.Frame.FunctionName
+		if name == "" {
+			name = "(anonymous)"
+		}
+		fmt.Printf("%6d  %5.1f%%  %s  %s:%d\n", n.HitCount, 100*float64(n.HitCount)/float64(total),
+			name, n.Frame.URL, n.Frame.LineNumber)
+	}
+}


### PR DESCRIPTION
A reader stuck returning (0, nil) — legal but discouraged by the io.Reader contract — would turn the sequential-rescue copy loop into a core-pegging spin: no bytes, no error, no block. The loop now tolerates a short streak and then fails the attempt, handing control back to the resume/retry logic. A core spin-lock was observed live on the browser visor's tab; this loop is the newest candidate and is now spin-proof either way.

Also adds scripts/tabshot/profile: samples a CDP page target's JS CPU profile for N seconds and prints the hottest functions by self time — the diagnostic that names a spin loop when a tab pegs a core (in-page evals queue behind the spin; the profiler samples through the inspector). First live run on the desk tab showed 97.7% idle — the spin is intermittent, and the monitor can now catch it in the act.