### PR TITLE
feat(hv): render the hypervisor UI as a netscrape tab on the native desk

### DIFF
--- a/cmd/wasm-visor/browser_js.go
+++ b/cmd/wasm-visor/browser_js.go
@@ -26,7 +26,8 @@ import (
 // open(el) mounts the Go browser into el and runs it in this instance.
 func installBrowser() {
 	js.Global().Set("skywireBrowser", js.ValueOf(map[string]interface{}{
-		"open": js.FuncOf(jsOpenBrowser),
+		"open":   js.FuncOf(jsOpenBrowser),
+		"newTab": js.FuncOf(jsBrowserNewTab),
 	}))
 }
 
@@ -45,6 +46,23 @@ func jsOpenBrowser(_ js.Value, args []js.Value) any {
 		return nil
 	}
 	netscrape.Open(netscrapeHost(el))
+	return nil
+}
+
+// jsBrowserNewTab(url, background?) opens url in a new netscrape tab. A host
+// that mounts the browser itself needs this: Open(el) brings the browser up on
+// its default page, and without a way to name the first page a host can only
+// show that. A no-op before open() — netscrape's own NewTab guards on the
+// document it captured there.
+//
+// Background defaults to false: the caller is normally opening the ONE page the
+// window exists for, and that page should have focus.
+func jsBrowserNewTab(_ js.Value, args []js.Value) any {
+	if len(args) == 0 || args[0].Type() != js.TypeString {
+		return nil
+	}
+	background := len(args) > 1 && args[1].Truthy()
+	netscrape.NewTab(args[0].String(), background)
 	return nil
 }
 

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -197,6 +197,7 @@ func main() {
 	// itself lives in a worker (which has no DOM). Each role installs only its
 	// surface and never boots a visor.
 	//   - "shell":   the websh terminal (shell_js.go).
+	//   - "browser": netscrape ONLY — no shell, no desk panel.
 	//   - "netview": the tpviz WebGL network visualizer (tpviz_js.go) — runs in
 	//                the main thread so it can own a WebGL canvas, and reaches
 	//                the worker-side visor for data over the skywireVisor proxy.
@@ -206,6 +207,17 @@ func main() {
 		installBrowser()
 		installDesk()
 		fmt.Println("wasm-visor: shell role — call skywireShell.open(el) / skywireBrowser.open(el)")
+		keepAlive()
+	case "browser":
+		// netscrape alone, for a page that already HAS a desk panel and wants
+		// only the nested browser. The native hypervisor is the case: its
+		// launcher mounts the engine-free JS panel (browseui/desk-panel.js) and
+		// publishes its own __skywireDesk, so installing the Go desk here would
+		// put two panels — and two taskbars — on one page. Installing just the
+		// browser lets that page render the hypervisor UI as a netscrape TAB
+		// instead of a bare iframe, without touching the panel it already has.
+		installBrowser()
+		fmt.Println("wasm-visor: browser role — call skywireBrowser.open(el)")
 		keepAlive()
 	case "netview":
 		installNetView()

--- a/pkg/visor/hypervisor_desk_test.go
+++ b/pkg/visor/hypervisor_desk_test.go
@@ -148,10 +148,49 @@ func TestNativeDeskServing(t *testing.T) {
 		}
 	})
 
-	t.Run("the wasm-visor module is not exposed on the hypervisor port", func(t *testing.T) {
-		for _, p := range []string{"/wasm-visor.wasm", "/skywire.wasm", "/wasm_exec.js", "/hv-boot.js", "/worker.js"} {
+	// The rule is that native mode must not START a visor in the page — not
+	// that the module may never be served. Those were the same thing while the
+	// only reason to ship the module was to boot a visor out of it; they came
+	// apart when the desk began rendering the hypervisor UI as a netscrape tab,
+	// because netscrape is Go/wasm and lives in that same module. So the module
+	// is served, in a role that installs the browser and nothing else, while
+	// everything that could actually start a visor stays absent.
+	t.Run("the visor BOOT path is not exposed on the hypervisor port", func(t *testing.T) {
+		// hv-boot.js and worker.js ARE the boot path (worker.js hosts a visor
+		// off-thread; hv-boot.js spawns it). skywire.wasm is the in-tab CLI,
+		// which is how the wasm desk starts one via `skywire autoconfig`.
+		// Without these three there is nothing on this origin that starts a
+		// visor, whatever else it serves.
+		for _, p := range []string{"/skywire.wasm", "/hv-boot.js", "/worker.js"} {
 			if w := get(p); w.Code != http.StatusNotFound {
-				t.Errorf("GET %s → %d, want 404 (native mode must not serve the in-page visor)", p, w.Code)
+				t.Errorf("GET %s → %d, want 404 (native mode must not be able to start an in-page visor)", p, w.Code)
+			}
+		}
+	})
+
+	t.Run("the desk-host module is served for the browser, not for a visor", func(t *testing.T) {
+		for _, p := range []string{"/wasm-visor.wasm", "/wasm_exec.js"} {
+			if w := get(p); w.Code != http.StatusOK {
+				t.Errorf("GET %s → %d, want 200 (netscrape lives in this module)", p, w.Code)
+			}
+		}
+	})
+
+	t.Run("the native desk page does not autostart a visor", func(t *testing.T) {
+		w := get("/")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status=%d, want 200", w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "native: true") {
+			t.Error("native desk page lost its native:true boot option")
+		}
+		// These two are what the WASM desk passes to run a visor in the tab.
+		// Their absence here is the guarantee, and it is what makes serving the
+		// module above safe: nothing tells the desk to boot one.
+		for _, never := range []string{"autostartVisor", "wasmURL: '/skywire.wasm'"} {
+			if strings.Contains(body, never) {
+				t.Errorf("native desk page carries %q — it must not start a visor", never)
 			}
 		}
 	})

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/wasmhv/browseui"
+	"github.com/skycoin/skywire/pkg/wasmhv/wasmbin"
 )
 
 // postBrowseFetch fetches a dmsg/skynet site for the in-UI browser (local visor).
@@ -58,6 +59,14 @@ func (hv *Hypervisor) postBrowseClearnet() http.HandlerFunc {
 // wasm-visor has.
 func (hv *Hypervisor) uiHandler() http.Handler {
 	fileServer := uiCacheControl(http.FileServer(http.FS(hv.c.UIAssets)))
+	// Fingerprint the desk-host blob once, so a rebuilt binary serves a fresh
+	// module and an unchanged one 304s instead of re-sending ~59MB. Hash the
+	// COMPRESSED bytes: they are already in memory, and they change exactly
+	// when the module does.
+	deskWasmETag := func() string {
+		h := sha256.Sum256(wasmbin.GetVariantGz(wasmbin.Default()))
+		return `"` + hex.EncodeToString(h[:])[:16] + `"`
+	}()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/browse.js":
@@ -80,6 +89,37 @@ func (hv *Hypervisor) uiHandler() http.Handler {
 			return
 		case "/skywire-browse-launcher.js":
 			serveJS(w, []byte(nativeBrowseLauncherJS))
+			return
+		case "/wasm-visor.wasm":
+			// The desk-host blob. netscrape — the nested browser the desk
+			// renders its windows as TABS in — is Go/wasm and lives in this
+			// module (cmd/wasm-visor/browser_js.go installBrowser). Without it
+			// this origin has a window manager and no browser, so the
+			// hypervisor UI can only open as a bare iframe in a WinBox, which
+			// is not what the wasm desk at `hv serve` looks like.
+			//
+			// It boots in the "shell" ROLE: surfaces only (shell + browser +
+			// desk panel), boot() is never called, no visor runs in this tab.
+			// The native hypervisor already IS the visor.
+			w.Header().Set("Content-Type", "application/wasm")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("ETag", deskWasmETag)
+			if r.Header.Get("If-None-Match") == deskWasmETag {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			b, err := wasmbin.Get()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write(b) //nolint:errcheck
+			return
+		case "/wasm_exec.js":
+			// Go's loader, and it must be the one that PAIRS with the blob
+			// above — a std-Go wasm_exec.js cannot run a TinyGo module or vice
+			// versa (see wasmbin/embed.go).
+			serveJS(w, wasmbin.WasmExecJSVariant(wasmbin.Default()))
 			return
 		case "/desk-boot.js":
 			// The shared desk boot (skywireDeskBoot) — same asset `hv serve`

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -49,6 +49,20 @@
 		});
 	}
 
+	// loadScript appends a <script src> and resolves when it has run. The desk
+	// page normally carries wasm_exec.js as a tag of its own; the native
+	// hypervisor's page does not, because until the browser role existed it had
+	// no wasm to run.
+	function loadScript(src) {
+		return new Promise(function (res, rej) {
+			var s = document.createElement('script');
+			s.src = src;
+			s.onload = function () { res(); };
+			s.onerror = function () { rej(new Error('load ' + src)); };
+			document.head.appendChild(s);
+		});
+	}
+
 	function waitFor(fn, what, tries) {
 		return new Promise(function (res, rej) {
 			var n = 0;
@@ -229,9 +243,12 @@
 					// "0px" by most engines) and "auto" for a top dock.
 					var bd = bar ? bar.style.bottom : 'auto';
 					var topDocked = !(bd === '0' || bd === '0px');
+					// No `url:` — the body is handed to netscrape below, which
+					// opens dashURL as a TAB. WinBox's own `url` would make the
+					// body a bare iframe, which is what this page did before
+					// the browser was available here.
 					var wb = new WinBox({
 						title: 'dashboard',
-						url: dashURL,
 						root: root,
 						top: topDocked ? barH : 0,
 						bottom: topDocked ? 0 : barH,
@@ -241,9 +258,77 @@
 						x: 'center', y: 'center', width: '85%', height: '85%',
 					});
 					if (wb.maximize) wb.maximize(true);
+					mountDashboardBrowser(wb, dashURL);
 				} catch (e) { console.error('dashboard window:', e); }
 				return { panel: panel, startedVisor: false };
 			});
+		}
+
+		// mountDashboardBrowser puts netscrape inside the dashboard window and
+		// opens the hypervisor UI as a TAB, so the native desk matches the wasm
+		// one instead of showing a bare iframe in a plain window.
+		//
+		// netscrape is Go/wasm (cmd/wasm-visor). This page has a desk panel of
+		// its own already — the engine-free JS one the native launcher mounts —
+		// so the module is loaded in the "browser" ROLE: it installs netscrape
+		// and NOTHING else, no shell, no second desk panel, no visor. The native
+		// hypervisor serving this page IS the visor.
+		//
+		// Best-effort throughout: where the blob is not served (an older binary,
+		// or a build without it embedded) the window keeps the iframe it would
+		// have had, which is why the iframe is created here rather than left to
+		// WinBox's `url`.
+		function mountDashboardBrowser(wb, dashURL) {
+			var body = wb && wb.body;
+			if (!body) return;
+			function fallbackIframe() {
+				try {
+					var f = document.createElement('iframe');
+					f.setAttribute('src', dashURL);
+					f.style.cssText = 'border:0;width:100%;height:100%;display:block';
+					body.appendChild(f);
+				} catch (e) { /* nothing left to try */ }
+			}
+			loadDeskBrowser().then(function (ok) {
+				if (!ok || !globalThis.skywireBrowser) { fallbackIframe(); return; }
+				try {
+					globalThis.skywireBrowser.open(body);
+					globalThis.skywireBrowser.newTab(dashURL, false);
+				} catch (e) {
+					console.warn('dashboard browser:', e);
+					fallbackIframe();
+				}
+			}, function () { fallbackIframe(); });
+		}
+
+		// loadDeskBrowser loads the desk-host module in the browser-only role.
+		// Resolves true once globalThis.skywireBrowser is up, false if the
+		// assets are not served here. Runs at most once per page.
+		var deskBrowserPromise = null;
+		function loadDeskBrowser() {
+			if (deskBrowserPromise) return deskBrowserPromise;
+			if (globalThis.skywireBrowser) return (deskBrowserPromise = Promise.resolve(true));
+			// Set BEFORE the module runs: wasmRole() reads this global as the
+			// program starts, and a missing role would default to "visor" —
+			// which publishes the whole skywireVisor API on a page that already
+			// has a visor behind it.
+			globalThis.__SKYWIRE_WASM_ROLE__ = 'browser';
+			deskBrowserPromise = fetch(opts.deskWasmURL || 'wasm-visor.wasm', { method: 'HEAD' })
+				.then(function (r) {
+					if (!r.ok) return false;
+					return loadScript(opts.wasmExecURL || 'wasm_exec.js').then(function () {
+						var go = new Go();
+						return WebAssembly.instantiateStreaming(
+							fetch(opts.deskWasmURL || 'wasm-visor.wasm'), go.importObject,
+						).then(function (res) {
+							go.run(res.instance).catch(function (e) { console.error('desk browser:', e); });
+							return waitFor(function () { return globalThis.skywireBrowser; }, 'the browser', 200)
+								.then(function () { return true; });
+						});
+					});
+				})
+				.catch(function () { return false; });
+			return deskBrowserPromise;
 		}
 
 		// execWorker: the Worker every skywire command runs in once it is up,


### PR DESCRIPTION
Supersedes #4662, which conflicted with #4663 on the embedded blob. Same code and
test; the blob commit is dropped, since per this repo's convention the re-embed is
a follow-up PR (#4648→#4649, #4650→#4651, #4652→#4653).

The native hypervisor's desk opened its dashboard as a bare iframe in a plain
WinBox, while the wasm desk renders the same UI as a **tab** in the nested
browser. netscrape is Go/wasm and lives in `cmd/wasm-visor`, and the native
origin served no wasm at all — `/wasm-visor.wasm` and `/wasm_exec.js` both 404'd.
A page with a window manager and no browser can only show an iframe.

- `uiHandler` serves both assets, ETag'd off the compressed blob.
- New **`browser` role**: netscrape and nothing else. The native page already
  mounts the engine-free JS desk panel and publishes its own `__skywireDesk`, so
  the `shell` role would put two panels and two taskbars on one page — and *no*
  role falls through to the `visor` default, which publishes the whole
  `skywireVisor` API on a page that already has a native visor behind it.
- `skywireBrowser.newTab(url, background)` over netscrape's exported `NewTab`.
- Falls back to the iframe when the blob is not served, so the window is never
  worse than before.

## The test invariant, deliberately narrowed

`TestNativeDeskServing` asserted the native port serves none of
`/wasm-visor.wasm`, `/skywire.wasm`, `/wasm_exec.js`, `/hv-boot.js`,
`/worker.js`. Those were one rule while the only reason to ship the module was
to boot a visor out of it. They come apart here, because netscrape lives in that
same module.

The rule that matters is that native mode must not **start** a visor, so:

- **boot path stays 404** — `worker.js` hosts a visor off-thread, `hv-boot.js`
  spawns it, `skywire.wasm` is the in-tab CLI the wasm desk starts one with;
- **module is served**, in a role that cannot publish `skywireVisor`;
- **new third case**: the native desk page must carry neither `autostartVisor`
  nor `wasmURL: '/skywire.wasm'` — which is what makes serving the module safe.

`go build .` passes; the desk tests pass.