### PR TITLE
fix(dmsg): stop the server peer-mesh flap

### DIFF
--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -607,7 +607,7 @@ func (s *Server) maintainPeerConnection(ctx context.Context, peer PeerEntry) {
 		s.peerSessionsMx.Unlock()
 
 		log.Info("Connected to peer server.")
-		bo = 5 * time.Second // reset backoff on success
+		connectedAt := time.Now()
 
 		// Announce ourselves as a forwardable peer over this outbound
 		// link so we (and, for a non-public server, our clients) become
@@ -650,10 +650,32 @@ func (s *Server) maintainPeerConnection(ctx context.Context, peer PeerEntry) {
 		}
 		s.peerSessionsMx.Unlock()
 		ses.Close() //nolint:errcheck,gosec
-
-		log.Info("Peer session closed, will reconnect.")
+		// Pace the redial. A session that lived a while earned an immediate
+		// retry at the base delay; one that died young (the remote closed it
+		// right after the handshake) backs off, so a broken pair costs a
+		// handshake a minute rather than several a second.
+		if time.Since(connectedAt) >= peerSessionHealthyAfter {
+			bo = 5 * time.Second
+		}
+		log.WithField("lived", time.Since(connectedAt).Round(time.Second)).
+			WithField("redial_in", bo).Info("Peer session closed, will reconnect.")
+		select {
+		case <-time.After(bo):
+		case <-ctx.Done():
+			return
+		case <-s.done:
+			return
+		}
+		if time.Since(connectedAt) < peerSessionHealthyAfter && bo < time.Minute {
+			bo = time.Duration(float64(bo) * 1.5)
+		}
 	}
 }
+
+// peerSessionHealthyAfter is how long a peer session must have lived for its
+// close to be treated as ordinary (redial at the base delay) rather than as a
+// rejection worth backing off from.
+const peerSessionHealthyAfter = 30 * time.Second
 
 // isPeerPK returns true if the given PK is a known peer server.
 func (s *Server) isPeerPK(pk cipher.PubKey) bool {
@@ -748,6 +770,7 @@ func (s *Server) handleSession(conn net.Conn) {
 		return
 	}
 	log = log.WithField("remote_pk", dSes.RemotePK())
+	conn = dSes.GetConn() // may carry bytes buffered during the handshake
 
 	// Mark session as peer if remote PK is a known peer server.
 	if s.isPeerPK(dSes.RemotePK()) {

--- a/pkg/dmsg/dmsg/server_peer_mutual_test.go
+++ b/pkg/dmsg/dmsg/server_peer_mutual_test.go
@@ -1,0 +1,94 @@
+// Package dmsg pkg/dmsg/dmsg/server_peer_mutual_test.go c2-dmsg-core
+package dmsg
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// announceFailHook counts "Failed to announce as peer." warnings — the
+// symptom of the mutual-peer flap.
+type announceFailHook struct{ n atomic.Int64 }
+
+func (h *announceFailHook) Levels() []logrus.Level { return logrus.AllLevels }
+func (h *announceFailHook) Fire(e *logrus.Entry) error {
+	if e.Message == "Failed to announce as peer." {
+		h.n.Add(1)
+	}
+	return nil
+}
+
+// Two servers that each list the other as a peer must end up with a live,
+// acknowledged peer session in BOTH directions, with every announcement
+// accepted. Before the fix, the accepting side pre-marked the dialer as a
+// peer and then skipped its announcement, which fell through to the
+// StreamRequest parser, failed and closed the session; the dialer redialed
+// at once and the pair flapped (the old code still converged eventually
+// once one side's dial happened to land on a non-flapping window, which is
+// why the announce-failure count — not just eventual presence — is asserted).
+func TestPeerServers_MutualConfigAnnounceAccepted(t *testing.T) {
+	dc := disc.NewMock(0)
+	type srv struct {
+		pk   cipher.PubKey
+		sk   cipher.SecKey
+		lis  net.Listener
+		addr string
+	}
+	mk := func(name string) srv {
+		pk, sk := GenKeyPair(t, name)
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		return srv{pk: pk, sk: sk, lis: lis, addr: lis.Addr().String()}
+	}
+	a, b := mk("peer-a"), mk("peer-b")
+	confA := DefaultServerConfig()
+	confA.Peers = []PeerEntry{{PK: b.pk, Addr: b.addr}}
+	confB := DefaultServerConfig()
+	confB.Peers = []PeerEntry{{PK: a.pk, Addr: a.addr}}
+
+	hook := &announceFailHook{}
+	mkLog := func(name string) *logging.Logger {
+		l := logrus.New()
+		l.SetLevel(logrus.DebugLevel)
+		l.AddHook(hook)
+		return &logging.Logger{FieldLogger: l.WithField("_module", name)}
+	}
+	srvA := NewServer(a.pk, a.sk, dc, confA, nil)
+	srvA.SetLogger(mkLog("peer-a"))
+	srvB := NewServer(b.pk, b.sk, dc, confB, nil)
+	srvB.SetLogger(mkLog("peer-b"))
+	go func() { _ = srvA.Serve(a.lis, a.addr) }()            //nolint:errcheck
+	go func() { _ = srvB.Serve(b.lis, b.addr) }()            //nolint:errcheck
+	t.Cleanup(func() { _ = srvA.Close(); _ = srvB.Close() }) //nolint:errcheck
+
+	hasPeer := func(s *Server, pk cipher.PubKey) bool {
+		s.peerSessionsMx.Lock()
+		defer s.peerSessionsMx.Unlock()
+		ses, ok := s.peerSessions[pk]
+		return ok && ses != nil
+	}
+	require.Eventually(t, func() bool { return hasPeer(srvA, b.pk) && hasPeer(srvB, a.pk) },
+		15*time.Second, 100*time.Millisecond, "both sides must hold a peer session")
+
+	// Stability: the sessions must still be the same objects a few seconds on
+	// (no close-and-redial churn), and no announcement may have been refused.
+	snap := func(s *Server, pk cipher.PubKey) *SessionCommon {
+		s.peerSessionsMx.Lock()
+		defer s.peerSessionsMx.Unlock()
+		return s.peerSessions[pk]
+	}
+	ab, ba := snap(srvA, b.pk), snap(srvB, a.pk)
+	time.Sleep(3 * time.Second)
+	require.Same(t, ab, snap(srvA, b.pk), "A's session to B must not have been replaced")
+	require.Same(t, ba, snap(srvB, a.pk), "B's session to A must not have been replaced")
+	require.Zero(t, hook.n.Load(), "no peer announcement may fail between mutually configured servers")
+}

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -231,20 +231,31 @@ func (ss *ServerSession) serveStream(log logrus.FieldLogger, yStr io.ReadWriteCl
 	// Inbound peer announcement: when this server opts in, a dialing
 	// server's first stream may carry a signed PeerAnnounce that promotes
 	// this session to a forwardable peer — the reverse-path enabler for a
-	// non-public server. Checked before the StreamRequest path; a normal
-	// request decoded as an announce has a null/foreign SrcPK and fails
-	// Verify, so it falls through harmlessly.
-	if ss.entity.acceptPeerAnnouncements && !ss.isPeer {
-		if ann, aErr := obj.ObtainPeerAnnounce(); aErr == nil {
-			if ann.Verify(ss.rPK) == nil && ss.entity.peerAnnounceAllowed(ss.rPK) {
+	// non-public server. Gob is lenient, so an ordinary StreamRequest also
+	// decodes as an announce (SrcPK null); only an object that Verifies
+	// against the session's noise-authenticated PK is treated as one,
+	// everything else falls through to the StreamRequest path.
+	//
+	// This runs whether or not the session is already marked isPeer. With
+	// mutual configs both sides dial and both pre-mark the other as a peer;
+	// before, an announce on an already-peer session was skipped here, fell
+	// through to the StreamRequest parser, failed and closed the session.
+	// The dialer saw EOF, logged "Peer session closed, will reconnect" and
+	// redialed at once, so every mutually configured server pair flapped
+	// several times a second (thousands of noise handshakes a minute
+	// fleet-wide, 2026-09-10). The announce is idempotent: (re)register, ack.
+	if ss.entity.acceptPeerAnnouncements {
+		if ann, aErr := obj.ObtainPeerAnnounce(); aErr == nil && ann.Verify(ss.rPK) == nil {
+			accepted := ss.isPeer || ss.entity.peerAnnounceAllowed(ss.rPK)
+			if accepted {
 				ss.entity.promoteToPeer(ss.rPK, ss.SessionCommon)
-				resp := StreamResponse{ReqHash: obj.Hash(), Accepted: true}
-				ackObj, mErr := MakeSignedStreamResponse(&resp, ss.entity.LocalSK())
-				if mErr != nil {
-					return mErr
-				}
-				return ss.writeObject(yStr, ackObj)
 			}
+			resp := StreamResponse{ReqHash: obj.Hash(), Accepted: accepted}
+			ackObj, mErr := MakeSignedStreamResponse(&resp, ss.entity.LocalSK())
+			if mErr != nil {
+				return mErr
+			}
+			return ss.writeObject(yStr, ackObj)
 		}
 	}
 

--- a/pkg/dmsg/dmsg/session_common.go
+++ b/pkg/dmsg/dmsg/session_common.go
@@ -2,6 +2,7 @@
 package dmsg
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -225,8 +226,11 @@ func (sc *SessionCommon) initServer(entity *EntityCommon, conn net.Conn) error {
 	if err := rw.Handshake(HandshakeTimeout); err != nil {
 		return err
 	}
-	if rw.Buffered() > 0 {
-		return ErrSessionHandshakeExtraBytes
+	if early := rw.Unread(); len(early) > 0 {
+		// The initiator already sent session frames behind its final
+		// handshake message (a peering server announces itself immediately);
+		// keep them for the multiplexer instead of tearing the session down.
+		conn = &prefixedConn{Conn: conn, r: io.MultiReader(bytes.NewReader(early), conn)}
 	}
 
 	sc.entity = entity
@@ -498,3 +502,12 @@ func (sc *SessionCommon) Close() error {
 	sc.rMx.Unlock()
 	return err
 }
+
+// prefixedConn is a net.Conn whose reads first drain bytes that arrived
+// during the noise handshake but belong to the session (see initServer).
+type prefixedConn struct {
+	net.Conn
+	r io.Reader
+}
+
+func (c *prefixedConn) Read(p []byte) (int, error) { return c.r.Read(p) }

--- a/pkg/dmsg/dmsg/session_handshake_tail_test.go
+++ b/pkg/dmsg/dmsg/session_handshake_tail_test.go
@@ -1,0 +1,105 @@
+// Package dmsg pkg/dmsg/dmsg/session_handshake_tail_test.go c2-dmsg-core
+package dmsg
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/noise"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// holdLastConn passes the first write straight through and holds every later
+// write until Flush, so the initiator's final handshake message and the
+// session bytes behind it leave in ONE TCP write — the coalescing that a
+// peering server produces in the wild when it announces itself right after
+// the handshake.
+type holdLastConn struct {
+	net.Conn
+	mu     sync.Mutex
+	writes int
+	held   bytes.Buffer
+}
+
+func (c *holdLastConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.writes++
+	if c.writes == 1 {
+		return c.Conn.Write(p)
+	}
+	return c.held.Write(p)
+}
+
+func (c *holdLastConn) Flush() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, err := c.Conn.Write(c.held.Bytes())
+	c.held.Reset()
+	return err
+}
+
+// The responder must keep session bytes that arrive behind the initiator's
+// last handshake message instead of failing with "extra bytes received
+// during session handshake" (dmsg error 203) and dropping the connection.
+func TestServerSession_KeepsBytesBehindHandshake(t *testing.T) {
+	sPK, sSK := GenKeyPair(t, "server")
+	cPK, cSK := GenKeyPair(t, "client")
+	ent := &EntityCommon{}
+	ent.init(sPK, sSK, disc.NewMock(0), logging.MustGetLogger("hs-tail"), 0)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close() //nolint:errcheck
+
+	const payload = "session-bytes-behind-msg3"
+	got := make(chan string, 1)
+	errs := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			errs <- err
+			return
+		}
+		sc := new(SessionCommon)
+		if err := sc.initServer(ent, conn); err != nil {
+			errs <- err
+			return
+		}
+		buf := make([]byte, len(payload))
+		_ = sc.GetConn().SetReadDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
+		if _, err := io.ReadFull(sc.GetConn(), buf); err != nil {
+			errs <- err
+			return
+		}
+		got <- string(buf)
+	}()
+
+	raw, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer raw.Close() //nolint:errcheck
+	conn := &holdLastConn{Conn: raw}
+	ns, err := noise.New(noise.HandshakeXK, noise.Config{LocalPK: cPK, LocalSK: cSK, RemotePK: sPK, Initiator: true})
+	require.NoError(t, err)
+	rw := noise.NewReadWriter(conn, ns)
+	require.NoError(t, rw.Handshake(HandshakeTimeout)) // msg3 is now held
+	_, err = conn.Write([]byte(payload))               // rides behind msg3
+	require.NoError(t, err)
+	require.NoError(t, conn.Flush())
+
+	select {
+	case s := <-got:
+		require.Equal(t, payload, s)
+	case err := <-errs:
+		t.Fatalf("responder failed: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("responder did not deliver the trailing bytes")
+	}
+}

--- a/pkg/dmsg/noise/read_writer.go
+++ b/pkg/dmsg/noise/read_writer.go
@@ -351,3 +351,23 @@ func isTemp(err error) bool {
 	}
 	return false
 }
+
+// Unread returns a copy of the bytes the handshake reader has buffered past
+// the final handshake message. In an XK handshake the initiator may start
+// writing session frames the moment it has sent its last message, so those
+// frames can land in the responder's read buffer together with that message.
+// They are valid post-handshake data and must be handed to the session
+// transport, not discarded.
+func (rw *ReadWriter) Unread() []byte {
+	n := rw.rawInput.Buffered()
+	if n == 0 {
+		return nil
+	}
+	b, err := rw.rawInput.Peek(n)
+	if err != nil {
+		return nil
+	}
+	out := make([]byte, n)
+	copy(out, b)
+	return out
+}


### PR DESCRIPTION
Every mutually configured dmsg-server pair reconnected several times a second. On prod02's dmsg-server-7 the last 10 minutes of logs held 1726 "Started peer server session", 408 "Failed to announce as peer" and 324 "extra bytes received during session handshake". That churn is most of the servers' CPU (noise handshakes) and a large share of dmsg-discovery's entry GET load.

Two faults. The accepting side pre-marks a configured peer's session as a peer and then skipped its announcement, so the announce fell through to the StreamRequest parser, failed, and closed the session; the dialer redialed at once. Announcements are now handled on peer sessions too (idempotent: verify, register, ack), and non-announce objects still fall through, so client stream requests are unaffected. Separately, the responder failed the handshake whenever the initiator's first session frames arrived in the same read as its final handshake message, which a peering server does by design because it announces immediately. Those bytes are valid session data and are now handed to the multiplexer.

Redials of a session that lived under 30 s now back off up to a minute. Two new tests each fail on develop and pass here.
