### PR TITLE
feat(wasm-visor): headless exec for the desk — run a shell command over CDP and get text back

### DIFF
--- a/cmd/wasm-visor/desk_js.go
+++ b/cmd/wasm-visor/desk_js.go
@@ -13,8 +13,11 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"syscall/js"
+	"time"
 
 	"github.com/0magnet/desk"
 	"github.com/0magnet/desk/panes/files"
@@ -181,6 +184,31 @@ func installDesk() {
 				return err.Error()
 			}
 			return nil
+		}),
+		// exec(cmd, {timeoutMs}): run one shell command with no terminal and
+		// resolve {out, err} — the harness's way to drive the tab's visor over
+		// CDP and read text back instead of screenshotting a console.
+		"exec": js.FuncOf(func(_ js.Value, a []js.Value) any {
+			if len(a) == 0 || a[0].Type() != js.TypeString {
+				return promise(func() (interface{}, error) { return nil, errors.New("exec(cmd): missing command") })
+			}
+			cmd := a[0].String()
+			timeout := execDefaultTimeout
+			if len(a) > 1 && a[1].Type() == js.TypeObject {
+				if v := a[1].Get("timeoutMs"); v.Type() == js.TypeNumber && v.Int() > 0 {
+					timeout = time.Duration(v.Int()) * time.Millisecond
+				}
+			}
+			return promise(func() (interface{}, error) {
+				ctx, cancel := context.WithTimeout(context.Background(), timeout)
+				defer cancel()
+				out, err := runHeadless(ctx, cmd)
+				res := map[string]interface{}{"out": out}
+				if err != nil {
+					res["err"] = err.Error()
+				}
+				return res, nil
+			})
 		}),
 		// openConsole({title, initCmd, bg}): a websh console, optionally running a
 		// first command. The FIRST call opens the terminal window; every one

--- a/cmd/wasm-visor/shell_exec_js.go
+++ b/cmd/wasm-visor/shell_exec_js.go
@@ -1,0 +1,58 @@
+// Package main cmd/wasm-visor/shell_exec_js.go c3-wasm-visor
+//
+// A headless websh: one command line run in a shell with no terminal
+// attached, its output returned as text. This is what a CDP-driven harness
+// calls (globalThis.__skywireDesk.exec) to drive the tab's visor —
+// `skywire cli …` — and read the result back, where a console tab could
+// only be screenshotted.
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/0magnet/websh/shell"
+	"github.com/0magnet/websh/shell/browser"
+)
+
+// execDefaultTimeout bounds a headless command that gives no timeoutMs.
+const execDefaultTimeout = 60 * time.Second
+
+// lockedBuffer is a bytes.Buffer safe for the shell's concurrent stdout and
+// stderr writers.
+type lockedBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (l *lockedBuffer) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.b.Write(p)
+}
+
+func (l *lockedBuffer) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.b.String()
+}
+
+// runHeadless runs cmd in a fresh shell over the shared page filesystem with
+// the same applets a console has, and returns everything it wrote to stdout
+// and stderr. A non-zero exit is reported in the error, as "exit status N".
+func runHeadless(ctx context.Context, cmd string) (string, error) {
+	registerVisorApplets()
+	browser.Register()
+	registerMeshApplets()
+	registerCurl()
+	out := &lockedBuffer{}
+	sh, err := shell.New(sharedShellFS(), strings.NewReader(""), out, out)
+	if err != nil {
+		return "", err
+	}
+	_, runErr := sh.Run(ctx, cmd)
+	return out.String(), runErr
+}


### PR DESCRIPTION
Harness for #4484. The only way to run `skywire cli …` inside the tab's visor was a websh console, whose output could only be read by screenshot (xterm renders with WebGL). `globalThis.__skywireDesk.exec(cmd, {timeoutMs})` runs one command line in a shell with no terminal attached and resolves `{out, err}`. Blob re-embed follows.