### PR TITLE
perf(geoip): open the embedded database lazily, once per process

### DIFF
--- a/pkg/geoip/geoip_embedded.go
+++ b/pkg/geoip/geoip_embedded.go
@@ -60,3 +60,25 @@ func EmbeddedDB() []byte {
 func OpenEmbedded() (*geoip2.Reader, error) {
 	return geoip2.OpenBytes(EmbeddedDB())
 }
+
+var (
+	sharedOnce sync.Once
+	shared     *geoip2.Reader
+	sharedErr  error
+)
+
+// Embedded reports whether this build carries the database at all, without
+// decompressing it.
+func Embedded() bool { return len(embeddedGz) > 0 }
+
+// Shared returns the process-wide reader over the embedded database, opening
+// it on first use. Inflating the ~30 MB gzip costs ~60 MB of heap for the life
+// of the process, so callers keep this lazy: a visor that never answers a geo
+// query never pays it (every visor and dmsg server used to open it at start).
+// The reader is safe for concurrent use and is never closed.
+func Shared() (*geoip2.Reader, error) {
+	sharedOnce.Do(func() {
+		shared, sharedErr = OpenEmbedded()
+	})
+	return shared, sharedErr
+}

--- a/pkg/geoip/geoip_embedded_mobile.go
+++ b/pkg/geoip/geoip_embedded_mobile.go
@@ -21,3 +21,9 @@ func EmbeddedDB() []byte { return nil }
 func OpenEmbedded() (*geoip2.Reader, error) {
 	return nil, errors.New("geoip: embedded database not included in this build")
 }
+
+// Embedded reports the database absent in this build.
+func Embedded() bool { return false }
+
+// Shared reports the database absent in this build.
+func Shared() (*geoip2.Reader, error) { return OpenEmbedded() }

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -250,10 +250,16 @@ func (s *service) Run(ctx context.Context) error {
 	srv := dmsg.NewServer(cfg.PubKey, cfg.SecKey, newDmsgOnly(dmsgC, discPKs[0], log), &srvConf, m)
 	srv.SetLogger(log)
 
-	if geoDB, err := geoip.OpenEmbedded(); err != nil {
-		log.WithError(err).Warn("failed to open embedded geoip DB; LookupIPGeo will return empty geo fields")
+	// The embedded geoip DB opens on the first lookup (geoip.Shared): ~60 MB of
+	// heap, paid only if a geo field is ever asked for.
+	if !geoip.Embedded() {
+		log.Warn("no embedded geoip DB in this build; LookupIPGeo will return empty geo fields")
 	} else {
 		srv.SetGeoLookup(func(ip net.IP) (country, region string, lat, lon float64) {
+			geoDB, err := geoip.Shared()
+			if err != nil {
+				return "", "", 0, 0
+			}
 			res, err := geoip.Lookup(geoDB, ip.String())
 			if err != nil || res == nil {
 				return "", "", 0, 0

--- a/pkg/visor/geo_summary.go
+++ b/pkg/visor/geo_summary.go
@@ -33,7 +33,7 @@ func geoCountryForIP(ip string) string {
 		return ""
 	}
 	geoSummary.once.Do(func() {
-		if db, err := geoip.OpenEmbedded(); err == nil {
+		if db, err := geoip.Shared(); err == nil {
 			geoSummary.db = db
 		}
 	})

--- a/pkg/visor/init_services.go
+++ b/pkg/visor/init_services.go
@@ -264,11 +264,10 @@ func LookupGeo(ip string) *GeoData {
 	if ip == "" {
 		return nil
 	}
-	db, err := geoip.OpenEmbedded()
+	db, err := geoip.Shared()
 	if err != nil {
 		return nil
 	}
-	defer db.Close() //nolint:errcheck
 	res, err := geoip.Lookup(db, ip)
 	if err != nil {
 		return nil

--- a/pkg/visor/policy_provider.go
+++ b/pkg/visor/policy_provider.go
@@ -36,8 +36,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/oschwald/geoip2-golang/v2"
-
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/geoip"
 	"github.com/skycoin/skywire/pkg/servicedisc"
@@ -92,7 +90,6 @@ type visorPolicyProvider struct {
 	visor *Visor // for CXOSubMgr access + servicesFromCXO/HTTP fallback
 
 	geoMu sync.Mutex
-	geoDB *geoip2.Reader // nil when OpenEmbedded failed
 
 	// SD-derived PK→country map. Populated lazily on first Geo
 	// lookup and refreshed on a TTL. Lifetime-scoped to the
@@ -128,13 +125,10 @@ func newVisorPolicyProvider(v *Visor) *visorPolicyProvider {
 		arInFlight:  make(map[string]struct{}),
 	}
 
-	// Embedded geoip DB. Failure to open isn't fatal — Geo() just
-	// returns "??" until OpenEmbedded() works.
-	if db, err := geoip.OpenEmbedded(); err == nil {
-		p.geoDB = db
-	} else if v.log != nil {
-		v.log.WithError(err).Warn("routing-policy provider: embedded geoip db unavailable; geo.country() will return \"??\"")
-	}
+	// The embedded geoip DB is opened lazily on the first lookup (geoip.Shared):
+	// inflating it costs ~60 MB of heap for the life of the process, and most
+	// visors never evaluate geo.country(). Failure to open isn't fatal — Geo()
+	// just returns "??".
 
 	// Pre-build the hypervisor set from config. Hypervisors are
 	// auto-trusted (they're the operator's control plane).
@@ -171,12 +165,12 @@ func (p *visorPolicyProvider) Geo(pk string) string {
 	}
 
 	// 2. Direct-transport IP + embedded geoip.
-	if p.geoDB != nil && p.tpM != nil {
+	if geoip.Embedded() && p.tpM != nil {
 		if pubkey, ok := parsePK(pk); ok {
 			ip := p.remoteIPForPeer(pubkey)
 			if ip != "" {
 				p.geoMu.Lock()
-				res, err := geoip.Lookup(p.geoDB, ip)
+				res, err := p.geoLookup(ip)
 				p.geoMu.Unlock()
 				if err == nil && res != nil && res.CountryCode != "" {
 					return res.CountryCode
@@ -212,7 +206,7 @@ func (p *visorPolicyProvider) arGeoForPK(pk cipher.PubKey, pkLower string) strin
 	// Miss/expired: only spend a resolve when we actually can (AR
 	// client + geoip db present) and no resolve is already running
 	// for this PK.
-	if p.tpM == nil || p.geoDB == nil {
+	if p.tpM == nil || !geoip.Embedded() {
 		p.arMu.Unlock()
 		return ""
 	}
@@ -275,7 +269,7 @@ func (p *visorPolicyProvider) countryFromVisorData(vd addrresolver.VisorData) st
 			continue
 		}
 		p.geoMu.Lock()
-		res, err := geoip.Lookup(p.geoDB, ip)
+		res, err := p.geoLookup(ip)
 		p.geoMu.Unlock()
 		if err == nil && res != nil && res.CountryCode != "" {
 			return res.CountryCode
@@ -476,4 +470,14 @@ func (p *visorPolicyProvider) remoteIPForPeer(peer cipher.PubKey) string {
 		return ""
 	}
 	return mt.RemoteIP()
+}
+
+// geoLookup resolves ip against the shared embedded database, opening it on
+// first use.
+func (p *visorPolicyProvider) geoLookup(ip string) (*geoip.Result, error) {
+	db, err := geoip.Shared()
+	if err != nil {
+		return nil, err
+	}
+	return geoip.Lookup(db, ip)
 }

--- a/pkg/visor/policy_provider_test.go
+++ b/pkg/visor/policy_provider_test.go
@@ -35,12 +35,10 @@ func TestHostFromAddr(t *testing.T) {
 // in the embedded geoip db, and an AR record with no usable IP yields
 // "".
 func TestCountryFromVisorData(t *testing.T) {
-	db, err := geoip.OpenEmbedded()
-	if err != nil {
+	if _, err := geoip.Shared(); err != nil {
 		t.Skipf("embedded geoip db unavailable: %v", err)
 	}
-	defer db.Close() //nolint:errcheck,gosec
-	p := &visorPolicyProvider{geoDB: db}
+	p := &visorPolicyProvider{}
 
 	if got := p.countryFromVisorData(addrresolver.VisorData{RemoteAddr: gbIP + ":1234"}); got != "GB" {
 		t.Errorf("countryFromVisorData(v4) = %q, want GB", got)


### PR DESCRIPTION
Every visor and every dmsg server inflated the ~30 MB gzipped GeoLite2 database at start: ~60 MB of heap for the life of the process, the dmsg server's third-largest live allocation in today's heap profile on the TPD host, and paid by fleet visors that never evaluate a geo policy or answer a geo query.

`geoip.Shared` opens it on first use behind a sync.Once and `geoip.Embedded` reports availability without inflating. The routing-policy provider, the hypervisor geo summary, LookupGeo and the dmsg server's geo hook use it. Native, js and mobile builds pass; geoip, visor and dmsgsrv tests pass.