### PR TITLE
perf(cipher): use the pubkey verify cache on the gob path too

### DIFF
--- a/pkg/cipher/cipher.go
+++ b/pkg/cipher/cipher.go
@@ -222,6 +222,31 @@ var (
 
 const pubKeyVerifyCacheMax = 1 << 15
 
+// lookupVerifiedPubKey returns the already-validated key for the exact 33 bytes in
+// data, if secp256k1 has accepted those bytes before. A wrong length is never a
+// hit, so callers still get full validation for anything malformed.
+func lookupVerifiedPubKey(data []byte) (PubKey, bool) {
+	var cand PubKey
+	if len(data) != len(cand) {
+		return cand, false
+	}
+	copy(cand[:], data)
+	pubKeyVerifyMu.RLock()
+	_, ok := pubKeyVerifyCache[cand]
+	pubKeyVerifyMu.RUnlock()
+	return cand, ok
+}
+
+// rememberVerifiedPubKey records a key that secp256k1 has just accepted.
+func rememberVerifiedPubKey(pk PubKey) {
+	pubKeyVerifyMu.Lock()
+	if len(pubKeyVerifyCache) >= pubKeyVerifyCacheMax {
+		pubKeyVerifyCache = make(map[PubKey]struct{}, 1024) // bound growth; re-warms
+	}
+	pubKeyVerifyCache[pk] = struct{}{}
+	pubKeyVerifyMu.Unlock()
+}
+
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (pk *PubKey) UnmarshalText(data []byte) error {
 	if bytes.Count(data, []byte("0")) == len(data) {
@@ -230,13 +255,8 @@ func (pk *PubKey) UnmarshalText(data []byte) error {
 
 	// Fast path: an exact key we've already validated skips the expensive secp256k1
 	// point decompression (PubKeyFromHex → Verify). See pubKeyVerifyCache.
-	var cand PubKey
-	if b, derr := hex.DecodeString(string(data)); derr == nil && len(b) == len(cand) {
-		copy(cand[:], b)
-		pubKeyVerifyMu.RLock()
-		_, ok := pubKeyVerifyCache[cand]
-		pubKeyVerifyMu.RUnlock()
-		if ok {
+	if b, derr := hex.DecodeString(string(data)); derr == nil {
+		if cand, ok := lookupVerifiedPubKey(b); ok {
 			*pk = cand
 			return nil
 		}
@@ -247,12 +267,7 @@ func (pk *PubKey) UnmarshalText(data []byte) error {
 		return err
 	}
 	*pk = PubKey(dPK)
-	pubKeyVerifyMu.Lock()
-	if len(pubKeyVerifyCache) >= pubKeyVerifyCacheMax {
-		pubKeyVerifyCache = make(map[PubKey]struct{}, 1024) // bound growth; re-warms
-	}
-	pubKeyVerifyCache[PubKey(dPK)] = struct{}{}
-	pubKeyVerifyMu.Unlock()
+	rememberVerifiedPubKey(PubKey(dPK))
 	return nil
 }
 
@@ -263,11 +278,25 @@ func (pk PubKey) MarshalBinary() ([]byte, error) {
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
 func (pk *PubKey) UnmarshalBinary(data []byte) error {
-	dPK, err := cipher.NewPubKey(data)
-	if err == nil {
-		*pk = PubKey(dPK)
+	// Fast path, same as UnmarshalText: skip the secp256k1 point decompression for a
+	// key we have already validated. This is the gob path, which net/rpc uses for
+	// every hypervisor-to-visor response — the same ~1000 fleet PKs are decoded out
+	// of every summary several times a minute, and each occurrence was re-validated.
+	// A 30s CPU profile of the dev hypervisor put PubKey.Verify beneath
+	// UnmarshalBinary at 21% of all visor CPU (Field.Sqr alone 18% flat), so this
+	// path matters at least as much as the hex one. See pubKeyVerifyCache.
+	if cand, ok := lookupVerifiedPubKey(data); ok {
+		*pk = cand
+		return nil
 	}
-	return err
+
+	dPK, err := cipher.NewPubKey(data)
+	if err != nil {
+		return err
+	}
+	*pk = PubKey(dPK)
+	rememberVerifiedPubKey(PubKey(dPK))
+	return nil
 }
 
 // PubKeys represents a slice of PubKeys.

--- a/pkg/cipher/pubkey_verify_cache_test.go
+++ b/pkg/cipher/pubkey_verify_cache_test.go
@@ -1,0 +1,85 @@
+// Package cipher pkg/cipher/pubkey_verify_cache_test.go c1-cip-core
+package cipher
+
+import (
+	"bytes"
+	"encoding/gob"
+	"testing"
+)
+
+// TestUnmarshalBinaryRejectsInvalid guards the fast path added for the gob/net-rpc
+// decode: a cache hit must never let a malformed or off-curve key through.
+func TestUnmarshalBinaryRejectsInvalid(t *testing.T) {
+	pk, _ := GenerateKeyPair()
+
+	// Prime the cache with a genuinely valid key.
+	var round PubKey
+	if err := round.UnmarshalBinary(pk[:]); err != nil {
+		t.Fatalf("valid key rejected: %v", err)
+	}
+	if round != pk {
+		t.Fatalf("round-trip mismatch: got %s want %s", round.Hex(), pk.Hex())
+	}
+
+	// A second decode of the same bytes takes the cached path and must agree.
+	var cached PubKey
+	if err := cached.UnmarshalBinary(pk[:]); err != nil {
+		t.Fatalf("cached decode failed: %v", err)
+	}
+	if cached != pk {
+		t.Fatalf("cached decode mismatch: got %s want %s", cached.Hex(), pk.Hex())
+	}
+
+	// Wrong length must still fail rather than silently truncating.
+	var short PubKey
+	if err := short.UnmarshalBinary(pk[:len(pk)-1]); err == nil {
+		t.Fatal("short input accepted")
+	}
+
+	// Right length, not a curve point: flipping the leading prefix byte to a value
+	// that is not 0x02/0x03 must be rejected by secp256k1, cache or no cache.
+	bad := make([]byte, len(pk))
+	copy(bad, pk[:])
+	bad[0] = 0x07
+	var offCurve PubKey
+	if err := offCurve.UnmarshalBinary(bad); err == nil {
+		t.Fatal("non-curve point accepted")
+	}
+}
+
+// TestGobRoundTripPubKey exercises the actual path the fast path was added for.
+func TestGobRoundTripPubKey(t *testing.T) {
+	pk, _ := GenerateKeyPair()
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(&pk); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	var out PubKey
+	if err := gob.NewDecoder(&buf).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out != pk {
+		t.Fatalf("gob round-trip mismatch: got %s want %s", out.Hex(), pk.Hex())
+	}
+}
+
+// BenchmarkUnmarshalBinaryRepeat models the real gob/net-rpc shape: the same small
+// set of fleet PKs decoded over and over out of every RPC summary response.
+func BenchmarkUnmarshalBinaryRepeat(b *testing.B) {
+	const fleet = 64
+	keys := make([][]byte, fleet)
+	for i := range keys {
+		pk, _ := GenerateKeyPair()
+		buf := make([]byte, len(pk))
+		copy(buf, pk[:])
+		keys[i] = buf
+	}
+	b.ResetTimer()
+	var out PubKey
+	for i := 0; i < b.N; i++ {
+		if err := out.UnmarshalBinary(keys[i%fleet]); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Found while profiling the dev hypervisor for the wasm-visor CPU work.

`pubKeyVerifyCache` memoizes the secp256k1 on-curve validation that every `PubKey` parse runs. It was wired into `UnmarshalText` (the JSON/hex path) only — `UnmarshalBinary`, the gob path `net/rpc` uses for every hypervisor-to-visor response, went straight to `cipher.NewPubKey` and re-decompressed the point for every occurrence of every key.

A 30s CPU profile put `cipher.PubKey.Verify` beneath `UnmarshalBinary` at **21% of all visor CPU**, `secp256k1 Field.Sqr` alone at 18% flat, on one dominant stack:

```
Field.Sqr -> Field.Sqrt -> XY.SetXO -> XY.ParsePubkey -> PubkeyIsValid
  -> cipher.PubKey.Verify -> cipher.NewPubKey
  -> pkg/cipher.(*PubKey).UnmarshalBinary
  -> gob decodeGobDecoder -> net/rpc.(*Client).input
```

The hypervisor decodes the same ~1000 fleet PKs out of every summary response, several times a minute, and re-validated each occurrence. Decoding a 64-key fleet repeatedly:

```
before   14898 ns/op
after       86.18 ns/op
```

The cache comment already called out the single-threaded wasm visor as the reason it exists, so this should matter there more than on native.

A wrong length is never a cache hit, so malformed input still gets full validation. The added test covers a short input and a right-length non-curve point, plus a real gob round-trip. Both unmarshalers now share one lookup/remember pair rather than two copies of the cache logic.