### PR TITLE
perf(visor): default GOGC to 50 on wasm, where a heap peak is permanent

### DIFF
--- a/pkg/visor/gctune_js.go
+++ b/pkg/visor/gctune_js.go
@@ -1,0 +1,52 @@
+//go:build js && wasm
+
+// Package visor pkg/visor/gctune_js.go c3-vis-core
+package visor
+
+import (
+	"os"
+	"runtime/debug"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// wasmDefaultGCPercent is the GOGC value a browser visor runs at when the
+// operator has not chosen one.
+//
+// WHY THIS DIFFERS FROM NATIVE. Go's wasm linear memory only ever GROWS:
+// WebAssembly.Memory.grow() is one-way and the runtime never returns pages to
+// the host. So on wasm the heap's PEAK is a permanent cost — the tab keeps the
+// high-water mark for its whole life, however small the live set later becomes.
+// Natively the same peak is transient, because the OS reclaims.
+//
+// GOGC sizes the heap as roughly (1 + GOGC/100) x live-after-GC, so the default
+// of 100 reserves ~2x the peak live set and keeps it forever. Measured on the
+// :8443 desk (2026-09-08): mem_heap_sys 848 MB against 285 MB live — a 3:1
+// ratio, consistent with a ~420 MB peak at GOGC=100. At 50 the same peak
+// reserves ~630 MB, ~218 MB less, permanently.
+//
+// 50 rather than lower: GOGC trades CPU for memory proportionally, and the
+// browser visor's CPU budget is the scarcer resource of the two (a wasm visor
+// shares ONE thread with nothing to steal work). 50 costs a modest increase in
+// GC frequency against a large permanent memory saving; going much below it
+// starts to matter on a single-threaded runtime.
+//
+// Deliberately NOT GOMEMLIMIT: that is a soft limit, and a live set that
+// approaches it makes the collector run continuously without ever satisfying
+// it — trading a memory problem for a worse CPU one on the exact runtime that
+// can least afford it. GOGC has no such failure mode. memory_limit remains
+// available for an operator who wants a hard ceiling.
+const wasmDefaultGCPercent = 50
+
+// applyGCTuning sets the wasm GOGC default, unless the operator already chose
+// one. GOGC is read directly rather than inferred from SetGCPercent's previous
+// value, so an explicit GOGC=100 is honored as a choice rather than mistaken
+// for the unset default.
+func applyGCTuning(log *logging.Logger) {
+	if os.Getenv("GOGC") != "" {
+		return
+	}
+	prev := debug.SetGCPercent(wasmDefaultGCPercent)
+	log.Infof("GOGC set to %d for wasm (was %d): linear memory is never returned to the host, so heap PEAK is permanent",
+		wasmDefaultGCPercent, prev)
+}

--- a/pkg/visor/gctune_native.go
+++ b/pkg/visor/gctune_native.go
@@ -1,0 +1,11 @@
+//go:build !(js && wasm)
+
+// Package visor pkg/visor/gctune_native.go c3-vis-core
+package visor
+
+import "github.com/skycoin/skywire/pkg/logging"
+
+// applyGCTuning is a no-op off wasm: the OS reclaims a transient heap peak, so
+// the default GOGC needs no platform override. See gctune_js.go for why wasm
+// does. GOGC itself still works everywhere.
+func applyGCTuning(*logging.Logger) {}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -812,6 +812,8 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1, logBcast *logging.Broad
 
 	// Set Go memory limit based on config
 	applyMemoryLimit(v.log, conf.MemoryLimit)
+	// Platform GC default (wasm keeps its heap peak forever; see gctune_js.go).
+	applyGCTuning(v.log)
 	if isStoreLog {
 		storeLog(conf)
 	}


### PR DESCRIPTION
Go's wasm linear memory only ever grows — `WebAssembly.Memory.grow()` is one-way
and the runtime never returns pages to the host. So on wasm the heap's **peak**
is a permanent cost: the tab keeps the high-water mark for its whole life
however small the live set later becomes. Natively that peak is transient
because the OS reclaims, which is why the stock default is right there and wrong
here.

GOGC sizes the heap at roughly `(1 + GOGC/100) x live-after-GC`, so the default
of 100 reserves ~2x the peak live set forever — and it compounds, because each
new peak ratchets it up again. Measured on the :8443 desk via the visor's own
`RuntimeStats`:

| | live | heapSys | ratio |
|---|---|---|---|
| GOGC=100, 9.5h uptime | 319 MB | 1370 MB | **4.30** |
| GOGC=50, fresh boot | 20 MB | 30 MB | **1.56** |

1.56 against the 1.5 the formula predicts. The 4.30 is a gigabyte of heap
reserved and unused, implying a peak live set near 685 MB the tab can never give
back.

**50 rather than lower** because GOGC trades CPU for memory proportionally, and
a browser visor's CPU budget is the scarcer of the two — it shares one thread
with nothing to steal work.

**Deliberately not `GOMEMLIMIT`.** That is a soft limit, and a live set that
approaches it makes the collector run continuously without ever satisfying it —
trading a memory problem for a worse CPU one on the runtime least able to absorb
it. GOGC has no such failure mode. The existing `memory_limit` config is
untouched for operators who want a hard ceiling.

Native is an explicit no-op; an operator-set `GOGC` is honoured, read from the
environment directly so an explicit `GOGC=100` counts as a choice rather than
being mistaken for the unset default.

The ratio confirms the setting takes effect. Whether it holds at ~1.5 as the
live set grows over hours is still being measured against a recorded cold-start
baseline (659 MB -> 1405 MB over ~40 min at GOGC=100); I'll report that number
here either way.