### PR TITLE
fix(cli): give the direct-DMSG fetch a persistent identity

### DIFF
--- a/cmd/skywire-cli/cliutil/identity.go
+++ b/cmd/skywire-cli/cliutil/identity.go
@@ -1,0 +1,117 @@
+// Package cliutil cmd/skywire-cli/cliutil/identity.go c4-vis-cli
+package cliutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// CLIKeyFileEnv names the environment variable that relocates the CLI's
+// own dmsg identity file. Unset, the identity lives at
+// <user home>/.skywire/cli.key.
+const CLIKeyFileEnv = "SKYWIRE_CLI_KEYFILE"
+
+// cliKeyFileName is the basename of the CLI identity under ~/.skywire —
+// the same user-space directory the visor's own userspace config and the
+// skysocks-client MITM root already use.
+const cliKeyFileName = "cli.key"
+
+// CLIKeyFilePath returns where the CLI's persistent dmsg identity lives.
+func CLIKeyFilePath() (string, error) {
+	if p := os.Getenv(CLIKeyFileEnv); p != "" {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("locate user home dir: %w", err)
+	}
+	return filepath.Join(home, ".skywire", cliKeyFileName), nil
+}
+
+// CLIIdentity returns the keypair the CLI runs as when it has to hold a
+// dmsg client of its own, generating and persisting one on first use.
+//
+// A CLI invocation that talks dmsg directly needs *an* identity, and the
+// only wrong answer is a fresh one per run: every invocation then costs a
+// new keypair, a new Noise handshake against every production dmsg server,
+// and — on the code paths that publish — a new abandoned dmsg-discovery
+// entry (the shape removed from `hv serve` in #4501 and from the reward
+// server in #4502). One key per user, written once and reused, keeps the
+// CLI's footprint on the network constant no matter how often it is polled.
+//
+// It is deliberately NOT the local visor's key. dmsg-discovery holds one
+// entry per public key and a dmsg server one session per key, so a second
+// client under the visor's identity would fight the visor for both.
+//
+// Returns (pk, sk, path). Callers that can proceed without dmsg should
+// treat an error as non-fatal — an unwritable home is a reason to warn,
+// not to fail the command.
+func CLIIdentity() (cipher.PubKey, cipher.SecKey, string, error) {
+	path, err := CLIKeyFilePath()
+	if err != nil {
+		return cipher.PubKey{}, cipher.SecKey{}, "", err
+	}
+
+	if pk, sk, ok, rerr := readCLIKeyFile(path); ok {
+		return pk, sk, path, nil
+	} else if rerr != nil {
+		return cipher.PubKey{}, cipher.SecKey{}, path, rerr
+	}
+
+	// First use. Create with O_EXCL so two CLI invocations racing on a
+	// cold home directory converge on one key instead of clobbering
+	// each other; the loser re-reads what the winner wrote.
+	pk, sk := cipher.GenerateKeyPair()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return cipher.PubKey{}, cipher.SecKey{}, path, fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) //nolint:gosec // operator-chosen path (SKYWIRE_CLI_KEYFILE) or the default under $HOME
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			if rpk, rsk, ok, rerr := readCLIKeyFile(path); ok {
+				return rpk, rsk, path, nil
+			} else if rerr != nil {
+				return cipher.PubKey{}, cipher.SecKey{}, path, rerr
+			}
+		}
+		return cipher.PubKey{}, cipher.SecKey{}, path, fmt.Errorf("write keyfile %s: %w", path, err)
+	}
+	if _, err := f.WriteString(sk.Hex() + "\n"); err != nil {
+		f.Close() //nolint:errcheck,gosec
+		return cipher.PubKey{}, cipher.SecKey{}, path, fmt.Errorf("write keyfile %s: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return cipher.PubKey{}, cipher.SecKey{}, path, fmt.Errorf("write keyfile %s: %w", path, err)
+	}
+	// stderr, never stdout: --json output has to stay parseable.
+	fmt.Fprintf(os.Stderr, "skywire-cli: generated a persistent dmsg identity at %s\nskywire-cli: public key: %s\n", path, pk.Hex()) //nolint:errcheck
+	return pk, sk, path, nil
+}
+
+// readCLIKeyFile reads an existing identity file. ok reports whether a
+// usable keypair was read; a missing file is (false, nil) so the caller
+// can create one, while an unreadable or malformed file is an error —
+// silently minting a replacement would defeat the point of persisting.
+func readCLIKeyFile(path string) (cipher.PubKey, cipher.SecKey, bool, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cipher.PubKey{}, cipher.SecKey{}, false, nil
+		}
+		return cipher.PubKey{}, cipher.SecKey{}, false, fmt.Errorf("read keyfile %s: %w", path, err)
+	}
+	var sk cipher.SecKey
+	if err := sk.Set(strings.TrimSpace(string(raw))); err != nil {
+		return cipher.PubKey{}, cipher.SecKey{}, false, fmt.Errorf("keyfile %s: %w", path, err)
+	}
+	pk, err := sk.PubKey()
+	if err != nil {
+		return cipher.PubKey{}, cipher.SecKey{}, false, fmt.Errorf("keyfile %s: derive pubkey: %w", path, err)
+	}
+	return pk, sk, true, nil
+}

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -400,15 +400,16 @@ type FetchConfig struct {
 //	             step runs (--no-rpc or RPC unavailable). Visible in shell
 //	             history — prefer --config for production use.
 //	--config     path to a JSON file supplying {"sk":..., "dmsg":{...}}. SK
-//	             precedence: --sk > --config > $DMSG_SK > $DMSGCURL_SK > random
-//	             ephemeral. Dmsg.Servers from the config seeds the direct
-//	             client; absent, the embedded deployment server set is used.
+//	             precedence: --sk > --config > $DMSG_SK > $DMSGCURL_SK > the
+//	             CLI's persistent key at <home>/.skywire/cli.key. Dmsg.Servers
+//	             from the config seeds the direct client; absent, the embedded
+//	             deployment server set is used.
 func RegisterFetchFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&NoCXO, "no-cxo", false, "skip CXO subscriber-cache step")
 	cmd.Flags().BoolVar(&NoRPC, "no-rpc", false, "skip visor RPC (DmsgHTTP) step")
 	cmd.Flags().BoolVar(&NoDmsg, "no-dmsg", false, "skip direct DMSG HTTP step")
 	cmd.Flags().Var(&FetchSK, "sk",
-		"secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak)")
+		"secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak)")
 	cmd.Flags().StringVar(&FetchConfigPath, "config", "",
 		"path to a JSON file with the CLI's dmsg identity + bootstrap (see clirpc.FetchConfig)")
 }
@@ -420,7 +421,15 @@ func RegisterFetchFlags(cmd *cobra.Command) {
 //  2. --config path: parsed as FetchConfig; SK and Dmsg.Servers taken from it
 //  3. $DMSG_SK environment variable (same convention as `dmsg curl`/`dmsg cat`)
 //  4. $DMSGCURL_SK environment variable (same convention as log-fetch helpers)
-//  5. ephemeral random key (cipher.GenerateKeyPair)
+//  5. the CLI's own persistent identity, <home>/.skywire/cli.key, created on
+//     first use (cliutil.CLIIdentity)
+//  6. an ephemeral random key — reached only when 5 cannot be read or written
+//
+// Step 5 is what keeps a polled command from being an identity generator:
+// every `--no-rpc` fetch used to mint a fresh keypair and hand it to a direct
+// client on every production dmsg server, so a 60s sampler was 1440 one-shot
+// identities a day (#4512). One key per user, reused, costs the network the
+// same as one invocation.
 //
 // servers comes from --config when set, else from dmsg.Prod.DmsgServers.
 // Returns (pk, sk, servers, label) — label describes the resolution path
@@ -483,6 +492,15 @@ func resolveFetchIdentity(flags *pflag.FlagSet) (cipher.PubKey, cipher.SecKey, [
 			}
 		}
 	}
+
+	// The CLI's own persistent identity. Created on first use and reused by
+	// every later invocation, so repeated fetches present ONE key to the dmsg
+	// servers instead of one per run.
+	cliPK, cliSK, keyPath, err := internal.CLIIdentity()
+	if err == nil {
+		return cliPK, cliSK, servers, "cli keyfile " + keyPath
+	}
+	logger.Warnf("CLI dmsg identity unavailable (%v); falling back to a single-use key", err)
 
 	pk, sk := cipher.GenerateKeyPair()
 	return pk, sk, servers, label
@@ -678,11 +696,22 @@ func splitOn(s string, sep byte) []string {
 	return out
 }
 
-// fetchViaDmsgDirect creates ephemeral DMSG direct clients — one per DMSG server —
-// and uses a FallbackRoundTripper to try each until one reaches the target service.
-// This matches the pattern used by `skywire dmsg curl -B`: services connect to DMSG
-// servers directly (not via discovery), so we must connect to each server to find them.
+// directFetchMu serializes the direct-DMSG step within one process. The
+// identity is now stable (resolveFetchIdentity step 5), and a dmsg server
+// keeps ONE session per public key — so two overlapping direct fetches would
+// hand the same key to the same servers twice and evict each other. Each
+// fetch's clients are closed before the next one's are opened.
+var directFetchMu sync.Mutex
+
+// fetchViaDmsgDirect creates DMSG direct clients under the CLI's own identity —
+// one per DMSG server — and uses a FallbackRoundTripper to try each until one
+// reaches the target service. This matches the pattern used by
+// `skywire dmsg curl -B`: services connect to DMSG servers directly (not via
+// discovery), so we must connect to each server to find them.
 func fetchViaDmsgDirect(flags *pflag.FlagSet, dmsgURL string) ([]byte, error) {
+	directFetchMu.Lock()
+	defer directFetchMu.Unlock() // runs last: after the deferred closeFn calls below
+
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 

--- a/docs/skywire/cli/config/update/svc/README.md
+++ b/docs/skywire/cli/config/update/svc/README.md
@@ -18,7 +18,7 @@ skywire cli config update svc
       --no-cxo             skip CXO subscriber-cache step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --no-dmsg            skip direct DMSG HTTP step
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --config string      path to a JSON file with the CLI's dmsg identity + bootstrap (see clirpc.FetchConfig)
 ```
 

--- a/docs/skywire/cli/pv/README.md
+++ b/docs/skywire/cli/pv/README.md
@@ -36,7 +36,7 @@ skywire cli pv
   -r, --raw                print raw json data
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
   -a, --sdurl string       service discovery url (default "dmsg://0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7:80")
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
   -s, --stats              return only a count of the results
       --testenv            use test deployment
   -d, --tpdurl string      transport discovery url (also serves the integrated uptime tracker) (default "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80")

--- a/docs/skywire/cli/rewards/bw-collect/README.md
+++ b/docs/skywire/cli/rewards/bw-collect/README.md
@@ -45,7 +45,7 @@ skywire cli rewards bw-collect
       --no-cxo             skip CXO subscriber-cache step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --no-dmsg            skip direct DMSG HTTP step
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --config string      path to a JSON file with the CLI's dmsg identity + bootstrap (see clirpc.FetchConfig)
 ```
 

--- a/docs/skywire/cli/rewards/tp-collect/README.md
+++ b/docs/skywire/cli/rewards/tp-collect/README.md
@@ -32,7 +32,7 @@ skywire cli rewards tp-collect
       --no-cxo             skip CXO subscriber-cache step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --no-dmsg            skip direct DMSG HTTP step
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --config string      path to a JSON file with the CLI's dmsg identity + bootstrap (see clirpc.FetchConfig)
 ```
 

--- a/docs/skywire/cli/route/calc/README.md
+++ b/docs/skywire/cli/route/calc/README.md
@@ -32,7 +32,7 @@ skywire cli route calc [<src-pk>] <dst-pk>
       --no-dmsg            skip direct DMSG HTTP step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --queue-cap int      BFS queue cap (0 = server/local default ~200K, negative = unbounded)
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --source string      transport graph source: tpd (HTTP) | tps (AUTHORITATIVE: src+dst own transports via the setup node, same path as tp --remote; TPD-independent, single-intermediate). dht|auto are accepted for compatibility and also read from TPD, since the DHT store was removed; dht and tps force the non-streaming local-compute path (default "tpd")
   -t, --timeout duration   request timeout (default 30s)
   -a, --tpd string         transport discovery URL (default "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80")

--- a/docs/skywire/cli/route/trace/README.md
+++ b/docs/skywire/cli/route/trace/README.md
@@ -46,7 +46,7 @@ skywire cli route trace <pk>
       --no-cxo             skip CXO subscriber-cache step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --no-dmsg            skip direct DMSG HTTP step
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --config string      path to a JSON file with the CLI's dmsg identity + bootstrap (see clirpc.FetchConfig)
 ```
 

--- a/docs/skywire/cli/sd/README.md
+++ b/docs/skywire/cli/sd/README.md
@@ -39,7 +39,7 @@ skywire cli sd
   -o, --noton              do not filter by online status in UT
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
   -a, --sdurl string       service discovery url (default "dmsg://0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7:80")
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use test deployment
   -b, --tpdurl string      transport discovery url (default "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80")
   -w, --uturl string       TPD-integrated uptime tracker url (default "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80")

--- a/docs/skywire/cli/svc/README.md
+++ b/docs/skywire/cli/svc/README.md
@@ -37,7 +37,7 @@ skywire cli svc
       --no-cxo             skip CXO subscriber-cache step
       --no-dmsg            skip direct DMSG HTTP step
       --no-rpc             skip visor RPC (DmsgHTTP) step
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)
 ```

--- a/docs/skywire/cli/svc/ar/README.md
+++ b/docs/skywire/cli/svc/ar/README.md
@@ -39,7 +39,7 @@ skywire cli svc ar
       --no-dmsg            skip direct DMSG HTTP step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/ar/check/README.md
+++ b/docs/skywire/cli/svc/ar/check/README.md
@@ -27,7 +27,7 @@ skywire cli svc ar check <pk>
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/dmsgd/README.md
+++ b/docs/skywire/cli/svc/dmsgd/README.md
@@ -43,7 +43,7 @@ skywire cli svc dmsgd
       --no-dmsg            skip direct DMSG HTTP step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/dmsgd/all-servers/README.md
+++ b/docs/skywire/cli/svc/dmsgd/all-servers/README.md
@@ -25,7 +25,7 @@ skywire cli svc dmsgd all-servers
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/dmsgd/clients/README.md
+++ b/docs/skywire/cli/svc/dmsgd/clients/README.md
@@ -34,7 +34,7 @@ skywire cli svc dmsgd clients
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/dmsgd/server-clients/README.md
+++ b/docs/skywire/cli/svc/dmsgd/server-clients/README.md
@@ -25,7 +25,7 @@ skywire cli svc dmsgd server-clients
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/health/README.md
+++ b/docs/skywire/cli/svc/health/README.md
@@ -47,7 +47,7 @@ skywire cli svc health
       --no-dmsg            skip direct DMSG HTTP step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/nm/README.md
+++ b/docs/skywire/cli/svc/nm/README.md
@@ -36,7 +36,7 @@ skywire cli svc nm
       --no-dmsg            skip direct DMSG HTTP step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/tpd/README.md
+++ b/docs/skywire/cli/svc/tpd/README.md
@@ -48,7 +48,7 @@ skywire cli svc tpd
       --no-dmsg            skip direct DMSG HTTP step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/tpd/bandwidth-tp/README.md
+++ b/docs/skywire/cli/svc/tpd/bandwidth-tp/README.md
@@ -33,7 +33,7 @@ skywire cli svc tpd bandwidth-tp
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/tpd/bandwidth/README.md
+++ b/docs/skywire/cli/svc/tpd/bandwidth/README.md
@@ -32,7 +32,7 @@ skywire cli svc tpd bandwidth
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/tpd/metrics-tp/README.md
+++ b/docs/skywire/cli/svc/tpd/metrics-tp/README.md
@@ -33,7 +33,7 @@ skywire cli svc tpd metrics-tp
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/tpd/metrics-visor/README.md
+++ b/docs/skywire/cli/svc/tpd/metrics-visor/README.md
@@ -33,7 +33,7 @@ skywire cli svc tpd metrics-visor
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/tpd/per-key-stats/README.md
+++ b/docs/skywire/cli/svc/tpd/per-key-stats/README.md
@@ -25,7 +25,7 @@ skywire cli svc tpd per-key-stats
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/tpd/stats/README.md
+++ b/docs/skywire/cli/svc/tpd/stats/README.md
@@ -25,7 +25,7 @@ skywire cli svc tpd stats
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/tpd/uptime/README.md
+++ b/docs/skywire/cli/svc/tpd/uptime/README.md
@@ -41,7 +41,7 @@ skywire cli svc tpd uptime
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/tpd/versions-pk/README.md
+++ b/docs/skywire/cli/svc/tpd/versions-pk/README.md
@@ -33,7 +33,7 @@ skywire cli svc tpd versions-pk
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/tpd/versions/README.md
+++ b/docs/skywire/cli/svc/tpd/versions/README.md
@@ -25,7 +25,7 @@ skywire cli svc tpd versions
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/svc/tpd/visor-stats/README.md
+++ b/docs/skywire/cli/svc/tpd/visor-stats/README.md
@@ -39,7 +39,7 @@ skywire cli svc tpd visor-stats -p 02b3...
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --shape              print the output schema skeleton (zero values, all fields) instead of data
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --testenv            use the test deployment services (or set SKYWIRETEST=1)
       --timeout int        RPC timeout in seconds (0 = unlimited) (default 30)
       --tpdurl string      override the transport-discovery base URL (used by tpd / nm)

--- a/docs/skywire/cli/tp/add/README.md
+++ b/docs/skywire/cli/tp/add/README.md
@@ -37,7 +37,7 @@ skywire cli tp add <public-key> [public-key]...
       --no-cxo                 skip CXO subscriber-cache step
       --no-rpc                 skip visor RPC (DmsgHTTP) step
       --no-dmsg                skip direct DMSG HTTP step
-      --sk cipher.SecKey       secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey       secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --config string          path to a JSON file with the CLI's dmsg identity + bootstrap (see clirpc.FetchConfig)
 ```
 

--- a/docs/skywire/cli/tp/add/pv/README.md
+++ b/docs/skywire/cli/tp/add/pv/README.md
@@ -35,7 +35,7 @@ skywire cli tp add pv
       --retries int        number of times to retry per transport type (default 1)
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
   -a, --sdurl string       service discovery url (default "dmsg://0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7:80")
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
   -o, --timeout duration   operation timeout
   -d, --tpdurl string      transport discovery url (default "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80")
   -t, --type string        transport type (stcpr, sudph, dmsg)

--- a/docs/skywire/cli/tp/all/README.md
+++ b/docs/skywire/cli/tp/all/README.md
@@ -22,7 +22,7 @@ skywire cli tp all
       --no-cxo             skip CXO subscriber-cache step
       --no-dmsg            skip direct DMSG HTTP step
       --no-rpc             skip visor RPC (DmsgHTTP) step
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --tpdurl string      transport discovery url (default "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80")
 ```
 

--- a/docs/skywire/cli/tp/disc/README.md
+++ b/docs/skywire/cli/tp/disc/README.md
@@ -37,7 +37,7 @@ skywire cli tp disc
       --no-cxo                skip CXO subscriber-cache step
       --no-rpc                skip visor RPC (DmsgHTTP) step
       --no-dmsg               skip direct DMSG HTTP step
-      --sk cipher.SecKey      secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey      secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --config string         path to a JSON file with the CLI's dmsg identity + bootstrap (see clirpc.FetchConfig)
 ```
 

--- a/docs/skywire/cli/tp/metrics/README.md
+++ b/docs/skywire/cli/tp/metrics/README.md
@@ -29,7 +29,7 @@ skywire cli tp metrics
       --no-cxo             skip CXO subscriber-cache step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --no-dmsg            skip direct DMSG HTTP step
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --config string      path to a JSON file with the CLI's dmsg identity + bootstrap (see clirpc.FetchConfig)
 ```
 

--- a/docs/skywire/cli/tp/net-stats/README.md
+++ b/docs/skywire/cli/tp/net-stats/README.md
@@ -19,7 +19,7 @@ skywire cli tp net-stats
       --no-dmsg            skip direct DMSG HTTP step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
 ```
 
 ## Global Flags

--- a/docs/skywire/cli/tp/tpd-health/README.md
+++ b/docs/skywire/cli/tp/tpd-health/README.md
@@ -18,7 +18,7 @@ skywire cli tp tpd-health
       --no-dmsg            skip direct DMSG HTTP step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
 ```
 
 ## Global Flags

--- a/docs/skywire/cli/tp/tpd-stats/README.md
+++ b/docs/skywire/cli/tp/tpd-stats/README.md
@@ -25,7 +25,7 @@ skywire cli tp tpd-stats
       --no-dmsg            skip direct DMSG HTTP step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --rpc string         RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
   -n, --top int            show top N visors by transport count (0 = all)
   -t, --type string        filter by transport type (e.g. stcpr, sudph)
 ```

--- a/docs/skywire/cli/tp/tree/README.md
+++ b/docs/skywire/cli/tp/tree/README.md
@@ -37,7 +37,7 @@ skywire cli tp tree
       --no-cxo             skip CXO subscriber-cache step
       --no-rpc             skip visor RPC (DmsgHTTP) step
       --no-dmsg            skip direct DMSG HTTP step
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --config string      path to a JSON file with the CLI's dmsg identity + bootstrap (see clirpc.FetchConfig)
 ```
 

--- a/docs/skywire/cli/tp/uptime/README.md
+++ b/docs/skywire/cli/tp/uptime/README.md
@@ -34,7 +34,7 @@ skywire cli tp uptime
       --no-dmsg            skip direct DMSG HTTP step
       --no-rpc             skip visor RPC (DmsgHTTP) step
   -o, --on                 only include currently online transports
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --timeout duration   HTTP timeout (default 30s)
       --tpdurl string      transport-discovery url (default "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80")
   -t, --type string        filter by transport type (stcpr / sudph / dmsg / stcp)

--- a/docs/skywire/cli/tp/v/README.md
+++ b/docs/skywire/cli/tp/v/README.md
@@ -30,7 +30,7 @@ skywire cli tp v
   -k, --pk string          check visor service discovery for public key
   -r, --raw                print raw json data
   -a, --sdurl string       service discovery url (default "dmsg://0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7:80")
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
   -s, --stats              return only a count of the results
       --tpdurl string      transport-discovery url (alias of --uturl) (default "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80")
   -w, --uturl string       uptime tracker url (TPD integrated) (default "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80")

--- a/docs/skywire/cli/ut/README.md
+++ b/docs/skywire/cli/ut/README.md
@@ -55,7 +55,7 @@ skywire cli ut
   -o, --on                   list currently online visors
   -k, --pk string            check uptime for the specified key
       --rpc string           RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
-      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
   -s, --stats                count the number of results
   -t, --stats2               with --on: tally online visors by version instead of listing PKs
       --testenv              use test deployment

--- a/docs/skywire/cli/ut/mdisc/README.md
+++ b/docs/skywire/cli/ut/mdisc/README.md
@@ -37,7 +37,7 @@ skywire cli ut mdisc
   -o, --on                   only include online visors
   -k, --pk string            only show PKs matching this substring
       --since string         include days on or after this date (YYYY-MM-DD)
-      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
   -s, --stats                print count of matching visors only
       --timeout duration     HTTP timeout (default 30s)
       --until string         include days on or before this date (YYYY-MM-DD)

--- a/docs/skywire/cli/ut/mdisc/graph/README.md
+++ b/docs/skywire/cli/ut/mdisc/graph/README.md
@@ -40,7 +40,7 @@ skywire cli ut mdisc graph
       --shuffle              render rows in random order (test: do visual banding patterns travel with the rows or with PK-sort?)
       --shuffle-seed int     seed for --shuffle; 0 = time-based (different every run)
       --since string         include days on or after this date (YYYY-MM-DD)
-      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --timeout duration     HTTP timeout (default 30s)
       --until string         include days on or before this date (YYYY-MM-DD)
       --url string           discovery base URL (default "dmsg://022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa:80")

--- a/docs/skywire/cli/ut/sd/README.md
+++ b/docs/skywire/cli/ut/sd/README.md
@@ -37,7 +37,7 @@ skywire cli ut sd
   -o, --on                   only include online visors
   -k, --pk string            only show PKs matching this substring
       --since string         include days on or after this date (YYYY-MM-DD)
-      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
   -s, --stats                print count of matching visors only
       --timeout duration     HTTP timeout (default 30s)
       --until string         include days on or before this date (YYYY-MM-DD)

--- a/docs/skywire/cli/ut/sd/graph/README.md
+++ b/docs/skywire/cli/ut/sd/graph/README.md
@@ -40,7 +40,7 @@ skywire cli ut sd graph
       --shuffle              render rows in random order (test: do visual banding patterns travel with the rows or with PK-sort?)
       --shuffle-seed int     seed for --shuffle; 0 = time-based (different every run)
       --since string         include days on or after this date (YYYY-MM-DD)
-      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --timeout duration     HTTP timeout (default 30s)
       --until string         include days on or before this date (YYYY-MM-DD)
       --url string           discovery base URL (default "dmsg://0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7:80")

--- a/docs/skywire/cli/ut/tpd/README.md
+++ b/docs/skywire/cli/ut/tpd/README.md
@@ -43,7 +43,7 @@ skywire cli ut tpd
   -o, --on                   only include online visors
   -k, --pk string            only show PKs matching this substring
       --since string         include days on or after this date (YYYY-MM-DD)
-      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
   -s, --stats                print count of matching visors only
       --timeout duration     HTTP timeout (default 30s)
       --until string         include days on or before this date (YYYY-MM-DD)

--- a/docs/skywire/cli/ut/tpd/graph/README.md
+++ b/docs/skywire/cli/ut/tpd/graph/README.md
@@ -40,7 +40,7 @@ skywire cli ut tpd graph
       --shuffle              render rows in random order (test: do visual banding patterns travel with the rows or with PK-sort?)
       --shuffle-seed int     seed for --shuffle; 0 = time-based (different every run)
       --since string         include days on or after this date (YYYY-MM-DD)
-      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey     secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
       --timeout duration     HTTP timeout (default 30s)
       --until string         include days on or before this date (YYYY-MM-DD)
       --url string           discovery base URL (default "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80")

--- a/docs/skywire/cli/vpn/list/README.md
+++ b/docs/skywire/cli/vpn/list/README.md
@@ -36,7 +36,7 @@ skywire cli vpn list
   -k, --pk string          check vpn service discovery for public key
   -r, --raw                pretty print json data
   -a, --sdurl string       service discovery url (default "dmsg://0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7:80")
-      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
+      --sk cipher.SecKey   secret key for the CLI-owned dmsg client (defaults to the CLI's own persistent key; prefer --config to avoid shell-history leak) (default 0000000000000000000000000000000000000000000000000000000000000000)
   -s, --stats              return only a count of the results
       --testenv            use test deployment
   -w, --uturl string       TPD-integrated uptime tracker url (default "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80")


### PR DESCRIPTION
Closes #4512.

`resolveFetchIdentity` ended in `cipher.GenerateKeyPair()`, so every `--no-rpc` fetch ran under a brand-new keypair and handed it to a direct client on each production dmsg server. A 60-second sampler was 1440 one-shot identities a day — and it is per fetch, not per invocation.

Same shape as #4501 and #4502, different remedy, because there is no client here to reuse: the RPC path (the default, and correct) opens none, and the visor's own key is off limits — dmsg-discovery holds one entry per PK and a dmsg server one session per PK. So the CLI gets an identity of its own, written once to `<home>/.skywire/cli.key` (`SKYWIRE_CLI_KEYFILE` overrides; 0600; `O_EXCL` so racing invocations converge on one key) and reused. It slots in as step 5 of the existing precedence, ahead of the random key, which now appears only when the file cannot be read or written. Because the key is stable, the direct step also takes a mutex — two overlapping fetches under one PK would evict each other on the shared servers.

One correction to the issue text: this path builds its clients over an in-memory `direct.Client`, whose writes no-op, so the abandoned keys never reached dmsg-discovery (a lookup of the PK in the report 404s). What they did reach was every production dmsg server, one fresh Noise handshake and session apiece, per fetch.

Verified on the reported command, three consecutive runs:

```
before  pk=03bc093c3c63882cc16bfb9c8bad17edd406cba4aef55877f254b24c6dda001f11 source=ephemeral
        pk=03341a3c773ea1298c71eac8039053d2ad86c104d12c43563aa201ba6dd67de2eb source=ephemeral
        pk=0352e04bb2b8aca1da22f07ee40b9224cd283227c6c70a5f73b45e76aebb2d89d2 source=ephemeral

after   pk=02c48f70745ae06c02a4244a63aea8dd36e7c0faaa8e60ff02e7f8a1f8d8b8be63 source=cli keyfile
        pk=02c48f70745ae06c02a4244a63aea8dd36e7c0faaa8e60ff02e7f8a1f8d8b8be63 source=cli keyfile
        pk=02c48f70745ae06c02a4244a63aea8dd36e7c0faaa8e60ff02e7f8a1f8d8b8be63 source=cli keyfile
```

`cli sd proxy --no-rpc` and `cli ut --no-rpc` report the same key — the 46 subcommands on `RegisterFetchFlags` share the helper. Without `--no-rpc` nothing is minted and no keyfile appears; the RPC path stays identity-free. The generated `--sk` help line is updated in `docs/skywire/`.