### PR TITLE
fix(mobile): stop embedding the browser wasm-visor blobs in the android lib

### DIFF
--- a/pkg/wasmhv/wasmbin/select_go.go
+++ b/pkg/wasmhv/wasmbin/select_go.go
@@ -1,4 +1,4 @@
-//go:build !tinygo && !js
+//go:build !tinygo && !js && !mobile
 
 // Package wasmbin pkg/wasmhv/wasmbin/select_go.go c3-vis-wasm
 package wasmbin

--- a/pkg/wasmhv/wasmbin/select_mobile.go
+++ b/pkg/wasmhv/wasmbin/select_mobile.go
@@ -1,0 +1,30 @@
+//go:build mobile && !tinygo && !js
+
+// Package wasmbin pkg/wasmhv/wasmbin/select_mobile.go c3-vis-wasm
+package wasmbin
+
+// A mobile build embeds NEITHER wasm-visor pair.
+//
+// The blobs exist so a visor SERVING the browser PWA can hand a browser a
+// wasm-visor with no external --wasm file. An Android app is not that server:
+// it is the phone's own visor, and nothing in the mobile build reaches
+// GetVariant. Embedding them cost the android library 16.4 MB — 12.3 MB for
+// wasmgo..gobytes plus 4.1 MB for wasmtinygo..gobytes, measured with
+// `go tool nm -size` on an unstripped android/arm64 build — which is what put
+// libskywire-mobile.so 4.7 MB over its size budget.
+//
+// The package API is built for this case: Embedded() reports false, Has() is
+// false for every variant, Available() is empty and GetVariant() returns its
+// "not embedded in this build" error. Same shape as pkg/geoip, whose 29 MB
+// GeoLite2 embed is likewise stripped from mobile (geoip_embedded.go is
+// !mobile, with a stub alongside).
+// blob is a gzipped wasm-visor paired with its matching wasm_exec.js loader.
+type blob struct {
+	gz     []byte
+	execJS []byte
+}
+
+var (
+	variants       = map[Variant]blob{}
+	defaultVariant = Go
+)


### PR DESCRIPTION
The `android` lane has been red on develop independently of any PR — `libskywire-mobile.so` builds at 88,604,966 bytes against an 83,886,080 budget, 4.7 MB over, byte-identical on unmodified develop. The budget is a ratchet (its error reads *"the mobile variant regained fat"*), so raising it would discard whatever win it locks in.

The fat is two embedded wasm-visor blobs. `go tool nm -size` on an unstripped android/arm64 build:

```
12872523  pkg/wasmhv/wasmbin/wasmgo..gobytes
 4256490  pkg/wasmhv/wasmbin/wasmtinygo..gobytes
```

`select_go.go` was tagged `!tinygo && !js`, which includes android, so the phone library carried both. Those blobs exist so a visor **serving** the browser PWA can hand a browser a wasm-visor with no external `--wasm` file. An Android app is not that server — it is the phone's own visor, and nothing in the mobile build reaches `GetVariant`.

`select_mobile.go` mirrors `select_js.go`, which already embeds neither for the same reason (*"embedding wasm-visor blobs inside it would be wasm-in-wasm for ~11 MB of dead weight"*). The package API is built for this: `Embedded()` reports false, `Has()` false, `Available()` empty, `GetVariant()` returns its "not embedded in this build" error. `pkg/geoip` does the same with its 29 MB GeoLite2 embed.

```
before  88604966 bytes  (budget 83886080)  FAIL
after   71500070 bytes  (budget 83886080)  pass
```

`make android-mobile-check` passes. The native build, `pkg/wasmhv/wasmbin` tests and the visor wasmserve tests are unaffected.