### PR TITLE
feat(visor): run a standalone dmsg server in-process from its config file

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -128,6 +128,13 @@ const envfileLinux = `#
 #	hypervisors on a NAT.
 #LANDMSGPUBLIC='203.0.113.42:8082'
 
+#--	Run a public dmsg server inside the visor from a standalone dmsg-server
+#	config file (the one "skywire dmsg server start <file>" used). Replaces
+#	a separate dmsg server unit on the same host: stop and disable that
+#	unit first, and drop it from RESTART_SERVICES. The server keeps its own
+#	key, ports, wss domain and health endpoint from that file.
+#DMSGSERVERCONF='/etc/skywire-dmsg.json'
+
 ### Rewards #############################################################
 
 #--	Skycoin reward address or xpub key

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -473,6 +473,8 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "lan-dmsg-port")
 	genConfigCmd.Flags().StringVar(&lanDmsgPublicAddress, "lan-dmsg-public", scriptExecString("${LANDMSGPUBLIC}"), "embedded DMSG server WAN-reachable address (host:port; requires port-forward)")
 	gHiddenFlags = append(gHiddenFlags, "lan-dmsg-public")
+	genConfigCmd.Flags().StringVar(&dmsgServerConf, "dmsg-server-conf", scriptExecString("${DMSGSERVERCONF}"), "run the dmsg server from this standalone dmsg-server config file inside the visor (replaces a separate dmsg server unit)")
+	gHiddenFlags = append(gHiddenFlags, "dmsg-server-conf")
 
 	genConfigCmd.Flags().BoolVar(&isAll, "all", false, "show all flags")
 
@@ -1486,6 +1488,12 @@ func configureLauncher(log *logging.Logger) {
 		conf.Transport.Discovery = dmsgConf.TransportDiscovery
 		conf.Routing.RouteFinder = dmsgConf.RouteFinder
 		conf.Launcher.ServiceDisc = dmsgConf.ServiceDiscovery
+	}
+
+	// Fold a standalone dmsg server into this visor: DMSGSERVERCONF names the
+	// dmsg-server config file the separate unit used to run from.
+	if dmsgServerConf != "" {
+		conf.Dmsg.Server = &dmsgc.DmsgServerConfig{Enabled: true, ConfigPath: dmsgServerConf}
 	}
 
 	// Configure the skycoin-web wallet. Only emit a block when the operator

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -208,6 +208,7 @@ var (
 	// on whenever ISHYPERVISOR=true.
 	lanDmsgPort          int
 	lanDmsgPublicAddress string
+	dmsgServerConf       string
 )
 
 // RootCmd contains commands that interact with the config of local skywire-visor

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -158,6 +158,7 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	addInt("TRANSPORTPORT", "transport-port", autoconfigVals.TransportPort)
 	addInt("LANDMSGPORT", "lan-dmsg-port", autoconfigVals.LanDmsgPort)
 	addString("LANDMSGPUBLIC", "lan-dmsg-public", autoconfigVals.LanDmsgPublic)
+	addString("DMSGSERVERCONF", "dmsg-server-conf", autoconfigVals.DmsgServerConf)
 
 	// Whitelists
 	addArray("DMSGPTYPKS", "dmsgpty-pks", autoconfigVals.DmsgptyPks)

--- a/pkg/dmsg/dmsgc/dmsgc.go
+++ b/pkg/dmsg/dmsgc/dmsgc.go
@@ -31,6 +31,9 @@ type Deployment = spec.Deployment
 // spec.DmsgConfig for the type doc and the JSON-polymorphism notes.
 type DmsgConfig = spec.DmsgConfig
 
+// DmsgServerConfig is the in-process dmsg server block (Dmsg.Server).
+type DmsgServerConfig = spec.DmsgServerConfig
+
 // lanPriorityDisc wraps a disc.APIClient to prepend LAN server entries
 // to discovery results. LAN servers are tried first, with automatic
 // fallback to public servers if the LAN server is unreachable.

--- a/pkg/dmsg/dmsgc/spec/server_config_path_test.go
+++ b/pkg/dmsg/dmsgc/spec/server_config_path_test.go
@@ -1,0 +1,28 @@
+//go:build !js
+
+package spec
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The visor-wide `server` block rides the single-deployment object shape;
+// config_path must survive a marshal/unmarshal cycle like the other fields.
+func TestDmsgServerConfig_ConfigPathRoundTrip(t *testing.T) {
+	in := DmsgConfig{
+		Discovery: "dmsg://0208f9b6b6bd2fcf9c6ac1fa8a7bde5b5ad3a3e2d2f0f8a4d7e0c1b2a3d4e5f6a7:80",
+		Server:    &DmsgServerConfig{Enabled: true, ConfigPath: "/etc/skywire-dmsg.json"},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out DmsgConfig
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("%v\n%s", err, b)
+	}
+	if out.Server == nil || !out.Server.Enabled || out.Server.ConfigPath != in.Server.ConfigPath {
+		t.Fatalf("server block lost: %+v\n%s", out.Server, b)
+	}
+}

--- a/pkg/dmsg/dmsgc/spec/spec.go
+++ b/pkg/dmsg/dmsgc/spec/spec.go
@@ -138,6 +138,14 @@ type DmsgServerConfig struct {
 	// server's discovery entry. Empty = don't advertise a public address
 	// (the server is reachable only over whatever the listener resolves to).
 	PublicAddress string `json:"public_address,omitempty"`
+	// ConfigPath, when set, runs the full dmsg-server service (pkg/services/dmsgsrv)
+	// inside the visor process from that standalone dmsg-server config file
+	// — its own key, listen/public/wss addresses, health endpoint and
+	// max_sessions — instead of the bare server on the visor key above.
+	// LocalAddress and PublicAddress are ignored when it is set. This is
+	// how a host that ran `skywire dmsg server start <file>` as a separate
+	// unit folds that server into its visor (DMSGSERVERCONF in skywire.conf).
+	ConfigPath string `json:"config_path,omitempty"`
 }
 
 // MarshalJSON and UnmarshalJSON live in spec_native.go under

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -127,11 +127,12 @@ type Values struct {
 	MaxTransports int // MAXTRANSPORTS (pause service-discovery registration at this DISTINCT-PEER count)
 
 	// --- Transport ports ---
-	StcprPort     int
-	SudphPort     int
-	TransportPort int
-	LanDmsgPort   int
-	LanDmsgPublic string
+	StcprPort      int
+	SudphPort      int
+	TransportPort  int
+	LanDmsgPort    int
+	LanDmsgPublic  string
+	DmsgServerConf string
 
 	// --- Privacy / routing knobs ---
 	MinHops            int  // MINHOPS (>=2 forces multihop for sender privacy)
@@ -297,6 +298,7 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().BoolVar(&v.PtyRPCExec, "pty-rpc-exec", false, "allow visor-RPC-initiated dmsgpty exec (control/jump node opt-in; off closes a local privilege-escalation vector) — writes PTYRPCEXEC=true in skywire.conf")
 	cmd.Flags().IntVar(&v.LanDmsgPort, "lan-dmsg-port", 0, "LAN dmsg-server listening port (0 = leave unchanged) — writes LANDMSGPORT in skywire.conf")
 	cmd.Flags().StringVar(&v.LanDmsgPublic, "lan-dmsg-public", "", "public host:port for the LAN dmsg-server entry in dmsg discovery — writes LANDMSGPUBLIC in skywire.conf")
+	cmd.Flags().StringVar(&v.DmsgServerConf, "dmsg-server-conf", "", "standalone dmsg-server config file to run inside the visor instead of a separate unit — writes DMSGSERVERCONF in skywire.conf")
 
 	// --- Whitelists ---
 	cmd.Flags().StringVar(&v.DmsgptyPks, "dmsgpty-pks", "", "additional dmsgpty-whitelist PKs (hypervisor PKs are already implicit) — writes DMSGPTYPKS in skywire.conf")

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -38,6 +38,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgscp"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/pty"
+	"github.com/skycoin/skywire/pkg/services/dmsgsrv"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/util/osutil"
@@ -1049,6 +1050,12 @@ func initDmsgServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 	}
 	srvCfg := v.conf.Dmsg.Server
 
+	// A standalone dmsg-server config file: run the whole service in-process
+	// (own key, wss, health, route-setup surfaces) — nothing below applies.
+	if srvCfg.ConfigPath != "" {
+		return initDmsgServerFromFile(ctx, v, log, srvCfg.ConfigPath)
+	}
+
 	dmsgC := v.dmsgC
 	if dmsgC == nil {
 		return nil
@@ -1420,4 +1427,27 @@ func buildPtyAppFunc(v *Visor, host *pty.Host, dmsgPort uint16, sshAddr string) 
 		appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
 		return nil
 	}
+}
+
+// initDmsgServerFromFile runs the standalone dmsg-server service from its
+// config file inside the visor process. The service builds its own transit
+// dmsg client under the server's key, so it neither shares nor collides with
+// the visor's client; it is stopped through the close stack.
+func initDmsgServerFromFile(_ context.Context, v *Visor, log *logging.Logger, path string) error {
+	svc := dmsgsrv.New(&dmsgsrv.Config{ConfigPath: path}, log)
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := svc.Run(runCtx); err != nil && !errors.Is(err, context.Canceled) {
+			log.WithError(err).Error("in-process dmsg server (config file) stopped")
+		}
+	}()
+	log.WithField("config_path", path).Info("Started in-process dmsg server from config file")
+	v.pushCloseStack("dmsg_server", func() error {
+		cancel()
+		<-done
+		return nil
+	})
+	return nil
 }


### PR DESCRIPTION
The in-process dmsg server so far was a bare `dmsg.NewServer` on the visor key: no wss, no health endpoint, default max_sessions. The deployment's 1 GB hosts run the visor and a separate `skywire dmsg server start /etc/skywire-dmsg.json` unit, two Go processes fighting for memory.

`dmsg.server.config_path` now runs the full dmsg-server service (`pkg/services/dmsgsrv`, the same code the standalone command uses) inside the visor from that file, keeping the server's key, ports, wss domain and health endpoint. `DMSGSERVERCONF='/etc/skywire-dmsg.json'` in skywire.conf drives it through autoconfig; the template documents stopping the separate unit and dropping it from RESTART_SERVICES.

Round-trip test for the new field; root and js/wasm builds pass. First live cutover will be one nanode at a time.