### PR TITLE
fix(sn): serve /stats aggregate publicly, gate only the topology half

### DIFF
--- a/pkg/dmsg/dmsghttp/debug.go
+++ b/pkg/dmsg/dmsghttp/debug.go
@@ -58,6 +58,34 @@ func WithDebug(next http.Handler, whitelistPKs []cipher.PubKey, logSource func()
 	})
 }
 
+// RemoteIsWhitelisted reports whether the request's remote public key is in the
+// whitelist. When serving over dmsg, RemoteAddr is "<pk>:<port>".
+//
+// For a handler that serves a REDUCED response to non-whitelisted callers rather
+// than denying them — see the setup node's /stats, which is public in aggregate
+// and gated only for the per-destination detail. An empty whitelist, or a
+// RemoteAddr that will not parse, is not whitelisted: the caller then gets the
+// public view, never the privileged one.
+//
+// Deliberately not shared with WhitelistMiddleware below, which must keep
+// distinguishing an unparseable RemoteAddr (500) from a denied one (401). Here
+// both simply mean "not privileged".
+func RemoteIsWhitelisted(r *http.Request, whitelistedPKs []cipher.PubKey) bool {
+	if len(whitelistedPKs) == 0 || r == nil {
+		return false
+	}
+	remotePK, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return false
+	}
+	for _, pk := range whitelistedPKs {
+		if pk.String() == remotePK {
+			return true
+		}
+	}
+	return false
+}
+
 // WhitelistMiddleware wraps an http.Handler with public-key-based access control.
 // When serving over dmsg, RemoteAddr is in the format "<pk>:<port>".
 //

--- a/pkg/services/sn/sn.go
+++ b/pkg/services/sn/sn.go
@@ -329,10 +329,45 @@ func (s *service) startDMSGHealth(
 //
 // /health stays public; it carries no keys beyond the node's own.
 func statsHandler(collector *setupmetrics.Collector, whitelist []cipher.PubKey) http.Handler {
-	return dmsghttp.WhitelistMiddleware(whitelist, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	gated := dmsghttp.WhitelistMiddleware(whitelist, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(collector.Snapshot()) //nolint:errcheck,gosec
 	}))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if dmsghttp.RemoteIsWhitelisted(r, whitelist) {
+			gated.ServeHTTP(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(publicSnapshot(collector.Snapshot())) //nolint:errcheck,gosec
+	})
+}
+
+// publicSnapshot is the half of the route-setup snapshot that carries no
+// topology: counters, rates, latency percentiles, the failure-reason tally and
+// the hop-count histogram. It answers "is route setup working, how fast, and
+// failing for what reason" — which is the question anyone on the network has a
+// stake in, since every visor depends on this shared layer. A setup node that
+// silently fails 100% of requests for a month (as one did) is exactly what an
+// ungated health surface is for.
+//
+// What it drops is the who-talks-to-whom half: TopDestinations,
+// TopFailedDestinations and RecentFailures. The RSN participates in EVERY route
+// setup, so its view of which visors set up routes to which is unusually
+// complete — publishing it is traffic-analysis material, and a routing overlay
+// handing that out undermines the property it exists to provide. Those fields
+// stay behind the survey whitelist, along with the FailureEvent.Error strings
+// that embed the same keys in prose.
+//
+// This is the split the original stripping was reaching for. That code blanked
+// the structured PK fields on a public endpoint but left Error untouched, so
+// the topology went out anyway and only the machine-readable half was lost.
+func publicSnapshot(s setupmetrics.StatsSnapshot) setupmetrics.StatsSnapshot {
+	s.TopDestinations = nil
+	s.TopFailedDestinations = nil
+	s.RecentFailures = nil
+	return s
 }
 
 // getHTTPClient returns an *http.Client for the given service URL,

--- a/pkg/services/sn/stats_handler_test.go
+++ b/pkg/services/sn/stats_handler_test.go
@@ -40,28 +40,64 @@ func requestAs(h http.Handler, pk cipher.PubKey) *httptest.ResponseRecorder {
 	return rec
 }
 
-// TestStatsHandlerRequiresWhitelist is the access control the old code assumed
-// it had: dmsghttp.WithDebug gates only /debug/, so /stats was open to anyone
-// who could dial the setup node.
-func TestStatsHandlerRequiresWhitelist(t *testing.T) {
-	c, _, _ := collectorWithFailure(t)
+// decodeStats parses a /stats response body.
+func decodeStats(t *testing.T, rec *httptest.ResponseRecorder) setupmetrics.StatsSnapshot {
+	t.Helper()
+	var s setupmetrics.StatsSnapshot
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &s))
+	return s
+}
+
+// TestStatsHandlerPublicAggregateGatedDetail is the contract: the health half
+// is public, the topology half is not.
+//
+// Anyone on the network depends on this shared route-setup layer, so "is it
+// working, how fast, failing for what reason" must be answerable without
+// privilege — a setup node silently failing 100% of requests for a month is
+// exactly what an ungated health surface exists to catch. But the RSN
+// participates in EVERY route setup, so its record of which visors set up
+// routes to which is unusually complete, and publishing that is
+// traffic-analysis material.
+func TestStatsHandlerPublicAggregateGatedDetail(t *testing.T) {
+	c, _, dst := collectorWithFailure(t)
 	allowed, _ := cipher.GenerateKeyPair()
 	stranger, _ := cipher.GenerateKeyPair()
 
 	h := statsHandler(c, []cipher.PubKey{allowed})
 
-	require.Equal(t, http.StatusUnauthorized, requestAs(h, stranger).Code)
-	require.Equal(t, http.StatusOK, requestAs(h, allowed).Code)
+	// Public caller: 200, aggregate present, topology absent.
+	pub := requestAs(h, stranger)
+	require.Equal(t, http.StatusOK, pub.Code)
+	ps := decodeStats(t, pub)
+	require.Equal(t, uint64(1), ps.TotalRequests, "aggregate counters must be public")
+	require.NotEmpty(t, ps.FailuresByReason, "failure reasons must be public")
+	require.Empty(t, ps.RecentFailures, "per-failure detail must not be public")
+	require.Empty(t, ps.TopDestinations, "destination keys must not be public")
+	require.Empty(t, ps.TopFailedDestinations, "destination keys must not be public")
+
+	// The public body must not carry the destination key ANYWHERE — including
+	// inside a FailureEvent.Error string, which is how the previous
+	// field-blanking approach leaked it.
+	require.NotContains(t, pub.Body.String(), dst.Hex(),
+		"public body must not contain a destination public key in any form")
+
+	// Whitelisted caller: the detail is there.
+	priv := requestAs(h, allowed)
+	require.Equal(t, http.StatusOK, priv.Code)
+	require.NotEmpty(t, decodeStats(t, priv).RecentFailures)
 }
 
-// TestStatsHandlerEmptyWhitelistDeniesAll — an unconfigured whitelist must not
-// fail open (WhitelistMiddleware's contract; asserted here because /stats now
-// depends on it).
-func TestStatsHandlerEmptyWhitelistDeniesAll(t *testing.T) {
-	c, _, _ := collectorWithFailure(t)
+// TestStatsHandlerEmptyWhitelistServesPublicOnly — an unconfigured whitelist
+// must not fail OPEN into the privileged view. Nobody is whitelisted, so
+// everybody gets the public aggregate and nobody gets topology.
+func TestStatsHandlerEmptyWhitelistServesPublicOnly(t *testing.T) {
+	c, _, dst := collectorWithFailure(t)
 	caller, _ := cipher.GenerateKeyPair()
 
-	require.Equal(t, http.StatusUnauthorized, requestAs(statsHandler(c, nil), caller).Code)
+	rec := requestAs(statsHandler(c, nil), caller)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Empty(t, decodeStats(t, rec).RecentFailures)
+	require.NotContains(t, rec.Body.String(), dst.Hex())
 }
 
 // TestStatsHandlerServesStructuredPKs asserts the fields the old handler


### PR DESCRIPTION
Follow-up to #4639, which gated the whole of the setup node's `/stats` on the survey whitelist. That over-corrected: it took the public *health* data with the private *topology* data.

## The split

**Public** — no keys, pure health: `uptime_sec`, `total_requests`, `successful`, `failed`, `concurrency_drops`, `active_requests`, `success_rate_pct`, `failures_by_reason`, `latency_ms`, `route_length_hist`.

**Whitelisted only** — the who-talks-to-whom half: `top_destinations`, `top_failed_destinations`, `recent_failures` (including the `error` strings, which embed keys in prose).

## Why public at all

The RSN is shared infrastructure every visor depends on. "Is route setup working, how fast, failing for what reason" should be answerable without privilege, or diagnosis rests on trust in whoever holds the whitelist. This is not hypothetical: a production setup node was found silently failing **100% of route setups** (46 requests, 46 failures) for roughly a month. An ungated health surface is exactly what catches that.

## Why not the keys

The RSN participates in *every* route setup, so its record of which visors set up routes to which is unusually complete — far more so than any single visor's view. Publishing it is traffic-analysis material, and a routing overlay handing that out undermines the property it exists to provide.

## History

This is the split the original code was reaching for. It blanked the structured PK fields on a public endpoint (comment: *"strip src/dst PKs to avoid leaking visor topology"*) but left `FailureEvent.Error` untouched, and that string carries the same keys verbatim:

```
failed to reserve route ids: reserve routeID from
03d672c32a56a666a4931f6327ff85874af614dccf17b19cc6f665b1219c317dd7
failed: context deadline exceeded
```

So the topology went out anyway and only the machine-readable half was lost — the half a live incident actually needed. Dropping whole sections rather than blanking fields is what makes the intent hold.

## Also

Adds `dmsghttp.RemoteIsWhitelisted`, a plain predicate for handlers that serve a *reduced* response to non-whitelisted callers rather than denying them. Deliberately separate from `WhitelistMiddleware`, which must keep distinguishing an unparseable RemoteAddr (500) from a denied one (401); here both simply mean "not privileged", and an empty whitelist yields the public view rather than failing open into the privileged one.

The test asserts the public body contains the destination key **nowhere** — in any field or string — which is the check the original approach would have failed.

`go build .`, tests on both packages, `gofmt`, `golangci-lint`: clean.
