### PR TITLE
fix(tpd): stamp the snapshot behind /all-transports/stats and per-key-stats

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_pervisor.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_pervisor.go
@@ -29,13 +29,34 @@
 //     (#4526), the trailing-peak verdict on whether the total looks
 //     settled or is refilling.
 //   - self-consistency: every transport contributes exactly two edges, so
-//     the per-key index must sum to twice the aggregate's total. When it
-//     does not, the two views were read from different states of the same
-//     index — which is the oscillation itself, caught in the act.
+//     the per-key index must sum to twice the aggregate's total.
 //
 // Any of the three failing replaces the histogram with a named absence
 // carrying the reason, the same convention tuiMissing uses for a fetch
 // that died.
+//
+// WHAT THE THIRD CHECK IS ALLOWED TO COMPARE. It first ran the per-key sum
+// against the aggregate carried on the CXO stats feed, and fired constantly
+// — 13,298 edges against 10,892 transports, 39% apart, with the per-key
+// index blamed for losing them. It was not. Both endpoints are reductions of
+// ONE cached slice in TPD, and read off one snapshot they agree to the byte:
+// paired fetches measured 17,982/8,991, 17,754/8,877 and 21,644/10,822,
+// exactly 2:1 every time, over dmsg and on the host alike. What differed was
+// WHEN. The feed's aggregate is deliberately biased late and high — the
+// publisher holds the last complete sample for up to five minutes rather
+// than republish one that looks like a refill — while the per-key body is
+// fetched live, and the network total moves 2.4x inside forty seconds
+// (measured again for skywire#4513). Comparing those two is comparing two
+// moments, and the difference between two moments is not evidence about
+// either.
+//
+// So the check now runs against the transport total of the snapshot the
+// per-key body was ITSELF reduced from, which TPD stamps on that same
+// response. That comparison has no time in it: one snapshot disagreeing
+// with itself is a real defect and nothing else. When the header is absent
+// the check does not run, because an unverifiable comparison is worth less
+// than none — the first two checks still stand, and a false accusation
+// against the index is the failure this panel was built to avoid.
 package clirewardsserver
 
 import (
@@ -86,6 +107,11 @@ type tpSampleVerdict struct {
 	// Known is false when neither source produced an aggregate to judge
 	// against — an unjudged sample is not a passing sample.
 	Known bool
+	// SnapshotTotal is the transport total of the snapshot the PER-KEY body
+	// was itself reduced from, as TPD stamps it on that response. Zero when
+	// the header is absent. This — not Total — is what the two-edges check
+	// runs against; see tpSampleGate.
+	SnapshotTotal int
 }
 
 // tpPerVisorBuckets is the bucketing. Small counts get their own column
@@ -101,11 +127,13 @@ var tpPerVisorBuckets = []tpPerVisorBucket{
 	{Label: "10+", Lo: 10, Hi: -1},
 }
 
-// tpEdgeSkewTolerance is how far the per-key index may sum from twice the
-// aggregate total before the two are treated as different samples. Not
-// zero: the aggregate and the index are separate reads and a transport
-// registered between them moves the sum legitimately. One percent is far
-// below the swing #4513 produces and far above ordinary churn.
+// tpEdgeSkewTolerance is how far the per-key sum may sit from twice its own
+// snapshot's total before the sample is refused. Against the SNAPSHOT total
+// the exact answer is zero — one slice counted two ways — so this is slack
+// for a TPD that stamps the header from a different code path than the one
+// that built the body, not for churn. Kept at one percent rather than
+// tightened to zero so the check reports a systematic loss and not a
+// rounding argument.
 const tpEdgeSkewTolerance = 0.01
 
 // gatherTransportsPerVisor builds the histogram from the per-visor
@@ -115,7 +143,7 @@ const tpEdgeSkewTolerance = 0.01
 func gatherTransportsPerVisor(tpdURL string, v tpSampleVerdict) tpPerVisorStats {
 	var s tpPerVisorStats
 
-	counts, err := fetchPerKeyTransportCounts(tpdURL)
+	counts, snapTotal, err := fetchPerKeyTransportCountsSnapshot(tpdURL)
 	if err != nil {
 		s.Err = err.Error()
 		return s
@@ -130,6 +158,7 @@ func gatherTransportsPerVisor(tpdURL string, v tpSampleVerdict) tpPerVisorStats 
 	}
 	s.Src = "source: HTTP over dmsg /all-transports/per-key-stats" +
 		" — no CXO feed carries the per-key index"
+	v.SnapshotTotal = snapTotal
 	s.Gated, s.GateWhy = tpSampleGate(s.Edges, v)
 	return s
 }
@@ -189,17 +218,17 @@ func tpSampleGate(edges int, v tpSampleVerdict) (bool, string) {
 			"the index is readable while it refills and a histogram of a refilling index draws "+
 			"visors holding fewer transports than they hold (skywire#4513)", conf)
 	}
-	if v.Total > 0 {
-		want := 2 * v.Total
+	if v.SnapshotTotal > 0 {
+		want := 2 * v.SnapshotTotal
 		skew := float64(edges-want) / float64(want)
 		if skew < 0 {
 			skew = -skew
 		}
 		if skew > tpEdgeSkewTolerance {
-			return true, fmt.Sprintf("the per-key index sums to %d edges against %d transports "+
-				"(%d edges expected, %.1f%% apart) — the two views were read from different "+
-				"states of the same index, which is the oscillation itself (skywire#4513)",
-				edges, v.Total, want, 100*skew)
+			return true, fmt.Sprintf("the per-key index sums to %d edges against the %d transports "+
+				"of the SAME snapshot (%d edges expected, %.1f%% apart) — one snapshot cannot "+
+				"disagree with itself, so the index is losing edges (skywire#4513)",
+				edges, v.SnapshotTotal, want, 100*skew)
 		}
 	}
 	return false, ""

--- a/cmd/skywire-cli/commands/rewards/server/stats_tui_pervisor_test.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats_tui_pervisor_test.go
@@ -19,7 +19,8 @@ func evenCounts(visors, n int) map[string]int {
 
 // vouched returns a verdict that passes every gate for the given index.
 func vouched(edges int) tpSampleVerdict {
-	return tpSampleVerdict{Total: edges / 2, Complete: true, Confidence: "settled", Known: true}
+	return tpSampleVerdict{Total: edges / 2, SnapshotTotal: edges / 2,
+		Complete: true, Confidence: "settled", Known: true}
 }
 
 // The bars are visors per bucket. Getting this wrong — counting transports
@@ -92,17 +93,18 @@ func TestPerVisorPanelWithholdsARefillingSample(t *testing.T) {
 	}
 }
 
-// Self-consistency: every transport contributes exactly two edges. When
-// the per-key index and the aggregate disagree, the two were read from
-// different states of the same index — the oscillation, caught in the act.
-func TestPerVisorPanelWithholdsWhenEdgesDisagreeWithTheAggregate(t *testing.T) {
+// Self-consistency: every transport contributes exactly two edges, so a
+// per-key body must sum to twice the total of the snapshot it was reduced
+// from. Disagreeing with its OWN snapshot means edges are genuinely lost.
+func TestPerVisorPanelWithholdsWhenEdgesDisagreeWithTheirOwnSnapshot(t *testing.T) {
 	s := bucketTransportCounts(evenCounts(1000, 4)) // 4,000 edges
-	// The aggregate claims 3,000 transports = 6,000 edges. A third apart.
+	// The snapshot that produced this body held 3,000 transports = 6,000
+	// edges. A third of them are missing from the body itself.
 	s.Gated, s.GateWhy = tpSampleGate(s.Edges, tpSampleVerdict{
-		Total: 3000, Complete: true, Confidence: "settled", Known: true,
+		Total: 3000, SnapshotTotal: 3000, Complete: true, Confidence: "settled", Known: true,
 	})
 	if !s.Gated {
-		t.Fatal("an index disagreeing with the aggregate by a third was drawn as data")
+		t.Fatal("a body disagreeing with its own snapshot by a third was drawn as data")
 	}
 	if !strings.Contains(s.GateWhy, "#4513") {
 		t.Error("the skew reason does not cite the oscillation issue")
@@ -113,6 +115,40 @@ func TestPerVisorPanelWithholdsWhenEdgesDisagreeWithTheAggregate(t *testing.T) {
 	s2.Gated, s2.GateWhy = tpSampleGate(s2.Edges, vouched(s2.Edges))
 	if s2.Gated {
 		t.Fatalf("a self-consistent sample was refused: %s", s2.GateWhy)
+	}
+}
+
+// The regression this check was rewritten for. TPD's network total moves by
+// tens of percent in under a minute, and the feed's aggregate is
+// deliberately held at the trailing peak for up to five minutes, so the
+// per-key body and that aggregate routinely describe different moments.
+// Paired live fetches were exactly 2:1 every time (17,982/8,991,
+// 17,754/8,877, 21,644/10,822) while the total itself swung 8,089–10,825
+// across four minutes — so a body that agrees with its own snapshot must
+// draw, however far the feed's number has since moved.
+func TestPerVisorPanelDrawsWhenOnlyTheFeedsAggregateHasMovedOn(t *testing.T) {
+	s := bucketTransportCounts(evenCounts(1000, 4)) // 4,000 edges
+	gated, why := tpSampleGate(s.Edges, tpSampleVerdict{
+		// The body's own snapshot held 2,000 transports and accounts for
+		// every one of its edges. The feed, held at an older peak, says
+		// 3,000 — 33% away, the shape of the false accusation.
+		Total: 3000, SnapshotTotal: 2000,
+		Complete: true, Confidence: "settled", Known: true,
+	})
+	if gated {
+		t.Fatalf("a self-consistent body was refused because the feed had moved on: %s", why)
+	}
+}
+
+// An unstamped response cannot be checked for self-consistency, and a
+// comparison against some other moment is worth less than none: it produces
+// a confident accusation against an index that is not at fault.
+func TestPerVisorPanelDoesNotAccuseAnUnstampedBody(t *testing.T) {
+	gated, why := tpSampleGate(4000, tpSampleVerdict{
+		Total: 3000, SnapshotTotal: 0, Complete: true, Confidence: "settled", Known: true,
+	})
+	if gated {
+		t.Fatalf("an unstamped body was refused on a cross-moment comparison: %s", why)
 	}
 }
 
@@ -168,8 +204,11 @@ func TestPerVisorPanelNamesFailures(t *testing.T) {
 func TestGateReasonsAreWrappedToThePanel(t *testing.T) {
 	s := bucketTransportCounts(evenCounts(10, 1))
 	s.Gated, s.GateWhy = tpSampleGate(s.Edges, tpSampleVerdict{
-		Total: 500, Complete: true, Confidence: "settled", Known: true,
+		Total: 500, SnapshotTotal: 500, Complete: true, Confidence: "settled", Known: true,
 	})
+	if !s.Gated {
+		t.Fatal("the longest gate reason was not produced, so nothing was wrapped")
+	}
 	for _, line := range strings.Split(renderTPPerVisorPanelANSI(s), "\n") {
 		// Columns, not bytes: the rules are box-drawing runes.
 		plain := []rune(stripANSI(line))

--- a/cmd/skywire-cli/commands/rewards/server/visorbandwidth.go
+++ b/cmd/skywire-cli/commands/rewards/server/visorbandwidth.go
@@ -10,10 +10,12 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/skycoin/skywire/deployment"
+	tpdapi "github.com/skycoin/skywire/pkg/deployment/tpd/api"
 	tpdstore "github.com/skycoin/skywire/pkg/deployment/tpd/store"
 )
 
@@ -294,29 +296,50 @@ func fillVisorBandwidthFromMetrics(out *visorBandwidthData, metrics []tpdstore.T
 
 // fetchPerKeyTransportCounts reads the cheap per-visor transport index.
 func fetchPerKeyTransportCounts(tpdURL string) (map[string]int, error) {
+	counts, _, err := fetchPerKeyTransportCountsSnapshot(tpdURL)
+	return counts, err
+}
+
+// fetchPerKeyTransportCountsSnapshot additionally returns the transport total
+// of the SNAPSHOT this body was reduced from, as TPD stamps it on the
+// response, or zero when the header is absent (an older TPD, or a body counted
+// straight out of the store on a cold cache).
+//
+// That total is the only aggregate the per-key sum can honestly be checked
+// against. TPD's network total moves fast — skycoin/skywire#4513, measured
+// again at 2.4x inside forty seconds — so the aggregate from any OTHER moment
+// disagrees with this body by whatever the network did in between, which is a
+// statement about the two fetch times and not about the index.
+func fetchPerKeyTransportCountsSnapshot(tpdURL string) (map[string]int, int, error) {
 	resp, err := statsHTTPGet(tpdURL + "/all-transports/per-key-stats")
 	if err != nil {
-		return nil, fmt.Errorf("TPD per-key request failed: %w", err)
+		return nil, 0, fmt.Errorf("TPD per-key request failed: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("TPD returned status %d for per-key stats", resp.StatusCode)
+		return nil, 0, fmt.Errorf("TPD returned status %d for per-key stats", resp.StatusCode)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read TPD per-key stats: %w", err)
+		return nil, 0, fmt.Errorf("failed to read TPD per-key stats: %w", err)
 	}
 	// An OBJECT keyed by public key, not an array — each value is that visor's
 	// transport counts, with "total" alongside the per-type entries.
 	var raw map[string]map[string]int
 	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, fmt.Errorf("failed to parse TPD per-key stats: %w", err)
+		return nil, 0, fmt.Errorf("failed to parse TPD per-key stats: %w", err)
 	}
 	counts := make(map[string]int, len(raw))
 	for pk, byType := range raw {
 		counts[pk] = byType["total"]
 	}
-	return counts, nil
+	// An absent or unparseable stamp is zero, which the gate reads as "this
+	// body cannot be checked against itself" — the same as an older TPD.
+	snapTotal, sErr := strconv.Atoi(resp.Header.Get(tpdapi.SnapshotTransportsHeader))
+	if sErr != nil {
+		snapTotal = 0
+	}
+	return counts, snapTotal, nil
 }
 
 // fillVisorBandwidth asks TPD for the daily series of the selected visors in

--- a/pkg/deployment/tpd/api/api.go
+++ b/pkg/deployment/tpd/api/api.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -65,7 +66,12 @@ type API struct {
 
 	transportsCache         []*transport.Entry
 	transportsCacheFiltered []*transport.Entry // excludes self-transports
-	transportsMu            sync.RWMutex
+	// transportsCacheAt identifies the snapshot the two slices above are.
+	// Published on the read endpoints that derive from them (see
+	// snapshotHeaders) so a consumer comparing two of those bodies can tell
+	// whether it is comparing one snapshot or two.
+	transportsCacheAt time.Time
+	transportsMu      sync.RWMutex
 
 	// allTpsRespCache memoizes the marshaled (+gzip) /all-transports body so the
 	// dominant-egress endpoint doesn't re-marshal/re-send ~3MB per call.
@@ -489,6 +495,7 @@ func (api *API) refreshTransportsCache(ctx context.Context, logger logrus.FieldL
 	api.transportsMu.Lock()
 	api.transportsCache = entries
 	api.transportsCacheFiltered = filtered
+	api.transportsCacheAt = time.Now().UTC()
 	api.transportsMu.Unlock()
 
 	api.metrics.SetTPCounts(counts)
@@ -497,13 +504,54 @@ func (api *API) refreshTransportsCache(ctx context.Context, logger logrus.FieldL
 // getTransportsFromCache returns the cached transports, optionally filtering self-transports.
 // Returns nil if the cache has not been initialized yet (caller should fall back to the store).
 func (api *API) getTransportsFromCache(selfTransports bool) []*transport.Entry {
+	entries, _ := api.transportsSnapshot(selfTransports)
+	return entries
+}
+
+// transportsSnapshot returns the cached transports together with the instant
+// the cache was filled. The stamp is zero when the cache is cold, matching
+// getTransportsFromCache's nil.
+//
+// The stamp exists because /all-transports/stats and
+// /all-transports/per-key-stats are two REDUCTIONS OF ONE SLICE. Read off the
+// same snapshot they agree exactly — every transport is two edges, so the
+// per-key sum is twice the aggregate total — and a consumer checking that
+// identity is checking a real invariant. Read off two snapshots they do not,
+// and the network total moves fast enough (skycoin/skywire#4513 measured 2.4x
+// inside forty seconds) that the disagreement is large. Without a way to tell
+// the cases apart, a consumer that finds them disagreeing concludes the
+// per-key index is losing edges, which is the wrong conclusion drawn from a
+// correct observation.
+func (api *API) transportsSnapshot(selfTransports bool) ([]*transport.Entry, time.Time) {
 	api.transportsMu.RLock()
 	defer api.transportsMu.RUnlock()
 	if api.transportsCache == nil {
-		return nil
+		return nil, time.Time{}
 	}
 	if selfTransports {
-		return api.transportsCache
+		return api.transportsCache, api.transportsCacheAt
 	}
-	return api.transportsCacheFiltered
+	return api.transportsCacheFiltered, api.transportsCacheAt
+}
+
+// Snapshot headers. Absent on a cold-cache response, which is the honest
+// answer: that body was counted straight out of the store and shares no
+// snapshot with anything.
+const (
+	// SnapshotAtHeader carries the RFC3339Nano instant the serving snapshot
+	// was filled. Two bodies with the same value are two views of one set.
+	SnapshotAtHeader = "X-Tpd-Snapshot-At"
+	// SnapshotTransportsHeader carries how many transports that snapshot
+	// holds, so the per-key body can be checked against its OWN aggregate
+	// rather than against whatever the aggregate reads at some other moment.
+	SnapshotTransportsHeader = "X-Tpd-Snapshot-Transports"
+)
+
+// setSnapshotHeaders stamps a response with the snapshot it was derived from.
+func setSnapshotHeaders(w http.ResponseWriter, at time.Time, total int) {
+	if at.IsZero() {
+		return
+	}
+	w.Header().Set(SnapshotAtHeader, at.Format(time.RFC3339Nano))
+	w.Header().Set(SnapshotTransportsHeader, strconv.Itoa(total))
 }

--- a/pkg/deployment/tpd/api/endpoints.go
+++ b/pkg/deployment/tpd/api/endpoints.go
@@ -397,7 +397,8 @@ func (api *API) getAllTransportsStats(w http.ResponseWriter, r *http.Request) {
 	// the store via GetTransportSummary — a single index+MGET pass that
 	// never materializes []*transport.Entry.
 	var summary *store.TransportSummary
-	if entries := api.getTransportsFromCache(selfTransports); entries != nil {
+	if entries, at := api.transportsSnapshot(selfTransports); entries != nil {
+		setSnapshotHeaders(w, at, len(entries))
 		summary = &store.TransportSummary{ByType: make(map[string]int)}
 		uniqueVisors := make(map[cipher.PubKey]struct{})
 		for _, entry := range entries {
@@ -432,7 +433,7 @@ func (api *API) getAllTransportsPerKeyStats(w http.ResponseWriter, r *http.Reque
 		selfTransports = false
 	}
 
-	entries := api.getTransportsFromCache(selfTransports)
+	entries, at := api.transportsSnapshot(selfTransports)
 	if entries == nil {
 		var err error
 		entries, err = api.store.GetAllTransports(r.Context(), selfTransports)
@@ -445,6 +446,10 @@ func (api *API) getAllTransportsPerKeyStats(w http.ResponseWriter, r *http.Reque
 		api.writeError(w, r, store.ErrTransportNotFound)
 		return
 	}
+	// Same snapshot as /all-transports/stats when both are served warm, which
+	// is what makes "the per-key sum is twice the aggregate total" a checkable
+	// invariant rather than a race. See transportsSnapshot.
+	setSnapshotHeaders(w, at, len(entries))
 
 	// Build per-key statistics: map[pkHex]map[typeOrTotal]count
 	// Format: {"pk1": {"total": 15, "stcpr": 1, "sudph": 14}, ...}

--- a/pkg/deployment/tpd/api/snapshot_headers_test.go
+++ b/pkg/deployment/tpd/api/snapshot_headers_test.go
@@ -1,0 +1,95 @@
+// Package api pkg/deployment/tpd/api/snapshot_headers_test.go c4-net-discovery
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/storeconfig"
+	tpdiscmetrics "github.com/skycoin/skywire/pkg/deployment/tpd/metrics"
+	"github.com/skycoin/skywire/pkg/httpauth"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// /all-transports/stats and /all-transports/per-key-stats are two reductions
+// of one cached slice, so read off one snapshot the per-key sum is exactly
+// twice the aggregate total — every transport is two edges and nothing is
+// deduplicated. The headers say WHICH snapshot each body came from, which is
+// what lets a consumer check that identity instead of checking it against
+// whatever the aggregate happens to read at some other moment.
+//
+// Without the stamp a consumer comparing the two across the network total's
+// own movement (measured at 2.4x inside forty seconds, skycoin/skywire#4513)
+// finds them tens of percent apart and concludes the per-key index is losing
+// edges. It is not; the two fetches described different moments.
+func TestSnapshotHeadersMakeTheTwoViewsComparable(t *testing.T) {
+	ctx := context.Background()
+	mock := newTestStore(t)
+	nonceMock, err := httpauth.NewNonceStore(ctx, storeconfig.Config{Type: storeconfig.Memory}, "")
+	require.NoError(t, err)
+
+	a1, _ := cipher.GenerateKeyPair()
+	b1, _ := cipher.GenerateKeyPair()
+	b2, _ := cipher.GenerateKeyPair()
+	c1, _ := cipher.GenerateKeyPair()
+	c2, _ := cipher.GenerateKeyPair()
+	seed := []*transport.SignedEntry{
+		{Entry: &transport.Entry{ID: uuid.New(), Edges: transport.SortEdges(a1, b1), Type: "stcpr"}},
+		{Entry: &transport.Entry{ID: uuid.New(), Edges: transport.SortEdges(a1, b2), Type: "stcpr"}},
+		{Entry: &transport.Entry{ID: uuid.New(), Edges: transport.SortEdges(c1, c2), Type: "sudph"}},
+	}
+	require.NoError(t, mock.RegisterTransportsBatch(ctx, cipher.PubKey{}, seed))
+
+	api := New(nil, mock, nonceMock, false, tpdiscmetrics.NewEmpty(), "", "")
+
+	// A cold cache shares no snapshot with anything, and says so by carrying
+	// no stamp rather than by inventing one.
+	cold := httptest.NewRecorder()
+	api.ServeHTTP(cold, httptest.NewRequest(http.MethodGet, "/all-transports/per-key-stats", nil))
+	require.Equal(t, http.StatusOK, cold.Code, cold.Body.String())
+	assert.Empty(t, cold.Header().Get(SnapshotAtHeader),
+		"a cold-cache body was stamped with a snapshot it was not served from")
+
+	api.refreshTransportsCache(ctx, logging.MustGetLogger("test"))
+
+	stats := httptest.NewRecorder()
+	api.ServeHTTP(stats, httptest.NewRequest(http.MethodGet, "/all-transports/stats", nil))
+	require.Equal(t, http.StatusOK, stats.Code, stats.Body.String())
+
+	perKey := httptest.NewRecorder()
+	api.ServeHTTP(perKey, httptest.NewRequest(http.MethodGet, "/all-transports/per-key-stats", nil))
+	require.Equal(t, http.StatusOK, perKey.Code, perKey.Body.String())
+
+	at := stats.Header().Get(SnapshotAtHeader)
+	require.NotEmpty(t, at, "the aggregate carried no snapshot stamp")
+	assert.Equal(t, at, perKey.Header().Get(SnapshotAtHeader),
+		"the two views were served from different snapshots")
+
+	total := stats.Header().Get(SnapshotTransportsHeader)
+	require.Equal(t, "3", total)
+	assert.Equal(t, total, perKey.Header().Get(SnapshotTransportsHeader))
+
+	var agg struct {
+		Total int `json:"total_transports"`
+	}
+	require.NoError(t, json.Unmarshal(stats.Body.Bytes(), &agg))
+
+	var byKey map[string]map[string]int
+	require.NoError(t, json.Unmarshal(perKey.Body.Bytes(), &byKey))
+	edges := 0
+	for _, counts := range byKey {
+		edges += counts["total"]
+	}
+
+	assert.Equal(t, 2*agg.Total, edges,
+		"one snapshot disagreed with itself: %d edges over %d transports", edges, agg.Total)
+}


### PR DESCRIPTION
Part of #4513.

The reward server's transports-per-visor histogram refuses to draw because "the per-key index sums to 13,298 edges against 10,892 transports (21,784 expected, 39.0% apart)". The per-key index is not losing edges.

Both endpoints are reductions of one cached slice in TPD (`api.transportsCache`), so read off one snapshot the per-key sum is exactly twice the aggregate total. Paired live fetches — on the TPD host and through the dmsg proxy — came back at exactly 2:1 in 20 of 20 samples, while the total itself moved from 8,089 to 13,871 over the same seven minutes:

```
19:12:17 before=10825 edges=21650 after=10825
19:14:02 before=8089  edges=16178 after=8089
19:18:36 before=13871 edges=27742 after=13871
```

The Redis index is not short either: `SCARD transport-discovery:tp:_index` read 9,746 against 9,780 live `transport-discovery:tp:*` keys, and `RegisterTransport` SADDs the index in the same pipeline as the `SET`, so the write path cannot undercount.

What differed was *when*. The gate checked the live per-key body against the aggregate on the CXO stats feed, which is deliberately biased late and high — `statsIncompleteHoldover` keeps the last complete sample on the feed for up to five minutes rather than republish one that looks like a refill. With the network total moving 2.4x inside forty seconds, the difference between those two reads is whatever the network did in between, not a property of either.

So the check now runs against something with no time in it. TPD stamps both responses with the snapshot they were served from (`X-Tpd-Snapshot-At`, `X-Tpd-Snapshot-Transports`; absent on a cold-cache body, which shares a snapshot with nothing), and the histogram compares the per-key sum against the total of its own snapshot. One snapshot disagreeing with itself is a real defect and nothing else. An unstamped body skips that check rather than being accused on a cross-moment comparison — the store-partial (#4542) and feed-completeness checks are unchanged.

The oscillation itself is untouched and #4513 stays open. This stops it being misreported as an index that loses edges.