### PR TITLE
fix(transport): stop cleanupTransports busy-waiting on a canceled context

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -904,6 +904,7 @@ func (tm *Manager) acceptTransports(ctx context.Context, lis network.Listener, t
 func (tm *Manager) cleanupTransports(ctx context.Context) {
 	defer tm.wg.Done()
 	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
@@ -921,7 +922,17 @@ func (tm *Manager) cleanupTransports(ctx context.Context) {
 			if len(toDelete) > 0 {
 				tm.Logger.Debugf("Deleted %d unused transport entries", len(toDelete))
 			}
+		// Both cancellations end the loop. ctx.Done() previously had an empty
+		// body and no return, which is a busy-wait: a canceled context's
+		// channel stays ready forever, so this select spun as fast as the
+		// scheduler would run it from the moment ctx was canceled until
+		// Manager.Close() closed tm.done. Those are separate signals —
+		// Visor.Suspend cancels the network context first (api_suspend.go) and
+		// only then walks the close stack — so the spin covers the whole
+		// teardown window, and lasts indefinitely for any caller that cancels
+		// the serve context without going on to close the manager.
 		case <-ctx.Done():
+			return
 		case <-tm.done:
 			return
 		}


### PR DESCRIPTION
Found by an audit of the visor's periodic work.

`cleanupTransports`' select had `case <-ctx.Done():` with an empty body and no `return`. A canceled context keeps its channel ready forever, so from the moment `ctx` was canceled the loop spun as fast as the scheduler would run it — until `Manager.Close()` closed `tm.done`.

Those are separate signals. `Visor.Suspend` cancels the network context first (`pkg/visor/api_suspend.go:46-51`, *"Cancel the network ctx first so ctx-honoring module goroutines begin unwinding before we close the listeners"*) and only then walks the close stack, so the spin covers the whole teardown window — and lasts indefinitely for any caller that cancels the serve context without going on to close the manager.

Returns on either signal now, and stops the ticker on the way out; it was never stopped.