### PR TITLE
fix(deployment): gzip the routers that were left out

### DIFF
--- a/pkg/deployment/ar/api/api.go
+++ b/pkg/deployment/ar/api/api.go
@@ -264,6 +264,9 @@ func New(log *logging.Logger, s store.Store, nonceStore httpauth.NonceStore,
 	r.Use(middleware.RealIP) //nolint:staticcheck
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+	// gzip JSON responses on the wire — this router is also served over
+	// dmsg, where every byte is relayed. Matches rf/ut/sd.
+	r.Use(middleware.Compress(5))
 	if enableMetrics {
 		r.Use(api.reqsInFlightCountMiddleware.Handle)
 		r.Use(metricsutil.RequestDurationMiddleware)

--- a/pkg/deployment/conf/api/api.go
+++ b/pkg/deployment/conf/api/api.go
@@ -109,6 +109,9 @@ func New(log *logging.Logger, conf Config, domain, dmsgAddr string) *API {
 	r.Use(middleware.RealIP) //nolint:staticcheck
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+	// gzip JSON responses on the wire — this router is also served over
+	// dmsg, where every byte is relayed. Matches rf/ut/sd.
+	r.Use(middleware.Compress(5))
 	r.Use(httputil.SetLoggerMiddleware(log))
 	r.Get("/health", api.health)
 	r.Get("/", api.config)

--- a/pkg/deployment/monitor/api/api.go
+++ b/pkg/deployment/monitor/api/api.go
@@ -104,6 +104,8 @@ func New(s store.Store, logger *logging.Logger, urls ServicesURLs, config Networ
 		middleware.RealIP, //nolint:staticcheck
 		middleware.Logger,
 		middleware.Recoverer,
+		// gzip JSON responses on the wire. Matches rf/ut/sd.
+		middleware.Compress(5),
 		httputil.SetLoggerMiddleware(logger),
 	)
 	r.Get("/status", api.getStatus)

--- a/pkg/deployment/tpd/api/api.go
+++ b/pkg/deployment/tpd/api/api.go
@@ -141,6 +141,9 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
 	r.Use(middleware.RealIP) //nolint:staticcheck
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+	// gzip JSON responses on the wire — this router is also served over
+	// dmsg, where every byte is relayed. Matches rf/ut/sd.
+	r.Use(middleware.Compress(5))
 	if enableMetrics {
 		r.Use(api.reqsInFlightCountMiddleware.Handle)
 		r.Use(metricsutil.RequestDurationMiddleware)

--- a/pkg/dmsg/discovery/api/api.go
+++ b/pkg/dmsg/discovery/api/api.go
@@ -149,6 +149,9 @@ func New(log logrus.FieldLogger, db store.Storer, m metrics.Metrics, testMode, e
 	r.Use(middleware.RealIP) //nolint:staticcheck
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+	// gzip JSON responses on the wire — this router is also served over
+	// dmsg, where every byte is relayed. Matches rf/ut/sd.
+	r.Use(middleware.Compress(5))
 	if enableMetrics {
 		r.Use(api.reqsInFlightCountMiddleware.Handle)
 		r.Use(metricsutil.RequestDurationMiddleware)


### PR DESCRIPTION
rf, ut and sd got `middleware.Compress` in #3975. tpd, ar, dmsg-discovery, conf and monitor did not — and all five serve unbounded JSON lists over dmsg as well as TCP, where every byte is relayed. The dmsg HTTP transport auto-negotiates gzip and inflates transparently (`pkg/dmsg/dmsghttp/http_transport.go:128`), so those clients are already asking for it.

Measured on the live deployment:

| endpoint | raw | gzip (6) |
|---|---|---|
| tpd `/uptimes` | 110,968 | 43,085 |
| ar `/transports` | 190,806 | 107,078 |

TPD's hand-rolled pre-gzipped `/all-transports` path is unaffected: it sets `Content-Encoding` before `WriteHeader`, which is exactly the case chi's middleware skips.