### PR TITLE
fix(autoconnect): uncap direct carriers so stcpr is tried against every public visor

### DIFF
--- a/pkg/visor/autoconnect.go
+++ b/pkg/visor/autoconnect.go
@@ -247,7 +247,6 @@ func (a *autoconnector) Run(ctx context.Context, v *Visor) (err error) {
 			// Phase 4:  WebRTC LAST-RESORT fallback to peers no direct carrier reached
 
 			const maxPublicVisors = 5 // Connect to up to 5 public visors
-			const maxSUDPH = 30       // Max SUDPH transports to other visors
 			const maxWEBRTC = 20      // Max WebRTC transports to other (webrtc-capable) visors
 
 			// Count existing automatic transports by type and remote PK
@@ -293,7 +292,7 @@ func (a *autoconnector) Run(ctx context.Context, v *Visor) (err error) {
 			if localSupportsSUDPH {
 				a.log.Debug("Phase 1: Connecting to public visors via SUDPH")
 				phase1, err := a.conn.ConnectToVisors(ctx, v.conf.PK, absent1, tptypes.SUDPH,
-					existingByPK, sudphCapable, maxPublicVisors, 0, true)
+					existingByPK, sudphCapable, 0, 0, true)
 				if err != nil {
 					return err
 				}
@@ -311,11 +310,15 @@ func (a *autoconnector) Run(ctx context.Context, v *Visor) (err error) {
 				}
 			}
 
-			// Phase 2: STCPR to the same public visors
+			// Phase 2: STCPR to ALL public visors — not just the ones phase 1 reached.
+			// STCPR was previously gated behind phase 1's SUDPH selection and its
+			// 5-visor budget, so a visor only ever tried stcpr against <=5 randomly
+			// shuffled public visors and fell through to the phase-4 WebRTC
+			// last-resort for every other one — even though stcpr worked fine to them.
 			if localSupportsSTCPR {
 				a.log.Debug("Phase 2: Connecting to public visors via STCPR")
-				phase2, err := a.conn.ConnectToVisors(ctx, v.conf.PK, connectedPublicVisors, tptypes.STCPR,
-					existingByPK, nil, maxPublicVisors, 0, false)
+				phase2, err := a.conn.ConnectToVisors(ctx, v.conf.PK, absent1, tptypes.STCPR,
+					existingByPK, nil, 0, 0, false)
 				if err != nil {
 					return err
 				}
@@ -338,10 +341,10 @@ func (a *autoconnector) Run(ctx context.Context, v *Visor) (err error) {
 			}
 
 			// Phase 3: SUDPH to other connected visors (non-public visors only)
-			if localSupportsSUDPH && !visorIsPublic && countSUDPH < maxSUDPH && len(absent2) > 0 {
+			if localSupportsSUDPH && !visorIsPublic && len(absent2) > 0 {
 				a.log.Debug("Phase 3: Connecting to other visors via SUDPH")
 				phase3, err := a.conn.ConnectToVisors(ctx, v.conf.PK, absent2, tptypes.SUDPH,
-					existingByPK, sudphCapable, maxSUDPH, countSUDPH, false)
+					existingByPK, sudphCapable, 0, countSUDPH, false)
 				if err != nil {
 					return err
 				}

--- a/pkg/visor/visorcore/autoconnect.go
+++ b/pkg/visor/visorcore/autoconnect.go
@@ -82,7 +82,9 @@ func (c *Connector) ConnectToVisors(
 		}
 
 		mu.Lock()
-		reached := currentCount+result.Count >= maxCount
+		// maxCount <= 0 means unlimited: the direct carriers (stcpr, sudph) are no
+		// longer budget-limited, so a phase can enumerate every target.
+		reached := maxCount > 0 && currentCount+result.Count >= maxCount
 		mu.Unlock()
 		if reached {
 			break


### PR DESCRIPTION
Autoconnect only ever attempted STCPR against the <=5 public visors that Phase 1 had already selected with SUDPH, from a `ShufflePubKeys` — so which public visors a given visor reached over stcpr was a lottery, and every other one fell through to the Phase 4 WebRTC last-resort.

That is measurable on a live host visor. Of its 88 webrtc transports, 81 were inbound, and **none of those 81 peers had any other transport to it**. Asking their visors via TPS to dial stcpr succeeded 8/8, and a watcher that caught 4 more webrtc transports as they were created found stcpr and squicr available to all 4 at that exact moment. WebRTC was never a fallback from failure — those peers simply never tried the cheaper carrier.

The blast radius is small: there are 15 public visors on the network, and **all 14 reachable ones accept stcpr on request** (verified with `tp add -t stcpr` against every one, including the three with the lowest transport counts, which are dialable rather than misconfigured). So uncapping raises a visor's public-visor stcpr transports from <=5 to at most ~15.

Changes: Phase 2 targets all public visors instead of Phase 1's subset; the SUDPH budgets (`maxPublicVisors` on Phase 1, `maxSUDPH = 30` on Phase 3) are removed, since the other direct carriers were never capped and the limit was legacy. `ConnectToVisors` now treats `maxCount <= 0` as unlimited. QUIC and the WebRTC last-resort keep their existing caps.
