### PR TITLE
fix(rewards): seed the deployment-service PKs so stats fetches resolve

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/robert-nix/ansihtml"
 
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
@@ -1836,7 +1837,12 @@ func serveStandalone(r1 *gin.Engine, bindAddr string) {
 	// the clearnet dmsg-discovery HTTP frontend is gone (404). StartDmsgEmbedded
 	// seeds from the embedded dmsg-server set and registers/resolves over dmsg,
 	// so this reward-over-dmsg listener becomes reachable by PK.
-	dmsgClient, stopDmsg, err := dmsgclient.StartDmsgEmbedded(ctx, log, pk, sk, false)
+	// Seed the deployment-service PKs. They publish no dmsg-discovery entry of
+	// their own (deliberate — it avoids a lookup round-trip per caller), so
+	// without seeding, every stats fetch to TPD failed with "dmsg error 100 -
+	// entry is not found in discovery" and the panels that had no CXO feed to
+	// fall back on rendered "unavailable" in production.
+	dmsgClient, stopDmsg, err := dmsgclient.StartDmsgEmbedded(ctx, log, pk, sk, false, rewardServicePKs()...)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to start DMSG client")
 	}
@@ -2037,3 +2043,36 @@ _nextskywireclilogrun() {
 	fi
 }
 `
+
+// rewardServicePKs are the deployment services the stats handlers dial over
+// dmsg. Seeding them keeps StartDmsgEmbedded's discovery upgrade (so the
+// reward-over-dmsg listener still publishes its own entry and stays dialable by
+// any visor) while removing the per-request discovery lookup for services that
+// never publish an entry.
+func rewardServicePKs() []cipher.PubKey {
+	var out []cipher.PubKey
+	seen := map[cipher.PubKey]bool{}
+	add := func(addr string) {
+		if addr == "" {
+			return
+		}
+		var pk cipher.PubKey
+		if err := pk.Set(pkFromDmsgAddr(addr)); err != nil || pk.Null() || seen[pk] {
+			return
+		}
+		seen[pk] = true
+		out = append(out, pk)
+	}
+	add(deployment.Prod.TransportDiscoveryDmsg)
+	add(deployment.Prod.ServiceDiscoveryDmsg)
+	add(deployment.Prod.AddressResolverDmsg)
+	add(deployment.Prod.RouteFinderDmsg)
+	add(deployment.Prod.DmsgDiscoveryDmsg)
+	for _, pk := range deployment.Prod.RouteSetupNodes {
+		if !pk.Null() && !seen[pk] {
+			seen[pk] = true
+			out = append(out, pk)
+		}
+	}
+	return out
+}

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_coverage.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_coverage.go
@@ -71,12 +71,18 @@ func gatherServiceCoverage() coverageStats {
 
 	// Only the dmsg-addressed services: a clearnet service has no dmsg
 	// sessions to account for.
+	//
+	// The uptime tracker is NOT listed: it is TPD-integrated (CXO-backed v3), so
+	// there is no standalone tracker to probe. deployment.Prod.UptimeTrackerDmsg
+	// still names the retired standalone service, and probing it reported
+	// "unreachable ... entry is not found in discovery" on every page load — an
+	// alarming red row for a service that is not supposed to exist. Uptime
+	// reachability is covered by the transport-discovery entry above.
 	for _, s := range []struct{ name, url string }{
 		{"transport-discovery", deployment.Prod.TransportDiscoveryDmsg},
 		{"service-discovery", deployment.Prod.ServiceDiscoveryDmsg},
 		{"address-resolver", deployment.Prod.AddressResolverDmsg},
 		{"route-finder", deployment.Prod.RouteFinderDmsg},
-		{"uptime-tracker", deployment.Prod.UptimeTrackerDmsg},
 		{"dmsg-discovery", deployment.Prod.DmsgDiscoveryDmsg},
 	} {
 		if s.url == "" {

--- a/pkg/dmsg/dmsgclient/seeded.go
+++ b/pkg/dmsg/dmsgclient/seeded.go
@@ -168,12 +168,18 @@ func StartDmsgSeeded(ctx context.Context, log *logging.Logger, pk cipher.PubKey,
 	return direct.StartDmsgWithSetup(ctx, log, pk, sk, dClient, conf, beforeServe)
 }
 
+// Optional servicePKs are seeded as delegated entries, exactly as
+// StartDmsgEmbeddedForServices does, but WITHOUT giving up the discovery
+// upgrade — so the caller still publishes its own entry and stays dialable.
+// Deployment services publish no dmsg-discovery entry of their own by design,
+// so a caller that dials them must seed them or every request pays a lookup
+// that answers "entry is not found in discovery".
 // StartDmsgEmbedded starts a dmsg client seeded from the embedded production
 // dmsg-server set (dmsg.Prod.DmsgServers) and with discovery over dmsg
 // (deployment.Prod.DmsgDiscoveryDmsg) — a self-contained, clearnet-free dmsg
 // bootstrap for native standalone tools (e.g. the reward UI) on a dmsg-only
 // deployment, where the clearnet HTTP discovery is gone. preferWS=false uses TCP.
-func StartDmsgEmbedded(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey, preferWS bool) (*dmsg.Client, func(), error) {
+func StartDmsgEmbedded(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey, preferWS bool, servicePKs ...cipher.PubKey) (*dmsg.Client, func(), error) {
 	servers := dmsg.Prod.DmsgServers
 	if len(servers) == 0 {
 		return nil, nil, errors.New("dmsg: no embedded dmsg servers in deployment config")
@@ -182,7 +188,7 @@ func StartDmsgEmbedded(ctx context.Context, log *logging.Logger, pk cipher.PubKe
 	for i := range servers {
 		seeds[i] = &servers[i]
 	}
-	return StartDmsgSeeded(ctx, log, pk, sk, seeds, deployment.Prod.DmsgDiscoveryDmsg, preferWS)
+	return StartDmsgSeeded(ctx, log, pk, sk, seeds, deployment.Prod.DmsgDiscoveryDmsg, preferWS, servicePKs...)
 }
 
 // StartDmsgEmbeddedForServices starts an embedded-seed dmsg client that talks


### PR DESCRIPTION
Four panels on https://haltingstate.net/stats render "unavailable" in production, all from one cause:

```
TRANSPORTS PER VISOR: TPD per-key request failed: Get "dmsg://02b307...:80/all-transports/per-key-stats":
  dmsg error 100 - entry is not found in discovery
```

Deployment services publish no dmsg-discovery entry — deliberate, so callers do not pay a lookup round-trip. The reward server started its dmsg client with `StartDmsgEmbedded`, which seeds no service PKs, so every stats fetch did a discovery lookup for a service that never answers one. The split is visible on the page: everything sourced from CXO renders (`source: CXO stats/network`), everything still on HTTP-over-dmsg fails.

`StartDmsgEmbeddedForServices` exists for this but is the wrong tool here — it drops the discovery upgrade, and the reward server must keep publishing its own entry to stay dialable as the reward-over-dmsg listener. So `StartDmsgEmbedded` now takes optional `servicePKs` and seeds them while keeping registration; existing callers are unaffected.

Separately, the service-reachability panel probed `deployment.Prod.UptimeTrackerDmsg` — the retired standalone tracker. Uptime is TPD-integrated (CXO-backed v3), so that row reported "unreachable, entry is not found in discovery" on every page load for a service that is not supposed to exist. Removed; TPD is already probed as transport-discovery.

Verified by build, package tests and both lint tiers. The panels can only be confirmed live once the reward server picks this up.