### PR TITLE
fix(desk): files and viewer panes no longer deadlock the page

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/0magnet/bottle v0.0.0-20260908155251-920d2280a387
 	github.com/0magnet/calvin v0.0.0-20260908180241-0893f4bff56a
 	github.com/0magnet/desk v0.0.0-20260910001430-2e7b6fa4face
-	github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db
+	github.com/0magnet/desk/panes v0.0.0-20260910005138-02e96496996c
 	github.com/0magnet/gobrpc v0.0.0-20260906144809-5215ec59d553
 	github.com/0magnet/golang-ipc v1.2.5-0.20260905172007-25d9c1a262d0
 	github.com/0magnet/got v0.0.0-20260905231830-8b4c51f6f6f8
@@ -131,7 +131,7 @@ require (
 	github.com/0magnet/cosmos-go v0.0.0-20260908144221-45e3d0561585
 	github.com/0magnet/sh/v3 v3.13.2-0.20260818190530-13d0024da85c
 	github.com/0magnet/websh v0.0.0-20260908184825-10432f75b8da
-	github.com/0magnet/xterm-go v0.0.0-20260908011048-6bbc23473554
+	github.com/0magnet/xterm-go v0.0.0-20260909230905-494f3085d6ed
 	github.com/benhoyt/goawk v1.31.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/0magnet/desk v0.0.0-20260910001430-2e7b6fa4face h1:fnFyReJIvbc0OCeaSX
 github.com/0magnet/desk v0.0.0-20260910001430-2e7b6fa4face/go.mod h1:L+8Y1fP55UjK6RFOG0iAsR9oO6zXidCr9LZJy+8oN/k=
 github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db h1:t/kQDGFMvKhpRBTdEjiLCkVG9Pe/qmDuD8D65DJrdrs=
 github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db/go.mod h1:EDtFhI1TlDPunQIoT8IRbhe8wa5R4GAI+iL04vQDk2Y=
+github.com/0magnet/desk/panes v0.0.0-20260910005138-02e96496996c h1:2++YlzL8fNx2rHiA5whXsUrS5cvEFpAtJEU4ML1OOFs=
+github.com/0magnet/desk/panes v0.0.0-20260910005138-02e96496996c/go.mod h1:03HcaBfBFU2kiG/F3NUwNXxAn0rMOeSZM6EBiLesn3M=
 github.com/0magnet/go-dsp v0.0.0-20260907230215-136ba239cc2d h1:AE2MbqkqaB88h+jtiWo5aI6zODI+0QZZRI4lY0p9Fhw=
 github.com/0magnet/go-dsp v0.0.0-20260907230215-136ba239cc2d/go.mod h1:ThqukkPy/kmN6c6cyboZYESC9qdJKfYgHTMVp0iW7T0=
 github.com/0magnet/gobrpc v0.0.0-20260906144809-5215ec59d553 h1:Ko3+QbLQffRCkBiwD7O67LtZvDdhcuy0d9AtlWg0z5s=
@@ -136,6 +138,8 @@ github.com/0magnet/winbox-go v0.0.0-20260908011106-113d480c4188 h1:NY8NY7qUThHl9
 github.com/0magnet/winbox-go v0.0.0-20260908011106-113d480c4188/go.mod h1:19+/rRQWd/tc9/8CFcUr6C+3AipeZmHyyda2tVombe4=
 github.com/0magnet/xterm-go v0.0.0-20260908011048-6bbc23473554 h1:y8d7qkjDGex2mY5H1IOlQqMZWyK6ZvaFve5CPrO9EaE=
 github.com/0magnet/xterm-go v0.0.0-20260908011048-6bbc23473554/go.mod h1:W6c6ofSTsxXuQEr1rSZ3qmfOj5a3LGB3uLQBL0/TiKc=
+github.com/0magnet/xterm-go v0.0.0-20260909230905-494f3085d6ed h1:5vjSGoRZsXFVhOqfDIkuW/tpK7moB3sNSMcfkbRbSoE=
+github.com/0magnet/xterm-go v0.0.0-20260909230905-494f3085d6ed/go.mod h1:W6c6ofSTsxXuQEr1rSZ3qmfOj5a3LGB3uLQBL0/TiKc=
 github.com/0magnet/yamux v0.1.3-0.20260905172050-450c4058f851 h1:kCRHPdm/JLtNrPlHUyb/HiNRb5XJQEFtCKYtLEUlQT4=
 github.com/0magnet/yamux v0.1.3-0.20260905172050-450c4058f851/go.mod h1:Yu78IjOQxwmdP7GXF2D6ty5iyxdBiTU8JidU1WtNzbw=
 github.com/ActiveState/termtest/conpty v0.5.0 h1:JLUe6YDs4Jw4xNPCU+8VwTpniYOGeKzQg4SM2YHQNA8=

--- a/vendor/github.com/0magnet/desk/panes/files/files.go
+++ b/vendor/github.com/0magnet/desk/panes/files/files.go
@@ -62,6 +62,9 @@ type Pane struct {
 	fns                             dom.Funcs
 	menuTarget                      string
 	menuIsDir                       bool
+	// gen counts renders; a listing that comes back for an older render is
+	// dropped, so fast navigation never paints a stale directory.
+	gen int
 }
 
 // New opens at dir, or /home/user if empty.
@@ -162,12 +165,14 @@ func (p *Pane) mkdir() {
 	if name == "" {
 		return
 	}
-	if err := p.fs.MkdirAll(path.Join(p.dir, name), 0o755); err != nil {
-		p.fail(err)
-		return
-	}
-	p.fail(nil)
-	p.render()
+	go func() {
+		if err := p.fs.MkdirAll(path.Join(p.dir, name), 0o755); err != nil {
+			p.fail(err)
+			return
+		}
+		p.fail(nil)
+		p.render()
+	}()
 }
 
 func (p *Pane) rename(full string) {
@@ -176,12 +181,14 @@ func (p *Pane) rename(full string) {
 	if name == "" || name == old {
 		return
 	}
-	if err := p.fs.Rename(full, path.Join(path.Dir(full), name)); err != nil {
-		p.fail(err)
-		return
-	}
-	p.fail(nil)
-	p.render()
+	go func() {
+		if err := p.fs.Rename(full, path.Join(path.Dir(full), name)); err != nil {
+			p.fail(err)
+			return
+		}
+		p.fail(nil)
+		p.render()
+	}()
 }
 
 func (p *Pane) remove(full string, isDir bool) {
@@ -192,18 +199,20 @@ func (p *Pane) remove(full string, isDir bool) {
 	if !confirm(what) {
 		return
 	}
-	var err error
-	if isDir {
-		err = p.fs.RemoveAll(full)
-	} else {
-		err = p.fs.Remove(full)
-	}
-	if err != nil {
-		p.fail(err)
-		return
-	}
-	p.fail(nil)
-	p.render()
+	go func() {
+		var err error
+		if isDir {
+			err = p.fs.RemoveAll(full)
+		} else {
+			err = p.fs.Remove(full)
+		}
+		if err != nil {
+			p.fail(err)
+			return
+		}
+		p.fail(nil)
+		p.render()
+	}()
 }
 
 func prompt(message, def string) string {
@@ -226,11 +235,25 @@ func (p *Pane) chdir(dir string) {
 	p.render()
 }
 
+// render lists p.dir. The read happens on its own goroutine: on js/wasm a
+// filesystem call from the goroutine servicing a JS event (a click, the
+// desk's Launch) deadlocks the page — the filesystem answers on a microtask,
+// which cannot run until that handler returns. Every fs call here follows
+// the same rule.
 func (p *Pane) render() {
 	p.pathEl.Set("textContent", p.dir)
-	dom.Clear(p.list)
+	p.gen++
+	go p.renderGen(p.gen)
+}
 
+// renderGen lists p.dir for render generation gen and paints it unless a
+// newer render has started since.
+func (p *Pane) renderGen(gen int) {
 	infos, err := afero.ReadDir(p.fs, p.dir)
+	if gen != p.gen {
+		return
+	}
+	dom.Clear(p.list)
 	if err != nil {
 		p.list.Call("appendChild",
 			dom.El("div", dom.Class("dfm-empty"), dom.Text(err.Error())))

--- a/vendor/github.com/0magnet/xterm-go/screenbox.go
+++ b/vendor/github.com/0magnet/xterm-go/screenbox.go
@@ -1,0 +1,19 @@
+package xterm
+
+// screenBoxPx is the size of the terminal's screen box in CSS pixels.
+//
+// One expression with two users: .xterm-screen is laid out with it, and the
+// WebGL canvas is sized with it so that it overlays the screen exactly. They
+// used to be computed separately, and separately is how they drifted — the
+// canvas derived its box by dividing the ceil-ed DEVICE size back down by the
+// pixel ratio, which does not return the height it started from — ceil adds up
+// to a pixel per row at ANY pixel ratio, and more at a fractional one. On a 0.8125
+// dpr display at 46 rows that produced a 951px canvas over a 906px screen, and
+// the 41px difference hung out of the bottom of the terminal, putting a
+// scrollbar on a window whose content fitted.
+//
+// It lives in a file with no build tag so the arithmetic can be tested without
+// a browser, which is the whole of what went wrong.
+func screenBoxPx(cellW, cellH float64, cols, rows int) (w, h float64) {
+	return cellW * float64(cols), cellH * float64(rows)
+}

--- a/vendor/github.com/0magnet/xterm-go/webgl.go
+++ b/vendor/github.com/0magnet/xterm-go/webgl.go
@@ -883,8 +883,20 @@ func (r *webglRenderer) updateDimensions() {
 	d.deviceCharLeft = int(term.Core.Options.LetterSpacing / 2)
 	d.deviceCanvasHeight = term.Core.Rows() * d.deviceCellHeight
 	d.deviceCanvasWidth = term.Core.Cols() * d.deviceCellWidth
-	d.cssCanvasHeight = jsRound(float64(d.deviceCanvasHeight) / dpr)
-	d.cssCanvasWidth = jsRound(float64(d.deviceCanvasWidth) / dpr)
+	// The CSS box is the SCREEN's box, not the device buffer scaled back down.
+	//
+	// deviceCharHeight is ceil-ed so a glyph is never clipped in the atlas, and
+	// dividing that back by dpr does not return the height it came from — it
+	// returns up to 1/dpr more, per row. .xterm-screen is sized cellH*rows in CSS
+	// units with no such rounding, so the canvas came out TALLER than the screen
+	// it is supposed to overlay: 951px against 906 at 46 rows on a 0.8125 dpr
+	// display, which pushed 41px of canvas past the bottom of the terminal and
+	// put a scrollbar on a window whose content fitted.
+	//
+	// The drawing buffer stays at device resolution, so nothing about the
+	// rendering changes; only the box it is presented in, which now matches the
+	// element it sits on top of exactly.
+	d.cssCanvasWidth, d.cssCanvasHeight = screenBoxPx(term.cellW, term.cellH, term.Core.Cols(), term.Core.Rows())
 }
 
 func maxF(a, b float64) float64 {

--- a/vendor/github.com/0magnet/xterm-go/webgl_atlas.go
+++ b/vendor/github.com/0magnet/xterm-go/webgl_atlas.go
@@ -692,6 +692,29 @@ func (a *textureAtlas) findGlyphBoundingBox(pix []byte, canvasW, allowedWidth in
 		height = cfg.deviceCellHeight
 		width = cfg.deviceCellWidth
 	}
+	// Clamp every scan to the pixels that were actually read back.
+	//
+	// The left and right scans run to padding+width, which reaches past the
+	// end of the canvas whenever the temp canvas was grown to exactly
+	// allowedWidth -- a combined character of three runes or more does that,
+	// and a five-rune ZWJ emoji sequence does it at any font size. In
+	// JavaScript the overrun reads undefined out of the Uint8ClampedArray and
+	// compares unequal to 0, so upstream silently takes those columns as
+	// opaque and reports a glyph a few pixels too wide. Go indexes the same
+	// bytes and panics, which killed the renderer on the first emoji drawn.
+	//
+	// Clamping fixes both: the columns past the canvas hold no glyph, so
+	// leaving them out is what the scan meant to do.
+	if rows := len(pix) / maxIntv(canvasW*4, 1); height > rows {
+		height = rows
+	}
+	if width > canvasW {
+		width = canvasW
+	}
+	xMax := padding + width
+	if xMax > canvasW {
+		xMax = canvasW
+	}
 	alpha := func(x, y int) byte { return pix[y*canvasW*4+x*4+3] }
 
 	top := 0
@@ -706,7 +729,7 @@ found1:
 	}
 	left := 0
 found2:
-	for x := 0; x < padding+width; x++ {
+	for x := 0; x < xMax; x++ {
 		for y := 0; y < height; y++ {
 			if alpha(x, y) != 0 {
 				left = x
@@ -716,7 +739,7 @@ found2:
 	}
 	right := width
 found3:
-	for x := padding + width - 1; x >= padding; x-- {
+	for x := xMax - 1; x >= padding; x-- {
 		for y := 0; y < height; y++ {
 			if alpha(x, y) != 0 {
 				right = x

--- a/vendor/github.com/0magnet/xterm-go/xterm.go
+++ b/vendor/github.com/0magnet/xterm-go/xterm.go
@@ -256,8 +256,9 @@ func (t *Terminal) refreshRowEls() {
 		t.rowsEl.Call("removeChild", last)
 		t.rowEls = t.rowEls[:len(t.rowEls)-1]
 	}
-	t.screen.Get("style").Set("width", jsPx(t.cellW*float64(t.Core.Cols())))
-	t.screen.Get("style").Set("height", jsPx(t.cellH*float64(rows)))
+	sw, sh := screenBoxPx(t.cellW, t.cellH, t.Core.Cols(), rows)
+	t.screen.Get("style").Set("width", jsPx(sw))
+	t.screen.Get("style").Set("height", jsPx(sh))
 }
 
 func (t *Terminal) updateScrollArea() {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -51,7 +51,7 @@ github.com/0magnet/cosmos-go
 ## explicit; go 1.26
 github.com/0magnet/desk
 github.com/0magnet/desk/dom
-# github.com/0magnet/desk/panes v0.0.0-20260908190105-9bb2944487db
+# github.com/0magnet/desk/panes v0.0.0-20260910005138-02e96496996c
 ## explicit; go 1.26
 github.com/0magnet/desk/panes/files
 # github.com/0magnet/go-dsp v0.0.0-20260907230215-136ba239cc2d
@@ -140,7 +140,7 @@ github.com/0magnet/wfdrive/bidi
 ## explicit; go 1.24
 github.com/0magnet/winbox-go
 github.com/0magnet/winbox-go/dist
-# github.com/0magnet/xterm-go v0.0.0-20260908011048-6bbc23473554
+# github.com/0magnet/xterm-go v0.0.0-20260909230905-494f3085d6ed
 ## explicit; go 1.24
 github.com/0magnet/xterm-go
 github.com/0magnet/xterm-go/vt


### PR DESCRIPTION
Opening the file browser froze the desk (reported on :8000, reproduced over CDP): the pane read its directory on the goroutine servicing the launch click, and on js/wasm the filesystem answers on a microtask that cannot run until that handler returns. desk/panes 02e96496 does the listing, mkdir/rename/delete and the viewer's read in goroutines. Pin bump + vendor; blob re-embed follows.