### PR TITLE
fix(visorconfig): flush no longer erases config keys the binary doesn't know

### DIFF
--- a/pkg/visor/visorconfig/common_native.go
+++ b/pkg/visor/visorconfig/common_native.go
@@ -11,8 +11,10 @@
 package visorconfig
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
+	"reflect"
 )
 
 func (c *Common) flush(v interface{}) (err error) {
@@ -34,8 +36,31 @@ func (c *Common) flush(v interface{}) (err error) {
 		}
 	}()
 
-	raw, err := json.MarshalIndent(v, "", "\t")
+	raw, err := json.Marshal(v)
 	if err != nil {
+		return err
+	}
+	// Read-modify-WRITE. Marshaling the struct alone ERASES every key
+	// the file holds that this binary has no field for — one restart on
+	// a build predating a config key silently deletes that setting, and
+	// so does any third-party or hand-added key. So read the file we are
+	// about to overwrite and carry its unknown keys across. See
+	// preserve.go; a file that is absent, unreadable or not JSON yields
+	// no residue and the write proceeds exactly as before.
+	if prior, rErr := os.ReadFile(c.path); rErr == nil { //nolint:gosec // the config's own path
+		if residue := captureUnknown(prior, reflect.TypeOf(v)); residue != nil {
+			merged, mErr := mergeUnknown(raw, residue)
+			if mErr != nil {
+				log.WithError(mErr).Warn("Could not preserve unrecognized config keys; writing known fields only.")
+			} else {
+				raw = merged
+			}
+		}
+	}
+	// json.MarshalIndent is defined as Marshal followed by this, so the
+	// on-disk formatting is byte-for-byte what it has always been.
+	var indented bytes.Buffer
+	if err = json.Indent(&indented, raw, "", "\t"); err != nil {
 		return err
 	}
 	// 0640, not 0644: this config file holds the visor's SECRET KEY (Common.SK).
@@ -46,5 +71,5 @@ func (c *Common) flush(v interface{}) (err error) {
 	// os.WriteFile only applies this mode when CREATING the file — pre-existing
 	// 0644 configs must be tightened out-of-band (package postinstall chmod).
 	const filePerm = 0640
-	return os.WriteFile(c.path, raw, filePerm)
+	return os.WriteFile(c.path, indented.Bytes(), filePerm)
 }

--- a/pkg/visor/visorconfig/preserve.go
+++ b/pkg/visor/visorconfig/preserve.go
@@ -1,0 +1,430 @@
+//go:build !tinygo
+
+// Package visorconfig pkg/visor/visorconfig/preserve.go c3-vis-core
+//
+// Unknown-key preservation for the config read-modify-write cycle.
+//
+// The visor loads skywire-config.json into the typed V1 struct and
+// later re-marshals that struct back over the same file (Common.flush).
+// Anything in the file without a matching struct field never survives
+// that round trip: it is not ignored, it is ERASED. Running an older
+// build for a single restart — routine in the dev loop, and the whole
+// of a downgrade — therefore deletes every setting newer than that
+// binary, along with any third-party or experimental key an operator
+// added by hand.
+//
+// The fix: before overwriting, flush reads the file it is about to
+// replace and walks that JSON against the Go type being marshaled,
+// recording the RESIDUE — the subtrees, at any depth, that have no
+// counterpart field. The marshaled struct is then written with the
+// residue re-attached. Because residue keys are by construction keys
+// the struct does not model, they can never shadow a known key, and
+// clearing a known field still clears it on disk: the struct remains
+// the sole authority for everything it does model.
+//
+// Reading at flush rather than capturing at load is deliberate. The
+// residue then belongs to the file actually being overwritten, so it
+// survives the config being rebuilt in memory or handed a fresh
+// Common (`skywire cli config update` does exactly that, which is
+// where a load-time capture was observed to fall out), and an
+// operator's hand-edit landing while the visor runs is no longer
+// clobbered by the next flush.
+//
+// The alternative — json.RawMessage catch-alls with hand-written
+// Marshal/Unmarshal on V1, HypervisorConfig, WasmServeConf, … — was
+// rejected: it needs a new method pair on every nested block anyone
+// might ever extend, and each one is a fresh chance to get the
+// catch-all wrong. This walk covers every block at once and needs no
+// per-type maintenance.
+//
+// Deliberate omissions:
+//
+//   - retiredKeys. A load-time migration that RENAMES a key (V1's
+//     legacy "dmsgpty" → "pty", see config_compat.go) leaves the old
+//     key looking "unknown". Preserving it would resurrect a key the
+//     migration exists to retire, and leave two copies of the same
+//     block on disk. Such keys are listed below and dropped from the
+//     residue explicitly.
+//
+//   - Types with their own json.Unmarshaler / encoding.TextUnmarshaler
+//     are opaque: their on-disk shape is not their Go shape, so a
+//     field-name walk cannot tell known from unknown inside them.
+//     (Duration, cipher.PubKey, and Launcher.Apps' appsList wrapper.)
+//
+//   - Array elements re-attach by index and only while the flushed
+//     array still has the original length; a resized array drops that
+//     array's residue rather than risk grafting a key onto the wrong
+//     element.
+//
+// A config regenerated from scratch (`skywire cli config gen`,
+// `skywire autoconfig`) does not go through flush at all — those
+// paths build V1 in memory and write it with their own os.WriteFile —
+// so regenerating remains the way to clear genuinely stale keys.
+package visorconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// retiredKeys are JSON keys, given as dot-separated paths from the root
+// of the config, that a load-time migration deliberately consumes and
+// renames away. They read as "unknown" to the walk below but must NOT
+// be preserved: doing so would defeat the migration.
+var retiredKeys = map[string]struct{}{
+	// config_compat.go's V1.UnmarshalJSON reads the legacy "dmsgpty"
+	// block into V1.Pty; marshaling always emits the canonical "pty".
+	"dmsgpty": {},
+}
+
+var (
+	jsonUnmarshalerType = reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
+	textUnmarshalerType = reflect.TypeOf((*interface{ UnmarshalText([]byte) error })(nil)).Elem()
+)
+
+// captureUnknown returns the residue of raw against the Go type t: the
+// parts of the JSON document that t has no field for, at every level of
+// nesting. nil when the document is fully modeled by t (the common
+// case), which makes flush byte-for-byte identical to what it wrote
+// before this file existed.
+//
+// t is the type of the value that will later be marshaled back; its own
+// json.Unmarshaler (V1 has one) is not consulted — only its fields'.
+func captureUnknown(raw []byte, t reflect.Type) any {
+	if t == nil {
+		return nil
+	}
+	return residueOf(raw, t, "")
+}
+
+// residueOf walks one JSON value against one Go type. The result is
+// either nil (nothing unknown below here), a map[string]any for an
+// object, or a []any for an array; leaves are json.RawMessage holding
+// the wholly-unknown subtree verbatim.
+func residueOf(raw json.RawMessage, t reflect.Type, path string) any {
+	t = derefType(t)
+	switch firstByte(raw) {
+	case '{':
+		return objectResidue(raw, t, path)
+	case '[':
+		return arrayResidue(raw, t, path)
+	default:
+		// Scalars have no keys to lose.
+		return nil
+	}
+}
+
+func objectResidue(raw json.RawMessage, t reflect.Type, path string) any {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil
+	}
+
+	switch {
+	case t.Kind() == reflect.Struct:
+		fields := jsonFields(t)
+		out := make(map[string]any, len(obj))
+		for key, val := range obj {
+			sub := join(path, key)
+			ft, known := fields[key]
+			if !known {
+				ft, known = fields[strings.ToLower(key)]
+			}
+			if !known {
+				if _, retired := retiredKeys[sub]; retired {
+					continue
+				}
+				out[key] = val
+				continue
+			}
+			if isOpaque(ft) {
+				continue
+			}
+			if child := residueOf(val, ft, sub); child != nil {
+				out[key] = child
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+
+	case t.Kind() == reflect.Map && t.Key().Kind() == reflect.String:
+		// Every key of a map is modeled by definition; only the values
+		// can hide unknown fields.
+		et := t.Elem()
+		if isOpaque(derefType(et)) {
+			return nil
+		}
+		out := make(map[string]any, len(obj))
+		for key, val := range obj {
+			if child := residueOf(val, et, join(path, key)); child != nil {
+				out[key] = child
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+
+	default:
+		// A JSON object against a Go type that is neither struct nor
+		// string-keyed map (an interface field, say). Nothing to
+		// compare names against; leave it to the marshaler.
+		return nil
+	}
+}
+
+func arrayResidue(raw json.RawMessage, t reflect.Type, path string) any {
+	if k := t.Kind(); k != reflect.Slice && k != reflect.Array {
+		return nil
+	}
+	et := t.Elem()
+	if isOpaque(derefType(et)) {
+		return nil
+	}
+	var arr []json.RawMessage
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return nil
+	}
+	out := make([]any, len(arr))
+	found := false
+	for i, val := range arr {
+		if child := residueOf(val, et, path+"[]"); child != nil {
+			out[i] = child
+			found = true
+		}
+	}
+	if !found {
+		return nil
+	}
+	return out
+}
+
+// mergeUnknown re-attaches residue to freshly marshaled JSON, returning
+// compact JSON for the caller to indent. Known keys keep their order and
+// their marshaled bytes; residue keys are appended, sorted, at the end of
+// the object they came from. A nil residue returns marshaled untouched.
+func mergeUnknown(marshaled []byte, residue any) ([]byte, error) {
+	if residue == nil {
+		return marshaled, nil
+	}
+	var buf bytes.Buffer
+	if err := writeMerged(&buf, marshaled, residue); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func writeMerged(buf *bytes.Buffer, val json.RawMessage, residue any) error {
+	switch res := residue.(type) {
+	case map[string]any:
+		return writeMergedObject(buf, val, res)
+	case []any:
+		return writeMergedArray(buf, val, res)
+	default:
+		buf.Write(val)
+		return nil
+	}
+}
+
+func writeMergedObject(buf *bytes.Buffer, val json.RawMessage, res map[string]any) error {
+	dec := json.NewDecoder(bytes.NewReader(val))
+	tok, err := dec.Token()
+	if err != nil || tok != json.Delim('{') {
+		// The field no longer marshals as an object; its residue no
+		// longer has anywhere to attach. Drop it rather than guess.
+		buf.Write(val)
+		return nil //nolint:nilerr // shape change is not an error, just a dropped residue
+	}
+
+	used := make(map[string]bool, len(res))
+	buf.WriteByte('{')
+	first := true
+	for dec.More() {
+		kt, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		key, _ := kt.(string)
+		var sub json.RawMessage
+		if err := dec.Decode(&sub); err != nil {
+			return err
+		}
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		if err := writeKey(buf, key); err != nil {
+			return err
+		}
+		child, ok := res[key]
+		if !ok {
+			buf.Write(sub)
+			continue
+		}
+		used[key] = true
+		// A key present in BOTH the marshaled struct and the residue
+		// means the struct models it after all (a case-insensitive
+		// match, say): the struct wins, and its bytes are written
+		// unchanged. Only a nested residue descends.
+		switch child.(type) {
+		case map[string]any, []any:
+			if err := writeMerged(buf, sub, child); err != nil {
+				return err
+			}
+		default:
+			buf.Write(sub)
+		}
+	}
+	if _, err := dec.Token(); err != nil {
+		return err
+	}
+
+	leftover := make([]string, 0, len(res))
+	for key, child := range res {
+		if used[key] {
+			continue
+		}
+		// Only whole-subtree residue can be appended; a nested residue
+		// whose parent key vanished from the marshaled output has
+		// nothing to attach to.
+		if _, ok := child.(json.RawMessage); ok {
+			leftover = append(leftover, key)
+		}
+	}
+	sort.Strings(leftover)
+	for _, key := range leftover {
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		if err := writeKey(buf, key); err != nil {
+			return err
+		}
+		buf.Write(res[key].(json.RawMessage)) //nolint:forcetypeassert // filtered above
+	}
+	buf.WriteByte('}')
+	return nil
+}
+
+func writeMergedArray(buf *bytes.Buffer, val json.RawMessage, res []any) error {
+	var arr []json.RawMessage
+	if err := json.Unmarshal(val, &arr); err != nil || len(arr) != len(res) {
+		// Resized (or no longer an array): re-attaching by index could
+		// graft a key onto the wrong element. Drop the residue.
+		buf.Write(val)
+		return nil //nolint:nilerr // length change is not an error, just a dropped residue
+	}
+	buf.WriteByte('[')
+	for i, el := range arr {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		if res[i] == nil {
+			buf.Write(el)
+			continue
+		}
+		if err := writeMerged(buf, el, res[i]); err != nil {
+			return err
+		}
+	}
+	buf.WriteByte(']')
+	return nil
+}
+
+// writeKey emits key as a JSON object key. Re-encoding through
+// json.Marshal reproduces exactly what the marshaler wrote for a known
+// key, so known keys round-trip byte-for-byte.
+func writeKey(buf *bytes.Buffer, key string) error {
+	b, err := json.Marshal(key)
+	if err != nil {
+		return err
+	}
+	buf.Write(b)
+	buf.WriteByte(':')
+	return nil
+}
+
+// jsonFields maps the JSON names a struct type accepts to the Go types
+// behind them, flattening anonymous embedded structs the way
+// encoding/json does. Lowercased aliases are added for the
+// case-insensitive fallback match encoding/json performs.
+func jsonFields(t reflect.Type) map[string]reflect.Type {
+	out := make(map[string]reflect.Type)
+	collectFields(t, out)
+	return out
+}
+
+func collectFields(t reflect.Type, out map[string]reflect.Type) {
+	t = derefType(t)
+	if t.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		tag := f.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if f.Anonymous && name == "" && derefType(f.Type).Kind() == reflect.Struct {
+			// Embedded struct without an explicit name: its fields are
+			// promoted into this object. (An embedded NON-struct is
+			// encoded under its type name, so it falls through.)
+			collectFields(f.Type, out)
+			continue
+		}
+		if f.PkgPath != "" {
+			// Unexported and not embedded: invisible to encoding/json.
+			continue
+		}
+		if name == "" {
+			name = f.Name
+		}
+		out[name] = f.Type
+		if lower := strings.ToLower(name); lower != name {
+			if _, exists := out[lower]; !exists {
+				out[lower] = f.Type
+			}
+		}
+	}
+}
+
+// isOpaque reports whether a type decodes itself, in which case its
+// on-disk shape need not resemble its Go shape and a field-name walk
+// through it would mistake its own encoding for unknown keys.
+func isOpaque(t reflect.Type) bool {
+	pt := reflect.PointerTo(t)
+	return t.Implements(jsonUnmarshalerType) || pt.Implements(jsonUnmarshalerType) ||
+		t.Implements(textUnmarshalerType) || pt.Implements(textUnmarshalerType)
+}
+
+func derefType(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t
+}
+
+func firstByte(raw json.RawMessage) byte {
+	for _, c := range raw {
+		switch c {
+		case ' ', '\t', '\r', '\n':
+			continue
+		default:
+			return c
+		}
+	}
+	return 0
+}
+
+func join(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}

--- a/pkg/visor/visorconfig/preserve_test.go
+++ b/pkg/visor/visorconfig/preserve_test.go
@@ -1,0 +1,314 @@
+// Package visorconfig pkg/visor/visorconfig/preserve_test.go
+// — pins unknown-key preservation across load → modify → flush.
+package visorconfig
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// writeConf writes body to a temp file and returns its path.
+func writeConf(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "skywire-config.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// loadJSON re-reads a flushed config as a generic tree.
+func loadJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path) //nolint:gosec // test-controlled temp path
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("read back invalid json: %v\n%s", err, b)
+	}
+	return got
+}
+
+// dig walks a decoded JSON tree by key, failing the test if any hop is
+// missing or not an object.
+func dig(t *testing.T, tree map[string]any, keys ...string) map[string]any {
+	t.Helper()
+	for _, k := range keys {
+		next, ok := tree[k]
+		if !ok {
+			t.Fatalf("key %q missing", k)
+		}
+		obj, ok := next.(map[string]any)
+		if !ok {
+			t.Fatalf("key %q is %T, want object", k, next)
+		}
+		tree = obj
+	}
+	return tree
+}
+
+// TestFlushPreservesUnknownKeys is the regression test for the data
+// loss this file exists to fix: a config key the running binary has no
+// field for must survive a load → modify → flush cycle, at the top
+// level and at every level of nesting the visor rewrites.
+//
+// The nesting mirrors the real incident — hypervisor.wasm_serve.exec_wasm
+// was added by a newer build, and one restart on an older binary erased
+// it from disk. Here `future_setting` stands in for any such key.
+func TestFlushPreservesUnknownKeys(t *testing.T) {
+	path := writeConf(t, `{
+	"version": "v1.3.29",
+	"future_setting": "top-level",
+	"cli_addr": "localhost:3435",
+	"routing": {"min_hops": 1},
+	"hypervisor": {
+		"enable": true,
+		"http_addr": ":8000",
+		"future_setting": {"nested": true},
+		"wasm_serve": {
+			"addr": ":8009",
+			"exec_wasm": "/usr/local/bin/skywire.wasm"
+		}
+	}
+}`)
+
+	conf, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	// Modify a known field, exactly as a running visor does.
+	if err := conf.UpdateMinHops(3); err != nil {
+		t.Fatalf("UpdateMinHops (flush): %v", err)
+	}
+
+	got := loadJSON(t, path)
+
+	if got["future_setting"] != "top-level" {
+		t.Errorf("top-level unknown key lost: %v", got["future_setting"])
+	}
+	hv := dig(t, got, "hypervisor")
+	if nested, ok := hv["future_setting"].(map[string]any); !ok || nested["nested"] != true {
+		t.Errorf("hypervisor.future_setting lost: %v", hv["future_setting"])
+	}
+	// wasm_serve.exec_wasm is unknown to THIS binary only if the field
+	// has not landed yet; either way it must still be on disk.
+	ws := dig(t, got, "hypervisor", "wasm_serve")
+	if ws["exec_wasm"] != "/usr/local/bin/skywire.wasm" {
+		t.Errorf("hypervisor.wasm_serve.exec_wasm lost: %v", ws["exec_wasm"])
+	}
+	// The modification itself must have landed, and known keys must
+	// still be intact.
+	if hv["http_addr"] != ":8000" {
+		t.Errorf("known nested key corrupted: http_addr = %v", hv["http_addr"])
+	}
+	routing := dig(t, got, "routing")
+	if routing["min_hops"] != float64(3) {
+		t.Errorf("min_hops = %v, want 3", routing["min_hops"])
+	}
+}
+
+// TestFlushDoesNotResurrectClearedKnownFields: preserving unknown keys
+// must not make KNOWN keys sticky. Clearing a field the struct models
+// still clears it on disk.
+func TestFlushDoesNotResurrectClearedKnownFields(t *testing.T) {
+	path := writeConf(t, `{
+	"version": "v1.3.29",
+	"reward_address": "2fF1FoQ6BAgvNzn8jVBAe6xHFHiGPYRJPZ",
+	"routing": {"min_hops": 1}
+}`)
+
+	conf, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	conf.RewardAddress = "" // omitempty: drops out of the marshaled form
+	if err := conf.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if got := loadJSON(t, path); got["reward_address"] != nil {
+		t.Errorf("cleared known field was resurrected: %v", got["reward_address"])
+	}
+}
+
+// TestFlushDoesNotResurrectRetiredKeys: the legacy "dmsgpty" key is
+// consumed by a rename migration (config_compat.go). Preserving
+// unknown keys must not defeat that migration by writing the retired
+// key back alongside its canonical replacement.
+func TestFlushDoesNotResurrectRetiredKeys(t *testing.T) {
+	path := writeConf(t, `{
+	"version": "v1.3.29",
+	"dmsgpty": {"dmsg_port": 22, "ssh_listen": ":2022"}
+}`)
+
+	conf, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if conf.Pty == nil || conf.Pty.SshListen != ":2022" {
+		t.Fatalf("legacy dmsgpty key did not migrate into V1.Pty")
+	}
+	if err := conf.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	got := loadJSON(t, path)
+	if _, ok := got["dmsgpty"]; ok {
+		t.Error("retired key dmsgpty was written back, defeating the rename migration")
+	}
+	if _, ok := got["pty"]; !ok {
+		t.Error("canonical key pty missing after flush")
+	}
+}
+
+// TestFlushUnchangedWithoutUnknownKeys: a config fully modeled by this
+// binary must flush to exactly the bytes json.MarshalIndent produces,
+// so the merge changes nothing for the overwhelmingly common case.
+func TestFlushUnchangedWithoutUnknownKeys(t *testing.T) {
+	path := writeConf(t, `{"version": "v1.3.29", "cli_addr": "localhost:3435"}`)
+
+	conf, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if err := conf.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	want, err := json.MarshalIndent(conf, "", "\t")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	got, err := os.ReadFile(path) //nolint:gosec // test-controlled temp path
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("flushed bytes differ from MarshalIndent output\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestFlushPreservesUnknownKeysInsideArrays: unknown keys inside array
+// elements re-attach by index while the array keeps its length, and are
+// dropped rather than misplaced when it does not.
+func TestFlushPreservesUnknownKeysInsideArrays(t *testing.T) {
+	const body = `{
+	"version": "v1.3.29",
+	"coin_nodes": [
+		{"coin": "skycoin", "addr": "127.0.0.1:6420", "future_setting": 1},
+		{"coin": "mdl", "addr": "127.0.0.1:6421"}
+	]
+}`
+	path := writeConf(t, body)
+	conf, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if err := conf.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	nodes, ok := loadJSON(t, path)["coin_nodes"].([]any)
+	if !ok || len(nodes) != 2 {
+		t.Fatalf("coin_nodes not an array of 2: %v", nodes)
+	}
+	first, ok := nodes[0].(map[string]any)
+	if !ok {
+		t.Fatalf("coin_nodes[0] is %T", nodes[0])
+	}
+	if first["future_setting"] != float64(1) {
+		t.Errorf("unknown key inside array element lost: %v", first["future_setting"])
+	}
+
+	// Resized array: the residue can no longer be placed safely, so it
+	// is dropped — but nothing else may break.
+	path = writeConf(t, body)
+	conf, err = ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	conf.CoinNodes = conf.CoinNodes[:1]
+	if err := conf.Flush(); err != nil {
+		t.Fatalf("Flush after resize: %v", err)
+	}
+	if nodes, ok := loadJSON(t, path)["coin_nodes"].([]any); !ok || len(nodes) != 1 {
+		t.Fatalf("coin_nodes after resize: %v", nodes)
+	}
+}
+
+// TestFlushWithNoPriorFile: a config synthesized in memory (config gen,
+// STDIN) has no residue and must still write cleanly to a path that
+// does not exist yet.
+func TestFlushWithNoPriorFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "new-config.json")
+	_, sk := cipher.GenerateKeyPair()
+	cc, err := NewCommon(nil, path, &sk)
+	if err != nil {
+		t.Fatalf("NewCommon: %v", err)
+	}
+	conf := MakeBaseConfig(cc, false, true, nil, nil)
+	if err := conf.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if _, err := ReadFile(path); err != nil {
+		t.Fatalf("flushed config does not load back: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o640 {
+		t.Errorf("config file mode = %o, want 640 (it holds the secret key)", perm)
+	}
+}
+
+// TestCaptureUnknownOnInvalidJSON: a malformed document must not panic
+// the walk; it simply yields no residue.
+func TestCaptureUnknownOnInvalidJSON(t *testing.T) {
+	for _, body := range []string{"", "{not json", "[]", "null", `"scalar"`} {
+		if res := captureUnknown([]byte(body), reflect.TypeOf(V1{})); res != nil {
+			t.Errorf("captureUnknown(%q) = %#v, want nil", body, res)
+		}
+	}
+}
+
+// TestFlushPreservesUnknownKeysAfterCommonSwap: `skywire cli config
+// update` re-points the config at a fresh Common before flushing (see
+// initUpdate in cmd/skywire-cli/commands/config/update.go), so the
+// preserved keys cannot be carried on the loaded struct — they have to
+// come from the file being overwritten. Pins that.
+func TestFlushPreservesUnknownKeysAfterCommonSwap(t *testing.T) {
+	path := writeConf(t, `{
+	"version": "v1.3.29",
+	"future_setting": "top-level",
+	"routing": {"min_hops": 1},
+	"hypervisor": {"enable": true, "wasm_serve": {"addr": ":8009", "exec_wasm": "/x.wasm"}}
+}`)
+
+	conf, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	cc, err := NewCommon(nil, path, &conf.SK)
+	if err != nil {
+		t.Fatalf("NewCommon: %v", err)
+	}
+	conf.Common = cc
+	if err := conf.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	got := loadJSON(t, path)
+	if got["future_setting"] != "top-level" {
+		t.Errorf("top-level unknown key lost after Common swap: %v", got["future_setting"])
+	}
+	if ws := dig(t, got, "hypervisor", "wasm_serve"); ws["exec_wasm"] != "/x.wasm" {
+		t.Errorf("nested unknown key lost after Common swap: %v", ws["exec_wasm"])
+	}
+}


### PR DESCRIPTION
`Common.flush` re-marshals the typed `V1` struct over `skywire-config.json`, so any key the running binary has no field for is not ignored — it is erased. Restarting a visor once on a build that predates a config field deletes that setting from disk; a downgrade discards every forward setting at once, and operator- or third-party-added keys go the same way. I hit this twice on `hypervisor.wasm_serve.exec_wasm` (from an open PR) and had to re-apply it by hand both times, but the field is incidental: the loss is general and happens at every level of nesting.

`flush` now performs a real read-modify-write. It reads the file it is about to overwrite, walks that JSON against the Go type being marshaled, and re-attaches the subtrees with no counterpart field. Residue keys are by construction ones the struct does not model, so they can never shadow a known key, and clearing a known field still clears it on disk — the struct stays the sole authority for everything it models. Reading at flush rather than capturing at load keeps the residue attached to the file actually being written, which matters because `cli config update` hands the config a fresh `Common` before flushing.

Keys that a load-time migration deliberately retires are excluded by name, so this cannot resurrect the legacy `dmsgpty` block that the rename in `config_compat.go` exists to consume — there is a test for that. Types that decode themselves (`Duration`, `cipher.PubKey`, the `appsList` wrapper) stay opaque, and array residue re-attaches by index only while the array keeps its length. A config with nothing unknown in it flushes to byte-identical output, the file mode stays 0640, and `config gen` / `autoconfig` write with their own `os.WriteFile`, so regenerating remains the way to clear genuinely stale keys.

Verified with a real round trip beyond the unit tests: `config gen` a config, hand-add unknown keys at the top level, inside `hypervisor`, and inside `hypervisor.wasm_serve`, then `cli config update --set-minhop 2`. All three survive and every other key is unchanged.