### PR TITLE
feat(dmsg): let a client session carry stream requests for another key

### DIFF
--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -166,6 +166,12 @@ type EntityCommon struct {
 	maxRelayedStreams int
 	relayedStreams    int64
 
+	// acceptRelayedRequests admits a stream request over a CLIENT session
+	// whose SrcAddr.PK is not the session's remote key (see
+	// ServerConfig.AcceptRelayedRequests). Such a request is charged to the
+	// relay slots above exactly like a peer bridge.
+	acceptRelayedRequests bool
+
 	// lastPushedSrvPKs is the set of delegated server PKs most recently
 	// pushed to the dmsg discovery. It is used by updateClientEntry to
 	// short-circuit redundant GET/PUT round-trips when nothing has

--- a/pkg/dmsg/dmsg/relayed_request_test.go
+++ b/pkg/dmsg/dmsg/relayed_request_test.go
@@ -1,0 +1,194 @@
+package dmsg
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/noise"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// relayedTestEnv is one dmsg server with two ordinary clients on it: relay,
+// which will forward requests on a third key's behalf over its own session, and
+// dst, which listens on dstPort. src is a bare keypair that holds no session at
+// all — the identity a served desk tab or a service would have in stage 3.
+type relayedTestEnv struct {
+	srv           *Server
+	srvPK         cipher.PubKey
+	relay         *Client
+	dst           *Client
+	dstPK         cipher.PubKey
+	srcPK         cipher.PubKey
+	srcSK         cipher.SecKey
+	dstLis        *Listener
+	acceptedFirst chan *Stream
+}
+
+const relayedDstPort = 80
+
+func newRelayedTestEnv(t *testing.T, conf *ServerConfig) *relayedTestEnv {
+	t.Helper()
+	dc := disc.NewMock(0)
+	srvPK, srvSK := GenKeyPair(t, "relayed-srv")
+
+	srv := NewServer(srvPK, srvSK, dc, conf, nil)
+	srv.SetLogger(logging.MustGetLogger("relayed_server"))
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := lis.Addr().String()
+	srvEntry := disc.NewServerEntry(srvPK, 0, addr, 10)
+	require.NoError(t, srvEntry.Sign(srvSK))
+	require.NoError(t, dc.PostEntry(context.Background(), srvEntry))
+	go func() { _ = srv.Serve(lis, addr) }() //nolint:errcheck
+	t.Cleanup(func() { _ = srv.Close() })    //nolint:errcheck
+
+	connect := func(name string) (*Client, cipher.PubKey) {
+		pk, sk := GenKeyPair(t, name)
+		c := NewClient(pk, sk, dc, &Config{MinSessions: 1})
+		c.SetLogger(logging.MustGetLogger(name))
+		go c.Serve(context.Background()) //nolint:errcheck
+		require.Eventually(t, func() bool {
+			_, ok := c.Session(srvPK)
+			return ok
+		}, 15*time.Second, 100*time.Millisecond, "%s never formed a session", name)
+		t.Cleanup(func() { _ = c.Close() }) //nolint:errcheck
+		return c, pk
+	}
+	relay, _ := connect("relayed-relay")
+	dst, dstPK := connect("relayed-dst")
+	dstLis, err := dst.Listen(relayedDstPort)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dstLis.Close() }) //nolint:errcheck
+
+	srcPK, srcSK := GenKeyPair(t, "relayed-src")
+	return &relayedTestEnv{
+		srv: srv, srvPK: srvPK, relay: relay, dst: dst, dstPK: dstPK,
+		srcPK: srcPK, srcSK: srcSK, dstLis: dstLis,
+	}
+}
+
+// relaySession is the relay's own session to the server, viewed the way the
+// server-side forwarding code views a session: this is exactly the wrap the
+// visor relay acceptor uses to forward with forwardRequest.
+func (e *relayedTestEnv) relaySession(t *testing.T) ServerSession {
+	t.Helper()
+	ses, ok := e.relay.Session(e.srvPK)
+	require.True(t, ok)
+	return ServerSession{SessionCommon: ses.SessionCommon}
+}
+
+// signedRequest builds the request src would send to dst: signed by src, with
+// src's half of the client↔client KK handshake. The relay never sees src's key.
+func (e *relayedTestEnv) signedRequest(t *testing.T, ipinfo bool) (StreamRequest, SignedObject, *noise.Noise) {
+	t.Helper()
+	ns, err := noise.New(noise.HandshakeKK, noise.Config{
+		LocalPK: e.srcPK, LocalSK: e.srcSK, RemotePK: e.dstPK, Initiator: true,
+	})
+	require.NoError(t, err)
+	msg, err := ns.MakeHandshakeMessage()
+	require.NoError(t, err)
+	req := StreamRequest{
+		Timestamp: time.Now().UnixNano(),
+		SrcAddr:   Addr{PK: e.srcPK, Port: 1},
+		DstAddr:   Addr{PK: e.dstPK, Port: relayedDstPort},
+		NoiseMsg:  msg,
+		IPinfo:    ipinfo,
+	}
+	if ipinfo {
+		req.DstAddr = Addr{PK: e.srvPK}
+	}
+	obj, err := MakeSignedStreamRequest(&req, e.srcSK)
+	require.NoError(t, err)
+	req, err = obj.ObtainStreamRequest()
+	require.NoError(t, err)
+	return req, obj, ns
+}
+
+// expectRejected writes a request on a fresh stream of the relay's session and
+// requires that no response comes back: the server drops a refused request.
+func (e *relayedTestEnv) expectRejected(t *testing.T, obj SignedObject) {
+	t.Helper()
+	ses := e.relaySession(t)
+	str, err := ses.sm.yamux.OpenStream()
+	require.NoError(t, err)
+	defer str.Close() //nolint:errcheck
+	require.NoError(t, ses.writeObject(str, obj))
+	require.NoError(t, str.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, err = ses.readObject(str)
+	require.Error(t, err, "a refused relayed request must not be answered")
+}
+
+// A stream request signed by a key that holds no session, forwarded over
+// another client's session, reaches its destination under the SOURCE key and
+// carries data end to end; the server counts it against its relay slots.
+func TestRelayedRequest_ForwardedOverClientSession(t *testing.T) {
+	env := newRelayedTestEnv(t, &ServerConfig{
+		MaxSessions: 10, UpdateInterval: 0, AcceptRelayedRequests: true, MaxRelayedStreams: 1,
+	})
+
+	accepted := make(chan *Stream, 1)
+	go func() {
+		s, err := env.dstLis.AcceptStream()
+		if err != nil {
+			accepted <- nil
+			return
+		}
+		accepted <- s
+	}()
+
+	req, _, ns := env.signedRequest(t, false)
+	relay := env.relaySession(t)
+	yStr, respObj, err := relay.forwardRequest(req)
+	require.NoError(t, err, "server must accept a relayed request whose signature verifies against its source key")
+	defer yStr.Close() //nolint:errcheck
+	resp, err := respObj.ObtainStreamResponse()
+	require.NoError(t, err)
+	require.True(t, resp.Accepted)
+	require.NoError(t, ns.ProcessHandshakeMessage(resp.NoiseMsg))
+
+	var s *Stream
+	select {
+	case s = <-accepted:
+		require.NotNil(t, s, "dst failed to accept the relayed stream")
+	case <-time.After(10 * time.Second):
+		t.Fatal("dst never accepted the relayed stream")
+	}
+	defer s.Close() //nolint:errcheck
+	require.Equal(t, env.srcPK, s.RemoteAddr().(Addr).PK, "the destination must see the SOURCE key, not the relay's")
+
+	// End to end under src's own noise: the relay carries ciphertext only.
+	rw := noise.NewReadWriter(yStr, ns)
+	_, err = rw.Write([]byte("via relay"))
+	require.NoError(t, err)
+	buf := make([]byte, 9)
+	require.NoError(t, s.SetReadDeadline(time.Now().Add(5*time.Second)))
+	_, err = s.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, "via relay", string(buf))
+
+	// Charged to the relay slots for as long as the bridge lives...
+	require.Equal(t, int64(1), atomic.LoadInt64(&env.srv.relayedStreams))
+	// ...so at MaxRelayedStreams 1 a second relayed request is refused.
+	_, obj2, _ := env.signedRequest(t, false)
+	env.expectRejected(t, obj2)
+}
+
+// With acceptance off, a client session may only carry its own key's requests
+// (the pre-existing rule), and an IP request may never be relayed: the address
+// it would report is the relay's.
+func TestRelayedRequest_Refusals(t *testing.T) {
+	strict := newRelayedTestEnv(t, &ServerConfig{MaxSessions: 10, UpdateInterval: 0})
+	_, obj, _ := strict.signedRequest(t, false)
+	strict.expectRejected(t, obj)
+
+	open := newRelayedTestEnv(t, &ServerConfig{MaxSessions: 10, UpdateInterval: 0, AcceptRelayedRequests: true})
+	_, ipObj, _ := open.signedRequest(t, true)
+	open.expectRejected(t, ipObj)
+}

--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -61,15 +61,25 @@ type ServerConfig struct {
 	// Zero uses DefaultMaxRelayedStreams. Local client↔client bridging on
 	// this same server is unaffected — only peer-relayed streams count.
 	MaxRelayedStreams int
+
+	// AcceptRelayedRequests lets a CLIENT session carry stream requests whose
+	// source key is not the session's own: a visor forwarding a request on
+	// another key's behalf over its own session (#4484 stage 3, dmsg over
+	// skynet through a host). The request is still signed by, and verified
+	// against, its source key, so the relaying session cannot impersonate
+	// anyone; what it spends is this server's relay capacity, charged like a
+	// peer bridge. Peer sessions carry foreign sources regardless.
+	AcceptRelayedRequests bool
 }
 
 // DefaultServerConfig returns the default server config.
 func DefaultServerConfig() *ServerConfig {
 	return &ServerConfig{
-		MaxSessions:       DefaultMaxSessions,
-		UpdateInterval:    DefaultUpdateInterval,
-		MaxPeerLinks:      DefaultMaxPeerLinks,
-		MaxRelayedStreams: DefaultMaxRelayedStreams,
+		MaxSessions:           DefaultMaxSessions,
+		UpdateInterval:        DefaultUpdateInterval,
+		MaxPeerLinks:          DefaultMaxPeerLinks,
+		MaxRelayedStreams:     DefaultMaxRelayedStreams,
+		AcceptRelayedRequests: true,
 	}
 }
 
@@ -193,6 +203,7 @@ func NewServer(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Serv
 		s.acceptedPeerPKs[pk] = struct{}{}
 	}
 	s.EntityCommon.acceptPeerAnnouncements = true
+	s.EntityCommon.acceptRelayedRequests = conf.AcceptRelayedRequests
 	s.EntityCommon.maxRelayedStreams = conf.MaxRelayedStreams
 	if s.EntityCommon.maxRelayedStreams <= 0 {
 		s.EntityCommon.maxRelayedStreams = DefaultMaxRelayedStreams

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -245,9 +245,21 @@ func (ss *ServerSession) serveStream(log logrus.FieldLogger, yStr io.ReadWriteCl
 		ss.m.RecordStream(metrics.DeltaFailed) // record failed stream
 		return err
 	}
-	// For peer sessions, the SrcAddr.PK is the original client, not the
-	// peer server. The request signature is still verified above.
-	if !ss.isPeer && req.SrcAddr.PK != ss.rPK {
+	// A request whose source is not this session's remote key is RELAYED: a
+	// peer server has always carried its clients' requests this way, and a
+	// visor may now forward a request on another key's behalf over its own
+	// client session (#4484 stage 3). The signature verified above binds the
+	// envelope to the claimed source key, so the relaying session cannot
+	// impersonate anyone; what it spends is this server's relay capacity,
+	// charged in bridgeStream.
+	relayed := req.SrcAddr.PK != ss.rPK
+	if relayed && !ss.isPeer && !ss.entity.acceptRelayedRequests {
+		ss.m.RecordStream(metrics.DeltaFailed) // record failed stream
+		return ErrReqInvalidSrcPK
+	}
+	// The address an IP request reports is the session's, which for a relayed
+	// request is the relay's, not the source's. Refuse rather than mislead.
+	if relayed && req.IPinfo {
 		ss.m.RecordStream(metrics.DeltaFailed) // record failed stream
 		return ErrReqInvalidSrcPK
 	}
@@ -317,12 +329,12 @@ func (ss *ServerSession) serveStream(log logrus.FieldLogger, yStr io.ReadWriteCl
 
 // bridgeStream forwards a request to a destination session and bridges the two streams.
 func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteCloser, dst ServerSession, req StreamRequest) error {
-	// A bridge where either side is a peer session is a *relayed* stream —
-	// this server carrying traffic on behalf of another server. Bound the
-	// concurrent count so an always-open relay can't be amplified. A plain
-	// local client↔client bridge (neither side a peer) is normal operation
-	// and is never gated.
-	if ss.isPeer || dst.isPeer {
+	// A bridge where either side is a peer session, or whose request arrived
+	// over a client session on another key's behalf, is a *relayed* stream —
+	// this server carrying traffic for someone that is not its own client.
+	// Bound the concurrent count so an always-open relay can't be amplified. A
+	// plain local client↔client bridge is normal operation and is never gated.
+	if ss.isPeer || dst.isPeer || req.SrcAddr.PK != ss.rPK {
 		if !ss.entity.tryAcquireRelaySlot() {
 			ss.m.RecordStream(metrics.DeltaFailed)
 			return ErrRelayCapacityReached

--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -192,6 +192,12 @@ type Config struct {
 	AcceptedPeerPKs   []cipher.PubKey `json:"accepted_peer_pks,omitempty"`
 	MaxPeerLinks      int             `json:"max_peer_links,omitempty"`
 	MaxRelayedStreams int             `json:"max_relayed_streams,omitempty"`
+	// RejectRelayedRequests turns off the default acceptance of stream
+	// requests that a visor forwards on another key's behalf over its own
+	// client session (dmsg over skynet through a host). They are signed by
+	// their source key and charged to max_relayed_streams; set this only to
+	// make the server relay for peers alone.
+	RejectRelayedRequests bool `json:"reject_relayed_requests,omitempty"`
 }
 
 // GenerateDefaultConfig generate default config for dmsg-server

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -216,12 +216,13 @@ func (s *service) Run(ctx context.Context) error {
 		// (disc.Entry.Version) instead of the vestigial "0.0.1" protocol
 		// constant, so `mdisc servers` / discovery consumers see it. Empty
 		// (unknown build) preserves "0.0.1".
-		Version:           dmsgEntryVersion(),
-		AuthPassphrase:    s.cfg.AuthPassphrase,
-		Peers:             peers,
-		AcceptedPeerPKs:   cfg.AcceptedPeerPKs,
-		MaxPeerLinks:      cfg.MaxPeerLinks,
-		MaxRelayedStreams: cfg.MaxRelayedStreams,
+		Version:               dmsgEntryVersion(),
+		AuthPassphrase:        s.cfg.AuthPassphrase,
+		Peers:                 peers,
+		AcceptedPeerPKs:       cfg.AcceptedPeerPKs,
+		MaxPeerLinks:          cfg.MaxPeerLinks,
+		MaxRelayedStreams:     cfg.MaxRelayedStreams,
+		AcceptRelayedRequests: !cfg.RejectRelayedRequests,
 	}
 
 	deployments := cfg.NormalizedDeployments()


### PR DESCRIPTION
Stage 3 (a) of #4484. A dmsg server bound every request on a client session to that session's key; only peer sessions could carry a foreign source. A visor forwarding a request on another key's behalf over its own session (dmsg over skynet through a host) needs the same allowance.

The request is still signed by, and verified against, its source key, so the relaying session cannot impersonate anyone; what it spends is the server's relay capacity, charged to the relay slots like a peer bridge. An IP request is never relayed (the address it would report is the relay's). On by default; `reject_relayed_requests` in the server config turns it off. The visor's LAN dmsg server keeps the strict rule.

Test: a key with no session at all is forwarded over another client's session, the destination sees the source key, data flows end to end under the source's own noise, the slot is charged (a second request at cap 1 is refused), and both refusals hold. Fails on develop.
