### PR TITLE
feat(dmsg): let one key register as both a client and a dmsg server

### DIFF
--- a/pkg/dmsg/discovery/api/registration_ingest.go
+++ b/pkg/dmsg/discovery/api/registration_ingest.go
@@ -34,11 +34,19 @@ func (a *API) IngestEntryFromCXO(ctx context.Context, entry *disc.Entry, reporte
 	if entry == nil {
 		return
 	}
-	// Registration-over-CXO is for client (visor) entries only. Server
-	// entries register over HTTP; a client must not be able to publish a
-	// server entry (which advertises a reachable address) via its own feed.
-	if entry.Client == nil || entry.Server != nil {
-		log.WithField("reporter", reporter).Debug("registration-cxo: ignoring non-client entry")
+	// This path carries CLIENT registration, so an entry with no client half
+	// has nothing to register here.
+	//
+	// A server half alongside it IS accepted. A visor running the in-process
+	// dmsg server on its own key has one entry carrying both sections, and
+	// rejecting it would force that visor back onto the HTTP re-PUT this
+	// whole path exists to avoid — a fresh Noise+PQ handshake per refresh,
+	// which is what dominated dmsg-discovery CPU. It grants nothing new:
+	// entry.Static == reporter is enforced below, so a visor can only ever
+	// publish its OWN key, and the HTTP path already accepts a server entry
+	// from that same key under the same signature check.
+	if entry.Client == nil {
+		log.WithField("reporter", reporter).Debug("registration-cxo: ignoring entry with no client section")
 		return
 	}
 	// A visor may only publish its OWN entry: the feed PK (reporter) signs

--- a/pkg/dmsg/discovery/api/registration_ingest_dual_test.go
+++ b/pkg/dmsg/discovery/api/registration_ingest_dual_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/discovery/store"
+)
+
+// signedDualEntry builds a signed entry carrying BOTH sections — what a visor
+// running the in-process dmsg server on its own key publishes.
+func signedDualEntry(t *testing.T, pk cipher.PubKey, sk cipher.SecKey, seq uint64, addr string) *disc.Entry {
+	t.Helper()
+	e := disc.NewClientEntry(pk, seq, nil)
+	e.Server = &disc.Server{Address: addr, AvailableSessions: 100}
+	require.NoError(t, e.Sign(sk))
+	return e
+}
+
+// An entry carrying both sections must be ingested, not dropped. Dropping it
+// forced a co-resident visor and dmsg server back onto the HTTP re-PUT that
+// registration-over-CXO exists to avoid, one Noise+PQ handshake per refresh.
+func TestIngestEntryFromCXO_AcceptsDualEntry(t *testing.T) {
+	ctx := context.Background()
+	db := store.NewMock()
+	a := newAPI(db)
+	pk, sk := cipher.GenerateKeyPair()
+
+	a.IngestEntryFromCXO(ctx, signedDualEntry(t, pk, sk, 0, "1.2.3.4:8081"), pk)
+	got, err := db.Entry(ctx, pk)
+	require.NoError(t, err, "a dual entry must be ingested")
+	require.NotNil(t, got.Client, "the client half is what this path registers")
+	require.NotNil(t, got.Server, "the server half must be stored, not stripped")
+	require.Equal(t, "1.2.3.4:8081", got.Server.Address)
+
+	// It iterates like any other entry.
+	a.IngestEntryFromCXO(ctx, signedDualEntry(t, pk, sk, 1, "1.2.3.4:9091"), pk)
+	got, err = db.Entry(ctx, pk)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), got.Sequence)
+	require.Equal(t, "1.2.3.4:9091", got.Server.Address)
+}
+
+// The guard that matters is unchanged: a visor may publish only its own key,
+// so it cannot advertise a reachable address for somebody else's.
+func TestIngestEntryFromCXO_DualEntryStillBoundToReporter(t *testing.T) {
+	ctx := context.Background()
+	db := store.NewMock()
+	a := newAPI(db)
+	pk, sk := cipher.GenerateKeyPair()
+	other, _ := cipher.GenerateKeyPair()
+
+	a.IngestEntryFromCXO(ctx, signedDualEntry(t, pk, sk, 0, "1.2.3.4:8081"), other)
+	_, err := db.Entry(ctx, pk)
+	require.Error(t, err, "an entry whose key is not the feed's must be dropped")
+}
+
+// A server-only entry has no client half, so this path has nothing to register.
+func TestIngestEntryFromCXO_IgnoresServerOnlyEntry(t *testing.T) {
+	ctx := context.Background()
+	db := store.NewMock()
+	a := newAPI(db)
+	pk, sk := cipher.GenerateKeyPair()
+
+	e := disc.NewServerEntry(pk, 0, "1.2.3.4:8081", 100)
+	require.NoError(t, e.Sign(sk))
+	a.IngestEntryFromCXO(ctx, e, pk)
+	_, err := db.Entry(ctx, pk)
+	require.Error(t, err)
+}

--- a/pkg/dmsg/dmsg/dual_entry_test.go
+++ b/pkg/dmsg/dmsg/dual_entry_test.go
@@ -1,0 +1,117 @@
+// Package dmsg pkg/dmsg/dmsg/dual_entry_test.go c1-net-dmsg
+package dmsg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// dualEntity wires an EntityCommon and a discovery endpoint over one mock
+// discovery, so both entry-update paths can be driven against the same key.
+func dualEntity(t *testing.T, name string) (*EntityCommon, *discoveryEndpoint, disc.APIClient, cipher.PubKey) {
+	t.Helper()
+	pk, sk := GenKeyPair(t, name)
+	dc := disc.NewMock(0)
+	c := new(EntityCommon)
+	c.init(pk, sk, dc, logging.MustGetLogger(name), 0)
+	return c, &discoveryEndpoint{Client: dc, PK: pk}, dc, pk
+}
+
+// A visor running the in-process dmsg server on its own key registers both
+// roles in ONE entry. Whichever half registers first, the second must be
+// ADDED to that entry rather than refused or replacing it, and the entry must
+// stay correctly signed.
+func TestDualEntry_ServerHalfAddedToExistingClientEntry(t *testing.T) {
+	c, ep, dc, pk := dualEntity(t, "client-first")
+	ctx := context.Background()
+	srv, _ := cipher.GenerateKeyPair()
+
+	_, err := c.updateClientEntryOnEndpoint(ctx, ep, "visor", []cipher.PubKey{srv}, true)
+	require.NoError(t, err)
+	got, err := dc.Entry(ctx, pk)
+	require.NoError(t, err)
+	require.NotNil(t, got.Client)
+	require.Nil(t, got.Server, "only the client half is registered yet")
+
+	// The dmsg server comes up on the same key.
+	require.NoError(t, c.updateServerEntryOnEndpoint(ctx, ep, "1.2.3.4:8081", "", 100, ""))
+
+	got, err = dc.Entry(ctx, pk)
+	require.NoError(t, err)
+	require.NotNil(t, got.Server, "the server half must be added")
+	require.Equal(t, "1.2.3.4:8081", got.Server.Address)
+	require.Equal(t, 100, got.Server.AvailableSessions)
+	require.NotNil(t, got.Client, "the client half must survive")
+	require.Equal(t, []cipher.PubKey{srv}, got.Client.DelegatedServers)
+	require.NoError(t, got.VerifySignature())
+	require.NoError(t, got.Validate(false))
+}
+
+// The reverse order: the server registered first, then the visor's client.
+// This is the direction that used to fail hardest — the client path replaced
+// the whole entry with a fresh sequence-0 one, which both dropped the server
+// half and was rejected because a new sequence must exceed the stored one.
+func TestDualEntry_ClientHalfAddedToExistingServerEntry(t *testing.T) {
+	c, ep, dc, pk := dualEntity(t, "server-first")
+	ctx := context.Background()
+	srv, _ := cipher.GenerateKeyPair()
+
+	require.NoError(t, c.updateServerEntryOnEndpoint(ctx, ep, "5.6.7.8:8081", "", 42, ""))
+	got, err := dc.Entry(ctx, pk)
+	require.NoError(t, err)
+	require.NotNil(t, got.Server)
+	require.Nil(t, got.Client, "only the server half is registered yet")
+	seqBefore := got.Sequence
+
+	entry, err := c.updateClientEntryOnEndpoint(ctx, ep, "visor", []cipher.PubKey{srv}, true)
+	require.NoError(t, err, "the client half must register, not be rejected")
+	require.NotNil(t, entry)
+
+	got, err = dc.Entry(ctx, pk)
+	require.NoError(t, err)
+	require.NotNil(t, got.Client, "the client half must be added")
+	require.Equal(t, []cipher.PubKey{srv}, got.Client.DelegatedServers)
+	require.NotNil(t, got.Server, "the server half must survive")
+	require.Equal(t, "5.6.7.8:8081", got.Server.Address)
+	require.Equal(t, 42, got.Server.AvailableSessions)
+	require.Greater(t, got.Sequence, seqBefore, "the merge iterates the entry, it does not restart it")
+	require.NoError(t, got.VerifySignature())
+	require.NoError(t, got.Validate(false))
+}
+
+// Once merged, each loop keeps refreshing its own half without disturbing the
+// other — the steady state for a co-resident visor and dmsg server.
+func TestDualEntry_RefreshKeepsBothHalves(t *testing.T) {
+	c, ep, dc, pk := dualEntity(t, "steady")
+	ctx := context.Background()
+	srvA, _ := cipher.GenerateKeyPair()
+	srvB, _ := cipher.GenerateKeyPair()
+
+	_, err := c.updateClientEntryOnEndpoint(ctx, ep, "visor", []cipher.PubKey{srvA}, true)
+	require.NoError(t, err)
+	require.NoError(t, c.updateServerEntryOnEndpoint(ctx, ep, "9.9.9.9:8081", "", 10, ""))
+
+	// The server's session count moves.
+	require.NoError(t, c.updateServerEntryOnEndpoint(ctx, ep, "9.9.9.9:8081", "", 7, ""))
+	got, err := dc.Entry(ctx, pk)
+	require.NoError(t, err)
+	require.Equal(t, 7, got.Server.AvailableSessions)
+	require.NotNil(t, got.Client)
+
+	// The client's delegated servers move.
+	_, err = c.updateClientEntryOnEndpoint(ctx, ep, "visor", []cipher.PubKey{srvB}, true)
+	require.NoError(t, err)
+	got, err = dc.Entry(ctx, pk)
+	require.NoError(t, err)
+	require.Equal(t, []cipher.PubKey{srvB}, got.Client.DelegatedServers)
+	require.NotNil(t, got.Server, "the server half must still be there")
+	require.Equal(t, "9.9.9.9:8081", got.Server.Address)
+	require.Equal(t, 7, got.Server.AvailableSessions)
+	require.NoError(t, got.VerifySignature())
+}

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -687,8 +687,16 @@ func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *disc
 		return ep.Client.PostEntry(ctx, entry)
 	}
 
-	if entry.Server == nil {
-		return errors.New("entry in discovery is not of a dmsg server")
+	// The key is already registered as a client: a visor running the
+	// in-process dmsg server on its own key. One Entry carries a Client and a
+	// Server section independently (Validate requires only that at least one
+	// is present), so ADD the server half to the existing entry rather than
+	// refusing it. Refusing is what made the two roles unable to share a key
+	// at all: whichever registered first locked the other out permanently,
+	// and silently, since this error is only ever logged by a retry loop.
+	serverAdded := entry.Server == nil
+	if serverAdded {
+		entry.Server = &disc.Server{Address: addr, AvailableSessions: availableSessions}
 	}
 
 	if authPassphrase != "" {
@@ -710,7 +718,7 @@ func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *disc
 	versionDelta := c.serverVersion != "" && entry.Version != c.serverVersion
 
 	// No update needed if entry has no delta AND update is not due.
-	if _, due := c.updateIsDue(); !sessionsDelta && !addrDelta && !addrV6Delta && !udpDelta && !wsDelta && !wtDelta && !versionDelta && !due {
+	if _, due := c.updateIsDue(); !serverAdded && !sessionsDelta && !addrDelta && !addrV6Delta && !udpDelta && !wsDelta && !wtDelta && !versionDelta && !due {
 		return nil
 	}
 
@@ -1114,18 +1122,14 @@ func (c *EntityCommon) updateClientEntryOnEndpoint(ctx context.Context, ep *disc
 		return entry, nil
 	}
 
-	// The entry might be a server entry (e.g., debug client running on a dmsg server).
-	// In that case, entry.Client is nil and we need to create a new client entry.
-	if entry.Client == nil {
-		entry = disc.NewClientEntry(c.pk, 0, srvPKs)
-		entry.ClientType = clientType
-		if err := entry.Sign(c.sk); err != nil {
-			return nil, err
-		}
-		if err := ep.Client.PostEntry(ctx, entry); err != nil {
-			return nil, err
-		}
-		return entry, nil
+	// The key is already registered as a server: the same key also running a
+	// dmsg server. ADD the client half to that entry. Replacing it with a
+	// fresh sequence-0 entry, as this used to, both dropped the server half
+	// and was rejected outright, because a new entry's sequence must exceed
+	// the stored one — so the client could never register at all.
+	clientAdded := entry.Client == nil
+	if clientAdded {
+		entry.Client = &disc.Client{DelegatedServers: srvPKs}
 	}
 
 	// Whether the client's CURRENT delegated servers is the same as what would be advertised.
@@ -1133,7 +1137,7 @@ func (c *EntityCommon) updateClientEntryOnEndpoint(ctx context.Context, ep *disc
 
 	// No update is needed if delegated servers has no delta, an entry update is
 	// not due, and this is not the client's first publish.
-	if _, due := c.updateIsDue(); sameSrvPKs && !due && !mustPublish {
+	if _, due := c.updateIsDue(); !clientAdded && sameSrvPKs && !due && !mustPublish {
 		return nil, nil
 	}
 


### PR DESCRIPTION
A discovery `Entry` has always carried an independent `Client` and `Server` section, and `Validate` asks only that at least one is present. But nothing could produce an entry with both, so a visor running the in-process dmsg server on its own key could not register both roles. This is the remaining blocker for combining a visor and a dmsg server, now that #4785 removed the port one.

Each update loop failed differently. The server loop fetched the entry and, finding no `Server` section, returned `entry in discovery is not of a dmsg server` and gave up, so it never added one. The client loop, finding no `Client` section, discarded the whole entry and posted a fresh sequence-0 entry, which both dropped the server half and was rejected anyway because a new sequence must exceed the stored one. Whichever role registered first locked the other out permanently, and silently, since both errors are only ever seen by a retry loop. Each loop now adds its own half to the entry it fetched and iterates it normally.

Registration over CXO separately refused any entry carrying a `Server` section, which would have pushed a co-resident visor back onto the HTTP re-PUT that path exists to avoid. It now accepts one. That grants no new capability: `entry.Static` must equal the reporting feed's key, so a visor can still only publish its own entry, and the HTTP path already accepts a server section from that same key under the same signature check. An entry with no client half is still ignored, having nothing to register there.

The six new tests each fail on develop with the exact errors above and pass here.
