### PR TITLE
fix(deps): drop the stale bottle go.sum pair left by the version bump

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,6 @@ github.com/0magnet/bbolt v1.5.1-0.20260905171939-18be1d6cb1b4 h1:W3MFVCfvoZwcf4L
 github.com/0magnet/bbolt v1.5.1-0.20260905171939-18be1d6cb1b4/go.mod h1:iNjI/1hMvAlx3dmHMyb+UHGhWA/y5S2q3hOzD9FEieg=
 github.com/0magnet/bitree v0.0.0-20260906144807-e66de0b4c738 h1:one/1GDeQAGNJex3BuFIX8Cp9R9npsgRaAf9ZRex9wE=
 github.com/0magnet/bitree v0.0.0-20260906144807-e66de0b4c738/go.mod h1:fXaS+dltJcAnMAHKz1LR5X4/hE+S3QoxlMgni9wlVhw=
-github.com/0magnet/bottle v0.0.0-20260907192433-f5df4aff4079 h1:nNTQ+yoVIogYlZeoa+u3Bs+uEW564VOksa3YzuS+RVI=
-github.com/0magnet/bottle v0.0.0-20260907192433-f5df4aff4079/go.mod h1:02z8sWzqF3QH4SjMxnx5bnysFUqsw9CdUTtIj+CIxkw=
 github.com/0magnet/bottle v0.0.0-20260907194324-ccf25f76a5da h1:ey3RsUFL6QbCFyuDmObc+36MzObNwL+8E95LaH57npE=
 github.com/0magnet/bottle v0.0.0-20260907194324-ccf25f76a5da/go.mod h1:02z8sWzqF3QH4SjMxnx5bnysFUqsw9CdUTtIj+CIxkw=
 github.com/0magnet/calvin v0.0.0-20260907164811-60c88e364a88 h1:6KjWJctu0iJI/qxBE/xCH+IvKJuzZrxcQHv1QAUmFFU=


### PR DESCRIPTION
#4624 bumped `github.com/0magnet/bottle` from `f5df4aff4079` to `ccf25f76a5da` but ran `go mod vendor` without `go mod tidy`, so `go.sum` kept both pairs. The `module-mode` job ("go.mod / go.sum are tidy") fails on develop as a result.

`go mod tidy` removes exactly the two `f5df4aff4079` lines and nothing else; `go mod verify` reports *all modules verified*.