### PR TITLE
feat(ar): publish a CXO bindings feed keyed by peer public key

### DIFF
--- a/pkg/deployment/ar/api/api.go
+++ b/pkg/deployment/ar/api/api.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -86,6 +87,44 @@ type API struct {
 	// owns its own DHT target.
 	dhtMirrorStcpr dhtMirror
 	dhtMirrorSudph dhtMirror
+
+	// bindPub is the CXO bindings publisher, installed after the dmsg client
+	// exists (see pkg/services/ar). Held atomically because the store writes
+	// that notify it run on HTTP, UDP and CXO-ingest goroutines while the
+	// service is already serving.
+	bindPub atomic.Pointer[BindingsCXOPublisher]
+}
+
+// SetBindingsCXOPublisher installs (or clears, with nil) the publisher that
+// mirrors this AR's bindings onto its CXO feed. Safe to call while serving.
+func (a *API) SetBindingsCXOPublisher(p *BindingsCXOPublisher) {
+	a.bindPub.Store(p)
+}
+
+// bindNotifyStore decorates the address store so that every successful write
+// marks the affected (peer, transport type) dirty for the CXO bindings feed.
+// A decorator rather than a call at each Bind / DelBind site: the eight sites
+// are spread across the HTTP handlers, the SUDPH UDP loop and the CXO bind
+// ingest, and a future ninth would silently miss the feed.
+type bindNotifyStore struct {
+	store.Store
+	api *API
+}
+
+func (s *bindNotifyStore) Bind(ctx context.Context, netType types.Type, pk cipher.PubKey, visorData addrresolver.VisorData) error {
+	err := s.Store.Bind(ctx, netType, pk, visorData)
+	if err == nil {
+		s.api.bindPub.Load().MarkDirty(netType, pk)
+	}
+	return err
+}
+
+func (s *bindNotifyStore) DelBind(ctx context.Context, netType types.Type, pk cipher.PubKey) error {
+	err := s.Store.DelBind(ctx, netType, pk)
+	if err == nil {
+		s.api.bindPub.Load().MarkDirty(netType, pk)
+	}
+	return err
 }
 
 // dhtMirror is the subset of dht.RedisMirror used by AR. Anything that
@@ -203,7 +242,6 @@ func New(log *logging.Logger, s store.Store, nonceStore httpauth.NonceStore,
 	enableMetrics bool, m armetrics.Metrics, dmsgAddr, publicUDPAddr string) *API {
 	api := &API{
 		log:                         log,
-		store:                       s,
 		metrics:                     m,
 		reqsInFlightCountMiddleware: metricsutil.NewRequestsInFlightCountMiddleware(),
 		udpConns:                    make(map[cipher.PubKey]net.Conn),
@@ -213,6 +251,12 @@ func New(log *logging.Logger, s store.Store, nonceStore httpauth.NonceStore,
 		DmsgServers:                 []string{},
 		publicUDPAddr:               publicUDPAddr,
 	}
+	// Every store write goes through the notifier so the CXO bindings feed
+	// (pkg/deployment/ar/api/cxo_publisher.go) learns about it from ONE place
+	// rather than from each of the eight Bind / DelBind call sites — the HTTP
+	// handlers, the SUDPH UDP loop and the CXO bind ingest. The notifier is
+	// inert until SetBindingsCXOPublisher installs a publisher.
+	api.store = &bindNotifyStore{Store: s, api: api}
 
 	r := chi.NewRouter()
 

--- a/pkg/deployment/ar/api/cxo_publisher.go
+++ b/pkg/deployment/ar/api/cxo_publisher.go
@@ -1,0 +1,438 @@
+// Package api pkg/deployment/ar/api/cxo_publisher.go c4-net-discovery
+//
+// CXO publisher for the address-resolver's bindings, keyed by peer public key.
+//
+// Until now the AR published no CXO feed at all: visors push their bindings in
+// over CXO (pkg/deployment/ar/regcxo) and nothing comes back, so the ~1.5k
+// warm CXO connections the AR already holds carry traffic in one direction
+// only. This adds the read side, in the shape a per-dial address lookup wants
+// — see pkg/deployment/ar/arfeed for the tree layout and why it is 256
+// always-present buckets rather than a flat per-peer level or a per-server
+// batch.
+//
+// Purely additive: HTTP GET /resolve stays authoritative and unchanged, and
+// the feed is inert until something subscribes to or previews it.
+//
+// # Where the data comes from
+//
+// Two sources, because neither alone is both fresh and correct:
+//
+//   - Every write to the store marks (peer, type) dirty. The worker resolves
+//     the STORED record for that pair on the next flush and re-encodes the
+//     peer's bucket. Resolving rather than trusting the value passed to Bind
+//     matters: the redis store merges IPv4/IPv6 families across two separate
+//     binds, so only the stored record is the whole truth.
+//   - A periodic full resync rebuilds the state from the per-type index. This
+//     is what removes peers whose binding TTL'd out — an expiry never calls
+//     DelBind, so an incremental-only publisher would keep stale addresses
+//     forever.
+//
+// Both run on one worker goroutine, so the state map needs no lock, and the
+// store writes never block on the publisher: marks go through a buffered
+// channel and are dropped (counted) on overflow. A dropped mark costs at most
+// one resync interval of staleness for that peer.
+package api
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/deployment/ar/arfeed"
+	"github.com/skycoin/skywire/pkg/deployment/ar/store"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// bindingsBatchWindow is how long treestore coalesces tree mutations before it
+// re-encodes and publishes the Root. A publish clones and re-encodes the whole
+// in-memory tree, so the window trades publish frequency against CPU; 30s
+// matches the dmsg-discovery clients-by-server publisher, which learned the
+// same lesson the expensive way.
+const bindingsBatchWindow = 30 * time.Second
+
+// bindingsFlushWindow coalesces the per-bucket leaf re-encode (resolve + JSON +
+// gzip). Under the fleet's ~90s SUDPH re-bind cadence roughly twenty peers go
+// dirty per second, most of them in distinct buckets, so flushing per mark
+// would gzip the same bucket repeatedly for no change in content. Kept well
+// under bindingsBatchWindow so a bucket is current before a publish captures
+// it.
+const bindingsFlushWindow = 3 * time.Second
+
+// bindingsResyncInterval is how often the whole tree is rebuilt from the
+// store's per-type index. It bounds how long a TTL-expired binding can linger
+// in the feed, since an expiry produces no DelBind to mark it dirty.
+const bindingsResyncInterval = 5 * time.Minute
+
+// bindingsQueueDepth bounds in-flight dirty marks. Sized for the fleet's
+// re-bind rate with headroom for a restart thundering herd. Overflow is
+// dropped and counted; the store write never blocks.
+const bindingsQueueDepth = 8192
+
+// bindableTypes is the set of transport types the AR stores bindings for, and
+// therefore the set the feed carries.
+var bindableTypes = []types.Type{types.STCPR, types.SUDPH, types.QUIC, types.WT}
+
+// dirtyMark is one (peer, transport type) pair awaiting a re-resolve.
+type dirtyMark struct {
+	pk cipher.PubKey
+	t  types.Type
+}
+
+// BindingsCXOPublisher mirrors the address-resolver's bindings onto a CXO
+// TreeStore feed keyed by peer public key.
+type BindingsCXOPublisher struct {
+	pub   *treestore.Publisher
+	store store.Store
+	log   *logging.Logger
+
+	// flushWindow and resyncInterval are fields rather than constants so a
+	// test can drive the worker at a pace it can wait on.
+	flushWindow    time.Duration
+	resyncInterval time.Duration
+
+	marks chan dirtyMark
+	done  chan struct{}
+	wg    sync.WaitGroup
+
+	dropped uint64 // atomic; bumped when marks overflows
+
+	// state is the live per-peer record set, and pending the marks awaiting a
+	// re-resolve. Both are owned exclusively by the worker goroutine (run), so
+	// they need no lock.
+	state   map[cipher.PubKey]*arfeed.PeerBindings
+	pending map[dirtyMark]struct{}
+
+	mu        sync.Mutex
+	lastError error
+}
+
+// StartBindingsCXOPublisher constructs the publisher backed by the given dmsg
+// client and the AR's secret key, and runs an immediate full resync so the
+// feed is complete before anything reads it. The allowlist is open: GET
+// /resolve is a public read, so its CXO mirror inherits that.
+//
+// Returns nil plus an error if the underlying treestore publisher cannot be
+// created; callers log and continue without it, HTTP staying the source of
+// truth.
+func StartBindingsCXOPublisher(dmsgC *dmsg.Client, sk cipher.SecKey, st store.Store, logger logrus.FieldLogger) (*BindingsCXOPublisher, error) {
+	log := logging.MustGetLogger("ar-cxo-bindings-pub")
+
+	pub, err := treestore.NewWithDMSG(dmsgC, sk, treestore.PubConfig{
+		Logger:      log,
+		InMemoryDB:  true, // the tree is recomputed from the store on every resync
+		DmsgPort:    skyenv.DmsgARBindingsCXOPort,
+		BatchWindow: bindingsBatchWindow,
+	})
+	if err != nil {
+		return nil, err
+	}
+	pub.SetAllowlist(nil)
+
+	p := newBindingsCXOPublisher(pub, st, log, bindingsFlushWindow, bindingsResyncInterval)
+
+	if logger != nil {
+		logger.WithField("feed_pk", pub.Feed()).WithField("dmsg_port", skyenv.DmsgARBindingsCXOPort).
+			Info("CXO bindings publisher running")
+	}
+	return p, nil
+}
+
+// newBindingsCXOPublisher wires the worker around an already-constructed
+// treestore publisher. Split out from StartBindingsCXOPublisher so a test can
+// drive the whole thing over the CXO node's native TCP transport, with no dmsg
+// client or discovery in the way.
+func newBindingsCXOPublisher(pub *treestore.Publisher, st store.Store, log *logging.Logger,
+	flushWindow, resyncInterval time.Duration) *BindingsCXOPublisher {
+	p := &BindingsCXOPublisher{
+		pub:            pub,
+		store:          st,
+		log:            log,
+		flushWindow:    flushWindow,
+		resyncInterval: resyncInterval,
+		marks:          make(chan dirtyMark, bindingsQueueDepth),
+		done:           make(chan struct{}),
+		state:          make(map[cipher.PubKey]*arfeed.PeerBindings),
+		pending:        make(map[dirtyMark]struct{}),
+	}
+	p.wg.Add(1)
+	go p.run()
+	return p
+}
+
+// FeedPK returns the publisher's feed PK (the AR's own PK).
+func (p *BindingsCXOPublisher) FeedPK() cipher.PubKey { return p.pub.Feed() }
+
+// Dropped returns the cumulative count of dropped dirty marks.
+func (p *BindingsCXOPublisher) Dropped() uint64 {
+	if p == nil {
+		return 0
+	}
+	return atomic.LoadUint64(&p.dropped)
+}
+
+// LastError returns the most recent publish error, or nil.
+func (p *BindingsCXOPublisher) LastError() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastError
+}
+
+// Close stops the worker and the underlying publisher. Safe to call twice.
+func (p *BindingsCXOPublisher) Close() error {
+	if p == nil || p.pub == nil {
+		return nil
+	}
+	select {
+	case <-p.done:
+	default:
+		close(p.done)
+	}
+	p.wg.Wait()
+	return p.pub.Close()
+}
+
+// MarkDirty records that a peer's binding for one transport type changed and
+// must be re-read from the store. Non-blocking and safe from any goroutine:
+// this runs on the HTTP / UDP / CXO-ingest write paths.
+func (p *BindingsCXOPublisher) MarkDirty(t types.Type, pk cipher.PubKey) {
+	if p == nil || pk == (cipher.PubKey{}) {
+		return
+	}
+	select {
+	case p.marks <- dirtyMark{pk: pk, t: types.NormalizeType(t)}:
+	case <-p.done:
+	default:
+		dropped := atomic.AddUint64(&p.dropped, 1)
+		if dropped&(dropped-1) == 0 {
+			p.log.WithField("dropped_total", dropped).
+				Warn("CXO bindings mark queue full; dropping (peer recovers on the next resync)")
+		}
+	}
+}
+
+// run is the single worker. It owns state and pending.
+func (p *BindingsCXOPublisher) run() {
+	defer p.wg.Done()
+
+	// Materialize all 256 buckets up front so every level is a dense sorted
+	// array from the very first Root — that density is what lets a reader
+	// address a bucket by computed index instead of searching for it.
+	paths := make(map[string]struct{}, arfeed.BucketCount)
+	for i := 0; i < arfeed.BucketCount; i++ {
+		paths[arfeed.BucketPathAt(i)] = struct{}{}
+	}
+	p.encodeBuckets(paths)
+	p.resync()
+
+	flush := time.NewTicker(p.flushWindow)
+	defer flush.Stop()
+	resync := time.NewTicker(p.resyncInterval)
+	defer resync.Stop()
+
+	for {
+		select {
+		case <-p.done:
+			return
+		case m := <-p.marks:
+			p.pending[m] = struct{}{}
+		case <-flush.C:
+			p.flush()
+		case <-resync.C:
+			p.resync()
+		}
+	}
+}
+
+// definitelyAbsent reports whether a Resolve error means the store really has
+// no such binding, as opposed to the store being briefly unable to say.
+//
+// The distinction is the whole correctness of this publisher. Treating every
+// error as absence would let one redis blip, or one flush that ran out of its
+// context budget under a restart herd, PUBLISH the absence of bindings that
+// exist — and a reader cannot tell a false absence from a real one.
+func definitelyAbsent(err error) bool {
+	return errors.Is(err, store.ErrNoEntry) || errors.Is(err, store.ErrUnknownTransportType)
+}
+
+// flush re-reads every pending (peer, type) from the store, updates the state
+// map and re-encodes each affected bucket. Marks the store could not answer
+// are put back for the next flush rather than published as absences.
+// Worker-only.
+func (p *BindingsCXOPublisher) flush() {
+	if len(p.pending) == 0 {
+		return
+	}
+	pending := p.pending
+	p.pending = make(map[dirtyMark]struct{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), p.flushWindow)
+	defer cancel()
+
+	dirty := make(map[string]struct{}, len(pending))
+	for m := range pending {
+		data, err := p.store.Resolve(ctx, m.t, m.pk)
+		if err != nil && !definitelyAbsent(err) {
+			// Transient: re-queue and leave whatever we already publish for
+			// this peer in place.
+			p.pending[m] = struct{}{}
+			p.recordError(err)
+			continue
+		}
+		rec := p.state[m.pk]
+		if rec == nil {
+			rec = &arfeed.PeerBindings{}
+		}
+		if err != nil {
+			rec.Set(m.t, nil)
+		} else {
+			v := data
+			rec.Set(m.t, &v)
+		}
+		if rec.Empty() {
+			delete(p.state, m.pk)
+		} else {
+			p.state[m.pk] = rec
+		}
+		dirty[arfeed.BucketPath(m.pk)] = struct{}{}
+	}
+	p.encodeBuckets(dirty)
+}
+
+// resync rebuilds the whole state map from the store's per-type indexes and
+// re-encodes every bucket whose membership or content moved. This is the only
+// thing that removes a peer whose binding expired by TTL. Worker-only.
+func (p *BindingsCXOPublisher) resync() {
+	ctx, cancel := context.WithTimeout(context.Background(), p.resyncInterval/2)
+	defer cancel()
+
+	next := make(map[cipher.PubKey]*arfeed.PeerBindings, len(p.state))
+	for _, t := range bindableTypes {
+		pks, err := p.store.GetAll(ctx, t)
+		if err != nil {
+			p.log.WithError(err).WithField("type", t).
+				Debug("CXO bindings resync: index read failed; keeping previous state for this type")
+			p.recordError(err)
+			// A partial resync would publish an absence that is not real, so
+			// abandon this round entirely and retry on the next tick.
+			return
+		}
+		for _, raw := range pks {
+			var pk cipher.PubKey
+			if err := pk.UnmarshalText([]byte(raw)); err != nil {
+				continue
+			}
+			data, err := p.store.Resolve(ctx, t, pk)
+			if err != nil {
+				if definitelyAbsent(err) {
+					continue // TTL'd out between the index read and now
+				}
+				// The store could not answer. Carry the value we already
+				// publish forward rather than dropping the peer, which would
+				// be a false absence.
+				p.recordError(err)
+				if prev := p.state[pk].Get(t); prev != nil {
+					rec := next[pk]
+					if rec == nil {
+						rec = &arfeed.PeerBindings{}
+						next[pk] = rec
+					}
+					rec.Set(t, prev)
+				}
+				continue
+			}
+			rec := next[pk]
+			if rec == nil {
+				rec = &arfeed.PeerBindings{}
+				next[pk] = rec
+			}
+			v := data
+			rec.Set(t, &v)
+		}
+	}
+
+	// Every bucket that gained or lost a peer, or whose peers changed, has to
+	// be re-encoded. Cheapest correct answer: re-encode the buckets touched by
+	// the symmetric difference of the two peer sets, plus any peer whose
+	// record differs. Re-encoding a bucket whose bytes did not change is a
+	// wire no-op (CXO is content-addressed), so a coarse dirty set only costs
+	// local gzip.
+	dirty := make(map[string]struct{})
+	for pk := range p.state {
+		if _, still := next[pk]; !still {
+			dirty[arfeed.BucketPath(pk)] = struct{}{}
+		}
+	}
+	for pk := range next {
+		dirty[arfeed.BucketPath(pk)] = struct{}{}
+	}
+	p.state = next
+	p.encodeBuckets(dirty)
+	p.clearError()
+}
+
+// encodeBuckets re-encodes and Puts each named bucket from the current state.
+// Worker-only.
+func (p *BindingsCXOPublisher) encodeBuckets(paths map[string]struct{}) {
+	if len(paths) == 0 {
+		return
+	}
+	byBucket := make(map[string]map[cipher.PubKey]*arfeed.PeerBindings, len(paths))
+	for pk, rec := range p.state {
+		path := arfeed.BucketPath(pk)
+		if _, want := paths[path]; !want {
+			continue
+		}
+		m := byBucket[path]
+		if m == nil {
+			m = make(map[cipher.PubKey]*arfeed.PeerBindings)
+			byBucket[path] = m
+		}
+		m[pk] = rec
+	}
+	// One batched tree mutation rather than one per bucket. treestore marks the
+	// tree dirty per write and re-encodes the WHOLE tree on the next publish
+	// tick, so 256 individual Puts inside one batch window can trigger repeated
+	// whole-tree re-encodes; PutBatch is a single mutex acquire and a single
+	// dirty mark. It matters most on the startup materialization, which touches
+	// every bucket at once.
+	ops := make([]treestore.PutOp, 0, len(paths))
+	for path := range paths {
+		blob, err := arfeed.EncodeBucket(byBucket[path])
+		if err != nil {
+			p.log.WithError(err).WithField("bucket", path).Debug("CXO bindings: bucket encode failed")
+			p.recordError(err)
+			continue
+		}
+		// An empty bucket is still published (as an empty map) rather than
+		// deleted: every level must stay dense for index addressing to work.
+		ops = append(ops, treestore.PutOp{Path: path, Value: blob})
+	}
+	if err := p.pub.PutBatch(ops); err != nil {
+		p.log.WithError(err).Debug("CXO bindings: bucket PutBatch failed")
+		p.recordError(err)
+	}
+}
+
+func (p *BindingsCXOPublisher) recordError(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastError = err
+}
+
+func (p *BindingsCXOPublisher) clearError() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastError = nil
+}

--- a/pkg/deployment/ar/api/cxo_publisher_test.go
+++ b/pkg/deployment/ar/api/cxo_publisher_test.go
@@ -1,0 +1,228 @@
+// Package api — cxo_publisher_test.go drives the bindings publisher end to end
+// over the CXO node's native TCP transport (no dmsg, no discovery) and asserts
+// the two things a Preview reader depends on: the bucket level is DENSE (all
+// 256 buckets published, so a bucket is addressable by computed index) and a
+// bound peer's record lands in the bucket its public key names.
+package api
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/storeconfig"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/deployment/ar/arfeed"
+	"github.com/skycoin/skywire/pkg/deployment/ar/store"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+func TestBindingsCXOPublisherTreeShape(t *testing.T) {
+	ctx := context.Background()
+	pkAR, skAR := cipher.GenerateKeyPair()
+
+	st, err := store.New(ctx, storeconfig.Config{Type: storeconfig.Memory}, time.Hour, logging.MustGetLogger("t"))
+	require.NoError(t, err)
+
+	// Seed before the publisher starts, so the startup resync is what puts
+	// these into the tree.
+	// Enough peers to spread across most buckets.
+	const nPeers = 200
+	peers := make([]cipher.PubKey, 0, nPeers)
+	for i := 0; i < nPeers; i++ {
+		pk, _ := cipher.GenerateKeyPair()
+		peers = append(peers, pk)
+		require.NoError(t, st.Bind(ctx, types.STCPR, pk, addrresolver.VisorData{
+			RemoteAddr:     "10.1.2.3:7777",
+			LocalAddresses: addrresolver.LocalAddresses{Port: "7777", Addresses: []string{"10.1.2.3"}},
+		}))
+	}
+
+	pub, err := treestore.NewWithTCP("127.0.0.1:0", skAR, treestore.PubConfig{
+		InMemoryDB:  true,
+		BatchWindow: 20 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pub.Close() }) //nolint:errcheck
+	pub.SetAllowlist(nil)
+
+	p := newBindingsCXOPublisher(pub, st, logging.MustGetLogger("t-bindings"), 50*time.Millisecond, time.Hour)
+	t.Cleanup(func() { _ = p.Close() }) //nolint:errcheck
+
+	sub, err := treestore.NewSubscriberTCP("", pkAR, treestore.SubConfig{InMemoryDB: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Close() }) //nolint:errcheck
+
+	// Connect, then wait on the CONTENT rather than on the first Root: under a
+	// loaded machine (this package's other CXO test runs first) the initial
+	// Root can take longer than a fixed wait, and every assertion below is
+	// already a poll with its own budget.
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	require.NoError(t, sub.ConnectTCP(cctx, pub.Node().TCP().Address()))
+
+	// The level must be dense: exactly BucketCount leaves, named by
+	// BucketNameAt(0..255). That density is what makes a bucket addressable by
+	// index rather than by a linear name scan.
+	waitFor(t, func() bool {
+		seen := 0
+		sub.Walk("", func(_ string, _ []byte) bool { seen++; return true })
+		return seen == arfeed.BucketCount
+	}, "publisher must materialize all %d buckets", arfeed.BucketCount)
+
+	for i := 0; i < arfeed.BucketCount; i++ {
+		_, ok := sub.Get(arfeed.BucketPathAt(i))
+		require.Truef(t, ok, "bucket %s must be present", arfeed.BucketPathAt(i))
+	}
+
+	// Every seeded peer must be readable from the bucket its own key names.
+	waitFor(t, func() bool {
+		for _, pk := range peers {
+			blob, ok := sub.Get(arfeed.BucketPath(pk))
+			if !ok {
+				return false
+			}
+			recs, err := arfeed.DecodeBucket(blob)
+			if err != nil {
+				return false
+			}
+			if recs[pk.Hex()].Get(types.STCPR) == nil {
+				return false
+			}
+		}
+		return true
+	}, "all seeded peers must appear in their own bucket")
+
+	// A later bind reaches the feed through the dirty-mark path, not a resync
+	// (the resync interval here is an hour).
+	late, _ := cipher.GenerateKeyPair()
+	require.NoError(t, st.Bind(ctx, types.SUDPH, late, addrresolver.VisorData{RemoteAddr: "9.9.9.9:1234"}))
+	p.MarkDirty(types.SUDPH, late)
+	waitFor(t, func() bool {
+		blob, ok := sub.Get(arfeed.BucketPath(late))
+		if !ok {
+			return false
+		}
+		recs, err := arfeed.DecodeBucket(blob)
+		if err != nil {
+			return false
+		}
+		vd := recs[late.Hex()].Get(types.SUDPH)
+		return vd != nil && vd.RemoteAddr == "9.9.9.9:1234"
+	}, "an incremental bind must reach the feed without waiting for a resync")
+
+	// And a DelBind must remove it again.
+	require.NoError(t, st.DelBind(ctx, types.SUDPH, late))
+	p.MarkDirty(types.SUDPH, late)
+	waitFor(t, func() bool {
+		blob, ok := sub.Get(arfeed.BucketPath(late))
+		if !ok {
+			return false
+		}
+		recs, err := arfeed.DecodeBucket(blob)
+		if err != nil {
+			return false
+		}
+		return recs[late.Hex()] == nil
+	}, "a DelBind must drop the peer from its bucket")
+}
+
+func waitFor(t *testing.T, cond func() bool, msg string, args ...interface{}) {
+	t.Helper()
+	// Generous: this waits on a real CXO publish + fill, and the budget is a
+	// deadlock backstop, not an expected duration. Under -race on a loaded
+	// runner the first Root of a 256-leaf tree took over 30s.
+	end := time.Now().Add(2 * time.Minute)
+	for {
+		if cond() {
+			return
+		}
+		if time.Now().After(end) {
+			t.Fatalf(msg, args...)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// toggleStore makes Resolve fail on demand with an error that is NOT
+// store.ErrNoEntry — a redis blip, a context that ran out — so the publisher's
+// handling of "cannot say" can be told apart from "not there".
+type toggleStore struct {
+	store.Store
+	failing atomic.Bool
+}
+
+func (s *toggleStore) Resolve(ctx context.Context, netType types.Type, pk cipher.PubKey) (addrresolver.VisorData, error) {
+	if s.failing.Load() {
+		return addrresolver.VisorData{}, errors.New("transient store failure")
+	}
+	return s.Store.Resolve(ctx, netType, pk)
+}
+
+// TestTransientStoreErrorDoesNotPublishAbsence is the correctness case the
+// publisher exists to get right: a reader cannot distinguish a peer the AR
+// genuinely has no binding for from one the publisher dropped because redis
+// blinked. So a Resolve failure that is not a definite "no entry" must leave
+// the published record alone.
+func TestTransientStoreErrorDoesNotPublishAbsence(t *testing.T) {
+	ctx := context.Background()
+	log := logging.MustGetLogger("t-transient")
+
+	base, err := store.New(ctx, storeconfig.Config{Type: storeconfig.Memory}, time.Hour, log)
+	require.NoError(t, err)
+	st := &toggleStore{Store: base}
+
+	pk, _ := cipher.GenerateKeyPair()
+	require.NoError(t, base.Bind(ctx, types.STCPR, pk, addrresolver.VisorData{RemoteAddr: "192.0.2.10:5000"}))
+
+	pkAR, skAR := cipher.GenerateKeyPair()
+	pub, err := treestore.NewWithTCP("127.0.0.1:0", skAR, treestore.PubConfig{
+		InMemoryDB:  true,
+		BatchWindow: 20 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pub.Close() }) //nolint:errcheck
+	pub.SetAllowlist(nil)
+
+	p := newBindingsCXOPublisher(pub, st, log, 50*time.Millisecond, time.Hour)
+	t.Cleanup(func() { _ = p.Close() }) //nolint:errcheck
+
+	sub, err := treestore.NewSubscriberTCP("", pkAR, treestore.SubConfig{InMemoryDB: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Close() }) //nolint:errcheck
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	require.NoError(t, sub.ConnectTCP(cctx, pub.Node().TCP().Address()))
+
+	hasBinding := func() bool {
+		blob, ok := sub.Get(arfeed.BucketPath(pk))
+		if !ok {
+			return false
+		}
+		recs, derr := arfeed.DecodeBucket(blob)
+		return derr == nil && recs[pk.Hex()].Get(types.STCPR) != nil
+	}
+	waitFor(t, hasBinding, "the seeded peer must reach the feed")
+
+	// Now the store cannot answer. Several flush windows of dirty marks must
+	// not remove the peer.
+	st.failing.Store(true)
+	for i := 0; i < 10; i++ {
+		p.MarkDirty(types.STCPR, pk)
+		time.Sleep(60 * time.Millisecond)
+	}
+	require.True(t, hasBinding(), "a transient store error must not publish an absence")
+
+	// A definite absence still removes it.
+	st.failing.Store(false)
+	require.NoError(t, base.DelBind(ctx, types.STCPR, pk))
+	p.MarkDirty(types.STCPR, pk)
+	waitFor(t, func() bool { return !hasBinding() }, "a real DelBind must still drop the peer")
+}

--- a/pkg/deployment/ar/arfeed/arfeed.go
+++ b/pkg/deployment/ar/arfeed/arfeed.go
@@ -1,0 +1,256 @@
+// Package arfeed pkg/deployment/ar/arfeed/arfeed.go c4-net-discovery
+//
+// Wire shape of the address-resolver's CXO bindings feed — the tree layout,
+// the record type and the codec, shared by the publisher
+// (pkg/deployment/ar/api) and any reader. It depends on nothing but the
+// VisorData type and the CXO frame helpers, so a visor can import it without
+// dragging in the AR service's HTTP stack.
+//
+// # Why this tree is shaped the way it is
+//
+// The feed exists to be read with CXO's Preview (pkg/cxo/node.Conn.Preview):
+// fetch the publisher's latest Root over an already-open connection, walk ONLY
+// the branches the lookup needs, and hold nothing afterwards. That pays off
+// only if the tree is keyed by the thing being looked up. The dmsg-discovery
+// clients-by-server feed is the counter-example — keyed by SERVER, so
+// resolving one client means pulling that server's whole batch.
+//
+// Three properties of treestore and registry.Refs decide the layout, and each
+// one was measured rather than assumed:
+//
+//  1. A level's children are individual objects, one network fetch each. So
+//     SCANNING a level of N children costs N round-trips.
+//  2. treestore encodes each level's children in sorted Name order
+//     (publisher.go sortedNames -> encodeNode), so a reader can address a
+//     child by INDEX and skip the scan entirely.
+//  3. Refs is a Merkle tree of degree 16. Addressing element i inside a level
+//     of more than 16 children walks the branch nodes preceding it, so a
+//     256-wide level costs between 1 and ~16 EXTRA fetches depending on where
+//     the key lands. A level of at most 16 children is a single Refs node:
+//     one fetch, whatever the index.
+//
+// Hence two levels of one hex character each, 16 wide apiece:
+//
+//	<pk-hex[2]>/<pk-hex[3]>    // FrameGzip(v1, JSON map pk-hex -> PeerBindings)
+//
+// 256 buckets, every one of them always published (empty ones included) so
+// both levels stay dense and index-addressable. A lookup is then a FIXED
+// handful of object fetches — schema registry, root TreeNode, root Refs node,
+// level-1 entry, level-2 TreeNode, its Refs node, the bucket entry — at any
+// network size and for any key. Widening to 4096 buckets later is one more
+// level and three more fetches.
+//
+// # The offset matters
+//
+// The bucket is named from hex[2:4], not hex[0:2]. A skywire public key is a
+// COMPRESSED secp256k1 point, so its leading byte is always 0x02 or 0x03:
+// bucketing on the first two hex characters puts the entire network into two
+// buckets and silently turns each "one indexed fetch" into a whole-network
+// download. Measured on the 1711 peers the production AR held on 2026-09-06:
+// hex[0:2] gives 2 buckets of 886 and 825; hex[2:4] gives 255 occupied buckets
+// with a maximum occupancy of 17. The offset skips the parity byte and starts
+// at the first byte of the X coordinate, which is uniform.
+//
+// Bucket occupancy is the tuning knob. At ~1.7k bound peers a bucket holds
+// around seven records, a few hundred bytes gzipped, so a lookup transfers the
+// target plus a handful of incidental neighbors. An order of magnitude more
+// peers wants a third level — a wire-format change, which is what the leading
+// version byte is for: an old reader rejects the frame cleanly and falls back
+// to HTTP rather than misparsing it.
+package arfeed
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// Version is the wire-format version byte of a bucket leaf body. Bump it on
+// any breaking change to the bucket encoding OR to the tree layout; readers
+// reject other values rather than misparsing them.
+const Version = 1
+
+// Levels is the depth of the bucket tree. Each level is named by one hex
+// character of the peer's public key.
+const Levels = 2
+
+// Fanout is the number of children at each level — one hex character. It is
+// deliberately not larger: registry.Refs has degree 16, so a level of at most
+// 16 children is a single Refs node and an indexed fetch there costs one
+// round-trip regardless of the index.
+const Fanout = 16
+
+// KeyOffset is the index of the first hex character of a peer's public key
+// used to name its path. It is one byte in, not zero, because a compressed
+// secp256k1 key's leading byte is always 0x02 or 0x03 — see the package doc.
+const KeyOffset = 2
+
+// BucketCount is the number of buckets the publisher always materializes.
+const BucketCount = 1 << (4 * Levels)
+
+// ErrBadVersion is returned by DecodeBucket for a frame whose version byte is
+// not Version. Callers treat it as "I cannot read this", not as an error worth
+// retrying.
+var ErrBadVersion = errors.New("arfeed: unsupported bucket frame version")
+
+// PeerBindings is one peer's address-resolver record: whichever of the four
+// bindable transport types the AR currently holds for it. Fields are pointers
+// so an absent binding is absent from the JSON rather than an empty object,
+// and the field order is fixed by the struct so a re-encode of unchanged
+// content produces identical bytes — a wire no-op on CXO's content-addressed
+// store.
+type PeerBindings struct {
+	STCPR *addrresolver.VisorData `json:"stcpr,omitempty"`
+	SUDPH *addrresolver.VisorData `json:"sudph,omitempty"`
+	QUIC  *addrresolver.VisorData `json:"squicr,omitempty"`
+	WT    *addrresolver.VisorData `json:"swtr,omitempty"`
+}
+
+// Empty reports whether the record carries no binding at all, in which case
+// the publisher drops the peer from its bucket.
+func (b *PeerBindings) Empty() bool {
+	return b == nil || (b.STCPR == nil && b.SUDPH == nil && b.QUIC == nil && b.WT == nil)
+}
+
+// Get returns the binding for one transport type, or nil.
+func (b *PeerBindings) Get(t types.Type) *addrresolver.VisorData {
+	if b == nil {
+		return nil
+	}
+	switch types.NormalizeType(t) {
+	case types.STCPR:
+		return b.STCPR
+	case types.SUDPH:
+		return b.SUDPH
+	case types.QUIC:
+		return b.QUIC
+	case types.WT:
+		return b.WT
+	default:
+		return nil
+	}
+}
+
+// Set installs the binding for one transport type; a nil value clears it.
+// Reports whether the type was a bindable one.
+func (b *PeerBindings) Set(t types.Type, v *addrresolver.VisorData) bool {
+	switch types.NormalizeType(t) {
+	case types.STCPR:
+		b.STCPR = v
+	case types.SUDPH:
+		b.SUDPH = v
+	case types.QUIC:
+		b.QUIC = v
+	case types.WT:
+		b.WT = v
+	default:
+		return false
+	}
+	return true
+}
+
+// Segments returns the per-level names of pk's bucket, outermost first.
+func Segments(pk cipher.PubKey) []string {
+	h := pk.Hex()
+	out := make([]string, Levels)
+	for i := 0; i < Levels; i++ {
+		out[i] = h[KeyOffset+i : KeyOffset+i+1]
+	}
+	return out
+}
+
+// Indices returns the per-level child POSITIONS of pk's bucket — what a reader
+// hands to an indexed child fetch instead of scanning the level for a name.
+// Valid only because the publisher keeps every level dense and treestore
+// writes children in sorted name order. A malformed segment yields -1, which
+// an indexed fetch treats as a miss.
+func Indices(pk cipher.PubKey) []int {
+	segs := Segments(pk)
+	out := make([]int, len(segs))
+	for i, s := range segs {
+		n, err := strconv.ParseUint(s, 16, 8)
+		if err != nil {
+			out[i] = -1
+			continue
+		}
+		out[i] = int(n)
+	}
+	return out
+}
+
+// BucketPath returns the full tree path of pk's bucket, e.g. "a/3".
+func BucketPath(pk cipher.PubKey) string {
+	return strings.Join(Segments(pk), "/")
+}
+
+// BucketPathAt returns the path of the i'th bucket in the dense enumeration
+// the publisher materializes, for 0 <= i < BucketCount.
+func BucketPathAt(i int) string {
+	segs := make([]string, Levels)
+	for lvl := Levels - 1; lvl >= 0; lvl-- {
+		segs[lvl] = fmt.Sprintf("%x", i%Fanout)
+		i /= Fanout
+	}
+	return strings.Join(segs, "/")
+}
+
+// EncodeBucket serializes one bucket's peer records into a leaf body: a JSON
+// object keyed by peer public key in sorted order (so unchanged content
+// re-encodes to identical bytes), version-framed and gzipped.
+func EncodeBucket(peers map[cipher.PubKey]*PeerBindings) ([]byte, error) {
+	pks := make([]string, 0, len(peers))
+	idx := make(map[string]*PeerBindings, len(peers))
+	for pk, b := range peers {
+		if b.Empty() {
+			continue
+		}
+		h := pk.Hex()
+		pks = append(pks, h)
+		idx[h] = b
+	}
+	sort.Strings(pks)
+
+	payload := make([]byte, 0, 64+len(pks)*256)
+	payload = append(payload, '{')
+	for i, h := range pks {
+		body, err := json.Marshal(idx[h])
+		if err != nil {
+			return nil, err
+		}
+		if i > 0 {
+			payload = append(payload, ',')
+		}
+		payload = append(payload, '"')
+		payload = append(payload, h...)
+		payload = append(payload, '"', ':')
+		payload = append(payload, body...)
+	}
+	payload = append(payload, '}')
+	return cxoutils.FrameGzip(Version, payload), nil
+}
+
+// DecodeBucket parses a bucket leaf body. An unknown version byte yields
+// ErrBadVersion so a reader degrades to its fallback path instead of
+// misparsing a newer wire shape.
+func DecodeBucket(blob []byte) (map[string]*PeerBindings, error) {
+	version, body, ok := cxoutils.UnframeGzip(blob)
+	if !ok {
+		return nil, errors.New("arfeed: empty bucket body")
+	}
+	if version != Version {
+		return nil, fmt.Errorf("%w: got %d want %d", ErrBadVersion, version, Version)
+	}
+	out := make(map[string]*PeerBindings)
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/pkg/deployment/ar/arfeed/arfeed_test.go
+++ b/pkg/deployment/ar/arfeed/arfeed_test.go
@@ -1,0 +1,150 @@
+// Package arfeed — arfeed_test.go pins the properties a Preview reader depends
+// on: every level is a dense, index-addressable run of names derived from the
+// public key alone, those names actually spread across the key space, and a
+// bucket body round-trips through the version-framed codec.
+package arfeed
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// TestBucketIndicesMatchSortedPositions is the invariant the whole design
+// rests on: Indices(pk)[lvl] must equal the position of Segments(pk)[lvl] in
+// that level's sorted name list, because that is the index the reader hands to
+// registry.Refs.ValueByIndex instead of scanning the level.
+func TestBucketIndicesMatchSortedPositions(t *testing.T) {
+	// BucketPathAt enumerates the tree in the order treestore sorts it. Check
+	// that each LEVEL is a dense ascending run of Fanout names, then that a
+	// key's computed indices address its own bucket.
+	seen := make(map[string]bool, BucketCount)
+	for i := 0; i < BucketCount; i++ {
+		path := BucketPathAt(i)
+		segs := strings.Split(path, "/")
+		require.Len(t, segs, Levels)
+		for _, s := range segs {
+			require.Len(t, s, 1)
+		}
+		require.False(t, seen[path], "duplicate bucket path %s", path)
+		seen[path] = true
+	}
+	require.Len(t, seen, BucketCount)
+
+	for i := 0; i < 500; i++ {
+		pk, _ := cipher.GenerateKeyPair()
+		segs, indices := Segments(pk), Indices(pk)
+		require.Len(t, segs, Levels)
+		for lvl := range segs {
+			require.GreaterOrEqual(t, indices[lvl], 0)
+			require.Less(t, indices[lvl], Fanout)
+			// The index must be the position of this segment among the Fanout
+			// names sorted ascending — that is the whole basis for addressing
+			// a child by index instead of scanning for it.
+			require.Equal(t, segs[lvl], fmt.Sprintf("%x", indices[lvl]))
+		}
+		require.True(t, seen[BucketPath(pk)], "%s addresses no published bucket", pk.Hex())
+	}
+}
+
+// TestBucketsSpreadAcrossKeySpace guards the offset. A skywire public key is a
+// compressed secp256k1 point, so its leading byte is always 0x02 or 0x03:
+// naming a bucket after hex[0:2] puts the entire network into two buckets and
+// silently turns every "one indexed fetch" into a whole-network download. This
+// is not hypothetical — it is what the first version of this file did, and the
+// 18 KB bucket leaf is what exposed it.
+func TestBucketsSpreadAcrossKeySpace(t *testing.T) {
+	const n = 4000
+	occupied := make(map[string]int)
+	for i := 0; i < n; i++ {
+		pk, _ := cipher.GenerateKeyPair()
+		occupied[BucketPath(pk)]++
+	}
+	require.Greater(t, len(occupied), BucketCount*3/4,
+		"bucket names must spread across the key space, got only %d distinct of %d",
+		len(occupied), BucketCount)
+
+	worst := 0
+	for _, c := range occupied {
+		if c > worst {
+			worst = c
+		}
+	}
+	// Uniform bucketing puts ~n/256 in a bucket; allow generous slack for the
+	// tail of the multinomial while still failing hard on a degenerate split.
+	require.Less(t, worst, 4*n/BucketCount+20,
+		"worst-case bucket occupancy %d suggests the bucket key is not uniform", worst)
+}
+
+func TestBucketRoundTrip(t *testing.T) {
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+
+	peers := map[cipher.PubKey]*PeerBindings{
+		pkA: {STCPR: &addrresolver.VisorData{RemoteAddr: "1.2.3.4:5000"}},
+		pkB: {SUDPH: &addrresolver.VisorData{RemoteAddr: "5.6.7.8:6000", RemoteAddrV6: "[2001:db8::1]:6000"}},
+	}
+	blob, err := EncodeBucket(peers)
+	require.NoError(t, err)
+
+	got, err := DecodeBucket(blob)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, "1.2.3.4:5000", got[pkA.Hex()].Get(types.STCPR).RemoteAddr)
+	require.Nil(t, got[pkA.Hex()].Get(types.SUDPH))
+	require.Equal(t, "[2001:db8::1]:6000", got[pkB.Hex()].Get(types.SUDPH).RemoteAddrV6)
+}
+
+// TestEncodeBucketIsDeterministic matters because CXO is content-addressed: an
+// unchanged bucket must re-encode to identical bytes so a republish is a wire
+// no-op rather than a fresh object every 30 seconds.
+func TestEncodeBucketIsDeterministic(t *testing.T) {
+	peers := map[cipher.PubKey]*PeerBindings{}
+	for i := 0; i < 32; i++ {
+		pk, _ := cipher.GenerateKeyPair()
+		peers[pk] = &PeerBindings{
+			STCPR: &addrresolver.VisorData{RemoteAddr: "10.0.0.1:1"},
+			WT:    &addrresolver.VisorData{RemoteAddr: "10.0.0.2:2"},
+		}
+	}
+	first, err := EncodeBucket(peers)
+	require.NoError(t, err)
+	for i := 0; i < 5; i++ {
+		again, err := EncodeBucket(peers)
+		require.NoError(t, err)
+		require.Equal(t, first, again, "re-encode of unchanged content must be byte-identical")
+	}
+}
+
+func TestDecodeBucketRejectsUnknownVersion(t *testing.T) {
+	blob, err := EncodeBucket(nil)
+	require.NoError(t, err)
+	blob[0] = Version + 1
+	_, err = DecodeBucket(blob)
+	require.ErrorIs(t, err, ErrBadVersion)
+}
+
+func TestEmptyBucketDecodesToNothing(t *testing.T) {
+	blob, err := EncodeBucket(nil)
+	require.NoError(t, err)
+	got, err := DecodeBucket(blob)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// A record with no binding at all is dropped rather than published as an empty
+// object, so a reader never sees a peer it cannot dial.
+func TestEmptyRecordsAreOmitted(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	blob, err := EncodeBucket(map[cipher.PubKey]*PeerBindings{pk: {}})
+	require.NoError(t, err)
+	got, err := DecodeBucket(blob)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}

--- a/pkg/services/ar/ar.go
+++ b/pkg/services/ar/ar.go
@@ -221,6 +221,25 @@ func (s *service) Run(ctx context.Context) error {
 		}
 	}
 
+	// CXO bindings publisher: the READ side, keyed by peer public key, so a
+	// caller can look one peer's addresses up over an already-open CXO
+	// connection with Preview instead of an authenticated HTTP round-trip —
+	// and without subscribing to (and holding) the whole set. Additive: GET
+	// /resolve is unchanged and stays authoritative, and the feed is inert
+	// until something reads it. Best-effort, like the aggregator above.
+	if h.DmsgClient != nil {
+		bindPub, berr := api.StartBindingsCXOPublisher(h.DmsgClient, sk, transportStore, logger)
+		if berr != nil {
+			logger.WithError(berr).Error("Failed to start CXO bindings publisher, continuing without it")
+		} else {
+			arAPI.SetBindingsCXOPublisher(bindPub)
+			defer func() {
+				arAPI.SetBindingsCXOPublisher(nil)
+				_ = bindPub.Close() //nolint:errcheck
+			}()
+		}
+	}
+
 	defer arAPI.Close()
 	select {
 	case <-runCtx.Done():

--- a/pkg/skyenv/ports_test.go
+++ b/pkg/skyenv/ports_test.go
@@ -38,6 +38,7 @@ func TestVisorPortsAreUnique(t *testing.T) {
 		"DmsgDMSGDClientsByServerCXOPort": DmsgDMSGDClientsByServerCXOPort,
 		"DmsgTPDAllTransportsCXOPort":     DmsgTPDAllTransportsCXOPort,
 		"DmsgTPDStatsCXOPort":             DmsgTPDStatsCXOPort,
+		"DmsgARBindingsCXOPort":           DmsgARBindingsCXOPort,
 		"DmsgDMSGDRegistrationCXOPort":    DmsgDMSGDRegistrationCXOPort,
 		"DmsgVisorARBindCXOPort":          DmsgVisorARBindCXOPort,
 		"DmsgVisorSDRegCXOPort":           DmsgVisorSDRegCXOPort,

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -119,6 +119,17 @@ const (
 	// only needs to be collision-free, which ports_test guards.
 	DmsgTPDStatsCXOPort uint16 = 73
 
+	// DmsgARBindingsCXOPort is the dmsg port the Address Resolver's CXO
+	// BINDINGS publisher listens on — the read side of the AR, keyed by peer
+	// public key (see pkg/deployment/ar/arfeed). Distinct from
+	// DmsgVisorARBindCXOPort (71), which is the opposite direction: there the
+	// AR aggregates each visor's own bind feed, here the AR publishes the
+	// merged result for anyone to look a peer up in. Two ports rather than one
+	// node serving both so the read feed cannot disturb the bind ingest.
+	// Numbered 74 (50-55 and 56-73 are all taken); the value only needs to be
+	// collision-free, which ports_test guards.
+	DmsgARBindingsCXOPort uint16 = 74
+
 	// DmsgDMSGDRegistrationCXOPort is the dmsg port the dmsg-discovery's CXO
 	// client-entry REGISTRATION aggregator binds (and each visor's entry
 	// publisher binds for the reverse subscribe). A visor publishes its own


### PR DESCRIPTION
The address resolver aggregates visor bind feeds over CXO but publishes nothing back, so the ~1.5k warm CXO connections it holds carry traffic in one direction only. This adds the read side: a treestore feed on a new dmsg port (74) carrying every binding the AR holds, keyed so one peer can be looked up without pulling the rest. It is the publisher half of #4584 — useful on its own, and the precondition for a Preview-backed reader that holds nothing.

The tree is 256 buckets across two levels of one hex character each, every bucket always published so both levels stay dense. Three measured properties of treestore and `registry.Refs` dictate that shape: a level's children are individual objects fetched one per Get, so scanning a level costs one round-trip per child; children are written in sorted name order, so a reader can address one by index instead; and Refs has degree 16, so a level wider than 16 makes an indexed fetch walk the branch nodes ahead of it (5 objects for a key at index 2, 14 at index 221). Two 16-wide levels keep a lookup at a fixed 7 fetches for any key at any network size. Contrast `dmsgd-clients-by-server`, keyed by server: resolving one client there means fetching batches until you hit it.

One thing worth flagging because it is easy to get wrong and was: the bucket is named from `hex[2:4]`, not `hex[0:2]`. A skywire public key is a compressed secp256k1 point, so its leading byte is always 0x02 or 0x03. Measured on the 1711 peers the production AR held on 2026-09-06, `hex[0:2]` gives 2 buckets of 886 and 825 — the whole network in two leaves — while `hex[2:4]` gives 255 occupied buckets with a maximum occupancy of 17.

State comes from two places because neither alone is both fresh and correct: a store decorator marks (peer, type) dirty on every Bind/DelBind so a new binding reaches the feed within seconds, and a five-minute resync rebuilds from the per-type index — the only thing that drops a binding that expired by TTL, since an expiry calls no DelBind. A Resolve error that is not a definite no-entry never publishes an absence: a reader cannot tell a peer the AR has nothing for from one the publisher dropped because redis blinked, so those marks are re-queued and the previous value carried forward. `GET /resolve` is untouched and stays authoritative; the feed is inert until something reads it.

Tested with TCP-transport end-to-end tests (no dmsg, no discovery) covering the dense level, a seeded peer readable from the bucket its own key names, incremental bind and DelBind propagation, and the transient-store-error case (verified to fail when the guard is removed). Smoke-tested against the real service: `skywire svc ar -t` logs `CXO bindings publisher running dmsg_port=74` alongside the existing aggregator on 71. Local `golangci-lint run` and `GOOS=windows golangci-lint run` are clean; the four redis store tests that fail locally are the usual no-local-redis failures.
