### PR TITLE
feat(visor): report the dmsg server, relay and transit roles in visor state

### DIFF
--- a/cmd/skywire-cli/commands/visor/state.go
+++ b/cmd/skywire-cli/commands/visor/state.go
@@ -52,9 +52,13 @@ dozen subcommands. The visor's secret key is never included.
 --select builds ONLY the requested subtree(s) SERVER-side, so a cheap
 '--select mux' skips the ~307 KB transports build (full snapshot ~900 KB, mux
 ~75 KB). Keys (comma-separated): summary, health, routing, mux, apps,
-transports, modules, cxo, proxy. The projected keys match the full snapshot's
-JSON field names, so --jq expressions transfer unchanged. 'proxy' is opt-in
-(the visor-side skysocks proxystatus: per-leg mux + range-split when pushed).
+transports, modules, cxo, proxy, diag, roles. The projected keys match the full
+snapshot's JSON field names, so --jq expressions transfer unchanged. 'proxy' is
+opt-in (the visor-side skysocks proxystatus: per-leg mux + range-split when
+pushed). 'roles' is what this visor is FOR the network: the in-process dmsg
+server (key, address, whether it shares the transport port), both directions of
+the dmsg relay (nominees, who it is attached to, who is attached to it and the
+streams carried against the cap), and whether it refuses transit.
 
 --watch <interval> opens the RPC once and emits one snapshot per tick as NDJSON
 (newline-delimited JSON, no banners/ANSI) to stdout until Ctrl-C — a clean pipe
@@ -67,6 +71,7 @@ Examples:
   skywire cli visor state --jq '.health'          # just the health section
   skywire cli visor state --select mux            # server builds ONLY mux_route_groups
   skywire cli visor state --select health,routing # several subtrees
+  skywire cli visor state --select roles          # dmsg server + relay + transit roles
   skywire cli visor state --watch 1s --select mux --jq '.mux_route_groups'
   skywire cli visor state --via dmsg://<pk> --jq '.routing_policy'  # a remote visor`,
 	Run: func(cmd *cobra.Command, _ []string) {

--- a/pkg/dmsg/dmsg/client_relay.go
+++ b/pkg/dmsg/dmsg/client_relay.go
@@ -165,6 +165,13 @@ func (ce *Client) RelayedStreams() int {
 	return int(atomic.LoadInt64(&ce.relayedStreams))
 }
 
+// MaxRelayedStreams is the relay-slot cap RelayedStreams is charged against
+// (Config.MaxRelayedStreams, i.e. dmsg.relay_max_streams). Zero or less means
+// this client refuses to relay at all. Set once at construction.
+func (ce *Client) MaxRelayedStreams() int {
+	return ce.maxRelayedStreams
+}
+
 func (ce *Client) relaySession(pk cipher.PubKey) (*SessionCommon, bool) {
 	ce.relaySessionsMx.Lock()
 	defer ce.relaySessionsMx.Unlock()

--- a/pkg/visor/api_state.go
+++ b/pkg/visor/api_state.go
@@ -77,6 +77,12 @@ type StateSnapshot struct {
 	// see DiagSnapshot. Cheap; part of the default snapshot.
 	Diag *DiagSnapshot `json:"diag,omitempty"`
 
+	// Roles is what this visor is FOR the network: the in-process dmsg
+	// server (if any, and on which key/address), both directions of the dmsg
+	// relay, and whether it refuses transit. See RolesSnapshot. Cheap; part
+	// of the default snapshot.
+	Roles *RolesSnapshot `json:"roles,omitempty"`
+
 	// Notes collects per-section errors ("routing: <err>") so the snapshot is
 	// self-describing about what it could and could not read.
 	Notes []string `json:"notes,omitempty"`
@@ -100,12 +106,14 @@ const (
 	SelectCXO        = "cxo"        // cxo feed publish-health
 	SelectProxy      = "proxy"      // visor-side proxystatus snapshot (skysocks); opt-in only
 	SelectDiag       = "diag"       // router intake, transport queues/handlers, vstream, dmsg ping/relay, runtime
+	SelectRoles      = "roles"      // in-process dmsg server, dmsg relay (both directions), transit refusal
 )
 
 // StateSelectKeys is the documented set of --select keys, in help order.
 var StateSelectKeys = []string{
 	SelectSummary, SelectHealth, SelectRouting, SelectMux,
 	SelectApps, SelectTransports, SelectModules, SelectCXO, SelectProxy, SelectDiag,
+	SelectRoles,
 }
 
 // stateFieldSet is the parsed --select set. A nil set means "everything in the
@@ -305,6 +313,10 @@ func (v *Visor) StateSnapshotProjected(fields []string) (*StateSnapshot, error) 
 
 	if want.has(SelectDiag) {
 		snap.Diag = v.DiagSnapshot()
+	}
+
+	if want.has(SelectRoles) {
+		snap.Roles = v.RolesSnapshot()
 	}
 
 	// proxy is opt-in (never in the default snapshot): the visor-side

--- a/pkg/visor/api_state_roles.go
+++ b/pkg/visor/api_state_roles.go
@@ -1,0 +1,246 @@
+// Package visor pkg/visor/api_state_roles.go c3-vis-api
+//
+// The `roles` section of `visor state`: what this visor is FOR the rest of the
+// network, as opposed to what it is doing for itself. Three answers an operator
+// used to have to assemble from `mdisc entry`, `ss` on the host and the logs:
+//
+//   - dmsg SERVER — is one running in-process, under which key, on which
+//     address, and is it sharing the visor's transport TCP port (#4785/#4787)
+//     or bound to one of its own. An own-key server registers in the SAME
+//     discovery entry as the visor's client; a config_path server is the
+//     standalone dmsg-server service folded into this process on its OWN key.
+//   - dmsg RELAY, both directions (#4789/#4790/#4791) — the peers this visor
+//     nominated as its relays and which of them it is actually attached to
+//     (with the carrier), plus the peers attached TO this visor and the
+//     streams it is carrying for them against the configured slot cap.
+//   - TRANSIT — whether this visor refuses to be an intermediate route hop
+//     (routing.no_transit, #4788).
+//
+// Everything here is a cheap read of live counters and config, so the section
+// is part of the default snapshot and is selectable on its own.
+package visor
+
+import (
+	"sort"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// RolesSnapshot is the `roles` section of a StateSnapshot.
+type RolesSnapshot struct {
+	// PK is the visor's own public key — the key the own-key dmsg server and
+	// the relay acceptor both answer under.
+	PK cipher.PubKey `json:"pk"`
+	// NoTransit reports routing.no_transit: this visor refuses to be an
+	// INTERMEDIATE hop on someone else's route (its own edges still work).
+	NoTransit bool `json:"no_transit"`
+
+	DmsgServer DmsgServerRole `json:"dmsg_server"`
+	DmsgRelay  DmsgRelayRole  `json:"dmsg_relay"`
+}
+
+// DmsgServerRole is the in-process dmsg server (dmsg.server.* in the config).
+type DmsgServerRole struct {
+	// Enabled is what the config asks for; Running is what actually started.
+	// Enabled && !Running is the interesting case — e.g. no dmsg discovery PK
+	// to register with, so the server no-opped at init.
+	Enabled bool `json:"enabled"`
+	Running bool `json:"running"`
+	// Mode distinguishes the two servers a visor can host: "own_key" is the
+	// bare server sharing the visor's PK/SK and dmsg client, "config_path" is
+	// the whole standalone dmsg-server service run in-process from its own
+	// config file, on its OWN key. Empty when no server is configured.
+	Mode string `json:"mode,omitempty"`
+	// PK is the key the server registers under: the visor's own key in
+	// "own_key" mode, the config file's key in "config_path" mode.
+	PK cipher.PubKey `json:"pk,omitempty"`
+	// OwnKey is true when the server shares the visor's identity, i.e. one
+	// discovery entry carries both the Client and the Server section.
+	OwnKey bool `json:"own_key"`
+	// SharedTransportPort: the server took the dmsg branch of the transport
+	// port's TCP multiplexer instead of opening a listener of its own, so no
+	// second port is bound or forwarded.
+	SharedTransportPort bool   `json:"shared_transport_port"`
+	LocalAddress        string `json:"local_address,omitempty"`
+	PublicAddress       string `json:"public_address,omitempty"`
+	ConfigPath          string `json:"config_path,omitempty"`
+	// StartedAt is when the server was started (zero when it is not running).
+	StartedAt time.Time `json:"started_at,omitempty"`
+}
+
+// DmsgRelayRole is both directions of the dmsg relay: the relays this visor
+// attaches to, and the peers it relays for.
+type DmsgRelayRole struct {
+	// Port is the dmsg port the relay acceptor listens on over skynet.
+	Port uint16 `json:"relay_port"`
+	// RelayPeers are the peers this visor NOMINATED as its relays
+	// (relayNominees → dmsg.Client.SetRelayPeers). Same field name and
+	// meaning as `dmsg sessions`.
+	RelayPeers []cipher.PubKey `json:"relay_peers,omitempty"`
+	// Attached is the subset of RelayPeers this visor currently holds a
+	// session with, and the carrier that session rides. Carrier "skynet" is
+	// an actual relay attachment; anything else means the nominee was reached
+	// as a plain dmsg server instead.
+	Attached []DmsgRelayAttachment `json:"attached,omitempty"`
+	// RelayClients are the peers attached TO this visor's relay acceptor,
+	// each with the streams open on its relay session. Same field name and
+	// meaning as `dmsg sessions`, which reports the keys alone.
+	RelayClients []DmsgRelayClient `json:"relay_clients,omitempty"`
+	// RelayedStreams is the relay slots in use across all attached peers, and
+	// MaxRelayedStreams the cap they are charged against (dmsg.relay_max_streams).
+	// A cap of 0 or less means this visor relays for nobody.
+	RelayedStreams    int `json:"relayed_streams"`
+	MaxRelayedStreams int `json:"max_relayed_streams"`
+}
+
+// DmsgRelayAttachment is one nominated relay this visor holds a session with.
+type DmsgRelayAttachment struct {
+	PK        cipher.PubKey `json:"pk"`
+	Carrier   string        `json:"carrier"`
+	Streams   int           `json:"streams"`
+	LatencyMS float64       `json:"latency_ms"`
+}
+
+// DmsgRelayClient is a peer attached to this visor as its dmsg relay.
+type DmsgRelayClient struct {
+	PK      cipher.PubKey `json:"pk"`
+	Streams int           `json:"streams"`
+}
+
+// dmsgSessionView is the handful of fields the roles section needs from a live
+// dmsg session, extracted so the assembly below is a pure function.
+type dmsgSessionView struct {
+	PK        cipher.PubKey
+	Carrier   string
+	Streams   int
+	LatencyMS float64
+}
+
+// RolesSnapshot builds the roles section. Cheap and best-effort: a
+// not-yet-initialized dmsg client or config leaves the corresponding role
+// zero-valued rather than failing.
+func (v *Visor) RolesSnapshot() *RolesSnapshot {
+	r := &RolesSnapshot{DmsgServer: dmsgServerRole(v.conf, v.dmsgSrvRole.Load())}
+	if v.conf != nil {
+		r.PK = confPK(v.conf)
+		if v.conf.Routing != nil {
+			r.NoTransit = v.conf.Routing.NoTransit
+		}
+	}
+
+	if v.dmsgC == nil {
+		return r
+	}
+	sessions := make([]dmsgSessionView, 0, 8)
+	for _, s := range v.dmsgC.AllSessions() {
+		sessions = append(sessions, dmsgSessionView{
+			PK:        s.RemotePK(),
+			Carrier:   s.Carrier(),
+			Streams:   s.NumStreams(),
+			LatencyMS: float64(s.LastPing()) / 1e6,
+		})
+	}
+	r.DmsgRelay = dmsgRelayRole(
+		skyenv.DmsgRelayPort,
+		v.dmsgC.RelayPeers(),
+		sessions,
+		v.dmsgC.RelaySessionStreams(),
+		v.dmsgC.RelayedStreams(),
+		v.dmsgC.MaxRelayedStreams(),
+	)
+	return r
+}
+
+// dmsgServerRole reports the in-process dmsg server: what the config asks for,
+// overlaid with what the running server recorded at init (live == nil means no
+// server started).
+func dmsgServerRole(conf *visorconfig.V1, live *DmsgServerRole) DmsgServerRole {
+	var role DmsgServerRole
+	if conf != nil && conf.Dmsg != nil && conf.Dmsg.Server != nil {
+		s := conf.Dmsg.Server
+		role.Enabled = s.Enabled
+		role.ConfigPath = s.ConfigPath
+		if s.Enabled {
+			if s.ConfigPath != "" {
+				role.Mode = dmsgServerModeConfigPath
+			} else {
+				role.Mode = dmsgServerModeOwnKey
+				role.OwnKey = true
+				role.PK = confPK(conf)
+				role.LocalAddress = s.LocalAddress
+				role.PublicAddress = s.PublicAddress
+			}
+		}
+	}
+	if live == nil {
+		return role
+	}
+	// The running server is authoritative for everything it knows: the address
+	// it actually listens on (the shared branch has no configured address), the
+	// key a config_path server loaded from its file, and the start time.
+	out := *live
+	out.Enabled = true
+	out.Running = true
+	if out.ConfigPath == "" {
+		out.ConfigPath = role.ConfigPath
+	}
+	return out
+}
+
+// confPK is the visor's public key, safe on a half-built config.
+func confPK(conf *visorconfig.V1) cipher.PubKey {
+	if conf == nil || conf.Common == nil {
+		return cipher.PubKey{}
+	}
+	return conf.PK
+}
+
+// dmsgServer modes; see DmsgServerRole.Mode.
+const (
+	dmsgServerModeOwnKey     = "own_key"
+	dmsgServerModeConfigPath = "config_path"
+)
+
+// dmsgRelayRole assembles the relay role from the dmsg client's live relay
+// state. nominees are this visor's relay nominees, sessions every session the
+// client holds (to pair a nominee with the carrier it was reached over),
+// clientStreams the per-peer stream count of the peers attached to this visor,
+// and relayed/max the slot usage against the configured cap.
+func dmsgRelayRole(port uint16, nominees []cipher.PubKey, sessions []dmsgSessionView,
+	clientStreams map[cipher.PubKey]int, relayed, maxStreams int) DmsgRelayRole {
+
+	role := DmsgRelayRole{
+		Port:              port,
+		RelayPeers:        sortedPKs(nominees),
+		RelayedStreams:    relayed,
+		MaxRelayedStreams: maxStreams,
+	}
+
+	nominated := make(map[cipher.PubKey]struct{}, len(nominees))
+	for _, pk := range nominees {
+		nominated[pk] = struct{}{}
+	}
+	for _, s := range sessions {
+		if _, ok := nominated[s.PK]; !ok {
+			continue
+		}
+		role.Attached = append(role.Attached, DmsgRelayAttachment{
+			PK:        s.PK,
+			Carrier:   s.Carrier,
+			Streams:   s.Streams,
+			LatencyMS: s.LatencyMS,
+		})
+	}
+	sort.Slice(role.Attached, func(i, j int) bool { return role.Attached[i].PK.String() < role.Attached[j].PK.String() })
+
+	for pk, n := range clientStreams {
+		role.RelayClients = append(role.RelayClients, DmsgRelayClient{PK: pk, Streams: n})
+	}
+	sort.Slice(role.RelayClients, func(i, j int) bool {
+		return role.RelayClients[i].PK.String() < role.RelayClients[j].PK.String()
+	})
+	return role
+}

--- a/pkg/visor/api_state_roles_test.go
+++ b/pkg/visor/api_state_roles_test.go
@@ -1,0 +1,218 @@
+// Package visor pkg/visor/api_state_roles_test.go c3-vis-api
+package visor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsgspec "github.com/skycoin/skywire/pkg/dmsg/dmsgc/spec"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+func testConf(pk cipher.PubKey, srv *dmsgspec.DmsgServerConfig) *visorconfig.V1 {
+	return &visorconfig.V1{
+		Common: &visorconfig.Common{PK: pk},
+		Dmsg:   &dmsgspec.DmsgConfig{Server: srv},
+	}
+}
+
+// A visor with no in-process dmsg server says so, and names no key: the
+// absence is the answer an operator is asking for.
+func TestDmsgServerRole_None(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+
+	for name, conf := range map[string]*visorconfig.V1{
+		"no config":    nil,
+		"no dmsg":      {Common: &visorconfig.Common{PK: pk}},
+		"no server":    testConf(pk, nil),
+		"not enabled":  testConf(pk, &dmsgspec.DmsgServerConfig{}),
+		"pinned addr":  testConf(pk, &dmsgspec.DmsgServerConfig{LocalAddress: ":8081"}),
+		"config path ": testConf(pk, &dmsgspec.DmsgServerConfig{ConfigPath: "/etc/skywire-dmsg.json"}),
+	} {
+		role := dmsgServerRole(conf, nil)
+		require.False(t, role.Running, name)
+		require.False(t, role.Enabled, name)
+		require.Empty(t, role.Mode, name)
+		require.True(t, role.PK.Null(), name)
+	}
+}
+
+// Enabled in the config but not started (e.g. no dmsg discovery PK to register
+// with) is the case worth seeing: enabled true, running false.
+func TestDmsgServerRole_EnabledNotRunning(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+
+	role := dmsgServerRole(testConf(pk, &dmsgspec.DmsgServerConfig{Enabled: true}), nil)
+	require.True(t, role.Enabled)
+	require.False(t, role.Running)
+	require.Equal(t, dmsgServerModeOwnKey, role.Mode)
+	require.Equal(t, pk, role.PK)
+}
+
+// An own-key server sharing the visor's transport TCP port: same key as the
+// visor, no address of its own in the config, and the address it actually
+// listens on comes from the running server.
+func TestDmsgServerRole_OwnKeySharedPort(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	started := time.Now()
+
+	role := dmsgServerRole(testConf(pk, &dmsgspec.DmsgServerConfig{Enabled: true}), &DmsgServerRole{
+		Mode:                dmsgServerModeOwnKey,
+		PK:                  pk,
+		OwnKey:              true,
+		SharedTransportPort: true,
+		LocalAddress:        "127.0.0.1:7777",
+		StartedAt:           started,
+	})
+
+	require.True(t, role.Enabled)
+	require.True(t, role.Running)
+	require.Equal(t, dmsgServerModeOwnKey, role.Mode)
+	require.True(t, role.OwnKey, "an own-key server registers under the visor's identity")
+	require.Equal(t, pk, role.PK)
+	require.True(t, role.SharedTransportPort, "it takes the transport port's dmsg branch")
+	require.Equal(t, "127.0.0.1:7777", role.LocalAddress)
+	require.Equal(t, started, role.StartedAt)
+	require.Empty(t, role.ConfigPath)
+}
+
+// An own-key server pinned to its own address does NOT share the transport port.
+func TestDmsgServerRole_OwnKeyOwnAddress(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+
+	role := dmsgServerRole(testConf(pk, &dmsgspec.DmsgServerConfig{
+		Enabled: true, LocalAddress: ":8081", PublicAddress: "1.2.3.4:8081",
+	}), &DmsgServerRole{
+		Mode: dmsgServerModeOwnKey, PK: pk, OwnKey: true,
+		LocalAddress: ":8081", PublicAddress: "1.2.3.4:8081",
+	})
+
+	require.True(t, role.Running)
+	require.False(t, role.SharedTransportPort)
+	require.Equal(t, ":8081", role.LocalAddress)
+	require.Equal(t, "1.2.3.4:8081", role.PublicAddress)
+}
+
+// A config_path server is the standalone dmsg-server service in-process: its
+// OWN key, not the visor's, and its own addresses.
+func TestDmsgServerRole_ConfigPath(t *testing.T) {
+	visorPK, _ := cipher.GenerateKeyPair()
+	srvPK, _ := cipher.GenerateKeyPair()
+
+	role := dmsgServerRole(testConf(visorPK, &dmsgspec.DmsgServerConfig{
+		Enabled: true, ConfigPath: "/etc/skywire-dmsg.json",
+	}), &DmsgServerRole{
+		Mode:          dmsgServerModeConfigPath,
+		ConfigPath:    "/etc/skywire-dmsg.json",
+		PK:            srvPK,
+		LocalAddress:  ":8081",
+		PublicAddress: "1.2.3.4:8081",
+	})
+
+	require.True(t, role.Running)
+	require.Equal(t, dmsgServerModeConfigPath, role.Mode)
+	require.False(t, role.OwnKey, "a config_path server runs on a key of its own")
+	require.Equal(t, srvPK, role.PK)
+	require.NotEqual(t, visorPK, role.PK)
+	require.Equal(t, "/etc/skywire-dmsg.json", role.ConfigPath)
+	require.False(t, role.SharedTransportPort, "its own listener, its own addresses")
+}
+
+// no_transit and the visor's identity come straight from the config.
+func TestDmsgServerRole_NoTransitAndPK(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	conf := testConf(pk, nil)
+	conf.Routing = &visorconfig.Routing{NoTransit: true}
+
+	require.Equal(t, pk, confPK(conf))
+	require.True(t, conf.Routing.NoTransit)
+	require.True(t, confPK(nil).Null(), "a half-built config must not panic")
+}
+
+// A visor that nominates nobody and relays for nobody reports empty lists and
+// the cap it would enforce if anyone attached.
+func TestDmsgRelayRole_Idle(t *testing.T) {
+	role := dmsgRelayRole(skyenv.DmsgRelayPort, nil, nil, nil, 0, 4096)
+
+	require.Equal(t, skyenv.DmsgRelayPort, role.Port)
+	require.Empty(t, role.RelayPeers)
+	require.Empty(t, role.Attached)
+	require.Empty(t, role.RelayClients)
+	require.Zero(t, role.RelayedStreams)
+	require.Equal(t, 4096, role.MaxRelayedStreams)
+}
+
+// Nominees are reported whether or not they were reached; only the ones with a
+// live session show up as attached, with the carrier that session rides.
+func TestDmsgRelayRole_AttachedNominees(t *testing.T) {
+	hub, _ := cipher.GenerateKeyPair()
+	unreached, _ := cipher.GenerateKeyPair()
+	server, _ := cipher.GenerateKeyPair()
+
+	role := dmsgRelayRole(skyenv.DmsgRelayPort,
+		[]cipher.PubKey{hub, unreached},
+		[]dmsgSessionView{
+			{PK: hub, Carrier: "skynet", Streams: 3, LatencyMS: 42},
+			{PK: server, Carrier: "tcp", Streams: 9}, // a plain server, not a nominee
+		}, nil, 0, 4096)
+
+	require.Len(t, role.RelayPeers, 2, "both nominees are reported")
+	require.Len(t, role.Attached, 1, "only the nominee with a session is attached")
+	require.Equal(t, hub, role.Attached[0].PK)
+	require.Equal(t, "skynet", role.Attached[0].Carrier)
+	require.Equal(t, 3, role.Attached[0].Streams)
+	require.InDelta(t, 42.0, role.Attached[0].LatencyMS, 0.001)
+	for _, a := range role.Attached {
+		require.NotEqual(t, server, a.PK, "a plain server session is not a relay attachment")
+	}
+}
+
+// The serving side: the peers attached to this visor, their streams, and the
+// total charged against the configured cap.
+func TestDmsgRelayRole_RelayingForPeers(t *testing.T) {
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+
+	role := dmsgRelayRole(skyenv.DmsgRelayPort, nil, nil,
+		map[cipher.PubKey]int{a: 2, b: 5}, 7, 4096)
+
+	require.Len(t, role.RelayClients, 2)
+	require.Equal(t, 7, role.RelayedStreams)
+	require.Equal(t, 4096, role.MaxRelayedStreams)
+
+	streams := map[cipher.PubKey]int{}
+	for _, c := range role.RelayClients {
+		streams[c.PK] = c.Streams
+	}
+	require.Equal(t, 2, streams[a])
+	require.Equal(t, 5, streams[b])
+
+	// Stable order: the snapshot is diffed tick to tick under --watch, so map
+	// iteration order must never leak into it.
+	require.Less(t, role.RelayClients[0].PK.String(), role.RelayClients[1].PK.String())
+}
+
+// A negative cap is the "never relay for anyone" setting, and stays visible as
+// such rather than being normalized away.
+func TestDmsgRelayRole_RefusesToRelay(t *testing.T) {
+	role := dmsgRelayRole(skyenv.DmsgRelayPort, nil, nil, nil, 0, -1)
+	require.Equal(t, -1, role.MaxRelayedStreams)
+	require.Empty(t, role.RelayClients)
+}
+
+// roles is its own --select subtree: asking for it builds nothing else (the
+// full snapshot is ~900 KB and a projected select must stay cheap).
+func TestStateFieldSet_RolesProjection(t *testing.T) {
+	set := newStateFieldSet([]string{SelectRoles})
+	require.True(t, set.has(SelectRoles))
+	for _, k := range []string{SelectSummary, SelectHealth, SelectRouting, SelectMux,
+		SelectApps, SelectTransports, SelectModules, SelectCXO, SelectProxy, SelectDiag} {
+		require.False(t, set.has(k), "--select roles must not build %q", k)
+	}
+	require.True(t, newStateFieldSet(nil).has(SelectRoles), "roles is in the default snapshot")
+	require.Contains(t, StateSelectKeys, SelectRoles, "the key must be documented in --select help")
+}

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -1122,7 +1122,18 @@ func initDmsgServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 		WithField("shared_transport_port", shared).
 		Info("Started in-process dmsg server on the visor key")
 
+	v.dmsgSrvRole.Store(&DmsgServerRole{
+		Mode:                dmsgServerModeOwnKey,
+		PK:                  v.conf.PK,
+		OwnKey:              true,
+		SharedTransportPort: shared,
+		LocalAddress:        localAddr,
+		PublicAddress:       srvCfg.PublicAddress,
+		StartedAt:           time.Now(),
+	})
+
 	v.pushCloseStack("dmsg_server", func() error {
+		v.dmsgSrvRole.Store(nil)
 		cerr := srv.Close()
 		// Only a listener this server owns is closed here. The shared branch
 		// belongs to the transport cmux, which stcpr and WS are still serving;
@@ -1464,7 +1475,26 @@ func initDmsgServerFromFile(_ context.Context, v *Visor, log *logging.Logger, pa
 		}
 	}()
 	log.WithField("config_path", path).Info("Started in-process dmsg server from config file")
+
+	role := &DmsgServerRole{
+		Mode:       dmsgServerModeConfigPath,
+		ConfigPath: path,
+		StartedAt:  time.Now(),
+	}
+	// The service holds the config privately; re-read the file for the public
+	// half of it (key and addresses — never the secret key) so `visor state`
+	// can name the key this server registers under, which is NOT the visor's.
+	if cfg, lerr := dmsgsrv.LoadFile(path); lerr != nil {
+		log.WithError(lerr).Debug("in-process dmsg server: config unreadable for state reporting")
+	} else {
+		role.PK = cfg.PubKey
+		role.LocalAddress = cfg.LocalAddress
+		role.PublicAddress = cfg.PublicAddress
+	}
+	v.dmsgSrvRole.Store(role)
+
 	v.pushCloseStack("dmsg_server", func() error {
+		v.dmsgSrvRole.Store(nil)
 		cancel()
 		<-done
 		return nil

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -144,6 +144,10 @@ type Visor struct {
 	// handed to the in-process dmsg server so it shares the visor's TCP port.
 	// nil when the server is off, keyed separately, or pinned to its own address.
 	dmsgSharedLis net.Listener
+	// dmsgSrvRole records the in-process dmsg server that actually started
+	// (nil = none), so `visor state --select roles` can report the running
+	// server's key and address rather than only what the config asked for.
+	dmsgSrvRole atomic.Pointer[DmsgServerRole]
 
 	// localGraph is an extra transport-graph source merged into every
 	// GetAllTransports answer (see local_graph.go).


### PR DESCRIPTION
A visor can now run a dmsg server on its own key, share its transport TCP port with it, relay dmsg for peers that attach to its relay acceptor, and refuse to be an intermediate hop. None of that was visible from the visor itself: finding out took an `mdisc entry`, `ss` on the host and a pass over the logs.

This adds a `roles` subtree to the state snapshot, selectable on its own with `skywire cli visor state --select roles` and built without touching the expensive sections. It answers whether an in-process dmsg server is running and in which of its two modes — `own_key`, sharing the visor's identity and usually its transport port, or `config_path`, the standalone server folded into the process on a key of its own — plus both directions of the relay: the nominees and which of them this visor is actually attached to over which carrier, and the peers attached to it with the streams it is carrying for them against `dmsg.relay_max_streams`. `routing.no_transit` is reported alongside. `relay_peers` and `relay_clients` keep the names and meanings `dmsg sessions` already uses.

The server role is recorded by the init that starts it, so the snapshot reports the address actually listened on (the shared branch has no configured address) and the key a `config_path` server loaded from its file, rather than only what the config asked for. `dmsg.Client` gains a `MaxRelayedStreams` accessor to pair with the existing `RelayedStreams`. Tested against the assembly functions directly: no server, an own-key server on the shared port, one pinned to its own address, a `config_path` server on a separate key, an idle relay, and a relay carrying streams for two attached peers.