### PR TITLE
fix(visor): US spelling in proxy-verify comments (misspell lint)

### DIFF
--- a/pkg/visor/init_apps_proxy_verify_test.go
+++ b/pkg/visor/init_apps_proxy_verify_test.go
@@ -27,7 +27,7 @@ func TestRelayedResponseOK(t *testing.T) {
 		"relayed 200":      {"HTTP/1.1 200 OK\r\nServer: nginx\r\n\r\n<html>hi</html>", true},
 		"relayed 301":      {"HTTP/1.1 301 Moved Permanently\r\nLocation: /x\r\n\r\n", true},
 		"relayed HTTP/1.0": {"HTTP/1.0 200 OK\r\n\r\nbody", true},
-		// An origin's 4xx/5xx still travelled through the exit — that is relay.
+		// An origin's 4xx/5xx still traveled through the exit — that is relay.
 		// neverssl.com answers a User-Agent-less request with 403; rejecting it
 		// failed every working exit.
 		"upstream 403":                     {"HTTP/1.1 403 Forbidden\r\n\r\n<html>", true},


### PR DESCRIPTION
golangci-lint's misspell check flags `travelled` (introduced in #4720) on the darwin/windows lint lanes. Comment-only change.