### PR TITLE
fix(hypervisor): send the node list only the transport fields it renders

### DIFF
--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -279,7 +279,7 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 							if visors[idx].Overview == nil {
 								return
 							}
-							visors[idx].Overview.Transports = full.Overview.Transports
+							visors[idx].Overview.Transports = compactTransportSummaries(full.Overview.Transports)
 						case <-time.After(5 * time.Second):
 						}
 					}(ft.idx, ft.pk)
@@ -372,6 +372,60 @@ func (hv *Hypervisor) collectLocalVisorSummaries() []Summary {
 	return out
 }
 
+// compactTransportSummaries projects transports down to the two fields
+// the node-list's Transports column actually renders — the type and
+// the direction — dropping the id, both public keys, the byte
+// counters, latency, throughput and the endpoint block.
+//
+// That array is essentially the whole node-list payload: on a
+// nine-visor deployment carrying 13.6k transports,
+// /api/visors-tree-summary measured 8,810,495 bytes, of which
+// 8,670,341 were overview.transports — and 3,082,324 of those were the
+// endpoint sub-object alone, whose remote_addr / local_addr strings
+// re-state the two public keys the entry already carries. The hvui
+// reads only `type`, `initiator` and the array length from it
+// (node-list.component.ts getTransportCounts / getTransportTotals).
+// Per-transport detail comes from /visors/{pk}/transports and
+// /visors/{pk}/summary, which are untouched.
+//
+// The JSON keys are unchanged, so an hvui build older than this one
+// still renders the column correctly against a newer hypervisor — it
+// just finds the fields it never read absent. TransportSummary's
+// MarshalJSON is what makes the dropped keys actually vanish rather
+// than serialize as zero-filled arrays.
+func compactTransportSummaries(in []*TransportSummary) []*TransportSummary {
+	if len(in) == 0 {
+		return in
+	}
+	out := make([]*TransportSummary, len(in))
+	for i, t := range in {
+		if t == nil {
+			continue
+		}
+		out[i] = &TransportSummary{Type: t.Type, Initiator: t.Initiator}
+	}
+	return out
+}
+
+// compactSummaryTransports applies compactTransportSummaries to a
+// slice of summaries bound for a node-list response.
+//
+// Overview is copied rather than mutated in place: the *Overview a
+// Summary carries is shared with hv.summaryCache, and the per-visor
+// detail endpoints serve out of that cache.
+func compactSummaryTransports(in []Summary) []Summary {
+	for i := range in {
+		ov := in[i].Overview
+		if ov == nil || len(ov.Transports) == 0 {
+			continue
+		}
+		cp := *ov
+		cp.Transports = compactTransportSummaries(ov.Transports)
+		in[i].Overview = &cp
+	}
+	return in
+}
+
 // projectEntryTransports returns the per-transport detail the
 // node-list's Transports column iterates. Prefers the full
 // TransportSummaries field populated post-#2789. Falls back to a slice
@@ -381,7 +435,10 @@ func (hv *Hypervisor) collectLocalVisorSummaries() []Summary {
 // least sees the right total instead of a "-" dash.
 func projectEntryTransports(e HVVisorEntry) []*TransportSummary {
 	if len(e.TransportSummaries) > 0 {
-		return e.TransportSummaries
+		// Compacted here as well as at the source (see
+		// populateEntryFromSummary) because a sub-hypervisor running
+		// an older binary still sends the full per-transport detail.
+		return compactTransportSummaries(e.TransportSummaries)
 	}
 	if e.Transports <= 0 {
 		return nil
@@ -792,6 +849,6 @@ func (hv *Hypervisor) getAllVisorsSummary() http.HandlerFunc {
 			}
 		}
 
-		httputil.WriteJSON(w, r, http.StatusOK, summaries)
+		httputil.WriteJSON(w, r, http.StatusOK, compactSummaryTransports(summaries))
 	}
 }

--- a/pkg/visor/hypervisor_nodelist_payload_test.go
+++ b/pkg/visor/hypervisor_nodelist_payload_test.go
@@ -1,0 +1,100 @@
+package visor
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// A fully-populated TransportSummary must serialize exactly as it did
+// before MarshalJSON existed — the detail endpoints depend on it.
+func TestTransportSummaryMarshalJSONKeepsSetIdentifiers(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	remote, _ := cipher.GenerateKeyPair()
+	id := uuid.New()
+
+	b, err := json.Marshal(TransportSummary{
+		ID:     id,
+		Local:  pk,
+		Remote: remote,
+		Type:   types.Type("stcpr"),
+	})
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &got))
+	require.Equal(t, id.String(), got["id"])
+	require.Equal(t, pk.Hex(), got["local_pk"])
+	require.Equal(t, remote.Hex(), got["remote_pk"])
+	require.Equal(t, "stcpr", got["type"])
+}
+
+// A compacted entry must not pay for the identifiers it doesn't carry.
+// omitempty cannot do this on its own (uuid.UUID and cipher.PubKey are
+// arrays), so a regression here silently costs ~170 bytes per transport
+// on every node-list poll.
+func TestTransportSummaryMarshalJSONOmitsZeroIdentifiers(t *testing.T) {
+	b, err := json.Marshal(TransportSummary{Type: types.Type("dmsg"), Initiator: true})
+	require.NoError(t, err)
+
+	s := string(b)
+	require.NotContains(t, s, `"id"`)
+	require.NotContains(t, s, `"local_pk"`)
+	require.NotContains(t, s, `"remote_pk"`)
+	require.Contains(t, s, `"type":"dmsg"`)
+	require.Contains(t, s, `"initiator":true`)
+	require.Less(t, len(b), 80, "compacted entry should stay tiny: %s", s)
+}
+
+func TestCompactTransportSummariesKeepsOnlyTypeAndDirection(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	in := []*TransportSummary{{
+		ID:            uuid.New(),
+		Local:         pk,
+		Remote:        pk,
+		Type:          types.Type("sudph"),
+		Initiator:     true,
+		LatencyMS:     42,
+		ThroughputBps: 1234,
+		RemoteIP:      "1.2.3.4",
+	}, nil}
+
+	out := compactTransportSummaries(in)
+	require.Len(t, out, 2)
+	require.Nil(t, out[1])
+	require.Equal(t, types.Type("sudph"), out[0].Type)
+	require.True(t, out[0].Initiator)
+	require.Zero(t, out[0].ID)
+	require.True(t, out[0].Local.Null())
+	require.True(t, out[0].Remote.Null())
+	require.Zero(t, out[0].LatencyMS)
+	require.Nil(t, out[0].Endpoint)
+
+	// The input — which may be the hypervisor's cached Overview — is
+	// left alone.
+	require.Equal(t, types.Type("sudph"), in[0].Type)
+	require.False(t, in[0].Local.Null())
+	require.Equal(t, float64(42), in[0].LatencyMS)
+}
+
+// compactSummaryTransports must copy the Overview it rewrites:
+// hv.summaryCache hands the same *Overview to the per-visor detail
+// endpoints, which do need the full transport records.
+func TestCompactSummaryTransportsDoesNotMutateSharedOverview(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	shared := &Overview{
+		PubKey:     pk,
+		Transports: []*TransportSummary{{ID: uuid.New(), Local: pk, Remote: pk, Type: types.Type("dmsg")}},
+	}
+
+	out := compactSummaryTransports([]Summary{{Overview: shared}})
+	require.Len(t, out, 1)
+	require.NotSame(t, shared, out[0].Overview)
+	require.True(t, out[0].Overview.Transports[0].Local.Null())
+	require.False(t, shared.Transports[0].Local.Null())
+}

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -116,6 +116,36 @@ type TransportSummary struct {
 	// Populated from tp.ConnDetails().
 	Endpoint *network.ConnDetails `json:"endpoint,omitempty"`
 }
+
+// MarshalJSON emits id / local_pk / remote_pk only when they are set.
+//
+// encoding/json's `omitempty` cannot express this: uuid.UUID and
+// cipher.PubKey are fixed-size arrays, and omitempty never treats an
+// array as empty — so an otherwise-blank entry still costs ~170 bytes
+// of "000…0" on the wire. That is what makes the node-list projection
+// worth doing at all (see compactTransportSummaries, which emits type
+// and direction only). A real transport has all three set and
+// serializes exactly as it did before.
+func (ts TransportSummary) MarshalJSON() ([]byte, error) {
+	type alias TransportSummary
+	out := struct {
+		*alias
+		ID     *uuid.UUID     `json:"id,omitempty"`
+		Local  *cipher.PubKey `json:"local_pk,omitempty"`
+		Remote *cipher.PubKey `json:"remote_pk,omitempty"`
+	}{alias: (*alias)(&ts)}
+	if ts.ID != (uuid.UUID{}) {
+		out.ID = &ts.ID
+	}
+	if !ts.Local.Null() {
+		out.Local = &ts.Local
+	}
+	if !ts.Remote.Null() {
+		out.Remote = &ts.Remote
+	}
+	return json.Marshal(out)
+}
+
 type TransportLogEntry struct {
 	TpID      uuid.UUID `json:"tp_id"`
 	RecvBytes uint64    `json:"recv_bytes"`

--- a/pkg/visor/rpc_hypervisor_proxy.go
+++ b/pkg/visor/rpc_hypervisor_proxy.go
@@ -123,7 +123,12 @@ func populateEntryFromSummary(entry *HVVisorEntry, summary *Summary) {
 	entry.CountryCode = summary.Overview.CountryCode
 	entry.IsSymmetricNAT = summary.Overview.IsSymmetricNAT
 	entry.Transports = len(summary.Overview.Transports)
-	entry.TransportSummaries = summary.Overview.Transports
+	// Only the type and the direction survive: this entry feeds the
+	// node-list table (and `hv ls`, which reads the count alone), and
+	// it crosses dmsg on every HVListDirectVisors call. Sending the
+	// full per-transport detail put ~2.7 MB on the wire per poll for a
+	// three-sub-hypervisor tree. See compactTransportSummaries.
+	entry.TransportSummaries = compactTransportSummaries(summary.Overview.Transports)
 	entry.Apps = len(summary.Overview.Apps)
 	entry.ConfigVersion = summary.ConfigVersion
 	entry.RewardAddress = summary.RewardAddress


### PR DESCRIPTION
On the operator's nine-visor deployment `GET /api/visors-tree-summary` returns 8,810,495 bytes, re-fetched every 10s by default. 8,670,341 of those bytes are `overview.transports` — 13,597 full `TransportSummary` records — and 3,082,324 are the `endpoint` sub-object alone, whose `remote_addr` / `local_addr` strings re-state the two public keys the record already carries.

The node list reads three things from that array: `type`, `initiator`, and its length (`node-list.component.ts` `getTransportCounts` / `getTransportTotals`). This projects it down to those. Per-transport detail still comes from `/visors/{pk}/transports` and `/visors/{pk}/summary`, which are unchanged.

The same projection is applied at the source in `populateEntryFromSummary`, so the full detail stops crossing dmsg on every `HVListDirectVisors` call — that leg was ~2.7 MB per poll for a three-sub-hypervisor tree. `hv ls` reads only the count, which is a separate field.

`TransportSummary` gains a `MarshalJSON` that omits `id` / `local_pk` / `remote_pk` when unset. `omitempty` cannot express that: `uuid.UUID` and `cipher.PubKey` are fixed-size arrays, which `omitempty` never treats as empty, so a projected entry would still cost ~170 bytes of `"000…0"`. A fully-populated record serializes exactly as it did before, and there is a test pinning that.

The JSON keys are unchanged, so an hvui build older than this one reading a newer hypervisor still renders the column correctly — it just finds the fields it never read absent.

Measured by decoding the live 8.8 MB body, applying the projection, and re-marshaling:

| `/api/visors-tree-summary` | raw | gzip (5) |
|---|---|---|
| before | 8,810,495 | 1,467,150 |
| after | 995,407 | 38,506 |