### PR TITLE
chore(lint): clear the golangci-lint findings left by the convergence PRs

### DIFF
--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -608,9 +608,9 @@ outstanding one. Fingerprint = first 40 bits of sha256(pk).`,
 			}
 			var b strings.Builder
 			tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(tw, "FINGERPRINT\tVIA\tFIRST SEEN\tLAST SEEN\tPUBLIC KEY")
+			_, _ = fmt.Fprintln(tw, "FINGERPRINT\tVIA\tFIRST SEEN\tLAST SEEN\tPUBLIC KEY") //nolint:errcheck // strings.Builder never errors
 			for _, p := range pending {
-				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", p.Fingerprint, p.Via,
+				_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", p.Fingerprint, p.Via, //nolint:errcheck // strings.Builder never errors
 					p.FirstSeen.Format(time.Kitchen), p.LastSeen.Format(time.Kitchen), p.PK.Hex())
 			}
 			_ = tw.Flush() //nolint:errcheck

--- a/cmd/skywire/commands/autoconfig_skyenv.go
+++ b/cmd/skywire/commands/autoconfig_skyenv.go
@@ -11,8 +11,6 @@ type skyenvEdit = skyenvfile.Edit
 
 func updateSkyenvFile(path string, edits []skyenvEdit) error { return skyenvfile.Update(path, edits) }
 
-func skyenvLineKey(line string) string { return skyenvfile.LineKey(line) }
-
 func formatSkyenvBool(b bool) string { return skyenvfile.FormatBool(b) }
 
 func formatSkyenvString(s string) string { return skyenvfile.FormatString(s) }

--- a/pkg/skysocks/client_statuswasm_test.go
+++ b/pkg/skysocks/client_statuswasm_test.go
@@ -44,7 +44,10 @@ func TestStatusWasmResponses(t *testing.T) {
 	if ct := execResp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/javascript") {
 		t.Errorf("/wasm_exec.js content-type = %q", ct)
 	}
-	body, _ := io.ReadAll(execResp.Body)
+	body, err := io.ReadAll(execResp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !strings.Contains(string(body), "this.argv=['skywire','desk-host','--role','netview']") {
 		t.Error("/wasm_exec.js is not pinned to the netview role")
 	}

--- a/pkg/skywireconfig/skyenvfile/skyenvfile_test.go
+++ b/pkg/skywireconfig/skyenvfile/skyenvfile_test.go
@@ -22,7 +22,7 @@ func TestUpdateReplacesCommentedKeyAndAppendsMissing(t *testing.T) {
 	if err := Update(p, edits); err != nil {
 		t.Fatal(err)
 	}
-	got, err := os.ReadFile(p)
+	got, err := os.ReadFile(p) //nolint:gosec // G304: p is this test's own temp file
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/visor/hypervisor_handlers_browse_mobile.go
+++ b/pkg/visor/hypervisor_handlers_browse_mobile.go
@@ -47,3 +47,7 @@ func (hv *Hypervisor) getUIVersion() http.HandlerFunc {
 		w.Header().Set("Cache-Control", "no-store")
 	}
 }
+
+// logUIRoot is a no-op on mobile: the phone serves no desk and no dashboard
+// root, so there is nothing to explain about the UI root.
+func (hv *Hypervisor) logUIRoot() {}


### PR DESCRIPTION
The lint lane flagged four leftovers on develop: unchecked tabwriter writes in `hv pair`, an unused skyenv wrapper, a gosec G304 on a test's own temp file, and an unchecked ReadAll in the skysocks status test. Also a mobile-build stub for the hypervisor's startup UI-root log (the mobile build excludes the browse handlers that define it; android-mobile failed to compile since #4760). No behaviour change.