### PR TITLE
fix(hv): --driver advertised its type as "hv drive"

### DIFF
--- a/cmd/skywire-cli/commands/hv/eval.go
+++ b/cmd/skywire-cli/commands/hv/eval.go
@@ -51,7 +51,7 @@ func init() {
 	evalCmd.Flags().StringVar(&evalPort, "port", "9222", "debug port of the running browser, when no webSocketDebuggerUrl is given")
 	evalCmd.Flags().StringVar(&evalBrowser, "browser", "auto", "protocol to speak: auto, cdp (Chromium/Brave) or bidi (Waterfox/Firefox)")
 	evalCmd.Flags().StringVar(&bidiTab, "tab", "", "BiDi only: substring of the URL of the already-open tab to attach to; the first tab otherwise")
-	evalCmd.Flags().StringVar(&evalDriver, "driver", "", "control port of a running `hv drive`, e.g. 127.0.0.1:9224 — evaluates through its session instead of opening one")
+	evalCmd.Flags().StringVar(&evalDriver, "driver", "", "control port of a running \"hv drive\", e.g. 127.0.0.1:9224 — evaluates through its session instead of opening one")
 	RootCmd.AddCommand(evalCmd)
 }
 

--- a/cmd/skywire-cli/commands/hv/probe.go
+++ b/cmd/skywire-cli/commands/hv/probe.go
@@ -51,7 +51,7 @@ var (
 func init() {
 	probeCmd.Flags().StringVar(&probePort, "port", "9222", "debug port of the running browser")
 	probeCmd.Flags().StringVar(&probeBrowser, "browser", "auto", "protocol to speak: auto, cdp (Chromium/Brave) or bidi (Waterfox/Firefox)")
-	probeCmd.Flags().StringVar(&probeDriver, "driver", "", "control port of a running `hv drive`, e.g. 127.0.0.1:9224 — probes through its session instead of opening one")
+	probeCmd.Flags().StringVar(&probeDriver, "driver", "", "control port of a running \"hv drive\", e.g. 127.0.0.1:9224 — probes through its session instead of opening one")
 	probeCmd.Flags().StringVar(&probeWS, "ws", "", "webSocketDebuggerUrl of an existing target; a fresh tab is opened when empty")
 	probeCmd.Flags().StringVar(&probeNavigate, "navigate", "", "URL to load while watching")
 	probeCmd.Flags().StringVar(&probeEval, "eval", "", "expression to evaluate; the stream is printed until the result arrives")


### PR DESCRIPTION
Cobra reads backticks in a flag description as the argument placeholder name, so `hv eval --help` printed `--driver hv drive` where it should read `--driver string`. Same fix on `hv probe`.

Follow-up to #4618.