### PR TITLE
fix(router): --direct actually bypasses the route finder

### DIFF
--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -1105,6 +1105,32 @@ func (r *router) fetchBestRoutes(ctx context.Context, log *logging.Logger, src, 
 		}
 	}
 
+	// A --direct dial over an EXISTING direct transport does not need the route
+	// finder: the route it would return is the transport this visor is already
+	// holding. Three comments (here at the baseMinHops downgrade, on
+	// EnsureDirectTransport in router.go, and at the app-server flag site) have
+	// long claimed UseExistingTpOnly "bypasses the route-finder", but nothing
+	// implemented it — useExistingOnly only skipped the transport-CREATION hooks,
+	// so every --direct dial still paid an RF round-trip to be told about its own
+	// transport (#4552).
+	//
+	// Guarded on baseMinHops == 1, which the caller sets only when a transport to
+	// dst is already known AND nothing (per-dial or visor-global min_hops) asked
+	// for more than one hop — so an operator running min_hops=3 is never silently
+	// handed a 1-hop route here.
+	//
+	// If no live transport is found we fall through to the route finder rather
+	// than failing: --direct means "prefer the direct leg", and EnsureDirectTransport
+	// may still be creating one.
+	if directDial && baseMinHops == 1 {
+		if hop, ok := r.directHop(src, dst); ok {
+			fwd := []routing.Hop{hop}
+			log.WithField("transport", hop.TpID).
+				Debug("--direct: 1-hop route over the existing transport; skipping the route finder")
+			return fwd, reverseHops(fwd), nil
+		}
+	}
+
 	retries := opts.Retries
 
 	log.Debugf("Requesting new routes from %s to %s", src, dst)
@@ -3353,4 +3379,33 @@ func validMuxLeg(fwd, rev []routing.Hop, src, dst cipher.PubKey, usedFwd, usedRe
 		return false
 	}
 	return disjointFrom(routeIntermediates(rev, dst, src), usedRev)
+}
+
+// directHop returns a 1-hop route over a live transport to dst, if this visor
+// already holds one.
+//
+// Setup transports are excluded: they carry route-setup traffic, not app data.
+// Closed transports are skipped so a dead leg is never turned into a route —
+// falling through to the route finder is the right answer there, not dialing
+// over something known to be down.
+func (r *router) directHop(src, dst cipher.PubKey) (routing.Hop, bool) {
+	if r.tm == nil {
+		return routing.Hop{}, false
+	}
+	var (
+		found routing.Hop
+		ok    bool
+	)
+	r.tm.WalkTransports(func(tp *transport.ManagedTransport) bool {
+		if tp == nil || tp.IsClosed() || tp.Entry.Label == transport.LabelSetup {
+			return true
+		}
+		if tp.Entry.RemoteEdge(src) != dst {
+			return true
+		}
+		found = routing.Hop{TpID: tp.Entry.ID, From: src, To: dst}
+		ok = true
+		return false
+	})
+	return found, ok
 }

--- a/pkg/router/router_direct_hop_test.go
+++ b/pkg/router/router_direct_hop_test.go
@@ -1,0 +1,70 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// injectHopTp adds a live transport between the router's own key and remote.
+func injectHopTp(t *testing.T, r *router, remote cipher.PubKey, label transport.Label) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	mt := transport.NewManagedTransportForTest(newWorkingTransport())
+	mt.Entry = transport.Entry{
+		ID:    id,
+		Type:  "test",
+		Edges: [2]cipher.PubKey{r.conf.PubKey, remote},
+		Label: label,
+	}
+	r.tm.InjectTransportForTest(mt)
+	return id
+}
+
+// TestDirectHopFindsExistingTransport is the point of #4552: a --direct dial
+// over a transport this visor already holds must not need the route finder,
+// which would only hand back the very transport being held.
+func TestDirectHopFindsExistingTransport(t *testing.T) {
+	r := newLegTestRouter(t)
+	remote, _ := cipher.GenerateKeyPair()
+	id := injectHopTp(t, r, remote, transport.LabelUser)
+
+	hop, ok := r.directHop(r.conf.PubKey, remote)
+	if !ok {
+		t.Fatal("directHop found no route over an existing transport")
+	}
+	if hop.TpID != id {
+		t.Errorf("hop uses transport %v, want %v", hop.TpID, id)
+	}
+	if hop.From != r.conf.PubKey || hop.To != remote {
+		t.Errorf("hop is %v -> %v, want %v -> %v", hop.From, hop.To, r.conf.PubKey, remote)
+	}
+}
+
+// TestDirectHopSkipsSetupTransport guards the one transport that must never
+// become an app-data route: setup transports carry route-setup traffic.
+func TestDirectHopSkipsSetupTransport(t *testing.T) {
+	r := newLegTestRouter(t)
+	remote, _ := cipher.GenerateKeyPair()
+	injectHopTp(t, r, remote, transport.LabelSetup)
+
+	if _, ok := r.directHop(r.conf.PubKey, remote); ok {
+		t.Fatal("directHop routed over a setup transport")
+	}
+}
+
+// TestDirectHopNoTransportFallsThrough pins the fall-through: with no transport
+// to dst, directHop must report no route so the caller uses the route finder
+// rather than failing the dial.
+func TestDirectHopNoTransportFallsThrough(t *testing.T) {
+	r := newLegTestRouter(t)
+	other, _ := cipher.GenerateKeyPair()
+	unrelated, _ := cipher.GenerateKeyPair()
+	injectHopTp(t, r, other, transport.LabelUser)
+
+	if _, ok := r.directHop(r.conf.PubKey, unrelated); ok {
+		t.Fatal("directHop invented a route to a peer it has no transport to")
+	}
+}


### PR DESCRIPTION
Closes #4552.

Three separate comments — at the `baseMinHops` downgrade in `router_dial.go`, on `EnsureDirectTransport` in `router.go`, and at the app-server flag site — claimed that `UseExistingTpOnly` "bypasses the route-finder". Nothing implemented it: `useExistingOnly` was consumed once, to skip the transport-*creation* hooks. So every `--direct` dial over an existing transport still made a route-finder round-trip, and the finder handed back, among other candidates, the very transport the dial was already holding.

`directHop` builds the 1-hop route locally instead. It is guarded on `baseMinHops == 1`, which the caller sets only when a transport to dst is already known AND neither the per-dial options nor the visor-global `min_hops` asked for more than one hop — so an operator on `min_hops=3` is never silently given a 1-hop route. Setup-labelled and closed transports are excluded, and finding nothing falls through to the route finder rather than failing the dial.

Unchanged: the setup-node handshake still happens, because installing rules on the remote edge has no peer-direct path. That half of #4552 stays open as a design question.