### PR TITLE
fix(hv): the BiDi driver broke the js/wasm root build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/0magnet/sysinfo v1.1.4-0.20260901201859-b4abd4e87c26
 	github.com/0magnet/termanim v0.0.0-20260905171704-496bb97da414
 	github.com/0magnet/visnetwork-go v0.0.0-20260906025559-6b0de1648ee9
-	github.com/0magnet/wfdrive v0.3.0
+	github.com/0magnet/wfdrive v0.3.1
 	github.com/0magnet/winbox-go v0.0.0-20260905172045-cfee586c8360
 	github.com/0magnet/yamux v0.1.3-0.20260901201804-38cdbd63617a
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/0magnet/visnetwork-go v0.0.0-20260906025559-6b0de1648ee9 h1:Gsalhpwzk
 github.com/0magnet/visnetwork-go v0.0.0-20260906025559-6b0de1648ee9/go.mod h1:BOarXYUS+pozU5nzdst9t1P+jMlWrMIM2ckEDdszOTE=
 github.com/0magnet/websh v0.0.0-20260906001908-5f8df8dbc4c5 h1:DIvQONJEuw+GCHWMLRha7MungXDNMWR8TNhkNYVvqNA=
 github.com/0magnet/websh v0.0.0-20260906001908-5f8df8dbc4c5/go.mod h1:zM6emVi15GzCgqt30dRv3cWxBVgt3A+W7Fwx3GZPcKI=
-github.com/0magnet/wfdrive v0.3.0 h1:zNK/ForoRgdxIsF2GxwIM3DbMDdUks9nNEtmMWbU7Tg=
-github.com/0magnet/wfdrive v0.3.0/go.mod h1:ckGVOflE4OC+G0MTrcin3hRoOwEFOCtRxY8nWxVt2bw=
+github.com/0magnet/wfdrive v0.3.1 h1:VKwgCprNRKJtyAO5RQ40yLsYec1QqaeLXykoDV9kT08=
+github.com/0magnet/wfdrive v0.3.1/go.mod h1:ckGVOflE4OC+G0MTrcin3hRoOwEFOCtRxY8nWxVt2bw=
 github.com/0magnet/winbox-go v0.0.0-20260905172045-cfee586c8360 h1:JvM2BRAHZqOWrTuC22RzgSCrmZZ1yWZrUlIU4cf6xxk=
 github.com/0magnet/winbox-go v0.0.0-20260905172045-cfee586c8360/go.mod h1:19+/rRQWd/tc9/8CFcUr6C+3AipeZmHyyda2tVombe4=
 github.com/0magnet/xterm-go v0.0.0-20260905172047-f0008e1479ee h1:gaoixDCvMDkgNqAnvqg7yRYZcgCkm7rcn6+dg8YA2Nk=

--- a/vendor/github.com/0magnet/wfdrive/bidi/serve.go
+++ b/vendor/github.com/0magnet/wfdrive/bidi/serve.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"syscall"
 	"time"
 )
 
@@ -167,7 +166,7 @@ func Serve(ctx context.Context, port, ctrlAddr, tab string, announce func(tab st
 	srv.Handler = mux
 
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	signal.Notify(sig, shutdownSignals...)
 	defer signal.Stop(sig)
 	go func() {
 		select {

--- a/vendor/github.com/0magnet/wfdrive/bidi/signals_js.go
+++ b/vendor/github.com/0magnet/wfdrive/bidi/signals_js.go
@@ -1,0 +1,14 @@
+//go:build js
+
+package bidi
+
+import (
+	"os"
+	"syscall"
+)
+
+// shutdownSignals omits SIGHUP: js/wasm does not define it, and this package is
+// linked into binaries that compile for GOOS=js. Naming it unconditionally
+// broke that build, which is worth a two-file split — the alternative is that
+// embedding a browser driver quietly costs you the wasm target.
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/vendor/github.com/0magnet/wfdrive/bidi/signals_notjs.go
+++ b/vendor/github.com/0magnet/wfdrive/bidi/signals_notjs.go
@@ -1,0 +1,13 @@
+//go:build !js
+
+package bidi
+
+import (
+	"os"
+	"syscall"
+)
+
+// shutdownSignals are the signals a driver must catch to release the BiDi
+// session before the process goes away. Firefox does not reclaim the session
+// when the socket merely drops, so an uncaught signal costs a browser restart.
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGHUP}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -133,7 +133,7 @@ github.com/0magnet/visnetwork-go/physics
 ## explicit; go 1.25.7
 github.com/0magnet/websh/shell
 github.com/0magnet/websh/shell/browser
-# github.com/0magnet/wfdrive v0.3.0
+# github.com/0magnet/wfdrive v0.3.1
 ## explicit; go 1.25.0
 github.com/0magnet/wfdrive/bidi
 # github.com/0magnet/winbox-go v0.0.0-20260905172045-cfee586c8360


### PR DESCRIPTION
js/wasm defines no `syscall.SIGHUP`, and the root binary compiles for GOOS=js to build the playground — so #4618 broke that target the moment it vendored a package naming it. The Docs job caught it: `vendor/github.com/0magnet/wfdrive/bidi/serve.go:170:62: undefined: syscall.SIGHUP`.

wfdrive v0.3.1 splits the signal set per-platform, keeping SIGHUP everywhere it exists. Verified locally with the command CI runs:

    GOOS=js GOARCH=wasm go build -tags "withoutsystray withoutgotop" -trimpath .