### PR TITLE
fix(router): stop planning mux legs the destination is guaranteed to refuse

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -232,6 +232,24 @@ type RouteGroup struct {
 	// (aux legs). Guarded by rg.mu.
 	legForwardHops map[uuid.UUID][]routing.Hop
 
+	// legRemoteTp maps a leg's LOCAL first-hop transport ID (the same key
+	// legForwardHops uses) to the FAR END's first-hop transport ID for that
+	// leg — i.e. Reverse[0].TpID of the plan this leg was dialed with.
+	//
+	// That value is an exact mirror of one entry in the peer's own rg.tps: the
+	// setup node installs `respEdge.Forward` on the destination, which is the
+	// ForwardRule generated for the reverse route's first hop, and
+	// appendRouteToGroup registers r.tm.Transport(rules.Forward.NextTransportID())
+	// as that leg's transport there. Keeping the mapping locally lets the
+	// aux-leg planners predict — before paying a setup-node round trip — that
+	// the destination would refuse a plan whose reverse leaves it over a
+	// transport it already has a leg on. Initiator-local; no wire change.
+	//
+	// Read only through remoteLegTransportIDs, which walks the LIVE tps, so an
+	// entry for a leg that has since been pruned stops excluding anything
+	// (it is inert, not sticky). Guarded by rg.mu.
+	legRemoteTp map[uuid.UUID]uuid.UUID
+
 	// initiator is true when this visor dialed the remote end (called
 	// router.DialRoutes); false when this visor accepted the route via
 	// AcceptRoutes / saveRouteGroupRules from a setup-node request.
@@ -420,6 +438,7 @@ func NewRouteGroup(cfg *RouteGroupConfig, rt routing.Table, desc routing.RouteDe
 		legE2ELatency:      make(map[uuid.UUID]float64),
 		legOWD:             make(map[uuid.UUID]*sbdWindow),
 		legForwardHops:     make(map[uuid.UUID][]routing.Hop),
+		legRemoteTp:        make(map[uuid.UUID]uuid.UUID),
 		legRecvSnap:        make(map[uuid.UUID]uint64),
 	}
 
@@ -1579,15 +1598,53 @@ func (rg *RouteGroup) SetForwardHops(hops []routing.Hop) {
 	}
 }
 
-// recordLegHops stores a mux leg's full forward route keyed by its
-// first-hop transport ID. Called by AddMuxRouteByHops for aux legs.
-func (rg *RouteGroup) recordLegHops(hops []routing.Hop) {
-	if len(hops) == 0 {
+// recordLegRoute stores a mux leg's full forward route keyed by its first-hop
+// transport ID, AND the far end's first-hop transport for that leg, taken from
+// the reverse path the leg was dialed with. Called by every aux-mux-leg commit path and by
+// the primary dial, so remoteLegTransportIDs mirrors the peer's live leg
+// transports. A nil/empty rev records the forward route only (best-effort: an
+// unrecorded leg simply contributes no exclusion).
+func (rg *RouteGroup) recordLegRoute(fwd, rev []routing.Hop) {
+	if len(fwd) == 0 {
 		return
 	}
 	rg.mu.Lock()
-	rg.legForwardHops[hops[0].TpID] = hops
+	rg.legForwardHops[fwd[0].TpID] = fwd
+	if len(rev) > 0 {
+		rg.legRemoteTp[fwd[0].TpID] = rev[0].TpID
+	}
 	rg.mu.Unlock()
+}
+
+// remoteLegTransportIDs returns the far end's first-hop transport ID for every
+// LIVE leg of this group — the peer's own rg.tps set, as far as this side
+// recorded it. A planned aux leg whose Reverse[0].TpID is in this set is
+// guaranteed to be refused by the peer's appendRouteToGroup/appendRouteAsymmetric
+// duplicate-transport guard, so the planners drop it BEFORE the setup-node dial.
+//
+// Derived from the live tps on every call (not from an accumulating set), so a
+// leg that has been pruned locally immediately stops excluding its remote
+// transport and a replacement leg over that same far-end link can be built
+// again. Callers must NOT hold rg.mu.
+func (rg *RouteGroup) remoteLegTransportIDs() []uuid.UUID {
+	if rg == nil {
+		return nil
+	}
+	rg.mu.Lock()
+	defer rg.mu.Unlock()
+	if len(rg.legRemoteTp) == 0 {
+		return nil
+	}
+	out := make([]uuid.UUID, 0, len(rg.tps))
+	for _, tp := range rg.tps {
+		if tp == nil {
+			continue
+		}
+		if remote, ok := rg.legRemoteTp[tp.Entry.ID]; ok {
+			out = append(out, remote)
+		}
+	}
+	return out
 }
 
 // legHopsFor returns a copy of the full forward route for the leg on

--- a/pkg/router/route_group_mux_test.go
+++ b/pkg/router/route_group_mux_test.go
@@ -438,7 +438,7 @@ func TestLegLivenessKeepsEchoingLeg(t *testing.T) {
 }
 
 // TestMuxStatsReportsFullMultihopLegChain verifies that a mux leg whose full
-// forward route was recorded (SetForwardHops for the primary, recordLegHops for
+// forward route was recorded (SetForwardHops for the primary, recordLegRoute for
 // aux legs — the two paths the dial-side establishment sites feed) reports EVERY
 // hop in MuxStats().Legs[i].Hops, ending at the true destination — not just the
 // leg's first-hop transport remote (the first INTERMEDIATE, which the pre-fix
@@ -460,12 +460,12 @@ func TestMuxStatsReportsFullMultihopLegChain(t *testing.T) {
 	})
 
 	// Leg 1 (aux): a 2-hop forward path src -> mid1 -> dst, recorded the way the
-	// establishMuxRoutes / rotation add-leg sites now do via recordLegHops.
+	// establishMuxRoutes / rotation add-leg sites now do via recordLegRoute.
 	mid1, _ := cipher.GenerateKeyPair()
-	rg.recordLegHops([]routing.Hop{
+	rg.recordLegRoute([]routing.Hop{
 		{TpID: mts[1].Entry.ID, From: src, To: mid1},
 		{TpID: uuid.New(), From: mid1, To: dst},
-	})
+	}, nil)
 
 	// Leg 2: deliberately NOT recorded — models the pre-fix gap.
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -280,6 +280,32 @@ type DialOptions struct {
 	ReverseHops           []routing.Hop // If set, use these hops for reverse path (skips route calculation)
 	MuxRoutes             int           // Number of parallel routes to establish (0 or 1 = single route, >1 = mux)
 	ExcludeTransportIDs   []uuid.UUID   // Transport IDs to exclude from route calculation (for mux)
+	// ExcludeRemoteTransportIDs is the DESTINATION-side analog of
+	// ExcludeTransportIDs: transport IDs the REVERSE path must not leave the
+	// destination over.
+	//
+	// Why it exists: the setup node hands the destination `respEdge.Forward`,
+	// which is the ForwardRule generated for the REVERSE route's first hop
+	// (setupnode.go GenerateRules — fwdRules is keyed by each route's
+	// Hops[0].From, and the reverse route starts at the destination). So the
+	// destination's route group registers one transport per leg, and that
+	// transport is exactly `Reverse[0].TpID` of the plan the initiator dialed.
+	// appendRouteToGroup then refuses any leg whose transport is already in
+	// that set ("refusing to append mux leg over transport %s already in the
+	// group"), because two legs over one link break the mux data plane (#3954).
+	//
+	// The forward and reverse paths are ranked INDEPENDENTLY (pickDisjointPath),
+	// and a 0-intermediate direct reverse carries no intermediates to exclude —
+	// so ExcludeIntermediatePKs cannot keep a new leg's reverse off the direct
+	// transport the destination is already using for the primary leg. Without
+	// this field every aux mux leg to such a destination is planned, dialed
+	// through the setup node (full ID reservation + intermediary rule install)
+	// and then refused: the churn measured on the live setup nodes.
+	//
+	// Populated by the aux-mux-leg planners from the group's live legs
+	// (RouteGroup.remoteLegTransportIDs). Unset for every non-mux dial, which
+	// is therefore byte-identical to before.
+	ExcludeRemoteTransportIDs []uuid.UUID
 	// Datagram, when true, asks the dial to build a faithful-UDP
 	// DatagramRouteGroup sibling over the established route (#2607).
 	// The route's reliable RouteGroup is still set up exactly as

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -353,7 +353,7 @@ func (r *router) DialRoutes(
 				}
 				nrg, rules, winIdx, rerr := r.raceCandidateSetup(ctx, log, candidates, dial, handshake, onLoser)
 				if rerr == nil {
-					return r.finishDial(log, nrg, rules, candidates[winIdx].Forward, forwardDesc, opts, rPK, lPort, rPort), nil
+					return r.finishDial(log, nrg, rules, candidates[winIdx].Forward, candidates[winIdx].Reverse, forwardDesc, opts, rPK, lPort, rPort), nil
 				}
 				if ctx.Err() != nil {
 					return nil, ctx.Err()
@@ -597,7 +597,7 @@ func (r *router) DialRoutes(
 
 		// The route group is up: this is the working base. Wire mux
 		// growth / self-heal / hooks on top and return.
-		return r.finishDial(log, nrg, rules, forwardPath, forwardDesc, opts, rPK, lPort, rPort), nil
+		return r.finishDial(log, nrg, rules, forwardPath, reversePath, forwardDesc, opts, rPK, lPort, rPort), nil
 	}
 
 	// Should never reach here, but handle it gracefully
@@ -615,7 +615,7 @@ func (r *router) finishDial(
 	log *logging.Logger,
 	nrg *NoiseRouteGroup,
 	rules routing.EdgeRules,
-	forwardPath []routing.Hop,
+	forwardPath, reversePath []routing.Hop,
 	forwardDesc routing.RouteDescriptor,
 	opts *DialOptions,
 	rPK cipher.PubKey,
@@ -623,6 +623,11 @@ func (r *router) finishDial(
 ) net.Conn {
 	// Store the complete forward route hops for later retrieval
 	nrg.SetForwardHops(forwardPath)
+	// Record the PRIMARY leg's far-end transport (reversePath[0].TpID) — the one
+	// the destination's route group registers for this leg. It is what every aux
+	// mux leg planned later must avoid re-using on its own reverse path, since
+	// the destination refuses a second leg over a transport already in its group.
+	nrg.rg.recordLegRoute(forwardPath, reversePath)
 
 	nrg.rg.startOffServiceLoops()
 
@@ -1351,6 +1356,31 @@ fetchRoutesAgain:
 				return localFwd, localRev, nil
 			}
 			log.Warnf("diversify: no disjoint first-hop transport to %s is free; extra tunnel shares an existing first hop (aggregation limited)", dst)
+		}
+	}
+
+	// Keep an aux mux leg's REVERSE off the far-end transports the destination's
+	// route group already has a leg on. The setup node installs the reverse
+	// route's first-hop ForwardRule on the destination, whose appendRouteToGroup
+	// refuses a duplicate transport — so a reverse candidate leaving over one of
+	// these is a route setup that is certain to fail. The forward and reverse
+	// directions are ranked independently below and a direct reverse carries no
+	// intermediates, so ExcludeIntermediatePKs cannot express this; only the
+	// far-end transport ID can.
+	//
+	// Preference, not a hard cut (same discipline as the forward diversify
+	// above): if no reverse candidate leaves over a free transport we keep the
+	// full set and let the caller's pre-dial gate decide, so no dial is ever
+	// starved of a route by this filter.
+	if len(opts.ExcludeRemoteTransportIDs) > 0 {
+		if disjoint := filterDisjointFirstHop(paths[backward], opts.ExcludeRemoteTransportIDs); len(disjoint) > 0 {
+			if len(disjoint) != len(paths[backward]) {
+				log.Debugf("mux: %d/%d reverse candidate(s) leave the destination over a free transport; preferring those",
+					len(disjoint), len(paths[backward]))
+			}
+			paths[backward] = disjoint
+		} else {
+			log.Debugf("mux: every reverse candidate leaves %s over a transport its route group already uses; the leg will be skipped before the setup-node dial", dst)
 		}
 	}
 
@@ -2428,6 +2458,13 @@ func (r *router) establishMuxRoutes(
 	rPK := forwardDesc.DstPK()
 	excludeIDs := []uuid.UUID{primaryTpID}
 
+	// Far-end transports the group's live legs (here: the primary) already
+	// occupy. See DialOptions.ExcludeRemoteTransportIDs — the destination
+	// refuses a leg whose reverse path leaves it over one of these, so the
+	// exclude set accumulates each planned leg's Reverse[0] exactly the way
+	// excludeIDs accumulates its Forward[0].
+	excludeRemoteIDs := nrg.rg.remoteLegTransportIDs()
+
 	// Disjoint-intermediate routing is the default for multiplexed
 	// routes: routes 2..N must NOT share intermediate visors with
 	// any earlier route (primary or aux). Operators who want
@@ -2510,18 +2547,19 @@ func (r *router) establishMuxRoutes(
 		}
 
 		muxOpts := &DialOptions{
-			MinForwardRts:          1,
-			MaxForwardRts:          1,
-			MinConsumeRts:          1,
-			MaxConsumeRts:          1,
-			Retries:                1,
-			MinHops:                parentMinHops,
-			ForwardMinHops:         parentFwdMinHops,
-			ReverseMinHops:         parentRevMinHops,
-			AppName:                parentAppName,
-			ExcludeTransportIDs:    excludeIDs,
-			ExcludeIntermediatePKs: excludePKs,
-			ExcludeDMSG:            true,
+			MinForwardRts:             1,
+			MaxForwardRts:             1,
+			MinConsumeRts:             1,
+			MaxConsumeRts:             1,
+			Retries:                   1,
+			MinHops:                   parentMinHops,
+			ForwardMinHops:            parentFwdMinHops,
+			ReverseMinHops:            parentRevMinHops,
+			AppName:                   parentAppName,
+			ExcludeTransportIDs:       excludeIDs,
+			ExcludeRemoteTransportIDs: excludeRemoteIDs,
+			ExcludeIntermediatePKs:    excludePKs,
+			ExcludeDMSG:               true,
 		}
 
 		// Mux aux legs plan over the GLOBAL TPD graph via the route-finder
@@ -2597,6 +2635,24 @@ func (r *router) establishMuxRoutes(
 			excludeIDs = append(excludeIDs, muxFwd[0].TpID)
 		}
 
+		// Destination-side twin of the check above. The setup node installs the
+		// reverse route's first-hop ForwardRule on the DESTINATION, so its route
+		// group holds one transport per leg — exactly Reverse[0].TpID — and it
+		// refuses a second leg over a transport already in that set. Forward and
+		// reverse are ranked independently, and a direct (0-intermediate) reverse
+		// gives ExcludeIntermediatePKs nothing to bite on, so the finder happily
+		// pairs a disjoint forward with a reverse over the destination's primary
+		// link. That plan is guaranteed to be refused after a full setup-node
+		// round trip, so drop it here and let the next slot diverge.
+		if firstHopTransportExcluded(muxRev, excludeRemoteIDs) {
+			log.Debugf("Mux route %d/%d: planned leg's reverse leaves the destination over transport %s, which already carries one of its legs (it would be refused); skipping before dial",
+				i+1, maxCount, muxRev[0].TpID)
+			continue
+		}
+		if len(muxRev) > 0 {
+			excludeRemoteIDs = append(excludeRemoteIDs, muxRev[0].TpID)
+		}
+
 		muxKeepAlive := DefaultRouteKeepAlive
 		if opts != nil && opts.KeepAlive > 0 {
 			muxKeepAlive = opts.KeepAlive
@@ -2662,7 +2718,7 @@ func (r *router) establishMuxRoutes(
 			// path's first-hop TpID matches muxRules.Forward.NextTransportID (the
 			// transport appendRouteAsymmetric registered), so legHopsFor finds it.
 			if p.addFwd {
-				nrg.rg.recordLegHops(p.req.Forward)
+				nrg.rg.recordLegRoute(p.req.Forward, p.req.Reverse)
 			}
 			log.Infof("Mux route %d/%d established (fwd=%v rev=%v) via tp %s",
 				p.slot, maxCount, p.addFwd, p.addRev, muxRules.Forward.NextTransportID())
@@ -2738,6 +2794,11 @@ func (r *router) addOneAuxLeg(ctx context.Context, nrg *NoiseRouteGroup, opts *D
 	}
 	nrg.rg.mu.Unlock()
 
+	// Far-end transports this group's live legs already occupy. The destination
+	// refuses a leg whose reverse leaves it over one of these, so they must be
+	// excluded from the REVERSE pick just as excludeIDs is from the forward one.
+	excludeRemoteIDs := nrg.rg.remoteLegTransportIDs()
+
 	parentMinHops := 0
 	parentFwdMinHops := 0
 	parentAppName := ""
@@ -2748,17 +2809,18 @@ func (r *router) addOneAuxLeg(ctx context.Context, nrg *NoiseRouteGroup, opts *D
 	}
 
 	muxOpts := &DialOptions{
-		MinForwardRts:          1,
-		MaxForwardRts:          1,
-		MinConsumeRts:          1,
-		MaxConsumeRts:          1,
-		Retries:                1,
-		MinHops:                parentMinHops,
-		ForwardMinHops:         parentFwdMinHops,
-		AppName:                parentAppName,
-		ExcludeTransportIDs:    excludeIDs,
-		ExcludeIntermediatePKs: excludePKs,
-		ExcludeDMSG:            true,
+		MinForwardRts:             1,
+		MaxForwardRts:             1,
+		MinConsumeRts:             1,
+		MaxConsumeRts:             1,
+		Retries:                   1,
+		MinHops:                   parentMinHops,
+		ForwardMinHops:            parentFwdMinHops,
+		AppName:                   parentAppName,
+		ExcludeTransportIDs:       excludeIDs,
+		ExcludeRemoteTransportIDs: excludeRemoteIDs,
+		ExcludeIntermediatePKs:    excludePKs,
+		ExcludeDMSG:               true,
 	}
 
 	// SHARED WARM-ROUTE POOL (phase 1): before the route-finder round-trip, try
@@ -2775,7 +2837,7 @@ func (r *router) addOneAuxLeg(ctx context.Context, nrg *NoiseRouteGroup, opts *D
 		keyMinHops = uint16(e) //nolint:gosec
 	}
 	var muxFwd, muxRev []routing.Hop
-	if cf, cr, ok := r.warmRoutes.bestPlan(rPK, keyMinHops, excludeIDs, excludePKs); ok {
+	if cf, cr, ok := r.warmRoutes.bestPlan(rPK, keyMinHops, excludeIDs, excludeRemoteIDs, excludePKs); ok {
 		muxFwd, muxRev = cf, cr
 		log.WithField("first_tp", func() string {
 			if len(cf) > 0 {
@@ -2831,6 +2893,21 @@ func (r *router) addOneAuxLeg(ctx context.Context, nrg *NoiseRouteGroup, opts *D
 		}
 	}
 
+	// The DESTINATION-side twin of the check above, and the one that was missing.
+	// The setup node installs the reverse route's first-hop ForwardRule on the
+	// destination, so the destination's route group holds exactly Reverse[0].TpID
+	// per leg — and its appendRouteToGroup refuses a second leg over a transport
+	// already in that set. Forward and reverse are ranked INDEPENDENTLY and a
+	// direct (0-intermediate) reverse carries nothing for ExcludeIntermediatePKs
+	// to bite on, so the finder keeps handing back a reverse over the destination's
+	// primary-leg transport. Dialing that burns a full setup-node round trip (ID
+	// reservation on every hop + intermediary rule install) for a guaranteed
+	// "refusing to append mux leg over transport %s already in the group".
+	// Skip before the dial; the group keeps the legs it has and retries next tick.
+	if firstHopTransportExcluded(muxRev, excludeRemoteIDs) {
+		return fmt.Errorf("rotation add-leg: planned leg's reverse leaves the destination over transport %s, which already carries one of its legs (it would be refused); skipping before dial", muxRev[0].TpID)
+	}
+
 	muxKeepAlive := DefaultRouteKeepAlive
 	if opts != nil && opts.KeepAlive > 0 {
 		muxKeepAlive = opts.KeepAlive
@@ -2863,7 +2940,7 @@ func (r *router) addOneAuxLeg(ctx context.Context, nrg *NoiseRouteGroup, opts *D
 	// Record this leg's full forward route (addFwd is always true here) so the
 	// per-leg mux view shows its whole path instead of the first-hop transport's
 	// remote — which for a multihop leg is the first intermediate, not the exit.
-	nrg.rg.recordLegHops(muxFwd)
+	nrg.rg.recordLegRoute(muxFwd, muxRev)
 	log.Infof("Rotation aux leg established (addRev=%v) via tp %s", addRev, muxRules.Forward.NextTransportID())
 	return nil
 }

--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -141,9 +141,24 @@ func (r *router) appendRouteToGroup(nrg *NoiseRouteGroup, rules routing.EdgeRule
 		return fmt.Errorf("SaveRoutingRules: %w", err)
 	}
 
+	// Every rejection below must also drop the rules SaveRoutingRules just
+	// installed, exactly as appendRouteAsymmetric does. A refused aux leg is
+	// never added to the group, so nothing will ever read or expire these two
+	// rules through the group; and the setup node cannot clean them up either —
+	// CreateRouteGroup only records the destination edge in its teardown tracker
+	// AFTER AddEdgeRules returns ok, so a refusal leaves the pair pinned until
+	// the ~10-minute keepalive GC. On the live network the duplicate-transport
+	// refusal below fires often enough (98 of 128 sampled route-setup failures)
+	// that the leak is a standing rule-table and transport-pin cost on every
+	// popular exit.
+	drop := func() {
+		r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
+	}
+
 	nextTpID := rules.Forward.NextTransportID()
 	tp := r.tm.Transport(nextTpID)
 	if tp == nil {
+		drop()
 		return fmt.Errorf("transport %s not found for additional mux route", nextTpID)
 	}
 
@@ -151,6 +166,7 @@ func (r *router) appendRouteToGroup(nrg *NoiseRouteGroup, rules routing.EdgeRule
 	// A dmsg server is an opaque intermediary; multiplexing routes that share or
 	// overlap dmsg servers can loop traffic with no way to detect it.
 	if tp.Entry.Type == tptypes.DMSG {
+		drop()
 		return errors.New("refusing to append DMSG transport to mux route group")
 	}
 	nrg.rg.mu.Lock()
@@ -160,11 +176,25 @@ func (r *router) appendRouteToGroup(nrg *NoiseRouteGroup, rules routing.EdgeRule
 		}
 		if existing.Entry.Type == tptypes.DMSG {
 			nrg.rg.mu.Unlock()
+			drop()
 			return errors.New("refusing to mux: route group already contains a DMSG transport")
 		}
 		// Mux invariant: no two legs share a transport (see appendRouteAsymmetric).
+		//
+		// This refusal MUST stay an error. The rules carry freshly reserved route
+		// IDs and the far end has been told this leg exists; answering the setup
+		// node "ok" would make the initiator append a leg locally whose consume
+		// rule here has been discarded, so everything the peer stripes onto it is
+		// dropped — and because the reorder buffer is lossless, the missing
+		// sequences head-of-line-stall the whole group (the black-hole failure
+		// mode documented at addOneAuxLeg). The duplicate is not idempotent
+		// either: it is a DIFFERENT route-ID chain over the same physical link,
+		// which is exactly what #3954 removed. The fix for the churn is to stop
+		// the initiator from planning a leg over a transport we already hold —
+		// see DialOptions.ExcludeRemoteTransportIDs — not to accept it here.
 		if existing.Entry.ID == nextTpID {
 			nrg.rg.mu.Unlock()
+			drop()
 			return fmt.Errorf("refusing to append mux leg over transport %s already in the group", nextTpID)
 		}
 	}
@@ -253,6 +283,17 @@ func (r *router) AddMuxRouteByHops(desc routing.RouteDescriptor, fwd, rev []rout
 	}
 	nrg.rg.mu.Unlock()
 
+	// Same rejection, on the DESTINATION's side of the leg. The setup node gives
+	// the destination the reverse route's first-hop ForwardRule, so its route
+	// group registers rev[0].TpID for this leg and its own duplicate-transport
+	// guard refuses a second leg over a transport it already holds. Catch it at
+	// this commit boundary — the one chokepoint every explicit-hops caller passes
+	// through — so a doomed leg never reaches the setup node. Derived from the
+	// LIVE legs, so a pruned leg immediately frees its far-end transport again.
+	if remoteIDs := nrg.rg.remoteLegTransportIDs(); firstHopTransportExcluded(rev, remoteIDs) {
+		return fmt.Errorf("reverse path leaves the destination over transport %s, which already carries one of its legs (the destination would refuse this leg)", rev[0].TpID)
+	}
+
 	// Hard mux invariants, enforced at the commit boundary so they hold for
 	// every caller (GrowMuxRoute's planner and external callers that supply
 	// explicit hops alike): (b) neither the forward nor the reverse path may
@@ -312,7 +353,7 @@ func (r *router) AddMuxRouteByHops(desc routing.RouteDescriptor, fwd, rev []rout
 
 	// Record this leg's full forward route so the per-leg mux view can show
 	// its whole path (all hops, full PKs, per-hop transport type).
-	nrg.rg.recordLegHops(fwd)
+	nrg.rg.recordLegRoute(fwd, rev)
 
 	r.logger.Infof("Added mux route via %d-hop path (first tp=%s) to route group %s", len(fwd), tpID, desc.String())
 	return nil
@@ -362,6 +403,12 @@ func (r *router) GrowMuxRoute(desc routing.RouteDescriptor, target, minHops int)
 	}
 	nrg.rg.mu.Unlock()
 
+	// Far-end transports the live legs already occupy: the destination refuses a
+	// leg whose reverse leaves it over one of these (see
+	// DialOptions.ExcludeRemoteTransportIDs), so they are excluded from the
+	// reverse pick and accumulated per planned leg just like excludeIDs.
+	excludeRemoteIDs := nrg.rg.remoteLegTransportIDs()
+
 	deficit := target - current
 	if deficit <= 0 {
 		return 0, nil
@@ -383,15 +430,16 @@ func (r *router) GrowMuxRoute(desc routing.RouteDescriptor, target, minHops int)
 			break
 		}
 		muxOpts := &DialOptions{
-			MinForwardRts:          1,
-			MaxForwardRts:          1,
-			MinConsumeRts:          1,
-			MaxConsumeRts:          1,
-			Retries:                1,
-			MinHops:                minHops,
-			ExcludeTransportIDs:    excludeIDs,
-			ExcludeIntermediatePKs: excludePKs,
-			ExcludeDMSG:            true,
+			MinForwardRts:             1,
+			MaxForwardRts:             1,
+			MinConsumeRts:             1,
+			MaxConsumeRts:             1,
+			Retries:                   1,
+			MinHops:                   minHops,
+			ExcludeTransportIDs:       excludeIDs,
+			ExcludeRemoteTransportIDs: excludeRemoteIDs,
+			ExcludeIntermediatePKs:    excludePKs,
+			ExcludeDMSG:               true,
 		}
 
 		// Route-finder FIRST, local calc as fallback — matching the initial mux
@@ -472,6 +520,22 @@ func (r *router) GrowMuxRoute(desc routing.RouteDescriptor, target, minHops int)
 			}
 		}
 
+		// Destination-side twin of the check above: the destination's route group
+		// holds one transport per leg — the reverse route's first hop — and
+		// refuses a second leg over one it already has. Independent forward/reverse
+		// ranking plus a 0-intermediate reverse (nothing for ExcludeIntermediatePKs
+		// to reject) makes that the finder's default answer, so without this gate
+		// every iteration pays a setup-node round trip to be refused.
+		if firstHopTransportExcluded(rev, excludeRemoteIDs) {
+			consecutiveFailures++
+			log.Debugf("GrowMuxRoute: planned leg %d/%d has a reverse leaving the destination over transport %s, which already carries one of its legs (it would be refused); skipping before dial",
+				current+added+1, target, rev[0].TpID)
+			if consecutiveFailures >= maxConsecutiveFailures {
+				break
+			}
+			continue
+		}
+
 		if err := r.AddMuxRouteByHops(desc, fwd, rev); err != nil {
 			consecutiveFailures++
 			log.Debugf("GrowMuxRoute: add leg %d/%d failed: %v", current+added+1, target, err)
@@ -481,6 +545,9 @@ func (r *router) GrowMuxRoute(desc routing.RouteDescriptor, target, minHops int)
 			continue
 		}
 		excludeIDs = append(excludeIDs, fwd[0].TpID)
+		if len(rev) > 0 {
+			excludeRemoteIDs = append(excludeRemoteIDs, rev[0].TpID)
+		}
 		consecutiveFailures = 0
 		added++
 	}

--- a/pkg/router/router_mux_remote_leg_test.go
+++ b/pkg/router/router_mux_remote_leg_test.go
@@ -1,0 +1,202 @@
+// Package router pkg/router/router_mux_remote_leg_test.go
+//
+// Regression coverage for the setup-node churn measured on sn1
+// (0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557): 80-88%
+// of its route-setup failures were one error, raised by the DESTINATION visor —
+// "failed to broadcast rules to destination router: failure code 1 (refusing to
+// append mux leg over transport <uuid> already in the group)".
+//
+// Mechanism: the setup node installs `respEdge.Forward` on the destination, and
+// GenerateRules keys fwdRules by each route's Hops[0].From — so the rule the
+// destination receives is the REVERSE route's first hop, and the destination's
+// route group registers exactly Reverse[0].TpID for that leg. Its
+// appendRouteToGroup then refuses any leg whose transport is already in the
+// group. Every initiator-side guard shipped so far (#4095/#4096) checks
+// Forward[0].TpID against the INITIATOR's transports, which cannot see this;
+// and because pickDisjointPath ranks forward and reverse INDEPENDENTLY and a
+// direct (0-intermediate) reverse gives ExcludeIntermediatePKs nothing to bite
+// on, the finder keeps pairing a disjoint forward with a reverse over the
+// destination's primary-leg transport.
+//
+// These tests pin the initiator-side state that makes the collision predictable
+// (RouteGroup.legRemoteTp / remoteLegTransportIDs) and the gate that stops the
+// doomed plan BEFORE the setup-node dial.
+package router
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// countingLegDialer is stubLegDialer plus a call counter: the point of the fix
+// is that a doomed leg never reaches the setup node at all, so "was Dial
+// called" is the assertion that matters, not just the returned error.
+type countingLegDialer struct {
+	rules routing.EdgeRules
+	calls int
+}
+
+func (d *countingLegDialer) Dial(_ context.Context, _ *logging.Logger, _ *dmsg.Client, _ []cipher.PubKey, _ routing.BidirectionalRoute) (routing.EdgeRules, cipher.PubKey, error) {
+	d.calls++
+	return d.rules, cipher.PubKey{}, nil
+}
+
+// TestRemoteLegTransportIDsMirrorsDestinationLegs pins the bookkeeping the gate
+// reads: remoteLegTransportIDs must report the far end's first-hop transport
+// for every LIVE leg, and must stop reporting one as soon as its leg is gone —
+// otherwise a pruned leg would permanently lock out a replacement over that
+// same far-end link.
+func TestRemoteLegTransportIDsMirrorsDestinationLegs(t *testing.T) {
+	r := newLegTestRouter(t)
+	rg, desc := r.setupInitializingPrimary(t)
+
+	local := desc.DstPK()
+	peer := desc.SrcPK()
+
+	// Primary leg: 1-hop direct, so the destination installs its ForwardRule
+	// over the very same direct transport (fwd[0].TpID == rev[0].TpID).
+	rg.mu.Lock()
+	primaryTpID := rg.tps[0].Entry.ID
+	rg.mu.Unlock()
+	rg.recordLegRoute(
+		[]routing.Hop{{TpID: primaryTpID, From: local, To: peer}},
+		[]routing.Hop{{TpID: primaryTpID, From: peer, To: local}},
+	)
+
+	require.Equal(t, []uuid.UUID{primaryTpID}, rg.remoteLegTransportIDs(),
+		"the destination holds this leg on the direct transport; that is what a second leg must avoid")
+
+	// An unrecorded leg contributes nothing rather than a zero UUID — the gate
+	// degrades to today's behavior for legs it has no plan for.
+	aux := r.makeAuxRules(t, desc, 1)
+	auxTpID := aux.Forward.NextTransportID()
+	nrg := &NoiseRouteGroup{rg: rg}
+	require.NoError(t, r.appendRouteToGroup(nrg, aux))
+	require.Equal(t, []uuid.UUID{primaryTpID}, rg.remoteLegTransportIDs(),
+		"a leg with no recorded reverse must not synthesize an exclusion")
+
+	// Record the aux leg's far end, then drop the PRIMARY: the surviving leg's
+	// entry must remain and the dropped one's must disappear.
+	auxRemote := uuid.New()
+	rg.recordLegRoute(
+		[]routing.Hop{{TpID: auxTpID, From: local, To: peer}},
+		[]routing.Hop{{TpID: auxRemote, From: peer, To: local}},
+	)
+	require.ElementsMatch(t, []uuid.UUID{primaryTpID, auxRemote}, rg.remoteLegTransportIDs())
+
+	require.NoError(t, r.RemoveMuxRouteByTransport(descOf(t, r, rg, desc), primaryTpID))
+	require.Equal(t, []uuid.UUID{auxRemote}, rg.remoteLegTransportIDs(),
+		"a pruned leg must free its far-end transport immediately, or the group can never re-grow over that link")
+}
+
+// descOf registers rg under desc in rgsNs (RemoveMuxRouteByTransport looks the
+// group up there) and returns desc.
+func descOf(t *testing.T, r *router, rg *RouteGroup, desc routing.RouteDescriptor) routing.RouteDescriptor {
+	t.Helper()
+	r.mx.Lock()
+	delete(r.rgsRaw, desc)
+	r.rgsNs[desc] = &NoiseRouteGroup{rg: rg}
+	r.mx.Unlock()
+	return desc
+}
+
+// TestAddMuxRouteByHopsRejectsCollidingReverseBeforeDial is the behavior change.
+// The planned leg has a perfectly good, disjoint FORWARD first hop — every
+// pre-existing guard passes it — but its reverse leaves the destination over
+// the transport the destination already holds the primary leg on. Before the
+// fix this was dialed through the setup node (route-ID reservation on every hop
+// plus intermediary rule installs) purely to be refused; now it is dropped
+// locally and the setup node is never contacted.
+func TestAddMuxRouteByHopsRejectsCollidingReverseBeforeDial(t *testing.T) {
+	r := newLegTestRouter(t)
+	rg, desc := r.setupInitializingPrimary(t)
+	nrg := &NoiseRouteGroup{rg: rg}
+	r.mx.Lock()
+	delete(r.rgsRaw, desc)
+	r.rgsNs[desc] = nrg
+	r.mx.Unlock()
+
+	local := desc.DstPK()
+	peer := desc.SrcPK()
+
+	rg.mu.Lock()
+	primaryTpID := rg.tps[0].Entry.ID
+	rg.mu.Unlock()
+	// Primary: 1-hop direct in both directions — the shape that dominates the
+	// live route_length_hist and the one that makes this collision the default.
+	rg.recordLegRoute(
+		[]routing.Hop{{TpID: primaryTpID, From: local, To: peer}},
+		[]routing.Hop{{TpID: primaryTpID, From: peer, To: local}},
+	)
+
+	auxRules := r.makeAuxRules(t, desc, 1)
+	auxTpID := auxRules.Forward.NextTransportID()
+	dialer := &countingLegDialer{rules: auxRules}
+	r.conf.RouteGroupDialer = dialer
+
+	mid, _ := cipher.GenerateKeyPair()
+	// Forward: 2-hop, disjoint first hop — passes the existing local guard.
+	fwd := []routing.Hop{
+		{TpID: auxTpID, From: local, To: mid},
+		{TpID: uuid.New(), From: mid, To: peer},
+	}
+	// Reverse: the latency-cheapest 1-hop direct, which the finder picks
+	// independently of the forward. Its first hop is the destination's own
+	// direct transport — already carrying the primary leg over there.
+	badRev := []routing.Hop{{TpID: primaryTpID, From: peer, To: local}}
+
+	err := r.AddMuxRouteByHops(desc, fwd, badRev)
+	require.Error(t, err, "a leg the destination is certain to refuse must not be committed")
+	require.Contains(t, err.Error(), "already carries one of its legs")
+	require.Zero(t, dialer.calls, "the doomed leg must be dropped BEFORE the setup-node dial — that dial is the churn")
+	require.Equal(t, 1, legCount(rg), "the working primary leg is untouched by the rejection")
+
+	// The SAME forward over a reverse that leaves the destination on a free
+	// transport is still accepted: the gate rejects the collision, not the leg.
+	goodRev := []routing.Hop{
+		{TpID: uuid.New(), From: peer, To: mid},
+		{TpID: auxTpID, From: mid, To: local},
+	}
+	require.NoError(t, r.AddMuxRouteByHops(desc, fwd, goodRev))
+	require.Equal(t, 1, dialer.calls)
+	require.Equal(t, 2, legCount(rg))
+	require.ElementsMatch(t, []uuid.UUID{primaryTpID, goodRev[0].TpID}, rg.remoteLegTransportIDs(),
+		"the committed leg claims its far-end transport so the NEXT leg diverges from it too")
+}
+
+// TestWarmRoutePoolSkipsPlanCollidingWithRemoteLeg covers the amplifier. The
+// shared plan cache dedupes buckets on the FORWARD first hop only, so a plan
+// whose reverse collides at the destination was re-served on every hit for its
+// whole TTL — one bad plan turning into a steady stream of refused setups.
+func TestWarmRoutePoolSkipsPlanCollidingWithRemoteLeg(t *testing.T) {
+	p := newWarmRoutePool(defaultWarmPlanTTL)
+	dst, _ := cipher.GenerateKeyPair()
+	src, _ := cipher.GenerateKeyPair()
+	mid, _ := cipher.GenerateKeyPair()
+
+	fwdTp, revTp := uuid.New(), uuid.New()
+	p.put(dst, 2,
+		[]routing.Hop{{TpID: fwdTp, From: src, To: mid}, {TpID: uuid.New(), From: mid, To: dst}},
+		[]routing.Hop{{TpID: revTp, From: dst, To: mid}, {TpID: uuid.New(), From: mid, To: src}},
+	)
+
+	// No far-end exclusions: the plan is served, as before.
+	_, _, ok := p.bestPlan(dst, 2, nil, nil, nil)
+	require.True(t, ok)
+
+	// The caller's group already has a leg the destination holds on revTp.
+	_, _, ok = p.bestPlan(dst, 2, nil, []uuid.UUID{revTp}, nil)
+	require.False(t, ok, "a cached plan the destination would refuse must be a MISS, so the caller re-plans instead of re-dialing it")
+
+	// A different far-end transport is not a collision.
+	_, _, ok = p.bestPlan(dst, 2, nil, []uuid.UUID{uuid.New()}, nil)
+	require.True(t, ok)
+}

--- a/pkg/router/warm_route_pool.go
+++ b/pkg/router/warm_route_pool.go
@@ -69,8 +69,15 @@ const warmPlanBucketCap = 64
 type routePlan struct {
 	fwd     []routing.Hop
 	rev     []routing.Hop
-	firstTp uuid.UUID       // fwd[0].TpID — the first-hop transport this plan rides
-	inter   []cipher.PubKey // intermediate visor PKs (for disjointness matching)
+	firstTp uuid.UUID // fwd[0].TpID — the first-hop transport this plan rides
+	// remoteTp is rev[0].TpID — the transport the DESTINATION would install this
+	// leg over (the setup node hands it the reverse route's first-hop
+	// ForwardRule). Matched against the caller's far-end exclude set so a cached
+	// plan the destination is certain to refuse is never re-served: the bucket
+	// dedupes on firstTp alone, so without this a single such plan is handed out
+	// for its whole TTL and every hit becomes a wasted setup-node round trip.
+	remoteTp uuid.UUID
+	inter    []cipher.PubKey // intermediate visor PKs (for disjointness matching)
 }
 
 // planKey identifies a bucket of disjoint plans to one exit at one min-hops
@@ -148,6 +155,9 @@ func (p *warmRoutePool) put(dst cipher.PubKey, minHops uint16, fwd, rev []routin
 		firstTp: fwd[0].TpID,
 		inter:   planIntermediates(fwd),
 	}
+	if len(rev) > 0 {
+		plan.remoteTp = rev[0].TpID
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	b := p.byExit[key]
@@ -177,9 +187,14 @@ func (p *warmRoutePool) put(dst cipher.PubKey, minHops uint16, fwd, rev []routin
 // disjointFrom reports whether plan's first-hop transport and intermediates
 // avoid the caller's per-group exclude sets — the same disjointness the caller
 // would demand of a freshly-fetched leg.
-func (pl *routePlan) disjointFrom(excludeTps map[uuid.UUID]struct{}, excludePKs map[cipher.PubKey]struct{}) bool {
+func (pl *routePlan) disjointFrom(excludeTps, excludeRemoteTps map[uuid.UUID]struct{}, excludePKs map[cipher.PubKey]struct{}) bool {
 	if _, bad := excludeTps[pl.firstTp]; bad {
 		return false
+	}
+	if pl.remoteTp != (uuid.UUID{}) {
+		if _, bad := excludeRemoteTps[pl.remoteTp]; bad {
+			return false
+		}
 	}
 	for _, pk := range pl.inter {
 		if _, bad := excludePKs[pk]; bad {
@@ -194,7 +209,11 @@ func (pl *routePlan) disjointFrom(excludeTps map[uuid.UUID]struct{}, excludePKs 
 // ok=false on a miss. The returned slices are the cached copies — callers feed
 // them into a setup-node Dial (read-only) and run their usual validMuxLeg gate,
 // so aliasing is safe. A miss is a clean signal to fall back to fetchBestRoutes.
-func (p *warmRoutePool) bestPlan(dst cipher.PubKey, minHops uint16, excludeTps []uuid.UUID, excludePKs []cipher.PubKey) (fwd, rev []routing.Hop, ok bool) {
+// excludeRemoteTps is the far-end (destination) transport set the plan's
+// REVERSE first hop must avoid — the destination refuses a leg over a transport
+// its own route group already holds, so a plan matching one of these is a
+// guaranteed setup-node failure and must not be served from cache.
+func (p *warmRoutePool) bestPlan(dst cipher.PubKey, minHops uint16, excludeTps, excludeRemoteTps []uuid.UUID, excludePKs []cipher.PubKey) (fwd, rev []routing.Hop, ok bool) {
 	if p == nil {
 		return nil, nil, false
 	}
@@ -202,6 +221,10 @@ func (p *warmRoutePool) bestPlan(dst cipher.PubKey, minHops uint16, excludeTps [
 	exTp := make(map[uuid.UUID]struct{}, len(excludeTps))
 	for _, id := range excludeTps {
 		exTp[id] = struct{}{}
+	}
+	exRemoteTp := make(map[uuid.UUID]struct{}, len(excludeRemoteTps))
+	for _, id := range excludeRemoteTps {
+		exRemoteTp[id] = struct{}{}
 	}
 	exPK := make(map[cipher.PubKey]struct{}, len(excludePKs))
 	for _, pk := range excludePKs {
@@ -218,7 +241,7 @@ func (p *warmRoutePool) bestPlan(dst cipher.PubKey, minHops uint16, excludeTps [
 		return nil, nil, false
 	}
 	for i := range b.plans {
-		if b.plans[i].disjointFrom(exTp, exPK) {
+		if b.plans[i].disjointFrom(exTp, exRemoteTp, exPK) {
 			p.hits++
 			return b.plans[i].fwd, b.plans[i].rev, true
 		}

--- a/pkg/router/warm_route_pool_test.go
+++ b/pkg/router/warm_route_pool_test.go
@@ -33,7 +33,7 @@ func TestWarmRoutePool_HitAfterPut(t *testing.T) {
 	p.put(dst, 2, fwd, rev)
 
 	// A second group dialing the same exit with no excludes gets the cached plan.
-	gotF, gotR, ok := p.bestPlan(dst, 2, nil, nil)
+	gotF, gotR, ok := p.bestPlan(dst, 2, nil, nil, nil)
 	require.True(t, ok)
 	require.Equal(t, tp1, gotF[0].TpID)
 	require.Len(t, gotR, 2)
@@ -47,7 +47,7 @@ func TestWarmRoutePool_HitAfterPut(t *testing.T) {
 func TestWarmRoutePool_MissOnEmpty(t *testing.T) {
 	dst, _ := cipher.GenerateKeyPair()
 	p := newWarmRoutePool(time.Minute)
-	_, _, ok := p.bestPlan(dst, 2, nil, nil)
+	_, _, ok := p.bestPlan(dst, 2, nil, nil, nil)
 	require.False(t, ok)
 	require.Equal(t, uint64(1), p.stats().Misses)
 }
@@ -62,9 +62,9 @@ func TestWarmRoutePool_MinHopsIsPartOfKey(t *testing.T) {
 	p.put(dst, 1, warmTwoHop(src, mid, dst, tp1, tp2), nil)
 
 	// A min-hops=2 dial must NOT be served the min-hops=1 plan.
-	_, _, ok := p.bestPlan(dst, 2, nil, nil)
+	_, _, ok := p.bestPlan(dst, 2, nil, nil, nil)
 	require.False(t, ok)
-	_, _, ok = p.bestPlan(dst, 1, nil, nil)
+	_, _, ok = p.bestPlan(dst, 1, nil, nil, nil)
 	require.True(t, ok)
 }
 
@@ -79,7 +79,7 @@ func TestWarmRoutePool_ExcludeTransport(t *testing.T) {
 
 	// The only cached plan rides tp1; a caller already using tp1 as a leg must
 	// get a miss (the pool must not hand back a leg the group already has).
-	_, _, ok := p.bestPlan(dst, 2, []uuid.UUID{tp1}, nil)
+	_, _, ok := p.bestPlan(dst, 2, []uuid.UUID{tp1}, nil, nil)
 	require.False(t, ok)
 }
 
@@ -97,13 +97,13 @@ func TestWarmRoutePool_ExcludeIntermediate(t *testing.T) {
 
 	// A group whose existing leg already goes through midA must be handed the
 	// midB plan (first-hop-disjoint growth from cache).
-	gotF, _, ok := p.bestPlan(dst, 2, []uuid.UUID{tpA1}, []cipher.PubKey{midA})
+	gotF, _, ok := p.bestPlan(dst, 2, []uuid.UUID{tpA1}, nil, []cipher.PubKey{midA})
 	require.True(t, ok)
 	require.Equal(t, tpB1, gotF[0].TpID)
 	require.Equal(t, midB, gotF[0].To)
 
 	// Exclude BOTH intermediates -> no disjoint plan left -> miss.
-	_, _, ok = p.bestPlan(dst, 2, nil, []cipher.PubKey{midA, midB})
+	_, _, ok = p.bestPlan(dst, 2, nil, nil, []cipher.PubKey{midA, midB})
 	require.False(t, ok)
 }
 
@@ -118,11 +118,11 @@ func TestWarmRoutePool_TTLExpiry(t *testing.T) {
 	p.now = func() time.Time { return now }
 	p.put(dst, 2, warmTwoHop(src, mid, dst, tp1, tp2), nil)
 
-	_, _, ok := p.bestPlan(dst, 2, nil, nil)
+	_, _, ok := p.bestPlan(dst, 2, nil, nil, nil)
 	require.True(t, ok)
 
 	now = now.Add(31 * time.Second) // past TTL
-	_, _, ok = p.bestPlan(dst, 2, nil, nil)
+	_, _, ok = p.bestPlan(dst, 2, nil, nil, nil)
 	require.False(t, ok, "expired plan must not be served")
 	require.Equal(t, 0, p.stats().Exits, "expired bucket evicted on read")
 }
@@ -152,9 +152,9 @@ func TestWarmRoutePool_Invalidate(t *testing.T) {
 	p.put(dstB, 2, warmTwoHop(src, mid, dstB, tp1, tp2), nil)
 
 	p.invalidate(dstA)
-	_, _, ok := p.bestPlan(dstA, 2, nil, nil)
+	_, _, ok := p.bestPlan(dstA, 2, nil, nil, nil)
 	require.False(t, ok)
-	_, _, ok = p.bestPlan(dstB, 2, nil, nil)
+	_, _, ok = p.bestPlan(dstB, 2, nil, nil, nil)
 	require.True(t, ok, "invalidate(dstA) must not touch dstB")
 
 	p.invalidateAll()
@@ -165,7 +165,7 @@ func TestWarmRoutePool_NilSafe(t *testing.T) {
 	var p *warmRoutePool
 	require.NotPanics(t, func() {
 		p.put(cipher.PubKey{}, 1, nil, nil)
-		_, _, ok := p.bestPlan(cipher.PubKey{}, 1, nil, nil)
+		_, _, ok := p.bestPlan(cipher.PubKey{}, 1, nil, nil, nil)
 		require.False(t, ok)
 		p.invalidate(cipher.PubKey{})
 		p.invalidateAll()


### PR DESCRIPTION
The live route setup node regressed from 92% to 71% success (reproduced across two builds), and 77-88% of its failures are one error, raised by the *destination* visor:

```
refusing to append mux leg over transport <uuid> already in the group
```

## Root cause

**The initiator enforces the mux "one leg per transport" invariant on its own side; the destination enforces it on a set the initiator never tracked.**

`GenerateRules` (setupnode.go:609) keys `fwdRules` by each route's `Hops[0].From`. The reverse route starts at the destination, so `fwdRules[dstPK][0]` is a ForwardRule over **`Reverse[0].TpID`**. The destination's `appendRouteToGroup` registers `rules.Forward.NextTransportID()`, so its `rg.tps` is exactly the set of `Reverse[0].TpID` of its legs — and `router_mux_ops.go:168` refuses a duplicate.

Every guard shipped so far (#4095 `establishMuxRoutes`, #4096 `addOneAuxLeg`, `GrowMuxRoute`, `AddMuxRouteByHops`) compares `Forward[0].TpID` against the **initiator's** `rg.tps`. Nothing read `Reverse[0].TpID`.

Meanwhile `pickDisjointPath` ranks the two directions independently (by design since #2782), and a 0-intermediate direct reverse contributes nothing to `ExcludeIntermediatePKs` — so the disjointness machinery has no term that can reject it, and it is the latency winner. Every aux leg therefore pairs a correctly-disjoint forward with a reverse over the destination's primary link: a guaranteed refusal, paid for with full route-ID reservation on every hop plus intermediary rule installs.

**Why now:** #4336 added the shared plan cache, whose bucket dedupes on `fwd[0].TpID` and whose `disjointFrom` never looked at `rev`. One colliding plan is re-served on every hit for its 30s TTL — converting an occasional bad pick into a steady stream, and matching the field note of "65 such dials in a 3-minute window, all for the same transport".

## Fix

Track the far-end transport and exclude it at planning time: `legRemoteTp` on the route group, `DialOptions.ExcludeRemoteTransportIDs`, a preference filter in `fetchBestRoutes` (a free reverse is usually available, so legs still get built) and a hard pre-dial gate in `addOneAuxLeg`, `establishMuxRoutes`, `GrowMuxRoute` and at the `AddMuxRouteByHops` commit boundary. `warm_route_pool` matches `remoteTp` in `disjointFrom`, so a doomed plan is a cache miss and the caller re-plans.

## The refusal stays an error

Returning ok would be wrong: the incoming rules are a different route-ID chain over the same physical link, so it is not idempotent — that is what #3954 removed, and two route IDs on one link stall the mux data plane. A false ok would also make the initiator append a leg the destination discarded, so the peer stripes onto a black-holing leg and the lossless reorder buffer head-of-line-stalls the whole group.

**Secondary bug fixed there:** `appendRouteToGroup` saved the rules then returned on rejection **without deleting them**, and `CreateRouteGroup` only adds the destination edge to its teardown tracker after `AddEdgeRules` succeeds — so every refusal leaked a forward+reverse pair until the ~10-minute keepalive GC. At ~4 failures/min on a popular exit that is a standing rule-table and transport-pin cost. `appendRouteAsymmetric` already did this cleanup; now both do.

## Safety

Only aux-mux-leg planning is touched — primary dials never set the new option, so `DialRoutes`/`PingRoute` are unchanged. The gate only skips a plan; nothing is removed, closed or re-homed. The exclude set is recomputed from live `rg.tps` each call, so a pruned leg frees its far-end transport immediately (tested). A leg with no recorded reverse contributes no exclusion, so any missed path degrades to today's behaviour rather than over-rejecting. The finder-side filter is a preference, never starving a dial of a route. Initiator-local: no wire change, no capability negotiation, no config flag.

## Tests

`TestAddMuxRouteByHopsRejectsCollidingReverseBeforeDial` asserts **`dialer.calls == 0`** — the setup-node round trip is the churn. Negative control: with the gate stubbed out it fails with the leg committed after a dial, reproducing the live behaviour. Plus `TestRemoteLegTransportIDsMirrorsDestinationLegs` and `TestWarmRoutePoolSkipsPlanCollidingWithRemoteLeg`.

`go test ./pkg/router/` ok (50.8s), lint 0 issues, binary builds.

## Note on the vanished 4-hop routes

`route_length_hist` went `{1:28,2:45,3:19,4:6}` to `{1:327,2:78,3:41}`. This is likely **downstream** of this bug rather than independent: the histogram is fed from `len(biRt.Forward)` on success only, and deep forwards are overwhelmingly aux mux legs — exactly the requests dying at the destination. Prediction, not proof: if 4-hop reappears once `destination_rules` collapses, it was downstream; if it stays at zero while the success rate recovers, it is a separate regression in the finder's candidate generation.