### PR TITLE
feat(rewards): source the statistics pages from CXO, add the stats/daily feed

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -501,14 +501,14 @@ func buildRouter() *gin.Engine {
 				l += "<p style='color:#FFCE56'>Yellow = Transport bandwidth inconsistent</p>"
 				l += "<p style='color:#FF6384'>Red = Error: sent or received is zero</p>"
 
-				tpdData, err := fetchTPDBandwidthMetrics(7)
+				tpdData, tpdSrc, err := fetchTPDBandwidthMetrics(7)
 				if err != nil {
 					l += fmt.Sprintf("<p style='color:red'>Error fetching TPD data: %v</p>", err)
 					// Fallback to shell-out
 					tp, _ := script.Exec(`skywire cli log tp -d rewards/log_backups`).String() //nolint:errcheck,gosec
 					l += fmt.Sprintf("%s\n", ansihtml.ConvertToHTML([]byte(tp)))
 				} else {
-					l += renderTPDBandwidthTable(tpdData)
+					l += renderTPDBandwidthTable(tpdData, tpdSrc)
 				}
 				l += htmltoplink
 				l += htmlend
@@ -1849,6 +1849,16 @@ func serveStandalone(r1 *gin.Engine, bindAddr string) {
 		Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgClient),
 		Timeout:   45 * time.Second,
 	}
+
+	// The statistics pages read TPD over CXO first and fall back to the
+	// dmsg-HTTP client above. Same client, same identity — a second dmsg
+	// client would mean a second discovery entry to read services this
+	// one already reaches (#4501/#4502). CXO is not an optimization
+	// here: an HTTP fetch fails outright whenever this client is between
+	// sessions (#4538), while a subscriber reads a snapshot it already
+	// holds.
+	setStatsCXOSubMgrFromDmsg(dmsgClient)
+	log.Info("stats pages: TPD aggregates sourced over CXO (HTTP-over-dmsg kept as fallback)")
 
 	// tp-viz reads the deployment over THIS client rather than one of its own.
 	// It is the same process and the same identity; a second dmsg client would

--- a/cmd/skywire-cli/commands/rewards/server/stats.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats.go
@@ -18,10 +18,11 @@ import (
 	"time"
 
 	"github.com/bitfield/script"
-	"github.com/oschwald/geoip2-golang/v2"
+	geoip2 "github.com/oschwald/geoip2-golang/v2"
 
 	geoipcmd "github.com/skycoin/skywire/cmd/svc/geoip/commands"
 	"github.com/skycoin/skywire/deployment"
+	tpdstore "github.com/skycoin/skywire/pkg/deployment/tpd/store"
 )
 
 var (
@@ -1180,8 +1181,29 @@ func statsHTTPGet(url string) (*http.Response, error) {
 	return http.Get(url) //nolint:noctx,gosec
 }
 
-func fetchTPDBandwidthMetrics(days int) ([]tpdTransportMetric, error) {
+// fetchTPDBandwidthMetrics returns the per-transport daily bandwidth records
+// for the last `days` days, plus a line naming where they came from.
+//
+// CXO first. This is the largest body the statistics pages read — tens of
+// megabytes of per-transport rows over HTTP, on a route that dies with EOF
+// whenever the reward server's dmsg client is between sessions (#4538) — and
+// it is exactly what TPD's metrics feed already publishes as one leaf per
+// calendar day. The local window is assembled from the N newest leaves.
+func fetchTPDBandwidthMetrics(days int) ([]tpdstore.TransportMetric, statsSource, error) {
+	metrics, src, cxoErr := cxoTransportMetrics(days)
+	if cxoErr == nil {
+		return metrics, src, nil
+	}
 	tpdURL := strings.TrimSuffix(deployment.Prod.TransportDiscovery, "/")
+	metrics, err := fetchTPDBandwidthMetricsHTTP(tpdURL, days)
+	if err != nil {
+		return nil, statsSource{}, err
+	}
+	return metrics, httpStatsSource(fmt.Sprintf("/metrics?days=%d", days), cxoErr.Error()), nil
+}
+
+// fetchTPDBandwidthMetricsHTTP is the pre-CXO path, kept as the fallback.
+func fetchTPDBandwidthMetricsHTTP(tpdURL string, days int) ([]tpdstore.TransportMetric, error) {
 	url := fmt.Sprintf("%s/metrics?days=%d&bandwidth=true&latency=false", tpdURL, days)
 
 	resp, err := statsHTTPGet(url)
@@ -1199,7 +1221,9 @@ func fetchTPDBandwidthMetrics(days int) ([]tpdTransportMetric, error) {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	var metrics []tpdTransportMetric
+	// Parsing is the validity test — never the body's length. Large reads
+	// through dmsg have repeatedly arrived truncated under a 200.
+	var metrics []tpdstore.TransportMetric
 	if err := json.Unmarshal(body, &metrics); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
@@ -1207,27 +1231,8 @@ func fetchTPDBandwidthMetrics(days int) ([]tpdTransportMetric, error) {
 	return metrics, nil
 }
 
-// tpdTransportMetric represents a transport metric from TPD /metrics endpoint
-type tpdTransportMetric struct {
-	ID    string   `json:"id"`
-	Type  string   `json:"type"`
-	Live  bool     `json:"live"`
-	Edges []string `json:"edges,omitempty"`
-	Daily []struct {
-		Date string `json:"date"`
-		A    *struct {
-			Sent uint64 `json:"sent"`
-			Recv uint64 `json:"recv"`
-		} `json:"a,omitempty"`
-		B *struct {
-			Sent uint64 `json:"sent"`
-			Recv uint64 `json:"recv"`
-		} `json:"b,omitempty"`
-	} `json:"daily"`
-}
-
 // renderTPDBandwidthTable renders TPD transport metrics as an HTML table
-func renderTPDBandwidthTable(metrics []tpdTransportMetric) string {
+func renderTPDBandwidthTable(metrics []tpdstore.TransportMetric, src statsSource) string {
 	if len(metrics) == 0 {
 		return "<p>No transport metrics available from TPD</p>"
 	}
@@ -1247,6 +1252,9 @@ func renderTPDBandwidthTable(metrics []tpdTransportMetric) string {
 
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("<p>Showing %d transports with bandwidth data over %d days</p>\n", len(metrics), len(dates)))
+	if line := src.String(); line != "" {
+		sb.WriteString(fmt.Sprintf("<p style='color:#888;font-size:11px;'>%s</p>\n", html.EscapeString(line)))
+	}
 	sb.WriteString("<table style='border-collapse: collapse; font-size: 10px;'>\n")
 	sb.WriteString("<thead><tr style='border-bottom: 1px solid #555;'>")
 	sb.WriteString("<th style='padding: 4px 8px; text-align: left;'>Transport</th>")
@@ -1324,6 +1332,11 @@ type tpdNetworkSummary struct {
 	// BandwidthErr carries why the bandwidth fetch failed, so the page can say
 	// so instead of quietly showing a zero.
 	BandwidthErr string `json:"bandwidth_err,omitempty"`
+	// CountsSrc and BandwidthSrc name where each figure came from — a CXO
+	// snapshot with its own age and completeness verdict, or a live HTTP
+	// fetch. Printed on the page: the two are not interchangeable claims.
+	CountsSrc    string `json:"counts_src,omitempty"`
+	BandwidthSrc string `json:"bandwidth_src,omitempty"`
 }
 
 const tpdSummaryCacheFile = "tpd_summary.json"
@@ -1382,9 +1395,29 @@ func getTPDNetworkSummary() (*tpdNetworkSummary, error) {
 	return summary, nil
 }
 
-// fillTPDCounts populates the transport/visor counts from TPD's small
-// aggregate endpoint.
+// fillTPDCounts populates the transport/visor counts, preferring TPD's CXO
+// stats/network leaf and falling back to the /all-transports/stats endpoint
+// it mirrors. The leaf carries the same three numbers plus a completeness
+// verdict, which the HTTP body does not: TPD's transport aggregate is
+// readable while it refills after a restart (#4513), and only the feed says
+// when it is.
 func fillTPDCounts(tpdURL string, summary *tpdNetworkSummary) error {
+	stats, src, cxoErr := cxoNetworkStats()
+	if cxoErr == nil {
+		summary.TotalTransports = stats.Total
+		summary.UniqueVisors = stats.UniqueVisors
+		for k, v := range stats.ByType {
+			summary.ByType[k] = v
+		}
+		summary.CountsSrc = src.String()
+		return nil
+	}
+	summary.CountsSrc = httpStatsSource("/all-transports/stats", cxoErr.Error()).String()
+	return fillTPDCountsHTTP(tpdURL, summary)
+}
+
+// fillTPDCountsHTTP is the pre-CXO path, kept as the fallback.
+func fillTPDCountsHTTP(tpdURL string, summary *tpdNetworkSummary) error {
 	resp, err := statsHTTPGet(tpdURL + "/all-transports/stats")
 	if err != nil {
 		return fmt.Errorf("TPD request failed: %w", err)
@@ -1415,58 +1448,39 @@ func fillTPDCounts(tpdURL string, summary *tpdNetworkSummary) error {
 
 // fillTPDBandwidth adds the verified-bandwidth total. Separate from the counts
 // so a failure here costs only that one line of the summary.
+//
+// The records now come from TPD's CXO metrics feed when it has them —
+// specifically the CURRENT day's leaf, which is what a 1-day window is. What
+// does NOT change is the arithmetic: this figure is the min()-verified one
+// that mirrors the reward calculation, and TPD's own cumulative aggregate
+// (stats/daily, /metric) is a DIFFERENT number. Moving the read must not
+// become swapping the number, so both paths decode into the same record type
+// and hand it to the same accumulator below.
 func fillTPDBandwidth(tpdURL string, summary *tpdNetworkSummary) error {
-	url := fmt.Sprintf("%s/metrics?days=1&bandwidth=true&latency=false&edges=false", tpdURL)
-
-	resp, err := statsHTTPGet(url)
-	if err != nil {
-		return fmt.Errorf("TPD request failed: %w", err)
+	metrics, src, cxoErr := cxoTransportMetrics(1)
+	if cxoErr == nil {
+		summary.TotalBandwidth = 0
+		accumulateVerifiedBandwidth(metrics, summary)
+		summary.BandwidthOK = true
+		summary.BandwidthSrc = src.String()
+		return nil
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	summary.BandwidthSrc = httpStatsSource("/metrics?days=1", cxoErr.Error()).String()
+	return fillTPDBandwidthHTTP(tpdURL, summary)
+}
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("TPD returned status %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read TPD response: %w", err)
-	}
-
-	var metrics []struct {
-		ID      string   `json:"id"`
-		Type    string   `json:"type"`
-		Live    bool     `json:"live"`
-		Edges   []string `json:"edges,omitempty"`
-		Latency *struct {
-			Avg int64 `json:"avg"`
-		} `json:"latency,omitempty"`
-		Daily []struct {
-			A *struct {
-				Sent uint64 `json:"sent"`
-				Recv uint64 `json:"recv"`
-			} `json:"a,omitempty"`
-			B *struct {
-				Sent uint64 `json:"sent"`
-				Recv uint64 `json:"recv"`
-			} `json:"b,omitempty"`
-		} `json:"daily"`
-	}
-	if err := json.Unmarshal(body, &metrics); err != nil {
-		return fmt.Errorf("failed to parse TPD metrics: %w", err)
-	}
-
-	for _, m := range metrics {
-		for _, daily := range m.Daily {
-			// Mirror the canonical three-branch trust model used by the reward
-			// bw-collect (cmd/.../rewards/transports.go) and `cli tp metrics`
-			// (verifiedBandwidth): an edge whose record is present but
-			// {sent:0,recv:0} has "not reported yet", NOT "verified zero". Key
-			// on reported-data, not record presence — otherwise a present
-			// {0,0} edge takes the min() branch and zeroes the counterparty's
-			// real bandwidth (e.g. min(0, 986MB)=0), which is exactly why
-			// single-edge-reporting transports showed 0 verified bandwidth here
-			// while the actual reward calc credited them.
+// accumulateVerifiedBandwidth applies the canonical three-branch trust model
+// used by the reward bw-collect (cmd/.../rewards/transports.go) and
+// `cli tp metrics` (verifiedBandwidth): an edge whose record is present but
+// {sent:0,recv:0} has "not reported yet", NOT "verified zero". It keys on
+// reported-data, not record presence — otherwise a present {0,0} edge takes
+// the min() branch and zeroes the counterparty's real bandwidth (e.g.
+// min(0, 986MB)=0), which is exactly why single-edge-reporting transports
+// once showed 0 verified bandwidth here while the reward calculation credited
+// them.
+func accumulateVerifiedBandwidth(metrics []tpdstore.TransportMetric, summary *tpdNetworkSummary) {
+	for i := range metrics {
+		for _, daily := range metrics[i].Daily {
 			aReported := daily.A != nil && (daily.A.Sent > 0 || daily.A.Recv > 0)
 			bReported := daily.B != nil && (daily.B.Sent > 0 || daily.B.Recv > 0)
 			switch {
@@ -1487,7 +1501,39 @@ func fillTPDBandwidth(tpdURL string, summary *tpdNetworkSummary) error {
 			}
 		}
 	}
+}
 
+// fillTPDBandwidthHTTP is the pre-CXO path, kept as the fallback. It decodes
+// into the same record type the feed publishes so the accumulator above is
+// literally the same code on both paths.
+func fillTPDBandwidthHTTP(tpdURL string, summary *tpdNetworkSummary) error {
+	url := fmt.Sprintf("%s/metrics?days=1&bandwidth=true&latency=false&edges=false", tpdURL)
+
+	resp, err := statsHTTPGet(url)
+	if err != nil {
+		return fmt.Errorf("TPD request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("TPD returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read TPD response: %w", err)
+	}
+
+	// Decoding is the validity test: a body that arrives truncated under a 200
+	// — which large reads through dmsg have repeatedly done — fails to parse
+	// and is reported, never partially believed.
+	var metrics []tpdstore.TransportMetric
+	if err := json.Unmarshal(body, &metrics); err != nil {
+		return fmt.Errorf("failed to parse TPD metrics: %w", err)
+	}
+
+	summary.TotalBandwidth = 0
+	accumulateVerifiedBandwidth(metrics, summary)
 	summary.BandwidthOK = true
 	return nil
 }
@@ -1521,6 +1567,19 @@ func renderTPDNetworkSummaryHTML() string {
 	}
 
 	l += "</pre>"
+	// Name the transport each figure arrived over. A CXO snapshot carries an
+	// age and a completeness verdict that a live HTTP fetch does not, and the
+	// two must not read as one measurement.
+	for _, line := range []struct{ label, src string }{
+		{"counts", summary.CountsSrc},
+		{"bandwidth", summary.BandwidthSrc},
+	} {
+		if line.src == "" {
+			continue
+		}
+		l += fmt.Sprintf("<p style='color: #888; font-size: 0.8em;'>%s — %s</p>",
+			line.label, html.EscapeString(line.src))
+	}
 	l += fmt.Sprintf("<p style='color: #888; font-size: 0.8em;'>Last updated: %s</p>", summary.LastUpdated)
 	return l
 }

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui.go
@@ -48,17 +48,25 @@ const tuiWidth = 78
 // page must render whatever was fetched successfully and say plainly what was
 // not, rather than failing whole. Each Err field carries why its section is
 // missing.
+// CountsSrc, DailySrc and VersionsSrc name which transport answered for
+// each section — a CXO snapshot with an age and a completeness verdict, or
+// a live HTTP-over-dmsg fetch. Rendered as a footer line on the panel. The
+// rule is the one that governs the Err fields: a figure whose provenance is
+// unstated is presented as more certain than it is.
 type statsTUIData struct {
 	Transports   int
 	UniqueVisors int
 	ByType       map[string]int
 	CountsErr    string
+	CountsSrc    string
 
 	// Daily is oldest-first. Callers reverse TPD's newest-first order.
 	Daily       []statsTUIDay
 	DailyErr    string
+	DailySrc    string
 	Versions    map[string]int
 	VersionsErr string
+	VersionsSrc string
 
 	// Liveness is visors-reporting-online per 5-minute slot, oldest-first,
 	// with the label of the day each run of slots belongs to.
@@ -173,6 +181,16 @@ func tuiMissing(title, why string) string {
 		tuiClose(width)
 }
 
+// tuiSource renders the provenance footer of a panel. Empty when nothing
+// recorded a source, so an older caller that does not set one is unchanged
+// rather than printing a blank line.
+func tuiSource(src string) string {
+	if src == "" {
+		return ""
+	}
+	return fmt.Sprintf("  %s%s%s\n", aDim, src, aReset)
+}
+
 // tuiPlot draws one labeled series panel.
 func tuiPlot(title string, series []float64, labels []string, height int, precision uint, color asciigraph.AnsiColor, width int, footer string) string {
 	if len(series) < 2 {
@@ -239,6 +257,7 @@ func RenderStatsANSI(d statsTUIData) string {
 			b.WriteString(fmt.Sprintf("  %son newest%s  %s%s%s  %s%d of %d (%.1f%%)%s\n",
 				aDim, aReset, aBold, newest, aReset, col, newestN, total, pct, aReset))
 		}
+		b.WriteString(tuiSource(d.CountsSrc))
 		b.WriteString(tuiClose(width))
 		b.WriteString("\n")
 	}
@@ -255,8 +274,8 @@ func RenderStatsANSI(d statsTUIData) string {
 			lat = append(lat, day.Latency)
 			labels = append(labels, tuiShortDate(day.Date))
 		}
-		b.WriteString(tuiPlot("BANDWIDTH — GB/day", bw, labels, 9, 1, asciigraph.Green, width, ""))
-		b.WriteString(tuiPlot("LATENCY — ms/day", lat, labels, 7, 0, asciigraph.Yellow, width, ""))
+		b.WriteString(tuiPlot("BANDWIDTH — GB/day", bw, labels, 9, 1, asciigraph.Green, width, d.DailySrc))
+		b.WriteString(tuiPlot("LATENCY — ms/day", lat, labels, 7, 0, asciigraph.Yellow, width, d.DailySrc))
 	}
 
 	// ---- visors online -----------------------------------------------------
@@ -369,6 +388,7 @@ func RenderStatsANSI(d statsTUIData) string {
 		if len(vs) > shown {
 			b.WriteString(fmt.Sprintf("  %s… %d further builds%s\n", aDim, len(vs)-shown, aReset))
 		}
+		b.WriteString(tuiSource(d.VersionsSrc))
 		b.WriteString(tuiClose(width))
 	}
 

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_data.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_data.go
@@ -7,6 +7,13 @@
 // That matters here more than usual, because the previous version reduced a
 // 24 MB per-transport body to produce three numbers and, when that fetch died
 // with EOF, the whole summary rendered as an error string.
+//
+// Each source is read from TPD's CXO feeds first and over HTTP-over-dmsg only
+// on a miss — see statscxo.go for why that is a fix and not a refactor. The
+// panel records WHICH of the two answered, alongside the failures, because a
+// snapshot minutes old and a fetch made just now are different claims about
+// the network and a panel that printed them identically would be lying by
+// omission in the same way a rendered zero is.
 package clirewardsserver
 
 import (
@@ -17,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/skycoin/skywire/deployment"
+	tpdapi "github.com/skycoin/skywire/pkg/deployment/tpd/api"
 )
 
 // gatherStatsTUI collects everything the panel draws. It never returns an
@@ -26,52 +34,74 @@ func gatherStatsTUI() statsTUIData {
 	tpdURL := strings.TrimSuffix(deployment.Prod.TransportDiscovery, "/")
 
 	// Counts — 138 bytes. The cheap aggregate, not a reduction of the bulk
-	// bodies.
-	var stats struct {
-		TotalTransports int            `json:"total_transports"`
-		ByType          map[string]int `json:"by_type"`
-		UniqueVisors    int            `json:"unique_visors"`
-	}
-	if err := statsGetJSON(tpdURL+"/all-transports/stats", &stats); err != nil {
-		d.CountsErr = err.Error()
+	// bodies. The CXO leaf additionally carries a completeness verdict the
+	// HTTP body has no field for: TPD's transport aggregate is readable
+	// while it refills after a restart (#4513), and only the feed says so.
+	if stats, src, err := cxoNetworkStats(); err == nil {
+		d.Transports, d.ByType, d.UniqueVisors = stats.Total, stats.ByType, stats.UniqueVisors
+		d.CountsSrc = src.String()
 	} else {
-		d.Transports, d.ByType, d.UniqueVisors = stats.TotalTransports, stats.ByType, stats.UniqueVisors
+		d.CountsSrc = httpStatsSource("/all-transports/stats", err.Error()).String()
+		var stats struct {
+			TotalTransports int            `json:"total_transports"`
+			ByType          map[string]int `json:"by_type"`
+			UniqueVisors    int            `json:"unique_visors"`
+		}
+		if hErr := statsGetJSON(tpdURL+"/all-transports/stats", &stats); hErr != nil {
+			d.CountsErr = hErr.Error()
+		} else {
+			d.Transports, d.ByType, d.UniqueVisors = stats.TotalTransports, stats.ByType, stats.UniqueVisors
+		}
 	}
 
 	// Daily bandwidth and latency — 2.7 KB for the whole series, against the
 	// tens of megabytes the per-transport route costs for the same shape.
-	var metric struct {
-		Daily []struct {
-			Date      string  `json:"date"`
-			Bandwidth uint64  `json:"bandwidth"`
-			Latency   float64 `json:"latency"`
-			ByType    map[string]struct {
-				Bandwidth uint64 `json:"bandwidth"`
-			} `json:"by_type"`
-		} `json:"daily"`
-	}
-	if err := statsGetJSON(fmt.Sprintf("%s/metric?days=30", tpdURL), &metric); err != nil {
-		d.DailyErr = err.Error()
+	// This 2.7 KB body is one of the fetches observed failing with EOF on the
+	// live site, which is what stats/daily was added for.
+	if daily, src, err := cxoDailyStats(); err == nil {
+		d.Daily = tuiDaysFromCXO(daily)
+		d.DailySrc = src.String()
 	} else {
-		// TPD returns newest-first; a time axis has to run oldest to newest or
-		// every chart reads backwards.
-		for i := len(metric.Daily) - 1; i >= 0; i-- {
-			m := metric.Daily[i]
-			day := statsTUIDay{Date: m.Date, Bandwidth: m.Bandwidth, Latency: m.Latency,
-				ByType: make(map[string]uint64, len(m.ByType))}
-			for t, v := range m.ByType {
-				day.ByType[t] = v.Bandwidth
+		d.DailySrc = httpStatsSource("/metric?days=30", err.Error()).String()
+		var metric struct {
+			Daily []struct {
+				Date      string  `json:"date"`
+				Bandwidth uint64  `json:"bandwidth"`
+				Latency   float64 `json:"latency"`
+				ByType    map[string]struct {
+					Bandwidth uint64 `json:"bandwidth"`
+				} `json:"by_type"`
+			} `json:"daily"`
+		}
+		if hErr := statsGetJSON(fmt.Sprintf("%s/metric?days=30", tpdURL), &metric); hErr != nil {
+			d.DailyErr = hErr.Error()
+		} else {
+			// TPD returns newest-first; a time axis has to run oldest to newest
+			// or every chart reads backwards.
+			for i := len(metric.Daily) - 1; i >= 0; i-- {
+				m := metric.Daily[i]
+				day := statsTUIDay{Date: m.Date, Bandwidth: m.Bandwidth, Latency: m.Latency,
+					ByType: make(map[string]uint64, len(m.ByType))}
+				for t, v := range m.ByType {
+					day.ByType[t] = v.Bandwidth
+				}
+				d.Daily = append(d.Daily, day)
 			}
-			d.Daily = append(d.Daily, day)
 		}
 	}
 
 	// Fleet version histogram — 300 bytes.
-	versions := map[string]int{}
-	if err := statsGetJSON(tpdURL+"/version", &versions); err != nil {
-		d.VersionsErr = err.Error()
+	if versions, src, err := cxoVersionStats(); err == nil {
+		d.Versions = versions.Versions
+		d.VersionsSrc = src.String()
 	} else {
-		d.Versions = versions
+		d.VersionsSrc = httpStatsSource("/version", err.Error()).String()
+		versions := map[string]int{}
+		if hErr := statsGetJSON(tpdURL+"/version", &versions); hErr != nil {
+			d.VersionsErr = hErr.Error()
+		} else {
+			d.Versions = versions
+		}
 	}
 
 	// Visors online, summed from the uptime tracker's per-5-minute timelines.
@@ -92,6 +122,31 @@ func gatherStatsTUI() statsTUIData {
 	d.Coverage = gatherServiceCoverage()
 
 	return d
+}
+
+// tuiDaysFromCXO converts the published stats/daily body into the panel's
+// per-day rows, OLDEST FIRST. The feed publishes newest-first, as the /metric
+// endpoint does, and a time axis has to run oldest to newest or every chart
+// reads backwards.
+func tuiDaysFromCXO(d *tpdapi.DailyStats) []statsTUIDay {
+	out := make([]statsTUIDay, 0, len(d.Daily))
+	for i := len(d.Daily) - 1; i >= 0; i-- {
+		m := d.Daily[i]
+		day := statsTUIDay{
+			Date:      m.Date,
+			Bandwidth: m.Bandwidth,
+			Latency:   m.Latency,
+			ByType:    make(map[string]uint64, len(m.ByType)),
+		}
+		for t, v := range m.ByType {
+			if v == nil {
+				continue
+			}
+			day.ByType[t] = v.Bandwidth
+		}
+		out = append(out, day)
+	}
+	return out
 }
 
 // livenessToTUIDays regroups the flat slot series into per-day runs, which is

--- a/cmd/skywire-cli/commands/rewards/server/statscxo.go
+++ b/cmd/skywire-cli/commands/rewards/server/statscxo.go
@@ -1,0 +1,456 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/statscxo.go c5-reward-server
+//
+// CXO as the first source for the statistics pages, with HTTP-over-dmsg
+// kept behind it.
+//
+// WHY. The statistics pages fetched everything from TPD over
+// HTTP-over-dmsg, and those fetches fail intermittently with EOF —
+// observed live on /stats and /stats/charts for bodies as small as
+// 2.7 KB, and for a /metric/visor/{pks} URL ~1,400 characters long. It
+// is not size. The reward server's long-lived dmsg client periodically
+// loses its sessions ("no mux session available for ping",
+// "session closed"; skycoin/skywire#4538) and every request issued
+// inside that window dies outright, because an HTTP fetch is
+// all-or-nothing AT REQUEST TIME.
+//
+// A CXO subscriber has no such exposure. It holds a local snapshot that
+// was filled in the background, so a read is served from memory and is
+// whole-object-or-nothing: a leaf is either present and complete or
+// absent, never half a body under a 200.
+//
+// WHAT THIS FILE PROVIDES. One cxosub.Manager built over the dmsg
+// client the reward server ALREADY holds — never a fresh identity;
+// minting throwaway keys is the bug removed in #4501/#4502 — plus typed
+// readers for the leaves the pages need:
+//
+//	stats/network        replaces GET /all-transports/stats
+//	stats/versions       replaces GET /version
+//	stats/daily          replaces GET /metric?days=30
+//	metrics/day/<date>   replaces GET /metrics?days=N&bandwidth=true
+//	                     AND the per-visor GET /metric/visor/{pks}
+//
+// The last line is the largest win and the reason this file holds the
+// per-transport feed at all. The per-transport day leaves carry `edges`
+// and per-day, per-edge bandwidth, so per-visor bandwidth is a local
+// sum by edge public key — the 1,400-character URL is not shortened,
+// it is deleted. The same records are what the min()-verified network
+// total is computed from, so that figure keeps its three-branch trust
+// model (see fillTPDBandwidth) applied to identical inputs rather than
+// being quietly swapped for TPD's own cumulative aggregate, which is a
+// different number.
+//
+// THE COST, stated plainly: the per-transport feed is ~30 day leaves of
+// a few megabytes each. That is a large first fill. It is paid once per
+// process — a settled day's leaf is content-addressed and hashes the
+// same forever, so only the current day moves afterwards — and it
+// replaces three separate HTTP bodies, one of which (the 7-day
+// per-transport table) is tens of megabytes on every uncached request.
+//
+// FALLBACK AND HONESTY. Every reader here returns a miss rather than an
+// error the caller must interpret, and every caller falls back to its
+// existing HTTP path on a miss. But a stale CXO snapshot and a fresh
+// HTTP fetch are not the same number, so each reader also returns a
+// statsSource the page prints. Naming the source is the same rule as
+// naming an absence: the page must never present a figure without
+// saying where it came from.
+package clirewardsserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxosub"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	tpdapi "github.com/skycoin/skywire/pkg/deployment/tpd/api"
+	tpdstore "github.com/skycoin/skywire/pkg/deployment/tpd/store"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// statsCXO holds the process-wide subscription manager. Set once from
+// serveStandalone; nil in the embedded/test contexts where the reward
+// handler is mounted without a dmsg client of its own, in which case
+// every reader below misses and the pages use HTTP exactly as before.
+var statsCXO struct {
+	sync.RWMutex
+	mgr *cxosub.Manager
+}
+
+// setStatsCXOSubMgrFromDmsg wires the statistics pages' CXO subscriber
+// over dmsgC — the reward server's OWN client. A no-op when dmsgC is
+// nil.
+//
+// Modeled on pkg/tpviz.SetCXOSubMgrFromDmsg, which does the same job
+// for the embedded tp-viz server in this same process. The two hold
+// separate managers because they subscribe to different feed sets and
+// acquire/release on different schedules; they share the one dmsg
+// identity, which is what matters.
+func setStatsCXOSubMgrFromDmsg(dmsgC *dmsg.Client) {
+	if dmsgC == nil {
+		return
+	}
+	tpd := statsCXOPeer(deployment.Prod.TransportDiscovery)
+	if (tpd == cipher.PubKey{}) {
+		tpd = statsCXOPeer(deployment.Prod.TransportDiscoveryDmsg)
+	}
+
+	feedSpec := func(f cxosub.Feed) (cipher.PubKey, uint16, string, error) {
+		port, prefix, ok := cxosub.FeedRoute(f)
+		if !ok {
+			return cipher.PubKey{}, 0, "", fmt.Errorf("unknown feed %d", f)
+		}
+		switch f {
+		case cxosub.FeedTPDStats, cxosub.FeedTPDMetrics:
+			if (tpd == cipher.PubKey{}) {
+				return cipher.PubKey{}, 0, "", fmt.Errorf("no TPD publisher PK (dmsg service URL unset)")
+			}
+			return tpd, port, prefix, nil
+		}
+		// The statistics pages read no other feed; refusing here keeps a
+		// stray AcquireFor from opening a subscription nothing consumes.
+		return cipher.PubKey{}, 0, "", fmt.Errorf("feed %d not used by the statistics pages", f)
+	}
+
+	mgr := cxosub.NewManager(cxosub.Deps{
+		Dmsg:     func() *dmsg.Client { return dmsgC },
+		FeedSpec: feedSpec,
+		Log:      logging.MustGetLogger("reward-stats-cxosub"),
+	}, 0) // 0 → default cycle interval
+
+	// Pin both feeds for the process lifetime. Without a pin the ~10s
+	// grace teardown closes each subscription as soon as the page that
+	// read it finishes, and the NEXT page load pays a cold first sync —
+	// 45s for the per-transport feed, on every request more than ten
+	// seconds after the last. A reward server exists to serve these
+	// pages continuously, so the snapshot should simply stay warm and
+	// every read should be a memory hit.
+	mgr.Pin(cxosub.FeedTPDStats)
+	mgr.Pin(cxosub.FeedTPDMetrics)
+
+	statsCXO.Lock()
+	statsCXO.mgr = mgr
+	statsCXO.Unlock()
+}
+
+// statsCXOMgr returns the manager, or nil when CXO is not wired.
+func statsCXOMgr() *cxosub.Manager {
+	statsCXO.RLock()
+	defer statsCXO.RUnlock()
+	return statsCXO.mgr
+}
+
+// statsCXOPeer extracts the publisher PK from a dmsg://<pk>:<port>
+// service URL, or the zero PubKey when raw is empty or not a dmsg URL.
+func statsCXOPeer(raw string) cipher.PubKey {
+	if raw == "" {
+		return cipher.PubKey{}
+	}
+	var u dmsgcurl.URL
+	if err := u.Fill(raw); err != nil || u.Scheme != "dmsg" {
+		return cipher.PubKey{}
+	}
+	return u.Addr.PK
+}
+
+// statsSource names where a rendered figure came from. A page that
+// prints a number without this is asserting a freshness it does not
+// know: a CXO snapshot can be minutes old while an HTTP fetch is by
+// definition current, and the two must not read identically.
+type statsSource struct {
+	// Via is "CXO" or "HTTP over dmsg".
+	Via string
+	// Path is the CXO leaf or the HTTP endpoint the figure came from.
+	Path string
+	// At is when the CXO snapshot's root landed. Zero for HTTP, whose
+	// answer is as of the request.
+	At time.Time
+	// Note carries the feed's own completeness caveat, or the CXO miss
+	// that sent the page to HTTP. Never empty when it applies.
+	Note string
+}
+
+// String renders the source as one line for a panel footer.
+func (s statsSource) String() string {
+	if s.Via == "" {
+		return ""
+	}
+	out := "source: " + s.Via
+	if s.Path != "" {
+		out += " " + s.Path
+	}
+	if !s.At.IsZero() {
+		out += fmt.Sprintf(" — snapshot %s old", statsAgeString(time.Since(s.At)))
+	}
+	if s.Note != "" {
+		out += " — " + s.Note
+	}
+	return out
+}
+
+// statsAgeString formats a snapshot age at the resolution a reader
+// cares about. Sub-minute ages are the normal case for the stats feed
+// and rounding them to "0m" would hide the distinction the label exists
+// to draw.
+func statsAgeString(d time.Duration) string {
+	switch {
+	case d < 0:
+		return "0s"
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%.1fh", d.Hours())
+	}
+}
+
+// cachedSourceLabel marks a figure the page is replaying from its own disk
+// cache. The stored label describes how the body was ORIGINALLY obtained and
+// would otherwise read as current — the cache is the third source, and it has
+// to name itself like the other two. A cache written before sources were
+// recorded carries none, and gets the age alone rather than a dangling dash.
+func cachedSourceLabel(age, stored string) string {
+	if stored == "" {
+		return "page cache, " + age + " old"
+	}
+	return "page cache, " + age + " old — " + stored
+}
+
+// httpStatsSource labels a figure that came from HTTP because CXO had
+// nothing, carrying the reason so the page can say why.
+func httpStatsSource(endpoint, whyCXOMissed string) statsSource {
+	s := statsSource{Via: "HTTP over dmsg", Path: endpoint}
+	if whyCXOMissed != "" {
+		s.Note = "CXO miss: " + whyCXOMissed
+	}
+	return s
+}
+
+// completenessNote turns a published completeness stamp into the caveat
+// a panel prints. An incomplete sample is still shown — a feed that
+// froze on real news would be worse — but never without saying so.
+func completenessNote(complete bool, confidence string) string {
+	if complete {
+		return ""
+	}
+	if confidence == "" {
+		confidence = "unknown"
+	}
+	return "INCOMPLETE sample (" + confidence + "): treat counts as a lower bound"
+}
+
+// statsCXOLeaf reads one leaf off the tpd-stats feed, waiting out the
+// first sync on a cold cache.
+//
+// The wait is not optional. AcquireFor only STARTS the fill; returning
+// a miss immediately would also release the reference, and the grace
+// teardown then closes the subscriber mid-fill — so a feed whose first
+// sync outlasts one call would never become readable however often the
+// page is refreshed. Hence WaitForFirstSync while the reference is
+// still held (see #4525).
+func statsCXOLeaf(path string) ([]byte, time.Time, error) {
+	mgr := statsCXOMgr()
+	if mgr == nil {
+		return nil, time.Time{}, fmt.Errorf("CXO not wired")
+	}
+	mgr.AcquireFor(cxosub.TabNetworkStats)
+	defer mgr.ReleaseFor(cxosub.TabNetworkStats)
+
+	if body, ts, ok := statsCXOGet(mgr, cxosub.FeedTPDStats, path); ok {
+		return body, ts, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), cxosub.FeedFirstSyncTimeout(cxosub.FeedTPDStats))
+	defer cancel()
+	if !mgr.WaitForFirstSync(ctx, cxosub.FeedTPDStats, cxosub.FeedFirstSyncTimeout(cxosub.FeedTPDStats)) {
+		return nil, time.Time{}, fmt.Errorf("feed not synced")
+	}
+	if body, ts, ok := statsCXOGet(mgr, cxosub.FeedTPDStats, path); ok {
+		return body, ts, nil
+	}
+	return nil, time.Time{}, fmt.Errorf("no %s leaf on the feed", path)
+}
+
+// statsCXOGet reads and decompresses one leaf. Gunzip passes a raw body
+// through unchanged, so this reads both the gzipped bodies the current
+// publisher writes and any uncompressed ones an older one left.
+func statsCXOGet(mgr *cxosub.Manager, feed cxosub.Feed, path string) ([]byte, time.Time, bool) {
+	body, ts, ok := mgr.Get(feed, path)
+	if !ok || len(body) == 0 {
+		return nil, time.Time{}, false
+	}
+	decoded := cxoutils.Gunzip(body)
+	if len(decoded) == 0 {
+		return nil, time.Time{}, false
+	}
+	// Get lends the snapshot's bytes and Gunzip of a raw body returns
+	// that same slice, so copy before handing it on.
+	return append([]byte(nil), decoded...), ts, true
+}
+
+// cxoNetworkStats reads stats/network — the GET /all-transports/stats
+// numbers. The body is validated by PARSING it, never by size: reads
+// through dmsg have repeatedly arrived truncated under a 200, and a
+// short body that unmarshals is a body that is whole.
+func cxoNetworkStats() (*tpdapi.NetworkStats, statsSource, error) {
+	body, ts, err := statsCXOLeaf(tpdapi.StatsPathNetwork)
+	if err != nil {
+		return nil, statsSource{}, err
+	}
+	var out tpdapi.NetworkStats
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, statsSource{}, fmt.Errorf("parse failed: %w", err)
+	}
+	return &out, statsSource{
+		Via: "CXO", Path: tpdapi.StatsPathNetwork, At: ts,
+		Note: completenessNote(out.Complete, out.Confidence),
+	}, nil
+}
+
+// cxoVersionStats reads stats/versions — the GET /version histogram.
+func cxoVersionStats() (*tpdapi.VersionStats, statsSource, error) {
+	body, ts, err := statsCXOLeaf(tpdapi.StatsPathVersions)
+	if err != nil {
+		return nil, statsSource{}, err
+	}
+	var out tpdapi.VersionStats
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, statsSource{}, fmt.Errorf("parse failed: %w", err)
+	}
+	if len(out.Versions) == 0 {
+		return nil, statsSource{}, fmt.Errorf("version histogram carried no builds")
+	}
+	return &out, statsSource{
+		Via: "CXO", Path: tpdapi.StatsPathVersions, At: ts,
+		Note: completenessNote(out.Complete, out.Confidence),
+	}, nil
+}
+
+// cxoDailyStats reads stats/daily — the GET /metric daily aggregate.
+// This is the leaf added alongside this change: the bandwidth- and
+// latency-over-time charts had no feed at all and were the pages that
+// failed most visibly.
+func cxoDailyStats() (*tpdapi.DailyStats, statsSource, error) {
+	body, ts, err := statsCXOLeaf(tpdapi.StatsPathDaily)
+	if err != nil {
+		return nil, statsSource{}, err
+	}
+	var out tpdapi.DailyStats
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, statsSource{}, fmt.Errorf("parse failed: %w", err)
+	}
+	if len(out.Daily) == 0 {
+		return nil, statsSource{}, fmt.Errorf("daily aggregate carried no days")
+	}
+	return &out, statsSource{
+		Via: "CXO", Path: tpdapi.StatsPathDaily, At: ts,
+		Note: completenessNote(out.Complete, out.Confidence),
+	}, nil
+}
+
+// cxoTransportMetrics assembles the newest `days` calendar-day leaves of
+// TPD's per-transport metrics feed into the []TransportMetric shape the
+// HTTP /metrics endpoint serves.
+//
+// Same assembly as the visor-side reader in
+// pkg/visor/api_tpd_metrics_subscriber.go: a window is a JOIN, because
+// one transport has a row in every day it moved bytes and the caller's
+// record shape is one record per transport carrying N daily rows.
+// MergeDailyMetrics walks newest-first so the current day's Live and
+// Latency — the only leaf that carries them — win.
+func cxoTransportMetrics(days int) ([]tpdstore.TransportMetric, statsSource, error) {
+	if days < 1 {
+		days = 1
+	}
+	mgr := statsCXOMgr()
+	if mgr == nil {
+		return nil, statsSource{}, fmt.Errorf("CXO not wired")
+	}
+	mgr.AcquireFor(cxosub.TabTransportMetrics)
+	defer mgr.ReleaseFor(cxosub.TabTransportMetrics)
+
+	recs, newest, err := readCXOTransportMetrics(mgr, days)
+	if err == nil {
+		return recs, statsSource{Via: "CXO", Path: tpdstore.MetricsDayPrefix + "*", At: newest}, nil
+	}
+	// Cold cache: hold the reference across the wait, or the grace
+	// teardown kills the fill this call started (#4525).
+	ctx, cancel := context.WithTimeout(context.Background(), cxosub.FeedFirstSyncTimeout(cxosub.FeedTPDMetrics))
+	defer cancel()
+	if !mgr.WaitForFirstSync(ctx, cxosub.FeedTPDMetrics, cxosub.FeedFirstSyncTimeout(cxosub.FeedTPDMetrics)) {
+		return nil, statsSource{}, err
+	}
+	recs, newest, err = readCXOTransportMetrics(mgr, days)
+	if err != nil {
+		return nil, statsSource{}, err
+	}
+	return recs, statsSource{Via: "CXO", Path: tpdstore.MetricsDayPrefix + "*", At: newest}, nil
+}
+
+// readCXOTransportMetrics does the assembly against a synced snapshot.
+func readCXOTransportMetrics(mgr *cxosub.Manager, days int) ([]tpdstore.TransportMetric, time.Time, error) {
+	byDate := make(map[string][][]byte)
+	var newest time.Time
+	ok := mgr.Walk(cxosub.FeedTPDMetrics, tpdstore.MetricsDayPrefix, func(path string, body []byte) bool {
+		date, isDay := tpdstore.MetricsDayDate(path)
+		if !isDay || len(body) == 0 {
+			return true
+		}
+		// Walk lends the snapshot's bytes and Gunzip of a raw body
+		// returns that same slice, so copy before the callback returns.
+		decoded := append([]byte(nil), cxoutils.Gunzip(body)...)
+		byDate[date] = append(byDate[date], decoded)
+		if ts, found := mgr.SyncedAt(cxosub.FeedTPDMetrics, path); found && ts.After(newest) {
+			newest = ts
+		}
+		return true
+	})
+	if !ok || len(byDate) == 0 {
+		return nil, time.Time{}, fmt.Errorf("no metrics day leaves on the feed")
+	}
+
+	dates := make([]string, 0, len(byDate))
+	for d := range byDate {
+		dates = append(dates, d)
+	}
+	// The date format sorts lexically into chronological order.
+	sort.Sort(sort.Reverse(sort.StringSlice(dates)))
+	if len(dates) > days {
+		dates = dates[:days]
+	}
+
+	perDay := make([][]tpdstore.TransportMetric, 0, len(dates))
+	for _, date := range dates {
+		bodies := byDate[date]
+		// A day too big for one CXO object arrives as several
+		// "<day>/part/<NNNN>" leaves. The parts are disjoint slices of
+		// the same array, so decoding each and concatenating is the same
+		// answer as splicing them — and it validates every part by
+		// parsing, which is the only trustworthy check.
+		var recs []tpdstore.TransportMetric
+		for _, body := range bodies {
+			var chunk []tpdstore.TransportMetric
+			if err := json.Unmarshal(body, &chunk); err != nil {
+				// One malformed leaf must not take the whole window
+				// down; the day is simply not represented.
+				recs = nil
+				break
+			}
+			recs = append(recs, chunk...)
+		}
+		if len(recs) == 0 {
+			continue
+		}
+		perDay = append(perDay, recs)
+	}
+	if len(perDay) == 0 {
+		return nil, time.Time{}, fmt.Errorf("no metrics day leaf parsed")
+	}
+	return tpdstore.MergeDailyMetrics(perDay), newest, nil
+}

--- a/cmd/skywire-cli/commands/rewards/server/statscxo_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/statscxo_test.go
@@ -1,0 +1,244 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/statscxo_test.go c5-reward-server
+//
+// Tests for the two arithmetic claims the CXO move rests on:
+//
+//   - per-visor bandwidth summed by edge public key is what
+//     GET /metric/visor/{pks} returns, so deleting that request loses
+//     nothing; and
+//   - the min()-verified network total keeps its three-branch trust
+//     model when the records arrive over CXO instead of HTTP.
+//
+// Both are pinned here because the constraint on this change was that
+// the SOURCE moves and the NUMBER does not.
+package clirewardsserver
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tpdstore "github.com/skycoin/skywire/pkg/deployment/tpd/store"
+)
+
+const (
+	pkA = "020000000000000000000000000000000000000000000000000000000000000001"
+	pkB = "020000000000000000000000000000000000000000000000000000000000000002"
+	pkC = "020000000000000000000000000000000000000000000000000000000000000003"
+)
+
+// TestFillVisorBandwidthFromMetricsAttributesEdgesByPosition pins the
+// mapping the derivation depends on: edge A is Edges[0] and edge B is
+// Edges[1]. The store keys the per-day hash by reporter public key and
+// reads it back in that order, and each reporter's deltas go into the
+// per-transport hash and its own per-visor rollup in one pipeline — so
+// getting this backwards would silently swap two visors' bandwidth
+// while still producing a plausible-looking chart.
+func TestFillVisorBandwidthFromMetricsAttributesEdgesByPosition(t *testing.T) {
+	metrics := []tpdstore.TransportMetric{
+		{
+			ID:    "tp-1",
+			Type:  "stcpr",
+			Edges: []string{pkA, pkB},
+			Daily: []tpdstore.DailyEdgeBandwidth{
+				{
+					Date: "2026-09-04",
+					A:    &tpdstore.EdgeBandwidth{Sent: 100, Recv: 20},
+					B:    &tpdstore.EdgeBandwidth{Sent: 7, Recv: 3},
+				},
+			},
+		},
+		{
+			ID:    "tp-2",
+			Type:  "dmsg",
+			Edges: []string{pkB, pkA},
+			Daily: []tpdstore.DailyEdgeBandwidth{
+				{
+					Date: "2026-09-04",
+					A:    &tpdstore.EdgeBandwidth{Sent: 1000, Recv: 0},
+					B:    &tpdstore.EdgeBandwidth{Sent: 0, Recv: 5},
+				},
+			},
+		},
+	}
+
+	out := &visorBandwidthData{Visors: []visorBWEntry{{PK: pkA}, {PK: pkB}}}
+	if err := fillVisorBandwidthFromMetrics(out, metrics); err != nil {
+		t.Fatalf("fill: %v", err)
+	}
+
+	// pkA: edge A of tp-1 (120) + edge B of tp-2 (5) = 125.
+	// pkB: edge B of tp-1 (10)  + edge A of tp-2 (1000) = 1010.
+	want := map[string]uint64{pkA: 125, pkB: 1010}
+	for _, v := range out.Visors {
+		if v.Total != want[v.PK] {
+			t.Fatalf("visor %s total = %d, want %d", v.PK, v.Total, want[v.PK])
+		}
+		if !v.Reported {
+			t.Fatalf("visor %s should be marked reported", v.PK)
+		}
+	}
+	if !out.BandwidthOK {
+		t.Fatal("BandwidthOK not set on a successful derivation")
+	}
+}
+
+// TestFillVisorBandwidthFromMetricsReportsOnlyMeasuredDays checks the
+// window is trimmed to the days that carry a measurement. Padding it out
+// with zeroes would assert the network moved nothing on days TPD simply
+// has no record for — the same rule the HTTP path applies, and the
+// reason the entry carries Reported at all.
+func TestFillVisorBandwidthFromMetricsReportsOnlyMeasuredDays(t *testing.T) {
+	metrics := []tpdstore.TransportMetric{
+		{
+			ID:    "tp-1",
+			Edges: []string{pkA, pkB},
+			Daily: []tpdstore.DailyEdgeBandwidth{
+				{Date: "2026-09-02", A: &tpdstore.EdgeBandwidth{Sent: 50}},
+				{Date: "2026-09-04", A: &tpdstore.EdgeBandwidth{Recv: 70}},
+			},
+		},
+	}
+
+	// pkC is selected but appears on no transport: listed, not charted.
+	out := &visorBandwidthData{Visors: []visorBWEntry{{PK: pkA}, {PK: pkC}}}
+	if err := fillVisorBandwidthFromMetrics(out, metrics); err != nil {
+		t.Fatalf("fill: %v", err)
+	}
+
+	if got := strings.Join(out.Dates, ","); got != "2026-09-02,2026-09-04" {
+		t.Fatalf("dates = %q, want only the two days that reported, oldest first", got)
+	}
+	for _, v := range out.Visors {
+		switch v.PK {
+		case pkA:
+			if !v.Reported || v.Total != 120 {
+				t.Fatalf("pkA = (reported=%v, total=%d), want (true, 120)", v.Reported, v.Total)
+			}
+			if len(v.Daily) != len(out.Dates) {
+				t.Fatalf("pkA has %d points for %d dates", len(v.Daily), len(out.Dates))
+			}
+		case pkC:
+			if v.Reported || v.Total != 0 {
+				t.Fatalf("pkC = (reported=%v, total=%d), want an unreported visor", v.Reported, v.Total)
+			}
+		}
+	}
+}
+
+// TestFillVisorBandwidthFromMetricsRefusesAnEmptyWindow checks a window
+// with nothing in it is an error the caller can fall back on, never a
+// page of zeroes.
+func TestFillVisorBandwidthFromMetricsRefusesAnEmptyWindow(t *testing.T) {
+	out := &visorBandwidthData{Visors: []visorBWEntry{{PK: pkA}}}
+	err := fillVisorBandwidthFromMetrics(out, []tpdstore.TransportMetric{
+		{ID: "tp-1", Edges: []string{pkB, pkC}, Daily: []tpdstore.DailyEdgeBandwidth{
+			{Date: "2026-09-04", A: &tpdstore.EdgeBandwidth{Sent: 9}},
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected an error when no selected visor reported")
+	}
+	if out.BandwidthOK {
+		t.Fatal("BandwidthOK must stay false so the caller falls back")
+	}
+}
+
+// TestAccumulateVerifiedBandwidthThreeBranchModel pins the trust model
+// the reward calculation mirrors. The branch that matters is the third:
+// an edge record present but {0,0} means "has not reported", NOT
+// "verified zero" — keying on record presence instead would take the
+// min() branch and zero the counterparty's real bandwidth.
+func TestAccumulateVerifiedBandwidthThreeBranchModel(t *testing.T) {
+	cases := []struct {
+		name string
+		day  tpdstore.DailyEdgeBandwidth
+		want uint64
+	}{
+		{
+			name: "both edges report: min per direction",
+			day: tpdstore.DailyEdgeBandwidth{
+				A: &tpdstore.EdgeBandwidth{Sent: 100, Recv: 40},
+				B: &tpdstore.EdgeBandwidth{Sent: 30, Recv: 90},
+			},
+			// aToB = min(100, 90) = 90; bToA = min(40, 30) = 30.
+			want: 120,
+		},
+		{
+			name: "only A reports: A is taken whole",
+			day: tpdstore.DailyEdgeBandwidth{
+				A: &tpdstore.EdgeBandwidth{Sent: 100, Recv: 40},
+			},
+			want: 140,
+		},
+		{
+			name: "B present but zero: still only A, never min(0, …)",
+			day: tpdstore.DailyEdgeBandwidth{
+				A: &tpdstore.EdgeBandwidth{Sent: 100, Recv: 40},
+				B: &tpdstore.EdgeBandwidth{},
+			},
+			want: 140,
+		},
+		{
+			name: "only B reports",
+			day: tpdstore.DailyEdgeBandwidth{
+				A: &tpdstore.EdgeBandwidth{},
+				B: &tpdstore.EdgeBandwidth{Sent: 11, Recv: 22},
+			},
+			want: 33,
+		},
+		{
+			name: "neither reports",
+			day:  tpdstore.DailyEdgeBandwidth{},
+			want: 0,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			summary := &tpdNetworkSummary{ByType: map[string]int{}}
+			accumulateVerifiedBandwidth([]tpdstore.TransportMetric{
+				{ID: "tp-1", Daily: []tpdstore.DailyEdgeBandwidth{c.day}},
+			}, summary)
+			if summary.TotalBandwidth != c.want {
+				t.Fatalf("total = %d, want %d", summary.TotalBandwidth, c.want)
+			}
+		})
+	}
+}
+
+// TestStatsSourceNamesTheTransport checks the provenance line actually
+// says which of the two answered. A page that printed the same string
+// for a stale snapshot and a live fetch would be the failure this label
+// exists to prevent.
+func TestStatsSourceNamesTheTransport(t *testing.T) {
+	cxo := statsSource{Via: "CXO", Path: "stats/network", At: time.Now().Add(-30 * time.Second)}
+	line := cxo.String()
+	if !strings.Contains(line, "CXO") || !strings.Contains(line, "stats/network") || !strings.Contains(line, "30s old") {
+		t.Fatalf("CXO source line = %q", line)
+	}
+
+	httpLine := httpStatsSource("/all-transports/stats", "feed not synced").String()
+	if !strings.Contains(httpLine, "HTTP over dmsg") || !strings.Contains(httpLine, "feed not synced") {
+		t.Fatalf("HTTP source line = %q", httpLine)
+	}
+	if strings.Contains(httpLine, "snapshot") {
+		t.Fatalf("HTTP source line claims a snapshot age: %q", httpLine)
+	}
+
+	if (statsSource{}).String() != "" {
+		t.Fatal("an unset source must render as nothing, not as a bare label")
+	}
+}
+
+// TestCompletenessNoteSurfacesAPartialSample checks an incomplete feed
+// body is shown WITH its caveat rather than suppressed. A feed that
+// froze on real news would be worse than one that publishes it marked.
+func TestCompletenessNoteSurfacesAPartialSample(t *testing.T) {
+	if note := completenessNote(true, "settled"); note != "" {
+		t.Fatalf("a complete sample should carry no caveat, got %q", note)
+	}
+	note := completenessNote(false, "refilling")
+	if !strings.Contains(note, "INCOMPLETE") || !strings.Contains(note, "refilling") {
+		t.Fatalf("incomplete note = %q", note)
+	}
+}

--- a/cmd/skywire-cli/commands/rewards/server/timeseries.go
+++ b/cmd/skywire-cli/commands/rewards/server/timeseries.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/skycoin/skywire/deployment"
+	tpdapi "github.com/skycoin/skywire/pkg/deployment/tpd/api"
 )
 
 // TPD's daily aggregate: the cheap time series behind the /stats charts.
@@ -25,6 +26,13 @@ import (
 // reduction the charts actually want at /metric?days=N: the whole 30-day series
 // with a per-transport-type breakdown, in under three kilobytes, carrying
 // LATENCY as well as bandwidth.
+//
+// Three kilobytes turned out not to be small enough. That fetch fails with EOF
+// too, because the failure is not about size: the reward server's dmsg client
+// periodically loses its sessions and every request in that window dies
+// (skycoin/skywire#4538). So the same reduction is now published on TPD's CXO
+// stats feed as stats/daily and read from a local snapshot; the HTTP endpoint
+// stays behind it as the fallback, and the page says which one answered.
 
 // tpdDailyByType is one transport type's contribution on one day.
 type tpdDailyByType struct {
@@ -40,7 +48,7 @@ type tpdDailyPoint struct {
 	ByType    map[string]tpdDailyByType `json:"by_type"`
 }
 
-// tpdDailyAggregate is the parsed /metric?days=N response plus the fetch
+// tpdDailyAggregate is the parsed daily aggregate plus the fetch
 // outcome. OK/Err follow the BandwidthOK/BandwidthErr convention in
 // tpdNetworkSummary: a failed fetch must never render as a zero, because a
 // "0 B" on a bandwidth page reads as a measurement rather than as a gap.
@@ -52,6 +60,11 @@ type tpdDailyAggregate struct {
 		ByType    map[string]tpdDailyByType `json:"by_type"`
 	} `json:"cumulative"`
 	Fetched string `json:"fetched"`
+	// Source names where these numbers came from — the CXO stats/daily
+	// leaf or the HTTP /metric endpoint — and is rendered on the page.
+	// A snapshot minutes old and a fetch made just now are different
+	// claims about the network and must not print identically.
+	Source string `json:"source,omitempty"`
 }
 
 const (
@@ -62,14 +75,30 @@ const (
 	tpdDailyDays = 30
 )
 
-// fetchTPDDailyAggregate GETs TPD's daily aggregate, cached on disk for
-// tpdSummaryCacheMaxAge the same way getTPDNetworkSummary caches its summary.
+// fetchTPDDailyAggregate returns TPD's daily aggregate — CXO first, then
+// the disk cache, then HTTP.
+//
+// The CXO leaf is checked BEFORE the disk cache because it is already a
+// local snapshot: reading it costs a map lookup and a gunzip, so there
+// is nothing for a five-minute page cache to save, and serving a cached
+// body over a live one would only make the page staler than it needs to
+// be. The disk cache stays in front of the HTTP path, which is what it
+// was always damping.
 func fetchTPDDailyAggregate() (*tpdDailyAggregate, error) {
+	daily, src, cxoErr := cxoDailyStats()
+	if cxoErr == nil {
+		agg := dailyAggregateFromCXO(daily)
+		agg.Source = src.String()
+		return agg, nil
+	}
+
 	cachePath := filepath.Join(tempStatsPath, tpdDailyCacheFile)
 	if info, err := os.Stat(cachePath); err == nil && time.Since(info.ModTime()) <= tpdSummaryCacheMaxAge {
 		if data, rErr := os.ReadFile(cachePath); rErr == nil { //nolint:gosec
 			var agg tpdDailyAggregate
 			if json.Unmarshal(data, &agg) == nil && len(agg.Daily) > 0 {
+				// Say that this is the page cache, not a fetch.
+				agg.Source = cachedSourceLabel(statsAgeString(time.Since(info.ModTime())), agg.Source)
 				return &agg, nil
 			}
 		}
@@ -101,6 +130,7 @@ func fetchTPDDailyAggregate() (*tpdDailyAggregate, error) {
 	// TPD returns newest-first; charts read left-to-right oldest-first.
 	sort.Slice(agg.Daily, func(i, j int) bool { return agg.Daily[i].Date < agg.Daily[j].Date })
 	agg.Fetched = time.Now().UTC().Format(time.RFC3339)
+	agg.Source = httpStatsSource("/metric", cxoErr.Error()).String()
 
 	if data, mErr := json.Marshal(&agg); mErr == nil {
 		os.WriteFile(cachePath, data, 0600) //nolint:errcheck,gosec
@@ -108,14 +138,67 @@ func fetchTPDDailyAggregate() (*tpdDailyAggregate, error) {
 	return &agg, nil
 }
 
+// dailyAggregateFromCXO converts the published stats/daily body into the
+// shape the charts already draw. The conversion is a rename, not a
+// recomputation: the publisher writes store.NetworkMetricResponse
+// verbatim, so these are the same numbers GET /metric returns.
+func dailyAggregateFromCXO(d *tpdapi.DailyStats) *tpdDailyAggregate {
+	agg := &tpdDailyAggregate{
+		Daily:   make([]tpdDailyPoint, 0, len(d.Daily)),
+		Fetched: d.ObservedAt.UTC().Format(time.RFC3339),
+	}
+	for _, day := range d.Daily {
+		p := tpdDailyPoint{
+			Date:      day.Date,
+			Bandwidth: day.Bandwidth,
+			Latency:   day.Latency,
+			ByType:    make(map[string]tpdDailyByType, len(day.ByType)),
+		}
+		for t, v := range day.ByType {
+			if v == nil {
+				continue
+			}
+			p.ByType[t] = tpdDailyByType{Bandwidth: v.Bandwidth, Latency: v.Latency}
+		}
+		agg.Daily = append(agg.Daily, p)
+	}
+	// The feed publishes newest-first, as the endpoint does; charts read
+	// left-to-right oldest-first.
+	sort.Slice(agg.Daily, func(i, j int) bool { return agg.Daily[i].Date < agg.Daily[j].Date })
+
+	if d.Cumulative != nil {
+		agg.Cumulative.Bandwidth = d.Cumulative.Bandwidth
+		agg.Cumulative.ByType = make(map[string]tpdDailyByType, len(d.Cumulative.ByType))
+		for t, v := range d.Cumulative.ByType {
+			if v == nil {
+				continue
+			}
+			agg.Cumulative.ByType[t] = tpdDailyByType{Bandwidth: v.Bandwidth, Latency: v.Latency}
+		}
+	}
+	return agg
+}
+
 // tpdAggregateCaveat is the provenance note the bandwidth and latency charts
 // must carry. These are TPD's own cumulative aggregates, not the min()-verified
 // figures the reward calculation uses (see the three-branch trust model in
 // fillTPDBandwidth). Correct as a trend; not a reward-verified number.
-const tpdAggregateCaveat = "Source: Transport Discovery's own daily aggregate (<code>/metric</code>). " +
+const tpdAggregateCaveat = "Transport Discovery's own daily aggregate. " +
 	"These are TPD's reported totals, <b>not</b> the min()-verified per-edge figures used by the " +
 	"reward calculation — a transport whose two edges disagree is counted here as reported. " +
 	"Correct as a trend; do not read these as reward-verified bandwidth."
+
+// aggregateProvenance renders the caveat plus which transport actually
+// delivered these numbers. Whether the page is showing a CXO snapshot
+// or a live HTTP fetch is not a footnote: they carry different
+// freshness and the CXO body carries its own completeness verdict.
+func aggregateProvenance(agg *tpdDailyAggregate) string {
+	out := fmt.Sprintf("<p style='color:#888;font-size:11px;'>%s</p>", tpdAggregateCaveat)
+	if agg != nil && agg.Source != "" {
+		out += fmt.Sprintf("<p style='color:#888;font-size:11px;'>%s</p>", html.EscapeString(agg.Source))
+	}
+	return out
+}
 
 // transportTypeSeries builds one chart series per transport type, ordered by
 // total contribution so the legend and the band order are stable between
@@ -184,7 +267,7 @@ func renderBandwidthTimeSeries(agg *tpdDailyAggregate, err error) string {
 		FormatY:    func(v float64) string { return formatBytesChart(uint64(v)) },
 	}
 	out := renderStackedAreaSVG(opts, series)
-	out += fmt.Sprintf("<p style='color:#888;font-size:11px;'>%s</p>", tpdAggregateCaveat)
+	out += aggregateProvenance(agg)
 	out += renderDailyTable(daily, "Bandwidth", func(d tpdDailyPoint) string {
 		return formatBytesChart(d.Bandwidth)
 	})
@@ -231,7 +314,7 @@ func renderLatencyTimeSeries(agg *tpdDailyAggregate, err error) string {
 		FormatY:    func(v float64) string { return fmt.Sprintf("%.0f ms", v) },
 	}
 	out := renderLineSVG(opts, series, hover)
-	out += fmt.Sprintf("<p style='color:#888;font-size:11px;'>%s</p>", tpdAggregateCaveat)
+	out += aggregateProvenance(agg)
 	out += renderDailyTable(daily, "Avg latency", func(d tpdDailyPoint) string {
 		return fmt.Sprintf("%.1f ms", d.Latency)
 	})

--- a/cmd/skywire-cli/commands/rewards/server/visorbandwidth.go
+++ b/cmd/skywire-cli/commands/rewards/server/visorbandwidth.go
@@ -14,24 +14,41 @@ import (
 	"time"
 
 	"github.com/skycoin/skywire/deployment"
+	tpdstore "github.com/skycoin/skywire/pkg/deployment/tpd/store"
 )
 
 // Per-visor bandwidth history.
 //
 // The network-wide daily aggregate (/metric) carries no per-visor breakdown, so
-// this page cannot be served from it. The heavy /metrics?days=N per-transport
-// body it used to use dies with EOF over dmsg. What works is TPD's
-// /metric/visor/{pks} — the same daily reduction, per visor, for a caller-named
-// set of public keys: 32 KB and ~1.5 s for twenty visors over thirty days.
+// this page cannot be served from it.
 //
-// The catch, and the reason this page's heading changed: TPD publishes no
-// bandwidth-ranked visor index. Ranking the whole network by bandwidth would
-// mean asking /metric/visor for all ~900 visors, which is neither cheap nor
-// quick. The cheap index that DOES exist is /all-transports/per-key-stats
-// (~100 KB, under a second) — transport COUNTS per visor. So the page now
-// selects the most-connected visors by transport count and reports their real
-// measured bandwidth, and says so on the page rather than implying these are
-// the network's top bandwidth carriers.
+// The bandwidth series now comes from the CXO per-transport metrics feed and
+// there is NO per-visor request at all. TPD's day leaves carry each
+// transport's `edges` and its per-day, per-edge sent/recv, and the store
+// increments the per-visor daily rollup from exactly those same deltas — the
+// reporter writes its own bytes into both places — so summing edge A's bytes
+// under Edges[0] and edge B's under Edges[1] reproduces what
+// /metric/visor/{pks} returns, computed locally.
+//
+// That deletes a request rather than shrinking one. The URL it replaces was
+// ~1,400 characters (twenty 66-character public keys, comma-separated) and was
+// failing with EOF over dmsg — not for its size, but because the reward
+// server's dmsg client periodically loses its sessions and every request in
+// that window dies (skycoin/skywire#4538). A subscriber reads a snapshot it
+// already holds and has no equivalent failure.
+//
+// One number does still come over HTTP: the RANKING. TPD publishes no
+// bandwidth-ranked visor index, and ranking the whole network by bandwidth
+// would have meant a per-visor query per registered key. The cheap index that
+// exists is /all-transports/per-key-stats (~100 KB) — transport COUNTS per
+// visor — and it has no CXO feed: it is two orders of magnitude larger than
+// the stats feed's other bodies and was deliberately left off that feed
+// (see cxo_stats_publisher.go). So the page selects the most-connected visors
+// by transport count and reports their real measured bandwidth, saying so
+// rather than implying these are the network's top bandwidth carriers. When
+// that one fetch fails, the ranking degrades to a count derived from the CXO
+// leaf's edges — a near-equivalent, labeled as such — so the page still
+// renders instead of collapsing to a single error line.
 
 const (
 	visorBWCacheFile = "tpd_visor_bw.json"
@@ -76,6 +93,12 @@ type visorBandwidthData struct {
 	BandwidthOK bool           `json:"bandwidth_ok"`
 	BandwidthE  string         `json:"bandwidth_err,omitempty"`
 	LastUpdated string         `json:"last_updated"`
+	// BandwidthSrc and RankSrc name where each half of the page came from.
+	// The two halves can legitimately disagree in freshness — a CXO
+	// snapshot minutes old alongside an HTTP fetch made just now — and the
+	// page must not present them as one measurement taken at one time.
+	BandwidthSrc string `json:"bandwidth_src,omitempty"`
+	RankSrc      string `json:"rank_src,omitempty"`
 }
 
 // fetchVisorBandwidth builds the per-visor series, cached on disk.
@@ -85,6 +108,12 @@ func fetchVisorBandwidth() (*visorBandwidthData, error) {
 		if data, rErr := os.ReadFile(cachePath); rErr == nil { //nolint:gosec
 			var d visorBandwidthData
 			if json.Unmarshal(data, &d) == nil && len(d.Visors) > 0 {
+				// The stored sources describe how the body was ORIGINALLY
+				// obtained; say the page is serving them from cache rather
+				// than letting them read as current.
+				age := statsAgeString(time.Since(info.ModTime()))
+				d.RankSrc = cachedSourceLabel(age, d.RankSrc)
+				d.BandwidthSrc = cachedSourceLabel(age, d.BandwidthSrc)
 				return &d, nil
 			}
 		}
@@ -92,12 +121,13 @@ func fetchVisorBandwidth() (*visorBandwidthData, error) {
 
 	tpdURL := strings.TrimSuffix(deployment.Prod.TransportDiscovery, "/")
 
-	counts, err := fetchPerKeyTransportCounts(tpdURL)
+	// One CXO read serves both halves of this page: the bandwidth series,
+	// and — only if the per-key index fetch fails — the ranking too.
+	metrics, metricsSrc, metricsErr := cxoTransportMetrics(tpdDailyDays)
+
+	counts, rankSrc, err := visorTransportCounts(tpdURL, metrics)
 	if err != nil {
 		return nil, err
-	}
-	if len(counts) == 0 {
-		return nil, fmt.Errorf("TPD per-key stats carried no visors")
 	}
 
 	ranked := sortedMapKeys(counts)
@@ -108,19 +138,158 @@ func fetchVisorBandwidth() (*visorBandwidthData, error) {
 	out := &visorBandwidthData{
 		TotalVisors: len(counts),
 		LastUpdated: time.Now().UTC().Format(time.RFC3339),
+		RankSrc:     rankSrc.String(),
 	}
 	for _, pk := range ranked {
 		out.Visors = append(out.Visors, visorBWEntry{PK: pk, Transports: counts[pk]})
 	}
 
-	if bwErr := fillVisorBandwidth(tpdURL, out); bwErr != nil {
-		out.BandwidthE = bwErr.Error()
+	cxoMiss := "not attempted"
+	if metricsErr != nil {
+		cxoMiss = metricsErr.Error()
+	} else if bwErr := fillVisorBandwidthFromMetrics(out, metrics); bwErr != nil {
+		cxoMiss = bwErr.Error()
+	} else {
+		out.BandwidthSrc = metricsSrc.String()
+	}
+	// Fall back to the per-visor HTTP query only when the local derivation
+	// produced nothing. It is the request this page exists to stop making,
+	// so it is the last resort rather than the first.
+	if !out.BandwidthOK {
+		if bwErr := fillVisorBandwidth(tpdURL, out); bwErr != nil {
+			out.BandwidthE = bwErr.Error()
+		} else {
+			out.BandwidthSrc = httpStatsSource("/metric/visor/{pks}", cxoMiss).String()
+		}
 	}
 
 	if data, mErr := json.Marshal(out); mErr == nil {
 		os.WriteFile(cachePath, data, 0600) //nolint:errcheck,gosec
 	}
 	return out, nil
+}
+
+// visorTransportCounts returns the per-visor transport counts the ranking
+// is built on.
+//
+// HTTP is tried FIRST here, against the CXO-first rule everywhere else in
+// this file, and deliberately: /all-transports/per-key-stats counts
+// REGISTERED transports and no CXO feed carries that number. The
+// derivation below counts transports that appear in the metrics window,
+// which is a near-equivalent but not the same set — a transport with no
+// metrics row is missing from it. Using it as the primary would silently
+// change what the column means; using it as a fallback keeps the page
+// rendering when the index fetch dies, with the substitution labeled.
+func visorTransportCounts(tpdURL string, metrics []tpdstore.TransportMetric) (map[string]int, statsSource, error) {
+	counts, err := fetchPerKeyTransportCounts(tpdURL)
+	if err == nil && len(counts) > 0 {
+		return counts, statsSource{Via: "HTTP over dmsg", Path: "/all-transports/per-key-stats"}, nil
+	}
+	why := "carried no visors"
+	if err != nil {
+		why = err.Error()
+	}
+	if len(metrics) == 0 {
+		return nil, statsSource{}, fmt.Errorf("TPD per-key stats unavailable (%s) and the CXO metrics feed is cold", why)
+	}
+	derived := make(map[string]int)
+	for i := range metrics {
+		for _, edge := range metrics[i].Edges {
+			derived[edge]++
+		}
+	}
+	if len(derived) == 0 {
+		return nil, statsSource{}, fmt.Errorf("TPD per-key stats unavailable (%s) and the CXO metrics feed named no edges", why)
+	}
+	return derived, statsSource{
+		Via:  "CXO",
+		Path: tpdstore.MetricsDayPrefix + "* (edges)",
+		Note: "per-key index unavailable (" + why + "); counts are transports SEEN IN THE METRICS WINDOW, not registered transports",
+	}, nil
+}
+
+// fillVisorBandwidthFromMetrics sums the selected visors' daily bandwidth out
+// of the per-transport records, with no request of any kind.
+//
+// Edge A is Edges[0] and edge B is Edges[1] — the store keys the per-day hash
+// by reporter public key and reads it back in that order — and each reporter's
+// deltas are written to the per-transport hash and to its own per-visor daily
+// rollup in the same pipeline. So this sum and GET /metric/visor/{pks} are the
+// same arithmetic over the same bytes.
+//
+// The one divergence is pre-per-edge data. A day whose hash holds only the
+// combined `bandwidth` field is read back as an even A/B split, whereas the
+// per-visor rollup recorded the reporter's real sent/recv; on those rows this
+// derivation attributes half to each edge. Such rows expire at 35 days and the
+// window here is 30.
+func fillVisorBandwidthFromMetrics(out *visorBandwidthData, metrics []tpdstore.TransportMetric) error {
+	selected := make(map[string]struct{}, len(out.Visors))
+	for _, v := range out.Visors {
+		selected[v.PK] = struct{}{}
+	}
+
+	// pk -> date -> bytes, for the selected visors only.
+	byPK := make(map[string]map[string]uint64, len(selected))
+	add := func(pk, date string, n uint64) {
+		if n == 0 {
+			return
+		}
+		if _, want := selected[pk]; !want {
+			return
+		}
+		days, ok := byPK[pk]
+		if !ok {
+			days = make(map[string]uint64)
+			byPK[pk] = days
+		}
+		days[date] += n
+	}
+	for i := range metrics {
+		m := &metrics[i]
+		if len(m.Edges) != 2 {
+			continue
+		}
+		for _, d := range m.Daily {
+			if d.A != nil {
+				add(m.Edges[0], d.Date, d.A.Sent+d.A.Recv)
+			}
+			if d.B != nil {
+				add(m.Edges[1], d.Date, d.B.Sent+d.B.Recv)
+			}
+		}
+	}
+
+	// Report the days that actually carry a measurement, never a window
+	// padded out to the requested length: a zero on a day TPD has no record
+	// for asserts the network moved nothing, which is a different claim.
+	reported := make(map[string]struct{})
+	for _, days := range byPK {
+		for date := range days {
+			reported[date] = struct{}{}
+		}
+	}
+	if len(reported) == 0 {
+		return fmt.Errorf("the CXO metrics window carries no bandwidth for the selected visors")
+	}
+	dates := make([]string, 0, len(reported))
+	for d := range reported {
+		dates = append(dates, d)
+	}
+	sort.Strings(dates)
+	out.Dates = dates
+
+	for i := range out.Visors {
+		days := byPK[out.Visors[i].PK]
+		out.Visors[i].Daily = nil
+		out.Visors[i].Total = 0
+		out.Visors[i].Reported = len(days) > 0
+		for _, d := range dates {
+			out.Visors[i].Daily = append(out.Visors[i].Daily, visorBWPoint{Date: d, Total: days[d]})
+			out.Visors[i].Total += days[d]
+		}
+	}
+	out.BandwidthOK = true
+	return nil
 }
 
 // fetchPerKeyTransportCounts reads the cheap per-visor transport index.
@@ -249,6 +418,7 @@ func renderVisorBandwidthBody(data *visorBandwidthData) string {
 		"The selection here is therefore by <b>transport count</b> — these are the best-connected visors, " +
 		"not necessarily the highest-bandwidth ones. Bandwidth figures are TPD's own reported totals, " +
 		"not the min()-verified figures used by the reward calculation.</p>")
+	sb.WriteString(renderVisorBandwidthSources(data))
 
 	if !data.BandwidthOK {
 		fmt.Fprintf(&sb, "<p style='color:#FF6384;'>Bandwidth series unavailable: %s — the transport-count ranking below is still current.</p>",
@@ -311,6 +481,24 @@ func renderVisorBandwidthBody(data *visorBandwidthData) string {
 	}
 	sb.WriteString(renderVisorRankTable(&visorBandwidthData{Visors: visors, TotalVisors: data.TotalVisors}, true))
 	fmt.Fprintf(&sb, "<p style='color:#888;font-size:0.8em;'>Last updated: %s</p>", html.EscapeString(data.LastUpdated))
+	return sb.String()
+}
+
+// renderVisorBandwidthSources prints where each half of the page came from.
+// Two figures fetched over different transports at different times are two
+// measurements, and the page says so rather than letting the layout imply one.
+func renderVisorBandwidthSources(data *visorBandwidthData) string {
+	var sb strings.Builder
+	for _, line := range []struct{ label, src string }{
+		{"ranking", data.RankSrc},
+		{"bandwidth", data.BandwidthSrc},
+	} {
+		if line.src == "" {
+			continue
+		}
+		fmt.Fprintf(&sb, "<p style='color:#888;font-size:11px;'>%s — %s</p>",
+			line.label, html.EscapeString(line.src))
+	}
 	return sb.String()
 }
 

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -597,6 +597,23 @@ func cxoFeedForURL(rawURL string) (feed, path string, ok bool) {
 		return "tpd-stats", "network", true
 	}
 
+	// TPD /metric (SINGULAR — the daily aggregate) → "tpd-stats" feed,
+	// "daily" path. Distinct from /metrics above: isUnderBase matches
+	// base+suffix exactly, so "/metrics?days=30" does not match the
+	// "/metric" target.
+	//
+	// The publisher writes ONE window (statsDailyDays, currently 30). A
+	// caller asking for a shorter window would be handed more days than
+	// it asked for, so anything but the published window falls through
+	// to HTTP rather than being answered with a wider series.
+	if isUnderBase(rawURL, deployment.Prod.TransportDiscovery, "/metric") ||
+		isUnderBase(rawURL, deployment.Prod.TransportDiscoveryDmsg, "/metric") {
+		if days := queryParamInt(rawURL, "days", 30); days == 30 {
+			return "tpd-stats", "daily", true
+		}
+		return "", "", false
+	}
+
 	// TPD /version → "tpd-stats" feed, "versions" path. Same rule for
 	// the ?on= online filter: the publisher writes the unfiltered
 	// histogram, which is what the endpoint serves by default.

--- a/cmd/skywire-cli/commands/visor/cxo.go
+++ b/cmd/skywire-cli/commands/visor/cxo.go
@@ -220,12 +220,17 @@ Paths per feed:
   tpd-uptime              uptimes/days/<N>          e.g. uptimes/days/30
   sd-services             type/<typeName>           e.g. type/proxy
   tpd-all-transports      with-self | without-self
-  tpd-stats               network | versions        the sub-kilobyte
-                          network aggregates (transports by type, unique
-                          visors, fleet version histogram), republished
-                          every ~12s and stamped with a completeness
-                          verdict — see the "complete"/"confidence"
-                          fields before charting an absolute count
+  tpd-stats               network | versions | daily
+                          the small network aggregates: transports by
+                          type and unique visors (network), the fleet
+                          version histogram (versions), and the daily
+                          bandwidth/latency series the /metric endpoint
+                          serves (daily). network and versions
+                          republish every ~12s; daily is a 30-day store
+                          query and republishes every ~5m. All three are
+                          stamped with a completeness verdict — see the
+                          "complete"/"confidence" fields before charting
+                          an absolute count
   (dmsgd-clients-by-server has no FetchCXO case — Walk it via your own RPC if needed)`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -76,9 +76,9 @@ const (
 	// HTTP-polling /all-transports.
 	FeedTPDAllTransports
 	// FeedTPDStats is TPD's network-aggregate stats publisher
-	// (stats/network, stats/versions). Sub-kilobyte reductions
-	// republished every few seconds — the feed a chart reads instead
-	// of downloading a bulk snapshot to reduce it locally.
+	// (stats/network, stats/versions, stats/daily). Small reductions
+	// republished on a timer — the feed a chart reads instead of
+	// downloading a bulk snapshot to reduce it locally.
 	FeedTPDStats
 )
 
@@ -152,6 +152,14 @@ const (
 	// tab so holding it does not drag in the ~8 MB all-transports
 	// snapshot TabCLITransports carries.
 	TabNetworkStats
+	// TabTransportMetrics is the consumer of TPD's per-transport
+	// metrics feed ALONE — the reward server's statistics pages, which
+	// reduce the per-day records locally (per-visor bandwidth summed by
+	// edge PK, the min()-verified network total) instead of asking TPD
+	// for a pre-reduced body over HTTP. Its own tab because TabMetrics
+	// also carries FeedTPDUptime, and a consumer that never reads an
+	// uptime leaf should not hold that subscription open.
+	TabTransportMetrics
 )
 
 // tabFeedDeps maps each tab to the set of feeds it depends on.
@@ -167,6 +175,7 @@ var tabFeedDeps = map[Tab][]Feed{
 	TabRoutingPolicy:     {FeedSDServices},
 	TabDmsgEntryLookup:   {FeedDMSGDClientsByServer},
 	TabNetworkStats:      {FeedTPDStats},
+	TabTransportMetrics:  {FeedTPDMetrics},
 }
 
 // Deps are the host-injected dependencies the manager needs. They

--- a/pkg/deployment/tpd/api/cxo_stats_daily_test.go
+++ b/pkg/deployment/tpd/api/cxo_stats_daily_test.go
@@ -1,0 +1,200 @@
+// Package api pkg/deployment/tpd/api/cxo_stats_daily_test.go c4-net-discovery
+//
+// Tests for the stats/daily leaf. The claim under test is that a
+// consumer can unmarshal the published body into
+// store.NetworkMetricResponse and get exactly what GET /metric returns
+// — the whole point of adding the path is that the charts stop making
+// that request, and they can only stop if the two agree.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/deployment/tpd/store"
+)
+
+// dailyOnlyStore satisfies store.Store by embedding the interface and
+// overriding the one method under test. Any other call panics on the
+// nil embedded value, which is the assertion that nothing else is
+// reached.
+type dailyOnlyStore struct {
+	store.Store
+	resp  *store.NetworkMetricResponse
+	err   error
+	calls int
+}
+
+func (s *dailyOnlyStore) GetNetworkMetrics(_ context.Context, q store.MetricsQuery) (*store.NetworkMetricResponse, error) {
+	s.calls++
+	if q.Days != statsDailyDays {
+		return nil, errors.New("publisher asked for a window other than statsDailyDays")
+	}
+	return s.resp, s.err
+}
+
+func testDailyResponse() *store.NetworkMetricResponse {
+	return &store.NetworkMetricResponse{
+		Daily: []store.DailyAggregate{
+			{
+				Date:      "2026-09-04",
+				Bandwidth: 9_000_000,
+				Latency:   41.5,
+				ByType: map[string]*store.TypeMetricAggregate{
+					"stcpr": {Bandwidth: 6_000_000, Latency: 30},
+					"dmsg":  {Bandwidth: 3_000_000, Latency: 80},
+				},
+			},
+			{
+				Date:      "2026-09-03",
+				Bandwidth: 4_000_000,
+				Latency:   52,
+				ByType: map[string]*store.TypeMetricAggregate{
+					"stcpr": {Bandwidth: 4_000_000, Latency: 52},
+				},
+			},
+		},
+		Cumulative: &store.CumulativeAggregate{
+			Bandwidth: 13_000_000,
+			ByType: map[string]*store.TypeMetricAggregate{
+				"stcpr": {Bandwidth: 10_000_000},
+				"dmsg":  {Bandwidth: 3_000_000},
+			},
+		},
+	}
+}
+
+// TestDailyStatsIsTheMetricEndpointBody pins the published body to the
+// GET /metric response shape: unmarshalling the leaf into
+// store.NetworkMetricResponse must reproduce the store's answer
+// field-for-field.
+func TestDailyStatsIsTheMetricEndpointBody(t *testing.T) {
+	want := testDailyResponse()
+	api := &API{store: &dailyOnlyStore{resp: want}}
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	sp, puts := newTestStatsPublisher(t, api, now.Add(-time.Hour))
+
+	sp.publishDaily(context.Background(), now)
+
+	p, ok := lastPutTo(*puts, StatsPathDaily)
+	if !ok {
+		t.Fatalf("nothing was published to %s", StatsPathDaily)
+	}
+	// decodePut asserts the body is gzipped and is JSON — every sibling
+	// path on this feed is, and subscribers gunzip unconditionally.
+	decodePut(t, p)
+
+	var got store.NetworkMetricResponse
+	if err := json.Unmarshal(cxoutils.Gunzip(p.body), &got); err != nil {
+		t.Fatalf("body does not unmarshal as store.NetworkMetricResponse: %v", err)
+	}
+	if len(got.Daily) != len(want.Daily) {
+		t.Fatalf("daily days = %d, want %d", len(got.Daily), len(want.Daily))
+	}
+	for i := range want.Daily {
+		w, g := want.Daily[i], got.Daily[i]
+		if g.Date != w.Date || g.Bandwidth != w.Bandwidth || g.Latency != w.Latency {
+			t.Fatalf("day %d = %+v, want %+v", i, g, w)
+		}
+		for tp, wv := range w.ByType {
+			gv, ok := g.ByType[tp]
+			if !ok || gv == nil {
+				t.Fatalf("day %d: type %q missing from the published body", i, tp)
+			}
+			if gv.Bandwidth != wv.Bandwidth || gv.Latency != wv.Latency {
+				t.Fatalf("day %d type %q = %+v, want %+v", i, tp, gv, wv)
+			}
+		}
+	}
+	if got.Cumulative == nil || got.Cumulative.Bandwidth != want.Cumulative.Bandwidth {
+		t.Fatalf("cumulative = %+v, want bandwidth %d", got.Cumulative, want.Cumulative.Bandwidth)
+	}
+
+	// The completeness stamp rides along; a consumer must be able to see
+	// that an early sample is not trustworthy as an absolute.
+	var stamped DailyStats
+	if err := json.Unmarshal(cxoutils.Gunzip(p.body), &stamped); err != nil {
+		t.Fatalf("body does not unmarshal as DailyStats: %v", err)
+	}
+	if stamped.Confidence != ConfidenceWarmup || stamped.Complete {
+		t.Fatalf("stamp = (%q, complete=%v), want warmup/incomplete before the transport set is judged",
+			stamped.Confidence, stamped.Complete)
+	}
+	if stamped.Days != statsDailyDays {
+		t.Fatalf("days = %d, want %d", stamped.Days, statsDailyDays)
+	}
+}
+
+// TestDailyStatsCarriesTheTransportVerdict checks the stamp is the
+// transport-set judgment rather than one invented from the bandwidth
+// figures — a quiet day is not a partial read.
+func TestDailyStatsCarriesTheTransportVerdict(t *testing.T) {
+	api := &API{store: &dailyOnlyStore{resp: testDailyResponse()}}
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	sp, puts := newTestStatsPublisher(t, api, now.Add(-time.Hour))
+	sp.lastTransportVerdict = completenessVerdict{complete: true, confidence: ConfidenceSettled, peak: 4321}
+
+	sp.publishDaily(context.Background(), now)
+
+	p, ok := lastPutTo(*puts, StatsPathDaily)
+	if !ok {
+		t.Fatal("nothing was published")
+	}
+	var stamped DailyStats
+	if err := json.Unmarshal(cxoutils.Gunzip(p.body), &stamped); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !stamped.Complete || stamped.Confidence != ConfidenceSettled || stamped.TrailingPeak != 4321 {
+		t.Fatalf("stamp = %+v, want the transport set's settled verdict with peak 4321", stamped)
+	}
+}
+
+// TestDailyStatsSkipsNothingness checks an empty or failed store answer
+// never overwrites a good body with an empty one. A store that has not
+// answered is not news about the network.
+func TestDailyStatsSkipsNothingness(t *testing.T) {
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+
+	for name, st := range map[string]*dailyOnlyStore{
+		"store error":  {err: errors.New("redis down")},
+		"empty series": {resp: &store.NetworkMetricResponse{}},
+		"nil response": {},
+	} {
+		api := &API{store: st}
+		sp, puts := newTestStatsPublisher(t, api, now.Add(-time.Hour))
+		sp.publishDaily(context.Background(), now)
+		if _, ok := lastPutTo(*puts, StatsPathDaily); ok {
+			t.Fatalf("%s: published a body anyway", name)
+		}
+	}
+}
+
+// TestPublishOnceRunsDailyOnItsOwnCadence checks the 30-day store query
+// does not run on the 12-second tick. The body is small; the recompute
+// is not, and that is the whole reason statsDailyInterval exists.
+func TestPublishOnceRunsDailyOnItsOwnCadence(t *testing.T) {
+	st := &dailyOnlyStore{resp: testDailyResponse()}
+	api := &API{transportsCache: testEntries(20), uptimesCache: testUptimes(), store: st}
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	sp, _ := newTestStatsPublisher(t, api, now.Add(-time.Hour))
+
+	// Twelve seconds apart for half the daily interval: one recompute.
+	for elapsed := time.Duration(0); elapsed < statsDailyInterval/2; elapsed += statsPublishInterval {
+		sp.publishOnce(context.Background())
+	}
+	if st.calls != 1 {
+		t.Fatalf("store queried %d times inside one interval, want 1", st.calls)
+	}
+
+	// publishOnce stamps wall-clock time, so drive the next window by
+	// rewinding the recorded attempt rather than sleeping.
+	sp.lastDailyAt = time.Now().UTC().Add(-statsDailyInterval - time.Second)
+	sp.publishOnce(context.Background())
+	if st.calls != 2 {
+		t.Fatalf("store queried %d times after the interval elapsed, want 2", st.calls)
+	}
+}

--- a/pkg/deployment/tpd/api/cxo_stats_daily_test.go
+++ b/pkg/deployment/tpd/api/cxo_stats_daily_test.go
@@ -69,7 +69,7 @@ func testDailyResponse() *store.NetworkMetricResponse {
 }
 
 // TestDailyStatsIsTheMetricEndpointBody pins the published body to the
-// GET /metric response shape: unmarshalling the leaf into
+// GET /metric response shape: unmarshaling the leaf into
 // store.NetworkMetricResponse must reproduce the store's answer
 // field-for-field.
 func TestDailyStatsIsTheMetricEndpointBody(t *testing.T) {

--- a/pkg/deployment/tpd/api/cxo_stats_publisher.go
+++ b/pkg/deployment/tpd/api/cxo_stats_publisher.go
@@ -5,15 +5,27 @@
 //
 //	stats/network   the GET /all-transports/stats shape (138 B live)
 //	stats/versions  the GET /version fleet histogram (300 B live)
+//	stats/daily     the GET /metric daily aggregate (~2.7 KB live)
 //
 // Why a separate feed rather than another path on an existing one: size
 // is cadence. The metrics and all-transports feeds are staggered to
-// minutes because recomputing them is expensive; these two bodies are a
-// few hundred bytes and cost a map walk over caches the HTTP handlers
-// already read, so they republish every statsPublishInterval. A chart
-// that wants "transports on the network, every 15 seconds" costs ~400 B
-// per sample here instead of the 2.4 MB all-transports snapshot or the
-// 16.8 MB metrics window it would otherwise reduce locally.
+// minutes because recomputing them is expensive; the first two bodies
+// are a few hundred bytes and cost a map walk over caches the HTTP
+// handlers already read, so they republish every statsPublishInterval.
+// A chart that wants "transports on the network, every 15 seconds"
+// costs ~400 B per sample here instead of the 2.4 MB all-transports
+// snapshot or the 16.8 MB metrics window it would otherwise reduce
+// locally.
+//
+// stats/daily is the exception on cadence and the reason
+// statsDailyInterval exists. Its BODY is small — the whole 30-day
+// series with a per-type breakdown in under three kilobytes — but
+// producing it is a 30-day store query, not a map walk, so it runs on
+// its own slow timer inside the same loop rather than on the 12 s tick.
+// It is here rather than on the metrics feed because a consumer that
+// wants the reduction must not be made to subscribe to the ~120 MB of
+// per-transport day leaves the reduction was computed from; that is the
+// entire point of this feed.
 //
 // The per-key rollup (GET /all-transports/per-key-stats, ~38 KB gzipped)
 // is deliberately NOT here. It is two orders of magnitude larger than
@@ -69,6 +81,10 @@ const (
 	// StatsPathVersions carries the fleet version histogram (the
 	// GET /version shape plus a completeness stamp).
 	StatsPathVersions = "stats/versions"
+	// StatsPathDaily carries the network-wide daily aggregate (the
+	// GET /metric shape plus a completeness stamp) — per-day
+	// bandwidth, latency and by-type breakdown over statsDailyDays.
+	StatsPathDaily = "stats/daily"
 )
 
 // statsPublishInterval is the recompute cadence. Both bodies are read
@@ -78,6 +94,23 @@ const (
 // resolution. 12s keeps a chart live without making the tick a
 // meaningful fraction of TPD's cache-refresh period.
 const statsPublishInterval = 12 * time.Second
+
+const (
+	// statsDailyDays is the window stats/daily carries. It matches the
+	// window the metrics feed publishes day leaves for, so the two
+	// describe the same span of history.
+	statsDailyDays = 30
+
+	// statsDailyInterval is how often the daily aggregate is
+	// recomputed. Deliberately far slower than statsPublishInterval:
+	// unlike the other two paths this one is a 30-day store query
+	// (GetNetworkMetrics pipelines one HGetAll per transport per day),
+	// so the cost is the recompute, not the ~2.7 KB body. The figures
+	// are calendar-day totals — they move slowly enough that five
+	// minutes is indistinguishable from twelve seconds to any consumer,
+	// and every consumer of this path already caches on top of it.
+	statsDailyInterval = 5 * time.Minute
+)
 
 // Completeness-judgment tunables. See completenessTracker.
 const (
@@ -159,9 +192,38 @@ type VersionStats struct {
 	TrailingWindowSeconds int `json:"trailing_window_seconds"`
 }
 
-// StatsCXOPublisher publishes the two network-aggregate bodies on a
-// short cadence, gating each against its own completeness tracker.
-// Closed by Close.
+// DailyStats is the body published at StatsPathDaily. The first two
+// fields are store.NetworkMetricResponse verbatim — a consumer that
+// unmarshals this into store.NetworkMetricResponse gets exactly what
+// GET /metric returns, newest day first — and the rest is the
+// completeness stamp.
+//
+// The stamp is the TRANSPORT-SET verdict, not one computed from the
+// bandwidth figures. These are sums over the same registry
+// stats/network counts, so "the registry is still refilling" is
+// precisely the thing that makes a day's total a lower bound; judging
+// the sums themselves against a trailing peak would instead flag every
+// ordinary quiet day as partial.
+type DailyStats struct {
+	Daily      []store.DailyAggregate     `json:"daily"`
+	Cumulative *store.CumulativeAggregate `json:"cumulative"`
+
+	// Days is the window requested from the store. TPD returns only the
+	// history it holds, so len(Daily) may be shorter.
+	Days int `json:"days"`
+
+	ObservedAt time.Time `json:"observed_at"`
+	Complete   bool      `json:"complete"`
+	Confidence string    `json:"confidence"`
+	// TrailingPeak is the transport-count peak the sample was judged
+	// against — the same field stats/network publishes, repeated here
+	// so this body stands on its own.
+	TrailingPeak          int `json:"trailing_peak_transports"`
+	TrailingWindowSeconds int `json:"trailing_window_seconds"`
+}
+
+// StatsCXOPublisher publishes the network-aggregate bodies, gating each
+// against a completeness tracker. Closed by Close.
 type StatsCXOPublisher struct {
 	api *API
 	pub *treestore.Publisher
@@ -175,6 +237,16 @@ type StatsCXOPublisher struct {
 	transports completenessTracker
 	visors     completenessTracker
 	heldSince  map[string]time.Time
+
+	// lastTransportVerdict is the most recent transport-set judgment,
+	// reused to stamp stats/daily (which is a reduction of that same
+	// set) without observing a second, unrelated series.
+	lastTransportVerdict completenessVerdict
+	// lastDailyAt is when the slow stats/daily recompute was last
+	// ATTEMPTED — set on attempt rather than on success so a store
+	// error backs off to statsDailyInterval instead of retrying the
+	// 30-day query on every 12 s tick.
+	lastDailyAt time.Time
 
 	// putFn writes one already-gzipped leaf. Always s.pub.Put in
 	// production; a seam so the publish path (gzip, holdover, the set
@@ -217,6 +289,10 @@ func StartStatsCXOPublisher(ctx context.Context, api *API, dmsgC *dmsg.Client, s
 		transports: newCompletenessTracker(time.Now()),
 		visors:     newCompletenessTracker(time.Now()),
 		heldSince:  make(map[string]time.Time),
+		// Until publishNetwork has observed anything, the honest verdict
+		// for a body stamped from the transport set is "warmup", not the
+		// zero value's empty confidence string.
+		lastTransportVerdict: completenessVerdict{confidence: ConfidenceWarmup},
 	}
 	sp.putFn = pub.Put
 	if logger != nil {
@@ -260,10 +336,16 @@ func (s *StatsCXOPublisher) loop(ctx context.Context) {
 	}
 }
 
+// publishOnce writes one round. publishNetwork runs first because it
+// sets the transport-set verdict publishDaily stamps its body with.
 func (s *StatsCXOPublisher) publishOnce(ctx context.Context) {
 	now := time.Now().UTC()
 	s.publishNetwork(ctx, now)
 	s.publishVersions(now)
+	if s.lastDailyAt.IsZero() || now.Sub(s.lastDailyAt) >= statsDailyInterval {
+		s.lastDailyAt = now
+		s.publishDaily(ctx, now)
+	}
 }
 
 // publishNetwork writes StatsPathNetwork. It reads the same warm cache
@@ -276,6 +358,7 @@ func (s *StatsCXOPublisher) publishNetwork(ctx context.Context, now time.Time) {
 		return
 	}
 	verdict := s.transports.observe(now, summary.Total)
+	s.lastTransportVerdict = verdict
 	body := NetworkStats{
 		Total:                 summary.Total,
 		ByType:                summary.ByType,
@@ -338,6 +421,47 @@ func (s *StatsCXOPublisher) publishVersions(now time.Time) {
 		TrailingWindowSeconds: int(statsTrailingWindow / time.Second),
 	}
 	s.put(StatsPathVersions, body, verdict.complete, now)
+}
+
+// publishDaily writes StatsPathDaily from the same store call
+// GET /metric serves, so the published series and the HTTP series are
+// one number computed once, not two that can disagree.
+//
+// This is the read the charts on the reward server's /stats pages need
+// and the one that had no feed: over HTTP it is a 2.7 KB body that
+// still fails outright whenever the requesting dmsg client loses its
+// sessions (skycoin/skywire#4538), because an HTTP fetch is
+// all-or-nothing at request time while a subscriber reads a snapshot it
+// already holds.
+func (s *StatsCXOPublisher) publishDaily(ctx context.Context, now time.Time) {
+	resp, err := s.api.store.GetNetworkMetrics(ctx, store.MetricsQuery{
+		Days:      statsDailyDays,
+		Live:      "all",
+		Bandwidth: true,
+		Latency:   true,
+	})
+	if err != nil {
+		s.log.WithError(err).Debug("daily aggregate query failed; will retry next cycle")
+		s.recordError(err)
+		return
+	}
+	// An empty series is not news, it is a store that has not answered.
+	// Publishing it would overwrite a good body with nothing.
+	if resp == nil || len(resp.Daily) == 0 {
+		return
+	}
+	verdict := s.lastTransportVerdict
+	body := DailyStats{
+		Daily:                 resp.Daily,
+		Cumulative:            resp.Cumulative,
+		Days:                  statsDailyDays,
+		ObservedAt:            now,
+		Complete:              verdict.complete,
+		Confidence:            verdict.confidence,
+		TrailingPeak:          verdict.peak,
+		TrailingWindowSeconds: int(statsTrailingWindow / time.Second),
+	}
+	s.put(StatsPathDaily, body, verdict.complete, now)
 }
 
 // put gzips and writes one body, applying the incomplete-sample

--- a/pkg/deployment/tpd/api/cxo_stats_publisher_test.go
+++ b/pkg/deployment/tpd/api/cxo_stats_publisher_test.go
@@ -31,11 +31,12 @@ func newTestStatsPublisher(t *testing.T, api *API, started time.Time) (*StatsCXO
 	t.Helper()
 	var puts []capturedPut
 	sp := &StatsCXOPublisher{
-		api:        api,
-		log:        logging.MustGetLogger("tpd-cxo-stats-pub-test"),
-		transports: newCompletenessTracker(started),
-		visors:     newCompletenessTracker(started),
-		heldSince:  make(map[string]time.Time),
+		api:                  api,
+		log:                  logging.MustGetLogger("tpd-cxo-stats-pub-test"),
+		transports:           newCompletenessTracker(started),
+		visors:               newCompletenessTracker(started),
+		heldSince:            make(map[string]time.Time),
+		lastTransportVerdict: completenessVerdict{confidence: ConfidenceWarmup},
 	}
 	sp.putFn = func(path string, body []byte) error {
 		puts = append(puts, capturedPut{path: path, body: append([]byte(nil), body...)})

--- a/pkg/visor/api_fetch_cxo.go
+++ b/pkg/visor/api_fetch_cxo.go
@@ -121,9 +121,10 @@ func (v *Visor) FetchCXO(args FetchCXOArgs) (*FetchCXOResult, error) {
 		return &FetchCXOResult{Hit: true, Body: body, LastRootAt: time.Now()}, nil
 
 	case "tpd-stats":
-		// Path is "network" or "versions". Bodies are sub-kilobyte and
-		// republished every ~12s, so LastRootAt is a real freshness
-		// signal here rather than the wall clock the bulk feeds report.
+		// Path is "network", "versions" or "daily". The bodies are small
+		// and republished on a timer (~12s for the first two, ~5m for
+		// daily), so LastRootAt is a real freshness signal here rather
+		// than the wall clock the bulk feeds report.
 		if _, ok := statsPathForKind(args.Path); !ok {
 			return &FetchCXOResult{Reason: "invalid path for tpd-stats: " + args.Path}, nil
 		}

--- a/pkg/visor/api_tpd_stats_subscriber.go
+++ b/pkg/visor/api_tpd_stats_subscriber.go
@@ -2,10 +2,11 @@
 //
 // Reader-side helper for TPD's network-aggregate stats feed. The
 // publisher lives in pkg/deployment/tpd/api/cxo_stats_publisher.go and
-// writes two gzipped sub-kilobyte leaves:
+// writes three gzipped leaves:
 //
 //	stats/network   the GET /all-transports/stats shape
 //	stats/versions  the GET /version fleet histogram
+//	stats/daily     the GET /metric daily aggregate (~2.7 KB)
 //
 // Both carry a completeness stamp (observed_at / complete / confidence
 // / trailing peak) that the reader passes through untouched — deciding
@@ -32,12 +33,16 @@ import (
 // Callers treat it as a cache miss and fall through to HTTP.
 var ErrTPDStatsNotReady = errors.New("tpd stats: cxo cache miss")
 
-// StatsKindNetwork and StatsKindVersions are the short path names the
-// RPC/CLI layer uses, mirroring tpd-all-transports' with-self /
-// without-self.
+// StatsKindNetwork, StatsKindVersions and StatsKindDaily are the short
+// path names the RPC/CLI layer uses, mirroring tpd-all-transports'
+// with-self / without-self.
 const (
 	StatsKindNetwork  = "network"
 	StatsKindVersions = "versions"
+	// StatsKindDaily is the GET /metric daily aggregate — per-day
+	// bandwidth, latency and by-type breakdown over the published
+	// window, newest day first.
+	StatsKindDaily = "daily"
 )
 
 // statsPathForKind maps a short kind to the publisher's TreeStore path.
@@ -49,6 +54,8 @@ func statsPathForKind(kind string) (string, bool) {
 		return tpdapi.StatsPathNetwork, true
 	case StatsKindVersions:
 		return tpdapi.StatsPathVersions, true
+	case StatsKindDaily:
+		return tpdapi.StatsPathDaily, true
 	}
 	return "", false
 }

--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -61,6 +61,7 @@ const (
 	TabRoutingPolicy     = cxosub.TabRoutingPolicy
 	TabDmsgEntryLookup   = cxosub.TabDmsgEntryLookup
 	TabNetworkStats      = cxosub.TabNetworkStats
+	TabTransportMetrics  = cxosub.TabTransportMetrics
 )
 
 // feedFirstSyncTimeout forwards to cxosub so the RPC fetch/refresh default


### PR DESCRIPTION
The reward server's statistics pages fetched every TPD aggregate over HTTP-over-dmsg, and those fetches fail intermittently with EOF — a 2.7 KB `/metric` body and the ~1,400-character `/metric/visor/{pks}` URL were both observed failing on https://haltingstate.net/stats today. It is not size: the server's long-lived dmsg client periodically loses its sessions (#4538) and every request issued in that window dies outright. A CXO subscriber reads a snapshot it already holds, from memory, whole-object-or-nothing.

The pages now read TPD's CXO feeds first — over the dmsg client the server already has, no new identity — with HTTP kept behind them and the source printed on the page, because a stale snapshot and a fresh fetch are not the same claim. `/all-transports/stats` and `/version` come from `stats/network` and `stats/versions`; the per-transport windows come from the metrics day leaves. Per-visor bandwidth is summed locally by edge public key, which deletes the `/metric/visor` request rather than shortening it — the store increments the per-visor rollup from the same per-edge deltas the day leaves carry, so it is the same arithmetic. The min()-verified network total keeps its three-branch trust model, now shared by both paths so the source can move without the number moving.

TPD's daily aggregate (`/metric`) had no feed at all, and it is what the bandwidth and latency charts need, so this adds `stats/daily` as a third path on the `tpd-stats` feed. The body is ~2.7 KB but producing it is a 30-day store query, so it republishes every 5 minutes instead of on the 12s tick, and carries the same gzip and completeness stamp as its siblings.

Two reads stay on HTTP, both because no feed can carry them: `/all-transports/per-key-stats` (the only per-visor transport-count index, deliberately left off the stats feed in #4526 as two orders of magnitude too large — the ranking degrades to a labeled CXO-derived count when it fails), and the visors-online chart, which needs the uptime tracker's per-5-minute timelines that no publisher writes.