### PR TITLE
fix(skysocks): raise yamux ConnectionWriteTimeout — saturated uploads reset at ~20s

### DIFF
--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -43,6 +43,20 @@ import (
 // speeds uploads.
 const muxStreamWindowBytes = 16 * 1024 * 1024
 
+// muxConnWriteTimeout replaces yamux's 10s ConnectionWriteTimeout "safety
+// valve" on both the client and server sessions. The valve exists to bound a
+// write into a silently dead conn — but on a skysocks tunnel liveness is
+// already owned by the client's keepalive loop (sessionHardDeadWindow, 45s of
+// total silence), and a genuinely dead session unblocks pending writes with
+// ErrSessionShutdown the moment it is retired. At 10s the valve fired on
+// HEALTHY sessions: a saturated upload backs the session send queue up behind
+// the mesh's actual drain rate, a stream Write blocks past 10s, and the
+// splice tears the connection down — measured live as a reproducible RST ~20s
+// into every bulk upload (and the server side does the same to saturated
+// downloads). Sized above sessionHardDeadWindow so the keepalive verdict,
+// not the valve, decides death.
+const muxConnWriteTimeout = 60 * time.Second
+
 // Client implement multiplexing proxy client using yamux.
 //
 // The client holds N independent yamux sessions ("tunnels"), each over its own
@@ -197,6 +211,7 @@ func newYamuxSession(conn net.Conn) (*yamux.Session, *atomic.Int64, error) {
 	sessionCfg := yamux.DefaultConfig()
 	sessionCfg.EnableKeepAlive = false
 	sessionCfg.MaxStreamWindowSize = muxStreamWindowBytes
+	sessionCfg.ConnectionWriteTimeout = muxConnWriteTimeout
 	session, err := yamux.Client(&recvStampConn{Conn: conn, stamp: stamp}, sessionCfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating client: yamux: %w", err)

--- a/pkg/skysocks/server.go
+++ b/pkg/skysocks/server.go
@@ -123,6 +123,10 @@ func (s *Server) Serve(l net.Listener) error {
 		sessionCfg := yamux.DefaultConfig()
 		sessionCfg.EnableKeepAlive = false
 		sessionCfg.MaxStreamWindowSize = muxStreamWindowBytes
+		// Same raised write valve as the client session (see muxConnWriteTimeout):
+		// at yamux's 10s default the server reset saturated DOWNLOADS the same way
+		// the client reset saturated uploads.
+		sessionCfg.ConnectionWriteTimeout = muxConnWriteTimeout
 		session, err := yamux.Server(conn, sessionCfg)
 		if err != nil {
 			return fmt.Errorf("yamux server failure: %w", err)

--- a/scripts/tabshot/jseval/main.go
+++ b/scripts/tabshot/jseval/main.go
@@ -1,0 +1,54 @@
+// Command jseval evaluates a JS expression in a CDP page target and prints
+
+// the JSON result — direct Runtime.evaluate, no serve-harness needed.
+//
+//	go run ./scripts/tabshot/jseval ws://127.0.0.1:9222/devtools/page/<id> <expr>
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: jseval <webSocketDebuggerUrl> <expr>")
+		os.Exit(2)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, os.Args[1], &websocket.DialOptions{})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "dial:", err)
+		os.Exit(1)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "")
+	b, _ := json.Marshal(map[string]interface{}{
+		"id": 1, "method": "Runtime.evaluate",
+		"params": map[string]interface{}{"expression": os.Args[2], "returnByValue": true, "awaitPromise": true},
+	})
+	if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+		fmt.Fprintln(os.Stderr, "write:", err)
+		os.Exit(1)
+	}
+	for {
+		_, msg, err := c.Read(ctx)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "read:", err)
+			os.Exit(1)
+		}
+		var m struct {
+			ID     int             `json:"id"`
+			Result json.RawMessage `json:"result"`
+		}
+		if json.Unmarshal(msg, &m) == nil && m.ID == 1 {
+			fmt.Println(string(m.Result))
+			return
+		}
+	}
+}

--- a/scripts/tabshot/nav/main.go
+++ b/scripts/tabshot/nav/main.go
@@ -1,0 +1,54 @@
+// Command nav navigates a CDP page target to a URL — the missing half of
+// hardreload for driving a fresh tab (PUT /json/new?url= no longer navigates
+// in current Chromium).
+//
+//	go run ./scripts/tabshot/nav ws://127.0.0.1:9222/devtools/page/<id> <url>
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: nav <webSocketDebuggerUrl> <url>")
+		os.Exit(2)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, os.Args[1], &websocket.DialOptions{})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "dial:", err)
+		os.Exit(1)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "")
+	b, _ := json.Marshal(map[string]interface{}{
+		"id": 1, "method": "Page.navigate",
+		"params": map[string]interface{}{"url": os.Args[2]},
+	})
+	if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+		fmt.Fprintln(os.Stderr, "write:", err)
+		os.Exit(1)
+	}
+	for {
+		_, msg, err := c.Read(ctx)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "read:", err)
+			os.Exit(1)
+		}
+		var m struct {
+			ID     int             `json:"id"`
+			Result json.RawMessage `json:"result"`
+		}
+		if json.Unmarshal(msg, &m) == nil && m.ID == 1 {
+			fmt.Println("navigated:", string(m.Result))
+			return
+		}
+	}
+}


### PR DESCRIPTION
yamux's default 10s ConnectionWriteTimeout fired on healthy sessions: a bulk upload backs the session send queue up behind the mesh's actual drain rate, a stream Write blocks past 10s, and the splice tears the connection down — measured as a reproducible RST ~19-20s into every 20MB upload through a mux3 route (the server side does the same to saturated downloads). Session liveness is already owned by the client keepalive loop (45s total-silence hard-dead window, and a genuinely dead session unblocks pending writes with ErrSessionShutdown), so the valve is raised to 60s on both client and server sessions — the keepalive verdict decides death, not the write valve.

Also adds two small CDP driver tools (scripts/tabshot/nav, jseval) used by the live-test harness.