### PR TITLE
fix(visor): the route-setup hook still minted dmsg-type transports in a tab

### DIFF
--- a/pkg/transport/dmsg_fallback_js.go
+++ b/pkg/transport/dmsg_fallback_js.go
@@ -2,7 +2,7 @@
 
 package transport
 
-// dmsgRelayFallback is false in a browser: a tab cannot make a direct
+// DmsgRelayFallback is false in a browser: a tab cannot make a direct
 // transport to an arbitrary peer, so with the fallback on every on-demand
 // dial (a proxy exit probe, a --direct dial) minted one more dmsg-type
 // transport that nothing ever released — a desk tab was seen holding 118 of
@@ -10,4 +10,4 @@ package transport
 // buys the tab nothing it does not already have through dmsg itself; its
 // routes go over the transports it can form (the same-origin link to the
 // visor serving it, webtransport, webrtc) or through the host's graph.
-const dmsgRelayFallback = false
+const DmsgRelayFallback = false

--- a/pkg/transport/dmsg_fallback_native.go
+++ b/pkg/transport/dmsg_fallback_native.go
@@ -2,8 +2,9 @@
 
 package transport
 
-// dmsgRelayFallback is whether EnsureBestTransport may mint a DMSG-type
-// transport when every direct type failed. A native visor keeps it: behind a
+// DmsgRelayFallback is whether the visor may mint a DMSG-type transport when
+// every direct type failed (EnsureBestTransport and the route-setup hook).
+// A native visor keeps it: behind a
 // NAT that defeats stcpr/sudph, the relayed data plane is what keeps its routes
 // alive. See dmsg_fallback_js.go for why a browser visor does not.
-const dmsgRelayFallback = true
+const DmsgRelayFallback = true

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -1088,11 +1088,11 @@ func (tm *Manager) EnsureBestTransport(ctx context.Context, remote cipher.PubKey
 	}
 	// Last resort: the DMSG relay — loud, because it means no direct type worked.
 	// Callers can opt OUT by passing types.DMSG in `skip`. The js build opts out
-	// for everyone (dmsgRelayFallback): a browser can rarely make a direct
+	// for everyone (DmsgRelayFallback): a browser can rarely make a direct
 	// transport to an arbitrary peer, so the fallback minted a NEW dmsg-type
 	// transport per on-demand dial. Those accumulate unbounded (each holds dmsg
 	// streams + goroutines) and wedge the single-threaded wasm runtime.
-	if dmsgRelayFallback && !skipSet[types.DMSG] {
+	if DmsgRelayFallback && !skipSet[types.DMSG] {
 		if _, err := tm.SaveTransport(ctx, remote, types.DMSG, LabelAutomatic); err == nil {
 			tm.Logger.Warnf("auto-transport: all direct types %v failed for %s — created a DMSG RELAY transport (relayed data plane; usually signals a p2p reachability problem)", order, remote)
 			return nil

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -124,6 +124,13 @@ func getRouteSetupHooks(ctx context.Context, v *Visor, log *logging.Logger) []ro
 			var lastErr error
 			for _, nType := range types.PreferredOrder(types.STCPR, types.SUDPH, types.DMSG) {
 				switch nType {
+				case types.DMSG:
+					// Same gate as EnsureBestTransport: a browser visor never
+					// mints a dmsg-type transport (it held one per proxy exit
+					// its auto-exit loop had tried, never released).
+					if !transport.DmsgRelayFallback {
+						continue
+					}
 				case types.STCPR:
 					if !advertised[types.STCPR] {
 						continue


### PR DESCRIPTION
#4707 gated `EnsureBestTransport`, but the route-setup hook's own preference walk (stcpr, sudph, dmsg) reaches dmsg whenever the peer advertises a direct type in the address resolver. In a browser the direct dials fail and the dmsg type was saved: the desk tab held four again within minutes of a reload.

Export the gate (`transport.DmsgRelayFallback`) and apply it in the hook. Native visors are unchanged.