### PR TITLE
fix(desk): give netscrape its own child element to own

### DIFF
--- a/cmd/wasm-visor/browser_js.go
+++ b/cmd/wasm-visor/browser_js.go
@@ -44,45 +44,47 @@ func jsOpenBrowser(_ js.Value, args []js.Value) any {
 	if !el.Truthy() {
 		return nil
 	}
-	ensureFlexColumn(el)
-	netscrape.Open(el)
+	netscrape.Open(netscrapeHost(el))
 	return nil
 }
 
-// ensureFlexColumn makes el a flex column before netscrape mounts into it.
+// netscrapeHost returns an element for netscrape to own, nested one level
+// inside el rather than el itself.
 //
-// netscrape lays its chrome out as a flex column: the tab strip and address bar
-// are fixed-height rows, and the views container that holds the page takes the
-// remainder with `position:relative;flex:1;min-height:0` (netscrape browser.go).
-// It repairs `position` on the element it is handed — turning a `static` host
-// element `relative` so the absolutely-positioned page views have a containing
-// block — but it does NOT repair `display`.
+// netscrape styles its host: it sets display:flex + flexDirection:column so its
+// tab strip and address bar sit above a views container that claims the rest
+// with `flex:1;min-height:0` (netscrape browser.go). That is correct and
+// netscrape does it unprompted — the host does not need to.
 //
-// So a host that passes a plain block element gets a views container whose
-// `flex:1` is inert (no flex parent to distribute along) and whose
-// `min-height:0` permits it to collapse. Its only child is an absolutely
-// positioned iframe, which contributes no content height, so the container
-// resolves to ZERO height. The page inside loads and runs perfectly and is
-// simply never visible — which is exactly how it presented: a fully loaded
-// hypervisor UI, document title and all, in a frame 1000px wide and 0px tall.
+// The problem is that something else styles the same element AFTERWARDS. The
+// desk's tab machinery shows a pane with `view.style.display = "block"`
+// (0magnet/desk tabs_js.go, both on add and on every tab SHOW). That overwrites
+// netscrape's `display:flex` while leaving `flex-direction:column` behind — the
+// contradictory pair is the fingerprint. The views container's `flex:1` then has
+// no flex parent to distribute along, `min-height:0` lets it collapse, and its
+// only child is an absolutely positioned iframe contributing no content height.
+// It resolves to ZERO height, so the page inside loads, runs, and is never
+// visible: a fully working hypervisor UI in a frame 1000px wide and 0px tall.
 //
-// Fixed here rather than in netscrape so no vendored dependency is patched, and
-// because the flex context is properly the host's responsibility — netscrape is
-// mounted into a WinBox body here, a docked pane elsewhere, and each host knows
-// its own layout. Only set when the element is not already a flex container, so
-// a host that has arranged this itself is left alone.
-func ensureFlexColumn(el js.Value) {
-	cs := js.Global().Call("getComputedStyle", el)
-	if !cs.Truthy() {
-		return
+// That file's own comment notes "one that styles its host (the browser does)
+// needs to find a position it can keep" — position was preserved, display was
+// not.
+//
+// Giving netscrape its own child means the tab machinery keeps setting
+// display:block on the outer element, where block is exactly right, and the
+// inner element netscrape owns is never touched. No vendored dependency is
+// patched and nothing has to win a race over one style property.
+func netscrapeHost(el js.Value) js.Value {
+	doc := js.Global().Get("document")
+	if !doc.Truthy() {
+		return el
 	}
-	if d := cs.Get("display").String(); d == "flex" || d == "inline-flex" {
-		return
-	}
-	style := el.Get("style")
-	if !style.Truthy() {
-		return
-	}
-	style.Set("display", "flex")
-	style.Set("flexDirection", "column")
+	inner := doc.Call("createElement", "div")
+	// position:relative so netscrape leaves position alone (it only supplies one
+	// when the host computes to static); 100%/100% so the inner box inherits the
+	// outer's geometry whatever the host sized it to.
+	inner.Get("style").Set("cssText",
+		"position:relative;width:100%;height:100%;display:flex;flex-direction:column;overflow:hidden")
+	el.Call("appendChild", inner)
+	return inner
 }

--- a/cmd/wasm-visor/desk_js.go
+++ b/cmd/wasm-visor/desk_js.go
@@ -63,13 +63,7 @@ func installDesk() {
 		Width: 1000, Height: 640,
 		Open: func(args []string) (desk.Pane, error) {
 			return funcPane{mount: func(el js.Value) error {
-				// Same flex-root requirement as the standalone entry in
-				// browser_js.go: netscrape sizes its views container with
-				// flex:1 and repairs only `position` on the element it is
-				// given, so a non-flex host collapses the page to zero height.
-				// This is the site the DESK uses.
-				ensureFlexColumn(el)
-				netscrape.Open(el)
+				netscrape.Open(netscrapeHost(el))
 				if len(args) > 0 && args[0] != "" {
 					netscrape.Navigate(args[0])
 				}


### PR DESCRIPTION
The nested browser rendered nothing on both desks while the page inside it was fully loaded and running. Measured live: an iframe **1000px wide and 0px tall**, `contentDocument.title` = "Skywire Hypervisor", body ~29KB and changing.

## My two previous attempts were wrong, instructively

#4648 and #4650 both made the *host* a flex column before calling `netscrape.Open`. But **netscrape already does that itself** — `browser.go:658-659` sets `display:flex` + `flexDirection:column` on its host unprompted. The guard was pure redundancy and changed nothing, which is why the symptom survived two code fixes and two blob rebuilds.

## The actual writer runs later

`0magnet/desk` `tabs_js.go` shows a pane with `view.style.display = "block"` — once on add (line 118) and again on **every tab show** (line 181). That overwrites netscrape's `display:flex` and leaves `flex-direction:column` stranded.

That contradictory pair on one element was the fingerprint, visible in the very first DOM dump, and I misread it as netscrape's own styling:

```
DIV  position:absolute; inset:0; display: block; flex-direction: column   h=605
 └ DIV  position:relative; flex:1 1 0%; min-height:0    display:block     h=0    <- views
    └ IFRAME  position:absolute; inset:0; 100%x100%                       h=0    <- the loaded UI
```

With no flex parent, `flex:1` is inert, `min-height:0` permits collapse, and the only child is an absolutely positioned iframe contributing no content height. It resolves to zero.

So it renders on first mount and breaks on every subsequent tab switch — which matches "it just looks like it's in a generic winbox window".

That file's own comment says *"one that styles its host (the browser does) needs to find a position it can keep"*. Position was preserved; display was not.

## Fix

netscrape gets its own child element, one level inside the pane view. The tab machinery keeps setting `display:block` on the outer element — where block is exactly right — and the element netscrape owns is never touched. No vendored dependency is patched, and nothing has to win a race over a single style property.

Also removes the redundant `ensureFlexColumn` helper added by the earlier attempts.

Needs the embedded desk-host blob regenerated to go live (`make embed-wasm-visor` from the main clone), which follows.