### PR TITLE
fix(lint): check the io.Copy error in the dmsghttp eviction test

### DIFF
--- a/pkg/dmsg/dmsghttp/http_transport_test.go
+++ b/pkg/dmsg/dmsghttp/http_transport_test.go
@@ -357,7 +357,8 @@ func TestHTTPTransport_IdleStreamEvictedUnattended(t *testing.T) {
 
 	resp, err := httpC.Get("http://" + addr + endpointHTML)
 	require.NoError(t, err)
-	_, _ = io.Copy(io.Discard, resp.Body)
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
 
 	require.Equal(t, 1, tr.idleLen(), "stream is parked in the pool once the body is closed")


### PR DESCRIPTION
errcheck runs with check-blank, so the blank assignment in the test added by #4671 failed the lint lanes.