### PR TITLE
feat(visor): publish service-discovery registrations over CXO

### DIFF
--- a/pkg/app/appdisc/factory.go
+++ b/pkg/app/appdisc/factory.go
@@ -38,6 +38,12 @@ type Factory struct {
 	// snapshot captured at init (before that lookup), which dropped country from
 	// every registration that lost the race.
 	GeoFunc any
+	// EntrySink, when set, is a `servicedisc.EntrySink` handed to every
+	// service-discovery client this factory builds, so the visor's
+	// SD-registration-over-CXO publisher sees the exact entries the SD
+	// accepted. Typed `any` for the same reason as Client/Geo: pkg/servicedisc
+	// pulls net/http, which this shared struct must not.
+	EntrySink any
 }
 
 func (f *Factory) setDefaults() {

--- a/pkg/app/appdisc/factory_native.go
+++ b/pkg/app/appdisc/factory_native.go
@@ -39,6 +39,15 @@ func (f *Factory) geoFunc() func() *geo.LocationData {
 	return fn
 }
 
+// entrySink recovers the servicedisc.EntrySink stored in the `any`-typed
+// Factory.EntrySink (nil if unset). Every client this factory builds gets it,
+// so the visor's SD-registration-over-CXO feed carries the live set of entries
+// across all of its apps, not just one.
+func (f *Factory) entrySink() servicedisc.EntrySink {
+	s, _ := f.EntrySink.(servicedisc.EntrySink)
+	return s
+}
+
 // VisorUpdater obtains a visor updater.
 func (f *Factory) VisorUpdater(port uint16) Updater {
 	// Always return empty updater if keys are not set.
@@ -55,6 +64,7 @@ func (f *Factory) VisorUpdater(port uint16) Updater {
 		DisplayNodeIP: f.DisplayNodeIP,
 		Geo:           f.geoData(),
 		GeoFunc:       f.geoFunc(),
+		Sink:          f.entrySink(),
 	}
 
 	return newServiceUpdater(
@@ -87,6 +97,7 @@ func (f *Factory) PublicVisorUpdater(
 		DisplayNodeIP: f.DisplayNodeIP,
 		Geo:           f.geoData(),
 		GeoFunc:       f.geoFunc(),
+		Sink:          f.entrySink(),
 	}
 
 	inner := newServiceUpdater(
@@ -130,6 +141,7 @@ func (f *Factory) AppUpdater(conf appcommon.ProcConfig) (Updater, bool) {
 			DiscAddr: f.ServiceDisc,
 			Geo:      f.geoData(),
 			GeoFunc:  f.geoFunc(),
+			Sink:     f.entrySink(),
 		}
 	}
 

--- a/pkg/servicedisc/client.go
+++ b/pkg/servicedisc/client.go
@@ -56,6 +56,24 @@ type Config struct {
 	// permanently registered with no country whenever it lost that race. With
 	// GeoFunc, the next heartbeat after the lookup completes carries the country.
 	GeoFunc func() *geo.LocationData
+	// Sink, when non-nil, is handed a copy of every entry this client
+	// successfully registers, and of every entry it deregisters. It is how
+	// the visor's SD-registration-over-CXO publisher learns its own live
+	// service set VERBATIM — the exact Service the SD accepted and echoed
+	// back, not a reconstruction. Purely additive: the HTTP register/delete
+	// calls are unchanged and remain authoritative.
+	Sink EntrySink
+}
+
+// EntrySink receives copies of the entries an HTTPClient registers and
+// deregisters. Implementations MUST NOT block: they run inline on the
+// caller's registration goroutine (the 90s heartbeat loop, or an app
+// start/stop).
+type EntrySink interface {
+	// PutEntry records a service entry as live.
+	PutEntry(entry Service)
+	// DelEntry records a service entry as gone.
+	DelEntry(entry Service)
 }
 
 // HTTPClient is responsible for interacting with the service-discovery
@@ -205,12 +223,29 @@ func (c *HTTPClient) SetCoinInfo(info *CoinInfo) {
 // if there are no ip addresses in the entry it also tries to fetch those
 // from local config
 func (c *HTTPClient) RegisterEntry(ctx context.Context) error {
+	entry, err := c.registerEntry(ctx)
+	if err != nil {
+		return err
+	}
+	// Mirror the accepted entry AFTER releasing entryMx: the sink is the
+	// SD-registration-over-CXO publisher, and a treestore Put briefly takes
+	// the publisher mutex that subscriber I/O also contends.
+	if c.conf.Sink != nil {
+		c.conf.Sink.PutEntry(entry)
+	}
+	return nil
+}
+
+// registerEntry does the locked register: refresh the entry's volatile
+// fields, POST it, and store what the SD echoed back. Returns a copy of
+// the stored entry for the caller to mirror.
+func (c *HTTPClient) registerEntry(ctx context.Context) (Service, error) {
 	c.entryMx.Lock()
 	defer c.entryMx.Unlock()
 	if c.conf.Type == ServiceTypeVisor && len(c.entry.LocalIPs) == 0 {
 		ips, err := netutil.DefaultNetworkInterfaceIPs()
 		if err != nil {
-			return err
+			return Service{}, err
 		}
 		c.entry.LocalIPs = make([]string, 0, len(ips))
 		for _, ip := range ips {
@@ -245,11 +280,11 @@ func (c *HTTPClient) RegisterEntry(ctx context.Context) error {
 
 	entry, err := c.postEntry(ctx)
 	if err != nil {
-		return err
+		return Service{}, err
 	}
 	c.entry = entry
 	c.log.WithField("entry", c.entry.String()).Debug("Entry registered successfully")
-	return nil
+	return c.entry, nil
 }
 
 // postEntry calls 'POST /api/services' and sends current service entry
@@ -309,28 +344,44 @@ func (c *HTTPClient) postEntry(ctx context.Context) (Service, error) {
 }
 
 // DeleteEntry calls 'DELETE /api/services/{entry_addr}'.
-func (c *HTTPClient) DeleteEntry(ctx context.Context) (err error) {
+func (c *HTTPClient) DeleteEntry(ctx context.Context) error {
+	entry, err := c.deleteEntry(ctx)
+	if err != nil {
+		return err
+	}
+	// Drop it from the mirrored live set too, so the CXO feed stops
+	// carrying an entry the SD no longer holds. See RegisterEntry for why
+	// this runs outside entryMx.
+	if c.conf.Sink != nil {
+		c.conf.Sink.DelEntry(entry)
+	}
+	return nil
+}
+
+// deleteEntry does the locked delete and returns the entry that was
+// removed, for the caller to mirror.
+func (c *HTTPClient) deleteEntry(ctx context.Context) (removed Service, err error) {
 	c.entryMx.Lock()
 	defer c.entryMx.Unlock()
 
 	auth, err := c.Auth(ctx)
 	if err != nil {
-		return err
+		return Service{}, err
 	}
 
 	url, err := c.addr("/api/services/"+c.entry.Addr.String(), c.entry.Type, "", "", 1)
 	if err != nil {
-		return err
+		return Service{}, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
-		return err
+		return Service{}, err
 	}
 
 	resp, err := auth.Do(req)
 	if err != nil {
-		return err
+		return Service{}, err
 	}
 	if resp != nil {
 		defer func() {
@@ -344,12 +395,12 @@ func (c *HTTPClient) DeleteEntry(ctx context.Context) (err error) {
 		var hErr HTTPError
 		if err = json.NewDecoder(resp.Body).Decode(&hErr); err != nil {
 			// If we can't decode JSON, return HTTP status info
-			return fmt.Errorf("service discovery error: %s (status %d)", http.StatusText(resp.StatusCode), resp.StatusCode)
+			return Service{}, fmt.Errorf("service discovery error: %s (status %d)", http.StatusText(resp.StatusCode), resp.StatusCode)
 		}
-		return &hErr
+		return Service{}, &hErr
 	}
 	c.log.WithField("entry", c.entry).Debug("Entry deleted successfully")
-	return nil
+	return c.entry, nil
 }
 
 // Register calls 'POST /api/services' to register service discovery entry

--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -169,10 +169,26 @@ func (v *Visor) cxoFeedSpec(fk cxosub.Feed) (cipher.PubKey, uint16, string, erro
 	return cipher.PubKey{}, 0, "", fmt.Errorf("unknown feed: %d", fk)
 }
 
-// sdCXOPeer extracts the SD publisher PK from the visor's
-// launcher.service_discovery_dmsg URL.
+// sdCXOPeer extracts the SD publisher PK from the visor's launcher
+// service-discovery configuration.
+//
+// Both service_discovery_dmsg AND service_discovery are tried, in that order,
+// mirroring tpdCXOPeer and initDiscovery's own URL selection. On a dmsg-only
+// deployment the PK lives in `service_discovery` (already `dmsg://<pk>:80`)
+// and service_discovery_dmsg is simply unset — reading only the latter is the
+// same bug that made dmsgdCXOPeer silently never resolve (#4566).
+// parseDmsgPeer rejects a non-dmsg scheme, so a clearnet `service_discovery`
+// is still correctly ignored.
 func sdCXOPeer(v *Visor) (cipher.PubKey, bool) {
-	return parseDmsgPeer(v.conf.Launcher.ServiceDiscDmsg)
+	if v.conf.Launcher == nil {
+		return cipher.PubKey{}, false
+	}
+	for _, raw := range []string{v.conf.Launcher.ServiceDiscDmsg, v.conf.Launcher.ServiceDisc} {
+		if pk, ok := parseDmsgPeer(raw); ok {
+			return pk, true
+		}
+	}
+	return cipher.PubKey{}, false
 }
 
 // dmsgdCXOPeer extracts the DMSG-D publisher PK from the visor's dmsg

--- a/pkg/visor/cxo_user_feeds.go
+++ b/pkg/visor/cxo_user_feeds.go
@@ -228,6 +228,15 @@ func (v *Visor) setRegCXOPub(pub *treestore.Publisher) {
 	v.cxoUserFeedsMu.Unlock()
 }
 
+// setSDRegCXOPub retains the SD-registration-over-CXO publisher so its
+// gating (allowlist + denied subscribers) shows up in
+// `skywire cli visor state`.
+func (v *Visor) setSDRegCXOPub(pub *treestore.Publisher) {
+	v.cxoUserFeedsMu.Lock()
+	v.sdRegCXOPub = pub
+	v.cxoUserFeedsMu.Unlock()
+}
+
 // setTPListCXOPub retains the dedicated tp-list discovery feed publisher
 // so CXOFeedStates can read its live PublishState. Called once by
 // initStats; pub is nil when the dedicated publisher didn't start (the
@@ -340,6 +349,7 @@ func (v *Visor) CXOFeedStates() []CXOFeedState {
 	sysPub := v.systemCXOPub
 	tplistPub := v.tplistCXOPub
 	regPub := v.regCXOPub
+	sdRegPub := v.sdRegCXOPub
 	users := make([]*cxoUserFeed, 0, len(v.cxoUserFeeds))
 	for _, fd := range v.cxoUserFeeds {
 		users = append(users, fd)
@@ -383,6 +393,19 @@ func (v *Visor) CXOFeedStates() []CXOFeedState {
 			Name:         "registration",
 			Port:         skyenv.DmsgDMSGDRegistrationCXOPort,
 			PublishState: regPub.PublishState(),
+			Allowlist:    allow,
+			Denied:       denied,
+		})
+	}
+	// The SD-registration-over-CXO feed (this visor's live service entry
+	// set). Same reasoning as above: a service-discovery whose subscribe is
+	// refused only shows up here.
+	if sdRegPub != nil {
+		allow, denied := feedGating(sdRegPub)
+		out = append(out, CXOFeedState{
+			Name:         "sd_registration",
+			Port:         skyenv.DmsgVisorSDRegCXOPort,
+			PublishState: sdRegPub.PublishState(),
 			Allowlist:    allow,
 			Denied:       denied,
 		})

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -157,6 +157,10 @@ var (
 	// arBindCXOMod mirrors this visor's AR bindings onto a CXO feed the
 	// address-resolver aggregates (AR-bind-over-CXO), always-on/additive
 	arBindCXOMod vinit.Module
+	// sdRegCXOMod mirrors this visor's live service-discovery entry set onto
+	// a CXO feed the service-discovery aggregates (SD-registration-over-CXO),
+	// always-on/additive
+	sdRegCXOMod vinit.Module
 	// visor that groups all modules together
 	vis vinit.Module
 )
@@ -284,8 +288,14 @@ func registerModules(logger *logging.MasterLogger) {
 	// client (the bind hook it publishes from) and dmsgC (the feed transport).
 	// See init_ar_bind_cxo.go.
 	arBindCXOMod = maker("ar_bind_cxo", initARBindCXO, &ar, &dmsgC)
+	// SD-registration-over-CXO publisher: mirror this visor's live
+	// service-discovery entry set onto a CXO feed the SD aggregates, off the
+	// 90s HTTP re-POST (each a fresh dmsg Noise handshake). Depends on disc
+	// (the SD clients whose entries it mirrors) and dmsgC (the feed
+	// transport). See init_sd_reg_cxo.go.
+	sdRegCXOMod = maker("sd_reg_cxo", initSDRegCXO, &disc, &dmsgC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &ptyModule,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgSrv, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &meshProxy, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod, &voiceMod, &coinNodesMod, &regCXOMod, &arBindCXOMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgSrv, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &meshProxy, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod, &voiceMod, &coinNodesMod, &regCXOMod, &arBindCXOMod, &sdRegCXOMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/init_coinnode.go
+++ b/pkg/visor/init_coinnode.go
@@ -175,6 +175,7 @@ func initCoinNodes(_ context.Context, v *Visor, log *logging.Logger) error {
 				SK:       v.conf.SK,
 				Port:     node.DmsgPort,
 				DiscAddr: sdURL,
+				Sink:     v.sdEntryMirror,
 			}, httpC, "")
 
 		go runCoinRegistrar(ctx, log.WithField("dmsg_port", node.DmsgPort), sdClient, localHTTP, node)

--- a/pkg/visor/init_sd_reg_cxo.go
+++ b/pkg/visor/init_sd_reg_cxo.go
@@ -1,0 +1,286 @@
+// Package visor pkg/visor/init_sd_reg_cxo.go c3-vis-core
+//
+// SD-registration-over-CXO publisher. The visor mirrors its own
+// service-discovery entries — the type=visor / vpn / skysocks / coin
+// registrations pkg/app/appdisc POSTs to /api/services and re-POSTs every
+// 90s (skyenv.ServiceDiscUpdateInterval) — onto a persistent CXO feed on
+// DmsgVisorSDRegCXOPort, and announces to the service-discovery, which
+// subscribes back and ingests them. This moves the SD heartbeat off the
+// timer-driven re-registration, each a fresh dmsg stream with a full Noise
+// handshake (the secp256k1 handshakeResponder that dominates discovery-
+// service CPU), onto one warm CXO connection.
+//
+// Purely ADDITIVE dual-write, exactly as for the AR-bind, dmsg-registration
+// and TPD feeds: the SD clients keep doing the HTTP POST / DELETE on the
+// same schedule (the authoritative path), and this feed is inert until an
+// SD subscribes to it.
+//
+// # What is published
+//
+// A visor's service set is per-app and changes when apps start and stop, so
+// the feed carries ONE batched leaf holding the visor's WHOLE current live
+// set, republished on every change:
+//
+//	services        // FrameGzip(v1, JSON []servicedisc.Service)
+//
+// The entries are verbatim what the SD accepted and echoed back (the
+// clients feed them in through servicedisc.EntrySink), so the ingest is a
+// drop-in mirror of the HTTP register.
+//
+// Deregistration is ABSENCE, not a tombstone — the same rule SD's own
+// publisher documents (pkg/deployment/sd/api/cxo_publisher.go). A service
+// that stops is simply missing from the next batch, and SD's Redis store
+// expires it on the existing entry TTL. When the set empties, the leaf
+// itself is deleted.
+package visor
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/servicedisc"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// sdRegLeafPath is the single CXO leaf the visor publishes its whole live
+// service set at. One leaf per feed keeps the Root a fixed two objects
+// however many apps are registered, so it always fills in one round-trip.
+const sdRegLeafPath = "services"
+
+// sdRegBatchVersion is the wire-format version byte of the batched leaf
+// body (cxoutils.FrameGzip). Bump on any breaking change to the encoding;
+// readers compare it and fall back rather than misparsing.
+const sdRegBatchVersion = 1
+
+// sdRegBatchWindow coalesces service-set mutations into the CXO datastore.
+// App start/stop is rare and the 90s heartbeat re-register is a keepalive
+// that usually re-encodes to identical bytes, so a short window adds no
+// latency while batching the startup burst (visor + vpn + skysocks entries
+// all registering at once) into a single publish.
+const sdRegBatchWindow = 5 * time.Second
+
+// sdRegAnnounceInterval is how often the visor pokes its CXO feed conn to
+// the SD. Short enough that a recovered visor/SD re-links well inside the
+// entry TTL.
+const sdRegAnnounceInterval = 30 * time.Second
+
+// sdEntryMirror holds the visor's live service-discovery entry set and
+// mirrors it onto the SD-registration CXO feed. It implements
+// servicedisc.EntrySink, and every SD client the visor builds is handed it
+// (see appdisc.Factory.EntrySink), so the set spans all of the visor's
+// apps rather than one client's single entry.
+//
+// It exists from NewVisor onward and is publisher-agnostic: entries
+// accumulate whether or not the CXO feed ever starts, and attaching a
+// publisher later flushes whatever has accumulated. That ordering
+// independence is deliberate — apps can register before (or without) the
+// CXO module running.
+type sdEntryMirror struct {
+	mu      sync.Mutex
+	entries map[string]servicedisc.Service
+	pub     *treestore.Publisher
+	log     *logging.Logger
+}
+
+func newSDEntryMirror() *sdEntryMirror {
+	return &sdEntryMirror{entries: make(map[string]servicedisc.Service)}
+}
+
+// sdEntryKey identifies one registration: an entry is unique per service
+// type AND address, matching SD's own (type, addr) store key — a visor can
+// hold a type=visor and a type=skysocks entry at once, and two apps of one
+// type on different routing ports are two entries.
+func sdEntryKey(e servicedisc.Service) string {
+	return e.Type + "|" + e.Addr.String()
+}
+
+// PutEntry records a service entry the SD accepted and republishes the set.
+// Implements servicedisc.EntrySink.
+func (m *sdEntryMirror) PutEntry(entry servicedisc.Service) {
+	if m == nil || entry.Type == "" || entry.Addr.PubKey().Null() {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries[sdEntryKey(entry)] = entry
+	m.flushLocked()
+}
+
+// DelEntry drops a deregistered entry and republishes the set. Its absence
+// from the next batch IS the deregistration — no tombstone. Implements
+// servicedisc.EntrySink.
+func (m *sdEntryMirror) DelEntry(entry servicedisc.Service) {
+	if m == nil || entry.Type == "" {
+		return
+	}
+	key := sdEntryKey(entry)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.entries[key]; !ok {
+		return
+	}
+	delete(m.entries, key)
+	m.flushLocked()
+}
+
+// setPublisher attaches (or, with nil, detaches) the CXO publisher and
+// immediately flushes the current set, so a feed that starts after the
+// first registrations still carries them.
+func (m *sdEntryMirror) setPublisher(pub *treestore.Publisher, log *logging.Logger) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pub = pub
+	m.log = log
+	if pub != nil {
+		m.flushLocked()
+	}
+}
+
+// flushLocked re-encodes the whole live set into the batched leaf, or
+// deletes the leaf when the set is empty. CXO is content-addressed, so a
+// re-encode of an unchanged set is a wire no-op — which is what a steady
+// 90s heartbeat produces. Caller holds m.mu.
+func (m *sdEntryMirror) flushLocked() {
+	if m.pub == nil {
+		return
+	}
+	if len(m.entries) == 0 {
+		if err := m.pub.Delete(sdRegLeafPath); err != nil && m.log != nil {
+			m.log.WithError(err).Debug("SD-reg-CXO: delete of emptied services leaf failed")
+		}
+		return
+	}
+	blob, err := encodeSDEntries(m.entries)
+	if err != nil {
+		if m.log != nil {
+			m.log.WithError(err).Debug("SD-reg-CXO: marshal service set failed")
+		}
+		return
+	}
+	if err := m.pub.Put(sdRegLeafPath, blob); err != nil && m.log != nil {
+		m.log.WithError(err).Debug("SD-reg-CXO: CXO Put failed")
+	}
+}
+
+// encodeSDEntries serializes the live set as one leaf body: a JSON array of
+// servicedisc.Service sorted by (type, addr) so an unchanged set re-encodes
+// to identical bytes, then version-framed + gzipped.
+func encodeSDEntries(entries map[string]servicedisc.Service) ([]byte, error) {
+	keys := make([]string, 0, len(entries))
+	for k := range entries {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]servicedisc.Service, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, entries[k])
+	}
+	payload, err := json.Marshal(out)
+	if err != nil {
+		return nil, err
+	}
+	return cxoutils.FrameGzip(sdRegBatchVersion, payload), nil
+}
+
+func initSDRegCXO(_ context.Context, v *Visor, log *logging.Logger) error {
+	if v.dmsgC == nil {
+		log.Warn("SD-reg-CXO: dmsg client absent; publisher not started")
+		return nil
+	}
+	// The whole point is to announce to the SD so it subscribes back.
+	// Without a dmsg:// service-discovery PK there is no announce target, so
+	// skip rather than run an orphan publisher.
+	sdPK, ok := sdCXOPeer(v)
+	if !ok {
+		log.Warn("SD-reg-CXO: no dmsg:// service_discovery PK; cannot announce to SD; skipping")
+		return nil
+	}
+
+	dataDir := filepath.Join(v.conf.LocalPath, "cxo-sd-reg")
+	// Gate the feed: peer whitelist (hypervisors + dmsgpty whitelist + own
+	// PK) plus the consuming SD. The SD MUST be allowed or its announce-conn
+	// subscribe is rejected by the OnSubscribeRemote hook. sdPK is always
+	// known here (we returned early above otherwise).
+	allow := composeFeedAllowlist(v, sdPK, true)
+	pub, err := treestore.NewWithDMSG(v.dmsgC, v.conf.SK, treestore.PubConfig{
+		DmsgPort:            skyenv.DmsgVisorSDRegCXOPort,
+		BatchWindow:         sdRegBatchWindow,
+		Logger:              log,
+		DataDir:             dataDir,
+		SubscriberAllowlist: allow,
+		// The leaf is rebuilt from the SD clients' live registrations on
+		// every restart (they re-register on boot), so skipping per-tx
+		// fdatasync is safe (matches the AR-bind + registration publishers).
+		NoSyncCXDS: true,
+	})
+	if err != nil {
+		log.WithError(err).Warn("SD-reg-CXO: publisher init failed; continuing with HTTP service registration only")
+		return nil
+	}
+
+	// Register so the feed's subscriber allowlist is recomputed and
+	// re-applied when the peer whitelist changes at runtime. The initial
+	// allowlist is already set at construction via PubConfig above.
+	v.registerGatedCXOFeed(pub, sdPK, true)
+	// Surface this feed's gating in `visor state`: a refused SD subscribe is
+	// otherwise invisible from both ends.
+	v.setSDRegCXOPub(pub)
+
+	// Attach the publisher to the mirror. Entries registered before this
+	// point (the boot burst) are flushed immediately.
+	v.sdEntryMirror.setPublisher(pub, log)
+
+	// Dial the SD so its aggregator sees the inbound conn and subscribes to
+	// our feed (PK = our PK). ConnectPK is idempotent, so the same loop
+	// handles initial announce + reconnect.
+	lastAnnounceOK := new(atomic.Int64)
+	go runSDRegAnnounceLoop(v.ctx, pub, sdPK, lastAnnounceOK, log)
+
+	v.pushCloseStack("sd_reg_cxo", func() error {
+		v.sdEntryMirror.setPublisher(nil, nil)
+		return pub.Close()
+	})
+
+	log.WithField("feed_pk", pub.Feed()).WithField("sd_pk", sdPK).
+		WithField("port", skyenv.DmsgVisorSDRegCXOPort).
+		Info("SD-reg-CXO: publisher running (service entries mirrored to service-discovery)")
+	return nil
+}
+
+// runSDRegAnnounceLoop dials the SD on a ticker (ConnectPK is idempotent —
+// a live conn is a no-op, a dropped one redials) and stamps lastOK with the
+// wall-clock time of each success.
+func runSDRegAnnounceLoop(ctx context.Context, pub *treestore.Publisher, sdPK cipher.PubKey, lastOK *atomic.Int64, log *logging.Logger) {
+	t := time.NewTicker(sdRegAnnounceInterval)
+	defer t.Stop()
+	announce := func() {
+		dctx, cancel := context.WithTimeout(ctx, sdRegAnnounceInterval/2)
+		defer cancel()
+		if err := pub.AnnounceTo(dctx, sdPK); err != nil {
+			log.WithError(err).WithField("sd_pk", sdPK).Trace("SD-reg-CXO: announce to service-discovery failed")
+			return
+		}
+		lastOK.Store(time.Now().UnixNano())
+	}
+	announce()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			announce()
+		}
+	}
+}

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -238,6 +238,11 @@ func initDiscovery(ctx context.Context, v *Visor, _ *logging.Logger) error {
 		// usually finishes AFTER this point, so the snapshot above is nil for the
 		// race-losers. GeoFunc lets each heartbeat re-read the current geo.
 		factory.GeoFunc = v.serviceGeo
+		// Mirror every entry these clients register onto the visor's live
+		// service set, which the SD-registration-over-CXO feed publishes.
+		// Inert until initSDRegCXO attaches a publisher. See
+		// init_sd_reg_cxo.go.
+		factory.EntrySink = v.sdEntryMirror
 
 		// Get public IP for service discovery (needed for NAT setups).
 		// Try dmsg first; fall back to STUN. No HTTP geoip query.

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -286,6 +286,20 @@ type Visor struct {
 	// path this feed exists to replace. Guarded by cxoUserFeedsMu.
 	regCXOPub *treestore.Publisher
 
+	// sdRegCXOPub is the SD-registration-over-CXO publisher (this visor's
+	// live service-discovery entry set, on DmsgVisorSDRegCXOPort) — retained
+	// for the same reason as regCXOPub: without its allowlist and DENIED
+	// subscribers in `visor state`, a service-discovery whose subscribe is
+	// refused is invisible from both ends. Guarded by cxoUserFeedsMu.
+	sdRegCXOPub *treestore.Publisher
+
+	// sdEntryMirror holds the visor's live service-discovery entry set and
+	// mirrors it onto the SD-registration CXO feed. Constructed in NewVisor
+	// (never nil) and handed to every servicedisc client the visor builds,
+	// so entries accumulate regardless of whether the CXO feed ever starts.
+	// See init_sd_reg_cxo.go.
+	sdEntryMirror *sdEntryMirror
+
 	// gatedCXOFeeds registers the visor's service-consumed CXO publishers
 	// (stats, tp-list, registration) together with the consuming service's
 	// PK so their subscriber allowlists can be recomputed and re-applied
@@ -755,6 +769,10 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1, logBcast *logging.Broad
 		dmsgLatency: dmsgLatencyState{
 			servers: make(map[cipher.PubKey]time.Duration),
 		},
+		// Always present so any servicedisc client built during init can be
+		// handed it, whatever order the modules run in; it stays inert until
+		// initSDRegCXO attaches a publisher.
+		sdEntryMirror: newSDEntryMirror(),
 	}
 	v.isServicesHealthy.init()
 	v.isUptimeTrackerHealthy.init()


### PR DESCRIPTION
Adds the visor-side publisher for SD-registration-over-CXO — the fourth instance of the pattern already carrying dmsgd client entries, AR bindings and TPD telemetry. The visor mirrors its live service-discovery entry set (the `type=visor`/`vpn`/`skysocks`/`coin` registrations appdisc POSTs to `/api/services` and re-POSTs every 90s) onto a CXO feed on `DmsgVisorSDRegCXOPort` (72, already reserved for exactly this) and announces to the SD every 30s so it subscribes back. Same motivation as the AR feed: each 90s re-POST is a fresh dmsg stream with a full Noise handshake, and that handshake dominates discovery-service CPU.

Entries are carried verbatim, fed in through a new `servicedisc.EntrySink` that each SD client hands its accepted entry to; the appdisc `Factory` passes one sink to every client it builds, so the feed holds the visor's whole set rather than one app's entry. One batched leaf (`services`, `FrameGzip(v1, JSON []servicedisc.Service)`) is republished on every change, so the Root stays two objects however many apps register. Deregistration is absence from the next batch — no tombstone, matching what SD's own publisher documents; SD's Redis entry TTL does the expiry. HTTP register/delete is untouched and remains authoritative, and the feed is inert until an SD subscribes (the aggregator side is a follow-up PR).

The feed is gated with `composeFeedAllowlist` (SD's PK plus the peer whitelist) and registered via `setSDRegCXOPub`, so `visor state` surfaces its allowlist and any denied subscriber. This also widens `sdCXOPeer` to try `service_discovery` after `service_discovery_dmsg`: on a dmsg-only deployment the `dmsg://` URL lives in the former, so the old single-field read never resolved — the same bug fixed for `dmsgdCXOPeer` in #4566.

Local: `go build .`, `golangci-lint run` and `GOOS=windows golangci-lint run` clean, `pkg/visor/...`, `pkg/servicedisc`, `pkg/app/appdisc` green.