### PR TITLE
fix(ci): give cmd/wasm-visor a host main so the CodeQL build step passes

### DIFF
--- a/cmd/wasm-visor/main_host.go
+++ b/cmd/wasm-visor/main_host.go
@@ -1,0 +1,26 @@
+//go:build !js || !wasm
+
+// Package main cmd/wasm-visor/main_host.go c3-vis-wasm
+// cmd/wasm-visor is a js/wasm program: its real main() is in main.go behind
+// `//go:build js && wasm`. vnetaddr.go, however, is deliberately left untagged
+// so `go test ./cmd/wasm-visor` exercises vnetTarget on the host — which makes
+// this directory a main package on every OTHER platform too, one with no main
+// function. `go build ./cmd/...` therefore fails on the host with
+//
+//	# github.com/skycoin/skywire/cmd/wasm-visor
+//	runtime.main_main·f: function main is undeclared in the main package
+//
+// (`go test` is unaffected, which is why only the CodeQL workflow — the one
+// place that builds ./cmd/... — went red.) This host-side main exists purely to
+// keep the package linkable off js/wasm; it does no work and ships nowhere.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "wasm-visor is a WebAssembly program: build it with GOOS=js GOARCH=wasm (see 'make build-wasm').")
+	os.Exit(1)
+}


### PR DESCRIPTION
The `Analyze (go)` job has been red on every workflow run for days, exiting 1 with no alert summary. The cause is its build step, not a code alert:

```
# github.com/skycoin/skywire/cmd/wasm-visor
runtime.main_main·f: function main is undeclared in the main package
##[error]Process completed with exit code 1.
```

`cmd/wasm-visor/main.go` is `//go:build js && wasm`, but `vnetaddr.go` is deliberately untagged so `go test ./cmd/wasm-visor` exercises `vnetTarget` on the host. That leaves the directory a `main` package on every other platform with no `main` function, so `go build ./cmd/...` fails there. `go test ./cmd/...` is unaffected, which is why only the CodeQL workflow — the one place that builds `./cmd/...` — noticed. The other wasm-only commands (`dmsg-wasm`, `wasm-visor-probe`, `websh-probe`) are fully tagged and are skipped by the pattern, so this is the sole outlier.

Adds a host-side `main` behind `//go:build !js || !wasm` that prints how to build the real thing and exits 1. `go build -mod=vendor ./cmd/...` now succeeds locally, and `GOOS=js GOARCH=wasm go list` confirms the stub is excluded from the wasm build.

Only CI can prove the CodeQL job goes green — the failure was reproduced locally, but the analysis step itself was not run here.