### PR TITLE
fix(visorconfig): the flush test asserted POSIX permissions on Windows

### DIFF
--- a/pkg/visor/visorconfig/preserve_test.go
+++ b/pkg/visor/visorconfig/preserve_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -262,6 +263,14 @@ func TestFlushWithNoPriorFile(t *testing.T) {
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("stat: %v", err)
+	}
+	// Windows has no POSIX mode bits: Go synthesizes them from the read-only
+	// attribute, so Perm() reports 0666 (or 0444) whatever mode WriteFile was
+	// given, and 0640 can never hold. The rest of this test — that a config
+	// flushes and loads back when no prior file exists — is meaningful on every
+	// platform, so only the permission assertion is skipped.
+	if runtime.GOOS == "windows" {
+		return
 	}
 	if perm := info.Mode().Perm(); perm != 0o640 {
 		t.Errorf("config file mode = %o, want 640 (it holds the secret key)", perm)


### PR DESCRIPTION
`TestFlushWithNoPriorFile` asserts the flushed config is `0640`, because that file holds the visor's secret key. **Windows has no POSIX mode bits** — Go synthesizes `Perm()` from the read-only attribute and reports `0666` whatever mode `WriteFile` was given — so on Windows that assertion can never hold. The `windows` job has been red since #4611 landed.

The rest of the test (a config with no prior file flushes and loads back) is meaningful on every platform, so only the permission assertion is skipped, with the reason in a comment.

Verified: passes on linux, and `GOOS=windows go vet ./pkg/visor/visorconfig/` is clean. I cannot run the windows job locally — only CI can confirm it goes green.