### PR TITLE
fix(visor): an unconfigured log level meant debug, not info

### DIFF
--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -39,6 +39,7 @@ import (
 	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/serviceuptime"
 	skycall "github.com/skycoin/skywire/pkg/skychat/call"
+	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/transport/network"
 	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
@@ -782,9 +783,21 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1, logBcast *logging.Broad
 	v.isAutoconnectHealthy.init()
 	v.isTransportabilityHealthy.init()
 
+	// An absent log_level means "unconfigured", so fall back to the SAME
+	// default config generation uses — skyenv.LogLevel ("info"), documented
+	// there as "the default log level of the visor". This used to fall back to
+	// "debug", so any config that reached the visor without the field ran at
+	// debug forever while every other layer said the default was info.
+	//
+	// It bites hardest in the browser: measured on the wasm desk, the visor
+	// emitted 11.6 log lines/sec of which 75% were DEBUG — string formatting
+	// and allocation nobody reads, on a single-threaded runtime where the Go
+	// heap's peak is never returned to the host. The wasm config writer
+	// (pkg/skywireconfig/genvisor/marshal_js.go) writes LogLevel verbatim with
+	// no default of its own, which is one way to arrive here empty.
 	logLevel := conf.LogLevel
 	if logLevel == "" {
-		logLevel = "debug"
+		logLevel = skyenv.LogLevel
 	}
 	if logLvl, err := logging.LevelFromString(logLevel); err != nil {
 		v.log.WithError(err).Warn("Failed to read log level from config.")


### PR DESCRIPTION
A config that reaches the visor without `log_level` fell back to a hardcoded
`"debug"` and ran there forever, while every other layer said the default was
info — `skyenv.LogLevel` is `"info"` and documents itself as *"the default log
level of the visor"*, and `cli config gen` resolves `${LOGLVL:-info}`.

Measured on the wasm desk, from the visor's own log ring over a 50s window:

| | lines/sec | DEBUG | INFO | WARN |
|---|---|---|---|---|
| before | 11.6 | 438 (75%) | 3 | 57 |
| after | **1.7** | **0** | 39 | 14 |

An 85% cut. The DEBUG traffic was `transport_manager` 188,
`public_autoconnect` 110, `webrtc` 78, `stcpr` 43 — formatting nobody reads, on
a single-threaded runtime whose Go heap peak is never returned to the host, so
the cost is permanent rather than transient.

The wasm config writer (`genvisor/marshal_js.go`) writes `LogLevel` verbatim
with no default of its own, which is one way to arrive here empty; fixing the
fallback rather than that one writer covers every path that can.

Validated on a rebuilt desk, not just compiled.