### PR TITLE
fix(logging): stop an unset log_level meaning debug, and give each service its own level

### DIFF
--- a/cmd/dmsg/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg/dmsg-server/commands/start/root.go
@@ -56,11 +56,16 @@ var RootCmd = &cobra.Command{
 			logger.WithError(err).Fatal("parsing config failed, generating default one...")
 		}
 
-		logLvl, _, err := cmdutil.LevelFromString(inner.LogLevel)
-		if err != nil {
-			log.Printf("Failed to set log level: %v", err)
+		// An empty log_level leaves the level the flags picked (info by
+		// default); an unparseable one is reported rather than silently
+		// dropping the server to debug for the life of the process.
+		if inner.LogLevel != "" {
+			logLvl, _, err := cmdutil.LevelFromString(inner.LogLevel)
+			if err != nil {
+				logger.WithError(err).Warnf("bad log_level in config; using %q", logLvl)
+			}
+			logging.SetLevel(logLvl)
 		}
-		logging.SetLevel(logLvl)
 
 		cfg := &dmsgsrv.Config{
 			Config:         inner,

--- a/pkg/cmdutil/service_flags.go
+++ b/pkg/cmdutil/service_flags.go
@@ -63,7 +63,7 @@ func (sf *ServiceFlags) Init(rootCmd *cobra.Command, defaultTag, defaultConf str
 		sf.SyslogNet = "udp" // NOTE: ServiceFlags is only used by vendored dmsg commands, not skywire itself
 	}
 	if sf.LogLevel == "" {
-		sf.LogLevel = "debug"
+		sf.LogLevel = "info"
 	}
 
 	// "exec" defaults

--- a/pkg/cmdutil/sysloghook_level_test.go
+++ b/pkg/cmdutil/sysloghook_level_test.go
@@ -1,0 +1,41 @@
+// Package cmdutil pkg/cmdutil/sysloghook_level_test.go c0-com-util
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// The syslog-aware parser must agree with pkg/logging: an unrecognized or
+// empty level is an error and yields info, never debug.
+func TestLevelFromStringFallsBackToInfo(t *testing.T) {
+	for _, s := range []string{"", "inof", "DEBUGG"} {
+		lvl, _, err := LevelFromString(s)
+		require.Errorf(t, err, "level %q must not parse", s)
+		require.ErrorIs(t, err, ErrInvalidLogString)
+		require.Equalf(t, logrus.InfoLevel, lvl, "level %q must fall back to info", s)
+		require.Containsf(t, err.Error(), s, "error must name the offending string %q", s)
+	}
+
+	for _, s := range []string{"debug", "info", "warn", "error", "fatal", "panic", "trace"} {
+		lvl, _, err := LevelFromString(s)
+		require.NoErrorf(t, err, "level %q must parse", s)
+		want, err := logging.LevelFromString(s)
+		require.NoError(t, err)
+		require.Equalf(t, want, lvl, "level %q must match pkg/logging", s)
+	}
+}
+
+// The default for --syslog-lvl is info. It used to be debug, which meant an
+// operator who never touched the flag ran the service verbose.
+func TestServiceFlagsDefaultLogLevelIsInfo(t *testing.T) {
+	var sf ServiceFlags
+	sf.Init(&cobra.Command{}, "test_tag", "")
+	require.Equal(t, "info", sf.LogLevel)
+	require.NoError(t, sf.Check())
+}

--- a/pkg/cmdutil/sysloghook_unix.go
+++ b/pkg/cmdutil/sysloghook_unix.go
@@ -5,6 +5,7 @@
 package cmdutil
 
 import (
+	"fmt"
 	"log/syslog"
 	"strings"
 
@@ -25,7 +26,10 @@ func (sf *ServiceFlags) sysLogHook(log *logging.Logger, sysLvl int) {
 	logging.AddHook(hook)
 }
 
-// LevelFromString returns a logrus.Level and syslog.Priority from a string identifier.
+// LevelFromString returns a logrus.Level and syslog.Priority from a string
+// identifier. An unrecognized (or empty) identifier yields info level plus an
+// error naming it — never debug, which would silently make an unattended
+// service verbose in production.
 func LevelFromString(s string) (logrus.Level, int, error) {
 	switch strings.ToLower(s) {
 	case "debug":
@@ -40,7 +44,9 @@ func LevelFromString(s string) (logrus.Level, int, error) {
 		return logrus.FatalLevel, int(syslog.LOG_CRIT), nil
 	case "panic":
 		return logrus.PanicLevel, int(syslog.LOG_EMERG), nil
+	case "trace":
+		return logrus.TraceLevel, int(syslog.LOG_DEBUG), nil
 	default:
-		return logrus.DebugLevel, int(syslog.LOG_DEBUG), ErrInvalidLogString
+		return logrus.InfoLevel, int(syslog.LOG_INFO), fmt.Errorf("%w: %q", ErrInvalidLogString, s)
 	}
 }

--- a/pkg/cmdutil/sysloghook_windows.go
+++ b/pkg/cmdutil/sysloghook_windows.go
@@ -5,6 +5,7 @@
 package cmdutil
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -15,7 +16,10 @@ import (
 func (sf *ServiceFlags) sysLogHook(_ *logging.Logger, _ int) {
 }
 
-// LevelFromString returns a logrus.Level and syslog.Priority from a string identifier.
+// LevelFromString returns a logrus.Level and syslog.Priority from a string
+// identifier. An unrecognized (or empty) identifier yields info level plus an
+// error naming it — never debug, which would silently make an unattended
+// service verbose in production.
 func LevelFromString(s string) (logrus.Level, int, error) {
 	switch strings.ToLower(s) {
 	case "debug":
@@ -30,7 +34,9 @@ func LevelFromString(s string) (logrus.Level, int, error) {
 		return logrus.FatalLevel, 0, nil
 	case "panic":
 		return logrus.PanicLevel, 0, nil
+	case "trace":
+		return logrus.TraceLevel, 0, nil
 	default:
-		return logrus.DebugLevel, 0, ErrInvalidLogString
+		return logrus.InfoLevel, 0, fmt.Errorf("%w: %q", ErrInvalidLogString, s)
 	}
 }

--- a/pkg/logging/level_default_test.go
+++ b/pkg/logging/level_default_test.go
@@ -1,0 +1,73 @@
+// Package logging pkg/logging/level_default_test.go c0-com-log
+package logging
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// An unrecognized or empty level must never mean debug: an unattended service
+// whose config says "log_level": "" (or "inof") would otherwise run verbose in
+// production, and the caller that logs the error and carries on would never say
+// so. Info is the fallback, and the error names the offending string.
+func TestLevelFromStringFallsBackToInfo(t *testing.T) {
+	for _, s := range []string{"", "inof", "DEBUGG", "verbose", " debug"} {
+		lvl, err := LevelFromString(s)
+		require.Errorf(t, err, "level %q must not parse", s)
+		require.Equalf(t, logrus.InfoLevel, lvl, "level %q must fall back to info", s)
+		require.Containsf(t, err.Error(), s, "error must name the offending string %q", s)
+	}
+
+	// An operator who explicitly asks for debug still gets debug.
+	lvl, err := LevelFromString("debug")
+	require.NoError(t, err)
+	require.Equal(t, logrus.DebugLevel, lvl)
+}
+
+// A scoped logger carries its own level: raising or lowering it leaves the
+// global master logger, and any other scoped logger, untouched.
+func TestScopedLoggerLevelIsIndependent(t *testing.T) {
+	origOut, origLevel := log.Out, log.GetLevel()
+	t.Cleanup(func() { log.Out = origOut; log.SetLevel(origLevel) })
+
+	var buf bytes.Buffer
+	SetOutputTo(&buf)
+	SetLevel(logrus.InfoLevel)
+
+	noisy := ScopedLogger("noisy", logrus.DebugLevel)
+	quiet := ScopedLogger("quiet", logrus.ErrorLevel)
+
+	require.Equal(t, logrus.DebugLevel, noisy.Level())
+	require.Equal(t, logrus.ErrorLevel, quiet.Level())
+	require.Equal(t, logrus.InfoLevel, GetLevel(), "the global level must not move")
+
+	noisy.Debug("noisy-debug")
+	quiet.Debug("quiet-debug")
+	quiet.Error("quiet-error")
+	MustGetLogger("global").Debug("global-debug")
+
+	out := buf.String()
+	require.Contains(t, out, "noisy-debug")
+	require.NotContains(t, out, "quiet-debug")
+	require.Contains(t, out, "quiet-error")
+	require.NotContains(t, out, "global-debug")
+}
+
+// A scoped logger still writes where everything else writes.
+func TestScopedLoggerSharesOutputAndHooks(t *testing.T) {
+	origOut, origLevel := log.Out, log.GetLevel()
+	t.Cleanup(func() { log.Out = origOut; log.SetLevel(origLevel) })
+
+	var buf bytes.Buffer
+	SetOutputTo(&buf)
+	c := &capture{}
+	AddHook(c)
+
+	ScopedLogger("scoped", logrus.WarnLevel).Warn("hook-me")
+	require.Contains(t, buf.String(), "hook-me")
+	require.Len(t, c.entries, 1)
+	require.Equal(t, "hook-me", c.entries[0].Message)
+}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -87,3 +87,38 @@ func (logger *MasterLogger) EnableColors() {
 func (logger *MasterLogger) DisableColors() {
 	logger.Formatter.(*TextFormatter).DisableColors = true
 }
+
+// ScopedLogger returns a package-aware logger whose minimum level is
+// independent of this master logger's, so setting it cannot change what any
+// other logger in the process emits.
+//
+// Output and formatter are shared with the parent; hooks are copied as of this
+// call. A scoped logger therefore still writes where everything else writes —
+// only the level is its own. Hooks installed on the parent afterwards do not
+// reach it, which is fine for the one caller that needs this: services install
+// their hooks (syslog) at startup, before any service builds its logger.
+func (logger *MasterLogger) ScopedLogger(module string, level logrus.Level) *Logger {
+	hooks := make(logrus.LevelHooks, len(logger.Hooks))
+	for lvl, hs := range logger.Hooks {
+		hooks[lvl] = append([]logrus.Hook(nil), hs...)
+	}
+	scoped := &MasterLogger{Logger: &logrus.Logger{
+		Out:          logger.Out,
+		Formatter:    logger.Formatter,
+		Hooks:        hooks,
+		Level:        level,
+		ExitFunc:     logger.ExitFunc,
+		ReportCaller: logger.ReportCaller,
+	}}
+	return scoped.PackageLogger(module)
+}
+
+// Level reports the minimum level this logger emits at. Loggers built by
+// PackageLogger or ScopedLogger report their own master's level; anything else
+// falls back to the process-global level.
+func (logger *Logger) Level() logrus.Level {
+	if e, ok := logger.FieldLogger.(*logrus.Entry); ok && e.Logger != nil {
+		return e.Logger.GetLevel()
+	}
+	return GetLevel()
+}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -5,7 +5,7 @@ Package logging provides application logging utilities
 package logging
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -23,7 +23,12 @@ const (
 	logPriorityCritical = "CRITICAL"
 )
 
-// LevelFromString returns a logrus.Level from a string identifier
+// LevelFromString returns a logrus.Level from a string identifier.
+//
+// An unrecognized (or empty) identifier returns logrus.InfoLevel along with an
+// error naming the offending string. It used to fall back to DebugLevel, which
+// meant a missing or misspelled "log_level" silently ran a service at debug in
+// production for callers that logged the error and carried on.
 func LevelFromString(s string) (logrus.Level, error) {
 	switch strings.ToLower(s) {
 	case "debug":
@@ -41,7 +46,7 @@ func LevelFromString(s string) (logrus.Level, error) {
 	case "trace":
 		return logrus.TraceLevel, nil
 	default:
-		return logrus.DebugLevel, errors.New("could not convert string to log level")
+		return logrus.InfoLevel, fmt.Errorf("unrecognized log level %q; want one of debug, info, warn, error, fatal, panic, trace", s)
 	}
 }
 
@@ -102,3 +107,10 @@ func TraceEnabled() bool { return log.GetLevel() >= logrus.TraceLevel }
 // interface omits the Trace methods (see Logger.Tracef). Callers on a hot
 // path must guard it with TraceEnabled: reaching the entry allocates.
 func Trace(l logrus.FieldLogger, msg string) { l.WithFields(logrus.Fields{}).Trace(msg) }
+
+// ScopedLogger returns a package-aware logger derived from the global master
+// logger whose minimum level is independent of it. See
+// MasterLogger.ScopedLogger.
+func ScopedLogger(module string, level logrus.Level) *Logger {
+	return log.ScopedLogger(module, level)
+}

--- a/pkg/services/ar/ar.go
+++ b/pkg/services/ar/ar.go
@@ -62,12 +62,7 @@ func (s *service) Run(ctx context.Context) error {
 	if tag == "" {
 		tag = "address_resolver"
 	}
-	logger := logging.MustGetLogger(tag)
-	if cfg.LogLevel != "" {
-		if lvl, err := logging.LevelFromString(cfg.LogLevel); err == nil {
-			logging.SetLevel(lvl)
-		}
-	}
+	logger := services.NewLogger(tag, cfg.LogLevel)
 	_ = s.log // logger is replaced with a tag-scoped one
 
 	redisURL := cfg.Redis

--- a/pkg/services/loglevel.go
+++ b/pkg/services/loglevel.go
@@ -1,0 +1,97 @@
+// Package services pkg/services/loglevel.go c2-vis-appsvc
+//
+// Per-service log levels.
+//
+// Every service block may carry its own "log_level". Historically each
+// service applied it by calling the package-global logging.SetLevel, which
+// is fine for a single-service binary (`skywire svc ar`) but wrong under
+// `skywire svc run`, where several services share one process: the last
+// service constructed decided the level for every other service, so a
+// per-service log_level was misleading and one block set to "debug" turned
+// on debug logging for the whole process.
+//
+// NewLogger keeps the single-service behavior exactly as it was and gives
+// each service its own independently-leveled logger when the process hosts
+// more than one.
+package services
+
+import (
+	"sync/atomic"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// hosted is the number of services this process runs. Zero — the default,
+// since the per-service cobra commands never call setHosted — means a
+// single-service binary.
+var hosted atomic.Int32
+
+// setHosted records how many services this process hosts. Run calls it
+// before building anything.
+func setHosted(n int) { hosted.Store(int32(n)) } //nolint:gosec
+
+// NewLogger returns the logger a service should log through, given the
+// "log_level" from its own config block and the tag it logs under.
+//
+// An empty level leaves everything alone. An unparseable one is reported at
+// warn — naming the offending string and the level actually used — and falls
+// back to info, so a typo in a config file can no longer put a production
+// service into debug without saying so.
+//
+// When this process hosts a single service, the level is applied to the
+// process-global master logger as before, so library packages (dmsg,
+// httpauth, the stores) are quieted along with the service. When several
+// services share the process, the level applies to the returned logger only;
+// Run separately picks the shared global level from all the blocks.
+func NewLogger(tag, level string) *logging.Logger {
+	logger := logging.MustGetLogger(tag)
+	if level == "" {
+		return logger
+	}
+	lvl := parseLevel(logger, tag, level)
+	if hosted.Load() > 1 {
+		return logging.ScopedLogger(tag, lvl)
+	}
+	logging.SetLevel(lvl)
+	return logger
+}
+
+// parseLevel converts level, warning through logger when it is not a level
+// name. The returned level is usable either way: LevelFromString falls back
+// to info on error.
+func parseLevel(logger *logging.Logger, tag, level string) logrus.Level {
+	lvl, err := logging.LevelFromString(level)
+	if err != nil {
+		logger.WithError(err).Warnf("%s: bad log_level %q; logging at %q instead", tag, level, lvl)
+	}
+	return lvl
+}
+
+// sharedLogLevel returns the level to apply to the process-global master
+// logger when several services share the process, and whether any block
+// asked for one at all.
+//
+// It is the quietest level any service asked for. The global is what the
+// shared library packages log through, and there is no per-service answer
+// for those; picking the quietest means hosting an extra service can never
+// make the process noisier than every block asked for, and — unlike the
+// last-one-wins behavior this replaces — the result does not depend on the
+// order the blocks happen to be built in.
+func sharedLogLevel(log *logging.Logger, file File) (logrus.Level, bool) {
+	var (
+		quietest logrus.Level
+		found    bool
+	)
+	for _, b := range file.Services {
+		if b.LogLevel == "" {
+			continue
+		}
+		lvl := parseLevel(log, b.Label(), b.LogLevel)
+		if !found || lvl < quietest {
+			quietest, found = lvl, true
+		}
+	}
+	return quietest, found
+}

--- a/pkg/services/loglevel_test.go
+++ b/pkg/services/loglevel_test.go
@@ -1,0 +1,148 @@
+// Package services pkg/services/loglevel_test.go c2-vis-appsvc
+package services
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// restoreLogging puts the process-global logger back where the rest of the
+// suite expects it.
+func restoreLogging(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	lvl := logging.GetLevel()
+	hostedBefore := hosted.Load()
+	t.Cleanup(func() {
+		logging.SetOutputTo(os.Stderr)
+		logging.SetLevel(lvl)
+		hosted.Store(hostedBefore)
+	})
+	var buf bytes.Buffer
+	logging.SetOutputTo(&buf)
+	return &buf
+}
+
+// A misspelled or empty log_level must land on info, not debug, and must say
+// so — the failure mode that put a production service into debug silently.
+func TestNewLoggerBadLevelWarnsAndUsesInfo(t *testing.T) {
+	for _, bad := range []string{"inof", "DEBUGG", "verbose"} {
+		buf := restoreLogging(t)
+		setHosted(1)
+		logging.SetLevel(logrus.DebugLevel)
+
+		logger := NewLogger("tag_"+bad[:4], bad)
+		require.Equal(t, logrus.InfoLevel, logger.Level(), "bad level %q must fall back to info", bad)
+		require.Equal(t, logrus.InfoLevel, logging.GetLevel())
+
+		out := buf.String()
+		require.Contains(t, out, bad, "the warning must name the offending string")
+		require.Contains(t, out, "info", "the warning must name the level actually used")
+		require.Contains(t, strings.ToLower(out), "warn", "the complaint must be logged at warn")
+	}
+
+	// Empty means "not configured": leave the level alone rather than
+	// pretending the operator asked for something.
+	buf := restoreLogging(t)
+	setHosted(1)
+	logging.SetLevel(logrus.WarnLevel)
+	require.Equal(t, logrus.WarnLevel, NewLogger("empty_level", "").Level())
+	require.Empty(t, buf.String())
+}
+
+// An operator explicitly asking for debug still gets debug.
+func TestNewLoggerExplicitDebugUnchanged(t *testing.T) {
+	restoreLogging(t)
+	setHosted(1)
+	logging.SetLevel(logrus.InfoLevel)
+
+	logger := NewLogger("noisy_service", "debug")
+	require.Equal(t, logrus.DebugLevel, logger.Level())
+	require.Equal(t, logrus.DebugLevel, logging.GetLevel(),
+		"a single-service binary still sets the process-global level, so library packages follow")
+}
+
+// Two services hosted in one process keep independent levels: neither the
+// order they are built in nor one block set to "debug" decides what the other
+// service emits.
+func TestNewLoggerTwoServicesKeepDifferentLevels(t *testing.T) {
+	buf := restoreLogging(t)
+	setHosted(2)
+	logging.SetLevel(logrus.WarnLevel)
+
+	noisy := NewLogger("service_noisy", "debug")
+	quiet := NewLogger("service_quiet", "error")
+
+	require.Equal(t, logrus.DebugLevel, noisy.Level())
+	require.Equal(t, logrus.ErrorLevel, quiet.Level())
+	require.Equal(t, logrus.WarnLevel, logging.GetLevel(),
+		"a hosted service must not move the process-global level")
+
+	buf.Reset()
+	noisy.Debug("noisy-debug")
+	quiet.Debug("quiet-debug")
+	quiet.Error("quiet-error")
+
+	out := buf.String()
+	require.Contains(t, out, "noisy-debug")
+	require.NotContains(t, out, "quiet-debug", "one block asking for debug must not make the other verbose")
+	require.Contains(t, out, "quiet-error")
+
+	// Building them the other way round gives the same answer.
+	quiet2 := NewLogger("service_quiet2", "error")
+	require.Equal(t, logrus.DebugLevel, noisy.Level())
+	require.Equal(t, logrus.ErrorLevel, quiet2.Level())
+}
+
+// The shared (library) level the supervisor picks is the quietest any block
+// asked for, and does not depend on block order.
+func TestSharedLogLevel(t *testing.T) {
+	restoreLogging(t)
+	log := logging.MustGetLogger("test-supervisor")
+
+	file, err := ParseFile([]byte(`{"services":[
+		{"type":"noop","name":"a","log_level":"debug"},
+		{"type":"noop","name":"b","log_level":"error"},
+		{"type":"noop","name":"c"}
+	]}`))
+	require.NoError(t, err)
+	lvl, ok := sharedLogLevel(log, file)
+	require.True(t, ok)
+	require.Equal(t, logrus.ErrorLevel, lvl)
+
+	reversed := File{Services: []Block{file.Services[2], file.Services[1], file.Services[0]}}
+	lvl, ok = sharedLogLevel(log, reversed)
+	require.True(t, ok)
+	require.Equal(t, logrus.ErrorLevel, lvl)
+
+	// No block configured a level: leave the global alone.
+	none, err := ParseFile([]byte(`{"services":[{"type":"noop","name":"a"}]}`))
+	require.NoError(t, err)
+	_, ok = sharedLogLevel(log, none)
+	require.False(t, ok)
+
+	// A misspelled level counts as info rather than dragging the process
+	// to debug.
+	bad, err := ParseFile([]byte(`{"services":[
+		{"type":"noop","name":"a","log_level":"inof"},
+		{"type":"noop","name":"b","log_level":"trace"}
+	]}`))
+	require.NoError(t, err)
+	lvl, ok = sharedLogLevel(log, bad)
+	require.True(t, ok)
+	require.Equal(t, logrus.InfoLevel, lvl)
+}
+
+// Block.UnmarshalJSON must surface log_level without disturbing Raw.
+func TestBlockCapturesLogLevel(t *testing.T) {
+	file, err := ParseFile([]byte(`{"services":[{"type":"noop","name":"n","log_level":"warn","extra":1}]}`))
+	require.NoError(t, err)
+	require.Equal(t, "warn", file.Services[0].LogLevel)
+	require.Contains(t, string(file.Services[0].Raw), `"extra"`)
+}

--- a/pkg/services/rf/rf.go
+++ b/pkg/services/rf/rf.go
@@ -111,12 +111,7 @@ func (s *service) Run(ctx context.Context) error {
 	if tag == "" {
 		tag = "route_finder"
 	}
-	logger := logging.MustGetLogger(tag)
-	if cfg.LogLevel != "" {
-		if lvl, err := logging.LevelFromString(cfg.LogLevel); err == nil {
-			logging.SetLevel(lvl)
-		}
-	}
+	logger := services.NewLogger(tag, cfg.LogLevel)
 	_ = s.log // logger is replaced with a tag-scoped one
 
 	redisURL := cfg.Redis

--- a/pkg/services/run.go
+++ b/pkg/services/run.go
@@ -57,6 +57,18 @@ func ParseFile(data []byte) (File, error) {
 // apart.
 func Run(ctx context.Context, file File, master *logging.MasterLogger) error {
 	log := master.PackageLogger("services-supervisor")
+
+	// Record the fan-out before building anything: NewLogger uses it to
+	// decide whether a block's log_level may touch the process-global
+	// level (single service) or must stay scoped to that service alone.
+	setHosted(len(file.Services))
+	if len(file.Services) > 1 {
+		if lvl, ok := sharedLogLevel(log, file); ok {
+			logging.SetLevel(lvl)
+			log.WithField("level", lvl.String()).
+				Info("several services share this process; shared library log level is the quietest any block asked for, each service's own level is independent")
+		}
+	}
 	// Build all services up front before starting any. A factory
 	// failure (bad config, bad PK, bad URL) is fatal — abort
 	// without partial startup. Cheaper than discovering it 30s in

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -67,6 +67,11 @@ type Block struct {
 	Type string
 	Name string
 	Raw  json.RawMessage
+
+	// LogLevel is the block's optional "log_level", read here so the
+	// supervisor can pick a shared level for the library packages
+	// before any service is built. Each factory still reads its own.
+	LogLevel string
 }
 
 // UnmarshalJSON captures both the typed fields ("type", optional
@@ -76,8 +81,9 @@ type Block struct {
 // object and reach the factory via Raw.
 func (b *Block) UnmarshalJSON(data []byte) error {
 	var probe struct {
-		Type string `json:"type"`
-		Name string `json:"name,omitempty"`
+		Type     string `json:"type"`
+		Name     string `json:"name,omitempty"`
+		LogLevel string `json:"log_level,omitempty"`
 	}
 	if err := json.Unmarshal(data, &probe); err != nil {
 		return fmt.Errorf("services: parse block header: %w", err)
@@ -87,6 +93,7 @@ func (b *Block) UnmarshalJSON(data []byte) error {
 	}
 	b.Type = probe.Type
 	b.Name = probe.Name
+	b.LogLevel = probe.LogLevel
 	b.Raw = make(json.RawMessage, len(data))
 	copy(b.Raw, data)
 	return nil

--- a/pkg/services/stun/stun.go
+++ b/pkg/services/stun/stun.go
@@ -84,12 +84,7 @@ func (s *service) Run(ctx context.Context) error {
 	// stunserver.Server.Log uses skycoin's logging package, not
 	// pkg/logging — supply a separate logger instance for it.
 	skyLogger := skycoinlogging.MustGetLogger(tag)
-	logger := logging.MustGetLogger(tag)
-	if cfg.LogLevel != "" {
-		if lvl, err := logging.LevelFromString(cfg.LogLevel); err == nil {
-			logging.SetLevel(lvl)
-		}
-	}
+	logger := services.NewLogger(tag, cfg.LogLevel)
 	_ = s.log // logger is replaced with a tag-scoped one
 	_ = logger
 

--- a/pkg/services/stun/stun_test.go
+++ b/pkg/services/stun/stun_test.go
@@ -114,8 +114,8 @@ func TestRunStartFailsWithExplicitConfig(t *testing.T) {
 }
 
 func TestRunInvalidLogLevelIgnored(t *testing.T) {
-	// A bad log level is swallowed (LevelFromString errors → no SetLevel);
-	// Run still proceeds and fails at start.
+	// A bad log level is reported at warn and falls back to info (never
+	// debug); Run still proceeds and fails at start.
 	cfg := &Config{PrimaryIP: "256.256.256.256", SecondaryIP: "256.256.256.256", LogLevel: "not-a-level"}
 	err := New(cfg, testLog()).(*service).Run(context.Background())
 	require.Error(t, err)

--- a/pkg/services/tpd/tpd.go
+++ b/pkg/services/tpd/tpd.go
@@ -77,13 +77,8 @@ func (s *service) Run(ctx context.Context) error {
 	if cfg.Tag == "" {
 		cfg.Tag = "transport_discovery"
 	}
-	logger := logging.MustGetLogger(cfg.Tag)
+	logger := services.NewLogger(cfg.Tag, cfg.LogLevel)
 	_ = s.log // logger is replaced with a tag-scoped one
-	if cfg.LogLevel != "" {
-		if lvl, err := logging.LevelFromString(cfg.LogLevel); err == nil {
-			logging.SetLevel(lvl)
-		}
-	}
 
 	redisURL := cfg.Redis
 	if redisURL == "" {

--- a/pkg/services/tps/tps.go
+++ b/pkg/services/tps/tps.go
@@ -87,12 +87,7 @@ func (s *service) Run(ctx context.Context) error {
 	if tag == "" {
 		tag = "transport_setup"
 	}
-	logger := logging.MustGetLogger(tag)
-	if cfg.LogLevel != "" {
-		if lvl, err := logging.LevelFromString(cfg.LogLevel); err == nil {
-			logging.SetLevel(lvl)
-		}
-	}
+	logger := services.NewLogger(tag, cfg.LogLevel)
 	_ = s.log
 
 	conf := &cfg.Config


### PR DESCRIPTION
`LevelFromString` fell back to `DebugLevel` for any string it could not parse, including `""`. Callers that logged the error and carried on — the dmsg server did exactly that — ran the whole process verbose whenever a config file was missing or misspelled its `log_level`. Both parsers (`pkg/logging` and the syslog-aware one in `pkg/cmdutil`) now fall back to info and name the offending string in the error; the dmsg server reports it at warn and leaves the level alone when `log_level` is absent. `ServiceFlags` defaults `--syslog-lvl` to info rather than debug, and the cmdutil parser learns `trace` so the two agree. Explicitly asking for debug still gets debug.

Separately, ar/rf/tpd/tps/stun each applied their block's `log_level` by calling the package-global `logging.SetLevel`. Under `skywire svc run`, which hosts several services in one process, whichever service was constructed last decided the level for all of them — so a per-service `log_level` was misleading, and one block set to debug turned on debug everywhere. They now go through `services.NewLogger`: a single-service binary behaves exactly as before (the global is still set, so library packages are quieted along with the service), while a hosted service gets a logger with its own level via `logging.ScopedLogger`, which shares the parent's output, formatter and hooks. The supervisor sets the shared global — what dmsg, httpauth and the stores log through — to the quietest level any block asked for, which is order-independent, unlike the behavior it replaces.

Regression tests cover the empty/misspelled level yielding info plus a warning naming it, and two services in one process keeping different levels while the global stays put. Built with `go build .`; `go vet` and targeted tests pass for pkg/logging, pkg/cmdutil and pkg/services/... including windows and js/wasm vet for the files with build tags.