### PR TITLE
fix(hypervisor): gzip the /api surface

### DIFF
--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -767,6 +767,18 @@ func (hv *Hypervisor) makeMux() chi.Router {
 		r.Route("/api", func(r chi.Router) {
 			r.Use(middleware.Timeout(httpTimeout))
 
+			// The /api surface is JSON, most of it list-shaped and
+			// re-sent on every UI poll (the node list refreshes every
+			// 10s by default). /visors-tree-summary alone measured
+			// 8.8 MB on a nine-visor deployment; gzip takes it to
+			// 1.5 MB. Restricted to application/json so SSE
+			// (text/event-stream, /log and /notify) and the websocket
+			// upgrades under /visors/{pk}/... are left untouched —
+			// chi only swaps in the compressing writer once it sees a
+			// listed Content-Type, so Hijack and Flush still reach the
+			// real ResponseWriter on those routes.
+			r.Use(middleware.Compress(5, "application/json"))
+
 			r.Get("/ping", hv.getPong())
 
 			r.Get("/csrf", hv.getCsrf())

--- a/pkg/visor/hypervisor_api_compress_test.go
+++ b/pkg/visor/hypervisor_api_compress_test.go
@@ -1,0 +1,51 @@
+package visor
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// The hypervisor's /api surface must negotiate gzip. Everything on it
+// is JSON, and the node list re-fetches the whole thing every 10s.
+func TestHypervisorAPICompressesJSON(t *testing.T) {
+	conf := visorconfig.MakeConfig(false)
+	conf.FillDefaults(false)
+	conf.DBPath = filepath.Join(t.TempDir(), "users_test.db")
+
+	hv, err := NewHypervisor(conf, nil, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(conf.DBPath)) }()
+	defer func() { _ = hv.users.Close() }() //nolint:errcheck
+
+	srv := httptest.NewServer(hv.HTTPHandler())
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/user-exists", nil)
+	require.NoError(t, err)
+	// net/http's transport strips Content-Encoding when it added
+	// Accept-Encoding itself; set it explicitly so the header survives.
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
+
+	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
+	require.Contains(t, resp.Header.Get("Vary"), "Accept-Encoding")
+
+	zr, err := gzip.NewReader(resp.Body)
+	require.NoError(t, err)
+	body, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(body), `"exists"`), "body: %s", body)
+}


### PR DESCRIPTION
The hypervisor has no compression middleware at all. The whole `/api` surface is JSON, most of it list-shaped, and the node list re-fetches it every 10s by default.

Measured on a live nine-visor deployment, `GET /api/visors-tree-summary`:

| | bytes |
|---|---|
| today | 8,810,495 |
| gzip (level 5) | 1,467,150 |

Restricted to `application/json` so the SSE routes (`/log`, `/notify`) and the websocket upgrades under `/visors/{pk}/` are untouched — chi only swaps in the compressing writer once it sees a listed Content-Type, so `Hijack` and `Flush` still reach the real ResponseWriter there.

Worth stating what this does *not* cover: the Angular `SkywireHttpBackend` bypasses HTTP in two of its four modes. This lands on the browser XHR path and on the remote-viewer dmsg path that goes through `dmsghttp.HTTPTransport` (which auto-adds `Accept-Encoding: gzip` and inflates transparently, `pkg/dmsg/dmsghttp/http_transport.go:128`). The tinygo `FetchOverDmsg` path sends no `Accept-Encoding` so it keeps getting plain JSON, and the in-wasm `hvApi` path never crosses a wire.