### PR TITLE
fix(dmsg-server): metrics ticker no longer crash-loops the server

### DIFF
--- a/pkg/dmsg/dmsg/session_common.go
+++ b/pkg/dmsg/dmsg/session_common.go
@@ -103,18 +103,58 @@ func (sc *SessionCommon) GetConn() net.Conn {
 	return sc.netConn
 }
 
-// GetDecNonce returns value of DecNonce of underlying `*noise.Noise`.
+// GetDecNonce returns value of DecNonce of underlying `*noise.Noise`, or 0
+// when there is no noise state to read (see NonceValues).
 func (sc *SessionCommon) GetDecNonce() uint64 {
+	if sc == nil {
+		return 0
+	}
 	sc.rMx.Lock()
 	defer sc.rMx.Unlock()
+	if sc.ns == nil {
+		return 0
+	}
 	return sc.ns.GetDecNonce()
 }
 
-// GetEncNonce returns value of EncNonce of underlying `*noise.Noise`.
+// GetEncNonce returns value of EncNonce of underlying `*noise.Noise`, or 0
+// when there is no noise state to read (see NonceValues).
 func (sc *SessionCommon) GetEncNonce() uint64 {
+	if sc == nil {
+		return 0
+	}
 	sc.wMx.Lock()
 	defer sc.wMx.Unlock()
+	if sc.ns == nil {
+		return 0
+	}
 	return sc.ns.GetEncNonce()
+}
+
+// NonceValues returns the session's decryption and encryption nonces together,
+// and whether they could be read at all.
+//
+// `ns` is only assigned once a handshake completes, so a session can be
+// reachable through the entity's session map — GetSessions returns a snapshot —
+// while having no noise state yet, or after being torn down. Callers that
+// merely observe sessions (the server's throughput metrics) must be able to
+// tell "no reading available" apart from "the nonce is 0": treating the second
+// as the first made a counter appear to run backwards, which the throughput
+// calculation reads as a uint64 overflow and turns into an enormous bogus
+// delta. Reading them separately would also let a session be torn down between
+// the two calls; this takes both under their locks in one go.
+func (sc *SessionCommon) NonceValues() (dec, enc uint64, ok bool) {
+	if sc == nil {
+		return 0, 0, false
+	}
+	sc.rMx.Lock()
+	sc.wMx.Lock()
+	defer sc.wMx.Unlock()
+	defer sc.rMx.Unlock()
+	if sc.ns == nil {
+		return 0, 0, false
+	}
+	return sc.ns.GetDecNonce(), sc.ns.GetEncNonce(), true
 }
 
 func (sc *SessionCommon) initClient(entity *EntityCommon, conn net.Conn, rPK cipher.PubKey) error {

--- a/pkg/dmsg/dmsgserver/api.go
+++ b/pkg/dmsg/dmsgserver/api.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -29,6 +30,7 @@ type ServerAPI struct {
 	metrics         metrics.Metrics
 	startedAt       time.Time
 	dmsgServer      *dmsg.Server
+	svcLog          *logging.Logger
 	sMu             sync.Mutex
 	minuteDecValues map[*dmsg.SessionCommon]uint64
 	minuteEncValues map[*dmsg.SessionCommon]uint64
@@ -42,6 +44,7 @@ func NewServerAPI(r *chi.Mux, log *logging.Logger, m metrics.Metrics) *ServerAPI
 	api := &ServerAPI{
 		metrics:         m,
 		startedAt:       time.Now(),
+		svcLog:          log,
 		minuteDecValues: make(map[*dmsg.SessionCommon]uint64),
 		minuteEncValues: make(map[*dmsg.SessionCommon]uint64),
 		secondDecValues: make(map[*dmsg.SessionCommon]uint64),
@@ -61,19 +64,40 @@ func (a *ServerAPI) RunBackgroundTasks(ctx context.Context) {
 	defer ticker.Stop()
 	//defer tickerEverySecond.Stop()
 	defer tickerEveryMinute.Stop()
-	a.updateInternalState()
+	a.safely("updateInternalState", a.updateInternalState)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			a.updateInternalState()
+			a.safely("updateInternalState", a.updateInternalState)
 		case <-tickerEveryMinute.C:
-			a.updateAverageNumberOfPacketsPerMinute()
+			a.safely("updateAverageNumberOfPacketsPerMinute", a.updateAverageNumberOfPacketsPerMinute)
 			/*case <-tickerEverySecond.C:
 			a.updateAverageNumberOfPacketsPerSecond()*/
 		}
 	}
+}
+
+// safely runs a periodic task so that a panic inside it cannot take the server
+// down with it. These tasks exist to publish metrics; nothing served depends on
+// them, and a server that stops reporting throughput is enormously preferable
+// to one that dies.
+//
+// This is not hypothetical. A nil noise state reached through the session
+// snapshot panicked in the throughput calculation, and because the panic
+// happened on this goroutine there was nothing to recover it: the process
+// exited, systemd restarted it, every session on the server dropped, and it
+// happened again a minute later. One production server logged 3317 restarts —
+// roughly one every 80 seconds — with the same stack each time.
+func (a *ServerAPI) safely(name string, fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			a.svcLog.Errorf("periodic task %s panicked (recovered, task skipped this tick): %v\n%s",
+				name, r, debug.Stack())
+		}
+	}()
+	fn()
 }
 
 // SetDmsgServer saves srv in the ServerAPI
@@ -261,8 +285,14 @@ func calculateThroughput(
 	newDecValues := make(map[*dmsg.SessionCommon]uint64)
 	newEncValues := make(map[*dmsg.SessionCommon]uint64)
 	for _, session := range sessions {
-		currentDecValue := session.GetDecNonce()
-		currentEncValue := session.GetEncNonce()
+		// A session in the map may have no noise state — it is a snapshot, and
+		// a session can be mid-handshake or already torn down. Skip it rather
+		// than recording a zero, which the delta arithmetic below would read as
+		// a uint64 overflow and turn into an enormous bogus throughput figure.
+		currentDecValue, currentEncValue, ok := session.NonceValues()
+		if !ok {
+			continue
+		}
 
 		newDecValues[session] = currentDecValue
 		newEncValues[session] = currentEncValue

--- a/pkg/dmsg/dmsgserver/throughput_panic_test.go
+++ b/pkg/dmsg/dmsgserver/throughput_panic_test.go
@@ -1,0 +1,91 @@
+// Package dmsgserver pkg/dmsg/dmsgserver/throughput_panic_test.go c1-net-dmsg
+package dmsgserver
+
+import (
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg/metrics"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// A session reaches the server's session map before its noise handshake has
+// installed any state, and stays reachable through the snapshot GetSessions
+// returns after it is torn down. Reading its nonces used to dereference that
+// missing state and panic — on the once-a-minute metrics goroutine, where
+// nothing could recover it. The process exited, systemd restarted it, and every
+// session on the server dropped; one production server logged 3317 restarts,
+// about one every 80 seconds.
+func TestCalculateThroughputSkipsSessionWithNoNoiseState(t *testing.T) {
+	// The zero SessionCommon is exactly the shape that crashed: reachable, with
+	// no noise state behind it.
+	var bare dmsg.SessionCommon
+
+	sessions := map[cipher.PubKey]*dmsg.SessionCommon{
+		{}: &bare,
+	}
+
+	dec, enc, average := calculateThroughput(
+		sessions,
+		map[*dmsg.SessionCommon]uint64{},
+		map[*dmsg.SessionCommon]uint64{},
+	)
+
+	// Skipped, not recorded as zero: recording zero would make the counter look
+	// like it ran backwards on the next tick, which the delta arithmetic reads
+	// as a uint64 overflow and turns into an enormous bogus throughput figure.
+	if _, ok := dec[&bare]; ok {
+		t.Error("a session with no noise state was recorded in the dec values")
+	}
+	if _, ok := enc[&bare]; ok {
+		t.Error("a session with no noise state was recorded in the enc values")
+	}
+	if average != 0 {
+		t.Errorf("average = %d, want 0 when no session could be read", average)
+	}
+}
+
+// NonceValues reports that it could not read, rather than panicking.
+func TestNonceValuesReportsUnavailable(t *testing.T) {
+	var bare dmsg.SessionCommon
+	if _, _, ok := bare.NonceValues(); ok {
+		t.Error("NonceValues reported ok for a session with no noise state")
+	}
+
+	var nilSession *dmsg.SessionCommon
+	if _, _, ok := nilSession.NonceValues(); ok {
+		t.Error("NonceValues reported ok for a nil session")
+	}
+	// The single-value getters are kept nil-safe for any other caller.
+	if got := nilSession.GetDecNonce(); got != 0 {
+		t.Errorf("GetDecNonce on a nil session = %d, want 0", got)
+	}
+	if got := nilSession.GetEncNonce(); got != 0 {
+		t.Errorf("GetEncNonce on a nil session = %d, want 0", got)
+	}
+}
+
+// A panic in a periodic task must never reach the goroutine that runs it: these
+// tasks publish metrics, and nothing served depends on them.
+func TestSafelyContainsAPanickingTask(t *testing.T) {
+	api := NewServerAPI(chi.NewRouter(), logging.MustGetLogger("test"), metrics.NewEmpty())
+
+	ran := false
+	api.safely("panicking-task", func() {
+		ran = true
+		panic("boom")
+	})
+	if !ran {
+		t.Fatal("the task did not run")
+	}
+
+	// Still usable afterwards — the recover must not leave state wedged.
+	after := false
+	api.safely("ordinary-task", func() { after = true })
+	if !after {
+		t.Error("a later task did not run after an earlier one panicked")
+	}
+}


### PR DESCRIPTION
Fixes #4504.

A production dmsg server (`172.105.110.46`, `03717576ada5b1744e395c66c2bb11cea73b0e23d0dcd54422139b1a7f12e962c4`) has been restarting **roughly every 80 seconds** — `NRestarts=3317` against 44 days of host uptime, 44 `Scheduled restart` entries in the last hour, 176 panic hits in two hours, all with the same stack. **Every restart drops every session on that server.**

The once-a-minute throughput task iterates the map returned by `GetSessions` and reads each session's noise nonces. `sc.ns` is only assigned when a handshake completes, so a session is reachable through that snapshot both before its handshake has installed any state and after it has been torn down. Reading the nonces then dereferenced nothing and panicked — and because the panic was on the background goroutine, nothing could recover it. The process exited, systemd restarted it, and a minute later it happened again.

Two changes, either of which alone would have prevented the outage:

**`NonceValues`** reads both nonces under their locks in one pass and reports whether they could be read at all. `calculateThroughput` now skips an unreadable session rather than recording zero — recording zero would make the counter appear to run backwards on the next tick, which the delta arithmetic interprets as a uint64 overflow and turns into an enormous bogus throughput figure. The single-value getters remain for any other caller, now nil-safe.

**Periodic tasks run through a `recover`.** They exist to publish metrics; nothing served depends on them, and a server that stops reporting throughput is enormously preferable to one that dies. A recovered panic is logged with its stack, so the underlying fault stays visible rather than becoming invisible.

Three regression tests cover it: a zero-valued session is skipped and not recorded, `NonceValues` reports unavailable instead of panicking (including on a nil receiver), and a panicking periodic task is contained without wedging later ticks.

Worth noting for anyone reading fleet health: this makes point-in-time dmsg-server checks meaningful again. I probed all nine wss endpoints as healthy earlier today and would have reported 9/9 — that host is simply up for most of an 80-second sawtooth. It is also a plausible driver of visor uptime flapping, since a visor delegated to a server that restarts every 80 seconds looks intermittent through no fault of its own.
