### PR TITLE
fix(dmsg): re-dial the server a client just lost before taking a new one

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -190,6 +190,19 @@ type Client struct {
 	carrierLastErr map[cipher.PubKey]string
 	carrierFailMx  sync.Mutex
 
+	// lostSession records dmsg-server PKs whose session just dropped, with the
+	// number of re-dial attempts spent on each. When the Serve loop wakes on
+	// errCh it re-dials the server it just lost BEFORE advancing to an arbitrary
+	// next candidate. Reconnecting to the same server leaves
+	// Client.DelegatedServers unchanged, so updateClientEntry's SamePubKeys
+	// check short-circuits and no discovery write happens; moving to a different
+	// server forces a PutEntry. At fleet scale that difference is the bulk of
+	// the discovery's entry-update load (#4086). Bounded by
+	// lostSessionMaxRetries so a genuinely dead server is abandoned rather than
+	// retried forever. Lazily initialized.
+	lostSession   map[cipher.PubKey]int
+	lostSessionMx sync.Mutex
+
 	// carrier convergence controls: convMx guards a runtime override of the
 	// ordered carrier preference (nil = Config.Carriers) and a live-only
 	// discovery client used to read a server's CURRENT WT/QUIC endpoints
@@ -594,6 +607,14 @@ func (ce *Client) Serve(ctx context.Context) {
 					ce.log.WithError(err).Debug("Session stopped.")
 					if isClosed(ce.done) {
 						return
+					}
+					// Prefer re-dialing the server we just lost. Reconnecting to
+					// the SAME server leaves Client.DelegatedServers unchanged, so
+					// no discovery entry update is triggered; advancing to the next
+					// candidate changes the set and forces a PutEntry (#4086). Fall
+					// through to the next candidate only when the re-dial fails.
+					if ce.redialLostSession(cancellabelCtx) {
+						continue
 					}
 				}
 			}
@@ -1057,6 +1078,78 @@ func (ce *Client) SetDHTLookup(fn func(pk cipher.PubKey) (*disc.Entry, error)) {
 // entry would mean someone passed a non-server PK as srvPK, which is
 // a programming error in the caller and we want to surface it the
 // same way the bare disc lookup did.
+
+// lostSessionMaxRetries bounds how many times the Serve loop re-dials a server
+// whose session dropped before giving up and taking the next candidate. Two
+// attempts covers a server restart or a transient carrier hiccup without
+// pinning the client to a host that is genuinely gone.
+const lostSessionMaxRetries = 2
+
+// noteLostSession marks a dmsg server as recently dropped so the Serve loop
+// prefers re-dialing it over moving to a different server.
+func (ce *Client) noteLostSession(pk cipher.PubKey) {
+	ce.lostSessionMx.Lock()
+	defer ce.lostSessionMx.Unlock()
+	if ce.lostSession == nil {
+		ce.lostSession = make(map[cipher.PubKey]int)
+	}
+	if _, ok := ce.lostSession[pk]; !ok {
+		ce.lostSession[pk] = 0
+	}
+}
+
+// takeLostSession pops one recently-dropped server PK that still has re-dial
+// budget, charging it an attempt. Entries past their budget are discarded.
+func (ce *Client) takeLostSession() (cipher.PubKey, bool) {
+	ce.lostSessionMx.Lock()
+	defer ce.lostSessionMx.Unlock()
+	for pk, attempts := range ce.lostSession {
+		if attempts >= lostSessionMaxRetries {
+			delete(ce.lostSession, pk)
+			continue
+		}
+		ce.lostSession[pk] = attempts + 1
+		return pk, true
+	}
+	return cipher.PubKey{}, false
+}
+
+func (ce *Client) clearLostSession(pk cipher.PubKey) {
+	ce.lostSessionMx.Lock()
+	defer ce.lostSessionMx.Unlock()
+	delete(ce.lostSession, pk)
+}
+
+// redialLostSession re-establishes a session with a server whose session
+// recently dropped, and reports whether one was restored. A restored session
+// keeps the client's delegated-server set identical, which is what avoids the
+// discovery entry update (#4086).
+func (ce *Client) redialLostSession(ctx context.Context) bool {
+	pk, ok := ce.takeLostSession()
+	if !ok {
+		return false
+	}
+	if _, held := ce.session(pk); held {
+		ce.clearLostSession(pk)
+		return true
+	}
+	entry, err := ce.resolveServerEntry(ctx, pk)
+	if err != nil || entry == nil || entry.Server == nil {
+		ce.log.WithField("remote_pk", pk).WithError(err).
+			Debug("Dropped server no longer resolvable; taking next candidate.")
+		return false
+	}
+	if err := ce.EnsureSession(ctx, entry); err != nil {
+		ce.log.WithField("remote_pk", pk).WithError(err).
+			Debug("Re-dial of dropped server failed; taking next candidate.")
+		return false
+	}
+	ce.clearLostSession(pk)
+	ce.log.WithField("remote_pk", pk).
+		Debug("Re-established session with the server that dropped; delegated servers unchanged.")
+	return true
+}
+
 func (ce *Client) resolveServerEntry(ctx context.Context, srvPK cipher.PubKey) (*disc.Entry, error) {
 	if entry, ok := ce.getCachedEntry(srvPK); ok && entry != nil && entry.Server != nil {
 		return entry, nil

--- a/pkg/dmsg/dmsg/client_lostsession_test.go
+++ b/pkg/dmsg/dmsg/client_lostsession_test.go
@@ -1,0 +1,69 @@
+package dmsg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLostSessionBudget covers the bookkeeping behind preferring a re-dial of
+// the server whose session just dropped over moving to a different one. A
+// client that reconnects to the SAME server keeps its delegated-server set
+// unchanged, so no discovery entry update is published; every rotation to a
+// different server forces one, which at fleet scale is the bulk of the
+// discovery's entry-update load (#4086).
+//
+// The budget is what keeps that preference from pinning a client to a server
+// that is genuinely gone.
+func TestLostSessionBudget(t *testing.T) {
+	ce := &Client{}
+	srv := mkPK(t)
+
+	// Nothing dropped yet.
+	_, ok := ce.takeLostSession()
+	require.False(t, ok)
+
+	// A drop is retried up to lostSessionMaxRetries times.
+	ce.noteLostSession(srv)
+	for i := 0; i < lostSessionMaxRetries; i++ {
+		pk, ok := ce.takeLostSession()
+		require.True(t, ok, "attempt %d should still have budget", i)
+		require.Equal(t, srv, pk)
+	}
+
+	// Budget spent: the entry is dropped rather than retried forever, so the
+	// Serve loop falls through to the next candidate.
+	_, ok = ce.takeLostSession()
+	require.False(t, ok)
+	require.Empty(t, ce.lostSession)
+}
+
+// TestLostSessionRenoteKeepsBudget ensures a flapping server cannot refresh its
+// own retry budget. noteLostSession is called on every drop; if it reset the
+// attempt count, a server that accepts a session and immediately drops it would
+// be re-dialed indefinitely.
+func TestLostSessionRenoteKeepsBudget(t *testing.T) {
+	ce := &Client{}
+	srv := mkPK(t)
+
+	ce.noteLostSession(srv)
+	_, ok := ce.takeLostSession()
+	require.True(t, ok)
+
+	// Re-noting the same server must not clear the attempt already charged.
+	ce.noteLostSession(srv)
+	require.Equal(t, 1, ce.lostSession[srv])
+}
+
+// TestClearLostSession covers the success path: once a session is restored the
+// server is no longer a re-dial candidate.
+func TestClearLostSession(t *testing.T) {
+	ce := &Client{}
+	srv := mkPK(t)
+
+	ce.noteLostSession(srv)
+	ce.clearLostSession(srv)
+
+	_, ok := ce.takeLostSession()
+	require.False(t, ok)
+}

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -726,6 +726,9 @@ func (ce *Client) finishDialedSession(ctx context.Context, dSes ClientSession, n
 			// replaced this session in the map (newest-session-wins);
 			// deleting by PK alone would evict that live successor.
 			ce.delSession(ctx, dSes.RemotePK(), dSes.SessionCommon)
+			// Remember which server we just lost so the Serve loop re-dials
+			// THIS server before moving to a different one (#4086).
+			ce.noteLostSession(dSes.RemotePK())
 		}
 
 		// Trigger disconnect callback.


### PR DESCRIPTION
When a client is at `MinSessions` the `Serve` loop parks on `errCh`, and on a session drop it advances to the next entry in its pre-shuffled candidate list. The server that just died is never reconsidered, so nearly every drop moves the client to a different server — changing `Client.DelegatedServers`, defeating `updateClientEntry`'s `SamePubKeys` check, and forcing a `PutEntry`.

Measured on production while investigating #4086: sampling one visor every 10s for 100s, its second session rotated through three servers while the first stayed pinned. Across 913 clients the discovery was taking ~38 entry POSTs/sec, 1.8% of which lost the sequence race and returned 422.

This prefers re-dialing the dropped server. Reconnecting to the same server leaves the delegated set identical and publishes nothing; only when that fails does the loop take the next candidate. `lostSessionMaxRetries` (2) bounds it so a server that is genuinely gone is abandoned, and re-noting a flapping server does not refresh its budget.

It reduces the update volume only — the read-modify-write race is a separate fix, tracked on #4086.

**Testing:** `go vet` and the full `pkg/dmsg/dmsg` suite pass, plus unit tests for the budget bookkeeping. The behaviour itself only manifests against a real fleet with real session churn, so it has **not** been verified under load — worth watching the discovery's POST rate after this lands.

Refs #4086.
