### PR TITLE
feat(hypervisor): serve the /api surface over a websocket at /ws

### DIFF
--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/0magnet/bottle/vnet"
@@ -62,6 +63,11 @@ type Hypervisor struct {
 	logger       *logging.Logger
 	tpvizServer  *tpviz.Server
 	lanDmsg      *LANDmsgServer // embedded LAN DMSG server (nil if disabled)
+
+	// wsMux holds the finished router (as a muxRef) so /ws can replay each
+	// frame through the SAME handlers the HTTP surface uses — one API, two
+	// transports. Written once at the end of makeMux, read per request.
+	wsMux atomic.Value
 
 	// summaryCache holds the most recent successful Summary per
 	// remote visor PK so the UI can keep showing version / IP / etc
@@ -1067,6 +1073,21 @@ func (hv *Hypervisor) makeMux() chi.Router {
 			r.Get("/{pk}", hv.getPty())
 		})
 
+		// /ws — the /api surface as a message transport, for a UI that talks to
+		// its visor over a socket instead of same-origin XHR. Out here beside
+		// /pty rather than under /api: that group's middleware.Timeout wraps the
+		// ResponseWriter in something that is not an http.Hijacker, which
+		// websocket.Accept requires, and its 30s deadline would cut a long-lived
+		// connection. Auth is opted into explicitly, as /pty does. Replayed
+		// requests still traverse /api and pick that middleware up per request.
+		r.Group(func(r chi.Router) {
+			if hv.c.EnableAuth {
+				r.Use(hv.users.Authorize)
+			}
+
+			r.Get("/ws", hv.getAPIWebSocket())
+		})
+
 		// Mount tp-viz UI if enabled.
 		//
 		// Inside its own authenticated group: these paths sit OUTSIDE the
@@ -1122,6 +1143,12 @@ func (hv *Hypervisor) makeMux() chi.Router {
 		r.Get("/api/ui-version", hv.getUIVersion())
 		r.Handle("/*", hv.uiHandler())
 	})
+
+	// Hand the finished router to the /ws transport, which replays each frame
+	// through it so the socket and the HTTP surface can never drift apart.
+	// Stored rather than closed over because the routes above are registered
+	// while r is still being built; /ws only reads this at request time.
+	hv.wsMux.Store(muxRef{h: r})
 
 	return r
 }

--- a/pkg/visor/hypervisor_ws.go
+++ b/pkg/visor/hypervisor_ws.go
@@ -31,6 +31,12 @@
 //
 // Bodies are strings, not base64: the hypervisor API is JSON in and JSON out,
 // and the UI's gateway contract already decodes a text body.
+//
+// wsReadLimit bounds what a client may SEND; responses are not capped, and some
+// are large — /api/visors-tree-summary is 8.6 MB on a fleet of nine visors, over
+// plain HTTP as much as here. A browser's WebSocket has no read limit so the UI
+// is unaffected, but a Go client must raise coder/websocket's 32 KiB default
+// (SetReadLimit) or the first big response closes the connection.
 package visor
 
 import (
@@ -42,6 +48,7 @@ import (
 	"sync"
 
 	"github.com/coder/websocket"
+	"github.com/go-chi/chi/v5"
 )
 
 const (
@@ -264,6 +271,13 @@ func (hv *Hypervisor) serveWSRequest(ctx context.Context, up *http.Request, req 
 	if req.Body != nil {
 		body = strings.NewReader(*req.Body)
 	}
+	// Drop the upgrade request's chi routing context before replaying. chi's
+	// Mux.ServeHTTP reuses an existing *chi.Context when it finds one — without
+	// resetting it — so a sub-request built from this handler's context inherits
+	// RoutePath "/ws" and every replayed path resolves straight back to this
+	// handler. Clearing the key makes chi's type assertion miss and allocate a
+	// fresh routing context, which is what a new request should get.
+	ctx = context.WithValue(ctx, chi.RouteCtxKey, nil)
 	sub, err := http.NewRequestWithContext(ctx, strings.ToUpper(req.Method), req.Path, body)
 	if err != nil {
 		res.Status, res.Body = http.StatusBadRequest, "bad request line"

--- a/pkg/visor/hypervisor_ws.go
+++ b/pkg/visor/hypervisor_ws.go
@@ -1,0 +1,301 @@
+// Package visor pkg/visor/hypervisor_ws.go c3-vis-core
+//
+// /ws — the hypervisor API as a message transport.
+//
+// The Angular UI already routes /api through one seam (SkywireHttpBackend,
+// "the bottom of the Angular HttpClient pipeline"), which today has four
+// backends: same-origin XHR for a visor-served build, a function call into an
+// in-tab wasm visor, a dmsg call for the standalone hypervisor, and dmsg frames
+// to a remote PK. Three of those are message-oriented; the native one is the
+// odd one out, and that asymmetry is what stops the two UI variants converging
+// on a single transport.
+//
+// This endpoint closes that gap WITHOUT a second API. A frame names a method, a
+// path and a body; the handler replays it through the hypervisor's OWN router,
+// so every route, middleware, permission check and response is byte-identical
+// to the HTTP call it stands in for. There is exactly one implementation of the
+// API — this is a transport, not a parallel surface.
+//
+// It is deliberately mounted OUTSIDE the /api group: that group carries
+// middleware.Timeout, whose wrapped ResponseWriter is not an http.Hijacker (so
+// websocket.Accept fails) and whose 30s deadline would kill a long-lived
+// socket. /pty sits outside for the same reason and opts into auth explicitly;
+// this follows it.
+//
+// Wire format is JSON text frames. `type` is carried from the first version so
+// server-push ("type":"event") can be added later without breaking the
+// request/response contract.
+//
+//	client → server  {"type":"req","id":7,"method":"GET","path":"/api/about","body":null,"headers":{}}
+//	server → client  {"type":"res","id":7,"status":200,"body":"{...}","headers":{"Content-Type":"application/json"}}
+//
+// Bodies are strings, not base64: the hypervisor API is JSON in and JSON out,
+// and the UI's gateway contract already decodes a text body.
+package visor
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/coder/websocket"
+)
+
+const (
+	// wsReadLimit caps a single request envelope. The API's largest bodies are
+	// config blobs measured in kilobytes; a megabyte is generous and keeps a
+	// misbehaving client from growing the read buffer without bound.
+	wsReadLimit = 1 << 20
+
+	// wsMaxInFlight bounds concurrently replayed requests per connection. The UI
+	// fans several /api calls out at once, so serializing them would make the
+	// socket slower than the XHR it replaces; an unbounded fan-out would let one
+	// socket occupy every handler goroutine.
+	wsMaxInFlight = 8
+)
+
+// muxRef boxes the finished router so it can go through an atomic.Value, which
+// panics on inconsistent concrete types.
+type muxRef struct{ h http.Handler }
+
+// wsRequest is one client→server frame.
+type wsRequest struct {
+	Type    string            `json:"type"`
+	ID      uint64            `json:"id"`
+	Method  string            `json:"method"`
+	Path    string            `json:"path"`
+	Body    *string           `json:"body,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+// wsResponse is one server→client frame.
+type wsResponse struct {
+	Type    string            `json:"type"`
+	ID      uint64            `json:"id"`
+	Status  int               `json:"status"`
+	Body    string            `json:"body"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+// wsAllowedMethods is what the hypervisor UI actually issues. An allowlist
+// rather than a denylist: this endpoint can reach every /api route, so a method
+// nobody uses is a method nobody has thought about.
+var wsAllowedMethods = map[string]bool{
+	http.MethodGet:    true,
+	http.MethodPost:   true,
+	http.MethodPut:    true,
+	http.MethodDelete: true,
+}
+
+// wsStrippedHeaders are never taken from the frame. Credentials come from the
+// connection, which was authenticated at upgrade time; hop-by-hop and framing
+// headers belong to the real HTTP request and would be nonsense on a replay.
+var wsStrippedHeaders = map[string]bool{
+	"cookie":                   true,
+	"authorization":            true,
+	"connection":               true,
+	"upgrade":                  true,
+	"host":                     true,
+	"content-length":           true,
+	"transfer-encoding":        true,
+	"sec-websocket-key":        true,
+	"sec-websocket-version":    true,
+	"sec-websocket-protocol":   true,
+	"sec-websocket-extensions": true,
+}
+
+// wsAllowedPath keeps the transport pointed at the API and nothing else.
+// Without it a frame could name /ws and recurse, or walk out of /api entirely.
+func wsAllowedPath(p string) bool {
+	if i := strings.IndexAny(p, "?#"); i >= 0 {
+		p = p[:i]
+	}
+	if strings.Contains(p, "..") {
+		return false
+	}
+	return p == "/api" || strings.HasPrefix(p, "/api/")
+}
+
+// wsRecorder is a minimal ResponseWriter. net/http/httptest would do, but it
+// registers an -httptest.serve flag in init(), which has no business in a
+// production binary.
+type wsRecorder struct {
+	hdr  http.Header
+	buf  strings.Builder
+	code int
+}
+
+func (w *wsRecorder) Header() http.Header {
+	if w.hdr == nil {
+		w.hdr = http.Header{}
+	}
+	return w.hdr
+}
+
+func (w *wsRecorder) Write(b []byte) (int, error) {
+	if w.code == 0 {
+		w.code = http.StatusOK
+	}
+	return w.buf.Write(b)
+}
+
+func (w *wsRecorder) WriteHeader(c int) {
+	if w.code == 0 {
+		w.code = c
+	}
+}
+
+func (w *wsRecorder) status() int {
+	if w.code == 0 {
+		return http.StatusOK
+	}
+	return w.code
+}
+
+// getAPIWebSocket serves /ws.
+func (hv *Hypervisor) getAPIWebSocket() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// nil options on purpose: coder/websocket then requires the Origin host
+		// to equal the Host header. A WebSocket upgrade is NOT subject to CORS
+		// and cookies ride along on a cross-origin connection, so skipping this
+		// would hand any page the operator visits the entire hypervisor API —
+		// the same class of hole as a wildcard Access-Control-Allow-Origin, but
+		// covering every route rather than a couple of endpoints. Do not pass
+		// InsecureSkipVerify or OriginPatterns{"*"} here.
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			hv.logger.WithError(err).Debug("ws: upgrade rejected")
+			return
+		}
+		defer func() { _ = c.CloseNow() }() //nolint:errcheck
+		c.SetReadLimit(wsReadLimit)
+
+		// Own cancelation: r.Context() ends when the handler returns, but the
+		// in-flight goroutines below have to be unwound explicitly first.
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+
+		var (
+			wmu sync.Mutex
+			wg  sync.WaitGroup
+		)
+		sem := make(chan struct{}, wsMaxInFlight)
+
+	readLoop:
+		for {
+			typ, data, rerr := c.Read(ctx)
+			if rerr != nil {
+				break
+			}
+			if typ != websocket.MessageText {
+				continue
+			}
+
+			var req wsRequest
+			if jerr := json.Unmarshal(data, &req); jerr != nil {
+				hv.writeWS(ctx, c, &wmu, wsResponse{
+					Type: "res", Status: http.StatusBadRequest, Body: "malformed envelope",
+				})
+				continue
+			}
+
+			// Labeled: a bare break here would leave the select, not the read
+			// loop, and the handler would keep accepting frames after the
+			// connection's context was already canceled.
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				break readLoop
+			}
+			wg.Add(1)
+			go func(req wsRequest) {
+				defer wg.Done()
+				defer func() { <-sem }()
+				hv.writeWS(ctx, c, &wmu, hv.serveWSRequest(ctx, r, req))
+			}(req)
+		}
+
+		cancel()
+		wg.Wait()
+	}
+}
+
+// writeWS serializes one frame onto the connection. A websocket connection
+// tolerates exactly one concurrent writer.
+func (hv *Hypervisor) writeWS(ctx context.Context, c *websocket.Conn, mu *sync.Mutex, resp wsResponse) {
+	if resp.Type == "" {
+		resp.Type = "res"
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		hv.logger.WithError(err).Warn("ws: marshaling response")
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+		hv.logger.WithError(err).Debug("ws: write failed")
+	}
+}
+
+// serveWSRequest replays one frame through the hypervisor's own router.
+func (hv *Hypervisor) serveWSRequest(ctx context.Context, up *http.Request, req wsRequest) wsResponse {
+	res := wsResponse{Type: "res", ID: req.ID}
+
+	if !wsAllowedMethods[strings.ToUpper(req.Method)] {
+		res.Status, res.Body = http.StatusMethodNotAllowed, "method not allowed on this transport"
+		return res
+	}
+	if !wsAllowedPath(req.Path) {
+		res.Status, res.Body = http.StatusForbidden, "path must be under /api"
+		return res
+	}
+
+	ref, ok := hv.wsMux.Load().(muxRef)
+	if !ok || ref.h == nil {
+		res.Status, res.Body = http.StatusServiceUnavailable, "router not ready"
+		return res
+	}
+
+	var body io.Reader = http.NoBody
+	if req.Body != nil {
+		body = strings.NewReader(*req.Body)
+	}
+	sub, err := http.NewRequestWithContext(ctx, strings.ToUpper(req.Method), req.Path, body)
+	if err != nil {
+		res.Status, res.Body = http.StatusBadRequest, "bad request line"
+		return res
+	}
+
+	for k, v := range req.Headers {
+		if wsStrippedHeaders[strings.ToLower(k)] {
+			continue
+		}
+		sub.Header.Set(k, v)
+	}
+	// Credentials come from the authenticated connection, never from the frame.
+	if ck := up.Header.Get("Cookie"); ck != "" {
+		sub.Header.Set("Cookie", ck)
+	}
+	sub.Host = up.Host
+	sub.RemoteAddr = up.RemoteAddr
+	if req.Body != nil && sub.Header.Get("Content-Type") == "" {
+		sub.Header.Set("Content-Type", "application/json")
+	}
+
+	rec := &wsRecorder{}
+	ref.h.ServeHTTP(rec, sub)
+
+	res.Status = rec.status()
+	res.Body = rec.buf.String()
+	if len(rec.hdr) > 0 {
+		res.Headers = make(map[string]string, len(rec.hdr))
+		for k := range rec.hdr {
+			res.Headers[k] = rec.hdr.Get(k)
+		}
+	}
+	return res
+}

--- a/pkg/visor/hypervisor_ws_test.go
+++ b/pkg/visor/hypervisor_ws_test.go
@@ -1,0 +1,226 @@
+//go:build !mobile
+
+// Package visor pkg/visor/hypervisor_ws_test.go c3-vis-core
+package visor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// wsTestHypervisor builds the minimum /ws needs: a logger and a router to
+// replay into. The stub router echoes what it received so a test can assert
+// the replayed request, not just the response.
+func wsTestHypervisor(t *testing.T) *Hypervisor {
+	t.Helper()
+	hv := &Hypervisor{logger: logging.MustGetLogger("ws-test")}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/echo", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Seen-Cookie", r.Header.Get("Cookie"))
+		w.Header().Set("X-Seen-Custom", r.Header.Get("X-Custom"))
+		w.WriteHeader(http.StatusTeapot)
+		w.Write([]byte(`{"method":"` + r.Method + `","query":"` + r.URL.RawQuery + `"}`)) //nolint:errcheck,gosec
+	})
+	mux.HandleFunc("/ws", func(w http.ResponseWriter, _ *http.Request) {
+		// If a frame ever reaches this, the path guard has failed.
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("RECURSED")) //nolint:errcheck,gosec
+	})
+	hv.wsMux.Store(muxRef{h: mux})
+	return hv
+}
+
+func TestWSAllowedPath(t *testing.T) {
+	ok := []string{"/api", "/api/", "/api/about", "/api/visors?x=1", "/api/a#frag"}
+	bad := []string{"/ws", "/", "/pty/abc", "/api/../ws", "/apifoo", "", "//api/x", "/tp-viz/"}
+
+	for _, p := range ok {
+		if !wsAllowedPath(p) {
+			t.Errorf("wsAllowedPath(%q) = false, want true", p)
+		}
+	}
+	for _, p := range bad {
+		if wsAllowedPath(p) {
+			t.Errorf("wsAllowedPath(%q) = true, want false", p)
+		}
+	}
+}
+
+// TestWSReplayMatchesHTTP is the contract that makes this a transport rather
+// than a second API: a frame produces the same status, body and headers the
+// equivalent HTTP request would.
+func TestWSReplayMatchesHTTP(t *testing.T) {
+	hv := wsTestHypervisor(t)
+	up := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	up.Header.Set("Cookie", "session=real")
+
+	res := hv.serveWSRequest(context.Background(), up, wsRequest{
+		Type: "req", ID: 42, Method: "GET", Path: "/api/echo?a=b",
+	})
+
+	if res.ID != 42 || res.Type != "res" {
+		t.Fatalf("envelope id/type = %d/%q, want 42/res", res.ID, res.Type)
+	}
+	if res.Status != http.StatusTeapot {
+		t.Errorf("status = %d, want %d (the router's own status must pass through)", res.Status, http.StatusTeapot)
+	}
+	if !strings.Contains(res.Body, `"query":"a=b"`) {
+		t.Errorf("body = %q, want the query string preserved", res.Body)
+	}
+	if got := res.Headers["Content-Type"]; got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+}
+
+// TestWSUsesConnectionCredentials: the frame must not be able to present its
+// own Cookie. The connection was authenticated at upgrade; a frame that could
+// override that would let one socket act as another session.
+func TestWSUsesConnectionCredentials(t *testing.T) {
+	hv := wsTestHypervisor(t)
+	up := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	up.Header.Set("Cookie", "session=real")
+
+	res := hv.serveWSRequest(context.Background(), up, wsRequest{
+		Method: "GET", Path: "/api/echo",
+		Headers: map[string]string{"Cookie": "session=forged", "X-Custom": "kept"},
+	})
+
+	if got := res.Headers["X-Seen-Cookie"]; got != "session=real" {
+		t.Errorf("replayed Cookie = %q, want the connection's own (session=real)", got)
+	}
+	if got := res.Headers["X-Seen-Custom"]; got != "kept" {
+		t.Errorf("ordinary header = %q, want it forwarded", got)
+	}
+}
+
+func TestWSRejectsPathAndMethod(t *testing.T) {
+	hv := wsTestHypervisor(t)
+	up := httptest.NewRequest(http.MethodGet, "/ws", nil)
+
+	t.Run("a frame cannot reach /ws and recurse", func(t *testing.T) {
+		res := hv.serveWSRequest(context.Background(), up, wsRequest{Method: "GET", Path: "/ws"})
+		if res.Status != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403", res.Status)
+		}
+		if strings.Contains(res.Body, "RECURSED") {
+			t.Fatal("the frame reached the /ws handler")
+		}
+	})
+
+	t.Run("method outside the allowlist", func(t *testing.T) {
+		res := hv.serveWSRequest(context.Background(), up, wsRequest{Method: "TRACE", Path: "/api/echo"})
+		if res.Status != http.StatusMethodNotAllowed {
+			t.Errorf("status = %d, want 405", res.Status)
+		}
+	})
+
+	t.Run("router not ready", func(t *testing.T) {
+		bare := &Hypervisor{logger: logging.MustGetLogger("ws-test")}
+		res := bare.serveWSRequest(context.Background(), up, wsRequest{Method: "GET", Path: "/api/echo"})
+		if res.Status != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503", res.Status)
+		}
+	})
+}
+
+// TestWSRejectsCrossOrigin pins the security property that motivated the
+// explicit Accept options: a WebSocket upgrade is NOT subject to CORS, so
+// without an Origin check any page the operator visits could drive the whole
+// hypervisor API with their cookies attached.
+func TestWSRejectsCrossOrigin(t *testing.T) {
+	hv := wsTestHypervisor(t)
+	srv := httptest.NewServer(hv.getAPIWebSocket())
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), &websocket.DialOptions{
+		HTTPHeader: http.Header{"Origin": []string{"http://evil.example"}},
+	})
+	if err == nil {
+		t.Fatal("cross-origin upgrade succeeded; the Origin check is not in force")
+	}
+}
+
+// TestWSRoundTrip drives the real handler over a real socket.
+func TestWSRoundTrip(t *testing.T) {
+	hv := wsTestHypervisor(t)
+	srv := httptest.NewServer(hv.getAPIWebSocket())
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	c, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = c.CloseNow() }() //nolint:errcheck,gosec
+
+	req, merr := json.Marshal(wsRequest{Type: "req", ID: 7, Method: "GET", Path: "/api/echo"})
+	if merr != nil {
+		t.Fatalf("marshal: %v", merr)
+	}
+	if err := c.Write(ctx, websocket.MessageText, req); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, data, err := c.Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var res wsResponse
+	if err := json.Unmarshal(data, &res); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if res.ID != 7 || res.Status != http.StatusTeapot {
+		t.Errorf("got id=%d status=%d, want id=7 status=418", res.ID, res.Status)
+	}
+}
+
+// TestWSMalformedEnvelope: a bad frame must not kill the connection — the UI
+// would otherwise lose every in-flight request to one serialization slip.
+func TestWSMalformedEnvelope(t *testing.T) {
+	hv := wsTestHypervisor(t)
+	srv := httptest.NewServer(hv.getAPIWebSocket())
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	c, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = c.CloseNow() }() //nolint:errcheck,gosec
+
+	if err := c.Write(ctx, websocket.MessageText, []byte("{not json")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := c.Read(ctx); err != nil {
+		t.Fatalf("no error frame for a malformed envelope: %v", err)
+	}
+
+	// The connection is still usable.
+	req, merr := json.Marshal(wsRequest{Type: "req", ID: 1, Method: "GET", Path: "/api/echo"})
+	if merr != nil {
+		t.Fatalf("marshal: %v", merr)
+	}
+	if err := c.Write(ctx, websocket.MessageText, req); err != nil {
+		t.Fatalf("write after malformed frame: %v", err)
+	}
+	if _, _, err := c.Read(ctx); err != nil {
+		t.Fatalf("connection died after a malformed frame: %v", err)
+	}
+}

--- a/pkg/visor/hypervisor_ws_test.go
+++ b/pkg/visor/hypervisor_ws_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/go-chi/chi/v5"
 
 	"github.com/skycoin/skywire/pkg/logging"
 )
@@ -222,5 +223,45 @@ func TestWSMalformedEnvelope(t *testing.T) {
 	}
 	if _, _, err := c.Read(ctx); err != nil {
 		t.Fatalf("connection died after a malformed frame: %v", err)
+	}
+}
+
+// TestWSReplayEscapesParentRouteContext is a regression test for a bug the unit
+// tests could not see and a live visor found immediately: chi's Mux.ServeHTTP
+// REUSES an existing *chi.Context when the request context carries one, and
+// does not reset it. A sub-request built from the /ws handler's own context
+// therefore inherited RoutePath "/ws", and every replayed path — /api/about,
+// /api/ping, anything — resolved straight back to the websocket handler, which
+// answered 426 "Connection header does not contain Upgrade".
+//
+// Uses a real chi router, because http.ServeMux has no such behavior and would
+// pass regardless.
+func TestWSReplayEscapesParentRouteContext(t *testing.T) {
+	hv := &Hypervisor{logger: logging.MustGetLogger("ws-test")}
+	r := chi.NewRouter()
+	r.Get("/api/about", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`)) //nolint:errcheck,gosec
+	})
+	r.Get("/ws", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUpgradeRequired)
+		w.Write([]byte("REACHED /ws")) //nolint:errcheck,gosec
+	})
+	hv.wsMux.Store(muxRef{h: r})
+
+	// Simulate what the live handler had: a context already carrying chi's
+	// routing state for the /ws request.
+	rctx := chi.NewRouteContext()
+	rctx.RoutePath = "/ws"
+	ctx := context.WithValue(context.Background(), chi.RouteCtxKey, rctx)
+
+	up := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	res := hv.serveWSRequest(ctx, up, wsRequest{Method: "GET", Path: "/api/about"})
+
+	if res.Status == http.StatusUpgradeRequired || strings.Contains(res.Body, "REACHED /ws") {
+		t.Fatalf("replay resolved back to /ws (status=%d body=%q); the parent route context leaked", res.Status, res.Body)
+	}
+	if res.Status != http.StatusOK || !strings.Contains(res.Body, `"ok":true`) {
+		t.Errorf("status=%d body=%q, want 200 and the /api/about body", res.Status, res.Body)
 	}
 }


### PR DESCRIPTION
The Angular UI already routes `/api` through one seam — `SkywireHttpBackend`, "the bottom of the Angular HttpClient pipeline" — with four backends: same-origin XHR when a visor serves the build, a call into an in-tab wasm visor, a dmsg call for the standalone hypervisor, and dmsg frames to a remote PK. Three are message-oriented; the native one is the odd one out, and that is what stops the two UI variants converging on a single transport.

`/ws` closes the gap **without a second API**. A frame names a method, a path and a body, and the handler replays it through the hypervisor's own router, so routes, middleware, permission checks and responses are whatever the equivalent HTTP call produces. It sits outside the `/api` group because that group's `middleware.Timeout` wraps the ResponseWriter in a non-Hijacker (so `websocket.Accept` fails) and its 30s deadline would cut a long-lived socket — `/pty` is out there for the same reason and opts into auth the same way. `type` is on the wire from the start so server push can be added later without breaking the request/response contract.

**Security.** A websocket upgrade is not subject to CORS and cookies ride along, so the Origin check is left on — no `InsecureSkipVerify`, no `OriginPatterns{"*"}`. Without it any page the operator visited could drive the whole API. Frames also cannot present their own `Cookie` (credentials come from the authenticated connection), name a path outside `/api`, or use a method the UI never issues.

**One bug worth calling out**, because it is a trap for anything that replays a request through chi: `chi.Mux.ServeHTTP` reuses an existing `*chi.Context` when the request context carries one, and does not reset it. A sub-request built from the websocket handler's own context inherited `RoutePath "/ws"`, so every replayed path resolved back to the upgrade handler and returned 426. The unit tests used `http.ServeMux`, which has no such behavior, and passed; a live visor found it on the first request. Fixed by clearing the key before replay, with a chi-backed regression test that fails without the fix.

Verified on a running visor: bare `GET /ws` → 426, cross-origin upgrade → 403, same-origin → 101, and `/api/about`, `/api/ping`, `/api/visors-tree-summary` all return 200 with the same bodies as plain HTTP. Nine tests, `go build .`, `go vet` and golangci-lint clean.

Nothing consumes this yet — the client side (a fifth `SkywireHttpBackend` mode) is a separate change.