### PR TITLE
perf(tpd): stop re-registering unchanged transports on every visor heartbeat

### DIFF
--- a/pkg/deployment/tpd/api/api.go
+++ b/pkg/deployment/tpd/api/api.go
@@ -59,6 +59,7 @@ type API struct {
 	reqsInFlightCountMiddleware *metricsutil.RequestsInFlightCountMiddleware
 	rateLimiter                 *PubKeyRateLimiter
 	store                       store.Store
+	reconcile                   *reconcileThrottle
 	startedAt                   time.Time
 	dmsgAddr                    string
 	DmsgServers                 []string
@@ -127,6 +128,7 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
 		reqsInFlightCountMiddleware: metricsutil.NewRequestsInFlightCountMiddleware(),
 		rateLimiter:                 NewPubKeyRateLimiter(30, 10), // 30 req/min with burst of 10
 		store:                       s,
+		reconcile:                   newReconcileThrottle(defaultReconcileRefreshGap, reconcileHeartbeatGap),
 		startedAt:                   time.Now(),
 		dmsgAddr:                    dmsgAddr,
 		DmsgServers:                 []string{},
@@ -559,4 +561,14 @@ func setSnapshotHeaders(w http.ResponseWriter, at time.Time, total int) {
 	}
 	w.Header().Set(SnapshotAtHeader, at.Format(time.RFC3339Nano))
 	w.Header().Set(SnapshotTransportsHeader, strconv.Itoa(total))
+}
+
+// SetEntryTimeout tells the API the store's transport entry TTL so the CXO
+// reconcile path refreshes an unchanged registration a third of the way
+// through it rather than on every visor heartbeat (see reconcileThrottle).
+func (api *API) SetEntryTimeout(ttl time.Duration) {
+	if ttl <= 0 {
+		return
+	}
+	api.reconcile.setRefreshGap(ttl / 3)
 }

--- a/pkg/deployment/tpd/api/cxo_register.go
+++ b/pkg/deployment/tpd/api/cxo_register.go
@@ -107,30 +107,37 @@ func (api *API) ReconcileTransportsFromCXO(ctx context.Context, entries []*trans
 	// Accept only entries the reporter is actually an edge of (auth parity with the
 	// per-entry path); build the authoritative keep-set.
 	keep := make(map[uuid.UUID]struct{}, len(entries))
-	signed := make([]*transport.SignedEntry, 0, len(entries))
+	accepted := make([]*transport.Entry, 0, len(entries))
 	touchedEdges := map[cipher.PubKey]struct{}{}
 	for _, e := range entries {
 		if e == nil || e.EdgeIndex(reporter) < 0 {
 			continue
 		}
 		keep[e.ID] = struct{}{}
-		signed = append(signed, &transport.SignedEntry{Entry: e, Version: version})
+		accepted = append(accepted, e)
 		touchedEdges[e.Edges[0]] = struct{}{}
 		touchedEdges[e.Edges[1]] = struct{}{}
 	}
 
-	// Register/refresh everything currently present.
-	if len(signed) > 0 {
+	// Register/refresh what is new, changed, or due for a TTL refresh, and
+	// record heartbeats that are due; the rest was written moments ago by
+	// this or the other edge's snapshot (see reconcileThrottle).
+	toRegister, toHeartbeat := api.reconcile.plan(time.Now(), accepted)
+	if len(toRegister) > 0 {
+		signed := make([]*transport.SignedEntry, 0, len(toRegister))
+		for _, e := range toRegister {
+			signed = append(signed, &transport.SignedEntry{Entry: e, Version: version})
+		}
 		if err := api.store.RegisterTransportsBatch(ctx, reporter, signed); err != nil {
+			api.reconcile.forget(toRegister)
 			return fmt.Errorf("register batch: %w", err)
 		}
-		for _, se := range signed {
-			if err := api.store.RecordTransportHeartbeat(ctx, se.Entry.ID, string(se.Entry.Type), time.Time{}); err != nil {
-				_ = err //nolint:errcheck // uptime is auxiliary; store logs
-			}
+	}
+	for _, e := range toHeartbeat {
+		if err := api.store.RecordTransportHeartbeat(ctx, e.ID, string(e.Type), time.Time{}); err != nil {
+			_ = err //nolint:errcheck // uptime is auxiliary; store logs
 		}
 	}
-
 	// Deregister any of the reporter's existing transports absent from the snapshot.
 	// A transport the reporter no longer lists is a deregister signal for that edge —
 	// exactly what a tombstone was in the delta model.

--- a/pkg/deployment/tpd/api/reconcile_throttle.go
+++ b/pkg/deployment/tpd/api/reconcile_throttle.go
@@ -1,0 +1,134 @@
+// Package api pkg/deployment/tpd/api/reconcile_throttle.go c4-net-discovery
+package api
+
+import (
+	"hash/fnv"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// Every visor republishes its whole transport list with every CXO
+// heartbeat (45 s), and both edges of a transport publish it, so the
+// aggregator hands each live transport to ReconcileTransportsFromCXO
+// roughly every 20 s. Registering it again each time is nine redis writes
+// (the tp blob, five index SADDs, two EXPIREs, the edge pair) for a 5 min
+// TTL that only needs refreshing a couple of times per period, and the
+// per-transport heartbeat is another eight. On the TPD host that was
+// ~460k of redis's 640k commands a minute (2026-09-10).
+//
+// reconcileThrottle remembers, per transport, what was last written and
+// when: an unchanged entry is re-registered only once refreshGap has
+// passed (a third of the TTL by default, so a refresh is never missed),
+// and its heartbeat recorded at most once per heartbeatGap.
+
+const (
+	// defaultReconcileRefreshGap is used until SetEntryTimeout is called.
+	// A third of the default 5 min entry TTL.
+	defaultReconcileRefreshGap = 100 * time.Second
+	// reconcileHeartbeatGap dedupes the two edges' reports of one transport.
+	// The legacy uptime count expects a heartbeat every ~90 s (960/day, see
+	// store.expectedHeartbeatsPerDay); 30 s keeps every 45 s report of at
+	// least one edge, so a transport still lands ≥1920/day and reads 100%.
+	reconcileHeartbeatGap = 30 * time.Second
+)
+
+type reconcileMark struct {
+	fp           uint64
+	registeredAt time.Time
+	heartbeatAt  time.Time
+}
+
+type reconcileThrottle struct {
+	mu           sync.Mutex
+	refreshGap   time.Duration
+	heartbeatGap time.Duration
+	marks        map[uuid.UUID]*reconcileMark
+	sweptAt      time.Time
+}
+
+func newReconcileThrottle(refreshGap, heartbeatGap time.Duration) *reconcileThrottle {
+	return &reconcileThrottle{
+		refreshGap:   refreshGap,
+		heartbeatGap: heartbeatGap,
+		marks:        make(map[uuid.UUID]*reconcileMark),
+	}
+}
+
+// setRefreshGap adjusts the registration gap (from the configured TTL).
+func (t *reconcileThrottle) setRefreshGap(d time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.refreshGap = d
+}
+
+// entryFingerprint covers everything the store persists for a transport.
+func entryFingerprint(e *transport.Entry) uint64 {
+	h := fnv.New64a()
+	h.Write(e.Edges[0][:])   //nolint:errcheck,gosec
+	h.Write(e.Edges[1][:])   //nolint:errcheck,gosec
+	h.Write([]byte(e.Type))  //nolint:errcheck,gosec
+	h.Write([]byte{0})       //nolint:errcheck,gosec
+	h.Write([]byte(e.Label)) //nolint:errcheck,gosec
+	return h.Sum64()
+}
+
+// plan splits entries into those that must be (re)registered now and those
+// whose heartbeat is due, marking both as done as of now. A registration
+// that then fails must be handed back through forget so it is retried on
+// the next snapshot.
+func (t *reconcileThrottle) plan(now time.Time, entries []*transport.Entry) (register, heartbeat []*transport.Entry) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.sweepLocked(now)
+	for _, e := range entries {
+		fp := entryFingerprint(e)
+		m := t.marks[e.ID]
+		if m == nil {
+			m = &reconcileMark{}
+			t.marks[e.ID] = m
+		}
+		if m.fp != fp || now.Sub(m.registeredAt) >= t.refreshGap {
+			m.fp, m.registeredAt = fp, now
+			register = append(register, e)
+		}
+		if now.Sub(m.heartbeatAt) >= t.heartbeatGap {
+			m.heartbeatAt = now
+			heartbeat = append(heartbeat, e)
+		}
+	}
+	return register, heartbeat
+}
+
+// forget clears the registration mark of entries whose write failed.
+func (t *reconcileThrottle) forget(entries []*transport.Entry) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, e := range entries {
+		if m := t.marks[e.ID]; m != nil {
+			m.registeredAt = time.Time{}
+		}
+	}
+}
+
+// sweepLocked drops marks of transports not seen for a few refresh gaps,
+// so the map tracks live transports rather than every one ever reported.
+func (t *reconcileThrottle) sweepLocked(now time.Time) {
+	if now.Sub(t.sweptAt) < t.refreshGap {
+		return
+	}
+	t.sweptAt = now
+	stale := 4 * t.refreshGap
+	for id, m := range t.marks {
+		last := m.registeredAt
+		if m.heartbeatAt.After(last) {
+			last = m.heartbeatAt
+		}
+		if now.Sub(last) > stale {
+			delete(t.marks, id)
+		}
+	}
+}

--- a/pkg/deployment/tpd/api/reconcile_throttle_test.go
+++ b/pkg/deployment/tpd/api/reconcile_throttle_test.go
@@ -1,0 +1,119 @@
+// Package api pkg/deployment/tpd/api/reconcile_throttle_test.go c4-net-discovery
+package api
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/storeconfig"
+	tpdiscmetrics "github.com/skycoin/skywire/pkg/deployment/tpd/metrics"
+	"github.com/skycoin/skywire/pkg/deployment/tpd/store"
+	"github.com/skycoin/skywire/pkg/httpauth"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+func TestReconcileThrottle_Plan(t *testing.T) {
+	th := newReconcileThrottle(100*time.Second, 30*time.Second)
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	e1 := &transport.Entry{ID: uuid.New(), Edges: transport.SortEdges(a, b), Type: "stcpr"}
+	e2 := &transport.Entry{ID: uuid.New(), Edges: transport.SortEdges(a, b), Type: "sudph"}
+	t0 := time.Date(2026, 9, 10, 19, 0, 0, 0, time.UTC)
+
+	reg, hb := th.plan(t0, []*transport.Entry{e1, e2})
+	require.Len(t, reg, 2, "first sight registers everything")
+	require.Len(t, hb, 2)
+
+	// The other edge's snapshot 20 s later: nothing to write.
+	reg, hb = th.plan(t0.Add(20*time.Second), []*transport.Entry{e1, e2})
+	require.Empty(t, reg)
+	require.Empty(t, hb)
+
+	// 45 s: heartbeat due again, registration is not.
+	reg, hb = th.plan(t0.Add(45*time.Second), []*transport.Entry{e1, e2})
+	require.Empty(t, reg)
+	require.Len(t, hb, 2)
+
+	// A changed label registers at once; the unchanged sibling waits.
+	e1b := *e1
+	e1b.Label = "renamed"
+	reg, _ = th.plan(t0.Add(50*time.Second), []*transport.Entry{&e1b, e2})
+	require.Equal(t, []*transport.Entry{&e1b}, reg)
+
+	// The refresh gap elapses: the unchanged entry is registered again.
+	reg, _ = th.plan(t0.Add(100*time.Second), []*transport.Entry{&e1b, e2})
+	require.Equal(t, []*transport.Entry{e2}, reg)
+
+	// A failed write is retried on the very next snapshot.
+	th.forget([]*transport.Entry{e2})
+	reg, _ = th.plan(t0.Add(101*time.Second), []*transport.Entry{&e1b, e2})
+	require.Equal(t, []*transport.Entry{e2}, reg)
+
+	// Marks of transports not reported for a while are dropped.
+	reg, _ = th.plan(t0.Add(10*time.Minute), []*transport.Entry{e2})
+	require.Len(t, reg, 1)
+	th.mu.Lock()
+	_, hasE1 := th.marks[e1.ID]
+	th.mu.Unlock()
+	require.False(t, hasE1, "e1 unseen for 4 gaps must be swept")
+}
+
+// countingStore counts the two write paths the throttle guards.
+type countingStore struct {
+	store.Store
+	registered atomic.Int64
+	heartbeats atomic.Int64
+}
+
+func (c *countingStore) RegisterTransportsBatch(ctx context.Context, r cipher.PubKey, es []*transport.SignedEntry) error {
+	c.registered.Add(int64(len(es)))
+	return c.Store.RegisterTransportsBatch(ctx, r, es)
+}
+
+func (c *countingStore) RecordTransportHeartbeat(ctx context.Context, id uuid.UUID, typ string, at time.Time) error {
+	c.heartbeats.Add(1)
+	return c.Store.RecordTransportHeartbeat(ctx, id, typ, at)
+}
+
+// Two snapshots of the same list in quick succession (the two edges, or one
+// visor's 45 s heartbeat) must write the transports once, and the second
+// snapshot must still be reconciled (absent entries deregistered).
+func TestReconcileTransportsFromCXO_ThrottlesRepeats(t *testing.T) {
+	ctx := context.Background()
+	base, err := store.New(ctx, storeconfig.Config{Type: storeconfig.Memory}, 10*time.Minute, logging.MustGetLogger("test"))
+	require.NoError(t, err)
+	cs := &countingStore{Store: base}
+	nonceMock, err := httpauth.NewNonceStore(ctx, storeconfig.Config{Type: storeconfig.Memory}, "")
+	require.NoError(t, err)
+	api := New(nil, cs, nonceMock, false, tpdiscmetrics.NewEmpty(), "", "")
+
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	e1 := &transport.Entry{ID: uuid.New(), Edges: transport.SortEdges(a, b), Type: "stcpr"}
+	e2 := &transport.Entry{ID: uuid.New(), Edges: transport.SortEdges(a, b), Type: "stcpr"}
+
+	require.NoError(t, api.ReconcileTransportsFromCXO(ctx, []*transport.Entry{e1, e2}, a, "v"))
+	require.EqualValues(t, 2, cs.registered.Load())
+	require.EqualValues(t, 2, cs.heartbeats.Load())
+
+	// The other edge reports the same two: no writes.
+	require.NoError(t, api.ReconcileTransportsFromCXO(ctx, []*transport.Entry{e1, e2}, b, "v"))
+	require.EqualValues(t, 2, cs.registered.Load())
+	require.EqualValues(t, 2, cs.heartbeats.Load())
+
+	// Edge a drops e2: e2 is deregistered even though nothing was registered.
+	require.NoError(t, api.ReconcileTransportsFromCXO(ctx, []*transport.Entry{e1}, a, "v"))
+	_, err = base.GetTransportByID(ctx, e2.ID)
+	require.ErrorIs(t, err, store.ErrTransportNotFound)
+	got, err := base.GetTransportByID(ctx, e1.ID)
+	require.NoError(t, err)
+	require.Equal(t, e1.ID, got.ID)
+	require.EqualValues(t, 2, cs.registered.Load())
+}

--- a/pkg/services/tpd/tpd.go
+++ b/pkg/services/tpd/tpd.go
@@ -192,6 +192,7 @@ func (s *service) Run(ctx context.Context) error {
 		storeDataPath = "/var/lib/skywire/tpd/bandwidth"
 	}
 	tpdAPI := api.New(logger, st, nonceStore, enableMetrics, m, dmsgAddr, storeDataPath)
+	tpdAPI.SetEntryTimeout(cfg.EntryTimeout.Std())
 	if uptimeRec != nil {
 		tpdAPI.SetUptimeRecorder(uptimeRec)
 	}


### PR DESCRIPTION
Every visor republishes its whole transport list with each CXO heartbeat (45 s) and both edges publish every transport, so the aggregator hands each live transport to ReconcileTransportsFromCXO about every 20 s and it was re-registered each time: nine redis writes for a 5 min TTL, plus eight for the per-transport heartbeat. With the read side fixed in #4774, those writes are about 460k of redis's 640k commands a minute on the TPD host (SADD 170k, EXPIRE 117k, SET 62k, HSET 39k per minute).

The reconcile now remembers per transport what it last wrote and when. An unchanged entry is re-registered once a third of the entry TTL has passed, a changed one at once, and a failed write is retried on the next snapshot. Heartbeats are recorded at most every 30 s per transport, which still lands more than the 960 a day the legacy uptime count expects. Deregistering absent transports is unchanged, and the API-level test checks that a snapshot which writes nothing still deregisters.
