### PR TITLE
fix(cli): drop the jsoncontract allowlist entry for the deleted visor top

### DIFF
--- a/cmd/skywire-cli/jsoncontract_test.go
+++ b/cmd/skywire-cli/jsoncontract_test.go
@@ -38,7 +38,6 @@ var scanDirs = []string{"commands", "../../pkg/flags"}
 // instead?".
 var streamingCommands = map[string]string{
 	"commands/gotop/root.go":                        "a full-screen TUI; there is no document to emit",
-	"commands/visor/top.go":                         "a full-screen TUI; there is no document to emit",
 	"commands/visor/ping/mux_bandwidth_tui_impl.go": "a live bandwidth TUI",
 	"commands/proxy/mux_plot.go":                    "a live per-leg bandwidth+RTT terminal chart; there is no document to emit",
 	"commands/tp/tp-viz.go":                         "starts a visualizer HTTP server; it serves pages, it does not return a value",


### PR DESCRIPTION
Follow-up to #4626, which deleted `cmd/skywire-cli/commands/visor/top.go` (a `//go:build ignore` file that could not compile — its `//go:embed` pointed at a missing `description.txt`).

`TestEveryPrintingCommandHonoursJSON` also asserts the allowlist contains no entries that no longer apply, so the orphaned entry fails on develop:

```
jsoncontract_test.go:202: 1 allowlist entr(ies) no longer apply — delete them:
  commands/visor/top.go
```

The live system monitor is `cmd/skywire-cli/commands/gotop`, whose allowlist entry is untouched. Caught by a local `make check`; the PR CI was queue-starved and had not run.