### PR TITLE
feat(dmsg): browser visor is an unpublished dmsg client; relay-only sessions

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -509,7 +509,10 @@ func (ce *Client) Serve(ctx context.Context) {
 	porterReapLoopOnce := new(sync.Once)
 	reapLoopOnce := new(sync.Once)
 
-	needInitialPost := true
+	// An unpublished client (Config.NoRegister) never posts an entry; it also
+	// deletes any stale one it left behind while it was published.
+	needInitialPost := !ce.noRegister
+	staleEntryChecked := false
 
 serve:
 	for {
@@ -685,6 +688,10 @@ serve:
 				ce.log.Info("Initial post entry succeeded")
 				needInitialPost = false
 			}
+		}
+		if ce.noRegister && !staleEntryChecked {
+			staleEntryChecked = true
+			go ce.deleteOwnEntry(cancellabelCtx)
 		}
 
 		for n, entry := range entries {
@@ -1582,6 +1589,12 @@ func (ce *Client) reapExcessIdleSessions(idleStreak map[cipher.PubKey]int, idleC
 	min := ce.MinSessions()
 	if min <= 0 {
 		return
+	}
+	if ce.noRegister && ce.hasRelaySession() {
+		// An unpublished client with a relay attached keeps no server-session
+		// floor: the relay carries its dmsg; servers are dialed on demand and
+		// reaped when idle. The relay session itself is never idle (see below).
+		min = 1
 	}
 	ce.sessionsMx.Lock()
 	sessions := make(map[cipher.PubKey]*SessionCommon, len(ce.sessions))

--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -378,6 +378,12 @@ func (ce *Client) hasRelaySession() bool {
 // met, and — when relays are nominated and dialable — at least one relay
 // session held. Only meaningful when MinSessions != 0.
 func (ce *Client) sessionsSatisfied() bool {
+	if ce.noRegister && ce.hasRelaySession() {
+		// Unpublished client on a relay: the relay is the session. Holding
+		// MinSessions servers besides it would only republish what the relay
+		// already carries (#4484 stage 4: exactly one session).
+		return true
+	}
 	if ce.SessionCount() < ce.conf.MinSessions {
 		return false
 	}

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -1439,3 +1439,36 @@ func (c *EntityCommon) nudgeEntryUpdate() {
 func (c *EntityCommon) recordUpdate() {
 	atomic.StoreInt64(&c.lastUpdate, time.Now().UnixNano())
 }
+
+// Unpublished reports whether this entity publishes no discovery entry
+// (Config.NoRegister). For `visor state`.
+func (c *EntityCommon) Unpublished() bool { return c.noRegister }
+
+// deleteOwnEntry removes this entity's discovery entry if one exists — an
+// unpublished client that was published in an earlier life (or by an older
+// build) would otherwise keep advertising delegated servers it no longer
+// holds sessions with. Best effort: a discovery that has no entry, or that
+// cannot be reached, is left alone.
+func (c *EntityCommon) deleteOwnEntry(ctx context.Context) {
+	for _, ep := range c.snapshotDiscoveries() {
+		callCtx, cancel := context.WithTimeout(ctx, entryUpdateAttemptTimeout)
+		entry, err := ep.Client.Entry(callCtx, c.pk)
+		if err != nil || entry == nil {
+			cancel()
+			continue
+		}
+		entry.Sequence++
+		entry.Timestamp = time.Now().UnixNano()
+		if err := entry.Sign(c.sk); err != nil {
+			cancel()
+			c.log.WithError(err).Debug("Unpublished client: could not sign stale entry for deletion.")
+			continue
+		}
+		if err := ep.Client.DelEntry(callCtx, entry); err != nil {
+			c.log.WithError(err).Debug("Unpublished client: stale discovery entry not deleted.")
+		} else {
+			c.log.Info("Unpublished client: deleted stale discovery entry.")
+		}
+		cancel()
+	}
+}

--- a/pkg/dmsg/dmsg/relay_nominee_test.go
+++ b/pkg/dmsg/dmsg/relay_nominee_test.go
@@ -346,3 +346,46 @@ func TestRelayNominee_DialSkipsRelayAfterItFails(t *testing.T) {
 	require.True(t, c.relayDialSkipped(env.dstPK), "the relay is skipped for this destination now")
 	echoCheck(t, str, s)
 }
+
+// TestRelayNominee_UnpublishedClientHoldsRelayOnly: a client that publishes no
+// discovery entry (Config.NoRegister — the browser visor) keeps no server-
+// session floor once its relay is attached: the reaper trims idle server
+// sessions down to the relay alone and the serve loop does not re-dial them
+// (#4484 stage 4: exactly one dmsg session). A published client with the same
+// MinSessions would redial the server it just lost.
+func TestRelayNominee_UnpublishedClientHoldsRelayOnly(t *testing.T) {
+	env := newRelayedTestEnv(t, nil)
+	env.relay.maxRelayedStreams = 8
+	relayPK := env.relay.LocalPK()
+
+	pk, sk := GenKeyPair(t, "unpublished-client")
+	c := NewClient(pk, sk, env.dc, &Config{MinSessions: 2, NoRegister: true})
+	c.SetLogger(logging.MustGetLogger("unpublished-client"))
+	var dials atomic.Int32
+	c.SetSessionDialer(skynetDialer(t, env.relay, relayPK, nil, &dials))
+	go c.Serve(context.Background())
+	t.Cleanup(func() { _ = c.Close() }) //nolint:errcheck
+	require.Eventually(t, func() bool { _, ok := c.Session(env.srvPK); return ok }, 15*time.Second, 50*time.Millisecond)
+	require.True(t, c.Unpublished())
+	require.False(t, c.sessionsSatisfied(), "one server, MinSessions 2, no relay: not satisfied")
+
+	c.SetRelayPeers([]cipher.PubKey{relayPK}, 70)
+	require.Eventually(t, c.hasRelaySession, 15*time.Second, 50*time.Millisecond)
+	require.True(t, c.sessionsSatisfied(), "the relay alone satisfies an unpublished client")
+
+	// Idle server session reaped below MinSessions; the relay stays.
+	streak := map[cipher.PubKey]int{}
+	c.reapExcessIdleSessions(streak, 1)
+	require.Eventually(t, func() bool { _, ok := c.Session(env.srvPK); return !ok }, 5*time.Second, 50*time.Millisecond)
+	require.True(t, c.hasRelaySession())
+	require.Equal(t, 1, c.SessionCount())
+
+	// And it is not dialed straight back: still one session a little later.
+	time.Sleep(1500 * time.Millisecond)
+	require.Equal(t, 1, c.SessionCount(), "unpublished client must not redial servers to reach MinSessions")
+	require.True(t, c.sessionsSatisfied())
+
+	// Its entry was never posted.
+	_, err := env.dc.Entry(context.Background(), pk)
+	require.Error(t, err, "an unpublished client posts no discovery entry")
+}

--- a/pkg/dmsg/dmsgc/dmsgc.go
+++ b/pkg/dmsg/dmsgc/dmsgc.go
@@ -101,6 +101,8 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 		// the client must skip its own server entry in the serve loop rather
 		// than dial a transit session to itself.
 		SkipSelfServer: conf.Server != nil && conf.Server.Enabled,
+		// A browser visor publishes no discovery entry (browserUnpublished).
+		NoRegister: browserUnpublished,
 		// The visor runs a dmsg relay acceptor on skyenv.DmsgRelayPort (see
 		// initDmsgRelay): streams it carries for attached peers are bounded here.
 		MaxRelayedStreams: dmsg.DefaultClientMaxRelayedStreams,

--- a/pkg/dmsg/dmsgc/dmsgc_js.go
+++ b/pkg/dmsg/dmsgc/dmsgc_js.go
@@ -1,0 +1,12 @@
+//go:build js
+
+package dmsgc
+
+// browserUnpublished: a browser visor publishes no dmsg discovery entry. It is
+// reached over skynet (its host's transport, the forwarding mux) and its own
+// dmsg traffic rides its relay; an entry would only advertise server sessions
+// it does not hold. Route setup no longer needs the entry either — the
+// source-driven cascade is the browser default (#4730). Without an entry the
+// client also holds no server-session floor once a relay is attached (see
+// dmsg.Client sessionsSatisfied / reapExcessIdleSessions): #4484 stage 4.
+const browserUnpublished = true

--- a/pkg/dmsg/dmsgc/dmsgc_native.go
+++ b/pkg/dmsg/dmsgc/dmsgc_native.go
@@ -1,0 +1,7 @@
+//go:build !js
+
+package dmsgc
+
+// browserUnpublished is false on native builds: a native visor publishes its
+// discovery entry so peers can reach it over dmsg. See dmsgc_js.go.
+const browserUnpublished = false

--- a/pkg/visor/api_state_diag.go
+++ b/pkg/visor/api_state_diag.go
@@ -64,6 +64,8 @@ type DiagVStreamMux struct {
 
 // DiagDmsg is the dmsg client's session and relay state.
 type DiagDmsg struct {
+	// Unpublished: this client publishes no discovery entry (a browser visor).
+	Unpublished   bool              `json:"unpublished"`
 	Sessions      []DiagDmsgSession `json:"sessions,omitempty"`
 	RelayNominees []cipher.PubKey   `json:"relay_nominees,omitempty"`
 	RelayingFor   []DiagRelayClient `json:"relaying_for,omitempty"`
@@ -171,7 +173,7 @@ func (v *Visor) DiagSnapshot() *DiagSnapshot {
 	}
 
 	if v.dmsgC != nil {
-		dd := &DiagDmsg{}
+		dd := &DiagDmsg{Unpublished: v.dmsgC.Unpublished()}
 		for _, s := range v.dmsgC.AllSessions() {
 			dd.Sessions = append(dd.Sessions, DiagDmsgSession{
 				PK:        s.RemotePK(),


### PR DESCRIPTION
A browser visor is reached over skynet (its host's transport, the forwarding mux) and its own dmsg traffic rides its relay, so a discovery entry would only advertise server sessions it does not hold; with the source-driven cascade now the browser default (#4730) route setup no longer needs one. dmsgc sets NoRegister under js: the client posts no entry and deletes a stale one left from when it was published.

An unpublished client with a relay attached keeps no server-session floor: the relay alone satisfies the serve loop and the idle reaper trims server sessions down to it (servers are dialed on demand and reaped when idle). Published clients are unchanged. `visor state --select diag` shows dmsg.unpublished. #4484 stage 4: exactly one dmsg session, mdisc entry absent.