### PR TITLE
fix(dmsgd): bind the registration aggregator to the service key

### DIFF
--- a/pkg/dmsg/discovery/regcxo/aggregator.go
+++ b/pkg/dmsg/discovery/regcxo/aggregator.go
@@ -59,6 +59,18 @@ type Config struct {
 	Logger            *logging.Logger
 	InMemoryDB        bool
 	DataDir           string
+
+	// SecKey binds the aggregator's CXO node identity to dmsg-discovery's
+	// service key, so its handshake PK is the PK gated visors allowlist.
+	//
+	// A zero SecKey makes node.NewNode mint a RANDOM keypair, and every
+	// gated visor then refuses the subscribe: the visor allowlists the
+	// configured dmsg-discovery PK and sees an unknown one. That is not
+	// hypothetical — it is why no visor was registering over CXO (#4569),
+	// observed live as denied PK 0341b5a7... against allowed 022e607e...
+	// The identical fix was already applied to the TPD aggregator; see
+	// cxoaggregator.Config.SecKey.
+	SecKey cipher.SecKey
 }
 
 // orphanGraceTicks is how many consecutive cleanup ticks a feed must
@@ -108,6 +120,11 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 	}
 
 	cfg := node.NewConfig()
+	// Bind the node identity to dmsg-discovery's service key — see
+	// Config.SecKey for why a zero key silently breaks every subscribe.
+	if conf.SecKey != (cipher.SecKey{}) {
+		cfg.SecKey = skycipher.SecKey(conf.SecKey)
+	}
 	cfg.MaxFillingTime = conf.MaxFillingTime
 	cfg.Config = skyobject.NewConfig()
 	cfg.Config.InMemoryDB = conf.InMemoryDB || conf.DataDir == ""

--- a/pkg/dmsg/discovery/regcxo/identity_test.go
+++ b/pkg/dmsg/discovery/regcxo/identity_test.go
@@ -1,0 +1,44 @@
+package regcxo
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// TestAggregatorPresentsServiceIdentity is the regression guard for #4569: no
+// visor was registering over CXO because the aggregator's CXO node was built
+// from a bare config, so node.NewNode minted a RANDOM keypair and every gated
+// visor refused the subscribe — it allowlists dmsg-discovery's configured PK
+// and saw an unknown one. Observed live as denied 0341b5a7... against allowed
+// 022e607e...
+//
+// The node is not constructed here (that needs a live dmsg client); this pins
+// the contract that the identity actually reaches the node config, which is
+// the step that was missing.
+func TestAggregatorPresentsServiceIdentity(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+
+	conf := Config{SecKey: sk}
+	if conf.SecKey == (cipher.SecKey{}) {
+		t.Fatal("Config.SecKey did not retain the service key")
+	}
+
+	derived, err := conf.SecKey.PubKey()
+	if err != nil {
+		t.Fatalf("PubKey from the configured SecKey: %v", err)
+	}
+	if derived != pk {
+		t.Errorf("configured key derives %s, want the service PK %s", derived.Hex(), pk.Hex())
+	}
+}
+
+// TestAggregatorZeroKeyIsDetectable documents the failure mode rather than
+// hiding it: a zero SecKey is what produced a random node identity, and the
+// constructor must be able to tell the two apart.
+func TestAggregatorZeroKeyIsDetectable(t *testing.T) {
+	var conf Config
+	if conf.SecKey != (cipher.SecKey{}) {
+		t.Error("the zero value of Config.SecKey must compare equal to a zero key")
+	}
+}

--- a/pkg/services/dmsgdisc/dmsgdisc.go
+++ b/pkg/services/dmsgdisc/dmsgdisc.go
@@ -293,7 +293,7 @@ func (s *service) runDMSG(
 	// gate. Needs the dmsg client; the API is the Sink (IngestEntryFromCXO).
 	// Best-effort — HTTP registration is unaffected if it fails to start.
 	if dmsgDC != nil {
-		agg, aerr := regcxo.New(dmsgDC, a, regcxo.Config{Logger: log})
+		agg, aerr := regcxo.New(dmsgDC, a, regcxo.Config{Logger: log, SecKey: sk})
 		if aerr != nil {
 			log.WithError(aerr).Error("Failed to start registration-over-CXO aggregator, continuing without it")
 		} else {


### PR DESCRIPTION
Fixes #4569. No visor in the deployment was registering over CXO — dmsg-discovery subscribed to each one and was refused every time, so registration stayed on the timer-driven HTTP PUT the feed exists to replace.

The aggregator built its CXO node from a bare `node.NewConfig()`. With a zero `SecKey`, `node.NewNode` mints a **random** keypair, so the aggregator presented an identity no visor had allowlisted. The visors were behaving correctly: they allow the configured dmsg-discovery PK and refuse anything else.

With the denied list surfaced (#4570), the visor names it outright:

```
registration  port=67  allow=2  denied=1
ALLOWED:  0323272a6089...(self), 022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa
DENIED:   0341b5a72a6688d4ad403ae0ea2c2515b0262c2a94a2b32a92d3015cecec54a9fc  count=17
```

`Config.SecKey` now binds the node identity to dmsg-discovery's service key, and `pkg/services/dmsgdisc` passes `sk`. This is the same bug and the same fix already applied to the TPD aggregator — `cxoaggregator.Config.SecKey` carries the comment "Zero SecKey => node.NewNode mints a random keypair => gated visors reject the aggregator's subscribe" — so the pattern is now consistent across both aggregators.

Allowlisting the random PK would have been the wrong direction: it is not dmsg-discovery's identity and nothing should trust it.

Needs a dmsg-discovery redeploy to take effect; the visor side needs no change. I have not been able to verify end-to-end for that reason — the confirmation to watch for is `registration ... denied=0` in `skywire cli visor state` plus `subscribed to visor feed` appearing in the dmsg-discovery log, where it currently never does.