### PR TITLE
feat(desk): netscrape browses the mesh and clearnet natively, with a proxy setting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/0magnet/gotop/v4 v4.2.1-0.20260905172009-f9d674fb6dfd
 	github.com/0magnet/lolcat-go v0.0.0-20260907230215-22c54b7702c7
 	github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c
-	github.com/0magnet/netscrape v0.0.0-20260908195716-c9218b3f4966
+	github.com/0magnet/netscrape v0.0.0-20260908202925-8a8dea1c8609
 	github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d
 	github.com/0magnet/plot-go v0.0.0-20260908184629-9cfdeb563e8f
 	github.com/0magnet/realorigin v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/0magnet/lolcat-go v0.0.0-20260907230215-22c54b7702c7 h1:0l4PGiCpSu06V
 github.com/0magnet/lolcat-go v0.0.0-20260907230215-22c54b7702c7/go.mod h1:DbbClVrvQ558CvwGWU78xx0k03aEY/uS9qf5Wtw+n3o=
 github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c h1:Uj+2n5pWraLqGRmu9uFMZDr2TImQN0LqLUSSMd92iWk=
 github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c/go.mod h1:9MHaZG+XGoXfQW/L7yOpJx/gbKmCynAejV3Xpll/usw=
-github.com/0magnet/netscrape v0.0.0-20260908195716-c9218b3f4966 h1:d+xEuIADmGxnurlqSzVRIwV4KC9j32pgSTUVWT1eS+8=
-github.com/0magnet/netscrape v0.0.0-20260908195716-c9218b3f4966/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
+github.com/0magnet/netscrape v0.0.0-20260908202925-8a8dea1c8609 h1:NaNeMDXsvjbGkE/qSX0lmx7GcVKJDmiarFV+suNPWaI=
+github.com/0magnet/netscrape v0.0.0-20260908202925-8a8dea1c8609/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
 github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d h1:T/CISGqaX8Sw1F+SYH6Uz8UQTsSN4KBabrCLShG+WRk=
 github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d/go.mod h1:xNKk6t2OtJQfb/pmWNiH8zUi0YCBuhYAr+fYa+rQ46s=
 github.com/0magnet/plot-go v0.0.0-20260908184629-9cfdeb563e8f h1:P1mbxDg4oisWjKscItJzjTaT38BS59GRQ3uLzoNuojU=

--- a/pkg/visor/api_apps.go
+++ b/pkg/visor/api_apps.go
@@ -962,7 +962,7 @@ func (v *Visor) GetVPNClientAddress() string {
 // GetSkysocksClientAddress get PK address of server set on skysocks-client
 func (v *Visor) GetSkysocksClientAddress() string {
 	for _, v := range v.conf.Launcher.Apps {
-		if v.Name == skyenv.SkysocksClientAddr {
+		if v.Name == skyenv.SkysocksClientName {
 			for index := range v.Args {
 				if v.Args[index] == "--srv" && index+1 < len(v.Args) {
 					return v.Args[index+1]

--- a/pkg/visor/api_browse.go
+++ b/pkg/visor/api_browse.go
@@ -237,6 +237,18 @@ func (v *Visor) BrowseClearnet(req BrowseClearnetRequest) (*SkynetHTTPResponse, 
 	// upstream proxy to the local visor's own PK. The visor fetches and the caller
 	// inlines, so unlike a browser-direct iframe load it isn't blocked by the target
 	// site's X-Frame-Options/frame-ancestors.
+	// No exit named: use the one the visor already routes its own proxy traffic
+	// through, the skysocks-client's --srv. That is what the wasm visor's
+	// fetchClearnet does with an empty exit, and what the browse-API caller
+	// (netscrape on the native desk) means by "auto". Routing to the zero key
+	// failed with "empty remote public key", so the choice is this or an error.
+	if req.ExitPK.Null() {
+		pk, ok := v.browseDefaultExit()
+		if !ok {
+			return nil, fmt.Errorf("no proxy exit: pass exit_pk or configure skysocks-client --srv")
+		}
+		req.ExitPK = pk
+	}
 	if req.ExitPK == v.conf.PK {
 		return v.directClearnetFetch(req)
 	}
@@ -379,4 +391,18 @@ func (v *Visor) skysocksDialFunc(exitPK cipher.PubKey) func(network, addr string
 		}
 		return &tunnelConn{Conn: stream, closers: []io.Closer{sess, conn}}, nil
 	}
+}
+
+// browseDefaultExit is the exit a clearnet browse uses when the caller names
+// none: the skysocks server the visor's own skysocks-client is configured
+// against. False when there is no such app or it has no --srv.
+func (v *Visor) browseDefaultExit() (cipher.PubKey, bool) {
+	if v.conf == nil || v.conf.Launcher == nil {
+		return cipher.PubKey{}, false
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(v.GetSkysocksClientAddress()); err != nil || pk.Null() {
+		return cipher.PubKey{}, false
+	}
+	return pk, true
 }

--- a/pkg/visor/api_browse_exit_test.go
+++ b/pkg/visor/api_browse_exit_test.go
@@ -1,0 +1,34 @@
+package visor
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// TestBrowseDefaultExit pins where an unnamed clearnet browse gets its exit:
+// the skysocks-client's --srv. It also pins the app-name match itself —
+// GetSkysocksClientAddress compared the app's name against the client's
+// LISTEN ADDRESS constant (":1080") and so never matched anything, which left
+// every caller believing no skysocks server was configured.
+func TestBrowseDefaultExit(t *testing.T) {
+	exit, _ := cipher.GenerateKeyPair()
+	v := &Visor{conf: &visorconfig.V1{Launcher: &visorconfig.Launcher{}}}
+	if _, ok := v.browseDefaultExit(); ok {
+		t.Fatal("no apps configured: must report no exit")
+	}
+	v.conf.Launcher.Apps = []appserver.AppConfig{{
+		Name: skyenv.SkysocksClientName,
+		Args: []string{"app", "skysocks-client", "--srv", exit.Hex(), "--addr", skyenv.SkysocksClientAddr},
+	}}
+	got, ok := v.browseDefaultExit()
+	if !ok || got != exit {
+		t.Fatalf("browseDefaultExit = (%s,%v), want (%s,true)", got, ok, exit)
+	}
+	if v.GetSkysocksClientAddress() != exit.Hex() {
+		t.Fatal("GetSkysocksClientAddress must find the skysocks-client by its app name")
+	}
+}

--- a/pkg/visor/hypervisor_desk_test.go
+++ b/pkg/visor/hypervisor_desk_test.go
@@ -93,6 +93,21 @@ func TestNativeDeskServing(t *testing.T) {
 		}
 	})
 
+	t.Run("the launcher gives netscrape a transport through the browse API", func(t *testing.T) {
+		w := get("/skywire-browse-launcher.js")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status=%d, want 200", w.Code)
+		}
+		body := w.Body.String()
+		// Without a hook netscrape falls back to a same-origin /fetch proxy this
+		// server does not have, and every foreign URL renders a 404 body.
+		for _, want := range []string{"__netscrapeFetch", "/api/browse/fetch", "/api/browse/clearnet"} {
+			if !strings.Contains(body, want) {
+				t.Errorf("launcher lacks %s", want)
+			}
+		}
+	})
+
 	t.Run("the old /desk path redirects to the root", func(t *testing.T) {
 		w := get("/desk")
 		if w.Code != http.StatusMovedPermanently {

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -347,6 +347,55 @@ const uiAutoReloadJS = `(function(){
 // desk-boot and from the ☰ menu here, until the shared shell integration lands.
 const nativeBrowseLauncherJS = `(function () {
   if (/[#?&]embed=1/.test(location.hash + location.search)) { return; }
+  // netscrape's transport on this page: the hypervisor's browse API. Mesh
+  // hosts (.dmsg / .skynet / .skysocks, or a bare PK) go through
+  // /api/browse/fetch — a skynet route first, dmsg-HTTP as the fallback — and
+  // everything else through /api/browse/clearnet, where the visor picks a
+  // proxy exit. The wasm desk does the same through its in-page visor's
+  // fetchDmsg/fetchClearnet. Without a hook netscrape asks for a same-origin
+  // /fetch proxy this server has never had, and every foreign URL rendered
+  // "404 page not found" (seen live). Same-origin pages never get here: the
+  // browser role's DirectLoader renders them natively.
+  function b64Bytes(b64) {
+    var s = atob(b64 || "");
+    var out = new Uint8Array(s.length);
+    for (var i = 0; i < s.length; i++) { out[i] = s.charCodeAt(i); }
+    return out;
+  }
+  function browseResponse(r) {
+    var h = new Headers();
+    if (r && r.header) { for (var k in r.header) { try { h.set(k, r.header[k]); } catch (e) { /* forbidden name */ } } }
+    return new Response(b64Bytes(r && r.body), { status: (r && r.status_code) || 200, headers: h });
+  }
+  function browsePost(path, req) {
+    return fetch(path, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(req) })
+      .then(function (res) {
+        return res.json().then(function (j) {
+          if (!res.ok) {
+            return new Response("skywire browse: " + ((j && j.error) || res.status), { status: 502, headers: { "content-type": "text/plain" } });
+          }
+          return browseResponse(j);
+        });
+      });
+  }
+  if (!globalThis.__netscrapeFetch) {
+    globalThis.__netscrapeFetch = function (url) {
+      var u;
+      try { u = new URL(url, location.href); } catch (e) { return fetch(url); }
+      var host = u.hostname || "";
+      if (/\.(dmsg|skynet|skysocks)$/i.test(host) || /^[0-9a-f]{66}$/i.test(host)) {
+        return browsePost("/api/browse/fetch", { host: host, port: u.port ? (parseInt(u.port, 10) || 80) : 80, method: "GET", path: (u.pathname || "/") + (u.search || "") });
+      }
+      // The browser's proxy setting (its ⚙ panel) picks the exit: a named
+      // skysocks exit, this visor's own egress ("direct" — the visor's PK is
+      // the exit the API treats as fetch-it-yourself), or the visor's default.
+      var p = globalThis.__netscrapeProxy || {};
+      var req = { method: "GET", url: u.href };
+      if (p.mode === "direct" && window.__SKYWIRE_LOCAL_PK__) { req.exit_pk = window.__SKYWIRE_LOCAL_PK__; }
+      else if (p.mode === "exit" && /^[0-9a-f]{66}$/i.test(p.exit || "")) { req.exit_pk = p.exit; }
+      return browsePost("/api/browse/clearnet", req);
+    };
+  }
   function ready() {
     if (!self.skywireDeskPanel || !document.body || typeof self.WinBox !== "function") { return setTimeout(ready, 200); }
     // RELATIVE: reached through the vnet service worker this page lives under

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -547,7 +547,14 @@
 						return Promise.resolve(sv.fetchDmsg(u.hostname, 'GET', path, null)).then(respond);
 					}
 					if (sv.fetchClearnet) {
-						return Promise.resolve(sv.fetchClearnet('', 'GET', url, null)).then(respond);
+						// The browser's proxy setting (netscrape's ⚙ panel) picks the
+						// exit: a named skysocks exit, this visor's own egress
+						// ("direct"), or empty for the visor's default.
+						var p = globalThis.__netscrapeProxy || {};
+						var exit = '';
+						if (p.mode === 'direct') exit = deskSelfPK;
+						else if (p.mode === 'exit' && /^[0-9a-f]{66}$/i.test(p.exit || '')) exit = p.exit;
+						return Promise.resolve(sv.fetchClearnet(exit, 'GET', url, null)).then(respond);
 					}
 					return fetch(url);
 				};

--- a/vendor/github.com/0magnet/netscrape/browser.go
+++ b/vendor/github.com/0magnet/netscrape/browser.go
@@ -685,7 +685,8 @@ func Open(root js.Value) {
 		return nil
 	}))
 	goBtn := btn("Go", "padding:2px 8px")
-	for _, el := range []js.Value{back, fwd, reload, addr, goBtn} {
+	proxyBtn, proxyRow := proxyPanel()
+	for _, el := range []js.Value{back, fwd, reload, addr, goBtn, proxyBtn} {
 		bar.Call("appendChild", el)
 	}
 
@@ -694,6 +695,7 @@ func Open(root js.Value) {
 
 	root.Call("appendChild", strip)
 	root.Call("appendChild", bar)
+	root.Call("appendChild", proxyRow)
 	root.Call("appendChild", views)
 
 	onClick(goBtn, func() {
@@ -925,4 +927,134 @@ func moveTab(from, to int) {
 		strip.Call("insertBefore", t.btn, strip.Get("lastChild"))
 	}
 	active = indexOf(cur)
+}
+
+// Proxy setting. netscrape does not carry traffic itself — the host's
+// __netscrapeFetch does — so the proxy control is a published preference the
+// host reads: globalThis.__netscrapeProxy = {mode, exit}. mode is "auto" (the
+// host's default exit), "exit" (the named skysocks exit PK) or "direct" (the
+// host egresses itself, no anonymity). It persists in localStorage so a
+// person's choice survives a reload, the way a browser's proxy setting does.
+const proxyStoreKey = "netscrape.proxy"
+
+var (
+	proxyMode = "auto"
+	proxyExit = ""
+)
+
+// Proxy reports the current proxy preference: mode and, for mode "exit", the
+// exit public key (hex).
+func Proxy() (mode, exit string) { return proxyMode, proxyExit }
+
+func loadProxy() {
+	ls := js.Global().Get("localStorage")
+	if !ls.Truthy() {
+		return
+	}
+	raw := ls.Call("getItem", proxyStoreKey)
+	if raw.Type() != js.TypeString || raw.String() == "" {
+		publishProxy()
+		return
+	}
+	obj := js.Global().Get("JSON").Call("parse", raw.String())
+	if m := obj.Get("mode"); m.Type() == js.TypeString {
+		proxyMode = m.String()
+	}
+	if e := obj.Get("exit"); e.Type() == js.TypeString {
+		proxyExit = e.String()
+	}
+	publishProxy()
+}
+
+func saveProxy() {
+	if ls := js.Global().Get("localStorage"); ls.Truthy() {
+		ls.Call("setItem", proxyStoreKey, `{"mode":"`+proxyMode+`","exit":"`+proxyExit+`"}`)
+	}
+	publishProxy()
+}
+
+func publishProxy() {
+	obj := js.Global().Get("Object").New()
+	obj.Set("mode", proxyMode)
+	obj.Set("exit", proxyExit)
+	js.Global().Set("__netscrapeProxy", obj)
+}
+
+// proxyPanel builds the ⚙ button and the settings row it toggles: a mode
+// selector and, for "exit", a field for the exit PK. Returns the button (for
+// the address bar) and the panel (for below it).
+func proxyPanel() (button, panel js.Value) {
+	button = btn("⚙", "padding:2px 8px")
+	button.Set("title", "proxy settings")
+	panel = mk("div")
+	panel.Get("style").Set("cssText", "display:none;gap:8px;align-items:center;padding:4px 6px;background:#100d18;border-bottom:1px solid #2a2342;font:12px monospace;color:#cdd2da")
+	label := mk("span")
+	label.Set("textContent", "clearnet pages via")
+	sel := mk("select")
+	sel.Get("style").Set("cssText", "background:#0e0c14;color:#cdd2da;border:1px solid #2a2342;font:12px monospace;padding:1px 4px")
+	for _, o := range [][2]string{{"auto", "auto (host's default exit)"}, {"exit", "a skysocks exit"}, {"direct", "direct (this visor egresses, not anonymous)"}} {
+		opt := mk("option")
+		opt.Set("value", o[0])
+		opt.Set("textContent", o[1])
+		sel.Call("appendChild", opt)
+	}
+	exit := mk("input")
+	exit.Set("spellcheck", false)
+	exit.Set("placeholder", "exit public key (66 hex)")
+	exit.Get("style").Set("cssText", "flex:1;background:#0e0c14;color:#cdd2da;border:1px solid #2a2342;padding:1px 6px;font:12px monospace")
+	status := mk("span")
+	status.Get("style").Set("cssText", "opacity:.7")
+	sync := func() {
+		sel.Set("value", proxyMode)
+		exit.Set("value", proxyExit)
+		if proxyMode == "exit" {
+			exit.Get("style").Set("display", "")
+		} else {
+			exit.Get("style").Set("display", "none")
+		}
+		switch {
+		case proxyMode == "exit" && !isPK(proxyExit):
+			status.Set("textContent", "needs a 66-hex public key")
+		default:
+			status.Set("textContent", "")
+		}
+	}
+	sel.Call("addEventListener", "change", js.FuncOf(func(_ js.Value, _ []js.Value) any {
+		proxyMode = sel.Get("value").String()
+		saveProxy()
+		sync()
+		return nil
+	}))
+	exit.Call("addEventListener", "change", js.FuncOf(func(_ js.Value, _ []js.Value) any {
+		proxyExit = strings.TrimSpace(exit.Get("value").String())
+		saveProxy()
+		sync()
+		return nil
+	}))
+	onClick(button, func() {
+		if panel.Get("style").Get("display").String() == "none" {
+			panel.Get("style").Set("display", "flex")
+		} else {
+			panel.Get("style").Set("display", "none")
+		}
+	})
+	for _, el := range []js.Value{label, sel, exit, status} {
+		panel.Call("appendChild", el)
+	}
+	loadProxy()
+	sync()
+	return button, panel
+}
+
+// isPK reports whether s looks like a compressed secp256k1 public key in hex.
+func isPK(s string) bool {
+	if len(s) != 66 || (s[:2] != "02" && s[:2] != "03") {
+		return false
+	}
+	for _, c := range s[2:] {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,7 +85,7 @@ github.com/0magnet/lolcat-go/lol
 # github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c
 ## explicit; go 1.25.0
 github.com/0magnet/metrics
-# github.com/0magnet/netscrape v0.0.0-20260908195716-c9218b3f4966
+# github.com/0magnet/netscrape v0.0.0-20260908202925-8a8dea1c8609
 ## explicit; go 1.24
 github.com/0magnet/netscrape
 # github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d


### PR DESCRIPTION
On the native hypervisor page netscrape had no transport: without a `__netscrapeFetch` hook it asked for a same-origin `/fetch` proxy this server never had, and every foreign URL rendered "404 page not found" (seen live). The launcher now gives it one over the hypervisor's browse API: mesh hosts through `/api/browse/fetch`, everything else through `/api/browse/clearnet`. Same-origin pages keep rendering natively.

netscrape gains a proxy setting (vendors 0magnet/netscrape 8a8dea1): auto, a named skysocks exit, or direct egress, persisted in localStorage. Both desks' hooks honor it.

Two visor fixes underneath: `BrowseClearnet` with no exit routed to the zero key and failed with "empty remote public key"; it now falls back to the skysocks-client's `--srv`. `GetSkysocksClientAddress` compared the app name against the `:1080` address constant and never matched; the skysocks server setter paths depended on it. Tests pin both. Blob re-embed follows as its own PR.