### PR TITLE
fix(tpd): gzip + chunk the metrics CXO feed instead of dropping bandwidth

### DIFF
--- a/pkg/deployment/tpd/api/cxo_metrics_publisher.go
+++ b/pkg/deployment/tpd/api/cxo_metrics_publisher.go
@@ -3,16 +3,34 @@
 // CXO publisher for the network-wide transport-metrics aggregate.
 // On a fixed cadence (default 60s) the publisher recomputes the
 // metrics for a small set of day windows (1, 7, 30) and writes the
-// JSON-encoded []store.TransportMetric to a TreeStore path
+// gzipped JSON-encoded []store.TransportMetric to a TreeStore path
 //
 //	metrics/days/<n>
 //
 // Subscribers (the hvui's Transports tab via the visor's CXO
-// subscriber) watch the feed instead of HTTP-polling /metrics. CXO's
-// content-addressing means the publisher only re-encodes subtrees
-// that actually changed, so unchanged transport rows produce a
-// stable Root and the wire footprint is the delta, not the full
-// dataset.
+// subscriber) watch the feed instead of HTTP-polling /metrics.
+//
+// Two properties of CXO shape how the body is written:
+//
+//   - CXO stores and propagates object bytes verbatim — it does not
+//     compress. Bodies are gzipped here, as every sibling TPD
+//     publisher already does (see cxo_uptime_publisher.go and
+//     cxo_all_transports_publisher.go). Readers use cxoutils.Gunzip,
+//     which passes a raw body through unchanged.
+//
+//   - An object over skyobject MaxObjectSize (16 MB) is refused at
+//     Put time, and refusing one window kills the whole feed: no
+//     Root is ever published and every subscriber sits in "timeout
+//     waiting for Root" forever. Measured on production, even the
+//     1-day window is 16.02 MB of JSON — every window was over.
+//     Gzip (~4x on this data) carries the short windows; long
+//     windows are additionally split across
+//
+//     metrics/days/<n>/part/<NNNN>
+//
+//     leaves so no data is dropped. Readers stitch the parts back
+//     into one array; the prefix Walk that pkg/tpviz already used
+//     picks them up unchanged.
 package api
 
 import (
@@ -25,6 +43,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/deployment/tpd/store"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
@@ -74,6 +93,10 @@ type MetricsCXOPublisher struct {
 
 	mu        sync.Mutex
 	lastError error
+	// lastParts records how many part leaves each day window was last
+	// published as (0 = a single leaf), so the next cycle knows which
+	// leaves to retire.
+	lastParts map[int]int
 }
 
 // StartMetricsCXOPublisher constructs a publisher backed by the
@@ -102,11 +125,12 @@ func StartMetricsCXOPublisher(ctx context.Context, api *API, dmsgC *dmsg.Client,
 
 	pubCtx, cancel := context.WithCancel(ctx)
 	mp := &MetricsCXOPublisher{
-		api:    api,
-		pub:    pub,
-		log:    log,
-		cancel: cancel,
-		done:   make(chan struct{}),
+		api:       api,
+		pub:       pub,
+		log:       log,
+		cancel:    cancel,
+		done:      make(chan struct{}),
+		lastParts: make(map[int]int),
 	}
 	if logger != nil {
 		logger.WithField("feed_pk", pub.Feed()).WithField("dmsg_port", skyenv.DmsgTPDMetricsCXOPort).
@@ -158,15 +182,16 @@ func (m *MetricsCXOPublisher) loop(ctx context.Context) {
 	wg.Wait()
 }
 
-// maxPublishBody bounds a single published body. CXO refuses an object over
-// skyobject.Config.MaxObjectSize (16 MB by default) — and refuses it at Put
-// time, so an oversized window does not merely lose that window: the feed never
-// gets a Root at all, and every subscriber sits in "timeout waiting for Root"
-// forever. That is what was happening in production: the whole tpd-metrics feed
-// was dead, silently, because one window did not fit.
-//
-// The margin below 16 MB covers the encoding overhead CXO adds around the JSON.
+// maxPublishBody bounds a single published body, measured on the GZIPPED bytes
+// since those are what CXO stores. The margin below skyobject's 16 MB
+// MaxObjectSize covers the encoding overhead CXO adds around the payload.
 const maxPublishBody = 12 * 1024 * 1024
+
+// partTargetBody is what a split aims each part at. Sizing the split from the
+// measured compressed size and then aiming well under the hard cap means a part
+// whose records happen to compress worse than the window average still lands
+// inside it, so the verify-and-halve pass below rarely has to run.
+const partTargetBody = 8 * 1024 * 1024
 
 func (m *MetricsCXOPublisher) publishWindow(ctx context.Context, days int) {
 	query := store.MetricsQuery{
@@ -185,39 +210,122 @@ func (m *MetricsCXOPublisher) publishWindow(ctx context.Context, days int) {
 		m.recordError(err)
 		return
 	}
-	body, err := json.Marshal(metrics)
-	// Oversized body: re-fetch without the per-day per-edge bandwidth, which is
-	// the bulk of a long window, and publish the smaller shape rather than
-	// nothing. Subscribers that only read type/live/edges/latency (the
-	// visualizer's latency view) are then served; anything wanting bandwidth
-	// still has the HTTP endpoint. Partial data beats a feed with no Root.
-	if err == nil && len(body) > maxPublishBody {
-		m.log.WithField("days", days).WithField("bytes", len(body)).
-			Warn("metrics body exceeds the CXO object limit; republishing this window without per-edge bandwidth")
-		query.Bandwidth = false
-		if reduced, rerr := m.api.store.GetAllTransportMetrics(ctx, query); rerr == nil {
-			if rbody, merr := json.Marshal(reduced); merr == nil {
-				body, err = rbody, nil
-			}
-		}
-		if len(body) > maxPublishBody {
-			m.log.WithField("days", days).WithField("bytes", len(body)).
-				Error("metrics body still exceeds the CXO object limit without bandwidth; skipping this window")
-			m.recordError(fmt.Errorf("metrics/days/%d: body %d bytes exceeds max %d", days, len(body), maxPublishBody))
-			return
-		}
-	}
+
+	bodies, err := gzipParts(metrics, maxPublishBody)
 	if err != nil {
 		m.log.WithError(err).WithField("days", days).Warn("metrics marshal failed")
 		m.recordError(err)
 		return
 	}
-	path := metricsPath(days)
-	if err := m.pub.Put(path, body); err != nil {
-		m.log.WithError(err).WithField("path", path).Warn("publisher Put failed")
+
+	base := metricsPath(days)
+	m.mu.Lock()
+	prevParts := m.lastParts[days]
+	m.mu.Unlock()
+
+	// Deletes are emitted before puts: PutBatch applies ops in order, and a
+	// path cannot be a leaf and a sub-tree at once. Switching a window between
+	// the two forms therefore has to retire the old form first or the put
+	// fails with ErrPathConflict.
+	var deletes, puts []treestore.PutOp
+	staleFrom := len(bodies)
+	if len(bodies) == 1 {
+		puts = append(puts, treestore.PutOp{Path: base, Value: bodies[0]})
+		staleFrom = 0 // every part path from a previous split is now stale
+	} else {
+		deletes = append(deletes, treestore.PutOp{Path: base})
+		for i, b := range bodies {
+			puts = append(puts, treestore.PutOp{Path: metricsPartPath(days, i), Value: b})
+		}
+	}
+	// A shrinking network splits into fewer parts than last time. Without this
+	// the leftover high-index leaves stay in the tree and a prefix Walk keeps
+	// serving records that no longer exist.
+	for i := staleFrom; i < prevParts; i++ {
+		deletes = append(deletes, treestore.PutOp{Path: metricsPartPath(days, i)})
+	}
+
+	if err := m.pub.PutBatch(append(deletes, puts...)); err != nil {
+		m.log.WithError(err).WithField("path", base).Warn("publisher PutBatch failed")
 		m.recordError(err)
 		return
 	}
+
+	nowParts := 0
+	if len(bodies) > 1 {
+		nowParts = len(bodies)
+		m.log.WithField("days", days).WithField("parts", nowParts).
+			Debug("metrics window exceeded the CXO object limit; published as parts")
+	}
+	m.mu.Lock()
+	m.lastParts[days] = nowParts
+	m.mu.Unlock()
+}
+
+// gzipParts encodes metrics as one or more gzipped JSON arrays, each at most
+// max bytes. One part is the normal case; a window only splits when even
+// compressed it will not fit in a single CXO object.
+func gzipParts(metrics []store.TransportMetric, max int) ([][]byte, error) {
+	whole, err := json.Marshal(metrics)
+	if err != nil {
+		return nil, err
+	}
+	if gz := cxoutils.Gzip(whole); len(gz) <= max {
+		return [][]byte{gz}, nil
+	}
+
+	var out [][]byte
+	n := len(whole)/partTargetBody + 1
+	for _, part := range splitEvenly(metrics, n) {
+		if err := appendGzipped(&out, part, max); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// appendGzipped gzips part, halving it until every piece fits in max. A single
+// record that will not fit on its own is appended anyway rather than silently
+// dropped — the Put then fails loudly, which is the honest outcome.
+func appendGzipped(out *[][]byte, part []store.TransportMetric, max int) error {
+	if len(part) == 0 {
+		return nil
+	}
+	body, err := json.Marshal(part)
+	if err != nil {
+		return err
+	}
+	if gz := cxoutils.Gzip(body); len(gz) <= max || len(part) == 1 {
+		*out = append(*out, gz)
+		return nil
+	}
+	mid := len(part) / 2
+	if err := appendGzipped(out, part[:mid], max); err != nil {
+		return err
+	}
+	return appendGzipped(out, part[mid:], max)
+}
+
+func splitEvenly(metrics []store.TransportMetric, n int) [][]store.TransportMetric {
+	if len(metrics) == 0 {
+		return nil
+	}
+	if n < 1 {
+		n = 1
+	}
+	if n > len(metrics) {
+		n = len(metrics)
+	}
+	size := (len(metrics) + n - 1) / n
+	out := make([][]store.TransportMetric, 0, n)
+	for i := 0; i < len(metrics); i += size {
+		end := i + size
+		if end > len(metrics) {
+			end = len(metrics)
+		}
+		out = append(out, metrics[i:end])
+	}
+	return out
 }
 
 func (m *MetricsCXOPublisher) recordError(err error) {
@@ -242,4 +350,12 @@ func MetricsPath(days int) string { return metricsPath(days) }
 
 func metricsPath(days int) string {
 	return fmt.Sprintf("metrics/days/%d", days)
+}
+
+// MetricsPartPath returns the path of one part of a split window. Zero-padded
+// so a reader that sorts the paths lexically gets them in publication order.
+func MetricsPartPath(days, part int) string { return metricsPartPath(days, part) }
+
+func metricsPartPath(days, part int) string {
+	return fmt.Sprintf("%s/part/%04d", metricsPath(days), part)
 }

--- a/pkg/deployment/tpd/api/cxo_metrics_publisher_test.go
+++ b/pkg/deployment/tpd/api/cxo_metrics_publisher_test.go
@@ -1,0 +1,168 @@
+// Package api pkg/deployment/tpd/api/cxo_metrics_publisher_test.go c4-net-discovery
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/deployment/tpd/store"
+)
+
+// metricsFixture builds n records shaped like the production ones: a uuid-ish
+// id, two 66-char edge keys and a day of per-edge bandwidth. Sizes here track
+// the real thing closely enough that the split arithmetic is exercised.
+func metricsFixture(n, days int) []store.TransportMetric {
+	out := make([]store.TransportMetric, 0, n)
+	for i := 0; i < n; i++ {
+		daily := make([]store.DailyEdgeBandwidth, 0, days)
+		for d := 0; d < days; d++ {
+			daily = append(daily, store.DailyEdgeBandwidth{
+				Date: fmt.Sprintf("2026-09-%02d", 1+d%28),
+				A:    &store.EdgeBandwidth{Sent: uint64(i*7919 + d), Recv: uint64(i*104729 + d)},
+				B:    &store.EdgeBandwidth{Sent: uint64(i*15485863 + d), Recv: uint64(i*32452843 + d)},
+			})
+		}
+		out = append(out, store.TransportMetric{
+			ID:      fmt.Sprintf("%08x-4660-0f05-aff8-8b006cc4c9%02x", i, i%256),
+			Type:    []string{"stcpr", "sudph", "dmsg", "webrtc"}[i%4],
+			Live:    i%3 != 0,
+			Edges:   []string{fmt.Sprintf("02%064x", i), fmt.Sprintf("03%064x", i+1)},
+			Latency: &store.TransportLatency{Min: int64(1000 + i), Max: int64(90000 + i), Avg: int64(14000 + i)},
+			Daily:   daily,
+		})
+	}
+	return out
+}
+
+// decodeParts is the reader half: gunzip each part and concatenate the records.
+func decodeParts(t *testing.T, parts [][]byte) []store.TransportMetric {
+	t.Helper()
+	var all []store.TransportMetric
+	for i, p := range parts {
+		var chunk []store.TransportMetric
+		if err := json.Unmarshal(cxoutils.Gunzip(p), &chunk); err != nil {
+			t.Fatalf("part %d did not decode: %v", i, err)
+		}
+		all = append(all, chunk...)
+	}
+	return all
+}
+
+// A window that fits is published as one leaf, and it is gzipped — CXO stores
+// bytes verbatim, so an uncompressed body is what pushed this feed over the
+// object limit in the first place.
+func TestGzipPartsSingleLeafIsCompressed(t *testing.T) {
+	metrics := metricsFixture(200, 1)
+	parts, err := gzipParts(metrics, maxPublishBody)
+	if err != nil {
+		t.Fatalf("gzipParts: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("got %d parts, want 1 for a small window", len(parts))
+	}
+	if len(parts[0]) < 2 || parts[0][0] != 0x1f || parts[0][1] != 0x8b {
+		t.Error("the published body is not gzipped")
+	}
+
+	raw, err := json.Marshal(metrics)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parts[0]) >= len(raw) {
+		t.Errorf("gzipped body (%d) is not smaller than the raw one (%d)", len(parts[0]), len(raw))
+	}
+	if got := decodeParts(t, parts); len(got) != len(metrics) {
+		t.Errorf("round-trip returned %d records, want %d", len(got), len(metrics))
+	}
+}
+
+// The point of the split: every part fits, and NO record is dropped. The
+// previous behaviour re-fetched the window without per-edge bandwidth and
+// published that instead, which silently lost data.
+func TestGzipPartsSplitsWithoutLosingRecords(t *testing.T) {
+	metrics := metricsFixture(4000, 30)
+
+	// A cap far below the real one so the fixture reliably splits.
+	const max = 64 * 1024
+
+	parts, err := gzipParts(metrics, max)
+	if err != nil {
+		t.Fatalf("gzipParts: %v", err)
+	}
+	if len(parts) < 2 {
+		t.Fatalf("got %d parts, want a split", len(parts))
+	}
+	for i, p := range parts {
+		if len(p) > max {
+			t.Errorf("part %d is %d bytes, over the %d cap", i, len(p), max)
+		}
+	}
+
+	got := decodeParts(t, parts)
+	if len(got) != len(metrics) {
+		t.Fatalf("round-trip returned %d records, want %d", len(got), len(metrics))
+	}
+	// Order is preserved, and the per-day bandwidth survives intact.
+	for i := range metrics {
+		if got[i].ID != metrics[i].ID {
+			t.Fatalf("record %d is %q, want %q — parts were reassembled out of order", i, got[i].ID, metrics[i].ID)
+		}
+		if len(got[i].Daily) != len(metrics[i].Daily) {
+			t.Fatalf("record %d kept %d daily rows, want %d", i, len(got[i].Daily), len(metrics[i].Daily))
+		}
+	}
+}
+
+// A cap so small that no single record fits must not spin or drop records: the
+// halving bottoms out at one record per part and lets the Put fail loudly.
+func TestGzipPartsBottomsOutAtOneRecord(t *testing.T) {
+	metrics := metricsFixture(8, 4)
+	parts, err := gzipParts(metrics, 1)
+	if err != nil {
+		t.Fatalf("gzipParts: %v", err)
+	}
+	if len(parts) != len(metrics) {
+		t.Fatalf("got %d parts, want one per record (%d)", len(parts), len(metrics))
+	}
+	if got := decodeParts(t, parts); len(got) != len(metrics) {
+		t.Errorf("round-trip returned %d records, want %d", len(got), len(metrics))
+	}
+}
+
+func TestSplitEvenlyCoversEveryRecordOnce(t *testing.T) {
+	for _, tc := range []struct{ records, n int }{{100, 1}, {100, 3}, {100, 7}, {5, 10}, {1, 4}} {
+		metrics := metricsFixture(tc.records, 1)
+		var total int
+		for _, part := range splitEvenly(metrics, tc.n) {
+			if len(part) == 0 {
+				t.Errorf("records=%d n=%d: produced an empty part", tc.records, tc.n)
+			}
+			total += len(part)
+		}
+		if total != tc.records {
+			t.Errorf("records=%d n=%d: parts hold %d records, want %d", tc.records, tc.n, total, tc.records)
+		}
+	}
+	if got := splitEvenly(nil, 4); got != nil {
+		t.Errorf("splitEvenly(nil) = %v, want nil", got)
+	}
+}
+
+// Part paths must sort lexically into publication order, because the reader
+// recovers ordering from a sort of the paths a map-ordered Walk hands it.
+func TestMetricsPartPathSortsNumerically(t *testing.T) {
+	if a, b := metricsPartPath(30, 9), metricsPartPath(30, 10); !(a < b) {
+		t.Errorf("%q should sort before %q", a, b)
+	}
+	if got, want := metricsPartPath(7, 3), "metrics/days/7/part/0003"; got != want {
+		t.Errorf("metricsPartPath(7,3) = %q, want %q", got, want)
+	}
+	// The part paths must live under the window path so the subscriber's
+	// "metrics/days/" prefix keeps covering them.
+	if base := metricsPath(30); len(metricsPartPath(30, 0)) <= len(base) ||
+		metricsPartPath(30, 0)[:len(base)] != base {
+		t.Error("part paths do not sit under the window path")
+	}
+}

--- a/pkg/tpviz/cxo_latency.go
+++ b/pkg/tpviz/cxo_latency.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 )
 
 // latencyMetricsDays is the day window read from the feed. The publisher
@@ -90,7 +92,11 @@ func (s *Server) tryCXOLatency() (*LatencyGraph, bool) {
 	prefix := fmt.Sprintf("metrics/days/%d", latencyMetricsDays)
 	ok := mgr.Walk(CXOFeedTPDMetrics, prefix, func(_ string, body []byte) bool {
 		var metrics []cxoTransportMetric
-		if err := json.Unmarshal(body, &metrics); err != nil {
+		// The publisher gzips; Gunzip passes a raw body through unchanged. A
+		// long window arrives as several "<prefix>/part/<NNNN>" leaves, which
+		// this prefix Walk already visits — taking the minimum per visor pair
+		// is the same answer whether the records came in one body or several.
+		if err := json.Unmarshal(cxoutils.Gunzip(body), &metrics); err != nil {
 			return true
 		}
 		for i := range metrics {

--- a/pkg/visor/api_tpd_metrics_subscriber.go
+++ b/pkg/visor/api_tpd_metrics_subscriber.go
@@ -14,9 +14,13 @@
 package visor
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
+
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 )
 
 // ErrTPDMetricsNotReady is returned by FetchTransportMetricsCXO when
@@ -43,9 +47,88 @@ func (v *Visor) FetchTransportMetricsCXO(days int) ([]byte, time.Time, error) {
 	defer mgr.ReleaseFor(TabMetrics)
 
 	path := fmt.Sprintf("metrics/days/%d", days)
-	body, ts, ok := mgr.Get(FeedTPDMetrics, path)
-	if !ok || len(body) == 0 {
+	if body, ts, ok := mgr.Get(FeedTPDMetrics, path); ok && len(body) > 0 {
+		// Gunzip passes a raw body through unchanged, so this reads both the
+		// gzipped bodies the publisher writes now and any uncompressed ones
+		// still cached from an older TPD.
+		return cxoutils.Gunzip(body), ts, nil
+	}
+
+	// A window too large for one CXO object is published as
+	// "metrics/days/<n>/part/<NNNN>" leaves. Stitch them back into the single
+	// JSON array every caller of this function expects.
+	return v.joinTransportMetricParts(path)
+}
+
+// joinTransportMetricParts concatenates the part leaves under base into one
+// JSON array. Parts are spliced as bytes rather than decoded and re-encoded:
+// these windows run to tens of megabytes, and the caller only forwards the
+// array on.
+func (v *Visor) joinTransportMetricParts(base string) ([]byte, time.Time, error) {
+	mgr := v.CXOSubMgr()
+	if mgr == nil {
 		return nil, time.Time{}, ErrTPDMetricsNotReady
 	}
-	return body, ts, nil
+
+	type part struct {
+		path string
+		body []byte
+	}
+	var parts []part
+	var newest time.Time
+
+	mgr.Walk(FeedTPDMetrics, base+"/part/", func(p string, body []byte) bool {
+		if len(body) == 0 {
+			return true
+		}
+		// Walk lends the snapshot's bytes; Gunzip of a raw body returns that
+		// same slice, so copy before the callback returns.
+		decoded := cxoutils.Gunzip(body)
+		parts = append(parts, part{path: p, body: append([]byte(nil), decoded...)})
+		if ts, ok := mgr.SyncedAt(FeedTPDMetrics, p); ok && ts.After(newest) {
+			newest = ts
+		}
+		return true
+	})
+	if len(parts) == 0 {
+		return nil, time.Time{}, ErrTPDMetricsNotReady
+	}
+	// Walk iterates a map, so order is arbitrary; the zero-padded part index
+	// makes a lexical sort the publication order.
+	sort.Slice(parts, func(i, j int) bool { return parts[i].path < parts[j].path })
+
+	bodies := make([][]byte, len(parts))
+	for i, p := range parts {
+		bodies[i] = p.body
+	}
+	joined, err := spliceJSONArrays(bodies)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("%w: %v", ErrTPDMetricsNotReady, err)
+	}
+	return joined, newest, nil
+}
+
+// spliceJSONArrays concatenates JSON arrays into one array at the byte level.
+// Splicing a body that is not an array would produce silently malformed JSON,
+// so that is an error rather than something the caller discovers downstream.
+func spliceJSONArrays(bodies [][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	first := true
+	for i, body := range bodies {
+		inner := bytes.TrimSpace(body)
+		if len(inner) < 2 || inner[0] != '[' || inner[len(inner)-1] != ']' {
+			return nil, fmt.Errorf("part %d is not a JSON array", i)
+		}
+		if inner = bytes.TrimSpace(inner[1 : len(inner)-1]); len(inner) == 0 {
+			continue
+		}
+		if !first {
+			buf.WriteByte(',')
+		}
+		buf.Write(inner)
+		first = false
+	}
+	buf.WriteByte(']')
+	return buf.Bytes(), nil
 }

--- a/pkg/visor/api_tpd_metrics_subscriber_test.go
+++ b/pkg/visor/api_tpd_metrics_subscriber_test.go
@@ -1,0 +1,53 @@
+// Package visor pkg/visor/api_tpd_metrics_subscriber_test.go c3-vis-core
+package visor
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The reader stitches the publisher's part leaves back into the single array
+// its callers expect. Splicing at the byte level is what makes a 30-megabyte
+// window affordable, so the boundaries have to be exactly right.
+func TestSpliceJSONArrays(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{"single part", []string{`[{"id":"a"}]`}, `[{"id":"a"}]`},
+		{"two parts", []string{`[{"id":"a"}]`, `[{"id":"b"},{"id":"c"}]`}, `[{"id":"a"},{"id":"b"},{"id":"c"}]`},
+		{"empty part in the middle", []string{`[{"id":"a"}]`, `[]`, `[{"id":"b"}]`}, `[{"id":"a"},{"id":"b"}]`},
+		{"all parts empty", []string{`[]`, `[]`}, `[]`},
+		{"surrounding whitespace", []string{"  [ {\"id\":\"a\"} ] \n", `[{"id":"b"}]`}, `[{"id":"a"},{"id":"b"}]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bodies := make([][]byte, len(tc.parts))
+			for i, p := range tc.parts {
+				bodies[i] = []byte(p)
+			}
+			got, err := spliceJSONArrays(bodies)
+			if err != nil {
+				t.Fatalf("spliceJSONArrays: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("got %s, want %s", got, tc.want)
+			}
+			var decoded []map[string]any
+			if err := json.Unmarshal(got, &decoded); err != nil {
+				t.Errorf("result is not valid JSON: %v", err)
+			}
+		})
+	}
+}
+
+// A body that is not an array must be reported, not spliced: pasting it between
+// the brackets would yield malformed JSON that only fails much further
+// downstream, in the hvui.
+func TestSpliceJSONArraysRejectsNonArray(t *testing.T) {
+	for _, bad := range []string{`{"id":"a"}`, ``, `[`, `null`, `"a"`} {
+		if _, err := spliceJSONArrays([][]byte{[]byte(`[{"id":"a"}]`), []byte(bad)}); err == nil {
+			t.Errorf("spliceJSONArrays accepted a non-array part %q", bad)
+		}
+	}
+}


### PR DESCRIPTION
The metrics publisher was the only TPD publisher that did not gzip its body. CXO stores object bytes verbatim, so the raw JSON went on the wire — and even the 1-day window measures 16.02 MB against production, just over skyobject's 16 MB `MaxObjectSize`. An oversized object is refused at `Put` time, which kills the whole feed rather than one window: no Root is published and every subscriber sits in "timeout waiting for Root".

#4508 kept the feed alive by re-fetching an oversized window without per-edge bandwidth, which published less than was asked for. Gzipping instead — matching `cxo_uptime_publisher.go` and `cxo_all_transports_publisher.go` — carries it with room to spare. Compression alone is not a guarantee as the network grows, so a window that still will not fit is split across `metrics/days/<n>/part/<NNNN>` leaves and stitched back by the readers. `pkg/tpviz` already walked the window prefix and needed only the gunzip. Nothing is dropped in either path.

Verified against the live production body, fetched over the resolving proxy:

| case | in | out |
| --- | --- | --- |
| real 1-day window | 16,799,370 B, 79,257 records | one 3,998,295 B leaf, 79,257 records |
| same, cap forced to 2 MB | as above | 3 parts (~1.33 MB each), 79,257 records |
