### PR TITLE
feat(tpd): publish transport metrics as immutable per-day leaves

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/0magnet/bottle/vnet"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -534,13 +533,14 @@ func DmsgURLForHTTP(httpURL string) string {
 // deprecated; mirroring it over CXO would just be sunk effort.
 func cxoFeedForURL(rawURL string) (feed, path string, ok bool) {
 	// TPD /metrics → "tpd-metrics" feed, "metrics/days/<n>" path.
-	// Only the windows the publisher actually writes are CXO-eligible
-	// — see uptimePublishDays / metricsPublishDays in TPD. Anything
-	// else falls through to the network chain.
+	// The path stays the request form the visor's FetchCXO parses; the
+	// feed itself is one leaf per calendar day, so ANY window up to the
+	// published history is now CXO-eligible rather than only the three
+	// the old publisher happened to write.
 	if isUnderBase(rawURL, deployment.Prod.TransportDiscovery, "/metrics") ||
 		isUnderBase(rawURL, deployment.Prod.TransportDiscoveryDmsg, "/metrics") {
 		days := queryParamInt(rawURL, "days", -1)
-		if days == 1 || days == 7 || days == 30 {
+		if days >= 1 && days <= 30 {
 			return "tpd-metrics", fmt.Sprintf("metrics/days/%d", days), true
 		}
 		return "", "", false

--- a/cmd/skywire-cli/commands/visor/cxo.go
+++ b/cmd/skywire-cli/commands/visor/cxo.go
@@ -215,6 +215,8 @@ broken" from the higher-level command.
 
 Paths per feed:
   tpd-metrics             metrics/days/<N>          e.g. metrics/days/7
+                          (any N up to the published history; the feed
+                           itself is one leaf per day, assembled locally)
   tpd-uptime              uptimes/days/<N>          e.g. uptimes/days/30
   sd-services             type/<typeName>           e.g. type/proxy
   tpd-all-transports      with-self | without-self

--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -55,8 +55,9 @@ import (
 type Feed int
 
 const (
-	// FeedTPDMetrics is TPD's metrics-aggregate publisher
-	// (metrics/days/<n>).
+	// FeedTPDMetrics is TPD's metrics-aggregate publisher (one leaf
+	// per calendar day at metrics/day/<YYYY-MM-DD>; older publishers
+	// used one leaf per day-window at metrics/days/<n>).
 	FeedTPDMetrics Feed = iota
 	// FeedTPDUptime is TPD's uptime-aggregate publisher
 	// (uptimes/days/<n>).
@@ -84,7 +85,12 @@ const (
 func FeedRoute(f Feed) (port uint16, prefix string, ok bool) {
 	switch f {
 	case FeedTPDMetrics:
-		return skyenv.DmsgTPDMetricsCXOPort, "metrics/days/", true
+		// "metrics/" rather than "metrics/day/": the prefix has to
+		// cover BOTH the per-day leaves and the legacy per-window ones,
+		// since a subscriber can outrun the TPD it reads (and the
+		// reverse). hasPathPrefix is segment-aware, so a narrower
+		// prefix would silently match nothing on the other layout.
+		return skyenv.DmsgTPDMetricsCXOPort, "metrics/", true
 	case FeedTPDUptime:
 		return skyenv.DmsgTPDUptimeCXOPort, "uptimes/days/", true
 	case FeedSDServices:

--- a/pkg/cxo/treestore/path_test.go
+++ b/pkg/cxo/treestore/path_test.go
@@ -63,6 +63,14 @@ func TestHasPrefix(t *testing.T) {
 		// days/, services/, clients-by-server/, transports/all/) walking
 		// empty even when the publisher had Put leaves.
 		{"metrics/days/1", "metrics/days/", true},
+		// The tpd-metrics subscription prefix is "metrics/" precisely so
+		// it covers BOTH the per-day leaves and the legacy per-window
+		// ones. A narrower prefix would match only one layout, and the
+		// other would silently walk empty.
+		{"metrics/day/2026-09-04", "metrics/", true},
+		{"metrics/day/2026-09-04/part/0003", "metrics/", true},
+		{"metrics/days/7", "metrics/", true},
+		{"metrics/day/2026-09-04", "metrics/days/", false},
 		{"transports/all/with-self", "transports/all/", true},
 		{"services/proxy/abc/entry", "services/", true},
 		{"tiers/dmsg/2026-04-27", "tiers/", true},

--- a/pkg/deployment/tpd/api/api_test.go
+++ b/pkg/deployment/tpd/api/api_test.go
@@ -628,9 +628,9 @@ func TestRegisterDeregisterFromCXO(t *testing.T) {
 }
 
 func TestCXOPathHelpers(t *testing.T) {
-	require.Equal(t, MetricsPath(7), metricsPath(7))
+	require.Equal(t, "metrics/day/2026-09-04", store.MetricsDayPath("2026-09-04"))
 	require.Equal(t, "uptimes/days/7", UptimePath(7))
-	require.NotEmpty(t, MetricsPath(30))
+	require.Equal(t, "metrics/day/2026-09-04/part/0003", store.MetricsDayPartPath("2026-09-04", 3))
 }
 
 func TestTrimSummariesToDays(t *testing.T) {
@@ -677,9 +677,11 @@ func TestCXOPublisherErrorTracking(t *testing.T) {
 
 type fakeDHTMirror struct{ mirrored, deleted int }
 
-func (m *fakeDHTMirror) Mirror(cipher.PubKey, interface{}, uint64)       { m.mirrored++ }
+func (m *fakeDHTMirror) Mirror(cipher.PubKey, interface{}, uint64) { m.mirrored++ }
+
 func (m *fakeDHTMirror) MirrorMany([]cipher.PubKey, interface{}, uint64) { m.mirrored++ }
-func (m *fakeDHTMirror) Delete(cipher.PubKey)                            { m.deleted++ }
+
+func (m *fakeDHTMirror) Delete(cipher.PubKey) { m.deleted++ }
 
 func TestDHTMirror(t *testing.T) {
 	api := newTestAPI(t)

--- a/pkg/deployment/tpd/api/cxo_metrics_publisher.go
+++ b/pkg/deployment/tpd/api/cxo_metrics_publisher.go
@@ -1,42 +1,55 @@
 // Package api pkg/deployment/tpd/api/cxo_metrics_publisher.go c4-net-discovery
 //
 // CXO publisher for the network-wide transport-metrics aggregate.
-// On a fixed cadence (default 60s) the publisher recomputes the
-// metrics for a small set of day windows (1, 7, 30) and writes the
-// gzipped JSON-encoded []store.TransportMetric to a TreeStore path
+// The publisher writes ONE GZIPPED JSON LEAF PER CALENDAR DAY
 //
-//	metrics/days/<n>
+//	metrics/day/<YYYY-MM-DD>
 //
-// Subscribers (the hvui's Transports tab via the visor's CXO
-// subscriber) watch the feed instead of HTTP-polling /metrics.
+// and a day window (1, 7, 30) is assembled reader-side from the N
+// newest leaves. See pkg/deployment/tpd/store/cxo_metrics_layout.go
+// for the pivot/merge pair and for why Live and Latency live only in
+// the newest day's leaf.
 //
-// Two properties of CXO shape how the body is written:
+// This replaced three OVERLAPPING window leaves (metrics/days/1, /7,
+// /30) recomputed on separate tickers. Two things were wrong with
+// that:
+//
+//   - Content-addressing bought nothing. One leaf per window meant a
+//     single changed byte made the whole multi-megabyte object new,
+//     so the 30-day window went back over the wire in full every 30
+//     minutes even though 29 of its 30 days could not have changed.
+//     Per-day leaves make a settled day hash identically forever, so
+//     only the current day actually moves.
+//
+//   - The recompute was redundant. Every 30 minutes the old scheme
+//     asked the store for 30×1 + 6×7 + 1×30 = 102 transport-days;
+//     this one asks for 30×1 + 1×30 = 60, because the short windows
+//     are no longer separate queries at all.
+//
+// Two properties of CXO still shape how a body is written:
 //
 //   - CXO stores and propagates object bytes verbatim — it does not
 //     compress. Bodies are gzipped here, as every sibling TPD
-//     publisher already does (see cxo_uptime_publisher.go and
-//     cxo_all_transports_publisher.go). Readers use cxoutils.Gunzip,
-//     which passes a raw body through unchanged.
+//     publisher already does. Readers use cxoutils.Gunzip, which
+//     passes a raw body through unchanged.
 //
 //   - An object over skyobject MaxObjectSize (16 MB) is refused at
-//     Put time, and refusing one window kills the whole feed: no
-//     Root is ever published and every subscriber sits in "timeout
-//     waiting for Root" forever. Measured on production, even the
-//     1-day window is 16.02 MB of JSON — every window was over.
-//     Gzip (~4x on this data) carries the short windows; long
-//     windows are additionally split across
+//     Put time, and one refused Put kills the whole feed: no Root is
+//     ever published and every subscriber sits in "timeout waiting
+//     for Root" forever. A single production day is ~16 MB of JSON
+//     that gzips to ~4 MB, so a day fits comfortably — but the
+//     part-splitting safety net is kept, at
 //
-//     metrics/days/<n>/part/<NNNN>
+//     metrics/day/<YYYY-MM-DD>/part/<NNNN>
 //
-//     leaves so no data is dropped. Readers stitch the parts back
-//     into one array; the prefix Walk that pkg/tpviz already used
-//     picks them up unchanged.
+//     because "it fits today" is not a guarantee about a larger
+//     network tomorrow.
 package api
 
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -51,38 +64,37 @@ import (
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
-// metricsPublishWindow defines a CXO-published day-window and the
-// cadence at which its body is recomputed. Heavy windows (7d, 30d)
-// aggregate over long periods and barely change minute-to-minute, so
-// they recompute less often than the 1d window — the previous
-// uniform 60s tick across all three windows drove TPD into a GC
-// storm (~70% of CPU in gcBgMarkWorker under prod load, since
-// buildTransportMetrics walks all transports × days × per-edge
-// fields each call). Staggering the heavy windows keeps subscribers
-// fed without paying the full cost every minute.
-type metricsPublishWindow struct {
-	days     int
-	interval time.Duration
-}
+const (
+	// metricsWindowDays is how much history the feed carries. It is
+	// the longest window the hvui's day selector offers, and it sits
+	// inside the 35-day TTL on the bw:daily:* keys the store reads.
+	metricsWindowDays = 30
 
-// metricsPublishWindows is the set of day windows the publisher
-// refreshes, each on its own ticker. The hvui picks one of these via
-// the day selector; everything else falls through to the HTTP path.
-// Cadence picks: 60s for the 1d window matches a typical hvui-open
-// freshness expectation; 5m for the 7d window and 30m for the 30d
-// window are short enough that an opening hvui sees recent data
-// (well inside human-noticeable freshness on a long aggregate) and
-// long enough that the buildTransportMetrics cost amortizes.
-var metricsPublishWindows = []metricsPublishWindow{
-	{days: 1, interval: 60 * time.Second},
-	{days: 7, interval: 5 * time.Minute},
-	{days: 30, interval: 30 * time.Minute},
-}
+	// metricsTick is the cadence of the current day's leaf. It matches
+	// the 60s the old 1-day window ran at, which is the freshness an
+	// open hvui expects.
+	metricsTick = 60 * time.Second
 
-// MetricsCXOPublisher periodically computes the /metrics aggregate
-// for a fixed set of day windows and publishes each result as a
-// JSON leaf at "metrics/days/<n>". The struct is owned by the API;
-// Close shuts the publisher and stops the ticker.
+	// metricsFullEvery is how many ticks pass between full-window
+	// republishes. A settled day does not change, but three things
+	// still move it: bandwidth for yesterday keeps arriving for a
+	// while after UTC midnight, the store's expired-transport
+	// recovery adds records for past days, and days fall out of the
+	// window and must be retired. Republishing all 30 leaves every 30
+	// minutes covers all three at the cost of ONE 30-day store query
+	// — and the 29 settled leaves re-encode to the bytes they already
+	// had, so CXO ships nothing for them.
+	metricsFullEvery = 30
+
+	// legacyMetricsPrefix is the sub-tree the pre-day-leaf publisher
+	// wrote (metrics/days/<n>). Pruned once at startup so a feed
+	// backed by a persistent DB cannot serve a stale window forever.
+	legacyMetricsPrefix = "metrics/days"
+)
+
+// MetricsCXOPublisher periodically recomputes the /metrics aggregate
+// and publishes it as one leaf per calendar day. The struct is owned
+// by the API; Close shuts the publisher and stops the ticker.
 type MetricsCXOPublisher struct {
 	api *API
 	pub *treestore.Publisher
@@ -91,12 +103,19 @@ type MetricsCXOPublisher struct {
 	cancel context.CancelFunc
 	done   chan struct{}
 
+	// parts records, per published date, how many part leaves that day
+	// was last written as (0 = a single leaf). The next cycle needs it
+	// to retire leaves that are no longer produced. Only the publish
+	// loop touches it.
+	parts map[string]int
+	// curDate is the date the last cycle treated as "today", so a UTC
+	// midnight rollover can force a full republish instead of leaving
+	// yesterday's leaf carrying stale Live/Latency for up to 30
+	// minutes.
+	curDate string
+
 	mu        sync.Mutex
 	lastError error
-	// lastParts records how many part leaves each day window was last
-	// published as (0 = a single leaf), so the next cycle knows which
-	// leaves to retire.
-	lastParts map[int]int
 }
 
 // StartMetricsCXOPublisher constructs a publisher backed by the
@@ -125,12 +144,12 @@ func StartMetricsCXOPublisher(ctx context.Context, api *API, dmsgC *dmsg.Client,
 
 	pubCtx, cancel := context.WithCancel(ctx)
 	mp := &MetricsCXOPublisher{
-		api:       api,
-		pub:       pub,
-		log:       log,
-		cancel:    cancel,
-		done:      make(chan struct{}),
-		lastParts: make(map[int]int),
+		api:    api,
+		pub:    pub,
+		log:    log,
+		cancel: cancel,
+		done:   make(chan struct{}),
+		parts:  make(map[string]int),
 	}
 	if logger != nil {
 		logger.WithField("feed_pk", pub.Feed()).WithField("dmsg_port", skyenv.DmsgTPDMetricsCXOPort).
@@ -154,32 +173,31 @@ func (m *MetricsCXOPublisher) Close() error {
 	return m.pub.Close()
 }
 
+// loop drives both cadences from ONE goroutine. The three windows
+// used to each have their own ticker; a single loop means the
+// per-date bookkeeping below needs no lock and the full and current
+// publishes can never interleave.
 func (m *MetricsCXOPublisher) loop(ctx context.Context) {
 	defer close(m.done)
 
-	var wg sync.WaitGroup
-	for _, w := range metricsPublishWindows {
-		wg.Add(1)
-		go func(w metricsPublishWindow) {
-			defer wg.Done()
-			// Publish once immediately so a subscriber that connects
-			// shortly after TPD starts gets a snapshot without waiting
-			// a full tick.
-			m.publishWindow(ctx, w.days)
-
-			t := time.NewTicker(w.interval)
-			defer t.Stop()
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case <-t.C:
-					m.publishWindow(ctx, w.days)
-				}
-			}
-		}(w)
+	if err := m.pub.PrunePrefix(legacyMetricsPrefix); err != nil {
+		m.log.WithError(err).Debug("could not prune the legacy metrics/days sub-tree")
 	}
-	wg.Wait()
+
+	// Publish the whole window once immediately so a subscriber that
+	// connects shortly after TPD starts gets history without waiting.
+	m.publish(ctx, true)
+
+	t := time.NewTicker(metricsTick)
+	defer t.Stop()
+	for n := 1; ; n++ {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			m.publish(ctx, n%metricsFullEvery == 0)
+		}
+	}
 }
 
 // maxPublishBody bounds a single published body, measured on the GZIPPED bytes
@@ -187,17 +205,35 @@ func (m *MetricsCXOPublisher) loop(ctx context.Context) {
 // MaxObjectSize covers the encoding overhead CXO adds around the payload.
 const maxPublishBody = 12 * 1024 * 1024
 
-func (m *MetricsCXOPublisher) publishWindow(ctx context.Context, days int) {
-	query := store.MetricsQuery{
+// publish recomputes and writes the day leaves. full=false refreshes
+// only the current day, which is the only leaf that can move
+// minute-to-minute; full=true recomputes the whole window, rewrites
+// every day leaf (settled ones re-encode to their existing bytes and
+// cost nothing on the wire) and retires the days that dropped out.
+func (m *MetricsCXOPublisher) publish(ctx context.Context, full bool) {
+	now := time.Now().UTC()
+	today := now.Format(store.MetricsDateFormat)
+	if today != m.curDate {
+		// A UTC rollover means yesterday's leaf still carries the Live
+		// and Latency fields only the current day is supposed to hold.
+		// Rewrite the window rather than leaving that until the next
+		// scheduled full cycle.
+		full = true
+	}
+
+	days := 1
+	if full {
+		days = metricsWindowDays
+	}
+	metrics, err := m.api.store.GetAllTransportMetrics(ctx, store.MetricsQuery{
 		Days:      days,
 		Live:      "all",
 		Edges:     true,
 		Bandwidth: true,
 		Latency:   true,
-	}
-	metrics, err := m.api.store.GetAllTransportMetrics(ctx, query)
+	})
 	if err != nil {
-		// WARN, not DEBUG. A window that fails every tick makes the whole feed
+		// WARN, not DEBUG. A cycle that fails every tick makes the whole feed
 		// unusable, and at DEBUG that is invisible on a production deployment —
 		// which is exactly how this went unnoticed.
 		m.log.WithError(err).WithField("days", days).Warn("metrics fetch failed; will retry next tick")
@@ -205,61 +241,115 @@ func (m *MetricsCXOPublisher) publishWindow(ctx context.Context, days int) {
 		return
 	}
 
-	bodies, err := gzipParts(metrics, maxPublishBody)
-	if err != nil {
-		m.log.WithError(err).WithField("days", days).Warn("metrics marshal failed")
-		m.recordError(err)
-		return
-	}
+	dates := store.MetricsWindowDates(now, days)
+	byDate := store.PivotDailyMetrics(metrics, dates)
 
-	base := metricsPath(days)
-	m.mu.Lock()
-	prevParts := m.lastParts[days]
-	m.mu.Unlock()
-
-	// Deletes are emitted before puts: PutBatch applies ops in order, and a
-	// path cannot be a leaf and a sub-tree at once. Switching a window between
-	// the two forms therefore has to retire the old form first or the put
-	// fails with ErrPathConflict.
-	var deletes, puts []treestore.PutOp
-	staleFrom := len(bodies)
-	if len(bodies) == 1 {
-		puts = append(puts, treestore.PutOp{Path: base, Value: bodies[0]})
-		staleFrom = 0 // every part path from a previous split is now stale
-	} else {
-		deletes = append(deletes, treestore.PutOp{Path: base})
-		for i, b := range bodies {
-			puts = append(puts, treestore.PutOp{Path: metricsPartPath(days, i), Value: b})
+	bodies := make(map[string][][]byte, len(dates))
+	for _, date := range dates {
+		parts, gerr := gzipParts(byDate[date], maxPublishBody)
+		if gerr != nil {
+			m.log.WithError(gerr).WithField("date", date).Warn("metrics marshal failed")
+			m.recordError(gerr)
+			return
 		}
-	}
-	// A shrinking network splits into fewer parts than last time. Without this
-	// the leftover high-index leaves stay in the tree and a prefix Walk keeps
-	// serving records that no longer exist.
-	for i := staleFrom; i < prevParts; i++ {
-		deletes = append(deletes, treestore.PutOp{Path: metricsPartPath(days, i)})
+		bodies[date] = parts
 	}
 
-	if err := m.pub.PutBatch(append(deletes, puts...)); err != nil {
-		m.log.WithError(err).WithField("path", base).Warn("publisher PutBatch failed")
+	ops, next := planDayOps(bodies, dates, m.parts, full)
+	if err := m.pub.PutBatch(ops); err != nil {
+		m.log.WithError(err).Warn("publisher PutBatch failed")
 		m.recordError(err)
 		return
 	}
-
-	nowParts := 0
-	if len(bodies) > 1 {
-		nowParts = len(bodies)
-		m.log.WithField("days", days).WithField("parts", nowParts).
-			Debug("metrics window exceeded the CXO object limit; published as parts")
-	}
-	m.mu.Lock()
-	m.lastParts[days] = nowParts
-	m.mu.Unlock()
+	m.parts, m.curDate = next, today
 }
 
-// gzipParts encodes metrics as one or more gzipped JSON arrays, each at most
-// max bytes. One part is the normal case; a window only splits when even
+// planDayOps turns one cycle's gzipped bodies into the PutBatch that
+// realizes them, and returns the per-date part counts the next cycle
+// should compare against.
+//
+// Deletes are emitted before puts because PutBatch applies ops IN
+// ORDER and a path cannot be a leaf and a sub-tree at once: a day
+// that switches between the single-leaf and the split form has to
+// retire the old form first or the put fails with ErrPathConflict.
+//
+// prune=true additionally retires day leaves that have fallen out of
+// the window. Without it a rolling window grows a leaf a day forever,
+// and a prefix Walk keeps serving days the store no longer has data
+// for.
+func planDayOps(bodies map[string][][]byte, dates []string, prev map[string]int, prune bool) (ops []treestore.PutOp, next map[string]int) {
+	next = make(map[string]int, len(prev)+len(dates))
+	for d, n := range prev {
+		next[d] = n
+	}
+
+	inWindow := make(map[string]bool, len(dates))
+	var deletes, puts []treestore.PutOp
+	for _, date := range dates {
+		inWindow[date] = true
+		bs := bodies[date]
+		if len(bs) == 0 {
+			continue
+		}
+		base := store.MetricsDayPath(date)
+		staleFrom := len(bs)
+		if len(bs) == 1 {
+			puts = append(puts, treestore.PutOp{Path: base, Value: bs[0]})
+			staleFrom = 0 // every part path from a previous split is now stale
+		} else {
+			deletes = append(deletes, treestore.PutOp{Path: base})
+			for i, b := range bs {
+				puts = append(puts, treestore.PutOp{Path: store.MetricsDayPartPath(date, i), Value: b})
+			}
+		}
+		// A day that splits into fewer parts than last time leaves the
+		// leftover high-index leaves behind; a reader stitching by
+		// prefix would then serve records that no longer exist.
+		for i := staleFrom; i < prev[date]; i++ {
+			deletes = append(deletes, treestore.PutOp{Path: store.MetricsDayPartPath(date, i)})
+		}
+		if len(bs) > 1 {
+			next[date] = len(bs)
+		} else {
+			next[date] = 0
+		}
+	}
+
+	if prune {
+		for date, n := range next {
+			if inWindow[date] {
+				continue
+			}
+			if n == 0 {
+				deletes = append(deletes, treestore.PutOp{Path: store.MetricsDayPath(date)})
+			}
+			for i := 0; i < n; i++ {
+				deletes = append(deletes, treestore.PutOp{Path: store.MetricsDayPartPath(date, i)})
+			}
+			delete(next, date)
+		}
+		// Retiring days must be deterministic too: a map iteration
+		// order in the batch would make the same cycle emit different
+		// op sequences on different runs, which is untestable.
+		sortOpsByPath(deletes)
+	}
+
+	return append(deletes, puts...), next
+}
+
+func sortOpsByPath(ops []treestore.PutOp) {
+	sort.Slice(ops, func(i, j int) bool { return ops[i].Path < ops[j].Path })
+}
+
+// gzipParts encodes one day's records as one or more gzipped JSON arrays, each
+// at most max bytes. One part is the normal case; a day only splits when even
 // compressed it will not fit in a single CXO object.
 func gzipParts(metrics []store.TransportMetric, max int) ([][]byte, error) {
+	if metrics == nil {
+		// json.Marshal of a nil slice is "null", which is not the empty
+		// array a reader unmarshals into []TransportMetric.
+		metrics = []store.TransportMetric{}
+	}
 	whole, err := json.Marshal(metrics)
 	if err != nil {
 		return nil, err
@@ -341,27 +431,10 @@ func (m *MetricsCXOPublisher) recordError(err error) {
 }
 
 // LastError returns the most recent error encountered by the publish
-// loop, or nil if the last tick succeeded for every window. Exposed
-// for /health-style introspection if a future caller wants it.
+// loop, or nil if the last tick succeeded. Exposed for /health-style
+// introspection if a future caller wants it.
 func (m *MetricsCXOPublisher) LastError() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.lastError
-}
-
-// MetricsPath returns the TreeStore path the publisher writes to for
-// a given day window. Exported so visor-side subscribers don't have
-// to duplicate the format string.
-func MetricsPath(days int) string { return metricsPath(days) }
-
-func metricsPath(days int) string {
-	return fmt.Sprintf("metrics/days/%d", days)
-}
-
-// MetricsPartPath returns the path of one part of a split window. Zero-padded
-// so a reader that sorts the paths lexically gets them in publication order.
-func MetricsPartPath(days, part int) string { return metricsPartPath(days, part) }
-
-func metricsPartPath(days, part int) string {
-	return fmt.Sprintf("%s/part/%04d", metricsPath(days), part)
 }

--- a/pkg/deployment/tpd/api/cxo_metrics_publisher_test.go
+++ b/pkg/deployment/tpd/api/cxo_metrics_publisher_test.go
@@ -4,9 +4,11 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/deployment/tpd/store"
 )
 
@@ -50,7 +52,7 @@ func decodeParts(t *testing.T, parts [][]byte) []store.TransportMetric {
 	return all
 }
 
-// A window that fits is published as one leaf, and it is gzipped — CXO stores
+// A day leaf that fits is published as one body, and it is gzipped — CXO stores
 // bytes verbatim, so an uncompressed body is what pushed this feed over the
 // object limit in the first place.
 func TestGzipPartsSingleLeafIsCompressed(t *testing.T) {
@@ -60,7 +62,7 @@ func TestGzipPartsSingleLeafIsCompressed(t *testing.T) {
 		t.Fatalf("gzipParts: %v", err)
 	}
 	if len(parts) != 1 {
-		t.Fatalf("got %d parts, want 1 for a small window", len(parts))
+		t.Fatalf("got %d parts, want 1 for a small day", len(parts))
 	}
 	if len(parts[0]) < 2 || parts[0][0] != 0x1f || parts[0][1] != 0x8b {
 		t.Error("the published body is not gzipped")
@@ -78,8 +80,29 @@ func TestGzipPartsSingleLeafIsCompressed(t *testing.T) {
 	}
 }
 
+// A day with no data must publish the empty ARRAY. json.Marshal of a nil slice
+// is "null", which does not unmarshal into []TransportMetric the way the
+// reader's merge expects.
+func TestGzipPartsEmptyDayIsAnEmptyArray(t *testing.T) {
+	for name, in := range map[string][]store.TransportMetric{
+		"nil":   nil,
+		"empty": {},
+	} {
+		parts, err := gzipParts(in, maxPublishBody)
+		if err != nil {
+			t.Fatalf("%s: gzipParts: %v", name, err)
+		}
+		if len(parts) != 1 {
+			t.Fatalf("%s: got %d parts, want 1", name, len(parts))
+		}
+		if got := string(cxoutils.Gunzip(parts[0])); got != "[]" {
+			t.Errorf("%s: published %q, want %q", name, got, "[]")
+		}
+	}
+}
+
 // The point of the split: every part fits, and NO record is dropped. The
-// previous behavior re-fetched the window without per-edge bandwidth and
+// pre-#4509 behavior re-fetched the window without per-edge bandwidth and
 // published that instead, which silently lost data.
 func TestGzipPartsSplitsWithoutLosingRecords(t *testing.T) {
 	metrics := metricsFixture(4000, 30)
@@ -150,27 +173,53 @@ func TestSplitEvenlyCoversEveryRecordOnce(t *testing.T) {
 	}
 }
 
-// Part paths must sort lexically into publication order, because the reader
-// recovers ordering from a sort of the paths a map-ordered Walk hands it.
-func TestMetricsPartPathSortsNumerically(t *testing.T) {
-	if a, b := metricsPartPath(30, 9), metricsPartPath(30, 10); !(a < b) {
-		t.Errorf("%q should sort before %q", a, b)
+// opPaths flattens a batch for assertions; deletes are marked so the ordering
+// checks below can read.
+func opPaths(ops []treestore.PutOp) []string {
+	out := make([]string, 0, len(ops))
+	for _, op := range ops {
+		if op.Value == nil {
+			out = append(out, "-"+op.Path)
+			continue
+		}
+		out = append(out, "+"+op.Path)
 	}
-	if got, want := metricsPartPath(7, 3), "metrics/days/7/part/0003"; got != want {
-		t.Errorf("metricsPartPath(7,3) = %q, want %q", got, want)
+	return out
+}
+
+func body(n int) [][]byte {
+	out := make([][]byte, n)
+	for i := range out {
+		out[i] = []byte{byte(i)}
 	}
-	// The part paths must live under the window path so the subscriber's
-	// "metrics/days/" prefix keeps covering them.
-	if base := metricsPath(30); len(metricsPartPath(30, 0)) <= len(base) ||
-		metricsPartPath(30, 0)[:len(base)] != base {
-		t.Error("part paths do not sit under the window path")
+	return out
+}
+
+// The steady state: one put per day in the window, nothing else.
+func TestPlanDayOpsSteadyState(t *testing.T) {
+	dates := []string{"2026-09-04", "2026-09-03", "2026-09-02"}
+	bodies := map[string][][]byte{dates[0]: body(1), dates[1]: body(1), dates[2]: body(1)}
+
+	ops, next := planDayOps(bodies, dates, map[string]int{}, true)
+	want := []string{
+		"+metrics/day/2026-09-04",
+		"+metrics/day/2026-09-03",
+		"+metrics/day/2026-09-02",
+	}
+	if got := opPaths(ops); !equalStrings(got, want) {
+		t.Errorf("ops = %v, want %v", got, want)
+	}
+	for _, d := range dates {
+		if next[d] != 0 {
+			t.Errorf("%s recorded %d parts, want 0 (single leaf)", d, next[d])
+		}
 	}
 }
 
-// The split is sized against the compressed total, because partTargetBody
-// budgets the gzipped part. Sizing it from the raw size instead over-splits by
-// the compression ratio, which costs a filling subscriber a round trip per
-// surplus leaf.
+// The split is sized against the compressed total, because the per-part
+// target and the cap both budget the gzipped part. Sizing it from the raw size
+// instead over-splits by the compression ratio, which costs a filling
+// subscriber a round trip per surplus leaf.
 func TestGzipPartsDoesNotOverSplit(t *testing.T) {
 	metrics := metricsFixture(4000, 30)
 	const max = 64 * 1024
@@ -200,4 +249,100 @@ func TestGzipPartsDoesNotOverSplit(t *testing.T) {
 	if got := decodeParts(t, parts); len(got) != len(metrics) {
 		t.Errorf("round-trip returned %d records, want %d", len(got), len(metrics))
 	}
+}
+
+// A day that only refreshes "today" must leave every other day's leaf alone —
+// that is the whole point of the layout, and the bookkeeping for those days has
+// to survive the cycle so the next full one can still retire them.
+func TestPlanDayOpsCurrentDayOnlyTouchesToday(t *testing.T) {
+	prev := map[string]int{"2026-09-04": 0, "2026-09-03": 0, "2026-08-20": 3}
+	ops, next := planDayOps(map[string][][]byte{"2026-09-04": body(1)}, []string{"2026-09-04"}, prev, false)
+
+	if got, want := opPaths(ops), []string{"+metrics/day/2026-09-04"}; !equalStrings(got, want) {
+		t.Errorf("ops = %v, want %v", got, want)
+	}
+	if len(next) != len(prev) {
+		t.Errorf("next tracks %d days, want %d — a non-full cycle must not forget days", len(next), len(prev))
+	}
+	if next["2026-08-20"] != 3 {
+		t.Errorf("part count for an untouched day became %d, want 3", next["2026-08-20"])
+	}
+}
+
+// A rolling window has to retire the days that fall out of it, leaf AND parts,
+// or the tree grows by a day forever and a prefix Walk keeps serving them.
+func TestPlanDayOpsRetiresDaysOutOfWindow(t *testing.T) {
+	prev := map[string]int{"2026-09-04": 0, "2026-09-03": 0, "2026-08-05": 0, "2026-08-04": 2}
+	dates := []string{"2026-09-04", "2026-09-03"}
+	bodies := map[string][][]byte{dates[0]: body(1), dates[1]: body(1)}
+
+	ops, next := planDayOps(bodies, dates, prev, true)
+	want := []string{
+		"-metrics/day/2026-08-04/part/0000",
+		"-metrics/day/2026-08-04/part/0001",
+		"-metrics/day/2026-08-05",
+		"+metrics/day/2026-09-04",
+		"+metrics/day/2026-09-03",
+	}
+	if got := opPaths(ops); !equalStrings(got, want) {
+		t.Errorf("ops = %v, want %v", got, want)
+	}
+	if _, still := next["2026-08-05"]; still {
+		t.Error("a retired day is still tracked")
+	}
+	if _, still := next["2026-08-04"]; still {
+		t.Error("a retired split day is still tracked")
+	}
+}
+
+// A path cannot be a leaf and a sub-tree at once, and PutBatch applies ops in
+// order — so a day changing form has to retire the old form FIRST.
+func TestPlanDayOpsDeletesBeforePutsWhenFormChanges(t *testing.T) {
+	// Single leaf -> split.
+	ops, next := planDayOps(map[string][][]byte{"2026-09-04": body(2)}, []string{"2026-09-04"}, map[string]int{"2026-09-04": 0}, false)
+	want := []string{
+		"-metrics/day/2026-09-04",
+		"+metrics/day/2026-09-04/part/0000",
+		"+metrics/day/2026-09-04/part/0001",
+	}
+	if got := opPaths(ops); !equalStrings(got, want) {
+		t.Errorf("leaf->split ops = %v, want %v", got, want)
+	}
+	if next["2026-09-04"] != 2 {
+		t.Errorf("recorded %d parts, want 2", next["2026-09-04"])
+	}
+
+	// Split -> single leaf: every old part must go before the leaf lands.
+	ops, next = planDayOps(map[string][][]byte{"2026-09-04": body(1)}, []string{"2026-09-04"}, map[string]int{"2026-09-04": 3}, false)
+	want = []string{
+		"-metrics/day/2026-09-04/part/0000",
+		"-metrics/day/2026-09-04/part/0001",
+		"-metrics/day/2026-09-04/part/0002",
+		"+metrics/day/2026-09-04",
+	}
+	if got := opPaths(ops); !equalStrings(got, want) {
+		t.Errorf("split->leaf ops = %v, want %v", got, want)
+	}
+	if next["2026-09-04"] != 0 {
+		t.Errorf("recorded %d parts, want 0", next["2026-09-04"])
+	}
+
+	// Shrinking split: the leftover high-index parts must be retired.
+	ops, _ = planDayOps(map[string][][]byte{"2026-09-04": body(2)}, []string{"2026-09-04"}, map[string]int{"2026-09-04": 4}, false)
+	want = []string{
+		"-metrics/day/2026-09-04",
+		"-metrics/day/2026-09-04/part/0002",
+		"-metrics/day/2026-09-04/part/0003",
+		"+metrics/day/2026-09-04/part/0000",
+		"+metrics/day/2026-09-04/part/0001",
+	}
+	if got := opPaths(ops); !equalStrings(got, want) {
+		t.Errorf("shrinking-split ops = %v, want %v", got, want)
+	}
+}
+
+// equalStrings compares op sequences; joining is enough here and keeps the
+// comparison free of index arithmetic.
+func equalStrings(a, b []string) bool {
+	return strings.Join(a, "\n") == strings.Join(b, "\n")
 }

--- a/pkg/deployment/tpd/store/cxo_metrics_layout.go
+++ b/pkg/deployment/tpd/store/cxo_metrics_layout.go
@@ -1,0 +1,229 @@
+// Package store pkg/deployment/tpd/store/cxo_metrics_layout.go c4-net-discovery
+//
+// Layout of TPD's transport-metrics CXO feed, plus the pivot/merge
+// pair that converts between it and the []TransportMetric window
+// shape every caller already expects.
+//
+// The feed publishes ONE LEAF PER CALENDAR DAY at
+//
+//	metrics/day/<YYYY-MM-DD>
+//
+// rather than one leaf per day-window. A window (1, 7, 30 days) is
+// assembled reader-side from the N newest day leaves. The point is
+// that a past day cannot change, so its leaf hashes the same on
+// every republish and CXO ships nothing for it — whereas one leaf
+// per window meant a 30-day body was a new object every time any
+// single byte moved, and the whole multi-megabyte window went back
+// over the wire even though 29 of its 30 days were settled.
+//
+// Two fields are current-state, not day-scoped: Live (a transport's
+// registration can expire at any moment) and Latency (a rolling
+// min/max/avg that moves constantly). Carrying them in every day
+// leaf would make every past day mutable again and defeat the whole
+// exercise — across tens of thousands of transports, at least one
+// liveness flip between cycles is a certainty, so every leaf would
+// be a new object every time. They therefore live ONLY in the
+// newest day's leaf, which is rewritten every cycle anyway. Older
+// leaves carry the day-scoped facts and the transport's stable
+// identity (ID, Type, Edges). MergeDailyMetrics walks the days
+// newest-first, so the newest leaf's values win and the merged
+// record has the shape it always had.
+//
+// The rule this implies, stated plainly: the current day's leaf
+// holds exactly what a 1-day query returns — every transport with a
+// latency measurement or bandwidth today — and a transport that
+// appears in NO current-day record reads back Live=false with no
+// latency. That is the one behavioral difference from the old
+// per-window bodies, where a 30-day window reported current
+// liveness for a transport last seen three weeks ago. In practice a
+// registered transport has a latency record (lat:<id> outlives
+// registration by 35 days), so it is in the current leaf regardless
+// of whether it moved bytes today.
+//
+// These live in the store package rather than next to the publisher
+// because they are the contract BETWEEN the publisher and its
+// readers (pkg/visor, pkg/tpviz), and TransportMetric — the thing
+// being pivoted — is defined right here.
+package store
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// MetricsDayPrefix is the sub-tree the per-day leaves live under. It
+// is also what a subscriber's path prefix must cover.
+const MetricsDayPrefix = "metrics/day/"
+
+// MetricsDateFormat is the calendar-date layout used in a day leaf's
+// path. It matches the format the bw:daily:<id>:<date> Redis keys
+// already use, so a leaf's name and its source rows agree.
+const MetricsDateFormat = "2006-01-02"
+
+// MetricsDayPath returns the leaf path for one calendar day. Dates
+// in this format sort lexically into chronological order, so a
+// reader recovers "the N newest days" from a plain string sort.
+func MetricsDayPath(date string) string { return MetricsDayPrefix + date }
+
+// MetricsDayPartPath returns the path of one part of a day leaf that
+// did not fit in a single CXO object. Zero-padded so a lexical sort
+// of the paths is the publication order.
+func MetricsDayPartPath(date string, part int) string {
+	return fmt.Sprintf("%s/part/%04d", MetricsDayPath(date), part)
+}
+
+// MetricsDayDate extracts the calendar date from a day-leaf path or
+// from one of its part paths. ok is false for any path that is not
+// under MetricsDayPrefix — including the legacy metrics/days/<n>
+// window leaves, which a reader must not mistake for a day.
+func MetricsDayDate(path string) (string, bool) {
+	if !strings.HasPrefix(path, MetricsDayPrefix) {
+		return "", false
+	}
+	rest := path[len(MetricsDayPrefix):]
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		rest = rest[:i]
+	}
+	if rest == "" {
+		return "", false
+	}
+	return rest, true
+}
+
+// MetricsWindowDates returns the calendar dates of a `days`-long
+// window ending at now, NEWEST FIRST. The stepping matches
+// buildTransportMetrics exactly (UTC, one AddDate per day back) so a
+// pivoted row always finds its date in the window.
+func MetricsWindowDates(now time.Time, days int) []string {
+	if days < 1 {
+		days = 1
+	}
+	now = now.UTC()
+	out := make([]string, 0, days)
+	for d := 0; d < days; d++ {
+		out = append(out, now.AddDate(0, 0, -d).Format(MetricsDateFormat))
+	}
+	return out
+}
+
+// PivotDailyMetrics splits a window's metrics into one slice per
+// calendar day. dates is the window newest-first (as returned by
+// MetricsWindowDates); every date gets an entry, empty days
+// included, so the published path set is a deterministic function of
+// the window rather than of the data.
+//
+// dates[0] — the current day — is the only leaf that carries Live
+// and Latency, and it carries a record for every transport that has
+// latency at all, not just those with bandwidth today. That keeps
+// pkg/tpviz's latency graph (which reads a single day) seeing
+// exactly the transports the old 1-day window showed it.
+//
+// A record with neither latency nor a row on the current day is
+// omitted from the current leaf, mirroring the store's own rule that
+// a transport with no metrics data is not reported.
+func PivotDailyMetrics(metrics []TransportMetric, dates []string) map[string][]TransportMetric {
+	byDate := make(map[string][]TransportMetric, len(dates))
+	for _, d := range dates {
+		byDate[d] = []TransportMetric{}
+	}
+	if len(dates) == 0 {
+		return byDate
+	}
+	current := dates[0]
+
+	for i := range metrics {
+		m := &metrics[i]
+		var currentRows []DailyEdgeBandwidth
+		for _, row := range m.Daily {
+			if row.Date == current {
+				currentRows = append(currentRows, row)
+				continue
+			}
+			if _, inWindow := byDate[row.Date]; !inWindow {
+				continue
+			}
+			byDate[row.Date] = append(byDate[row.Date], TransportMetric{
+				ID:    m.ID,
+				Type:  m.Type,
+				Edges: m.Edges,
+				Daily: []DailyEdgeBandwidth{row},
+			})
+		}
+		if m.Latency == nil && len(currentRows) == 0 {
+			continue
+		}
+		if currentRows == nil {
+			currentRows = []DailyEdgeBandwidth{}
+		}
+		byDate[current] = append(byDate[current], TransportMetric{
+			ID:      m.ID,
+			Type:    m.Type,
+			Live:    m.Live,
+			Edges:   m.Edges,
+			Latency: m.Latency,
+			Daily:   currentRows,
+		})
+	}
+
+	// Sorting is not cosmetic: an unsorted leaf would re-encode to
+	// different bytes every cycle just because Redis handed the
+	// transports back in a different order, and a body that changes
+	// for no reason is exactly the retransmission this layout exists
+	// to avoid.
+	for d := range byDate {
+		sortMetricsByID(byDate[d])
+	}
+	return byDate
+}
+
+// MergeDailyMetrics rebuilds the []TransportMetric window shape from
+// day slices given NEWEST FIRST. Records are joined on transport ID;
+// daily rows accumulate in the order the days were supplied (newest
+// first, matching buildTransportMetrics), and the first day that
+// mentions a transport supplies its Live/Latency/Type/Edges.
+//
+// The result is sorted by ID so a window assembled from the same
+// leaves is byte-identical every time.
+func MergeDailyMetrics(days [][]TransportMetric) []TransportMetric {
+	idx := make(map[string]int)
+	out := make([]TransportMetric, 0)
+	for _, day := range days {
+		for i := range day {
+			src := &day[i]
+			j, seen := idx[src.ID]
+			if !seen {
+				out = append(out, TransportMetric{
+					ID:      src.ID,
+					Type:    src.Type,
+					Live:    src.Live,
+					Edges:   src.Edges,
+					Latency: src.Latency,
+					Daily:   append([]DailyEdgeBandwidth{}, src.Daily...),
+				})
+				idx[src.ID] = len(out) - 1
+				continue
+			}
+			out[j].Daily = append(out[j].Daily, src.Daily...)
+			// Older leaves omit the current-state fields by design;
+			// fill from a later day only if the newest one had none
+			// (which is also what makes a mixed old/new body safe).
+			if out[j].Type == "" {
+				out[j].Type = src.Type
+			}
+			if len(out[j].Edges) == 0 {
+				out[j].Edges = src.Edges
+			}
+			if out[j].Latency == nil {
+				out[j].Latency = src.Latency
+			}
+		}
+	}
+	sortMetricsByID(out)
+	return out
+}
+
+func sortMetricsByID(m []TransportMetric) {
+	sort.Slice(m, func(i, j int) bool { return m[i].ID < m[j].ID })
+}

--- a/pkg/deployment/tpd/store/cxo_metrics_layout_test.go
+++ b/pkg/deployment/tpd/store/cxo_metrics_layout_test.go
@@ -1,0 +1,402 @@
+// Package store pkg/deployment/tpd/store/cxo_metrics_layout_test.go c4-net-discovery
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// windowFixture builds what GetAllTransportMetrics returns for a
+// `days` window: one record per transport, each carrying a daily row
+// for a subset of the days so the pivot has to deal with sparse
+// coverage rather than a dense rectangle.
+func windowFixture(transports int, dates []string) []TransportMetric {
+	out := make([]TransportMetric, 0, transports)
+	for i := 0; i < transports; i++ {
+		var daily []DailyEdgeBandwidth
+		for d, date := range dates {
+			// Transport i is silent on every (i+1)th day, so coverage is
+			// ragged and no two transports share a day set.
+			if (d+i)%(i%4+2) == 0 {
+				continue
+			}
+			daily = append(daily, DailyEdgeBandwidth{
+				Date: date,
+				A:    &EdgeBandwidth{Sent: uint64(i*7919 + d), Recv: uint64(i*104729 + d)},
+				B:    &EdgeBandwidth{Sent: uint64(i*15485863 + d), Recv: uint64(i*32452843 + d)},
+			})
+		}
+		m := TransportMetric{
+			ID:    fmt.Sprintf("%08x-4660-0f05-aff8-8b006cc4c9%02x", i, i%256),
+			Type:  []string{"stcpr", "sudph", "dmsg", "webrtc"}[i%4],
+			Live:  i%3 != 0,
+			Edges: []string{fmt.Sprintf("02%064x", i), fmt.Sprintf("03%064x", i+1)},
+			Daily: daily,
+		}
+		// Two thirds of the transports have measured latency; the rest
+		// only exist through their bandwidth history.
+		if i%3 != 2 {
+			m.Latency = &TransportLatency{Min: int64(1000 + i), Max: int64(90000 + i), Avg: int64(14000 + i)}
+		}
+		if m.Latency == nil && len(m.Daily) == 0 {
+			// Mirrors the store's own rule: a transport with no metrics
+			// data at all is not reported.
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// pivotAndMerge is the whole wire path in miniature: split the window
+// into day leaves, then reassemble it the way the visor does, through
+// the JSON each leaf is actually published as.
+func pivotAndMerge(t *testing.T, window []TransportMetric, dates []string) []TransportMetric {
+	t.Helper()
+	byDate := PivotDailyMetrics(window, dates)
+	days := make([][]TransportMetric, 0, len(dates))
+	for _, date := range dates {
+		leaf, ok := byDate[date]
+		if !ok {
+			t.Fatalf("no leaf produced for %s", date)
+		}
+		encoded, err := json.Marshal(leaf)
+		if err != nil {
+			t.Fatalf("leaf %s did not encode: %v", date, err)
+		}
+		if string(encoded) == "null" {
+			t.Fatalf("leaf %s encoded as null, not an empty array", date)
+		}
+		var decoded []TransportMetric
+		if err := json.Unmarshal(encoded, &decoded); err != nil {
+			t.Fatalf("leaf %s did not decode: %v", date, err)
+		}
+		days = append(days, decoded)
+	}
+	return MergeDailyMetrics(days)
+}
+
+// The load-bearing property: a window assembled from day leaves holds
+// every record and every daily row the single-window body held.
+func TestPivotMergeRoundTripLosesNothing(t *testing.T) {
+	dates := MetricsWindowDates(time.Date(2026, 9, 4, 11, 0, 0, 0, time.UTC), 30)
+	window := windowFixture(400, dates)
+
+	got := pivotAndMerge(t, window, dates)
+
+	if len(got) != len(window) {
+		t.Fatalf("round-trip returned %d records, want %d", len(got), len(window))
+	}
+	byID := make(map[string]*TransportMetric, len(got))
+	for i := range got {
+		byID[got[i].ID] = &got[i]
+	}
+	var wantRows, gotRows int
+	for i := range window {
+		want := &window[i]
+		wantRows += len(want.Daily)
+		have, ok := byID[want.ID]
+		if !ok {
+			t.Fatalf("transport %s is missing from the assembled window", want.ID)
+		}
+		gotRows += len(have.Daily)
+		if have.Type != want.Type {
+			t.Errorf("%s: type = %q, want %q", want.ID, have.Type, want.Type)
+		}
+		if !reflect.DeepEqual(have.Edges, want.Edges) {
+			t.Errorf("%s: edges = %v, want %v", want.ID, have.Edges, want.Edges)
+		}
+		// Live and Latency belong to the current day's leaf, so they
+		// survive for the transports that leaf holds — see
+		// TestCurrentStateFollowsTheCurrentDayLeaf for the rule.
+		if inCurrentDay(want, dates[0]) {
+			if have.Live != want.Live {
+				t.Errorf("%s: live = %v, want %v", want.ID, have.Live, want.Live)
+			}
+			if !reflect.DeepEqual(have.Latency, want.Latency) {
+				t.Errorf("%s: latency = %+v, want %+v", want.ID, have.Latency, want.Latency)
+			}
+		} else if have.Live || have.Latency != nil {
+			t.Errorf("%s: absent from the current day but reports live=%v latency=%+v", want.ID, have.Live, have.Latency)
+		}
+		// Daily rows are compared as a set: the assembly orders them by
+		// day, newest first, which the fixture's per-transport gaps do
+		// not necessarily match index-for-index.
+		wantByDate := make(map[string]DailyEdgeBandwidth, len(want.Daily))
+		for _, row := range want.Daily {
+			wantByDate[row.Date] = row
+		}
+		for _, row := range have.Daily {
+			w, ok := wantByDate[row.Date]
+			if !ok {
+				t.Fatalf("%s: assembled window invented a row for %s", want.ID, row.Date)
+			}
+			if !reflect.DeepEqual(row, w) {
+				t.Errorf("%s %s: row = %+v, want %+v", want.ID, row.Date, row, w)
+			}
+			delete(wantByDate, row.Date)
+		}
+		if len(wantByDate) != 0 {
+			t.Errorf("%s: %d daily rows were dropped", want.ID, len(wantByDate))
+		}
+	}
+	if gotRows != wantRows {
+		t.Errorf("assembled window holds %d daily rows, want %d", gotRows, wantRows)
+	}
+}
+
+// inCurrentDay reports whether the current day's leaf will hold a
+// record for m: it does so for anything with latency, or with a row
+// on that day.
+func inCurrentDay(m *TransportMetric, current string) bool {
+	if m.Latency != nil {
+		return true
+	}
+	for _, row := range m.Daily {
+		if row.Date == current {
+			return true
+		}
+	}
+	return false
+}
+
+// The documented rule, pinned: current state rides on the current
+// day's leaf and nowhere else. A transport with no presence on that
+// day reads back not-live with no latency — the single behavioral
+// difference from the old per-window bodies, and the price of past
+// days being immutable.
+func TestCurrentStateFollowsTheCurrentDayLeaf(t *testing.T) {
+	dates := MetricsWindowDates(time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC), 4)
+	window := []TransportMetric{
+		{ // live, measured, active today: everything survives
+			ID: "today", Type: "dmsg", Live: true, Edges: []string{"02a", "03b"},
+			Latency: &TransportLatency{Min: 1, Max: 3, Avg: 2},
+			Daily:   []DailyEdgeBandwidth{{Date: dates[0], A: &EdgeBandwidth{Sent: 7}}},
+		},
+		{ // live and measured but silent today: the latency puts it in
+			// the current leaf anyway, so Live survives
+			ID: "quiet", Type: "stcpr", Live: true, Edges: []string{"02c", "03d"},
+			Latency: &TransportLatency{Min: 4, Max: 6, Avg: 5},
+			Daily:   []DailyEdgeBandwidth{{Date: dates[2], A: &EdgeBandwidth{Sent: 9}}},
+		},
+		{ // no latency and nothing today: history only, reads not-live
+			ID: "historic", Type: "sudph", Live: true, Edges: []string{"02e", "03f"},
+			Daily: []DailyEdgeBandwidth{{Date: dates[2], A: &EdgeBandwidth{Sent: 11}}},
+		},
+	}
+
+	got := pivotAndMerge(t, window, dates)
+	if len(got) != 3 {
+		t.Fatalf("assembled %d records, want 3", len(got))
+	}
+	byID := map[string]TransportMetric{}
+	for _, m := range got {
+		byID[m.ID] = m
+	}
+	for _, id := range []string{"today", "quiet"} {
+		if m := byID[id]; !m.Live || m.Latency == nil {
+			t.Errorf("%s: live=%v latency=%+v, want both present", id, m.Live, m.Latency)
+		}
+	}
+	if m := byID["historic"]; m.Live || m.Latency != nil {
+		t.Errorf("historic: live=%v latency=%+v, want not-live and unmeasured", m.Live, m.Latency)
+	}
+	// The history itself is never lost, whatever the current state says.
+	for _, id := range []string{"quiet", "historic"} {
+		if m := byID[id]; len(m.Daily) != 1 || m.Daily[0].Date != dates[2] {
+			t.Errorf("%s: daily = %+v, want the row on %s", id, m.Daily, dates[2])
+		}
+	}
+}
+
+// Daily rows come back newest-first, which is the order
+// buildTransportMetrics produces and therefore the order every caller
+// of the single-window body already saw.
+func TestMergeOrdersDailyRowsNewestFirst(t *testing.T) {
+	dates := MetricsWindowDates(time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC), 7)
+	got := pivotAndMerge(t, windowFixture(40, dates), dates)
+	for _, m := range got {
+		for i := 1; i < len(m.Daily); i++ {
+			if m.Daily[i-1].Date <= m.Daily[i].Date {
+				t.Fatalf("%s: daily rows out of order (%s then %s)", m.ID, m.Daily[i-1].Date, m.Daily[i].Date)
+			}
+		}
+	}
+}
+
+// Determinism is the whole economic argument: a leaf whose bytes move
+// because Redis handed the transports back in a different order is a
+// new CXO object, and content-addressing buys nothing. Both halves of
+// the round trip must be stable under input permutation.
+func TestPivotAndMergeAreDeterministic(t *testing.T) {
+	dates := MetricsWindowDates(time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC), 12)
+	window := windowFixture(120, dates)
+
+	shuffled := make([]TransportMetric, len(window))
+	copy(shuffled, window)
+	// A fixed, reproducible permutation — not a random one, so a
+	// failure here is reproducible too.
+	for i := range shuffled {
+		j := (i*7 + 3) % len(shuffled)
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	}
+
+	a, b := PivotDailyMetrics(window, dates), PivotDailyMetrics(shuffled, dates)
+	for _, date := range dates {
+		ja, err := json.Marshal(a[date])
+		if err != nil {
+			t.Fatal(err)
+		}
+		jb, err := json.Marshal(b[date])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(ja) != string(jb) {
+			t.Fatalf("leaf %s encodes differently after permuting the input — the leaf is not content-stable", date)
+		}
+	}
+
+	if !reflect.DeepEqual(pivotAndMerge(t, window, dates), pivotAndMerge(t, shuffled, dates)) {
+		t.Error("assembled windows differ after permuting the input")
+	}
+}
+
+// Live and Latency are current state, not day-scoped. They belong to
+// the current day's leaf only — carrying them in every leaf would make
+// every past day mutable and defeat the layout.
+func TestOnlyTheCurrentDayLeafCarriesCurrentState(t *testing.T) {
+	dates := MetricsWindowDates(time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC), 5)
+	byDate := PivotDailyMetrics(windowFixture(60, dates), dates)
+
+	if len(byDate[dates[0]]) == 0 {
+		t.Fatal("the current day's leaf is empty")
+	}
+	var sawLatency, sawLive bool
+	for _, m := range byDate[dates[0]] {
+		sawLatency = sawLatency || m.Latency != nil
+		sawLive = sawLive || m.Live
+	}
+	if !sawLatency || !sawLive {
+		t.Error("the current day's leaf carries neither latency nor liveness")
+	}
+	for _, date := range dates[1:] {
+		for _, m := range byDate[date] {
+			if m.Latency != nil {
+				t.Errorf("%s: past-day leaf carries latency for %s", date, m.ID)
+			}
+			if m.Live {
+				t.Errorf("%s: past-day leaf carries liveness for %s", date, m.ID)
+			}
+			if len(m.Daily) != 1 || m.Daily[0].Date != date {
+				t.Errorf("%s: past-day record for %s holds %d rows, want exactly that day's", date, m.ID, len(m.Daily))
+			}
+			if m.ID == "" || m.Type == "" || len(m.Edges) != 2 {
+				t.Errorf("%s: past-day record lost its identity: %+v", date, m)
+			}
+		}
+	}
+}
+
+// A transport with latency but no bandwidth on any day in the window
+// still has to appear — pkg/tpviz's latency graph reads exactly one
+// day's leaf and would otherwise lose it.
+func TestLatencyOnlyTransportLandsInTheCurrentDayLeaf(t *testing.T) {
+	dates := MetricsWindowDates(time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC), 7)
+	window := []TransportMetric{{
+		ID:      "quiet",
+		Type:    "dmsg",
+		Live:    true,
+		Edges:   []string{"02aa", "03bb"},
+		Latency: &TransportLatency{Min: 1, Max: 3, Avg: 2},
+		Daily:   []DailyEdgeBandwidth{},
+	}}
+	byDate := PivotDailyMetrics(window, dates)
+	if len(byDate[dates[0]]) != 1 {
+		t.Fatalf("current-day leaf holds %d records, want 1", len(byDate[dates[0]]))
+	}
+	if got := byDate[dates[0]][0]; got.Latency == nil || !got.Live {
+		t.Errorf("latency-only record lost its state: %+v", got)
+	}
+	for _, date := range dates[1:] {
+		if len(byDate[date]) != 0 {
+			t.Errorf("%s: past-day leaf should be empty, holds %d", date, len(byDate[date]))
+		}
+	}
+}
+
+// Rows dated outside the window belong to no leaf. Publishing them
+// under a day that is not in the window would resurrect data the
+// window is supposed to have retired.
+func TestPivotDropsRowsOutsideTheWindow(t *testing.T) {
+	dates := MetricsWindowDates(time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC), 3)
+	window := []TransportMetric{{
+		ID:   "t",
+		Type: "stcpr",
+		Daily: []DailyEdgeBandwidth{
+			{Date: dates[1], A: &EdgeBandwidth{Sent: 1}},
+			{Date: "2020-01-01", A: &EdgeBandwidth{Sent: 99}},
+		},
+	}}
+	byDate := PivotDailyMetrics(window, dates)
+	if _, ok := byDate["2020-01-01"]; ok {
+		t.Error("the pivot created a leaf outside the window")
+	}
+	if len(byDate) != len(dates) {
+		t.Errorf("pivot produced %d leaves, want %d — one per window day", len(byDate), len(dates))
+	}
+	total := 0
+	for _, recs := range byDate {
+		total += len(recs)
+	}
+	if total != 1 {
+		t.Errorf("pivot placed %d records, want 1", total)
+	}
+}
+
+func TestMetricsWindowDates(t *testing.T) {
+	now := time.Date(2026, 3, 2, 5, 30, 0, 0, time.UTC)
+	got := MetricsWindowDates(now, 4)
+	want := []string{"2026-03-02", "2026-03-01", "2026-02-28", "2026-02-27"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MetricsWindowDates = %v, want %v", got, want)
+	}
+	if got := MetricsWindowDates(now, 0); len(got) != 1 {
+		t.Errorf("a zero window returned %v, want a single day", got)
+	}
+	// A non-UTC clock must still name UTC days, or the leaf a reader
+	// asks for and the leaf the publisher wrote can differ by one.
+	east := time.FixedZone("UTC+13", 13*3600)
+	if got := MetricsWindowDates(now.In(east), 1); got[0] != "2026-03-02" {
+		t.Errorf("window dates are not UTC: got %v", got)
+	}
+}
+
+func TestMetricsDayPaths(t *testing.T) {
+	if got, want := MetricsDayPath("2026-09-04"), "metrics/day/2026-09-04"; got != want {
+		t.Errorf("MetricsDayPath = %q, want %q", got, want)
+	}
+	// Zero-padded so a lexical sort of the paths is publication order.
+	if a, b := MetricsDayPartPath("2026-09-04", 9), MetricsDayPartPath("2026-09-04", 10); a >= b {
+		t.Errorf("%q should sort before %q", a, b)
+	}
+	for _, tc := range []struct {
+		path string
+		date string
+		ok   bool
+	}{
+		{"metrics/day/2026-09-04", "2026-09-04", true},
+		{"metrics/day/2026-09-04/part/0003", "2026-09-04", true},
+		{"metrics/days/7", "", false},
+		{"metrics/days/7/part/0000", "", false},
+		{"metrics/day/", "", false},
+		{"uptimes/days/7", "", false},
+	} {
+		date, ok := MetricsDayDate(tc.path)
+		if ok != tc.ok || date != tc.date {
+			t.Errorf("MetricsDayDate(%q) = %q,%v; want %q,%v", tc.path, date, ok, tc.date, tc.ok)
+		}
+	}
+}

--- a/pkg/deployment/tpd/store/expired_entries_cache.go
+++ b/pkg/deployment/tpd/store/expired_entries_cache.go
@@ -19,10 +19,11 @@ import (
 // This cache exists because the CXO metrics publisher
 // (pkg/deployment/tpd/api/cxo_metrics_publisher.go) turned
 // expiredTransportEntries from a low-frequency path (rewards dashboard /
-// daily reward calc) into a per-60s path: publishWindow calls
-// GetAllTransportMetrics on a ticker (1d/60s, 7d/5m, 30d/30m), and each call
-// SCANned the bw:daily:*:<date> keyspace once per day in the window (up to 35
-// passes) over a ~13k-transport keyspace, then recovered edges per candidate.
+// daily reward calc) into a per-60s path: the publisher calls
+// GetAllTransportMetrics on a ticker (1 day every 60s, the full 30-day window
+// every 30m), and each call SCANned the bw:daily:*:<date> keyspace once per
+// day in the window (up to 35 passes) over a ~13k-transport keyspace, then
+// recovered edges per candidate.
 // That put expiredTransportEntries at ~12% of TPD CPU with redis I/O
 // dominating. Memoizing the registered-INDEPENDENT SCAN result collapses the
 // repeated ticks onto one SCAN per TTL per window.
@@ -33,8 +34,8 @@ const expiredEntriesCacheTTL = 5 * time.Minute
 // It deliberately does NOT bake in the caller's `registered` filter: that
 // filter is applied fresh on every call (see expiredTransportEntries) so a
 // transport that just (re)registered is dropped immediately and never counted
-// as expired for up to the TTL. Keyed by `days` because the 1/7/30 windows
-// scan different date ranges.
+// as expired for up to the TTL. Keyed by `days` because the publisher's
+// current-day and full-window queries scan different date ranges.
 type expiredEntriesCache struct {
 	mu     sync.Mutex
 	ttl    time.Duration

--- a/pkg/tpviz/cxo_latency.go
+++ b/pkg/tpviz/cxo_latency.go
@@ -4,29 +4,35 @@
 // weighted graph over visor public keys where an edge weight is the
 // measured round-trip time between the two visors.
 //
-// Source is TPD's metrics CXO feed (metrics/days/<n>), NOT the HTTP
-// /metrics endpoint. The publisher writes []TransportMetric there every
-// 60s and content-addressing means a subscriber pays the delta rather
-// than the whole dataset — 85k transport rows is ~31MB over HTTP, and
-// re-fetching that to move a few edges is what the feed exists to avoid.
-// There is deliberately no HTTP fallback: a view that silently starts
-// polling a rate-limited endpoint when the feed is cold is worse than a
-// view that says the feed is cold.
+// Source is TPD's metrics CXO feed (metrics/day/<YYYY-MM-DD>), NOT the
+// HTTP /metrics endpoint. The publisher writes []TransportMetric there
+// every 60s and content-addressing means a subscriber pays the delta
+// rather than the whole dataset — 85k transport rows is ~31MB over HTTP,
+// and re-fetching that to move a few edges is what the feed exists to
+// avoid. There is deliberately no HTTP fallback: a view that silently
+// starts polling a rate-limited endpoint when the feed is cold is worse
+// than a view that says the feed is cold.
+//
+// Only the CURRENT day's leaf is read. Latency is transport-level
+// current state, so that is the only leaf carrying it — and it is also
+// the most representative of the network as it is now, which is what a
+// positional embedding wants. Reading the whole 30-day window would
+// decode ~30 multi-megabyte bodies to find latency in one of them.
 package tpviz
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"sort"
 
 	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	tpdstore "github.com/skycoin/skywire/pkg/deployment/tpd/store"
 )
 
-// latencyMetricsDays is the day window read from the feed. The publisher
-// writes 1, 7 and 30; the shortest is the most representative of the
-// network as it is now, which is what a positional embedding wants.
-const latencyMetricsDays = 1
+// legacyLatencyPrefix is the one-leaf-per-window path a TPD that
+// predates the day leaves publishes. Read only when no day leaf is
+// present, so a visor that updated before TPD did keeps a graph.
+const legacyLatencyPrefix = "metrics/days/1"
 
 // cxoTransportMetric is the decoding shape of store.TransportMetric,
 // narrowed to the fields this view needs. Declared locally rather than
@@ -89,13 +95,17 @@ func (s *Server) tryCXOLatency() (*LatencyGraph, bool) {
 	}
 	best := make(map[[2]string]*agg)
 
-	prefix := fmt.Sprintf("metrics/days/%d", latencyMetricsDays)
+	prefix := legacyLatencyPrefix
+	if date, found := s.newestMetricsDay(mgr); found {
+		prefix = tpdstore.MetricsDayPath(date)
+	}
 	ok := mgr.Walk(CXOFeedTPDMetrics, prefix, func(_ string, body []byte) bool {
 		var metrics []cxoTransportMetric
 		// The publisher gzips; Gunzip passes a raw body through unchanged. A
-		// long window arrives as several "<prefix>/part/<NNNN>" leaves, which
-		// this prefix Walk already visits — taking the minimum per visor pair
-		// is the same answer whether the records came in one body or several.
+		// leaf too big for one CXO object arrives as several
+		// "<prefix>/part/<NNNN>" leaves, which this prefix Walk already visits
+		// — taking the minimum per visor pair is the same answer whether the
+		// records came in one body or several.
 		if err := json.Unmarshal(cxoutils.Gunzip(body), &metrics); err != nil {
 			return true
 		}
@@ -134,7 +144,7 @@ func (s *Server) tryCXOLatency() (*LatencyGraph, bool) {
 		return nil, false
 	}
 
-	g := &LatencyGraph{Days: latencyMetricsDays, Edges: make([]LatencyEdge, 0, len(best))}
+	g := &LatencyGraph{Days: 1, Edges: make([]LatencyEdge, 0, len(best))}
 	seen := make(map[string]struct{})
 	for k, v := range best {
 		g.Edges = append(g.Edges, LatencyEdge{A: k[0], B: k[1], MS: v.ms, N: v.n, Type: v.tType})
@@ -155,6 +165,21 @@ func (s *Server) tryCXOLatency() (*LatencyGraph, bool) {
 	}
 	sort.Strings(g.Visors)
 	return g, true
+}
+
+// newestMetricsDay returns the most recent date TPD has a day leaf
+// for. The Walk inspects paths only — it never touches a body — so
+// finding the newest of 30 days costs a map scan, not 30 gunzips.
+func (s *Server) newestMetricsDay(mgr CXOSubMgr) (string, bool) {
+	var newest string
+	mgr.Walk(CXOFeedTPDMetrics, tpdstore.MetricsDayPrefix, func(p string, _ []byte) bool {
+		// The date format sorts lexically into chronological order.
+		if date, ok := tpdstore.MetricsDayDate(p); ok && date > newest {
+			newest = date
+		}
+		return true
+	})
+	return newest, newest != ""
 }
 
 // handleLatency serves the latency graph for the latency-space view.

--- a/pkg/tpviz/cxo_subscriber.go
+++ b/pkg/tpviz/cxo_subscriber.go
@@ -35,7 +35,7 @@ const (
 // Feed identifiers used in calls to CXOSubMgr.Walk. Values match
 // pkg/visor.CXOFeed / cxosub.Feed; the adapters pass them through.
 const (
-	CXOFeedTPDMetrics           = 0 // metrics/days/<n>
+	CXOFeedTPDMetrics           = 0 // metrics/day/<YYYY-MM-DD> (legacy: metrics/days/<n>)
 	CXOFeedTPDUptime            = 1 // uptimes/days/<n> — []VisorSummary
 	CXOFeedSDServices           = 2 // services/<type>/all (batched; legacy .../<pk>/entry)
 	CXOFeedDMSGDClientsByServer = 3 // clients-by-server/<server> (batched; legacy .../<client>/entry)

--- a/pkg/visor/api_tpd_metrics_subscriber.go
+++ b/pkg/visor/api_tpd_metrics_subscriber.go
@@ -5,6 +5,19 @@
 // (see cxo_subscription_manager.go); this file is a thin facade that
 // AcquireFor's the relevant tab and serves the cached blob.
 //
+// TPD publishes one leaf per calendar day at
+// "metrics/day/<YYYY-MM-DD>", so a day window is assembled HERE from
+// the N newest leaves — see the pivot/merge pair in
+// pkg/deployment/tpd/store/cxo_metrics_layout.go. Callers still get
+// the single JSON array of store.TransportMetric they always got.
+//
+// The reader also still understands the previous layout, one leaf
+// per window at "metrics/days/<n>". TPD and visors update
+// independently from the same develop-latest binary on a ~5 minute
+// timer, so a new visor talking to a not-yet-updated TPD is a real
+// state, and it is one visor-side branch rather than a second set of
+// leaves TPD would have to keep publishing.
+//
 // Pre-task-#134 this file owned its own standalone Subscriber that
 // bound DmsgTPDMetricsCXOPort directly. That subscriber raced with
 // the unified manager for the same DMSG port, causing one of them to
@@ -15,30 +28,35 @@ package visor
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	tpdstore "github.com/skycoin/skywire/pkg/deployment/tpd/store"
 )
 
 // ErrTPDMetricsNotReady is returned by FetchTransportMetricsCXO when
 // the local manager has no snapshot for the requested day window yet
 // (manager not initialized, first cycle hasn't completed, or TPD
-// hasn't published that window). Callers should fall back to the
-// HTTP path on this error.
+// hasn't published anything). Callers should fall back to the HTTP
+// path on this error.
 var ErrTPDMetricsNotReady = errors.New("tpd metrics: cxo cache miss")
 
-// FetchTransportMetricsCXO returns the cached metrics blob for the
-// given day window. (bytes, lastRootAt, nil) on a hit; (nil, zero,
-// ErrTPDMetricsNotReady) when the cache has nothing for that path
-// yet.
+// FetchTransportMetricsCXO returns the metrics blob for the given day
+// window as a single JSON array of store.TransportMetric —
+// (bytes, lastRootAt, nil) on a hit, (nil, zero,
+// ErrTPDMetricsNotReady) when the feed has nothing to serve it from.
 //
-// `days` should be one of the values the TPD publisher writes
-// (currently 1, 7, 30); other values always miss because the
-// publisher doesn't write them.
+// `days` may be any positive count; it is satisfied from however many
+// day leaves TPD is currently publishing (30 at present), so asking
+// for more days than exist returns the days that do.
 func (v *Visor) FetchTransportMetricsCXO(days int) ([]byte, time.Time, error) {
+	if days < 1 {
+		days = 1
+	}
 	mgr := v.CXOSubMgr()
 	if mgr == nil {
 		return nil, time.Time{}, ErrTPDMetricsNotReady
@@ -46,30 +64,126 @@ func (v *Visor) FetchTransportMetricsCXO(days int) ([]byte, time.Time, error) {
 	mgr.AcquireFor(TabMetrics)
 	defer mgr.ReleaseFor(TabMetrics)
 
-	path := fmt.Sprintf("metrics/days/%d", days)
-	if body, ts, ok := mgr.Get(FeedTPDMetrics, path); ok && len(body) > 0 {
-		// Gunzip passes a raw body through unchanged, so this reads both the
-		// gzipped bodies the publisher writes now and any uncompressed ones
-		// still cached from an older TPD.
-		return cxoutils.Gunzip(body), ts, nil
+	return readTransportMetricsCXO(mgr, days)
+}
+
+// metricsSnapshot is the slice of CXOSubscriptionManager the assembly
+// below reads. Named as an interface so the assembly is exercised by
+// unit tests against a plain map instead of a live DMSG subscription.
+type metricsSnapshot interface {
+	Get(feed CXOFeed, path string) ([]byte, time.Time, bool)
+	SyncedAt(feed CXOFeed, path string) (time.Time, bool)
+	Walk(feed CXOFeed, prefix string, fn func(path string, body []byte) bool) bool
+}
+
+func readTransportMetricsCXO(mgr metricsSnapshot, days int) ([]byte, time.Time, error) {
+	if body, ts, err := assembleTransportMetricDays(mgr, days); err == nil {
+		return body, ts, nil
+	}
+	// Fall back to the pre-day-leaf layout, which a TPD that has not
+	// updated yet is still publishing.
+	return fetchLegacyMetricsWindow(mgr, days)
+}
+
+// assembleTransportMetricDays merges the N newest day leaves into one
+// window.
+//
+// The window is decoded and re-encoded rather than spliced at the
+// byte level, because a window is a JOIN: the same transport has a
+// row in every day it moved bytes, and the caller's record shape is
+// one record per transport carrying N daily rows. A one-day window
+// skips that entirely and passes the leaf's bytes straight through,
+// which is the case pkg/tpviz and the hvui's default view take.
+func assembleTransportMetricDays(mgr metricsSnapshot, days int) ([]byte, time.Time, error) {
+	dates := transportMetricDates(mgr)
+	if len(dates) == 0 {
+		return nil, time.Time{}, ErrTPDMetricsNotReady
+	}
+	if len(dates) > days {
+		dates = dates[:days]
 	}
 
-	// A window too large for one CXO object is published as
-	// "metrics/days/<n>/part/<NNNN>" leaves. Stitch them back into the single
-	// JSON array every caller of this function expects.
-	return v.joinTransportMetricParts(path)
+	var newest time.Time
+	perDay := make([][]tpdstore.TransportMetric, 0, len(dates))
+	for _, date := range dates {
+		body, ts, err := dayLeafBody(mgr, date)
+		if err != nil {
+			continue
+		}
+		if ts.After(newest) {
+			newest = ts
+		}
+		if len(dates) == 1 {
+			return body, ts, nil
+		}
+		var recs []tpdstore.TransportMetric
+		if err := json.Unmarshal(body, &recs); err != nil {
+			return nil, time.Time{}, fmt.Errorf("%w: day %s: %v", ErrTPDMetricsNotReady, date, err)
+		}
+		perDay = append(perDay, recs)
+	}
+	if len(perDay) == 0 {
+		return nil, time.Time{}, ErrTPDMetricsNotReady
+	}
+
+	merged, err := json.Marshal(tpdstore.MergeDailyMetrics(perDay))
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("%w: %v", ErrTPDMetricsNotReady, err)
+	}
+	return merged, newest, nil
+}
+
+// transportMetricDates returns the dates TPD currently has leaves
+// for, NEWEST FIRST. It Walks paths only — the callback never touches
+// a body, so enumerating 30 days costs a map scan, not 30 gunzips.
+func transportMetricDates(mgr metricsSnapshot) []string {
+	seen := make(map[string]struct{})
+	mgr.Walk(FeedTPDMetrics, tpdstore.MetricsDayPrefix, func(p string, _ []byte) bool {
+		if date, ok := tpdstore.MetricsDayDate(p); ok {
+			seen[date] = struct{}{}
+		}
+		return true
+	})
+	if len(seen) == 0 {
+		return nil
+	}
+	dates := make([]string, 0, len(seen))
+	for d := range seen {
+		dates = append(dates, d)
+	}
+	// The date format sorts lexically into chronological order.
+	sort.Sort(sort.Reverse(sort.StringSlice(dates)))
+	return dates
+}
+
+// dayLeafBody returns one day's decoded (gunzipped) JSON array,
+// stitching the part leaves back together if the day was split.
+func dayLeafBody(mgr metricsSnapshot, date string) ([]byte, time.Time, error) {
+	base := tpdstore.MetricsDayPath(date)
+	if body, ts, ok := mgr.Get(FeedTPDMetrics, base); ok && len(body) > 0 {
+		// Gunzip passes a raw body through unchanged, so this reads both
+		// the gzipped bodies the publisher writes and any uncompressed
+		// ones still cached from an older TPD.
+		return cxoutils.Gunzip(body), ts, nil
+	}
+	return joinTransportMetricParts(mgr, base)
+}
+
+// fetchLegacyMetricsWindow reads the one-leaf-per-window layout a TPD
+// that predates the day leaves still publishes.
+func fetchLegacyMetricsWindow(mgr metricsSnapshot, days int) ([]byte, time.Time, error) {
+	path := fmt.Sprintf("metrics/days/%d", days)
+	if body, ts, ok := mgr.Get(FeedTPDMetrics, path); ok && len(body) > 0 {
+		return cxoutils.Gunzip(body), ts, nil
+	}
+	return joinTransportMetricParts(mgr, path)
 }
 
 // joinTransportMetricParts concatenates the part leaves under base into one
 // JSON array. Parts are spliced as bytes rather than decoded and re-encoded:
-// these windows run to tens of megabytes, and the caller only forwards the
-// array on.
-func (v *Visor) joinTransportMetricParts(base string) ([]byte, time.Time, error) {
-	mgr := v.CXOSubMgr()
-	if mgr == nil {
-		return nil, time.Time{}, ErrTPDMetricsNotReady
-	}
-
+// the parts of one leaf are disjoint slices of the same array, so no join is
+// needed and these bodies run to megabytes.
+func joinTransportMetricParts(mgr metricsSnapshot, base string) ([]byte, time.Time, error) {
 	type part struct {
 		path string
 		body []byte

--- a/pkg/visor/api_tpd_metrics_subscriber_test.go
+++ b/pkg/visor/api_tpd_metrics_subscriber_test.go
@@ -2,8 +2,16 @@
 package visor
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	tpdstore "github.com/skycoin/skywire/pkg/deployment/tpd/store"
 )
 
 // The reader stitches the publisher's part leaves back into the single array
@@ -49,5 +57,243 @@ func TestSpliceJSONArraysRejectsNonArray(t *testing.T) {
 		if _, err := spliceJSONArrays([][]byte{[]byte(`[{"id":"a"}]`), []byte(bad)}); err == nil {
 			t.Errorf("spliceJSONArrays accepted a non-array part %q", bad)
 		}
+	}
+}
+
+// fakeSnapshot is a metricsSnapshot backed by a plain path→body map,
+// standing in for a live CXO subscription.
+type fakeSnapshot struct {
+	leaves map[string][]byte
+	at     time.Time
+}
+
+func (f *fakeSnapshot) Get(_ CXOFeed, path string) ([]byte, time.Time, bool) {
+	b, ok := f.leaves[path]
+	return b, f.at, ok
+}
+
+func (f *fakeSnapshot) SyncedAt(_ CXOFeed, path string) (time.Time, bool) {
+	_, ok := f.leaves[path]
+	return f.at, ok
+}
+
+func (f *fakeSnapshot) Walk(_ CXOFeed, prefix string, fn func(string, []byte) bool) bool {
+	if len(f.leaves) == 0 {
+		return false
+	}
+	for path, body := range f.leaves {
+		if prefix != "" && !treestore.HasPrefix(path, prefix) {
+			continue
+		}
+		if !fn(path, body) {
+			return true
+		}
+	}
+	return true
+}
+
+// dayLeaves publishes `window` through the publisher's pivot, exactly
+// as TPD does, and hands back the leaves a subscriber would hold.
+func dayLeaves(t *testing.T, window []tpdstore.TransportMetric, dates []string) *fakeSnapshot {
+	t.Helper()
+	f := &fakeSnapshot{leaves: map[string][]byte{}, at: time.Unix(1767225600, 0).UTC()}
+	for date, recs := range tpdstore.PivotDailyMetrics(window, dates) {
+		body, err := json.Marshal(recs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.leaves[tpdstore.MetricsDayPath(date)] = cxoutils.Gzip(body)
+	}
+	return f
+}
+
+func metricsWindowFixture(dates []string) []tpdstore.TransportMetric {
+	out := make([]tpdstore.TransportMetric, 0, 12)
+	for i := 0; i < 12; i++ {
+		var daily []tpdstore.DailyEdgeBandwidth
+		for d, date := range dates {
+			if (d+i)%3 == 0 {
+				continue
+			}
+			daily = append(daily, tpdstore.DailyEdgeBandwidth{
+				Date: date,
+				A:    &tpdstore.EdgeBandwidth{Sent: uint64(i*100 + d)},
+				B:    &tpdstore.EdgeBandwidth{Recv: uint64(i*200 + d)},
+			})
+		}
+		out = append(out, tpdstore.TransportMetric{
+			ID:      fmt.Sprintf("tp-%02d", i),
+			Type:    "dmsg",
+			Live:    i%2 == 0,
+			Edges:   []string{fmt.Sprintf("02%02d", i), fmt.Sprintf("03%02d", i)},
+			Latency: &tpdstore.TransportLatency{Min: int64(i), Max: int64(i + 10), Avg: int64(i + 5)},
+			Daily:   daily,
+		})
+	}
+	return out
+}
+
+// The reader's half of the round trip: a window assembled from day
+// leaves must hold every record and every daily row TPD computed, and
+// must decode as the single JSON array every caller expects.
+func TestAssembleTransportMetricDaysRebuildsTheWindow(t *testing.T) {
+	dates := tpdstore.MetricsWindowDates(time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC), 7)
+	window := metricsWindowFixture(dates)
+	snap := dayLeaves(t, window, dates)
+
+	body, ts, err := readTransportMetricsCXO(snap, 7)
+	if err != nil {
+		t.Fatalf("readTransportMetricsCXO: %v", err)
+	}
+	if ts.IsZero() {
+		t.Error("no sync timestamp reported")
+	}
+	var got []tpdstore.TransportMetric
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("assembled window is not a JSON array of TransportMetric: %v", err)
+	}
+	if len(got) != len(window) {
+		t.Fatalf("assembled %d records, want %d", len(got), len(window))
+	}
+
+	var wantRows, gotRows int
+	for i := range window {
+		wantRows += len(window[i].Daily)
+	}
+	byID := map[string]tpdstore.TransportMetric{}
+	for _, m := range got {
+		gotRows += len(m.Daily)
+		byID[m.ID] = m
+	}
+	if gotRows != wantRows {
+		t.Errorf("assembled window holds %d daily rows, want %d", gotRows, wantRows)
+	}
+	for i := range window {
+		have, ok := byID[window[i].ID]
+		if !ok {
+			t.Fatalf("%s is missing from the assembled window", window[i].ID)
+		}
+		if have.Latency == nil || have.Latency.Avg != window[i].Latency.Avg {
+			t.Errorf("%s: latency = %+v, want %+v", window[i].ID, have.Latency, window[i].Latency)
+		}
+		if have.Live != window[i].Live {
+			t.Errorf("%s: live = %v, want %v", window[i].ID, have.Live, window[i].Live)
+		}
+	}
+}
+
+// Asking for fewer days than are published must narrow the window,
+// not return everything TPD happens to be holding.
+func TestAssembleTransportMetricDaysHonoursTheDayCount(t *testing.T) {
+	dates := tpdstore.MetricsWindowDates(time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC), 30)
+	snap := dayLeaves(t, metricsWindowFixture(dates), dates)
+
+	for _, days := range []int{1, 3, 7, 30} {
+		body, _, err := readTransportMetricsCXO(snap, days)
+		if err != nil {
+			t.Fatalf("days=%d: %v", days, err)
+		}
+		var got []tpdstore.TransportMetric
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("days=%d: %v", days, err)
+		}
+		for _, m := range got {
+			for _, row := range m.Daily {
+				if row.Date < dates[days-1] {
+					t.Errorf("days=%d: %s carries a row dated %s, outside the window", days, m.ID, row.Date)
+				}
+			}
+		}
+	}
+}
+
+// Assembly must be byte-stable: the same leaves have to produce the
+// same window however the snapshot map iterates.
+func TestAssembleTransportMetricDaysIsDeterministic(t *testing.T) {
+	dates := tpdstore.MetricsWindowDates(time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC), 9)
+	snap := dayLeaves(t, metricsWindowFixture(dates), dates)
+
+	first, _, err := readTransportMetricsCXO(snap, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 8; i++ {
+		again, _, err := readTransportMetricsCXO(snap, 9)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(first, again) {
+			t.Fatal("two assemblies of the same leaves differ")
+		}
+	}
+}
+
+// A visor can outrun the TPD it reads: both update from the same
+// develop-latest binary on a ~5 minute timer. With no day leaves the
+// reader must still serve the previous layout instead of reporting a
+// cold feed and pushing the hvui onto the HTTP path.
+func TestReadFallsBackToTheLegacyWindowLayout(t *testing.T) {
+	legacy := []byte(`[{"id":"tp-legacy","type":"stcpr","live":true,"daily":[]}]`)
+	snap := &fakeSnapshot{
+		leaves: map[string][]byte{"metrics/days/7": cxoutils.Gzip(legacy)},
+		at:     time.Unix(1767225600, 0).UTC(),
+	}
+	body, _, err := readTransportMetricsCXO(snap, 7)
+	if err != nil {
+		t.Fatalf("readTransportMetricsCXO: %v", err)
+	}
+	if !bytes.Equal(body, legacy) {
+		t.Errorf("got %s, want the legacy window body %s", body, legacy)
+	}
+
+	// A legacy window split across part leaves stitches the same way.
+	snap.leaves = map[string][]byte{
+		"metrics/days/7/part/0000": cxoutils.Gzip([]byte(`[{"id":"a"}]`)),
+		"metrics/days/7/part/0001": cxoutils.Gzip([]byte(`[{"id":"b"}]`)),
+	}
+	body, _, err = readTransportMetricsCXO(snap, 7)
+	if err != nil {
+		t.Fatalf("readTransportMetricsCXO (parts): %v", err)
+	}
+	if want := `[{"id":"a"},{"id":"b"}]`; string(body) != want {
+		t.Errorf("got %s, want %s", body, want)
+	}
+
+	// Nothing at all is still a miss, not a panic or an empty array.
+	snap.leaves = map[string][]byte{}
+	if _, _, err := readTransportMetricsCXO(snap, 7); !errors.Is(err, ErrTPDMetricsNotReady) {
+		t.Errorf("empty feed returned %v, want ErrTPDMetricsNotReady", err)
+	}
+}
+
+// A day too large for one CXO object is published as part leaves; the
+// reader has to stitch them before merging, or that day's records
+// vanish from every window containing it.
+func TestAssembleStitchesASplitDayLeaf(t *testing.T) {
+	dates := tpdstore.MetricsWindowDates(time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC), 2)
+	snap := &fakeSnapshot{leaves: map[string][]byte{}, at: time.Unix(1767225600, 0).UTC()}
+	snap.leaves[tpdstore.MetricsDayPath(dates[0])] = cxoutils.Gzip(
+		[]byte(`[{"id":"x","type":"dmsg","live":true,"daily":[]}]`))
+	snap.leaves[tpdstore.MetricsDayPartPath(dates[1], 0)] = cxoutils.Gzip(
+		[]byte(`[{"id":"x","type":"dmsg","daily":[{"date":"` + dates[1] + `","a":{"sent":5,"recv":0}}]}]`))
+	snap.leaves[tpdstore.MetricsDayPartPath(dates[1], 1)] = cxoutils.Gzip(
+		[]byte(`[{"id":"y","type":"stcpr","daily":[{"date":"` + dates[1] + `","a":{"sent":9,"recv":0}}]}]`))
+
+	body, _, err := readTransportMetricsCXO(snap, 2)
+	if err != nil {
+		t.Fatalf("readTransportMetricsCXO: %v", err)
+	}
+	var got []tpdstore.TransportMetric
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("assembled %d records, want 2 (x and y)", len(got))
+	}
+	if got[0].ID != "x" || !got[0].Live || len(got[0].Daily) != 1 {
+		t.Errorf("x = %+v, want the live current-day record joined to its split-day row", got[0])
+	}
+	if got[1].ID != "y" || len(got[1].Daily) != 1 {
+		t.Errorf("y = %+v, want the record that only existed in the second part", got[1])
 	}
 }

--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -128,7 +128,10 @@ func (v *Visor) cxoFeedSpec(fk cxosub.Feed) (cipher.PubKey, uint16, string, erro
 		if !ok {
 			return cipher.PubKey{}, 0, "", errors.New("no TPD CXO peer (transport.discovery_dmsg unset)")
 		}
-		return pk, skyenv.DmsgTPDMetricsCXOPort, "metrics/days/", nil
+		// "metrics/" covers both the per-day leaves TPD publishes now
+		// and the legacy per-window ones a not-yet-updated TPD still
+		// writes. Must stay in step with cxosub.FeedRoute.
+		return pk, skyenv.DmsgTPDMetricsCXOPort, "metrics/", nil
 	case FeedTPDUptime:
 		pk, ok := tpdCXOPeer(v)
 		if !ok {


### PR DESCRIPTION
Closes #4510. Follow-up to #4509, which stopped the metrics feed dying on an oversized object but left the publishing shape alone.

The publisher wrote three overlapping windows (1, 7, 30 days), one leaf each. Content-addressing bought nothing that way: one changed byte made the whole multi-megabyte object new, so the 30-day window went back over the wire in full every 30 minutes even though 29 of its 30 days could not have changed. It now writes one leaf per calendar day at `metrics/day/<YYYY-MM-DD>`, so a settled day hashes identically forever and only the current day moves; a window is assembled reader-side from the N newest leaves.

The pivot needs no new store query — the existing `GetAllTransportMetrics(Days: n)` result is split by the `Date` on each `DailyEdgeBandwidth` row, and the reader joins the day slices back on transport ID. `Live` and `Latency` are current state rather than day-scoped facts, so they ride only on the current day's leaf; carrying them everywhere would make every past leaf mutable again and defeat the exercise. The one behavioural difference, documented in `cxo_metrics_layout.go`: a transport with no latency record and no bandwidth today reads back not-live in a long window, where the old 30-day body reported current liveness for a transport last seen three weeks ago. Per 30 minutes the store is asked for 30×1 + 1×30 = 60 transport-days instead of 30×1 + 6×7 + 1×30 = 102.

TPD and visors update independently from the same `develop-latest` binary, so skew is real in both directions. The publisher emits only the new layout and the reader accepts either, with the subscription prefix widened to `metrics/` so it covers both — publishing both layouts would double exactly the traffic this removes, and an old visor against a new TPD still has its HTTP fallback. Gzip and the part-splitting fallback are kept as the safety net for a day that somehow does not fit. Round-trip tests cover record and daily-row preservation, deterministic ordering under input permutation, leaf retirement, and the legacy fallback.