### PR TITLE
feat(rewards): three more panels on the statistics page

### DIFF
--- a/cmd/skywire-cli/cliuptime/cliuptime.go
+++ b/cmd/skywire-cli/cliuptime/cliuptime.go
@@ -543,7 +543,7 @@ func printTimelines(entries []uptimestats.VisorSummary, dr dateRange, verbose, p
 			continue
 		}
 		for _, d := range days {
-			blocks := bitmapToBlocks(e.Timeline[d])
+			blocks := uptimestats.BitmapToBlocks(e.Timeline[d])
 			pct := "-"
 			if v, ok := e.Daily[d]; ok {
 				pct = v + "%"
@@ -591,7 +591,7 @@ func printSingleLineTimelines(entries []uptimestats.VisorSummary, dr dateRange, 
 				bar.WriteString(strings.Repeat(" ", 24))
 				continue
 			}
-			bar.WriteString(bitmapToBlocks(bmp))
+			bar.WriteString(uptimestats.BitmapToBlocks(bmp))
 		}
 		bars[i] = bar.String()
 	}
@@ -666,29 +666,15 @@ func printRollingTimelines(entries []uptimestats.VisorSummary, hoursBack int, ve
 	}
 
 	for _, e := range sorted {
-		var bar strings.Builder
-		bar.Grow(hoursBack)
-		for i := hoursBack - 1; i >= 0; i-- {
-			hourStart := now.Add(-time.Duration(i+1) * time.Hour)
-			hourEnd := now.Add(-time.Duration(i) * time.Hour)
-			count := countOnlineSlots(e.Timeline, hourStart, hourEnd)
-			bar.WriteString(shadeForCount(count))
-		}
-		fmt.Printf("%s %s\n", e.PK.Hex(), bar.String())
+		fmt.Printf("%s %s\n", e.PK.Hex(), uptimestats.RollingBar(e.Timeline, now, hoursBack))
 
 		if verbose {
 			// Per-window aggregate underneath the bar when verbose.
-			total, online := 0, 0
+			total := 0
 			for t := start; t.Before(now); t = t.Add(5 * time.Minute) {
 				total++
-				day := t.UTC().Format("2006-01-02")
-				if bmp, ok := e.Timeline[day]; ok {
-					slot := t.Hour()*12 + t.Minute()/5
-					if slot < len(bmp) && bmp[slot] == '.' {
-						online++
-					}
-				}
 			}
+			online := uptimestats.CountOnlineSlots(e.Timeline, start, now)
 			pct := 0.0
 			if total > 0 {
 				pct = 100 * float64(online) / float64(total)
@@ -752,69 +738,10 @@ func rollingLabels(hoursBack int) string {
 	return strings.TrimRight(string(buf), " ")
 }
 
-// countOnlineSlots returns how many 5-minute slots between [from, to)
-// are marked online across per-day bitmaps.
-func countOnlineSlots(timelines map[string]string, from, to time.Time) int {
-	n := 0
-	for t := from; t.Before(to); t = t.Add(5 * time.Minute) {
-		day := t.UTC().Format("2006-01-02")
-		bmp, ok := timelines[day]
-		if !ok {
-			continue
-		}
-		slot := t.Hour()*12 + t.Minute()/5
-		if slot >= 0 && slot < len(bmp) && bmp[slot] == '.' {
-			n++
-		}
-	}
-	return n
-}
-
-func shadeForCount(count int) string {
-	switch {
-	case count == 0:
-		return " "
-	case count <= 3:
-		return "░"
-	case count <= 6:
-		return "▒"
-	case count <= 9:
-		return "▓"
-	default:
-		return "█"
-	}
-}
-
-// bitmapToBlocks turns a 288-char timeline string (".  "/" ") into
-// 24 hourly blocks with 5 density levels.
-func bitmapToBlocks(bitmap string) string {
-	const hours = 24
-	const slotsPerHour = 12
-	const totalSlots = hours * slotsPerHour
-	counts := make([]int, hours)
-	if len(bitmap) == 0 {
-		return strings.Repeat(" ", hours)
-	}
-	step := len(bitmap)
-	if step > totalSlots {
-		step = totalSlots
-	}
-	for i := 0; i < step; i++ {
-		if bitmap[i] == '.' {
-			hr := i * hours / step
-			if hr >= hours {
-				hr = hours - 1
-			}
-			counts[hr]++
-		}
-	}
-	var b strings.Builder
-	b.Grow(hours)
-	for _, c := range counts {
-		b.WriteString(shadeForCount(c))
-	}
-	return b.String()
-}
+// The glyph mapping and the bar builders now live in pkg/uptimestats
+// (timeline.go). They are pure functions of the timeline map and had a
+// second consumer copy-pasting them; a third — the reward server's
+// statistics panel — is what moved them beside the type they read.
 
 func fatal(c *cobra.Command, err error) {
 	fmt.Fprintf(c.ErrOrStderr(), "error: %v\n", err) //nolint:errcheck,gosec

--- a/cmd/skywire-cli/commands/rewards/server/liveness.go
+++ b/cmd/skywire-cli/commands/rewards/server/liveness.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/bitfield/script"
 )
 
 // Visors online over time, at five-minute resolution.
@@ -60,6 +58,13 @@ type utGraphVisor struct {
 }
 
 // fetchLivenessSeries pulls the tracker's timelines and sums them by slot.
+//
+// This used to run `skywire cli ut tpd graph --json` as a subprocess. It
+// now reads the shared in-process fetch (stats_tui_uptime.go), which calls
+// the same CXO → visor-RPC → dmsg chain the command's own Run calls — so
+// the ~2 MB dump is pulled once and both this plot and the per-visor
+// timeline panel are drawn from the identical bytes. A subprocess could
+// not offer that, and two subprocesses would have pulled it twice.
 func fetchLivenessSeries() (*livenessSeries, error) {
 	livenessCache.Lock()
 	defer livenessCache.Unlock()
@@ -70,12 +75,16 @@ func fetchLivenessSeries() (*livenessSeries, error) {
 		return nil, livenessCache.err
 	}
 
-	out, err := script.Exec(`skywire cli ut tpd graph --json`).String()
+	entries, _, err := fetchUptimeEntries()
 	if err != nil {
 		livenessCache.at, livenessCache.err = time.Now(), fmt.Errorf("uptime tracker query failed: %w", err)
 		return nil, livenessCache.err
 	}
-	series, err := parseLivenessSeries([]byte(out))
+	visors := make([]utGraphVisor, 0, len(entries))
+	for _, e := range entries {
+		visors = append(visors, utGraphVisor{PK: e.PK.Hex(), Timeline: e.Timeline})
+	}
+	series, err := sumLivenessTimelines(visors)
 	livenessCache.at = time.Now()
 	if err != nil {
 		livenessCache.err = err
@@ -85,13 +94,20 @@ func fetchLivenessSeries() (*livenessSeries, error) {
 	return series, nil
 }
 
-// parseLivenessSeries sums the per-visor timelines into one series.
+// parseLivenessSeries sums the per-visor timelines of a raw graph body.
+// Kept as the JSON entry point so the trimming rules stay testable against
+// a recorded response.
 func parseLivenessSeries(raw []byte) (*livenessSeries, error) {
 	var visors []utGraphVisor
 	if err := json.Unmarshal(raw, &visors); err != nil {
 		return nil, fmt.Errorf("failed to parse uptime tracker graph: %w", err)
 	}
+	return sumLivenessTimelines(visors)
+}
 
+// sumLivenessTimelines is the summing and trimming, over already-decoded
+// timelines.
+func sumLivenessTimelines(visors []utGraphVisor) (*livenessSeries, error) {
 	// Collect the dates present, sorted, so the series reads left to right.
 	dateSet := make(map[string]struct{})
 	counted := 0

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui.go
@@ -76,6 +76,14 @@ type statsTUIData struct {
 	// Coverage is each service measured against the registered dmsg server set.
 	Coverage    coverageStats
 	LivenessErr string
+
+	// PerVisor is the transports-per-visor distribution, which carries its
+	// own refusal-to-draw verdict rather than an Err field alone.
+	PerVisor tpPerVisorStats
+	// UptimeGraph is the per-visor shaded timeline `ut tpd graph` renders.
+	UptimeGraph uptimeGraphStats
+	// Arch is the surveyed architecture breakdown.
+	Arch archStats
 }
 
 type statsTUIDay struct {
@@ -184,11 +192,52 @@ func tuiMissing(title, why string) string {
 // tuiSource renders the provenance footer of a panel. Empty when nothing
 // recorded a source, so an older caller that does not set one is unchanged
 // rather than printing a blank line.
+//
+// Wrapped: a source line carries a transport, a path, a snapshot age and
+// often a completeness caveat, which comfortably exceeds the panel width.
+// An unwrapped one runs past the rule and the caveat is the part that
+// falls off the edge.
 func tuiSource(src string) string {
 	if src == "" {
 		return ""
 	}
-	return fmt.Sprintf("  %s%s%s\n", aDim, src, aReset)
+	return tuiWrap("  " + src)
+}
+
+// tuiWrap word-wraps a paragraph into the panel width, preserving the
+// leading indent on every line. The panels' explanatory lines are
+// sentences, not labels, and a sentence that runs past the rule is
+// unreadable in the 80-column target.
+func tuiWrap(s string) string {
+	indent := ""
+	for _, r := range s {
+		if r != ' ' {
+			break
+		}
+		indent += " "
+	}
+	words := strings.Fields(s)
+	if len(words) == 0 {
+		return ""
+	}
+	var out strings.Builder
+	line := indent
+	for _, w := range words {
+		if len([]rune(line))+1+len([]rune(w)) > tuiWidth && strings.TrimSpace(line) != "" {
+			out.WriteString(aDim + line + aReset + "\n")
+			line = indent + w
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			line += w
+		} else {
+			line += " " + w
+		}
+	}
+	if strings.TrimSpace(line) != "" {
+		out.WriteString(aDim + line + aReset + "\n")
+	}
+	return out.String()
 }
 
 // tuiPlot draws one labeled series panel.
@@ -338,6 +387,18 @@ func RenderStatsANSI(d statsTUIData) string {
 		b.WriteString("\n")
 	}
 
+	// ---- transports per visor ----------------------------------------------
+	//
+	// The distribution the headline average hides. Gated: TPD's index
+	// oscillates (#4513) and a histogram of a refilling sample draws an
+	// artifact as a finding — see stats_tui_pervisor.go.
+	b.WriteString(renderTPPerVisorPanelANSI(d.PerVisor))
+
+	// ---- architecture ------------------------------------------------------
+	//
+	// From the operator surveys, not TPD, which carries no arch field.
+	b.WriteString(renderArchPanelANSI(d.Arch))
+
 	// ---- dmsg substrate ----------------------------------------------------
 	//
 	// The layer everything else runs over, and previously shown nowhere on the
@@ -390,7 +451,16 @@ func RenderStatsANSI(d statsTUIData) string {
 		}
 		b.WriteString(tuiSource(d.VersionsSrc))
 		b.WriteString(tuiClose(width))
+		b.WriteString("\n")
 	}
+
+	// ---- per-visor uptime timeline -----------------------------------------
+	//
+	// Last, because it is one row per visor and everything above it is a
+	// fixed-height summary. The VISORS ONLINE plot says how many were up;
+	// this says which, which is the difference between a steady fleet and
+	// a churning one holding the same count.
+	b.WriteString(renderUptimeGraphPanelANSI(d.UptimeGraph))
 
 	return b.String()
 }

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_arch.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_arch.go
@@ -1,0 +1,234 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/stats_tui_arch.go c5-reward-server
+//
+// The fleet's CPU architectures, as a pie.
+//
+// WHERE THE DATA COMES FROM, AND WHERE IT DOES NOT.
+//
+// It does not come from TPD. TPD's visor heartbeat carries one free-form
+// field — the version string — and nothing else; there is no arch field in
+// store.VisorSummary, in the /version or /versions endpoints, or in any of
+// the three CXO stats leaves. An architecture breakdown cannot be sourced
+// from the transport discovery today without first plumbing arch through
+// RecordHeartbeat, which is a TPD protocol change and not this panel's job.
+//
+// It comes from the operator surveys the reward server already holds: each
+// visor's node-info.json carries `go_arch`, and the frequency table built
+// from it is what /stats has been rendering as an HTML pie since before
+// this terminal panel existed. This is the same data, same parse
+// (ParseFrequencyStats), drawn where the rest of the page now lives — so
+// the two renderings cannot disagree.
+//
+// That provenance is stated on the panel rather than left implied, because
+// the two populations genuinely differ: the survey set is visors that
+// submitted a survey, which is a subset of the visors TPD counts. A
+// percentage over the wrong denominator is exactly the kind of confident
+// wrong number the rest of this file's conventions exist to prevent.
+//
+// WHY THE PIE IS DRAWN HERE AND NOT BY A LIBRARY.
+//
+// Nothing vendored draws one. asciigraph plots series; 0magnet/plot-go is a
+// stream-processing pipeline with no chart types; pterm has bar, heatmap
+// and tree printers and no pie. Adding a dependency for one disc is worse
+// than rasterizing it: the disc below is a cell-by-cell angle test, which
+// is a dozen lines and has no version to track.
+package clirewardsserver
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/bitfield/script"
+)
+
+// archStats is the panel's data.
+type archStats struct {
+	// Items is biggest-first; the renderer never reorders.
+	Items []PieChartItem
+	Total int
+	Src   string
+	Err   string
+}
+
+// archSliceColors cycles the panel palette. Adjacent slices must differ,
+// so the order matters more than the individual choices.
+var archSliceColors = []string{aCyan, aGreen, aYellow, aMag, aBlue, aRed}
+
+// archSliceGlyphs cycles alongside the colors so the disc still separates
+// into slices with color stripped — a monochrome terminal, or a reader who
+// cannot distinguish two of the six. A pie that needs color to be read is
+// a pie that is unreadable for some of its readers.
+var archSliceGlyphs = []string{"█", "▓", "▒", "░", "▚", "▞"}
+
+// Disc geometry. Terminal cells are about twice as tall as they are wide,
+// so a round disc needs twice as many columns as rows.
+const (
+	archPieRows = 13
+	archPieCols = 27
+)
+
+// gatherArchStats reads the survey architecture frequency table. As
+// everywhere else in this panel, a failure is recorded, not returned.
+func gatherArchStats() archStats {
+	var a archStats
+
+	raw, err := script.File(tempStatsPath + "/arch.txt").String()
+	if err != nil {
+		a.Err = fmt.Sprintf("survey architecture table unreadable: %s", err)
+		return a
+	}
+	items := ParseFrequencyStats(raw)
+	if len(items) == 0 {
+		a.Err = "the survey architecture table carried no architectures"
+		return a
+	}
+	for _, it := range items {
+		a.Total += it.Count
+	}
+	if a.Total == 0 {
+		a.Err = "the survey architecture table summed to zero visors"
+		return a
+	}
+	// Biggest first: the disc is drawn clockwise from twelve o'clock and
+	// a reader follows it in that order.
+	sort.SliceStable(items, func(i, j int) bool { return items[i].Count > items[j].Count })
+	a.Items = items
+	a.Src = fmt.Sprintf("source: operator surveys (node-info.json go_arch), %d visors — "+
+		"NOT the TPD visor count; TPD carries no architecture field", a.Total)
+	return a
+}
+
+// archPieDisc rasterizes the pie into rows of cells, and reports how many
+// cells each slice got.
+//
+// Angles run clockwise from twelve o'clock, which is where a reader
+// expects a pie to start: with screen coordinates (x right, y down),
+// atan2(x, -y) is 0 at north, π/2 at east, π at south.
+//
+// The cell counts are returned because a disc this size quantizes to
+// roughly a percent, so a slice under that threshold draws NOTHING. It is
+// still in the legend with its real count, and the panel says how many
+// slices fell below the disc's resolution — an architecture silently
+// absent from a picture of all architectures is the failure this avoids.
+func archPieDisc(items []PieChartItem, total int) ([]string, []int) {
+	if total <= 0 || len(items) == 0 {
+		return nil, nil
+	}
+	cells := make([]int, len(items))
+	// Cumulative slice boundaries as fractions of a turn.
+	bounds := make([]float64, len(items))
+	acc := 0.0
+	for i, it := range items {
+		acc += float64(it.Count) / float64(total)
+		bounds[i] = acc
+	}
+	bounds[len(bounds)-1] = 1.0
+
+	cx := float64(archPieCols-1) / 2
+	cy := float64(archPieRows-1) / 2
+	rows := make([]string, 0, archPieRows)
+	for r := 0; r < archPieRows; r++ {
+		var line strings.Builder
+		lastColor := ""
+		for c := 0; c < archPieCols; c++ {
+			x := (float64(c) - cx) / cx
+			y := (float64(r) - cy) / cy
+			if x*x+y*y > 1.0 {
+				if lastColor != "" {
+					line.WriteString(aReset)
+					lastColor = ""
+				}
+				line.WriteByte(' ')
+				continue
+			}
+			frac := math.Atan2(x, -y) / (2 * math.Pi)
+			if frac < 0 {
+				frac++
+			}
+			idx := len(items) - 1
+			for i, bnd := range bounds {
+				if frac < bnd {
+					idx = i
+					break
+				}
+			}
+			col := archSliceColors[idx%len(archSliceColors)]
+			if col != lastColor {
+				line.WriteString(col)
+				lastColor = col
+			}
+			line.WriteString(archSliceGlyphs[idx%len(archSliceGlyphs)])
+			cells[idx]++
+		}
+		if lastColor != "" {
+			line.WriteString(aReset)
+		}
+		rows = append(rows, line.String())
+	}
+	return rows, cells
+}
+
+// renderArchPanelANSI draws the disc with its legend beside it.
+func renderArchPanelANSI(a archStats) string {
+	const title = "ARCHITECTURE"
+	width := tuiWidth
+
+	if a.Err != "" {
+		return tuiMissing(title, a.Err) + "\n"
+	}
+	if len(a.Items) == 0 || a.Total == 0 {
+		return tuiMissing(title, "no data returned") + "\n"
+	}
+
+	disc, cells := archPieDisc(a.Items, a.Total)
+
+	// Legend rows, one per architecture. Built first so the two columns
+	// can be zipped to whichever is taller.
+	legend := make([]string, 0, len(a.Items))
+	for i, it := range a.Items {
+		col := archSliceColors[i%len(archSliceColors)]
+		glyph := archSliceGlyphs[i%len(archSliceGlyphs)]
+		pct := 100 * float64(it.Count) / float64(a.Total)
+		label := it.Label
+		if len(label) > 9 {
+			label = label[:9]
+		}
+		legend = append(legend, fmt.Sprintf("%s%s%s %s%-9s%s %s%5d%s %s%5.1f%%%s",
+			col, glyph, aReset, col, label, aReset, aBold, it.Count, aReset, aDim, pct, aReset))
+	}
+
+	var b strings.Builder
+	b.WriteString(tuiRule(title+" — share of surveyed visors", width))
+	rows := len(disc)
+	if len(legend) > rows {
+		rows = len(legend)
+	}
+	for i := 0; i < rows; i++ {
+		left := strings.Repeat(" ", archPieCols)
+		if i < len(disc) {
+			left = disc[i]
+		}
+		right := ""
+		if i < len(legend) {
+			right = legend[i]
+		}
+		b.WriteString("  " + left + "  " + right + "\n")
+	}
+	tooSmall := 0
+	for i := range a.Items {
+		if i < len(cells) && cells[i] == 0 {
+			tooSmall++
+		}
+	}
+	note := ""
+	if tooSmall > 0 {
+		note = fmt.Sprintf(" · %d below the disc's resolution, legend only", tooSmall)
+	}
+	b.WriteString(tuiWrap(fmt.Sprintf("  %d architectures · %d surveyed visors%s",
+		len(a.Items), a.Total, note)))
+	b.WriteString(tuiSource(a.Src))
+	b.WriteString(tuiClose(width))
+	b.WriteString("\n")
+	return b.String()
+}

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_arch_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_arch_test.go
@@ -1,0 +1,177 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/stats_tui_arch_test.go c5-reward-server
+package clirewardsserver
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// sampleArch is the shape the survey frequency table produces: a count
+// and a go_arch value per line, biggest first after gathering.
+func sampleArch() archStats {
+	items := []PieChartItem{
+		{Label: "amd64", Count: 520},
+		{Label: "arm64", Count: 260},
+		{Label: "arm", Count: 130},
+		{Label: "386", Count: 60},
+		{Label: "riscv64", Count: 20},
+		{Label: "wasm", Count: 10},
+	}
+	total := 0
+	for _, it := range items {
+		total += it.Count
+	}
+	sort.SliceStable(items, func(i, j int) bool { return items[i].Count > items[j].Count })
+	return archStats{Items: items, Total: total, Src: "source: operator surveys (node-info.json go_arch)"}
+}
+
+// The survey table is the same text /stats already renders as an HTML
+// pie. Parsing it here rather than re-deriving it is what keeps the two
+// renderings from disagreeing.
+func TestArchParsesTheSurveyFrequencyTable(t *testing.T) {
+	items := ParseFrequencyStats("Survey architecture statistics:\n    520 amd64\n    260 arm64\n      7 riscv64\n")
+	if len(items) != 3 {
+		t.Fatalf("parsed %d architectures, want 3", len(items))
+	}
+	if items[0].Label != "amd64" || items[0].Count != 520 {
+		t.Errorf("first row is %+v, want amd64/520", items[0])
+	}
+}
+
+// Every architecture must appear in the legend. A pie that silently drops
+// its smallest slices reports a fleet that does not exist.
+func TestArchPanelNamesEveryArchitecture(t *testing.T) {
+	a := sampleArch()
+	out := renderArchPanelANSI(a)
+	for _, it := range a.Items {
+		if !strings.Contains(out, it.Label) {
+			t.Errorf("architecture %q is missing from the legend", it.Label)
+		}
+	}
+	if !strings.Contains(out, "ARCHITECTURE") {
+		t.Error("the panel title is missing")
+	}
+}
+
+// The disc must be proportional: a slice's area is its share. Counting
+// cells is the only way to assert that the angle arithmetic is right
+// rather than merely producing a circle.
+func TestArchPieSlicesAreProportional(t *testing.T) {
+	a := sampleArch()
+	rows, _ := archPieDisc(a.Items, a.Total)
+	if len(rows) != archPieRows {
+		t.Fatalf("disc is %d rows, want %d", len(rows), archPieRows)
+	}
+
+	cells := make(map[string]int)
+	filled := 0
+	for _, r := range rows {
+		for i, g := range archSliceGlyphs {
+			if i >= len(a.Items) {
+				break
+			}
+			n := strings.Count(r, g)
+			cells[a.Items[i].Label] += n
+			filled += n
+		}
+	}
+	if filled < 200 {
+		t.Fatalf("only %d cells were filled; the disc is not being drawn", filled)
+	}
+	for _, it := range a.Items {
+		want := float64(it.Count) / float64(a.Total)
+		got := float64(cells[it.Label]) / float64(filled)
+		// A disc of this size holds a few hundred cells, so a slice is
+		// quantized to roughly a percent. Five points of slack keeps the
+		// assertion about proportionality rather than about rasterization.
+		if got-want > 0.05 || want-got > 0.05 {
+			t.Errorf("%s covers %.1f%% of the disc, want %.1f%%", it.Label, 100*got, 100*want)
+		}
+	}
+}
+
+// The slices must separate without color: a monochrome terminal, or a
+// reader who cannot tell two of the six apart, still has to read the pie.
+// Slices too small to occupy a cell are legend-only by construction, so
+// the assertion is over the slices that were actually drawn.
+func TestArchPieSlicesDifferWithoutColor(t *testing.T) {
+	a := sampleArch()
+	rows, cells := archPieDisc(a.Items, a.Total)
+
+	drawn := 0
+	for _, n := range cells {
+		if n > 0 {
+			drawn++
+		}
+	}
+	if drawn < 2 {
+		t.Fatalf("only %d slices were drawn; the disc is not being rasterized", drawn)
+	}
+	seen := make(map[rune]bool)
+	for _, r := range rows {
+		for _, ch := range stripANSI(r) {
+			if ch != ' ' {
+				seen[ch] = true
+			}
+		}
+	}
+	if len(seen) < drawn {
+		t.Errorf("the disc uses %d distinct glyphs for %d drawn slices; slices merge without color",
+			len(seen), drawn)
+	}
+}
+
+// A slice too small to draw must still be accounted for in words, or the
+// picture claims to cover every architecture while omitting one.
+func TestArchPanelAccountsForUndrawableSlices(t *testing.T) {
+	a := archStats{Items: []PieChartItem{
+		{Label: "amd64", Count: 9990},
+		{Label: "riscv64", Count: 1},
+	}, Total: 9991}
+	_, cells := archPieDisc(a.Items, a.Total)
+	if cells[1] != 0 {
+		t.Skip("the disc grew enough resolution to draw a 0.01% slice")
+	}
+	out := renderArchPanelANSI(a)
+	if !strings.Contains(out, "below the disc's resolution") {
+		t.Error("a slice too small to draw was omitted with no mention")
+	}
+	if !strings.Contains(out, "riscv64") {
+		t.Error("the undrawable slice is missing from the legend too")
+	}
+}
+
+// The provenance is the point: the survey population is not the TPD visor
+// count, and a percentage over the wrong denominator is a confident wrong
+// number.
+func TestArchPanelStatesItsProvenance(t *testing.T) {
+	a := sampleArch()
+	a.Src = "source: operator surveys (node-info.json go_arch), 1000 visors — " +
+		"NOT the TPD visor count; TPD carries no architecture field"
+	out := renderArchPanelANSI(a)
+	if !strings.Contains(out, "surveys") || !strings.Contains(out, "TPD carries no architecture field") {
+		t.Error("the panel does not say where its population came from")
+	}
+}
+
+// A failed read is named; an empty panel never silently vanishes.
+func TestArchPanelNamesFailures(t *testing.T) {
+	out := renderArchPanelANSI(archStats{Err: "survey architecture table unreadable: no such file"})
+	if !strings.Contains(out, "unavailable") || !strings.Contains(out, "no such file") {
+		t.Error("a failed read was not reported")
+	}
+	out = renderArchPanelANSI(archStats{})
+	if !strings.Contains(out, "ARCHITECTURE") || !strings.Contains(out, "unavailable") {
+		t.Error("an empty panel disappeared instead of reporting itself absent")
+	}
+}
+
+// The panel is drawn beside a legend inside a 78-column rule.
+func TestArchPanelFitsThePanelWidth(t *testing.T) {
+	for _, line := range strings.Split(renderArchPanelANSI(sampleArch()), "\n") {
+		if got := len([]rune(stripANSI(line))); got > tuiWidth+2 {
+			t.Errorf("line runs to %d columns: %q", got, stripANSI(line))
+		}
+	}
+}

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_data.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_data.go
@@ -37,20 +37,42 @@ func gatherStatsTUI() statsTUIData {
 	// bodies. The CXO leaf additionally carries a completeness verdict the
 	// HTTP body has no field for: TPD's transport aggregate is readable
 	// while it refills after a restart (#4513), and only the feed says so.
+	//
+	// The verdict is kept, not just the counts: the transports-per-visor
+	// histogram refuses to draw a sample the aggregate does not vouch for,
+	// so it needs the completeness stamp and the store's own partial-read
+	// flag (#4542), not merely the numbers.
+	var verdict tpSampleVerdict
 	if stats, src, err := cxoNetworkStats(); err == nil {
 		d.Transports, d.ByType, d.UniqueVisors = stats.Total, stats.ByType, stats.UniqueVisors
 		d.CountsSrc = src.String()
+		verdict = tpSampleVerdict{
+			Total: stats.Total, Complete: stats.Complete, Confidence: stats.Confidence,
+			Partial: stats.Partial, MissingBatches: stats.MissingBatches, Known: true,
+		}
 	} else {
 		d.CountsSrc = httpStatsSource("/all-transports/stats", err.Error()).String()
+		// The HTTP body is store.TransportSummary marshaled directly, so it
+		// carries partial/missing_batches but has no field for the feed's
+		// completeness stamp. An unstamped body is treated as complete —
+		// the store's own flag is the only verdict it can offer, and
+		// refusing every HTTP-sourced sample would gate the panel off
+		// permanently whenever CXO is cold.
 		var stats struct {
 			TotalTransports int            `json:"total_transports"`
 			ByType          map[string]int `json:"by_type"`
 			UniqueVisors    int            `json:"unique_visors"`
+			Partial         bool           `json:"partial"`
+			MissingBatches  int            `json:"missing_batches"`
 		}
 		if hErr := statsGetJSON(tpdURL+"/all-transports/stats", &stats); hErr != nil {
 			d.CountsErr = hErr.Error()
 		} else {
 			d.Transports, d.ByType, d.UniqueVisors = stats.TotalTransports, stats.ByType, stats.UniqueVisors
+			verdict = tpSampleVerdict{
+				Total: stats.TotalTransports, Complete: true, Confidence: "unstamped",
+				Partial: stats.Partial, MissingBatches: stats.MissingBatches, Known: true,
+			}
 		}
 	}
 
@@ -120,6 +142,16 @@ func gatherStatsTUI() statsTUIData {
 
 	d.Dmsg = gatherDmsgStats()
 	d.Coverage = gatherServiceCoverage()
+
+	// Transports per visor, judged against the aggregate read above.
+	d.PerVisor = gatherTransportsPerVisor(tpdURL, verdict)
+
+	// The per-visor uptime bars `ut tpd graph` draws, from the same dump
+	// the liveness plot sums — pulled once, in-process, for both.
+	d.UptimeGraph = gatherUptimeGraph()
+
+	// Architecture, from the operator surveys. TPD has no arch field.
+	d.Arch = gatherArchStats()
 
 	return d
 }

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_pervisor.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_pervisor.go
@@ -1,0 +1,272 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/stats_tui_pervisor.go c5-reward-server
+//
+// How many transports each visor holds, as a histogram.
+//
+// The network panel says how many transports exist and how many visors
+// exist; their ratio is an average that describes nobody. The shape that
+// matters is the distribution: a network where every visor holds three
+// transports and one where a tenth of the visors hold thirty and the rest
+// hold one produce the same average and are not the same network.
+//
+// WHY THIS PANEL IS GATED AND THE OTHERS ARE NOT.
+//
+// TPD's transport index oscillates. Adjacent samples of the same aggregate
+// have been observed at 14,162 and 30,538 total edges (skycoin/skywire
+// #4513) — the index is readable while it is still refilling after a
+// restart, and nothing in the HTTP body distinguished a refill from the
+// network having halved. A line chart of a fluctuating total at least
+// shows the fluctuation. A histogram does not: it renders one sample as a
+// static shape, and a sample taken mid-refill draws a network whose visors
+// each hold half the transports they hold. That is an artifact presented
+// as a finding, which is worse than no panel.
+//
+// So this panel refuses to draw unless the sample is vouched for, on three
+// independent counts:
+//
+//   - store-level: TransportSummary.Partial / MissingBatches (#4542) — a
+//     batched read over the index whose batches did not all return.
+//   - publisher-level: the stats feed's complete / confidence stamp
+//     (#4526), the trailing-peak verdict on whether the total looks
+//     settled or is refilling.
+//   - self-consistency: every transport contributes exactly two edges, so
+//     the per-key index must sum to twice the aggregate's total. When it
+//     does not, the two views were read from different states of the same
+//     index — which is the oscillation itself, caught in the act.
+//
+// Any of the three failing replaces the histogram with a named absence
+// carrying the reason, the same convention tuiMissing uses for a fetch
+// that died.
+package clirewardsserver
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// tpPerVisorBucket is one column of the histogram.
+type tpPerVisorBucket struct {
+	// Label is the bucket as printed ("1", "5-9", "10+").
+	Label string
+	// Lo and Hi are inclusive bounds; Hi < 0 means unbounded.
+	Lo, Hi int
+	Visors int
+}
+
+// tpPerVisorStats is the panel's data.
+type tpPerVisorStats struct {
+	Buckets []tpPerVisorBucket
+	// Visors is how many visors the per-key index named.
+	Visors int
+	// Edges is the sum of the per-visor counts. Two per transport.
+	Edges int
+	// Median and Max describe the tail the buckets compress.
+	Median, Max int
+	// Gated reports that the sample must not be drawn as a histogram;
+	// GateWhy says which check refused it, in the words a reader needs.
+	Gated   bool
+	GateWhy string
+	// Src names where the counts came from, as every other panel does.
+	Src string
+	// Err is a failure to obtain the counts at all.
+	Err string
+}
+
+// tpSampleVerdict is what the network aggregate says about itself, lifted
+// out of whichever of the two sources answered for it.
+type tpSampleVerdict struct {
+	// Total is the aggregate's transport count, for the two-edges check.
+	Total int
+	// Complete and Confidence are the feed's completeness stamp.
+	Complete   bool
+	Confidence string
+	// Partial and MissingBatches are the store's own verdict (#4542).
+	Partial        bool
+	MissingBatches int
+	// Known is false when neither source produced an aggregate to judge
+	// against — an unjudged sample is not a passing sample.
+	Known bool
+}
+
+// tpPerVisorBuckets is the bucketing. Small counts get their own column
+// because the difference between one transport and two is the difference
+// between a visor with no redundancy and a visor with some; above five the
+// distinction stops meaning anything at this resolution.
+var tpPerVisorBuckets = []tpPerVisorBucket{
+	{Label: "1", Lo: 1, Hi: 1},
+	{Label: "2", Lo: 2, Hi: 2},
+	{Label: "3", Lo: 3, Hi: 3},
+	{Label: "4", Lo: 4, Hi: 4},
+	{Label: "5-9", Lo: 5, Hi: 9},
+	{Label: "10+", Lo: 10, Hi: -1},
+}
+
+// tpEdgeSkewTolerance is how far the per-key index may sum from twice the
+// aggregate total before the two are treated as different samples. Not
+// zero: the aggregate and the index are separate reads and a transport
+// registered between them moves the sum legitimately. One percent is far
+// below the swing #4513 produces and far above ordinary churn.
+const tpEdgeSkewTolerance = 0.01
+
+// gatherTransportsPerVisor builds the histogram from the per-visor
+// transport index, and decides whether it may be drawn.
+//
+// Failure is recorded, never returned, as everywhere else in this panel.
+func gatherTransportsPerVisor(tpdURL string, v tpSampleVerdict) tpPerVisorStats {
+	var s tpPerVisorStats
+
+	counts, err := fetchPerKeyTransportCounts(tpdURL)
+	if err != nil {
+		s.Err = err.Error()
+		return s
+	}
+	if len(counts) == 0 {
+		s.Err = "the per-key index named no visors"
+		return s
+	}
+	s = bucketTransportCounts(counts)
+	if s.Err != "" {
+		return s
+	}
+	s.Src = "source: HTTP over dmsg /all-transports/per-key-stats" +
+		" — no CXO feed carries the per-key index"
+	s.Gated, s.GateWhy = tpSampleGate(s.Edges, v)
+	return s
+}
+
+// bucketTransportCounts turns the per-key index into the histogram. Split
+// from the fetch so the shape can be asserted without a network.
+func bucketTransportCounts(counts map[string]int) tpPerVisorStats {
+	s := tpPerVisorStats{Buckets: make([]tpPerVisorBucket, len(tpPerVisorBuckets))}
+	copy(s.Buckets, tpPerVisorBuckets)
+
+	all := make([]int, 0, len(counts))
+	for _, n := range counts {
+		if n <= 0 {
+			continue
+		}
+		s.Visors++
+		s.Edges += n
+		if n > s.Max {
+			s.Max = n
+		}
+		all = append(all, n)
+		for i := range s.Buckets {
+			b := &s.Buckets[i]
+			if n >= b.Lo && (b.Hi < 0 || n <= b.Hi) {
+				b.Visors++
+				break
+			}
+		}
+	}
+	if s.Visors == 0 {
+		s.Err = "every visor in the per-key index reported zero transports"
+		return s
+	}
+	sort.Ints(all)
+	s.Median = all[len(all)/2]
+	return s
+}
+
+// tpSampleGate applies the three checks. Returns true when the sample must
+// not be drawn, with the reason.
+func tpSampleGate(edges int, v tpSampleVerdict) (bool, string) {
+	if !v.Known {
+		return true, "the network aggregate this sample would be checked against could not be " +
+			"read, so nothing vouches for the per-key index being a complete one (skywire#4513)"
+	}
+	if v.Partial {
+		return true, fmt.Sprintf("TPD reported the transport index read as PARTIAL — %d batch(es) "+
+			"failed, so the counts undercount by an unknown amount (skywire#4542, #4513)",
+			v.MissingBatches)
+	}
+	if !v.Complete {
+		conf := v.Confidence
+		if conf == "" {
+			conf = "unknown"
+		}
+		return true, fmt.Sprintf("the transport aggregate is stamped INCOMPLETE (confidence %q): "+
+			"the index is readable while it refills and a histogram of a refilling index draws "+
+			"visors holding fewer transports than they hold (skywire#4513)", conf)
+	}
+	if v.Total > 0 {
+		want := 2 * v.Total
+		skew := float64(edges-want) / float64(want)
+		if skew < 0 {
+			skew = -skew
+		}
+		if skew > tpEdgeSkewTolerance {
+			return true, fmt.Sprintf("the per-key index sums to %d edges against %d transports "+
+				"(%d edges expected, %.1f%% apart) — the two views were read from different "+
+				"states of the same index, which is the oscillation itself (skywire#4513)",
+				edges, v.Total, want, 100*skew)
+		}
+	}
+	return false, ""
+}
+
+// renderTPPerVisorPanelANSI draws the histogram, or says why it will not.
+func renderTPPerVisorPanelANSI(s tpPerVisorStats) string {
+	const title = "TRANSPORTS PER VISOR"
+	width := tuiWidth
+
+	if s.Err != "" {
+		return tuiMissing(title, s.Err) + "\n"
+	}
+	if len(s.Buckets) == 0 || s.Visors == 0 {
+		return tuiMissing(title, "no data returned") + "\n"
+	}
+	if s.Gated {
+		// Deliberately NOT a drawn histogram with a caveat under it. A
+		// rendered shape is read before any footnote is, and the whole
+		// point of the gate is that this shape would be wrong.
+		return tuiRule(title, width) +
+			fmt.Sprintf("  %shistogram withheld%s %sthis sample must not be drawn as a distribution%s\n",
+				aRed, aReset, aDim, aReset) +
+			tuiWrap("  "+s.GateWhy) +
+			tuiWrap(fmt.Sprintf("  %d visors in the index, %d edges — figures kept for "+
+				"reference, shape not charted", s.Visors, s.Edges)) +
+			tuiSource(s.Src) +
+			tuiClose(width) + "\n"
+	}
+
+	var b strings.Builder
+	b.WriteString(tuiRule(title+" — distribution", width))
+
+	maxVisors := 0
+	for _, bk := range s.Buckets {
+		if bk.Visors > maxVisors {
+			maxVisors = bk.Visors
+		}
+	}
+	for _, bk := range s.Buckets {
+		frac := 0.0
+		if maxVisors > 0 {
+			frac = float64(bk.Visors) / float64(maxVisors)
+		}
+		share := 0.0
+		if s.Visors > 0 {
+			share = float64(bk.Visors) / float64(s.Visors)
+		}
+		col := aGreen
+		switch bk.Label {
+		case "1":
+			// One transport is one failure away from isolated.
+			col = aRed
+		case "2":
+			col = aYellow
+		}
+		b.WriteString(fmt.Sprintf("  %s%-4s%s %s%5d%s %s %s%5.1f%%%s\n",
+			col, bk.Label, aReset, aBold, bk.Visors, aReset,
+			tuiBar(frac, 40, col), aDim, 100*share, aReset))
+	}
+	b.WriteString(fmt.Sprintf("  %s%d visors · median %d · max %d · %d edges%s\n",
+		aDim, s.Visors, s.Median, s.Max, s.Edges, aReset))
+	// Its own line, not appended to the figures: wrapped away from the
+	// numbers it qualifies, this caveat is the one that stops being read.
+	b.WriteString(fmt.Sprintf("  %sbars count visors per bucket, not transports%s\n", aDim, aReset))
+	b.WriteString(tuiSource(s.Src))
+	b.WriteString(tuiClose(width))
+	b.WriteString("\n")
+	return b.String()
+}

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_pervisor_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_pervisor_test.go
@@ -1,0 +1,195 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/stats_tui_pervisor_test.go c5-reward-server
+package clirewardsserver
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// evenCounts builds a per-key index of `visors` visors each holding `n`
+// transports, keyed by full-length public keys.
+func evenCounts(visors, n int) map[string]int {
+	out := make(map[string]int, visors)
+	for i := 0; i < visors; i++ {
+		out[fmt.Sprintf("%066x", i)] = n
+	}
+	return out
+}
+
+// vouched returns a verdict that passes every gate for the given index.
+func vouched(edges int) tpSampleVerdict {
+	return tpSampleVerdict{Total: edges / 2, Complete: true, Confidence: "settled", Known: true}
+}
+
+// The bars are visors per bucket. Getting this wrong — counting transports
+// instead of visors — would draw a plausible shape describing nothing.
+func TestPerVisorBucketsCountVisorsNotTransports(t *testing.T) {
+	counts := map[string]int{
+		strings.Repeat("a", 66): 1,
+		strings.Repeat("b", 66): 1,
+		strings.Repeat("c", 66): 3,
+		strings.Repeat("d", 66): 7,
+		strings.Repeat("e", 66): 40,
+	}
+	s := bucketTransportCounts(counts)
+	if s.Visors != 5 {
+		t.Errorf("counted %d visors, want 5", s.Visors)
+	}
+	if s.Edges != 52 {
+		t.Errorf("summed %d edges, want 52", s.Edges)
+	}
+	if s.Max != 40 {
+		t.Errorf("max is %d, want 40", s.Max)
+	}
+	want := map[string]int{"1": 2, "2": 0, "3": 1, "4": 0, "5-9": 1, "10+": 1}
+	for _, b := range s.Buckets {
+		if b.Visors != want[b.Label] {
+			t.Errorf("bucket %q holds %d visors, want %d", b.Label, b.Visors, want[b.Label])
+		}
+	}
+}
+
+// A store-level partial read (#4542) is a KNOWN undercount. It must stop
+// the histogram outright, not annotate it.
+func TestPerVisorPanelWithholdsAPartialSample(t *testing.T) {
+	s := bucketTransportCounts(evenCounts(100, 4))
+	s.Gated, s.GateWhy = tpSampleGate(s.Edges, tpSampleVerdict{
+		Total: 200, Complete: true, Confidence: "settled",
+		Partial: true, MissingBatches: 3, Known: true,
+	})
+	if !s.Gated {
+		t.Fatal("a partial store read was not gated")
+	}
+	out := renderTPPerVisorPanelANSI(s)
+	if !strings.Contains(out, "histogram withheld") {
+		t.Error("the panel did not say the histogram was withheld")
+	}
+	if !strings.Contains(out, "#4513") {
+		t.Error("the gate reason does not cite the oscillation issue")
+	}
+	if !strings.Contains(out, "#4542") {
+		t.Error("a partial read must name the flag it came from")
+	}
+	if strings.Contains(out, "█") {
+		t.Error("a withheld sample still drew bars; the shape is exactly what must not be shown")
+	}
+}
+
+// The published completeness stamp (#4526) is the other refusal: a
+// refilling index reads as visors holding fewer transports than they hold.
+func TestPerVisorPanelWithholdsARefillingSample(t *testing.T) {
+	s := bucketTransportCounts(evenCounts(50, 2))
+	s.Gated, s.GateWhy = tpSampleGate(s.Edges, tpSampleVerdict{
+		Total: 50, Complete: false, Confidence: "refilling", Known: true,
+	})
+	if !s.Gated {
+		t.Fatal("an incomplete sample was not gated")
+	}
+	out := renderTPPerVisorPanelANSI(s)
+	if !strings.Contains(out, "refilling") || !strings.Contains(out, "#4513") {
+		t.Error("the refilling verdict or its issue reference is missing from the notice")
+	}
+}
+
+// Self-consistency: every transport contributes exactly two edges. When
+// the per-key index and the aggregate disagree, the two were read from
+// different states of the same index — the oscillation, caught in the act.
+func TestPerVisorPanelWithholdsWhenEdgesDisagreeWithTheAggregate(t *testing.T) {
+	s := bucketTransportCounts(evenCounts(1000, 4)) // 4,000 edges
+	// The aggregate claims 3,000 transports = 6,000 edges. A third apart.
+	s.Gated, s.GateWhy = tpSampleGate(s.Edges, tpSampleVerdict{
+		Total: 3000, Complete: true, Confidence: "settled", Known: true,
+	})
+	if !s.Gated {
+		t.Fatal("an index disagreeing with the aggregate by a third was drawn as data")
+	}
+	if !strings.Contains(s.GateWhy, "#4513") {
+		t.Error("the skew reason does not cite the oscillation issue")
+	}
+	// Within tolerance the same sample must draw: the gate is a guard, not
+	// a permanent off switch.
+	s2 := bucketTransportCounts(evenCounts(1000, 4))
+	s2.Gated, s2.GateWhy = tpSampleGate(s2.Edges, vouched(s2.Edges))
+	if s2.Gated {
+		t.Fatalf("a self-consistent sample was refused: %s", s2.GateWhy)
+	}
+}
+
+// No aggregate to check against is not a pass. An unjudged sample is
+// exactly the one #4513 makes untrustworthy.
+func TestPerVisorPanelWithholdsAnUnjudgedSample(t *testing.T) {
+	gated, why := tpSampleGate(400, tpSampleVerdict{})
+	if !gated {
+		t.Fatal("a sample with no aggregate to check against was drawn")
+	}
+	if !strings.Contains(why, "#4513") {
+		t.Error("the reason does not cite the oscillation issue")
+	}
+}
+
+// A vouched sample draws, with the figures that make the shape readable.
+func TestPerVisorPanelDrawsAVouchedSample(t *testing.T) {
+	s := bucketTransportCounts(evenCounts(300, 3))
+	s.Src = "source: HTTP over dmsg /all-transports/per-key-stats"
+	s.Gated, s.GateWhy = tpSampleGate(s.Edges, vouched(s.Edges))
+	out := renderTPPerVisorPanelANSI(s)
+
+	if strings.Contains(out, "withheld") {
+		t.Fatalf("a vouched sample was withheld: %s", s.GateWhy)
+	}
+	if !strings.Contains(out, "█") {
+		t.Error("no bars were drawn")
+	}
+	for _, want := range []string{"TRANSPORTS PER VISOR", "median 3", "300 visors", "\x1b["} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendering is missing %q", want)
+		}
+	}
+	if !strings.Contains(out, "not transports") {
+		t.Error("the panel does not say the bars count visors")
+	}
+}
+
+// A failed fetch is named, never rendered as an empty or zeroed panel.
+func TestPerVisorPanelNamesFailures(t *testing.T) {
+	out := renderTPPerVisorPanelANSI(tpPerVisorStats{Err: "request failed: EOF"})
+	if !strings.Contains(out, "unavailable") || !strings.Contains(out, "EOF") {
+		t.Error("a failed fetch was not reported")
+	}
+	out = renderTPPerVisorPanelANSI(tpPerVisorStats{})
+	if !strings.Contains(out, "TRANSPORTS PER VISOR") || !strings.Contains(out, "unavailable") {
+		t.Error("an empty panel disappeared instead of reporting itself absent")
+	}
+}
+
+// The gate reasons are sentences and the panel is 78 columns. An
+// unwrapped sentence runs off the rule in the 80-column target.
+func TestGateReasonsAreWrappedToThePanel(t *testing.T) {
+	s := bucketTransportCounts(evenCounts(10, 1))
+	s.Gated, s.GateWhy = tpSampleGate(s.Edges, tpSampleVerdict{
+		Total: 500, Complete: true, Confidence: "settled", Known: true,
+	})
+	for _, line := range strings.Split(renderTPPerVisorPanelANSI(s), "\n") {
+		// Columns, not bytes: the rules are box-drawing runes.
+		plain := []rune(stripANSI(line))
+		if len(plain) > tuiWidth+2 {
+			t.Errorf("line runs to %d columns: %q", len(plain), string(plain))
+		}
+	}
+}
+
+// stripANSI removes SGR sequences so a rendered line can be measured.
+func stripANSI(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\x1b' {
+			for i < len(s) && s[i] != 'm' {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_test.go
@@ -33,9 +33,35 @@ func TestRenderStatsANSIEmitsColor(t *testing.T) {
 	if !strings.Contains(out, "\x1b[") {
 		t.Fatal("no ANSI escape sequences in the rendering")
 	}
-	for _, want := range []string{"NETWORK", "BANDWIDTH", "LATENCY", "VISORS ONLINE", "TRANSPORTS BY TYPE", "VERSION ADOPTION"} {
+	for _, want := range []string{
+		"NETWORK", "BANDWIDTH", "LATENCY", "VISORS ONLINE", "TRANSPORTS BY TYPE",
+		"VERSION ADOPTION", "TRANSPORTS PER VISOR", "ARCHITECTURE", "UPTIME TIMELINE",
+	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("panel %q missing", want)
+		}
+	}
+}
+
+// The three panels added alongside the originals obey the same rule as the
+// originals: with nothing gathered they name themselves absent rather than
+// vanishing. sampleTUIData leaves all three zero, which is exactly the
+// "nothing even attempted to fetch it" case.
+func TestRenderStatsANSINamesTheNewPanelsWhenUnpopulated(t *testing.T) {
+	out := RenderStatsANSI(sampleTUIData())
+	for _, title := range []string{"TRANSPORTS PER VISOR", "ARCHITECTURE", "UPTIME TIMELINE"} {
+		i := strings.Index(out, title)
+		if i < 0 {
+			t.Fatalf("panel %q vanished instead of reporting itself absent", title)
+		}
+		// The rule that follows the title is 78 box-drawing runes at three
+		// bytes each, so the window has to be generous in bytes.
+		end := i + 600
+		if end > len(out) {
+			end = len(out)
+		}
+		if !strings.Contains(out[i:end], "unavailable") {
+			t.Errorf("panel %q rendered without data and without saying so", title)
 		}
 	}
 }

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_uptime.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_uptime.go
@@ -1,0 +1,290 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/stats_tui_uptime.go c5-reward-server
+//
+// `skywire cli ut tpd graph`, folded into the statistics panel.
+//
+// The command already renders the uptime tracker's v3 per-5-minute
+// bitmaps as shaded hourly blocks, one bar per visor. That rendering
+// existed only at a terminal; the site showed the same tracker data
+// summed into a single visors-online line, which says how many were up
+// and never which ones. A fleet holding steady at 880 online looks
+// identical whether the same 880 visors are up all week or a churning
+// 1,200 take turns, and only the per-visor bars tell those apart.
+//
+// TWO THINGS ARE DELIBERATE HERE.
+//
+// It does not shell out. The reward server's liveness chart ran
+// `skywire cli ut tpd graph --json` as a subprocess. This file reads the
+// SAME sources that command's fetch chain reads, in-process: the
+// tpd-uptime CXO feed first (clirpc maps /uptimes?v=v3 onto exactly the
+// uptimes/days/<n> leaf read below), then HTTP over dmsg. It cannot
+// literally call clirpc — pkg/visor imports this package, so importing
+// clirpc here is an import cycle — but it reads the same leaf and the
+// same endpoint, and fetchLivenessSeries now shares the result, so the
+// ~2 MB dump is pulled once for both renderings rather than once per
+// subprocess.
+//
+// The glyphs are not re-implemented. ShadeForCount / RollingBar were
+// hoisted into pkg/uptimestats (they had already been copy-pasted once,
+// into cmd/skywire-cli/commands/visor/info.go), so the bars in this panel
+// are byte-for-byte what the CLI prints.
+package clirewardsserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/cxo/cxosub"
+	"github.com/skycoin/skywire/pkg/uptimestats"
+)
+
+const (
+	// uptimeGraphHours is the rolling window the panel draws. One block
+	// per hour at 72 columns fits inside tuiWidth beside a two-space
+	// indent, which is what fixes the number: a wider window would
+	// either overflow the 80-column target or need the public key
+	// truncated, and public keys are never truncated.
+	uptimeGraphHours = 72
+	// uptimeFetchMaxAge bounds how often the tracker dump is pulled. The
+	// underlying data advances one five-minute slot at a time.
+	uptimeFetchMaxAge = 10 * time.Minute
+	// uptimeCXODays is the published window. TPD writes uptimes/days/<n>
+	// for n in {1,7,30}; 30 is the bucket clirpc maps /uptimes?v=v3 onto,
+	// so this reads the leaf the CLI would have read.
+	uptimeCXODays = 30
+)
+
+// uptimeGraphRow is one visor's line, in the order the command emits.
+type uptimeGraphRow struct {
+	PK      string
+	Version string
+	Online  bool
+	// Bar is uptimeGraphHours block glyphs, oldest hour on the left.
+	Bar string
+	// OnlineSlots of TotalSlots five-minute slots in the window.
+	OnlineSlots, TotalSlots int
+}
+
+// uptimeGraphStats is the panel's data.
+type uptimeGraphStats struct {
+	Rows    []uptimeGraphRow
+	Hours   int
+	EndedAt time.Time
+	Src     string
+	Err     string
+}
+
+// uptimeEntriesCache memoizes the tracker dump across the two panels that
+// read it. Megabytes, and both would otherwise pull it per page load.
+var uptimeEntriesCache struct {
+	sync.Mutex
+	at      time.Time
+	entries []uptimestats.VisorSummary
+	src     string
+	err     error
+}
+
+// fetchUptimeEntries pulls the v3 uptime dump, CXO first and HTTP over
+// dmsg behind it — the same order, and the same two sources, the CLI's
+// fetch chain uses for this URL. v3 is not optional: only v3 carries the
+// per-5-minute bitmaps the bars are drawn from.
+//
+// Returns the entries and a source label, on the rule the rest of these
+// panels follow: a snapshot minutes old and a fetch made just now are
+// different claims and must not print identically.
+func fetchUptimeEntries() ([]uptimestats.VisorSummary, string, error) {
+	uptimeEntriesCache.Lock()
+	defer uptimeEntriesCache.Unlock()
+	if uptimeEntriesCache.entries != nil && time.Since(uptimeEntriesCache.at) <= uptimeFetchMaxAge {
+		return uptimeEntriesCache.entries, uptimeEntriesCache.src, nil
+	}
+	// A failure is held only briefly: these failures are transient (a lost
+	// dmsg session), and pinning one for ten minutes would blank both
+	// panels long after the cause cleared.
+	if uptimeEntriesCache.err != nil && time.Since(uptimeEntriesCache.at) <= time.Minute {
+		return nil, "", uptimeEntriesCache.err
+	}
+
+	leaf := fmt.Sprintf("uptimes/days/%d", uptimeCXODays)
+	entries, src, err := cxoUptimeEntries(leaf)
+	if err != nil {
+		httpURL := strings.TrimSuffix(deployment.Prod.TransportDiscovery, "/") + "/uptimes?v=v3"
+		label := httpStatsSource("/uptimes?v=v3", err.Error())
+		var out []uptimestats.VisorSummary
+		if hErr := statsGetJSON(httpURL, &out); hErr != nil {
+			uptimeEntriesCache.at, uptimeEntriesCache.err = time.Now(), hErr
+			return nil, "", hErr
+		}
+		entries, src = out, label.String()
+	}
+
+	uptimeEntriesCache.at = time.Now()
+	if len(entries) == 0 {
+		uptimeEntriesCache.err = fmt.Errorf("the uptime tracker returned no visors")
+		return nil, "", uptimeEntriesCache.err
+	}
+	uptimeEntriesCache.entries, uptimeEntriesCache.src, uptimeEntriesCache.err = entries, src, nil
+	return entries, src, nil
+}
+
+// cxoUptimeEntries reads one uptimes/days/<n> leaf off the tpd-uptime
+// feed. Validated by parsing, never by size — reads through dmsg have
+// repeatedly arrived truncated under a 200, and this is the largest body
+// any of these panels touches.
+func cxoUptimeEntries(leaf string) ([]uptimestats.VisorSummary, string, error) {
+	body, ts, err := statsCXOFeedLeaf(cxosub.FeedTPDUptime, cxosub.TabUptime, leaf)
+	if err != nil {
+		return nil, "", err
+	}
+	var out []uptimestats.VisorSummary
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, "", fmt.Errorf("parse failed: %w", err)
+	}
+	if len(out) == 0 {
+		return nil, "", fmt.Errorf("the uptime leaf carried no visors")
+	}
+	return out, statsSource{Via: "CXO", Path: leaf, At: ts}.String(), nil
+}
+
+// gatherUptimeGraph builds the rows. Ordering is the command's — sorted
+// by public key — so a row here and a row from the CLI are the same row.
+func gatherUptimeGraph() uptimeGraphStats {
+	s := uptimeGraphStats{Hours: uptimeGraphHours}
+
+	entries, src, err := fetchUptimeEntries()
+	if err != nil {
+		s.Err = err.Error()
+		return s
+	}
+	now := time.Now().UTC()
+	s.EndedAt = now
+	start := now.Add(-time.Duration(uptimeGraphHours) * time.Hour)
+	totalSlots := uptimeGraphHours * uptimestats.TimelineSlotsPerHour
+
+	sorted := make([]uptimestats.VisorSummary, len(entries))
+	copy(sorted, entries)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].PK.Hex() < sorted[j].PK.Hex() })
+
+	for _, e := range sorted {
+		if len(e.Timeline) == 0 {
+			// A visor with no timeline has nothing to draw and a blank
+			// bar would read as 72 hours offline, which is a different
+			// claim from "the tracker holds no timeline for it".
+			continue
+		}
+		s.Rows = append(s.Rows, uptimeGraphRow{
+			PK:          e.PK.Hex(),
+			Version:     e.Version,
+			Online:      e.Online,
+			Bar:         uptimestats.RollingBar(e.Timeline, now, uptimeGraphHours),
+			OnlineSlots: uptimestats.CountOnlineSlots(e.Timeline, start, now),
+			TotalSlots:  totalSlots,
+		})
+	}
+	if len(s.Rows) == 0 {
+		s.Err = "the uptime tracker returned no visor timelines"
+		return s
+	}
+	s.Src = src + " — uptime tracker v3 timelines, the data `skywire cli ut tpd graph` renders"
+	return s
+}
+
+// renderUptimeGraphPanelANSI draws the per-visor timeline bars.
+//
+// Two lines per visor rather than the command's one: the CLI prints
+// "<pk> <bar>", which is 66 + 1 + 72 columns and does not fit the panel.
+// Splitting the row keeps the whole public key — the dmsg panel splits
+// its rows the same way and for the same reason.
+func renderUptimeGraphPanelANSI(s uptimeGraphStats) string {
+	const title = "UPTIME TIMELINE"
+	width := tuiWidth
+
+	if s.Err != "" {
+		return tuiMissing(title, s.Err) + "\n"
+	}
+	if len(s.Rows) == 0 {
+		return tuiMissing(title, "no data returned") + "\n"
+	}
+
+	var b strings.Builder
+	b.WriteString(tuiRule(fmt.Sprintf("%s — ut tpd graph, last %dh", title, s.Hours), width))
+	b.WriteString(fmt.Sprintf("  %sone block per hour, oldest left · %s%s\n",
+		aDim, s.EndedAt.Format("2006-01-02 15:04 UTC"), aReset))
+	b.WriteString(fmt.Sprintf("  %sdensity: ' ' none  ░ ≤3  ▒ ≤6  ▓ ≤9  █ 12 of 12 five-minute slots%s\n",
+		aDim, aReset))
+	b.WriteString(tuiHourRuler(s.Hours))
+
+	full := 0
+	for _, r := range s.Rows {
+		pct := 0.0
+		if r.TotalSlots > 0 {
+			pct = 100 * float64(r.OnlineSlots) / float64(r.TotalSlots)
+		}
+		col := aGreen
+		switch {
+		case pct >= 99.5:
+			full++
+		case pct < 50:
+			col = aRed
+		case pct < 90:
+			col = aYellow
+		}
+		ver := r.Version
+		if ver == "" {
+			ver = "—"
+		}
+		// The version rides on the key line, not the bar line: 72 blocks
+		// plus a percentage is already the full panel width, and the
+		// public key is never shortened to make room for anything.
+		b.WriteString(fmt.Sprintf("  %s%s %s%s\n", aDim, r.PK, ver, aReset))
+		// One SGR pair for the whole bar, not one per glyph: this panel
+		// draws a line per visor and per-character color would multiply
+		// the exported HTML by the span count for no added meaning.
+		b.WriteString(fmt.Sprintf("  %s%s%s %s%3.0f%%%s\n",
+			col, r.Bar, aReset, aBold, pct, aReset))
+	}
+	b.WriteString(tuiWrap(fmt.Sprintf("  %d visors with a timeline · %d up for the whole "+
+		"window · liveness, NOT the uptime figure rewards use (skywire#4533)",
+		len(s.Rows), full)))
+	b.WriteString(tuiSource(s.Src))
+	b.WriteString(tuiClose(width))
+	b.WriteString("\n")
+	return b.String()
+}
+
+// tuiHourRuler draws hour-offset ticks above the bars. Without it a block
+// that is clearly bad tells you nothing about WHEN it was bad, which is
+// the first question anyone asks of an outage.
+func tuiHourRuler(hours int) string {
+	if hours <= 0 {
+		return ""
+	}
+	const step = 12
+	ticks := []rune(strings.Repeat(" ", hours))
+	labels := []rune(strings.Repeat(" ", hours))
+	for off := hours; off >= 0; off -= step {
+		col := hours - off
+		if col >= hours {
+			col = hours - 1
+		}
+		ticks[col] = '┬'
+		lb := []rune(fmt.Sprintf("-%dh", off))
+		if off == 0 {
+			lb = []rune("now")
+		}
+		start := col
+		if start+len(lb) > hours {
+			start = hours - len(lb)
+		}
+		if start < 0 {
+			continue
+		}
+		copy(labels[start:], lb)
+	}
+	return aDim + "  " + string(ticks) + aReset + "\n" +
+		aDim + "  " + string(labels) + aReset + "\n"
+}

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_uptime_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_uptime_test.go
@@ -1,0 +1,149 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/stats_tui_uptime_test.go c5-reward-server
+package clirewardsserver
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/uptimestats"
+)
+
+// sampleUptimeGraph builds a panel with one solid visor, one intermittent
+// and one dark, so every density level is exercised.
+func sampleUptimeGraph() uptimeGraphStats {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	solid := map[string]string{}
+	patchy := map[string]string{}
+	for d := 0; d < 4; d++ {
+		day := now.Add(-time.Duration(d) * 24 * time.Hour).Format("2006-01-02")
+		solid[day] = strings.Repeat(".", uptimestats.TimelineSlots)
+		var b strings.Builder
+		for i := 0; i < uptimestats.TimelineSlots; i++ {
+			if i%4 == 0 {
+				b.WriteByte('.')
+			} else {
+				b.WriteByte(' ')
+			}
+		}
+		patchy[day] = b.String()
+	}
+	dark := map[string]string{now.Format("2006-01-02"): strings.Repeat(" ", uptimestats.TimelineSlots)}
+
+	rows := []uptimeGraphRow{}
+	for _, in := range []struct {
+		pk string
+		tl map[string]string
+	}{
+		{"02a2d4c346dabd165fd555dfdba4a7f4d18786fe7e055e562397cd5102bdd7f8dd", solid},
+		{"03b1e5f457ebce276fe666efecb5b8f5e29897ff8f166f673498de6213cee8f9ee", patchy},
+		{"024c9c4b2a6a1f3d5e7c8b9a0d1e2f3a4b5c6d7e8f90a1b2c3d4e5f60718293a4b", dark},
+	} {
+		rows = append(rows, uptimeGraphRow{
+			PK:          in.pk,
+			Version:     "v1.3.94-0",
+			Online:      true,
+			Bar:         uptimestats.RollingBar(in.tl, now, uptimeGraphHours),
+			OnlineSlots: uptimestats.CountOnlineSlots(in.tl, now.Add(-uptimeGraphHours*time.Hour), now),
+			TotalSlots:  uptimeGraphHours * uptimestats.TimelineSlotsPerHour,
+		})
+	}
+	return uptimeGraphStats{
+		Rows: rows, Hours: uptimeGraphHours, EndedAt: now,
+		Src: "source: CXO uptimes/days/30",
+	}
+}
+
+// An operator matching a row against their own visor needs the whole key.
+// This is why the row is split over two lines at all.
+func TestUptimeGraphPanelPrintsFullPublicKeys(t *testing.T) {
+	s := sampleUptimeGraph()
+	out := renderUptimeGraphPanelANSI(s)
+	for _, r := range s.Rows {
+		if !strings.Contains(out, r.PK) {
+			t.Errorf("public key %s is not present in full", r.PK)
+		}
+	}
+}
+
+// The bars must be the CLI's bars. If this panel ever grew its own glyph
+// mapping, the same visor would read differently here and at a terminal.
+func TestUptimeGraphBarsAreTheCLIGlyphs(t *testing.T) {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	tl := map[string]string{now.Format("2006-01-02"): strings.Repeat(".", uptimestats.TimelineSlots)}
+	want := uptimestats.RollingBar(tl, now, uptimeGraphHours)
+	if len([]rune(want)) != uptimeGraphHours {
+		t.Fatalf("bar is %d blocks, want %d", len([]rune(want)), uptimeGraphHours)
+	}
+	out := renderUptimeGraphPanelANSI(uptimeGraphStats{
+		Rows:  []uptimeGraphRow{{PK: strings.Repeat("a", 66), Bar: want, OnlineSlots: 1, TotalSlots: 1}},
+		Hours: uptimeGraphHours, EndedAt: now,
+	})
+	if !strings.Contains(out, want) {
+		t.Error("the rendered bar is not the shared-glyph bar")
+	}
+}
+
+// A fully dark visor and a fully up one must not render alike, and the
+// panel must carry the density legend that makes the middle states
+// readable at all.
+func TestUptimeGraphPanelSeparatesUpFromDark(t *testing.T) {
+	out := renderUptimeGraphPanelANSI(sampleUptimeGraph())
+	if !strings.Contains(out, "█") {
+		t.Error("no full-density blocks; a visor that was up all window did not render as up")
+	}
+	if !strings.Contains(out, "density:") {
+		t.Error("the block-density legend is missing, so the shades are unreadable")
+	}
+	if !strings.Contains(out, "  0%") {
+		t.Error("the dark visor's window uptime was not reported")
+	}
+}
+
+// The bar is 72 blocks and the public key is 66 characters; neither may be
+// shortened, so the row is split and every line must still fit the box.
+func TestUptimeGraphPanelFitsThePanelWidth(t *testing.T) {
+	for _, line := range strings.Split(renderUptimeGraphPanelANSI(sampleUptimeGraph()), "\n") {
+		if got := len([]rune(stripANSI(line))); got > tuiWidth+2 {
+			t.Errorf("line runs to %d columns: %q", got, stripANSI(line))
+		}
+	}
+}
+
+// The panel says which visors were up, and must not be mistaken for the
+// uptime figure the reward calculation uses (#4533).
+func TestUptimeGraphPanelDisclaimsBeingUptime(t *testing.T) {
+	out := renderUptimeGraphPanelANSI(sampleUptimeGraph())
+	if !strings.Contains(out, "#4533") {
+		t.Error("the liveness-not-uptime caveat is missing")
+	}
+}
+
+// The ruler is what turns a bad block into a time. Without it the bar
+// shows that something happened and never when.
+func TestUptimeGraphRulerMarksTheWindow(t *testing.T) {
+	r := tuiHourRuler(uptimeGraphHours)
+	if !strings.Contains(r, "now") {
+		t.Error("the ruler does not mark the right-hand end")
+	}
+	if !strings.Contains(r, "-72h") {
+		t.Error("the ruler does not mark the start of the window")
+	}
+	for _, line := range strings.Split(strings.TrimRight(r, "\n"), "\n") {
+		if got := len([]rune(stripANSI(line))); got > tuiWidth {
+			t.Errorf("ruler line runs to %d columns: %q", got, stripANSI(line))
+		}
+	}
+}
+
+// A failed fetch is named; an empty panel never silently vanishes.
+func TestUptimeGraphPanelNamesFailures(t *testing.T) {
+	out := renderUptimeGraphPanelANSI(uptimeGraphStats{Err: "empty response (every fetch path failed)"})
+	if !strings.Contains(out, "unavailable") || !strings.Contains(out, "every fetch path failed") {
+		t.Error("a failed fetch was not reported")
+	}
+	out = renderUptimeGraphPanelANSI(uptimeGraphStats{})
+	if !strings.Contains(out, "UPTIME TIMELINE") || !strings.Contains(out, "unavailable") {
+		t.Error("an empty panel disappeared instead of reporting itself absent")
+	}
+}

--- a/cmd/skywire-cli/commands/rewards/server/statscxo.go
+++ b/cmd/skywire-cli/commands/rewards/server/statscxo.go
@@ -107,7 +107,7 @@ func setStatsCXOSubMgrFromDmsg(dmsgC *dmsg.Client) {
 			return cipher.PubKey{}, 0, "", fmt.Errorf("unknown feed %d", f)
 		}
 		switch f {
-		case cxosub.FeedTPDStats, cxosub.FeedTPDMetrics:
+		case cxosub.FeedTPDStats, cxosub.FeedTPDMetrics, cxosub.FeedTPDUptime:
 			if (tpd == cipher.PubKey{}) {
 				return cipher.PubKey{}, 0, "", fmt.Errorf("no TPD publisher PK (dmsg service URL unset)")
 			}
@@ -133,6 +133,12 @@ func setStatsCXOSubMgrFromDmsg(dmsgC *dmsg.Client) {
 	// every read should be a memory hit.
 	mgr.Pin(cxosub.FeedTPDStats)
 	mgr.Pin(cxosub.FeedTPDMetrics)
+	// The uptime feed too: the visors-online plot and the per-visor
+	// timeline panel both read the tracker's v3 dump, which was being
+	// pulled by running `skywire cli ut tpd graph --json` as a subprocess
+	// every ten minutes. Pinning it makes that a memory read of a feed
+	// this process already keeps warm.
+	mgr.Pin(cxosub.FeedTPDUptime)
 
 	statsCXO.Lock()
 	statsCXO.mgr = mgr
@@ -256,22 +262,29 @@ func completenessNote(complete bool, confidence string) string {
 // page is refreshed. Hence WaitForFirstSync while the reference is
 // still held (see #4525).
 func statsCXOLeaf(path string) ([]byte, time.Time, error) {
+	return statsCXOFeedLeaf(cxosub.FeedTPDStats, cxosub.TabNetworkStats, path)
+}
+
+// statsCXOFeedLeaf is statsCXOLeaf over an arbitrary feed. The uptime
+// feed is read the same way and by the same rules; only the feed and the
+// acquiring tab differ.
+func statsCXOFeedLeaf(feed cxosub.Feed, tab cxosub.Tab, path string) ([]byte, time.Time, error) {
 	mgr := statsCXOMgr()
 	if mgr == nil {
 		return nil, time.Time{}, fmt.Errorf("CXO not wired")
 	}
-	mgr.AcquireFor(cxosub.TabNetworkStats)
-	defer mgr.ReleaseFor(cxosub.TabNetworkStats)
+	mgr.AcquireFor(tab)
+	defer mgr.ReleaseFor(tab)
 
-	if body, ts, ok := statsCXOGet(mgr, cxosub.FeedTPDStats, path); ok {
+	if body, ts, ok := statsCXOGet(mgr, feed, path); ok {
 		return body, ts, nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), cxosub.FeedFirstSyncTimeout(cxosub.FeedTPDStats))
+	ctx, cancel := context.WithTimeout(context.Background(), cxosub.FeedFirstSyncTimeout(feed))
 	defer cancel()
-	if !mgr.WaitForFirstSync(ctx, cxosub.FeedTPDStats, cxosub.FeedFirstSyncTimeout(cxosub.FeedTPDStats)) {
+	if !mgr.WaitForFirstSync(ctx, feed, cxosub.FeedFirstSyncTimeout(feed)) {
 		return nil, time.Time{}, fmt.Errorf("feed not synced")
 	}
-	if body, ts, ok := statsCXOGet(mgr, cxosub.FeedTPDStats, path); ok {
+	if body, ts, ok := statsCXOGet(mgr, feed, path); ok {
 		return body, ts, nil
 	}
 	return nil, time.Time{}, fmt.Errorf("no %s leaf on the feed", path)

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -21,6 +21,7 @@ import (
 	"github.com/skycoin/skywire/cmd/skywire-cli/cliutil/livetui"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/uptimestats"
 	"github.com/skycoin/skywire/pkg/visor"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
@@ -697,24 +698,11 @@ func localUptime24h(rpc visor.API) (map[string]string, map[string]float64, bool)
 	return bars, pcts, true
 }
 
-// shadeForCount maps an online-slot count (0–12) per hour to one of
-// five density characters. Same thresholds + glyphs as
-// cliuptime.shadeForCount so the visor-info bar reads identically
-// next to a `cli ut tpd graph` output.
-func shadeForCount(count int) string {
-	switch {
-	case count == 0:
-		return " "
-	case count <= 3:
-		return "░"
-	case count <= 6:
-		return "▒"
-	case count <= 9:
-		return "▓"
-	default:
-		return "█"
-	}
-}
+// shadeForCount maps an online-slot count (0–12) per hour to one of five
+// density characters. Delegates to uptimestats.ShadeForCount so the
+// visor-info bar reads identically next to `cli ut tpd graph` output —
+// this used to be a verbatim copy, which is the drift the hoist removed.
+func shadeForCount(count int) string { return uptimestats.ShadeForCount(count) }
 
 // formatARAddr renders one AR self-registration entry.
 //

--- a/pkg/deployment/tpd/api/cxo_stats_publisher.go
+++ b/pkg/deployment/tpd/api/cxo_stats_publisher.go
@@ -165,6 +165,18 @@ type NetworkStats struct {
 	ByType       map[string]int `json:"by_type"`
 	UniqueVisors int            `json:"unique_visors"`
 
+	// Partial and MissingBatches are the store's own verdict on the read
+	// that produced these counts (see store.TransportSummary): a batched
+	// MGET over the transport index whose batches did not all come back.
+	// GET /all-transports/stats has carried them since #4542 and this
+	// body dropped them, which left a subscriber holding a sample the
+	// store already KNEW was an undercount while the only signal on the
+	// feed was the trailing-peak heuristic below — an independent
+	// estimate that can read "settled" over exactly that body. The two
+	// are different claims and both belong here.
+	Partial        bool `json:"partial,omitempty"`
+	MissingBatches int  `json:"missing_batches,omitempty"`
+
 	ObservedAt time.Time `json:"observed_at"`
 	Complete   bool      `json:"complete"`
 	Confidence string    `json:"confidence"`
@@ -359,17 +371,26 @@ func (s *StatsCXOPublisher) publishNetwork(ctx context.Context, now time.Time) {
 	}
 	verdict := s.transports.observe(now, summary.Total)
 	s.lastTransportVerdict = verdict
+	// A partial store read is a KNOWN undercount, so it counts against
+	// completeness — both in the published stamp and for the holdover
+	// rule. The trailing-peak heuristic is an independent estimate and
+	// can well read "settled" over a body the store already told us was
+	// short; publishing complete:true over partial:true would be a
+	// contradiction a consumer has no way to resolve.
+	complete := verdict.complete && !summary.Partial
 	body := NetworkStats{
 		Total:                 summary.Total,
 		ByType:                summary.ByType,
 		UniqueVisors:          summary.UniqueVisors,
+		Partial:               summary.Partial,
+		MissingBatches:        summary.MissingBatches,
 		ObservedAt:            now,
-		Complete:              verdict.complete,
+		Complete:              complete,
 		Confidence:            verdict.confidence,
 		TrailingPeak:          verdict.peak,
 		TrailingWindowSeconds: int(statsTrailingWindow / time.Second),
 	}
-	s.put(StatsPathNetwork, body, verdict.complete, now)
+	s.put(StatsPathNetwork, body, complete, now)
 }
 
 // networkSummary mirrors getAllTransportsStats' source selection: warm

--- a/pkg/uptimestats/timeline.go
+++ b/pkg/uptimestats/timeline.go
@@ -1,0 +1,122 @@
+// Package uptimestats pkg/uptimestats/timeline.go c2-net-discovery
+//
+// The shaded-block timeline glyphs, hoisted out of the CLI.
+//
+// `skywire cli ut <svc> graph` renders the v3 per-5-minute bitmaps as
+// hourly blocks at five density levels. That rendering lived entirely
+// inside cmd/skywire-cli/cliuptime as unexported helpers, so the second
+// consumer (cmd/skywire-cli/commands/visor/info.go) copy-pasted
+// shadeForCount verbatim with a comment saying pkg-level helpers were not
+// exported. This file is that comment's fix: the glyph mapping and the
+// bar builders are pure functions of the timeline map, so they belong
+// beside the types they read rather than beside one of the printers.
+//
+// The package doc for cliuptime already anticipated this — "keep this
+// thin ... so the hypervisor UI / RPC layer can eventually render the
+// same data without going through a CLI subprocess". A third consumer
+// (the reward server's statistics panel) is what forced it.
+package uptimestats
+
+import (
+	"strings"
+	"time"
+)
+
+const (
+	// TimelineSlotsPerHour is the v3 bitmap's resolution: one character
+	// per five minutes.
+	TimelineSlotsPerHour = 12
+	// TimelineHours is how many hours one day's bitmap covers.
+	TimelineHours = 24
+	// TimelineSlots is the full length of a day's bitmap.
+	TimelineSlots = TimelineHours * TimelineSlotsPerHour
+	// TimelineOnline is the character the tracker writes for a slot the
+	// visor was seen in. Anything else means not seen.
+	TimelineOnline = '.'
+)
+
+// ShadeForCount maps a count of online five-minute slots within one hour
+// to a block glyph. Five levels, so an hour that was half up is visibly
+// different from one that was fully up or fully down — a two-state
+// on/off glyph would render an intermittent visor identically to a
+// solid one.
+func ShadeForCount(count int) string {
+	switch {
+	case count == 0:
+		return " "
+	case count <= 3:
+		return "░"
+	case count <= 6:
+		return "▒"
+	case count <= 9:
+		return "▓"
+	default:
+		return "█"
+	}
+}
+
+// BitmapToBlocks turns one day's bitmap into TimelineHours hourly blocks.
+// A bitmap longer than a full day is truncated and a shorter one is
+// scaled, so a publisher that changes resolution still renders 24 blocks
+// rather than a bar of a different width than every other row.
+func BitmapToBlocks(bitmap string) string {
+	counts := make([]int, TimelineHours)
+	if len(bitmap) == 0 {
+		return strings.Repeat(" ", TimelineHours)
+	}
+	step := len(bitmap)
+	if step > TimelineSlots {
+		step = TimelineSlots
+	}
+	for i := 0; i < step; i++ {
+		if bitmap[i] == TimelineOnline {
+			hr := i * TimelineHours / step
+			if hr >= TimelineHours {
+				hr = TimelineHours - 1
+			}
+			counts[hr]++
+		}
+	}
+	var b strings.Builder
+	b.Grow(TimelineHours)
+	for _, c := range counts {
+		b.WriteString(ShadeForCount(c))
+	}
+	return b.String()
+}
+
+// CountOnlineSlots returns how many five-minute slots in [from, to) are
+// marked online across the per-day bitmaps.
+func CountOnlineSlots(timelines map[string]string, from, to time.Time) int {
+	n := 0
+	for t := from; t.Before(to); t = t.Add(5 * time.Minute) {
+		day := t.UTC().Format("2006-01-02")
+		bmp, ok := timelines[day]
+		if !ok {
+			continue
+		}
+		slot := t.Hour()*TimelineSlotsPerHour + t.Minute()/5
+		if slot >= 0 && slot < len(bmp) && bmp[slot] == TimelineOnline {
+			n++
+		}
+	}
+	return n
+}
+
+// RollingBar renders the hoursBack hours ending at now as one block per
+// hour, oldest on the left. Crossing a day boundary is handled by
+// CountOnlineSlots, which is why this is not just a concatenation of
+// BitmapToBlocks over whole days.
+func RollingBar(timelines map[string]string, now time.Time, hoursBack int) string {
+	if hoursBack <= 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(hoursBack)
+	for i := hoursBack - 1; i >= 0; i-- {
+		hourStart := now.Add(-time.Duration(i+1) * time.Hour)
+		hourEnd := now.Add(-time.Duration(i) * time.Hour)
+		b.WriteString(ShadeForCount(CountOnlineSlots(timelines, hourStart, hourEnd)))
+	}
+	return b.String()
+}

--- a/pkg/uptimestats/timeline_test.go
+++ b/pkg/uptimestats/timeline_test.go
@@ -1,0 +1,74 @@
+// Package uptimestats pkg/uptimestats/timeline_test.go c2-net-discovery
+package uptimestats
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The five levels and their thresholds are what two existing renderings
+// already draw. Hoisting them out of the CLI must not have moved a
+// boundary: a visor's bar has to read identically at a terminal and on the
+// reward page.
+func TestShadeForCountThresholdsAreUnchanged(t *testing.T) {
+	for _, tc := range []struct {
+		count int
+		want  string
+	}{
+		{0, " "}, {1, "░"}, {3, "░"}, {4, "▒"}, {6, "▒"},
+		{7, "▓"}, {9, "▓"}, {10, "█"}, {12, "█"},
+	} {
+		if got := ShadeForCount(tc.count); got != tc.want {
+			t.Errorf("ShadeForCount(%d) = %q, want %q", tc.count, got, tc.want)
+		}
+	}
+}
+
+// A day's bitmap always renders as exactly 24 blocks, whatever arrives —
+// rows of differing widths would make the whole graph unreadable.
+func TestBitmapToBlocksIsAlwaysADayWide(t *testing.T) {
+	for _, in := range []string{
+		"",
+		strings.Repeat(".", TimelineSlots),
+		strings.Repeat(" ", TimelineSlots),
+		strings.Repeat(".", 100),
+		strings.Repeat(".", TimelineSlots*2),
+	} {
+		if got := len([]rune(BitmapToBlocks(in))); got != TimelineHours {
+			t.Errorf("bitmap of %d chars rendered %d blocks, want %d", len(in), got, TimelineHours)
+		}
+	}
+	if got := BitmapToBlocks(strings.Repeat(".", TimelineSlots)); got != strings.Repeat("█", TimelineHours) {
+		t.Errorf("a fully online day rendered %q", got)
+	}
+	if got := BitmapToBlocks(strings.Repeat(" ", TimelineSlots)); got != strings.Repeat(" ", TimelineHours) {
+		t.Errorf("a fully offline day rendered %q", got)
+	}
+}
+
+// The rolling window crosses UTC midnight, which is the only part of this
+// that is not a per-day concatenation.
+func TestRollingBarCrossesTheDayBoundary(t *testing.T) {
+	now := time.Date(2026, 9, 5, 3, 0, 0, 0, time.UTC)
+	// Online all of the 4th, offline all of the 5th so far.
+	tl := map[string]string{
+		"2026-09-04": strings.Repeat(".", TimelineSlots),
+		"2026-09-05": strings.Repeat(" ", TimelineSlots),
+	}
+	bar := []rune(RollingBar(tl, now, 6))
+	if len(bar) != 6 {
+		t.Fatalf("bar is %d blocks, want 6", len(bar))
+	}
+	// The first three hours fall in the 4th (21:00–00:00), the last three
+	// in the 5th (00:00–03:00).
+	if string(bar[:3]) != "███" {
+		t.Errorf("yesterday's hours rendered %q, want full", string(bar[:3]))
+	}
+	if string(bar[3:]) != "   " {
+		t.Errorf("today's hours rendered %q, want empty", string(bar[3:]))
+	}
+	if n := CountOnlineSlots(tl, now.Add(-6*time.Hour), now); n != 3*TimelineSlotsPerHour {
+		t.Errorf("counted %d online slots in the window, want %d", n, 3*TimelineSlotsPerHour)
+	}
+}


### PR DESCRIPTION
Adds three panels to the reward server's statistics renderer, through the existing ANSI path so the terminal output and the served HTML stay one rendering: a transports-per-visor histogram, an architecture pie, and the per-visor uptime timeline `skywire cli ut tpd graph` draws.

The histogram is gated rather than drawn unconditionally. TPD's transport index oscillates (#4513), and a distribution taken mid-refill draws a network whose visors each hold half the transports they hold — a line chart at least shows the fluctuation, a histogram renders one sample as a static shape. It refuses to draw on the store's partial-read flag (#4542), on the stats feed's completeness stamp, or when the per-key index fails to sum to twice the aggregate's transport count, and prints the reason instead. #4542's flag was being dropped at publish time, so `stats/network` now carries `partial`/`missing_batches` and a partial read counts against that body's `complete`.

Architecture comes from the operator surveys, not TPD — TPD's heartbeat carries a version string and no arch field, so there is nothing to source from the discovery. The panel prints that provenance, since the surveyed population is a subset of the visors TPD counts. The pie is rasterized in-tree (nothing vendored draws one) with a distinct glyph per slice so it reads without color.

The timeline panel reuses the CLI's data path instead of shelling out: `ShadeForCount`/`BitmapToBlocks`/`RollingBar` move to `pkg/uptimestats` — they had already been copy-pasted into `visor/info.go` — and the v3 dump is read from the tpd-uptime CXO feed with HTTP over dmsg behind it. The liveness chart, which ran `skywire cli ut tpd graph --json` as a subprocess, now shares that fetch, so the ~2 MB body is pulled once for both.

Tests per panel, following the existing convention. `golangci-lint run` and `GOOS=windows golangci-lint run` are clean for the changed files.