### PR TITLE
fix(dmsg): remember relay forward failures during the server rollout

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -333,11 +333,13 @@ type Client struct {
 	// relayPeers are the peers the visor nominated as relays (SetRelayPeers),
 	// relayPort the dmsg port their acceptors listen on, relayFailAt the
 	// per-nominee backoff after a failed dial. Guarded by relayMx.
-	relayPeers  map[cipher.PubKey]struct{}
-	relayPort   uint16
-	relayFailAt map[cipher.PubKey]time.Time
-	relayGen    uint64 // bumped on every nomination change; the serve loop restarts its pass on a new value
-	relayMx     sync.Mutex
+	relayPeers      map[cipher.PubKey]struct{}
+	relayPort       uint16
+	relayFailAt     map[cipher.PubKey]time.Time
+	relayGen        uint64                      // bumped on every nomination change; the serve loop restarts its pass on a new value
+	relayForwardBad map[dstPeer]time.Time       // relay side: peers that recently failed for a destination
+	relayDialSkip   map[cipher.PubKey]time.Time // dialer side: destinations the relay recently failed to reach
+	relayMx         sync.Mutex
 }
 
 // AddDiscovery registers an additional dmsg-discovery this client
@@ -397,6 +399,7 @@ func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Conf
 	c.EntityCommon.relaySessionLookup = c.relaySession
 	c.EntityCommon.forwardSessionsFunc = c.relayForwardSessions
 	c.EntityCommon.forwardedFunc = c.setCachedRoute
+	c.EntityCommon.forwardFailedFunc = c.noteRelayForwardFailure
 
 	// Init callback: on set session.
 	c.EntityCommon.setSessionCallback = func(ctx context.Context) error {

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -46,11 +46,15 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	// itself — so it goes before the discovery lookup (the deployment services
 	// have no client entry and would otherwise take the connected-servers
 	// fallback), before the cached route, and before any server session.
-	if relaySessions := ce.sortedRelaySessions(); len(relaySessions) > 0 {
+	if relaySessions := ce.sortedRelaySessions(); len(relaySessions) > 0 && !ce.relayDialSkipped(addr.PK) {
 		if stream, ok := ce.sequentialPhaseDial(ctx, addr, relaySessions, len(relaySessions)); ok {
 			ce.dialFailClear(addr.PK)
 			return stream, nil
 		}
+		// The relay could not reach this destination (its servers may predate
+		// #4703): leave it out of the ladder for this destination for a while
+		// so the server phases are not delayed by the same failure each time.
+		ce.noteRelayDialFailure(addr.PK)
 	}
 
 	entry, discErr := ce.getClientEntryCached(ctx, addr.PK)

--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -189,18 +189,25 @@ func (ce *Client) relayForwardSessions(dst cipher.PubKey) []*SessionCommon {
 	// entry, so without it every relayed request walked the mesh in latency
 	// order and burned a handshake timeout on each server that did not hold
 	// the service.
-	if cached, ok := ce.getCachedRoute(dst); ok {
+	if cached, ok := ce.getCachedRoute(dst); ok && !ce.relayForwardFailed(dst, cached) {
 		if ses, ok := ce.session(cached); ok && ses.carrier != CarrierSkynet {
 			out = append(out, ses)
 		}
 	}
+	// Peers that recently failed for dst go last: during the #4703 rollout a
+	// server without it lets a relayed request hit the handshake timeout.
+	var failed []*SessionCommon
 	for _, s := range ordered {
 		if s.carrier == CarrierSkynet || (len(out) > 0 && s.SessionCommon == out[0]) {
 			continue
 		}
+		if ce.relayForwardFailed(dst, s.RemotePK()) {
+			failed = append(failed, s.SessionCommon)
+			continue
+		}
 		out = append(out, s.SessionCommon)
 	}
-	return out
+	return append(out, failed...)
 }
 
 // relayFailureBackoff is how long a nominated relay that refused or failed a
@@ -399,5 +406,57 @@ func (ce *Client) relayBackedOff(pk cipher.PubKey) bool {
 	ce.relayMx.Lock()
 	defer ce.relayMx.Unlock()
 	until, ok := ce.relayFailAt[pk]
+	return ok && time.Now().Before(until)
+}
+
+// relayForwardFailureTTL is how long a (destination, peer) pair that failed a
+// relayed forward is demoted to the end of the relay's forwarding order.
+const relayForwardFailureTTL = 2 * time.Minute
+
+// relayDialSkipTTL is how long a dialer leaves the relay out of the ladder for
+// a destination the relay just failed to reach, so the server phases are not
+// delayed by a relay attempt that will fail the same way.
+const relayDialSkipTTL = time.Minute
+
+type dstPeer struct{ dst, peer cipher.PubKey }
+
+// noteRelayForwardFailure records that peer could not carry a relayed request
+// to dst (relay side), and evicts a cached route that pointed at it.
+func (ce *Client) noteRelayForwardFailure(dst, peer cipher.PubKey) {
+	ce.relayMx.Lock()
+	if ce.relayForwardBad == nil {
+		ce.relayForwardBad = make(map[dstPeer]time.Time)
+	}
+	ce.relayForwardBad[dstPeer{dst, peer}] = time.Now().Add(relayForwardFailureTTL)
+	ce.relayMx.Unlock()
+	if cached, ok := ce.getCachedRoute(dst); ok && cached == peer {
+		ce.evictCachedRoute(dst)
+	}
+}
+
+// relayForwardFailed reports whether peer recently failed to carry a relayed
+// request to dst.
+func (ce *Client) relayForwardFailed(dst, peer cipher.PubKey) bool {
+	ce.relayMx.Lock()
+	defer ce.relayMx.Unlock()
+	until, ok := ce.relayForwardBad[dstPeer{dst, peer}]
+	return ok && time.Now().Before(until)
+}
+
+// noteRelayDialFailure records (dialer side) that the relay could not reach dst.
+func (ce *Client) noteRelayDialFailure(dst cipher.PubKey) {
+	ce.relayMx.Lock()
+	if ce.relayDialSkip == nil {
+		ce.relayDialSkip = make(map[cipher.PubKey]time.Time)
+	}
+	ce.relayDialSkip[dst] = time.Now().Add(relayDialSkipTTL)
+	ce.relayMx.Unlock()
+}
+
+// relayDialSkipped reports whether dials to dst currently bypass the relay.
+func (ce *Client) relayDialSkipped(dst cipher.PubKey) bool {
+	ce.relayMx.Lock()
+	defer ce.relayMx.Unlock()
+	until, ok := ce.relayDialSkip[dst]
 	return ok && time.Now().Before(until)
 }

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -161,6 +161,9 @@ type EntityCommon struct {
 	// forwardedFunc, if set, is told which peer carried a relayed request to
 	// dst, so the next request for dst can try that peer first.
 	forwardedFunc func(dst, peer cipher.PubKey)
+	// forwardFailedFunc, if set, is told which peer failed to carry a relayed
+	// request to dst, so it is not the first tried next time.
+	forwardFailedFunc func(dst, peer cipher.PubKey)
 
 	// acceptPeerAnnouncements, peerAnnounceAllowedFunc and
 	// promoteToPeerFunc support inbound peer announcements: a server

--- a/pkg/dmsg/dmsg/relay_nominee_test.go
+++ b/pkg/dmsg/dmsg/relay_nominee_test.go
@@ -284,3 +284,65 @@ func TestRelayForwardSessions_CachedRouteFirst(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, env.srvPK, learned)
 }
+
+// A peer that failed to carry a relayed request to dst is demoted behind the
+// others (and a cached route to it dropped); the demotion lapses.
+func TestRelayForwardSessions_FailedPeerDemoted(t *testing.T) {
+	env := newRelayedTestEnv(t, nil)
+	other := addServer(t, env.dc, "demoted-other")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	entry, err := env.dc.Entry(ctx, other)
+	require.NoError(t, err)
+	require.NoError(t, env.relay.EnsureSession(ctx, entry))
+
+	env.relay.setCachedRoute(env.dstPK, env.srvPK)
+	got := env.relay.relayForwardSessions(env.dstPK)
+	require.Equal(t, env.srvPK, got[0].RemotePK())
+
+	env.relay.noteRelayForwardFailure(env.dstPK, env.srvPK)
+	_, cached := env.relay.getCachedRoute(env.dstPK)
+	require.False(t, cached, "a cached route to the failing peer is dropped")
+	got = env.relay.relayForwardSessions(env.dstPK)
+	require.Len(t, got, 2)
+	require.Equal(t, other, got[0].RemotePK(), "the failing peer goes last")
+	require.Equal(t, env.srvPK, got[1].RemotePK(), "but is still tried")
+
+	env.relay.relayMx.Lock()
+	env.relay.relayForwardBad[dstPeer{env.dstPK, env.srvPK}] = time.Now().Add(-time.Second)
+	env.relay.relayMx.Unlock()
+	got = env.relay.relayForwardSessions(env.dstPK)
+	require.Equal(t, env.srvPK, got[0].RemotePK(), "the demotion lapses")
+}
+
+// A dialer whose relay could not reach dst leaves the relay out of the ladder
+// for that destination for a while, and the server session carries the stream.
+func TestRelayNominee_DialSkipsRelayAfterItFails(t *testing.T) {
+	env := newRelayedTestEnv(t, nil)
+	require.Equal(t, 0, env.relay.maxRelayedStreams, "this relay refuses every stream")
+	relayPK := env.relay.LocalPK()
+
+	pk, sk := GenKeyPair(t, "nominee-skip")
+	c := NewClient(pk, sk, env.dc, &Config{MinSessions: 1})
+	c.SetLogger(logging.MustGetLogger("nominee-skip"))
+	var dials atomic.Int32
+	c.SetSessionDialer(skynetDialer(t, env.relay, relayPK, nil, &dials))
+	go c.Serve(context.Background())
+	t.Cleanup(func() { _ = c.Close() }) //nolint:errcheck
+	require.Eventually(t, func() bool { _, ok := c.Session(env.srvPK); return ok }, 15*time.Second, 50*time.Millisecond)
+	c.SetRelayPeers([]cipher.PubKey{relayPK}, 70)
+	require.Eventually(t, c.hasRelaySession, 15*time.Second, 50*time.Millisecond)
+
+	accepted := acceptOne(t, env.dstLis)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	str, err := c.DialStream(ctx, Addr{PK: env.dstPK, Port: relayedDstPort})
+	require.NoError(t, err)
+	defer str.Close() //nolint:errcheck
+	s := <-accepted
+	require.NotNil(t, s)
+	defer s.Close() //nolint:errcheck
+	require.Equal(t, 0, env.relay.RelayedStreams())
+	require.True(t, c.relayDialSkipped(env.dstPK), "the relay is skipped for this destination now")
+	echoCheck(t, str, s)
+}

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -470,6 +470,9 @@ func (ss *ServerSession) forwardViaPeer(log logrus.FieldLogger, yStr io.ReadWrit
 			return nil
 		}
 		log.WithError(err).Debug("Peer forward failed, trying next.")
+		if ss.relayInbound && ss.entity.forwardFailedFunc != nil {
+			ss.entity.forwardFailedFunc(req.DstAddr.PK, peer.RemotePK())
+		}
 	}
 
 	ss.m.RecordStream(metrics.DeltaFailed)


### PR DESCRIPTION
The two largest deployment dmsg servers (about 1850 clients each) run builds that predate #4703, and a relayed request sent to them hits the handshake timeout instead of being answered or refused. The host's cached route for a service points at such a server because its own dials succeed there, so the desk tab's 5 s health probes read DOWN while the host walked its servers.

The relay now demotes a peer that failed to carry a request for a destination (two minutes) and drops a cached route to it; a dialer whose relay failed for a destination leaves the relay out of its ladder for that destination for a minute, so the server phases are not delayed by the same failure each time. Rolling #4703 to those servers remains the real fix.