### PR TITLE
fix(desk): /desk must redirect RELATIVE or it escapes the vnet prefix

### DIFF
--- a/pkg/visor/hypervisor_desk_test.go
+++ b/pkg/visor/hypervisor_desk_test.go
@@ -86,8 +86,11 @@ func TestNativeDeskServing(t *testing.T) {
 		if w.Code != http.StatusMovedPermanently {
 			t.Fatalf("status=%d, want 301", w.Code)
 		}
-		if loc := w.Header().Get("Location"); loc != "/" {
-			t.Errorf("Location=%q, want /", loc)
+		// RELATIVE on purpose: served under a /vnet/<port>/ prefix an absolute
+		// "/" escapes to the outer server's root, a different visor. See the
+		// handler.
+		if loc := w.Header().Get("Location"); loc != "./" {
+			t.Errorf("Location=%q, want ./ (relative, so the vnet prefix survives)", loc)
 		}
 	})
 

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -109,7 +109,18 @@ func (hv *Hypervisor) uiHandler() http.Handler {
 			return
 		case "/desk":
 			// The old separate desk path — gone; the desk IS the root now.
-			http.Redirect(w, r, "/", http.StatusMovedPermanently)
+			//
+			// The Location is written by hand, and is RELATIVE. Reached
+			// through the vnet service worker this page lives under a
+			// /vnet/<port>/ prefix that the server never sees, so an absolute
+			// "/" escapes the prefix and lands on the OUTER server's root — a
+			// different visor entirely. "./" is resolved by the BROWSER
+			// against the URL it actually asked for, which keeps the prefix.
+			// http.Redirect cannot be used here: it resolves a relative
+			// target against the request path server-side, turning it back
+			// into the absolute "/" this is avoiding.
+			w.Header().Set("Location", "./")
+			w.WriteHeader(http.StatusMovedPermanently)
 			return
 		case "/dashboard", "/dashboard/":
 			// The Angular dashboard's index, served injected exactly as the old

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -322,8 +322,14 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	// The desk IS the root here too, matching the visor-attached hypervisor
 	// (#4491). The old separate path redirects rather than serving a second
 	// copy, so a bookmark or a docs link still lands somewhere sensible.
-	mux.HandleFunc("/desk", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/", http.StatusMovedPermanently)
+	mux.HandleFunc("/desk", func(w http.ResponseWriter, _ *http.Request) {
+		// A hand-written RELATIVE Location. Reached through the vnet service
+		// worker this page lives under a /vnet/<port>/ prefix the server never
+		// sees, so an absolute "/" escapes it and lands on the OUTER server's
+		// root — a different visor entirely. http.Redirect cannot do this: it
+		// resolves a relative target server-side, back into the absolute "/".
+		w.Header().Set("Location", "./")
+		w.WriteHeader(http.StatusMovedPermanently)
 	})
 	// The Angular dashboard keeps its own path, for a link that wants the
 	// dashboard specifically rather than the shell around it.


### PR DESCRIPTION
Reached through the vnet service worker, a hypervisor page lives under a `/vnet/<port>/` prefix that the server never sees. The `/desk` redirect sent an absolute `/`, so following it from `/vnet/8001/desk` landed on the **outer** server's root — a different visor entirely, and silently.

The `Location` is now written by hand as `./`, which the browser resolves against the URL it actually asked for. `http.Redirect` cannot express this: it resolves a relative target against the request path server-side, turning it straight back into the absolute `/` this is avoiding — which is why the existing test kept passing while the behaviour was wrong. The test now asserts the relative form and says why.

Verified live: `/vnet/8001/desk` lands on `/vnet/8001/` instead of the outer origin.

Worth noting for anyone touching the framed-request detection added in #4498: the vnet service worker does **not** forward `Sec-Fetch-Dest`, so for a page reached through it the `?embed=1` query is the signal that actually does the work. Both are checked; on a directly-served page `Sec-Fetch-Dest` is the one that survives a frame reload.