### PR TITLE
perf(dmsg): stop tracing every stream twice at debug level

### DIFF
--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -14,6 +14,7 @@ import (
 	"github.com/xtaci/smux"
 
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg/metrics"
+	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
 )
 
@@ -87,7 +88,7 @@ func (ss *ServerSession) Serve() {
 				continue
 			}
 
-			log.Debug("Initiating stream.")
+			started := time.Now()
 			go func(sStr *smux.Stream) {
 				defer func() { <-sem }()
 				defer func() {
@@ -97,7 +98,12 @@ func (ss *ServerSession) Serve() {
 				}()
 				err := ss.serveStream(log, sStr, ss.sm.addr)
 				ss.closeRefused(sStr, err)
-				log.WithError(err).Debug("Stopped stream.")
+				// One line per stream, at its close, carrying the outcome and how
+				// long it lived. It used to be two ("Initiating stream." on open,
+				// "Stopped stream." on close), which at 8.8k streams a minute on a
+				// production server is 17.6k lines that say the same thing twice.
+				log.WithError(err).WithField("took", time.Since(started)).
+					Debug("Stream closed.")
 			}(sStr)
 		}
 	} else if ss.sm.quic != nil {
@@ -117,7 +123,7 @@ func (ss *ServerSession) Serve() {
 				continue
 			}
 
-			log.Debug("Initiating stream.")
+			started := time.Now()
 			go func(qStr quicStream) {
 				defer func() { <-sem }()
 				defer func() {
@@ -127,7 +133,12 @@ func (ss *ServerSession) Serve() {
 				}()
 				err := ss.serveStream(log, qStr, ss.sm.addr)
 				ss.closeRefused(qStr, err)
-				log.WithError(err).Debug("Stopped stream.")
+				// One line per stream, at its close, carrying the outcome and how
+				// long it lived. It used to be two ("Initiating stream." on open,
+				// "Stopped stream." on close), which at 8.8k streams a minute on a
+				// production server is 17.6k lines that say the same thing twice.
+				log.WithError(err).WithField("took", time.Since(started)).
+					Debug("Stream closed.")
 			}(qStr)
 		}
 	} else {
@@ -156,7 +167,7 @@ func (ss *ServerSession) Serve() {
 				continue
 			}
 
-			log.Debug("Initiating stream.")
+			started := time.Now()
 			go func(yStr *yamux.Stream) {
 				defer func() { <-sem }()
 				defer func() {
@@ -166,7 +177,12 @@ func (ss *ServerSession) Serve() {
 				}()
 				err := ss.serveStream(log, yStr, ss.sm.addr)
 				ss.closeRefused(yStr, err)
-				log.WithError(err).Debug("Stopped stream.")
+				// One line per stream, at its close, carrying the outcome and how
+				// long it lived. It used to be two ("Initiating stream." on open,
+				// "Stopped stream." on close), which at 8.8k streams a minute on a
+				// production server is 17.6k lines that say the same thing twice.
+				log.WithError(err).WithField("took", time.Since(started)).
+					Debug("Stream closed.")
 			}(yStr)
 		}
 	}
@@ -292,13 +308,21 @@ func (ss *ServerSession) serveStream(log logrus.FieldLogger, yStr io.ReadWriteCl
 		return ErrReqInvalidSrcPK
 	}
 
-	log = log.
-		WithField("src_addr", req.SrcAddr).
-		WithField("dst_addr", req.DstAddr)
+	// Only the trace/debug lines below read these, and WithField allocates
+	// an Entry and copies the field map even when the level is off.
+	if logging.DebugEnabled() {
+		log = log.
+			WithField("src_addr", req.SrcAddr).
+			WithField("dst_addr", req.DstAddr)
+	}
 
-	log.Debug("Read stream request from initiating side.")
+	if logging.TraceEnabled() {
+		logging.Trace(log, "Read stream request from initiating side.")
+	}
 	if req.IPinfo && req.DstAddr.PK == ss.entity.LocalPK() {
-		log.Debug("Received IP stream request.")
+		if logging.TraceEnabled() {
+			logging.Trace(log, "Received IP stream request.")
+		}
 
 		ip, err := addrToIP(addr)
 		if err != nil {
@@ -334,7 +358,9 @@ func (ss *ServerSession) serveStream(log logrus.FieldLogger, yStr io.ReadWriteCl
 			ss.m.RecordStream(metrics.DeltaFailed) // record failed stream
 			return err
 		}
-		log.Debug("Wrote IP stream response.")
+		if logging.TraceEnabled() {
+			logging.Trace(log, "Wrote IP stream response.")
+		}
 		return nil
 	}
 
@@ -350,7 +376,9 @@ func (ss *ServerSession) serveStream(log logrus.FieldLogger, yStr io.ReadWriteCl
 		}
 		return ss.forwardViaPeer(log, yStr, req)
 	}
-	log.Debug("Obtained next session.")
+	if logging.TraceEnabled() {
+		logging.Trace(log, "Obtained next session.")
+	}
 
 	return ss.bridgeStream(log, yStr, ss2, req)
 }
@@ -375,7 +403,9 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 		ss.m.RecordStream(metrics.DeltaFailed)
 		return err
 	}
-	log.Debug("Forwarded stream request.")
+	if logging.TraceEnabled() {
+		logging.Trace(log, "Forwarded stream request.")
+	}
 	if ss.relayInbound && ss.entity.forwardedFunc != nil {
 		// The peer accepted: remember it for the next request to this dst.
 		ss.entity.forwardedFunc(req.DstAddr.PK, dst.RemotePK())
@@ -393,7 +423,9 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 		ss.m.RecordStream(metrics.DeltaFailed)
 		return err
 	}
-	log.Debug("Forwarded stream response.")
+	if logging.TraceEnabled() {
+		logging.Trace(log, "Forwarded stream response.")
+	}
 
 	// Set an idle timeout on both sides of the bridge. If no data flows
 	// in either direction for this duration, both streams are closed.
@@ -408,7 +440,9 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 	yStr = &idleTimeoutConn{rwc: yStr, timeout: streamIdleTimeout}
 	yStr2 = &idleTimeoutConn{rwc: yStr2, timeout: streamIdleTimeout}
 
-	log.Debug("Serving stream.")
+	if logging.TraceEnabled() {
+		logging.Trace(log, "Serving stream.")
+	}
 	ss.m.RecordStream(metrics.DeltaConnect)
 	defer ss.m.RecordStream(metrics.DeltaDisconnect)
 	return netutil.CopyReadWriteCloser(yStr, yStr2)
@@ -474,7 +508,9 @@ func (ss *ServerSession) forwardViaPeer(log logrus.FieldLogger, yStr io.ReadWrit
 		}
 
 		log := log.WithField("peer", peer.RemotePK())
-		log.Debug("Trying peer server for forwarding.")
+		if logging.TraceEnabled() {
+			logging.Trace(log, "Trying peer server for forwarding.")
+		}
 
 		err := ss.bridgeStream(log, yStr, peer, req)
 		if err == nil {
@@ -511,9 +547,14 @@ func (ss *ServerSession) forwardRequest(req StreamRequest) (mStr io.ReadWriteClo
 	// allocations in the dmsg-server heap).
 	defer func() {
 		if err != nil && mStr != nil {
-			ss.log.
-				WithError(mStr.Close()).
-				Debugf("After forwardRequest failed, the yamux stream is closed.")
+			// Close FIRST, then log. The close used to be the log call's
+			// argument, so anything that skipped or removed the log line would
+			// silently stop reclaiming the stream.
+			cerr := mStr.Close()
+			if logging.TraceEnabled() {
+				logging.Trace(ss.log.WithError(cerr),
+					"After forwardRequest failed, the yamux stream is closed.")
+			}
 		}
 	}()
 	switch {

--- a/pkg/logging/level_gate_test.go
+++ b/pkg/logging/level_gate_test.go
@@ -1,0 +1,58 @@
+// Package logging pkg/logging/level_gate_test.go c0-com-util
+package logging
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+type capture struct{ entries []*logrus.Entry }
+
+func (c *capture) Levels() []logrus.Level { return logrus.AllLevels }
+func (c *capture) Fire(e *logrus.Entry) error {
+	c.entries = append(c.entries, e)
+	return nil
+}
+
+// The gates follow the master logger's level, and Trace reaches a level the
+// logrus.FieldLogger interface does not expose.
+func TestLevelGates(t *testing.T) {
+	old := GetLevel()
+	defer SetLevel(old)
+
+	SetLevel(logrus.InfoLevel)
+	require.False(t, DebugEnabled())
+	require.False(t, TraceEnabled())
+
+	SetLevel(logrus.DebugLevel)
+	require.True(t, DebugEnabled())
+	require.False(t, TraceEnabled(), "debug must not turn on the per-stream trace")
+
+	SetLevel(logrus.TraceLevel)
+	require.True(t, DebugEnabled())
+	require.True(t, TraceEnabled())
+}
+
+func TestTraceReachesTraceLevel(t *testing.T) {
+	l := logrus.New()
+	l.SetLevel(logrus.TraceLevel)
+	l.SetOutput(discard{})
+	c := &capture{}
+	l.AddHook(c)
+
+	Trace(l, "per-stream detail")
+	require.Len(t, c.entries, 1)
+	require.Equal(t, logrus.TraceLevel, c.entries[0].Level)
+	require.Equal(t, "per-stream detail", c.entries[0].Message)
+
+	// Below trace it emits nothing.
+	l.SetLevel(logrus.DebugLevel)
+	Trace(l, "dropped")
+	require.Len(t, c.entries, 1)
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -84,3 +84,21 @@ func SetOutputTo(w io.Writer) {
 func Disable() {
 	log.Out = io.Discard
 }
+
+// DebugEnabled reports whether the master logger emits at debug level or
+// below. Use it to skip building log fields on a hot path: logrus's
+// WithField allocates a new Entry and copies the field map whether or not
+// the level is enabled, so an ungated WithField chain costs the same when
+// the line is never printed.
+func DebugEnabled() bool { return log.GetLevel() >= logrus.DebugLevel }
+
+// TraceEnabled reports whether the master logger emits at trace level.
+// Same rationale as DebugEnabled; trace carries the per-stream and
+// per-frame diagnostics that are useless in aggregate and expensive to
+// format at volume.
+func TraceEnabled() bool { return log.GetLevel() >= logrus.TraceLevel }
+
+// Trace emits msg at trace level through a logrus.FieldLogger, whose
+// interface omits the Trace methods (see Logger.Tracef). Callers on a hot
+// path must guard it with TraceEnabled: reaching the entry allocates.
+func Trace(l logrus.FieldLogger, msg string) { l.WithFields(logrus.Fields{}).Trace(msg) }


### PR DESCRIPTION
A dmsg server logs seven debug lines per forwarded stream. On dmsg-server-6, which runs at debug, that is 8.8k streams a minute producing 61.7k of its 67k log lines, 4% of the process's CPU in the formatter and 9% of host CPU in dockerd's json-file driver.

The six state-machine notes move to trace behind a level check, and the open/close pair becomes a single line at close carrying the outcome and the stream's lifetime. The `src_addr`/`dst_addr` enrichment is also guarded, because logrus `WithField` allocates an `Entry` and copies the field map even when the level is off, which the server pays per stream at info too.

One correctness fix comes with it: the close of a failed forward's yamux stream was written as the argument of its own log call, so anything that skipped or removed that line would silently stop reclaiming the stream. That is the leak the surrounding comment attributes to a ~340 MB dmsg-server heap. It now closes first and logs after.

From the same logging audit as #4779.
