### PR TITLE
fix(dmsg-server): advertise the full build string in the discovery entry

### DIFF
--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -88,10 +88,16 @@ type Config struct {
 
 // dmsgEntryVersion returns the build version to advertise in the dmsg server's
 // discovery entry, or "" when the binary carries no meaningful version (dev
-// builds) so the entity keeps the "0.0.1" default. Uses runtime/debug build
-// info via buildinfo — the same source the /health endpoint reports.
+// builds) so the entity keeps the "0.0.1" default.
+//
+// buildinfo.Get() rather than buildinfo.Version(): Get appends the commit, so
+// the entry carries the same "v1.3.94-0-659adf35d256" string /health reports
+// and every visor shows. Version() alone stops at the release tag, which made
+// all nine production servers advertise an identical "v1.3.94-0" and left no
+// way to tell from discovery which commit any of them was running — so after a
+// dmsg-server fix ships there is no way to see which servers picked it up.
 func dmsgEntryVersion() string {
-	if v := buildinfo.Version(); v != "" && v != "unknown" {
+	if v := buildinfo.Get().Version; v != "" && v != "unknown" {
 		return v
 	}
 	return ""

--- a/pkg/services/dmsgsrv/entry_version_test.go
+++ b/pkg/services/dmsgsrv/entry_version_test.go
@@ -1,0 +1,35 @@
+// Package dmsgsrv pkg/services/dmsgsrv/entry_version_test.go c1-net-dmsg
+package dmsgsrv
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/buildinfo"
+)
+
+// The discovery entry must advertise the same build string /health reports and
+// every visor shows — release tag plus commit. Advertising the bare tag made
+// all nine production servers identical in discovery, so there was no way to
+// tell which commit any of them ran, and no way to confirm a shipped
+// dmsg-server fix had reached them.
+func TestDmsgEntryVersionCarriesTheCommit(t *testing.T) {
+	got := dmsgEntryVersion()
+	want := buildinfo.Get().Version
+
+	if got == "" {
+		// A dev build with no version info advertises nothing, so the entity
+		// keeps its "0.0.1" default. Nothing further to assert.
+		if want != "" && want != "unknown" {
+			t.Errorf("dmsgEntryVersion() = %q, want %q", got, want)
+		}
+		return
+	}
+	if got != want {
+		t.Errorf("dmsgEntryVersion() = %q, want %q — the entry must match what /health reports", got, want)
+	}
+	// The whole point: it must not stop at the bare release tag when a commit
+	// is available to distinguish builds within that release.
+	if c := buildinfo.Commit(); c != "" && c != "unknown" && got == buildinfo.Version() && want != buildinfo.Version() {
+		t.Errorf("dmsgEntryVersion() = %q is the bare version; the commit %q is available and must be included", got, c)
+	}
+}


### PR DESCRIPTION
`dmsgEntryVersion` used `buildinfo.Version()`, which stops at the release tag. Its own comment claimed that was *"the same source the /health endpoint reports"* — but `/health` uses `buildinfo.Get()`, which appends the commit.

So every production dmsg server advertises an identical string in dmsg-discovery:

```
0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13  version="v1.3.94-0"  45.79.213.251:30087
03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf  version="v1.3.94-0"  172.235.168.146:30081
0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb  version="v1.3.94-0"  139.162.160.227:30086
                                                          … all nine identical …
```

while TPD's health on the same host and image reports `v1.3.94-0-659adf35d256`, and `hv ls` shows visors with the full string too. Discovery cannot distinguish builds within a release, so after a dmsg-server fix ships — #4506, say — there is no way to see which servers have picked it up.

`buildinfo.Get().Version` gives the entry the same string every other surface shows. A dev build with no version info still advertises nothing and keeps the entity's `0.0.1` default.
