### PR TITLE
fix(dmsg): the idle-session reaper re-dialed every server it reaped

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -1468,6 +1468,7 @@ func (ce *Client) reapExcessIdleSessions(idleStreak map[cipher.PubKey]int, idleC
 		if ses := sessions[pk]; ses != nil {
 			ce.log.WithField("remote_pk", pk.String()).
 				Debug("reaping idle dmsg session (streamless, over min_sessions)")
+			ses.markReaped()
 			_ = ses.Close() //nolint:errcheck
 		}
 	}
@@ -1505,6 +1506,12 @@ func pickIdleSessionsToReap(streams, idleStreak map[cipher.PubKey]int, min, idle
 	}
 	if len(reap) > surplus {
 		reap = reap[:surplus]
+	}
+	// A reaped server starts over: if a later DialStream re-dials it, the new
+	// session gets the full idle grace rather than inheriting a streak that
+	// would reap it on its first check.
+	for _, pk := range reap {
+		delete(idleStreak, pk)
 	}
 	return reap
 }

--- a/pkg/dmsg/dmsg/client_reaper_test.go
+++ b/pkg/dmsg/dmsg/client_reaper_test.go
@@ -39,6 +39,8 @@ func TestPickIdleSessionsToReap(t *testing.T) {
 	reap := pickIdleSessionsToReap(streams, streak, min, thresh)
 	require.Len(t, reap, 1, "reap only the surplus above MinSessions")
 	require.NotEqual(t, c, reap[0], "never reap a busy session")
+	_, streakKept := streak[reap[0]]
+	require.False(t, streakKept, "a reaped server's idle streak is cleared so a re-dialed session gets a fresh grace period")
 
 	// A busy session resets its streak.
 	streams2 := map[cipher.PubKey]int{a: 0, b: 5}
@@ -66,4 +68,18 @@ func TestPickIdleSessionsToReap(t *testing.T) {
 	pickIdleSessionsToReap(map[cipher.PubKey]int{a: 0}, streak5, 1, 5)
 	_, stillThere := streak5[gone]
 	require.False(t, stillThere, "streak pruned for a session no longer present")
+}
+
+// TestReapedSessionFlag pins the marker the reaper sets before closing a
+// session. The serve goroutine's exit path reads it to skip the errCh wake and
+// the lost-server note that would otherwise re-dial the server just trimmed —
+// observed live as one reap and one re-dial of the same server every minute.
+func TestReapedSessionFlag(t *testing.T) {
+	var nilSes *SessionCommon
+	require.False(t, nilSes.wasReaped(), "a nil session is never reaped")
+
+	sc := &SessionCommon{}
+	require.False(t, sc.wasReaped(), "fresh session is not reaped")
+	sc.markReaped()
+	require.True(t, sc.wasReaped(), "flag sticks once set")
 }

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -716,6 +716,15 @@ func (ce *Client) finishDialedSession(ctx context.Context, dSes ClientSession, n
 		ce.sesMx.Lock()
 		if isClosed(ce.done) {
 			ce.sesMx.Unlock()
+		} else if dSes.wasReaped() {
+			// The idle-session reaper closed this session on purpose. Neither
+			// wake the Serve loop nor note the server as lost: either re-dials
+			// it (redialLostSession, or the fall-through to EnsureSession after
+			// an errCh wake) and undoes the trim. The floor is intact by
+			// construction, since the reaper never takes the count below
+			// MinSessions.
+			ce.sesMx.Unlock()
+			ce.delSession(ctx, dSes.RemotePK(), dSes.SessionCommon)
 		} else {
 			select {
 			case ce.errCh <- fmt.Errorf("failed to serve dialed session to %s: %v", dSes.RemotePK(), err):

--- a/pkg/dmsg/dmsg/session_common.go
+++ b/pkg/dmsg/dmsg/session_common.go
@@ -61,6 +61,15 @@ type SessionCommon struct {
 	// A value of 0 means no measurement yet (treated as max latency for sorting).
 	lastPingNs atomic.Int64
 
+	// reaped is set by the client's idle-session reaper just before it closes
+	// this session. The serve goroutine's exit path reads it so a deliberate
+	// trim is not mistaken for a dropped server. Without it the exit path
+	// reported the close on errCh and noted the server as lost, and the Serve
+	// loop's prefer-the-server-we-just-lost re-dial (#4086) dialed it straight
+	// back: one reap and one re-dial of the same server every minute, with the
+	// session count never actually falling.
+	reaped atomic.Bool
+
 	log logrus.FieldLogger
 }
 
@@ -97,6 +106,13 @@ func (sm *SessionManager) NumStreams() int {
 // NumStreams reports the number of open mux streams on this session (0 = idle;
 // -1 = unmeasurable, treated as busy). Used by the idle-session reaper.
 func (sc *SessionCommon) NumStreams() int { return sc.sm.NumStreams() }
+
+// markReaped flags this session as deliberately closed by the idle-session
+// reaper, so its serve goroutine does not report the server as lost.
+func (sc *SessionCommon) markReaped() { sc.reaped.Store(true) }
+
+// wasReaped reports whether the idle-session reaper closed this session.
+func (sc *SessionCommon) wasReaped() bool { return sc != nil && sc.reaped.Load() }
 
 // GetConn returns underlying TCP `net.Conn`.
 func (sc *SessionCommon) GetConn() net.Conn {


### PR DESCRIPTION
Reaping a surplus idle session closes it, which ends its serve goroutine. That exit path reported the close on errCh and noted the server as lost, so the Serve loop's prefer-the-server-we-just-lost re-dial (#4503) dialed it straight back. Observed live on the host visor: the same server reaped and re-dialed within the same second, every minute, with the session count never falling.

The reaper now marks a session before closing it, and the exit path skips the errCh wake and the lost-server note for a marked session. The idle streak is cleared for a reaped server so a later re-dial gets a fresh grace period.

Log excerpt before the fix (one server, four consecutive minutes):

```
12:54:16 reaping idle dmsg session (streamless, over min_sessions) remote_pk=0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7
12:54:16 Session stopped. error="failed to serve dialed session to 0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7 ..."
12:54:16 Dialing session... remote_pk=0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7
12:54:17 Serving session. remote_pk=0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7
```

Tests: `go test ./pkg/dmsg/dmsg -run 'TestPickIdleSessionsToReap|TestReapedSessionFlag|TestLostSession'`.