### PR TITLE
fix(router): make the local-route memo actually hit, and stop the BFS allocating per graph edge

### DIFF
--- a/pkg/router/local_route_bfs.go
+++ b/pkg/router/local_route_bfs.go
@@ -1,0 +1,329 @@
+// Package router pkg/router/local_route_bfs.go c2-net-routing
+//
+// The breadth-first search behind calculateLocalRoutes' multi-hop fallback:
+// given the visor's own first-hop transports and one snapshot of the
+// network-wide transport graph, find the shortest path to dst whose length
+// lands in [minHops, maxHops].
+//
+// It lives in its own file because it is the single most expensive thing the
+// router does per dial — on a visor with no direct transport to the
+// destination it walks the whole ~16k-edge TPD graph — and it needs to be
+// benchmarkable in isolation (see local_route_bfs_test.go).
+package router
+
+import (
+	"hash/fnv"
+	"sort"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// localTpRef is one usable first-hop transport of the local visor, flattened
+// out of the transport manager so the BFS never touches manager locks.
+type localTpRef struct {
+	id       uuid.UUID
+	remotePK cipher.PubKey
+	tpType   string
+}
+
+// localTpsByTypePref orders first-hop transports by type preference (direct
+// types before DMSG). Concrete sort.Interface for the same reason as
+// bfsNodesByPK: sort.SliceStable's reflect swapper is measurable here.
+type localTpsByTypePref []localTpRef
+
+func (s localTpsByTypePref) Len() int      { return len(s) }
+func (s localTpsByTypePref) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s localTpsByTypePref) Less(i, j int) bool {
+	return tptypes.TypePreference(tptypes.Type(s[i].tpType)) <
+		tptypes.TypePreference(tptypes.Type(s[j].tpType))
+}
+
+// localTpSignature identifies the SET of first-hop transports, independent of
+// the order they were collected in.
+//
+// This matters because it is the local half of the route memo's generation
+// key, and the transports are collected by Manager.WalkTransports — which
+// snapshots a Go map, so its order is randomized per call. The previous
+// signature hashed the IDs in that order, so it came out different on nearly
+// every call and reset the memo each time even when the transport set had not
+// changed at all. Sorting the slice first does not help: it sorts by transport
+// TYPE, and same-type transports keep their (random) relative order.
+//
+// Summation is commutative, which is exactly the property wanted; the length
+// is folded in so that adding and removing transports whose id-hashes happen
+// to cancel still moves the signature.
+func localTpSignature(localTps []localTpRef) uint64 {
+	var sum uint64
+	for i := range localTps {
+		h := fnv.New64a()
+		id := localTps[i].id
+		_, _ = h.Write(id[:])
+		sum += h.Sum64()
+	}
+	return sum ^ (uint64(len(localTps)) * 0x9E3779B97F4A7C15)
+}
+
+// localBFSGraph is the immutable graph + per-transport metric view the BFS
+// reads. All four maps come straight off one tpdSnapshot and are never
+// mutated here.
+type localBFSGraph struct {
+	byEdge         map[cipher.PubKey][]*transport.Entry
+	latencyByID    map[uuid.UUID]float64
+	typeByID       map[uuid.UUID]string
+	throughputByID map[uuid.UUID]float64
+}
+
+// bfsNodesByPK orders BFS frontier nodes by remote public key. A concrete
+// sort.Interface, not sort.SliceStable: the reflect-based swapper that
+// sort.Slice installs showed up in browser profiles of the wasm visor
+// (internal/reflectlite.Swapper.func9) at a level worth avoiding in a loop
+// that runs once per expanded node.
+type bfsNodesByPK []bfsNode
+
+func (s bfsNodesByPK) Len() int           { return len(s) }
+func (s bfsNodesByPK) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s bfsNodesByPK) Less(i, j int) bool { return pkLess(s[i].pk, s[j].pk) }
+
+// bfsNode is one frontier entry. The path that reaches it is NOT stored
+// inline: parent indexes the arena slot of the node one hop closer to src (-1
+// for a seed), and (tpID, pk) are the single hop that extends it — the hop's
+// From is simply the parent's pk, or src at a seed, so it is not stored. The
+// whole path is materialized only for the handful of nodes that actually hit
+// dst — see materializePath.
+//
+// This is the allocation fix. Storing []routing.Hop per node meant one
+// make+copy per graph EDGE traversed (a routing.Hop is 82 bytes, paths run to
+// maxHops entries), so a single failed search over the network-wide graph
+// allocated tens of megabytes and the GC — single-threaded on js/wasm — ate
+// the visor's only core.
+type bfsNode struct {
+	pk     cipher.PubKey
+	tpID   uuid.UUID
+	parent int32
+	self   int32
+}
+
+// bfsArena holds every node the search has created, so a node's parent chain
+// stays addressable after its frontier slice is dropped. src is the origin
+// every seed's chain terminates at.
+type bfsArena struct {
+	nodes []bfsNode
+	src   cipher.PubKey
+}
+
+// add appends n to the arena and returns it with its slot index filled in.
+// The index is int32 to keep bfsNode at 57 bytes; 2^31 nodes would be ~120 GB
+// of arena, orders of magnitude past what maxHops over the TPD graph can
+// reach, so the narrowing cannot occur in practice.
+func (a *bfsArena) add(n bfsNode) bfsNode {
+	n.self = int32(len(a.nodes)) //nolint:gosec // see doc comment: bounded far below 2^31
+	a.nodes = append(a.nodes, n)
+	return n
+}
+
+// materializePath walks n's parent chain back to the seed and returns the
+// forward hop list in src→dst order.
+func (a *bfsArena) materializePath(n bfsNode, depth int) []routing.Hop {
+	path := make([]routing.Hop, depth)
+	cur := n
+	for i := depth - 1; i >= 0; i-- {
+		from := a.src
+		if cur.parent >= 0 {
+			from = a.nodes[cur.parent].pk
+		}
+		path[i] = routing.Hop{TpID: cur.tpID, From: from, To: cur.pk}
+		if cur.parent < 0 {
+			break
+		}
+		cur = a.nodes[cur.parent]
+	}
+	return path
+}
+
+// pkInChain reports whether pk already appears anywhere on n's path (as the
+// src edge or as any hop's destination) — per-path loop prevention. Walking
+// the parent chain is the same work the old per-node slice scan did, minus
+// the slice.
+func (a *bfsArena) pkInChain(pk cipher.PubKey, n bfsNode) bool {
+	cur := n
+	for {
+		if cur.pk == pk {
+			return true
+		}
+		if cur.parent < 0 {
+			return a.src == pk
+		}
+		cur = a.nodes[cur.parent]
+	}
+}
+
+// expandKey identifies a (node, depth) pair for the "already expanded" set.
+// One flat map instead of the old map-of-maps: same semantics, one hash
+// lookup and no inner map allocated per visor.
+type expandKey struct {
+	pk    cipher.PubKey
+	depth int
+}
+
+// localRouteBFS searches the transport graph for a path src→dst of between
+// minHops and maxHops hops, seeded by the local visor's own transports.
+//
+// Behavior is exactly the pre-extraction inline search: levels are visited
+// in increasing hop count so the first level that reaches dst wins; within a
+// level every dst-hit is collected and the lowest pathLatencyScore among them
+// is returned; expansion order is deterministic (children sorted by remote
+// PK, seeds likewise) so identical inputs always yield an identical path.
+//
+// DMSG edges are excluded everywhere but the (already-handled elsewhere)
+// direct case: a dmsg transport relays through a server neither endpoint can
+// observe, so it cannot be accounted for as a multihop leg.
+//
+// ok=false means no acceptable path exists in this graph — the caller turns
+// that into the "local BFS found no path" error (and caches it; a miss is as
+// expensive to recompute as a hit).
+func localRouteBFS(
+	src, dst cipher.PubKey,
+	localTps []localTpRef,
+	g localBFSGraph,
+	excludeIntermediates map[cipher.PubKey]struct{},
+	minHops, maxHops int,
+) (path []routing.Hop, level int, ok bool) {
+	arena := &bfsArena{src: src}
+
+	// Seed the BFS with the local transports (each is a 1-hop path from src
+	// to a direct neighbor). Sort for determinism — same seeding order
+	// across calls means same expansion order.
+	//
+	// DMSG seeds are dropped here on purpose. A DMSG transport relays
+	// through a dmsg server (and, since server-to-server forwarding landed,
+	// potentially a chain of dmsg servers) that neither end of the route can
+	// observe — the intermediate server is unaccounted-for in the transport
+	// entry. Using a DMSG hop anywhere in a multihop route would let data
+	// transit the same dmsg server multiple times with no way to detect it.
+	// Direct DMSG dials (1-hop, src→dst over a DMSG transport) are fine and
+	// are handled by the caller before we get here; the BFS only produces
+	// multihop paths, so we strictly require non-DMSG hops.
+	seed := make([]bfsNode, 0, len(localTps))
+	for _, tp := range localTps {
+		if tp.tpType == "dmsg" {
+			continue
+		}
+		if _, hit := excludeIntermediates[tp.remotePK]; hit {
+			continue
+		}
+		seed = append(seed, arena.add(bfsNode{
+			pk:     tp.remotePK,
+			tpID:   tp.id,
+			parent: -1,
+		}))
+	}
+	sort.Stable(bfsNodesByPK(seed))
+
+	// expandedAtDepth records which (pk, depth) pairs have been expanded —
+	// avoids redundant work when several inbound paths converge on the same
+	// node at the same depth. State is capped at O(|visors| × maxHops).
+	// Without it the search could revisit identical (node, depth)
+	// combinations exponentially; with it each pair expands at most once and
+	// the BFS stays linear in graph size.
+	expandedAtDepth := make(map[expandKey]struct{})
+
+	// Per-TpID latency / type / throughput lookups (hydrated by the CXO
+	// telemetry aggregator on TPD's side) come prebuilt from the snapshot
+	// alongside byEdge. Used to rank multiple same-level dst-hits below.
+	latencyFor := func(id uuid.UUID) float64 { return g.latencyByID[id] }
+	typeFor := func(id uuid.UUID) string { return g.typeByID[id] }
+	throughputFor := func(id uuid.UUID) float64 { return g.throughputByID[id] }
+
+	queue := seed
+	var nextQueue, children []bfsNode
+	var dstHits []bfsNode
+	for level = 1; level <= maxHops && len(queue) > 0; level++ {
+		nextQueue = nextQueue[:0]
+		// Collect ALL dst-hits at this level, then pick the lowest-latency
+		// among them. Returning on the first hit left the BFS's
+		// deterministic-by-PK ordering as the only tiebreaker — which
+		// empirically picked geo-distant intermediates over healthier
+		// same-hop-count alternatives.
+		dstHits = dstHits[:0]
+		for _, node := range queue {
+			// Did we reach the destination at an acceptable depth?
+			if node.pk == dst && level >= minHops {
+				dstHits = append(dstHits, node)
+				continue
+			}
+			// Stop expanding nodes already at maxHops — children would
+			// exceed the cap.
+			if level >= maxHops {
+				continue
+			}
+			// Skip excluded intermediates (DisjointMux).
+			if _, hit := excludeIntermediates[node.pk]; hit {
+				continue
+			}
+			// Skip if this (pk, depth) was already expanded — the same
+			// children would be produced. Deliberately not a global
+			// visited[pk] check, which would (incorrectly) block the same
+			// node at OTHER depths and could shadow longer paths when a
+			// shorter one existed.
+			ek := expandKey{pk: node.pk, depth: level}
+			if _, done := expandedAtDepth[ek]; done {
+				continue
+			}
+			expandedAtDepth[ek] = struct{}{}
+			// Expand: every transport from this node to a new neighbor
+			// becomes a candidate next node, sorted by remote PK for
+			// deterministic order.
+			entries := g.byEdge[node.pk]
+			children = children[:0]
+			for _, entry := range entries {
+				if entry == nil {
+					continue
+				}
+				if entry.Type == tptypes.DMSG {
+					continue
+				}
+				nextPK := entry.RemoteEdge(node.pk)
+				// Loop prevention: skip when the next PK is already part of
+				// this path. Per-path check (not global) — the same
+				// intermediate may legitimately appear in other paths at
+				// other depths.
+				if arena.pkInChain(nextPK, node) {
+					continue
+				}
+				children = append(children, arena.add(bfsNode{
+					pk:     nextPK,
+					tpID:   entry.ID,
+					parent: node.self,
+				}))
+			}
+			sort.Stable(bfsNodesByPK(children))
+			nextQueue = append(nextQueue, children...)
+		}
+		// If any dst-candidates were collected at this level, pick the
+		// lowest-latency one and return. BFS continues to higher levels only
+		// when no dst-hit happened — shorter paths still beat longer ones;
+		// the score is purely a tiebreaker among same-hop-count candidates.
+		if len(dstHits) > 0 {
+			best := arena.materializePath(dstHits[0], level)
+			bestScore := pathLatencyScore(best, latencyFor, typeFor, throughputFor)
+			for _, n := range dstHits[1:] {
+				p := arena.materializePath(n, level)
+				if s := pathLatencyScore(p, latencyFor, typeFor, throughputFor); s < bestScore {
+					best = p
+					bestScore = s
+				}
+			}
+			return best, level, true
+		}
+		// Swap rather than copy: nextQueue is truncated at the top of the next
+		// iteration, so the two frontier buffers just alternate.
+		queue, nextQueue = nextQueue, queue
+	}
+
+	return nil, 0, false
+}

--- a/pkg/router/local_route_bfs_test.go
+++ b/pkg/router/local_route_bfs_test.go
@@ -1,0 +1,423 @@
+// pkg/router/local_route_bfs_test.go — equivalence + cost of the local-route
+// BFS rewrite.
+//
+// legacyLocalRouteBFS below is a verbatim copy of the search as it stood before
+// the parent-arena rewrite (per-node []routing.Hop, map-of-maps expansion set,
+// sort.SliceStable). It exists for two reasons: TestLocalRouteBFSMatchesLegacy
+// proves the new search returns the SAME path on randomized graphs, and
+// BenchmarkLocalRouteBFS measures the two side by side on identical input so
+// the before/after numbers come from one run.
+
+// Package router pkg/router/local_route_bfs_test.go c2-net-routing
+package router
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// legacyLocalRouteBFS is the pre-rewrite search, kept for A/B comparison.
+func legacyLocalRouteBFS(
+	src, dst cipher.PubKey,
+	localTps []localTpRef,
+	g localBFSGraph,
+	excludeIntermediates map[cipher.PubKey]struct{},
+	minHops, maxHops int,
+) (path []routing.Hop, level int, ok bool) {
+	type legacyNode struct {
+		pk   cipher.PubKey
+		path []routing.Hop
+	}
+
+	seed := make([]legacyNode, 0, len(localTps))
+	for _, tp := range localTps {
+		if tp.tpType == "dmsg" {
+			continue
+		}
+		if _, hit := excludeIntermediates[tp.remotePK]; hit {
+			continue
+		}
+		seed = append(seed, legacyNode{
+			pk:   tp.remotePK,
+			path: []routing.Hop{{TpID: tp.id, From: src, To: tp.remotePK}},
+		})
+	}
+	sort.SliceStable(seed, func(i, j int) bool { return pkLess(seed[i].pk, seed[j].pk) })
+
+	pkInPath := func(pk cipher.PubKey, path []routing.Hop) bool {
+		if len(path) > 0 && path[0].From == pk {
+			return true
+		}
+		for _, h := range path {
+			if h.To == pk {
+				return true
+			}
+		}
+		return false
+	}
+
+	expandedAtDepth := make(map[cipher.PubKey]map[int]bool)
+	latencyFor := func(id uuid.UUID) float64 { return g.latencyByID[id] }
+	typeFor := func(id uuid.UUID) string { return g.typeByID[id] }
+	throughputFor := func(id uuid.UUID) float64 { return g.throughputByID[id] }
+
+	queue := seed
+	for level = 1; level <= maxHops && len(queue) > 0; level++ {
+		nextQueue := make([]legacyNode, 0)
+		var dstCandidates [][]routing.Hop
+		for _, node := range queue {
+			if node.pk == dst && level >= minHops {
+				dstCandidates = append(dstCandidates, node.path)
+				continue
+			}
+			if level >= maxHops {
+				continue
+			}
+			if _, hit := excludeIntermediates[node.pk]; hit {
+				continue
+			}
+			if expandedAtDepth[node.pk][level] {
+				continue
+			}
+			if expandedAtDepth[node.pk] == nil {
+				expandedAtDepth[node.pk] = make(map[int]bool)
+			}
+			expandedAtDepth[node.pk][level] = true
+			entries := g.byEdge[node.pk]
+			children := make([]legacyNode, 0, len(entries))
+			for _, entry := range entries {
+				if entry == nil {
+					continue
+				}
+				if entry.Type == tptypes.DMSG {
+					continue
+				}
+				nextPK := entry.RemoteEdge(node.pk)
+				if pkInPath(nextPK, node.path) {
+					continue
+				}
+				newPath := make([]routing.Hop, len(node.path), len(node.path)+1)
+				copy(newPath, node.path)
+				newPath = append(newPath, routing.Hop{TpID: entry.ID, From: node.pk, To: nextPK})
+				children = append(children, legacyNode{pk: nextPK, path: newPath})
+			}
+			sort.SliceStable(children, func(i, j int) bool { return pkLess(children[i].pk, children[j].pk) })
+			nextQueue = append(nextQueue, children...)
+		}
+		if len(dstCandidates) > 0 {
+			best := dstCandidates[0]
+			bestScore := pathLatencyScore(best, latencyFor, typeFor, throughputFor)
+			for _, p := range dstCandidates[1:] {
+				if s := pathLatencyScore(p, latencyFor, typeFor, throughputFor); s < bestScore {
+					best = p
+					bestScore = s
+				}
+			}
+			return best, level, true
+		}
+		queue = nextQueue
+	}
+	return nil, 0, false
+}
+
+// bfsFixture is one synthetic transport graph plus the local visor's first-hop
+// set — shaped like the live TPD dataset the wasm visor works over.
+type bfsFixture struct {
+	src, dst cipher.PubKey
+	localTps []localTpRef
+	graph    localBFSGraph
+}
+
+// newBFSFixture builds a random connected graph of `visors` nodes with roughly
+// `degree` transports each. When reachable is false, dst is an isolated visor
+// with no edges at all — the expensive "search finds nothing" case, which is
+// what a NAT'd visor dialing an unreachable destination actually runs.
+func newBFSFixture(seed int64, visors, degree int, reachable bool) bfsFixture {
+	rng := rand.New(rand.NewSource(seed)) //nolint:gosec // deterministic fixture
+
+	pks := make([]cipher.PubKey, visors)
+	for i := range pks {
+		var pk cipher.PubKey
+		_, _ = rng.Read(pk[:]) //nolint:staticcheck // deterministic fixture source
+		pks[i] = pk
+	}
+	src := pks[0]
+	dst := pks[visors-1]
+
+	var entries []*transport.Entry
+	// dst is the last visor; when unreachable we simply never wire an edge to
+	// it (its index is skipped as an endpoint).
+	limit := visors
+	if !reachable {
+		limit = visors - 1
+	}
+	for i := 0; i < limit; i++ {
+		for d := 0; d < degree; d++ {
+			j := rng.Intn(limit)
+			if j == i {
+				continue
+			}
+			typ := tptypes.STCPR
+			if rng.Intn(4) == 0 {
+				typ = tptypes.SUDPH
+			}
+			entries = append(entries, &transport.Entry{
+				ID:            transport.MakeTransportID(pks[i], pks[j], typ),
+				Type:          typ,
+				Edges:         [2]cipher.PubKey{pks[i], pks[j]},
+				Latency:       float64(rng.Intn(200) + 1),
+				ThroughputBps: float64(rng.Intn(1_000_000)),
+			})
+		}
+	}
+
+	byEdge, lat, typ, thr := deriveTransportLookups(entries)
+
+	// The local visor's own first hops: a handful of direct neighbors.
+	var localTps []localTpRef
+	for _, e := range byEdge[src] {
+		localTps = append(localTps, localTpRef{
+			id:       e.ID,
+			remotePK: e.RemoteEdge(src),
+			tpType:   string(e.Type),
+		})
+		if len(localTps) == 4 {
+			break
+		}
+	}
+
+	return bfsFixture{
+		src:      src,
+		dst:      dst,
+		localTps: localTps,
+		graph:    localBFSGraph{byEdge: byEdge, latencyByID: lat, typeByID: typ, throughputByID: thr},
+	}
+}
+
+// TestLocalRouteBFSMatchesLegacy: the parent-arena search returns byte-identical
+// paths to the pre-rewrite one across randomized graphs, reachable and not, at
+// every hop bound. This is the correctness argument for the rewrite — the route
+// selected cannot change.
+func TestLocalRouteBFSMatchesLegacy(t *testing.T) {
+	for _, reachable := range []bool{true, false} {
+		for seed := int64(1); seed <= 12; seed++ {
+			for _, maxHops := range []int{2, 3, 5, 7} {
+				f := newBFSFixture(seed, 60, 3, reachable)
+				if len(f.localTps) == 0 {
+					continue
+				}
+				name := fmt.Sprintf("reach=%v/seed=%d/max=%d", reachable, seed, maxHops)
+				t.Run(name, func(t *testing.T) {
+					wantPath, wantLevel, wantOK := legacyLocalRouteBFS(
+						f.src, f.dst, f.localTps, f.graph, nil, 2, maxHops)
+					gotPath, gotLevel, gotOK := localRouteBFS(
+						f.src, f.dst, f.localTps, f.graph, nil, 2, maxHops)
+					assert.Equal(t, wantOK, gotOK, "found-ness must match")
+					assert.Equal(t, wantLevel, gotLevel, "hop count must match")
+					assert.Equal(t, wantPath, gotPath, "selected path must match exactly")
+				})
+			}
+		}
+	}
+}
+
+// TestLocalRouteBFSHonorsExclusions: intermediate exclusions (DisjointMux) keep
+// working after the rewrite, and both implementations agree.
+func TestLocalRouteBFSHonorsExclusions(t *testing.T) {
+	f := newBFSFixture(7, 60, 3, true)
+	require.NotEmpty(t, f.localTps)
+
+	path, _, ok := localRouteBFS(f.src, f.dst, f.localTps, f.graph, nil, 2, 5)
+	require.True(t, ok, "baseline route must exist")
+	require.NotEmpty(t, path)
+
+	// Exclude the first intermediate the baseline chose; the new path must not
+	// route through it, and must equal what the legacy search picks.
+	excl := map[cipher.PubKey]struct{}{path[0].To: {}}
+	gotPath, gotLevel, gotOK := localRouteBFS(f.src, f.dst, f.localTps, f.graph, excl, 2, 5)
+	wantPath, wantLevel, wantOK := legacyLocalRouteBFS(f.src, f.dst, f.localTps, f.graph, excl, 2, 5)
+	assert.Equal(t, wantOK, gotOK)
+	assert.Equal(t, wantLevel, gotLevel)
+	assert.Equal(t, wantPath, gotPath)
+	for _, h := range gotPath {
+		if h.To != f.dst {
+			assert.NotEqual(t, path[0].To, h.To, "excluded intermediate must not appear")
+		}
+	}
+}
+
+// TestLocalRouteBFSNoLoops: no PK appears twice in a returned path.
+func TestLocalRouteBFSNoLoops(t *testing.T) {
+	for seed := int64(1); seed <= 20; seed++ {
+		f := newBFSFixture(seed, 80, 4, true)
+		if len(f.localTps) == 0 {
+			continue
+		}
+		path, _, ok := localRouteBFS(f.src, f.dst, f.localTps, f.graph, nil, 2, 6)
+		if !ok {
+			continue
+		}
+		seen := map[cipher.PubKey]int{f.src: 1}
+		for _, h := range path {
+			seen[h.To]++
+			assert.Equal(t, 1, seen[h.To], "pk %s repeats in path", h.To)
+		}
+	}
+}
+
+// BenchmarkLocalRouteBFS measures the search on a graph sized like the live TPD
+// dataset. The "unreachable" variants are the ones that matter: with no path to
+// dst the search exhausts the graph to maxHops, which is exactly the case a
+// NAT'd visor hits on every retry.
+func BenchmarkLocalRouteBFS(b *testing.B) {
+	cases := []struct {
+		name      string
+		visors    int
+		degree    int
+		maxHops   int
+		reachable bool
+	}{
+		{"reachable/1k-visors/max5", 1000, 4, 5, true},
+		{"unreachable/1k-visors/max5", 1000, 4, 5, false},
+		{"unreachable/2k-visors/max7", 2000, 4, 7, false},
+	}
+	for _, c := range cases {
+		f := newBFSFixture(42, c.visors, c.degree, c.reachable)
+		if len(f.localTps) == 0 {
+			b.Fatalf("fixture %s produced no local transports", c.name)
+		}
+		b.Run("new/"+c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				localRouteBFS(f.src, f.dst, f.localTps, f.graph, nil, 2, c.maxHops)
+			}
+		})
+		b.Run("legacy/"+c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				legacyLocalRouteBFS(f.src, f.dst, f.localTps, f.graph, nil, 2, c.maxHops)
+			}
+		})
+	}
+}
+
+// BenchmarkLocalRouteMemo contrasts a memo hit with recomputing the search. This
+// is the other half of the fix: before, the memo was gated on a non-zero CXO
+// snapshot timestamp, so on the TTL path (and on any visor whose CXO feed never
+// primes) every call paid the full search below.
+func BenchmarkLocalRouteMemo(b *testing.B) {
+	f := newBFSFixture(42, 1000, 4, true)
+	path, _, ok := localRouteBFS(f.src, f.dst, f.localTps, f.graph, nil, 2, 5)
+	require.True(b, ok)
+	rev := reverseHops(path)
+
+	memo := newLocalRouteMemo()
+	key := localRouteKey{src: f.src, dst: f.dst, min: 2, max: 5}
+	memo.put(1, 99, key, path, rev)
+
+	b.Run("memo-hit", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, _, _, hit := memo.get(1, 99, key); !hit {
+				b.Fatal("expected memo hit")
+			}
+		}
+	})
+	b.Run("recompute", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			localRouteBFS(f.src, f.dst, f.localTps, f.graph, nil, 2, 5)
+		}
+	})
+}
+
+// TestLocalRouteMemoCachesMisses: a searched-and-empty result is cached, and a
+// generation change drops it.
+func TestLocalRouteMemoCachesMisses(t *testing.T) {
+	memo := newLocalRouteMemo()
+	key := localRouteKey{src: cipher.PubKey{0x1}, dst: cipher.PubKey{0x2}, min: 2, max: 5}
+
+	_, _, _, ok := memo.get(1, 1, key)
+	assert.False(t, ok, "empty memo must miss")
+
+	memo.putMiss(1, 1, key)
+	fwd, rev, found, ok := memo.get(1, 1, key)
+	assert.True(t, ok, "a recorded miss is a cache hit")
+	assert.False(t, found, "and reports no path")
+	assert.Nil(t, fwd)
+	assert.Nil(t, rev)
+
+	// New snapshot generation invalidates.
+	_, _, _, ok = memo.get(2, 1, key)
+	assert.False(t, ok, "generation change must invalidate")
+	// So does a change in the local first-hop set.
+	memo.putMiss(1, 1, key)
+	_, _, _, ok = memo.get(1, 2, key)
+	assert.False(t, ok, "local-transport signature change must invalidate")
+}
+
+// TestLocalRouteMemoWorksWithoutCXOVersion is the regression for the CPU peg:
+// the memo keys on the snapshot cache's generation counter, which is set on the
+// TTL path too. Before, it keyed on tpdSnapshot.version — the zero time
+// whenever the discovery client reports no CXO sync timestamp — and
+// calculateLocalRoutes disabled the memo outright for a zero version.
+func TestLocalRouteMemoWorksWithoutCXOVersion(t *testing.T) {
+	c := newTPDSnapshotCache()
+	fetch := func(_ context.Context) ([]*transport.Entry, error) {
+		return []*transport.Entry{{
+			ID:    uuid.New(),
+			Type:  tptypes.STCPR,
+			Edges: [2]cipher.PubKey{{0xA}, {0xB}},
+		}}, nil
+	}
+
+	// No version probe at all — the plain-HTTP / unprimed-CXO path.
+	snap, err := c.snapshot(context.Background(), fetch, nil)
+	require.NoError(t, err)
+	assert.True(t, snap.version.IsZero(), "TTL path carries no CXO timestamp")
+	assert.NotZero(t, snap.gen, "but it does carry a usable generation")
+
+	// Same snapshot served again keeps the same generation, so the memo holds.
+	again, err := c.snapshot(context.Background(), fetch, nil)
+	require.NoError(t, err)
+	assert.Equal(t, snap.gen, again.gen)
+}
+
+// TestLocalTpSignatureOrderIndependent is the second half of the memo
+// regression: WalkTransports hands back the transport set in randomized map
+// order, so a signature that depends on that order changes on nearly every
+// call and resets the memo even when nothing changed.
+func TestLocalTpSignatureOrderIndependent(t *testing.T) {
+	tps := []localTpRef{
+		{id: uuid.MustParse("11111111-1111-1111-1111-111111111111")},
+		{id: uuid.MustParse("22222222-2222-2222-2222-222222222222")},
+		{id: uuid.MustParse("33333333-3333-3333-3333-333333333333")},
+		{id: uuid.MustParse("44444444-4444-4444-4444-444444444444")},
+	}
+	want := localTpSignature(tps)
+
+	rng := rand.New(rand.NewSource(5)) //nolint:gosec // deterministic shuffle
+	for i := 0; i < 50; i++ {
+		shuffled := append([]localTpRef(nil), tps...)
+		rng.Shuffle(len(shuffled), func(a, b int) { shuffled[a], shuffled[b] = shuffled[b], shuffled[a] })
+		assert.Equal(t, want, localTpSignature(shuffled), "signature must not depend on collection order")
+	}
+
+	// But it must still move when the SET changes.
+	assert.NotEqual(t, want, localTpSignature(tps[:3]), "dropping a transport must change the signature")
+	assert.NotEqual(t, want, localTpSignature(append(append([]localTpRef(nil), tps...),
+		localTpRef{id: uuid.MustParse("55555555-5555-5555-5555-555555555555")})),
+		"adding a transport must change the signature")
+}

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"hash/fnv"
 	"net"
 	"sort"
 	"strings"
@@ -1954,12 +1953,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 	log.Debugf("Calculating route locally from %s to %s (self-ping=%v)", src, dst, isSelfPing)
 
 	// Collect local transports
-	type localTp struct {
-		id       uuid.UUID
-		remotePK cipher.PubKey
-		tpType   string
-	}
-	var localTps []localTp
+	var localTps []localTpRef
 
 	r.tm.WalkTransports(func(tp *transport.ManagedTransport) bool {
 		if tp == nil {
@@ -1978,7 +1972,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 		if tp.Entry.Label == transport.LabelSetup {
 			return true
 		}
-		localTps = append(localTps, localTp{
+		localTps = append(localTps, localTpRef{
 			id:       tp.Entry.ID,
 			remotePK: tp.Entry.RemoteEdge(src),
 			tpType:   string(tp.Entry.Type),
@@ -1992,10 +1986,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 
 	// Sort local transports by type preference so direct types (STCPR > SUDPH > STCP)
 	// are tried before DMSG. WalkTransports iteration order is undefined.
-	sort.SliceStable(localTps, func(i, j int) bool {
-		return tptypes.TypePreference(tptypes.Type(localTps[i].tpType)) <
-			tptypes.TypePreference(tptypes.Type(localTps[j].tpType))
-	})
+	sort.Stable(localTpsByTypePref(localTps))
 
 	log.Debugf("Found %d local transports", len(localTps))
 
@@ -2067,7 +2058,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 		tpLatencyMs      map[uuid.UUID]float64
 		tpTypeOf         map[uuid.UUID]string
 		tpThroughput     map[uuid.UUID]float64
-		snapVersion      time.Time // TPD-snapshot generation, for the local-route memo (zero on the no-cache path)
+		snapGen          uint64 // TPD-snapshot generation, for the local-route memo (zero on the no-cache path)
 	)
 	if r.tpdCache != nil {
 		snap, serr := r.tpdCache.snapshot(ctx, dc.GetAllTransports, versionProbe(dc))
@@ -2082,7 +2073,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 		tpLatencyMs = snap.latencyByID
 		tpTypeOf = snap.typeByID
 		tpThroughput = snap.throughputByID
-		snapVersion = snap.version
+		snapGen = snap.gen
 	} else {
 		allEntries, err = dc.GetAllTransports(ctx)
 		if err != nil {
@@ -2181,196 +2172,56 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 	// single js/wasm thread. Only the plain case (no DisjointMux intermediate
 	// exclusions) is memoized; the mux path varies the exclusions per leg on purpose
 	// and must always recompute.
+	//
+	// The generation is snapGen, a counter the snapshot cache bumps on every
+	// rebuild — NOT the CXO sync timestamp it used to be. That timestamp is the
+	// zero time on the cache's TTL path (a discovery client with no CXO version
+	// signal, or a CXO feed that hasn't primed), and the memo used to require it
+	// to be non-zero, so on exactly the visor this cache exists for — the wasm
+	// visor, whose big tpd-all-transports feed frequently never primes — the memo
+	// was unconditionally disabled and every dial re-ran the whole BFS.
 	var (
 		memoKey     localRouteKey
-		memoEnabled = len(excludeIntermediates) == 0 && r.localRoutes != nil && !snapVersion.IsZero()
+		memoEnabled = len(excludeIntermediates) == 0 && r.localRoutes != nil && snapGen != 0
 		localSig    uint64
 	)
 	if memoEnabled {
-		h := fnv.New64a()
-		for i := range localTps {
-			id := localTps[i].id
-			_, _ = h.Write(id[:])
-		}
-		localSig = h.Sum64()
+		localSig = localTpSignature(localTps)
 		memoKey = localRouteKey{src: src, dst: dst, min: minHops, max: maxHops}
-		if fwd, rev, ok := r.localRoutes.get(snapVersion, localSig, memoKey); ok {
+		if fwd, rev, found, ok := r.localRoutes.get(snapGen, localSig, memoKey); ok {
+			if !found {
+				log.Debugf("Local-route memo hit (no path) %s→%s (min=%d max=%d)", src, dst, minHops, maxHops)
+				return nil, nil, fmt.Errorf("local BFS found no path to %s with min_hops=%d max_hops=%d", dst, minHops, maxHops)
+			}
 			log.Debugf("Local-route memo hit %s→%s (min=%d max=%d)", src, dst, minHops, maxHops)
 			return fwd, rev, nil
 		}
 	}
 
-	type bfsNode struct {
-		pk   cipher.PubKey
-		path []routing.Hop
+	best, level, found := localRouteBFS(src, dst, localTps, localBFSGraph{
+		byEdge:         transportsByEdge,
+		latencyByID:    tpLatencyMs,
+		typeByID:       tpTypeOf,
+		throughputByID: tpThroughput,
+	}, excludeIntermediates, minHops, maxHops)
+	if !found {
+		// Cache the miss too. A search that finds nothing is the EXPENSIVE
+		// case — it exhausts the graph to maxHops instead of returning at the
+		// first level that reaches dst — and it is the common one on a visor
+		// with no path to the destination, where the caller retries. Leaving
+		// misses uncached meant the memo never covered the calls that cost
+		// the most.
+		if memoEnabled {
+			r.localRoutes.putMiss(snapGen, localSig, memoKey)
+		}
+		return nil, nil, fmt.Errorf("local BFS found no path to %s with min_hops=%d max_hops=%d", dst, minHops, maxHops)
 	}
-
-	// Seed the BFS with the local transports (each is a 1-hop path
-	// from src to a direct neighbor). Sort for determinism — same
-	// seeding order across calls means same expansion order.
-	//
-	// DMSG seeds are dropped here on purpose. A DMSG transport
-	// relays through a dmsg server (and, since server-to-server
-	// forwarding landed, potentially a chain of dmsg servers) that
-	// neither end of the route can observe — the intermediate
-	// server is unaccounted-for in the transport entry. Using a
-	// DMSG hop anywhere in a multihop route would let data transit
-	// the same dmsg server multiple times with no way to detect it.
-	// Direct DMSG dials (1-hop, src→dst over a DMSG transport) are
-	// fine and were already handled above; the BFS only produces
-	// multihop paths, so we strictly require non-DMSG hops here.
-	seed := make([]bfsNode, 0, len(localTps))
-	for _, tp := range localTps {
-		if tp.tpType == "dmsg" {
-			continue
-		}
-		if _, hit := excludeIntermediates[tp.remotePK]; hit {
-			continue
-		}
-		seed = append(seed, bfsNode{
-			pk: tp.remotePK,
-			path: []routing.Hop{
-				{TpID: tp.id, From: src, To: tp.remotePK},
-			},
-		})
+	log.Debugf("Local BFS found %d-hop route via %v", level, hopPath(best))
+	revPath := reverseHops(best)
+	if memoEnabled {
+		r.localRoutes.put(snapGen, localSig, memoKey, best, revPath)
 	}
-	sort.SliceStable(seed, func(i, j int) bool {
-		return pkLess(seed[i].pk, seed[j].pk)
-	})
-
-	// pkInPath returns true if pk already appears as a From or To in
-	// the path (loop prevention). Per-path membership, not global —
-	// the same intermediate can appear in different paths at
-	// different depths.
-	pkInPath := func(pk cipher.PubKey, path []routing.Hop) bool {
-		if len(path) > 0 && path[0].From == pk {
-			return true
-		}
-		for _, h := range path {
-			if h.To == pk {
-				return true
-			}
-		}
-		return false
-	}
-
-	// expandedAtDepth caches which (pk, depth) pairs we've already
-	// expanded — avoids redundant work when multiple inbound paths
-	// converge on the same node at the same depth. State capped to
-	// O(|visors| × MaxHops), bounded by Config.MaxHops. Without this
-	// the search could revisit identical (node, depth) combinations
-	// exponentially; with it, each (node, depth) is expanded at most
-	// once and the BFS stays linear in graph size.
-	expandedAtDepth := make(map[cipher.PubKey]map[int]bool)
-
-	// Per-TpID latency / type / throughput lookups (hydrated by the CXO
-	// telemetry aggregator on TPD's side) come prebuilt from the snapshot
-	// alongside transportsByEdge — see the derive comment above. Used to
-	// rank multiple same-level dst-hits below.
-	localLatencyFor := func(id uuid.UUID) float64 { return tpLatencyMs[id] }
-	localTypeFor := func(id uuid.UUID) string { return tpTypeOf[id] }
-	localThroughputFor := func(id uuid.UUID) float64 { return tpThroughput[id] }
-
-	queue := seed
-	for level := 1; level <= maxHops && len(queue) > 0; level++ {
-		nextQueue := make([]bfsNode, 0)
-		// Collect ALL dst-hits at this level, then pick the lowest-
-		// latency among them. Pre-fix this loop returned on the first
-		// hit, leaving the BFS's deterministic-by-PK ordering as the
-		// only tiebreaker — which empirically picked geo-distant
-		// intermediates over healthier same-hop-count alternatives.
-		var dstCandidates [][]routing.Hop
-		for _, node := range queue {
-			// Did we reach the destination at an acceptable depth?
-			if node.pk == dst && level >= minHops {
-				dstCandidates = append(dstCandidates, node.path)
-				continue
-			}
-			// Stop expanding nodes already at maxHops — children would
-			// exceed the cap.
-			if level >= maxHops {
-				continue
-			}
-			// Skip excluded intermediates (DisjointMux).
-			if _, hit := excludeIntermediates[node.pk]; hit {
-				continue
-			}
-			// Skip if we've already expanded this (pk, depth) — same
-			// children would be produced. Different from the previous
-			// global visited[pk] check, which (incorrectly) blocked
-			// the same node at OTHER depths and could shadow longer
-			// paths when a shorter one existed.
-			if expandedAtDepth[node.pk][level] {
-				continue
-			}
-			if expandedAtDepth[node.pk] == nil {
-				expandedAtDepth[node.pk] = make(map[int]bool)
-			}
-			expandedAtDepth[node.pk][level] = true
-			// Expand: every transport from this node to a new neighbor
-			// becomes a candidate next node, sorted by remote-PK for
-			// deterministic order. DMSG entries are skipped — see the
-			// seed-loop comment above; a DMSG hop anywhere in a
-			// multihop path makes the route unaccountable since the
-			// dmsg server (and any server-to-server hops) are
-			// invisible to both endpoints.
-			entries := transportsByEdge[node.pk]
-			children := make([]bfsNode, 0, len(entries))
-			for _, entry := range entries {
-				if entry == nil {
-					continue
-				}
-				if entry.Type == tptypes.DMSG {
-					continue
-				}
-				nextPK := entry.RemoteEdge(node.pk)
-				// Loop prevention: skip when the next PK is already
-				// part of this path. Per-path check (not global) —
-				// the same intermediate may legitimately appear in
-				// other paths at other depths.
-				if pkInPath(nextPK, node.path) {
-					continue
-				}
-				newPath := make([]routing.Hop, len(node.path), len(node.path)+1)
-				copy(newPath, node.path)
-				newPath = append(newPath, routing.Hop{
-					TpID: entry.ID,
-					From: node.pk,
-					To:   nextPK,
-				})
-				children = append(children, bfsNode{pk: nextPK, path: newPath})
-			}
-			sort.SliceStable(children, func(i, j int) bool {
-				return pkLess(children[i].pk, children[j].pk)
-			})
-			nextQueue = append(nextQueue, children...)
-		}
-		// If any dst-candidates were collected at this level, pick the
-		// lowest-latency one and return. BFS continues to higher levels
-		// only when no dst-hit happened — shorter paths still beat
-		// longer ones, as before; the change is purely a tiebreaker
-		// among same-hop-count candidates.
-		if len(dstCandidates) > 0 {
-			best := dstCandidates[0]
-			bestScore := pathLatencyScore(best, localLatencyFor, localTypeFor, localThroughputFor)
-			for _, p := range dstCandidates[1:] {
-				if s := pathLatencyScore(p, localLatencyFor, localTypeFor, localThroughputFor); s < bestScore {
-					best = p
-					bestScore = s
-				}
-			}
-			log.Debugf("Local BFS found %d-hop route via %v (best of %d same-level candidates, score=%.1fms)",
-				level, hopPath(best), len(dstCandidates), bestScore)
-			rev := reverseHops(best)
-			if memoEnabled {
-				r.localRoutes.put(snapVersion, localSig, memoKey, best, rev)
-			}
-			return best, rev, nil
-		}
-		queue = nextQueue
-	}
-
-	return nil, nil, fmt.Errorf("local BFS found no path to %s with min_hops=%d max_hops=%d", dst, minHops, maxHops)
+	return best, revPath, nil
 }
 
 // localRouteMemo caches calculateLocalRoutes' multi-hop BFS result. That BFS over
@@ -2389,7 +2240,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 // ExcludeIntermediatePKs per leg on purpose and must always recompute.
 type localRouteMemo struct {
 	mu       sync.Mutex
-	version  time.Time
+	gen      uint64
 	localSig uint64
 	m        map[localRouteKey]localRoutePair
 }
@@ -2399,42 +2250,74 @@ type localRouteKey struct {
 	min, max int
 }
 
-type localRoutePair struct{ fwd, rev []routing.Hop }
+// localRoutePair is one memoized answer. found=false records a searched-and-
+// empty result — the "no path" case, which costs MORE to compute than a hit
+// (it exhausts the graph rather than stopping at the first level that reaches
+// dst) and so is the one most worth caching.
+type localRoutePair struct {
+	fwd, rev []routing.Hop
+	found    bool
+}
 
 func newLocalRouteMemo() *localRouteMemo { return &localRouteMemo{} }
 
-// get returns cached (fwd, rev) copies for k when the memo's generation matches
-// the current snapshot version + local signature; a mismatch or miss returns ok
-// false so the caller recomputes (and put resets the generation).
-func (c *localRouteMemo) get(version time.Time, sig uint64, k localRouteKey) (fwd, rev []routing.Hop, ok bool) {
+// get returns the cached answer for k when the memo's generation matches the
+// current snapshot generation + local signature. ok=false means "not cached,
+// recompute"; ok=true with found=false means "cached: this search finds no
+// path".
+func (c *localRouteMemo) get(gen, sig uint64, k localRouteKey) (fwd, rev []routing.Hop, found, ok bool) {
+	if c == nil {
+		return nil, nil, false, false
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.m == nil || !c.version.Equal(version) || c.localSig != sig {
-		return nil, nil, false
+	if c.m == nil || c.gen != gen || c.localSig != sig {
+		return nil, nil, false, false
 	}
 	p, hit := c.m[k]
 	if !hit {
-		return nil, nil, false
+		return nil, nil, false, false
 	}
-	return append([]routing.Hop(nil), p.fwd...), append([]routing.Hop(nil), p.rev...), true
+	if !p.found {
+		return nil, nil, false, true
+	}
+	return append([]routing.Hop(nil), p.fwd...), append([]routing.Hop(nil), p.rev...), true, true
 }
 
 // put stores (fwd, rev) copies for k, resetting the whole generation first when the
-// snapshot version or local signature moved (keeps the map fresh and bounded).
-func (c *localRouteMemo) put(version time.Time, sig uint64, k localRouteKey, fwd, rev []routing.Hop) {
+// snapshot generation or local signature moved (keeps the map fresh and bounded).
+func (c *localRouteMemo) put(gen, sig uint64, k localRouteKey, fwd, rev []routing.Hop) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.m == nil || !c.version.Equal(version) || c.localSig != sig {
-		c.version = version
+	c.reseatLocked(gen, sig)
+	c.m[k] = localRoutePair{
+		fwd:   append([]routing.Hop(nil), fwd...),
+		rev:   append([]routing.Hop(nil), rev...),
+		found: true,
+	}
+}
+
+// putMiss records that k has no acceptable path in this generation.
+func (c *localRouteMemo) putMiss(gen, sig uint64, k localRouteKey) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.reseatLocked(gen, sig)
+	c.m[k] = localRoutePair{}
+}
+
+// reseatLocked drops the whole map when the generation moved, so a stale route
+// is never served and the map stays bounded to one graph's worth of entries.
+func (c *localRouteMemo) reseatLocked(gen, sig uint64) {
+	if c.m == nil || c.gen != gen || c.localSig != sig {
+		c.gen = gen
 		c.localSig = sig
 		c.m = make(map[localRouteKey]localRoutePair)
-	}
-	c.m[k] = localRoutePair{
-		fwd: append([]routing.Hop(nil), fwd...),
-		rev: append([]routing.Hop(nil), rev...),
 	}
 }
 

--- a/pkg/router/tpd_cache.go
+++ b/pkg/router/tpd_cache.go
@@ -58,8 +58,13 @@ const defaultTPDSnapshotTTL = 5 * time.Minute
 // pointer under the write lock, so a snapshot handed to a caller is
 // never mutated underneath it.
 type tpdSnapshotCache struct {
-	mu    sync.RWMutex
-	snap  *tpdSnapshot
+	mu   sync.RWMutex
+	snap *tpdSnapshot
+	// gen counts snapshot rebuilds. It is the identity consumers memoize
+	// against (see localRouteMemo): unlike tpdSnapshot.version it is set on
+	// EVERY path, including the TTL fallback where there is no CXO timestamp
+	// to key on. Starts at 1 so zero can mean "no snapshot / no cache".
+	gen   uint64
 	ttl   time.Duration
 	clock func() time.Time // injectable for tests
 }
@@ -94,6 +99,10 @@ type tpdSnapshot struct {
 	// (a discovery client with no version signal — tests, bare HTTP). It is
 	// not consulted on the CXO path.
 	expires time.Time
+	// gen is the cache's rebuild counter at the time this snapshot was
+	// built — a generation identity that exists on both the CXO and the TTL
+	// path, which version does not. Never zero for a real snapshot.
+	gen uint64
 }
 
 // tpdVersioner is implemented by a discovery client whose GetAllTransports
@@ -177,8 +186,11 @@ func (c *tpdSnapshotCache) fresh() *tpdSnapshot {
 
 // buildSnapshot materializes a snapshot (and its derived lookups) from a
 // freshly-fetched entry set, stamping it with the CXO version (zero on the
-// TTL path) and always setting the wall-clock TTL floor.
+// TTL path), the next generation counter, and the wall-clock TTL floor.
+//
+// Callers hold c.mu for writing (gen is bumped here).
 func (c *tpdSnapshotCache) buildSnapshot(entries []*transport.Entry, version time.Time) *tpdSnapshot {
+	c.gen++
 	byID := make(map[uuid.UUID]*transport.Entry, len(entries))
 	for _, e := range entries {
 		if e != nil {
@@ -195,6 +207,7 @@ func (c *tpdSnapshotCache) buildSnapshot(entries []*transport.Entry, version tim
 		throughputByID: throughputByID,
 		version:        version,
 		expires:        c.clock().Add(c.ttl),
+		gen:            c.gen,
 	}
 }
 


### PR DESCRIPTION
A fresh browser profile of the in-tab wasm visor put `calculateLocalRoutes` at **46% cumulative — the only application frame** — under a wall of GC (`scanObject`, `bulkBarrierPreWrite`, `wbBufFlush1`) and scheduler frames. On js/wasm with `GOMAXPROCS=1`, GC cannot run in parallel, so that is what heavy allocation looks like from the profiler.

It is not a boot cost. Bursts of 84-93% of a core recur indefinitely, 10+ minutes after boot, in 30-55s bursts interleaved with 1-5% idle windows:

```
16:28:01  92% (31s)   16:29:44  92% (54s)   16:32:00  84% (51s)
16:32:46  93% (45s)   16:33:31  87% (45s)
```

### Why the memo never hit — two independent reasons

**1. Gated on a signal that is zero on the path that needs it.** `memoEnabled` required a non-zero `tpdSnapshot.version`, which is the CXO `tpd-all-transports` sync timestamp. The snapshot cache leaves that as the zero time on its TTL path — a discovery client with no CXO version signal, or a CXO feed that has not primed. So on exactly the visor the memo exists for, it was disabled outright and every dial re-ran the whole BFS. #4382/#4384 fixed the derived-lookup rebuild (that stayed fixed); #4394 added the memo but keyed it on the one field absent from the fallback path.

**2. The local half was randomized per call.** The signature hashed first-hop transport IDs in *collection order*, and they come from `WalkTransports`, which snapshots a Go map — order randomized per call. `sort.SliceStable` by type preference does not fix it, since same-type transports keep their random relative order. The signature differed nearly every call, and a signature change resets the memo, so it thrashed itself even on a CXO-primed visor.

Misses were also never cached — and a search that finds no path is the *expensive* case, exhausting the graph to `maxHops` rather than stopping at the first level reaching dst.

### Fix

- `tpdSnapshotCache` gains a rebuild-generation counter set on **both** the CXO and TTL paths; the memo keys on that instead of the CXO timestamp.
- `localTpSignature` is order-independent.
- Misses are memoized.
- The search moves to `pkg/router/local_route_bfs.go` with parent-linked arena nodes instead of a `[]routing.Hop` per frontier node — it no longer allocates a path copy per graph edge traversed; the path is materialized only for nodes that reach dst.

No flags, no gates.

### Measurements (`-benchmem`, legacy implementation kept in the test file for a same-run A/B)

| case | before | after |
|---|---|---|
| no path, 1k visors, max5 | 7.09 ms · 6.87 MB · 14822 allocs | 3.93 ms · 4.18 MB · **1224** |
| no path, 2k visors, max7 | 37.8 ms · 36.9 MB · 61187 allocs | 24.8 ms · 20.7 MB · **5274** |
| route found, 1k, max5 | 6.46 ms · 5.89 MB · 12667 allocs | 3.51 ms · 3.97 MB · **1052** |
| **memo hit vs recompute** | 3.00 ms · 3.97 MB · 1052 allocs | **724 ns · 804 B · 4** |

The BFS rewrite is ~1.6x time and ~12x allocations; the memo fix is the structural win at ~4000x per repeat dial. Repeat dials are the workload that produced the 45-55s bursts. (Memo row reproduced independently on review.)

### Correctness

`TestLocalRouteBFSMatchesLegacy` runs old and new side by side over 96 randomized graphs (reachable and unreachable x 12 seeds x maxHops 2/3/5/7) and asserts **byte-identical** returned paths, plus level and found-ness. Exclusions and loop-freedom are covered separately. Expansion order, per-level dst-candidate collection and the `pathLatencyScore` tiebreak are unchanged, so route selection cannot change. The memo generation resets on any snapshot rebuild or local-transport-set change, so a stale route is never served past a graph change; mux legs (non-empty `ExcludeIntermediatePKs`) still bypass the memo entirely.

`go test ./pkg/router/` passes, lint clean, binary builds.