### PR TITLE
feat(rewards): show the dmsg substrate in the stats panel

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/stats_tui.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui.go
@@ -62,7 +62,9 @@ type statsTUIData struct {
 
 	// Liveness is visors-reporting-online per 5-minute slot, oldest-first,
 	// with the label of the day each run of slots belongs to.
-	Liveness    []statsTUILivenessDay
+	Liveness []statsTUILivenessDay
+	// Dmsg is the substrate layer: server capacity and client registrations.
+	Dmsg        dmsgStats
 	LivenessErr string
 }
 
@@ -314,6 +316,13 @@ func RenderStatsANSI(d statsTUIData) string {
 		b.WriteString(tuiClose(width))
 		b.WriteString("\n")
 	}
+
+	// ---- dmsg substrate ----------------------------------------------------
+	//
+	// The layer everything else runs over, and previously shown nowhere on the
+	// site. A dmsg server sitting at capacity is invisible in every transport
+	// and uptime view while it quietly pushes clients elsewhere.
+	b.WriteString(renderDmsgPanelANSI(d.Dmsg))
 
 	// ---- version adoption --------------------------------------------------
 	if d.VersionsErr != "" {

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_data.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_data.go
@@ -88,6 +88,8 @@ func gatherStatsTUI() statsTUIData {
 		d.Liveness = livenessToTUIDays(series)
 	}
 
+	d.Dmsg = gatherDmsgStats()
+
 	return d
 }
 

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_dmsg.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_dmsg.go
@@ -1,0 +1,157 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/stats_tui_dmsg.go c5-reward-server
+//
+// The dmsg layer, in the terminal panel.
+//
+// Nothing on the reward site showed dmsg at all: the transport and uptime
+// views describe what the network carries, and none of it describes the
+// substrate carrying it. A saturated dmsg server is invisible in every
+// existing chart, yet it silently pushes clients elsewhere.
+package clirewardsserver
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/skycoin/skywire/deployment"
+)
+
+// dmsgServerRow is one registered dmsg server as discovery describes it.
+type dmsgServerRow struct {
+	PK      string
+	Address string
+	Version string
+	// Available is REMAINING capacity, not sessions in use. Discovery excludes
+	// a server at zero from available_servers by design, so a server reading 0
+	// here is FULL, not idle — the inversion that made a saturated server look
+	// like a dead one.
+	Available int
+	// Listed reports whether the server appears in available_servers.
+	Listed bool
+}
+
+type dmsgStats struct {
+	Servers []dmsgServerRow
+	// Entries is the number of client entries registered in discovery.
+	Entries    int
+	EntriesErr string
+	ServersErr string
+}
+
+// discServerEntry is the shape dmsg-discovery returns per server.
+type discServerEntry struct {
+	Static string `json:"static"`
+	// Version carries the build string. Before #4521 every server advertised a
+	// bare release tag, so a blank or tag-only value here means the server has
+	// not restarted onto a build that reports its commit.
+	Version string `json:"version"`
+	Server  struct {
+		Address           string `json:"address"`
+		AvailableSessions int    `json:"availableSessions"`
+	} `json:"server"`
+}
+
+// gatherDmsgStats reads the dmsg-discovery views the panel draws. As with the
+// other sources, a failure is recorded rather than returned.
+func gatherDmsgStats() dmsgStats {
+	var d dmsgStats
+	base := strings.TrimSuffix(deployment.Prod.DmsgDiscovery, "/")
+
+	var all, avail []discServerEntry
+	if err := statsGetJSON(base+"/dmsg-discovery/all_servers", &all); err != nil {
+		d.ServersErr = err.Error()
+	} else {
+		listed := make(map[string]bool)
+		if err := statsGetJSON(base+"/dmsg-discovery/available_servers", &avail); err == nil {
+			for _, e := range avail {
+				listed[e.Static] = true
+			}
+		}
+		for _, e := range all {
+			d.Servers = append(d.Servers, dmsgServerRow{
+				PK: e.Static, Address: e.Server.Address, Version: e.Version,
+				Available: e.Server.AvailableSessions, Listed: listed[e.Static],
+			})
+		}
+		// Fullest first: a server at zero spare is the one worth seeing.
+		sort.Slice(d.Servers, func(i, j int) bool {
+			if d.Servers[i].Available != d.Servers[j].Available {
+				return d.Servers[i].Available < d.Servers[j].Available
+			}
+			return d.Servers[i].PK < d.Servers[j].PK
+		})
+	}
+
+	var entries []string
+	if err := statsGetJSON(base+"/dmsg-discovery/entries", &entries); err != nil {
+		d.EntriesErr = err.Error()
+	} else {
+		d.Entries = len(entries)
+	}
+	return d
+}
+
+// renderDmsgPanelANSI draws the dmsg substrate panel.
+func renderDmsgPanelANSI(d dmsgStats) string {
+	width := tuiWidth
+	var b strings.Builder
+
+	if d.ServersErr != "" {
+		return tuiMissing("DMSG SERVERS", d.ServersErr) + "\n"
+	}
+	if len(d.Servers) == 0 {
+		return tuiMissing("DMSG SERVERS", "no data returned") + "\n"
+	}
+
+	b.WriteString(tuiRule("DMSG SERVERS — spare capacity", width))
+
+	// Capacity remaining, NOT load. Labeled explicitly because reading these
+	// as sessions-in-use inverts the meaning: it makes the fullest server look
+	// like the emptiest.
+	maxAvail := 0
+	for _, s := range d.Servers {
+		if s.Available > maxAvail {
+			maxAvail = s.Available
+		}
+	}
+	full := 0
+	for _, s := range d.Servers {
+		frac := 0.0
+		if maxAvail > 0 {
+			frac = float64(s.Available) / float64(maxAvail)
+		}
+		col := aGreen
+		state := aDim + "accepting" + aReset
+		if !s.Listed || s.Available <= 0 {
+			col = aRed
+			state = aRed + "FULL" + aReset
+			full++
+		} else if frac < 0.25 {
+			col = aYellow
+		}
+		ver := s.Version
+		if ver == "" {
+			ver = "—"
+		}
+		b.WriteString(fmt.Sprintf("  %s%-21s%s %s%6d%s %s  %s\n",
+			aDim, s.Address, aReset, aBold, s.Available, aReset,
+			tuiBar(frac, 20, col), state))
+		b.WriteString(fmt.Sprintf("  %s%s  %s%s\n", aDim, s.PK, ver, aReset))
+	}
+	b.WriteString(fmt.Sprintf("  %s%d servers · %d at capacity · figures are spare slots, not load%s\n",
+		aDim, len(d.Servers), full, aReset))
+	b.WriteString(tuiClose(width))
+	b.WriteString("\n")
+
+	// Client entries.
+	if d.EntriesErr != "" {
+		b.WriteString(tuiMissing("DMSG CLIENT ENTRIES", d.EntriesErr) + "\n")
+	} else {
+		b.WriteString(tuiRule("DMSG CLIENT ENTRIES", width))
+		b.WriteString(fmt.Sprintf("  %sregistered in discovery%s %s%d%s\n",
+			aDim, aReset, aBold, d.Entries, aReset))
+		b.WriteString(tuiClose(width))
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_dmsg_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_dmsg_test.go
@@ -1,0 +1,88 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/stats_tui_dmsg_test.go c5-reward-server
+package clirewardsserver
+
+import (
+	"strings"
+	"testing"
+)
+
+// availableSessions is capacity REMAINING. A server at zero is FULL and gets
+// excluded from available_servers by design — reading it as load inverts the
+// meaning and makes the busiest server look like the emptiest. That inversion
+// really happened: a saturated server was reported as having no clients.
+func TestDmsgPanelMarksAFullServerAsFullNotIdle(t *testing.T) {
+	out := renderDmsgPanelANSI(dmsgStats{
+		Servers: []dmsgServerRow{
+			{PK: strings.Repeat("a", 66), Address: "45.79.124.73:30082", Available: 0, Listed: false},
+			{PK: strings.Repeat("b", 66), Address: "143.42.59.213:30088", Available: 1259, Listed: true},
+		},
+		Entries: 931,
+	})
+
+	if !strings.Contains(out, "FULL") {
+		t.Error("a server at zero spare capacity was not marked FULL")
+	}
+	if !strings.Contains(out, "spare slots, not load") {
+		t.Error("the panel does not say the figures are spare capacity rather than load")
+	}
+	if !strings.Contains(out, "1 at capacity") {
+		t.Error("the at-capacity count is wrong or missing")
+	}
+}
+
+// Public keys are never truncated: an operator matching a server against their
+// own config needs the whole key.
+func TestDmsgPanelPrintsFullPublicKeys(t *testing.T) {
+	pk := "02a2d4c346dabd165fd555dfdba4a7f4d18786fe7e055e562397cd5102bdd7f8dd"
+	out := renderDmsgPanelANSI(dmsgStats{
+		Servers: []dmsgServerRow{{PK: pk, Address: "45.79.124.73:30082", Available: 997, Listed: true}},
+	})
+	if !strings.Contains(out, pk) {
+		t.Error("the full public key is not present")
+	}
+}
+
+// Ordering belongs to the gatherer (fullest first), not the renderer. Assert
+// the renderer draws rows in exactly the order it is handed, so there is only
+// one place that decides what "first" means.
+func TestDmsgPanelPreservesGivenOrder(t *testing.T) {
+	out := renderDmsgPanelANSI(dmsgStats{Servers: []dmsgServerRow{
+		{PK: strings.Repeat("b", 66), Address: "roomy:1", Available: 1200, Listed: true},
+		{PK: strings.Repeat("a", 66), Address: "full:2", Available: 0, Listed: false},
+	}})
+
+	roomy, full := strings.Index(out, "roomy:1"), strings.Index(out, "full:2")
+	if roomy < 0 || full < 0 {
+		t.Fatal("a server row is missing from the rendering")
+	}
+	if roomy > full {
+		t.Error("the renderer reordered rows; sorting must stay in gatherDmsgStats")
+	}
+}
+
+// A failed fetch is named, never rendered as an empty or zeroed panel.
+func TestDmsgPanelNamesFailures(t *testing.T) {
+	out := renderDmsgPanelANSI(dmsgStats{ServersErr: "request failed: EOF"})
+	if !strings.Contains(out, "unavailable") || !strings.Contains(out, "EOF") {
+		t.Error("a failed server fetch was not reported")
+	}
+	// Servers fine, entries dead: the working half must still draw.
+	out = renderDmsgPanelANSI(dmsgStats{
+		Servers:    []dmsgServerRow{{PK: "x", Address: "a:1", Available: 5, Listed: true}},
+		EntriesErr: "status 502",
+	})
+	if !strings.Contains(out, "DMSG SERVERS") {
+		t.Error("a working section was suppressed by an unrelated failure")
+	}
+	if !strings.Contains(out, "502") {
+		t.Error("the entries failure was not reported")
+	}
+}
+
+// No data and no error must still say something rather than vanish.
+func TestDmsgPanelNeverSilentlyEmpty(t *testing.T) {
+	out := renderDmsgPanelANSI(dmsgStats{})
+	if !strings.Contains(out, "DMSG SERVERS") || !strings.Contains(out, "unavailable") {
+		t.Error("an empty panel disappeared instead of reporting itself absent")
+	}
+}


### PR DESCRIPTION
Nothing on the reward site showed dmsg. The transport and uptime views describe what the network carries; none describe the layer carrying it — so a dmsg server sitting at capacity was invisible in every chart while it quietly pushed clients elsewhere.

Two panels: **per-server spare capacity** (fullest first) and **client entries registered in discovery**.

The capacity figure is labeled as spare slots, never as load, and that distinction is the point. `availableSessions` is capacity REMAINING; discovery excludes a server at zero from `available_servers` by design; reading it as load inverts the meaning and makes the fullest server look like the emptiest. That inversion is exactly how a saturated server was recently reported as having no clients — it was at `max_sessions: 600` while attracting ~750. A server at zero is marked `FULL` and the footer states the units.

Public keys print whole: an operator matching a server against their own config needs the entire key.

Failure handling matches the rest of the panel — a dead fetch is named with its reason, a working half still draws when the other fails, and an empty panel reports itself absent rather than vanishing. Tests cover each of those plus the full-not-idle labeling.
