### PR TITLE
feat(visor): GoroutineDump RPC; visor goroutines falls back to it

### DIFF
--- a/cmd/skywire-cli/commands/visor/goroutines.go
+++ b/cmd/skywire-cli/commands/visor/goroutines.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/cobra"
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/pkg/cliout"
 	"github.com/skycoin/skywire/pkg/cliout/clivisor"
 )
@@ -85,7 +86,15 @@ Examples:
 		defer cancel()
 		raw, err := fetchPprofGoroutines(ctx, pprofAddr)
 		if err != nil {
-			internal.PrintFatalError(cmd.Flags(), err)
+			// No pprof listener (a visor in a browser tab has none): ask the
+			// visor itself over RPC for the same debug=2 text.
+			rpcClient, rpcErr := clirpc.Client(cmd.Flags())
+			if rpcErr != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("%w; rpc: %v", err, rpcErr))
+			}
+			if raw, rpcErr = rpcClient.GoroutineDump(); rpcErr != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("%w; rpc GoroutineDump: %v", err, rpcErr))
+			}
 		}
 
 		goroutines, parseErr := parseGoroutineDump(raw)

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -49,6 +49,7 @@ type API interface {
 	Uptime() (float64, error)
 	UptimeHistory(args UptimeHistoryArgs) (*UptimeHistoryResponse, error)
 	RuntimeStats() (*RuntimeStatsInfo, error)
+	GoroutineDump() (string, error)
 	Reload() error
 	Suspend() error
 	Resume() error

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -462,6 +462,20 @@ func (v *Visor) RuntimeStats() (*RuntimeStatsInfo, error) {
 	}, nil
 }
 
+// GoroutineDump implements API: every goroutine's stack in the pprof debug=2
+// text format. For builds with no pprof listener (a visor in a browser tab):
+// the CLI's `visor goroutines` falls back to it.
+func (v *Visor) GoroutineDump() (string, error) {
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return string(buf[:n]), nil
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
 // SetRewardAddress implements API. The durable store is <local_path>/reward.txt,
 // not skywire-config.json — the in-memory conf field below is never flushed, and
 // reward.txt sits outside the generated json, so the address survives both a

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -130,6 +130,10 @@ func (proxyDefaultAPI) RuntimeStats() (*RuntimeStatsInfo, error) {
 	return nil, ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) GoroutineDump() (string, error) {
+	return "", ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) Reload() error {
 	return ErrProxyNotSupported
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1154,6 +1154,13 @@ func (rc *rpcClient) RuntimeStats() (*RuntimeStatsInfo, error) {
 	return &stats, err
 }
 
+// GoroutineDump calls GoroutineDump.
+func (rc *rpcClient) GoroutineDump() (string, error) {
+	var out string
+	err := rc.Call("GoroutineDump", &struct{}{}, &out)
+	return out, err
+}
+
 // SetMinHops sets the min_hops from visor routing config
 func (rc *rpcClient) SetMinHops(hops uint16) error {
 	err := rc.Call("SetMinHops", &hops, &struct{}{})

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -966,6 +966,11 @@ func (mc *mockRPCClient) RuntimeLogs() (string, error) {
 	return "", nil
 }
 
+// GoroutineDump implements API.
+func (mc *mockRPCClient) GoroutineDump() (string, error) {
+	return "", nil
+}
+
 // RuntimeStats implements API.
 func (mc *mockRPCClient) RuntimeStats() (*RuntimeStatsInfo, error) {
 	return &RuntimeStatsInfo{

--- a/pkg/visor/rpc_visor.go
+++ b/pkg/visor/rpc_visor.go
@@ -79,6 +79,13 @@ func (r *RPC) Health(_ *struct{}, out *HealthInfo) (err error) {
 	return err
 }
 
+// GoroutineDump returns every goroutine's stack (pprof debug=2 text).
+func (r *RPC) GoroutineDump(_ *struct{}, out *string) (err error) {
+	defer rpcutil.LogCall(r.log, "GoroutineDump", nil)(nil, &err)
+	*out, err = r.visor.GoroutineDump()
+	return err
+}
+
 // RuntimeStats returns Go runtime statistics for the visor process.
 func (r *RPC) RuntimeStats(_ *struct{}, out *RuntimeStatsInfo) (err error) {
 	defer rpcutil.LogCall(r.log, "RuntimeStats", nil)(out, &err)


### PR DESCRIPTION
A visor in a browser tab has no pprof listener, so `skywire cli visor goroutines` could not show what its goroutines were blocked on. This adds a GoroutineDump API/RPC (runtime.Stack, all goroutines, pprof debug=2 text) and makes the CLI use it when the pprof fetch fails. Output is unchanged otherwise. Needed to debug the tab-side transport stalls in #4484 stage 4.