### PR TITLE
feat(ci): publish the js/wasm command module beside the binary; default hv serve to it

### DIFF
--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -93,6 +93,17 @@ jobs:
           build_arch armhf   arm     7
           build_arch 386     386     ""
           build_arch riscv64 riscv64 ""
+          # The full skywire command module for GOOS=js: the `skywire` command
+          # inside a desk terminal, which is what turns a served wasm-visor page
+          # into the desk (hv serve --exec-wasm; visor-hosted wasm_serve.exec_wasm).
+          # Too large to embed, so it ships beside the native binary and the
+          # auto-updater installs it as /opt/skywire/bin/skywire.wasm. Same
+          # toolchain as the embedded wasm_exec.js, same version stamping.
+          echo "==> building js/wasm command module"
+          GOOS=js GOARCH=wasm \
+            go build -trimpath -buildvcs=true -mod=vendor -tags "withoutsystray withoutgotop" -ldflags="${LDFLAGS}" -o skywire.wasm .
+          zstd -19 -q -f -o "dist/skywire-js-wasm.zst" skywire.wasm
+          rm -f skywire.wasm
           ( cd dist && sha256sum *.zst > SHA256SUMS )
           {
             echo "BRANCH=${BRANCH}"
@@ -123,9 +134,9 @@ jobs:
               --prerelease \
               --title "${BRANCH} latest (${VERSION})" \
               --notes "${NOTES}"
-            gh release upload "${TAG}" dist/skywire-linux-*.zst dist/SHA256SUMS --clobber
+            gh release upload "${TAG}" dist/*.zst dist/SHA256SUMS --clobber
           else
-            gh release create "${TAG}" dist/skywire-linux-*.zst dist/SHA256SUMS \
+            gh release create "${TAG}" dist/*.zst dist/SHA256SUMS \
               --target "${GITHUB_SHA}" \
               --prerelease \
               --title "${BRANCH} latest (${VERSION})" \

--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -44,7 +44,7 @@ func init() {
 	serveCmd.Flags().StringVar(&serveBrowseOrigin, "browse-origin", "", "ALSO serve the browse-origin SW bootstrap on this second addr (e.g. 127.0.0.1:7998), for the hosted real-origin browser's B origins. Caddy routes *.<browse-suffix> here; this same process serves V on --addr and B here. Empty = off (V host-routes B on --addr, local mode)")
 	serveCmd.Flags().StringVar(&serveVOrigin, "v-origin", "", "the PUBLIC origin of the visor app V that B's bootstrap postMessages to, e.g. https://theskywirenetwork.net. Only needed with --browse-origin behind a proxy; empty = derive from --addr (local)")
 	serveCmd.Flags().BoolVar(&serveBrowseWasmSW, "browse-origin-wasm", false, "serve the Go/wasm transport worker on the browse origins instead of the JS one. TESTING ONLY — the JS worker is what every deployment serves, and its security property is that a hundred readable lines on the untrusted origin name no transport. This swaps in a slice of the visor binary, which cannot make that claim")
-	serveCmd.Flags().StringVar(&serveExecWasm, "exec-wasm", "", "path to the full skywire CLI wasm module to serve at /skywire.wasm — enables the terminal's 'skywire' command (build: GOOS=js GOARCH=wasm go build -tags \"withoutsystray withoutgotop\" -o build/skywire.wasm .). Empty = off")
+	serveCmd.Flags().StringVar(&serveExecWasm, "exec-wasm", "", "path to the full skywire CLI wasm module to serve at /skywire.wasm — enables the terminal's 'skywire' command (build: GOOS=js GOARCH=wasm go build -tags \"withoutsystray withoutgotop\" -o build/skywire.wasm .). Empty = /opt/skywire/bin/skywire.wasm when that file exists (installed by the package or the binary auto-updater), else off")
 	RootCmd.AddCommand(serveCmd)
 }
 

--- a/pkg/skyenv/execwasm.go
+++ b/pkg/skyenv/execwasm.go
@@ -1,0 +1,17 @@
+// Package skyenv pkg/skyenv/execwasm.go c3-env
+package skyenv
+
+// ExecWasmFile is the name of the full skywire command module built for
+// GOOS=js (the `skywire` command inside a desk terminal), as installed
+// beside the native binary by the package and the binary auto-updater.
+const ExecWasmFile = "skywire.wasm"
+
+// ExecWasmPath is where a package install keeps the command module:
+// <SkywirePath>/bin/skywire.wasm. `hv serve` and a visor-hosted wasm_serve
+// use it when no explicit path is configured and the file exists.
+func ExecWasmPath() string {
+	if SkywirePath == "" {
+		return ""
+	}
+	return SkywirePath + "/bin/" + ExecWasmFile
+}

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -409,8 +409,8 @@ const uiAutoReloadJS = `(function(){
 // the operator configured one for the wasm-serve port; the desk on this port
 // shares it. Empty when there is none.
 func (hv *Hypervisor) execWasmPath() string {
-	if hv.c.WasmServe == nil {
-		return ""
+	if hv.c.WasmServe != nil && hv.c.WasmServe.ExecWasm != "" {
+		return hv.c.WasmServe.ExecWasm
 	}
-	return hv.c.WasmServe.ExecWasm
+	return DefaultExecWasmPath()
 }

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -40,6 +40,7 @@ import (
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/wallet/coins"
 	"github.com/skycoin/skywire/pkg/wasmhv"
 	"github.com/skycoin/skywire/pkg/wasmhv/ctlbridge"
@@ -325,6 +326,9 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	// The full skywire CLI module for the terminal's `skywire` command —
 	// served from disk (too large to embed), gzip left to the transport.
 	// Absent path = 404, and the shell simply doesn't register the command.
+	if cfg.ExecWasmPath == "" {
+		cfg.ExecWasmPath = DefaultExecWasmPath()
+	}
 	if cfg.ExecWasmPath != "" {
 		execWasmPath := cfg.ExecWasmPath
 		mux.HandleFunc("/skywire.wasm", func(w http.ResponseWriter, r *http.Request) {
@@ -1156,4 +1160,19 @@ skywireDeskBoot(Object.assign({
 func deskShellHTML(scriptsHTML, deskOptsJS string) []byte {
 	out := strings.ReplaceAll(deskShellTemplate, "__DESK_SCRIPTS__", scriptsHTML)
 	return []byte(strings.ReplaceAll(out, "__DESK_OPTS__", deskOptsJS))
+}
+
+// DefaultExecWasmPath returns the package location of the skywire command
+// module (skyenv.ExecWasmPath) when that file exists, else "". It is the
+// fallback for an empty ExecWasmPath, so a host whose updater installed the
+// module serves the desk without any flag or config change.
+func DefaultExecWasmPath() string {
+	p := skyenv.ExecWasmPath()
+	if p == "" {
+		return ""
+	}
+	if st, err := os.Stat(p); err != nil || st.IsDir() {
+		return ""
+	}
+	return p
 }


### PR DESCRIPTION
theskywirenetwork.net (prod02, `hv serve` from the binary-channel /usr/bin/skywire) still serves the legacy hv-boot page: the desk needs the full skywire command module for GOOS=js at /skywire.wasm, which is too large to embed and was not published anywhere, so `--exec-wasm` had nothing to point at.

- Publish Binary also builds `skywire-js-wasm.zst` (same toolchain and version stamping as the native binaries) into the rolling `<branch>-latest` release and SHA256SUMS.
- `hv serve --exec-wasm` and a visor-hosted `wasm_serve.exec_wasm` default to `/opt/skywire/bin/skywire.wasm` when that file exists (`skyenv.ExecWasmPath`), so no unit or config change is needed once the updater installs it.

The updater side (fetch the module beside the binary) is a separate change in skycoin/aur skywire-bin/skywire-update.