### PR TITLE
feat(sd): aggregate service registrations over CXO

### DIFF
--- a/pkg/deployment/sd/api/service_ingest.go
+++ b/pkg/deployment/sd/api/service_ingest.go
@@ -1,0 +1,99 @@
+// Package api pkg/deployment/sd/api/service_ingest.go c4-net-discovery
+//
+// SD-registration-over-CXO ingest: the server side of the fan-in path where
+// visors publish their live service-entry set as a CXO feed instead of
+// re-POSTing every entry over a fresh dmsg stream every 90s (each with a full
+// Noise handshake — the secp256k1 handshakeResponder that dominates discovery
+// -service CPU). The CXO aggregator (pkg/deployment/sd/regcxo) calls
+// IngestServiceFromCXO once per entry in each batch it replicates.
+//
+// This is purely ADDITIVE and dual-write: the HTTP POST /api/services path
+// remains authoritative and keeps writing the same store on the same 90s
+// schedule. The CXO ingest therefore never clobbers a fresh HTTP register:
+//
+//   - When a record already exists (the common case — HTTP registered first),
+//     the CXO ingest is a keepalive: it re-writes the STORED entry to refresh
+//     its TTL, off a warm CXO connection instead of a fresh handshake. It
+//     writes back exactly what is there, so it can never overwrite a newer
+//     HTTP registration (mirrors the AR's bind keepalive, which likewise
+//     refreshes off the stored record rather than the incoming one).
+//   - When no record exists yet, only the non-visor types take a fresh insert.
+//     A type=visor registration is gated on ipIsPublic(entry, observed-remote-
+//     addr), and the CXO path has no observed remote address to check against
+//     — so a fresh visor entry is left to HTTP, exactly as a fresh SUDPH bind
+//     is left to the AR's UDP path.
+//
+// Deregistration is ABSENCE, not a tombstone: a service the visor stops
+// publishing simply stops being refreshed here and expires on the store's
+// existing entry TTL (Config.EntryTimeout). There is deliberately no CXO
+// delete path.
+package api
+
+import (
+	"context"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/servicedisc"
+)
+
+// IngestServiceFromCXO applies one service entry received over the
+// SD-registration-over-CXO feed. reporter is the feed's publisher PK (the
+// visor); an entry whose address is not reporter's own is DROPPED, so a visor
+// can only ever register its own services — the ownership check the HTTP path
+// enforces via httpauth is structural here.
+//
+// See the package doc for the dual-write / no-clobber semantics.
+func (a *API) IngestServiceFromCXO(ctx context.Context, reporter cipher.PubKey, se servicedisc.Service) {
+	if reporter == (cipher.PubKey{}) || se.Type == "" {
+		return
+	}
+	if se.Addr.PubKey() != reporter {
+		a.log.WithField("reporter", reporter).WithField("entry_pk", se.Addr.PubKey()).
+			Debug("sd-reg-cxo: entry address is not the publishing visor; dropping")
+		return
+	}
+
+	// Keepalive-first: if a record already exists, refresh its TTL off the
+	// STORED entry. This is the common case and the whole CPU win — a warm
+	// CXO Root keeps the registration alive with no fresh Noise handshake.
+	// Writing back the stored value can never clobber a newer HTTP register.
+	if stored, sErr := a.db.Service(ctx, se.Type, se.Addr); sErr == nil && stored != nil {
+		if uErr := a.db.UpdateServiceAndHeartbeat(ctx, stored, stored.Version); uErr != nil {
+			a.log.WithError(uErr).WithField("reporter", reporter).WithField("type", se.Type).
+				Debug("sd-reg-cxo: TTL keepalive refresh failed")
+			return
+		}
+		a.mirrorVisorServices(ctx, reporter)
+		a.cxoPublisher.PutEntry(stored)
+		return
+	}
+
+	// No record yet. A type=visor entry is admitted by HTTP only after
+	// ipIsPublic() matches the observed remote address against the declared
+	// LocalIPs; the CXO path observes no address, so it cannot make that
+	// judgement — leave a fresh visor registration to HTTP.
+	if se.Type == servicedisc.ServiceTypeVisor {
+		return
+	}
+	// Mirror the HTTP handler's version gate for the exit types.
+	if (se.Type == servicedisc.ServiceTypeVPN || se.Type == servicedisc.ServiceTypeSkysocks) && se.Version == "" {
+		a.log.WithField("reporter", reporter).WithField("type", se.Type).
+			Debug("sd-reg-cxo: " + ErrVisorVersionIsTooOld.Error() + "; dropping")
+		return
+	}
+
+	// Fresh insert. Geo is best-effort enrichment for these types and the
+	// HTTP handler already registers them without it when the lookup fails,
+	// so an entry that carries none (the visor attaches its own when it has
+	// one) is registered as-is.
+	entry := se
+	if uErr := a.db.UpdateServiceAndHeartbeat(ctx, &entry, entry.Version); uErr != nil {
+		a.log.WithError(uErr).WithField("reporter", reporter).WithField("type", entry.Type).
+			Debug("sd-reg-cxo: fresh registration failed")
+		return
+	}
+	a.mirrorVisorServices(ctx, reporter)
+	a.cxoPublisher.PutEntry(&entry)
+	a.log.WithField("reporter", reporter).WithField("type", entry.Type).
+		Debug("sd-reg-cxo: fresh registration ingested")
+}

--- a/pkg/deployment/sd/regcxo/aggregator.go
+++ b/pkg/deployment/sd/regcxo/aggregator.go
@@ -1,0 +1,186 @@
+// Package regcxo pkg/deployment/sd/regcxo/aggregator.go c4-net-discovery
+//
+// SD-registration-over-CXO aggregator — the service-discovery side of the
+// fan-in path. Visors publish their live service-entry set (the type=visor /
+// vpn / skysocks / coin registrations they POST to /api/services) as a CXO
+// feed and AnnounceTo this service; the aggregator owns one CXO Node
+// listening on DmsgVisorSDRegCXOPort, subscribes to each visor's feed on
+// connect, and on every filled Root decodes the batched services leaf and
+// hands each entry to the Sink (the SD API's IngestServiceFromCXO).
+//
+// This moves registration off the 90s HTTP re-POST — each a fresh dmsg
+// stream with a full Noise handshake (the secp256k1 handshakeResponder that
+// dominates discovery-service CPU) — onto a persistent CXO connection kept
+// warm by the treestore heartbeat. The HTTP path remains authoritative, so
+// ingest is idempotent and no-clobber (see IngestServiceFromCXO).
+//
+// The node, the connect-driven subscribe loop, the grace-gated orphan-feed
+// reclaim and the service-identity binding all live in pkg/cxo/cxoaggregate,
+// shared with the dmsg-discovery, AR and TPD aggregators. What is left here
+// is only what is specific to this feed: the single batched services leaf.
+package regcxo
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoaggregate"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject/registry"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/servicedisc"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// logTag prefixes this aggregator's log lines.
+const logTag = "sd-reg-cxo aggregator"
+
+// servicesLeafPath is the single leaf a visor's SD-registration feed
+// carries: its WHOLE live service set, republished on every change. Must
+// match the visor publisher (pkg/visor/init_sd_reg_cxo.go).
+const servicesLeafPath = "services"
+
+// servicesBatchVersion is the wire-format version byte of that leaf's body
+// (cxoutils.FrameGzip). A Root carrying any other version is from a newer
+// publisher and is skipped rather than misparsed; the visor's HTTP
+// registration keeps it discoverable meanwhile.
+const servicesBatchVersion = 1
+
+// ingestTimeout bounds one entry's store round-trip. Generous relative to a
+// redis pipeline, so a slow store degrades into skipped keepalives rather
+// than a wedged CXO event loop.
+const ingestTimeout = 10 * time.Second
+
+// Sink ingests service entries replicated from visor SD-registration feeds.
+// The SD API satisfies it via (*api.API).IngestServiceFromCXO.
+type Sink interface {
+	IngestServiceFromCXO(ctx context.Context, reporter cipher.PubKey, se servicedisc.Service)
+}
+
+// Config tunes the aggregator loops. Zero values get sane defaults.
+//
+// The service SecKey is deliberately NOT here — it is a required argument to
+// New. As an optional field on the sibling dmsg-discovery aggregator it was
+// omitted, node.NewNode minted a random keypair, and every gated visor
+// refused the subscribe (#4569).
+type Config struct {
+	ReconcileInterval time.Duration
+	CleanupInterval   time.Duration
+	MaxFillingTime    time.Duration
+	Logger            *logging.Logger
+	InMemoryDB        bool
+	DataDir           string
+}
+
+// Aggregator receives visor SD-registration feeds. It is the shared
+// cxoaggregate.Core plus this feed's batched-leaf decoding.
+type Aggregator struct {
+	core *cxoaggregate.Core
+	sink Sink
+	log  *logging.Logger
+}
+
+// New constructs an Aggregator: a CXO Node with DMSG enabled on
+// DmsgVisorSDRegCXOPort so remote visors can dial in, wired to forward each
+// filled Root's service entries to sink.
+//
+// sk is the SD's service secret key. It binds the CXO node identity so the
+// aggregator's handshake PK is the SD PK gated visors allowlist (they hold
+// it in launcher.service_discovery / service_discovery_dmsg).
+func New(dmsgC *dmsg.Client, sk cipher.SecKey, sink Sink, conf Config) (*Aggregator, error) {
+	if conf.Logger == nil {
+		conf.Logger = logging.MustGetLogger("sd-reg-cxo")
+	}
+	a := &Aggregator{sink: sink, log: conf.Logger}
+
+	core, err := cxoaggregate.New(dmsgC, sk, skyenv.DmsgVisorSDRegCXOPort, cxoaggregate.Options{
+		ReconcileInterval: conf.ReconcileInterval,
+		CleanupInterval:   conf.CleanupInterval,
+		MaxFillingTime:    conf.MaxFillingTime,
+		Logger:            conf.Logger,
+		LogTag:            logTag,
+		InMemoryDB:        conf.InMemoryDB,
+		DataDir:           conf.DataDir,
+		OnRootFilled:      a.handleRootFilled,
+		OnFillingBreaks: func(r *registry.Root, reason error) {
+			a.log.WithError(reason).WithField("visor", cipher.PubKey(r.Pub)).
+				Debug(logTag + ": root filling broke")
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	a.core = core
+	return a, nil
+}
+
+// Run starts the reconcile + cleanup loops. Returns immediately; the loop
+// runs until ctx is canceled or Close is called. Idempotent.
+func (a *Aggregator) Run(ctx context.Context) { a.core.Run(ctx) }
+
+// Close stops the loops and tears down the CXO node. Idempotent.
+func (a *Aggregator) Close() error { return a.core.Close() }
+
+// FeedPK returns the aggregator's own CXO node identity — the SD's service PK.
+func (a *Aggregator) FeedPK() cipher.PubKey { return a.core.FeedPK() }
+
+// handleRootFilled decodes the batched services leaf from a filled Root and
+// forwards every entry to the Sink. r.Pub is the visor whose feed produced
+// this Root — the reporter PK the ingest attributes the entries to.
+func (a *Aggregator) handleRootFilled(r *registry.Root) {
+	if r == nil || len(r.Refs) == 0 {
+		return
+	}
+	reporter := cipher.PubKey(r.Pub)
+	if reporter == (cipher.PubKey{}) {
+		a.log.Debug(logTag + ": dropping root with zero publisher PK")
+		return
+	}
+	pack, err := a.core.Container().Pack(r, treestore.Registry)
+	if err != nil {
+		a.log.WithError(err).Debug(logTag + ": get pack failed")
+		return
+	}
+	var rootNode treestore.TreeNode
+	if err := r.Refs[0].Value(pack, &rootNode); err != nil {
+		a.log.WithError(err).Debug(logTag + ": decode root TreeNode failed")
+		return
+	}
+
+	leaf, ok := cxoaggregate.LeafByName(pack, &rootNode, servicesLeafPath)
+	if !ok || len(leaf) == 0 {
+		// A visor with no live services publishes no leaf at all — its
+		// entries are meant to lapse on the store TTL. Nothing to do.
+		return
+	}
+	entries, ok := decodeServicesBatch(leaf)
+	if !ok {
+		a.log.WithField("visor", reporter).Debug(logTag + ": services leaf decode failed")
+		return
+	}
+	for i := range entries {
+		ctx, cancel := context.WithTimeout(context.Background(), ingestTimeout)
+		a.sink.IngestServiceFromCXO(ctx, reporter, entries[i])
+		cancel()
+	}
+}
+
+// decodeServicesBatch unframes + gunzips the batched leaf body and decodes
+// the JSON service array. A version byte this build does not know yields
+// ok=false, so an older SD skips a newer publisher's leaf cleanly instead of
+// misparsing it.
+func decodeServicesBatch(body []byte) ([]servicedisc.Service, bool) {
+	version, payload, ok := cxoutils.UnframeGzip(body)
+	if !ok || version != servicesBatchVersion {
+		return nil, false
+	}
+	var out []servicedisc.Service
+	if err := json.Unmarshal(payload, &out); err != nil {
+		return nil, false
+	}
+	return out, true
+}

--- a/pkg/deployment/sd/regcxo/aggregator_test.go
+++ b/pkg/deployment/sd/regcxo/aggregator_test.go
@@ -1,0 +1,83 @@
+// Package regcxo — aggregator_test.go: pins the SD-registration
+// aggregator's service-identity binding and its batched-leaf decoding.
+//
+// A visor gates this feed's subscriber allowlist on the CXO node's PeerID,
+// allowing the SD PK it holds in launcher.service_discovery(_dmsg). If the
+// aggregator's node is built without the SD's SecKey, node.NewNode mints a
+// random keypair and every gated visor rejects the subscribe — silently,
+// with the HTTP register still carrying registration so nothing looks
+// broken. That is #4168 on TPD and #4569 on dmsg-discovery.
+package regcxo
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoaggregate"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgtest"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/servicedisc"
+)
+
+type nopSink struct{}
+
+func (nopSink) IngestServiceFromCXO(_ context.Context, _ cipher.PubKey, _ servicedisc.Service) {}
+
+// TestAggregatorPresentsServiceIdentity: the aggregator's CXO node must
+// advertise the SD's own PK on every handshake.
+func TestAggregatorPresentsServiceIdentity(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+
+	env := dmsgtest.NewEnv(t, 30*time.Second)
+	require.NoError(t, env.Startup(0, 1, 0, &dmsg.Config{MinSessions: 1}))
+	t.Cleanup(env.Shutdown)
+	dmsgC, err := env.NewClientWithKeys(pk, sk, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err)
+
+	agg, err := New(dmsgC, sk, nopSink{}, Config{
+		InMemoryDB: true,
+		Logger:     logging.MustGetLogger("sd-reg-cxo-test"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agg.Close() }) //nolint:errcheck
+
+	require.Equal(t, pk, agg.FeedPK(),
+		"the SD-registration aggregator must present the SD's configured PK, not a random one")
+}
+
+// TestAggregatorRejectsZeroKey: a zero key must be a construction error,
+// never a random identity.
+func TestAggregatorRejectsZeroKey(t *testing.T) {
+	_, err := New(nil, cipher.SecKey{}, nopSink{}, Config{InMemoryDB: true})
+	require.ErrorIs(t, err, cxoaggregate.ErrNoServiceKey)
+}
+
+// TestDecodeServicesBatch round-trips the leaf shape the visor publisher
+// writes, and pins the version gate: a leaf framed with an unknown version
+// is skipped, not misparsed.
+func TestDecodeServicesBatch(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	in := []servicedisc.Service{
+		{Addr: servicedisc.NewSWAddr(pk, 44), Type: servicedisc.ServiceTypeVisor, Version: "v1.3.30"},
+		{Addr: servicedisc.NewSWAddr(pk, 3), Type: servicedisc.ServiceTypeVPN, Version: "v1.3.30"},
+	}
+	payload, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	out, ok := decodeServicesBatch(cxoutils.FrameGzip(servicesBatchVersion, payload))
+	require.True(t, ok)
+	require.Equal(t, in, out)
+
+	_, ok = decodeServicesBatch(cxoutils.FrameGzip(servicesBatchVersion+1, payload))
+	require.False(t, ok, "an unknown version byte must be skipped, not decoded")
+
+	_, ok = decodeServicesBatch([]byte("not a frame"))
+	require.False(t, ok)
+}

--- a/pkg/services/sd/sd.go
+++ b/pkg/services/sd/sd.go
@@ -17,12 +17,14 @@ import (
 	"github.com/skycoin/skywire/pkg/cxo/storeconfig"
 	"github.com/skycoin/skywire/pkg/deployment/sd/api"
 	sdmetrics "github.com/skycoin/skywire/pkg/deployment/sd/metrics"
+	"github.com/skycoin/skywire/pkg/deployment/sd/regcxo"
 	"github.com/skycoin/skywire/pkg/deployment/sd/store"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/httpauth"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/metricsutil"
 	"github.com/skycoin/skywire/pkg/services"
+	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/svcmode"
 )
 
@@ -185,6 +187,26 @@ func (s *service) Run(ctx context.Context) error {
 
 	if h.DmsgClient != nil {
 		s.startServicesCXO(runCtx, h.DmsgClient, sdAPI, sk, log)
+
+		// SD-registration-over-CXO aggregator: always-on fan-in path where
+		// visors publish their live service-entry set as a CXO feed instead
+		// of re-POSTing it over a fresh dmsg stream (each a full Noise
+		// handshake) every 90s. Inert until visors subscribe (just a
+		// listener), purely additive to the authoritative HTTP register, so
+		// it needs no gate. The API is the Sink (IngestServiceFromCXO). The
+		// node identity is bound to the SD's service SecKey so gated visors
+		// accept its subscribe (see #4168). Best-effort — HTTP registration
+		// is unaffected if it fails to start.
+		agg, aerr := regcxo.New(h.DmsgClient, sk, sdAPI, regcxo.Config{Logger: log})
+		if aerr != nil {
+			log.WithError(aerr).Error("Failed to start SD-registration-over-CXO aggregator, continuing without it")
+		} else {
+			agg.Run(runCtx)
+			defer func() { _ = agg.Close() }() //nolint:errcheck
+			log.WithField("feed_pk", agg.FeedPK()).
+				WithField("port", skyenv.DmsgVisorSDRegCXOPort).
+				Info("SD-registration-over-CXO aggregator running")
+		}
 	}
 
 	select {


### PR DESCRIPTION
Server side of SD-registration-over-CXO, completing the path opened by #4585. The service-discovery now runs a `cxoaggregate`-backed aggregator on `DmsgVisorSDRegCXOPort`: it subscribes to each visor's feed on connect, decodes the batched `services` leaf from every filled Root, and hands each entry to the API's new `IngestServiceFromCXO`. That takes the 90s re-registration off a fresh dmsg stream with a full Noise handshake — the `handshakeResponder` that dominates SD CPU — and onto one warm CXO connection. SD is the fourth user of `cxoaggregate`, so the node, the identity binding, the subscribe loop and the orphan-feed reclaim are all shared; only the leaf decoding is new here.

Ingest is no-clobber and additive. When an entry already exists — the common case, since the authoritative HTTP POST registered it first — the CXO ingest refreshes the TTL off the *stored* record, so it can never overwrite a newer HTTP registration. A fresh insert is taken only for the non-visor types: a `type=visor` registration is gated on the observed remote address matching the declared `LocalIPs`, which the CXO path cannot check, so it stays with HTTP (the same carve-out the AR makes for SUDPH). Deregistration remains absence — an entry the visor stops publishing simply stops being refreshed and expires on the store's existing entry TTL; there is no CXO delete path and no tombstone.

Local: `go build .`, both lint tiers clean, `pkg/deployment/sd/...` and `pkg/services/sd` green. The new tests pin the service-identity binding (the #4569 / #4168 failure mode) and the leaf version gate.