### PR TITLE
fix(visor): route-setup hook skips transport types this visor has no client for

### DIFF
--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -123,6 +123,12 @@ func getRouteSetupHooks(ctx context.Context, v *Visor, log *logging.Logger) []ro
 			// wins, and the ~20 s STUN wait with it.
 			var lastErr error
 			for _, nType := range types.PreferredOrder(types.STCPR, types.SUDPH, types.DMSG) {
+				// A type this visor has no client for (a browser has no stcpr/sudph
+				// socket) can only fail with ErrUnknownNetwork — skip it rather than
+				// spend the retrier's three attempts (~4 s) on it at every dial.
+				if !tm.IsKnownNetwork(nType) {
+					continue
+				}
 				switch nType {
 				case types.DMSG:
 					// Same gate as EnsureBestTransport: a browser visor never


### PR DESCRIPTION
In a browser the route-setup hook still tried stcpr to every peer that advertises it. The transport manager has no stcpr client there, so each dial spent the retrier's three attempts (~4 s) on `save transport: unknown network type` before falling through — visible on every proxy exit dial in a desk tab's log.

Skip a type the manager does not know (`IsKnownNetwork`); the STCPR/SUDPH advertisement and STUN gates below are unchanged.