### PR TITLE
feat(desk): netscrape's proxy setting is one [scheme://]host:port; BrowseClearnetRequest gains proxy

### DIFF
--- a/docs/skynet-browser.md
+++ b/docs/skynet-browser.md
@@ -4,10 +4,10 @@ The wasm-visor ships an in-tab **skynet browser** — a WinBox window whose addr
 bar accepts a visor **PK**, **`pk.dmsg`**, an **`alias.dmsg`** (e.g.
 **`home.dmsg`**), or an **`https://`** clearnet URL. Pages are fetched over dmsg
 (skynet) — no DNS, no certificate authorities, IP-anonymous — or, for clearnet,
-routed through a skysocks exit selected in the ⚙ panel.
+sent through the proxy named in the ⚙ field — one `[scheme://]host:port` (empty: the visor's default egress).
 
 Nav bar: `◀ ▶ ⟳ ⌂` (back / forward / reload / **home** → `home.dmsg`), the
-address bar + `go`, `⚙` (skysocks proxy + per-window request log), and `ⓘ`
+address bar + `go`, `⚙` (the proxy address + per-window request log), and `ⓘ`
 (this page's summary, in-UI).
 
 ## Limitations (by design)

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/0magnet/gotop/v4 v4.2.1-0.20260905172009-f9d674fb6dfd
 	github.com/0magnet/lolcat-go v0.0.0-20260907230215-22c54b7702c7
 	github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c
-	github.com/0magnet/netscrape v0.0.0-20260908202925-8a8dea1c8609
+	github.com/0magnet/netscrape v0.0.0-20260909235121-57c7ea4544f8
 	github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d
 	github.com/0magnet/plot-go v0.0.0-20260908184629-9cfdeb563e8f
 	github.com/0magnet/realorigin v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c h1:Uj+2n5pWraLq
 github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c/go.mod h1:9MHaZG+XGoXfQW/L7yOpJx/gbKmCynAejV3Xpll/usw=
 github.com/0magnet/netscrape v0.0.0-20260908202925-8a8dea1c8609 h1:NaNeMDXsvjbGkE/qSX0lmx7GcVKJDmiarFV+suNPWaI=
 github.com/0magnet/netscrape v0.0.0-20260908202925-8a8dea1c8609/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
+github.com/0magnet/netscrape v0.0.0-20260909235121-57c7ea4544f8 h1:EyD0MMVbgrIiJoCek49mg41SvAz8X9q2y+V8KiL6Dwo=
+github.com/0magnet/netscrape v0.0.0-20260909235121-57c7ea4544f8/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
 github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d h1:T/CISGqaX8Sw1F+SYH6Uz8UQTsSN4KBabrCLShG+WRk=
 github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d/go.mod h1:xNKk6t2OtJQfb/pmWNiH8zUi0YCBuhYAr+fYa+rQ46s=
 github.com/0magnet/plot-go v0.0.0-20260908184629-9cfdeb563e8f h1:P1mbxDg4oisWjKscItJzjTaT38BS59GRQ3uLzoNuojU=

--- a/pkg/visor/api_browse.go
+++ b/pkg/visor/api_browse.go
@@ -7,10 +7,12 @@ package visor
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -220,16 +222,28 @@ func (v *Visor) dmsgHTTPFetch(pk cipher.PubKey, port uint16, method, path string
 // BrowseClearnetRequest fetches a CLEARNET url through a skysocks exit over a
 // skywire route (IP-anonymous; the exit does the egress).
 type BrowseClearnetRequest struct {
+	// ExitPK names a skysocks exit to route the fetch through; zero means the
+	// visor's default exit (the skysocks-client's server). Ignored when Proxy
+	// is set.
 	ExitPK cipher.PubKey `json:"exit_pk"`
-	Method string        `json:"method"`
-	URL    string        `json:"url"`
-	Body   []byte        `json:"body,omitempty"`
+	// Proxy is "[scheme://]host:port" of a proxy THIS visor dials for the
+	// fetch — socks5 (default scheme), socks5h, http or https. It is the one
+	// proxy setting a browser has (#4484 stage 6): "vnet:1080" and
+	// "localhost:1080" name the visor's own loopback (its skysocks-client),
+	// anything else a proxy the visor can reach.
+	Proxy  string `json:"proxy,omitempty"`
+	Method string `json:"method"`
+	URL    string `json:"url"`
+	Body   []byte `json:"body,omitempty"`
 }
 
 // BrowseClearnet originates a route group to the skysocks server, runs SOCKS5
 // over a yamux stream, and performs the HTTP(S) request — TLS terminates here
 // (system cert pool), so the exit only relays ciphertext for https.
 func (v *Visor) BrowseClearnet(req BrowseClearnetRequest) (*SkynetHTTPResponse, error) {
+	if strings.TrimSpace(req.Proxy) != "" {
+		return v.proxyClearnetFetch(req)
+	}
 	// Self-PK exit = "fall through to clearnet directly": the local visor does the
 	// egress itself (a plain http.Get over the host's default route), NOT a skysocks
 	// route to its own PK (which would hang dialing itself, like the home.dmsg
@@ -405,4 +419,74 @@ func (v *Visor) browseDefaultExit() (cipher.PubKey, bool) {
 		return cipher.PubKey{}, false
 	}
 	return pk, true
+}
+
+// parseBrowseProxy turns "[scheme://]host:port" into a URL the fetch dials
+// through. No scheme means socks5; "vnet" and the loopback names resolve to
+// 127.0.0.1 — the visor's own virtual or real loopback, where its
+// skysocks-client listens.
+func parseBrowseProxy(s string) (*url.URL, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, errors.New("empty proxy address")
+	}
+	if !strings.Contains(s, "://") {
+		s = "socks5://" + s
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, fmt.Errorf("proxy %q: %w", s, err)
+	}
+	switch u.Scheme {
+	case "socks5", "socks5h", "http", "https":
+	default:
+		return nil, fmt.Errorf("proxy %q: scheme must be socks5, socks5h, http or https", s)
+	}
+	if u.Port() == "" {
+		return nil, fmt.Errorf("proxy %q: port required", s)
+	}
+	switch strings.ToLower(u.Hostname()) {
+	case "vnet", "localhost", "::1":
+		u.Host = net.JoinHostPort("127.0.0.1", u.Port())
+	}
+	return u, nil
+}
+
+// proxyClearnetFetch fetches req.URL through the proxy req.Proxy names, dialed
+// by this visor.
+func (v *Visor) proxyClearnetFetch(req BrowseClearnetRequest) (*SkynetHTTPResponse, error) {
+	pu, err := parseBrowseProxy(req.Proxy)
+	if err != nil {
+		return nil, err
+	}
+	tr := &http.Transport{TLSHandshakeTimeout: 20 * time.Second}
+	switch pu.Scheme {
+	case "socks5", "socks5h":
+		sd, err := proxy.SOCKS5("tcp", pu.Host, nil, proxy.Direct)
+		if err != nil {
+			return nil, err
+		}
+		tr.DialContext = func(_ context.Context, network, addr string) (net.Conn, error) { return sd.Dial(network, addr) }
+	default:
+		tr.Proxy = http.ProxyURL(pu)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), browseFetchTimeout)
+	defer cancel()
+	method := req.Method
+	if method == "" {
+		method = "GET"
+	}
+	var rdr io.Reader
+	if len(req.Body) > 0 {
+		rdr = bytes.NewReader(req.Body)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, method, req.URL, rdr)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := (&http.Client{Transport: tr, Timeout: browseFetchTimeout}).Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("fetch via proxy %s: %w", pu.Redacted(), err)
+	}
+	return readBrowseResp(resp)
 }

--- a/pkg/visor/api_browse_proxy_test.go
+++ b/pkg/visor/api_browse_proxy_test.go
@@ -1,0 +1,35 @@
+package visor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseBrowseProxy: the one proxy field a browser has (#4484 stage 6) —
+// "[scheme://]host:port", socks5 by default, loopback names resolved to the
+// visor's own loopback.
+func TestParseBrowseProxy(t *testing.T) {
+	u, err := parseBrowseProxy("vnet:1080")
+	require.NoError(t, err)
+	require.Equal(t, "socks5", u.Scheme)
+	require.Equal(t, "127.0.0.1:1080", u.Host)
+
+	u, err = parseBrowseProxy("localhost:1080")
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1:1080", u.Host)
+
+	u, err = parseBrowseProxy("http://192.168.1.2:3128")
+	require.NoError(t, err)
+	require.Equal(t, "http", u.Scheme)
+	require.Equal(t, "192.168.1.2:3128", u.Host)
+
+	u, err = parseBrowseProxy("socks5h://proxy.example:1080")
+	require.NoError(t, err)
+	require.Equal(t, "proxy.example:1080", u.Host)
+
+	for _, bad := range []string{"", "   ", "ftp://x:1", "192.168.1.2", "socks5://host"} {
+		_, err := parseBrowseProxy(bad)
+		require.Error(t, err, bad)
+	}
+}

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -348,6 +348,25 @@
 					}
 					return 0;
 				}
+					// The browser's proxy setting (netscrape's ⚙ field) is one
+					// [scheme://]host:port, or empty for the visor's default egress.
+					// proxyPort reads it: {addr, port, err} — port is set when the
+					// address is this tab's own loopback (vnet:<port>, localhost:<port>),
+					// the one proxy a page can speak SOCKS5 to itself; err names an
+					// address that parses as nothing.
+					function proxyPort(p) {
+						var addr = String((p && p.proxy) || '').trim();
+						if (!addr) return { addr: '', port: 0 };
+						var s = /:\/\//.test(addr) ? addr : 'socks5://' + addr;
+						var pu;
+						try { pu = new URL(s); } catch (e) { return { addr: addr, port: 0, err: 'proxy: not [scheme://]host:port: ' + addr }; }
+						if (!pu.port) return { addr: addr, port: 0, err: 'proxy: port required: ' + addr };
+						return { addr: addr, port: vnetPort(pu) };
+					}
+					function proxyError(msg) {
+						return new Response('<body style="font:14px sans-serif;padding:2em;color:#a33">' + msg + '</body>',
+							{ status: 502, headers: new Headers({ 'content-type': 'text/html' }) });
+					}
 				globalThis.__netscrapeFetch = function (url) {
 					var u;
 					try { u = new URL(url, 'http://x/'); } catch (e) { return fetch(url); }
@@ -378,16 +397,21 @@
 					if (mesh && sv.fetchDmsg) {
 						return Promise.resolve(sv.fetchDmsg(u.hostname, 'GET', path, null)).then(respond);
 					}
-					if (sv.fetchClearnet) {
-						// The browser's proxy setting (netscrape's ⚙ panel) picks the
-						// exit: a named skysocks exit, this visor's own egress
-						// ("direct"), or empty for the visor's default.
-						var p = globalThis.__netscrapeProxy || {};
-						var exit = '';
-						if (p.mode === 'direct') exit = deskSelfPK;
-						else if (p.mode === 'exit' && /^[0-9a-f]{66}$/i.test(p.exit || '')) exit = p.exit;
-						return Promise.resolve(sv.fetchClearnet(exit, 'GET', url, null)).then(respond);
-					}
+						// A loopback proxy is this tab's own visor (its skysocks-client on
+						// the virtual loopback): the page speaks SOCKS5 to it directly, for
+						// http — it cannot do TLS through it. A page cannot reach any other
+						// proxy; the host-bridged desk below hands those to the visor.
+						var pp = proxyPort(globalThis.__netscrapeProxy);
+						if (pp.err) return Promise.resolve(proxyError(pp.err));
+						if (pp.port) {
+							if (u.protocol === 'https:') return Promise.resolve(proxyError('https through a loopback proxy needs the visor: use a proxy address the host can dial, or leave the field empty'));
+							if (!(globalThis.vnet && globalThis.vnet.listening(pp.port))) return Promise.resolve(proxyError('nothing is listening on vnet port ' + pp.port));
+							return Promise.resolve(globalThis.vnet.socksHttpFetch(pp.port, u.hostname + ':' + (u.port || 80), 'GET', path, null, {})).then(respond);
+						}
+						if (pp.addr) return Promise.resolve(proxyError('a browser visor can only use a proxy on its own loopback (vnet:&lt;port&gt;); ' + pp.addr + ' is not one'));
+						if (sv.fetchClearnet) {
+							return Promise.resolve(sv.fetchClearnet('', 'GET', url, null)).then(respond);
+						}
 					return fetch(url);
 				};
 				// The desk chrome comes from the library (0magnet/desk), mounted by
@@ -430,30 +454,24 @@
 						if (/\.(dmsg|skynet|skysocks)$/i.test(host) || /^[0-9a-f]{66}$/i.test(host)) {
 							return browsePost('/api/browse/fetch', { host: host, port: u.port ? (parseInt(u.port, 10) || 80) : 80, method: 'GET', path: (u.pathname || '/') + (u.search || '') });
 						}
-						var p = globalThis.__netscrapeProxy || {};
-						var req = { method: 'GET', url: u.href };
-						if (p.mode === 'direct' && globalThis.__SKYWIRE_LOCAL_PK__) { req.exit_pk = globalThis.__SKYWIRE_LOCAL_PK__; }
-						else if (p.mode === 'exit' && /^[0-9a-f]{66}$/i.test(p.exit || '')) { req.exit_pk = p.exit; }
-						return browsePost('/api/browse/clearnet', req);
+							// The proxy field: a loopback address is this tab's own visor's
+							// SOCKS on the virtual loopback (http only — the page cannot do
+							// TLS through it); anything else the host visor dials.
+							var pp = proxyPort(globalThis.__netscrapeProxy);
+							if (pp.err) return Promise.resolve(proxyError(pp.err));
+							if (pp.port && u.protocol !== 'https:' && globalThis.vnet && globalThis.vnet.listening(pp.port)) {
+								return Promise.resolve(globalThis.vnet.socksHttpFetch(pp.port, host + ':' + (u.port || 80), 'GET', (u.pathname || '/') + (u.search || ''), null, {})).then(function (r) {
+									var h = new Headers();
+									if (r && r.headers) { try { for (var k in r.headers) h.set(k, r.headers[k]); } catch (e) { /* ignore */ } }
+									return new Response((r && r.body) || new Uint8Array(0), { status: (r && r.status) || 200, headers: h });
+								});
+							}
+							var req = { method: 'GET', url: u.href };
+							if (pp.addr && !pp.port) { req.proxy = pp.addr; }
+							return browsePost('/api/browse/clearnet', req);
 					};
 				}
 				var panel = globalThis.__skywireDesk;
-				// selfPK cache: poll the visor's /api/about once its HV listens;
-				// re-check occasionally in case the operator restarts the visor
-				// under a different identity.
-				var deskSelfPK = '';
-				(function pollPK() {
-					if (globalThis.vnet && globalThis.vnet.listening(hvPort)) {
-						globalThis.vnet.httpFetch(hvPort, 'GET', '/api/about', null, {}).then(function (r) {
-							try {
-								var a = JSON.parse(new TextDecoder().decode(r.body));
-								if (a && a.public_key) deskSelfPK = a.public_key;
-							} catch (e) { /* ignore */ }
-						}).catch(function () { /* ignore */ });
-					}
-					setTimeout(pollPK, deskSelfPK ? 60000 : 3000);
-				})();
-
 				// Session: remember across reloads whether a visor was RUNNING when
 				// the page went away — a visor the operator stopped stays stopped.
 				// Start the docs server. It is a plain HTTP server over the embedded

--- a/vendor/github.com/0magnet/netscrape/browser.go
+++ b/vendor/github.com/0magnet/netscrape/browser.go
@@ -931,20 +931,20 @@ func moveTab(from, to int) {
 
 // Proxy setting. netscrape does not carry traffic itself — the host's
 // __netscrapeFetch does — so the proxy control is a published preference the
-// host reads: globalThis.__netscrapeProxy = {mode, exit}. mode is "auto" (the
-// host's default exit), "exit" (the named skysocks exit PK) or "direct" (the
-// host egresses itself, no anonymity). It persists in localStorage so a
+// host reads: globalThis.__netscrapeProxy = {proxy}. proxy is one
+// [scheme://]host:port — the address of a SOCKS5 (default) or HTTP proxy the
+// host should send clearnet pages through — or "" for the host's default
+// egress. A host running in a browser maps a loopback address (vnet:<port>,
+// localhost:<port>) to its own virtual-loopback SOCKS and hands anything else
+// to the visor behind the page to dial. It persists in localStorage so a
 // person's choice survives a reload, the way a browser's proxy setting does.
 const proxyStoreKey = "netscrape.proxy"
 
-var (
-	proxyMode = "auto"
-	proxyExit = ""
-)
+var proxyAddr = ""
 
-// Proxy reports the current proxy preference: mode and, for mode "exit", the
-// exit public key (hex).
-func Proxy() (mode, exit string) { return proxyMode, proxyExit }
+// Proxy reports the current proxy preference: "[scheme://]host:port", or ""
+// for the host's default.
+func Proxy() string { return proxyAddr }
 
 func loadProxy() {
 	ls := js.Global().Get("localStorage")
@@ -957,76 +957,80 @@ func loadProxy() {
 		return
 	}
 	obj := js.Global().Get("JSON").Call("parse", raw.String())
-	if m := obj.Get("mode"); m.Type() == js.TypeString {
-		proxyMode = m.String()
+	if p := obj.Get("proxy"); p.Type() == js.TypeString {
+		proxyAddr = strings.TrimSpace(p.String())
 	}
-	if e := obj.Get("exit"); e.Type() == js.TypeString {
-		proxyExit = e.String()
-	}
+	// An older {mode, exit} value is dropped: the address field replaced it.
 	publishProxy()
 }
 
 func saveProxy() {
 	if ls := js.Global().Get("localStorage"); ls.Truthy() {
-		ls.Call("setItem", proxyStoreKey, `{"mode":"`+proxyMode+`","exit":"`+proxyExit+`"}`)
+		v := js.Global().Get("Object").New()
+		v.Set("proxy", proxyAddr)
+		ls.Call("setItem", proxyStoreKey, js.Global().Get("JSON").Call("stringify", v).String())
 	}
 	publishProxy()
 }
 
 func publishProxy() {
 	obj := js.Global().Get("Object").New()
-	obj.Set("mode", proxyMode)
-	obj.Set("exit", proxyExit)
+	obj.Set("proxy", proxyAddr)
 	js.Global().Set("__netscrapeProxy", obj)
 }
 
-// proxyPanel builds the ⚙ button and the settings row it toggles: a mode
-// selector and, for "exit", a field for the exit PK. Returns the button (for
-// the address bar) and the panel (for below it).
+// validProxyAddr reports whether s is "[scheme://]host:port" with a numeric
+// port; scheme, when present, is socks5, socks5h, http or https.
+func validProxyAddr(s string) bool {
+	if s == "" {
+		return true
+	}
+	if i := strings.Index(s, "://"); i >= 0 {
+		switch strings.ToLower(s[:i]) {
+		case "socks5", "socks5h", "http", "https":
+		default:
+			return false
+		}
+		s = s[i+3:]
+	}
+	j := strings.LastIndex(s, ":")
+	if j <= 0 || j == len(s)-1 {
+		return false
+	}
+	for _, c := range s[j+1:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// proxyPanel builds the ⚙ button and the settings row it toggles: one field,
+// the proxy address clearnet pages go through. Returns the button (for the
+// address bar) and the panel (for below it).
 func proxyPanel() (button, panel js.Value) {
 	button = btn("⚙", "padding:2px 8px")
 	button.Set("title", "proxy settings")
 	panel = mk("div")
 	panel.Get("style").Set("cssText", "display:none;gap:8px;align-items:center;padding:4px 6px;background:#100d18;border-bottom:1px solid #2a2342;font:12px monospace;color:#cdd2da")
 	label := mk("span")
-	label.Set("textContent", "clearnet pages via")
-	sel := mk("select")
-	sel.Get("style").Set("cssText", "background:#0e0c14;color:#cdd2da;border:1px solid #2a2342;font:12px monospace;padding:1px 4px")
-	for _, o := range [][2]string{{"auto", "auto (host's default exit)"}, {"exit", "a skysocks exit"}, {"direct", "direct (this visor egresses, not anonymous)"}} {
-		opt := mk("option")
-		opt.Set("value", o[0])
-		opt.Set("textContent", o[1])
-		sel.Call("appendChild", opt)
-	}
-	exit := mk("input")
-	exit.Set("spellcheck", false)
-	exit.Set("placeholder", "exit public key (66 hex)")
-	exit.Get("style").Set("cssText", "flex:1;background:#0e0c14;color:#cdd2da;border:1px solid #2a2342;padding:1px 6px;font:12px monospace")
+	label.Set("textContent", "clearnet pages via proxy")
+	addr := mk("input")
+	addr.Set("spellcheck", false)
+	addr.Set("placeholder", "[scheme://]host:port — empty: the visor's default egress; e.g. vnet:1080 or socks5://192.168.1.2:1080")
+	addr.Get("style").Set("cssText", "flex:1;background:#0e0c14;color:#cdd2da;border:1px solid #2a2342;padding:1px 6px;font:12px monospace")
 	status := mk("span")
 	status.Get("style").Set("cssText", "opacity:.7")
 	sync := func() {
-		sel.Set("value", proxyMode)
-		exit.Set("value", proxyExit)
-		if proxyMode == "exit" {
-			exit.Get("style").Set("display", "")
-		} else {
-			exit.Get("style").Set("display", "none")
-		}
-		switch {
-		case proxyMode == "exit" && !isPK(proxyExit):
-			status.Set("textContent", "needs a 66-hex public key")
-		default:
+		addr.Set("value", proxyAddr)
+		if validProxyAddr(proxyAddr) {
 			status.Set("textContent", "")
+		} else {
+			status.Set("textContent", "needs [scheme://]host:port")
 		}
 	}
-	sel.Call("addEventListener", "change", js.FuncOf(func(_ js.Value, _ []js.Value) any {
-		proxyMode = sel.Get("value").String()
-		saveProxy()
-		sync()
-		return nil
-	}))
-	exit.Call("addEventListener", "change", js.FuncOf(func(_ js.Value, _ []js.Value) any {
-		proxyExit = strings.TrimSpace(exit.Get("value").String())
+	addr.Call("addEventListener", "change", js.FuncOf(func(_ js.Value, _ []js.Value) any {
+		proxyAddr = strings.TrimSpace(addr.Get("value").String())
 		saveProxy()
 		sync()
 		return nil
@@ -1038,23 +1042,10 @@ func proxyPanel() (button, panel js.Value) {
 			panel.Get("style").Set("display", "none")
 		}
 	})
-	for _, el := range []js.Value{label, sel, exit, status} {
+	for _, el := range []js.Value{label, addr, status} {
 		panel.Call("appendChild", el)
 	}
 	loadProxy()
 	sync()
 	return button, panel
-}
-
-// isPK reports whether s looks like a compressed secp256k1 public key in hex.
-func isPK(s string) bool {
-	if len(s) != 66 || (s[:2] != "02" && s[:2] != "03") {
-		return false
-	}
-	for _, c := range s[2:] {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
-			return false
-		}
-	}
-	return true
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,7 +85,7 @@ github.com/0magnet/lolcat-go/lol
 # github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c
 ## explicit; go 1.25.0
 github.com/0magnet/metrics
-# github.com/0magnet/netscrape v0.0.0-20260908202925-8a8dea1c8609
+# github.com/0magnet/netscrape v0.0.0-20260909235121-57c7ea4544f8
 ## explicit; go 1.24
 github.com/0magnet/netscrape
 # github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d


### PR DESCRIPTION
The ⚙ mode/exit panel from #4684 is replaced (netscrape 57c7ea45) by one proxy field: the address of a SOCKS5 (default) or HTTP proxy clearnet pages go through, or empty for the visor's default egress.

The desk hook maps a loopback address (vnet:<port>, localhost:<port>) to this tab's own visor over vnet.socksHttpFetch (http only, a page cannot do TLS through it) and sends anything else to the host as `BrowseClearnetRequest.proxy`, which the visor dials (socks5/socks5h via x/net/proxy, http/https via http.Transport.Proxy). The desk's exit-PK plumbing and the self-PK poller are removed; `exit_pk` stays on the request for the wallet. #4484 stage 6; blob re-embed follows (netscrape is compiled into the desk host).