### PR TITLE
fix(dmsg): serialize the client entry read-modify-write against the discovery

### DIFF
--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -173,6 +173,19 @@ type EntityCommon struct {
 	// a single batched update, matching the transport manager's
 	// re-registration debounce pattern.
 	entryNudge chan struct{}
+	// entryUpdateSem serializes this entity's discovery read-modify-write so
+	// two concurrent publishes cannot interleave. updateClientEntry does a GET
+	// (Entry) then a PUT (PutEntry, sequence+1); the GET sits outside
+	// httpClient.updateMux, so the startup publish, the loop tick and a session
+	// nudge could each read the same sequence and have all but one rejected 422
+	// "not old + 1" (#4086). Each rejected POST costs a full Noise handshake on
+	// the discovery.
+	//
+	// Deliberately a channel, not a Mutex: acquisition must honour the caller's
+	// context. A plain mutex here is what wedged services in #3157/#3168 — a
+	// stuck PUT held it while every other caller blocked forever, their own
+	// per-attempt timeouts useless because mutex acquisition ignores context.
+	entryUpdateSem chan struct{}
 
 	// geoLookup is set by Server.SetGeoLookup. Server-side IP-info
 	// stream handler reads it; client entities leave it nil.
@@ -191,6 +204,7 @@ func (c *EntityCommon) init(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClien
 	c.sessionsMx = new(sync.Mutex)
 	c.updateInterval = updateInterval
 	c.entryNudge = make(chan struct{}, 1)
+	c.entryUpdateSem = make(chan struct{}, 1)
 	c.noListenerHits = newPortHitTracker(defaultPortHitCap)
 	c.log = log
 }
@@ -887,6 +901,25 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 	if isClosed(done) {
 		return nil
 	}
+
+	// Serialize this entity's read-modify-write against the discovery: the GET
+	// in updateClientEntryOnEndpoint and its PUT must not interleave with another
+	// publisher's, or one of them posts a stale sequence and is rejected 422
+	// (#4086). Acquisition honours ctx and done, so a stuck holder cannot wedge
+	// its callers the way the plain mutex did in #3157/#3168; a caller that times
+	// out simply retries on the next tick. Nil-checked because a zero-value
+	// EntityCommon (tests) never ran init.
+	if sem := c.entryUpdateSem; sem != nil {
+		select {
+		case sem <- struct{}{}:
+			defer func() { <-sem }()
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-done:
+			return nil
+		}
+	}
+
 	var publishedEntry *disc.Entry
 	for i, ep := range endpoints {
 		entry, updateErr := c.updateClientEntryOnEndpoint(ctx, ep, clientType, srvPKs, mustPublish)

--- a/pkg/dmsg/dmsg/entity_entryupdate_test.go
+++ b/pkg/dmsg/dmsg/entity_entryupdate_test.go
@@ -1,0 +1,70 @@
+package dmsg
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestEntryUpdateSemSerializes covers the mutual exclusion that keeps two
+// concurrent publishes from interleaving their GET/PUT and having one rejected
+// 422 "not old + 1" (#4086).
+func TestEntryUpdateSemSerializes(t *testing.T) {
+	sem := make(chan struct{}, 1)
+	sem <- struct{}{} // held by a publisher in flight
+
+	select {
+	case sem <- struct{}{}:
+		t.Fatal("a second publisher acquired the semaphore while one was in flight")
+	default:
+	}
+
+	<-sem // holder finishes
+	select {
+	case sem <- struct{}{}:
+	default:
+		t.Fatal("semaphore not released")
+	}
+}
+
+// TestEntryUpdateSemHonoursContext is the property that distinguishes this from
+// a sync.Mutex. #3157/#3168 wedged services precisely because mutex acquisition
+// ignores context: one stuck PUT held the lock and every other caller blocked
+// forever, their own per-attempt timeouts useless. A caller here must give up
+// when its context expires and retry on the next tick instead.
+func TestEntryUpdateSemHonoursContext(t *testing.T) {
+	sem := make(chan struct{}, 1)
+	sem <- struct{}{} // a stuck publisher never releases
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	var err error
+	select {
+	case sem <- struct{}{}:
+		t.Fatal("acquired a held semaphore")
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(start), time.Second, "caller should give up with its context, not block")
+}
+
+// TestEntryUpdateSemInitialised guards the nil-channel case: a send on a nil
+// channel blocks forever, so init must create the semaphore and the acquire
+// site must tolerate a zero-value EntityCommon.
+func TestEntryUpdateSemInitialised(t *testing.T) {
+	var c EntityCommon
+	require.Nil(t, c.entryUpdateSem, "zero value has no semaphore; acquire site must nil-check")
+
+	pk, sk := cipher.GenerateKeyPair()
+	c.init(pk, sk, nil, logging.MustGetLogger("test"), 0)
+	require.NotNil(t, c.entryUpdateSem)
+	require.Equal(t, 1, cap(c.entryUpdateSem))
+}


### PR DESCRIPTION
`updateClientEntry` does a GET (`Entry`) followed by a PUT (`PutEntry`, which posts `sequence+1`). Only the PUT is guarded — `httpClient.updateMux` is taken *inside* `PutEntry` — so the read-modify-write window is wide open. The startup publish (`client.go` setSessionCallback), the update-loop tick and a session nudge can each read the same sequence, and all but one get rejected `422 "sequence field of new entry is not sequence of old entry + 1"`. Every rejection costs a full Noise handshake on the discovery.

Measured on production before this: 913 clients, ~38 entry POSTs/sec, **1.8% rejected 422** (475 in 11.5 min), spread thin across clients rather than concentrated — a distributed race, which is what you'd expect from an unguarded RMW.

This takes a per-entity semaphore across the whole cycle, so only one publish is in flight for an entity at a time.

**Why a channel and not a `sync.Mutex`.** Acquisition has to honour the caller's context. A plain mutex here is what wedged dmsg-only services in #3157/#3168 — the code comment in `client.go` spells it out: one stuck PUT held `updateMux` while every other caller blocked forever, *"because mutex acquisition does not honor context — so the loop's retry never fires either"*. With a channel the acquire sits in a `select` with `ctx.Done()`, so a caller behind a stuck holder expires on its own 30s bound and retries next tick instead of wedging.

**Testing:** `go vet`, `go build .`, full `pkg/dmsg/dmsg` suite (34s) all pass. Three unit tests cover mutual exclusion, the context-honouring property that distinguishes this from a mutex, and the nil-channel guard for a zero-value `EntityCommon`.

Not verified under production load — the 422 rate is the number to watch after this deploys.

Closes the RMW half of #4086. The update *volume* is a separate axis, addressed by #4503.
