### PR TITLE
fix(router): route over any existing transport; no stcpr/sudph in a browser

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -111,9 +111,9 @@ var (
 
 // RouteSetupHook is an alias for a function that takes remote public key
 // and a reference to transport manager in order to setup i.e:
-// 1. If the remote is either available stcpr or sudph, establish the transport to the remote and then continue with the route creation process.
-// 2. If neither of these direct transports is available, check if automatic transports are currently active. If they are continue with route creation.
-// 3. If none of the first two checks was successful, establish a dmsg transport and then continue with route creation.
+// 1. If a transport of any type to the remote already exists, continue with route creation over it.
+// 2. Otherwise, if the remote advertises stcpr or sudph, establish that transport and continue.
+// 3. Otherwise try the remaining direct types in preference order, and a dmsg transport last.
 type RouteSetupHook func(cipher.PubKey, *transport.Manager) error
 
 // Config configures Router.

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -34,7 +34,12 @@ func getRouteSetupHooks(ctx context.Context, v *Visor, log *logging.Logger) []ro
 	retrier := netutil.NewRetrier(log, time.Second, time.Second*20, 3, 1.3)
 	return []router.RouteSetupHook{
 		func(rPK cipher.PubKey, tm *transport.Manager) error {
-			establishedTransports, _ := v.Transports([]string{string(types.STCPR), string(types.SUDPH), string(types.DMSG)}, []cipher.PubKey{v.conf.PK}, false) //nolint:errcheck
+			// ANY established transport to the peer carries a 1-hop route — a
+			// WebSocket a browser visor opened to this hypervisor as much as an
+			// stcpr this visor dialed. Filtering to stcpr/sudph/dmsg here made
+			// the router dial a NEW stcpr transport to a peer it already held a
+			// swsr to, and fail the dial when that peer had no address to dial.
+			establishedTransports, _ := v.Transports(nil, []cipher.PubKey{v.conf.PK}, false) //nolint:errcheck
 			for _, transportSum := range establishedTransports {
 				if transportSum.Remote.Hex() == rPK.Hex() {
 					log.Debugf("Established transport exist. Type: %s", transportSum.Type)

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"runtime"
 	"sync"
 	"time"
 
@@ -372,6 +373,11 @@ func (v *Visor) retryStunOnTransientFail(log *logging.Logger) {
 }
 
 func initSudphClient(ctx context.Context, v *Visor, log *logging.Logger) error {
+	if runtime.GOOS == "js" {
+		// No UDP in a browser either; see initStcprClient.
+		log.Debug("sudph transport is not available in a browser; not started")
+		return nil
+	}
 	// Previously this short-circuited when AR was reached via dmsg
 	// because the dmsg URL host is a PK with no IP for SUDPH. The AR
 	// client now learns AR's public UDP address from /health
@@ -394,7 +400,17 @@ func initSudphClient(ctx context.Context, v *Visor, log *logging.Logger) error {
 	return nil
 }
 
-func initStcprClient(ctx context.Context, v *Visor, _ *logging.Logger) error {
+func initStcprClient(ctx context.Context, v *Visor, log *logging.Logger) error {
+	if runtime.GOOS == "js" {
+		// A browser has no TCP: it can neither accept nor dial stcpr. Starting
+		// the client here would still "listen" — on a port of the page's
+		// virtual network — and BIND that port in the address resolver, so
+		// every peer that looked the visor up dialed a public IP:port nothing
+		// answers at. The browser visor advertises nothing; its peers reach
+		// it over the transports it opens (ws/wt/webrtc).
+		log.Debug("stcpr transport is not available in a browser; not started")
+		return nil
+	}
 	v.tpM.InitClient(ctx, types.STCPR, v.conf.Transport.StcprPort)
 	return nil
 }


### PR DESCRIPTION
Two things the attached desk (#4690) exposed on the host visor:

- The route-setup hook counted only stcpr, sudph and dmsg as an existing transport. Holding a `swsr` to the tab, the router dialed a NEW stcpr to it; the tab has no address that answers, the skynet dial timed out, and hypervisor RPC fell back to dmsg. Any transport to the peer is a 1-hop route; the hook now counts them all.
- The browser build started the stcpr client, which "listened" on a port of the page's virtual network and bound it in the address resolver (`/resolve/stcpr/<tab>` → `70.121.13.123:11`). A browser has neither TCP nor UDP; stcpr and sudph are not started on `GOOS=js`.

`go build .`, `go vet` native, js/wasm build of `pkg/visor` and `cmd/wasm-visor` clean. Live check follows on the host: hypervisor RPC to the tab should now log `via=skynet`, and a fresh tab identity should leave no AR record.
