### PR TITLE
fix(tpd): the metrics CXO feed never published — one oversized window killed it

### DIFF
--- a/pkg/deployment/tpd/api/cxo_metrics_publisher.go
+++ b/pkg/deployment/tpd/api/cxo_metrics_publisher.go
@@ -158,6 +158,16 @@ func (m *MetricsCXOPublisher) loop(ctx context.Context) {
 	wg.Wait()
 }
 
+// maxPublishBody bounds a single published body. CXO refuses an object over
+// skyobject.Config.MaxObjectSize (16 MB by default) — and refuses it at Put
+// time, so an oversized window does not merely lose that window: the feed never
+// gets a Root at all, and every subscriber sits in "timeout waiting for Root"
+// forever. That is what was happening in production: the whole tpd-metrics feed
+// was dead, silently, because one window did not fit.
+//
+// The margin below 16 MB covers the encoding overhead CXO adds around the JSON.
+const maxPublishBody = 12 * 1024 * 1024
+
 func (m *MetricsCXOPublisher) publishWindow(ctx context.Context, days int) {
 	query := store.MetricsQuery{
 		Days:      days,
@@ -168,11 +178,35 @@ func (m *MetricsCXOPublisher) publishWindow(ctx context.Context, days int) {
 	}
 	metrics, err := m.api.store.GetAllTransportMetrics(ctx, query)
 	if err != nil {
-		m.log.WithError(err).WithField("days", days).Debug("metrics fetch failed; will retry next tick")
+		// WARN, not DEBUG. A window that fails every tick makes the whole feed
+		// unusable, and at DEBUG that is invisible on a production deployment —
+		// which is exactly how this went unnoticed.
+		m.log.WithError(err).WithField("days", days).Warn("metrics fetch failed; will retry next tick")
 		m.recordError(err)
 		return
 	}
 	body, err := json.Marshal(metrics)
+	// Oversized body: re-fetch without the per-day per-edge bandwidth, which is
+	// the bulk of a long window, and publish the smaller shape rather than
+	// nothing. Subscribers that only read type/live/edges/latency (the
+	// visualizer's latency view) are then served; anything wanting bandwidth
+	// still has the HTTP endpoint. Partial data beats a feed with no Root.
+	if err == nil && len(body) > maxPublishBody {
+		m.log.WithField("days", days).WithField("bytes", len(body)).
+			Warn("metrics body exceeds the CXO object limit; republishing this window without per-edge bandwidth")
+		query.Bandwidth = false
+		if reduced, rerr := m.api.store.GetAllTransportMetrics(ctx, query); rerr == nil {
+			if rbody, merr := json.Marshal(reduced); merr == nil {
+				body, err = rbody, nil
+			}
+		}
+		if len(body) > maxPublishBody {
+			m.log.WithField("days", days).WithField("bytes", len(body)).
+				Error("metrics body still exceeds the CXO object limit without bandwidth; skipping this window")
+			m.recordError(fmt.Errorf("metrics/days/%d: body %d bytes exceeds max %d", days, len(body), maxPublishBody))
+			return
+		}
+	}
 	if err != nil {
 		m.log.WithError(err).WithField("days", days).Warn("metrics marshal failed")
 		m.recordError(err)


### PR DESCRIPTION
`skywire cli visor cxo status` shows `tpd-metrics` as the **only** dead feed on the deployment — paths 0, `last_sync (never)`, `timeout waiting for Root after 10s` — while `tpd-uptime`, `tpd-all-transports` and `sd-services` all sync normally against the same peer. TPD's own log says why, once per publish attempt:

```
WARN [tpd-cxo-metrics-pub]: treestore: publish failed
  error="treestore encode/save: object is too large: 1fa7384"
```

CXO refuses an object over `MaxObjectSize` (16 MB) **at Put time**, so an oversized window does not merely lose that window — the feed never gets a Root at all, and every subscriber waits forever. A 30-day window over ~10,500 transports carrying per-day per-edge bandwidth clears 16 MB comfortably.

**Raising the limit would be the wrong fix.** It exists because CXO holds whole objects in RAM on the *subscriber* side too, and the subscribers include wasm visors running in browser tabs; a multi-megabyte blob is exactly what kills one.

So an oversized window now re-fetches without the per-day per-edge bandwidth — the bulk of a long window — and publishes the smaller shape. Subscribers reading `type`/`live`/`edges`/`latency` (the visualizer's latency view, the main CXO consumer) get served; anything needing bandwidth still has the HTTP endpoint. Partial data beats a feed with no Root. If it still does not fit, that window is skipped with an error rather than silently poisoning the feed for every other window.

Also promotes the metrics-fetch failure from `Debug` to `Warn`. A window failing every tick makes the whole feed unusable, and at `Debug` that is invisible on a production deployment — which is precisely how this went unnoticed.

Follow-up worth considering separately: the long-term shape is chunking rather than degrading, since `metrics/days/<n>` already implies per-window leaves and `sd-services` is described as batched. This change is the minimal one that gets the feed publishing again.
