### PR TITLE
fix(router): judge proactive HoL overdueness by the seq's own send leg

### DIFF
--- a/pkg/router/hol_retx.go
+++ b/pkg/router/hol_retx.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/transport"
 )
 
@@ -184,6 +186,24 @@ func (m *routeMux) fastestLegLatency(tps []*transport.ManagedTransport) float64 
 	return best
 }
 
+// legLatencyByTp returns each live leg's measured RTT (ms) keyed by transport
+// UUID (unmeasured/zero RTTs omitted). Standby legs are included: a seq sent
+// on a since-demoted leg is still in flight on THAT leg's latency, and judging
+// it against anything else declares it stalled while it is merely slow. Caller
+// holds rg.mu (reads the tps slice).
+func (m *routeMux) legLatencyByTp(tps []*transport.ManagedTransport) map[uuid.UUID]float64 {
+	out := make(map[uuid.UUID]float64, len(tps))
+	for _, tp := range tps {
+		if tp == nil || tp.IsClosed() {
+			continue
+		}
+		if lat := tp.GetLatency(); lat > 0 {
+			out[tp.Entry.ID] = lat
+		}
+	}
+	return out
+}
+
 // proactiveRetxSeqs is the sender-side decision for a received SACK: which
 // frontier seqs to retransmit NOW on the fastest leg, bypassing retxMinAge.
 // Returns nil (a clean no-op fallback) when HoL retx was not negotiated, so a
@@ -191,9 +211,10 @@ func (m *routeMux) fastestLegLatency(tps []*transport.ManagedTransport) float64 
 // takes the head-of-line run from the SACK (frontierMissingSeqs), keeps only the
 // seqs we still hold in the retx buffer, and per-seq rate-limits them to one
 // nudge per fast-leg RTT (holRetxTracker.Due). fastestRTTms is the fastest live
-// leg's measured RTT, used for the per-seq interval. It also purges the tracker
-// below lastContiguous so it can't grow without bound.
-func (m *routeMux) proactiveRetxSeqs(lastContiguous uint32, words []uint64, fastestRTTms float64, now time.Time) []uint32 {
+// leg's measured RTT, used for the per-seq interval; legRTTms maps each live
+// leg's transport UUID to its RTT for the per-seq overdueness gate. It also
+// purges the tracker below lastContiguous so it can't grow without bound.
+func (m *routeMux) proactiveRetxSeqs(lastContiguous uint32, words []uint64, fastestRTTms float64, legRTTms map[uuid.UUID]float64, now time.Time) []uint32 {
 	if !m.holRetxEnabled || m.retxBuf == nil || m.holRetx == nil {
 		return nil
 	}
@@ -203,23 +224,32 @@ func (m *routeMux) proactiveRetxSeqs(lastContiguous uint32, words []uint64, fast
 		return nil
 	}
 	interval := holPerSeqInterval(fastestRTTms)
-	gapTh := holGapThreshold(fastestRTTms)
+	fallbackTh := holGapThreshold(fastestRTTms)
 	var due []uint32
 	for _, seq := range cand {
 		// Only retransmit seqs we still hold: a seq already purged from the retx
 		// buffer was acknowledged, so it is not the one blocking the frontier.
-		sentAt, held := m.retxBuf.SentAt(seq)
+		sentAt, tpID, held := m.retxBuf.SentInfo(seq)
 		if !held {
 			continue
 		}
-		// Age gate (holGapThreshold): a seq younger than ~one fast-leg RTT
-		// cannot have been acked yet no matter which leg it rode, so a nudge is
-		// spurious by construction — SACKs arrive every few ms and, ungated,
-		// the first SACK naming a seq striped onto a slower leg retransmitted
-		// it at ~25ms of age, then every fast-RTT until the original landed
-		// (measured ~12% duplicate bytes concentrated on the fast leg). Gating
-		// the FIRST nudge on age preserves the design's intent: a genuine stall
-		// is still healed in about one fast round-trip.
+		// Age gate: a seq is overdue only relative to the leg it is actually in
+		// flight on — one own-leg RTT × the RACK reorder margin. Judged against
+		// the FASTEST leg's RTT instead (the original design), every frame
+		// striped onto a slower leg looked "stalled" one fast-RTT into its
+		// perfectly ordinary flight and was retransmitted on the fast leg; its
+		// original then landed as a duplicate (measured live on a 60ms/300ms
+		// pair: 30MB of duplicates against 11MB of payload on the slow leg —
+		// the fast leg carrying the slow leg's whole stripe twice negated the
+		// aggregation). The fastest-leg threshold remains only as the fallback
+		// for a seq whose send leg is unknown or unmeasured. A genuinely lost
+		// or wedged seq still heals in ~1.25× its own leg's RTT, on the fastest
+		// leg, well ahead of the reactive slowest-leg RACK threshold for all
+		// but the slowest leg's own frames.
+		gapTh := fallbackTh
+		if rtt, ok := legRTTms[tpID]; ok && rtt > 0 {
+			gapTh = holGapThreshold(rtt * rackReorderFactor)
+		}
 		if now.Sub(sentAt) < gapTh {
 			continue
 		}

--- a/pkg/router/hol_retx_test.go
+++ b/pkg/router/hol_retx_test.go
@@ -234,7 +234,7 @@ func TestProactiveRetxSeqs(t *testing.T) {
 		m := newMux(false)
 		m.retxBuf.Store(101, []byte("a"), uuid.Nil)
 		m.retxBuf.Store(102, []byte("b"), uuid.Nil)
-		if got := m.proactiveRetxSeqs(last, words, 20, now); got != nil {
+		if got := m.proactiveRetxSeqs(last, words, 20, nil, now); got != nil {
 			t.Errorf("HoL disabled must return nil, got %v", got)
 		}
 	})
@@ -244,7 +244,7 @@ func TestProactiveRetxSeqs(t *testing.T) {
 		m.retxBuf.Store(101, []byte("a"), uuid.Nil)
 		m.retxBuf.Store(102, []byte("b"), uuid.Nil)
 		m.retxBuf.Store(103, []byte("c"), uuid.Nil)
-		got := m.proactiveRetxSeqs(last, words, 20, now)
+		got := m.proactiveRetxSeqs(last, words, 20, nil, now)
 		if !equalSeqs(got, []uint32{101, 102, 103}) {
 			t.Errorf("got %v, want [101 102 103]", got)
 		}
@@ -255,7 +255,7 @@ func TestProactiveRetxSeqs(t *testing.T) {
 		// 102 already acked/purged -> not retransmitted; 101,103 held.
 		m.retxBuf.Store(101, []byte("a"), uuid.Nil)
 		m.retxBuf.Store(103, []byte("c"), uuid.Nil)
-		got := m.proactiveRetxSeqs(last, words, 20, now)
+		got := m.proactiveRetxSeqs(last, words, 20, nil, now)
 		if !equalSeqs(got, []uint32{101, 103}) {
 			t.Errorf("got %v, want [101 103]", got)
 		}
@@ -267,16 +267,16 @@ func TestProactiveRetxSeqs(t *testing.T) {
 		m.retxBuf.Store(102, []byte("b"), uuid.Nil)
 		m.retxBuf.Store(103, []byte("c"), uuid.Nil)
 		// fastestMs=20 -> interval 20ms.
-		first := m.proactiveRetxSeqs(last, words, 20, now)
+		first := m.proactiveRetxSeqs(last, words, 20, nil, now)
 		if !equalSeqs(first, []uint32{101, 102, 103}) {
 			t.Fatalf("first nudge got %v, want [101 102 103]", first)
 		}
 		// Immediately again: all inside interval -> nothing due.
-		if again := m.proactiveRetxSeqs(last, words, 20, now.Add(5*time.Millisecond)); again != nil {
+		if again := m.proactiveRetxSeqs(last, words, 20, nil, now.Add(5*time.Millisecond)); again != nil {
 			t.Errorf("re-nudge inside interval must be nil, got %v", again)
 		}
 		// Past the interval -> due again.
-		later := m.proactiveRetxSeqs(last, words, 20, now.Add(25*time.Millisecond))
+		later := m.proactiveRetxSeqs(last, words, 20, nil, now.Add(25*time.Millisecond))
 		if !equalSeqs(later, []uint32{101, 102, 103}) {
 			t.Errorf("re-nudge past interval got %v, want [101 102 103]", later)
 		}
@@ -289,11 +289,11 @@ func TestProactiveRetxSeqs(t *testing.T) {
 		// cannot have been acked yet on ANY leg, so a nudge would be spurious
 		// by construction — this is the ungated behavior that duplicated ~12%
 		// of a striped transfer onto the fast leg. Must be nil.
-		if got := m.proactiveRetxSeqs(last, words, 20, time.Now()); got != nil {
+		if got := m.proactiveRetxSeqs(last, words, 20, nil, time.Now()); got != nil {
 			t.Errorf("seq younger than the gap threshold must not be nudged, got %v", got)
 		}
 		// Same seq once genuinely overdue: nudged.
-		if got := m.proactiveRetxSeqs(last, words, 20, time.Now().Add(time.Second)); !equalSeqs(got, []uint32{101}) {
+		if got := m.proactiveRetxSeqs(last, words, 20, nil, time.Now().Add(time.Second)); !equalSeqs(got, []uint32{101}) {
 			t.Errorf("aged seq must be nudged, got %v, want [101]", got)
 		}
 	})
@@ -301,8 +301,40 @@ func TestProactiveRetxSeqs(t *testing.T) {
 	t.Run("empty bitmap -> nil (no stall)", func(t *testing.T) {
 		m := newMux(true)
 		m.retxBuf.Store(101, []byte("a"), uuid.Nil)
-		if got := m.proactiveRetxSeqs(last, nil, 20, now); got != nil {
+		if got := m.proactiveRetxSeqs(last, nil, 20, nil, now); got != nil {
 			t.Errorf("empty SACK bitmap must return nil, got %v", got)
+		}
+	})
+
+	t.Run("slow-leg seq judged by its own leg's RTT", func(t *testing.T) {
+		// The live 60ms/300ms failure mode: a seq striped onto the 300ms leg is
+		// in ordinary flight at 100ms of age. Judged by the fastest leg's RTT
+		// (60ms) it looked stalled and was duplicated onto the fast leg for
+		// every slow-leg frame (measured 30MB dup vs 11MB payload); judged by
+		// its OWN leg's RTT × the RACK margin (375ms) it is left alone, and
+		// only a genuinely overdue seq (age 500ms) is nudged.
+		m := newMux(true)
+		slowTp := uuid.New()
+		m.retxBuf.Store(101, []byte("a"), slowTp)
+		legRTT := map[uuid.UUID]float64{slowTp: 300}
+		sentAt, _, _ := m.retxBuf.SentInfo(101)
+		if got := m.proactiveRetxSeqs(last, words, 60, legRTT, sentAt.Add(100*time.Millisecond)); got != nil {
+			t.Errorf("seq inside its own leg's RTT must not be nudged, got %v", got)
+		}
+		if got := m.proactiveRetxSeqs(last, words, 60, legRTT, sentAt.Add(500*time.Millisecond)); !equalSeqs(got, []uint32{101}) {
+			t.Errorf("seq overdue on its own leg must be nudged, got %v, want [101]", got)
+		}
+	})
+
+	t.Run("unknown-leg seq falls back to fastest-leg gate", func(t *testing.T) {
+		m := newMux(true)
+		m.retxBuf.Store(101, []byte("a"), uuid.Nil) // send leg unknown
+		legRTT := map[uuid.UUID]float64{uuid.New(): 300}
+		sentAt, _, _ := m.retxBuf.SentInfo(101)
+		// Past the fastest-leg threshold (60ms) but well under the slow leg's:
+		// with no send-leg tag the conservative fastest-leg gate applies.
+		if got := m.proactiveRetxSeqs(last, words, 60, legRTT, sentAt.Add(100*time.Millisecond)); !equalSeqs(got, []uint32{101}) {
+			t.Errorf("untagged seq past the fallback gate must be nudged, got %v, want [101]", got)
 		}
 	})
 }

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -4107,8 +4107,9 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 	if rg.mux.holRetxEnabled {
 		rg.mu.Lock()
 		fastMs := rg.mux.fastestLegLatency(rg.tps)
+		legRTT := rg.mux.legLatencyByTp(rg.tps)
 		rg.mu.Unlock()
-		if due := rg.mux.proactiveRetxSeqs(lastContig, words, fastMs, time.Now()); len(due) > 0 {
+		if due := rg.mux.proactiveRetxSeqs(lastContig, words, fastMs, legRTT, time.Now()); len(due) > 0 {
 			retxSeqs = mergeSeqs(retxSeqs, due)
 		}
 	}

--- a/pkg/router/sack.go
+++ b/pkg/router/sack.go
@@ -404,6 +404,23 @@ func (rb *retxBuffer) SentAt(seq uint32) (time.Time, bool) {
 	return time.Time{}, false
 }
 
+// SentInfo returns when seq was originally sent AND which transport it last
+// rode (uuid.Nil = unknown), with ok=false for a seq no longer held. The
+// proactive HoL path needs the transport identity to judge overdueness against
+// the RTT of the leg the seq is actually in flight on: judged against the
+// FASTEST leg's RTT instead, every frame striped onto a slower leg looks
+// "stalled" one fast-RTT in and gets a spurious duplicate (measured live:
+// 30MB of duplicates against 11MB of payload on the slow leg of a 2-leg mux).
+func (rb *retxBuffer) SentInfo(seq uint32) (time.Time, uuid.UUID, bool) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	if entry, ok := rb.entries[seq]; ok {
+		return entry.sentAt, entry.tpID, true
+	}
+	return time.Time{}, uuid.Nil, false
+}
+
 // Len returns current buffer occupancy.
 func (rb *retxBuffer) Len() int {
 	rb.mu.Lock()

--- a/scripts/tabshot/profile/main.go
+++ b/scripts/tabshot/profile/main.go
@@ -98,17 +98,29 @@ func main() {
 	}
 	nodes := prof.Profile.Nodes
 	sort.Slice(nodes, func(i, j int) bool { return nodes[i].HitCount > nodes[j].HitCount })
-	total := 0
+	// V8 meta-nodes ((idle), (program), (garbage collector), (root)) are not
+	// script execution — counting them as "busy" turns an idle tab into a
+	// false spin alarm, so utilization is computed from real frames only.
+	meta := map[string]bool{"(idle)": true, "(program)": true, "(garbage collector)": true, "(root)": true}
+	total, busy := 0, 0
 	for _, n := range nodes {
 		total += n.HitCount
+		if !meta[n.Frame.FunctionName] {
+			busy += n.HitCount
+		}
 	}
 	wallMs := float64(prof.Profile.EndTime-prof.Profile.StartTime) / 1000
-	fmt.Printf("samples=%d wall=%.0fms (≈%.0f%% of one core busy)\n", total, wallMs,
-		100*float64(total)/(wallMs)) // 1 sample/ms ⇒ samples/ms ≈ core utilization
-	for i, n := range nodes {
-		if i >= 20 || n.HitCount == 0 {
+	fmt.Printf("samples=%d wall=%.0fms (≈%.0f%% of one core busy)\n", busy, wallMs,
+		100*float64(busy)/(wallMs)) // 1 sample/ms ⇒ samples/ms ≈ core utilization
+	shown := 0
+	for _, n := range nodes {
+		if shown >= 20 || n.HitCount == 0 {
 			break
 		}
+		if meta[n.Frame.FunctionName] {
+			continue
+		}
+		shown++
 		name := n.Frame.FunctionName
 		if name == "" {
 			name = "(anonymous)"


### PR DESCRIPTION
The proactive HoL retransmit gated a frontier seq's first nudge on the fastest live leg's RTT. On a heterogeneous leg pair (60ms direct / 300ms multihop) every frame striped onto the slow leg looks stalled one fast-RTT into its ordinary flight and gets retransmitted on the fast leg; the original then lands as a duplicate. A clean 20MB mux transfer measured 30MB of duplicates against 11MB of payload on the slow leg — the fast leg carried the slow leg's stripe twice, negating the aggregation.

Gate each seq on the RTT of the leg it was actually sent on (the retx-buffer transport tag from #4452) times the RACK reorder margin, falling back to the fastest-leg gate when the send leg is unknown. A genuinely lost seq still heals on the fastest leg at ~1.25x its own leg's RTT.

Also fixes the tabshot CDP profiler counting V8 meta-nodes as busy (an idle tab profiled as a 92% spin alarm).