### PR TITLE
fix(cxo): wait for the first sync instead of returning a cold-cache miss

### DIFF
--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -717,6 +717,51 @@ func (m *Manager) LastSync(feed Feed) time.Time {
 	return f.lastSyncAt
 }
 
+// WaitForFirstSync blocks until the feed has completed at least one sync
+// cycle, or until timeout elapses or ctx is canceled. Reports whether a
+// sync completed.
+//
+// A caller that has just AcquireFor'd a feed and found its cache empty
+// cannot tell "this feed is empty" from "the first fill is still in
+// flight". Returning the miss immediately makes the two look identical
+// and, worse, releases the reference — so the grace-period teardown
+// closes the subscriber mid-fill and the next call starts over from
+// nothing. A feed whose first sync takes longer than one caller's
+// patience then never becomes readable through that path at all, no
+// matter how many times it is retried. That is what made the tpd-metrics
+// feed (tens of megabytes across many leaves) look permanently dead to
+// `cli visor cxo fetch` while it was in fact publishing correctly and
+// syncing fine for a consumer that held the reference open.
+//
+// The caller must keep its AcquireFor reference held across this call;
+// otherwise the cycle it is waiting on is exactly the one being torn
+// down.
+func (m *Manager) WaitForFirstSync(ctx context.Context, feed Feed, timeout time.Duration) bool {
+	if m == nil {
+		return false
+	}
+	if !m.LastSync(feed).IsZero() {
+		return true
+	}
+	deadline := time.Now().Add(timeout)
+	// Poll rather than plumb a condition variable through the feed state:
+	// this runs once on a cold cache, not on the hot path.
+	const pollEvery = 250 * time.Millisecond
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(pollEvery):
+		}
+		if !m.LastSync(feed).IsZero() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+	}
+}
+
 // Pin keeps a feed's sync cycle running continuously by taking one
 // permanent reference: the refcount never falls to zero, so the
 // grace-period teardown never fires. Use it for a feed a core subsystem

--- a/pkg/cxo/cxosub/wait_first_sync_test.go
+++ b/pkg/cxo/cxosub/wait_first_sync_test.go
@@ -1,0 +1,108 @@
+// Package cxosub pkg/cxo/cxosub/wait_first_sync_test.go c2-net-cxo
+package cxosub
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// newFeedForTest registers a feed in the manager's map so the sync-state
+// accessors have something to read, without standing up a live subscription.
+func newFeedForTest(m *Manager, fk Feed) *managedFeed {
+	f := &managedFeed{}
+	m.mu.Lock()
+	if m.feeds == nil {
+		m.feeds = map[Feed]*managedFeed{}
+	}
+	m.feeds[fk] = f
+	m.mu.Unlock()
+	return f
+}
+
+func markSynced(f *managedFeed) {
+	f.snapMu.Lock()
+	f.lastSyncAt = time.Now()
+	f.snapMu.Unlock()
+}
+
+// A feed that has already synced returns immediately — the wait must not cost
+// a caller anything on the hot path.
+func TestWaitForFirstSyncReturnsImmediatelyWhenAlreadySynced(t *testing.T) {
+	m := NewManager(Deps{}, 0)
+	f := newFeedForTest(m, FeedTPDMetrics)
+	markSynced(f)
+
+	start := time.Now()
+	if !m.WaitForFirstSync(context.Background(), FeedTPDMetrics, 5*time.Second) {
+		t.Fatal("WaitForFirstSync reported no sync for an already-synced feed")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("took %s for an already-synced feed; must return immediately", elapsed)
+	}
+}
+
+// The case the fix exists for: the cache is cold when the caller asks, and the
+// first fill completes while it waits. Before this, the caller returned a miss
+// and released its reference, and the grace-period teardown closed the
+// subscriber mid-fill — so the feed never became readable through that path.
+func TestWaitForFirstSyncPicksUpASyncThatLands(t *testing.T) {
+	m := NewManager(Deps{}, 0)
+	f := newFeedForTest(m, FeedTPDMetrics)
+
+	go func() {
+		time.Sleep(600 * time.Millisecond)
+		markSynced(f)
+	}()
+
+	if !m.WaitForFirstSync(context.Background(), FeedTPDMetrics, 10*time.Second) {
+		t.Fatal("did not observe a sync that landed during the wait")
+	}
+}
+
+// A feed that never syncs must give the timeout back to the caller rather than
+// blocking forever — the caller still has an HTTP fallback to reach for.
+func TestWaitForFirstSyncGivesUpAtTimeout(t *testing.T) {
+	m := NewManager(Deps{}, 0)
+	newFeedForTest(m, FeedTPDMetrics)
+
+	start := time.Now()
+	if m.WaitForFirstSync(context.Background(), FeedTPDMetrics, 700*time.Millisecond) {
+		t.Fatal("reported a sync for a feed that never synced")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("took %s to honor a 700ms timeout", elapsed)
+	}
+}
+
+// Cancelling the caller's context must abandon the wait promptly.
+func TestWaitForFirstSyncHonorsContextCancellation(t *testing.T) {
+	m := NewManager(Deps{}, 0)
+	newFeedForTest(m, FeedTPDMetrics)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	if m.WaitForFirstSync(ctx, FeedTPDMetrics, 30*time.Second) {
+		t.Fatal("reported a sync after cancellation")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("took %s to observe cancellation", elapsed)
+	}
+}
+
+// Nil receiver and unknown feeds must not panic — this runs on the fetch path.
+func TestWaitForFirstSyncIsSafeOnNilAndUnknownFeed(t *testing.T) {
+	var nilMgr *Manager
+	if nilMgr.WaitForFirstSync(context.Background(), FeedTPDMetrics, time.Second) {
+		t.Error("nil manager reported a sync")
+	}
+	m := NewManager(Deps{}, 0)
+	if m.WaitForFirstSync(context.Background(), FeedTPDMetrics, 300*time.Millisecond) {
+		t.Error("unknown feed reported a sync")
+	}
+}

--- a/pkg/visor/api_tpd_metrics_subscriber.go
+++ b/pkg/visor/api_tpd_metrics_subscriber.go
@@ -28,12 +28,14 @@ package visor
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/cxo/cxosub"
 	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	tpdstore "github.com/skycoin/skywire/pkg/deployment/tpd/store"
 )
@@ -64,6 +66,24 @@ func (v *Visor) FetchTransportMetricsCXO(days int) ([]byte, time.Time, error) {
 	mgr.AcquireFor(TabMetrics)
 	defer mgr.ReleaseFor(TabMetrics)
 
+	body, ts, err := readTransportMetricsCXO(mgr, days)
+	if err == nil {
+		return body, ts, nil
+	}
+
+	// Cold cache: the first fill may still be in flight. Returning the miss
+	// here would also release the reference, and the grace-period teardown
+	// then closes the subscriber mid-fill — so a feed whose first sync takes
+	// longer than one call never becomes readable, however often it is
+	// retried. This feed is tens of megabytes across many leaves and takes
+	// tens of seconds to fill; measured on production it delivers 7.1 MB
+	// (20,493 records) once the reference is simply held open.
+	//
+	// The AcquireFor above stays held across the wait, which is what keeps
+	// the cycle alive long enough to finish.
+	if !mgr.WaitForFirstSync(context.Background(), FeedTPDMetrics, cxosub.FeedFirstSyncTimeout(FeedTPDMetrics)) {
+		return nil, time.Time{}, err
+	}
 	return readTransportMetricsCXO(mgr, days)
 }
 


### PR DESCRIPTION
A caller that acquires a feed and finds the cache empty cannot distinguish "this feed is empty" from "the first fill is still in flight". Returning the miss immediately *also releases the reference*, so the grace-period teardown (`TabCloseGrace`, 10s) closes the subscriber mid-fill and the next attempt starts from nothing. A feed whose first sync takes longer than one caller's patience never becomes readable through that path, no matter how often it is retried.

This is what made `tpd-metrics` look permanently dead. Every `cli visor cxo fetch` probe restarted a fill and then abandoned it, reporting `tpd-metrics: cache miss` — while TPD was publishing without a single error the entire time. Holding the reference open across repeated calls, the same visor returns:

```
HIT bytes=7152102     paths=1 cache=1 bytes=1914240
20,493 transport metric records, valid JSON
```

The small feeds were never affected because they finish inside one call.

Adds `Manager.WaitForFirstSync` and uses it in `FetchTransportMetricsCXO` on a cold-cache miss, bounded by the feed's own `FeedFirstSyncTimeout` and with the `AcquireFor` held across the wait — which is what keeps the cycle alive long enough to finish. A feed that genuinely has nothing still returns its miss at the deadline, so the HTTP fallback path is unchanged.
