### PR TITLE
fix(cxo): sweep superseded Roots on the treestore subscriber

### DIFF
--- a/pkg/cxo/treestore/leak_subscriber_repro_test.go
+++ b/pkg/cxo/treestore/leak_subscriber_repro_test.go
@@ -76,3 +76,74 @@ func TestPublisherCleanupBoundedWithSubscriber(t *testing.T) {
 		t.Errorf("CXDS volume %d > 16 MB — leak with a subscriber connected (per-Root retention should be ~4 MB)", vol)
 	}
 }
+
+// TestSubscriberCXDSBounded is the subscriber-side mirror of
+// TestPublisherCleanupBoundedWithSubscriber.
+//
+// CXO never reclaims anything on its own: every filled Root and every object
+// it references keeps rc>=1 forever unless something calls DelRoot +
+// IterateDel. The Publisher has run that sweep since #3047
+// (Publisher.runCleanupLoop → cxoutils.RemoveRootObjects/RemoveObjects); the
+// Subscriber never did. So a subscriber that owns its node accumulates every
+// version of every leaf it has ever filled — with InMemoryDB (what
+// cxosub.Manager uses on every visor) that is straight, unbounded heap
+// growth, and because memoryCXDS.Set stores the caller's slice by reference
+// the retained bytes are the msg.Decode buffers the fill decoded them from.
+//
+// One fixed path re-published with a fresh 2 MB body 40 times: steady state
+// is ~one kept Root (~4 MB with structural objects); 80 MB is "nothing is
+// ever released".
+func TestSubscriberCXDSBounded(t *testing.T) {
+	pkA, skA := cipher.GenerateKeyPair()
+
+	pub, err := NewWithTCP("127.0.0.1:0", skA, PubConfig{
+		InMemoryDB:  true,
+		BatchWindow: 5 * time.Millisecond,
+	})
+	require.NoError(t, err, "NewWithTCP publisher")
+	t.Cleanup(func() { _ = pub.Close() }) //nolint:errcheck
+
+	addr := pub.Node().TCP().Address()
+	require.NotEmpty(t, addr)
+
+	sub, err := NewSubscriberTCP("", pkA, SubConfig{InMemoryDB: true})
+	require.NoError(t, err, "NewSubscriberTCP")
+	t.Cleanup(func() { _ = sub.Close() }) //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, sub.ConnectTCP(ctx, addr), "ConnectTCP")
+
+	mkRandom := func(size int) []byte {
+		b := make([]byte, size)
+		_, _ = rand.Read(b)
+		return b
+	}
+
+	const ticks = 40
+	for i := 0; i < ticks; i++ {
+		require.NoError(t, pub.Put("all-transports", mkRandom(2*1024*1024)))
+		require.NoError(t, pub.Flush())
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Let the last fills land and the sweep run.
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := sub.Get("all-transports"); ok {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	time.Sleep(2 * time.Second)
+
+	cxds := sub.cxoNode.Container().DB().CXDS()
+	amount, _ := cxds.Amount()
+	vol, _ := cxds.Volume()
+	t.Logf("subscriber CXDS after %d republishes: amount=%d volume=%d", ticks, amount, vol)
+
+	if vol > 16*1024*1024 {
+		t.Errorf("subscriber CXDS volume %d > 16 MB after %d republishes of a single 2 MB leaf — "+
+			"superseded Roots and their objects are never released", vol, ticks)
+	}
+}

--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -25,6 +25,7 @@ import (
 	skycipher "github.com/skycoin/skycoin/src/cipher"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/cxo/node"
 	cxotransport "github.com/skycoin/skywire/pkg/cxo/node/transport"
 	"github.com/skycoin/skywire/pkg/cxo/skyobject"
@@ -177,6 +178,15 @@ type Subscriber struct {
 	// Surfaced only for tests; treat as opaque metric otherwise.
 	reconnectAttempts atomic.Int64
 
+	// cleanupNudge / cleanupStop / cleanupDone drive the CXDS sweep
+	// goroutine (runCleanupLoop). Non-nil only when this Subscriber owns
+	// its node — a caller-owned node is swept by whoever owns it (a
+	// co-hosted Publisher already runs the identical sweep). See
+	// startCleanup.
+	cleanupNudge chan struct{}
+	cleanupStop  chan struct{}
+	cleanupDone  chan struct{}
+
 	closed   bool
 	closeMu  sync.Mutex
 	closeErr error
@@ -257,6 +267,7 @@ func NewSubscriber(dmsgC *dmsg.Client, feedPK cipher.PubKey, conf SubConfig) (*S
 	cxoNode.SwapOnFillingBreaks(func(_ *node.Node, r *registry.Root, err error) {
 		s.handleFillingBreaks(r, err)
 	})
+	s.startCleanup()
 	return s, nil
 }
 
@@ -308,6 +319,7 @@ func NewSubscriberTCP(listenAddr string, feedPK cipher.PubKey, conf SubConfig) (
 	cxoNode.SwapOnFillingBreaks(func(_ *node.Node, r *registry.Root, err error) {
 		s.handleFillingBreaks(r, err)
 	})
+	s.startCleanup()
 	return s, nil
 }
 
@@ -736,6 +748,15 @@ func (s *Subscriber) Close() error {
 			close(stop)
 		}
 	})
+	// Stop the sweeper before the node goes away — runCleanup touches the
+	// Container, so it must not still be running when Close tears it down.
+	// No final sweep: the node (and, for InMemoryDB, the whole CXDS) is
+	// about to be dropped anyway, and a last O(CXDS) pass would only slow
+	// Close down. Nil when this Subscriber does not own its node.
+	if s.cleanupStop != nil {
+		close(s.cleanupStop)
+		<-s.cleanupDone
+	}
 	if s.ownsNode {
 		s.closeErr = s.cxoNode.Close()
 	}
@@ -831,6 +852,91 @@ func (s *Subscriber) handleRootFilled(r *registry.Root) {
 	// subscriber that a Root was received and the fill walk
 	// completed — the subscription is verifiably live now.
 	s.signalRootObserved()
+	// The walk above copied every leaf it cares about into s.cache, so
+	// the Root we just superseded (and its whole object tree) is dead
+	// weight in the CXDS from here on. Ask the sweeper to drop it.
+	s.nudgeCleanup()
+}
+
+// subCleanupForceInterval is how often the subscriber's sweep runs even
+// without a fill nudge — the backstop for a feed that went quiet while
+// still holding superseded Roots, and for orphans a nudge-driven sweep
+// missed (DelRoot's rc-decrement walk short-circuits on a missing hash,
+// leaving siblings at rc>=1 until a later unconditional pass). Matches
+// the publisher's cleanupForceInterval; the nudge remains the fast path.
+const subCleanupForceInterval = 10 * time.Minute
+
+// startCleanup arms the CXDS sweep goroutine. Called only from the
+// constructors that give the Subscriber sole ownership of its node
+// (NewSubscriber / NewSubscriberTCP); NewSubscriberOnNode shares a
+// container whose owner — in practice a co-hosted Publisher, which has
+// run this same sweep since #3047 — is responsible for cleaning it.
+func (s *Subscriber) startCleanup() {
+	s.cleanupNudge = make(chan struct{}, 1)
+	s.cleanupStop = make(chan struct{})
+	s.cleanupDone = make(chan struct{})
+	go s.runCleanupLoop()
+}
+
+// nudgeCleanup asks for a sweep without ever blocking the CXO filler
+// goroutine that calls it; a burst of Roots coalesces into one pass.
+func (s *Subscriber) nudgeCleanup() {
+	if s.cleanupNudge == nil {
+		return
+	}
+	select {
+	case s.cleanupNudge <- struct{}{}:
+	default:
+	}
+}
+
+// runCleanupLoop drops superseded Roots and frees CXDS entries whose
+// reference count fell to zero.
+//
+// CXO reclaims nothing on its own: a filled Root and every object under
+// it stay at rc>=1 forever unless something calls DelRoot and then
+// sweeps the rc==0 remainder. The Publisher has done that since #3047;
+// the Subscriber never did, so it accumulated every version of every
+// leaf it had ever filled. With InMemoryDB — what cxosub.Manager gives
+// every visor's feed subscribers — that is unbounded heap growth, and
+// because memoryCXDS.Set keeps the caller's slice by reference the
+// retained bytes are the msg.Decode buffers the fill decoded them from
+// (which is why heap profiles pinned the growth on
+// encoder.DeserializeRawToValue under Conn.receiveMsg rather than on
+// anything that looks like storage).
+//
+// keepLast=1: the subscriber re-walks the whole tree on every Root and
+// keeps what it needs in s.cache, so only the newest Root has any value
+// to it. RemoveRootObjects works off the last FULL Root's seq, so a
+// newer Root still being filled is never touched, and RemoveObjects
+// skips keys the Cache is tracking (an in-flight fill's wanted items).
+func (s *Subscriber) runCleanupLoop() {
+	defer close(s.cleanupDone)
+
+	t := time.NewTicker(subCleanupForceInterval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-s.cleanupStop:
+			return
+		case <-s.cleanupNudge:
+			s.runCleanup()
+		case <-t.C:
+			s.runCleanup()
+		}
+	}
+}
+
+func (s *Subscriber) runCleanup() {
+	c := s.cxoNode.Container()
+	if err := cxoutils.RemoveRootObjects(c, 1); err != nil {
+		s.log.WithError(err).Debug("treestore-sub: RemoveRootObjects failed; will retry on the next Root")
+		return
+	}
+	if err := cxoutils.RemoveObjects(c); err != nil {
+		s.log.WithError(err).Debug("treestore-sub: RemoveObjects failed; will retry on the next Root")
+	}
 }
 
 // signalRootObserved closes the current rootObservedSignal channel


### PR DESCRIPTION
Fixes a confirmed unbounded memory leak: **~2.5 MB/min (~150 MB/h), linear, no plateau**, reproduced on three separate visor instances.

## Evidence it was real

Two forced-GC heap profiles (`/debug/pprof/heap?gc=1`) 10 minutes apart on a visor up >1h:

```
encoder.DeserializeRawToValue inuse   131.07 MB (43.6%) -> 156.18 MB (46.8%)   +25.11 MB
same site alloc_space (lifetime)      0.13 GB -> 0.15 GB   => ~99% still live
inuse_objects / alloc_objects         10222/10250 -> 10411/10439  (28 ever freed)
-base diff: 38.99% of ALL heap growth, top grower by an order of magnitude
```

GC lag ruled out: `NumGC` 123 -> 136 between samples, plus a forced GC before each. Globally 98.6% of all bytes ever allocated were reclaimed; at this one site, 0.4%.

## Root cause

**`treestore.Subscriber` never ran the object sweep that `Publisher` has run since #3047.**

`cxosub/manager.go:945,1035` build every per-feed subscriber with `SubConfig{InMemoryDB: true}`, so its CXDS is `memoryCXDS`. CXO reclaims nothing on its own — a filled Root and its whole object tree stay at `rc>=1` forever unless something calls `DelRoot` and then sweeps the `rc==0` remainder. `Publisher.runCleanupLoop` does exactly that; `Subscriber` had no equivalent, so it accumulated every version of every leaf it had ever filled.

It *surfaced* at `DeserializeRawToValue <- msg.Decode <- Conn.receiveMsg` because `memoryCXDS.Set` stores the caller's slice **by reference**, and the fill path hands it the alias (`head.go:629` `SetWanted(key, x.Value)`). Each stored object therefore pins the whole decode buffer, and the store's contents get attributed to the decoder's allocation site. The aliasing is why the bytes are attributed there — it is not the leak.

## How the holder was identified

An in-process retention meter (`runtime.MemProfile`, filtered to stacks containing `msg.Decode`) driving a real two-node fill:

| receiver CXDS | round 9 | round 30 | behaviour |
|---|---|---|---|
| on-disk (bbolt) | 8.52 MB | 5.75 MB | sawtooths at the 8 MB `CacheMaxVolume`, tracking `CacheObjects.Volume` byte-for-byte |
| in-memory | 8.52 MB | 26.41 MB | **monotonic, unbounded**, tracking `AllObjects.Volume` |

That eliminates the `Cache` (correctly bounded) and identifies the store. `storeUsed == storeAll` at every sample even when each round's leaves were fully replaced — nothing ever reaches `rc==0` because nothing ever deletes the old Root.

Also verified and excluded: `registry.DecodeRoot` copies; the pending-request map's `defer delRequest` is correct; `skyobject.Preview.m` is per-pack and unused on a visor; `treestore.walkTree` already copies its leaf.

## Fix

`Subscriber` now runs the same `cxoutils.RemoveRootObjects(c, 1)` + `RemoveObjects(c)` pass as `Publisher`: a dedicated goroutine nudged (non-blocking) after each successful fill walk, with a 10-minute unconditional backstop, torn down in `Close`. Armed only from `NewSubscriber` / `NewSubscriberTCP` (the `ownsNode: true` constructors) — `NewSubscriberOnNode` callers all attach to a Publisher's node, which already sweeps.

Deliberately not fixed at the decoder: a copy in `memoryCXDS.Set` would *raise* steady-state memory, since `Cache.Set` stores the same slice in both cache and store and a copy would split one array into two for up to 8 MB of cached objects. Measured aliasing amplification is only 3.9% (size-class rounding).

## Before / after

`TestSubscriberCXDSBounded` — publisher republishes a fresh 2 MB body to one fixed path 40 times with a live subscriber:

```
before:  amount=161  volume=83899724   (83.9 MB, ~40 x 2 MB, nothing released)
after:   amount=5    volume=2098043    (2.1 MB, one kept Root)
```

## Behaviour change worth noting

The sweep deletes every Root below the last full one, so a subscriber can no longer serve historical Roots of a feed it subscribes to. That matches what `Publisher` already does to the same container, and what the subscriber actually uses (it re-walks the newest tree into `s.cache` each time) — but it is a change if anything downstream expects a subscriber node to retain history.

`go build .` OK, `go test ./pkg/cxo/...` all pass, `gofmt` clean, lint 0 issues.
