### PR TITLE
fix(transport): Set*Handler must not hold handlerMu across tm.mx — boot deadlock

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -702,10 +702,17 @@ func (tm *Manager) SetPTpsCache(pTps []PersistentTransports) {
 // SetCascadeHandler sets the handler for cascade protocol packets (route ID 0).
 // Called by the router to register its cascade handler.
 func (tm *Manager) SetCascadeHandler(h func(p routing.Packet, mt *ManagedTransport)) {
+	// Lock-ordering rule (all Set*Handler funcs): NEVER hold the handler
+	// mutex while taking tm.mx. acceptTransport does the reverse — it holds
+	// tm.mx (write) while reading the handlers under handlerMu.RLock — so a
+	// setter that held handlerMu across tm.mx.RLock deadlocked the whole
+	// manager the moment an inbound transport was being accepted while an
+	// init module installed its handler (AB-BA; live-caught: the visor's
+	// entire transport layer, RPC and hypervisor UI wedged from boot).
 	tm.cascadeHandlerMu.Lock()
-	defer tm.cascadeHandlerMu.Unlock()
 	tm.cascadeHandler = h
-	// Propagate to existing transports.
+	tm.cascadeHandlerMu.Unlock()
+	// Propagate to existing transports (local h, no handlerMu held).
 	tm.mx.RLock()
 	for _, mt := range tm.tps {
 		mt.cascadeHandler = h
@@ -722,8 +729,8 @@ func (tm *Manager) ShouldRegisterAR() bool {
 // SetDHTHandler sets the handler for DHT protocol packets (route ID 0).
 func (tm *Manager) SetDHTHandler(h func(p routing.Packet, mt *ManagedTransport)) {
 	tm.dhtHandlerMu.Lock()
-	defer tm.dhtHandlerMu.Unlock()
 	tm.dhtHandler = h
+	tm.dhtHandlerMu.Unlock() // see SetCascadeHandler: never hold handlerMu across tm.mx
 	tm.mx.RLock()
 	for _, mt := range tm.tps {
 		mt.dhtHandler = h
@@ -734,8 +741,8 @@ func (tm *Manager) SetDHTHandler(h func(p routing.Packet, mt *ManagedTransport))
 // SetVisorRPCHandler sets the handler for visor RPC packets (route ID 0).
 func (tm *Manager) SetVisorRPCHandler(h func(p routing.Packet, mt *ManagedTransport)) {
 	tm.visorRPCHandlerMu.Lock()
-	defer tm.visorRPCHandlerMu.Unlock()
 	tm.visorRPCHandler = h
+	tm.visorRPCHandlerMu.Unlock() // see SetCascadeHandler: never hold handlerMu across tm.mx
 	tm.mx.RLock()
 	for _, mt := range tm.tps {
 		mt.visorRPCHandler = h
@@ -746,8 +753,8 @@ func (tm *Manager) SetVisorRPCHandler(h func(p routing.Packet, mt *ManagedTransp
 // SetSkynetForwardHandler sets the handler for skynet forward packets (route ID 0).
 func (tm *Manager) SetSkynetForwardHandler(h func(p routing.Packet, mt *ManagedTransport)) {
 	tm.skynetFwdHandlerMu.Lock()
-	defer tm.skynetFwdHandlerMu.Unlock()
 	tm.skynetFwdHandler = h
+	tm.skynetFwdHandlerMu.Unlock() // see SetCascadeHandler: never hold handlerMu across tm.mx
 	tm.mx.RLock()
 	for _, mt := range tm.tps {
 		mt.skynetFwdHandler = h
@@ -760,8 +767,8 @@ func (tm *Manager) SetSkynetForwardHandler(h func(p routing.Packet, mt *ManagedT
 // streams to the per-app server-side accept loop without route setup.
 func (tm *Manager) SetAppDirectHandler(h func(p routing.Packet, mt *ManagedTransport)) {
 	tm.appDirectHandlerMu.Lock()
-	defer tm.appDirectHandlerMu.Unlock()
 	tm.appDirectHandler = h
+	tm.appDirectHandlerMu.Unlock() // see SetCascadeHandler: never hold handlerMu across tm.mx
 	tm.mx.RLock()
 	for _, mt := range tm.tps {
 		mt.appDirectHandler = h
@@ -772,8 +779,8 @@ func (tm *Manager) SetAppDirectHandler(h func(p routing.Packet, mt *ManagedTrans
 // SetSetupRPCHandler sets the handler for RSN RPC relay packets (route ID 0).
 func (tm *Manager) SetSetupRPCHandler(h func(p routing.Packet, mt *ManagedTransport)) {
 	tm.setupRPCHandlerMu.Lock()
-	defer tm.setupRPCHandlerMu.Unlock()
 	tm.setupRPCHandler = h
+	tm.setupRPCHandlerMu.Unlock() // see SetCascadeHandler: never hold handlerMu across tm.mx
 	tm.mx.RLock()
 	for _, mt := range tm.tps {
 		mt.setupRPCHandler = h


### PR DESCRIPTION
acceptTransport holds tm.mx (write) while reading the six packet handlers under their handlerMu.RLocks (manager.go:1092-1109); every Set*Handler held its handlerMu across tm.mx.RLock. When an inbound transport was accepted at the moment an init module installed its handler, the two deadlocked (AB-BA) and the entire transport layer — RPC on :3435, the hypervisor UI, every transport operation — wedged from boot until restart. Intermittent because it needs an accept to land inside the init window.

Live-caught on the dev visor via pprof goroutine dump: acceptTransport parked at manager.go:1104 (skynetFwdHandlerMu.RLock) while initSkywireForwardConn's SetSkynetForwardHandler held that mutex waiting at manager.go:751 for tm.mx.RLock.

Fix: all six setters release handlerMu before taking tm.mx (propagation uses the local handler value), so the two locks are never held together in either order. pkg/transport passes with -race.