### PR TITLE
fix(config): make a supplied secret key actually pin the visor's identity

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1017,7 +1017,16 @@ func readExistingConfig(log *logging.Logger) {
 				}
 				_, sk = cipher.GenerateKeyPair()
 			} else {
-				sk = oldConf.SK
+				// An explicitly supplied key wins over the one already in the
+				// config: --sk, or SK in skywire.conf, which the flag default
+				// reads. Taking oldConf.SK unconditionally made SK look like it
+				// pinned the visor's identity while silently doing nothing,
+				// because autoconfig regenerates on every run and handed the old
+				// key straight back. Unset leaves sk null, so the overwhelmingly
+				// common case still keeps the existing identity.
+				if sk.Null() {
+					sk = oldConf.SK
+				}
 				if isRetainHypervisors {
 					for _, j := range oldConf.Hypervisors {
 						hypervisorPKs = hypervisorPKs + "," + fmt.Sprintf("\t%s\n", j)

--- a/cmd/skywire-cli/commands/config/regen_sk_test.go
+++ b/cmd/skywire-cli/commands/config/regen_sk_test.go
@@ -1,0 +1,43 @@
+// Package cliconfig cmd/skywire-cli/commands/config/regen_sk_test.go c0-cli
+package cliconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// regenKey mirrors the generator's choice on a regen: an explicitly supplied
+// key wins, and only an unset one falls back to the identity already in the
+// config.
+func regenKey(supplied, old cipher.SecKey) cipher.SecKey {
+	if supplied.Null() {
+		return old
+	}
+	return supplied
+}
+
+// SK in skywire.conf, and --sk, must actually pin the visor's identity. Taking
+// the old config's key unconditionally made both look like they did while
+// silently doing nothing, because autoconfig regenerates on every run.
+func TestRegenHonoursSuppliedKey(t *testing.T) {
+	_, oldSK := cipher.GenerateKeyPair()
+	_, newSK := cipher.GenerateKeyPair()
+
+	require.Equal(t, newSK, regenKey(newSK, oldSK), "a supplied key changes the identity")
+
+	var unset cipher.SecKey
+	require.True(t, unset.Null())
+	require.Equal(t, oldSK, regenKey(unset, oldSK), "unset keeps the existing identity")
+
+	// The flag default is the all-zero key. Set rejects it outright, so a
+	// missed env lookup leaves sk at its zero value, which is what the
+	// fallback must key on.
+	var zero cipher.SecKey
+	require.Error(t, zero.Set("0000000000000000000000000000000000000000000000000000000000000000"),
+		"the all-zero key is not a usable key")
+	require.True(t, zero.Null())
+	require.Equal(t, oldSK, regenKey(zero, oldSK))
+}


### PR DESCRIPTION
`SK` in `skywire.conf`, and `--sk`, looked like they set the visor's key and silently did not. The generator reads them into `sk`, but on a regen it then overwrote that with the key from the existing config, unconditionally. Autoconfig regenerates on every run, so from the second run onward the value was dead: an operator could change `SK`, watch autoconfig complete without complaint, and get the old identity back.

Found while folding a deployment dmsg server and its visor onto one key. The plan was to give the visor the server's key so the fleet's existing references stay valid, `SK` was changed accordingly, autoconfig ran cleanly, and the visor came back up under its old identity with the dmsg server now answering on the wrong key. Rolled back from a pre-armed timer.

An explicitly supplied key now wins, and only an unset one falls back to the identity already in the config. Unset leaves `sk` at its zero value, because `Set` rejects the all-zero default the env lookup falls back to, so the common case is unchanged and no visor's key moves on its own.
