### PR TITLE
fix(cxo): clear the two lint issues and the CodeQL alert failing develop

### DIFF
--- a/pkg/cxo/cxosub/wait_first_sync_test.go
+++ b/pkg/cxo/cxosub/wait_first_sync_test.go
@@ -7,15 +7,18 @@ import (
 	"time"
 )
 
-// newFeedForTest registers a feed in the manager's map so the sync-state
-// accessors have something to read, without standing up a live subscription.
-func newFeedForTest(m *Manager, fk Feed) *managedFeed {
+// newFeedForTest registers FeedTPDMetrics in the manager's map so the
+// sync-state accessors have something to read, without standing up a live
+// subscription. Which feed it is does not matter to these tests — they
+// exercise the wait, not the routing — so the constant stays here rather
+// than at four identical call sites.
+func newFeedForTest(m *Manager) *managedFeed {
 	f := &managedFeed{}
 	m.mu.Lock()
 	if m.feeds == nil {
 		m.feeds = map[Feed]*managedFeed{}
 	}
-	m.feeds[fk] = f
+	m.feeds[FeedTPDMetrics] = f
 	m.mu.Unlock()
 	return f
 }
@@ -30,7 +33,7 @@ func markSynced(f *managedFeed) {
 // a caller anything on the hot path.
 func TestWaitForFirstSyncReturnsImmediatelyWhenAlreadySynced(t *testing.T) {
 	m := NewManager(Deps{}, 0)
-	f := newFeedForTest(m, FeedTPDMetrics)
+	f := newFeedForTest(m)
 	markSynced(f)
 
 	start := time.Now()
@@ -48,7 +51,7 @@ func TestWaitForFirstSyncReturnsImmediatelyWhenAlreadySynced(t *testing.T) {
 // subscriber mid-fill — so the feed never became readable through that path.
 func TestWaitForFirstSyncPicksUpASyncThatLands(t *testing.T) {
 	m := NewManager(Deps{}, 0)
-	f := newFeedForTest(m, FeedTPDMetrics)
+	f := newFeedForTest(m)
 
 	go func() {
 		time.Sleep(600 * time.Millisecond)
@@ -64,7 +67,7 @@ func TestWaitForFirstSyncPicksUpASyncThatLands(t *testing.T) {
 // blocking forever — the caller still has an HTTP fallback to reach for.
 func TestWaitForFirstSyncGivesUpAtTimeout(t *testing.T) {
 	m := NewManager(Deps{}, 0)
-	newFeedForTest(m, FeedTPDMetrics)
+	newFeedForTest(m)
 
 	start := time.Now()
 	if m.WaitForFirstSync(context.Background(), FeedTPDMetrics, 700*time.Millisecond) {
@@ -75,10 +78,10 @@ func TestWaitForFirstSyncGivesUpAtTimeout(t *testing.T) {
 	}
 }
 
-// Cancelling the caller's context must abandon the wait promptly.
+// Canceling the caller's context must abandon the wait promptly.
 func TestWaitForFirstSyncHonorsContextCancellation(t *testing.T) {
 	m := NewManager(Deps{}, 0)
-	newFeedForTest(m, FeedTPDMetrics)
+	newFeedForTest(m)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {

--- a/pkg/cxo/cxoutils/frame.go
+++ b/pkg/cxo/cxoutils/frame.go
@@ -24,12 +24,13 @@ package cxoutils
 
 // FrameGzip wraps payload as [version byte][gzip(payload)]. Callers pick
 // a per-feed version const; readers compare it in UnframeGzip and branch.
+// Built by appending onto the one-byte version slice rather than by
+// pre-sizing with make(0, 1+len(gz)): the payload is an untrusted leaf body,
+// so `1 + len(gz)` is a size computation over an attacker-influenced length,
+// which CodeQL flags as go/allocation-size-overflow. append reaches the same
+// single allocation without the arithmetic.
 func FrameGzip(version byte, payload []byte) []byte {
-	gz := Gzip(payload)
-	out := make([]byte, 0, 1+len(gz))
-	out = append(out, version)
-	out = append(out, gz...)
-	return out
+	return append([]byte{version}, Gzip(payload)...)
 }
 
 // UnframeGzip splits a FrameGzip blob into its version byte and the


### PR DESCRIPTION
Three small fixes in `pkg/cxo`, all currently red on `develop`.

**`windows` CI job.** It runs golangci-lint against `GOOS=windows`, which the linux jobs don't cover, and fails on `wait_first_sync_test.go`:

```
pkg\cxo\cxosub\wait_first_sync_test.go:78:4: `Cancelling` is a misspelling of `Canceling` (misspell)
pkg\cxo\cxosub\wait_first_sync_test.go:12:33: newFeedForTest - fk always receives FeedTPDMetrics (0) (unparam)
```

`misspell` runs with `locale: US`. For the second, the feed doesn't matter to those tests — they exercise the wait, not the routing — so the constant moves into the helper rather than being repeated at four call sites.

**CodeQL alert #312** (high severity, open since 2026-08-25) flags `FrameGzip`'s `make([]byte, 0, 1+len(gz))` as `go/allocation-size-overflow`: the payload is an untrusted leaf body, so `1 + len(gz)` is a size computation over an attacker-influenced length. Appending onto the one-byte version slice reaches the same single allocation without the arithmetic. Not exploitable in practice (it would need a 9-exabyte slice), but it's the alert that turns the CodeQL check red on every PR that touches a `cxoutils` call path.

Verified with golangci-lint under both `GOOS=linux` and `GOOS=windows`, `go build .`, and the `pkg/cxo` tree plus `pkg/dmsg/discovery/api` (the one `FrameGzip` caller).