### PR TITLE
fix(desk): same-origin/loopback fetches stay local; proxy dial timeout; "+" for terminal tabs

### DIFF
--- a/cmd/wasm-visor/desk_js.go
+++ b/cmd/wasm-visor/desk_js.go
@@ -88,8 +88,9 @@ func installDesk() {
 	}
 	desk.Register(desk.App{
 		Name: "console", Title: "console", Unlisted: true,
-		Help:  "websh — the skywire shell",
-		Width: 900, Height: 540,
+		NewTab: true, // "+" in the strip: another shell beside this one
+		Help:   "websh — the skywire shell",
+		Width:  900, Height: 540,
 		Open: websh,
 	})
 	// The terminal app. On a page a hypervisor serves (host-bridge mode) the
@@ -100,14 +101,14 @@ func installDesk() {
 	// which one they got.
 	if ptyURL := js.Global().Get("__SKYWIRE_PTY_URL__"); ptyURL.Type() == js.TypeString && ptyURL.String() != "" {
 		desk.Register(desk.App{
-			Name: "terminal", Title: "terminal",
+			Name: "terminal", Title: "terminal", NewTab: true,
 			Help:  "the host's shell (pty over websocket)",
 			Width: 900, Height: 540,
 			Open: func(_ []string) (desk.Pane, error) { return framePane(ptyURL.String()), nil },
 		})
 	} else {
 		desk.Register(desk.App{
-			Name: "terminal", Title: "terminal",
+			Name: "terminal", Title: "terminal", NewTab: true,
 			Help:  "websh — the skywire shell",
 			Width: 900, Height: 540,
 			Open: websh,

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/0magnet/bitree v0.0.0-20260906144807-e66de0b4c738
 	github.com/0magnet/bottle v0.0.0-20260908155251-920d2280a387
 	github.com/0magnet/calvin v0.0.0-20260908180241-0893f4bff56a
-	github.com/0magnet/desk v0.0.0-20260909171253-833d45f6d44f
+	github.com/0magnet/desk v0.0.0-20260910001430-2e7b6fa4face
 	github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db
 	github.com/0magnet/gobrpc v0.0.0-20260906144809-5215ec59d553
 	github.com/0magnet/golang-ipc v1.2.5-0.20260905172007-25d9c1a262d0

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585 h1:G2m5S+A3CMsHo
 github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585/go.mod h1:dp0q1zfKQmTaohUrPEPZbPExxBWLu9DyeaFxKUBnw6Y=
 github.com/0magnet/desk v0.0.0-20260909171253-833d45f6d44f h1:F5PQgLQLBMtSNWPnj2pBpVPY4KrDJYyhQKD/TlIjaWA=
 github.com/0magnet/desk v0.0.0-20260909171253-833d45f6d44f/go.mod h1:L+8Y1fP55UjK6RFOG0iAsR9oO6zXidCr9LZJy+8oN/k=
+github.com/0magnet/desk v0.0.0-20260910001430-2e7b6fa4face h1:fnFyReJIvbc0OCeaSXs4Xc/J/OyCSAa1W0apbahKYOM=
+github.com/0magnet/desk v0.0.0-20260910001430-2e7b6fa4face/go.mod h1:L+8Y1fP55UjK6RFOG0iAsR9oO6zXidCr9LZJy+8oN/k=
 github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db h1:t/kQDGFMvKhpRBTdEjiLCkVG9Pe/qmDuD8D65DJrdrs=
 github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db/go.mod h1:EDtFhI1TlDPunQIoT8IRbhe8wa5R4GAI+iL04vQDk2Y=
 github.com/0magnet/go-dsp v0.0.0-20260907230215-136ba239cc2d h1:AE2MbqkqaB88h+jtiWo5aI6zODI+0QZZRI4lY0p9Fhw=

--- a/pkg/visor/api_browse.go
+++ b/pkg/visor/api_browse.go
@@ -30,6 +30,10 @@ import (
 const browseFetchTimeout = 60 * time.Second
 const browseMaxBody = 16 << 20 // 16 MiB
 
+// browseProxyDialTimeout bounds the connect to a proxy named in
+// BrowseClearnetRequest.Proxy.
+const browseProxyDialTimeout = 10 * time.Second
+
 // BrowseFetchRequest fetches a dmsg/skynet site for the HV-UI browser. Host is
 // the resolving-proxy form (NOT dmsg://): a bare PK, "<pk>:<port>", "<pk>.dmsg",
 // a friendly alias like "home.dmsg"/"tpd.dmsg", or "name.skynet" — resolved the
@@ -462,13 +466,16 @@ func (v *Visor) proxyClearnetFetch(req BrowseClearnetRequest) (*SkynetHTTPRespon
 	tr := &http.Transport{TLSHandshakeTimeout: 20 * time.Second}
 	switch pu.Scheme {
 	case "socks5", "socks5h":
-		sd, err := proxy.SOCKS5("tcp", pu.Host, nil, proxy.Direct)
+		// A proxy that does not answer (an unroutable address) must fail in
+		// seconds, not after the OS connect timeout: the browser is waiting.
+		sd, err := proxy.SOCKS5("tcp", pu.Host, nil, &net.Dialer{Timeout: browseProxyDialTimeout})
 		if err != nil {
 			return nil, err
 		}
 		tr.DialContext = func(_ context.Context, network, addr string) (net.Conn, error) { return sd.Dial(network, addr) }
 	default:
 		tr.Proxy = http.ProxyURL(pu)
+		tr.DialContext = (&net.Dialer{Timeout: browseProxyDialTimeout}).DialContext
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), browseFetchTimeout)
 	defer cancel()

--- a/pkg/wasmhv/browseui/desk-boot.js
+++ b/pkg/wasmhv/browseui/desk-boot.js
@@ -451,6 +451,22 @@
 						var u;
 						try { u = new URL(url, location.href); } catch (e) { return fetch(url); }
 						var host = u.hostname || '';
+						// Same-origin URLs — this page's own assets, above all the favicon
+						// of a natively rendered same-origin tab — and the tab's own
+						// loopback (vnet:<port>) are fetched here, not sent to the host to
+						// dial as clearnet: the host would reach for a loopback of its own.
+						if (u.origin === location.origin) return fetch(url);
+						var lp = vnetPort(u);
+						if (lp) {
+							if (globalThis.vnet && globalThis.vnet.listening(lp)) {
+								return Promise.resolve(globalThis.vnet.httpFetch(lp, 'GET', (u.pathname || '/') + (u.search || ''), null, {})).then(function (r) {
+									var h = new Headers();
+									if (r && r.headers) { try { for (var k in r.headers) h.set(k, r.headers[k]); } catch (e) { /* ignore */ } }
+									return new Response((r && r.body) || new Uint8Array(0), { status: (r && r.status) || 200, headers: h });
+								});
+							}
+							return Promise.resolve(proxyError('nothing is listening on vnet port ' + lp));
+						}
 						if (/\.(dmsg|skynet|skysocks)$/i.test(host) || /^[0-9a-f]{66}$/i.test(host)) {
 							return browsePost('/api/browse/fetch', { host: host, port: u.port ? (parseInt(u.port, 10) || 80) : 80, method: 'GET', path: (u.pathname || '/') + (u.search || '') });
 						}

--- a/vendor/github.com/0magnet/desk/desk.go
+++ b/vendor/github.com/0magnet/desk/desk.go
@@ -121,6 +121,14 @@ type App struct {
 	// a console the boot script fills with a command, say — while Launch and
 	// AddTab still find it by name.
 	Unlisted bool
+
+	// NewTab puts a "+" at the end of the window's tab strip that opens another
+	// instance of this app — Open with no args — as a tab of the same window:
+	// what a terminal wants (another shell beside this one) and a file browser
+	// does not. The strip stays visible for a window whose app has it, so the
+	// "+" can be found while there is still only one tab. An app that draws its
+	// own tab strip (a browser) leaves it false.
+	NewTab bool
 }
 
 var (
@@ -279,6 +287,7 @@ func LaunchOpts(name string, opt Options, args ...string) (*winbox.WinBox, error
 	// tab set even for its first pane — see tabs_js.go for why one cannot be
 	// retrofitted later.
 	ts := newTabset(win)
+	ts.setApp(app)
 	if err := ts.add(pane, title); err != nil {
 		dropTabset(win)
 		win.Close(true)

--- a/vendor/github.com/0magnet/desk/tabs_js.go
+++ b/vendor/github.com/0magnet/desk/tabs_js.go
@@ -27,6 +27,10 @@ type tabset struct {
 	views  js.Value
 	tabs   []*paneTab
 	active int
+	// app is the app the window was opened with; plus is the "+" its NewTab
+	// puts at the end of the strip (a zero js.Value otherwise).
+	app  App
+	plus js.Value
 }
 
 type paneTab struct {
@@ -182,7 +186,11 @@ func (ts *tabset) add(pane Pane, title string) error {
 		return nil
 	}))
 	// Before the "+"-less strip's end; the strip holds only tab buttons.
-	ts.strip.Call("appendChild", t.btn)
+	if ts.plus.Truthy() {
+		ts.strip.Call("insertBefore", t.btn, ts.plus)
+	} else {
+		ts.strip.Call("appendChild", t.btn)
+	}
 
 	ts.tabs = append(ts.tabs, t)
 	ts.activate(idx)
@@ -252,7 +260,7 @@ func (ts *tabset) closeTab(i int) {
 
 // sync hides the strip while there is nothing to choose between.
 func (ts *tabset) sync() {
-	if len(ts.tabs) > 1 {
+	if len(ts.tabs) > 1 || ts.plus.Truthy() {
 		ts.strip.Get("style").Set("display", "flex")
 	} else {
 		ts.strip.Get("style").Set("display", "none")
@@ -318,4 +326,32 @@ func AddTabOpts(win *winbox.WinBox, name string, opt Options, args ...string) er
 		title = opt.Title
 	}
 	return ts.add(pane, title)
+}
+
+// setApp records the app a window was opened with and, when that app asks
+// for NewTab, puts a "+" at the end of its strip that opens another instance
+// of the app (Open with no args) as a tab of this window.
+func (ts *tabset) setApp(app App) {
+	ts.app = app
+	if !app.NewTab || ts.plus.Truthy() {
+		return
+	}
+	doc := js.Global().Get("document")
+	plus := doc.Call("createElement", "div")
+	plus.Set("textContent", "+")
+	plus.Set("title", "new "+app.Title)
+	plus.Get("style").Set("cssText", "display:flex;align-items:center;color:#cdd2da;border:1px solid #2a3040;"+
+		"border-bottom:none;border-radius:5px 5px 0 0;padding:3px 9px;cursor:pointer;font:12px monospace;opacity:.8")
+	plus.Call("addEventListener", "click", js.FuncOf(func(_ js.Value, a []js.Value) any {
+		if len(a) > 0 {
+			a[0].Call("stopPropagation")
+		}
+		// Open with no args: a fresh instance, not a replay of whatever the
+		// first tab was started with.
+		_ = AddTabOpts(ts.win, ts.app.Name, Options{}) //nolint:errcheck // a failed open leaves the strip as it was
+		return nil
+	}))
+	ts.strip.Call("appendChild", plus)
+	ts.plus = plus
+	ts.sync()
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -47,7 +47,7 @@ github.com/0magnet/coloredcobra
 # github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585
 ## explicit; go 1.24
 github.com/0magnet/cosmos-go
-# github.com/0magnet/desk v0.0.0-20260909171253-833d45f6d44f
+# github.com/0magnet/desk v0.0.0-20260910001430-2e7b6fa4face
 ## explicit; go 1.26
 github.com/0magnet/desk
 github.com/0magnet/desk/dom


### PR DESCRIPTION
On a hypervisor-served desk every non-mesh URL, including the page's own assets such as the favicon of a natively rendered same-origin tab, went to the host's /api/browse/clearnet, where the host reached for a loopback of its own. Same-origin URLs are now fetched by the page and vnet:<port> ones through the tab's loopback, as the wasm desk already did.

A proxy named in `BrowseClearnetRequest.Proxy` that does not answer failed only after the OS connect timeout; the connect is bounded to 10 s.

The terminal (host pty) and console windows get a "+" in their tab strip that opens another shell beside the current one (desk 2e7b6fa4, App.NewTab). Blob re-embed follows.