### PR TITLE
fix(cxds): let the sparse-file compaction run on stores the old scan cleared

### DIFF
--- a/pkg/cxo/data/cxds/drive_compact.go
+++ b/pkg/cxo/data/cxds/drive_compact.go
@@ -44,9 +44,14 @@ const (
 )
 
 // gcCheckedSizeKey records (in the meta bucket) the file size at the last scan
-// that decided the store was mostly live, so we don't rescan a large healthy
-// store on every start.
-var gcCheckedSizeKey = []byte("gc_checked_size")
+// that decided the store was mostly live and not sparse, so we don't rescan a
+// large healthy store on every start. The key is versioned: a memo written
+// under an earlier criterion must not veto a rescan under a stricter one.
+// The v1 memo only meant "mostly live"; the sparse-file criterion added
+// afterwards never got to run on a store v1 had already cleared, which is
+// why a 2.9 GB telemetry store holding a few MB of objects survived every
+// restart (2026-09-10).
+var gcCheckedSizeKey = []byte("gc_checked_size_v2")
 
 func putUint64Meta(b *bolt.Bucket, key []byte, v uint64) error {
 	var ub [8]byte

--- a/pkg/cxo/data/cxds/drive_compact_test.go
+++ b/pkg/cxo/data/cxds/drive_compact_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	bolt "github.com/0magnet/bbolt"
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/stretchr/testify/require"
 
@@ -159,4 +160,57 @@ func TestStartupGCCompact_ReclaimsFreedPages(t *testing.T) {
 		require.Equal(t, v, got)
 		require.Equal(t, uint32(1), rc)
 	}
+}
+
+// A memo written by the pre-sparse-criterion scan ("gc_checked_size", v1)
+// must not stop the sparse check from running: the file below is exactly the
+// case that memo used to hide, and it must still be compacted.
+func TestStartupGCCompact_IgnoresPreCriteriaMemo(t *testing.T) {
+	fn := filepath.Join(t.TempDir(), "cxds.db")
+	ds, err := NewDriveCXDS(fn)
+	require.NoError(t, err)
+	var drop [][]byte
+	for i := 0; i < 600; i++ {
+		v := mkVal(byte(i%251), 8192)
+		v[0], v[1] = byte(i>>8), byte(i)
+		_, err := ds.Set(cipher.SumSHA256(v), v, 1)
+		require.NoError(t, err)
+		if i >= 6 {
+			drop = append(drop, v)
+		}
+	}
+	require.NoError(t, ds.Close())
+	ds, err = NewDriveCXDS(fn)
+	require.NoError(t, err)
+	for _, v := range drop {
+		require.NoError(t, ds.Del(cipher.SumSHA256(v)))
+	}
+	require.NoError(t, ds.Close())
+	before, err := os.Stat(fn)
+	require.NoError(t, err)
+
+	// Plant the v1 memo saying "checked at this very size, mostly live".
+	db, err := bolt.Open(fn, 0600, nil)
+	require.NoError(t, err)
+	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
+		m, err := tx.CreateBucketIfNotExists(metaBucket)
+		if err != nil {
+			return err
+		}
+		return putUint64Meta(m, []byte("gc_checked_size"), uint64(before.Size()))
+	}))
+	require.NoError(t, db.Close())
+
+	old := compactMinFileBytes
+	compactMinFileBytes = 4096
+	defer func() { compactMinFileBytes = old }()
+
+	reclaimed, err := startupGCCompact(fn)
+	require.NoError(t, err)
+	require.Greater(t, reclaimed, int64(0), "the v1 memo must not veto the sparse-file rewrite")
+
+	// And the v2 memo now written does veto a second, pointless scan.
+	reclaimed, err = startupGCCompact(fn)
+	require.NoError(t, err)
+	require.Zero(t, reclaimed)
 }


### PR DESCRIPTION
#4769 added the sparse-file criterion to the startup compaction, but the scan memoizes "checked at this size, nothing to do" and skips until the file grows 25%. Stores the pre-#4769 scan had cleared carried that memo, so the new criterion never ran on them. The TPD host visor's 2.9 GB cxo-stats/cxds.db (a few MB of live objects, 2.7 GB of the visor's 3.1 GB RSS as mapped file pages) came through today's restart on a build with #4769 unchanged.

The memo key is versioned now, so each store is judged once more under the current criteria and memoized again. The new test plants the v1 memo on a sparse store and requires the rewrite to happen anyway; it fails on develop.
