### PR TITLE
feat(dmsg): raise the visor relay stream cap and make it configurable

### DIFF
--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -32,10 +32,22 @@ import (
 )
 
 // DefaultClientMaxRelayedStreams is the relay-slot cap a visor gives its dmsg
-// client when it runs the relay acceptor: enough for a desk's worth of
-// concurrent streams, small enough that an attached peer cannot amplify the
-// visor into a public relay.
-const DefaultClientMaxRelayedStreams = 256
+// client when it runs the relay acceptor.
+//
+// It was 256, sized for a desk's worth of streams from a handful of attached
+// peers. That is the wrong order of magnitude for a hub: a visor co-resident
+// with a dmsg server is what visors attach to when they stop holding their own
+// server sessions, and one core dmsg server carries several hundred client
+// connections today (771 on a production server, 2026-09-10). A hub fronting a
+// few hundred of those, each with a few concurrent streams, exhausts 256 long
+// before it runs out of anything real, and the failure is a refused stream that
+// looks like an unreachable service.
+//
+// Any visor with transports can be nominated as a relay by a peer, and a visor
+// co-resident with a dmsg server is doing a server's job outright, so this now
+// matches DefaultMaxRelayedStreams: what the server beside it would allow.
+// Bound it per visor with dmsg.relay_max_streams.
+const DefaultClientMaxRelayedStreams = DefaultMaxRelayedStreams
 
 // relayEntryLookupTimeout bounds the discovery lookup the relay makes to
 // order its forward candidates by the destination's delegated servers. The

--- a/pkg/dmsg/dmsgc/dmsgc.go
+++ b/pkg/dmsg/dmsgc/dmsgc.go
@@ -109,7 +109,7 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 		RelayOnly: browserRelayOnly,
 		// The visor runs a dmsg relay acceptor on skyenv.DmsgRelayPort (see
 		// initDmsgRelay): streams it carries for attached peers are bounded here.
-		MaxRelayedStreams: dmsg.DefaultClientMaxRelayedStreams,
+		MaxRelayedStreams: relayMaxStreams(conf),
 	}
 	dmsgConf.ClientType = "visor"
 
@@ -225,4 +225,14 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 		)
 	}
 	return dmsgC
+}
+
+// relayMaxStreams resolves the relay-slot cap for this visor's dmsg client:
+// the configured dmsg.relay_max_streams, or the default when unset. A negative
+// value is passed through so a visor can refuse to relay entirely.
+func relayMaxStreams(conf *spec.DmsgConfig) int {
+	if conf != nil && conf.RelayMaxStreams != 0 {
+		return conf.RelayMaxStreams
+	}
+	return dmsg.DefaultClientMaxRelayedStreams
 }

--- a/pkg/dmsg/dmsgc/relay_cap_test.go
+++ b/pkg/dmsg/dmsgc/relay_cap_test.go
@@ -1,0 +1,28 @@
+// Package dmsgc pkg/dmsg/dmsgc/relay_cap_test.go c1-net-dmsg
+package dmsgc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgc/spec"
+)
+
+// The relay-slot cap is the default unless the operator names a number.
+func TestRelayMaxStreams(t *testing.T) {
+	require.Equal(t, dmsg.DefaultClientMaxRelayedStreams, relayMaxStreams(nil))
+	require.Equal(t, dmsg.DefaultClientMaxRelayedStreams, relayMaxStreams(&spec.DmsgConfig{}))
+
+	// A relaying visor allows what the dmsg server beside it would allow: it
+	// is doing the same job for the peers attached to it.
+	require.Equal(t, dmsg.DefaultMaxRelayedStreams, dmsg.DefaultClientMaxRelayedStreams)
+	require.Greater(t, dmsg.DefaultClientMaxRelayedStreams, 256, "raised from the old desk-sized cap")
+
+	// An explicit value always wins.
+	require.Equal(t, 42, relayMaxStreams(&spec.DmsgConfig{RelayMaxStreams: 42}))
+
+	// Negative refuses to relay at all, and must not be turned into a default.
+	require.Equal(t, -1, relayMaxStreams(&spec.DmsgConfig{RelayMaxStreams: -1}))
+}

--- a/pkg/dmsg/dmsgc/spec/spec.go
+++ b/pkg/dmsg/dmsgc/spec/spec.go
@@ -120,6 +120,12 @@ type DmsgConfig struct {
 	// dmsg client for discovery rather than standing up a second transit
 	// client. Nil (the default) = no in-process server. See DmsgServerConfig.
 	Server *DmsgServerConfig `json:"server,omitempty"`
+
+	// RelayMaxStreams bounds the concurrent streams this visor will relay for
+	// peers attached to its dmsg relay acceptor. 0 uses
+	// dmsg.DefaultClientMaxRelayedStreams. A negative value refuses to relay at
+	// all, for a visor that should never carry other people's traffic.
+	RelayMaxStreams int `json:"relay_max_streams,omitempty"`
 }
 
 // DmsgServerConfig configures the OPTIONAL in-process dmsg server co-resident


### PR DESCRIPTION
A visor's relay-slot cap was 256, sized for a desk's worth of streams from a handful of attached peers. That is the wrong order of magnitude for what a relaying visor is about to become.

Once visors stop holding their own dmsg-server sessions and reach deployment services over a skynet-carried session, they attach to a visor co-resident with a dmsg server. One core server carries several hundred client connections today (771 on a production server). A relay fronting a few hundred of those, each with a few concurrent streams, exhausts 256 long before it runs out of anything real, and the failure surfaces as a refused stream that looks like an unreachable service.

The cap is now what the dmsg server beside it allows, since a relaying visor is doing the same job for the peers attached to it, and `dmsg.relay_max_streams` bounds it per visor. A negative value refuses to relay at all, for a visor that should never carry other people's traffic. This closes the "no config knob for the relay cap" follow-up from the skynet-carried session work.
