### PR TITLE
feat(desk): PWA for the hypervisor-served desk; browser visor relay-only while attached, normal dmsg client otherwise

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/0magnet/gotop/v4 v4.2.1-0.20260905172009-f9d674fb6dfd
 	github.com/0magnet/lolcat-go v0.0.0-20260907230215-22c54b7702c7
 	github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c
-	github.com/0magnet/netscrape v0.0.0-20260909235121-57c7ea4544f8
+	github.com/0magnet/netscrape v0.0.0-20260910002431-4317eab0bb2d
 	github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d
 	github.com/0magnet/plot-go v0.0.0-20260908184629-9cfdeb563e8f
 	github.com/0magnet/realorigin v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/0magnet/netscrape v0.0.0-20260908202925-8a8dea1c8609 h1:NaNeMDXsvjbGk
 github.com/0magnet/netscrape v0.0.0-20260908202925-8a8dea1c8609/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
 github.com/0magnet/netscrape v0.0.0-20260909235121-57c7ea4544f8 h1:EyD0MMVbgrIiJoCek49mg41SvAz8X9q2y+V8KiL6Dwo=
 github.com/0magnet/netscrape v0.0.0-20260909235121-57c7ea4544f8/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
+github.com/0magnet/netscrape v0.0.0-20260910002431-4317eab0bb2d h1:lHHWnvMOSM25S3RnxsoTkF3Hzwpqqqg0Tzdx7TnyM60=
+github.com/0magnet/netscrape v0.0.0-20260910002431-4317eab0bb2d/go.mod h1:8KUKD6yyp1VhFqWG8MYA+xM9CD+6cdjoNoXrhP/QMOM=
 github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d h1:T/CISGqaX8Sw1F+SYH6Uz8UQTsSN4KBabrCLShG+WRk=
 github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d/go.mod h1:xNKk6t2OtJQfb/pmWNiH8zUi0YCBuhYAr+fYa+rQ46s=
 github.com/0magnet/plot-go v0.0.0-20260908184629-9cfdeb563e8f h1:P1mbxDg4oisWjKscItJzjTaT38BS59GRQ3uLzoNuojU=

--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -85,7 +85,16 @@ type Config struct {
 	// The alternative it replaces was handing the client a discovery whose
 	// writes silently succeed without publishing (direct.NewClient), which left
 	// the client believing it had registered.
-	NoRegister           bool
+	NoRegister bool
+	// RelayOnly makes a relay session (SetRelayPeers, the skynet carrier) the
+	// only session this client holds while one is attached: the serve loop is
+	// satisfied by it, the idle reaper trims server sessions to it, and with no
+	// server session there is nothing to publish — the discovery entry is
+	// deleted. With no relay attached the client behaves as any other: it holds
+	// MinSessions server sessions and publishes an entry naming them. A browser
+	// visor sets it: attached to its host it rides the relay; off the host's
+	// LAN it falls back to servers over wss and is reachable over dmsg.
+	RelayOnly            bool
 	Callbacks            *ClientCallbacks
 	ClientType           string
 	ConnectedServersType string
@@ -390,6 +399,7 @@ func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Conf
 	// Init common fields.
 	c.EntityCommon.init(pk, sk, dc, log, conf.UpdateInterval)
 	c.EntityCommon.noRegister = conf.NoRegister
+	c.EntityCommon.relayOnly = conf.RelayOnly
 	c.EntityCommon.maxRelayedStreams = conf.MaxRelayedStreams
 	// Relay acceptor hooks (see client_relay.go): a request arriving over an
 	// accepted relay session is forwarded over this client's own server
@@ -509,8 +519,9 @@ func (ce *Client) Serve(ctx context.Context) {
 	porterReapLoopOnce := new(sync.Once)
 	reapLoopOnce := new(sync.Once)
 
-	// An unpublished client (Config.NoRegister) never posts an entry; it also
-	// deletes any stale one it left behind while it was published.
+	// A NoRegister client never posts an entry. A RelayOnly client posts one
+	// only while it holds server sessions (initilizeClientEntry checks), and
+	// deletes the stale one it left behind once it rides its relay.
 	needInitialPost := !ce.noRegister
 	staleEntryChecked := false
 
@@ -679,7 +690,7 @@ serve:
 			entries = append(relays, entries...)
 		}
 
-		if needInitialPost {
+		if needInitialPost && !(ce.relayOnly && !ce.hasServerSession()) {
 			// use this for put protocol type of client to disc, for dicision part of dmsg-server
 			err = ce.initilizeClientEntry(cancellabelCtx, ce.conf.ClientType, ce.conf.Protocol)
 			if err != nil {
@@ -689,7 +700,7 @@ serve:
 				needInitialPost = false
 			}
 		}
-		if ce.noRegister && !staleEntryChecked {
+		if (ce.noRegister || (ce.relayOnly && ce.hasRelaySession())) && !staleEntryChecked {
 			staleEntryChecked = true
 			go ce.deleteOwnEntry(cancellabelCtx)
 		}
@@ -1590,8 +1601,8 @@ func (ce *Client) reapExcessIdleSessions(idleStreak map[cipher.PubKey]int, idleC
 	if min <= 0 {
 		return
 	}
-	if ce.noRegister && ce.hasRelaySession() {
-		// An unpublished client with a relay attached keeps no server-session
+	if ce.relayOnly && ce.hasRelaySession() {
+		// A relay-only client with a relay attached keeps no server-session
 		// floor: the relay carries its dmsg; servers are dialed on demand and
 		// reaped when idle. The relay session itself is never idle (see below).
 		min = 1

--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -378,8 +378,8 @@ func (ce *Client) hasRelaySession() bool {
 // met, and — when relays are nominated and dialable — at least one relay
 // session held. Only meaningful when MinSessions != 0.
 func (ce *Client) sessionsSatisfied() bool {
-	if ce.noRegister && ce.hasRelaySession() {
-		// Unpublished client on a relay: the relay is the session. Holding
+	if ce.relayOnly && ce.hasRelaySession() {
+		// Relay-only client on a relay: the relay is the session. Holding
 		// MinSessions servers besides it would only republish what the relay
 		// already carries (#4484 stage 4: exactly one session).
 		return true
@@ -507,4 +507,17 @@ func (ce *Client) RelaySessionStreams() map[cipher.PubKey]int {
 		out[pk] = ses.NumStreams()
 	}
 	return out
+}
+
+// hasServerSession reports whether any session is to a dmsg server (not the
+// skynet relay carrier): what a discovery entry can name.
+func (ce *Client) hasServerSession() bool {
+	ce.sessionsMx.Lock()
+	defer ce.sessionsMx.Unlock()
+	for _, ses := range ce.sessions {
+		if ses.carrier != CarrierSkynet {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -73,6 +73,8 @@ type EntityCommon struct {
 	// with a fixed set of destinations, or for a deployment with no discovery
 	// at all; leave it clear for anything that must be findable by public key.
 	noRegister bool
+	// relayOnly: see Config.RelayOnly — publish only while server sessions exist.
+	relayOnly bool
 
 	// serverVersion, when non-empty, overrides the disc.Entry.Version a dmsg
 	// SERVER advertises (default "0.0.1") with its real build version. Set once
@@ -975,6 +977,18 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 	c.pushedSrvPKsMx.Lock()
 	lastPushed := c.lastPushedSrvPKs
 	c.pushedSrvPKsMx.Unlock()
+	if c.relayOnly && len(srvPKs) == 0 {
+		// Relay-only and riding the relay: no server session, nothing to name in
+		// an entry. Take down the one published while servers were held; peers
+		// reach this client over skynet, not through a server it left.
+		if len(lastPushed) > 0 {
+			c.deleteOwnEntry(ctx)
+			c.pushedSrvPKsMx.Lock()
+			c.lastPushedSrvPKs = []cipher.PubKey{}
+			c.pushedSrvPKsMx.Unlock()
+		}
+		return nil
+	}
 	if _, due := c.updateIsDue(); !due && lastPushed != nil && cipher.SamePubKeys(srvPKs, lastPushed) {
 		return nil
 	}
@@ -1442,7 +1456,24 @@ func (c *EntityCommon) recordUpdate() {
 
 // Unpublished reports whether this entity publishes no discovery entry
 // (Config.NoRegister). For `visor state`.
-func (c *EntityCommon) Unpublished() bool { return c.noRegister }
+func (c *EntityCommon) Unpublished() bool {
+	return c.noRegister || (c.relayOnly && c.hasSkynetSession())
+}
+
+// RelayOnly reports Config.RelayOnly.
+func (c *EntityCommon) RelayOnly() bool { return c.relayOnly }
+
+// hasSkynetSession reports whether a session rides the skynet carrier (a relay).
+func (c *EntityCommon) hasSkynetSession() bool {
+	c.sessionsMx.Lock()
+	defer c.sessionsMx.Unlock()
+	for _, ses := range c.sessions {
+		if ses.carrier == CarrierSkynet {
+			return true
+		}
+	}
+	return false
+}
 
 // deleteOwnEntry removes this entity's discovery entry if one exists — an
 // unpublished client that was published in an earlier life (or by an older

--- a/pkg/dmsg/dmsg/relay_nominee_test.go
+++ b/pkg/dmsg/dmsg/relay_nominee_test.go
@@ -347,27 +347,29 @@ func TestRelayNominee_DialSkipsRelayAfterItFails(t *testing.T) {
 	echoCheck(t, str, s)
 }
 
-// TestRelayNominee_UnpublishedClientHoldsRelayOnly: a client that publishes no
-// discovery entry (Config.NoRegister — the browser visor) keeps no server-
-// session floor once its relay is attached: the reaper trims idle server
-// sessions down to the relay alone and the serve loop does not re-dial them
-// (#4484 stage 4: exactly one dmsg session). A published client with the same
-// MinSessions would redial the server it just lost.
-func TestRelayNominee_UnpublishedClientHoldsRelayOnly(t *testing.T) {
+// TestRelayNominee_RelayOnlyClientHoldsRelayOnly: a Config.RelayOnly client
+// (the browser visor) behaves as any client until a relay attaches — server
+// sessions, a published entry — then keeps no server-session floor: the
+// reaper trims idle server sessions down to the relay alone, the serve loop
+// does not re-dial them, and with nothing to name the entry is deleted (#4484
+// stages 4 and 7). A published client with the same MinSessions would redial
+// the server it just lost.
+func TestRelayNominee_RelayOnlyClientHoldsRelayOnly(t *testing.T) {
 	env := newRelayedTestEnv(t, nil)
 	env.relay.maxRelayedStreams = 8
 	relayPK := env.relay.LocalPK()
 
 	pk, sk := GenKeyPair(t, "unpublished-client")
-	c := NewClient(pk, sk, env.dc, &Config{MinSessions: 2, NoRegister: true})
-	c.SetLogger(logging.MustGetLogger("unpublished-client"))
+	c := NewClient(pk, sk, env.dc, &Config{MinSessions: 2, RelayOnly: true})
+	c.SetLogger(logging.MustGetLogger("relayonly-client"))
 	var dials atomic.Int32
 	c.SetSessionDialer(skynetDialer(t, env.relay, relayPK, nil, &dials))
 	go c.Serve(context.Background())
 	t.Cleanup(func() { _ = c.Close() }) //nolint:errcheck
 	require.Eventually(t, func() bool { _, ok := c.Session(env.srvPK); return ok }, 15*time.Second, 50*time.Millisecond)
-	require.True(t, c.Unpublished())
+	require.False(t, c.Unpublished(), "no relay yet: a published client like any other")
 	require.False(t, c.sessionsSatisfied(), "one server, MinSessions 2, no relay: not satisfied")
+	require.Eventually(t, func() bool { _, err := env.dc.Entry(context.Background(), pk); return err == nil }, 10*time.Second, 50*time.Millisecond, "with a server session the entry is published")
 
 	c.SetRelayPeers([]cipher.PubKey{relayPK}, 70)
 	require.Eventually(t, c.hasRelaySession, 15*time.Second, 50*time.Millisecond)
@@ -385,7 +387,9 @@ func TestRelayNominee_UnpublishedClientHoldsRelayOnly(t *testing.T) {
 	require.Equal(t, 1, c.SessionCount(), "unpublished client must not redial servers to reach MinSessions")
 	require.True(t, c.sessionsSatisfied())
 
-	// Its entry was never posted.
+	// Riding the relay with no server session, the entry comes down.
+	require.True(t, c.Unpublished())
+	require.NoError(t, c.updateClientEntry(context.Background(), c.done, c.conf.ClientType))
 	_, err := env.dc.Entry(context.Background(), pk)
-	require.Error(t, err, "an unpublished client posts no discovery entry")
+	require.Error(t, err, "a relay-only client on its relay has no discovery entry")
 }

--- a/pkg/dmsg/dmsgc/dmsgc.go
+++ b/pkg/dmsg/dmsgc/dmsgc.go
@@ -101,8 +101,9 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 		// the client must skip its own server entry in the serve loop rather
 		// than dial a transit session to itself.
 		SkipSelfServer: conf.Server != nil && conf.Server.Enabled,
-		// A browser visor publishes no discovery entry (browserUnpublished).
-		NoRegister: browserUnpublished,
+		// A browser visor rides its host's relay when attached and publishes an
+		// entry only while it holds server sessions (browserRelayOnly).
+		RelayOnly: browserRelayOnly,
 		// The visor runs a dmsg relay acceptor on skyenv.DmsgRelayPort (see
 		// initDmsgRelay): streams it carries for attached peers are bounded here.
 		MaxRelayedStreams: dmsg.DefaultClientMaxRelayedStreams,

--- a/pkg/dmsg/dmsgc/dmsgc_js.go
+++ b/pkg/dmsg/dmsgc/dmsgc_js.go
@@ -2,11 +2,11 @@
 
 package dmsgc
 
-// browserUnpublished: a browser visor publishes no dmsg discovery entry. It is
-// reached over skynet (its host's transport, the forwarding mux) and its own
-// dmsg traffic rides its relay; an entry would only advertise server sessions
-// it does not hold. Route setup no longer needs the entry either — the
-// source-driven cascade is the browser default (#4730). Without an entry the
-// client also holds no server-session floor once a relay is attached (see
-// dmsg.Client sessionsSatisfied / reapExcessIdleSessions): #4484 stage 4.
-const browserUnpublished = true
+// browserRelayOnly: a browser visor served by a hypervisor rides that host's
+// dmsg relay (the skynet carrier) and holds no server session while it does —
+// so it has no discovery entry then (there is nothing to name in one; peers
+// reach it over skynet). Off the host's LAN the relay never attaches and the
+// same visor behaves as any other: server sessions over wss and a normal
+// entry, so the host reaches it as its hypervisor over dmsg. #4484 stages 4
+// and 7. See dmsg.Config.RelayOnly.
+const browserRelayOnly = true

--- a/pkg/dmsg/dmsgc/dmsgc_native.go
+++ b/pkg/dmsg/dmsgc/dmsgc_native.go
@@ -2,6 +2,7 @@
 
 package dmsgc
 
-// browserUnpublished is false on native builds: a native visor publishes its
-// discovery entry so peers can reach it over dmsg. See dmsgc_js.go.
-const browserUnpublished = false
+// browserRelayOnly is false on native builds: a native visor keeps its server
+// sessions and discovery entry whether or not a relay is nominated. See
+// dmsgc_js.go.
+const browserRelayOnly = false

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -70,6 +70,27 @@ func (hv *Hypervisor) uiHandler() http.Handler {
 	}()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		// PWA: the desk installs as an app. The manifest and icons are the ones
+		// `hv serve` uses; the service worker precaches THIS context's shell and
+		// is named by the served-build stamp, so a new build re-installs it.
+		case "/manifest.webmanifest":
+			w.Header().Set("Content-Type", "application/manifest+json")
+			w.Header().Set("Cache-Control", "no-cache")
+			_, _ = w.Write(wasmhv.PWAManifest) //nolint:errcheck
+			return
+		case "/icon-192.png":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(wasmhv.PWAIcon192) //nolint:errcheck
+			return
+		case "/icon-512.png":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(wasmhv.PWAIcon512) //nolint:errcheck
+			return
+		case "/sw.js":
+			w.Header().Set("Content-Type", "text/javascript")
+			w.Header().Set("Cache-Control", "no-store")
+			_, _ = w.Write(wasmhv.ServiceWorkerFor(hv.servedUIVersion(), []string{"/", "/manifest.webmanifest", "/icon-192.png", "/icon-512.png", "/browse.js", "/desk-boot.js", "/wasm_exec.js", "/winbox.wasm", "/skywire-worker.js", "/autoupdate.js"})) //nolint:errcheck
+			return
 		case "/browse.js":
 			serveJS(w, browseui.BrowseJS)
 			return

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -406,7 +406,7 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	}
 	serveBytes("/browse-responder.js", "text/javascript", realorigin.ResponderJS())
 	serveBytes("/browse-transport.js", "text/javascript", wasmhv.BrowseTransportJS)
-	swJS := bytes.ReplaceAll(wasmhv.ServiceWorkerJS, []byte("__BUILD__"), []byte(wasmVer))
+	swJS := wasmhv.ServiceWorkerFor(wasmVer, []string{"./", "manifest.webmanifest", "icon-192.png", "icon-512.png", "wasm_exec.js", "hv-boot.js", "worker.js", "browse.js", "winbox.wasm"})
 	mux.HandleFunc("/sw.js", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/javascript")
 		w.Header().Set("Cache-Control", "no-store")
@@ -1092,9 +1092,13 @@ const deskShellTemplate = `<!DOCTYPE html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="manifest" href="manifest.webmanifest">
+<meta name="theme-color" content="#0e0c14">
+<link rel="apple-touch-icon" href="icon-192.png">
 <title>skywire</title>
 <style>
   html,body{margin:0;height:100%;background:#0e0c14;color:#cdd2da;font:14px/1.5 system-ui,sans-serif}
+  #install{position:fixed;right:14px;bottom:14px;z-index:20;display:none;padding:8px 14px;border-radius:8px;border:1px solid #2a2342;background:#1b1626;color:#cdd2da;font:13px system-ui;cursor:pointer}
   #boot{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:.8em;z-index:10}
   #boot .t{color:#9d7cff;font:600 18px system-ui}
   #boot .s{color:#9aa0a6;font:12px monospace;max-width:44em;text-align:center}
@@ -1102,10 +1106,27 @@ const deskShellTemplate = `<!DOCTYPE html>
 </style>
 </head>
 <body>
+<button id="install" title="Install this desk as an app: it opens on its own and keeps working when this address is out of reach">Install Skywire</button>
 <div id="boot">
   <div class="t">skywire</div>
   <div class="s" id="boot-msg">loading…</div>
 </div>
+<script>
+// PWA: a service worker keeps the desk shell (and, once fetched, the wasm
+// modules) so the installed app opens off the LAN too — its visor then falls
+// back to dmsg over wss. The install prompt is offered as a button, not forced.
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function () {
+    navigator.serviceWorker.register('sw.js').catch(function (e) { console.warn('sw register failed', e); });
+  });
+}
+(function () {
+  var btn = document.getElementById('install'), deferred = null;
+  window.addEventListener('beforeinstallprompt', function (e) { e.preventDefault(); deferred = e; if (btn) btn.style.display = 'block'; });
+  window.addEventListener('appinstalled', function () { deferred = null; if (btn) btn.style.display = 'none'; });
+  if (btn) btn.addEventListener('click', function () { if (!deferred) return; deferred.prompt(); deferred.userChoice.then(function () { deferred = null; btn.style.display = 'none'; }); });
+})();
+</script>
 <script>
 window.__errs = [];
 Error.stackTraceLimit = 300;

--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -2,7 +2,9 @@
 package wasmhv
 
 import (
+	"bytes"
 	_ "embed"
+	"encoding/json"
 
 	"github.com/skycoin/skywire/pkg/wasmhv/browseui"
 )
@@ -163,3 +165,13 @@ var FaviconICO []byte
 //
 //go:embed wasm_exec.js
 var WasmExecJS []byte
+
+// ServiceWorkerFor renders sw.js for one serving context: build is the
+// fingerprint that names the cache (a new build ships a byte-different worker,
+// which is what makes the browser re-install it), precache the shell files
+// installed up front — the rest is cached as it is fetched.
+func ServiceWorkerFor(build string, precache []string) []byte {
+	list, _ := json.Marshal(precache) //nolint:errcheck // a []string always marshals
+	out := bytes.ReplaceAll(ServiceWorkerJS, []byte("__BUILD__"), []byte(build))
+	return bytes.ReplaceAll(out, []byte("__PRECACHE__"), list)
+}

--- a/pkg/wasmhv/sw.js
+++ b/pkg/wasmhv/sw.js
@@ -19,17 +19,10 @@
 // cache. Routine deploys need no manual edit here.
 
 const CACHE_VERSION = 'skywire-wasm-visor-__BUILD__';
-const PRECACHE = [
-  './',
-  'manifest.webmanifest',
-  'icon-192.png',
-  'icon-512.png',
-  'wasm_exec.js',
-  'hv-boot.js',
-  'worker.js',
-  'browse.js',
-  'winbox.wasm',
-];
+// The shell to precache is per serving context — the standalone wasm-visor
+// page and the hypervisor-served desk load different files — so the server
+// substitutes the list (a JSON array) along with the build fingerprint.
+const PRECACHE = __PRECACHE__;
 
 // Content-hashed (immutable) build assets: Angular emits main.<hash>.js,
 // styles.<hash>.css, <chunk>.<hash>.js — an 8+ hex-char segment between dots.

--- a/vendor/github.com/0magnet/netscrape/browser.go
+++ b/vendor/github.com/0magnet/netscrape/browser.go
@@ -369,6 +369,12 @@ func setFavicon(t *tab, iconURL string) {
 		if h := a[0].Get("headers").Call("get", "content-type"); h.Truthy() {
 			ct = h.String()
 		}
+		// A favicon is an image. A same-origin fallback that answers /favicon.ico
+		// with an HTML page (a single-page app's catch-all) is not one, and
+		// showing it as the icon painted a broken image in the tab.
+		if !strings.HasPrefix(strings.ToLower(ct), "image/") {
+			return g.Get("Promise").Call("reject")
+		}
 		return a[0].Call("arrayBuffer")
 	})
 	fetchVia(iconURL).Call("then", onResp).Call("then", onBuf).Call("catch", onErr)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,7 +85,7 @@ github.com/0magnet/lolcat-go/lol
 # github.com/0magnet/metrics v1.44.1-0.20260905010813-7e01f8bb5a1c
 ## explicit; go 1.25.0
 github.com/0magnet/metrics
-# github.com/0magnet/netscrape v0.0.0-20260909235121-57c7ea4544f8
+# github.com/0magnet/netscrape v0.0.0-20260910002431-4317eab0bb2d
 ## explicit; go 1.24
 github.com/0magnet/netscrape
 # github.com/0magnet/osnotify v0.0.0-20260906144808-7a227da43a0d


### PR DESCRIPTION
The desk shell carries the web-app manifest, theme colour and icons, registers a service worker and offers an "Install Skywire" button on beforeinstallprompt. The native hypervisor serves /manifest.webmanifest, the icons and /sw.js; sw.js takes its precache list from the serving context (`wasmhv.ServiceWorkerFor`) and caches everything else as fetched, so an installed desk opens off the LAN from the cache.

Off the LAN there is no same-origin transport, so the tab's visor must be a normal dmsg client. `dmsg.Config.RelayOnly` (browser visors; replaces the NoRegister of #4731) makes a relay session the only one held while one is attached — serve loop satisfied, idle server sessions reaped, discovery entry deleted — and otherwise leaves the client as any other: MinSessions server sessions over wss and a published entry, so the host reaches it as its hypervisor over dmsg. #4484 stage 7. Also pins netscrape 4317eab0 (a favicon must be an image). Re-embed follows.