### PR TITLE
fix(dmsg-disc): default the official-server allowlist to the deployment seed list

### DIFF
--- a/pkg/services/dmsgdisc/dmsgdisc.go
+++ b/pkg/services/dmsgdisc/dmsgdisc.go
@@ -140,7 +140,7 @@ func (s *service) Run(ctx context.Context) error {
 		api.WhitelistPKs.Set(k)
 	}
 
-	a.OfficialServers = officialServersMap(cfg.OfficialServers)
+	a.OfficialServers = officialServersMap(officialServerPKs(cfg.OfficialServers))
 
 	resolvedMode, err := svcmode.ResolveMode(cfg.Mode, !sk.Null())
 	if err != nil {
@@ -330,6 +330,30 @@ func openStore(ctx context.Context, cfg *Config, log *logging.Logger) (store.Sto
 		dbConf.URL = store.DefaultURL
 	}
 	return store.NewStore(ctx, "redis", dbConf, log)
+}
+
+// officialServerPKs resolves the official-server allowlist. An explicitly
+// configured list (--official-servers, or official_servers in the config file)
+// wins outright; with none set the canonical deployment seed list is used, so a
+// server shipped in services-config.json is official by construction.
+//
+// Before this, the allowlist was maintained by hand alongside the seed list and
+// the two drifted: production had 7 of the 9 seeded servers listed plus 2 PKs
+// for servers that no longer exist, so two live deployment servers were served
+// to clients as "community" and were skipped by anyone running
+// connected_servers_type=official.
+func officialServerPKs(configured []string) []string {
+	if len(configured) > 0 {
+		return configured
+	}
+	pks := make([]string, 0, len(dmsg.Prod.DmsgServers))
+	for i := range dmsg.Prod.DmsgServers {
+		if dmsg.Prod.DmsgServers[i].Static.Null() {
+			continue
+		}
+		pks = append(pks, dmsg.Prod.DmsgServers[i].Static.Hex())
+	}
+	return pks
 }
 
 func officialServersMap(list []string) map[string]bool {

--- a/pkg/services/dmsgdisc/dmsgdisc_test.go
+++ b/pkg/services/dmsgdisc/dmsgdisc_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/disc/metrics"
 	"github.com/skycoin/skywire/pkg/dmsg/discovery/api"
 	"github.com/skycoin/skywire/pkg/dmsg/discovery/store"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
@@ -215,4 +216,27 @@ func TestRun_StoreOpenFails(t *testing.T) {
 	err := svc.Run(canceledCtx())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "open store")
+}
+
+// TestOfficialServerPKsDefaultsToSeedList pins the rule that the official-server
+// allowlist falls back to the embedded deployment seed list. Maintaining the two
+// by hand let them drift: production listed 7 of the 9 seeded servers plus 2 PKs
+// for servers that no longer exist, so two live deployment servers were labelled
+// "community" and skipped by clients running connected_servers_type=official.
+func TestOfficialServerPKsDefaultsToSeedList(t *testing.T) {
+	seeded := officialServerPKs(nil)
+	require.NotEmpty(t, seeded, "embedded deployment config should seed the allowlist")
+	require.Len(t, seeded, len(dmsg.Prod.DmsgServers))
+
+	for i := range dmsg.Prod.DmsgServers {
+		require.Contains(t, seeded, dmsg.Prod.DmsgServers[i].Static.Hex())
+	}
+}
+
+// TestOfficialServerPKsExplicitWins keeps the operator override intact: an
+// explicitly configured list replaces the seed default rather than merging with
+// it, so a deployment can still narrow or redirect the allowlist.
+func TestOfficialServerPKsExplicitWins(t *testing.T) {
+	explicit := []string{"abc", "def"}
+	require.Equal(t, explicit, officialServerPKs(explicit))
 }


### PR DESCRIPTION
`OfficialServers` was populated only from `--official-servers` / the config file's `official_servers` (`dmsg-discovery.go:143`), never from the embedded deployment config — so the allowlist had to be maintained by hand alongside `deployment/services-config.json`. The two drifted.

Production had 7 of the 9 seeded servers listed, plus 2 PKs for servers that no longer exist. Because the discovery downgrades anything that is neither allowlisted nor carrying the auth passphrase (`discovery/api/api.go:509`), two live deployment servers were being served to clients as `community`:

- `03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf` — 172.235.168.146:30081
- `0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7` — 70.121.13.123:9083

Both are in the prod seed list. A client running `connected_servers_type=official` skips them outright, so this silently removes capacity.

This falls back to the PKs in `dmsg.Prod.DmsgServers` when nothing is configured, so a server shipped in `services-config.json` is official by construction and the lists cannot drift. An explicit list still wins outright, keeping the operator override.

Production has been corrected by hand in the meantime (allowlist now matches the 9 seeded servers; all 9 report `official`), but that is exactly the manual step this removes.

**Testing:** `go vet`, `go build .`, and the full `pkg/services/dmsgdisc` suite pass, plus two tests pinning the seed default and the explicit override.
