### PR TITLE
feat(dmsg): skynet carrier and per-visor relay acceptor (#4484 stage 3)

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"net"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -107,6 +110,21 @@ type Config struct {
 	// its own PK (see self_session_test.go), so only the co-resident-server
 	// visor sets it.
 	SkipSelfServer bool
+
+	// SessionDialer dials the byte pipe to a server whose advertised address
+	// names a carrier this client has no native dial for — today the skynet
+	// carrier: a "skynet://<pk>:<port>" address is a dmsg relay run by a visor
+	// (see Client.AcceptRelaySession) reached over a skywire route. The conn it
+	// returns is wrapped in the same Noise+yamux session as every other
+	// carrier; the pipe is invisible above it. nil leaves such servers
+	// undialable (the seeded entry is skipped with an error, like a browser
+	// meeting a tcp-only server).
+	SessionDialer SessionDialer
+
+	// MaxRelayedStreams bounds the concurrent streams this client relays for
+	// sessions accepted through AcceptRelaySession. 0 (the default) refuses
+	// every relayed stream: a client is not a relay unless configured as one.
+	MaxRelayedStreams int
 }
 
 // Carrier names for Config.Carriers.
@@ -115,7 +133,49 @@ const (
 	CarrierWS   = "ws"
 	CarrierWT   = "wt"
 	CarrierQUIC = "quic"
+
+	// CarrierSkynet is the skynet carrier: the session rides a skywire route to
+	// a visor acting as a dmsg relay (not a discovery-registered server). It is
+	// selected by the server entry's address, never by Config.Carriers, and
+	// dialed through Config.SessionDialer.
+	CarrierSkynet = "skynet"
 )
+
+// SessionDialer dials the byte pipe for a session over a carrier the client
+// cannot dial natively (Config.SessionDialer). network is the carrier name
+// (CarrierSkynet) and addr the server entry's advertised address.
+type SessionDialer func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// SkynetScheme prefixes the advertised address of a dmsg relay reachable over a
+// skywire route: "skynet://<relay pk>:<dmsg port>". See SkynetAddr.
+const SkynetScheme = "skynet://"
+
+// SkynetAddr renders the advertised address of a dmsg relay listening on the
+// given dmsg port of the visor pk. A server entry carrying it is dialed over the
+// skynet carrier.
+func SkynetAddr(pk cipher.PubKey, port uint16) string {
+	return SkynetScheme + pk.String() + ":" + strconv.Itoa(int(port))
+}
+
+// ParseSkynetAddr parses an address produced by SkynetAddr.
+func ParseSkynetAddr(addr string) (cipher.PubKey, uint16, error) {
+	var pk cipher.PubKey
+	if !strings.HasPrefix(addr, SkynetScheme) {
+		return pk, 0, fmt.Errorf("dmsg: %q is not a %s address", addr, SkynetScheme)
+	}
+	host, portStr, err := net.SplitHostPort(strings.TrimPrefix(addr, SkynetScheme))
+	if err != nil {
+		return pk, 0, fmt.Errorf("dmsg: skynet address %q: %w", addr, err)
+	}
+	if err := pk.Set(host); err != nil {
+		return pk, 0, fmt.Errorf("dmsg: skynet address %q: %w", addr, err)
+	}
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return pk, 0, fmt.Errorf("dmsg: skynet address %q: %w", addr, err)
+	}
+	return pk, uint16(port), nil
+}
 
 // Ensure ensures all config values are set.
 func (c *Config) Ensure() {
@@ -260,6 +320,14 @@ type Client struct {
 	// the closed-set in Close and the closed-check + Add in
 	// dialSession provides the happens-before edge.
 	closed bool
+
+	// relaySessions are the server-role sessions this client accepted through
+	// AcceptRelaySession, keyed by the attached peer's PK. Kept apart from
+	// sessions (which are this client's sessions TO servers) so nothing that
+	// walks sessions — entry publishing, dial phases, pings, the reaper —
+	// mistakes an attached peer for a server. Guarded by relaySessionsMx.
+	relaySessions   map[cipher.PubKey]*SessionCommon
+	relaySessionsMx sync.Mutex
 }
 
 // AddDiscovery registers an additional dmsg-discovery this client
@@ -310,6 +378,14 @@ func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Conf
 	// Init common fields.
 	c.EntityCommon.init(pk, sk, dc, log, conf.UpdateInterval)
 	c.EntityCommon.noRegister = conf.NoRegister
+	c.EntityCommon.maxRelayedStreams = conf.MaxRelayedStreams
+	// Relay acceptor hooks (see client_relay.go): a request arriving over an
+	// accepted relay session is forwarded over this client's own server
+	// sessions, and a destination that is itself attached to this relay is
+	// reached directly.
+	c.relaySessions = make(map[cipher.PubKey]*SessionCommon)
+	c.EntityCommon.relaySessionLookup = c.relaySession
+	c.EntityCommon.forwardSessionsFunc = c.relayForwardSessions
 
 	// Init callback: on set session.
 	c.EntityCommon.setSessionCallback = func(ctx context.Context) error {
@@ -788,6 +864,7 @@ func (ce *Client) Close() error {
 		ce.sessions = make(map[cipher.PubKey]*SessionCommon)
 		ce.log.Debug("All sessions closed.")
 		ce.sessionsMx.Unlock()
+		ce.closeRelaySessions()
 		ce.porter.CloseAll(ce.log)
 		ce.wg.Wait()
 		// Use a short timeout for discovery cleanup — if the discovery

--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -1,0 +1,193 @@
+// Package dmsg pkg/dmsg/dmsg/client_relay.go
+//
+// A dmsg client as a RELAY (#4484 stage 3): a peer that cannot, or should not,
+// hold its own dmsg server sessions attaches to this client over a skywire
+// route (the skynet carrier, see CarrierSkynet) and this client carries the
+// peer's stream requests over its own server sessions with the existing
+// forwardRequest/bridgeStream path. No discovery registration, no TCP
+// listener, no server peering: the relay is a server-role session on the
+// shared EntityCommon, nothing more.
+//
+// What the relay sees is the signed StreamRequest envelope — enough to route
+// it. What it cannot see is the stream: the Noise KK handshake inside the
+// request runs between the attached peer and the destination, so the relay
+// (and the server after it) only copy ciphertext. The server accepts the
+// forwarded request because its signature verifies against the peer's own key
+// (ServerConfig.AcceptRelayedRequests), and charges it to relay slots. The
+// destination sees the attached peer's key, not the relay's.
+package dmsg
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/0magnet/yamux"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg/metrics"
+)
+
+// DefaultClientMaxRelayedStreams is the relay-slot cap a visor gives its dmsg
+// client when it runs the relay acceptor: enough for a desk's worth of
+// concurrent streams, small enough that an attached peer cannot amplify the
+// visor into a public relay.
+const DefaultClientMaxRelayedStreams = 256
+
+// relayEntryLookupTimeout bounds the discovery lookup the relay makes to
+// order its forward candidates by the destination's delegated servers. The
+// lookup rides the relay's own sessions; a miss just falls back to
+// latency order over every session.
+const relayEntryLookupTimeout = 3 * time.Second
+
+// ErrRelayPeerNotAllowed is returned by AcceptRelaySession when the allow
+// callback refuses the handshaken peer.
+var ErrRelayPeerNotAllowed = errors.New("dmsg: relay peer not allowed")
+
+// SetSessionDialer installs (or, with nil, removes) the dialer used for
+// carriers this client cannot dial natively. See Config.SessionDialer. Safe
+// to call before Serve; takes effect for every subsequent session dial.
+func (ce *Client) SetSessionDialer(d SessionDialer) {
+	ce.convMx.Lock()
+	ce.conf.SessionDialer = d
+	ce.convMx.Unlock()
+}
+
+func (ce *Client) sessionDialer() SessionDialer {
+	ce.convMx.RLock()
+	defer ce.convMx.RUnlock()
+	return ce.conf.SessionDialer
+}
+
+// AcceptRelaySession runs one attached peer's relay session over conn until
+// the peer hangs up, ctx is canceled, or the client closes; it blocks for the
+// session's lifetime, so callers run it in the accept loop's goroutine. The
+// client answers the peer's Noise XK handshake as the server side, learns the
+// peer's key from it, and asks allow (if non-nil) whether to keep the peer;
+// then it serves the yamux session the way a dmsg server serves a client:
+// each stream request is bridged to another peer attached here, or forwarded
+// over one of this client's own server sessions, charged to
+// Config.MaxRelayedStreams. Newest-session-wins per peer key, like servers.
+//
+// conn is closed on every return.
+func (ce *Client) AcceptRelaySession(ctx context.Context, conn net.Conn, allow func(cipher.PubKey) bool) error {
+	ss, err := makeServerSession(metrics.NewEmpty(), &ce.EntityCommon, conn)
+	if err != nil {
+		_ = conn.Close() //nolint:errcheck
+		return err
+	}
+	pk := ss.RemotePK()
+	log := ce.log.WithField("relay_peer", pk)
+	if allow != nil && !allow(pk) {
+		_ = conn.Close() //nolint:errcheck
+		log.Debug("Refused relay session.")
+		return ErrRelayPeerNotAllowed
+	}
+	ss.relayInbound = true
+
+	ss.sm.mutx.Lock()
+	ss.sm.yamux, err = yamux.Server(conn, YamuxConfig())
+	if err != nil {
+		ss.sm.mutx.Unlock()
+		_ = conn.Close() //nolint:errcheck
+		return err
+	}
+	ss.sm.addr = ss.sm.yamux.RemoteAddr()
+	ss.sm.mutx.Unlock()
+
+	ce.relaySessionsMx.Lock()
+	if isClosed(ce.done) {
+		ce.relaySessionsMx.Unlock()
+		_ = ss.Close() //nolint:errcheck
+		return errors.New("client closed")
+	}
+	old, hadOld := ce.relaySessions[pk]
+	ce.relaySessions[pk] = ss.SessionCommon
+	ce.relaySessionsMx.Unlock()
+	if hadOld && old != ss.SessionCommon {
+		_ = old.Close() //nolint:errcheck
+	}
+
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = ss.Close() //nolint:errcheck
+		case <-ce.done:
+			_ = ss.Close() //nolint:errcheck
+		case <-done:
+		}
+	}()
+
+	log.Info("Started relay session.")
+	ss.Serve()
+	close(done)
+	log.Info("Stopped relay session.")
+
+	// Identity-checked: a fresh session for the same peer may already have
+	// replaced this one.
+	ce.relaySessionsMx.Lock()
+	if ce.relaySessions[pk] == ss.SessionCommon {
+		delete(ce.relaySessions, pk)
+	}
+	ce.relaySessionsMx.Unlock()
+	return nil
+}
+
+// RelaySessions lists the peers currently attached to this client as a relay.
+func (ce *Client) RelaySessions() []cipher.PubKey {
+	ce.relaySessionsMx.Lock()
+	defer ce.relaySessionsMx.Unlock()
+	out := make([]cipher.PubKey, 0, len(ce.relaySessions))
+	for pk := range ce.relaySessions {
+		out = append(out, pk)
+	}
+	return out
+}
+
+// RelayedStreams reports how many relayed streams this client is carrying.
+func (ce *Client) RelayedStreams() int {
+	return int(atomic.LoadInt64(&ce.relayedStreams))
+}
+
+func (ce *Client) relaySession(pk cipher.PubKey) (*SessionCommon, bool) {
+	ce.relaySessionsMx.Lock()
+	defer ce.relaySessionsMx.Unlock()
+	ses, ok := ce.relaySessions[pk]
+	return ses, ok
+}
+
+func (ce *Client) closeRelaySessions() {
+	ce.relaySessionsMx.Lock()
+	sessions := ce.relaySessions
+	ce.relaySessions = make(map[cipher.PubKey]*SessionCommon)
+	ce.relaySessionsMx.Unlock()
+	for _, ses := range sessions {
+		_ = ses.Close() //nolint:errcheck
+	}
+}
+
+// relayForwardSessions orders this client's server sessions for forwarding a
+// relayed request to dst: sessions to dst's delegated servers first (by
+// latency), then every other session (by latency) — the same order DialStream
+// uses for its own dials. Sessions that are themselves relay attachments
+// (skynet carrier) are skipped: a relay does not chain through a relay.
+func (ce *Client) relayForwardSessions(dst cipher.PubKey) []*SessionCommon {
+	var delegated []cipher.PubKey
+	ctx, cancel := context.WithTimeout(context.Background(), relayEntryLookupTimeout)
+	defer cancel()
+	if entry, err := ce.getClientEntryCached(ctx, dst); err == nil && entry != nil && entry.Client != nil {
+		delegated = entry.Client.DelegatedServers
+	}
+	ordered := append(ce.sortedDelegatedSessions(delegated), ce.sortedMeshSessions(delegated)...)
+	out := make([]*SessionCommon, 0, len(ordered))
+	for _, s := range ordered {
+		if s.carrier == CarrierSkynet {
+			continue
+		}
+		out = append(out, s.SessionCommon)
+	}
+	return out
+}

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -294,6 +294,9 @@ func (ce *Client) ConvergeCarriers() int {
 
 	converged := 0
 	for _, s := range sessions {
+		if s.carrier == CarrierSkynet {
+			continue // a relay has one carrier and no discovery entry to converge on
+		}
 		if ce.carrierBackedOff(s.pk) {
 			continue
 		}
@@ -392,6 +395,11 @@ func (ce *Client) carrierNote(pk cipher.PubKey) string {
 }
 
 func pickCarrier(carriers []string, entry *disc.Entry) (network, addr string) {
+	// A relay reached over a skywire route advertises only a skynet address; it
+	// is dialable by exactly that carrier, whatever the preference list says.
+	if strings.HasPrefix(entry.Server.Address, SkynetScheme) {
+		return CarrierSkynet, entry.Server.Address
+	}
 	for _, c := range carriers {
 		switch c {
 		case CarrierWT:
@@ -446,6 +454,8 @@ func ProtocolLabel(carrier, addr string) string {
 		return "webtransport"
 	case CarrierQUIC:
 		return "quic"
+	case CarrierSkynet:
+		return "skynet"
 	case "":
 		return "accepted"
 	default:
@@ -596,6 +606,25 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 			}
 			ce.log.Infof("yamux stream session initial for %s", dSes.RemotePK().String())
 		}
+	}
+	if network == CarrierSkynet {
+		dialer := ce.sessionDialer()
+		if dialer == nil {
+			return ClientSession{}, fmt.Errorf("dmsg: server %s is reachable only over %s and this client has no session dialer", entry.Static, dialAddr)
+		}
+		conn, err := dialer(ctx, network, dialAddr)
+		if err != nil {
+			return ClientSession{}, fmt.Errorf("failed to dial %s: %w", dialAddr, err)
+		}
+		if dSes, err = makeClientSession(&ce.EntityCommon, ce.porter, conn, entry.Static); err != nil {
+			conn.Close() //nolint:errcheck,gosec
+			return ClientSession{}, err
+		}
+		if dSes.sm.yamux, err = yamux.Client(conn, YamuxConfig()); err != nil {
+			conn.Close() //nolint:errcheck,gosec
+			return ClientSession{}, err
+		}
+		ce.log.Infof("skynet stream session initial for %s", dSes.RemotePK().String())
 	}
 
 	return ce.finishDialedSession(ctx, dSes, network, dialAddr, entry)

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -148,6 +148,17 @@ type EntityCommon struct {
 	// Only set on Server entities; nil for clients.
 	peerSessionsFunc func() []*SessionCommon
 
+	// forwardSessionsFunc is the CLIENT counterpart of peerSessionsFunc: a
+	// client acting as a dmsg relay (Client.AcceptRelaySession) forwards a
+	// request it cannot serve locally over its own server sessions, ordered
+	// for the destination. nil on servers and on clients not relaying.
+	forwardSessionsFunc func(dst cipher.PubKey) []*SessionCommon
+
+	// relaySessionLookup finds a server-role session this client accepted
+	// through AcceptRelaySession, so a destination that is itself attached to
+	// this relay is bridged locally instead of forwarded. nil on servers.
+	relaySessionLookup func(pk cipher.PubKey) (*SessionCommon, bool)
+
 	// acceptPeerAnnouncements, peerAnnounceAllowedFunc and
 	// promoteToPeerFunc support inbound peer announcements: a server
 	// announcing itself as a forwardable peer over the link it dials out.
@@ -371,7 +382,28 @@ func (c *EntityCommon) session(pk cipher.PubKey) (*SessionCommon, bool) {
 // serverSession obtains a session as a server.
 func (c *EntityCommon) serverSession(pk cipher.PubKey) (ServerSession, bool) {
 	ses, ok := c.session(pk)
+	if !ok && c.relaySessionLookup != nil {
+		ses, ok = c.relaySessionLookup(pk)
+	}
 	return ServerSession{SessionCommon: ses}, ok
+}
+
+// forwardSessions returns the sessions a request for dst may be forwarded
+// over when dst is not attached locally: a server's peer servers, or a
+// relaying client's own server sessions (ordered for dst). nil = no forwarding.
+func (c *EntityCommon) forwardSessions(dst cipher.PubKey) []ServerSession {
+	if c.peerSessionsFunc != nil {
+		return c.peerServerSessions()
+	}
+	if c.forwardSessionsFunc == nil {
+		return nil
+	}
+	raw := c.forwardSessionsFunc(dst)
+	sessions := make([]ServerSession, len(raw))
+	for i, ses := range raw {
+		sessions[i] = ServerSession{SessionCommon: ses}
+	}
+	return sessions
 }
 
 // peerServerSessions returns all peer server sessions for mesh forwarding.
@@ -805,6 +837,11 @@ func (c *EntityCommon) initilizeClientEntry(ctx context.Context, clientType stri
 	c.sessionsMx.Lock()
 	srvPKs := make([]cipher.PubKey, 0, len(c.sessions))
 	for pk := range c.sessions {
+		// A relay reached over skynet is not a discovery-registered server:
+		// nobody can resolve it, so advertising it as delegated only misleads.
+		if c.sessions[pk].carrier == CarrierSkynet {
+			continue
+		}
 		srvPKs = append(srvPKs, pk)
 	}
 	c.sessionsMx.Unlock()
@@ -913,6 +950,11 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 	c.sessionsMx.Lock()
 	srvPKs := make([]cipher.PubKey, 0, len(c.sessions))
 	for pk := range c.sessions {
+		// A relay reached over skynet is not a discovery-registered server:
+		// nobody can resolve it, so advertising it as delegated only misleads.
+		if c.sessions[pk].carrier == CarrierSkynet {
+			continue
+		}
 		srvPKs = append(srvPKs, pk)
 	}
 	c.sessionsMx.Unlock()

--- a/pkg/dmsg/dmsg/relayed_request_test.go
+++ b/pkg/dmsg/dmsg/relayed_request_test.go
@@ -20,15 +20,15 @@ import (
 // dst, which listens on dstPort. src is a bare keypair that holds no session at
 // all — the identity a served desk tab or a service would have in stage 3.
 type relayedTestEnv struct {
-	srv           *Server
-	srvPK         cipher.PubKey
-	relay         *Client
-	dst           *Client
-	dstPK         cipher.PubKey
-	srcPK         cipher.PubKey
-	srcSK         cipher.SecKey
-	dstLis        *Listener
-	acceptedFirst chan *Stream
+	dc     disc.APIClient
+	srv    *Server
+	srvPK  cipher.PubKey
+	relay  *Client
+	dst    *Client
+	dstPK  cipher.PubKey
+	srcPK  cipher.PubKey
+	srcSK  cipher.SecKey
+	dstLis *Listener
 }
 
 const relayedDstPort = 80
@@ -69,6 +69,7 @@ func newRelayedTestEnv(t *testing.T, conf *ServerConfig) *relayedTestEnv {
 
 	srcPK, srcSK := GenKeyPair(t, "relayed-src")
 	return &relayedTestEnv{
+		dc:  dc,
 		srv: srv, srvPK: srvPK, relay: relay, dst: dst, dstPK: dstPK,
 		srcPK: srcPK, srcSK: srcSK, dstLis: dstLis,
 	}

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -96,6 +96,7 @@ func (ss *ServerSession) Serve() {
 					}
 				}()
 				err := ss.serveStream(log, sStr, ss.sm.addr)
+				ss.closeRefused(sStr, err)
 				log.WithError(err).Debug("Stopped stream.")
 			}(sStr)
 		}
@@ -125,6 +126,7 @@ func (ss *ServerSession) Serve() {
 					}
 				}()
 				err := ss.serveStream(log, qStr, ss.sm.addr)
+				ss.closeRefused(qStr, err)
 				log.WithError(err).Debug("Stopped stream.")
 			}(qStr)
 		}
@@ -163,10 +165,25 @@ func (ss *ServerSession) Serve() {
 					}
 				}()
 				err := ss.serveStream(log, yStr, ss.sm.addr)
+				ss.closeRefused(yStr, err)
 				log.WithError(err).Debug("Stopped stream.")
 			}(yStr)
 		}
 	}
+}
+
+// closeRefused closes a stream whose request serveStream did not serve. A
+// refusal (bad signature, no listener, relay slots exhausted, no next
+// session) carries no response the dialer could verify — a StreamResponse is
+// signed by the destination, which never saw the request — so the only signal
+// is EOF. Without the close the dialer sat out the full HandshakeTimeout on a
+// stream nobody would ever write to. Closing after a served bridge is a no-op:
+// CopyReadWriteCloser has already closed both sides.
+func (ss *ServerSession) closeRefused(str io.Closer, err error) {
+	if err == nil {
+		return
+	}
+	_ = str.Close() //nolint:errcheck,gosec
 }
 
 // struct
@@ -334,7 +351,7 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 	// this server carrying traffic for someone that is not its own client.
 	// Bound the concurrent count so an always-open relay can't be amplified. A
 	// plain local client↔client bridge is normal operation and is never gated.
-	if ss.isPeer || dst.isPeer || req.SrcAddr.PK != ss.rPK {
+	if ss.isPeer || dst.isPeer || ss.relayInbound || req.SrcAddr.PK != ss.rPK {
 		if !ss.entity.tryAcquireRelaySlot() {
 			ss.m.RecordStream(metrics.DeltaFailed)
 			return ErrRelayCapacityReached
@@ -429,7 +446,7 @@ func (c *idleTimeoutConn) SetWriteDeadline(t time.Time) error {
 // forwardViaPeer tries to forward a stream request through peer server sessions.
 // This is only called for client-originated requests (not peer-originated, enforcing 1-hop max).
 func (ss *ServerSession) forwardViaPeer(log logrus.FieldLogger, yStr io.ReadWriteCloser, req StreamRequest) error {
-	peers := ss.entity.peerServerSessions()
+	peers := ss.entity.forwardSessions(req.DstAddr.PK)
 	if len(peers) == 0 {
 		ss.m.RecordStream(metrics.DeltaFailed)
 		return ErrReqNoNextSession

--- a/pkg/dmsg/dmsg/session_common.go
+++ b/pkg/dmsg/dmsg/session_common.go
@@ -47,6 +47,12 @@ type SessionCommon struct {
 	// server that can't do WT just re-dials wss on the next tick (churn).
 	wtCapable bool
 
+	// relayInbound marks a server-role session a CLIENT accepted through
+	// Client.AcceptRelaySession: the attached peer's requests are relayed over
+	// this client's own server sessions, so every bridge from it is charged to
+	// the relay slots (see bridgeStream). Never set on server entities.
+	relayInbound bool
+
 	netConn net.Conn // underlying net.Conn (TCP connection to the dmsg server)
 	// ys      *yamux.Session
 	// ss      *smux.Session

--- a/pkg/dmsg/dmsg/skynet_relay_test.go
+++ b/pkg/dmsg/dmsg/skynet_relay_test.go
@@ -1,0 +1,237 @@
+package dmsg
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// skynetDialer stands in for the visor's skywire route: each dial hands the
+// far end of a net.Pipe to relay.AcceptRelaySession, exactly as the visor's
+// relay listener does with an accepted skynet conn.
+func skynetDialer(t *testing.T, relay *Client, relayPK cipher.PubKey, allow func(cipher.PubKey) bool, dials *atomic.Int32) SessionDialer {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		require.Equal(t, CarrierSkynet, network)
+		require.Equal(t, SkynetAddr(relayPK, 70), addr)
+		dials.Add(1)
+		c1, c2 := net.Pipe()
+		// The relay session outlives the dial that opened it, as the visor's does.
+		go func() { _ = relay.AcceptRelaySession(context.WithoutCancel(ctx), c2, allow) }() //nolint:errcheck
+		return c1, nil
+	}
+}
+
+// entryOnlyDisc resolves entries by key but lists no servers, so the client's
+// serve loop can only ever reach the relay it was seeded with — while its
+// DialStream fallback can still resolve a destination's delegated server.
+type entryOnlyDisc struct{ disc.APIClient }
+
+func (entryOnlyDisc) AvailableServers(context.Context) ([]*disc.Entry, error) { return nil, nil }
+func (entryOnlyDisc) AllServers(context.Context) ([]*disc.Entry, error)       { return nil, nil }
+
+// newSkynetDialer makes a client that knows dst's entry but NO dmsg server:
+// its only seeded "server" is the relay, at a skynet address.
+func newSkynetDialer(t *testing.T, env *relayedTestEnv, name string, extra ...*disc.Entry) (*Client, cipher.PubKey) {
+	t.Helper()
+	dc := disc.NewMock(0)
+	var dialerDisc disc.APIClient = entryOnlyDisc{dc}
+	dstEntry, err := env.dc.Entry(context.Background(), env.dstPK)
+	require.NoError(t, err)
+	require.NoError(t, dc.PostEntry(context.Background(), dstEntry))
+	for _, e := range extra {
+		require.NoError(t, dc.PostEntry(context.Background(), e))
+	}
+	relayPK := env.relay.LocalPK()
+	pk, sk := GenKeyPair(t, name)
+	c := NewClient(pk, sk, dialerDisc, &Config{MinSessions: 1, NoRegister: true})
+	c.SetLogger(logging.MustGetLogger(name))
+	c.SeedEntryCache(relayPK, &disc.Entry{
+		Static: relayPK,
+		Server: &disc.Server{Address: SkynetAddr(relayPK, 70), AvailableSessions: 1},
+	})
+	go c.Serve(context.Background())
+	t.Cleanup(func() { _ = c.Close() }) //nolint:errcheck
+	return c, pk
+}
+
+func acceptOne(t *testing.T, lis *Listener) <-chan *Stream {
+	t.Helper()
+	ch := make(chan *Stream, 1)
+	go func() {
+		s, err := lis.AcceptStream()
+		if err != nil {
+			ch <- nil
+			return
+		}
+		ch <- s
+	}()
+	return ch
+}
+
+func echoCheck(t *testing.T, a, b net.Conn) {
+	t.Helper()
+	_, err := a.Write([]byte("over the relay"))
+	require.NoError(t, err)
+	buf := make([]byte, 14)
+	require.NoError(t, b.SetReadDeadline(time.Now().Add(5*time.Second)))
+	_, err = b.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, "over the relay", string(buf))
+}
+
+// A client seeded only with a relay at a skynet address forms exactly one
+// session — carrier "skynet" — and reaches a destination through the relay's
+// own server session under its OWN key, without ever touching a dmsg server.
+func TestSkynetRelay_DialerReachesDestinationUnderOwnKey(t *testing.T) {
+	env := newRelayedTestEnv(t, nil)
+	env.relay.maxRelayedStreams = 8
+	relayPK := env.relay.LocalPK()
+
+	var dials atomic.Int32
+	var dialerPK cipher.PubKey
+	allow := func(pk cipher.PubKey) bool { return pk == dialerPK }
+	c, pk := newSkynetDialer(t, env, "skynet-dialer")
+	dialerPK = pk
+	c.SetSessionDialer(skynetDialer(t, env.relay, relayPK, allow, &dials))
+
+	require.Eventually(t, func() bool { _, ok := c.Session(relayPK); return ok }, 15*time.Second, 50*time.Millisecond)
+	carriers := c.SessionCarriers()
+	require.Len(t, carriers, 1)
+	require.Equal(t, CarrierSkynet, carriers[0].Carrier)
+	require.Equal(t, "skynet", ProtocolLabel(carriers[0].Carrier, carriers[0].Addr))
+	require.Eventually(t, func() bool { return len(env.relay.RelaySessions()) == 1 }, 5*time.Second, 50*time.Millisecond)
+	require.Equal(t, pk, env.relay.RelaySessions()[0])
+
+	accepted := acceptOne(t, env.dstLis)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	str, err := c.DialStream(ctx, Addr{PK: env.dstPK, Port: relayedDstPort})
+	require.NoError(t, err)
+	defer str.Close() //nolint:errcheck
+
+	var s *Stream
+	select {
+	case s = <-accepted:
+		require.NotNil(t, s)
+	case <-time.After(10 * time.Second):
+		t.Fatal("dst never accepted the relayed stream")
+	}
+	defer s.Close() //nolint:errcheck
+	require.Equal(t, pk, s.RawRemoteAddr().PK, "the destination must see the dialer's key")
+	echoCheck(t, str, s)
+	echoCheck(t, s, str)
+
+	require.Len(t, c.AllSessions(), 1, "the dialer must hold no session but the relay")
+	_, onServer := env.srv.session(pk)
+	require.False(t, onServer, "the dialer must never appear on the dmsg server")
+	require.Equal(t, 1, env.relay.RelayedStreams())
+	require.Equal(t, int32(1), dials.Load())
+}
+
+// Two peers attached to the same relay reach each other through it, bridged
+// locally without any server involved.
+func TestSkynetRelay_AttachedPeersBridgeLocally(t *testing.T) {
+	env := newRelayedTestEnv(t, nil)
+	env.relay.maxRelayedStreams = 8
+	relayPK := env.relay.LocalPK()
+	var dials atomic.Int32
+
+	a, aPK := newSkynetDialer(t, env, "skynet-a")
+	a.SetSessionDialer(skynetDialer(t, env.relay, relayPK, nil, &dials))
+	b, bPK := newSkynetDialer(t, env, "skynet-b")
+	b.SetSessionDialer(skynetDialer(t, env.relay, relayPK, nil, &dials))
+	require.Eventually(t, func() bool { return len(env.relay.RelaySessions()) == 2 }, 15*time.Second, 50*time.Millisecond)
+
+	bLis, err := b.Listen(81)
+	require.NoError(t, err)
+	defer bLis.Close() //nolint:errcheck
+	accepted := acceptOne(t, bLis)
+
+	// a has no entry for b anywhere; seed one whose delegated servers are
+	// irrelevant — the relay resolves b as an attached peer before forwarding.
+	a.SeedEntryCache(bPK, disc.NewClientEntry(bPK, 0, []cipher.PubKey{relayPK}))
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	str, err := a.DialStream(ctx, Addr{PK: bPK, Port: 81})
+	require.NoError(t, err)
+	defer str.Close() //nolint:errcheck
+	s := <-accepted
+	require.NotNil(t, s)
+	defer s.Close() //nolint:errcheck
+	require.Equal(t, aPK, s.RawRemoteAddr().PK)
+	echoCheck(t, str, s)
+}
+
+// A relay that refuses to carry a stream (no relay slots) closes it at once,
+// and the dialer falls back to a normal session with a dmsg server it CAN
+// resolve — well inside the handshake timeout it used to sit out.
+func TestSkynetRelay_RefusedFallsBackToServerSession(t *testing.T) {
+	env := newRelayedTestEnv(t, nil)
+	require.Equal(t, 0, env.relay.maxRelayedStreams, "an unconfigured client must not relay")
+	relayPK := env.relay.LocalPK()
+	var dials atomic.Int32
+
+	srvEntry, err := env.dc.Entry(context.Background(), env.srvPK)
+	require.NoError(t, err)
+	c, pk := newSkynetDialer(t, env, "skynet-fallback", srvEntry)
+	c.SetSessionDialer(skynetDialer(t, env.relay, relayPK, nil, &dials))
+	require.Eventually(t, func() bool { _, ok := c.Session(relayPK); return ok }, 15*time.Second, 50*time.Millisecond)
+
+	accepted := acceptOne(t, env.dstLis)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	start := time.Now()
+	str, err := c.DialStream(ctx, Addr{PK: env.dstPK, Port: relayedDstPort})
+	require.NoError(t, err)
+	defer str.Close() //nolint:errcheck
+	require.Less(t, time.Since(start), HandshakeTimeout, "a refused relay must fail fast, not time out")
+	s := <-accepted
+	require.NotNil(t, s)
+	defer s.Close() //nolint:errcheck
+	require.Equal(t, pk, s.RawRemoteAddr().PK)
+	_, direct := c.Session(env.srvPK)
+	require.True(t, direct, "the fallback is a normal session to the destination's server")
+	echoCheck(t, str, s)
+}
+
+// The relay's allow callback is the admission control: a refused peer gets no
+// session, and the dialer keeps failing rather than reaching anything.
+func TestSkynetRelay_UnlistedPeerRefused(t *testing.T) {
+	env := newRelayedTestEnv(t, nil)
+	env.relay.maxRelayedStreams = 8
+	relayPK := env.relay.LocalPK()
+	var dials atomic.Int32
+
+	c, _ := newSkynetDialer(t, env, "skynet-unlisted")
+	c.SetSessionDialer(skynetDialer(t, env.relay, relayPK, func(cipher.PubKey) bool { return false }, &dials))
+	require.Eventually(t, func() bool { return dials.Load() >= 1 }, 15*time.Second, 50*time.Millisecond)
+	// The dialer completes its half of the handshake before the relay refuses,
+	// so its session may exist for an instant; it must not survive.
+	require.Eventually(t, func() bool {
+		_, ok := c.Session(relayPK)
+		return !ok && len(env.relay.RelaySessions()) == 0
+	}, 5*time.Second, 50*time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
+	_, ok := c.Session(relayPK)
+	require.False(t, ok)
+}
+
+func TestSkynetAddrRoundTrip(t *testing.T) {
+	pk, _ := GenKeyPair(t, "skynet-addr")
+	addr := SkynetAddr(pk, 70)
+	gotPK, port, err := ParseSkynetAddr(addr)
+	require.NoError(t, err)
+	require.Equal(t, pk, gotPK)
+	require.Equal(t, uint16(70), port)
+	_, _, err = ParseSkynetAddr("127.0.0.1:8080")
+	require.Error(t, err)
+	require.Equal(t, CarrierSkynet, func() string { n, _ := pickCarrier(nil, &disc.Entry{Server: &disc.Server{Address: addr}}); return n }())
+}

--- a/pkg/dmsg/dmsgc/dmsgc.go
+++ b/pkg/dmsg/dmsgc/dmsgc.go
@@ -101,6 +101,9 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 		// the client must skip its own server entry in the serve loop rather
 		// than dial a transit session to itself.
 		SkipSelfServer: conf.Server != nil && conf.Server.Enabled,
+		// The visor runs a dmsg relay acceptor on skyenv.DmsgRelayPort (see
+		// initDmsgRelay): streams it carries for attached peers are bounded here.
+		MaxRelayedStreams: dmsg.DefaultClientMaxRelayedStreams,
 	}
 	dmsgConf.ClientType = "visor"
 

--- a/pkg/skyenv/ports_test.go
+++ b/pkg/skyenv/ports_test.go
@@ -44,6 +44,7 @@ func TestVisorPortsAreUnique(t *testing.T) {
 		"DmsgVisorSDRegCXOPort":           DmsgVisorSDRegCXOPort,
 		"DmsgVisorTPListCXOPort":          DmsgVisorTPListCXOPort,
 		"DmsgTransportQueryPort":          DmsgTransportQueryPort,
+		"DmsgRelayPort":                   DmsgRelayPort,
 		"DmsgWebRTCSignalPort":            DmsgWebRTCSignalPort,
 		"SkychatVoiceSignalPort":          SkychatVoiceSignalPort,
 		"SkychatVoiceMediaPort":           SkychatVoiceMediaPort,

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -192,6 +192,17 @@ const (
 	// is set (default OFF), so it adds no listener on the default configuration.
 	DmsgTransportQueryPort uint16 = 68
 
+	// DmsgRelayPort is the dmsg port a visor's dmsg RELAY listens on over
+	// skynet (pkg/dmsg/dmsg/client_relay.go, #4484 stage 3). A peer with a
+	// skywire route to this visor — a served desk tab, a visor behind a network
+	// that cannot reach any dmsg server — dials skynet://<this pk>:70 as its
+	// dmsg "server": the visor answers with a server-role dmsg session on its
+	// own dmsg client and carries the peer's stream requests over its own
+	// server sessions, under the peer's key. Gated by the peer whitelist.
+	// Numbered 70 (69 is DmsgVisorTPListCXOPort, 71 DmsgVisorARBindCXOPort);
+	// the value only needs to be collision-free, which ports_test guards.
+	DmsgRelayPort uint16 = 70
+
 	// DmsgWebRTCSignalPort is the dmsg port the WebRTC carrier exchanges its SDP
 	// offer/answer + ICE candidates on (a visor dials a peer here to open a
 	// signaling stream; the answerer listens). It MUST live in this registry: it

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -228,6 +228,9 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 		entryResolve = v.newDmsgEntryCXOResolver()
 	}
 	dmsgC := dmsgc.New(v.conf.PK, v.conf.SK, v.ebc, &dmsgConf, httpC, v.dClient, directOnly, entryResolve, v.MasterLogger())
+	// skynet carrier: seeded "skynet://<pk>:70" server entries are dialed as a
+	// skywire route to that visor's dmsg relay (init_dmsg_relay.go).
+	dmsgC.SetSessionDialer(skynetSessionDialer)
 	httpC.Transport = dmsghttp.MakeHTTPTransport(ctx, dmsgC)
 
 	wg := new(sync.WaitGroup)
@@ -272,6 +275,8 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 	v.dmsgDC = dmsgC // single client: dmsgDC consumers (router, resolver, vpn) ride dmsgC
 	v.dmsgHTTP = httpC
 	v.initLock.Unlock()
+	// The other half of the skynet carrier: serve attached peers as a dmsg relay.
+	v.initDmsgRelay(ctx, dmsgC)
 	select {
 	case <-v.dmsgHTTPReady:
 	default:

--- a/pkg/visor/init_dmsg_relay.go
+++ b/pkg/visor/init_dmsg_relay.go
@@ -1,0 +1,103 @@
+// Package visor pkg/visor/init_dmsg_relay.go c3-vis-core
+//
+// dmsg over skynet through this visor (#4484 stage 3). Two halves of one
+// mechanism, both on the visor's single dmsg client:
+//
+//   - RELAY (accept side): a listener on skyenv.DmsgRelayPort over skynet. A
+//     whitelisted peer that dials it gets a server-role dmsg session on this
+//     client (dmsg.Client.AcceptRelaySession); its stream requests are carried
+//     over this visor's own dmsg server sessions under the PEER's key.
+//   - CARRIER (dial side): the client's session dialer for skynet:// server
+//     addresses. A seeded server entry "skynet://<pk>:70" is dialed as a
+//     skywire route to that visor's relay, then wrapped in the usual
+//     Noise+yamux dmsg session.
+//
+// Neither half registers anything in discovery or opens a TCP listener.
+package visor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// skynetSessionDialer is the dmsg client's SessionDialer for the skynet
+// carrier: it turns "skynet://<pk>:<port>" into a skywire route dial to that
+// visor's relay listener. Bounded by dmsg.DialTimeout like the TCP carrier.
+func skynetSessionDialer(ctx context.Context, network, addr string) (net.Conn, error) {
+	if network != dmsg.CarrierSkynet {
+		return nil, fmt.Errorf("dmsg session dialer: unsupported carrier %q", network)
+	}
+	pk, port, err := dmsg.ParseSkynetAddr(addr)
+	if err != nil {
+		return nil, err
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, dmsg.DialTimeout)
+	defer cancel()
+	return appnet.DialContext(dialCtx, appnet.Addr{
+		Net:    appnet.TypeSkynet,
+		PubKey: pk,
+		Port:   routing.Port(port),
+	})
+}
+
+// initDmsgRelay binds the relay listener on skyenv.DmsgRelayPort over skynet
+// (once the router's networker exists) and serves every accepted conn as a
+// relay session on dmsgC. Admission is the peer whitelist — self, configured
+// hypervisors, the pty whitelist and anything a hypervisor vouched for — and
+// the key the peer proves in the dmsg Noise handshake must be the key the
+// route was set up for.
+func (v *Visor) initDmsgRelay(ctx context.Context, dmsgC *dmsg.Client) {
+	log := v.MasterLogger().PackageLogger("dmsg_relay")
+	goServeSkynetMirror(ctx, v.conf.PK, skyenv.DmsgRelayPort, "dmsg_relay", log,
+		func(lis net.Listener) {
+			go func() {
+				<-ctx.Done()
+				_ = lis.Close() //nolint:errcheck
+			}()
+			for {
+				conn, err := lis.Accept()
+				if err != nil {
+					if ctx.Err() == nil && !errors.Is(err, net.ErrClosed) {
+						log.WithError(err).Warn("dmsg relay accept failed; relay listener stopped")
+					}
+					return
+				}
+				routePK, hasRoutePK := remotePK(conn.RemoteAddr())
+				if hasRoutePK && !v.relayPeerAllowed(routePK) {
+					// Refuse before the handshake: the route already names the
+					// peer, so an unlisted one costs no crypto.
+					log.WithField("peer", routePK.String()).Debug("dmsg relay: peer not whitelisted")
+					_ = conn.Close() //nolint:errcheck
+					continue
+				}
+				go func(conn net.Conn) {
+					allow := func(pk cipher.PubKey) bool {
+						if hasRoutePK && pk != routePK {
+							return false
+						}
+						return v.relayPeerAllowed(pk)
+					}
+					if err := dmsgC.AcceptRelaySession(ctx, conn, allow); err != nil {
+						log.WithError(err).Debug("dmsg relay session ended with error")
+					}
+				}(conn)
+			}
+		})
+}
+
+// relayPeerAllowed reports whether pk may attach to this visor's dmsg relay.
+func (v *Visor) relayPeerAllowed(pk cipher.PubKey) bool {
+	if v.peerWhitelist == nil {
+		return false
+	}
+	ok, err := v.peerWhitelist.Get(pk)
+	return err == nil && ok
+}


### PR DESCRIPTION
Stage 3 (b) and (c) of #4484; (a) landed in #4703.

**Carrier.** A dmsg client seeded with a server entry whose address is `skynet://<pk>:70` dials it through a new session-dial hook (`Config.SessionDialer`), which the visor fills with an appnet skynet dial. The conn is wrapped in the usual Noise+yamux session; nothing above the session changes. No discovery, no registration, and the relay is excluded from the delegated servers the client publishes.

**Relay.** Every visor serves a relay acceptor on dmsg port 70 over skynet, gated by the peer whitelist. It answers with a server-role session on its own dmsg client and carries each stream request over one of its own server sessions using the existing forward/bridge path, ordered by the destination's delegated servers and bounded by relay slots (256). Peers attached to the same relay are bridged locally. With #4703 the server accepts the forwarded request under the dialer's key, so the destination sees the dialer.

**Fallback.** A refused stream request is closed immediately (a rejection carries no response the dialer can verify), so the dialer moves to its next dial phase, a normal server session, instead of waiting out the handshake timeout.

Tests: relay-only dialer reaches a destination under its own key with exactly one session (carrier `skynet`) and never appears on the server; attached peers bridge locally; a relay with no slots falls back to a server session inside the handshake timeout; an unlisted peer is refused. Race-clean.

Local checks: targeted dmsg/dmsgc/skyenv tests, vet, golangci-lint, `go build .`, js/wasm build of cmd/wasm-visor. The two-native-visor proof follows on the dev host once this is deployed.
