### PR TITLE
fix(desk): give netscrape a flex root so the page it loads is visible

### DIFF
--- a/cmd/wasm-visor/browser_js.go
+++ b/cmd/wasm-visor/browser_js.go
@@ -44,6 +44,45 @@ func jsOpenBrowser(_ js.Value, args []js.Value) any {
 	if !el.Truthy() {
 		return nil
 	}
+	ensureFlexColumn(el)
 	netscrape.Open(el)
 	return nil
+}
+
+// ensureFlexColumn makes el a flex column before netscrape mounts into it.
+//
+// netscrape lays its chrome out as a flex column: the tab strip and address bar
+// are fixed-height rows, and the views container that holds the page takes the
+// remainder with `position:relative;flex:1;min-height:0` (netscrape browser.go).
+// It repairs `position` on the element it is handed — turning a `static` host
+// element `relative` so the absolutely-positioned page views have a containing
+// block — but it does NOT repair `display`.
+//
+// So a host that passes a plain block element gets a views container whose
+// `flex:1` is inert (no flex parent to distribute along) and whose
+// `min-height:0` permits it to collapse. Its only child is an absolutely
+// positioned iframe, which contributes no content height, so the container
+// resolves to ZERO height. The page inside loads and runs perfectly and is
+// simply never visible — which is exactly how it presented: a fully loaded
+// hypervisor UI, document title and all, in a frame 1000px wide and 0px tall.
+//
+// Fixed here rather than in netscrape so no vendored dependency is patched, and
+// because the flex context is properly the host's responsibility — netscrape is
+// mounted into a WinBox body here, a docked pane elsewhere, and each host knows
+// its own layout. Only set when the element is not already a flex container, so
+// a host that has arranged this itself is left alone.
+func ensureFlexColumn(el js.Value) {
+	cs := js.Global().Call("getComputedStyle", el)
+	if !cs.Truthy() {
+		return
+	}
+	if d := cs.Get("display").String(); d == "flex" || d == "inline-flex" {
+		return
+	}
+	style := el.Get("style")
+	if !style.Truthy() {
+		return
+	}
+	style.Set("display", "flex")
+	style.Set("flexDirection", "column")
 }


### PR DESCRIPTION
The nested browser rendered nothing — on **both** the standalone wasm desk (`:8443`) and the host-native desk (`:8000`) — while the page inside it loaded perfectly.

Measured on a live desk, stable across repeated samples 12s apart:

```
iframe src : https://127.0.0.1:8443/vnet/8001/?embed=1#/?embed=1
           : w=1000  h=0        <- the frame
contentDoc : title "Skywire Hypervisor"
           : body 33273 -> 29307 bytes   <- live, changing content
parent     : <div style="position:relative; flex:1 1 0%; min-height:0px">  h=0
grandparent: display:block  h=605
wb-body    : display:flex   h=605
```

So the hypervisor UI was fully loaded, running, and updating — in a frame 1000px wide and **0px tall**. Reported as "it just looks like it's in a generic winbox window", which is precisely what a collapsed content area looks like.

## Cause

netscrape lays its chrome out as a flex column: the tab strip and address bar are fixed-height rows, and the views container that holds the page takes the remainder with `position:relative;flex:1;min-height:0` (`netscrape/browser.go:692`).

It repairs `position` on the element it is handed — turning a `static` host element `relative` so the absolutely-positioned page views have a containing block — but it does **not** repair `display`.

`jsOpenBrowser` passed the element straight through to `netscrape.Open(el)`. Mounted into a WinBox body, that element is `display:block`, so:

- `flex:1` on the views container is **inert** — there is no flex parent to distribute along,
- `min-height:0` permits it to collapse,
- its only child is an absolutely positioned iframe, which contributes no content height.

It resolves to zero. The `wb-body` two levels up *is* `display:flex`, but a plain block div in between breaks the chain.

## Why fixed here rather than in netscrape

No vendored dependency gets patched, and the flex context is properly the host's responsibility — netscrape mounts into a WinBox body here and into other containers elsewhere, and each host knows its own layout. The guard only applies the style when the element is not already a flex container, so a host that has arranged this itself is untouched.

## Note for the follow-up

`cmd/wasm-visor` is the desk **host module**, embedded as `pkg/wasmhv/wasmbin/wasmgo/wasm-visor.wasm.gz`. This change is therefore not live until that blob is regenerated with `make embed-wasm-visor`, which the `embeddable-tree` guard requires be run from the main clone. That follows as a separate commit.

`GOOS=js GOARCH=wasm go build ./cmd/wasm-visor/` clean, `gofmt` clean, `golangci-lint` 0 issues.
