### PR TITLE
fix(cxoaggregate): log a successful subscribe at Info

### DIFF
--- a/pkg/cxo/cxoaggregate/aggregate.go
+++ b/pkg/cxo/cxoaggregate/aggregate.go
@@ -363,8 +363,15 @@ func (c *Core) reconcile() {
 				Debug(c.tag + ": Subscribe failed; will retry next reconcile")
 			continue
 		}
+		// Info, not Debug: this is the state change that answers "is
+		// registration-over-CXO actually working for this service", it fires once
+		// per visor feed (alreadySubscribed guards the retry), and the services
+		// that run it are NOT started with --loglvl debug. At Debug the answer was
+		// unobtainable in production -- AR carried 464 live CXO connections while
+		// its log showed no aggregator activity at all, which reads identically to
+		// the feature being switched off.
 		c.log.WithField("visor", cipher.PubKey(peerPK)).
-			Debug(c.tag + ": subscribed to visor feed")
+			Info(c.tag + ": subscribed to visor feed")
 	}
 }
 


### PR DESCRIPTION
Asking whether AR registration actually uses CXO turned out to be unanswerable from AR itself. Its `/debug/log` showed no aggregator activity whatsoever — no subscribes, no failures — which reads exactly like the feature being switched off.

It was not: AR carries **464 live CXO connections** (`cxo/node/transport.(*Connection).readLoop`/`writeLoop` and `node.(*Conn).run` in its goroutine profile), so visors are announcing and the aggregator is accepting. The subscribe line was simply logged at Debug, and AR runs at info — only the visor, setup-node and test units carry `--loglvl debug`. dmsg-discovery showed its 54 subscribes solely because its unit on the other host happens to run debug.

A successful subscribe is a state change worth recording: it fires once per visor feed, guarded by `alreadySubscribed`, so the volume is bounded by fleet size rather than the reconcile interval, and it is the one line that distinguishes "working" from "silently doing nothing". Now Info.

The failure line stays at Debug — it retries every reconcile and would be noisy, and a persistent failure is already visible as the absence of the success line plus the denied list on the publisher side.

One line in the shared core, so it covers dmsg-discovery, AR and TPD at once — a direct payoff from the aggregator convergence.