### PR TITLE
fix(desk): stop booting two idle Go/wasm runtimes nobody asked for

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -14,6 +14,8 @@ import (
 var (
 	serveAddr         string
 	serveHarness      bool
+	serveHelpTerminal bool
+	serveDocsPort     int
 	serveTLS          bool
 	serveTLSCert      string
 	serveTLSKey       string
@@ -30,6 +32,8 @@ var (
 func init() {
 	serveCmd.Flags().StringVarP(&serveAddr, "addr", "a", ":7999", "HTTP listen address")
 	serveCmd.Flags().BoolVar(&serveHarness, "harness", false, "mount the /ctl/* operator control bridge (drive the in-tab visor from a shell); DEV ONLY — never expose publicly")
+	serveCmd.Flags().BoolVar(&serveHelpTerminal, "desk-help-terminal", false, "open a desk terminal that has already run 'skywire --help' — costs a whole extra Go/wasm runtime of the full binary, and that memory is never returned")
+	serveCmd.Flags().IntVar(&serveDocsPort, "desk-docs-port", 0, "run 'skywire doc serve' on this desk vnet port (0 = off) — same cost as above")
 	serveCmd.Flags().BoolVar(&serveTLS, "tls", false, "serve over HTTPS with a self-signed localhost cert (a real https origin for local testing — wss works, ws:// is mixed-content-blocked exactly as in prod). Accept the browser cert warning once; the cert is persisted across restarts")
 	serveCmd.Flags().StringVar(&serveTLSCert, "tls-cert", "", "PEM cert to serve TLS with instead of the self-signed localhost cert — e.g. a locally-trusted *.mesh.localhost cert (mkcert) so real-origin browse iframes load without a per-host accept. Requires --tls-key")
 	serveCmd.Flags().StringVar(&serveTLSKey, "tls-key", "", "PEM key paired with --tls-cert")
@@ -80,6 +84,8 @@ page never asks anyone to type a secret key.`,
 			TLSCert:          serveTLSCert,
 			TLSKey:           serveTLSKey,
 			Harness:          serveHarness,
+			DeskHelpTerminal: serveHelpTerminal,
+			DeskDocsPort:     serveDocsPort,
 			Wallet:           serveWallet,
 			Variant:          serveVariant,
 			Password:         servePassword,

--- a/pkg/visor/hypervisor_desk_test.go
+++ b/pkg/visor/hypervisor_desk_test.go
@@ -165,7 +165,7 @@ func TestDeskShellHTMLWasmMode(t *testing.T) {
 		`<script src="/wasm_exec.js?variant=go"></script>`+"\n"+
 			`<script src="/browse.js"></script>`+"\n"+
 			`<script src="/desk-boot.js"></script>`,
-		deskWasmBootOpts))
+		deskWasmBootOpts(false, 0)))
 	for _, want := range []string{
 		"deskWasmURL: '/wasm-visor.wasm'",
 		"wasmURL: '/skywire.wasm'",

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -645,6 +645,8 @@ func run(parentCtx context.Context, conf *visorconfig.V1) error {
 				Variant:          ws.Variant,
 				Password:         ws.Password,
 				ExecWasmPath:     ws.ExecWasm,
+				DeskHelpTerminal: ws.DeskHelpTerminal,
+				DeskDocsPort:     ws.DeskDocsPort,
 				BrowseSuffix:     ws.BrowseSuffix,
 				BrowseOriginAddr: ws.BrowseOriginAddr,
 				VOrigin:          ws.VOrigin,

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -137,6 +137,14 @@ type WasmServeConf struct {
 	//   GOOS=js GOARCH=wasm go build -tags "withoutsystray withoutgotop" \
 	//     -trimpath -ldflags "-s -w" -o build/skywire.wasm .
 	ExecWasm string `json:"exec_wasm,omitempty"`
+	// DeskHelpTerminal opens a second desk terminal that has already run
+	// `skywire --help`. Off by default: it is a whole extra Go/wasm runtime of
+	// the full binary, and that memory is never returned to the browser. See
+	// pkg/visor.deskWasmBootOpts for the measurement.
+	DeskHelpTerminal bool `json:"desk_help_terminal,omitempty"`
+	// DeskDocsPort runs `skywire doc serve` on this virtual-loopback port of the
+	// desk. 0 (the default) = off, for the same reason.
+	DeskDocsPort int `json:"desk_docs_port,omitempty"`
 	// BrowseSuffix is the real-origin browser's browse-origin domain suffix
 	// (leading dot); empty = ".mesh.localhost".
 	BrowseSuffix string `json:"browse_suffix,omitempty"`

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -81,6 +81,13 @@ type WasmServeConfig struct {
 	//   GOOS=js GOARCH=wasm go build -tags "withoutsystray withoutgotop" \
 	//     -trimpath -ldflags "-s -w" -o build/skywire.wasm .
 	ExecWasmPath string
+	// DeskHelpTerminal opens a second terminal that has already run
+	// `skywire --help`. Off by default: it costs a whole extra Go/wasm runtime
+	// of the full binary, permanently — see deskWasmBootOpts.
+	DeskHelpTerminal bool
+	// DeskDocsPort runs `skywire doc serve` on this virtual-loopback port.
+	// 0 (default) = off, for the same reason.
+	DeskDocsPort int
 	Log          *logging.Logger // nil → package default
 }
 
@@ -338,7 +345,7 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 			`<script src="/wasm_exec.js?variant=go"></script>`+"\n"+
 				`<script src="/browse.js"></script>`+"\n"+
 				`<script src="/desk-boot.js"></script>`,
-			deskWasmBootOpts)
+			deskWasmBootOpts(cfg.DeskHelpTerminal, cfg.DeskDocsPort))
 		if cfg.Harness {
 			// Same rule as injectWasmBoot on the standalone page: --harness
 			// injects ctl-bridge.js (its presence IS the harness signal). On
@@ -977,21 +984,36 @@ func browseSWAssetType(p string) string {
 	return "text/javascript"
 }
 
-// deskWasmBootOpts is the skywireDeskBoot options object for the wasm-served
-// desk (`hv serve --exec-wasm`'s /desk): the tab as a Linux host. Assets come
-// from the routes ServeWasm already exposes: /browse.js is the full desk
-// bundle, /wasm-visor.wasm the desk host (raw), /skywire.wasm the command
+// deskWasmBootOpts renders the skywireDeskBoot options object for the
+// wasm-served desk (`hv serve --exec-wasm`'s /desk): the tab as a Linux host.
+// Assets come from the routes ServeWasm already exposes: /browse.js is the full
+// desk bundle, /wasm-visor.wasm the desk host (raw), /skywire.wasm the command
 // module, /wasm_exec.js?variant=go the matching loader.
-const deskWasmBootOpts = `{
+//
+// helpTerminal and the docs server are OFF unless asked for, because each one
+// is a whole extra Go/wasm runtime of the full skywire binary and that memory
+// never comes back. Measured on a live desk: three instances — `autoconfig`,
+// `doc serve` and an already-EXITED `--help` — held a 1.3 GB renderer, of which
+// the JS heap was 27 MB; a forced GC returned 36 MB. WebAssembly.Memory only
+// ever grows and Go's wasm runtime never hands pages back, so every instance's
+// peak becomes a permanent floor for the tab, and exiting does not release it.
+//
+// The visor is worth that cost. A terminal whose sole content is the output of
+// `skywire --help`, printed once and then exited, is not — and the docs are a
+// server that most sessions never open. Both stay available on request.
+func deskWasmBootOpts(helpTerminal bool, docsPort int) string {
+	return fmt.Sprintf(`{
   persistDB: 'skywire-desk',
   deskWasmURL: '/wasm-visor.wasm',
   wasmURL: '/skywire.wasm',
   wasmExecURL: '/wasm_exec.js?variant=go',
   winboxURL: '/winbox.wasm',
   autostartVisor: true,
-  helpTerminal: true,
+  helpTerminal: %t,
+  docsPort: %d,
   hvWindow: true,
-}`
+}`, helpTerminal, docsPort)
+}
 
 // deskShellTemplate is the shared skeleton of the converged desk page (/desk):
 // boot overlay + error capture + the skywireDeskBoot call. ONE skeleton behind


### PR DESCRIPTION
The wasm-served desk booted **three** instances of the full skywire binary: `autoconfig` (the visor), `doc serve`, and a terminal whose entire purpose was to have run `skywire --help` once.

Measured on a live desk via CDP — three instances, JS heap **27 MB**, renderer RSS **1.3 GB**, and a forced `HeapProfiler.collectGarbage` + `Memory.forciblyPurgeJavaScriptMemory` returned only 36 MB. So it is not garbage; it is live wasm linear memory.

`WebAssembly.Memory` only ever grows and Go's wasm runtime never hands pages back, so every instance's peak becomes a permanent floor for the tab — and exiting does not release it. The `--help` instance had already exited cleanly (`exitInfo {code:0}`) and was still fully resident.

The visor earns that cost. A help screen printed once, and a docs server most sessions never open, do not. Both become opt-in: `desk_help_terminal` / `desk_docs_port` in the config's `wasm_serve` block, and `--desk-help-terminal` / `--desk-docs-port` on `hv serve`. `autostartVisor` and `hvWindow` are unchanged.

`docsPort` was already respected by `desk-boot.js` (`opts.docsPort === 0` disables); it simply had no way to reach it from either serving path. Build, `pkg/visor` tests and golangci-lint clean.