### PR TITLE
fix(skysocks): count send progress as tunnel liveness — uploads retired at hard-dead window

### DIFF
--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -186,9 +186,16 @@ func (c *countingConn) Write(p []byte) (int, error) {
 var errAllTunnelsDown = errors.New("all tunnels to the exit are down")
 
 // recvStampConn wraps a net.Conn to record the wall time of every successful
-// read. The keepalive loop reads the stamp as proof the remote is still
-// sending, so a tunnel mid-download is never retired just because its pong is
-// queued behind the download's own frames (both ride the same conn).
+// read AND write. The keepalive loop reads the stamp as proof the tunnel is
+// still moving bytes, so it is never retired mid-transfer just because its
+// ping/pong is queued behind the transfer's own frames (all ride the same
+// conn). Reads cover a download (the remote is sending); writes cover an
+// UPLOAD — there the tunnel receives nothing and the ping cannot get through
+// the saturated send queue, so send progress is the only liveness evidence
+// (measured live: a healthy 20MB upload retired at the hard-dead window ~112s
+// in). A write that merely lands in a dead conn's buffers stamps briefly, but
+// those buffers fill within seconds under load and the stamps stop — the
+// hard-dead window still ages out a genuinely dead tunnel.
 type recvStampConn struct {
 	net.Conn
 	stamp *atomic.Int64
@@ -196,6 +203,14 @@ type recvStampConn struct {
 
 func (c *recvStampConn) Read(p []byte) (int, error) {
 	n, err := c.Conn.Read(p)
+	if n > 0 {
+		c.stamp.Store(time.Now().UnixNano())
+	}
+	return n, err
+}
+
+func (c *recvStampConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
 	if n > 0 {
 		c.stamp.Store(time.Now().UnixNano())
 	}
@@ -799,7 +814,7 @@ func (c *Client) sessionKeepAliveLoop() {
 				}
 				if now.Sub(lastAlive) >= sessionHardDeadWindow {
 					if c.appCl != nil {
-						c.appCl.Log().Warnf("No pong and no inbound bytes for %v (> hard-dead window); tunnel gone, retiring it", now.Sub(lastAlive).Truncate(time.Second))
+						c.appCl.Log().Warnf("No pong and no traffic either way for %v (> hard-dead window); tunnel gone, retiring it", now.Sub(lastAlive).Truncate(time.Second))
 					}
 					_ = s.Close() //nolint:errcheck
 					delete(lastPong, s)

--- a/pkg/skysocks/client_liveness_test.go
+++ b/pkg/skysocks/client_liveness_test.go
@@ -293,3 +293,78 @@ func TestKeepAlive_DataFlowSurvivesPongStarvation(t *testing.T) {
 	}
 	t.Fatal("fully-silent tunnel was never retired after data stopped")
 }
+
+// TestKeepAlive_UploadSurvivesPongStarvation is the mirror regression test for
+// the upload direction: a peer that DRAINS everything the client sends but
+// sends nothing back (no pong — the client's ping is queued behind the
+// upload's own frames; no data — an upload has no inbound traffic) must
+// survive the hard-dead window, because send progress is liveness evidence in
+// its own right. Measured live before the fix: a healthy 20MB upload retired
+// at ~112s. Once the upload stops (and the peer stays silent), the tunnel must
+// still retire.
+func TestKeepAlive_UploadSurvivesPongStarvation(t *testing.T) {
+	oldInterval, oldWindow := livenessProbeInterval, sessionHardDeadWindow
+	livenessProbeInterval = 15 * time.Millisecond
+	sessionHardDeadWindow = 90 * time.Millisecond
+	t.Cleanup(func() { livenessProbeInterval, sessionHardDeadWindow = oldInterval, oldWindow })
+
+	p1, p2 := net.Pipe()
+	c, err := NewClient(p1, nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	t.Cleanup(func() {
+		c.Close() //nolint:errcheck,gosec
+	})
+
+	// The peer: drain and discard everything the client writes, send nothing.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			if _, err := p2.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	// The upload: a stream writing a chunk every ~10ms. OpenStream's SYN needs
+	// no reply, and every accepted Write stamps the conn as alive.
+	sess := c.snapshotSessions()[0]
+	stream, err := sess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	stopSend := make(chan struct{})
+	go func() {
+		chunk := make([]byte, 1024)
+		tick := time.NewTicker(10 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-stopSend:
+				return
+			case <-tick.C:
+				if _, err := stream.Write(chunk); err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	// Phase 1: upload flowing, nothing inbound — must survive several windows.
+	time.Sleep(4 * sessionHardDeadWindow)
+	if clientClosed(c) {
+		t.Fatal("tunnel with flowing outbound data was retired despite pong starvation")
+	}
+
+	// Phase 2: upload stops, peer stays silent — must now retire.
+	close(stopSend)
+	deadline := time.Now().Add(8 * sessionHardDeadWindow)
+	for time.Now().Before(deadline) {
+		if clientClosed(c) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("fully-silent tunnel was never retired after the upload stopped")
+}


### PR DESCRIPTION
The keepalive verdict (no pong AND no inbound bytes for the 45s hard-dead window) covered downloads but not uploads: a saturated upload has no inbound traffic and the client's own ping is queued behind the upload's frames, so a healthy tunnel mid-upload was retired at the hard-dead window — measured live at ~112s into a 20MB upload, with the whole tunnel set rebuilt after.

A Write accepted by the route-group conn is liveness evidence in its own right: writes now stamp the same activity stamp as reads, and the keepalive loop's verdict is unchanged (no pong and no traffic either way). A dead conn's buffers fill within seconds so the stamps stop, and true silence still ages the tunnel out — pinned by a new mirror regression test (upload flowing + total pong starvation survives; upload stopped + silence retires).