### PR TITLE
fix(cli): pty, dmsg curl and reward dial the visor RPC through vnet

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/curl.go
+++ b/cmd/skywire-cli/commands/dmsg/curl.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/0magnet/bottle/vnet"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -446,7 +447,7 @@ func startDmsgClientWT(ctx context.Context, log *logging.Logger, pk cipher.PubKe
 
 func rpcClient(_ *cobra.Command) (visor.API, error) {
 	const rpcDialTimeout = time.Second * 5
-	conn, err := net.DialTimeout("tcp", rpcAddr, rpcDialTimeout)
+	conn, err := vnet.DialTimeout("tcp", rpcAddr, rpcDialTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/skywire-cli/commands/dmsg/pty.go
+++ b/cmd/skywire-cli/commands/dmsg/pty.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net"
 	"os"
 	"regexp"
 	"strconv"
 	"time"
 
+	"github.com/0magnet/bottle/vnet"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/toqueteos/webbrowser"
@@ -611,7 +611,7 @@ var ptyURLCmd = &cobra.Command{
 
 func ptyRPCClient(cmdFlags *pflag.FlagSet) visor.API {
 	const rpcDialTimeout = time.Second * 5
-	conn, err := net.DialTimeout("tcp", ptyRpcAddr, rpcDialTimeout)
+	conn, err := vnet.DialTimeout("tcp", ptyRpcAddr, rpcDialTimeout)
 	if err != nil {
 		internal.PrintFatalError(cmdFlags, fmt.Errorf("RPC connection failed; is skywire running?: %v", err))
 	}

--- a/cmd/skywire-cli/commands/reward/root.go
+++ b/cmd/skywire-cli/commands/reward/root.go
@@ -3,11 +3,11 @@ package clireward
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/0magnet/bottle/vnet"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -154,7 +154,7 @@ func longText() string {
 	//show configured reward address if valid configuration exists
 	// try RPC first to get the visor's actual reward address
 	const rpcDialTimeout = time.Second * 2
-	conn, dialErr := net.DialTimeout("tcp", clirpc.Addr, rpcDialTimeout)
+	conn, dialErr := vnet.DialTimeout("tcp", clirpc.Addr, rpcDialTimeout)
 	if dialErr == nil {
 		rpcLogger := logging.MustGetLogger("rpc-reward")
 		client := visor.NewRPCClient(rpcLogger, conn, visor.RPCPrefix, 0)


### PR DESCRIPTION
Three commands still opened their local RPC connection with net.DialTimeout on localhost:3435. In a browser tab the netstack has no name resolution, so `skywire cli pty exec` failed with "lookup localhost" before dialing anything, while every other command (which goes through vnet.DialTimeout) works. Use vnet for these three too. Found running the #4484 stage-4 dmsgpty check from the desk tab.