### PR TITLE
feat(desk): pair and identity windows; config identity; removing a hypervisor drops its live trust

### DIFF
--- a/cmd/skywire-cli/commands/config/identity.go
+++ b/cmd/skywire-cli/commands/config/identity.go
@@ -1,0 +1,113 @@
+// Package cliconfig cmd/skywire-cli/commands/config/identity.go c4-vis-cli
+//
+// `skywire cli config identity` — export the keypair a config file holds, or
+// install a secret key into it. The desk's identity window drives this for a
+// browser visor (#4484 stage 5): the tab's key lives in the visor's own config
+// file in the exec worker's filesystem, which the running visor's RPC never
+// reveals (GetRuntimeConfig redacts sk), so the file is read here.
+package cliconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+var (
+	identityPath string
+	identitySK   string
+)
+
+func init() {
+	identityCmd.PersistentFlags().StringVarP(&identityPath, "input", "i", "", "config file (default: this install's config path)")
+	identityImportCmd.Flags().StringVar(&identitySK, "sk", "", "secret key to install (64 hex characters)")
+	identityCmd.AddCommand(identityExportCmd)
+	identityCmd.AddCommand(identityImportCmd)
+	RootCmd.AddCommand(identityCmd)
+}
+
+var identityCmd = &cobra.Command{
+	Use:   "identity",
+	Short: "Export or import the keypair a config file holds",
+	Long: `Read or replace the identity in a config file — the pk/sk pair that
+makes a visor the same visor across restarts. 'export' prints them;
+'import --sk' installs a secret key (and the public key derived from
+it). A running visor picks the change up on its next start.`,
+}
+
+// Identity is the exported keypair.
+type Identity struct {
+	PK cipher.PubKey `json:"pk"`
+	SK cipher.SecKey `json:"sk"`
+}
+
+func identityFile() string {
+	if identityPath != "" {
+		return identityPath
+	}
+	return visorconfig.SkywireConfig()
+}
+
+var identityExportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Print the config file's public and secret key as JSON",
+	Run: func(cmd *cobra.Command, _ []string) {
+		raw, err := os.ReadFile(identityFile()) //nolint:gosec
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		var id Identity
+		if err := json.Unmarshal(raw, &id); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("%s: %w", identityFile(), err))
+		}
+		if id.SK.Null() {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("%s holds no secret key", identityFile()))
+		}
+		out, _ := json.MarshalIndent(id, "", "  ") //nolint:errcheck
+		internal.PrintOutput(cmd.Flags(), id, string(out)+"\n")
+	},
+}
+
+var identityImportCmd = &cobra.Command{
+	Use:   "import --sk <hex>",
+	Short: "Install a secret key (and its public key) into the config file",
+	Run: func(cmd *cobra.Command, _ []string) {
+		var sk cipher.SecKey
+		if err := sk.Set(identitySK); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--sk: %w", err))
+		}
+		pk, err := sk.PubKey()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--sk: %w", err))
+		}
+		path := identityFile()
+		raw, err := os.ReadFile(path) //nolint:gosec
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		// Edit the two fields in place; every other field of the file is kept
+		// byte-for-byte as JSON re-serializes it.
+		var conf map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &conf); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("%s: %w", path, err))
+		}
+		pkJSON, _ := json.Marshal(pk) //nolint:errcheck
+		skJSON, _ := json.Marshal(sk) //nolint:errcheck
+		conf["pk"] = pkJSON
+		conf["sk"] = skJSON
+		out, err := json.MarshalIndent(conf, "", "  ")
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := os.WriteFile(path, append(out, '\n'), 0o600); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(), Identity{PK: pk, SK: sk}, fmt.Sprintf("Installed identity %s into %s\n", pk.Hex(), path))
+	},
+}

--- a/cmd/wasm-visor/desk_js.go
+++ b/cmd/wasm-visor/desk_js.go
@@ -137,6 +137,7 @@ func installDesk() {
 			return files.New(sharedShellFS(), dir), nil
 		},
 	})
+	registerPairingApps()
 	// The hypervisor UI is a browser TAB, not a window of its own — the desk
 	// puts surfaces in tabs wherever the pane already has them, and the
 	// dashboard is just a page. DirectLoader is what makes that tab render

--- a/cmd/wasm-visor/desk_pair_js.go
+++ b/cmd/wasm-visor/desk_pair_js.go
@@ -1,0 +1,269 @@
+//go:build js && wasm
+
+// Package main cmd/wasm-visor/desk_pair_js.go c4-wasm-desk
+//
+// Two ☰ apps for a desk a visor serves (#4484 stage 5):
+//
+//   - pair: this tab's visor asks to drive the host as its hypervisor. The
+//     window shows the tab's key and the fingerprint the operator sees in
+//     `skywire cli visor hv pair`, whether the host has approved it, and takes
+//     the one-time code from `hv pair --code` as the fallback. Both calls go
+//     to the page's own origin (GET /pair/status, POST /pair), pre-auth.
+//   - identity: export the tab's key (the persisted identity behind the
+//     per-origin PK) as text to copy, or import one; a reload restarts the
+//     visor under the imported key.
+//
+// The key never leaves the tab except as text the operator copies; the desk
+// asks the CLI for it (`skywire cli config identity`), which reads the visor's
+// own config file in the exec worker's filesystem.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"syscall/js"
+	"time"
+
+	"github.com/0magnet/desk"
+)
+
+func registerPairingApps() {
+	desk.Register(desk.App{
+		Name: "pair", Title: "pair",
+		Help:  "pair this tab with the visor serving it (hypervisor approval)",
+		Width: 620, Height: 380,
+		Open: func(_ []string) (desk.Pane, error) { return funcPane{mount: mountPairPane}, nil },
+	})
+	desk.Register(desk.App{
+		Name: "identity", Title: "identity",
+		Help:  "export or import this tab's key",
+		Width: 680, Height: 460,
+		Open: func(_ []string) (desk.Pane, error) { return funcPane{mount: mountIdentityPane}, nil },
+	})
+}
+
+const paneCSS = "padding:14px 18px;font:14px/1.5 system-ui,sans-serif;color:#cdd2da;background:#15121d;height:100%;box-sizing:border-box;overflow:auto"
+
+func paneEl(doc js.Value, tag, css, text string) js.Value {
+	e := doc.Call("createElement", tag)
+	if css != "" {
+		e.Get("style").Set("cssText", css)
+	}
+	if text != "" {
+		e.Set("textContent", text)
+	}
+	return e
+}
+
+func paneButton(doc js.Value, label string, onClick func()) js.Value {
+	b := paneEl(doc, "button", "margin:4px 8px 4px 0;padding:6px 14px;font:inherit;cursor:pointer", label)
+	b.Call("addEventListener", "click", js.FuncOf(func(js.Value, []js.Value) any {
+		go onClick()
+		return nil
+	}))
+	return b
+}
+
+// pageOrigin is the served page's origin, or "" when there is no page.
+func pageOrigin() string {
+	loc := js.Global().Get("location")
+	if !loc.Truthy() {
+		return ""
+	}
+	return loc.Get("origin").String()
+}
+
+// ownPK asks the tab's visor for its public key.
+func ownPK(ctx context.Context) (string, error) {
+	out, err := runHeadless(ctx, "skywire cli visor pk")
+	if err != nil {
+		return "", err
+	}
+	pk := strings.TrimSpace(out)
+	if len(pk) != 66 {
+		return "", fmt.Errorf("visor pk: %q", pk)
+	}
+	return pk, nil
+}
+
+type pairStatus struct {
+	Fingerprint string `json:"fingerprint"`
+	Paired      bool   `json:"paired"`
+	Pending     bool   `json:"pending"`
+}
+
+func fetchPairStatus(ctx context.Context, origin, pk string) (pairStatus, error) {
+	var st pairStatus
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, origin+"/pair/status?pk="+pk, nil)
+	if err != nil {
+		return st, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return st, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512)) //nolint:errcheck
+		return st, fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	return st, json.NewDecoder(resp.Body).Decode(&st)
+}
+
+func redeemPairCode(ctx context.Context, origin, pk, code string) error {
+	body, _ := json.Marshal(map[string]string{"pk": pk, "code": code}) //nolint:errcheck
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, origin+"/pair", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode == http.StatusForbidden {
+		return errors.New("the host rejected that code")
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512)) //nolint:errcheck
+		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	return nil
+}
+
+func mountPairPane(el js.Value) error {
+	doc := js.Global().Get("document")
+	root := paneEl(doc, "div", paneCSS, "")
+	el.Call("appendChild", root)
+	origin := pageOrigin()
+	if js.Global().Get("__SKYWIRE_LOCAL_PK__").Type() != js.TypeString || origin == "" {
+		root.Call("appendChild", paneEl(doc, "p", "", "This desk is not served by a visor, so there is nothing to pair with."))
+		return nil
+	}
+	hostPK := js.Global().Get("__SKYWIRE_LOCAL_PK__").String()
+	root.Call("appendChild", paneEl(doc, "h3", "margin:0 0 8px", "Pair with the host"))
+	root.Call("appendChild", paneEl(doc, "div", "font:12px monospace;word-break:break-all;color:#9aa0a6", "host "+hostPK))
+	pkLine := paneEl(doc, "div", "font:12px monospace;word-break:break-all;margin-top:6px", "this tab: …")
+	root.Call("appendChild", pkLine)
+	status := paneEl(doc, "p", "margin:10px 0", "checking…")
+	root.Call("appendChild", status)
+	root.Call("appendChild", paneEl(doc, "p", "color:#9aa0a6;font-size:13px",
+		"On the host: `skywire cli visor hv pair` lists this tab by fingerprint; `hv pair <fingerprint>` approves it. "+
+			"Or make a code there with `hv pair --code` and enter it here."))
+	code := paneEl(doc, "input", "font:16px monospace;letter-spacing:2px;padding:6px 8px;width:14em", "")
+	code.Set("placeholder", "one-time code")
+	code.Set("autocapitalize", "characters")
+	row := paneEl(doc, "div", "display:flex;align-items:center;gap:8px;flex-wrap:wrap", "")
+	row.Call("appendChild", code)
+	result := paneEl(doc, "span", "", "")
+
+	var pk string
+	refresh := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		if pk == "" {
+			p, err := ownPK(ctx)
+			if err != nil {
+				status.Set("textContent", "cannot read this tab's key: "+err.Error())
+				return
+			}
+			pk = p
+			pkLine.Set("textContent", "this tab: "+pk)
+		}
+		st, err := fetchPairStatus(ctx, origin, pk)
+		if err != nil {
+			status.Set("textContent", "status unavailable: "+err.Error())
+			return
+		}
+		switch {
+		case st.Paired:
+			status.Set("textContent", "Paired: the host accepts this tab as its hypervisor. Fingerprint "+st.Fingerprint+".")
+		case st.Pending:
+			status.Set("textContent", "Waiting for approval on the host. Fingerprint "+st.Fingerprint+".")
+		default:
+			status.Set("textContent", "Not paired. Fingerprint "+st.Fingerprint+" (the host lists it once this tab's transport is up).")
+		}
+	}
+	row.Call("appendChild", paneButton(doc, "pair", func() {
+		c := strings.TrimSpace(code.Get("value").String())
+		if c == "" || pk == "" {
+			result.Set("textContent", "enter the code first")
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		if err := redeemPairCode(ctx, origin, pk, c); err != nil {
+			result.Set("textContent", err.Error())
+			return
+		}
+		result.Set("textContent", "paired")
+		code.Set("value", "")
+		refresh()
+	}))
+	row.Call("appendChild", paneButton(doc, "refresh", refresh))
+	row.Call("appendChild", result)
+	root.Call("appendChild", row)
+	go refresh()
+	return nil
+}
+
+func mountIdentityPane(el js.Value) error {
+	doc := js.Global().Get("document")
+	root := paneEl(doc, "div", paneCSS, "")
+	el.Call("appendChild", root)
+	root.Call("appendChild", paneEl(doc, "h3", "margin:0 0 8px", "This tab's identity"))
+	root.Call("appendChild", paneEl(doc, "p", "color:#9aa0a6;font-size:13px",
+		"The key is what makes this tab the same visor every time this page is opened here. "+
+			"Export it to carry the identity to another browser; import one to take that identity over here."))
+	out := paneEl(doc, "textarea", "width:100%;height:90px;font:12px monospace;box-sizing:border-box", "")
+	out.Set("readOnly", true)
+	out.Set("placeholder", "press “show key”")
+	msg := paneEl(doc, "div", "margin:6px 0;min-height:1.4em", "")
+	root.Call("appendChild", paneButton(doc, "show key", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		text, err := runHeadless(ctx, "skywire cli config identity export")
+		if err != nil {
+			msg.Set("textContent", "export failed: "+err.Error())
+			return
+		}
+		out.Set("value", strings.TrimSpace(text))
+		msg.Set("textContent", "copy this somewhere safe; anyone holding it is this visor")
+	}))
+	root.Call("appendChild", out)
+	root.Call("appendChild", msg)
+
+	root.Call("appendChild", paneEl(doc, "h4", "margin:14px 0 6px", "Import a key"))
+	in := paneEl(doc, "input", "width:100%;font:12px monospace;padding:6px 8px;box-sizing:border-box", "")
+	in.Set("placeholder", "secret key (64 hex characters)")
+	root.Call("appendChild", in)
+	imsg := paneEl(doc, "div", "margin:6px 0;min-height:1.4em", "")
+	row := paneEl(doc, "div", "", "")
+	row.Call("appendChild", paneButton(doc, "import and reload", func() {
+		sk := strings.TrimSpace(in.Get("value").String())
+		if len(sk) != 64 {
+			imsg.Set("textContent", "a secret key is 64 hex characters")
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		text, err := runHeadless(ctx, "skywire cli config identity import --sk "+sk)
+		if err != nil {
+			imsg.Set("textContent", "import failed: "+err.Error()+" "+strings.TrimSpace(text))
+			return
+		}
+		imsg.Set("textContent", "imported; reloading so the visor restarts under the new key…")
+		time.Sleep(800 * time.Millisecond)
+		js.Global().Get("location").Call("reload")
+	}))
+	row.Call("appendChild", imsg)
+	root.Call("appendChild", row)
+	return nil
+}

--- a/pkg/visor/api_hypervisors.go
+++ b/pkg/visor/api_hypervisors.go
@@ -149,7 +149,28 @@ func (v *Visor) RemoveHypervisor(hvPK cipher.PubKey) error {
 	// Persist the removal regardless (even if the connection was already gone or
 	// never tracked) so the visor doesn't reconnect to it on the next restart.
 	v.persistHypervisors(removePK(v.configuredHypervisors(), hvPK))
+	v.dropPeerTrust(hvPK)
 	return nil
+}
+
+// dropPeerTrust takes a removed hypervisor off the live peer whitelist, so
+// it stops driving RPC and pty now and shows up as pending again if it
+// tries — unless it is whitelisted in its own right (Pty.Whitelist) or is
+// this visor. The inverse of the admission AddHypervisor does.
+func (v *Visor) dropPeerTrust(pk cipher.PubKey) {
+	if v.peerWhitelist == nil || v.conf == nil || pk == v.conf.PK {
+		return
+	}
+	if v.conf.Pty != nil {
+		for _, w := range v.conf.Pty.Whitelist {
+			if w == pk {
+				return
+			}
+		}
+	}
+	if err := v.peerWhitelist.Remove(pk); err == nil {
+		v.refreshGatedCXOAllowlists()
+	}
 }
 
 // RemoveAllHypervisors tears down every runtime-added hypervisor


### PR DESCRIPTION
Two ☰ apps for a desk a visor serves (#4484 stage 5): "pair" shows the tab's key and fingerprint, whether the host approved it (GET /pair/status), and redeems a one-time code from `hv pair --code` (POST /pair); "identity" exports the tab's key as text or imports one and reloads. The desk asks the CLI for the key: `skywire cli config identity export|import --sk` reads/writes the config file, since the RPC redacts sk and a tab's config lives in the exec worker's filesystem.

RemoveHypervisor now also drops the key from the live peer whitelist (the inverse of AddHypervisor's admission), so a removed tab stops driving RPC/pty at once and becomes pending again. Blob re-embed follows.