### PR TITLE
refactor(dmsgd): move the registration aggregator onto the shared CXO core

### DIFF
--- a/pkg/dmsg/discovery/regcxo/aggregator.go
+++ b/pkg/dmsg/discovery/regcxo/aggregator.go
@@ -14,25 +14,20 @@
 // connection kept warm by the treestore heartbeat. HTTP PUT remains the
 // fallback, so ingest is idempotent (see Sink.IngestEntryFromCXO).
 //
-// Structure mirrors pkg/deployment/tpd/cxoaggregator, trimmed to a
-// single "entry" leaf: same connect-driven subscribe, same grace-gated
-// orphan-feed reclaim that keeps the in-memory CXDS from growing without
-// bound as visor PKs churn.
+// The node, the connect-driven subscribe loop, the grace-gated
+// orphan-feed reclaim and the service-identity binding all live in
+// pkg/cxo/cxoaggregate, shared with the AR and TPD aggregators. What is
+// left here is only what is specific to this feed: a single "entry"
+// leaf carrying a disc.Entry.
 package regcxo
 
 import (
 	"context"
 	"encoding/json"
-	"sync"
 	"time"
 
-	skycipher "github.com/skycoin/skycoin/src/cipher"
-
 	"github.com/skycoin/skywire/pkg/cipher"
-	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
-	"github.com/skycoin/skywire/pkg/cxo/node"
-	cxotransport "github.com/skycoin/skywire/pkg/cxo/node/transport"
-	"github.com/skycoin/skywire/pkg/cxo/skyobject"
+	"github.com/skycoin/skywire/pkg/cxo/cxoaggregate"
 	"github.com/skycoin/skywire/pkg/cxo/skyobject/registry"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
@@ -45,6 +40,9 @@ import (
 // discovery entry at. MUST match pkg/visor's registrationEntryPath.
 const registrationEntryPath = "entry"
 
+// logTag prefixes this aggregator's log lines.
+const logTag = "registration-cxo aggregator"
+
 // Sink ingests entries replicated from visor registration feeds. The
 // discovery API satisfies it via (*api.API).IngestEntryFromCXO.
 type Sink interface {
@@ -52,6 +50,11 @@ type Sink interface {
 }
 
 // Config tunes the aggregator loops. Zero values get sane defaults.
+//
+// The service SecKey is deliberately NOT here — it is a required
+// argument to New. As an optional field it was omitted, node.NewNode
+// minted a random keypair, and every gated visor refused the subscribe
+// (#4569).
 type Config struct {
 	ReconcileInterval time.Duration
 	CleanupInterval   time.Duration
@@ -59,258 +62,60 @@ type Config struct {
 	Logger            *logging.Logger
 	InMemoryDB        bool
 	DataDir           string
-
-	// SecKey binds the aggregator's CXO node identity to dmsg-discovery's
-	// service key, so its handshake PK is the PK gated visors allowlist.
-	//
-	// A zero SecKey makes node.NewNode mint a RANDOM keypair, and every
-	// gated visor then refuses the subscribe: the visor allowlists the
-	// configured dmsg-discovery PK and sees an unknown one. That is not
-	// hypothetical — it is why no visor was registering over CXO (#4569),
-	// observed live as denied PK 0341b5a7... against allowed 022e607e...
-	// The identical fix was already applied to the TPD aggregator; see
-	// cxoaggregator.Config.SecKey.
-	SecKey cipher.SecKey
 }
 
-// orphanGraceTicks is how many consecutive cleanup ticks a feed must
-// have zero connected conns before it is reclaimed. At the 2-minute
-// default CleanupInterval this is a ~4-minute grace — long enough to
-// ride out a visor's dmsg reconnect without churning a stable feed.
-const orphanGraceTicks = 2
-
-// Aggregator owns one CXO Node listening on DMSG; visors dial in,
-// subscribe happens per-conn during reconcile, and OnRootFilled reads
-// the entry leaf and forwards it to the Sink.
+// Aggregator receives visor registration feeds. It is the shared
+// cxoaggregate.Core plus this feed's entry-leaf decoding.
 type Aggregator struct {
-	cxoNode *node.Node
-	sink    Sink
-	conf    Config
-	log     *logging.Logger
-
-	mu     sync.Mutex
-	cancel context.CancelFunc
-	done   chan struct{}
-
-	// nudge triggers an immediate reconcile out of band from the ticker.
-	// Buffered(1) so a burst of connects coalesces into one pending
-	// reconcile (idempotent — it walks the full conn set anyway).
-	nudge chan struct{}
-
-	// orphanStrikes counts consecutive cleanup ticks a feed has had no
-	// connected conn. Touched only from cleanup() (single goroutine).
-	orphanStrikes map[skycipher.PubKey]int
+	core *cxoaggregate.Core
+	sink Sink
+	log  *logging.Logger
 }
 
 // New constructs an Aggregator: a CXO Node with DMSG enabled on
 // DmsgDMSGDRegistrationCXOPort so remote visors can dial in, wired to
 // forward each filled Root's entry leaf to sink.
-func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
-	if conf.ReconcileInterval <= 0 {
-		conf.ReconcileInterval = 30 * time.Second
-	}
-	if conf.CleanupInterval <= 0 {
-		conf.CleanupInterval = 2 * time.Minute
-	}
-	if conf.MaxFillingTime <= 0 {
-		conf.MaxFillingTime = 90 * time.Second
-	}
+//
+// sk is dmsg-discovery's service secret key. It binds the CXO node
+// identity so the aggregator's handshake PK is the PK gated visors
+// allowlist.
+func New(dmsgC *dmsg.Client, sk cipher.SecKey, sink Sink, conf Config) (*Aggregator, error) {
 	if conf.Logger == nil {
 		conf.Logger = logging.MustGetLogger("dmsgd-registration-cxo")
 	}
+	a := &Aggregator{sink: sink, log: conf.Logger}
 
-	cfg := node.NewConfig()
-	// Bind the node identity to dmsg-discovery's service key — see
-	// Config.SecKey for why a zero key silently breaks every subscribe.
-	if conf.SecKey != (cipher.SecKey{}) {
-		cfg.SecKey = skycipher.SecKey(conf.SecKey)
-	}
-	cfg.MaxFillingTime = conf.MaxFillingTime
-	cfg.Config = skyobject.NewConfig()
-	cfg.Config.InMemoryDB = conf.InMemoryDB || conf.DataDir == ""
-	if conf.DataDir != "" {
-		cfg.Config.DataDir = conf.DataDir
-	}
-
-	cxoNode, err := node.NewNode(cfg)
+	core, err := cxoaggregate.New(dmsgC, sk, skyenv.DmsgDMSGDRegistrationCXOPort, cxoaggregate.Options{
+		ReconcileInterval: conf.ReconcileInterval,
+		CleanupInterval:   conf.CleanupInterval,
+		MaxFillingTime:    conf.MaxFillingTime,
+		Logger:            conf.Logger,
+		LogTag:            logTag,
+		InMemoryDB:        conf.InMemoryDB,
+		DataDir:           conf.DataDir,
+		OnRootFilled:      a.handleRootFilled,
+		OnFillingBreaks: func(r *registry.Root, reason error) {
+			a.log.WithError(reason).WithField("visor", cipher.PubKey(r.Pub)).
+				Debug(logTag + ": root filling broke")
+		},
+	})
 	if err != nil {
 		return nil, err
 	}
-	factory := cxotransport.NewDMSGFactory(dmsgC, skyenv.DmsgDMSGDRegistrationCXOPort)
-	if err := cxoNode.EnableDMSG(factory); err != nil {
-		_ = cxoNode.Close() //nolint:errcheck
-		return nil, err
-	}
-
-	a := &Aggregator{
-		cxoNode:       cxoNode,
-		sink:          sink,
-		conf:          conf,
-		log:           conf.Logger,
-		done:          make(chan struct{}),
-		nudge:         make(chan struct{}, 1),
-		orphanStrikes: make(map[skycipher.PubKey]int),
-	}
-
-	// Subscribe the moment a visor dials in, rather than waiting up to a
-	// full ReconcileInterval. The conn's handshake completes (peerID set)
-	// before OnConnect fires, so the nudged reconcile can subscribe at
-	// once; it stays idempotent via alreadySubscribed.
-	cxoNode.Config().OnConnect = func(_ *node.Conn) error {
-		select {
-		case a.nudge <- struct{}{}:
-		default:
-		}
-		return nil
-	}
-	cxoNode.Config().OnRootFilled = func(_ *node.Node, r *registry.Root) {
-		a.handleRootFilled(r)
-	}
-	cxoNode.Config().OnFillingBreaks = func(_ *node.Node, r *registry.Root, reason error) {
-		a.log.WithError(reason).WithField("visor", cipher.PubKey(r.Pub)).
-			Debug("registration-cxo aggregator: root filling broke")
-	}
+	a.core = core
 	return a, nil
 }
 
 // Run starts the reconcile + cleanup loops. Returns immediately; the loop
 // runs until ctx is canceled or Close is called. Idempotent.
-func (a *Aggregator) Run(ctx context.Context) {
-	a.mu.Lock()
-	if a.cancel != nil {
-		a.mu.Unlock()
-		return
-	}
-	loopCtx, cancel := context.WithCancel(ctx)
-	a.cancel = cancel
-	a.mu.Unlock()
-	go a.loop(loopCtx)
-}
+func (a *Aggregator) Run(ctx context.Context) { a.core.Run(ctx) }
 
 // Close stops the loops and tears down the CXO node. Idempotent.
-func (a *Aggregator) Close() error {
-	a.mu.Lock()
-	cancel := a.cancel
-	a.cancel = nil
-	a.mu.Unlock()
-	if cancel != nil {
-		cancel()
-		<-a.done
-	}
-	return a.cxoNode.Close()
-}
+func (a *Aggregator) Close() error { return a.core.Close() }
 
-// FeedPK returns the aggregator's own CXO node identity.
-func (a *Aggregator) FeedPK() cipher.PubKey { return cipher.PubKey(a.cxoNode.ID()) }
-
-func (a *Aggregator) loop(ctx context.Context) {
-	defer close(a.done)
-	t := time.NewTicker(a.conf.ReconcileInterval)
-	defer t.Stop()
-	ct := time.NewTicker(a.conf.CleanupInterval)
-	defer ct.Stop()
-
-	a.reconcile()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.C:
-			a.reconcile()
-		case <-ct.C:
-			a.cleanup()
-		case <-a.nudge:
-			a.reconcile()
-		}
-	}
-}
-
-// reconcile subscribes to every connected visor's own feed (feed PK ==
-// peer PK) that isn't already subscribed. Dropped conns simply aren't in
-// the list anymore.
-func (a *Aggregator) reconcile() {
-	for _, conn := range a.cxoNode.Connections() {
-		peerPK := conn.PeerID()
-		if peerPK == (skycipher.PubKey{}) {
-			continue
-		}
-		if alreadySubscribed(conn, peerPK) {
-			continue
-		}
-		if err := conn.Subscribe(peerPK); err != nil {
-			a.log.WithError(err).WithField("visor", cipher.PubKey(peerPK)).
-				Debug("registration-cxo aggregator: Subscribe failed; will retry next reconcile")
-			continue
-		}
-		a.log.WithField("visor", cipher.PubKey(peerPK)).
-			Debug("registration-cxo aggregator: subscribed to visor feed")
-	}
-}
-
-func alreadySubscribed(conn *node.Conn, feed skycipher.PubKey) bool {
-	for _, f := range conn.Feeds() {
-		if f == feed {
-			return true
-		}
-	}
-	return false
-}
-
-// cleanup prunes superseded Roots (keeping only the latest per feed) and
-// reclaims feeds whose visor has gone away, then sweeps ownerless
-// objects. Without this the in-memory store grows without bound as visor
-// PKs churn (each keeps its final Root tree pinned).
-func (a *Aggregator) cleanup() {
-	c := a.cxoNode.Container()
-	if err := cxoutils.RemoveRootObjects(c, 1); err != nil {
-		a.log.WithError(err).Debug("registration-cxo aggregator: RemoveRootObjects failed; will retry next tick")
-		return
-	}
-	a.reclaimOrphanFeeds(c)
-	if err := cxoutils.RemoveObjects(c); err != nil {
-		a.log.WithError(err).Debug("registration-cxo aggregator: RemoveObjects failed; will retry next tick")
-	}
-}
-
-// reclaimOrphanFeeds un-shares and hard-deletes feeds that no longer have
-// a connected conn, grace-gated by orphanGraceTicks so a brief drop +
-// redial keeps the feed.
-func (a *Aggregator) reclaimOrphanFeeds(c *skyobject.Container) {
-	connected := make(map[skycipher.PubKey]struct{})
-	for _, conn := range a.cxoNode.Connections() {
-		if pk := conn.PeerID(); pk != (skycipher.PubKey{}) {
-			connected[pk] = struct{}{}
-		}
-	}
-	self := a.cxoNode.ID()
-	for _, feed := range c.Feeds() {
-		if feed == self {
-			delete(a.orphanStrikes, feed)
-			continue
-		}
-		if _, ok := connected[feed]; ok {
-			delete(a.orphanStrikes, feed)
-			continue
-		}
-		a.orphanStrikes[feed]++
-		if a.orphanStrikes[feed] < orphanGraceTicks {
-			continue
-		}
-		delete(a.orphanStrikes, feed)
-		if err := a.cxoNode.DontShare(feed); err != nil {
-			a.log.WithError(err).WithField("visor", cipher.PubKey(feed)).
-				Debug("registration-cxo aggregator: DontShare orphan feed failed; will retry next tick")
-			continue
-		}
-		if err := c.DelFeed(feed); err != nil {
-			a.log.WithError(err).WithField("visor", cipher.PubKey(feed)).
-				Debug("registration-cxo aggregator: DelFeed orphan feed failed; will retry next tick")
-			continue
-		}
-		a.log.WithField("visor", cipher.PubKey(feed)).
-			Debug("registration-cxo aggregator: reclaimed orphan feed (no connected conn)")
-	}
-}
+// FeedPK returns the aggregator's own CXO node identity — dmsg-discovery's
+// service PK.
+func (a *Aggregator) FeedPK() cipher.PubKey { return a.core.FeedPK() }
 
 // handleRootFilled reads the "entry" leaf from a filled Root and forwards
 // the decoded disc.Entry to the Sink. r.Pub is the visor whose feed
@@ -322,51 +127,31 @@ func (a *Aggregator) handleRootFilled(r *registry.Root) {
 	}
 	reporter := cipher.PubKey(r.Pub)
 	if reporter == (cipher.PubKey{}) {
-		a.log.Debug("registration-cxo aggregator: dropping root with zero publisher PK")
+		a.log.Debug(logTag + ": dropping root with zero publisher PK")
 		return
 	}
-	pack, err := a.cxoNode.Container().Pack(r, treestore.Registry)
+	pack, err := a.core.Container().Pack(r, treestore.Registry)
 	if err != nil {
-		a.log.WithError(err).Debug("registration-cxo aggregator: get pack failed")
+		a.log.WithError(err).Debug(logTag + ": get pack failed")
 		return
 	}
 	var rootNode treestore.TreeNode
 	if err := r.Refs[0].Value(pack, &rootNode); err != nil {
-		a.log.WithError(err).Debug("registration-cxo aggregator: decode root TreeNode failed")
+		a.log.WithError(err).Debug(logTag + ": decode root TreeNode failed")
 		return
 	}
 
-	leaf, ok := findLeaf(pack, &rootNode, registrationEntryPath)
+	leaf, ok := cxoaggregate.LeafByName(pack, &rootNode, registrationEntryPath)
 	if !ok || len(leaf) == 0 {
 		return
 	}
 	entry := new(disc.Entry)
 	if err := json.Unmarshal(leaf, entry); err != nil {
 		a.log.WithError(err).WithField("visor", reporter).
-			Debug("registration-cxo aggregator: entry leaf decode failed")
+			Debug(logTag + ": entry leaf decode failed")
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	a.sink.IngestEntryFromCXO(ctx, entry, reporter)
-}
-
-// findLeaf returns the leaf value stored directly under n at the given
-// top-level name. The registration feed is flat (one "entry" leaf), so a
-// single level of lookup suffices — no recursive walk.
-func findLeaf(pack registry.Pack, n *treestore.TreeNode, name string) ([]byte, bool) {
-	count, err := n.Children.Len(pack)
-	if err != nil {
-		return nil, false
-	}
-	for i := 0; i < count; i++ {
-		var entry treestore.TreeEntry
-		if _, err := n.Children.ValueByIndex(pack, i, &entry); err != nil {
-			continue
-		}
-		if entry.Name == name && len(entry.Leaf) > 0 {
-			return entry.Leaf, true
-		}
-	}
-	return nil, false
 }

--- a/pkg/dmsg/discovery/regcxo/identity_test.go
+++ b/pkg/dmsg/discovery/regcxo/identity_test.go
@@ -1,44 +1,61 @@
+// Package regcxo — identity_test.go: the regression guard for #4569.
+//
+// No visor was registering over CXO because this aggregator's CXO node
+// was built from a bare config, so node.NewNode minted a RANDOM keypair
+// and every gated visor refused the subscribe — it allowlists
+// dmsg-discovery's configured PK and saw an unknown one — observed live
+// as a denied subscriber PK matching nothing the visor allowlisted.
+//
+// The key is now a required argument to New, so the omission cannot
+// recur; this asserts the constructed aggregator really does present
+// dmsg-discovery's PK.
 package regcxo
 
 import (
+	"context"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoaggregate"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgtest"
+	"github.com/skycoin/skywire/pkg/logging"
 )
 
-// TestAggregatorPresentsServiceIdentity is the regression guard for #4569: no
-// visor was registering over CXO because the aggregator's CXO node was built
-// from a bare config, so node.NewNode minted a RANDOM keypair and every gated
-// visor refused the subscribe — it allowlists dmsg-discovery's configured PK
-// and saw an unknown one. Observed live as denied 0341b5a7... against allowed
-// 022e607e...
-//
-// The node is not constructed here (that needs a live dmsg client); this pins
-// the contract that the identity actually reaches the node config, which is
-// the step that was missing.
+type nopSink struct{}
+
+func (nopSink) IngestEntryFromCXO(_ context.Context, _ *disc.Entry, _ cipher.PubKey) {}
+
+// TestAggregatorPresentsServiceIdentity: the aggregator's CXO node must
+// advertise dmsg-discovery's own PK on every handshake, because that is
+// the PK gated visors allowlist for this feed.
 func TestAggregatorPresentsServiceIdentity(t *testing.T) {
 	pk, sk := cipher.GenerateKeyPair()
 
-	conf := Config{SecKey: sk}
-	if conf.SecKey == (cipher.SecKey{}) {
-		t.Fatal("Config.SecKey did not retain the service key")
-	}
+	env := dmsgtest.NewEnv(t, 30*time.Second)
+	require.NoError(t, env.Startup(0, 1, 0, &dmsg.Config{MinSessions: 1}))
+	t.Cleanup(env.Shutdown)
+	dmsgC, err := env.NewClientWithKeys(pk, sk, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err)
 
-	derived, err := conf.SecKey.PubKey()
-	if err != nil {
-		t.Fatalf("PubKey from the configured SecKey: %v", err)
-	}
-	if derived != pk {
-		t.Errorf("configured key derives %s, want the service PK %s", derived.Hex(), pk.Hex())
-	}
+	agg, err := New(dmsgC, sk, nopSink{}, Config{
+		InMemoryDB: true,
+		Logger:     logging.MustGetLogger("dmsgd-registration-cxo-test"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agg.Close() }) //nolint:errcheck
+
+	require.Equal(t, pk, agg.FeedPK(),
+		"the registration aggregator must present dmsg-discovery's configured PK, not a random one")
 }
 
-// TestAggregatorZeroKeyIsDetectable documents the failure mode rather than
-// hiding it: a zero SecKey is what produced a random node identity, and the
-// constructor must be able to tell the two apart.
-func TestAggregatorZeroKeyIsDetectable(t *testing.T) {
-	var conf Config
-	if conf.SecKey != (cipher.SecKey{}) {
-		t.Error("the zero value of Config.SecKey must compare equal to a zero key")
-	}
+// TestAggregatorRejectsZeroKey: a zero key is the exact #4569 shape and
+// must be a construction error, never a random identity.
+func TestAggregatorRejectsZeroKey(t *testing.T) {
+	_, err := New(nil, cipher.SecKey{}, nopSink{}, Config{InMemoryDB: true})
+	require.ErrorIs(t, err, cxoaggregate.ErrNoServiceKey)
 }

--- a/pkg/services/dmsgdisc/dmsgdisc.go
+++ b/pkg/services/dmsgdisc/dmsgdisc.go
@@ -293,7 +293,7 @@ func (s *service) runDMSG(
 	// gate. Needs the dmsg client; the API is the Sink (IngestEntryFromCXO).
 	// Best-effort — HTTP registration is unaffected if it fails to start.
 	if dmsgDC != nil {
-		agg, aerr := regcxo.New(dmsgDC, a, regcxo.Config{Logger: log, SecKey: sk})
+		agg, aerr := regcxo.New(dmsgDC, sk, a, regcxo.Config{Logger: log})
 		if aerr != nil {
 			log.WithError(aerr).Error("Failed to start registration-over-CXO aggregator, continuing without it")
 		} else {


### PR DESCRIPTION
First of the three migrations onto `pkg/cxo/cxoaggregate` (#4573). The registration-over-CXO aggregator now composes the shared core for the node, the connect-driven subscribe loop, orphan-feed reclaim, cleanup and close; what stays in `pkg/dmsg/discovery/regcxo` is only what is specific to this feed — the single `entry` leaf carrying a signed `disc.Entry`. Net −198 lines, no behavior change to the ingest path.

dmsg-discovery's service key moves from an optional `Config` field to a required argument of `New`, so the omission that made every gated visor refuse this aggregator's subscribe (#4569) cannot be repeated — a caller that forgets it no longer compiles. Two things the shared core brings along: the CXO node's default TCP (:8870) and RPC (:8871) listeners are now zeroed, as they already were on the AR and TPD copies (they are unreachable over dmsg and collide between two nodes in one process, #4152), and `New` now fails at startup if the node's identity is not the service PK instead of being silently refused by every visor.

Verified: `go build .`, `go test` green for `pkg/dmsg/discovery/regcxo` and `pkg/services/dmsgdisc`, `golangci-lint` clean on both the default and `GOOS=windows` tiers. The package test now constructs the real aggregator over an in-process dmsg env and asserts `FeedPK()` is dmsg-discovery's configured PK.

Part of #4572.
