### PR TITLE
fix(visor): stop hammering the address resolver: lazy own-key refresh, dead-target backoff

### DIFF
--- a/pkg/visor/api_ar.go
+++ b/pkg/visor/api_ar.go
@@ -109,7 +109,33 @@ type ARSelfRegistration struct {
 // visors that don't self-publish are covered by the AR mirror).
 type arSelfState struct {
 	mu      sync.RWMutex
-	entries map[string]addrresolver.VisorData // key: "stcpr" | "sudph"
+	entries map[string]addrresolver.VisorData // key: "stcpr" | "sudph" | "wt"
+	// refreshedAt is when the last refresh completed; zero = never. The CLI
+	// path refreshes on demand when this is older than arSelfMaxAge, so the
+	// background loop can be slow (every visor on the network was asking the
+	// address resolver for its own key three times a minute — a third of the
+	// AR's request load, 2026-09-10).
+	refreshedAt time.Time
+	refreshMu   sync.Mutex // serializes refreshes (loop + on-demand)
+}
+
+// arSelfMaxAge is how old the cached self-registration may be before a CLI
+// query refreshes it first.
+const arSelfMaxAge = 5 * time.Minute
+
+func (s *arSelfState) age() time.Duration {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.refreshedAt.IsZero() {
+		return time.Duration(1<<62 - 1)
+	}
+	return time.Since(s.refreshedAt)
+}
+
+func (s *arSelfState) stamp() {
+	s.mu.Lock()
+	s.refreshedAt = time.Now()
+	s.mu.Unlock()
 }
 
 func newARSelfState() arSelfState {
@@ -155,6 +181,14 @@ func (s *arSelfState) snapshot() map[string]addrresolver.VisorData { //nolint:un
 // ARSelfInfo returns the visor's own cached AR registration. Reads the
 // in-memory cache populated by the refresh loop — no HTTP round-trip.
 func (v *Visor) ARSelfInfo() (*ARSelfRegistration, error) {
+	// Refresh on demand: the background loop is deliberately slow (see
+	// arSelfRefreshLoop), so a query answers from a cache no older than
+	// arSelfMaxAge, refreshing synchronously when it is.
+	if v.arSelf.age() > arSelfMaxAge {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		v.arSelfRefreshOnce(ctx, nil)
+		cancel()
+	}
 	out := &ARSelfRegistration{Queried: append([]string(nil), arSelfTypes...)}
 	for _, tpType := range arSelfTypes {
 		d, ok := v.arSelf.get(tpType)
@@ -181,9 +215,13 @@ func (v *Visor) ARSelfInfo() (*ARSelfRegistration, error) {
 //
 // The first refresh runs after a short warmup, then every refreshEvery.
 func (v *Visor) arSelfRefreshLoop(ctx context.Context, log *logging.Logger) {
+	// refreshEvery was 60 s: every visor on the network resolved its own key
+	// for three transport types each minute, only to keep a CLI display warm —
+	// a third of the address resolver's requests (2026-09-10). The display now
+	// refreshes on demand (ARSelfInfo), so the loop is a slow reconciler.
 	const (
 		warmup       = 15 * time.Second
-		refreshEvery = 60 * time.Second
+		refreshEvery = 15 * time.Minute
 	)
 
 	select {
@@ -217,6 +255,9 @@ func (v *Visor) arSelfRefreshOnce(ctx context.Context, _ *logging.Logger) {
 	if arClient == nil {
 		return
 	}
+	v.arSelf.refreshMu.Lock()
+	defer v.arSelf.refreshMu.Unlock()
+	defer v.arSelf.stamp()
 
 	for _, tpType := range arSelfTypes {
 		rctx, rcancel := context.WithTimeout(ctx, 10*time.Second)

--- a/pkg/visor/visorcore/autoconnect.go
+++ b/pkg/visor/visorcore/autoconnect.go
@@ -32,6 +32,11 @@ type Connector struct {
 	DmsgC          *dmsg.Client // for reachability probes
 	ClientPublicIP string
 	Log            *logging.Logger
+
+	// failed remembers (target, type) pairs whose last dial failed and when
+	// they may be tried again — see autoconnect_backoff.go.
+	failedMu sync.Mutex
+	failed   map[dialKey]dialFailure
 }
 
 // ConnectPhaseResult tracks the outcome of a connection phase.
@@ -93,6 +98,15 @@ func (c *Connector) ConnectToVisors(
 		if pk == selfPK {
 			continue
 		}
+		// A target whose last dial failed waits out its backoff (autoconnect_backoff.go).
+		if c.inBackoff(pk, tpType, time.Now()) {
+			if trackAll {
+				mu.Lock()
+				result.Connected = append(result.Connected, pk)
+				mu.Unlock()
+			}
+			continue
+		}
 
 		// Skip if we already have this transport type to this visor
 		if existingByPK[pk][tpType] {
@@ -145,7 +159,8 @@ func (c *Connector) ConnectToVisors(
 				if isContextError(err) {
 					logger.WithError(err).Debugln("Transport creation canceled (shutdown)")
 				} else {
-					logger.WithError(err).Warnln("Failed to add transport")
+					wait := c.noteFailure(pk, tpType, time.Now())
+					logger.WithError(err).WithField("retry_in", wait).Warnln("Failed to add transport")
 				}
 				if trackAll {
 					mu.Lock()
@@ -156,6 +171,7 @@ func (c *Connector) ConnectToVisors(
 			}
 
 			mu.Lock()
+			c.noteSuccess(pk, tpType)
 			result.Count++
 			result.Connected = append(result.Connected, pk)
 			mu.Unlock()

--- a/pkg/visor/visorcore/autoconnect_backoff.go
+++ b/pkg/visor/visorcore/autoconnect_backoff.go
@@ -1,0 +1,90 @@
+// Package visorcore pkg/visor/visorcore/autoconnect_backoff.go c3-vis-core
+//
+// Per-target dial backoff for the autoconnect Connector. Offline public
+// visors stay in the discovery lists for a long time, and without this every
+// visor on the network re-dialed the same dead keys each cycle — several
+// address-resolver lookups per attempt, fleet-wide (a third of the AR's
+// load on 2026-09-10 was this plus self-lookups). The wait doubles per
+// consecutive failure from dialBackoffMin up to dialBackoffMax and is
+// forgotten on the first success. Keyed per (target, type): a visor that is
+// unreachable over one carrier may still answer on another.
+package visorcore
+
+import (
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+type dialKey struct {
+	pk  cipher.PubKey
+	typ tptypes.Type
+}
+
+type dialFailure struct {
+	until time.Time
+	n     int
+}
+
+const (
+	dialBackoffMin = 5 * time.Minute
+	dialBackoffMax = 2 * time.Hour
+)
+
+// dialBackoff is the wait after the n-th consecutive failure (n >= 1).
+func dialBackoff(n int) time.Duration {
+	d := dialBackoffMin
+	for i := 1; i < n && d < dialBackoffMax; i++ {
+		d *= 2
+	}
+	if d > dialBackoffMax {
+		return dialBackoffMax
+	}
+	return d
+}
+
+// inBackoff reports whether pk/typ failed recently enough to skip this cycle.
+func (c *Connector) inBackoff(pk cipher.PubKey, typ tptypes.Type, now time.Time) bool {
+	c.failedMu.Lock()
+	defer c.failedMu.Unlock()
+	f, ok := c.failed[dialKey{pk, typ}]
+	return ok && now.Before(f.until)
+}
+
+// noteFailure extends the backoff for pk/typ after a failed dial and returns
+// the new wait.
+func (c *Connector) noteFailure(pk cipher.PubKey, typ tptypes.Type, now time.Time) time.Duration {
+	c.failedMu.Lock()
+	defer c.failedMu.Unlock()
+	if c.failed == nil {
+		c.failed = make(map[dialKey]dialFailure)
+	}
+	k := dialKey{pk, typ}
+	f := c.failed[k]
+	f.n++
+	wait := dialBackoff(f.n)
+	f.until = now.Add(wait)
+	c.failed[k] = f
+	return wait
+}
+
+// noteSuccess forgets any backoff for pk/typ.
+func (c *Connector) noteSuccess(pk cipher.PubKey, typ tptypes.Type) {
+	c.failedMu.Lock()
+	delete(c.failed, dialKey{pk, typ})
+	c.failedMu.Unlock()
+}
+
+// BackedOff returns how many (target, type) pairs are currently skipped.
+func (c *Connector) BackedOff(now time.Time) int {
+	c.failedMu.Lock()
+	defer c.failedMu.Unlock()
+	n := 0
+	for _, f := range c.failed {
+		if now.Before(f.until) {
+			n++
+		}
+	}
+	return n
+}

--- a/pkg/visor/visorcore/autoconnect_backoff_test.go
+++ b/pkg/visor/visorcore/autoconnect_backoff_test.go
@@ -1,0 +1,50 @@
+// Package visorcore pkg/visor/visorcore/autoconnect_backoff_test.go c3-vis-core
+package visorcore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+func TestDialBackoffSchedule(t *testing.T) {
+	want := []time.Duration{5 * time.Minute, 10 * time.Minute, 20 * time.Minute, 40 * time.Minute, 80 * time.Minute, 2 * time.Hour, 2 * time.Hour}
+	for i, w := range want {
+		if got := dialBackoff(i + 1); got != w {
+			t.Fatalf("dialBackoff(%d) = %v, want %v", i+1, got, w)
+		}
+	}
+}
+
+func TestConnectorBackoffLifecycle(t *testing.T) {
+	c := &Connector{}
+	pk, _ := cipher.GenerateKeyPair()
+	now := time.Now()
+	if c.inBackoff(pk, tptypes.STCPR, now) {
+		t.Fatal("fresh target must not be in backoff")
+	}
+	if w := c.noteFailure(pk, tptypes.STCPR, now); w != dialBackoffMin {
+		t.Fatalf("first failure wait %v", w)
+	}
+	if !c.inBackoff(pk, tptypes.STCPR, now.Add(time.Minute)) {
+		t.Fatal("target must be skipped inside the wait")
+	}
+	if c.inBackoff(pk, tptypes.SUDPH, now.Add(time.Minute)) {
+		t.Fatal("backoff is per transport type")
+	}
+	if c.inBackoff(pk, tptypes.STCPR, now.Add(dialBackoffMin+time.Second)) {
+		t.Fatal("target must be retried after the wait")
+	}
+	if w := c.noteFailure(pk, tptypes.STCPR, now.Add(dialBackoffMin+time.Second)); w != 2*dialBackoffMin {
+		t.Fatalf("second failure wait %v", w)
+	}
+	if c.BackedOff(now.Add(dialBackoffMin+2*time.Second)) != 1 {
+		t.Fatal("one pair should be backed off")
+	}
+	c.noteSuccess(pk, tptypes.STCPR)
+	if c.inBackoff(pk, tptypes.STCPR, now.Add(dialBackoffMin+2*time.Second)) || c.BackedOff(now) != 0 {
+		t.Fatal("success must clear the backoff")
+	}
+}


### PR DESCRIPTION
The address resolver on the TPD host sees ~95 resolve requests/s from ~900 visors. From its access log: a third are visors resolving their OWN key (every visor, three transport types, once a minute), and the rest are the fleet re-dialing the same handful of offline public visors each autoconnect cycle (their AR entries are gone, their dmsg entries have no server).

- The own-key lookups feed only the CLI's AR self-registration display. The cache now refreshes on demand when a query finds it older than 5 min; the background loop drops from 60 s to 15 min.
- The autoconnect Connector remembers a failed (target, type) and skips it for 5 min, doubling per consecutive failure up to 2 h, cleared on the first success. Per type, so a peer unreachable on one carrier is still tried on another.

Unit tests for the backoff schedule and lifecycle; visor and visorcore suites pass; root and js builds pass. Companion to #4765 (AR GC pressure).