### PR TITLE
fix(visor): upgrade a dmsg hypervisor RPC conn to skynet when a direct transport appears

### DIFF
--- a/pkg/visor/init_hypervisor_transport.go
+++ b/pkg/visor/init_hypervisor_transport.go
@@ -151,20 +151,11 @@ func (v *Visor) autoUpgradeHypervisorTransport(ctx context.Context, hvPK cipher.
 	}
 }
 
-// hasFastTransportTo returns true when the transport manager has a
-// stcpr or sudph automatic-label transport to the given peer.
+// hasFastTransportTo reports whether a direct (non-dmsg) transport to
+// remotePK exists, whatever its label: an automatic stcpr/sudph one this
+// loop created, or the swsr a browser visor opened back to us at the
+// page origin. Any of those is the fast path the RPC dialer wants, so
+// there is nothing left for this loop to do while one is present.
 func (v *Visor) hasFastTransportTo(remotePK cipher.PubKey) bool {
-	if v.tpM == nil {
-		return false
-	}
-	for _, tp := range v.tpM.GetTransportsByLabel(transport.LabelAutomatic) {
-		if tp.Remote() != remotePK {
-			continue
-		}
-		switch tp.Type() {
-		case tptypes.STCPR, tptypes.SUDPH:
-			return true
-		}
-	}
-	return false
+	return hasFastTransportTo(v.tpM, remotePK)
 }

--- a/pkg/visor/rpc_client_serve.go
+++ b/pkg/visor/rpc_client_serve.go
@@ -165,6 +165,36 @@ func dialHypervisorRPC(
 	return conn, transportDmsg, nil
 }
 
+// rpcUpgradePoll is how often a dmsg-served hypervisor RPC conn checks
+// whether a direct transport to the hypervisor has appeared.
+const rpcUpgradePoll = 3 * time.Second
+
+// shouldUpgradeToSkynet is the decision behind watchForSkynetUpgrade: a
+// direct transport exists and skynet is not in its failure cooldown.
+func shouldUpgradeToSkynet(hasFast bool, lastSkyFail *atomic.Int64) bool {
+	return hasFast && !inSkynetCooldown(lastSkyFail)
+}
+
+// watchForSkynetUpgrade closes conn (a dmsg-served RPC conn) once a direct
+// transport to pk exists and skynet is dialable, so ServeRPCClient redials
+// over skynet. Returns when ctx (the conn's serve context) ends.
+func watchForSkynetUpgrade(ctx context.Context, log logrus.FieldLogger, tpM *transport.Manager, pk cipher.PubKey, lastSkyFail *atomic.Int64, conn net.Conn) {
+	t := time.NewTicker(rpcUpgradePoll)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if shouldUpgradeToSkynet(hasFastTransportTo(tpM, pk), lastSkyFail) {
+				log.Info("Direct transport to hypervisor is up; closing dmsg RPC conn to redial over skynet.")
+				_ = conn.Close() //nolint:errcheck,gosec
+				return
+			}
+		}
+	}
+}
+
 // inSkynetCooldown reports whether the most recent recorded skynet
 // failure is recent enough to skip skynet on this dial cycle.
 func inSkynetCooldown(lastFail *atomic.Int64) bool {
@@ -219,6 +249,14 @@ func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, tpM *transport.
 			rpcS.ServeConn(idleConn)
 			cancel()
 		}()
+		// A conn that came up over dmsg is only the bootstrap: if a direct
+		// transport to the hypervisor appears while it is serving (the
+		// upgrade loop built one, or a browser visor attached over /tp/ws
+		// after we had already started redialing), drop it so the next
+		// dial rides skynet instead of sitting on the relay until idle.
+		if via == transportDmsg {
+			go watchForSkynetUpgrade(connCtx, log, tpM, rAddr.PK, &lastSkyFail, idleConn)
+		}
 		<-connCtx.Done()
 		idleConn.stop()
 

--- a/pkg/visor/rpc_client_serve_test.go
+++ b/pkg/visor/rpc_client_serve_test.go
@@ -1,0 +1,29 @@
+package visor
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestShouldUpgradeToSkynet(t *testing.T) {
+	var never atomic.Int64
+	if shouldUpgradeToSkynet(false, &never) {
+		t.Fatal("no direct transport must not trigger an upgrade")
+	}
+	if !shouldUpgradeToSkynet(true, &never) {
+		t.Fatal("a direct transport with no recorded failure must trigger an upgrade")
+	}
+
+	var recent atomic.Int64
+	recent.Store(time.Now().UnixNano())
+	if shouldUpgradeToSkynet(true, &recent) {
+		t.Fatal("a skynet failure inside the cooldown must hold the dmsg conn")
+	}
+
+	var stale atomic.Int64
+	stale.Store(time.Now().Add(-rpcSkynetCooldown - time.Second).UnixNano())
+	if !shouldUpgradeToSkynet(true, &stale) {
+		t.Fatal("a failure older than the cooldown must allow the upgrade")
+	}
+}


### PR DESCRIPTION
Stage 2 follow-up for #4484.

The hypervisor RPC client only considered skynet at dial time. When the hypervisor is a browser visor attached over `/tp/ws`, the host starts redialing the moment the tab unloads, lands on dmsg, and stays there; the swsr the new tab opens a second later is never used. While a conn is served over dmsg the client now polls for a direct transport and closes the conn once one exists (outside the skynet cooldown), so the redial rides skynet.

The visor-level `hasFastTransportTo` counted only automatic stcpr/sudph, so the upgrade loop kept dialing a browser hypervisor's stale address-resolver record every cycle despite the swsr being up. It now reuses the RPC dialer's check, which includes WS.