### PR TITLE
fix(autoconfig): retain existing hypervisors across config regen

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -563,6 +563,18 @@ func generateConfig(r resolvedConfig, hvArg string) error {
 	// and gen writes to a cwd-relative path instead of the absolute
 	// /opt/skywire/skywire.json (PKGENV) or ~/skywire-config.json
 	// (USRENV) that autoconfig already stat-checks downstream.
+	// -x (retainhv): carry the EXISTING config's hypervisors and dmsgpty
+	// whitelist into the regenerated one. autoconfig runs on every update, and
+	// without this the regen replaces the hypervisor list with whatever -j
+	// carries — so an operator who attached a second hypervisor at runtime
+	// (cli visor hv add, which persists) silently loses it on the next release,
+	// and the pty whitelist with it. Observed live: a fleet update mid-rollout
+	// wiped freshly-added hypervisors from every visor that restarted, while
+	// the ones that had not yet updated kept theirs. -j still supplies the
+	// configured hypervisor; -x only ADDS the ones already on disk.
+	args = append(args, "-x")
+	printableArgs = append(printableArgs, "-x")
+
 	switch {
 	case r.usrEnv:
 		args = append(args, "-u")


### PR DESCRIPTION
`cli visor hv add` is documented as persisted, and it is — until the next update. autoconfig regenerates the config on every update and does not pass `-x/--retainhv`, so `config gen` replaces the hypervisor list with whatever `-j` carries. A second hypervisor attached at runtime is silently dropped, and `-x` also carries the **dmsgpty whitelist**, so that goes too.

This was observed live, not inferred: while adding two hypervisors across 24 visors, a fleet update landed mid-rollout and every visor that restarted came back with its `hypervisors` list reset, while the nodes that had not yet updated kept theirs.

`-x` is additive — it appends `oldConf.Hypervisors` to the generated list — so `-j` still supplies the configured hypervisor and nothing about the default single-hypervisor case changes. Removing one stays an explicit `hv rm`.