### PR TITLE
perf(noise): size the DH keypair pool for the browser

### DIFF
--- a/pkg/dmsg/noise/dh.go
+++ b/pkg/dmsg/noise/dh.go
@@ -12,8 +12,6 @@ import (
 	secp256k1 "github.com/skycoin/skycoin/src/cipher/secp256k1-go"
 )
 
-const keypairPoolSize = 512
-
 // keypairPool holds pre-generated ephemeral keypairs for noise handshakes.
 // secp256k1 key generation is expensive (EC multiply + validation), so we
 // generate them in the background and serve them from a buffered channel.
@@ -25,10 +23,14 @@ const keypairPoolSize = 512
 //
 // Multiple generator goroutines fill the pool in parallel to keep up with
 // burst demand (thundering herd after deployment restart).
+//
+// keypairPoolSize and keypairGenerators are build-tagged — see
+// dh_pool_native.go and dh_pool_js.go. "In parallel" is only true off the
+// browser: js/wasm is GOMAXPROCS=1, so extra generators there take turns with
+// the boot path rather than adding throughput.
 var keypairPool = func() chan noise.DHKey {
 	ch := make(chan noise.DHKey, keypairPoolSize)
-	numGenerators := 4
-	for i := 0; i < numGenerators; i++ {
+	for i := 0; i < keypairGenerators; i++ {
 		go func() {
 			for {
 				ch <- generateDHKey()

--- a/pkg/dmsg/noise/dh_pool_js.go
+++ b/pkg/dmsg/noise/dh_pool_js.go
@@ -1,0 +1,24 @@
+//go:build js
+
+// Package noise pkg/dmsg/noise/dh_pool_js.go c1-net-dmsg
+package noise
+
+// Pool sizing for the browser.
+//
+// The native sizing (512 keypairs, 4 generators) is wrong here in both terms.
+// secp256k1 key generation measures 444us/op under js/wasm against 144us
+// native, so filling 512 slots is ~227ms of CPU — and js/wasm is
+// GOMAXPROCS=1, so those four generator goroutines do not fill the pool in
+// parallel, they take turns with the boot path on the one thread available.
+// The pool is a package-level var, so this begins the moment the module
+// initializes, competing with everything the visor does to come up.
+//
+// A browser tab establishes one to three dmsg sessions, not hundreds. Eight
+// keypairs is ~3.6ms of work and still covers a reconnect burst; one
+// generator refills behind demand without contending for the thread. The
+// channel is unchanged, so a consumer that outruns the pool simply blocks
+// until the generator catches up, exactly as before.
+const (
+	keypairPoolSize   = 8
+	keypairGenerators = 1
+)

--- a/pkg/dmsg/noise/dh_pool_native.go
+++ b/pkg/dmsg/noise/dh_pool_native.go
@@ -1,0 +1,13 @@
+//go:build !js
+
+// Package noise pkg/dmsg/noise/dh_pool_native.go c1-net-dmsg
+package noise
+
+// Pool sizing for a native visor or deployment service. Sized for the
+// thundering herd after a deployment restart: hundreds of peers redialing at
+// once, each needing an ephemeral keypair for its noise handshake, on a host
+// with cores to spare.
+const (
+	keypairPoolSize   = 512
+	keypairGenerators = 4
+)


### PR DESCRIPTION
Found by an audit of package initialization cost, run with `GODEBUG=inittrace=1`.

A package-level var in `pkg/dmsg/noise/dh.go` starts **4 goroutines pre-generating 512 secp256k1 keypairs** for noise handshakes:

```go
var keypairPool = func() chan noise.DHKey {
    ch := make(chan noise.DHKey, 512)
    for i := 0; i < 4; i++ { go func() { for { ch <- generateDHKey() } }() }
    return ch
}()
```

That sizing is right for what it was written for — the thundering herd after a deployment restart, hundreds of peers redialing at once on a host with cores to spare.

It is wrong in both terms under js/wasm:

- `secp256k1.GenerateKeyPair()` benchmarks at **444 us/op on js/wasm** against 144 us native, so filling 512 slots is **~227 ms of CPU**.
- js/wasm is **GOMAXPROCS=1**, so the four generators do not fill the pool in parallel. They take turns with the boot path on the only thread available.
- Being a package-level var, this starts the moment the module initializes, competing with everything the visor does to come up.

A browser tab establishes one to three dmsg sessions, not hundreds. Eight keypairs is ~3.6 ms of work and still absorbs a reconnect burst; one generator refills behind demand without contending for the thread. The channel is unchanged, so a consumer that outruns the pool blocks until the generator catches up, exactly as before. **Native sizing is untouched** — the constants are build-tagged, matching the repo's existing `_js.go` / `_native.go` idiom.

### Why this would not show in an init profile

`inittrace` charges this package only **1.17 ms**, because init merely *starts* the goroutines. The 227 ms lands afterwards, during boot. So a `doInit1`-based profile does not attribute it — which is how it survived several rounds of looking at wasm boot cost.

Worth stating for context: the same audit found `runtime.doInit1` was top-frame in an earlier boot profile only because that profile is **flat**, not because init is a hotspot. Total wasm package init is 282 ms against a multi-second boot. This change is the largest single item the audit found, and it is not init.

`go build .` (native) and `GOOS=js GOARCH=wasm go build ./pkg/dmsg/noise/` both clean, `go test ./pkg/dmsg/noise/` passes, `gofmt` clean, `golangci-lint` 0 issues.
