### PR TITLE
fix(lint): clear the six findings failing the lint lanes

### DIFF
--- a/pkg/proxyinterstitial/interstitial.go
+++ b/pkg/proxyinterstitial/interstitial.go
@@ -189,7 +189,7 @@ const css = `:root{--bg:#0b0d17;--fg:#c7cbe6;--muted:#7a80a8;--accent:#7c83ff;--
 	`.ready{color:var(--accent);margin:12px 0 0;font-size:13px;font-weight:600}` +
 	`.err #mesh-title{color:var(--err)}.err .sp{display:none}`
 
-// MarkerHeader labels every HTTP response THIS package synthesises in-process —
+// MarkerHeader labels every HTTP response THIS package synthesizes in-process —
 // the waiting interstitial and the fall-through reload page. Both are minted by
 // the local skysocks-client when it cannot reach the exit, yet on the wire they
 // are indistinguishable from an ordinary relayed "HTTP/1.1 200 OK" with an HTML
@@ -202,10 +202,10 @@ const MarkerHeader = "X-Skywire-Interstitial"
 // markerHeaderLine is MarkerHeader as a ready-to-write response header line.
 const markerHeaderLine = MarkerHeader + ": 1\r\n"
 
-// IsSyntheticResponse reports whether raw HTTP response bytes were synthesised
+// IsSyntheticResponse reports whether raw HTTP response bytes were synthesized
 // by this package rather than relayed from a real exit. It checks MarkerHeader
 // first and falls back to sniffing the two page bodies for their distinctive
-// markup, so a NEWER verifier still recognises a page served by an OLDER
+// markup, so a NEWER verifier still recognizes a page served by an OLDER
 // skysocks-client build that predates the header. raw may be a prefix of the
 // response (callers commonly read a bounded first chunk), so the sniff runs
 // over whatever was supplied.

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -307,10 +307,7 @@ func (v *Visor) holdVerifiedProxyExit(ctx context.Context, log *logging.Logger) 
 		case <-time.After(proxyExitRecheckInterval):
 		}
 		if !v.verifyProxyExit(ctx, log) {
-			if ctx.Err() != nil {
-				return false
-			}
-			return true
+			return ctx.Err() == nil
 		}
 		log.Debug("proxy exit re-verified end to end")
 	}
@@ -369,7 +366,7 @@ func (v *Visor) verifyProxyExit(ctx context.Context, log *logging.Logger) bool {
 // listener are a real reply RELAYED from the exit. Two things have to hold: it
 // must be a well-formed HTTP/1.x status line with a 2xx/3xx code (a zombie exit
 // that accepts the CONNECT and then relays nothing produces neither), and it
-// must not be one of the responses the local client synthesises when it has no
+// must not be one of the responses the local client synthesizes when it has no
 // session — those are ordinary-looking 200s carrying an HTML page, and treating
 // one as proof of life is the bug this guards.
 func relayedResponseOK(raw []byte) bool {

--- a/pkg/visor/init_apps_proxy_verify_test.go
+++ b/pkg/visor/init_apps_proxy_verify_test.go
@@ -82,7 +82,7 @@ func TestRelayedResponseOKRejectsLiveInterstitial(t *testing.T) {
 					}
 					go func(c net.Conn) {
 						_ = proxyinterstitial.ServeSOCKS5(c, "", "skysocks", nil, tc.exitReachable) //nolint:errcheck
-						c.Close()                                                                   //nolint:errcheck
+						_ = c.Close()                                                               //nolint:errcheck
 					}(c)
 				}
 			}()


### PR DESCRIPTION
Four misspell findings (locale US), one staticcheck S1008, one gosec G104 in a test. All from the proxy-exit verification change; the windows lint lane has been red on develop since.