### PR TITLE
perf(visor): let real inbound traffic answer the self-probe question

### DIFF
--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -16,7 +16,7 @@ import (
 
 // Listen listens on a given dmsg port.
 func (ce *Client) Listen(port uint16) (*Listener, error) {
-	lis := newListener(ce.porter, Addr{PK: ce.pk, Port: port})
+	lis := newListener(ce.porter, Addr{PK: ce.pk, Port: port}, ce.markInbound)
 	ok, doneFn := ce.porter.Reserve(port, lis)
 	if !ok {
 		lis.close()

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -39,6 +39,12 @@ type EntityCommon struct {
 	// atomic requires 64-bit alignment for struct field access
 	lastUpdate int64 // Timestamp (in unix seconds) of last update.
 
+	// lastInbound is the time a remote-initiated stream was last accepted on any
+	// of this entity's listeners, as unix nanoseconds. atomic.Int64 rather than a
+	// bare int64 because it carries its own alignment guarantee — this repo ships
+	// armv7, where a misaligned 64-bit atomic panics at runtime.
+	lastInbound atomic.Int64
+
 	pk cipher.PubKey
 	sk cipher.SecKey
 	// dc is the primary discovery — kept as a separate field for
@@ -308,6 +314,27 @@ func (c *EntityCommon) LocalPK() cipher.PubKey { return c.pk }
 
 // LocalSK returns the local secret key of the entity.
 func (c *EntityCommon) LocalSK() cipher.SecKey { return c.sk }
+
+// markInbound records that a remote-initiated stream was just accepted. Passed to
+// every Listener this entity creates; see Listener.onInbound.
+func (c *EntityCommon) markInbound() { c.lastInbound.Store(time.Now().UnixNano()) }
+
+// InboundSince reports whether any remote peer has opened a stream to this entity
+// since t.
+//
+// This is positive, zero-cost evidence that the dmsg server is still forwarding
+// inbound streams to us — the same property a self-dial through the server proves,
+// established by a real remote rather than by talking to ourselves. A caller that
+// would otherwise probe its own reachability on a timer can consult this first and
+// only probe during genuine inbound silence.
+//
+// False means "no evidence", not "unreachable": a visor nobody has contacted is
+// indistinguishable from one nobody can contact, which is exactly the case where an
+// active probe is worth its cost.
+func (c *EntityCommon) InboundSince(t time.Time) bool {
+	ns := c.lastInbound.Load()
+	return ns != 0 && ns > t.UnixNano()
+}
 
 // Logger obtains the logger.
 func (c *EntityCommon) Logger() logrus.FieldLogger { return c.log }

--- a/pkg/dmsg/dmsg/entity_inbound_test.go
+++ b/pkg/dmsg/dmsg/entity_inbound_test.go
@@ -1,0 +1,32 @@
+// Package dmsg pkg/dmsg/dmsg/entity_inbound_test.go c1-net-dmsg
+package dmsg
+
+import (
+	"testing"
+	"time"
+)
+
+// TestInboundSince covers the signal the visor's self-probe gates on: no evidence
+// before anything arrives, positive evidence after, and no false positive for a
+// window that closed before the arrival.
+func TestInboundSince(t *testing.T) {
+	var ec EntityCommon
+
+	// Nothing has ever arrived — never claim reachability.
+	if ec.InboundSince(time.Now().Add(-time.Hour)) {
+		t.Fatal("InboundSince true with no inbound recorded")
+	}
+
+	before := time.Now()
+	time.Sleep(2 * time.Millisecond)
+	ec.markInbound()
+	time.Sleep(2 * time.Millisecond)
+	after := time.Now()
+
+	if !ec.InboundSince(before) {
+		t.Fatal("InboundSince false for a window containing the arrival")
+	}
+	if ec.InboundSince(after) {
+		t.Fatal("InboundSince true for a window starting after the arrival")
+	}
+}

--- a/pkg/dmsg/dmsg/listener.go
+++ b/pkg/dmsg/dmsg/listener.go
@@ -24,14 +24,21 @@ type Listener struct {
 	doneFunc atomic.Value // callback when done, type: func()
 	done     chan struct{}
 	once     sync.Once
+
+	// onInbound, when non-nil, is called each time a remote-initiated stream is
+	// successfully queued for Accept. It is the client's evidence that the dmsg
+	// server is still forwarding inbound streams to us — see
+	// EntityCommon.markInbound. Called with l.mx held, so it must not block.
+	onInbound func()
 }
 
-func newListener(porter *netutil.Porter, addr Addr) *Listener {
+func newListener(porter *netutil.Porter, addr Addr, onInbound func()) *Listener {
 	return &Listener{
-		porter: porter,
-		addr:   addr,
-		accept: make(chan *Stream, AcceptBufferSize),
-		done:   make(chan struct{}),
+		porter:    porter,
+		addr:      addr,
+		accept:    make(chan *Stream, AcceptBufferSize),
+		done:      make(chan struct{}),
+		onInbound: onInbound,
 	}
 }
 
@@ -55,6 +62,13 @@ func (l *Listener) introduceStream(tp *Stream) error {
 
 	select {
 	case l.accept <- tp:
+		// A remote peer just reached us through the dmsg server, which is exactly
+		// what a self-probe dial sets out to prove — with a real remote instead of
+		// ourselves. Recording it lets the visor's self-probe stay quiet while
+		// there is live evidence of reachability.
+		if l.onInbound != nil {
+			l.onInbound()
+		}
 		return nil
 
 	case <-l.done:

--- a/pkg/visor/init_selfprobe.go
+++ b/pkg/visor/init_selfprobe.go
@@ -3,17 +3,12 @@ package visor
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"net/http"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
-	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
 // selfProbeInterval is how often the visor probes its own dmsg listeners.
@@ -32,12 +27,20 @@ const selfProbeRecoveryThreshold = 2
 // side and reconnecting won't help — we only try once per cooldown.
 const selfProbeRecoveryCooldown = 5 * time.Minute
 
-// initSelfProbe starts a background loop that periodically verifies the
-// visor's own dmsg listeners are reachable end-to-end. Each probe dials
-// the visor's own PK through the dmsg server — exercising the full path
-// that remote clients use:
+// initSelfProbe starts a background loop that verifies the visor's own dmsg
+// listeners are reachable end-to-end, but only when nothing else already proves
+// it. Each probe dials the visor's own PK through the dmsg server — exercising
+// the full path that remote clients use:
 //
 //	visor → session → server → forward back to visor → listener → accept
+//
+// An accepted inbound stream from any real peer traverses that same path, so the
+// loop consults dmsgC.InboundSince first and skips the probe entirely whenever a
+// remote has reached us since the previous tick. A visor with live traffic — any
+// hypervisor with transports, which is the common case — therefore never dials
+// itself at all. The probe remains for the situation it was written for: a visor
+// nobody is contacting, where silence and unreachability look identical from the
+// inside and only an active dial can tell them apart.
 //
 // If a probe fails persistently (selfProbeRecoveryThreshold consecutive
 // misses), the loop calls dmsgC.ForceReconnect() to tear down and re-dial
@@ -83,13 +86,30 @@ func selfProbeLoop(ctx context.Context, v *Visor, dmsgC *dmsg.Client, log *loggi
 	ticker := time.NewTicker(selfProbeInterval)
 	defer ticker.Stop()
 
+	lastTick := time.Now()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			now := time.Now()
+			// Skip the probe when a real remote has reached us since the last tick.
+			// An accepted inbound stream traverses the same path the probe tests —
+			// server forwards to our session, listener accepts — so it is strictly
+			// better evidence than dialing ourselves, and it costs nothing. A busy
+			// visor therefore never probes; the probe survives for the case it was
+			// written for, a visor nobody is reaching, where observation tells us
+			// nothing and we genuinely cannot distinguish quiet from broken.
+			if dmsgC.InboundSince(lastTick) {
+				lastTick = now
+				for port := range state.consecutiveFails {
+					state.consecutiveFails[port] = 0
+				}
+				continue
+			}
+			lastTick = now
 			probeResults := runSelfProbes(ctx, v, dmsgC, log)
-			handleProbeResults(dmsgC, state, probeResults, time.Now(), log)
+			handleProbeResults(dmsgC, state, probeResults, now, log)
 		}
 	}
 }
@@ -150,7 +170,7 @@ func handleProbeResults(reconn probeReconnector, state *probeState, results map[
 }
 
 // runSelfProbes probes each critical dmsg port and returns a map of port → healthy.
-func runSelfProbes(ctx context.Context, _ *Visor, dmsgC *dmsg.Client, log *logging.Logger) map[uint16]bool {
+func runSelfProbes(ctx context.Context, _ *Visor, dmsgC *dmsg.Client, _ *logging.Logger) map[uint16]bool {
 	results := make(map[uint16]bool)
 	myPK := dmsgC.LocalPK()
 
@@ -160,12 +180,6 @@ func runSelfProbes(ctx context.Context, _ *Visor, dmsgC *dmsg.Client, log *loggi
 	// closes for untrusted — but the dial success confirms reachability.
 	results[skyenv.DmsgAwaitSetupPort] = probeRawDial(ctx, dmsgC, myPK, skyenv.DmsgAwaitSetupPort)
 
-	// Probe port 80 (dmsghttp log server) — HTTP GET /health over dmsg.
-	// Uses the visor's own dmsg client to make an HTTP request through
-	// the server bridge back to itself. /health is the lightest open
-	// endpoint on the log server (open to everyone, no auth required).
-	results[visorconfig.DmsgHTTPPort] = probeDmsgHTTP(ctx, dmsgC, myPK, log)
-
 	return results
 }
 
@@ -174,29 +188,4 @@ func probeRawDial(ctx context.Context, dmsgC *dmsg.Client, pk cipher.PubKey, por
 	probeCtx, cancel := context.WithTimeout(ctx, selfProbeTimeout)
 	defer cancel()
 	return dmsgC.Probe(probeCtx, pk, port)
-}
-
-// probeDmsgHTTP does an HTTP GET /health over dmsg to the visor's own log server.
-func probeDmsgHTTP(ctx context.Context, dmsgC *dmsg.Client, myPK cipher.PubKey, log *logging.Logger) bool {
-	probeCtx, cancel := context.WithTimeout(ctx, selfProbeTimeout)
-	defer cancel()
-
-	tr := dmsghttp.MakeHTTPTransport(probeCtx, dmsgC)
-	client := &http.Client{Transport: tr, Timeout: selfProbeTimeout}
-
-	url := fmt.Sprintf("dmsg://%s:%d/health", myPK.Hex(), visorconfig.DmsgHTTPPort)
-	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, url, nil)
-	if err != nil {
-		log.WithError(err).Debug("Self-probe HTTP: failed to create request")
-		return false
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		log.WithError(err).Debug("Self-probe HTTP: request failed")
-		return false
-	}
-	_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck,gosec
-	_ = resp.Body.Close()                 //nolint:errcheck,gosec
-	return resp.StatusCode == http.StatusOK
 }


### PR DESCRIPTION
The visor dialed its own PK through the dmsg server every 60s to check that inbound streams still reach it, escalating to `ForceReconnect()` after two consecutive misses. The recovery action is worth keeping. Dialing ourselves to decide whether to take it is not — a real remote reaching us proves the same property over the same path:

```
visor -> session -> server -> forward back to visor -> listener -> accept
```

`Listener.introduceStream` is the single funnel for every remote-initiated stream, so it now records the arrival on the entity. `EntityCommon.InboundSince` exposes it, and the probe loop skips a tick entirely when a peer has reached us since the previous one. A visor with live traffic — any hypervisor with transports — never self-dials at all. The probe survives for the case it was written for: a visor nobody is contacting, where quiet and unreachable are indistinguishable from the inside and only an active dial separates them.

`false` from `InboundSince` means "no evidence", not "unreachable", which is why it gates a probe rather than replacing one.

**Also drops the second probe.** Each cycle additionally built an `http.Transport` and `http.Client` to GET `/health` on port 80 over dmsg. That tests the same reachability the port-136 raw dial already established, plus the log server's HTTP handler — which `ForceReconnect` cannot fix, so its failure could only cause a pointless session churn.

`lastInbound` is an `atomic.Int64` rather than a bare `int64` so it carries its own alignment guarantee; this repo ships armv7, where a misaligned 64-bit atomic panics at runtime.

Test covers the three cases that matter: no evidence before any arrival, positive evidence after, and no false positive for a window that closed before it.