### PR TITLE
fix(cli): stop tp viz publishing a discovery entry it never needs

### DIFF
--- a/cmd/skywire-cli/commands/tp/tp-viz.go
+++ b/cmd/skywire-cli/commands/tp/tp-viz.go
@@ -12,6 +12,7 @@ import (
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -167,12 +168,20 @@ Auto-refresh keeps the cache updated at the specified interval.`,
 		// Without it /api/transports etc. fail with "dmsg URL requested but no dmsg
 		// HTTP client set" — standalone `tp viz` was unusable against the current
 		// dmsg-only deployment (only --visor and the reward server wired dmsg).
-		// Ephemeral keypair; best-effort and async, so the UI serves immediately and
-		// the graph populates once dmsg connects.
+		// Best-effort and async, so the UI serves immediately and the graph
+		// populates once dmsg connects.
+		//
+		// The keypair is per-run, so the client must NOT publish an entry to the
+		// dmsg-discovery: a long-running server that registers a fresh identity on
+		// every restart leaves abandoned entries behind, which is the litter #4501
+		// removed from `hv serve`. This process is a pure consumer — nothing dials
+		// it — and every PK it will ever reach is a deployment service known here,
+		// so seeding those directly and skipping the registering fallback gives it
+		// what it needs without an entry.
 		go func() {
 			dlog := logging.MustGetLogger("tpviz-dmsg")
 			pk, sk := cipher.GenerateKeyPair()
-			dmsgC, _, err := dmsgclient.StartDmsgEmbedded(cmd.Context(), dlog, pk, sk, false)
+			dmsgC, _, err := dmsgclient.StartDmsgEmbeddedForServices(cmd.Context(), dlog, pk, sk, false, vizServicePKs(cfg)...)
 			if err != nil {
 				dlog.WithError(err).Warn("dmsg client for deployment discovery failed to start; network-graph data unavailable")
 				return
@@ -187,4 +196,35 @@ Auto-refresh keeps the cache updated at the specified interval.`,
 			os.Exit(1)
 		}
 	},
+}
+
+// vizServicePKs returns the deployment-service public keys the standalone
+// server will dial, taken from the dmsg:// URLs already resolved into cfg.
+//
+// These are seeded directly into the dmsg client so it can reach them without
+// the registering fallback discovery — which would publish an entry for a
+// process nothing ever dials. Entries that are not dmsg:// (or are empty) are
+// skipped: they are reached over clearnet HTTP and need no seed.
+func vizServicePKs(cfg tpviz.Config) []cipher.PubKey {
+	var out []cipher.PubKey
+	seen := make(map[cipher.PubKey]struct{})
+	for _, raw := range []string{cfg.TPDURLDmsg, cfg.SDURLDmsg, cfg.DMSGURLDmsg} {
+		if raw == "" {
+			continue
+		}
+		hex := dmsg.ExtractPKFromDmsgAddr(raw)
+		if hex == "" {
+			continue
+		}
+		var pk cipher.PubKey
+		if err := pk.UnmarshalText([]byte(hex)); err != nil || pk.Null() {
+			continue
+		}
+		if _, dup := seen[pk]; dup {
+			continue
+		}
+		seen[pk] = struct{}{}
+		out = append(out, pk)
+	}
+	return out
 }

--- a/cmd/skywire-cli/commands/tp/tp_viz_service_pks_test.go
+++ b/cmd/skywire-cli/commands/tp/tp_viz_service_pks_test.go
@@ -1,0 +1,96 @@
+// Package clitp cmd/skywire-cli/commands/tp/tp_viz_service_pks_test.go c4-vis-cli
+package clitp
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/tpviz"
+)
+
+const (
+	tpdPK   = "02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae"
+	sdPK    = "0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7"
+	dmsgdPK = "022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa"
+)
+
+// The seeded set is what lets the standalone server reach the deployment
+// without a registering discovery — every dmsg:// service it will dial has to
+// be in it, or that service becomes unreachable rather than merely unregistered.
+func TestVizServicePKsSeedsEveryDmsgService(t *testing.T) {
+	pks := vizServicePKs(tpviz.Config{
+		TPDURLDmsg:  "dmsg://" + tpdPK + ":80",
+		SDURLDmsg:   "dmsg://" + sdPK + ":80",
+		DMSGURLDmsg: "dmsg://" + dmsgdPK + ":80",
+	})
+	if len(pks) != 3 {
+		t.Fatalf("got %d service keys, want 3", len(pks))
+	}
+	for _, want := range []string{tpdPK, sdPK, dmsgdPK} {
+		found := false
+		for _, pk := range pks {
+			if pk.Hex() == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("service key %s was not seeded", want)
+		}
+	}
+}
+
+// A clearnet or unset URL needs no seed — it is reached over HTTP, not dmsg.
+// Seeding a zero key would put a null entry in the client's cache.
+func TestVizServicePKsSkipsNonDmsgAndEmpty(t *testing.T) {
+	pks := vizServicePKs(tpviz.Config{
+		TPDURLDmsg:  "dmsg://" + tpdPK + ":80",
+		SDURLDmsg:   "",
+		DMSGURLDmsg: "http://dmsgd.skywire.example/",
+	})
+	if len(pks) != 1 {
+		t.Fatalf("got %d service keys, want only the dmsg one", len(pks))
+	}
+	if pks[0].Hex() != tpdPK {
+		t.Errorf("seeded %s, want %s", pks[0].Hex(), tpdPK)
+	}
+	for _, pk := range pks {
+		if pk.Null() {
+			t.Error("a null public key was seeded")
+		}
+	}
+}
+
+// Deployments can point two services at one host. Seeding the same key twice
+// is harmless but pointless, and a duplicate would misreport how many distinct
+// peers the client is being told about.
+func TestVizServicePKsDeduplicates(t *testing.T) {
+	pks := vizServicePKs(tpviz.Config{
+		TPDURLDmsg:  "dmsg://" + tpdPK + ":80",
+		SDURLDmsg:   "dmsg://" + tpdPK + ":81",
+		DMSGURLDmsg: "dmsg://" + dmsgdPK + ":80",
+	})
+	if len(pks) != 2 {
+		t.Fatalf("got %d service keys, want 2 distinct", len(pks))
+	}
+}
+
+// A malformed key must be dropped rather than panicking or seeding garbage —
+// these come from user-supplied --tpd-url / --sd-url / --dmsg-url flags.
+func TestVizServicePKsIgnoresMalformed(t *testing.T) {
+	pks := vizServicePKs(tpviz.Config{
+		TPDURLDmsg:  "dmsg://not-a-public-key:80",
+		SDURLDmsg:   "dmsg://:80",
+		DMSGURLDmsg: "dmsg://" + dmsgdPK + ":80",
+	})
+	if len(pks) != 1 || pks[0].Hex() != dmsgdPK {
+		t.Fatalf("got %v, want only the well-formed key", pks)
+	}
+}
+
+// No dmsg services configured is a legitimate clearnet-only run, and must
+// yield an empty seed set rather than a slice containing a null key.
+func TestVizServicePKsEmptyWhenNoDmsgServices(t *testing.T) {
+	if pks := vizServicePKs(tpviz.Config{}); len(pks) != 0 {
+		t.Errorf("got %v, want no service keys", pks)
+	}
+}

--- a/pkg/dmsg/dmsgclient/seeded.go
+++ b/pkg/dmsg/dmsgclient/seeded.go
@@ -184,3 +184,33 @@ func StartDmsgEmbedded(ctx context.Context, log *logging.Logger, pk cipher.PubKe
 	}
 	return StartDmsgSeeded(ctx, log, pk, sk, seeds, deployment.Prod.DmsgDiscoveryDmsg, preferWS)
 }
+
+// StartDmsgEmbeddedForServices starts an embedded-seed dmsg client that talks
+// ONLY to the named services and never publishes an entry to the
+// dmsg-discovery.
+//
+// StartDmsgEmbedded seeds no service PKs, so it depends on the registering
+// fallback discovery to resolve anything — and that fallback publishes our own
+// entry as a side effect of being installed. For a read-only consumer that
+// already knows every PK it will ever dial, that entry is pure litter: the
+// process is never dialed by anyone, and a fresh key per run leaves an
+// abandoned registration behind (the pattern removed from `hv serve` in #4501).
+//
+// Passing the service PKs seeds them directly, and passing an empty discovery
+// address skips the upgrade entirely, leaving the client in the seed-only mode
+// StartDmsgSeeded already degrades to on upgrade failure: dialable, but unable
+// to resolve peers it was not told about. That is the correct trade for a
+// consumer with a fixed set of destinations, and the wrong one for anything
+// that needs to reach arbitrary peers — those should keep using
+// StartDmsgEmbedded.
+func StartDmsgEmbeddedForServices(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey, preferWS bool, servicePKs ...cipher.PubKey) (*dmsg.Client, func(), error) {
+	servers := dmsg.Prod.DmsgServers
+	if len(servers) == 0 {
+		return nil, nil, errors.New("dmsg: no embedded dmsg servers in deployment config")
+	}
+	seeds := make([]*disc.Entry, len(servers))
+	for i := range servers {
+		seeds[i] = &servers[i]
+	}
+	return StartDmsgSeeded(ctx, log, pk, sk, seeds, "", preferWS, servicePKs...)
+}


### PR DESCRIPTION
Closes #4518.

Standalone `tp viz` generates a keypair and starts an embedded dmsg client via `StartDmsgEmbedded`, which seeds **no** service PKs and therefore depends on the registering fallback discovery to resolve anything. Installing that fallback publishes our own entry as a side effect — so every run of a long-running server left an abandoned registration in the production dmsg-discovery. Same shape as the litter removed from `hv serve` in #4501, and worse here because the key lives for the process lifetime and a restart loop mints a new one each time.

Nothing ever dials `tp viz`, and every peer it reaches is a deployment service already named in its own config. Seeding those PKs directly and passing an empty discovery address leaves the client in the seed-only mode `StartDmsgSeeded` already degrades to on upgrade failure: dialable, publishes nothing. The trade — it cannot resolve peers it was not told about — is the right one for a consumer with a fixed destination set, and the new helper says so, so anything needing arbitrary peers keeps using `StartDmsgEmbedded`.

Verified against the live deployment:

```
/api/transports                      http=200
dmsg-discovery/entry/035c3c40be80d743e89fc61d21fca2b4e5ba0bff38e0a6a4818ff18ffee0abe899
                                     404 entry of public key is not found
present in /dmsg-discovery/entries?  no (931 entries)
```

So it still reaches the dmsg-only deployment, and leaves nothing behind.
