### PR TITLE
fix(visor): reload the desk when the served skywire.wasm is rebuilt

### DIFF
--- a/pkg/visor/hypervisor_desk_test.go
+++ b/pkg/visor/hypervisor_desk_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
@@ -234,11 +235,7 @@ func TestNativeDeskServing(t *testing.T) {
 // the shared skeleton: `hv serve`'s desk must still wire the wasm assets and
 // the harness injection anchor exactly as before.
 func TestDeskShellHTMLWasmMode(t *testing.T) {
-	page := string(deskShellHTML(
-		`<script src="/wasm_exec.js?variant=go"></script>`+"\n"+
-			`<script src="/browse.js"></script>`+"\n"+
-			`<script src="/desk-boot.js"></script>`,
-		deskWasmBootOpts(false, 0)))
+	page := string(deskShellHTML(wasmDeskScripts(), deskWasmBootOpts(false, 0)))
 	for _, want := range []string{
 		"deskWasmURL: '/wasm-visor.wasm'",
 		"wasmURL: '/skywire.wasm'",
@@ -246,6 +243,11 @@ func TestDeskShellHTMLWasmMode(t *testing.T) {
 		"skywireDeskBoot(",
 		// The exact tag ServeWasm's --harness injection keys on.
 		`<script src="/desk-boot.js"></script>`,
+		// The served-build stamp the poller compares against, and the poller
+		// itself — without both, a desk tab never learns that the skywire.wasm
+		// its visor runs has been rebuilt (one sat 22 h on a stale blob).
+		`window.__SKYWIRE_WASM_VERSION__="` + servedVersionToken + `"`,
+		`<script src="/autoupdate.js"></script>`,
 	} {
 		if !strings.Contains(page, want) {
 			t.Errorf("wasm desk page lacks %s", want)
@@ -253,6 +255,73 @@ func TestDeskShellHTMLWasmMode(t *testing.T) {
 	}
 	if strings.Contains(page, "__DESK_SCRIPTS__") || strings.Contains(page, "__DESK_OPTS__") {
 		t.Error("template placeholders leaked into the rendered page")
+	}
+	// The poller must run before desk-boot, so it is armed even if boot fails.
+	if strings.Index(page, "/autoupdate.js") > strings.Index(page, "/desk-boot.js") {
+		t.Error("autoupdate.js must be included before desk-boot.js")
+	}
+	rendered := string(renderServedVersion([]byte(page), "abc-def"))
+	if strings.Contains(rendered, servedVersionToken) || !strings.Contains(rendered, `window.__SKYWIRE_WASM_VERSION__="abc-def"`) {
+		t.Error("served-version token not filled in the rendered page")
+	}
+}
+
+// TestServedUIVersionTracksExecWasm pins that the native port's /api/ui-version
+// — what the desk's poller compares against — changes when the skywire command
+// module it serves changes (appears, or is rebuilt in place), and that the
+// served desk page boots with exactly the value the endpoint answers, so a
+// poll compares like with like.
+func TestServedUIVersionTracksExecWasm(t *testing.T) {
+	hv, _ := deskTestHypervisor(t)
+	h := hv.uiHandler()
+	get := func(path string) string {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET %s: status=%d", path, w.Code)
+		}
+		return w.Body.String()
+	}
+	// /api/ui-version is mounted on the API router, not uiHandler; ask its
+	// handler directly.
+	version := func() string {
+		w := httptest.NewRecorder()
+		hv.getUIVersion()(w, httptest.NewRequest(http.MethodGet, "/api/ui-version", nil))
+		return w.Body.String()
+	}
+	v0 := version()
+	if v0 == "" {
+		t.Fatal("/api/ui-version is empty with UI assets present")
+	}
+	if !strings.Contains(get("/"), `window.__SKYWIRE_UI_VERSION__="`+v0+`"`) {
+		t.Errorf("desk page does not boot with the polled version %q", v0)
+	}
+
+	// A command module appears (hypervisor.wasm_serve.exec_wasm).
+	p := filepath.Join(t.TempDir(), "skywire.wasm")
+	if err := os.WriteFile(p, []byte("build one"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t0 := time.Date(2026, 9, 8, 9, 38, 0, 0, time.UTC)
+	if err := os.Chtimes(p, t0, t0); err != nil {
+		t.Fatal(err)
+	}
+	hv.c.WasmServe = &visorconfig.WasmServeConf{ExecWasm: p}
+	v1 := version()
+	if v1 == v0 {
+		t.Fatalf("version %q did not change when a command module appeared", v1)
+	}
+	if !strings.Contains(get("/"), `window.__SKYWIRE_UI_VERSION__="`+v1+`"`) {
+		t.Errorf("desk page does not boot with the polled version %q", v1)
+	}
+
+	// The module is rebuilt in place while the server runs.
+	t1 := t0.Add(5 * time.Hour)
+	if err := os.Chtimes(p, t1, t1); err != nil {
+		t.Fatal(err)
+	}
+	if v2 := version(); v2 == v1 {
+		t.Fatalf("version %q did not change when the command module was rebuilt", v2)
 	}
 }
 

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -236,12 +236,11 @@ func (hv *Hypervisor) serveInjectedIndex(w http.ResponseWriter, r *http.Request,
 		fallback.ServeHTTP(w, r)
 		return
 	}
-	// Stamp the served bundle's fingerprint + a poller that reloads the tab when
-	// a newer bundle is served (after the visor binary updates its embedded UI),
-	// so an open dashboard never sits on a stale build. Mirrors the wasm
-	// visor's autoupdate.js. The fingerprint is a hash of index.html, which
-	// references the content-hashed chunk filenames — it changes iff the UI does.
-	ver := uiVersionHash(b)
+	// Stamp the served build's fingerprint + a poller that reloads the tab when
+	// a newer build is served (a visor binary with a new embedded UI or desk
+	// client, or a rebuilt skywire.wasm), so an open dashboard never sits on a
+	// stale build. Mirrors the wasm visor's autoupdate.js.
+	ver := hv.servedUIVersion()
 	inject := []byte(`<script>window.__SKYWIRE_LOCAL_PK__=` + strconv.Quote(hv.visor.conf.PK.Hex()) +
 		`;window.__SKYWIRE_UI_VERSION__=` + strconv.Quote(ver) + `;` + browseOriginInjectJS(hv.visor) + `</script>` +
 		`<script src="browse.js"></script>` +
@@ -274,15 +273,7 @@ func (hv *Hypervisor) serveNativeDesk(w http.ResponseWriter) {
 	// dashboard beneath it see the same page and update together. The local
 	// PK doubles as the desk module's "this page is served by a visor" signal:
 	// its DirectLoader renders same-origin pages natively only when it is set.
-	var ver string
-	if hv.c.UIAssets != nil {
-		if f, err := hv.c.UIAssets.Open("index.html"); err == nil {
-			if b, rerr := io.ReadAll(f); rerr == nil {
-				ver = uiVersionHash(b)
-			}
-			_ = f.Close() //nolint:errcheck
-		}
-	}
+	ver := hv.servedUIVersion()
 	scripts := `<script>window.__SKYWIRE_LOCAL_PK__=` + strconv.Quote(localPK) +
 		`;window.__SKYWIRE_UI_VERSION__=` + strconv.Quote(ver) + `;` + browseJS + `</script>` + "\n" +
 		`<script src="/wasm_exec.js"></script>` + "\n" +
@@ -341,22 +332,33 @@ func uiVersionHash(indexHTML []byte) string {
 	return hex.EncodeToString(sum[:])[:16]
 }
 
-// getUIVersion → GET /api/ui-version : the current served-bundle fingerprint
+// servedUIVersion is the fingerprint the pages on this port boot with and poll
+// at /api/ui-version: the Angular bundle (index.html names its content-hashed
+// chunks), the desk client this binary embeds, and — when one is served — the
+// skywire command module on disk, stat'd per call. That last part is what a
+// rebuilt skywire.wasm changes: the desk's own visor is that module, and it
+// only ever runs a new one after a reload. Before it was folded in, a desk sat
+// on a blob that had been rebuilt several times.
+func (hv *Hypervisor) servedUIVersion() string {
+	var ui string
+	if hv.c.UIAssets != nil {
+		if f, err := hv.c.UIAssets.Open("index.html"); err == nil {
+			if b, rerr := io.ReadAll(f); rerr == nil {
+				ui = uiVersionHash(b)
+			}
+			_ = f.Close() //nolint:errcheck
+		}
+	}
+	return servedVersion(ui+"."+deskAssetsStamp(), hv.execWasmPath())
+}
+
+// getUIVersion → GET /api/ui-version : the current served-build fingerprint
 // (no-store), polled by the injected auto-reloader.
 func (hv *Hypervisor) getUIVersion() http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
-		var ver string
-		if hv.c.UIAssets != nil {
-			if f, err := hv.c.UIAssets.Open("index.html"); err == nil {
-				if b, rerr := io.ReadAll(f); rerr == nil {
-					ver = uiVersionHash(b)
-				}
-				_ = f.Close() //nolint:errcheck
-			}
-		}
 		w.Header().Set("Content-Type", "text/plain")
 		w.Header().Set("Cache-Control", "no-store")
-		_, _ = w.Write([]byte(ver)) //nolint:errcheck
+		_, _ = w.Write([]byte(hv.servedUIVersion())) //nolint:errcheck
 	}
 }
 

--- a/pkg/visor/servedversion.go
+++ b/pkg/visor/servedversion.go
@@ -1,0 +1,71 @@
+// Package visor pkg/visor/servedversion.go c3-vis-core
+package visor
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/wasmhv"
+)
+
+// servedVersionToken is the placeholder a pre-rendered page carries where its
+// served-build fingerprint goes; renderServedVersion fills it per request. The
+// pages are rendered once at startup, but the fingerprint is not a startup-time
+// constant: it folds in the skywire command module served from disk, which is
+// rebuilt in place while the server runs.
+const servedVersionToken = "__SKYWIRE_SERVED_VERSION__"
+
+// execWasmStamp fingerprints the skywire command module served at
+// /skywire.wasm from disk — size + mtime, stat'd on every call. The file is
+// ~170 MB and rebuilt in place, so hashing its content per poll is out, and a
+// hash taken once at startup would miss every rebuild, which is exactly what
+// the fingerprint exists to catch. Empty when there is no such file.
+func execWasmStamp(path string) string {
+	if path == "" {
+		return ""
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	h := sha256.New()
+	fmt.Fprintf(h, "%d:%d", fi.Size(), fi.ModTime().UnixNano())
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// deskAssetsStamp fingerprints the desk client the host binary embeds and
+// serves itself (desk-boot, the browse bundle, the exec worker) plus the
+// binary's version, once. A rebuilt host that changes any of them changes the
+// served build; one that changes none of them does not, and an open desk is
+// not reloaded for nothing.
+var deskAssetsStamp = sync.OnceValue(func() string {
+	h := sha256.New()
+	h.Write(wasmhv.DeskBootJS())
+	h.Write(wasmhv.BrowseJS)
+	h.Write(wasmhv.ExecWorkerJS())
+	h.Write(wasmhv.AutoUpdateJS)
+	h.Write([]byte(buildinfo.Version()))
+	return hex.EncodeToString(h.Sum(nil))[:16]
+})
+
+// servedVersion is the fingerprint a desk page boots with and polls for: the
+// served build plus the command module's stamp when one is served. It changes
+// iff a reload would load something different.
+func servedVersion(build, execWasmPath string) string {
+	if s := execWasmStamp(execWasmPath); s != "" {
+		return build + "-" + s
+	}
+	return build
+}
+
+// renderServedVersion fills a pre-rendered page's servedVersionToken with the
+// current fingerprint. The token is hex/dash-free of quoting hazards on both
+// sides, so it sits inside a JS string literal in the page.
+func renderServedVersion(page []byte, version string) []byte {
+	return bytes.ReplaceAll(page, []byte(servedVersionToken), []byte(version))
+}

--- a/pkg/visor/servedversion_test.go
+++ b/pkg/visor/servedversion_test.go
@@ -1,0 +1,58 @@
+// Package visor pkg/visor/servedversion_test.go c3-vis-core
+package visor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecWasmStamp pins the command-module stamp: absent → empty, present →
+// stable while the file is untouched and different once it is rebuilt in
+// place (size or mtime), stat'd fresh on every call rather than cached.
+func TestExecWasmStamp(t *testing.T) {
+	require.Empty(t, execWasmStamp(""))
+	require.Empty(t, execWasmStamp(filepath.Join(t.TempDir(), "missing.wasm")))
+
+	p := filepath.Join(t.TempDir(), "skywire.wasm")
+	require.NoError(t, os.WriteFile(p, []byte("build one"), 0o600))
+	t0 := time.Date(2026, 9, 8, 9, 38, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(p, t0, t0))
+	s1 := execWasmStamp(p)
+	require.Len(t, s1, 16)
+	require.Equal(t, s1, execWasmStamp(p), "unchanged file → unchanged stamp")
+
+	// Same size, newer mtime: a rebuild that happened to produce the same
+	// number of bytes is still a new build.
+	t1 := t0.Add(time.Hour)
+	require.NoError(t, os.Chtimes(p, t1, t1))
+	s2 := execWasmStamp(p)
+	require.NotEqual(t, s1, s2, "rebuilt (mtime) → new stamp")
+
+	// Different size, same mtime.
+	require.NoError(t, os.WriteFile(p, []byte("build one, larger"), 0o600))
+	require.NoError(t, os.Chtimes(p, t1, t1))
+	require.NotEqual(t, s2, execWasmStamp(p), "rebuilt (size) → new stamp")
+}
+
+// TestServedVersion pins that the fingerprint a page polls is the build plus
+// the module stamp, and that a page's placeholder is filled with exactly that.
+func TestServedVersion(t *testing.T) {
+	require.Equal(t, "abc", servedVersion("abc", ""), "no module → build alone")
+
+	p := filepath.Join(t.TempDir(), "skywire.wasm")
+	require.NoError(t, os.WriteFile(p, []byte("x"), 0o600))
+	v := servedVersion("abc", p)
+	require.Equal(t, "abc-"+execWasmStamp(p), v)
+
+	page := []byte(`<script>window.__SKYWIRE_WASM_VERSION__="` + servedVersionToken + `";</script>`)
+	got := string(renderServedVersion(page, v))
+	require.Equal(t, `<script>window.__SKYWIRE_WASM_VERSION__="`+v+`";</script>`, got)
+	require.NotContains(t, got, servedVersionToken)
+
+	require.Len(t, deskAssetsStamp(), 16)
+	require.Equal(t, deskAssetsStamp(), deskAssetsStamp())
+}

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -182,7 +182,10 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	// Injected so browse.js enters real-origin mode and builds <pk><suffix>[:<port>]
 	// origins for the WinBox browser iframe.
 	browseOriginJS := "window.__SKYWIRE_BROWSE_ORIGIN__={suffix:" + strconv.Quote(suffix) + ",scheme:" + strconv.Quote(bScheme) + ",port:" + strconv.Quote(bPort) + "};"
-	index := injectWasmBoot(indexB, wasmVer, cfg.Harness, browseOriginJS)
+	// The page's boot stamp is the servedVersionToken, filled per request by
+	// the root handler: the fingerprint it polls (/wasm-version) folds in the
+	// command module on disk, which changes underneath a running server.
+	index := injectWasmBoot(indexB, servedVersionToken, cfg.Harness, browseOriginJS)
 
 	browseBootstrap := bytes.ReplaceAll(wasmhv.BrowseBootstrapHTML, []byte("__APP_ORIGIN__"), []byte(browseScheme+"://"+vHostPort))
 	browseBootstrap = bytes.ReplaceAll(browseBootstrap, []byte("__SUFFIX__"), []byte(suffix))
@@ -336,11 +339,7 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 		// nested browser opens it maximized on top. A visor the operator
 		// stopped stays stopped across reloads (desk-boot's session).
 		serveBytes("/desk-boot.js", "text/javascript", wasmhv.DeskBootJS())
-		deskHTML := deskShellHTML(
-			`<script src="/wasm_exec.js?variant=go"></script>`+"\n"+
-				`<script src="/browse.js"></script>`+"\n"+
-				`<script src="/desk-boot.js"></script>`,
-			deskWasmBootOpts(cfg.DeskHelpTerminal, cfg.DeskDocsPort))
+		deskHTML := deskShellHTML(wasmDeskScripts(), deskWasmBootOpts(cfg.DeskHelpTerminal, cfg.DeskDocsPort))
 		if cfg.Harness {
 			// Same rule as injectWasmBoot on the standalone page: --harness
 			// injects ctl-bridge.js (its presence IS the harness signal). On
@@ -413,10 +412,15 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 		w.Header().Set("Cache-Control", "no-store")
 		_, _ = w.Write(swJS) //nolint:errcheck
 	})
+	// /wasm-version is what autoupdate.js polls. It is wasmVer plus, when a
+	// command module is served, that file's current stamp — stat'd per
+	// request, because skywire.wasm is rebuilt in place under a running
+	// server and a desk tab whose visor IS that module must reload to run the
+	// new one. (An open desk sat 22 h on a blob rebuilt several times over.)
 	mux.HandleFunc("/wasm-version", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.Header().Set("Cache-Control", "no-store")
-		_, _ = w.Write([]byte(wasmVer)) //nolint:errcheck
+		_, _ = w.Write([]byte(servedVersion(wasmVer, cfg.ExecWasmPath))) //nolint:errcheck
 	})
 	// Distinct browser-tab favicon for the wasm-visor surface (violet mesh-cloud),
 	// so it reads apart at a glance from a host-native hypervisor tab.
@@ -554,11 +558,14 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 			// /vnet/<port>/ prefix has its <base href> rewritten to that
 			// prefix, so a deeper path is normalised back to here anyway.
 			framed := r.Header.Get("Sec-Fetch-Dest") == "iframe" || r.URL.Query().Get("embed") == "1"
+			// Both pages boot with the fingerprint /wasm-version answers RIGHT
+			// NOW, so a poll compares like with like.
+			cur := servedVersion(wasmVer, cfg.ExecWasmPath)
 			if deskPage != nil && !framed {
-				_, _ = w.Write(deskPage) //nolint:errcheck
+				_, _ = w.Write(renderServedVersion(deskPage, cur)) //nolint:errcheck
 				return
 			}
-			_, _ = w.Write(index) //nolint:errcheck
+			_, _ = w.Write(renderServedVersion(index, cur)) //nolint:errcheck
 			return
 		}
 		fileServer.ServeHTTP(w, r)
@@ -1055,6 +1062,20 @@ func deskWasmBootOpts(helpTerminal bool, docsPort int) string {
   docsPort: %d,
   hvWindow: true,
 }`, helpTerminal, docsPort)
+}
+
+// wasmDeskScripts is the script include list of the wasm-served desk: the Go
+// loader, the desk bundle, the served-build stamp with its poller, then
+// desk-boot. autoupdate.js reloads the tab once /wasm-version moves — which a
+// rebuilt skywire.wasm now makes it do — and the exec worker the tab's visor
+// runs in dies with the page, so the reload boots the new module. The stamp
+// is the servedVersionToken; the root handler fills it per request.
+func wasmDeskScripts() string {
+	return `<script src="/wasm_exec.js?variant=go"></script>` + "\n" +
+		`<script src="/browse.js"></script>` + "\n" +
+		`<script>window.__SKYWIRE_WASM_VERSION__="` + servedVersionToken + `";</script>` + "\n" +
+		`<script src="/autoupdate.js"></script>` + "\n" +
+		`<script src="/desk-boot.js"></script>`
 }
 
 // deskShellTemplate is the shared skeleton of the converged desk page (/desk):

--- a/pkg/wasmhv/autoupdate.js
+++ b/pkg/wasmhv/autoupdate.js
@@ -1,13 +1,15 @@
-// autoupdate.js — wasm-visor self-update for the `skywire cli hv serve` page.
+// autoupdate.js — self-update for the pages wasm-serve serves (`skywire cli hv
+// serve`, or a visor's hypervisor.wasm_serve): the legacy wasm-visor page and
+// the desk.
 //
-// The standalone wasm-visor's ONLY update step is a page reload: the server
-// (hv serve) embeds the wasm in the running skywire binary, so when that binary
-// updates the served /wasm-visor.wasm changes and a reload picks it up. This
-// script polls a tiny /wasm-version fingerprint and, when it differs from the
-// version this page booted with, reloads to the new build — by default, with a
-// user-visible toast that lets them keep the current version (disabling
-// auto-update). It is injected ONLY by hv serve, so it never runs for a
-// native-hosted hypervisor UI.
+// Their ONLY update step is a page reload: the served /wasm-visor.wasm is
+// embedded in the running skywire binary and the desk's /skywire.wasm is read
+// from disk, so when either changes a reload picks it up. This script polls a
+// tiny /wasm-version fingerprint (the build plus the served command module's
+// stamp) and, when it differs from the version this page booted with, reloads
+// to the new build — by default, with a user-visible toast that lets them keep
+// the current version (disabling auto-update). It is injected ONLY by
+// wasm-serve; the native hypervisor port has its own poller (uiAutoReloadJS).
 (function () {
   'use strict';
   var POLL_MS = 60000;          // how often to check for a new build
@@ -30,15 +32,19 @@
 
   var notifying = false;
 
-  // The wasm runs in a SharedWorker that stays alive across a tab's
-  // location.reload() (it dies only when the LAST tab disconnects), so a plain
-  // reload reconnects to the SAME stale runtime — the new wasm never loads.
-  // Before reloading, tell the worker to self.close() so the post-reload page
-  // boots a FRESH worker that fetches the new wasm-visor.wasm. (The dedicated-
-  // Worker fallback already dies on unload, so the message is a no-op there.)
+  // On the legacy page the wasm runs in a SharedWorker that stays alive across
+  // a tab's location.reload() (it dies only when the LAST tab disconnects), so
+  // a plain reload reconnects to the SAME stale runtime — the new wasm never
+  // loads. Before reloading, tell the worker to self.close() so the post-reload
+  // page boots a FRESH worker that fetches the new wasm-visor.wasm. (The
+  // dedicated-Worker fallback already dies on unload, so the message is a no-op
+  // there.) Only where hv-boot.js is on the page: the desk has no SharedWorker
+  // visor — its visor is an exec worker that dies with the page — and
+  // constructing one here would fetch and boot a whole wasm-visor just to shut
+  // it down (worker.js instantiates on load).
   function reloadFresh() {
     try {
-      if (typeof SharedWorker !== 'undefined') {
+      if (typeof SharedWorker !== 'undefined' && document.querySelector('script[src*="hv-boot"]')) {
         var w = new SharedWorker('worker.js');
         if (w.port.start) { w.port.start(); }
         w.port.postMessage({ t: 'shutdown' });
@@ -55,7 +61,7 @@
       'background:#2b2540;color:#eee;font:13px/1.4 system-ui,sans-serif;padding:12px 14px;' +
       'border:1px solid #6c5ce7;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,.4)';
     var secs = Math.round(GRACE_MS / 1000);
-    box.innerHTML = '<b>New wasm-visor available</b><br>Updating in <span id="su-c">' + secs +
+    box.innerHTML = '<b>New skywire build available</b><br>Updating in <span id="su-c">' + secs +
       '</span>s… <div style="margin-top:8px"><button id="su-now" style="margin-right:8px">Update now</button>' +
       '<button id="su-keep">Keep this version</button></div>';
     document.body.appendChild(box);


### PR DESCRIPTION
The desk's visor is the skywire command module served at `/skywire.wasm`, read from disk, and only a page reload runs a new one. Nothing told the page to reload: the wasm-serve desk had no version stamp and no poller at all (`autoupdate.js` was injected only into the legacy page), and the native port's `/api/ui-version` hashed the Angular `index.html` alone. A desk tab sat 22 h on a blob that had been rebuilt several times.

This folds the served module's size+mtime (stat'd per request) into both fingerprints, along with the desk client the host binary embeds, and puts the stamp + `autoupdate.js` on the wasm-serve desk. Both pages are rendered with the fingerprint `/wasm-version` answers right now, so a poll compares like with like. `autoupdate.js` pokes the SharedWorker only on the legacy page; the desk's exec worker dies with the page. Verified live on a spare `hv serve` port: touching the blob moves `/wasm-version` and the page stamp together.
