### PR TITLE
fix(transport/webrtc): close the signaling stream once the DataChannel opens

### DIFF
--- a/pkg/transport/network/webrtc_native.go
+++ b/pkg/transport/network/webrtc_native.go
@@ -213,7 +213,8 @@ func webrtcDial(ctx context.Context, signal io.ReadWriteCloser, iceURLs []string
 			errCh <- derr
 			return
 		}
-		connCh <- newDCConn(raw, pc, signal)
+		releaseSignaling(signal)
+		connCh <- newDCConn(raw, pc, nil)
 	})
 
 	wireLocalCandidates(pc, sc)
@@ -253,7 +254,8 @@ func webrtcAccept(ctx context.Context, signal io.ReadWriteCloser, iceURLs []stri
 				errCh <- derr
 				return
 			}
-			connCh <- newDCConn(raw, pc, signal)
+			releaseSignaling(signal)
+			connCh <- newDCConn(raw, pc, nil)
 		})
 	})
 
@@ -508,3 +510,24 @@ type dcTimeout struct{}
 func (dcTimeout) Error() string   { return "webrtc: i/o timeout" }
 func (dcTimeout) Timeout() bool   { return true }
 func (dcTimeout) Temporary() bool { return true }
+
+// releaseSignaling closes the dmsg signaling stream now that the DataChannel is
+// open, rather than holding it for the transport's whole lifetime.
+//
+// Signaling exists only to carry the SDP offer/answer and trickle ICE
+// candidates. Once the DataChannel opens, ICE has selected a candidate pair and
+// the SCTP association is up, and nothing reads the stream any more: its reader,
+// pumpRemoteSignals, is bound to the DIAL context and has already returned.
+// Measured on a host visor: 4 pumpRemoteSignals goroutines against 35 webrtc
+// transports — 31 streams open, unread, each holding a reserved dmsg port, a
+// third of that visor's total.
+//
+// Safe against a peer that still writes candidates: the sender ignores write
+// errors (wireLocalCandidates) and its own pumpRemoteSignals simply returns on a
+// read error. Nothing that worked before stops working — an ICE restart was
+// already impossible, because the reader was gone.
+func releaseSignaling(signal io.Closer) {
+	if signal != nil {
+		signal.Close() //nolint:errcheck,gosec
+	}
+}

--- a/pkg/transport/network/webrtc_signal_release_test.go
+++ b/pkg/transport/network/webrtc_signal_release_test.go
@@ -1,0 +1,69 @@
+//go:build !tinygo && !(js && wasm)
+
+package network
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+)
+
+// countingCloser records how many times Close was called.
+type countingCloser struct{ n atomic.Int32 }
+
+func (c *countingCloser) Close() error {
+	c.n.Add(1)
+	return nil
+}
+
+// TestReleaseSignalingClosesOnce pins that the signaling stream is closed when
+// handed off. The stream used to be retained for the transport's lifetime with
+// no reader, holding a reserved dmsg port each — 31 of a host visor's 94.
+func TestReleaseSignalingClosesOnce(t *testing.T) {
+	c := &countingCloser{}
+	releaseSignaling(c)
+	if got := c.n.Load(); got != 1 {
+		t.Fatalf("signaling stream closed %d times, want 1", got)
+	}
+}
+
+// TestReleaseSignalingNilSafe covers the accept path, where a conn may be
+// constructed without a signaling stream.
+func TestReleaseSignalingNilSafe(t *testing.T) {
+	releaseSignaling(nil) // must not panic
+}
+
+// TestDCConnCloseDoesNotDoubleCloseSignal is the regression guard for the
+// handoff: newDCConn is now given a nil signal because releaseSignaling already
+// closed it. If a future change passes the live stream again, the transport
+// would close an already-closed dmsg stream on teardown.
+func TestDCConnCloseDoesNotDoubleCloseSignal(t *testing.T) {
+	c := &countingCloser{}
+	releaseSignaling(c)
+
+	api := newWebRTCAPI()
+	pc, err := api.NewPeerConnection(webrtcConfig(nil))
+	if err != nil {
+		t.Fatalf("NewPeerConnection: %v", err)
+	}
+	defer func() { _ = pc.Close() }() //nolint:errcheck
+
+	conn := newDCConn(nopRWC{}, pc, nil)
+	if conn.signal != nil {
+		t.Fatal("dcConn must not retain the signaling stream after handoff")
+	}
+	if got := c.n.Load(); got != 1 {
+		t.Fatalf("signaling stream closed %d times, want exactly 1", got)
+	}
+}
+
+// nopRWC satisfies the detached-DataChannel interface for construction only.
+type nopRWC struct{}
+
+func (nopRWC) Read([]byte) (int, error)  { return 0, errors.New("closed") }
+func (nopRWC) Write([]byte) (int, error) { return 0, errors.New("closed") }
+func (nopRWC) ReadDataChannel([]byte) (int, bool, error) {
+	return 0, false, errors.New("closed")
+}
+func (nopRWC) WriteDataChannel([]byte, bool) (int, error) { return 0, errors.New("closed") }
+func (nopRWC) Close() error                               { return nil }


### PR DESCRIPTION
Each WebRTC transport held its dmsg signaling stream open for the transport's whole lifetime, one reserved dmsg port apiece. Nothing was reading it: `pumpRemoteSignals` is bound to the *dial* context and has already returned by the time the DataChannel opens. Measured on a host visor: 4 pump goroutines against 35 webrtc transports — so 31 streams open, unread, a third of that visor's 94 dmsg ports.

Signaling only carries the SDP offer/answer and trickle ICE candidates. Once the DataChannel is open, ICE has selected a pair and the SCTP association is up, so the stream is closed at handoff and `newDCConn` is given a nil signal instead.

This costs nothing that was working. A peer still sending candidates is unaffected — the sender ignores write errors and its own reader just returns on a read error — and an ICE restart was already impossible, since the reader was gone. A test pins the single close and guards against a future change handing the live stream back to `dcConn`, which would double-close a dmsg stream on teardown.