### PR TITLE
wasm-visor: let the desk place the browser tab strip

### DIFF
--- a/cmd/wasm-visor/browser_js.go
+++ b/cmd/wasm-visor/browser_js.go
@@ -129,8 +129,12 @@ func netscrapeHost(el js.Value) js.Value {
 // hoistBrowserTabs moves netscrape's tab strip out of the browser's box and
 // into the title bar of the desk window that holds el, level with the window
 // controls — where a browser keeps its tabs. A host element outside any window
-// keeps the strip where netscrape put it. Both desks come through here: the
-// wasm desk's browser pane and the native page's dashboard window.
+// keeps the strip where netscrape put it.
+//
+// Only jsOpenBrowser needs this now: it is called from the native page's JS
+// with an element the desk never mounted, so there is no pane for the desk to
+// ask. The wasm desk's browser is a desk.HeaderPane and the desk moves its
+// strip without being told — see browserPane in desk_js.go.
 func hoistBrowserTabs(el js.Value) {
 	if !el.Truthy() || el.Get("closest").Type() != js.TypeFunction {
 		return

--- a/cmd/wasm-visor/desk_js.go
+++ b/cmd/wasm-visor/desk_js.go
@@ -40,6 +40,32 @@ type funcPane struct{ mount func(el js.Value) error }
 func (p funcPane) Mount(el js.Value) error { return p.mount(el) }
 func (funcPane) Close()                    {}
 
+// browserPane is the netscrape browser as a desk pane.
+//
+// A type of its own rather than another funcPane because it has something to
+// say about the window it lands in: desk.HeaderPane asks a pane for the element
+// that belongs in the title bar, and the desk moves it there. That is how the
+// tab strip ends up level with the window controls without this file reaching
+// into the window to put it there.
+//
+// jsOpenBrowser still hoists by hand — see browser_js.go. It is not a desk pane
+// and has no window of the desk's to be asked about, being called from the
+// native page's JS with an element the desk never mounted.
+type browserPane struct{ url string }
+
+func (p browserPane) Mount(el js.Value) error {
+	netscrape.Open(netscrapeHost(el))
+	if p.url != "" {
+		netscrape.Navigate(p.url)
+	}
+	return nil
+}
+
+func (browserPane) Close() {}
+
+// HeaderEl is desk.HeaderPane: netscrape's tab strip goes in the title bar.
+func (browserPane) HeaderEl() js.Value { return netscrape.TabStrip() }
+
 // installDesk registers skywire's desk apps and mounts the library panel.
 // Call from a DOM-bearing role after installShell/installBrowser.
 func installDesk() {
@@ -92,14 +118,11 @@ func installDesk() {
 		Help:  "netscrape — browse the mesh and the clearnet",
 		Width: 1000, Height: 640,
 		Open: func(args []string) (desk.Pane, error) {
-			return funcPane{mount: func(el js.Value) error {
-				netscrape.Open(netscrapeHost(el))
-				hoistBrowserTabs(el)
-				if len(args) > 0 && args[0] != "" {
-					netscrape.Navigate(args[0])
-				}
-				return nil
-			}}, nil
+			var url string
+			if len(args) > 0 {
+				url = args[0]
+			}
+			return browserPane{url: url}, nil
 		},
 	})
 	desk.Register(desk.App{

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/0magnet/bitree v0.0.0-20260906144807-e66de0b4c738
 	github.com/0magnet/bottle v0.0.0-20260908155251-920d2280a387
 	github.com/0magnet/calvin v0.0.0-20260908180241-0893f4bff56a
-	github.com/0magnet/desk v0.0.0-20260909002914-271c2999cd2c
+	github.com/0magnet/desk v0.0.0-20260909171253-833d45f6d44f
 	github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db
 	github.com/0magnet/gobrpc v0.0.0-20260906144809-5215ec59d553
 	github.com/0magnet/golang-ipc v1.2.5-0.20260905172007-25d9c1a262d0

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/0magnet/coloredcobra v1.0.3 h1:s/3WW+wAssjMEKgzlXWcQ6PGSoKJIoambL68yt
 github.com/0magnet/coloredcobra v1.0.3/go.mod h1:Kn7dmRJcnVybFNKY0FNUjLcsivW4FCbAec8ZfVmz51I=
 github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585 h1:G2m5S+A3CMsHobihQUfsl2ZLnepQCPjeWcwDp7505Rs=
 github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585/go.mod h1:dp0q1zfKQmTaohUrPEPZbPExxBWLu9DyeaFxKUBnw6Y=
-github.com/0magnet/desk v0.0.0-20260909002914-271c2999cd2c h1:ucnkHbW+5CNsVGtX3sJCkAoJjeyOMwjN/DT++Vwursg=
-github.com/0magnet/desk v0.0.0-20260909002914-271c2999cd2c/go.mod h1:L+8Y1fP55UjK6RFOG0iAsR9oO6zXidCr9LZJy+8oN/k=
+github.com/0magnet/desk v0.0.0-20260909171253-833d45f6d44f h1:F5PQgLQLBMtSNWPnj2pBpVPY4KrDJYyhQKD/TlIjaWA=
+github.com/0magnet/desk v0.0.0-20260909171253-833d45f6d44f/go.mod h1:L+8Y1fP55UjK6RFOG0iAsR9oO6zXidCr9LZJy+8oN/k=
 github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db h1:t/kQDGFMvKhpRBTdEjiLCkVG9Pe/qmDuD8D65DJrdrs=
 github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db/go.mod h1:EDtFhI1TlDPunQIoT8IRbhe8wa5R4GAI+iL04vQDk2Y=
 github.com/0magnet/go-dsp v0.0.0-20260907230215-136ba239cc2d h1:AE2MbqkqaB88h+jtiWo5aI6zODI+0QZZRI4lY0p9Fhw=

--- a/vendor/github.com/0magnet/desk/desk.go
+++ b/vendor/github.com/0magnet/desk/desk.go
@@ -44,6 +44,26 @@ type Resizer interface {
 	Resize(width, height float64)
 }
 
+// HeaderPane is implemented by a pane with an element that belongs in the
+// window's title bar rather than in its body — a browser's tab strip, level
+// with the window controls, is the case this exists for.
+//
+// Most panes have none. Implement it and the desk moves the element into the
+// title bar after the pane mounts; return a zero Value to keep everything in
+// the body, and a pane mounted outside any window keeps its element where it
+// built it.
+//
+// The desk does this rather than each host doing it, because the desk is what
+// owns the window. A host wiring it up itself has to find the window from the
+// mount element and has to remember at every call site — and both hosts using
+// this package wanted the same behavior while only one of them had the call,
+// which is the argument against leaving it to them.
+type HeaderPane interface {
+	// HeaderEl returns the element to move into the title bar. Called once,
+	// after Mount, so a pane can build the element while mounting.
+	HeaderEl() js.Value
+}
+
 // TexturePane is implemented by a pane whose pixels all live in one canvas.
 //
 // It exists because the DOM cannot be sampled into a WebGL texture and a canvas

--- a/vendor/github.com/0magnet/desk/tabs_js.go
+++ b/vendor/github.com/0magnet/desk/tabs_js.go
@@ -136,6 +136,15 @@ func (ts *tabset) add(pane Pane, title string) error {
 		ts.views.Call("removeChild", view)
 		return err
 	}
+	// A pane may own an element that belongs in the title bar rather than the
+	// body — a browser's tab strip. After Mount, because the pane builds it
+	// while mounting; here rather than in the host, because this is what knows
+	// the window.
+	if hp, ok := pane.(HeaderPane); ok {
+		if el := hp.HeaderEl(); el.Truthy() {
+			MountInHeader(ts.win.DOM, el)
+		}
+	}
 	// Read back what Mount left: a pane that styles its host keeps that display
 	// from here on, and only the show/hide toggle is ours. Falls back to
 	// "block" if the pane cleared it entirely.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -47,7 +47,7 @@ github.com/0magnet/coloredcobra
 # github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585
 ## explicit; go 1.24
 github.com/0magnet/cosmos-go
-# github.com/0magnet/desk v0.0.0-20260909002914-271c2999cd2c
+# github.com/0magnet/desk v0.0.0-20260909171253-833d45f6d44f
 ## explicit; go 1.26
 github.com/0magnet/desk
 github.com/0magnet/desk/dom


### PR DESCRIPTION
The desk package gained an optional `HeaderPane` interface: a pane names the element that belongs in its window title bar and the desk moves it there, the same way `Resizer` lets a pane ask to be told its size.

The browser becomes a pane of its own with a `HeaderEl` rather than a `funcPane` that calls `hoistBrowserTabs` after mounting. Same result — the tab strip sits level with the window controls — with the placement owned by the thing that owns the window.

`hoistBrowserTabs` stays for `jsOpenBrowser`, which the native page calls from JS with an element the desk never mounted, so there is no pane there for the desk to ask.

Motivation: the call joining netscrape and desk was the host's to make, and of the two hosts using both libraries only this one made it — the other mounted the same browser in the same desk and left its tabs in the window body.