### PR TITLE
fix(desk): apply the netscrape flex root at the DESK call site too

### DIFF
--- a/cmd/wasm-visor/desk_js.go
+++ b/cmd/wasm-visor/desk_js.go
@@ -63,6 +63,12 @@ func installDesk() {
 		Width: 1000, Height: 640,
 		Open: func(args []string) (desk.Pane, error) {
 			return funcPane{mount: func(el js.Value) error {
+				// Same flex-root requirement as the standalone entry in
+				// browser_js.go: netscrape sizes its views container with
+				// flex:1 and repairs only `position` on the element it is
+				// given, so a non-flex host collapses the page to zero height.
+				// This is the site the DESK uses.
+				ensureFlexColumn(el)
 				netscrape.Open(el)
 				if len(args) > 0 && args[0] != "" {
 					netscrape.Navigate(args[0])


### PR DESCRIPTION
Follow-up to #4648, which fixed the wrong call site.

There are **two** `netscrape.Open` call sites and the desk uses the other one:

```
cmd/wasm-visor/browser_js.go:48   <- fixed in #4648 (standalone jsOpenBrowser entry)
cmd/wasm-visor/desk_js.go:66      <- what the DESK actually uses (the "browser" pane)
```

So the nested browser still rendered an invisible page after #4648 and its blob rebuild — verified live: frame `w=1000 h=0`, `parentH=0`, `contentDocument.title` "Skywire Hypervisor", body 29,319 bytes. Loaded and running, zero height.

Same cause and the same one-line guard: netscrape sizes its views container with `flex:1;min-height:0` and repairs only `position` on the element it is handed, so a `display:block` host makes the flex inert and the container collapses.

Needs the embedded desk-host blob regenerated again to go live (`make embed-wasm-visor` from the main clone), which follows.