### PR TITLE
perf(services): gzip only responses over 1 KiB

### DIFF
--- a/pkg/deployment/conf/api/api.go
+++ b/pkg/deployment/conf/api/api.go
@@ -111,7 +111,9 @@ func New(log *logging.Logger, conf Config, domain, dmsgAddr string) *API {
 	r.Use(middleware.Recoverer)
 	// gzip JSON responses on the wire — this router is also served over
 	// dmsg, where every byte is relayed. Matches rf/ut/sd.
-	r.Use(middleware.Compress(5))
+	// gzip only bodies over CompressMinBytes: single entries and health lines are
+	// smaller than the flate state that would compress them (httputil.CompressMin).
+	r.Use(httputil.CompressMin(httputil.CompressMinBytes, 5))
 	r.Use(httputil.SetLoggerMiddleware(log))
 	r.Get("/health", api.health)
 	r.Get("/", api.config)

--- a/pkg/deployment/monitor/api/api.go
+++ b/pkg/deployment/monitor/api/api.go
@@ -105,7 +105,7 @@ func New(s store.Store, logger *logging.Logger, urls ServicesURLs, config Networ
 		middleware.Logger,
 		middleware.Recoverer,
 		// gzip JSON responses on the wire. Matches rf/ut/sd.
-		middleware.Compress(5),
+		httputil.CompressMin(httputil.CompressMinBytes, 5),
 		httputil.SetLoggerMiddleware(logger),
 	)
 	r.Get("/status", api.getStatus)

--- a/pkg/deployment/rf/api/api.go
+++ b/pkg/deployment/rf/api/api.go
@@ -70,7 +70,9 @@ func New(s store.Store, logger logrus.FieldLogger, enableMetrics bool, dmsgAddr 
 	r.Use(middleware.Recoverer)
 	// gzip route-finder JSON responses on the wire (skips small bodies,
 	// honors Vary; net/http clients get transparent gzip).
-	r.Use(middleware.Compress(5))
+	// gzip only bodies over CompressMinBytes: single entries and health lines are
+	// smaller than the flate state that would compress them (httputil.CompressMin).
+	r.Use(httputil.CompressMin(httputil.CompressMinBytes, 5))
 	if enableMetrics {
 		r.Use(api.reqsInFlightCountMiddleware.Handle)
 		r.Use(metricsutil.RequestDurationMiddleware)

--- a/pkg/deployment/sd/api/api.go
+++ b/pkg/deployment/sd/api/api.go
@@ -237,7 +237,9 @@ func (a *API) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r.Use(middleware.Logger)
 	// gzip service-discovery JSON responses on the wire (skips small bodies,
 	// honors Vary; net/http clients get transparent gzip).
-	r.Use(middleware.Compress(5))
+	// gzip only bodies over CompressMinBytes: single entries and health lines are
+	// smaller than the flate state that would compress them (httputil.CompressMin).
+	r.Use(httputil.CompressMin(httputil.CompressMinBytes, 5))
 	if a.enableMetrics {
 		r.Use(a.reqsInFlightCountMiddleware.Handle)
 		r.Use(metricsutil.RequestDurationMiddleware)

--- a/pkg/deployment/tpd/api/api.go
+++ b/pkg/deployment/tpd/api/api.go
@@ -143,7 +143,9 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
 	r.Use(middleware.Recoverer)
 	// gzip JSON responses on the wire — this router is also served over
 	// dmsg, where every byte is relayed. Matches rf/ut/sd.
-	r.Use(middleware.Compress(5))
+	// gzip only bodies over CompressMinBytes: single entries and health lines are
+	// smaller than the flate state that would compress them (httputil.CompressMin).
+	r.Use(httputil.CompressMin(httputil.CompressMinBytes, 5))
 	if enableMetrics {
 		r.Use(api.reqsInFlightCountMiddleware.Handle)
 		r.Use(metricsutil.RequestDurationMiddleware)

--- a/pkg/deployment/ut/api/api.go
+++ b/pkg/deployment/ut/api/api.go
@@ -118,7 +118,9 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore, 
 	// constantly by the reward system + CLIs; it compresses ~80-90%. Clients
 	// using net/http get transparent gzip (Accept-Encoding auto-added +
 	// decoded); the middleware skips small bodies and honors Vary.
-	r.Use(middleware.Compress(5))
+	// gzip only bodies over CompressMinBytes: single entries and health lines are
+	// smaller than the flate state that would compress them (httputil.CompressMin).
+	r.Use(httputil.CompressMin(httputil.CompressMinBytes, 5))
 	if enableMetrics {
 		r.Use(api.reqsInFlightCountMiddleware.Handle)
 		r.Use(metricsutil.RequestDurationMiddleware)

--- a/pkg/dmsg/discovery/api/api.go
+++ b/pkg/dmsg/discovery/api/api.go
@@ -151,7 +151,9 @@ func New(log logrus.FieldLogger, db store.Storer, m metrics.Metrics, testMode, e
 	r.Use(middleware.Recoverer)
 	// gzip JSON responses on the wire — this router is also served over
 	// dmsg, where every byte is relayed. Matches rf/ut/sd.
-	r.Use(middleware.Compress(5))
+	// gzip only bodies over CompressMinBytes: single entries and health lines are
+	// smaller than the flate state that would compress them (httputil.CompressMin).
+	r.Use(httputil.CompressMin(httputil.CompressMinBytes, 5))
 	if enableMetrics {
 		r.Use(api.reqsInFlightCountMiddleware.Handle)
 		r.Use(metricsutil.RequestDurationMiddleware)

--- a/pkg/httputil/compress.go
+++ b/pkg/httputil/compress.go
@@ -1,0 +1,168 @@
+// Package httputil pkg/httputil/compress.go c0-com-util
+package httputil
+
+import (
+	"bufio"
+	"compress/gzip"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// CompressMinBytes is the default body size below which CompressMin leaves a
+// response uncompressed. The deployment services answer most requests with a
+// few hundred bytes (one entry, one binding, one health line); gzipping those
+// costs a flate writer (~800 KB of state, pooled) and CPU for no wire saving
+// — flate was 15% of dmsg-discovery's CPU and the pooled writers 110 MB of the
+// address resolver's heap (2026-09-10).
+const CompressMinBytes = 1024
+
+var gzipPool = sync.Pool{New: func() any { return gzip.NewWriter(nil) }}
+
+// CompressMin gzips responses larger than minBytes for clients that accept
+// gzip, when the content type is text, JSON, JavaScript, XML or SVG. Smaller
+// responses, other types, flushes before the threshold, and hijacked
+// connections pass through untouched. level is a compress/gzip level.
+func CompressMin(minBytes, level int) func(http.Handler) http.Handler {
+	if level < gzip.HuffmanOnly || level > gzip.BestCompression {
+		level = gzip.DefaultCompression
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") || r.Method == http.MethodHead {
+				next.ServeHTTP(w, r)
+				return
+			}
+			cw := &compressWriter{ResponseWriter: w, min: minBytes, level: level, status: http.StatusOK}
+			defer cw.finish()
+			next.ServeHTTP(cw, r)
+		})
+	}
+}
+
+// compressible reports whether a body of this content type is worth gzipping.
+func compressible(ct string) bool {
+	ct = strings.ToLower(ct)
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	ct = strings.TrimSpace(ct)
+	switch {
+	case strings.HasPrefix(ct, "text/"),
+		ct == "application/json", ct == "application/javascript", ct == "application/x-javascript",
+		ct == "application/xml", ct == "image/svg+xml",
+		strings.HasSuffix(ct, "+json"), strings.HasSuffix(ct, "+xml"):
+		return true
+	}
+	return false
+}
+
+// compressWriter buffers the response until it is known to exceed min bytes;
+// then it either flushes the buffer through gzip and streams the rest
+// compressed, or (small, non-compressible, flushed early) writes it plain.
+type compressWriter struct {
+	http.ResponseWriter
+	min     int
+	level   int
+	status  int
+	buf     []byte
+	decided bool // headers sent to the underlying writer
+	gz      *gzip.Writer
+}
+
+func (c *compressWriter) WriteHeader(status int) {
+	if !c.decided {
+		c.status = status
+	}
+}
+
+func (c *compressWriter) Write(p []byte) (int, error) {
+	if c.decided {
+		if c.gz != nil {
+			return c.gz.Write(p)
+		}
+		return c.ResponseWriter.Write(p)
+	}
+	c.buf = append(c.buf, p...)
+	if len(c.buf) > c.min {
+		if err := c.decide(true); err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
+}
+
+// decide sends the headers and the buffered bytes, compressed when the body
+// is large and of a compressible type.
+func (c *compressWriter) decide(large bool) error {
+	c.decided = true
+	h := c.ResponseWriter.Header()
+	ct := h.Get("Content-Type")
+	if ct == "" && len(c.buf) > 0 {
+		ct = http.DetectContentType(c.buf)
+		h.Set("Content-Type", ct)
+	}
+	if large && compressible(ct) && h.Get("Content-Encoding") == "" {
+		h.Del("Content-Length")
+		h.Set("Content-Encoding", "gzip")
+		h.Add("Vary", "Accept-Encoding")
+		gz := gzipPool.Get().(*gzip.Writer)
+		gz.Reset(c.ResponseWriter)
+		c.gz = gz
+		c.ResponseWriter.WriteHeader(c.status)
+		_, err := gz.Write(c.buf)
+		c.buf = nil
+		return err
+	}
+	c.ResponseWriter.WriteHeader(c.status)
+	if len(c.buf) > 0 {
+		_, err := c.ResponseWriter.Write(c.buf)
+		c.buf = nil
+		return err
+	}
+	return nil
+}
+
+// finish closes out the response: undecided (small) bodies go plain; a gzip
+// stream is closed and its writer returned to the pool.
+func (c *compressWriter) finish() {
+	if !c.decided {
+		_ = c.decide(false) //nolint:errcheck // response already ending
+		return
+	}
+	if c.gz != nil {
+		_ = c.gz.Close() //nolint:errcheck // response already ending
+		gz := c.gz
+		c.gz = nil
+		gz.Reset(nil)
+		gzipPool.Put(gz)
+	}
+}
+
+// Flush streams what is buffered so far. A flush before the threshold commits
+// to a plain response: the handler wants bytes on the wire now.
+func (c *compressWriter) Flush() {
+	if !c.decided {
+		_ = c.decide(false) //nolint:errcheck // best-effort flush
+	}
+	if c.gz != nil {
+		_ = c.gz.Flush() //nolint:errcheck // best-effort flush
+	}
+	if f, ok := c.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack hands the connection over untouched (WebSocket upgrades).
+func (c *compressWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := c.ResponseWriter.(http.Hijacker); ok {
+		c.decided = true
+		return hj.Hijack()
+	}
+	return nil, nil, errors.New("httputil: underlying ResponseWriter does not support hijacking")
+}
+
+// Unwrap exposes the underlying writer for http.ResponseController.
+func (c *compressWriter) Unwrap() http.ResponseWriter { return c.ResponseWriter }

--- a/pkg/httputil/compress_test.go
+++ b/pkg/httputil/compress_test.go
@@ -1,0 +1,88 @@
+// Package httputil pkg/httputil/compress_test.go c0-com-util
+package httputil
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func serve(t *testing.T, h http.Handler, gzipOK bool) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	if gzipOK {
+		r.Header.Set("Accept-Encoding", "gzip, deflate")
+	}
+	w := httptest.NewRecorder()
+	CompressMin(1024, gzip.DefaultCompression)(h).ServeHTTP(w, r)
+	return w
+}
+
+func TestCompressMin_SmallStaysPlain(t *testing.T) {
+	w := serve(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}), true)
+	if w.Code != http.StatusCreated || w.Header().Get("Content-Encoding") != "" || w.Body.String() != `{"ok":true}` {
+		t.Fatalf("small body must pass through: code=%d enc=%q body=%q", w.Code, w.Header().Get("Content-Encoding"), w.Body.String())
+	}
+}
+
+func TestCompressMin_LargeJSONIsGzipped(t *testing.T) {
+	body := []byte("[" + strings.Repeat(`{"pk":"0123456789abcdef"},`, 300) + `{"pk":"end"}]`)
+	w := serve(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Two writes: one below, one over the threshold.
+		_, _ = w.Write(body[:500])
+		_, _ = w.Write(body[500:])
+	}), true)
+	if w.Code != 200 || w.Header().Get("Content-Encoding") != "gzip" {
+		t.Fatalf("large json must be gzipped: code=%d enc=%q", w.Code, w.Header().Get("Content-Encoding"))
+	}
+	zr, err := gzip.NewReader(w.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := io.ReadAll(zr)
+	if !bytes.Equal(got, body) {
+		t.Fatalf("round trip mismatch: %d vs %d bytes", len(got), len(body))
+	}
+	if w.Body.Len() >= len(body) {
+		t.Fatalf("no compression gain: %d >= %d", w.Body.Len(), len(body))
+	}
+}
+
+func TestCompressMin_NonCompressibleAndNoAccept(t *testing.T) {
+	big := bytes.Repeat([]byte{0xff, 0x00, 0x7a}, 2000)
+	w := serve(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/wasm")
+		_, _ = w.Write(big)
+	}), true)
+	if w.Header().Get("Content-Encoding") != "" || !bytes.Equal(w.Body.Bytes(), big) {
+		t.Fatal("application/wasm must not be gzipped")
+	}
+	w = serve(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(bytes.Repeat([]byte("a"), 5000))
+	}), false)
+	if w.Header().Get("Content-Encoding") != "" || w.Body.Len() != 5000 {
+		t.Fatal("client without gzip must get plain bytes")
+	}
+}
+
+func TestCompressMin_EarlyFlushStaysPlain(t *testing.T) {
+	w := serve(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("first chunk\n"))
+		w.(http.Flusher).Flush()
+		_, _ = w.Write(bytes.Repeat([]byte("x"), 3000))
+	}), true)
+	if w.Header().Get("Content-Encoding") != "" || w.Body.Len() != len("first chunk\n")+3000 || !w.Flushed {
+		t.Fatalf("flushed stream must stay plain: enc=%q len=%d flushed=%v", w.Header().Get("Content-Encoding"), w.Body.Len(), w.Flushed)
+	}
+}


### PR DESCRIPTION
Every deployment service applied chi's blanket `Compress(5)`, so each one-entry answer, binding and health line went through a flate writer (~800 KB of state, pooled) for no wire saving. In today's profiles flate was 15% of dmsg-discovery's CPU on prod02, and the pooled writers were 110 MB of the address resolver's live heap on the TPD host (#4765 dropped it there).

`httputil.CompressMin(minBytes, level)` buffers a response up to the threshold and gzips only a larger text/JSON/XML/SVG body for a gzip-accepting client; small bodies, other content types, an early Flush and Hijack pass through untouched. dmsg-discovery, route-finder, service-discovery, transport-discovery, uptime-tracker, the config service and the monitor switch to it at 1 KiB. Tests cover small/large/non-compressible/no-accept/early-flush; all seven API packages' tests pass.