### PR TITLE
perf(sd): build the service-discovery router once, not per request

### DIFF
--- a/pkg/deployment/sd/api/api.go
+++ b/pkg/deployment/sd/api/api.go
@@ -67,6 +67,12 @@ var WhitelistPKs = nmpk.GetWhitelistPKs()
 
 // API represents the service-discovery API.
 type API struct {
+	// Handler is the chi router, built once in New. Every sibling
+	// service (tpd, ar, dmsg-discovery) does the same; SD used to
+	// rebuild the whole router — middleware stack and all routes —
+	// on every single request before serving it.
+	http.Handler
+
 	log                         logrus.FieldLogger
 	db                          store.Store
 	metrics                     sdmetrics.Metrics
@@ -227,11 +233,16 @@ func New(log logrus.FieldLogger, db store.Store, nonceDB httpauth.NonceStore,
 		dmsgAddr:                    dmsgAddr,
 		DmsgServers:                 []string{},
 	}
+	api.Handler = api.newRouter()
 	return api
 }
 
-// ServeHTTP implements http.Handler
-func (a *API) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+// newRouter builds the service-discovery router. Called once from New,
+// after every field it closes over is set. Everything it reads
+// (log, enableMetrics, nonceDB, reqsInFlightCountMiddleware) is
+// assigned in New and never mutated afterwards, so the resulting
+// handler is safe to share across request goroutines.
+func (a *API) newRouter() chi.Router {
 	r := chi.NewRouter()
 	r.Use(middleware.RealIP) //nolint:staticcheck
 	r.Use(httputil.NewLogMiddleware(a.log))
@@ -278,7 +289,7 @@ func (a *API) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		r.Get("/security/nonces/{pk}", handler.ServeHTTP)
 	}
 
-	r.ServeHTTP(w, req)
+	return r
 }
 
 // RunBackgroundTasks is goroutine which runs in background periodic tasks of skycoin-service-discovery.

--- a/pkg/deployment/sd/api/router_test.go
+++ b/pkg/deployment/sd/api/router_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/skycoin/skycoin/src/util/logging"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/cxo/storeconfig"
+	sdmetrics "github.com/skycoin/skywire/pkg/deployment/sd/metrics"
+	"github.com/skycoin/skywire/pkg/deployment/sd/store"
+	"github.com/skycoin/skywire/pkg/httpauth"
+)
+
+// quietAPI builds an API whose request logging is silenced, so allocation
+// counts and benchmark timings measure the router rather than log formatting.
+func quietAPI() *API {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	log.SetLevel(logrus.PanicLevel)
+	return New(log, &store.MockStore{}, nil, false,
+		sdmetrics.NewEmpty(), "bench-dmsg-addr", deployment.Prod.GeoIP)
+}
+
+// TestRouterRoutesResolve walks every route the router registers and asserts
+// it is reachable — i.e. the handler ran and produced its own status rather
+// than chi's 404/405. Guards the route table against regressions now that it
+// is built once in New instead of per request.
+func TestRouterRoutesResolve(t *testing.T) {
+	api := newTestAPI(t, &store.MockStore{})
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"health", http.MethodGet, "/health", ""},
+		{"get uptimes", http.MethodGet, "/uptimes", ""},
+		{"post uptimes", http.MethodPost, "/uptimes", "not json"},
+		{"get services", http.MethodGet, "/api/services", ""},
+		{"get service by addr", http.MethodGet, "/api/services/someaddr", ""},
+		{"post service", http.MethodPost, "/api/services", "not json"},
+		{"delete service", http.MethodDelete, "/api/services/someaddr", ""},
+		{"deregister", http.MethodDelete, "/api/services/deregister/vpn", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			api.ServeHTTP(rr, httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body)))
+			require.NotEqual(t, http.StatusNotFound, rr.Code, "route did not resolve")
+			require.NotEqual(t, http.StatusMethodNotAllowed, rr.Code, "method not registered")
+		})
+	}
+
+	// An unregistered path must still 404 — the table is not a catch-all.
+	rr := httptest.NewRecorder()
+	api.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/no-such-route", nil))
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+// TestRouterNonceRouteIsConditional pins the conditional registration: the
+// nonce endpoint exists only when a nonce store is configured.
+func TestRouterNonceRouteIsConditional(t *testing.T) {
+	noAuth := newTestAPI(t, &store.MockStore{})
+	rr := httptest.NewRecorder()
+	noAuth.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/security/nonces/somepk", nil))
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	nonceDB, err := httpauth.NewNonceStore(context.Background(),
+		storeconfig.Config{Type: storeconfig.Memory}, "sd")
+	require.NoError(t, err)
+	withAuth := New(logging.MustGetLogger("test_sd"), &store.MockStore{}, nonceDB, false,
+		sdmetrics.NewEmpty(), "test-dmsg-addr", deployment.Prod.GeoIP)
+
+	rr = httptest.NewRecorder()
+	withAuth.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/security/nonces/somepk", nil))
+	require.NotEqual(t, http.StatusNotFound, rr.Code)
+}
+
+// TestRouterBuiltOnce asserts the router is constructed at New time and that
+// serving requests neither replaces it nor builds another one: the handler
+// identity is stable across requests, and a request allocates far less than
+// building a fresh chi router with six middlewares and ten routes ever could.
+func TestRouterBuiltOnce(t *testing.T) {
+	api := newTestAPI(t, &store.MockStore{})
+	require.NotNil(t, api.Handler, "router must be built in New")
+
+	before := api.Handler
+	for i := 0; i < 5; i++ {
+		rr := httptest.NewRecorder()
+		api.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/health", nil))
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Same(t, before, api.Handler, "router was rebuilt while serving")
+	}
+
+	// Building the router costs thousands of allocations; serving a
+	// health check off a prebuilt one costs tens. The bound is
+	// deliberately loose — it only has to fail if construction moves
+	// back into the request path.
+	quiet := quietAPI()
+	allocs := testing.AllocsPerRun(50, func() {
+		quiet.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/health", nil))
+	})
+	require.Less(t, allocs, float64(400), "per-request allocations suggest the router is rebuilt per request")
+}
+
+// BenchmarkServeHTTPHealth measures a simple GET through the router.
+func BenchmarkServeHTTPHealth(b *testing.B) {
+	api := quietAPI()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		api.ServeHTTP(httptest.NewRecorder(), req)
+	}
+}


### PR DESCRIPTION
SD's `API.ServeHTTP` called `chi.NewRouter()` and re-registered the whole middleware stack and every route before serving each incoming request, then threw the router away. Service discovery was measured at 18% CPU on prod02, and this is a large part of it. tpd, ar and dmsg-discovery all build their router once in `New` and embed `http.Handler`; SD was the outlier.

The construction moves into `New` as `newRouter()`, assigned after every field it reads is set. Nothing in the route table is request-dependent — the conditional pieces (`enableMetrics`, `nonceDB`) are constructor arguments that are never mutated after `New`, so the now-shared router is race-free. Middleware order, route paths and the conditional `/security/nonces/{pk}` registration are unchanged.

Added `router_test.go`: a table walking every registered route (plus a negative case), a test pinning the conditional nonce route, one asserting the handler is built in `New` and its identity is stable across requests with a per-request allocation ceiling, and a `ServeHTTP` benchmark. A `GET /health` goes from ~46 us / 15,505 B / 196 allocs per request to ~15 us / 4,161 B / 36 allocs (`-benchtime 50000x -count 10`, medians; the box is loaded so ns/op is noisy, allocs are not).