### PR TITLE
feat(dmsg): pluggable entry resolvers; drop the vestigial DHT lookup hook

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -226,18 +226,16 @@ type Client struct {
 	carriersOverride []string
 	liveDisc         disc.APIClient
 
-	// DHTLookup, when set, is called by DialStream before the HTTP
-	// discovery lookup. If it returns a valid entry, the HTTP discovery
-	// is skipped entirely. This lets the visor resolve DMSG client
-	// entries from the local DHT store (instant, no network) for PKs
-	// that have published their entries to the DHT.
-	DHTLookup func(pk cipher.PubKey) (*disc.Entry, error)
+	// entryResolvers are consulted before the discovery, in the order added by
+	// AddEntryResolver. See EntryResolver for what belongs here and why it is a
+	// per-deployment choice rather than a default.
+	entryResolvers []EntryResolver
 
 	// Lookup counters for diagnostics.
-	LookupCacheHits  atomic.Int64 // resolved from entry cache
-	LookupDHTHits    atomic.Int64 // resolved from DHT (DHTLookup callback)
-	LookupHTTPHits   atomic.Int64 // resolved from HTTP discovery
-	LookupHTTPMisses atomic.Int64 // HTTP discovery returned not found
+	LookupCacheHits    atomic.Int64 // resolved from entry cache
+	LookupResolverHits atomic.Int64 // resolved from an injected EntryResolver
+	LookupHTTPHits     atomic.Int64 // resolved from HTTP discovery
+	LookupHTTPMisses   atomic.Int64 // HTTP discovery returned not found
 
 	// pinnedFailures counts consecutive failed Serve-loop passes
 	// while in pinned mode (--dmsg-server / ctx.Value("dmsgServer")
@@ -1071,13 +1069,6 @@ func (ce *Client) setCachedEntry(pk cipher.PubKey, entry *disc.Entry) {
 		return
 	}
 	ce.entryCache[pk] = entryCacheEntry{entry: entry, fetchedAt: time.Now()}
-}
-
-// SetDHTLookup sets a callback for DHT-based client entry resolution.
-// DialStream calls this before the HTTP discovery, avoiding network
-// round-trips for PKs that have published to the DHT.
-func (ce *Client) SetDHTLookup(fn func(pk cipher.PubKey) (*disc.Entry, error)) {
-	ce.DHTLookup = fn
 }
 
 // resolveServerEntry returns the discovery entry for the given dmsg

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -211,14 +211,14 @@ func (ce *Client) getClientEntryCached(ctx context.Context, clientPK cipher.PubK
 		ce.LookupCacheHits.Add(1)
 		return entry, nil
 	}
-	// Try DHT before HTTP discovery — avoids network round-trip for
-	// PKs that have published their DMSG entry to the DHT.
-	if ce.DHTLookup != nil {
-		if entry, err := ce.DHTLookup(clientPK); err == nil && entry != nil && entry.Client != nil {
-			ce.LookupDHTHits.Add(1)
-			ce.setCachedEntry(clientPK, entry)
-			return entry, nil
-		}
+	// Injected resolvers first: they answer from local state, so they cost no
+	// network round-trip at all. See EntryResolver.
+	if entry, name, ok := ce.resolveViaResolvers(ctx, clientPK); ok {
+		ce.LookupResolverHits.Add(1)
+		ce.log.WithField("resolver", name).WithField("remote_pk", clientPK.Hex()).
+			Debug("Resolved client entry locally; skipping the discovery lookup")
+		ce.setCachedEntry(clientPK, entry)
+		return entry, nil
 	}
 	entry, err := getClientEntry(ctx, ce.dc, clientPK)
 	if err != nil {
@@ -720,4 +720,72 @@ func (ce *Client) sweepNewSessions(ctx context.Context, addr Addr) (*Stream, err
 	}
 	return nil, fmt.Errorf("sweep: destination unreachable via %d newly dialed server(s): %w",
 		tried, ErrCannotConnectToDelegated)
+}
+
+// EntryResolver answers "which servers bridge to this public key" without a
+// discovery round-trip.
+//
+// This is the dependency-inversion seam that lets a resolver live OUTSIDE
+// pkg/dmsg. A CXO-backed resolver is the motivating case: pkg/cxo imports
+// pkg/dmsg/dmsg, so the dmsg client can never import CXO — but the visor
+// imports both and can inject one. The discovery already publishes its whole
+// clients-by-server mapping over CXO (FeedDMSGDClientsByServer), so a
+// subscriber holds every entry locally and needs no per-dial lookup at all.
+//
+// A resolver MUST be fast and local. It is consulted on the dial path ahead of
+// the discovery, and resolverTimeout bounds it precisely so that a resolver
+// which is cold, syncing, or wedged degrades to a discovery lookup instead of
+// stalling the dial. Answering "I don't know" quickly is always better than
+// answering slowly.
+//
+// Whether to install one is a per-deployment judgment, not a default: the cost
+// is a resident copy of the mapping (~930 client entries on the production
+// deployment today, growing with the network) and the benefit scales with how
+// many distinct peers this client dials. Right for a setup node, a route
+// finder or a hypervisor; wrong for a microcontroller, a browser tab, or a
+// short-lived CLI invocation that dials one known peer.
+type EntryResolver interface {
+	// Name identifies the resolver in logs and metrics.
+	Name() string
+	// Entry returns the peer's entry. Any error means "I cannot answer",
+	// and resolution falls through to the next resolver.
+	Entry(ctx context.Context, pk cipher.PubKey) (*disc.Entry, error)
+}
+
+// resolverTimeout bounds a single resolver call. Resolvers are meant to answer
+// from memory, so this is a guard against a wedged implementation rather than a
+// budget anything should need.
+const resolverTimeout = 500 * time.Millisecond
+
+// AddEntryResolver installs a resolver, consulted before the discovery in the
+// order added.
+//
+// Call it during setup, before the client starts dialing: the resolver list is
+// read without a lock on the dial path, which is safe for an append-only list
+// that is fully built before serving and would not be safe for mutation
+// afterwards.
+func (ce *Client) AddEntryResolver(r EntryResolver) {
+	if r == nil {
+		return
+	}
+	ce.entryResolvers = append(ce.entryResolvers, r)
+}
+
+// resolveViaResolvers consults the installed resolvers in order, returning the
+// first entry that actually carries client data. A resolver that errors, times
+// out, or returns a server-only entry is skipped.
+func (ce *Client) resolveViaResolvers(ctx context.Context, pk cipher.PubKey) (*disc.Entry, string, bool) {
+	for _, r := range ce.entryResolvers {
+		if ctx.Err() != nil {
+			return nil, "", false
+		}
+		rctx, cancel := context.WithTimeout(ctx, resolverTimeout)
+		entry, err := r.Entry(rctx, pk)
+		cancel()
+		if err != nil || entry == nil || entry.Client == nil {
+			continue
+		}
+		return entry, r.Name(), true
+	}
+	return nil, "", false
 }

--- a/pkg/dmsg/dmsg/client_resolver_test.go
+++ b/pkg/dmsg/dmsg/client_resolver_test.go
@@ -1,0 +1,157 @@
+package dmsg
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// fakeResolver is an EntryResolver with scripted behavior.
+type fakeResolver struct {
+	name    string
+	entry   *disc.Entry
+	err     error
+	delay   time.Duration
+	calls   int
+	lastCtx context.Context //nolint:containedctx // recorded to assert the timeout is applied
+}
+
+func (f *fakeResolver) Name() string { return f.name }
+
+func (f *fakeResolver) Entry(ctx context.Context, _ cipher.PubKey) (*disc.Entry, error) {
+	f.calls++
+	f.lastCtx = ctx
+	if f.delay > 0 {
+		select {
+		case <-time.After(f.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return f.entry, f.err
+}
+
+func clientEntry(pk cipher.PubKey, servers ...cipher.PubKey) *disc.Entry {
+	return &disc.Entry{Static: pk, Client: &disc.Client{DelegatedServers: servers}}
+}
+
+func newResolverTestClient(t *testing.T) *Client {
+	t.Helper()
+	pk, sk := cipher.GenerateKeyPair()
+	c := &Client{entryCache: make(map[cipher.PubKey]entryCacheEntry)}
+	c.EntityCommon.init(pk, sk, nil, logging.MustGetLogger("resolver_test"), 0)
+	return c
+}
+
+// TestEntryResolverAnswersBeforeDiscovery is the seam: an injected resolver
+// that can answer must satisfy resolution with no discovery involvement. This
+// is what lets a CXO-backed resolver live outside pkg/dmsg — pkg/cxo imports
+// pkg/dmsg/dmsg, so the dependency can only run this way.
+func TestEntryResolverAnswersBeforeDiscovery(t *testing.T) {
+	c := newResolverTestClient(t)
+	peer, _ := cipher.GenerateKeyPair()
+	srv, _ := cipher.GenerateKeyPair()
+
+	r := &fakeResolver{name: "test", entry: clientEntry(peer, srv)}
+	c.AddEntryResolver(r)
+
+	// dc is nil, so any fall-through to the discovery would panic — proving the
+	// resolver alone satisfied the lookup.
+	got, err := c.getClientEntryCached(context.Background(), peer)
+	if err != nil {
+		t.Fatalf("getClientEntryCached: %v", err)
+	}
+	if got == nil || got.Client == nil || len(got.Client.DelegatedServers) != 1 {
+		t.Fatalf("resolver entry not returned: %+v", got)
+	}
+	if got.Client.DelegatedServers[0] != srv {
+		t.Errorf("wrong server: got %v want %v", got.Client.DelegatedServers[0], srv)
+	}
+	if c.LookupResolverHits.Load() != 1 {
+		t.Errorf("resolver hit counter = %d, want 1", c.LookupResolverHits.Load())
+	}
+}
+
+// TestEntryResolverOrderAndFallThrough pins that resolvers are tried in the
+// order added and that one which cannot answer is skipped rather than failing
+// the resolution.
+func TestEntryResolverOrderAndFallThrough(t *testing.T) {
+	c := newResolverTestClient(t)
+	peer, _ := cipher.GenerateKeyPair()
+	srv, _ := cipher.GenerateKeyPair()
+
+	first := &fakeResolver{name: "empty", err: errors.New("nothing here")}
+	second := &fakeResolver{name: "has-it", entry: clientEntry(peer, srv)}
+	c.AddEntryResolver(first)
+	c.AddEntryResolver(second)
+
+	if _, err := c.getClientEntryCached(context.Background(), peer); err != nil {
+		t.Fatalf("getClientEntryCached: %v", err)
+	}
+	if first.calls != 1 || second.calls != 1 {
+		t.Errorf("calls: first=%d second=%d, want 1 and 1", first.calls, second.calls)
+	}
+}
+
+// TestEntryResolverServerOnlyEntryIsSkipped guards the shape check: an entry
+// with no Client section names no delegated servers, so it cannot drive a dial
+// and must not be treated as a hit.
+func TestEntryResolverServerOnlyEntryIsSkipped(t *testing.T) {
+	c := newResolverTestClient(t)
+	peer, _ := cipher.GenerateKeyPair()
+
+	r := &fakeResolver{name: "server-only", entry: &disc.Entry{Static: peer, Server: &disc.Server{}}}
+	c.AddEntryResolver(r)
+
+	if entry, _, ok := c.resolveViaResolvers(context.Background(), peer); ok {
+		t.Errorf("a server-only entry was accepted as a client entry: %+v", entry)
+	}
+}
+
+// TestEntryResolverTimeoutDoesNotStallDial is the safety property. A resolver
+// is on the dial path; one that is cold, syncing or wedged must degrade to the
+// discovery lookup rather than hold the dial open. Without the bound, adding a
+// CXO-backed resolver would make every dial wait on a feed sync.
+func TestEntryResolverTimeoutDoesNotStallDial(t *testing.T) {
+	c := newResolverTestClient(t)
+	peer, _ := cipher.GenerateKeyPair()
+
+	wedged := &fakeResolver{name: "wedged", delay: time.Hour}
+	c.AddEntryResolver(wedged)
+
+	start := time.Now()
+	_, _, ok := c.resolveViaResolvers(context.Background(), peer)
+	elapsed := time.Since(start)
+
+	if ok {
+		t.Error("a wedged resolver must not report a hit")
+	}
+	if elapsed > 2*resolverTimeout {
+		t.Errorf("a wedged resolver held the dial for %v; resolverTimeout is %v", elapsed, resolverTimeout)
+	}
+	if wedged.lastCtx == nil {
+		t.Fatal("resolver was not called")
+	}
+	if _, hasDeadline := wedged.lastCtx.Deadline(); !hasDeadline {
+		t.Error("resolver was called without a deadline")
+	}
+}
+
+// TestNoResolversIsUnchanged pins the default: with none installed, nothing is
+// consulted and no counter moves, so existing clients are unaffected.
+func TestNoResolversIsUnchanged(t *testing.T) {
+	c := newResolverTestClient(t)
+	peer, _ := cipher.GenerateKeyPair()
+
+	if _, _, ok := c.resolveViaResolvers(context.Background(), peer); ok {
+		t.Error("resolution succeeded with no resolvers installed")
+	}
+	if c.LookupResolverHits.Load() != 0 {
+		t.Error("resolver hit counter moved with no resolvers installed")
+	}
+}


### PR DESCRIPTION
Makes CXO-backed entry resolution buildable. `pkg/cxo` imports `pkg/dmsg/dmsg`, so the dmsg client can never import CXO — the resolver has to be injected from outside, by something that imports both (the visor). `EntryResolver` is that seam, consulted ahead of the discovery: a client subscribed to `FeedDMSGDClientsByServer` already holds the whole clients-by-server mapping locally and needs no per-dial lookup at all.

Each call is bounded by `resolverTimeout` (500ms). That bound is the point rather than a detail — a resolver sits on the dial path, and a CXO-backed one can be cold, syncing, or wedged. Without it, installing one would make every dial wait on a feed sync. A resolver that answers "I do not know" quickly is always better than one that answers slowly, and a test pins that a wedged resolver cannot hold a dial open.

Installing one is a per-deployment judgment, not a default, and the doc comment says so with numbers: the cost is a resident copy of the mapping (930 client entries on the production deployment today, growing with the network) and the benefit scales with how many distinct peers the client dials. Right for a setup node, route finder or hypervisor; wrong for a microcontroller, a browser tab, or a `dmsg curl` that dials one known peer.

This also removes `DHTLookup` / `SetDHTLookup` / `LookupDHTHits`. Nothing set them — they are leftovers from the DHT that CXO replaced, and the resolver seam is their general-purpose successor. (`pkg/dmsg/discovery/api`'s `dhtMirror` is a separate, also-unwired server-side remnant; left alone here.)

No behavior change with no resolvers installed, which is every current caller — pinned by a test.