### PR TITLE
fix(serviceuptime): assert New's cost in transactions, not milliseconds

### DIFF
--- a/pkg/serviceuptime/recorder_test.go
+++ b/pkg/serviceuptime/recorder_test.go
@@ -149,15 +149,25 @@ func TestNewIsCheapEnoughForEarlyMain(t *testing.T) {
 	// Sanity: New must be a single bbolt open + two writes. Anything
 	// more risks slowing the canary-process startup we depend on for
 	// recording crashes during config parsing.
+	//
+	// That is a claim about WORK, so count transactions rather than
+	// milliseconds. The wall-clock form of this assertion ("New took %v,
+	// expected <500ms") measured the runner's disk instead of this code and
+	// failed on Windows CI at 4.10s: three fsync-ing commits on a loaded
+	// shared runner have no business fitting in a fixed 500ms, and widening
+	// the constant would only move the next false failure. The count below
+	// cannot be moved by load, and unlike a duration it actually fails when
+	// someone adds a fourth transaction — which is the regression the
+	// comment above is guarding against.
 	path := filepath.Join(t.TempDir(), "uptime.db")
-	start := time.Now()
 	r, err := New(path, Config{Service: "tester", Version: "v0.0"})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	took := time.Since(start)
-	if took > 500*time.Millisecond {
-		t.Errorf("New took %v, expected <500ms", took)
+	defer r.Close() //nolint:errcheck
+
+	// OpenStore's schema transaction, then PutSession, then MarkSlot.
+	if got := r.Store().writeTxns.Load(); got != 3 {
+		t.Errorf("New performed %d write transactions, want 3 (bbolt open + two writes)", got)
 	}
-	_ = r.Close() //nolint:errcheck
 }

--- a/pkg/serviceuptime/store.go
+++ b/pkg/serviceuptime/store.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync/atomic"
 	"time"
 
 	"github.com/0magnet/bbolt"
@@ -79,6 +80,24 @@ func (r SessionRecord) Duration() time.Duration {
 type Store struct {
 	db         *bbolt.DB
 	instanceID string
+
+	// writeTxns counts committed read-write transactions on this store.
+	// One atomic add per transaction, so it costs nothing measurable, and
+	// it lets a test assert the COST of an operation in transactions —
+	// which is what "New must be a single bbolt open plus two writes"
+	// actually means — instead of in wall-clock milliseconds, which on a
+	// loaded CI runner measures the disk rather than the code.
+	writeTxns atomic.Int64
+}
+
+// update runs fn in a read-write transaction and counts it. Every write
+// path on Store goes through here so writeTxns stays honest.
+func (s *Store) update(fn func(tx *bbolt.Tx) error) error {
+	if err := s.db.Update(fn); err != nil {
+		return err
+	}
+	s.writeTxns.Add(1)
+	return nil
 }
 
 // OpenStore opens (or creates) the bbolt database at path and ensures
@@ -103,7 +122,7 @@ func OpenStore(path string) (*Store, error) {
 		return nil, fmt.Errorf("serviceuptime: open %s: %w", path, err)
 	}
 	s := &Store{db: db}
-	if err := db.Update(func(tx *bbolt.Tx) error {
+	if err := s.update(func(tx *bbolt.Tx) error {
 		for _, b := range [][]byte{bucketMeta, bucketSessions, bucketSlots} {
 			if _, err := tx.CreateBucketIfNotExists(b); err != nil {
 				return fmt.Errorf("create bucket %s: %w", b, err)
@@ -160,7 +179,7 @@ func (s *Store) PutSession(rec SessionRecord) error {
 	if err != nil {
 		return err
 	}
-	return s.db.Update(func(tx *bbolt.Tx) error {
+	return s.update(func(tx *bbolt.Tx) error {
 		return tx.Bucket(bucketSessions).Put(sessionKey(rec.StartedAt), data)
 	})
 }
@@ -201,7 +220,7 @@ func (s *Store) MarkSlot(date time.Time, slot int) error {
 		return fmt.Errorf("serviceuptime: slot %d out of range", slot)
 	}
 	dateKey := []byte(date.UTC().Format(dateFmt))
-	return s.db.Update(func(tx *bbolt.Tx) error {
+	return s.update(func(tx *bbolt.Tx) error {
 		bm := tx.Bucket(bucketSlots).Get(dateKey)
 		buf := make([]byte, BitmapSize)
 		if bm != nil {
@@ -248,7 +267,7 @@ func (s *Store) Dates() ([]string, error) {
 func (s *Store) Prune(cutoff time.Time) (sessions, bitmaps int, err error) {
 	cutoffUTC := cutoff.UTC()
 	cutoffDate := cutoffUTC.Format(dateFmt)
-	err = s.db.Update(func(tx *bbolt.Tx) error {
+	err = s.update(func(tx *bbolt.Tx) error {
 		// Sessions: walk and delete by key (which is StartedAt). A
 		// session that started before the cutoff but has a fresh
 		// LastSeen is preserved — that's a long-running incarnation


### PR DESCRIPTION
The `windows` job fails on:

```
--- FAIL: TestNewIsCheapEnoughForEarlyMain (4.10s)
```

The test times `New()` and requires under 500ms. `New` is one bbolt open plus two writes — three fsync-ing commits — and on a loaded shared Windows runner that has no business fitting a fixed 500ms. Raising the constant would only move the next false failure, and a duration never actually fails when someone adds a fourth transaction, which is the regression the test's own comment says it exists to catch.

So count the work instead of the clock. `Store` gains an atomic counter and a small `update()` wrapper that every write path already funnels through; the test requires exactly three write transactions (the schema transaction, `PutSession`, `MarkSlot`). Load cannot move that number, and it tightens the guard rather than loosening it.

Verified on Linux: package tests, `-race`, `go vet` and golangci-lint all clean, and the count is exactly 3. **The Windows path was not verified locally — I have no Windows machine here, so only CI can confirm that job goes green.** The change is platform-independent, though: it removes the only timing-sensitive assertion in the package.