### PR TITLE
feat(desk): open the docs in the browser, addressed as vnet:<port>

### DIFF
--- a/cmd/skywire/commands/doc/serve.go
+++ b/cmd/skywire/commands/doc/serve.go
@@ -26,7 +26,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/fs"
-	"net"
 	"net/http"
 	"sort"
 	"strings"
@@ -35,6 +34,8 @@ import (
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	ghtml "github.com/yuin/goldmark/renderer/html"
+
+	"github.com/0magnet/bottle/vnet"
 
 	skydocs "github.com/skycoin/skywire/docs"
 )
@@ -67,7 +68,11 @@ natively, with no visor and no transport needed.
 	SilenceUsage:          true,
 	DisableFlagsInUseLine: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		ln, err := net.Listen("tcp", serveAddr)
+		// bottle/vnet, not net: a real socket natively, the page port table under
+		// js. Binding with net directly would serve fine on a workstation and
+		// bind nothing reachable in the browser — where the desk needs to open
+		// this at /vnet/<port>/, which is the case the command exists for.
+		ln, err := vnet.Listen("tcp", serveAddr)
 		if err != nil {
 			return fmt.Errorf("doc serve: listen %s: %w", serveAddr, err)
 		}

--- a/cmd/wasm-visor/desk_js.go
+++ b/cmd/wasm-visor/desk_js.go
@@ -89,27 +89,41 @@ func installDesk() {
 	// NATIVELY: without it netscrape would transcode the page into a sandboxed
 	// srcdoc, which strips the same-origin an Angular-style app needs.
 	//
-	// Claim same-origin /vnet/ URLs ONLY — those are served by this page's own
-	// service worker out of the visor's virtual loopback, so they are ours to
-	// render. Two surfaces arrive that way: the hypervisor UI, and the docs,
-	// which `skywire doc serve` binds on the loopback so a reader browses them
-	// inside the visor with a terminal beside them.
+	// Claim the visor's own loopback, however it is spelled, and hand back the
+	// service-worker URL that actually serves it. DirectLoader returns a src
+	// SEPARATE from the url: netscrape puts src on the iframe and leaves the
+	// url in the address bar, so a tab can be addressed canonically as
+	// "vnet:8002" while rendering natively out of "<origin>/vnet/8002/".
 	//
-	// This deliberately does NOT claim the whole origin. It briefly did, to let
-	// the docs be read from the site hosting the desk — but serving them from
-	// the binary is better in every way (no transport, no visor required, works
-	// wherever the binary runs, and the CLI reference cannot drift), and a
-	// claimed page is UNSANDBOXED. The narrower rule is the one to keep.
+	// Without the translation a caller has to navigate to the raw service-worker
+	// path to get native rendering, which puts the plumbing in the address bar
+	// (the hypervisor tab read "http://host:port/vnet/8001/?embed=1#/?embed=1")
+	// and makes the canonical spellings second-class — they resolve, but only
+	// through the transport, which transcodes into a sandbox and strips scripts.
+	//
+	// Spellings, per desk-boot's vnetPort(): vnet:<port> (canonical),
+	// <port>.vnet, and localhost/127.0.0.1:<port>. Same-origin /vnet/<port>/
+	// passes through unchanged — it is already the served form.
+	//
+	// Deliberately NOT the whole origin: a claimed page is UNSANDBOXED, and the
+	// docs come from the binary now (skywire doc serve), not from whatever site
+	// happens to host the desk.
 	netscrape.DirectLoader = func(u string) (string, bool) {
 		loc := js.Global().Get("location")
 		if !loc.Truthy() {
 			return "", false
 		}
 		origin := loc.Get("origin").String()
-		if origin == "" || !strings.HasPrefix(u, origin+"/vnet/") {
+		if origin == "" {
 			return "", false
 		}
-		return u, true
+		if strings.HasPrefix(u, origin+"/vnet/") {
+			return u, true // already the served form
+		}
+		if port, path := vnetTarget(u); port != "" {
+			return origin + "/vnet/" + port + path, true
+		}
+		return "", false
 	}
 
 	desk.NewPanel()

--- a/cmd/wasm-visor/vnetaddr.go
+++ b/cmd/wasm-visor/vnetaddr.go
@@ -1,0 +1,57 @@
+// Package main cmd/wasm-visor/vnetaddr.go c3-vis-wasm
+// Untagged on purpose: vnetTarget is pure string/URL work with no syscall/js
+// in it, and a js-only test never runs in CI. The rule it encodes — which
+// spellings get rendered UNSANDBOXED out of this origin — is worth a test
+// that actually executes.
+
+package main
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// vnetTarget parses the spellings that name the visor's own loopback and
+// returns its port and path, or "" when the URL names something else. It
+// mirrors desk-boot.js's vnetPort(), which resolves the same names for the
+// transcoding fetch path — the two must agree or a tab renders one way when
+// addressed "vnet:8001" and another when addressed "8001.vnet".
+//
+//	vnet:<port>       canonical
+//	<port>.vnet
+//	localhost:<port>  127.0.0.1:<port>, [::1]:<port>
+func vnetTarget(raw string) (port, path string) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return "", ""
+	}
+	path = u.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	if u.RawQuery != "" {
+		path += "?" + u.RawQuery
+	}
+	// A fragment is never sent to a server; the browser applies it to the
+	// document the src loads, so it has to ride along on the src.
+	if u.Fragment != "" {
+		path += "#" + u.EscapedFragment()
+	}
+	host := strings.ToLower(u.Hostname())
+	if p := u.Port(); p != "" {
+		switch host {
+		case "vnet", "localhost", "127.0.0.1", "::1":
+			if _, err := strconv.Atoi(p); err == nil {
+				return p, path
+			}
+		}
+		return "", ""
+	}
+	if rest, ok := strings.CutSuffix(host, ".vnet"); ok {
+		if _, err := strconv.Atoi(rest); err == nil {
+			return rest, path
+		}
+	}
+	return "", ""
+}

--- a/cmd/wasm-visor/vnetaddr_test.go
+++ b/cmd/wasm-visor/vnetaddr_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+// TestVnetTarget pins the spellings that name the visor's own loopback, and
+// the ones that must NOT be claimed. A claimed page is rendered UNSANDBOXED
+// out of this origin, so a false positive here would hand an arbitrary URL
+// same-origin privileges.
+func TestVnetTarget(t *testing.T) {
+	claimed := map[string][2]string{
+		"http://vnet:8002/":                   {"8002", "/"},
+		"http://vnet:8001/?embed=1#/?embed=1": {"8001", "/?embed=1#/?embed=1"},
+		"http://8002.vnet/":                   {"8002", "/"},
+		"http://8002.vnet/cli/dmsg":           {"8002", "/cli/dmsg"},
+		"http://localhost:8002/prose/":        {"8002", "/prose/"},
+		"http://127.0.0.1:8002/":              {"8002", "/"},
+		"http://VNET:8002/Mixed":              {"8002", "/Mixed"},
+	}
+	for in, want := range claimed {
+		port, path := vnetTarget(in)
+		if port != want[0] || path != want[1] {
+			t.Errorf("vnetTarget(%q) = (%q,%q), want (%q,%q)", in, port, path, want[0], want[1])
+		}
+	}
+
+	for _, in := range []string{
+		"http://example.com/",         // someone else entirely
+		"http://notvnet/",             // no port, not <n>.vnet
+		"http://vnet/",                // bare vnet, no port
+		"http://abc.vnet/",            // non-numeric label
+		"http://evil.com:8002/",       // right port, wrong host
+		"http://vnet.example.com:80/", // vnet as a subdomain label
+		"",                            // nothing
+		"::::",                        // unparseable
+	} {
+		if port, _ := vnetTarget(in); port != "" {
+			t.Errorf("vnetTarget(%q) claimed port %q — must not be claimed", in, port)
+		}
+	}
+}

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -20,6 +20,10 @@
 //   hvWindow        once the visor's hypervisor UI listens on the virtual
 //                   loopback, open a browser window on it, maximized on top
 //   hvPort          hypervisor UI port on the virtual loopback (8001)
+//   docsPort        port for `skywire doc serve` on the virtual loopback
+//                   (8002). The desk starts it and opens it as a browser tab,
+//                   so the CLI reference and the prose are readable BESIDE a
+//                   terminal you can run the documented commands in. 0 = off.
 //   native          the page is served by a NATIVE hypervisor — see below
 //   dashboardURL    native mode: the same-origin dashboard URL for the
 //                   dashboard window ('/#/?embed=1')
@@ -94,6 +98,14 @@
 		opts = opts || {};
 		var status = opts.onStatus || function () {};
 		var hvPort = opts.hvPort || 8001;
+		// 0 disables. Native mode leaves it off: a native hypervisor serves its
+		// own docs and has no vnet to bind.
+		var docsPort = opts.docsPort === 0 ? 0 : (opts.docsPort || 8002);
+		// The one browser window, whichever surface opens it first. The docs do
+		// not wait on the hypervisor: with no visor started — the docs-site case —
+		// nothing ever listens on hvPort, and a docs tab gated on that would
+		// never appear.
+		var deskWin = null;
 
 		// Native mode: the page is served by a NATIVE hypervisor, whose visor
 		// is the host process — the desk is a shell OVER that visor, never a
@@ -296,6 +308,18 @@
 
 			// Session: remember across reloads whether a visor was RUNNING when
 			// the page went away — a visor the operator stopped stays stopped.
+			// Start the docs server. It is a plain HTTP server over the embedded
+			// prose and the live cobra tree — no visor needed, nothing to wait
+			// for — so it is launched unconditionally and the tab that shows it
+			// opens with the rest once its port answers. Failure is silent by
+			// design: no docs tab is a smaller loss than a desk that will not boot.
+			if (docsPort && globalThis.skywireExec) {
+				try {
+					skywireExec(['doc', 'serve', '--addr', '127.0.0.1:' + docsPort], {})
+						.catch(function (e) { console.warn('doc serve:', e); });
+				} catch (e) { console.warn('doc serve:', e); }
+			}
+
 			var session = loadSession();
 			if (opts.autostartVisor) {
 				addEventListener('pagehide', saveSession);
@@ -347,7 +371,17 @@
 								// /vnet/ URLs, so the Angular app loads as an
 								// ordinary document instead of being transcoded
 								// into a sandbox that would strip its same-origin.
-								var win = panel.openWindow(true, globalThis.__DESK_DASHBOARD_URL__);
+								// Share the window if the docs got here first — doc serve
+								// binds in seconds and the hypervisor takes a while, so
+								// that is the ordinary order, and opening a second window
+								// unconditionally is how this produced two (measured).
+								var win = deskWin;
+								if (win && win.openTab) {
+									try { win.openTab('vnet:' + hvPort, '/?embed=1#/?embed=1', 'http', false); } catch (e2) {}
+								} else {
+									win = panel.openWindow(true, globalThis.__DESK_DASHBOARD_URL__);
+									deskWin = win;
+								}
 								if (win && win.openTab) {
 									try { win.openTab('home.dmsg', '/', 'http', true); } catch (e2) {}
 									try { win.openTab('status.skysocks', '/', 'http', true); } catch (e2) {}
@@ -379,6 +413,40 @@
 					setTimeout(function () { waitHV(n + 1); }, 500);
 				})(0);
 			}
+			// The docs tab, on its own schedule. `skywire doc serve` needs no
+			// visor and no dmsg — it renders the live cobra tree and the
+			// embedded prose — so it binds in seconds, usually well before any
+			// hypervisor UI. Gating it on hvPort would mean no docs tab at all
+			// wherever no visor is started, which is exactly the docs-site case
+			// this exists for. Shares the browser window when one exists and
+			// opens its own otherwise; whichever surface is ready first makes it.
+			if (docsPort) {
+				(function waitDocs(n) {
+					if (globalThis.vnet && globalThis.vnet.listening(docsPort)) {
+						swReady.then(function () {
+							try {
+								// vnet:<port> — the canonical spelling, and what the
+								// address bar shows. desk_js.go's DirectLoader claims it
+								// and hands netscrape the service-worker URL that serves
+								// it, so the tab renders natively without the plumbing
+								// leaking into the UI.
+								var docsURL = 'http://vnet:' + docsPort + '/';
+								if (deskWin && deskWin.openTab) {
+									// bg: the hypervisor window is already front when we
+									// are sharing it.
+									deskWin.openTab('vnet:' + docsPort, '/', 'http', true);
+									return;
+								}
+								deskWin = panel.openWindow(true, docsURL);
+							} catch (e) { console.warn('docs window:', e); }
+						});
+						return;
+					}
+					if (n > 120) return; // ~60s — doc serve never bound its port
+					setTimeout(function () { waitDocs(n + 1); }, 500);
+				})(0);
+			}
+
 			return { panel: panel, startedVisor: startedVisor };
 		});
 	};


### PR DESCRIPTION
The desk starts `skywire doc serve` on the virtual loopback and opens it as a browser tab, so the command reference and the prose sit beside a terminal that runs the commands they describe. No visor needed — `doc serve` renders the live cobra tree and the embedded prose, and binds in seconds.

## Three fixes, two of which only a browser could find

**`doc serve` binds with `bottle/vnet`, not `net`.** `net.Listen` serves fine on a workstation and binds nothing reachable in a tab — the case the command exists for. This is the pattern `hypervisor.go:229` already uses. (A miss in #4527, mine.)

**`DirectLoader` claims the loopback however it is spelled**, and hands netscrape the service-worker URL that serves it. It returns a `src` *separate* from the `url` — netscrape puts `src` on the iframe and leaves `url` in the address bar — so a tab reads `vnet:8002` while rendering natively out of `<origin>/vnet/8002/`.

Before this, a caller had to navigate the raw service-worker path to get native rendering. That put the plumbing in the address bar (the hypervisor tab read `.../vnet/8001/?embed=1#/?embed=1`) and made the canonical spellings second-class: `vnet:<port>` and `<port>.vnet` resolved, but only through the transport, which transcodes into a sandbox and **strips the page's scripts**. A tab addressed the documented way silently rendered wrong.

**The docs tab doesn't wait on the hypervisor.** Gating it there meant no docs wherever no visor starts — exactly the docs site. Both surfaces share one window now; whichever binds first opens it, the other adds a tab. (It opened two before.)

## Testing

`vnetTarget` is untagged so its test actually runs — a `js && wasm` test never executes in CI. The negative cases are the point: a claimed page renders **unsandboxed out of this origin**, so `evil.com:8002` and `vnet.example.com:80` must not match.

Verified in Brave over CDP, with both the Go and JS halves actually being served:

```
addressBar:  http://vnet:8002/
frame src:   http://127.0.0.1:7788/vnet/8002/
sandboxed:   false
windows:     visor, browser        (one browser window)
docs frame:  title "skywire", nav "command reference · prose", same-origin readable
```

Same-origin readability is the proof it rendered natively rather than being transcoded.

Refs #4527, #3704.
