### PR TITLE
fix(appdisc): never advertise a js/wasm visor as a clearnet exit

### DIFF
--- a/pkg/app/appdisc/egress_js.go
+++ b/pkg/app/appdisc/egress_js.go
@@ -1,0 +1,13 @@
+//go:build js
+
+// Package appdisc pkg/app/appdisc/egress_js.go c2-vis-appsvc
+package appdisc
+
+// canAdvertiseExit is false on js/wasm: a browser cannot open arbitrary
+// TCP/UDP connections, so a wasm visor's skysocks/VPN server has no clearnet
+// egress and must not register as an exit — peers that picked one from
+// service discovery formed the route, then every clearnet request failed
+// (the "zombie exit" the honest-probe machinery exists to weed out; better
+// not to enter the pool at all). The mesh-side skysocks server still works
+// for in-mesh targets; it just is not advertised as an exit.
+const canAdvertiseExit = false

--- a/pkg/app/appdisc/egress_native.go
+++ b/pkg/app/appdisc/egress_native.go
@@ -1,0 +1,9 @@
+//go:build !js
+
+// Package appdisc pkg/app/appdisc/egress_native.go c2-vis-appsvc
+package appdisc
+
+// canAdvertiseExit reports whether this build can serve as a clearnet exit —
+// the capability the ServiceTypeSkysocks / ServiceTypeVPN registrations
+// promise the fleet. Native builds can open arbitrary TCP/UDP egress.
+const canAdvertiseExit = true

--- a/pkg/app/appdisc/factory_native.go
+++ b/pkg/app/appdisc/factory_native.go
@@ -135,12 +135,21 @@ func (f *Factory) AppUpdater(conf appcommon.ProcConfig) (Updater, bool) {
 
 	switch conf.AppName {
 	case skyenv.VPNServerName:
+		if !canAdvertiseExit {
+			return &emptyUpdater{}, false
+		}
 		return newServiceUpdater(
 			log,
 			servicedisc.NewClient(log, f.MLog, getServiceDiscConf(conf, servicedisc.ServiceTypeVPN), f.httpClient(), f.ClientPublicIP),
 			f.HeartbeatInterval,
 		), true
 	case skyenv.SkysocksName:
+		// An exit registration promises clearnet egress; a build that cannot
+		// deliver it (js/wasm — see canAdvertiseExit) must stay out of the
+		// pool rather than hand the fleet a zombie exit.
+		if !canAdvertiseExit {
+			return &emptyUpdater{}, false
+		}
 		return newServiceUpdater(
 			log,
 			servicedisc.NewClient(log, f.MLog, getServiceDiscConf(conf, servicedisc.ServiceTypeSkysocks), f.httpClient(), f.ClientPublicIP),


### PR DESCRIPTION
An exit registration (ServiceTypeSkysocks / ServiceTypeVPN) promises clearnet egress a browser cannot deliver — a wasm visor's skysocks server entered the fleet's exit pool, and every peer that picked it formed the route then failed each clearnet request (the zombie-exit class the honest-probe machinery exists to weed out; better to never enter the pool). A per-build capability constant (canAdvertiseExit, false under GOOS=js) gates the AppUpdater exit registrations; the mesh-side skysocks server keeps working for in-mesh targets.