### PR TITLE
feat(desk): bridge the hypervisor /ws into vnet so the desk can drive the HOST visor

### DIFF
--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -110,24 +110,77 @@
 		// never appear.
 		var deskWin = null;
 
-		// Native mode: the page is served by a NATIVE hypervisor, whose visor
-		// is the host process — the desk is a shell OVER that visor, never a
+		// hostBridge: the capability probe behind the whole host/in-tab choice.
+		// A page served by a NATIVE hypervisor answers a plain GET /ws with 426
+		// Upgrade Required; nothing else on any desk origin does. Where one
+		// answers, claim the visor's virtual-loopback ports for the HOST visor
+		// (hvws-vnet.js) — after which every panel that already speaks vnet
+		// reaches the host process unchanged, because from the page's side a
+		// bridged port is indistinguishable from a wasm visor's.
+		//
+		// Nothing here is a flag or a build variant: a page that has no /ws
+		// gets null and boots exactly as it does today.
+		function hostBridge() {
+			if (!globalThis.SkywireHVWS || !globalThis.SkywireHVBridge || !globalThis.vnet) {
+				return Promise.resolve(null);
+			}
+			return globalThis.SkywireHVWS.probe().then(function (ok) {
+				if (!ok) return null;
+				// 3435 is the visor's control surface and hvPort its
+				// hypervisor UI — the two ports the desk asks about. The
+				// bridge claims only what is free, so a tab that is already
+				// running its own visor keeps it.
+				return globalThis.SkywireHVBridge.install({ ports: [3435, hvPort] });
+			}).catch(function () { return null; });
+		}
+
+		// bootHost: the page is served by a NATIVE hypervisor, whose visor is
+		// the host process — the desk is a shell OVER that visor, never a
 		// second one, so nothing wasm-shaped boots here (no jsfs snapshot, no
-		// desk-host module, no vnet, no skywireExec). The server injects
+		// desk-host module, no skywireExec). The server injects
 		// skywire-browse-launcher.js beside this file; that launcher mounts
 		// the panel with its /api-backed providers (the same ones the Angular
 		// dashboard gets) and publishes it as __skywireDesk. All that is left
-		// to do is open the dashboard window: the SAME-ORIGIN Angular UI in an
-		// iframe (embed=1 rides in the hash so the iframe's own injected
-		// launcher hides its taskbar — a desk never nests inside a desk
-		// window, the same guard the ☰ chat/log windows use).
-		if (opts.native) {
+		// to do is open the dashboard window.
+		//
+		// The bridge also makes the host's hypervisor UI addressable the way the
+		// wasm desk addresses its own: with the vnet service worker registered,
+		// /vnet/<hvPort>/ is a real same-origin URL that resolves natively —
+		// the Angular bundle comes off the host, its relative "api/" calls ride
+		// the /ws socket, and the nested browser's DirectLoader claims the URL
+		// as a document instead of transcoding it. Verified live.
+		//
+		// It is NOT what the dashboard window opens on, though, and the reason
+		// is worth writing down: bottle's vnet-sw.js gives a page 8s to answer
+		// each forwarded request (askClient), and this hypervisor's
+		// /api/visors-tree-summary takes 15s against a live fleet — measured,
+		// three runs, over plain HTTP as much as over the bridge. Through the
+		// service worker that endpoint 504s and the dashboard renders its
+		// "connection to the Hypervisor" error instead of the tree. The
+		// same-origin iframe has no such budget, so it stays the default until
+		// bottle's timeout is raised (or made per-request); until then the vnet
+		// address is published for whatever wants it, and nothing is forced
+		// through a path that would make a working dashboard worse.
+		function bootHost(bridge) {
 			status('starting the desk…');
+			// Registered up front: activation takes a moment, and the window
+			// below must not open before the question is settled either way.
+			var swReady = (bridge && globalThis.vnet.enableSW)
+				? globalThis.vnet.enableSW(opts.vnetSWURL || 'vnet-sw.js').catch(function () { return false; })
+				: Promise.resolve(false);
 			return Promise.all([
 				waitFor(function () { return globalThis.__skywireDesk; }, 'the desk panel'),
 				waitFor(function () { return typeof globalThis.WinBox === 'function'; }, 'the window manager'),
+				swReady,
 			]).then(function (r) {
 				var panel = r[0];
+				if (bridge && r[2] && globalThis.vnet.listening(hvPort)) {
+					globalThis.__DESK_VNET_DASHBOARD_URL__ =
+						globalThis.location.origin + '/vnet/' + hvPort + '/?embed=1#/?embed=1';
+				}
+				var dashURL = opts.dashboardURL || '/#/?embed=1';
+				// The ☰ menu's dashboard entry reads this too, on both pages.
+				globalThis.__DESK_DASHBOARD_URL__ = dashURL;
 				try {
 					// Join the panel's own stacking context (its windows root)
 					// so focus raises the dashboard above/below sibling windows
@@ -143,7 +196,7 @@
 					var topDocked = !(bd === '0' || bd === '0px');
 					var wb = new WinBox({
 						title: 'dashboard',
-						url: opts.dashboardURL || '/#/?embed=1',
+						url: dashURL,
 						root: root,
 						top: topDocked ? barH : 0,
 						bottom: topDocked ? 0 : barH,
@@ -158,299 +211,319 @@
 			});
 		}
 
-		skywireExec.wasmURL = opts.wasmURL || 'skywire.wasm.gz';
-		skywireExec.wasmExecURL = opts.wasmExecURL || 'wasm_exec.js';
-		globalThis.__WINBOX_WASM_URL__ = opts.winboxURL || 'winbox.wasm';
+		// bootWasm: the standalone desk — the tab IS the host. A wasm visor
+		// runs in a terminal, claims the virtual-loopback ports, and every
+		// panel reaches it through vnet. Unchanged by the host bridge above:
+		// where a page can run its own visor there is no /ws to bridge to, so
+		// the probe simply comes back empty.
+		function bootWasm() {
+			skywireExec.wasmURL = opts.wasmURL || 'skywire.wasm.gz';
+			skywireExec.wasmExecURL = opts.wasmExecURL || 'wasm_exec.js';
+			globalThis.__WINBOX_WASM_URL__ = opts.winboxURL || 'winbox.wasm';
 
-		// The vnet service worker: registered up front (it takes a moment to
-		// activate), so by the time anything opens a loopback window the
-		// nested browser can use real /vnet/<port>/ URLs — native rendering
-		// for the hypervisor UI. Resolves false where SWs are unavailable;
-		// the browser falls back to its transcoder, as before.
-		var swReady = (globalThis.vnet && globalThis.vnet.enableSW)
-			? globalThis.vnet.enableSW(opts.vnetSWURL || 'vnet-sw.js').catch(function () { return false; })
-			: Promise.resolve(false);
+			// The vnet service worker: registered up front (it takes a moment to
+			// activate), so by the time anything opens a loopback window the
+			// nested browser can use real /vnet/<port>/ URLs — native rendering
+			// for the hypervisor UI. Resolves false where SWs are unavailable;
+			// the browser falls back to its transcoder, as before.
+			var swReady = (globalThis.vnet && globalThis.vnet.enableSW)
+				? globalThis.vnet.enableSW(opts.vnetSWURL || 'vnet-sw.js').catch(function () { return false; })
+				: Promise.resolve(false);
 
-		status('restoring filesystem…');
-		return jsfs.persist.enable(opts.persistDB || 'skywire-desk', {
-			// Persist identity + config + user files; NEVER the runtime
-			// stores. A bbolt database snapshotted mid-write restores corrupt
-			// and hangs its consumer on the next boot (the hypervisor module
-			// stalling on a restored users.db) — caches rebuild, keys don't.
-			exclude: function (p) {
-				return /\.db$/.test(p) || p.indexOf('/opt/skywire/local/') === 0 || p === '/opt/skywire/local';
-			},
-		}).then(function (p) {
-			status((p.restored ? 'filesystem restored — ' : '') + 'starting the desk…');
-			// The desk host: the wasm-visor binary in-page. It installs the
-			// shell + the skywireVisor API and waits — boot() is never called,
-			// so no visor runs except the one started IN a terminal.
-			return gunzipFetch(opts.deskWasmURL || 'wasm-visor.wasm.gz');
-		}).then(function (buf) {
-			// Where the hypervisor UI lives, as an ABSOLUTE same-origin URL —
-			// the browser normalises a scheme-less address to http://, so a
-			// bare path would not survive being opened as a tab, and the
-			// DirectLoader that renders it natively matches on origin.
-			//
-			// The vnet ROOT with ?embed=1, not "/dashboard": the service worker
-			// rewrites a framed page's <base href> to the "/vnet/<port>/"
-			// prefix, so any deeper path is normalised away before the document
-			// finishes loading — a "/dashboard" URL lands back on the root and
-			// renders the desk inside the desk. At the root the hypervisor
-			// serves the dashboard instead whenever the request is framed, and
-			// embed=1 also rides in the hash so the injected launcher inside
-			// knows not to grow a taskbar of its own.
-			globalThis.__DESK_DASHBOARD_URL__ = globalThis.location.origin +
-				'/vnet/' + hvPort + '/?embed=1#/?embed=1';
-			var go = new Go();
-			return WebAssembly.instantiate(buf, go.importObject).then(function (r) {
-				go.run(r.instance).catch(function (e) { console.error('desk host:', e); });
-				return Promise.all([
-					waitFor(function () { return globalThis.skywireShell; }, 'the shell'),
-					waitFor(function () { return globalThis.__skywireDesk; }, 'the desk panel'),
-					waitFor(function () { return typeof globalThis.WinBox === 'function'; }, 'the window manager'),
-				]);
-			});
-		}).then(function () {
-			var sv = globalThis.skywireVisor;
-			// The desk's REAL visor is the root binary running in a terminal —
-			// a separate wasm instance the page cannot call. The desk host's
-			// own skywireVisor core is deliberately never booted here, so the
-			// nested browser reaches the mesh THROUGH the running visor's
-			// resolving proxy on the virtual loopback (dmsgweb, vnet:4445,
-			// chained to skynetweb + the proxy client): dmsg/skynet fetches go
-			// SOCKS5-over-vnet. Falls back to the in-page core for a page that
-			// booted it (nothing on the desk does today).
-			var RESOLVER_PORT = 4445;
-			function viaResolver() {
-				return !!(globalThis.vnet && globalThis.vnet.listening(RESOLVER_PORT) && globalThis.vnet.socksHttpFetch);
-			}
-			function resolverHost(pkHost) {
-				var h = String(pkHost || '');
-				// bare 66-hex PK → PK.dmsg (the resolver matches by suffix)
-				if (/^[0-9a-f]{66}$/i.test(h)) return h + '.dmsg';
-				return h;
-			}
-			// The desk's browser transport: mesh fetches go through the RUNNING
-			// visor's resolver on the virtual loopback (the terminal instance —
-			// this page's own core never boots), falling back to the in-page
-			// core's providers for a page that booted it. Installed BEFORE any
-			// browser window opens so the loader's page-core default never
-			// takes hold (gobrowser-loader only fills __netscrapeFetch when
-			// nothing did).
-			// The visor's OWN loopback — where its apps listen (hypervisor,
-			// resolver, proxy, status pages). In this tab that is the page's
-			// vnet port table, so `vnet:<port>` (canonical) and `<port>.vnet`
-			// name it; 127.0.0.1 / localhost keep resolving here too, as the
-			// retired JS engine had them. Returns 0 for anything else.
-			function vnetPort(u) {
-				var h = String(u.hostname || '').toLowerCase();
-				var m = /^(\d+)\.vnet$/.exec(h);
-				if (m) return parseInt(m[1], 10) || 0;
-				if (h === 'vnet' || h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '[::1]') {
-					return u.port ? (parseInt(u.port, 10) || 0) : 80;
-				}
-				return 0;
-			}
-			globalThis.__netscrapeFetch = function (url) {
-				var u;
-				try { u = new URL(url, 'http://x/'); } catch (e) { return fetch(url); }
-				var mesh = /\.(dmsg|skysocks|skynet)$/i.test(u.hostname) || /^[0-9a-f]{66}$/i.test(u.hostname);
-				var path = (u.pathname || '/') + (u.search || '');
-				function respond(r) {
-					var h = new Headers();
-					if (r && r.headers) { try { for (var k in r.headers) h.set(k, r.headers[k]); } catch (e) { /* ignore */ } }
-					return new Response((r && r.body) || new Uint8Array(0), { status: (r && r.status) || 200, headers: h });
-				}
-				// Loopback first, and it NEVER falls through: a loopback address
-				// that reached the clearnet branch would be dialed by the exit,
-				// against the exit's own localhost — wrong, and a surprise. When
-				// nothing listens on the vnet port, say so.
-				var lp = vnetPort(u);
-				if (lp) {
-					if (globalThis.vnet && globalThis.vnet.listening(lp)) {
-						return Promise.resolve(globalThis.vnet.httpFetch(lp, 'GET', path, null, {})).then(respond);
-					}
-					return Promise.resolve(new Response(
-						'<body style="font:14px sans-serif;padding:2em;color:#a33">nothing is listening on vnet port ' + lp +
-						' — this tab\'s visor has no such app running. (Loopback addresses resolve to this page\'s vnet, never to a remote exit.)</body>',
-						{ status: 502, headers: new Headers({ 'content-type': 'text/html' }) }));
-				}
-				if (mesh && viaResolver()) {
-					return Promise.resolve(globalThis.vnet.socksHttpFetch(RESOLVER_PORT, resolverHost(u.hostname) + ':80', 'GET', path, null, {})).then(respond);
-				}
-				if (mesh && sv.fetchDmsg) {
-					return Promise.resolve(sv.fetchDmsg(u.hostname, 'GET', path, null)).then(respond);
-				}
-				if (sv.fetchClearnet) {
-					return Promise.resolve(sv.fetchClearnet('', 'GET', url, null)).then(respond);
-				}
-				return fetch(url);
-			};
-			// The desk chrome comes from the library (0magnet/desk), mounted by
-			// the desk host module itself (installDesk); its façade carries the
-			// openConsole/openWindow contract this boot drives. The dashboard ☰
-			// entry reads __DESK_DASHBOARD_URL__ (set above) — the running
-			// visor's hypervisor UI over the vnet service worker.
-			var panel = globalThis.__skywireDesk;
-			// selfPK cache: poll the visor's /api/about once its HV listens;
-			// re-check occasionally in case the operator restarts the visor
-			// under a different identity.
-			var deskSelfPK = '';
-			(function pollPK() {
-				if (globalThis.vnet && globalThis.vnet.listening(hvPort)) {
-					globalThis.vnet.httpFetch(hvPort, 'GET', '/api/about', null, {}).then(function (r) {
-						try {
-							var a = JSON.parse(new TextDecoder().decode(r.body));
-							if (a && a.public_key) deskSelfPK = a.public_key;
-						} catch (e) { /* ignore */ }
-					}).catch(function () { /* ignore */ });
-				}
-				setTimeout(pollPK, deskSelfPK ? 60000 : 3000);
-			})();
-
-			// Session: remember across reloads whether a visor was RUNNING when
-			// the page went away — a visor the operator stopped stays stopped.
-			// Start the docs server. It is a plain HTTP server over the embedded
-			// prose and the live cobra tree — no visor needed, nothing to wait
-			// for — so it is launched unconditionally and the tab that shows it
-			// opens with the rest once its port answers. Failure is silent by
-			// design: no docs tab is a smaller loss than a desk that will not boot.
-			if (docsPort && globalThis.skywireExec) {
-				try {
-					skywireExec(['doc', 'serve', '--addr', '127.0.0.1:' + docsPort], {})
-						.catch(function (e) { console.warn('doc serve:', e); });
-				} catch (e) { console.warn('doc serve:', e); }
-			}
-
-			var session = loadSession();
-			if (opts.autostartVisor) {
-				addEventListener('pagehide', saveSession);
-				addEventListener('visibilitychange', function () {
-					if (document.visibilityState === 'hidden') saveSession();
+			status('restoring filesystem…');
+			return jsfs.persist.enable(opts.persistDB || 'skywire-desk', {
+				// Persist identity + config + user files; NEVER the runtime
+				// stores. A bbolt database snapshotted mid-write restores corrupt
+				// and hangs its consumer on the next boot (the hypervisor module
+				// stalling on a restored users.db) — caches rebuild, keys don't.
+				exclude: function (p) {
+					return /\.db$/.test(p) || p.indexOf('/opt/skywire/local/') === 0 || p === '/opt/skywire/local';
+				},
+			}).then(function (p) {
+				status((p.restored ? 'filesystem restored — ' : '') + 'starting the desk…');
+				// The desk host: the wasm-visor binary in-page. It installs the
+				// shell + the skywireVisor API and waits — boot() is never called,
+				// so no visor runs except the one started IN a terminal.
+				return gunzipFetch(opts.deskWasmURL || 'wasm-visor.wasm.gz');
+			}).then(function (buf) {
+				// Where the hypervisor UI lives, as an ABSOLUTE same-origin URL —
+				// the browser normalises a scheme-less address to http://, so a
+				// bare path would not survive being opened as a tab, and the
+				// DirectLoader that renders it natively matches on origin.
+				//
+				// The vnet ROOT with ?embed=1, not "/dashboard": the service worker
+				// rewrites a framed page's <base href> to the "/vnet/<port>/"
+				// prefix, so any deeper path is normalised away before the document
+				// finishes loading — a "/dashboard" URL lands back on the root and
+				// renders the desk inside the desk. At the root the hypervisor
+				// serves the dashboard instead whenever the request is framed, and
+				// embed=1 also rides in the hash so the injected launcher inside
+				// knows not to grow a taskbar of its own.
+				globalThis.__DESK_DASHBOARD_URL__ = globalThis.location.origin +
+					'/vnet/' + hvPort + '/?embed=1#/?embed=1';
+				var go = new Go();
+				return WebAssembly.instantiate(buf, go.importObject).then(function (r) {
+					go.run(r.instance).catch(function (e) { console.error('desk host:', e); });
+					return Promise.all([
+						waitFor(function () { return globalThis.skywireShell; }, 'the shell'),
+						waitFor(function () { return globalThis.__skywireDesk; }, 'the desk panel'),
+						waitFor(function () { return typeof globalThis.WinBox === 'function'; }, 'the window manager'),
+					]);
 				});
-				// Track up-transitions continuously so a save after a stop can
-				// tell "operator stopped it" from "it never came up".
-				setInterval(function () {
-					if (globalThis.vnet && globalThis.vnet.listening(3435)) { visorSawUp = true; }
-				}, 2000);
-			}
-
-			var startVisor = !!opts.autostartVisor && !(session && session.visorRunning === false);
-			var startedVisor = false;
-			if (opts.autostartVisor) {
-				// The visor terminal opens either way — running autoconfig
-				// (which ends by starting the visor in the foreground), or idle
-				// at the prompt when the operator had stopped it.
-				panel.openConsole({ title: 'visor', initCmd: startVisor ? 'skywire autoconfig' : '' });
-				startedVisor = startVisor;
-			}
-			if (opts.helpTerminal !== false) {
-				// bg: a background TAB of the terminal window — the visor's log
-				// stays front, and this tab's session (and its `skywire --help`)
-				// only starts when first clicked.
-				panel.openConsole({ title: 'skywire', initCmd: 'skywire --help', bg: !!startedVisor });
-			}
-			if (opts.hvWindow) {
-				// The hypervisor UI comes up on the virtual loopback a while
-				// after boot (its module waits on the visor tree + dmsg).
-				// Open the window once something actually listens — armed even
-				// when the session suppressed the autostart, so a visor the
-				// operator starts BY HAND still gets its UI window. Autostarted
-				// visors get a bounded wait; the manual case waits as long as
-				// the page lives.
-				(function waitHV(n) {
+			}).then(function () {
+				var sv = globalThis.skywireVisor;
+				// The desk's REAL visor is the root binary running in a terminal —
+				// a separate wasm instance the page cannot call. The desk host's
+				// own skywireVisor core is deliberately never booted here, so the
+				// nested browser reaches the mesh THROUGH the running visor's
+				// resolving proxy on the virtual loopback (dmsgweb, vnet:4445,
+				// chained to skynetweb + the proxy client): dmsg/skynet fetches go
+				// SOCKS5-over-vnet. Falls back to the in-page core for a page that
+				// booted it (nothing on the desk does today).
+				var RESOLVER_PORT = 4445;
+				function viaResolver() {
+					return !!(globalThis.vnet && globalThis.vnet.listening(RESOLVER_PORT) && globalThis.vnet.socksHttpFetch);
+				}
+				function resolverHost(pkHost) {
+					var h = String(pkHost || '');
+					// bare 66-hex PK → PK.dmsg (the resolver matches by suffix)
+					if (/^[0-9a-f]{66}$/i.test(h)) return h + '.dmsg';
+					return h;
+				}
+				// The desk's browser transport: mesh fetches go through the RUNNING
+				// visor's resolver on the virtual loopback (the terminal instance —
+				// this page's own core never boots), falling back to the in-page
+				// core's providers for a page that booted it. Installed BEFORE any
+				// browser window opens so the loader's page-core default never
+				// takes hold (gobrowser-loader only fills __netscrapeFetch when
+				// nothing did).
+				// The visor's OWN loopback — where its apps listen (hypervisor,
+				// resolver, proxy, status pages). In this tab that is the page's
+				// vnet port table, so `vnet:<port>` (canonical) and `<port>.vnet`
+				// name it; 127.0.0.1 / localhost keep resolving here too, as the
+				// retired JS engine had them. Returns 0 for anything else.
+				function vnetPort(u) {
+					var h = String(u.hostname || '').toLowerCase();
+					var m = /^(\d+)\.vnet$/.exec(h);
+					if (m) return parseInt(m[1], 10) || 0;
+					if (h === 'vnet' || h === 'localhost' || h === '127.0.0.1' || h === '::1' || h === '[::1]') {
+						return u.port ? (parseInt(u.port, 10) || 0) : 80;
+					}
+					return 0;
+				}
+				globalThis.__netscrapeFetch = function (url) {
+					var u;
+					try { u = new URL(url, 'http://x/'); } catch (e) { return fetch(url); }
+					var mesh = /\.(dmsg|skysocks|skynet)$/i.test(u.hostname) || /^[0-9a-f]{66}$/i.test(u.hostname);
+					var path = (u.pathname || '/') + (u.search || '');
+					function respond(r) {
+						var h = new Headers();
+						if (r && r.headers) { try { for (var k in r.headers) h.set(k, r.headers[k]); } catch (e) { /* ignore */ } }
+						return new Response((r && r.body) || new Uint8Array(0), { status: (r && r.status) || 200, headers: h });
+					}
+					// Loopback first, and it NEVER falls through: a loopback address
+					// that reached the clearnet branch would be dialed by the exit,
+					// against the exit's own localhost — wrong, and a surprise. When
+					// nothing listens on the vnet port, say so.
+					var lp = vnetPort(u);
+					if (lp) {
+						if (globalThis.vnet && globalThis.vnet.listening(lp)) {
+							return Promise.resolve(globalThis.vnet.httpFetch(lp, 'GET', path, null, {})).then(respond);
+						}
+						return Promise.resolve(new Response(
+							'<body style="font:14px sans-serif;padding:2em;color:#a33">nothing is listening on vnet port ' + lp +
+							' — this tab\'s visor has no such app running. (Loopback addresses resolve to this page\'s vnet, never to a remote exit.)</body>',
+							{ status: 502, headers: new Headers({ 'content-type': 'text/html' }) }));
+					}
+					if (mesh && viaResolver()) {
+						return Promise.resolve(globalThis.vnet.socksHttpFetch(RESOLVER_PORT, resolverHost(u.hostname) + ':80', 'GET', path, null, {})).then(respond);
+					}
+					if (mesh && sv.fetchDmsg) {
+						return Promise.resolve(sv.fetchDmsg(u.hostname, 'GET', path, null)).then(respond);
+					}
+					if (sv.fetchClearnet) {
+						return Promise.resolve(sv.fetchClearnet('', 'GET', url, null)).then(respond);
+					}
+					return fetch(url);
+				};
+				// The desk chrome comes from the library (0magnet/desk), mounted by
+				// the desk host module itself (installDesk); its façade carries the
+				// openConsole/openWindow contract this boot drives. The dashboard ☰
+				// entry reads __DESK_DASHBOARD_URL__ (set above) — the running
+				// visor's hypervisor UI over the vnet service worker.
+				var panel = globalThis.__skywireDesk;
+				// selfPK cache: poll the visor's /api/about once its HV listens;
+				// re-check occasionally in case the operator restarts the visor
+				// under a different identity.
+				var deskSelfPK = '';
+				(function pollPK() {
 					if (globalThis.vnet && globalThis.vnet.listening(hvPort)) {
-						// Hold the open until the service-worker question is
-						// settled either way — opening a beat earlier would
-						// route this first load through the transcoder.
-						swReady.then(function () {
+						globalThis.vnet.httpFetch(hvPort, 'GET', '/api/about', null, {}).then(function (r) {
 							try {
-								// ONE browser window, everything in TABS: the
-								// hypervisor UI first, then the deployment landing
-								// page and the proxy status page behind it. The
-								// dashboard tab renders NATIVELY — desk_js.go gives
-								// netscrape a DirectLoader that claims same-origin
-								// /vnet/ URLs, so the Angular app loads as an
-								// ordinary document instead of being transcoded
-								// into a sandbox that would strip its same-origin.
-								// Share the window if the docs got here first — doc serve
-								// binds in seconds and the hypervisor takes a while, so
-								// that is the ordinary order, and opening a second window
-								// unconditionally is how this produced two (measured).
-								var win = deskWin;
-								if (win && win.openTab) {
-									try { win.openTab('vnet:' + hvPort, '/?embed=1#/?embed=1', 'http', false); } catch (e2) {}
-								} else {
-									win = panel.openWindow(true, globalThis.__DESK_DASHBOARD_URL__);
-									deskWin = win;
-								}
-								if (win && win.openTab) {
-									try { win.openTab('home.dmsg', '/', 'http', true); } catch (e2) {}
-									try { win.openTab('status.skysocks', '/', 'http', true); } catch (e2) {}
-								}
-								// One-shot subresources (the Material icon font above
-								// all) are a load-lottery on first paint: the tab opens
-								// the moment the port listens, dozens of asset fetches
-								// land on the still-busy visor, and whichever ones time
-								// out are never retried — APIs re-poll, fonts don't, so
-								// the dashboard renders icon NAMES as text. Self-heal
-								// once: if the icon font hasn't arrived after the page
-								// has had time to settle, reload the frame — by then the
-								// visor is warm and the same fetches complete (verified
-								// live: a manual frame reload cured it every time).
-								setTimeout(function () {
-									try {
-										var fr = document.querySelector('iframe[src^="/vnet/' + hvPort + '"]');
-										if (!fr || !fr.contentWindow || !fr.contentWindow.document.fonts) return;
-										if (!fr.contentWindow.document.fonts.check('24px "Material Icons"')) {
-											fr.contentWindow.location.reload();
-										}
-									} catch (e3) { /* cross-origin or torn-down frame — leave it */ }
-								}, 25000);
-							} catch (e) { console.error('hv window:', e); }
-						});
-						return;
+								var a = JSON.parse(new TextDecoder().decode(r.body));
+								if (a && a.public_key) deskSelfPK = a.public_key;
+							} catch (e) { /* ignore */ }
+						}).catch(function () { /* ignore */ });
 					}
-					if (startVisor && n > 360) return; // ~3min — the autostarted visor never served a UI
-					setTimeout(function () { waitHV(n + 1); }, 500);
-				})(0);
-			}
-			// The docs tab, on its own schedule. `skywire doc serve` needs no
-			// visor and no dmsg — it renders the live cobra tree and the
-			// embedded prose — so it binds in seconds, usually well before any
-			// hypervisor UI. Gating it on hvPort would mean no docs tab at all
-			// wherever no visor is started, which is exactly the docs-site case
-			// this exists for. Shares the browser window when one exists and
-			// opens its own otherwise; whichever surface is ready first makes it.
-			if (docsPort) {
-				(function waitDocs(n) {
-					if (globalThis.vnet && globalThis.vnet.listening(docsPort)) {
-						swReady.then(function () {
-							try {
-								// vnet:<port> — the canonical spelling, and what the
-								// address bar shows. desk_js.go's DirectLoader claims it
-								// and hands netscrape the service-worker URL that serves
-								// it, so the tab renders natively without the plumbing
-								// leaking into the UI.
-								var docsURL = 'http://vnet:' + docsPort + '/';
-								if (deskWin && deskWin.openTab) {
-									// bg: the hypervisor window is already front when we
-									// are sharing it.
-									deskWin.openTab('vnet:' + docsPort, '/', 'http', true);
-									return;
-								}
-								deskWin = panel.openWindow(true, docsURL);
-							} catch (e) { console.warn('docs window:', e); }
-						});
-						return;
-					}
-					if (n > 120) return; // ~60s — doc serve never bound its port
-					setTimeout(function () { waitDocs(n + 1); }, 500);
-				})(0);
-			}
+					setTimeout(pollPK, deskSelfPK ? 60000 : 3000);
+				})();
 
-			return { panel: panel, startedVisor: startedVisor };
+				// Session: remember across reloads whether a visor was RUNNING when
+				// the page went away — a visor the operator stopped stays stopped.
+				// Start the docs server. It is a plain HTTP server over the embedded
+				// prose and the live cobra tree — no visor needed, nothing to wait
+				// for — so it is launched unconditionally and the tab that shows it
+				// opens with the rest once its port answers. Failure is silent by
+				// design: no docs tab is a smaller loss than a desk that will not boot.
+				if (docsPort && globalThis.skywireExec) {
+					try {
+						skywireExec(['doc', 'serve', '--addr', '127.0.0.1:' + docsPort], {})
+							.catch(function (e) { console.warn('doc serve:', e); });
+					} catch (e) { console.warn('doc serve:', e); }
+				}
+
+				var session = loadSession();
+				if (opts.autostartVisor) {
+					addEventListener('pagehide', saveSession);
+					addEventListener('visibilitychange', function () {
+						if (document.visibilityState === 'hidden') saveSession();
+					});
+					// Track up-transitions continuously so a save after a stop can
+					// tell "operator stopped it" from "it never came up".
+					setInterval(function () {
+						if (globalThis.vnet && globalThis.vnet.listening(3435)) { visorSawUp = true; }
+					}, 2000);
+				}
+
+				var startVisor = !!opts.autostartVisor && !(session && session.visorRunning === false);
+				var startedVisor = false;
+				if (opts.autostartVisor) {
+					// The visor terminal opens either way — running autoconfig
+					// (which ends by starting the visor in the foreground), or idle
+					// at the prompt when the operator had stopped it.
+					panel.openConsole({ title: 'visor', initCmd: startVisor ? 'skywire autoconfig' : '' });
+					startedVisor = startVisor;
+				}
+				if (opts.helpTerminal !== false) {
+					// bg: a background TAB of the terminal window — the visor's log
+					// stays front, and this tab's session (and its `skywire --help`)
+					// only starts when first clicked.
+					panel.openConsole({ title: 'skywire', initCmd: 'skywire --help', bg: !!startedVisor });
+				}
+				if (opts.hvWindow) {
+					// The hypervisor UI comes up on the virtual loopback a while
+					// after boot (its module waits on the visor tree + dmsg).
+					// Open the window once something actually listens — armed even
+					// when the session suppressed the autostart, so a visor the
+					// operator starts BY HAND still gets its UI window. Autostarted
+					// visors get a bounded wait; the manual case waits as long as
+					// the page lives.
+					(function waitHV(n) {
+						if (globalThis.vnet && globalThis.vnet.listening(hvPort)) {
+							// Hold the open until the service-worker question is
+							// settled either way — opening a beat earlier would
+							// route this first load through the transcoder.
+							swReady.then(function () {
+								try {
+									// ONE browser window, everything in TABS: the
+									// hypervisor UI first, then the deployment landing
+									// page and the proxy status page behind it. The
+									// dashboard tab renders NATIVELY — desk_js.go gives
+									// netscrape a DirectLoader that claims same-origin
+									// /vnet/ URLs, so the Angular app loads as an
+									// ordinary document instead of being transcoded
+									// into a sandbox that would strip its same-origin.
+									// Share the window if the docs got here first — doc serve
+									// binds in seconds and the hypervisor takes a while, so
+									// that is the ordinary order, and opening a second window
+									// unconditionally is how this produced two (measured).
+									var win = deskWin;
+									if (win && win.openTab) {
+										try { win.openTab('vnet:' + hvPort, '/?embed=1#/?embed=1', 'http', false); } catch (e2) {}
+									} else {
+										win = panel.openWindow(true, globalThis.__DESK_DASHBOARD_URL__);
+										deskWin = win;
+									}
+									if (win && win.openTab) {
+										try { win.openTab('home.dmsg', '/', 'http', true); } catch (e2) {}
+										try { win.openTab('status.skysocks', '/', 'http', true); } catch (e2) {}
+									}
+									// One-shot subresources (the Material icon font above
+									// all) are a load-lottery on first paint: the tab opens
+									// the moment the port listens, dozens of asset fetches
+									// land on the still-busy visor, and whichever ones time
+									// out are never retried — APIs re-poll, fonts don't, so
+									// the dashboard renders icon NAMES as text. Self-heal
+									// once: if the icon font hasn't arrived after the page
+									// has had time to settle, reload the frame — by then the
+									// visor is warm and the same fetches complete (verified
+									// live: a manual frame reload cured it every time).
+									setTimeout(function () {
+										try {
+											var fr = document.querySelector('iframe[src^="/vnet/' + hvPort + '"]');
+											if (!fr || !fr.contentWindow || !fr.contentWindow.document.fonts) return;
+											if (!fr.contentWindow.document.fonts.check('24px "Material Icons"')) {
+												fr.contentWindow.location.reload();
+											}
+										} catch (e3) { /* cross-origin or torn-down frame — leave it */ }
+									}, 25000);
+								} catch (e) { console.error('hv window:', e); }
+							});
+							return;
+						}
+						if (startVisor && n > 360) return; // ~3min — the autostarted visor never served a UI
+						setTimeout(function () { waitHV(n + 1); }, 500);
+					})(0);
+				}
+				// The docs tab, on its own schedule. `skywire doc serve` needs no
+				// visor and no dmsg — it renders the live cobra tree and the
+				// embedded prose — so it binds in seconds, usually well before any
+				// hypervisor UI. Gating it on hvPort would mean no docs tab at all
+				// wherever no visor is started, which is exactly the docs-site case
+				// this exists for. Shares the browser window when one exists and
+				// opens its own otherwise; whichever surface is ready first makes it.
+				if (docsPort) {
+					(function waitDocs(n) {
+						if (globalThis.vnet && globalThis.vnet.listening(docsPort)) {
+							swReady.then(function () {
+								try {
+									// vnet:<port> — the canonical spelling, and what the
+									// address bar shows. desk_js.go's DirectLoader claims it
+									// and hands netscrape the service-worker URL that serves
+									// it, so the tab renders natively without the plumbing
+									// leaking into the UI.
+									var docsURL = 'http://vnet:' + docsPort + '/';
+									if (deskWin && deskWin.openTab) {
+										// bg: the hypervisor window is already front when we
+										// are sharing it.
+										deskWin.openTab('vnet:' + docsPort, '/', 'http', true);
+										return;
+									}
+									deskWin = panel.openWindow(true, docsURL);
+								} catch (e) { console.warn('docs window:', e); }
+							});
+							return;
+						}
+						if (n > 120) return; // ~60s — doc serve never bound its port
+						setTimeout(function () { waitDocs(n + 1); }, 500);
+					})(0);
+				}
+
+				return { panel: panel, startedVisor: startedVisor };
+			});
+		}
+
+		// Which visor this desk is a shell over is decided by a CAPABILITY, not
+		// by configuration: hostBridge probes for a /ws on this origin and, if
+		// one answers, claims the visor's vnet ports for the host visor. A
+		// bridge means there is a native visor underneath; no bridge means the
+		// tab is on its own and boots the wasm path. opts.native stays as the
+		// server's own declaration of the same fact, so a native page whose
+		// socket is refused still gets its desk (over same-origin /api) rather
+		// than trying to start a wasm visor that was never served to it.
+		return hostBridge().then(function (bridge) {
+			if (bridge || opts.native) return bootHost(bridge);
+			return bootWasm();
 		});
 	};
 })();

--- a/pkg/wasmhv/browseui/embed.go
+++ b/pkg/wasmhv/browseui/embed.go
@@ -48,6 +48,23 @@ var skywireExecJS []byte
 //go:embed gobrowser-loader.js
 var goBrowserLoaderJS []byte
 
+// hvwsClientJS is the page-side client for the hypervisor's /ws endpoint
+// (pkg/visor/hypervisor_ws.go): globalThis.SkywireHVWS — a capability probe
+// plus one multiplexed socket that replays /api calls through the hypervisor's
+// own router.
+//
+//go:embed hvws-client.js
+var hvwsClientJS []byte
+
+// hvwsVNetJS is the vnet adapter over that client: globalThis.SkywireHVBridge
+// claims the visor's virtual-loopback ports and serves them from the HOST
+// visor, so a desk page served by a native hypervisor reaches it through the
+// exact vnet calls the in-tab wasm visor answers. Loaded on every desk-ish
+// origin; it installs only where a /ws actually answers.
+//
+//go:embed hvws-vnet.js
+var hvwsVNetJS []byte
+
 // deskBootJS is the shared desk boot (skywireDeskBoot(opts)) behind both
 // desk-first pages: the docs playground and the converged visor page. Served
 // as its own asset (not part of the bundle) because it runs page-level
@@ -75,6 +92,11 @@ var BrowseJS = func() []byte {
 		bottle.JSFS(),
 		seedSkywireJS,
 		bottle.VNetJS(),
+		// The host-visor bridge sits directly on vnet: it is a listener on the
+		// same port table, so it belongs beside it and ahead of anything that
+		// might dial one of those ports.
+		hvwsClientJS,
+		hvwsVNetJS,
 		bottle.ProcJS(),
 		winboxdist.ExecJS(),
 		winboxdist.LoaderJS(),

--- a/pkg/wasmhv/browseui/hvws-client.js
+++ b/pkg/wasmhv/browseui/hvws-client.js
@@ -1,0 +1,227 @@
+// pkg/wasmhv/browseui/hvws-client.js c3-vis-wasm
+// The page-side client for /ws — the hypervisor's own /api surface carried as
+// a message transport (pkg/visor/hypervisor_ws.go).
+//
+// The endpoint takes a frame naming a method, a path and a body and replays it
+// through the hypervisor's OWN chi router, so a response over this socket is
+// byte-identical to the HTTP call it stands in for. That request-in /
+// response-out shape is an exact impedance match for a virtual-loopback port,
+// which is what hvws-vnet.js builds on top of this: with the two together, a
+// desk page served by a NATIVE hypervisor reaches the HOST visor through the
+// same vnet calls the in-tab wasm visor answers, and no panel has to know
+// which kind of visor is behind them.
+//
+//	SkywireHVWS.probe()          -> Promise<boolean>   is there a /ws here?
+//	SkywireHVWS.open(opts)       -> client
+//	client.request(m, p, b, h)   -> Promise<{status, body:string, headers}>
+//	client.state                 'connecting' | 'open' | 'closed'
+//	client.onstate = fn(state)
+//	client.close()
+//
+// Only ONE socket is needed per page: the server replays up to wsMaxInFlight
+// frames concurrently, so requests are correlated by id rather than serialized
+// or spread over several connections.
+(function () {
+	'use strict';
+	if (globalThis.SkywireHVWS) return;
+
+	var PATH = '/ws';
+	// A replayed request still traverses /api, which carries a 30s
+	// middleware.Timeout server-side; giving up a little sooner keeps a
+	// timed-out call from outliving the response that is about to arrive.
+	var REQ_TIMEOUT_MS = 25000;
+	var BACKOFF_MIN_MS = 250;
+	var BACKOFF_MAX_MS = 8000;
+	// Frames written while the socket is down. Bounded: a socket that stays
+	// down must not let a polling panel grow the page's heap without limit.
+	var MAX_QUEUE = 64;
+
+	function wsURL(path) {
+		var l = globalThis.location;
+		return (l.protocol === 'https:' ? 'wss://' : 'ws://') + l.host + (path || PATH);
+	}
+
+	// probe answers "is this page served by something that has a /ws?" in ONE
+	// cheap request, without opening a socket to find out. The endpoint answers
+	// a plain GET with 426 Upgrade Required (coder/websocket's rejection of a
+	// non-upgrade request); an origin that has no such route answers 404, and a
+	// static host — the docs site — answers 404 too. That is the whole
+	// capability test behind the desk's host-vs-in-tab decision: no flag, no
+	// build tag, no configuration.
+	//
+	// 426 specifically, not "anything but 404": with EnableAuth on, an
+	// unauthenticated caller gets 401 from the same route, and a socket opened
+	// on that answer would be closed again immediately. A page whose operator
+	// is not logged in has no business claiming the visor's ports.
+	function probe(path) {
+		try {
+			return fetch(path || PATH, { method: 'GET', cache: 'no-store', credentials: 'same-origin' })
+				.then(function (r) { return r.status === 426; })
+				.catch(function () { return false; });
+		} catch (e) {
+			return Promise.resolve(false);
+		}
+	}
+
+	function Client(opts) {
+		opts = opts || {};
+		this.path = opts.path || PATH;
+		this.state = 'closed';
+		this.onstate = opts.onstate || function () {};
+		this.ws = null;
+		this.nextID = 1;
+		this.pending = new Map();
+		this.queue = [];
+		this.backoff = BACKOFF_MIN_MS;
+		this.retryTimer = null;
+		this.stopped = false;
+		this.connect();
+	}
+
+	Client.prototype.setState = function (s) {
+		if (this.state === s) return;
+		this.state = s;
+		try { this.onstate(s); } catch (e) { console.error('hvws: state listener:', e); }
+	};
+
+	Client.prototype.connect = function () {
+		if (this.stopped || this.ws) return;
+		var self = this;
+		var sock;
+		try {
+			sock = new WebSocket(wsURL(this.path));
+		} catch (e) {
+			this.retry();
+			return;
+		}
+		sock.binaryType = 'arraybuffer';
+		this.ws = sock;
+		this.setState('connecting');
+
+		sock.onopen = function () {
+			if (self.ws !== sock) return;
+			self.backoff = BACKOFF_MIN_MS;
+			self.setState('open');
+			var q = self.queue;
+			self.queue = [];
+			q.forEach(function (f) {
+				try { sock.send(f); } catch (e) { console.warn('hvws: send:', e); }
+			});
+		};
+		sock.onmessage = function (ev) { self.onFrame(ev.data); };
+		sock.onerror = function () { /* onclose always follows; nothing to add */ };
+		sock.onclose = function () {
+			if (self.ws !== sock) return;
+			self.ws = null;
+			self.setState('closed');
+			// Fail every in-flight request. A reconnected socket is a NEW
+			// server-side connection with its own handler goroutines; a reply
+			// to an id issued on the old one is never coming, so a caller left
+			// waiting would hang until its own timeout for no reason.
+			var p = self.pending;
+			self.pending = new Map();
+			p.forEach(function (e) {
+				clearTimeout(e.timer);
+				e.reject(new Error('/ws: connection closed'));
+			});
+			// Queued frames were rejected with the rest of `pending` above.
+			self.queue = [];
+			self.retry();
+		};
+	};
+
+	Client.prototype.retry = function () {
+		if (this.stopped || this.retryTimer) return;
+		var self = this;
+		// Jitter: several tabs of the same visor must not all reconnect on the
+		// same tick after the visor restarts.
+		var wait = this.backoff + Math.floor(Math.random() * (this.backoff / 2));
+		this.backoff = Math.min(this.backoff * 2, BACKOFF_MAX_MS);
+		this.retryTimer = setTimeout(function () {
+			self.retryTimer = null;
+			self.connect();
+		}, wait);
+	};
+
+	Client.prototype.onFrame = function (data) {
+		var m;
+		try {
+			m = JSON.parse(typeof data === 'string' ? data : new TextDecoder().decode(data));
+		} catch (e) {
+			return;
+		}
+		// "event" is reserved by the wire format for server push; there is no
+		// consumer yet, and an unknown type must never be mistaken for a reply.
+		if (!m || (m.type && m.type !== 'res')) return;
+		var e = this.pending.get(m.id);
+		// id 0 is the server's answer to a malformed envelope — it names no
+		// request, so there is nothing to settle.
+		if (!e) return;
+		this.pending.delete(m.id);
+		clearTimeout(e.timer);
+		e.resolve({ status: m.status || 0, body: m.body || '', headers: m.headers || {} });
+	};
+
+	// request replays one HTTP call over the socket. Bodies are strings both
+	// ways — the hypervisor API is JSON in and JSON out.
+	Client.prototype.request = function (method, path, body, headers) {
+		var self = this;
+		return new Promise(function (resolve, reject) {
+			if (self.stopped) { reject(new Error('/ws: client closed')); return; }
+			var id = self.nextID++;
+			var frame = JSON.stringify({
+				type: 'req',
+				id: id,
+				method: (method || 'GET').toUpperCase(),
+				path: path,
+				body: (body == null ? null : String(body)),
+				headers: headers || {},
+			});
+			var timer = setTimeout(function () {
+				self.pending.delete(id);
+				reject(new Error('/ws: timeout on ' + path));
+			}, REQ_TIMEOUT_MS);
+			self.pending.set(id, { resolve: resolve, reject: reject, timer: timer });
+
+			if (self.ws && self.state === 'open') {
+				try {
+					self.ws.send(frame);
+				} catch (e) {
+					self.pending.delete(id);
+					clearTimeout(timer);
+					reject(e);
+				}
+				return;
+			}
+			if (self.queue.length >= MAX_QUEUE) {
+				self.pending.delete(id);
+				clearTimeout(timer);
+				reject(new Error('/ws: not connected (queue full)'));
+				return;
+			}
+			self.queue.push(frame);
+		});
+	};
+
+	Client.prototype.close = function () {
+		this.stopped = true;
+		if (this.retryTimer) { clearTimeout(this.retryTimer); this.retryTimer = null; }
+		var sock = this.ws;
+		this.ws = null;
+		if (sock) { try { sock.close(); } catch (e) { /* already gone */ } }
+		var p = this.pending;
+		this.pending = new Map();
+		p.forEach(function (e) {
+			clearTimeout(e.timer);
+			e.reject(new Error('/ws: client closed'));
+		});
+		this.queue = [];
+		this.setState('closed');
+	};
+
+	globalThis.SkywireHVWS = {
+		probe: probe,
+		url: wsURL,
+		open: function (opts) { return new Client(opts); },
+	};
+})();

--- a/pkg/wasmhv/browseui/hvws-vnet.js
+++ b/pkg/wasmhv/browseui/hvws-vnet.js
@@ -1,0 +1,291 @@
+// pkg/wasmhv/browseui/hvws-vnet.js c3-vis-wasm
+// The vnet adapter for the HOST visor: claims the visor's virtual-loopback
+// ports and serves them from the /ws socket (hvws-client.js).
+//
+// The desk never talks to a visor directly — everything goes through vnet, the
+// page-side namespace both sides of the wasm/native split already agree on.
+// Panels call vnet.httpFetch(<port>, …); the nested browser and the vnet
+// service worker resolve /vnet/<port>/… against the same port table. So the
+// whole of "make the desk work against the host visor" reduces to: put a
+// listener on those ports whose handler is the host visor.
+//
+// That is what this does. Nothing above it changes — not one panel, not the
+// service worker, not the browser's DirectLoader — because from the page's
+// side a bridged port is indistinguishable from a wasm visor's.
+//
+// Two request classes, and they are routed differently on purpose:
+//
+//   /api/…      over /ws. The endpoint replays the frame through the
+//               hypervisor's own router, so permissions, middleware and the
+//               response body are the real thing.
+//   everything  one same-origin fetch. /ws deliberately refuses any path
+//   else        outside /api (wsAllowedPath), and it does not need to carry
+//               them: this bridge only ever installs on a page the hypervisor
+//               ITSELF served, so its assets — the Angular bundle, its fonts,
+//               index.html — are already same-origin. That is what makes
+//               /vnet/<hvPort>/ a complete, natively-resolving mirror of the
+//               dashboard rather than an API-only port.
+//
+//	SkywireHVBridge.install({ports:[3435, 8001]}) -> Promise<bridge|null>
+//
+// The claim tracks the socket: ports are bound when /ws is open and released
+// when it drops, so vnet.listening(<port>) keeps meaning what the desk reads
+// it as — "a visor is up and reachable from this page" — instead of becoming a
+// permanent lie the moment the host visor restarts.
+(function () {
+	'use strict';
+	if (globalThis.SkywireHVBridge) return;
+
+	var te = new TextEncoder();
+	var td = new TextDecoder();
+
+	// A reason phrase is decorative here (vnet's HTTP reader takes the status
+	// from the second field and ignores the rest), but a readable one shows up
+	// in a devtools network panel and in the browser's own error pages.
+	var REASON = {
+		200: 'OK', 204: 'No Content', 301: 'Moved Permanently', 302: 'Found',
+		304: 'Not Modified', 400: 'Bad Request', 401: 'Unauthorized',
+		403: 'Forbidden', 404: 'Not Found', 405: 'Method Not Allowed',
+		500: 'Internal Server Error', 502: 'Bad Gateway', 503: 'Service Unavailable',
+	};
+
+	// Headers that belong to the real HTTP hop and would be nonsense — or
+	// actively wrong — on the far side of a virtual pipe.
+	var HOP_HEADERS = /^(host|connection|content-length|transfer-encoding|upgrade|via|accept-encoding|keep-alive|proxy-.*)$/i;
+
+	// A request head larger than this is not one this bridge will ever serve;
+	// the cap stops a peer that never sends CRLFCRLF from growing the buffer.
+	var MAX_HEAD = 65536;
+
+	function joinChunks(chunks, total) {
+		var out = new Uint8Array(total);
+		var off = 0;
+		for (var i = 0; i < chunks.length; i++) {
+			out.set(chunks[i], off);
+			off += chunks[i].length;
+		}
+		return out;
+	}
+
+	function sieve(headers) {
+		var out = {};
+		for (var k in headers) {
+			if (!Object.prototype.hasOwnProperty.call(headers, k)) continue;
+			if (HOP_HEADERS.test(k)) continue;
+			out[k] = headers[k];
+		}
+		return out;
+	}
+
+	// readRequest pulls ONE HTTP/1.x request off the accepter side of a vnet
+	// conn and hands it to cb, or cb(null) when the peer is not speaking HTTP.
+	//
+	// The shape check matters beyond hygiene: 3435 is the visor's RPC port, and
+	// on a wasm desk what listens there speaks Go's net/rpc GOB stream, not
+	// HTTP. This bridge cannot carry gob — /ws is request/response, with no
+	// streaming — so a gob dialer is refused at the first bytes and fails fast
+	// with a closed pipe, instead of being answered with an HTTP response it
+	// would try to decode as a gob header.
+	function readRequest(v, id, cb) {
+		var chunks = [];
+		var total = 0;
+		var head = null;
+		var settled = false;
+
+		function done(req) {
+			if (settled) return;
+			settled = true;
+			cb(req);
+		}
+
+		function parseHead(buf) {
+			var sep = -1;
+			for (var i = 0; i + 3 < buf.length; i++) {
+				if (buf[i] === 13 && buf[i + 1] === 10 && buf[i + 2] === 13 && buf[i + 3] === 10) { sep = i; break; }
+			}
+			if (sep < 0) {
+				if (buf.length > MAX_HEAD) done(null);
+				return null;
+			}
+			var lines = td.decode(buf.subarray(0, sep)).split('\r\n');
+			var rl = /^([A-Z]{3,10}) (\S+) HTTP\/1\.[01]$/.exec(lines[0] || '');
+			if (!rl) { done(null); return null; }
+			var hs = {};
+			for (var j = 1; j < lines.length; j++) {
+				var ci = lines[j].indexOf(':');
+				if (ci > 0) hs[lines[j].slice(0, ci).trim().toLowerCase()] = lines[j].slice(ci + 1).trim();
+			}
+			var cl = /^\d+$/.test(hs['content-length'] || '') ? parseInt(hs['content-length'], 10) : 0;
+			return { method: rl[1], path: rl[2], headers: hs, bodyStart: sep + 4, contentLength: cl };
+		}
+
+		function emit(buf, upTo) {
+			done({
+				method: head.method,
+				path: head.path,
+				headers: head.headers,
+				body: buf.subarray(head.bodyStart, upTo),
+			});
+		}
+
+		function pump() {
+			if (settled) return;
+			for (;;) {
+				var b = v.recv(id, 'b');
+				if (b) {
+					chunks.push(b);
+					total += b.length;
+					var buf = joinChunks(chunks, total);
+					if (!head) head = parseHead(buf);
+					if (settled) return;
+					if (head && total - head.bodyStart >= head.contentLength) {
+						emit(buf, head.bodyStart + head.contentLength);
+						return;
+					}
+					continue;
+				}
+				if (v.eof(id, 'b')) {
+					// EOF with a complete head: httpFetch writes
+					// Content-Length, but a caller that closed early still gets
+					// whatever body did arrive rather than a dropped request.
+					if (head) { emit(joinChunks(chunks, total), total); } else { done(null); }
+					return;
+				}
+				v.onReadable(id, 'b', pump);
+				return;
+			}
+		}
+		pump();
+	}
+
+	// writeResponse serializes one HTTP/1.0 response onto the pipe and closes
+	// it. Connection: close with an explicit Content-Length is exactly what
+	// vnet's reader expects; no chunked encoding exists on this wire.
+	function writeResponse(v, id, status, headers, body) {
+		var out = 'HTTP/1.0 ' + status + ' ' + (REASON[status] || 'Status') + '\r\n';
+		var hs = headers || {};
+		for (var k in hs) {
+			if (!Object.prototype.hasOwnProperty.call(hs, k)) continue;
+			if (HOP_HEADERS.test(k)) continue;
+			// A header value carrying CR/LF would split the response into two.
+			out += k + ': ' + String(hs[k]).replace(/[\r\n]+/g, ' ') + '\r\n';
+		}
+		out += 'Content-Length: ' + body.length + '\r\nConnection: close\r\n\r\n';
+		v.send(id, 'b', te.encode(out));
+		if (body.length) v.send(id, 'b', body);
+		v.close(id, 'b');
+	}
+
+	function isAPI(path) {
+		var p = String(path).split('?')[0].split('#')[0];
+		return p === '/api' || p.indexOf('/api/') === 0;
+	}
+
+	// route answers one parsed request from the host visor.
+	function route(client, req) {
+		if (isAPI(req.path)) {
+			var body = (req.body && req.body.length) ? td.decode(req.body) : null;
+			return client.request(req.method, req.path, body, sieve(req.headers)).then(function (r) {
+				return { status: r.status, headers: r.headers, body: te.encode(r.body || '') };
+			});
+		}
+		var init = {
+			method: req.method,
+			credentials: 'same-origin',
+			cache: 'no-store',
+			headers: sieve(req.headers),
+			// Follow redirects here rather than relaying a 3xx: the Location
+			// the hypervisor writes is relative to ITS root, and the page that
+			// receives it sits under a /vnet/<port>/ prefix the server never
+			// saw, so a relayed redirect walks straight out of the prefix.
+			redirect: 'follow',
+		};
+		if (req.method !== 'GET' && req.method !== 'HEAD' && req.body && req.body.length) {
+			init.body = req.body;
+		}
+		return fetch(req.path, init).then(function (r) {
+			return r.arrayBuffer().then(function (buf) {
+				var hs = {};
+				r.headers.forEach(function (val, key) { hs[key] = val; });
+				return { status: r.status, headers: hs, body: new Uint8Array(buf) };
+			});
+		});
+	}
+
+	function serve(v, id, client) {
+		readRequest(v, id, function (req) {
+			if (!req) { v.close(id, 'b'); return; }
+			route(client, req).then(function (r) {
+				writeResponse(v, id, r.status, r.headers, r.body);
+			}).catch(function (e) {
+				writeResponse(v, id, 502, { 'content-type': 'text/plain' },
+					te.encode('vnet→/ws bridge: ' + ((e && e.message) || e)));
+			});
+		});
+	}
+
+	// install opens the socket and, once it is up, claims the given virtual
+	// ports for the host visor. Resolves the bridge, or null when there is no
+	// /ws to bridge to (the standalone desk, the docs playground) or when every
+	// requested port is already claimed by something in this page — an in-tab
+	// wasm visor keeps its own ports; the host bridge never evicts it.
+	function install(opts) {
+		opts = opts || {};
+		var v = globalThis.vnet;
+		if (!v || !globalThis.SkywireHVWS) return Promise.resolve(null);
+		var ports = opts.ports || [];
+		var claimed = [];
+
+		var client = globalThis.SkywireHVWS.open({ path: opts.path });
+
+		function claim() {
+			ports.forEach(function (port) {
+				if (claimed.indexOf(port) >= 0) return;
+				var ok = v.listen(port, function (id) { serve(v, id, client); });
+				if (ok) { claimed.push(port); }
+			});
+		}
+		function release() {
+			claimed.forEach(function (port) { v.unlisten(port); });
+			claimed = [];
+		}
+
+		client.onstate = function (s) {
+			if (s === 'open') { claim(); } else { release(); }
+		};
+
+		var bridge = {
+			client: client,
+			ports: ports,
+			claimed: function () { return claimed.slice(); },
+			// fetch is the /api call as the desk's own code would make it —
+			// handy for a caller that has a bridge in hand and does not want to
+			// go back out through the vnet pipe to reach the same socket.
+			fetch: function (m, p, b, h) { return client.request(m, p, b, h); },
+			close: function () { release(); client.close(); },
+		};
+
+		return new Promise(function (resolve) {
+			var settled = false;
+			var timer = setTimeout(function () {
+				if (settled) return;
+				settled = true;
+				// The probe said /ws was there, so keep the client (it will
+				// reconnect and claim on its own); just do not make the boot
+				// wait any longer for it.
+				resolve(claimed.length ? bridge : null);
+			}, opts.timeoutMs || 8000);
+			var prev = client.onstate;
+			client.onstate = function (s) {
+				prev(s);
+				if (s !== 'open' || settled) return;
+				settled = true;
+				clearTimeout(timer);
+				resolve(bridge);
+			};
+			if (client.state === 'open') { client.onstate('open'); }
+		});
+	}
+
+	globalThis.SkywireHVBridge = { install: install };
+})();


### PR DESCRIPTION
Gives the desk a data path to the HOST native visor, so the host hypervisor UI can have the same surfaces the wasm desk has. First and enabling piece of the wasm/native UI convergence.

## Design

The desk never talks to a visor directly — its whole contract is `vnet.httpFetch(port, ...)` plus `/vnet/<port>/...` through the vnet service worker. So this does **not** rewrite any panel. It registers a vnet listener on the visor ports whose handler forwards to the hypervisor's `/ws` (#4607), and every existing panel works unchanged, because vnet is the page-side namespace on both sides by design.

Three pieces under `pkg/wasmhv/browseui/`, added to `BrowseJS` so both desk origins get them:

- **`hvws-client.js`** — one multiplexed socket, id-correlated request/response frames, backoff reconnect with jitter, `state`/`onstate`, bounded pre-open queue. In-flight requests fail on close, since a reconnected socket is a new id space server-side.
- **`hvws-vnet.js`** — claims the ports, reads an HTTP/1.x request off the vnet pipe and splits it: `/api/...` goes over `/ws`, everything else is one same-origin `fetch`. That split is enforced (`wsAllowedPath` refuses anything outside `/api`) and is what makes `/vnet/8001/` a *complete* mirror rather than an API-only port — the bridge only installs on a page the hypervisor itself served, so it need not carry the Angular bundle over the socket. Ports are claimed on socket-open and released on close, so `vnet.listening()` stays a truthful liveness answer. A non-HTTP first line (a gob RPC dialer on 3435) is refused at the first bytes rather than answered with an HTTP response.
- **`desk-boot.js`** — split into `bootHost(bridge)` / `bootWasm()`, selected by a capability probe: one `GET /ws`, bridge iff the status is **426**. `401` is deliberately excluded — an unauthenticated page has no business claiming the visor's ports. No flag, no build variant. Most of the diff is a one-tab reindent; `git diff -w` is +82/-9.

## Evidence (Brave, CDP, against the live :8000 visor)

With **no in-tab wasm visor at all**:

```
listening3435: true   listening8001: true
wasmVisorInstances: 0   deskWasmHost: false
httpFetch(8001,'/api/about')          -> 200 in 5 ms
   hostPK 0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
   version v1.3.94-0.-a4189e08a71c+dirty, dmsg_connected true
httpFetch(8001,'/api/visors-summary') -> 200, 638458 bytes, 23 visors
httpFetch(3435,'/api/about')          -> 200
errs: []
```

The Angular dashboard renders **fully** through `/vnet/8001/?embed=1` — visor list, transports, DMSG counts, keys, reward ticks, icons. Base href rewritten to `/vnet/8001/`, all bundles served through the bridge, its relative `api/` calls riding the socket. A bridged asset is byte-identical to the direct one (`styles-*.css`, 258734 bytes, compared byte-for-byte).

Standalone desk regression check (`https://127.0.0.1:8443`): probe `false` -> `bootWasm`, desk host loaded, `skywire autoconfig` running, in-tab visor claims 3435/8001 itself. Both modes work.

## Known limitation

The dashboard window still opens the same-origin iframe rather than the vnet URL, deliberately. bottle's `vnet-sw.js` `askClient` allows **8s** per forwarded request; `/api/visors-tree-summary` on this hypervisor takes **15s** (measured 15.07 / 15.06 / 13.47s, 658 kB — that is the endpoint, not the bridge). Through the SW it 504s. Defaulting to vnet would have made a working dashboard worse, so the address is published as `__DESK_VNET_DASHBOARD_URL__` and becomes the default once that budget is raised.

Note that endpoint is independently known to be slow: an earlier audit measured `collectLocalVisorSummaries` JSON round-tripping the whole node list through an in-memory recorder — encode, decode, re-encode — at ~66 MB allocated per request for a 39 kB body, 13% of all allocations in the process. Fixing that is likely to bring it under the existing budget without a bottle change.

`go build`, `go test ./pkg/wasmhv/...`, `go test -run 'Desk|WS|Browse|UIHandler' ./pkg/visor/`, `gofmt -l`, `golangci-lint` — all clean. No vendor edits.
