### PR TITLE
fix(ci): stamp the buildinfo package that still exists

### DIFF
--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -58,7 +58,7 @@ jobs:
           DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           COMMIT="$(git rev-list -1 HEAD)"
           BASE="github.com/skycoin/skywire"
-          UTIL="$BASE/pkg/skywire-utilities/pkg/buildinfo"
+          UTIL="$BASE/pkg/buildinfo"
           # Same stamping as `make build`, plus -s -w to shrink the artifact.
           LDFLAGS="-s -w -X ${UTIL}.version=${VERSION} -X ${UTIL}.date=${DATE} -X ${UTIL}.commit=${COMMIT} -X ${BASE}/pkg/visor.BuildTag=${BRANCH}"
           mkdir -p dist


### PR DESCRIPTION
publish-binary.yml stamps `-X` on `github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo`, a package deleted in #2356. The linker silently ignores a `-X` for a symbol it cannot find, so every rolling develop binary shipped with version, date and commit left at their zero defaults and reported itself as unversioned.

`pkg/buildinfo` is the package the code actually imports. This is the companion to #4623, which fixed the same dead path in the Makefile; it was split out only because the token pushing that branch lacked the `workflow` scope.

Verified empirically on the Makefile half: stale path produced `v1.3.94-0.-d4120754982a+dirty`, the corrected path produced the injected `STAMPTEST-v9.9.9`.