### PR TITLE
perf(logging): stop formatting every log entry twice in the capture hooks

### DIFF
--- a/pkg/logging/broadcaster.go
+++ b/pkg/logging/broadcaster.go
@@ -20,6 +20,15 @@ import (
 type Broadcaster struct {
 	mu   sync.RWMutex
 	subs map[*subscription]struct{}
+	// subCount mirrors len(subs) so Fire can tell there is nobody to fan out
+	// to with one atomic load instead of an RWMutex acquire plus a map range,
+	// on every entry. Zero subscribers is the steady state: the verbose
+	// gRPC stream only exists while somebody is watching it.
+	subCount atomic.Int64
+
+	// ringCaptureOff disables the per-app ring below. Inverted so the zero
+	// value keeps capture on, matching the previous behavior.
+	ringCaptureOff atomic.Bool
 
 	// ring is a bounded per-app history captured from the same Fire path
 	// that feeds live subscribers (see ring.go). It lets the proxy status
@@ -80,22 +89,43 @@ func (b *Broadcaster) Levels() []logrus.Level {
 	return logrus.AllLevels
 }
 
+// SetRingCapture turns the bounded per-app ring on or off. It is on by
+// default; a process that never reads the ring back (nothing calls
+// RecentByApp / RecentMerged) can turn it off so Fire returns on a single
+// atomic load, before any field resolution or Record allocation.
+func (b *Broadcaster) SetRingCapture(enabled bool) {
+	b.ringCaptureOff.Store(!enabled)
+}
+
 // Fire delivers e to every subscriber whose filter matches. Never
 // blocks on a slow consumer: full subscriber channels increment a
 // drop counter and continue.
+//
+// The hook is installed on the visor's master logger at AllLevels, so Fire
+// runs on every entry the process emits — measured at ~67k lines/min on a
+// busy node. Both halves are therefore short-circuited: the subscriber
+// fan-out is skipped entirely (no RWMutex acquire, no map range) when nothing
+// is subscribed, which is the steady state, and the ring capture is skipped
+// when it has been turned off. Only when one of them is actually live does an
+// entry pay for field resolution or allocation.
 func (b *Broadcaster) Fire(e *logrus.Entry) error {
-	b.mu.RLock()
-	for sub := range b.subs {
-		if !sub.matches(e) {
-			continue
+	if b.subCount.Load() > 0 {
+		b.mu.RLock()
+		for sub := range b.subs {
+			if !sub.matches(e) {
+				continue
+			}
+			select {
+			case sub.ch <- e:
+			default:
+				atomic.AddUint64(&sub.dropped, 1)
+			}
 		}
-		select {
-		case sub.ch <- e:
-		default:
-			atomic.AddUint64(&sub.dropped, 1)
-		}
+		b.mu.RUnlock()
 	}
-	b.mu.RUnlock()
+	if b.ringCaptureOff.Load() {
+		return nil
+	}
 	// Capture into the bounded per-app ring for later read-back. Same tap,
 	// not a second sink.
 	b.record(e)
@@ -118,7 +148,11 @@ func (b *Broadcaster) Subscribe(f Filter, capacity int) (<-chan *logrus.Entry, f
 		ch:     make(chan *logrus.Entry, capacity),
 	}
 	b.mu.Lock()
+	if b.subs == nil {
+		b.subs = make(map[*subscription]struct{})
+	}
 	b.subs[sub] = struct{}{}
+	b.subCount.Store(int64(len(b.subs)))
 	b.mu.Unlock()
 
 	cancel := func() uint64 {
@@ -130,6 +164,7 @@ func (b *Broadcaster) Subscribe(f Filter, capacity int) (<-chan *logrus.Entry, f
 		// sending to a closed channel.
 		b.mu.Lock()
 		delete(b.subs, sub)
+		b.subCount.Store(int64(len(b.subs)))
 		b.mu.Unlock()
 		close(sub.ch)
 		return atomic.LoadUint64(&sub.dropped)

--- a/pkg/logging/hook_levels_test.go
+++ b/pkg/logging/hook_levels_test.go
@@ -1,0 +1,158 @@
+// Package logging pkg/logging/hook_levels_test.go c0-com-log
+package logging
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// countingFormatter wraps a formatter and counts how many times it ran, so a
+// test can assert the SECOND format pass a capture hook performs is actually
+// skipped rather than merely producing no output.
+type countingFormatter struct {
+	inner logrus.Formatter
+	n     int
+}
+
+func (c *countingFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	c.n++
+	return c.inner.Format(e)
+}
+
+func newCountingWriteHook(w io.Writer, level logrus.Level) (*WriteHook, *countingFormatter) {
+	h := NewWriteHookLevel(w, level)
+	cf := &countingFormatter{inner: h.formatter}
+	h.formatter = cf
+	return h, cf
+}
+
+// The default WriteHook must not re-format debug entries: that second pass was
+// ~10 MB/min of formatting on a production dmsg-server at debug level, poured
+// into a 256 KiB ring that could only hold ~1.5s of it.
+func TestWriteHookSkipsDebugByDefault(t *testing.T) {
+	require.Equal(t, logrus.InfoLevel, DefaultHookLevel)
+
+	var buf bytes.Buffer
+	h := NewWriteHook(&buf)
+	require.NotContains(t, h.Levels(), logrus.DebugLevel)
+	require.NotContains(t, h.Levels(), logrus.TraceLevel)
+	require.Contains(t, h.Levels(), logrus.InfoLevel)
+	require.Contains(t, h.Levels(), logrus.ErrorLevel)
+
+	h, cf := newCountingWriteHook(&buf, HookLevel(DefaultHookLevel))
+	l := logrus.New()
+	l.SetLevel(logrus.TraceLevel)
+	l.SetOutput(io.Discard)
+	l.AddHook(h)
+
+	l.Trace("hot-trace")
+	l.Debug("hot-debug")
+	require.Zero(t, cf.n, "debug/trace must never reach the hook's formatter")
+
+	l.Info("kept-info")
+	l.Error("kept-error")
+	require.Equal(t, 2, cf.n)
+
+	out := buf.String()
+	require.Contains(t, out, "kept-info")
+	require.Contains(t, out, "kept-error")
+	require.NotContains(t, out, "hot-debug")
+	require.NotContains(t, out, "hot-trace")
+}
+
+// An operator debugging a service must still be able to put debug lines back
+// into the ring the /debug/log endpoint serves.
+func TestWriteHookDebugOptIn(t *testing.T) {
+	var buf bytes.Buffer
+	h, cf := newCountingWriteHook(&buf, logrus.DebugLevel)
+	l := logrus.New()
+	l.SetLevel(logrus.DebugLevel)
+	l.SetOutput(io.Discard)
+	l.AddHook(h)
+
+	l.Debug("wanted-debug")
+	require.Equal(t, 1, cf.n)
+	require.Contains(t, buf.String(), "wanted-debug")
+}
+
+func TestHookLevelEnvOverride(t *testing.T) {
+	require.Equal(t, logrus.InfoLevel, HookLevel(logrus.InfoLevel))
+
+	t.Setenv(HookLevelEnv, "debug")
+	require.Equal(t, logrus.DebugLevel, HookLevel(logrus.InfoLevel))
+
+	// The env var reaches the constructor, so an operator gets debug in the
+	// ring without a code change.
+	var buf bytes.Buffer
+	require.Contains(t, NewWriteHook(&buf).Levels(), logrus.DebugLevel)
+
+	// Garbage falls back to the caller's default rather than silently
+	// widening or breaking /debug/log.
+	t.Setenv(HookLevelEnv, "not-a-level")
+	require.Equal(t, logrus.InfoLevel, HookLevel(logrus.InfoLevel))
+}
+
+func TestLevelsUpTo(t *testing.T) {
+	require.Equal(t, []logrus.Level{logrus.PanicLevel}, LevelsUpTo(logrus.PanicLevel))
+	require.Equal(t, logrus.AllLevels, LevelsUpTo(logrus.TraceLevel))
+	// Out-of-range clamps rather than panicking on the slice bound.
+	require.Equal(t, logrus.AllLevels, LevelsUpTo(logrus.Level(99)))
+}
+
+// With nothing subscribed and the ring off, Fire must return before doing any
+// field resolution or allocation — it runs on every entry the process emits.
+func TestBroadcasterFireShortCircuits(t *testing.T) {
+	b := NewBroadcaster()
+
+	// No subscribers and ring capture off: Fire must do nothing at all.
+	b.SetRingCapture(false)
+	e := logrus.NewEntry(logrus.New())
+	e.Level = logrus.InfoLevel
+	e.Message = "orphan"
+	e.Data = logrus.Fields{logModuleKey: "proc:skysocks-client:abc"}
+	require.NoError(t, b.Fire(e))
+
+	events, logs := b.RecentByApp("skysocks-client", logrus.DebugLevel)
+	require.Nil(t, events)
+	require.Nil(t, logs)
+
+	// Ring capture back on (the default) still records.
+	b.SetRingCapture(true)
+	require.NoError(t, b.Fire(e))
+	_, logs = b.RecentByApp("skysocks-client", logrus.DebugLevel)
+	require.Len(t, logs, 1)
+	require.Equal(t, "orphan", logs[0].Message)
+}
+
+// The fan-out is skipped on the zero-subscriber fast path, so subCount must
+// track Subscribe/cancel exactly or live subscribers would go silent.
+func TestBroadcasterSubCountTracksSubscribers(t *testing.T) {
+	b := NewBroadcaster()
+	b.SetRingCapture(false)
+	require.Zero(t, b.subCount.Load())
+
+	ch, cancel := b.Subscribe(Filter{Modules: []string{"router"}}, 4)
+	require.EqualValues(t, 1, b.subCount.Load())
+
+	e := logrus.NewEntry(logrus.New())
+	e.Level = logrus.InfoLevel
+	e.Message = "delivered"
+	e.Data = logrus.Fields{logModuleKey: "router"}
+	require.NoError(t, b.Fire(e))
+
+	select {
+	case got := <-ch:
+		require.Equal(t, "delivered", got.Message)
+	default:
+		t.Fatal("entry was not delivered to a live subscriber")
+	}
+
+	cancel()
+	require.Zero(t, b.subCount.Load())
+	// Fire after cancel must not panic on the closed channel.
+	require.NoError(t, b.Fire(e))
+}

--- a/pkg/logging/hooks.go
+++ b/pkg/logging/hooks.go
@@ -3,18 +3,78 @@ package logging
 
 import (
 	"io"
+	"os"
 
 	"github.com/sirupsen/logrus"
 )
+
+// DefaultHookLevel is the most verbose level a capture hook accepts unless the
+// caller asks for something else.
+//
+// It is deliberately not logrus.AllLevels. A capture hook is a SECOND complete
+// formatting pass over every entry it accepts: WriteHook.Fire below runs
+// TextFormatter.Format into a fresh buffer for each entry, on top of the pass
+// the logger already did for stdout. Measured on a production dmsg-server
+// running at debug: ~67k lines/min reached the hook, ~10 MB/min of formatted
+// output poured into a 256 KiB RingBuffer (DefaultRingBufferBytes). That is
+// ~1.5 seconds of retained history on the /debug/log endpoint the ring feeds,
+// bought by doubling the formatting cost of every log line in the process.
+//
+// Info and above is what /debug/log is actually read for, and the services
+// default to info anyway (skyenv.LogLevel), so this changes nothing about what
+// the endpoint returns at the normal level — it only keeps the debug/trace
+// firehose out of the second formatter.
+const DefaultHookLevel = logrus.InfoLevel
+
+// HookLevelEnv names the environment variable an operator sets to change the
+// levels the capture hooks accept, e.g. SKYWIRE_LOG_HOOK_LEVEL=debug to put
+// debug lines back into /debug/log for a debugging session. Accepted values
+// are the ones LevelFromString takes; anything unparseable is ignored.
+const HookLevelEnv = "SKYWIRE_LOG_HOOK_LEVEL"
+
+// HookLevel returns def, or the level named by HookLevelEnv when that variable
+// is set to something LevelFromString understands. Capture hooks that want the
+// operator override use this to resolve their level.
+func HookLevel(def logrus.Level) logrus.Level {
+	s := os.Getenv(HookLevelEnv)
+	if s == "" {
+		return def
+	}
+	lvl, err := LevelFromString(s)
+	if err != nil {
+		return def
+	}
+	return lvl
+}
+
+// LevelsUpTo returns the logrus levels at least as severe as level, i.e. the
+// slice a logrus.Hook returns from Levels() to be fired only for those.
+func LevelsUpTo(level logrus.Level) []logrus.Level {
+	if level > logrus.TraceLevel {
+		level = logrus.TraceLevel
+	}
+	out := make([]logrus.Level, level+1)
+	copy(out, logrus.AllLevels[:level+1])
+	return out
+}
 
 // WriteHook is a logrus.Hook that logs to an io.Writer
 type WriteHook struct {
 	w         io.Writer
 	formatter logrus.Formatter
+	levels    []logrus.Level
 }
 
-// NewWriteHook returns a new WriteHook
+// NewWriteHook returns a new WriteHook accepting DefaultHookLevel and above,
+// or the level named by HookLevelEnv when the operator has set it.
 func NewWriteHook(w io.Writer) *WriteHook {
+	return NewWriteHookLevel(w, HookLevel(DefaultHookLevel))
+}
+
+// NewWriteHookLevel returns a new WriteHook that fires only for entries at
+// least as severe as level. Use it when the call site knows what it wants to
+// capture; NewWriteHook is the operator-configurable default.
+func NewWriteHookLevel(w io.Writer, level logrus.Level) *WriteHook {
 	return &WriteHook{
 		w: w,
 		formatter: &TextFormatter{
@@ -24,13 +84,15 @@ func NewWriteHook(w io.Writer) *WriteHook {
 			QuoteEmptyFields:   true,
 			ForceFormatting:    true,
 		},
+		levels: LevelsUpTo(level),
 	}
 }
 
-// Levels returns Levels accepted by the WriteHook.
-// All logrus.Levels are returned.
+// Levels returns the levels accepted by the WriteHook. Entries below the
+// configured level never reach Fire, and so never pay the second
+// TextFormatter.Format pass.
 func (f *WriteHook) Levels() []logrus.Level {
-	return logrus.AllLevels
+	return f.levels
 }
 
 // Fire writes a logrus.Entry to the file

--- a/pkg/logging/logging_more_test.go
+++ b/pkg/logging/logging_more_test.go
@@ -120,7 +120,9 @@ func TestWithAppName(t *testing.T) {
 func TestWriteHook(t *testing.T) {
 	var buf bytes.Buffer
 	h := NewWriteHook(&buf)
-	assert.Equal(t, logrus.AllLevels, h.Levels())
+	// Info and above by default — see DefaultHookLevel; the full-level
+	// behavior is covered in hook_levels_test.go.
+	assert.Equal(t, logrus.AllLevels[:logrus.InfoLevel+1], h.Levels())
 
 	require.NoError(t, h.Fire(newEntry(logrus.InfoLevel, "hooked-line", logrus.Fields{"k": "v"})))
 	out := buf.String()

--- a/pkg/visor/logstore/logstore.go
+++ b/pkg/visor/logstore/logstore.go
@@ -31,14 +31,45 @@ type Store interface {
 	GetLogsSince(since int64) (entries []string, dropped int64, latest int64)
 }
 
+// DefaultHookLevel is the most verbose level the hook returned by MakeStore
+// accepts.
+//
+// It is deliberately not logrus.AllLevels. Fire below takes a process-wide
+// mutex, allocates a new Entry via entry.WithField, runs a full
+// logrus.JSONFormatter.Format and copies the result into a string — for every
+// entry the visor emits, on top of the formatting the logger already did for
+// its own output. Measured on a production node running at debug, ~67k
+// lines/min reach a hook like this one; the store holds 300 entries, so at
+// that rate the buffer `cli visor log` and the hypervisor log viewer read back
+// is a sub-second window, bought by serializing the whole visor's logging
+// through one mutex and a second JSON encode.
+//
+// The visor's default log level is info (skyenv.LogLevel), so info-and-above
+// is exactly what those readers see today — this only keeps the hot debug and
+// trace paths out of the formatter and off the mutex.
+const DefaultHookLevel = logrus.InfoLevel
+
 // MakeStore returns a new store that will hold up to max entries,
 // overwriting the oldest entry when over the capacity
 // returned hook should be registered in logrus master logger to
-// store log entries
+// store log entries. The hook accepts DefaultHookLevel and above; use
+// MakeStoreLevel to capture more.
 func MakeStore(maxx int) (Store, logrus.Hook) {
+	return MakeStoreLevel(maxx, DefaultHookLevel)
+}
+
+// MakeStoreLevel is MakeStore with an explicit minimum severity for the
+// returned hook: entries less severe than level never reach Fire, and so never
+// pay the JSON encode or the store mutex.
+func MakeStoreLevel(maxx int, level logrus.Level) (Store, logrus.Hook) {
+	if level > logrus.TraceLevel {
+		level = logrus.TraceLevel
+	}
+	levels := make([]logrus.Level, level+1)
+	copy(levels, logrus.AllLevels[:level+1])
 	entries := make([]string, maxx)
 	formatter := &logrus.JSONFormatter{}
-	store := &store{cap: int64(maxx), entries: entries, formatter: formatter}
+	store := &store{cap: int64(maxx), entries: entries, formatter: formatter, levels: levels}
 	return store, store
 }
 
@@ -50,6 +81,7 @@ type store struct {
 	entryNum  int64
 	entries   []string
 	formatter logrus.Formatter
+	levels    []logrus.Level
 }
 
 // collect log lines into a single string, starting at from (inclusive)
@@ -112,9 +144,10 @@ func (s *store) GetLogsSince(since int64) ([]string, int64, int64) {
 }
 
 // Levels implements logrus.Hook interface. It denotes log levels
-// that we are interested in
+// that we are interested in — see DefaultHookLevel for why this is not
+// logrus.AllLevels.
 func (s *store) Levels() []logrus.Level {
-	return logrus.AllLevels
+	return s.levels
 }
 
 // Fire implements logrus.Hook interface to process new log entry

--- a/pkg/visor/logstore/logstore_test.go
+++ b/pkg/visor/logstore/logstore_test.go
@@ -1,6 +1,7 @@
 package logstore
 
 import (
+	"io"
 	"strings"
 	"testing"
 
@@ -21,7 +22,47 @@ func TestMakeStoreAndLevels(t *testing.T) {
 	store, hook := MakeStore(10)
 	require.NotNil(t, store)
 	require.NotNil(t, hook)
-	require.Equal(t, logrus.AllLevels, hook.Levels())
+	// Info and above only: the hook JSON-encodes every accepted entry under a
+	// process-wide mutex, so the debug firehose must not reach it by default.
+	require.Equal(t, logrus.AllLevels[:logrus.InfoLevel+1], hook.Levels())
+	require.NotContains(t, hook.Levels(), logrus.DebugLevel)
+	require.NotContains(t, hook.Levels(), logrus.TraceLevel)
+}
+
+// The hook must be a genuine no-op below its level — logrus consults Levels()
+// before calling Fire, so a debug line never reaches the JSON formatter or the
+// store mutex.
+func TestHookLevelGatesFire(t *testing.T) {
+	store, hook := MakeStore(10)
+
+	l := logrus.New()
+	l.SetLevel(logrus.DebugLevel)
+	l.SetOutput(io.Discard)
+	l.AddHook(hook)
+
+	l.Debug("hot-path-debug")
+	l.Info("kept-info")
+
+	logs, _ := store.GetLogs()
+	require.Len(t, logs, 1)
+	require.Contains(t, logs[0], "kept-info")
+}
+
+// An operator can still opt back in to capturing debug in the buffer.
+func TestMakeStoreLevelOptIn(t *testing.T) {
+	store, hook := MakeStoreLevel(10, logrus.DebugLevel)
+	require.Contains(t, hook.Levels(), logrus.DebugLevel)
+
+	l := logrus.New()
+	l.SetLevel(logrus.DebugLevel)
+	l.SetOutput(io.Discard)
+	l.AddHook(hook)
+
+	l.Debug("wanted-debug")
+
+	logs, _ := store.GetLogs()
+	require.Len(t, logs, 1)
+	require.Contains(t, logs[0], "wanted-debug")
 }
 
 func TestGetLogs_UnderCapacity(t *testing.T) {

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -579,7 +579,11 @@ func preflightSingleInstance(conf *visorconfig.V1, log logrus.FieldLogger) error
 // and the multi-service supervisor. parentCtx is the parent of the
 // SignalContext built around it.
 func run(parentCtx context.Context, conf *visorconfig.V1) error {
-	store, hook := logstore.MakeStore(runtimeLogMaxEntries)
+	// The runtime-log hook JSON-encodes every entry it accepts under a
+	// process-wide mutex, so it captures info and above by default rather than
+	// every level (see logstore.DefaultHookLevel). SKYWIRE_LOG_HOOK_LEVEL puts
+	// debug back in the buffer for a debugging session.
+	store, hook := logstore.MakeStoreLevel(runtimeLogMaxEntries, logging.HookLevel(logstore.DefaultHookLevel))
 	mLog.AddHook(hook)
 
 	// logBroadcaster fans out logrus entries to gRPC StreamAppLogs


### PR DESCRIPTION
The `/debug/log` ring hook (`logging.WriteHook`) and the visor's runtime-log store hook both accepted `logrus.AllLevels`, so every entry the process emitted got a second complete formatting pass on top of the one the logger already did for its own output. Measured on a production dmsg-server running at debug: ~67k lines/min through `WriteHook.Fire` is ~10 MB/min of `TextFormatter` output poured into a 256 KiB ring — the endpoint it feeds retained about 1.5 seconds of history in exchange for doubling the cost of every log line. The visor's logstore hook is worse per entry: a process-wide mutex, an `entry.WithField` allocation and a full `JSONFormatter` encode, for a 300-entry buffer.

Both hooks now default to info and above. `skyenv.LogLevel` is `"info"`, so `/debug/log`, `cli visor log` and the hypervisor log viewer return exactly what they returned before at the normal level; only the debug/trace firehose stops paying for the second formatter. Both stay configurable — `NewWriteHookLevel` / `MakeStoreLevel` for callers, and `SKYWIRE_LOG_HOOK_LEVEL=debug` for an operator who wants debug lines back in the buffer for a debugging session.

`Broadcaster.Fire` runs on every entry too. It now skips the subscriber fan-out on a single atomic load when nothing is subscribed (the steady state) instead of taking the RWMutex and ranging an empty map, and the per-app ring capture can be turned off with `SetRingCapture`. Ring capture stays on by default because the visor reads it back for `cli proxy log`. Tests in `pkg/logging` and `pkg/visor/logstore` cover the level gate — including a counting formatter asserting the second pass never runs below the configured level — and fail against the previous `AllLevels` behavior.