### PR TITLE
fix: correct four misspellings failing the CI lint job

### DIFF
--- a/pkg/deployment/tpd/api/cxo_metrics_publisher_test.go
+++ b/pkg/deployment/tpd/api/cxo_metrics_publisher_test.go
@@ -79,7 +79,7 @@ func TestGzipPartsSingleLeafIsCompressed(t *testing.T) {
 }
 
 // The point of the split: every part fits, and NO record is dropped. The
-// previous behaviour re-fetched the window without per-edge bandwidth and
+// previous behavior re-fetched the window without per-edge bandwidth and
 // published that instead, which silently lost data.
 func TestGzipPartsSplitsWithoutLosingRecords(t *testing.T) {
 	metrics := metricsFixture(4000, 30)

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -181,7 +181,7 @@ type EntityCommon struct {
 	// "not old + 1" (#4086). Each rejected POST costs a full Noise handshake on
 	// the discovery.
 	//
-	// Deliberately a channel, not a Mutex: acquisition must honour the caller's
+	// Deliberately a channel, not a Mutex: acquisition must honor the caller's
 	// context. A plain mutex here is what wedged services in #3157/#3168 — a
 	// stuck PUT held it while every other caller blocked forever, their own
 	// per-attempt timeouts useless because mutex acquisition ignores context.
@@ -905,7 +905,7 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 	// Serialize this entity's read-modify-write against the discovery: the GET
 	// in updateClientEntryOnEndpoint and its PUT must not interleave with another
 	// publisher's, or one of them posts a stale sequence and is rejected 422
-	// (#4086). Acquisition honours ctx and done, so a stuck holder cannot wedge
+	// (#4086). Acquisition honors ctx and done, so a stuck holder cannot wedge
 	// its callers the way the plain mutex did in #3157/#3168; a caller that times
 	// out simply retries on the next tick. Nil-checked because a zero-value
 	// EntityCommon (tests) never ran init.

--- a/pkg/services/dmsgdisc/dmsgdisc_test.go
+++ b/pkg/services/dmsgdisc/dmsgdisc_test.go
@@ -221,7 +221,7 @@ func TestRun_StoreOpenFails(t *testing.T) {
 // TestOfficialServerPKsDefaultsToSeedList pins the rule that the official-server
 // allowlist falls back to the embedded deployment seed list. Maintaining the two
 // by hand let them drift: production listed 7 of the 9 seeded servers plus 2 PKs
-// for servers that no longer exist, so two live deployment servers were labelled
+// for servers that no longer exist, so two live deployment servers were labeled
 // "community" and skipped by clients running connected_servers_type=official.
 func TestOfficialServerPKsDefaultsToSeedList(t *testing.T) {
 	seeded := officialServerPKs(nil)


### PR DESCRIPTION
The `golangci-lint` job fails on develop for every PR, so the lint check has not been gating anything. The cause is four British spellings caught by `misspell`, which `.golangci.yml` runs with `locale: US`:

```
pkg/deployment/tpd/api/cxo_metrics_publisher_test.go:82  behaviour -> behavior
pkg/dmsg/dmsg/entity_common.go:184                       honour    -> honor
pkg/dmsg/dmsg/entity_common.go:908                       honours   -> honors
pkg/services/dmsgdisc/dmsgdisc_test.go:224               labelled  -> labeled
```

Comments only — no behavior change. A repo-wide `misspell` sweep is clean afterwards.

Worth noting because it was masking things: with this job red on every run, `linux`, `darwin`, `windows` and `android` all report failure regardless of whether the actual tests pass, so a genuinely broken PR looks the same as a clean one.
