### PR TITLE
feat(cmdutil): js goroutine-dump hook — SIGQUIT parity for wasm instances

### DIFF
--- a/pkg/cmdutil/signal_js.go
+++ b/pkg/cmdutil/signal_js.go
@@ -9,6 +9,7 @@ package cmdutil
 
 import (
 	"os"
+	"runtime"
 	"syscall/js"
 )
 
@@ -38,5 +39,26 @@ func notifyPlatformInterrupt(ch chan<- os.Signal) {
 		default:
 		}
 		return nil
+	}))
+
+	// SIGQUIT parity: globalThis.__skywireDump[SKYWIRE_EXEC_ID]() returns the
+	// full goroutine dump as a string — the diagnostic a native process gives
+	// on SIGQUIT, which the browser otherwise has no way to ask for. A wedged
+	// or CPU-spinning instance (a scheduler pegged by a zero-delay timer loop
+	// shows only runtime frames in a CDP CPU profile) names the looping
+	// goroutine here, from DevTools or the serve harness's js-eval bridge.
+	dumps := g.Get("__skywireDump")
+	if !dumps.Truthy() {
+		dumps = g.Get("Object").New()
+		g.Set("__skywireDump", dumps)
+	}
+	dumps.Set(id, js.FuncOf(func(js.Value, []js.Value) any {
+		buf := make([]byte, 1<<22)
+		n := runtime.Stack(buf, true)
+		for n == len(buf) && len(buf) < 1<<26 {
+			buf = make([]byte, len(buf)*2)
+			n = runtime.Stack(buf, true)
+		}
+		return string(buf[:n])
 	}))
 }

--- a/scripts/tabshot/profile/main.go
+++ b/scripts/tabshot/profile/main.go
@@ -114,7 +114,7 @@ func main() {
 		100*float64(busy)/(wallMs)) // 1 sample/ms ⇒ samples/ms ≈ core utilization
 	shown := 0
 	for _, n := range nodes {
-		if shown >= 20 || n.HitCount == 0 {
+		if shown >= 70 || n.HitCount == 0 {
 			break
 		}
 		if meta[n.Frame.FunctionName] {


### PR DESCRIPTION
A CPU-spinning wasm instance shows only Go scheduler frames in a CDP profile, so the looping goroutine can't be named from outside the runtime. This registers `globalThis.__skywireDump[SKYWIRE_EXEC_ID]()` alongside the existing interrupt hook: it returns the full `runtime.Stack` dump as a string, callable from DevTools or the serve harness's js-eval bridge — the diagnostic SIGQUIT gives a native process. Also lets the tabshot profiler print 70 frames instead of 20.