### PR TITLE
fix(visor): mirror paired hypervisors into skywire.conf so autoconfig keeps them

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -469,23 +469,6 @@ func autoconfigRun(cmd *cobra.Command, args []string) {
 	finishAutoconfig(resolved)
 }
 
-// defaultSkyenvPath returns the canonical SKYENV file location for
-// the host OS. Linux uses /etc/skywire.conf (FHS); Windows uses
-// %ProgramData%\Skywire\skywire.conf (the equivalent system-wide
-// configuration path — picked up by an elevated Notepad or the
-// %ProgramData% environment variable). Anything else falls back to
-// the Linux path so darwin / freebsd builds keep their previous
-// behavior; they're not formally supported here but shouldn't regress.
-func defaultSkyenvPath() string {
-	if runtime.GOOS == "windows" {
-		if pd := os.Getenv("ProgramData"); pd != "" {
-			return filepath.Join(pd, "Skywire", "skywire.conf")
-		}
-		return `C:\ProgramData\Skywire\skywire.conf`
-	}
-	return "/etc/skywire.conf"
-}
-
 // resolveConfig reads the skyenv file and translates it to the
 // concrete answers downstream code needs. Falls back gracefully to
 // the legacy PKGENV-on-root behavior when the file is silent.

--- a/cmd/skywire/commands/autoconfig_skyenv.go
+++ b/cmd/skywire/commands/autoconfig_skyenv.go
@@ -1,229 +1,24 @@
 // Package commands cmd/skywire/commands/autoconfig_skyenv.go c4-vis-cli
 //
-// updateSkyenvFile applies a list of key/value edits to a bash-style
-// env file (e.g. /etc/skywire.conf). For each edit:
-//
-//   - If a line `KEY=...` exists (commented `#KEY=...` or not), it is
-//     replaced with the new `KEY=value` form, uncommented.
-//   - If no such line exists, the edit is appended at the end of the
-//     file under a "set by skywire autoconfig" header.
-//
-// Other lines (comments, unrelated settings, formatting) are preserved
-// verbatim. Write is atomic: temp file + fsync + rename.
-//
-// This is the implementation behind the `skywire autoconfig --hvpks ...`
-// family of flags that bypass having operators hand-edit the config
-// file for the common knobs while still keeping that file as the
-// single source of truth for `skywire cli config gen`.
+// Thin aliases over pkg/skywireconfig/skyenvfile, which owns editing the
+// bash-style skyenv file (/etc/skywire.conf). The visor shares that
+// package so a paired hypervisor survives the next autoconfig run.
 package commands
 
-import (
-	"bufio"
-	"fmt"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-)
+import "github.com/skycoin/skywire/pkg/skywireconfig/skyenvfile"
 
-// skyenvEdit is one key/value update applied to a skyenv file.
-// Value should already be formatted in the bash syntax expected for
-// that key — single-quoted strings, bare booleans/ints, or
-// '(...)'-wrapped arrays. See formatSkyenvBool / formatSkyenvString /
-// formatSkyenvBashArray helpers below.
-type skyenvEdit struct {
-	Key   string // bash variable name (e.g. "HYPERVISORPKS")
-	Value string // RHS, including quoting / array parens / value
-	Raw   string // the value as the flag gave it: bool text, string, number, or comma-separated list
-}
+type skyenvEdit = skyenvfile.Edit
 
-// updateSkyenvFile applies the edits to the file at path. The file
-// must already exist — `skywire autoconfig` always installs the
-// template via the package, so this is a safe assumption for the
-// operator-facing flow. Returns an error if the file is missing or
-// the atomic rename fails.
-//
-// If two edits target the same key, the LATER one wins (mirrors the
-// bash semantics of sequential assignment).
-func updateSkyenvFile(path string, edits []skyenvEdit) error {
-	if len(edits) == 0 {
-		return nil
-	}
-	if path == "" {
-		return fmt.Errorf("updateSkyenvFile: empty path")
-	}
+func updateSkyenvFile(path string, edits []skyenvEdit) error { return skyenvfile.Update(path, edits) }
 
-	// De-dupe + last-write-wins, preserving insertion order for the
-	// append-tail case. Map provides constant-time lookup during the
-	// scan; slice holds order for the eventual append.
-	desired := make(map[string]string, len(edits))
-	ordered := make([]string, 0, len(edits))
-	for _, e := range edits {
-		if _, ok := desired[e.Key]; !ok {
-			ordered = append(ordered, e.Key)
-		}
-		desired[e.Key] = e.Value
-	}
+func skyenvLineKey(line string) string { return skyenvfile.LineKey(line) }
 
-	src, err := os.Open(path) //nolint:gosec
-	if err != nil {
-		return fmt.Errorf("updateSkyenvFile: open %s: %w", path, err)
-	}
-	defer src.Close() //nolint:errcheck
+func formatSkyenvBool(b bool) string { return skyenvfile.FormatBool(b) }
 
-	matched := make(map[string]bool, len(desired))
-	out := make([]string, 0, 256)
+func formatSkyenvString(s string) string { return skyenvfile.FormatString(s) }
 
-	scanner := bufio.NewScanner(src)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20) // tolerate long lines
-	for scanner.Scan() {
-		line := scanner.Text()
-		if k := skyenvLineKey(line); k != "" {
-			if v, ok := desired[k]; ok {
-				out = append(out, k+"="+v)
-				matched[k] = true
-				continue
-			}
-		}
-		out = append(out, line)
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("updateSkyenvFile: scan %s: %w", path, err)
-	}
+func formatSkyenvBashArray(csv string) string { return skyenvfile.FormatBashArray(csv) }
 
-	// Append any keys we never matched. Tag the block so operators
-	// scanning the file later can tell autoconfig wrote it.
-	var appended []string
-	for _, k := range ordered {
-		if !matched[k] {
-			appended = append(appended, k+"="+desired[k])
-		}
-	}
-	if len(appended) > 0 {
-		// Trim a trailing empty line on the existing file so the
-		// header block stays visually attached without a double blank.
-		for len(out) > 0 && out[len(out)-1] == "" {
-			out = out[:len(out)-1]
-		}
-		out = append(out,
-			"",
-			"### Added by `skywire autoconfig` ######################################",
-		)
-		out = append(out, appended...)
-	}
+func formatSkyenvInt(i int) string { return skyenvfile.FormatInt(i) }
 
-	// Atomic write: temp file in the same dir, fsync, rename. Same-dir
-	// is required so the rename is on the same filesystem.
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".skywire.conf.tmp-")
-	if err != nil {
-		return fmt.Errorf("updateSkyenvFile: tempfile: %w", err)
-	}
-	tmpPath := tmp.Name()
-	cleanup := func() { _ = os.Remove(tmpPath) } //nolint:errcheck
-	w := bufio.NewWriter(tmp)
-	for _, line := range out {
-		if _, err := w.WriteString(line); err != nil {
-			_ = tmp.Close() //nolint:errcheck,gosec
-			cleanup()
-			return fmt.Errorf("updateSkyenvFile: write: %w", err)
-		}
-		if _, err := w.WriteString("\n"); err != nil {
-			_ = tmp.Close() //nolint:errcheck,gosec
-			cleanup()
-			return fmt.Errorf("updateSkyenvFile: write: %w", err)
-		}
-	}
-	if err := w.Flush(); err != nil {
-		_ = tmp.Close() //nolint:errcheck,gosec
-		cleanup()
-		return fmt.Errorf("updateSkyenvFile: flush: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close() //nolint:errcheck,gosec
-		cleanup()
-		return fmt.Errorf("updateSkyenvFile: sync: %w", err)
-	}
-	// Preserve original mode if possible; otherwise default to 0644
-	// (autoconfig usually runs as root via systemd, and the file is
-	// world-readable by design — operators view it without sudo).
-	mode := os.FileMode(0644)
-	if st, err := os.Stat(path); err == nil {
-		mode = st.Mode().Perm()
-	}
-	if err := tmp.Chmod(mode); err != nil {
-		_ = tmp.Close() //nolint:errcheck,gosec
-		cleanup()
-		return fmt.Errorf("updateSkyenvFile: chmod: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		cleanup()
-		return fmt.Errorf("updateSkyenvFile: close: %w", err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		cleanup()
-		return fmt.Errorf("updateSkyenvFile: rename: %w", err)
-	}
-	return nil
-}
-
-// skyenvKeyRE matches `KEY=` or `#KEY=` (with optional leading
-// whitespace and optional space between `#` and the key). Captures the
-// key name. Anchored at line start.
-//
-// Conservative on the LHS: only matches the bash-conventional shape
-// (UPPER_CASE plus underscore + digits). Mixed-case `key=value` lines,
-// rare in skywire.conf, are left untouched — autoconfig will append
-// them as new lines instead of trying to replace.
-var skyenvKeyRE = regexp.MustCompile(`^\s*#?\s*([A-Z_][A-Z0-9_]*)=`)
-
-// skyenvLineKey returns the bash variable name from a line that looks
-// like `KEY=value` or `#KEY=value`, or empty if the line isn't a
-// recognizable variable assignment.
-func skyenvLineKey(line string) string {
-	m := skyenvKeyRE.FindStringSubmatch(line)
-	if len(m) < 2 {
-		return ""
-	}
-	return m[1]
-}
-
-// formatSkyenvBool returns the bash-literal form for a boolean knob:
-// "true" or "false". Bash treats both as bare words; the visor's
-// scriptExecBool unwraps either to a Go bool.
-func formatSkyenvBool(b bool) string {
-	if b {
-		return "true"
-	}
-	return "false"
-}
-
-// formatSkyenvString returns the bash-literal form for a string knob.
-// Single-quoted with `'` escaped via `'\”`. Operators read these
-// values verbatim; we don't try to be clever about it.
-func formatSkyenvString(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
-}
-
-// formatSkyenvBashArray returns the `('a' 'b' 'c')` form expected by
-// HYPERVISORPKS / DMSGPTYPKS / etc. Input is split on commas; each
-// element is trimmed and single-quoted. Empty input produces `(”)`
-// to match the template's default-empty representation.
-func formatSkyenvBashArray(csv string) string {
-	parts := strings.Split(csv, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		out = append(out, "'"+strings.ReplaceAll(p, "'", `'\''`)+"'")
-	}
-	if len(out) == 0 {
-		return "('')"
-	}
-	return "(" + strings.Join(out, " ") + ")"
-}
-
-// formatSkyenvInt returns the bash-literal form for an int knob.
-func formatSkyenvInt(i int) string { return fmt.Sprintf("%d", i) }
+func defaultSkyenvPath() string { return skyenvfile.DefaultPath() }

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -54,6 +54,9 @@ host as a hypervisor. Approve it on the machine with
 `skywire cli visor hv pair` (lists pending tabs by fingerprint, then
 `hv pair <fingerprint>`), or mint a one-time code with
 `skywire cli visor hv pair --code` and type it into the tab's Pair window.
+Approval is written to the visor config and, on a package install, mirrored
+into `HYPERVISORPKS` in `/etc/skywire.conf`, so it survives the next
+`skywire autoconfig` run (every package update performs one).
 
 ## Hypervisor terminal UI
 

--- a/pkg/skywireconfig/skyenvfile/skyenvfile.go
+++ b/pkg/skywireconfig/skyenvfile/skyenvfile.go
@@ -1,0 +1,247 @@
+// Package skyenvfile pkg/skywireconfig/skyenvfile/skyenvfile.go c4-vis-cli
+//
+// Update applies a list of key/value edits to a bash-style env file
+// (e.g. /etc/skywire.conf). For each edit:
+//
+//   - If a line `KEY=...` exists (commented `#KEY=...` or not), it is
+//     replaced with the new `KEY=value` form, uncommented.
+//   - If no such line exists, the edit is appended at the end of the
+//     file under a "set by skywire autoconfig" header.
+//
+// Other lines (comments, unrelated settings, formatting) are preserved
+// verbatim. Write is atomic: temp file + fsync + rename.
+//
+// `skywire autoconfig` is the main writer; the visor also uses it to keep
+// a runtime change (a paired hypervisor) in skywire.conf, because the
+// json config is a derived artifact that the next autoconfig run
+// rebuilds from this file.
+package skyenvfile
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// DefaultPath returns the canonical SKYENV file location for the host
+// OS. Linux uses /etc/skywire.conf (FHS); Windows uses
+// %ProgramData%\Skywire\skywire.conf (the equivalent system-wide
+// configuration path — picked up by an elevated Notepad or the
+// %ProgramData% environment variable). Anything else falls back to the
+// Linux path so darwin / freebsd builds keep their previous behavior;
+// they're not formally supported here but shouldn't regress.
+func DefaultPath() string {
+	if runtime.GOOS == "windows" {
+		if pd := os.Getenv("ProgramData"); pd != "" {
+			return filepath.Join(pd, "Skywire", "skywire.conf")
+		}
+		return `C:\ProgramData\Skywire\skywire.conf`
+	}
+	return "/etc/skywire.conf"
+}
+
+// Edit is one key/value update applied to a skyenv file.
+// Value should already be formatted in the bash syntax expected for
+// that key — single-quoted strings, bare booleans/ints, or
+// '(...)'-wrapped arrays. See FormatBool / FormatString /
+// FormatBashArray helpers below.
+type Edit struct {
+	Key   string // bash variable name (e.g. "HYPERVISORPKS")
+	Value string // RHS, including quoting / array parens / value
+	Raw   string // the value as the flag gave it: bool text, string, number, or comma-separated list
+}
+
+// Update applies the edits to the file at path. The file
+// must already exist — `skywire autoconfig` always installs the
+// template via the package, so this is a safe assumption for the
+// operator-facing flow. Returns an error if the file is missing or
+// the atomic rename fails.
+//
+// If two edits target the same key, the LATER one wins (mirrors the
+// bash semantics of sequential assignment).
+func Update(path string, edits []Edit) error {
+	if len(edits) == 0 {
+		return nil
+	}
+	if path == "" {
+		return fmt.Errorf("Update: empty path")
+	}
+
+	// De-dupe + last-write-wins, preserving insertion order for the
+	// append-tail case. Map provides constant-time lookup during the
+	// scan; slice holds order for the eventual append.
+	desired := make(map[string]string, len(edits))
+	ordered := make([]string, 0, len(edits))
+	for _, e := range edits {
+		if _, ok := desired[e.Key]; !ok {
+			ordered = append(ordered, e.Key)
+		}
+		desired[e.Key] = e.Value
+	}
+
+	src, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("Update: open %s: %w", path, err)
+	}
+	defer src.Close() //nolint:errcheck
+
+	matched := make(map[string]bool, len(desired))
+	out := make([]string, 0, 256)
+
+	scanner := bufio.NewScanner(src)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20) // tolerate long lines
+	for scanner.Scan() {
+		line := scanner.Text()
+		if k := LineKey(line); k != "" {
+			if v, ok := desired[k]; ok {
+				out = append(out, k+"="+v)
+				matched[k] = true
+				continue
+			}
+		}
+		out = append(out, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("Update: scan %s: %w", path, err)
+	}
+
+	// Append any keys we never matched. Tag the block so operators
+	// scanning the file later can tell autoconfig wrote it.
+	var appended []string
+	for _, k := range ordered {
+		if !matched[k] {
+			appended = append(appended, k+"="+desired[k])
+		}
+	}
+	if len(appended) > 0 {
+		// Trim a trailing empty line on the existing file so the
+		// header block stays visually attached without a double blank.
+		for len(out) > 0 && out[len(out)-1] == "" {
+			out = out[:len(out)-1]
+		}
+		out = append(out,
+			"",
+			"### Added by `skywire autoconfig` ######################################",
+		)
+		out = append(out, appended...)
+	}
+
+	// Atomic write: temp file in the same dir, fsync, rename. Same-dir
+	// is required so the rename is on the same filesystem.
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".skywire.conf.tmp-")
+	if err != nil {
+		return fmt.Errorf("Update: tempfile: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) } //nolint:errcheck
+	w := bufio.NewWriter(tmp)
+	for _, line := range out {
+		if _, err := w.WriteString(line); err != nil {
+			_ = tmp.Close() //nolint:errcheck,gosec
+			cleanup()
+			return fmt.Errorf("Update: write: %w", err)
+		}
+		if _, err := w.WriteString("\n"); err != nil {
+			_ = tmp.Close() //nolint:errcheck,gosec
+			cleanup()
+			return fmt.Errorf("Update: write: %w", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		_ = tmp.Close() //nolint:errcheck,gosec
+		cleanup()
+		return fmt.Errorf("Update: flush: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close() //nolint:errcheck,gosec
+		cleanup()
+		return fmt.Errorf("Update: sync: %w", err)
+	}
+	// Preserve original mode if possible; otherwise default to 0644
+	// (autoconfig usually runs as root via systemd, and the file is
+	// world-readable by design — operators view it without sudo).
+	mode := os.FileMode(0644)
+	if st, err := os.Stat(path); err == nil {
+		mode = st.Mode().Perm()
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close() //nolint:errcheck,gosec
+		cleanup()
+		return fmt.Errorf("Update: chmod: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("Update: close: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("Update: rename: %w", err)
+	}
+	return nil
+}
+
+// keyRE matches `KEY=` or `#KEY=` (with optional leading
+// whitespace and optional space between `#` and the key). Captures the
+// key name. Anchored at line start.
+//
+// Conservative on the LHS: only matches the bash-conventional shape
+// (UPPER_CASE plus underscore + digits). Mixed-case `key=value` lines,
+// rare in skywire.conf, are left untouched — autoconfig will append
+// them as new lines instead of trying to replace.
+var keyRE = regexp.MustCompile(`^\s*#?\s*([A-Z_][A-Z0-9_]*)=`)
+
+// LineKey returns the bash variable name from a line that looks
+// like `KEY=value` or `#KEY=value`, or empty if the line isn't a
+// recognizable variable assignment.
+func LineKey(line string) string {
+	m := keyRE.FindStringSubmatch(line)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// FormatBool returns the bash-literal form for a boolean knob:
+// "true" or "false". Bash treats both as bare words; the visor's
+// scriptExecBool unwraps either to a Go bool.
+func FormatBool(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// FormatString returns the bash-literal form for a string knob.
+// Single-quoted with `'` escaped via `'\”`. Operators read these
+// values verbatim; we don't try to be clever about it.
+func FormatString(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// FormatBashArray returns the `('a' 'b' 'c')` form expected by
+// HYPERVISORPKS / DMSGPTYPKS / etc. Input is split on commas; each
+// element is trimmed and single-quoted. Empty input produces `(”)`
+// to match the template's default-empty representation.
+func FormatBashArray(csv string) string {
+	parts := strings.Split(csv, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, "'"+strings.ReplaceAll(p, "'", `'\''`)+"'")
+	}
+	if len(out) == 0 {
+		return "('')"
+	}
+	return "(" + strings.Join(out, " ") + ")"
+}
+
+// FormatInt returns the bash-literal form for an int knob.
+func FormatInt(i int) string { return fmt.Sprintf("%d", i) }

--- a/pkg/skywireconfig/skyenvfile/skyenvfile_test.go
+++ b/pkg/skywireconfig/skyenvfile/skyenvfile_test.go
@@ -1,0 +1,50 @@
+// Package skyenvfile pkg/skywireconfig/skyenvfile/skyenvfile_test.go c4-vis-cli
+package skyenvfile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpdateReplacesCommentedKeyAndAppendsMissing(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "skywire.conf")
+	src := "PKGENV=true\n#--\tSet remote hypervisor public keys\n#HYPERVISORPKS=('')\nISHYPERVISOR=false\n"
+	if err := os.WriteFile(p, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	edits := []Edit{
+		{Key: "HYPERVISORPKS", Value: FormatBashArray("aa,bb"), Raw: "aa,bb"},
+		{Key: "DMSGSERVERCONF", Value: FormatString("/etc/skywire-dmsg.json"), Raw: "/etc/skywire-dmsg.json"},
+	}
+	if err := Update(p, edits); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(got)
+	for _, want := range []string{
+		"PKGENV=true\n",
+		"#--\tSet remote hypervisor public keys\n",
+		"HYPERVISORPKS=('aa' 'bb')\n",
+		"ISHYPERVISOR=false\n",
+		"DMSGSERVERCONF='/etc/skywire-dmsg.json'",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %q in:\n%s", want, s)
+		}
+	}
+	if strings.Contains(s, "#HYPERVISORPKS") {
+		t.Errorf("commented key not replaced:\n%s", s)
+	}
+	if LineKey("  # FOO_1=x") != "FOO_1" || LineKey("foo=x") != "" {
+		t.Errorf("LineKey mismatch")
+	}
+	if FormatBashArray("") != "('')" {
+		t.Errorf("empty array = %q", FormatBashArray(""))
+	}
+}

--- a/pkg/visor/api_hypervisors.go
+++ b/pkg/visor/api_hypervisors.go
@@ -4,19 +4,21 @@ package visor
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/skywireconfig/skyenvfile"
 )
 
 // AddHypervisor adds a remote hypervisor PK and connects to it at runtime.
 // The PK is written to the config's hypervisors list (see persistHypervisors),
-// so the connection survives a restart — but skywire-config.json is a derived
-// artifact: the next `skywire autoconfig` run rebuilds it from
-// /etc/skywire.conf and drops a PK that is only in the json. Set HYPERVISORPKS
-// in skywire.conf for a hypervisor that must survive a package update.
+// so the connection survives a restart, and on a package install it is mirrored
+// into HYPERVISORPKS in skywire.conf so the next `skywire autoconfig` run (every
+// package update) keeps it.
 func (v *Visor) AddHypervisor(hvPK cipher.PubKey) error {
 	if v.dmsgC == nil {
 		return fmt.Errorf("DMSG client not running")
@@ -116,12 +118,37 @@ func removePK(pks []cipher.PubKey, pk cipher.PubKey) []cipher.PubKey {
 // a restart. Best-effort: a non-file-backed config (wasm tab / STDIN) can't write
 // — the runtime connection change already took effect, so a write error is only
 // logged, never fatal.
+//
+// On a package install the json is a derived artifact: `skywire autoconfig`
+// (run by every package update) rebuilds it from skywire.conf, so the list is
+// mirrored into HYPERVISORPKS there too. Only the package config path does
+// this — a dev visor on a repo-local config never touches /etc/skywire.conf.
 func (v *Visor) persistHypervisors(want []cipher.PubKey) {
 	if v.conf == nil || v.conf.Path() == "" {
 		return // not file-backed; runtime change stands without persistence
 	}
 	if err := v.conf.UpdateHypervisors(want); err != nil {
 		v.log.WithError(err).Warn("failed to persist hypervisors to config")
+	}
+	if v.conf.Path() != skyenv.SkywireConfig() {
+		return
+	}
+	skyenvPath := skyenvfile.DefaultPath()
+	if _, err := os.Stat(skyenvPath); err != nil {
+		return // not an autoconfig-managed host
+	}
+	pks := make([]string, 0, len(want))
+	for _, pk := range want {
+		pks = append(pks, pk.String())
+	}
+	edit := skyenvfile.Edit{
+		Key:   "HYPERVISORPKS",
+		Value: skyenvfile.FormatBashArray(strings.Join(pks, ",")),
+		Raw:   strings.Join(pks, ","),
+	}
+	if err := skyenvfile.Update(skyenvPath, []skyenvfile.Edit{edit}); err != nil {
+		v.log.WithError(err).WithField("path", skyenvPath).
+			Warn("failed to mirror hypervisors into skywire.conf; the next autoconfig run will drop them")
 	}
 }
 


### PR DESCRIPTION
A hypervisor approved with `hv pair` (or `hv add`) was written only to skywire-config.json. `skywire autoconfig` rebuilds that file from /etc/skywire.conf on every package update, so the pairing was silently lost on the next update.

The skyenv file editor moves from cmd/skywire/commands into `pkg/skywireconfig/skyenvfile` (same code, exported), and `persistHypervisors` now also writes `HYPERVISORPKS` there when the visor runs on the package config path. Dev visors on a repo-local config are unaffected. Docs note added. Follow-up to #4484 stage 5.