### PR TITLE
fix(desk): let hypervisor UI windows receive clicks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/0magnet/bitree v0.0.0-20260906024001-ee60eac20a9d
 	github.com/0magnet/bottle v0.0.0-20260905154223-835049919520
 	github.com/0magnet/calvin v0.0.0-20260905171945-6d046e156c9b
-	github.com/0magnet/desk v0.0.0-20260905010738-0c9209d8b7b7
+	github.com/0magnet/desk v0.0.0-20260906155330-9925d12693bb
 	github.com/0magnet/desk/panes v0.0.0-20260905010738-0c9209d8b7b7
 	github.com/0magnet/gobrpc v0.0.0-20260906024008-cd93b2d1ef48
 	github.com/0magnet/golang-ipc v1.2.5-0.20260901195306-becfc11f7586

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/0magnet/coloredcobra v1.0.3-0.20260902084726-57ccbecfc077 h1:cWpt53uN
 github.com/0magnet/coloredcobra v1.0.3-0.20260902084726-57ccbecfc077/go.mod h1:Kn7dmRJcnVybFNKY0FNUjLcsivW4FCbAec8ZfVmz51I=
 github.com/0magnet/cosmos-go v0.0.0-20260905162431-a5584b3ff959 h1:5Cm6K8ajBt653BHbYaXkD/ul6weOkViWtpc0205GIUY=
 github.com/0magnet/cosmos-go v0.0.0-20260905162431-a5584b3ff959/go.mod h1:dp0q1zfKQmTaohUrPEPZbPExxBWLu9DyeaFxKUBnw6Y=
-github.com/0magnet/desk v0.0.0-20260905010738-0c9209d8b7b7 h1:lo7ac0NQnL0xAAX8pp5FsFs2LwOfaXoFZHgovKvUUUc=
-github.com/0magnet/desk v0.0.0-20260905010738-0c9209d8b7b7/go.mod h1:9VSe+GQN9638OmSPr8J84CgTMinZ6qNj4Xj6aNCfKlU=
+github.com/0magnet/desk v0.0.0-20260906155330-9925d12693bb h1:JjxsT6JlhNIgzxxihgHP0+r9bWOAMQOMfmoq8wJjlpk=
+github.com/0magnet/desk v0.0.0-20260906155330-9925d12693bb/go.mod h1:9VSe+GQN9638OmSPr8J84CgTMinZ6qNj4Xj6aNCfKlU=
 github.com/0magnet/desk/panes v0.0.0-20260905010738-0c9209d8b7b7 h1:L26z7aBIBiDk8q2i/YhJyi6x9hrvdRgIygKtkGUUVmM=
 github.com/0magnet/desk/panes v0.0.0-20260905010738-0c9209d8b7b7/go.mod h1:z/ML2hEd//x/SznagiS5+g3NskrU49QYO2zpkO3Y3p8=
 github.com/0magnet/go-dsp v0.0.0-20260904172328-4474a45054c8 h1:dix2DTc6kVttvmez6KKA6Zux4khpyE3Lrfv7iPXDUQM=

--- a/vendor/github.com/0magnet/desk/Makefile
+++ b/vendor/github.com/0magnet/desk/Makefile
@@ -90,7 +90,7 @@ lint: ## Run golangci-lint. Needs it installed (make install-linters)
 	fi
 	@# A host run cannot see js/wasm-tagged files, so anything only they use
 	@# reads as dead — and anything wrong inside them is never checked at all.
-	@if grep -rlq '^//go:build js' --include='*.go' . 2>/dev/null; then \
+	@if grep -rlq '^//go:build js' --include='*.go' --exclude-dir=vendor . 2>/dev/null; then \
 		echo '--- again in the js/wasm build context'; \
 		CGO_ENABLED=0 GOOS=js GOARCH=wasm ${OPTS} golangci-lint run --modules-download-mode=$(MODMODE) -c $(LINTCFG) $(JSPKGS); \
 	fi
@@ -100,7 +100,7 @@ vet: ## Run go vet
 	@if [ -n "$(PKGS)" ]; then \
 		CGO_ENABLED=$(CGO) ${OPTS} go vet $(PKGS); \
 	fi
-	@if grep -rlq '^//go:build js' --include='*.go' . 2>/dev/null; then \
+	@if grep -rlq '^//go:build js' --include='*.go' --exclude-dir=vendor . 2>/dev/null; then \
 		CGO_ENABLED=0 GOOS=js GOARCH=wasm ${OPTS} go vet $(JSPKGS); \
 	fi
 	$(recurse)

--- a/vendor/github.com/0magnet/desk/README.md
+++ b/vendor/github.com/0magnet/desk/README.md
@@ -138,18 +138,51 @@ nothing about MIME types.
 The desk is a desktop environment that could touch nothing: its shell is websh,
 a Bash interpreter compiled to wasm, and its filesystem is an in-memory afero
 kept in IndexedDB. All of it works and none of it is yours. Two flags change
-that, and both are off:
+that, and both are off. A third, `--reconnect`, changes how long a host shell
+lives:
 
 ```
-(cd panes && go run ./cmd/desk-serve --shell)          # a real pty in a window
-(cd panes && go run ./cmd/desk-serve --fs)             # real files
-(cd panes && go run ./cmd/desk-serve --fs --fs-root ~) # ...confined to a subtree
+(cd panes && go run ./cmd/desk-serve --shell)             # a real pty in a window
+(cd panes && go run ./cmd/desk-serve --shell --reconnect) # ...that outlives its window
+(cd panes && go run ./cmd/desk-serve --fs)                # real files
+(cd panes && go run ./cmd/desk-serve --fs --fs-root ~)    # ...confined to a subtree
 ```
 
 `--shell` adds the **host shell** app: xterm-go in a window, attached over a
 WebSocket to a pty running your `$SHELL`. It resizes with the window, because a
 resize becomes a `TIOCSWINSZ` and so a `SIGWINCH`, which is what makes a
 full-screen program redraw.
+
+`--reconnect` lets a **named** host shell outlive its window. Open it as `host
+build` rather than `host`, and closing the window leaves the shell running —
+reopening it under the same name re-attaches, replays the last 256 KiB of
+output, and resizes the pty to whatever the new window is. Nothing is polled:
+the session owns its own read loop for its whole life, which is what keeps a
+background build from blocking in `write(2)` against a pty nobody is draining.
+A second window on the same name **takes over** rather than being refused,
+which is `tmux attach -d` and is right because the usual cause of a stale
+attachment is a socket that died without saying so. Detached shells are reaped
+after an hour of nobody attaching (`--reconnect-idle`, negative to never), and
+stopping the server kills them all — including one that trapped `SIGHUP`.
+
+A shell with no window on it is invisible, so the server says what it has, on
+the terminal it was started in and nowhere else. Every session that starts, is
+left running or ends prints a line there, and `kill -USR1 <pid>` prints the
+whole listing — name, pid, attached or not, how long it has been that way, when
+it will be reaped, how much replay it is holding:
+
+```
+desk: 2 host shell(s), 1 of them detached:
+desk: NAME      PID      STATE     FOR  REAPED IN  BUFFER
+desk: build     3099788  detached  13s  59m47s     163 B
+desk: watching  3100073  attached  3s   -          172 B
+```
+
+The pid is what makes `ps` and `kill` the rest of the interface: killing a
+shell closes its pty, and the session notices and unregisters itself. Note that
+an interactive shell ignores a plain `SIGTERM`, so it is `kill -HUP` or
+`kill -9`. There is no *endpoint* that lists sessions and deliberately never
+will be — see below.
 
 `--fs` is the one that does more than it looks like. websh's shell and the file
 manager both work against `afero.Fs`, an **interface**, and websh takes any
@@ -211,7 +244,18 @@ machine, and any page you visit may try to reach localhost. So:
   the page by default, or printed to the terminal instead with `--auth`;
 - `--fs-root` confines paths for real: they are resolved through
   `EvalSymlinks` on the longest **existing** prefix, so a symlink planted inside
-  the root cannot be followed out of it.
+  the root cannot be followed out of it;
+- `--reconnect` is off, and it is the one flag here that takes a revocation
+  away: without it, closing the window ends the shell. With it, a session is
+  addressed by `HMAC(per-run secret, len(token) ‖ token ‖ name)` — so the name
+  a client picks need not be unguessable, and a session created under one token
+  is not merely refused under another but unaddressable. A name that resolves
+  to nothing starts a session rather than reporting one, so the endpoint is not
+  an oracle for what exists; the number of live shells is capped; and stopping
+  the server still kills every one of them. What exists *is* reported to the
+  process's own stdout, on `SIGUSR1` — a channel a page cannot address and that
+  only whoever started the server can use, which is the whole difference
+  between telling the operator and answering the wire.
 
 The Origin check is the load-bearing one and the token is honestly the weaker
 guard: a browser sets `Origin` itself and script cannot forge it, whereas a

--- a/vendor/github.com/0magnet/desk/panel-nowasm.js
+++ b/vendor/github.com/0magnet/desk/panel-nowasm.js
@@ -32,6 +32,16 @@
 			root = doc.createElement('div');
 			root.id = 'skywire-skynet-root';
 			root.style.cssText = 'position:fixed;inset:0;pointer-events:none;z-index:50';
+			// The root spans the viewport and is pointer-events:none so clicks fall
+			// through to the page wherever no window covers it. Anything mounted in
+			// it must opt back in or it renders and updates but cannot be clicked --
+			// the taskbar and menu set auto inline, windows had nothing, so every
+			// WinBox was inert. A rule rather than a per-instance assignment: it
+			// covers windows opened later and does not depend on the WinBox API
+			// exposing its root element.
+			var peStyle = doc.createElement('style');
+			peStyle.textContent = '#skywire-skynet-root .winbox{pointer-events:auto}';
+			root.appendChild(peStyle);
 			doc.body.appendChild(root);
 		}
 		var bar = doc.getElementById('skywire-skynet-taskbar');

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -47,7 +47,7 @@ github.com/0magnet/coloredcobra
 # github.com/0magnet/cosmos-go v0.0.0-20260905162431-a5584b3ff959
 ## explicit; go 1.24
 github.com/0magnet/cosmos-go
-# github.com/0magnet/desk v0.0.0-20260905010738-0c9209d8b7b7
+# github.com/0magnet/desk v0.0.0-20260906155330-9925d12693bb
 ## explicit; go 1.26
 github.com/0magnet/desk
 github.com/0magnet/desk/dom


### PR DESCRIPTION
The hypervisor UI is unclickable in the browser. The Angular app renders, polls and updates — it just never receives a click. Observed on `http://127.0.0.1:8000/` in Brave: the desk panel responds, the window does not.

The desk mounts its windows in `#skywire-skynet-root`, a viewport-spanning `position:fixed; inset:0` overlay with `pointer-events:none` so clicks fall through to the page wherever no window covers it. The taskbar and the menu items set `pointer-events:auto` inline. Windows set nothing, so the whole WinBox subtree — including the iframe holding the Angular UI — inherited `none`. Hit-testing the centre of a maximized window returned `BODY`.

Confirmed live before and after: with `pointer-events:auto` applied to the window, the same hit test returns the `IFRAME` inside it.

Fixed upstream in `0magnet/desk` (`9925d12`) as a style rule rather than a per-instance assignment, so it covers windows opened later and does not depend on WinBox exposing its root element, then re-vendored here. The vendored xterm-go blink-timer patch survives the re-vendor.