### PR TITLE
fix(pty): direct-TCP host panicked after serving one session

### DIFF
--- a/pkg/pty/host.go
+++ b/pkg/pty/host.go
@@ -430,7 +430,18 @@ func (h *Host) authorize(log logrus.FieldLogger, rPK cipher.PubKey) bool {
 }
 
 // log returns the logrus.FieldLogger that should be used for all log outputs.
+//
+// The direct-TCP host (`cli pty host`, and the sshd command backing it) is
+// constructed as NewHost(nil, wl): it serves the dmsgpty protocol over a
+// plain TCP listener and never joins the overlay, so there is no dmsg client
+// to borrow a logger from. Every other dmsgC read on that path already guards
+// for nil; this one did not, and handlePty's teardown goroutine is the first
+// caller once a connection closes — so the host panicked after serving
+// exactly one session.
 func (h *Host) log() logrus.FieldLogger {
+	if h == nil || h.dmsgC == nil {
+		return logging.MustGetLogger("dmsgpty_host")
+	}
 	return h.dmsgC.Logger().WithField("dmsgpty", "host")
 }
 

--- a/pkg/pty/host_nil_logger_test.go
+++ b/pkg/pty/host_nil_logger_test.go
@@ -1,0 +1,39 @@
+// Package pty pkg/pty/host_nil_logger_test.go c3-vis-pty
+package pty
+
+import (
+	"context"
+	"net/rpc"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// TestHostLog_NilDmsgClient covers the direct-TCP host, which is built as
+// NewHost(nil, wl) by `cli pty host`: it has no dmsg client to borrow a
+// logger from, so log() must fall back rather than dereference nil.
+func TestHostLog_NilDmsgClient(t *testing.T) {
+	h := NewHost(nil, NewMemoryWhitelist())
+	if got := h.log(); got == nil {
+		t.Fatal("log() returned nil for a host with no dmsg client")
+	}
+	h.log().Debug("must not panic")
+}
+
+// TestHandlePty_TeardownWithNilDmsgClient reproduces the actual crash: the
+// classic path spawns a goroutine that calls h.log() once the connection's
+// context is done, so a direct-TCP host panicked as soon as its first session
+// ended. A panic in that goroutine takes the process down, so reaching the
+// end of this test is the assertion.
+func TestHandlePty_TeardownWithNilDmsgClient(t *testing.T) {
+	h := NewHost(nil, NewMemoryWhitelist())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := handlePty(h)(ctx, &url.URL{}, rpc.NewServer()); err != nil {
+		t.Fatalf("handlePty: %v", err)
+	}
+
+	// Canceling is what fires the teardown goroutine.
+	cancel()
+	time.Sleep(250 * time.Millisecond)
+}


### PR DESCRIPTION
`skywire cli pty host` — the direct-TCP, no-overlay entry point — segfaulted as soon as its first session ended, so the second connection got ECONNREFUSED. Found while using it as a durable maintenance channel to a LAN host.

```
panic: runtime error: invalid memory address or nil pointer dereference
pkg/pty.(*Host).log(0x0?)                  pkg/pty/host.go:434
pkg/pty.dmsgEndpoints.handlePty.func1.2()  pkg/pty/host.go:484
```

The TCP host is constructed as `NewHost(nil, wl)` (cmd/skywire-cli/commands/sshd/sshd.go:146) because it never joins dmsg, but `Host.log()` read `h.dmsgC` unguarded. `handlePty`'s teardown goroutine calls it on `ctx.Done()`, which is exactly when a session closes.

Every other `dmsgC` read reachable from the TCP path already nil-guards — host_tcp.go:73, host_tcp.go:145, exec_http.go:278, sftp_subsystem.go:41, host.go:341 — so this restores the convention rather than introducing one, using the same `logging.MustGetLogger` fallback as host.go:341.

Two regression tests. Both were confirmed to fail against the unfixed code (panicking at host.go:434); the teardown test asserts by reaching its end, since a panic in that goroutine takes the process down. `go test ./pkg/pty/` green, both lint tiers 0 issues.