### PR TITLE
perf(treestore): pace nudge-driven cleanup sweeps by their own cost

### DIFF
--- a/pkg/cxo/treestore/cleanup_pacer.go
+++ b/pkg/cxo/treestore/cleanup_pacer.go
@@ -1,0 +1,37 @@
+// Package treestore pkg/cxo/treestore/cleanup_pacer.go c2-net-cxo
+package treestore
+
+import "time"
+
+// cleanupDutyFactor bounds the share of wall time the publisher's cleanup
+// sweep may occupy: after a sweep that took T, the next nudge-driven sweep
+// is held until cleanupDutyFactor*T has passed since it started, so the
+// sweep never takes more than ~1/cleanupDutyFactor of the process's time.
+// A sweep over a few-MB store takes milliseconds and is effectively
+// unpaced; one over a multi-GB store is spread out instead of running
+// back-to-back on every publish. The forced periodic sweep is not paced.
+const cleanupDutyFactor = 20
+
+// cleanupPacer remembers when the last sweep started and how long it took.
+type cleanupPacer struct {
+	lastStart time.Time
+	lastTook  time.Duration
+}
+
+// ran records a completed sweep.
+func (c *cleanupPacer) ran(start time.Time, took time.Duration) {
+	c.lastStart, c.lastTook = start, took
+}
+
+// holdFor returns how much longer a nudge arriving at now must wait before
+// the next sweep may start; zero means run now.
+func (c *cleanupPacer) holdFor(now time.Time) time.Duration {
+	if c.lastStart.IsZero() {
+		return 0
+	}
+	next := c.lastStart.Add(c.lastTook * cleanupDutyFactor)
+	if d := next.Sub(now); d > 0 {
+		return d
+	}
+	return 0
+}

--- a/pkg/cxo/treestore/cleanup_pacer_test.go
+++ b/pkg/cxo/treestore/cleanup_pacer_test.go
@@ -1,0 +1,26 @@
+// Package treestore pkg/cxo/treestore/cleanup_pacer_test.go c2-net-cxo
+package treestore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupPacer(t *testing.T) {
+	var p cleanupPacer
+	t0 := time.Date(2026, 9, 10, 19, 0, 0, 0, time.UTC)
+	require.Zero(t, p.holdFor(t0), "first sweep runs at once")
+
+	// A 10 s sweep holds the next nudge for 200 s from its start.
+	p.ran(t0, 10*time.Second)
+	require.Equal(t, 190*time.Second, p.holdFor(t0.Add(10*time.Second)))
+	require.Equal(t, 100*time.Second, p.holdFor(t0.Add(100*time.Second)))
+	require.Zero(t, p.holdFor(t0.Add(200*time.Second)))
+	require.Zero(t, p.holdFor(t0.Add(time.Hour)))
+
+	// A millisecond sweep is effectively unpaced.
+	p.ran(t0, time.Millisecond)
+	require.Zero(t, p.holdFor(t0.Add(50*time.Millisecond)))
+}

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -986,6 +986,23 @@ func (p *Publisher) runCleanupLoop() {
 	// case; this is the backstop, not the steady-state sweeper.
 	t := time.NewTicker(cleanupForceInterval)
 	defer t.Stop()
+	// Nudges are paced by the cost of the previous sweep (see
+	// cleanupPacer): a sweep walks the whole object store in one bbolt
+	// write transaction, so on a large store a nudge per publish
+	// (every 12 s for the visor's telemetry feed) kept the visor at 80%
+	// of its CPU in IterateDel over a 2.9 GB file (2026-09-10).
+	var pacer cleanupPacer
+	var wait *time.Timer
+	var waitC <-chan time.Time
+	sweep := func() {
+		start := time.Now()
+		p.runCleanup()
+		pacer.ran(start, time.Since(start))
+		if wait != nil {
+			wait.Stop()
+			wait, waitC = nil, nil
+		}
+	}
 	for {
 		select {
 		case <-p.done:
@@ -993,9 +1010,18 @@ func (p *Publisher) runCleanupLoop() {
 			p.runCleanup()
 			return
 		case <-p.cleanupNudge:
-			p.runCleanup()
+			if d := pacer.holdFor(time.Now()); d > 0 {
+				if wait == nil {
+					wait = time.NewTimer(d)
+					waitC = wait.C
+				}
+				continue
+			}
+			sweep()
+		case <-waitC:
+			sweep()
 		case <-t.C:
-			p.runCleanup()
+			sweep()
 		}
 	}
 }


### PR DESCRIPTION
Every publish nudges the publisher's cleanup loop, and each sweep walks the whole object store in one bbolt write transaction. For the visor's telemetry feed that is a full walk every 12 s; over the TPD host visor's 2.9 GB cxo-stats store it was 81% of the visor's CPU in a 12 s profile today, and it keeps the whole file hot in page cache.

A nudge now waits until 20x the previous sweep's duration has elapsed since that sweep started, coalescing the nudges that arrive meanwhile, so sweeping is bounded to about 5% of wall time. A millisecond sweep over a small store is effectively unpaced, and the 10 minute forced sweep and the shutdown sweep are unchanged.
