### PR TITLE
fix(visor): proxy auto-exit loop must not re-point an operator-started client

### DIFF
--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -219,6 +219,7 @@ func (v *Visor) autoStartProxyClient(log *logging.Logger, pinned bool) {
 		// The launcher autostarted the configured exit; give it a beat, then
 		// hold it to the same end-to-end bar. A live pin wins and we're done;
 		// a dead one is stopped and the discovery rotation below takes over.
+		want := v.GetSkysocksClientAddress()
 		select {
 		case <-ctx.Done():
 			return
@@ -232,6 +233,9 @@ func (v *Visor) autoStartProxyClient(log *logging.Logger, pinned bool) {
 			log.Warn("configured proxy exit stopped relaying; rotating to discovery")
 		} else {
 			log.Warn("configured proxy exit failed end-to-end verification; rotating to discovery")
+		}
+		if v.proxyClientTakenOver(log, want, true) {
+			return
 		}
 		_ = v.StopSkysocksClients() //nolint:errcheck
 	}
@@ -259,6 +263,11 @@ func (v *Visor) autoStartProxyClient(log *logging.Logger, pinned bool) {
 			default:
 			}
 			pk := svcs[i].Addr.PubKey().String()
+			// The loop last left the client STOPPED; a client running now was
+			// started by the operator in the meantime, and is theirs.
+			if v.proxyClientTakenOver(log, "", false) {
+				return
+			}
 			if err := v.StartSkysocksClient(pk); err != nil {
 				log.WithError(err).Debug("proxy-client auto-exit candidate failed to start; trying another")
 				continue
@@ -272,9 +281,49 @@ func (v *Visor) autoStartProxyClient(log *logging.Logger, pinned bool) {
 			} else {
 				log.WithField("exit", pk).Warn("proxy-client exit failed end-to-end verification; rotating")
 			}
+			if v.proxyClientTakenOver(log, pk, true) {
+				return
+			}
 			_ = v.StopSkysocksClients() //nolint:errcheck
 		}
 	}
+}
+
+// proxyClientTakenOver reports whether the operator has taken skysocks-client
+// over from the auto-exit loop, and says so once. The loop owns the client only
+// while it is the last thing to have touched it: want is the exit the loop set
+// ("" when it has set none yet) and expectRunning is whether the loop believes
+// the client is up. An operator's hand — `cli proxy start <pk>`, the
+// hypervisor's proxy page, `visor app set-pk` — shows as either the configured
+// --srv no longer being the loop's pick, or the client running when the loop
+// last stopped it. In both cases the explicit choice wins and the loop stands
+// down: it must never stop or re-point a client it did not start. Without this
+// the loop verified the operator's session as if it were its own candidate and,
+// on a failed probe, "rotated" it onto a random discovery exit — an operator's
+// `proxy start <pk>` lost its exit 30-90s in, every time.
+func (v *Visor) proxyClientTakenOver(log *logging.Logger, want string, expectRunning bool) bool {
+	configured := v.GetSkysocksClientAddress()
+	running := false
+	if v.procM != nil {
+		_, running = v.procM.ProcByName(skyenv.SkysocksClientName)
+	}
+	if !proxyExitTakenOver(configured, want, running, expectRunning) {
+		return false
+	}
+	log.WithField("configured_exit", configured).WithField("loop_exit", want).
+		Info("proxy client re-pointed by the operator; auto-exit rotation stands down")
+	return true
+}
+
+// proxyExitTakenOver is the decision behind proxyClientTakenOver, kept pure so
+// it is unit-tested directly: configured is the client's current --srv, want
+// the exit the loop set ("" = none yet), running whether a skysocks-client proc
+// is live and expectRunning whether the loop believes it left one running.
+func proxyExitTakenOver(configured, want string, running, expectRunning bool) bool {
+	if want != "" && configured != "" && configured != want {
+		return true
+	}
+	return running && !expectRunning
 }
 
 // proxyExitRecheckInterval is how often an already-VERIFIED exit is re-probed.

--- a/pkg/visor/init_apps_proxy_verify_test.go
+++ b/pkg/visor/init_apps_proxy_verify_test.go
@@ -150,3 +150,36 @@ func (l *pipeListener) Close() error {
 }
 
 func (l *pipeListener) Addr() net.Addr { return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)} }
+
+// TestProxyExitTakenOver covers the decision that stops the auto-exit loop from
+// stopping or re-pointing a skysocks-client the operator started. The observed
+// failure was `cli proxy start <pk>` losing its exit to a random discovery pick
+// because the loop treated the operator's session as its own failed candidate.
+func TestProxyExitTakenOver(t *testing.T) {
+	const loopPK = "02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36"
+	const operatorPK = "038af6b913d13eb726d8d1e195968af0cb894f2a0316fe98a031135e3c102da165"
+	cases := []struct {
+		name          string
+		configured    string
+		want          string
+		running       bool
+		expectRunning bool
+		takenOver     bool
+	}{
+		{"loop's own exit still configured", loopPK, loopPK, true, true, false},
+		{"operator re-pointed the client", operatorPK, loopPK, true, true, true},
+		{"operator re-pointed it and it already died", operatorPK, loopPK, false, true, true},
+		{"operator started a client the loop had stopped", operatorPK, "", true, false, true},
+		{"nothing running where the loop expects nothing", operatorPK, "", false, false, false},
+		{"pinned exit unchanged and down", loopPK, loopPK, false, true, false},
+		{"srv cleared entirely is not a takeover", "", loopPK, false, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := proxyExitTakenOver(tc.configured, tc.want, tc.running, tc.expectRunning); got != tc.takenOver {
+				t.Fatalf("proxyExitTakenOver(%q, %q, running=%v, expectRunning=%v) = %v, want %v",
+					tc.configured, tc.want, tc.running, tc.expectRunning, got, tc.takenOver)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Did you run `make format && make check`?**

gofmt, `go vet ./pkg/visor/`, the targeted tests, `go build -o /dev/null .` and the js/wasm `cmd/wasm-visor` build all pass. Not the full `make check`.

**Fixes:** `cli proxy start <pk>` (with `--direct` or `--routing-policy none`) losing its exit and restarting 30-90s in.

**Changes:**
- `autoStartProxyClient` verifies whatever is behind :1080 and, on a failed probe, stops skysocks-client and starts it on a random discovery exit. It never checked that the client it was judging was still its own candidate, so an operator's `proxy start <pk>` was treated as a failed candidate and "rotated": `proxy_client_auto` logged `exit failed end-to-end verification; rotating` and the visor logged `Changing skysocks-client PK to <random exit>` at exactly the moments the operator's session died (reproduced three times on a dev visor).
- Before the loop stops or re-points the client, it now checks that the configured `--srv` is still the exit it set and that the client is not running where it left it stopped. Either means the operator took over; the loop logs that once and stands down.
- The decision is a pure function with a table test (`TestProxyExitTakenOver`).

**How to test this PR:**
On a visor whose `skysocks-client` has `auto_start: true`, run `skywire cli proxy start <exit pk> --verbose` and leave it for a few minutes. Before: within ~30-90s the visor log shows `Changing skysocks-client PK to <other pk>` and the proxy restarts on an exit you did not pick. After: the session stays on your exit and `proxy_client_auto` logs `proxy client re-pointed by the operator; auto-exit rotation stands down` once.
