### PR TITLE
Revert "fix(autoconfig): retain existing hypervisors across config regen"

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -563,18 +563,6 @@ func generateConfig(r resolvedConfig, hvArg string) error {
 	// and gen writes to a cwd-relative path instead of the absolute
 	// /opt/skywire/skywire.json (PKGENV) or ~/skywire-config.json
 	// (USRENV) that autoconfig already stat-checks downstream.
-	// -x (retainhv): carry the EXISTING config's hypervisors and dmsgpty
-	// whitelist into the regenerated one. autoconfig runs on every update, and
-	// without this the regen replaces the hypervisor list with whatever -j
-	// carries — so an operator who attached a second hypervisor at runtime
-	// (cli visor hv add, which persists) silently loses it on the next release,
-	// and the pty whitelist with it. Observed live: a fleet update mid-rollout
-	// wiped freshly-added hypervisors from every visor that restarted, while
-	// the ones that had not yet updated kept theirs. -j still supplies the
-	// configured hypervisor; -x only ADDS the ones already on disk.
-	args = append(args, "-x")
-	printableArgs = append(printableArgs, "-x")
-
 	switch {
 	case r.usrEnv:
 		args = append(args, "-u")


### PR DESCRIPTION
Reverts #4590, which I got wrong.

`/etc/skywire.conf` is the source of truth — autoconfig writes `HYPERVISORPKS` there and generates `skywire.json` from it. A regen discarding state that only ever existed in the derived artifact is the design working as intended, not a bug. The codebase already documents the correct pattern for this exact situation in `api_proxies.go`: *"regenerates the config from skywire.conf and would reset this; on autoconfig-managed hosts, set DMSGWEBADDR in skywire.conf instead."*

Passing `-x` made `skywire.json` partially authoritative for one setting out of the **45 runtime setters** the visor API exposes, with json-config writes spread across six files. That is the worst of both models: it does not fix the general problem, and it makes the preservation rule more arbitrary rather than less — which is precisely the confusion the conf/json split exists to avoid.

The underlying issue is that the runtime API claims persistence it does not have (`hv add` reports "persisted"), and it is tracked separately.