### PR TITLE
fix(visor): proxy exit verification rejected every working exit

### DIFF
--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -393,8 +393,11 @@ func (v *Visor) verifyProxyExit(ctx context.Context, log *logging.Logger) bool {
 			log.WithError(err).Debug("proxy verify: CONNECT failed; retrying within window")
 			continue
 		}
-		_ = conn.SetDeadline(time.Now().Add(15 * time.Second))                                         //nolint:errcheck
-		_, _ = conn.Write([]byte("GET / HTTP/1.0\r\nHost: neverssl.com\r\nConnection: close\r\n\r\n")) //nolint:errcheck
+		_ = conn.SetDeadline(time.Now().Add(15 * time.Second)) //nolint:errcheck
+		// The User-Agent matters: neverssl.com (Apache) answers a header-less
+		// request with 403. relayedResponseOK no longer judges the code, but a
+		// 200 is the reply the read limit below was sized for.
+		_, _ = conn.Write([]byte("GET / HTTP/1.0\r\nHost: neverssl.com\r\nUser-Agent: skywire-visor\r\nConnection: close\r\n\r\n")) //nolint:errcheck
 		// Read a bounded prefix, not one byte: the verdict needs the status line,
 		// the whole header block and enough body for the pre-header fallback
 		// marker, which sits ~3 KiB into the interstitial. The request asked for
@@ -414,11 +417,17 @@ func (v *Visor) verifyProxyExit(ctx context.Context, log *logging.Logger) bool {
 
 // relayedResponseOK reports whether the bytes read back through the skysocks
 // listener are a real reply RELAYED from the exit. Two things have to hold: it
-// must be a well-formed HTTP/1.x status line with a 2xx/3xx code (a zombie exit
-// that accepts the CONNECT and then relays nothing produces neither), and it
-// must not be one of the responses the local client synthesizes when it has no
-// session — those are ordinary-looking 200s carrying an HTML page, and treating
-// one as proof of life is the bug this guards.
+// must be a well-formed HTTP/1.x status line (a zombie exit that accepts the
+// CONNECT and then relays nothing produces none), and it must not be one of the
+// responses the local client synthesizes when it has no session — those are
+// ordinary-looking 200s carrying an HTML page, and treating one as proof of
+// life is the bug this guards. The status CODE is deliberately not judged: a
+// 4xx/5xx still came from the origin through the exit, which is all that is
+// being proven — the skysocks exit never synthesizes HTTP, and the origin's
+// policy toward the request says nothing about the exit's health. The old
+// 2xx/3xx-only rule, paired with a request that carried no User-Agent,
+// rejected every working exit once neverssl.com started answering such
+// requests with 403.
 func relayedResponseOK(raw []byte) bool {
 	line, _, ok := bytes.Cut(raw, []byte("\r\n"))
 	if !ok || !bytes.HasPrefix(line, []byte("HTTP/1.")) {
@@ -429,7 +438,7 @@ func relayedResponseOK(raw []byte) bool {
 		return false
 	}
 	code, err := strconv.Atoi(string(f[1]))
-	if err != nil || code < 200 || code >= 400 {
+	if err != nil || code < 100 || code >= 600 {
 		return false
 	}
 	return !proxyinterstitial.IsSyntheticResponse(raw)

--- a/pkg/visor/init_apps_proxy_verify_test.go
+++ b/pkg/visor/init_apps_proxy_verify_test.go
@@ -24,11 +24,16 @@ func TestRelayedResponseOK(t *testing.T) {
 		raw  string
 		want bool
 	}{
-		"relayed 200":                      {"HTTP/1.1 200 OK\r\nServer: nginx\r\n\r\n<html>hi</html>", true},
-		"relayed 301":                      {"HTTP/1.1 301 Moved Permanently\r\nLocation: /x\r\n\r\n", true},
-		"relayed HTTP/1.0":                 {"HTTP/1.0 200 OK\r\n\r\nbody", true},
-		"upstream 404":                     {"HTTP/1.1 404 Not Found\r\n\r\n", false},
-		"upstream 502":                     {"HTTP/1.1 502 Bad Gateway\r\n\r\n", false},
+		"relayed 200":      {"HTTP/1.1 200 OK\r\nServer: nginx\r\n\r\n<html>hi</html>", true},
+		"relayed 301":      {"HTTP/1.1 301 Moved Permanently\r\nLocation: /x\r\n\r\n", true},
+		"relayed HTTP/1.0": {"HTTP/1.0 200 OK\r\n\r\nbody", true},
+		// An origin's 4xx/5xx still travelled through the exit — that is relay.
+		// neverssl.com answers a User-Agent-less request with 403; rejecting it
+		// failed every working exit.
+		"upstream 403":                     {"HTTP/1.1 403 Forbidden\r\n\r\n<html>", true},
+		"upstream 404":                     {"HTTP/1.1 404 Not Found\r\n\r\n", true},
+		"upstream 502":                     {"HTTP/1.1 502 Bad Gateway\r\n\r\n", true},
+		"impossible code":                  {"HTTP/1.1 999 Nope\r\n\r\n", false},
 		"not HTTP at all":                  {"garbage bytes from a zombie exit", false},
 		"truncated status line":            {"HTTP/1.1 200 OK", false},
 		"status line without a code":       {"HTTP/1.1\r\n\r\n", false},


### PR DESCRIPTION
`verifyProxyExit` sent a GET with no User-Agent and accepted only a 2xx/3xx status. neverssl.com answers a header-less request with 403 (`curl -A "" http://neverssl.com/` → 403; with a UA → 200), so the verdict was "failed end-to-end verification" on every exit and `proxy_client_auto` rotated exits forever — observed in a desk tab where a manual SOCKS fetch through the same :1080 returned 200 from two different exits while the loop kept rotating.

Send a User-Agent, and judge relay by "a well-formed status line came back that the local client did not synthesize": a 4xx/5xx still travelled from the origin through the exit, which is all the probe proves (the skysocks exit never synthesizes HTTP). The zombie-exit and interstitial cases are unchanged; tests updated.