### PR TITLE
fix(router): segment route group writes larger than one packet

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"sort"
 	"sync"
@@ -687,8 +688,17 @@ func (rg *RouteGroup) Read(p []byte) (n int, err error) {
 	return rg.read(p)
 }
 
-// Write writes payload to a RouteGroup
-// For the first version, only the first ForwardRule (fwd[0]) is used for writing.
+// Write writes payload to a RouteGroup, splitting it into as many data frames as
+// the wire format needs. A routing packet's payload length is a uint16, so one
+// frame carries at most maxWritePayload bytes of application data. Before
+// per-frame noise the stream-noise wrapper (EncryptConn) sliced every write into
+// ≤4 KiB frames, so this path never saw a large payload; with per-frame noise the
+// group receives the application's raw writes (net/rpc hands a >64 KiB gob reply
+// down in a single call), and a payload over the frame limit has to be segmented
+// here rather than rejected — the rejection burned a sequence number, and the
+// peer's no-skip reorder buffer then waited on that hole forever (#4484 stage 2:
+// hypervisor RPC over skynet stalled after the first 4 KiB of a Summary reply).
+// Each segment goes through leg selection on its own, so a mux stripes them.
 func (rg *RouteGroup) Write(p []byte) (n int, err error) {
 	if rg.isClosed() {
 		return 0, io.ErrClosedPipe
@@ -702,15 +712,36 @@ func (rg *RouteGroup) Write(p []byte) (n int, err error) {
 		return 0, nil
 	}
 
-	rg.mu.Lock()
-	tp, rule, leg, err := rg.nextTransport(p)
-	if err != nil {
+	for n < len(p) {
+		rg.mu.Lock()
+		chunk := len(p) - n
+		if maxChunk := rg.maxWritePayload(); chunk > maxChunk {
+			chunk = maxChunk
+		}
+		tp, rule, leg, err := rg.nextTransport(p[n : n+chunk])
 		rg.mu.Unlock()
-		return 0, err
-	}
-	rg.mu.Unlock()
+		if err != nil {
+			return n, err
+		}
 
-	return rg.write(p, tp, rule, leg)
+		written, err := rg.write(p[n:n+chunk], tp, rule, leg)
+		n += written
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}
+
+// maxWritePayload is the most application bytes one data frame of this group
+// can carry: the uint16 packet payload limit less the mux frame's own overhead
+// (sequence number, and the AEAD tag under per-frame noise). Called with rg.mu
+// held (mux.seal is wired under it).
+func (rg *RouteGroup) maxWritePayload() int {
+	if rg.mux == nil {
+		return math.MaxUint16
+	}
+	return math.MaxUint16 - rg.mux.frameOverhead()
 }
 
 // Close closes a RouteGroup.

--- a/pkg/router/route_group_write_segment_test.go
+++ b/pkg/router/route_group_write_segment_test.go
@@ -1,0 +1,122 @@
+//go:build !tinygo || (js && wasm)
+
+package router
+
+import (
+	"math"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// capturedFrames returns every sequenced data frame written to any leg, ordered
+// by sequence number, so a segmented write can be reassembled and checked.
+func capturedFrames(conns []*capturingTransport) []routing.Packet {
+	var frames []routing.Packet
+	for _, c := range conns {
+		c.mu.Lock()
+		for _, p := range c.written {
+			if p.Type() == routing.DataPacket {
+				frames = append(frames, p)
+			}
+		}
+		c.mu.Unlock()
+	}
+	sort.Slice(frames, func(i, j int) bool { return frames[i].SequenceNumber() < frames[j].SequenceNumber() })
+	return frames
+}
+
+func patterned(n int) []byte {
+	p := make([]byte, n)
+	for i := range p {
+		p[i] = byte(i*7 + i>>8)
+	}
+	return p
+}
+
+// A write larger than one routing packet can carry (uint16 payload length) must
+// be split into consecutive frames, not rejected. net/rpc hands a >64 KiB gob
+// reply to Write in one call once per-frame noise bypasses the stream-noise
+// chunking, and the rejection stalled hypervisor RPC over skynet (#4484).
+func TestRouteGroupWriteSegmentsOversizedPayload(t *testing.T) {
+	rg, conns := createCapturingMuxRouteGroup(t)
+	t.Cleanup(func() {
+		for _, c := range conns {
+			c.Close() //nolint:errcheck,gosec
+		}
+	})
+	require.NoError(t, rg.SetWriteDeadline(time.Now().Add(5*time.Second)))
+
+	payload := patterned(3*math.MaxUint16 + 1234)
+	n, err := rg.Write(payload)
+	require.NoError(t, err)
+	require.Equal(t, len(payload), n)
+
+	maxChunk := math.MaxUint16 - routing.SeqSize
+	wantFrames := (len(payload) + maxChunk - 1) / maxChunk
+	frames := capturedFrames(conns)
+	require.Len(t, frames, wantFrames)
+	require.Equal(t, uint32(wantFrames), rg.mux.writeSeqValue(), "one sequence number per frame, none burned") //nolint:gosec
+
+	var got []byte
+	for i, f := range frames {
+		require.Equal(t, uint32(i), f.SequenceNumber(), "frames must be consecutive") //nolint:gosec
+		require.LessOrEqual(t, int(f.Size()), math.MaxUint16)
+		got = append(got, f.DataPayloadAfterSeq()...)
+	}
+	require.Equal(t, payload, got, "reassembled frames must equal the written payload")
+}
+
+// Under per-frame noise every frame also carries the AEAD tag, so the segment
+// size must leave room for it or the sealed frame overflows the packet.
+func TestRouteGroupWriteSegmentsUnderPerFrameSeal(t *testing.T) {
+	rg, conns := createCapturingMuxRouteGroup(t)
+	t.Cleanup(func() {
+		for _, c := range conns {
+			c.Close() //nolint:errcheck,gosec
+		}
+	})
+	require.NoError(t, rg.SetWriteDeadline(time.Now().Add(5*time.Second)))
+
+	tag := make([]byte, perFrameSealOverhead)
+	rg.mu.Lock()
+	rg.mux.seal = func(_ uint32, plaintext []byte) []byte { return append(append([]byte{}, plaintext...), tag...) }
+	rg.mu.Unlock()
+
+	payload := patterned(math.MaxUint16) // fits one frame unsealed, not once tagged
+	n, err := rg.Write(payload)
+	require.NoError(t, err)
+	require.Equal(t, len(payload), n)
+
+	frames := capturedFrames(conns)
+	require.Len(t, frames, 2)
+	var got []byte
+	for _, f := range frames {
+		require.LessOrEqual(t, int(f.Size()), math.MaxUint16)
+		sealed := f.DataPayloadAfterSeq()
+		got = append(got, sealed[:len(sealed)-perFrameSealOverhead]...)
+	}
+	require.Equal(t, payload, got)
+}
+
+// An oversized frame must be refused before a sequence number is taken: a seq
+// with no frame behind it is a hole the peer's no-skip reorder buffer waits on
+// forever.
+func TestWrapPayloadOversizedDoesNotConsumeSeq(t *testing.T) {
+	m := newRouteMux(logging.MustGetLogger("wrap-oversize"), true)
+	m.growLegs(1)
+
+	_, _, err := m.wrapPayload(1, make([]byte, math.MaxUint16), uuid.Nil)
+	require.ErrorIs(t, err, routing.ErrPayloadTooBig)
+	require.Equal(t, uint32(0), m.writeSeqValue(), "a rejected frame must not advance the sequence")
+
+	_, seq, err := m.wrapPayload(1, make([]byte, math.MaxUint16-routing.SeqSize), uuid.Nil)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), seq)
+}

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -2,6 +2,7 @@
 package router
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1013,6 +1014,21 @@ func ewmaRate(prev float64, delta uint64, secs float64) float64 {
 	return goodputEWMAAlpha*sample + (1-goodputEWMAAlpha)*prev
 }
 
+// perFrameSealOverhead is the AEAD tag the per-frame seal appends to every mux
+// frame. Both noise cipher suites in use (AES-GCM, ChaCha20-Poly1305) carry a
+// 16-byte tag.
+const perFrameSealOverhead = 16
+
+// frameOverhead is what a sequenced data frame spends on top of the application
+// payload: the sequence number, plus the AEAD tag once per-frame noise is wired.
+func (m *routeMux) frameOverhead() int {
+	overhead := routing.SeqSize
+	if m.seal != nil {
+		overhead += perFrameSealOverhead
+	}
+	return overhead
+}
+
 // wrapPayload creates a sequenced data packet and optionally stores it for
 // retransmission, tagged with the TRANSPORT UUID of the leg it is about to be
 // sent on (uuid.Nil = unknown) so the demote-time flush can target only the
@@ -1020,6 +1036,13 @@ func ewmaRate(prev float64, delta uint64, secs float64) float64 {
 // index — indices shift on slice compaction.
 // Returns the packet and the sequence number used.
 func (m *routeMux) wrapPayload(routeID routing.RouteID, data []byte, tpID uuid.UUID) (routing.Packet, uint32, error) {
+	// Reject an oversized frame BEFORE taking a sequence number. A seq consumed by
+	// a frame that never goes out is a permanent hole: the receiver's no-skip
+	// reorder buffer waits on it forever. RouteGroup.Write segments to
+	// maxWritePayload so this is a guard, not a path.
+	if len(data)+m.frameOverhead() > math.MaxUint16 {
+		return nil, 0, routing.ErrPayloadTooBig
+	}
 	seq := atomic.AddUint32(&m.writeSeq, 1) - 1
 	// Per-frame AEAD: seal the app payload under seq as the nonce. The sealed
 	// bytes are what go on the wire AND into the retx buffer, so a SACK


### PR DESCRIPTION
`RouteGroup.Write` put the whole payload into one data frame, and a routing packet's payload length is a uint16. Before per-frame noise the stream-noise wrapper chunked every write to 4 KiB so this never hit; with per-frame noise the group receives the application's raw writes, and net/rpc hands down a >64 KiB gob reply in one call. The frame was rejected after a sequence number had been taken, so the peer's no-skip reorder buffer waited on the hole forever.

Observed on #4484 stage 2: hypervisor RPC over skynet delivered the first 4 KiB of a `Summary` reply and stalled (host `write_seq 3`, `sent_packets 2`; tab received 4096 + 97 payload bytes, no reorder gap, three RPC timeouts, conn closed).

`Write` now segments to what one frame carries (less the seq and, under per-frame noise, the AEAD tag), and `wrapPayload` refuses an oversized frame before consuming a seq. Tests reassemble a 3×64 KiB write from the captured frames, cover the sealed case, and check that a rejected frame leaves the sequence untouched; all three fail on develop.
