### PR TITLE
feat(visor): attached visors' transports as a local route graph on the hypervisor

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -124,11 +124,16 @@ type Config struct {
 	SecKey           cipher.SecKey
 	TransportManager *transport.Manager
 	RouteFinder      rfclient.Client
-	RouteGroupDialer RouteGroupDialer
-	SetupNodes       []cipher.PubKey
-	RulesGCInterval  time.Duration
-	MinHops          uint16
-	MaxHops          uint16
+	// PreferLocalRouteTo, when set and true for dst, tries the local route
+	// calculation (this visor's transports plus the transport-discovery
+	// snapshot, which includes any local graph source) before the route
+	// finder is asked. A hypervisor sets it for its attached visors.
+	PreferLocalRouteTo func(dst cipher.PubKey) bool
+	RouteGroupDialer   RouteGroupDialer
+	SetupNodes         []cipher.PubKey
+	RulesGCInterval    time.Duration
+	MinHops            uint16
+	MaxHops            uint16
 	// ExcludeTransportTypes hard-excludes routes traversing any of these transport
 	// types from the candidate set (see visorconfig.Routing.RouteExcludeTransportTypes).
 	// Empty = nothing excluded. Lowercased type names.

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -1180,6 +1180,18 @@ fetchRoutesAgain:
 	fwdNum := findRouteNum(opts.EffectiveMuxRoutes(true))
 	revNum := findRouteNum(opts.EffectiveMuxRoutes(false))
 
+	// A destination this visor already holds a graph for (a hypervisor's
+	// attached visors) is routed locally first; the route finder is asked
+	// only when that yields nothing.
+	if r.conf.PreferLocalRouteTo != nil && r.conf.PreferLocalRouteTo(dst) {
+		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, src, dst, opts)
+		if localErr == nil {
+			log.Infof("Local route from attached graph: Forward=%v, Reverse=%v", localFwd, localRev)
+			return localFwd, localRev, nil
+		}
+		log.WithError(localErr).Debug("Attached-graph local route failed; asking the route finder")
+	}
+
 	var paths map[routing.PathEdges][][]routing.Hop
 	if fwdMinHops == revMinHops {
 		// Common path: single query covers both directions. One count

--- a/pkg/visor/cxo_transport_discovery.go
+++ b/pkg/visor/cxo_transport_discovery.go
@@ -49,7 +49,7 @@ type cxoAwareTPD struct {
 // of re-tearing-down between dials. JSON unmarshal of the snapshot
 // is the same code the HTTP path runs; cost is negligible compared
 // to a DMSG-HTTP round-trip.
-func (c *cxoAwareTPD) GetAllTransports(ctx context.Context) ([]*transport.Entry, error) {
+func (c *cxoAwareTPD) getAllTransportsBase(ctx context.Context) ([]*transport.Entry, error) {
 	if c.v != nil {
 		if mgr := c.v.CXOSubMgr(); mgr != nil {
 			mgr.AcquireFor(TabCLITransports)
@@ -84,7 +84,7 @@ func (c *cxoAwareTPD) GetAllTransports(ctx context.Context) ([]*transport.Entry,
 // CXO sync cadence instead of an independent wall-clock TTL. ok=false
 // (feed not yet primed / CXO unavailable) tells the caller to keep its
 // TTL fallback. Copies no body — a cheap version probe.
-func (c *cxoAwareTPD) AllTransportsSyncedAt() (time.Time, bool) {
+func (c *cxoAwareTPD) allTransportsSyncedAtCXO() (time.Time, bool) {
 	if c.v == nil {
 		return time.Time{}, false
 	}
@@ -103,4 +103,30 @@ func wrapDiscoveryClientWithCXO(dc transport.DiscoveryClient, v *Visor) transpor
 		return dc
 	}
 	return &cxoAwareTPD{DiscoveryClient: dc, v: v}
+}
+
+// GetAllTransports is the CXO-or-HTTP network view (getAllTransportsBase)
+// plus the visor's local graph source, deduplicated by transport ID with the
+// network view preferred. The merge is what lets route calculation and the
+// router's local BFS see a hypervisor's attached visors without a TPD query.
+func (c *cxoAwareTPD) GetAllTransports(ctx context.Context) ([]*transport.Entry, error) {
+	entries, err := c.getAllTransportsBase(ctx)
+	if err != nil {
+		return entries, err
+	}
+	local, _ := c.v.localGraphEntries()
+	return mergeTransportEntries(entries, local), nil
+}
+
+// AllTransportsSyncedAt is the CXO sync time with the local graph's
+// version folded in: the later of the two, so a change on either side
+// advances it. Only reported when the CXO side is primed — without that the
+// TTL fallback must keep refetching the network view.
+func (c *cxoAwareTPD) AllTransportsSyncedAt() (time.Time, bool) {
+	ts, ok := c.allTransportsSyncedAtCXO()
+	if !ok {
+		return time.Time{}, false
+	}
+	_, localAt := c.v.localGraphEntries()
+	return laterTime(ts, localAt), true
 }

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -86,6 +86,13 @@ type Hypervisor struct {
 	uiServing      bool      // web UI (HTTP) server active — independent of `enabled`
 	tpvizStartOnce sync.Once // tpviz is start-once (its Stop closes a chan that can't be reopened)
 	enableMu       sync.Mutex
+
+	// attachedGraph* version the attached-visor transport graph
+	// (hypervisor_attached_graph.go): the hash of the last ID set and
+	// when it last changed.
+	attachedGraphMu   sync.Mutex
+	attachedGraphHash [32]byte
+	attachedGraphAt   time.Time
 }
 
 // cachedSummary is one entry in Hypervisor.summaryCache.
@@ -406,6 +413,11 @@ func (hv *Hypervisor) ServeRPC(ctx context.Context, dmsgPort uint16) error {
 	// redial+re-accept needlessly. It's slower than typical UI
 	// poll cadence so we don't double-fire when both are active
 	// (UI polls overlap-and-skip via summary's own goroutine).
+	// The attached visors' transports become a local graph source for this
+	// visor's route calculation (#4750).
+	if hv.visor != nil {
+		hv.visor.SetLocalGraphSource(hv.AttachedTransportEntries)
+	}
 	go hv.runBackgroundSummaryPoll(ctx)
 
 	// setup local PTY using direct connection (bypasses DMSG for local visor)

--- a/pkg/visor/hypervisor_attached_graph.go
+++ b/pkg/visor/hypervisor_attached_graph.go
@@ -1,0 +1,97 @@
+// Package visor pkg/visor/hypervisor_attached_graph.go c3-vis-api
+//
+// The hypervisor's attached visors report their transports in the Summary it
+// polls every hypervisorBackgroundPollInterval. AttachedTransportEntries turns
+// that cache into transport entries, so route calculation on the hypervisor's
+// own visor can use those edges without a TPD or route-finder query (#4750).
+package visor
+
+import (
+	"crypto/sha256"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// attachedGraphStaleAfter drops a visor whose last summary is older than two
+// poll rounds: it is offline or its RPC conn is being redialed, and its
+// transports may be gone.
+const attachedGraphStaleAfter = 2 * hypervisorBackgroundPollInterval
+
+// AttachedTransportEntries is the hypervisor's LocalGraphSource: the
+// transports of every attached visor seen within attachedGraphStaleAfter,
+// setup transports excluded, deduplicated by ID (both ends of an edge between
+// two attached visors report it). The returned time advances only when the
+// set of IDs changes.
+func (hv *Hypervisor) AttachedTransportEntries() ([]*transport.Entry, time.Time) {
+	hv.summaryCacheMx.RLock()
+	cache := make(map[cipher.PubKey]cachedSummary, len(hv.summaryCache))
+	for pk, cs := range hv.summaryCache {
+		cache[pk] = cs
+	}
+	hv.summaryCacheMx.RUnlock()
+
+	entries, sum := attachedEntriesFromSummaries(cache, time.Now())
+
+	hv.attachedGraphMu.Lock()
+	if sum != hv.attachedGraphHash {
+		hv.attachedGraphHash = sum
+		hv.attachedGraphAt = time.Now()
+	}
+	at := hv.attachedGraphAt
+	hv.attachedGraphMu.Unlock()
+	return entries, at
+}
+
+// attachedEntriesFromSummaries builds the entries from a summary cache
+// snapshot and returns them sorted by ID with a hash of the ID set.
+func attachedEntriesFromSummaries(cache map[cipher.PubKey]cachedSummary, now time.Time) ([]*transport.Entry, [32]byte) {
+	byID := make(map[uuid.UUID]*transport.Entry)
+	for _, cs := range cache {
+		if cs.sum == nil || cs.sum.Overview == nil || now.Sub(cs.seenAt) > attachedGraphStaleAfter {
+			continue
+		}
+		for _, ts := range cs.sum.Overview.Transports {
+			if ts == nil || ts.IsSetup || ts.Remote == (cipher.PubKey{}) || ts.Local == (cipher.PubKey{}) {
+				continue
+			}
+			id := ts.ID
+			if id == (uuid.UUID{}) {
+				id = transport.MakeTransportID(ts.Local, ts.Remote, ts.Type)
+			}
+			if have, ok := byID[id]; ok {
+				// The other end already reported it; keep the better metric.
+				if have.Latency == 0 && ts.LatencyMS > 0 {
+					have.Latency = ts.LatencyMS
+				}
+				if ts.ThroughputBps > have.ThroughputBps {
+					have.ThroughputBps = ts.ThroughputBps
+				}
+				continue
+			}
+			e := transport.MakeEntry(ts.Local, ts.Remote, ts.Type, ts.Label)
+			e.ID = id
+			e.Latency = ts.LatencyMS
+			e.ThroughputBps = ts.ThroughputBps
+			byID[id] = &e
+		}
+	}
+	entries := make([]*transport.Entry, 0, len(byID))
+	for _, e := range byID {
+		entries = append(entries, e)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].ID.String() < entries[j].ID.String()
+	})
+	h := sha256.New()
+	for _, e := range entries {
+		h.Write(e.ID[:])
+	}
+	var sum [32]byte
+	copy(sum[:], h.Sum(nil))
+	return entries, sum
+}

--- a/pkg/visor/hypervisor_attached_graph_test.go
+++ b/pkg/visor/hypervisor_attached_graph_test.go
@@ -1,0 +1,133 @@
+// Package visor pkg/visor/hypervisor_attached_graph_test.go c3-vis-api
+package visor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+func summaryWith(tps ...*TransportSummary) *Summary {
+	return &Summary{Overview: &Overview{Transports: tps}}
+}
+
+func TestAttachedEntriesFromSummaries(t *testing.T) {
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	c, _ := cipher.GenerateKeyPair()
+	d, _ := cipher.GenerateKeyPair()
+	rsn, _ := cipher.GenerateKeyPair()
+	now := time.Now()
+	abID := transport.MakeTransportID(a, b, tptypes.STCPR)
+
+	cache := map[cipher.PubKey]cachedSummary{
+		a: {seenAt: now, sum: summaryWith(
+			&TransportSummary{ID: abID, Local: a, Remote: b, Type: tptypes.STCPR, LatencyMS: 12},
+			&TransportSummary{Local: a, Remote: c, Type: tptypes.SUDPH}, // zero ID: derived
+			&TransportSummary{Local: a, Remote: rsn, Type: tptypes.DMSG, IsSetup: true},
+		)},
+		b: {seenAt: now.Add(-time.Second), sum: summaryWith(
+			&TransportSummary{ID: abID, Local: b, Remote: a, Type: tptypes.STCPR, ThroughputBps: 5000}, // other end
+		)},
+		d: {seenAt: now.Add(-attachedGraphStaleAfter - time.Second), sum: summaryWith(
+			&TransportSummary{Local: d, Remote: c, Type: tptypes.STCPR},
+		)},
+	}
+
+	entries, sum := attachedEntriesFromSummaries(cache, now)
+	if len(entries) != 2 {
+		t.Fatalf("want 2 entries (a-b, a-c), got %d", len(entries))
+	}
+	var ab *transport.Entry
+	for _, e := range entries {
+		if e.ID == abID {
+			ab = e
+		}
+		if e.Label == transport.LabelSetup || e.Edges[0] == rsn || e.Edges[1] == rsn {
+			t.Fatalf("setup transport leaked: %+v", e)
+		}
+		if e.Edges[0] == d || e.Edges[1] == d {
+			t.Fatalf("stale visor leaked: %+v", e)
+		}
+	}
+	if ab == nil {
+		t.Fatal("a-b entry missing")
+	}
+	if ab.Latency != 12 || ab.ThroughputBps != 5000 {
+		t.Fatalf("metrics not merged across both ends: %+v", ab)
+	}
+
+	// Same set, different order/metrics → same hash; a new edge → new hash.
+	_, sum2 := attachedEntriesFromSummaries(cache, now)
+	if sum != sum2 {
+		t.Fatal("hash not stable for an unchanged set")
+	}
+	cache[b] = cachedSummary{seenAt: now, sum: summaryWith(
+		&TransportSummary{ID: abID, Local: b, Remote: a, Type: tptypes.STCPR},
+		&TransportSummary{Local: b, Remote: c, Type: tptypes.STCPR},
+	)}
+	_, sum3 := attachedEntriesFromSummaries(cache, now)
+	if sum == sum3 {
+		t.Fatal("hash unchanged after a new edge")
+	}
+}
+
+type fakeAllTransports struct {
+	transport.DiscoveryClient
+	entries []*transport.Entry
+}
+
+func (f fakeAllTransports) GetAllTransports(context.Context) ([]*transport.Entry, error) {
+	return f.entries, nil
+}
+
+func TestCXOAwareTPD_MergesLocalGraph(t *testing.T) {
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	c, _ := cipher.GenerateKeyPair()
+	shared := transport.MakeEntry(a, b, tptypes.STCPR, transport.LabelUser)
+	shared.Latency = 7
+	localOnly := transport.MakeEntry(b, c, tptypes.SUDPH, transport.LabelUser)
+	localDup := transport.MakeEntry(a, b, tptypes.STCPR, transport.LabelUser) // same ID as shared
+
+	v := &Visor{initLock: new(sync.RWMutex)}
+	at := time.Now()
+	v.SetLocalGraphSource(func() ([]*transport.Entry, time.Time) {
+		return []*transport.Entry{&localDup, &localOnly}, at
+	})
+	dc := &cxoAwareTPD{DiscoveryClient: fakeAllTransports{entries: []*transport.Entry{&shared}}, v: v}
+
+	got, err := dc.GetAllTransports(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 (shared + local-only), got %d", len(got))
+	}
+	if got[0].ID != shared.ID || got[0].Latency != 7 {
+		t.Fatalf("network view must win on a duplicate: %+v", got[0])
+	}
+	if got[1].ID != localOnly.ID {
+		t.Fatalf("local-only entry missing: %+v", got[1])
+	}
+	if !v.localGraphHasPeer(c) || v.localGraphHasPeer(cipher.PubKey{}) {
+		t.Fatal("localGraphHasPeer wrong")
+	}
+	// No CXO feed primed → no version, whatever the local graph says.
+	if _, ok := dc.AllTransportsSyncedAt(); ok {
+		t.Fatal("version must stay unreported without a primed CXO feed")
+	}
+	v.SetLocalGraphSource(nil)
+	got, _ = dc.GetAllTransports(context.Background())
+	if len(got) != 1 {
+		t.Fatalf("source removed but %d entries", len(got))
+	}
+	_ = uuid.Nil
+}

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -306,6 +306,7 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 		SecKey:                v.conf.SK,
 		TransportManager:      v.tpM,
 		RouteFinder:           rfClient,
+		PreferLocalRouteTo:    v.localGraphHasPeer,
 		RouteGroupDialer:      rgDialer,
 		SetupNodes:            v.conf.EffectiveRouteSetupNodes(),
 		MinHops:               v.conf.Routing.MinHops,

--- a/pkg/visor/local_graph.go
+++ b/pkg/visor/local_graph.go
@@ -1,0 +1,92 @@
+// Package visor pkg/visor/local_graph.go c3-vis-core
+//
+// A local graph source is a set of transport entries this visor knows about
+// beyond its own transport manager and the network-wide TPD snapshot. Today
+// the one source is a hypervisor's view of its attached visors
+// (Hypervisor.AttachedTransportEntries, #4750): every attached visor reports
+// its transports in the summary the hypervisor already polls, so route
+// calculation can use those edges without a TPD or route-finder query.
+package visor
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// LocalGraphSource returns transport entries and a version: a time that
+// advances only when the returned set changes, so a cache keyed on it
+// rebuilds exactly then and not otherwise.
+type LocalGraphSource func() ([]*transport.Entry, time.Time)
+
+// SetLocalGraphSource installs (or with nil, removes) the local graph source.
+func (v *Visor) SetLocalGraphSource(src LocalGraphSource) {
+	v.localGraphMu.Lock()
+	v.localGraph = src
+	v.localGraphMu.Unlock()
+}
+
+// localGraphEntries returns the source's entries and version, or nil and a
+// zero time when no source is installed.
+func (v *Visor) localGraphEntries() ([]*transport.Entry, time.Time) {
+	if v == nil {
+		return nil, time.Time{}
+	}
+	v.localGraphMu.RLock()
+	src := v.localGraph
+	v.localGraphMu.RUnlock()
+	if src == nil {
+		return nil, time.Time{}
+	}
+	return src()
+}
+
+// localGraphHasPeer reports whether pk is an edge of any local-graph entry —
+// the router's cue to try a local route before asking the route finder.
+func (v *Visor) localGraphHasPeer(pk cipher.PubKey) bool {
+	entries, _ := v.localGraphEntries()
+	for _, e := range entries {
+		if e != nil && (e.Edges[0] == pk || e.Edges[1] == pk) {
+			return true
+		}
+	}
+	return false
+}
+
+// mergeTransportEntries appends the extra entries whose IDs are not already
+// in base. Base wins on a duplicate: the TPD view carries label and QoS
+// metadata a local view may lack.
+func mergeTransportEntries(base, extra []*transport.Entry) []*transport.Entry {
+	if len(extra) == 0 {
+		return base
+	}
+	seen := make(map[uuid.UUID]struct{}, len(base))
+	for _, e := range base {
+		if e != nil {
+			seen[e.ID] = struct{}{}
+		}
+	}
+	out := base
+	for _, e := range extra {
+		if e == nil {
+			continue
+		}
+		if _, dup := seen[e.ID]; dup {
+			continue
+		}
+		seen[e.ID] = struct{}{}
+		out = append(out, e)
+	}
+	return out
+}
+
+// laterTime returns the later of a and b.
+func laterTime(a, b time.Time) time.Time {
+	if b.After(a) {
+		return b
+	}
+	return a
+}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -139,10 +139,15 @@ type Visor struct {
 	// STUN client state
 	stun stunState
 
-	tpM      *transport.Manager
-	arClient addrresolver.APIClient
-	router   router.Router
-	rfClient rfclient.Client
+	tpM *transport.Manager
+
+	// localGraph is an extra transport-graph source merged into every
+	// GetAllTransports answer (see local_graph.go).
+	localGraphMu sync.RWMutex
+	localGraph   LocalGraphSource
+	arClient     addrresolver.APIClient
+	router       router.Router
+	rfClient     rfclient.Client
 
 	procM       appserver.ProcManager // proc manager
 	appL        *launcher.AppLauncher // app launcher

--- a/pkg/visor/visorcore/router.go
+++ b/pkg/visor/visorcore/router.go
@@ -25,11 +25,14 @@ import (
 // Zero values for the optional native-only fields (AppLookup, DialHook,
 // RulesGCInterval, SetupHooks) are correct for a browser edge.
 type RouterDeps struct {
-	DmsgC                 *dmsg.Client
-	PubKey                cipher.PubKey
-	SecKey                cipher.SecKey
-	TransportManager      *transport.Manager
-	RouteFinder           rfclient.Client
+	DmsgC            *dmsg.Client
+	PubKey           cipher.PubKey
+	SecKey           cipher.SecKey
+	TransportManager *transport.Manager
+	RouteFinder      rfclient.Client
+	// PreferLocalRouteTo is router.Config.PreferLocalRouteTo: try a local
+	// route to dst before the route finder (a hypervisor's attached visors).
+	PreferLocalRouteTo    func(dst cipher.PubKey) bool
 	RouteGroupDialer      router.RouteGroupDialer
 	SetupNodes            []cipher.PubKey
 	MinHops               uint16
@@ -77,6 +80,7 @@ func BuildRouter(serveCtx context.Context, deps RouterDeps) (router.Router, erro
 		SecKey:                deps.SecKey,
 		TransportManager:      deps.TransportManager,
 		RouteFinder:           deps.RouteFinder,
+		PreferLocalRouteTo:    deps.PreferLocalRouteTo,
 		RouteGroupDialer:      deps.RouteGroupDialer,
 		SetupNodes:            deps.SetupNodes,
 		MinHops:               deps.MinHops,


### PR DESCRIPTION
Phase 1 of #4750. The hypervisor already polls every attached visor's summary every 30 s, and that summary carries each transport with ID, endpoints, type, label, latency and throughput. Nothing read it as a graph.

- `Hypervisor.AttachedTransportEntries` builds entries from the summary cache (visors unseen for two polls and setup transports skipped, both ends of a shared edge deduplicated with merged metrics) and versions the set by an ID hash.
- The visor gets a `LocalGraphSource`; the CXO-aware transport discovery merges it into every `GetAllTransports` answer and folds its version into the snapshot version, so route calc, the HV routing tools and the router's local BFS all see attached edges, and the router's cache rebuilds only when the set changes.
- `router.Config.PreferLocalRouteTo`: when the destination is in the local graph, the local route calculation runs before the route finder is asked; every fallback is unchanged.

Unit tests for the summary-to-entries conversion, the merge and the version gating. Root and js/wasm builds pass.