### PR TITLE
fix(dmsg): a relay forwards via the server that last reached the destination first

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -396,6 +396,7 @@ func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Conf
 	c.relaySessions = make(map[cipher.PubKey]*SessionCommon)
 	c.EntityCommon.relaySessionLookup = c.relaySession
 	c.EntityCommon.forwardSessionsFunc = c.relayForwardSessions
+	c.EntityCommon.forwardedFunc = c.setCachedRoute
 
 	// Init callback: on set session.
 	c.EntityCommon.setSessionCallback = func(ctx context.Context) error {

--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -184,8 +184,18 @@ func (ce *Client) relayForwardSessions(dst cipher.PubKey) []*SessionCommon {
 	}
 	ordered := append(ce.sortedDelegatedSessions(delegated), ce.sortedMeshSessions(delegated)...)
 	out := make([]*SessionCommon, 0, len(ordered))
+	// The server that last reached dst — from this client's own dials or an
+	// earlier forward — goes first. The deployment services have no client
+	// entry, so without it every relayed request walked the mesh in latency
+	// order and burned a handshake timeout on each server that did not hold
+	// the service.
+	if cached, ok := ce.getCachedRoute(dst); ok {
+		if ses, ok := ce.session(cached); ok && ses.carrier != CarrierSkynet {
+			out = append(out, ses)
+		}
+	}
 	for _, s := range ordered {
-		if s.carrier == CarrierSkynet {
+		if s.carrier == CarrierSkynet || (len(out) > 0 && s.SessionCommon == out[0]) {
 			continue
 		}
 		out = append(out, s.SessionCommon)

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -158,6 +158,9 @@ type EntityCommon struct {
 	// through AcceptRelaySession, so a destination that is itself attached to
 	// this relay is bridged locally instead of forwarded. nil on servers.
 	relaySessionLookup func(pk cipher.PubKey) (*SessionCommon, bool)
+	// forwardedFunc, if set, is told which peer carried a relayed request to
+	// dst, so the next request for dst can try that peer first.
+	forwardedFunc func(dst, peer cipher.PubKey)
 
 	// acceptPeerAnnouncements, peerAnnounceAllowedFunc and
 	// promoteToPeerFunc support inbound peer announcements: a server

--- a/pkg/dmsg/dmsg/relay_nominee_test.go
+++ b/pkg/dmsg/dmsg/relay_nominee_test.go
@@ -243,3 +243,44 @@ func TestRelayNominee_RetriesAfterBackoffLapses(t *testing.T) {
 	require.False(t, c.SetRelayPeers([]cipher.PubKey{relayPK}, 70), "the set did not change")
 	require.Eventually(t, c.hasRelaySession, 15*time.Second, 50*time.Millisecond)
 }
+
+// The relay forwards via the server that last reached the destination first,
+// and learns that server from a forward it carried.
+func TestRelayForwardSessions_CachedRouteFirst(t *testing.T) {
+	env := newRelayedTestEnv(t, nil)
+	env.relay.maxRelayedStreams = 8
+	relayPK := env.relay.LocalPK()
+	other := addServer(t, env.dc, "cached-other")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	entry, err := env.dc.Entry(ctx, other)
+	require.NoError(t, err)
+	require.NoError(t, env.relay.EnsureSession(ctx, entry))
+
+	// No cache: the destination's delegated server (srv) leads.
+	got := env.relay.relayForwardSessions(env.dstPK)
+	require.Len(t, got, 2)
+	require.Equal(t, env.srvPK, got[0].RemotePK())
+	// A cached route to the other server outranks it.
+	env.relay.setCachedRoute(env.dstPK, other)
+	got = env.relay.relayForwardSessions(env.dstPK)
+	require.Len(t, got, 2, "the cached server is not listed twice")
+	require.Equal(t, other, got[0].RemotePK())
+	env.relay.evictCachedRoute(env.dstPK)
+
+	// A forward the relay carries teaches it the route.
+	c, _ := newSkynetDialer(t, env, "cached-dialer")
+	var dials atomic.Int32
+	c.SetSessionDialer(skynetDialer(t, env.relay, relayPK, nil, &dials))
+	require.Eventually(t, func() bool { _, ok := c.Session(relayPK); return ok }, 15*time.Second, 50*time.Millisecond)
+	accepted := acceptOne(t, env.dstLis)
+	str, err := c.DialStream(ctx, Addr{PK: env.dstPK, Port: relayedDstPort})
+	require.NoError(t, err)
+	defer str.Close() //nolint:errcheck
+	s := <-accepted
+	require.NotNil(t, s)
+	defer s.Close() //nolint:errcheck
+	learned, ok := env.relay.getCachedRoute(env.dstPK)
+	require.True(t, ok)
+	require.Equal(t, env.srvPK, learned)
+}

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -365,6 +365,10 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 		return err
 	}
 	log.Debug("Forwarded stream request.")
+	if ss.relayInbound && ss.entity.forwardedFunc != nil {
+		// The peer accepted: remember it for the next request to this dst.
+		ss.entity.forwardedFunc(req.DstAddr.PK, dst.RemotePK())
+	}
 
 	if err := ss.writeObject(yStr, resp); err != nil {
 		// Original client disconnected (or stream broke) while we were


### PR DESCRIPTION
For the desk tab's relayed requests the host walked its server sessions in latency order. The deployment services have no client entry, so each server that did not hold the service cost a handshake timeout before the next was tried: the host log showed 7 `Peer forward failed` (`i/o deadline reached`) next to 7 successful forwards, and the tab's 5 s health probes read DOWN while the forward eventually succeeded behind them.

The relay now tries its cached route for the destination first (its own dials to the services fill that cache) and learns a route from every forward a peer accepts. Test covers the ordering and the learning.