### PR TITLE
docs: stop the runtime config API claiming persistence it does not have

### DIFF
--- a/VISOR_CONFIG_RUNTIME.md
+++ b/VISOR_CONFIG_RUNTIME.md
@@ -9,17 +9,38 @@ For config file changes (config gen, config update, SKYENV), see
 
 ## Important Notes
 
-### Config Persistence
+### Config Persistence — three different lifetimes
 
-**Runtime changes are not written to the config file.** They affect
-the running visor only and are lost on restart. To make changes
-permanent, set the corresponding SKYENV variable in
-`/etc/skywire.conf` and regenerate the config. See
-[VISOR_CONFIG_GEN.md](VISOR_CONFIG_GEN.md#skyenv-config-file).
+`/etc/skywire.conf` is the source of truth. `skywire-config.json` is a
+derived artifact: `skywire autoconfig` regenerates it from
+`skywire.conf`, and a package install or update runs autoconfig. A
+runtime change therefore has one of three lifetimes, and the tables
+below do not yet distinguish them:
+
+1. **Runtime-only** — held in the running subsystem, never written to
+   the json, gone on restart. Example: `proxy mux mode`.
+2. **Written to the json** — survives a restart, but a config regen
+   rebuilds the json and discards it. Example: `visor hv add`.
+3. **Declared in `skywire.conf`** — the only lifetime that survives a
+   package update. Set the SKYENV variable and re-run autoconfig. See
+   [VISOR_CONFIG_GEN.md](VISOR_CONFIG_GEN.md#skyenv-config-file).
+
+Lifetime 2 is the one that surprises operators: the change looks
+durable, and stays durable until the next update. If a setting must
+outlive an update, put it in `skywire.conf`.
+
+A regen is not purely destructive — `config gen -r` deliberately
+carries some state forward from the old json: the secret key, launcher
+apps (`auto_start`, `args`, `launcher_mode`, `restart_policy`, plus
+operator-added apps), `dmsg.protocol`, `dmsg.carriers`,
+`routing.min_hops` when `MINHOPS` is unset, and
+`routing.enable_cascade_route_setup`. `hypervisors` is preserved only
+with `config gen -r -x`, which autoconfig does not pass.
 
 **Package install/update runs `skywire autoconfig`** which
 regenerates the config file. Any customization that isn't in the
-SKYENV file will be overwritten. To disable:
+SKYENV file, and isn't in the carried-forward list above, will be
+overwritten. To disable:
 ```bash
 echo "NOAUTOCONFIG=true" >> /etc/skywire.conf
 ```
@@ -116,11 +137,15 @@ Config gen: [`VPNSERVER`](VISOR_CONFIG_GEN.md#apps), [`PROXYSERVER`](VISOR_CONFI
 | `hypervisor.enable` | `skywire cli visor hv enable\|disable` |
 | `hypervisors` (add remote HV) | `skywire cli visor hv add <pk>` |
 
-`hv add` connects out to the hypervisor immediately and persists the
-PK — but the *inbound* access the PK grants (the `skywire cli --via
-dmsg://<pk>` bridge) starts on the next restart, when the dmsg RPC
-listeners and the peer whitelist are rebuilt from config. See
+`hv add` connects out to the hypervisor immediately and writes the PK
+to the json — but the *inbound* access the PK grants (the `skywire cli
+--via dmsg://<pk>` bridge) starts on the next restart, when the dmsg
+RPC listeners and the peer whitelist are rebuilt from config. See
 [docs/guides/remote-visor-cli.md](docs/guides/remote-visor-cli.md).
+
+Lifetime 2 (above): a runtime-added hypervisor is dropped by the next
+`skywire autoconfig` run. Put the PK in `HYPERVISORPKS` in
+`/etc/skywire.conf` for a hypervisor that must survive an update.
 
 Config gen: [`ISHYPERVISOR`](VISOR_CONFIG_GEN.md#hypervisor), [`HYPERVISORPKS`](VISOR_CONFIG_GEN.md#remote-access)
 

--- a/cmd/skywire-cli/commands/dmsg/connect_all.go
+++ b/cmd/skywire-cli/commands/dmsg/connect_all.go
@@ -22,7 +22,7 @@ func init() {
 
 	setSessionsCmd.Flags().SortFlags = false
 	setSessionsCmd.Flags().IntVarP(&setSessionsCount, "count", "n", 0,
-		"sessions_count to persist; 0 = connect to all available servers")
+		"sessions_count to write to the config; 0 = connect to all available servers")
 	setSessionsCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr,
 		"RPC server address (env: SKYWIRE_RPC)")
 	setSessionsCmd.Flags().Bool(internal.JSONString, false, "print output in json")
@@ -61,12 +61,16 @@ waiting on phase-3 new-session dials during route setup.`,
 
 var setSessionsCmd = &cobra.Command{
 	Use:   "set-sessions",
-	Short: "Persist dmsg.sessions_count and connect-all immediately",
+	Short: "Write dmsg.sessions_count to config and connect-all immediately",
 	Long: `Updates the dmsg.sessions_count at runtime and in the config file.
 
-The live DMSG client's MinSessions is updated immediately, the config
-file is persisted (survives restart), and a connect-all is triggered
-to reach the new target right away.
+The live DMSG client's MinSessions is updated immediately,
+skywire-config.json is written (survives restart), and a connect-all
+is triggered to reach the new target right away.
+
+It does not survive a config regen: 'skywire autoconfig' rebuilds the
+json from /etc/skywire.conf. Set MINDMSGSESS there to make the value
+durable on an autoconfig-managed host.
 
 A value of 0 means "connect to all available servers and keep
 reconnecting to any that drop" — recommended for RSN / TPS visors.`,
@@ -89,7 +93,7 @@ reconnecting to any that drop" — recommended for RSN / TPS visors.`,
 		}
 		isJSON, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
 		if !isJSON {
-			fmt.Printf("Updated dmsg.sessions_count = %d (runtime + persisted)\n\n", setSessionsCount)
+			fmt.Printf("Updated dmsg.sessions_count = %d (runtime + written to config)\n\n", setSessionsCount)
 		}
 		printConnectAllResult(cmd, result)
 	},

--- a/cmd/skywire-cli/commands/proxy/mux_ops.go
+++ b/cmd/skywire-cli/commands/proxy/mux_ops.go
@@ -475,8 +475,12 @@ var muxModeCmd = &cobra.Command{
              Unlike ECF it does not decline a slow leg once it is active.
 
 Affects every active and future mux'd route group on this visor
-IMMEDIATELY (the router re-applies the mode to live route groups). The
-setting persists to skywire-config.json so it survives restart.
+IMMEDIATELY (the router re-applies the mode to live route groups).
+
+Runtime-only: the mode is held in the router, never written to
+skywire-config.json, and is lost on restart. There is no skywire.conf
+field for it — re-apply after a restart, or pin the behavior through
+POLICYPERDIAL.
 
 Example:
   skywire cli proxy mux mode ecf        # predictive earliest-completion-first

--- a/cmd/skywire-cli/commands/resolver/resolver.go
+++ b/cmd/skywire-cli/commands/resolver/resolver.go
@@ -49,7 +49,7 @@ func init() {
 	upCmd.Flags().BoolVar(&resolverDmsgOnly, "dmsg-only", false, "only enable the .dmsg resolver")
 	upCmd.Flags().BoolVar(&resolverSkynetOnly, "skynet-only", false, "only enable the .skynet resolver")
 	upCmd.Flags().StringVar(&resolverUpstream, "upstream", "", "upstream SOCKS5 for non-matching traffic (e.g. 127.0.0.1:1080)")
-	upCmd.Flags().StringVar(&resolverBind, "bind", "", "SOCKS5 bind host, persisted (e.g. 0.0.0.0 or a LAN IP to serve the LAN; empty = loopback)")
+	upCmd.Flags().StringVar(&resolverBind, "bind", "", "SOCKS5 bind host, written to the config (e.g. 0.0.0.0 or a LAN IP to serve the LAN; empty = loopback). A config regen resets it — set DMSGWEBADDR/SKYNETWEBADDR in skywire.conf on an autoconfig-managed host")
 	upCmd.Flags().BoolVar(&resolverNoChain, "no-chain", false, "skip the dmsgweb→skynetweb auto-chain even when both resolvers are up")
 	upCmd.MarkFlagsMutuallyExclusive("dmsg-only", "skynet-only")
 
@@ -127,9 +127,11 @@ different flags update the upstream.`,
 			}
 		}
 
-		// Bind host (persisted). Empty leaves the resolver on loopback.
-		// A LAN IP or 0.0.0.0 makes the resolver reachable from the LAN and
-		// survives a restart (the visor re-reads the persisted proxy_addr).
+		// Bind host (written to the config). Empty leaves the resolver on
+		// loopback. A LAN IP or 0.0.0.0 makes the resolver reachable from the
+		// LAN and survives a restart (the visor re-reads proxy_addr) — but not
+		// a config regen, which rebuilds the json from skywire.conf. See
+		// (*Visor).SetEmbeddedProxyBind.
 		if resolverBind != "" {
 			if wantDmsg {
 				if err := rpcClient.SetEmbeddedProxyBind("dmsg", resolverBind); err != nil {
@@ -170,7 +172,7 @@ different flags update the upstream.`,
 		var msg strings.Builder
 		msg.WriteString("Resolver up.\n")
 		if resolverBind != "" {
-			fmt.Fprintf(&msg, "  bind:     %s (persisted; reachable from the LAN)\n", resolverBind)
+			fmt.Fprintf(&msg, "  bind:     %s (written to config; reachable from the LAN)\n", resolverBind)
 		}
 		if resolverUpstream != "" {
 			fmt.Fprintf(&msg, "  upstream: %s\n", resolverUpstream)

--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -151,7 +151,7 @@ func HypervisorPort(cmdFlags *pflag.FlagSet) string {
 var hvUIEnableCmd = &cobra.Command{
 	Use:   "enable",
 	Short: "Start the hypervisor web UI (leaves DMSG-RPC + hv ls running)",
-	Long:  "Start ONLY the hypervisor web UI. The DMSG-RPC listener, managed-visor tracking, and `hv ls` are unaffected. Requires the hypervisor to be enabled.\nUse -w to also persist the change to the config file.",
+	Long:  "Start ONLY the hypervisor web UI. The DMSG-RPC listener, managed-visor tracking, and `hv ls` are unaffected. Requires the hypervisor to be enabled.\nUse -w to also write hypervisor.ui_disable to skywire-config.json, so it survives a restart. That json is a derived artifact: a later `skywire autoconfig` run (which a package install or update performs) rebuilds it from /etc/skywire.conf and resets the change. There is no skywire.conf field for ui_disable, so on an autoconfig-managed host this setting cannot currently be made durable.",
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
@@ -161,7 +161,7 @@ var hvUIEnableCmd = &cobra.Command{
 			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 		if hvPersist {
-			internal.PrintOutput(cmd.Flags(), "Hypervisor web UI enabled (persisted to config)\n", "Hypervisor web UI enabled (persisted to config)\n")
+			internal.PrintOutput(cmd.Flags(), "Hypervisor web UI enabled (written to config)\n", "Hypervisor web UI enabled (written to config)\n")
 		} else {
 			internal.PrintOutput(cmd.Flags(), "Hypervisor web UI enabled\n", "Hypervisor web UI enabled\n")
 		}
@@ -171,7 +171,7 @@ var hvUIEnableCmd = &cobra.Command{
 var hvUIDisableCmd = &cobra.Command{
 	Use:   "disable",
 	Short: "Stop the hypervisor web UI (keeps DMSG-RPC + hv ls running)",
-	Long:  "Stop ONLY the hypervisor web UI (the HTTP server). The DMSG-RPC listener, managed-visor tracking, and `hv ls` over the visor RPC keep working — useful to shrink the public attack surface while retaining CLI access to connected visors.\nUse -w to also persist the change to the config file.",
+	Long:  "Stop ONLY the hypervisor web UI (the HTTP server). The DMSG-RPC listener, managed-visor tracking, and `hv ls` over the visor RPC keep working — useful to shrink the public attack surface while retaining CLI access to connected visors.\nUse -w to also write hypervisor.ui_disable to skywire-config.json, so it survives a restart. That json is a derived artifact: a later `skywire autoconfig` run (which a package install or update performs) rebuilds it from /etc/skywire.conf and resets the change. There is no skywire.conf field for ui_disable, so on an autoconfig-managed host this setting cannot currently be made durable.",
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
@@ -181,7 +181,7 @@ var hvUIDisableCmd = &cobra.Command{
 			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 		if hvPersist {
-			internal.PrintOutput(cmd.Flags(), "Hypervisor web UI disabled (persisted to config)\n", "Hypervisor web UI disabled (persisted to config)\n")
+			internal.PrintOutput(cmd.Flags(), "Hypervisor web UI disabled (written to config)\n", "Hypervisor web UI disabled (written to config)\n")
 		} else {
 			internal.PrintOutput(cmd.Flags(), "Hypervisor web UI disabled\n", "Hypervisor web UI disabled\n")
 		}
@@ -191,7 +191,7 @@ var hvUIDisableCmd = &cobra.Command{
 var hvEnableCmd = &cobra.Command{
 	Use:   "enable",
 	Short: "Enable the hypervisor (DMSG-RPC + tracking + web UI) at runtime",
-	Long:  "Enable the hypervisor — DMSG-RPC listener, managed-visor tracking, and the web UI (unless ui_disable is set). Use `hv ui enable/disable` to toggle just the web UI.\nUse -w to also persist the change to the config file.",
+	Long:  "Enable the hypervisor — DMSG-RPC listener, managed-visor tracking, and the web UI (unless ui_disable is set). Use `hv ui enable/disable` to toggle just the web UI.\nUse -w to also write the change to skywire-config.json, so it survives a restart. That json is a derived artifact: a later `skywire autoconfig` run (which a package install or update performs) rebuilds it from /etc/skywire.conf and resets the change. Set ISHYPERVISOR there to make it durable.",
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
@@ -201,7 +201,7 @@ var hvEnableCmd = &cobra.Command{
 			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 		if hvPersist {
-			internal.PrintOutput(cmd.Flags(), "Hypervisor enabled (persisted to config)\n", "Hypervisor enabled (persisted to config)\n")
+			internal.PrintOutput(cmd.Flags(), "Hypervisor enabled (written to config)\n", "Hypervisor enabled (written to config)\n")
 		} else {
 			internal.PrintOutput(cmd.Flags(), "Hypervisor enabled\n", "Hypervisor enabled\n")
 		}
@@ -211,7 +211,7 @@ var hvEnableCmd = &cobra.Command{
 var hvDisableCmd = &cobra.Command{
 	Use:   "disable",
 	Short: "Disable the hypervisor entirely (DMSG-RPC + tracking + web UI) at runtime",
-	Long:  "Disable the whole hypervisor — stops the DMSG-RPC listener, disconnects managed visors, and stops the web UI (so `hv ls` no longer works). To stop ONLY the web UI while keeping CLI access, use `hv ui disable`.\nUse -w to also persist the change to the config file.",
+	Long:  "Disable the whole hypervisor — stops the DMSG-RPC listener, disconnects managed visors, and stops the web UI (so `hv ls` no longer works). To stop ONLY the web UI while keeping CLI access, use `hv ui disable`.\nUse -w to also write the change to skywire-config.json, so it survives a restart. That json is a derived artifact: a later `skywire autoconfig` run (which a package install or update performs) rebuilds it from /etc/skywire.conf and resets the change. Set ISHYPERVISOR there to make it durable.",
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
@@ -221,7 +221,7 @@ var hvDisableCmd = &cobra.Command{
 			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 		if hvPersist {
-			internal.PrintOutput(cmd.Flags(), "Hypervisor disabled (persisted to config)\n", "Hypervisor disabled (persisted to config)\n")
+			internal.PrintOutput(cmd.Flags(), "Hypervisor disabled (written to config)\n", "Hypervisor disabled (written to config)\n")
 		} else {
 			internal.PrintOutput(cmd.Flags(), "Hypervisor disabled\n", "Hypervisor disabled\n")
 		}
@@ -246,13 +246,22 @@ var hvStatusCmd = &cobra.Command{
 
 var hvAddCmd = &cobra.Command{
 	Use:   "add <public-key>",
-	Short: "Connect to a remote hypervisor at runtime (persisted)",
+	Short: "Connect to a remote hypervisor at runtime (survives restart, not config regen)",
 	Long: `Add a remote hypervisor connection at runtime without editing
 the config file by hand. The visor connects to the hypervisor
-immediately via DMSG AND persists the PK to the config's
-hypervisors list, so the connection survives a restart. (On a
-non-file-backed config — wasm tab / STDIN — the connection is made
-but cannot be persisted.)
+immediately via DMSG AND writes the PK to the config's hypervisors
+list, so the connection survives a restart. (On a non-file-backed
+config — wasm tab / STDIN — the connection is made but nothing is
+written.)
+
+It does NOT survive a config regen. skywire-config.json is a derived
+artifact: on a packaged install every 'skywire autoconfig' run — which
+a package install or update performs — rebuilds it from
+/etc/skywire.conf, and a PK that is only in the json is dropped. To
+make a hypervisor durable, add it to HYPERVISORPKS in
+/etc/skywire.conf and re-run autoconfig. A source-run visor that has
+no skywire.conf and never runs autoconfig keeps the runtime-added PK
+indefinitely.
 
 The outbound connection (hv ls / hv tui / web UI on the hypervisor)
 works right away. The INBOUND access the PK grants — driving this
@@ -279,12 +288,17 @@ See docs/guides/remote-visor-cli.md.`,
 
 var hvRmCmd = &cobra.Command{
 	Use:   "rm [public-key]",
-	Short: "Disconnect from a remote hypervisor at runtime (persisted)",
+	Short: "Disconnect from a remote hypervisor at runtime (survives restart, not config regen)",
 	Long: `Tear down a hypervisor connection at runtime AND remove its PK
 from the config's hypervisors list, so it stays removed across a
 restart. Works for both runtime-added (hv add) and config-loaded
 hypervisors. (On a non-file-backed config — wasm tab / STDIN — the
-disconnect happens but cannot be persisted.)
+disconnect happens but nothing is written.)
+
+The removal does NOT survive a config regen. If the PK is listed in
+HYPERVISORPKS in /etc/skywire.conf, the next 'skywire autoconfig' run
+— which a package install or update performs — writes it back. Remove
+it from HYPERVISORPKS to make the removal durable.
 
 Pass --all to disconnect every hypervisor and clear the configured
 list in one call. Without --all, exactly one <public-key> argument

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -73,9 +73,11 @@ OR:
 ```
 skywire cli config gen --hvpks <public-key>
 ```
-OR, on a running visor (connects out immediately and persists the PK —
-but the *inbound* CLI-bridge access the PK grants starts on the visor's
-next restart, when the RPC listeners and whitelist are rebuilt):
+OR, on a running visor (connects out immediately and writes the PK to
+skywire-config.json — but the *inbound* CLI-bridge access the PK grants
+starts on the visor's next restart, when the RPC listeners and
+whitelist are rebuilt, and the PK is dropped by the next `skywire
+autoconfig` run unless it is also in `HYPERVISORPKS`):
 ```
 skywire cli visor hv add <public-key>
 ```

--- a/docs/guides/remote-visor-cli.md
+++ b/docs/guides/remote-visor-cli.md
@@ -41,8 +41,12 @@ Two consequences worth knowing before you troubleshoot:
   be managed is unreachable by construction.
 - **The whitelist and listeners are built at boot.** `skywire cli
   visor hv add <pk>` connects out to the new hypervisor immediately
-  and persists the PK, but *inbound* access for that PK (the `--via`
-  path below) starts on the target's next restart.
+  and writes the PK to the json, but *inbound* access for that PK (the
+  `--via` path below) starts on the target's next restart.
+- **A runtime-added PK does not survive a package update.** The json
+  is regenerated from `/etc/skywire.conf` by `skywire autoconfig`, so
+  a PK added only with `hv add` is dropped. Put it in `HYPERVISORPKS`
+  to make the grant durable.
 
 Trust is transitive upward: when a visor connects to its hypervisor,
 the hypervisor pushes its *own* hypervisors into the visor's live

--- a/docs/skywire/cli/dmsg/README.md
+++ b/docs/skywire/cli/dmsg/README.md
@@ -47,7 +47,7 @@ skywire cli dmsg
 - [probe](probe/README.md) — Probe a remote port's reachability over dmsg, skynet, or a direct TCP connection
 - [scp](scp/README.md) — Copy a file between this host and a remote visor over dmsg
 - [sessions](sessions/README.md) — List dmsg servers each visor dmsg client is connected to
-- [set-sessions](set-sessions/README.md) — Persist dmsg.sessions_count and connect-all immediately
+- [set-sessions](set-sessions/README.md) — Write dmsg.sessions_count to config and connect-all immediately
 - [smb](smb/README.md) — Standalone SMTP→dmsg bridge — relays *.skynet envelopes via own dmsg client
 - [sub](sub/README.md) — Standalone UDP→dmsg bridge — ferries length-prefixed UDP datagrams over dmsg streams
 

--- a/docs/skywire/cli/dmsg/set-sessions/README.md
+++ b/docs/skywire/cli/dmsg/set-sessions/README.md
@@ -4,9 +4,13 @@
 
 Updates the dmsg.sessions_count at runtime and in the config file.
 
-The live DMSG client's MinSessions is updated immediately, the config
-file is persisted (survives restart), and a connect-all is triggered
-to reach the new target right away.
+The live DMSG client's MinSessions is updated immediately,
+skywire-config.json is written (survives restart), and a connect-all
+is triggered to reach the new target right away.
+
+It does not survive a config regen: 'skywire autoconfig' rebuilds the
+json from /etc/skywire.conf. Set MINDMSGSESS there to make the value
+durable on an autoconfig-managed host.
 
 A value of 0 means "connect to all available servers and keep
 reconnecting to any that drop" — recommended for RSN / TPS visors.
@@ -20,7 +24,7 @@ skywire cli dmsg set-sessions
 ## Flags
 
 ```
-  -n, --count int    sessions_count to persist; 0 = connect to all available servers
+  -n, --count int    sessions_count to write to the config; 0 = connect to all available servers
       --rpc string   RPC server address (env: SKYWIRE_RPC) (default "localhost:3435")
       --json         print output in json
 ```

--- a/docs/skywire/cli/proxy/mux/mode/README.md
+++ b/docs/skywire/cli/proxy/mux/mode/README.md
@@ -37,8 +37,12 @@ Set the mux transport-selection mode for the visor.
              Unlike ECF it does not decline a slow leg once it is active.
 
 Affects every active and future mux'd route group on this visor
-IMMEDIATELY (the router re-applies the mode to live route groups). The
-setting persists to skywire-config.json so it survives restart.
+IMMEDIATELY (the router re-applies the mode to live route groups).
+
+Runtime-only: the mode is held in the router, never written to
+skywire-config.json, and is lost on restart. There is no skywire.conf
+field for it — re-apply after a restart, or pin the behavior through
+POLICYPERDIAL.
 
 Example:
   skywire cli proxy mux mode ecf        # predictive earliest-completion-first

--- a/docs/skywire/cli/resolver/up/README.md
+++ b/docs/skywire/cli/resolver/up/README.md
@@ -24,7 +24,7 @@ skywire cli resolver up
 ## Flags
 
 ```
-      --bind string       SOCKS5 bind host, persisted (e.g. 0.0.0.0 or a LAN IP to serve the LAN; empty = loopback)
+      --bind string       SOCKS5 bind host, written to the config (e.g. 0.0.0.0 or a LAN IP to serve the LAN; empty = loopback). A config regen resets it — set DMSGWEBADDR/SKYNETWEBADDR in skywire.conf on an autoconfig-managed host
       --dmsg-only         only enable the .dmsg resolver
       --no-chain          skip the dmsgweb→skynetweb auto-chain even when both resolvers are up
       --skynet-only       only enable the .skynet resolver

--- a/docs/skywire/cli/visor/hv/README.md
+++ b/docs/skywire/cli/visor/hv/README.md
@@ -15,14 +15,14 @@ skywire cli visor hv
 
 ## Subcommands
 
-- [add](add/README.md) — Connect to a remote hypervisor at runtime (persisted)
+- [add](add/README.md) — Connect to a remote hypervisor at runtime (survives restart, not config regen)
 - [cpk](cpk/README.md) — Public key of remote hypervisor(s) set in config
 - [disable](disable/README.md) — Disable the hypervisor entirely (DMSG-RPC + tracking + web UI) at runtime
 - [enable](enable/README.md) — Enable the hypervisor (DMSG-RPC + tracking + web UI) at runtime
 - [ls](ls/README.md) — List visors connected to this hypervisor (default: one section per hypervisor)
 - [passwd](passwd/README.md) — Set the hypervisor UI admin password
 - [pk](pk/README.md) — Public key of remote hypervisor(s)
-- [rm](rm/README.md) — Disconnect from a remote hypervisor at runtime (persisted)
+- [rm](rm/README.md) — Disconnect from a remote hypervisor at runtime (survives restart, not config regen)
 - [status](status/README.md) — Check if hypervisor is enabled
 - [tui](tui/README.md) — Hypervisor terminal UI
 - [ui](ui/README.md) — Open Hypervisor UI in default browser

--- a/docs/skywire/cli/visor/hv/add/README.md
+++ b/docs/skywire/cli/visor/hv/add/README.md
@@ -4,10 +4,19 @@
 
 Add a remote hypervisor connection at runtime without editing
 the config file by hand. The visor connects to the hypervisor
-immediately via DMSG AND persists the PK to the config's
-hypervisors list, so the connection survives a restart. (On a
-non-file-backed config — wasm tab / STDIN — the connection is made
-but cannot be persisted.)
+immediately via DMSG AND writes the PK to the config's hypervisors
+list, so the connection survives a restart. (On a non-file-backed
+config — wasm tab / STDIN — the connection is made but nothing is
+written.)
+
+It does NOT survive a config regen. skywire-config.json is a derived
+artifact: on a packaged install every 'skywire autoconfig' run — which
+a package install or update performs — rebuilds it from
+/etc/skywire.conf, and a PK that is only in the json is dropped. To
+make a hypervisor durable, add it to HYPERVISORPKS in
+/etc/skywire.conf and re-run autoconfig. A source-run visor that has
+no skywire.conf and never runs autoconfig keeps the runtime-added PK
+indefinitely.
 
 The outbound connection (hv ls / hv tui / web UI on the hypervisor)
 works right away. The INBOUND access the PK grants — driving this

--- a/docs/skywire/cli/visor/hv/disable/README.md
+++ b/docs/skywire/cli/visor/hv/disable/README.md
@@ -3,7 +3,7 @@
 [← skywire cli visor hv](../README.md)
 
 Disable the whole hypervisor — stops the DMSG-RPC listener, disconnects managed visors, and stops the web UI (so `hv ls` no longer works). To stop ONLY the web UI while keeping CLI access, use `hv ui disable`.
-Use -w to also persist the change to the config file.
+Use -w to also write the change to skywire-config.json, so it survives a restart. That json is a derived artifact: a later `skywire autoconfig` run (which a package install or update performs) rebuilds it from /etc/skywire.conf and resets the change. Set ISHYPERVISOR there to make it durable.
 
 ## Usage
 

--- a/docs/skywire/cli/visor/hv/enable/README.md
+++ b/docs/skywire/cli/visor/hv/enable/README.md
@@ -3,7 +3,7 @@
 [← skywire cli visor hv](../README.md)
 
 Enable the hypervisor — DMSG-RPC listener, managed-visor tracking, and the web UI (unless ui_disable is set). Use `hv ui enable/disable` to toggle just the web UI.
-Use -w to also persist the change to the config file.
+Use -w to also write the change to skywire-config.json, so it survives a restart. That json is a derived artifact: a later `skywire autoconfig` run (which a package install or update performs) rebuilds it from /etc/skywire.conf and resets the change. Set ISHYPERVISOR there to make it durable.
 
 ## Usage
 

--- a/docs/skywire/cli/visor/hv/rm/README.md
+++ b/docs/skywire/cli/visor/hv/rm/README.md
@@ -6,7 +6,12 @@ Tear down a hypervisor connection at runtime AND remove its PK
 from the config's hypervisors list, so it stays removed across a
 restart. Works for both runtime-added (hv add) and config-loaded
 hypervisors. (On a non-file-backed config — wasm tab / STDIN — the
-disconnect happens but cannot be persisted.)
+disconnect happens but nothing is written.)
+
+The removal does NOT survive a config regen. If the PK is listed in
+HYPERVISORPKS in /etc/skywire.conf, the next 'skywire autoconfig' run
+— which a package install or update performs — writes it back. Remove
+it from HYPERVISORPKS to make the removal durable.
 
 Pass --all to disconnect every hypervisor and clear the configured
 list in one call. Without --all, exactly one <public-key> argument

--- a/docs/skywire/cli/visor/hv/ui/disable/README.md
+++ b/docs/skywire/cli/visor/hv/ui/disable/README.md
@@ -3,7 +3,7 @@
 [← skywire cli visor hv ui](../README.md)
 
 Stop ONLY the hypervisor web UI (the HTTP server). The DMSG-RPC listener, managed-visor tracking, and `hv ls` over the visor RPC keep working — useful to shrink the public attack surface while retaining CLI access to connected visors.
-Use -w to also persist the change to the config file.
+Use -w to also write hypervisor.ui_disable to skywire-config.json, so it survives a restart. That json is a derived artifact: a later `skywire autoconfig` run (which a package install or update performs) rebuilds it from /etc/skywire.conf and resets the change. There is no skywire.conf field for ui_disable, so on an autoconfig-managed host this setting cannot currently be made durable.
 
 ## Usage
 

--- a/docs/skywire/cli/visor/hv/ui/enable/README.md
+++ b/docs/skywire/cli/visor/hv/ui/enable/README.md
@@ -3,7 +3,7 @@
 [← skywire cli visor hv ui](../README.md)
 
 Start ONLY the hypervisor web UI. The DMSG-RPC listener, managed-visor tracking, and `hv ls` are unaffected. Requires the hypervisor to be enabled.
-Use -w to also persist the change to the config file.
+Use -w to also write hypervisor.ui_disable to skywire-config.json, so it survives a restart. That json is a derived artifact: a later `skywire autoconfig` run (which a package install or update performs) rebuilds it from /etc/skywire.conf and resets the change. There is no skywire.conf field for ui_disable, so on an autoconfig-managed host this setting cannot currently be made durable.
 
 ## Usage
 

--- a/pkg/visor/api_dmsg.go
+++ b/pkg/visor/api_dmsg.go
@@ -614,8 +614,10 @@ func (v *Visor) DmsgConnectAll() (*DmsgConnectAllResult, error) {
 	return out, nil
 }
 
-// SetDmsgSessionsCount updates the visor's persisted dmsg.sessions_count
-// setting (written to the config file so it survives restart) and
+// SetDmsgSessionsCount updates the visor's dmsg.sessions_count setting
+// (written to skywire-config.json so it survives restart — but not a config
+// regen, which rebuilds the json from /etc/skywire.conf; set MINDMSGSESS
+// there to make it durable on an autoconfig-managed host) and
 // immediately attempts to maximize current session count if the new value
 // is higher or zero (zero = connect to all available servers).
 //

--- a/pkg/visor/api_hypervisors.go
+++ b/pkg/visor/api_hypervisors.go
@@ -12,7 +12,11 @@ import (
 )
 
 // AddHypervisor adds a remote hypervisor PK and connects to it at runtime.
-// The connection is not persisted — use SKYENV HYPERVISORPKS for persistence.
+// The PK is written to the config's hypervisors list (see persistHypervisors),
+// so the connection survives a restart — but skywire-config.json is a derived
+// artifact: the next `skywire autoconfig` run rebuilds it from
+// /etc/skywire.conf and drops a PK that is only in the json. Set HYPERVISORPKS
+// in skywire.conf for a hypervisor that must survive a package update.
 func (v *Visor) AddHypervisor(hvPK cipher.PubKey) error {
 	if v.dmsgC == nil {
 		return fmt.Errorf("DMSG client not running")

--- a/pkg/visor/api_transport.go
+++ b/pkg/visor/api_transport.go
@@ -35,15 +35,18 @@ type RouterSettings struct {
 	//   []             — revert to the built-in default;
 	//   non-empty      — that order, most-preferred first (unlisted types
 	//                    sort after it).
-	// Persisted to routing.transport_preference, so it survives a restart.
+	// Written to routing.transport_preference, so it survives a restart —
+	// but not a config regen (no skywire.conf field).
 	TransportPreference []string `json:"transport_preference,omitempty"`
 }
 
 // GetRouterSettings returns the current runtime values of the four
-// router knobs. MinHops and MuxRoutes are persisted to Routing.* and
+// router knobs. MinHops and MuxRoutes are written to Routing.* and
 // seeded back into the router at boot, so they survive a restart;
 // ForceLocalRoutes / ExistingTPOnly are runtime-only, mirroring the
-// CLI's behavior.
+// CLI's behavior. Surviving a restart is not the same as surviving a
+// config regen — of these, only MinHops has a skywire.conf field
+// (MINHOPS) and is preserved by `config gen -r`.
 func (v *Visor) GetRouterSettings() (RouterSettings, error) {
 	if v.router == nil {
 		return RouterSettings{}, errors.New("router not available")
@@ -96,7 +99,9 @@ func (v *Visor) SetRouterSettings(s RouterSettings) error {
 }
 
 // SetTransportPreference installs the transport-type priority order and
-// persists it to routing.transport_preference. An empty slice reverts to
+// writes it to routing.transport_preference, so it survives a restart — but
+// not a config regen: `skywire autoconfig` rebuilds the json from
+// /etc/skywire.conf, which has no field for it. An empty slice reverts to
 // the built-in default. Every name must be a known transport type — a
 // silently-dropped typo would leave the caller believing a preference is
 // in force that isn't.
@@ -139,7 +144,11 @@ func (v *Visor) SetForceLocalRoutes(enabled bool) error {
 
 // SetMuxRoutes implements API.
 // Sets the number of parallel mux routes for new connections at runtime.
-// Also persists to the visor config file.
+// Also writes routing.mux_routes to skywire-config.json, so it survives a
+// restart — but not a config regen: `skywire autoconfig` rebuilds the json
+// from /etc/skywire.conf, and the MUXROUTES line in the generated
+// skywire.conf template is not read by `config gen`, so there is currently
+// no durable skywire.conf field for this.
 func (v *Visor) SetMuxRoutes(n int) error {
 	if v.router == nil {
 		return errors.New("router not available")
@@ -162,6 +171,8 @@ func (v *Visor) SetMuxRoutes(n int) error {
 
 // SetMuxMode implements API.
 // Sets the weight distribution mode for mux transport selection.
+// Runtime-only: held in the router, never written to the config, lost on
+// restart. There is no skywire.conf field for it.
 func (v *Visor) SetMuxMode(mode string) error {
 	if v.router == nil {
 		return errors.New("router not available")
@@ -448,13 +459,16 @@ func (v *Visor) GetTransportLogs(days int) ([]TransportLogEntry, error) {
 	return out, nil
 }
 
-// SetPersistentTransports sets min_hops routing config of visor
+// SetPersistentTransports replaces the visor's persistent_transports list —
+// in the transport manager's cache and in skywire-config.json, so it survives
+// a restart. Not a config regen: `skywire autoconfig` rebuilds the json from
+// /etc/skywire.conf, which has no field for persistent_transports.
 func (v *Visor) SetPersistentTransports(pTps []transport.PersistentTransports) error {
 	v.tpM.SetPTpsCache(pTps)
 	return v.conf.UpdatePersistentTransports(pTps)
 }
 
-// GetPersistentTransports gets min_hops routing config of visor
+// GetPersistentTransports returns the visor's configured persistent_transports.
 func (v *Visor) GetPersistentTransports() ([]transport.PersistentTransports, error) {
 	return v.conf.GetPersistentTransports()
 }

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -462,11 +462,14 @@ func (v *Visor) RuntimeStats() (*RuntimeStatsInfo, error) {
 	}, nil
 }
 
-// SetRewardAddress implements API.
+// SetRewardAddress implements API. The durable store is <local_path>/reward.txt,
+// not skywire-config.json — the in-memory conf field below is never flushed, and
+// reward.txt sits outside the generated json, so the address survives both a
+// restart and a config regen. REWARDSKYADDR in skywire.conf sets it at gen time.
 func (v *Visor) SetRewardAddress(p string) (string, error) {
-	// Write to config
+	// In-memory only, so the running visor reports the new address; not flushed.
 	v.conf.RewardAddress = p
-	// Also write to reward file for backward compatibility
+	// The durable write: reward.txt is what survey/reward reporting reads.
 	path := v.conf.LocalPath + "/" + skyenv.RewardFile
 	err := os.WriteFile(path, []byte(p), 0600)
 	if err != nil {


### PR DESCRIPTION
`skywire-config.json` is derived from `/etc/skywire.conf` by autoconfig, which a package install or update runs. Several runtime setters write the json and document that as "persisted" — true until the next regen discards it. `hv add` is the case that bit a fleet update: freshly added hypervisors were wiped from every visor that restarted mid-rollout, while nodes that had not yet updated kept theirs.

Help text and doc comments only; no persistence behavior changed. Each corrected string now says which of the three lifetimes it has — runtime-only, written to the json, or declared in skywire.conf — and names the SKYENV variable where one exists (`HYPERVISORPKS`, `MINDMSGSESS`, `DMSGWEBADDR`, `ISHYPERVISOR`). Where none exists, it says so.

Two strings were wrong rather than optimistic: `proxy mux mode` claimed "persists to skywire-config.json so it survives restart" when `SetMuxMode` never touches the config, and `AddHypervisor`'s doc comment said "The connection is not persisted" when it has written `hypervisors` since the runtime add/remove work landed. `SetPersistentTransports` also carried a copy-pasted "sets min_hops routing config" comment.

`VISOR_CONFIG_RUNTIME.md`'s blanket "runtime changes are not written to the config file" was wrong in both directions; it now describes the three lifetimes and lists what `config gen -r` already carries forward from the old json (secret key, launcher apps, `dmsg.protocol`/`carriers`, `min_hops`, cascade).

`docs/skywire/` regenerated with `make doc-gen`, limited to the pages these strings appear on.

This is the doc-only half. The inventory of all 45 `(v *Visor) Set*` setters, which of them write the json, and which have a `skywire.conf` field is in #4592, along with the design question this does not settle. Not a revival of #4590/#4591 — nothing here changes what regen preserves.