### PR TITLE
perf(services): put the request log under log_level and behind the outcome

### DIFF
--- a/pkg/deployment/ar/api/api.go
+++ b/pkg/deployment/ar/api/api.go
@@ -269,7 +269,7 @@ func New(log *logging.Logger, s store.Store, nonceStore httpauth.NonceStore,
 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP) //nolint:staticcheck
-	r.Use(middleware.Logger)
+	r.Use(httputil.NewLogMiddleware(log))
 	r.Use(middleware.Recoverer)
 	// gzip JSON responses on the wire — this router is also served over
 	// dmsg, where every byte is relayed. Matches rf/ut/sd.

--- a/pkg/deployment/conf/api/api.go
+++ b/pkg/deployment/conf/api/api.go
@@ -107,7 +107,7 @@ func New(log *logging.Logger, conf Config, domain, dmsgAddr string) *API {
 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP) //nolint:staticcheck
-	r.Use(middleware.Logger)
+	r.Use(httputil.NewLogMiddleware(log))
 	r.Use(middleware.Recoverer)
 	// gzip JSON responses on the wire — this router is also served over
 	// dmsg, where every byte is relayed. Matches rf/ut/sd.

--- a/pkg/deployment/monitor/api/api.go
+++ b/pkg/deployment/monitor/api/api.go
@@ -102,7 +102,7 @@ func New(s store.Store, logger *logging.Logger, urls ServicesURLs, config Networ
 	r.Use(
 		middleware.RequestID,
 		middleware.RealIP, //nolint:staticcheck
-		middleware.Logger,
+		httputil.NewLogMiddleware(logger),
 		middleware.Recoverer,
 		// gzip JSON responses on the wire. Matches rf/ut/sd.
 		httputil.CompressMin(httputil.CompressMinBytes, 5),

--- a/pkg/deployment/rf/api/api.go
+++ b/pkg/deployment/rf/api/api.go
@@ -66,7 +66,7 @@ func New(s store.Store, logger logrus.FieldLogger, enableMetrics bool, dmsgAddr 
 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP) //nolint:staticcheck
-	r.Use(middleware.Logger)
+	r.Use(httputil.NewLogMiddleware(logger))
 	r.Use(middleware.Recoverer)
 	// gzip route-finder JSON responses on the wire (skips small bodies,
 	// honors Vary; net/http clients get transparent gzip).

--- a/pkg/deployment/sd/api/api.go
+++ b/pkg/deployment/sd/api/api.go
@@ -234,7 +234,7 @@ func New(log logrus.FieldLogger, db store.Store, nonceDB httpauth.NonceStore,
 func (a *API) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r := chi.NewRouter()
 	r.Use(middleware.RealIP) //nolint:staticcheck
-	r.Use(middleware.Logger)
+	r.Use(httputil.NewLogMiddleware(a.log))
 	// gzip service-discovery JSON responses on the wire (skips small bodies,
 	// honors Vary; net/http clients get transparent gzip).
 	// gzip only bodies over CompressMinBytes: single entries and health lines are

--- a/pkg/deployment/tpd/api/api.go
+++ b/pkg/deployment/tpd/api/api.go
@@ -141,7 +141,7 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP) //nolint:staticcheck
-	r.Use(middleware.Logger)
+	r.Use(httputil.NewLogMiddleware(log))
 	r.Use(middleware.Recoverer)
 	// gzip JSON responses on the wire — this router is also served over
 	// dmsg, where every byte is relayed. Matches rf/ut/sd.

--- a/pkg/deployment/tps/api/api.go
+++ b/pkg/deployment/tps/api/api.go
@@ -42,7 +42,7 @@ func New(log *logging.Logger, conf config.Config) *API {
 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP) //nolint:staticcheck
-	r.Use(middleware.Logger)
+	r.Use(httputil.NewLogMiddleware(log))
 	r.Use(middleware.Recoverer)
 	r.Use(httputil.SetLoggerMiddleware(log))
 

--- a/pkg/dmsg/discovery/api/api.go
+++ b/pkg/dmsg/discovery/api/api.go
@@ -147,7 +147,7 @@ func New(log logrus.FieldLogger, db store.Storer, m metrics.Metrics, testMode, e
 	}
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP) //nolint:staticcheck
-	r.Use(middleware.Logger)
+	r.Use(httputil.NewLogMiddleware(log))
 	r.Use(middleware.Recoverer)
 	// gzip JSON responses on the wire — this router is also served over
 	// dmsg, where every byte is relayed. Matches rf/ut/sd.

--- a/pkg/httputil/log.go
+++ b/pkg/httputil/log.go
@@ -14,6 +14,10 @@ type structuredLogger struct {
 	logger logrus.FieldLogger
 }
 
+// RequestLogSlow is the latency above which a request that otherwise
+// succeeded is still logged at Info. A var, not a const, so tests can lower it.
+var RequestLogSlow = 2 * time.Second
+
 // NewLogMiddleware creates a new instance of logging middleware. This will allow
 // adding log fields in the handler and any further middleware. At the end of request, this
 // log entry will be printed at Info level via passed logger
@@ -40,8 +44,23 @@ func NewLogMiddleware(logger logrus.FieldLogger) func(http.Handler) http.Handler
 			if requestID != "" {
 				fields["request_id"] = requestID
 			}
-			sl.logger.WithFields(fields).Info()
-
+			entry := sl.logger.WithFields(fields)
+			// Level by outcome. A deployment service answers thousands of
+			// requests a minute; logging each one at Info made the request log
+			// the bulk of the service's output and told an operator nothing a
+			// counter would not. What is worth a line is a request that failed
+			// on our side, or one that took long enough to be a symptom.
+			switch {
+			case ww.Status() >= http.StatusInternalServerError:
+				entry.Warn("Served request.")
+			case latency >= RequestLogSlow:
+				entry.Info("Served slow request.")
+			default:
+				// 4xx included: a malformed or out-of-sequence request is the
+				// client's mistake, and a noisy client must not be able to fill
+				// the service's log at Info.
+				entry.Debug("Served request.")
+			}
 		}
 		return http.HandlerFunc(fn)
 	}

--- a/pkg/httputil/log_level_test.go
+++ b/pkg/httputil/log_level_test.go
@@ -1,0 +1,78 @@
+// Package httputil pkg/httputil/log_level_test.go c0-com-http
+package httputil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// collectHook records every entry the logger emits.
+type collectHook struct{ entries []*logrus.Entry }
+
+func (h *collectHook) Levels() []logrus.Level { return logrus.AllLevels }
+func (h *collectHook) Fire(e *logrus.Entry) error {
+	h.entries = append(h.entries, e)
+	return nil
+}
+
+func serveOnce(t *testing.T, level logrus.Level, status int, delay time.Duration) []*logrus.Entry {
+	t.Helper()
+	log := logrus.New()
+	log.SetOutput(discardWriter{})
+	log.SetLevel(level)
+	hook := &collectHook{}
+	log.AddHook(hook)
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(delay)
+		w.WriteHeader(status)
+	})
+	NewLogMiddleware(log)(next).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/p", nil))
+	return hook.entries
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// The request log's level follows the outcome: an ordinary answered request is
+// Debug (a service answering thousands a minute must not fill its log at Info),
+// a server error is Warn, and a slow request is Info even when it succeeded.
+func TestLogMiddleware_LevelByOutcome(t *testing.T) {
+	one := func(status int, delay time.Duration) *logrus.Entry {
+		es := serveOnce(t, logrus.DebugLevel, status, delay)
+		require.Len(t, es, 1)
+		return es[0]
+	}
+
+	require.Equal(t, logrus.DebugLevel, one(http.StatusOK, 0).Level)
+	require.Equal(t, logrus.DebugLevel, one(http.StatusUnprocessableEntity, 0).Level,
+		"a client's own malformed request must not be loggable at Info by that client")
+	require.Equal(t, logrus.WarnLevel, one(http.StatusInternalServerError, 0).Level)
+
+	old := RequestLogSlow
+	RequestLogSlow = 10 * time.Millisecond
+	defer func() { RequestLogSlow = old }()
+	slow := one(http.StatusOK, 40*time.Millisecond)
+	require.Equal(t, logrus.InfoLevel, slow.Level)
+	require.Equal(t, "Served slow request.", slow.Message)
+	RequestLogSlow = old
+
+	// Every entry still carries the fields operators filter on.
+	e := one(http.StatusOK, 0)
+	require.Equal(t, "Served request.", e.Message)
+	for _, k := range []string{"status", "took", "remote", "request", "method"} {
+		require.Contains(t, e.Data, k)
+	}
+}
+
+// At Info the ordinary request log is silent — the whole point of the change.
+func TestLogMiddleware_QuietAtInfo(t *testing.T) {
+	require.Empty(t, serveOnce(t, logrus.InfoLevel, http.StatusOK, 0))
+	require.Len(t, serveOnce(t, logrus.InfoLevel, http.StatusBadGateway, 0), 1,
+		"a server error must still be logged at Info")
+}

--- a/pkg/metricsutil/http.go
+++ b/pkg/metricsutil/http.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/httputil"
 )
 
 // AddMetricsHandler adds a prometheus-format Handle at '/metrics' to the provided serve mux.
@@ -90,7 +91,7 @@ func ServeHTTPMetrics(log logrus.FieldLogger, addr string) {
 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP) //nolint:staticcheck
-	r.Use(middleware.Logger)
+	r.Use(httputil.NewLogMiddleware(log))
 	r.Use(middleware.Recoverer)
 
 	AddMetricsHandler(r)

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -198,7 +198,7 @@ func (s *service) Run(ctx context.Context) error {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP) //nolint:staticcheck
-	r.Use(middleware.Logger)
+	r.Use(httputil.NewLogMiddleware(log))
 	r.Use(middleware.Recoverer)
 
 	srvAPI := dmsgserver.NewServerAPI(r, log, m)


### PR DESCRIPTION
Every deployment service routed its request log through chi's `middleware.Logger`. That is a stdlib logger writing to `os.Stdout`, not logrus, so it has no level: setting `log_level` to info, warn or error silenced none of it. On prod02 it accounted for about 4.1k of dmsg-discovery's 4.4k log lines per minute, mostly `GET /dmsg-discovery/entry/<pk>`, and the same middleware is on nine other routers (ar, tpd, rf, sd, conf, tps, monitor, metricsutil, dmsg-server).

They now use the existing `httputil.NewLogMiddleware`, which logs through the service's own logrus logger, so `log_level` applies. The level follows the outcome: 5xx is Warn, a request slower than `RequestLogSlow` is Info even when it succeeded, and everything else including 4xx is Debug, so a noisy client cannot fill a service's log at Info. The entry also gets a message; it was previously emitted with an empty one, which is part of the blank-line noise in these logs.

Found by an audit of deployment-service logging prompted by dmsg-server-6 emitting 67k lines/minute.
