### PR TITLE
feat(tabshot): evallat — time CDP Runtime.evaluate round-trips

### DIFF
--- a/cmd/wasm-visor/browser_js.go
+++ b/cmd/wasm-visor/browser_js.go
@@ -44,45 +44,47 @@ func jsOpenBrowser(_ js.Value, args []js.Value) any {
 	if !el.Truthy() {
 		return nil
 	}
-	ensureFlexColumn(el)
-	netscrape.Open(el)
+	netscrape.Open(netscrapeHost(el))
 	return nil
 }
 
-// ensureFlexColumn makes el a flex column before netscrape mounts into it.
+// netscrapeHost returns an element for netscrape to own, nested one level
+// inside el rather than el itself.
 //
-// netscrape lays its chrome out as a flex column: the tab strip and address bar
-// are fixed-height rows, and the views container that holds the page takes the
-// remainder with `position:relative;flex:1;min-height:0` (netscrape browser.go).
-// It repairs `position` on the element it is handed — turning a `static` host
-// element `relative` so the absolutely-positioned page views have a containing
-// block — but it does NOT repair `display`.
+// netscrape styles its host: it sets display:flex + flexDirection:column so its
+// tab strip and address bar sit above a views container that claims the rest
+// with `flex:1;min-height:0` (netscrape browser.go). That is correct and
+// netscrape does it unprompted — the host does not need to.
 //
-// So a host that passes a plain block element gets a views container whose
-// `flex:1` is inert (no flex parent to distribute along) and whose
-// `min-height:0` permits it to collapse. Its only child is an absolutely
-// positioned iframe, which contributes no content height, so the container
-// resolves to ZERO height. The page inside loads and runs perfectly and is
-// simply never visible — which is exactly how it presented: a fully loaded
-// hypervisor UI, document title and all, in a frame 1000px wide and 0px tall.
+// The problem is that something else styles the same element AFTERWARDS. The
+// desk's tab machinery shows a pane with `view.style.display = "block"`
+// (0magnet/desk tabs_js.go, both on add and on every tab SHOW). That overwrites
+// netscrape's `display:flex` while leaving `flex-direction:column` behind — the
+// contradictory pair is the fingerprint. The views container's `flex:1` then has
+// no flex parent to distribute along, `min-height:0` lets it collapse, and its
+// only child is an absolutely positioned iframe contributing no content height.
+// It resolves to ZERO height, so the page inside loads, runs, and is never
+// visible: a fully working hypervisor UI in a frame 1000px wide and 0px tall.
 //
-// Fixed here rather than in netscrape so no vendored dependency is patched, and
-// because the flex context is properly the host's responsibility — netscrape is
-// mounted into a WinBox body here, a docked pane elsewhere, and each host knows
-// its own layout. Only set when the element is not already a flex container, so
-// a host that has arranged this itself is left alone.
-func ensureFlexColumn(el js.Value) {
-	cs := js.Global().Call("getComputedStyle", el)
-	if !cs.Truthy() {
-		return
+// That file's own comment notes "one that styles its host (the browser does)
+// needs to find a position it can keep" — position was preserved, display was
+// not.
+//
+// Giving netscrape its own child means the tab machinery keeps setting
+// display:block on the outer element, where block is exactly right, and the
+// inner element netscrape owns is never touched. No vendored dependency is
+// patched and nothing has to win a race over one style property.
+func netscrapeHost(el js.Value) js.Value {
+	doc := js.Global().Get("document")
+	if !doc.Truthy() {
+		return el
 	}
-	if d := cs.Get("display").String(); d == "flex" || d == "inline-flex" {
-		return
-	}
-	style := el.Get("style")
-	if !style.Truthy() {
-		return
-	}
-	style.Set("display", "flex")
-	style.Set("flexDirection", "column")
+	inner := doc.Call("createElement", "div")
+	// position:relative so netscrape leaves position alone (it only supplies one
+	// when the host computes to static); 100%/100% so the inner box inherits the
+	// outer's geometry whatever the host sized it to.
+	inner.Get("style").Set("cssText",
+		"position:relative;width:100%;height:100%;display:flex;flex-direction:column;overflow:hidden")
+	el.Call("appendChild", inner)
+	return inner
 }

--- a/cmd/wasm-visor/desk_js.go
+++ b/cmd/wasm-visor/desk_js.go
@@ -63,13 +63,7 @@ func installDesk() {
 		Width: 1000, Height: 640,
 		Open: func(args []string) (desk.Pane, error) {
 			return funcPane{mount: func(el js.Value) error {
-				// Same flex-root requirement as the standalone entry in
-				// browser_js.go: netscrape sizes its views container with
-				// flex:1 and repairs only `position` on the element it is
-				// given, so a non-flex host collapses the page to zero height.
-				// This is the site the DESK uses.
-				ensureFlexColumn(el)
-				netscrape.Open(el)
+				netscrape.Open(netscrapeHost(el))
 				if len(args) > 0 && args[0] != "" {
 					netscrape.Navigate(args[0])
 				}

--- a/scripts/tabshot/evallat/main.go
+++ b/scripts/tabshot/evallat/main.go
@@ -1,0 +1,77 @@
+// Command evallat times CDP Runtime.evaluate round-trips on one open socket,
+// isolating the evaluate from process startup and dial cost.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func main() {
+	n := 40
+	if len(os.Args) > 2 {
+		if v, err := strconv.Atoi(os.Args[2]); err == nil && v > 0 {
+			n = v
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, os.Args[1], &websocket.DialOptions{})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "dial:", err)
+		os.Exit(1)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+
+	var ms []float64
+	for i := 1; i <= n; i++ {
+		b, merr := json.Marshal(map[string]interface{}{
+			"id": i, "method": "Runtime.evaluate",
+			"params": map[string]interface{}{"expression": "1+1", "returnByValue": true},
+		})
+		if merr != nil {
+			fmt.Fprintln(os.Stderr, "marshal:", merr)
+			os.Exit(1)
+		}
+		st := time.Now()
+		if err := c.Write(ctx, websocket.MessageText, b); err != nil {
+			fmt.Fprintln(os.Stderr, "write:", err)
+			os.Exit(1)
+		}
+		for {
+			_, msg, err := c.Read(ctx)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "read:", err)
+				os.Exit(1)
+			}
+			var m struct {
+				ID int `json:"id"`
+			}
+			if json.Unmarshal(msg, &m) == nil && m.ID == i {
+				break
+			}
+		}
+		ms = append(ms, float64(time.Since(st).Microseconds())/1000)
+		time.Sleep(200 * time.Millisecond)
+	}
+	sort.Float64s(ms)
+	var sum float64
+	for _, v := range ms {
+		sum += v
+	}
+	over := 0
+	for _, v := range ms {
+		if v > 100 {
+			over++
+		}
+	}
+	fmt.Printf("n=%d  min=%.1fms  p50=%.1fms  p95=%.1fms  max=%.1fms  mean=%.1fms  over_100ms=%d\n",
+		len(ms), ms[0], ms[len(ms)/2], ms[len(ms)*95/100], ms[len(ms)-1], sum/float64(len(ms)), over)
+}


### PR DESCRIPTION
Measures UI responsiveness the way it was actually broken.

When the wasm visor ran on the page main thread, `Runtime.evaluate("1+1")` took **11.8 s and then timed out at 45 s** — a trivial expression could not get scheduled past the Go runtime. That is the symptom users described as the desk being unresponsive.

The obvious way to measure it — calling the existing `jseval` in a loop and timing the process — reads 120-170 ms per call and is almost entirely `go run` startup plus the websocket dial. It cannot see a 1 ms round trip, and would not distinguish a fixed desk from a slightly-less-broken one.

`evallat` dials once and times N evaluates on the open socket, reporting min/p50/p95/max/mean and how many exceeded 100 ms.

On the worker-hosted desk, with a visor running in the tab:

```
n=40  min=0.6ms  p50=0.8ms  p95=1.6ms  max=1.9ms  mean=0.9ms  over_100ms=0
```

`gofmt` clean, `golangci-lint` 0 issues.