### PR TITLE
fix(desk): native hypervisor desk renders its dashboard natively and gets a terminal window

### DIFF
--- a/cmd/wasm-visor/browser_js.go
+++ b/cmd/wasm-visor/browser_js.go
@@ -31,6 +31,23 @@ func installBrowser() {
 	}))
 }
 
+// installBrowserDirectLoader gives netscrape the browser role's DirectLoader:
+// same-origin pages render natively (sameOriginSrc). The browser role installs
+// no desk, so it never ran installDesk's loader, and without ANY loader the
+// native desk's dashboard tab was fetched through netscrape's transcoder —
+// which, absent a __netscrapeFetch hook, asks the origin's /fetch proxy. A
+// native hypervisor has no such endpoint, so the tab rendered the server's
+// "404 page not found" body (observed live on :8000).
+func installBrowserDirectLoader() {
+	netscrape.DirectLoader = func(u string) (string, bool) {
+		loc := js.Global().Get("location")
+		if !loc.Truthy() {
+			return "", false
+		}
+		return sameOriginSrc(loc.Get("origin").String(), u)
+	}
+}
+
 // jsOpenBrowser(el) mounts the netscrape browser into el (an element, or its
 // id). It returns nil — the browser lives on through its own event handlers,
 // this instance's runtime already being kept alive by the visor/shell.

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -217,6 +217,7 @@ func main() {
 		// browser lets that page render the hypervisor UI as a netscrape TAB
 		// instead of a bare iframe, without touching the panel it already has.
 		installBrowser()
+		installBrowserDirectLoader()
 		fmt.Println("wasm-visor: browser role — call skywireBrowser.open(el)")
 		keepAlive()
 	case "netview":

--- a/cmd/wasm-visor/sameorigin.go
+++ b/cmd/wasm-visor/sameorigin.go
@@ -1,0 +1,28 @@
+// Package main cmd/wasm-visor/sameorigin.go c3-vis-wasm
+// Untagged on purpose, like vnetaddr.go: pure string work with no syscall/js,
+// so the rule it encodes — which URLs the browser role renders UNSANDBOXED —
+// is pinned by a test that actually runs in CI.
+package main
+
+import "strings"
+
+// sameOriginSrc claims u for NATIVE rendering when it is a page of the origin
+// serving this module. It is the DirectLoader of the "browser" role, which is
+// the role the native hypervisor page loads netscrape in: there the server
+// behind the page IS the visor, so every same-origin page is the visor's own
+// UI and may render as an ordinary document. installDesk's loader deliberately
+// claims only the vnet spellings, because the desk page may be hosted by a docs
+// site whose other pages are not the visor's; that reasoning does not hold on a
+// page the visor serves itself.
+//
+// Returns u unchanged: netscrape puts it on the iframe as src and keeps it in
+// the address bar.
+func sameOriginSrc(origin, u string) (string, bool) {
+	if origin == "" || u == "" {
+		return "", false
+	}
+	if u == origin || strings.HasPrefix(u, origin+"/") || strings.HasPrefix(u, origin+"?") || strings.HasPrefix(u, origin+"#") {
+		return u, true
+	}
+	return "", false
+}

--- a/cmd/wasm-visor/sameorigin_test.go
+++ b/cmd/wasm-visor/sameorigin_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+// TestSameOriginSrc pins the browser role's DirectLoader rule: pages of the
+// serving origin render natively, anything else goes through the transcoder.
+// A claimed page is rendered UNSANDBOXED, so the negatives matter as much as
+// the positives — a prefix match must not be fooled by a longer port or a
+// look-alike host.
+func TestSameOriginSrc(t *testing.T) {
+	const origin = "http://127.0.0.1:8000"
+	for _, in := range []string{
+		"http://127.0.0.1:8000",
+		"http://127.0.0.1:8000/",
+		"http://127.0.0.1:8000/?embed=1#/?embed=1",
+		"http://127.0.0.1:8000/pty/0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c",
+		"http://127.0.0.1:8000?embed=1",
+		"http://127.0.0.1:8000#/nodes",
+	} {
+		src, ok := sameOriginSrc(origin, in)
+		if !ok || src != in {
+			t.Errorf("sameOriginSrc(%q) = (%q,%v), want (%q,true)", in, src, ok, in)
+		}
+	}
+	for _, in := range []string{
+		"http://127.0.0.1:80001/",         // longer port sharing the prefix
+		"http://127.0.0.1:8000.evil.com/", // look-alike host
+		"https://127.0.0.1:8000/",         // other scheme
+		"http://localhost:8000/",          // other spelling of the same host is NOT the origin string
+		"http://example.com/",
+		"vnet:8001",
+		"",
+	} {
+		if src, ok := sameOriginSrc(origin, in); ok {
+			t.Errorf("sameOriginSrc(%q) claimed %q, want no claim", in, src)
+		}
+	}
+	if _, ok := sameOriginSrc("", "http://127.0.0.1:8000/"); ok {
+		t.Error("an empty origin must claim nothing")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/0magnet/bitree v0.0.0-20260906144807-e66de0b4c738
 	github.com/0magnet/bottle v0.0.0-20260908155251-920d2280a387
 	github.com/0magnet/calvin v0.0.0-20260907164811-60c88e364a88
-	github.com/0magnet/desk v0.0.0-20260908155111-f022a08dc97e
+	github.com/0magnet/desk v0.0.0-20260908190105-9bb2944487db
 	github.com/0magnet/desk/panes v0.0.0-20260908155111-f022a08dc97e
 	github.com/0magnet/gobrpc v0.0.0-20260906144809-5215ec59d553
 	github.com/0magnet/golang-ipc v1.2.5-0.20260905172007-25d9c1a262d0
@@ -83,7 +83,7 @@ require (
 	github.com/0magnet/termanim v0.0.0-20260907160035-43b5e3d1c5a0
 	github.com/0magnet/visnetwork-go v0.0.0-20260906025559-6b0de1648ee9
 	github.com/0magnet/wfdrive v0.3.1
-	github.com/0magnet/winbox-go v0.0.0-20260907164818-1573f12aafdd
+	github.com/0magnet/winbox-go v0.0.0-20260908011106-113d480c4188
 	github.com/0magnet/yamux v0.1.3-0.20260905172050-450c4058f851
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/DiSiqueira/GoTree v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/0magnet/cosmos-go v0.0.0-20260907164823-2289c429c265 h1:BSqhgkPVV41wl
 github.com/0magnet/cosmos-go v0.0.0-20260907164823-2289c429c265/go.mod h1:dp0q1zfKQmTaohUrPEPZbPExxBWLu9DyeaFxKUBnw6Y=
 github.com/0magnet/desk v0.0.0-20260908155111-f022a08dc97e h1:Np4v54K+p2UG0rTePEdTpVtuuD8Z0IyKA/T6oiaBErc=
 github.com/0magnet/desk v0.0.0-20260908155111-f022a08dc97e/go.mod h1:tlA6mjcvote1DMv2iJT4N6r15Ns+gX7HJyNXbDwVvBg=
+github.com/0magnet/desk v0.0.0-20260908190105-9bb2944487db h1:EerFzR/1OAe/NG6r1ysuG1+lyS0qMJ6YwaoognLG6gY=
+github.com/0magnet/desk v0.0.0-20260908190105-9bb2944487db/go.mod h1:L+8Y1fP55UjK6RFOG0iAsR9oO6zXidCr9LZJy+8oN/k=
 github.com/0magnet/desk/panes v0.0.0-20260908155111-f022a08dc97e h1:yR9YzpJcwax4fwdAiY5K7SoTYi+ICp+oc1wLjto91dA=
 github.com/0magnet/desk/panes v0.0.0-20260908155111-f022a08dc97e/go.mod h1:EDtFhI1TlDPunQIoT8IRbhe8wa5R4GAI+iL04vQDk2Y=
 github.com/0magnet/go-dsp v0.0.0-20260905172003-9e5bb50ba887 h1:m2cjiimELUkK59z1J/0syXp4fsEnpyO8Jf2v70zkhGo=
@@ -128,6 +130,8 @@ github.com/0magnet/wfdrive v0.3.1 h1:VKwgCprNRKJtyAO5RQ40yLsYec1QqaeLXykoDV9kT08
 github.com/0magnet/wfdrive v0.3.1/go.mod h1:ckGVOflE4OC+G0MTrcin3hRoOwEFOCtRxY8nWxVt2bw=
 github.com/0magnet/winbox-go v0.0.0-20260907164818-1573f12aafdd h1:R4cseJyrJHzO46elDoJZ8aOJRMyPSACpFc/XM/tvuAU=
 github.com/0magnet/winbox-go v0.0.0-20260907164818-1573f12aafdd/go.mod h1:19+/rRQWd/tc9/8CFcUr6C+3AipeZmHyyda2tVombe4=
+github.com/0magnet/winbox-go v0.0.0-20260908011106-113d480c4188 h1:NY8NY7qUThHl9fc4IRUefZMFtBQ0M82A1rKL2IiiTFA=
+github.com/0magnet/winbox-go v0.0.0-20260908011106-113d480c4188/go.mod h1:19+/rRQWd/tc9/8CFcUr6C+3AipeZmHyyda2tVombe4=
 github.com/0magnet/xterm-go v0.0.0-20260907164817-c5d24e1daacc h1:HkftUgw2zzaOsyqi1dPm6wBoESvsJ5awDhNqx+RbyYE=
 github.com/0magnet/xterm-go v0.0.0-20260907164817-c5d24e1daacc/go.mod h1:W6c6ofSTsxXuQEr1rSZ3qmfOj5a3LGB3uLQBL0/TiKc=
 github.com/0magnet/yamux v0.1.3-0.20260905172050-450c4058f851 h1:kCRHPdm/JLtNrPlHUyb/HiNRb5XJQEFtCKYtLEUlQT4=

--- a/pkg/visor/hypervisor_desk_test.go
+++ b/pkg/visor/hypervisor_desk_test.go
@@ -78,6 +78,12 @@ func TestNativeDeskServing(t *testing.T) {
 		if !strings.Contains(body, pk.Hex()) {
 			t.Error("page lacks the injected local PK")
 		}
+		// The terminal window: the host visor's pty page, relative like the
+		// dashboard URL, keyed by the local PK. Parity with the wasm desk's
+		// console window.
+		if !strings.Contains(body, "terminalURL: './pty/"+pk.Hex()+"'") {
+			t.Error("page lacks the relative pty terminal window URL")
+		}
 		// The ONE-VISOR rule, as served bytes: the native desk page must not
 		// even reference the wasm-visor module or its loader.
 		for _, banned := range []string{"wasm-visor.wasm", "wasm_exec", "skywire.wasm"} {

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -269,7 +269,7 @@ func (hv *Hypervisor) serveNativeDesk(w http.ResponseWriter) {
 		`<script src="/skywire-browse-launcher.js"></script>` + "\n" +
 		`<script>` + uiAutoReloadJS + `</script>` + "\n" +
 		`<script src="/desk-boot.js"></script>`
-	page := deskShellHTML(scripts, nativeDeskBootOpts)
+	page := deskShellHTML(scripts, nativeDeskBootOpts(localPK))
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
 	_, _ = w.Write(page) //nolint:errcheck
@@ -277,13 +277,21 @@ func (hv *Hypervisor) serveNativeDesk(w http.ResponseWriter) {
 
 // nativeDeskBootOpts is the skywireDeskBoot options object for the
 // native-served /desk: native mode (no wasm anything), dashboard window on
-// the same-origin Angular UI. embed=1 rides in the HASH (the Angular UI is
-// hash-routed) so the iframe's own injected launcher hides its taskbar — the
-// same chrome-less guard the ☰ chat/log windows rely on.
-const nativeDeskBootOpts = `{
-  native: true,
-  dashboardURL: './?embed=1#/?embed=1',
-}`
+// the same-origin Angular UI, and a terminal window on the host visor's pty
+// page. embed=1 rides in the HASH (the Angular UI is hash-routed) so the
+// iframe's own injected launcher hides its taskbar — the same chrome-less
+// guard the ☰ chat/log windows rely on.
+//
+// terminalURL is the page the dashboard's Terminal tab opens: /pty/<pk>,
+// xterm over a websocket to the local visor's pty. Relative for the same
+// reason dashboardURL is. Absent when no visor is attached (nothing to open).
+func nativeDeskBootOpts(localPK string) string {
+	opts := "{\n  native: true,\n  dashboardURL: './?embed=1#/?embed=1',\n"
+	if localPK != "" {
+		opts += "  terminalURL: './pty/" + localPK + "',\n"
+	}
+	return opts + "}"
+}
 
 // uiVersionHash fingerprints the served UI bundle (short sha256 of index.html,
 // which embeds the content-hashed chunk names).
@@ -333,9 +341,10 @@ const uiAutoReloadJS = `(function(){
 // on before opening the dashboard window. It refuses to mount inside an
 // embedded frame (embed=1 in the hash/query): the dashboard window is an
 // iframe of the framed root and must not grow its own taskbar. The retired
-// browse.js engine's providers are gone with it; the native desk's terminal
-// remains the dashboard's Terminal tab (dmsgpty) until the shared shell
-// integration lands.
+// browse.js engine's providers are gone with it. The native desk's terminal
+// is the host visor's pty page (/pty/<pk>, xterm over a websocket — the same
+// backend as the dashboard's Terminal tab), opened as a desk window at boot by
+// desk-boot and from the ☰ menu here, until the shared shell integration lands.
 const nativeBrowseLauncherJS = `(function () {
   if (/[#?&]embed=1/.test(location.hash + location.search)) { return; }
   function ready() {
@@ -351,7 +360,11 @@ const nativeBrowseLauncherJS = `(function () {
     // paths away anyway. The launcher already returns early on an embed=1
     // page, so this only ever runs on the desk root.
     var dashURL = "./?embed=1#/?embed=1";
-    var p = self.skywireDeskPanel.mount(document, { dashboardURL: dashURL });
+    // The terminal entry: the host visor's pty over a websocket (/pty/<pk>),
+    // the page the dashboard's Terminal tab opens. Relative for the same
+    // reason dashURL is.
+    var termURL = window.__SKYWIRE_LOCAL_PK__ ? "./pty/" + window.__SKYWIRE_LOCAL_PK__ : "";
+    var p = self.skywireDeskPanel.mount(document, { dashboardURL: dashURL, terminalURL: termURL });
     // Stream the NATIVE visor's server-side log (/api/log SSE) into the log
     // window's buffer, when a log consumer exists on the page.
     try {

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -1,3 +1,13 @@
+					// The terminal, for parity with the wasm desk's console window: the
+					// host visor's pty over a websocket (/pty/<pk>), the page the
+					// dashboard's Terminal tab opens. Opened BEFORE the dashboard so the
+					// dashboard keeps focus, the way the wasm desk keeps its dashboard in
+					// front of the console it has already opened.
+					if (opts.terminalURL && panel && typeof panel.open === 'function') {
+						try {
+							panel.open({ title: 'skywire', url: opts.terminalURL, x: 'center', y: 'center', width: '70%', height: '60%' });
+						} catch (e) { console.warn('terminal window:', e); }
+					}
 // pkg/wasmhv/browseui/desk-boot.js c3-vis-wasm
 // The shared desk boot: one parameterized entry point behind both desk-first
 // pages — the docs-site playground (no visor by default) and the converged

--- a/vendor/github.com/0magnet/desk/panel-nowasm.js
+++ b/vendor/github.com/0magnet/desk/panel-nowasm.js
@@ -131,6 +131,15 @@
 		// Capability-gated entries: present only when the page actually carries
 		// the machinery (the wasm-visor DOM instance installs these; the native
 		// desk page has neither and shows neither).
+		// A host with no in-page shell can still name a terminal PAGE: the native
+		// hypervisor passes its /pty/<pk> — xterm over a websocket to the host
+		// visor's pty — and it opens as an iframe window the way the dashboard
+		// does. The in-page shell wins where both exist.
+		if (opts.terminalURL && !(globalThis.skywireShell && typeof globalThis.skywireShell.open === 'function')) {
+			menuItem('terminal', function () {
+				panel.open({ title: 'terminal', url: opts.terminalURL, x: 'center', y: 'center', width: '70%', height: '60%' });
+			});
+		}
 		if (globalThis.skywireShell && typeof globalThis.skywireShell.open === 'function') {
 			menuItem('terminal', function () {
 				var wb = panel.open({ title: 'terminal', x: 'center', y: 'center', width: '70%', height: '60%' });

--- a/vendor/github.com/0magnet/desk/panel.go
+++ b/vendor/github.com/0magnet/desk/panel.go
@@ -229,10 +229,23 @@ func (p *Panel) key(ev js.Value) {
 	}
 }
 
+// launchFromMenu starts an app the person picked, off the event callback.
+//
+// The goroutine is not decoration. This runs inside a DOM click (or keydown)
+// handler, and on js/wasm a syscall/js callback MUST NOT BLOCK: the Go runtime
+// is executing on the browser's event loop, so anything that waits for JS to
+// call back — a host filesystem read, a fetch, a worker — waits for a turn of
+// the loop that this handler is itself holding, and the page hangs with no
+// error anywhere. Mounting is exactly where a pane does that: a terminal over
+// the machine's filesystem asks the host for /bin before it can draw a prompt.
+// Off the handler, the launch blocks a goroutine of its own and the loop keeps
+// turning.
 func launchFromMenu(name string) {
-	if _, err := Launch(name); err != nil {
-		js.Global().Get("console").Call("warn", "desk: "+err.Error())
-	}
+	go func() {
+		if _, err := Launch(name); err != nil {
+			js.Global().Get("console").Call("warn", "desk: "+err.Error())
+		}
+	}()
 }
 
 // SetActive marks which window the task buttons should show as focused. Only

--- a/vendor/github.com/0magnet/winbox-go/README.md
+++ b/vendor/github.com/0magnet/winbox-go/README.md
@@ -3,7 +3,7 @@
 </h1>
 <h3>winbox-go: a full Go/WebAssembly port of WinBox.js — modern window manager for the web: lightweight, no dependencies, fully customizable, open source!</h3>
 
-<a href="https://0magnet.github.io/winbox-go/">Demo</a> &ensp;&bull;&ensp; <a href="#started">Getting Started</a> &ensp;&bull;&ensp; <a href="#options">Options</a> &ensp;&bull;&ensp; <a href="#api">API</a> &ensp;&bull;&ensp; <a href="#themes">Themes</a> &ensp;&bull;&ensp; <a href="#customize">Customize</a> &ensp;&bull;&ensp; <a href="#jsapi">From JavaScript</a> &ensp;&bull;&ensp; <a href="#differences">Differences from WinBox.js</a>
+<a href="https://winbox-go.magnetosphere.net/">Demo</a> &ensp;&bull;&ensp; <a href="#started">Getting Started</a> &ensp;&bull;&ensp; <a href="#options">Options</a> &ensp;&bull;&ensp; <a href="#api">API</a> &ensp;&bull;&ensp; <a href="#themes">Themes</a> &ensp;&bull;&ensp; <a href="#customize">Customize</a> &ensp;&bull;&ensp; <a href="#jsapi">From JavaScript</a> &ensp;&bull;&ensp; <a href="#differences">Differences from WinBox.js</a>
 
 This is a complete port of [WinBox.js](https://github.com/nextapps-de/winbox) by Thomas Wilkerling to Go, targeting WebAssembly via `syscall/js`. It compiles with both the **standard Go toolchain** (`GOOS=js GOARCH=wasm`) and **TinyGo** (`-target wasm`), and ports the entire feature set: drag, 8-direction resize, minimize with split-screen taskbar stacking, maximize, browser fullscreen, modals, DOM mount/unmount, iframes, custom controls and templates, viewport limits, percentage/centered positioning, and all lifecycle callbacks.
 
@@ -14,7 +14,7 @@ If you find the underlying window manager useful, consider [supporting the origi
 <a name="demo"></a>
 ### Live Demo
 
-<a href="https://0magnet.github.io/winbox-go/">https://0magnet.github.io/winbox-go/</a> (compiled with TinyGo)
+<a href="https://winbox-go.magnetosphere.net/">https://winbox-go.magnetosphere.net/</a> (compiled with TinyGo)
 
 ![winbox-go in the browser](docs/winbox-go-demo.png "windows with drag, resize, minimize and the split-screen taskbar, drawn from Go")
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -47,7 +47,7 @@ github.com/0magnet/coloredcobra
 # github.com/0magnet/cosmos-go v0.0.0-20260907164823-2289c429c265
 ## explicit; go 1.24
 github.com/0magnet/cosmos-go
-# github.com/0magnet/desk v0.0.0-20260908155111-f022a08dc97e
+# github.com/0magnet/desk v0.0.0-20260908190105-9bb2944487db
 ## explicit; go 1.26
 github.com/0magnet/desk
 github.com/0magnet/desk/dom
@@ -136,7 +136,7 @@ github.com/0magnet/websh/shell/browser
 # github.com/0magnet/wfdrive v0.3.1
 ## explicit; go 1.25.0
 github.com/0magnet/wfdrive/bidi
-# github.com/0magnet/winbox-go v0.0.0-20260907164818-1573f12aafdd
+# github.com/0magnet/winbox-go v0.0.0-20260908011106-113d480c4188
 ## explicit; go 1.24
 github.com/0magnet/winbox-go
 github.com/0magnet/winbox-go/dist


### PR DESCRIPTION
Two parity gaps with the wasm desk, both seen live on the host at :8000.

**Dashboard tab showed "404 page not found".** The wasm module runs in the `browser` role on the native page and installs only netscrape; `netscrape.DirectLoader` is set in `installDesk`, which that role never runs. With no loader, netscrape fetched the page through its transcoder, which asks the origin's `/fetch` proxy, and a native hypervisor has none. The browser role now claims same-origin URLs for native rendering (`sameOriginSrc`, tested). The desk page's loader stays vnet-only, since a docs site may host it.

**No terminal window.** The native desk now opens the host visor's pty page (`/pty/<pk>`, xterm over a websocket, the same backend and auth gate as the dashboard's Terminal tab) as a desk window at boot and from the panel's menu. The server fills `terminalURL` from the local PK; vendors 0magnet/desk 9bb2944 for the menu entry. Verified live in the :8000 tab: the window connects and shows a shell prompt.

The dashboard half needs the embedded wasm-visor blob rebuilt; that follows as its own PR per the usual convention, so `TestCommittedWasmNotStale` is expected red here.