### PR TITLE
perf(tpd): index bandwidth days with one SCAN instead of per-key probing

### DIFF
--- a/pkg/deployment/tpd/store/bandwidth_day_index.go
+++ b/pkg/deployment/tpd/store/bandwidth_day_index.go
@@ -1,0 +1,287 @@
+// Package store pkg/deployment/tpd/store/bandwidth_day_index.go c4-net-discovery
+package store
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// bwIndexMaxDays is the deepest day the index tracks: the 35-day TTL of the
+// bw:daily hashes, so nothing older can exist.
+const bwIndexMaxDays = 35
+
+// bwDayIndex records, per transport, which UTC days in the history window
+// have a bw:daily hash, learned from ONE SCAN of the keyspace, plus the edge
+// pair recovered for every such transport. It answers two questions the
+// metrics paths used to put to redis one key at a time: "which transports
+// carried bandwidth in the last N days but are no longer registered" and
+// "which of this transport's 30 daily hashes actually exist".
+type bwDayIndex struct {
+	// anchor is the UTC epoch day the scan ran on. Bit k of a transport's
+	// mask means a hash exists for day anchor-k.
+	anchor    int64
+	byID      map[uuid.UUID]uint64
+	edges     map[uuid.UUID][2]cipher.PubKey
+	scannedAt time.Time
+}
+
+func epochDay(t time.Time) int64 { return t.UTC().Unix() / 86400 }
+
+// dayBit maps a calendar day to its bit in the masks: (bit, true), or false
+// when the day is after the scan (nothing was known about it) or before the
+// window (nothing can exist).
+func (ix *bwDayIndex) dayBit(t time.Time) (uint, bool) {
+	k := ix.anchor - epochDay(t)
+	if k < 0 || k >= 64 {
+		return 0, false
+	}
+	return uint(k), true
+}
+
+// mayHave reports whether a bw:daily hash for id on day (now-offset) may
+// exist: true for today and yesterday, which may have gained one since the
+// scan (writes stamp the current UTC day of the writer, so a hash further back can
+// only be one the scan already saw), and otherwise only when the scan saw
+// it. A nil index knows nothing and answers true.
+func (ix *bwDayIndex) mayHave(id uuid.UUID, day time.Time, offset int) bool {
+	if ix == nil || offset <= 1 {
+		return true
+	}
+	k, ok := ix.dayBit(day)
+	return ok && ix.byID[id]&(1<<k) != 0
+}
+
+// fetchDays returns the day offsets d in [0,days) worth an HGETALL for id
+// (see mayHave).
+func (ix *bwDayIndex) fetchDays(id uuid.UUID, now time.Time, days int) []int {
+	out := make([]int, 0, 4)
+	for d := 0; d < days; d++ {
+		if ix.mayHave(id, now.AddDate(0, 0, -d), d) {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// windowMask is the bit set covering days now-0 .. now-(days-1).
+func (ix *bwDayIndex) windowMask(now time.Time, days int) uint64 {
+	var m uint64
+	for d := 0; d < days; d++ {
+		if k, ok := ix.dayBit(now.AddDate(0, 0, -d)); ok {
+			m |= 1 << k
+		}
+	}
+	return m
+}
+
+// parseBWDailyKey splits "<prefix><id>:<date>" into its transport id and day.
+func parseBWDailyKey(key, prefix string) (uuid.UUID, time.Time, bool) {
+	rest := strings.TrimPrefix(key, prefix)
+	i := strings.LastIndexByte(rest, ':')
+	if i < 0 {
+		return uuid.UUID{}, time.Time{}, false
+	}
+	id, err := uuid.Parse(rest[:i])
+	if err != nil {
+		return uuid.UUID{}, time.Time{}, false
+	}
+	t, err := time.Parse("2006-01-02", rest[i+1:])
+	if err != nil {
+		return uuid.UUID{}, time.Time{}, false
+	}
+	return id, t, true
+}
+
+// edgesFromDailyHash reconstructs a transport's edge public keys from a daily
+// bandwidth hash whose fields are "<edgePK>:sent" / "<edgePK>:recv". Only the
+// reporting edge(s) can be recovered this way; a single-reporter transport
+// leaves the second edge zero-valued (its bandwidth fields simply won't match,
+// contributing 0 — the total stays correct). False when the hash has only the
+// legacy combined "bandwidth" field.
+func edgesFromDailyHash(h map[string]string) ([2]cipher.PubKey, bool) {
+	var edges [2]cipher.PubKey
+	seenHex := make(map[string]bool)
+	var hexes []string
+	for field := range h {
+		var hex string
+		switch {
+		case strings.HasSuffix(field, ":sent"):
+			hex = strings.TrimSuffix(field, ":sent")
+		case strings.HasSuffix(field, ":recv"):
+			hex = strings.TrimSuffix(field, ":recv")
+		default:
+			continue
+		}
+		if hex == "" || seenHex[hex] {
+			continue
+		}
+		seenHex[hex] = true
+		hexes = append(hexes, hex)
+	}
+	if len(hexes) == 0 {
+		return edges, false
+	}
+	sort.Strings(hexes)
+	n := 0
+	for _, hex := range hexes {
+		if n >= 2 {
+			break
+		}
+		var pk cipher.PubKey
+		if err := pk.UnmarshalText([]byte(hex)); err != nil {
+			continue
+		}
+		edges[n] = pk
+		n++
+	}
+	return edges, n > 0
+}
+
+// bandwidthIndex returns the cached index, rebuilding it after bwIndexTTL.
+func (s *redisStore) bandwidthIndex(ctx context.Context) *bwDayIndex {
+	if ix, ok := s.bwIndex.get(); ok {
+		return ix
+	}
+	ix := s.scanBandwidthIndex(ctx)
+	s.bwIndex.put(ix)
+	return ix
+}
+
+// scanBatch bounds one pipeline in the edge-recovery pass.
+const scanBatch = 1000
+
+// scanBandwidthIndex walks the bw:daily:* keyspace once and recovers the edge
+// pair of every transport it finds: from the persisted bw:edges:<id> value
+// (pipelined GETs), falling back to the field names of a daily hash the scan
+// saw for transports registered before that value existed.
+func (s *redisStore) scanBandwidthIndex(ctx context.Context) *bwDayIndex {
+	started := time.Now()
+	now := started.UTC()
+	ix := &bwDayIndex{
+		anchor:    epochDay(now),
+		byID:      make(map[uuid.UUID]uint64),
+		edges:     make(map[uuid.UUID][2]cipher.PubKey),
+		scannedAt: started,
+	}
+	prefix := serviceName + ":bw:daily:"
+	iter := s.client.Scan(ctx, 0, prefix+"*", 10000).Iterator()
+	for iter.Next(ctx) {
+		id, day, ok := parseBWDailyKey(iter.Val(), prefix)
+		if !ok {
+			continue
+		}
+		if k, ok := ix.dayBit(day); ok {
+			ix.byID[id] |= 1 << k
+		}
+	}
+	if err := iter.Err(); err != nil {
+		s.log.WithError(err).Warn("bandwidth index scan failed; index is partial")
+	}
+
+	ids := make([]uuid.UUID, 0, len(ix.byID))
+	for id := range ix.byID {
+		ids = append(ids, id)
+	}
+	var fallback []uuid.UUID
+	for start := 0; start < len(ids); start += scanBatch {
+		end := start + scanBatch
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		pipe := s.client.Pipeline()
+		cmds := make([]*redis.StringCmd, len(batch))
+		for i, id := range batch {
+			cmds[i] = pipe.Get(ctx, s.bandwidthEdgesKey(id.String()))
+		}
+		_, _ = pipe.Exec(ctx) //nolint:errcheck // per-command results below
+		for i, id := range batch {
+			if pair, err := cmds[i].Result(); err == nil {
+				if e, ok := parseBandwidthEdgePair(pair); ok {
+					ix.edges[id] = e
+					continue
+				}
+			}
+			fallback = append(fallback, id)
+		}
+	}
+	// Legacy transports without a persisted pair: read the newest daily hash
+	// the scan saw for each, pipelined the same way.
+	for start := 0; start < len(fallback); start += scanBatch {
+		end := start + scanBatch
+		if end > len(fallback) {
+			end = len(fallback)
+		}
+		batch := fallback[start:end]
+		pipe := s.client.Pipeline()
+		cmds := make([]*redis.StringStringMapCmd, len(batch))
+		for i, id := range batch {
+			day := now.AddDate(0, 0, -newestBit(ix.byID[id]))
+			cmds[i] = pipe.HGetAll(ctx, s.bandwidthDailyKey(id.String(), day))
+		}
+		_, _ = pipe.Exec(ctx) //nolint:errcheck // per-command results below
+		for i, id := range batch {
+			if h, err := cmds[i].Result(); err == nil {
+				if e, ok := edgesFromDailyHash(h); ok {
+					ix.edges[id] = e
+				}
+			}
+		}
+	}
+	s.log.WithField("transports", len(ix.byID)).WithField("edges", len(ix.edges)).
+		WithField("took", time.Since(started).Round(time.Millisecond)).
+		Debug("Rebuilt bandwidth day index")
+	return ix
+}
+
+// newestBit is the lowest set bit's position: the most recent day with data.
+func newestBit(mask uint64) int {
+	for k := 0; k < 64; k++ {
+		if mask&(1<<k) != 0 {
+			return k
+		}
+	}
+	return 0
+}
+
+// expiredTransportEntries returns synthetic transport.Entry values for
+// transports that have daily-bandwidth records within the last `days` days but
+// are no longer in the registered set. The returned set marks those IDs so
+// buildTransportMetrics reports them Live=false. Their bw:daily:* keys have a
+// 35-day TTL and outlive the ~5-minute registration TTL, so the bandwidth they
+// carried keeps counting toward the metrics and rewards after the transport
+// drops offline. The `registered` filter is applied FRESH on every call so a
+// transport that just (re)registered is dropped at once rather than being
+// reported as expired for up to the index TTL.
+func (s *redisStore) expiredTransportEntries(ctx context.Context, registered map[uuid.UUID]bool, days int) ([]*transport.Entry, map[uuid.UUID]bool) {
+	if days <= 0 || days > bwIndexMaxDays {
+		days = bwIndexMaxDays
+	}
+	ix := s.bandwidthIndex(ctx)
+	mask := ix.windowMask(time.Now().UTC(), days)
+	expiredIDs := make(map[uuid.UUID]bool)
+	var entries []*transport.Entry
+	for id, bits := range ix.byID {
+		if bits&mask == 0 || registered[id] {
+			continue
+		}
+		edges, ok := ix.edges[id]
+		if !ok {
+			continue // only legacy/combined data, no per-edge fields — skip
+		}
+		entries = append(entries, &transport.Entry{ID: id, Edges: edges})
+		expiredIDs[id] = true
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	return entries, expiredIDs
+}

--- a/pkg/deployment/tpd/store/bandwidth_day_index_test.go
+++ b/pkg/deployment/tpd/store/bandwidth_day_index_test.go
@@ -1,0 +1,99 @@
+// Package store pkg/deployment/tpd/store/bandwidth_day_index_test.go c4-net-discovery
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestParseBWDailyKey(t *testing.T) {
+	prefix := serviceName + ":bw:daily:"
+	id := uuid.New()
+	gotID, day, ok := parseBWDailyKey(prefix+id.String()+":2026-09-10", prefix)
+	require.True(t, ok)
+	require.Equal(t, id, gotID)
+	require.Equal(t, "2026-09-10", day.Format("2006-01-02"))
+
+	for _, bad := range []string{prefix + "nope", prefix + id.String() + ":yesterday", prefix + "x:2026-09-10"} {
+		_, _, ok := parseBWDailyKey(bad, prefix)
+		require.False(t, ok, bad)
+	}
+}
+
+func testIndex(anchor time.Time) *bwDayIndex {
+	return &bwDayIndex{
+		anchor:    epochDay(anchor),
+		byID:      map[uuid.UUID]uint64{},
+		edges:     map[uuid.UUID][2]cipher.PubKey{},
+		scannedAt: anchor,
+	}
+}
+
+// A nil index knows nothing: every day is fetched, as before the index existed.
+func TestBWDayIndex_NilFetchesEverything(t *testing.T) {
+	var ix *bwDayIndex
+	require.Equal(t, []int{0, 1, 2, 3, 4}, ix.fetchDays(uuid.New(), time.Now(), 5))
+}
+
+// Only days the scan saw are fetched, plus today and yesterday, which may
+// have gained a hash since the scan. Unknown transports get just those two.
+func TestBWDayIndex_FetchDays(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	ix := testIndex(now)
+	known := uuid.New()
+	ix.byID[known] = 1<<5 | 1<<12 | 1<<29 // data 5, 12 and 29 days ago
+	require.Equal(t, []int{0, 1, 5, 12, 29}, ix.fetchDays(known, now, 30))
+	require.Equal(t, []int{0, 1, 5, 12}, ix.fetchDays(known, now, 20))
+	require.Equal(t, []int{0}, ix.fetchDays(known, now, 1))
+	require.Equal(t, []int{0, 1}, ix.fetchDays(uuid.New(), now, 30))
+}
+
+// After a UTC rollover the scan's "today" is the caller's "yesterday": bits
+// must shift with the calendar, not with the offset.
+func TestBWDayIndex_Rollover(t *testing.T) {
+	scanned := time.Date(2026, 9, 10, 23, 58, 0, 0, time.UTC)
+	ix := testIndex(scanned)
+	id := uuid.New()
+	ix.byID[id] = 1 << 3 // data on 2026-09-07
+	later := time.Date(2026, 9, 11, 0, 2, 0, 0, time.UTC)
+	require.Equal(t, []int{0, 1, 4}, ix.fetchDays(id, later, 30), "09-07 is now 4 days back")
+
+	// The window mask likewise follows the calendar: a 3-day window from the
+	// 11th covers the 9th..11th and must not match data on the 7th.
+	require.Zero(t, ix.byID[id]&ix.windowMask(later, 3))
+	require.NotZero(t, ix.byID[id]&ix.windowMask(later, 5))
+}
+
+func TestBWDayIndex_DayBitBounds(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	ix := testIndex(now)
+	_, ok := ix.dayBit(now.AddDate(0, 0, 1))
+	require.False(t, ok, "a day after the scan has no bit")
+	_, ok = ix.dayBit(now.AddDate(0, 0, -64))
+	require.False(t, ok, "beyond the mask width has no bit")
+	k, ok := ix.dayBit(now.AddDate(0, 0, -63))
+	require.True(t, ok)
+	require.Equal(t, uint(63), k)
+}
+
+func TestNewestBit(t *testing.T) {
+	require.Equal(t, 0, newestBit(0))
+	require.Equal(t, 0, newestBit(1))
+	require.Equal(t, 3, newestBit(1<<3|1<<9))
+}
+
+func TestEdgesFromDailyHash(t *testing.T) {
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	edges, ok := edgesFromDailyHash(map[string]string{a.Hex() + ":sent": "1", a.Hex() + ":recv": "2", b.Hex() + ":sent": "3"})
+	require.True(t, ok)
+	require.ElementsMatch(t, []cipher.PubKey{a, b}, edges[:])
+
+	_, ok = edgesFromDailyHash(map[string]string{"bandwidth": "10"})
+	require.False(t, ok, "legacy combined hash has no edges")
+}

--- a/pkg/deployment/tpd/store/expired_entries_cache.go
+++ b/pkg/deployment/tpd/store/expired_entries_cache.go
@@ -4,78 +4,65 @@ package store
 import (
 	"sync"
 	"time"
-
-	"github.com/google/uuid"
-
-	"github.com/skycoin/skywire/pkg/transport"
 )
 
-// expiredEntriesCacheTTL bounds how long the SCAN-derived expired-transport
-// candidate set is reused before it is recomputed. The expired set changes
-// on a ~daily cadence (a transport ages out of the registered set), not
-// every minute, so a few-minute TTL is safe: a newly-EXPIRED transport may
-// appear up to one TTL late, which is acceptable.
+// bwIndexTTL bounds how long one SCAN-derived bandwidth day index is reused
+// before it is rebuilt. Which (transport, day) hashes exist changes on the
+// cadence of a transport's first bandwidth report of a day, and the index
+// treats today and yesterday as "may have appeared since the scan" anyway
+// (see bwDayIndex.fetchDays), so a few-minute TTL costs nothing in
+// correctness: only a transport newly aged out of the registered set can
+// show up late, by at most one TTL.
 //
-// This cache exists because the CXO metrics publisher
-// (pkg/deployment/tpd/api/cxo_metrics_publisher.go) turned
-// expiredTransportEntries from a low-frequency path (rewards dashboard /
-// daily reward calc) into a per-60s path: the publisher calls
-// GetAllTransportMetrics on a ticker (1 day every 60s, the full 30-day window
-// every 30m), and each call SCANned the bw:daily:*:<date> keyspace once per
-// day in the window (up to 35 passes) over a ~13k-transport keyspace, then
-// recovered edges per candidate.
-// That put expiredTransportEntries at ~12% of TPD CPU with redis I/O
-// dominating. Memoizing the registered-INDEPENDENT SCAN result collapses the
-// repeated ticks onto one SCAN per TTL per window.
-const expiredEntriesCacheTTL = 5 * time.Minute
+// The index exists because the CXO metrics publisher
+// (pkg/deployment/tpd/api/cxo_metrics_publisher.go) calls
+// GetAllTransportMetrics on a ticker (1 day every 60 s, the full 30-day
+// window every 30 min). Before it, every full cycle SCANned the whole
+// keyspace once per day in the window (35 passes over ~3M keys, ~70 s of
+// redis CPU), fetched each candidate's edge pair with an unpipelined GET
+// (~270k round trips) and then HGETALLed every (transport × day) key of the
+// window whether or not it existed — 8.4M HGETALLs of which 92% missed.
+const bwIndexTTL = 5 * time.Minute
 
-// expiredEntriesCache memoizes, per day-window, the raw expired-transport
-// candidate set derived purely from the redis SCAN + recoverBandwidthEdges.
-// It deliberately does NOT bake in the caller's `registered` filter: that
-// filter is applied fresh on every call (see expiredTransportEntries) so a
-// transport that just (re)registered is dropped immediately and never counted
-// as expired for up to the TTL. Keyed by `days` because the publisher's
-// current-day and full-window queries scan different date ranges.
-type expiredEntriesCache struct {
-	mu     sync.Mutex
-	ttl    time.Duration
-	byDays map[int]expiredEntriesCacheEntry
+// bwIndexCache memoizes the registered-INDEPENDENT bandwidth day index. The
+// caller's `registered` filter is applied fresh on every use (see
+// expiredTransportEntries) so a transport that just (re)registered is dropped
+// immediately and never reported as expired for up to the TTL.
+type bwIndexCache struct {
+	mu  sync.Mutex
+	ttl time.Duration
+	ix  *bwDayIndex
 }
 
-type expiredEntriesCacheEntry struct {
-	entries    []*transport.Entry
-	expiredIDs map[uuid.UUID]bool
-	cachedAt   time.Time
-}
-
-func newExpiredEntriesCache(ttl time.Duration) *expiredEntriesCache {
+func newBWIndexCache(ttl time.Duration) *bwIndexCache {
 	if ttl <= 0 {
-		ttl = expiredEntriesCacheTTL
+		ttl = bwIndexTTL
 	}
-	return &expiredEntriesCache{ttl: ttl, byDays: make(map[int]expiredEntriesCacheEntry)}
+	return &bwIndexCache{ttl: ttl}
 }
 
-// get returns the cached raw candidate set for the window if present and
-// unexpired. The returned slice/map are the cache's own backing storage —
-// callers must treat them as read-only.
-func (c *expiredEntriesCache) get(days int) ([]*transport.Entry, map[uuid.UUID]bool, bool) {
+// get returns the cached index if present and unexpired.
+func (c *bwIndexCache) get() (*bwDayIndex, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	e, ok := c.byDays[days]
-	if !ok || time.Since(e.cachedAt) > c.ttl {
-		return nil, nil, false
+	if c.ix == nil || time.Since(c.ix.scannedAt) > c.ttl {
+		return nil, false
 	}
-	return e.entries, e.expiredIDs, true
+	return c.ix, true
 }
 
-// put stores the raw candidate set for the window, stamped with the current
-// time so get can treat entries older than the TTL as stale.
-func (c *expiredEntriesCache) put(days int, entries []*transport.Entry, expiredIDs map[uuid.UUID]bool) {
+// peek returns whatever index is cached, stale or not, or nil. Readers that
+// only use it to skip keys the scan proved absent can tolerate a stale index:
+// a key can only appear for today (or yesterday across a UTC rollover), and
+// fetchDays always includes those two days.
+func (c *bwIndexCache) peek() *bwDayIndex {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.byDays[days] = expiredEntriesCacheEntry{
-		entries:    entries,
-		expiredIDs: expiredIDs,
-		cachedAt:   time.Now(),
-	}
+	return c.ix
+}
+
+func (c *bwIndexCache) put(ix *bwDayIndex) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ix = ix
 }

--- a/pkg/deployment/tpd/store/redis_metrics.go
+++ b/pkg/deployment/tpd/store/redis_metrics.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -178,11 +177,15 @@ func (s *redisStore) GetNetworkMetrics(ctx context.Context, query MetricsQuery) 
 	var bwKeys []bwKey
 	var bwResults []*redis.StringStringMapCmd
 
+	ix := s.bwIndex.peek()
 	pipe := s.client.Pipeline()
 	for d := 0; d < days; d++ {
 		t := now.AddDate(0, 0, -d)
 		dateStr := t.Format("2006-01-02")
 		for i, entry := range entries {
+			if !ix.mayHave(entry.ID, t, d) {
+				continue
+			}
 			key := s.bandwidthDailyKey(entry.ID.String(), t)
 			bwKeys = append(bwKeys, bwKey{
 				dayIdx:   d,
@@ -428,93 +431,6 @@ func (s *redisStore) GetAllTransportMetrics(ctx context.Context, query MetricsQu
 	return s.buildTransportMetrics(ctx, entries, expiredIDs, query)
 }
 
-// expiredTransportEntries returns synthetic transport.Entry values for
-// transports that have daily-bandwidth records within the last `days` days but
-// are no longer in the registered set. The returned set marks those IDs so
-// buildTransportMetrics reports them Live=false. Edges are recovered from the
-// daily-hash field names (see recoverBandwidthEdges).
-//
-// The expensive part — the multi-day bw:daily:*:<date> SCAN plus per-candidate
-// edge recovery — is memoized by expiredEntriesCache (see scanExpiredCandidates
-// and expired_entries_cache.go). That memoized set is deliberately
-// registered-INDEPENDENT: the `registered` filter is applied FRESH here on
-// every call so a transport that just (re)registered is dropped immediately
-// rather than being wrongly reported as expired for up to the cache TTL.
-func (s *redisStore) expiredTransportEntries(ctx context.Context, registered map[uuid.UUID]bool, days int) ([]*transport.Entry, map[uuid.UUID]bool) {
-	if days <= 0 || days > 35 {
-		days = 35
-	}
-
-	rawEntries, rawIDs, ok := s.expiredCache.get(days)
-	if !ok {
-		rawEntries, rawIDs = s.scanExpiredCandidates(ctx, days)
-		s.expiredCache.put(days, rawEntries, rawIDs)
-	}
-	if len(rawEntries) == 0 {
-		return nil, nil
-	}
-
-	// Apply the registered filter FRESH on every call (hit or miss). Caching
-	// the post-filter result would let a newly-registered transport keep
-	// showing up as expired (and get double-counted) for up to the TTL; a
-	// newly-expired one appearing up to a TTL late is the acceptable trade.
-	expiredIDs := make(map[uuid.UUID]bool, len(rawIDs))
-	entries := make([]*transport.Entry, 0, len(rawEntries))
-	for _, e := range rawEntries {
-		if registered[e.ID] {
-			continue
-		}
-		entries = append(entries, e)
-		expiredIDs[e.ID] = true
-	}
-	if len(entries) == 0 {
-		return nil, nil
-	}
-	return entries, expiredIDs
-}
-
-// scanExpiredCandidates performs the raw, registered-INDEPENDENT SCAN of the
-// bw:daily:*:<date> keyspace across the window and recovers edges for every
-// candidate found. Its result is what expiredEntriesCache memoizes; the
-// caller's `registered` filter is layered on top afterwards (see
-// expiredTransportEntries). It SCANs the keyspace once per day in the window,
-// mirroring the existing BackupAndCleanOldBandwidth SCAN pattern.
-func (s *redisStore) scanExpiredCandidates(ctx context.Context, days int) ([]*transport.Entry, map[uuid.UUID]bool) {
-	now := time.Now().UTC()
-	prefix := serviceName + ":bw:daily:"
-
-	seen := make(map[uuid.UUID]bool)
-	for d := 0; d < days; d++ {
-		dateStr := now.AddDate(0, 0, -d).Format("2006-01-02")
-		pattern := prefix + "*:" + dateStr
-		iter := s.client.Scan(ctx, 0, pattern, 10000).Iterator()
-		for iter.Next(ctx) {
-			// key = transport-discovery:bw:daily:<id>:<date>
-			rest := strings.TrimSuffix(strings.TrimPrefix(iter.Val(), prefix), ":"+dateStr)
-			id, err := uuid.Parse(rest)
-			if err != nil || seen[id] {
-				continue
-			}
-			seen[id] = true
-		}
-	}
-	if len(seen) == 0 {
-		return nil, nil
-	}
-
-	expiredIDs := make(map[uuid.UUID]bool, len(seen))
-	var entries []*transport.Entry
-	for id := range seen {
-		edges, ok := s.recoverBandwidthEdges(ctx, id, now, days)
-		if !ok {
-			continue // only legacy/combined data, no per-edge fields — skip
-		}
-		entries = append(entries, &transport.Entry{ID: id, Edges: edges})
-		expiredIDs[id] = true
-	}
-	return entries, expiredIDs
-}
-
 // parseBandwidthEdgePair parses the "<edge0hex>,<edge1hex>" value written by
 // bandwidthEdgesKey at registration back into an edge pair (kept in entry
 // order, which the transport.Entry contract already sorts ascending).
@@ -530,72 +446,6 @@ func parseBandwidthEdgePair(v string) ([2]cipher.PubKey, bool) {
 		}
 	}
 	return edges, true
-}
-
-// recoverBandwidthEdges reconstructs an (offline) transport's edge public keys
-// from its most recent daily-bandwidth hash, whose fields are
-// "<edgePK>:sent" / "<edgePK>:recv". Returns false if no day in the window has
-// per-edge fields. Edges are sorted ascending per the transport.Entry contract;
-// a single-reporter transport leaves the second edge zero-valued (its bandwidth
-// fields simply won't match, contributing 0 — the total stays correct).
-func (s *redisStore) recoverBandwidthEdges(ctx context.Context, id uuid.UUID, now time.Time, days int) ([2]cipher.PubKey, bool) {
-	var edges [2]cipher.PubKey
-
-	// Prefer the real edge pair persisted at registration (bandwidthEdgesKey,
-	// 35-day TTL). It keeps the counterparty identifiable even when only one
-	// edge ever published bandwidth — the field-name reconstruction below can
-	// only recover the reporting edge, collapsing the other to the zero PK
-	// (which the reward calc cannot credit).
-	if pair, err := s.client.Get(ctx, s.bandwidthEdgesKey(id.String())).Result(); err == nil {
-		if e, ok := parseBandwidthEdgePair(pair); ok {
-			return e, true
-		}
-	}
-
-	for d := 0; d < days; d++ {
-		h, err := s.client.HGetAll(ctx, s.bandwidthDailyKey(id.String(), now.AddDate(0, 0, -d))).Result()
-		if err != nil || len(h) == 0 {
-			continue
-		}
-		seenHex := make(map[string]bool)
-		var hexes []string
-		for field := range h {
-			var hex string
-			switch {
-			case strings.HasSuffix(field, ":sent"):
-				hex = strings.TrimSuffix(field, ":sent")
-			case strings.HasSuffix(field, ":recv"):
-				hex = strings.TrimSuffix(field, ":recv")
-			default:
-				continue
-			}
-			if hex == "" || seenHex[hex] {
-				continue
-			}
-			seenHex[hex] = true
-			hexes = append(hexes, hex)
-		}
-		if len(hexes) == 0 {
-			continue
-		}
-		sort.Strings(hexes)
-		n := 0
-		for _, hex := range hexes {
-			if n >= 2 {
-				break
-			}
-			var pk cipher.PubKey
-			if err := pk.UnmarshalText([]byte(hex)); err != nil {
-				continue
-			}
-			edges[n] = pk
-			n++
-		}
-		if n > 0 {
-			return edges, true
-		}
-	}
-	return edges, false
 }
 
 // GetTransportMetricsByIDs returns metrics for specific transports.
@@ -725,13 +575,17 @@ func (s *redisStore) buildTransportMetrics(ctx context.Context, entries []*trans
 		for d := 0; d < days; d++ {
 			dateStrs[d] = now.AddDate(0, 0, -d).Format("2006-01-02")
 		}
-		n := len(filtered) * days
+		ix := s.bwIndex.peek()
+		n := len(filtered) * 2
+		if ix == nil {
+			n = len(filtered) * days
+		}
 		bwKeys = make([]bwKey, 0, n)
 		bwResults = make([]*redis.StringStringMapCmd, 0, n)
 		pipe := s.client.Pipeline()
 		for i := range filtered {
 			idStr := idStrs[i]
-			for d := 0; d < days; d++ {
+			for _, d := range ix.fetchDays(filtered[i].entry.ID, now, days) {
 				// Same key as bandwidthDailyKey ("<svc>:bw:daily:<id>:<date>")
 				// but built by concat (single alloc, no fmt reflection) with the
 				// id + date precomputed above rather than re-formatting per day.

--- a/pkg/deployment/tpd/store/redis_store.go
+++ b/pkg/deployment/tpd/store/redis_store.go
@@ -73,13 +73,13 @@ type ThroughputRecord struct {
 const throughputTTL = latencyTTL
 
 type redisStore struct {
-	client       *redis.Client
-	ttl          time.Duration
-	log          *logging.Logger
-	pkCache      *pubKeyCache
-	edgeCache    *edgeEntriesCache
-	allTpsCache  *allTransportsCache
-	expiredCache *expiredEntriesCache
+	client      *redis.Client
+	ttl         time.Duration
+	log         *logging.Logger
+	pkCache     *pubKeyCache
+	edgeCache   *edgeEntriesCache
+	allTpsCache *allTransportsCache
+	bwIndex     *bwIndexCache
 }
 
 func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl time.Duration, logger *logging.Logger) (*redisStore, error) {
@@ -114,13 +114,13 @@ func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl
 	}
 
 	return &redisStore{
-		client:       redisCl,
-		ttl:          ttl,
-		log:          logger,
-		pkCache:      newPubKeyCache(defaultPubKeyCacheCap),
-		edgeCache:    newEdgeEntriesCache(defaultEdgeEntriesCacheCap, defaultEdgeEntriesCacheTTL),
-		allTpsCache:  newAllTransportsCache(defaultAllTransportsCacheTTL),
-		expiredCache: newExpiredEntriesCache(expiredEntriesCacheTTL),
+		client:      redisCl,
+		ttl:         ttl,
+		log:         logger,
+		pkCache:     newPubKeyCache(defaultPubKeyCacheCap),
+		edgeCache:   newEdgeEntriesCache(defaultEdgeEntriesCacheCap, defaultEdgeEntriesCacheTTL),
+		allTpsCache: newAllTransportsCache(defaultAllTransportsCacheTTL),
+		bwIndex:     newBWIndexCache(bwIndexTTL),
 	}, nil
 }
 func (s *redisStore) Close() {


### PR DESCRIPTION
On the TPD host redis sits at 64% CPU and transport-discovery at 108%, nearly all of it redis syscalls. The metrics publisher's full cycle SCANned the ~3M-key keyspace once per day of the window (35 passes, ~70 s of redis CPU), fetched each of ~270k expired candidates' edge pair with an unpipelined GET, then HGETALLed every (transport × day) hash of the 30-day window: 8.4M per cycle, 92% misses (redis commandstats after a cold start: 10.6M HGETALL in 203 s).

One SCAN now builds a per-transport bitmask of the days that have a hash, plus the edge pair via pipelined GETs. Expired candidates come from the index, and the metrics paths fetch only the days the scan saw plus today and yesterday, the only days that can gain a hash after the scan. Results are unchanged; a full cycle drops to about 680k existing hashes plus two probes per transport.
