### PR TITLE
feat(dmsg): nominate relays from live transports, no configuration

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -328,6 +328,14 @@ type Client struct {
 	// mistakes an attached peer for a server. Guarded by relaySessionsMx.
 	relaySessions   map[cipher.PubKey]*SessionCommon
 	relaySessionsMx sync.Mutex
+
+	// relayPeers are the peers the visor nominated as relays (SetRelayPeers),
+	// relayPort the dmsg port their acceptors listen on, relayFailAt the
+	// per-nominee backoff after a failed dial. Guarded by relayMx.
+	relayPeers  map[cipher.PubKey]struct{}
+	relayPort   uint16
+	relayFailAt map[cipher.PubKey]time.Time
+	relayMx     sync.Mutex
 }
 
 // AddDiscovery registers an additional dmsg-discovery this client
@@ -587,6 +595,13 @@ func (ce *Client) Serve(ctx context.Context) {
 				continue
 			}
 		}
+		// Relay nominees (SetRelayPeers) are dialed FIRST: the visor chose them
+		// for this client's dmsg traffic. They count as entries so a client with
+		// no reachable server still attaches through its relay.
+		var relays []*disc.Entry
+		if !pinned {
+			relays = ce.relayEntries()
+		}
 		if len(entries) == 0 && !pinned {
 			// Fallback for dmsg-only deployments and fleet cold-starts:
 			// when the disc.APIClient yields no entries (because the HTTP
@@ -602,7 +617,7 @@ func (ce *Client) Serve(ctx context.Context) {
 				entries = seeded
 			}
 		}
-		if len(entries) == 0 {
+		if len(entries) == 0 && len(relays) == 0 {
 			ce.log.Warnf("No entries found. Retrying after %s...", ce.bo.String())
 			if pinned {
 				ce.pinnedFailures.Add(1)
@@ -649,6 +664,9 @@ func (ce *Client) Serve(ctx context.Context) {
 		for i := range weighted {
 			entries[i] = weighted[i].entry
 		}
+		if len(relays) > 0 {
+			entries = append(relays, entries...)
+		}
 
 		if needInitialPost {
 			// use this for put protocol type of client to disc, for dicision part of dmsg-server
@@ -687,7 +705,7 @@ func (ce *Client) Serve(ctx context.Context) {
 
 			// If MinSessions is set to 0 then we connect to all available servers.
 			// If MinSessions is not 0 AND we have enough sessions, we wait for error or done signal.
-			if ce.conf.MinSessions != 0 && ce.SessionCount() >= ce.conf.MinSessions {
+			if ce.conf.MinSessions != 0 && ce.sessionsSatisfied() {
 				select {
 				case <-ce.done:
 					return
@@ -711,6 +729,11 @@ func (ce *Client) Serve(ctx context.Context) {
 				if err == context.Canceled || err == context.DeadlineExceeded {
 					ce.log.WithField("remote_pk", entry.Static).WithError(err).Warn("Failed to establish session.")
 					return
+				}
+				if ce.isRelayPeer(entry.Static) {
+					// A nominee that refused us or has no acceptor: leave it alone for
+					// a while and carry on with the servers.
+					ce.noteRelayFailure(entry.Static)
 				}
 				// we send an error if this is the last server
 				if n == (len(entries) - 1) {
@@ -1537,6 +1560,12 @@ func (ce *Client) reapExcessIdleSessions(idleStreak map[cipher.PubKey]int, idleC
 	streams := make(map[cipher.PubKey]int, len(ce.sessions))
 	for pk, ses := range ce.sessions {
 		sessions[pk] = ses
+		if ses.carrier == CarrierSkynet {
+			// A relay session counts toward the floor but is never reaped: it is
+			// the path the visor chose, idle or not.
+			streams[pk] = -1
+			continue
+		}
 		streams[pk] = ses.NumStreams()
 	}
 	ce.sessionsMx.Unlock()

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -136,6 +136,16 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	// calls consume — breaking any caller that expects consecutive
 	// dials to produce consecutive, usable streams (the exact failure
 	// mode of TestMultiServerStreams).
+	// Phase 0: relay sessions (skynet carrier). The visor nominated these
+	// peers to carry this client's dmsg traffic; the relay forwards to the
+	// destination's servers itself, so they go before any server session.
+	if relaySessions := ce.sortedRelaySessions(); len(relaySessions) > 0 {
+		if stream, ok := ce.sequentialPhaseDial(ctx, addr, relaySessions, maxPerExistingPhase); ok {
+			ce.dialFailClear(addr.PK)
+			return stream, nil
+		}
+	}
+
 	delegatedSessions := ce.sortedDelegatedSessions(entry.Client.DelegatedServers)
 	if stream, ok := ce.sequentialPhaseDial(ctx, addr, delegatedSessions, maxPerExistingPhase); ok {
 		ce.dialFailClear(addr.PK)
@@ -297,6 +307,9 @@ func (ce *Client) sortedMeshSessions(delegatedServers []cipher.PubKey) []ClientS
 	for _, ses := range ce.allClientSessions(ce.porter) {
 		if hasPK(delegatedServers, ses.RemotePK()) {
 			continue
+		}
+		if ses.carrier == CarrierSkynet {
+			continue // relay sessions are DialStream's phase 0, not a mesh path
 		}
 		sessions = append(sessions, ses)
 	}

--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -27,6 +27,7 @@ import (
 	"github.com/0magnet/yamux"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg/metrics"
 )
 
@@ -189,5 +190,154 @@ func (ce *Client) relayForwardSessions(dst cipher.PubKey) []*SessionCommon {
 		}
 		out = append(out, s.SessionCommon)
 	}
+	return out
+}
+
+// relayFailureBackoff is how long a nominated relay that refused or failed a
+// session dial is left alone before the serve loop tries it again. It is the
+// capability negotiation for relays: a peer without a relay acceptor, or one
+// that will not admit us, simply fails the dial, and we stop asking for a while.
+const relayFailureBackoff = 5 * time.Minute
+
+// relayProbation is how long a fresh relay session must survive before its
+// loss counts as an ordinary disconnect rather than a refusal: an acceptor
+// that will not admit us can only say so after the Noise handshake has
+// proven our key, by closing the conn.
+const relayProbation = 10 * time.Second
+
+// errRelayNominated is the sentinel the serve loop is woken with when new
+// relay candidates arrive while it is parked waiting for a session to fail.
+var errRelayNominated = errors.New("dmsg: relay candidates changed")
+
+// SetRelayPeers nominates the peers this client should hold a dmsg session
+// through as RELAYS, at the given dmsg port, replacing any earlier nomination.
+// The visor calls it as its transports change: a nominee is a peer it has a
+// live skywire transport to and a reason to trust with its dmsg traffic (a
+// hypervisor, a pinned persistent peer). The serve loop dials nominees FIRST
+// and treats "no relay session while nominees exist" as one session short, so
+// a client already at MinSessions still attaches; a nominee that refuses is
+// backed off for relayFailureBackoff. Stream dials prefer a relay session
+// (see DialStream). Passing an empty set withdraws every nomination; existing
+// relay sessions are left to close on their own.
+func (ce *Client) SetRelayPeers(pks []cipher.PubKey, port uint16) {
+	ce.relayMx.Lock()
+	changed := len(pks) != len(ce.relayPeers) || port != ce.relayPort
+	next := make(map[cipher.PubKey]struct{}, len(pks))
+	for _, pk := range pks {
+		if pk.Null() || pk == ce.pk {
+			continue
+		}
+		next[pk] = struct{}{}
+		if _, had := ce.relayPeers[pk]; !had {
+			changed = true
+		}
+	}
+	ce.relayPeers = next
+	ce.relayPort = port
+	ce.relayMx.Unlock()
+	if !changed {
+		return
+	}
+	// Wake a serve loop parked on errCh so it re-evaluates the candidate list.
+	ce.sesMx.Lock()
+	if !isClosed(ce.done) {
+		select {
+		case ce.errCh <- errRelayNominated:
+		default:
+		}
+	}
+	ce.sesMx.Unlock()
+}
+
+// RelayPeers returns the current relay nominees.
+func (ce *Client) RelayPeers() []cipher.PubKey {
+	ce.relayMx.Lock()
+	defer ce.relayMx.Unlock()
+	out := make([]cipher.PubKey, 0, len(ce.relayPeers))
+	for pk := range ce.relayPeers {
+		out = append(out, pk)
+	}
+	return out
+}
+
+// relayEntries returns server entries for the nominated relays this client has
+// no session with and is not backing off, at their skynet address.
+func (ce *Client) relayEntries() []*disc.Entry {
+	ce.relayMx.Lock()
+	defer ce.relayMx.Unlock()
+	if len(ce.relayPeers) == 0 {
+		return nil
+	}
+	now := time.Now()
+	out := make([]*disc.Entry, 0, len(ce.relayPeers))
+	for pk := range ce.relayPeers {
+		if _, ok := ce.session(pk); ok {
+			continue
+		}
+		if until, ok := ce.relayFailAt[pk]; ok && now.Before(until) {
+			continue
+		}
+		out = append(out, &disc.Entry{
+			Static: pk,
+			Server: &disc.Server{Address: SkynetAddr(pk, ce.relayPort), AvailableSessions: 1},
+		})
+	}
+	return out
+}
+
+// isRelayPeer reports whether pk is a current relay nominee.
+func (ce *Client) isRelayPeer(pk cipher.PubKey) bool {
+	ce.relayMx.Lock()
+	defer ce.relayMx.Unlock()
+	_, ok := ce.relayPeers[pk]
+	return ok
+}
+
+// noteRelayFailure backs a nominee off after a failed session dial.
+func (ce *Client) noteRelayFailure(pk cipher.PubKey) {
+	ce.relayMx.Lock()
+	if ce.relayFailAt == nil {
+		ce.relayFailAt = make(map[cipher.PubKey]time.Time)
+	}
+	ce.relayFailAt[pk] = time.Now().Add(relayFailureBackoff)
+	ce.relayMx.Unlock()
+}
+
+// hasRelaySession reports whether any current session rides the skynet carrier.
+func (ce *Client) hasRelaySession() bool {
+	ce.sessionsMx.Lock()
+	defer ce.sessionsMx.Unlock()
+	for _, ses := range ce.sessions {
+		if ses.carrier == CarrierSkynet {
+			return true
+		}
+	}
+	return false
+}
+
+// sessionsSatisfied is the serve loop's "enough sessions" test: MinSessions
+// met, and — when relays are nominated and dialable — at least one relay
+// session held. Only meaningful when MinSessions != 0.
+func (ce *Client) sessionsSatisfied() bool {
+	if ce.SessionCount() < ce.conf.MinSessions {
+		return false
+	}
+	if len(ce.relayEntries()) > 0 && !ce.hasRelaySession() {
+		return false
+	}
+	return true
+}
+
+// sortedRelaySessions returns the sessions riding the skynet carrier, by
+// latency. DialStream tries these before any server session: a relay is the
+// path the visor chose for this client's dmsg traffic.
+func (ce *Client) sortedRelaySessions() []ClientSession {
+	var out []ClientSession
+	for _, ses := range ce.allClientSessions(ce.porter) {
+		if ses.carrier == CarrierSkynet {
+			out = append(out, ses)
+		}
+	}
+	sortSessionsByLatency(out)
 	return out
 }

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -728,6 +728,7 @@ func (ce *Client) finishDialedSession(ctx context.Context, dSes ClientSession, n
 		}
 	}
 
+	started := time.Now()
 	go func() {
 		defer ce.wg.Done()
 		defer func() {
@@ -766,7 +767,18 @@ func (ce *Client) finishDialedSession(ctx context.Context, dSes ClientSession, n
 			ce.delSession(ctx, dSes.RemotePK(), dSes.SessionCommon)
 			// Remember which server we just lost so the Serve loop re-dials
 			// THIS server before moving to a different one (#4086).
-			ce.noteLostSession(dSes.RemotePK())
+			if dSes.carrier == CarrierSkynet {
+				// A relay session is re-derived from the nominee list, not re-dialed
+				// as a lost server (its entry is synthetic — a lookup would 404). One
+				// that died within its probation was refused after the handshake
+				// (the acceptor's allow check runs on the proven key): back the
+				// nominee off instead of re-dialing it on every loss.
+				if time.Since(started) < relayProbation {
+					ce.noteRelayFailure(dSes.RemotePK())
+				}
+			} else {
+				ce.noteLostSession(dSes.RemotePK())
+			}
 		}
 
 		// Trigger disconnect callback.

--- a/pkg/dmsg/dmsg/relay_nominee_test.go
+++ b/pkg/dmsg/dmsg/relay_nominee_test.go
@@ -1,0 +1,104 @@
+package dmsg
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// A client that already holds its MinSessions server sessions, then has a
+// relay nominated at runtime, attaches to the relay without being told about
+// any server address, keeps its server sessions, and dials destinations
+// through the relay first.
+func TestRelayNominee_AttachesAtRuntimeAndIsPreferred(t *testing.T) {
+	env := newRelayedTestEnv(t, nil)
+	env.relay.maxRelayedStreams = 8
+	relayPK := env.relay.LocalPK()
+
+	// An ordinary client on the shared discovery: one server session.
+	pk, sk := GenKeyPair(t, "nominee-client")
+	c := NewClient(pk, sk, env.dc, &Config{MinSessions: 1})
+	c.SetLogger(logging.MustGetLogger("nominee-client"))
+	var dials atomic.Int32
+	c.SetSessionDialer(skynetDialer(t, env.relay, relayPK, nil, &dials))
+	go c.Serve(context.Background())
+	t.Cleanup(func() { _ = c.Close() }) //nolint:errcheck
+	require.Eventually(t, func() bool { _, ok := c.Session(env.srvPK); return ok }, 15*time.Second, 50*time.Millisecond)
+	require.False(t, c.hasRelaySession())
+
+	// Nominate the relay: the serve loop, parked at MinSessions, must wake and dial it.
+	c.SetRelayPeers([]cipher.PubKey{relayPK}, 70)
+	require.Eventually(t, c.hasRelaySession, 15*time.Second, 50*time.Millisecond)
+	_, direct := c.Session(env.srvPK)
+	require.True(t, direct, "the server session stays; the relay is added, not swapped in")
+	require.Equal(t, []cipher.PubKey{relayPK}, c.RelayPeers())
+
+	// A stream to dst goes through the relay (phase 0), not the shared server.
+	accepted := acceptOne(t, env.dstLis)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	str, err := c.DialStream(ctx, Addr{PK: env.dstPK, Port: relayedDstPort})
+	require.NoError(t, err)
+	defer str.Close() //nolint:errcheck
+	s := <-accepted
+	require.NotNil(t, s)
+	defer s.Close() //nolint:errcheck
+	require.Equal(t, pk, s.RawRemoteAddr().PK)
+	require.Equal(t, 1, env.relay.RelayedStreams(), "the stream must be carried by the relay")
+	echoCheck(t, str, s)
+
+	// The idle reaper never takes the relay session: with MinSessions 1 and two
+	// sessions, the streamless SERVER session is the surplus.
+	streak := map[cipher.PubKey]int{}
+	c.reapExcessIdleSessions(streak, 1)
+	require.Eventually(t, func() bool { _, ok := c.Session(env.srvPK); return !ok }, 5*time.Second, 50*time.Millisecond)
+	require.True(t, c.hasRelaySession())
+}
+
+// A nominee that refuses is backed off: the client does not keep re-dialing it,
+// and stays satisfied with its server sessions.
+func TestRelayNominee_RefusalBacksOff(t *testing.T) {
+	env := newRelayedTestEnv(t, nil)
+	relayPK := env.relay.LocalPK()
+
+	pk, sk := GenKeyPair(t, "nominee-refused")
+	c := NewClient(pk, sk, env.dc, &Config{MinSessions: 1})
+	c.SetLogger(logging.MustGetLogger("nominee-refused"))
+	var dials atomic.Int32
+	c.SetSessionDialer(skynetDialer(t, env.relay, relayPK, func(cipher.PubKey) bool { return false }, &dials))
+	go c.Serve(context.Background())
+	t.Cleanup(func() { _ = c.Close() }) //nolint:errcheck
+	require.Eventually(t, func() bool { _, ok := c.Session(env.srvPK); return ok }, 15*time.Second, 50*time.Millisecond)
+
+	c.SetRelayPeers([]cipher.PubKey{relayPK}, 70)
+	require.Eventually(t, func() bool { return dials.Load() >= 1 }, 15*time.Second, 50*time.Millisecond)
+	require.Eventually(t, func() bool { return len(c.relayEntries()) == 0 }, 5*time.Second, 50*time.Millisecond, "a refused nominee must be backed off")
+	require.True(t, c.sessionsSatisfied(), "with the nominee backed off the server session suffices")
+	time.Sleep(time.Second)
+	require.LessOrEqual(t, dials.Load(), int32(2), "no redial storm against a refusing nominee")
+	require.False(t, c.hasRelaySession())
+
+	// Withdrawing the nomination clears the candidate list entirely.
+	c.SetRelayPeers(nil, 70)
+	require.Empty(t, c.RelayPeers())
+}
+
+func TestRelayNominee_EntriesSkipSelfAndSessions(t *testing.T) {
+	pk, sk := GenKeyPair(t, "nominee-entries")
+	c := NewClient(pk, sk, disc.NewMock(0), &Config{MinSessions: 1})
+	other, _ := GenKeyPair(t, "nominee-other")
+	c.SetRelayPeers([]cipher.PubKey{pk, other}, 70)
+	require.Equal(t, []cipher.PubKey{other}, c.RelayPeers(), "a client never nominates itself")
+	entries := c.relayEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, SkynetAddr(other, 70), entries[0].Server.Address)
+	c.noteRelayFailure(other)
+	require.Empty(t, c.relayEntries())
+}

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -305,7 +305,8 @@ func (v *Visor) proxyClientTakenOver(log *logging.Logger, want string, expectRun
 	configured := v.GetSkysocksClientAddress()
 	running := false
 	if v.procM != nil {
-		_, running = v.procM.ProcByName(skyenv.SkysocksClientName)
+		proc, ok := v.procM.ProcByName(skyenv.SkysocksClientName)
+		running = ok && proc != nil
 	}
 	if !proxyExitTakenOver(configured, want, running, expectRunning) {
 		return false

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -277,6 +277,7 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 	v.initLock.Unlock()
 	// The other half of the skynet carrier: serve attached peers as a dmsg relay.
 	v.initDmsgRelay(ctx, dmsgC)
+	go v.nominateRelayPeers(ctx, dmsgC)
 	select {
 	case <-v.dmsgHTTPReady:
 	default:

--- a/pkg/visor/init_dmsg_relay.go
+++ b/pkg/visor/init_dmsg_relay.go
@@ -20,12 +20,14 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/transport"
 )
 
 // skynetSessionDialer is the dmsg client's SessionDialer for the skynet
@@ -112,5 +114,80 @@ func (v *Visor) relayPeerAllowed(pk cipher.PubKey) bool {
 			return true
 		}
 	}
-	return false
+	// A peer we hold a transport to may relay through us: a transport is
+	// mutual, and a tab served by this visor has exactly one — to us.
+	return v.hasTransportTo(pk)
+}
+
+// relayNominationInterval is how often the visor re-derives its relay
+// nominees from the transports it currently holds.
+const relayNominationInterval = 10 * time.Second
+
+// nominateRelayPeers keeps the dmsg client's relay nominees in step with the
+// visor's transports: a hypervisor or a persistent-transport peer that this
+// visor has a live transport to is nominated (dmsg.Client.SetRelayPeers);
+// when the transport goes, so does the nomination. No configuration takes
+// part — the trust is the hypervisor relationship or the operator's pinned
+// transport, and the reachability is the transport itself. A nominee that
+// has no relay acceptor, or refuses us, fails the dial and is backed off by
+// the client; the configured servers stay the bootstrap and the fallback.
+func (v *Visor) nominateRelayPeers(ctx context.Context, dmsgC *dmsg.Client) {
+	t := time.NewTicker(relayNominationInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			dmsgC.SetRelayPeers(v.relayNominees(), skyenv.DmsgRelayPort)
+		}
+	}
+}
+
+// relayNominees returns the trusted peers this visor has a live transport to.
+func (v *Visor) relayNominees() []cipher.PubKey {
+	if v.tpM == nil || v.conf == nil {
+		return nil
+	}
+	trusted := make(map[cipher.PubKey]struct{}, len(v.conf.Hypervisors)+len(v.conf.PersistentTransports))
+	for _, pk := range v.conf.Hypervisors {
+		trusted[pk] = struct{}{}
+	}
+	for _, pt := range v.conf.PersistentTransports {
+		trusted[pt.PK] = struct{}{}
+	}
+	if len(trusted) == 0 {
+		return nil
+	}
+	seen := make(map[cipher.PubKey]struct{})
+	var out []cipher.PubKey
+	v.tpM.WalkTransports(func(tp *transport.ManagedTransport) bool {
+		pk := tp.Remote()
+		if _, ok := trusted[pk]; !ok || tp.IsClosed() || pk == v.conf.PK {
+			return true
+		}
+		if _, dup := seen[pk]; dup {
+			return true
+		}
+		seen[pk] = struct{}{}
+		out = append(out, pk)
+		return true
+	})
+	return out
+}
+
+// hasTransportTo reports whether this visor holds a live transport to pk.
+func (v *Visor) hasTransportTo(pk cipher.PubKey) bool {
+	if v.tpM == nil {
+		return false
+	}
+	found := false
+	v.tpM.WalkTransports(func(tp *transport.ManagedTransport) bool {
+		if tp.Remote() == pk && !tp.IsClosed() {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }


### PR DESCRIPTION
Completes #4484 stage 3 without any configuration. A visor nominates as dmsg relays the hypervisors and persistent-transport peers it holds a live transport to (`Client.SetRelayPeers`, re-derived every 10 s). The dmsg client dials nominees first, counts a relay session toward its floor, prefers it for every stream dial, never idle-reaps it, and backs a nominee off for five minutes when it refuses or has no acceptor. Configured servers stay the bootstrap and the fallback. A relay admits peers it holds a transport to, alongside the whitelist and managed visors (#4705).

Tests: a client at its session floor attaches when a relay is nominated, keeps its server session, dials destinations through the relay, and the reaper takes the idle server session rather than the relay; a refusing nominee is backed off without a redial storm. Race-clean.

Also fixes the errcheck finding left in #4706.

Local checks: targeted + full pkg/dmsg/dmsg tests, vet, golangci-lint, `go build .`, js/wasm build of cmd/wasm-visor.