### PR TITLE
feat(hypervisor): opt-in legacy Angular UI at the web UI root

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -101,6 +101,11 @@ const envfileLinux = `#
 #--	Start the hypervisor interface for this visor
 #ISHYPERVISOR=true
 
+#--	Serve the legacy Angular dashboard at the hypervisor web UI root instead
+#	of the desk (no wasm visor in the page). Default false = the desk.
+#	Runtime: skywire cli visor hv enable --legacy[=false] -w
+#LEGACYHVUI=true
+
 #--	Hypervisor web-UI listen address (host:port). Default ':8000' = all
 #	interfaces (reachable on the LAN at http://<this-host-ip>:8000).
 #	Use '127.0.0.1:8000' to restrict the UI to localhost, or pin a

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -250,6 +250,8 @@ func init() {
 
 	// Hypervisor and security flags
 	genConfigCmd.Flags().BoolVarP(&isHypervisor, "ishv", "i", scriptExecBool("${ISHYPERVISOR:-false}"), "local hypervisor configuration")
+	genConfigCmd.Flags().BoolVar(&isLegacyHVUI, "legacy-hv-ui", scriptExecBool("${LEGACYHVUI:-false}"), "serve the legacy Angular dashboard at the hypervisor web UI root instead of the desk")
+	gHiddenFlags = append(gHiddenFlags, "legacy-hv-ui")
 	msg = "list of public keys to add as hypervisor"
 	if scriptExecArray("${HYPERVISORPKS[@]}") != "" {
 		msg += "\n\r"
@@ -1609,6 +1611,7 @@ func configureHypervisor(log *logging.Logger) {
 	{
 		config := visorconfig.GenerateWorkDirConfig(isTestEnv)
 		config.Enable = isHypervisor
+		config.LegacyUI = isLegacyHVUI
 		config.EnablePKEndpoint = isEnablePKEndpoint
 		if hvHTTPAddr != "" {
 			config.HTTPAddr = hvHTTPAddr

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -45,6 +45,7 @@ var (
 	isPkgEnv                   bool
 	isUsrEnv                   bool
 	isHypervisor               bool
+	isLegacyHVUI               bool
 	hypervisorPKs              string
 	dmsgptyWlPKs               string
 	surveyWhitelistPKs         string

--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -28,6 +28,7 @@ func init() {
 	hvCmd.AddCommand(hvuiCmd)
 	hvuiCmd.AddCommand(hvUIEnableCmd)
 	hvUIEnableCmd.Flags().BoolVarP(&hvPersist, "persist", "w", false, "write change to config file")
+	hvUIEnableCmd.Flags().BoolVar(&hvLegacy, "legacy", false, "serve the legacy Angular dashboard at the web UI root instead of the desk (--legacy=false switches back); with -w also persists hypervisor.legacy_ui")
 	hvuiCmd.AddCommand(hvUIDisableCmd)
 	hvUIDisableCmd.Flags().BoolVarP(&hvPersist, "persist", "w", false, "write change to config file")
 	hvCmd.AddCommand(hvpkCmd)
@@ -36,6 +37,7 @@ func init() {
 	hvCmd.AddCommand(chvpkCmd)
 	hvCmd.AddCommand(hvEnableCmd)
 	hvEnableCmd.Flags().BoolVarP(&hvPersist, "persist", "w", false, "write change to config file")
+	hvEnableCmd.Flags().BoolVar(&hvLegacy, "legacy", false, "serve the legacy Angular dashboard at the web UI root instead of the desk (--legacy=false switches back); with -w also persists hypervisor.legacy_ui")
 	hvCmd.AddCommand(hvDisableCmd)
 	hvDisableCmd.Flags().BoolVarP(&hvPersist, "persist", "w", false, "write change to config file")
 	hvCmd.AddCommand(hvStatusCmd)
@@ -59,6 +61,7 @@ var (
 	hvPasswdForce bool
 	hvLsFlat      bool
 	hvLsLoad      bool
+	hvLegacy      bool
 )
 
 var hvCmd = &cobra.Command{
@@ -160,6 +163,7 @@ var hvUIEnableCmd = &cobra.Command{
 		if err := rpcClient.EnableHypervisorUIPersist(hvPersist); err != nil {
 			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
+		applyHVLegacyFlag(cmd, rpcClient)
 		if hvPersist {
 			internal.PrintOutput(cmd.Flags(), "Hypervisor web UI enabled (written to config)\n", "Hypervisor web UI enabled (written to config)\n")
 		} else {
@@ -200,6 +204,7 @@ var hvEnableCmd = &cobra.Command{
 		if err := rpcClient.EnableHypervisorPersist(hvPersist); err != nil {
 			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
+		applyHVLegacyFlag(cmd, rpcClient)
 		if hvPersist {
 			internal.PrintOutput(cmd.Flags(), "Hypervisor enabled (written to config)\n", "Hypervisor enabled (written to config)\n")
 		} else {
@@ -612,4 +617,21 @@ outstanding one. Fingerprint = first 40 bits of sha256(pk).`,
 			internal.PrintOutput(cmd.Flags(), pending, b.String())
 		}
 	},
+}
+
+// applyHVLegacyFlag switches the web UI root when --legacy was given
+// explicitly (either value); an absent flag leaves the current mode alone.
+func applyHVLegacyFlag(cmd *cobra.Command, rpcClient visor.API) {
+	if !cmd.Flags().Changed("legacy") {
+		return
+	}
+	if err := rpcClient.SetHypervisorLegacyUIPersist(hvLegacy, hvPersist); err != nil {
+		internal.PrintFatalRPCError(cmd.Flags(), err)
+	}
+	mode := "desk"
+	if hvLegacy {
+		mode = "legacy dashboard"
+	}
+	msg := "Hypervisor web UI root: " + mode + "\n"
+	internal.PrintOutput(cmd.Flags(), msg, msg)
 }

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -129,6 +129,7 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	addArray("HYPERVISORPKS", "hvpks", autoconfigVals.Hvpks)
 	addArray("WSPEERS", "ws-peer", autoconfigVals.WSPeers)
 	addBool("ISHYPERVISOR", "ishv", "no-ishv", autoconfigVals.Ishv, autoconfigVals.NoIshv)
+	addBool("LEGACYHVUI", "legacy-hv-ui", "no-legacy-hv-ui", autoconfigVals.LegacyHVUI, autoconfigVals.NoLegacyHVUI)
 	addBool("ENABLEPKENDPOINT", "pk-endpoint", "no-pk-endpoint", autoconfigVals.PkEndpoint, autoconfigVals.NoPkEndpoint)
 	addString("HVHTTPADDR", "hvaddr", autoconfigVals.HvAddr)
 	addString("SK", "sk", autoconfigVals.SecretKey)

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -58,6 +58,12 @@ Approval is written to the visor config and, on a package install, mirrored
 into `HYPERVISORPKS` in `/etc/skywire.conf`, so it survives the next
 `skywire autoconfig` run (every package update performs one).
 
+The desk is the default hypervisor UI. To serve the legacy Angular dashboard
+at the root instead, with no desk and no wasm visor in the page, set
+`LEGACYHVUI=true` in `/etc/skywire.conf` (or `config gen --legacy-hv-ui`),
+or switch a running hypervisor with `skywire cli visor hv enable --legacy -w`
+(`--legacy=false` switches back). The change applies on the next page load.
+
 ## Hypervisor terminal UI
 
 A terminal-based hypervisor that mirrors the web UI's read and write actions

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -103,6 +103,8 @@ type Values struct {
 	WSPeers      string // WSPEERS: <pk>@<ws(s)://…> peers held as WebSocket transports
 	Ishv         bool
 	NoIshv       bool
+	LegacyHVUI   bool
+	NoLegacyHVUI bool
 	PkEndpoint   bool // ENABLEPKENDPOINT
 	NoPkEndpoint bool
 	HvAddr       string // HVHTTPADDR
@@ -267,6 +269,8 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().StringVar(&v.WSPeers, "ws-peer", "", "peers held as WebSocket transports, <pk>@<ws(s)://host[:port]/path>, comma-separated — writes WSPEERS in skywire.conf")
 	cmd.Flags().BoolVar(&v.Ishv, "ishv", false, "enable local hypervisor — writes ISHYPERVISOR=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoIshv, "no-ishv", false, "disable local hypervisor — writes ISHYPERVISOR=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.LegacyHVUI, "legacy-hv-ui", false, "serve the legacy Angular dashboard at the hypervisor web UI root instead of the desk — writes LEGACYHVUI=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoLegacyHVUI, "no-legacy-hv-ui", false, "serve the desk at the hypervisor web UI root (default) — writes LEGACYHVUI=false in skywire.conf")
 	cmd.Flags().BoolVar(&v.PkEndpoint, "pk-endpoint", false, "expose unauthenticated GET /api/pk on the hypervisor — writes ENABLEPKENDPOINT=true in skywire.conf (skybian / Arch-ARM image builds set this)")
 	cmd.Flags().BoolVar(&v.NoPkEndpoint, "no-pk-endpoint", false, "do not expose GET /api/pk — writes ENABLEPKENDPOINT=false in skywire.conf")
 	cmd.Flags().StringVar(&v.HvAddr, "hvaddr", "", "hypervisor HTTP address (host:port) — writes HVHTTPADDR in skywire.conf")

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -43,6 +43,9 @@ type API interface {
 	DisableHypervisorPersist(persist bool) error
 	IsHypervisorEnabled() bool
 	EnableHypervisorUIPersist(persist bool) error
+	// SetHypervisorLegacyUIPersist serves the legacy Angular dashboard (true) or
+	// the desk (false) at the web UI root; persist writes hypervisor.legacy_ui.
+	SetHypervisorLegacyUIPersist(legacy, persist bool) error
 	DisableHypervisorUIPersist(persist bool) error
 	IsHypervisorUIServing() bool
 	DmsgPortHits() []dmsg.PortHit

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -595,3 +595,22 @@ func (v *Visor) RuntimeLogsSince(since int64) (RuntimeLogsDelta, error) {
 		Dropped: dropped,
 	}, nil
 }
+
+// SetHypervisorLegacyUIPersist implements API. Switches the hypervisor web UI
+// root between the desk and the legacy Angular dashboard, optionally
+// persisting hypervisor.legacy_ui to the config.
+func (v *Visor) SetHypervisorLegacyUIPersist(legacy, persist bool) error {
+	if v.hvInstance == nil {
+		return v.hvNotReadyErr()
+	}
+	v.hvInstance.SetLegacyUI(legacy)
+	if !persist {
+		return nil
+	}
+	if v.conf.Hypervisor == nil {
+		config := visorconfig.DefaultHypervisorConfig()
+		v.conf.Hypervisor = &config
+	}
+	v.conf.Hypervisor.LegacyUI = legacy
+	return v.conf.Flush()
+}

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -1401,3 +1401,20 @@ func setupLocalPtyUI(cliNet, cliAddr string) *dmsgPtyUI {
 		PtyUI: pty.NewUI(ptyDialer, pty.DefaultUIConfig()),
 	}
 }
+
+// LegacyUI reports whether the web UI root serves the legacy Angular
+// dashboard instead of the desk.
+func (hv *Hypervisor) LegacyUI() bool {
+	hv.enableMu.Lock()
+	defer hv.enableMu.Unlock()
+	return hv.c.LegacyUI
+}
+
+// SetLegacyUI switches the web UI root between the desk (false) and the
+// legacy Angular dashboard (true). Takes effect on the next page load; the
+// UI server keeps running.
+func (hv *Hypervisor) SetLegacyUI(legacy bool) {
+	hv.enableMu.Lock()
+	hv.c.LegacyUI = legacy
+	hv.enableMu.Unlock()
+}

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -181,6 +181,12 @@ func (hv *Hypervisor) uiHandler() http.Handler {
 			// The DESK is the hypervisor UI (operator decision 2026-09-04): the
 			// shell greets at the root with the Angular dashboard as a tab
 			// inside it, matching the wasm visor's desk surface.
+			if hv.LegacyUI() {
+				// Opt-in legacy mode: the Angular dashboard is the page, no desk
+				// and no wasm visor (hypervisor.legacy_ui / LEGACYHVUI).
+				hv.serveInjectedIndex(w, r, fileServer)
+				return
+			}
 			hv.serveNativeDesk(w)
 			return
 		case "/desk":

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -1269,3 +1269,7 @@ func (proxyDefaultAPI) HVUpdateForwardedPort(_ cipher.PubKey, _ ForwardedPort) e
 func (proxyDefaultAPI) Close() error {
 	return ErrProxyNotSupported
 }
+
+func (proxyDefaultAPI) SetHypervisorLegacyUIPersist(_, _ bool) error {
+	return ErrProxyNotSupported
+}

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -2439,3 +2439,8 @@ func (rc *rpcClient) ARSelfInfo() (*ARSelfRegistration, error) {
 	}
 	return &resp, nil
 }
+
+// SetHypervisorLegacyUIPersist serves the legacy dashboard (true) or the desk (false) at the web UI root.
+func (rc *rpcClient) SetHypervisorLegacyUIPersist(legacy, persist bool) error {
+	return rc.Call("SetHypervisorLegacyUI", &SetHypervisorLegacyUIIn{Legacy: legacy, Persist: persist}, &struct{}{})
+}

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1819,3 +1819,6 @@ func (mc *mockRPCClient) ARSelfInfo() (*ARSelfRegistration, error) {
 func (mc *mockRPCClient) Close() error {
 	return nil
 }
+
+// SetHypervisorLegacyUIPersist implements API
+func (mc *mockRPCClient) SetHypervisorLegacyUIPersist(_, _ bool) error { return nil }

--- a/pkg/visor/rpc_visor.go
+++ b/pkg/visor/rpc_visor.go
@@ -518,3 +518,19 @@ func (r *RPC) UIServerStatus(_ *struct{}, out *UIServerStatus) (err error) {
 	*out = *status
 	return nil
 }
+
+// SetHypervisorLegacyUIIn is the input for SetHypervisorLegacyUI.
+type SetHypervisorLegacyUIIn struct {
+	Legacy  bool
+	Persist bool
+}
+
+// SetHypervisorLegacyUI switches the hypervisor web UI root between the desk
+// and the legacy Angular dashboard.
+func (r *RPC) SetHypervisorLegacyUI(in *SetHypervisorLegacyUIIn, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "SetHypervisorLegacyUI", in)(nil, &err)
+	if in == nil {
+		in = &SetHypervisorLegacyUIIn{}
+	}
+	return r.visor.SetHypervisorLegacyUIPersist(in.Legacy, in.Persist)
+}

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -66,7 +66,13 @@ type HypervisorConfig struct {
 	// hypervisor's DMSG-RPC listener + managed-visor tracking (and `hv ls` over
 	// the visor RPC) stay active. Toggled at runtime with `hv ui enable/disable`.
 	// Default false (UI served) — backward-compatible with configs that omit it.
-	UIDisable  bool          `json:"ui_disable,omitempty"`
+	UIDisable bool `json:"ui_disable,omitempty"`
+	// LegacyUI, when true, serves the Angular hypervisor UI at the root of the
+	// web UI port instead of the desk (no wasm visor in the page). Set from
+	// LEGACYHVUI in skywire.conf, `config gen --legacy-hv-ui`, or at runtime
+	// with `hv enable --legacy` / `hv ui enable --legacy`. Default false: the
+	// desk is the hypervisor UI.
+	LegacyUI   bool          `json:"legacy_ui,omitempty"`
 	UIAssets   fs.FS         `json:"-"`
 	PK         cipher.PubKey `json:"-"`
 	SK         cipher.SecKey `json:"-"`


### PR DESCRIPTION
Operators who do not want the desk (or a wasm visor in the page) can serve the Angular dashboard at the hypervisor root instead. The desk stays the default.

- `hypervisor.legacy_ui` in the visor config; the root handler serves the injected Angular index when it is set, everything else on the port is unchanged.
- `LEGACYHVUI=true` in skywire.conf → `config gen --legacy-hv-ui`; `skywire autoconfig --legacy-hv-ui` / `--no-legacy-hv-ui` write it; template documented.
- Runtime: `skywire cli visor hv enable --legacy` and `hv ui enable --legacy` (`--legacy=false` switches back), `-w` persists. New RPC `SetHypervisorLegacyUI`.
- Configuration guide updated.