### PR TITLE
perf(logging): stop paying for log lines nobody reads

### DIFF
--- a/pkg/deployment/ar/api/api.go
+++ b/pkg/deployment/ar/api/api.go
@@ -889,7 +889,12 @@ func (a *API) ListenUDP(listener net.Listener) {
 			continue
 		}
 
-		a.log.Debugf("Accepted new UDP connection from %q", conn.RemoteAddr())
+		// Per-connection and below debug: every visor in the network
+		// re-dials this listener, and the interesting line is the "Bound
+		// ... (SUDPH)" that follows a successful handshake, not the accept.
+		if logging.TraceEnabled() {
+			logging.Trace(a.log, fmt.Sprintf("Accepted new UDP connection from %q", conn.RemoteAddr()))
+		}
 
 		go func(c net.Conn) {
 			defer func() { <-sem }()
@@ -1018,6 +1023,11 @@ func (a *API) bindSUDPH(conn net.Conn, remoteAddr, strPK string) {
 	go func(pk cipher.PubKey, fromAddr string, conn net.Conn) {
 		defer a.cleanupUDPConn(pk, conn)
 
+		// Last address this peer was bound to, so a routine re-register
+		// (once a minute per visor, address unchanged) stays at trace and
+		// only an actual move is worth debug.
+		boundV4, boundV6 := visorData.RemoteAddr, visorData.RemoteAddrV6
+
 		for {
 			if err := conn.SetReadDeadline(time.Now().Add(sudphReadTimeout)); err != nil {
 				a.log.Warnf("Failed to set read deadline for %v: %v", pk, err)
@@ -1033,7 +1043,7 @@ func (a *API) bindSUDPH(conn net.Conn, remoteAddr, strPK string) {
 			}
 
 			data := buf[:n]
-			a.log.Debugf("(SUDPH) New packet from %v@%v: %v", pk, fromAddr, string(data))
+			logSUDPHPacket(a.log, pk, fromAddr, data)
 			if string(data) == addrresolver.UDPKeepHeartbeatMessage {
 				// Echo heartbeats so the visor can detect a dead AR
 				// connection. Over KCP-on-UDP a visor's writes keep
@@ -1076,11 +1086,40 @@ func (a *API) bindSUDPH(conn net.Conn, remoteAddr, strPK string) {
 					a.log.Warnf("Failed to re-bind (SUDPH) for %v: %v", pk, err)
 				} else {
 					a.mirrorSUDPH(pk, &newVisorData)
-					a.log.Debugf("Re-bound %v to %v (SUDPH)", pk, fromAddr)
+					if v4Re != boundV4 || v6Re != boundV6 {
+						a.log.Debugf("Re-bound %v to %v/%v (SUDPH, was %v/%v)", pk, v4Re, v6Re, boundV4, boundV6)
+						boundV4, boundV6 = v4Re, v6Re
+					} else if logging.TraceEnabled() {
+						logging.Trace(a.log, fmt.Sprintf("(SUDPH) re-register from %v@%v, address unchanged", pk, fromAddr))
+					}
 				}
 			}
 		}
 	}(pk, remoteAddr, conn)
+}
+
+// logSUDPHPacket records the arrival of an inbound SUDPH datagram.
+//
+// It is on the hottest path in the address resolver: every visor in the
+// network sends a keepalive here on a short timer, and this runs once per
+// datagram. Two things therefore matter.
+//
+// The payload is not logged. It used to be formatted as string(data), which
+// copies the whole datagram on every packet whether or not the level is on,
+// because the conversion happens at the call site before the logger ever
+// sees it. The bytes are also not worth having: a packet is either one of
+// two fixed control words, which the branches below already report, or a
+// visor's local-address JSON, which the re-bind line reports. Only the
+// length is kept, in case a peer starts sending something unexpected.
+//
+// The level is trace, and guarded. Per-packet lines are noise in aggregate,
+// and reaching a logrus entry at all allocates even when the entry is
+// discarded, so the gate has to be here rather than inside logrus.
+func logSUDPHPacket(log logrus.FieldLogger, pk cipher.PubKey, fromAddr string, data []byte) {
+	if !logging.TraceEnabled() {
+		return
+	}
+	logging.Trace(log, fmt.Sprintf("(SUDPH) new packet from %v@%v: %d bytes", pk, fromAddr, len(data)))
 }
 
 // cleanupUDPConn removes the connection from the map (if it's still the same one)

--- a/pkg/deployment/ar/api/sudph_packet_log_test.go
+++ b/pkg/deployment/ar/api/sudph_packet_log_test.go
@@ -1,0 +1,74 @@
+// Package api pkg/deployment/ar/api/sudph_packet_log_test.go c4-net-discovery
+package api
+
+import (
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// packetLogHook records every entry the logger emits.
+type packetLogHook struct{ entries []*logrus.Entry }
+
+func (h *packetLogHook) Levels() []logrus.Level { return logrus.AllLevels }
+func (h *packetLogHook) Fire(e *logrus.Entry) error {
+	h.entries = append(h.entries, e)
+	return nil
+}
+
+func packetLogger() (*logrus.Logger, *packetLogHook) {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	l.SetLevel(logrus.TraceLevel)
+	h := &packetLogHook{}
+	l.AddHook(h)
+	return l, h
+}
+
+// The per-packet SUDPH log costs nothing when the level is off. It used to
+// format string(data) at the call site, copying every datagram the address
+// resolver received whether or not the line was ever printed.
+func TestLogSUDPHPacketCostsNothingWhenOff(t *testing.T) {
+	old := logging.GetLevel()
+	defer logging.SetLevel(old)
+
+	l, h := packetLogger()
+	pk, _ := cipher.GenerateKeyPair()
+	payload := []byte("SECRET-PAYLOAD-do-not-log")
+
+	logging.SetLevel(logrus.DebugLevel)
+	logSUDPHPacket(l, pk, "1.2.3.4:5", payload)
+	require.Empty(t, h.entries, "a per-packet line must not be emitted below trace")
+
+	allocs := testing.AllocsPerRun(100, func() {
+		logSUDPHPacket(l, pk, "1.2.3.4:5", payload)
+	})
+	require.Zero(t, allocs, "the disabled per-packet log must not allocate, let alone copy the payload")
+}
+
+// When the level is on, the line reports the length and never the bytes: the
+// payload is either a control word the caller already logs or a visor's
+// local-address JSON, and it may carry whatever a peer chose to send.
+func TestLogSUDPHPacketOmitsPayload(t *testing.T) {
+	old := logging.GetLevel()
+	defer logging.SetLevel(old)
+	logging.SetLevel(logrus.TraceLevel)
+
+	l, h := packetLogger()
+	pk, _ := cipher.GenerateKeyPair()
+	payload := []byte("SECRET-PAYLOAD-do-not-log")
+
+	logSUDPHPacket(l, pk, "1.2.3.4:5", payload)
+
+	require.Len(t, h.entries, 1)
+	e := h.entries[0]
+	require.Equal(t, logrus.TraceLevel, e.Level, "per-packet lines belong below debug")
+	require.NotContains(t, e.Message, "SECRET-PAYLOAD", "the payload must never reach the log")
+	require.Contains(t, e.Message, "25 bytes")
+	require.Contains(t, e.Message, pk.String())
+}

--- a/pkg/dmsg/discovery/api/api.go
+++ b/pkg/dmsg/discovery/api/api.go
@@ -267,6 +267,19 @@ func (a *API) log(r *http.Request) logrus.FieldLogger {
 	return httputil.GetLogger(r)
 }
 
+// logServerRegistration emits the dmsg-server registration line. reason names
+// what made this registration worth a line, so a grep can separate a restart
+// from a key collision without diffing sequences by eye.
+func (a *API) logServerRegistration(r *http.Request, entry *disc.Entry, prevSeq uint64, reason string) {
+	a.log(r).WithField("server_pk", entry.Static).
+		WithField("address", entry.Server.Address).
+		WithField("sequence", entry.Sequence).
+		WithField("prev_sequence", prevSeq).
+		WithField("src", r.RemoteAddr).
+		WithField("reason", reason).
+		Info("dmsg-server entry registration")
+}
+
 // RunBackgroundTasks is goroutine which runs in background periodic tasks of dmsg-discovery.
 func (a *API) RunBackgroundTasks(ctx context.Context, log logrus.FieldLogger) {
 	ticker := time.NewTicker(time.Second * 10)
@@ -529,17 +542,32 @@ func (a *API) setEntry() func(w http.ResponseWriter, r *http.Request) {
 		// `src` for one `server_pk`, or a sequence climbing far faster than the
 		// ~1/min heartbeat, points straight at the offender. Placed before the
 		// iteration check so rejected (out-of-sequence) attempts are logged too.
+		//
+		// Only when something actually changed. A healthy server re-registers
+		// about once a minute and the entry is identical bar a sequence that
+		// stepped by exactly one — nine servers logging that at Info was ~78
+		// lines per two minutes saying nothing. A first registration, a
+		// sequence that did not step by one (a restart, an out-of-order
+		// attempt, or two processes sharing a key), or a moved address are all
+		// news and still logged.
 		if entry.Server != nil {
 			var prevSeq uint64
-			if err == nil && oldEntry != nil {
+			var prevAddr string
+			known := err == nil && oldEntry != nil
+			if known {
 				prevSeq = oldEntry.Sequence
+				if oldEntry.Server != nil {
+					prevAddr = oldEntry.Server.Address
+				}
 			}
-			a.log(r).WithField("server_pk", entry.Static).
-				WithField("address", entry.Server.Address).
-				WithField("sequence", entry.Sequence).
-				WithField("prev_sequence", prevSeq).
-				WithField("src", r.RemoteAddr).
-				Info("dmsg-server entry registration")
+			switch {
+			case !known:
+				a.logServerRegistration(r, entry, prevSeq, "new")
+			case entry.Sequence != prevSeq+1:
+				a.logServerRegistration(r, entry, prevSeq, "sequence-gap")
+			case prevAddr != entry.Server.Address:
+				a.logServerRegistration(r, entry, prevSeq, "address-changed")
+			}
 		}
 
 		if err == disc.ErrKeyNotFound {

--- a/pkg/dmsg/discovery/api/error_handler.go
+++ b/pkg/dmsg/discovery/api/error_handler.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 )
 
@@ -47,9 +49,29 @@ func (a *API) handleError(w http.ResponseWriter, r *http.Request, e error) {
 		code, msg = f()
 	}
 
-	if code != http.StatusNotFound {
-		a.log(r).Warnf("%d: %s", code, e)
-	}
+	logAPIError(a.log(r), code, e)
 
 	a.writeJSON(w, r, code, disc.HTTPMessage{Code: code, Message: msg})
+}
+
+// logAPIError records a rejected request at a level that matches whose fault
+// it is.
+//
+// A 4xx is the remote peer's mistake and the response already tells it so;
+// the discovery has nothing to act on. Logging those at warn let any peer
+// fill this service's log at warn just by re-posting a stale entry — the 422
+// "sequence field of new entry is not sequence of old entry" alone ran at ~88
+// per two minutes in production, drowning the warnings that do mean something
+// is wrong here. A 5xx is this service's own failure and stays at warn. A 404
+// is the ordinary answer to a lookup for a key that was never registered, so
+// it stays unlogged.
+func logAPIError(log logrus.FieldLogger, code int, e error) {
+	switch {
+	case code == http.StatusNotFound:
+		// A miss is a normal answer, not an error worth a line.
+	case code >= http.StatusInternalServerError:
+		log.Warnf("%d: %s", code, e)
+	default:
+		log.Debugf("%d: %s", code, e)
+	}
 }

--- a/pkg/dmsg/discovery/api/error_level_test.go
+++ b/pkg/dmsg/discovery/api/error_level_test.go
@@ -1,0 +1,52 @@
+// Package api pkg/dmsg/discovery/api/error_level_test.go c1-net-dmsg
+package api
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+type levelHook struct{ entries []*logrus.Entry }
+
+func (h *levelHook) Levels() []logrus.Level { return logrus.AllLevels }
+func (h *levelHook) Fire(e *logrus.Entry) error {
+	h.entries = append(h.entries, e)
+	return nil
+}
+
+// Rejecting a peer's bad request is not a warning about this service. A remote
+// peer re-posting a stale entry could otherwise fill the discovery's log at
+// Warn — the 422 below was measured at ~88 per two minutes in production.
+func TestLogAPIErrorLevelByStatus(t *testing.T) {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	l.SetLevel(logrus.DebugLevel)
+	h := &levelHook{}
+	l.AddHook(h)
+
+	// A lookup for an unregistered key is the ordinary answer: unlogged.
+	logAPIError(l, http.StatusNotFound, disc.ErrKeyNotFound)
+	require.Empty(t, h.entries)
+
+	// 4xx is the peer's mistake, and the response already says so.
+	logAPIError(l, http.StatusUnprocessableEntity,
+		disc.NewEntryValidationError("sequence field of new entry is not sequence of old entry"))
+	require.Len(t, h.entries, 1)
+	require.Equal(t, logrus.DebugLevel, h.entries[0].Level)
+
+	logAPIError(l, http.StatusUnauthorized, disc.ErrUnauthorized)
+	require.Len(t, h.entries, 2)
+	require.Equal(t, logrus.DebugLevel, h.entries[1].Level)
+
+	// 5xx is this service failing, and stays a warning.
+	logAPIError(l, http.StatusInternalServerError, disc.ErrUnexpected)
+	require.Len(t, h.entries, 3)
+	require.Equal(t, logrus.WarnLevel, h.entries[2].Level)
+	require.Contains(t, h.entries[2].Message, "500")
+}

--- a/pkg/httputil/get_logger_test.go
+++ b/pkg/httputil/get_logger_test.go
@@ -1,0 +1,76 @@
+// Package httputil pkg/httputil/get_logger_test.go c0-com-http
+package httputil
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// A context miss is the common case (SetLoggerMiddleware only populates the
+// context when a request ID is present), so it must not build a logger. It
+// used to return a fresh logging.NewMasterLogger() per call.
+func TestGetLoggerFallbackIsShared(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/p", nil)
+
+	first := GetLogger(r)
+	second := GetLogger(r)
+
+	require.NotNil(t, first)
+	require.Same(t, first, second, "a context miss must reuse one logger, not construct one per call")
+
+	allocs := testing.AllocsPerRun(100, func() { _ = GetLogger(r) })
+	require.Zero(t, allocs, "a context miss must not allocate")
+}
+
+// A logger in the context still wins.
+func TestGetLoggerPrefersContext(t *testing.T) {
+	ctxLog := logrus.New().WithField("RequestID", "abc")
+	r := httptest.NewRequest(http.MethodGet, "/p", nil).
+		WithContext(context.WithValue(context.Background(), LoggerKey, logrus.FieldLogger(ctxLog)))
+
+	require.Same(t, ctxLog, GetLogger(r))
+}
+
+// The fallback routes through the master logger, so the process's hooks and
+// configured level apply to it. The per-call master logger it replaced was its
+// own root and its entries escaped both.
+func TestGetLoggerFallbackObeysMasterLogger(t *testing.T) {
+	logging.SetOutputTo(io.Discard)
+	defer logging.SetOutputTo(os.Stderr)
+
+	oldLevel := logging.GetLevel()
+	defer logging.SetLevel(oldLevel)
+
+	hook := &collectHook{}
+	logging.AddHook(hook)
+
+	const msg = "httputil-fallback-probe"
+	count := func() int {
+		n := 0
+		for _, e := range hook.entries {
+			if e.Message == msg {
+				n++
+			}
+		}
+		return n
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/p", nil)
+
+	logging.SetLevel(logrus.InfoLevel)
+	GetLogger(r).Debug(msg)
+	require.Zero(t, count(), "the configured level must apply to the fallback logger")
+
+	logging.SetLevel(logrus.DebugLevel)
+	GetLogger(r).Debug(msg)
+	require.Equal(t, 1, count(), "the process hooks must see the fallback logger's entries")
+}

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -130,13 +130,22 @@ type ctxKeyLogger int
 // LoggerKey defines logger HTTP context key.
 const LoggerKey ctxKeyLogger = -1
 
-// GetLogger returns logger from HTTP context.
+// GetLogger returns the logger carried by the HTTP request context, or the
+// package logger when the context has none.
+//
+// The miss is the common case, not an edge case: SetLoggerMiddleware only
+// puts a logger in the context when a request ID is present. This used to
+// return logging.NewMasterLogger(), which built a whole logrus.Logger,
+// TextFormatter and hook map per call, and whose entries then bypassed the
+// process hooks and configured level because it was its own master. The
+// package logger is created once and routes through the master logger, so
+// hooks and level apply.
 func GetLogger(r *http.Request) logrus.FieldLogger {
-	if log, ok := r.Context().Value(LoggerKey).(logrus.FieldLogger); ok && log != nil {
-		return log
+	if ctxLog, ok := r.Context().Value(LoggerKey).(logrus.FieldLogger); ok && ctxLog != nil {
+		return ctxLog
 	}
 
-	return logging.NewMasterLogger()
+	return log
 }
 
 // todo: investigate if it's used throughout the services (didn't work properly for UT)


### PR DESCRIPTION
Three hot paths built log messages regardless of level, or logged a peer's mistakes as if they were ours.

The address resolver formatted `string(data)` for every inbound SUDPH datagram, copying the whole payload at the call site whether or not debug was on. The payload is not useful — a packet is a fixed control word or a visor's local-address JSON, both reported by the branches that follow — and may be whatever a peer chose to send, so only its length is logged now, behind a `TraceEnabled` gate. The accept and routine re-register lines drop to trace too; a re-bind is still logged at debug when the address actually moves.

`httputil.GetLogger` built a fresh `MasterLogger` on every context miss, and misses are the common case since `SetLoggerMiddleware` only fills the context when a request ID is present. That per-call logger was also its own master, so its entries bypassed the process hooks and configured level. It returns the package logger instead.

The dmsg discovery logged every 4xx at warn, so any peer could fill the service's log by re-posting a stale entry — the 422 sequence rejection alone ran at ~88 lines per two minutes on production. 4xx goes to debug, 5xx stays at warn. The per-server registration line (~78 per two minutes of "sequence advanced by one, nothing else changed") now logs only a first registration, a sequence gap, or a moved address. Regression tests cover all three.