### PR TITLE
feat(doc): serve the docs from the binary that they document

### DIFF
--- a/cmd/skywire/commands/doc/serve.go
+++ b/cmd/skywire/commands/doc/serve.go
@@ -1,0 +1,174 @@
+// Package doc cmd/skywire/commands/doc/serve.go c1-cli-doc
+// `skywire doc serve` — the documentation, served by the thing it documents.
+//
+// Two sources, one site:
+//
+//	/            the cobra tree, walked live by collect() — zero embedded
+//	             bytes, and it cannot drift from the binary because it IS the
+//	             binary's command tree
+//	/prose/…     the hand-written markdown embedded by package docs
+//
+// Why this exists rather than a link to the docs site: in the browser visor
+// the nested browser has no transport until someone starts a visor, so a
+// clearnet fetch of the docs strands on a placeholder (measured live). Served
+// on the virtual loopback this is a same-origin /vnet/<port>/ URL, which
+// netscrape's DirectLoader already claims for NATIVE rendering — so the docs
+// render with no visor running, no transport in the path, and the reader can
+// keep a terminal beside them.
+//
+// It emits HTML, not markdown. Browsers do not render markdown — a native
+// `skywire doc serve` is meant to be opened in an ordinary browser, and making
+// netscrape grow a private content type would make these docs readable only
+// inside skywire.
+package doc
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	ghtml "github.com/yuin/goldmark/renderer/html"
+
+	skydocs "github.com/skycoin/skywire/docs"
+)
+
+var serveAddr string
+
+func init() {
+	RootCmd.AddCommand(serveCmd)
+	// --addr, matching the 144 other commands that spell it that way (only
+	// four use --bind). The wording is the address-resolver's.
+	serveCmd.Flags().StringVarP(&serveAddr, "addr", "a", ":8085", "address to bind to")
+}
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Serve the CLI reference and prose docs over HTTP",
+	Long: `Serve this binary's own documentation.
+
+The command reference is generated from the live cobra tree on every
+request, so it always describes the binary serving it. The prose is the
+embedded docs/ markdown. Both are rendered to HTML.
+
+In the browser visor this binds the virtual loopback, so the nested
+browser reaches it at /vnet/<port>/ — a same-origin URL it renders
+natively, with no visor and no transport needed.
+
+  skywire doc serve                    # :8085
+  skywire doc serve --addr 127.0.0.1:9000`,
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableFlagsInUseLine: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		ln, err := net.Listen("tcp", serveAddr)
+		if err != nil {
+			return fmt.Errorf("doc serve: listen %s: %w", serveAddr, err)
+		}
+		cmd.Printf("serving docs on http://%s\n", ln.Addr())
+		return http.Serve(ln, docHandler(cmd.Root())) //nolint:gosec // long-lived docs server; no timeouts wanted on a loopback reader
+	},
+}
+
+// docHandler builds the site. The cobra tree is walked once per request
+// rather than cached: it is cheap, and a served page that disagrees with the
+// binary would defeat the point of generating it.
+func docHandler(root *cobra.Command) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/prose/", func(w http.ResponseWriter, r *http.Request) {
+		name := strings.TrimPrefix(r.URL.Path, "/prose/")
+		if name == "" {
+			writeHTML(w, "prose", proseIndex())
+			return
+		}
+		b, err := fs.ReadFile(skydocs.Prose(), name)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		writeHTML(w, name, mdToHTML(b))
+	})
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		var pages []page
+		collect(root, nil, &pages)
+
+		// URL path -> page. page.path() is the FILE layout ("cli/dmsg/cat/
+		// README.md"); the URL drops the README.md. Leaving path() alone keeps
+		// the file generator's contract untouched.
+		want := strings.Trim(r.URL.Path, "/")
+		for i := range pages {
+			if strings.Join(pages[i].segs, "/") == want {
+				var md bytes.Buffer
+				if err := render(&md, pages[i]); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				writeHTML(w, pages[i].title(), mdToHTML(md.Bytes()))
+				return
+			}
+		}
+		http.NotFound(w, r)
+	})
+
+	return mux
+}
+
+// proseIndex lists the embedded prose. A flat sorted list rather than a tree:
+// 102 files fit on a page, and a reader looking for one knows its name.
+func proseIndex() []byte {
+	var names []string
+	_ = fs.WalkDir(skydocs.Prose(), ".", func(p string, d fs.DirEntry, err error) error {
+		if err == nil && !d.IsDir() && strings.HasSuffix(p, ".md") {
+			names = append(names, p)
+		}
+		return nil
+	})
+	sort.Strings(names)
+	var b strings.Builder
+	b.WriteString("<h1>prose</h1><ul>")
+	for _, n := range names {
+		fmt.Fprintf(&b, "<li><a href=%q>%s</a></li>", "/prose/"+n, n)
+	}
+	b.WriteString("</ul>")
+	return []byte(b.String())
+}
+
+// mdToHTML renders markdown the way `skywire cli reward rules --html` already
+// does, so the two agree on what markdown means here.
+func mdToHTML(src []byte) []byte {
+	var buf bytes.Buffer
+	md := goldmark.New(
+		goldmark.WithExtensions(extension.Strikethrough, extension.Table),
+		goldmark.WithRendererOptions(ghtml.WithUnsafe()),
+	)
+	if err := md.Convert(src, &buf); err != nil {
+		return []byte("<pre>" + err.Error() + "</pre>")
+	}
+	return buf.Bytes()
+}
+
+// writeHTML wraps rendered markdown in a minimal document. No external assets:
+// this is served on a loopback with no transport behind it, so a stylesheet
+// from a CDN would simply never arrive.
+func writeHTML(w http.ResponseWriter, title string, body []byte) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<!doctype html><meta charset=utf-8>
+<meta name=viewport content="width=device-width,initial-scale=1">
+<title>%s</title><style>
+body{max-width:46em;margin:2em auto;padding:0 1em;font:15px/1.6 system-ui,sans-serif;color:#cdd2da;background:#15131c}
+a{color:#9d7cff}code{background:#221d2e;padding:.1em .3em;border-radius:3px}
+pre{background:#221d2e;padding:1em;overflow-x:auto;border-radius:4px}
+pre code{background:none;padding:0}
+table{border-collapse:collapse}td,th{border:1px solid #3a3350;padding:.3em .6em}
+nav{margin-bottom:2em;font-size:13px}
+</style><nav><a href="/">command reference</a> · <a href="/prose/">prose</a></nav>
+%s`, title, body)
+}

--- a/cmd/wasm-visor/desk_js.go
+++ b/cmd/wasm-visor/desk_js.go
@@ -89,33 +89,24 @@ func installDesk() {
 	// NATIVELY: without it netscrape would transcode the page into a sandboxed
 	// srcdoc, which strips the same-origin an Angular-style app needs.
 	//
-	// Claim the whole ORIGIN, not just /vnet/. Two pages want this and both are
-	// ours by definition — the origin is what this page is served from:
+	// Claim same-origin /vnet/ URLs ONLY — those are served by this page's own
+	// service worker out of the visor's virtual loopback, so they are ours to
+	// render. Two surfaces arrive that way: the hypervisor UI, and the docs,
+	// which `skywire doc serve` binds on the loopback so a reader browses them
+	// inside the visor with a terminal beside them.
 	//
-	//   /vnet/<port>/…  the visor's virtual loopback, via our service worker
-	//   everything else  the site hosting the desk — on the docs deployment that
-	//                    is MkDocs, which the desk opens in a tab so the reader
-	//                    browses the docs inside the visor rather than beside it
-	//
-	// This also removes the transport from the path: a same-origin page loads as
-	// an ordinary document, so the docs render with no visor running. Going
-	// through fetchPage would strand them — __netscrapeFetch exists but has
-	// nothing behind it until someone starts a visor (measured live).
-	//
-	// A claimed page is UNSANDBOXED, so this must stay same-origin-only.
+	// This deliberately does NOT claim the whole origin. It briefly did, to let
+	// the docs be read from the site hosting the desk — but serving them from
+	// the binary is better in every way (no transport, no visor required, works
+	// wherever the binary runs, and the CLI reference cannot drift), and a
+	// claimed page is UNSANDBOXED. The narrower rule is the one to keep.
 	netscrape.DirectLoader = func(u string) (string, bool) {
 		loc := js.Global().Get("location")
 		if !loc.Truthy() {
 			return "", false
 		}
 		origin := loc.Get("origin").String()
-		if origin == "" {
-			return "", false
-		}
-		// Exact origin, or origin followed by a path separator — never a
-		// prefix match that a sibling origin could satisfy
-		// ("https://evil.com" must not match "https://evil.com.attacker.net").
-		if u != origin && !strings.HasPrefix(u, origin+"/") {
+		if origin == "" || !strings.HasPrefix(u, origin+"/vnet/") {
 			return "", false
 		}
 		return u, true

--- a/docs/embed.go
+++ b/docs/embed.go
@@ -1,0 +1,48 @@
+// Package docs docs/embed.go c1-cli-doc
+// The prose half of `skywire doc serve`, embedded from where it lives.
+//
+// go:embed cannot reach outside its own package directory, so the embed
+// declaration sits in docs/ rather than beside the command that serves it.
+// Nothing else belongs in this package.
+//
+// The CLI reference is NOT here and never will be: `skywire doc` walks the
+// live cobra tree, so those pages ARE the binary and cannot drift from it.
+// Only hand-written prose has to travel.
+//
+// The tree list below is explicit and must stay that way: a depth glob like
+// `*/*.md` would sweep in the 528 generated pages under skywire/. TestProse-
+// CoversEveryTree fails if a new prose directory is added without being listed
+// here, which is how the list stopped being wrong the first time.
+//
+// Deliberately excluded:
+//
+//	graph/    37 MB of dependency graphs
+//	img/      5.2 MB, mostly a 2.1 MB TUI gif and a CLI screenshot — both of
+//	          surfaces the desk demonstrates live, so a still of them is the
+//	          weaker copy
+//	skywire/  the generated CLI reference, served from the cobra tree instead
+//	specs/    derived by scripts/docs-prepare.sh at docs-build time and
+//	rewards/  gitignored, so neither exists when `go build` runs
+//	*.wasm    examples/routing-policies/wasm/ holds built policy modules. A
+//	          whole-directory embed took 551 KB of them — 40% of the embed for
+//	          nothing a reader can use — so examples/ is globbed at the depth
+//	          its prose and .star sources actually live at instead.
+//
+// What remains is 102 files, ~960 KB, which gzips to roughly a quarter of
+// that — about 2% of the wasm blob it rides in, and noise in a native build.
+//
+// Prose images are almost all remote (github.com/skycoin/.../assets/...): 26
+// references across those files. With no transport they degrade to alt text;
+// once a visor is running they load — a fairer demonstration than shipping
+// them, and cheaper.
+package docs
+
+import "embed"
+
+//go:embed *.md deploy deployment design guides packaging pty skychat skynet skysocks vpn
+//go:embed examples/*/*.md examples/*/*.star
+var proseFS embed.FS
+
+// Prose returns the embedded prose tree: hand-written markdown, rooted at
+// docs/. Paths are as they appear in the repo ("guides/foo.md").
+func Prose() embed.FS { return proseFS }

--- a/docs/embed_test.go
+++ b/docs/embed_test.go
@@ -1,0 +1,90 @@
+package docs
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+// notProse are the trees deliberately left out of the embed. skywire/ is the
+// GENERATED cli reference — `skywire doc serve` walks the cobra tree for that,
+// so embedding 528 stale copies would be worse than useless. graph/ and img/
+// are weight (37 MB and 5.2 MB). specs/ and rewards/ are staged by
+// scripts/docs-prepare.sh at docs-build time and gitignored, so they do not
+// exist when `go build` runs.
+var notProse = map[string]bool{
+	"skywire": true, "graph": true, "img": true,
+	"specs": true, "rewards": true, "playground": true,
+}
+
+// TestProseCoversEveryTree fails when a prose directory exists on disk but is
+// missing from the //go:embed line. The list has to be enumerated by hand — a
+// depth glob would sweep in skywire/'s generated pages — and it was wrong on
+// the first attempt: deploy/, skynet/ and skysocks/ were silently absent, so
+// five files never shipped and nothing said so. This is the guard.
+func TestProseCoversEveryTree(t *testing.T) {
+	ents, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read docs/: %v", err)
+	}
+	for _, e := range ents {
+		if !e.IsDir() || notProse[e.Name()] || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		// A tree counts as prose once it holds any markdown.
+		var hasMD bool
+		_ = fs.WalkDir(os.DirFS(e.Name()), ".", func(p string, d fs.DirEntry, err error) error {
+			if err == nil && !d.IsDir() && strings.HasSuffix(p, ".md") {
+				hasMD = true
+			}
+			return nil
+		})
+		if !hasMD {
+			continue
+		}
+		if _, err := fs.Stat(proseFS, e.Name()); err != nil {
+			t.Errorf("docs/%s/ holds prose but is not in the //go:embed line — add it", e.Name())
+		}
+	}
+}
+
+// TestProseExcludesGenerated is the other direction: the generated CLI
+// reference must never creep into the embed. It is served from the live cobra
+// tree, and a second copy would be stale the moment the tree changed.
+func TestProseExcludesGenerated(t *testing.T) {
+	for name := range notProse {
+		if _, err := fs.Stat(proseFS, name); err == nil {
+			t.Errorf("docs/%s/ is embedded but must not be", name)
+		}
+	}
+}
+
+// TestProseCarriesNoBuildOutput guards the byte budget. Embedding a directory
+// takes EVERYTHING in it: the first version of this embed pulled 551 KB of
+// built .wasm from examples/routing-policies/wasm — 40% of the embed, useless
+// to a reader. Small companions the prose references (.star policy sources,
+// compose.yaml, a Caddyfile) are wanted and stay.
+func TestProseCarriesNoBuildOutput(t *testing.T) {
+	banned := map[string]bool{".wasm": true, ".gz": true, ".png": true, ".gif": true, ".jpg": true, ".svg": true, ".zip": true}
+	var total int64
+	_ = fs.WalkDir(proseFS, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		info, ierr := d.Info()
+		if ierr == nil {
+			total += info.Size()
+		}
+		if ext := path.Ext(p); banned[ext] {
+			t.Errorf("%s embedded — build output does not belong in the docs embed", p)
+		}
+		return nil
+	})
+	// The prose is ~762 KB today. Generous enough for ordinary writing, tight
+	// enough that a tree of binaries trips it.
+	if total > 2<<20 {
+		t.Errorf("embedded prose is %.1f MB — over the 2 MB budget", float64(total)/(1<<20))
+	}
+}


### PR DESCRIPTION
`skywire doc serve` puts two sources on one site:

```
/          the cobra tree, walked live by collect() on every request
/prose/…   the hand-written markdown, embedded
```

The command reference **costs nothing to carry and cannot drift** — it *is* the binary's command tree, not a copy of it. `render()` was already documented as pure-writer output, so it needed no change. Only prose travels.

## Why not just link to the docs site

In the browser visor the nested browser has no transport until someone starts a visor. Measured live on the deployed site, in the shell's iframe:

```
__netscrapeFetch: "function"    ← transport exists
visorStarted:     false         ← nothing behind it
```

The tab sat on netscrape's `data:` placeholder while the address bar read the docs URL. Bound on the virtual loopback this is a same-origin `/vnet/<port>/` URL, which `DirectLoader` **already claimed** — so the docs render with no visor running, no transport in the path, and wherever the binary runs rather than only where the outer origin serves docs.

## HTML, not markdown

Browsers don't render markdown, and a native `doc serve` is meant to be opened in an ordinary browser. Teaching netscrape a private content type would make these docs readable only inside skywire. goldmark does the rendering, matching `skywire cli reward rules --html` so the two agree on what markdown means here.

## The embed: 762 KB, 127 files

Three corrections, each caught by measuring rather than reading:

- `/docs/specs/` and `/docs/rewards/` are **gitignored** — staged by `scripts/docs-prepare.sh` at docs-build time, so absent when `go build` runs
- the tree list must be **hand-enumerated**: a `*/*.md` glob sweeps in `skywire/`'s **528 generated pages**. The first list silently missed `deploy/`, `skynet/`, `skysocks/` — five files never shipped and nothing said so
- a whole-directory embed of `examples/` took **551 KB of built `.wasm`** (40% of the embed), so it's globbed at the depth its prose actually lives at

Three tests guard exactly those: a new prose tree missing from the embed fails; the generated `skywire/` creeping in fails; build output or a 2 MB overrun fails.

Images aren't embedded — 26 of the prose's image references are remote `github.com/skycoin/.../assets/…`. Without a transport they degrade to alt text; once a visor is running they load. `docs/img/` is 5.2 MB, mostly a TUI gif and a CLI screenshot of surfaces the desk demonstrates live.

## DirectLoader narrowed back

To `/vnet/` only. It briefly claimed the whole origin (#4524) to let the docs be read from the site hosting the desk; serving them from the binary is better in every way, and a claimed page is unsandboxed. The framing guard from that PR **stays** — embedded mkdocs output still carries `desk-shell.js`.

## Testing

Built and run natively. All routes verified serving rendered HTML — headings, lists, `<pre>` code blocks:

```
/ /cli /cli/dmsg /cli/visor/pk /visor   200
/prose/                                 200, 100 files
/prose/guides/README.md                 200
```

`GOOS=js GOARCH=wasm` vet+build pass. Not yet exercised in the browser visor end to end — the desk still needs wiring to launch it, which is the follow-up.
