### PR TITLE
fix(config): carry LOGLVL through the in-process autoconfig re-entry

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -2525,6 +2525,7 @@ var (
 	// String flags: KEY='value' lines.
 	valueFlagToEnv = map[string]string{
 		"cliaddr": "CLIADDR",
+		"loglvl":  "LOGLVL",
 		"hvaddr":  "HVHTTPADDR",
 		"timeout": "SHUTDOWNTIMEOUT",
 		"reward":  "REWARDSKYADDR",

--- a/cmd/skywire-cli/commands/config/gen_flagargs_test.go
+++ b/cmd/skywire-cli/commands/config/gen_flagargs_test.go
@@ -20,6 +20,7 @@ func TestFlagArgsForSkyenv(t *testing.T) {
 		{"HYPERVISORPKS", "a,b", []string{"--hvpks", "a,b"}, true},
 		{"TRANSPORTPORT", "7777", []string{"--transport-port", "7777"}, true},
 		{"REWARDSKYADDR", "2jBbGxZ", []string{"--reward", "2jBbGxZ"}, true},
+		{"LOGLVL", "debug", []string{"--loglvl", "debug"}, true},
 		{"NOSUCHKEY", "x", nil, false},
 	} {
 		got, ok := FlagArgsForSkyenv(tc.key, tc.value)


### PR DESCRIPTION
The SKYENV→flag map the in-process config gen re-entry uses (#4693) had no entry for LOGLVL, so `skywire autoconfig --loglvl debug` in the browser wrote the level to skywire.conf and then generated a config without it. Native autoconfig re-executes gen and was unaffected.