### PR TITLE
perf(geoip): memory-map the embedded database instead of inflating it on the heap

### DIFF
--- a/pkg/geoip/geoip_embedded.go
+++ b/pkg/geoip/geoip_embedded.go
@@ -72,13 +72,20 @@ var (
 func Embedded() bool { return len(embeddedGz) > 0 }
 
 // Shared returns the process-wide reader over the embedded database, opening
-// it on first use. Inflating the ~30 MB gzip costs ~60 MB of heap for the life
-// of the process, so callers keep this lazy: a visor that never answers a geo
-// query never pays it (every visor and dmsg server used to open it at start).
-// The reader is safe for concurrent use and is never closed.
+// it on first use. Callers keep this lazy: a visor that never answers a geo
+// query never pays for it. The reader is memory-mapped over a cached inflated
+// copy (see geoip_mapped.go) so the ~60 MB database stays out of the Go heap;
+// only if that cache cannot be written does it fall back to inflating into
+// memory. The reader is safe for concurrent use and is never closed.
 func Shared() (*geoip2.Reader, error) {
 	sharedOnce.Do(func() {
+		if r, err := openMapped(mappedDir()); err == nil {
+			shared = r
+			return
+		}
 		shared, sharedErr = OpenEmbedded()
 	})
 	return shared, sharedErr
 }
+
+func bytesReader(b []byte) io.Reader { return bytes.NewReader(b) }

--- a/pkg/geoip/geoip_mapped.go
+++ b/pkg/geoip/geoip_mapped.go
@@ -1,0 +1,108 @@
+//go:build !mobile && !js
+
+// Package geoip pkg/geoip/geoip_mapped.go c0-com-util
+package geoip
+
+import (
+	"compress/gzip"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/oschwald/geoip2-golang/v2"
+)
+
+// The inflated database is ~60 MB. Held as a heap []byte it is 60 MB of
+// resident, GC-accounted memory in every visor and dmsg server for the life
+// of the process, and under a GOMEMLIMIT it eats that much of the budget
+// and drives GC cycles for a blob that never changes. Written once to a
+// cache file and memory-mapped instead, its pages are file-backed: the
+// kernel shares them between processes on the host, evicts them under
+// pressure, and the Go runtime never sees them. Decompression streams
+// straight to the file, so the heap never holds the whole database.
+
+// mappedDir is the directory the inflated database is cached in: the
+// user's cache directory, else the system temp directory.
+func mappedDir() string {
+	if d, err := os.UserCacheDir(); err == nil && d != "" {
+		return filepath.Join(d, "skywire")
+	}
+	return filepath.Join(os.TempDir(), "skywire-geoip")
+}
+
+// gzTrailer reads the CRC32 and uncompressed size a gzip member ends with;
+// together they identify the database version and validate a cached copy
+// without inflating anything.
+func gzTrailer(gz []byte) (crc uint32, size int64, ok bool) {
+	if len(gz) < 8 {
+		return 0, 0, false
+	}
+	t := gz[len(gz)-8:]
+	return binary.LittleEndian.Uint32(t[:4]), int64(binary.LittleEndian.Uint32(t[4:])), true
+}
+
+// mappedPath is the cache file for this build's database.
+func mappedPath(dir string, crc uint32) string {
+	return filepath.Join(dir, fmt.Sprintf("GeoLite2-City-%08x.mmdb", crc))
+}
+
+// openMapped returns a reader memory-mapped over a cached inflated copy of
+// the embedded database under dir, writing the copy first if it is missing
+// or the wrong size. The write goes to a temp file renamed into place, so a
+// concurrent process (visor and dmsg server on one host) sees either no
+// file or a complete one.
+func openMapped(dir string) (*geoip2.Reader, error) {
+	crc, size, ok := gzTrailer(embeddedGz)
+	if !ok {
+		return nil, fmt.Errorf("geoip: embedded database is not a gzip member")
+	}
+	path := mappedPath(dir, crc)
+	if fi, err := os.Stat(path); err != nil || fi.Size() != size {
+		if err := inflateTo(dir, path, size); err != nil {
+			return nil, err
+		}
+	}
+	return geoip2.Open(path)
+}
+
+func inflateTo(dir, path string, want int64) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("geoip: cache dir: %w", err)
+	}
+	f, err := os.CreateTemp(dir, "GeoLite2-City-*.tmp")
+	if err != nil {
+		return fmt.Errorf("geoip: cache file: %w", err)
+	}
+	tmp := f.Name()
+	defer os.Remove(tmp) //nolint:errcheck // gone after a successful rename
+	zr, err := newEmbeddedGzipReader()
+	if err != nil {
+		f.Close() //nolint:errcheck,gosec
+		return err
+	}
+	n, err := io.Copy(f, zr) //nolint:gosec // G110: the source is the build's own embedded blob, not remote input
+	if cerr := f.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
+		return fmt.Errorf("geoip: inflate to cache: %w", err)
+	}
+	if n != want {
+		return fmt.Errorf("geoip: inflated %d bytes, gzip trailer says %d", n, want)
+	}
+	_ = os.Remove(path) //nolint:errcheck // Windows cannot rename over an existing (stale) file
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("geoip: publish cache file: %w", err)
+	}
+	return nil
+}
+
+func newEmbeddedGzipReader() (*gzip.Reader, error) {
+	zr, err := gzip.NewReader(bytesReader(embeddedGz))
+	if err != nil {
+		return nil, fmt.Errorf("geoip: embedded database: %w", err)
+	}
+	return zr, nil
+}

--- a/pkg/geoip/geoip_mapped_test.go
+++ b/pkg/geoip/geoip_mapped_test.go
@@ -1,0 +1,91 @@
+//go:build !mobile && !js
+
+// Package geoip pkg/geoip/geoip_mapped_test.go c0-com-util
+package geoip
+
+import (
+	"net/netip"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The mapped reader must answer exactly like the in-memory one, and reuse the
+// cache file it wrote instead of inflating again.
+func TestOpenMapped_WritesCacheOnceAndMatchesEmbedded(t *testing.T) {
+	if !Embedded() {
+		t.Skip("no embedded database in this build")
+	}
+	dir := filepath.Join(t.TempDir(), "nested", "skywire")
+	r, err := openMapped(dir)
+	require.NoError(t, err)
+	defer r.Close() //nolint:errcheck
+
+	crc, size, ok := gzTrailer(embeddedGz)
+	require.True(t, ok)
+	fi, err := os.Stat(mappedPath(dir, crc))
+	require.NoError(t, err)
+	require.Equal(t, size, fi.Size(), "cache file is the inflated database")
+	first := fi.ModTime()
+
+	mem, err := OpenEmbedded()
+	require.NoError(t, err)
+	defer mem.Close() //nolint:errcheck
+	ip := netip.MustParseAddr("8.8.8.8")
+	got, err := r.City(ip)
+	require.NoError(t, err)
+	want, err := mem.City(ip)
+	require.NoError(t, err)
+	require.Equal(t, want.Country.ISOCode, got.Country.ISOCode)
+
+	// A second open finds the file and does not rewrite it.
+	r2, err := openMapped(dir)
+	require.NoError(t, err)
+	defer r2.Close() //nolint:errcheck
+	fi2, err := os.Stat(mappedPath(dir, crc))
+	require.NoError(t, err)
+	require.Equal(t, first, fi2.ModTime())
+
+	// A truncated cache file is rewritten.
+	require.NoError(t, os.WriteFile(mappedPath(dir, crc), []byte("stale"), 0o600))
+	r3, err := openMapped(dir)
+	require.NoError(t, err)
+	defer r3.Close() //nolint:errcheck
+	fi3, err := os.Stat(mappedPath(dir, crc))
+	require.NoError(t, err)
+	require.Equal(t, size, fi3.Size())
+}
+
+func TestOpenMapped_UnwritableDirFails(t *testing.T) {
+	if !Embedded() {
+		t.Skip("no embedded database in this build")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root can write anywhere")
+	}
+	ro := t.TempDir()
+	require.NoError(t, os.Chmod(ro, 0o500))
+	_, err := openMapped(filepath.Join(ro, "skywire"))
+	require.Error(t, err, "Shared() falls back to the in-memory reader on this error")
+}
+
+// Not an assertion, evidence: how much heap each open path pins.
+func TestOpenMapped_HeapFootprint(t *testing.T) {
+	if !Embedded() {
+		t.Skip("no embedded database in this build")
+	}
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	r, err := openMapped(t.TempDir())
+	require.NoError(t, err)
+	defer r.Close() //nolint:errcheck
+	runtime.GC()
+	runtime.ReadMemStats(&after)
+	t.Logf("mapped: heap +%d KiB", (int64(after.HeapInuse)-int64(before.HeapInuse))/1024)
+
+	t.Logf("in-memory: heap +%d KiB pinned by EmbeddedDB()", len(EmbeddedDB())/1024)
+}


### PR DESCRIPTION
Every visor and dmsg server that answers a geo query inflated the embedded GeoLite2 gzip into a 60 MB heap slice for the life of the process (dmsg-server-7 heap profile today: 59 MB of 156 MB in use). Under a GOMEMLIMIT that is a quarter of a 256 MiB budget spent on a blob that never changes, paid for in GC cycles, and the 1 GB nanode dmsg servers have been OOM-killed.

Shared() now inflates the database once into a cache file (user cache dir, else the temp dir, named by the gzip CRC so a new build gets a new file) and memory-maps it. The pages are file-backed, shared between the visor and dmsg server on one host, evictable under pressure, and invisible to the Go runtime: the mapped open pins 32 KiB of heap. If the cache cannot be written it falls back to the in-memory reader. Lookups are byte-for-byte the same database, and the test compares the two readers' answers.
