### PR TITLE
feat(config): add DMSGSERVER, for a dmsg server on the visor's own key

### DIFF
--- a/cmd/skywire-cli/commands/config/dmsg_server_knob_test.go
+++ b/cmd/skywire-cli/commands/config/dmsg_server_knob_test.go
@@ -1,0 +1,46 @@
+// Package config cmd/skywire-cli/commands/config/dmsg_server_knob_test.go c0-cli
+package cliconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgc"
+)
+
+// applyDmsgServer mirrors the generator's decision so the two modes can be
+// checked without building a whole config.
+func applyDmsgServer(confPath string, ownKey bool, public string) *dmsgc.DmsgServerConfig {
+	if confPath != "" {
+		return &dmsgc.DmsgServerConfig{Enabled: true, ConfigPath: confPath}
+	}
+	if ownKey {
+		return &dmsgc.DmsgServerConfig{Enabled: true, PublicAddress: public}
+	}
+	return nil
+}
+
+// The two modes are distinct and must not be confused: a config-path server
+// keeps its own key and its own ports, while the own-key server shares the
+// visor's identity and, with no local address, its transport port.
+func TestDmsgServerModes(t *testing.T) {
+	require.Nil(t, applyDmsgServer("", false, ""), "off by default")
+
+	own := applyDmsgServer("", true, "1.2.3.4:30084")
+	require.NotNil(t, own)
+	require.True(t, own.Enabled)
+	require.Empty(t, own.ConfigPath, "the own-key server has no standalone config")
+	require.Empty(t, own.LocalAddress, "empty local address is what shares the transport port")
+	require.Equal(t, "1.2.3.4:30084", own.PublicAddress)
+
+	sep := applyDmsgServer("/etc/skywire-dmsg.json", false, "")
+	require.NotNil(t, sep)
+	require.Equal(t, "/etc/skywire-dmsg.json", sep.ConfigPath)
+
+	// A config path wins, so an operator who sets both does not silently get a
+	// second server on a different key.
+	both := applyDmsgServer("/etc/skywire-dmsg.json", true, "1.2.3.4:30084")
+	require.Equal(t, "/etc/skywire-dmsg.json", both.ConfigPath)
+	require.Empty(t, both.PublicAddress)
+}

--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -140,6 +140,17 @@ const envfileLinux = `#
 #	key, ports, wss domain and health endpoint from that file.
 #DMSGSERVERCONF='/etc/skywire-dmsg.json'
 
+#--	Run a dmsg server inside the visor on the visor's OWN key, so the host has
+#	one identity and one discovery entry carrying both roles. The server shares
+#	the visor's transport port, so pin TRANSPORTPORT to a port that is actually
+#	reachable from outside. Mutually exclusive with DMSGSERVERCONF, which runs a
+#	server on its own key instead.
+#DMSGSERVER=true
+
+#--	Address the in-visor dmsg server advertises (host:port). Empty advertises
+#	whatever its listener resolves to, which is only right on a LAN.
+#DMSGSERVERPUBLIC='1.2.3.4:30084'
+
 ### Rewards #############################################################
 
 #--	Skycoin reward address or xpub key

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -477,6 +477,10 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "lan-dmsg-public")
 	genConfigCmd.Flags().StringVar(&dmsgServerConf, "dmsg-server-conf", scriptExecString("${DMSGSERVERCONF}"), "run the dmsg server from this standalone dmsg-server config file inside the visor (replaces a separate dmsg server unit)")
 	gHiddenFlags = append(gHiddenFlags, "dmsg-server-conf")
+	genConfigCmd.Flags().BoolVar(&dmsgServerOwnKey, "dmsg-server", scriptExecBool("${DMSGSERVER:-false}"), "run a dmsg server inside the visor on the visor's OWN key, sharing its transport port")
+	gHiddenFlags = append(gHiddenFlags, "dmsg-server")
+	genConfigCmd.Flags().StringVar(&dmsgServerPublicAddr, "dmsg-server-public", scriptExecString("${DMSGSERVERPUBLIC}"), "address that in-visor dmsg server advertises (host:port); empty advertises whatever its listener resolves to")
+	gHiddenFlags = append(gHiddenFlags, "dmsg-server-public")
 
 	genConfigCmd.Flags().BoolVar(&isAll, "all", false, "show all flags")
 
@@ -1493,9 +1497,20 @@ func configureLauncher(log *logging.Logger) {
 	}
 
 	// Fold a standalone dmsg server into this visor: DMSGSERVERCONF names the
-	// dmsg-server config file the separate unit used to run from.
+	// dmsg-server config file the separate unit used to run from. That server
+	// keeps its OWN key and its own ports.
 	if dmsgServerConf != "" {
 		conf.Dmsg.Server = &dmsgc.DmsgServerConfig{Enabled: true, ConfigPath: dmsgServerConf}
+	} else if dmsgServerOwnKey {
+		// DMSGSERVER runs the server on the VISOR's key instead, so the host has
+		// one identity and one discovery entry carrying both roles. Leaving
+		// LocalAddress empty shares the visor's transport port, so no second
+		// port is opened and none has to be forwarded — which also means
+		// TRANSPORTPORT should be pinned to a port that is actually reachable.
+		conf.Dmsg.Server = &dmsgc.DmsgServerConfig{
+			Enabled:       true,
+			PublicAddress: dmsgServerPublicAddr,
+		}
 	}
 
 	// Configure the skycoin-web wallet. Only emit a block when the operator

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -210,6 +210,8 @@ var (
 	lanDmsgPort          int
 	lanDmsgPublicAddress string
 	dmsgServerConf       string
+	dmsgServerOwnKey     bool
+	dmsgServerPublicAddr string
 )
 
 // RootCmd contains commands that interact with the config of local skywire-visor

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -160,6 +160,8 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	addInt("LANDMSGPORT", "lan-dmsg-port", autoconfigVals.LanDmsgPort)
 	addString("LANDMSGPUBLIC", "lan-dmsg-public", autoconfigVals.LanDmsgPublic)
 	addString("DMSGSERVERCONF", "dmsg-server-conf", autoconfigVals.DmsgServerConf)
+	addBool("DMSGSERVER", "dmsg-server", "no-dmsg-server", autoconfigVals.DmsgServer, autoconfigVals.NoDmsgServer)
+	addString("DMSGSERVERPUBLIC", "dmsg-server-public", autoconfigVals.DmsgServerPublic)
 
 	// Whitelists
 	addArray("DMSGPTYPKS", "dmsgpty-pks", autoconfigVals.DmsgptyPks)

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -135,6 +135,14 @@ type Values struct {
 	LanDmsgPort    int
 	LanDmsgPublic  string
 	DmsgServerConf string
+	// DmsgServer runs a dmsg server inside the visor on the visor's OWN key,
+	// sharing its transport port — writes DMSGSERVER. NoDmsgServer turns it
+	// back off, the way every other boolean here is unset.
+	DmsgServer   bool
+	NoDmsgServer bool
+	// DmsgServerPublic is the address that server advertises — writes
+	// DMSGSERVERPUBLIC.
+	DmsgServerPublic string
 
 	// --- Privacy / routing knobs ---
 	MinHops            int  // MINHOPS (>=2 forces multihop for sender privacy)
@@ -303,6 +311,9 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().IntVar(&v.LanDmsgPort, "lan-dmsg-port", 0, "LAN dmsg-server listening port (0 = leave unchanged) — writes LANDMSGPORT in skywire.conf")
 	cmd.Flags().StringVar(&v.LanDmsgPublic, "lan-dmsg-public", "", "public host:port for the LAN dmsg-server entry in dmsg discovery — writes LANDMSGPUBLIC in skywire.conf")
 	cmd.Flags().StringVar(&v.DmsgServerConf, "dmsg-server-conf", "", "standalone dmsg-server config file to run inside the visor instead of a separate unit — writes DMSGSERVERCONF in skywire.conf")
+	cmd.Flags().BoolVar(&v.DmsgServer, "dmsg-server", false, "run a dmsg server inside the visor on the visor's own key, sharing its transport port — writes DMSGSERVER in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoDmsgServer, "no-dmsg-server", false, "stop running a dmsg server inside the visor — unsets DMSGSERVER in skywire.conf")
+	cmd.Flags().StringVar(&v.DmsgServerPublic, "dmsg-server-public", "", "address that in-visor dmsg server advertises (host:port) — writes DMSGSERVERPUBLIC in skywire.conf")
 
 	// --- Whitelists ---
 	cmd.Flags().StringVar(&v.DmsgptyPks, "dmsgpty-pks", "", "additional dmsgpty-whitelist PKs (hypervisor PKs are already implicit) — writes DMSGPTYPKS in skywire.conf")


### PR DESCRIPTION
Only the two-key mode was reachable from `skywire.conf`. `DMSGSERVERCONF` runs a standalone dmsg-server config inside the visor, and that server keeps its own key and its own ports by definition. The one-key mode existed in the visor config but nothing generated it, so setting it by hand survived until the next autoconfig run and then silently vanished, taking the host's dmsg server with it.

`DMSGSERVER` turns it on through the same path as every other knob, with `DMSGSERVERPUBLIC` for the advertised address and `--no-dmsg-server` to unset it. Leaving the local address unset is what makes the server share the visor's transport port (#4785), so `TRANSPORTPORT` should name a port that is actually reachable from outside. A config path still wins when both are set, so an operator who sets both does not quietly end up with a second server on a different key.

This is the prerequisite for folding a deployment dmsg server into its visor under one identity and having that survive updates.
