### PR TITLE
feat(hv): same-origin transport for the desk the hypervisor serves

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -85,6 +85,9 @@ const envfileLinux = `#
 #--	Set remote hypervisor public keys
 #HYPERVISORPKS=('')
 
+#--	Peers held as WebSocket transports at a known address: <pk>@<ws(s)://host[:port]/path>
+#WSPEERS=('')
+
 #--	Grant access to pseudoterminal (pty) for public keys
 #DMSGPTYPKS=('')
 
@@ -487,6 +490,9 @@ const envfileWindows = `#
 
 #--	Set remote hypervisor public keys
 #$HYPERVISORPKS=@('')
+
+#--	Peers held as WebSocket transports at a known address: <pk>@<ws(s)://host[:port]/path>
+#$WSPEERS=@('')
 
 #--	Grant access to pseudoterminal (pty) for public keys
 #$DMSGPTYPKS=@('')

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -40,6 +40,8 @@ import (
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport/network"
+	tspec "github.com/skycoin/skywire/pkg/transport/spec"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/visor/rewardconfig"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
@@ -253,6 +255,7 @@ func init() {
 		msg += "\n\r"
 	}
 	genConfigCmd.Flags().StringVarP(&hypervisorPKs, "hvpks", "j", scriptExecArray("${HYPERVISORPKS[@]}"), msg)
+	genConfigCmd.Flags().StringVar(&wsPeers, "ws-peer", scriptExecArray("${WSPEERS[@]}"), "peers to hold a WebSocket transport to, <pk>@<ws(s)://host[:port]/path>, comma-separated — pins each in transport.ws_table and makes it a persistent transport (no address-resolver lookup; the address is the one given)")
 	genConfigCmd.Flags().BoolVarP(&isDisableAuth, "noauth", "c", false, "disable authentication for hypervisor UI")
 	gHiddenFlags = append(gHiddenFlags, "noauth")
 	genConfigCmd.Flags().BoolVarP(&isEnableAuth, "auth", "e", false, "enable auth on hypervisor UI")
@@ -732,6 +735,7 @@ var genConfigCmd = &cobra.Command{
 		configureLauncher(log)
 
 		configureHypervisor(log)
+		configureWSPeers(log)
 
 		configureApps(log)
 
@@ -1519,6 +1523,47 @@ func configureLauncher(log *logging.Logger) {
 
 // configureHypervisor sets up hypervisor PKs, dmsgpty whitelist, survey
 // whitelist, and package/user-specific config paths.
+// wsPeers is --ws-peer: peers reached over a WebSocket transport at an address
+// the operator names, "<pk>@<ws(s)://…>". It is the unresolved WS dial — as stcp
+// is to stcpr — for a peer whose address is already known and never published:
+// the desk a hypervisor serves reaches that hypervisor at its own origin.
+var wsPeers string
+
+// configureWSPeers pins each --ws-peer in transport.ws_table (the dialer
+// consults the table before the address resolver) and lists it as a persistent
+// transport, so the visor opens it at boot and re-dials it when it drops.
+func configureWSPeers(log *logging.Logger) {
+	if strings.TrimSpace(wsPeers) == "" {
+		return
+	}
+	for _, spec := range strings.Split(wsPeers, ",") {
+		spec = strings.TrimSpace(spec)
+		if spec == "" {
+			continue
+		}
+		at := strings.IndexByte(spec, '@')
+		if at <= 0 || at == len(spec)-1 {
+			log.Fatalf("--ws-peer %q: want <pk>@<ws(s)://host[:port]/path>", spec)
+		}
+		var pk cipher.PubKey
+		if err := pk.Set(spec[:at]); err != nil {
+			log.WithError(err).Fatalf("--ws-peer %q: invalid public key", spec)
+		}
+		url := spec[at+1:]
+		if !strings.HasPrefix(url, "ws://") && !strings.HasPrefix(url, "wss://") {
+			log.Fatalf("--ws-peer %q: address must start with ws:// or wss://", spec)
+		}
+		if conf.Transport == nil {
+			conf.Transport = &visorconfig.Transport{}
+		}
+		if conf.Transport.WSTable == nil {
+			conf.Transport.WSTable = map[cipher.PubKey]string{}
+		}
+		conf.Transport.WSTable[pk] = url
+		conf.PersistentTransports = append(conf.PersistentTransports, tspec.PersistentTransports{PK: pk, NetType: tptypes.WS})
+	}
+}
+
 func configureHypervisor(log *logging.Logger) {
 	// Manipulate Hypervisor PKs
 	conf.Hypervisors = make([]cipher.PubKey, 0)

--- a/cmd/skywire-cli/commands/config/gen_wspeer_test.go
+++ b/cmd/skywire-cli/commands/config/gen_wspeer_test.go
@@ -1,0 +1,42 @@
+package cliconfig
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// TestConfigureWSPeers pins --ws-peer: each <pk>@<ws(s)://…> lands in
+// transport.ws_table (so the WS dialer never asks the address resolver for it)
+// AND in persistent_transports as a WS transport (so the visor opens it at
+// boot and re-dials it). This is the attached desk's one transport back to the
+// hypervisor that served it.
+func TestConfigureWSPeers(t *testing.T) {
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+	prev := conf
+	t.Cleanup(func() { conf = prev })
+	conf = new(visorconfig.V1)
+	wsPeers = pk1.Hex() + "@ws://node.local:8000/tp/ws, " + pk2.Hex() + "@wss://example.org/tp/ws,"
+	configureWSPeers(logging.MustGetLogger("test"))
+	if conf.Transport == nil {
+		t.Fatal("transport section not created")
+	}
+	if got := conf.Transport.WSTable[pk1]; got != "ws://node.local:8000/tp/ws" {
+		t.Errorf("ws_table[pk1]=%q", got)
+	}
+	if got := conf.Transport.WSTable[pk2]; got != "wss://example.org/tp/ws" {
+		t.Errorf("ws_table[pk2]=%q", got)
+	}
+	if len(conf.PersistentTransports) != 2 {
+		t.Fatalf("persistent_transports=%d, want 2", len(conf.PersistentTransports))
+	}
+	for i, pk := range []cipher.PubKey{pk1, pk2} {
+		if pt := conf.PersistentTransports[i]; pt.PK != pk || pt.NetType != tptypes.WS {
+			t.Errorf("persistent_transports[%d]=%+v, want %s over %s", i, pt, pk, tptypes.WS)
+		}
+	}
+}

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -126,6 +126,7 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 
 	// Hypervisor / identity
 	addArray("HYPERVISORPKS", "hvpks", autoconfigVals.Hvpks)
+	addArray("WSPEERS", "ws-peer", autoconfigVals.WSPeers)
 	addBool("ISHYPERVISOR", "ishv", "no-ishv", autoconfigVals.Ishv, autoconfigVals.NoIshv)
 	addBool("ENABLEPKENDPOINT", "pk-endpoint", "no-pk-endpoint", autoconfigVals.PkEndpoint, autoconfigVals.NoPkEndpoint)
 	addString("HVHTTPADDR", "hvaddr", autoconfigVals.HvAddr)

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -100,6 +100,7 @@ type Values struct {
 
 	// --- Hypervisor / identity ---
 	Hvpks        string
+	WSPeers      string // WSPEERS: <pk>@<ws(s)://…> peers held as WebSocket transports
 	Ishv         bool
 	NoIshv       bool
 	PkEndpoint   bool // ENABLEPKENDPOINT
@@ -262,6 +263,7 @@ func New(v *Values) *cobra.Command {
 
 	// --- Hypervisor / identity ---
 	cmd.Flags().StringVar(&v.Hvpks, "hvpks", "", "comma-separated remote hypervisor PKs to dial — writes HYPERVISORPKS in skywire.conf")
+	cmd.Flags().StringVar(&v.WSPeers, "ws-peer", "", "peers held as WebSocket transports, <pk>@<ws(s)://host[:port]/path>, comma-separated — writes WSPEERS in skywire.conf")
 	cmd.Flags().BoolVar(&v.Ishv, "ishv", false, "enable local hypervisor — writes ISHYPERVISOR=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoIshv, "no-ishv", false, "disable local hypervisor — writes ISHYPERVISOR=false in skywire.conf")
 	cmd.Flags().BoolVar(&v.PkEndpoint, "pk-endpoint", false, "expose unauthenticated GET /api/pk on the hypervisor — writes ENABLEPKENDPOINT=true in skywire.conf (skybian / Arch-ARM image builds set this)")
@@ -411,6 +413,7 @@ func EnvMap() map[string]EnvMapping {
 var envMap = map[string]EnvMapping{
 	// Hypervisor / identity
 	"hvpks":          {Key: "HYPERVISORPKS", Format: EnvFormatBashArray},
+	"ws-peer":        {Key: "WSPEERS", Format: EnvFormatBashArray},
 	"ishv":           {Key: "ISHYPERVISOR", Format: EnvFormatBool},
 	"no-ishv":        {Key: "ISHYPERVISOR", Format: EnvFormatBool, Negate: true},
 	"pk-endpoint":    {Key: "ENABLEPKENDPOINT", Format: EnvFormatBool},

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"sync"
 	"time"
 
@@ -865,6 +866,21 @@ func (tm *Manager) InitClient(ctx context.Context, netType types.Type, port int)
 	// Transport Manager is 'ready' once we have successfully initilized
 	// with at least one transport client.
 	tm.readyOnce.Do(func() { close(tm.ready) })
+}
+
+// HTTPAcceptor returns the network client for netType as an http.Handler when
+// it can take transport handshakes arriving on a foreign HTTP server — the WS
+// client on native builds does (wsClient.ServeHTTP). The hypervisor UI port
+// mounts it so a desk it serves can open a transport at the address it knows.
+func (tm *Manager) HTTPAcceptor(netType types.Type) (http.Handler, bool) {
+	tm.mx.RLock()
+	c := tm.netClients[netType]
+	tm.mx.RUnlock()
+	if c == nil {
+		return nil, false
+	}
+	h, ok := c.(http.Handler)
+	return h, ok
 }
 
 // Ready checks if the transport manager is ready with atleast one transport

--- a/pkg/transport/network/ws.go
+++ b/pkg/transport/network/ws.go
@@ -40,6 +40,10 @@ type wsClient struct {
 	// stcpr cmux port, so resolveWSURLViaAR resolves the peer's stcpr address and
 	// forms ws://host:port/. nil on the browser (which dials from the table only).
 	ar any
+	// wsLis is the running *wsListener (native only; `any` for the same reason
+	// as ar), so ServeHTTP can hand it handshakes that arrive on a foreign HTTP
+	// server — the hypervisor UI port mounting this client at /tp/ws.
+	wsLis any
 }
 
 func newWS(generic *genericClient, table stcp.PKTable) Client {

--- a/pkg/transport/network/ws_native.go
+++ b/pkg/transport/network/ws_native.go
@@ -80,7 +80,35 @@ func (c *wsClient) serve() {
 			return
 		}
 	}
+	c.mu.Lock()
+	c.wsLis = lis
+	c.mu.Unlock()
 	c.acceptTransports(lis)
+}
+
+// ServeHTTP lets a foreign HTTP server take WS transport handshakes for this
+// visor — the hypervisor UI port mounts it at /tp/ws so a desk it serves can
+// open a transport at the one address it already knows (no address-resolver
+// lookup, nothing published). The socket is then exactly what the WS listener
+// would have accepted on the transport port: same Noise handshake, same peer
+// verification, same transport. Requests before the listener is up wait for it.
+func (c *wsClient) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	select {
+	case <-c.listenStarted:
+	case <-c.done:
+		http.Error(w, "ws transport client closed", http.StatusServiceUnavailable)
+		return
+	case <-r.Context().Done():
+		return
+	}
+	c.mu.RLock()
+	lis, _ := c.wsLis.(*wsListener)
+	c.mu.RUnlock()
+	if lis == nil {
+		http.Error(w, "ws transport listener not running", http.StatusServiceUnavailable)
+		return
+	}
+	lis.handle(w, r)
 }
 
 // wsListener fronts a WebSocket HTTP server as a net.Listener: each upgraded

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -1088,6 +1088,16 @@ func (hv *Hypervisor) makeMux() chi.Router {
 			r.Get("/ws", hv.getAPIWebSocket())
 		})
 
+		// /tp/ws — a skywire TRANSPORT handshake over a WebSocket on this port.
+		// A page this hypervisor serves knows exactly one address for the visor
+		// behind it: its own origin. It dials the WS transport here with no
+		// address-resolver lookup, no forwarded port and nothing published about
+		// itself. The transport authenticates itself by key in its own handshake,
+		// so this sits outside the session-auth group — the pairing gate is on
+		// the RPC the transport carries, not on the socket. Beside /ws for the
+		// reason /ws is: /api's timeout middleware is not an http.Hijacker.
+		r.Get("/tp/ws", hv.getTransportWS())
+
 		// Mount tp-viz UI if enabled.
 		//
 		// Inside its own authenticated group: these paths sit OUTSIDE the

--- a/pkg/visor/hypervisor_desk_test.go
+++ b/pkg/visor/hypervisor_desk_test.go
@@ -6,6 +6,8 @@ package visor
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -88,12 +90,13 @@ func TestNativeDeskServing(t *testing.T) {
 		if !strings.Contains(body, "terminalURL: './pty/"+pk.Hex()+"'") {
 			t.Error("page lacks the relative pty terminal window URL")
 		}
-		// The ONE-VISOR rule, as served bytes: the desk module is served, but
-		// nothing that would start a visor of the tab's own is — no autostart
-		// and no reference to the skywire command module.
+		// With no command module configured (hypervisor.wasm_serve.exec_wasm
+		// unset) the page is a shell over the host visor only: no autostart and
+		// no reference to the skywire command module. TestNativeDeskAttachedVisor
+		// covers the configured case.
 		for _, banned := range []string{"autostartVisor: true", "/skywire.wasm", "skywire.wasm.gz", "skywire-browse-launcher"} {
 			if strings.Contains(body, banned) {
-				t.Errorf("desk page references %s — the native visor IS the visor", banned)
+				t.Errorf("desk page references %s without a command module to serve", banned)
 			}
 		}
 	})
@@ -187,13 +190,13 @@ func TestNativeDeskServing(t *testing.T) {
 	// everything that could actually start a visor stays absent.
 	t.Run("the visor BOOT path is not exposed on the hypervisor port", func(t *testing.T) {
 		// hv-boot.js and worker.js ARE the boot path (worker.js hosts a visor
-		// off-thread; hv-boot.js spawns it). skywire.wasm is the in-tab CLI,
-		// which is how the wasm desk starts one via `skywire autoconfig`.
-		// Without these three there is nothing on this origin that starts a
-		// visor, whatever else it serves.
+		// off-thread; hv-boot.js spawns it) and are never served here.
+		// skywire.wasm is the in-tab CLI the desk starts a visor with; it is
+		// served only when the operator configured a command module (see
+		// TestNativeDeskAttachedVisor) — with none, 404 like the rest.
 		for _, p := range []string{"/skywire.wasm", "/hv-boot.js", "/worker.js"} {
 			if w := get(p); w.Code != http.StatusNotFound {
-				t.Errorf("GET %s → %d, want 404 (native mode must not be able to start an in-page visor)", p, w.Code)
+				t.Errorf("GET %s → %d, want 404 (no command module configured)", p, w.Code)
 			}
 		}
 	})
@@ -206,7 +209,7 @@ func TestNativeDeskServing(t *testing.T) {
 		}
 	})
 
-	t.Run("the native desk page does not autostart a visor", func(t *testing.T) {
+	t.Run("the native desk page does not autostart a visor without a command module", func(t *testing.T) {
 		w := get("/")
 		if w.Code != http.StatusOK {
 			t.Fatalf("status=%d, want 200", w.Code)
@@ -250,5 +253,91 @@ func TestDeskShellHTMLWasmMode(t *testing.T) {
 	}
 	if strings.Contains(page, "__DESK_SCRIPTS__") || strings.Contains(page, "__DESK_OPTS__") {
 		t.Error("template placeholders leaked into the rendered page")
+	}
+}
+
+// TestNativeDeskAttachedVisor pins the ATTACHED desk: when the operator has a
+// skywire command module for js/wasm (hypervisor.wasm_serve.exec_wasm), the
+// hypervisor UI port serves it and its worker, and the page boots a visor of
+// the tab's own whose one transport is a WebSocket back to this origin — the
+// same-origin transport at /tp/ws, addressed by the host's public key, no
+// address-resolver lookup — with public autoconnect off.
+func TestNativeDeskAttachedVisor(t *testing.T) {
+	hv, pk := deskTestHypervisor(t)
+	exec := filepath.Join(t.TempDir(), "skywire.wasm")
+	if err := os.WriteFile(exec, []byte("\x00asm-test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hv.c.WasmServe = &visorconfig.WasmServeConf{ExecWasm: exec}
+	h := hv.uiHandler()
+	get := func(path string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+		return w
+	}
+
+	t.Run("the command module and its worker are served", func(t *testing.T) {
+		w := get("/skywire.wasm")
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET /skywire.wasm → %d, want 200", w.Code)
+		}
+		if ct := w.Header().Get("Content-Type"); ct != "application/wasm" {
+			t.Errorf("Content-Type=%q, want application/wasm", ct)
+		}
+		if w.Body.String() != "\x00asm-test" {
+			t.Errorf("served body is not the configured module")
+		}
+		if w := get("/skywire-worker.js"); w.Code != http.StatusOK {
+			t.Errorf("GET /skywire-worker.js → %d, want 200", w.Code)
+		}
+		// The off-thread boot path stays absent: the attached visor runs in
+		// the desk's own terminal, not in a worker the page spawns.
+		for _, p := range []string{"/hv-boot.js", "/worker.js"} {
+			if w := get(p); w.Code != http.StatusNotFound {
+				t.Errorf("GET %s → %d, want 404", p, w.Code)
+			}
+		}
+	})
+
+	t.Run("the page boots a visor attached to this origin", func(t *testing.T) {
+		w := get("/")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status=%d, want 200", w.Code)
+		}
+		body := w.Body.String()
+		for _, want := range []string{
+			"autostartVisor: true",
+			"wasmURL: '/skywire.wasm'",
+			"execWorkerURL: '/skywire-worker.js'",
+			"attach: { pk: '" + pk.Hex() + "', path: '/tp/ws' }",
+			// Still the ONE desk: dashboard and pty are the host's.
+			"dashboardURL: './?embed=1#/?embed=1'",
+			"terminalURL: './pty/" + pk.Hex() + "'",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("attached desk page lacks %s", want)
+			}
+		}
+		if strings.Contains(body, "autostartVisor: false") {
+			t.Error("attached desk page still carries autostartVisor: false")
+		}
+	})
+}
+
+// TestTransportWSEndpoint pins /tp/ws on the hypervisor port: it is the WS
+// transport client's own acceptor, so with no visor (or no transport manager)
+// behind the hypervisor it refuses rather than pretending.
+func TestTransportWSEndpoint(t *testing.T) {
+	hv, _ := deskTestHypervisor(t)
+	w := httptest.NewRecorder()
+	hv.getTransportWS()(w, httptest.NewRequest(http.MethodGet, "/tp/ws", nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("no transport manager: status=%d, want 503", w.Code)
+	}
+	hv.visor = nil
+	w = httptest.NewRecorder()
+	hv.getTransportWS()(w, httptest.NewRequest(http.MethodGet, "/tp/ws", nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("no visor: status=%d, want 503", w.Code)
 	}
 }

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"github.com/skycoin/skywire/pkg/wasmhv"
 	"io"
 	"net"
 	"net/http"
@@ -117,6 +118,23 @@ func (hv *Hypervisor) uiHandler() http.Handler {
 			// above — a std-Go wasm_exec.js cannot run a TinyGo module or vice
 			// versa (see wasmbin/embed.go).
 			serveJS(w, wasmbin.WasmExecJSVariant(wasmbin.Default()))
+			return
+		case "/skywire.wasm":
+			// The FULL skywire command module — the visor the served desk runs
+			// in its terminal — from the same file the wasm-serve port serves,
+			// when the operator has one (hypervisor.wasm_serve.exec_wasm).
+			// Absent that, the desk boots with no visor of its own, as before.
+			if p := hv.execWasmPath(); p != "" {
+				w.Header().Set("Content-Type", "application/wasm")
+				w.Header().Set("Cache-Control", "no-cache")
+				http.ServeFile(w, r, p)
+				return
+			}
+			http.NotFound(w, r)
+			return
+		case "/skywire-worker.js":
+			// The worker every skywire command runs on when the page hosts one.
+			serveJS(w, wasmhv.ExecWorkerJS())
 			return
 		case "/desk-boot.js":
 			// The shared desk boot (skywireDeskBoot) — same asset `hv serve`
@@ -271,7 +289,7 @@ func (hv *Hypervisor) serveNativeDesk(w http.ResponseWriter) {
 		`<script src="/browse.js"></script>` + "\n" +
 		`<script>` + uiAutoReloadJS + `</script>` + "\n" +
 		`<script src="/desk-boot.js"></script>`
-	page := deskShellHTML(scripts, nativeDeskBootOpts(localPK))
+	page := deskShellHTML(scripts, nativeDeskBootOpts(localPK, hv.execWasmPath() != ""))
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
 	_, _ = w.Write(page) //nolint:errcheck
@@ -287,17 +305,29 @@ func (hv *Hypervisor) serveNativeDesk(w http.ResponseWriter) {
 // embed=1 rides in the HASH (the Angular UI is hash-routed) so the framed
 // dashboard hides its own taskbar. terminalURL is the host's pty page,
 // /pty/<pk>, xterm over a websocket; absent when no visor is attached.
-func nativeDeskBootOpts(localPK string) string {
+func nativeDeskBootOpts(localPK string, execWasm bool) string {
 	opts := "{\n" +
 		"  persistDB: 'skywire-desk',\n" +
 		"  deskWasmURL: '/wasm-visor.wasm',\n" +
 		"  wasmExecURL: '/wasm_exec.js',\n" +
-		"  winboxURL: '/winbox.wasm',\n" +
-		"  autostartVisor: false,\n" +
+		"  winboxURL: '/winbox.wasm',\n"
+	if execWasm && localPK != "" {
+		// The command module is served here, so the desk runs a visor of the
+		// tab's own — ATTACHED to this hypervisor: its one transport is a
+		// WebSocket back to this origin (see /tp/ws), it does not go looking
+		// for public peers, and the host reaches it over that socket.
+		opts += "  autostartVisor: true,\n" +
+			"  wasmURL: '/skywire.wasm',\n" +
+			"  execWorkerURL: '/skywire-worker.js',\n" +
+			"  attach: { pk: '" + localPK + "', path: '/tp/ws' },\n"
+	} else {
+		opts += "  autostartVisor: false,\n"
+	}
+	opts +=
 		"  helpTerminal: false,\n" +
-		"  docsPort: 0,\n" +
-		"  hvWindow: true,\n" +
-		"  dashboardURL: './?embed=1#/?embed=1',\n"
+			"  docsPort: 0,\n" +
+			"  hvWindow: true,\n" +
+			"  dashboardURL: './?embed=1#/?embed=1',\n"
 	if localPK != "" {
 		opts += "  terminalURL: './pty/" + localPK + "',\n"
 	}
@@ -345,3 +375,13 @@ const uiAutoReloadJS = `(function(){
     }).catch(function(){});
   }, 30000);
 })();`
+
+// execWasmPath is the path of the full skywire command module for js/wasm, when
+// the operator configured one for the wasm-serve port; the desk on this port
+// shares it. Empty when there is none.
+func (hv *Hypervisor) execWasmPath() string {
+	if hv.c.WasmServe == nil {
+		return ""
+	}
+	return hv.c.WasmServe.ExecWasm
+}

--- a/pkg/visor/hypervisor_ws.go
+++ b/pkg/visor/hypervisor_ws.go
@@ -42,6 +42,7 @@ package visor
 import (
 	"context"
 	"encoding/json"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 	"io"
 	"net/http"
 	"strings"
@@ -312,4 +313,23 @@ func (hv *Hypervisor) serveWSRequest(ctx context.Context, up *http.Request, req 
 		}
 	}
 	return res
+}
+
+// getTransportWS → GET /tp/ws : hands the WebSocket upgrade to the visor's WS
+// transport client, which runs its normal accept-side handshake on it. The
+// same-origin transport a served desk opens back to this visor (see the route
+// comment in hypervisor.go).
+func (hv *Hypervisor) getTransportWS() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if hv.visor == nil || hv.visor.tpM == nil {
+			http.Error(w, "no visor behind this hypervisor", http.StatusServiceUnavailable)
+			return
+		}
+		h, ok := hv.visor.tpM.HTTPAcceptor(tptypes.WS)
+		if !ok {
+			http.Error(w, "ws transport not available on this visor", http.StatusServiceUnavailable)
+			return
+		}
+		h.ServeHTTP(w, r)
+	}
 }

--- a/pkg/visor/rpc_client_serve.go
+++ b/pkg/visor/rpc_client_serve.go
@@ -100,6 +100,12 @@ func hasFastTransportTo(tpM *transport.Manager, pk cipher.PubKey) bool {
 	if tp, err := tpM.GetTransport(pk, tptypes.SUDPH); err == nil && tp != nil {
 		return true
 	}
+	// A WebSocket transport is direct too: a browser visor attached to this
+	// hypervisor opens one back to it at the page's own origin, and that socket
+	// is the fast path for the RPC and pty this visor serves it.
+	if tp, err := tpM.GetTransport(pk, tptypes.WS); err == nil && tp != nil {
+		return true
+	}
 	return false
 }
 

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -487,7 +487,16 @@
 					// The visor terminal opens either way — running autoconfig
 					// (which ends by starting the visor in the foreground), or idle
 					// at the prompt when the operator had stopped it.
-					panel.openConsole({ title: 'visor', initCmd: startVisor ? 'skywire autoconfig' : '' });
+					var autoconfigCmd = 'skywire autoconfig';
+					if (opts.attach && opts.attach.pk) {
+						// Attached to the hypervisor that served this page: the visor's one
+						// transport is a WebSocket back to this origin — an address the page
+						// already has, so no address-resolver lookup — and it does not go
+						// looking for public peers; everything else rides that socket.
+						var tpURL = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + (opts.attach.path || '/tp/ws');
+						autoconfigCmd += ' --disable-public-autoconn --ws-peer ' + opts.attach.pk + '@' + tpURL;
+					}
+					panel.openConsole({ title: 'visor', initCmd: startVisor ? autoconfigCmd : '' });
 					startedVisor = startVisor;
 				}
 				if (opts.helpTerminal !== false) {

--- a/pkg/wasmhv/browseui/deskboot_test.go
+++ b/pkg/wasmhv/browseui/deskboot_test.go
@@ -43,3 +43,26 @@ func TestDeskBootHasNoCodeBeforeItsHeader(t *testing.T) {
 		}
 	}
 }
+
+// TestDeskBootAttachBuildsTheWSPeer pins the attached boot: when the page is
+// served with attach:{pk,path}, the visor the desk starts is told to hold ONE
+// WebSocket transport back to the page origin (--ws-peer <pk>@<ws(s)://origin
+// + path>) and to stay off public autoconnect. The address comes from
+// location, so the same page works on any hostname the host is reached by.
+func TestDeskBootAttachBuildsTheWSPeer(t *testing.T) {
+	b, err := os.ReadFile("desk-boot.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(b)
+	for _, want := range []string{
+		"if (opts.attach && opts.attach.pk)",
+		"location.host + (opts.attach.path || '/tp/ws')",
+		"' --disable-public-autoconn --ws-peer ' + opts.attach.pk + '@' + tpURL",
+		"initCmd: startVisor ? autoconfigCmd : ''",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("desk-boot.js lacks %q", want)
+		}
+	}
+}


### PR DESCRIPTION
Stage 2 of #4484. The desk served on the hypervisor port can run a visor of the tab's own, attached to the host: its one transport is a WebSocket back to the page origin at `/tp/ws`, addressed by the host's public key the page already carries. No address-resolver lookup; nothing about the tab is published.

- `/tp/ws` on the hypervisor port hands the WS transport client's own listener the upgrade (`Manager.HTTPAcceptor`), so the socket is exactly what the transport port would have accepted, Noise handshake included. It sits outside the password gate for that reason.
- The hypervisor RPC dialer counts a WS transport as direct, so RPC and pty to the tab go over skynet first.
- With `hypervisor.wasm_serve.exec_wasm` set, `:8000` also serves `/skywire.wasm` and `/skywire-worker.js`, and the page boots the visor with `skywire autoconfig --disable-public-autoconn --ws-peer <pk>@ws(s)://<origin>/tp/ws`. Without it the page stays a shell over the host visor, as today.
- New `--ws-peer pk@url` on `config gen` and `autoconfig` (`WSPEERS`): pins the peer in `transport.ws_table` and as a persistent WS transport.

Tests: attached and non-attached page serving, `/tp/ws` refusal without a manager, `--ws-peer` parsing, desk-boot attach string. `go build .`, js/wasm build of cmd/wasm-visor, golangci-lint on the touched packages all clean. Live validation on the host visor follows the merge (the exec module must be rebuilt from this source).
