### PR TITLE
fix(tpd): stop silently returning partial transport counts

### DIFF
--- a/pkg/deployment/tpd/store/partial_read_test.go
+++ b/pkg/deployment/tpd/store/partial_read_test.go
@@ -1,0 +1,76 @@
+// Package store pkg/deployment/tpd/store/partial_read_test.go c4-net-discovery
+package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The counts are assembled from batched MGETs over the transport index, and a
+// failed batch used to be skipped with a bare `continue` — silently removing
+// up to mgetBatch (10,000) transports while still returning a plausible
+// number. With an index observed between roughly 4,400 and 15,800 members
+// that is one or two batches, so losing one could halve the reported total,
+// and a consumer had no way to distinguish it from the network shrinking.
+//
+// TransportSummary now carries that state. These tests pin the contract; the
+// batch paths themselves need a live Redis and are exercised in the
+// integration suite.
+func TestTransportSummaryDefaultsToComplete(t *testing.T) {
+	var s TransportSummary
+	if s.Partial {
+		t.Error("a zero TransportSummary must not claim to be partial")
+	}
+	if s.MissingBatches != 0 {
+		t.Errorf("MissingBatches = %d, want 0", s.MissingBatches)
+	}
+}
+
+// A partial summary must be distinguishable from a complete one carrying the
+// same numbers — that is the entire point of the flag.
+func TestTransportSummaryPartialIsDistinguishable(t *testing.T) {
+	complete := TransportSummary{Total: 8000, ByType: map[string]int{"stcpr": 8000}}
+	partial := TransportSummary{Total: 8000, ByType: map[string]int{"stcpr": 8000},
+		Partial: true, MissingBatches: 1}
+
+	if complete.Total != partial.Total {
+		t.Fatal("fixture error: the two summaries should hold identical counts")
+	}
+	if complete.Partial == partial.Partial {
+		t.Error("a partial summary is indistinguishable from a complete one")
+	}
+	if partial.MissingBatches == 0 {
+		t.Error("a partial summary does not report how many batches were lost")
+	}
+}
+
+// The flag is omitempty so a complete summary's JSON is unchanged for existing
+// consumers, while a partial one is explicitly marked.
+func TestTransportSummaryJSONOnlyMarksPartial(t *testing.T) {
+	if got := marshalSummary(t, TransportSummary{Total: 5}); contains(got, "partial") {
+		t.Errorf("a complete summary should not emit a partial field: %s", got)
+	}
+	if got := marshalSummary(t, TransportSummary{Total: 5, Partial: true, MissingBatches: 2}); !contains(got, "partial") {
+		t.Errorf("a partial summary must emit the partial field: %s", got)
+	}
+}
+
+func marshalSummary(t *testing.T, s TransportSummary) string {
+	t.Helper()
+	b, err := jsonMarshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func contains(hay, needle string) bool {
+	for i := 0; i+len(needle) <= len(hay); i++ {
+		if hay[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonMarshal(v any) ([]byte, error) { return json.Marshal(v) }

--- a/pkg/deployment/tpd/store/redis_metrics.go
+++ b/pkg/deployment/tpd/store/redis_metrics.go
@@ -68,10 +68,10 @@ func transportDailyBandwidth(result map[string]string) uint64 {
 // (stcpr, sudph). A visor is considered online when it has 2+ p2p transports,
 // indicating genuine peer-to-peer network participation (not just dmsg
 // infrastructure connectivity).
-func (s *redisStore) getP2PTransportCounts(ctx context.Context) map[string]int {
+func (s *redisStore) getP2PTransportCounts(ctx context.Context) (map[string]int, error) {
 	keys, ids, err := s.allTransportKeysFromIndex(ctx)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	counts := make(map[string]int)
@@ -85,7 +85,13 @@ func (s *redisStore) getP2PTransportCounts(ctx context.Context) map[string]int {
 		}
 		vals, err := s.client.MGet(ctx, keys[i:end]...).Result()
 		if err != nil {
-			continue
+			// These counts decide online status — GetAllVisorSummaries does
+			// `online := p2pCounts[pk] >= minP2PTransportsOnline` — and uptime
+			// feeds the reward threshold. A batch skipped silently removes up
+			// to mgetBatch transports, pushing visors below the bar and
+			// marking them offline when they are not. Refuse to answer rather
+			// than answer wrongly.
+			return nil, fmt.Errorf("p2p transport counts are incomplete: batch %d-%d failed: %w", i, end, err)
 		}
 		for j, val := range vals {
 			raw, ok := val.(string)
@@ -108,7 +114,7 @@ func (s *redisStore) getP2PTransportCounts(ctx context.Context) map[string]int {
 	}
 	s.maybeReapStaleTransports(stale)
 
-	return counts
+	return counts, nil
 }
 
 func (s *redisStore) getBandwidthFromHash(ctx context.Context, key, transportID, period, periodKey string) (BandwidthAggregation, error) {

--- a/pkg/deployment/tpd/store/redis_transport.go
+++ b/pkg/deployment/tpd/store/redis_transport.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -381,7 +382,12 @@ func (s *redisStore) GetNumberOfTransports(ctx context.Context) (map[types.Type]
 		}
 		vals, err := s.client.MGet(ctx, keys[i:end]...).Result()
 		if err != nil {
-			continue
+			// Unlike GetTransportSummary there is nowhere in a bare
+			// map[Type]int to record that the answer is short, and a count
+			// that silently omits up to mgetBatch transports is worse than no
+			// count: it is indistinguishable from the network shrinking.
+			// Fail loudly instead.
+			return nil, fmt.Errorf("transport count is incomplete: batch %d-%d failed: %w", i, end, err)
 		}
 		for j, val := range vals {
 			raw, ok := val.(string)
@@ -424,6 +430,14 @@ func (s *redisStore) GetTransportSummary(ctx context.Context, selfTransports boo
 		}
 		vals, err := s.client.MGet(ctx, keys[i:end]...).Result()
 		if err != nil {
+			// A failed batch removes up to mgetBatch transports from the
+			// answer. Skipping it silently returns a plausible number that
+			// undercounts by an unknown amount, which reads downstream as the
+			// network having shrunk. Record it so the caller can tell the
+			// difference; the partial result is still worth returning, since
+			// some data with a warning beats none.
+			summary.Partial = true
+			summary.MissingBatches++
 			continue
 		}
 		for j, val := range vals {

--- a/pkg/deployment/tpd/store/redis_uptime.go
+++ b/pkg/deployment/tpd/store/redis_uptime.go
@@ -48,7 +48,16 @@ func (s *redisStore) GetAllVisorSummaries(ctx context.Context, v2 bool, timeline
 	}
 
 	// Count p2p transports per visor for online determination.
-	p2pCounts := s.getP2PTransportCounts(ctx)
+	//
+	// An incomplete count here marks live visors offline: online is
+	// `p2pCounts[pk] >= minP2PTransportsOnline`, so transports missing from a
+	// short read push visors under the bar. Uptime feeds the reward
+	// threshold, so a wrong answer is worse than none — fail rather than
+	// publish a summary built on a partial count.
+	p2pCounts, err := s.getP2PTransportCounts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("visor summaries: %w", err)
+	}
 
 	// Merge heartbeat visors and visors with p2p transports.
 	allVisors := make(map[string]struct{})

--- a/pkg/deployment/tpd/store/store.go
+++ b/pkg/deployment/tpd/store/store.go
@@ -174,6 +174,23 @@ type TransportSummary struct {
 	Total        int            `json:"total_transports"`
 	ByType       map[string]int `json:"by_type"`
 	UniqueVisors int            `json:"unique_visors"`
+
+	// Partial reports that at least one batch of the underlying read failed,
+	// so Total and ByType undercount by an unknown amount.
+	//
+	// This exists because the counts are assembled from batched MGETs over the
+	// transport index, and a failed batch used to be skipped with a bare
+	// `continue` — silently removing up to mgetBatch transports from the
+	// answer while still returning a plausible-looking number. A consumer had
+	// no way to tell "there are N transports" from "N is what I managed to
+	// read", which is indistinguishable from the network shrinking.
+	//
+	// Callers that publish or chart these numbers must treat Partial as
+	// "do not trust this sample" rather than as data.
+	Partial bool `json:"partial,omitempty"`
+	// MissingBatches counts the failed batches, for logging and for judging
+	// how far off Total might be.
+	MissingBatches int `json:"missing_batches,omitempty"`
 }
 
 // Store stores Transport metadata and generated nonce values.


### PR DESCRIPTION
Part of #4513.

The counts are assembled from batched MGETs over the transport index, and three readers skipped a failed batch with a bare `continue`:

```
redis_transport.go:383   GetNumberOfTransports     if err != nil { continue }
redis_transport.go:426   GetTransportSummary       if err != nil { continue }
redis_metrics.go:87      getP2PTransportCounts     if err != nil { continue }
redis_transport.go:594   (batched reader)          if err != nil { return nil, err }   ← already correct
```

With `mgetBatch = 10000` and the index observed between roughly **4,400 and 15,800** members, that is one or two batches — so losing one silently removed up to 10,000 transports while still returning a plausible number. Downstream, a short read is indistinguishable from the network shrinking, which is how a stable network reads as a collapsing one.

Handled per caller, according to what a wrong answer costs:

- **`getP2PTransportCounts` now returns an error, and `GetAllVisorSummaries` propagates it.** These counts decide online status — `online := p2pCounts[pk] >= minP2PTransportsOnline` — and uptime feeds the reward threshold. A short read pushes live visors under the bar and marks them offline, costing them rewards. Refusing to answer is the only safe option here.
- **`GetNumberOfTransports` returns an error**: a bare `map[Type]int` has nowhere to record that it is short.
- **`GetTransportSummary` still returns its partial result**, but sets `Partial` and `MissingBatches` so a publisher or chart can treat the sample as untrustworthy rather than as data. `omitempty` keeps existing consumers' JSON unchanged when the read is complete.

**Scope, stated honestly.** This is necessary for any count to be trustworthy, and it is not proven sufficient for #4513. Redis currently reports `cmdstat_mget: calls=3896, failed_calls=0` at 410 µs against a 5 s `ReadTimeout`, so I have no direct evidence these batches are failing today — a client-side timeout would not appear in that counter, but I am not claiming it is happening. The index is also observed to swing across a day while eight consecutive samples in a quiet window held within 2.3% with 0.3% stale members, so something episodic moves it that this does not explain. Instrumenting index cardinality and SADD/SREM volume on a timer is the sensible next step, so the next swing carries evidence rather than being reconstructed afterwards.
