### PR TITLE
feat(desk): tabs in the window title bar, reorderable, and a tabbed native terminal

### DIFF
--- a/cmd/wasm-visor/browser_js.go
+++ b/cmd/wasm-visor/browser_js.go
@@ -19,6 +19,7 @@ package main
 import (
 	"syscall/js"
 
+	"github.com/0magnet/desk"
 	"github.com/0magnet/netscrape"
 )
 
@@ -63,6 +64,7 @@ func jsOpenBrowser(_ js.Value, args []js.Value) any {
 		return nil
 	}
 	netscrape.Open(netscrapeHost(el))
+	hoistBrowserTabs(el)
 	return nil
 }
 
@@ -122,4 +124,20 @@ func netscrapeHost(el js.Value) js.Value {
 		"position:relative;width:100%;height:100%;display:flex;flex-direction:column;overflow:hidden")
 	el.Call("appendChild", inner)
 	return inner
+}
+
+// hoistBrowserTabs moves netscrape's tab strip out of the browser's box and
+// into the title bar of the desk window that holds el, level with the window
+// controls — where a browser keeps its tabs. A host element outside any window
+// keeps the strip where netscrape put it. Both desks come through here: the
+// wasm desk's browser pane and the native page's dashboard window.
+func hoistBrowserTabs(el js.Value) {
+	if !el.Truthy() || el.Get("closest").Type() != js.TypeFunction {
+		return
+	}
+	win := el.Call("closest", ".winbox")
+	if !win.Truthy() {
+		return
+	}
+	desk.MountInHeader(win, netscrape.TabStrip())
 }

--- a/cmd/wasm-visor/desk_js.go
+++ b/cmd/wasm-visor/desk_js.go
@@ -64,6 +64,7 @@ func installDesk() {
 		Open: func(args []string) (desk.Pane, error) {
 			return funcPane{mount: func(el js.Value) error {
 				netscrape.Open(netscrapeHost(el))
+				hoistBrowserTabs(el)
 				if len(args) > 0 && args[0] != "" {
 					netscrape.Navigate(args[0])
 				}

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/0magnet/bitree v0.0.0-20260906144807-e66de0b4c738
 	github.com/0magnet/bottle v0.0.0-20260908155251-920d2280a387
 	github.com/0magnet/calvin v0.0.0-20260908180241-0893f4bff56a
-	github.com/0magnet/desk v0.0.0-20260908190105-9bb2944487db
+	github.com/0magnet/desk v0.0.0-20260908195947-f72d9b0a9bb1
 	github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db
 	github.com/0magnet/gobrpc v0.0.0-20260906144809-5215ec59d553
 	github.com/0magnet/golang-ipc v1.2.5-0.20260905172007-25d9c1a262d0
@@ -73,7 +73,7 @@ require (
 	github.com/0magnet/gotop/v4 v4.2.1-0.20260905172009-f9d674fb6dfd
 	github.com/0magnet/lolcat-go v0.0.0-20260907230215-22c54b7702c7
 	github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c
-	github.com/0magnet/netscrape v0.0.0-20260908062733-9acf9bfa0061
+	github.com/0magnet/netscrape v0.0.0-20260908195716-c9218b3f4966
 	github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d
 	github.com/0magnet/plot-go v0.0.0-20260908184629-9cfdeb563e8f
 	github.com/0magnet/realorigin v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/0magnet/coloredcobra v1.0.3 h1:s/3WW+wAssjMEKgzlXWcQ6PGSoKJIoambL68yt
 github.com/0magnet/coloredcobra v1.0.3/go.mod h1:Kn7dmRJcnVybFNKY0FNUjLcsivW4FCbAec8ZfVmz51I=
 github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585 h1:G2m5S+A3CMsHobihQUfsl2ZLnepQCPjeWcwDp7505Rs=
 github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585/go.mod h1:dp0q1zfKQmTaohUrPEPZbPExxBWLu9DyeaFxKUBnw6Y=
-github.com/0magnet/desk v0.0.0-20260908190105-9bb2944487db h1:EerFzR/1OAe/NG6r1ysuG1+lyS0qMJ6YwaoognLG6gY=
-github.com/0magnet/desk v0.0.0-20260908190105-9bb2944487db/go.mod h1:L+8Y1fP55UjK6RFOG0iAsR9oO6zXidCr9LZJy+8oN/k=
+github.com/0magnet/desk v0.0.0-20260908195947-f72d9b0a9bb1 h1:818rzhVmbPOZLtwshwHs04zsFLv/Q5GXdt+oLwZg6CY=
+github.com/0magnet/desk v0.0.0-20260908195947-f72d9b0a9bb1/go.mod h1:L+8Y1fP55UjK6RFOG0iAsR9oO6zXidCr9LZJy+8oN/k=
 github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db h1:t/kQDGFMvKhpRBTdEjiLCkVG9Pe/qmDuD8D65DJrdrs=
 github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db/go.mod h1:EDtFhI1TlDPunQIoT8IRbhe8wa5R4GAI+iL04vQDk2Y=
 github.com/0magnet/go-dsp v0.0.0-20260907230215-136ba239cc2d h1:AE2MbqkqaB88h+jtiWo5aI6zODI+0QZZRI4lY0p9Fhw=
@@ -100,8 +100,8 @@ github.com/0magnet/lolcat-go v0.0.0-20260907230215-22c54b7702c7 h1:0l4PGiCpSu06V
 github.com/0magnet/lolcat-go v0.0.0-20260907230215-22c54b7702c7/go.mod h1:DbbClVrvQ558CvwGWU78xx0k03aEY/uS9qf5Wtw+n3o=
 github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c h1:Uj+2n5pWraLqGRmu9uFMZDr2TImQN0LqLUSSMd92iWk=
 github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c/go.mod h1:9MHaZG+XGoXfQW/L7yOpJx/gbKmCynAejV3Xpll/usw=
-github.com/0magnet/netscrape v0.0.0-20260908062733-9acf9bfa0061 h1:57zEXMWapu1Ta3yEImhq+JReM015aj7J99CCXVJhQR4=
-github.com/0magnet/netscrape v0.0.0-20260908062733-9acf9bfa0061/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
+github.com/0magnet/netscrape v0.0.0-20260908195716-c9218b3f4966 h1:d+xEuIADmGxnurlqSzVRIwV4KC9j32pgSTUVWT1eS+8=
+github.com/0magnet/netscrape v0.0.0-20260908195716-c9218b3f4966/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
 github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d h1:T/CISGqaX8Sw1F+SYH6Uz8UQTsSN4KBabrCLShG+WRk=
 github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d/go.mod h1:xNKk6t2OtJQfb/pmWNiH8zUi0YCBuhYAr+fYa+rQ46s=
 github.com/0magnet/plot-go v0.0.0-20260908184629-9cfdeb563e8f h1:P1mbxDg4oisWjKscItJzjTaT38BS59GRQ3uLzoNuojU=

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -250,7 +250,10 @@
 					// front of the console it has already opened.
 					if (opts.terminalURL && panel && typeof panel.open === 'function') {
 						try {
-							panel.open({ title: 'skywire', url: opts.terminalURL, x: 'center', y: 'center', width: '70%', height: '60%' });
+							// openTabbed where the panel has it: tabs in the title bar, "+"
+							// for another session, the way the wasm desk tabs its terminals.
+							var openTerm = typeof panel.openTabbed === 'function' ? panel.openTabbed : panel.open;
+							openTerm.call(panel, { title: 'skywire', url: opts.terminalURL, x: 'center', y: 'center', width: '70%', height: '60%' });
 						} catch (e) { console.warn('terminal window:', e); }
 					}
 					// No `url:` — the body is handed to netscrape below, which

--- a/vendor/github.com/0magnet/desk/header_js.go
+++ b/vendor/github.com/0magnet/desk/header_js.go
@@ -1,0 +1,59 @@
+//go:build js && wasm
+
+package desk
+
+import "syscall/js"
+
+// MountInHeader moves el into the title bar of the window whose outer element
+// is wbEl (winbox's ".winbox" node), to the right of the title and level with
+// the window controls — where a browser keeps its tabs. It reports false, and
+// leaves el where it is, when wbEl has no title bar to speak of.
+//
+// The title bar is winbox's drag handle. Pressing on anything inside el would
+// start a window drag, which swallows the click and defeats an HTML5 tab drag,
+// so presses that land on el's children stop there; a press on el's own empty
+// space still moves the window, as the rest of the bar does.
+func MountInHeader(wbEl, el js.Value) bool {
+	if !wbEl.Truthy() || !el.Truthy() {
+		return false
+	}
+	drag := wbEl.Call("querySelector", ".wb-drag")
+	if !drag.Truthy() {
+		return false
+	}
+	ds := drag.Get("style")
+	ds.Set("display", "flex")
+	ds.Set("alignItems", "flex-end")
+	ds.Set("minWidth", "0")
+	if title := wbEl.Call("querySelector", ".wb-title"); title.Truthy() {
+		ts := title.Get("style")
+		ts.Set("flex", "0 1 auto")
+		ts.Set("maxWidth", "40%")
+		ts.Set("marginRight", "8px")
+		ts.Set("alignSelf", "center")
+	}
+	es := el.Get("style")
+	es.Set("flex", "1 1 auto")
+	es.Set("minWidth", "0")
+	es.Set("height", "100%")
+	es.Set("alignItems", "flex-end")
+	es.Set("padding", "0 4px")
+	es.Set("background", "transparent")
+	es.Set("border", "0")
+	es.Set("borderBottom", "0")
+	es.Set("minHeight", "0")
+	es.Set("overflowX", "auto")
+	es.Set("overflowY", "hidden")
+	es.Set("lineHeight", "normal")
+	es.Set("cursor", "default")
+	stop := js.FuncOf(func(_ js.Value, a []js.Value) any {
+		if len(a) > 0 && !a[0].Get("target").Equal(el) {
+			a[0].Call("stopPropagation")
+		}
+		return nil
+	})
+	el.Call("addEventListener", "mousedown", stop)
+	el.Call("addEventListener", "touchstart", stop)
+	drag.Call("appendChild", el)
+	return true
+}

--- a/vendor/github.com/0magnet/desk/panel-nowasm.js
+++ b/vendor/github.com/0magnet/desk/panel-nowasm.js
@@ -92,6 +92,25 @@
 			return b;
 		}
 
+		// mountInHeader puts el in a window's title bar, right of the title and level
+		// with the controls, where a browser keeps its tabs. Presses on el's children
+		// stop before winbox's drag handle sees them, so a tab click is a click and an
+		// HTML5 tab drag is not swallowed by a window drag; a press on el's own empty
+		// space still moves the window, as the rest of the bar does.
+		function mountInHeader(wbEl, el) {
+			var drag = wbEl && wbEl.querySelector('.wb-drag');
+			if (!drag) return false;
+			drag.style.display = 'flex'; drag.style.alignItems = 'flex-end'; drag.style.minWidth = '0';
+			var title = wbEl.querySelector('.wb-title');
+			if (title) { title.style.flex = '0 1 auto'; title.style.maxWidth = '40%'; title.style.marginRight = '8px'; title.style.alignSelf = 'center'; }
+			el.style.cssText += ';flex:1 1 auto;min-width:0;height:100%;display:flex;align-items:flex-end;gap:2px;padding:0 4px;background:transparent;border:0;overflow-x:auto;overflow-y:hidden;line-height:normal;cursor:default';
+			var stop = function (ev) { if (ev.target !== el) ev.stopPropagation(); };
+			el.addEventListener('mousedown', stop);
+			el.addEventListener('touchstart', stop);
+			drag.appendChild(el);
+			return true;
+		}
+
 		var panel = {
 			root: root,
 			bar: bar,
@@ -121,6 +140,63 @@
 				winArea.appendChild(btn);
 				return wb;
 			},
+			// openTabbed opens a window whose body is a stack of iframes behind a tab
+			// strip in the title bar: "+" adds another tab on wo.url (a terminal page
+			// gives a fresh session each time), × closes one, closing the last closes
+			// the window. The engine-free twin of the Go desk's tabbed panes, for a
+			// host page with no wasm desk of its own.
+			openTabbed: function (wo) {
+				wo = wo || {};
+				var url = wo.url; delete wo.url;
+				var wb = panel.open(wo);
+				var body = wb.body;
+				if (!body.style.position) body.style.position = 'relative';
+				var strip = doc.createElement('div');
+				strip.style.cssText = 'display:flex;gap:2px;align-items:flex-end';
+				var plus = doc.createElement('div');
+				plus.textContent = '+';
+				plus.title = 'new tab';
+				plus.style.cssText = 'color:#cdd2da;border:1px solid #2a3040;border-bottom:none;border-radius:5px 5px 0 0;padding:3px 8px;cursor:pointer;font:12px monospace';
+				strip.appendChild(plus);
+				var tabs = [];
+				function activate(t) {
+					tabs.forEach(function (x) {
+						x.frame.style.display = x === t ? 'block' : 'none';
+						x.btn.style.background = x === t ? '#2a3040' : 'transparent';
+					});
+				}
+				function addTab() {
+					var t = { btn: doc.createElement('div'), frame: doc.createElement('iframe') };
+					t.btn.style.cssText = 'display:flex;align-items:center;gap:6px;color:#cdd2da;border:1px solid #2a3040;border-bottom:none;border-radius:5px 5px 0 0;padding:3px 8px;cursor:pointer;font:12px monospace;white-space:nowrap';
+					var lbl = doc.createElement('span');
+					lbl.textContent = (wo.title || 'tab') + (tabs.length ? ' ' + (tabs.length + 1) : '');
+					var x = doc.createElement('span');
+					x.textContent = '×'; x.style.cssText = 'opacity:.6;padding:0 2px';
+					t.btn.appendChild(lbl); t.btn.appendChild(x);
+					t.frame.src = url;
+					t.frame.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;border:0;display:none';
+					t.btn.addEventListener('click', function (ev) { ev.stopPropagation(); activate(t); });
+					x.addEventListener('click', function (ev) {
+						ev.stopPropagation();
+						if (tabs.length === 1) { wb.close(); return; }
+						var i = tabs.indexOf(t);
+						tabs.splice(i, 1); t.btn.remove(); t.frame.remove();
+						activate(tabs[Math.min(i, tabs.length - 1)]);
+					});
+					strip.insertBefore(t.btn, plus);
+					body.appendChild(t.frame);
+					tabs.push(t);
+					activate(t);
+				}
+				plus.addEventListener('click', function (ev) { ev.stopPropagation(); addTab(); });
+				if (!mountInHeader(wb.dom || body.closest('.winbox'), strip)) {
+					strip.style.background = '#151922';
+					body.insertBefore(strip, body.firstChild);
+				}
+				addTab();
+				return wb;
+			},
+			mountInHeader: mountInHeader,
 		};
 
 		if (opts.dashboardURL) {
@@ -137,7 +213,7 @@
 		// does. The in-page shell wins where both exist.
 		if (opts.terminalURL && !(globalThis.skywireShell && typeof globalThis.skywireShell.open === 'function')) {
 			menuItem('terminal', function () {
-				panel.open({ title: 'terminal', url: opts.terminalURL, x: 'center', y: 'center', width: '70%', height: '60%' });
+				panel.openTabbed({ title: 'terminal', url: opts.terminalURL, x: 'center', y: 'center', width: '70%', height: '60%' });
 			});
 		}
 		if (globalThis.skywireShell && typeof globalThis.skywireShell.open === 'function') {

--- a/vendor/github.com/0magnet/desk/tabs_js.go
+++ b/vendor/github.com/0magnet/desk/tabs_js.go
@@ -88,7 +88,12 @@ func newTabset(win *winbox.WinBox) *tabset {
 	views := doc.Call("createElement", "div")
 	views.Get("style").Set("cssText", "position:relative;flex:1 1 auto;min-height:0")
 
-	body.Call("appendChild", strip)
+	// The strip lives in the title bar, level with the window controls, the way
+	// a browser keeps its tabs. Only if the window has no title bar does it
+	// fall back to the top of the body.
+	if !MountInHeader(win.DOM, strip) {
+		body.Call("appendChild", strip)
+	}
 	body.Call("appendChild", views)
 
 	ts := &tabset{win: win, strip: strip, views: views, active: -1}

--- a/vendor/github.com/0magnet/netscrape/browser.go
+++ b/vendor/github.com/0magnet/netscrape/browser.go
@@ -556,6 +556,7 @@ func addTab(url string) {
 
 	onClick(t.btn, func() { activate(indexOf(t)) })
 	onClick(x, func() { closeTab(indexOf(t)) })
+	wireTabDrag(t)
 	// Middle-click closes a tab, as everywhere else.
 	t.btn.Call("addEventListener", "auxclick", js.FuncOf(func(_ js.Value, a []js.Value) any {
 		if len(a) > 0 && a[0].Get("button").Int() == 1 {
@@ -822,8 +823,20 @@ func Navigate(url string) {
 // NewTab opens url in a new tab. With background true the current tab keeps
 // focus — the browser-style "open in background tab" a host uses to preload
 // secondary pages behind the one the user is looking at. A no-op before Open.
+//
+// The first host-driven tab REPLACES the start page rather than joining it.
+// Open has to show something, so it opens the built-in page; a host that then
+// names its own first page (the visor desk opens its hypervisor UI) was left
+// with a "new tab" nobody asked for sitting first in the strip. The
+// replacement happens only while that tab is still the untouched start page —
+// one tab, no history — so a person who has begun using it keeps it.
 func NewTab(url string, background bool) {
 	if doc.IsUndefined() {
+		return
+	}
+	if len(tabs) == 1 && isUntouchedStart(tabs[0]) {
+		navigate(tabs[0], url)
+		activate(0)
 		return
 	}
 	prev := active
@@ -831,4 +844,85 @@ func NewTab(url string, background bool) {
 	if background && prev >= 0 && prev < len(tabs) {
 		activate(prev)
 	}
+}
+
+// isUntouchedStart reports whether t is still the tab Open created and nobody
+// has used: its only history entry is the start page.
+func isUntouchedStart(t *tab) bool {
+	return t != nil && len(t.hist) == 1 && t.pos == 0 && t.hist[0] == home()
+}
+
+// TabStrip returns the tab strip element once Open has built it, so a host can
+// move it out of the browser's own box — into its window's title bar, where a
+// browser keeps its tabs, level with the window controls. The strip keeps
+// working wherever it lives: tabs are wired to their frames, not to their
+// parent. Undefined before Open.
+func TabStrip() js.Value {
+	return strip
+}
+
+// dragging is the tab being dragged across the strip, nil between drags.
+var dragging *tab
+
+// wireTabDrag lets a tab be picked up and dropped on another to reorder them,
+// the way every browser's strip works. HTML5 drag events, not pointer math:
+// the strip may live in a window's title bar whose own pointer handler moves
+// the window, and a native drag does not start one of those.
+func wireTabDrag(t *tab) {
+	t.btn.Set("draggable", true)
+	t.btn.Call("addEventListener", "dragstart", js.FuncOf(func(_ js.Value, a []js.Value) any {
+		dragging = t
+		if len(a) > 0 {
+			if dt := a[0].Get("dataTransfer"); dt.Truthy() {
+				dt.Set("effectAllowed", "move")
+				// Some engines cancel the drag with an empty payload.
+				dt.Call("setData", "text/plain", labelFor(t.hist[t.pos]))
+			}
+		}
+		return nil
+	}))
+	t.btn.Call("addEventListener", "dragover", js.FuncOf(func(_ js.Value, a []js.Value) any {
+		if dragging != nil && dragging != t && len(a) > 0 {
+			a[0].Call("preventDefault") // allow the drop
+			if dt := a[0].Get("dataTransfer"); dt.Truthy() {
+				dt.Set("dropEffect", "move")
+			}
+		}
+		return nil
+	}))
+	t.btn.Call("addEventListener", "drop", js.FuncOf(func(_ js.Value, a []js.Value) any {
+		if len(a) > 0 {
+			a[0].Call("preventDefault")
+		}
+		if dragging != nil && dragging != t {
+			moveTab(indexOf(dragging), indexOf(t))
+		}
+		dragging = nil
+		return nil
+	}))
+	t.btn.Call("addEventListener", "dragend", js.FuncOf(func(_ js.Value, _ []js.Value) any {
+		dragging = nil
+		return nil
+	}))
+}
+
+// moveTab moves the tab at from to position to, in the slice and in the strip,
+// keeping the active tab active.
+func moveTab(from, to int) {
+	if from < 0 || to < 0 || from >= len(tabs) || to >= len(tabs) || from == to {
+		return
+	}
+	cur := tabs[active]
+	t := tabs[from]
+	tabs = append(tabs[:from], tabs[from+1:]...)
+	rest := append([]*tab{}, tabs[to:]...)
+	tabs = append(append(tabs[:to], t), rest...)
+	// Re-place the button before the one now following it, or before the +
+	// button when it moved to the end.
+	if to+1 < len(tabs) {
+		strip.Call("insertBefore", t.btn, tabs[to+1].btn)
+	} else {
+		strip.Call("insertBefore", t.btn, strip.Get("lastChild"))
+	}
+	active = indexOf(cur)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -47,7 +47,7 @@ github.com/0magnet/coloredcobra
 # github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585
 ## explicit; go 1.24
 github.com/0magnet/cosmos-go
-# github.com/0magnet/desk v0.0.0-20260908190105-9bb2944487db
+# github.com/0magnet/desk v0.0.0-20260908195947-f72d9b0a9bb1
 ## explicit; go 1.26
 github.com/0magnet/desk
 github.com/0magnet/desk/dom
@@ -85,7 +85,7 @@ github.com/0magnet/lolcat-go/lol
 # github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c
 ## explicit; go 1.25.0
 github.com/0magnet/metrics
-# github.com/0magnet/netscrape v0.0.0-20260908062733-9acf9bfa0061
+# github.com/0magnet/netscrape v0.0.0-20260908195716-c9218b3f4966
 ## explicit; go 1.24
 github.com/0magnet/netscrape
 # github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d


### PR DESCRIPTION
Browser tabs sit in the desk window's title bar, level with the window controls, in both the wasm desk and the native hypervisor page: netscrape's strip is hoisted there after it mounts (`desk.MountInHeader`). Tabs drag to reorder. The first host-driven tab replaces netscrape's start page, so the stray "new tab" is gone.

The native desk's terminal becomes a tabbed window: "+" opens another pty session. The wasm desk's pane tab strip moves to the title bar as well.

Vendors 0magnet/netscrape c9218b3 and 0magnet/desk f72d9b0. Blob re-embed follows in its own PR, so `TestCommittedWasmNotStale` is expected red here.