### PR TITLE
feat(visor): let a visor-hosted wasm_serve serve the desk, not just the legacy page

### DIFF
--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -644,6 +644,7 @@ func run(parentCtx context.Context, conf *visorconfig.V1) error {
 				Wallet:           !ws.NoWallet,
 				Variant:          ws.Variant,
 				Password:         ws.Password,
+				ExecWasmPath:     ws.ExecWasm,
 				BrowseSuffix:     ws.BrowseSuffix,
 				BrowseOriginAddr: ws.BrowseOriginAddr,
 				VOrigin:          ws.VOrigin,

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -126,6 +126,17 @@ type WasmServeConf struct {
 	NoWallet bool   `json:"no_wallet,omitempty"` // default serves the bundled skycoin-web wallet; set true to omit it
 	Variant  string `json:"variant,omitempty"`   // "" = build default; "go" | "tinygo"
 	Password string `json:"password,omitempty"`  // optional access-password gate (use with TLS)
+	// ExecWasm is the path to the FULL skywire CLI built for GOOS=js, served at
+	// /skywire.wasm. It is what turns this surface into the DESK: without it the
+	// root serves the legacy hv-boot page (bare Angular over a SharedWorker
+	// core), because the desk's terminal has no `skywire` command to run
+	// `autoconfig` in. `skywire cli hv serve` has always had this as
+	// --exec-wasm; the visor-hosted equivalent had no way to set it, so a
+	// visor-hosted wasm_serve could never produce a desk. Empty = legacy page.
+	// Build it with:
+	//   GOOS=js GOARCH=wasm go build -tags "withoutsystray withoutgotop" \
+	//     -trimpath -ldflags "-s -w" -o build/skywire.wasm .
+	ExecWasm string `json:"exec_wasm,omitempty"`
 	// BrowseSuffix is the real-origin browser's browse-origin domain suffix
 	// (leading dot); empty = ".mesh.localhost".
 	BrowseSuffix string `json:"browse_suffix,omitempty"`


### PR DESCRIPTION
`ServeWasm` builds the desk page only when `ExecWasmPath` is set — the desk's terminal runs `skywire autoconfig`, so without the full CLI blob there is no visor for it to run and the root handler falls through to the legacy hv-boot page (bare Angular over a SharedWorker core).

`skywire cli hv serve` has always exposed this as `--exec-wasm`, but the visor-hosted path had no config field for it and the daemon's `ServeWasm` call passed eleven fields without it. So `hypervisor.wasm_serve` could not produce a desk at all, whatever it was set to — which reads as a broken config rather than a missing feature. Adds `exec_wasm` to `WasmServeConf` and plumbs it through.

Verified on a live visor: with `exec_wasm` set, `/skywire.wasm` serves (206) and the root switches from `hv-boot` to `desk-boot`/`skywireDeskBoot` — the desk comes up with the visor in a websh terminal and the hypervisor UI in the nested browser at `vnet:8001`. Empty keeps the previous behaviour exactly.

Build, `go vet` and golangci-lint clean.