### PR TITLE
feat(router): count where multi-hop routes came from in visor state diag

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -667,6 +667,7 @@ type router struct {
 	rgsRaw             map[routing.RouteDescriptor]*RouteGroup         // Not-yet-noise-wrapped route groups. when one of these gets wrapped, it gets removed from here
 	rgsDatagrams       map[routing.RouteDescriptor]*DatagramRouteGroup // faithful-UDP (DatagramPacket) route groups, keyed like rgsNs; #2607 stage-4 dispatch
 	intake             intakeCounters                                  // inbound-path counters for `visor state` (router_intake.go)
+	routeSource        routeSourceCounters                             // where routes came from (router_route_source.go)
 	datagramPorts      map[routing.Port]struct{}                       // local ports with faithful-UDP intent; the accept side builds a datagram sibling only for these (#2607 on-demand-by-local-intent)
 	acceptDatagram     chan datagramAccept                             // accept-side datagram siblings, drained by AcceptDatagram (the forwarded_ports.udp server loop)
 	pending            *pendingPackets                                 // frames parked during the rule-save -> route-group-register window (see router_pending.go)

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -1186,12 +1186,14 @@ fetchRoutesAgain:
 	if r.conf.PreferLocalRouteTo != nil && r.conf.PreferLocalRouteTo(dst) {
 		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, src, dst, opts)
 		if localErr == nil {
+			r.routeSource.localAttached.Add(1)
 			log.Infof("Local route from attached graph: Forward=%v, Reverse=%v", localFwd, localRev)
 			return localFwd, localRev, nil
 		}
 		log.WithError(localErr).Debug("Attached-graph local route failed; asking the route finder")
 	}
 
+	r.routeSource.rfQueries.Add(1)
 	var paths map[routing.PathEdges][][]routing.Hop
 	if fwdMinHops == revMinHops {
 		// Common path: single query covers both directions. One count
@@ -1229,6 +1231,7 @@ fetchRoutesAgain:
 		log.Info("Route finder returned transport not found, attempting local route calculation...")
 		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, src, dst, opts)
 		if localErr == nil {
+			r.routeSource.localFallback.Add(1)
 			log.Infof("Local route calculation succeeded: Forward=%v, Reverse=%v", localFwd, localRev)
 			return localFwd, localRev, nil
 		}
@@ -1241,6 +1244,7 @@ fetchRoutesAgain:
 		log.Info("Route finder exhausted retries, attempting local route calculation...")
 		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, src, dst, opts)
 		if localErr == nil {
+			r.routeSource.localFallback.Add(1)
 			log.Infof("Local route calculation succeeded: Forward=%v, Reverse=%v", localFwd, localRev)
 			return localFwd, localRev, nil
 		}
@@ -1268,6 +1272,7 @@ fetchRoutesAgain:
 			log.Info("Route finder timed out, attempting local route calculation...")
 			localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, src, dst, opts)
 			if localErr == nil {
+				r.routeSource.localFallback.Add(1)
 				log.Infof("Local route calculation succeeded: Forward=%v, Reverse=%v", localFwd, localRev)
 				return localFwd, localRev, nil
 			}

--- a/pkg/router/router_route_source.go
+++ b/pkg/router/router_route_source.go
@@ -1,0 +1,37 @@
+// Package router pkg/router/router_route_source.go c3-rtr-core
+//
+// Where multi-hop routes came from, for `visor state --select diag`: the
+// route finder, the local graph (a hypervisor's attached visors, #4750), or
+// the local fallback after a route-finder miss. Counted so the saving from a
+// local graph is visible in a snapshot rather than only in logs.
+package router
+
+import "sync/atomic"
+
+// RouteSourceStats counts fetchBestRoutes outcomes since the router started.
+type RouteSourceStats struct {
+	// LocalAttached is routes built from the local graph before the route
+	// finder was asked (Config.PreferLocalRouteTo): each one is a route-finder
+	// query that did not happen.
+	LocalAttached int64 `json:"local_attached"`
+	// RouteFinderQueries is route-finder requests made (one per attempt).
+	RouteFinderQueries int64 `json:"route_finder_queries"`
+	// LocalFallback is routes built locally after the route finder missed or
+	// ran out of retries.
+	LocalFallback int64 `json:"local_fallback"`
+}
+
+type routeSourceCounters struct {
+	localAttached atomic.Int64
+	rfQueries     atomic.Int64
+	localFallback atomic.Int64
+}
+
+// RouteSourceStats returns the counters.
+func (r *router) RouteSourceStats() RouteSourceStats {
+	return RouteSourceStats{
+		LocalAttached:      r.routeSource.localAttached.Load(),
+		RouteFinderQueries: r.routeSource.rfQueries.Load(),
+		LocalFallback:      r.routeSource.localFallback.Load(),
+	}
+}

--- a/pkg/visor/api_state_diag.go
+++ b/pkg/visor/api_state_diag.go
@@ -29,6 +29,9 @@ type DiagSnapshot struct {
 	// Intake is the router's inbound-path view: unknown/control packets by
 	// type, stale-route drops, and each route group's app queue depth.
 	Intake *router.IntakeStats `json:"intake,omitempty"`
+	// RouteSource is where multi-hop routes came from: the local graph (a
+	// hypervisor's attached visors), the route finder, or the local fallback.
+	RouteSource *router.RouteSourceStats `json:"route_source,omitempty"`
 	// VStream is one entry per virtual-stream mux (skynet forwarding,
 	// app-direct dials, visor RPC): open streams, relay legs, and frames that
 	// arrived for streams this side does not have.
@@ -151,6 +154,13 @@ func (v *Visor) DiagSnapshot() *DiagSnapshot {
 			return true
 		})
 		sort.Slice(d.Transports, func(i, j int) bool { return d.Transports[i].ID.String() < d.Transports[j].ID.String() })
+	}
+
+	if rs, ok := v.router.(interface {
+		RouteSourceStats() router.RouteSourceStats
+	}); ok {
+		stats := rs.RouteSourceStats()
+		d.RouteSource = &stats
 	}
 
 	if is, ok := v.router.(interface{ IntakeStats() router.IntakeStats }); ok {


### PR DESCRIPTION
`visor state --select diag` gains `route_source`: routes built from the local graph before the route finder was asked (#4751), route-finder queries made, and local fallbacks after a miss. Atomic counters on the router, no behaviour change.