### PR TITLE
fix(skychat): mint a message id on every send natively too

### DIFF
--- a/cmd/apps/skychat/commands/lifecycle_test.go
+++ b/cmd/apps/skychat/commands/lifecycle_test.go
@@ -319,7 +319,8 @@ func TestMessageHandler_SendsPlainAndReceipts(t *testing.T) {
 	h := messageHandler(context.Background())
 	pk, _ := cipher.GenerateKeyPair()
 
-	// Plain send: byte-identical wire (no envelope), empty 200 body.
+	// Plain send: rides an id'd envelope like every other message (replies,
+	// read ticks and delete-for-everyone key on the id), empty 200 body.
 	rr := httptest.NewRecorder()
 	h(rr, httptest.NewRequest(http.MethodPost, "/message",
 		strings.NewReader(`{"recipient":"`+pk.Hex()+`","message":"plain hello"}`)))
@@ -328,8 +329,9 @@ func TestMessageHandler_SendsPlainAndReceipts(t *testing.T) {
 	}
 	select {
 	case raw := <-cc.frames:
-		if string(raw) != "plain hello" {
-			t.Errorf("wire payload = %q, want the bare text (a default send must stay envelope-free)", raw)
+		env, ok := message.ParseEnvelope(raw)
+		if !ok || env.Type != message.TypeMsg || env.ID == "" || env.Body != "plain hello" {
+			t.Errorf("wire payload = %q, want a chat-msg envelope with an id and body %q", raw, "plain hello")
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("nothing reached the wire on a plain send")

--- a/cmd/wasm-visor/skychat_js.go
+++ b/cmd/wasm-visor/skychat_js.go
@@ -238,14 +238,14 @@ func runBrowserSkychat(ctx context.Context, _ []string) error {
 	// pkg/skychat/dm.Controller — the same core the native app uses. It listens
 	// on dmsg:1 + skynet:1, surfaces every message (in + the outbound mirror)
 	// through OnEvent → appendChat (which persists to the in-memory history
-	// store the page polls). AlwaysID keeps every DM addressable (id-keyed
-	// buffer, quoted replies). Store is nil here — appendChat owns persistence
-	// so file entries (fileMeta) and DM text share one MemStore writer.
+	// store the page polls). The controller ids every DM, which keeps the
+	// id-keyed buffer and quoted replies addressable. Store is nil here —
+	// appendChat owns persistence so file entries (fileMeta) and DM text share
+	// one MemStore writer.
 	chatCtrl = dm.New(dm.Config{
 		Client:   cl,
 		Networks: []appnet.Type{appnet.TypeDmsg, appnet.TypeSkynet},
 		Port:     skychatPort,
-		AlwaysID: true,
 		OnEvent: func(ev dm.Event) {
 			appendChat(chatMsg{
 				ID: ev.ID, From: ev.Peer, Text: ev.Text,
@@ -286,7 +286,7 @@ func runBrowserSkychat(ctx context.Context, _ []string) error {
 }
 
 // sendChat delivers text to the peer via the shared DM controller. network is
-// "dmsg" (default) or "skynet". The controller mints the message id (AlwaysID),
+// "dmsg" (default) or "skynet". The controller mints the message id,
 // frames the chat-msg envelope (carrying replyTo when set), dials/reuses the
 // conn, and surfaces the outbound mirror through OnEvent → appendChat — so this
 // no longer buffers or frames anything itself.

--- a/pkg/skychat/dm/controller.go
+++ b/pkg/skychat/dm/controller.go
@@ -130,12 +130,13 @@ type Config struct {
 	// decoding; returning true consumes the frame (used by the native app for
 	// its pair-control envelopes). Nil = no interception.
 	PreHandleFrame func(peer cipher.PubKey, payload []byte) bool
-	// AlwaysID makes every send ride a chat-msg envelope with a minted id, even
-	// a plain (no-reply, no-ack) message — so every message is addressable for
-	// replies. The wasm visor sets this (its whole buffer is id-keyed). The
-	// native app leaves it false so a default send stays byte-identical on the
-	// wire for pre-envelope peers.
-	AlwaysID bool
+	// RawText sends a plain (no-reply, no-ack) message as bare text instead of
+	// a chat-msg envelope with a minted id. Off by default: every message then
+	// carries a stable id, which is what quoted replies, read ticks and
+	// delete-for-everyone key on, natively and in the wasm visor alike. Set it
+	// only to keep a default send byte-identical on the wire for pre-envelope
+	// peers; inbound bare text is always accepted regardless.
+	RawText bool
 	// Log is an optional structured logger sink.
 	Log func(format string, args ...interface{})
 }
@@ -510,7 +511,7 @@ func (c *Controller) Send(ctx context.Context, pk cipher.PubKey, netType appnet.
 	var ackID string
 	var ackCh <-chan struct{}
 	var unreg func()
-	if wantAck || opt.ReplyTo != "" || c.cfg.AlwaysID {
+	if wantAck || opt.ReplyTo != "" || !c.cfg.RawText {
 		ackID = newID()
 		res.ID = ackID
 		env := message.Envelope{Type: message.TypeMsg, ID: ackID, Body: text, Ack: wantAck, ReplyTo: opt.ReplyTo}

--- a/pkg/skychat/dm/controller_test.go
+++ b/pkg/skychat/dm/controller_test.go
@@ -136,13 +136,22 @@ func TestController_SendReceive(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = ctrlA.Close(); _ = ctrlB.Close() }) //nolint
 
-	// Plain send A -> B.
-	if _, err := ctrlA.Send(context.Background(), pkB, appnet.TypeDmsg, "hello B", SendOpts{}); err != nil {
+	// Plain send A -> B. Even with no ack or reply requested the message rides
+	// an envelope with a minted id — replies, read ticks and delete-for-everyone
+	// all key on it, on the native app and the wasm visor alike.
+	res, err := ctrlA.Send(context.Background(), pkB, appnet.TypeDmsg, "hello B", SendOpts{})
+	if err != nil {
 		t.Fatalf("send: %v", err)
+	}
+	if res.ID == "" {
+		t.Fatal("plain send returned no id")
 	}
 	inB := waitFor(t, recB, func(e Event) bool { return e.Dir == "in" && e.Text == "hello B" })
 	if inB.Peer != pkA.Hex() {
 		t.Errorf("inbound peer = %s, want %s", inB.Peer, pkA.Hex())
+	}
+	if inB.ID != res.ID {
+		t.Errorf("inbound id %q != sent id %q", inB.ID, res.ID)
 	}
 	// A sees the outbound mirror.
 	if _, ok := recA.find(func(e Event) bool { return e.Dir == "out" && e.Text == "hello B" && e.Peer == pkB.Hex() }); !ok {
@@ -440,5 +449,35 @@ func TestController_AutoDmsgFirstThenSkynetUpgrade(t *testing.T) {
 	}
 	if res2.Network != appnet.TypeSkynet {
 		t.Fatalf("second auto send network = %q, want skynet", res2.Network)
+	}
+}
+
+// TestController_RawTextPeerStillDecodes pins interop with a pre-envelope peer:
+// a bare-text frame (what RawText sends, and what older peers put on the wire)
+// is still surfaced as a chat line — it just has no id to address.
+func TestController_RawTextPeerStillDecodes(t *testing.T) {
+	hub := newMemHub()
+	pkOld, pkB := mustPK(t), mustPK(t)
+	recB := &recorder{}
+
+	ctrlB := New(Config{Client: &memClient{hub, pkB}, Networks: []appnet.Type{appnet.TypeDmsg}, OnEvent: recB.on})
+	ctrlOld := New(Config{Client: &memClient{hub, pkOld}, Networks: []appnet.Type{appnet.TypeDmsg}, OnEvent: func(Event) {}, RawText: true})
+	_ = ctrlB.Start(context.Background())                        //nolint
+	_ = ctrlOld.Start(context.Background())                      //nolint
+	t.Cleanup(func() { _ = ctrlOld.Close(); _ = ctrlB.Close() }) //nolint
+
+	res, err := ctrlOld.Send(context.Background(), pkB, appnet.TypeDmsg, "plain text", SendOpts{})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if res.ID != "" {
+		t.Errorf("RawText send minted an id %q; want none", res.ID)
+	}
+	in := waitFor(t, recB, func(e Event) bool { return e.Dir == "in" && e.Text == "plain text" })
+	if in.Peer != pkOld.Hex() {
+		t.Errorf("inbound peer = %s, want %s", in.Peer, pkOld.Hex())
+	}
+	if in.ID != "" {
+		t.Errorf("bare-text frame surfaced with id %q; want none", in.ID)
 	}
 }


### PR DESCRIPTION
A plain skychat send (no ack, no reply requested) went out as bare text unless the host set `dm.Config.AlwaysID`, and only the wasm visor did. The native app's inbound messages therefore had no id, so quoted replies, read ticks and delete-for-everyone worked in the browser tab but not natively.

This inverts the knob: `pkg/skychat/dm` now envelopes every message with a stable id by default, and `RawText` is the explicit opt-out that keeps a default send byte-identical on the wire. The wasm visor drops its `AlwaysID: true` and rides the same default, so both hosts behave identically with no per-host wiring. Inbound bare text from older peers still decodes exactly as before.

Tests: `TestController_SendReceive` now asserts a plain send yields a non-empty inbound id matching the sender's; new `TestController_RawTextPeerStillDecodes` pins the raw-text interop; the native `TestMessageHandler_SendsPlainAndReceipts` assertion is flipped to expect the envelope. `go build .`, `go vet` (native and `GOOS=js GOARCH=wasm` for cmd/wasm-visor) and `go test` on the touched packages pass.
