### PR TITLE
fix(visor): surface the registration-CXO feed gating in visor state

### DIFF
--- a/pkg/visor/cxo_user_feeds.go
+++ b/pkg/visor/cxo_user_feeds.go
@@ -220,6 +220,14 @@ func (v *Visor) setSystemCXOPub(pub *treestore.Publisher) {
 	v.cxoUserFeedsMu.Unlock()
 }
 
+// setRegCXOPub retains the registration-over-CXO publisher so its gating
+// (allowlist + denied subscribers) shows up in `skywire cli visor state`.
+func (v *Visor) setRegCXOPub(pub *treestore.Publisher) {
+	v.cxoUserFeedsMu.Lock()
+	v.regCXOPub = pub
+	v.cxoUserFeedsMu.Unlock()
+}
+
 // setTPListCXOPub retains the dedicated tp-list discovery feed publisher
 // so CXOFeedStates can read its live PublishState. Called once by
 // initStats; pub is nil when the dedicated publisher didn't start (the
@@ -331,6 +339,7 @@ func (v *Visor) CXOFeedStates() []CXOFeedState {
 	v.cxoUserFeedsMu.Lock()
 	sysPub := v.systemCXOPub
 	tplistPub := v.tplistCXOPub
+	regPub := v.regCXOPub
 	users := make([]*cxoUserFeed, 0, len(v.cxoUserFeeds))
 	for _, fd := range v.cxoUserFeeds {
 		users = append(users, fd)
@@ -362,6 +371,18 @@ func (v *Visor) CXOFeedStates() []CXOFeedState {
 			Name:         tplistCXOFeedName,
 			Port:         skyenv.DmsgVisorTPListCXOPort,
 			PublishState: tplistPub.PublishState(),
+			Allowlist:    allow,
+			Denied:       denied,
+		})
+	}
+	// The registration-over-CXO feed. Surfacing its denied list is the
+	// only way to see a dmsg-discovery whose subscribe is being refused.
+	if regPub != nil {
+		allow, denied := feedGating(regPub)
+		out = append(out, CXOFeedState{
+			Name:         "registration",
+			Port:         skyenv.DmsgDMSGDRegistrationCXOPort,
+			PublishState: regPub.PublishState(),
 			Allowlist:    allow,
 			Denied:       denied,
 		})

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -272,8 +272,8 @@ func registerModules(logger *logging.MasterLogger) {
 	// dmsg + health-gated type=coin SD registration. Depends on dmsgC (forward
 	// + SD dmsg client) and skyFwd (dmsg forwarder). See init_coinnode.go.
 	coinNodesMod = maker("coin_nodes", initCoinNodes, &dmsgC, &skyFwd)
-	// Registration-over-CXO publisher: when opted in (Dmsg.RegistrationCXO),
-	// mirror this visor's signed discovery entry onto a CXO feed that
+	// Registration-over-CXO publisher: runs whenever a dmsg-discovery PK
+	// resolves (no opt-in flag exists, despite older comments). Mirrors this visor's signed discovery entry onto a CXO feed that
 	// dmsg-discovery aggregates, off the timer-driven HTTP re-PUT. Depends on
 	// dmsgC (the entry it publishes + the feed's transport). See
 	// init_registration_cxo.go.

--- a/pkg/visor/init_registration_cxo.go
+++ b/pkg/visor/init_registration_cxo.go
@@ -1,8 +1,10 @@
 // Package visor pkg/visor/init_registration_cxo.go c3-vis-core
 //
-// Registration-over-CXO publisher. When the visor opts in
-// (Dmsg.RegistrationCXO), it publishes its own signed discovery entry as
-// a CXO feed on DmsgDMSGDRegistrationCXOPort and announces to the
+// Registration-over-CXO publisher. Runs whenever a dmsg-discovery PK
+// resolves (there is no opt-in flag — earlier comments referenced a
+// Dmsg.RegistrationCXO field that was never added). It publishes this
+// visor's own signed discovery entry as a CXO feed on
+// DmsgDMSGDRegistrationCXOPort and announces to the
 // deployment's dmsg-discovery, which subscribes back and ingests the
 // entry. This moves client-entry registration off the timer-driven HTTP
 // PUT — each a fresh dmsg stream with a full Noise + post-quantum
@@ -85,6 +87,9 @@ func initRegistrationCXO(_ context.Context, v *Visor, log *logging.Logger) error
 	// re-applied when the peer whitelist changes at runtime. The initial
 	// allowlist is already set at construction via PubConfig above.
 	v.registerGatedCXOFeed(pub, dmsgdPK, true)
+	// Surface this feed's gating in `visor state`: a refused dmsg-discovery
+	// subscribe is otherwise invisible from both ends.
+	v.setRegCXOPub(pub)
 
 	// Mirror every successful primary-discovery registration onto the feed.
 	// The hook runs on the dmsg entry-update goroutine and must not block;

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -277,6 +277,15 @@ type Visor struct {
 	// initStats fell back to the combined telemetry feed.
 	tplistCXOPub *treestore.Publisher
 
+	// regCXOPub is the registration-over-CXO publisher (this visor's own
+	// signed discovery entry, on DmsgDMSGDRegistrationCXOPort) — retained so
+	// CXOFeedStates can surface its allowlist and, critically, its DENIED
+	// subscribers. Without that, a dmsg-discovery whose subscribe is refused
+	// is invisible: the visor logs nothing, dmsgd logs only the generic
+	// "subscribe rejected", and registration silently stays on the HTTP PUT
+	// path this feed exists to replace. Guarded by cxoUserFeedsMu.
+	regCXOPub *treestore.Publisher
+
 	// gatedCXOFeeds registers the visor's service-consumed CXO publishers
 	// (stats, tp-list, registration) together with the consuming service's
 	// PK so their subscriber allowlists can be recomputed and re-applied


### PR DESCRIPTION
Groundwork for #4569 — no visor in the deployment is registering over CXO, and the reason was undiagnosable from either end.

dmsg-discovery logs only a generic `subscribe rejected`; the visor logged nothing at all. `CXOFeedState.Denied` and `treestore.Publisher.Denied()` already exist for precisely this case — the field's doc even describes "TPD dialing in under a CXO node key that differs from the ... PK the visor allowlisted" — but the registration publisher was never registered for state reporting, so its allowlist and denied list were never populated. `skywire cli visor state` now names the rejected PK directly, which is the difference between inferring the cause and reading it.

Also corrects two comments describing the feature as opt-in via `Dmsg.RegistrationCXO`. No such field is defined and `initRegistrationCXO` has no flag check — it runs whenever a dmsg-discovery PK resolves. Someone looking for a switch would not find one and might conclude the feature was off.

Diagnostic only: no change to gating, publishing, or the announce path. Verified live that the two feeds already reported (`stats`, `tp-list`) render their allowlists correctly, and this adds the third alongside them.