### PR TITLE
docs(config): correct two config fields whose docs describe behaviour that does not exist

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -348,7 +348,7 @@ const envfileLinux = `#
 #REGTIMEOUT='10m'
 
 #--	Public visor max transports (default 1000)
-#MAXTRANSPORTS=1000
+#MAXTRANSPORTS=2048
 
 #--	Number of parallel mux routes per connection (default 0)
 #MUXROUTES=0
@@ -574,7 +574,7 @@ const envfileWindows = `#
 #$REGTIMEOUT='10m'
 
 #--	Public visor max transports (default 1000)
-#$MAXTRANSPORTS=1000
+#$MAXTRANSPORTS=2048
 
 #--	Number of parallel mux routes per connection (default 0)
 #$MUXROUTES=0

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -123,7 +123,7 @@ type Values struct {
 	StunServers string // STUNSERVERS (comma-separated)
 
 	// --- Public-visor transport limit ---
-	MaxTransports int // MAXTRANSPORTS (deregister from AR once this many transports exist)
+	MaxTransports int // MAXTRANSPORTS (pause service-discovery registration at this DISTINCT-PEER count)
 
 	// --- Transport ports ---
 	StcprPort     int
@@ -282,7 +282,7 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().StringVar(&v.URL, "url", "", "services-config URL(s), comma-separated — writes SVCCONFADDR in skywire.conf")
 	cmd.Flags().StringVar(&v.SvcConf, "svcconf", "", "fallback service-configuration file path — writes SVCCONF in skywire.conf")
 	cmd.Flags().IntVar(&v.MinSess, "minsess", 0, "number of dmsg servers to connect to (0 = unlimited; leave unset to keep default 2) — writes MINDMSGSESS in skywire.conf")
-	cmd.Flags().IntVar(&v.MaxTransports, "maxtransports", 0, "public visor transport limit — deregister from the address resolver once this many transports exist (0 = leave unset; default 1000) — writes MAXTRANSPORTS in skywire.conf")
+	cmd.Flags().IntVar(&v.MaxTransports, "maxtransports", 0, "public visor peer limit — pause service-discovery registration once this many DISTINCT PEERS are connected, resuming when it drops (0 = leave unset; default 2048) — writes MAXTRANSPORTS in skywire.conf")
 	cmd.Flags().StringVar(&v.StunServers, "stun", "", "STUN servers, comma-separated — writes STUNSERVERS in skywire.conf")
 
 	// --- Transport ports ---
@@ -290,7 +290,7 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().IntVar(&v.SudphPort, "sudph", 0, "sudp transport listening port (0 = leave unchanged, random at runtime) — writes SUDPHPORT in skywire.conf")
 	cmd.Flags().IntVar(&v.TransportPort, "transport-port", 0, "ONE shared master port for ALL transport types — stcpr+WS on <port>/tcp, sudph+quic+wt+webrtc on <port>/udp (0 = per-type ports) — writes TRANSPORTPORT in skywire.conf")
 	cmd.Flags().IntVar(&v.MinHops, "min-hops", 1, "minimum route hops — 1 = allow direct 1-hop routes, >=2 = force multihop through intermediaries for sender privacy — writes MINHOPS in skywire.conf")
-	cmd.Flags().IntVar(&v.ARTransportLimit, "ar-transport-limit", 0, "address-resolver registration: 0 = stay registered, N>0 = deregister after N transports, N<0 = never register (inbound-invisible) — writes ARTRANSPORTLIMIT in skywire.conf")
+	cmd.Flags().IntVar(&v.ARTransportLimit, "ar-transport-limit", 0, "address-resolver registration: >=0 = register (default), <0 = never register (inbound-invisible). Only the sign is used; a positive value does NOT deregister after N transports — writes ARTRANSPORTLIMIT in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoDirectTransports, "no-direct-transports", false, "never create direct p2p transports; dmsg relay still allowed — writes NODIRECTTRANSPORTS=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.PtyRPCExec, "pty-rpc-exec", false, "allow visor-RPC-initiated dmsgpty exec (control/jump node opt-in; off closes a local privilege-escalation vector) — writes PTYRPCEXEC=true in skywire.conf")
 	cmd.Flags().IntVar(&v.LanDmsgPort, "lan-dmsg-port", 0, "LAN dmsg-server listening port (0 = leave unchanged) — writes LANDMSGPORT in skywire.conf")
@@ -431,7 +431,7 @@ var envMap = map[string]EnvMapping{
 	"url":           {Key: "SVCCONFADDR", Format: EnvFormatBashArray},
 	"svcconf":       {Key: "SVCCONF", Format: EnvFormatString},
 	"minsess":       {Key: "MINDMSGSESS", Format: EnvFormatInt, Default: "2"},
-	"maxtransports": {Key: "MAXTRANSPORTS", Format: EnvFormatInt, Default: "1000"},
+	"maxtransports": {Key: "MAXTRANSPORTS", Format: EnvFormatInt, Default: "2048"},
 	"stun":          {Key: "STUNSERVERS", Format: EnvFormatBashArray},
 
 	// Transport ports. 0 = OS-assigned random port at runtime;

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -589,11 +589,16 @@ type Transport struct {
 	// wt_table). Lets a visor DIAL a QUIC transport to a configured peer with no
 	// address-resolver lookup. Consulted before the AR; empty/omitted = AR-only.
 	QUICTable map[cipher.PubKey]string `json:"quic_table,omitempty"`
-	// ARTransportLimit controls address resolver registration for privacy:
-	//   0 (default): stay registered indefinitely
-	//   N > 0: deregister from AR after N transports are established
-	//   N < 0: never register with AR at all
-	// When deregistered, the visor cannot receive new inbound transports
+	// ARTransportLimit controls address resolver registration for privacy.
+	// Only its SIGN is meaningful — it is a static switch, not a counter:
+	//   >= 0 (default): register with the address resolver
+	//   <  0: never register with AR at all
+	// A positive value does NOT deregister after N transports. That was
+	// deliberately not implemented: a running visor must never drop its AR
+	// registration on a transport count, because AR discoverability is what
+	// lets peers dial it. Runtime load-shedding is a separate mechanism —
+	// the public-visor service-discovery drain (PublicVisorConfig.MaxTransports).
+	// When never-registered, the visor cannot receive new inbound transports
 	// but can still initiate outbound connections.
 	ARTransportLimit int `json:"ar_transport_limit,omitempty"`
 	// NoDirectTransports, when true, stops the visor from CREATING direct
@@ -765,11 +770,12 @@ type PublicVisorConfig struct {
 	// Default: 10m
 	RegistrationTimeout Duration `json:"registration_timeout,omitempty"`
 
-	// MaxTransports is the maximum transport count before deregistering from
-	// service discovery. Once reached, the visor has served its purpose of
-	// bootstrapping other visors and deregisters to make room for others.
-	// Set to 0 to never deregister based on transport count.
-	// Default: 1000
+	// MaxTransports is the DISTINCT-PEER count at which a public visor
+	// drain-pauses its service-discovery registration, resuming when the
+	// count drops back below it. It counts unique remote visors, not raw
+	// transports — several transport types to the same peer count as one.
+	// Set to 0 to never drain based on peer count.
+	// Default: PublicVisorMaxTransports (2048).
 	MaxTransports int `json:"max_transports,omitempty"`
 }
 


### PR DESCRIPTION
Two config fields are documented as doing something they do not do, and both
errors surface in `--help`.

**`ar_transport_limit`** is documented as "N > 0: deregister from AR after N
transports are established". No counter exists — only the sign is read
(`Manager.ShouldRegisterAR`), and `manager.go:51-61` records that the counting
behaviour was deliberately *not* implemented, since a visor that drops its AR
registration stops being dialable. An operator who sets `50` for the documented
privacy behaviour gets ordinary registration and no warning.

**`max_transports`** is documented as a raw transport count defaulting to 1000.
It is a *distinct-peer* count, the generated config writes
`PublicVisorMaxTransports` (2048), and it drain-*pauses* service-discovery
registration — resuming when the count drops — rather than deregistering.

Fixes the struct comments plus the places the same text reaches users: the two
flag descriptions, the install-page default hint, and the commented
`MAXTRANSPORTS` examples in the env files.

Comments and help strings only; no behaviour change. `go build .` passes.