### PR TITLE
fix(visor): proxy-exit verification passed on the interstitial it minted itself

### DIFF
--- a/pkg/proxyinterstitial/interstitial.go
+++ b/pkg/proxyinterstitial/interstitial.go
@@ -189,6 +189,43 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#7a80a8;--accent:#7c83ff;--
 	`.ready{color:var(--accent);margin:12px 0 0;font-size:13px;font-weight:600}` +
 	`.err #mesh-title{color:var(--err)}.err .sp{display:none}`
 
+// MarkerHeader labels every HTTP response THIS package synthesises in-process —
+// the waiting interstitial and the fall-through reload page. Both are minted by
+// the local skysocks-client when it cannot reach the exit, yet on the wire they
+// are indistinguishable from an ordinary relayed "HTTP/1.1 200 OK" with an HTML
+// body. Anything that has to tell "the exit really relayed this" from "our own
+// client answered for it" — the visor's end-to-end proxy-exit verification, for
+// one — is otherwise fooled by the very page it triggered. The header makes the
+// distinction explicit; see IsSyntheticResponse.
+const MarkerHeader = "X-Skywire-Interstitial"
+
+// markerHeaderLine is MarkerHeader as a ready-to-write response header line.
+const markerHeaderLine = MarkerHeader + ": 1\r\n"
+
+// IsSyntheticResponse reports whether raw HTTP response bytes were synthesised
+// by this package rather than relayed from a real exit. It checks MarkerHeader
+// first and falls back to sniffing the two page bodies for their distinctive
+// markup, so a NEWER verifier still recognises a page served by an OLDER
+// skysocks-client build that predates the header. raw may be a prefix of the
+// response (callers commonly read a bounded first chunk), so the sniff runs
+// over whatever was supplied.
+func IsSyntheticResponse(raw []byte) bool {
+	head := raw
+	if i := bytes.Index(raw, []byte("\r\n\r\n")); i >= 0 {
+		head = raw[:i]
+	}
+	for _, line := range bytes.Split(head, []byte("\r\n")) {
+		name, _, ok := bytes.Cut(line, []byte(":"))
+		if ok && strings.EqualFold(strings.TrimSpace(string(name)), MarkerHeader) {
+			return true
+		}
+	}
+	// Pre-header fallbacks: the interstitial's wrapper element and the reload
+	// page's self-re-request. Both are unique to the pages minted here.
+	return bytes.Contains(raw, []byte(`id="mesh-boot"`)) ||
+		bytes.Contains(raw, []byte("location.replace(location.href)"))
+}
+
 // httpResponse wraps the HTML in a minimal HTTP/1.1 response. Connection:close
 // so the browser tears the socket down and honors the meta-refresh cleanly;
 // no-store so a transient page is never cached in place of the real content.
@@ -202,6 +239,7 @@ func httpResponse(target, detail, mechanism string, isError bool) []byte {
 	fmt.Fprintf(&b, "HTTP/1.1 %s\r\n", status)
 	b.WriteString("Content-Type: text/html; charset=utf-8\r\n")
 	fmt.Fprintf(&b, "Content-Length: %d\r\n", len(bodyStr))
+	b.WriteString(markerHeaderLine)
 	b.WriteString("Cache-Control: no-store, must-revalidate\r\n")
 	b.WriteString("Connection: close\r\n")
 	b.WriteString("\r\n")
@@ -409,6 +447,7 @@ func reloadHTTPResponse() []byte {
 	b.WriteString("HTTP/1.1 200 OK\r\n")
 	b.WriteString("Content-Type: text/html; charset=utf-8\r\n")
 	fmt.Fprintf(&b, "Content-Length: %d\r\n", len(body))
+	b.WriteString(markerHeaderLine)
 	b.WriteString("Cache-Control: no-store, must-revalidate\r\n")
 	b.WriteString("Connection: close\r\n\r\n")
 	b.WriteString(body)

--- a/pkg/proxyinterstitial/interstitial_test.go
+++ b/pkg/proxyinterstitial/interstitial_test.go
@@ -367,3 +367,81 @@ func TestPageMechanismAndSteps(t *testing.T) {
 		}
 	}
 }
+
+// TestSyntheticMarker pins the header that lets a caller tell a page minted in
+// this process from a reply actually relayed by an exit. Both synthetic
+// responses must carry it, and IsSyntheticResponse must accept it as well as
+// the pre-header body markers an older client build would emit.
+func TestSyntheticMarker(t *testing.T) {
+	t.Run("interstitial response carries the marker", func(t *testing.T) {
+		cli, srv := net.Pipe()
+		defer cli.Close() //nolint:errcheck
+		done := make(chan error, 1)
+		go func() { done <- ServeSOCKS5(srv, "", "skysocks", nil, nil); srv.Close() }() //nolint:errcheck,gosec
+		got := serveSOCKS5CONNECT(t, cli, "example.com", 80)
+		if !strings.Contains(got, MarkerHeader+": 1\r\n") {
+			t.Errorf("interstitial response is missing %s", MarkerHeader)
+		}
+		if !IsSyntheticResponse([]byte(got)) {
+			t.Error("IsSyntheticResponse rejected the interstitial response")
+		}
+		if err := <-done; err != nil {
+			t.Errorf("ServeSOCKS5: %v", err)
+		}
+	})
+
+	t.Run("reload fall-through carries the marker", func(t *testing.T) {
+		cli, srv := net.Pipe()
+		defer cli.Close() //nolint:errcheck
+		done := make(chan error, 1)
+		go func() { done <- ServeSOCKS5(srv, "", "skysocks", nil, func() bool { return true }); srv.Close() }() //nolint:errcheck,gosec
+		got := serveSOCKS5CONNECT(t, cli, "example.com", 80)
+		if !strings.Contains(got, MarkerHeader+": 1\r\n") {
+			t.Errorf("reload response is missing %s", MarkerHeader)
+		}
+		if !IsSyntheticResponse([]byte(got)) {
+			t.Error("IsSyntheticResponse rejected the reload response")
+		}
+		if err := <-done; err != nil {
+			t.Errorf("ServeSOCKS5: %v", err)
+		}
+	})
+
+	t.Run("Conn response carries the marker", func(t *testing.T) {
+		c := Conn("example.com", "", "skysocks", false)
+		raw, err := io.ReadAll(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !IsSyntheticResponse(raw) {
+			t.Error("IsSyntheticResponse rejected the Conn response")
+		}
+	})
+
+	t.Run("classification", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			raw  string
+			want bool
+		}{
+			"relayed page": {
+				"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<html><body>hi</body></html>", false,
+			},
+			"header, case-insensitive": {
+				"HTTP/1.1 200 OK\r\nx-skywire-interstitial: 1\r\n\r\n<html></html>", true,
+			},
+			"older build, interstitial body only": {
+				"HTTP/1.1 200 OK\r\n\r\n<body><div id=\"mesh-boot\"><div class=\"card\">", true,
+			},
+			"older build, reload body only": {
+				"HTTP/1.1 200 OK\r\n\r\n<script>location.replace(location.href)</script>", true,
+			},
+			"marker-looking text in the body only is not a header": {
+				"HTTP/1.1 200 OK\r\n\r\nX-Skywire-Interstitial: 1 (quoted in an article)", false,
+			},
+		} {
+			if got := IsSyntheticResponse([]byte(tc.raw)); got != tc.want {
+				t.Errorf("%s: IsSyntheticResponse = %v, want %v", name, got, tc.want)
+			}
+		}
+	})
+}

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -3,13 +3,16 @@
 package visor
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	mathrand "math/rand"
 	"mime"
 	"net"
 	nrpc "net/rpc"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -29,6 +32,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
+	"github.com/skycoin/skywire/pkg/proxyinterstitial"
 	"github.com/skycoin/skywire/pkg/proxystatus"
 	"github.com/skycoin/skywire/pkg/pty"
 	"github.com/skycoin/skywire/pkg/router"
@@ -222,9 +226,13 @@ func (v *Visor) autoStartProxyClient(log *logging.Logger, pinned bool) {
 		}
 		if v.verifyProxyExit(ctx, log) {
 			log.Info("Configured proxy exit verified end to end")
-			return
+			if !v.holdVerifiedProxyExit(ctx, log) {
+				return
+			}
+			log.Warn("configured proxy exit stopped relaying; rotating to discovery")
+		} else {
+			log.Warn("configured proxy exit failed end-to-end verification; rotating to discovery")
 		}
-		log.Warn("configured proxy exit failed end-to-end verification; rotating to discovery")
 		_ = v.StopSkysocksClients() //nolint:errcheck
 	}
 	for {
@@ -257,11 +265,54 @@ func (v *Visor) autoStartProxyClient(log *logging.Logger, pinned bool) {
 			}
 			if v.verifyProxyExit(ctx, log) {
 				log.WithField("exit", pk).Info("Proxy client auto-started on a VERIFIED exit")
-				return
+				if !v.holdVerifiedProxyExit(ctx, log) {
+					return
+				}
+				log.WithField("exit", pk).Warn("verified proxy exit stopped relaying; rotating")
+			} else {
+				log.WithField("exit", pk).Warn("proxy-client exit failed end-to-end verification; rotating")
 			}
-			log.WithField("exit", pk).Warn("proxy-client exit failed end-to-end verification; rotating")
 			_ = v.StopSkysocksClients() //nolint:errcheck
 		}
+	}
+}
+
+// proxyExitRecheckInterval is how often an already-VERIFIED exit is re-probed.
+// Verification is cheap but not free — it fetches a small clearnet page through
+// the exit — and an exit that is relaying is the common case, so this is
+// deliberately slow: half an hour bounds how long a visor can sit on an exit
+// that died AFTER it was accepted (previously: forever) without turning a
+// healthy exit into a metronome of extra traffic, and without risking a rotation
+// off a working exit because of one unlucky probe during a route hiccup —
+// verifyProxyExit already retries for 90s internally before it gives a verdict.
+const proxyExitRecheckInterval = 30 * time.Minute
+
+// proxyVerifyReadLimit bounds how much of the verification response is read.
+// It has to clear the interstitial's `id="mesh-boot"` wrapper (~3 KiB in, past
+// the inlined CSS and cloud image) so the pre-header fallback marker is still
+// seen when the page comes from an older skysocks-client build.
+const proxyVerifyReadLimit = 4096
+
+// holdVerifiedProxyExit keeps a verified exit in place, re-verifying it every
+// proxyExitRecheckInterval. It returns true when the exit has stopped relaying
+// and the caller should rotate, and false when the visor is shutting down. A
+// single verification pass only proves the exit worked at that instant; without
+// this the visor would stay pinned to an exit that died later — the same
+// failure end-to-end verification exists to prevent, just deferred.
+func (v *Visor) holdVerifiedProxyExit(ctx context.Context, log *logging.Logger) bool {
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(proxyExitRecheckInterval):
+		}
+		if !v.verifyProxyExit(ctx, log) {
+			if ctx.Err() != nil {
+				return false
+			}
+			return true
+		}
+		log.Debug("proxy exit re-verified end to end")
 	}
 }
 
@@ -271,6 +322,13 @@ func (v *Visor) autoStartProxyClient(log *logging.Logger, pinned bool) {
 // on the page's virtual loopback and a native visor's on the real one. Route
 // establishment can take a while on a fresh visor, so it retries within a
 // bounded window before giving the verdict.
+//
+// The response is VALIDATED, not merely counted: when every tunnel is down the
+// skysocks client answers a plaintext-HTTP CONNECT itself with the branded
+// interstitial (pkg/skysocks: proxyinterstitial.ServeSOCKS5 on a nil session),
+// and port 80 is exactly that case — so "some bytes arrived" is satisfied by a
+// page this visor just generated for itself, which would certify a dead exit as
+// working. See relayedResponseOK.
 func (v *Visor) verifyProxyExit(ctx context.Context, log *logging.Logger) bool {
 	deadline := time.Now().Add(90 * time.Second)
 	for time.Now().Before(deadline) {
@@ -290,15 +348,44 @@ func (v *Visor) verifyProxyExit(ctx context.Context, log *logging.Logger) bool {
 		}
 		_ = conn.SetDeadline(time.Now().Add(15 * time.Second))                                         //nolint:errcheck
 		_, _ = conn.Write([]byte("GET / HTTP/1.0\r\nHost: neverssl.com\r\nConnection: close\r\n\r\n")) //nolint:errcheck
-		one := make([]byte, 16)
-		n, rerr := conn.Read(one)
+		// Read a bounded prefix, not one byte: the verdict needs the status line,
+		// the whole header block and enough body for the pre-header fallback
+		// marker, which sits ~3 KiB into the interstitial. The request asked for
+		// HTTP/1.0 + Connection: close, so this stops at EOF well before the cap
+		// on any real reply.
+		head := make([]byte, proxyVerifyReadLimit)
+		n, rerr := io.ReadFull(conn, head)
 		_ = conn.Close() //nolint:errcheck
-		if n > 0 {
+		if n > 0 && relayedResponseOK(head[:n]) {
 			return true
 		}
-		log.WithError(rerr).Debug("proxy verify: no response byte; retrying within window")
+		log.WithError(rerr).WithField("bytes", n).
+			Debug("proxy verify: no relayed HTTP response (locally synthesized or malformed); retrying within window")
 	}
 	return false
+}
+
+// relayedResponseOK reports whether the bytes read back through the skysocks
+// listener are a real reply RELAYED from the exit. Two things have to hold: it
+// must be a well-formed HTTP/1.x status line with a 2xx/3xx code (a zombie exit
+// that accepts the CONNECT and then relays nothing produces neither), and it
+// must not be one of the responses the local client synthesises when it has no
+// session — those are ordinary-looking 200s carrying an HTML page, and treating
+// one as proof of life is the bug this guards.
+func relayedResponseOK(raw []byte) bool {
+	line, _, ok := bytes.Cut(raw, []byte("\r\n"))
+	if !ok || !bytes.HasPrefix(line, []byte("HTTP/1.")) {
+		return false
+	}
+	f := bytes.Fields(line)
+	if len(f) < 2 {
+		return false
+	}
+	code, err := strconv.Atoi(string(f[1]))
+	if err != nil || code < 200 || code >= 400 {
+		return false
+	}
+	return !proxyinterstitial.IsSyntheticResponse(raw)
 }
 
 // vnetProxyDialer adapts bottle/vnet dialing to x/net/proxy's Dialer, so the

--- a/pkg/visor/init_apps_proxy_verify_test.go
+++ b/pkg/visor/init_apps_proxy_verify_test.go
@@ -1,0 +1,152 @@
+// Package visor pkg/visor/init_apps_proxy_verify_test.go c3-vis-core
+package visor
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/net/proxy"
+
+	"github.com/skycoin/skywire/pkg/proxyinterstitial"
+)
+
+// TestRelayedResponseOK covers the verdict verifyProxyExit turns into
+// "this exit works". The load-bearing case is the interstitial: with every
+// tunnel down the local skysocks-client answers a plaintext-HTTP CONNECT
+// itself with a perfectly ordinary-looking 200, so a check that only counts
+// bytes certifies a dead exit.
+func TestRelayedResponseOK(t *testing.T) {
+	interstitial := readAllInterstitial(t)
+
+	cases := map[string]struct {
+		raw  string
+		want bool
+	}{
+		"relayed 200":                      {"HTTP/1.1 200 OK\r\nServer: nginx\r\n\r\n<html>hi</html>", true},
+		"relayed 301":                      {"HTTP/1.1 301 Moved Permanently\r\nLocation: /x\r\n\r\n", true},
+		"relayed HTTP/1.0":                 {"HTTP/1.0 200 OK\r\n\r\nbody", true},
+		"upstream 404":                     {"HTTP/1.1 404 Not Found\r\n\r\n", false},
+		"upstream 502":                     {"HTTP/1.1 502 Bad Gateway\r\n\r\n", false},
+		"not HTTP at all":                  {"garbage bytes from a zombie exit", false},
+		"truncated status line":            {"HTTP/1.1 200 OK", false},
+		"status line without a code":       {"HTTP/1.1\r\n\r\n", false},
+		"non-numeric code":                 {"HTTP/1.1 OK OK\r\n\r\n", false},
+		"locally synthesized interstitial": {interstitial, false},
+		"older-build interstitial body": {
+			"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<body><div id=\"mesh-boot\">", false,
+		},
+	}
+	for name, tc := range cases {
+		if got := relayedResponseOK([]byte(tc.raw)); got != tc.want {
+			t.Errorf("%s: relayedResponseOK = %v, want %v", name, got, tc.want)
+		}
+	}
+}
+
+// readAllInterstitial renders the exact bytes the local skysocks-client writes
+// back when it has no session to the exit.
+func readAllInterstitial(t *testing.T) string {
+	t.Helper()
+	c := proxyinterstitial.Conn("neverssl.com", "", "skysocks", false)
+	buf := make([]byte, 4096)
+	n, _ := c.Read(buf) //nolint:errcheck
+	if n == 0 {
+		t.Fatal("interstitial rendered no bytes")
+	}
+	return string(buf[:n])
+}
+
+// TestRelayedResponseOKRejectsLiveInterstitial drives the REAL wire path the
+// bug ran through: a SOCKS5 client CONNECTs to a plaintext-HTTP target, the
+// local skysocks-client answers it in-process because it has no session to the
+// exit (proxyinterstitial.ServeSOCKS5), and the reply is read back exactly as
+// verifyProxyExit reads it. The verdict must be "not relayed".
+func TestRelayedResponseOKRejectsLiveInterstitial(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		exitReachable func() bool
+	}{
+		{"no session at all", nil},
+		{"transient failure, reload fall-through", func() bool { return true }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ln := newPipeListener()
+			defer ln.Close() //nolint:errcheck
+			go func() {
+				for {
+					c, err := ln.Accept()
+					if err != nil {
+						return
+					}
+					go func(c net.Conn) {
+						_ = proxyinterstitial.ServeSOCKS5(c, "", "skysocks", nil, tc.exitReachable) //nolint:errcheck
+						c.Close()                                                                   //nolint:errcheck
+					}(c)
+				}
+			}()
+
+			sd, err := proxy.SOCKS5("tcp", "socks.invalid:1080", nil, ln)
+			if err != nil {
+				t.Fatal(err)
+			}
+			conn, err := sd.Dial("tcp", "neverssl.com:80")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()                                                                             //nolint:errcheck
+			_ = conn.SetDeadline(time.Now().Add(5 * time.Second))                                          //nolint:errcheck
+			_, _ = conn.Write([]byte("GET / HTTP/1.0\r\nHost: neverssl.com\r\nConnection: close\r\n\r\n")) //nolint:errcheck
+			head := make([]byte, proxyVerifyReadLimit)
+			n, _ := io.ReadFull(conn, head) //nolint:errcheck
+			if n == 0 {
+				t.Fatal("no response from the interstitial path")
+			}
+			if relayedResponseOK(head[:n]) {
+				t.Errorf("locally synthesized response was accepted as a relayed reply:\n%q", head[:n])
+			}
+		})
+	}
+}
+
+// pipeListener is a net.Listener whose Dial hands back the client end of an
+// in-memory pipe, so it can also serve as the proxy.Dialer that reaches it.
+type pipeListener struct {
+	conns  chan net.Conn
+	closed chan struct{}
+}
+
+func newPipeListener() *pipeListener {
+	return &pipeListener{conns: make(chan net.Conn), closed: make(chan struct{})}
+}
+
+func (l *pipeListener) Dial(_, _ string) (net.Conn, error) {
+	cli, srv := net.Pipe()
+	select {
+	case l.conns <- srv:
+		return cli, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *pipeListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.conns:
+		return c, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *pipeListener) Close() error {
+	select {
+	case <-l.closed:
+	default:
+		close(l.closed)
+	}
+	return nil
+}
+
+func (l *pipeListener) Addr() net.Addr { return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)} }


### PR DESCRIPTION
`verifyProxyExit` accepted any first byte read back through the skysocks listener. With every tunnel down the local skysocks-client answers a plaintext-HTTP CONNECT in-process with the branded interstitial (`proxyinterstitial.ServeSOCKS5` on a nil session), and the probe targets port 80 — so the visor read a page it had just generated for itself, logged "Configured proxy exit verified end to end", and stayed pinned to a dead exit indefinitely. That is the failure the verification exists to prevent; observed live with a visor holding a dead exit for hours while skysocks-client sat in `starting`.

`proxyinterstitial` now stamps `X-Skywire-Interstitial: 1` on both responses it synthesises (the waiting interstitial and the reload fall-through) and exposes `IsSyntheticResponse`, which also sniffs the two page bodies so a newer verifier still recognises a page served by an older client build. `verifyProxyExit` reads a bounded prefix instead of one byte and requires an `HTTP/1.x` 2xx/3xx status line that is not synthetic.

A verified exit is now also re-probed every 30 minutes. A single pass only proves the exit worked at that instant, so an exit that died later never rotated. The interval is deliberately slow — `verifyProxyExit` already retries for 90s internally, so a route hiccup will not rotate a working exit.

Tests: new coverage in both packages, including one that drives the real SOCKS5 wire path through `ServeSOCKS5` and asserts the verifier rejects what comes back. `go test ./pkg/proxyinterstitial/` and `go test ./pkg/visor/ -run TestRelayedResponseOK` pass; `go build .` and `GOOS=js GOARCH=wasm go build ./pkg/visor/` are green. Not exercised against a live dead exit on the mesh.