### PR TITLE
fix(dmsg): a failed client entry publish was never retried

### DIFF
--- a/pkg/dmsg/dmsg/client_entry_publish_test.go
+++ b/pkg/dmsg/dmsg/client_entry_publish_test.go
@@ -82,9 +82,9 @@ func TestUpdateClientEntry_FirstPublishIsNotSkipped(t *testing.T) {
 	c.init(pk, sk, dc, logging.MustGetLogger("test"), time.Minute*5)
 	c.sessions[srvPK] = &SessionCommon{rPK: srvPK}
 
-	// initilizeClientEntry records an update before any session exists, so the
-	// periodic timer is NOT due when the first session lands. Without that the
-	// due-timer alone would force the write and hide the bug.
+	// Stand in for a publish that already landed, so the periodic timer is NOT
+	// due when the session lands. Without that the due-timer alone would force
+	// the write and hide the bug.
 	c.recordUpdate()
 	_, due := c.updateIsDue()
 	require.False(t, due, "test setup: the first publish must race a not-due timer")

--- a/pkg/dmsg/dmsg/client_entry_retry_test.go
+++ b/pkg/dmsg/dmsg/client_entry_retry_test.go
@@ -1,0 +1,133 @@
+// Package dmsg pkg/dmsg/dmsg/client_entry_retry_test.go c1-net-dmsg
+package dmsg
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// flakyPutDisc fails the first failPuts PutEntry calls and succeeds after,
+// counting every attempt. Reads always answer, so the publish gets as far as
+// the write.
+type flakyPutDisc struct {
+	disc.APIClient // unused methods panic if ever called
+
+	mx       sync.Mutex
+	entry    *disc.Entry
+	failPuts int
+	attempts int
+}
+
+func (d *flakyPutDisc) Entry(_ context.Context, _ cipher.PubKey) (*disc.Entry, error) {
+	d.mx.Lock()
+	defer d.mx.Unlock()
+	return d.entry, nil
+}
+
+func (d *flakyPutDisc) PutEntry(_ context.Context, _ cipher.SecKey, _ *disc.Entry) error {
+	d.mx.Lock()
+	defer d.mx.Unlock()
+	d.attempts++
+	if d.attempts <= d.failPuts {
+		return errors.New("dmsg error 202 - cannot connect to delegated server")
+	}
+	return nil
+}
+
+func (d *flakyPutDisc) attemptCount() int {
+	d.mx.Lock()
+	defer d.mx.Unlock()
+	return d.attempts
+}
+
+// TestUpdateClientEntryLoop_RetriesAfterFailedPublish pins the retry ladder in
+// updateClientEntryLoop against the due-gate that used to swallow it.
+//
+// The gate was added with the CXO keepalive stretch (#3829) and sits in front
+// of the exponential backoff added by #3168. A failed publish does not advance
+// lastUpdate, so when the 1 s backoff timer fired the entry was still "not
+// due", the gate reset the timer to the full updateInterval and dropped the
+// retry on the floor — silently, since that branch logs nothing.
+//
+// The consequence in the field: a client that lost the dmsg-HTTP cold-start
+// race on its first publish stayed in discovery with an EMPTY delegated-server
+// list, and so unresolvable by anyone looking it up, until the whole interval
+// elapsed — 30 minutes once the CXO keepalive reports healthy. It is what put
+// e2e's "visor did not appear in DMSG discovery with delegated servers within
+// 2m0s" on the board, and it is the same wedge shape as #3157/#3168.
+//
+// updateInterval is an hour here, so the periodic tick can never fire: every
+// attempt after the first is necessarily the backoff doing its job.
+func TestUpdateClientEntryLoop_RetriesAfterFailedPublish(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+	srvPK, _ := cipher.GenerateKeyPair()
+
+	dc := &flakyPutDisc{
+		entry:    disc.NewClientEntry(pk, 1, nil),
+		failPuts: 2,
+	}
+
+	c := new(EntityCommon)
+	c.init(pk, sk, dc, logging.MustGetLogger("test"), time.Hour)
+	c.sessions[srvPK] = &SessionCommon{rPK: srvPK}
+
+	// A publish landed at some earlier point, so the periodic timer is not
+	// due. This is the steady state a session flap runs into.
+	c.recordUpdate()
+	_, due := c.updateIsDue()
+	require.False(t, due, "test setup: the retry must race a not-due timer")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	defer close(done)
+
+	go c.updateClientEntryLoop(ctx, done, "dmsg")
+
+	// A session change nudges the loop into its first attempt, which fails.
+	c.nudgeEntryUpdate()
+
+	// Backoff is 1 s then 2 s, so the third attempt — the one that succeeds —
+	// lands about 4 s in counting the 1 s debounce. Without the fix the count
+	// stops at 1 and the loop sleeps for the full hour.
+	require.Eventually(t, func() bool {
+		return dc.attemptCount() >= 3
+	}, 20*time.Second, 100*time.Millisecond,
+		"loop stopped retrying after a failed publish; the due-gate swallowed the backoff")
+
+	// And the successful attempt is what records the update.
+	require.Eventually(t, func() bool {
+		c.pushedSrvPKsMx.Lock()
+		defer c.pushedSrvPKsMx.Unlock()
+		return len(c.lastPushedSrvPKs) == 1
+	}, 5*time.Second, 100*time.Millisecond, "successful publish did not record the delegated set")
+}
+
+// TestInitilizeClientEntryDoesNotRecordUpdate pins the other half: the initial
+// type/protocol POST runs before any session exists, so the entry it writes
+// carries no delegated servers at all. Stamping lastUpdate for it told the
+// update loop the registration was current and pushed the first real publish a
+// whole updateInterval away — the amplifier that turned one lost cold-start
+// race into a 30-minute outage.
+func TestInitilizeClientEntryDoesNotRecordUpdate(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+
+	dc := &flakyPutDisc{entry: disc.NewClientEntry(pk, 1, nil)}
+
+	c := new(EntityCommon)
+	c.init(pk, sk, dc, logging.MustGetLogger("test"), time.Hour)
+
+	require.NoError(t, c.initilizeClientEntry(context.Background(), "dmsg", "tcp"))
+
+	_, due := c.updateIsDue()
+	require.True(t, due, "the initial post published no delegated servers; it must not count as a registration")
+}

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -776,12 +776,18 @@ func (c *EntityCommon) initilizeClientEntry(ctx context.Context, clientType stri
 	}
 	c.sessionsMx.Unlock()
 
+	// Deliberately no recordUpdate() anywhere below. lastUpdate means "the
+	// delegated-server set now in discovery is current", and this function
+	// asserts nothing of the sort: it runs before any session exists, so the
+	// entry it posts carries an EMPTY srvPKs, and on the already-registered
+	// path it writes nothing at all. Stamping lastUpdate here pushed the first
+	// real publish a whole updateInterval — 30 m once the CXO keepalive is
+	// healthy — into the future, so a client that failed its first publish
+	// stayed advertised with no delegated servers for that long.
 	var firstErr error
-	anyOK := false
 	for _, ep := range endpoints {
 		_, lookupErr := ep.Client.Entry(ctx, c.pk)
 		if lookupErr == nil {
-			anyOK = true
 			continue
 		}
 		// Only a genuine "entry not found" means we should register a fresh
@@ -814,10 +820,6 @@ func (c *EntityCommon) initilizeClientEntry(ctx context.Context, clientType stri
 			}
 			continue
 		}
-		anyOK = true
-	}
-	if anyOK {
-		c.recordUpdate()
 	}
 	return firstErr
 }
@@ -1098,6 +1100,13 @@ const (
 	entryUpdateMaxBackoff = 30 * time.Second
 )
 
+// entryUpdateMaxFastRetries bounds how many consecutive failures keep the loop
+// on the backoff ladder instead of the periodic cadence. 1+2+4+8+16+30+30+30 ≈
+// 2 minutes of fast retries, which covers the transient failures the ladder is
+// for (the dmsg-HTTP cold-start race, a discovery restart) without leaving a
+// whole fleet retrying a genuinely-down discovery every 30 s.
+const entryUpdateMaxFastRetries = 8
+
 // entryFailureBackoff returns the delay before the next attempt after
 // `consecutiveFailures` consecutive failed updates. Exponential, clamped
 // to entryUpdateMaxBackoff.
@@ -1163,16 +1172,36 @@ func (c *EntityCommon) updateClientEntryLoop(ctx context.Context, done chan stru
 			return
 
 		case <-t.C:
-			if _, due := c.updateIsDue(); !due {
-				// Re-evaluate every base updateInterval rather than sleeping
-				// the full (possibly CXO-stretched) remaining time: this
-				// bounds how long a keepalive stays stretched after the CXO
-				// feed drops (effectiveUpdateInterval falls back to the base
-				// interval the moment cxoKeepaliveHealthyFn goes false), and
-				// avoids a negative Reset when the effective interval exceeds
-				// the base one.
-				t.Reset(c.updateInterval)
-				continue
+			// The due-gate governs the PERIODIC tick only. A failed attempt
+			// leaves lastUpdate untouched, so updateIsDue() is still false
+			// when the short backoff timer that rearm() armed fires: gating
+			// on it here resets the timer to the full updateInterval and
+			// silently discards the retry. That is what has happened to every
+			// retry since #3829 put this check in front of #3168's backoff —
+			// a client whose publish lost the dmsg-HTTP cold-start race sat
+			// in discovery with an EMPTY delegated-server set, unreachable by
+			// lookup, until the whole (CXO-stretched: 30 m) interval elapsed,
+			// and this branch logs nothing to say so.
+			//
+			// The bypass is capped rather than open-ended: past
+			// entryUpdateMaxFastRetries the failure is not the transient race
+			// the ladder is for, and letting every client in the fleet keep
+			// hammering a discovery that is down at the 30 s backoff floor is
+			// the handshake storm the coalescing elsewhere in this file exists
+			// to avoid. Beyond the cap we fall back to the periodic cadence,
+			// which still republishes — just once per updateInterval.
+			if consecutiveFailures == 0 || consecutiveFailures > entryUpdateMaxFastRetries {
+				if _, due := c.updateIsDue(); !due {
+					// Re-evaluate every base updateInterval rather than
+					// sleeping the full (possibly CXO-stretched) remaining
+					// time: this bounds how long a keepalive stays stretched
+					// after the CXO feed drops (effectiveUpdateInterval falls
+					// back to the base interval the moment
+					// cxoKeepaliveHealthyFn goes false), and avoids a negative
+					// Reset when the effective interval exceeds the base one.
+					t.Reset(c.updateInterval)
+					continue
+				}
 			}
 
 			// updateClientEntry takes sessionsMx itself for its snapshot;


### PR DESCRIPTION
The `e2e` job fails intermittently with four-plus tests dying at a uniform ~121 s on `visor visor-a did not appear in DMSG discovery with delegated servers within 2m0s`. It is not the Docker flake and not a timeout that wants raising — the visor really is advertised with an empty delegated-server list, and stays that way.

`updateClientEntryLoop` checks `updateIsDue()` at the top of its timer branch. A failed attempt does not advance `lastUpdate`, so when the backoff timer `rearm()` armed fires the entry is still "not due": the check resets the timer to the full `updateInterval` and drops the retry, silently, since that branch logs nothing. #3168's exponential backoff has been dead since #3829 put this check in front of it. A client that loses the dmsg-HTTP cold-start race on its first publish is then unresolvable by lookup until the whole interval elapses — 30 minutes once the CXO keepalive reports healthy. From the failing job's visor-a log:

```
21:13:55.7663 INFO  [dmsgC]: Initial post entry succeeded
21:13:55.7712 DEBUG [dmsgC]: Updating entry ... delegated servers: <empty>
21:13:56.7873 DEBUG [dmsgC]: Updating entry
21:13:56.7876 WARN  [dmsgC]: Failed to update discovery entry (nudge).
```

and then nothing at all for the next 25 minutes, across every dumped log in the run.

Apply the due-gate to the periodic tick only, capped at eight consecutive failures (~2 min of ladder) so a discovery that is genuinely down does not get retried by the whole fleet at the 30 s backoff floor. Also stop `initilizeClientEntry` stamping `lastUpdate`: it runs before any session exists, so the entry it posts carries no delegated servers, and recording that as a registration is what pushed the first real publish a full interval away.

Two regression tests; both fail on current develop and pass here. `go test -race ./pkg/dmsg/dmsg/` and golangci-lint are clean locally. The Docker e2e suite itself was not run locally.