### PR TITLE
fix(config): a regen keeps the hypervisor auth gate as the existing config has it

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -2323,6 +2323,12 @@ func configureApps(log *logging.Logger) {
 		if !isRegen && !isDisableAuth && skyenv.OS != "js" {
 			conf.Hypervisor.EnableAuth = true
 		}
+		// A regen keeps the gate as the existing config has it — the default
+		// config is rebuilt from scratch and would otherwise reset an operator's
+		// --noauth to the platform default on every autoconfig run.
+		if isRegen && !isDisableAuth && !isEnableAuth && oldConfCache != nil && oldConfCache.Hypervisor != nil {
+			conf.Hypervisor.EnableAuth = oldConfCache.Hypervisor.EnableAuth
+		}
 	}
 	// Enable hypervisor UI authentication on windows & macos
 	if (selectedOS == "win") || (selectedOS == "mac") {


### PR DESCRIPTION
The default config is rebuilt from scratch on --regen, so an operator's --noauth was reset to the platform default on every autoconfig run. Carry the existing enable_auth over unless --auth/--noauth is given explicitly. Verified: fresh --noauth then -r stays false; fresh default then -r stays true. Completes the #4732 first-run rule for #4484 stage 5.