### PR TITLE
fix(cxo): give tpd-metrics the large-feed first-sync timeout

### DIFF
--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -229,8 +229,9 @@ const TabCloseGrace = 10 * time.Second
 const FirstSyncTimeout = 10 * time.Second
 
 // largeFeedFirstSyncTimeout is the first-Root wait for the big feeds.
-// all-transports (~8MB network-wide snapshot) and sd-services (the full
-// service-discovery listing, ~1000 servers) are large, deep trees that
+// all-transports (~8MB network-wide snapshot), sd-services (the full
+// service-discovery listing, ~1000 servers) and tpd-metrics (the
+// network-wide per-transport aggregate) are large, deep trees that
 // routinely need well over FirstSyncTimeout to deliver their first Root
 // over dmsg — a 10s bound left them never syncing over CXO (sd-services
 // timed out at 10s → empty proxy/vpn pickers). These feeds get the room
@@ -243,7 +244,7 @@ const largeFeedFirstSyncTimeout = 45 * time.Second
 // fast feeds.
 func FeedFirstSyncTimeout(f Feed) time.Duration {
 	switch f {
-	case FeedTPDAllTransports, FeedSDServices:
+	case FeedTPDAllTransports, FeedSDServices, FeedTPDMetrics:
 		return largeFeedFirstSyncTimeout
 	}
 	return FirstSyncTimeout

--- a/pkg/cxo/cxosub/manager_pin_test.go
+++ b/pkg/cxo/cxosub/manager_pin_test.go
@@ -57,3 +57,24 @@ func feedHasStopTimer(m *Manager, fk Feed) bool {
 	f, ok := m.feeds[fk]
 	return ok && f != nil && f.stopTimer != nil
 }
+
+// Every feed that carries a large, deep tree must get the longer first-Root
+// wait. tpd-metrics is the network-wide per-transport aggregate — by far the
+// largest feed published — and it was left on the 10s default, so its first
+// sync timed out before the tree could arrive and the feed never populated.
+// That is the same failure the sd-services timeout was widened to fix.
+func TestLargeFeedsGetTheLongerFirstSyncTimeout(t *testing.T) {
+	for _, f := range []Feed{FeedTPDAllTransports, FeedSDServices, FeedTPDMetrics} {
+		if got := FeedFirstSyncTimeout(f); got != largeFeedFirstSyncTimeout {
+			t.Errorf("FeedFirstSyncTimeout(%v) = %s, want %s — a large feed on the short bound never finishes its first sync",
+				f, got, largeFeedFirstSyncTimeout)
+		}
+	}
+	// The small feeds keep the tighter bound so a UI Acquire on a dead
+	// publisher still reports its cache miss promptly.
+	for _, f := range []Feed{FeedTPDUptime, FeedDMSGDClientsByServer} {
+		if got := FeedFirstSyncTimeout(f); got != FirstSyncTimeout {
+			t.Errorf("FeedFirstSyncTimeout(%v) = %s, want the %s default", f, got, FirstSyncTimeout)
+		}
+	}
+}


### PR DESCRIPTION
`FeedFirstSyncTimeout` grants the 45s `largeFeedFirstSyncTimeout` to `FeedTPDAllTransports` and `FeedSDServices`, and leaves `FeedTPDMetrics` on the 10s default. That classification is backwards now: all-transports is ~679 KB in practice, while tpd-metrics is the network-wide per-transport aggregate — tens of megabytes across 20+ leaves since #4509 began splitting oversized windows into parts.

So it hits exactly the failure the constant's own comment describes for sd-services — *"a 10s bound left them never syncing over CXO"*. On production right now, TPD publishes without error:

```
23:24:06  published as parts days=7  parts=9
23:30:53  published as parts days=7  parts=15
23:24:38  published as parts days=30 parts=10
```

while subscribers sit at `timeout waiting for Root after 10s` with zero cached bytes, retrying from scratch every cycle.

The small feeds keep the tighter bound so a UI Acquire on a dead publisher still reports its cache miss promptly.
