### PR TITLE
perf(cxo): run the per-second stat loops only where something reads them

### DIFF
--- a/pkg/cxo/node/node.go
+++ b/pkg/cxo/node/node.go
@@ -134,6 +134,16 @@ func NewNode(conf *Config) (n *Node, err error) {
 		return // invalid
 	}
 
+	// The container's per-second rolling-average goroutines exist only to feed
+	// Container.Stat() -> Node.Stat(), which is reachable solely over this
+	// node's RPC. With no RPC listener (the check at the bottom of this
+	// function) nothing can ever read them, so don't start them. Every in-visor
+	// CXO node sets conf.RPC = "" — treestore publisher and subscriber,
+	// cxoaggregate, cxopreview — which is where the saving lands.
+	if conf.RPC == "" {
+		conf.Config.TrackRollingAverages = false
+	}
+
 	var c *skyobject.Container
 
 	if c, err = skyobject.NewContainer(conf.Config); err != nil {

--- a/pkg/cxo/node/node.go
+++ b/pkg/cxo/node/node.go
@@ -131,7 +131,7 @@ func NewNode(conf *Config) (n *Node, err error) {
 	}
 
 	if err = conf.Validate(); err != nil {
-		return // invalid
+		return nil, err // invalid
 	}
 
 	// The container's per-second rolling-average goroutines exist only to feed
@@ -147,7 +147,7 @@ func NewNode(conf *Config) (n *Node, err error) {
 	var c *skyobject.Container
 
 	if c, err = skyobject.NewContainer(conf.Config); err != nil {
-		return
+		return nil, err
 	}
 
 	return NewNodeContainer(conf, c)

--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -170,7 +170,7 @@ func (c *Container) initCache() {
 	c.Cache.rs = make(map[registry.RegistryRef]*itemRegistry,
 		c.conf.CacheRegistries)
 
-	c.Cache.stat = newCxdsStat(c.conf.RollAvgSamples)
+	c.Cache.stat = newCxdsStat(c.conf.RollAvgSamples, c.conf.TrackRollingAverages)
 }
 
 func (c *Cache) amountVolume() (a, v int) {

--- a/pkg/cxo/skyobject/config.go
+++ b/pkg/cxo/skyobject/config.go
@@ -105,6 +105,22 @@ type Config struct {
 	// statistic
 	RollAvgSamples int
 
+	// TrackRollingAverages runs the per-second goroutines that roll the
+	// statistics above into moving averages. Default true.
+	//
+	// Those averages are readable only through Container.Stat() -> Node.Stat()
+	// -> the node RPC, so a node started without an RPC listener has no way to
+	// observe them and the goroutines tick once a second for nobody. The node
+	// clears this for itself when conf.RPC is empty (see node.NewNode), which
+	// is every in-visor CXO construction — treestore publisher and subscriber,
+	// cxoaggregate and cxopreview — seven nodes per visor, each running two of
+	// these loops. Costly out of proportion on the single-threaded js/wasm
+	// visor, where every wakeup is a full scheduler cycle.
+	//
+	// Counters and totals are unaffected; only the derived per-second averages
+	// stop advancing, and only where nothing could read them.
+	TrackRollingAverages bool
+
 	// Cache configs. Set the CacheMaxAmount or the
 	// CacheMaxVolume to zero to switch the cache off
 
@@ -225,6 +241,7 @@ func NewConfig() (conf *Config) {
 
 	conf.Degree = Degree
 	conf.RollAvgSamples = RollAvgSamples
+	conf.TrackRollingAverages = true
 
 	// cache configs
 

--- a/pkg/cxo/skyobject/cxds_stat.go
+++ b/pkg/cxo/skyobject/cxds_stat.go
@@ -29,7 +29,7 @@ type cxdsStat struct {
 	closeo sync.Once
 }
 
-func newCxdsStat(rollAvgSamples int) (c *cxdsStat) {
+func newCxdsStat(rollAvgSamples int, rollingAverages bool) (c *cxdsStat) {
 
 	c = new(cxdsStat)
 
@@ -42,7 +42,12 @@ func newCxdsStat(rollAvgSamples int) (c *cxdsStat) {
 
 	c.quit = make(chan struct{})
 
-	go c.secondLoop()
+	// Same reasoning as newIndexStat: these rolling averages surface only via
+	// Container.Stat() -> Node.Stat() -> the node RPC, so a node with no RPC
+	// listener never reads them. See Config.TrackRollingAverages.
+	if rollingAverages {
+		go c.secondLoop()
+	}
 
 	return
 }

--- a/pkg/cxo/skyobject/index.go
+++ b/pkg/cxo/skyobject/index.go
@@ -66,7 +66,7 @@ type Index struct {
 func (i *Index) load(c *Container) (err error) {
 
 	// create statistic
-	i.stat = newIndexStat(c.conf.RollAvgSamples)
+	i.stat = newIndexStat(c.conf.RollAvgSamples, c.conf.TrackRollingAverages)
 
 	i.feeds = make(map[cipher.PubKey]*indexHeads)
 	i.c = c

--- a/pkg/cxo/skyobject/index_stat.go
+++ b/pkg/cxo/skyobject/index_stat.go
@@ -17,13 +17,19 @@ type indexStat struct {
 	closeo sync.Once
 }
 
-func newIndexStat(samples int) (i *indexStat) {
+func newIndexStat(samples int, rollingAverages bool) (i *indexStat) {
 	i = new(indexStat)
 
 	i.rps = statutil.NewFloat(samples)
 	i.quit = make(chan struct{})
 
-	go i.secondLoop()
+	// The per-second roll only feeds rootsPerSecond, which is reachable solely
+	// through Container.Stat() -> Node.Stat() -> the node RPC. A node with no RPC
+	// listener has no reader, so the goroutine would tick forever for nobody.
+	// See Config.TrackRollingAverages.
+	if rollingAverages {
+		go i.secondLoop()
+	}
 
 	return
 }
@@ -51,6 +57,8 @@ func (i *indexStat) secondLoop() {
 		tk = time.NewTicker(time.Second)
 		tc = tk.C
 	)
+
+	defer tk.Stop() // was missing; its twin in cxds_stat.go has it
 
 	for {
 

--- a/pkg/cxo/skyobject/stat_loops_test.go
+++ b/pkg/cxo/skyobject/stat_loops_test.go
@@ -1,0 +1,40 @@
+// Package skyobject pkg/cxo/skyobject/stat_loops_test.go c2-net-cxo
+package skyobject
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestTrackRollingAveragesGatesGoroutines guards the invariant that the
+// per-second rolling-average goroutines run only where something can read them.
+// They surface solely through Container.Stat() -> Node.Stat() -> the node RPC,
+// so a node started without an RPC listener must not pay for them — which is
+// every in-visor CXO node (treestore publisher/subscriber, cxoaggregate,
+// cxopreview), seven per visor at two loops each.
+func TestTrackRollingAveragesGatesGoroutines(t *testing.T) {
+	if !NewConfig().TrackRollingAverages {
+		t.Fatal("NewConfig should default TrackRollingAverages true")
+	}
+
+	count := func(rolling bool) int {
+		runtime.GC()
+		before := runtime.NumGoroutine()
+		is := newIndexStat(5, rolling)
+		cs := newCxdsStat(5, rolling)
+		// Give any spawned loop a moment to actually be scheduled.
+		time.Sleep(50 * time.Millisecond)
+		got := runtime.NumGoroutine() - before
+		is.Close()
+		cs.Close()
+		return got
+	}
+
+	if n := count(false); n != 0 {
+		t.Errorf("TrackRollingAverages=false spawned %d goroutine(s), want 0", n)
+	}
+	if n := count(true); n != 2 {
+		t.Errorf("TrackRollingAverages=true spawned %d goroutine(s), want 2", n)
+	}
+}


### PR DESCRIPTION
Found by an audit of the visor's periodic work.

Every CXO container starts two goroutines that tick once a second to roll counters into moving averages — `indexStat.secondLoop` and `cxdsStat.secondLoop`.

Those averages are readable **only** through `Container.Stat()` → `Node.Stat()` → the node RPC (`rpc.go:159`), and the RPC listener is gated on `conf.RPC != ""` (`node.go:234`). Every in-visor CXO construction sets `conf.RPC = ""`:

```
pkg/cxo/treestore/publisher.go:243,308
pkg/cxo/treestore/subscriber.go:224,289
pkg/cxo/cxoaggregate/aggregate.go:212
pkg/cxo/cxopreview/cxopreview.go:191
```

So inside a visor these values are structurally unreachable and the goroutines tick for nobody. At seven CXO nodes per visor that is **14 goroutines waking every second** — which matters out of proportion on the single-threaded js/wasm visor, where each wakeup is a full scheduler cycle.

The node clears the new `skyobject.Config.TrackRollingAverages` when it has no RPC listener, so the invariant lives in one place rather than at six call sites. All six in-visor constructions go through `NewNode`, and nothing calls `NewNodeContainer` directly except `NewNode`, so the gate is complete. `cmd/cxo` (which sets `RPC`) is unaffected.

Counters and totals are untouched; only the derived per-second averages stop advancing, and only where nothing could observe them.

Also adds the `defer tk.Stop()` missing from `indexStat.secondLoop` — its twin in `cxds_stat.go` already had one.

The test counts the goroutines actually spawned (0 gated off, 2 gated on) rather than restating the decision, so it fails if the gate is removed.