### PR TITLE
test(cli): declare hv/bidi.go as streaming for the --json contract

### DIFF
--- a/cmd/skywire-cli/jsoncontract_test.go
+++ b/cmd/skywire-cli/jsoncontract_test.go
@@ -50,6 +50,7 @@ var streamingCommands = map[string]string{
 	"commands/hv/shell.go":                          "drives a browser terminal over CDP; output is a live transcript",
 	"commands/hv/eval.go":                           "prints whatever the page's JS returned; the caller chose the shape",
 	"commands/hv/probe.go":                          "streams CDP events as they arrive, unbounded",
+	"commands/hv/bidi.go":                           "streams BiDi events as they arrive, and hv drive is a control server, not a command that returns a value",
 	"commands/dmsg/curl.go":                         "writes the fetched body, which is the point",
 	"commands/dmsg/iperf.go":                        "a throughput meter; prints intervals as they elapse",
 	"commands/dmsg/probe.go":                        "prints per-port progress while probing",


### PR DESCRIPTION
`TestEveryPrintingCommandHonoursJSON` flags any command file that prints without consulting `--json`. `cmd/skywire-cli/commands/hv/bidi.go`, added in #4618, is two such things: `probeBiDi` streams events as they arrive, and `hv drive` is a control server rather than a command that returns a value — the same ground `shell.go`, `eval.go` and `probe.go` already stand on.

My fault: I read the `make check` log while it was still being written and reported only the `pkg/router` flake, missing this one.