### PR TITLE
chore: drop superseded 0magnet pseudo-versions from go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -74,10 +74,6 @@ github.com/0magnet/coloredcobra v1.0.3-0.20260902084726-57ccbecfc077 h1:cWpt53uN
 github.com/0magnet/coloredcobra v1.0.3-0.20260902084726-57ccbecfc077/go.mod h1:Kn7dmRJcnVybFNKY0FNUjLcsivW4FCbAec8ZfVmz51I=
 github.com/0magnet/cosmos-go v0.0.0-20260903205521-b833a4163dfd h1:3zl4nVNKDb+qGcjbvVyADT/owZ2U4itbfwMnQxZne8Q=
 github.com/0magnet/cosmos-go v0.0.0-20260903205521-b833a4163dfd/go.mod h1:dp0q1zfKQmTaohUrPEPZbPExxBWLu9DyeaFxKUBnw6Y=
-github.com/0magnet/desk v0.0.0-20260904153426-e1ccc4f22bc6 h1:6EcuaKK/1OHm5mwUSP6cUVNihXiAlLlDKr2G/O1X0w8=
-github.com/0magnet/desk v0.0.0-20260904153426-e1ccc4f22bc6/go.mod h1:+cZlrl5Xi6wnQB9M7EgUOu/8oWs2Y9zIQ8FO0YjG6Wg=
-github.com/0magnet/desk v0.0.0-20260904185513-88675d048d28 h1:IpNH8cFtaga2VzdNAH2BkqNLUwV2rUHZNU+TvAp+B1M=
-github.com/0magnet/desk v0.0.0-20260904185513-88675d048d28/go.mod h1:+cZlrl5Xi6wnQB9M7EgUOu/8oWs2Y9zIQ8FO0YjG6Wg=
 github.com/0magnet/desk v0.0.0-20260904190029-7fd5c5344d76 h1:AzBYlJwONhrDmKUKFw9/dk3WeF10RZuOFysBwuEiKkM=
 github.com/0magnet/desk v0.0.0-20260904190029-7fd5c5344d76/go.mod h1:+cZlrl5Xi6wnQB9M7EgUOu/8oWs2Y9zIQ8FO0YjG6Wg=
 github.com/0magnet/desk/panes v0.0.0-20260904153426-e1ccc4f22bc6 h1:mTjsP4+o+5aX0yq1j55eSSNg6jIm9fkrAzC2e4Du3XY=
@@ -88,12 +84,6 @@ github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77 h1:4Th5JTWexd+r
 github.com/0magnet/gotop/v4 v4.2.1-0.20260901202627-53911da3ad77/go.mod h1:F6WLpAz89R80LgQy9Veg6jZVdfY3FLmxqt23Okck35A=
 github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b h1:l/c7X12CNncX2phqLeQPiNjxu2ou7spv3xslwloyPjE=
 github.com/0magnet/metrics v1.44.1-0.20260901202122-8656b26f968b/go.mod h1:SwLy2vvXGWJQxefDI4DncGdXJWIob5IGczxeFMtUIj8=
-github.com/0magnet/netscrape v0.0.0-20260904153405-6004fca16433 h1:SF7Gvlb8dw+KSZDoMK1V0p8APf2t9P90+ijAesAsRZ0=
-github.com/0magnet/netscrape v0.0.0-20260904153405-6004fca16433/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
-github.com/0magnet/netscrape v0.0.0-20260904183604-cf46751f7969 h1:oQMJT905NpAWNHa7ur/Ky6OY4T31bHFwqWX1kDmV6NI=
-github.com/0magnet/netscrape v0.0.0-20260904183604-cf46751f7969/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
-github.com/0magnet/netscrape v0.0.0-20260904190635-96173244fabf h1:UpVC9d0btL4qjLyrhtG7RdaktKfYECvYxagvTS5JyvA=
-github.com/0magnet/netscrape v0.0.0-20260904190635-96173244fabf/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
 github.com/0magnet/netscrape v0.0.0-20260904193824-1b1603747c93 h1:vemMB/aUKtgvQJq/NeGS4Vy/BD2rUnQyUlpd2Y4yqnI=
 github.com/0magnet/netscrape v0.0.0-20260904193824-1b1603747c93/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
 github.com/0magnet/plot-go v0.0.0-20260903194102-268453e774b6 h1:OamIbxneZwMYkmxy1mMd5Cys783e2ZFV6W7s81ohbDc=


### PR DESCRIPTION
go.sum carried five stale pseudo-versions of `0magnet/desk` and `0magnet/netscrape` from same-day dependency bumps. `go mod tidy` removes them; the Module Integrity check has been failing on develop since (#4502, #4503, #4506 all red on it).

`go.mod` is unchanged and `go mod vendor` produces no diff, so this is purely the ten superseded `go.sum` lines. Verified `go build .` passes and a repeat `go mod tidy` is now a no-op — which is what the check runs.