### PR TITLE
fix(dmsg): name the destination in the failed-lookup log line

### DIFF
--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -46,7 +46,14 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 		// doesn't register in discovery, try all connected servers as forwarders.
 		// Only attempt if context has enough remaining time to avoid races.
 		if ctx.Err() == nil && ce.hasEnoughTimeForFallback(ctx) {
-			ce.log.WithError(discErr).Debug("Discovery lookup failed, trying connected servers")
+			// Name the destination. Without it this line says only that "a lookup
+			// failed", which is undiagnosable in aggregate: the deployment services
+			// are not registered as client entries — they are reached through seeded
+			// delegated-server entries — so every dial to one logs this and then
+			// succeeds via the fallback. Telling those apart from a genuinely
+			// unreachable peer requires knowing which PK was being dialed.
+			ce.log.WithError(discErr).WithField("remote_pk", addr.PK.Hex()).
+				Debug("Discovery lookup failed, trying connected servers")
 			// Use a separate context with enough budget for multiple servers.
 			// Each server attempt takes up to HandshakeTimeout (5s), so budget
 			// for all connected sessions (typically 6) plus a small margin.


### PR DESCRIPTION
`Discovery lookup failed, trying connected servers` says only that a lookup failed, never for whom — while `addr.PK` is right there.

That matters because the line is common and usually benign. The deployment services are **not registered as client entries** in dmsg-discovery: an entry lookup for TPD (`02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae`) and SD (`0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7`) both return **404**, and they are reached through the seeded delegated-server entries `StartDmsgSeeded` installs. So every dial to a service logs this and then succeeds on the fallback.

Which means the expected case and a genuinely unreachable peer look identical in the log. Investigating 21 of these in 30 minutes of reward-server output, with no way to tell which destination any referred to, is what prompted this.

Adds `remote_pk` to the line. Debug level, one field.
