### PR TITLE
fix(transport): don't offer webrtc where the runtime has no peer connection

### DIFF
--- a/cmd/wasm-visor/autoconnect_js.go
+++ b/cmd/wasm-visor/autoconnect_js.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall/js"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -359,10 +358,10 @@ func dialDirect(ctx context.Context, ar *arDmsg, pk cipher.PubKey, port uint16, 
 // RTCPeerConnection (page main thread / in-page boot) OR the main-thread bridge
 // (globalThis.__skywireRTC, installed by worker.js) that proxies it out of the Web
 // Worker where the wasm runtime runs. Absent both, WebRTC dials would fail, so the
-// autoconnect pass is skipped.
-func webrtcAvailable() bool {
-	return js.Global().Get("RTCPeerConnection").Truthy() || js.Global().Get("__skywireRTC").Truthy()
-}
+// autoconnect pass is skipped. The probe itself lives with the carrier
+// (network.WebRTCAvailable) so this and the transport manager's client
+// registration cannot drift apart.
+func webrtcAvailable() bool { return network.WebRTCAvailable() }
 
 var warnedWebRTCUnavailable bool
 

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -828,6 +828,12 @@ func (tm *Manager) hasActiveRoutes(tpID uuid.UUID) bool {
 func (tm *Manager) InitClient(ctx context.Context, netType types.Type, port int) {
 	client, err := tm.factory.MakeClient(netType, port)
 	if err != nil {
+		if errors.Is(err, network.ErrWebRTCUnavailable) {
+			// Expected on a runtime with no peer connection (a plain Web
+			// Worker): the type is simply not offered here, not broken.
+			tm.Logger.WithError(err).Infof("Not registering %s transport client in this runtime", netType)
+			return
+		}
 		// Do NOT install the result. MakeClient yields a nil client alongside
 		// its error, and storing that used to replace a perfectly good client
 		// with nothing — a failed re-init took down a working network type.

--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -166,6 +166,16 @@ func (f *ClientFactory) MakeClient(netType types.Type, port int) (Client, error)
 		}
 		return wc, nil
 	case types.WEBRTC:
+		// Capability probe, not a build tag: the same js/wasm binary HAS a peer
+		// connection on a page main thread (and through worker.js's __skywireRTC
+		// bridge in the hypervisor's SharedWorker) but has none in a plain Web
+		// Worker such as the desk's exec worker. Refusing the client there keeps
+		// WEBRTC out of tm.netClients, so IsKnownNetwork is false and
+		// public_autoconnect never queues dials that can only fail — instead of
+		// one "RTCPeerConnection unavailable in this runtime" per peer per cycle.
+		if !WebRTCAvailable() {
+			return nil, ErrWebRTCUnavailable
+		}
 		return newWebRTC(generic, f.DmsgC, f.ICEURLs), nil
 	case types.DMSG:
 		return newDmsgClient(f.DmsgC), nil

--- a/pkg/transport/network/webrtc.go
+++ b/pkg/transport/network/webrtc.go
@@ -43,6 +43,13 @@ import (
 // and browser carriers share this constant so they interoperate.
 const webrtcSignalPort = skyenv.DmsgWebRTCSignalPort
 
+// ErrWebRTCUnavailable is the sentinel MakeClient returns when the runtime has
+// no way to construct a peer connection (see WebRTCAvailable). It is expected,
+// not a failure: the transport manager simply leaves WEBRTC out of its known
+// networks, and every caller that picks candidate transport types from the
+// manager stops offering it.
+var ErrWebRTCUnavailable = errors.New("webrtc: no peer connection available in this runtime")
+
 // signalMsg is one signaling message exchanged over the dmsg signaling stream.
 // The JSON field set + names match the browser carrier exactly (interop).
 type signalMsg struct {

--- a/pkg/transport/network/webrtc_capability_browser.go
+++ b/pkg/transport/network/webrtc_capability_browser.go
@@ -1,0 +1,21 @@
+//go:build js && wasm
+
+// Package network pkg/transport/network/webrtc_capability_browser.go c2-net-transport
+//
+// Runtime capability probe for the browser WebRTC carrier. The SAME js/wasm
+// binary can run on a page's main thread (RTCPeerConnection present), inside the
+// hypervisor's SharedWorker (no RTCPeerConnection, but worker.js installs the
+// __skywireRTC bridge that proxies one from the agent tab), or inside a plain
+// Web Worker such as the desk's exec worker (neither) — so this must be checked
+// at runtime, per realm, not by build tag or config.
+package network
+
+import "syscall/js"
+
+// WebRTCAvailable reports whether this js realm can construct a peer connection:
+// directly (page main thread) or through the main-thread bridge that worker.js
+// installs for the wasm visor's Web Worker. Mirrors newPeerConnection's own
+// lookup order, so a true here means a dial has a real peer connection to use.
+func WebRTCAvailable() bool {
+	return js.Global().Get("__skywireRTC").Truthy() || js.Global().Get("RTCPeerConnection").Truthy()
+}

--- a/pkg/transport/network/webrtc_capability_native.go
+++ b/pkg/transport/network/webrtc_capability_native.go
@@ -1,0 +1,8 @@
+//go:build !tinygo && !(js && wasm)
+
+// Package network pkg/transport/network/webrtc_capability_native.go c2-net-transport
+package network
+
+// WebRTCAvailable reports whether this runtime can construct a peer connection.
+// Native builds carry pion, which always can.
+func WebRTCAvailable() bool { return true }

--- a/pkg/transport/network/webrtc_tinygo.go
+++ b/pkg/transport/network/webrtc_tinygo.go
@@ -25,3 +25,7 @@ func webrtcDial(_ context.Context, _ io.ReadWriteCloser, _ []string) (net.Conn, 
 func webrtcAccept(_ context.Context, _ io.ReadWriteCloser, _ []string) (net.Conn, error) {
 	return nil, errWebRTCUnsupported
 }
+
+// WebRTCAvailable reports whether this runtime can construct a peer connection.
+// These targets have neither pion nor RTCPeerConnection, so it never can.
+func WebRTCAvailable() bool { return false }


### PR DESCRIPTION
A wasm visor running in a plain Web Worker (the desk's exec worker) has no `RTCPeerConnection`, so every `public_autoconnect` cycle queued a webrtc dial to every public visor and every one failed with `mt.client.Dial: webrtc: RTCPeerConnection unavailable in this runtime`. Measured on the live desk this saturated the visor's runtime log ring (6600+ lines, ~30 lines/sec at peak, webrtc the 3rd busiest log source over a 50s sample) and burned the single-threaded wasm runtime on dials that can never succeed.

The gate is a runtime capability probe, not a build tag or config flag: the same js/wasm binary does have a peer connection on a page main thread, and inside the hypervisor's SharedWorker via the `__skywireRTC` bridge that `worker.js` installs, so the answer depends on the current realm. `network.WebRTCAvailable()` mirrors `newPeerConnection`'s own lookup order (`__skywireRTC` first, then `RTCPeerConnection`), so a bridged peer connection still counts as available. When it is false `MakeClient` returns `ErrWebRTCUnavailable`, WEBRTC never enters `tm.netClients`, and every caller that sources candidate types from the manager — autoconnect, `EnsureBestTransport`, `PreferredDirectCreateOrder` — stops offering it. `InitClient` logs that once at Info instead of a warning.

Native is unchanged (pion is always available). Non-browser TinyGo targets, whose carrier is already a fail-closed stub, now report false as well. `cmd/wasm-visor`'s duplicate copy of the probe delegates to the shared one.

Verified with `go build .`, the `make build-wasm` set (all five js/wasm binaries), and `go test ./pkg/transport/ ./pkg/transport/network/` (webrtc + MakeClient). Not verified on a live desk visor in a worker — the probe path itself is only reachable there.