### PR TITLE
fix(transport): never mint a dmsg-type transport as a fallback in the browser

### DIFF
--- a/pkg/transport/dmsg_fallback_js.go
+++ b/pkg/transport/dmsg_fallback_js.go
@@ -1,0 +1,13 @@
+//go:build js
+
+package transport
+
+// dmsgRelayFallback is false in a browser: a tab cannot make a direct
+// transport to an arbitrary peer, so with the fallback on every on-demand
+// dial (a proxy exit probe, a --direct dial) minted one more dmsg-type
+// transport that nothing ever released — a desk tab was seen holding 118 of
+// them, one per exit its auto-exit loop had tried. A dmsg-type transport
+// buys the tab nothing it does not already have through dmsg itself; its
+// routes go over the transports it can form (the same-origin link to the
+// visor serving it, webtransport, webrtc) or through the host's graph.
+const dmsgRelayFallback = false

--- a/pkg/transport/dmsg_fallback_native.go
+++ b/pkg/transport/dmsg_fallback_native.go
@@ -1,0 +1,9 @@
+//go:build !js
+
+package transport
+
+// dmsgRelayFallback is whether EnsureBestTransport may mint a DMSG-type
+// transport when every direct type failed. A native visor keeps it: behind a
+// NAT that defeats stcpr/sudph, the relayed data plane is what keeps its routes
+// alive. See dmsg_fallback_js.go for why a browser visor does not.
+const dmsgRelayFallback = true

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -1087,12 +1087,12 @@ func (tm *Manager) EnsureBestTransport(ctx context.Context, remote cipher.PubKey
 		lastErr = err
 	}
 	// Last resort: the DMSG relay — loud, because it means no direct type worked.
-	// Callers can opt OUT by passing types.DMSG in `skip`: the wasm visor does,
-	// because it can rarely make a direct transport to an arbitrary exit and would
-	// otherwise create a NEW dmsg RELAY transport per exit. Those accumulate
-	// unbounded (each holds dmsg streams + goroutines) and wedge the single-threaded
-	// wasm runtime; it routes multihop over its webrtc entry transports instead.
-	if !skipSet[types.DMSG] {
+	// Callers can opt OUT by passing types.DMSG in `skip`. The js build opts out
+	// for everyone (dmsgRelayFallback): a browser can rarely make a direct
+	// transport to an arbitrary peer, so the fallback minted a NEW dmsg-type
+	// transport per on-demand dial. Those accumulate unbounded (each holds dmsg
+	// streams + goroutines) and wedge the single-threaded wasm runtime.
+	if dmsgRelayFallback && !skipSet[types.DMSG] {
 		if _, err := tm.SaveTransport(ctx, remote, types.DMSG, LabelAutomatic); err == nil {
 			tm.Logger.Warnf("auto-transport: all direct types %v failed for %s — created a DMSG RELAY transport (relayed data plane; usually signals a p2p reachability problem)", order, remote)
 			return nil


### PR DESCRIPTION
The js build compiles out EnsureBestTransport's last resort (a DMSG-type transport when every direct type failed). In a browser that fallback fired on every on-demand dial — the route-setup hook during the proxy auto-exit loop's exit probes, or `--direct` — and each one minted a dmsg-type transport nothing released; a desk tab was holding 118 of them. Native visors keep the fallback.

Local checks: vet, golangci-lint, transport tests, `go build .`, js/wasm build of cmd/wasm-visor.