### PR TITLE
fix(build): stamp the buildinfo package that exists

### DIFF
--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -58,7 +58,7 @@ jobs:
           DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           COMMIT="$(git rev-list -1 HEAD)"
           BASE="github.com/skycoin/skywire"
-          UTIL="$BASE/pkg/skywire-utilities/pkg/buildinfo"
+          UTIL="$BASE/pkg/buildinfo"
           # Same stamping as `make build`, plus -s -w to shrink the artifact.
           LDFLAGS="-s -w -X ${UTIL}.version=${VERSION} -X ${UTIL}.date=${DATE} -X ${UTIL}.commit=${COMMIT} -X ${BASE}/pkg/visor.BuildTag=${BRANCH}"
           mkdir -p dist

--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -58,7 +58,7 @@ jobs:
           DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           COMMIT="$(git rev-list -1 HEAD)"
           BASE="github.com/skycoin/skywire"
-          UTIL="$BASE/pkg/buildinfo"
+          UTIL="$BASE/pkg/skywire-utilities/pkg/buildinfo"
           # Same stamping as `make build`, plus -s -w to shrink the artifact.
           LDFLAGS="-s -w -X ${UTIL}.version=${VERSION} -X ${UTIL}.date=${DATE} -X ${UTIL}.commit=${COMMIT} -X ${BASE}/pkg/visor.BuildTag=${BRANCH}"
           mkdir -p dist

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ RFC_3339 := "+%Y-%m-%dT%H:%M:%SZ"
 COMMIT := $(shell git rev-list -1 HEAD)
 
 PROJECT_BASE := github.com/skycoin/skywire
-SKYWIRE_UTILITIES_BASE := github.com/skycoin/skywire/pkg/skywire-utilities
 ifeq ($(OS),Windows_NT)
 	SHELL := pwsh
 	OPTS?=powershell -Command setx GO111MODULE on;
@@ -83,7 +82,7 @@ ifneq (,$(findstring 64,$(GOARCH)))
     TEST_OPTS:=$(TEST_OPTS) -race
 endif
 
-BUILDINFO_PATH := $(SKYWIRE_UTILITIES_BASE)/pkg/buildinfo
+BUILDINFO_PATH := $(PROJECT_BASE)/pkg/buildinfo
 BUILD_PATH := ./build/
 
 BUILDINFO_VERSION := -X $(BUILDINFO_PATH).version=$(VERSION)
@@ -206,9 +205,10 @@ MOBILE_TAGS := mobile,withoutsystray
 # over it so the lite variant can't silently rot or regain the stripped fat.
 ANDROID_MOBILE_MAX_BYTES := 83886080
 
-# Both buildinfo paths are stamped: the visor internals read skywire-utilities'
-# buildinfo ($(BUILDINFO)), but /api/about + cobra --version — what the phone
-# app's info card shows — read the repo-local pkg/buildinfo. That version MUST
+# MOBILE_APPINFO stamps the same symbols as $(BUILDINFO) with the phone's own
+# version. It is listed AFTER $(BUILDINFO) on the ldflags line, and the linker
+# takes the last -X for a symbol, so MOBILE_VERSION wins — which is what
+# /api/about + cobra --version show on the phone's info card. That version MUST
 # parse as semver (visorconfig.Parse semver-checks it and FATALs otherwise), and
 # on a checkout with no reachable tag `git describe --always` is a bare hash —
 # so fall back to a v0.0.0-<sha> pseudo-version.


### PR DESCRIPTION
The version stamp has been landing on nothing.

`Makefile` set `BUILDINFO_PATH := $(SKYWIRE_UTILITIES_BASE)/pkg/buildinfo`, but `pkg/skywire-utilities` was flattened away in #2356 and `github.com/skycoin/skywire-utilities` is not a dependency. `-X` on an unknown symbol is **silently ignored**, so `make build` and the develop-channel publish have been shipping binaries whose version, date and commit are unset, falling back to Go's `debug.BuildInfo` VCS pseudo-version.

Measured both ways on the same tree:

```
-X .../pkg/skywire-utilities/pkg/buildinfo.version=STALE-v9.9.9
  → skywire version v1.3.94-0.-d4120754982a+dirty
-X .../pkg/buildinfo.version=STAMPTEST-v9.9.9
  → skywire version STAMPTEST-v9.9.9
```

The correct path was already present as `SKYWIRE_BUILDINFO_PATH`; line 86 just never used it. `.github/workflows/publish-binary.yml:61` stamped the same dead path.

**Mobile is unaffected.** `MOBILE_APPINFO` already used the correct path and is listed after `$(BUILDINFO)` on the ldflags line, so the linker's last-wins rule still gives it `MOBILE_VERSION`. The comment above it claimed the visor internals read a separate skywire-utilities buildinfo; that was the belief behind the bug, so it is corrected too.

Also drops `SKYWIRE_UTILITIES_BASE`, now unused and naming a package that does not exist.