### PR TITLE
fix(visor): identify the peer of a route-group conn on the skynet hypervisor RPC mirror

### DIFF
--- a/pkg/visor/dual_listen.go
+++ b/pkg/visor/dual_listen.go
@@ -139,6 +139,11 @@ func remotePK(addr net.Addr) (cipher.PubKey, bool) {
 		return a.PK, true
 	case appnet.Addr:
 		return a.PubKey, true
+	case routing.Addr:
+		// A route-group conn (the setup-node path, taken when no direct
+		// app-dial mux stream could be opened) reports its remote as the
+		// route descriptor's source address.
+		return a.PubKey, true
 	}
 	return cipher.PubKey{}, false
 }

--- a/pkg/visor/dual_listen_test.go
+++ b/pkg/visor/dual_listen_test.go
@@ -1,0 +1,31 @@
+package visor
+
+import (
+	"net"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// A skynet mirror listener hands out conns of two shapes: a direct
+// app-dial stream (appnet.Addr) and a route-group conn (routing.Addr).
+// Both must identify the peer, or the hypervisor rejects the conn.
+func TestRemotePKAcceptsEveryAcceptedConnShape(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	for name, addr := range map[string]net.Addr{
+		"dmsg":        dmsg.Addr{PK: pk, Port: 46},
+		"direct":      appnet.Addr{Net: appnet.TypeSkynet, PubKey: pk, Port: 46},
+		"route-group": routing.Addr{PubKey: pk, Port: 46},
+	} {
+		got, ok := remotePK(addr)
+		if !ok || got != pk {
+			t.Fatalf("%s: remotePK = (%s, %v), want (%s, true)", name, got, ok, pk)
+		}
+	}
+	if _, ok := remotePK(&net.TCPAddr{}); ok {
+		t.Fatal("a TCP addr must not identify a peer")
+	}
+}


### PR DESCRIPTION
Stage 2 follow-up for #4484.

The hypervisor's skynet RPC accept loop identified the peer from the conn's remote address but handled only dmsg and direct app-dial addresses. A conn that arrived via route setup (taken whenever the direct app-dial shortcut is unavailable, e.g. under a mux/min-hops routing policy) reports a `routing.Addr`, so the hypervisor logged "unable to identify peer; rejecting", closed it, and the visor fell back to dmsg for the cooldown. Seen on a browser hypervisor attached over `/tp/ws`; native hypervisors behind the same policy are affected the same way.

Accept `routing.Addr` too, with a test over the three accepted conn shapes.