### PR TITLE
fix(security): four one-line fixes from a source review

### DIFF
--- a/cmd/skywire-cli/commands/edit/edit.go
+++ b/cmd/skywire-cli/commands/edit/edit.go
@@ -81,7 +81,10 @@ func saveFile(filename string, view *femto.View) error {
 	if filename == "untitled" {
 		return fmt.Errorf("no filename specified, use: edit <filename>")
 	}
-	return os.WriteFile(filename, []byte(view.Buf.String()), 0644) //nolint:gosec
+	// 0640, matching visorconfig's own write path: this editor is pointed at the
+	// visor config, which holds the SECRET KEY. Writing it back world-readable
+	// silently undid that protection.
+	return os.WriteFile(filename, []byte(view.Buf.String()), 0640) //nolint:gosec
 }
 
 func loadColorscheme() femto.Colorscheme {

--- a/pkg/deployment/ar/api/api.go
+++ b/pkg/deployment/ar/api/api.go
@@ -444,7 +444,7 @@ func (a *API) bindForType(w http.ResponseWriter, r *http.Request, tpType types.T
 			remoteAddr = localAddresses.PublicIP
 		} else {
 			err := fmt.Sprintf("Cannot bind %v to %v (%s). Invalid IP address in request: %v", pk, remoteAddr, tpType, localAddresses)
-			a.logger(r).Errorf(err)
+			a.logger(r).Errorf("%s", err)
 			a.writeJSON(w, r, http.StatusBadRequest, &Error{
 				Error: err,
 			})
@@ -456,7 +456,7 @@ func (a *API) bindForType(w http.ResponseWriter, r *http.Request, tpType types.T
 		// visor didn't provide the IP it's trying to bind from
 		// probably is behind NAT and shouldn't bind
 		err := fmt.Sprintf("Cannot bind %v to %v (%s). Remote address not present in request: %v", pk, remoteAddr, tpType, localAddresses)
-		a.logger(r).Errorf(err)
+		a.logger(r).Errorf("%s", err)
 
 		a.writeJSON(w, r, http.StatusBadRequest, &Error{
 			Error: err,

--- a/pkg/services/sn/sn.go
+++ b/pkg/services/sn/sn.go
@@ -133,7 +133,11 @@ func (s *service) Run(ctx context.Context) error {
 		return errors.New("setup-node: public_key and secret_key required (inline or via config_path)")
 	}
 
-	log.Infof("Config: %#v", conf)
+	// Never log the whole SetupConfig: it embeds this node's SECRET KEY, and
+	// cipher.SecKey.String() returns the raw hex rather than a mask, so no
+	// verb is safe here. Log the fields that are useful for diagnosis instead.
+	log.Infof("Config: public_key=%s transport_discovery=%s log_level=%s cascade=%t transport=%t",
+		conf.PK, conf.TransportDiscovery, conf.LogLevel, conf.Cascade != nil, conf.Transport != nil)
 	sn, err := router.NewNode(conf)
 	if err != nil {
 		return fmt.Errorf("setup-node: create node: %w", err)

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -268,8 +268,13 @@ func (c *CookieConfig) Secure() bool {
 }
 
 // HTTPOnly gets cookie's `HTTPOnly` value.
+//
+// Unconditionally true: the session cookie is never read from JavaScript, so
+// keeping it out of document.cookie costs nothing and blocks XSS-based session
+// theft. It used to return !c.TLS, which inverted the protection exactly when
+// an operator opted into TLS — the safer configuration turned HTTPOnly off.
 func (c *CookieConfig) HTTPOnly() bool {
-	return !c.TLS
+	return true
 }
 
 // SameSite gets cookie's `SameSite` value.


### PR DESCRIPTION
Four independent one-line issues surfaced by a static source review, each re-verified against current develop.

- **The setup node logged its own secret key.** `pkg/services/sn/sn.go` logged the whole `SetupConfig` with `%#v` at Info on every startup, dumping the embedded `SK`. Note `cipher.SecKey.String()` returns `sk.Hex()` and does not mask, so `%v` would have leaked it too — the fix logs named non-secret fields rather than adding a masking `GoString()`.
- **`HTTPOnly` was inverted against TLS.** It returned `!c.TLS`, so enabling TLS — the safer choice — turned the flag off and made the session cookie readable from JavaScript. Now unconditionally true. `Secure()` still tracks TLS, which is correct.
- **`skywire-cli edit` wrote configs world-readable** (`0644`), undoing the `0640` that `visorconfig` applies two files away with a comment explaining that the file holds the secret key.
- **Two address-resolver log calls used attacker-controlled text as the format string**, so a `%` in a bind request corrupted the log line. A repo-wide sweep found no other instances of this pattern.

Tests pass and `golangci-lint` reports 0 issues across the four touched packages.