### PR TITLE
fix(hypervisor): tpviz write endpoints were reachable unauthenticated, cross-origin

### DIFF
--- a/pkg/tpviz/tpviz.go
+++ b/pkg/tpviz/tpviz.go
@@ -1825,17 +1825,34 @@ func (s *Server) handleTPSStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleTPSAddTransport creates a transport between two remote visors via TPS RPC.
+// requireSameOriginJSON gates the four endpoints that MUTATE a visor's
+// transports. They are only ever called same-origin by the tpviz UI, so they
+// send no Access-Control-Allow-Origin header and refuse preflight outright —
+// they previously answered both with "*", which let any page the operator
+// happened to visit create or delete transports on their visor.
+//
+// Requiring a JSON content type closes the other half: without it a
+// cross-origin caller could skip preflight entirely with a "simple" POST,
+// whose side effect lands even though the attacker cannot read the reply.
+//
+// Returns true when the request may proceed.
+func requireSameOriginJSON(w http.ResponseWriter, r *http.Request) bool {
+	switch {
+	case r.Method == http.MethodOptions:
+		http.Error(w, `{"error":"cross-origin requests are not allowed"}`, http.StatusForbidden)
+	case r.Method != http.MethodPost:
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+	case !strings.HasPrefix(r.Header.Get("Content-Type"), "application/json"):
+		http.Error(w, `{"error":"content-type must be application/json"}`, http.StatusUnsupportedMediaType)
+	default:
+		return true
+	}
+	return false
+}
+
 func (s *Server) handleTPSAddTransport(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	if r.Method == http.MethodOptions {
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-		w.WriteHeader(http.StatusOK)
-		return
-	}
-	if r.Method != http.MethodPost {
-		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+	if !requireSameOriginJSON(w, r) {
 		return
 	}
 
@@ -1886,15 +1903,7 @@ func (s *Server) handleTPSAddTransport(w http.ResponseWriter, r *http.Request) {
 // handleTPSRemoveTransport removes a transport from a remote visor via TPS RPC.
 func (s *Server) handleTPSRemoveTransport(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	if r.Method == http.MethodOptions {
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-		w.WriteHeader(http.StatusOK)
-		return
-	}
-	if r.Method != http.MethodPost {
-		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+	if !requireSameOriginJSON(w, r) {
 		return
 	}
 
@@ -1969,15 +1978,7 @@ func (s *Server) handleTPSRefreshTransports(w http.ResponseWriter, r *http.Reque
 // handleLocalAddTransport creates a transport from the local visor to a remote visor.
 func (s *Server) handleLocalAddTransport(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	if r.Method == http.MethodOptions {
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-		w.WriteHeader(http.StatusOK)
-		return
-	}
-	if r.Method != http.MethodPost {
-		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+	if !requireSameOriginJSON(w, r) {
 		return
 	}
 
@@ -2033,15 +2034,7 @@ func (s *Server) handleLocalAddTransport(w http.ResponseWriter, r *http.Request)
 // handleLocalRemoveTransport removes a transport from the local visor.
 func (s *Server) handleLocalRemoveTransport(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	if r.Method == http.MethodOptions {
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-		w.WriteHeader(http.StatusOK)
-		return
-	}
-	if r.Method != http.MethodPost {
-		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+	if !requireSameOriginJSON(w, r) {
 		return
 	}
 

--- a/pkg/tpviz/tpviz_extra_test.go
+++ b/pkg/tpviz/tpviz_extra_test.go
@@ -607,10 +607,10 @@ func TestTPSRemoveTransport_Paths(t *testing.T) {
 	s := testServer(t)
 	s.SetTPSAPI(&fakeTPSAPI{pk: "PK"})
 
-	t.Run("OPTIONS", func(t *testing.T) {
+	t.Run("OPTIONS is refused", func(t *testing.T) {
 		rec := httptest.NewRecorder()
 		s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodOptions, "/api/tps/remove-transport", nil))
-		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, http.StatusForbidden, rec.Code)
 	})
 	t.Run("wrong method", func(t *testing.T) {
 		rec := httptest.NewRecorder()
@@ -619,12 +619,12 @@ func TestTPSRemoveTransport_Paths(t *testing.T) {
 	})
 	t.Run("invalid body", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/tps/remove-transport", strings.NewReader("{bad")))
+		s.Handler().ServeHTTP(rec, postJSON("/api/tps/remove-transport", "{bad"))
 		require.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 	t.Run("success", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/tps/remove-transport", strings.NewReader(`{"target_pk":"a","id":"b"}`)))
+		s.Handler().ServeHTTP(rec, postJSON("/api/tps/remove-transport", `{"target_pk":"a","id":"b"}`))
 		require.Equal(t, http.StatusOK, rec.Code)
 	})
 }
@@ -634,10 +634,10 @@ func TestLocalTransportHandlers_EdgePaths(t *testing.T) {
 		s := testServer(t)
 		s.SetVisorAPI(&fakeVisorAPI{}, "PK")
 
-		t.Run("OPTIONS "+p, func(t *testing.T) {
+		t.Run("OPTIONS is refused "+p, func(t *testing.T) {
 			rec := httptest.NewRecorder()
 			s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodOptions, p, nil))
-			require.Equal(t, http.StatusOK, rec.Code)
+			require.Equal(t, http.StatusForbidden, rec.Code)
 		})
 		t.Run("wrong method "+p, func(t *testing.T) {
 			rec := httptest.NewRecorder()
@@ -646,7 +646,7 @@ func TestLocalTransportHandlers_EdgePaths(t *testing.T) {
 		})
 		t.Run("invalid body "+p, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, p, strings.NewReader("{bad")))
+			s.Handler().ServeHTTP(rec, postJSON(p, "{bad"))
 			require.Equal(t, http.StatusBadRequest, rec.Code)
 		})
 	}

--- a/pkg/tpviz/tpviz_test.go
+++ b/pkg/tpviz/tpviz_test.go
@@ -499,23 +499,31 @@ func TestHandleTPSStatus(t *testing.T) {
 	require.Equal(t, "TPSPK", body["tps_pk"])
 }
 
+// postJSON builds a same-origin JSON POST, as the tpviz UI sends. The
+// transport-mutating endpoints require the content type; see
+// requireSameOriginJSON.
+func postJSON(path, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
 func TestHandleTPSAddTransport(t *testing.T) {
 	s := testServer(t)
 
 	t.Run("TPS not running", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/api/tps/add-transport",
-			strings.NewReader(`{"target_pk":"a","remote_pk":"b","type":"stcpr"}`))
+		req := postJSON("/api/tps/add-transport", `{"target_pk":"a","remote_pk":"b","type":"stcpr"}`)
 		s.Handler().ServeHTTP(rec, req)
 		require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 	})
 
-	t.Run("OPTIONS preflight", func(t *testing.T) {
+	t.Run("OPTIONS preflight is refused", func(t *testing.T) {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodOptions, "/api/tps/add-transport", nil)
 		s.Handler().ServeHTTP(rec, req)
-		require.Equal(t, http.StatusOK, rec.Code)
-		require.Contains(t, rec.Header().Get("Access-Control-Allow-Methods"), "POST")
+		require.Equal(t, http.StatusForbidden, rec.Code)
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
 	})
 
 	t.Run("wrong method", func(t *testing.T) {
@@ -528,8 +536,7 @@ func TestHandleTPSAddTransport(t *testing.T) {
 	t.Run("invalid type rejected", func(t *testing.T) {
 		s.SetTPSAPI(&fakeTPSAPI{pk: "PK"})
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/api/tps/add-transport",
-			strings.NewReader(`{"target_pk":"a","remote_pk":"b","type":"dmsg"}`))
+		req := postJSON("/api/tps/add-transport", `{"target_pk":"a","remote_pk":"b","type":"dmsg"}`)
 		s.Handler().ServeHTTP(rec, req)
 		require.Equal(t, http.StatusBadRequest, rec.Code)
 	})
@@ -537,8 +544,7 @@ func TestHandleTPSAddTransport(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		s.SetTPSAPI(&fakeTPSAPI{pk: "PK"})
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/api/tps/add-transport",
-			strings.NewReader(`{"target_pk":"a","remote_pk":"b","type":"stcpr"}`))
+		req := postJSON("/api/tps/add-transport", `{"target_pk":"a","remote_pk":"b","type":"stcpr"}`)
 		s.Handler().ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
 	})
@@ -934,7 +940,7 @@ func TestLocalTransportHandlers_NotConnected(t *testing.T) {
 
 	for _, path := range []string{"/api/local/add-transport", "/api/local/remove-transport"} {
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{}`))
+		req := postJSON(path, `{}`)
 		s.Handler().ServeHTTP(rec, req)
 		require.Equal(t, http.StatusServiceUnavailable, rec.Code, path)
 	}
@@ -946,23 +952,21 @@ func TestHandleLocalAddTransport(t *testing.T) {
 
 	t.Run("missing remote_pk", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/api/local/add-transport", strings.NewReader(`{}`))
+		req := postJSON("/api/local/add-transport", `{}`)
 		s.Handler().ServeHTTP(rec, req)
 		require.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 
 	t.Run("invalid type", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/api/local/add-transport",
-			strings.NewReader(`{"remote_pk":"abc","type":"bogus"}`))
+		req := postJSON("/api/local/add-transport", `{"remote_pk":"abc","type":"bogus"}`)
 		s.Handler().ServeHTTP(rec, req)
 		require.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 
 	t.Run("success", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/api/local/add-transport",
-			strings.NewReader(`{"remote_pk":"abc","type":"stcpr"}`))
+		req := postJSON("/api/local/add-transport", `{"remote_pk":"abc","type":"stcpr"}`)
 		s.Handler().ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
 	})
@@ -974,15 +978,14 @@ func TestHandleLocalRemoveTransport(t *testing.T) {
 
 	t.Run("missing id", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/api/local/remove-transport", strings.NewReader(`{}`))
+		req := postJSON("/api/local/remove-transport", `{}`)
 		s.Handler().ServeHTTP(rec, req)
 		require.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 
 	t.Run("success", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/api/local/remove-transport",
-			strings.NewReader(`{"id":"tp-id"}`))
+		req := postJSON("/api/local/remove-transport", `{"id":"tp-id"}`)
 		s.Handler().ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code)
 	})
@@ -1002,8 +1005,42 @@ func TestTPSHandlers_NotRunning(t *testing.T) {
 	for _, c := range cases {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(c.method, c.path, strings.NewReader(c.body))
+		if c.method == http.MethodPost {
+			// The mutating endpoints require a JSON content type, as the UI sends.
+			req.Header.Set("Content-Type", "application/json")
+		}
 		s.Handler().ServeHTTP(rec, req)
 		require.Equal(t, http.StatusServiceUnavailable, rec.Code, c.path)
+	}
+}
+
+// TestTPSWriteEndpointsAreSameOriginOnly pins the guard on the endpoints that
+// mutate a visor's transports: no wildcard CORS header, no preflight approval,
+// and no "simple" cross-origin POST slipping past preflight without one.
+func TestTPSWriteEndpointsAreSameOriginOnly(t *testing.T) {
+	s := testServer(t)
+	s.SetTPSAPI(&fakeTPSAPI{pk: "PK"})
+
+	for _, path := range []string{
+		"/api/tps/add-transport",
+		"/api/tps/remove-transport",
+		"/api/local/add-transport",
+		"/api/local/remove-transport",
+	} {
+		// Preflight is refused outright, and never answered with "*".
+		rec := httptest.NewRecorder()
+		s.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodOptions, path, nil))
+		require.Equal(t, http.StatusForbidden, rec.Code, path)
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"), path)
+
+		// A form-encoded POST is a "simple" request that skips preflight, so it
+		// must be rejected before it can take effect.
+		rec = httptest.NewRecorder()
+		req := postJSON(path, `{}`)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		s.Handler().ServeHTTP(rec, req)
+		require.Equal(t, http.StatusUnsupportedMediaType, rec.Code, path)
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"), path)
 	}
 }
 

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -1055,26 +1055,39 @@ func (hv *Hypervisor) makeMux() chi.Router {
 			r.Get("/{pk}", hv.getPty())
 		})
 
-		// Mount tp-viz UI if enabled
+		// Mount tp-viz UI if enabled.
+		//
+		// Inside its own authenticated group: these paths sit OUTSIDE the
+		// r.Route("/api") group above, so before this they carried no session
+		// check at all — including the two POSTs that add and remove transports
+		// on the visor. Registering them here with the same Authorize middleware
+		// the rest of the hypervisor uses keeps every path identical while
+		// putting them behind the session.
 		if hv.tpvizServer != nil {
-			r.Mount("/tp-viz", http.StripPrefix("/tp-viz", hv.tpvizServer.Handler()))
-			// tp-viz bundle.js uses absolute paths like /api/health, /api/transports etc.
-			// Mount the tp-viz handler at root to serve those paths too.
-			tpvHandler := hv.tpvizServer.Handler()
-			r.Get("/api/health", tpvHandler.ServeHTTP)
-			r.Get("/api/transports", tpvHandler.ServeHTTP)
-			r.Get("/api/uptimes", tpvHandler.ServeHTTP)
-			r.Get("/api/services", tpvHandler.ServeHTTP)
-			r.Get("/api/ip-groups", tpvHandler.ServeHTTP)
-			r.Get("/api/local-visor", tpvHandler.ServeHTTP)
-			r.Get("/api/tps/status", tpvHandler.ServeHTTP)
-			r.Post("/api/tps/add-transport", tpvHandler.ServeHTTP)
-			r.Post("/api/tps/remove-transport", tpvHandler.ServeHTTP)
-			r.Get("/api/tps/refresh-transports", tpvHandler.ServeHTTP)
-			r.Post("/api/local/add-transport", tpvHandler.ServeHTTP)
-			r.Get("/api/dmsg/servers", tpvHandler.ServeHTTP)
-			r.Get("/api/dmsg/entries", tpvHandler.ServeHTTP)
-			r.Get("/api/dmsg/health", tpvHandler.ServeHTTP)
+			r.Group(func(r chi.Router) {
+				if hv.c.EnableAuth {
+					r.Use(hv.users.Authorize)
+				}
+
+				r.Mount("/tp-viz", http.StripPrefix("/tp-viz", hv.tpvizServer.Handler()))
+				// tp-viz bundle.js uses absolute paths like /api/health, /api/transports etc.
+				// Mount the tp-viz handler at root to serve those paths too.
+				tpvHandler := hv.tpvizServer.Handler()
+				r.Get("/api/health", tpvHandler.ServeHTTP)
+				r.Get("/api/transports", tpvHandler.ServeHTTP)
+				r.Get("/api/uptimes", tpvHandler.ServeHTTP)
+				r.Get("/api/services", tpvHandler.ServeHTTP)
+				r.Get("/api/ip-groups", tpvHandler.ServeHTTP)
+				r.Get("/api/local-visor", tpvHandler.ServeHTTP)
+				r.Get("/api/tps/status", tpvHandler.ServeHTTP)
+				r.Post("/api/tps/add-transport", tpvHandler.ServeHTTP)
+				r.Post("/api/tps/remove-transport", tpvHandler.ServeHTTP)
+				r.Get("/api/tps/refresh-transports", tpvHandler.ServeHTTP)
+				r.Post("/api/local/add-transport", tpvHandler.ServeHTTP)
+				r.Get("/api/dmsg/servers", tpvHandler.ServeHTTP)
+				r.Get("/api/dmsg/entries", tpvHandler.ServeHTTP)
+				r.Get("/api/dmsg/health", tpvHandler.ServeHTTP)
+			})
 		}
 
 		// Route visualizer: a self-contained static page (no Angular build)


### PR DESCRIPTION
The tpviz routes are registered on the hypervisor's **root** router — `r.Route("/api")` opens at `hypervisor.go:767` and applies `Authorize` inside it, but the tpviz block sits well outside that group. So `POST /api/tps/add-transport` and `/api/tps/remove-transport` carried no session check at all. Both handlers additionally set `Access-Control-Allow-Origin: *` and answered preflight, so any page the operator visited could create or delete transports on their visor with `fetch()`.

Two changes:

- **Auth.** The tpviz registrations move into their own `r.Group` with the same `Authorize` middleware the rest of the hypervisor uses. Every path stays identical, so the UI is unaffected — it is a same-origin page that already carries the session cookie.
- **CORS/CSRF.** The four transport-mutating handlers no longer send `Access-Control-Allow-Origin` and refuse preflight outright. They also now require `Content-Type: application/json`, which the UI already sends: without it a cross-origin *simple* POST skips preflight altogether and its side effect still lands, even though the attacker cannot read the response. Read-only endpoints keep their existing CORS behaviour, since tpviz also runs standalone.

Several tests asserted the old preflight-with-`*` response; those now assert it is refused, and there is new coverage for both the preflight refusal and the simple-POST case.

`go build .` clean, `pkg/tpviz` and `pkg/visor` tests pass, `golangci-lint` reports 0 issues.