### PR TITLE
fix(router): RACK threshold tracks measured ack delay, not just idle RTT

### DIFF
--- a/pkg/router/hol_retx.go
+++ b/pkg/router/hol_retx.go
@@ -225,6 +225,10 @@ func (m *routeMux) proactiveRetxSeqs(lastContiguous uint32, words []uint64, fast
 	}
 	interval := holPerSeqInterval(fastestRTTms)
 	fallbackTh := holGapThreshold(fastestRTTms)
+	// Measured send→ack delay floors every gate: when our own sending is
+	// saturated the queue delays acks by seconds, and a frontier hole younger
+	// than that is queued, not lost — nudging it duplicates the queue.
+	ackTh := time.Duration(m.ackDelayMs()) * time.Millisecond
 	var due []uint32
 	for _, seq := range cand {
 		// Only retransmit seqs we still hold: a seq already purged from the retx
@@ -249,6 +253,9 @@ func (m *routeMux) proactiveRetxSeqs(lastContiguous uint32, words []uint64, fast
 		gapTh := fallbackTh
 		if rtt, ok := legRTTms[tpID]; ok && rtt > 0 {
 			gapTh = holGapThreshold(rtt * rackReorderFactor)
+		}
+		if ackTh > gapTh {
+			gapTh = ackTh
 		}
 		if now.Sub(sentAt) < gapTh {
 			continue

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -165,6 +165,15 @@ type routeMux struct {
 	tlpProbeCount   int32
 	rackFactorMilli int64
 	lastAckedContig uint32 // atomic: highest SACK lastContiguous seen (ack-progress edge for TLP reset)
+	// ackDelayMilli is an EWMA (×1000) of the measured send→ack delay of
+	// never-retransmitted frames (fed by retxBuf.onAckDelay). Under load it is
+	// the queue, not the wire, that dominates feedback delay: a saturated leg
+	// holds seconds of in-flight data while the transport's idle-ping RTT still
+	// reads ~25ms, and a RACK threshold built only on the latter declares every
+	// queued frame lost (measured: 899 spurious retransmits on a ~1250-frame
+	// upload). rackThreshold takes the max of both signals. Atomic; 0 = no
+	// sample yet.
+	ackDelayMilli int64
 
 	// lastSACKNano rate-limits receiver-side SACK feedback. Cross-leg
 	// reordering from latency skew makes nearly every packet arrive
@@ -367,6 +376,10 @@ func newRouteMux(logger *logging.Logger, sackEnabled bool) *routeMux {
 		// widens it and clean acks decay it back (see rack_tlp.go).
 		rackFactorMilli: int64(rackReorderFactor * 1000),
 	}
+	// Feed measured send→ack delays into the RACK basis (see ackDelayMs /
+	// rackThreshold): under load the queue, not the wire, dominates feedback
+	// delay, and only this sample sees it.
+	m.retxBuf.onAckDelay = m.recordAckDelay
 	// Default every mux to ECF (Earliest Completion First). It only spills a
 	// frame onto a slower leg once the fastest leg is saturated (a full BDP in
 	// flight), so it never over-assigns a slow leg and stalls the no-skip reorder
@@ -1246,6 +1259,13 @@ func (m *routeMux) rackThreshold() time.Duration {
 	if maxRtt <= 0 {
 		return rackDefaultNoRTT
 	}
+	// The reordering/feedback window is the LARGER of the idle-ping RTT and the
+	// measured send→ack delay (ackDelayMs): a saturated leg's queue delays acks
+	// by seconds while its ping RTT stays at wire level, and presuming loss
+	// inside the real feedback delay is spurious by construction.
+	if ad := m.ackDelayMs(); ad > maxRtt {
+		maxRtt = ad
+	}
 	th := time.Duration(maxRtt*m.rackFactor()) * time.Millisecond
 	if th < rackFloor {
 		th = rackFloor
@@ -1267,6 +1287,33 @@ func (m *routeMux) rackThreshold() time.Duration {
 		th = ceil
 	}
 	return th
+}
+
+// recordAckDelay folds one measured send→ack delay sample into the ackDelay
+// EWMA. Asymmetric on purpose: a sample ABOVE the running value takes it over
+// half-way (α=0.5) so the threshold tracks a queue building in a few SACKs
+// (each spurious retransmit before it catches up is pure waste), while a
+// sample below decays it gently (α=0.125) so one lucky fast ack doesn't
+// re-arm eager retransmission while the queue is still draining.
+func (m *routeMux) recordAckDelay(d time.Duration) {
+	ms := float64(d) / float64(time.Millisecond)
+	for {
+		cur := atomic.LoadInt64(&m.ackDelayMilli)
+		curMs := float64(cur) / 1000
+		alpha := 0.125
+		if ms > curMs {
+			alpha = 0.5
+		}
+		next := int64((curMs + alpha*(ms-curMs)) * 1000)
+		if atomic.CompareAndSwapInt64(&m.ackDelayMilli, cur, next) {
+			return
+		}
+	}
+}
+
+// ackDelayMs returns the EWMA send→ack delay in milliseconds (0 = no sample).
+func (m *routeMux) ackDelayMs() float64 {
+	return float64(atomic.LoadInt64(&m.ackDelayMilli)) / 1000
 }
 
 // maxActiveLegRTTms returns the slowest active (non-standby) leg's EWMA RTT in

--- a/pkg/router/sack.go
+++ b/pkg/router/sack.go
@@ -209,6 +209,16 @@ type retxBuffer struct {
 	mu       sync.Mutex
 	entries  map[uint32]*retxEntry
 	capacity int
+
+	// onAckDelay, when set, receives one send→ack delay sample per ProcessSACK
+	// call: the LARGEST delay among the entries this SACK acknowledged that were
+	// never retransmitted (Karn's rule — a retransmitted entry's delay is
+	// ambiguous). This is the ground truth the RACK threshold needs under load:
+	// the transport's idle-ping RTT says ~25ms while a saturated leg's real
+	// feedback delay is seconds of queue, and a threshold built on the former
+	// declares every queued frame lost (measured live: 899 retransmits across a
+	// ~1250-frame upload). Called with rb.mu held — keep it lock-free/cheap.
+	onAckDelay func(time.Duration)
 }
 
 func newRetxBuffer(capacity int) *retxBuffer {
@@ -305,9 +315,23 @@ func (rb *retxBuffer) ProcessSACK(lastContiguous uint32, words []uint64, thresho
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 
+	// Ack-delay sampling (see onAckDelay): the largest send→ack delay among the
+	// never-retransmitted entries this SACK purges.
+	var ackDelayMax time.Duration
+	sampleNow := time.Now()
+	sample := func(e *retxEntry) {
+		if e.retxCount != 0 {
+			return
+		}
+		if d := sampleNow.Sub(e.sentAt); d > ackDelayMax {
+			ackDelayMax = d
+		}
+	}
+
 	// Purge all entries up to and including lastContiguous.
-	for seq := range rb.entries {
+	for seq, e := range rb.entries {
 		if seq <= lastContiguous {
+			sample(e)
 			delete(rb.entries, seq)
 		}
 	}
@@ -333,7 +357,10 @@ func (rb *retxBuffer) ProcessSACK(lastContiguous uint32, words []uint64, thresho
 		for i := uint32(0); i < 64; i++ {
 			checkSeq := base + i
 			if word&(1<<i) != 0 {
-				delete(rb.entries, checkSeq)
+				if e, ok := rb.entries[checkSeq]; ok {
+					sample(e)
+					delete(rb.entries, checkSeq)
+				}
 			} else if e, ok := rb.entries[checkSeq]; ok {
 				ref := e.sentAt
 				if e.lastTxAt.After(ref) {
@@ -352,6 +379,10 @@ func (rb *retxBuffer) ProcessSACK(lastContiguous uint32, words []uint64, thresho
 				}
 			}
 		}
+	}
+
+	if ackDelayMax > 0 && rb.onAckDelay != nil {
+		rb.onAckDelay(ackDelayMax)
 	}
 
 	return retransmit

--- a/pkg/router/sack_test.go
+++ b/pkg/router/sack_test.go
@@ -296,3 +296,59 @@ func TestRackThreshold(t *testing.T) {
 		t.Fatalf("fast-path threshold = %v, want floor %v", got, rackFloor)
 	}
 }
+
+// TestRackThresholdTracksAckDelay pins the bufferbloat guard: when the measured
+// send→ack delay (the queue) dwarfs the idle-ping RTT, the threshold must be
+// built on the ack delay — a saturated leg holds seconds of in-flight data
+// while its ping RTT reads wire-level, and a threshold under the real feedback
+// delay declares every queued frame lost (measured live: 899 spurious
+// retransmits across a ~1250-frame upload).
+func TestRackThresholdTracksAckDelay(t *testing.T) {
+	log := logging.NewMasterLogger().PackageLogger("rack-ackdelay-test")
+	m := newRouteMux(log, true)
+	m.growLegs(2)
+	m.legMu.Lock()
+	m.legs[0].ecfRttMs = 25
+	m.legs[1].ecfRttMs = 60
+	m.legMu.Unlock()
+
+	base := m.rackThreshold()
+
+	// One sample far above the running EWMA rises fast (α=0.5): 4s of queue.
+	m.recordAckDelay(4 * time.Second)
+	widened := m.rackThreshold()
+	if widened <= base {
+		t.Fatalf("threshold after 4s ack-delay sample = %v, want > base %v", widened, base)
+	}
+	// One sample took it half-way (EWMA 2s) → threshold ≥ 2s, above rackCeil —
+	// the ceil must floor at the measured feedback delay, mirroring the RTT rule.
+	if widened < 2*time.Second {
+		t.Fatalf("threshold %v did not track the ack-delay EWMA (want ≥ 2s)", widened)
+	}
+
+	// Fast samples decay it gently (α=0.125), never below the idle-RTT basis.
+	for i := 0; i < 100; i++ {
+		m.recordAckDelay(20 * time.Millisecond)
+	}
+	relaxed := m.rackThreshold()
+	if relaxed >= widened {
+		t.Fatalf("threshold must decay after fast acks: %v -> %v", widened, relaxed)
+	}
+	want := time.Duration(60*rackReorderFactor) * time.Millisecond
+	if relaxed != want {
+		t.Fatalf("decayed threshold = %v, want idle-RTT basis %v", relaxed, want)
+	}
+
+	// The HoL gate honors the same floor: with the EWMA re-inflated, a young
+	// frontier hole must not be nudged even when far older than its leg's RTT.
+	m.recordAckDelay(10 * time.Second)
+	m.holRetxEnabled = true
+	slowTp := uuid.New()
+	m.retxBuf.Store(101, []byte("a"), slowTp)
+	legRTT := map[uuid.UUID]float64{slowTp: 25}
+	sentAt, _, _ := m.retxBuf.SentInfo(101)
+	words := []uint64{bits(3)}
+	if got := m.proactiveRetxSeqs(100, words, 25, legRTT, sentAt.Add(2*time.Second)); got != nil {
+		t.Fatalf("HoL nudge inside the measured ack delay must be suppressed, got %v", got)
+	}
+}


### PR DESCRIPTION
Under a saturated leg the queue, not the wire, dominates feedback delay: seconds of in-flight data while the transport's idle-ping RTT still reads ~25ms. The RACK threshold built only on ping RTT declared every queued frame lost — 899 spurious retransmits across a ~1250-frame 20MB upload (1.63x wire amplification), even with per-entry backoff.

This samples the send→ack delay of never-retransmitted frames (Karn's rule) at SACK-purge time, folds it into an asymmetric EWMA (rises at α=0.5 so a building queue is tracked within a few SACKs; decays at α=0.125), and bases both the RACK threshold and the proactive HoL age gate on max(idle RTT, measured ack delay). Genuine loss is still detected at ~1.25x the real feedback delay — the earliest it can honestly be distinguished from queueing.