### PR TITLE
fix(transport): a transport dialed while a handler was registered never got it

### DIFF
--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -65,15 +65,23 @@ func (r *router) handleTransportPacket(ctx context.Context, packet routing.Packe
 		return r.dispatchToRouteGroup(ctx, packet)
 	case routing.DatagramPacket:
 		return r.handleDatagramPacket(ctx, packet)
+	case routing.DirectionPacket:
+		// Manual direction pin (CapUniDir): route-ID-driven like LegState — the
+		// destination route group applies it (handleDirectionPacket). Without
+		// this case the router dropped every pin as ErrUnknownPacketType.
+		return r.dispatchToRouteGroup(ctx, packet)
 	case routing.TransportPingPacket, routing.TransportPongPacket,
 		routing.CascadeSetupPacket, routing.CascadeAckPacket, routing.DHTPacket,
-		routing.SetupRPCPacket, routing.VisorRPCPacket:
-		// These should be intercepted at the transport layer (ManagedTransport.readLoop).
-		// If they reach the router, something is wrong — drop silently.
-		r.logger.Warn("Control-plane packet reached router (should be handled at transport layer)")
+		routing.SetupRPCPacket, routing.VisorRPCPacket, routing.SkynetForwardPacket,
+		routing.AppDirectPacket, routing.TransportBwProbePacket, routing.TransportBwAckPacket:
+		// These are intercepted in ManagedTransport.readLoop when the transport
+		// has the matching handler. Reaching the router means the transport has
+		// none (see Manager.applyHandlers) — name the type so that is visible.
+		r.logger.WithField("type", packet.Type().String()).
+			Warn("Control-plane packet reached router (should be handled at transport layer)")
 		return nil
 	default:
-		return ErrUnknownPacketType
+		return fmt.Errorf("%w: %s (routeID=%d)", ErrUnknownPacketType, packet.Type(), packet.RouteID())
 	}
 }
 

--- a/pkg/transport/coverage_test.go
+++ b/pkg/transport/coverage_test.go
@@ -623,6 +623,41 @@ func TestManagerHandlerSetters(t *testing.T) {
 	require.NotNil(t, tm.tpdLeafPublisher())
 }
 
+// TestManagerApplyHandlers: a transport that is NOT yet in tm.tps when the
+// handlers are registered (the dial path: created, dialing for up to ~20s,
+// inserted afterwards) gets them from applyHandlers at insertion time. Before
+// the fix the dial path copied them before the dial and never again, so a
+// handler registered during the dial was missed for the transport's lifetime.
+func TestManagerApplyHandlers(t *testing.T) {
+	tm := newTestManager(t)
+	mt := NewManagedTransportForTest(newMemTransport())
+	mt.Entry = MakeEntry(tm.Conf.PubKey, mustPK(t), types.STCPR, LabelUser)
+
+	// Registered while mt is "still dialing" — not in tm.tps, so the setters'
+	// fan-out cannot reach it.
+	h := func(_ routing.Packet, _ *ManagedTransport) {}
+	tm.SetCascadeHandler(h)
+	tm.SetDHTHandler(h)
+	tm.SetVisorRPCHandler(h)
+	tm.SetSkynetForwardHandler(h)
+	tm.SetAppDirectHandler(h)
+	tm.SetSetupRPCHandler(h)
+	require.Nil(t, mt.appDirectHandler)
+	require.Nil(t, mt.skynetFwdHandler)
+
+	// Insertion (what saveTransportInternal does once the dial returns).
+	tm.mx.Lock()
+	tm.tps[mt.Entry.ID] = mt
+	tm.applyHandlers(mt)
+	tm.mx.Unlock()
+	require.NotNil(t, mt.cascadeHandler)
+	require.NotNil(t, mt.dhtHandler)
+	require.NotNil(t, mt.visorRPCHandler)
+	require.NotNil(t, mt.skynetFwdHandler)
+	require.NotNil(t, mt.appDirectHandler)
+	require.NotNil(t, mt.setupRPCHandler)
+}
+
 func TestManagerARLimit(t *testing.T) {
 	// AR registration is a static, config-only switch: >= 0 registers, < 0 never
 	// registers. There is deliberately NO runtime transport-count deregister —

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -788,6 +788,36 @@ func (tm *Manager) SetAppDirectHandler(h func(p routing.Packet, mt *ManagedTrans
 	tm.mx.RUnlock()
 }
 
+// applyHandlers copies the manager's current route-ID-0 packet handlers onto
+// mTp. Call it once mTp is in tm.tps: the Set*Handler propagation walks that
+// map, so a transport that copied the handlers before its dial (which can
+// take up to ~20s) and was inserted afterwards kept nil/stale handlers for
+// life — every handler registered in between (init_services binds the skynet
+// and app-direct muxes while a persistent transport is still dialing) was
+// missed, and those packets fell through to the router as "unknown packet
+// type". Symptom: a browser tab whose only transport dropped every inbound
+// app-direct ack from its host.
+func (tm *Manager) applyHandlers(mTp *ManagedTransport) {
+	tm.cascadeHandlerMu.RLock()
+	mTp.cascadeHandler = tm.cascadeHandler
+	tm.cascadeHandlerMu.RUnlock()
+	tm.dhtHandlerMu.RLock()
+	mTp.dhtHandler = tm.dhtHandler
+	tm.dhtHandlerMu.RUnlock()
+	tm.setupRPCHandlerMu.RLock()
+	mTp.setupRPCHandler = tm.setupRPCHandler
+	tm.setupRPCHandlerMu.RUnlock()
+	tm.visorRPCHandlerMu.RLock()
+	mTp.visorRPCHandler = tm.visorRPCHandler
+	tm.visorRPCHandlerMu.RUnlock()
+	tm.skynetFwdHandlerMu.RLock()
+	mTp.skynetFwdHandler = tm.skynetFwdHandler
+	tm.skynetFwdHandlerMu.RUnlock()
+	tm.appDirectHandlerMu.RLock()
+	mTp.appDirectHandler = tm.appDirectHandler
+	tm.appDirectHandlerMu.RUnlock()
+}
+
 // SetSetupRPCHandler sets the handler for RSN RPC relay packets (route ID 0).
 func (tm *Manager) SetSetupRPCHandler(h func(p routing.Packet, mt *ManagedTransport)) {
 	tm.setupRPCHandlerMu.Lock()
@@ -1165,24 +1195,7 @@ func (tm *Manager) acceptTransport(ctx context.Context, lis network.Listener) er
 			QueueDeletion:  tm.queueDeletion,
 			IsInitiator:    false, // remote dialed us — incoming transport
 		})
-		tm.cascadeHandlerMu.RLock()
-		mTp.cascadeHandler = tm.cascadeHandler
-		tm.cascadeHandlerMu.RUnlock()
-		tm.dhtHandlerMu.RLock()
-		mTp.dhtHandler = tm.dhtHandler
-		tm.dhtHandlerMu.RUnlock()
-		tm.setupRPCHandlerMu.RLock()
-		mTp.setupRPCHandler = tm.setupRPCHandler
-		tm.setupRPCHandlerMu.RUnlock()
-		tm.visorRPCHandlerMu.RLock()
-		mTp.visorRPCHandler = tm.visorRPCHandler
-		tm.visorRPCHandlerMu.RUnlock()
-		tm.skynetFwdHandlerMu.RLock()
-		mTp.skynetFwdHandler = tm.skynetFwdHandler
-		tm.skynetFwdHandlerMu.RUnlock()
-		tm.appDirectHandlerMu.RLock()
-		mTp.appDirectHandler = tm.appDirectHandler
-		tm.appDirectHandlerMu.RUnlock()
+		tm.applyHandlers(mTp)
 
 		go func() {
 			mTp.Serve(tm.readCh)
@@ -1460,24 +1473,6 @@ func (tm *Manager) saveTransportInternal(ctx context.Context, remote cipher.PubK
 		QueueDeletion:  tm.queueDeletion,
 		IsInitiator:    true, // we are dialing out — outgoing transport
 	})
-	tm.cascadeHandlerMu.RLock()
-	mTp.cascadeHandler = tm.cascadeHandler
-	tm.cascadeHandlerMu.RUnlock()
-	tm.dhtHandlerMu.RLock()
-	mTp.dhtHandler = tm.dhtHandler
-	tm.dhtHandlerMu.RUnlock()
-	tm.setupRPCHandlerMu.RLock()
-	mTp.setupRPCHandler = tm.setupRPCHandler
-	tm.setupRPCHandlerMu.RUnlock()
-	tm.visorRPCHandlerMu.RLock()
-	mTp.visorRPCHandler = tm.visorRPCHandler
-	tm.visorRPCHandlerMu.RUnlock()
-	tm.skynetFwdHandlerMu.RLock()
-	mTp.skynetFwdHandler = tm.skynetFwdHandler
-	tm.skynetFwdHandlerMu.RUnlock()
-	tm.appDirectHandlerMu.RLock()
-	mTp.appDirectHandler = tm.appDirectHandler
-	tm.appDirectHandlerMu.RUnlock()
 
 	tm.Logger.Debugf("Dialing transport to %v via %v", mTp.Remote(), mTp.client.Type())
 	errCh := make(chan error)
@@ -1502,6 +1497,7 @@ func (tm *Manager) saveTransportInternal(ctx context.Context, remote cipher.PubK
 		return existing, nil
 	}
 	tm.tps[tpID] = mTp
+	tm.applyHandlers(mTp)
 	tm.mx.Unlock()
 	// Serve runs for the transport's lifetime, not the dial's; its internal
 	// datagram-read context correctly derives from Background (a short-lived


### PR DESCRIPTION
The dial path copied the route-ID-0 packet handlers onto a new ManagedTransport before the dial and only inserted it into the manager's map after the dial returned (up to ~20 s). Set*Handler propagates by walking that map, so a handler registered during the window was missed for the transport's lifetime and its packets reached the router as "unknown packet type".

A desk tab's only transport (the persistent swsr to its host) is dialed at page load while init binds the skynet and app-direct muxes; the tab dropped every app-direct ack from its host, so relay attaches over skynet fell back to route setup and failed (#4484 stage 4).

Handlers are now applied at insertion time; DirectionPacket is dispatched to its route group instead of being dropped; the router names the packet type it drops.