### PR TITLE
fix(skyenvfile): close the source file before renaming over it (Windows)

### DIFF
--- a/pkg/skywireconfig/skyenvfile/skyenvfile.go
+++ b/pkg/skywireconfig/skyenvfile/skyenvfile.go
@@ -108,6 +108,10 @@ func Update(path string, edits []Edit) error {
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("Update: scan %s: %w", path, err)
 	}
+	// Close the source before the rename below: Windows refuses to replace a
+	// file that is still open (the deferred Close alone left autoconfig and
+	// the visor unable to write skywire.conf there).
+	_ = src.Close() //nolint:errcheck
 
 	// Append any keys we never matched. Tag the block so operators
 	// scanning the file later can tell autoconfig wrote it.


### PR DESCRIPTION
The Windows test lane failed `TestUpdateReplacesCommentedKeyAndAppendsMissing` with `rename ...: Access is denied`: Update kept skywire.conf open (deferred Close) while renaming the temp file over it, which Windows refuses. Close it as soon as the scan is done. This code moved from cmd/skywire in #4746 and had no Windows test before, so autoconfig's skyenv writes were affected there too.