### PR TITLE
fix(transport): close the client InitClient replaces, and do not install a nil one

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -820,15 +820,40 @@ func (tm *Manager) hasActiveRoutes(tpID uuid.UUID) bool {
 	return rc(tpID)
 }
 
-// InitClient initilizes a network client
+// InitClient initilizes a network client.
+//
+// Safe to call again for a netType that already has one — ReinitiateModule
+// ("stcpr" et al, api_network.go) and the SUDPH retry in init_transport.go both
+// do. The previous client is closed before being replaced.
 func (tm *Manager) InitClient(ctx context.Context, netType types.Type, port int) {
 	client, err := tm.factory.MakeClient(netType, port)
 	if err != nil {
-		tm.Logger.Warnf("Cannot initialize %s transport client", netType)
+		// Do NOT install the result. MakeClient yields a nil client alongside
+		// its error, and storing that used to replace a perfectly good client
+		// with nothing — a failed re-init took down a working network type.
+		tm.Logger.WithError(err).Warnf("Cannot initialize %s transport client; keeping the existing one", netType)
+		return
 	}
+
+	// Swap under the lock, close outside it: a client's Close tears down its
+	// listener and waits on its serve goroutines, which is not work to do while
+	// holding the manager lock every dial and accept contends for.
 	tm.mx.Lock()
+	prev := tm.netClients[netType]
 	tm.netClients[netType] = client
 	tm.mx.Unlock()
+
+	// Without this the evicted client leaked. Its 90s AR re-registration loop
+	// exits only on the done channel that genericClient.Close closes, so an
+	// orphan kept POSTing /bind/<type> advertising the OLD port and fighting
+	// the live client for the address-resolver record, plus a leaked
+	// acceptTransports goroutine. Each re-init added another.
+	if prev != nil && prev != client {
+		if cerr := prev.Close(); cerr != nil {
+			tm.Logger.WithError(cerr).Debugf("Closing replaced %s transport client", netType)
+		}
+	}
+
 	tm.runClient(ctx, netType)
 
 	// Transport Manager is 'ready' once we have successfully initilized


### PR DESCRIPTION
Found by an audit of the visor's periodic work.

`InitClient` overwrote `tm.netClients[netType]` unconditionally. Two faults:

**1. A failed re-init took down a working network type.** On `MakeClient` error it logged a warning and then stored the result anyway — and `MakeClient` returns a nil client alongside its error (`makeResolvedClient` → `return nil, err`). So the failure path replaced a good client with nothing.

**2. The evicted client was never closed.** A client's 90s address-resolver re-registration loop exits only on the done channel that `genericClient.Close` closes. The orphan therefore kept POSTing `/bind/<type>` advertising the **old port**, fighting the live client for the AR record — plus a leaked `acceptTransports` goroutine. Each re-init added another.

Both are reachable through `ReinitiateModule` (`api_network.go:510`, STCPR) and the SUDPH retry at `init_transport.go:391`.

Now returns without touching the map when `MakeClient` fails, and closes the replaced client. The swap happens under `tm.mx` but the `Close` runs outside it — `Close` tears down a listener and waits on serve goroutines, which is not work to do while holding the lock every dial and accept contends for.

Targeted verification: `pkg/transport`, `pkg/transport/network` and `pkg/visor` tests pass, lint clean, binary builds.