### PR TITLE
fix(router): a sole leg that delivers payload is not a black hole

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -72,15 +72,19 @@ const (
 	legBlackHoleMinTopBytes = 128 * 1024
 	// soleBlackHole* gate the sole-leg black-hole reaping (see soleLegBlackHoled).
 	// A group down to one active leg whose route has SENT more than
-	// soleBlackHoleSentFloor (a real request went out) but RECEIVED less than
-	// soleBlackHoleRecvFloor (essentially nothing came back), held for
-	// soleBlackHoleTicks consecutive data-progress intervals, is a dead route the
-	// two ordinary prunes cannot see — dial a replacement. The recv floor is a few
-	// packets of handshake/headers; the sent floor rejects an idle group that
-	// never requested anything; the tick count (≥15s at a 5s cadence) rejects a
-	// merely-slow origin. recv is CUMULATIVE, so a route that ever delivered bulk
-	// is never flagged — this targets dead-from-establishment routes.
-	soleBlackHoleRecvFloor = 16 * 1024
+	// soleBlackHoleSentFloor (a real request went out) but DELIVERED no payload at
+	// all, held for soleBlackHoleTicks consecutive data-progress intervals, is a
+	// dead route the two ordinary prunes cannot see — dial a replacement. The
+	// judgment is on the leg's PayloadBytes (unique in-order payload), not its raw
+	// RecvBytes: the raw count includes the handshake, liveness pongs and SACKs,
+	// which a black-holed route still receives, so it used to be held against a
+	// 16 KiB floor — and a working route carrying a light session (a proxy client
+	// whose responses are a few hundred bytes) never cleared that floor and was
+	// replaced every 15 s, tearing down the session it was serving. The sent
+	// floor rejects an idle group that never requested anything; the tick count
+	// (≥15s at a 5s cadence) rejects a merely-slow origin. Both counters are
+	// CUMULATIVE, so a route that ever delivered payload is never flagged — this
+	// targets dead-from-establishment routes.
 	soleBlackHoleSentFloor = 256
 	soleBlackHoleTicks     = 3
 	// reorderStallInterval is how often the receive side checks for a reorder
@@ -2342,9 +2346,9 @@ func (rg *RouteGroup) legDataProgressServiceFn(_ time.Duration) {
 	// selectDataStalledLegs bails at active<2 (no leader to compare against). So
 	// a --mux 1 client that lands a black-holing route stays dead forever — the
 	// establishment lottery this fixes. Detect it directly: the sole active leg
-	// has SENT a request (cumulative sent past a floor) yet RECEIVED almost
-	// nothing (cumulative recv under a small floor) for several consecutive
-	// intervals, so dial a REPLACEMENT (bypassing the target<=1 self-heal gate).
+	// has SENT a request (cumulative sent past a floor) yet DELIVERED no payload
+	// (cumulative unique payload still zero) for several consecutive intervals,
+	// so dial a REPLACEMENT (bypassing the target<=1 self-heal gate).
 	// Once a second leg is up the ordinary black-hole prune sheds the dead one.
 	activeCnt, soleSent, soleRecv := 0, uint64(0), uint64(0)
 	for i, tp := range tpsCopy {
@@ -2352,7 +2356,7 @@ func (rg *RouteGroup) legDataProgressServiceFn(_ time.Duration) {
 			continue
 		}
 		activeCnt++
-		soleSent, soleRecv = stats[i].SentBytes, stats[i].RecvBytes
+		soleSent, soleRecv = stats[i].SentBytes, stats[i].PayloadBytes
 	}
 	// Direction-aware exemption: under unidirectional assignment (CapUniDir) the
 	// sole active leg is the light-direction leg (the direct upload leg on a
@@ -2366,7 +2370,7 @@ func (rg *RouteGroup) legDataProgressServiceFn(_ time.Duration) {
 	} else if soleLegBlackHoled(activeCnt, soleSent, soleRecv) {
 		rg.soleBHTicks++
 		if rg.soleBHTicks >= soleBlackHoleTicks {
-			rg.logger.Warnf("sole-leg black-hole: only active route sent %dB but received %dB over %v — dialing a replacement route",
+			rg.logger.Warnf("sole-leg black-hole: only active route sent %dB but delivered %dB of payload over %v — dialing a replacement route",
 				soleSent, soleRecv, time.Duration(soleBlackHoleTicks)*legDataProgressInterval)
 			rg.soleBHTicks = 0
 			go rg.healReplaceSoleLeg()
@@ -2418,11 +2422,12 @@ type legRecvDelta struct {
 // mux via SACK retransmits. It never selects so many that fewer than one active
 // leg would remain. Pure (no rg state / locks) so it is unit-tested directly.
 // soleLegBlackHoled reports whether a group's ONLY active leg is a data
-// black-hole: a request was sent (cumulative sent past the floor) but almost
-// nothing came back (cumulative recv under the floor). Pure so it is unit-tested
-// directly; the caller applies the consecutive-interval hysteresis and the dial.
-func soleLegBlackHoled(activeCnt int, sent, recv uint64) bool {
-	return activeCnt == 1 && sent > soleBlackHoleSentFloor && recv < soleBlackHoleRecvFloor
+// black-hole: a request was sent (cumulative sent past the floor) but no payload
+// ever came back (cumulative unique payload delivered is zero). Pure so it is
+// unit-tested directly; the caller applies the consecutive-interval hysteresis
+// and the dial.
+func soleLegBlackHoled(activeCnt int, sent, payload uint64) bool {
+	return activeCnt == 1 && sent > soleBlackHoleSentFloor && payload == 0
 }
 
 // parkStalledLegs decides whether data-stalled legs are PARKED to warm standby

--- a/pkg/router/route_group_latencyband_test.go
+++ b/pkg/router/route_group_latencyband_test.go
@@ -485,9 +485,14 @@ func TestDemoteStalledLegsParksNotRemoves(t *testing.T) {
 }
 
 func TestSoleLegBlackHoled(t *testing.T) {
-	// active==1, sent a request, got ~nothing -> black-hole
-	if !soleLegBlackHoled(1, 500, 160) {
-		t.Fatal("sole leg with sent=500 recv=160 should be flagged")
+	// active==1, sent a request, no payload ever delivered -> black-hole
+	if !soleLegBlackHoled(1, 500, 0) {
+		t.Fatal("sole leg with sent=500 payload=0 should be flagged")
+	}
+	// delivered a small response -> not a black-hole: a light session (a proxy
+	// client fetching a few hundred bytes) never reaches bulk, yet the route works
+	if soleLegBlackHoled(1, 500, 160) {
+		t.Fatal("sole leg that delivered payload must NOT be flagged")
 	}
 	// received bulk -> not a black-hole (route delivered)
 	if soleLegBlackHoled(1, 500, 20_000) {
@@ -498,11 +503,11 @@ func TestSoleLegBlackHoled(t *testing.T) {
 		t.Fatal("idle sole leg (no request sent) must NOT be flagged")
 	}
 	// more than one active leg -> the ordinary data-progress prune handles it
-	if soleLegBlackHoled(2, 500, 160) {
+	if soleLegBlackHoled(2, 500, 0) {
 		t.Fatal("multi-leg group must NOT use the sole-leg path")
 	}
 	// zero active legs -> not applicable
-	if soleLegBlackHoled(0, 500, 160) {
+	if soleLegBlackHoled(0, 500, 0) {
 		t.Fatal("zero active legs must NOT be flagged")
 	}
 }


### PR DESCRIPTION
The sole-leg black-hole reaper compared a route's raw RecvBytes against a 16 KiB floor. That count includes the handshake, liveness pongs and SACKs, so a light session — a proxy client whose responses are a few hundred bytes — never cleared it, and the reaper dialled a replacement route every 15 s, tearing down the yamux session it was serving. On a browser visor this made skysocks-client's end-to-end verification fail on every exit: each `sole-leg black-hole … dialing a replacement route` was followed within seconds by `CONNECT: EOF`, while a manual SOCKS fetch through the same :1080 returned 200 (measured in a desk tab: recv 366 B–6 KB per 15 s window, six reaps in two minutes).

Judge by the leg's PayloadBytes (unique in-order payload) instead: a route that has sent a request but delivered no payload is the black hole; any delivered payload means the route works. Unit test updated.