### PR TITLE
feat(desk-boot): boot the attached visor at the log level given by ?loglvl=

### DIFF
--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -496,6 +496,14 @@
 						var tpURL = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + (opts.attach.path || '/tp/ws');
 						autoconfigCmd += ' --disable-public-autoconn --ws-peer ' + opts.attach.pk + '@' + tpURL;
 					}
+					// ?loglvl=debug on the page URL boots the visor at that log level: the
+					// config is regenerated on every load, so this is the one place a
+					// level for the tab's visor can be set. Letters only, so the URL
+					// cannot inject anything else into the command.
+					var loglvl = new URLSearchParams(location.search).get('loglvl');
+					if (loglvl && /^[a-z]+$/.test(loglvl)) {
+						autoconfigCmd += ' --loglvl ' + loglvl;
+					}
 					panel.openConsole({ title: 'visor', initCmd: startVisor ? autoconfigCmd : '' });
 					startedVisor = startVisor;
 				}

--- a/pkg/wasmhv/browseui/deskboot_test.go
+++ b/pkg/wasmhv/browseui/deskboot_test.go
@@ -59,6 +59,8 @@ func TestDeskBootAttachBuildsTheWSPeer(t *testing.T) {
 		"if (opts.attach && opts.attach.pk)",
 		"location.host + (opts.attach.path || '/tp/ws')",
 		"' --disable-public-autoconn --ws-peer ' + opts.attach.pk + '@' + tpURL",
+		"new URLSearchParams(location.search).get('loglvl')",
+		"autoconfigCmd += ' --loglvl ' + loglvl",
 		"initCmd: startVisor ? autoconfigCmd : ''",
 	} {
 		if !strings.Contains(src, want) {


### PR DESCRIPTION
Stage 2 tooling for #4484. The attached desk regenerates the visor's config on every page load, so the tab's visor could not be run at debug level. `?loglvl=debug` on the page URL is appended to the autoconfig command as `--loglvl`; letters only.