### PR TITLE
fix(desk): tabbed native terminal rendered blank

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/0magnet/bitree v0.0.0-20260906144807-e66de0b4c738
 	github.com/0magnet/bottle v0.0.0-20260908155251-920d2280a387
 	github.com/0magnet/calvin v0.0.0-20260908180241-0893f4bff56a
-	github.com/0magnet/desk v0.0.0-20260908195947-f72d9b0a9bb1
+	github.com/0magnet/desk v0.0.0-20260908201307-31a6f6d6f00c
 	github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db
 	github.com/0magnet/gobrpc v0.0.0-20260906144809-5215ec59d553
 	github.com/0magnet/golang-ipc v1.2.5-0.20260905172007-25d9c1a262d0

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/0magnet/coloredcobra v1.0.3 h1:s/3WW+wAssjMEKgzlXWcQ6PGSoKJIoambL68yt
 github.com/0magnet/coloredcobra v1.0.3/go.mod h1:Kn7dmRJcnVybFNKY0FNUjLcsivW4FCbAec8ZfVmz51I=
 github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585 h1:G2m5S+A3CMsHobihQUfsl2ZLnepQCPjeWcwDp7505Rs=
 github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585/go.mod h1:dp0q1zfKQmTaohUrPEPZbPExxBWLu9DyeaFxKUBnw6Y=
-github.com/0magnet/desk v0.0.0-20260908195947-f72d9b0a9bb1 h1:818rzhVmbPOZLtwshwHs04zsFLv/Q5GXdt+oLwZg6CY=
-github.com/0magnet/desk v0.0.0-20260908195947-f72d9b0a9bb1/go.mod h1:L+8Y1fP55UjK6RFOG0iAsR9oO6zXidCr9LZJy+8oN/k=
+github.com/0magnet/desk v0.0.0-20260908201307-31a6f6d6f00c h1:9kMeRmyuFTLwMcsW5i62bM6JdkCtzwkT3noo6FWobdg=
+github.com/0magnet/desk v0.0.0-20260908201307-31a6f6d6f00c/go.mod h1:L+8Y1fP55UjK6RFOG0iAsR9oO6zXidCr9LZJy+8oN/k=
 github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db h1:t/kQDGFMvKhpRBTdEjiLCkVG9Pe/qmDuD8D65DJrdrs=
 github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db/go.mod h1:EDtFhI1TlDPunQIoT8IRbhe8wa5R4GAI+iL04vQDk2Y=
 github.com/0magnet/go-dsp v0.0.0-20260907230215-136ba239cc2d h1:AE2MbqkqaB88h+jtiWo5aI6zODI+0QZZRI4lY0p9Fhw=

--- a/vendor/github.com/0magnet/desk/panel-nowasm.js
+++ b/vendor/github.com/0magnet/desk/panel-nowasm.js
@@ -150,7 +150,9 @@
 				var url = wo.url; delete wo.url;
 				var wb = panel.open(wo);
 				var body = wb.body;
-				if (!body.style.position) body.style.position = 'relative';
+				// winbox positions .wb-body absolutely under the title bar; the frames
+				// below are absolute against it as-is. Setting position here collapsed
+				// the body to zero height (a blank window, seen live).
 				var strip = doc.createElement('div');
 				strip.style.cssText = 'display:flex;gap:2px;align-items:flex-end';
 				var plus = doc.createElement('div');

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -47,7 +47,7 @@ github.com/0magnet/coloredcobra
 # github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585
 ## explicit; go 1.24
 github.com/0magnet/cosmos-go
-# github.com/0magnet/desk v0.0.0-20260908195947-f72d9b0a9bb1
+# github.com/0magnet/desk v0.0.0-20260908201307-31a6f6d6f00c
 ## explicit; go 1.26
 github.com/0magnet/desk
 github.com/0magnet/desk/dom


### PR DESCRIPTION
Vendors 0magnet/desk 31a6f6d. openTabbed set position:relative on the winbox body, replacing its absolute geometry; the body collapsed to zero height and the terminal window showed nothing. Seen live right after #4681. JS-only, served from the vendored embed, so no blob re-embed.