### PR TITLE
perf(logging): render log lines without fmt, cutting 4% of dmsg-server CPU

### DIFF
--- a/pkg/logging/formatter.go
+++ b/pkg/logging/formatter.go
@@ -5,15 +5,22 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/mgutz/ansi"
 	"github.com/sirupsen/logrus"
 )
 
 const defaultTimestampFormat = time.RFC3339
+
+// stackKeys is the number of entry fields whose key list fits in Format's
+// stack scratch array. Skywire entries carry the module key plus a handful of
+// fields, so the heap allocation is avoided on effectively every line.
+const stackKeys = 8
 
 var (
 	baseTimestamp      = time.Now()
@@ -31,17 +38,17 @@ var (
 		CriticalStyle:    "magenta+h",
 	}
 	noColorsColorScheme = &compiledColorScheme{
-		InfoLevelColor:   ansi.ColorFunc(""),
-		WarnLevelColor:   ansi.ColorFunc(""),
-		ErrorLevelColor:  ansi.ColorFunc(""),
-		FatalLevelColor:  ansi.ColorFunc(""),
-		PanicLevelColor:  ansi.ColorFunc(""),
-		DebugLevelColor:  ansi.ColorFunc(""),
-		TraceLevelColor:  ansi.ColorFunc(""),
-		PrefixColor:      ansi.ColorFunc(""),
-		TimestampColor:   ansi.ColorFunc(""),
-		CallContextColor: ansi.ColorFunc(""),
-		CriticalColor:    ansi.ColorFunc(""),
+		InfoLevelColor:   newANSIStyle(""),
+		WarnLevelColor:   newANSIStyle(""),
+		ErrorLevelColor:  newANSIStyle(""),
+		FatalLevelColor:  newANSIStyle(""),
+		PanicLevelColor:  newANSIStyle(""),
+		DebugLevelColor:  newANSIStyle(""),
+		TraceLevelColor:  newANSIStyle(""),
+		PrefixColor:      newANSIStyle(""),
+		TimestampColor:   newANSIStyle(""),
+		CallContextColor: newANSIStyle(""),
+		CriticalColor:    newANSIStyle(""),
 	}
 	defaultCompiledColorScheme = compileColorScheme(defaultColorScheme)
 )
@@ -65,18 +72,69 @@ type ColorScheme struct {
 	CriticalStyle    string
 }
 
+// ansiStyle is a compiled color held as its raw escape prefix rather than as
+// the closure ansi.ColorFunc returns, so colored text can be appended straight
+// into the output buffer instead of allocating a new string for every element
+// of every log line. Its semantics match ansi.ColorFunc exactly: an empty
+// style is the identity, and any other style leaves an empty input untouched.
+type ansiStyle struct {
+	code     string
+	identity bool
+}
+
+func newANSIStyle(style string) ansiStyle {
+	if style == "" {
+		return ansiStyle{identity: true}
+	}
+	return ansiStyle{code: ansi.ColorCode(style)}
+}
+
+// apply is the equivalent of ansi.ColorFunc(style)(s).
+func (s ansiStyle) apply(str string) string {
+	if s.identity || str == "" {
+		return str
+	}
+	return s.code + str + ansi.Reset
+}
+
+// write appends str to b colored, without allocating.
+func (s ansiStyle) write(b *bytes.Buffer, str string) {
+	if s.identity || str == "" {
+		b.WriteString(str) //nolint:gosec
+		return
+	}
+	b.WriteString(s.code) //nolint:gosec
+	b.WriteString(str)    //nolint:gosec
+	b.WriteString(ansi.Reset)
+}
+
+// open and close bracket content appended to b piecewise. Callers must only
+// use them around content that is never empty, since apply leaves an empty
+// string uncolored.
+func (s ansiStyle) open(b *bytes.Buffer) {
+	if !s.identity {
+		b.WriteString(s.code) //nolint:gosec
+	}
+}
+
+func (s ansiStyle) close(b *bytes.Buffer) {
+	if !s.identity {
+		b.WriteString(ansi.Reset) //nolint:gosec
+	}
+}
+
 type compiledColorScheme struct {
-	InfoLevelColor   func(string) string
-	WarnLevelColor   func(string) string
-	ErrorLevelColor  func(string) string
-	FatalLevelColor  func(string) string
-	PanicLevelColor  func(string) string
-	DebugLevelColor  func(string) string
-	TraceLevelColor  func(string) string
-	PrefixColor      func(string) string
-	TimestampColor   func(string) string
-	CallContextColor func(string) string
-	CriticalColor    func(string) string
+	InfoLevelColor   ansiStyle
+	WarnLevelColor   ansiStyle
+	ErrorLevelColor  ansiStyle
+	FatalLevelColor  ansiStyle
+	PanicLevelColor  ansiStyle
+	DebugLevelColor  ansiStyle
+	TraceLevelColor  ansiStyle
+	PrefixColor      ansiStyle
+	TimestampColor   ansiStyle
+	CallContextColor ansiStyle
+	CriticalColor    ansiStyle
 }
 
 // TextFormatter formats log output
@@ -133,14 +191,14 @@ type TextFormatter struct {
 	sync.Once
 }
 
-func getCompiledColor(main string, fallback string) func(string) string {
+func getCompiledColor(main string, fallback string) ansiStyle {
 	var style string
 	if main != "" {
 		style = main
 	} else {
 		style = fallback
 	}
-	return ansi.ColorFunc(style)
+	return newANSIStyle(style)
 }
 
 func compileColorScheme(s *ColorScheme) *compiledColorScheme {
@@ -181,13 +239,20 @@ func (f *TextFormatter) SetColorScheme(colorScheme *ColorScheme) {
 // Format formats a logrus.Entry
 func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	var b *bytes.Buffer
-	keys := make([]string, 0, len(entry.Data))
+
+	var keyArr [stackKeys]string
+	keys := keyArr[:0]
+	if len(entry.Data) > stackKeys {
+		keys = make([]string, 0, len(entry.Data))
+	}
 	for k := range entry.Data {
 		keys = append(keys, k)
 	}
 	lastKeyIdx := len(keys) - 1
 
-	if !f.DisableSorting {
+	// Nothing to order below two keys, and the overwhelming majority of
+	// entries carry just the module key plus a field or two.
+	if !f.DisableSorting && len(keys) > 1 {
 		sort.Strings(keys)
 	}
 	if entry.Buffer != nil {
@@ -235,8 +300,7 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys []string, timestampFormat string, colorScheme *compiledColorScheme) {
-	var levelColor func(string) string
-	var levelText string
+	var levelColor ansiStyle
 	switch entry.Level {
 	case logrus.InfoLevel:
 		levelColor = colorScheme.InfoLevelColor
@@ -254,9 +318,10 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 		levelColor = colorScheme.DebugLevelColor
 	}
 
-	priority, ok := entry.Data[logPriorityKey]
-	hasPriority := ok && priority == logPriorityCritical
+	module, priority := prefixParts(entry)
+	hasPriority := priority == logPriorityCritical
 
+	var levelText string
 	if entry.Level != logrus.WarnLevel {
 		levelText = entry.Level.String()
 	} else {
@@ -264,19 +329,61 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 	}
 
 	if !f.DisableUppercase {
-		levelText = strings.ToUpper(levelText)
+		levelText = upperLevelText(entry.Level, levelText)
 	}
 
-	level := levelColor(levelText)
 	message := entry.Message
-	prefix := ""
+	ccFile, ccFunc, ccLine := callContext(entry)
+	hasCallContext := ccFile != "" || ccFunc != "" || ccLine != ""
 
-	prefixText := extractPrefix(entry)
-	if prefixText != "" {
-		prefixText = " " + prefixText + ":"
-		prefix = colorScheme.PrefixColor(prefixText)
+	if hasPriority {
+		// The critical color wraps the whole line, so it cannot be streamed
+		// piecewise; this path is rare enough to leave on fmt.
+		f.printCritical(b, entry, colorScheme, levelText, message, timestampFormat, ccFile, ccFunc, ccLine)
+	} else {
+		if !f.DisableTimestamp {
+			colorScheme.TimestampColor.open(b)
+			b.WriteByte('[') //nolint:gosec
+			f.appendTimestamp(b, entry, timestampFormat)
+			b.WriteByte(']') //nolint:gosec
+			colorScheme.TimestampColor.close(b)
+			b.WriteByte(' ') //nolint:gosec
+		}
+		levelColor.write(b, levelText)
+		if hasCallContext {
+			// The leading space sits outside the color, as it did when this
+			// was " " + CallContextColor(strings.Join(parts, ":")).
+			b.WriteByte(' ') //nolint:gosec
+			colorScheme.CallContextColor.open(b)
+			writeJoined(b, ccFile, ccFunc, ccLine)
+			colorScheme.CallContextColor.close(b)
+		}
+		// extractPrefix never returns an empty string: with no module and no
+		// priority it still renders "[]". The bracketed module is therefore
+		// unconditional, and is written piecewise to skip the per-entry
+		// Sprintf plus the " " + text + ":" concatenation it used to cost.
+		colorScheme.PrefixColor.open(b)
+		b.WriteString(" [") //nolint:gosec
+		writePrefixBody(b, module, priority)
+		b.WriteString("]:") //nolint:gosec
+		colorScheme.PrefixColor.close(b)
+		f.appendMessage(b, message)
 	}
 
+	for _, k := range keys {
+		if k != "prefix" && k != "file" && k != "func" && k != "line" && k != logPriorityKey && k != logModuleKey {
+			b.WriteByte(' ') //nolint:gosec
+			levelColor.write(b, k)
+			b.WriteByte('=') //nolint:gosec
+			f.appendFormattedValue(b, entry.Data[k])
+		}
+	}
+}
+
+// printCritical renders a _priority=CRITICAL entry, whose whole line is wrapped
+// in one color. Kept on fmt deliberately: it is a rare path and the padded
+// message format is easier to get right there.
+func (f *TextFormatter) printCritical(b *bytes.Buffer, entry *logrus.Entry, colorScheme *compiledColorScheme, levelText, message, timestampFormat string, ccFile, ccFunc, ccLine string) {
 	messageFormat := "%s"
 	if f.SpacePadding != 0 {
 		messageFormat = fmt.Sprintf("%%-%ds", f.SpacePadding)
@@ -285,66 +392,149 @@ func (f *TextFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry, keys 
 		messageFormat = " " + messageFormat
 	}
 
-	callContextParts := []string{}
-	if ifile, ok := entry.Data["file"]; ok {
-		if sfile, ok := ifile.(string); ok && sfile != "" {
-			callContextParts = append(callContextParts, sfile)
-		}
-	}
-	if ifunc, ok := entry.Data["func"]; ok {
-		if sfunc, ok := ifunc.(string); ok && sfunc != "" {
-			callContextParts = append(callContextParts, sfunc)
-		}
-	}
-	if iline, ok := entry.Data["line"]; ok {
-		sline := ""
-		switch iline := iline.(type) {
-		case string:
-			sline = iline
-		case int, uint, int32, int64, uint32, uint64:
-			sline = fmt.Sprint(iline)
-		}
-		if sline != "" {
-			callContextParts = append(callContextParts, fmt.Sprint(sline))
-		}
-	}
-	callContextText := strings.Join(callContextParts, ":")
-	callContext := colorScheme.CallContextColor(callContextText)
-	if callContext != "" {
-		callContext = " " + callContext
+	var cc bytes.Buffer
+	writeJoined(&cc, ccFile, ccFunc, ccLine)
+	callContextText := cc.String()
+
+	prefixText := extractPrefix(entry)
+	if prefixText != "" {
+		prefixText = " " + prefixText + ":"
 	}
 
+	var str string
 	if f.DisableTimestamp {
-		if hasPriority {
-			str := fmt.Sprintf("%s%s%s"+messageFormat, levelText, callContextText, prefixText, message)
-			fmt.Fprint(b, colorScheme.CriticalColor(str))
-		} else {
-			fmt.Fprintf(b, "%s%s%s"+messageFormat, level, callContext, prefix, message)
-		}
+		str = fmt.Sprintf("%s%s%s"+messageFormat, levelText, callContextText, prefixText, message)
 	} else {
-		var timestamp string
-		if !f.FullTimestamp {
-			timestamp = fmt.Sprintf("[%04d]", miniTS())
-		} else {
-			timestamp = fmt.Sprintf("[%s]", entry.Time.Format(timestampFormat))
-		}
+		var ts bytes.Buffer
+		ts.WriteByte('[') //nolint:gosec
+		f.appendTimestamp(&ts, entry, timestampFormat)
+		ts.WriteByte(']') //nolint:gosec
+		str = fmt.Sprintf("%s %s%s%s"+messageFormat, ts.String(), levelText, callContextText, prefixText, message)
+	}
+	b.WriteString(colorScheme.CriticalColor.apply(str)) //nolint:gosec
+}
 
-		coloredTimestamp := colorScheme.TimestampColor(timestamp)
+// upperLevelText returns the uppercased level name. strings.ToUpper allocates
+// for the lowercase names logrus hands back, and the set is closed.
+func upperLevelText(level logrus.Level, text string) string {
+	switch level {
+	case logrus.PanicLevel:
+		return "PANIC"
+	case logrus.FatalLevel:
+		return "FATAL"
+	case logrus.ErrorLevel:
+		return "ERROR"
+	case logrus.WarnLevel:
+		return "WARN"
+	case logrus.InfoLevel:
+		return "INFO"
+	case logrus.DebugLevel:
+		return "DEBUG"
+	case logrus.TraceLevel:
+		return "TRACE"
+	default:
+		return strings.ToUpper(text)
+	}
+}
 
-		if hasPriority {
-			str := fmt.Sprintf("%s %s%s%s"+messageFormat, timestamp, levelText, callContextText, prefixText, message)
-			fmt.Fprint(b, colorScheme.CriticalColor(str))
-		} else {
-			fmt.Fprintf(b, "%s %s%s%s"+messageFormat, coloredTimestamp, level, callContext, prefix, message)
+// writeJoined appends the non-empty parts separated by ":", as
+// strings.Join(parts, ":") did over a slice built per entry.
+func writeJoined(b *bytes.Buffer, parts ...string) {
+	first := true
+	for _, p := range parts {
+		if p == "" {
+			continue
 		}
+		if !first {
+			b.WriteByte(':') //nolint:gosec
+		}
+		b.WriteString(p) //nolint:gosec
+		first = false
+	}
+}
+
+func writePrefixBody(b *bytes.Buffer, module, priority string) {
+	switch {
+	case priority == "":
+		b.WriteString(module) //nolint:gosec
+	case module == "":
+		b.WriteString(priority) //nolint:gosec
+	default:
+		b.WriteString(module)   //nolint:gosec
+		b.WriteByte(':')        //nolint:gosec
+		b.WriteString(priority) //nolint:gosec
+	}
+}
+
+// appendTimestamp writes the timestamp without its brackets.
+func (f *TextFormatter) appendTimestamp(b *bytes.Buffer, entry *logrus.Entry, timestampFormat string) {
+	if f.FullTimestamp {
+		var scratch [64]byte
+		b.Write(entry.Time.AppendFormat(scratch[:0], timestampFormat)) //nolint:gosec,errcheck
+		return
 	}
 
-	for _, k := range keys {
-		if k != "prefix" && k != "file" && k != "func" && k != "line" && k != logPriorityKey && k != logModuleKey {
-			v := entry.Data[k]
-			fmt.Fprintf(b, " %s", f.formatKeyValue(levelColor(k), v))
+	// "%04d" over the seconds since process start.
+	n := miniTS()
+	if n < 0 {
+		fmt.Fprintf(b, "%04d", n)
+		return
+	}
+	var scratch [20]byte
+	digits := strconv.AppendInt(scratch[:0], int64(n), 10)
+	for i := len(digits); i < 4; i++ {
+		b.WriteByte('0') //nolint:gosec
+	}
+	b.Write(digits) //nolint:gosec,errcheck
+}
+
+// appendMessage writes the message, padded to SpacePadding runes when set, as
+// the "%s" / "%-<n>ds" format did.
+func (f *TextFormatter) appendMessage(b *bytes.Buffer, message string) {
+	if message != "" {
+		b.WriteByte(' ') //nolint:gosec
+	}
+	if f.SpacePadding < 0 {
+		// A negative width makes a malformed verb; leave that to fmt so the
+		// output stays whatever it always was.
+		fmt.Fprintf(b, fmt.Sprintf("%%-%ds", f.SpacePadding), message)
+		return
+	}
+	b.WriteString(message) //nolint:gosec
+	for n := f.SpacePadding - utf8.RuneCountInString(message); n > 0; n-- {
+		b.WriteByte(' ') //nolint:gosec
+	}
+}
+
+// callContext pulls the file/func/line keys out of the entry. Skywire sets
+// none of them, so returning three strings keeps the common case free of the
+// slice that used to be built and thrown away for every line.
+func callContext(entry *logrus.Entry) (file, fn, line string) {
+	if v, ok := entry.Data["file"]; ok {
+		file, _ = v.(string)
+	}
+	if v, ok := entry.Data["func"]; ok {
+		fn, _ = v.(string)
+	}
+	if v, ok := entry.Data["line"]; ok {
+		switch v := v.(type) {
+		case string:
+			line = v
+		case int:
+			line = strconv.Itoa(v)
+		case uint:
+			line = strconv.FormatUint(uint64(v), 10)
+		case int32:
+			line = strconv.FormatInt(int64(v), 10)
+		case int64:
+			line = strconv.FormatInt(v, 10)
+		case uint32:
+			line = strconv.FormatUint(uint64(v), 10)
+		case uint64:
+			line = strconv.FormatUint(v, 10)
 		}
 	}
+	return file, fn, line
 }
 
 func (f *TextFormatter) needsQuoting(text string) bool {
@@ -368,47 +558,50 @@ func (f *TextFormatter) needsQuoting(text string) bool {
 	return false
 }
 
-func extractPrefix(e *logrus.Entry) string {
-	var module string
+func prefixParts(e *logrus.Entry) (module, priority string) {
 	if iModule, ok := e.Data[logModuleKey]; ok {
 		module, _ = iModule.(string)
 	}
-
-	var priority string
 	if iPriority, ok := e.Data[logPriorityKey]; ok {
 		priority, _ = iPriority.(string)
 	}
+	return module, priority
+}
+
+func extractPrefix(e *logrus.Entry) string {
+	module, priority := prefixParts(e)
 
 	switch {
 	case priority == "":
-		return fmt.Sprintf("[%s]", module)
+		return "[" + module + "]"
 	case module == "":
-		return fmt.Sprintf("[%s]", priority)
+		return "[" + priority + "]"
 	default:
-		return fmt.Sprintf("[%s:%s]", module, priority)
+		return "[" + module + ":" + priority + "]"
 	}
 }
 
-func (f *TextFormatter) formatKeyValue(key string, value interface{}) string {
-	return fmt.Sprintf("%s=%s", key, f.formatValue(value))
-}
-
-func (f *TextFormatter) formatValue(value interface{}) string {
+// appendFormattedValue is the buffer-appending equivalent of the old
+// formatKeyValue/formatValue pair, which cost two Sprintf calls per field.
+func (f *TextFormatter) appendFormattedValue(b *bytes.Buffer, value interface{}) {
 	switch value := value.(type) {
 	case string:
-		if f.needsQuoting(value) {
-			return fmt.Sprintf("%s%+v%s", f.QuoteCharacter, value, f.QuoteCharacter)
-		}
-		return value
+		f.appendMaybeQuoted(b, value)
 	case error:
-		errmsg := value.Error()
-		if f.needsQuoting(errmsg) {
-			return fmt.Sprintf("%s%+v%s", f.QuoteCharacter, errmsg, f.QuoteCharacter)
-		}
-		return errmsg
+		f.appendMaybeQuoted(b, value.Error())
 	default:
-		return fmt.Sprintf("%+v", value)
+		fmt.Fprintf(b, "%+v", value)
 	}
+}
+
+func (f *TextFormatter) appendMaybeQuoted(b *bytes.Buffer, s string) {
+	if !f.needsQuoting(s) {
+		b.WriteString(s) //nolint:gosec
+		return
+	}
+	b.WriteString(f.QuoteCharacter) //nolint:gosec
+	b.WriteString(s)                //nolint:gosec
+	b.WriteString(f.QuoteCharacter) //nolint:gosec
 }
 
 func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key string, value interface{}, appendSpace bool) {

--- a/pkg/logging/formatter_bench_test.go
+++ b/pkg/logging/formatter_bench_test.go
@@ -1,0 +1,49 @@
+// Package logging pkg/logging/formatter_bench_test.go c0-com-log
+package logging
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+// benchFormat drives Format the way logrus does on a live logger: the entry
+// carries a pooled buffer that is reset between writes.
+func benchFormat(b *testing.B, f *TextFormatter, entry *logrus.Entry) {
+	buf := &bytes.Buffer{}
+	entry.Buffer = buf
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		if _, err := f.Format(entry); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkFormat covers the shapes a dmsg-server actually emits: a bare
+// message, one or two fields, and an error field, uncolored (stderr is a
+// pipe under systemd) as well as colored.
+func BenchmarkFormat(b *testing.B) {
+	cases := []struct {
+		name  string
+		newf  func() *TextFormatter
+		entry *logrus.Entry
+	}{
+		{"plain/no-fields", prodFormatter, goldenEntry(logrus.InfoLevel, "serving", moduleFields("dmsg_server", nil))},
+		{"plain/one-field", prodFormatter, goldenEntry(logrus.InfoLevel, "stream closed", moduleFields("dmsg_server", logrus.Fields{"dst": "abc"}))},
+		{"plain/three-fields", prodFormatter, goldenEntry(logrus.InfoLevel, "stream closed", moduleFields("dmsg_server", logrus.Fields{"dst": "abc", "src": "def", "size": 4096}))},
+		{"plain/error-field", prodFormatter, goldenEntry(logrus.ErrorLevel, "dial failed", moduleFields("dmsg_server", logrus.Fields{logrus.ErrorKey: errors.New("connection refused")}))},
+		{"colored/no-fields", coloredFormatter, goldenEntry(logrus.InfoLevel, "serving", moduleFields("dmsg_server", nil))},
+		{"colored/three-fields", coloredFormatter, goldenEntry(logrus.InfoLevel, "stream closed", moduleFields("dmsg_server", logrus.Fields{"dst": "abc", "src": "def", "size": 4096}))},
+	}
+
+	for _, c := range cases {
+		c := c
+		b.Run(c.name, func(b *testing.B) { benchFormat(b, c.newf(), c.entry) })
+	}
+}

--- a/pkg/logging/formatter_golden_test.go
+++ b/pkg/logging/formatter_golden_test.go
@@ -1,0 +1,326 @@
+// Package logging pkg/logging/formatter_golden_test.go c0-com-log
+package logging
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+var updateGolden = flag.Bool("update", false, "rewrite testdata/formatter_golden.txt from the current formatter output")
+
+const goldenFile = "testdata/formatter_golden.txt"
+
+// goldenTime is fixed and in UTC so the rendered timestamps do not depend on
+// the machine's clock or zone.
+var goldenTime = time.Date(2026, 3, 4, 5, 6, 7, 890123456, time.UTC)
+
+// prodFormatter mirrors NewMasterLogger's formatter, which is what every
+// skywire process actually runs with.
+func prodFormatter() *TextFormatter {
+	return &TextFormatter{
+		FullTimestamp:      true,
+		AlwaysQuoteStrings: true,
+		QuoteEmptyFields:   true,
+		ForceFormatting:    true,
+		DisableColors:      false,
+		ForceColors:        false,
+		TimestampFormat:    "2006-01-02T15:04:05.0000Z07:00",
+	}
+}
+
+func coloredFormatter() *TextFormatter {
+	f := prodFormatter()
+	f.ForceColors = true
+	return f
+}
+
+func goldenEntry(level logrus.Level, msg string, data logrus.Fields) *logrus.Entry {
+	if data == nil {
+		data = logrus.Fields{}
+	}
+	return &logrus.Entry{
+		Logger:  &logrus.Logger{Out: io.Discard, Formatter: &logrus.TextFormatter{}, Level: logrus.TraceLevel},
+		Data:    data,
+		Time:    goldenTime,
+		Level:   level,
+		Message: msg,
+	}
+}
+
+func moduleFields(module string, extra logrus.Fields) logrus.Fields {
+	d := logrus.Fields{logModuleKey: module}
+	for k, v := range extra {
+		d[k] = v
+	}
+	return d
+}
+
+type goldenCase struct {
+	name  string
+	newf  func() *TextFormatter
+	entry *logrus.Entry
+}
+
+func goldenCases() []goldenCase {
+	cases := []goldenCase{
+		{"plain/no-fields", prodFormatter, goldenEntry(logrus.InfoLevel, "serving", moduleFields("dmsg_server", nil))},
+		{"plain/empty-message", prodFormatter, goldenEntry(logrus.InfoLevel, "", moduleFields("dmsg_server", nil))},
+		{"plain/no-module", prodFormatter, goldenEntry(logrus.InfoLevel, "serving", nil)},
+		{"plain/one-field", prodFormatter, goldenEntry(logrus.InfoLevel, "stream closed", moduleFields("dmsg_server", logrus.Fields{"dst": "abc"}))},
+		{"plain/three-fields", prodFormatter, goldenEntry(logrus.InfoLevel, "stream closed", moduleFields("dmsg_server", logrus.Fields{"dst": "abc", "src": "def", "size": 4096}))},
+		{"plain/unsorted-keys", prodFormatter, goldenEntry(logrus.InfoLevel, "z first", moduleFields("dmsg_server", logrus.Fields{"zulu": 1, "alpha": 2, "mike": 3}))},
+		{"plain/error-field", prodFormatter, goldenEntry(logrus.ErrorLevel, "dial failed", moduleFields("dmsg_server", logrus.Fields{logrus.ErrorKey: errors.New("connection refused")}))},
+		{"plain/error-field-plain-word", prodFormatter, goldenEntry(logrus.ErrorLevel, "dial failed", moduleFields("dmsg_server", logrus.Fields{logrus.ErrorKey: errors.New("refused")}))},
+		{"plain/message-with-spaces-and-quotes", prodFormatter, goldenEntry(logrus.InfoLevel, `he said "hi there" & left`, moduleFields("dmsg_server", nil))},
+		{"plain/value-with-quotes", prodFormatter, goldenEntry(logrus.InfoLevel, "quoting", moduleFields("dmsg_server", logrus.Fields{"raw": `a "b" c`}))},
+		{"plain/empty-value", prodFormatter, goldenEntry(logrus.InfoLevel, "empty", moduleFields("dmsg_server", logrus.Fields{"empty": ""}))},
+		{"plain/bool-and-float-values", prodFormatter, goldenEntry(logrus.InfoLevel, "typed", moduleFields("dmsg_server", logrus.Fields{"ok": true, "ratio": 1.5, "n": int64(-7)}))},
+		{"plain/struct-value", prodFormatter, goldenEntry(logrus.InfoLevel, "typed", moduleFields("dmsg_server", logrus.Fields{"pt": struct {
+			X int
+			Y string
+		}{1, "two"}}))},
+		{"plain/nil-value", prodFormatter, goldenEntry(logrus.InfoLevel, "typed", moduleFields("dmsg_server", logrus.Fields{"nothing": nil}))},
+		{"plain/module-with-colon", prodFormatter, goldenEntry(logrus.InfoLevel, "serving", moduleFields("dmsgC:disc:cxo-lookup", nil))},
+		{"plain/empty-module", prodFormatter, goldenEntry(logrus.InfoLevel, "serving", moduleFields("", nil))},
+		{"plain/skipped-prefix-key", prodFormatter, goldenEntry(logrus.InfoLevel, "serving", moduleFields("dmsg_server", logrus.Fields{"prefix": "ignored", "kept": "yes"}))},
+		{"plain/many-fields", prodFormatter, goldenEntry(logrus.InfoLevel, "many", moduleFields("dmsg_server", logrus.Fields{
+			"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6, "g": 7, "h": 8, "i": 9, "j": 10, "k": 11, "l": 12,
+		}))},
+		{"plain/exactly-eight-keys", prodFormatter, goldenEntry(logrus.InfoLevel, "eight", moduleFields("dmsg_server", logrus.Fields{
+			"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6, "g": 7,
+		}))},
+		{"colored/many-fields", coloredFormatter, goldenEntry(logrus.InfoLevel, "many", moduleFields("dmsg_server", logrus.Fields{
+			"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6, "g": 7, "h": 8, "i": 9, "j": 10, "k": 11, "l": 12,
+		}))},
+	}
+
+	for _, lvl := range []logrus.Level{logrus.TraceLevel, logrus.DebugLevel, logrus.InfoLevel, logrus.WarnLevel, logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel} {
+		lvl := lvl
+		cases = append(cases,
+			goldenCase{"level/plain/" + lvl.String(), prodFormatter, goldenEntry(lvl, "level check", moduleFields("dmsg_server", logrus.Fields{"k": "v"}))},
+			goldenCase{"level/colored/" + lvl.String(), coloredFormatter, goldenEntry(lvl, "level check", moduleFields("dmsg_server", logrus.Fields{"k": "v"}))},
+		)
+	}
+
+	cases = append(cases,
+		goldenCase{"colored/no-fields", coloredFormatter, goldenEntry(logrus.InfoLevel, "serving", moduleFields("dmsg_server", nil))},
+		goldenCase{"colored/no-module", coloredFormatter, goldenEntry(logrus.InfoLevel, "serving", nil)},
+		goldenCase{"colored/three-fields", coloredFormatter, goldenEntry(logrus.InfoLevel, "stream closed", moduleFields("dmsg_server", logrus.Fields{"dst": "abc", "src": "def", "size": 4096}))},
+		goldenCase{"colored/error-field", coloredFormatter, goldenEntry(logrus.ErrorLevel, "dial failed", moduleFields("dmsg_server", logrus.Fields{logrus.ErrorKey: errors.New("connection refused")}))},
+
+		goldenCase{"critical/plain", prodFormatter, goldenEntry(logrus.ErrorLevel, "the sky is falling", logrus.Fields{logModuleKey: "dmsg_server", logPriorityKey: logPriorityCritical})},
+		goldenCase{"critical/colored", coloredFormatter, goldenEntry(logrus.ErrorLevel, "the sky is falling", logrus.Fields{logModuleKey: "dmsg_server", logPriorityKey: logPriorityCritical})},
+		goldenCase{"critical/colored-with-fields", coloredFormatter, goldenEntry(logrus.ErrorLevel, "the sky is falling", logrus.Fields{logModuleKey: "dmsg_server", logPriorityKey: logPriorityCritical, "k": "v"})},
+		goldenCase{"critical/no-module", coloredFormatter, goldenEntry(logrus.ErrorLevel, "the sky is falling", logrus.Fields{logPriorityKey: logPriorityCritical})},
+		goldenCase{"critical/non-critical-priority", coloredFormatter, goldenEntry(logrus.ErrorLevel, "odd priority", logrus.Fields{logModuleKey: "dmsg_server", logPriorityKey: "LOW"})},
+
+		goldenCase{"callcontext/file-only", coloredFormatter, goldenEntry(logrus.InfoLevel, "cc", moduleFields("dmsg_server", logrus.Fields{"file": "server.go"}))},
+		goldenCase{"callcontext/func-only", coloredFormatter, goldenEntry(logrus.InfoLevel, "cc", moduleFields("dmsg_server", logrus.Fields{"func": "Serve"}))},
+		goldenCase{"callcontext/line-int", coloredFormatter, goldenEntry(logrus.InfoLevel, "cc", moduleFields("dmsg_server", logrus.Fields{"line": 42}))},
+		goldenCase{"callcontext/line-string", coloredFormatter, goldenEntry(logrus.InfoLevel, "cc", moduleFields("dmsg_server", logrus.Fields{"line": "42"}))},
+		goldenCase{"callcontext/line-uint64", coloredFormatter, goldenEntry(logrus.InfoLevel, "cc", moduleFields("dmsg_server", logrus.Fields{"line": uint64(42)}))},
+		goldenCase{"callcontext/line-float-ignored", coloredFormatter, goldenEntry(logrus.InfoLevel, "cc", moduleFields("dmsg_server", logrus.Fields{"line": 42.5}))},
+		goldenCase{"callcontext/all-three", coloredFormatter, goldenEntry(logrus.InfoLevel, "cc", moduleFields("dmsg_server", logrus.Fields{"file": "server.go", "func": "Serve", "line": 42}))},
+		goldenCase{"callcontext/all-three-plain", prodFormatter, goldenEntry(logrus.InfoLevel, "cc", moduleFields("dmsg_server", logrus.Fields{"file": "server.go", "func": "Serve", "line": 42}))},
+		goldenCase{"callcontext/empty-strings", coloredFormatter, goldenEntry(logrus.InfoLevel, "cc", moduleFields("dmsg_server", logrus.Fields{"file": "", "func": "", "line": ""}))},
+		goldenCase{"callcontext/wrong-types", coloredFormatter, goldenEntry(logrus.InfoLevel, "cc", moduleFields("dmsg_server", logrus.Fields{"file": 7, "func": true}))},
+		goldenCase{"callcontext/critical", coloredFormatter, goldenEntry(logrus.ErrorLevel, "cc", logrus.Fields{logModuleKey: "dmsg_server", logPriorityKey: logPriorityCritical, "file": "server.go", "line": 42})},
+
+		goldenCase{"opt/no-timestamp", func() *TextFormatter {
+			f := coloredFormatter()
+			f.DisableTimestamp = true
+			return f
+		}, goldenEntry(logrus.InfoLevel, "no ts", moduleFields("dmsg_server", logrus.Fields{"k": "v"}))},
+		goldenCase{"opt/no-timestamp-critical", func() *TextFormatter {
+			f := coloredFormatter()
+			f.DisableTimestamp = true
+			return f
+		}, goldenEntry(logrus.ErrorLevel, "no ts", logrus.Fields{logModuleKey: "dmsg_server", logPriorityKey: logPriorityCritical})},
+		goldenCase{"opt/mini-timestamp", func() *TextFormatter {
+			f := coloredFormatter()
+			f.FullTimestamp = false
+			return f
+		}, goldenEntry(logrus.InfoLevel, "mini ts", moduleFields("dmsg_server", nil))},
+		goldenCase{"opt/mini-timestamp-critical", func() *TextFormatter {
+			f := coloredFormatter()
+			f.FullTimestamp = false
+			return f
+		}, goldenEntry(logrus.InfoLevel, "mini ts", logrus.Fields{logModuleKey: "dmsg_server", logPriorityKey: logPriorityCritical})},
+		goldenCase{"opt/default-timestamp-format", func() *TextFormatter {
+			f := coloredFormatter()
+			f.TimestampFormat = ""
+			return f
+		}, goldenEntry(logrus.InfoLevel, "rfc3339", moduleFields("dmsg_server", nil))},
+		goldenCase{"opt/no-uppercase", func() *TextFormatter {
+			f := coloredFormatter()
+			f.DisableUppercase = true
+			return f
+		}, goldenEntry(logrus.WarnLevel, "lowercase level", moduleFields("dmsg_server", nil))},
+		goldenCase{"opt/no-sorting", func() *TextFormatter {
+			f := prodFormatter()
+			f.DisableSorting = true
+			return f
+		}, goldenEntry(logrus.InfoLevel, "unsorted", moduleFields("dmsg_server", logrus.Fields{"only": "one"}))},
+		goldenCase{"opt/space-padding", func() *TextFormatter {
+			f := coloredFormatter()
+			f.SpacePadding = 30
+			return f
+		}, goldenEntry(logrus.InfoLevel, "padded", moduleFields("dmsg_server", logrus.Fields{"k": "v"}))},
+		goldenCase{"opt/space-padding-empty-message", func() *TextFormatter {
+			f := coloredFormatter()
+			f.SpacePadding = 10
+			return f
+		}, goldenEntry(logrus.InfoLevel, "", moduleFields("dmsg_server", nil))},
+		goldenCase{"opt/space-padding-overflow", func() *TextFormatter {
+			f := coloredFormatter()
+			f.SpacePadding = 3
+			return f
+		}, goldenEntry(logrus.InfoLevel, "a much longer message", moduleFields("dmsg_server", nil))},
+		goldenCase{"opt/space-padding-multibyte", func() *TextFormatter {
+			f := coloredFormatter()
+			f.SpacePadding = 12
+			return f
+		}, goldenEntry(logrus.InfoLevel, "héllo wörld", moduleFields("dmsg_server", nil))},
+		goldenCase{"opt/space-padding-critical", func() *TextFormatter {
+			f := coloredFormatter()
+			f.SpacePadding = 30
+			return f
+		}, goldenEntry(logrus.ErrorLevel, "padded", logrus.Fields{logModuleKey: "dmsg_server", logPriorityKey: logPriorityCritical})},
+		goldenCase{"opt/no-quoting", func() *TextFormatter {
+			f := coloredFormatter()
+			f.AlwaysQuoteStrings = false
+			f.QuoteEmptyFields = false
+			return f
+		}, goldenEntry(logrus.InfoLevel, "quotes off", moduleFields("dmsg_server", logrus.Fields{"plain": "abc-1.2", "spaced": "a b", "empty": "", "err": errors.New("a b"), "errplain": errors.New("ab")}))},
+		goldenCase{"opt/custom-quote-character", func() *TextFormatter {
+			f := coloredFormatter()
+			f.QuoteCharacter = "'"
+			return f
+		}, goldenEntry(logrus.InfoLevel, "custom quote", moduleFields("dmsg_server", logrus.Fields{"k": "v"}))},
+		goldenCase{"opt/disable-colors-wins", func() *TextFormatter {
+			f := coloredFormatter()
+			f.DisableColors = true
+			return f
+		}, goldenEntry(logrus.InfoLevel, "no colors", moduleFields("dmsg_server", logrus.Fields{"k": "v"}))},
+		goldenCase{"opt/custom-color-scheme", func() *TextFormatter {
+			f := coloredFormatter()
+			f.SetColorScheme(&ColorScheme{InfoLevelStyle: "magenta", PrefixStyle: "red+h"})
+			return f
+		}, goldenEntry(logrus.InfoLevel, "custom scheme", moduleFields("dmsg_server", logrus.Fields{"k": "v"}))},
+
+		goldenCase{"unformatted/no-fields", func() *TextFormatter {
+			f := prodFormatter()
+			f.ForceFormatting = false
+			return f
+		}, goldenEntry(logrus.InfoLevel, "serving", moduleFields("dmsg_server", nil))},
+		goldenCase{"unformatted/fields", func() *TextFormatter {
+			f := prodFormatter()
+			f.ForceFormatting = false
+			return f
+		}, goldenEntry(logrus.InfoLevel, "serving", moduleFields("dmsg_server", logrus.Fields{"dst": "abc", "n": 3}))},
+		goldenCase{"unformatted/no-timestamp-no-message", func() *TextFormatter {
+			f := prodFormatter()
+			f.ForceFormatting = false
+			f.DisableTimestamp = true
+			return f
+		}, goldenEntry(logrus.InfoLevel, "", moduleFields("dmsg_server", logrus.Fields{"dst": "abc"}))},
+	)
+
+	return cases
+}
+
+// render is the formatter under test, driven exactly as logrus drives it.
+func render(t *testing.T, f *TextFormatter, entry *logrus.Entry) string {
+	t.Helper()
+	out, err := f.Format(entry)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	return string(out)
+}
+
+// TestFormatterGolden pins the formatter's byte-for-byte output, colors
+// included, so the rendering can be rewritten for speed without changing a
+// single byte of what operators read.
+func TestFormatterGolden(t *testing.T) {
+	// miniTS reads the package clock; pin it so the [%04d] cases are stable.
+	baseTimestamp = time.Now().Add(-42*time.Second - 500*time.Millisecond)
+
+	cases := goldenCases()
+
+	if *updateGolden {
+		var sb strings.Builder
+		for _, c := range cases {
+			fmt.Fprintf(&sb, "%s\n%s\n", c.name, strconv.Quote(render(t, c.newf(), c.entry)))
+		}
+		if err := os.WriteFile(goldenFile, []byte(sb.String()), 0o600); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		t.Logf("wrote %d cases to %s", len(cases), goldenFile)
+		return
+	}
+
+	want, err := readGolden()
+	if err != nil {
+		t.Fatalf("read golden (run 'go test ./pkg/logging/ -run TestFormatterGolden -update'): %v", err)
+	}
+
+	seen := make(map[string]bool, len(cases))
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			if seen[c.name] {
+				t.Fatalf("duplicate golden case name %q", c.name)
+			}
+			seen[c.name] = true
+
+			expected, ok := want[c.name]
+			if !ok {
+				t.Fatalf("no golden entry for %q", c.name)
+			}
+			got := render(t, c.newf(), c.entry)
+			if got != expected {
+				t.Errorf("output changed\n want: %s\n  got: %s", strconv.Quote(expected), strconv.Quote(got))
+			}
+		})
+	}
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("golden entry %q has no matching case", name)
+		}
+	}
+}
+
+func readGolden() (map[string]string, error) {
+	fh, err := os.Open(goldenFile)
+	if err != nil {
+		return nil, err
+	}
+	defer fh.Close() //nolint:errcheck
+
+	out := make(map[string]string)
+	sc := bufio.NewScanner(fh)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		name := sc.Text()
+		if !sc.Scan() {
+			return nil, fmt.Errorf("golden entry %q has no value line", name)
+		}
+		v, err := strconv.Unquote(sc.Text())
+		if err != nil {
+			return nil, fmt.Errorf("golden entry %q: %w", name, err)
+		}
+		out[name] = v
+	}
+	return out, sc.Err()
+}

--- a/pkg/logging/testdata/formatter_golden.txt
+++ b/pkg/logging/testdata/formatter_golden.txt
@@ -1,0 +1,146 @@
+plain/no-fields
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: serving\n"
+plain/empty-message
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]:\n"
+plain/no-module
+"[2026-03-04T05:06:07.8901Z] INFO []: serving\n"
+plain/one-field
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: stream closed dst=\"abc\"\n"
+plain/three-fields
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: stream closed dst=\"abc\" size=4096 src=\"def\"\n"
+plain/unsorted-keys
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: z first alpha=2 mike=3 zulu=1\n"
+plain/error-field
+"[2026-03-04T05:06:07.8901Z] ERROR [dmsg_server]: dial failed error=\"connection refused\"\n"
+plain/error-field-plain-word
+"[2026-03-04T05:06:07.8901Z] ERROR [dmsg_server]: dial failed error=\"refused\"\n"
+plain/message-with-spaces-and-quotes
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: he said \"hi there\" & left\n"
+plain/value-with-quotes
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: quoting raw=\"a \"b\" c\"\n"
+plain/empty-value
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: empty empty=\"\"\n"
+plain/bool-and-float-values
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: typed n=-7 ok=true ratio=1.5\n"
+plain/struct-value
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: typed pt={X:1 Y:two}\n"
+plain/nil-value
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: typed nothing=<nil>\n"
+plain/module-with-colon
+"[2026-03-04T05:06:07.8901Z] INFO [dmsgC:disc:cxo-lookup]: serving\n"
+plain/empty-module
+"[2026-03-04T05:06:07.8901Z] INFO []: serving\n"
+plain/skipped-prefix-key
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: serving kept=\"yes\"\n"
+plain/many-fields
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: many a=1 b=2 c=3 d=4 e=5 f=6 g=7 h=8 i=9 j=10 k=11 l=12\n"
+plain/exactly-eight-keys
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: eight a=1 b=2 c=3 d=4 e=5 f=6 g=7\n"
+colored/many-fields
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m many \x1b[0;32ma\x1b[0m=1 \x1b[0;32mb\x1b[0m=2 \x1b[0;32mc\x1b[0m=3 \x1b[0;32md\x1b[0m=4 \x1b[0;32me\x1b[0m=5 \x1b[0;32mf\x1b[0m=6 \x1b[0;32mg\x1b[0m=7 \x1b[0;32mh\x1b[0m=8 \x1b[0;32mi\x1b[0m=9 \x1b[0;32mj\x1b[0m=10 \x1b[0;32mk\x1b[0m=11 \x1b[0;32ml\x1b[0m=12\n"
+level/plain/trace
+"[2026-03-04T05:06:07.8901Z] TRACE [dmsg_server]: level check k=\"v\"\n"
+level/colored/trace
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;30mTRACE\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m level check \x1b[0;30mk\x1b[0m=\"v\"\n"
+level/plain/debug
+"[2026-03-04T05:06:07.8901Z] DEBUG [dmsg_server]: level check k=\"v\"\n"
+level/colored/debug
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;34mDEBUG\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m level check \x1b[0;34mk\x1b[0m=\"v\"\n"
+level/plain/info
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: level check k=\"v\"\n"
+level/colored/info
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m level check \x1b[0;32mk\x1b[0m=\"v\"\n"
+level/plain/warning
+"[2026-03-04T05:06:07.8901Z] WARN [dmsg_server]: level check k=\"v\"\n"
+level/colored/warning
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;33mWARN\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m level check \x1b[0;33mk\x1b[0m=\"v\"\n"
+level/plain/error
+"[2026-03-04T05:06:07.8901Z] ERROR [dmsg_server]: level check k=\"v\"\n"
+level/colored/error
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;31mERROR\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m level check \x1b[0;31mk\x1b[0m=\"v\"\n"
+level/plain/fatal
+"[2026-03-04T05:06:07.8901Z] FATAL [dmsg_server]: level check k=\"v\"\n"
+level/colored/fatal
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;31mFATAL\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m level check \x1b[0;31mk\x1b[0m=\"v\"\n"
+level/plain/panic
+"[2026-03-04T05:06:07.8901Z] PANIC [dmsg_server]: level check k=\"v\"\n"
+level/colored/panic
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;31mPANIC\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m level check \x1b[0;31mk\x1b[0m=\"v\"\n"
+colored/no-fields
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m serving\n"
+colored/no-module
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m []:\x1b[0m serving\n"
+colored/three-fields
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m stream closed \x1b[0;32mdst\x1b[0m=\"abc\" \x1b[0;32msize\x1b[0m=4096 \x1b[0;32msrc\x1b[0m=\"def\"\n"
+colored/error-field
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;31mERROR\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m dial failed \x1b[0;31merror\x1b[0m=\"connection refused\"\n"
+critical/plain
+"[2026-03-04T05:06:07.8901Z] ERROR [dmsg_server:CRITICAL]: the sky is falling\n"
+critical/colored
+"\x1b[0;95m[2026-03-04T05:06:07.8901Z] ERROR [dmsg_server:CRITICAL]: the sky is falling\x1b[0m\n"
+critical/colored-with-fields
+"\x1b[0;95m[2026-03-04T05:06:07.8901Z] ERROR [dmsg_server:CRITICAL]: the sky is falling\x1b[0m \x1b[0;31mk\x1b[0m=\"v\"\n"
+critical/no-module
+"\x1b[0;95m[2026-03-04T05:06:07.8901Z] ERROR [CRITICAL]: the sky is falling\x1b[0m\n"
+critical/non-critical-priority
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;31mERROR\x1b[0m\x1b[0;36m [dmsg_server:LOW]:\x1b[0m odd priority\n"
+callcontext/file-only
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m \x1b[0;90mserver.go\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m cc\n"
+callcontext/func-only
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m \x1b[0;90mServe\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m cc\n"
+callcontext/line-int
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m \x1b[0;90m42\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m cc\n"
+callcontext/line-string
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m \x1b[0;90m42\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m cc\n"
+callcontext/line-uint64
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m \x1b[0;90m42\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m cc\n"
+callcontext/line-float-ignored
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m cc\n"
+callcontext/all-three
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m \x1b[0;90mserver.go:Serve:42\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m cc\n"
+callcontext/all-three-plain
+"[2026-03-04T05:06:07.8901Z] INFO server.go:Serve:42 [dmsg_server]: cc\n"
+callcontext/empty-strings
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m cc\n"
+callcontext/wrong-types
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m cc\n"
+callcontext/critical
+"\x1b[0;95m[2026-03-04T05:06:07.8901Z] ERRORserver.go:42 [dmsg_server:CRITICAL]: cc\x1b[0m\n"
+opt/no-timestamp
+"\x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m no ts \x1b[0;32mk\x1b[0m=\"v\"\n"
+opt/no-timestamp-critical
+"\x1b[0;95mERROR [dmsg_server:CRITICAL]: no ts\x1b[0m\n"
+opt/mini-timestamp
+"\x1b[0;90m[0042]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m mini ts\n"
+opt/mini-timestamp-critical
+"\x1b[0;95m[0042] INFO [dmsg_server:CRITICAL]: mini ts\x1b[0m\n"
+opt/default-timestamp-format
+"\x1b[0;90m[2026-03-04T05:06:07Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m rfc3339\n"
+opt/no-uppercase
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;33mwarn\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m lowercase level\n"
+opt/no-sorting
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: unsorted only=\"one\"\n"
+opt/space-padding
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m padded                         \x1b[0;32mk\x1b[0m=\"v\"\n"
+opt/space-padding-empty-message
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m          \n"
+opt/space-padding-overflow
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m a much longer message\n"
+opt/space-padding-multibyte
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m héllo wörld \n"
+opt/space-padding-critical
+"\x1b[0;95m[2026-03-04T05:06:07.8901Z] ERROR [dmsg_server:CRITICAL]: padded                        \x1b[0m\n"
+opt/no-quoting
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m quotes off \x1b[0;32mempty\x1b[0m= \x1b[0;32merr\x1b[0m=\"a b\" \x1b[0;32merrplain\x1b[0m=ab \x1b[0;32mplain\x1b[0m=abc-1.2 \x1b[0;32mspaced\x1b[0m=\"a b\"\n"
+opt/custom-quote-character
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;32mINFO\x1b[0m\x1b[0;36m [dmsg_server]:\x1b[0m custom quote \x1b[0;32mk\x1b[0m='v'\n"
+opt/disable-colors-wins
+"[2026-03-04T05:06:07.8901Z] INFO [dmsg_server]: no colors k=\"v\"\n"
+opt/custom-color-scheme
+"\x1b[0;90m[2026-03-04T05:06:07.8901Z]\x1b[0m \x1b[0;35mINFO\x1b[0m\x1b[0;91m [dmsg_server]:\x1b[0m custom scheme \x1b[0;35mk\x1b[0m=\"v\"\n"
+unformatted/no-fields
+"time=\"2026-03-04T05:06:07.8901Z\" level=\"info\" msg=\"serving\" _module=\"dmsg_server\"\n"
+unformatted/fields
+"time=\"2026-03-04T05:06:07.8901Z\" level=\"info\" msg=\"serving\" _module=\"dmsg_server\" dst=\"abc\" n=3\n"
+unformatted/no-timestamp-no-message
+"level=\"info\" _module=\"dmsg_server\" dst=\"abc\"\n"


### PR DESCRIPTION
`logging.(*TextFormatter).Format` measured ~4% of a production dmsg-server's CPU at 67k log lines/min. `ForceFormatting` is set for every skywire process, so `printColored` is always the path taken, and it reached `fmt` at least seven times per entry: a `Sprintf` for the `[module]` prefix, one for the timestamp, a format string built by concatenation and handed to `Fprintf` over five reflected arguments, and two more `Sprintf` calls per field. It also allocated a key slice and a `callContextParts` slice for every entry, though nothing in skywire sets `file`, `func` or `line`.

This appends into the entry's buffer instead. Colors are kept as their raw escape prefix rather than as `ansi.ColorFunc`'s closure so they can be written around content in place, the timestamp goes through `Time.AppendFormat`, the level name comes from a table rather than `strings.ToUpper`, the key slice lives in a stack array for the usual field counts, sorting is skipped below two keys, and the call context is only assembled when one of those three keys is present. The critical-priority path stays on `fmt` — its color wraps the whole line and it is rare.

Output is unchanged byte for byte. `TestFormatterGolden` pins 73 renderings captured from the old formatter (every level, colors on and off, no/one/many fields, error values, quoting, padding, call context, critical priority, both timestamp modes, and the unformatted path) and the rewrite still matches all of them.

`BenchmarkFormat`, minimum of 12 interleaved runs on the same busy machine:

| case | before | after |
| --- | --- | --- |
| plain/no-fields | 1494 ns, 200 B, 11 allocs | 573 ns, 0 B, 0 allocs |
| plain/one-field | 2275 ns, 320 B, 19 allocs | 687 ns, 0 B, 0 allocs |
| plain/three-fields | 3759 ns, 560 B, 33 allocs | 903 ns, 0 B, 0 allocs |
| plain/error-field | 2385 ns, 352 B, 19 allocs | 679 ns, 0 B, 0 allocs |
| colored/no-fields | 2244 ns, 360 B, 15 allocs | 729 ns, 0 B, 0 allocs |
| colored/three-fields | 3664 ns, 808 B, 40 allocs | 1114 ns, 0 B, 0 allocs |
