### PR TITLE
feat(rewards/server): route setup node panel on /stats

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/stats_tui.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui.go
@@ -74,7 +74,11 @@ type statsTUIData struct {
 	// Dmsg is the substrate layer: server capacity and client registrations.
 	Dmsg dmsgStats
 	// Coverage is each service measured against the registered dmsg server set.
-	Coverage    coverageStats
+	Coverage coverageStats
+	// SetupNodes is the route-setup control plane: one snapshot per configured
+	// route setup node, with an unreachable node carrying its error rather
+	// than being dropped from the list.
+	SetupNodes  snStats
 	LivenessErr string
 
 	// PerVisor is the transports-per-visor distribution, which carries its
@@ -222,7 +226,28 @@ func tuiWrap(s string) string {
 	}
 	var out strings.Builder
 	line := indent
+	room := tuiWidth - len([]rune(indent))
+	if room < 8 {
+		room = 8
+	}
 	for _, w := range words {
+		// A token wider than the panel — a dmsg URL carrying a whole 66-rune
+		// public key is the usual one — has no space to break at, so word
+		// wrapping alone leaves it running past the rule. Break it across
+		// lines instead of dropping the overflow: the key stays complete,
+		// which truncating it would not.
+		for len([]rune(w)) > room {
+			if strings.TrimSpace(line) != "" {
+				out.WriteString(aDim + line + aReset + "\n")
+				line = indent
+			}
+			r := []rune(w)
+			out.WriteString(aDim + indent + string(r[:room]) + aReset + "\n")
+			w = string(r[room:])
+		}
+		if w == "" {
+			continue
+		}
 		if len([]rune(line))+1+len([]rune(w)) > tuiWidth && strings.TrimSpace(line) != "" {
 			out.WriteString(aDim + line + aReset + "\n")
 			line = indent + w
@@ -259,8 +284,11 @@ func tuiPlot(title string, series []float64, labels []string, height int, precis
 		b.WriteString("  " + ln + "\n")
 	}
 	b.WriteString(tuiXAxis(labels, width-14, 8))
+	// Wrapped for the same reason tuiSource is: a footer carries a provenance
+	// line or a full public key, either of which exceeds the panel width, and
+	// an unwrapped one runs past the rule with the tail falling off the edge.
 	if footer != "" {
-		b.WriteString("  " + aDim + footer + aReset + "\n")
+		b.WriteString(tuiWrap("  " + footer))
 	}
 	b.WriteString(tuiClose(width))
 	b.WriteString("\n")
@@ -412,6 +440,14 @@ func RenderStatsANSI(d statsTUIData) string {
 	// to only some dmsg servers is invisible: reachable for clients on those
 	// servers, silently unresolvable for the rest, with no error anywhere.
 	b.WriteString(renderCoveragePanelANSI(d.Coverage))
+
+	// ---- route setup nodes -------------------------------------------------
+	//
+	// Every route in the network is negotiated by one of these, and nothing on
+	// the site showed them. A setup node refusing setups leaves no mark on any
+	// transport or uptime chart: the transports stay registered and the visors
+	// stay online while routing across them quietly stops working.
+	b.WriteString(renderSetupNodePanelANSI(d.SetupNodes))
 
 	// ---- version adoption --------------------------------------------------
 	if d.VersionsErr != "" {

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_data.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_data.go
@@ -143,6 +143,12 @@ func gatherStatsTUI() statsTUIData {
 	d.Dmsg = gatherDmsgStats()
 	d.Coverage = gatherServiceCoverage()
 
+	// The route-setup control plane, read from each configured route setup
+	// node's own /stats over dmsg. That endpoint is not survey-gated — only
+	// /debug/* on the same listener is — so the reward server's existing dmsg
+	// identity reaches it without being whitelisted.
+	d.SetupNodes = gatherSetupNodeStats()
+
 	// Transports per visor, judged against the aggregate read above.
 	d.PerVisor = gatherTransportsPerVisor(tpdURL, verdict)
 

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_sn.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_sn.go
@@ -1,0 +1,358 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/stats_tui_sn.go c5-reward-server
+//
+// The route setup nodes, in the terminal panel.
+//
+// Every route in the network is negotiated by a route setup node, and until now
+// nothing on the reward site said anything about them. The transport and uptime
+// views describe what the network is made of; the setup nodes describe whether a
+// route across it can actually be established. A setup node refusing nearly
+// every request — circuit breakers open, destinations unreachable — leaves no
+// mark on any existing chart: the transports are still registered, the visors
+// are still online, and routing is simply not working.
+//
+// The nodes are enumerated from the deployment's route_setup_nodes list rather
+// than hardcoded (that list is NOT transport_setup, which is a different set of
+// keys for a different job), and a node that does not answer is drawn as an
+// explicit unreachable row. Silently omitting it would make a dead setup node
+// look like a deployment that has one fewer.
+package clirewardsserver
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/guptarohit/asciigraph"
+
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/router/setupmetrics"
+)
+
+// snNode is one route setup node's /stats snapshot, or the reason it has none.
+type snNode struct {
+	PK string
+	// Err is set when the node did not answer. The row is still drawn.
+	Err  string
+	Snap setupmetrics.StatsSnapshot
+	// DestsTracked and DestsBreakerOpen summarize the per-destination table.
+	// The destinations themselves cannot be named: the setup node's /stats
+	// handler deliberately blanks every PK in top_destinations,
+	// top_failed_destinations and recent_failures so the endpoint does not
+	// leak network topology. The counts are still a measurement; the names
+	// are simply not on the wire.
+	DestsTracked     int
+	DestsBreakerOpen int
+}
+
+type snStats struct {
+	Nodes []snNode
+}
+
+// gatherSetupNodeStats reads /stats from every configured route setup node.
+// Concurrently: the dmsg HTTP client's timeout is 45s and an unreachable node
+// spends all of it, which would otherwise be paid once per node in series.
+// As with every other source here, a failure is recorded, never returned.
+func gatherSetupNodeStats() snStats {
+	pks := deployment.Prod.RouteSetupNodes
+	if len(pks) == 0 {
+		return snStats{}
+	}
+	nodes := make([]snNode, len(pks))
+	var wg sync.WaitGroup
+	for i, pk := range pks {
+		nodes[i].PK = pk.Hex()
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			url := fmt.Sprintf("dmsg://%s:%d/stats", nodes[i].PK, dmsg.DefaultDmsgHTTPPort)
+			if err := statsGetJSON(url, &nodes[i].Snap); err != nil {
+				nodes[i].Err = err.Error()
+				return
+			}
+			seen := make(map[string]bool)
+			for _, d := range nodes[i].Snap.TopDestinations {
+				nodes[i].DestsTracked++
+				if d.Circuit != "" && d.Circuit != string(setupmetrics.CircuitClosed) {
+					nodes[i].DestsBreakerOpen++
+				}
+				seen[d.PK] = true
+			}
+			// top_failed_destinations is a re-ranking of the same table, so it
+			// adds nothing to the count — except that both are PK-blanked, so
+			// they cannot be de-duplicated by key and only the larger of the
+			// two is a defensible count.
+			if n := len(nodes[i].Snap.TopFailedDestinations); n > nodes[i].DestsTracked {
+				nodes[i].DestsTracked = n
+			}
+		}(i)
+	}
+	wg.Wait()
+	return snStats{Nodes: nodes}
+}
+
+// tuiDuration renders an uptime in the largest two units that are non-zero.
+func tuiDuration(sec int64) string {
+	if sec < 0 {
+		sec = 0
+	}
+	d, h, m := sec/86400, (sec%86400)/3600, (sec%3600)/60
+	switch {
+	case d > 0:
+		return fmt.Sprintf("%dd %dh", d, h)
+	case h > 0:
+		return fmt.Sprintf("%dh %dm", h, m)
+	case m > 0:
+		return fmt.Sprintf("%dm %ds", m, sec%60)
+	default:
+		return fmt.Sprintf("%ds", sec)
+	}
+}
+
+// renderSetupNodePanelANSI draws the route-setup control plane: volume and
+// outcome, latency percentiles, failures by reason, and route length.
+func renderSetupNodePanelANSI(s snStats) string {
+	width := tuiWidth
+	if len(s.Nodes) == 0 {
+		return tuiMissing("ROUTE SETUP NODES", "no route setup nodes configured") + "\n"
+	}
+	var b strings.Builder
+	b.WriteString(renderSNOutcomeANSI(s, width))
+	b.WriteString(renderSNLatencyANSI(s, width))
+	b.WriteString(renderSNFailuresANSI(s, width))
+	b.WriteString(renderSNRouteLenANSI(s, width))
+	return b.String()
+}
+
+// renderSNOutcomeANSI draws request volume and the success rate per node.
+func renderSNOutcomeANSI(s snStats, width int) string {
+	var b strings.Builder
+	b.WriteString(tuiRule("ROUTE SETUP NODES — requests & outcome", width))
+	reachable, stripped := 0, false
+	for _, n := range s.Nodes {
+		b.WriteString(fmt.Sprintf("  %s%s%s\n", aDim, n.PK, aReset))
+		if n.Err != "" {
+			// The reason is wrapped: a dmsg fetch error embeds the whole
+			// 66-character key in the URL it failed on, which alone is wider
+			// than the panel.
+			b.WriteString(fmt.Sprintf("    %sunreachable%s\n", aRed, aReset))
+			b.WriteString(tuiWrap("      " + n.Err))
+			continue
+		}
+		reachable++
+		snap := n.Snap
+		b.WriteString(fmt.Sprintf("    %sup%s %s  %s%d%s req  %s%d%s ok  %s%d%s fail  %s%d%s dropped  %s%d%s active\n",
+			aDim, aReset, tuiDuration(snap.UptimeSec),
+			aBold, snap.TotalRequests, aReset,
+			aGreen, snap.Successful, aReset,
+			aRed, snap.Failed, aReset,
+			aYellow, snap.ConcurrencyDrops, aReset,
+			aCyan, snap.ActiveRequests, aReset))
+		// A zero-request node draws no rate bar. A 0% success rate over zero
+		// attempts is not a failing node, it is an idle one, and a red empty
+		// bar would report the first while measuring the second.
+		if snap.TotalRequests == 0 {
+			b.WriteString(fmt.Sprintf("    %sno route-setup requests recorded in this uptime window%s\n", aDim, aReset))
+		} else {
+			frac := snap.SuccessRatePct / 100
+			col := aRed
+			switch {
+			case snap.SuccessRatePct >= 90:
+				col = aGreen
+			case snap.SuccessRatePct >= 50:
+				col = aYellow
+			}
+			b.WriteString(fmt.Sprintf("    %ssuccess%s %s %s%5.1f%%%s\n",
+				aDim, aReset, tuiBar(frac, 24, col), col, snap.SuccessRatePct, aReset))
+		}
+		if n.DestsTracked > 0 {
+			stripped = true
+			col := aDim
+			if n.DestsBreakerOpen > 0 {
+				col = aRed
+			}
+			b.WriteString(fmt.Sprintf("    %s%d destinations tracked · %s%d with the circuit breaker not closed%s\n",
+				aDim, n.DestsTracked, col, n.DestsBreakerOpen, aReset))
+		}
+	}
+	b.WriteString(tuiWrap(fmt.Sprintf("  %d of %d configured route setup nodes answered.",
+		reachable, len(s.Nodes))))
+	if stripped {
+		b.WriteString(tuiWrap("  Destination public keys are blanked by the setup node's own /stats " +
+			"handler so the endpoint does not leak network topology, so hot and failing " +
+			"destinations are counted here but cannot be named."))
+	}
+	b.WriteString(tuiClose(width))
+	b.WriteString("\n")
+	return b.String()
+}
+
+// renderSNLatencyANSI draws the successful-setup latency percentiles. Scaled to
+// the node's own max, so the ladder reads as a shape rather than five numbers.
+func renderSNLatencyANSI(s snStats, width int) string {
+	var b strings.Builder
+	b.WriteString(tuiRule("ROUTE SETUP LATENCY — successful setups", width))
+	var curves []string
+	drew := false
+	for _, n := range s.Nodes {
+		if n.Err != "" {
+			continue
+		}
+		drew = true
+		l := n.Snap.LatencyMs
+		b.WriteString(fmt.Sprintf("  %s%s%s\n", aDim, n.PK, aReset))
+		if l.Count == 0 {
+			// No successful setup means no sample. A ladder of zeroes here
+			// would read as "every setup completed instantly".
+			b.WriteString(fmt.Sprintf("    %sno successful setups recorded — no latency samples%s\n", aDim, aReset))
+			continue
+		}
+		maxMs := l.Max
+		if maxMs <= 0 {
+			maxMs = 1
+		}
+		for _, row := range []struct {
+			name string
+			v    int64
+		}{{"min", l.Min}, {"p50", l.P50}, {"p95", l.P95}, {"p99", l.P99}, {"max", l.Max}} {
+			frac := float64(row.v) / float64(maxMs)
+			col := aGreen
+			switch {
+			case row.v >= 5000:
+				col = aRed
+			case row.v >= 1000:
+				col = aYellow
+			}
+			b.WriteString(fmt.Sprintf("    %s%-3s%s %s %s%6d ms%s\n",
+				aDim, row.name, aReset, tuiBar(frac, 24, col), aBold, row.v, aReset))
+		}
+		b.WriteString(fmt.Sprintf("    %s%d samples · mean %d ms%s\n", aDim, l.Count, l.Mean, aReset))
+		// The percentile curve is only a curve once the percentiles are drawn
+		// from distinct samples. Below ten, p95 and p99 land on the same
+		// element and the plot draws a step that is an artifact of the ring
+		// size, not of the network.
+		if l.Count >= 10 {
+			curves = append(curves, tuiPlot("ROUTE SETUP LATENCY — percentile curve (ms)",
+				[]float64{float64(l.Min), float64(l.P50), float64(l.P95), float64(l.P99), float64(l.Max)},
+				[]string{"min", "p50", "p95", "p99", "max"}, 7, 0, asciigraph.Yellow, width,
+				fmt.Sprintf("%s · %d samples", n.PK, l.Count)))
+		}
+	}
+	if !drew {
+		return tuiMissing("ROUTE SETUP LATENCY", "no route setup node answered") + "\n"
+	}
+	b.WriteString(tuiClose(width))
+	b.WriteString("\n")
+	for _, c := range curves {
+		b.WriteString(c)
+	}
+	return b.String()
+}
+
+// renderSNFailuresANSI breaks the failures down by reason. This is the panel
+// that distinguishes "the destination is down" from "this setup node is the
+// problem": source_unreachable and concurrency_limit are the node's own,
+// destination_rules and circuit_open are the network's.
+func renderSNFailuresANSI(s snStats, width int) string {
+	var b strings.Builder
+	b.WriteString(tuiRule("ROUTE SETUP FAILURES — by reason", width))
+	drew := false
+	for _, n := range s.Nodes {
+		if n.Err != "" {
+			continue
+		}
+		drew = true
+		b.WriteString(fmt.Sprintf("  %s%s%s\n", aDim, n.PK, aReset))
+		total := uint64(0)
+		for _, v := range n.Snap.FailuresByReason {
+			total += v
+		}
+		if total == 0 {
+			if n.Snap.TotalRequests == 0 {
+				b.WriteString(fmt.Sprintf("    %sno requests recorded — nothing to classify%s\n", aDim, aReset))
+			} else {
+				b.WriteString(fmt.Sprintf("    %sno failures recorded across %d requests%s\n",
+					aGreen, n.Snap.TotalRequests, aReset))
+			}
+			continue
+		}
+		type reasonRow struct {
+			name string
+			n    uint64
+		}
+		rows := make([]reasonRow, 0, len(n.Snap.FailuresByReason))
+		for r, v := range n.Snap.FailuresByReason {
+			rows = append(rows, reasonRow{string(r), v})
+		}
+		sort.Slice(rows, func(i, j int) bool {
+			if rows[i].n != rows[j].n {
+				return rows[i].n > rows[j].n
+			}
+			return rows[i].name < rows[j].name
+		})
+		for _, r := range rows {
+			frac := float64(r.n) / float64(total)
+			b.WriteString(fmt.Sprintf("    %s%-24s%s %s%5d%s %s %s%5.1f%%%s\n",
+				aRed, r.name, aReset, aBold, r.n, aReset,
+				tuiBar(frac, 20, aRed), aDim, 100*frac, aReset))
+		}
+	}
+	if !drew {
+		return tuiMissing("ROUTE SETUP FAILURES", "no route setup node answered") + "\n"
+	}
+	b.WriteString(tuiClose(width))
+	b.WriteString("\n")
+	return b.String()
+}
+
+// renderSNRouteLenANSI draws the hop-count histogram of successful setups. It
+// counts successes only, so a node failing everything has an empty histogram
+// and says so rather than drawing a bar chart of nothing.
+func renderSNRouteLenANSI(s snStats, width int) string {
+	var b strings.Builder
+	b.WriteString(tuiRule("ROUTE SETUP ROUTE LENGTH — hops per successful setup", width))
+	drew := false
+	for _, n := range s.Nodes {
+		if n.Err != "" {
+			continue
+		}
+		drew = true
+		b.WriteString(fmt.Sprintf("  %s%s%s\n", aDim, n.PK, aReset))
+		hist := n.Snap.RouteLengthHist
+		if len(hist) == 0 {
+			b.WriteString(fmt.Sprintf("    %sno successful setups recorded — no route lengths sampled%s\n",
+				aDim, aReset))
+			continue
+		}
+		hops := make([]int, 0, len(hist))
+		total, maxN := uint64(0), uint64(0)
+		for h, v := range hist {
+			hops = append(hops, h)
+			total += v
+			if v > maxN {
+				maxN = v
+			}
+		}
+		sort.Ints(hops)
+		if maxN == 0 {
+			maxN = 1
+		}
+		for _, h := range hops {
+			v := hist[h]
+			pct := 0.0
+			if total > 0 {
+				pct = 100 * float64(v) / float64(total)
+			}
+			b.WriteString(fmt.Sprintf("    %s%2d hop%s %s%5d%s %s %s%5.1f%%%s\n",
+				aCyan, h, aReset, aBold, v, aReset,
+				tuiBar(float64(v)/float64(maxN), 24, aCyan), aDim, pct, aReset))
+		}
+	}
+	if !drew {
+		return tuiMissing("ROUTE SETUP ROUTE LENGTH", "no route setup node answered") + "\n"
+	}
+	b.WriteString(tuiClose(width))
+	b.WriteString("\n")
+	return b.String()
+}

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_sn_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_sn_test.go
@@ -1,0 +1,234 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/stats_tui_sn_test.go c5-reward-server
+package clirewardsserver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/router/setupmetrics"
+)
+
+const (
+	snPKa = "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
+	snPKb = "024fbd3997d4260f731b01abcfce60b8967a6d4c6a11d1008812810ea1437ce438"
+)
+
+// snSample mirrors the shape a live setup node returned on 2026-09-05.
+func snSample() snStats {
+	return snStats{Nodes: []snNode{{
+		PK: snPKa,
+		Snap: setupmetrics.StatsSnapshot{
+			UptimeSec: 7320, TotalRequests: 63, Successful: 4, Failed: 59,
+			ConcurrencyDrops: 0, ActiveRequests: 0, SuccessRatePct: 6.349206349206349,
+			FailuresByReason: map[setupmetrics.FailureReason]uint64{
+				setupmetrics.ReasonCircuitOpen:             46,
+				setupmetrics.ReasonDestinationRules:        10,
+				setupmetrics.ReasonIntermediateUnreachable: 3,
+			},
+			LatencyMs: setupmetrics.LatencyStats{
+				Count: 4, Min: 1170, Max: 5110, Mean: 2821, P50: 1910, P95: 3097, P99: 3097,
+			},
+			RouteLengthHist: map[int]uint64{1: 4},
+			// PKs arrive blank: the setup node strips them before marshaling.
+			TopDestinations: []setupmetrics.DestStat{
+				{Total: 44, Failed: 40, Circuit: "closed"},
+				{Total: 18, Failed: 16, Circuit: "closed"},
+				{Total: 0, Failed: 0, Circuit: "open"},
+			},
+		},
+		DestsTracked: 3, DestsBreakerOpen: 1,
+	}, {
+		PK:  snPKb,
+		Err: "request failed: context deadline exceeded",
+	}}}
+}
+
+// An unreachable setup node must be an explicit row. Dropping it makes a dead
+// node indistinguishable from a deployment that has one fewer.
+func TestSetupNodePanelDrawsUnreachableNodesExplicitly(t *testing.T) {
+	out := renderSetupNodePanelANSI(snSample())
+	if !strings.Contains(out, snPKb) {
+		t.Fatal("the unreachable node was omitted from the panel")
+	}
+	if !strings.Contains(out, "unreachable") {
+		t.Error("the unreachable node was not labeled")
+	}
+	if !strings.Contains(out, "context deadline exceeded") {
+		t.Error("the reason the node did not answer was not surfaced")
+	}
+	if !strings.Contains(out, "1 of 2 configured route setup nodes answered") {
+		t.Error("the reachable-node count is wrong or missing")
+	}
+}
+
+// Public keys are never truncated: an operator matching a node against their
+// own config needs the whole key.
+func TestSetupNodePanelPrintsFullPublicKeys(t *testing.T) {
+	out := renderSetupNodePanelANSI(snSample())
+	for _, pk := range []string{snPKa, snPKb} {
+		if !strings.Contains(out, pk) {
+			t.Errorf("public key %s is not present in full", pk)
+		}
+	}
+}
+
+// The four required readings: volume and rate, percentiles, failure reasons,
+// route length.
+func TestSetupNodePanelRendersEveryRequiredReading(t *testing.T) {
+	out := renderSetupNodePanelANSI(snSample())
+	for _, want := range []string{
+		"ROUTE SETUP NODES", "ROUTE SETUP LATENCY", "ROUTE SETUP FAILURES",
+		"ROUTE SETUP ROUTE LENGTH",
+		"63", "6.3%", // volume and success rate
+		"1910", "3097", "5110", // p50, p95/p99, max
+		"circuit_open", "destination_rules", "intermediate_unreachable",
+		"1 hop",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("panel is missing %q", want)
+		}
+	}
+}
+
+// The setup node blanks destination PKs on purpose. The panel must say so
+// rather than printing an unexplained table of nameless destinations.
+func TestSetupNodePanelSaysDestinationKeysAreStripped(t *testing.T) {
+	out := renderSetupNodePanelANSI(snSample())
+	if !strings.Contains(out, "3 destinations tracked") {
+		t.Error("the tracked-destination count is missing")
+	}
+	if !strings.Contains(out, "1 with the circuit breaker not closed") {
+		t.Error("the open-breaker count is missing")
+	}
+	if !strings.Contains(out, "blanked") {
+		t.Error("the panel does not explain that destination keys are unavailable")
+	}
+}
+
+// An idle node has a 0% success rate over zero attempts. That is not a failing
+// node, and a full-width red bar reporting it as one is the misleading-empty-
+// chart failure this panel is supposed to avoid.
+func TestSetupNodePanelDoesNotDrawARateForZeroRequests(t *testing.T) {
+	out := renderSetupNodePanelANSI(snStats{Nodes: []snNode{{PK: snPKa}}})
+	if !strings.Contains(out, "no route-setup requests recorded") {
+		t.Error("an idle node did not say it had recorded no requests")
+	}
+	if strings.Contains(out, "0.0%") {
+		t.Error("a percentage was drawn over zero attempts")
+	}
+	if !strings.Contains(out, "no successful setups recorded — no latency samples") {
+		t.Error("an empty latency ring was not named")
+	}
+	if !strings.Contains(out, "no route lengths sampled") {
+		t.Error("an empty route-length histogram was not named")
+	}
+	if !strings.Contains(out, "nothing to classify") {
+		t.Error("an empty failure breakdown was not named")
+	}
+}
+
+// Below ten samples p95 and p99 land on the same ring element, so the
+// percentile plot draws a step that is an artifact of the ring size. The
+// ladder still renders; only the curve is withheld.
+func TestSetupNodePanelWithholdsThePercentileCurveOnATinySample(t *testing.T) {
+	out := renderSetupNodePanelANSI(snSample()) // Count == 4
+	if strings.Contains(out, "percentile curve") {
+		t.Error("a percentile curve was plotted from four samples")
+	}
+	if !strings.Contains(out, "4 samples") {
+		t.Error("the sample count is not stated")
+	}
+
+	s := snSample()
+	s.Nodes[0].Snap.LatencyMs.Count = 240
+	out = renderSetupNodePanelANSI(s)
+	if !strings.Contains(out, "percentile curve") {
+		t.Error("the curve was withheld from a sample large enough to draw one")
+	}
+}
+
+// No node at all is a configuration statement, not an empty panel.
+func TestSetupNodePanelNeverSilentlyEmpty(t *testing.T) {
+	out := renderSetupNodePanelANSI(snStats{})
+	if !strings.Contains(out, "ROUTE SETUP NODES") || !strings.Contains(out, "unavailable") {
+		t.Error("an empty panel disappeared instead of reporting itself absent")
+	}
+}
+
+// Every node dead must still name the sections rather than dropping three of
+// the four panels.
+func TestSetupNodePanelNamesSectionsWhenEveryNodeIsDead(t *testing.T) {
+	out := renderSetupNodePanelANSI(snStats{Nodes: []snNode{{PK: snPKa, Err: "status 502"}}})
+	for _, want := range []string{
+		"ROUTE SETUP LATENCY", "ROUTE SETUP FAILURES", "ROUTE SETUP ROUTE LENGTH",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("section %q vanished when every node was unreachable", want)
+		}
+	}
+	if strings.Count(out, "no route setup node answered") != 3 {
+		t.Error("the three data sections did not each say why they are empty")
+	}
+}
+
+// The panel is 78 columns and its explanatory lines are sentences. An
+// unwrapped one runs off the rule in the 80-column target.
+func TestSetupNodePanelStaysWithinTheRule(t *testing.T) {
+	s := snSample()
+	s.Nodes[0].Snap.LatencyMs.Count = 240
+	s.Nodes[0].Snap.FailuresByReason[setupmetrics.ReasonIntermediaryRules] = 999999
+	s.Nodes[0].Snap.RouteLengthHist[12] = 4000000
+	// A real dmsg fetch error embeds the full 66-character key in the URL it
+	// failed on, so the reason alone is wider than the panel.
+	s.Nodes[1].Err = `Get "dmsg://` + snPKb + `:80/stats": EOF`
+	for _, line := range strings.Split(renderSetupNodePanelANSI(s), "\n") {
+		// Columns, not bytes: the rules are box-drawing runes.
+		plain := []rune(stripANSI(line))
+		if len(plain) > tuiWidth+2 {
+			t.Errorf("line runs to %d columns: %q", len(plain), string(plain))
+		}
+	}
+}
+
+// The node list comes from route_setup_nodes, NOT transport_setup — a
+// different set of keys for a different job. Confusing the two would render
+// the transport setup nodes under a route-setup heading.
+func TestGatherSetupNodeStatsEnumeratesTheConfiguredRouteSetupNodes(t *testing.T) {
+	// No dmsg client in the test binary, so every fetch fails; what is under
+	// test is the enumeration and that failures become rows.
+	got := gatherSetupNodeStats()
+	if len(got.Nodes) == 0 {
+		t.Fatal("no route setup nodes enumerated from the deployment config")
+	}
+	for _, n := range got.Nodes {
+		if len(n.PK) != 66 {
+			t.Errorf("node key %q is not a full public key", n.PK)
+		}
+	}
+	if len(got.Nodes) != len(deployment.Prod.RouteSetupNodes) {
+		t.Error("the enumerated node count does not match route_setup_nodes")
+	}
+	// transport_setup is a different list for a different job; the panel must
+	// not be enumerating it.
+	for _, n := range got.Nodes {
+		for _, tsn := range deployment.Prod.TransportSetupPKs {
+			if n.PK == tsn.Hex() {
+				t.Errorf("transport setup node %s was enumerated as a route setup node", n.PK)
+			}
+		}
+	}
+}
+
+func TestTuiDurationPicksTheTopTwoUnits(t *testing.T) {
+	for _, c := range []struct {
+		sec  int64
+		want string
+	}{
+		{0, "0s"}, {45, "45s"}, {125, "2m 5s"}, {7320, "2h 2m"}, {200000, "2d 7h"}, {-5, "0s"},
+	} {
+		if got := tuiDuration(c.sec); got != c.want {
+			t.Errorf("tuiDuration(%d) = %q, want %q", c.sec, got, c.want)
+		}
+	}
+}

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_test.go
@@ -36,6 +36,7 @@ func TestRenderStatsANSIEmitsColor(t *testing.T) {
 	for _, want := range []string{
 		"NETWORK", "BANDWIDTH", "LATENCY", "VISORS ONLINE", "TRANSPORTS BY TYPE",
 		"VERSION ADOPTION", "TRANSPORTS PER VISOR", "ARCHITECTURE", "UPTIME TIMELINE",
+		"ROUTE SETUP NODES",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("panel %q missing", want)
@@ -49,7 +50,7 @@ func TestRenderStatsANSIEmitsColor(t *testing.T) {
 // "nothing even attempted to fetch it" case.
 func TestRenderStatsANSINamesTheNewPanelsWhenUnpopulated(t *testing.T) {
 	out := RenderStatsANSI(sampleTUIData())
-	for _, title := range []string{"TRANSPORTS PER VISOR", "ARCHITECTURE", "UPTIME TIMELINE"} {
+	for _, title := range []string{"TRANSPORTS PER VISOR", "ARCHITECTURE", "UPTIME TIMELINE", "ROUTE SETUP NODES"} {
 		i := strings.Index(out, title)
 		if i < 0 {
 			t.Fatalf("panel %q vanished instead of reporting itself absent", title)
@@ -126,6 +127,29 @@ func TestTUIXAxisPlacesLabels(t *testing.T) {
 	}
 	if got := tuiXAxis(nil, 60, 8); got != "" {
 		t.Errorf("expected empty axis for no labels, got %q", got)
+	}
+}
+
+// A token wider than the panel has no space to break at. Wrapping must split
+// it rather than let it run past the rule — and must not drop the overflow,
+// because the token that does this in practice is a dmsg URL carrying a whole
+// public key.
+func TestTUIWrapBreaksATokenWiderThanThePanel(t *testing.T) {
+	pk := "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
+	out := tuiWrap(`      Get "dmsg://` + pk + `:80/stats": EOF`)
+	var joined string
+	for _, line := range strings.Split(out, "\n") {
+		plain := stripANSI(line)
+		if len([]rune(plain)) > tuiWidth {
+			t.Errorf("line runs to %d columns: %q", len([]rune(plain)), plain)
+		}
+		joined += strings.TrimSpace(plain)
+	}
+	if !strings.Contains(joined, pk) {
+		t.Error("the public key did not survive the wrap intact")
+	}
+	if !strings.Contains(joined, "EOF") {
+		t.Error("text after the over-long token was dropped")
 	}
 }
 


### PR DESCRIPTION
Every route in the network is negotiated by a route setup node, and the statistics page said nothing about them. A setup node refusing setups leaves no mark on any existing chart: the transports stay registered and the visors stay online while routing across them quietly stops working.

The panel reads each node's `/stats` over the reward server's own dmsg client — that endpoint is not survey-gated, only `/debug/*` on the same listener is — enumerating nodes from the deployment's `route_setup_nodes` rather than a hardcoded key. It draws request volume and success rate, the successful-setup latency percentiles, failures by reason, and the route-length histogram. A node that does not answer is an explicit unreachable row, and every empty sample says why rather than drawing a zeroed chart: a 0% success rate over zero attempts is an idle node, not a failing one. Destination public keys are blanked by the setup node's own handler, so destinations are counted but the panel says plainly that they cannot be named.

Two shared-helper fixes fall out of it: `tuiWrap` now breaks a token wider than the panel instead of letting it overrun the rule, and `tuiPlot` wraps its footer for the same reason `tuiSource` already did — a dmsg fetch error carries a whole public key in the URL it failed on. Verified live against both production setup nodes (one answering with 256 requests / 42 successes, one freshly restarted at zero, and on an earlier pass one unreachable); `go build .`, package tests, and both lint tiers repo-wide are clean.