### PR TITLE
fix(transport): gzip the tp-list CXO leaf

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
@@ -686,7 +687,13 @@ func (tm *Manager) publishTPDList(entries []*Entry) {
 		tm.Logger.WithError(err).Debug("Failed to marshal transport list leaf")
 		return
 	}
-	if err := pub.Put(tpdListPath, body); err != nil {
+	// CXO stores and propagates object bytes verbatim, so the leaf travels
+	// uncompressed unless the publisher compresses it — and this one is a
+	// JSON array of near-identical records, which gzip crushes. TPD's reader
+	// has been self-describing since #4105 (cxoutils.Gunzip magic-byte-detects
+	// and passes raw bodies through), so an aggregator that predates this
+	// still reads the feed and a visor that predates it still publishes raw.
+	if err := pub.Put(tpdListPath, cxoutils.Gzip(body)); err != nil {
 		tm.Logger.WithError(err).Debug("Failed to publish transport list leaf to CXO")
 	}
 }

--- a/pkg/transport/manager_lan_test.go
+++ b/pkg/transport/manager_lan_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	types "github.com/skycoin/skywire/pkg/transport/types"
 )
 
@@ -137,12 +138,14 @@ func TestManagerPublishTPDList(t *testing.T) {
 
 	tm.publishTPDList([]*Entry{&entry})
 	require.Equal(t, tpdListPath, cap.path)
+	// The leaf is gzipped on the wire; TPD's reader gunzips it.
+	require.NotEqual(t, cap.body, cxoutils.Gunzip(cap.body), "tp-list leaf should be published gzipped")
 
 	var got struct {
 		Version string         `json:"version,omitempty"`
 		Compact []CompactEntry `json:"c"`
 	}
-	require.NoError(t, json.Unmarshal(cap.body, &got))
+	require.NoError(t, json.Unmarshal(cxoutils.Gunzip(cap.body), &got))
 	require.Len(t, got.Compact, 1)
 	// Compact form drops the reporter's own PK and keeps the remote edge + type.
 	require.Equal(t, remote, got.Compact[0].Remote)
@@ -151,7 +154,7 @@ func TestManagerPublishTPDList(t *testing.T) {
 
 	// nil entries publishes an explicit empty list.
 	tm.publishTPDList(nil)
-	require.NoError(t, json.Unmarshal(cap.body, &got))
+	require.NoError(t, json.Unmarshal(cxoutils.Gunzip(cap.body), &got))
 	require.Empty(t, got.Compact)
 }
 


### PR DESCRIPTION
CXO stores and propagates object bytes verbatim, so this leaf travels uncompressed unless the publisher compresses it — and it is a JSON array of near-identical records, which gzip crushes. Every visor republishes its whole list on every transport change.

Shaped from the largest visor on the operator's deployment (1,343 transports):

| tp-list leaf | bytes |
|---|---|
| today | 138,821 |
| gzipped | 42,488 |

TPD's reader has been self-describing since #4105 (`cxoutils.Gunzip` magic-byte-detects gzip and passes raw bodies through unchanged), so an aggregator that predates this still reads the feed and a visor that predates it still publishes raw. Both TPD read paths gunzip — `cxoaggregator/aggregator.go:756` and `:891`.

This also buys headroom against the 16 MB `MaxObjectSize` Put ceiling, which is a whole-feed kill rather than a dropped object.