### PR TITLE
feat(cxo): publish TPD's network aggregates as a small, fast feed

### DIFF
--- a/cmd/skywire-cli/commands/rpc/cxo_feed_map_test.go
+++ b/cmd/skywire-cli/commands/rpc/cxo_feed_map_test.go
@@ -1,0 +1,53 @@
+// Package clirpc cxo_feed_map_test.go
+package clirpc
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/deployment"
+)
+
+// TestCXOFeedForURLStats locks in the tpd-stats rows. The two
+// aggregates are the only TPD endpoints a chart needs, so the mapping
+// has to route them to CXO — and has to NOT route the parameterized
+// variants the publisher does not write, which would otherwise be
+// answered with numbers computed over a different set.
+func TestCXOFeedForURLStats(t *testing.T) {
+	tpd := deployment.Prod.TransportDiscovery
+	tpdDmsg := deployment.Prod.TransportDiscoveryDmsg
+
+	cases := []struct {
+		url       string
+		wantFeed  string
+		wantPath  string
+		wantMatch bool
+	}{
+		{tpd + "/all-transports/stats", "tpd-stats", "network", true},
+		{tpdDmsg + "/all-transports/stats", "tpd-stats", "network", true},
+		{tpd + "/version", "tpd-stats", "versions", true},
+		{tpdDmsg + "/version", "tpd-stats", "versions", true},
+		// The endpoint's defaults, spelled out explicitly, still match.
+		{tpd + "/version?on=all", "tpd-stats", "versions", true},
+		{tpd + "/version?on=none", "tpd-stats", "versions", true},
+
+		// Variants the publisher does not write must fall through to the
+		// HTTP chain rather than be served a mismatched body.
+		{tpd + "/all-transports/stats?selfTransports=hide", "", "", false},
+		{tpd + "/version?on=true", "", "", false},
+		{tpd + "/version?on=false", "", "", false},
+
+		// The per-key rollup is deliberately not on this feed.
+		{tpd + "/all-transports/per-key-stats", "", "", false},
+
+		// And the sibling bulk endpoint keeps its own feed.
+		{tpd + "/all-transports", "tpd-all-transports", "without-self", true},
+	}
+
+	for _, c := range cases {
+		feed, path, ok := cxoFeedForURL(c.url)
+		if ok != c.wantMatch || feed != c.wantFeed || path != c.wantPath {
+			t.Errorf("cxoFeedForURL(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				c.url, feed, path, ok, c.wantFeed, c.wantPath, c.wantMatch)
+		}
+	}
+}

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -582,6 +582,32 @@ func cxoFeedForURL(rawURL string) (feed, path string, ok bool) {
 		return "", "", false
 	}
 
+	// TPD /all-transports/stats → "tpd-stats" feed, "network" path.
+	// isUnderBase matches base+suffix exactly, so this is a distinct
+	// endpoint from /all-transports below and the order of the two
+	// blocks does not matter. The publisher writes only the default
+	// (self-transports included) variant, so an explicit
+	// ?selfTransports= falls through to the HTTP chain rather than
+	// being answered with a body that counted a different set.
+	if isUnderBase(rawURL, deployment.Prod.TransportDiscovery, "/all-transports/stats") ||
+		isUnderBase(rawURL, deployment.Prod.TransportDiscoveryDmsg, "/all-transports/stats") {
+		if queryParam(rawURL, "selfTransports") != "" {
+			return "", "", false
+		}
+		return "tpd-stats", "network", true
+	}
+
+	// TPD /version → "tpd-stats" feed, "versions" path. Same rule for
+	// the ?on= online filter: the publisher writes the unfiltered
+	// histogram, which is what the endpoint serves by default.
+	if isUnderBase(rawURL, deployment.Prod.TransportDiscovery, "/version") ||
+		isUnderBase(rawURL, deployment.Prod.TransportDiscoveryDmsg, "/version") {
+		if on := queryParam(rawURL, "on"); on != "" && on != "all" && on != "none" {
+			return "", "", false
+		}
+		return "tpd-stats", "versions", true
+	}
+
 	// TPD /all-transports → "tpd-all-transports" feed. The publisher
 	// emits two variants (with-self / without-self) on a 60s
 	// cadence; the CLI's `pv -t`, `tp tree`, and `tp viz` callers

--- a/cmd/skywire-cli/commands/visor/cxo.go
+++ b/cmd/skywire-cli/commands/visor/cxo.go
@@ -169,7 +169,7 @@ work" check. Useful right after deploy: if 'cxo refresh sd-services'
 shows paths>0 then any subsequent 'tp -m' will serve from the snapshot.
 
 Feed names: tpd-metrics, tpd-uptime, sd-services,
-dmsgd-clients-by-server, tpd-all-transports.`,
+dmsgd-clients-by-server, tpd-all-transports, tpd-stats.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
@@ -178,7 +178,7 @@ dmsgd-clients-by-server, tpd-all-transports.`,
 
 		var feeds []string
 		if cxoRefreshAll {
-			feeds = []string{"tpd-metrics", "tpd-uptime", "sd-services", "dmsgd-clients-by-server", "tpd-all-transports"}
+			feeds = []string{"tpd-metrics", "tpd-uptime", "sd-services", "dmsgd-clients-by-server", "tpd-all-transports", "tpd-stats"}
 		} else {
 			if len(args) != 1 {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("usage: visor cxo refresh <feed>  (or --all)"))
@@ -220,6 +220,12 @@ Paths per feed:
   tpd-uptime              uptimes/days/<N>          e.g. uptimes/days/30
   sd-services             type/<typeName>           e.g. type/proxy
   tpd-all-transports      with-self | without-self
+  tpd-stats               network | versions        the sub-kilobyte
+                          network aggregates (transports by type, unique
+                          visors, fleet version histogram), republished
+                          every ~12s and stamped with a completeness
+                          verdict — see the "complete"/"confidence"
+                          fields before charting an absolute count
   (dmsgd-clients-by-server has no FetchCXO case — Walk it via your own RPC if needed)`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/docs/skywire/cli/visor/cxo/fetch/README.md
+++ b/docs/skywire/cli/visor/cxo/fetch/README.md
@@ -10,9 +10,17 @@ broken" from the higher-level command.
 
 Paths per feed:
   tpd-metrics             metrics/days/<N>          e.g. metrics/days/7
+                          (any N up to the published history; the feed
+                           itself is one leaf per day, assembled locally)
   tpd-uptime              uptimes/days/<N>          e.g. uptimes/days/30
   sd-services             type/<typeName>           e.g. type/proxy
   tpd-all-transports      with-self | without-self
+  tpd-stats               network | versions        the sub-kilobyte
+                          network aggregates (transports by type, unique
+                          visors, fleet version histogram), republished
+                          every ~12s and stamped with a completeness
+                          verdict — see the "complete"/"confidence"
+                          fields before charting an absolute count
   (dmsgd-clients-by-server has no FetchCXO case — Walk it via your own RPC if needed)
 
 ## Usage

--- a/docs/skywire/cli/visor/cxo/refresh/README.md
+++ b/docs/skywire/cli/visor/cxo/refresh/README.md
@@ -13,7 +13,7 @@ work" check. Useful right after deploy: if 'cxo refresh sd-services'
 shows paths>0 then any subsequent 'tp -m' will serve from the snapshot.
 
 Feed names: tpd-metrics, tpd-uptime, sd-services,
-dmsgd-clients-by-server, tpd-all-transports.
+dmsgd-clients-by-server, tpd-all-transports, tpd-stats.
 
 ## Usage
 

--- a/docs/tpviz-cxo-subscriber.md
+++ b/docs/tpviz-cxo-subscriber.md
@@ -24,6 +24,7 @@ PR #3388 patched it via HTTP-over-dmsg; this doc is the proper CXO version.
   | `FeedSDServices` | SD | `DmsgSDServicesCXOPort` (53) | `services/` | services entries |
   | `FeedDMSGDClientsByServer` | DMSG-D | `DmsgDMSGDClientsByServerCXOPort` | `clients-by-server/` | client entries |
   | `FeedTPDAllTransports` | TPD | `DmsgTPDAllTransportsCXOPort` | `transports/all/` | all-transports snapshot |
+  | `FeedTPDStats` | TPD | `DmsgTPDStatsCXOPort` (73) | `stats/` | network aggregates (`stats/network`, `stats/versions`) |
 - `pkg/visor/cxo_subscription_manager.go` (800 lines) implements the intermittent
   subscriber: `syncOnce` (subscribe/snapshot/unsubscribe), `AcquireForTab` /
   `ReleaseForTab` grace batching, `Get`/`Walk`, `feedSpec` (feed → pk/port/prefix

--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -75,6 +75,11 @@ const (
 	// `pv -t`, `tp tree`, `tp viz` commands as a CXO alternative to
 	// HTTP-polling /all-transports.
 	FeedTPDAllTransports
+	// FeedTPDStats is TPD's network-aggregate stats publisher
+	// (stats/network, stats/versions). Sub-kilobyte reductions
+	// republished every few seconds — the feed a chart reads instead
+	// of downloading a bulk snapshot to reduce it locally.
+	FeedTPDStats
 )
 
 // FeedRoute returns the fixed dmsg CXO port and TreeStore path prefix a feed's
@@ -99,6 +104,8 @@ func FeedRoute(f Feed) (port uint16, prefix string, ok bool) {
 		return skyenv.DmsgDMSGDClientsByServerCXOPort, "clients-by-server/", true
 	case FeedTPDAllTransports:
 		return skyenv.DmsgTPDAllTransportsCXOPort, "transports/all/", true
+	case FeedTPDStats:
+		return skyenv.DmsgTPDStatsCXOPort, "stats/", true
 	}
 	return 0, "", false
 }
@@ -139,6 +146,12 @@ const (
 	// lookups resolve from CXO instead of a fresh HTTP-over-dmsg
 	// Noise handshake. HTTP stays the fallback on a snapshot miss.
 	TabDmsgEntryLookup
+	// TabNetworkStats is the consumer of TPD's network-aggregate
+	// stats feed (`cli tp net-stats`, `cli visor cxo fetch tpd-stats
+	// …`, dashboards charting the by-type counts over time). Its own
+	// tab so holding it does not drag in the ~8 MB all-transports
+	// snapshot TabCLITransports carries.
+	TabNetworkStats
 )
 
 // tabFeedDeps maps each tab to the set of feeds it depends on.
@@ -153,6 +166,7 @@ var tabFeedDeps = map[Tab][]Feed{
 	TabCLITransports:     {FeedTPDAllTransports},
 	TabRoutingPolicy:     {FeedSDServices},
 	TabDmsgEntryLookup:   {FeedDMSGDClientsByServer},
+	TabNetworkStats:      {FeedTPDStats},
 }
 
 // Deps are the host-injected dependencies the manager needs. They
@@ -657,6 +671,8 @@ func FeedString(feed Feed) string {
 		return "dmsgd-clients-by-server"
 	case FeedTPDAllTransports:
 		return "tpd-all-transports"
+	case FeedTPDStats:
+		return "tpd-stats"
 	}
 	return fmt.Sprintf("feed#%d", feed)
 }
@@ -675,6 +691,8 @@ func FeedFromString(name string) (Feed, bool) {
 		return FeedDMSGDClientsByServer, true
 	case "tpd-all-transports":
 		return FeedTPDAllTransports, true
+	case "tpd-stats":
+		return FeedTPDStats, true
 	}
 	return 0, false
 }

--- a/pkg/deployment/tpd/api/cxo_stats_publisher.go
+++ b/pkg/deployment/tpd/api/cxo_stats_publisher.go
@@ -1,0 +1,456 @@
+// Package api pkg/deployment/tpd/api/cxo_stats_publisher.go c4-net-discovery
+//
+// CXO publisher for TPD's NETWORK-AGGREGATE stats — the sub-kilobyte
+// reductions that the bulk feeds are otherwise downloaded to compute.
+//
+//	stats/network   the GET /all-transports/stats shape (138 B live)
+//	stats/versions  the GET /version fleet histogram (300 B live)
+//
+// Why a separate feed rather than another path on an existing one: size
+// is cadence. The metrics and all-transports feeds are staggered to
+// minutes because recomputing them is expensive; these two bodies are a
+// few hundred bytes and cost a map walk over caches the HTTP handlers
+// already read, so they republish every statsPublishInterval. A chart
+// that wants "transports on the network, every 15 seconds" costs ~400 B
+// per sample here instead of the 2.4 MB all-transports snapshot or the
+// 16.8 MB metrics window it would otherwise reduce locally.
+//
+// The per-key rollup (GET /all-transports/per-key-stats, ~38 KB gzipped)
+// is deliberately NOT here. It is two orders of magnitude larger than
+// these bodies and belongs on its own slower tier; putting it on this
+// feed would drag the whole feed onto the large-feed first-sync budget
+// and defeat the point of a feed a dashboard can hold continuously.
+//
+// PARTIAL-AGGREGATE HAZARD (skycoin/skywire#4513). TPD's transport
+// aggregate is READABLE WHILE IT REFILLS after a restart: the count
+// climbs monotonically from near zero to its settled value, every type
+// diluted in proportion, with nothing in the body to say it is partial.
+// TPD restarts on every deploy, so a naive publisher at this cadence
+// would stamp a permanent sawtooth into every time series built on it.
+// This publisher therefore judges each sample against a trailing peak
+// (see completenessTracker) and:
+//
+//   - stamps every body with observed_at, complete, confidence and the
+//     trailing peak it was judged against, so a consumer can filter;
+//   - HOLDS the last complete sample on the feed rather than overwriting
+//     it with one that looks partial, for up to statsIncompleteHoldover.
+//
+// The holdover bound rather than an indefinite hold is deliberate: a
+// genuine network-wide drop below the trailing peak (a dmsg server
+// outage, say) is indistinguishable from a refill at sample time, and a
+// feed that silently freezes on real news is worse than one that
+// publishes the news marked complete=false. After the bound the sample
+// goes out with its honest verdict attached.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/deployment/tpd/store"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// Published paths. Exported so visor-side subscribers don't have to
+// duplicate the strings.
+const (
+	// StatsPathNetwork carries the network-wide transport aggregate
+	// (the GET /all-transports/stats shape plus a completeness stamp).
+	StatsPathNetwork = "stats/network"
+	// StatsPathVersions carries the fleet version histogram (the
+	// GET /version shape plus a completeness stamp).
+	StatsPathVersions = "stats/versions"
+)
+
+// statsPublishInterval is the recompute cadence. Both bodies are read
+// off caches the HTTP handlers already serve from and reduce to a few
+// hundred bytes, so unlike the metrics/uptime publishers (60s, because
+// the recompute itself is the cost) this can run at time-series
+// resolution. 12s keeps a chart live without making the tick a
+// meaningful fraction of TPD's cache-refresh period.
+const statsPublishInterval = 12 * time.Second
+
+// Completeness-judgment tunables. See completenessTracker.
+const (
+	// statsTrailingWindow is how far back the peak a sample is judged
+	// against is remembered. Wide enough to span several refill
+	// sawteeth (#4513 observed a ~36 minute band of them) so a reset
+	// does not reset the yardstick with it.
+	statsTrailingWindow = 15 * time.Minute
+
+	// statsCompleteRatio is the fraction of the trailing peak a sample
+	// must reach to be called complete. #4513 measured the refill
+	// passing through roughly half the settled value; 0.9 puts the
+	// verdict well clear of ordinary churn (the settled value moved
+	// ~1% between consecutive live samples) without demanding the peak
+	// be re-attained exactly.
+	statsCompleteRatio = 0.9
+
+	// statsWarmup is how long after the publisher starts every sample
+	// is reported complete=false regardless of value. The publisher
+	// starts with TPD, so its first minutes ARE the refill; without
+	// this the first sample would define the peak it is judged against
+	// and a partial set would certify itself.
+	statsWarmup = 2 * time.Minute
+
+	// statsIncompleteHoldover bounds how long a last-known-complete
+	// sample is held on the feed rather than being overwritten by one
+	// that looks partial.
+	statsIncompleteHoldover = 5 * time.Minute
+)
+
+// Confidence values stamped on a published body.
+const (
+	// ConfidenceSettled means the sample reached statsCompleteRatio of
+	// the trailing peak — safe to chart as an absolute count.
+	ConfidenceSettled = "settled"
+	// ConfidenceRefilling means the sample fell materially below the
+	// trailing peak. Under #4513 that is the signature of reading the
+	// aggregate mid-rebuild; treat the value as a lower bound.
+	ConfidenceRefilling = "refilling"
+	// ConfidenceWarmup means the publisher has not observed long
+	// enough to have a trustworthy peak to judge against.
+	ConfidenceWarmup = "warmup"
+)
+
+// NetworkStats is the body published at StatsPathNetwork. The first
+// three fields are store.TransportSummary verbatim — a consumer that
+// unmarshals this into store.TransportSummary gets exactly what
+// GET /all-transports/stats returns — and the rest is the completeness
+// stamp #4513 makes necessary.
+type NetworkStats struct {
+	Total        int            `json:"total_transports"`
+	ByType       map[string]int `json:"by_type"`
+	UniqueVisors int            `json:"unique_visors"`
+
+	ObservedAt time.Time `json:"observed_at"`
+	Complete   bool      `json:"complete"`
+	Confidence string    `json:"confidence"`
+	// TrailingPeak is the highest total_transports seen in the last
+	// TrailingWindowSeconds. Published so a consumer can apply its own
+	// threshold instead of trusting ours.
+	TrailingPeak          int `json:"trailing_peak_transports"`
+	TrailingWindowSeconds int `json:"trailing_window_seconds"`
+}
+
+// VersionStats is the body published at StatsPathVersions. Versions is
+// the GET /version body verbatim; the rest is the completeness stamp.
+// The histogram is derived from the uptime cache, not the transport
+// cache, so it carries its own independent verdict.
+type VersionStats struct {
+	Versions map[string]int `json:"versions"`
+	Visors   int            `json:"visors"`
+
+	ObservedAt time.Time `json:"observed_at"`
+	Complete   bool      `json:"complete"`
+	Confidence string    `json:"confidence"`
+	// TrailingPeak is the highest visor count seen in the last
+	// TrailingWindowSeconds.
+	TrailingPeak          int `json:"trailing_peak_visors"`
+	TrailingWindowSeconds int `json:"trailing_window_seconds"`
+}
+
+// StatsCXOPublisher publishes the two network-aggregate bodies on a
+// short cadence, gating each against its own completeness tracker.
+// Closed by Close.
+type StatsCXOPublisher struct {
+	api *API
+	pub *treestore.Publisher
+	log *logging.Logger
+
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	// Trackers and holdover state are touched only from the publish
+	// loop, which is single-goroutine; no lock needed for them.
+	transports completenessTracker
+	visors     completenessTracker
+	heldSince  map[string]time.Time
+
+	// putFn writes one already-gzipped leaf. Always s.pub.Put in
+	// production; a seam so the publish path (gzip, holdover, the set
+	// of paths written) is exercised by unit tests without standing up
+	// a DMSG client.
+	putFn func(path string, body []byte) error
+
+	mu        sync.Mutex
+	lastError error
+}
+
+// StartStatsCXOPublisher constructs a publisher backed by the given
+// DMSG client and TPD secret key, then kicks off the publish ticker.
+// The allowlist is left open (any subscriber may read) — same access
+// policy as the HTTP endpoints it mirrors.
+//
+// Best-effort: the HTTP routes stay the source of truth, so the caller
+// should log and continue if this returns an error.
+func StartStatsCXOPublisher(ctx context.Context, api *API, dmsgC *dmsg.Client, sk cipher.SecKey, logger logrus.FieldLogger) (*StatsCXOPublisher, error) {
+	log := logging.MustGetLogger("tpd-cxo-stats-pub")
+
+	pub, err := treestore.NewWithDMSG(dmsgC, sk, treestore.PubConfig{
+		Logger:     log,
+		InMemoryDB: true, // recomputed from the in-RAM caches each tick
+		DmsgPort:   skyenv.DmsgTPDStatsCXOPort,
+	})
+	if err != nil {
+		return nil, err
+	}
+	// nil allowlist = open feed (any subscriber accepted).
+	pub.SetAllowlist(nil)
+
+	pubCtx, cancel := context.WithCancel(ctx)
+	sp := &StatsCXOPublisher{
+		api:        api,
+		pub:        pub,
+		log:        log,
+		cancel:     cancel,
+		done:       make(chan struct{}),
+		transports: newCompletenessTracker(time.Now()),
+		visors:     newCompletenessTracker(time.Now()),
+		heldSince:  make(map[string]time.Time),
+	}
+	sp.putFn = pub.Put
+	if logger != nil {
+		logger.WithField("feed_pk", pub.Feed()).WithField("dmsg_port", skyenv.DmsgTPDStatsCXOPort).
+			Info("CXO stats publisher running")
+	}
+	go sp.loop(pubCtx)
+	return sp, nil
+}
+
+// FeedPK returns the publisher's feed PK (TPD's own PK). Subscribers
+// connect to this PK at port skyenv.DmsgTPDStatsCXOPort.
+func (s *StatsCXOPublisher) FeedPK() cipher.PubKey { return s.pub.Feed() }
+
+// Close stops the ticker and tears down the publisher.
+func (s *StatsCXOPublisher) Close() error {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	<-s.done
+	return s.pub.Close()
+}
+
+func (s *StatsCXOPublisher) loop(ctx context.Context) {
+	defer close(s.done)
+
+	// Publish once immediately so a freshly-connected subscriber gets a
+	// snapshot without waiting a full tick. It will be stamped
+	// confidence=warmup, which is the honest answer this early.
+	s.publishOnce(ctx)
+
+	t := time.NewTicker(statsPublishInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.publishOnce(ctx)
+		}
+	}
+}
+
+func (s *StatsCXOPublisher) publishOnce(ctx context.Context) {
+	now := time.Now().UTC()
+	s.publishNetwork(ctx, now)
+	s.publishVersions(now)
+}
+
+// publishNetwork writes StatsPathNetwork. It reads the same warm cache
+// GET /all-transports/stats counts off, falling back to the store's
+// single-pass summary when the cache is cold — so the published numbers
+// and the HTTP numbers come from one source, not two.
+func (s *StatsCXOPublisher) publishNetwork(ctx context.Context, now time.Time) {
+	summary := s.networkSummary(ctx)
+	if summary == nil {
+		return
+	}
+	verdict := s.transports.observe(now, summary.Total)
+	body := NetworkStats{
+		Total:                 summary.Total,
+		ByType:                summary.ByType,
+		UniqueVisors:          summary.UniqueVisors,
+		ObservedAt:            now,
+		Complete:              verdict.complete,
+		Confidence:            verdict.confidence,
+		TrailingPeak:          verdict.peak,
+		TrailingWindowSeconds: int(statsTrailingWindow / time.Second),
+	}
+	s.put(StatsPathNetwork, body, verdict.complete, now)
+}
+
+// networkSummary mirrors getAllTransportsStats' source selection: warm
+// cache first, store summary on a cold cache. Self-transports are
+// included, matching the endpoint's default.
+func (s *StatsCXOPublisher) networkSummary(ctx context.Context) *store.TransportSummary {
+	if entries := s.api.getTransportsFromCache(true); entries != nil {
+		summary := &store.TransportSummary{ByType: make(map[string]int)}
+		uniqueVisors := make(map[cipher.PubKey]struct{})
+		for _, entry := range entries {
+			summary.Total++
+			summary.ByType[string(entry.Type)]++
+			for _, edge := range entry.Edges {
+				uniqueVisors[edge] = struct{}{}
+			}
+		}
+		summary.UniqueVisors = len(uniqueVisors)
+		return summary
+	}
+	summary, err := s.api.store.GetTransportSummary(ctx, true)
+	if err != nil {
+		s.log.WithError(err).Debug("network stats summary failed; will retry next tick")
+		s.recordError(err)
+		return nil
+	}
+	return summary
+}
+
+// publishVersions writes StatsPathVersions from the same uptime cache
+// GET /version reads, with no online filter (the endpoint's default).
+func (s *StatsCXOPublisher) publishVersions(now time.Time) {
+	uptimes := s.api.getUptimesFromCache()
+	versions := make(map[string]int, 32)
+	for _, vs := range uptimes {
+		version := vs.Version
+		if version == "" {
+			version = "unknown"
+		}
+		versions[version]++
+	}
+	verdict := s.visors.observe(now, len(uptimes))
+	body := VersionStats{
+		Versions:              versions,
+		Visors:                len(uptimes),
+		ObservedAt:            now,
+		Complete:              verdict.complete,
+		Confidence:            verdict.confidence,
+		TrailingPeak:          verdict.peak,
+		TrailingWindowSeconds: int(statsTrailingWindow / time.Second),
+	}
+	s.put(StatsPathVersions, body, verdict.complete, now)
+}
+
+// put gzips and writes one body, applying the incomplete-sample
+// holdover: while a complete sample published within
+// statsIncompleteHoldover still stands on the feed, an incomplete one
+// is dropped rather than overwriting it. Past that bound the incomplete
+// sample is published with its complete=false stamp, so a feed never
+// freezes indefinitely on what might be real news.
+func (s *StatsCXOPublisher) put(path string, body interface{}, complete bool, now time.Time) {
+	if !complete {
+		if held, ok := s.heldSince[path]; ok && now.Sub(held) < statsIncompleteHoldover {
+			s.log.WithField("path", path).Debug("holding last complete stats sample; this one looks partial")
+			return
+		}
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		s.log.WithError(err).WithField("path", path).Warn("stats marshal failed")
+		s.recordError(err)
+		return
+	}
+	// gzip before Put: CXO stores and propagates object bytes verbatim,
+	// so a raw JSON body travels uncompressed. Subscribers auto-detect
+	// and gunzip (cxoutils.Gunzip). Matches every sibling publisher.
+	if err := s.putFn(path, cxoutils.Gzip(raw)); err != nil {
+		s.log.WithError(err).WithField("path", path).Warn("stats publisher Put failed")
+		s.recordError(err)
+		return
+	}
+	if complete {
+		s.heldSince[path] = now
+	} else {
+		// An incomplete sample now stands on the feed; there is no
+		// complete one left to hold, so the next tick may publish
+		// freely.
+		delete(s.heldSince, path)
+	}
+}
+
+func (s *StatsCXOPublisher) recordError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastError = err
+}
+
+// LastError returns the most recent error encountered by the publish
+// loop, or nil if the last tick succeeded for both paths.
+func (s *StatsCXOPublisher) LastError() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastError
+}
+
+// completenessVerdict is one sample's judgment.
+type completenessVerdict struct {
+	complete   bool
+	confidence string
+	peak       int
+}
+
+// completenessSample is one remembered observation.
+type completenessSample struct {
+	at    time.Time
+	value int
+}
+
+// completenessTracker decides whether an aggregate sample is settled or
+// still refilling, using the shape of the #4513 artifact: the count
+// climbs monotonically from near zero to a settled plateau, resets, and
+// climbs again. A sample well below the highest value seen recently is
+// therefore far more likely to be a partial read than a real collapse,
+// and a sample at or near that peak is the plateau.
+//
+// It deliberately does NOT try to detect the reset itself. A monotonic
+// -rise detector would call the first sample after a reset "complete"
+// (it has no predecessor to be lower than); a trailing peak has no such
+// blind spot, and it degrades gracefully — as the window ages past a
+// genuine network shrink, the peak follows the network down.
+//
+// Not safe for concurrent use; the publish loop is single-goroutine.
+type completenessTracker struct {
+	started time.Time
+	samples []completenessSample
+}
+
+func newCompletenessTracker(started time.Time) completenessTracker {
+	return completenessTracker{started: started}
+}
+
+// observe records a sample and returns its verdict.
+func (c *completenessTracker) observe(now time.Time, value int) completenessVerdict {
+	cutoff := now.Add(-statsTrailingWindow)
+	kept := c.samples[:0]
+	for _, s := range c.samples {
+		if !s.at.Before(cutoff) {
+			kept = append(kept, s)
+		}
+	}
+	c.samples = append(kept, completenessSample{at: now, value: value})
+
+	peak := 0
+	for _, s := range c.samples {
+		if s.value > peak {
+			peak = s.value
+		}
+	}
+
+	switch {
+	case now.Sub(c.started) < statsWarmup:
+		return completenessVerdict{complete: false, confidence: ConfidenceWarmup, peak: peak}
+	case float64(value) >= float64(peak)*statsCompleteRatio:
+		return completenessVerdict{complete: true, confidence: ConfidenceSettled, peak: peak}
+	default:
+		return completenessVerdict{complete: false, confidence: ConfidenceRefilling, peak: peak}
+	}
+}

--- a/pkg/deployment/tpd/api/cxo_stats_publisher_test.go
+++ b/pkg/deployment/tpd/api/cxo_stats_publisher_test.go
@@ -1,0 +1,433 @@
+// Package api pkg/deployment/tpd/api/cxo_stats_publisher_test.go c4-net-discovery
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/deployment/tpd/store"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// capturedPut is one leaf the publisher wrote.
+type capturedPut struct {
+	path string
+	body []byte
+}
+
+// newTestStatsPublisher builds a publisher with no DMSG/CXO node behind
+// it: putFn captures leaves instead of writing them, which is the whole
+// publish path minus the network.
+func newTestStatsPublisher(t *testing.T, api *API, started time.Time) (*StatsCXOPublisher, *[]capturedPut) {
+	t.Helper()
+	var puts []capturedPut
+	sp := &StatsCXOPublisher{
+		api:        api,
+		log:        logging.MustGetLogger("tpd-cxo-stats-pub-test"),
+		transports: newCompletenessTracker(started),
+		visors:     newCompletenessTracker(started),
+		heldSince:  make(map[string]time.Time),
+	}
+	sp.putFn = func(path string, body []byte) error {
+		puts = append(puts, capturedPut{path: path, body: append([]byte(nil), body...)})
+		return nil
+	}
+	return sp, &puts
+}
+
+// pkFromByte builds a distinct (invalid but distinct) PubKey per index,
+// which is all the aggregate counting needs.
+func pkFromByte(b byte) cipher.PubKey {
+	var pk cipher.PubKey
+	pk[0] = 0x02
+	pk[1] = b
+	return pk
+}
+
+// testEntries builds n transports across two types over n+1 visors.
+func testEntries(n int) []*transport.Entry {
+	out := make([]*transport.Entry, 0, n)
+	for i := 0; i < n; i++ {
+		tp := types.Type("stcpr")
+		if i%3 == 0 {
+			tp = types.Type("sudph")
+		}
+		out = append(out, &transport.Entry{
+			Edges: [2]cipher.PubKey{pkFromByte(byte(i)), pkFromByte(byte(i + 1))},
+			Type:  tp,
+		})
+	}
+	return out
+}
+
+func testUptimes() []store.VisorSummary {
+	return []store.VisorSummary{
+		{PK: pkFromByte(1), Online: true, Version: "v1.3.93"},
+		{PK: pkFromByte(2), Online: true, Version: "v1.3.93"},
+		{PK: pkFromByte(3), Online: false, Version: "v1.3.91"},
+		{PK: pkFromByte(4), Online: true, Version: ""}, // → "unknown"
+	}
+}
+
+// decodePut gunzips one captured leaf into a generic JSON object. It
+// asserts the body really was gzipped, which is the failure #4509
+// caught the hard way: CXO stores bytes verbatim, so a publisher that
+// forgets Gzip silently ships an uncompressed body that every reader's
+// Gunzip then passes through — the feed "works" while costing several
+// times what it should.
+func decodePut(t *testing.T, p capturedPut) map[string]interface{} {
+	t.Helper()
+	if len(p.body) < 2 || p.body[0] != 0x1f || p.body[1] != 0x8b {
+		t.Fatalf("%s: body is not gzipped (first bytes %x)", p.path, p.body[:min(2, len(p.body))])
+	}
+	raw := cxoutils.Gunzip(p.body)
+	if len(raw) == 0 || len(raw) == len(p.body) {
+		t.Fatalf("%s: Gunzip did not decompress the body", p.path)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("%s: published body is not JSON: %v", p.path, err)
+	}
+	return out
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// lastPutTo returns the most recent leaf written to path.
+func lastPutTo(puts []capturedPut, path string) (capturedPut, bool) {
+	for i := len(puts) - 1; i >= 0; i-- {
+		if puts[i].path == path {
+			return puts[i], true
+		}
+	}
+	return capturedPut{}, false
+}
+
+// TestNetworkStatsMatchesHTTPHandler pins the published body to the
+// GET /all-transports/stats body. Every key the handler emits must be
+// present in the published object with an equal value — the feed is
+// only a drop-in for the endpoint if a consumer can unmarshal it into
+// the same struct and get the same numbers.
+func TestNetworkStatsMatchesHTTPHandler(t *testing.T) {
+	api := &API{transportsCache: testEntries(30)}
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+
+	// Handler body.
+	rec := httptest.NewRecorder()
+	api.getAllTransportsStats(rec, httptest.NewRequest(http.MethodGet, "/all-transports/stats", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handler status = %d, want 200", rec.Code)
+	}
+	var handlerBody map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &handlerBody); err != nil {
+		t.Fatalf("handler body not JSON: %v", err)
+	}
+
+	// Published body. Past warmup so the sample is judged on value.
+	sp, puts := newTestStatsPublisher(t, api, now.Add(-time.Hour))
+	sp.publishNetwork(context.Background(), now)
+
+	p, ok := lastPutTo(*puts, StatsPathNetwork)
+	if !ok {
+		t.Fatalf("nothing published to %s", StatsPathNetwork)
+	}
+	published := decodePut(t, p)
+
+	for k, want := range handlerBody {
+		got, present := published[k]
+		if !present {
+			t.Fatalf("published body is missing handler key %q", k)
+		}
+		if !jsonEqual(got, want) {
+			t.Fatalf("key %q: published %v, handler %v", k, got, want)
+		}
+	}
+
+	// And it unmarshals into the handler's own struct type.
+	var summary store.TransportSummary
+	raw := cxoutils.Gunzip(p.body)
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		t.Fatalf("published body does not unmarshal into store.TransportSummary: %v", err)
+	}
+	if summary.Total != 30 {
+		t.Fatalf("total_transports = %d, want 30", summary.Total)
+	}
+
+	// The completeness stamp #4513 requires is present and honest.
+	for _, k := range []string{"observed_at", "complete", "confidence", "trailing_peak_transports", "trailing_window_seconds"} {
+		if _, present := published[k]; !present {
+			t.Fatalf("published body is missing completeness field %q", k)
+		}
+	}
+	if published["confidence"] != ConfidenceSettled || published["complete"] != true {
+		t.Fatalf("first post-warmup sample should be settled+complete, got %v/%v",
+			published["confidence"], published["complete"])
+	}
+}
+
+// TestVersionStatsMatchesHTTPHandler pins the published histogram to
+// the GET /version body.
+func TestVersionStatsMatchesHTTPHandler(t *testing.T) {
+	api := &API{uptimesCache: testUptimes()}
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+
+	rec := httptest.NewRecorder()
+	api.getVersionStats(rec, httptest.NewRequest(http.MethodGet, "/version", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handler status = %d, want 200", rec.Code)
+	}
+	var handlerBody map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &handlerBody); err != nil {
+		t.Fatalf("handler body not JSON: %v", err)
+	}
+
+	sp, puts := newTestStatsPublisher(t, api, now.Add(-time.Hour))
+	sp.publishVersions(now)
+
+	p, ok := lastPutTo(*puts, StatsPathVersions)
+	if !ok {
+		t.Fatalf("nothing published to %s", StatsPathVersions)
+	}
+	published := decodePut(t, p)
+
+	versions, ok := published["versions"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("published versions is %T, want object", published["versions"])
+	}
+	if len(versions) != len(handlerBody) {
+		t.Fatalf("published %d versions, handler emitted %d", len(versions), len(handlerBody))
+	}
+	for k, want := range handlerBody {
+		if !jsonEqual(versions[k], want) {
+			t.Fatalf("version %q: published %v, handler %v", k, versions[k], want)
+		}
+	}
+	if versions["unknown"] == nil {
+		t.Fatalf("empty version should be bucketed as \"unknown\", got %v", versions)
+	}
+}
+
+func jsonEqual(a, b interface{}) bool {
+	ab, err1 := json.Marshal(a)
+	bb, err2 := json.Marshal(b)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return string(ab) == string(bb)
+}
+
+// TestStatsPublisherWritesOnlyFixedPaths guards the property that makes
+// stale-path retirement unnecessary here: the publisher writes exactly
+// two paths, overwriting them, no matter how the underlying data
+// changes. A leaf set that grew with the data (per-visor leaves, say)
+// would need a Delete pass to retire what fell out; a fixed pair does
+// not, and this fails the moment that stops being true.
+func TestStatsPublisherWritesOnlyFixedPaths(t *testing.T) {
+	api := &API{transportsCache: testEntries(20), uptimesCache: testUptimes()}
+	start := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	sp, puts := newTestStatsPublisher(t, api, start.Add(-time.Hour))
+
+	now := start
+	for i := 0; i < 20; i++ {
+		// Vary the data so a data-dependent path would show up.
+		api.transportsCache = testEntries(20 + i)
+		sp.publishNetwork(context.Background(), now)
+		sp.publishVersions(now)
+		now = now.Add(statsPublishInterval)
+	}
+
+	seen := make(map[string]int)
+	for _, p := range *puts {
+		seen[p.path]++
+	}
+	paths := make([]string, 0, len(seen))
+	for p := range seen {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	want := []string{StatsPathNetwork, StatsPathVersions}
+	if len(paths) != len(want) || paths[0] != want[0] || paths[1] != want[1] {
+		t.Fatalf("published paths = %v, want exactly %v", paths, want)
+	}
+	if seen[StatsPathNetwork] != 20 || seen[StatsPathVersions] != 20 {
+		t.Fatalf("expected 20 writes per path, got %v", seen)
+	}
+}
+
+// TestCompletenessTrackerVerdicts walks the tracker through the #4513
+// sawtooth: warm up, settle, get reset to a partial count, climb back.
+func TestCompletenessTrackerVerdicts(t *testing.T) {
+	start := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	c := newCompletenessTracker(start)
+
+	// Inside the warmup window nothing certifies itself, even at a value
+	// that would otherwise look like a plateau. This is the case that
+	// matters: the publisher starts WITH TPD, so its first samples are
+	// the refill.
+	v := c.observe(start.Add(30*time.Second), 5000)
+	if v.complete || v.confidence != ConfidenceWarmup {
+		t.Fatalf("in-warmup sample: got %+v, want incomplete/warmup", v)
+	}
+
+	// Past warmup, climbing toward the plateau.
+	now := start.Add(statsWarmup + time.Second)
+	for _, val := range []int{7045, 8119, 9959, 10647} {
+		v = c.observe(now, val)
+		now = now.Add(statsPublishInterval)
+	}
+	if !v.complete || v.confidence != ConfidenceSettled {
+		t.Fatalf("plateau sample: got %+v, want complete/settled", v)
+	}
+	if v.peak != 10647 {
+		t.Fatalf("peak = %d, want 10647", v.peak)
+	}
+
+	// Ordinary churn around the plateau stays settled.
+	v = c.observe(now, 10400)
+	now = now.Add(statsPublishInterval)
+	if !v.complete {
+		t.Fatalf("1%% dip below peak should stay complete: %+v", v)
+	}
+
+	// TPD restarts: the aggregate is readable while it refills, so the
+	// count collapses. That must NOT be certified.
+	v = c.observe(now, 5200)
+	now = now.Add(statsPublishInterval)
+	if v.complete || v.confidence != ConfidenceRefilling {
+		t.Fatalf("post-restart partial: got %+v, want incomplete/refilling", v)
+	}
+	if v.peak != 10647 {
+		t.Fatalf("peak should survive the reset, got %d", v.peak)
+	}
+
+	// Climbing back through the middle is still partial…
+	v = c.observe(now, 8000)
+	now = now.Add(statsPublishInterval)
+	if v.complete {
+		t.Fatalf("mid-refill sample should not be complete: %+v", v)
+	}
+	// …until it reaches the plateau again.
+	v = c.observe(now, 10500)
+	if !v.complete || v.confidence != ConfidenceSettled {
+		t.Fatalf("refilled sample: got %+v, want complete/settled", v)
+	}
+}
+
+// TestCompletenessTrackerPeakDecays checks the tracker degrades
+// gracefully rather than jamming: once the old peak ages out of the
+// trailing window, a genuinely smaller network settles at its new size
+// instead of being called partial forever.
+func TestCompletenessTrackerPeakDecays(t *testing.T) {
+	start := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	c := newCompletenessTracker(start)
+
+	now := start.Add(statsWarmup + time.Second)
+	c.observe(now, 10000)
+
+	// Half the network leaves for good.
+	now = now.Add(time.Minute)
+	if v := c.observe(now, 5000); v.complete {
+		t.Fatalf("immediately after a halving the sample is indistinguishable from a refill, must not be complete: %+v", v)
+	}
+
+	// Past the trailing window the old peak is gone and 5000 is the network.
+	now = now.Add(statsTrailingWindow + time.Minute)
+	v := c.observe(now, 5000)
+	if !v.complete || v.peak != 5000 {
+		t.Fatalf("after the window aged out: got %+v, want complete with peak 5000", v)
+	}
+}
+
+// TestStatsPublisherHoldsLastCompleteSample is the #4513 guarantee at
+// the feed level: while a complete sample stands, a partial one does
+// not overwrite it — so a subscriber reads the last known-good numbers
+// through a TPD restart instead of a sawtooth.
+func TestStatsPublisherHoldsLastCompleteSample(t *testing.T) {
+	api := &API{transportsCache: testEntries(1000)}
+	start := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	sp, puts := newTestStatsPublisher(t, api, start.Add(-time.Hour))
+
+	now := start
+	sp.publishNetwork(context.Background(), now)
+	if len(*puts) != 1 {
+		t.Fatalf("expected the settled sample to publish, got %d puts", len(*puts))
+	}
+	if body := decodePut(t, (*puts)[0]); body["complete"] != true {
+		t.Fatalf("first sample should be complete: %v", body)
+	}
+
+	// TPD restarts; the aggregate now reads a fraction of the set.
+	api.transportsCache = testEntries(300)
+	for i := 0; i < 5; i++ {
+		now = now.Add(statsPublishInterval)
+		sp.publishNetwork(context.Background(), now)
+	}
+	if len(*puts) != 1 {
+		t.Fatalf("partial samples must not overwrite the held complete one; got %d puts", len(*puts))
+	}
+
+	// Past the holdover bound the partial goes out — marked partial. A
+	// feed that froze forever on a real network change would be worse
+	// than one that publishes the change with its verdict attached.
+	now = now.Add(statsIncompleteHoldover)
+	sp.publishNetwork(context.Background(), now)
+	if len(*puts) != 2 {
+		t.Fatalf("after the holdover the partial sample should publish; got %d puts", len(*puts))
+	}
+	body := decodePut(t, (*puts)[1])
+	if body["complete"] != false || body["confidence"] != ConfidenceRefilling {
+		t.Fatalf("held-over sample must be stamped incomplete/refilling, got %v/%v",
+			body["complete"], body["confidence"])
+	}
+	if body["total_transports"] != float64(300) {
+		t.Fatalf("held-over sample should carry the observed value, got %v", body["total_transports"])
+	}
+
+	// Recovery re-arms the hold.
+	api.transportsCache = testEntries(1000)
+	now = now.Add(statsPublishInterval)
+	sp.publishNetwork(context.Background(), now)
+	if len(*puts) != 3 {
+		t.Fatalf("recovered sample should publish; got %d puts", len(*puts))
+	}
+	if body := decodePut(t, (*puts)[2]); body["complete"] != true {
+		t.Fatalf("recovered sample should be complete: %v", body)
+	}
+	api.transportsCache = testEntries(300)
+	now = now.Add(statsPublishInterval)
+	sp.publishNetwork(context.Background(), now)
+	if len(*puts) != 3 {
+		t.Fatalf("hold should be re-armed after recovery; got %d puts", len(*puts))
+	}
+}
+
+// TestStatsBodiesAreSmall is the premise of the whole feed: these
+// republish every few seconds because they are tiny. If a body grows
+// past a kilobyte gzipped, the cadence needs revisiting.
+func TestStatsBodiesAreSmall(t *testing.T) {
+	api := &API{transportsCache: testEntries(200), uptimesCache: testUptimes()}
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	sp, puts := newTestStatsPublisher(t, api, now.Add(-time.Hour))
+	sp.publishNetwork(context.Background(), now)
+	sp.publishVersions(now)
+
+	for _, p := range *puts {
+		if len(p.body) > 1024 {
+			t.Fatalf("%s: gzipped body is %d bytes; this feed's cadence assumes sub-kilobyte", p.path, len(p.body))
+		}
+	}
+}

--- a/pkg/services/tpd/tpd.go
+++ b/pkg/services/tpd/tpd.go
@@ -341,6 +341,15 @@ func (s *service) startCXO(
 			pub.Close() //nolint:errcheck,gosec
 		}()
 	}
+
+	if pub, perr := api.StartStatsCXOPublisher(ctx, tpdAPI, h.DmsgClient, sk, logger); perr != nil {
+		logger.WithError(perr).Error("Failed to start CXO stats publisher, continuing without it")
+	} else {
+		go func() {
+			<-ctx.Done()
+			pub.Close() //nolint:errcheck,gosec
+		}()
+	}
 }
 
 // aggregatorSink composes the cxoaggregator.Sink contract from the

--- a/pkg/skyenv/ports_test.go
+++ b/pkg/skyenv/ports_test.go
@@ -37,6 +37,7 @@ func TestVisorPortsAreUnique(t *testing.T) {
 		"DmsgSDServicesCXOPort":           DmsgSDServicesCXOPort,
 		"DmsgDMSGDClientsByServerCXOPort": DmsgDMSGDClientsByServerCXOPort,
 		"DmsgTPDAllTransportsCXOPort":     DmsgTPDAllTransportsCXOPort,
+		"DmsgTPDStatsCXOPort":             DmsgTPDStatsCXOPort,
 		"DmsgDMSGDRegistrationCXOPort":    DmsgDMSGDRegistrationCXOPort,
 		"DmsgVisorARBindCXOPort":          DmsgVisorARBindCXOPort,
 		"DmsgVisorSDRegCXOPort":           DmsgVisorSDRegCXOPort,

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -108,6 +108,17 @@ const (
 	// subscribe to one TPD feed without dragging in the others.
 	DmsgTPDAllTransportsCXOPort uint16 = 55
 
+	// DmsgTPDStatsCXOPort is the DMSG port the TPD's CXO network-aggregate
+	// stats publisher listens on. It carries the sub-kilobyte reductions the
+	// bulk feeds are otherwise downloaded to compute — the /all-transports/stats
+	// by-type counts and the /version fleet histogram — so a chart costs a few
+	// hundred bytes every few seconds instead of megabytes every few minutes.
+	// Distinct port from DmsgTPDAllTransportsCXOPort so a dashboard can hold
+	// the tiny feed continuously without dragging in the 8 MB snapshot.
+	// Numbered 73 (the 50–55 CXO block and 56–72 are all taken); the value
+	// only needs to be collision-free, which ports_test guards.
+	DmsgTPDStatsCXOPort uint16 = 73
+
 	// DmsgDMSGDRegistrationCXOPort is the dmsg port the dmsg-discovery's CXO
 	// client-entry REGISTRATION aggregator binds (and each visor's entry
 	// publisher binds for the reverse subscribe). A visor publishes its own

--- a/pkg/tpviz/cxo_standalone.go
+++ b/pkg/tpviz/cxo_standalone.go
@@ -58,7 +58,7 @@ func (s *Server) SetCXOSubMgrFromDmsg(dmsgC *dmsg.Client) {
 		}
 		var pk cipher.PubKey
 		switch f {
-		case cxosub.FeedTPDMetrics, cxosub.FeedTPDUptime, cxosub.FeedTPDAllTransports:
+		case cxosub.FeedTPDMetrics, cxosub.FeedTPDUptime, cxosub.FeedTPDAllTransports, cxosub.FeedTPDStats:
 			pk = tpd
 		case cxosub.FeedSDServices:
 			pk = sd
@@ -84,7 +84,9 @@ func (s *Server) SetCXOSubMgrFromDmsg(dmsgC *dmsg.Client) {
 type standaloneCXOAdapter struct{ m *cxosub.Manager }
 
 func (a *standaloneCXOAdapter) AcquireForTab(tab int) { a.m.AcquireFor(cxosub.Tab(tab)) }
+
 func (a *standaloneCXOAdapter) ReleaseForTab(tab int) { a.m.ReleaseFor(cxosub.Tab(tab)) }
+
 func (a *standaloneCXOAdapter) Walk(feed int, prefix string, fn func(path string, body []byte) bool) bool {
 	return a.m.Walk(cxosub.Feed(feed), prefix, fn)
 }

--- a/pkg/tpviz/cxo_subscriber.go
+++ b/pkg/tpviz/cxo_subscriber.go
@@ -40,6 +40,7 @@ const (
 	CXOFeedSDServices           = 2 // services/<type>/all (batched; legacy .../<pk>/entry)
 	CXOFeedDMSGDClientsByServer = 3 // clients-by-server/<server> (batched; legacy .../<client>/entry)
 	CXOFeedTPDAllTransports     = 4 // transports/all/{with-self,without-self}
+	CXOFeedTPDStats             = 5 // stats/{network,versions} — network aggregates
 )
 
 // CXOSubMgr is the minimal slice of pkg/visor.CXOSubscriptionManager

--- a/pkg/visor/api_fetch_cxo.go
+++ b/pkg/visor/api_fetch_cxo.go
@@ -120,6 +120,22 @@ func (v *Visor) FetchCXO(args FetchCXOArgs) (*FetchCXOResult, error) {
 		}
 		return &FetchCXOResult{Hit: true, Body: body, LastRootAt: time.Now()}, nil
 
+	case "tpd-stats":
+		// Path is "network" or "versions". Bodies are sub-kilobyte and
+		// republished every ~12s, so LastRootAt is a real freshness
+		// signal here rather than the wall clock the bulk feeds report.
+		if _, ok := statsPathForKind(args.Path); !ok {
+			return &FetchCXOResult{Reason: "invalid path for tpd-stats: " + args.Path}, nil
+		}
+		body, ts, err := v.FetchTPDStatsCXO(args.Path)
+		if err != nil {
+			if errors.Is(err, ErrTPDStatsNotReady) {
+				return &FetchCXOResult{Reason: "tpd-stats: cache miss"}, nil
+			}
+			return &FetchCXOResult{Reason: "tpd-stats: " + err.Error()}, nil
+		}
+		return &FetchCXOResult{Hit: true, Body: body, LastRootAt: ts}, nil
+
 	default:
 		return &FetchCXOResult{Reason: "unknown feed: " + args.Feed}, nil
 	}
@@ -154,7 +170,7 @@ func (v *Visor) CXORefreshFeed(args CXORefreshArgs) (*FeedStatus, error) {
 	}
 	feed, ok := CXOFeedFromString(args.Feed)
 	if !ok {
-		return nil, fmt.Errorf("unknown feed %q (valid: tpd-metrics, tpd-uptime, sd-services, dmsgd-clients-by-server, tpd-all-transports)", args.Feed)
+		return nil, fmt.Errorf("unknown feed %q (valid: tpd-metrics, tpd-uptime, sd-services, dmsgd-clients-by-server, tpd-all-transports, tpd-stats)", args.Feed)
 	}
 	timeout := args.Timeout
 	if timeout <= 0 {

--- a/pkg/visor/api_tpd_stats_subscriber.go
+++ b/pkg/visor/api_tpd_stats_subscriber.go
@@ -1,0 +1,113 @@
+// Package visor pkg/visor/api_tpd_stats_subscriber.go c3-vis-core
+//
+// Reader-side helper for TPD's network-aggregate stats feed. The
+// publisher lives in pkg/deployment/tpd/api/cxo_stats_publisher.go and
+// writes two gzipped sub-kilobyte leaves:
+//
+//	stats/network   the GET /all-transports/stats shape
+//	stats/versions  the GET /version fleet histogram
+//
+// Both carry a completeness stamp (observed_at / complete / confidence
+// / trailing peak) that the reader passes through untouched — deciding
+// whether a partial sample is usable is the consumer's call, not the
+// visor's, and stripping the stamp here would recreate exactly the
+// blind spot skycoin/skywire#4513 describes.
+//
+// The subscription itself lives in the unified CXOSubscriptionManager;
+// this is a thin facade that AcquireFor's TabNetworkStats and serves
+// the cached blob.
+package visor
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	tpdapi "github.com/skycoin/skywire/pkg/deployment/tpd/api"
+)
+
+// ErrTPDStatsNotReady is returned when the CXO subscriber has nothing
+// for the requested path yet (no manager, no TPD PK, hasn't synced).
+// Callers treat it as a cache miss and fall through to HTTP.
+var ErrTPDStatsNotReady = errors.New("tpd stats: cxo cache miss")
+
+// StatsKindNetwork and StatsKindVersions are the short path names the
+// RPC/CLI layer uses, mirroring tpd-all-transports' with-self /
+// without-self.
+const (
+	StatsKindNetwork  = "network"
+	StatsKindVersions = "versions"
+)
+
+// statsPathForKind maps a short kind to the publisher's TreeStore path.
+// ok is false for anything else, which the caller reports as an invalid
+// path rather than syncing a feed for a leaf that cannot exist.
+func statsPathForKind(kind string) (string, bool) {
+	switch kind {
+	case StatsKindNetwork:
+		return tpdapi.StatsPathNetwork, true
+	case StatsKindVersions:
+		return tpdapi.StatsPathVersions, true
+	}
+	return "", false
+}
+
+// FetchTPDStatsCXO returns the JSON body for one aggregate — (bytes,
+// lastRootAt, nil) on a hit, (nil, zero, ErrTPDStatsNotReady) when the
+// feed has nothing to serve it from.
+//
+// The publisher republishes every ~12s, so lastRootAt doubles as a
+// liveness signal: a root much older than that means the subscription,
+// not the network, went quiet.
+func (v *Visor) FetchTPDStatsCXO(kind string) ([]byte, time.Time, error) {
+	path, ok := statsPathForKind(kind)
+	if !ok {
+		return nil, time.Time{}, ErrTPDStatsNotReady
+	}
+	mgr := v.CXOSubMgr()
+	if mgr == nil {
+		return nil, time.Time{}, ErrTPDStatsNotReady
+	}
+	mgr.AcquireFor(TabNetworkStats)
+	defer mgr.ReleaseFor(TabNetworkStats)
+
+	if body, ts, ok := readStatsLeaf(mgr, path); ok {
+		return body, ts, nil
+	}
+	// Cold snapshot: AcquireFor only started the cycle. Block briefly for the
+	// first sync (over dmsg) so CXO serves this call instead of the caller
+	// falling back to dmsg-http. These are sub-kilobyte leaves, so the short
+	// FirstSyncTimeout applies — no large-feed budget for this feed.
+	ctx, cancel := context.WithTimeout(context.Background(), feedFirstSyncTimeout(FeedTPDStats))
+	_, _ = mgr.RefreshNow(ctx, FeedTPDStats) //nolint:errcheck
+	cancel()
+	if body, ts, ok := readStatsLeaf(mgr, path); ok {
+		return body, ts, nil
+	}
+	return nil, time.Time{}, ErrTPDStatsNotReady
+}
+
+// statsSnapshot is the slice of the CXO subscription manager
+// readStatsLeaf needs. An interface so the read path is unit-testable
+// against a plain map instead of a live DMSG subscription.
+type statsSnapshot interface {
+	Get(feed CXOFeed, path string) ([]byte, time.Time, bool)
+}
+
+// readStatsLeaf serves one leaf, decompressing it. Gunzip passes a raw
+// body through unchanged, so this reads both the gzipped bodies the
+// publisher writes and any uncompressed ones an older publisher left.
+func readStatsLeaf(mgr statsSnapshot, path string) ([]byte, time.Time, bool) {
+	body, ts, ok := mgr.Get(FeedTPDStats, path)
+	if !ok || len(body) == 0 {
+		return nil, time.Time{}, false
+	}
+	decoded := cxoutils.Gunzip(body)
+	if len(decoded) == 0 {
+		return nil, time.Time{}, false
+	}
+	// Walk/Get lend the snapshot's bytes and Gunzip of a raw body returns
+	// that same slice, so copy before handing it to an RPC marshaller.
+	return append([]byte(nil), decoded...), ts, true
+}

--- a/pkg/visor/api_tpd_stats_subscriber_test.go
+++ b/pkg/visor/api_tpd_stats_subscriber_test.go
@@ -1,0 +1,137 @@
+// Package visor pkg/visor/api_tpd_stats_subscriber_test.go c3-vis-core
+package visor
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	tpdapi "github.com/skycoin/skywire/pkg/deployment/tpd/api"
+)
+
+// fakeStatsSnapshot serves canned leaves in place of a live CXO
+// subscription.
+type fakeStatsSnapshot struct {
+	bodies map[string][]byte
+	at     time.Time
+}
+
+func (f fakeStatsSnapshot) Get(_ CXOFeed, path string) ([]byte, time.Time, bool) {
+	b, ok := f.bodies[path]
+	if !ok {
+		return nil, time.Time{}, false
+	}
+	return b, f.at, true
+}
+
+func TestStatsPathForKind(t *testing.T) {
+	// The kinds the CLI accepts must resolve to the paths the TPD
+	// publisher actually writes — the two constants are the contract
+	// between the two packages.
+	for kind, want := range map[string]string{
+		StatsKindNetwork:  tpdapi.StatsPathNetwork,
+		StatsKindVersions: tpdapi.StatsPathVersions,
+	} {
+		got, ok := statsPathForKind(kind)
+		if !ok || got != want {
+			t.Fatalf("statsPathForKind(%q) = (%q, %v), want (%q, true)", kind, got, ok, want)
+		}
+	}
+	// Anything else is rejected before a feed is synced for a leaf that
+	// cannot exist.
+	for _, bad := range []string{"", "stats/network", "per-key", "with-self"} {
+		if _, ok := statsPathForKind(bad); ok {
+			t.Fatalf("statsPathForKind(%q) unexpectedly resolved", bad)
+		}
+	}
+}
+
+// TestReadStatsLeafRoundTrip is the reader half of the gzip contract:
+// what the publisher Gzips, the reader Gunzips back to the exact JSON,
+// completeness stamp intact.
+func TestReadStatsLeafRoundTrip(t *testing.T) {
+	want := tpdapi.NetworkStats{
+		Total:                 10423,
+		ByType:                map[string]int{"stcpr": 2405, "sudph": 3868},
+		UniqueVisors:          930,
+		ObservedAt:            time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC),
+		Complete:              true,
+		Confidence:            tpdapi.ConfidenceSettled,
+		TrailingPeak:          10500,
+		TrailingWindowSeconds: 900,
+	}
+	raw, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	at := time.Date(2026, 9, 4, 12, 0, 12, 0, time.UTC)
+	mgr := fakeStatsSnapshot{
+		bodies: map[string][]byte{tpdapi.StatsPathNetwork: cxoutils.Gzip(raw)},
+		at:     at,
+	}
+
+	body, ts, ok := readStatsLeaf(mgr, tpdapi.StatsPathNetwork)
+	if !ok {
+		t.Fatal("readStatsLeaf missed a present leaf")
+	}
+	if !ts.Equal(at) {
+		t.Fatalf("last-root time = %v, want %v", ts, at)
+	}
+	var got tpdapi.NetworkStats
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decoded body is not the published shape: %v", err)
+	}
+	if got.Total != want.Total || got.UniqueVisors != want.UniqueVisors {
+		t.Fatalf("counts round-tripped wrong: %+v", got)
+	}
+	if !got.Complete || got.Confidence != tpdapi.ConfidenceSettled || got.TrailingPeak != want.TrailingPeak {
+		t.Fatalf("completeness stamp lost in transit: %+v", got)
+	}
+	if !got.ObservedAt.Equal(want.ObservedAt) {
+		t.Fatalf("observed_at = %v, want %v", got.ObservedAt, want.ObservedAt)
+	}
+}
+
+// TestReadStatsLeafPassesRawThrough covers a publisher that has not
+// been updated to gzip yet: Gunzip returns a non-gzip body unchanged,
+// so the reader must still serve it rather than treating it as garbage.
+func TestReadStatsLeafPassesRawThrough(t *testing.T) {
+	raw := []byte(`{"total_transports":42,"by_type":{},"unique_visors":7}`)
+	mgr := fakeStatsSnapshot{bodies: map[string][]byte{tpdapi.StatsPathVersions: raw}}
+	body, _, ok := readStatsLeaf(mgr, tpdapi.StatsPathVersions)
+	if !ok || string(body) != string(raw) {
+		t.Fatalf("raw body did not pass through: ok=%v body=%q", ok, body)
+	}
+}
+
+// TestReadStatsLeafMisses covers the miss paths the FetchCXO case turns
+// into a cache-miss reason rather than an error.
+func TestReadStatsLeafMisses(t *testing.T) {
+	mgr := fakeStatsSnapshot{bodies: map[string][]byte{
+		tpdapi.StatsPathNetwork: nil, // present but empty
+	}}
+	if _, _, ok := readStatsLeaf(mgr, tpdapi.StatsPathNetwork); ok {
+		t.Fatal("an empty leaf must read as a miss")
+	}
+	if _, _, ok := readStatsLeaf(mgr, tpdapi.StatsPathVersions); ok {
+		t.Fatal("an absent leaf must read as a miss")
+	}
+}
+
+// TestReadStatsLeafCopiesBody guards against handing the RPC layer a
+// slice the snapshot still owns — Get lends its bytes, and Gunzip of a
+// raw body returns that same slice.
+func TestReadStatsLeafCopiesBody(t *testing.T) {
+	raw := []byte(`{"versions":{"v1.3.93":591},"visors":591}`)
+	stored := append([]byte(nil), raw...)
+	mgr := fakeStatsSnapshot{bodies: map[string][]byte{tpdapi.StatsPathVersions: stored}}
+	body, _, ok := readStatsLeaf(mgr, tpdapi.StatsPathVersions)
+	if !ok {
+		t.Fatal("unexpected miss")
+	}
+	stored[0] = 'X'
+	if string(body) != string(raw) {
+		t.Fatalf("returned body aliases the snapshot: %q", body)
+	}
+}

--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -47,6 +47,7 @@ const (
 	FeedSDServices           = cxosub.FeedSDServices
 	FeedDMSGDClientsByServer = cxosub.FeedDMSGDClientsByServer
 	FeedTPDAllTransports     = cxosub.FeedTPDAllTransports
+	FeedTPDStats             = cxosub.FeedTPDStats
 )
 
 // Re-exported tab constants.
@@ -59,6 +60,7 @@ const (
 	TabCLITransports     = cxosub.TabCLITransports
 	TabRoutingPolicy     = cxosub.TabRoutingPolicy
 	TabDmsgEntryLookup   = cxosub.TabDmsgEntryLookup
+	TabNetworkStats      = cxosub.TabNetworkStats
 )
 
 // feedFirstSyncTimeout forwards to cxosub so the RPC fetch/refresh default
@@ -156,6 +158,12 @@ func (v *Visor) cxoFeedSpec(fk cxosub.Feed) (cipher.PubKey, uint16, string, erro
 			return cipher.PubKey{}, 0, "", errors.New("no TPD CXO peer (transport.discovery_dmsg unset)")
 		}
 		return pk, skyenv.DmsgTPDAllTransportsCXOPort, "transports/all/", nil
+	case FeedTPDStats:
+		pk, ok := tpdCXOPeer(v)
+		if !ok {
+			return cipher.PubKey{}, 0, "", errors.New("no TPD CXO peer (transport.discovery_dmsg unset)")
+		}
+		return pk, skyenv.DmsgTPDStatsCXOPort, "stats/", nil
 	}
 	return cipher.PubKey{}, 0, "", fmt.Errorf("unknown feed: %d", fk)
 }

--- a/pkg/visor/helpers_test.go
+++ b/pkg/visor/helpers_test.go
@@ -26,7 +26,7 @@ import (
 func TestCXOFeedStringRoundTrip(t *testing.T) {
 	feeds := []CXOFeed{
 		FeedTPDMetrics, FeedTPDUptime, FeedSDServices,
-		FeedDMSGDClientsByServer, FeedTPDAllTransports,
+		FeedDMSGDClientsByServer, FeedTPDAllTransports, FeedTPDStats,
 	}
 	for _, f := range feeds {
 		name := CXOFeedString(f)


### PR DESCRIPTION
Closes #4514.

Every network-level number worth charting is today obtainable only by downloading a bulk dataset and reducing it locally. To learn "how many transports are on the network" a subscriber pulls 2.4 MB (the all-transports snapshot) or 16.8 MB (a metrics window) to compute a value TPD already holds in 138 bytes.

New `tpd-stats` feed — dmsg port 73, path prefix `stats/`, publisher in `pkg/deployment/tpd/api/cxo_stats_publisher.go`:

| path | source handler | live payload |
| --- | --- | --- |
| `stats/network` | `getAllTransportsStats` | 138 B |
| `stats/versions` | `getVersionStats` | 300 B |

Both gzipped (`cxoutils.Gzip`, as every sibling publisher does), both well under 1 KB, republished every **12 seconds**. The cadence is the point: these reduce off caches the HTTP handlers already serve from, so unlike the metrics windows there is nothing expensive to stagger.

The per-key rollup is deliberately **not** on this feed. At ~38 KB gzipped it is two orders of magnitude larger than these bodies, belongs on the ~minute tier the issue describes, and putting it here would push the whole feed onto `largeFeedFirstSyncTimeout` — defeating the point of a feed a dashboard holds continuously. It stays on the short `FirstSyncTimeout`.

## The #4513 partial-aggregate hazard

TPD's transport aggregate is readable while it refills after a restart, so a caller can get a partial count with no way to tell. At a 12s cadence a naive publisher would stamp that sawtooth permanently into every chart built on the feed. So the publisher does both things the issue asks for:

- **Stamp.** Each body carries `observed_at`, `complete`, `confidence` (`settled` / `refilling` / `warmup`), and the `trailing_peak_*` it was judged against, so a consumer can apply its own threshold. The first three fields of `stats/network` are `store.TransportSummary` verbatim, so an existing consumer unmarshals it unchanged.
- **Suppress.** A sample below 90% of the highest value seen in the last 15 minutes is judged partial and does **not** overwrite a standing complete sample — subscribers keep reading the last known-good numbers through a TPD restart.

The suppression is bounded at 5 minutes rather than indefinite, and that is the deliberate part. A genuine network-wide drop is indistinguishable from a refill at sample time, so a feed that freezes forever on the first big decline would be worse than one that publishes it marked `complete=false`. Past the bound the sample goes out with its honest verdict attached. A 2-minute warm-up covers the case where the publisher starts *with* TPD and its own first samples are the refill — without it the first partial sample would define the peak and certify itself.

This does not fix #4513 (TPD should still swap its aggregate in atomically); it stops the new feed from propagating the artifact as if it were data.

## Tests

`pkg/deployment/tpd/api/cxo_stats_publisher_test.go` drives the real publish path through a captured sink: bodies are asserted to be gzip and to round-trip; every key the HTTP handler emits must be present in the published body with an equal value (both handlers, via `httptest`); repeated ticks over changing data write exactly two paths, which is what makes stale-path retirement unnecessary here and will fail if that stops being true; the completeness tracker is walked through the #4513 sawtooth (warm-up, plateau, restart, climb back) and through a genuine halving to check the peak decays instead of jamming; the holdover is exercised end to end.

`pkg/visor/api_tpd_stats_subscriber_test.go` covers the reader half of the gzip contract, raw-body pass-through, miss paths, and that the returned body does not alias the snapshot. `cmd/skywire-cli/commands/rpc/cxo_feed_map_test.go` pins the URL rows, including that `?selfTransports=hide` and `?on=true` fall through to HTTP rather than being answered from a set the publisher never wrote.

`go build .`, `golangci-lint` and the affected package tests are clean.