### PR TITLE
perf(dmsg): pooled relay copy buffers; per-session lines at debug

### DIFF
--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -754,13 +754,13 @@ func (s *Server) handleSession(conn net.Conn) {
 		dSes.isPeer = true
 		log.Info("Started peer server session.")
 	} else {
-		log.Info("Started session.")
+		log.Debug("Started session.")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		awaitDone(ctx, s.done)
-		log.WithError(dSes.Close()).Info("Stopped session.")
+		log.WithError(dSes.Close()).Debug("Stopped session.")
 	}()
 
 	if hook := testHookHandleSessionPreMux; hook != nil {
@@ -781,7 +781,7 @@ func (s *Server) handleSession(conn net.Conn) {
 			return
 		}
 		dSes.sm.addr = dSes.sm.smux.RemoteAddr()
-		log.Infof("smux stream session initial for %s", dSes.RemotePK().String())
+		log.Debugf("smux stream session initial for %s", dSes.RemotePK().String())
 	} else {
 		dSes.sm.yamux, err = yamux.Server(conn, YamuxConfig())
 		if err != nil {
@@ -791,7 +791,7 @@ func (s *Server) handleSession(conn net.Conn) {
 			return
 		}
 		dSes.sm.addr = dSes.sm.yamux.RemoteAddr()
-		log.Infof("yamux stream session initial for %s", dSes.RemotePK().String())
+		log.Debugf("yamux stream session initial for %s", dSes.RemotePK().String())
 	}
 	dSes.sm.mutx.Unlock()
 

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -68,7 +68,7 @@ func (ss *ServerSession) Serve() {
 			sStr, err := ss.sm.smux.AcceptStream()
 			if err != nil {
 				if err == io.EOF || err == smux.ErrInvalidProtocol || ss.sm.smux.IsClosed() {
-					ss.log.WithError(err).Info("Stopping session...")
+					ss.log.WithError(err).Debug("Stopping session...")
 					return
 				}
 				ss.log.WithError(err).Warn("Failed to accept smux stream, continuing...")
@@ -104,7 +104,7 @@ func (ss *ServerSession) Serve() {
 		for {
 			qStr, err := ss.sm.quic.AcceptStream(context.Background())
 			if err != nil {
-				ss.log.WithError(err).Info("Stopping session...")
+				ss.log.WithError(err).Debug("Stopping session...")
 				return
 			}
 			log := ss.log.WithField("quic_id", qStr.quicStreamID())
@@ -141,7 +141,7 @@ func (ss *ServerSession) Serve() {
 				// it can arrive before yamux.IsClosed() flips — so the old narrow
 				// check spun this loop forever ("Failed to accept yamux stream,
 				// continuing"). Stop the session on any accept error.
-				ss.log.WithError(err).Info("Stopping session...")
+				ss.log.WithError(err).Debug("Stopping session...")
 				return
 			}
 

--- a/pkg/netutil/copy.go
+++ b/pkg/netutil/copy.go
@@ -3,6 +3,7 @@ package netutil
 
 import (
 	"io"
+	"sync"
 	"time"
 )
 
@@ -31,12 +32,10 @@ func forceInterrupt(conn io.ReadWriteCloser) {
 func CopyReadWriteCloser(conn1, conn2 io.ReadWriteCloser) error {
 	done := make(chan error, 2)
 	go func() {
-		_, err := io.Copy(conn2, conn1)
-		done <- err
+		done <- copyPooled(conn2, conn1)
 	}()
 	go func() {
-		_, err := io.Copy(conn1, conn2)
-		done <- err
+		done <- copyPooled(conn1, conn2)
 	}()
 
 	// Wait for one direction to finish.
@@ -63,4 +62,22 @@ func CopyReadWriteCloser(conn1, conn2 io.ReadWriteCloser) error {
 	}
 
 	return firstErr
+}
+
+// copyBufSize is the per-direction relay buffer. io.Copy would allocate a
+// fresh 32 KiB for every stream direction; a dmsg server bridging ~2,000
+// streams held ~120 MB of those (heap profile on the TPD host, 2026-09-10),
+// and re-allocated them on every stream open. Pooled, the buffers are reused
+// across streams and released when idle.
+const copyBufSize = 32 * 1024
+
+var copyBufPool = sync.Pool{New: func() any { b := make([]byte, copyBufSize); return &b }}
+
+// copyPooled is io.Copy with a pooled buffer. io.CopyBuffer still prefers the
+// destination's ReaderFrom / the source's WriterTo when either exists.
+func copyPooled(dst io.Writer, src io.Reader) error {
+	bp := copyBufPool.Get().(*[]byte)
+	_, err := io.CopyBuffer(dst, src, *bp)
+	copyBufPool.Put(bp)
+	return err
 }


### PR DESCRIPTION
From today's heap and CPU profiles of dmsg-server-6 on the TPD host (~1,100 sessions, ~9,000 goroutines, 55% CPU): `io.Copy` in the stream bridge allocated a fresh 32 KiB per direction per stream, ~120 MB live and the top allocation churn (2.3 GB in the sample); the per-session INFO lines (Started/Stopped session, stream-session initial) were the top formatting churn (~1.3 GB through the text formatter in the sample).

`netutil.CopyReadWriteCloser` now copies through a pooled buffer (io.CopyBuffer, so ReaderFrom/WriterTo still short-circuit), and the per-session lines log at debug. No protocol or behaviour change. netutil and dmsg tests pass; root and js builds pass.