### PR TITLE
fix(visor): resolve the DMSG-D CXO peer from dmsg.discovery too

### DIFF
--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -175,13 +175,26 @@ func sdCXOPeer(v *Visor) (cipher.PubKey, bool) {
 	return parseDmsgPeer(v.conf.Launcher.ServiceDiscDmsg)
 }
 
-// dmsgdCXOPeer extracts the DMSG-D publisher PK from the visor's
-// dmsg.discovery_dmsg URL.
+// dmsgdCXOPeer extracts the DMSG-D publisher PK from the visor's dmsg
+// discovery configuration.
+//
+// Both discovery_dmsg AND discovery are tried, in that order, mirroring
+// tpdCXOPeer. On a dmsg-only deployment the PK lives in `discovery` (already
+// `dmsg://<pk>:80`) and discovery_dmsg is simply unset — reading only the
+// latter meant the feed spec always failed with "no DMSG-D CXO peer", so
+// enabling dmsg.lookup_cxo silently did nothing and every lookup fell back to
+// HTTP. parseDmsgPeer rejects a non-dmsg scheme, so a clearnet `discovery` is
+// still correctly ignored.
 func dmsgdCXOPeer(v *Visor) (cipher.PubKey, bool) {
 	if v.conf.Dmsg == nil {
 		return cipher.PubKey{}, false
 	}
-	return parseDmsgPeer(v.conf.Dmsg.DiscoveryDmsg)
+	for _, raw := range []string{v.conf.Dmsg.DiscoveryDmsg, v.conf.Dmsg.Discovery} {
+		if pk, ok := parseDmsgPeer(raw); ok {
+			return pk, true
+		}
+	}
+	return cipher.PubKey{}, false
 }
 
 func parseDmsgPeer(raw string) (cipher.PubKey, bool) {

--- a/pkg/visor/dmsgd_cxo_peer_test.go
+++ b/pkg/visor/dmsgd_cxo_peer_test.go
@@ -1,0 +1,67 @@
+package visor
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgc/spec"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+const testDmsgdPK = "022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa"
+
+func visorWithDmsg(discovery, discoveryDmsg string) *Visor {
+	return &Visor{conf: &visorconfig.V1{
+		Dmsg: &spec.DmsgConfig{
+			Discovery:     discovery,
+			DiscoveryDmsg: discoveryDmsg,
+		},
+	}}
+}
+
+// TestDmsgdCXOPeerFallsBackToDiscovery is the live bug this fixes. On a
+// dmsg-only deployment the discovery PK lives in `discovery` (already a
+// dmsg:// URL) and `discovery_dmsg` is unset. Reading only the latter made the
+// clients-by-server feed spec fail with "no DMSG-D CXO peer", so enabling
+// dmsg.lookup_cxo silently did nothing and every peer lookup fell back to HTTP
+// — the feature was unreachable in the deployment it ships against.
+func TestDmsgdCXOPeerFallsBackToDiscovery(t *testing.T) {
+	v := visorWithDmsg("dmsg://"+testDmsgdPK+":80", "")
+	pk, ok := dmsgdCXOPeer(v)
+	if !ok {
+		t.Fatal("no peer resolved from a dmsg:// discovery URL")
+	}
+	if pk.Hex() != testDmsgdPK {
+		t.Errorf("peer = %s, want %s", pk.Hex(), testDmsgdPK)
+	}
+}
+
+// TestDmsgdCXOPeerPrefersDiscoveryDmsg pins the ordering: when both are set the
+// explicit field wins, matching tpdCXOPeer.
+func TestDmsgdCXOPeerPrefersDiscoveryDmsg(t *testing.T) {
+	other := "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
+	v := visorWithDmsg("dmsg://"+other+":80", "dmsg://"+testDmsgdPK+":80")
+	pk, ok := dmsgdCXOPeer(v)
+	if !ok {
+		t.Fatal("no peer resolved")
+	}
+	if pk.Hex() != testDmsgdPK {
+		t.Errorf("peer = %s, want the discovery_dmsg value %s", pk.Hex(), testDmsgdPK)
+	}
+}
+
+// TestDmsgdCXOPeerIgnoresClearnetDiscovery guards the fallback: a clearnet
+// discovery URL names no dmsg peer and must not be accepted as one.
+func TestDmsgdCXOPeerIgnoresClearnetDiscovery(t *testing.T) {
+	v := visorWithDmsg("http://dmsgd.skywire.skycoin.com", "")
+	if _, ok := dmsgdCXOPeer(v); ok {
+		t.Error("a clearnet discovery URL was accepted as a dmsg CXO peer")
+	}
+}
+
+// TestDmsgdCXOPeerNoDmsgConfig covers the nil path.
+func TestDmsgdCXOPeerNoDmsgConfig(t *testing.T) {
+	v := &Visor{conf: &visorconfig.V1{}}
+	if _, ok := dmsgdCXOPeer(v); ok {
+		t.Error("a peer was resolved with no dmsg config")
+	}
+}


### PR DESCRIPTION
Found by turning `dmsg.lookup_cxo` on for the first time. The flag had no effect: the clients-by-server feed never appeared in `cxo status`, and every peer entry lookup still went over HTTP.

`dmsgdCXOPeer` read only `dmsg.discovery_dmsg`. On a dmsg-only deployment that field is unset and the discovery PK lives in `dmsg.discovery`, already in `dmsg://<pk>:80` form — so the feed spec always failed with "no DMSG-D CXO peer (dmsg.discovery_dmsg unset)" and the resolver silently degraded to HTTP on every lookup. The feature has been unreachable in the deployment it ships against.

`tpdCXOPeer` already gets this right — it tries `DiscoveryDmsg` then `Discovery` — which is exactly why the TPD feeds work and this one never has. `dmsgdCXOPeer` now does the same. `parseDmsgPeer` rejects a non-dmsg scheme, so a clearnet `discovery` is still correctly ignored; a test covers that.

Live evidence from the visor this was found on: `dmsg.discovery` = `dmsg://022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa:80`, `dmsg.discovery_dmsg` = null, and with `lookup_cxo: true` the `dmsgd-clients-by-server` feed was absent from `cxo status` while `tpd-stats`, `tpd-all-transports` and `sd-services` were all syncing normally.