### PR TITLE
fix: config update against dmsg-only, AR log flood, and setup-node /stats exposure

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -761,7 +761,17 @@ func fetchServiceConfig(log *logging.Logger) {
 		if fetchServiceConfigDmsg(log) {
 			return
 		}
-		// Fall back to HTTP
+		// Fall back to HTTP. A dmsg:// conf URL has no plain-HTTP form —
+		// net/http rejects it with "unsupported protocol scheme" — so skip
+		// straight to the embedded config rather than logging a bogus fetch
+		// failure.
+		if strings.HasPrefix(serviceConfURL, "dmsg://") {
+			if !isStdout {
+				log.Warnf("Could not reach %s over dmsg; falling back on embedded config", serviceConfURL)
+			}
+			loadServicesFromFile(log)
+			return
+		}
 		client := http.Client{Timeout: servicesFetchTimeout}
 		if serviceConfURL == "" {
 			serviceConfURL = "http://"
@@ -844,6 +854,13 @@ func fetchServiceConfigDmsg(log *logging.Logger) bool {
 	embeddedConf := deployment.Prod
 	if isTestEnv {
 		embeddedConf = deployment.Test
+	}
+
+	// An explicit dmsg:// --url overrides the embedded conf-service address.
+	// Without this the flag was silently ignored on the DMSG path and only
+	// reached the (now dead for a dmsg-only deployment) plain-HTTP fallback.
+	if strings.HasPrefix(serviceConfURL, "dmsg://") {
+		embeddedConf.ConfDmsg = serviceConfURL
 	}
 
 	// Need both embedded DMSG servers and a config service DMSG address

--- a/cmd/skywire-cli/commands/config/update.go
+++ b/cmd/skywire-cli/commands/config/update.go
@@ -121,27 +121,13 @@ min-hops (--set-minhop). Passing -b/--url a value implies --endpoints.`,
 			if isTestEnv {
 				serviceConfURL = deployment.TestConf.Conf
 			}
-			mLog := logging.NewMasterLogger()
-			mLog.SetLevel(logrus.InfoLevel)
-			services := visorconfig.Fetch(mLog, serviceConfURL, isStdout)
-			conf.Dmsg = &dmsgc.DmsgConfig{
-				Discovery: services.DmsgDiscovery, //utilenv.DefaultDmsgDiscAddr,
-			}
-			conf.Transport = &visorconfig.Transport{
-				Discovery:       services.TransportDiscovery, //utilenv.DefaultTpDiscAddr,
-				AddressResolver: services.AddressResolver,    //utilenv.DefaultAddressResolverAddr,
-			}
-			conf.Routing = &visorconfig.Routing{
-				RouteFinder:     services.RouteFinder,     //utilenv.DefaultRouteFinderAddr,
-				RouteSetupNodes: services.RouteSetupNodes, //[]cipher.PubKey{utilenv.MustPK(utilenv.DefaultSetupPK)},
-			}
-			conf.Launcher = &visorconfig.Launcher{
-				ServiceDisc: services.ServiceDiscovery, //utilenv.DefaultServiceDiscAddr,
-			}
-			conf.UptimeTracker = &visorconfig.UptimeTracker{
-				Addr: services.UptimeTracker, //utilenv.DefaultUptimeTrackerAddr,
-			}
-			conf.StunServers = services.StunServers //utilenv.GetStunServers()
+			// Reuse the same fetch chain `config gen` uses: DMSG first (the
+			// deployment is dmsg-only, so a plain http.Client can never reach
+			// the conf service), then plain HTTP, then the embedded
+			// services-config.json. Every branch leaves `services` populated,
+			// so there is no nil to dereference below.
+			fetchServiceConfig(logging.MustGetLogger("config-update"))
+			applyServiceEndpoints(conf)
 		}
 
 		if conf.LogLevel != logLevel {
@@ -165,6 +151,83 @@ min-hops (--set-minhop). Passing -b/--url a value implies --endpoints.`,
 		}
 		saveConfig(conf)
 	},
+}
+
+// applyServiceEndpoints writes the service endpoints held in the package-level
+// `services` (filled by fetchServiceConfig) into an EXISTING config.
+//
+// It mutates only the endpoint fields. It deliberately does NOT replace
+// conf.Dmsg / conf.Transport / conf.Routing / conf.Launcher with fresh structs
+// the way this code used to: those carry unrelated operator state — launcher
+// apps and binary paths, the transport log store and stcpr/sudph/quic ports,
+// the dmsg session count, carriers and protocol, min-hops — and `config update
+// -a` (documented as "update server endpoints") must not silently discard it.
+//
+// Empty values are skipped rather than written, so a services payload that
+// omits a field leaves the config's existing value alone instead of blanking
+// it. The deployment is dmsg-only, so the plain-HTTP endpoint fields in
+// services-config.json are all null today; the *_dmsg URLs are applied to the
+// primary config fields exactly as `config gen` does.
+func applyServiceEndpoints(conf *visorconfig.V1) {
+	if conf.Dmsg == nil {
+		conf.Dmsg = &dmsgc.DmsgConfig{}
+	}
+	if conf.Transport == nil {
+		conf.Transport = &visorconfig.Transport{}
+	}
+	if conf.Routing == nil {
+		conf.Routing = &visorconfig.Routing{}
+	}
+	if conf.Launcher == nil {
+		conf.Launcher = &visorconfig.Launcher{}
+	}
+
+	setIfNotEmpty(&conf.Dmsg.Discovery, services.DmsgDiscovery)
+	setIfNotEmpty(&conf.Transport.Discovery, services.TransportDiscovery)
+	setIfNotEmpty(&conf.Transport.AddressResolver, services.AddressResolver)
+	setIfNotEmpty(&conf.Routing.RouteFinder, services.RouteFinder)
+	setIfNotEmpty(&conf.Launcher.ServiceDisc, services.ServiceDiscovery)
+	setIfNotEmpty(&conf.ConfServiceDmsg, services.ConfDmsg)
+
+	// Deployment services are dmsg-only: the dmsg:// URLs go into the primary
+	// fields, mirroring configureServiceURLs() in gen.go.
+	if services.HasDmsgEndpoints() {
+		if servers := deployment.DmsgServerEntriesToDisc(services.DmsgServers); len(servers) > 0 {
+			conf.Dmsg.Servers = servers
+		}
+		setIfNotEmpty(&conf.Dmsg.Discovery, services.DmsgDiscoveryDmsg)
+		setIfNotEmpty(&conf.Transport.Discovery, services.TransportDiscoveryDmsg)
+		setIfNotEmpty(&conf.Transport.AddressResolver, services.AddressResolverDmsg)
+		setIfNotEmpty(&conf.Routing.RouteFinder, services.RouteFinderDmsg)
+		setIfNotEmpty(&conf.Launcher.ServiceDisc, services.ServiceDiscoveryDmsg)
+	}
+
+	if len(services.RouteSetupNodes) > 0 {
+		conf.Routing.RouteSetupNodes = services.RouteSetupNodes
+	}
+	if len(services.TransportSetupPKs) > 0 {
+		conf.Transport.TransportSetupPKs = services.TransportSetupPKs
+	}
+	if len(services.StunServers) > 0 {
+		conf.StunServers = services.StunServers
+	}
+	// The standalone uptime tracker is deprecated and fresh configs no longer
+	// carry the block (see configureLauncher in gen.go) — only refresh it for a
+	// config that already has one.
+	if conf.UptimeTracker != nil {
+		addr := services.UptimeTrackerDmsg
+		if addr == "" {
+			addr = services.UptimeTracker
+		}
+		setIfNotEmpty(&conf.UptimeTracker.Addr, addr)
+	}
+}
+
+// setIfNotEmpty assigns v to *dst unless v is empty.
+func setIfNotEmpty(dst *string, v string) {
+	if v != "" {
+		*dst = v
+	}
 }
 
 func changeAppsConfig(conf *visorconfig.V1, appName string, argName string, argValue string) {

--- a/cmd/skywire-cli/commands/config/update_endpoints_test.go
+++ b/cmd/skywire-cli/commands/config/update_endpoints_test.go
@@ -1,0 +1,129 @@
+// Package cliconfig cmd/skywire-cli/commands/config/update_endpoints_test.go c4-vis-cli
+package cliconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgc"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// saveEndpointFetchState snapshots the package-level state the fetch/apply
+// helpers read and restores it when the test ends.
+func saveEndpointFetchState(t *testing.T) {
+	t.Helper()
+	oldServices, oldNoFetch, oldDmsgHTTP := services, noFetch, isDmsgHTTP
+	oldPath, oldURL, oldTest, oldStdout := configServicePath, serviceConfURL, isTestEnv, isStdout
+	t.Cleanup(func() {
+		services, noFetch, isDmsgHTTP = oldServices, oldNoFetch, oldDmsgHTTP
+		configServicePath, serviceConfURL, isTestEnv, isStdout = oldPath, oldURL, oldTest, oldStdout
+	})
+}
+
+// TestFetchServiceConfigFallsBackToEmbedded asserts that the "falling back on
+// embedded config" log line corresponds to an actual fallback: `services` must
+// come out populated. The old visorconfig.Fetch logged that message and then
+// returned a nil *Services, which segfaulted its caller.
+func TestFetchServiceConfigFallsBackToEmbedded(t *testing.T) {
+	saveEndpointFetchState(t)
+
+	services = visorconfig.Services{}
+	noFetch, isDmsgHTTP, isStdout = true, false, false
+	configServicePath = ""
+	isTestEnv = false
+
+	fetchServiceConfig(logging.MustGetLogger("test"))
+
+	require.True(t, services.HasDmsgEndpoints(),
+		"embedded fallback must populate the dmsg service endpoints")
+	require.NotEmpty(t, services.RouteFinderDmsg)
+	require.NotEmpty(t, services.AddressResolverDmsg)
+}
+
+// TestApplyServiceEndpointsNoPanicOnEmptyFetch is the direct regression for the
+// nil-dereference at update.go:128: a fetch that yields nothing must leave the
+// config untouched rather than crash the CLI.
+func TestApplyServiceEndpointsNoPanicOnEmptyFetch(t *testing.T) {
+	saveEndpointFetchState(t)
+	services = visorconfig.Services{}
+
+	// Every endpoint-holding sub-struct nil — the worst case for a config the
+	// user hands us.
+	require.NotPanics(t, func() { applyServiceEndpoints(&visorconfig.V1{}) })
+
+	conf := &visorconfig.V1{
+		Dmsg:      &dmsgc.DmsgConfig{Discovery: "dmsg://keep-me:80", SessionsCount: 3},
+		Transport: &visorconfig.Transport{Discovery: "dmsg://keep-tpd:80", StcprPort: 7777},
+		Routing:   &visorconfig.Routing{RouteFinder: "dmsg://keep-rf:80", MinHops: 2},
+		Launcher:  &visorconfig.Launcher{ServiceDisc: "dmsg://keep-sd:80", BinPath: "/apps"},
+	}
+	require.NotPanics(t, func() { applyServiceEndpoints(conf) })
+
+	require.Equal(t, "dmsg://keep-me:80", conf.Dmsg.Discovery)
+	require.Equal(t, "dmsg://keep-tpd:80", conf.Transport.Discovery)
+	require.Equal(t, "dmsg://keep-rf:80", conf.Routing.RouteFinder)
+	require.Equal(t, "dmsg://keep-sd:80", conf.Launcher.ServiceDisc)
+}
+
+// TestApplyServiceEndpointsPreservesUnrelatedState checks that -a updates the
+// endpoints and nothing else. The previous implementation replaced conf.Dmsg /
+// conf.Transport / conf.Routing / conf.Launcher wholesale, silently discarding
+// launcher apps, transport ports, dmsg session count and min-hops.
+func TestApplyServiceEndpointsPreservesUnrelatedState(t *testing.T) {
+	saveEndpointFetchState(t)
+	services = deployment.Prod
+
+	conf := &visorconfig.V1{
+		Dmsg: &dmsgc.DmsgConfig{
+			Discovery:     "dmsg://stale:80",
+			SessionsCount: 4,
+			Protocol:      "yamux",
+			Carriers:      []string{"tcp"},
+		},
+		Transport: &visorconfig.Transport{
+			Discovery:       "dmsg://stale:80",
+			AddressResolver: "dmsg://stale:80",
+			StcprPort:       7070,
+			SudphPort:       7071,
+			LogStore:        &visorconfig.LogStore{Type: visorconfig.MemoryLogStore},
+		},
+		Routing: &visorconfig.Routing{
+			RouteFinder: "dmsg://stale:80",
+			MinHops:     3,
+		},
+		Launcher: &visorconfig.Launcher{
+			ServiceDisc: "dmsg://stale:80",
+			BinPath:     "/opt/skywire/apps",
+		},
+	}
+
+	launcher := conf.Launcher
+
+	applyServiceEndpoints(conf)
+
+	// Endpoints refreshed from the deployment...
+	require.Equal(t, deployment.Prod.DmsgDiscoveryDmsg, conf.Dmsg.Discovery)
+	require.Equal(t, deployment.Prod.TransportDiscoveryDmsg, conf.Transport.Discovery)
+	require.Equal(t, deployment.Prod.AddressResolverDmsg, conf.Transport.AddressResolver)
+	require.Equal(t, deployment.Prod.RouteFinderDmsg, conf.Routing.RouteFinder)
+	require.Equal(t, deployment.Prod.ServiceDiscoveryDmsg, conf.Launcher.ServiceDisc)
+	require.NotEmpty(t, conf.Dmsg.Servers)
+
+	// ...everything else left alone.
+	require.Equal(t, 4, conf.Dmsg.SessionsCount)
+	require.Equal(t, "yamux", conf.Dmsg.Protocol)
+	require.Equal(t, []string{"tcp"}, conf.Dmsg.Carriers)
+	require.Equal(t, 7070, conf.Transport.StcprPort)
+	require.Equal(t, 7071, conf.Transport.SudphPort)
+	require.NotNil(t, conf.Transport.LogStore)
+	require.Equal(t, uint16(3), conf.Routing.MinHops)
+	require.Equal(t, "/opt/skywire/apps", conf.Launcher.BinPath)
+	require.Same(t, launcher, conf.Launcher, "launcher struct must be mutated in place, not replaced")
+
+	// No uptime_tracker block is invented for a config that lacks one.
+	require.Nil(t, conf.UptimeTracker)
+}

--- a/pkg/deployment/ar/api/api.go
+++ b/pkg/deployment/ar/api/api.go
@@ -88,6 +88,12 @@ type API struct {
 	dhtMirrorStcpr dhtMirror
 	dhtMirrorSudph dhtMirror
 
+	// dialAssistFails aggregates the SUDPH reverse dial-assist requests that
+	// are skipped because the peer has no live UDP connection — an expected
+	// outcome that was logged once per attempt and, at ~9,475 lines/min on the
+	// live deployment, drowned the address-resolver log. See dial_assist_log.go.
+	dialAssistFails *dialAssistFailures
+
 	// bindPub is the CXO bindings publisher, installed after the dmsg client
 	// exists (see pkg/services/ar). Held atomically because the store writes
 	// that notify it run on HTTP, UDP and CXO-ingest goroutines while the
@@ -250,6 +256,7 @@ func New(log *logging.Logger, s store.Store, nonceStore httpauth.NonceStore,
 		dmsgAddr:                    dmsgAddr,
 		DmsgServers:                 []string{},
 		publicUDPAddr:               publicUDPAddr,
+		dialAssistFails:             newDialAssistFailures(dialAssistSummaryInterval),
 	}
 	// Every store write goes through the notifier so the CXO bindings feed
 	// (pkg/deployment/ar/api/cxo_publisher.go) learns about it from ONE place
@@ -607,6 +614,24 @@ func (a *API) resolve(w http.ResponseWriter, r *http.Request) {
 
 		// The receiver is also asked to dail to the sender in (SUDPH).
 		if err := a.askToDialUDP(receiverPK, senderPK, r, senderVisorData); err != nil {
+			// "peer is not connected" means the receiver has an AR record but
+			// no live UDP control connection right now — it is offline, or the
+			// record is stale. The sender already has its 200 and will still
+			// dial; only the simultaneous-open nudge is skipped. That is an
+			// expected outcome, not a fault, and one WARN per attempt made it
+			// ~9,475 lines/min in production. Count it and report the rate
+			// once per window instead; the individual event stays at Debug.
+			if errors.Is(err, ErrNotConnected) {
+				a.logger(r).Debugf("Failed to ask %v to dial %v@%v: %v", receiverPK, senderPK, remoteAddr, err)
+				if s := a.dialAssistFails.record(time.Now(), receiverPK); s != nil {
+					a.log.WithField("window", s.Window.Round(time.Second).String()).
+						WithField("skipped", s.Count).
+						WithField("peers", s.Peers).
+						WithField("top_peers", s.TopPeers).
+						Info("SUDPH dial-assist requests skipped: peer is not connected")
+				}
+				return
+			}
 			a.logger(r).Warnf("Failed to ask %v to dial %v@%v: %v", receiverPK, senderPK, remoteAddr, err)
 			return
 		}

--- a/pkg/deployment/ar/api/dial_assist_log.go
+++ b/pkg/deployment/ar/api/dial_assist_log.go
@@ -1,0 +1,137 @@
+// Package api pkg/deployment/ar/api/dial_assist_log.go c4-net-discovery
+//
+// Rate accounting for the SUDPH reverse dial-assist, whose "peer is not
+// connected" outcome used to be logged once per attempt.
+//
+// On a /resolve of type sudph the AR also nudges the RECEIVER to dial the
+// sender, so both sides punch at once. That nudge needs a live UDP control
+// connection from the receiver; when the receiver is offline (or its AR
+// record is stale) there is none and askToDialUDP returns ErrNotConnected.
+// The sender's /resolve response has already been written at that point —
+// nothing is lost but the simultaneous-open optimisation, and the sender
+// still dials. It is a routine outcome of a network where visors come and go.
+//
+// Measured on the live deployment it was also 94,752 log lines in ten
+// minutes — ~9,475/min against 2,450/min for the entire transport-discovery
+// and 38/min for the route-finder. That is a real disk and IO cost, and it
+// buried every other address-resolver diagnostic.
+//
+// A per-peer rate limit was rejected: the cardinality IS the signal here
+// (thousands of distinct offline peers), so per-peer state would grow with
+// the fleet while still emitting a line per newly-seen peer. A plain demotion
+// to Debug was rejected too: it makes the condition invisible at the level
+// operators actually run, and the RATE is what tells them whether something
+// is wrong (a jump from ~9k/min to ~90k/min matters; the individual line does
+// not). Aggregation keeps the rate, the distinct-peer count and the worst
+// offenders, at one line per window; the individual event stays available at
+// Debug for anyone who raises the level.
+package api
+
+import (
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// dialAssistSummaryInterval is the window over which skipped dial-assist
+// requests are counted before one summary line is emitted.
+const dialAssistSummaryInterval = time.Minute
+
+// dialAssistTopPeers is how many of the worst offenders the summary names.
+const dialAssistTopPeers = 5
+
+// dialAssistFailures counts dial-assist requests skipped because the peer had
+// no live UDP connection, and hands back a summary once per interval.
+//
+// Flushing is lazy — the window is closed by the next recorded failure rather
+// than by a timer — so there is no goroutine to own or shut down. The trailing
+// partial window is therefore only reported when the next failure arrives; at
+// the observed rate (thousands per minute) that is immediate, and when the
+// rate really does fall to zero there is nothing left to warn about.
+type dialAssistFailures struct {
+	mu       sync.Mutex
+	interval time.Duration
+	since    time.Time
+	count    int
+	peers    map[cipher.PubKey]int
+}
+
+// dialAssistSummary is one closed window's worth of skipped dial-assists.
+type dialAssistSummary struct {
+	// Window is the elapsed time the counts cover.
+	Window time.Duration
+	// Count is the number of skipped dial-assist requests.
+	Count int
+	// Peers is the number of distinct peers they were addressed to.
+	Peers int
+	// TopPeers names the worst offenders as "<pk>=<count>", full keys.
+	TopPeers []string
+}
+
+func newDialAssistFailures(interval time.Duration) *dialAssistFailures {
+	return &dialAssistFailures{
+		interval: interval,
+		peers:    make(map[cipher.PubKey]int),
+	}
+}
+
+// record notes one skipped dial-assist for peer. It returns a summary of the
+// window that just closed, or nil when the window is still open.
+func (d *dialAssistFailures) record(now time.Time, peer cipher.PubKey) *dialAssistSummary {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.since.IsZero() {
+		d.since = now
+	}
+	d.count++
+	d.peers[peer]++
+
+	if now.Sub(d.since) < d.interval {
+		return nil
+	}
+
+	summary := &dialAssistSummary{
+		Window:   now.Sub(d.since),
+		Count:    d.count,
+		Peers:    len(d.peers),
+		TopPeers: topPeers(d.peers, dialAssistTopPeers),
+	}
+
+	d.since = now
+	d.count = 0
+	d.peers = make(map[cipher.PubKey]int)
+
+	return summary
+}
+
+// topPeers renders the n highest-count peers as "<pk>=<count>". Public keys
+// are never abbreviated — an operator has to be able to paste one straight
+// into `skywire cli`.
+func topPeers(counts map[cipher.PubKey]int, n int) []string {
+	type entry struct {
+		pk cipher.PubKey
+		n  int
+	}
+	entries := make([]entry, 0, len(counts))
+	for pk, c := range counts {
+		entries = append(entries, entry{pk: pk, n: c})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].n != entries[j].n {
+			return entries[i].n > entries[j].n
+		}
+		return entries[i].pk.Hex() < entries[j].pk.Hex()
+	})
+	if len(entries) > n {
+		entries = entries[:n]
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.pk.Hex()+"="+strconv.Itoa(e.n))
+	}
+	return out
+}

--- a/pkg/deployment/ar/api/dial_assist_log_test.go
+++ b/pkg/deployment/ar/api/dial_assist_log_test.go
@@ -1,0 +1,107 @@
+// Package api pkg/deployment/ar/api/dial_assist_log_test.go c4-net-discovery
+package api
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// testPKs returns n distinct, valid public keys. cipher.PubKey validates the
+// point, so hand-built byte patterns are rejected.
+func testPKs(t *testing.T, n int) []cipher.PubKey {
+	t.Helper()
+	pks := make([]cipher.PubKey, n)
+	for i := range pks {
+		pk, _ := cipher.GenerateKeyPair()
+		pks[i] = pk
+	}
+	return pks
+}
+
+// TestDialAssistFailuresCollapsesWindow is the point of the change: many
+// skipped dial-assists inside one window produce ONE summary, not one line
+// each, and the summary carries the rate and the distinct-peer count.
+func TestDialAssistFailuresCollapsesWindow(t *testing.T) {
+	d := newDialAssistFailures(time.Minute)
+	start := time.Now()
+
+	pks := testPKs(t, 2)
+	pkA, pkB := pks[0], pks[1]
+
+	// 1000 failures spread over 59s across two peers: nothing emitted yet.
+	summaries := 0
+	for i := 0; i < 1000; i++ {
+		pk := pkA
+		if i%4 == 0 {
+			pk = pkB
+		}
+		if s := d.record(start.Add(time.Duration(i)*59*time.Millisecond), pk); s != nil {
+			summaries++
+		}
+	}
+	require.Zero(t, summaries, "no summary before the window closes")
+
+	// One more past the minute closes it.
+	s := d.record(start.Add(61*time.Second), pkA)
+	require.NotNil(t, s)
+	require.Equal(t, 1001, s.Count)
+	require.Equal(t, 2, s.Peers)
+	require.Equal(t, 61*time.Second, s.Window)
+	// pkA took 750 of the first 1000 plus the closing one.
+	require.Equal(t, []string{pkA.Hex() + "=751", pkB.Hex() + "=250"}, s.TopPeers)
+
+	// Counters reset for the next window.
+	require.Nil(t, d.record(start.Add(62*time.Second), pkA))
+	s2 := d.record(start.Add(2*time.Minute+2*time.Second), pkB)
+	require.NotNil(t, s2)
+	require.Equal(t, 2, s2.Count)
+	require.Equal(t, 2, s2.Peers)
+}
+
+// TestDialAssistFailuresTopPeersBounded keeps the summary line a fixed size no
+// matter how many distinct peers are offline.
+func TestDialAssistFailuresTopPeersBounded(t *testing.T) {
+	d := newDialAssistFailures(time.Minute)
+	start := time.Now()
+
+	pks := testPKs(t, 50)
+	for i := 0; i < 50; i++ {
+		pk := pks[i]
+		// Peer i gets i+1 records, so the ranking is deterministic.
+		for j := 0; j <= i; j++ {
+			require.Nil(t, d.record(start, pk))
+		}
+	}
+
+	s := d.record(start.Add(time.Minute), pks[0])
+	require.NotNil(t, s)
+	require.Equal(t, 50, s.Peers)
+	require.Len(t, s.TopPeers, dialAssistTopPeers)
+	// Highest count first: peer 50 recorded 50 times.
+	require.Equal(t, pks[49].Hex()+"=50", s.TopPeers[0])
+}
+
+// TestDialAssistFailuresConcurrent exercises the lock: /resolve runs one
+// goroutine per request.
+func TestDialAssistFailuresConcurrent(t *testing.T) {
+	d := newDialAssistFailures(time.Millisecond)
+	pks := testPKs(t, 16)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			pk := pks[n]
+			for j := 0; j < 200; j++ {
+				d.record(time.Now(), pk)
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/pkg/services/sn/sn.go
+++ b/pkg/services/sn/sn.go
@@ -22,6 +22,7 @@ import (
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
@@ -280,26 +281,13 @@ func (s *service) startDMSGHealth(
 		}
 		json.NewEncoder(w).Encode(resp) //nolint:errcheck,gosec
 	})
-	mux.HandleFunc("/stats", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		snap := collector.Snapshot()
-		// Sanitize: strip src/dst PKs to avoid leaking visor topology.
-		for i := range snap.RecentFailures {
-			snap.RecentFailures[i].SrcPK = ""
-			snap.RecentFailures[i].DstPK = ""
-		}
-		for i := range snap.TopDestinations {
-			snap.TopDestinations[i].PK = ""
-		}
-		for i := range snap.TopFailedDestinations {
-			snap.TopFailedDestinations[i].PK = ""
-		}
-		json.NewEncoder(w).Encode(snap) //nolint:errcheck,gosec
-	})
+	mux.Handle("/stats", statsHandler(collector, deployment.Prod.SurveyWhitelist))
 
 	snClient := sn.DmsgClient()
 	// Fold pprof + /debug/log onto the main dmsg :80 (survey-gated) instead of a
-	// separate :81 listener. The ring buffer captures route-setup logs (the
+	// separate :81 listener. Note WithDebug gates ONLY /debug/ — /health and
+	// /stats fall through to the mux, which is why /stats carries its own
+	// whitelist above. The ring buffer captures route-setup logs (the
 	// router logs via the global logger) so /debug/log needs no disk file —
 	// e.g. the live id-reservation failures behind the /stats counters.
 	rb := logging.NewRingBuffer(0)
@@ -312,6 +300,39 @@ func (s *service) startDMSGHealth(
 		}
 	}()
 	log.Infof("DMSG HTTP (health/stats/debug) available at %s", dmsgAddr)
+}
+
+// statsHandler serves the route-setup metrics snapshot, restricted to the
+// survey whitelist.
+//
+// It used to be public and blanked the structured public keys before encoding
+// (RecentFailures[].SrcPK / DstPK, TopDestinations[].PK,
+// TopFailedDestinations[].PK) with the comment "strip src/dst PKs to avoid
+// leaking visor topology". That did not work. The FailureEvent.Error string is
+// not sanitized and carries the same keys verbatim, e.g.
+//
+//	failed to reserve route ids: reserve routeID from
+//	03d672c32a56a666a4931f6327ff85874af614dccf17b19cc6f665b1219c317dd7
+//	failed: context deadline exceeded
+//
+// so the topology went out anyway; all the blanking removed was the
+// machine-readable half — exactly the fields needed to answer "which
+// destination is failing", which a live incident could not get.
+//
+// The stripping was written as if /stats were already behind the survey
+// whitelist. It was not: dmsghttp.WithDebug gates only paths under /debug/,
+// and /stats fell through to the plain mux, unauthenticated to anyone able to
+// dial the setup node over dmsg. So the choice was never "gate or sanitize" —
+// there was no gate and no working sanitizer. Gating it is what makes the
+// stated intent true, and once the endpoint is actually restricted there is no
+// reason to withhold the fields from the operators it is restricted to.
+//
+// /health stays public; it carries no keys beyond the node's own.
+func statsHandler(collector *setupmetrics.Collector, whitelist []cipher.PubKey) http.Handler {
+	return dmsghttp.WhitelistMiddleware(whitelist, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(collector.Snapshot()) //nolint:errcheck,gosec
+	}))
 }
 
 // getHTTPClient returns an *http.Client for the given service URL,

--- a/pkg/services/sn/stats_handler_test.go
+++ b/pkg/services/sn/stats_handler_test.go
@@ -1,0 +1,92 @@
+// Package sn stats_handler_test.go: access control and payload shape of the
+// setup-node /stats handler.
+package sn
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/router/setupmetrics"
+)
+
+// collectorWithFailure returns a collector holding one recorded route-setup
+// failure, plus the src/dst keys it was recorded against.
+func collectorWithFailure(t *testing.T) (*setupmetrics.Collector, cipher.PubKey, cipher.PubKey) {
+	t.Helper()
+	c := setupmetrics.NewCollector(setupmetrics.CollectorConfig{})
+	src, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	err := errors.New("failed to reserve route ids: reserve routeID from " +
+		dst.Hex() + " failed: context deadline exceeded")
+	c.RecordRouteContext(context.Background(), src, dst, 2)(&err)
+	return c, src, dst
+}
+
+// requestAs issues a GET /stats whose RemoteAddr is "<pk>:<port>", the shape
+// an http.Server sees when the listener is a dmsg listener.
+func requestAs(h http.Handler, pk cipher.PubKey) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/stats", nil)
+	req.RemoteAddr = pk.Hex() + ":80"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestStatsHandlerRequiresWhitelist is the access control the old code assumed
+// it had: dmsghttp.WithDebug gates only /debug/, so /stats was open to anyone
+// who could dial the setup node.
+func TestStatsHandlerRequiresWhitelist(t *testing.T) {
+	c, _, _ := collectorWithFailure(t)
+	allowed, _ := cipher.GenerateKeyPair()
+	stranger, _ := cipher.GenerateKeyPair()
+
+	h := statsHandler(c, []cipher.PubKey{allowed})
+
+	require.Equal(t, http.StatusUnauthorized, requestAs(h, stranger).Code)
+	require.Equal(t, http.StatusOK, requestAs(h, allowed).Code)
+}
+
+// TestStatsHandlerEmptyWhitelistDeniesAll — an unconfigured whitelist must not
+// fail open (WhitelistMiddleware's contract; asserted here because /stats now
+// depends on it).
+func TestStatsHandlerEmptyWhitelistDeniesAll(t *testing.T) {
+	c, _, _ := collectorWithFailure(t)
+	caller, _ := cipher.GenerateKeyPair()
+
+	require.Equal(t, http.StatusUnauthorized, requestAs(statsHandler(c, nil), caller).Code)
+}
+
+// TestStatsHandlerServesStructuredPKs asserts the fields the old handler
+// blanked are present for an authorized caller — and shows why blanking them
+// achieved nothing: the same key is in the unsanitized error string.
+func TestStatsHandlerServesStructuredPKs(t *testing.T) {
+	c, src, dst := collectorWithFailure(t)
+	allowed, _ := cipher.GenerateKeyPair()
+
+	rec := requestAs(statsHandler(c, []cipher.PubKey{allowed}), allowed)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var snap setupmetrics.StatsSnapshot
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &snap))
+
+	require.Len(t, snap.RecentFailures, 1)
+	require.Equal(t, src.Hex(), snap.RecentFailures[0].SrcPK)
+	require.Equal(t, dst.Hex(), snap.RecentFailures[0].DstPK)
+	require.NotEmpty(t, snap.TopDestinations)
+	require.Equal(t, dst.Hex(), snap.TopDestinations[0].PK)
+	require.NotEmpty(t, snap.TopFailedDestinations)
+	require.Equal(t, dst.Hex(), snap.TopFailedDestinations[0].PK)
+
+	// The error string carried the destination key all along, which is why
+	// stripping the structured fields never delivered any privacy.
+	require.True(t, strings.Contains(snap.RecentFailures[0].Error, dst.Hex()),
+		"error string is expected to embed the destination key")
+}

--- a/pkg/visor/visorconfig/services_native.go
+++ b/pkg/visor/visorconfig/services_native.go
@@ -2,21 +2,26 @@
 
 // Package visorconfig pkg/visor/visorconfig/services_native.go c3-vis-core
 //
-// Native (non-WASM) implementation of Fetch, the HTTP helper that
-// retrieves a Services payload from a conf-service endpoint. Lives
-// here (rather than in services.go) so the WASM build graph for
-// genvisor/autoconfigcmd/install-page doesn't pull in net/http.
-// See services.go's package doc for context.
+// Native (non-WASM) home of the EnvServices alias. Lives here (rather
+// than in services.go) because deployment.EnvServices is itself only
+// defined under !js — its json.RawMessage fields need encoding/json,
+// which is build-tag-gated off the WASM path. See services.go's
+// package doc for context.
+//
+// This file used to also carry Fetch(), a plain-net/http helper that
+// pulled a Services payload from the conf-service URL. It was removed:
+// the deployment's conf service is dmsg-only (deployment.ProdConf.Conf
+// is a dmsg:// URL), and a bare http.Client can never dial one — it
+// fails with `unsupported protocol scheme "dmsg"`. Standing a dmsg
+// client up here is not possible either: the CLI's dmsg fetch chain
+// lives in cmd/skywire-cli, which imports pkg/visor, which imports this
+// package, so the dependency can only run in that direction. Its sole
+// caller (`skywire cli config update -a`) now uses the same
+// dmsg-first fetch that `config gen` uses.
 package visorconfig
 
 import (
-	"encoding/json"
-	"io"
-	"net/http"
-	"time"
-
 	"github.com/skycoin/skywire/deployment"
-	"github.com/skycoin/skywire/pkg/logging"
 )
 
 // EnvServices is the wrapper struct for the outer JSON. Aliased to
@@ -24,46 +29,3 @@ import (
 // config.go package doc for the WASM-stripping rationale). Consumers
 // using visorconfig.EnvServices keep working under non-WASM builds.
 type EnvServices = deployment.EnvServices
-
-// Fetch fetches the service URLs & ip:ports from the config service
-// endpoint over HTTP. Used by the visor's CLI config-gen path; not
-// reachable from the WASM-clean genvisor.Generate flow (which uses
-// the embedded deployment.Prod instead).
-func Fetch(mLog *logging.MasterLogger, serviceConf string, stdout bool) (services *Services) {
-	client := http.Client{
-		Timeout: time.Second * 15, // Timeout after 15 seconds
-	}
-	//create the http request
-	req, err := http.NewRequest(http.MethodGet, serviceConf, nil)
-	if err != nil {
-		mLog.WithError(err).Fatal("Failed to create http request")
-	}
-	req.Header.Add("Cache-Control", "no-cache")
-	//check for errors in the response
-	res, err := client.Do(req)
-	if err != nil {
-		//silence errors for stdout
-		if !stdout {
-			mLog.WithError(err).Error("Failed to fetch servers")
-			mLog.Warn("Falling back on hardcoded servers")
-		}
-	} else {
-		// nil error from client.Do(req)
-		if res.Body != nil {
-			defer res.Body.Close() //nolint:errcheck
-		}
-		body, err := io.ReadAll(res.Body)
-		if err != nil {
-			mLog.WithError(err).Fatal("Failed to read response")
-		}
-		//fill in services struct with the response
-		err = json.Unmarshal(body, &services)
-		if err != nil {
-			mLog.WithError(err).Fatal("Failed to unmarshal json response")
-		}
-		if !stdout {
-			mLog.Infof("Fetched service endpoints from '%s'", serviceConf)
-		}
-	}
-	return services
-}


### PR DESCRIPTION
Three independent fixes found while auditing the live deployment. Separate commits so they can be split.

## 1. `config update -a` could never work, and panicked (`e76b961e6`)

Reproduced: `ERROR Failed to fetch servers error="Get \"dmsg://...\": unsupported protocol scheme \"dmsg\"" / WARN Falling back on hardcoded servers / panic: nil pointer dereference` at `update.go:128`.

Three defects, not the two I expected:

- **No dmsg transport.** `visorconfig.Fetch` used a bare `http.Client`, so the *default* `dmsg://` conf URL could never resolve. A dmsg client cannot be stood up in `visorconfig` (import cycle), so `Fetch` — which had exactly one caller — is deleted in favour of `fetchServiceConfig()`, the DMSG → HTTP → embedded chain **already in that package** and used by `config gen`. No new machinery.
- **The fallback was fake.** It logged "Falling back on hardcoded servers" and returned nil — the named return was never assigned. Now every branch leaves `services` populated and the log matches the behaviour.
- **New finding: the command was destructive even on success.** It replaced `conf.Dmsg`/`Transport`/`Routing`/`Launcher` with fresh structs, discarding launcher apps and bin path, transport log store and ports, dmsg session count/carriers/protocol, and min-hops — and wrote only the plain-HTTP endpoint fields, which are all `null` in the current `services-config.json`, so a *successful* fetch would have blanked the endpoints. `applyServiceEndpoints` now mutates in place, skips empty values, and applies the `*_dmsg` URLs the way `gen.go` does.

Verified live: fetched over dmsg, exit 0, all 9 launcher apps and `sessions_count` preserved, endpoints unchanged. Bogus-PK path falls back to the embedded config, exit 0, no panic.

## 2. address-resolver log flood (`aa5ad10ae`)

`pkg/deployment/ar/api/api.go:610` emitted **9,475 lines/minute** in production, all `ErrNotConnected` from `askToDialUDP` on the SUDPH half of `/resolve`. For scale: TPD 2,450/min, setup-node 240/min, route-finder 38/min.

Aggregated rather than rate-limited or demoted. Rate-limiting per peer is the wrong shape — the cardinality *is* the signal (thousands of distinct offline peers), so per-peer state grows with the fleet and still emits a line per newly-seen peer. Demoting to Debug hides it at the level operators actually run. And the *rate* is the diagnostic: 9k/min is normal, 90k/min is not. Now one INFO per minute with count, distinct-peer count and the five worst offenders (full public keys); the individual event drops to Debug; non-`ErrNotConnected` errors keep their per-instance WARN. Flush is lazy, so no goroutine to own.

## 3. setup-node `/stats` was publicly readable (`5089e6b5b`)

I assumed `/stats` was survey-gated and that the PK-stripping was therefore redundant. **That assumption was wrong.** `dmsghttp.WithDebug` (`debug.go:50-59`) gates only paths prefixed `/debug/`; everything else falls through to the mux, and `ListenAndServe` applies no whitelist. `/stats` was readable by any visor that could dial the setup node.

So simply removing the stripping would have published route-setup topology to the network. Instead the missing precondition is supplied — `/stats` now carries `WhitelistMiddleware(deployment.Prod.SurveyWhitelist, ...)` — and the stripping is removed, restoring `top_destinations[].pk` and `recent_failures[].src_pk/.dst_pk`. `/health` stays public.

The stripping was ineffective anyway, and there is now a test asserting it: the `error` string embeds the destination key regardless, e.g. `"reserve routeID from 03d672c32a56a666a4931f6327ff85874af614dccf17b19cc6f665b1219c317dd7 failed: context deadline exceeded"`. So it cost the machine-readable fields — exactly what a live incident needed today — while delivering no privacy.

Verified the gate does not lock out existing readers: `/debug/log`, which is already survey-gated, returns 200 over the same proxy path that reads `/stats`.

`go build .` clean, `gofmt` clean, `golangci-lint` 0 issues, tests green on all four touched packages.