### PR TITLE
fix(wasm-visor): openConsole must open websh, not the host pty

### DIFF
--- a/cmd/wasm-visor/desk_js.go
+++ b/cmd/wasm-visor/desk_js.go
@@ -40,12 +40,35 @@ func (funcPane) Close()                    {}
 // installDesk registers skywire's desk apps and mounts the library panel.
 // Call from a DOM-bearing role after installShell/installBrowser.
 func installDesk() {
+	// websh, the in-tab shell, is ALWAYS registered — as "console", unlisted:
+	// it is what openConsole fills with a command (the boot script starts the
+	// tab's visor in one), so it must exist and must be websh whatever the
+	// terminal entry below turns out to be. Only when the page does not name a
+	// host pty does it also stand in as the listed "terminal".
+	websh := func(args []string) (desk.Pane, error) {
+		return funcPane{mount: func(el js.Value) error {
+			h := jsOpenShell(js.Undefined(), []js.Value{el})
+			// args[0] (optional): a command to run once the session is up.
+			if len(args) > 0 && args[0] != "" {
+				if hv, ok := h.(js.Value); ok && hv.Truthy() && hv.Get("run").Type() == js.TypeFunction {
+					hv.Call("run", args[0])
+				}
+			}
+			return nil
+		}}, nil
+	}
+	desk.Register(desk.App{
+		Name: "console", Title: "console", Unlisted: true,
+		Help:  "websh — the skywire shell",
+		Width: 900, Height: 540,
+		Open: websh,
+	})
 	// The terminal app. On a page a hypervisor serves (host-bridge mode) the
 	// terminal is the HOST's pty page — xterm over a websocket to the machine
 	// the visor runs on — which the page names in __SKYWIRE_PTY_URL__ before
-	// this module runs. Elsewhere it is websh, the in-tab shell. Same app name
-	// and the same tabbing either way, so the ☰ entry and desk-boot's launch
-	// need not know which one they got.
+	// this module runs. Elsewhere it is websh. Same app name and the same
+	// tabbing either way, so the ☰ entry and desk-boot's launch need not know
+	// which one they got.
 	if ptyURL := js.Global().Get("__SKYWIRE_PTY_URL__"); ptyURL.Type() == js.TypeString && ptyURL.String() != "" {
 		desk.Register(desk.App{
 			Name: "terminal", Title: "terminal",
@@ -58,18 +81,7 @@ func installDesk() {
 			Name: "terminal", Title: "terminal",
 			Help:  "websh — the skywire shell",
 			Width: 900, Height: 540,
-			Open: func(args []string) (desk.Pane, error) {
-				return funcPane{mount: func(el js.Value) error {
-					h := jsOpenShell(js.Undefined(), []js.Value{el})
-					// args[0] (optional): a command to run once the session is up.
-					if len(args) > 0 && args[0] != "" {
-						if hv, ok := h.(js.Value); ok && hv.Truthy() && hv.Get("run").Type() == js.TypeFunction {
-							hv.Call("run", args[0])
-						}
-					}
-					return nil
-				}}, nil
-			},
+			Open: websh,
 		})
 	}
 	desk.Register(desk.App{
@@ -170,7 +182,7 @@ func installDesk() {
 			}
 			return nil
 		}),
-		// openConsole({title, initCmd, bg}): a terminal, optionally running a
+		// openConsole({title, initCmd, bg}): a websh console, optionally running a
 		// first command. The FIRST call opens the terminal window; every one
 		// after joins it as a tab, so a desk with three shells has one window
 		// and three tabs rather than three frames. bg leaves the new tab
@@ -188,7 +200,7 @@ func installDesk() {
 			}
 			if termWin != nil {
 				front := termFront
-				if err := desk.AddTabOpts(termWin, "terminal", desk.Options{Title: title}, initCmd); err == nil {
+				if err := desk.AddTabOpts(termWin, "console", desk.Options{Title: title}, initCmd); err == nil {
 					if bg && front != "" {
 						// Put the previously-front tab back; the new one is
 						// open, just not on top.
@@ -202,7 +214,7 @@ func installDesk() {
 				// than reporting an error for a terminal nobody can see.
 				termWin = nil
 			}
-			w, err := desk.LaunchOpts("terminal", desk.Options{Title: title}, initCmd)
+			w, err := desk.LaunchOpts("console", desk.Options{Title: title}, initCmd)
 			if err != nil {
 				return err.Error()
 			}

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/0magnet/bitree v0.0.0-20260906144807-e66de0b4c738
 	github.com/0magnet/bottle v0.0.0-20260908155251-920d2280a387
 	github.com/0magnet/calvin v0.0.0-20260908180241-0893f4bff56a
-	github.com/0magnet/desk v0.0.0-20260908201307-31a6f6d6f00c
+	github.com/0magnet/desk v0.0.0-20260909002914-271c2999cd2c
 	github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db
 	github.com/0magnet/gobrpc v0.0.0-20260906144809-5215ec59d553
 	github.com/0magnet/golang-ipc v1.2.5-0.20260905172007-25d9c1a262d0

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585 h1:G2m5S+A3CMsHo
 github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585/go.mod h1:dp0q1zfKQmTaohUrPEPZbPExxBWLu9DyeaFxKUBnw6Y=
 github.com/0magnet/desk v0.0.0-20260908201307-31a6f6d6f00c h1:9kMeRmyuFTLwMcsW5i62bM6JdkCtzwkT3noo6FWobdg=
 github.com/0magnet/desk v0.0.0-20260908201307-31a6f6d6f00c/go.mod h1:L+8Y1fP55UjK6RFOG0iAsR9oO6zXidCr9LZJy+8oN/k=
+github.com/0magnet/desk v0.0.0-20260909002914-271c2999cd2c h1:ucnkHbW+5CNsVGtX3sJCkAoJjeyOMwjN/DT++Vwursg=
+github.com/0magnet/desk v0.0.0-20260909002914-271c2999cd2c/go.mod h1:L+8Y1fP55UjK6RFOG0iAsR9oO6zXidCr9LZJy+8oN/k=
 github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db h1:t/kQDGFMvKhpRBTdEjiLCkVG9Pe/qmDuD8D65DJrdrs=
 github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db/go.mod h1:EDtFhI1TlDPunQIoT8IRbhe8wa5R4GAI+iL04vQDk2Y=
 github.com/0magnet/go-dsp v0.0.0-20260907230215-136ba239cc2d h1:AE2MbqkqaB88h+jtiWo5aI6zODI+0QZZRI4lY0p9Fhw=

--- a/vendor/github.com/0magnet/desk/desk.go
+++ b/vendor/github.com/0magnet/desk/desk.go
@@ -95,6 +95,12 @@ type App struct {
 	// both are set, since an app that can do its own thing has no use for a
 	// pane the desk would wrap it in.
 	Run func(args []string) error
+
+	// Unlisted keeps the app out of the launcher. For a pane type a page opens
+	// itself and does not want offered as a menu entry beside the real apps —
+	// a console the boot script fills with a command, say — while Launch and
+	// AddTab still find it by name.
+	Unlisted bool
 }
 
 var (

--- a/vendor/github.com/0magnet/desk/panel.go
+++ b/vendor/github.com/0magnet/desk/panel.go
@@ -167,6 +167,9 @@ func (p *Panel) refilter() {
 	q := p.search.Get("value").String()
 	p.filtered = p.filtered[:0]
 	for _, a := range Apps() {
+		if a.Unlisted {
+			continue
+		}
 		if q == "" || containsFold(a.Name, q) || containsFold(a.Help, q) {
 			p.filtered = append(p.filtered, a)
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -47,7 +47,7 @@ github.com/0magnet/coloredcobra
 # github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585
 ## explicit; go 1.24
 github.com/0magnet/cosmos-go
-# github.com/0magnet/desk v0.0.0-20260908201307-31a6f6d6f00c
+# github.com/0magnet/desk v0.0.0-20260909002914-271c2999cd2c
 ## explicit; go 1.26
 github.com/0magnet/desk
 github.com/0magnet/desk/dom


### PR DESCRIPTION
On a page a hypervisor serves, the `terminal` app is the host's pty page (#4676). `openConsole` launched that same app, so the `initCmd` the boot script passes (`skywire autoconfig …`, which starts the tab's visor) landed in an iframe that cannot run it. The attached desk from #4690 therefore never started its visor.

websh is now always registered as an unlisted `console` app (desk bump: `App.Unlisted` keeps it out of the launcher) and `openConsole` targets it. The listed `terminal` entry is unchanged: host pty when the page names one, websh otherwise.

Blob re-embed follows as its own PR.
