### PR TITLE
feat(rewards): check every service is reachable through every dmsg server

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/stats_tui.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui.go
@@ -64,7 +64,9 @@ type statsTUIData struct {
 	// with the label of the day each run of slots belongs to.
 	Liveness []statsTUILivenessDay
 	// Dmsg is the substrate layer: server capacity and client registrations.
-	Dmsg        dmsgStats
+	Dmsg dmsgStats
+	// Coverage is each service measured against the registered dmsg server set.
+	Coverage    coverageStats
 	LivenessErr string
 }
 
@@ -323,6 +325,13 @@ func RenderStatsANSI(d statsTUIData) string {
 	// site. A dmsg server sitting at capacity is invisible in every transport
 	// and uptime view while it quietly pushes clients elsewhere.
 	b.WriteString(renderDmsgPanelANSI(d.Dmsg))
+
+	// ---- service reachability ----------------------------------------------
+	//
+	// Services deliberately publish no discovery entry, so a service connected
+	// to only some dmsg servers is invisible: reachable for clients on those
+	// servers, silently unresolvable for the rest, with no error anywhere.
+	b.WriteString(renderCoveragePanelANSI(d.Coverage))
 
 	// ---- version adoption --------------------------------------------------
 	if d.VersionsErr != "" {

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_coverage.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_coverage.go
@@ -1,0 +1,168 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/stats_tui_coverage.go c5-reward-server
+//
+// Service reachability across the dmsg servers.
+//
+// The deployment services deliberately do NOT register client entries in
+// dmsg-discovery — an entry lookup for TPD or SD returns 404. That is the
+// design: a service should not cost every caller a discovery round-trip, it
+// should be equally reachable through whichever dmsg server the caller already
+// holds a session with. Callers reach them through seeded delegated-server
+// entries instead.
+//
+// That design has a failure mode nothing was checking. If a service is
+// connected to only some of the dmsg servers, it stays perfectly reachable for
+// clients on those servers and quietly unreachable for the rest — no error
+// anywhere, just a subset of the network unable to resolve it. Since the
+// service publishes no entry, discovery cannot report the gap either.
+//
+// Each service's /health lists the dmsg servers it currently holds sessions
+// with. Comparing that against the registered server set turns an invisible
+// partial connection into a number.
+package clirewardsserver
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/skycoin/skywire/deployment"
+)
+
+// serviceCoverage is one service measured against the dmsg server set.
+type serviceCoverage struct {
+	Name string
+	PK   string
+	// Connected is how many of the registered servers the service reports
+	// sessions with; Total is how many are registered.
+	Connected int
+	Total     int
+	// Missing lists the servers it is NOT connected to, which is the
+	// actionable part: those are the servers whose clients cannot reach it.
+	Missing []string
+	Err     string
+}
+
+type coverageStats struct {
+	Services []serviceCoverage
+	Err      string
+}
+
+// healthDoc is the slice of a service's /health that matters here.
+type healthDoc struct {
+	DmsgServers []string `json:"dmsg_servers"`
+}
+
+// gatherServiceCoverage asks each dmsg-addressed service which servers it is
+// connected to and compares against the registered set.
+func gatherServiceCoverage() coverageStats {
+	var c coverageStats
+
+	var all []discServerEntry
+	base := strings.TrimSuffix(deployment.Prod.DmsgDiscovery, "/")
+	if err := statsGetJSON(base+"/dmsg-discovery/all_servers", &all); err != nil {
+		c.Err = err.Error()
+		return c
+	}
+	registered := make([]string, 0, len(all))
+	for _, e := range all {
+		registered = append(registered, e.Static)
+	}
+	sort.Strings(registered)
+
+	// Only the dmsg-addressed services: a clearnet service has no dmsg
+	// sessions to account for.
+	for _, s := range []struct{ name, url string }{
+		{"transport-discovery", deployment.Prod.TransportDiscoveryDmsg},
+		{"service-discovery", deployment.Prod.ServiceDiscoveryDmsg},
+		{"address-resolver", deployment.Prod.AddressResolverDmsg},
+		{"route-finder", deployment.Prod.RouteFinderDmsg},
+		{"uptime-tracker", deployment.Prod.UptimeTrackerDmsg},
+		{"dmsg-discovery", deployment.Prod.DmsgDiscoveryDmsg},
+	} {
+		if s.url == "" {
+			continue
+		}
+		cov := serviceCoverage{Name: s.name, PK: pkFromDmsgAddr(s.url), Total: len(registered)}
+		var h healthDoc
+		if err := statsGetJSON(strings.TrimSuffix(s.url, "/")+"/health", &h); err != nil {
+			cov.Err = err.Error()
+			c.Services = append(c.Services, cov)
+			continue
+		}
+		have := make(map[string]bool, len(h.DmsgServers))
+		for _, pk := range h.DmsgServers {
+			have[pk] = true
+		}
+		for _, pk := range registered {
+			if have[pk] {
+				cov.Connected++
+			} else {
+				cov.Missing = append(cov.Missing, pk)
+			}
+		}
+		c.Services = append(c.Services, cov)
+	}
+	return c
+}
+
+// pkFromDmsgAddr pulls the public key out of a dmsg://<pk>:<port> address.
+func pkFromDmsgAddr(u string) string {
+	s := strings.TrimPrefix(u, "dmsg://")
+	if i := strings.IndexByte(s, ':'); i > 0 {
+		s = s[:i]
+	}
+	if i := strings.IndexByte(s, '/'); i > 0 {
+		s = s[:i]
+	}
+	return s
+}
+
+// renderCoveragePanelANSI draws the service-reachability panel.
+func renderCoveragePanelANSI(c coverageStats) string {
+	width := tuiWidth
+	if c.Err != "" {
+		return tuiMissing("SERVICE REACHABILITY", c.Err) + "\n"
+	}
+	if len(c.Services) == 0 {
+		return tuiMissing("SERVICE REACHABILITY", "no dmsg-addressed services configured") + "\n"
+	}
+
+	var b strings.Builder
+	b.WriteString(tuiRule("SERVICE REACHABILITY — dmsg servers connected", width))
+
+	gaps := 0
+	for _, s := range c.Services {
+		if s.Err != "" {
+			b.WriteString(fmt.Sprintf("  %s%-20s%s %sunreachable%s %s%s%s\n",
+				aDim, s.Name, aReset, aRed, aReset, aDim, s.Err, aReset))
+			gaps++
+			continue
+		}
+		frac := 0.0
+		if s.Total > 0 {
+			frac = float64(s.Connected) / float64(s.Total)
+		}
+		col := aGreen
+		if s.Connected < s.Total {
+			col = aRed
+			gaps++
+		}
+		b.WriteString(fmt.Sprintf("  %s%-20s%s %s%2d/%-2d%s %s\n",
+			aDim, s.Name, aReset, aBold, s.Connected, s.Total, aReset, tuiBar(frac, 24, col)))
+		b.WriteString(fmt.Sprintf("  %s%s%s\n", aDim, s.PK, aReset))
+		// Name the servers it cannot be reached through: those are precisely
+		// the clients that cannot resolve it, and nothing else reports them.
+		for _, pk := range s.Missing {
+			b.WriteString(fmt.Sprintf("    %sunreachable via %s%s\n", aRed, pk, aReset))
+		}
+	}
+	if gaps == 0 {
+		b.WriteString(fmt.Sprintf("  %severy service reachable through every dmsg server%s\n", aDim, aReset))
+	} else {
+		b.WriteString(fmt.Sprintf("  %s%d service(s) not reachable through every server — clients on the "+
+			"missing servers cannot resolve them%s\n", aRed, gaps, aReset))
+	}
+	b.WriteString(tuiClose(width))
+	b.WriteString("\n")
+	return b.String()
+}

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_coverage_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_coverage_test.go
@@ -1,0 +1,100 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/stats_tui_coverage_test.go c5-reward-server
+package clirewardsserver
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	srvA = "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7"
+	srvB = "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0"
+	svc  = "02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae"
+)
+
+// A service connected to every server is the healthy case and must read as
+// such without qualification.
+func TestCoveragePanelReportsFullReachability(t *testing.T) {
+	out := renderCoveragePanelANSI(coverageStats{Services: []serviceCoverage{
+		{Name: "transport-discovery", PK: svc, Connected: 9, Total: 9},
+	}})
+	if !strings.Contains(out, "9/9") {
+		t.Error("the connected/total figure is missing")
+	}
+	if !strings.Contains(out, "every service reachable through every dmsg server") {
+		t.Error("full coverage was not stated")
+	}
+	if strings.Contains(out, "unreachable via") {
+		t.Error("a fully-connected service was reported as having gaps")
+	}
+}
+
+// The failure this panel exists to catch: a service on only some servers stays
+// perfectly reachable for clients on those servers and silently unresolvable
+// for the rest. Since services publish no discovery entry, nothing else
+// reports it — so the missing servers must be named, not merely counted.
+func TestCoveragePanelNamesUnreachableServers(t *testing.T) {
+	out := renderCoveragePanelANSI(coverageStats{Services: []serviceCoverage{
+		{Name: "service-discovery", PK: svc, Connected: 1, Total: 2, Missing: []string{srvB}},
+	}})
+	if !strings.Contains(out, "1/2") {
+		t.Error("the partial figure is missing")
+	}
+	if !strings.Contains(out, srvB) {
+		t.Error("the unreachable server was not named in full")
+	}
+	if !strings.Contains(out, "cannot resolve them") {
+		t.Error("the consequence of the gap was not stated")
+	}
+}
+
+// A service whose health cannot be fetched is unknown, not healthy: reporting
+// it as fully connected would be worse than saying nothing.
+func TestCoveragePanelMarksUnreachableService(t *testing.T) {
+	out := renderCoveragePanelANSI(coverageStats{Services: []serviceCoverage{
+		{Name: "route-finder", PK: svc, Err: "request failed: EOF"},
+	}})
+	if !strings.Contains(out, "unreachable") || !strings.Contains(out, "EOF") {
+		t.Error("a service whose health failed was not reported")
+	}
+	if strings.Contains(out, "every service reachable") {
+		t.Error("a service with no health data was counted as healthy")
+	}
+}
+
+// Whole keys: an operator matching a server against their own config needs all
+// 66 characters.
+func TestCoveragePanelPrintsFullKeys(t *testing.T) {
+	out := renderCoveragePanelANSI(coverageStats{Services: []serviceCoverage{
+		{Name: "transport-discovery", PK: svc, Connected: 1, Total: 2, Missing: []string{srvA}},
+	}})
+	for _, k := range []string{svc, srvA} {
+		if !strings.Contains(out, k) {
+			t.Errorf("key %s was not printed in full", k)
+		}
+	}
+}
+
+// A failed server list, or none configured, must say so rather than render an
+// empty panel that reads as "nothing wrong".
+func TestCoveragePanelNamesItsOwnFailure(t *testing.T) {
+	if out := renderCoveragePanelANSI(coverageStats{Err: "status 502"}); !strings.Contains(out, "502") {
+		t.Error("the panel did not report why it had no data")
+	}
+	if out := renderCoveragePanelANSI(coverageStats{}); !strings.Contains(out, "unavailable") {
+		t.Error("an empty panel did not report itself absent")
+	}
+}
+
+func TestPKFromDmsgAddr(t *testing.T) {
+	for in, want := range map[string]string{
+		"dmsg://" + svc + ":80":  svc,
+		"dmsg://" + svc + ":80/": svc,
+		"dmsg://" + svc:          svc,
+		"":                       "",
+	} {
+		if got := pkFromDmsgAddr(in); got != want {
+			t.Errorf("pkFromDmsgAddr(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_data.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_data.go
@@ -89,6 +89,7 @@ func gatherStatsTUI() statsTUIData {
 	}
 
 	d.Dmsg = gatherDmsgStats()
+	d.Coverage = gatherServiceCoverage()
 
 	return d
 }


### PR DESCRIPTION
The deployment services deliberately publish **no** dmsg-discovery entry — an entry lookup for TPD (`02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae`) or SD (`0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7`) returns 404. That is the design: a service should not cost every caller a discovery round-trip, it should be equally reachable through whichever dmsg server the caller already holds a session with, via seeded delegated-server entries.

Nothing was checking that the premise holds. **A service connected to only some of the servers stays perfectly reachable for clients on those servers and silently unresolvable for the rest** — no error anywhere, and because the service publishes no entry, discovery cannot report the gap either.

`/health` already carries the answer, and it is live state rather than configured intent: `svcmode.pollDmsgServers` calls `dmsg.Client.ConnectedServersPK()` on a one-second ticker and the services assign the result straight onto their health response (`pkg/services/tpd/tpd.go:239` and the equivalents in sd/ar/rf). Comparing it against `all_servers` gives coverage per service, and names the specific servers whose clients cannot reach it.

Currently reads 9/9 for transport-discovery.

A service whose health cannot be fetched is reported as unknown, never as healthy — the same rule as the rest of the panel, since a silent pass here would defeat the point.
