### PR TITLE
feat(visor): expose per-session dmsg stream counts in visor state

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/sessions.go
+++ b/cmd/skywire-cli/commands/dmsg/sessions.go
@@ -64,7 +64,7 @@ func printDmsgSessions(result *visor.DmsgClientSessions) {
 		// reached over); fall back to bare PKs for older visors.
 		if len(info.Sessions) > 0 {
 			for _, s := range info.Sessions {
-				fmt.Printf("    %s  %s\n", s.PK, s.Protocol)
+				fmt.Printf("    %s  %s  %s\n", s.PK, s.Protocol, formatStreams(s.Streams))
 			}
 		} else {
 			for _, s := range info.Servers {
@@ -79,5 +79,22 @@ func printDmsgSessions(result *visor.DmsgClientSessions) {
 
 	if result.Main == nil && result.RouteSetup == nil && result.TransportSetup == nil {
 		fmt.Println("No dmsg clients running on this visor.")
+	}
+}
+
+// formatStreams renders a session's open mux stream count. "idle" is the state
+// the idle-session reaper looks for, so it is spelled out rather than printed
+// as a bare 0; "?" is an unmeasurable count (quic), which the reaper treats as
+// busy and never closes.
+func formatStreams(n int) string {
+	switch {
+	case n < 0:
+		return "? streams"
+	case n == 0:
+		return "idle"
+	case n == 1:
+		return "1 stream"
+	default:
+		return fmt.Sprintf("%d streams", n)
 	}
 }

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -333,19 +334,25 @@ var dmsgServersCmd = &cobra.Command{
 }
 
 func formatDMSGServers(servers []visor.DMSGServerInfo) string {
-	msg := "+--------------------------------------------------------------------+-------------+\n"
-	msg += fmt.Sprintf("| %-66s | %11s |\n", "Server Public Key", "Latency")
-	msg += "|--------------------------------------------------------------------+-------------|\n"
+	msg := "+--------------------------------------------------------------------+-------------+---------+\n"
+	msg += fmt.Sprintf("| %-66s | %11s | %7s |\n", "Server Public Key", "Latency", "Streams")
+	msg += "|--------------------------------------------------------------------+-------------+---------|\n"
 	for _, server := range servers {
 		latStr := "-"
 		if server.Latency > 0 {
 			latStr = fmt.Sprintf("%.1fms", float64(server.Latency.Milliseconds()))
 		}
-		msg += fmt.Sprintf("| %-66s | %11s |\n", server.PK.String(), latStr)
+		strStr := strconv.Itoa(server.Streams)
+		if server.Streams < 0 {
+			strStr = "?"
+		}
+		msg += fmt.Sprintf("| %-66s | %11s | %7s |\n", server.PK.String(), latStr, strStr)
 	}
-	msg += "+--------------------------------------------------------------------+-------------+\n"
+	msg += "+--------------------------------------------------------------------+-------------+---------+\n"
 	msg += "Note: Latency is measured via self-ping through each server.\n"
 	msg += "Servers with '-' latency have not been measured yet (wait ~5s after startup).\n"
+	msg += "Streams is the session's open mux stream count: 0 = idle (reapable once\n"
+	msg += "over dmsg.sessions_count), '?' = unmeasurable (quic), treated as busy.\n"
 	return msg
 }
 

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -1277,7 +1277,7 @@ func (s visorSelf) SelfSummary() wasmhv.Summary {
 	if dmsgC != nil {
 		for _, cs := range dmsgC.AllSessions() {
 			srv := cs.RemotePK()
-			dmsgServers = append(dmsgServers, wasmhv.DMSGServerInfo{PK: srv, Carrier: cs.Carrier(), Protocol: cs.Protocol()})
+			dmsgServers = append(dmsgServers, wasmhv.DMSGServerInfo{PK: srv, Carrier: cs.Carrier(), Protocol: cs.Protocol(), Streams: cs.NumStreams()})
 			if primarySrv == (cipher.PubKey{}) {
 				primarySrv = srv
 			}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -817,6 +817,14 @@ type DMSGServerInfo struct {
 	// UI show HOW each server was reached, not just that it was.
 	Carrier  string `json:"carrier,omitempty"`
 	Protocol string `json:"protocol,omitempty"`
+	// Streams is the number of open mux streams on this session: 0 = idle (a
+	// candidate for the idle-session reaper once it is over min_sessions), >0 =
+	// carrying traffic, -1 = unmeasurable (quic, or no session matched this
+	// server PK) which the reaper treats as busy. This is the same count
+	// reapExcessIdleSessions decides on, so an operator seeing more sessions
+	// than sessions_count can tell whether they are legitimately in use or the
+	// reaper is not doing its job.
+	Streams int `json:"streams"`
 }
 
 // DmsgClientSessions enumerates every dmsg client running inside the visor
@@ -855,6 +863,9 @@ type DmsgServerSession struct {
 	Protocol string `json:"protocol"`
 	// Address is the endpoint the carrier dialed (host:port or ws(s)://…).
 	Address string `json:"address,omitempty"`
+	// Streams is the number of open mux streams on this session (0 = idle,
+	// -1 = unmeasurable/quic). Same count the idle-session reaper uses.
+	Streams int `json:"streams"`
 }
 
 // DmsgHTTPRequest represents an HTTP request to be made over dmsg

--- a/pkg/visor/api_dmsg.go
+++ b/pkg/visor/api_dmsg.go
@@ -533,11 +533,18 @@ func (v *Visor) DMSGServers() ([]DMSGServerInfo, error) {
 	// Map each server PK to the carrier/protocol of its live session, so the UI
 	// can show HOW the visor reached each server (tcp/ws/wt/quic), not just that
 	// it did — the same data `cli dmsg sessions` reports.
+	//
+	// The open-stream count of each session comes along for the ride: it is the
+	// number reapExcessIdleSessions decides on, and without it an operator
+	// holding more sessions than dmsg.sessions_count cannot tell a session
+	// legitimately carrying streams from an idle one the reaper failed to close.
 	carrier := make(map[cipher.PubKey]string)
 	protocol := make(map[cipher.PubKey]string)
+	streams := make(map[cipher.PubKey]int)
 	for _, s := range v.dmsgC.AllSessions() {
 		carrier[s.RemotePK()] = s.Carrier()
 		protocol[s.RemotePK()] = s.Protocol()
+		streams[s.RemotePK()] = s.NumStreams()
 	}
 
 	// Build list with latencies
@@ -548,11 +555,18 @@ func (v *Visor) DMSGServers() ([]DMSGServerInfo, error) {
 		if err := pk.Set(pkStr); err != nil {
 			continue
 		}
+		// No matching session means the count is unknown, not zero: -1 keeps
+		// "unmeasurable" distinct from "idle", as NumStreams itself does.
+		n, ok := streams[pk]
+		if !ok {
+			n = -1
+		}
 		info := DMSGServerInfo{
 			PK:       pk,
 			Latency:  v.dmsgLatency.servers[pk],
 			Carrier:  carrier[pk],
 			Protocol: protocol[pk],
+			Streams:  n,
 		}
 		servers = append(servers, info)
 	}
@@ -733,6 +747,7 @@ func dmsgClientServerSessions(c *dmsg.Client) ([]cipher.PubKey, []DmsgServerSess
 			Carrier:  s.Carrier(),
 			Protocol: s.Protocol(),
 			Address:  s.CarrierAddr(),
+			Streams:  s.NumStreams(),
 		})
 	}
 	sort.Slice(sessions, func(i, j int) bool { return sessions[i].PK.String() < sessions[j].PK.String() })

--- a/pkg/wasmhv/core.go
+++ b/pkg/wasmhv/core.go
@@ -137,6 +137,9 @@ type DMSGServerInfo struct {
 	// visor.DMSGServerInfo so the shared node UI shows the connection type.
 	Carrier  string `json:"carrier,omitempty"`
 	Protocol string `json:"protocol,omitempty"`
+	// Streams is the session's open mux stream count (0 = idle, -1 =
+	// unmeasurable). Mirrors visor.DMSGServerInfo.
+	Streams int `json:"streams"`
 }
 
 // Summary mirrors the scalar fields of visor.Summary the node table reads.


### PR DESCRIPTION
A visor configured with `dmsg.sessions_count: 2` was observed holding 5-8 sessions. The idle-session reaper (`reapExcessIdleSessions`) already decides on each session's open mux stream count, but that number was not exposed anywhere, so there was no way to tell whether the excess sessions were legitimately carrying streams or idle ones the reaper had failed to close.

Adds a `streams` field to `visor.DMSGServerInfo` — `summary.dmsg_servers[]` in `skywire cli visor state --json` — and to `visor.DmsgServerSession` (`skywire cli dmsg sessions`), populated from `SessionCommon.NumStreams()`, the same count the reaper uses. `0` = idle, `>0` = in use, `-1` = unmeasurable (quic, or no session matched that server PK), which the reaper treats as busy. Also rendered in the `cli visor info --dmsg` table and the `cli dmsg sessions` human output, and mirrored in `wasmhv.DMSGServerInfo`.

Additive JSON fields only; no RPC method added.

Verified: `go build .`; `GOOS=js GOARCH=wasm go build -mod=vendor -tags withoutsystray,withoutgotop ./pkg/visor/`; `go vet` and `go test` on `pkg/visor`, `pkg/dmsg/dmsg`, `cmd/skywire-cli` (incl. the jsoncontract checks) and the two touched CLI command packages. Not verified against a live visor.