### PR TITLE
perf(transport/webrtc): hardcode mDNS off, drop the env override

### DIFF
--- a/pkg/transport/network/webrtc_native.go
+++ b/pkg/transport/network/webrtc_native.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -82,14 +81,10 @@ func newWebRTCAPI() *webrtc.API {
 	// TRADE-OFF: Disabled also DISCARDS remote mDNS candidates. Browsers obfuscate
 	// private host IPs as ".local", so a browser (wasm) visor on the SAME LAN as a
 	// native visor loses that direct path and must fall back to a STUN-derived
-	// srflx candidate — and iceURLs may be empty, in which case such a pair has no
-	// candidate left at all. Loopback is unaffected (browsers do not obfuscate
-	// 127.0.0.1), so the local dev loop keeps working. Set SKYWIRE_WEBRTC_MDNS=1
-	// to restore pion's QueryOnly default if a deployment needs same-LAN browser
-	// peers without STUN.
-	if !mdnsEnabled() {
-		se.SetICEMulticastDNSMode(ice.MulticastDNSModeDisabled)
-	}
+	// srflx candidate. Loopback is unaffected (browsers do not obfuscate
+	// 127.0.0.1), so the local dev loop and the usual WAN case are untouched; the
+	// narrow same-LAN-browser case is not worth 38% of the process.
+	se.SetICEMulticastDNSMode(ice.MulticastDNSModeDisabled)
 	// Empty MediaEngine: skywire uses WebRTC for DATA CHANNELS ONLY, never audio/
 	// video, so registering no codecs keeps the negotiated SDP media-free.
 	//
@@ -513,15 +508,3 @@ type dcTimeout struct{}
 func (dcTimeout) Error() string   { return "webrtc: i/o timeout" }
 func (dcTimeout) Timeout() bool   { return true }
 func (dcTimeout) Temporary() bool { return true }
-
-// mdnsEnabled reports whether pion's mDNS ICE machinery should be left on.
-// Default off — see newWebRTCAPI for the goroutine cost and the same-LAN
-// browser-peer trade-off that SKYWIRE_WEBRTC_MDNS=1 buys back.
-func mdnsEnabled() bool {
-	switch os.Getenv("SKYWIRE_WEBRTC_MDNS") {
-	case "1", "true", "TRUE", "yes":
-		return true
-	default:
-		return false
-	}
-}

--- a/pkg/transport/network/webrtc_native_goroutine_test.go
+++ b/pkg/transport/network/webrtc_native_goroutine_test.go
@@ -61,16 +61,3 @@ func TestPeerConnectionSpawnsNoMDNSOrInterceptorGoroutines(t *testing.T) {
 		}
 	}
 }
-
-// TestMDNSEnabledDefaultsOff documents that the goroutine saving is the default
-// and that a deployment needing same-LAN browser peers can opt back in.
-func TestMDNSEnabledDefaultsOff(t *testing.T) {
-	t.Setenv("SKYWIRE_WEBRTC_MDNS", "")
-	if mdnsEnabled() {
-		t.Error("mDNS must default to disabled")
-	}
-	t.Setenv("SKYWIRE_WEBRTC_MDNS", "1")
-	if !mdnsEnabled() {
-		t.Error("SKYWIRE_WEBRTC_MDNS=1 must re-enable mDNS")
-	}
-}


### PR DESCRIPTION
Follow-up to #4544. The `SKYWIRE_WEBRTC_MDNS` escape hatch was the wrong shape: whether a data-channel-only mesh carrier resolves `.local` peer names is a policy decision, not a per-deployment knob.

Disabling is the right hardcoded answer. Skywire addresses peers by public key and exchanges ICE candidates over a dmsg signaling stream, so mDNS buys only the same-LAN browser-peer path — and loopback is unaffected, so the local dev loop and the ordinary WAN case are untouched. That narrow case is not worth 38% of the process.

The goroutine assertion from #4544 is unchanged and still fails if either fix is reverted.