### PR TITLE
feat(dmsg): make "do not register" explicit instead of a silently-lying writer

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -67,8 +67,21 @@ func (sc *ClientCallbacks) ensure() {
 
 // Config configures a dmsg client entity.
 type Config struct {
-	MinSessions          int
-	UpdateInterval       time.Duration // Duration between discovery entry updates.
+	MinSessions    int
+	UpdateInterval time.Duration // Duration between discovery entry updates.
+
+	// NoRegister disables publishing this client's own discovery entry.
+	//
+	// Registration and resolution are independent axes. Not registering does
+	// NOT make a client undialable — anyone who knows (or is seeded with) the
+	// servers it sits on can still reach it; it is only unresolvable by lookup.
+	// Set it for a read-only consumer with a fixed set of destinations, or for a
+	// deployment running without a discovery at all.
+	//
+	// The alternative it replaces was handing the client a discovery whose
+	// writes silently succeed without publishing (direct.NewClient), which left
+	// the client believing it had registered.
+	NoRegister           bool
 	Callbacks            *ClientCallbacks
 	ClientType           string
 	ConnectedServersType string
@@ -298,6 +311,7 @@ func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Conf
 
 	// Init common fields.
 	c.EntityCommon.init(pk, sk, dc, log, conf.UpdateInterval)
+	c.EntityCommon.noRegister = conf.NoRegister
 
 	// Init callback: on set session.
 	c.EntityCommon.setSessionCallback = func(ctx context.Context) error {

--- a/pkg/dmsg/dmsg/client_noregister_test.go
+++ b/pkg/dmsg/dmsg/client_noregister_test.go
@@ -1,0 +1,65 @@
+package dmsg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// countingWriter records publish attempts so a test can prove none were made.
+type countingWriter struct {
+	disc.APIClient
+	puts  int
+	posts int
+}
+
+func (w *countingWriter) PutEntry(_ context.Context, _ cipher.SecKey, _ *disc.Entry) error {
+	w.puts++
+	return nil
+}
+
+func (w *countingWriter) PostEntry(_ context.Context, _ *disc.Entry) error {
+	w.posts++
+	return nil
+}
+
+// TestNoRegisterSuppressesPublish is the point of the flag: a client told not
+// to register must make no publish attempt at all.
+//
+// The behavior it replaces was expressible only by passing a discovery whose
+// writes silently succeed without publishing (direct.NewClient's PutEntry
+// returns nil), which left the client believing it had registered — the reason
+// this needed to become explicit rather than a property of the injected
+// discovery.
+func TestNoRegisterSuppressesPublish(t *testing.T) {
+	w := &countingWriter{}
+	c := &EntityCommon{}
+	pk, sk := cipher.GenerateKeyPair()
+	c.init(pk, sk, w, logging.MustGetLogger("noregister_test"), 0)
+	c.noRegister = true
+
+	done := make(chan struct{})
+	if err := c.updateClientEntry(context.Background(), done, ""); err != nil {
+		t.Fatalf("updateClientEntry returned %v, want nil", err)
+	}
+	if w.puts != 0 || w.posts != 0 {
+		t.Errorf("a non-registering client published: %d PutEntry, %d PostEntry", w.puts, w.posts)
+	}
+}
+
+// TestRegisterByDefault pins that the flag is opt-in — the zero value must keep
+// publishing, or every existing caller would silently stop being resolvable.
+func TestRegisterByDefault(t *testing.T) {
+	c := &EntityCommon{}
+	if c.noRegister {
+		t.Fatal("registration must be enabled by default")
+	}
+
+	conf := DefaultConfig()
+	if conf.NoRegister {
+		t.Error("DefaultConfig must register")
+	}
+}

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -58,6 +58,16 @@ type EntityCommon struct {
 
 	updateInterval time.Duration // Minimum duration between discovery entry updates.
 
+	// noRegister disables publishing this entity's own discovery entry.
+	//
+	// Resolution and registration are INDEPENDENT: a client that does not
+	// register can still resolve peers (from seeded entries or a discovery
+	// lookup) and can still be dialed by anyone who knows which servers it is
+	// on. It is only unresolvable BY LOOKUP. Set it for a read-only consumer
+	// with a fixed set of destinations, or for a deployment with no discovery
+	// at all; leave it clear for anything that must be findable by public key.
+	noRegister bool
+
 	// serverVersion, when non-empty, overrides the disc.Entry.Version a dmsg
 	// SERVER advertises (default "0.0.1") with its real build version. Set once
 	// from ServerConfig.Version in NewServer; read-only afterward. Empty for
@@ -848,6 +858,12 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 	if isClosed(done) {
 		return nil
 	}
+	// Gated here rather than only in updateClientEntryLoop so EVERY publish path
+	// is covered — the first-session callback publishes directly to get an entry
+	// in place before Ready fires, and the nudge path calls in too.
+	if c.noRegister {
+		return nil
+	}
 
 	endpoints := c.snapshotDiscoveries()
 	if len(endpoints) == 0 {
@@ -1097,6 +1113,18 @@ func entryFailureBackoff(consecutiveFailures int) time.Duration {
 }
 
 func (c *EntityCommon) updateClientEntryLoop(ctx context.Context, done chan struct{}, clientType string) {
+	// A client configured not to register never runs this loop.
+	//
+	// Before this existed, "do not register" could only be expressed by handing
+	// the client a discovery whose writes are silent no-op successes —
+	// direct.NewClient's PutEntry returns nil without publishing anything. The
+	// loop then ran forever, reported success, and the client believed it had
+	// advertised itself while being unresolvable by lookup. Making it explicit
+	// means the caller says what it wants and the log says what happened.
+	if c.noRegister {
+		c.log.Debug("Discovery registration disabled; not publishing a client entry.")
+		return
+	}
 	t := time.NewTimer(c.updateInterval)
 	defer t.Stop()
 

--- a/pkg/dmsg/dmsgclient/seeded.go
+++ b/pkg/dmsg/dmsgclient/seeded.go
@@ -85,6 +85,13 @@ func StartDmsgSeeded(ctx context.Context, log *logging.Logger, pk cipher.PubKey,
 	dClient := direct.NewClient(entries, log)
 
 	conf := dmsg.DefaultConfig()
+	// A seed-only client (no discovery address) has nowhere to publish. Say so
+	// rather than leaving the registration loop to call direct.NewClient's
+	// PutEntry, which returns nil without publishing — the client would run the
+	// loop forever and report success while being unresolvable by lookup.
+	// Registration and resolution are independent: this client still resolves
+	// its seeded peers and is still dialable by anyone who knows its servers.
+	conf.NoRegister = discDmsgAddr == ""
 	if preferWS {
 		// Browser (wasm): prefer WebTransport, fall back to WebSocket. The seed
 		// entry carries only AddressWS (a wss:// bootstrap endpoint) — there's no


### PR DESCRIPTION
Registration (publishing our own entry) and resolution (finding a peer's) are independent, but there was no way to say "do not register". The only way to get it was to hand the client a discovery whose writes are silent no-op successes — `direct.NewClient`'s `PutEntry` returns `nil` without publishing anything. The registration loop then ran on its normal interval, got `nil` every time, and the client believed it had advertised itself while being unresolvable by lookup. No error, no warning.

`Config.NoRegister` states it. It is gated inside `updateClientEntry` rather than only in `updateClientEntryLoop`, so every publish path is covered — the first-session callback publishes directly to get an entry in place before `Ready` fires, and the nudge path calls in too. `StartDmsgSeeded` sets it when no discovery address was given, which is precisely where the lying writer was being relied on.

Worth being exact about the semantics, since the naming invites the wrong reading: **not registering does not make a client undialable.** Anyone who knows — or is seeded with — the servers it sits on still reaches it. It is only unresolvable *by lookup*. That is the correct trade for a read-only consumer with a fixed set of destinations, and for a deployment running with no discovery at all, which this makes a first-class configuration rather than something you get by accident.

Default is unchanged: the zero value registers, and a test pins that.

The three `pkg/dmsg/discovery/store` redis tests fail locally with `connection refused` to `[::1]:6379` — no local redis; the `redis-store` CI job covers them and this change does not touch that package.