### PR TITLE
fix(cxds): compact a sparse store, not only a dead-heavy one

### DIFF
--- a/pkg/cxo/data/cxds/drive_compact.go
+++ b/pkg/cxo/data/cxds/drive_compact.go
@@ -30,6 +30,13 @@ const (
 	// object volume is dead (rc==0); otherwise the store is mostly live and a
 	// rewrite would reclaim little.
 	compactMinDeadFrac = 0.40
+	// compactMinFreeFrac: also compact when at least this fraction of the FILE is
+	// not object data (bbolt free pages). The publisher deletes dead objects at runtime
+	// (cxoutils.RemoveObjects), so the object scan sees a mostly-live store,
+	// but bbolt never shrinks its file: a visor's telemetry store sat at 2.9 GB
+	// on disk (and in page cache, pulled in by this very scan) holding a few MB
+	// of live objects (2026-09-10). Only a rewrite gives that back.
+	compactMinFreeFrac = 0.50
 	// compactRescanGrowth: after a scan that decided NOT to compact, skip
 	// re-scanning until the file has grown by this factor, so a legitimately
 	// large mostly-live store is not rescanned on every start.
@@ -123,8 +130,14 @@ func startupGCCompact(fileName string) (reclaimed int64, err error) {
 		return 0, sErr
 	}
 
+	// Sparse file: the objects (live and dead) occupy well under half of it, the
+	// rest being freed pages bbolt keeps for reuse but never returns. Measured
+	// from the scan rather than the freelist, which bbolt loads lazily (it can
+	// read as empty right after open).
 	totalVol := liveVol + deadVol
-	if totalVol == 0 || float64(deadVol) < compactMinDeadFrac*float64(totalVol) {
+	sparse := float64(totalVol) < (1-compactMinFreeFrac)*float64(origSize)
+	mostlyLive := totalVol == 0 || float64(deadVol) < compactMinDeadFrac*float64(totalVol)
+	if mostlyLive && !sparse {
 		// Mostly live — remember this size so we don't rescan until it grows.
 		_ = src.Update(func(tx *bolt.Tx) error { //nolint:errcheck // best-effort meta write
 			if m := tx.Bucket(metaBucket); m != nil {

--- a/pkg/cxo/data/cxds/drive_compact_test.go
+++ b/pkg/cxo/data/cxds/drive_compact_test.go
@@ -4,6 +4,7 @@
 package cxds
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -102,6 +103,60 @@ func TestStartupGCCompact_SkipsMostlyLive(t *testing.T) {
 	for _, v := range live {
 		_, rc, err := ds2.Get(cipher.SumSHA256(v), 0)
 		require.NoError(t, err, "all-live store must be untouched")
+		require.Equal(t, uint32(1), rc)
+	}
+}
+
+// A store whose dead objects were already deleted at runtime is "mostly live"
+// to the object scan, yet the file keeps every freed page: the free-page
+// criterion must still rewrite it and give the space back.
+func TestStartupGCCompact_ReclaimsFreedPages(t *testing.T) {
+	fn := filepath.Join(t.TempDir(), "cxds.db")
+	ds, err := NewDriveCXDS(fn)
+	require.NoError(t, err)
+	// Phase 1: grow the file with 600 live objects.
+	var keep, drop [][]byte
+	for i := 0; i < 600; i++ {
+		v := mkVal(byte(i%251), 8192)
+		v[0], v[1] = byte(i>>8), byte(i) // distinct objects
+		_, err := ds.Set(cipher.SumSHA256(v), v, 1)
+		require.NoError(t, err)
+		if i < 6 {
+			keep = append(keep, v)
+		} else {
+			drop = append(drop, v)
+		}
+	}
+	require.NoError(t, ds.Close())
+	// Phase 2: delete nearly all of them in a fresh session — the pages they
+	// used go to the freelist, the file keeps its high-water size.
+	ds, err = NewDriveCXDS(fn)
+	require.NoError(t, err)
+	for _, v := range drop {
+		require.NoError(t, ds.Del(cipher.SumSHA256(v)))
+	}
+	require.NoError(t, ds.Close())
+	before, err := os.Stat(fn)
+	require.NoError(t, err)
+
+	old := compactMinFileBytes
+	compactMinFileBytes = 4096
+	defer func() { compactMinFileBytes = old }()
+
+	reclaimed, err := startupGCCompact(fn)
+	require.NoError(t, err)
+	require.Greater(t, reclaimed, int64(0), "freed pages must be reclaimed by a rewrite")
+	after, err := os.Stat(fn)
+	require.NoError(t, err)
+	require.Less(t, after.Size(), before.Size()/2, "file must shrink: %d -> %d", before.Size(), after.Size())
+
+	ds2, err := NewDriveCXDS(fn)
+	require.NoError(t, err)
+	defer ds2.Close() //nolint:errcheck
+	for _, v := range keep {
+		got, rc, err := ds2.Get(cipher.SumSHA256(v), 0)
+		require.NoError(t, err)
+		require.Equal(t, v, got)
 		require.Equal(t, uint32(1), rc)
 	}
 }


### PR DESCRIPTION
The TPD host visor's telemetry store (`local/cxo-stats/cxds.db`) is 2.9 GB on disk and shows up as 2.7 GB of file-backed RSS: the startup scan reads the whole file into page cache and then decides not to compact, because the publisher already deletes dead objects at runtime and the store looks mostly live. bbolt never returns freed pages, so the file keeps its high-water mark forever.

The startup compaction now also rewrites when the objects (live and dead) occupy under half the file, measured from the scan itself rather than the freelist, which bbolt loads lazily and reports empty right after open. Test builds a sparse store in two sessions (grow, then delete) and checks it shrinks with the live objects intact. Existing compaction tests pass; root and js builds pass.