### PR TITLE
fix(rewards): tp-viz reuses the server's dmsg client instead of a second one

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/cmd.go
+++ b/cmd/skywire-cli/commands/rewards/server/cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/skycoin/skywire/pkg/calvin"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/tpviz"
 )
 
 var err error
@@ -45,6 +46,11 @@ var (
 	// could conflict with the visor's hypervisor API when the reward
 	// system is hosted by the visor.
 	disableTpVizAPI bool
+
+	// tpvizSrv is the tp-viz server built by buildRouter, kept here so
+	// serveStandalone can hand it the ONE dmsg client this process owns once
+	// that client exists. buildRouter runs first and has no client to give.
+	tpvizSrv *tpviz.Server
 )
 
 var skyenvfile = os.Getenv("SKYENV")

--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -241,31 +241,17 @@ func buildRouter() *gin.Engine {
 		tpvizServer := tpviz.NewServer(tpvizCfg)
 		tpvizServer.Start() // Initialize cache and start auto-refresh
 
-		// Source deployment discovery (TPD/SD/DMSG) over dmsg instead of the
-		// now-dead clearnet HTTP frontends: start an embedded dmsg client
-		// (seeded from the deployment's dmsg servers, discovery over dmsg) and
-		// hand tp-viz an HTTP-over-dmsg client. Background + best-effort so the
-		// UI starts immediately; until dmsg connects, tp-viz gates the clearnet
-		// fetches (no 404 spam). Standalone only — when hosted by a visor the
-		// visor's CXO feeds tp-viz instead.
-		if !disableTpVizAPI {
-			go func() {
-				dlog := logging.MustGetLogger("tpviz-dmsg")
-				pk, sk := cipher.GenerateKeyPair()
-				dmsgC, _, err := dmsgclient.StartDmsgEmbedded(context.Background(), dlog, pk, sk, false)
-				if err != nil {
-					dlog.WithError(err).Warn("tp-viz: dmsg client for discovery failed to start; network-viz tabs disabled")
-					return
-				}
-				tpvizServer.SetDmsgHTTPClient(&http.Client{Transport: dmsghttp.MakeHTTPTransport(context.Background(), dmsgC)})
-				// Prefer the intermittent CXO subscriber over the same dmsg client:
-				// tp-viz sources TPD/SD/DMSG-D data (transports, uptime, services,
-				// dmsg-clients) from the deployment CXO feeds and only falls back to
-				// the HTTP-over-dmsg client above on a cache miss.
-				tpvizServer.SetCXOSubMgrFromDmsg(dmsgC)
-				dlog.Info("tp-viz: deployment discovery now sourced over dmsg (CXO-first)")
-			}()
-		}
+		// tp-viz sources deployment discovery (TPD/SD/DMSG) over dmsg, the
+		// clearnet HTTP frontends being gone. It does NOT get a dmsg client of
+		// its own: this process already runs one under its CONFIGURED key
+		// (serveStandalone), and a second client is a second identity in the
+		// discovery for no gain — the old code minted a throwaway keypair here,
+		// shadowing the very `pk, sk` this function derives from the configured
+		// secret key a few lines up. serveStandalone hands the real client over
+		// once it exists; until then tp-viz gates its fetches (no 404 spam).
+		// Hosted by a visor, disableTpVizAPI is set and the visor's CXO feeds
+		// tp-viz instead.
+		tpvizSrv = tpvizServer
 
 		// Delegate /api/* to tpviz server (uses file caching to avoid rate limits)
 		// When hosted by the visor, /api/* routes are disabled to prevent
@@ -1826,6 +1812,17 @@ func serveStandalone(r1 *gin.Engine, bindAddr string) {
 	statsDmsgHTTPClient = &http.Client{
 		Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgClient),
 		Timeout:   45 * time.Second,
+	}
+
+	// tp-viz reads the deployment over THIS client rather than one of its own.
+	// It is the same process and the same identity; a second dmsg client would
+	// mean a second entry in the discovery to read services this one already
+	// reaches. CXO-first: tp-viz sources TPD/SD/DMSG-D data from the deployment
+	// feeds and falls back to the HTTP-over-dmsg client only on a cache miss.
+	if !disableTpVizAPI && tpvizSrv != nil {
+		tpvizSrv.SetDmsgHTTPClient(&http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgClient)})
+		tpvizSrv.SetCXOSubMgrFromDmsg(dmsgClient)
+		log.Info("tp-viz: deployment discovery sourced over the reward server's own dmsg client (CXO-first)")
 	}
 
 	lis, err := dmsgClient.Listen(dmsgPort) //nolint: gosec


### PR DESCRIPTION
Follow-up to #4501, same bug shape in the one place that legitimately runs standalone tp-viz.

The reward server is configured with a dmsg identity — `--sk`, or `DMSGHTTP_SK` — and `serveStandalone` starts a client under it and **listens** on the dmsg port, so it must be registered and reachable by PK. Then `buildRouter` started a **second** client from `cipher.GenerateKeyPair()`, shadowing the very `pk, sk` it had derived from that configured secret key a few lines above, purely so tp-viz could read TPD/SD/DMSG-D.

Two clients, two entries in the discovery, one process — and the second identity thrown away and re-minted on every restart, to reach services the first client already reaches.

tp-viz now takes the client this process already owns: `buildRouter` keeps the server it built, and `serveStandalone` hands it the client once that exists (`buildRouter` runs first and has none to give). Until then tp-viz gates its fetches, exactly as before. The visor-hosted path is unaffected — the visor sets `DisableTpVizAPI` (`pkg/visor/api_network.go:171`) and feeds tp-viz its own CXO.

Worth stating explicitly, since it is the obvious-looking alternative: the two clients could **not** simply share the configured key. dmsg-discovery holds one entry per public key, so two clients under one key fight over it. Reusing the client is the only correct form.