### PR TITLE
feat(desk): run the wasm visor in a Worker, not on the page main thread

### DIFF
--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -320,6 +320,11 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	// page's virtual loopback, so the nested browser renders in-page servers
 	// (the hypervisor UI SPA) natively. Must live beside the pages (scope cap).
 	serveBytes("/vnet-sw.js", "text/javascript", wasmhv.VNetSWJS())
+	// The worker bundle every skywire COMMAND runs in. Its presence IS the
+	// capability the desk probes for: where it answers, the visor's Go runtime
+	// schedules on its own thread instead of the one that draws the page;
+	// where it 404s, desk-boot keeps the in-page skywireExec unchanged.
+	serveBytes("/skywire-worker.js", "text/javascript", wasmhv.ExecWorkerJS())
 	// deskPage is the desk shell, served AT THE ROOT below when there is one.
 	// Declared out here because the root handler is built further down and the
 	// desk is only assembled when a CLI module was given to run in it.

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -24,6 +24,12 @@
 //                   (8002). The desk starts it and opens it as a browser tab,
 //                   so the CLI reference and the prose are readable BESIDE a
 //                   terminal you can run the documented commands in. 0 = off.
+//   execWorkerURL   the worker bundle that hosts the skywire commands
+//                   ('skywire-worker.js'). Where it is served, every command —
+//                   the visor above all — runs on that thread instead of this
+//                   one; where it is not, the commands stay in-page exactly as
+//                   they were. Nothing selects between the two but whether the
+//                   asset answers.
 //   native          the page is served by a NATIVE hypervisor — see below
 //   dashboardURL    native mode: the same-origin dashboard URL for the
 //                   dashboard window ('/#/?embed=1')
@@ -211,6 +217,26 @@
 			});
 		}
 
+		// execWorker: the Worker every skywire command runs in once it is up,
+		// or null where this page cannot host one (see workerExec below).
+		var execWorker = null;
+
+		// workerExec moves the skywire CLI — and therefore the visor — off the
+		// page main thread. Resolves the installed worker, or null to keep the
+		// in-page skywireExec.
+		function workerExec() {
+			if (!globalThis.SkywireExecWorker) return Promise.resolve(null);
+			return globalThis.SkywireExecWorker.install({
+				url: opts.execWorkerURL || 'skywire-worker.js',
+				persistDB: opts.persistDB || 'skywire-desk',
+				wasmURL: skywireExec.wasmURL,
+				wasmExecURL: skywireExec.wasmExecURL,
+			}).catch(function (e) {
+				console.warn('exec worker:', e);
+				return null;
+			});
+		}
+
 		// bootWasm: the standalone desk — the tab IS the host. A wasm visor
 		// runs in a terminal, claims the virtual-loopback ports, and every
 		// panel reaches it through vnet. Unchanged by the host bridge above:
@@ -231,14 +257,35 @@
 				: Promise.resolve(false);
 
 			status('restoring filesystem…');
-			return jsfs.persist.enable(opts.persistDB || 'skywire-desk', {
-				// Persist identity + config + user files; NEVER the runtime
-				// stores. A bbolt database snapshotted mid-write restores corrupt
-				// and hangs its consumer on the next boot (the hypervisor module
-				// stalling on a restored users.db) — caches rebuild, keys don't.
-				exclude: function (p) {
-					return /\.db$/.test(p) || p.indexOf('/opt/skywire/local/') === 0 || p === '/opt/skywire/local';
-				},
+			// Where the skywire commands RUN. A Go/wasm visor never lets its
+			// runtime idle — profiled on this page 2026-09-07, 95% of
+			// one-second samples over 16.5 minutes sat above 90% of a core,
+			// with findRunnable/stealWork/nanotime1 and NOT ONE application or
+			// GC frame in the symbolized profile — so on the main thread it
+			// starves the compositor and dragging a window stutters. Given a
+			// Worker, every command's runtime spins over there instead and this
+			// thread only draws. hv-boot.js has refused an in-page visor for
+			// this exact reason since the legacy page; the desk had regressed
+			// it.
+			//
+			// A capability, not a setting: no Worker, no vnet, or no
+			// /skywire-worker.js served and install() resolves null, after
+			// which everything below is the in-page path exactly as before.
+			// The worker owns the IndexedDB snapshot when it comes up (one
+			// writer, and it is the side the visor writes from), so the page
+			// enables persistence only when there is no worker.
+			return workerExec().then(function (w) {
+				execWorker = w;
+				if (w) return { restored: w.restored };
+				return jsfs.persist.enable(opts.persistDB || 'skywire-desk', {
+					// Persist identity + config + user files; NEVER the runtime
+					// stores. A bbolt database snapshotted mid-write restores corrupt
+					// and hangs its consumer on the next boot (the hypervisor module
+					// stalling on a restored users.db) — caches rebuild, keys don't.
+					exclude: function (p) {
+						return /\.db$/.test(p) || p.indexOf('/opt/skywire/local/') === 0 || p === '/opt/skywire/local';
+					},
+				});
 			}).then(function (p) {
 				status((p.restored ? 'filesystem restored — ' : '') + 'starting the desk…');
 				// The desk host: the wasm-visor binary in-page. It installs the
@@ -509,7 +556,9 @@
 					})(0);
 				}
 
-				return { panel: panel, startedVisor: startedVisor };
+				// execWorker is null on the in-page fallback — a caller (and a
+				// CDP probe) can tell which thread the visor is on from it.
+				return { panel: panel, startedVisor: startedVisor, execWorker: execWorker };
 			});
 		}
 

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -103,8 +103,37 @@
 		} catch (e) { /* storage denied — session just resets to defaults */ }
 	}
 
+	// framedWithoutEmbed: this desk page is running INSIDE a frame and its URL
+	// carries no embed marker — which can only mean a server served the desk
+	// where it meant to serve the dashboard.
+	//
+	// Both servers decide by `Sec-Fetch-Dest: iframe` OR `?embed=1`, and through
+	// bottle's vnet service worker only the second survives: Sec-Fetch-* are
+	// forbidden header names, unreadable from a service worker, so vnet-sw.js
+	// cannot forward them however much it would like to. Any in-frame
+	// navigation that drops the query — the Angular router rewrites the frame's
+	// URL to its current route within seconds of loading — therefore comes back
+	// as a DESK, and a desk inside the desk's own dashboard window is never what
+	// anyone wanted. The servers say so themselves, in the comment above each
+	// `framed` test.
+	//
+	// So the page corrects its own address and lets the server answer again.
+	// Bounded by construction: the retry carries embed=1, so the second load
+	// cannot reach here.
+	function framedWithoutEmbed() {
+		try {
+			if (self === top) return false;
+			if (/(^|[?&])embed=1(&|$)/.test(location.search)) return false;
+			return true;
+		} catch (e) { return false; } // cross-origin top — not our frame to judge
+	}
+
 	globalThis.skywireDeskBoot = function (opts) {
 		opts = opts || {};
+		if (framedWithoutEmbed()) {
+			location.replace(location.pathname + '?embed=1' + (location.hash || ''));
+			return new Promise(function () {}); // never settles; the document is going away
+		}
 		var status = opts.onStatus || function () {};
 		var hvPort = opts.hvPort || 8001;
 		// 0 disables. Native mode leaves it off: a native hypervisor serves its
@@ -510,7 +539,21 @@
 											var fr = document.querySelector('iframe[src^="/vnet/' + hvPort + '"]');
 											if (!fr || !fr.contentWindow || !fr.contentWindow.document.fonts) return;
 											if (!fr.contentWindow.document.fonts.check('24px "Material Icons"')) {
-												fr.contentWindow.location.reload();
+												// NOT reload(): by now the Angular router has
+												// rewritten the frame's URL to its current route
+												// (".../vnet/8001/#/nodes/list/1") and the
+												// ?embed=1 that opened it is GONE. Reloading that
+												// URL asks the hypervisor for its ROOT with no
+												// embed marker, and the marker is the only one it
+												// can see — bottle's vnet service worker cannot
+												// forward Sec-Fetch-Dest (a forbidden header name,
+												// unreadable from a SW), so the server's "am I
+												// framed?" test has nothing else to go on and it
+												// serves its DESK page. That is the "desk inside
+												// the desk" this window exists to avoid, and it is
+												// what the self-heal itself was producing.
+												var w2 = fr.contentWindow;
+												w2.location.replace(w2.location.pathname + '?embed=1' + (w2.location.hash || ''));
 											}
 										} catch (e3) { /* cross-origin or torn-down frame — leave it */ }
 									}, 25000);

--- a/pkg/wasmhv/browseui/embed.go
+++ b/pkg/wasmhv/browseui/embed.go
@@ -39,6 +39,22 @@ var seedSkywireJS []byte
 //go:embed skywire-exec.js
 var skywireExecJS []byte
 
+// execRemoteJS provides globalThis.SkywireExecWorker: the page half of running
+// skywire commands in a dedicated Worker instead of on the page main thread. It
+// replaces globalThis.skywireExec with a same-contract shim and bridges the
+// worker's vnet claims onto the page's port table, so a visor over there is
+// indistinguishable from one in here to every panel, the service worker and
+// desk-boot's vnet.listening() gates.
+//
+//go:embed exec-remote.js
+var execRemoteJS []byte
+
+// execWorkerJS is the worker half — the tail of ExecWorkerJS() below, not part
+// of the page bundle.
+//
+//go:embed exec-worker.js
+var execWorkerJS []byte
+
 // goBrowserLoaderJS defines globalThis.SkywireGoBrowser.open() — the launcher
 // for the netscrape Go/wasm browser (github.com/0magnet/netscrape). The browser
 // is NOT a separate module any more: it is compiled into the wasm-visor binary
@@ -102,8 +118,18 @@ var BrowseJS = func() []byte {
 		winboxdist.LoaderJS(),
 		desk.PanelNoWasmJS(),
 		skywireExecJS,
+		// Directly after it: the shim that can REPLACE it with a worker-hosted
+		// one. Nothing else in the bundle cares which of the two is installed.
+		execRemoteJS,
 		goBrowserLoaderJS,
 	}
+	return concat(parts)
+}()
+
+// concat joins bundle parts with a statement separator between them — an IIFE
+// that ends without a semicolon must not run into the next part's opening
+// paren.
+func concat(parts [][]byte) []byte {
 	n := 0
 	for _, p := range parts {
 		n += len(p) + 3
@@ -116,6 +142,29 @@ var BrowseJS = func() []byte {
 		out = append(out, p...)
 	}
 	return out
+}
+
+// ExecWorkerJS is the worker bundle — served BESIDE each desk page as
+// skywire-worker.js, and started by exec-remote.js with `new Worker()`.
+//
+// It is a whole bottle of its own: jsfs (with the same skywire seeding the page
+// gets), vnet, proc and skywire-exec, plus the glue that speaks the page's
+// protocol. That duplication is the point — a Worker has its own global scope,
+// so the visor's filesystem, port table and process table have to exist over
+// there, and sharing the page's would take SharedArrayBuffer (bottle's
+// fsbridge.js) and therefore cross-origin isolation the desk does not have.
+//
+// No window-manager, browser or desk parts: this thread runs Go COMMANDS and
+// nothing that draws.
+var ExecWorkerJS = func() []byte {
+	return concat([][]byte{
+		bottle.JSFS(),
+		seedSkywireJS,
+		bottle.VNetJS(),
+		bottle.ProcJS(),
+		skywireExecJS,
+		execWorkerJS,
+	})
 }()
 
 // VNetSWJS is bottle's vnet service worker — served BESIDE each desk page as

--- a/pkg/wasmhv/browseui/exec-remote.js
+++ b/pkg/wasmhv/browseui/exec-remote.js
@@ -1,0 +1,360 @@
+// pkg/wasmhv/browseui/exec-remote.js c3-vis-wasm
+// The page half of "skywire commands run OFF the main thread".
+//
+// WHY. The desk runs its visor as a skywireExec process — the root binary's
+// Go/wasm module, `skywire autoconfig`, in a terminal. Until now that ran on
+// the PAGE MAIN THREAD, and a Go runtime with a live visor in it never idles:
+// profiled 2026-09-07 over 16.5 minutes, 95% of one-second samples were above
+// 90% CPU, and the symbolized profile contained no application frame and no GC
+// frame at all — only runtime.findRunnable / runtime.stealWork /
+// runtime.nanotime1, the scheduler looking for work, finding none, and reading
+// the clock through a JS crossing. Nothing in skywire can be optimized to fix
+// that: the cost is the runtime's, and the only cure is to put it on a thread
+// that is not drawing the UI. hv-boot.js has refused to boot a visor in-page
+// for exactly this reason since the legacy page existed; the desk regressed the
+// property and this restores it.
+//
+// WHAT. install() starts ONE dedicated Worker (exec-worker.js, bundled with
+// jsfs + vnet + proc + skywire-exec) and REPLACES globalThis.skywireExec with a
+// same-contract shim that runs each command over there. Nothing above it
+// changes: cmd/wasm-visor's `skywire` applet still calls
+// skywireExec(args, hooks) and still gets hooks.instance({interrupt})
+// synchronously and a Promise<exitCode> back.
+//
+// NO SharedArrayBuffer, no COOP/COEP. bottle's own proc.spawnWorker needs
+// cross-origin isolation because its child shares the page's jsfs through
+// Atomics.wait; a visor does not need the page's filesystem, so the worker
+// carries its own jsfs and owns the IndexedDB snapshot outright. This is plain
+// postMessage.
+//
+// THE PART THAT IS NOT OBVIOUS: vnet does not cross a worker boundary. The
+// desk is vnet-shaped end to end — panels call vnet.httpFetch(port, …), the
+// service worker resolves /vnet/<port>/…, desk-boot gates on
+// vnet.listening(3435) — and a visor inside a worker binds those ports in the
+// WORKER's port table, which the page cannot see. A visor that looked healthy
+// while nothing in the page could reach it is the exact silent failure to
+// avoid. So the worker ADVERTISES every claim it makes, the page claims the
+// same port locally, and each inbound conn is forwarded byte-for-byte over
+// postMessage to a dial on the far side. Bytes, not HTTP: 3435 speaks Go's
+// net/rpc gob stream and 4445 speaks SOCKS5, and neither survives an
+// HTTP-shaped bridge (which is why hvws-vnet.js, whose backend really is
+// request/response, refuses a non-HTTP dialer instead of bridging it).
+//
+//	SkywireExecWorker.install({url, persistDB, wasmURL, wasmExecURL})
+//	  -> Promise<{restored, ports(), close()} | null>
+//
+// null means "this page cannot host one" (no Worker constructor, no vnet, the
+// script 404s, the worker never reported ready) — every caller then keeps the
+// in-page skywireExec it already had, unchanged.
+(function () {
+	'use strict';
+	if (globalThis.SkywireExecWorker) return;
+
+	// The stderr ring size skywire-exec.js asks proc for, mirrored here because
+	// with the process off-thread there is no proc record on this side and
+	// ctl-bridge.js + desk-boot.js both read one.
+	var TAIL_BYTES = 16384;
+	var ROUTERISH = /(router|route_setup|RouteGroup|routegroup|setupclient|rule|cascade|rsn)/i;
+
+	// READY_MS: how long a worker gets to compile nothing at all and answer.
+	// It only has to load its own bundle and open IndexedDB — the wasm module
+	// is not touched until the first spawn — so this is generous.
+	var READY_MS = 20000;
+
+	function abs(u) {
+		try { return new URL(u, globalThis.location.href).href; } catch (e) { return u; }
+	}
+
+	function install(opts) {
+		opts = opts || {};
+		var v = globalThis.vnet;
+		// Capability probe, not a flag: a realm with no Worker constructor, or
+		// no vnet to forward the visor's ports into, cannot host one.
+		if (typeof Worker !== 'function' || !v || !globalThis.skywireExec) {
+			return Promise.resolve(null);
+		}
+		var url = opts.url || 'skywire-worker.js';
+
+		// HEAD first. `new Worker()` on a 404 fails asynchronously through an
+		// error event, which would leave the boot waiting out READY_MS for a
+		// worker that was never served (the docs playground before its assets
+		// are staged, any deployment that ships an older bundle).
+		return fetch(url, { method: 'HEAD' }).then(function (r) {
+			if (!r.ok) return null;
+			return start(url, opts, v);
+		}).catch(function () { return null; });
+	}
+
+	function start(url, opts, v) {
+		var w;
+		try { w = new Worker(url); } catch (e) { return Promise.resolve(null); }
+
+		// ---- exec bookkeeping ------------------------------------------
+		// live: exec id -> { out, err, resolve, reject, rec }
+		var live = {};
+		var seq = 0;
+		// tails is published as globalThis.__skywireExecTails, the same
+		// registry name (and record shape) skywire-exec.js aliases proc.tails
+		// to: { argv, tail, filtered, exitInfo:{code,crashed} }. desk-boot.js
+		// reads it to tell a CRASHED visor from one the operator stopped, and
+		// ctl-bridge.js mirrors the ring to /ctl/log. The records are built
+		// here from the stderr stream we already receive, because proc's own
+		// ring now lives in the worker where neither consumer can see it.
+		var tails = {};
+
+		// ---- vnet bridging ---------------------------------------------
+		// claimed: ports this bridge holds on the PAGE's port table.
+		var claimed = {};
+		// conns: bridge conn id -> { id: page-side vnet conn id, port }.
+		var conns = {};
+		var connSeq = 0;
+		var dec = new TextDecoder();
+
+		function post(m, transfer) {
+			try { w.postMessage(m, transfer || []); } catch (e) { /* worker gone */ }
+		}
+
+		// sendable decides whether a chunk's buffer can be handed over rather
+		// than copied. Only when the view owns the whole buffer — a subarray
+		// would take its siblings with it.
+		function sendable(b) {
+			return (b && b.buffer && b.byteOffset === 0 && b.byteLength === b.buffer.byteLength)
+				? [b.buffer] : [];
+		}
+
+		// pumpPage drains the page side of a bridged conn toward the worker.
+		// Side 'b': the page is the ACCEPTER here (the visor's listener lives
+		// in the worker, so on this side the page only ever accepts).
+		function pumpPage(cid) {
+			var c = conns[cid];
+			if (!c) return;
+			for (;;) {
+				var b = v.recv(c.id, 'b');
+				if (b) {
+					// recv shifts the queue's own copy out — nothing else holds
+					// it, so its buffer travels instead of being copied again.
+					post({ t: 'vdata', cid: cid, b: b }, sendable(b));
+					continue;
+				}
+				// EOF here means the page-side DIALER closed, so nothing is
+				// reading this pipe any more: shut our end too. vnet drops a
+				// conn only once both sides are closed, and a half-closed one
+				// left behind is a permanent entry in the page's conn map —
+				// one per request through /vnet/<port>/, which the dashboard
+				// makes continuously.
+				if (v.eof(c.id, 'b')) { post({ t: 'vclose', cid: cid }); dropConn(cid, true); return; }
+				v.onReadable(c.id, 'b', function () { pumpPage(cid); });
+				return;
+			}
+		}
+
+		function dropConn(cid, closeLocal) {
+			var c = conns[cid];
+			if (!c) return;
+			delete conns[cid];
+			if (closeLocal) { try { v.close(c.id, 'b'); } catch (e) { /* already gone */ } }
+		}
+
+		function onAccept(port, id) {
+			var cid = ++connSeq;
+			conns[cid] = { id: id, port: port };
+			post({ t: 'vopen', cid: cid, port: port });
+			pumpPage(cid);
+		}
+
+		function claim(port) {
+			if (claimed[port]) return;
+			// Never evict: a host bridge (hvws-vnet.js) or an in-page server
+			// that already holds the port keeps it, and the worker's listener
+			// is simply unreachable from this page — which is visible rather
+			// than silent, because vnet.listening() still answers for whoever
+			// does hold it.
+			var ok = v.listen(port, function (id) { onAccept(port, id); }, 'skywire-exec-worker');
+			if (!ok) {
+				console.warn('[exec-worker] vnet port ' + port + ' is already claimed in this page — the worker\'s listener is not reachable');
+				return;
+			}
+			claimed[port] = true;
+		}
+
+		function release(port) {
+			if (!claimed[port]) return;
+			delete claimed[port];
+			try { v.unlisten(port); } catch (e) { /* ignore */ }
+			// Close the conns that were riding that port — and only those. The
+			// far side is gone; their peers must read EOF rather than block on
+			// a listener that will never answer again. Conns on the ports the
+			// worker still holds are untouched.
+			Object.keys(conns).forEach(function (cid) {
+				if (conns[cid] && conns[cid].port === port) dropConn(cid, true);
+			});
+		}
+
+		function releaseAll() {
+			Object.keys(claimed).forEach(function (p) { release(parseInt(p, 10)); });
+		}
+
+		// ---- the stderr ring, rebuilt page-side ------------------------
+		function tailPush(rec, s) {
+			rec.tail = (rec.tail + s).slice(-TAIL_BYTES);
+			rec._line = (rec._line + s).slice(-TAIL_BYTES);
+			var nl;
+			while ((nl = rec._line.indexOf('\n')) >= 0) {
+				var line = rec._line.slice(0, nl);
+				rec._line = rec._line.slice(nl + 1);
+				if (ROUTERISH.test(line)) rec.filtered = (rec.filtered + line + '\n').slice(-TAIL_BYTES);
+			}
+		}
+
+		function finish(id, code, err) {
+			var e = live[id];
+			if (!e) return;
+			delete live[id];
+			if (e.rec && !e.rec.exitInfo) e.rec.exitInfo = { code: err ? (code || 1) : code, crashed: !!err };
+			if (err) {
+				console.error('[exec-worker ' + id + '] ' + err +
+					(e.rec && e.rec.tail ? '\n--- last stderr ---\n' + e.rec.tail : ''));
+				e.reject(new Error(err));
+				return;
+			}
+			if (code !== 0) {
+				console.error('[exec-worker ' + id + '] exited code ' + code +
+					(e.rec && e.rec.tail ? '\n--- last stderr ---\n' + e.rec.tail : ''));
+			}
+			e.resolve(code);
+		}
+
+		// ---- the replacement skywireExec -------------------------------
+		function remoteExec(args, hooks) {
+			hooks = hooks || {};
+			var id = 'w' + (++seq);
+			var argv = ['skywire'].concat(args);
+			var rec = { argv: argv.slice(), tail: '', filtered: '', exitInfo: null, _line: '' };
+			tails[id] = rec;
+			var p = new Promise(function (res, rej) {
+				live[id] = { out: hooks.stdout || null, err: hooks.stderr || null, resolve: res, reject: rej, rec: rec };
+			});
+			// The interrupt is handed over SYNCHRONOUSLY, before the command
+			// starts — the contract cmd/wasm-visor/skywirecmd_js.go relies on
+			// for Ctrl+C. Here it posts a kill the worker turns into the same
+			// registered interrupt the in-page path would have invoked.
+			if (typeof hooks.instance === 'function') {
+				hooks.instance({ interrupt: function () { post({ t: 'kill', id: id }); return true; } });
+			}
+			post({ t: 'spawn', id: id, args: args.slice(), env: hooks.env || null });
+			return p;
+		}
+		remoteExec.wasmURL = globalThis.skywireExec.wasmURL;
+		remoteExec.wasmExecURL = globalThis.skywireExec.wasmExecURL;
+		// The module lives on the worker's side now, but the question callers
+		// ask ("is there a skywire command on this page at all?") is still
+		// answered by whether the module is served.
+		remoteExec.available = function () {
+			return fetch(remoteExec.wasmURL, { method: 'HEAD' })
+				.then(function (r) { return r.ok; }).catch(function () { return false; });
+		};
+		remoteExec.inWorker = true;
+
+		// ---- message pump ----------------------------------------------
+		var readyRes = null;
+		var settled = false;
+
+		w.onmessage = function (ev) {
+			var m = ev.data || {};
+			switch (m.t) {
+			case 'ready':
+				if (settled) return;
+				settled = true;
+				readyRes({ restored: !!m.restored });
+				return;
+			case 'out': {
+				var eo = live[m.id];
+				if (eo && eo.out) { try { eo.out(m.b); } catch (e) { /* sink gone */ } }
+				return;
+			}
+			case 'err': {
+				var ee = live[m.id];
+				if (ee) {
+					if (ee.rec) { try { tailPush(ee.rec, dec.decode(m.b, { stream: true })); } catch (e) { /* ignore */ } }
+					if (ee.err) { try { ee.err(m.b); } catch (e) { /* sink gone */ } }
+				}
+				return;
+			}
+			case 'exit': finish(m.id, m.code, null); return;
+			case 'fail': finish(m.id, 1, m.msg || 'exec failed'); return;
+			case 'vlisten': claim(m.port); return;
+			case 'vunlisten': release(m.port); return;
+			case 'vdata': {
+				var cv = conns[m.cid];
+				if (!cv) return;
+				// send() false means the page-side peer hung up; tell the
+				// worker so its dialer sees a closed pipe instead of writing
+				// into a conn nobody reads.
+				if (!v.send(cv.id, 'b', m.b)) { post({ t: 'vclose', cid: m.cid }); dropConn(m.cid, true); }
+				return;
+			}
+			case 'vclose': dropConn(m.cid, true); return;
+			case 'log':
+				// Worker console output, mirrored so a desk page's own log
+				// window and a CDP probe see the visor's JS-side errors.
+				try { (console[m.level] || console.log).call(console, '[worker]', m.line); } catch (e) { /* ignore */ }
+				return;
+			default: return;
+			}
+		};
+
+		w.onerror = function (e) {
+			var msg = (e && e.message) || 'worker error';
+			console.error('[exec-worker]', msg);
+			if (!settled) { settled = true; readyRes(null); return; }
+			// After ready, a worker-level error is fatal to everything running
+			// in it: fail the live commands rather than leaving their promises
+			// pending forever, and drop the port claims so vnet.listening()
+			// stops asserting a visor that is gone.
+			Object.keys(live).forEach(function (id) { finish(id, 1, msg); });
+			releaseAll();
+		};
+
+		var ready = new Promise(function (res) { readyRes = res; });
+		post({
+			t: 'init',
+			persistDB: opts.persistDB || '',
+			wasmURL: abs(opts.wasmURL || globalThis.skywireExec.wasmURL),
+			wasmExecURL: abs(opts.wasmExecURL || globalThis.skywireExec.wasmExecURL),
+		});
+		setTimeout(function () {
+			if (settled) return;
+			settled = true;
+			readyRes(null);
+		}, READY_MS);
+
+		return ready.then(function (r) {
+			if (!r) {
+				console.warn('[exec-worker] worker did not come up — commands stay on the page main thread');
+				try { w.terminate(); } catch (e) { /* ignore */ }
+				return null;
+			}
+			remoteExec.wasmURL = abs(opts.wasmURL || globalThis.skywireExec.wasmURL);
+			remoteExec.wasmExecURL = abs(opts.wasmExecURL || globalThis.skywireExec.wasmExecURL);
+			globalThis.skywireExec = remoteExec;
+			// The registries under the names skywire's page code already uses.
+			// __skywireSignals is deliberately NOT re-aliased: the interrupt
+			// registry that matters is the worker's (that is where
+			// pkg/cmdutil/signal_js.go registers), and kill() reaches it
+			// through the shim's interrupt above.
+			globalThis.__skywireExecTails = tails;
+			// A page going away should not leave a worker holding a dmsg
+			// session and a registered identity for the browser to reap
+			// whenever it feels like it.
+			addEventListener('pagehide', function () { try { w.terminate(); } catch (e) { /* ignore */ } });
+			return {
+				restored: r.restored,
+				worker: w,
+				ports: function () { return Object.keys(claimed).map(Number); },
+				close: function () { releaseAll(); try { w.terminate(); } catch (e) { /* ignore */ } },
+			};
+		});
+	}
+
+	globalThis.SkywireExecWorker = { install: install };
+})();

--- a/pkg/wasmhv/browseui/exec-worker.js
+++ b/pkg/wasmhv/browseui/exec-worker.js
@@ -1,0 +1,245 @@
+// pkg/wasmhv/browseui/exec-worker.js c3-vis-wasm
+// The worker half of "skywire commands run OFF the main thread". Tail of the
+// worker bundle (jsfs + the skywire seeding + vnet + proc + skywire-exec are
+// concatenated ahead of it by browseui/embed.go, so this thread owns a whole
+// bottle of its own), and the far end of exec-remote.js's protocol.
+//
+// A worker is the right home for a wasm visor and a poor home for a shell, so
+// the split is: the page keeps the UI — the desk, the terminals, the nested
+// browser, all of cmd/wasm-visor — and this thread keeps every Go runtime that
+// is a skywire COMMAND. The page's own jsfs stays where it is, seeded and
+// in-memory; this worker's jsfs is the one the visor writes and the one that
+// holds the IndexedDB snapshot, so the identity in /opt/skywire survives a
+// reload exactly as before, just from over here.
+//
+// The filesystems are therefore SEPARATE, and that is a real consequence, not
+// an oversight: `cat /opt/skywire/skywire.json` typed at the desk's shell reads
+// the page's tree, which the visor no longer writes to. Sharing one jsfs across
+// the boundary is what bottle's fsbridge.js does, and it needs SharedArrayBuffer
+// (Atomics.wait, forbidden on the main thread and required by a Go runtime's
+// synchronous syscalls) — which needs cross-origin isolation, which the desk
+// does not have and will not take on for this. Every skywire command runs HERE,
+// so the tree the binary reads and the tree it writes are always the same one;
+// only the shell's own builtins see a different one.
+//
+// Protocol (page ⇄ worker), page first:
+//   → {t:'init', persistDB, wasmURL, wasmExecURL}   restore the FS, bind the module
+//   ← {t:'ready', restored}
+//   → {t:'spawn', id, args, env}                    run `skywire <args...>`
+//   ← {t:'out'|'err', id, b}                        stdout/stderr chunks
+//   ← {t:'exit', id, code} | {t:'fail', id, msg}
+//   → {t:'kill', id}                                the instance's own interrupt
+//   ← {t:'vlisten'|'vunlisten', port}               this thread's vnet claims
+//   → {t:'vopen', cid, port} ⇄ {t:'vdata', cid, b} ⇄ {t:'vclose', cid}
+//   ← {t:'log', level, line}                        console output
+(function () {
+	'use strict';
+	// Page-side load of the bundle is a no-op: everything below is worker-only.
+	if (typeof importScripts !== 'function' || typeof self === 'undefined' || typeof self.postMessage !== 'function') return;
+	if (!globalThis.jsfs || !globalThis.proc || !globalThis.vnet || !globalThis.skywireExec) return;
+
+	var v = globalThis.vnet;
+
+	function post(m, transfer) {
+		try { self.postMessage(m, transfer || []); } catch (e) { /* page gone */ }
+	}
+
+	// sendable hands a chunk's buffer over instead of copying it — only when
+	// the view owns the whole buffer, or its siblings would travel with it.
+	function sendable(b) {
+		return (b && b.buffer && b.byteOffset === 0 && b.byteLength === b.buffer.byteLength)
+			? [b.buffer] : [];
+	}
+
+	// ---- console forwarding ------------------------------------------------
+	// The visor's JS-side errors (a failed WebSocket dial, a rejected fetch)
+	// would otherwise land only in a worker inspector nobody has open. Mirror
+	// them to the page so the desk's log window and a CDP probe see them, and
+	// still call the real console for worker devtools.
+	var real = { log: console.log, warn: console.warn, error: console.error };
+	function forward(level, args) {
+		try {
+			var line = Array.prototype.map.call(args, function (a) {
+				if (typeof a === 'string') return a;
+				try { return JSON.stringify(a); } catch (e) { return String(a); }
+			}).join(' ');
+			post({ t: 'log', level: level, line: line });
+		} catch (e) { /* never let logging break the program */ }
+	}
+	console.log = function () { forward('log', arguments); real.log.apply(console, arguments); };
+	console.warn = function () { forward('warn', arguments); real.warn.apply(console, arguments); };
+	console.error = function () { forward('error', arguments); real.error.apply(console, arguments); };
+
+	// ---- vnet claim advertisement -----------------------------------------
+	// A listener bound in this thread is invisible to the page, and the page is
+	// where every desk consumer asks (vnet.httpFetch, the vnet service worker,
+	// desk-boot's vnet.listening(3435) gate). So every claim made here is
+	// announced, and exec-remote.js mirrors it onto the page's port table with
+	// a forwarding handler.
+	//
+	// Wrapping the three mutators is exact rather than approximate: vnet.js
+	// deletes from its port map in unlisten() and releaseOwner() and nowhere
+	// else, so no poll is needed to notice a claim going away. releaseOwner is
+	// the one that matters in practice — a wasm instance that exits cannot
+	// unlisten itself, and proc calls it on every reap.
+	var advertised = {};
+	var rawListen = v.listen.bind(v);
+	var rawUnlisten = v.unlisten.bind(v);
+	var rawRelease = v.releaseOwner ? v.releaseOwner.bind(v) : null;
+
+	v.listen = function (port, onconn, owner) {
+		var ok = rawListen(port, onconn, owner);
+		if (ok && !advertised[port]) { advertised[port] = true; post({ t: 'vlisten', port: port }); }
+		return ok;
+	};
+	v.unlisten = function (port) {
+		rawUnlisten(port);
+		if (advertised[port]) { delete advertised[port]; post({ t: 'vunlisten', port: port }); }
+	};
+	if (rawRelease) {
+		v.releaseOwner = function (owner) {
+			var n = rawRelease(owner);
+			// vnet has no port enumeration, so reconcile what we announced
+			// against what is still bound.
+			Object.keys(advertised).forEach(function (p) {
+				var port = parseInt(p, 10);
+				if (!v.listening(port)) { delete advertised[p]; post({ t: 'vunlisten', port: port }); }
+			});
+			return n;
+		};
+	}
+
+	// ---- bridged conns -----------------------------------------------------
+	// conns: bridge conn id -> this thread's vnet conn id. The worker is always
+	// the DIALER (side 'a'): the page accepts, we dial the local listener.
+	var conns = {};
+
+	function pumpWorker(cid) {
+		var id = conns[cid];
+		if (id === undefined) return;
+		for (;;) {
+			var b = v.recv(id, 'a');
+			if (b) { post({ t: 'vdata', cid: cid, b: b }, sendable(b)); continue; }
+			// EOF: the listener closed its end, so close ours as well — vnet
+			// drops a conn only when both sides are closed, and a half-closed
+			// one is a map entry that never goes away.
+			if (v.eof(id, 'a')) {
+				post({ t: 'vclose', cid: cid });
+				delete conns[cid];
+				try { v.close(id, 'a'); } catch (e) { /* already gone */ }
+				return;
+			}
+			v.onReadable(id, 'a', function () { pumpWorker(cid); });
+			return;
+		}
+	}
+
+	function openConn(cid, port) {
+		var id = v.dial(port, 'exec-worker-bridge');
+		if (id < 0) {
+			// Refused: the claim was released between the page's accept and
+			// this dial. Closing is the whole answer — the page's peer reads
+			// EOF, which is what a connection to a dead listener should look
+			// like.
+			post({ t: 'vclose', cid: cid });
+			return;
+		}
+		conns[cid] = id;
+		pumpWorker(cid);
+	}
+
+	// ---- exec --------------------------------------------------------------
+	// instances: exec id -> { interrupt }, the handle skywireExec hands over
+	// synchronously so a page-side Ctrl+C reaches the running command's own
+	// registered interrupt (pkg/cmdutil/signal_js.go) — a foreground visor
+	// shuts down exactly as it would on SIGINT.
+	var instances = {};
+	// pendingKill: a Ctrl+C that beat its command's registration. The page hands
+	// the interrupt to its caller SYNCHRONOUSLY (the contract
+	// skywirecmd_js.go relies on), so a kill can be posted before the spawn it
+	// belongs to has been processed over here — and dropping it would leave a
+	// visor running that the operator has already stopped.
+	var pendingKill = {};
+
+	function interrupt(id) {
+		var inst = instances[id];
+		if (!inst || typeof inst.interrupt !== 'function') return false;
+		try { inst.interrupt(); } catch (e) { /* already gone */ }
+		return true;
+	}
+
+	function spawn(m) {
+		var id = m.id;
+		var hooks = {
+			stdout: function (b) { post({ t: 'out', id: id, b: b }, sendable(b)); },
+			stderr: function (b) { post({ t: 'err', id: id, b: b }, sendable(b)); },
+			instance: function (inst) {
+				instances[id] = inst;
+				if (pendingKill[id]) { delete pendingKill[id]; interrupt(id); }
+			},
+		};
+		if (m.env) hooks.env = m.env;
+		try {
+			globalThis.skywireExec(m.args || [], hooks).then(function (code) {
+				delete instances[id]; delete pendingKill[id];
+				post({ t: 'exit', id: id, code: code });
+			}, function (e) {
+				delete instances[id]; delete pendingKill[id];
+				post({ t: 'fail', id: id, msg: (e && e.message) || String(e) });
+			});
+		} catch (e) {
+			delete instances[id]; delete pendingKill[id];
+			post({ t: 'fail', id: id, msg: (e && e.message) || String(e) });
+		}
+	}
+
+	// ---- persistence -------------------------------------------------------
+	// The same exclusion the desk has always used, moved to the side that now
+	// owns the snapshot: identity and config persist, runtime stores do not. A
+	// bbolt database snapshotted mid-write restores corrupt and hangs its
+	// consumer on the next boot (observed: the hypervisor module stalling on a
+	// restored users.db). Caches rebuild; keys don't.
+	function excluded(p) {
+		return /\.db$/.test(p) || p.indexOf('/opt/skywire/local/') === 0 || p === '/opt/skywire/local';
+	}
+
+	function init(m) {
+		if (m.wasmURL) globalThis.skywireExec.wasmURL = m.wasmURL;
+		if (m.wasmExecURL) globalThis.skywireExec.wasmExecURL = m.wasmExecURL;
+		if (!m.persistDB) { post({ t: 'ready', restored: false }); return; }
+		globalThis.jsfs.persist.enable(m.persistDB, { exclude: excluded }).then(function (p) {
+			post({ t: 'ready', restored: !!(p && p.restored) });
+		}, function (e) {
+			// A denied or corrupt IndexedDB is not a reason to have no visor:
+			// the filesystem stays in memory for this session.
+			console.warn('exec-worker: persistence unavailable:', (e && e.message) || e);
+			post({ t: 'ready', restored: false });
+		});
+	}
+
+	self.onmessage = function (ev) {
+		var m = ev.data || {};
+		switch (m.t) {
+		case 'init': init(m); return;
+		case 'spawn': spawn(m); return;
+		case 'kill':
+			if (!interrupt(m.id)) pendingKill[m.id] = true;
+			return;
+		case 'vopen': openConn(m.cid, m.port); return;
+		case 'vdata': {
+			var idv = conns[m.cid];
+			if (idv === undefined) return;
+			if (!v.send(idv, 'a', m.b)) { post({ t: 'vclose', cid: m.cid }); delete conns[m.cid]; }
+			return;
+		}
+		case 'vclose': {
+			var idc = conns[m.cid];
+			if (idc === undefined) return;
+			delete conns[m.cid];
+			try { v.close(idc, 'a'); } catch (e) { /* already gone */ }
+			return;
+		}
+		default: return;
+		}
+	};
+})();

--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -47,6 +47,12 @@ func DeskBootJS() []byte { return browseui.DeskBootJS() }
 // Re-exported from the browseui leaf like BrowseJS.
 func VNetSWJS() []byte { return browseui.VNetSWJS() }
 
+// ExecWorkerJS is the worker bundle served beside the desk pages as
+// /skywire-worker.js — the thread every skywire COMMAND runs on, so the visor's
+// Go runtime is not the thing scheduling on the page's main thread. Re-exported
+// from the browseui leaf like BrowseJS.
+func ExecWorkerJS() []byte { return browseui.ExecWorkerJS }
+
 // WalletConfigHTML is the single wallet-config page (served at /wallet/config by
 // both the native HV and `hv serve`, embedded via iframe by the ☰ wallet window
 // and the Angular wallet tab). Re-exported from the browseui leaf like BrowseJS.

--- a/scripts/stage-playground/main.go
+++ b/scripts/stage-playground/main.go
@@ -28,7 +28,11 @@ func main() {
 		"bundle.js":    browseui.BrowseJS,
 		"desk-boot.js": browseui.DeskBootJS(),
 		"vnet-sw.js":   browseui.VNetSWJS(),
-		"winbox.wasm":  browseui.WinBoxWasm(),
+		// The worker every skywire command runs in — the playground's terminal
+		// starts real visors, and a Go runtime on the page main thread makes
+		// the whole desk stutter.
+		"skywire-worker.js": browseui.ExecWorkerJS,
+		"winbox.wasm":       browseui.WinBoxWasm(),
 	}
 	for name, data := range files {
 		p := filepath.Join(out, name)


### PR DESCRIPTION
The desk ran the wasm visor on the page's main thread, so the Go runtime and the compositor shared one thread. The result was a renderer pegged continuously — not bursts, not boot — and a UI that could not service a window drag.

## Measurement

Same origin, same identity, same binary except the change. 960 one-second samples of the renderer's **main thread** (`/proc/PID/task/PID/stat`) each way, in the same renderer process.

| | n | mean | >=90% | 50-90 | 20-50 | 10-20 | <10 |
|---|---|---|---|---|---|---|---|
| earlier baseline (in-page) | 1151 | 97.5% | 1097 (95.3%) | 4 | 2 | 8 | 40 |
| BEFORE (in-page) | 960 | 86.5% | 797 (83.0%) | 16 | 22 | 30 | 95 |
| **AFTER (worker)** | 960 | **5.2%** | **0 (0.0%)** | 1 | 35 | 103 | **821** |

Whole renderer 89.4% -> 15.3%. The worker thread averages 6.3%.

Page profiles, 14 runs each. BEFORE: 92-93% of a core, top frames `runtime.nanotime1` 76.8%, `now` 39.7%, and the unnamed `wasm-function[1220]/[1222]` (findRunnable/stealWork) at 73.5%/58.2% — **and two runs where the profiler could not attach at all**, `context deadline exceeded`, because the main thread could not service CDP. AFTER: all 14 attached, 0-7% of a core, **no Go runtime frames at all**; the heaviest page frame is 2.4% and the bridge itself is 0.2%.

## Proof the visor is really running, not merely quiet

Low CPU is also what a broken visor looks like, so this was verified from **outside the browser**:

- `curl -x socks5h://127.0.0.1:4443 http://030d05ec0e940c7442333ad63193caa9246da168f3e16997aa27ca71aa0fb843aa.dmsg/health` -> **200**, `"service_name":"visor"`, `"os":"js","arch":"wasm"`, `"transport_counts":{"dmsg":1,"swtr":7}`. That path is shell -> host visor's resolving proxy -> mesh -> the tab's Web Worker -> back. Independently reproduced by the reviewer.
- `skywire cli tp add -t dmsg <pk>` from host visor `0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c` -> **established**, id `931c98f4-5070-00ec-8be8-12fe85bf7431`, with the worker-hosted visor reporting the same UUID. Removed afterwards.
- 13/13 in-window probes over 16 minutes: `l3435=true l8001=true l4445=true inWorker=true`, `/api/about` 200, `[skywire autoconfig]` running, and the visor's own log advancing — one probe caught `path="/api/visors-tree-summary" status=200 elapsed=5.4ms`, i.e. the page's dashboard calling the visor in the worker through the bridge.

## Design

`skywire-worker.js` is a worker bundle with its own jsfs/vnet/proc/skywire-exec. `exec-remote.js` replaces `globalThis.skywireExec` with a same-contract shim, so the Go side is unchanged. The worker advertises every vnet claim; the page claims the same port and forwards each connection **byte-for-byte** rather than as HTTP — 3435 is gob and 4445 is SOCKS5, so an HTTP-shaped bridge would have corrupted them.

**No SharedArrayBuffer, no COOP/COEP, no vendor edits.** bottle's `spawnWorker` needs cross-origin isolation because its child shares the page's filesystem synchronously; a visor does not need that, and `worker.js` already demonstrated plain postMessage hosting.

Mode selection is a capability probe, verified live: `install({url:'/no-such-worker.js'})` returns null and touches nothing.

## Second commit: the framed hypervisor UI

The operator reported the netscrape nested browser not showing the hypervisor UI. It is **pre-existing on develop** — reproduced on a `fc3999128` build with these changes stashed out — and it is not any of the obvious causes.

Both servers decide "am I framed?" from `Sec-Fetch-Dest: iframe` **or** `?embed=1`. Through bottle's vnet service worker only the second survives, because `Sec-Fetch-*` are forbidden header names and unreadable from `event.request.headers`. Then `desk-boot.js`'s 25-second Material-icons self-heal calls `contentWindow.location.reload()` — and by then the Angular router has rewritten the frame to `/vnet/8001/#/nodes/list/1` with the query gone. The hypervisor sees no marker and serves its **desk**. So the dashboard renders for 25 seconds and the self-heal replaces it with a desk.

Fixed by having the self-heal navigate to an embed-carrying URL, and by `skywireDeskBoot` refusing to be a desk inside a frame (correcting its own address once, bounded). After: 13/13 probes read "Skywire Hypervisor", `appRoot:true`, 14 populated table cells.

## Known consequences, documented in the file headers

- The page's and the worker's filesystems are **separate**. The shell's own builtins see a different tree from `skywire` commands. Sharing them would need fsbridge, hence SAB, hence cross-origin isolation.
- **WebRTC is unavailable in a Worker.** `newPeerConnection` errors cleanly and the visor falls back to other carriers; the `__skywireRTC` agent proxy that `worker.js` uses was not wired.

`go build .`, `go vet`, `gofmt`, `go test ./pkg/wasmhv/...` and `pkg/visor -run 'Desk|Wasm|Browse|Serve'` pass; `golangci-lint` 0 issues.
