### PR TITLE
fix(dmsghttp): evict a pooled idle stream on a timer, not only on the next request

### DIFF
--- a/pkg/dmsg/dmsghttp/http_transport.go
+++ b/pkg/dmsg/dmsghttp/http_transport.go
@@ -31,6 +31,10 @@ const (
 	poolIdleTimeout = 90 * time.Second
 )
 
+// idleEvictDelay is how long after a stream is parked in the pool an unattended
+// eviction fires (see evictIdle). poolIdleTimeout by default; tests shorten it.
+var idleEvictDelay = poolIdleTimeout
+
 // HTTPTransport implements http.RoundTripper. It dials fresh dmsg
 // streams via dmsgC.DialStream, runs HTTP/1.1 request/response over
 // the stream directly, and pools idle streams per destination so
@@ -292,9 +296,59 @@ func (t *HTTPTransport) putIdle(ps *pooledStream) {
 		delete(t.tracking, oldest)
 	}
 	ps.idleAt = time.Now()
+	idleAt := ps.idleAt
 	queue = append(queue, ps)
 	t.idle[ps.host] = queue
 	t.mu.Unlock()
+	time.AfterFunc(idleEvictDelay, func() { t.evictIdle(ps, idleAt) })
+}
+
+// evictIdle drops ps from the idle pool if it is still parked there from the
+// putIdle that scheduled this call (a stream taken and re-parked since carries
+// a newer idleAt and is left to its own timer).
+//
+// Eviction used to happen only inside takeIdle, on the transport's NEXT
+// request. A transport built for a single request and then dropped — a
+// periodic probe, a one-shot push — parked its stream in a pool nobody would
+// ever read again, and the stream stayed reserved in the dmsg porter for the
+// life of the process. The v1.3.93 self-probe leaked one this way every
+// minute; long-lived visors were measured holding several thousand reserved
+// ephemeral ports, which also pinned every dmsg session as busy so the
+// idle-session reaper could never trim any of them.
+func (t *HTTPTransport) evictIdle(ps *pooledStream, idleAt time.Time) {
+	t.mu.Lock()
+	queue := t.idle[ps.host]
+	found := -1
+	for i, q := range queue {
+		if q == ps && q.idleAt.Equal(idleAt) {
+			found = i
+			break
+		}
+	}
+	if found < 0 {
+		t.mu.Unlock()
+		return
+	}
+	queue = append(queue[:found], queue[found+1:]...)
+	if len(queue) == 0 {
+		delete(t.idle, ps.host)
+	} else {
+		t.idle[ps.host] = queue
+	}
+	delete(t.tracking, ps)
+	t.mu.Unlock()
+	ps.discard()
+}
+
+// idleLen reports how many streams the pool currently holds. Test hook.
+func (t *HTTPTransport) idleLen() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	n := 0
+	for _, q := range t.idle {
+		n += len(q)
+	}
+	return n
 }
 
 func (t *HTTPTransport) track(ps *pooledStream) {

--- a/pkg/dmsg/dmsghttp/http_transport_test.go
+++ b/pkg/dmsg/dmsghttp/http_transport_test.go
@@ -331,3 +331,38 @@ func TestHTTPTransport_TransparentGzip(t *testing.T) {
 		assert.Equal(t, payload, string(body))
 	})
 }
+
+// TestHTTPTransport_IdleStreamEvictedUnattended pins that a stream parked in
+// the keep-alive pool is released even when the transport never sees another
+// request. Eviction used to run only inside takeIdle, so a transport built for
+// one request and then dropped (the v1.3.93 self-probe did this every minute)
+// kept its stream reserved in the dmsg porter for the life of the process.
+func TestHTTPTransport_IdleStreamEvictedUnattended(t *testing.T) {
+	logging.SetLevel(logrus.WarnLevel)
+	old := idleEvictDelay
+	idleEvictDelay = 500 * time.Millisecond
+	t.Cleanup(func() { idleEvictDelay = old })
+
+	dc := startDmsgEnv(t, 1, 10)
+	results := make(chan httpServerResult, 4)
+	lis, err := newDmsgClient(t, dc, 1, "server").Listen(80)
+	require.NoError(t, err)
+	startHTTPServer(t, results, lis)
+	addr := lis.Addr().String()
+
+	dmsgC := newDmsgClient(t, dc, 1, "client")
+	tr := MakeHTTPTransport(context.Background(), dmsgC)
+	httpC := http.Client{Transport: tr, Timeout: 30 * time.Second}
+	time.Sleep(2 * time.Second)
+
+	resp, err := httpC.Get("http://" + addr + endpointHTML)
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, resp.Body.Close())
+
+	require.Equal(t, 1, tr.idleLen(), "stream is parked in the pool once the body is closed")
+	require.Eventually(t, func() bool {
+		return tr.idleLen() == 0 && len(dmsgC.AllStreams()) == 0
+	}, 5*time.Second, 50*time.Millisecond,
+		"the parked stream must be evicted and its porter entry freed with no further request")
+}


### PR DESCRIPTION
The keep-alive pool evicted idle streams only inside `takeIdle`, on the transport's next request. A transport built for one request and then dropped (a periodic probe, a one-shot push) parked its stream in a pool nobody read again, and the stream stayed reserved in the dmsg porter for the life of the process.

Measured on the fleet via the hypervisor ports API, ephemeral-port dmsg streams per visor:

| build | streams | change over 17 min |
|---|---|---|
| v1.3.93 (8 nodes) | 1,433 to 6,449 | +10 to +21 each |
| develop-latest (6 nodes) | 47 to 209 | 0 to +4 |

The v1.3.93 self-probe built a throwaway dmsg-HTTP transport every 60 s; develop dropped that probe in #4630, which is why develop is flat, but the pool behaviour that leaked is unchanged. The leaked streams also mark every session busy, so the idle-session reaper never trims those visors below 7 to 10 sessions.

`putIdle` now schedules an eviction for `poolIdleTimeout` later; the callback drops the stream only if it is still parked from that same `putIdle`. New test `TestHTTPTransport_IdleStreamEvictedUnattended` uses the existing dmsg env harness.