### PR TITLE
test: fix a cross-test data race in skysocks, and make the cxo churn test say why it failed

### DIFF
--- a/pkg/cxo/treestore/churn_lag_test.go
+++ b/pkg/cxo/treestore/churn_lag_test.go
@@ -10,6 +10,7 @@ package treestore
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -64,6 +65,29 @@ func (c *churnSub) snapshot() (int, int, int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return len(c.present), c.events, c.roots
+}
+
+// diff compares the subscriber's live set against the publisher's expected one,
+// returning what the subscriber is missing and what it is holding that it should
+// not be. A convergence failure is otherwise just a count: this says WHICH paths
+// are wrong, which is what separates "the newest write has not landed yet" (tail
+// lag) from "an old delete was dropped" (the lost-delete hazard).
+func (c *churnSub) diff(want map[string]struct{}) (missing, extra []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for p := range want {
+		if _, ok := c.present[p]; !ok {
+			missing = append(missing, p)
+		}
+	}
+	for p := range c.present {
+		if _, ok := want[p]; !ok {
+			extra = append(extra, p)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	return missing, extra
 }
 
 // waitConverge blocks until the subscriber's present-set size equals want (or
@@ -189,6 +213,11 @@ func TestCXOChurn_Sustained(t *testing.T) {
 			const (
 				churnDur   = 4 * time.Second
 				liveTarget = 40
+				// convergeBudget is the lag figure this test reports. convergeGrace is
+				// the extra time allowed before calling a miss a dropped update rather
+				// than a slow runner — see the tail assertion below.
+				convergeBudget = 10 * time.Second
+				convergeGrace  = 20 * time.Second
 			)
 			for i := 0; i < liveTarget; i++ {
 				require.NoError(t, pub.Put(fmt.Sprintf("tp/%05d", i), []byte("seed")))
@@ -217,11 +246,45 @@ func TestCXOChurn_Sustained(t *testing.T) {
 			// after the flap stops.
 			require.NoError(t, pub.Flush())
 
-			tailLag, ok := cs.waitConverge(liveTarget, 10*time.Second)
+			// The live set after churn is the last liveTarget paths written:
+			// every iteration added one and deleted one, so [oldest, next) is
+			// exactly what the publisher should be holding.
+			wantLive := make(map[string]struct{}, liveTarget)
+			for i := oldest; i < next; i++ {
+				wantLive[fmt.Sprintf("tp/%05d", i)] = struct{}{}
+			}
+
+			tailLag, ok := cs.waitConverge(liveTarget, convergeBudget)
+			// Missing the budget is ambiguous on a loaded runner, and the two
+			// readings call for opposite responses: the subscriber may still be
+			// draining (CI noise), or an update may be gone for good (the
+			// lost-delete hazard this test exists to catch). Failing on the
+			// budget alone conflates them — it fails the build for slowness and
+			// reports a dropped update as "too slow". So keep watching, and let
+			// what happens next decide which it was.
+			var graceLag time.Duration
+			graceOK := false
+			if !ok {
+				graceLag, graceOK = cs.waitConverge(liveTarget, convergeGrace)
+			}
+
 			present, events, roots := cs.snapshot()
-			t.Logf("churn rate=%d/s: %d ops in %s; post-churn+flush converge=%v in %s; final present=%d (want %d) events=%d roots=%d",
-				mutPerSec, ops, churnDur, ok, tailLag.Round(time.Millisecond), present, liveTarget, events, roots)
-			require.True(t, ok, "subscriber must converge to the final live set after churn stops (rate=%d/s)", mutPerSec)
+			t.Logf("churn rate=%d/s: %d ops in %s (%.0f/s achieved of %d/s asked); post-churn+flush converge=%v in %s; final present=%d (want %d) events=%d roots=%d",
+				mutPerSec, ops, churnDur, float64(ops)/churnDur.Seconds(), 2*mutPerSec,
+				ok, tailLag.Round(time.Millisecond), present, liveTarget, events, roots)
+
+			if !ok && graceOK {
+				// Slow, not inconsistent. Worth seeing in the log, not worth
+				// failing a build over — this test's header says it is not a
+				// timing gate.
+				t.Logf("rate=%d/s: converged only after %s of extra grace (%.0f/s achieved); treating as a slow runner, not an inconsistency",
+					mutPerSec, graceLag.Round(time.Millisecond), float64(ops)/churnDur.Seconds())
+			}
+			if !ok && !graceOK {
+				missing, extra := cs.diff(wantLive)
+				t.Fatalf("rate=%d/s: subscriber never reached the publisher's final live set, even after %s + %s of grace — this is a DROPPED UPDATE, not slowness.\n  present=%d want=%d events=%d roots=%d\n  missing (publisher has, subscriber lacks): %v\n  extra (subscriber has, publisher deleted): %v",
+					mutPerSec, convergeBudget, convergeGrace, present, liveTarget, events, roots, missing, extra)
+			}
 			require.Equal(t, liveTarget, present, "no stale/lost entries after convergence (rate=%d/s)", mutPerSec)
 		})
 	}

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -87,10 +87,25 @@ type Client struct {
 	listener  net.Listener
 	once      sync.Once
 	closeC    chan struct{}
-	// keepAliveDone is closed when sessionKeepAliveLoop returns, so a test can
-	// join the loop (it reads the package-level probe tunables) before
-	// restoring them.
+	// keepAliveDone is closed when sessionKeepAliveLoop returns, so a caller can
+	// join the loop before tearing down what it depends on.
 	keepAliveDone chan struct{}
+
+	// probeInterval and hardDeadWindow are this client's copies of the
+	// package-level liveness tunables (see livenessProbeInterval and
+	// sessionHardDeadWindow), snapshotted by NewClient BEFORE the keepalive
+	// goroutine starts and never written afterwards. The loop reads only these.
+	//
+	// They are per-client rather than global because the loop outlives the call
+	// that created it: NewClient spawns the goroutine, and a caller that closes
+	// the client without joining keepAliveDone leaves it running a while longer.
+	// In tests that meant one test's leaked loop was still reading the globals
+	// while the next test's harness shrank them — a genuine data race, and one
+	// that care inside any single test could not fix, because the racing ends
+	// belong to different tests. Copying per client removes the sharing rather
+	// than synchronizing it.
+	probeInterval  time.Duration
+	hardDeadWindow time.Duration
 
 	// streams tracks the currently open tunneled streams so the status page can
 	// expand the "N open stream(s)" count into per-stream rows (id + CONNECT
@@ -254,6 +269,10 @@ func NewClient(conn net.Conn, appCl *app.Client) (*Client, error) {
 		// SetTunnelTarget so a re-dial can refill even after a short initial dial.
 		target: 1,
 		rs:     defaultRangeSplitConfig(),
+		// Snapshotted before the keepalive goroutine below starts, so the loop
+		// never reads the package-level vars.
+		probeInterval:  livenessProbeInterval,
+		hardDeadWindow: sessionHardDeadWindow,
 	}
 
 	session, stamp, err := newYamuxSession(conn)
@@ -715,8 +734,10 @@ func (c *Client) ListenAndServe(addr string) error {
 // seen for sessionHardDeadWindow, which tolerates a merely-slow or
 // transiently reorder-wedged route (a false close costs a reconnect cycle).
 //
-// livenessProbeInterval is how often the keepalive loop probes each tunnel. A
-// var so tests can drive the loop fast.
+// livenessProbeInterval is the DEFAULT for how often the keepalive loop probes
+// each tunnel. NewClient snapshots it into Client.probeInterval; the loop reads
+// only that field. A var so tests can set it before constructing a client to
+// drive that client's loop fast.
 var livenessProbeInterval = 15 * time.Second
 
 // sessionHardDeadWindow is how long a tunnel may go WITHOUT any pong before the
@@ -734,7 +755,9 @@ var livenessProbeInterval = 15 * time.Second
 // been seen for this window, which distinguishes a wedged-but-live tunnel
 // (pongs arrive late, or the download's own bytes keep arriving while the pong
 // sits behind them) from a genuinely silent/black-holed one (never sends
-// again). A var so tests can shrink it. Kept comfortably above the worst
+// again). This is the DEFAULT: NewClient snapshots it into
+// Client.hardDeadWindow and the loop reads only that field. A var so tests can
+// shrink it before constructing a client. Kept comfortably above the worst
 // realistic wedge duration.
 var sessionHardDeadWindow = 45 * time.Second
 
@@ -758,7 +781,7 @@ var sessionHardDeadWindow = 45 * time.Second
 // re-dials a fresh DISJOINT replacement via maybeRedial (docs/mux_aggregation_rfc.md
 // steps 3-4).
 func (c *Client) sessionKeepAliveLoop() {
-	ticker := time.NewTicker(livenessProbeInterval)
+	ticker := time.NewTicker(c.probeInterval)
 	defer ticker.Stop()
 
 	type probeResult struct {
@@ -820,7 +843,7 @@ func (c *Client) sessionKeepAliveLoop() {
 				if rt := c.lastRecvTime(s); rt.After(lastAlive) {
 					lastAlive = rt
 				}
-				if now.Sub(lastAlive) >= sessionHardDeadWindow {
+				if now.Sub(lastAlive) >= c.hardDeadWindow {
 					if c.appCl != nil {
 						c.appCl.Log().Warnf("No pong and no traffic either way for %v (> hard-dead window); tunnel gone, retiring it", now.Sub(lastAlive).Truncate(time.Second))
 					}

--- a/pkg/skysocks/client_liveness_test.go
+++ b/pkg/skysocks/client_liveness_test.go
@@ -171,9 +171,10 @@ func newLoopHarness(t *testing.T) (*Client, *gatedConn) {
 	}
 	t.Cleanup(func() {
 		c.Close() //nolint:errcheck,gosec
-		// Join the keepalive loop before the tunable-restoring cleanup (registered
-		// earlier, so it runs after this one) writes the package-level cadence
-		// vars the loop reads.
+		// Join the keepalive loop so the goroutine is done before the test ends.
+		// The loop reads this client's own snapshot of the cadence tunables, not
+		// the package-level vars, so restoring those no longer races it — but
+		// joining still keeps the goroutine from outliving its test.
 		<-c.keepAliveDone
 	})
 	return c, gate


### PR DESCRIPTION
Two pre-existing test bugs behind intermittent `windows` CI failures. Neither is caused by recent work; both reproduce on develop.

**skysocks.** `livenessProbeInterval` and `sessionHardDeadWindow` were package vars read by the keepalive goroutine and written by a test helper. The loop outlives the call that starts it — `TestSessionAlive_Healthy` closes its client but never joins `keepAliveDone` — so one test's leaked loop was still reading them while the next test's harness shrank them. No care inside a single test could fix that, because the racing ends belong to different tests. `NewClient` now snapshots both into `Client` fields before starting the goroutine, and the loop reads only those. A probe reproducing the pattern trips the race detector repeatedly against the old code and is clean against this one.

**cxo/treestore.** `TestCXOChurn_Sustained` missed a fixed 10s convergence deadline on a slow runner. Just extending it would have been the wrong fix: the failing run had only 81 events to drain, so 10s was never the binding constraint, and a subscriber stuck at 41 for the whole window is the lost-delete hazard this test's own comment says it exists to catch. It now waits a further grace period and distinguishes the two cases — converged-late logs "slow runner, not an inconsistency" and passes; still-stuck fails as a DROPPED UPDATE and prints which paths are missing versus extra, so the next occurrence diagnoses itself. It also logs achieved-vs-asked throughput, which is what made the original failure hard to read.

`gofmt`, `go vet` and golangci-lint clean on both packages. `pkg/skysocks` passes `-race -count=5`; `pkg/cxo/treestore` passes in full, and both new branches were exercised by forcing them.