### PR TITLE
fix(dmsg): retry a lapsed relay backoff on the next nomination

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -692,9 +692,10 @@ serve:
 				// heard while parked): rebuild the list with them in front.
 				continue serve
 			}
-			if ce.isRelayPeer(entry.Static) && ce.relayBackedOff(entry.Static) {
-				// Backed off after this pass's list was built (a refusal that
-				// only showed after the handshake): do not re-dial it now.
+			if ce.relayBackedOff(entry.Static) {
+				// A relay (nominee or seeded skynet entry) backed off after this
+				// pass's list was built — a refusal only shows after the
+				// handshake: do not re-dial it now.
 				continue
 			}
 

--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -239,8 +239,17 @@ func (ce *Client) SetRelayPeers(pks []cipher.PubKey, port uint16) bool {
 		ce.relayGen++
 	}
 	ce.relayMx.Unlock()
-	if !changed {
+	// An unchanged set still wakes the loop while a nominee is pending: a
+	// dialable nominee with no session, i.e. one whose failure backoff has
+	// lapsed. Nothing else re-runs the pass when a backoff expires — the loop
+	// is parked on errCh — so the visor's periodic re-nomination is the retry.
+	if !changed && !ce.relayPending() {
 		return false
+	}
+	if !changed {
+		ce.relayMx.Lock()
+		ce.relayGen++
+		ce.relayMx.Unlock()
 	}
 	// Wake a serve loop parked on errCh so it re-evaluates the candidate list.
 	ce.sesMx.Lock()
@@ -251,7 +260,13 @@ func (ce *Client) SetRelayPeers(pks []cipher.PubKey, port uint16) bool {
 		}
 	}
 	ce.sesMx.Unlock()
-	return true
+	return changed
+}
+
+// relayPending reports whether a nominee is dialable right now (not backed
+// off) while no relay session exists.
+func (ce *Client) relayPending() bool {
+	return len(ce.relayEntries()) > 0 && !ce.hasRelaySession()
 }
 
 // relayGeneration is the nomination change counter (see SetRelayPeers).

--- a/pkg/dmsg/dmsg/relay_nominee_test.go
+++ b/pkg/dmsg/dmsg/relay_nominee_test.go
@@ -208,3 +208,38 @@ func TestRelayNominee_RelayGoesBeforeLookupAndCache(t *testing.T) {
 	c.setCachedRoute(env.dstPK, env.srvPK)
 	dialThroughRelay()
 }
+
+// A nominee whose failure backoff has lapsed is dialed again on the next
+// (unchanged) nomination: nothing else wakes the parked serve loop.
+func TestRelayNominee_RetriesAfterBackoffLapses(t *testing.T) {
+	env := newRelayedTestEnv(t, nil)
+	env.relay.maxRelayedStreams = 8
+	relayPK := env.relay.LocalPK()
+
+	pk, sk := GenKeyPair(t, "nominee-retry")
+	c := NewClient(pk, sk, env.dc, &Config{MinSessions: 1})
+	c.SetLogger(logging.MustGetLogger("nominee-retry"))
+	var admit atomic.Bool
+	var dials atomic.Int32
+	c.SetSessionDialer(skynetDialer(t, env.relay, relayPK, func(cipher.PubKey) bool { return admit.Load() }, &dials))
+	go c.Serve(context.Background())
+	t.Cleanup(func() { _ = c.Close() }) //nolint:errcheck
+	require.Eventually(t, func() bool { _, ok := c.Session(env.srvPK); return ok }, 15*time.Second, 50*time.Millisecond)
+
+	// Refused once: backed off, no relay session.
+	require.True(t, c.SetRelayPeers([]cipher.PubKey{relayPK}, 70))
+	require.Eventually(t, func() bool { return dials.Load() >= 1 && c.relayBackedOff(relayPK) }, 15*time.Second, 50*time.Millisecond)
+	require.False(t, c.hasRelaySession())
+
+	// The same nomination while still backed off is a no-op.
+	require.False(t, c.SetRelayPeers([]cipher.PubKey{relayPK}, 70))
+	time.Sleep(300 * time.Millisecond)
+	require.False(t, c.hasRelaySession())
+
+	// Backoff lapses (and the relay now admits us): the next unchanged
+	// nomination wakes the loop and the client attaches.
+	admit.Store(true)
+	c.noteRelayFailure(relayPK, -time.Second)
+	require.False(t, c.SetRelayPeers([]cipher.PubKey{relayPK}, 70), "the set did not change")
+	require.Eventually(t, c.hasRelaySession, 15*time.Second, 50*time.Millisecond)
+}


### PR DESCRIPTION
After a nominee's backoff expired nothing re-ran the serve loop's pass: the loop was parked on errCh and the visor's 10 s re-nomination was a no-op for an unchanged set. The desk tab never re-attached after its first relay dial timed out at boot.

An unchanged nomination now wakes the loop while a nominee is pending (dialable, no relay session). A backed-off skynet entry, nominee or seeded, is skipped inside the current pass instead of re-dialed, which also removes the redial the refused-peer test flaked on.