### PR TITLE
fix(visor): embedded setup nodes connected to every dmsg server, forever

### DIFF
--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -425,8 +425,18 @@ func initEmbeddedRouteSetup(ctx context.Context, v *Visor, log *logging.Logger) 
 
 	// Create a separate dmsg client with the route setup-node identity.
 	// Reuses the visor's dmsg discovery URL but with route setup-node keys.
+	// MinSessions follows the visor's own sessions_count rather than 0. Zero
+	// means "connect to every server in the deployment" AND disables the
+	// idle-session reaper (reapIdleSessionsLoop returns immediately at <=0), so
+	// this client's sessions only ever grow — see initEmbeddedTransportSetup for
+	// the measured numbers. Reachability does not depend on it: peers dial this
+	// client via the delegated servers in its own discovery entry.
+	rsMinSessions := 0
+	if v.conf.Dmsg != nil {
+		rsMinSessions = v.conf.Dmsg.SessionsCount
+	}
 	dmsgConf := &dmsg.Config{
-		MinSessions: 0, // Connect to all servers for better connectivity
+		MinSessions: rsMinSessions,
 		Protocol:    v.conf.Dmsg.Protocol,
 	}
 	dmsgConf.ClientType = "route_setup"

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -705,8 +705,25 @@ func initEmbeddedTPS(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 	// Create a separate dmsg client with the TPS identity.
 	// Reuses the visor's dmsg discovery URL but with TPS keys.
-	// Default: MinSessions=0 (connect to ALL servers), ServerType="" (all types).
+	//
+	// MinSessions defaults to the VISOR's own sessions_count, not 0. Zero means
+	// "connect to every server in the deployment" AND disables the idle-session
+	// reaper (reapIdleSessionsLoop returns immediately at <=0), so the setup
+	// node's sessions only ever grow. Measured on a visor with
+	// sessions_count: 2 — the main client held 6 sessions while this one held 9,
+	// one per server in the deployment, permanently.
+	//
+	// Connect-to-all was never needed for reachability: a dmsg client is dialed
+	// via the delegated servers published in its own discovery entry, so peers
+	// find it through those regardless of how many it holds. What connect-to-all
+	// buys is a rendezvous shortcut; what it costs is N_visors x N_servers
+	// connections across the fleet, which is the shape that does not scale.
+	// transport.tps_dmsg.min_sessions still overrides for a deployment that
+	// wants the old behavior (0 = all).
 	minSessions := 0
+	if v.conf.Dmsg != nil {
+		minSessions = v.conf.Dmsg.SessionsCount
+	}
 	serverType := ""
 	if tpsDmsgConf := v.conf.Transport.TPSDmsg; tpsDmsgConf != nil {
 		minSessions = tpsDmsgConf.MinSessions


### PR DESCRIPTION
The embedded transport-setup and route-setup nodes each run their own dmsg
client, and both defaulted to `MinSessions=0`. That value does **two** things,
and the second is the one that hurts: it means "connect to every server in the
deployment", and it also disables the idle-session reaper, since
`reapIdleSessionsLoop` returns immediately at `<= 0`. Those clients' sessions
therefore only ever grow.

Measured on a visor configured with `dmsg.sessions_count: 2`, via
`skywire cli dmsg sessions`:

```
main             (0323272a…)   6 sessions
transport_setup  (03271c0de…)  9 sessions   <- one per server in the deployment
```

`sessions_count` only ever bounded the *main* client, which is why setting it
does not reduce the total — and the reaper (which does now exist, and correctly
closes streamless sessions above `MinSessions`) never ran on the client holding
the most.

Connect-to-all is only needed for reachability by a **direct** client with no
entry in the discovery. These two are not that: both build a `dmsgdisc` client
and publish their own entries, so peers dial them via their delegated servers
however many sessions they hold.

**Scope, stated small deliberately:** `tps_sk` is not generated by config gen,
so this affects only visors explicitly configured with an embedded setup node.
On a 25-visor deployment surveyed while writing this, exactly one visor ran one.
This is a per-visor correctness fix, not a fleet-wide one — an earlier draft of
this description claimed an `N_visors x N_servers` effect, which is wrong.

For context on the fleet-wide session counts (a *separate* matter this does not
address), across 25 online visors:

| track | visors | mean sessions | range |
|---|---|---|---|
| release v1.3.93 | 12 | 7.92 | 5-9 |
| develop | 13 | 5.38 | 3-8 |

The reaper already landed in develop and is measurably working. Neither track
reaches the configured 2, because on-demand rendezvous sessions that still carry
streams are correctly not reaped.

Both clients now default to the visor's own `sessions_count`.
`transport.tps_dmsg.min_sessions` still overrides for a deployment that wants the
old behaviour (`0` = all); the route-setup client had no such knob and simply
hardcoded 0.

Native and js/wasm both build.