### PR TITLE
feat(dmsg): nominate co-resident visor+dmsg-server hubs as relays

### DIFF
--- a/pkg/visor/init_dmsg_relay.go
+++ b/pkg/visor/init_dmsg_relay.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sort"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/app/appnet"
@@ -156,9 +157,77 @@ func (v *Visor) nominateRelayPeers(ctx context.Context, dmsgC *dmsg.Client, log 
 	}
 }
 
-// relayNominees returns the persistent-transport peers this visor has a live
-// transport to.
+// relayHubLimit bounds how many co-resident visor+dmsg-server hubs are
+// nominated alongside the operator's own pins. Each nominee costs a dial
+// attempt, and one working relay is all a visor needs; a handful is enough
+// cover for the working one going away.
+const relayHubLimit = 4
+
+// relayNominees returns this visor's relay candidates: the persistent-transport
+// peers it holds a live transport to, then the hubs it can find.
 func (v *Visor) relayNominees() []cipher.PubKey {
+	if v.conf == nil {
+		return nil
+	}
+	seen := make(map[cipher.PubKey]struct{})
+	out := v.pinnedRelayNominees(seen)
+	return append(out, v.hubRelayNominees(seen)...)
+}
+
+// hubRelayNominees returns the visors that also run a dmsg server on their own
+// key. Those are the hubs: a plain dmsg server has no visor behind it and so no
+// relay acceptor to attach to, while a visor that IS a server holds the real
+// sessions this visor is trying to stop holding itself.
+//
+// The signal is the discovery entry carrying BOTH a Client and a Server
+// section, which only a co-resident pair produces. No direct transport is
+// required: the attach dials skynet://<pk>:70, which resolves over a direct
+// transport, a one-hop relay through a shared peer, or a route. A nominee that
+// cannot be reached, has no acceptor, or refuses simply fails and is backed off
+// by the client, so proposing one costs a dial and nothing else.
+//
+// Peers already reachable directly come first, being the cheapest path.
+func (v *Visor) hubRelayNominees(seen map[cipher.PubKey]struct{}) []cipher.PubKey {
+	if v.dmsgServersCache == nil || v.conf == nil {
+		return nil
+	}
+	var direct, remote []cipher.PubKey
+	for _, e := range v.dmsgServersCache.All() {
+		if e == nil || e.Server == nil || e.Client == nil {
+			continue // a plain server, or a plain client: not a hub
+		}
+		pk := e.Static
+		if pk == v.conf.PK {
+			continue
+		}
+		if _, dup := seen[pk]; dup {
+			continue
+		}
+		seen[pk] = struct{}{}
+		if v.hasTransportTo(pk) {
+			direct = append(direct, pk)
+			continue
+		}
+		remote = append(remote, pk)
+	}
+	// Stable order: the nominee set is compared for equality every tick, and a
+	// set that reshuffles would restart the client's serve pass each time.
+	sortPubKeys(direct)
+	sortPubKeys(remote)
+	out := append(direct, remote...)
+	if len(out) > relayHubLimit {
+		out = out[:relayHubLimit]
+	}
+	return out
+}
+
+func sortPubKeys(pks []cipher.PubKey) {
+	sort.Slice(pks, func(i, j int) bool { return pks[i].Hex() < pks[j].Hex() })
+}
+
+// pinnedRelayNominees returns the persistent-transport peers this visor has a
+// live transport to.
+func (v *Visor) pinnedRelayNominees(seen map[cipher.PubKey]struct{}) []cipher.PubKey {
 	if v.tpM == nil || v.conf == nil {
 		return nil
 	}
@@ -169,7 +238,6 @@ func (v *Visor) relayNominees() []cipher.PubKey {
 	if len(trusted) == 0 {
 		return nil
 	}
-	seen := make(map[cipher.PubKey]struct{})
 	var out []cipher.PubKey
 	v.tpM.WalkTransports(func(tp *transport.ManagedTransport) bool {
 		pk := tp.Remote()

--- a/pkg/visor/relay_hub_nominee_test.go
+++ b/pkg/visor/relay_hub_nominee_test.go
@@ -1,0 +1,84 @@
+// Package visor pkg/visor/relay_hub_nominee_test.go c3-visor-core
+package visor
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+func hubEntry(pk cipher.PubKey) *dmsgdisc.Entry {
+	e := dmsgdisc.NewClientEntry(pk, 0, nil)
+	e.Server = &dmsgdisc.Server{Address: "1.2.3.4:8081", AvailableSessions: 10}
+	return e
+}
+
+func serverOnlyEntry(pk cipher.PubKey) *dmsgdisc.Entry {
+	return dmsgdisc.NewServerEntry(pk, 0, "1.2.3.4:8081", 10)
+}
+
+// A hub is a visor that ALSO runs a dmsg server on its own key, which shows up
+// as a discovery entry carrying both sections. Those get nominated; a plain
+// server (no visor behind it, so no relay acceptor) and a plain client do not.
+func TestHubRelayNominees(t *testing.T) {
+	self, _ := cipher.GenerateKeyPair()
+	cache := NewDmsgServersCache(filepath.Join(t.TempDir(), "dmsg_servers.json"))
+
+	var hubs []cipher.PubKey
+	for i := 0; i < 6; i++ {
+		pk, _ := cipher.GenerateKeyPair()
+		hubs = append(hubs, pk)
+		require.NoError(t, cache.Set(hubEntry(pk)))
+	}
+	plainServer, _ := cipher.GenerateKeyPair()
+	require.NoError(t, cache.Set(serverOnlyEntry(plainServer)))
+	// The cache only ever holds server entries — it rejects anything without a
+	// server address — so the client section is the discriminator AMONG servers.
+	plainClient, _ := cipher.GenerateKeyPair()
+	require.Error(t, cache.Set(dmsgdisc.NewClientEntry(plainClient, 0, nil)))
+	require.NoError(t, cache.Set(hubEntry(self))) // this visor itself
+
+	v := &Visor{conf: &visorconfig.V1{Common: &visorconfig.Common{PK: self}}, dmsgServersCache: cache}
+	got := v.hubRelayNominees(make(map[cipher.PubKey]struct{}))
+
+	require.Len(t, got, relayHubLimit, "the nominee set is bounded")
+	for _, pk := range got {
+		require.NotEqual(t, self, pk, "a visor must not nominate itself")
+		require.NotEqual(t, plainServer, pk, "a plain dmsg server has no relay acceptor")
+		require.NotEqual(t, plainClient, pk, "a plain client is not a hub")
+		require.Contains(t, hubs, pk)
+	}
+
+	// Stable across calls: a reshuffling set would restart the client's serve
+	// pass on every nomination tick.
+	require.Equal(t, got, v.hubRelayNominees(make(map[cipher.PubKey]struct{})))
+	sorted := append([]cipher.PubKey(nil), got...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Hex() < sorted[j].Hex() })
+	require.Equal(t, sorted, got, "nominees are emitted in a deterministic order")
+}
+
+// A key already nominated as an operator pin is not nominated twice.
+func TestHubRelayNominees_SkipsAlreadySeen(t *testing.T) {
+	self, _ := cipher.GenerateKeyPair()
+	pinned, _ := cipher.GenerateKeyPair()
+	cache := NewDmsgServersCache(filepath.Join(t.TempDir(), "dmsg_servers.json"))
+	require.NoError(t, cache.Set(hubEntry(pinned)))
+
+	v := &Visor{conf: &visorconfig.V1{Common: &visorconfig.Common{PK: self}}, dmsgServersCache: cache}
+	seen := map[cipher.PubKey]struct{}{pinned: {}}
+	require.Empty(t, v.hubRelayNominees(seen))
+}
+
+// With no cache and no pins there is nothing to nominate, and nothing panics.
+func TestRelayNominees_Empty(t *testing.T) {
+	self, _ := cipher.GenerateKeyPair()
+	v := &Visor{conf: &visorconfig.V1{Common: &visorconfig.Common{PK: self}}}
+	require.Empty(t, v.relayNominees())
+	require.Empty(t, (&Visor{}).relayNominees())
+}


### PR DESCRIPTION
A visor only nominated a dmsg relay it had pinned as a persistent transport *and* held a live direct transport to. Most visors pin nothing, so most nominated nothing, and a hub reachable only through a shared peer could never be nominated even though the dial would have worked. Reaching one meant seeding it into the config by hand, which is the blocker for visors dropping their own dmsg-server sessions in a fleet where the hubs are not public visors.

A hub is now recognised from discovery: an entry carrying both a client and a server section, which only a visor running a dmsg server on its own key produces (#4787). That distinction is the point. A plain dmsg server has no visor behind it and so no relay acceptor to attach to, while a visor that is also a server holds exactly the sessions the attaching visor wants to stop holding.

No direct transport is required, because the attach dials `skynet://<pk>:70` and that resolves over a direct transport, a one-hop relay through a shared peer, or a route. So a hub needs no address-resolver entry and no public listing to be usable, only a transport to a well-connected public visor. An unreachable nominee fails its dial and is backed off, so proposing one costs a dial. Directly reachable peers come first, the set is bounded, and the order is stable because a reshuffling set restarts the client's serve pass every tick.

Inert until a co-resident pair exists, since nothing publishes a dual entry before then.
