### PR TITLE
fix(rewards-server): time-series charts; unbreak bandwidth-history and visor-bandwidth

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/liveness.go
+++ b/cmd/skywire-cli/commands/rewards/server/liveness.go
@@ -1,0 +1,225 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/liveness.go c4-vis-cli
+package clirewardsserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bitfield/script"
+)
+
+// Visors online over time, at five-minute resolution.
+//
+// The uptime tracker already records this and nothing displayed it: `ut tpd
+// graph --json` returns, per visor, a per-day timeline string of 288 slots —
+// one per five minutes — where '.' marks the visor as online. Summing a column
+// across every visor gives the number online in that slot, a week of network
+// liveness at 5-minute resolution.
+
+const (
+	// livenessSlotsPerDay is the timeline's fixed resolution: 288 five-minute
+	// slots covering 24 hours.
+	livenessSlotsPerDay = 288
+	// livenessOnline is the character the tracker writes for an online slot.
+	livenessOnline = '.'
+	// livenessCacheMaxAge bounds how often the ~2 MB tracker dump is pulled.
+	livenessCacheMaxAge = 10 * time.Minute
+)
+
+// livenessSeries is the summed column counts plus the labels for each slot.
+type livenessSeries struct {
+	// Counts[i] is the number of visors online in slot i, oldest first.
+	Counts []int
+	// Dates[i] is the calendar date slot i belongs to.
+	Dates []string
+	// DayStarts indexes the first slot of each day, for the x-axis ticks.
+	DayStarts []int
+	// Visors is how many visors carried a timeline at all.
+	Visors int
+}
+
+// livenessCache memoizes the tracker dump; it is megabytes and the underlying
+// data only advances one five-minute slot at a time.
+var livenessCache struct {
+	sync.Mutex
+	at     time.Time
+	series *livenessSeries
+	err    error
+}
+
+// utGraphVisor is one visor's entry in `ut tpd graph --json`.
+type utGraphVisor struct {
+	PK string `json:"pk"`
+	// Timeline maps a date to a 288-character slot string.
+	Timeline map[string]string `json:"timeline"`
+}
+
+// fetchLivenessSeries pulls the tracker's timelines and sums them by slot.
+func fetchLivenessSeries() (*livenessSeries, error) {
+	livenessCache.Lock()
+	defer livenessCache.Unlock()
+	if livenessCache.series != nil && time.Since(livenessCache.at) <= livenessCacheMaxAge {
+		return livenessCache.series, nil
+	}
+	if livenessCache.err != nil && time.Since(livenessCache.at) <= time.Minute {
+		return nil, livenessCache.err
+	}
+
+	out, err := script.Exec(`skywire cli ut tpd graph --json`).String()
+	if err != nil {
+		livenessCache.at, livenessCache.err = time.Now(), fmt.Errorf("uptime tracker query failed: %w", err)
+		return nil, livenessCache.err
+	}
+	series, err := parseLivenessSeries([]byte(out))
+	livenessCache.at = time.Now()
+	if err != nil {
+		livenessCache.err = err
+		return nil, err
+	}
+	livenessCache.series, livenessCache.err = series, nil
+	return series, nil
+}
+
+// parseLivenessSeries sums the per-visor timelines into one series.
+func parseLivenessSeries(raw []byte) (*livenessSeries, error) {
+	var visors []utGraphVisor
+	if err := json.Unmarshal(raw, &visors); err != nil {
+		return nil, fmt.Errorf("failed to parse uptime tracker graph: %w", err)
+	}
+
+	// Collect the dates present, sorted, so the series reads left to right.
+	dateSet := make(map[string]struct{})
+	counted := 0
+	for _, v := range visors {
+		if len(v.Timeline) == 0 {
+			continue
+		}
+		counted++
+		for d := range v.Timeline {
+			dateSet[d] = struct{}{}
+		}
+	}
+	if counted == 0 {
+		return nil, fmt.Errorf("uptime tracker returned no visor timelines")
+	}
+	dates := make([]string, 0, len(dateSet))
+	for d := range dateSet {
+		dates = append(dates, d)
+	}
+	sort.Strings(dates)
+
+	dayIndex := make(map[string]int, len(dates))
+	for i, d := range dates {
+		dayIndex[d] = i
+	}
+	counts := make([]int, len(dates)*livenessSlotsPerDay)
+	for _, v := range visors {
+		for d, tl := range v.Timeline {
+			base, ok := dayIndex[d]
+			if !ok {
+				continue
+			}
+			base *= livenessSlotsPerDay
+			for i := 0; i < len(tl) && i < livenessSlotsPerDay; i++ {
+				if tl[i] == livenessOnline {
+					counts[base+i]++
+				}
+			}
+		}
+	}
+
+	// The current day's timeline is pre-allocated for a full 24 hours, so every
+	// slot after "now" is a zero that has not happened yet. Charting those
+	// would show the network going dark at a midnight that has not arrived.
+	// Trim the trailing run of zeroes; the series then ends at the last slot
+	// that was actually observed.
+	end := len(counts)
+	for end > 0 && counts[end-1] == 0 {
+		end--
+	}
+	if end == 0 {
+		return nil, fmt.Errorf("uptime tracker timelines recorded no online slots")
+	}
+	counts = counts[:end]
+
+	slotDates := make([]string, len(counts))
+	var dayStarts []int
+	for i := range counts {
+		day := i / livenessSlotsPerDay
+		slotDates[i] = dates[day]
+		if i%livenessSlotsPerDay == 0 {
+			dayStarts = append(dayStarts, i)
+		}
+	}
+	return &livenessSeries{Counts: counts, Dates: slotDates, DayStarts: dayStarts, Visors: counted}, nil
+}
+
+// renderLivenessChart draws visors-online over time.
+//
+// Deliberately labeled "visors online", never "uptime": the timeline disagrees
+// with the same endpoint's daily percentage for intermittent visors (#4533), so
+// this is a liveness count and must not be read as the uptime figure the reward
+// calculation uses.
+func renderLivenessChart(s *livenessSeries, err error) string {
+	if err != nil {
+		return fmt.Sprintf("<h3>Visors Online</h3><p style='color:#FF6384;'>Visors-online series unavailable: %s</p>",
+			html.EscapeString(err.Error()))
+	}
+
+	vals := make([]float64, len(s.Counts))
+	minOn, maxOn := s.Counts[0], s.Counts[0]
+	for i, c := range s.Counts {
+		vals[i] = float64(c)
+		if c < minOn {
+			minOn = c
+		}
+		if c > maxOn {
+			maxOn = c
+		}
+	}
+
+	labels := make([]string, len(s.Dates))
+	copy(labels, s.Dates)
+	for i := range labels {
+		labels[i] = shortSlotLabel(labels[i], i)
+	}
+
+	opts := chartOpts{
+		Width: 900, Height: 260,
+		Labels:  labels,
+		XTicks:  s.DayStarts,
+		Title:   fmt.Sprintf("Visors Online (%d days, 5-minute resolution)", len(s.DayStarts)),
+		FormatY: func(v float64) string { return fmt.Sprintf("%.0f", v) },
+		YAxisLabel: fmt.Sprintf("visors reporting online, of %d with a recorded timeline — range %d to %d",
+			s.Visors, minOn, maxOn),
+	}
+	out := renderLineSVG(opts, []chartSeries{{
+		Name:  "visors online",
+		Color: "#4BC0C0",
+		Vals:  vals,
+		Note:  fmt.Sprintf("%d–%d online", minOn, maxOn),
+	}}, nil)
+	out += "<p style='color:#888;font-size:11px;'>Source: uptime tracker per-visor timelines " +
+		"(<code>ut tpd graph</code>), 288 five-minute slots per day, summed across visors. " +
+		"This is a <b>liveness count, not uptime</b>: the timeline disagrees with the same endpoint's " +
+		"daily percentage for intermittent visors (skywire#4533), and the reward calculation uses the " +
+		"daily percentage. The current day is trimmed at the last observed slot rather than padded to midnight.</p>"
+	return out
+}
+
+// shortSlotLabel keeps the year on the first tick only.
+func shortSlotLabel(date string, i int) string {
+	if i == 0 {
+		return date
+	}
+	parts := strings.Split(date, "-")
+	if len(parts) == 3 {
+		return parts[1] + "-" + parts[2]
+	}
+	return date
+}

--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -559,6 +559,8 @@ func buildRouter() *gin.Engine {
 			l += navlinks
 			l += "<h1>Skywire Network Statistics</h1>"
 
+			l += "<p><a href='/stats/charts'>Network time series (bandwidth, latency, version adoption, visors online)</a></p>"
+
 			// Transport Discovery Network Summary (on-demand cached)
 			l += renderTPDNetworkSummaryHTML()
 
@@ -686,6 +688,48 @@ func buildRouter() *gin.Engine {
 			c.Writer.Write([]byte(l)) //nolint:errcheck,gosec
 		})
 
+		// Network time series — every chart on one page. The /stats page keeps
+		// its own presentation; this is the SVG view of the same network.
+		r1.GET("/stats/charts", func(c *gin.Context) {
+			c.Writer.Header().Set("Server", "")
+			c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+			c.Writer.WriteHeader(http.StatusOK)
+
+			l := chunkedPageHead("Network Time Series", "Skywire Network bandwidth, latency, version adoption and liveness over time", "/stats/charts")
+			l += "<style type='text/css'>a { color: #3399FF; } a:visited { color: #FF00FF; }</style>"
+			l += "</head>"
+			l += "<body style='background-color:black;color:white;font-family:monospace;'>"
+			l += "<a id='top'></a>"
+			l += navlinks
+			l += "<h1>Skywire Network Over Time</h1>"
+			l += "<p>Every series the deployment publishes, drawn as inline SVG — no external scripts. " +
+				"A one-day snapshot says nothing about direction; these say where the network is going. " +
+				"<a href='/stats'>Network statistics</a> has the current-day detail.</p>"
+
+			// One TPD fetch (/metric, under 3 KB, disk-cached) feeds both the
+			// bandwidth and the latency chart, so the second costs nothing.
+			agg, aggErr := fetchTPDDailyAggregate()
+			l += renderBandwidthTimeSeries(agg, aggErr)
+			l += renderLatencyTimeSeries(agg, aggErr)
+
+			l += renderLivenessChart(fetchLivenessSeries())
+
+			l += "<h2><a href='/stats/version-history'>Version Adoption</a></h2>"
+			if history, hErr := ParseHistoricUptimeData(filepath.Join(wd, "hist"), 75.0); hErr != nil {
+				l += fmt.Sprintf("<p style='color:#FF6384;'>Version history unavailable: %v</p>", hErr)
+			} else if len(history) == 0 {
+				l += "<p style='color:#888;'>No historic uptime data on disk yet.</p>"
+			} else {
+				l += GenerateVersionHistoryChartHTML(history, 900, 320)
+			}
+
+			l += "<p><a href='/stats/visor-bandwidth'>Per-visor bandwidth</a></p>"
+			l += "<br>" + htmltoplink
+			l += "</body></html>"
+
+			c.Writer.Write([]byte(l)) //nolint:errcheck,gosec
+		})
+
 		// Version history chart route
 		r1.GET("/stats/version-history", func(c *gin.Context) {
 			c.Writer.Header().Set("Server", "")
@@ -700,24 +744,16 @@ func buildRouter() *gin.Engine {
 			l += navlinks
 			l += "<h1>Version Distribution History</h1>"
 			l += "<p>Shows the count of visors per version that achieved ≥75% uptime on each day.</p>"
+			l += "<p><a href='/stats/charts'>This chart also appears on the network time series page</a>, alongside bandwidth, latency and visors online.</p>"
 
 			histDir := filepath.Join(wd, "hist")
 			history, err := ParseHistoricUptimeData(histDir, 75.0)
 			if err != nil {
-				l += fmt.Sprintf("<p>Error loading historic data: %v</p>", err)
+				l += fmt.Sprintf("<p style='color:#FF6384;'>Error loading historic data: %v</p>", err)
 			} else if len(history) == 0 {
 				l += "<p>No historic data available</p>"
 			} else {
-				// Generate chart (responsive width)
-				chartWidth := 800
-				chartHeight := 300
-				l += GenerateVersionHistoryChartHTML(history, chartWidth, chartHeight)
-
-				// Show latest data summary
-				if len(history) > 0 {
-					latest := history[len(history)-1]
-					l += fmt.Sprintf("<h3>Latest: %s (Total: %d visors ≥75%% uptime)</h3>", latest.Date, latest.Total)
-				}
+				l += GenerateVersionHistoryChartHTML(history, 900, 320)
 			}
 
 			l += "<br>" + htmltoplink
@@ -739,16 +775,14 @@ func buildRouter() *gin.Engine {
 			l += "<a id='top'></a>"
 			l += navlinks
 			l += "<h1>Network Bandwidth History</h1>"
-			l += "<p>Shows daily total bandwidth across all transports (from Transport Discovery).</p>"
+			l += "<p>Daily total bandwidth across all transports, broken down by transport type.</p>"
+			l += "<p><a href='/stats/charts'>These series also appear on the network time series page.</a></p>"
 
-			tpdMetrics, err := fetchTPDBandwidthMetrics(7)
-			if err != nil {
-				l += fmt.Sprintf("<p>Error fetching TPD bandwidth data: %v</p>", err)
-			} else if len(tpdMetrics) == 0 {
-				l += "<p>No bandwidth data available from Transport Discovery.</p>"
-			} else {
-				l += renderTPDBandwidthHistoryChart(tpdMetrics)
-			}
+			// One fetch, two charts: the daily aggregate carries latency as
+			// well as bandwidth, and latency was previously shown nowhere.
+			agg, aggErr := fetchTPDDailyAggregate()
+			l += renderBandwidthTimeSeries(agg, aggErr)
+			l += renderLatencyTimeSeries(agg, aggErr)
 
 			l += "<br>" + htmltoplink
 			l += "</body></html>"
@@ -769,16 +803,7 @@ func buildRouter() *gin.Engine {
 			l += "<a id='top'></a>"
 			l += navlinks
 			l += "<h1>Per-Visor Bandwidth History</h1>"
-			l += "<p>Shows daily bandwidth per visor from Transport Discovery. Top 20 visors by total bandwidth shown individually.</p>"
-
-			tpdMetrics, err := fetchTPDBandwidthMetrics(7)
-			if err != nil {
-				l += fmt.Sprintf("<p>Error fetching TPD bandwidth data: %v</p>", err)
-			} else if len(tpdMetrics) == 0 {
-				l += "<p>No bandwidth data available from Transport Discovery.</p>"
-			} else {
-				l += renderTPDVisorBandwidthChart(tpdMetrics)
-			}
+			l += renderVisorBandwidthHTML()
 
 			l += "<br>" + htmltoplink
 			l += "</body></html>"

--- a/cmd/skywire-cli/commands/rewards/server/stats.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bitfield/script"
@@ -472,6 +473,30 @@ type UptimeVisor struct {
 	Daily   map[string]string `json:"daily"`
 }
 
+// histCache memoizes ParseHistoricUptimeData. The parse globs every
+// hist/*_ut.json, then reads and unmarshals all of them — hundreds of files,
+// on EVERY request to /stats and /stats/version-history. The key is the newest
+// file's modification time plus the file count, so a new daily drop (or a
+// rewritten one) invalidates it immediately; it is not a timed cache and never
+// serves data older than the directory.
+var histCache struct {
+	sync.Mutex
+	key     string
+	minUp   float64
+	entries []VersionHistoryEntry
+}
+
+// histCacheKey summarizes the directory cheaply: newest mtime + file count.
+func histCacheKey(files []string) string {
+	var newest time.Time
+	for _, f := range files {
+		if info, err := os.Stat(f); err == nil && info.ModTime().After(newest) {
+			newest = info.ModTime()
+		}
+	}
+	return fmt.Sprintf("%d|%d", len(files), newest.UnixNano())
+}
+
 // ParseHistoricUptimeData reads all _ut.json files and returns version counts per day
 // Only counts visors that had >= minUptime% uptime on each specific day
 func ParseHistoricUptimeData(histDir string, minUptime float64) ([]VersionHistoryEntry, error) {
@@ -479,6 +504,15 @@ func ParseHistoricUptimeData(histDir string, minUptime float64) ([]VersionHistor
 	if err != nil {
 		return nil, err
 	}
+
+	key := histCacheKey(files)
+	histCache.Lock()
+	if histCache.entries != nil && histCache.key == key && histCache.minUp == minUptime {
+		cached := histCache.entries
+		histCache.Unlock()
+		return cached, nil
+	}
+	histCache.Unlock()
 
 	// Sort files by date (newest first) so we use most recent data for each visor+date
 	sort.Slice(files, func(i, j int) bool {
@@ -557,6 +591,10 @@ func ParseHistoricUptimeData(histDir string, minUptime float64) ([]VersionHistor
 		})
 	}
 
+	histCache.Lock()
+	histCache.key, histCache.minUp, histCache.entries = key, minUptime, history
+	histCache.Unlock()
+
 	return history, nil
 }
 
@@ -572,28 +610,6 @@ func normalizeVersion(v string) string {
 	v = strings.ReplaceAll(v, "-dirty", "")
 	v = strings.TrimSpace(v)
 	return v
-}
-
-// getAllVersions extracts all unique versions from history, sorted by first appearance
-func getAllVersions(history []VersionHistoryEntry) []string {
-	versionSet := make(map[string]int) // version -> first seen index
-	for i, entry := range history {
-		for version := range entry.Versions {
-			if _, exists := versionSet[version]; !exists {
-				versionSet[version] = i
-			}
-		}
-	}
-
-	// Sort versions by semantic version (newest first for legend)
-	var versions []string
-	for v := range versionSet {
-		versions = append(versions, v)
-	}
-	sort.Slice(versions, func(i, j int) bool {
-		return compareVersions(versions[i], versions[j]) > 0
-	})
-	return versions
 }
 
 // compareVersions compares two version strings (simple semver comparison)
@@ -624,148 +640,122 @@ func compareVersions(a, b string) int {
 	return len(partsA) - len(partsB)
 }
 
-// GenerateVersionHistoryChartHTML creates a CSS-based stacked area chart
+// versionChartBands caps how many versions get their own band. The network has
+// carried 140+ distinct version strings; drawing every one gives an unreadable
+// chart and a path per version. The rest are summed into "other versions",
+// which is honest — the total still adds up to the day's visor count.
+const versionChartBands = 12
+
+// GenerateVersionHistoryChartHTML renders version adoption over time as an
+// inline SVG stacked area.
+//
+// This previously emitted one absolutely-positioned 1-pixel <div> per plotted
+// pixel — 14,417 elements and 2.1 MB of HTML for two years of history, which
+// took eight seconds to serve. The same data is now a handful of <path>
+// elements. Hover detail is a <title> per band rather than per pixel.
 func GenerateVersionHistoryChartHTML(history []VersionHistoryEntry, chartWidth, chartHeight int) string {
 	if len(history) == 0 {
 		return "<p>No historic data available</p>"
 	}
+	if chartWidth <= 0 {
+		chartWidth = 900
+	}
+	if chartHeight <= 0 {
+		chartHeight = 300
+	}
 
-	versions := getAllVersions(history)
-	if len(versions) == 0 {
+	// Rank versions by their PEAK SHARE of the network on any single day, then
+	// order the chosen bands oldest-first so the stack reads as an adoption
+	// curve. Ranking by total visor-days instead looks reasonable and is not:
+	// it weights by how long a version survived, so the 2024 releases with two
+	// years of accumulated days crowd out every version running today, and the
+	// whole current network collapses into the "other" band. Peak share scores
+	// a wave by how much of the network it actually held, whenever it held it.
+	share := make(map[string]float64)
+	for _, entry := range history {
+		if entry.Total == 0 {
+			continue
+		}
+		for v, c := range entry.Versions {
+			if s := float64(c) / float64(entry.Total); s > share[v] {
+				share[v] = s
+			}
+		}
+	}
+	if len(share) == 0 {
 		return "<p>No version data available</p>"
 	}
+	ranked := sortedMapKeys(share)
 
-	// Find max total for scaling
-	maxTotal := 0
-	for _, entry := range history {
-		if entry.Total > maxTotal {
-			maxTotal = entry.Total
+	top := ranked
+	var rest []string
+	if len(ranked) > versionChartBands {
+		top, rest = ranked[:versionChartBands], ranked[versionChartBands:]
+	}
+	sort.Slice(top, func(i, j int) bool { return compareVersions(top[i], top[j]) < 0 })
+
+	var series []chartSeries
+	if len(rest) > 0 {
+		vals := make([]float64, len(history))
+		restTotal := 0
+		for i, entry := range history {
+			sum := 0
+			for _, v := range rest {
+				sum += entry.Versions[v]
+			}
+			vals[i] = float64(sum)
+			restTotal += sum
 		}
+		series = append(series, chartSeries{
+			Name:  fmt.Sprintf("%d older/other versions", len(rest)),
+			Color: "#555555",
+			Vals:  vals,
+			Note:  fmt.Sprintf("%d visor-days combined", restTotal),
+		})
 	}
-	if maxTotal == 0 {
-		return "<p>No data points</p>"
-	}
-
-	// Assign colors to versions
-	versionColors := make(map[string]string)
-	for i, v := range versions {
-		versionColors[v] = pieChartColors[i%len(pieChartColors)]
-	}
-
-	var sb strings.Builder
-
-	// Container with responsive styles
-	sb.WriteString("<div style='margin: 20px 0; max-width: 100%; overflow-x: auto;'>\n")
-	sb.WriteString("<h3>Version Distribution Over Time (≥75% daily uptime)</h3>\n")
-
-	// Chart container with axes
-	sb.WriteString("<div style='display: flex; align-items: flex-end; gap: 5px; min-width: fit-content;'>\n")
-
-	// Y-axis labels
-	fmt.Fprintf(&sb, "<div style='display: flex; flex-direction: column; justify-content: space-between; height: %dpx; font-size: 11px; color: #888; text-align: right; padding-right: 5px; flex-shrink: 0;'>\n", chartHeight)
-	fmt.Fprintf(&sb, "<span>%d</span>\n", maxTotal)
-	fmt.Fprintf(&sb, "<span>%d</span>\n", maxTotal*3/4)
-	fmt.Fprintf(&sb, "<span>%d</span>\n", maxTotal/2)
-	fmt.Fprintf(&sb, "<span>%d</span>\n", maxTotal/4)
-	sb.WriteString("<span>0</span>\n")
-	sb.WriteString("</div>\n")
-
-	// Chart area - use min-width so it can scroll on mobile
-	fmt.Fprintf(&sb, "<div style='position: relative; min-width: %dpx; height: %dpx; border-left: 1px solid #444; border-bottom: 1px solid #444; background: #1a1a1a; flex-shrink: 0;'>\n", chartWidth, chartHeight) //nolint:errcheck,gosec
-
-	// Grid lines
-	for i := 1; i <= 4; i++ {
-		y := chartHeight - (chartHeight * i / 4)
-		fmt.Fprintf(&sb, "<div style='position: absolute; left: 0; right: 0; top: %dpx; border-top: 1px dashed #333;'></div>\n", y) //nolint:errcheck,gosec
+	for i, v := range top {
+		vals := make([]float64, len(history))
+		peak := 0
+		for di, entry := range history {
+			c := entry.Versions[v]
+			vals[di] = float64(c)
+			if c > peak {
+				peak = c
+			}
+		}
+		series = append(series, chartSeries{
+			Name:  v,
+			Color: chartColors[i%len(chartColors)],
+			Vals:  vals,
+			Note:  fmt.Sprintf("peak %d visors", peak),
+		})
 	}
 
-	// Calculate bar width
-	barWidth := chartWidth / len(history)
-	if barWidth < 2 {
-		barWidth = 2
-	}
-
-	// Draw stacked bars for each day
+	dates := make([]string, len(history))
 	for i, entry := range history {
-		x := i * barWidth
-		currentY := 0
-
-		// Draw each version's segment (stacked)
-		for _, version := range versions {
-			count := entry.Versions[version]
-			if count == 0 {
-				continue
-			}
-
-			segmentHeight := count * chartHeight / maxTotal
-			if segmentHeight < 1 {
-				segmentHeight = 1
-			}
-
-			color := versionColors[version]
-			bottom := currentY
-			currentY += segmentHeight
-
-			fmt.Fprintf(&sb, "<div style='position: absolute; left: %dpx; bottom: %dpx; width: %dpx; height: %dpx; background: %s;' title='%s: %s (%d)'></div>\n", //nolint:errcheck,gosec
-				x, bottom, barWidth-1, segmentHeight, color, entry.Date, version, count)
-		}
+		dates[i] = entry.Date
 	}
 
-	sb.WriteString("</div>\n") // chart area
-	sb.WriteString("</div>\n") // flex container
-
-	// X-axis labels (show every Nth date to avoid crowding)
-	labelInterval := len(history) / 10
-	if labelInterval < 1 {
-		labelInterval = 1
+	opts := chartOpts{
+		Width: chartWidth, Height: chartHeight,
+		Labels:     shortDates(dates),
+		Title:      fmt.Sprintf("Version Distribution Over Time (≥75%% daily uptime, %d days)", len(history)),
+		YAxisLabel: "visors per version, stacked",
+		FormatY:    func(v float64) string { return strconv.FormatFloat(v, 'f', 0, 64) },
+		MaxXLabels: 10,
 	}
+	out := renderStackedAreaSVG(opts, series)
 
-	fmt.Fprintf(&sb, "<div style='position: relative; margin-left: 40px; height: 20px; min-width: %dpx; font-size: 10px; color: #888;'>\n", chartWidth) //nolint:errcheck,gosec
-	lastLabelIdx := -1
-	prevYear := ""
-	for i, entry := range history {
-		isRegular := i%labelInterval == 0
-		isLast := i == len(history)-1
-
-		if !isRegular && !isLast {
-			continue
-		}
-
-		// Skip last label if it would overlap the previous label
-		if isLast && lastLabelIdx >= 0 && (i-lastLabelIdx) < labelInterval/2 {
-			continue
-		}
-
-		dateParts := strings.Split(entry.Date, "-")
-		label := entry.Date
-		if len(dateParts) == 3 {
-			year := dateParts[0]
-			// Show year on first label and when year changes
-			if prevYear == "" || year != prevYear {
-				label = dateParts[0] + "-" + dateParts[1] + "-" + dateParts[2]
-				prevYear = year
-			} else {
-				label = dateParts[1] + "-" + dateParts[2]
-			}
-		}
-
-		x := i * barWidth
-		fmt.Fprintf(&sb, "<span style='position: absolute; left: %dpx;'>%s</span>\n", x, label) //nolint:errcheck,gosec
-		lastLabelIdx = i
+	// The most recent days as text — the readable form of the right edge.
+	latest := history[len(history)-1]
+	out += fmt.Sprintf("<p>Latest: <b>%s</b> — %d visors at ≥75%% uptime.</p>",
+		html.EscapeString(latest.Date), latest.Total)
+	out += "<details style='margin:8px 0;'><summary style='cursor:pointer;color:#3399FF;'>latest day, all versions</summary><pre>"
+	for _, v := range sortedMapKeys(latest.Versions) {
+		out += fmt.Sprintf("%-28s %d\n", html.EscapeString(v), latest.Versions[v])
 	}
-	sb.WriteString("</div>\n")
-
-	// Legend - responsive wrapping
-	sb.WriteString("<div style='margin-top: 15px; display: flex; flex-wrap: wrap; gap: 8px 15px; font-size: 12px;'>\n")
-	for _, version := range versions {
-		color := versionColors[version]
-		fmt.Fprintf(&sb, "<span style='display: inline-flex; align-items: center; gap: 4px; white-space: nowrap;'><span style='display: inline-block; width: 12px; height: 12px; background: %s; flex-shrink: 0;'></span>%s</span>\n", color, html.EscapeString(version)) //nolint:errcheck,gosec
-	}
-	sb.WriteString("</div>\n")
-
-	sb.WriteString("</div>\n") // container
-
-	return sb.String()
+	out += "</pre></details>"
+	return out
 }
 
 // GeneratePieChartHTML generates a CSS-based pie chart with legend
@@ -1337,6 +1327,7 @@ type tpdNetworkSummary struct {
 }
 
 const tpdSummaryCacheFile = "tpd_summary.json"
+
 const tpdSummaryCacheMaxAge = 5 * time.Minute
 
 // getTPDNetworkSummary returns cached TPD network summary, fetching fresh data
@@ -1531,206 +1522,6 @@ func renderTPDNetworkSummaryHTML() string {
 
 	l += "</pre>"
 	l += fmt.Sprintf("<p style='color: #888; font-size: 0.8em;'>Last updated: %s</p>", summary.LastUpdated)
-	return l
-}
-
-// renderTPDBandwidthHistoryChart generates a bar chart of daily total bandwidth from TPD metrics.
-func renderTPDBandwidthHistoryChart(metrics []tpdTransportMetric) string {
-	// Aggregate bandwidth by date
-	dailyTotals := make(map[string]uint64)
-	for _, m := range metrics {
-		for _, d := range m.Daily {
-			var bw uint64
-			if d.A != nil {
-				bw += d.A.Sent + d.A.Recv
-			}
-			if d.B != nil {
-				bw += d.B.Sent + d.B.Recv
-			}
-			dailyTotals[d.Date] += bw
-		}
-	}
-
-	if len(dailyTotals) == 0 {
-		return "<p>No bandwidth data available.</p>"
-	}
-
-	// Sort dates
-	var dates []string
-	for d := range dailyTotals {
-		dates = append(dates, d)
-	}
-	sort.Strings(dates)
-
-	// Build Chart.js bar chart
-	var labels, data []string
-	for _, d := range dates {
-		parts := strings.Split(d, "-")
-		label := d
-		if len(parts) == 3 {
-			label = parts[1] + "-" + parts[2]
-		}
-		labels = append(labels, fmt.Sprintf("'%s'", label))
-		data = append(data, fmt.Sprintf("%d", dailyTotals[d]))
-	}
-
-	l := "<canvas id='bw-history-chart' width='800' height='300'></canvas>\n"
-	l += "<script src='https://cdn.jsdelivr.net/npm/chart.js'></script>\n"
-	l += "<script>\n"
-	l += "new Chart(document.getElementById('bw-history-chart'), {\n"
-	l += "  type: 'bar',\n"
-	l += "  data: {\n"
-	l += "    labels: [" + strings.Join(labels, ",") + "],\n"
-	l += "    datasets: [{\n"
-	l += "      label: 'Total Bandwidth (bytes)',\n"
-	l += "      data: [" + strings.Join(data, ",") + "],\n"
-	l += "      backgroundColor: '#36A2EB'\n"
-	l += "    }]\n"
-	l += "  },\n"
-	l += "  options: {\n"
-	l += "    responsive: true,\n"
-	l += "    plugins: { legend: { labels: { color: 'white' } } },\n"
-	l += "    scales: {\n"
-	l += "      x: { ticks: { color: 'white' }, grid: { color: '#333' } },\n"
-	l += "      y: { ticks: { color: 'white', callback: function(v) { if(v>=1073741824) return (v/1073741824).toFixed(1)+'GB'; if(v>=1048576) return (v/1048576).toFixed(1)+'MB'; if(v>=1024) return (v/1024).toFixed(1)+'KB'; return v+'B'; } }, grid: { color: '#333' } }\n"
-	l += "    }\n"
-	l += "  }\n"
-	l += "});\n"
-	l += "</script>\n"
-
-	// Summary table
-	l += "<table style='border-collapse:collapse;margin-top:10px;'>"
-	l += "<tr><th style='border:1px solid #444;padding:4px 8px;'>Date</th><th style='border:1px solid #444;padding:4px 8px;'>Bandwidth</th></tr>"
-	for _, d := range dates {
-		parts := strings.Split(d, "-")
-		label := d
-		if len(parts) == 3 {
-			label = parts[1] + "-" + parts[2]
-		}
-		l += fmt.Sprintf("<tr><td style='border:1px solid #444;padding:4px 8px;'>%s</td><td style='border:1px solid #444;padding:4px 8px;'>%s</td></tr>", label, formatBytesChart(dailyTotals[d]))
-	}
-	l += "</table>"
-
-	return l
-}
-
-// renderTPDVisorBandwidthChart generates a stacked bar chart of per-visor bandwidth from TPD metrics.
-func renderTPDVisorBandwidthChart(metrics []tpdTransportMetric) string {
-	// Aggregate bandwidth per visor (by edge PKs) per date
-	type visorBW struct {
-		pk      string
-		daily   map[string]uint64
-		totalBW uint64
-	}
-
-	visorMap := make(map[string]*visorBW)
-	for _, m := range metrics {
-		for _, edge := range m.Edges {
-			if _, ok := visorMap[edge]; !ok {
-				visorMap[edge] = &visorBW{pk: edge, daily: make(map[string]uint64)}
-			}
-		}
-		for _, d := range m.Daily {
-			var bw uint64
-			if d.A != nil {
-				bw += d.A.Sent + d.A.Recv
-			}
-			if d.B != nil {
-				bw += d.B.Sent + d.B.Recv
-			}
-			// Attribute to both edges
-			for _, edge := range m.Edges {
-				if v, ok := visorMap[edge]; ok {
-					v.daily[d.Date] += bw
-					v.totalBW += bw
-				}
-			}
-		}
-	}
-
-	if len(visorMap) == 0 {
-		return "<p>No per-visor bandwidth data available.</p>"
-	}
-
-	// Sort visors by total bandwidth, take top 20
-	var allVisors []*visorBW
-	for _, v := range visorMap {
-		allVisors = append(allVisors, v)
-	}
-	sort.Slice(allVisors, func(i, j int) bool {
-		return allVisors[i].totalBW > allVisors[j].totalBW
-	})
-
-	maxVisors := 20
-	if len(allVisors) < maxVisors {
-		maxVisors = len(allVisors)
-	}
-	topVisors := allVisors[:maxVisors]
-
-	// Collect all dates
-	dateSet := make(map[string]struct{})
-	for _, v := range topVisors {
-		for d := range v.daily {
-			dateSet[d] = struct{}{}
-		}
-	}
-	var dates []string
-	for d := range dateSet {
-		dates = append(dates, d)
-	}
-	sort.Strings(dates)
-
-	// Build labels
-	var labels []string
-	for _, d := range dates {
-		parts := strings.Split(d, "-")
-		label := d
-		if len(parts) == 3 {
-			label = parts[1] + "-" + parts[2]
-		}
-		labels = append(labels, fmt.Sprintf("'%s'", label))
-	}
-
-	// Colors for datasets
-	colors := []string{
-		"#FF6384", "#36A2EB", "#FFCE56", "#4BC0C0", "#9966FF",
-		"#FF9F40", "#C9CBCF", "#7BC8A4", "#E7E9ED", "#FF6B6B",
-		"#4ECDC4", "#45B7D1", "#96CEB4", "#FFEEAD", "#D4A5A5",
-		"#9B59B6", "#3498DB", "#E74C3C", "#2ECC71", "#F39C12",
-	}
-
-	// Build datasets
-	var datasets []string
-	for i, v := range topVisors {
-		var data []string
-		for _, d := range dates {
-			data = append(data, fmt.Sprintf("%d", v.daily[d]))
-		}
-		color := colors[i%len(colors)]
-		datasets = append(datasets, fmt.Sprintf("{ label: '%s', data: [%s], backgroundColor: '%s' }",
-			v.pk, strings.Join(data, ","), color))
-	}
-
-	l := "<canvas id='visor-bw-chart' width='800' height='400'></canvas>\n"
-	l += "<script src='https://cdn.jsdelivr.net/npm/chart.js'></script>\n"
-	l += "<script>\n"
-	l += "new Chart(document.getElementById('visor-bw-chart'), {\n"
-	l += "  type: 'bar',\n"
-	l += "  data: {\n"
-	l += "    labels: [" + strings.Join(labels, ",") + "],\n"
-	l += "    datasets: [" + strings.Join(datasets, ",\n") + "]\n"
-	l += "  },\n"
-	l += "  options: {\n"
-	l += "    responsive: true,\n"
-	l += "    scales: {\n"
-	l += "      x: { stacked: true, ticks: { color: 'white' }, grid: { color: '#333' } },\n"
-	l += "      y: { stacked: true, ticks: { color: 'white', callback: function(v) { if(v>=1073741824) return (v/1073741824).toFixed(1)+'GB'; if(v>=1048576) return (v/1048576).toFixed(1)+'MB'; if(v>=1024) return (v/1024).toFixed(1)+'KB'; return v+'B'; } }, grid: { color: '#333' } }\n"
-	l += "    },\n"
-	l += "    plugins: { legend: { labels: { color: 'white', font: { size: 10 } } } }\n"
-	l += "  }\n"
-	l += "});\n"
-	l += "</script>\n"
-
 	return l
 }
 

--- a/cmd/skywire-cli/commands/rewards/server/svgchart.go
+++ b/cmd/skywire-cli/commands/rewards/server/svgchart.go
@@ -1,0 +1,512 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/svgchart.go c4-vis-cli
+package clirewardsserver
+
+import (
+	"fmt"
+	"html"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Server-rendered SVG charting for the /stats pages.
+//
+// These pages carry no external JS or CSS — no CDN, no chart library — so the
+// charts are emitted as inline SVG with a handful of elements each. The
+// predecessor drew a stacked area as one absolutely-positioned 1-pixel <div>
+// per pixel: 14,417 elements and 2.1 MB of HTML for the version history alone.
+// A <path> per series replaces the whole column of divs.
+
+// chartColors is the categorical palette shared by every chart here. It is the
+// pie-chart palette with the same leading entries, so a version or transport
+// type keeps a recognizable color across the page.
+var chartColors = []string{
+	"#36A2EB", "#FF6384", "#4BC0C0", "#FFCE56", "#9966FF",
+	"#FF9F40", "#7BC8A4", "#C9CBCF", "#E7526B", "#45B7D1",
+	"#96CEB4", "#D4A5A5", "#9B59B6", "#2ECC71", "#F39C12",
+	"#3498DB", "#E74C3C", "#1ABC9C", "#E67E22", "#95A5A6",
+}
+
+// chartSeries is one named band or line, aligned index-for-index with the
+// chart's label slice.
+type chartSeries struct {
+	Name  string
+	Color string
+	// Vals is the series, aligned to chartOpts.Labels. A NaN is a RECORDED GAP
+	// — no measurement for that index — and the line renderer breaks rather
+	// than bridging it. That distinction matters for averages like latency: a
+	// line dropped to the axis reads as "measured 0 ms", which is a phantom
+	// measurement, not a missing one.
+	Vals []float64
+	// Note is appended to the series' <title>, e.g. a peak or current value.
+	Note string
+}
+
+// chartOpts controls the shared geometry and axis formatting.
+type chartOpts struct {
+	// Width/Height are viewBox units. The <svg> itself is width:100% so the
+	// chart scales to the viewport; the viewBox fixes the aspect ratio.
+	Width, Height int
+	// Labels are the x-axis categories (dates), one per data index.
+	Labels []string
+	// FormatY renders a y-axis tick. Defaults to a plain integer.
+	FormatY func(float64) string
+	// Title is rendered above the chart as an <h3>.
+	Title string
+	// YAxisLabel is shown under the title, e.g. the unit.
+	YAxisLabel string
+	// MaxXLabels caps how many x labels are drawn before thinning.
+	MaxXLabels int
+	// XTicks names the exact indices to label. When set it overrides the
+	// even-stride thinning, which is what a series sampled far finer than its
+	// natural period needs — 288 five-minute slots per day want a label on each
+	// day boundary, not every 252nd slot.
+	XTicks []int
+}
+
+const (
+	chartMarginLeft   = 62
+	chartMarginRight  = 12
+	chartMarginTop    = 10
+	chartMarginBottom = 26
+)
+
+func (o chartOpts) plotWidth() int  { return o.Width - chartMarginLeft - chartMarginRight }
+func (o chartOpts) plotHeight() int { return o.Height - chartMarginTop - chartMarginBottom }
+
+// fmtCoord trims a coordinate to one decimal and drops a trailing ".0". Over
+// thousands of points this is a material share of the document size.
+func fmtCoord(v float64) string {
+	s := strconv.FormatFloat(v, 'f', 1, 64)
+	return strings.TrimSuffix(s, ".0")
+}
+
+// niceTicks returns up to n round-numbered gridline values spanning 0..max.
+func niceTicks(max float64, n int) []float64 {
+	if max <= 0 || n <= 0 {
+		return []float64{0}
+	}
+	raw := max / float64(n)
+	mag := 1.0
+	for mag*10 <= raw {
+		mag *= 10
+	}
+	for mag > raw && mag > 1e-9 {
+		mag /= 10
+	}
+	step := mag
+	for _, m := range []float64{1, 2, 2.5, 5, 10} {
+		if mag*m >= raw {
+			step = mag * m
+			break
+		}
+	}
+	var ticks []float64
+	for v := 0.0; v <= max*1.0001; v += step {
+		ticks = append(ticks, v)
+	}
+	if len(ticks) == 0 {
+		ticks = []float64{0, max}
+	}
+	return ticks
+}
+
+// chartFrame emits the gridlines, y tick labels, x labels and the axis line.
+// Shared by the stacked-area and line renderers so both read identically.
+func chartFrame(sb *strings.Builder, o chartOpts, vmax float64) {
+	iw, ih := o.plotWidth(), o.plotHeight()
+	formatY := o.FormatY
+	if formatY == nil {
+		formatY = func(v float64) string { return strconv.FormatFloat(v, 'f', -1, 64) }
+	}
+	yOf := func(v float64) float64 {
+		if vmax <= 0 {
+			return float64(chartMarginTop + ih)
+		}
+		return float64(chartMarginTop) + float64(ih) - v/vmax*float64(ih)
+	}
+
+	for _, t := range niceTicks(vmax, 4) {
+		y := fmtCoord(yOf(t))
+		fmt.Fprintf(sb, "<line x1='%d' x2='%d' y1='%s' y2='%s' stroke='#333' stroke-dasharray='3 3'/>",
+			chartMarginLeft, chartMarginLeft+iw, y, y)
+		fmt.Fprintf(sb, "<text x='%d' y='%s' text-anchor='end' fill='#888' font-size='10'>%s</text>",
+			chartMarginLeft-6, fmtCoord(yOf(t)+3.5), html.EscapeString(formatY(t)))
+	}
+	fmt.Fprintf(sb, "<line x1='%d' x2='%d' y1='%d' y2='%d' stroke='#555'/>",
+		chartMarginLeft, chartMarginLeft+iw, chartMarginTop+ih, chartMarginTop+ih)
+
+	// X labels, thinned so they cannot overlap.
+	n := len(o.Labels)
+	if n == 0 {
+		return
+	}
+	if len(o.XTicks) > 0 {
+		for _, i := range o.XTicks {
+			if i < 0 || i >= n {
+				continue
+			}
+			anchor := "middle"
+			if i == 0 {
+				anchor = "start"
+			} else if i == n-1 {
+				anchor = "end"
+			}
+			fmt.Fprintf(sb, "<text x='%s' y='%d' text-anchor='%s' fill='#888' font-size='10'>%s</text>",
+				fmtCoord(chartX(o, i)), o.Height-6, anchor, html.EscapeString(o.Labels[i]))
+		}
+		return
+	}
+
+	maxLabels := o.MaxXLabels
+	if maxLabels <= 0 {
+		maxLabels = 8
+	}
+	step := 1
+	if n > maxLabels {
+		step = (n + maxLabels - 1) / maxLabels
+	}
+	last := n - 1
+	for i := 0; i < n; i += step {
+		// Leave the right edge to the final label below, so a thinned label and
+		// the last one cannot land on top of each other.
+		if i != 0 && last-i < step {
+			break
+		}
+		anchor := "middle"
+		if i == 0 {
+			anchor = "start"
+		}
+		fmt.Fprintf(sb, "<text x='%s' y='%d' text-anchor='%s' fill='#888' font-size='10'>%s</text>",
+			fmtCoord(chartX(o, i)), o.Height-6, anchor, html.EscapeString(o.Labels[i]))
+	}
+	if n > 1 {
+		fmt.Fprintf(sb, "<text x='%s' y='%d' text-anchor='end' fill='#888' font-size='10'>%s</text>",
+			fmtCoord(chartX(o, last)), o.Height-6, html.EscapeString(o.Labels[last]))
+	}
+}
+
+// svgOpenTag sizes the chart from its viewBox alone: width:100% with height
+// auto scales uniformly, so the axis text scales with the plot. An explicit
+// pixel height would let a wide viewport stretch x without y and smear the
+// labels sideways.
+func svgOpenTag(o chartOpts) string {
+	return fmt.Sprintf("<svg viewBox='0 0 %d %d' role='img' style='width:100%%;height:auto;max-width:%dpx;background:#111;'>",
+		o.Width, o.Height, o.Width*2)
+}
+
+// chartX maps a data index to a viewBox x coordinate.
+func chartX(o chartOpts, i int) float64 {
+	n := len(o.Labels)
+	if n <= 1 {
+		return float64(chartMarginLeft + o.plotWidth()/2)
+	}
+	return float64(chartMarginLeft) + float64(i)/float64(n-1)*float64(o.plotWidth())
+}
+
+// renderStackedAreaSVG draws series as a stacked area, one <path> per series.
+//
+// The bands are drawn as OVERLAPPING cumulative areas — the full stack first,
+// then the stack minus the top series, and so on — rather than as closed
+// ribbons. Each band therefore needs only its own upper edge plus two points to
+// close along the baseline, which halves the coordinate count versus emitting
+// an up-path and a reversed down-path per band. Painter order makes the visible
+// result identical to a conventional stack.
+func renderStackedAreaSVG(o chartOpts, series []chartSeries) string {
+	n := len(o.Labels)
+	if n == 0 || len(series) == 0 {
+		return "<p style='color:#888;'>No data points.</p>"
+	}
+
+	// Cumulative totals, and the running sums each band's upper edge sits at.
+	upper := make([][]float64, len(series))
+	running := make([]float64, n)
+	for si := range series {
+		edge := make([]float64, n)
+		for i := 0; i < n; i++ {
+			if i < len(series[si].Vals) {
+				running[i] += series[si].Vals[i]
+			}
+			edge[i] = running[i]
+		}
+		upper[si] = edge
+	}
+	vmax := 0.0
+	for _, v := range running {
+		if v > vmax {
+			vmax = v
+		}
+	}
+	if vmax <= 0 {
+		return "<p style='color:#888;'>No data points.</p>"
+	}
+
+	ih := o.plotHeight()
+	baseY := float64(chartMarginTop + ih)
+	yOf := func(v float64) float64 { return baseY - v/vmax*float64(ih) }
+
+	var sb strings.Builder
+	if o.Title != "" {
+		fmt.Fprintf(&sb, "<h3>%s</h3>", html.EscapeString(o.Title))
+	}
+	if o.YAxisLabel != "" {
+		fmt.Fprintf(&sb, "<p style='color:#888;font-size:11px;margin:2px 0;'>%s</p>", html.EscapeString(o.YAxisLabel))
+	}
+	sb.WriteString(svgOpenTag(o))
+	chartFrame(&sb, o, vmax)
+
+	// Paint from the outermost cumulative band inward, so each successive
+	// (smaller) area covers the one below it and the uncovered remainder is
+	// exactly that series' contribution.
+	for si := len(series) - 1; si >= 0; si-- {
+		d := cumulativePath(o, upper[si], yOf, baseY)
+		if d == "" {
+			continue
+		}
+		fmt.Fprintf(&sb, "<path d='%s' fill='%s' fill-opacity='0.9' stroke='%s' stroke-width='0.4'><title>%s</title></path>",
+			d, series[si].Color, series[si].Color, html.EscapeString(seriesTitle(series[si])))
+	}
+	sb.WriteString("</svg>")
+	sb.WriteString(renderChartLegend(series))
+	return sb.String()
+}
+
+// cumulativePath builds the closed area under one cumulative edge.
+//
+// Coordinates are rounded to whole viewBox units — the plot is a few hundred
+// units tall and sub-unit precision is invisible — and runs of points that
+// round to the same y are collapsed to the run's first and last point. Keeping
+// BOTH ends of a flat run matters: dropping the interior only would leave the
+// path sloping across the whole run instead of running flat and then stepping,
+// which silently redraws the data. Two years of daily version counts sit still
+// for long stretches, so this is most of the compression.
+//
+// Consecutive line-tos also drop the repeated "L" command, which SVG allows.
+func cumulativePath(o chartOpts, edge []float64, yOf func(float64) float64, baseY float64) string {
+	n := len(o.Labels)
+	if n == 0 {
+		return ""
+	}
+	xs := make([]int, n)
+	ys := make([]int, n)
+	for i := 0; i < n; i++ {
+		v := 0.0
+		if i < len(edge) {
+			v = edge[i]
+		}
+		xs[i] = int(chartX(o, i) + 0.5)
+		ys[i] = int(yOf(v) + 0.5)
+	}
+
+	d, emitted := compactPath(xs, ys)
+	if emitted == 0 {
+		return ""
+	}
+	if emitted == 1 {
+		d.WriteString("L")
+	} else {
+		d.WriteString(" ")
+	}
+	fmt.Fprintf(d, "%d %d %d %dZ", xs[n-1], int(baseY+0.5), xs[0], int(baseY+0.5))
+	return d.String()
+}
+
+// gapY marks an index with no measurement. Real y coordinates are viewBox
+// units, always well inside the canvas, so a large sentinel cannot collide.
+const gapY = math.MinInt32
+
+// compactPath encodes rounded points as SVG path data: runs of points sharing a
+// y are collapsed to the run's two ends, consecutive line-tos drop the repeated
+// "L", and a gapY lifts the pen so a missing measurement breaks the line
+// instead of being bridged or drawn down to the axis. Returns the builder and
+// the number of points emitted.
+func compactPath(xs, ys []int) (*strings.Builder, int) {
+	var d strings.Builder
+	n := len(ys)
+	emitted := 0
+	// inSub counts points already written in the CURRENT subpath: 0 means the
+	// next point opens one with "M", 1 means it needs an explicit "L", and from
+	// 2 on the lineto is implicit and only a separator is written.
+	inSub := 0
+	for i := 0; i < n; i++ {
+		if ys[i] == gapY {
+			inSub = 0
+			continue
+		}
+		// Drop the interior of a flat run, keeping the point that starts it and
+		// the point that ends it. Keeping only one end would leave the line
+		// sloping across the whole run instead of running flat and then
+		// stepping, which redraws the data.
+		if inSub > 0 && i > 0 && i < n-1 && ys[i-1] == ys[i] && ys[i+1] == ys[i] {
+			continue
+		}
+		switch inSub {
+		case 0:
+			d.WriteString("M")
+		case 1:
+			d.WriteString("L")
+		default:
+			d.WriteString(" ")
+		}
+		fmt.Fprintf(&d, "%d %d", xs[i], ys[i])
+		inSub++
+		emitted++
+	}
+	return &d, emitted
+}
+
+// renderLineSVG draws each series as one <polyline>, with a transparent hit
+// rect per x column carrying the full cross-series readout for that column as
+// a <title>. That is one element per date rather than one per pixel, so hover
+// detail survives without the document size.
+func renderLineSVG(o chartOpts, series []chartSeries, hover []string) string {
+	n := len(o.Labels)
+	if n == 0 || len(series) == 0 {
+		return "<p style='color:#888;'>No data points.</p>"
+	}
+	vmax := 0.0
+	for _, s := range series {
+		for _, v := range s.Vals {
+			if !math.IsNaN(v) && v > vmax {
+				vmax = v
+			}
+		}
+	}
+	if vmax <= 0 {
+		return "<p style='color:#888;'>No data points.</p>"
+	}
+
+	ih := o.plotHeight()
+	baseY := float64(chartMarginTop + ih)
+	yOf := func(v float64) float64 { return baseY - v/vmax*float64(ih) }
+
+	var sb strings.Builder
+	if o.Title != "" {
+		fmt.Fprintf(&sb, "<h3>%s</h3>", html.EscapeString(o.Title))
+	}
+	if o.YAxisLabel != "" {
+		fmt.Fprintf(&sb, "<p style='color:#888;font-size:11px;margin:2px 0;'>%s</p>", html.EscapeString(o.YAxisLabel))
+	}
+	sb.WriteString(svgOpenTag(o))
+	chartFrame(&sb, o, vmax)
+
+	for _, s := range series {
+		// A <path> rather than a <polyline> so the pen can lift over a gap.
+		xs, ys := make([]int, n), make([]int, n)
+		measured := 0
+		for i := 0; i < n; i++ {
+			v := math.NaN()
+			if i < len(s.Vals) {
+				v = s.Vals[i]
+			}
+			xs[i] = int(chartX(o, i) + 0.5)
+			if math.IsNaN(v) {
+				ys[i] = gapY
+				continue
+			}
+			ys[i] = int(yOf(v) + 0.5)
+			measured++
+		}
+		d, emitted := compactPath(xs, ys)
+		if emitted == 0 {
+			continue
+		}
+		fmt.Fprintf(&sb, "<path d='%s' fill='none' stroke='%s' stroke-width='2' stroke-linejoin='round' stroke-linecap='round'><title>%s</title></path>",
+			d.String(), s.Color, html.EscapeString(seriesTitle(s)))
+		// A single measured point draws no stroke at all, so mark it.
+		if measured == 1 {
+			for i := 0; i < n; i++ {
+				if ys[i] != gapY {
+					fmt.Fprintf(&sb, "<circle cx='%d' cy='%d' r='3' fill='%s'/>", xs[i], ys[i], s.Color)
+					break
+				}
+			}
+		}
+	}
+	writeHoverRects(&sb, o, hover)
+	sb.WriteString("</svg>")
+	sb.WriteString(renderChartLegend(series))
+	return sb.String()
+}
+
+// writeHoverRects emits one transparent column per data index whose <title> is
+// the readout for that column. Skipped when there is no readout to show.
+func writeHoverRects(sb *strings.Builder, o chartOpts, hover []string) {
+	n := len(o.Labels)
+	if len(hover) == 0 || n == 0 {
+		return
+	}
+	w := float64(o.plotWidth()) / float64(n)
+	if w <= 0 {
+		return
+	}
+	for i := 0; i < n && i < len(hover); i++ {
+		if hover[i] == "" {
+			continue
+		}
+		x := chartX(o, i) - w/2
+		if x < float64(chartMarginLeft) {
+			x = float64(chartMarginLeft)
+		}
+		fmt.Fprintf(sb, "<rect x='%s' y='%d' width='%s' height='%d' fill='transparent'><title>%s</title></rect>",
+			fmtCoord(x), chartMarginTop, fmtCoord(w), o.plotHeight(), html.EscapeString(hover[i]))
+	}
+}
+
+func seriesTitle(s chartSeries) string {
+	if s.Note != "" {
+		return s.Name + " — " + s.Note
+	}
+	return s.Name
+}
+
+// renderChartLegend renders the swatch list under a chart.
+func renderChartLegend(series []chartSeries) string {
+	var sb strings.Builder
+	sb.WriteString("<div style='margin-top:8px;display:flex;flex-wrap:wrap;gap:6px 14px;font-size:12px;'>")
+	for _, s := range series {
+		fmt.Fprintf(&sb, "<span style='display:inline-flex;align-items:center;gap:4px;white-space:nowrap;'><span style='display:inline-block;width:11px;height:11px;background:%s;flex-shrink:0;'></span>%s</span>",
+			s.Color, html.EscapeString(s.Name))
+	}
+	sb.WriteString("</div>")
+	return sb.String()
+}
+
+// shortDate turns 2026-09-04 into 09-04, keeping the year only when it changes
+// across the label set.
+func shortDates(dates []string) []string {
+	out := make([]string, len(dates))
+	prevYear := ""
+	for i, d := range dates {
+		parts := strings.Split(d, "-")
+		if len(parts) != 3 {
+			out[i] = d
+			continue
+		}
+		if parts[0] != prevYear {
+			out[i] = d
+			prevYear = parts[0]
+			continue
+		}
+		out[i] = parts[1] + "-" + parts[2]
+	}
+	return out
+}
+
+// sortedMapKeys returns a map's keys ordered by descending value, ties broken
+// by name. Ranging a Go map directly reshuffles rendered output between
+// requests, which makes unchanged data look like it moved.
+func sortedMapKeys[V int | uint64 | float64](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if m[keys[i]] != m[keys[j]] {
+			return m[keys[i]] > m[keys[j]]
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}

--- a/cmd/skywire-cli/commands/rewards/server/svgchart_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/svgchart_test.go
@@ -1,0 +1,210 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/svgchart_test.go c4-vis-cli
+package clirewardsserver
+
+import (
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func lineOpts(n int) chartOpts {
+	labels := make([]string, n)
+	for i := range labels {
+		labels[i] = "d"
+	}
+	return chartOpts{Width: 900, Height: 300, Labels: labels}
+}
+
+// A flat run must keep BOTH of its ends. Dropping only the interior would leave
+// the path sloping across the whole run instead of running flat then stepping,
+// which redraws the data while looking like a size optimization.
+func TestCumulativePathKeepsBothEndsOfAFlatRun(t *testing.T) {
+	o := lineOpts(6)
+	edge := []float64{10, 10, 10, 10, 50, 50}
+	yOf := func(v float64) float64 { return 200 - v }
+
+	d := cumulativePath(o, edge, yOf, 260)
+	// Points at index 0 and 3 bound the flat run; index 1 and 2 are interior.
+	x0, x3 := int(chartX(o, 0)+0.5), int(chartX(o, 3)+0.5)
+	if !strings.Contains(d, "M"+itoa(x0)+" 190") {
+		t.Fatalf("missing start of flat run in %q", d)
+	}
+	if !strings.Contains(d, itoa(x3)+" 190") {
+		t.Fatalf("missing end of flat run in %q", d)
+	}
+	x1 := int(chartX(o, 1) + 0.5)
+	if strings.Contains(d, itoa(x1)+" 190") {
+		t.Errorf("interior point of flat run was kept in %q", d)
+	}
+}
+
+// The whole point of the rewrite: a long series must not cost one element per
+// point. The predecessor emitted 14,417 absolutely-positioned divs.
+func TestStackedAreaEmitsOneElementPerSeries(t *testing.T) {
+	n := 600
+	o := lineOpts(n)
+	o.Labels = make([]string, n)
+	for i := range o.Labels {
+		o.Labels[i] = "2026-01-01"
+	}
+	var series []chartSeries
+	for s := 0; s < 5; s++ {
+		vals := make([]float64, n)
+		for i := range vals {
+			vals[i] = float64(i%7 + s)
+		}
+		series = append(series, chartSeries{Name: "s", Color: "#fff", Vals: vals})
+	}
+	out := renderStackedAreaSVG(o, series)
+	if got := strings.Count(out, "<path"); got != len(series) {
+		t.Errorf("got %d paths for %d series, want one each", got, len(series))
+	}
+	if strings.Contains(out, "position: absolute") {
+		t.Error("stacked area fell back to positioned divs")
+	}
+	if strings.Contains(out, "cdn.") || strings.Contains(out, "<script") {
+		t.Error("chart pulled in external script; these pages must be self-contained")
+	}
+}
+
+// A NaN is a recorded gap, not a zero. Bridging it — or worse, drawing the line
+// down to the axis — would assert a measurement that was never taken.
+func TestLineChartBreaksOnGapsRatherThanDrawingZero(t *testing.T) {
+	o := lineOpts(5)
+	s := chartSeries{Name: "sudph", Color: "#36A2EB",
+		Vals: []float64{300, math.NaN(), math.NaN(), 400, 420}}
+	out := renderLineSVG(o, []chartSeries{s}, nil)
+
+	// Two pen-downs: one before the gap, one after.
+	if got := strings.Count(out, "M"); got != 2 {
+		t.Errorf("got %d subpaths, want 2 (the line must break at the gap): %s", got, out)
+	}
+	baseY := chartMarginTop + o.plotHeight()
+	if strings.Contains(out, " "+itoa(baseY)+"L") {
+		t.Error("gap was drawn down to the axis, which reads as a zero measurement")
+	}
+}
+
+// Missing latency records are gaps; missing bandwidth records are real zeroes.
+func TestTransportTypeSeriesDistinguishesGapFromZero(t *testing.T) {
+	daily := []tpdDailyPoint{
+		{Date: "2026-09-01", ByType: map[string]tpdDailyByType{"sudph": {Bandwidth: 10, Latency: 300}}},
+		{Date: "2026-09-02", ByType: map[string]tpdDailyByType{}},
+	}
+	bw := transportTypeSeries(daily, false, func(v tpdDailyByType) float64 { return float64(v.Bandwidth) })
+	if len(bw) != 1 || bw[0].Vals[1] != 0 {
+		t.Errorf("absent bandwidth should be zero, got %v", bw)
+	}
+	lat := transportTypeSeries(daily, true, func(v tpdDailyByType) float64 { return v.Latency })
+	if len(lat) != 1 || !math.IsNaN(lat[0].Vals[1]) {
+		t.Errorf("absent latency should be a gap, got %v", lat)
+	}
+}
+
+// A failed fetch must say so. Rendering a zero would read as a measurement.
+func TestTimeSeriesSurfaceFetchErrorsInsteadOfZeroes(t *testing.T) {
+	boom := errTest("failed to read response: EOF")
+	for name, out := range map[string]string{
+		"bandwidth": renderBandwidthTimeSeries(nil, boom),
+		"latency":   renderLatencyTimeSeries(nil, boom),
+	} {
+		if !strings.Contains(out, "unavailable") || !strings.Contains(out, "EOF") {
+			t.Errorf("%s: error not surfaced on the page: %s", name, out)
+		}
+		if strings.Contains(out, "0 B") || strings.Contains(out, "0 ms") {
+			t.Errorf("%s: rendered a zero for a failed fetch: %s", name, out)
+		}
+	}
+}
+
+// Series order comes from a map and must not reshuffle between renders.
+func TestSortedMapKeysIsStable(t *testing.T) {
+	m := map[string]float64{"a": 3, "b": 9, "c": 3, "d": 1}
+	want := []string{"b", "a", "c", "d"}
+	for i := 0; i < 50; i++ {
+		if got := sortedMapKeys(m); !reflect.DeepEqual(got, want) {
+			t.Fatalf("iteration %d: got %v, want %v", i, got, want)
+		}
+	}
+}
+
+func TestShortDatesKeepsYearOnlyWhenItChanges(t *testing.T) {
+	got := shortDates([]string{"2025-12-30", "2025-12-31", "2026-01-01", "2026-01-02"})
+	want := []string{"2025-12-30", "12-31", "2026-01-01", "01-02"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	if neg {
+		return "-" + string(b)
+	}
+	return string(b)
+}
+
+// The current day's timeline is pre-allocated to a full 24 hours, so its
+// not-yet-elapsed slots are zeroes. Charting them shows the network going dark
+// at a midnight that has not arrived.
+func TestLivenessTrimsTheNotYetElapsedTail(t *testing.T) {
+	full := strings.Repeat(".", livenessSlotsPerDay)
+	half := strings.Repeat(".", 100) + strings.Repeat(" ", livenessSlotsPerDay-100)
+	raw := `[{"pk":"a","timeline":{"2026-09-01":"` + full + `","2026-09-02":"` + half + `"}}]`
+
+	s, err := parseLivenessSeries([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := livenessSlotsPerDay + 100; len(s.Counts) != want {
+		t.Errorf("got %d slots, want %d (the unelapsed tail must be trimmed)", len(s.Counts), want)
+	}
+	if s.Counts[len(s.Counts)-1] == 0 {
+		t.Error("series still ends on a zero slot")
+	}
+	if len(s.DayStarts) != 2 {
+		t.Errorf("got %d day ticks, want 2", len(s.DayStarts))
+	}
+}
+
+// The timeline disagrees with the tracker's own daily percentage for
+// intermittent visors (#4533), so this series must never be labeled uptime.
+func TestLivenessChartIsLabeledOnlineNotUptime(t *testing.T) {
+	s := &livenessSeries{
+		Counts: []int{5, 6, 7}, Dates: []string{"2026-09-01", "2026-09-01", "2026-09-01"},
+		DayStarts: []int{0}, Visors: 9,
+	}
+	out := renderLivenessChart(s, nil)
+	if !strings.Contains(out, "Visors Online") {
+		t.Error("chart is not labeled as a visors-online count")
+	}
+	if strings.Contains(out, ">Uptime") || strings.Contains(out, "uptime over") {
+		t.Errorf("chart presents itself as uptime: %s", out)
+	}
+	if !strings.Contains(out, "4533") {
+		t.Error("the daily-percentage discrepancy caveat is missing")
+	}
+}
+
+func TestLivenessSurfacesFetchErrors(t *testing.T) {
+	out := renderLivenessChart(nil, errTest("uptime tracker query failed"))
+	if !strings.Contains(out, "unavailable") || !strings.Contains(out, "uptime tracker query failed") {
+		t.Errorf("error not surfaced: %s", out)
+	}
+}

--- a/cmd/skywire-cli/commands/rewards/server/timeseries.go
+++ b/cmd/skywire-cli/commands/rewards/server/timeseries.go
@@ -1,0 +1,269 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/timeseries.go c4-vis-cli
+package clirewardsserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/skycoin/skywire/deployment"
+)
+
+// TPD's daily aggregate: the cheap time series behind the /stats charts.
+//
+// The per-transport body (/metrics?days=N&bandwidth=true) is tens of megabytes
+// over dmsg and was failing outright — /stats/bandwidth-history rendered
+// "failed to read response: EOF" after six seconds. TPD already publishes the
+// reduction the charts actually want at /metric?days=N: the whole 30-day series
+// with a per-transport-type breakdown, in under three kilobytes, carrying
+// LATENCY as well as bandwidth.
+
+// tpdDailyByType is one transport type's contribution on one day.
+type tpdDailyByType struct {
+	Bandwidth uint64  `json:"bandwidth"`
+	Latency   float64 `json:"latency"`
+}
+
+// tpdDailyPoint is one day of the network-wide aggregate.
+type tpdDailyPoint struct {
+	Date      string                    `json:"date"`
+	Bandwidth uint64                    `json:"bandwidth"`
+	Latency   float64                   `json:"latency"`
+	ByType    map[string]tpdDailyByType `json:"by_type"`
+}
+
+// tpdDailyAggregate is the parsed /metric?days=N response plus the fetch
+// outcome. OK/Err follow the BandwidthOK/BandwidthErr convention in
+// tpdNetworkSummary: a failed fetch must never render as a zero, because a
+// "0 B" on a bandwidth page reads as a measurement rather than as a gap.
+type tpdDailyAggregate struct {
+	Daily []tpdDailyPoint `json:"daily"`
+	// Cumulative is TPD's running total, kept for the summary line.
+	Cumulative struct {
+		Bandwidth uint64                    `json:"bandwidth"`
+		ByType    map[string]tpdDailyByType `json:"by_type"`
+	} `json:"cumulative"`
+	Fetched string `json:"fetched"`
+}
+
+const (
+	tpdDailyCacheFile = "tpd_daily.json"
+	// tpdDailyDays is the window requested. TPD returns only the history it
+	// holds — currently far fewer points than this — and the pages report what
+	// came back rather than padding the series out to the requested length.
+	tpdDailyDays = 30
+)
+
+// fetchTPDDailyAggregate GETs TPD's daily aggregate, cached on disk for
+// tpdSummaryCacheMaxAge the same way getTPDNetworkSummary caches its summary.
+func fetchTPDDailyAggregate() (*tpdDailyAggregate, error) {
+	cachePath := filepath.Join(tempStatsPath, tpdDailyCacheFile)
+	if info, err := os.Stat(cachePath); err == nil && time.Since(info.ModTime()) <= tpdSummaryCacheMaxAge {
+		if data, rErr := os.ReadFile(cachePath); rErr == nil { //nolint:gosec
+			var agg tpdDailyAggregate
+			if json.Unmarshal(data, &agg) == nil && len(agg.Daily) > 0 {
+				return &agg, nil
+			}
+		}
+	}
+
+	tpdURL := strings.TrimSuffix(deployment.Prod.TransportDiscovery, "/")
+	url := fmt.Sprintf("%s/metric?days=%d", tpdURL, tpdDailyDays)
+
+	resp, err := statsHTTPGet(url)
+	if err != nil {
+		return nil, fmt.Errorf("TPD request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("TPD returned status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read TPD response: %w", err)
+	}
+
+	var agg tpdDailyAggregate
+	if err := json.Unmarshal(body, &agg); err != nil {
+		return nil, fmt.Errorf("failed to parse TPD daily aggregate: %w", err)
+	}
+	if len(agg.Daily) == 0 {
+		return nil, fmt.Errorf("TPD daily aggregate carried no days")
+	}
+	// TPD returns newest-first; charts read left-to-right oldest-first.
+	sort.Slice(agg.Daily, func(i, j int) bool { return agg.Daily[i].Date < agg.Daily[j].Date })
+	agg.Fetched = time.Now().UTC().Format(time.RFC3339)
+
+	if data, mErr := json.Marshal(&agg); mErr == nil {
+		os.WriteFile(cachePath, data, 0600) //nolint:errcheck,gosec
+	}
+	return &agg, nil
+}
+
+// tpdAggregateCaveat is the provenance note the bandwidth and latency charts
+// must carry. These are TPD's own cumulative aggregates, not the min()-verified
+// figures the reward calculation uses (see the three-branch trust model in
+// fillTPDBandwidth). Correct as a trend; not a reward-verified number.
+const tpdAggregateCaveat = "Source: Transport Discovery's own daily aggregate (<code>/metric</code>). " +
+	"These are TPD's reported totals, <b>not</b> the min()-verified per-edge figures used by the " +
+	"reward calculation — a transport whose two edges disagree is counted here as reported. " +
+	"Correct as a trend; do not read these as reward-verified bandwidth."
+
+// transportTypeSeries builds one chart series per transport type, ordered by
+// total contribution so the legend and the band order are stable between
+// renders — ranging the map directly reshuffles them between requests. pick
+// selects bandwidth or latency from a day's per-type record.
+//
+// missingIsGap decides what a day with no record for that type means. For
+// bandwidth it is a genuine zero: the type moved no bytes, and the stack's
+// total is still right. For latency it is a GAP — a type that was not measured
+// has no average, and plotting one as 0 ms would invent a measurement — so the
+// value is NaN and the line breaks.
+func transportTypeSeries(daily []tpdDailyPoint, missingIsGap bool, pick func(tpdDailyByType) float64) []chartSeries {
+	totals := make(map[string]float64)
+	for _, d := range daily {
+		for t, v := range d.ByType {
+			totals[t] += pick(v)
+		}
+	}
+	types := sortedMapKeys(totals)
+
+	series := make([]chartSeries, 0, len(types))
+	for i, t := range types {
+		vals := make([]float64, len(daily))
+		for di, d := range daily {
+			rec, ok := d.ByType[t]
+			switch {
+			case ok:
+				vals[di] = pick(rec)
+			case missingIsGap:
+				vals[di] = math.NaN()
+			default:
+				vals[di] = 0
+			}
+		}
+		series = append(series, chartSeries{
+			Name:  t,
+			Color: chartColors[i%len(chartColors)],
+			Vals:  vals,
+		})
+	}
+	return series
+}
+
+// renderBandwidthTimeSeries renders daily total bandwidth as a stacked area by
+// transport type. On a fetch failure it says so; it never draws a zero series.
+func renderBandwidthTimeSeries(agg *tpdDailyAggregate, err error) string {
+	if err != nil {
+		return fmt.Sprintf("<h3>Bandwidth Over Time</h3><p style='color:#FF6384;'>Bandwidth time series unavailable: %s</p>",
+			html.EscapeString(err.Error()))
+	}
+	daily := agg.Daily
+	labels := shortDates(datesOf(daily))
+	series := transportTypeSeries(daily, false, func(v tpdDailyByType) float64 { return float64(v.Bandwidth) })
+	for i := range series {
+		var tot uint64
+		for _, d := range daily {
+			tot += d.ByType[series[i].Name].Bandwidth
+		}
+		series[i].Note = formatBytesChart(tot) + " over the window"
+	}
+
+	opts := chartOpts{
+		Width: 900, Height: 280, Labels: labels,
+		Title:      fmt.Sprintf("Bandwidth Over Time (%d days reported)", len(daily)),
+		YAxisLabel: "daily bytes across all transports, stacked by transport type",
+		FormatY:    func(v float64) string { return formatBytesChart(uint64(v)) },
+	}
+	out := renderStackedAreaSVG(opts, series)
+	out += fmt.Sprintf("<p style='color:#888;font-size:11px;'>%s</p>", tpdAggregateCaveat)
+	out += renderDailyTable(daily, "Bandwidth", func(d tpdDailyPoint) string {
+		return formatBytesChart(d.Bandwidth)
+	})
+	return out
+}
+
+// renderLatencyTimeSeries renders average transport latency per day, per
+// transport type. Latency is an average, so the types are drawn as separate
+// lines — stacking averages would be meaningless.
+func renderLatencyTimeSeries(agg *tpdDailyAggregate, err error) string {
+	if err != nil {
+		return fmt.Sprintf("<h3>Latency Over Time</h3><p style='color:#FF6384;'>Latency time series unavailable: %s</p>",
+			html.EscapeString(err.Error()))
+	}
+	daily := agg.Daily
+	labels := shortDates(datesOf(daily))
+
+	series := []chartSeries{{
+		Name:  "all transports",
+		Color: "#FFFFFF",
+		Vals:  make([]float64, len(daily)),
+	}}
+	for i, d := range daily {
+		series[0].Vals[i] = d.Latency
+	}
+	byType := transportTypeSeries(daily, true, func(v tpdDailyByType) float64 { return v.Latency })
+	series = append(series, byType...)
+
+	// One readout per day covering every line, so hovering a column reports the
+	// whole cross-section without an element per pixel.
+	hover := make([]string, len(daily))
+	for i, d := range daily {
+		parts := []string{fmt.Sprintf("%s — all: %.0f ms", d.Date, d.Latency)}
+		for _, t := range sortedMapKeys(latencyOf(d)) {
+			parts = append(parts, fmt.Sprintf("%s: %.0f ms", t, d.ByType[t].Latency))
+		}
+		hover[i] = strings.Join(parts, "\n")
+	}
+
+	opts := chartOpts{
+		Width: 900, Height: 260, Labels: labels,
+		Title:      fmt.Sprintf("Latency Over Time (%d days reported)", len(daily)),
+		YAxisLabel: "average transport latency, milliseconds",
+		FormatY:    func(v float64) string { return fmt.Sprintf("%.0f ms", v) },
+	}
+	out := renderLineSVG(opts, series, hover)
+	out += fmt.Sprintf("<p style='color:#888;font-size:11px;'>%s</p>", tpdAggregateCaveat)
+	out += renderDailyTable(daily, "Avg latency", func(d tpdDailyPoint) string {
+		return fmt.Sprintf("%.1f ms", d.Latency)
+	})
+	return out
+}
+
+// latencyOf returns a day's per-type latency map for stable ordering.
+func latencyOf(d tpdDailyPoint) map[string]float64 {
+	m := make(map[string]float64, len(d.ByType))
+	for t, v := range d.ByType {
+		m[t] = v.Latency
+	}
+	return m
+}
+
+func datesOf(daily []tpdDailyPoint) []string {
+	out := make([]string, len(daily))
+	for i, d := range daily {
+		out[i] = d.Date
+	}
+	return out
+}
+
+// renderDailyTable prints the same series as text under the chart — the pages
+// are terminal-themed and the numbers are worth reading directly.
+func renderDailyTable(daily []tpdDailyPoint, header string, cell func(tpdDailyPoint) string) string {
+	var sb strings.Builder
+	sb.WriteString("<details style='margin:8px 0;'><summary style='cursor:pointer;color:#3399FF;'>daily values</summary><pre>")
+	fmt.Fprintf(&sb, "%-12s %s\n", "Date", header)
+	for i := len(daily) - 1; i >= 0; i-- {
+		fmt.Fprintf(&sb, "%-12s %s\n", daily[i].Date, cell(daily[i]))
+	}
+	sb.WriteString("</pre></details>")
+	return sb.String()
+}

--- a/cmd/skywire-cli/commands/rewards/server/visorbandwidth.go
+++ b/cmd/skywire-cli/commands/rewards/server/visorbandwidth.go
@@ -1,0 +1,341 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/visorbandwidth.go c4-vis-cli
+package clirewardsserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/skycoin/skywire/deployment"
+)
+
+// Per-visor bandwidth history.
+//
+// The network-wide daily aggregate (/metric) carries no per-visor breakdown, so
+// this page cannot be served from it. The heavy /metrics?days=N per-transport
+// body it used to use dies with EOF over dmsg. What works is TPD's
+// /metric/visor/{pks} — the same daily reduction, per visor, for a caller-named
+// set of public keys: 32 KB and ~1.5 s for twenty visors over thirty days.
+//
+// The catch, and the reason this page's heading changed: TPD publishes no
+// bandwidth-ranked visor index. Ranking the whole network by bandwidth would
+// mean asking /metric/visor for all ~900 visors, which is neither cheap nor
+// quick. The cheap index that DOES exist is /all-transports/per-key-stats
+// (~100 KB, under a second) — transport COUNTS per visor. So the page now
+// selects the most-connected visors by transport count and reports their real
+// measured bandwidth, and says so on the page rather than implying these are
+// the network's top bandwidth carriers.
+
+const (
+	visorBWCacheFile = "tpd_visor_bw.json"
+	// visorBWCacheMaxAge is longer than the summary cache: this costs two TPD
+	// round trips, one of them ~100 KB, and per-visor daily totals do not move
+	// within a quarter hour.
+	visorBWCacheMaxAge = 15 * time.Minute
+	// visorBWTopN is how many visors get their own band. Each adds ~1.6 KB to
+	// the TPD request and one path to the chart.
+	visorBWTopN = 20
+)
+
+// visorBWPoint is one visor's bandwidth on one day.
+type visorBWPoint struct {
+	Date  string `json:"date"`
+	Total uint64 `json:"total"`
+}
+
+// visorBWEntry is one visor's series plus the transport count it was selected
+// on.
+type visorBWEntry struct {
+	PK         string         `json:"pk"`
+	Transports int            `json:"transports"`
+	Daily      []visorBWPoint `json:"daily"`
+	Total      uint64         `json:"total"`
+	// Reported is false when TPD returned no bandwidth record for this visor on
+	// any day of the window. TPD omits the bandwidth object rather than sending
+	// a zero, so "not reported" and "moved no bytes" are indistinguishable in
+	// the total — and printing "0 B" for the former would read as a
+	// measurement. Unreported visors are listed but not charted.
+	Reported bool `json:"reported"`
+}
+
+// visorBandwidthData is the cached page payload. BandwidthOK/BandwidthErr
+// follow tpdNetworkSummary: the transport-count ranking is useful on its own,
+// so a failed bandwidth fetch degrades to "ranking shown, bandwidth
+// unavailable" rather than to a page of zeroes.
+type visorBandwidthData struct {
+	Dates       []string       `json:"dates"`
+	Visors      []visorBWEntry `json:"visors"`
+	TotalVisors int            `json:"total_visors"`
+	BandwidthOK bool           `json:"bandwidth_ok"`
+	BandwidthE  string         `json:"bandwidth_err,omitempty"`
+	LastUpdated string         `json:"last_updated"`
+}
+
+// fetchVisorBandwidth builds the per-visor series, cached on disk.
+func fetchVisorBandwidth() (*visorBandwidthData, error) {
+	cachePath := filepath.Join(tempStatsPath, visorBWCacheFile)
+	if info, err := os.Stat(cachePath); err == nil && time.Since(info.ModTime()) <= visorBWCacheMaxAge {
+		if data, rErr := os.ReadFile(cachePath); rErr == nil { //nolint:gosec
+			var d visorBandwidthData
+			if json.Unmarshal(data, &d) == nil && len(d.Visors) > 0 {
+				return &d, nil
+			}
+		}
+	}
+
+	tpdURL := strings.TrimSuffix(deployment.Prod.TransportDiscovery, "/")
+
+	counts, err := fetchPerKeyTransportCounts(tpdURL)
+	if err != nil {
+		return nil, err
+	}
+	if len(counts) == 0 {
+		return nil, fmt.Errorf("TPD per-key stats carried no visors")
+	}
+
+	ranked := sortedMapKeys(counts)
+	if len(ranked) > visorBWTopN {
+		ranked = ranked[:visorBWTopN]
+	}
+
+	out := &visorBandwidthData{
+		TotalVisors: len(counts),
+		LastUpdated: time.Now().UTC().Format(time.RFC3339),
+	}
+	for _, pk := range ranked {
+		out.Visors = append(out.Visors, visorBWEntry{PK: pk, Transports: counts[pk]})
+	}
+
+	if bwErr := fillVisorBandwidth(tpdURL, out); bwErr != nil {
+		out.BandwidthE = bwErr.Error()
+	}
+
+	if data, mErr := json.Marshal(out); mErr == nil {
+		os.WriteFile(cachePath, data, 0600) //nolint:errcheck,gosec
+	}
+	return out, nil
+}
+
+// fetchPerKeyTransportCounts reads the cheap per-visor transport index.
+func fetchPerKeyTransportCounts(tpdURL string) (map[string]int, error) {
+	resp, err := statsHTTPGet(tpdURL + "/all-transports/per-key-stats")
+	if err != nil {
+		return nil, fmt.Errorf("TPD per-key request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("TPD returned status %d for per-key stats", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read TPD per-key stats: %w", err)
+	}
+	// An OBJECT keyed by public key, not an array — each value is that visor's
+	// transport counts, with "total" alongside the per-type entries.
+	var raw map[string]map[string]int
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse TPD per-key stats: %w", err)
+	}
+	counts := make(map[string]int, len(raw))
+	for pk, byType := range raw {
+		counts[pk] = byType["total"]
+	}
+	return counts, nil
+}
+
+// fillVisorBandwidth asks TPD for the daily series of the selected visors in
+// one request and fills in their points. Best effort: a failure here leaves the
+// ranking intact and is reported on the page.
+func fillVisorBandwidth(tpdURL string, out *visorBandwidthData) error {
+	pks := make([]string, 0, len(out.Visors))
+	for _, v := range out.Visors {
+		pks = append(pks, v.PK)
+	}
+	url := fmt.Sprintf("%s/metric/visor/%s?days=%d", tpdURL, strings.Join(pks, ","), tpdDailyDays)
+
+	resp, err := statsHTTPGet(url)
+	if err != nil {
+		return fmt.Errorf("TPD per-visor metric request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("TPD returned status %d for per-visor metrics", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read TPD per-visor metrics: %w", err)
+	}
+
+	var raw map[string]struct {
+		Daily []struct {
+			Date      string `json:"date"`
+			Bandwidth *struct {
+				Total uint64 `json:"total"`
+			} `json:"bandwidth,omitempty"`
+		} `json:"daily"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return fmt.Errorf("failed to parse TPD per-visor metrics: %w", err)
+	}
+
+	// TPD pads the response out to the requested window with date entries that
+	// carry no bandwidth object at all. Charting those as zero would assert
+	// that the network moved nothing on days TPD simply has no record for, so
+	// the window is trimmed to the span that actually reported. Same rule as
+	// the network aggregate: report what exists, do not pad.
+	reported := make(map[string]struct{})
+	for _, v := range raw {
+		for _, d := range v.Daily {
+			if d.Bandwidth != nil {
+				reported[d.Date] = struct{}{}
+			}
+		}
+	}
+	if len(reported) == 0 {
+		return fmt.Errorf("TPD reported no per-visor bandwidth over the last %d days", tpdDailyDays)
+	}
+	dates := make([]string, 0, len(reported))
+	for d := range reported {
+		dates = append(dates, d)
+	}
+	sort.Strings(dates)
+	out.Dates = dates
+
+	for i := range out.Visors {
+		series, ok := raw[out.Visors[i].PK]
+		if !ok {
+			continue
+		}
+		byDate := make(map[string]uint64, len(series.Daily))
+		for _, d := range series.Daily {
+			if d.Bandwidth != nil {
+				byDate[d.Date] = d.Bandwidth.Total
+				out.Visors[i].Reported = true
+			}
+		}
+		for _, d := range dates {
+			out.Visors[i].Daily = append(out.Visors[i].Daily, visorBWPoint{Date: d, Total: byDate[d]})
+			out.Visors[i].Total += byDate[d]
+		}
+	}
+	out.BandwidthOK = true
+	return nil
+}
+
+// renderVisorBandwidthHTML fetches and renders the per-visor page body.
+func renderVisorBandwidthHTML() string {
+	data, err := fetchVisorBandwidth()
+	if err != nil {
+		return fmt.Sprintf("<p style='color:#FF6384;'>Per-visor bandwidth unavailable: %s</p>",
+			html.EscapeString(err.Error()))
+	}
+	return renderVisorBandwidthBody(data)
+}
+
+// renderVisorBandwidthBody renders an already-fetched payload.
+func renderVisorBandwidthBody(data *visorBandwidthData) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "<p>The %d most-connected visors of %d registered with Transport Discovery, "+
+		"ranked by transport count, with their measured daily bandwidth.</p>", len(data.Visors), data.TotalVisors)
+	sb.WriteString("<p style='color:#888;font-size:11px;'>TPD publishes no bandwidth-ranked visor index, " +
+		"and ranking the whole network by bandwidth would mean a per-visor query for every registered key. " +
+		"The selection here is therefore by <b>transport count</b> — these are the best-connected visors, " +
+		"not necessarily the highest-bandwidth ones. Bandwidth figures are TPD's own reported totals, " +
+		"not the min()-verified figures used by the reward calculation.</p>")
+
+	if !data.BandwidthOK {
+		fmt.Fprintf(&sb, "<p style='color:#FF6384;'>Bandwidth series unavailable: %s — the transport-count ranking below is still current.</p>",
+			html.EscapeString(data.BandwidthE))
+		sb.WriteString(renderVisorRankTable(data, false))
+		fmt.Fprintf(&sb, "<p style='color:#888;font-size:0.8em;'>Last updated: %s</p>", html.EscapeString(data.LastUpdated))
+		return sb.String()
+	}
+
+	// Order bands by measured bandwidth so the chart reads largest-first.
+	visors := make([]visorBWEntry, len(data.Visors))
+	copy(visors, data.Visors)
+	sort.Slice(visors, func(i, j int) bool {
+		if visors[i].Total != visors[j].Total {
+			return visors[i].Total > visors[j].Total
+		}
+		return visors[i].PK < visors[j].PK
+	})
+
+	series := make([]chartSeries, 0, len(visors))
+	unreported := 0
+	for _, v := range visors {
+		if !v.Reported {
+			unreported++
+			continue
+		}
+		vals := make([]float64, len(data.Dates))
+		for di, p := range v.Daily {
+			if di < len(vals) {
+				vals[di] = float64(p.Total)
+			}
+		}
+		series = append(series, chartSeries{
+			// Public keys are never truncated here; the legend wraps instead.
+			Name:  v.PK,
+			Color: chartColors[len(series)%len(chartColors)],
+			Vals:  vals,
+			Note:  formatBytesChart(v.Total) + " over the window",
+		})
+	}
+	if len(series) == 0 {
+		sb.WriteString("<p style='color:#FFCE56;'>None of the selected visors has reported bandwidth to Transport Discovery over this window.</p>")
+		sb.WriteString(renderVisorRankTable(data, true))
+		fmt.Fprintf(&sb, "<p style='color:#888;font-size:0.8em;'>Last updated: %s</p>", html.EscapeString(data.LastUpdated))
+		return sb.String()
+	}
+
+	opts := chartOpts{
+		Width: 900, Height: 320,
+		Labels:     shortDates(data.Dates),
+		Title:      fmt.Sprintf("Per-Visor Bandwidth (%d days reported)", len(data.Dates)),
+		YAxisLabel: "daily bytes per visor, stacked",
+		FormatY:    func(v float64) string { return formatBytesChart(uint64(v)) },
+	}
+	sb.WriteString(renderStackedAreaSVG(opts, series))
+	if unreported > 0 {
+		fmt.Fprintf(&sb, "<p style='color:#888;font-size:11px;'>%d of the %d selected visors reported no bandwidth to "+
+			"Transport Discovery over this window and are listed below as <i>not reported</i> rather than charted as zero.</p>",
+			unreported, len(visors))
+	}
+	sb.WriteString(renderVisorRankTable(&visorBandwidthData{Visors: visors, TotalVisors: data.TotalVisors}, true))
+	fmt.Fprintf(&sb, "<p style='color:#888;font-size:0.8em;'>Last updated: %s</p>", html.EscapeString(data.LastUpdated))
+	return sb.String()
+}
+
+// renderVisorRankTable lists the selected visors. withBandwidth is false when
+// the bandwidth fetch failed, so the column is omitted rather than filled with
+// zeroes that would read as measurements.
+func renderVisorRankTable(data *visorBandwidthData, withBandwidth bool) string {
+	var sb strings.Builder
+	sb.WriteString("<pre>")
+	if withBandwidth {
+		fmt.Fprintf(&sb, "%-4s %-66s %-11s %s\n", "#", "Public Key", "Transports", "Bandwidth")
+	} else {
+		fmt.Fprintf(&sb, "%-4s %-66s %s\n", "#", "Public Key", "Transports")
+	}
+	for i, v := range data.Visors {
+		if withBandwidth {
+			bw := "not reported"
+			if v.Reported {
+				bw = formatBytesChart(v.Total)
+			}
+			fmt.Fprintf(&sb, "%-4d %-66s %-11d %s\n", i+1, html.EscapeString(v.PK), v.Transports, bw)
+			continue
+		}
+		fmt.Fprintf(&sb, "%-4d %-66s %d\n", i+1, html.EscapeString(v.PK), v.Transports)
+	}
+	sb.WriteString("</pre>")
+	return sb.String()
+}


### PR DESCRIPTION
`/stats/bandwidth-history` and `/stats/visor-bandwidth` were both rendering `failed to read response: EOF` — they fetched TPD's per-transport `/metrics?days=7` body, which is tens of MB over dmsg. TPD already publishes the reduction these charts want: `/metric?days=30` is 2.7 KB and carries per-day latency as well as bandwidth, broken down by transport type, and `/metric/visor/{pks}` carries the same per visor.

`/stats/version-history` was 2.1 MB and 8.1 s because the chart was 14,417 absolutely-positioned one-pixel `<div>`s, and because every request re-globbed and re-parsed all of `hist/*_ut.json`. It is now inline SVG (152 elements, ~70 KB for 684 days) with the parse memoized on the newest file's mtime.

New `/stats/charts` collects the series — bandwidth, latency, visors online, version adoption. The visors-online series comes from the uptime tracker's per-visor timelines and was not displayed anywhere before; it is labeled a liveness count rather than uptime, since that timeline disagrees with the same endpoint's daily percentage for intermittent visors (#4533).

Everything is self-contained SVG, which also removes the two Chart.js CDN `<script>` tags the old renderers emitted. Failed fetches still render as visible error text, and a missing measurement breaks the line instead of being drawn as a zero.

Measured (live, before): version-history 2,157,603 B / 7.2 s; bandwidth-history and visor-bandwidth both error pages. Rendered locally against the same live data (after): version-history chart 71.5 KB, bandwidth 4.8 KB, latency 6.5 KB, visors-online 8.4 KB, visor-bandwidth 8.6 KB.

`/stats` itself is left alone apart from one added link, so the TUI-renderer work can land there independently.