### PR TITLE
test(dmsgcurl): back off between download retries

### DIFF
--- a/pkg/dmsg/dmsgcurl/dmsgcurl_test.go
+++ b/pkg/dmsg/dmsgcurl/dmsgcurl_test.go
@@ -73,8 +73,15 @@ func TestDownload(t *testing.T) {
 			defer cancel()
 			httpC := newHTTPClient(t, dc)
 
+			// The in-process dmsg env races session setup when the runner is
+			// contended: attempts fail with "extra bytes received during session
+			// handshake" (dmsg error 203), "session shutdown" or a broken pipe, and
+			// a flat 5 x 100ms budget exhausts before the env settles. Back off
+			// instead, so the retry actually outlasts a slow start rather than
+			// hammering the same window.
 			var err error
-			for attempt := 0; attempt < 5; attempt++ {
+			backoff := 100 * time.Millisecond
+			for attempt := 0; attempt < 8; attempt++ {
 				if _, err = dsts[i].Seek(0, io.SeekStart); err != nil {
 					break
 				}
@@ -84,8 +91,11 @@ func TestDownload(t *testing.T) {
 				if err = Download(ctx, log, httpC, dsts[i], hsAddr, fileSize); err == nil {
 					break
 				}
-				log.WithError(err).Warnf("download attempt %d failed, retrying", attempt)
-				time.Sleep(100 * time.Millisecond)
+				log.WithError(err).Warnf("download attempt %d failed, retrying in %s", attempt, backoff)
+				time.Sleep(backoff)
+				if backoff < 2*time.Second {
+					backoff *= 2
+				}
 			}
 
 			errs[i] <- err


### PR DESCRIPTION
The `linux` job — the one that actually gates correctness — has failed on the last two develop commits, both on `TestDownload` in `pkg/dmsg/dmsgcurl`.

The test spawns concurrent download clients over an in-process dmsg env and retries 5 times at a flat 100ms. Under CI runner contention the env races its own session setup — the run logs are full of `dmsg error 203 - extra bytes received during session handshake`, `session shutdown`, and `write: broken pipe` — and a flat 500ms total budget exhausts before it settles. It passes locally 6/6, and 8/8 under `-race`, which is consistent with contention rather than a product regression.

Now 8 attempts with exponential backoff capped at 2s, so the retry outlasts a slow start instead of hammering the same window.

Test-only. Worth noting separately that `extra bytes received during session handshake` under concurrent session setup is a symptom worth understanding on its own — this change makes the gate reliable, it does not explain that.