### PR TITLE
fix(transport): VStream segmentation, per-transport stream ids, no silent drops; visor state diag section

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -1490,6 +1490,7 @@ func (ce *Client) pingSessions(_ context.Context, fails map[*SessionCommon]int) 
 		rtt, err := ses.Ping()
 		if err != nil {
 			fails[key]++
+			key.pingFails.Store(int32(fails[key])) //nolint:gosec
 			ce.log.WithError(err).
 				WithField("server", ses.RemotePK()).
 				WithField("consecutive_fails", fails[key]).
@@ -1504,6 +1505,7 @@ func (ce *Client) pingSessions(_ context.Context, fails map[*SessionCommon]int) 
 			continue
 		}
 		fails[key] = 0
+		key.pingFails.Store(0)
 		ses.SetLastPing(rtt)
 		ce.log.WithField("server", ses.RemotePK()).WithField("rtt", rtt).
 			Trace("Session ping measured")

--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -460,3 +460,45 @@ func (ce *Client) relayDialSkipped(dst cipher.PubKey) bool {
 	until, ok := ce.relayDialSkip[dst]
 	return ok && time.Now().Before(until)
 }
+
+// RelayBackoffs lists the relay nominees currently backed off after a failed
+// attach, with the time each backoff lapses. For `visor state`.
+func (ce *Client) RelayBackoffs() map[cipher.PubKey]time.Time {
+	ce.relayMx.Lock()
+	defer ce.relayMx.Unlock()
+	out := make(map[cipher.PubKey]time.Time, len(ce.relayFailAt))
+	now := time.Now()
+	for pk, until := range ce.relayFailAt {
+		if until.After(now) {
+			out[pk] = until
+		}
+	}
+	return out
+}
+
+// RelayDialSkips lists the destinations DialStream is currently not trying
+// over the relay (the relay failed to reach them), with the skip's end.
+func (ce *Client) RelayDialSkips() map[cipher.PubKey]time.Time {
+	ce.relayMx.Lock()
+	defer ce.relayMx.Unlock()
+	out := make(map[cipher.PubKey]time.Time, len(ce.relayDialSkip))
+	now := time.Now()
+	for pk, until := range ce.relayDialSkip {
+		if until.After(now) {
+			out[pk] = until
+		}
+	}
+	return out
+}
+
+// RelaySessionStreams is the open-stream count of every peer attached to
+// this client as a relay (the "Relaying for" side).
+func (ce *Client) RelaySessionStreams() map[cipher.PubKey]int {
+	ce.relaySessionsMx.Lock()
+	defer ce.relaySessionsMx.Unlock()
+	out := make(map[cipher.PubKey]int, len(ce.relaySessions))
+	for pk, ses := range ce.relaySessions {
+		out[pk] = ses.NumStreams()
+	}
+	return out
+}

--- a/pkg/dmsg/dmsg/session_common.go
+++ b/pkg/dmsg/dmsg/session_common.go
@@ -67,6 +67,11 @@ type SessionCommon struct {
 	// A value of 0 means no measurement yet (treated as max latency for sorting).
 	lastPingNs atomic.Int64
 
+	// pingFails is the consecutive liveness-ping failure count the client's
+	// ping loop is at for this session (pingDeadThreshold closes it). For
+	// `visor state`.
+	pingFails atomic.Int32
+
 	// reaped is set by the client's idle-session reaper just before it closes
 	// this session. The serve goroutine's exit path reads it so a deliberate
 	// trim is not mistaken for a dropped server. Without it the exit path
@@ -460,6 +465,9 @@ func (sc *SessionCommon) smuxPing(smuxSes *smux.Session) (time.Duration, error) 
 
 // LastPing returns the last measured round-trip latency.
 // Returns 0 if no measurement has been taken yet.
+// PingFails is the consecutive liveness-ping failure count for this session.
+func (sc *SessionCommon) PingFails() int { return int(sc.pingFails.Load()) }
+
 func (sc *SessionCommon) LastPing() time.Duration {
 	return time.Duration(sc.lastPingNs.Load())
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -661,6 +661,7 @@ type router struct {
 	rgsNs              map[routing.RouteDescriptor]*NoiseRouteGroup    // Noise-wrapped route groups to push incoming reads from transports.
 	rgsRaw             map[routing.RouteDescriptor]*RouteGroup         // Not-yet-noise-wrapped route groups. when one of these gets wrapped, it gets removed from here
 	rgsDatagrams       map[routing.RouteDescriptor]*DatagramRouteGroup // faithful-UDP (DatagramPacket) route groups, keyed like rgsNs; #2607 stage-4 dispatch
+	intake             intakeCounters                                  // inbound-path counters for `visor state` (router_intake.go)
 	datagramPorts      map[routing.Port]struct{}                       // local ports with faithful-UDP intent; the accept side builds a datagram sibling only for these (#2607 on-demand-by-local-intent)
 	acceptDatagram     chan datagramAccept                             // accept-side datagram siblings, drained by AcceptDatagram (the forwarded_ports.udp server loop)
 	pending            *pendingPackets                                 // frames parked during the rule-save -> route-group-register window (see router_pending.go)

--- a/pkg/router/router_intake.go
+++ b/pkg/router/router_intake.go
@@ -1,0 +1,125 @@
+// Package router pkg/router/router_intake.go c3-rtr-core
+//
+// Intake diagnostics for `visor state`: what the router's single inbound
+// packet loop is doing with what the transports hand it. Counted here rather
+// than only logged so a stalled or misdelivered path shows up in a snapshot.
+package router
+
+import (
+	"sync"
+
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// IntakeStats is the router's inbound-path view.
+type IntakeStats struct {
+	// UnknownPacketTypes counts packets dropped as ErrUnknownPacketType, by
+	// type name. Non-zero means a peer sends a type this build does not
+	// route, or a transport lost its route-ID-0 handler (#4725).
+	UnknownPacketTypes map[string]int64 `json:"unknown_packet_types,omitempty"`
+	// ControlPlaneToRouter counts route-ID-0 control packets that reached
+	// the router instead of being intercepted on the transport, by type.
+	ControlPlaneToRouter map[string]int64 `json:"control_plane_to_router,omitempty"`
+	// StaleRouteDrops counts frames for rules that no longer exist (normal
+	// during teardown; a climbing count on an idle visor is not).
+	StaleRouteDrops int64 `json:"stale_route_drops"`
+	// RouteGroupQueues is the inbound app queue of every active route group:
+	// a queue at capacity is an app that stopped reading, and the router
+	// blocks on it (up to 30 s per packet) — stalling every transport.
+	RouteGroupQueues []RouteGroupQueue `json:"route_group_queues,omitempty"`
+}
+
+// RouteGroupQueue is one route group's inbound queue depth.
+type RouteGroupQueue struct {
+	Desc     string `json:"desc"`
+	App      string `json:"app,omitempty"`
+	Queue    int    `json:"queue"`
+	Capacity int    `json:"capacity"`
+}
+
+type intakeCounters struct {
+	mx      sync.Mutex
+	unknown map[string]int64
+	control map[string]int64
+	stale   int64
+}
+
+func (c *intakeCounters) noteUnknown(t routing.PacketType) {
+	c.mx.Lock()
+	if c.unknown == nil {
+		c.unknown = make(map[string]int64)
+	}
+	c.unknown[t.String()]++
+	c.mx.Unlock()
+}
+
+func (c *intakeCounters) noteControl(t routing.PacketType) {
+	c.mx.Lock()
+	if c.control == nil {
+		c.control = make(map[string]int64)
+	}
+	c.control[t.String()]++
+	c.mx.Unlock()
+}
+
+func (c *intakeCounters) noteStale() {
+	c.mx.Lock()
+	c.stale++
+	c.mx.Unlock()
+}
+
+func (c *intakeCounters) snapshot() (unknown, control map[string]int64, stale int64) {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+	unknown = make(map[string]int64, len(c.unknown))
+	for k, v := range c.unknown {
+		unknown[k] = v
+	}
+	control = make(map[string]int64, len(c.control))
+	for k, v := range c.control {
+		control[k] = v
+	}
+	return unknown, control, c.stale
+}
+
+// IntakeStats snapshots the router's inbound-path counters and every active
+// route group's inbound queue depth. Reached through a type assertion from
+// the visor so the Router interface (and its mock) stay unchanged.
+func (r *router) IntakeStats() IntakeStats {
+	unknown, control, stale := r.intake.snapshot()
+	out := IntakeStats{StaleRouteDrops: stale}
+	if len(unknown) > 0 {
+		out.UnknownPacketTypes = unknown
+	}
+	if len(control) > 0 {
+		out.ControlPlaneToRouter = control
+	}
+	r.mx.Lock()
+	rgs := make([]*RouteGroup, 0, len(r.rgsNs)+len(r.rgsRaw))
+	for _, nrg := range r.rgsNs {
+		if nrg != nil && nrg.rg != nil {
+			rgs = append(rgs, nrg.rg)
+		}
+	}
+	for _, rg := range r.rgsRaw {
+		if rg != nil {
+			rgs = append(rgs, rg)
+		}
+	}
+	r.mx.Unlock()
+	for _, rg := range rgs {
+		q, c := rg.readQueue()
+		out.RouteGroupQueues = append(out.RouteGroupQueues, RouteGroupQueue{
+			Desc:     rg.desc.String(),
+			App:      rg.AppName(),
+			Queue:    q,
+			Capacity: c,
+		})
+	}
+	return out
+}
+
+// readQueue is the depth and capacity of the group's inbound app queue.
+func (rg *RouteGroup) readQueue() (int, int) {
+	return len(rg.readCh), cap(rg.readCh)
+}

--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -77,10 +77,12 @@ func (r *router) handleTransportPacket(ctx context.Context, packet routing.Packe
 		// These are intercepted in ManagedTransport.readLoop when the transport
 		// has the matching handler. Reaching the router means the transport has
 		// none (see Manager.applyHandlers) — name the type so that is visible.
+		r.intake.noteControl(packet.Type())
 		r.logger.WithField("type", packet.Type().String()).
 			Warn("Control-plane packet reached router (should be handled at transport layer)")
 		return nil
 	default:
+		r.intake.noteUnknown(packet.Type())
 		return fmt.Errorf("%w: %s (routeID=%d)", ErrUnknownPacketType, packet.Type(), packet.RouteID())
 	}
 }

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -185,6 +185,7 @@ func (r *router) serveTransportManager(ctx context.Context) {
 			// for stale or torn-down routes and are normal during teardown, so
 			// demote them to DEBUG; keep genuinely unexpected frame errors at WARN.
 			if errors.Is(err, routing.ErrRuleNotFound) || errors.Is(err, errRouteDescNotExist) {
+				r.intake.noteStale()
 				r.logger.WithError(err).Debug("Dropped transport frame for stale route")
 			} else {
 				r.logger.Warnf("Failed to handle transport frame: %v", err)

--- a/pkg/transport/coverage_test.go
+++ b/pkg/transport/coverage_test.go
@@ -8,6 +8,7 @@
 package transport
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -860,4 +861,91 @@ func mustPK(t *testing.T) cipher.PubKey {
 	t.Helper()
 	pk, _ := cipher.GenerateKeyPair()
 	return pk
+}
+
+// TestVStreamIDsScopedPerTransport: wire stream ids are only unique per peer
+// pair, and both ends allocate them. Streams must be keyed by (transport, id)
+// so equal ids on two transports are two streams, and ids this side allocates
+// must not collide with ids the peer allocates on the same transport (parity
+// split by PK order). Before this fix a tab's relay session and its host's RPC
+// dial to the tab shared an id and yamux died with "invalid protocol version".
+func TestVStreamIDsScopedPerTransport(t *testing.T) {
+	tm := newTestManager(t)
+	remoteA := mustPK(t)
+	remoteB := mustPK(t)
+	mtA, _ := servingTransport(t, tm, remoteA, types.STCPR)
+	mtB, _ := servingTransport(t, tm, remoteB, types.SUDPH)
+	mux := NewVStreamMux(tm, routing.DHTPacket, logging.MustGetLogger("vstream-test"))
+
+	// Same wire id from two peers → two streams.
+	const sid = uint64(7)
+	mux.HandlePacket(buildVStreamPacket(routing.DHTPacket, sid, remoteA, VStreamFlagSyn, nil), mtA)
+	sA, err := mux.Accept()
+	require.NoError(t, err)
+	mux.HandlePacket(buildVStreamPacket(routing.DHTPacket, sid, remoteB, VStreamFlagSyn, nil), mtB)
+	sB, err := mux.Accept()
+	require.NoError(t, err)
+	require.NotSame(t, sA, sB)
+	mux.HandlePacket(buildVStreamPacket(routing.DHTPacket, sid, remoteB, VStreamFlagData, []byte("b")), mtB)
+	buf := make([]byte, 1)
+	n, err := sB.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, "b", string(buf[:n]))
+	select {
+	case <-sA.readBuf:
+		t.Fatal("frame for B's stream landed on A's stream with the same id")
+	default:
+	}
+	require.Equal(t, int64(0), mux.Stats().FramesUnknownStream)
+
+	// Local ids never share parity with the peer's on the same transport.
+	local := tm.Local()
+	idA := mux.nextIDFor(remoteA)
+	idB := mux.nextIDFor(remoteB)
+	wantOddA := bytes.Compare(local[:], remoteA[:]) > 0
+	wantOddB := bytes.Compare(local[:], remoteB[:]) > 0
+	require.Equal(t, wantOddA, idA%2 == 1)
+	require.Equal(t, wantOddB, idB%2 == 1)
+
+	// A frame for an id nobody has is counted, not silently dropped.
+	mux.HandlePacket(buildVStreamPacket(routing.DHTPacket, 999, remoteA, VStreamFlagData, []byte("x")), mtA)
+	require.Equal(t, int64(1), mux.Stats().FramesUnknownStream)
+}
+
+// TestVStreamWriteSegments: a Write larger than the 16-bit packet size field
+// must go out as several DATA frames, each declared exactly as long as it is,
+// and reassemble to the input. Before this fix it went out as ONE packet with a
+// truncated size field, and the receiver parsed the rest as garbage headers.
+func TestVStreamWriteSegments(t *testing.T) {
+	tm := newTestManager(t)
+	mt, mem := servingTransport(t, tm, mustPK(t), types.STCPR)
+	mux := NewVStreamMux(tm, routing.DHTPacket, logging.MustGetLogger("vstream-test"))
+	s, err := mux.DialOnTransport(mt)
+	require.NoError(t, err)
+	mem.written = nil
+
+	data := make([]byte, 200_000)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	n, err := s.Write(data)
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
+
+	var got []byte
+	frames := 0
+	for buf := mem.written; len(buf) > 0; frames++ {
+		require.GreaterOrEqual(t, len(buf), routing.PacketHeaderSize)
+		pkt := routing.Packet(buf)
+		size := int(pkt.Size())
+		require.Equal(t, routing.DHTPacket, pkt.Type())
+		require.LessOrEqual(t, size, int(vstreamMaxData)+VStreamHeaderSize)
+		require.GreaterOrEqual(t, len(buf), routing.PacketHeaderSize+size, "declared size must not exceed the bytes written")
+		payload := buf[routing.PacketHeaderSize : routing.PacketHeaderSize+size]
+		require.Equal(t, byte(VStreamFlagData), payload[41])
+		got = append(got, payload[VStreamHeaderSize:]...)
+		buf = buf[routing.PacketHeaderSize+size:]
+	}
+	require.Equal(t, 4, frames)
+	require.Equal(t, data, got)
 }

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -170,6 +170,11 @@ type ManagedTransport struct {
 	// have failed pongMissThreshold consecutive ticks the link is closed.
 	pingWriteFails atomic.Int64
 
+	// malformedFrames counts received packets whose type byte is outside the
+	// known range: the peer's framing is off (a size field that did not match
+	// the bytes written). Logged with the header bytes; for `visor state`.
+	malformedFrames atomic.Int64
+
 	// cascadeHandler handles cascade protocol packets (route ID 0).
 	// Set by the transport manager from the router's CascadeHandler.
 	cascadeHandler func(p routing.Packet, mt *ManagedTransport)
@@ -504,6 +509,16 @@ func (mt *ManagedTransport) readLoop(readCh chan<- routing.Packet) {
 		// Any received packet (pong, the peer's own ping, or route data) proves
 		// the link is alive — feed the unarmed-silence reaper in tickPing.
 		mt.lastRecvNanos.Store(time.Now().UnixNano())
+		if p.Type() > routing.DirectionPacket {
+			mt.malformedFrames.Add(1)
+			head := p
+			if len(head) > 24 {
+				head = head[:24]
+			}
+			log.WithField("type", byte(p.Type())).WithField("size", p.Size()).
+				WithField("head_hex", fmt.Sprintf("%x", []byte(head))).
+				Debug("Malformed frame: unknown packet type (peer framing off)")
+		}
 		// Intercept transport-level ping/pong before forwarding to router.
 		if p.RouteID() == 0 {
 			switch p.Type() {
@@ -1377,3 +1392,49 @@ func (mt *ManagedTransport) ConnDetails() *network.ConnDetails {
 	cd := d.ConnDetails()
 	return &cd
 }
+
+// MissedPongs is the number of transport pings sent since the last pong
+// (pongMissThreshold closes the transport). For `visor state`.
+func (mt *ManagedTransport) MissedPongs() int64 { return mt.missedPongs.Load() }
+
+// PongSeen reports whether the peer has ever answered a transport ping.
+func (mt *ManagedTransport) PongSeen() bool { return mt.pongSeen.Load() }
+
+// LastRecvAt is when the read loop last received any packet (zero = never).
+func (mt *ManagedTransport) LastRecvAt() time.Time {
+	ns := mt.lastRecvNanos.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
+}
+
+// Handlers names the route-ID-0 packet handlers wired on this transport. A
+// transport missing one delivers that packet type to the router instead, where
+// it is dropped as unknown — the #4725 failure mode, visible here per transport.
+func (mt *ManagedTransport) Handlers() []string {
+	var out []string
+	if mt.cascadeHandler != nil {
+		out = append(out, "cascade")
+	}
+	if mt.dhtHandler != nil {
+		out = append(out, "dht")
+	}
+	if mt.setupRPCHandler != nil {
+		out = append(out, "setup_rpc")
+	}
+	if mt.visorRPCHandler != nil {
+		out = append(out, "visor_rpc")
+	}
+	if mt.skynetFwdHandler != nil {
+		out = append(out, "skynet_forward")
+	}
+	if mt.appDirectHandler != nil {
+		out = append(out, "app_direct")
+	}
+	return out
+}
+
+// MalformedFrames counts received frames whose type byte is outside the known
+// range — the peer's framing is off. For `visor state`.
+func (mt *ManagedTransport) MalformedFrames() int64 { return mt.malformedFrames.Load() }

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -1854,3 +1854,11 @@ func (tm *Manager) isClosing() bool {
 func (tm *Manager) tpIDFromPK(pk cipher.PubKey, netType types.Type) uuid.UUID {
 	return MakeTransportID(tm.Conf.PubKey, pk, netType)
 }
+
+// ReadQueue is the depth and capacity of the shared inbound packet queue every
+// transport's read loop feeds and the router drains. A full queue means the
+// router is not keeping up (a route group whose app stopped reading blocks it),
+// and every transport's read loop — pings and pongs included — stalls behind it.
+func (tm *Manager) ReadQueue() (depth, capacity int) {
+	return len(tm.readCh), cap(tm.readCh)
+}

--- a/pkg/transport/vstream.go
+++ b/pkg/transport/vstream.go
@@ -26,12 +26,15 @@
 package transport
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -70,9 +73,18 @@ type VStreamMux struct {
 	tm         *Manager
 	packetType routing.PacketType // which route-ID-0 packet type to use
 
-	streams   map[uint64]*VStream
+	// streams is keyed by (transport, wire stream id): ids are only unique
+	// per peer pair, and both ends allocate them. Local ids take the parity
+	// nextIDFor derives from the two PKs, so a stream this side opened can
+	// never collide with one the peer opened on the same transport.
+	streams   map[streamKey]*VStream
 	streamsMu sync.Mutex
 	streamID  uint64
+
+	// Counters for `visor state` (see Stats). Atomics.
+	framesUnknownStream int64 // DATA/FIN for a stream id we do not have
+	stalledStreams      int64 // streams closed because the reader never drained
+	acceptDropped       int64 // SYNs closed because Accept was not called in time
 
 	// relays holds active relay legs keyed by (inbound transport, wire
 	// streamID). Each direction of a bridged stream is registered pointing
@@ -102,7 +114,7 @@ func NewVStreamMux(tm *Manager, packetType routing.PacketType, log *logging.Logg
 		log:        log,
 		tm:         tm,
 		packetType: packetType,
-		streams:    make(map[uint64]*VStream),
+		streams:    make(map[streamKey]*VStream),
 		relays:     make(map[relayKey]relayKey),
 		maxRelays:  DefaultMaxRelayedVStreams,
 		incoming:   make(chan *VStream, 32),
@@ -110,8 +122,80 @@ func NewVStreamMux(tm *Manager, packetType routing.PacketType, log *logging.Logg
 	}
 }
 
-func (m *VStreamMux) nextID() uint64 {
-	return atomic.AddUint64(&m.streamID, 1)
+// streamKey identifies a stream on one transport. Wire ids are per peer pair.
+type streamKey struct {
+	tp uuid.UUID
+	id uint64
+}
+
+const (
+	// vstreamReadBuf is the per-stream inbound frame queue.
+	vstreamReadBuf = 1024
+	// vstreamStallTimeout is how long HandlePacket (the transport read loop)
+	// waits for a full queue to drain before it gives the stream up.
+	vstreamStallTimeout = 30 * time.Second
+	// vstreamAcceptTimeout bounds the wait for Accept on an inbound SYN.
+	vstreamAcceptTimeout = 5 * time.Second
+)
+
+// nextIDFor allocates a wire stream id for a stream this side opens to
+// remotePK. Both ends of a transport allocate ids, and the map is keyed per
+// transport, so the two allocators must not overlap: the side with the larger
+// PK uses odd ids, the other even. Before this both used a plain counter and,
+// with both sides freshly started, a tab's relay session and its host's RPC
+// dial to the tab got the same id — frames crossed streams and yamux died
+// with "invalid protocol version".
+func (m *VStreamMux) nextIDFor(remotePK cipher.PubKey) uint64 {
+	id := atomic.AddUint64(&m.streamID, 1) << 1
+	local := m.localPK()
+	if bytes.Compare(local[:], remotePK[:]) > 0 {
+		id |= 1
+	}
+	return id
+}
+
+// deliver queues one inbound DATA frame for the stream's reader, blocking the
+// transport's read loop (back-pressure) while the queue is full. A VStream
+// carries yamux/Noise sessions that assume a reliable ordered byte stream, so
+// a frame must never be dropped: that corrupts the session instead of closing
+// it. A reader that drains nothing for vstreamStallTimeout is dead — close the
+// stream so the peer sees EOF and the read loop is freed.
+func (m *VStreamMux) deliver(stream *VStream, buf []byte) {
+	select {
+	case stream.readBuf <- buf:
+		return
+	case <-stream.closed:
+		return
+	default:
+	}
+	t := time.NewTimer(vstreamStallTimeout)
+	defer t.Stop()
+	select {
+	case stream.readBuf <- buf:
+	case <-stream.closed:
+	case <-t.C:
+		atomic.AddInt64(&m.stalledStreams, 1)
+		m.log.WithField("stream", stream.id).WithField("remote", stream.remotePK.String()).
+			Warn("vstream: reader stalled; closing stream")
+		stream.Close() //nolint:errcheck,gosec
+	}
+}
+
+// offerIncoming hands an inbound stream to Accept, waiting up to
+// vstreamAcceptTimeout for the accept loop; a mux nobody accepts from closes
+// the stream (counted) instead of leaking it.
+func (m *VStreamMux) offerIncoming(stream *VStream, what string) {
+	t := time.NewTimer(vstreamAcceptTimeout)
+	defer t.Stop()
+	select {
+	case m.incoming <- stream:
+	case <-m.done:
+		stream.Close() //nolint:errcheck,gosec
+	case <-t.C:
+		atomic.AddInt64(&m.acceptDropped, 1)
+		m.log.Warn("vstream: " + what + " not accepted in time; closing")
+		stream.Close() //nolint:errcheck,gosec
+	}
 }
 
 func (m *VStreamMux) localPK() cipher.PubKey {
@@ -224,18 +308,18 @@ func (m *VStreamMux) DialByTransportID(remotePK cipher.PubKey, tpID uuid.UUID) (
 
 // DialOnTransport opens a virtual stream on a specific transport.
 func (m *VStreamMux) DialOnTransport(tp *ManagedTransport) (*VStream, error) {
-	id := m.nextID()
+	id := m.nextIDFor(tp.Remote())
 	stream := &VStream{
 		id:       id,
 		remotePK: tp.Remote(),
 		tpID:     tp.Entry.ID,
-		readBuf:  make(chan []byte, 64),
+		readBuf:  make(chan []byte, vstreamReadBuf),
 		closed:   make(chan struct{}),
 		mux:      m,
 	}
 
 	m.streamsMu.Lock()
-	m.streams[id] = stream
+	m.streams[streamKey{tp.Entry.ID, id}] = stream
 	m.streamsMu.Unlock()
 
 	// Send SYN.
@@ -287,47 +371,40 @@ func (m *VStreamMux) HandlePacket(p routing.Packet, mt *ManagedTransport) {
 			id:       streamID,
 			remotePK: remotePK,
 			tpID:     mt.Entry.ID,
-			readBuf:  make(chan []byte, 64),
+			readBuf:  make(chan []byte, vstreamReadBuf),
 			closed:   make(chan struct{}),
 			mux:      m,
 		}
 		m.streamsMu.Lock()
-		m.streams[streamID] = stream
+		m.streams[streamKey{mt.Entry.ID, streamID}] = stream
 		m.streamsMu.Unlock()
-
-		select {
-		case m.incoming <- stream:
-		default:
-			m.log.Warn("vstream: incoming stream dropped (buffer full)")
-			stream.Close() //nolint:errcheck,gosec
-		}
+		m.offerIncoming(stream, "incoming stream")
 
 	case flags&VStreamFlagFin != 0:
+		key := streamKey{mt.Entry.ID, streamID}
 		m.streamsMu.Lock()
-		stream, ok := m.streams[streamID]
+		stream, ok := m.streams[key]
 		if ok {
-			delete(m.streams, streamID)
+			delete(m.streams, key)
 		}
 		m.streamsMu.Unlock()
 		if ok {
 			stream.Close() //nolint:errcheck,gosec
+		} else {
+			atomic.AddInt64(&m.framesUnknownStream, 1)
 		}
 
 	default: // DATA
 		m.streamsMu.Lock()
-		stream, ok := m.streams[streamID]
+		stream, ok := m.streams[streamKey{mt.Entry.ID, streamID}]
 		m.streamsMu.Unlock()
 		if !ok {
+			atomic.AddInt64(&m.framesUnknownStream, 1)
 			return
 		}
 		buf := make([]byte, len(data))
 		copy(buf, data)
-		select {
-		case stream.readBuf <- buf:
-		case <-stream.closed:
-		default:
-			m.log.Warn("vstream: read buffer full, dropping data")
-		}
+		m.deliver(stream, buf)
 	}
 }
 
@@ -398,9 +475,32 @@ func (s *VStream) Read(p []byte) (int, error) {
 	}
 }
 
-// Write implements io.Writer.
+// vstreamMaxData is the most payload one DATA frame carries: the transport
+// packet size field is 16 bits and the frame header takes VStreamHeaderSize
+// of it.
+const vstreamMaxData = math.MaxUint16 - VStreamHeaderSize
+
+// Write implements io.Writer, segmenting p into frames of at most
+// vstreamMaxData bytes. Before this the whole of p went into ONE packet whose
+// 16-bit size field silently truncated (uint16(len)), so a yamux frame or RPC
+// reply over 64 KiB was written in full but declared short — the receiver
+// parsed the excess as packet headers ("unknown packet type: Unknown(112)"
+// with ASCII payload bytes as the type) and the session on top died with
+// "invalid protocol version".
 func (s *VStream) Write(p []byte) (int, error) {
-	return len(p), s.sendFlag(VStreamFlagData, p)
+	n := 0
+	for len(p) > 0 {
+		chunk := p
+		if len(chunk) > vstreamMaxData {
+			chunk = p[:vstreamMaxData]
+		}
+		if err := s.sendFlag(VStreamFlagData, chunk); err != nil {
+			return n, err
+		}
+		n += len(chunk)
+		p = p[len(chunk):]
+	}
+	return n, nil
 }
 
 // Close closes the virtual stream.
@@ -408,7 +508,7 @@ func (s *VStream) Close() error {
 	s.once.Do(func() {
 		close(s.closed)
 		s.mux.streamsMu.Lock()
-		delete(s.mux.streams, s.id)
+		delete(s.mux.streams, streamKey{s.tpID, s.id})
 		s.mux.streamsMu.Unlock()
 		// Best-effort FIN — don't block if transport is dead.
 		s.sendFlag(VStreamFlagFin, nil) //nolint:errcheck,gosec
@@ -435,6 +535,9 @@ func (s *VStream) sendFlag(flag byte, data []byte) error {
 		return fmt.Errorf("vstream write: transport %s: %w", s.tpID, err)
 	}
 
+	if len(data) > vstreamMaxData {
+		return fmt.Errorf("vstream write: frame of %d bytes exceeds %d", len(data), vstreamMaxData)
+	}
 	localPK := s.mux.localPK()
 	payload := make([]byte, VStreamHeaderSize+len(data))
 	binary.BigEndian.PutUint64(payload[:8], s.id)
@@ -448,4 +551,32 @@ func (s *VStream) sendFlag(flag byte, data []byte) error {
 	copy(pkt[routing.PacketPayloadOffset:], payload)
 
 	return tp.WriteRawPacket(pkt)
+}
+
+// VStreamMuxStats is the mux's `visor state` view: what the logs used to be the
+// only window on. Counters are cumulative since start.
+type VStreamMuxStats struct {
+	PacketType          string `json:"packet_type"`
+	Streams             int    `json:"streams"`
+	RelayLegs           int64  `json:"relay_legs"`
+	FramesUnknownStream int64  `json:"frames_unknown_stream"`
+	StalledStreams      int64  `json:"stalled_streams"`
+	AcceptDropped       int64  `json:"accept_dropped"`
+}
+
+// Stats snapshots the mux counters. FramesUnknownStream climbing on a healthy
+// link means frames are arriving for streams this side does not have: the
+// peer's transport lost a handler (see Manager.applyHandlers) or ids collided.
+func (m *VStreamMux) Stats() VStreamMuxStats {
+	m.streamsMu.Lock()
+	n := len(m.streams)
+	m.streamsMu.Unlock()
+	return VStreamMuxStats{
+		PacketType:          m.packetType.String(),
+		Streams:             n,
+		RelayLegs:           atomic.LoadInt64(&m.relayCount),
+		FramesUnknownStream: atomic.LoadInt64(&m.framesUnknownStream),
+		StalledStreams:      atomic.LoadInt64(&m.stalledStreams),
+		AcceptDropped:       atomic.LoadInt64(&m.acceptDropped),
+	}
 }

--- a/pkg/transport/vstream_relay.go
+++ b/pkg/transport/vstream_relay.go
@@ -9,6 +9,7 @@ package transport
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"sync/atomic"
 
 	"github.com/google/uuid"
@@ -104,19 +105,14 @@ func (m *VStreamMux) handleRelaySyn(mt *ManagedTransport, wireID uint64, senderP
 			id:       wireID,
 			remotePK: senderPK,
 			tpID:     mt.Entry.ID,
-			readBuf:  make(chan []byte, 64),
+			readBuf:  make(chan []byte, vstreamReadBuf),
 			closed:   make(chan struct{}),
 			mux:      m,
 		}
 		m.streamsMu.Lock()
-		m.streams[wireID] = stream
+		m.streams[streamKey{mt.Entry.ID, wireID}] = stream
 		m.streamsMu.Unlock()
-		select {
-		case m.incoming <- stream:
-		default:
-			m.log.Warn("vstream relay: incoming (relayed) stream dropped (buffer full)")
-			stream.Close() //nolint:errcheck,gosec
-		}
+		m.offerIncoming(stream, "incoming (relayed) stream")
 		return
 	}
 
@@ -137,7 +133,7 @@ func (m *VStreamMux) handleRelaySyn(mt *ManagedTransport, wireID uint64, senderP
 		return
 	}
 
-	outID := m.nextID()
+	outID := m.nextIDFor(outTp.Remote())
 	inKey := relayKey{tp: mt.Entry.ID, streamID: wireID}
 	outKey := relayKey{tp: outTp.Entry.ID, streamID: outID}
 	m.registerRelayLeg(inKey, outKey)
@@ -170,7 +166,7 @@ func (m *VStreamMux) DialThroughRelay(relayPK, dstPK cipher.PubKey, appName stri
 		}
 	}
 
-	id := m.nextID()
+	id := m.nextIDFor(relayTp.Remote())
 	sig, err := cipher.SignPayload(relaySigPayload(id, m.localPK(), dstPK), m.tm.Conf.SecKey)
 	if err != nil {
 		return nil, fmt.Errorf("vstream: sign relay SYN: %w", err)
@@ -180,12 +176,12 @@ func (m *VStreamMux) DialThroughRelay(relayPK, dstPK cipher.PubKey, appName stri
 		id:       id,
 		remotePK: dstPK,
 		tpID:     relayTp.Entry.ID,
-		readBuf:  make(chan []byte, 64),
+		readBuf:  make(chan []byte, vstreamReadBuf),
 		closed:   make(chan struct{}),
 		mux:      m,
 	}
 	m.streamsMu.Lock()
-	m.streams[id] = stream
+	m.streams[streamKey{relayTp.Entry.ID, id}] = stream
 	m.streamsMu.Unlock()
 
 	// originID == id: the origin's own stream id, preserved end-to-end so the
@@ -216,6 +212,9 @@ func (m *VStreamMux) sendRelaySyn(tp *ManagedTransport, wireID uint64, senderPK,
 // writePayload frames payload as a route-ID-0 packet of this mux's type and
 // writes it on tp.
 func (m *VStreamMux) writePayload(tp *ManagedTransport, payload []byte) error {
+	if len(payload) > math.MaxUint16 {
+		return fmt.Errorf("vstream relay: frame of %d bytes exceeds the packet size field", len(payload))
+	}
 	pkt := make(routing.Packet, routing.PacketHeaderSize+len(payload))
 	pkt[routing.PacketTypeOffset] = byte(m.packetType)
 	binary.BigEndian.PutUint16(pkt[routing.PacketPayloadSizeOffset:], uint16(len(payload))) //nolint:gosec

--- a/pkg/visor/api_state.go
+++ b/pkg/visor/api_state.go
@@ -72,6 +72,11 @@ type StateSnapshot struct {
 	// snapshot, so the default payload is unchanged.
 	Proxy *proxystatus.Snapshot `json:"proxy,omitempty"`
 
+	// Diag is the in-process plumbing view (router intake, transport read
+	// queue and handlers, VStream muxes, dmsg ping/relay state, Go runtime) —
+	// see DiagSnapshot. Cheap; part of the default snapshot.
+	Diag *DiagSnapshot `json:"diag,omitempty"`
+
 	// Notes collects per-section errors ("routing: <err>") so the snapshot is
 	// self-describing about what it could and could not read.
 	Notes []string `json:"notes,omitempty"`
@@ -94,12 +99,13 @@ const (
 	SelectModules    = "modules"    // modules
 	SelectCXO        = "cxo"        // cxo feed publish-health
 	SelectProxy      = "proxy"      // visor-side proxystatus snapshot (skysocks); opt-in only
+	SelectDiag       = "diag"       // router intake, transport queues/handlers, vstream, dmsg ping/relay, runtime
 )
 
 // StateSelectKeys is the documented set of --select keys, in help order.
 var StateSelectKeys = []string{
 	SelectSummary, SelectHealth, SelectRouting, SelectMux,
-	SelectApps, SelectTransports, SelectModules, SelectCXO, SelectProxy,
+	SelectApps, SelectTransports, SelectModules, SelectCXO, SelectProxy, SelectDiag,
 }
 
 // stateFieldSet is the parsed --select set. A nil set means "everything in the
@@ -295,6 +301,10 @@ func (v *Visor) StateSnapshotProjected(fields []string) (*StateSnapshot, error) 
 		if cf := v.CXOFeedStates(); len(cf) > 0 {
 			snap.CXOFeeds = cf
 		}
+	}
+
+	if want.has(SelectDiag) {
+		snap.Diag = v.DiagSnapshot()
 	}
 
 	// proxy is opt-in (never in the default snapshot): the visor-side

--- a/pkg/visor/api_state_diag.go
+++ b/pkg/visor/api_state_diag.go
@@ -1,0 +1,209 @@
+// Package visor pkg/visor/api_state_diag.go c3-vis-api
+//
+// The `diag` section of `visor state`: the in-process plumbing — router
+// intake, transport read queue and per-transport handlers/pong health, VStream
+// muxes, dmsg session ping health and relay state, Go runtime — that until now
+// could only be inferred from logs. Every value is a cheap read of live
+// counters; the section is built for the default snapshot.
+package visor
+
+import (
+	"runtime"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/router"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// DiagSnapshot is the `diag` section of a StateSnapshot.
+type DiagSnapshot struct {
+	Runtime DiagRuntime `json:"runtime"`
+	// TransportReadQueue is the shared queue every transport read loop feeds
+	// and the router drains; at capacity, every transport stalls behind the
+	// router (pings and pongs included).
+	TransportReadQueue *DiagQueue `json:"transport_read_queue,omitempty"`
+	// Intake is the router's inbound-path view: unknown/control packets by
+	// type, stale-route drops, and each route group's app queue depth.
+	Intake *router.IntakeStats `json:"intake,omitempty"`
+	// VStream is one entry per virtual-stream mux (skynet forwarding,
+	// app-direct dials, visor RPC): open streams, relay legs, and frames that
+	// arrived for streams this side does not have.
+	VStream []DiagVStreamMux `json:"vstream,omitempty"`
+	// Dmsg is per-session ping health plus the relay nominee/backoff state.
+	Dmsg *DiagDmsg `json:"dmsg,omitempty"`
+	// Transports is per-transport liveness: missed pongs, last packet age,
+	// and which route-ID-0 handlers are wired (a missing one means that
+	// packet type is dropped by the router — #4725).
+	Transports []DiagTransport `json:"transports,omitempty"`
+}
+
+// DiagRuntime is the Go runtime at a glance.
+type DiagRuntime struct {
+	Goroutines  int     `json:"goroutines"`
+	HeapAllocMB float64 `json:"heap_alloc_mb"`
+	SysMB       float64 `json:"sys_mb"`
+	NumGC       uint32  `json:"num_gc"`
+	GoVersion   string  `json:"go_version"`
+}
+
+// DiagQueue is a bounded queue's depth and capacity.
+type DiagQueue struct {
+	Depth    int `json:"depth"`
+	Capacity int `json:"capacity"`
+}
+
+// DiagVStreamMux names one VStream mux and carries its counters.
+type DiagVStreamMux struct {
+	Name string `json:"name"`
+	transport.VStreamMuxStats
+}
+
+// DiagDmsg is the dmsg client's session and relay state.
+type DiagDmsg struct {
+	Sessions      []DiagDmsgSession `json:"sessions,omitempty"`
+	RelayNominees []cipher.PubKey   `json:"relay_nominees,omitempty"`
+	RelayingFor   []DiagRelayClient `json:"relaying_for,omitempty"`
+	RelayBackoff  []DiagRelayTimer  `json:"relay_backoff,omitempty"`
+	RelayDialSkip []DiagRelayTimer  `json:"relay_dial_skip,omitempty"`
+}
+
+// DiagDmsgSession is one dmsg session's liveness.
+type DiagDmsgSession struct {
+	PK        cipher.PubKey `json:"pk"`
+	Carrier   string        `json:"carrier"`
+	Protocol  string        `json:"protocol"`
+	Streams   int           `json:"streams"`
+	LatencyMS float64       `json:"latency_ms"`
+	// PingFails is the consecutive liveness-ping failures; 2 closes the session.
+	PingFails int `json:"ping_fails"`
+}
+
+// DiagRelayClient is a peer attached to this visor as its dmsg relay.
+type DiagRelayClient struct {
+	PK      cipher.PubKey `json:"pk"`
+	Streams int           `json:"streams"`
+}
+
+// DiagRelayTimer is a relay-side backoff or skip with its remaining time.
+type DiagRelayTimer struct {
+	PK         cipher.PubKey `json:"pk"`
+	RemainingS float64       `json:"remaining_s"`
+}
+
+// DiagTransport is one transport's liveness and wiring.
+type DiagTransport struct {
+	ID          uuid.UUID     `json:"id"`
+	Remote      cipher.PubKey `json:"remote"`
+	Type        string        `json:"type"`
+	MissedPongs int64         `json:"missed_pongs"`
+	PongSeen    bool          `json:"pong_seen"`
+	// LastRecvAgoS is seconds since the read loop last received any packet
+	// (-1 = never). A transport with pongs flowing but climbing app-level
+	// timeouts is the router-intake case, not a link problem.
+	LastRecvAgoS float64 `json:"last_recv_ago_s"`
+	// MalformedFrames counts frames whose type byte was outside the known
+	// range — the peer wrote a packet whose size field did not match it.
+	MalformedFrames int64    `json:"malformed_frames"`
+	Handlers        []string `json:"handlers,omitempty"`
+}
+
+// DiagSnapshot builds the diag section. Every part is best-effort on a
+// partially initialized visor: a missing subsystem leaves its field nil.
+func (v *Visor) DiagSnapshot() *DiagSnapshot {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	d := &DiagSnapshot{Runtime: DiagRuntime{
+		Goroutines:  runtime.NumGoroutine(),
+		HeapAllocMB: float64(m.HeapAlloc) / (1 << 20),
+		SysMB:       float64(m.Sys) / (1 << 20),
+		NumGC:       m.NumGC,
+		GoVersion:   runtime.Version(),
+	}}
+
+	if v.tpM != nil {
+		depth, capacity := v.tpM.ReadQueue()
+		d.TransportReadQueue = &DiagQueue{Depth: depth, Capacity: capacity}
+		now := time.Now()
+		v.tpM.WalkTransports(func(mt *transport.ManagedTransport) bool {
+			if mt.IsClosed() {
+				return true
+			}
+			ago := -1.0
+			if at := mt.LastRecvAt(); !at.IsZero() {
+				ago = now.Sub(at).Seconds()
+			}
+			d.Transports = append(d.Transports, DiagTransport{
+				ID:              mt.Entry.ID,
+				Remote:          mt.Remote(),
+				Type:            string(mt.Type()),
+				MissedPongs:     mt.MissedPongs(),
+				PongSeen:        mt.PongSeen(),
+				LastRecvAgoS:    ago,
+				MalformedFrames: mt.MalformedFrames(),
+				Handlers:        mt.Handlers(),
+			})
+			return true
+		})
+		sort.Slice(d.Transports, func(i, j int) bool { return d.Transports[i].ID.String() < d.Transports[j].ID.String() })
+	}
+
+	if is, ok := v.router.(interface{ IntakeStats() router.IntakeStats }); ok {
+		stats := is.IntakeStats()
+		d.Intake = &stats
+	}
+
+	for _, mux := range []struct {
+		name string
+		m    *transport.VStreamMux
+	}{
+		{"skynet_forward", v.skynetFwdMux},
+		{"app_direct", v.appDirectMux},
+		{"visor_rpc", v.transportRPCMux},
+	} {
+		if mux.m == nil {
+			continue
+		}
+		d.VStream = append(d.VStream, DiagVStreamMux{Name: mux.name, VStreamMuxStats: mux.m.Stats()})
+	}
+
+	if v.dmsgC != nil {
+		dd := &DiagDmsg{}
+		for _, s := range v.dmsgC.AllSessions() {
+			dd.Sessions = append(dd.Sessions, DiagDmsgSession{
+				PK:        s.RemotePK(),
+				Carrier:   s.Carrier(),
+				Protocol:  s.Protocol(),
+				Streams:   s.NumStreams(),
+				LatencyMS: float64(s.LastPing()) / 1e6,
+				PingFails: s.PingFails(),
+			})
+		}
+		sort.Slice(dd.Sessions, func(i, j int) bool { return dd.Sessions[i].PK.String() < dd.Sessions[j].PK.String() })
+		dd.RelayNominees = sortedPKs(v.dmsgC.RelayPeers())
+		for pk, n := range v.dmsgC.RelaySessionStreams() {
+			dd.RelayingFor = append(dd.RelayingFor, DiagRelayClient{PK: pk, Streams: n})
+		}
+		sort.Slice(dd.RelayingFor, func(i, j int) bool { return dd.RelayingFor[i].PK.String() < dd.RelayingFor[j].PK.String() })
+		dd.RelayBackoff = relayTimers(v.dmsgC.RelayBackoffs())
+		dd.RelayDialSkip = relayTimers(v.dmsgC.RelayDialSkips())
+		d.Dmsg = dd
+	}
+	return d
+}
+
+func relayTimers(m map[cipher.PubKey]time.Time) []DiagRelayTimer {
+	if len(m) == 0 {
+		return nil
+	}
+	now := time.Now()
+	out := make([]DiagRelayTimer, 0, len(m))
+	for pk, until := range m {
+		out = append(out, DiagRelayTimer{PK: pk, RemainingS: until.Sub(now).Seconds()})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].PK.String() < out[j].PK.String() })
+	return out
+}

--- a/pkg/visor/init_services.go
+++ b/pkg/visor/init_services.go
@@ -441,6 +441,7 @@ func initSkywireForwardConn(ctx context.Context, v *Visor, log *logging.Logger) 
 	// networker for outbound dials too.
 	if v.tpM != nil {
 		appDirectMux := transport.NewVStreamMux(v.tpM, routing.AppDirectPacket, log)
+		v.appDirectMux = appDirectMux
 		v.tpM.SetAppDirectHandler(appDirectMux.HandlePacket)
 		wireDirectDialPolicyHook(v, appDirectMux)
 		if n, err := appnet.ResolveNetworker(appnet.TypeSkynet); err == nil {

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -355,6 +355,7 @@ type Visor struct {
 	// Shared VStreamMux for skynet forwarding (route ID 0).
 	// Used by both the forwarding server (Accept) and the skynetweb dialer (Dial).
 	skynetFwdMux *transport.VStreamMux
+	appDirectMux *transport.VStreamMux // direct skywire-network app dials (route ID 0); diag only
 	// Shared VStreamMux for visor RPC over transport (VisorRPCPacket,
 	// route ID 0). Used by BOTH the TransportRPCServer's Accept loop
 	// AND by TransportRPCCall's outbound dial. Sharing one mux per


### PR DESCRIPTION
VStream.Write put the whole payload in one packet and truncated the 16-bit size field, so a yamux frame or RPC reply over 64 KiB was written in full but declared short. The receiver parsed the excess as packet headers ("unknown packet type: Unknown(112)", ASCII payload bytes as the type) and the dmsg relay session riding the stream died with "invalid protocol version". Writes are now segmented at the packet limit.

Streams were also keyed by id alone although both ends allocate ids, so a tab's relay session and its host's RPC dial to the tab could collide; streams are now keyed by (transport, id) with local ids on a PK-ordered parity. Inbound delivery applies back-pressure instead of dropping frames, and closes a stream whose reader stalls for 30 s.

`visor state` gains a `diag` section (router intake by packet type, route-group app queue depth, shared transport read queue, per-transport pong/handler/malformed-frame state, VStream mux counters, dmsg per-session ping failures and relay nominee/backoff state, Go runtime) so this layer is visible without log-grepping. #4484 stage 4.