### PR TITLE
feat(dmsg): serve the in-process dmsg server on the visor's transport port

### DIFF
--- a/pkg/dmsg/dmsgc/spec/spec.go
+++ b/pkg/dmsg/dmsgc/spec/spec.go
@@ -132,7 +132,11 @@ type DmsgServerConfig struct {
 	// = the visor runs no server.
 	Enabled bool `json:"enabled"`
 	// LocalAddress is the TCP listen address for inbound sessions. Empty
-	// defaults to ":8081".
+	// means the server SHARES the visor's transport TCP port — the same cmux
+	// that already splits stcpr from WS gains a dmsg branch — so no second
+	// port is opened and none has to be forwarded. Set it to pin the server
+	// to an address of its own instead (the old default was ":8081", which is
+	// what a visor with no transport cmux still falls back to).
 	LocalAddress string `json:"local_address,omitempty"`
 	// PublicAddress is the externally-reachable address advertised in the
 	// server's discovery entry. Empty = don't advertise a public address

--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -110,6 +110,15 @@ type ClientFactory struct {
 	// WS case in MakeClient (untagged) can read wsSharedListener directly.
 	stcprSharedListener net.Listener
 	wsSharedListener    net.Listener
+	// dmsgSharedListener is the tcpDemux branch carrying dmsg sessions, set
+	// only when ShareTCPWithDmsgServer was true at bind time.
+	dmsgSharedListener net.Listener
+	// ShareTCPWithDmsgServer asks the TCP cmux for a dmsg branch, so a visor
+	// running the in-process dmsg server on its own key serves it on the same
+	// TCP port as stcpr and WS instead of binding a second one. Set it before
+	// EnableUnifiedTCP / EnableDefaultTCPDemux; the branch is not installed
+	// afterwards, because an unconsumed cmux branch stalls its connections.
+	ShareTCPWithDmsgServer bool
 	// tcpDefaultDemux is true when the TCP cmux is the DEFAULT one bound on the
 	// stcpr port (EnableDefaultTCPDemux) rather than an explicit transport_port
 	// master. In that case stcpr always rides the cmux (the demux IS its port), so

--- a/pkg/transport/network/client_unified_tcp.go
+++ b/pkg/transport/network/client_unified_tcp.go
@@ -48,10 +48,11 @@ func (f *ClientFactory) bindTCPDemux(port int) error {
 	if err != nil {
 		return fmt.Errorf("tcp cmux (stcpr+ws) port %d: %w", port, err)
 	}
-	d := newTCPDemux(lis)
+	d := newTCPDemux(lis, f.ShareTCPWithDmsgServer)
 	f.tcpDemux = d
 	f.stcprSharedListener = d.STCPR()
 	f.wsSharedListener = d.WS()
+	f.dmsgSharedListener = d.DMSG()
 	return nil
 }
 
@@ -80,3 +81,10 @@ func (f *ClientFactory) stcprSharedListenerFor(perTypePort int) net.Listener {
 	}
 	return f.stcprSharedListener
 }
+
+// DmsgSharedListener returns the TCP cmux branch the co-resident dmsg server
+// serves on, or nil when the port is not shared with it (ShareTCPWithDmsgServer
+// was false, or no demux is bound). Its Addr is the master listener's, so a
+// server that advertises what its listener resolves to advertises the shared
+// transport port.
+func (f *ClientFactory) DmsgSharedListener() net.Listener { return f.dmsgSharedListener }

--- a/pkg/transport/network/tcpdemux.go
+++ b/pkg/transport/network/tcpdemux.go
@@ -12,31 +12,55 @@
 // routes HTTP/1 to the WS listener, everything else to the stcpr listener. cmux
 // is the established connection-mux library, so unlike the UDP side this needs no
 // custom classifier. The TCP analog of udpDemux.
+//
+// A visor running the in-process dmsg server on its own key takes a third
+// branch here, so the server shares the visor's transport port rather than
+// binding one of its own. That branch is only installed when something will
+// consume it: an unconsumed cmux listener queues its matched connections and
+// then blocks their goroutines.
 package network
 
 import (
 	"net"
 
 	"github.com/soheilhy/cmux"
+
+	"github.com/skycoin/skywire/pkg/transport/network/handshake"
 )
 
 // tcpDemux fans one TCP listener out to a WS (HTTP) and an stcpr (raw) virtual
-// net.Listener. The protocols' accept loops consume the virtual listeners
-// unchanged. Closing the demux closes the master listener, which stops cmux and
-// the virtual listeners.
+// net.Listener, plus a dmsg one when the co-resident dmsg server shares the
+// port. The protocols' accept loops consume the virtual listeners unchanged.
+// Closing the demux closes the master listener, which stops cmux and the
+// virtual listeners.
 type tcpDemux struct {
 	master net.Listener
 	ws     net.Listener
 	stcpr  net.Listener
+	dmsg   net.Listener // nil unless the in-process dmsg server shares this port
 }
 
-func newTCPDemux(master net.Listener) *tcpDemux {
+func newTCPDemux(master net.Listener, withDMSG bool) *tcpDemux {
 	m := cmux.New(master)
-	// Order matters: match the HTTP/1 (WebSocket-upgrade) connections first, then
-	// everything else is the raw skywire stcpr handshake.
+	// Order matters: match the HTTP/1 (WebSocket-upgrade) connections first.
 	ws := m.Match(cmux.HTTP1Fast())
-	stcpr := m.Match(cmux.Any())
-	d := &tcpDemux{master: master, ws: ws, stcpr: stcpr}
+	d := &tcpDemux{master: master, ws: ws}
+	if !withDMSG {
+		// Nothing else consumes this port: everything non-HTTP is the raw
+		// skywire stcpr handshake, exactly as before the dmsg branch existed.
+		d.stcpr = m.Match(cmux.Any())
+		go m.Serve() //nolint:errcheck // returns when the master listener closes
+		return d
+	}
+	// With the dmsg server sharing the port, stcpr can no longer be the
+	// catch-all — but it does not need to be. An stcpr initiator's very first
+	// bytes are the literal handshake.Message ("get_nonce"), so it is matched
+	// positively and the catch-all is free for dmsg, whose sessions open with a
+	// length-prefixed noise frame that no fixed prefix can match. Anything that
+	// is neither lands on the dmsg branch and fails its handshake there, which
+	// is what it did on the stcpr branch before.
+	d.stcpr = m.Match(cmux.PrefixMatcher(handshake.Message))
+	d.dmsg = m.Match(cmux.Any())
 	go m.Serve() //nolint:errcheck // returns when the master listener closes
 	return d
 }
@@ -44,8 +68,12 @@ func newTCPDemux(master net.Listener) *tcpDemux {
 // WS returns the virtual listener carrying HTTP/1 (WebSocket-upgrade) connections.
 func (d *tcpDemux) WS() net.Listener { return d.ws }
 
-// STCPR returns the virtual listener carrying raw (non-HTTP) connections.
+// STCPR returns the virtual listener carrying the raw skywire handshake.
 func (d *tcpDemux) STCPR() net.Listener { return d.stcpr }
+
+// DMSG returns the virtual listener carrying dmsg sessions, or nil when the
+// demux was built without that branch.
+func (d *tcpDemux) DMSG() net.Listener { return d.dmsg }
 
 // Close closes the master listener, stopping cmux and the virtual listeners.
 func (d *tcpDemux) Close() error { return d.master.Close() }

--- a/pkg/transport/network/tcpdemux_dmsg_test.go
+++ b/pkg/transport/network/tcpdemux_dmsg_test.go
@@ -1,0 +1,125 @@
+//go:build !tinygo
+
+// Package network pkg/transport/network/tcpdemux_dmsg_test.go c2-net-transport
+package network
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/transport/network/handshake"
+)
+
+// speak dials the demux and writes what a protocol opens with, holding the
+// connection open long enough for the demux to route it.
+func speak(t *testing.T, addr string, open []byte) {
+	t.Helper()
+	go func() {
+		c, err := net.Dial("tcp", addr)
+		if err != nil {
+			return
+		}
+		defer c.Close()      //nolint:errcheck
+		_, _ = c.Write(open) //nolint:errcheck
+		time.Sleep(500 * time.Millisecond)
+	}()
+}
+
+// wantOn accepts on the listener the protocol is supposed to land on and checks
+// the sniffed opening bytes were replayed intact. A connection routed anywhere
+// else shows up here as an accept timeout.
+func wantOn(t *testing.T, lis net.Listener, open []byte, what string) {
+	t.Helper()
+	c, err := acceptWithTimeout(t, lis)
+	require.NoError(t, err, "%s did not land on its own listener", what)
+	defer c.Close() //nolint:errcheck
+	buf := make([]byte, len(open))
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+	_, err = io.ReadFull(c, buf)
+	require.NoError(t, err, "%s: reading the replayed opening bytes", what)
+	require.Equal(t, open, buf, "%s: the sniffed bytes must be replayed intact", what)
+}
+
+// dmsgFrame is what a dmsg session opens with: a 2-byte big-endian length
+// followed by the noise handshake message. It has no fixed prefix, which is why
+// dmsg takes the catch-all and stcpr is the one matched positively.
+func dmsgFrame(n int) []byte {
+	b := make([]byte, 2+n)
+	binary.BigEndian.PutUint16(b, uint16(n)) //nolint:gosec // test sizes are small
+	for i := 2; i < len(b); i++ {
+		b[i] = byte(i)
+	}
+	return b
+}
+
+// With the dmsg branch installed each protocol reaches its own listener: stcpr
+// by its literal handshake message, WS by the HTTP method, dmsg by everything
+// else.
+func TestTCPDemux_RoutesDmsgAlongsideStcprAndWS(t *testing.T) {
+	master, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	d := newTCPDemux(master, true)
+	defer d.Close() //nolint:errcheck
+	require.NotNil(t, d.DMSG(), "the dmsg branch must exist when asked for")
+	addr := master.Addr().String()
+
+	stcpr := []byte(handshake.Message)
+	speak(t, addr, stcpr)
+	wantOn(t, d.STCPR(), stcpr, "stcpr")
+
+	ws := []byte("GET /dmsg HTTP/1.1\r\nHost: x\r\n\r\n")
+	speak(t, addr, ws)
+	wantOn(t, d.WS(), ws, "ws")
+
+	small := dmsgFrame(48)
+	speak(t, addr, small)
+	wantOn(t, d.DMSG(), small, "dmsg")
+
+	// The post-quantum first message is over a KiB, so its length prefix has a
+	// non-zero high byte. It must route the same way.
+	big := dmsgFrame(1216)
+	speak(t, addr, big)
+	wantOn(t, d.DMSG(), big, "dmsg (post-quantum sized)")
+}
+
+// Without the dmsg branch nothing changes: there is no dmsg listener and every
+// non-HTTP opener still falls through to stcpr, as it did before.
+func TestTCPDemux_WithoutDmsgKeepsStcprCatchAll(t *testing.T) {
+	master, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	d := newTCPDemux(master, false)
+	defer d.Close() //nolint:errcheck
+	require.Nil(t, d.DMSG())
+	addr := master.Addr().String()
+
+	stcpr := []byte(handshake.Message)
+	speak(t, addr, stcpr)
+	wantOn(t, d.STCPR(), stcpr, "stcpr")
+
+	other := dmsgFrame(48)
+	speak(t, addr, other)
+	wantOn(t, d.STCPR(), other, "an unrecognised opener with dmsg not sharing")
+}
+
+// The shared listener is handed out only when the factory asked for it, and it
+// reports the master port, so a server that advertises what its listener
+// resolves to advertises the shared transport port.
+func TestClientFactory_DmsgSharedListener(t *testing.T) {
+	var off ClientFactory
+	require.NoError(t, off.EnableDefaultTCPDemux(0))
+	defer off.CloseUnifiedTCP() //nolint:errcheck
+	require.Nil(t, off.DmsgSharedListener())
+
+	on := ClientFactory{ShareTCPWithDmsgServer: true}
+	require.NoError(t, on.EnableDefaultTCPDemux(0))
+	defer on.CloseUnifiedTCP() //nolint:errcheck
+	shared := on.DmsgSharedListener()
+	require.NotNil(t, shared)
+	require.Equal(t, on.stcprSharedListener.Addr().String(), shared.Addr().String(),
+		"the dmsg branch listens on the same port as stcpr")
+}

--- a/pkg/transport/network/tcpdemux_test.go
+++ b/pkg/transport/network/tcpdemux_test.go
@@ -20,7 +20,7 @@ func TestTCPDemux_RoutesByPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen master: %v", err)
 	}
-	d := newTCPDemux(master)
+	d := newTCPDemux(master, false)
 	defer d.Close() //nolint:errcheck
 	addr := master.Addr().String()
 

--- a/pkg/visor/dmsg_shared_port_test.go
+++ b/pkg/visor/dmsg_shared_port_test.go
@@ -1,0 +1,34 @@
+// Package visor pkg/visor/dmsg_shared_port_test.go c3-visor-core
+package visor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dmsgspec "github.com/skycoin/skywire/pkg/dmsg/dmsgc/spec"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// The in-process dmsg server shares the visor's transport TCP port by default,
+// and steps aside the moment the operator says otherwise.
+func TestDmsgServerSharesTransportPort(t *testing.T) {
+	conf := func(s *dmsgspec.DmsgServerConfig) *visorconfig.V1 {
+		return &visorconfig.V1{Dmsg: &dmsgspec.DmsgConfig{Server: s}}
+	}
+
+	require.True(t, dmsgServerSharesTransportPort(conf(&dmsgspec.DmsgServerConfig{Enabled: true})),
+		"enabled on the visor key with no address of its own shares the port")
+
+	require.False(t, dmsgServerSharesTransportPort(nil))
+	require.False(t, dmsgServerSharesTransportPort(&visorconfig.V1{}), "no dmsg config")
+	require.False(t, dmsgServerSharesTransportPort(conf(nil)), "no server block")
+	require.False(t, dmsgServerSharesTransportPort(conf(&dmsgspec.DmsgServerConfig{})),
+		"disabled server takes no branch, so none is installed for it")
+	require.False(t, dmsgServerSharesTransportPort(conf(&dmsgspec.DmsgServerConfig{
+		Enabled: true, LocalAddress: ":8081",
+	})), "an operator-pinned address wins over the shared port")
+	require.False(t, dmsgServerSharesTransportPort(conf(&dmsgspec.DmsgServerConfig{
+		Enabled: true, ConfigPath: "/etc/skywire-dmsg.json",
+	})), "a standalone config runs on its own key and its own addresses")
+}

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -242,7 +242,9 @@ func registerModules(logger *logging.MasterLogger) {
 	skyFwd = maker("sky_forward_conn", initSkywireForwardConn, &dmsgC, &dmsgCtrl, &tr, &launch)
 	pi = maker("ping", initPing, &dmsgC, &tm)
 	dmsgPi = maker("dmsg_ping", initDmsgPing, &dmsgC)
-	dmsgSrv = maker("dmsg_server", initDmsgServer, &dmsgC)
+	// &tr: the in-process server serves on the transport stage's shared TCP
+	// cmux branch by default, so that stage must have bound it first.
+	dmsgSrv = maker("dmsg_server", initDmsgServer, &dmsgC, &tr)
 	dmsgServerLatency = maker("dmsg_server_latency", initDmsgServerLatency, &dmsgPi)
 	tc = maker("transportable", initEnsureVisorIsTransportable, &dmsgC, &tm, &stcprC)
 	tpdco = maker("tpd_concurrency", initEnsureTPDConcurrency, &dmsgC, &tm)

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -1081,18 +1081,31 @@ func initDmsgServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 		return nil
 	}
 
+	// Share the visor's transport TCP port unless the operator pinned this
+	// server to an address of its own. The shared branch comes from the same
+	// cmux that already splits stcpr from WS, so the server needs no port of
+	// its own and nothing new has to be opened on the host or forwarded.
+	lis := v.dmsgSharedLis
+	shared := lis != nil
 	localAddr := srvCfg.LocalAddress
-	if localAddr == "" {
-		localAddr = ":8081"
+	if !shared {
+		if localAddr == "" {
+			localAddr = ":8081"
+		}
 	}
 
 	srvConf := dmsg.DefaultServerConfig()
 	srv := dmsg.NewServer(v.conf.PK, v.conf.SK, dmsgOnlyDisc(dmsgC, discPK, log), srvConf, dmsgmetrics.NewEmpty())
 	srv.SetLogger(log)
 
-	lis, err := net.Listen("tcp", localAddr)
-	if err != nil {
-		return fmt.Errorf("in-process dmsg server: listen on %s: %w", localAddr, err)
+	if !shared {
+		var err error
+		if lis, err = net.Listen("tcp", localAddr); err != nil {
+			return fmt.Errorf("in-process dmsg server: listen on %s: %w", localAddr, err)
+		}
+	}
+	if localAddr == "" {
+		localAddr = lis.Addr().String()
 	}
 
 	go func() {
@@ -1106,10 +1119,17 @@ func initDmsgServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 	log.WithField("local_pk", v.conf.PK).
 		WithField("local_address", localAddr).
 		WithField("public_address", srvCfg.PublicAddress).
+		WithField("shared_transport_port", shared).
 		Info("Started in-process dmsg server on the visor key")
 
 	v.pushCloseStack("dmsg_server", func() error {
 		cerr := srv.Close()
+		// Only a listener this server owns is closed here. The shared branch
+		// belongs to the transport cmux, which stcpr and WS are still serving;
+		// closing it is the transport stage's job.
+		if shared {
+			return cerr
+		}
 		if lerr := lis.Close(); lerr != nil && !errors.Is(lerr, net.ErrClosed) && cerr == nil {
 			cerr = lerr
 		}

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -614,6 +614,11 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 	//     cmux peeks: WS-upgrade → WS, else raw handshake → stcpr; existing stcpr
 	//     peers unaffected). This is what lets a browser visor reach any visor
 	//     over WS. UDP-side unification stays opt-in (it would shift sudph's port).
+	// A visor running the in-process dmsg server on its own key shares this
+	// TCP port with it by default: the server binds nothing of its own unless
+	// dmsg.server.local_address says otherwise. Decided before the bind — the
+	// cmux branch cannot be added afterwards.
+	factory.ShareTCPWithDmsgServer = dmsgServerSharesTransportPort(v.conf)
 	if v.conf.Transport != nil && v.conf.Transport.TransportPort != 0 {
 		port := v.conf.Transport.TransportPort
 		if err := factory.EnableUnifiedUDP(port); err != nil {
@@ -635,6 +640,11 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		}
 		log.Info("stcpr + WS share the stcpr TCP port (cmux) — this visor is reachable over WebSocket")
 		v.pushCloseStack("transport.tcp_cmux", factory.CloseUnifiedTCP)
+	}
+	if lis := factory.DmsgSharedListener(); lis != nil {
+		v.dmsgSharedLis = lis
+		log.WithField("addr", lis.Addr()).
+			Info("In-process dmsg server will share the visor's transport TCP port")
 	}
 	// Shared construction (pkg/visor/visorcore) — the same seam the wasm edge
 	// uses. Serve stays in this visor's own WaitGroup-wrapped goroutine below
@@ -1390,4 +1400,17 @@ func newV6ForcedHTTPClient() *http.Client {
 		},
 	}
 	return &http.Client{Transport: tr, Timeout: 30 * time.Second}
+}
+
+// dmsgServerSharesTransportPort reports whether the in-process dmsg server
+// should serve on the visor's shared transport TCP port rather than bind its
+// own. It does when it is enabled, runs on the visor's key (a standalone
+// config_path server has its own key and its own addresses), and the operator
+// has not pinned it to an address with dmsg.server.local_address.
+func dmsgServerSharesTransportPort(conf *visorconfig.V1) bool {
+	if conf == nil || conf.Dmsg == nil || conf.Dmsg.Server == nil {
+		return false
+	}
+	s := conf.Dmsg.Server
+	return s.Enabled && s.ConfigPath == "" && s.LocalAddress == ""
 }

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -140,6 +140,10 @@ type Visor struct {
 	stun stunState
 
 	tpM *transport.Manager
+	// dmsgSharedLis is the transport port's cmux branch for dmsg sessions,
+	// handed to the in-process dmsg server so it shares the visor's TCP port.
+	// nil when the server is off, keyed separately, or pinned to its own address.
+	dmsgSharedLis net.Listener
 
 	// localGraph is an extra transport-graph source merged into every
 	// GetAllTransports answer (see local_graph.go).


### PR DESCRIPTION
A visor running the dmsg server on its own key had to bind a second TCP port for it, defaulting to `:8081`. That is another port to open on the host and another to forward. It now shares the port the visor already listens on, so combining a visor and a dmsg server needs no extra port at all.

The transport port already carries two protocols: a cmux splits HTTP (WebSocket) from the raw stcpr handshake. This adds a third branch. stcpr stops being the catch-all and is matched positively instead, which is exact because an stcpr initiator's first bytes are the literal `handshake.Message`. That frees the catch-all for dmsg, whose sessions open with a length-prefixed noise frame that no fixed prefix can match. Anything that is neither now lands on the dmsg branch and fails its handshake there, which is what it did on the stcpr branch before.

The branch is installed only when something will consume it, because an unconsumed cmux branch queues its connections and then blocks their goroutines. A visor with the server off, on a separate key via `config_path`, or pinned by `dmsg.server.local_address` gets exactly the two-way demux it has today. Setting `local_address` still pins the server to a port of its own; leaving it empty now means sharing rather than `:8081`.
