### PR TITLE
fix(dmsg): per-destination dial-failure backoff — wedged dst pegged a browser core

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -165,6 +165,18 @@ type Client struct {
 	entryCache   map[cipher.PubKey]entryCacheEntry
 	entryCacheMx sync.RWMutex
 
+	// dialFail backs off repeated DialStream failures per DESTINATION. When a
+	// destination is persistently unreachable (its delegated server refuses —
+	// dmsg error 202), every periodic caller (discovery updates, trackers)
+	// otherwise re-pays the full dial ladder each tick — up to 16 existing-
+	// session stream attempts plus 2 brand-new noise handshakes — which pegged
+	// a browser core at ~92% (measured: ~12.6 goroutines/s created for 44
+	// minutes straight in a wasm visor whose dmsgd path had wedged). Within
+	// the backoff window DialStream fast-fails with the recorded error; any
+	// success clears the state. Lazily initialized.
+	dialFail   map[cipher.PubKey]*dialFailState
+	dialFailMx sync.Mutex
+
 	// carrierFailAt records, per dmsg-server PK, the time of the last carrier
 	// convergence re-dial that landed on a less-preferred carrier or failed
 	// (see ConvergeCarriers). A server whose preferred endpoint is unreachable
@@ -916,6 +928,58 @@ func hasPK(pks []cipher.PubKey, pk cipher.PubKey) bool {
 		}
 	}
 	return false
+}
+
+// Per-destination dial-failure backoff bounds (see Client.dialFail).
+const (
+	dialFailBackoffMin = 2 * time.Second
+	dialFailBackoffMax = 60 * time.Second
+)
+
+// dialFailState is one destination's failure-backoff record.
+type dialFailState struct {
+	until   time.Time     // fast-fail DialStream calls before this instant
+	backoff time.Duration // next window length (doubles per failure, capped)
+	lastErr error         // the error fast-failed calls return
+}
+
+// dialFailCheck reports whether dst is inside its failure-backoff window, and
+// the error to fast-fail with.
+func (ce *Client) dialFailCheck(dst cipher.PubKey) (error, bool) {
+	ce.dialFailMx.Lock()
+	defer ce.dialFailMx.Unlock()
+	st, ok := ce.dialFail[dst]
+	if !ok || time.Now().After(st.until) {
+		return nil, false
+	}
+	return st.lastErr, true
+}
+
+// dialFailRecord notes a full DialStream failure for dst, doubling its
+// backoff window up to the cap.
+func (ce *Client) dialFailRecord(dst cipher.PubKey, err error) {
+	ce.dialFailMx.Lock()
+	defer ce.dialFailMx.Unlock()
+	if ce.dialFail == nil {
+		ce.dialFail = make(map[cipher.PubKey]*dialFailState)
+	}
+	st, ok := ce.dialFail[dst]
+	if !ok {
+		st = &dialFailState{backoff: dialFailBackoffMin}
+		ce.dialFail[dst] = st
+	}
+	st.until = time.Now().Add(st.backoff)
+	st.lastErr = err
+	if st.backoff *= 2; st.backoff > dialFailBackoffMax {
+		st.backoff = dialFailBackoffMax
+	}
+}
+
+// dialFailClear wipes dst's failure state on a successful dial.
+func (ce *Client) dialFailClear(dst cipher.PubKey) {
+	ce.dialFailMx.Lock()
+	delete(ce.dialFail, dst)
+	ce.dialFailMx.Unlock()
 }
 
 // getCachedRoute returns the server PK that last successfully reached the given destination.

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -32,6 +32,14 @@ func (ce *Client) Dial(ctx context.Context, addr Addr) (net.Conn, error) {
 
 // DialStream dials to a remote client entity with the given address.
 func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
+	// Fast-fail inside a destination's failure-backoff window (see
+	// Client.dialFail): a persistently unreachable destination otherwise costs
+	// every periodic caller the full dial ladder — stream attempts across all
+	// existing sessions plus new-session noise handshakes — every tick.
+	if failErr, backing := ce.dialFailCheck(addr.PK); backing {
+		return nil, failErr
+	}
+
 	entry, discErr := ce.getClientEntryCached(ctx, addr.PK)
 	if discErr != nil {
 		// Discovery lookup failed. For direct clients or when the destination
@@ -49,8 +57,12 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 			defer fallbackCancel()
 			stream, err := ce.dialViaConnectedServers(fallbackCtx, addr)
 			if err == nil {
+				ce.dialFailClear(addr.PK)
 				return stream, nil
 			}
+		}
+		if ctx.Err() == nil {
+			ce.dialFailRecord(addr.PK, discErr)
 		}
 		return nil, discErr
 	}
@@ -64,6 +76,7 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 					Debug("DialStream failed via cached route, evicting")
 				ce.evictCachedRoute(addr.PK)
 			} else {
+				ce.dialFailClear(addr.PK)
 				return stream, nil
 			}
 		} else {
@@ -109,6 +122,7 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	// mode of TestMultiServerStreams).
 	delegatedSessions := ce.sortedDelegatedSessions(entry.Client.DelegatedServers)
 	if stream, ok := ce.sequentialPhaseDial(ctx, addr, delegatedSessions, maxPerExistingPhase); ok {
+		ce.dialFailClear(addr.PK)
 		return stream, nil
 	}
 
@@ -118,6 +132,7 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	// Skips negative-cached pairs.
 	meshSessions := ce.sortedMeshSessions(entry.Client.DelegatedServers)
 	if stream, ok := ce.sequentialPhaseDial(ctx, addr, meshSessions, maxPerExistingPhase); ok {
+		ce.dialFailClear(addr.PK)
 		return stream, nil
 	}
 
@@ -137,9 +152,16 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 			continue
 		}
 		ce.setCachedRoute(addr.PK, srvPK)
+		ce.dialFailClear(addr.PK)
 		return stream, nil
 	}
 
+	// The whole ladder failed. Skip recording when the CALLER's context ran
+	// out (its short deadline says nothing about the destination — recording
+	// it would fast-fail other callers with healthy budgets).
+	if ctx.Err() == nil {
+		ce.dialFailRecord(addr.PK, ErrCannotConnectToDelegated)
+	}
 	return nil, ErrCannotConnectToDelegated
 }
 

--- a/pkg/dmsg/dmsg/client_dialfail_test.go
+++ b/pkg/dmsg/dmsg/client_dialfail_test.go
@@ -1,0 +1,62 @@
+package dmsg
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDialFailBackoff covers the per-destination dial-failure backoff state
+// machine: no backoff before a failure, fast-fail with the recorded error
+// inside the window, doubling per repeat up to the cap, and a full reset on
+// success. This is the guard against a persistently unreachable destination
+// costing every periodic caller the full dial ladder (existing-session stream
+// attempts plus new-session noise handshakes) every tick — measured as a
+// wedged wasm visor pegging ~92% of a browser core for 44 minutes.
+func TestDialFailBackoff(t *testing.T) {
+	ce := &Client{}
+	dst := mkPK(t)
+	errBoom := errors.New("boom")
+
+	// Clean destination: no backoff.
+	if _, backing := ce.dialFailCheck(dst); backing {
+		t.Fatal("fresh destination must not be backing off")
+	}
+
+	// First failure opens a window carrying the error.
+	ce.dialFailRecord(dst, errBoom)
+	gotErr, backing := ce.dialFailCheck(dst)
+	require.True(t, backing, "recorded failure must open a backoff window")
+	require.ErrorIs(t, gotErr, errBoom)
+
+	// Repeated failures double the NEXT window up to the cap.
+	st := ce.dialFail[dst]
+	require.Equal(t, 2*dialFailBackoffMin, st.backoff, "second window must double")
+	for i := 0; i < 10; i++ {
+		ce.dialFailRecord(dst, errBoom)
+	}
+	require.Equal(t, dialFailBackoffMax, ce.dialFail[dst].backoff, "backoff must cap")
+
+	// An expired window stops fast-failing (the next real attempt goes through).
+	ce.dialFail[dst].until = time.Now().Add(-time.Millisecond)
+	if _, backing := ce.dialFailCheck(dst); backing {
+		t.Fatal("expired window must not fast-fail")
+	}
+
+	// Success wipes the state entirely, including the grown backoff.
+	ce.dialFailRecord(dst, errBoom)
+	ce.dialFailClear(dst)
+	if _, backing := ce.dialFailCheck(dst); backing {
+		t.Fatal("cleared destination must not be backing off")
+	}
+	require.NotContains(t, ce.dialFail, dst)
+
+	// Another destination is unaffected throughout.
+	other := mkPK(t)
+	ce.dialFailRecord(dst, errBoom)
+	if _, backing := ce.dialFailCheck(other); backing {
+		t.Fatal("backoff must be per-destination")
+	}
+}


### PR DESCRIPTION
A persistently unreachable destination (delegated server refusing — dmsg error 202) cost every periodic caller the full DialStream ladder each tick: up to 16 existing-session stream attempts plus 2 brand-new noise handshakes. In the wasm visor a wedged dmsgd path created ~12.6 goroutines/s for 44 minutes straight and pegged ~92% of a browser core in scheduler/handshake churn — the intermittent desk-tab CPU spin-lock, caught by a goroutine dump via the new __skywireDump hook.

DialStream now records a full-ladder failure per destination and fast-fails inside a doubling backoff window (2s to 60s cap); any successful dial clears the state, and a caller whose own context expired records nothing (its short deadline says nothing about the destination). Recovery after a genuine outage is retried within at most 60s.