### PR TITLE
feat(desk): render same-origin pages natively, and never nest the shell

### DIFF
--- a/cmd/wasm-visor/desk_js.go
+++ b/cmd/wasm-visor/desk_js.go
@@ -86,17 +86,36 @@ func installDesk() {
 	// The hypervisor UI is a browser TAB, not a window of its own — the desk
 	// puts surfaces in tabs wherever the pane already has them, and the
 	// dashboard is just a page. DirectLoader is what makes that tab render
-	// NATIVELY: without it netscrape would transcode the Angular app into a
-	// sandboxed srcdoc, which strips the same-origin it needs. Claim only
-	// same-origin /vnet/ URLs — those are served by this page's own service
-	// worker out of the visor's virtual loopback, so they are ours to render.
+	// NATIVELY: without it netscrape would transcode the page into a sandboxed
+	// srcdoc, which strips the same-origin an Angular-style app needs.
+	//
+	// Claim the whole ORIGIN, not just /vnet/. Two pages want this and both are
+	// ours by definition — the origin is what this page is served from:
+	//
+	//   /vnet/<port>/…  the visor's virtual loopback, via our service worker
+	//   everything else  the site hosting the desk — on the docs deployment that
+	//                    is MkDocs, which the desk opens in a tab so the reader
+	//                    browses the docs inside the visor rather than beside it
+	//
+	// This also removes the transport from the path: a same-origin page loads as
+	// an ordinary document, so the docs render with no visor running. Going
+	// through fetchPage would strand them — __netscrapeFetch exists but has
+	// nothing behind it until someone starts a visor (measured live).
+	//
+	// A claimed page is UNSANDBOXED, so this must stay same-origin-only.
 	netscrape.DirectLoader = func(u string) (string, bool) {
 		loc := js.Global().Get("location")
 		if !loc.Truthy() {
 			return "", false
 		}
 		origin := loc.Get("origin").String()
-		if origin == "" || !strings.HasPrefix(u, origin+"/vnet/") {
+		if origin == "" {
+			return "", false
+		}
+		// Exact origin, or origin followed by a path separator — never a
+		// prefix match that a sibling origin could satisfy
+		// ("https://evil.com" must not match "https://evil.com.attacker.net").
+		if u != origin && !strings.HasPrefix(u, origin+"/") {
 			return "", false
 		}
 		return u, true

--- a/docs/javascripts/desk-shell.js
+++ b/docs/javascripts/desk-shell.js
@@ -30,6 +30,16 @@
 (function () {
   'use strict';
 
+  // FRAMED: do nothing. The desk opens the docs in a netscrape tab, and
+  // desk_js.go's DirectLoader claims same-origin URLs so that tab renders the
+  // real page — scripts and all, this one included. Without this guard the
+  // docs would mount a desk inside the desk's own browser, which would open
+  // the docs, without end. Reading the docs framed is the point; running a
+  // second shell inside them is not.
+  try {
+    if (window.top !== window.self) { return; }
+  } catch (e) { return; } // cross-origin top — framed by someone else
+
   if (window.__skwDeskShell) { window.__skwDeskShell.onNavigate(); return; }
 
   // Site root from this script's own URL (".../javascripts/desk-shell.js"),


### PR DESCRIPTION
Two changes that let the docs be **read inside** the desk's browser rather than sit behind it.

## DirectLoader claims the whole origin

It claimed only same-origin `/vnet/` URLs, so anything else went through the transport and was transcoded into a sandboxed `srcdoc` — scripts stripped. That is wrong for a page the host already serves on its own origin, and on the docs deployment it is fatal twice over: MkDocs loses its JS, *and* the fetch has nowhere to go.

Measured live on the deployed site, in the shell's iframe with no visor started:

```
__netscrapeFetch: "function"    ← the transport exists
visorStarted:     false         ← nothing behind it
```

The tab sat on netscrape's `data:` placeholder while the address bar read `https://skycoin.github.io/skywire/`. Claiming the whole origin renders those pages as ordinary documents with no transport in the path, so they work with **no visor running** — which is the point, since the docs shell deliberately doesn't autostart one.

The match is exact-origin or `origin+"/"`, never a bare prefix a sibling origin could satisfy (`https://evil.com` must not match `https://evil.com.attacker.net`). A claimed page is unsandboxed, so same-origin is the whole permission.

## desk-shell.js gets a framing guard

It had none. Once the docs render natively in a tab they execute their own scripts — `desk-shell.js` included — and would mount a desk inside the desk's browser, which opens the docs, without end. Framed, the shell now returns immediately.

This was a latent bug before this PR: anything that framed a docs page got a second shell. It only becomes reachable now, which is why it ships here.

**Testing:** `GOOS=js GOARCH=wasm go vet` and build pass, host `go build .` passes, `node --check` on the shell. The live measurement above was taken over CDP against the deployed docs site.

Not yet exercised: the docs actually rendering in the tab needs a deployed build to confirm end to end.
