### PR TITLE
fix(desk): the terminal-window block landed outside skywireDeskBoot

### DIFF
--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -1,13 +1,3 @@
-					// The terminal, for parity with the wasm desk's console window: the
-					// host visor's pty over a websocket (/pty/<pk>), the page the
-					// dashboard's Terminal tab opens. Opened BEFORE the dashboard so the
-					// dashboard keeps focus, the way the wasm desk keeps its dashboard in
-					// front of the console it has already opened.
-					if (opts.terminalURL && panel && typeof panel.open === 'function') {
-						try {
-							panel.open({ title: 'skywire', url: opts.terminalURL, x: 'center', y: 'center', width: '70%', height: '60%' });
-						} catch (e) { console.warn('terminal window:', e); }
-					}
 // pkg/wasmhv/browseui/desk-boot.js c3-vis-wasm
 // The shared desk boot: one parameterized entry point behind both desk-first
 // pages — the docs-site playground (no visor by default) and the converged
@@ -253,6 +243,16 @@
 					// "0px" by most engines) and "auto" for a top dock.
 					var bd = bar ? bar.style.bottom : 'auto';
 					var topDocked = !(bd === '0' || bd === '0px');
+					// The terminal, for parity with the wasm desk's console window: the
+					// host visor's pty over a websocket (/pty/<pk>), the page the
+					// dashboard's Terminal tab opens. Opened BEFORE the dashboard so the
+					// dashboard keeps focus, the way the wasm desk keeps its dashboard in
+					// front of the console it has already opened.
+					if (opts.terminalURL && panel && typeof panel.open === 'function') {
+						try {
+							panel.open({ title: 'skywire', url: opts.terminalURL, x: 'center', y: 'center', width: '70%', height: '60%' });
+						} catch (e) { console.warn('terminal window:', e); }
+					}
 					// No `url:` — the body is handed to netscrape below, which
 					// opens dashURL as a TAB. WinBox's own `url` would make the
 					// body a bare iframe, which is what this page did before

--- a/pkg/wasmhv/browseui/deskboot_test.go
+++ b/pkg/wasmhv/browseui/deskboot_test.go
@@ -1,0 +1,45 @@
+package browseui
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDeskBootHasNoCodeBeforeItsHeader guards the shape of desk-boot.js: the
+// file opens with its header comment and every statement lives inside the
+// skywireDeskBoot definition. A block that lands OUTSIDE it runs at load time
+// against names that only exist inside — which is exactly what shipped once
+// (a terminal-window insert anchored on a line that occurs twice), throwing
+// "opts is not defined" before skywireDeskBoot was ever defined and leaving
+// the native hypervisor page blank.
+func TestDeskBootHasNoCodeBeforeItsHeader(t *testing.T) {
+	b, err := os.ReadFile("desk-boot.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(b)
+	if !strings.HasPrefix(src, "// pkg/wasmhv/browseui/desk-boot.js") {
+		first, _, _ := strings.Cut(src, "\n")
+		t.Fatalf("desk-boot.js must open with its header comment; first line is %q", first)
+	}
+	if !strings.Contains(src, "skywireDeskBoot") {
+		t.Fatal("desk-boot.js does not define skywireDeskBoot")
+	}
+	// The boot options exist only inside the function that receives them, so
+	// no code before its definition may touch them. Comments are allowed to
+	// mention the name; code is not.
+	def := strings.Index(src, "globalThis.skywireDeskBoot = function (opts)")
+	if def < 0 {
+		t.Fatal("cannot locate the skywireDeskBoot definition")
+	}
+	for i, line := range strings.Split(src[:def], "\n") {
+		l := strings.TrimSpace(line)
+		if strings.HasPrefix(l, "//") {
+			continue
+		}
+		if strings.Contains(l, "opts.") {
+			t.Fatalf("line %d references opts before skywireDeskBoot is defined: %q", i+1, l)
+		}
+	}
+}


### PR DESCRIPTION
#4675 anchored its insert on a line that occurs twice in desk-boot.js and the block landed at the top of the file, throwing `opts is not defined` at load before `skywireDeskBoot` existed; the native hypervisor page came up blank (seen live after the visor restart). The block is moved inside the native boot branch, and a test pins that no code before the boot definition references `opts` (fails on the develop file, passes here).