### PR TITLE
fix(desk): retire /dashboard — the framed root already serves it

### DIFF
--- a/pkg/visor/hypervisor_desk_test.go
+++ b/pkg/visor/hypervisor_desk_test.go
@@ -59,8 +59,14 @@ func TestNativeDeskServing(t *testing.T) {
 		if !strings.Contains(body, "native: true") {
 			t.Error("page lacks the native-mode marker (native: true)")
 		}
-		if !strings.Contains(body, "dashboardURL: '/dashboard#/?embed=1'") {
-			t.Error("page lacks the same-origin dashboard window URL")
+		// RELATIVE and rooted: an absolute URL escapes the /vnet/<port>/ prefix
+		// onto the outer server's root (the trap #4499 fixed for /desk), and the
+		// dashboard lives at the framed root now, not a /dashboard path.
+		if !strings.Contains(body, "dashboardURL: './?embed=1#/?embed=1'") {
+			t.Error("page lacks the relative framed-root dashboard window URL")
+		}
+		if strings.Contains(body, "dashboardURL: '/") {
+			t.Error("dashboardURL is absolute — it would escape the vnet prefix")
 		}
 		// The shell is assembled from the SAME assets the dashboard injection
 		// uses plus the shared desk boot.
@@ -94,17 +100,41 @@ func TestNativeDeskServing(t *testing.T) {
 		}
 	})
 
-	t.Run("Angular serves at /dashboard, with the launcher injection intact", func(t *testing.T) {
-		w := get("/dashboard")
-		if w.Code != http.StatusOK {
-			t.Fatalf("status=%d, want 200", w.Code)
+	t.Run("Angular serves at the FRAMED root, with the launcher injection intact", func(t *testing.T) {
+		// The dashboard has no path of its own. Under the vnet service worker a
+		// framed page gets its <base href> rewritten to the /vnet/<port>/ prefix,
+		// so any deeper path is normalised back to the root before the document
+		// finishes loading — which is why desk-boot.js stopped pointing at
+		// /dashboard. The root serves the dashboard whenever the request is framed.
+		for _, framed := range []func() *httptest.ResponseRecorder{
+			func() *httptest.ResponseRecorder { return get("/?embed=1") },
+			func() *httptest.ResponseRecorder {
+				w := httptest.NewRecorder()
+				r := httptest.NewRequest(http.MethodGet, "/", nil)
+				r.Header.Set("Sec-Fetch-Dest", "iframe")
+				h.ServeHTTP(w, r)
+				return w
+			},
+		} {
+			w := framed()
+			if w.Code != http.StatusOK {
+				t.Fatalf("status=%d, want 200", w.Code)
+			}
+			body := w.Body.String()
+			if !strings.Contains(body, "ANGULAR") {
+				t.Error("Angular index not served at the framed root")
+			}
+			if !strings.Contains(body, `src="browse.js"`) || !strings.Contains(body, "__SKYWIRE_LOCAL_PK__") {
+				t.Error("index injection (desk launcher) missing on the framed root")
+			}
 		}
-		body := w.Body.String()
-		if !strings.Contains(body, "ANGULAR") {
-			t.Error("Angular index not served at /dashboard")
-		}
-		if !strings.Contains(body, `src="browse.js"`) || !strings.Contains(body, "__SKYWIRE_LOCAL_PK__") {
-			t.Error("index injection (desk launcher) missing on the dashboard page")
+	})
+
+	t.Run("the retired /dashboard path is gone", func(t *testing.T) {
+		for _, p := range []string{"/dashboard", "/dashboard/"} {
+			if w := get(p); w.Code != http.StatusNotFound {
+				t.Errorf("GET %s → %d, want 404 (the dashboard is the framed root now)", p, w.Code)
+			}
 		}
 	})
 

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -122,19 +122,6 @@ func (hv *Hypervisor) uiHandler() http.Handler {
 			w.Header().Set("Location", "./")
 			w.WriteHeader(http.StatusMovedPermanently)
 			return
-		case "/dashboard", "/dashboard/":
-			// The Angular dashboard's index, served injected exactly as the old
-			// root was. The SPA is hash-routed, so this one path carries every
-			// dashboard view — as the desk's dashboard tab (embed=1 in the
-			// hash hides the taskbar in the iframe) or standalone.
-			//
-			// The trailing-slash spelling is the one to embed. The SPA rewrites
-			// its own URL relative to the current DIRECTORY, so from
-			// ".../dashboard" a route change resolves to ".../" — which is the
-			// desk, giving a desk nested inside a desk window. From
-			// ".../dashboard/" it stays put.
-			hv.serveInjectedIndex(w, r, fileServer)
-			return
 		}
 		fileServer.ServeHTTP(w, r)
 	})
@@ -255,7 +242,7 @@ func (hv *Hypervisor) serveNativeDesk(w http.ResponseWriter) {
 // same chrome-less guard the ☰ chat/log windows rely on.
 const nativeDeskBootOpts = `{
   native: true,
-  dashboardURL: '/dashboard#/?embed=1',
+  dashboardURL: './?embed=1#/?embed=1',
 }`
 
 // uiVersionHash fingerprints the served UI bundle (short sha256 of index.html,
@@ -305,7 +292,7 @@ const uiAutoReloadJS = `(function(){
 // publishes it as __skywireDesk — the handle desk-boot's native branch waits
 // on before opening the dashboard window. It refuses to mount inside an
 // embedded frame (embed=1 in the hash/query): the dashboard window is an
-// iframe of /dashboard and must not grow its own taskbar. The retired
+// iframe of the framed root and must not grow its own taskbar. The retired
 // browse.js engine's providers are gone with it; the native desk's terminal
 // remains the dashboard's Terminal tab (dmsgpty) until the shared shell
 // integration lands.
@@ -313,9 +300,17 @@ const nativeBrowseLauncherJS = `(function () {
   if (/[#?&]embed=1/.test(location.hash + location.search)) { return; }
   function ready() {
     if (!self.skywireDeskPanel || !document.body || typeof self.WinBox !== "function") { return setTimeout(ready, 200); }
-    // On the dashboard page itself, no dashboard menu entry (it IS the
-    // dashboard); on the desk root, the entry opens /dashboard in a window.
-    var dashURL = location.pathname === "/dashboard" ? "" : "/dashboard#/?embed=1";
+    // RELATIVE: reached through the vnet service worker this page lives under
+    // a "/vnet/<port>/" prefix the server never sees, so an absolute URL
+    // escapes it onto the outer server's root — a different visor entirely
+    // (the same trap #4499 fixed for /desk). "./" is resolved by the browser
+    // against the URL it actually asked for, which keeps the prefix.
+    //
+    // The root, not a /dashboard path: the hypervisor serves the dashboard at
+    // the root whenever the request is framed, and the SW normalises deeper
+    // paths away anyway. The launcher already returns early on an embed=1
+    // page, so this only ever runs on the desk root.
+    var dashURL = "./?embed=1#/?embed=1";
     var p = self.skywireDeskPanel.mount(document, { dashboardURL: dashURL });
     // Stream the NATIVE visor's server-side log (/api/log SSE) into the log
     // window's buffer, when a log consumer exists on the page.

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -363,15 +363,6 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 		w.Header().Set("Location", "./")
 		w.WriteHeader(http.StatusMovedPermanently)
 	})
-	// The Angular dashboard keeps its own path, for a link that wants the
-	// dashboard specifically rather than the shell around it.
-	dashboard := func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Header().Set("Cache-Control", "no-cache")
-		_, _ = w.Write(index) //nolint:errcheck
-	}
-	mux.HandleFunc("/dashboard", dashboard)
-	mux.HandleFunc("/dashboard/", dashboard)
 	serveBytes("/winbox.wasm", "application/wasm", wasmhv.WinBoxWasm())
 	serveBytes("/autoupdate.js", "text/javascript", wasmhv.AutoUpdateJS)
 	serveBytes("/manifest.webmanifest", "application/manifest+json", wasmhv.PWAManifest)


### PR DESCRIPTION
The dashboard has no need of a path of its own.

Under the vnet service worker a framed page gets its `<base href>` rewritten to the `/vnet/<port>/` prefix, so any deeper path is normalised back to the root before the document finishes loading. `desk-boot.js:180` already spells this out and stopped using `/dashboard` for exactly that reason — it opens the framed root instead, and the root handler serves the Angular index whenever the request is framed (`Sec-Fetch-Dest: iframe`, or `embed=1`).

The native hypervisor was the last caller still on the old path. This drops the route from both the native HV and `hv serve`, and points the two native call sites at the framed root.

**Both were absolute** — `'/dashboard#/?embed=1'` — which escapes the vnet prefix onto the outer server's root, a different visor entirely. Same trap #4499 fixed for `/desk`. They're relative now (`'./?embed=1#/?embed=1'`), resolved by the browser against the URL it actually requested. The launcher's companion check `location.pathname === "/dashboard"` could never match under a prefix either and goes with it — the launcher already returns early on an `embed=1` page, so it only ever runs on the desk root.

**Tests.** Two subtests in `TestNativeDeskServing` encoded the old contract and are updated rather than deleted:

- the `dashboardURL` assertion now checks the relative form *and* that it isn't absolute, so the prefix escape can't silently return
- `"Angular serves at /dashboard"` becomes `"Angular serves at the FRAMED root"`, exercising **both** framing signals (`?embed=1` and the `Sec-Fetch-Dest` header — the header path wasn't covered before) with the same Angular-index and launcher-injection assertions
- new `"the retired /dashboard path is gone"` pins `/dashboard` and `/dashboard/` at 404

`go vet`, `go build .`, full `pkg/visor` suite (11s) all pass.

With this and #4501, no route `hv serve` mounts needs a server to decide anything — every response is fixed bytes. That is what lets the surface be published as static files (#3704).

Not exercised in a browser: the desk's dashboard window opening through the vnet prefix is worth a manual check.
