### PR TITLE
fix(tpd): size the metrics split from the compressed total, not the raw

### DIFF
--- a/pkg/deployment/tpd/api/cxo_metrics_publisher.go
+++ b/pkg/deployment/tpd/api/cxo_metrics_publisher.go
@@ -187,12 +187,6 @@ func (m *MetricsCXOPublisher) loop(ctx context.Context) {
 // MaxObjectSize covers the encoding overhead CXO adds around the payload.
 const maxPublishBody = 12 * 1024 * 1024
 
-// partTargetBody is what a split aims each part at. Sizing the split from the
-// measured compressed size and then aiming well under the hard cap means a part
-// whose records happen to compress worse than the window average still lands
-// inside it, so the verify-and-halve pass below rarely has to run.
-const partTargetBody = 8 * 1024 * 1024
-
 func (m *MetricsCXOPublisher) publishWindow(ctx context.Context, days int) {
 	query := store.MetricsQuery{
 		Days:      days,
@@ -270,12 +264,24 @@ func gzipParts(metrics []store.TransportMetric, max int) ([][]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if gz := cxoutils.Gzip(whole); len(gz) <= max {
+	gz := cxoutils.Gzip(whole)
+	if len(gz) <= max {
 		return [][]byte{gz}, nil
 	}
 
+	// Size the split from the COMPRESSED total against a target derived from
+	// max, since gzipped bytes are what CXO stores and what the cap applies
+	// to. Dividing the raw size by a fixed byte budget instead over-splits by
+	// the compression ratio: on production data that turned a 7-day window
+	// into 15 parts where four would fit, and every surplus leaf is another
+	// round trip for a subscriber filling the tree. Aiming below max leaves
+	// room for a part that compresses worse than the window average.
+	target := max * 3 / 4
+	if target < 1 {
+		target = 1 // a pathologically small cap must not divide by zero
+	}
 	var out [][]byte
-	n := len(whole)/partTargetBody + 1
+	n := len(gz)/target + 1
 	for _, part := range splitEvenly(metrics, n) {
 		if err := appendGzipped(&out, part, max); err != nil {
 			return nil, err

--- a/pkg/deployment/tpd/api/cxo_metrics_publisher_test.go
+++ b/pkg/deployment/tpd/api/cxo_metrics_publisher_test.go
@@ -166,3 +166,38 @@ func TestMetricsPartPathSortsNumerically(t *testing.T) {
 		t.Error("part paths do not sit under the window path")
 	}
 }
+
+// The split is sized against the compressed total, because partTargetBody
+// budgets the gzipped part. Sizing it from the raw size instead over-splits by
+// the compression ratio, which costs a filling subscriber a round trip per
+// surplus leaf.
+func TestGzipPartsDoesNotOverSplit(t *testing.T) {
+	metrics := metricsFixture(4000, 30)
+	const max = 64 * 1024
+
+	parts, err := gzipParts(metrics, max)
+	if err != nil {
+		t.Fatalf("gzipParts: %v", err)
+	}
+	if len(parts) < 2 {
+		t.Fatalf("got %d parts, want a split", len(parts))
+	}
+
+	// The floor: how many parts the compressed payload actually requires.
+	whole, err := json.Marshal(metrics)
+	if err != nil {
+		t.Fatal(err)
+	}
+	need := len(cxoutils.Gzip(whole))/max + 1
+
+	// Some slack for per-part framing and uneven compression, but nowhere
+	// near the ~4x the raw-size bug produced.
+	if limit := need * 2; len(parts) > limit {
+		t.Errorf("split into %d parts; a compressed payload needing ~%d should not exceed %d", len(parts), need, limit)
+	}
+
+	// Over-splitting must not be "fixed" by dropping records.
+	if got := decodeParts(t, parts); len(got) != len(metrics) {
+		t.Errorf("round-trip returned %d records, want %d", len(got), len(metrics))
+	}
+}


### PR DESCRIPTION
`gzipParts` budgeted each part against `partTargetBody` but computed the part count from the **raw** JSON size, while both that budget and `maxPublishBody` apply to the gzipped bytes CXO stores. The estimate was off by the compression ratio.

Production, right now, on #4509:

```
23:24:06  published as parts days=7  parts=9
23:30:53  published as parts days=7  parts=15
23:24:38  published as parts days=30 parts=10
```

Four parts would carry the 7-day window. Each surplus leaf is another object a subscriber has to fetch before the window is usable, which is the opposite of what the split is for.

Also derives the per-part target from `max` instead of keeping a second constant that must be maintained in the right ratio to it — that coupling is what made the mistake invisible. The verify-and-halve pass still guarantees the cap.

The added test fails on the old sizing (267 parts against ~26 needed) and passes on the new.
