### PR TITLE
docs(specs): correct five wire formats that were documented wrong

### DIFF
--- a/skywire-specs/specifications/02-HTTP_Authorization_Middleware.md
+++ b/skywire-specs/specifications/02-HTTP_Authorization_Middleware.md
@@ -34,7 +34,10 @@ denotes Skywire):
 |-------------|-------|
 | `SW-Public` | The remote's public key, hexadecimal-encoded. |
 | `SW-Nonce`  | The current Security Nonce for this request, decimal-encoded. |
-| `SW-Sig`    | The signature, hexadecimal-encoded, over `SHA256(nonce_bytes \|\| body)`, where `nonce_bytes` is the 8-byte big-endian encoding of the nonce and `body` is the verbatim request body. |
+| `SW-Sig`    | The signature, hexadecimal-encoded, over `SHA256(body || nonce)`, where `body` is the verbatim request body and `nonce` is the nonce rendered as decimal ASCII and appended to it (NOT a fixed-width binary encoding, and NOT prefixed). |
+
+Concretely: for body `{"a":1}` and nonce `7`, the signed preimage is the
+eight-byte string `{"a":1}7`, and the signature is over its SHA256.
 
 The server SHALL reject a request with HTTP 401 if any of the
 following hold:
@@ -44,7 +47,7 @@ following hold:
 - The nonce in `SW-Nonce` does not match the server's next-expected
   nonce for the entity.
 - The signature in `SW-Sig` does not verify against the
-  reconstructed `SHA256(nonce_bytes || body)` digest using the
+  reconstructed `SHA256(body || nonce)` digest using the
   declared public key.
 - The request body length exceeds the server's configured maximum
   (when set).

--- a/skywire-specs/specifications/06-Packets.md
+++ b/skywire-specs/specifications/06-Packets.md
@@ -24,7 +24,7 @@ Packets are the data units transmitted over Skywire transports and routes. Every
 | `PingPacket` | 4 | Timestamp (8 bytes BE) + throughput (8 bytes BE) | Route-level latency measurement. Requires an established route. |
 | `PongPacket` | 5 | Timestamp (8 bytes BE) | Route-level pong response. Echoes the timestamp from PingPacket. |
 | `ErrorPacket` | 6 | Error message (variable) | Error notification to the route group. |
-| `SACKPacket` | 7 | Last contiguous seq (4 bytes BE) + bitmap (8 bytes BE) | Selective acknowledgment for CapSACK retransmission. |
+| `SACKPacket` | 7 | `last_contiguous_seq` (4 bytes BE) + `word_count` (1 byte) + `word_count` bitmap words (8 bytes BE each), optionally followed by a DSACK field `[flag:1][dsack_seq:4 BE]` | Selective acknowledgment for CapSACK retransmission. Minimum payload is 5 bytes (zero words); `word_count` is capped at 32 (2048 sequences). A reader MUST consume exactly `word_count` words and ignore any trailing bytes it does not recognise — that is what makes the optional DSACK field backward-compatible. The fixed 12-byte single-word form is legacy. |
 | `TransportPingPacket` | 8 | Timestamp (8 bytes BE, unix nano) | Transport-level latency measurement. Route ID = 0. Intercepted before routing. |
 | `TransportPongPacket` | 9 | Timestamp (8 bytes BE, echoed) | Transport-level pong response. Route ID = 0. Intercepted before routing. |
 

--- a/skywire-specs/specifications/08-Route_Finder.md
+++ b/skywire-specs/specifications/08-Route_Finder.md
@@ -53,15 +53,30 @@ POST /routes
 Content-Type: application/json
 ```
 
+> The request and response structs carry no `json` struct tags (except
+> `Latency`), so the wire keys are the Go field names verbatim. Two
+> consequences, and they differ by direction:
+>
+> - **Responses** are emitted capitalised: `TpID`, `From`, `To`. A client
+>   reading `tp_id` finds nothing.
+> - **Requests** are decoded case-insensitively, so `edges` and `opts` do
+>   match. But `min_hops` and `max_hops` do NOT — case-folding does not
+>   bridge an underscore. Those options are dropped silently and the
+>   request still succeeds, so a hop-constrained query comes back
+>   unconstrained with no error to indicate why.
+>
+> Use the exact keys below in both directions.
+
 ```json
 {
-    "edges": [
+    "Edges": [
         ["<source-public-key>", "<destination-public-key>"],
         ["<source-public-key-2>", "<destination-public-key-2>"]
     ],
-    "opts": {
-        "min_hops": 0,
-        "max_hops": 16
+    "Opts": {
+        "MinHops": 0,
+        "MaxHops": 16,
+        "NumRoutes": 0
     }
 }
 ```
@@ -70,10 +85,11 @@ Content-Type: application/json
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `edges` | array | Yes | Array of [source, destination] public key pairs |
-| `opts` | object | No | Route filtering options |
-| `opts.min_hops` | integer | No | Minimum number of hops (default: 0) |
-| `opts.max_hops` | integer | No | Maximum number of hops (default: 0, meaning no limit) |
+| `Edges` | array | Yes | Array of [source, destination] public key pairs |
+| `Opts` | object | No | Route filtering options |
+| `Opts.MinHops` | integer | No | Minimum number of hops (default: 0) |
+| `Opts.MaxHops` | integer | No | Maximum number of hops (default: 0, meaning no limit) |
+| `Opts.NumRoutes` | integer | No | Desired number of distinct routes per edge. Zero means the service default. A multiplexed dial MUST set this to its mux degree (plus headroom); otherwise the finder caps at 3 routes and a higher requested mux degree silently degrades. |
 
 **Responses:**
 
@@ -83,14 +99,15 @@ Content-Type: application/json
         "<source-pk>:<destination-pk>": [
             [
                 {
-                    "tp_id": "<transport-id-uuid>",
-                    "from": "<source-visor-pk>",
-                    "to": "<next-hop-visor-pk>"
+                    "TpID": "<transport-id-uuid>",
+                    "From": "<source-visor-pk>",
+                    "To": "<next-hop-visor-pk>",
+                    "Latency": 12.5
                 },
                 {
-                    "tp_id": "<transport-id-uuid>",
-                    "from": "<next-hop-visor-pk>",
-                    "to": "<destination-visor-pk>"
+                    "TpID": "<transport-id-uuid>",
+                    "From": "<next-hop-visor-pk>",
+                    "To": "<destination-visor-pk>"
                 }
             ]
         ]
@@ -107,9 +124,10 @@ The response is a JSON object where:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `tp_id` | string (UUID) | Transport ID connecting the two nodes |
-| `from` | string | Source visor public key (hex) |
-| `to` | string | Destination visor public key (hex) |
+| `TpID` | string (UUID) | Transport ID connecting the two nodes |
+| `From` | string | Source visor public key (hex) |
+| `To` | string | Destination visor public key (hex) |
+| `Latency` | number | Measured transport latency for this hop, in milliseconds. Informational only — it is NOT used in route-rule setup. Omitted when the edge has no measurement, and by route-finders that predate the field. |
 
 **Error Responses:**
 

--- a/skywire-specs/specifications/10-Routing_Table.md
+++ b/skywire-specs/specifications/10-Routing_Table.md
@@ -20,34 +20,37 @@ A routing rule is a variable-length byte slice with a fixed header:
 
 Delivers the packet to a local application. Additional fields:
 
-| Field | Size | Description |
-|---|---|---|
-| SrcPK | 33 bytes | Source visor public key |
-| DstPK | 33 bytes | Destination visor public key |
-| SrcPort | 2 bytes | Source routing port |
-| DstPort | 2 bytes | Destination routing port |
+| Field | Offset | Size | Description |
+|---|---|---|---|
+| SrcPK | 13 | 33 bytes | Source visor public key |
+| DstPK | 46 | 33 bytes | Destination visor public key |
+| SrcPort | 79 | 2 bytes | Source routing port |
+| DstPort | 81 | 2 bytes | Destination routing port |
 
 ### Forward Rule
 
 Forwards the packet to the next hop. Additional fields:
 
-| Field | Size | Description |
-|---|---|---|
-| NextRouteID | 4 bytes | Route ID on the next hop |
-| NextTransportID | 16 bytes | UUID of the transport to use |
-| SrcPK | 33 bytes | Source visor public key |
-| DstPK | 33 bytes | Destination visor public key |
-| SrcPort | 2 bytes | Source routing port |
-| DstPort | 2 bytes | Destination routing port |
+Fields appear in this order on the wire — the route descriptor comes first,
+then the next-hop fields. Offsets are from the start of the rule.
+
+| Field | Offset | Size | Description |
+|---|---|---|---|
+| SrcPK | 13 | 33 bytes | Source visor public key |
+| DstPK | 46 | 33 bytes | Destination visor public key |
+| SrcPort | 79 | 2 bytes | Source routing port |
+| DstPort | 81 | 2 bytes | Destination routing port |
+| NextRouteID | 83 | 4 bytes | Route ID on the next hop |
+| NextTransportID | 87 | 16 bytes | UUID of the transport to use |
 
 ### IntermediaryForward Rule
 
 Forwards the packet through an intermediary visor. Additional fields:
 
-| Field | Size | Description |
-|---|---|---|
-| NextRouteID | 4 bytes | Route ID on the next hop |
-| NextTransportID | 16 bytes | UUID of the transport to use |
+| Field | Offset | Size | Description |
+|---|---|---|---|
+| NextRouteID | 13 | 4 bytes | Route ID on the next hop |
+| NextTransportID | 17 | 16 bytes | UUID of the transport to use |
 
 Intermediary rules do not contain source/destination PKs or ports — the intermediary visor only knows the previous and next hop.
 

--- a/skywire-specs/transports/STCP.md
+++ b/skywire-specs/transports/STCP.md
@@ -105,12 +105,23 @@ Each entry in the PK table maps a visor's public key to its network address:
 
 ## Transport Handshake
 
-After TCP connection is established:
+The connection is authenticated by a four-frame nonce-challenge exchange —
+this is **not** a Noise handshake, and Noise runs only after it succeeds:
 
-1. Initiator sends Noise protocol handshake initiation
-2. Responder verifies initiator's public key
-3. Session keys are derived for encrypted communication
-4. Transport is ready for use
+1. Initiator sends frame 0: the literal string `get_nonce`.
+2. Responder replies with frame 1: a freshly generated random nonce.
+3. Initiator sends frame 2: its `{SrcAddr, DstAddr, Nonce}` signed under its
+   secret key.
+4. Responder verifies the signature against the nonce it issued, checks the
+   destination port has a listener, and replies with frame 3: OK, or an
+   error message.
+
+Only once frame 3 reports OK is the connection wrapped in a Noise `KK`
+handshake, which derives the session keys used for all subsequent traffic.
+
+The nonce challenge is what makes the signature non-replayable: because the
+responder chooses the nonce per connection, a captured frame 2 cannot
+authenticate a later one.
 
 ## Error Handling
 

--- a/skywire-specs/transports/STCPR.md
+++ b/skywire-specs/transports/STCPR.md
@@ -84,11 +84,11 @@ If a visor fails to re-register, its entry expires and it becomes unreachable vi
 
 ## Transport Handshake
 
-After TCP connection is established, a Noise protocol handshake authenticates both parties:
-
-1. Initiator sends handshake initiation with its public key
-2. Responder verifies and responds
-3. Both parties derive session keys for encrypted communication
+STCPR uses the same authentication as STCP — see
+[STCP.md](STCP.md#transport-handshake). After the TCP connection is
+established, a four-frame nonce-challenge exchange authenticates both parties
+(`get_nonce` → nonce → signed addresses → OK), and only then is the connection
+wrapped in a Noise `KK` handshake to derive session keys.
 
 ## Configuration
 

--- a/skywire-specs/transports/SUDPH.md
+++ b/skywire-specs/transports/SUDPH.md
@@ -58,7 +58,7 @@ When both visors share the same public IP (same LAN), SUDPH:
 2. Creates a `PacketFilter` to multiplex the UDP socket between:
    - Address-resolver connection (for registration and signaling)
    - Peer connections (for hole-punched transports)
-3. Performs Noise handshake with address-resolver over UDP
+3. Performs the four-frame nonce-challenge handshake with the address-resolver over UDP (the same exchange STCP uses — see [STCP.md](STCP.md#transport-handshake) — not Noise)
 4. Sends binding information (port, local addresses)
 5. Waits for incoming dial requests via `addrCh` channel
 
@@ -101,11 +101,13 @@ const holePunchMessage = "holepunch"
 
 ## Address Resolver API
 
-### UDP Binding (Noise Handshake)
+### UDP Binding (nonce-challenge handshake)
 
-Visors bind via UDP with a Noise protocol handshake:
+Visors bind via UDP with the same four-frame nonce-challenge handshake used for
+STCP transports (`get_nonce` -> nonce -> signed addresses -> OK). It is NOT a
+Noise handshake:
 
-1. Visor initiates Noise handshake with address-resolver
+1. Visor completes the nonce-challenge handshake with the address-resolver
 2. After handshake, visor sends binding data:
    ```json
    {


### PR DESCRIPTION
Five things in `skywire-specs/` are specified in a way that yields a
non-interoperable implementation. Each was checked against the code, not
inferred.

- **02 httpauth** — signature is `SHA256(body || nonce)` with the nonce
  appended as decimal ASCII, not `SHA256(8-byte-BE nonce || body)`. A client
  following the old text never authenticates. Adds a worked preimage.
- **06 SACK** — `[seq:4][word_count:1][words:8 each]` + optional DSACK, min 5
  bytes. The documented fixed 12-byte form is the legacy single-word shape.
- **08 route-finder** — no json tags, so wire keys are the Go field names.
  Responses emit `TpID`/`From`/`To`; requests decode case-insensitively, so
  `min_hops`/`max_hops` decode to zero and a hop-constrained query silently
  returns unconstrained routes. Also documents `NumRoutes`, without which a
  mux dial caps at 3 routes.
- **10 Forward rule** — fields were listed next-hop-first; the route
  descriptor comes first on the wire. Byte offsets added to all three tables.
- **STCP/STCPR/SUDPH** — the handshake is a four-frame nonce challenge, not
  Noise. Noise KK wraps the connection only afterwards.

The 08 case-insensitivity behaviour was confirmed empirically rather than
assumed; the STCP frame direction was corrected against the code (the
initiator opens the exchange).

Docs only, no code change.