### PR TITLE
fix(doc): clear the lint debt that is failing every Test run on develop

### DIFF
--- a/cmd/skywire/commands/doc/serve.go
+++ b/cmd/skywire/commands/doc/serve.go
@@ -25,6 +25,7 @@ package doc
 import (
 	"bytes"
 	"fmt"
+	"html"
 	"io/fs"
 	"net/http"
 	"sort"
@@ -130,7 +131,7 @@ func docHandler(root *cobra.Command) http.Handler {
 // 102 files fit on a page, and a reader looking for one knows its name.
 func proseIndex() []byte {
 	var names []string
-	_ = fs.WalkDir(skydocs.Prose(), ".", func(p string, d fs.DirEntry, err error) error {
+	walkErr := fs.WalkDir(skydocs.Prose(), ".", func(p string, d fs.DirEntry, err error) error {
 		if err == nil && !d.IsDir() && strings.HasSuffix(p, ".md") {
 			names = append(names, p)
 		}
@@ -143,6 +144,12 @@ func proseIndex() []byte {
 		fmt.Fprintf(&b, "<li><a href=%q>%s</a></li>", "/prose/"+n, n)
 	}
 	b.WriteString("</ul>")
+	// The walk cannot fail over an embedded FS, but a truncated index that
+	// says nothing is the one outcome worth ruling out: a reader would take
+	// a short list for the whole of the prose.
+	if walkErr != nil {
+		fmt.Fprintf(&b, "<p>index incomplete: %s</p>", html.EscapeString(walkErr.Error()))
+	}
 	return []byte(b.String())
 }
 
@@ -160,12 +167,10 @@ func mdToHTML(src []byte) []byte {
 	return buf.Bytes()
 }
 
-// writeHTML wraps rendered markdown in a minimal document. No external assets:
-// this is served on a loopback with no transport behind it, so a stylesheet
-// from a CDN would simply never arrive.
-func writeHTML(w http.ResponseWriter, title string, body []byte) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, `<!doctype html><meta charset=utf-8>
+// docPage is the whole document, hoisted to a constant so the Fprintf that
+// emits it is one line — a raw string spanning ten lines leaves nowhere to
+// put the directive that says why its error is dropped.
+const docPage = `<!doctype html><meta charset=utf-8>
 <meta name=viewport content="width=device-width,initial-scale=1">
 <title>%s</title><style>
 body{max-width:46em;margin:2em auto;padding:0 1em;font:15px/1.6 system-ui,sans-serif;color:#cdd2da;background:#15131c}
@@ -175,5 +180,15 @@ pre code{background:none;padding:0}
 table{border-collapse:collapse}td,th{border:1px solid #3a3350;padding:.3em .6em}
 nav{margin-bottom:2em;font-size:13px}
 </style><nav><a href="/">command reference</a> · <a href="/prose/">prose</a></nav>
-%s`, title, body)
+%s`
+
+// writeHTML wraps rendered markdown in a minimal document. No external assets:
+// this is served on a loopback with no transport behind it, so a stylesheet
+// from a CDN would simply never arrive.
+func writeHTML(w http.ResponseWriter, title string, body []byte) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// A dropped error, deliberately: a write failure here is the client
+	// hanging up mid-page. There is no second channel to report it on and
+	// nothing to retry.
+	fmt.Fprintf(w, docPage, title, body) //nolint:errcheck,gosec
 }

--- a/docs/embed.go
+++ b/docs/embed.go
@@ -1,8 +1,9 @@
 // Package docs docs/embed.go c1-cli-doc
 // The prose half of `skywire doc serve`, embedded from where it lives.
 //
-// go:embed cannot reach outside its own package directory, so the embed
-// declaration sits in docs/ rather than beside the command that serves it.
+// The `go:embed` directive cannot reach outside its own package directory, so
+// the embed declaration sits in docs/ rather than beside the command that
+// serves it.
 // Nothing else belongs in this package.
 //
 // The CLI reference is NOT here and never will be: `skywire doc` walks the

--- a/docs/embed_test.go
+++ b/docs/embed_test.go
@@ -35,12 +35,16 @@ func TestProseCoversEveryTree(t *testing.T) {
 		}
 		// A tree counts as prose once it holds any markdown.
 		var hasMD bool
-		_ = fs.WalkDir(os.DirFS(e.Name()), ".", func(p string, d fs.DirEntry, err error) error {
+		if err := fs.WalkDir(os.DirFS(e.Name()), ".", func(p string, d fs.DirEntry, err error) error {
 			if err == nil && !d.IsDir() && strings.HasSuffix(p, ".md") {
 				hasMD = true
 			}
 			return nil
-		})
+		}); err != nil {
+			// A directory this test cannot walk is one it cannot vouch for,
+			// which is the opposite of the assertion below passing.
+			t.Fatalf("walk docs/%s/: %v", e.Name(), err)
+		}
 		if !hasMD {
 			continue
 		}
@@ -69,7 +73,7 @@ func TestProseExcludesGenerated(t *testing.T) {
 func TestProseCarriesNoBuildOutput(t *testing.T) {
 	banned := map[string]bool{".wasm": true, ".gz": true, ".png": true, ".gif": true, ".jpg": true, ".svg": true, ".zip": true}
 	var total int64
-	_ = fs.WalkDir(proseFS, ".", func(p string, d fs.DirEntry, err error) error {
+	if err := fs.WalkDir(proseFS, ".", func(p string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return nil
 		}
@@ -81,7 +85,11 @@ func TestProseCarriesNoBuildOutput(t *testing.T) {
 			t.Errorf("%s embedded — build output does not belong in the docs embed", p)
 		}
 		return nil
-	})
+	}); err != nil {
+		// An unwalkable embed is an unmeasured embed; the size budget below
+		// would otherwise pass on a total of zero.
+		t.Fatalf("walk the prose embed: %v", err)
+	}
 	// The prose is ~762 KB today. Generous enough for ordinary writing, tight
 	// enough that a tree of binaries trips it.
 	if total > 2<<20 {


### PR DESCRIPTION
The linux, windows and darwin jobs of the `Test` workflow have failed on every commit since #4527 — four errcheck findings and one staticcheck SA9009, all in the docs embed and its server. The workflow has been red for days, so nothing merged in that window was actually checked by it.

errcheck runs with `check-blank`, so `_ = fs.WalkDir(...)` counts as unchecked. The two in `embed_test.go` become fatals: an unwalkable tree is one the test cannot vouch for, and the size-budget assertion would otherwise pass on a total of zero. The one in `proseIndex` renders the failure into the page instead, since a short list of prose reads as the whole of it. The `Fprintf` in `writeHTML` keeps its dropped error — a write failure there is the client hanging up mid-page — but now carries the directive saying so; the document template moves to a constant so the call fits on one line and has somewhere to put it.

SA9009 was a doc comment opening with `// go:embed`, which reads as a malformed compiler directive. Reworded.

`golangci-lint run` and `GOOS=windows golangci-lint run` both report 0 issues after this; `go build .` and the two affected packages' tests pass.