### PR TITLE
fix(autoconfig): pass the SKYENV edits to config gen as explicit flags

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -2505,13 +2505,12 @@ func getInterfaceNames() string { //nolint Note: pending implementation for conf
 	return strings.Join(interfaceNames, ", ")
 }
 
-// applyFlagsToConf uncomments settings in the conf template that correspond
-// to flags passed on the command line. This makes -q/-Q output reflect the
-// user's intent (e.g., `config gen -iq` uncomments ISHYPERVISOR=true).
-func applyFlagsToConf(conf string, cmd *cobra.Command) string {
-	// Map of flag names to the SKYENV variable they control.
-	// When a flag is explicitly set, uncomment the corresponding line.
-	flagToEnv := map[string]string{
+// Which SKYENV variable each `config gen` flag controls. applyFlagsToConf
+// uses them to uncomment the matching template line; FlagArgsForSkyenv walks
+// them the other way, from a variable to the flag that sets it.
+var (
+	// Boolean flags: the line the flag turns on.
+	flagToEnv = map[string]string{
 		"pkg":                  "PKGENV=true",
 		"ishv":                 "ISHYPERVISOR=true",
 		"testenv":              "TESTENV=true",
@@ -2523,33 +2522,26 @@ func applyFlagsToConf(conf string, cmd *cobra.Command) string {
 		"no-direct-transports": "NODIRECTTRANSPORTS=true",
 		"pty-rpc-exec":         "PTYRPCEXEC=true",
 	}
-
-	// Also handle string/value flags
-	valueFlagToEnv := map[string]string{
+	// String flags: KEY='value' lines.
+	valueFlagToEnv = map[string]string{
 		"cliaddr": "CLIADDR",
 		"hvaddr":  "HVHTTPADDR",
 		"timeout": "SHUTDOWNTIMEOUT",
 		"reward":  "REWARDSKYADDR",
 	}
-
-	// Integer/port flags map to bare KEY=N env lines (e.g. #TRANSPORTPORT=0).
-	// When the flag is explicitly set, uncomment + replace with the value so
-	// `config gen --transport-port 7777 -q` reflects it in the template.
-	intFlagToEnv := map[string]string{
+	// Integer/port flags: bare KEY=N lines (e.g. #TRANSPORTPORT=0).
+	intFlagToEnv = map[string]string{
 		"transport-port":     "TRANSPORTPORT",
 		"stcpr":              "STCPRPORT",
 		"sudph":              "SUDPHPORT",
 		"min-hops":           "MINHOPS",
 		"ar-transport-limit": "ARTRANSPORTLIMIT",
 	}
-
-	// Array-shaped flags map to bash-array env vars of the form
-	// KEY=('a' 'b' 'c'). Values come in comma-separated form from the
-	// CLI (`--hvpks PK1,PK2`); we split on comma, trim each entry,
-	// drop empties, and emit the canonical single-quoted-space-joined
-	// bash-array form. Mirrors how SkyenvArray decodes the same lines
-	// back out — round-trip safe.
-	arrayFlagToEnv := map[string]string{
+	// Array-shaped flags: bash-array lines KEY=('a' 'b' 'c'), taken
+	// comma-separated on the CLI (`--hvpks PK1,PK2`) — split, trimmed, empties
+	// dropped, single-quoted. Mirrors how SkyenvArray decodes them: round-trip
+	// safe.
+	arrayFlagToEnv = map[string]string{
 		"hvpks":           "HYPERVISORPKS",
 		"dmsgpty":         "DMSGPTYPKS",
 		"survey":          "SURVEYPKS",
@@ -2560,8 +2552,40 @@ func applyFlagsToConf(conf string, cmd *cobra.Command) string {
 		"proxywl":         "PROXYSERVERWL",
 		"skycoinwebnodes": "SKYCOINWEBNODES",
 		"stun":            "STUNSERVERS",
+		"ws-peer":         "WSPEERS",
 	}
+)
 
+// FlagArgsForSkyenv returns the `config gen` arguments that set what the
+// SKYENV line key=value would — value in the plain form autoconfig holds
+// before it quotes it for the file: "true"/"false", a string, a number, or a
+// comma-separated list. ok is false when no flag controls key.
+//
+// It exists for a caller that has just EDITED the SKYENV file and re-enters
+// `config gen` in the same process (the browser build has no subprocess):
+// gen reads the file into its flag DEFAULTS at init, so an edit made after
+// that is invisible to it unless passed explicitly. A subprocess would have
+// re-read the file; passing the flags gives both paths the same result.
+func FlagArgsForSkyenv(key, value string) (args []string, ok bool) {
+	for flag, line := range flagToEnv {
+		if k, _, _ := strings.Cut(line, "="); k == key {
+			return []string{"--" + flag + "=" + value}, true
+		}
+	}
+	for _, m := range []map[string]string{valueFlagToEnv, intFlagToEnv, arrayFlagToEnv} {
+		for flag, k := range m {
+			if k == key {
+				return []string{"--" + flag, value}, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// applyFlagsToConf uncomments settings in the conf template that correspond
+// to flags passed on the command line. This makes -q/-Q output reflect the
+// user's intent (e.g., `config gen -iq` uncomments ISHYPERVISOR=true).
+func applyFlagsToConf(conf string, cmd *cobra.Command) string {
 	lines := strings.Split(conf, "\n")
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)

--- a/cmd/skywire-cli/commands/config/gen_flagargs_test.go
+++ b/cmd/skywire-cli/commands/config/gen_flagargs_test.go
@@ -1,0 +1,30 @@
+package cliconfig
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestFlagArgsForSkyenv pins the SKYENV-variable → gen-flag direction the
+// in-process autoconfig re-entry depends on: each kind of variable maps to
+// the flag form gen accepts for it, and an unknown variable maps to nothing.
+func TestFlagArgsForSkyenv(t *testing.T) {
+	for _, tc := range []struct {
+		key, value string
+		want       []string
+		ok         bool
+	}{
+		{"DISABLEPUBLICAUTOCONN", "true", []string{"--autoconn=true"}, true},
+		{"DISABLEPUBLICAUTOCONN", "false", []string{"--autoconn=false"}, true},
+		{"WSPEERS", "pk@ws://node.local:8000/tp/ws", []string{"--ws-peer", "pk@ws://node.local:8000/tp/ws"}, true},
+		{"HYPERVISORPKS", "a,b", []string{"--hvpks", "a,b"}, true},
+		{"TRANSPORTPORT", "7777", []string{"--transport-port", "7777"}, true},
+		{"REWARDSKYADDR", "2jBbGxZ", []string{"--reward", "2jBbGxZ"}, true},
+		{"NOSUCHKEY", "x", nil, false},
+	} {
+		got, ok := FlagArgsForSkyenv(tc.key, tc.value)
+		if ok != tc.ok || !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("FlagArgsForSkyenv(%s, %q) = %v, %v; want %v, %v", tc.key, tc.value, got, ok, tc.want, tc.ok)
+		}
+	}
+}

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	cliconfig "github.com/skycoin/skywire/cmd/skywire-cli/commands/config"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/skywireconfig/autoconfigcmd"
@@ -98,29 +99,29 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	addBool := func(key, onName, offName string, on, off bool) {
 		switch {
 		case cmd.Flags().Changed(onName) && on:
-			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBool(true)})
+			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBool(true), Raw: "true"})
 		case cmd.Flags().Changed(offName) && off:
-			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBool(false)})
+			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBool(false), Raw: "false"})
 		}
 	}
 	addSoloBool := func(key, name string, val bool) {
 		if cmd.Flags().Changed(name) {
-			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBool(val)})
+			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBool(val), Raw: formatSkyenvBool(val)})
 		}
 	}
 	addString := func(key, name, val string) {
 		if cmd.Flags().Changed(name) {
-			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvString(val)})
+			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvString(val), Raw: val})
 		}
 	}
 	addArray := func(key, name, val string) {
 		if cmd.Flags().Changed(name) {
-			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBashArray(val)})
+			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBashArray(val), Raw: val})
 		}
 	}
 	addInt := func(key, name string, val int) {
 		if cmd.Flags().Changed(name) {
-			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvInt(val)})
+			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvInt(val), Raw: formatSkyenvInt(val)})
 		}
 	}
 
@@ -275,7 +276,8 @@ func autoconfigRun(cmd *cobra.Command, args []string) {
 	// Resolves the skyenv path FIRST so we know which file to
 	// edit — same lookup the downstream stages use, just lifted
 	// up to do the edits first.
-	if edits := collectSkyenvEdits(cmd); len(edits) > 0 {
+	edits := collectSkyenvEdits(cmd)
+	if len(edits) > 0 {
 		pre := resolveConfig()
 		target := pre.skyenvPath
 		if target == "" {
@@ -307,7 +309,7 @@ func autoconfigRun(cmd *cobra.Command, args []string) {
 
 	resolved := resolveConfig()
 
-	if err := generateConfig(resolved, hvArg); err != nil {
+	if err := generateConfig(resolved, hvArg, edits); err != nil {
 		fmt.Printf("%s>>> FATAL:%s %v\n", colorRed, colorReset, err)
 		os.Exit(1)
 	}
@@ -545,7 +547,7 @@ func resolveConfig() resolvedConfig {
 // `cli config show .hypervisors` returned `[]` even though
 // HYPERVISORPKS / ISHYPERVISOR were set in the env file. Propagating
 // -p/-u from resolvedConfig closes the gap.
-func generateConfig(r resolvedConfig, hvArg string) error {
+func generateConfig(r resolvedConfig, hvArg string, edits []skyenvEdit) error {
 	// printableArgs is what we PRINT for the operator to copy-paste.
 	// Intentionally omits -w (we suppress the noisy fetch logs
 	// ourselves). If the install fails, the operator can paste this
@@ -605,6 +607,23 @@ func generateConfig(r resolvedConfig, hvArg string) error {
 	extra := extraGenArgs()
 	args = append(args, extra...)
 	printableArgs = append(printableArgs, extra...)
+
+	// Every edit just written to the SKYENV file, as the gen flag that sets
+	// the same thing. gen reads that file into its flag DEFAULTS when the
+	// program starts; in a subprocess that is after the edit, in the browser
+	// build (which re-enters gen in this process) it is before, and the edit
+	// would be lost. Explicit flags make both paths read the same. Keys that
+	// the arguments above already carry are left to them.
+	for _, e := range edits {
+		switch e.Key {
+		case "PKGENV", "USRENV", "ISHYPERVISOR", "HYPERVISORPKS":
+			continue
+		}
+		if fa, ok := cliconfig.FlagArgsForSkyenv(e.Key, e.Raw); ok {
+			args = append(args, fa...)
+			printableArgs = append(printableArgs, fa...)
+		}
+	}
 
 	envPrefix := ""
 	if r.skyenvPath != "" {

--- a/cmd/skywire/commands/autoconfig_skyenv.go
+++ b/cmd/skywire/commands/autoconfig_skyenv.go
@@ -34,6 +34,7 @@ import (
 type skyenvEdit struct {
 	Key   string // bash variable name (e.g. "HYPERVISORPKS")
 	Value string // RHS, including quoting / array parens / value
+	Raw   string // the value as the flag gave it: bool text, string, number, or comma-separated list
 }
 
 // updateSkyenvFile applies the edits to the file at path. The file


### PR DESCRIPTION
`skywire autoconfig` edits the SKYENV file, then runs `config gen`, which reads that file into its flag defaults at program start. In a subprocess that happens after the edit; in the browser build, which re-enters gen in the same process, it happens before, so every `--flag` given to autoconfig there reached `/etc/skywire.conf` and nothing else. The attached desk from #4690 asked for `--disable-public-autoconn --ws-peer …` and got neither.

Each edit is now also passed to gen as the flag that sets the same thing (`cliconfig.FlagArgsForSkyenv`, built from the flag→variable maps `-q` already uses; they gain `ws-peer`). Native and browser paths read the same either way. Unit test for the mapping included.
