### PR TITLE
feat(visor): hypervisor pairing (pending keys, hv pair, one-time code); auth on at first run

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -2315,6 +2315,14 @@ func configureApps(log *logging.Logger) {
 		if isEnableAuth {
 			conf.Hypervisor.EnableAuth = true
 		}
+		// First run: the UI password gate is on unless the operator said
+		// --disable-auth. A regen keeps whatever the existing config has (the
+		// reset stays `skywire cli visor hv passwd --force`, on the board). Not
+		// in a browser tab: its visor keeps no users.db across reloads, so a
+		// forced gate there would demand a new password every load.
+		if !isRegen && !isDisableAuth && skyenv.OS != "js" {
+			conf.Hypervisor.EnableAuth = true
+		}
 	}
 	// Enable hypervisor UI authentication on windows & macos
 	if (selectedOS == "win") || (selectedOS == "mac") {

--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -543,3 +543,73 @@ var hvTreeCmd = &cobra.Command{
 	Hidden: true,
 	Run:    hvLsCmd.Run,
 }
+
+var (
+	hvPairCode bool
+	hvPairTTL  time.Duration
+)
+
+func init() {
+	hvPairCmd.Flags().BoolVar(&hvPairCode, "code", false, "mint a one-time pairing code to type into the tab instead of approving here")
+	hvPairCmd.Flags().DurationVar(&hvPairTTL, "ttl", 10*time.Minute, "how long a minted code stays valid")
+	hvCmd.AddCommand(hvPairCmd)
+}
+
+var hvPairCmd = &cobra.Command{
+	Use:   "pair [fingerprint|public-key]",
+	Short: "List pending hypervisors by fingerprint and approve one (or mint a one-time code)",
+	Long: `Pair a desk tab (or any peer) with this visor as its hypervisor.
+
+A peer that holds a same-origin transport to this visor, or that tried
+the transport RPC without being whitelisted, is PENDING. With no
+argument this lists pending keys by fingerprint; with a fingerprint
+(or a unique prefix of one, or a full public key) it approves that
+peer — the existing 'hv add' path, so the approval persists like one
+and takes effect at once.
+
+--code mints a one-time code instead. Type it into the tab's Pair
+window; the tab redeems it over the page's own origin. Codes expire
+after --ttl and are single-use; a few wrong codes revoke every
+outstanding one. Fingerprint = first 40 bits of sha256(pk).`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		switch {
+		case hvPairCode:
+			code, err := rpcClient.NewPairCode(hvPairTTL)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			internal.PrintOutput(cmd.Flags(), code,
+				fmt.Sprintf("Pairing code: %s  (valid until %s)\n", code.Code, code.Expires.Format(time.Kitchen)))
+		case len(args) == 1:
+			pk, err := rpcClient.ApproveHypervisor(args[0])
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			internal.PrintOutput(cmd.Flags(), map[string]any{"pk": pk.Hex(), "paired": true},
+				fmt.Sprintf("Paired %s (%s)\n", pk.Hex(), visor.HypervisorFingerprint(pk)))
+		default:
+			pending, err := rpcClient.PendingHypervisors()
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			if len(pending) == 0 {
+				internal.PrintOutput(cmd.Flags(), pending, "No pending hypervisors.\n")
+				return
+			}
+			var b strings.Builder
+			tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(tw, "FINGERPRINT\tVIA\tFIRST SEEN\tLAST SEEN\tPUBLIC KEY")
+			for _, p := range pending {
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", p.Fingerprint, p.Via,
+					p.FirstSeen.Format(time.Kitchen), p.LastSeen.Format(time.Kitchen), p.PK.Hex())
+			}
+			_ = tw.Flush() //nolint:errcheck
+			internal.PrintOutput(cmd.Flags(), pending, b.String())
+		}
+	},
+}

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -41,6 +41,20 @@ skywire cli config gen -i
 
 After starting up the visor, the UI will be exposed by default on `localhost:8000`.
 
+From another device on the same LAN, use the machine's mDNS name:
+`http://<hostname>.local:8000/`. That name comes from the OS (Avahi on
+Linux, Bonjour on macOS/Windows); the visor advertises nothing itself.
+
+The UI password gate is on for a freshly generated hypervisor config; the
+first visit creates the admin account, and the reset is
+`skywire cli visor hv passwd --force` on the machine itself.
+
+A desk tab opened from that page runs its own visor and asks to drive the
+host as a hypervisor. Approve it on the machine with
+`skywire cli visor hv pair` (lists pending tabs by fingerprint, then
+`hv pair <fingerprint>`), or mint a one-time code with
+`skywire cli visor hv pair --code` and type it into the tab's Pair window.
+
 ## Hypervisor terminal UI
 
 A terminal-based hypervisor that mirrors the web UI's read and write actions

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -378,6 +378,14 @@ type API interface {
 	DmsgReconnect() (int, error)
 	DmsgSetMinSessions(n int) error
 	AddHypervisor(pk cipher.PubKey) error
+	// PendingHypervisors lists peers waiting to be approved as hypervisors
+	// (a same-origin transport or a refused RPC), by fingerprint.
+	PendingHypervisors() ([]PendingHypervisor, error)
+	// ApproveHypervisor approves a pending key by public key or fingerprint
+	// (or unique prefix); it is AddHypervisor with a lookup in front.
+	ApproveHypervisor(sel string) (cipher.PubKey, error)
+	// NewPairCode mints a one-time pairing code valid for ttl (0 = default).
+	NewPairCode(ttl time.Duration) (PairCode, error)
 	RemoveHypervisor(pk cipher.PubKey) error
 	RemoveAllHypervisors() (int, error)
 	SetHypervisorPassword(oldPassword, newPassword string) error

--- a/pkg/visor/api_hypervisors.go
+++ b/pkg/visor/api_hypervisors.go
@@ -67,6 +67,16 @@ func (v *Visor) AddHypervisor(hvPK cipher.PubKey) error {
 	// hypervisor, not just connecting once). Best-effort — see persistHypervisors.
 	v.persistHypervisors(addPK(v.configuredHypervisors(), hvPK))
 
+	// A hypervisor drives this visor over RPC and pty: admit it now, not on
+	// the next restart when the whitelist is rebuilt from config (#4484 stage
+	// 5 — approval must take effect while the tab waits).
+	if v.peerWhitelist != nil {
+		if err := v.peerWhitelist.Add(hvPK); err == nil {
+			v.refreshGatedCXOAllowlists()
+		}
+	}
+	v.hvPairingState().forget(hvPK)
+
 	return nil
 }
 

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -1098,6 +1098,12 @@ func (hv *Hypervisor) makeMux() chi.Router {
 		// reason /ws is: /api's timeout middleware is not an http.Hijacker.
 		r.Get("/tp/ws", hv.getTransportWS())
 
+		// /pair — pairing for a tab that has no session yet: its own standing,
+		// and the one-time-code fallback to `skywire cli visor hv pair`. See
+		// hypervisor_handlers_pair.go.
+		r.Get("/pair/status", hv.getPairStatus())
+		r.Post("/pair", hv.postPair())
+
 		// Mount tp-viz UI if enabled.
 		//
 		// Inside its own authenticated group: these paths sit OUTSIDE the

--- a/pkg/visor/hypervisor_handlers_pair.go
+++ b/pkg/visor/hypervisor_handlers_pair.go
@@ -1,0 +1,66 @@
+// Package visor pkg/visor/hypervisor_handlers_pair.go c3-vis-api
+//
+// Pre-auth pairing endpoints (#4484 stage 5). A desk tab this hypervisor
+// serves has no session yet; it learns its own standing from GET /pair/status
+// and, as the fallback to `skywire cli visor hv pair`, redeems a one-time code
+// the operator made on the board with POST /pair. Both sit beside /tp/ws,
+// outside the session-auth group; the code is the credential, single-use and
+// revoked after a few wrong attempts.
+package visor
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/httputil"
+)
+
+// getPairStatus — GET /pair/status?pk=<hex>: whether pk is paired (trusted)
+// or pending, plus its fingerprint for the operator to match on the board.
+func (hv *Hypervisor) getPairStatus() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if hv.visor == nil {
+			httputil.WriteJSON(w, r, http.StatusServiceUnavailable, "no visor behind this hypervisor")
+			return
+		}
+		var pk cipher.PubKey
+		if err := pk.Set(r.URL.Query().Get("pk")); err != nil {
+			httputil.WriteJSON(w, r, http.StatusBadRequest, "pk: "+err.Error())
+			return
+		}
+		httputil.WriteJSON(w, r, http.StatusOK, hv.visor.PairStatusOf(pk))
+	}
+}
+
+type pairRequest struct {
+	PK   cipher.PubKey `json:"pk"`
+	Code string        `json:"code"`
+}
+
+// postPair — POST /pair {"pk","code"}: approve pk if code is an outstanding
+// one-time code. Any failure is 403 with one message, so a guess learns
+// nothing about which codes exist.
+func (hv *Hypervisor) postPair() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if hv.visor == nil {
+			httputil.WriteJSON(w, r, http.StatusServiceUnavailable, "no visor behind this hypervisor")
+			return
+		}
+		var req pairRequest
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&req); err != nil {
+			httputil.WriteJSON(w, r, http.StatusBadRequest, "body: "+err.Error())
+			return
+		}
+		if err := hv.visor.PairWithCode(req.PK, req.Code); err != nil {
+			if errors.Is(err, ErrPairCodeInvalid) {
+				httputil.WriteJSON(w, r, http.StatusForbidden, ErrPairCodeInvalid.Error())
+				return
+			}
+			httputil.WriteJSON(w, r, http.StatusInternalServerError, err.Error())
+			return
+		}
+		httputil.WriteJSON(w, r, http.StatusOK, hv.visor.PairStatusOf(req.PK))
+	}
+}

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -1023,17 +1023,20 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 		if v.conf.Pty != nil {
 			whitelistPKs = append(whitelistPKs, v.conf.Pty.Whitelist...)
 		}
-		if len(whitelistPKs) > 0 {
-			tpRPCS, tpRPCErr := newRPCServer(v, "TransportRPC")
-			if tpRPCErr != nil {
-				log.WithError(tpRPCErr).Warn("Failed to create transport RPC server")
-			} else {
-				tpRPCSrv := NewTransportRPCServer(tpRPCLog, tpRPCS, v.peerWhitelist, v.transportRPCMux)
-				v.pushCloseStack("transport_rpc.server", tpRPCSrv.Close)
-				go tpRPCSrv.Serve()
-				tpRPCLog.WithField("whitelist_pks", len(whitelistPKs)).
-					Info("Transport RPC server started (VisorRPCPacket on route ID 0)")
-			}
+		// Always serve: the whitelist is consulted live per stream, so a peer
+		// approved at runtime (`hv pair`) is admitted without a restart; with
+		// nothing whitelisted every stream is refused — and recorded as a
+		// pending hypervisor for the operator to approve.
+		tpRPCS, tpRPCErr := newRPCServer(v, "TransportRPC")
+		if tpRPCErr != nil {
+			log.WithError(tpRPCErr).Warn("Failed to create transport RPC server")
+		} else {
+			tpRPCSrv := NewTransportRPCServer(tpRPCLog, tpRPCS, v.peerWhitelist, v.transportRPCMux)
+			tpRPCSrv.SetRejectedHook(func(pk cipher.PubKey) { v.notePendingHypervisor(pk, "rpc") })
+			v.pushCloseStack("transport_rpc.server", tpRPCSrv.Close)
+			go tpRPCSrv.Serve()
+			tpRPCLog.WithField("whitelist_pks", len(whitelistPKs)).
+				Info("Transport RPC server started (VisorRPCPacket on route ID 0)")
 		}
 	}
 

--- a/pkg/visor/init_dmsg_relay.go
+++ b/pkg/visor/init_dmsg_relay.go
@@ -147,6 +147,7 @@ func (v *Visor) nominateRelayPeers(ctx context.Context, dmsgC *dmsg.Client, log 
 		case <-ctx.Done():
 			return
 		case <-t.C:
+			v.scanPendingPairs()
 			nominees := v.relayNominees()
 			if dmsgC.SetRelayPeers(nominees, skyenv.DmsgRelayPort) {
 				log.WithField("nominees", nominees).Info("dmsg relay nominees changed")

--- a/pkg/visor/pairing_hv.go
+++ b/pkg/visor/pairing_hv.go
@@ -1,0 +1,344 @@
+// Package visor pkg/visor/pairing_hv.go c3-vis-api
+//
+// Hypervisor pairing (#4484 stage 5). A peer that holds a same-origin
+// transport to this visor (a desk tab the hypervisor serves) or that tried the
+// transport RPC without being whitelisted is a PENDING hypervisor: listed by
+// fingerprint for `skywire cli visor hv pair`, and approved either there or
+// with a one-time code the operator makes on the board and types into the
+// tab. Approval is the existing AddHypervisor path, so the host dials the
+// peer as its hypervisor and lets it drive RPC and pty — and nothing else
+// grants that.
+package visor
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+const (
+	// pairPendingMax bounds the pending list; the oldest entry goes first.
+	pairPendingMax = 64
+	// pairCodeLen is the one-time code length; the alphabet omits 0/O/1/I.
+	pairCodeLen      = 8
+	pairCodeAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+	// pairCodeDefaultTTL is how long a code stays valid unless the CLI says.
+	pairCodeDefaultTTL = 10 * time.Minute
+	// pairCodeMaxTries is the number of wrong codes accepted before every
+	// outstanding code is revoked (a new one has to be made on the board).
+	pairCodeMaxTries = 5
+)
+
+// ErrPairCodeInvalid is returned for any code that does not pair: unknown,
+// expired, already used, or revoked. Deliberately one error.
+var ErrPairCodeInvalid = errors.New("pairing: invalid code")
+
+// ErrNoPendingMatch is returned when a selection matches no pending key.
+var ErrNoPendingMatch = errors.New("pairing: no pending key matches")
+
+// PendingHypervisor is a peer that asked to drive this visor but is not yet
+// in its hypervisor list.
+type PendingHypervisor struct {
+	PK          cipher.PubKey `json:"pk"`
+	Fingerprint string        `json:"fingerprint"`
+	FirstSeen   time.Time     `json:"first_seen"`
+	LastSeen    time.Time     `json:"last_seen"`
+	// Via is how the peer was noticed: "transport" (it holds a same-origin
+	// transport to us) or "rpc" (it tried the transport RPC and was refused).
+	Via string `json:"via"`
+}
+
+// PairCode is a one-time pairing code and when it stops working.
+type PairCode struct {
+	Code    string    `json:"code"`
+	Expires time.Time `json:"expires"`
+}
+
+// PairStatus is the pre-auth view a tab gets of its own standing.
+type PairStatus struct {
+	PK          cipher.PubKey `json:"pk"`
+	Fingerprint string        `json:"fingerprint"`
+	Paired      bool          `json:"paired"`
+	Pending     bool          `json:"pending"`
+}
+
+// HypervisorFingerprint is the short, stable name a pending key is approved
+// by: the first 40 bits of sha256(pk) as two hex groups ("a1b2c-3d4e5").
+func HypervisorFingerprint(pk cipher.PubKey) string {
+	sum := sha256.Sum256(pk[:])
+	s := hex.EncodeToString(sum[:5])
+	return s[:5] + "-" + s[5:]
+}
+
+type hvPairing struct {
+	mu      sync.Mutex
+	pending map[cipher.PubKey]*PendingHypervisor
+	codes   map[string]time.Time // code → expiry
+	tries   int
+}
+
+func newHVPairing() *hvPairing {
+	return &hvPairing{
+		pending: make(map[cipher.PubKey]*PendingHypervisor),
+		codes:   make(map[string]time.Time),
+	}
+}
+
+// note records pk as pending (or refreshes it). Returns true when new.
+func (p *hvPairing) note(pk cipher.PubKey, via string, now time.Time) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if e, ok := p.pending[pk]; ok {
+		e.LastSeen = now
+		if via == "rpc" {
+			e.Via = via // an RPC attempt is the stronger signal
+		}
+		return false
+	}
+	for len(p.pending) >= pairPendingMax {
+		var oldest cipher.PubKey
+		var oldestAt time.Time
+		for k, e := range p.pending {
+			if oldestAt.IsZero() || e.LastSeen.Before(oldestAt) {
+				oldest, oldestAt = k, e.LastSeen
+			}
+		}
+		delete(p.pending, oldest)
+	}
+	p.pending[pk] = &PendingHypervisor{
+		PK: pk, Fingerprint: HypervisorFingerprint(pk), FirstSeen: now, LastSeen: now, Via: via,
+	}
+	return true
+}
+
+func (p *hvPairing) forget(pk cipher.PubKey) {
+	p.mu.Lock()
+	delete(p.pending, pk)
+	p.mu.Unlock()
+}
+
+func (p *hvPairing) isPending(pk cipher.PubKey) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, ok := p.pending[pk]
+	return ok
+}
+
+func (p *hvPairing) list() []PendingHypervisor {
+	p.mu.Lock()
+	out := make([]PendingHypervisor, 0, len(p.pending))
+	for _, e := range p.pending {
+		out = append(out, *e)
+	}
+	p.mu.Unlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].LastSeen.After(out[j].LastSeen) })
+	return out
+}
+
+// resolve turns a selection — a full public key, or a fingerprint or unique
+// fingerprint prefix of a pending key — into the key.
+func (p *hvPairing) resolve(sel string) (cipher.PubKey, error) {
+	sel = strings.ToLower(strings.TrimSpace(sel))
+	if sel == "" {
+		return cipher.PubKey{}, ErrNoPendingMatch
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(sel); err == nil {
+		return pk, nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var found *PendingHypervisor
+	for _, e := range p.pending {
+		if e.Fingerprint == sel || strings.HasPrefix(e.Fingerprint, sel) {
+			if found != nil {
+				return cipher.PubKey{}, fmt.Errorf("pairing: %q matches more than one pending key", sel)
+			}
+			found = e
+		}
+	}
+	if found == nil {
+		return cipher.PubKey{}, ErrNoPendingMatch
+	}
+	return found.PK, nil
+}
+
+func (p *hvPairing) newCode(ttl time.Duration, now time.Time) (PairCode, error) {
+	if ttl <= 0 {
+		ttl = pairCodeDefaultTTL
+	}
+	buf := make([]byte, pairCodeLen)
+	if _, err := rand.Read(buf); err != nil {
+		return PairCode{}, err
+	}
+	code := make([]byte, pairCodeLen)
+	for i, b := range buf {
+		code[i] = pairCodeAlphabet[int(b)%len(pairCodeAlphabet)]
+	}
+	c := PairCode{Code: string(code), Expires: now.Add(ttl)}
+	p.mu.Lock()
+	p.pruneLocked(now)
+	p.codes[c.Code] = c.Expires
+	p.tries = 0
+	p.mu.Unlock()
+	return c, nil
+}
+
+// consume checks code (case- and separator-insensitive) against the
+// outstanding codes; a match is used up. Wrong codes count towards revoking
+// every code.
+func (p *hvPairing) consume(code string, now time.Time) error {
+	norm := normalizePairCode(code)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.pruneLocked(now)
+	var matched string
+	for c := range p.codes {
+		if subtle.ConstantTimeCompare([]byte(c), []byte(norm)) == 1 {
+			matched = c
+		}
+	}
+	if matched == "" {
+		p.tries++
+		if p.tries >= pairCodeMaxTries {
+			p.codes = make(map[string]time.Time)
+			p.tries = 0
+		}
+		return ErrPairCodeInvalid
+	}
+	delete(p.codes, matched)
+	p.tries = 0
+	return nil
+}
+
+func (p *hvPairing) pruneLocked(now time.Time) {
+	for c, exp := range p.codes {
+		if !exp.After(now) {
+			delete(p.codes, c)
+		}
+	}
+}
+
+func normalizePairCode(code string) string {
+	var b strings.Builder
+	for _, r := range strings.ToUpper(code) {
+		if r == ' ' || r == '-' || r == '_' {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// hvPairingState returns the hypervisor pairing state, made on first use.
+func (v *Visor) hvPairingState() *hvPairing {
+	v.hvPairOnce.Do(func() { v.hvPair = newHVPairing() })
+	return v.hvPair
+}
+
+// isTrustedPeer reports whether pk already drives this visor: itself, a
+// configured hypervisor, or a whitelisted pty/RPC peer.
+func (v *Visor) isTrustedPeer(pk cipher.PubKey) bool {
+	if v.conf != nil && pk == v.conf.PK {
+		return true
+	}
+	for _, hv := range v.configuredHypervisors() {
+		if hv == pk {
+			return true
+		}
+	}
+	if v.peerWhitelist != nil {
+		if ok, err := v.peerWhitelist.Get(pk); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// notePendingHypervisor records a peer that wants to drive this visor and is
+// not yet allowed to. via names how it was noticed.
+func (v *Visor) notePendingHypervisor(pk cipher.PubKey, via string) {
+	if pk.Null() || v.isTrustedPeer(pk) {
+		return
+	}
+	if v.hvPairingState().note(pk, via, time.Now()) {
+		v.log.WithField("pk", pk.String()).WithField("fingerprint", HypervisorFingerprint(pk)).
+			WithField("via", via).Info("Pending hypervisor: approve with `skywire cli visor hv pair <fingerprint>`")
+	}
+}
+
+// scanPendingPairs notices peers holding a same-origin (swsr, tptypes.WS) transport to
+// this visor that are not yet trusted — a desk tab this hypervisor serves.
+func (v *Visor) scanPendingPairs() {
+	if v.tpM == nil {
+		return
+	}
+	v.tpM.WalkTransports(func(mt *transport.ManagedTransport) bool {
+		if mt.Type() == tptypes.WS && !mt.IsClosed() {
+			v.notePendingHypervisor(mt.Remote(), "transport")
+		}
+		return true
+	})
+}
+
+// PendingHypervisors implements API: the peers waiting to be approved.
+func (v *Visor) PendingHypervisors() ([]PendingHypervisor, error) {
+	return v.hvPairingState().list(), nil
+}
+
+// ApproveHypervisor implements API: sel is a public key, or a fingerprint (or
+// unique prefix) of a pending key. Approval is AddHypervisor.
+func (v *Visor) ApproveHypervisor(sel string) (cipher.PubKey, error) {
+	pk, err := v.hvPairingState().resolve(sel)
+	if err != nil {
+		return cipher.PubKey{}, err
+	}
+	if err := v.AddHypervisor(pk); err != nil && !strings.Contains(err.Error(), "already connected") {
+		return pk, err
+	}
+	return pk, nil
+}
+
+// NewPairCode implements API: a one-time code a tab can present to be
+// approved without the CLI seeing its fingerprint.
+func (v *Visor) NewPairCode(ttl time.Duration) (PairCode, error) {
+	return v.hvPairingState().newCode(ttl, time.Now())
+}
+
+// PairWithCode approves pk if code is an outstanding one-time code.
+func (v *Visor) PairWithCode(pk cipher.PubKey, code string) error {
+	if pk.Null() {
+		return ErrPairCodeInvalid
+	}
+	if v.isTrustedPeer(pk) {
+		return nil
+	}
+	if err := v.hvPairingState().consume(code, time.Now()); err != nil {
+		v.log.WithField("pk", pk.String()).Warn("Pairing: rejected code")
+		return err
+	}
+	if err := v.AddHypervisor(pk); err != nil && !strings.Contains(err.Error(), "already connected") {
+		return err
+	}
+	return nil
+}
+
+// PairStatusOf reports whether pk is paired (trusted) or pending.
+func (v *Visor) PairStatusOf(pk cipher.PubKey) PairStatus {
+	return PairStatus{
+		PK: pk, Fingerprint: HypervisorFingerprint(pk),
+		Paired:  v.isTrustedPeer(pk),
+		Pending: v.hvPairingState().isPending(pk),
+	}
+}

--- a/pkg/visor/pairing_hv_test.go
+++ b/pkg/visor/pairing_hv_test.go
@@ -1,0 +1,85 @@
+package visor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestHypervisorFingerprint(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	fp := HypervisorFingerprint(pk)
+	require.Len(t, fp, 11)
+	require.Equal(t, fp, HypervisorFingerprint(pk), "stable")
+	pk2, _ := cipher.GenerateKeyPair()
+	require.NotEqual(t, fp, HypervisorFingerprint(pk2))
+}
+
+func TestHVPairing_PendingAndResolve(t *testing.T) {
+	p := newHVPairing()
+	now := time.Now()
+	pk, _ := cipher.GenerateKeyPair()
+	require.True(t, p.note(pk, "transport", now))
+	require.False(t, p.note(pk, "rpc", now.Add(time.Second)), "second sighting refreshes, not duplicates")
+	list := p.list()
+	require.Len(t, list, 1)
+	require.Equal(t, "rpc", list[0].Via, "an RPC attempt upgrades the reason")
+	require.Equal(t, now.Add(time.Second), list[0].LastSeen)
+
+	fp := HypervisorFingerprint(pk)
+	got, err := p.resolve(fp)
+	require.NoError(t, err)
+	require.Equal(t, pk, got)
+	got, err = p.resolve(fp[:4])
+	require.NoError(t, err)
+	require.Equal(t, pk, got, "a unique prefix resolves")
+	got, err = p.resolve(pk.Hex())
+	require.NoError(t, err)
+	require.Equal(t, pk, got, "a full key resolves without being pending")
+	_, err = p.resolve("zzzzz-zzzzz")
+	require.ErrorIs(t, err, ErrNoPendingMatch)
+
+	p.forget(pk)
+	require.False(t, p.isPending(pk))
+
+	// The list is bounded; the oldest sighting is evicted first.
+	oldest, _ := cipher.GenerateKeyPair()
+	p.note(oldest, "transport", now.Add(-time.Hour))
+	for i := 0; i < pairPendingMax; i++ {
+		k, _ := cipher.GenerateKeyPair()
+		p.note(k, "transport", now)
+	}
+	require.Len(t, p.list(), pairPendingMax)
+	require.False(t, p.isPending(oldest))
+}
+
+func TestHVPairing_Codes(t *testing.T) {
+	p := newHVPairing()
+	now := time.Now()
+	c, err := p.newCode(0, now)
+	require.NoError(t, err)
+	require.Len(t, c.Code, pairCodeLen)
+	require.Equal(t, now.Add(pairCodeDefaultTTL), c.Expires)
+
+	require.ErrorIs(t, p.consume("nope", now), ErrPairCodeInvalid)
+	// Case and separators do not matter to a human typing it.
+	spaced := c.Code[:4] + "-" + c.Code[4:]
+	require.NoError(t, p.consume(spaced, now))
+	require.ErrorIs(t, p.consume(c.Code, now), ErrPairCodeInvalid, "single use")
+
+	// Expiry.
+	c2, err := p.newCode(time.Minute, now)
+	require.NoError(t, err)
+	require.ErrorIs(t, p.consume(c2.Code, now.Add(2*time.Minute)), ErrPairCodeInvalid)
+
+	// Too many wrong codes revoke the outstanding ones.
+	c3, err := p.newCode(time.Hour, now)
+	require.NoError(t, err)
+	for i := 0; i < pairCodeMaxTries; i++ {
+		require.ErrorIs(t, p.consume("WRONG"+string(rune('A'+i)), now), ErrPairCodeInvalid)
+	}
+	require.ErrorIs(t, p.consume(c3.Code, now), ErrPairCodeInvalid, "revoked after repeated wrong codes")
+}

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -1102,6 +1102,18 @@ func (proxyDefaultAPI) AddHypervisor(_ cipher.PubKey) error {
 	return ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) PendingHypervisors() ([]PendingHypervisor, error) {
+	return nil, ErrProxyNotSupported
+}
+
+func (proxyDefaultAPI) ApproveHypervisor(_ string) (cipher.PubKey, error) {
+	return cipher.PubKey{}, ErrProxyNotSupported
+}
+
+func (proxyDefaultAPI) NewPairCode(_ time.Duration) (PairCode, error) {
+	return PairCode{}, ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) RemoveHypervisor(_ cipher.PubKey) error {
 	return ErrProxyNotSupported
 }

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -623,6 +623,27 @@ func (r *RPC) AddHypervisor(in *cipher.PubKey, _ *struct{}) (err error) {
 	return r.visor.AddHypervisor(*in)
 }
 
+// PendingHypervisors lists peers waiting to be approved as hypervisors.
+func (r *RPC) PendingHypervisors(_ *struct{}, out *[]PendingHypervisor) (err error) {
+	defer rpcutil.LogCall(r.log, "PendingHypervisors", nil)(out, &err)
+	*out, err = r.visor.PendingHypervisors()
+	return err
+}
+
+// ApproveHypervisor approves a pending key by public key or fingerprint.
+func (r *RPC) ApproveHypervisor(sel *string, out *cipher.PubKey) (err error) {
+	defer rpcutil.LogCall(r.log, "ApproveHypervisor", sel)(out, &err)
+	*out, err = r.visor.ApproveHypervisor(*sel)
+	return err
+}
+
+// NewPairCode mints a one-time pairing code.
+func (r *RPC) NewPairCode(ttl *time.Duration, out *PairCode) (err error) {
+	defer rpcutil.LogCall(r.log, "NewPairCode", ttl)(out, &err)
+	*out, err = r.visor.NewPairCode(*ttl)
+	return err
+}
+
 // RemoveHypervisor tears down a runtime-added hypervisor connection
 // by PK. Idempotent: succeeds with nil if the PK is not currently a
 // runtime-added hypervisor on this visor (covers double-rm, rm of a

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -2132,6 +2132,27 @@ func (rc *rpcClient) AddHypervisor(pk cipher.PubKey) error {
 	return rc.Call("AddHypervisor", &pk, &struct{}{})
 }
 
+// PendingHypervisors calls PendingHypervisors.
+func (rc *rpcClient) PendingHypervisors() ([]PendingHypervisor, error) {
+	var out []PendingHypervisor
+	err := rc.Call("PendingHypervisors", &struct{}{}, &out)
+	return out, err
+}
+
+// ApproveHypervisor calls ApproveHypervisor.
+func (rc *rpcClient) ApproveHypervisor(sel string) (cipher.PubKey, error) {
+	var out cipher.PubKey
+	err := rc.Call("ApproveHypervisor", &sel, &out)
+	return out, err
+}
+
+// NewPairCode calls NewPairCode.
+func (rc *rpcClient) NewPairCode(ttl time.Duration) (PairCode, error) {
+	var out PairCode
+	err := rc.Call("NewPairCode", &ttl, &out)
+	return out, err
+}
+
 // RemoveHypervisor tears down a runtime-added hypervisor connection.
 func (rc *rpcClient) RemoveHypervisor(pk cipher.PubKey) error {
 	return rc.Call("RemoveHypervisor", &pk, &struct{}{})

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1760,6 +1760,21 @@ func (mc *mockRPCClient) AddHypervisor(_ cipher.PubKey) error {
 	return nil
 }
 
+// PendingHypervisors implements API.
+func (mc *mockRPCClient) PendingHypervisors() ([]PendingHypervisor, error) {
+	return nil, nil
+}
+
+// ApproveHypervisor implements API.
+func (mc *mockRPCClient) ApproveHypervisor(_ string) (cipher.PubKey, error) {
+	return cipher.PubKey{}, nil
+}
+
+// NewPairCode implements API.
+func (mc *mockRPCClient) NewPairCode(_ time.Duration) (PairCode, error) {
+	return PairCode{}, nil
+}
+
 // RemoveHypervisor implements API.
 func (mc *mockRPCClient) RemoveHypervisor(_ cipher.PubKey) error {
 	return nil

--- a/pkg/visor/transport_rpc.go
+++ b/pkg/visor/transport_rpc.go
@@ -10,6 +10,7 @@
 package visor
 
 import (
+	"github.com/skycoin/skywire/pkg/cipher"
 	"net/rpc"
 	"sync"
 
@@ -23,9 +24,12 @@ type TransportRPCServer struct {
 	log       *logging.Logger
 	rpcServer *rpc.Server
 	whitelist pty.Whitelist
-	mux       *transport.VStreamMux
-	done      chan struct{}
-	once      sync.Once
+	// onRejected, when set, is told about each peer refused for not being
+	// whitelisted — the pairing list feeds on it.
+	onRejected func(cipher.PubKey)
+	mux        *transport.VStreamMux
+	done       chan struct{}
+	once       sync.Once
 }
 
 // NewTransportRPCServer creates a transport-level RPC server.
@@ -79,6 +83,9 @@ func (s *TransportRPCServer) Serve() {
 		if ok, err := s.whitelist.Get(remotePK); err != nil || !ok {
 			s.log.WithField("remote_pk", remotePK.String()).
 				Warn("Transport RPC rejected: PK not in whitelist")
+			if s.onRejected != nil {
+				s.onRejected(remotePK)
+			}
 			stream.Close() //nolint:errcheck,gosec
 			continue
 		}
@@ -92,6 +99,9 @@ func (s *TransportRPCServer) Serve() {
 		}()
 	}
 }
+
+// SetRejectedHook installs the callback run for each refused peer.
+func (s *TransportRPCServer) SetRejectedHook(f func(cipher.PubKey)) { s.onRejected = f }
 
 // Close stops the server.
 func (s *TransportRPCServer) Close() error {

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -171,6 +171,10 @@ type Visor struct {
 	// Seeded from config; extended at runtime when a connected
 	// hypervisor pushes its own hypervisors. See peer_whitelist.go.
 	peerWhitelist pty.Whitelist
+
+	// hvPair is the hypervisor pairing state (pairing_hv.go), made on first use.
+	hvPairOnce sync.Once
+	hvPair     *hvPairing
 	// hypervisorCancels holds the per-hypervisor context.CancelFunc
 	// installed by AddHypervisor, keyed by the remote hypervisor PK.
 	// RemoveHypervisor looks up the cancel func and invokes it; the


### PR DESCRIPTION
A peer holding a same-origin (swsr) transport to this visor, or refused by the transport RPC for not being whitelisted, is recorded as a pending hypervisor. `skywire cli visor hv pair` lists pending keys by fingerprint and `hv pair <fingerprint|pk>` approves one through the existing AddHypervisor path, which now also admits the key to the live peer whitelist so RPC and pty work immediately. `hv pair --code` mints a one-time code a tab redeems at `POST /pair` (pre-auth, beside /tp/ws); `GET /pair/status` tells a tab its standing. Codes expire, are single-use, and a few wrong ones revoke all outstanding.

The transport RPC server always runs now (whitelist checked per stream). `config gen` turns the UI password gate on for a freshly generated hypervisor config unless --disable-auth (not under js). The configuration guide names the mDNS hostname as the LAN address and describes pairing. #4484 stage 5; the desk-side Pair window and identity export/import follow in the wasm-visor PR.