### PR TITLE
feat(hv serve): address wasm variants by path so the surface can be static files

### DIFF
--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -259,6 +259,42 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 		}
 		_, _ = w.Write(wasmbin.WasmExecJSVariant(pickVariant(r))) //nolint:errcheck
 	})
+	// Per-variant PATHS alongside the ?variant= query form above. A query string
+	// cannot select bytes on a static host (GitHub Pages and friends serve one
+	// body per path), so publishing this surface as files requires the variant to
+	// live in the URL path. The blob and its wasm_exec.js loader are
+	// toolchain-specific and must never be mixed (see wasmbin/embed.go), so both
+	// are served under the same /wasm/<variant>/ prefix and travel as a pair.
+	// The query form stays for already-cached clients.
+	for _, v := range wasmbin.Available() {
+		v := v
+		tag := `"` + wasmVer + "-" + string(v) + `"`
+		mux.HandleFunc("/wasm/"+string(v)+"/wasm-visor.wasm", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/wasm")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("ETag", tag)
+			if r.Header.Get("If-None-Match") == tag {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			b, err := wasmbin.GetVariant(v)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write(b) //nolint:errcheck
+		})
+		mux.HandleFunc("/wasm/"+string(v)+"/wasm_exec.js", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/javascript")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("ETag", tag)
+			if r.Header.Get("If-None-Match") == tag {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			_, _ = w.Write(wasmbin.WasmExecJSVariant(v)) //nolint:errcheck
+		})
+	}
 	mux.HandleFunc("/wasm-variants.json", func(w http.ResponseWriter, _ *http.Request) {
 		avail := wasmbin.Available()
 		names := make([]string, len(avail))

--- a/pkg/visor/wasmserve_test.go
+++ b/pkg/visor/wasmserve_test.go
@@ -6,6 +6,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/wasmhv/wasmbin"
 )
 
 func TestIsMeshBrowseHost(t *testing.T) {
@@ -162,4 +166,36 @@ func TestWasmPasswordGate(t *testing.T) {
 			t.Error("secure=true did not set the Secure cookie attribute")
 		}
 	})
+}
+
+// TestVariantPathsServeEachToolchainPair pins the per-variant PATH surface.
+// A query string cannot select bytes on a static host, so publishing this
+// surface as plain files needs the variant in the URL path. The wasm blob and
+// its wasm_exec.js loader are toolchain-specific and must never be mixed (see
+// wasmbin/embed.go), so both live under the same /wasm/<variant>/ prefix.
+func TestVariantPathsServeEachToolchainPair(t *testing.T) {
+	avail := wasmbin.Available()
+	if len(avail) == 0 {
+		t.Skip("no wasm variants embedded in this build")
+	}
+	for _, v := range avail {
+		blob, err := wasmbin.GetVariant(v)
+		require.NoError(t, err, "variant %s", v)
+		require.NotEmpty(t, blob, "variant %s blob", v)
+		require.NotEmpty(t, wasmbin.WasmExecJSVariant(v), "variant %s loader", v)
+	}
+
+	// Distinct variants must not share bytes — that is the whole point of
+	// addressing them separately.
+	if len(avail) > 1 {
+		a, err := wasmbin.GetVariant(avail[0])
+		require.NoError(t, err)
+		b, err := wasmbin.GetVariant(avail[1])
+		require.NoError(t, err)
+		require.NotEqual(t, len(a), len(b), "variants %s and %s should differ", avail[0], avail[1])
+		require.NotEqual(t,
+			string(wasmbin.WasmExecJSVariant(avail[0])),
+			string(wasmbin.WasmExecJSVariant(avail[1])),
+			"each toolchain ships its own wasm_exec.js loader")
+	}
 }

--- a/pkg/wasmhv/hv-boot.js
+++ b/pkg/wasmhv/hv-boot.js
@@ -113,6 +113,12 @@
   var VARIANT_KEY = 'skywire-visor-variant';
   function loadVariant() { try { return localStorage.getItem(VARIANT_KEY) || ''; } catch (e) { return ''; } }
   function variantQS() { var v = loadVariant(); return v ? ('?variant=' + encodeURIComponent(v)) : ''; }
+  // variantPath puts the variant in the URL PATH instead of a query. A query
+  // string cannot select bytes on a static host, so publishing this surface as
+  // plain files needs the wasm blob and its toolchain-matched wasm_exec.js —
+  // which must never be mixed — addressable by path. The bare name is the
+  // default variant, which every host serves.
+  function variantPath(name) { var v = loadVariant(); return v ? ('wasm/' + encodeURIComponent(v) + '/' + name) : name; }
   function variantSuffix() { var v = loadVariant(); return v ? ('-' + v) : ''; }
   function newSKHex() {
     var b = crypto.getRandomValues(new Uint8Array(32));
@@ -704,14 +710,14 @@
   // are unavailable or worker.js can't be loaded (e.g. exotic embeddings). Keeps the
   // page working, at the cost of the main-thread-freeze risk the worker path avoids.
   async function bootInPage(sk) {
-    await loadScript('wasm_exec.js' + variantQS());
+    await loadScript(variantPath('wasm_exec.js'));
     var go = new Go();
     if (go.importObject.gojs && !go.importObject.gojs['runtime.getRandomData']) {
       go.importObject.gojs['runtime.getRandomData'] = function (ptr, len) {
         crypto.getRandomValues(new Uint8Array(go._inst.exports.memory.buffer, ptr >>> 0, len >>> 0));
       };
     }
-    var buf = await fetch('wasm-visor.wasm' + variantQS()).then(function (r) { return r.arrayBuffer(); });
+    var buf = await fetch(variantPath('wasm-visor.wasm')).then(function (r) { return r.arrayBuffer(); });
     var res = await WebAssembly.instantiate(buf, go.importObject);
     go.run(res.instance); // installs globalThis.skywireVisor
     while (!self.skywireVisor || !self.skywireVisor.boot) {

--- a/pkg/wasmhv/worker.js
+++ b/pkg/wasmhv/worker.js
@@ -160,8 +160,12 @@
   // which must match toolchains. Empty = the server default.
   var __variant = '';
   try { __variant = (new URLSearchParams(self.location.search)).get('variant') || ''; } catch (e) {}
-  var __vqs = __variant ? ('?variant=' + encodeURIComponent(__variant)) : '';
-  importScripts('wasm_exec.js' + __vqs);
+  // Variant in the PATH, not a query: a query cannot select bytes on a static
+  // host, and the blob and its toolchain-matched wasm_exec.js must never be
+  // mixed. The worker still learns its variant from its OWN url query, which
+  // hv-boot sets so each variant gets a distinct SharedWorker identity.
+  var __vpath = function (name) { return __variant ? ('wasm/' + encodeURIComponent(__variant) + '/' + name) : name; };
+  importScripts(__vpath('wasm_exec.js'));
   var go = new Go();
   // TinyGo's wasm_exec.js omits the gojs getRandomData import the crypto-using Go
   // runtime needs to seed itself; inject it only when absent (mirrors hv-boot.js).
@@ -450,7 +454,7 @@
     registerPort(selfPort);
   }
 
-  fetch('wasm-visor.wasm' + __vqs).then(function (r) { return r.arrayBuffer(); }).then(function (buf) {
+  fetch(__vpath('wasm-visor.wasm')).then(function (r) { return r.arrayBuffer(); }).then(function (buf) {
     return WebAssembly.instantiate(buf, go.importObject);
   }).then(function (res) {
     go.run(res.instance); // installs self.skywireVisor, then parks on select{}


### PR DESCRIPTION
`?variant=go|tinygo` selects which toolchain's blob is served at `/wasm-visor.wasm` and `/wasm_exec.js`. A query string cannot select bytes on a static host — GitHub Pages and friends serve one body per path — so with the tpviz API gone (#4501) this is the last piece of `hv serve` that needs a server to decide anything.

This serves each variant under `/wasm/<variant>/` as well, and has `hv-boot.js` and `worker.js` build that path instead of appending the query. The blob and its `wasm_exec.js` loader are toolchain-specific and must never be mixed (`wasmbin/embed.go`), so both live under the same prefix and travel as a pair:

```
/wasm/go/wasm-visor.wasm      + /wasm/go/wasm_exec.js       (12.26 MB gz, full crypto/tls)
/wasm/tinygo/wasm-visor.wasm  + /wasm/tinygo/wasm_exec.js   ( 4.04 MB gz, TinyGo gaps)
```

The `?variant=` form stays, so clients holding an older `hv-boot.js` in cache keep working; it costs two extra mux entries.

`worker.js` keeps its own `?variant=` query — that is how the worker learns which variant it is, and how each variant gets a distinct SharedWorker identity (`{name: 'skywire-wasm-visor-' + variant}`). Its bytes don't vary by variant, so a static host serves it unchanged and the worker still reads the value from `self.location.search`.

A TinyGo-built visor embeds only the TinyGo pair, and `wasm-variants.json` already advertises what is actually available, so the client only ever asks for a path that exists.

**Testing:** `go vet`, `go build .`, full `pkg/visor` suite (11s), `node --check` on both JS files, plus a test pinning that each embedded variant has a non-empty blob and loader and that two variants never share bytes.

Not exercised in a browser — the runtime switch is worth a manual check on the deployed PWA.
