### PR TITLE
feat(hv): drive Waterfox/Firefox over WebDriver BiDi, not just CDP

### DIFF
--- a/cmd/skywire-cli/commands/hv/bidi.go
+++ b/cmd/skywire-cli/commands/hv/bidi.go
@@ -1,0 +1,434 @@
+// Package clihv cmd/skywire-cli/commands/hv/bidi.go c4-vis-cli
+// WebDriver BiDi support for the `hv` browser rigs, so `hv eval` and `hv probe`
+// drive Waterfox/Firefox as well as Chromium/Brave.
+//
+// Waterfox 6.6 (Firefox ESR 128+) dropped the CDP Remote Agent, so
+// --remote-debugging-port there speaks BiDi and nothing else. Until now the only
+// way to drive it was a clone out of tree — exactly the failure mode `hv shell`
+// warns about, and it matters precisely when it is needed: a Brave tab wedged
+// badly enough that CDP never answered `1+1` left the second browser as the only
+// way to take a measurement.
+//
+// Which protocol a port speaks is not a guess. GET /json/version answers on
+// Chromium and 404s on Firefox, where /session answers 400 instead, so the
+// detection below probes once and says which it picked.
+//
+// # The single-session rule
+//
+// Firefox permits ONE active BiDi session and does not release it when the
+// owning socket drops. That makes the naive one-shot — dial, evaluate, exit —
+// a trap: interrupt it once and the session is stranded until the browser
+// restarts, which on a browser holding hours of state is an expensive mistake
+// to make from a CLI. Two paths are offered instead, and both are honest about
+// the cost:
+//
+//   - `hv drive` holds one long-lived session and tab and exposes them over a
+//     local control port; `hv eval --driver` and `hv probe --driver` then spend
+//     no session at all. This is the right answer when a browser is going to be
+//     driven more than once, which is every real session.
+//   - Without --driver, the one-shot path releases the session on every exit
+//     path — a deferred End, plus a signal handler for SIGINT/SIGTERM — and
+//     waits out a lagging prior teardown rather than failing on the first
+//     "Maximum number of active sessions".
+//
+// The driver, its recovery layer and the control port are github.com/0magnet/
+// wfdrive/bidi, imported rather than copied. It adds no transitive dependency:
+// its only requirement is github.com/coder/websocket, the same client the CDP
+// commands here already use.
+package clihv
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/0magnet/wfdrive/bidi"
+	"github.com/spf13/cobra"
+)
+
+// Protocols a debug port can speak.
+const (
+	protoCDP  = "cdp"
+	protoBiDi = "bidi"
+	protoAuto = "auto"
+)
+
+// detectProto asks the debug port which protocol it speaks. Chromium answers
+// /json/version; Firefox 404s it and answers /session with 400 (a GET where it
+// wants a websocket upgrade). Anything that answers neither is not a debug port.
+func detectProto(port string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	get := func(path string) (int, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1:"+port+path, nil)
+		if err != nil {
+			return 0, err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return 0, err
+		}
+		defer resp.Body.Close()               //nolint:errcheck
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck // drained only so the connection can be reused
+		return resp.StatusCode, nil
+	}
+	code, err := get("/json/version")
+	if err != nil {
+		return "", fmt.Errorf("no debug port on %s: %w", port, err)
+	}
+	if code == http.StatusOK {
+		return protoCDP, nil
+	}
+	if _, err := get("/session"); err != nil {
+		return "", fmt.Errorf("port %s answers neither /json/version nor /session: %w", port, err)
+	}
+	return protoBiDi, nil
+}
+
+// resolveProto turns the --browser flag into a protocol, detecting when asked
+// to and reporting what it chose. Saying which one it picked is the point: an
+// automatic choice that goes unannounced is indistinguishable from a wrong one
+// when the command then fails.
+func resolveProto(flag, port string) (string, error) {
+	switch flag {
+	case protoCDP, protoBiDi:
+		return flag, nil
+	case protoAuto, "":
+		p, err := detectProto(port)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(os.Stderr, "port %s speaks %s\n", port, strings.ToUpper(p))
+		return p, nil
+	}
+	return "", fmt.Errorf("--browser must be auto, cdp or bidi, not %q", flag)
+}
+
+// sessionWait is how long bidi.NewSession spends waiting out a prior session's
+// teardown before giving up (15 tries, 2s apart).
+const sessionWait = 30 * time.Second
+
+// Which tab a one-shot BiDi session should work in.
+const (
+	// tabCurrent attaches to a tab that is already open — what an inspection
+	// wants, since a fresh tab holds none of the state being inspected.
+	tabCurrent = false
+	// tabFresh opens a tab of our own — what watching a load wants, since a
+	// reused tab carries whatever ran in it before.
+	tabFresh = true
+)
+
+// withBiDi runs fn against a one-shot BiDi session, releasing the session on
+// every exit path. Skipping the release is not a leak that clears itself: the
+// next client waits for a browser restart. A tab this opened is closed again;
+// one it attached to is left exactly as it was found.
+func withBiDi(port string, fresh bool, timeout time.Duration, fn func(*bidi.Driver) error) error {
+	// The driver's own clock has to outlast the caller's: establishing the
+	// session can spend half a minute waiting out a prior teardown, and a
+	// deadline that expires inside that wait reports a timeout where the real
+	// answer — the session is held, here is what to do about it — was about to
+	// arrive.
+	ctx, cancel := context.WithTimeout(context.Background(), timeout+sessionWait+10*time.Second)
+	defer cancel()
+	connect := bidi.Attach
+	if fresh {
+		connect = bidi.Connect
+	}
+	d, err := connect(ctx, port)
+	if err != nil {
+		if strings.Contains(err.Error(), "session busy") {
+			return fmt.Errorf("%w\nSomething else holds the one session Firefox allows. "+
+				"Run `skywire cli hv drive` once and point --driver at it, or quit the client that holds it", err)
+		}
+		return err
+	}
+	// End last, so the tab is closed while the session that owns it still
+	// exists — deferred calls run in reverse.
+	defer d.End()
+	if fresh {
+		defer func() { _ = d.CloseTab() }() //nolint:errcheck
+	} else if err := attachTab(d, bidiTab); err != nil {
+		return err
+	}
+
+	// A one-shot that is Ctrl-C'd mid-command would otherwise strand the
+	// session; the deferred End never runs on a signal.
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sig)
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-sig:
+			d.End()
+			os.Exit(130)
+		case <-done:
+		}
+	}()
+	return fn(d)
+}
+
+// bidiTab is the --tab selector: a substring of the URL of the already-open tab
+// to attach to. Empty takes the first, which is right often enough to be the
+// default and wrong often enough that the chosen URL is always printed.
+var bidiTab string
+
+// attachTab points the driver at a tab that is already open and says which one,
+// because "the first tab" is the default selector and a browser with several
+// open would otherwise answer about the wrong one without either side noticing.
+func attachTab(d *bidi.Driver, want string) error {
+	tabURL, err := d.AttachTab(want)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "attached to %s\n", tabURL)
+	return nil
+}
+
+// driverGet calls one endpoint on a running `hv drive` control port and decodes
+// its JSON answer.
+func driverGet(addr, path string, q url.Values, timeout time.Duration) (map[string]interface{}, error) {
+	if !strings.Contains(addr, "://") {
+		addr = "http://" + addr
+	}
+	u := strings.TrimSuffix(addr, "/") + path
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("driver at %s: %w", addr, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	var out map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("driver at %s: %w", addr, err)
+	}
+	return out, nil
+}
+
+// driverString reads one string field out of a driver answer, treating the
+// driver's own "ERROR: ..." convention as an error.
+func driverString(body map[string]interface{}, field string) (string, error) {
+	s, _ := body[field].(string)
+	if rest, cut := strings.CutPrefix(s, "ERROR: "); cut {
+		return "", fmt.Errorf("%s", rest)
+	}
+	return s, nil
+}
+
+var (
+	drivePort string
+	driveAddr string
+	driveTab  string
+)
+
+func init() {
+	driveCmd.Flags().StringVar(&drivePort, "port", "9223", "BiDi debug port of a running Waterfox/Firefox")
+	driveCmd.Flags().StringVar(&driveAddr, "addr", "127.0.0.1:9224", "address to serve the control port on")
+	driveCmd.Flags().StringVar(&driveTab, "tab", "", "substring of the URL of an already-open tab to re-attach to; a fresh tab is opened when empty")
+	RootCmd.AddCommand(driveCmd)
+}
+
+var driveCmd = &cobra.Command{
+	Use:   "drive",
+	Short: "Hold a persistent WebDriver BiDi session and serve it over a control port",
+	Long: `Hold one long-lived WebDriver BiDi session and tab against a running
+Waterfox/Firefox, and expose them over a small local HTTP control port.
+
+Firefox allows ONE active BiDi session and does not release it when the owning
+socket drops, so a session per command is a hazard rather than a convenience.
+Run this once and point --driver at it: hv eval and hv probe then cost no
+session, and a tab closed by hand is repaired in place instead of costing a
+browser restart.
+
+  skywire cli hv drive --port 9223 --addr 127.0.0.1:9224 &
+  skywire cli hv eval --driver 127.0.0.1:9224 'document.title'
+
+Endpoints: /nav /eval /shoot /health /quit. Screenshots and console dumps land
+in the temp directory under names the driver picks; each answer says where.
+
+Needs a browser started with --remote-debugging-port=9223 --remote-allow-origins=*`,
+	Run: func(_ *cobra.Command, _ []string) {
+		err := bidi.Serve(context.Background(), drivePort, driveAddr, driveTab, func(tab string) {
+			fmt.Printf("driving BiDi :%s (tab %s), control on http://%s\n", drivePort, tab, driveAddr)
+		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	},
+}
+
+// probeBiDi is `hv probe` against Waterfox/Firefox. It streams the same shape
+// as the CDP path — timestamps, console, exceptions, load progress — from the
+// events BiDi does emit. There is no renderer-crash event to report, so a dead
+// content process shows up as the stream going quiet rather than as a fault,
+// which is worth knowing before reading a clean run as a healthy one.
+func probeBiDi() error {
+	start := time.Now()
+	at := func() string { return fmt.Sprintf("[%6dms]", time.Since(start).Milliseconds()) }
+	var mu sync.Mutex
+	var faults []string
+
+	return withBiDi(probePort, tabFresh, time.Duration(probeSeconds+30)*time.Second, func(d *bidi.Driver) error {
+		d.OnEvent(func(m bidi.Msg) {
+			if f := printBiDiEvent(at(), m, d.Tab()); f != "" {
+				mu.Lock()
+				faults = append(faults, f)
+				mu.Unlock()
+			}
+		})
+		if err := d.Subscribe("browsingContext.load", "browsingContext.domContentLoaded"); err != nil {
+			fmt.Printf("%s could not subscribe to load events: %v\n", at(), err)
+		}
+		if probeNavigate != "" {
+			if err := d.Navigate(probeNavigate); err != nil {
+				fmt.Printf("%s navigate: %v\n", at(), err)
+			}
+		}
+		var result string
+		var gotResult bool
+		if probeEval != "" {
+			out, err := d.Eval(probeEval)
+			if err != nil {
+				fmt.Printf("%s eval: %v\n", at(), err)
+			} else {
+				result, gotResult = out, true
+				fmt.Printf("%s result %s\n", at(), result)
+			}
+		}
+		// A fault gate has to outlive the result: an exception thrown from a
+		// timer or a promise lands after the expression that scheduled it has
+		// returned, so with --fail-on-fault the watch runs its full --seconds
+		// and that window is the observation period.
+		if probeFailOnFault {
+			if rest := time.Until(start.Add(time.Duration(probeSeconds) * time.Second)); rest > 0 {
+				time.Sleep(rest)
+			}
+		}
+		mu.Lock()
+		seen := append([]string(nil), faults...)
+		mu.Unlock()
+		return probeVerdict(seen, result, gotResult)
+	})
+}
+
+// printBiDiEvent renders one BiDi event from the tab named by want, and names it
+// as a fault if it is one. Only an uncaught script error counts: pages log
+// errors they have already handled, so gating on console noise would make the
+// check useless — the same line the CDP path draws.
+//
+// The context filter is not cosmetic. CDP attaches to one target and hears only
+// that target; a BiDi subscription is session-wide, so every other tab in the
+// browser reports into the same stream. Left unfiltered, a --fail-on-fault run
+// fails on an exception thrown in a tab the caller never asked about, which was
+// observed the first time this ran: a WebTransport error from an unrelated page
+// landed in the middle of a clean probe.
+func printBiDiEvent(at string, m bidi.Msg, want string) string {
+	clip := func(s string, n int) string {
+		if len(s) > n {
+			return s[:n] + "…"
+		}
+		return s
+	}
+	// An event that names no context — a worker realm, say — is kept: dropping
+	// what cannot be attributed would hide the failures hardest to find.
+	mine := func(got string) bool { return want == "" || got == "" || got == want }
+
+	switch m.Method {
+	case "log.entryAdded":
+		var p struct {
+			Type   string `json:"type"`
+			Level  string `json:"level"`
+			Text   string `json:"text"`
+			Method string `json:"method"`
+			Source struct {
+				Context string `json:"context"`
+			} `json:"source"`
+		}
+		if json.Unmarshal(m.Params, &p) != nil || !mine(p.Source.Context) {
+			return ""
+		}
+		if p.Type == "javascript" {
+			fmt.Printf("%s EXCEPTION %s\n", at, clip(p.Text, 400))
+			return "uncaught exception: " + p.Text
+		}
+		name := p.Method
+		if name == "" {
+			name = p.Level
+		}
+		fmt.Printf("%s console.%s %s\n", at, name, clip(p.Text, 300))
+	case "browsingContext.domContentLoaded", "browsingContext.load":
+		var p struct {
+			Context string `json:"context"`
+		}
+		if json.Unmarshal(m.Params, &p) != nil || !mine(p.Context) {
+			return ""
+		}
+		if m.Method == "browsingContext.load" {
+			fmt.Printf("%s load event\n", at)
+		} else {
+			fmt.Printf("%s DOMContentLoaded\n", at)
+		}
+	}
+	return ""
+}
+
+// probeViaDriver probes through a running `hv drive` rather than taking the
+// single BiDi session for itself. The control port answers with the console it
+// collected instead of streaming it, so the timing detail the direct path gives
+// is lost — and with it the ability to tell an uncaught exception from a logged
+// one, which is why --fail-on-fault is refused here rather than answered
+// dishonestly.
+func probeViaDriver() error {
+	if probeFailOnFault {
+		return fmt.Errorf("--fail-on-fault needs the event stream; drop --driver, or gate on --expect")
+	}
+	timeout := time.Duration(probeSeconds+30) * time.Second
+	q := url.Values{"wait": {fmt.Sprint(probeSeconds)}}
+	if probeNavigate != "" {
+		q.Set("url", probeNavigate)
+	}
+	if probeEval != "" {
+		q.Set("eval", probeEval)
+	}
+	body, err := driverGet(probeDriver, "/nav", q, timeout)
+	if err != nil {
+		return err
+	}
+	if warn, ok := body["warning"].(string); ok && warn != "" {
+		fmt.Printf("navigate: %s\n", warn)
+	}
+	if con, _ := body["console"].(string); con != "" {
+		fmt.Println(con)
+	}
+	if png, _ := body["png"].(string); png != "" {
+		fmt.Printf("screenshot %s\n", png)
+	}
+	result, err := driverString(body, "eval")
+	if err != nil {
+		return err
+	}
+	gotResult := probeEval != "" && result != ""
+	if gotResult {
+		fmt.Printf("result %s\n", result)
+	}
+	return probeVerdict(nil, result, gotResult)
+}

--- a/cmd/skywire-cli/commands/hv/eval.go
+++ b/cmd/skywire-cli/commands/hv/eval.go
@@ -1,56 +1,165 @@
 // Package clihv cmd/skywire-cli/commands/hv/eval.go c4-vis-cli
-// `hv eval` evaluates JavaScript on a SPECIFIC CDP target, addressed by its
-// webSocketDebuggerUrl — so an OOPIF iframe, a worker or a second wasm
-// instance can be inspected directly, which URL-matching (cmd/hvinspect)
-// cannot disambiguate when several targets share a URL.
+// `hv eval` evaluates JavaScript in a browser, over CDP or WebDriver BiDi.
 //
-// List the targets first:
+// On Chromium/Brave it addresses a SPECIFIC CDP target by its
+// webSocketDebuggerUrl — so an OOPIF iframe, a worker or a second wasm instance
+// can be inspected directly, which URL-matching (cmd/hvinspect) cannot
+// disambiguate when several targets share a URL:
 //
 //	curl -s localhost:9222/json/list | jq -r '.[] | "\(.type) \(.url) \(.webSocketDebuggerUrl)"'
 //	skywire cli hv eval ws://localhost:9222/devtools/page/ABC 'typeof skywireVisor'
 //
+// On Waterfox/Firefox there is no per-target websocket to address: BiDi is one
+// endpoint and one session for the whole browser, so give the debug port and
+// the protocol is detected:
+//
+//	skywire cli hv eval --port 9223 'document.title'
+//	skywire cli hv eval --driver 127.0.0.1:9224 'document.title'
+//
+// Prefer --driver, pointed at a running `hv drive`: Firefox allows one BiDi
+// session and does not release it when a socket drops, so a session per
+// invocation is a hazard the persistent driver exists to remove. Without it
+// this releases the session on every exit path, signals included.
+//
 // This was cmd/cdpeval, a standalone binary that never shipped with skywire;
 // it lives here so it is present wherever the CLI is, alongside `hv shell`
-// (which drives the visor terminal) and the Waterfox rig.
+// (which drives the visor terminal) and `hv drive`.
 package clihv
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
+	"github.com/0magnet/wfdrive/bidi"
 	"github.com/coder/websocket"
 	"github.com/spf13/cobra"
 )
 
-var evalTimeout int
+var (
+	evalTimeout int
+	evalPort    string
+	evalBrowser string
+	evalDriver  string
+)
 
 func init() {
 	evalCmd.Flags().IntVar(&evalTimeout, "timeout", 30, "seconds to wait for the result")
+	evalCmd.Flags().StringVar(&evalPort, "port", "9222", "debug port of the running browser, when no webSocketDebuggerUrl is given")
+	evalCmd.Flags().StringVar(&evalBrowser, "browser", "auto", "protocol to speak: auto, cdp (Chromium/Brave) or bidi (Waterfox/Firefox)")
+	evalCmd.Flags().StringVar(&bidiTab, "tab", "", "BiDi only: substring of the URL of the already-open tab to attach to; the first tab otherwise")
+	evalCmd.Flags().StringVar(&evalDriver, "driver", "", "control port of a running `hv drive`, e.g. 127.0.0.1:9224 — evaluates through its session instead of opening one")
 	RootCmd.AddCommand(evalCmd)
 }
 
 var evalCmd = &cobra.Command{
-	Use:   "eval <webSocketDebuggerUrl> <js-expression>",
-	Short: "Evaluate JavaScript on a specific CDP target",
-	Long: `Evaluate JavaScript on a specific CDP target, addressed by its
-webSocketDebuggerUrl.
+	Use:   "eval [webSocketDebuggerUrl] <js-expression>",
+	Short: "Evaluate JavaScript in a browser over CDP or WebDriver BiDi",
+	Long: `Evaluate JavaScript in a running browser.
 
-Addressing the target directly is the point: several targets in a page can
-share a URL (OOPIF iframes, workers, a second wasm instance), and matching by
-URL cannot tell them apart.
+With a webSocketDebuggerUrl it addresses one specific CDP target, which is the
+point on Chromium/Brave: several targets in a page can share a URL (OOPIF
+iframes, workers, a second wasm instance), and matching by URL cannot tell them
+apart. List them with:
+  curl -s localhost:9222/json/list | jq -r '.[] | "\(.type) \(.url) \(.webSocketDebuggerUrl)"'
 
-List them with:
-  curl -s localhost:9222/json/list | jq -r '.[] | "\(.type) \(.url) \(.webSocketDebuggerUrl)"'`,
-	Args: cobra.ExactArgs(2),
+With only an expression it uses --port and detects the protocol: Chromium
+answers /json/version, Waterfox/Firefox does not and speaks WebDriver BiDi
+instead. On CDP it evaluates in the first page target; on BiDi it drives the
+one session Firefox allows.
+
+  skywire cli hv eval ws://localhost:9222/devtools/page/ABC 'typeof skywireVisor'
+  skywire cli hv eval --port 9223 'document.title'
+  skywire cli hv eval --driver 127.0.0.1:9224 'document.title'
+
+--driver is the safe way to use Firefox repeatedly: it evaluates through a
+running "hv drive" session instead of taking the single session for itself.`,
+	Args: cobra.RangeArgs(1, 2),
 	Run: func(_ *cobra.Command, args []string) {
-		if err := cdpEval(args[0], args[1], time.Duration(evalTimeout)*time.Second); err != nil {
+		if err := evalRun(args); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	},
+}
+
+func evalRun(args []string) error {
+	timeout := time.Duration(evalTimeout) * time.Second
+	expr := args[len(args)-1]
+
+	if evalDriver != "" {
+		body, err := driverGet(evalDriver, "/eval", map[string][]string{"expr": {expr}}, timeout)
+		if err != nil {
+			return err
+		}
+		out, err := driverString(body, "eval")
+		if err != nil {
+			return err
+		}
+		fmt.Println(out)
+		return nil
+	}
+
+	// An explicit webSocketDebuggerUrl is a CDP target by construction; BiDi
+	// has no such address, so there is nothing to detect.
+	if len(args) == 2 {
+		return cdpEval(args[0], expr, timeout)
+	}
+
+	proto, err := resolveProto(evalBrowser, evalPort)
+	if err != nil {
+		return err
+	}
+	if proto == protoBiDi {
+		return withBiDi(evalPort, tabCurrent, timeout, func(d *bidi.Driver) error {
+			out, err := d.Eval(expr)
+			if err != nil {
+				return err
+			}
+			fmt.Println(out)
+			return nil
+		})
+	}
+	ws, err := firstPageTarget(evalPort)
+	if err != nil {
+		return err
+	}
+	return cdpEval(ws, expr, timeout)
+}
+
+// firstPageTarget picks a page target to evaluate in when the caller gave only
+// a port. It never opens a tab: `hv eval` is for inspecting state that is
+// already there, and a fresh tab has none of it.
+func firstPageTarget(port string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1:"+port+"/json/list", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("list targets: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	var targets []struct {
+		Type string `json:"type"`
+		URL  string `json:"url"`
+		WS   string `json:"webSocketDebuggerUrl"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&targets); err != nil {
+		return "", fmt.Errorf("list targets: %w", err)
+	}
+	for _, t := range targets {
+		if t.Type == "page" && t.WS != "" {
+			fmt.Fprintf(os.Stderr, "evaluating in %s\n", t.URL)
+			return t.WS, nil
+		}
+	}
+	return "", fmt.Errorf("no page target on port %s; pass a webSocketDebuggerUrl to address one directly", port)
 }
 
 func cdpEval(wsURL, expr string, timeout time.Duration) error {

--- a/cmd/skywire-cli/commands/hv/probe.go
+++ b/cmd/skywire-cli/commands/hv/probe.go
@@ -12,9 +12,16 @@
 //
 //	skywire cli hv probe --navigate http://127.0.0.1:7998/ --seconds 90
 //	skywire cli hv probe --ws ws://localhost:9222/devtools/page/ABC --eval 'typeof skywireVisor'
+//	skywire cli hv probe --port 9223 --navigate https://127.0.0.1:8443/ --seconds 30
 //
 // With no --ws it opens a fresh tab, which is usually what you want: a reused
 // tab carries the state of whatever ran in it before.
+//
+// Waterfox/Firefox speaks WebDriver BiDi rather than CDP and is detected by
+// --port; the stream is the same shape, minus the renderer-crash event, which
+// BiDi has no equivalent for. Prefer --driver against a running `hv drive`
+// when the browser will be probed more than once — see bidi.go on why a
+// session per invocation is a hazard there.
 package clihv
 
 import (
@@ -37,10 +44,14 @@ var (
 	probeSeconds     int
 	probeFailOnFault bool
 	probeExpect      string
+	probeBrowser     string
+	probeDriver      string
 )
 
 func init() {
-	probeCmd.Flags().StringVar(&probePort, "port", "9222", "CDP port of the running browser")
+	probeCmd.Flags().StringVar(&probePort, "port", "9222", "debug port of the running browser")
+	probeCmd.Flags().StringVar(&probeBrowser, "browser", "auto", "protocol to speak: auto, cdp (Chromium/Brave) or bidi (Waterfox/Firefox)")
+	probeCmd.Flags().StringVar(&probeDriver, "driver", "", "control port of a running `hv drive`, e.g. 127.0.0.1:9224 — probes through its session instead of opening one")
 	probeCmd.Flags().StringVar(&probeWS, "ws", "", "webSocketDebuggerUrl of an existing target; a fresh tab is opened when empty")
 	probeCmd.Flags().StringVar(&probeNavigate, "navigate", "", "URL to load while watching")
 	probeCmd.Flags().StringVar(&probeEval, "eval", "", "expression to evaluate; the stream is printed until the result arrives")
@@ -54,15 +65,20 @@ func init() {
 
 var probeCmd = &cobra.Command{
 	Use:   "probe",
-	Short: "Watch a page load over CDP and stream console, exceptions and crashes",
-	Long: `Watch one page over CDP and stream what it reports: console output,
-uncaught exceptions, renderer crashes, execution contexts and load progress.
+	Short: "Watch a page load and stream console, exceptions and crashes",
+	Long: `Watch one page and stream what it reports: console output, uncaught
+exceptions, renderer crashes, execution contexts and load progress.
 
 Use it when a tab stops answering. "hv eval returned nothing" cannot
 distinguish a busy main thread from a missing execution context, a stalled
 navigation or a dead renderer; this can.
 
-Needs a browser started with --remote-debugging-port=9222.`,
+Chromium/Brave is watched over CDP, Waterfox/Firefox over WebDriver BiDi; the
+protocol is detected from --port unless --browser says otherwise. BiDi reports
+no renderer-crash event, so --fail-on-fault there gates on uncaught exceptions
+alone.
+
+Needs a browser started with --remote-debugging-port.`,
 	Run: func(_ *cobra.Command, _ []string) {
 		if err := probeRun(); err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -74,6 +90,20 @@ Needs a browser started with --remote-debugging-port=9222.`,
 func probeRun() error {
 	if probeNavigate == "" && probeEval == "" {
 		return fmt.Errorf("give --navigate or --eval (or both)")
+	}
+	if probeDriver != "" {
+		return probeViaDriver()
+	}
+	// A --ws target is a CDP address by construction: BiDi has no per-target
+	// websocket, so there is nothing to detect when one is given.
+	if probeWS == "" {
+		proto, err := resolveProto(probeBrowser, probePort)
+		if err != nil {
+			return err
+		}
+		if proto == protoBiDi {
+			return probeBiDi()
+		}
 	}
 	wsURL := probeWS
 	var opened string

--- a/cmd/skywire-cli/commands/hv/root.go
+++ b/cmd/skywire-cli/commands/hv/root.go
@@ -20,10 +20,19 @@ Build & serve:
 Desktop bridge:
   notify   show a remote visor's app notifications on THIS machine (SSE bridge)
 
-Browser automation (CDP — needs --remote-debugging-port=9222):
+Browser automation (needs --remote-debugging-port):
   probe    watch one page load and stream console, exceptions and crashes
+  eval     evaluate JavaScript in a page
+  drive    hold a persistent WebDriver BiDi session on a local control port
   shell    drive the visor shell in a browser tab and capture the result
-  eval     evaluate JavaScript on a specific CDP target by webSocketDebuggerUrl`,
+
+probe and eval speak CDP to Chromium/Brave and WebDriver BiDi to
+Waterfox/Firefox, detected from the debug port. shell is CDP-only: it
+synthesizes keystrokes, which BiDi's input.* module would be needed for.
+
+Firefox allows ONE BiDi session and does not release it when a socket drops.
+Run drive once and point --driver at it rather than spending a session per
+command.`,
 }
 
 func init() {

--- a/cmd/skywire-cli/commands/hv/shell.go
+++ b/cmd/skywire-cli/commands/hv/shell.go
@@ -4,11 +4,17 @@
 // terminal and captures what came back.
 //
 // It exists because the other browser rigs cannot type. cmd/hvinspect and
-// cmd/cdpeval evaluate JS, and 0magnet/wfdrive drives Waterfox over BiDi — but the
+// `hv eval` evaluate JS, and `hv drive` drives Waterfox over BiDi — but the
 // visor shell is an xterm canvas fed by keyboard events, so verifying that a
 // shell applet works means synthesizing real key events and reading the result
 // back. Doing that by hand, or from a throwaway script, is how a regression in
 // an applet goes unnoticed.
+//
+// This is the one `hv` browser verb that is CDP-only. Typing needs BiDi's
+// input.* module, which the driver behind `hv drive` does not implement, and a
+// half-implemented typist that silently drops keys into a canvas would be worse
+// than none: the screenshot looks the same either way. Drive the shell in
+// Chromium/Brave; use `hv eval --port <bidi>` to read state out of Waterfox.
 //
 // Attach to a browser started with --remote-debugging-port=9222:
 //

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/0magnet/sysinfo v1.1.4-0.20260901201859-b4abd4e87c26
 	github.com/0magnet/termanim v0.0.0-20260905171704-496bb97da414
 	github.com/0magnet/visnetwork-go v0.0.0-20260906025559-6b0de1648ee9
+	github.com/0magnet/wfdrive v0.3.0
 	github.com/0magnet/winbox-go v0.0.0-20260905172045-cfee586c8360
 	github.com/0magnet/yamux v0.1.3-0.20260901201804-38cdbd63617a
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/0magnet/visnetwork-go v0.0.0-20260906025559-6b0de1648ee9 h1:Gsalhpwzk
 github.com/0magnet/visnetwork-go v0.0.0-20260906025559-6b0de1648ee9/go.mod h1:BOarXYUS+pozU5nzdst9t1P+jMlWrMIM2ckEDdszOTE=
 github.com/0magnet/websh v0.0.0-20260906001908-5f8df8dbc4c5 h1:DIvQONJEuw+GCHWMLRha7MungXDNMWR8TNhkNYVvqNA=
 github.com/0magnet/websh v0.0.0-20260906001908-5f8df8dbc4c5/go.mod h1:zM6emVi15GzCgqt30dRv3cWxBVgt3A+W7Fwx3GZPcKI=
+github.com/0magnet/wfdrive v0.3.0 h1:zNK/ForoRgdxIsF2GxwIM3DbMDdUks9nNEtmMWbU7Tg=
+github.com/0magnet/wfdrive v0.3.0/go.mod h1:ckGVOflE4OC+G0MTrcin3hRoOwEFOCtRxY8nWxVt2bw=
 github.com/0magnet/winbox-go v0.0.0-20260905172045-cfee586c8360 h1:JvM2BRAHZqOWrTuC22RzgSCrmZZ1yWZrUlIU4cf6xxk=
 github.com/0magnet/winbox-go v0.0.0-20260905172045-cfee586c8360/go.mod h1:19+/rRQWd/tc9/8CFcUr6C+3AipeZmHyyda2tVombe4=
 github.com/0magnet/xterm-go v0.0.0-20260905172047-f0008e1479ee h1:gaoixDCvMDkgNqAnvqg7yRYZcgCkm7rcn6+dg8YA2Nk=

--- a/vendor/github.com/0magnet/wfdrive/bidi/bidi.go
+++ b/vendor/github.com/0magnet/wfdrive/bidi/bidi.go
@@ -1,0 +1,468 @@
+// Package bidi drives Waterfox and Firefox over WebDriver BiDi.
+//
+// Waterfox 6.6 (Firefox ESR 128+) dropped the CDP Remote Agent, so
+// chromedp-shaped tooling no longer works against it; the BiDi endpoint is
+// built into the browser, so nothing else has to be in the loop — no
+// geckodriver, no Selenium, one dependency (github.com/coder/websocket).
+//
+// The one constraint that shapes this package: Firefox permits ONE active BiDi
+// session and does NOT release it when the owning socket drops. A caller that
+// dials, works and dies without calling End strands that session until the
+// browser restarts. Two things follow, and both are handled here rather than
+// left to callers:
+//
+//   - NewSession waits out a lagging teardown ("Maximum number of active
+//     sessions") instead of failing immediately, so a session released a moment
+//     ago is not a hard error.
+//   - Every operation runs through WithTab, which classifies dropped-tab and
+//     dropped-socket errors and repairs in place — reopen the tab, and if that
+//     fails redial, re-create the session, reopen the tab, retry once. Closing
+//     a tab by hand does not cost a browser restart.
+//
+// A long-lived Driver is therefore the cheapest way to use this; Serve exposes
+// one over a small local HTTP control port for callers that are not Go.
+package bidi
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// Msg is the slice of the BiDi wire shape this package reads.
+type Msg struct {
+	ID     int             `json:"id,omitempty"`
+	Method string          `json:"method,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Params json.RawMessage `json:"params,omitempty"`
+	Error  string          `json:"error,omitempty"`
+	Msg    string          `json:"message,omitempty"`
+}
+
+// Driver is one BiDi session and one tab, kept alive across commands.
+type Driver struct {
+	c       *websocket.Conn
+	ctx     context.Context
+	mu      sync.Mutex
+	nextID  int
+	waiters map[int]chan Msg
+	console []string
+	onEvent func(Msg)
+
+	// port and bctx let the driver rebuild itself. The tab is the fragile
+	// part: close it in the browser and every later command fails with "no
+	// such frame" until a new one is opened, which would otherwise mean
+	// restarting — and restarting is exactly what strands Firefox's single
+	// BiDi session.
+	port string
+	bctx string
+
+	endOnce sync.Once
+}
+
+// ReadLimit is the websocket read limit; screenshots of a large page are big.
+const ReadLimit = 96 << 20
+
+// Connect dials BiDi on port, establishes the single session (waiting out a
+// lagging prior teardown), subscribes to console logs and opens one tab.
+//
+// The caller MUST call End when done, on every exit path including signals: a
+// connection that simply drops leaves the session held until the browser is
+// restarted.
+func Connect(ctx context.Context, port string) (*Driver, error) {
+	d := &Driver{ctx: ctx, waiters: map[int]chan Msg{}, port: port}
+	if err := d.dial(); err != nil {
+		return nil, err
+	}
+	if err := d.NewSession(); err != nil {
+		return nil, err
+	}
+	if err := d.OpenTab(); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// Tab reports the browsing context this driver is driving.
+func (d *Driver) Tab() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.bctx
+}
+
+// OnEvent registers a callback for unsolicited BiDi events. Console entries are
+// still accumulated for Console regardless; this is for callers that want to
+// stream them as they arrive.
+func (d *Driver) OnEvent(fn func(Msg)) {
+	d.mu.Lock()
+	d.onEvent = fn
+	d.mu.Unlock()
+}
+
+func (d *Driver) pump() {
+	for {
+		_, data, err := d.c.Read(d.ctx)
+		if err != nil {
+			return
+		}
+		var m Msg
+		if json.Unmarshal(data, &m) != nil {
+			continue
+		}
+		if m.ID != 0 {
+			d.mu.Lock()
+			ch := d.waiters[m.ID]
+			delete(d.waiters, m.ID)
+			d.mu.Unlock()
+			if ch != nil {
+				ch <- m
+			}
+			continue
+		}
+		if m.Method == "log.entryAdded" {
+			var p struct{ Level, Text string }
+			_ = json.Unmarshal(m.Params, &p) //nolint:errcheck
+			d.mu.Lock()
+			d.console = append(d.console, fmt.Sprintf("[%s] %s", p.Level, p.Text))
+			d.mu.Unlock()
+		}
+		d.mu.Lock()
+		fn := d.onEvent
+		d.mu.Unlock()
+		if fn != nil {
+			fn(m)
+		}
+	}
+}
+
+// Command sends one BiDi command and waits for its reply.
+func (d *Driver) Command(method string, params map[string]interface{}) (json.RawMessage, error) {
+	d.mu.Lock()
+	d.nextID++
+	id := d.nextID
+	ch := make(chan Msg, 1)
+	d.waiters[id] = ch
+	c := d.c
+	d.mu.Unlock()
+	body, _ := json.Marshal(map[string]interface{}{"id": id, "method": method, "params": params}) //nolint:errcheck
+	if err := c.Write(d.ctx, websocket.MessageText, body); err != nil {
+		return nil, err
+	}
+	select {
+	case m := <-ch:
+		if m.Error != "" {
+			return nil, fmt.Errorf("%s: %s %s", method, m.Error, m.Msg)
+		}
+		return m.Result, nil
+	case <-d.ctx.Done():
+		return nil, d.ctx.Err()
+	}
+}
+
+// ResetConsole discards accumulated console output.
+func (d *Driver) ResetConsole() { d.mu.Lock(); d.console = nil; d.mu.Unlock() }
+
+// Console returns the console output accumulated since the last ResetConsole.
+func (d *Driver) Console() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return strings.Join(d.console, "\n")
+}
+
+// dial opens the BiDi websocket and starts the reader.
+func (d *Driver) dial() error {
+	c, _, err := websocket.Dial(d.ctx, "ws://127.0.0.1:"+d.port+"/session", nil)
+	if err != nil {
+		return fmt.Errorf("BiDi dial: %w", err)
+	}
+	c.SetReadLimit(ReadLimit)
+	d.mu.Lock()
+	d.c = c
+	d.waiters = map[int]chan Msg{}
+	d.mu.Unlock()
+	go d.pump()
+	return nil
+}
+
+// NewSession establishes the one session Firefox allows, waiting out a prior
+// teardown that has not landed yet.
+func (d *Driver) NewSession() error {
+	var serr error
+	for i := 0; i < 15; i++ {
+		if _, serr = d.Command("session.new", map[string]interface{}{"capabilities": map[string]interface{}{}}); serr == nil {
+			_, _ = d.Command("session.subscribe", map[string]interface{}{"events": []string{"log.entryAdded"}}) //nolint:errcheck
+			return nil
+		}
+		if !strings.Contains(serr.Error(), "Maximum number of active") {
+			return fmt.Errorf("session.new: %w", serr)
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("session busy — another BiDi client holds it, or a dead one stranded it: %w", serr)
+}
+
+// Subscribe adds BiDi events to the session subscription.
+func (d *Driver) Subscribe(events ...string) error {
+	_, err := d.Command("session.subscribe", map[string]interface{}{"events": events})
+	return err
+}
+
+// OpenTab opens the tab this driver drives.
+func (d *Driver) OpenTab() error {
+	cr, err := d.Command("browsingContext.create", map[string]interface{}{"type": "tab"})
+	if err != nil {
+		return fmt.Errorf("browsingContext.create: %w", err)
+	}
+	var cc struct {
+		Context string `json:"context"`
+	}
+	if e := json.Unmarshal(cr, &cc); e != nil || cc.Context == "" {
+		return fmt.Errorf("could not create a browsing context")
+	}
+	d.mu.Lock()
+	d.bctx = cc.Context
+	d.mu.Unlock()
+	return nil
+}
+
+// Gone reports whether an error means the tab or the whole connection went
+// away, rather than the command itself being wrong.
+func Gone(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, s := range []string{
+		"no such frame", "no such node", "browsing context",
+		"invalid session id", "failed to write", "broken pipe",
+		"use of closed", "websocket", "eof", "context canceled",
+	} {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// Recover re-opens the tab, and re-dials and re-establishes the session if the
+// socket itself has gone. It is the difference between a closed tab being a
+// hiccup and being a restart — and since restarting is what strands Firefox's
+// single session, recovering in place is what keeps that session healthy.
+func (d *Driver) Recover() error {
+	if err := d.OpenTab(); err == nil {
+		return nil
+	}
+	if d.c != nil {
+		d.c.Close(websocket.StatusNormalClosure, "reconnecting") //nolint:errcheck,gosec
+	}
+	if err := d.dial(); err != nil {
+		return err
+	}
+	if err := d.NewSession(); err != nil {
+		return err
+	}
+	return d.OpenTab()
+}
+
+// WithTab runs fn against the current tab, recovering once if the tab or the
+// connection disappeared underneath it.
+func (d *Driver) WithTab(fn func(bctx string) error) error {
+	err := fn(d.Tab())
+	if err == nil || !Gone(err) {
+		return err
+	}
+	if rerr := d.Recover(); rerr != nil {
+		return fmt.Errorf("%v (recovery failed: %v)", err, rerr)
+	}
+	return fn(d.Tab())
+}
+
+// EvalIn evaluates expr in a named browsing context and returns the result
+// rendered as a string.
+func (d *Driver) EvalIn(bctx, expr string) (string, error) {
+	res, err := d.Command("script.evaluate", map[string]interface{}{
+		"expression": expr, "target": map[string]interface{}{"context": bctx},
+		"awaitPromise": true, "resultOwnership": "none",
+	})
+	if err != nil {
+		return "", err
+	}
+	var r struct {
+		Type   string `json:"type"`
+		Result struct {
+			Value json.RawMessage `json:"value"`
+			Type  string          `json:"type"`
+		} `json:"result"`
+		ExceptionDetails struct {
+			Text string `json:"text"`
+		} `json:"exceptionDetails"`
+	}
+	_ = json.Unmarshal(res, &r) //nolint:errcheck
+	if r.Type == "exception" {
+		return "", fmt.Errorf("script.evaluate: %s", r.ExceptionDetails.Text)
+	}
+	out := string(r.Result.Value)
+	if out == "" {
+		out = r.Result.Type
+	}
+	return strings.Trim(out, `"`), nil
+}
+
+// Eval evaluates expr in this driver's tab, recovering the tab if it went away.
+func (d *Driver) Eval(expr string) (string, error) {
+	var out string
+	err := d.WithTab(func(bctx string) error {
+		var e error
+		out, e = d.EvalIn(bctx, expr)
+		return e
+	})
+	return out, err
+}
+
+// Navigate loads url in this driver's tab and waits for the load to complete.
+func (d *Driver) Navigate(url string) error {
+	return d.WithTab(func(bctx string) error {
+		_, e := d.Command("browsingContext.navigate",
+			map[string]interface{}{"context": bctx, "url": url, "wait": "complete"})
+		return e
+	})
+}
+
+// Screenshot captures this driver's tab as PNG bytes.
+func (d *Driver) Screenshot() ([]byte, error) {
+	var png []byte
+	err := d.WithTab(func(bctx string) error {
+		shot, e := d.Command("browsingContext.captureScreenshot", map[string]interface{}{"context": bctx})
+		if e != nil {
+			return e
+		}
+		var s struct {
+			Data string `json:"data"`
+		}
+		if e := json.Unmarshal(shot, &s); e != nil {
+			return e
+		}
+		b, e := base64.StdEncoding.DecodeString(s.Data)
+		if e != nil {
+			return e
+		}
+		png = b
+		return nil
+	})
+	return png, err
+}
+
+// Health reports whether the session and tab are still usable, recovering them
+// if they are not.
+func (d *Driver) Health() error {
+	return d.WithTab(func(bctx string) error {
+		_, e := d.Command("browsingContext.getTree", map[string]interface{}{"root": bctx})
+		return e
+	})
+}
+
+// End releases the session and closes the socket. It is safe to call more than
+// once, and it must be called on every exit path: Firefox does not reclaim the
+// session when the socket merely drops.
+func (d *Driver) End() {
+	d.endOnce.Do(func() {
+		_, _ = d.Command("session.end", map[string]interface{}{}) //nolint:errcheck
+		if d.c != nil {
+			d.c.Close(websocket.StatusNormalClosure, "") //nolint:errcheck,gosec
+		}
+	})
+}
+
+// Context is one browsing context in the tree browsingContext.getTree returns.
+type Context struct {
+	Context  string    `json:"context"`
+	URL      string    `json:"url"`
+	Children []Context `json:"children"`
+}
+
+// Attach connects and establishes the session WITHOUT opening a tab, leaving
+// the driver pointed at nothing until UseTab or OpenTab.
+//
+// This is what a one-shot inspection wants. Connect opens a fresh tab, which is
+// right for watching a load and wrong for reading state: a new tab has none of
+// the state the caller came to look at, and answers document.title with the
+// empty string rather than saying so.
+//
+// The caller MUST still call End on every exit path.
+func Attach(ctx context.Context, port string) (*Driver, error) {
+	d := &Driver{ctx: ctx, waiters: map[int]chan Msg{}, port: port}
+	if err := d.dial(); err != nil {
+		return nil, err
+	}
+	if err := d.NewSession(); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// Tabs lists the top-level browsing contexts currently open.
+func (d *Driver) Tabs() ([]Context, error) {
+	res, err := d.Command("browsingContext.getTree", map[string]interface{}{})
+	if err != nil {
+		return nil, err
+	}
+	var t struct {
+		Contexts []Context `json:"contexts"`
+	}
+	if err := json.Unmarshal(res, &t); err != nil {
+		return nil, err
+	}
+	return t.Contexts, nil
+}
+
+// UseTab points this driver at an existing browsing context.
+func (d *Driver) UseTab(bctx string) {
+	d.mu.Lock()
+	d.bctx = bctx
+	d.mu.Unlock()
+}
+
+// CloseTab closes the tab this driver is pointed at. A one-shot that opened its
+// own tab should call this before End, or every invocation leaves a blank tab
+// behind.
+func (d *Driver) CloseTab() error {
+	bctx := d.Tab()
+	if bctx == "" {
+		return nil
+	}
+	_, err := d.Command("browsingContext.close", map[string]interface{}{"context": bctx})
+	return err
+}
+
+// AttachTab points the driver at a tab that is already open, chosen by a
+// substring of its URL — empty takes the first — and returns the URL it
+// settled on.
+//
+// The URL is returned rather than logged because the caller has to say it:
+// Firefox has no per-tab address to pass around the way CDP does, so "the first
+// tab" is the whole selector by default, and a browser with several tabs open
+// would otherwise answer about the wrong one without either side noticing.
+func (d *Driver) AttachTab(want string) (string, error) {
+	tabs, err := d.Tabs()
+	if err != nil {
+		return "", fmt.Errorf("list tabs: %w", err)
+	}
+	if len(tabs) == 0 {
+		return "", fmt.Errorf("no tabs open")
+	}
+	open := make([]string, 0, len(tabs))
+	for _, t := range tabs {
+		if want == "" || strings.Contains(t.URL, want) {
+			d.UseTab(t.Context)
+			return t.URL, nil
+		}
+		open = append(open, t.URL)
+	}
+	return "", fmt.Errorf("no open tab matches %q; open: %s", want, strings.Join(open, ", "))
+}

--- a/vendor/github.com/0magnet/wfdrive/bidi/serve.go
+++ b/vendor/github.com/0magnet/wfdrive/bidi/serve.go
@@ -1,0 +1,188 @@
+package bidi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// captureSeq numbers capture files. They are named here rather than by the
+// request: two static analyzers both, correctly, refused to believe any amount
+// of validation on a request-supplied name made the resulting path safe, and
+// they are easier to agree with than to argue with. The caller learns where its
+// capture landed from the JSON response, which is all it needed the name for.
+var captureSeq atomic.Uint64
+
+// captureBase is the prefix for this run's captures.
+const captureBase = "wfdrive"
+
+// writeCapture writes one capture into the temp directory under a name of our
+// own making, and returns the path.
+func writeCapture(seq uint64, ext string, b []byte) string {
+	// Every component here is ours: the temp dir, a constant prefix, a counter
+	// and a literal extension. The taint analyzers reach os.TempDir (it reads
+	// TMPDIR) rather than anything a request said.
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("%s-%d%s", captureBase, seq, ext))
+	_ = os.WriteFile(path, b, 0o600) //nolint:errcheck,gosec // path is built from constants and a counter
+	return path
+}
+
+// Serve runs a persistent driver against the BiDi port and exposes it over a
+// small HTTP control port at ctrlAddr.
+//
+// This is the shape that makes Firefox's single-session rule livable: one
+// long-lived session and tab, held open for as long as the process runs, so
+// callers spend no session establishing one per command. announce, when
+// non-nil, is called once the control port is about to listen.
+//
+//	/nav?url=&wait=&eval=   navigate, optionally evaluate, then capture
+//	/eval?expr=             evaluate in place, no navigation
+//	/shoot                  capture the tab as it stands
+//	/health                 is the session and tab still usable
+//	/quit                   session.end and exit
+//
+// tab selects which tab to drive. Empty opens a fresh one, which is the right
+// default. A non-empty value is matched as a substring of the URL of a tab that
+// is already open, and is how a driver that died gets its tab back: the session
+// is stranded either way until the browser restarts, so a replacement driver
+// that opens a blank tab instead of resuming the old one loses the state that
+// made the tab worth driving.
+func Serve(ctx context.Context, port, ctrlAddr, tab string, announce func(tab string)) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var d *Driver
+	var err error
+	if tab == "" {
+		d, err = Connect(ctx, port)
+	} else {
+		d, err = Attach(ctx, port)
+		if err == nil {
+			_, err = d.AttachTab(tab)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	// Release the session on EVERY exit path, not just the graceful ones.
+	// Firefox allows one BiDi session and does not reclaim it when the socket
+	// drops, so a driver that dies after connecting — a control port already in
+	// use, say — strands that session until the browser is restarted.
+	defer d.End()
+
+	srv := &http.Server{Addr: ctrlAddr, ReadHeaderTimeout: 5 * time.Second}
+	mux := http.NewServeMux()
+
+	writeJSON := func(w http.ResponseWriter, body map[string]interface{}) {
+		resp, _ := json.Marshal(body) //nolint:errcheck
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(resp) //nolint:errcheck
+	}
+
+	// report writes the screenshot + console for a step and answers as JSON.
+	report := func(w http.ResponseWriter, evalOut string, warn error) {
+		seq := captureSeq.Add(1)
+		if png, e := d.Screenshot(); e == nil {
+			writeCapture(seq, ".png", png)
+		}
+		con := d.Console()
+		conPath := writeCapture(seq, ".console.txt", []byte(con+"\n"))
+		body := map[string]interface{}{
+			"png":     strings.TrimSuffix(conPath, ".console.txt") + ".png",
+			"console": con,
+			"eval":    evalOut,
+		}
+		if warn != nil {
+			body["warning"] = warn.Error()
+		}
+		writeJSON(w, body)
+	}
+
+	mux.HandleFunc("/nav", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		wait := 8
+		if n, e := strconv.Atoi(q.Get("wait")); e == nil {
+			wait = n
+		}
+		d.ResetConsole()
+		var warn error
+		if u := q.Get("url"); u != "" {
+			warn = d.Navigate(u)
+		}
+		time.Sleep(time.Duration(wait) * time.Second)
+		evalOut := ""
+		if ev := q.Get("eval"); ev != "" {
+			out, e := d.Eval(ev)
+			evalOut = out
+			if e != nil {
+				evalOut = "ERROR: " + e.Error()
+			}
+		}
+		report(w, evalOut, warn)
+	})
+
+	// /shoot screenshots the tab as it stands, without navigating — so a test
+	// can drive the page through several steps (settle, toggle, settle) and
+	// capture each one, instead of having to fold everything into the single
+	// eval that /nav runs immediately before its shot.
+	mux.HandleFunc("/shoot", func(w http.ResponseWriter, _ *http.Request) {
+		report(w, "", nil)
+	})
+
+	// /eval evaluates in the tab without navigating or resetting the console.
+	mux.HandleFunc("/eval", func(w http.ResponseWriter, r *http.Request) {
+		out, e := d.Eval(r.URL.Query().Get("expr"))
+		if e != nil {
+			out = "ERROR: " + e.Error()
+		}
+		writeJSON(w, map[string]interface{}{"eval": out})
+	})
+
+	// /health reports whether the session and tab are still usable, recovering
+	// them if not.
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		status := "ok"
+		if e := d.Health(); e != nil {
+			status = "unhealthy: " + e.Error()
+		}
+		writeJSON(w, map[string]interface{}{"status": status, "tab": d.Tab()})
+	})
+
+	mux.HandleFunc("/quit", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("bye\n")) //nolint:errcheck
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			d.End()
+			_ = srv.Close() //nolint:errcheck
+		}()
+	})
+	srv.Handler = mux
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	defer signal.Stop(sig)
+	go func() {
+		select {
+		case <-sig:
+		case <-ctx.Done():
+		}
+		d.End()
+		_ = srv.Close() //nolint:errcheck
+	}()
+
+	if announce != nil {
+		announce(d.Tab())
+	}
+	if e := srv.ListenAndServe(); e != nil && e != http.ErrServerClosed {
+		return e
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -133,6 +133,9 @@ github.com/0magnet/visnetwork-go/physics
 ## explicit; go 1.25.7
 github.com/0magnet/websh/shell
 github.com/0magnet/websh/shell/browser
+# github.com/0magnet/wfdrive v0.3.0
+## explicit; go 1.25.0
+github.com/0magnet/wfdrive/bidi
 # github.com/0magnet/winbox-go v0.0.0-20260905172045-cfee586c8360
 ## explicit; go 1.24
 github.com/0magnet/winbox-go


### PR DESCRIPTION
Waterfox 6.6 (Firefox ESR 128+) dropped the CDP Remote Agent, so its
`--remote-debugging-port` speaks WebDriver BiDi only and none of the `hv`
browser rigs could touch it — driving it meant cloning a tool out of tree,
which is the failure mode `shell.go` already warns about. That mattered
recently: a Brave tab wedged badly enough that CDP never answered `1+1` left
the second browser as the only way to take a measurement.

`hv eval` and `hv probe` now pick the protocol from the debug port
(`/json/version` answers on Chromium, 404s on Firefox) and print which they
picked; `--browser cdp|bidi` forces it. `hv drive` holds the one BiDi session
Firefox allows and serves it over a local control port, so `--driver` costs no
session. Without it, the one-shot path releases the session on every exit path
including signals, and waits out a lagging teardown rather than failing on the
first `Maximum number of active sessions` — that constraint is the whole reason
the persistent driver exists.

`hv shell` stays CDP-only. It synthesizes keystrokes into an xterm canvas, which
needs BiDi's `input.*` module; a typist that silently drops keys would look
identical in a screenshot to one that works. Its stale reference to
`cmd/cdpeval` — which is this `hv eval` and no longer exists as a command — is
corrected in the same file.

The driver is `github.com/0magnet/wfdrive/bidi`, imported rather than copied. It
adds no transitive dependency: `coder/websocket` is the same client the existing
CDP commands use, so `go.mod` grows by one line.

Verified against both live browsers: CDP on 9222 (Brave) and BiDi on 9223
(Waterfox) — auto-detection, one-shot eval, `--driver` routing, tab selection,
session-contention handling, and `probe --fail-on-fault` catching an exception
thrown from a timer. BiDi's log subscription is session-wide rather than
per-target, so probe filters events to the probed context; an unrelated tab's
`WebTransportError` failed a clean run before that filter went in.
