### PR TITLE
feat(dmsg): opt-in all-servers sweep for unregistered, unseeded peers

### DIFF
--- a/cmd/dmsg/dmsgcurl/commands/dmsgcurl.go
+++ b/cmd/dmsg/dmsgcurl/commands/dmsgcurl.go
@@ -42,6 +42,7 @@ var (
 	dmsgcurlOutput string
 	replace        bool
 	proxyAddr      string
+	anyServer      bool
 	dialer         = proxy.Direct //nolint unused
 	err            error
 )
@@ -56,6 +57,7 @@ func init() {
 	RootCmd.Flags().BoolVarP(&replace, "replace", "r", false, "replace existing file with new downloaded")
 	RootCmd.Flags().IntVarP(&dmsgcurlTries, "try", "t", 1, "download attempts (0 unlimits)")
 	RootCmd.Flags().IntVarP(&dmsgcurlWait, "wait", "w", 0, "time to wait between requests")
+	RootCmd.Flags().BoolVar(&anyServer, "any-server", false, "if the destination is in no discovery and was never seeded, try reaching it through every dmsg server (opens a session to each; off by default)")
 	RootCmd.Flags().StringVarP(&dmsgcurlAgent, "agent", "a", "dmsgcurl/"+buildinfo.Version(), "identify as `AGENT`")
 	if os.Getenv("DMSGCURL_SK") != "" {
 		sk.Set(os.Getenv("DMSGCURL_SK")) //nolint
@@ -141,6 +143,14 @@ var RootCmd = &cobra.Command{
 				Transport: transport,
 			}
 			ctx = context.WithValue(ctx, "socks5_proxy", proxyAddr) //nolint
+		}
+
+		// Opt into the all-servers sweep for this invocation only. The normal dial
+		// ladder reaches a destination that is in the discovery, was seeded, or sits
+		// on a server we already hold a session to; --any-server covers the
+		// remaining case by establishing a session to every server in turn.
+		if anyServer {
+			ctx = dmsg.WithServerSweep(ctx)
 		}
 
 		cErr = handleRequest(ctx, pk, sk, httpClient, parsedURL, dmsgcurlData)

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -3,6 +3,7 @@ package dmsg
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"net"
 	"sort"
@@ -64,6 +65,14 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 			defer fallbackCancel()
 			stream, err := ce.dialViaConnectedServers(fallbackCtx, addr)
 			if err == nil {
+				ce.dialFailClear(addr.PK)
+				return stream, nil
+			}
+		}
+		// Opt-in last resort: the destination is in no discovery and was never
+		// seeded, so nothing named a server for it. Sweep every server.
+		if serverSweepEnabled(ctx) {
+			if stream, sErr := ce.sweepNewSessions(ctx, addr); sErr == nil {
 				ce.dialFailClear(addr.PK)
 				return stream, nil
 			}
@@ -161,6 +170,15 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 		ce.setCachedRoute(addr.PK, srvPK)
 		ce.dialFailClear(addr.PK)
 		return stream, nil
+	}
+
+	// Opt-in last resort: the entry named servers but none of them worked — a
+	// stale entry listing servers the destination has since left. Sweep the rest.
+	if serverSweepEnabled(ctx) {
+		if stream, sErr := ce.sweepNewSessions(ctx, addr); sErr == nil {
+			ce.dialFailClear(addr.PK)
+			return stream, nil
+		}
 	}
 
 	// The whole ladder failed. Skip recording when the CALLER's context ran
@@ -614,4 +632,92 @@ func (ce *Client) ConnectionsSummary() ConnectionsSummary {
 	}
 
 	return out
+}
+
+// serverSweepKey is the context key that opts a single dial into the
+// all-servers sweep. Typed (not a bare string) so it cannot collide and so the
+// only way to set it is WithServerSweep.
+type serverSweepKey struct{}
+
+// WithServerSweep opts the dials made with the returned context into a
+// last-resort sweep: after the normal ladder fails, establish NEW sessions to
+// every server in the deployment and try the destination through each.
+//
+// This is deliberately OPT-IN and must stay that way. The automatic fallback
+// (dialViaConnectedServers) only reuses sessions this client already holds, so
+// it costs a yamux stream per server and nothing more. A sweep costs a full
+// Noise handshake per server. Firing that automatically on every failed
+// resolution would turn one typo'd or dead public key into a handshake storm
+// against the whole server fleet — and would defeat the dial-failure backoff
+// (Client.dialFail), which exists precisely because repeated failed dials are
+// expensive.
+//
+// It is for an operator dialing a key they know about out of band: a client
+// that is in no discovery, was never seeded, and sits on a server this client
+// holds no session to. That is the one case the normal ladder cannot reach.
+func WithServerSweep(ctx context.Context) context.Context {
+	return context.WithValue(ctx, serverSweepKey{}, true)
+}
+
+// serverSweepEnabled reports whether ctx opted into the sweep.
+func serverSweepEnabled(ctx context.Context) bool {
+	v, _ := ctx.Value(serverSweepKey{}).(bool)
+	return v
+}
+
+// maxSweepNewSessions bounds the sweep's new-session handshakes. The deployment
+// runs ~9 servers, so this is headroom rather than a real limit; it exists so a
+// misconfigured discovery returning thousands of entries cannot hang the dial.
+// The caller's context governs in practice.
+const maxSweepNewSessions = 32
+
+// sweepNewSessions is the opt-in last resort: enumerate every server in the
+// discovery and try the destination through each one we are not already
+// connected to.
+//
+// Servers we DO hold a session to are skipped: the caller has already tried
+// them, either through the delegated/mesh phases or through
+// dialViaConnectedServers, and retrying them here would only add latency to a
+// dial that is already failing.
+func (ce *Client) sweepNewSessions(ctx context.Context, addr Addr) (*Stream, error) {
+	entries, err := ce.discoverServers(ctx, true)
+	if err != nil {
+		return nil, fmt.Errorf("sweep: enumerate servers: %w", err)
+	}
+
+	tried := 0
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if entry == nil || entry.Server == nil {
+			continue
+		}
+		if _, ok := ce.session(entry.Static); ok {
+			continue // already tried via an existing session
+		}
+		if tried >= maxSweepNewSessions {
+			break
+		}
+		tried++
+
+		dSes, err := ce.EnsureAndObtainSession(ctx, entry.Static)
+		if err != nil {
+			ce.log.WithError(err).WithField("server", entry.Static.Hex()).
+				Debug("sweep: could not establish session")
+			continue
+		}
+		stream, err := dSes.DialStream(ctx, addr)
+		if err != nil {
+			ce.log.WithError(err).WithField("server", entry.Static.Hex()).
+				Debug("sweep: destination not reachable via this server")
+			continue
+		}
+		ce.log.WithField("server", entry.Static.Hex()).WithField("remote_pk", addr.PK.Hex()).
+			Debug("sweep: reached destination via a newly established session")
+		ce.setCachedRoute(addr.PK, entry.Static)
+		return stream, nil
+	}
+	return nil, fmt.Errorf("sweep: destination unreachable via %d newly dialed server(s): %w",
+		tried, ErrCannotConnectToDelegated)
 }

--- a/pkg/dmsg/dmsg/client_sweep_test.go
+++ b/pkg/dmsg/dmsg/client_sweep_test.go
@@ -1,0 +1,44 @@
+package dmsg
+
+import (
+	"context"
+	"testing"
+)
+
+// TestServerSweepIsOptIn pins the default. The sweep costs a full Noise
+// handshake per server in the deployment, so a plain context must never enable
+// it — otherwise one dead public key becomes a handshake storm against the
+// whole fleet, and the dial-failure backoff that exists to prevent exactly that
+// is defeated.
+func TestServerSweepIsOptIn(t *testing.T) {
+	if serverSweepEnabled(context.Background()) {
+		t.Fatal("a plain context must not enable the server sweep")
+	}
+}
+
+// TestWithServerSweepEnables covers the opt-in and that it survives being
+// wrapped, which is how callers actually use it (WithServerSweep then
+// WithTimeout, or the reverse).
+func TestWithServerSweepEnables(t *testing.T) {
+	ctx := WithServerSweep(context.Background())
+	if !serverSweepEnabled(ctx) {
+		t.Fatal("WithServerSweep must enable the sweep")
+	}
+
+	wrapped, cancel := context.WithCancel(ctx)
+	defer cancel()
+	if !serverSweepEnabled(wrapped) {
+		t.Error("the sweep opt-in must survive context wrapping")
+	}
+}
+
+// TestServerSweepKeyIsTyped guards the collision the typed key exists to
+// prevent: the package already carries string-keyed context values
+// ("dmsgServer", "socks5_proxy"), so a bare string key here could be set —
+// or cleared — by unrelated code that happens to use the same literal.
+func TestServerSweepKeyIsTyped(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "serverSweep", true) //nolint:staticcheck,revive // deliberately the wrong key shape
+	if serverSweepEnabled(ctx) {
+		t.Error("a string-keyed value must not enable the sweep")
+	}
+}


### PR DESCRIPTION
Closes the one hole in the dial ladder. Today a destination is reachable if it is in the discovery, was seeded, or sits on a server this client already holds a session to — `dialViaConnectedServers` already forwards through every existing session when a lookup fails, which is how the unregistered deployment services are reached. What has no path at all is a peer that is in no discovery, was never seeded, AND sits on a server we hold no session to: phase 3 iterates `entry.Client.DelegatedServers`, and there is no entry.

`WithServerSweep(ctx)` opts a single dial into a last resort that establishes a session to each server in turn and tries the destination through it. It hooks both failure exits — no entry at all, and an entry whose servers have all gone stale — and skips servers already covered by the earlier phases.

**It is opt-in and should stay opt-in.** The automatic fallback costs one yamux stream per session already held. A sweep costs a full Noise handshake per server in the deployment, so firing it automatically on every failed resolution would turn one typo or one dead key into a handshake storm against the whole fleet, and would defeat the dial-failure backoff that exists for exactly that reason. Exposed as `dmsg curl --any-server`; the visor's automatic paths do not set it.

The context key is a typed struct rather than a bare string: this package already carries string-keyed context values (`"dmsgServer"`, `"socks5_proxy"`), and a test pins that a string-keyed value cannot enable the sweep.

Not verified live — reaching the one case this fixes needs a peer that is unregistered, unseeded, and on a server this client is not connected to.