### PR TITLE
fix(rewards): trim the partial final slot, and never omit a panel silently

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/liveness.go
+++ b/cmd/skywire-cli/commands/rewards/server/liveness.go
@@ -145,6 +145,30 @@ func parseLivenessSeries(raw []byte) (*livenessSeries, error) {
 	if end == 0 {
 		return nil, fmt.Errorf("uptime tracker timelines recorded no online slots")
 	}
+
+	// Trimming zeroes is not enough: the LAST recorded slot is normally still
+	// being written, so it holds a partial count and plots as a cliff. Observed
+	// live within minutes of each other, the final slot read 808 in one sample
+	// and 114 in another while the preceding hour sat steady near 880 — the
+	// network did not move, the bucket was simply incomplete.
+	//
+	// Drop trailing slots that are far below the recent norm, bounded so a
+	// genuine sustained drop is never eaten: at most maxPartialTrim slots
+	// (30 minutes) and only while a slot is under half the median of the hour
+	// before it. A real outage lasting longer than that still charts.
+	const (
+		maxPartialTrim  = 6  // 30 minutes at 5-minute resolution
+		medianWindow    = 12 // one hour
+		partialFraction = 0.5
+	)
+	for dropped := 0; dropped < maxPartialTrim && end > medianWindow+1; dropped++ {
+		lo := end - 1 - medianWindow
+		ref := medianOf(counts[lo : end-1])
+		if ref <= 0 || float64(counts[end-1]) >= partialFraction*float64(ref) {
+			break
+		}
+		end--
+	}
 	counts = counts[:end]
 
 	slotDates := make([]string, len(counts))
@@ -222,4 +246,16 @@ func shortSlotLabel(date string, i int) string {
 		return parts[1] + "-" + parts[2]
 	}
 	return date
+}
+
+// medianOf returns the median of a slice without disturbing the caller's
+// ordering — the series is time-ordered and must stay that way.
+func medianOf(xs []int) int {
+	if len(xs) == 0 {
+		return 0
+	}
+	c := make([]int, len(xs))
+	copy(c, xs)
+	sort.Ints(c)
+	return c[len(c)/2]
 }

--- a/cmd/skywire-cli/commands/rewards/server/liveness_trim_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/liveness_trim_test.go
@@ -1,0 +1,117 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/liveness_trim_test.go c4-vis-cli
+package clirewardsserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// buildTimeline makes one visor's day string: online for the first n slots.
+func buildTimeline(n int) string {
+	return strings.Repeat(".", n) + strings.Repeat(" ", livenessSlotsPerDay-n)
+}
+
+// rawGraph encodes visors with the given per-visor online-slot counts.
+func rawGraph(t *testing.T, date string, onlineCounts []int) []byte {
+	t.Helper()
+	var vs []utGraphVisor
+	for i, n := range onlineCounts {
+		vs = append(vs, utGraphVisor{
+			PK:       fmt.Sprintf("%064x", i),
+			Timeline: map[string]string{date: buildTimeline(n)},
+		})
+	}
+	b, err := json.Marshal(vs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// The final slot is normally still being written, so it holds a partial count.
+// Charting it plots a cliff that did not happen: observed live, the last slot
+// read 808 in one sample and 114 in another while the preceding hour sat near
+// 880 and the network had not moved.
+func TestParseLivenessTrimsThePartialFinalSlot(t *testing.T) {
+	// 880 visors online for 47 slots; 114 of them also cover slot 48, so slot
+	// 48 sums to 114 against a steady 880 before it.
+	counts := make([]int, 880)
+	for i := range counts {
+		counts[i] = 47
+	}
+	for i := 0; i < 114; i++ {
+		counts[i] = 48
+	}
+
+	s, err := parseLivenessSeries(rawGraph(t, "2026-09-05", counts))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := s.Counts[len(s.Counts)-1]; got == 114 {
+		t.Error("the partial final slot was charted; it must be trimmed")
+	}
+	if got := s.Counts[len(s.Counts)-1]; got != 880 {
+		t.Errorf("series ends at %d, want the last complete slot (880)", got)
+	}
+}
+
+// A real sustained drop must survive: the guard is bounded to 30 minutes, so an
+// outage longer than that still charts. Silently eating a genuine decline would
+// be worse than the artifact it removes.
+func TestParseLivenessKeepsASustainedDrop(t *testing.T) {
+	// 880 visors online for 40 slots; 100 of them continue through slot 60.
+	// Slots 40..59 therefore sit at 100 — a real, hours-long decline.
+	counts := make([]int, 880)
+	for i := range counts {
+		counts[i] = 40
+	}
+	for i := 0; i < 100; i++ {
+		counts[i] = 60
+	}
+
+	s, err := parseLivenessSeries(rawGraph(t, "2026-09-05", counts))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The drop lasts 20 slots; at most 6 may be trimmed, so the low plateau
+	// must still be visible.
+	low := 0
+	for _, c := range s.Counts {
+		if c == 100 {
+			low++
+		}
+	}
+	if low < 10 {
+		t.Errorf("only %d slots of a 20-slot sustained drop survived; a real outage was eaten", low)
+	}
+}
+
+// Trailing not-yet-elapsed slots are zero and must not chart as the network
+// going dark at a midnight that has not arrived.
+func TestParseLivenessTrimsTrailingZeroes(t *testing.T) {
+	counts := make([]int, 500)
+	for i := range counts {
+		counts[i] = 100
+	}
+	s, err := parseLivenessSeries(rawGraph(t, "2026-09-05", counts))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.Counts) > 100 {
+		t.Errorf("series has %d slots, want the trailing zeroes dropped", len(s.Counts))
+	}
+	for i, c := range s.Counts {
+		if c == 0 {
+			t.Fatalf("slot %d is zero after trimming", i)
+		}
+	}
+}
+
+// An all-empty tracker response is an error, not an empty chart.
+func TestParseLivenessRejectsEmpty(t *testing.T) {
+	if _, err := parseLivenessSeries([]byte(`[]`)); err == nil {
+		t.Error("expected an error for a response with no timelines")
+	}
+}

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui.go
@@ -263,7 +263,13 @@ func RenderStatsANSI(d statsTUIData) string {
 	// #4533), so it must not be presented as the uptime figure rewards use.
 	if d.LivenessErr != "" {
 		b.WriteString(tuiMissing("VISORS ONLINE", d.LivenessErr) + "\n")
-	} else if len(d.Liveness) > 0 {
+	} else if len(d.Liveness) == 0 {
+		// Neither data nor an error means nothing even attempted to fetch it.
+		// Rendering nothing at all is the one outcome this design must not
+		// produce: an absent section is indistinguishable from a section that
+		// was never meant to be there. Say so instead.
+		b.WriteString(tuiMissing("VISORS ONLINE", "no data returned") + "\n")
+	} else {
 		var series []float64
 		var labels []string
 		samples := 0

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_data.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_data.go
@@ -74,7 +74,41 @@ func gatherStatsTUI() statsTUIData {
 		d.Versions = versions
 	}
 
+	// Visors online, summed from the uptime tracker's per-5-minute timelines.
+	// Shares the cache the SVG chart uses, so the ~2 MB tracker dump is pulled
+	// once for both renderings rather than twice.
+	//
+	// This was missing when the panel first shipped: the field existed and the
+	// renderer drew it, but nothing populated it, so the section vanished with
+	// no error — the one failure mode the design is supposed to make
+	// impossible. An unattempted source is now an explicit one.
+	if series, err := fetchLivenessSeries(); err != nil {
+		d.LivenessErr = err.Error()
+	} else {
+		d.Liveness = livenessToTUIDays(series)
+	}
+
 	return d
+}
+
+// livenessToTUIDays regroups the flat slot series into per-day runs, which is
+// the shape the panel's x-axis labels are built from.
+func livenessToTUIDays(s *livenessSeries) []statsTUILivenessDay {
+	if s == nil || len(s.Counts) == 0 {
+		return nil
+	}
+	var out []statsTUILivenessDay
+	for i, c := range s.Counts {
+		date := ""
+		if i < len(s.Dates) {
+			date = s.Dates[i]
+		}
+		if len(out) == 0 || out[len(out)-1].Date != date {
+			out = append(out, statsTUILivenessDay{Date: date})
+		}
+		out[len(out)-1].Slots = append(out[len(out)-1].Slots, c)
+	}
+	return out
 }
 
 // statsGetJSON fetches and decodes one JSON body. Decoding is the validity

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_test.go
@@ -117,3 +117,39 @@ func TestGatherStatsTUILive(t *testing.T) {
 		t.Fatal("rendered nothing from live data")
 	}
 }
+
+// A section with neither data nor an error must still be named. This shipped
+// broken once: the Liveness field existed and the renderer drew it, but
+// gatherStatsTUI never populated it, so the panel vanished silently — the one
+// failure mode the whole design exists to prevent.
+func TestRenderStatsANSINeverSilentlyOmitsAPanel(t *testing.T) {
+	d := sampleTUIData()
+	d.Liveness = nil // no data, and crucially no error either
+	out := RenderStatsANSI(d)
+	if !strings.Contains(out, "VISORS ONLINE") {
+		t.Fatal("the panel disappeared entirely instead of reporting itself absent")
+	}
+	if !strings.Contains(out, "unavailable") {
+		t.Error("an unpopulated panel was drawn without saying it had no data")
+	}
+}
+
+// The flat slot series regroups into per-day runs for the x-axis labels.
+func TestLivenessToTUIDaysGroupsByDate(t *testing.T) {
+	got := livenessToTUIDays(&livenessSeries{
+		Counts: []int{1, 2, 3, 4, 5},
+		Dates:  []string{"2026-09-04", "2026-09-04", "2026-09-05", "2026-09-05", "2026-09-05"},
+	})
+	if len(got) != 2 {
+		t.Fatalf("got %d days, want 2", len(got))
+	}
+	if got[0].Date != "2026-09-04" || len(got[0].Slots) != 2 {
+		t.Errorf("day 0 = %+v", got[0])
+	}
+	if got[1].Date != "2026-09-05" || len(got[1].Slots) != 3 {
+		t.Errorf("day 1 = %+v", got[1])
+	}
+	if livenessToTUIDays(nil) != nil {
+		t.Error("nil series should produce no days")
+	}
+}


### PR DESCRIPTION
Two defects on the live stats page.

**The visors-online chart showed a cliff at its right edge.** The final 5-minute slot is normally still being written, so it holds a partial count. Sampled minutes apart, that slot read **808** in one fetch and **114** in another (the deployed page's `range 114 to 950`) while the preceding hour sat steady near **880** — the network had not moved, the bucket was incomplete. Trimming trailing zeroes did not catch it because the value is not zero.

Trailing slots below half the median of the preceding hour are now dropped as well, bounded to six slots (30 minutes) so a real outage is never eaten. A test asserts a 20-slot sustained decline survives the guard.

**The terminal panel omitted its VISORS ONLINE section entirely.** The struct field and the renderer both existed, but `gatherStatsTUI` never populated it — so the section vanished with no error, which is precisely the failure mode that design is meant to make impossible. It now shares the SVG chart's cache (one ~2 MB tracker fetch serves both renderings), and a panel with neither data nor an error says so rather than disappearing.

Not included, because it turned out not to exist: I thought the uptime timeline had stalled after the TPD restart, having read a last slot of 03:55 at 11:41. Fetched uncached and with the default cache it returns the current slot both times — the data path is healthy and the stall was my measurement, not the network.
