### PR TITLE
fix(dmsg): a relay dial that times out at boot retries in 30 s, not 5 min

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -692,6 +692,11 @@ serve:
 				// heard while parked): rebuild the list with them in front.
 				continue serve
 			}
+			if ce.isRelayPeer(entry.Static) && ce.relayBackedOff(entry.Static) {
+				// Backed off after this pass's list was built (a refusal that
+				// only showed after the handshake): do not re-dial it now.
+				continue
+			}
 
 			// A visor running its own dmsg server in-process (same PK) must
 			// not open a transit session to itself. Conditional: the
@@ -749,7 +754,7 @@ serve:
 				if ce.isRelayPeer(entry.Static) {
 					// A nominee that refused us or has no acceptor: leave it alone for
 					// a while and carry on with the servers.
-					ce.noteRelayFailure(entry.Static)
+					ce.noteRelayFailure(entry.Static, relayBackoffFor(err))
 				}
 				// we send an error if this is the last server
 				if n == (len(entries) - 1) {

--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -305,13 +305,28 @@ func (ce *Client) isRelayPeer(pk cipher.PubKey) bool {
 	return ok
 }
 
-// noteRelayFailure backs a nominee off after a failed session dial.
-func (ce *Client) noteRelayFailure(pk cipher.PubKey) {
+// relayTimeoutRetry is the backoff after a nominee dial that merely timed out:
+// at boot the skynet dial races the router's own cold start (setup node,
+// route finder), so a timeout says nothing about the nominee. Refusals and
+// other errors get relayFailureBackoff.
+const relayTimeoutRetry = 30 * time.Second
+
+// relayBackoffFor picks the backoff a failed nominee dial earns.
+func relayBackoffFor(err error) time.Duration {
+	var nerr net.Error
+	if errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &nerr) && nerr.Timeout()) {
+		return relayTimeoutRetry
+	}
+	return relayFailureBackoff
+}
+
+// noteRelayFailure backs a nominee off for d after a failed session dial.
+func (ce *Client) noteRelayFailure(pk cipher.PubKey, d time.Duration) {
 	ce.relayMx.Lock()
 	if ce.relayFailAt == nil {
 		ce.relayFailAt = make(map[cipher.PubKey]time.Time)
 	}
-	ce.relayFailAt[pk] = time.Now().Add(relayFailureBackoff)
+	ce.relayFailAt[pk] = time.Now().Add(d)
 	ce.relayMx.Unlock()
 }
 
@@ -352,4 +367,12 @@ func (ce *Client) sortedRelaySessions() []ClientSession {
 	}
 	sortSessionsByLatency(out)
 	return out
+}
+
+// relayBackedOff reports whether nominee pk is inside its failure backoff.
+func (ce *Client) relayBackedOff(pk cipher.PubKey) bool {
+	ce.relayMx.Lock()
+	defer ce.relayMx.Unlock()
+	until, ok := ce.relayFailAt[pk]
+	return ok && time.Now().Before(until)
 }

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -777,7 +777,7 @@ func (ce *Client) finishDialedSession(ctx context.Context, dSes ClientSession, n
 				// (the acceptor's allow check runs on the proven key): back the
 				// nominee off instead of re-dialing it on every loss.
 				if time.Since(started) < relayProbation {
-					ce.noteRelayFailure(dSes.RemotePK())
+					ce.noteRelayFailure(dSes.RemotePK(), relayFailureBackoff)
 				}
 			} else {
 				ce.noteLostSession(dSes.RemotePK())

--- a/pkg/dmsg/dmsg/relay_nominee_test.go
+++ b/pkg/dmsg/dmsg/relay_nominee_test.go
@@ -102,7 +102,7 @@ func TestRelayNominee_EntriesSkipSelfAndSessions(t *testing.T) {
 	entries := c.relayEntries()
 	require.Len(t, entries, 1)
 	require.Equal(t, SkynetAddr(other, 70), entries[0].Server.Address)
-	c.noteRelayFailure(other)
+	c.noteRelayFailure(other, relayFailureBackoff)
 	require.Empty(t, c.relayEntries())
 }
 

--- a/pkg/visor/init_dmsg_relay.go
+++ b/pkg/visor/init_dmsg_relay.go
@@ -31,9 +31,13 @@ import (
 	"github.com/skycoin/skywire/pkg/transport"
 )
 
+// skynetSessionDialTimeout bounds one relay session dial over skynet.
+const skynetSessionDialTimeout = 30 * time.Second
+
 // skynetSessionDialer is the dmsg client's SessionDialer for the skynet
 // carrier: it turns "skynet://<pk>:<port>" into a skywire route dial to that
-// visor's relay listener. Bounded by dmsg.DialTimeout like the TCP carrier.
+// visor's relay listener. Bounded by skynetSessionDialTimeout: unlike a TCP dial
+// this one sets up a route, and at boot that waits on the setup node.
 func skynetSessionDialer(ctx context.Context, network, addr string) (net.Conn, error) {
 	if network != dmsg.CarrierSkynet {
 		return nil, fmt.Errorf("dmsg session dialer: unsupported carrier %q", network)
@@ -42,7 +46,7 @@ func skynetSessionDialer(ctx context.Context, network, addr string) (net.Conn, e
 	if err != nil {
 		return nil, err
 	}
-	dialCtx, cancel := context.WithTimeout(ctx, dmsg.DialTimeout)
+	dialCtx, cancel := context.WithTimeout(ctx, skynetSessionDialTimeout)
 	defer cancel()
 	return appnet.DialContext(dialCtx, appnet.Addr{
 		Net:    appnet.TypeSkynet,


### PR DESCRIPTION
The desk tab's first relay dial raced the router's cold start (setup node connect, route finder) and hit the 10 s dmsg dial timeout; the nominee was then backed off for 5 minutes as if it had refused. A skynet dial to the same host a few minutes later took about a second.

The skynet session dial is bounded at 30 s; a timed-out nominee retries after 30 s while refusals keep the 5 minute backoff; and a nominee backed off during the current pass is skipped instead of re-dialed (the refusal test flaked on exactly that re-dial).