### PR TITLE
fix(router): RemoteThroughput returned garbage for a zero-width window

### DIFF
--- a/pkg/router/network_stats.go
+++ b/pkg/router/network_stats.go
@@ -2,6 +2,7 @@
 package router
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -69,14 +70,44 @@ func (s *networkStats) AddBandwidthReceived(amount uint64) {
 }
 
 func (s *networkStats) RemoteThroughput() int64 {
+	return s.remoteThroughputAt(time.Now().UTC())
+}
+
+// remoteThroughputAt is RemoteThroughput with the sampling instant injected, so
+// the zero-width and backwards-clock windows can be tested deterministically
+// instead of racing the real clock.
+func (s *networkStats) remoteThroughputAt(now time.Time) int64 {
+
 	s.bandwidthReceivedRecStartMu.Lock()
-	timePassed := time.Now().UTC().Sub(s.bandwidthReceivedRecStart)
-	s.bandwidthReceivedRecStart = time.Now().UTC()
+	timePassed := now.Sub(s.bandwidthReceivedRecStart)
+	// Only open a new sampling window when this one had measurable width. Two
+	// calls inside a single clock tick — routine on Windows, whose timer
+	// granularity is coarse — would otherwise both divide by zero AND discard
+	// the bytes counted so far. Leaving the start time and the accumulator
+	// alone lets the next call measure the wider window instead.
+	if timePassed > 0 {
+		s.bandwidthReceivedRecStart = now
+	}
 	s.bandwidthReceivedRecStartMu.Unlock()
 
-	bandwidth := atomic.SwapUint64(&s.bandwidthReceived, 0)
+	if timePassed <= 0 {
+		return 0
+	}
 
+	bandwidth := atomic.SwapUint64(&s.bandwidthReceived, 0)
 	throughput := float64(bandwidth) / timePassed.Seconds()
+
+	// Go leaves float64->int64 UNDEFINED for NaN and for values outside int64's
+	// range; on amd64 it yields math.MinInt64. A zero-width window therefore used
+	// to report a large NEGATIVE throughput, and this value does not stay local:
+	// it is written into the ping packet sent to the peer (MakePingPacket), so
+	// the garbage propagated into the remote's view of the leg.
+	if math.IsNaN(throughput) || throughput <= 0 {
+		return 0
+	}
+	if throughput >= math.MaxInt64 {
+		return math.MaxInt64
+	}
 
 	return int64(throughput)
 }

--- a/pkg/router/network_stats_throughput_test.go
+++ b/pkg/router/network_stats_throughput_test.go
@@ -1,0 +1,79 @@
+package router
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRemoteThroughputZeroWindow is the regression guard: sampling twice inside
+// one clock tick left timePassed == 0, and float64->int64 is undefined in Go for
+// the resulting Inf/NaN — on amd64 it yields math.MinInt64. That value is not
+// local; it goes into the ping packet sent to the peer, so a nonsense negative
+// throughput propagated into the remote's view of the leg. Windows CI hits this
+// deterministically because its timer granularity is coarse.
+func TestRemoteThroughputZeroWindow(t *testing.T) {
+	s := &networkStats{}
+	now := time.Now().UTC()
+	s.bandwidthReceivedRecStart = now
+
+	// Bytes counted, but no time has passed: the +Inf case.
+	atomic.StoreUint64(&s.bandwidthReceived, 4096)
+	if got := s.remoteThroughputAt(now); got != 0 {
+		t.Errorf("zero-width window with traffic returned %d, want 0", got)
+	}
+
+	// No bytes and no time: the NaN case.
+	atomic.StoreUint64(&s.bandwidthReceived, 0)
+	if got := s.remoteThroughputAt(now); got != 0 {
+		t.Errorf("zero-width window with no traffic returned %d, want 0", got)
+	}
+}
+
+// TestRemoteThroughputZeroWindowKeepsBytes pins that an unmeasurable sample does
+// not silently discard the bytes counted so far — the next real window must
+// still see them, or a fast poller would zero out the accumulator forever.
+func TestRemoteThroughputZeroWindowKeepsBytes(t *testing.T) {
+	s := &networkStats{}
+	start := time.Now().UTC()
+	s.bandwidthReceivedRecStart = start
+
+	atomic.StoreUint64(&s.bandwidthReceived, 1000)
+	if got := s.remoteThroughputAt(start); got != 0 {
+		t.Fatalf("zero-width window returned %d, want 0", got)
+	}
+	if got := atomic.LoadUint64(&s.bandwidthReceived); got != 1000 {
+		t.Fatalf("zero-width window consumed the accumulator: %d bytes left, want 1000", got)
+	}
+
+	// One second later the same bytes must be reported as throughput.
+	if got := s.remoteThroughputAt(start.Add(time.Second)); got != 1000 {
+		t.Errorf("throughput over a 1s window = %d, want 1000", got)
+	}
+}
+
+// TestRemoteThroughputBackwardsClock covers an NTP step: a negative window must
+// not produce a negative throughput.
+func TestRemoteThroughputBackwardsClock(t *testing.T) {
+	s := &networkStats{}
+	now := time.Now().UTC()
+	s.bandwidthReceivedRecStart = now.Add(time.Second) // start is in the future
+
+	atomic.StoreUint64(&s.bandwidthReceived, 4096)
+	if got := s.remoteThroughputAt(now); got != 0 {
+		t.Errorf("backwards clock returned %d, want 0", got)
+	}
+}
+
+// TestRemoteThroughputNormalWindow keeps the ordinary path honest.
+func TestRemoteThroughputNormalWindow(t *testing.T) {
+	s := &networkStats{}
+	start := time.Now().UTC()
+	s.bandwidthReceivedRecStart = start
+
+	atomic.StoreUint64(&s.bandwidthReceived, 8192)
+	got := s.remoteThroughputAt(start.Add(2 * time.Second))
+	if got != 4096 {
+		t.Errorf("throughput = %d, want 4096 (8192 bytes over 2s)", got)
+	}
+}


### PR DESCRIPTION
Go leaves `float64` -> `int64` conversion **undefined** for NaN and for values outside `int64`, and on amd64 it yields `math.MinInt64`. `RemoteThroughput` divided by `timePassed.Seconds()` with no guard, so two samples inside a single clock tick produced `+Inf` (bytes, no time) or `NaN` (no bytes, no time) and returned a large negative number.

That value does not stay local. It is passed to `routing.MakePingPacket` and sent to the peer, so a nonsense negative throughput propagated into the remote's view of the leg — and into `SetDownloadSpeed`, where the `uint32` truncation of `MinInt64` reads as 0. Windows CI hits this deterministically because its timer granularity is coarse, but the window is only ever *usually* non-zero on Linux, not guaranteed.

A zero-width or backwards window (an NTP step) now returns 0, and deliberately does **not** open a new sampling window — so the bytes counted so far are still there for the next real measurement rather than being swapped away by a poll that measured nothing. NaN and overflow are clamped explicitly. The sampling instant is injectable so the cases are tested without racing the clock; the tests fail against the old code.