### PR TITLE
feat(cxo): Preview-backed point reads, and an address-resolver lookup that holds nothing

### DIFF
--- a/pkg/cxo/cxoaggregate/leaf.go
+++ b/pkg/cxo/cxoaggregate/leaf.go
@@ -34,6 +34,94 @@ func LeafByName(pack registry.Pack, n *treestore.TreeNode, name string) ([]byte,
 	return nil, false
 }
 
+// ChildByIndex returns the inline leaf bytes or the sub-node of n's child at
+// the given POSITION, verifying that the child found there is really named
+// want. Exactly one of leaf/sub is non-nil on ok=true.
+//
+// This is the cheap addressing mode, and the reason it exists: a level's
+// children are individual objects fetched one per Get, so ChildByName costs up
+// to one network round-trip per child, while this costs one. It is only usable
+// when the reader can compute the position — treestore writes each level's
+// children in sorted Name order (publisher.go sortedNames), so a publisher
+// that keeps a level DENSE over a known name space (every child always
+// published, empty ones included) makes the index a pure function of the key
+// being looked up. See pkg/deployment/ar/arfeed, and note the fan-out it
+// chooses: registry.Refs has degree 16, so a level wider than 16 makes an
+// indexed fetch walk the branch nodes preceding the target and costs more for
+// a key late in the level than for one early in it.
+//
+// The name check is what makes it safe: if the level is not the dense shape
+// the caller assumed — an older publisher, a partial fill — the position holds
+// some other child and this reports a miss instead of the wrong record.
+func ChildByIndex(pack registry.Pack, n *treestore.TreeNode, index int, want string) (leaf []byte, sub *treestore.TreeNode, ok bool) {
+	if index < 0 {
+		return nil, nil, false
+	}
+	count, err := n.Children.Len(pack)
+	if err != nil || index >= count {
+		return nil, nil, false
+	}
+	var entry treestore.TreeEntry
+	if _, err := n.Children.ValueByIndex(pack, index, &entry); err != nil {
+		return nil, nil, false
+	}
+	if entry.Name != want {
+		return nil, nil, false
+	}
+	if len(entry.Leaf) > 0 {
+		return entry.Leaf, nil, true
+	}
+	if entry.Sub.Hash != (skycipher.SHA256{}) {
+		var s treestore.TreeNode
+		if err := entry.Sub.Value(pack, &s); err != nil {
+			return nil, nil, false
+		}
+		return nil, &s, true
+	}
+	return nil, nil, false
+}
+
+// ChildByNameSorted returns the inline leaf bytes or sub-node of n's child
+// with the given name, found by BINARY SEARCH rather than a scan. Valid
+// because treestore encodes each level's children in sorted Name order; costs
+// O(log N) fetches where ChildByName costs O(N).
+//
+// Use it as the fallback when ChildByIndex misses: it does not require the
+// level to be dense, only sorted.
+func ChildByNameSorted(pack registry.Pack, n *treestore.TreeNode, name string) (leaf []byte, sub *treestore.TreeNode, ok bool) {
+	count, err := n.Children.Len(pack)
+	if err != nil {
+		return nil, nil, false
+	}
+	lo, hi := 0, count-1
+	for lo <= hi {
+		mid := int(uint(lo+hi) >> 1)
+		var entry treestore.TreeEntry
+		if _, err := n.Children.ValueByIndex(pack, mid, &entry); err != nil {
+			return nil, nil, false // unreadable child: the search can't continue
+		}
+		switch {
+		case entry.Name < name:
+			lo = mid + 1
+		case entry.Name > name:
+			hi = mid - 1
+		default:
+			if len(entry.Leaf) > 0 {
+				return entry.Leaf, nil, true
+			}
+			if entry.Sub.Hash != (skycipher.SHA256{}) {
+				var s treestore.TreeNode
+				if err := entry.Sub.Value(pack, &s); err != nil {
+					return nil, nil, false
+				}
+				return nil, &s, true
+			}
+			return nil, nil, false
+		}
+	}
+	return nil, nil, false
+}
+
 // ChildByName returns the inline leaf bytes or the sub-node of n's child
 // with the given name. An unreadable child (its object absent from the
 // store, i.e. never fetched by a partial fill) yields ok=false rather

--- a/pkg/cxo/cxopreview/cxopreview.go
+++ b/pkg/cxo/cxopreview/cxopreview.go
@@ -1,0 +1,493 @@
+// Package cxopreview pkg/cxo/cxopreview/cxopreview.go c2-net-cxo
+//
+// Point reads of a remote CXO treestore feed WITHOUT subscribing to it.
+//
+// Every other CXO consumer in the tree subscribes to a whole feed and holds it
+// resident. That is the right trade for a caller that walks the whole set
+// repeatedly — the reward pages, the network visualizer — and the wrong one
+// for a caller that wants one record by key, once. `dmsgd-clients-by-server`
+// is 1 MB for 930 entries and its cold first sync is bounded at 45s and can
+// fail outright, which is why "CXO lookup is too expensive for a constrained
+// client" became received wisdom. That conclusion was drawn against
+// subscription, not against CXO.
+//
+// (*node.Conn).Preview is the other half of the API and, until this package,
+// had no caller anywhere in skywire: it fetches the peer's latest Root over an
+// ALREADY-OPEN connection, hands the callback a pack that pulls objects from
+// that peer on demand, and subscribes only if the callback says so. Returning
+// false leaves the reader holding nothing — verified, not assumed, by
+// TestLookupDoesNotSubscribe.
+//
+// # What a caller must know
+//
+// Preview fetches only the branches the walk touches, so the COST IS THE TREE
+// SHAPE, not the feed size. A level's children are individual objects fetched
+// one per Get, so scanning a level of N children costs N network round-trips;
+// treestore writes children in sorted name order, so an index is far cheaper
+// than a name. A feed meant to be read this way should be laid out for it —
+// see pkg/deployment/ar/arfeed, whose dense 256-bucket level makes a lookup a
+// fixed handful of fetches at any network size.
+//
+// Everything here is bounded twice over, because this runs on a dial path: the
+// caller's context bounds the whole lookup, and a per-Get object/deadline
+// budget unwinds a walk that would otherwise chase an oversized or hostile
+// Root. A reader that answers "I don't know" quickly is always better than one
+// that answers slowly.
+//
+// # When this is the right tool, measured
+//
+// Against the address resolver's bindings feed (1711 peers, 256 buckets) over
+// the live dmsg network, 40 lookups each:
+//
+//	preview, this package        p50  16.4 ms   7 objects, 2.2 KB, 0 resident
+//	HTTP GET /resolve over dmsg  p50 140.3 ms   0 resident, occasional multi-second tail
+//	warm subscription to it      p50 119 us     100 KB resident, 0.8 s cold sync
+//
+// So Preview is roughly an order of magnitude faster than the authenticated
+// HTTP round-trip it replaces, and roughly two orders SLOWER than a resident
+// copy. It buys latency over HTTP and memory over subscription; it wins
+// outright over neither.
+//
+// The deciding question is therefore not speed but whether the caller can
+// afford to hold the feed. A visor that dials constantly and has 100 KB to
+// spare should subscribe. A browser tab, a microcontroller, a short-lived CLI
+// invocation, or any client resolving a handful of peers should preview — it
+// pays one round-trip and keeps nothing, where a subscription pays a cold sync
+// and holds the whole set to answer one question. Do not make this a default
+// anywhere without measuring the specific feed: a feed an order of magnitude
+// larger moves the subscription line, and a feed keyed the wrong way (see
+// arfeed on why the tree shape decides the cost) moves the preview line.
+package cxopreview
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	skycipher "github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/node"
+	cxotransport "github.com/skycoin/skywire/pkg/cxo/node/transport"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject/registry"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// ErrBudget is returned through the walk when the per-lookup object or
+// deadline budget is exhausted. It unwinds a treestore walk cleanly rather
+// than letting it hang.
+var ErrBudget = errors.New("cxopreview: object budget exhausted")
+
+// DefaultMaxObjects bounds how many objects one lookup may pull from the peer.
+// A correctly-shaped feed needs single digits; the cap exists so a malformed
+// or hostile Root cannot turn one lookup into a feed download.
+const DefaultMaxObjects = 64
+
+// DefaultResponseTimeout replaces the CXO node default of 59s for a reader's
+// node. A per-request wait that long is a footgun on a dial path: it pins the
+// request against a peer that has stopped answering long past the point the
+// caller gave up.
+const DefaultResponseTimeout = 5 * time.Second
+
+// Stats reports what one lookup actually cost, which is the number worth
+// reporting when comparing this against a subscription or an HTTP round-trip.
+type Stats struct {
+	// Objects is how many objects were fetched from the peer.
+	Objects int
+	// Bytes is their total encoded size — everything the reader touched, none
+	// of which it kept.
+	Bytes int
+	// Elapsed is the wall time of the whole lookup, dial excluded.
+	Elapsed time.Duration
+}
+
+// WalkFunc inspects the previewed tree. It receives a pack that resolves
+// objects from the peer on demand and the feed's root TreeNode. It must not
+// retain either past its return.
+//
+// One caveat, because Conn.Preview is a blocking call with no context of its
+// own: if the caller's context expires, Lookup returns while the walk is still
+// in flight, so a WalkFunc CAN run (and write to whatever it closes over)
+// after Lookup has returned. Write into locals and let the caller copy them
+// out only on a nil error — never publish from inside the walk to something a
+// concurrent reader can observe.
+type WalkFunc func(pack registry.Pack, root *treestore.TreeNode) error
+
+// Config tunes a Reader.
+type Config struct {
+	Logger *logging.Logger
+	// MaxObjects bounds one lookup; zero means DefaultMaxObjects.
+	MaxObjects int
+	// ResponseTimeout bounds a single request to the peer; zero means
+	// DefaultResponseTimeout.
+	ResponseTimeout time.Duration
+	// DataDir, when set, backs the node's container with a directory instead
+	// of memory. Previewed objects are never written to it — only the schema
+	// registry is — so memory is the sensible default.
+	DataDir string
+}
+
+// Reader owns a CXO node used ONLY for previewing. It never subscribes to a
+// feed, so its container holds nothing but the treestore schema registry.
+type Reader struct {
+	log  *logging.Logger
+	node *node.Node
+	port uint16
+
+	maxObjects int
+
+	// tcpAddr maps a peer's public key to the TCP address it was reached at,
+	// for the native-TCP variant. TCP.Connect is idempotent per address, so
+	// this is an address book, not a connection cache.
+	mu      sync.Mutex
+	tcpAddr map[cipher.PubKey]string
+}
+
+// NewDMSG builds a Reader whose node speaks dmsg on the given port. The port
+// is the publisher's listen port — for the address resolver's bindings feed
+// that is skyenv.DmsgARBindingsCXOPort.
+func NewDMSG(dmsgC *dmsg.Client, sk cipher.SecKey, port uint16, conf Config) (*Reader, error) {
+	if dmsgC == nil {
+		return nil, errors.New("cxopreview: nil dmsg client")
+	}
+	cxoNode, maxObjects, err := newNode(sk, conf)
+	if err != nil {
+		return nil, err
+	}
+	if err := cxoNode.EnableDMSG(cxotransport.NewDMSGFactory(dmsgC, port)); err != nil {
+		_ = cxoNode.Close() //nolint:errcheck
+		return nil, err
+	}
+	return &Reader{
+		log:        conf.Logger,
+		node:       cxoNode,
+		port:       port,
+		maxObjects: maxObjects,
+	}, nil
+}
+
+// newNode builds the preview-only CXO node shared by both constructors.
+func newNode(sk cipher.SecKey, conf Config) (*node.Node, int, error) {
+	if conf.Logger == nil {
+		conf.Logger = logging.MustGetLogger("cxo-preview")
+	}
+	cfg := node.NewConfig()
+	cfg.Config = skyobject.NewConfig()
+	cfg.Config.InMemoryDB = conf.DataDir == ""
+	if conf.DataDir != "" {
+		cfg.Config.DataDir = conf.DataDir
+	}
+	// Dial-only in both variants: a hardcoded listener would collide with any
+	// other CXO node in the same process (a visor runs several), and a reader
+	// has nothing to serve. TCP's factory is still created (Listen "" means
+	// dial-only) so the native-TCP variant can dial.
+	cfg.TCP.Listen = ""
+	cfg.UDP.Listen = ""
+	cfg.RPC = ""
+	rt := conf.ResponseTimeout
+	if rt <= 0 {
+		rt = DefaultResponseTimeout
+	}
+	cfg.TCP.ResponseTimeout = rt
+	cfg.UDP.ResponseTimeout = rt
+	if !sk.Null() {
+		cfg.SecKey = skycipher.SecKey(sk)
+	}
+
+	cxoNode, err := node.NewNode(cfg)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	maxObjects := conf.MaxObjects
+	if maxObjects <= 0 {
+		maxObjects = DefaultMaxObjects
+	}
+	return cxoNode, maxObjects, nil
+}
+
+// NewTCP is the native-TCP analog of NewDMSG: a dial-only reader that reaches
+// a publisher by address, with no dmsg and no discovery. Its purpose is to
+// make the preview path testable end to end in-process; production readers use
+// NewDMSG.
+func NewTCP(sk cipher.SecKey, conf Config) (*Reader, error) {
+	cxoNode, maxObjects, err := newNode(sk, conf)
+	if err != nil {
+		return nil, err
+	}
+	return &Reader{
+		log:        conf.Logger,
+		node:       cxoNode,
+		maxObjects: maxObjects,
+		tcpAddr:    make(map[cipher.PubKey]string),
+	}, nil
+}
+
+// ConnectTCP dials a publisher by address and returns its public key, which is
+// then the handle for Lookup.
+func (r *Reader) ConnectTCP(address string) (cipher.PubKey, error) {
+	tcp := r.node.TCP()
+	if tcp == nil {
+		return cipher.PubKey{}, errors.New("cxopreview: node has no tcp transport")
+	}
+	c, err := tcp.Connect(address)
+	if err != nil {
+		return cipher.PubKey{}, err
+	}
+	pk := cipher.PubKey(c.PeerID())
+	r.mu.Lock()
+	r.tcpAddr[pk] = address
+	r.mu.Unlock()
+	return pk, nil
+}
+
+// Node exposes the underlying CXO node, for tests that need to assert the
+// reader really is holding nothing.
+func (r *Reader) Node() *node.Node { return r.node }
+
+// Close releases the node and every connection it holds.
+func (r *Reader) Close() error {
+	if r == nil || r.node == nil {
+		return nil
+	}
+	return r.node.Close()
+}
+
+// Connect opens (or reuses) the connection to a publisher. Call it once at
+// setup: the whole point of Preview is that the lookup rides a connection that
+// is ALREADY open, so a lookup that has to dial first has lost the argument.
+func (r *Reader) Connect(ctx context.Context, peerPK cipher.PubKey) error {
+	_, err := r.conn(ctx, peerPK)
+	return err
+}
+
+// conn returns a live connection to peerPK. ConnectPK is idempotent — it
+// returns the existing conn when one is alive, evicts and re-dials when it is
+// stale — so there is no connection cache to keep here.
+func (r *Reader) conn(ctx context.Context, peerPK cipher.PubKey) (*node.Conn, error) {
+	if d := r.node.DMSG(); d != nil {
+		return d.ConnectPK(ctx, peerPK)
+	}
+	r.mu.Lock()
+	addr := r.tcpAddr[peerPK]
+	r.mu.Unlock()
+	if addr == "" {
+		return nil, fmt.Errorf("cxopreview: no route to %s (call ConnectTCP first)", peerPK)
+	}
+	// TCP.Connect returns the existing conn for an address it already holds.
+	return r.node.TCP().Connect(addr)
+}
+
+// Connected reports whether the node already holds a connection to peerPK.
+func (r *Reader) Connected(peerPK cipher.PubKey) bool {
+	if d := r.node.DMSG(); d != nil {
+		for _, pk := range d.Connections() {
+			if pk == peerPK {
+				return true
+			}
+		}
+		return false
+	}
+	r.mu.Lock()
+	_, ok := r.tcpAddr[peerPK]
+	r.mu.Unlock()
+	return ok
+}
+
+// Lookup previews feed on peerPK's connection and hands walk the root of the
+// treestore tree. It NEVER subscribes: the preview callback returns false, so
+// nothing about the feed is retained after the call.
+//
+// The context bounds the whole call. Because (*node.Conn).Preview is a
+// blocking API with no context of its own, an expired context returns to the
+// caller immediately while the in-flight request unwinds on its own — bounded
+// by the node's ResponseTimeout — and its result is discarded.
+//
+// Two failure modes are retried once, both of them observed live rather than
+// imagined, and each retried the way its cause requires:
+//
+//   - CONNECTION. The CXO node closes a conn after idleWatchdogThreshold with
+//     no inbound traffic, and a preview reader is idle by construction between
+//     lookups — it subscribes to nothing, so the publisher sends it nothing.
+//     The first lookup after a quiet period therefore lands on a conn the
+//     local node has already closed. Retried by dropping the conn and
+//     re-dialing.
+//   - STALE ROOT. Preview pins the peer's LastRoot at the instant of the
+//     request, then fetches objects one at a time. A publisher that republishes
+//     mid-walk can garbage-collect the previous Root's objects out from under
+//     the reader, and the tree-walk helpers cannot tell an object that failed
+//     to fetch from a child that is genuinely absent — so the lookup would
+//     report a false "not found". Measured at a few percent of lookups against
+//     a publisher on a 30-second publish cadence. Retried on the SAME conn,
+//     which re-requests the now-current Root.
+//
+// A walk that completed with every fetch succeeding is NOT retried: its answer,
+// found or not found, is the real one.
+func (r *Reader) Lookup(ctx context.Context, peerPK, feed cipher.PubKey, walk WalkFunc) (Stats, error) {
+	var total Stats
+	for attempt := 0; ; attempt++ {
+		stats, retry, err := r.lookupOnce(ctx, peerPK, feed, walk)
+		total.Objects += stats.Objects
+		total.Bytes += stats.Bytes
+		total.Elapsed += stats.Elapsed
+		if retry == retryNone || attempt >= lookupAttempts-1 || ctx.Err() != nil {
+			return total, err
+		}
+		if retry == retryRedial {
+			// Drop the dead conn so ConnectPK dials a fresh one rather than
+			// handing back the same corpse.
+			if d := r.node.DMSG(); d != nil {
+				_ = d.CloseConn(peerPK) //nolint:errcheck
+			}
+		}
+	}
+}
+
+// lookupAttempts is the total number of tries one Lookup may make. Three
+// rather than two because a single re-read does not close the stale-Root
+// window: measured against a publisher on a 30-second cadence, one retry left
+// a residual ~1.7% of lookups reporting a false miss, since the second attempt
+// can land in the same collection window as the first. Each extra attempt is
+// only paid on a failure that is already known to be untrustworthy.
+const lookupAttempts = 3
+
+// retryKind says how (and whether) a failed attempt is worth repeating.
+type retryKind int
+
+const (
+	retryNone   retryKind = iota // the answer is real; repeating costs a round-trip for nothing
+	retryReread                  // the Root went stale under us; re-preview on the same conn
+	retryRedial                  // the connection is gone; drop it and dial again
+)
+
+// lookupOnce is one attempt.
+func (r *Reader) lookupOnce(ctx context.Context, peerPK, feed cipher.PubKey, walk WalkFunc) (Stats, retryKind, error) {
+	started := time.Now()
+	c, err := r.conn(ctx, peerPK)
+	if err != nil {
+		return Stats{Elapsed: time.Since(started)}, retryRedial, err
+	}
+
+	type result struct {
+		stats Stats
+		err   error
+		retry retryKind
+	}
+	done := make(chan result, 1)
+
+	go func() {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			deadline = started.Add(DefaultResponseTimeout)
+		}
+		bg := &boundedGetter{inner: c.Getter(), max: r.maxObjects, deadline: deadline}
+
+		var walkErr error
+		perr := c.Preview(skycipher.PubKey(feed), func(_ registry.Pack, root *registry.Root) bool {
+			// Deliberately NOT the pack handed in: this one is wrapped in the
+			// object/deadline budget, and counts what the lookup cost.
+			pack, e := r.node.Container().Preview(root, bg)
+			if e != nil {
+				walkErr = fmt.Errorf("preview pack: %w", e)
+				return false
+			}
+			if len(root.Refs) == 0 {
+				walkErr = errors.New("cxopreview: previewed root has no refs")
+				return false
+			}
+			var rootNode treestore.TreeNode
+			if e := root.Refs[0].Value(pack, &rootNode); e != nil {
+				walkErr = fmt.Errorf("root node: %w", e)
+				return false
+			}
+			walkErr = walk(pack, &rootNode)
+			return false // never subscribe — this is the whole point
+		})
+		res := result{
+			stats: Stats{Objects: bg.count(), Bytes: bg.byteCount(), Elapsed: time.Since(started)},
+			err:   walkErr,
+		}
+		switch {
+		case perr != nil:
+			res.err, res.retry = perr, retryRedial
+		case walkErr != nil && bg.missed() > 0:
+			// The walk failed AND at least one object could not be fetched, so
+			// "not found" here is not trustworthy — the Root we pinned has
+			// been collected under us. See Lookup's doc.
+			res.retry = retryReread
+		}
+		done <- res
+	}()
+
+	select {
+	case res := <-done:
+		return res.stats, res.retry, res.err
+	case <-ctx.Done():
+		return Stats{Elapsed: time.Since(started)}, retryNone, ctx.Err()
+	}
+}
+
+// boundedGetter wraps the connection's on-demand object getter with an object
+// count cap and a wall-clock deadline. Past either bound every Get fails with
+// ErrBudget, which unwinds the treestore walk cleanly (the walk helpers treat
+// an unreadable child as absent) instead of hanging. Mirrors the bound the TPD
+// aggregator puts on its targeted discovery-leaf fetch.
+type boundedGetter struct {
+	inner    skyobject.Getter
+	max      int
+	deadline time.Time
+
+	mu     sync.Mutex
+	n      int
+	bytes  int
+	misses int
+}
+
+func (g *boundedGetter) Get(key skycipher.SHA256) ([]byte, error) {
+	g.mu.Lock()
+	over := g.n >= g.max || time.Now().After(g.deadline)
+	if !over {
+		g.n++
+	}
+	g.mu.Unlock()
+	if over {
+		return nil, ErrBudget
+	}
+	val, err := g.inner.Get(key)
+	if err != nil {
+		g.mu.Lock()
+		g.misses++
+		g.mu.Unlock()
+		return nil, err
+	}
+	g.mu.Lock()
+	g.bytes += len(val)
+	g.mu.Unlock()
+	return val, nil
+}
+
+func (g *boundedGetter) count() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.n
+}
+
+func (g *boundedGetter) byteCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.bytes
+}
+
+// missed reports how many object fetches the peer could not answer. A non-zero
+// count during a failed walk means the pinned Root was collected mid-walk, not
+// that the record is absent.
+func (g *boundedGetter) missed() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.misses
+}

--- a/pkg/deployment/ar/api/cxo_preview_e2e_test.go
+++ b/pkg/deployment/ar/api/cxo_preview_e2e_test.go
@@ -1,0 +1,202 @@
+// Package api — cxo_preview_e2e_test.go runs the whole read path in-process
+// over the CXO node's native TCP transport: this package's bindings publisher
+// on one side, the Preview-backed resolver on the other. It pins the three
+// claims the design rests on — the lookup finds the record, it costs a small
+// FIXED number of object fetches no matter how many peers the feed holds, and
+// the reader ends up subscribed to nothing.
+//
+// It lives here rather than under arpreview because it needs this package's
+// unexported publisher constructor; arpreview imports nothing from here, so
+// there is no cycle.
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	skycipher "github.com/skycoin/skycoin/src/cipher"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxopreview"
+	"github.com/skycoin/skywire/pkg/cxo/storeconfig"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/deployment/ar/arfeed"
+	"github.com/skycoin/skywire/pkg/deployment/ar/arpreview"
+	"github.com/skycoin/skywire/pkg/deployment/ar/store"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// maxLookupObjects is the ceiling the walk must stay under. The walk itself is
+// the schema registry, the root TreeNode, the Refs nodes on the path to the
+// bucket, and the bucket entry. If the reader were scanning the bucket level
+// instead of indexing into it this would be in the hundreds, and if it were
+// subscribing it would be the whole feed.
+const maxLookupObjects = 12
+
+func TestPreviewLookupIsFixedCostAndHoldsNothing(t *testing.T) {
+	ctx := context.Background()
+	log := logging.MustGetLogger("ar-preview-e2e")
+
+	st, err := store.New(ctx, storeconfig.Config{Type: storeconfig.Memory}, time.Hour, log)
+	require.NoError(t, err)
+
+	// Deliberately far more peers than fit in one bucket: a scanning walk's
+	// cost would scale with this number, an indexed walk's does not.
+	const nPeers = 1000
+	peers := make([]cipher.PubKey, 0, nPeers)
+	for i := 0; i < nPeers; i++ {
+		pk, _ := cipher.GenerateKeyPair()
+		peers = append(peers, pk)
+		require.NoError(t, st.Bind(ctx, types.STCPR, pk, addrresolver.VisorData{
+			RemoteAddr: "203.0.113.7:7777",
+			LocalAddresses: addrresolver.LocalAddresses{
+				Port: "7777", Addresses: []string{"203.0.113.7", "10.0.0.5"},
+			},
+		}))
+		require.NoError(t, st.Bind(ctx, types.SUDPH, pk, addrresolver.VisorData{
+			RemoteAddr: "203.0.113.7:30000",
+		}))
+	}
+
+	arPK, arSK := cipher.GenerateKeyPair()
+	pub, err := treestore.NewWithTCP("127.0.0.1:0", arSK, treestore.PubConfig{
+		InMemoryDB:  true,
+		BatchWindow: 50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pub.Close() }) //nolint:errcheck
+	pub.SetAllowlist(nil)
+
+	p := newBindingsCXOPublisher(pub, st, log, 50*time.Millisecond, time.Hour)
+	t.Cleanup(func() { _ = p.Close() }) //nolint:errcheck
+
+	_, readerSK := cipher.GenerateKeyPair()
+	reader, err := cxopreview.NewTCP(readerSK, cxopreview.Config{Logger: log})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reader.Close() }) //nolint:errcheck
+
+	gotPK, err := reader.ConnectTCP(pub.Node().TCP().Address())
+	require.NoError(t, err)
+	require.Equal(t, arPK, gotPK, "the publisher's node identity is the AR key")
+
+	res := arpreview.NewWithReader(reader, arPK, log)
+
+	// Wait for the publisher's first Root to carry the seeded peers. Every
+	// attempt is a real preview, so this also proves a lookup against a feed
+	// that is not yet complete fails cheaply rather than hanging.
+	target := peers[nPeers/2]
+	var stats cxopreview.Stats
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		lctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		rec, s, lerr := res.Bindings(lctx, target)
+		cancel()
+		if lerr == nil && rec != nil {
+			stats = s
+			require.NotNil(t, rec.Get(types.STCPR))
+			require.NotNil(t, rec.Get(types.SUDPH))
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("target peer never appeared in the previewed feed: %v", lerr)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Logf("preview lookup over %d peers: objects=%d bytes=%d elapsed=%s",
+		nPeers, stats.Objects, stats.Bytes, stats.Elapsed)
+	require.LessOrEqual(t, stats.Objects, maxLookupObjects,
+		"a bucket lookup must be a fixed handful of fetches, not a scan")
+
+	// Peers at both ends of the key space must cost the same as one in the
+	// middle — that is what "independent of position" means.
+	for _, pk := range []cipher.PubKey{peers[0], peers[1], peers[nPeers-1]} {
+		lctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		vd, lerr := res.Resolve(lctx, string(types.STCPR), pk)
+		cancel()
+		require.NoErrorf(t, lerr, "resolving %s", pk)
+		require.Equal(t, "203.0.113.7:7777", vd.RemoteAddr)
+		require.LessOrEqual(t, res.LastStats().Objects, maxLookupObjects)
+	}
+
+	// An unknown peer is a clean, cheap miss the caller can fall through on.
+	unknown, _ := cipher.GenerateKeyPair()
+	lctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	_, lerr := res.Resolve(lctx, string(types.STCPR), unknown)
+	cancel()
+	require.ErrorIs(t, lerr, arpreview.ErrNoEntry)
+	require.LessOrEqual(t, res.LastStats().Objects, maxLookupObjects)
+
+	// The claim everything else rests on: after all those lookups the reader
+	// is subscribed to nothing.
+	n := reader.Node()
+	require.Empty(t, n.Feeds(), "preview must leave the reader subscribed to nothing")
+	require.False(t, n.IsSharing(skycipher.PubKey(arPK)),
+		"the preview callback returned false, so the feed must not be subscribed")
+}
+
+// TestPreviewFallsBackOnASparseTree covers the compatibility path: a publisher
+// that does NOT keep its levels dense — an older build, or one that dropped
+// empty buckets — breaks index addressing, because the child at the computed
+// position is then some other bucket. The reader must notice (the name check)
+// and fall back to a binary search over the sorted level rather than returning
+// a wrong record or a false miss.
+func TestPreviewFallsBackOnASparseTree(t *testing.T) {
+	ctx := context.Background()
+	log := logging.MustGetLogger("ar-preview-sparse")
+
+	arPK, arSK := cipher.GenerateKeyPair()
+	pub, err := treestore.NewWithTCP("127.0.0.1:0", arSK, treestore.PubConfig{
+		InMemoryDB:  true,
+		BatchWindow: 50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pub.Close() }) //nolint:errcheck
+	pub.SetAllowlist(nil)
+
+	// Publish ONLY the buckets that have content, so both levels are sparse.
+	target, _ := cipher.GenerateKeyPair()
+	other, _ := cipher.GenerateKeyPair()
+	for _, pk := range []cipher.PubKey{target, other} {
+		blob, eerr := arfeed.EncodeBucket(map[cipher.PubKey]*arfeed.PeerBindings{
+			pk: {STCPR: &addrresolver.VisorData{RemoteAddr: "198.51.100.9:1234"}},
+		})
+		require.NoError(t, eerr)
+		require.NoError(t, pub.Put(arfeed.BucketPath(pk), blob))
+	}
+	require.NoError(t, pub.Flush())
+
+	_, readerSK := cipher.GenerateKeyPair()
+	reader, err := cxopreview.NewTCP(readerSK, cxopreview.Config{Logger: log})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reader.Close() }) //nolint:errcheck
+	_, err = reader.ConnectTCP(pub.Node().TCP().Address())
+	require.NoError(t, err)
+
+	res := arpreview.NewWithReader(reader, arPK, log)
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		lctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		vd, lerr := res.Resolve(lctx, string(types.STCPR), target)
+		cancel()
+		if lerr == nil {
+			require.Equal(t, "198.51.100.9:1234", vd.RemoteAddr)
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sparse-tree lookup never succeeded: %v", lerr)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// And a key whose bucket was never published is still a clean miss.
+	absent, _ := cipher.GenerateKeyPair()
+	lctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	_, lerr := res.Resolve(lctx, string(types.STCPR), absent)
+	cancel()
+	require.Error(t, lerr)
+}

--- a/pkg/deployment/ar/arpreview/arpreview.go
+++ b/pkg/deployment/ar/arpreview/arpreview.go
@@ -1,0 +1,219 @@
+// Package arpreview pkg/deployment/ar/arpreview/arpreview.go c4-net-discovery
+//
+// Preview-backed reads of the address resolver's CXO bindings feed: resolve
+// one peer's transport addresses over an already-open CXO connection, holding
+// nothing afterwards.
+//
+// This is the consumer half of #4584. The AR's own feed
+// (pkg/deployment/ar/api/cxo_publisher.go) publishes a dense 256-bucket level
+// keyed by peer public key, which lets a lookup here be a FIXED walk — root
+// TreeNode, then one indexed child fetch — regardless of how many peers the
+// network holds. The reader never subscribes, so it costs no resident copy and
+// no cold first sync.
+//
+// It lives outside pkg/transport/network/addrresolver on purpose. The AR
+// client is imported by pkg/cxo (through arfeed's VisorData), so it can never
+// import CXO itself; the visor imports both and wires this in. Same dependency
+// inversion as dmsg's EntryResolver seam.
+//
+// Positioning: this is a FAST PATH, never an authority. Any miss, any error,
+// any budget exhaustion returns "I don't know" and the caller falls through to
+// the authenticated HTTP GET /resolve, which remains the source of truth. The
+// feed lags the store by the publisher's flush plus batch window, so a binding
+// created seconds ago may not be here yet — which is exactly why a miss must
+// be cheap and must fall through rather than being cached as a negative.
+//
+// # Who should use this, measured
+//
+// Over the live dmsg network against a 1711-peer feed, 40 lookups: this path
+// runs at a p50 of 16.4 ms holding nothing, where the authenticated HTTP
+// /resolve it fronts runs at 140.3 ms, and a warm subscription to the same
+// feed answers in 119 us for 100 KB resident and a 0.8 s cold sync.
+//
+// So it is the right tool for a caller that cannot hold the feed — a browser
+// tab, a microcontroller, a short-lived CLI run, anything resolving a handful
+// of peers — and the WRONG tool for a long-running visor that dials constantly
+// and can spare 100 KB, which should subscribe instead. It is deliberately not
+// wired into the visor dial path for that reason.
+package arpreview
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoaggregate"
+	"github.com/skycoin/skywire/pkg/cxo/cxopreview"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject/registry"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/deployment/ar/arfeed"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// ErrNoEntry means the feed carried no binding of the requested type for that
+// peer. It is deliberately the same shape of answer as a 404 from GET
+// /resolve, but callers should treat it as "not here" and fall through rather
+// than as a definitive absence: the feed lags the store.
+var ErrNoEntry = errors.New("arpreview: no binding in the AR feed")
+
+// Resolver reads one peer's bindings out of the AR's CXO feed.
+type Resolver struct {
+	log    *logging.Logger
+	reader *cxopreview.Reader
+	arPK   cipher.PubKey
+
+	// lastStats is diagnostic only, but Bindings is safe to call from several
+	// goroutines (a dial path is), so the write needs guarding.
+	mu        sync.Mutex
+	lastStats cxopreview.Stats
+}
+
+// Config tunes a Resolver.
+type Config struct {
+	Logger *logging.Logger
+	// Port is the AR's bindings-feed dmsg port; zero means
+	// skyenv.DmsgARBindingsCXOPort.
+	Port uint16
+	// MaxObjects bounds one lookup. A correctly-shaped bucket walk needs
+	// single digits; zero takes the cxopreview default.
+	MaxObjects int
+}
+
+// New builds a Resolver against the address resolver at arPK. sk is the
+// identity the reader's CXO node presents; pass the visor's own so the AR sees
+// a known peer rather than a fresh key on every restart.
+//
+// It does NOT dial. Call Connect once at setup — a lookup that has to dial
+// first has given up the property that makes this worth doing.
+func New(dmsgC *dmsg.Client, sk cipher.SecKey, arPK cipher.PubKey, conf Config) (*Resolver, error) {
+	if arPK == (cipher.PubKey{}) {
+		return nil, errors.New("arpreview: zero address-resolver public key")
+	}
+	if conf.Logger == nil {
+		conf.Logger = logging.MustGetLogger("ar-preview")
+	}
+	port := conf.Port
+	if port == 0 {
+		port = skyenv.DmsgARBindingsCXOPort
+	}
+	reader, err := cxopreview.NewDMSG(dmsgC, sk, port, cxopreview.Config{
+		Logger:     conf.Logger,
+		MaxObjects: conf.MaxObjects,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return NewWithReader(reader, arPK, conf.Logger), nil
+}
+
+// NewWithReader builds a Resolver over an already-constructed preview reader.
+// New is the normal entry point; this one exists so a caller that already owns
+// a reader (or one running over the CXO node's native TCP transport, as the
+// end-to-end test does) can reuse it.
+func NewWithReader(reader *cxopreview.Reader, arPK cipher.PubKey, log *logging.Logger) *Resolver {
+	if log == nil {
+		log = logging.MustGetLogger("ar-preview")
+	}
+	return &Resolver{log: log, reader: reader, arPK: arPK}
+}
+
+// Reader exposes the underlying preview reader — for setup (dialing over a
+// non-dmsg transport) and for assertions about what it is holding.
+func (r *Resolver) Reader() *cxopreview.Reader { return r.reader }
+
+// Connect opens the CXO connection to the address resolver, and keeps it open.
+func (r *Resolver) Connect(ctx context.Context) error {
+	return r.reader.Connect(ctx, r.arPK)
+}
+
+// Connected reports whether the connection to the AR is up.
+func (r *Resolver) Connected() bool { return r.reader.Connected(r.arPK) }
+
+// Close releases the reader's CXO node.
+func (r *Resolver) Close() error { return r.reader.Close() }
+
+// Bindings returns every binding the feed holds for pk, plus what the lookup
+// cost. The walk is: preview the Root, read the root TreeNode, fetch the one
+// bucket child at the index pk's own key names. Nothing else is touched and
+// nothing is retained.
+func (r *Resolver) Bindings(ctx context.Context, pk cipher.PubKey) (*arfeed.PeerBindings, cxopreview.Stats, error) {
+	var rec *arfeed.PeerBindings
+	stats, err := r.reader.Lookup(ctx, r.arPK, r.arPK, func(pack registry.Pack, root *treestore.TreeNode) error {
+		segs, indices := arfeed.Segments(pk), arfeed.Indices(pk)
+		node, blob := root, []byte(nil)
+		for lvl, seg := range segs {
+			leaf, sub, ok := cxoaggregate.ChildByIndex(pack, node, indices[lvl], seg)
+			if !ok {
+				// The level was not the dense shape we assumed — an older
+				// publisher, or a Root whose objects we could not read. Binary
+				// search still works on any sorted level, at O(log N) fetches
+				// instead of one.
+				leaf, sub, ok = cxoaggregate.ChildByNameSorted(pack, node, seg)
+				if !ok {
+					return ErrNoEntry
+				}
+			}
+			if lvl == len(segs)-1 {
+				if len(leaf) == 0 {
+					return ErrNoEntry
+				}
+				blob = leaf
+				break
+			}
+			if sub == nil {
+				return ErrNoEntry
+			}
+			node = sub
+		}
+		peers, derr := arfeed.DecodeBucket(blob)
+		if derr != nil {
+			return fmt.Errorf("decode bucket %s: %w", arfeed.BucketPath(pk), derr)
+		}
+		got, found := peers[pk.Hex()]
+		if !found || got.Empty() {
+			return ErrNoEntry
+		}
+		rec = got
+		return nil
+	})
+	r.mu.Lock()
+	r.lastStats = stats
+	r.mu.Unlock()
+	if err != nil {
+		return nil, stats, err
+	}
+	return rec, stats, nil
+}
+
+// Resolve returns one transport type's binding for pk, matching the shape of
+// addrresolver.APIClient.Resolve so it can sit in front of it.
+func (r *Resolver) Resolve(ctx context.Context, tType string, pk cipher.PubKey) (addrresolver.VisorData, error) {
+	rec, _, err := r.Bindings(ctx, pk)
+	if err != nil {
+		return addrresolver.VisorData{}, err
+	}
+	vd := rec.Get(types.Type(tType))
+	if vd == nil {
+		return addrresolver.VisorData{}, ErrNoEntry
+	}
+	return *vd, nil
+}
+
+// LastStats reports the cost of the most recent lookup. Diagnostic only.
+func (r *Resolver) LastStats() cxopreview.Stats {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastStats
+}
+
+// LookupTimeout is the budget a dial-path caller should give a lookup. It
+// matches dmsg's resolverTimeout: a resolver that is cold, wedged or simply
+// slower than the fallback must lose the race, not delay it.
+const LookupTimeout = 500 * time.Millisecond


### PR DESCRIPTION
CXO's `Conn.Preview` fetches a peer's latest Root over an already-open connection, serves objects from that peer on demand, and subscribes only if the callback says so. It has been implemented end to end since the library was vendored and had no caller anywhere in skywire (#4584). This adds one — `pkg/cxo/cxopreview` wraps it as a bounded point read that always declines the subscription — and a consumer, `pkg/deployment/ar/arpreview`, which resolves one peer's transport addresses out of the AR bindings feed from #4586. Preview behaves exactly as documented: returning `false` leaves the reader subscribed to nothing, asserted rather than assumed.

Measured over the live dmsg network against a 1711-peer feed, 40 lookups each, three runs:

| path | p50 | per lookup | resident |
|---|---|---|---|
| preview (this) | 16.4 ms | 7 objects, 2.2 KB | 0 |
| HTTP `GET /resolve` over dmsg | 140.3 ms | — | 0 |
| warm subscription to the same feed | 119 µs | — | 100 KB, 0.8 s cold sync |

So preview is roughly an order of magnitude faster than the authenticated HTTP round-trip it fronts, and two orders slower than a resident copy: it buys latency over HTTP and memory over subscription, and wins outright over neither. For this feed the subscription is cheap, so a long-running visor should subscribe — and this is deliberately **not** wired into the visor dial path. It is for a caller that cannot hold the feed: a browser tab, a microcontroller, a short-lived CLI run. All 40 lookups fit inside dmsg's 500 ms `resolverTimeout`, and cost was identical for every key.

Two failure modes turned up live and are handled rather than papered over. A preview reader is idle by construction between lookups — it subscribes to nothing, so the publisher sends it nothing — so the node's idle watchdog reaps its connection and the next lookup lands on a corpse; that is retried by re-dialling. And Preview pins a Root that a republishing publisher can collect mid-walk, which the tree-walk helpers cannot tell apart from an absent child; that produced a ~1.7% false-miss rate at one retry, so a failed walk with any unanswered object fetch is re-read up to three times. The residual is why the resolver is positioned as a fast path that falls through to HTTP, never an authority.

`cxoaggregate` gains `ChildByIndex` and `ChildByNameSorted`. Indexed addressing is what makes the walk a fixed seven fetches instead of a scan; the sorted binary search is the fallback for a level that is not dense (an older publisher), covered by a test that publishes a deliberately sparse tree. Local `golangci-lint run` and `GOOS=windows golangci-lint run` are clean.
