### PR TITLE
feat(routing): let a visor refuse to be an intermediate hop

### DIFF
--- a/pkg/router/cascade_handler.go
+++ b/pkg/router/cascade_handler.go
@@ -38,6 +38,24 @@ type CascadeHandler struct {
 
 	// defaultTimeout is the per-hop timeout for waiting for a cascade ACK.
 	defaultTimeout time.Duration
+
+	// noTransit refuses cascade installs that would make this visor a transit
+	// hop (routing.no_transit). Cascade reaches a transit hop over the wire,
+	// so the guard belongs on that path only: ProcessLocalOrigin shares
+	// processInstall to lay THIS visor's own rules as the source of its own
+	// route, and refusing there would stop it originating routes at all.
+	noTransit bool
+}
+
+// SetNoTransit makes the handler refuse cascade installs that would make this
+// visor an intermediate hop on another visor's route.
+func (ch *CascadeHandler) SetNoTransit(v bool) { ch.noTransit = v }
+
+// refusesTransit reports whether this install, arriving over the wire, would
+// make this visor a transit hop it has been configured not to be. An EDGE
+// install means the route ENDS here, which no_transit does not forbid.
+func (ch *CascadeHandler) refusesTransit(msg *routing.CascadeSetup) bool {
+	return ch.noTransit && !msg.IsEdge()
 }
 
 // NewCascadeHandler creates a new cascade handler. introduceRules is the
@@ -159,6 +177,14 @@ func (ch *CascadeHandler) processReserve(msg *routing.CascadeSetup) (*routing.Ca
 }
 
 func (ch *CascadeHandler) handleInstall(msg *routing.CascadeSetup, sourceTp *transport.ManagedTransport) {
+	// A non-edge install arriving over the wire is another visor asking this
+	// one to forward for it. That is precisely transit. An edge install (this
+	// visor is the route's responding destination) is not, and still applies.
+	if ch.refusesTransit(msg) {
+		ch.log.Debug("Refusing cascade install: this visor does not transit routes.")
+		ch.sendErrorAck(sourceTp, msg.SessionID, msg.Phase, "visor does not transit routes")
+		return
+	}
 	ack, err := ch.processInstall(msg)
 	if err != nil {
 		ch.log.WithError(err).Warn("Cascade install failed")

--- a/pkg/router/map_test.go
+++ b/pkg/router/map_test.go
@@ -106,7 +106,7 @@ func serveRouterRPC(t *testing.T, r Router) (addr string) {
 
 	mlog := logging.NewMasterLogger()
 	rpcS := rpc.NewServer()
-	require.NoError(t, rpcS.Register(NewRPCGateway(r, mlog)))
+	require.NoError(t, rpcS.Register(NewRPCGateway(r, mlog, false)))
 	go rpcS.Accept(l)
 
 	return l.Addr().String()

--- a/pkg/router/no_transit_test.go
+++ b/pkg/router/no_transit_test.go
@@ -1,0 +1,81 @@
+// Package router pkg/router/no_transit_test.go c2-net-router
+package router
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/testhelpers"
+)
+
+// A visor with no_transit set refuses to be an intermediate hop, and says so
+// through the setup node's own failure channel rather than silently dropping.
+func TestRPCGateway_NoTransitRefusesIntermediaryRules(t *testing.T) {
+	mlog := logging.NewMasterLogger()
+	r := &MockRouter{}
+	gw := NewRPCGateway(r, mlog, true)
+
+	var ok bool
+	err := gw.AddIntermediaryRules([]routing.Rule{{0, 0, 0}}, &ok)
+	require.Error(t, err)
+	require.False(t, ok)
+	var f routing.Failure
+	require.ErrorAs(t, err, &f)
+	require.Equal(t, routing.FailureAddRules, f.Code)
+	r.AssertNotCalled(t, "SaveRoutingRules")
+}
+
+// Without it, nothing changes: the rules are saved as before.
+func TestRPCGateway_TransitAllowedByDefault(t *testing.T) {
+	mlog := logging.NewMasterLogger()
+	rule := routing.Rule{0, 0, 0}
+	r := &MockRouter{}
+	r.On("SaveRoutingRules", rule).Return(testhelpers.NoErr)
+	gw := NewRPCGateway(r, mlog, false)
+
+	var ok bool
+	require.NoError(t, gw.AddIntermediaryRules([]routing.Rule{rule}, &ok))
+	require.True(t, ok)
+	r.AssertCalled(t, "SaveRoutingRules", rule)
+}
+
+// Refusing transit must not stop a route that ENDS here: edge rules arrive by
+// a different RPC and are untouched.
+func TestRPCGateway_NoTransitStillAcceptsEdgeRules(t *testing.T) {
+	mlog := logging.NewMasterLogger()
+	r := &MockRouter{}
+	edge := routing.EdgeRules{Forward: routing.Rule{0, 0, 0}, Reverse: routing.Rule{1, 1, 1}}
+	r.On("IntroduceRules", edge).Return(testhelpers.NoErr)
+	gw := NewRPCGateway(r, mlog, true)
+
+	var ok bool
+	require.NoError(t, gw.AddEdgeRules(edge, &ok))
+	require.True(t, ok)
+	r.AssertCalled(t, "IntroduceRules", edge)
+}
+
+// The cascade path reaches a transit hop over the wire, so the same refusal
+// applies there. A cascade handler is refusing when noTransit is set and the
+// install is not an edge install; ProcessLocalOrigin (this visor's own rules
+// as the SOURCE of its own route) shares processInstall and must keep working.
+func TestCascadeHandler_RefusesTransitButNotEdges(t *testing.T) {
+	src, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	transit := &routing.CascadeSetup{}
+	edge := &routing.CascadeSetup{EdgeDesc: routing.NewRouteDescriptor(src, dst, 100, 110)}
+	require.False(t, transit.IsEdge())
+	require.True(t, edge.IsEdge())
+
+	ch := &CascadeHandler{}
+	ch.SetNoTransit(false)
+	require.False(t, ch.refusesTransit(transit), "transit is allowed by default")
+	require.False(t, ch.refusesTransit(edge))
+
+	ch.SetNoTransit(true)
+	require.True(t, ch.refusesTransit(transit), "a wire install that is not an edge is transit")
+	require.False(t, ch.refusesTransit(edge), "a route that ENDS here is not transit")
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -138,6 +138,10 @@ type Config struct {
 	// types from the candidate set (see visorconfig.Routing.RouteExcludeTransportTypes).
 	// Empty = nothing excluded. Lowercased type names.
 	ExcludeTransportTypes []string
+	// NoTransit refuses every request to act as an intermediate hop on another
+	// visor's route (visorconfig.Routing.NoTransit). Routes that originate or
+	// terminate here are unaffected.
+	NoTransit bool
 	// MuxRoutes seeds the router's runtime parallel-mux-routes value from
 	// routing.mux_routes at construction, the way MinHops already is. The
 	// dial-time default is applied by the app networker (which the launcher

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -113,6 +113,7 @@ func (r *router) Serve(ctx context.Context) error {
 		trustedPKs = append(trustedPKs, pk)
 	}
 	ch := NewCascadeHandler(r.logger, r.conf.PubKey, trustedPKs, r.rt, r.tm, r.IntroduceRules)
+	ch.SetNoTransit(r.conf.NoTransit)
 
 	// Source-driven cascade: the visor's route-group dialer owns a send-only
 	// CascadeBuilder that injects RSN-signed cascades down this visor's own

--- a/pkg/router/router_setup_rpc_native.go
+++ b/pkg/router/router_setup_rpc_native.go
@@ -9,5 +9,5 @@ import "github.com/skycoin/skywire/pkg/logging"
 // (gobrpc.Server is net/rpc.Server on native builds). The TinyGo build registers
 // explicit handlers instead — see router_setup_rpc_tinygo.go.
 func (r *router) registerSetupRPC(mLog *logging.MasterLogger) error {
-	return r.rpcSrv.Register(NewRPCGateway(r, mLog))
+	return r.rpcSrv.Register(NewRPCGateway(r, mLog, r.conf.NoTransit))
 }

--- a/pkg/router/router_setup_rpc_tinygo.go
+++ b/pkg/router/router_setup_rpc_tinygo.go
@@ -17,7 +17,7 @@ import (
 // (matching the gateway method's arg type) and returns the reply value; the wire
 // format is identical to net/rpc, so a native router peer interoperates.
 func (r *router) registerSetupRPC(mLog *logging.MasterLogger) error {
-	gw := NewRPCGateway(r, mLog)
+	gw := NewRPCGateway(r, mLog, r.conf.NoTransit)
 
 	r.rpcSrv.HandleFunc(RPCName+".AddEdgeRules", func(dec *gob.Decoder) (interface{}, error) {
 		var rules routing.EdgeRules

--- a/pkg/router/routerclient_test.go
+++ b/pkg/router/routerclient_test.go
@@ -94,7 +94,7 @@ func prepRPCServerAndClient(t *testing.T, r Router) (s *rpc.Server, cl *Client, 
 	require.NoError(t, err)
 	mlog := logging.NewMasterLogger()
 	s = rpc.NewServer()
-	require.NoError(t, s.Register(NewRPCGateway(r, mlog)))
+	require.NoError(t, s.Register(NewRPCGateway(r, mlog, false)))
 	go s.Accept(l)
 
 	conn, err := net.Dial("tcp", l.Addr().String())

--- a/pkg/router/rpc_gateway.go
+++ b/pkg/router/rpc_gateway.go
@@ -16,13 +16,16 @@ const RPCName = "RPCGateway"
 type RPCGateway struct {
 	logger *logging.Logger
 	router Router
+	// noTransit refuses intermediary rules outright (routing.no_transit).
+	noTransit bool
 }
 
 // NewRPCGateway creates a new RPCGateway.
-func NewRPCGateway(router Router, mLog *logging.MasterLogger) *RPCGateway {
+func NewRPCGateway(router Router, mLog *logging.MasterLogger, noTransit bool) *RPCGateway {
 	return &RPCGateway{
-		logger: mLog.PackageLogger("router-gateway"),
-		router: router,
+		logger:    mLog.PackageLogger("router-gateway"),
+		router:    router,
+		noTransit: noTransit,
 	}
 }
 
@@ -41,8 +44,16 @@ func (r *RPCGateway) AddEdgeRules(rules routing.EdgeRules, ok *bool) error {
 	return nil
 }
 
-// AddIntermediaryRules adds intermediary rules.
+// AddIntermediaryRules adds intermediary rules. This RPC exists only to make
+// this visor a transit hop on someone else's route, so refusing it outright is
+// exactly what routing.no_transit means. Edge rules arrive by AddEdgeRules and
+// are untouched, so routes that start or end here still work.
 func (r *RPCGateway) AddIntermediaryRules(rules []routing.Rule, ok *bool) error {
+	if r.noTransit {
+		*ok = false
+		r.logger.Debug("Refusing intermediary rules: this visor does not transit routes.")
+		return routing.Failure{Code: routing.FailureAddRules, Msg: "visor does not transit routes"}
+	}
 	if err := r.router.SaveRoutingRules(rules...); err != nil {
 		*ok = false
 

--- a/pkg/router/rpc_gateway_test.go
+++ b/pkg/router/rpc_gateway_test.go
@@ -33,7 +33,7 @@ func TestRPCGateway_AddEdgeRules(t *testing.T) {
 		r.On("IntroduceRules", rules).Return(testhelpers.NoErr)
 		r.On("SaveRoutingRules", rules.Forward, rules.Reverse).Return(testhelpers.NoErr)
 
-		gateway := NewRPCGateway(r, mlog)
+		gateway := NewRPCGateway(r, mlog, false)
 
 		var ok bool
 		err := gateway.AddEdgeRules(rules, &ok)
@@ -45,7 +45,7 @@ func TestRPCGateway_AddEdgeRules(t *testing.T) {
 		r := &MockRouter{}
 		r.On("IntroduceRules", rules).Return(testhelpers.Err)
 
-		gateway := NewRPCGateway(r, mlog)
+		gateway := NewRPCGateway(r, mlog, false)
 
 		var ok bool
 		err := gateway.AddEdgeRules(rules, &ok)
@@ -63,7 +63,7 @@ func TestRPCGateway_AddEdgeRules(t *testing.T) {
 		r := &MockRouter{}
 		r.On("IntroduceRules", rules).Return(testhelpers.Err)
 
-		gateway := NewRPCGateway(r, mlog)
+		gateway := NewRPCGateway(r, mlog, false)
 
 		wantErr := routing.Failure{
 			Code: routing.FailureAddRules,
@@ -87,7 +87,7 @@ func TestRPCGateway_AddIntermediaryRules(t *testing.T) {
 		r := &MockRouter{}
 		r.On("SaveRoutingRules", rulesIfc...).Return(testhelpers.NoErr)
 
-		gateway := NewRPCGateway(r, mlog)
+		gateway := NewRPCGateway(r, mlog, false)
 
 		var ok bool
 		err := gateway.AddIntermediaryRules(rules, &ok)
@@ -99,7 +99,7 @@ func TestRPCGateway_AddIntermediaryRules(t *testing.T) {
 		r := &MockRouter{}
 		r.On("SaveRoutingRules", rulesIfc...).Return(testhelpers.Err)
 
-		gateway := NewRPCGateway(r, mlog)
+		gateway := NewRPCGateway(r, mlog, false)
 
 		wantErr := routing.Failure{
 			Code: routing.FailureAddRules,
@@ -121,7 +121,7 @@ func TestRPCGateway_ReserveIDs(t *testing.T) {
 		r := &MockRouter{}
 		r.On("ReserveKeys", n).Return(ids, testhelpers.NoErr)
 
-		gateway := NewRPCGateway(r, mlog)
+		gateway := NewRPCGateway(r, mlog, false)
 
 		var gotIDs []routing.RouteID
 		err := gateway.ReserveIDs(uint8(n), &gotIDs) //nolint: gosec
@@ -133,7 +133,7 @@ func TestRPCGateway_ReserveIDs(t *testing.T) {
 		r := &MockRouter{}
 		r.On("ReserveKeys", n).Return(nil, testhelpers.Err)
 
-		gateway := NewRPCGateway(r, mlog)
+		gateway := NewRPCGateway(r, mlog, false)
 
 		wantErr := routing.Failure{
 			Code: routing.FailureReserveRtIDs,

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -313,6 +313,7 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 		MuxRoutes:             v.conf.Routing.MuxRoutes,
 		ParallelRouteSetup:    v.conf.Routing.ParallelRouteSetup,
 		ExcludeTransportTypes: v.conf.Routing.RouteExcludeTransportTypes,
+		NoTransit:             v.conf.Routing.NoTransit,
 		AwaitSetupListener:    v.awaitSetupListener,
 		Logger:                logger,
 		MasterLogger:          v.MasterLogger(),

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -650,6 +650,18 @@ type Routing struct {
 	RouteFinderDmsg     string          `json:"route_finder_dmsg,omitempty"`
 	RouteFinderTimeout  Duration        `json:"route_finder_timeout,omitempty"`
 	MinHops             uint16          `json:"min_hops"`
+	// NoTransit, when true, makes this visor refuse to be an INTERMEDIATE hop
+	// on anyone else's route. It still originates its own routes and still
+	// accepts routes that END here, and it is unaffected by anything that does
+	// not install a routing rule — dmsg-over-skynet relaying rides VStreamMux
+	// at route ID 0 and is deliberately not a route, so a visor hosting a dmsg
+	// server can carry that traffic while refusing transit.
+	//
+	// This is the ENFORCING half and needs nobody's cooperation. The route
+	// finder is told separately so it stops proposing routes that would be
+	// refused here; a stale or missing advertisement costs a failed setup and
+	// a retry, never a transited visor.
+	NoTransit bool `json:"no_transit,omitempty"`
 	// CalculateRoutes enables local route calculation instead of using the route finder service.
 	// When enabled, routes are calculated locally using cached TPD data.
 	// Can be overridden at runtime with --use-rf flag.

--- a/pkg/visor/visorcore/router.go
+++ b/pkg/visor/visorcore/router.go
@@ -38,10 +38,13 @@ type RouterDeps struct {
 	MinHops               uint16
 	MuxRoutes             int
 	ExcludeTransportTypes []string
-	ParallelRouteSetup    int
-	AwaitSetupListener    *dmsg.Listener
-	Logger                *logging.Logger
-	MasterLogger          *logging.MasterLogger
+	// NoTransit refuses to act as an intermediate hop on another visor's route
+	// (visorconfig.Routing.NoTransit).
+	NoTransit          bool
+	ParallelRouteSetup int
+	AwaitSetupListener *dmsg.Listener
+	Logger             *logging.Logger
+	MasterLogger       *logging.MasterLogger
 
 	AppLookup       func(routing.Port) (string, bool)
 	DialHook        router.DialHook
@@ -86,6 +89,7 @@ func BuildRouter(serveCtx context.Context, deps RouterDeps) (router.Router, erro
 		MinHops:               deps.MinHops,
 		MuxRoutes:             deps.MuxRoutes,
 		ExcludeTransportTypes: deps.ExcludeTransportTypes,
+		NoTransit:             deps.NoTransit,
 		ParallelRouteSetup:    deps.ParallelRouteSetup,
 		AwaitSetupListener:    deps.AwaitSetupListener,
 		AppLookup:             deps.AppLookup,


### PR DESCRIPTION
A visor hosting a dmsg server should carry dmsg-over-skynet traffic without becoming a transit hop for other visors' routes. `routing.no_transit` makes it refuse, and the refusal is enforced at the point the rule would be installed, so it needs no cooperation from the route finder, the setup node, or any peer's build.

Two paths install a transit rule and both are guarded. The setup node asks over `AddIntermediaryRules`, an RPC that exists only to make this visor a transit hop, so it is refused outright and answers with the failure code the setup node already handles. Cascade reaches a transit hop over the wire and installs through its own handler, which now refuses a non-edge install and returns an error ACK. The guard sits on the wire path only: `ProcessLocalOrigin` shares the same install code to lay this visor's own rules as the source of its own route, and refusing there would stop it originating routes at all.

Nothing else changes. Routes that start or end here still work, because edge rules arrive by a different RPC and an edge cascade install is explicitly allowed. Relaying is untouched: the VStream relay and the dmsg relay session are dispatched by packet type over route ID 0 and never consult the routing table. Default is off.

This is the enforcing half. Telling the route finder, so it stops proposing routes that would be refused here, is a separate change.
